### PR TITLE
Add lots of files to Quaddicted, remove one missing download

### DIFF
--- a/json/by-sha256/02/02db7a514bc0516efc7c71814067c1e3abff4199bd4f2249ca2f7b586cf76026.json
+++ b/json/by-sha256/02/02db7a514bc0516efc7c71814067c1e3abff4199bd4f2249ca2f7b586cf76026.json
@@ -368,6 +368,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/02/02db7a514bc0516efc7c71814067c1e3abff4199bd4f2249ca2f7b586cf76026/lth1.1.zip",
   "https://x901.net/quaddictedfiles/lth1.1.zip"
  ]
 }

--- a/json/by-sha256/04/04d8fa78d751ab394b54e4771f6eeef573675309825bca2928af6acff6baa105.json
+++ b/json/by-sha256/04/04d8fa78d751ab394b54e4771f6eeef573675309825bca2928af6acff6baa105.json
@@ -43,6 +43,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/04/04d8fa78d751ab394b54e4771f6eeef573675309825bca2928af6acff6baa105/memgrot.zip",
   "https://x901.net/quaddictedfiles/memgrot.zip"
  ]
 }

--- a/json/by-sha256/08/08a5bbe3014be5f58c5b4a39c9a93656952567352fd300a8db6519716cea89a8.json
+++ b/json/by-sha256/08/08a5bbe3014be5f58c5b4a39c9a93656952567352fd300a8db6519716cea89a8.json
@@ -987,6 +987,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/08/08a5bbe3014be5f58c5b4a39c9a93656952567352fd300a8db6519716cea89a8/tobv1.2.zip",
   "https://x901.net/quaddictedfiles/tobv1.2.zip"
  ]
 }

--- a/json/by-sha256/09/098d3c95478106a404292082c1ffa5ae986365a2e97ca65e8f4c8c90ddab7f10.json
+++ b/json/by-sha256/09/098d3c95478106a404292082c1ffa5ae986365a2e97ca65e8f4c8c90ddab7f10.json
@@ -155,6 +155,7 @@
   "zipbasedir=copper/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/09/098d3c95478106a404292082c1ffa5ae986365a2e97ca65e8f4c8c90ddab7f10/amarna_v1.2.zip",
   "https://x901.net/quaddictedfiles/amarna_v1.2.zip"
  ]
 }

--- a/json/by-sha256/10/10925a22837d3cd7c1c1b6b492da14394c38a9c30154d7f0b1560aa59117de62.json
+++ b/json/by-sha256/10/10925a22837d3cd7c1c1b6b492da14394c38a9c30154d7f0b1560aa59117de62.json
@@ -50,6 +50,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/10/10925a22837d3cd7c1c1b6b492da14394c38a9c30154d7f0b1560aa59117de62/fotac_1_0.zip",
   "https://x901.net/quaddictedfiles/fotac_1_0.zip"
  ]
 }

--- a/json/by-sha256/12/12f23892afa818ab5b10ad0c76ee2e9304196e74415f49345e0cfba0504826ed.json
+++ b/json/by-sha256/12/12f23892afa818ab5b10ad0c76ee2e9304196e74415f49345e0cfba0504826ed.json
@@ -55,6 +55,7 @@
   "zipbasedir=e1/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/12/12f23892afa818ab5b10ad0c76ee2e9304196e74415f49345e0cfba0504826ed/e1.zip",
   "https://x901.net/quaddictedfiles/e1.zip"
  ]
 }

--- a/json/by-sha256/15/152db76fa2af981c5e4dbd823681f0431c9635df5156171e0e9ed5efea8e4b4f.json
+++ b/json/by-sha256/15/152db76fa2af981c5e4dbd823681f0431c9635df5156171e0e9ed5efea8e4b4f.json
@@ -106,6 +106,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/15/152db76fa2af981c5e4dbd823681f0431c9635df5156171e0e9ed5efea8e4b4f/plaw03.zip",
   "https://x901.net/quaddictedfiles/plaw03.zip"
  ]
 }

--- a/json/by-sha256/16/16c3107c413b9cef531b6ef3866ddaa539b1e84b6027fab50c17611b9f4a30f7.json
+++ b/json/by-sha256/16/16c3107c413b9cef531b6ef3866ddaa539b1e84b6027fab50c17611b9f4a30f7.json
@@ -73,6 +73,7 @@
   "zipbasedir=copper/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/16/16c3107c413b9cef531b6ef3866ddaa539b1e84b6027fab50c17611b9f4a30f7/ferric_oxide_v1.01.zip",
   "https://x901.net/quaddictedfiles/ferric_oxide_v1.01.zip"
  ]
 }

--- a/json/by-sha256/19/19f0a4886d4ec681e546628f2a75013dc545ad1ac2d48665aa4d09450c603af0.json
+++ b/json/by-sha256/19/19f0a4886d4ec681e546628f2a75013dc545ad1ac2d48665aa4d09450c603af0.json
@@ -1722,6 +1722,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/19/19f0a4886d4ec681e546628f2a75013dc545ad1ac2d48665aa4d09450c603af0/grinch.zip",
   "https://x901.net/quaddictedfiles/grinch.zip"
  ]
 }

--- a/json/by-sha256/1d/1d3bd09e4f0a5acd88e4bfdca0e0486ca86c063456b34fc2661ff00c9187d771.json
+++ b/json/by-sha256/1d/1d3bd09e4f0a5acd88e4bfdca0e0486ca86c063456b34fc2661ff00c9187d771.json
@@ -300,6 +300,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/1d/1d3bd09e4f0a5acd88e4bfdca0e0486ca86c063456b34fc2661ff00c9187d771/ad_rje2m6.zip",
   "https://x901.net/quaddictedfiles/ad_rje2m6.zip"
  ]
 }

--- a/json/by-sha256/20/20d04696f40d03c81f749cadf8e1a5d2e82bd88ab4c4fe055d90f89f193b8b56.json
+++ b/json/by-sha256/20/20d04696f40d03c81f749cadf8e1a5d2e82bd88ab4c4fe055d90f89f193b8b56.json
@@ -39,6 +39,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/20/20d04696f40d03c81f749cadf8e1a5d2e82bd88ab4c4fe055d90f89f193b8b56/drmelon-roomview.zip",
   "https://x901.net/quaddictedfiles/drmelon-roomview.zip"
  ]
 }

--- a/json/by-sha256/24/24a93f05c7c71af8993229ad5446ce45ae47d176b02cc27b71fdd85dde69afa8.json
+++ b/json/by-sha256/24/24a93f05c7c71af8993229ad5446ce45ae47d176b02cc27b71fdd85dde69afa8.json
@@ -2529,6 +2529,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/24/24a93f05c7c71af8993229ad5446ce45ae47d176b02cc27b71fdd85dde69afa8/qbj2_1.2.zip",
   "https://x901.net/quaddictedfiles/qbj2_1.2.zip"
  ]
 }

--- a/json/by-sha256/26/2668ca81f1901853171b658fdbabd78d2b4a80feed84c0ceb2d0c64c3f8c1049.json
+++ b/json/by-sha256/26/2668ca81f1901853171b658fdbabd78d2b4a80feed84c0ceb2d0c64c3f8c1049.json
@@ -44,6 +44,7 @@
   "zipbasedir=id1/maps/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/26/2668ca81f1901853171b658fdbabd78d2b4a80feed84c0ceb2d0c64c3f8c1049/thefortressofdoom.zip",
   "https://x901.net/quaddictedfiles/thefortressofdoom.zip"
  ]
 }

--- a/json/by-sha256/29/2932bdfda11224125c3f7207701bed8c4b7a765a2370a581589a5e17337b7eb8.json
+++ b/json/by-sha256/29/2932bdfda11224125c3f7207701bed8c4b7a765a2370a581589a5e17337b7eb8.json
@@ -829,6 +829,7 @@
   "version=1.30"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/29/2932bdfda11224125c3f7207701bed8c4b7a765a2370a581589a5e17337b7eb8/copper_v1_30.zip",
   "https://x901.net/quaddictedfiles/copper_v1_30.zip"
  ]
 }

--- a/json/by-sha256/35/35712c45cfd4cf8bd30a98855a48c6ba4ac8a7e64b7a017221a42d1d6cbf8b86.json
+++ b/json/by-sha256/35/35712c45cfd4cf8bd30a98855a48c6ba4ac8a7e64b7a017221a42d1d6cbf8b86.json
@@ -104,6 +104,7 @@
   "zipbasedir=copper/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/35/35712c45cfd4cf8bd30a98855a48c6ba4ac8a7e64b7a017221a42d1d6cbf8b86/nkstrq1m1_v1.1.zip",
   "https://x901.net/quaddictedfiles/nkstrq1m1_v1.1.zip"
  ]
 }

--- a/json/by-sha256/35/357a74c5d2b59cab7c742a2ec27357522760bac3655f2c8741d4b9f06975601c.json
+++ b/json/by-sha256/35/357a74c5d2b59cab7c742a2ec27357522760bac3655f2c8741d4b9f06975601c.json
@@ -44,6 +44,7 @@
   "zipbasedir=id1/maps/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/35/357a74c5d2b59cab7c742a2ec27357522760bac3655f2c8741d4b9f06975601c/spasp1_1.3.zip",
   "https://x901.net/quaddictedfiles/spasp1_1.3.zip"
  ]
 }

--- a/json/by-sha256/37/373f362d2fdcd64482fe8976cef50bfdf2502495da3197d666ca763c3d446b65.json
+++ b/json/by-sha256/37/373f362d2fdcd64482fe8976cef50bfdf2502495da3197d666ca763c3d446b65.json
@@ -886,6 +886,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/37/373f362d2fdcd64482fe8976cef50bfdf2502495da3197d666ca763c3d446b65/gsh_castleod.zip",
   "https://x901.net/quaddictedfiles/gsh_castleod.zip"
  ]
 }

--- a/json/by-sha256/38/389a0ece381bb3a3bf899286ffff30344087d4e6156f3892096eadf7e8a5c691.json
+++ b/json/by-sha256/38/389a0ece381bb3a3bf899286ffff30344087d4e6156f3892096eadf7e8a5c691.json
@@ -646,6 +646,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/38/389a0ece381bb3a3bf899286ffff30344087d4e6156f3892096eadf7e8a5c691/pain.zip",
   "https://x901.net/quaddictedfiles/pain.zip"
  ]
 }

--- a/json/by-sha256/3c/3cf13c44cabfdc48109fe38abbc95ab40a1bcd33d29ac8cab794fd4985de887d.json
+++ b/json/by-sha256/3c/3cf13c44cabfdc48109fe38abbc95ab40a1bcd33d29ac8cab794fd4985de887d.json
@@ -511,6 +511,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/3c/3cf13c44cabfdc48109fe38abbc95ab40a1bcd33d29ac8cab794fd4985de887d/quotes20240414.zip",
   "https://x901.net/quaddictedfiles/quotes20240414.zip"
  ]
 }

--- a/json/by-sha256/3e/3e7b133a82737b006cd8fb99913076672f981222c7a3cb131d95a4aae2d6795e.json
+++ b/json/by-sha256/3e/3e7b133a82737b006cd8fb99913076672f981222c7a3cb131d95a4aae2d6795e.json
@@ -1882,6 +1882,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/3e/3e7b133a82737b006cd8fb99913076672f981222c7a3cb131d95a4aae2d6795e/rmxjam_r3.zip",
   "https://x901.net/quaddictedfiles/rmxjam_r3.zip"
  ]
 }

--- a/json/by-sha256/45/4558b104f87306491e9233ba01ae25caea9100e624956bd7778c3333bd163862.json
+++ b/json/by-sha256/45/4558b104f87306491e9233ba01ae25caea9100e624956bd7778c3333bd163862.json
@@ -48,6 +48,7 @@
   "zipbasedir=snack3/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/45/4558b104f87306491e9233ba01ae25caea9100e624956bd7778c3333bd163862/latenightsnack.zip",
   "https://x901.net/quaddictedfiles/latenightsnack.zip"
  ]
 }

--- a/json/by-sha256/45/45ddd187e07af6b3d43a5f9f5597172e43aae7cebe73cdd2a5057ad6a36f570e.json
+++ b/json/by-sha256/45/45ddd187e07af6b3d43a5f9f5597172e43aae7cebe73cdd2a5057ad6a36f570e.json
@@ -2460,6 +2460,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/45/45ddd187e07af6b3d43a5f9f5597172e43aae7cebe73cdd2a5057ad6a36f570e/enyo_hd_20240115.zip",
   "https://x901.net/quaddictedfiles/enyo_hd_20240115.zip"
  ]
 }

--- a/json/by-sha256/45/45e98720be07485c11b2779beec267309f2767dda1882994c3367b87b3e96c92.json
+++ b/json/by-sha256/45/45e98720be07485c11b2779beec267309f2767dda1882994c3367b87b3e96c92.json
@@ -34,6 +34,7 @@
   "zipbasedir=id1/maps/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/45/45e98720be07485c11b2779beec267309f2767dda1882994c3367b87b3e96c92/gubbins.zip",
   "https://x901.net/quaddictedfiles/gubbins.zip"
  ]
 }

--- a/json/by-sha256/46/466f2e6a033b85a5d1c88769a71b97c1cbf60ce097783882f52d99db3cc007b3.json
+++ b/json/by-sha256/46/466f2e6a033b85a5d1c88769a71b97c1cbf60ce097783882f52d99db3cc007b3.json
@@ -2326,6 +2326,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/46/466f2e6a033b85a5d1c88769a71b97c1cbf60ce097783882f52d99db3cc007b3/euclidius_v1.5.zip",
   "https://x901.net/quaddictedfiles/euclidius_v1.5.zip"
  ]
 }

--- a/json/by-sha256/46/469b95616d62b61a8956adfeea2f896ac88f8702a580f8e4def2ffb3d67277ce.json
+++ b/json/by-sha256/46/469b95616d62b61a8956adfeea2f896ac88f8702a580f8e4def2ffb3d67277ce.json
@@ -71,6 +71,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/46/469b95616d62b61a8956adfeea2f896ac88f8702a580f8e4def2ffb3d67277ce/apterous_pale_peril.zip",
   "https://x901.net/quaddictedfiles/apterous_pale_peril.zip"
  ]
 }

--- a/json/by-sha256/4d/4d8ac1f91d16e9785d4b4e2250743cc33ac95154c0bd2de0a2542bc591aad9a4.json
+++ b/json/by-sha256/4d/4d8ac1f91d16e9785d4b4e2250743cc33ac95154c0bd2de0a2542bc591aad9a4.json
@@ -42,6 +42,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/4d/4d8ac1f91d16e9785d4b4e2250743cc33ac95154c0bd2de0a2542bc591aad9a4/puzzlebox1_1.zip",
   "https://x901.net/quaddictedfiles/puzzlebox1_1.zip"
  ]
 }

--- a/json/by-sha256/4e/4e7a4ebe590974771d066c54bc7196e4205e3a783de7254f5b165de992a402c1.json
+++ b/json/by-sha256/4e/4e7a4ebe590974771d066c54bc7196e4205e3a783de7254f5b165de992a402c1.json
@@ -13622,6 +13622,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/4e/4e7a4ebe590974771d066c54bc7196e4205e3a783de7254f5b165de992a402c1/peril3.0c.zip",
   "https://x901.net/quaddictedfiles/peril3.0c.zip"
  ]
 }

--- a/json/by-sha256/4f/4f10f1518bbebb074d103305bb17ed14a26cd8bdb607a71efc4c2a858b95b9cc.json
+++ b/json/by-sha256/4f/4f10f1518bbebb074d103305bb17ed14a26cd8bdb607a71efc4c2a858b95b9cc.json
@@ -44,6 +44,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/4f/4f10f1518bbebb074d103305bb17ed14a26cd8bdb607a71efc4c2a858b95b9cc/dkbrutic.zip",
   "https://x901.net/quaddictedfiles/dkbrutic.zip"
  ]
 }

--- a/json/by-sha256/4f/4f471481c4fb360ba822685cae347e8dfe905335127a1b9f6a5ce437ffc8147f.json
+++ b/json/by-sha256/4f/4f471481c4fb360ba822685cae347e8dfe905335127a1b9f6a5ce437ffc8147f.json
@@ -44,6 +44,7 @@
   "zipbasedir=id1/maps/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/4f/4f471481c4fb360ba822685cae347e8dfe905335127a1b9f6a5ce437ffc8147f/the_requiem.zip",
   "https://x901.net/quaddictedfiles/the_requiem.zip"
  ]
 }

--- a/json/by-sha256/52/52915bea35f25dc3756f6fca68ef90c144a3870549b2ae6bd969afd0a230d144.json
+++ b/json/by-sha256/52/52915bea35f25dc3756f6fca68ef90c144a3870549b2ae6bd969afd0a230d144.json
@@ -715,6 +715,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/52/52915bea35f25dc3756f6fca68ef90c144a3870549b2ae6bd969afd0a230d144/two_tone_jam.v2.zip",
   "https://x901.net/quaddictedfiles/two_tone_jam.v2.zip"
  ]
 }

--- a/json/by-sha256/53/53c8d9513a801ff5fd07b35f88a3af46aa6eac5b356df321c17580952cf2ceb1.json
+++ b/json/by-sha256/53/53c8d9513a801ff5fd07b35f88a3af46aa6eac5b356df321c17580952cf2ceb1.json
@@ -2808,6 +2808,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/53/53c8d9513a801ff5fd07b35f88a3af46aa6eac5b356df321c17580952cf2ceb1/zet_z374_v1.01.zip",
   "https://x901.net/quaddictedfiles/zet_z374_v1.01.zip"
  ]
 }

--- a/json/by-sha256/55/55e93aeece837b90b35fc42dc244b4da98a752e29aacfa79c7cc5d8645412c52.json
+++ b/json/by-sha256/55/55e93aeece837b90b35fc42dc244b4da98a752e29aacfa79c7cc5d8645412c52.json
@@ -110,6 +110,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/55/55e93aeece837b90b35fc42dc244b4da98a752e29aacfa79c7cc5d8645412c52/dungeonascension-3.0.zip",
   "https://x901.net/quaddictedfiles/dungeonascension-3.0.zip"
  ]
 }

--- a/json/by-sha256/56/569bbe3f6030eace88701c016434f8aa268967df1c60c52fe1608227f48f044f.json
+++ b/json/by-sha256/56/569bbe3f6030eace88701c016434f8aa268967df1c60c52fe1608227f48f044f.json
@@ -64,6 +64,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/56/569bbe3f6030eace88701c016434f8aa268967df1c60c52fe1608227f48f044f/drmelon-thrallbreak.zip",
   "https://x901.net/quaddictedfiles/drmelon-thrallbreak.zip"
  ]
 }

--- a/json/by-sha256/57/574e41986025b438c55b6b77d904a1c7098cac1440aa8c46f047231347e26826.json
+++ b/json/by-sha256/57/574e41986025b438c55b6b77d904a1c7098cac1440aa8c46f047231347e26826.json
@@ -81,6 +81,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/57/574e41986025b438c55b6b77d904a1c7098cac1440aa8c46f047231347e26826/mtsch001.zip",
   "https://x901.net/quaddictedfiles/mtsch001.zip"
  ]
 }

--- a/json/by-sha256/5b/5befea02cf4ff90f85be93a43b590814e8abe46007637c51b91f6da5578e634e.json
+++ b/json/by-sha256/5b/5befea02cf4ff90f85be93a43b590814e8abe46007637c51b91f6da5578e634e.json
@@ -36,6 +36,7 @@
   "zipbasedir=id1/maps/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/5b/5befea02cf4ff90f85be93a43b590814e8abe46007637c51b91f6da5578e634e/twitown-v2.zip",
   "https://x901.net/quaddictedfiles/twitown-v2.zip"
  ]
 }

--- a/json/by-sha256/5d/5db34752666516d306b0c78504bef2b4d2af054b0ddc3167c974d8e08da2556f.json
+++ b/json/by-sha256/5d/5db34752666516d306b0c78504bef2b4d2af054b0ddc3167c974d8e08da2556f.json
@@ -958,6 +958,7 @@
   "version=1.1J"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/5d/5db34752666516d306b0c78504bef2b4d2af054b0ddc3167c974d8e08da2556f/rmj1.zip",
   "https://x901.net/quaddictedfiles/rmj1.zip"
  ]
 }

--- a/json/by-sha256/5d/5dd84ca583cf98d9f8deeea79567bd014e6f0636f19e2afd1117d5df70a7ecbe.json
+++ b/json/by-sha256/5d/5dd84ca583cf98d9f8deeea79567bd014e6f0636f19e2afd1117d5df70a7ecbe.json
@@ -105,6 +105,7 @@
   "zipbasedir=id1/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/5d/5dd84ca583cf98d9f8deeea79567bd014e6f0636f19e2afd1117d5df70a7ecbe/wdg_qbblock1.zip",
   "https://x901.net/quaddictedfiles/wdg_qbblock1.zip"
  ]
 }

--- a/json/by-sha256/5f/5f96f0649ccd114708566f3710357cb56e0ae0b060b2f19aade60cd8f26052a4.json
+++ b/json/by-sha256/5f/5f96f0649ccd114708566f3710357cb56e0ae0b060b2f19aade60cd8f26052a4.json
@@ -3015,6 +3015,7 @@
   "zipbasedir=drake/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/5f/5f96f0649ccd114708566f3710357cb56e0ae0b060b2f19aade60cd8f26052a4/drake290111.zip",
   "https://x901.net/quaddictedfiles/drake290111.zip"
  ]
 }

--- a/json/by-sha256/65/65894a8a8a6be1d28d6f7ee5a653f67aaaaa8a27846a8f5ba181fc9123d15059.json
+++ b/json/by-sha256/65/65894a8a8a6be1d28d6f7ee5a653f67aaaaa8a27846a8f5ba181fc9123d15059.json
@@ -2516,7 +2516,5 @@
   "type=episode",
   "type=mod"
  ],
- "urls": [
-  "https://x901.net/quaddictedfiles/tombofthunder_mod_2024_v1032a.zip"
- ]
+ "urls": []
 }

--- a/json/by-sha256/66/66fc810f84d34a73d2f7d8eb5a2ee83857333d41df11f57278a3d6afe77c0f66.json
+++ b/json/by-sha256/66/66fc810f84d34a73d2f7d8eb5a2ee83857333d41df11f57278a3d6afe77c0f66.json
@@ -60,6 +60,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/66/66fc810f84d34a73d2f7d8eb5a2ee83857333d41df11f57278a3d6afe77c0f66/hcmaq1.zip",
   "https://x901.net/quaddictedfiles/hcmaq1.zip"
  ]
 }

--- a/json/by-sha256/67/674f15cef0570ab896220fc05ae0e0ee087106a0b4a8bcd80cd91b11f7ae2114.json
+++ b/json/by-sha256/67/674f15cef0570ab896220fc05ae0e0ee087106a0b4a8bcd80cd91b11f7ae2114.json
@@ -49,6 +49,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/67/674f15cef0570ab896220fc05ae0e0ee087106a0b4a8bcd80cd91b11f7ae2114/drmelon-smallgate.zip",
   "https://x901.net/quaddictedfiles/drmelon-smallgate.zip"
  ]
 }

--- a/json/by-sha256/68/681d67a59ff42a6114ef48e5c717ddceb1713371a8736075b0f8847649295747.json
+++ b/json/by-sha256/68/681d67a59ff42a6114ef48e5c717ddceb1713371a8736075b0f8847649295747.json
@@ -860,6 +860,7 @@
   "type=speedmap"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/68/681d67a59ff42a6114ef48e5c717ddceb1713371a8736075b0f8847649295747/sm227.zip",
   "https://x901.net/quaddictedfiles/sm227.zip"
  ]
 }

--- a/json/by-sha256/6e/6e8dcde54e83560b2515277f198fedf3fcd8ddacbf14b3e86a37da812bb6e9c9.json
+++ b/json/by-sha256/6e/6e8dcde54e83560b2515277f198fedf3fcd8ddacbf14b3e86a37da812bb6e9c9.json
@@ -39,6 +39,7 @@
   "zipbasedir=id1/maps/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/6e/6e8dcde54e83560b2515277f198fedf3fcd8ddacbf14b3e86a37da812bb6e9c9/planetside.zip",
   "https://x901.net/quaddictedfiles/planetside.zip"
  ]
 }

--- a/json/by-sha256/6f/6fa8076f2494e9b1766a7367fecbbc499a3b3897212f48911e09c7bded31152f.json
+++ b/json/by-sha256/6f/6fa8076f2494e9b1766a7367fecbbc499a3b3897212f48911e09c7bded31152f.json
@@ -39,6 +39,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/6f/6fa8076f2494e9b1766a7367fecbbc499a3b3897212f48911e09c7bded31152f/deception1.1.zip",
   "https://x901.net/quaddictedfiles/deception1.1.zip"
  ]
 }

--- a/json/by-sha256/72/72163b4d7131602c593ef028004108886483c5d2a2c1a831a4d5cf7068bbc3c6.json
+++ b/json/by-sha256/72/72163b4d7131602c593ef028004108886483c5d2a2c1a831a4d5cf7068bbc3c6.json
@@ -130,6 +130,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/72/72163b4d7131602c593ef028004108886483c5d2a2c1a831a4d5cf7068bbc3c6/zet_auriga_v1.01.zip",
   "https://x901.net/quaddictedfiles/zet_auriga_v1.01.zip"
  ]
 }

--- a/json/by-sha256/76/76ec31782bf5c8cf9a372c59bfd20b5e38f7d76c94aa1190078cfb72ecb41cd3.json
+++ b/json/by-sha256/76/76ec31782bf5c8cf9a372c59bfd20b5e38f7d76c94aa1190078cfb72ecb41cd3.json
@@ -7632,6 +7632,7 @@
   "zipbasedir=drake/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/76/76ec31782bf5c8cf9a372c59bfd20b5e38f7d76c94aa1190078cfb72ecb41cd3/drakebeta2021.zip",
   "https://x901.net/quaddictedfiles/drakebeta2021.zip"
  ]
 }

--- a/json/by-sha256/7c/7cc783ecf6332fd1c8b0d14862f1e7e3d23e81c240bf09a0dceaa4d8d284154a.json
+++ b/json/by-sha256/7c/7cc783ecf6332fd1c8b0d14862f1e7e3d23e81c240bf09a0dceaa4d8d284154a.json
@@ -2914,6 +2914,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/7c/7cc783ecf6332fd1c8b0d14862f1e7e3d23e81c240bf09a0dceaa4d8d284154a/utotp.zip",
   "https://x901.net/quaddictedfiles/utotp.zip"
  ]
 }

--- a/json/by-sha256/84/84617c1428197c3f9144b54620a6bc6d075183cc4c00c3f1a225442276421c49.json
+++ b/json/by-sha256/84/84617c1428197c3f9144b54620a6bc6d075183cc4c00c3f1a225442276421c49.json
@@ -96,6 +96,7 @@
   "zipbasedir=id1/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/84/84617c1428197c3f9144b54620a6bc6d075183cc4c00c3f1a225442276421c49/coger.zip",
   "https://x901.net/quaddictedfiles/coger.zip"
  ]
 }

--- a/json/by-sha256/85/853df5101ad6a79af9aa8d7179d9496112b822c77a4d9109b889923a268c8fb1.json
+++ b/json/by-sha256/85/853df5101ad6a79af9aa8d7179d9496112b822c77a4d9109b889923a268c8fb1.json
@@ -38,6 +38,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/85/853df5101ad6a79af9aa8d7179d9496112b822c77a4d9109b889923a268c8fb1/casana.zip",
   "https://x901.net/quaddictedfiles/casana.zip"
  ]
 }

--- a/json/by-sha256/86/86f887964816d2231410655d07dd636331a805b94b465faf9186751a6b65cfae.json
+++ b/json/by-sha256/86/86f887964816d2231410655d07dd636331a805b94b465faf9186751a6b65cfae.json
@@ -1104,6 +1104,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/86/86f887964816d2231410655d07dd636331a805b94b465faf9186751a6b65cfae/reload.zip",
   "https://x901.net/quaddictedfiles/reload.zip"
  ]
 }

--- a/json/by-sha256/8a/8adcd23c3a814448ba3edb5182b976dcdd85a094ab3c266afca02eccfd00acc7.json
+++ b/json/by-sha256/8a/8adcd23c3a814448ba3edb5182b976dcdd85a094ab3c266afca02eccfd00acc7.json
@@ -54,6 +54,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/8a/8adcd23c3a814448ba3edb5182b976dcdd85a094ab3c266afca02eccfd00acc7/lostandfoundry1.1.zip",
   "https://x901.net/quaddictedfiles/lostandfoundry1.1.zip"
  ]
 }

--- a/json/by-sha256/8f/8f5282bcbee8d013afc6101847f795a07cc6b76b62f0ca0c4c401314eb97be0a.json
+++ b/json/by-sha256/8f/8f5282bcbee8d013afc6101847f795a07cc6b76b62f0ca0c4c401314eb97be0a.json
@@ -41,6 +41,7 @@
   "zipbasedir=id1/maps/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/8f/8f5282bcbee8d013afc6101847f795a07cc6b76b62f0ca0c4c401314eb97be0a/soulrunnerquakemaps.zip",
   "https://x901.net/quaddictedfiles/soulrunnerquakemaps.zip"
  ]
 }

--- a/json/by-sha256/8f/8fb5284bf6038f9ec9a821e4b37f2c5e439c0f5d752e794d1db583fbc0f4056b.json
+++ b/json/by-sha256/8f/8fb5284bf6038f9ec9a821e4b37f2c5e439c0f5d752e794d1db583fbc0f4056b.json
@@ -155,6 +155,7 @@
   "zipbasedir=ad/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/8f/8fb5284bf6038f9ec9a821e4b37f2c5e439c0f5d752e794d1db583fbc0f4056b/replicon.zip",
   "https://x901.net/quaddictedfiles/replicon.zip"
  ]
 }

--- a/json/by-sha256/92/92b11d3749b3b7d0ada1cbf779417d56ccfbfaf24347c91a416c5da91f82d687.json
+++ b/json/by-sha256/92/92b11d3749b3b7d0ada1cbf779417d56ccfbfaf24347c91a416c5da91f82d687.json
@@ -1285,6 +1285,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/92/92b11d3749b3b7d0ada1cbf779417d56ccfbfaf24347c91a416c5da91f82d687/snack3.zip",
   "https://x901.net/quaddictedfiles/snack3.zip"
  ]
 }

--- a/json/by-sha256/93/930176a96fb051241696843fa6840d28b4c36671078d50b1ec24ccd6d023c854.json
+++ b/json/by-sha256/93/930176a96fb051241696843fa6840d28b4c36671078d50b1ec24ccd6d023c854.json
@@ -45,6 +45,7 @@
   "zipbasedir=ad/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/93/930176a96fb051241696843fa6840d28b4c36671078d50b1ec24ccd6d023c854/ad_tower.zip",
   "https://x901.net/quaddictedfiles/ad_tower.zip"
  ]
 }

--- a/json/by-sha256/9b/9b37a5d251225d0e8778d8eeb78c24f35bdd9355d4880dbbb0cddcb0b5533eb8.json
+++ b/json/by-sha256/9b/9b37a5d251225d0e8778d8eeb78c24f35bdd9355d4880dbbb0cddcb0b5533eb8.json
@@ -67,6 +67,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/9b/9b37a5d251225d0e8778d8eeb78c24f35bdd9355d4880dbbb0cddcb0b5533eb8/zafp.zip",
   "https://x901.net/quaddictedfiles/zafp.zip"
  ]
 }

--- a/json/by-sha256/9b/9bc22a1b3ae830eef815d3eb2570b109434dd1535b993f8315e4539d595a604f.json
+++ b/json/by-sha256/9b/9bc22a1b3ae830eef815d3eb2570b109434dd1535b993f8315e4539d595a604f.json
@@ -39,6 +39,7 @@
   "zipbasedir=id1/maps/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/9b/9bc22a1b3ae830eef815d3eb2570b109434dd1535b993f8315e4539d595a604f/castle.zip",
   "https://x901.net/quaddictedfiles/castle.zip"
  ]
 }

--- a/json/by-sha256/9e/9efb783db0d413d272c9a95a2aca1c37bad452276d6a55f12bd4cc9cfdb58d5f.json
+++ b/json/by-sha256/9e/9efb783db0d413d272c9a95a2aca1c37bad452276d6a55f12bd4cc9cfdb58d5f.json
@@ -127,6 +127,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/9e/9efb783db0d413d272c9a95a2aca1c37bad452276d6a55f12bd4cc9cfdb58d5f/vothlogV1.zip",
   "https://x901.net/quaddictedfiles/vothlogV1.zip"
  ]
 }

--- a/json/by-sha256/a6/a6c8789e985b110718aa249a9f53565c507ff57831498def218ea9939324d5f1.json
+++ b/json/by-sha256/a6/a6c8789e985b110718aa249a9f53565c507ff57831498def218ea9939324d5f1.json
@@ -1044,6 +1044,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/a6/a6c8789e985b110718aa249a9f53565c507ff57831498def218ea9939324d5f1/bv.zip",
   "https://x901.net/quaddictedfiles/bv.zip"
  ]
 }

--- a/json/by-sha256/a7/a751f4eff0ef861669e28fd1cfaf518a1cc3bbc2758c02db42c3a34c37a98e63.json
+++ b/json/by-sha256/a7/a751f4eff0ef861669e28fd1cfaf518a1cc3bbc2758c02db42c3a34c37a98e63.json
@@ -106,6 +106,7 @@
   "zipbasedir=ad/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/a7/a751f4eff0ef861669e28fd1cfaf518a1cc3bbc2758c02db42c3a34c37a98e63/freyja-ad-1.5.zip",
   "https://x901.net/quaddictedfiles/freyja-ad-1.5.zip"
  ]
 }

--- a/json/by-sha256/a7/a75f04317459e69961acfcded5e43c6fdc5d44d7775730f741daf71ebfbb7042.json
+++ b/json/by-sha256/a7/a75f04317459e69961acfcded5e43c6fdc5d44d7775730f741daf71ebfbb7042.json
@@ -46,6 +46,7 @@
   "zipbasedir=ad/maps/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/a7/a75f04317459e69961acfcded5e43c6fdc5d44d7775730f741daf71ebfbb7042/ad_roj1.zip",
   "https://x901.net/quaddictedfiles/ad_roj1.zip"
  ]
 }

--- a/json/by-sha256/af/afccd47d4ab7f6c4a8b5f81f8261977934875b11f6782f1f6d1de3b24ad78fd3.json
+++ b/json/by-sha256/af/afccd47d4ab7f6c4a8b5f81f8261977934875b11f6782f1f6d1de3b24ad78fd3.json
@@ -295,6 +295,7 @@
   "type=speedmap"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/af/afccd47d4ab7f6c4a8b5f81f8261977934875b11f6782f1f6d1de3b24ad78fd3/sm228.zip",
   "https://x901.net/quaddictedfiles/sm228.zip"
  ]
 }

--- a/json/by-sha256/af/aff4eab971e06a5f6800e277d72bdbfec36e3ba40c08fedba2dffb5161e9b0a8.json
+++ b/json/by-sha256/af/aff4eab971e06a5f6800e277d72bdbfec36e3ba40c08fedba2dffb5161e9b0a8.json
@@ -885,6 +885,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/af/aff4eab971e06a5f6800e277d72bdbfec36e3ba40c08fedba2dffb5161e9b0a8/taintedv1_2.zip",
   "https://x901.net/quaddictedfiles/taintedv1_2.zip"
  ]
 }

--- a/json/by-sha256/b1/b17fbfd4d5b93e75b418ed1038f0ca8a0c529ebb26cc87fc55c60baa6fc49cc3.json
+++ b/json/by-sha256/b1/b17fbfd4d5b93e75b418ed1038f0ca8a0c529ebb26cc87fc55c60baa6fc49cc3.json
@@ -2268,6 +2268,7 @@
   "zipbasedir=mjam/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/b1/b17fbfd4d5b93e75b418ed1038f0ca8a0c529ebb26cc87fc55c60baa6fc49cc3/mjam.zip",
   "https://x901.net/quaddictedfiles/mjam.zip"
  ]
 }

--- a/json/by-sha256/b9/b936d086fece844fbf88dc0681011b80513f92aa3542474e3d8d2b6540cec409.json
+++ b/json/by-sha256/b9/b936d086fece844fbf88dc0681011b80513f92aa3542474e3d8d2b6540cec409.json
@@ -8008,6 +8008,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/b9/b936d086fece844fbf88dc0681011b80513f92aa3542474e3d8d2b6540cec409/limjam.zip",
   "https://x901.net/quaddictedfiles/limjam.zip"
  ]
 }

--- a/json/by-sha256/be/be5340fc87d86533c3560bf13cd3cf804fd17cc94220b1890d7e9fcdcc2ea097.json
+++ b/json/by-sha256/be/be5340fc87d86533c3560bf13cd3cf804fd17cc94220b1890d7e9fcdcc2ea097.json
@@ -51,6 +51,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/be/be5340fc87d86533c3560bf13cd3cf804fd17cc94220b1890d7e9fcdcc2ea097/itisover2024.zip",
   "https://x901.net/quaddictedfiles/itisover2024.zip"
  ]
 }

--- a/json/by-sha256/bf/bfc0900ab7e079e256ff7307f40df2f48cd6f40a9095e630b037ff9b246ade5e.json
+++ b/json/by-sha256/bf/bfc0900ab7e079e256ff7307f40df2f48cd6f40a9095e630b037ff9b246ade5e.json
@@ -63,6 +63,7 @@
   "zipbasedir=copper/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/bf/bfc0900ab7e079e256ff7307f40df2f48cd6f40a9095e630b037ff9b246ade5e/dungeonechoparadox-1.0.zip",
   "https://x901.net/quaddictedfiles/dungeonechoparadox-1.0.zip"
  ]
 }

--- a/json/by-sha256/c2/c2d00dddc98fe7d65c0f10ee995423ed69ffbad8309834b8ce885aec7e337e85.json
+++ b/json/by-sha256/c2/c2d00dddc98fe7d65c0f10ee995423ed69ffbad8309834b8ce885aec7e337e85.json
@@ -3230,6 +3230,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/c2/c2d00dddc98fe7d65c0f10ee995423ed69ffbad8309834b8ce885aec7e337e85/aqualusV11.zip",
   "https://x901.net/quaddictedfiles/aqualusV11.zip"
  ]
 }

--- a/json/by-sha256/c8/c81e697588a9e81990c79b42d016781889726c616f4d1cc712abec8f5ab92e8a.json
+++ b/json/by-sha256/c8/c81e697588a9e81990c79b42d016781889726c616f4d1cc712abec8f5ab92e8a.json
@@ -104,6 +104,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/c8/c81e697588a9e81990c79b42d016781889726c616f4d1cc712abec8f5ab92e8a/blorgsp1.zip",
   "https://x901.net/quaddictedfiles/blorgsp1.zip"
  ]
 }

--- a/json/by-sha256/c8/c849d7d59b951d80d745ba25caf923e22144a9f65b73a9055ccd300efaa01e10.json
+++ b/json/by-sha256/c8/c849d7d59b951d80d745ba25caf923e22144a9f65b73a9055ccd300efaa01e10.json
@@ -2565,6 +2565,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/c8/c849d7d59b951d80d745ba25caf923e22144a9f65b73a9055ccd300efaa01e10/qbj_1.05.zip",
   "https://x901.net/quaddictedfiles/qbj_1.05.zip"
  ]
 }

--- a/json/by-sha256/c8/c8911acf99b9addd84579c9614125dac8c1b1bc7b631bc9b02bc23b4b7bde027.json
+++ b/json/by-sha256/c8/c8911acf99b9addd84579c9614125dac8c1b1bc7b631bc9b02bc23b4b7bde027.json
@@ -230,6 +230,7 @@
   "zipbasedir=ad/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/c8/c8911acf99b9addd84579c9614125dac8c1b1bc7b631bc9b02bc23b4b7bde027/gibtropolis.zip",
   "https://x901.net/quaddictedfiles/gibtropolis.zip"
  ]
 }

--- a/json/by-sha256/cc/cc9d348b4a116ce60cbaa89c8deb2b95e9e0ef78c0a26a297d7ad5a7927e0317.json
+++ b/json/by-sha256/cc/cc9d348b4a116ce60cbaa89c8deb2b95e9e0ef78c0a26a297d7ad5a7927e0317.json
@@ -2998,6 +2998,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/cc/cc9d348b4a116ce60cbaa89c8deb2b95e9e0ef78c0a26a297d7ad5a7927e0317/alk_tonrotusspmp4_1_1_1.zip",
   "https://x901.net/quaddictedfiles/alk_tonrotusspmp4_1_1_1.zip"
  ]
 }

--- a/json/by-sha256/d4/d4e45c20a816ce13c49c5f717c492b4acc9181ed969505aa34548da1d7e28f55.json
+++ b/json/by-sha256/d4/d4e45c20a816ce13c49c5f717c492b4acc9181ed969505aa34548da1d7e28f55.json
@@ -2631,6 +2631,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/d4/d4e45c20a816ce13c49c5f717c492b4acc9181ed969505aa34548da1d7e28f55/lamothe-1.0.zip",
   "https://x901.net/quaddictedfiles/lamothe-1.0.zip"
  ]
 }

--- a/json/by-sha256/da/da3c76fe3b2f55dba8c182dfc747e0b521e5205f135ce7a247213074a28ac322.json
+++ b/json/by-sha256/da/da3c76fe3b2f55dba8c182dfc747e0b521e5205f135ce7a247213074a28ac322.json
@@ -44,6 +44,7 @@
   "zipbasedir=id1/maps/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/da/da3c76fe3b2f55dba8c182dfc747e0b521e5205f135ce7a247213074a28ac322/nola1.zip",
   "https://x901.net/quaddictedfiles/nola1.zip"
  ]
 }

--- a/json/by-sha256/dc/dcb5f9bbf05322e4d6a9740e9add5ef9486050cc35218d762d88a3d4f8feb7fe.json
+++ b/json/by-sha256/dc/dcb5f9bbf05322e4d6a9740e9add5ef9486050cc35218d762d88a3d4f8feb7fe.json
@@ -147,6 +147,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/dc/dcb5f9bbf05322e4d6a9740e9add5ef9486050cc35218d762d88a3d4f8feb7fe/srj1.zip",
   "https://x901.net/quaddictedfiles/srj1.zip"
  ]
 }

--- a/json/by-sha256/e5/e5cb36d0adf69c587523f0f1706c6cd01602cd41e690adfb9c998691966fa0e0.json
+++ b/json/by-sha256/e5/e5cb36d0adf69c587523f0f1706c6cd01602cd41e690adfb9c998691966fa0e0.json
@@ -36,6 +36,7 @@
   "zipbasedir=id1/maps/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/e5/e5cb36d0adf69c587523f0f1706c6cd01602cd41e690adfb9c998691966fa0e0/tc_cemix.zip",
   "https://x901.net/quaddictedfiles/tc_cemix.zip"
  ]
 }

--- a/json/by-sha256/e6/e616f0398ea0c9180f576b86ef71d49b43988b2d55344e35a8a5c571306c1e4d.json
+++ b/json/by-sha256/e6/e616f0398ea0c9180f576b86ef71d49b43988b2d55344e35a8a5c571306c1e4d.json
@@ -50,6 +50,7 @@
   "zipbasedir=ad/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/e6/e616f0398ea0c9180f576b86ef71d49b43988b2d55344e35a8a5c571306c1e4d/ad_behop_1d.zip",
   "https://x901.net/quaddictedfiles/ad_behop_1d.zip"
  ]
 }

--- a/json/by-sha256/e8/e8ae95cbf8baee5e566c62aa4ba98a79ccba62075bd3fcbecd131a5a4491de9e.json
+++ b/json/by-sha256/e8/e8ae95cbf8baee5e566c62aa4ba98a79ccba62075bd3fcbecd131a5a4491de9e.json
@@ -2963,6 +2963,7 @@
   "version=1.2"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/e8/e8ae95cbf8baee5e566c62aa4ba98a79ccba62075bd3fcbecd131a5a4491de9e/rm1.2b.zip",
   "https://x901.net/quaddictedfiles/rm1.2b.zip"
  ]
 }

--- a/json/by-sha256/ee/ee055107b62f559a9278f5f523eaad1a96b5b5a4db558b8e747e3d4e0dc82365.json
+++ b/json/by-sha256/ee/ee055107b62f559a9278f5f523eaad1a96b5b5a4db558b8e747e3d4e0dc82365.json
@@ -49,6 +49,7 @@
   "zipbasedir=id1/maps/"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/ee/ee055107b62f559a9278f5f523eaad1a96b5b5a4db558b8e747e3d4e0dc82365/the_roted_castle.zip",
   "https://x901.net/quaddictedfiles/the_roted_castle.zip"
  ]
 }

--- a/json/by-sha256/ef/efe242cc0162e77377fa3026f17226da8472e60b1291bbd86154dcf0589e27f0.json
+++ b/json/by-sha256/ef/efe242cc0162e77377fa3026f17226da8472e60b1291bbd86154dcf0589e27f0.json
@@ -45,6 +45,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/ef/efe242cc0162e77377fa3026f17226da8472e60b1291bbd86154dcf0589e27f0/ad_digs10.zip",
   "https://x901.net/quaddictedfiles/ad_digs10.zip"
  ]
 }

--- a/json/by-sha256/f4/f4942be97fa248998042f480e37a506e65c7e59a577d480605b0f0fc5cc52482.json
+++ b/json/by-sha256/f4/f4942be97fa248998042f480e37a506e65c7e59a577d480605b0f0fc5cc52482.json
@@ -45,6 +45,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/f4/f4942be97fa248998042f480e37a506e65c7e59a577d480605b0f0fc5cc52482/cataclysm_v1.1.zip",
   "https://x901.net/quaddictedfiles/cataclysm_v1.1.zip"
  ]
 }

--- a/json/by-sha256/f5/f56997aa143e503e08a20b840563851075da39f583a42ae42eab9f35a9782a4f.json
+++ b/json/by-sha256/f5/f56997aa143e503e08a20b840563851075da39f583a42ae42eab9f35a9782a4f.json
@@ -1021,6 +1021,7 @@
   "type=mod"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/f5/f56997aa143e503e08a20b840563851075da39f583a42ae42eab9f35a9782a4f/starslave_v1_3.zip",
   "https://x901.net/quaddictedfiles/starslave_v1_3.zip"
  ]
 }

--- a/json/by-sha256/f5/f5f544edd314baa28e0e2395f5ef15527c57ecfbf35e44f4d1795a1b223769df.json
+++ b/json/by-sha256/f5/f5f544edd314baa28e0e2395f5ef15527c57ecfbf35e44f4d1795a1b223769df.json
@@ -49,6 +49,7 @@
   "type=map"
  ],
  "urls": [
+  "https://www.quaddicted.com/files/by-sha256/f5/f5f544edd314baa28e0e2395f5ef15527c57ecfbf35e44f4d1795a1b223769df/dope1.zip",
   "https://x901.net/quaddictedfiles/dope1.zip"
  ]
 }


### PR DESCRIPTION
I mirrored lots of files to Quaddicted.

65894a8a8a6be1d28d6f7ee5a653f67aaaaa8a27846a8f5ba181fc9123d15059 -> https://x901.net/quaddictedfiles/tombofthunder_mod_2024_v1032a.zip was a 404 (cc @rjthorne) so I used the opportunity to test what happens if we don't have any download URL and removed the dead link. I will mirror it once available ;)