### PR TITLE
20 new releases, take 2

### DIFF
--- a/json/by-sha256/05/05301468d36e0b017c4f90622100bc0bb325ea2d2d8c44be915b9f7732edfbce.json
+++ b/json/by-sha256/05/05301468d36e0b017c4f90622100bc0bb325ea2d2d8c44be915b9f7732edfbce.json
@@ -1,0 +1,48 @@
+{
+ "bytes": 8419025,
+ "description": "Gothic-themed map set in an overridden chapel. The author's first finished map.",
+ "files": {
+  "hgs.bsp": {
+   "bytes": 16771020,
+   "sha256": "73cd953e44610fde78254f7f80078116e2f6c7f3ff4b691d86a37967bfc1f5f3",
+   "timestamp": "2024-09-16T20:02:56.000Z"
+  },
+  "hgs.map": {
+   "bytes": 3785051,
+   "sha256": "bf0bbcd00e57c293108c5db9166d810c25f27536f668e0d31d22443f853373a6",
+   "timestamp": "2024-09-16T20:09:58.000Z"
+  },
+  "hgs.txt": {
+   "bytes": 1436,
+   "sha256": "03bfe2c183a66caa1423f5724f89ba2f7762886d8fae4caa5b72db9e1e40765e",
+   "timestamp": "2024-09-16T20:34:56.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/copper/maps"
+ },
+ "json_version": "2023.11.06-23.20",
+ "notes": [
+  "This map requires <a href=\"2932bdfda11224125c3f7207701bed8c4b7a765a2370a581589a5e17337b7eb8\">Copper</a>."
+ ],
+ "sha256": "05301468d36e0b017c4f90622100bc0bb325ea2d2d8c44be915b9f7732edfbce",
+ "tags": [
+  "author=Livehyperion",
+  "commandline=-game copper",
+  "dependency=copper_v1_30",
+  "depends=('copper=1.30')",
+  "filename=hgs.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/hellgate-sanctuary.399/)",
+  "mod=copper",
+  "release_date=2024-09-18",
+  "startmap=hgs",
+  "title=Hellgate Sanctuary",
+  "type=map",
+  "zipbasedir=copper/maps"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/hgs.zip"
+ ]
+}

--- a/json/by-sha256/68/68b42dbcdae2b9e7136f0575034b6eebdd67dfa7c3a9af06b65904aadeae225a.json
+++ b/json/by-sha256/68/68b42dbcdae2b9e7136f0575034b6eebdd67dfa7c3a9af06b65904aadeae225a.json
@@ -1,0 +1,45 @@
+{
+ "bytes": 1440473,
+ "description": "Small, confined map with an original bright and airy theme and action-packed gameplay. An updated version of <a href=\"e5cb36d0adf69c587523f0f1706c6cd01602cd41e690adfb9c998691966fa0e0\">tc_cemix</a>",
+ "files": {
+  "tc_cemix.bsp": {
+   "bytes": 2361024,
+   "sha256": "43d5740eb5b5441ab4dc514f299af1727ce812b66de159d92603aa20c88b4d4b",
+   "timestamp": "2024-07-27T02:46:14.000Z"
+  },
+  "tc_cemix.lit": {
+   "bytes": 672020,
+   "sha256": "5a96d5f076c2db48de2403a67cbdfde7b79e9ff20fa4b9b0adb2d57ad243c46c",
+   "timestamp": "2024-07-27T02:46:14.000Z"
+  },
+  "tc_cemix.txt": {
+   "bytes": 1647,
+   "sha256": "4f656656dc95053624707f0154f35d5c7f57c416a3509829e9a52c2f7489386e",
+   "timestamp": "2024-07-11T15:05:24.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/id1/maps/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "sha256": "68b42dbcdae2b9e7136f0575034b6eebdd67dfa7c3a9af06b65904aadeae225a",
+ "tags": [
+  "author=Carter",
+  "current_main_group_package=yes",
+  "filename=tc_cemix1_1.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/1024-cement-mixer.370/)",
+  "provides='tc_cemix=1.1'",
+  "release_date=2024-07-27",
+  "release_group=tc_cemix",
+  "startmap=tc_cemix",
+  "title=1024 Cement Mixer",
+  "type=map",
+  "version=1.1",
+  "zipbasedir=id1/maps/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/tc_cemix1_1.zip"
+ ]
+}

--- a/json/by-sha256/69/6983ada1102109ee59f1a27c9a73de9b3858d302ba989dba3608b7722474d4be.json
+++ b/json/by-sha256/69/6983ada1102109ee59f1a27c9a73de9b3858d302ba989dba3608b7722474d4be.json
@@ -1,0 +1,41 @@
+{
+ "bytes": 1180991,
+ "description": "Unsealed map using a variety of textures.",
+ "files": {
+  "voices.bsp": {
+   "bytes": 2883396,
+   "sha256": "d9aa8bd48f7a8653ad6033d540858b05b003f91af8b0a6a1936b58ea5531e5f9",
+   "timestamp": "2024-08-12T14:52:40.000Z"
+  },
+  "voices.pts": {
+   "bytes": 32207,
+   "sha256": "f2b7274eace08662d2aa5341d482208111240777468e8c8a7b81c2d152f43602",
+   "timestamp": "2024-08-10T13:53:38.000Z"
+  },
+  "voices.txt": {
+   "bytes": 346,
+   "sha256": "30435424635e63d7e664a9ee7bfa3be803c431e855d3d6cdd5744d20156503e1",
+   "timestamp": "2024-08-12T14:58:26.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/id1/maps/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "sha256": "6983ada1102109ee59f1a27c9a73de9b3858d302ba989dba3608b7722474d4be",
+ "tags": [
+  "author=GraveyardKaiser",
+  "filename=voices.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/dead-voices.385/)",
+  "release_date=2024-08-12",
+  "startmap=voices",
+  "title=Dead Voices",
+  "type=map",
+  "zipbasedir=id1/maps/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/voices.zip"
+ ]
+}

--- a/json/by-sha256/72/72467c8320ad09118e7fb41932eef0884da7ced283b738ede3db09870a5d0166.json
+++ b/json/by-sha256/72/72467c8320ad09118e7fb41932eef0884da7ced283b738ede3db09870a5d0166.json
@@ -1,0 +1,41 @@
+{
+ "bytes": 1049080,
+ "description": "Unsealed map using a variety of textures.",
+ "files": {
+  "funeral.bsp": {
+   "bytes": 2613776,
+   "sha256": "fd48c814953c6ec1445f6fa66cdc133ddd5b3c4986a2d1833f2eb9c9592b4a15",
+   "timestamp": "2024-09-02T21:20:34.000Z"
+  },
+  "funeral.pts": {
+   "bytes": 16606,
+   "sha256": "f803c9cf47e33bd1c2ad2a3e6a5adfa1f866f48decef329c7c3ceb7745afc2e6",
+   "timestamp": "2024-09-02T18:42:06.000Z"
+  },
+  "funeral.txt": {
+   "bytes": 395,
+   "sha256": "affb168a10d2dd5b8d2915218a0a526e3fcd2f782b95da83fb02677d7e499f7d",
+   "timestamp": "2024-09-02T21:26:56.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/id1/maps/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "sha256": "72467c8320ad09118e7fb41932eef0884da7ced283b738ede3db09870a5d0166",
+ "tags": [
+  "author=GraveyardKaiser",
+  "filename=funeral.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/pipe-funeral.393/)",
+  "release_date=2024-09-02",
+  "startmap=funeral",
+  "title=Pipe Funeral",
+  "type=map",
+  "zipbasedir=id1/maps/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/funeral.zip"
+ ]
+}

--- a/json/by-sha256/7c/7c3c3248aad0ed208ea072fc595220627d403f158a82884b0b6630f0f06229d9.json
+++ b/json/by-sha256/7c/7c3c3248aad0ed208ea072fc595220627d403f158a82884b0b6630f0f06229d9.json
@@ -1,0 +1,513 @@
+{
+ "bytes": 28206782,
+ "description": "Pack of 24 maps in a retro e2/metal/wizard style, connected by a start map. The first Quake jam hosted by Quake 2's Map Center discord, featuring entries from many first-time Quake mappers alongside a few veterans.",
+ "files": {
+  "mc_retrojam1/bots/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-08-06T19:38:20.000Z"
+  },
+  "mc_retrojam1/bots/navigation/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-08-06T19:38:20.000Z"
+  },
+  "mc_retrojam1/bots/navigation/mc_rj1_cc.nav": {
+   "bytes": 6344,
+   "sha256": "5dc5570aacea20e8863f9f4b2373bcd8ad3f91f7d6e71f425a5fb3473c5c1e0d",
+   "timestamp": "2024-08-06T15:40:26.000Z"
+  },
+  "mc_retrojam1/bots/navigation/mc_rj1_dumptruck.nav": {
+   "bytes": 6224,
+   "sha256": "371db4386d42dade1ba6d117131aa737485d1a7bc258f68a883f0d89b8e41825",
+   "timestamp": "2024-08-06T14:57:44.000Z"
+  },
+  "mc_retrojam1/bots/navigation/mc_rj1_iyago.nav": {
+   "bytes": 12136,
+   "sha256": "83cfa6036c16d5e2260a6cfefb0c3804eaa114593bddb049d6f50aa402ed116a",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/bots/navigation/mc_rj1_niccolicious.nav": {
+   "bytes": 3640,
+   "sha256": "0c7459270bd84abeafd234d8b5454800c4f1b75f6827f12a209bb8e5310662c9",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/bots/navigation/mc_rj1_sock.nav": {
+   "bytes": 3906,
+   "sha256": "511bca6fbc66af71d722558ce85903a1ecf63c18878978f61d9f0b51380d0df3",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/bots/navigation/mc_rj1_thundergoose.nav": {
+   "bytes": 4520,
+   "sha256": "b42b75c2de3e16c660b9cffce9ed3b9abce97689eb8c6641771c6ff25c13c62d",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/descript.ion": {
+   "bytes": 23,
+   "sha256": "14162b1a3c46ce2628215363bf0e4e170dd9dd98a4c4c12dfe7002fec1a8e4b1",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-08-06T19:38:20.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_atom1k.txt": {
+   "bytes": 1298,
+   "sha256": "1ff3ffb8ac8f62c68bac5d9834393d933f2cbc767f0b84fcec626162715c6c8d",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_cc.txt": {
+   "bytes": 1434,
+   "sha256": "d15203bcb4d1bed27cebf24953708c41e64a9e0cab73fc6ad976bb8eb9d6c61e",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_chnuckierdbeer.txt": {
+   "bytes": 84,
+   "sha256": "5f7fb9ecf0a89c96b33a6acaf680ef780ba9b674c10ed9c66d8e8d7bbc555ed8",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_chuma.txt": {
+   "bytes": 2339,
+   "sha256": "99ece7383c4758c85049ba8a630fb7bec1ca783083748ca7f546a71d8c6923f8",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_colossus.txt": {
+   "bytes": 1527,
+   "sha256": "1eef89f5e8e4e56cee0c2d2c4fc0ec69dd319e8c6a1aa07c8731a24922dae24f",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_detrohogga.txt": {
+   "bytes": 1934,
+   "sha256": "3221448829ceb7823424159983141cee8d92383eef96eff23c576452a229a8f2",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_deviltower.txt": {
+   "bytes": 3067,
+   "sha256": "64c874e8ffa5cd34826f2ae3487be447a1e3f5d0f85c55d93755c568a3174068",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_dumptruck.txt": {
+   "bytes": 599,
+   "sha256": "40a495265df559b95851b354136af7aaa669c26330c662df3e04bf4f8a97c04b",
+   "timestamp": "2024-08-06T15:54:06.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_fix.txt": {
+   "bytes": 357,
+   "sha256": "6e0a78261ca271ffdd632731970c2fa7be377dea39d3b5737ee55b5588233a4f",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_indigo.txt": {
+   "bytes": 701,
+   "sha256": "7f2ad4791c8e1efc047b50765987ab75c3e44f4a4abc40eae0d47fb90206f175",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_ioridyson.txt": {
+   "bytes": 516,
+   "sha256": "42887a396a472658090aee8995e30838599766f803ab1d0ee74ca9a7d1f5a9b2",
+   "timestamp": "2024-08-06T15:34:22.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_iyago.txt": {
+   "bytes": 3088,
+   "sha256": "327524510a51a39cb8c7ed0af8cacdf253c860b44737bbe5f4caa621d05de2b4",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_jerry_readme.txt": {
+   "bytes": 646,
+   "sha256": "b37b3b3320adc71f3d9b57147b66be41263c3c5c6a429c8dba0aab13a35756da",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_kdmg_readme.txt": {
+   "bytes": 1948,
+   "sha256": "2872607b1128982820fa10946d888a62cf8784d3259d863e5ed8ee7d84b6edfa",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_knefarious.txt": {
+   "bytes": 244,
+   "sha256": "1b7d9c8bec8b61ca708670e22211ab6d75b45b0b04ca5bbf6cf158bcff87aacb",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_niccolicious.txt": {
+   "bytes": 2230,
+   "sha256": "d9596dab046843f78f0ad4bf838becbdb56a50da8c4b34723098118e3af9575a",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_scump.txt": {
+   "bytes": 1919,
+   "sha256": "b70adce76b3f83912281bed6e7791b9699e163bbac9b99ac14c73ab62d87ff00",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_shades.txt": {
+   "bytes": 1843,
+   "sha256": "e232f14ee989e85123791c7b61aac22845621cdd10fe4e8400d88e30982b74ef",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_simonn.txt": {
+   "bytes": 1797,
+   "sha256": "539b888b24b0d0adfb8fd48e7b4b1cac6e171915b8b90e73b061ae513676c5fd",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_sixsik6.txt": {
+   "bytes": 2094,
+   "sha256": "27f0729ea1a7e8d84ded23a780c9163df97820e25c6d98ef3ed3404b2a6db145",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_thelokk.txt": {
+   "bytes": 1980,
+   "sha256": "b02ef07382e32790f40ea2f7234f36cecc9fd8830d650ad39d66329ad5ae3b13",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/docs/mc_rj1_thundergoose.txt": {
+   "bytes": 1353,
+   "sha256": "b95cdaf9832c7897362d773b89fe26b0d28f263d80bbcf0dc08f6f984562e0be",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/gfx/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-08-07T00:11:12.000Z"
+  },
+  "mc_retrojam1/gfx/conback.lmp": {
+   "bytes": 64008,
+   "sha256": "7eab535261fc6641bc3d549bf53d4afaeaffddf56c64e88673d5360ef5ffca6d",
+   "timestamp": "2024-08-07T00:10:50.000Z"
+  },
+  "mc_retrojam1/mapdb.json": {
+   "bytes": 6953,
+   "sha256": "ca3a29589ed9a24ca2df324cc2cd77939ceed250f685794d51ebca54181dd51a",
+   "timestamp": "2024-08-06T15:43:30.000Z"
+  },
+  "mc_retrojam1/maps/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-08-06T23:50:16.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_atom1k.bsp": {
+   "bytes": 930634,
+   "sha256": "e0c91ce8d548e46bd71db869ae4acf9616b6a030558220482acd51ae88fff286",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_cc.bsp": {
+   "bytes": 2452164,
+   "sha256": "702de68772866c1bf9154b26d75029fb18a45f8aae50bb8d96350fb5a51fcec6",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_chnuckierdbeer.bsp": {
+   "bytes": 2791112,
+   "sha256": "3a42ee2c628fe079ab44da4c9a10c7d23e71a283b19de77cdb72199b65fe5ab9",
+   "timestamp": "2024-08-05T15:30:28.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_chuma.bsp": {
+   "bytes": 1280480,
+   "sha256": "e06a6c0dc256ecb5733d6f5592de64552ba5d8e5c74b34c4e77994ce314b569f",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_colossus.bsp": {
+   "bytes": 2229364,
+   "sha256": "cbbb550102d3b3236a09eeeda97f5b90a1fef42ce3f8ee6f1bae4e164ba2c563",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_detrohogga.bsp": {
+   "bytes": 2352096,
+   "sha256": "6da63f7cd16824484bdacf269f820fb70d34399fe3e58f31ae9d82a5fa099b33",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_detrohogga.lit": {
+   "bytes": 1351940,
+   "sha256": "1dcd356bc37de54157b8433042b15d8627079a79cf2fb8f0acc36de6c58fe868",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_deviltower.bsp": {
+   "bytes": 2483112,
+   "sha256": "f8a7bead68285d88633de68f34351639497cdb2453be30ec83e5d9627afc5cf2",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_dumptruck.bsp": {
+   "bytes": 1368392,
+   "sha256": "9315cfb3f185b7bce10d40f2056ff1cd9d8acc4835a0af2aa6158f80b9578f2f",
+   "timestamp": "2024-08-06T14:20:04.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_fix.bsp": {
+   "bytes": 1102044,
+   "sha256": "540249b8a89e2b80e9e1ccda343dc682ff7dcf68ba5a986dab5894775756a404",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_indigo.bsp": {
+   "bytes": 1658524,
+   "sha256": "b69a6862e783536ad41f25e0b165d0639848448799f6a3d8a5ff386cabef749f",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_ioridyson.bsp": {
+   "bytes": 3703944,
+   "sha256": "286a0d8af3bed6a53fa8d4be9256808bd28f3b75ad16fa7c1b1e707fdcd976ed",
+   "timestamp": "2024-08-06T15:31:12.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_ioridyson.lit": {
+   "bytes": 2025752,
+   "sha256": "0b2e9f63c25ed6e798f7ca5f94e160016b10e9dea956cde620dd65eb44054d6d",
+   "timestamp": "2024-08-06T15:31:12.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_iyago.bsp": {
+   "bytes": 1654400,
+   "sha256": "fd3ef97089c699c4fecfed79b2394c25ce24a9bc72f157dc97e5e6dbd5ac7ef5",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_jerry.bsp": {
+   "bytes": 1547692,
+   "sha256": "494b66d614012e073689126df2c5afa52fe2226466e0f24d0f2f79223a2e6b09",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_kdmg.bsp": {
+   "bytes": 1253016,
+   "sha256": "c57722f97209e91b98903e798a5ed59eeeeb33a061a5b7607cc5633c740f531b",
+   "timestamp": "2024-08-06T23:44:56.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_knefarious.bsp": {
+   "bytes": 3984152,
+   "sha256": "5e7e3dd14f55f400a141dd8e314a4cb3a0f8aa0373e2906f796c9d63eeabb9e7",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_niccolicious.bsp": {
+   "bytes": 3109204,
+   "sha256": "661fc934b261aab4468bc29759c439125297123f587589afcd6be57ac47a97da",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_niccolicious.lit": {
+   "bytes": 1849340,
+   "sha256": "51b8f2036537fbc803a85ce9592cbc53629e56f23c3feb41b485995fe8f0d7ec",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_scump.bsp": {
+   "bytes": 2016812,
+   "sha256": "4bdfb332ce0a97934f7c99c36f48ef5e6ff3a8ca8d3683b4b20aa4eea490dfe7",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_shades.bsp": {
+   "bytes": 2150756,
+   "sha256": "12f1d9aa76ff2a485b4cd7b9acf5c966e0476ec44892d0847c3156327e244c36",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_shades.lit": {
+   "bytes": 700202,
+   "sha256": "9cd0f056dfab5e818e61052374687086f28d1883a403564f5a874299ac62a600",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_simonn.bsp": {
+   "bytes": 1183680,
+   "sha256": "2191f6d61003db43c048fdf859f1d0cbd77924d51ea4f53a91df317fbea04d63",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_sixsik6.bsp": {
+   "bytes": 1943252,
+   "sha256": "12b686f9eb6fa0e813da44471847cf2357d66e93c5513adb04f8cfb29b362057",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_sixsik6.lit": {
+   "bytes": 763868,
+   "sha256": "03e21e3cf78c89ac92db43acaeea76dfcb4292051cea9aff0a806f28f91cf9a3",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_sock.bsp": {
+   "bytes": 812396,
+   "sha256": "cdef95b76dbb4faae2a8921c301095899c07f6056044598480637b9017efc814",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_stormcatcher77.bsp": {
+   "bytes": 1499400,
+   "sha256": "1234283e4768f34e9e3580fcbf883ad59f1af3c269c1a53e278bb460180974f9",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_thelokk.bsp": {
+   "bytes": 663468,
+   "sha256": "ae903ae84efa2f81af4744fd2d33e13721b610bdf78a55a21c8c0a6b66bfb271",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_thundergoose.bsp": {
+   "bytes": 3846652,
+   "sha256": "0862eb9724c810bc320fe5ddb08599c641e0d51dfcbd388c3b4acf650ea8e9ab",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/mc_rj1_thundergoose.lit": {
+   "bytes": 2408654,
+   "sha256": "3b41d9b37a46b777f644f8210e0c3fc3882e1d220dcdc7d92c5bccc9dd3b05dd",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/maps/start.bsp": {
+   "bytes": 1110720,
+   "sha256": "bfc9200c1fc8d6376c4f69ba83714165f586825a310ee943cbf0d6d54dc1bd23",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/mc_retrojam1_readme.txt": {
+   "bytes": 7171,
+   "sha256": "6c7e08735ac55a63af6b3f70336a884f9dc247993d42e3c8712e0a26c739823b",
+   "timestamp": "2024-08-07T00:22:06.000Z"
+  },
+  "mc_retrojam1/src/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-08-06T23:49:52.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_chnuckierdbeer+dm.map": {
+   "bytes": 1796143,
+   "sha256": "3abb63b016439f4b43ef1adaa5141290e812d91a4ef22c17262b02002f370d3e",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_chnuckierdbeer.map": {
+   "bytes": 1774566,
+   "sha256": "2c256e11bad4b5a98e094904bc14d94f73d601005f20c5f10a7f91e29a8c32d0",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_chuma.map": {
+   "bytes": 914635,
+   "sha256": "6121539f9b7d1d35916e303955141b467d76f78e371cba0ad8a9149b783f8fb3",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_colossus.map": {
+   "bytes": 2601483,
+   "sha256": "9ce1125c478aace93e53876a51a4589131e1510ad455241755ed3c009b31eef8",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_detrohogga.map": {
+   "bytes": 1750786,
+   "sha256": "ab9adce8cc784bca31bd175d31e024346266d4152259677fc3da2464ef5c92fe",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_deviltower.map": {
+   "bytes": 710414,
+   "sha256": "0ee7e06c161c83a2aee6150f305dcf14c16376a507f201e42deaf2f2d7ac1d5d",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_dumptruck.map": {
+   "bytes": 753758,
+   "sha256": "c5fc00244c81ec34dc29f91a5f48a2fca450d4be531698d58c3ebb3295a380d9",
+   "timestamp": "2024-08-06T14:23:44.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_fix.map": {
+   "bytes": 324316,
+   "sha256": "7bf7f4d8a6330ab7e41f4df4346039bd2d30ae7f4184cbecb8ac7d4ff273e12c",
+   "timestamp": "2024-08-05T15:30:30.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_indigo.map": {
+   "bytes": 811464,
+   "sha256": "e993d5f709d9ceffba9d838592096adc376115e0060407f27699c1d044da29fa",
+   "timestamp": "2024-08-05T15:30:32.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_ioridyson.map": {
+   "bytes": 1922375,
+   "sha256": "1d6f943f69d40671724220341bd283e6c0b63f6b3a432ea6dce0e51c79658c1e",
+   "timestamp": "2024-08-06T15:31:26.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_iyago.map": {
+   "bytes": 915097,
+   "sha256": "e7b28e850df2004933724f3400f8cf3c48f02028e6bbd660cb20575b33a9ddd4",
+   "timestamp": "2024-08-05T15:30:32.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_jerry.map": {
+   "bytes": 1149649,
+   "sha256": "c9696b17c0b622fcf03fc7d7aa05a966d8416701f9f30ab32f3b218fb67138ca",
+   "timestamp": "2024-08-05T15:30:32.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_kdmg.map": {
+   "bytes": 649857,
+   "sha256": "c4213051c8e6e2dc4e84e455dffadb5d4727db465a333998d1cc2db062b2c7aa",
+   "timestamp": "2024-08-05T15:30:32.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_knefarious.map": {
+   "bytes": 1241249,
+   "sha256": "096cbda7997571a41e7c4c6be124206cce487dab2dd544581addaa09da67154b",
+   "timestamp": "2024-08-05T15:30:32.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_niccolicious.map": {
+   "bytes": 1067876,
+   "sha256": "8506f880052a75b2c7cd57b7f6d340686b7eb6ef68c09d2c75f604ea53107e55",
+   "timestamp": "2024-08-05T15:30:32.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_scump.map": {
+   "bytes": 586458,
+   "sha256": "df28395b84577312103a36e455727ebaaa41c559cf1f02b9ecb1e13e5f55ea86",
+   "timestamp": "2024-08-05T15:30:32.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_shades.map": {
+   "bytes": 818099,
+   "sha256": "bb8c83a8fd2a6d2648525fbc3221f908f92a5e9e43ea3f3c43185ec8e080e9db",
+   "timestamp": "2024-08-05T15:30:32.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_simonn.map": {
+   "bytes": 818559,
+   "sha256": "0659811bf56d72ca33f770273ff34f93139a452c5c8dd794df668d5701fa043b",
+   "timestamp": "2024-08-05T15:30:32.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_sixsik6.map": {
+   "bytes": 1798345,
+   "sha256": "4dd84a9e1ecbaf2c47717f42d2bb54cac17382801d2d00afaa3147d1e2bcbabb",
+   "timestamp": "2024-08-05T15:30:32.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_sock.map": {
+   "bytes": 825225,
+   "sha256": "604c4c2bc71c6058ac743d5929c99c1245c2b37ee8c92914ef3735d37bd5c9c3",
+   "timestamp": "2024-08-05T15:30:32.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_thelokk.map": {
+   "bytes": 292845,
+   "sha256": "65e84a2c102465758664617acb34ebc5813b23f09a5b7cf34ab3372ed453496a",
+   "timestamp": "2024-08-05T15:30:32.000Z"
+  },
+  "mc_retrojam1/src/mc_rj1_thundergoose.map": {
+   "bytes": 3272981,
+   "sha256": "755eceecaef92e5afb2b87c9770d12394ac0246da740dacbbc4cba6d68d1b891",
+   "timestamp": "2024-08-05T15:30:32.000Z"
+  },
+  "mc_retrojam1/src/start.map": {
+   "bytes": 908002,
+   "sha256": "ef7321cc8716aaf74bc5549ac9f1fddc923e5de18331849d382e2a455d1fda9f",
+   "timestamp": "2024-08-05T15:30:32.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "notes": [
+  "May require a source port with increased limits / BSP2 support."
+ ],
+ "sha256": "7c3c3248aad0ed208ea072fc595220627d403f158a82884b0b6630f0f06229d9",
+ "tags": [
+  "author=Atom1K",
+  "author=Chnucki Erdbeer",
+  "author=Chuma",
+  "author=Colossus",
+  "author=CommonCold",
+  "author=DetroHogga",
+  "author=Fix",
+  "author=Indigo",
+  "author=Jerry",
+  "author=Knefarious",
+  "author=KurtDamage",
+  "author=Niccolicious",
+  "author=Shades",
+  "author=Simon Novak",
+  "author=Sock",
+  "author=StormCatcher.77",
+  "author=Thelokk",
+  "author=Thunder Goose",
+  "author=deviltower",
+  "author=dumptruck_ds",
+  "author=iYago",
+  "author=ioridyson",
+  "author=scumpsmallbrain",
+  "author=sixsik6",
+  "commandline=-game mc_retrojam1",
+  "exceeds_quake_limits=yes",
+  "filename=mc_retrojam1.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[ModDB page](https://www.moddb.com/games/quake/addons/map-center-quake-retrojam-1)",
+  "release_date=2024-08-08",
+  "startmap=start",
+  "title=Map-Center Quake Retrojam 1",
+  "type=mapjam"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/mc_retrojam1.zip"
+ ]
+}

--- a/json/by-sha256/7f/7f4321465335b8b145cb7a1b5bc5fd7eda19ec4803927bcf49a6094180ee6563.json
+++ b/json/by-sha256/7f/7f4321465335b8b145cb7a1b5bc5fd7eda19ec4803927bcf49a6094180ee6563.json
@@ -1,0 +1,2510 @@
+{
+ "bytes": 375069915,
+ "description": "A mod focused around a powerful new melee weapon known as the 'bonk hammer', which alters player movement. Contains 17 maps from various authors designed to make use of the new mechanics, as well as a couple of custom monsters and a skin-purchasing system for the hammer.",
+ "files": {
+  "Bonk Jam.pdf": {
+   "bytes": 200130,
+   "sha256": "2990b71b4863c54adde2302005e25ed5e15432d2624212559baaf9eadaa6b4bc",
+   "timestamp": "2024-07-22T07:22:02.000Z"
+  },
+  "docs/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-07-30T01:33:02.000Z"
+  },
+  "docs/bonk_4lt.txt": {
+   "bytes": 391,
+   "sha256": "c3d79d8232bc6ed8ff9110e91fa99ba8c692efb790bcb5ba77467d229f8fefb3",
+   "timestamp": "2024-07-07T21:36:36.000Z"
+  },
+  "docs/bonk_cc.txt": {
+   "bytes": 1765,
+   "sha256": "8614de2d615d50225b509c2c969c537360039928a5fc8eee07590176da2463ea",
+   "timestamp": "2024-07-06T21:18:30.000Z"
+  },
+  "docs/bonk_chuma.md": {
+   "bytes": 3467,
+   "sha256": "6fa52cae66adb6f305381426003ad3ccf7922f0876147d90cbfc1c45e3b6af51",
+   "timestamp": "2024-07-06T08:23:54.000Z"
+  },
+  "docs/bonk_iyago.txt": {
+   "bytes": 427,
+   "sha256": "610e294e8ca8d1cccdb022d29c6cf2afcbabcd94109eb65e907c60bd46e64180",
+   "timestamp": "2024-07-05T20:36:32.000Z"
+  },
+  "docs/bonk_makkon.txt": {
+   "bytes": 2323,
+   "sha256": "3a20a64c65c9f785a12feafa61d6be9ef9ebad4cda146ef76ff8ca4217a75c29",
+   "timestamp": "2024-07-17T15:55:24.000Z"
+  },
+  "docs/bonk_milestone.txt": {
+   "bytes": 1762,
+   "sha256": "7b6237939c24b390a35bc8d425f0af5bfe4468b7a3ddcf2bb0d67d695085ffc5",
+   "timestamp": "2024-07-16T17:44:28.000Z"
+  },
+  "docs/bonk_nickster.txt": {
+   "bytes": 1609,
+   "sha256": "7f9f04b4bba119d04c85731ef3dbffe48fae2a82072deb647a98344687edb169",
+   "timestamp": "2024-07-29T11:22:16.000Z"
+  },
+  "docs/bonk_pinchy.txt": {
+   "bytes": 3688,
+   "sha256": "14e93c86a07597ee61ce2ce7df8cf27ab229620665003980c25cf2132e5f1539",
+   "timestamp": "2024-07-12T23:50:08.000Z"
+  },
+  "docs/bonk_rabbit.html": {
+   "bytes": 1690,
+   "sha256": "9e8f1274455917df0c7fa18f951ee6ca895d59892cffa4aff6b5f75922e62a99",
+   "timestamp": "2024-07-01T15:19:54.000Z"
+  },
+  "docs/bonk_rabbit.md": {
+   "bytes": 1395,
+   "sha256": "5407e4d434c1c6a5372fcf053d283904d33620975fd8459c79f1736d39da3b10",
+   "timestamp": "2024-07-01T15:19:48.000Z"
+  },
+  "docs/bonk_rabbit2.txt": {
+   "bytes": 610,
+   "sha256": "2236cd2f6556b8ff7acdd711ee0d94a37e7b799d05460062cccfd377871aa1dc",
+   "timestamp": "2024-07-13T18:07:08.000Z"
+  },
+  "docs/bonk_recycledoj.txt": {
+   "bytes": 1770,
+   "sha256": "cd23e1449f89543cb7614a4ed06fba50e5a60a2aa8746d95d114852900a0e987",
+   "timestamp": "2024-07-14T03:37:08.000Z"
+  },
+  "docs/bonk_simonn.txt": {
+   "bytes": 1925,
+   "sha256": "2a7c42f2ee790c9410d768620addd2087103f6d8dd52034b3441048bc98e10ed",
+   "timestamp": "2024-07-06T08:37:00.000Z"
+  },
+  "docs/bonk_sze.txt": {
+   "bytes": 3095,
+   "sha256": "fb3cc42308cc211efa4b7487245d2c5c08fdea315b2f6f02fe83efd053d84578",
+   "timestamp": "2024-07-15T00:30:10.000Z"
+  },
+  "map sources.zip": {
+   "bytes": 19301577,
+   "files": {
+    "map sources/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2024-07-30T08:32:14.000Z"
+    },
+    "map sources/bonk_cc.map": {
+     "bytes": 1647779,
+     "sha256": "8d9de90190b05cd5112fd861805188b60313ebd41a1c38edf352abaa8ece2fa8",
+     "timestamp": "2024-07-08T08:45:12.000Z"
+    },
+    "map sources/bonk_chuma.map": {
+     "bytes": 1539733,
+     "sha256": "333d4c6e1a4172901394a7e059a812adf3148dd4b59e818485306e001d22cca4",
+     "timestamp": "2024-07-29T13:15:36.000Z"
+    },
+    "map sources/bonk_indigo.map": {
+     "bytes": 470023,
+     "sha256": "83cbaf1a8d8bd4bb68b0d50056b2169bd722cf385dd3adf197d9a928710e2ffd",
+     "timestamp": "2024-07-11T07:36:36.000Z"
+    },
+    "map sources/bonk_iyago.map": {
+     "bytes": 1510072,
+     "sha256": "5aad113c0a89e0a54fd9598b1a529adba180e35d0074e4e1540debb0f45e1114",
+     "timestamp": "2024-07-29T14:32:40.000Z"
+    },
+    "map sources/bonk_makkon.map": {
+     "bytes": 124582276,
+     "sha256": "59ae9ac0084a317593c4fa4716230dbe87a907fad6a63f2528bd5ffe44ae47a9",
+     "timestamp": "2024-07-17T22:27:36.000Z"
+    },
+    "map sources/bonk_milestone.map": {
+     "bytes": 3474081,
+     "sha256": "20edc1775c0018ecc36f54387c5a60c315fc7d0ab0e9a086227e167ef592ee04",
+     "timestamp": "2024-07-20T10:52:42.000Z"
+    },
+    "map sources/bonk_nickster.map": {
+     "bytes": 4830384,
+     "sha256": "65062a7401f3558b285849c2534ff5dd6fdd2067e434f5f8e1aa182157c60b58",
+     "timestamp": "2024-07-29T18:16:28.000Z"
+    },
+    "map sources/bonk_pinchy.map": {
+     "bytes": 37181713,
+     "sha256": "53ced1c73cd2731ef04a6aefcb8a855bbc3c740e91f36528df5707ce2292dd99",
+     "timestamp": "2024-07-14T20:43:54.000Z"
+    },
+    "map sources/bonk_rabbit.map": {
+     "bytes": 4772839,
+     "sha256": "621c4c3d76bda8ccecb45f8f3982725946d7272bedc58c21ef99e70eab1fa35f",
+     "timestamp": "2024-07-01T21:45:30.000Z"
+    },
+    "map sources/bonk_rabbit2.map": {
+     "bytes": 882739,
+     "sha256": "0e6d81ddab0feb77350211938022a29feeb5986761606e9214406bc679df0370",
+     "timestamp": "2024-07-14T00:46:18.000Z"
+    },
+    "map sources/bonk_roj.map": {
+     "bytes": 2828788,
+     "sha256": "04866c71e4a4f2647f75d8a3feabfb221d2107f4bf8fe48fe00158f7527280f6",
+     "timestamp": "2024-07-14T10:19:58.000Z"
+    },
+    "map sources/bonk_shades.map": {
+     "bytes": 591114,
+     "sha256": "524d3e986a060e0bb567ab0fe3dcb66ee2385728ef647532110cf260ca31a219",
+     "timestamp": "2024-07-14T21:00:04.000Z"
+    },
+    "map sources/bonk_simonn.map": {
+     "bytes": 2961806,
+     "sha256": "c2e389efff346734311b0d4502d2a8f4b79dfe259530093fc8a74bd1a51184ce",
+     "timestamp": "2024-07-06T19:27:22.000Z"
+    },
+    "map sources/bonk_sze.map": {
+     "bytes": 8439299,
+     "sha256": "f4fd5d7b6542001557cf1234c566750eca589b7299f21164d40451b920a075ad",
+     "timestamp": "2024-07-17T02:55:20.000Z"
+    },
+    "map sources/bonk_thatspacepirate1.map": {
+     "bytes": 1886958,
+     "sha256": "f5376ed73a64bbe8c432c9cadf8b326c1c3a2b7e3780ada500e7d43baa9779c0",
+     "timestamp": "2024-07-13T22:23:00.000Z"
+    }
+   },
+   "sha256": "aa28b92a5ad8852b201e75f939fc32a8e6876f6e1099976ec8901ecd6f6ee759",
+   "timestamp": "2024-07-30T01:34:10.000Z"
+  },
+  "pak0.pak": {
+   "bytes": 5232226,
+   "files": {
+    "conback.lmp": {
+     "bytes": 64008,
+     "sha256": "394be8d82c7bc2a781fe68bef2f5df9e60e7860b2959e4e2f931b4f828a43b2a"
+    },
+    "gfx.wad": {
+     "bytes": 197172,
+     "sha256": "fe672ef01708267b8afda4df12952640e513a3f90ad24d51337f1326990dc29b"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "31c4858fe496187dc1bac21c02aff8cf83cbc51e0b4ee5738d6118c328b299d2"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "ed0f79285d93d0ef35644ecaf9ab36f3b2c6ffd223c577b25fff2ea17f90080d"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "e9c210ab88f6e98965cd2f8470f084e32ef15b3ad3912cb1e9eb0363c6204eb7"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b56880e2f720a89dcd055f5278abb21a21514322d4a31b77b46c8b509b9f3be3"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "89c3ac6fd91cdcf15c20b0d15b4c01c153e0a820c660f9222b5c8f63d43af5b2"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "8b83ffaf6b5309d371f0107ebb1340a8a09cd1a52c6a5581b7c9c4a7afcefa77"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/debris1.mdl": {
+     "bytes": 33768,
+     "sha256": "3498dffa0c3522b011a76ada880dfae64de3ca1583c94474e1e07adbc220d981"
+    },
+    "progs/debris2.mdl": {
+     "bytes": 33944,
+     "sha256": "d6d535173bb4a3a2d469be9c63bf36a01b1e2b80dd6a71636d20178d813e443c"
+    },
+    "progs/debris3.mdl": {
+     "bytes": 34136,
+     "sha256": "d6b0a2b6353c4462196d2af116652b47d464a7bc1f161509aa8ee5dbe859f98b"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 17812,
+     "sha256": "74cd41d8d5a67570cdaca34a08e9868f3476d8c4ac4a645cfaf9e91cf778c793"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "4f5ca2553db07d5cc93987b11e9f9ff054d51b96488e2bcc35c9f03ed3040d42"
+    },
+    "progs/h_zombnm.mdl": {
+     "bytes": 3220,
+     "sha256": "45d9dfe5683264edf6f6eb7b8e8d794f84caeb8701e65e8ebe9add2192bbb6fc"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "b00951cd72bb5fb03c19a1d60943162652fe149b9ee60fd2e630a076d52956fb"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/k_spike2.mdl": {
+     "bytes": 17716,
+     "sha256": "e456eb93934dab43a83305988db82ab1954e66491c256fad3ef1451d0ecf97c2"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 36496,
+     "sha256": "a001c379917628354adfb62b698856b33f4eea5f22e7d8e232e640faf15d8465"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133936,
+     "sha256": "e2d6b9de9b879327f72d97ef3c07e0b7e35cf844747208f6e615015be84157e5"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "f414f3fd07b0278bd59dd90954770f81a5ffad7f46af5f5d0abee124905dcc17"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "progs/w_spike2.mdl": {
+     "bytes": 5816,
+     "sha256": "b07808c532059133c31be2ed2bc4e9bb9b01b75d5d23401768058cacc3192068"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 74976,
+     "sha256": "545d70abb8d44be8e12da24a3d09fb56f87ff960c41963148682fbbd9d47e417"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 218680,
+     "sha256": "6782603eadacc7cb4bd09c11d3b6326e0d2e69205f724fe2f6e533ee398f5a16"
+    },
+    "progs/zombienm.mdl": {
+     "bytes": 224900,
+     "sha256": "f4d1ce9667ebb36088bfb59a12c9a8d93c1aefa36515b51f388cffec5132f5b2"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    },
+    "sound/zombie/z_res.wav": {
+     "bytes": 23266,
+     "sha256": "10b2962ce2817fa8a250811313307cf0dfa93ad5257a669452fe3fc834ced976"
+    }
+   },
+   "sha256": "6958c536f6f0a278c64d7f9c4635b1f55516f6ad9c336bc8a6c2f31691892dc3",
+   "timestamp": "2024-07-23T06:52:30.000Z"
+  },
+  "pak1.pak": {
+   "bytes": 762503656,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 71918,
+     "sha256": "234bb97b5add306ddd8f7fe264cabba7061e63bd2d6bdec4f54a50402a35d183"
+    },
+    "gfx.wad": {
+     "bytes": 197172,
+     "sha256": "fe672ef01708267b8afda4df12952640e513a3f90ad24d51337f1326990dc29b"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "394be8d82c7bc2a781fe68bef2f5df9e60e7860b2959e4e2f931b4f828a43b2a"
+    },
+    "gfx/env/browncloudsmall_bk.tga": {
+     "bytes": 786476,
+     "sha256": "40ef22e28898025692b13240c1ba92bfcf742d7dcf34a45aa9ed4a85bb97d957"
+    },
+    "gfx/env/browncloudsmall_dn.tga": {
+     "bytes": 786476,
+     "sha256": "8336d53ac085cd3a1517cb21f34017134e35d8a579fc3f95e514cbea9a8bf801"
+    },
+    "gfx/env/browncloudsmall_ft.tga": {
+     "bytes": 786476,
+     "sha256": "ba3b8db26a17742027f610fc00c26d29908f50c256f32c3f9a40aaca1cc70679"
+    },
+    "gfx/env/browncloudsmall_lf.tga": {
+     "bytes": 786476,
+     "sha256": "510770e7962506b72fc1d67d42c854c4db58164dd63d0226ef6f3b7135c5036c"
+    },
+    "gfx/env/browncloudsmall_rt.tga": {
+     "bytes": 786476,
+     "sha256": "b015facacd6881b43a17f438b4a3d220341c78f6b95417067f647f8a05e0e767"
+    },
+    "gfx/env/browncloudsmall_up.tga": {
+     "bytes": 786476,
+     "sha256": "5b946ef04bac05dc0238ca05e79416ce3a89ed7a99370466e7845f6c02f8464f"
+    },
+    "gfx/env/deepblue_bk.tga": {
+     "bytes": 467895,
+     "sha256": "779c94406c20c444aeb931049bd75d3bc24a3f7dd2fdb982fa17e76c929df9d8"
+    },
+    "gfx/env/deepblue_dn.tga": {
+     "bytes": 781154,
+     "sha256": "4c58639453d239d4dbc1916817c0cbbf385491c501ab1ff54092fd3bada65892"
+    },
+    "gfx/env/deepblue_ft.tga": {
+     "bytes": 435549,
+     "sha256": "908c4b9797f7278b408b746031c81ad53a230857e280520637bd8690f9252f01"
+    },
+    "gfx/env/deepblue_lf.tga": {
+     "bytes": 499563,
+     "sha256": "d927f2cbe4dcf25a1b7c163e7a0910fdba730a9f1c95bf8b692ba74dad94add7"
+    },
+    "gfx/env/deepblue_rt.tga": {
+     "bytes": 436674,
+     "sha256": "2b8b8487108a6f43fb260fd4d090f78e3dc630fcfb3bf3ebc0d7ddc1af40e883"
+    },
+    "gfx/env/deepblue_up.tga": {
+     "bytes": 84377,
+     "sha256": "9b2b26fe2bbd08a3905032613cb7f982ad0c881ab654561c599f7c7c49d0da70"
+    },
+    "gfx/env/hw_desertnight/desert_night_bk.tga": {
+     "bytes": 728024,
+     "sha256": "8331f070c52bcd367c2a6ae78ba8543f48d80f2bd7f8b5ea19cf4ab4687f1011"
+    },
+    "gfx/env/hw_desertnight/desert_night_dn.tga": {
+     "bytes": 773033,
+     "sha256": "4c353c81eac8a132c2956de36b3c64a0457e38541277a773d6b1666f86ef78b3"
+    },
+    "gfx/env/hw_desertnight/desert_night_ft.tga": {
+     "bytes": 434091,
+     "sha256": "ae082f8c2fa11150dd10f45d7c8f6a500cf745c96ee79f41cff91f957af7a3d8"
+    },
+    "gfx/env/hw_desertnight/desert_night_lf.tga": {
+     "bytes": 598700,
+     "sha256": "260c8f74bbc74d17482cab58b82f06a8a928704e92e700f6676af7f7cbd3408a"
+    },
+    "gfx/env/hw_desertnight/desert_night_rt.tga": {
+     "bytes": 528631,
+     "sha256": "9bb37a8607388a4b10bf25e8c1e08540ba8718ad01dfb3c4d75279ba6ac2540d"
+    },
+    "gfx/env/hw_desertnight/desert_night_up.tga": {
+     "bytes": 440821,
+     "sha256": "f3fdfaba05a0e83e60763ace616d1b47e6ed0a3a24abd4200fc6029b2eba8789"
+    },
+    "gfx/env/hw_desertnight/hw_desertnight.shader": {
+     "bytes": 368,
+     "sha256": "c74762bfee27c268625d4fe80f35f2ad4e4eaa49b0a91027aef12477a3b5acb9"
+    },
+    "gfx/env/hw_desertnight/license.txt": {
+     "bytes": 283,
+     "sha256": "3c6a08e5dccedb87f67aaa50feb964c98fbde4bb4888c64c56bc35e5fd256b43"
+    },
+    "gfx/env/mak_aurora4_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "f36777df894379136a6cf38e7b8b338080fd8ba8b0dc06c4cc64442a86a21d44"
+    },
+    "gfx/env/mak_aurora4_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "9d850af9aa593c36b7e34115e5cb2e4a679c3c8c1e2befc01f8cb4bb8d7c815c"
+    },
+    "gfx/env/mak_aurora4_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "060b6ed8d82a87b0a90c00e5f8e117f329266dbf32e3f4a07604514092af0c9f"
+    },
+    "gfx/env/mak_aurora4_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "29fc09dc4a912fea87f7803258523dcce39c0e586e20a69378443f7360359628"
+    },
+    "gfx/env/mak_aurora4_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "a3574235c47108779926211e5e3bde17ed4c581c27ba98c84c601915210ce7d9"
+    },
+    "gfx/env/mak_aurora4_up.tga": {
+     "bytes": 3145772,
+     "sha256": "9fe52a73eaf6b3812cc79a3f5aebf4b51b00b5af57e02b74755118fc35b6cd17"
+    },
+    "gfx/env/mak_nightsky1_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "4078d021f89972ed7d11c41a0cdf3b053d7161cd142a8a8946101d86614beead"
+    },
+    "gfx/env/mak_nightsky1_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "41e728c4386d5461371933f51bb424a1c40b2882aa496db8f390976d21630f98"
+    },
+    "gfx/env/mak_nightsky1_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "544c88434228344c3c5087c13a0f27e06843312695565a48a73f819484db7741"
+    },
+    "gfx/env/mak_nightsky1_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "f4e5527e363c0a714300eaced314103208859bb75f74f57adb153114a9ba2051"
+    },
+    "gfx/env/mak_nightsky1_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "d3dd339652fdb82370730c5a18765c34858326d49b2cf3b82d1a429fcc9543c5"
+    },
+    "gfx/env/mak_nightsky1_up.tga": {
+     "bytes": 3145772,
+     "sha256": "17a39daadeed06e143b71808952ba84d7c608eebed78541aa4882367b4a83825"
+    },
+    "gfx/env/mak_purplesky4_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "a343ec8a7e494456fc46ce657a5a1db5a3cb5eec08e89dafd557f2349cef7896"
+    },
+    "gfx/env/mak_purplesky4_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "322e439464c9b831c05f493f1cf57f91eac4671b23cf9075902d84d35ddfa7a3"
+    },
+    "gfx/env/mak_purplesky4_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "1574f8008ef27836e4a68336805edf01e3a6b295a0ba902077fb71592308a48b"
+    },
+    "gfx/env/mak_purplesky4_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "d8d2e48267642cc32ce721d6620f84f4edad4a99ac5f37e5c914f5cb1aed3d99"
+    },
+    "gfx/env/mak_purplesky4_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "0778783241c92968c8abcbab7de4925f9133e7cc2bea0931bdf09b6bc53499dc"
+    },
+    "gfx/env/mak_purplesky4_up.tga": {
+     "bytes": 3145772,
+     "sha256": "71d04ac03de58d8410e08c6bcf5e25286e5368e228b5a85ffe51ea44cebf7f0c"
+    },
+    "gfx/env/mak_sunset3_nbonk_bk.tga": {
+     "bytes": 4194348,
+     "sha256": "39ed47345ea9631da38fb0c6c769371c613ae7d63b706167fd309747b097cae2"
+    },
+    "gfx/env/mak_sunset3_nbonk_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "097b0a2c8500edac31f3f77b476f27b56be949fd1e5f20d9a3402660ce757326"
+    },
+    "gfx/env/mak_sunset3_nbonk_ft.tga": {
+     "bytes": 4194348,
+     "sha256": "e46e61b0c29817569fbc783ba8fc31a0cdd40bf4011e8959c9c775eabe40aa9d"
+    },
+    "gfx/env/mak_sunset3_nbonk_lf.tga": {
+     "bytes": 4194348,
+     "sha256": "c0aa7fa089f3387940bb8171be4a17efbcd30f95ae04ba72530b08a1e1bd04dd"
+    },
+    "gfx/env/mak_sunset3_nbonk_rt.tga": {
+     "bytes": 4194348,
+     "sha256": "30f48768949cfeb23cb3940f12b7b5cf7916a63c4b2a48ba61a3f5c06284c468"
+    },
+    "gfx/env/mak_sunset3_nbonk_up.tga": {
+     "bytes": 4194348,
+     "sha256": "9550d051effd0abdba4286f90163d8b295923f1789160cabd6301e662b508af6"
+    },
+    "gfx/env/mak_sunset3_nbonk_wind.cfg": {
+     "bytes": 48,
+     "sha256": "cf11cf46895ca7462bc1451d80ca96ca9766797cb6a0773b5236cb34dfdb5624"
+    },
+    "gfx/env/rabbit/jungle_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "51d4224989a9d49b3866061c42eb254aeb01dbf6f6b790e79427870f50ce0c05"
+    },
+    "gfx/env/rabbit/jungle_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "2b0b80e7dfd90b2d29f01bc96eab0be41517bac6f5d321ebcab19fd5f78b5df4"
+    },
+    "gfx/env/rabbit/jungle_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "88af4c2ccd7bf97548234c7295a07df2ac8c4e19a7e144850eb075a836aec6b9"
+    },
+    "gfx/env/rabbit/jungle_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "78fb9d2798352247fca654f9484d7c3c88f073468575ed6a86bb0e1816ed3b67"
+    },
+    "gfx/env/rabbit/jungle_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "31c58f6dbb971486be9c95844f416ded1943ba9035f079eb7964e3648d156c8f"
+    },
+    "gfx/env/rabbit/jungle_up.tga": {
+     "bytes": 3145746,
+     "sha256": "fbd0ad4bd177f6955fbaaafc3d053a838c2988f0b3239b07b84dc0215c3cf0e4"
+    },
+    "gfx/env/rabbit/mak_bluesky2_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "bc242bd204b40a89bd572ebe2d4d4f4202ccbe4658d534065477414837efb970"
+    },
+    "gfx/env/rabbit/mak_bluesky2_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "35199d0182e22c02c36143f934f8f3f29747625a7609dae40e0f339318645bd5"
+    },
+    "gfx/env/rabbit/mak_bluesky2_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "c42b34347ed48bd1279b1b53fb0ec6cf834ee571d814b7742e8f3365f618dbdb"
+    },
+    "gfx/env/rabbit/mak_bluesky2_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "c3d0be6c7ba64bfc93f0785433c50c11d8c6bc8c54c9954491e36b5fe74f6f6f"
+    },
+    "gfx/env/rabbit/mak_bluesky2_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "03fa680ec85bf5d74faed72e94ebde9a1ada380acee19b37b400162af92fcf34"
+    },
+    "gfx/env/rabbit/mak_bluesky2_up.tga": {
+     "bytes": 3145772,
+     "sha256": "4525860d5a23a25d4a10f4b78d138fa1cd340685c40936fa94961be3acdd2934"
+    },
+    "gfx/env/roj/jajsundown1_bk.tga": {
+     "bytes": 786476,
+     "sha256": "257c3f41d70179e7f371f29a35542788a580e46ef9fe96f7321d74a77fab54e8"
+    },
+    "gfx/env/roj/jajsundown1_dn.tga": {
+     "bytes": 786476,
+     "sha256": "e534b8d81df676cf80282dc3a63abc1b8d66648a833d390a475156472834480e"
+    },
+    "gfx/env/roj/jajsundown1_ft.tga": {
+     "bytes": 786476,
+     "sha256": "b1a273da93ae7eebc6659f60662e5a37f4f0663bd2667c17879e4d6ff6fb86fb"
+    },
+    "gfx/env/roj/jajsundown1_lf.tga": {
+     "bytes": 786476,
+     "sha256": "ec2b579b1ec484ec3f5a4a4d09803629acfb82721290be54672fc858a640c059"
+    },
+    "gfx/env/roj/jajsundown1_rt.tga": {
+     "bytes": 786476,
+     "sha256": "14aed5df2783c0afa620be84ec8a1d77ba02995ed6ee55207d657d9f50e27ff0"
+    },
+    "gfx/env/roj/jajsundown1_up.tga": {
+     "bytes": 786476,
+     "sha256": "9cb883fb0077ac79482cb0561f7c1a82af61b5fb374fcbdc5eb63bae49e525be"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "c376bda6d071bf7b939db999c723d0b08ab50878d9ce2e1b4428fd8da85daa9f"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "dfb6683fed7f727680ba0990ce2f9cf9bf67cd44e1783f4f11574ca0f7e8a07c"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "6703415cfb25c1a30c1bc1e9b3318acb081c3dae0f3909ab497fe32df731a52a"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "2be70dca4a990b9d7446703c0bfa2551fedc19fc6fc5f10ea5e310407c9ce57b"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "364ec3f50db7caf006579158c510897bb2b88380d19e2a30857f486001aeb273"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "57c1866118fe01630859189ec0c07a0657ee28403808913e3b8fe06ea2da15e6"
+    },
+    "maps/bonk_4lt.bsp": {
+     "bytes": 6146300,
+     "sha256": "b23af4e38f30ffef45bfd8113bf46defbf82ae63ff183f6fabff45d3ed9d1ad4"
+    },
+    "maps/bonk_4lt.lit": {
+     "bytes": 7601180,
+     "sha256": "e553c60ee40ce55cd67eb2351946d16d9f2f1992c891644d9217fcfe54ea872e"
+    },
+    "maps/bonk_cc.bsp": {
+     "bytes": 24839532,
+     "sha256": "0af1e6e6921bcf645562c130714a18f1cf7f28a1975949205526048dedaa417d"
+    },
+    "maps/bonk_cc.lit": {
+     "bytes": 2874440,
+     "sha256": "e73196495065dc13c8463aaea435b91c5dde58b0059d6c1a8ef655afef9c6f81"
+    },
+    "maps/bonk_chadquad.bsp": {
+     "bytes": 9018888,
+     "sha256": "5ff0df380201fd91c52d0e9010e6f6cd329193fe7e7f3ddc7d1c0051eb06a2ee"
+    },
+    "maps/bonk_chadquad.lit": {
+     "bytes": 6402296,
+     "sha256": "5d90870babc60d620663f754c970913f4b512e8a4ca691c37ce73abe54423c1d"
+    },
+    "maps/bonk_chuma.bsp": {
+     "bytes": 4801256,
+     "sha256": "c9aca137a3803adfd470599df43d19fe2e7bcb74df006c5812ae7f011da8eee9"
+    },
+    "maps/bonk_chuma.lit": {
+     "bytes": 1393112,
+     "sha256": "b659b33a2d34076db3ba5317513d2e102c0c2e40c3f5d8613a2a2fb77c32ee59"
+    },
+    "maps/bonk_indigo.bsp": {
+     "bytes": 973828,
+     "sha256": "a62ddad51b20b93a1b0e72e3110087f78339454fbc949f03e09ba6258b6987ee"
+    },
+    "maps/bonk_iyago.bsp": {
+     "bytes": 3605424,
+     "sha256": "2b8b0808f277dd1e64d75b59ce89388f77a89126750b49d65d15b902185a2724"
+    },
+    "maps/bonk_iyago.lit": {
+     "bytes": 3027344,
+     "sha256": "6f32204b2ccb68bec14dcff4dae822cd38f85913601803e718a7392941a89b75"
+    },
+    "maps/bonk_makkon.bsp": {
+     "bytes": 63269936,
+     "sha256": "295eb72e586df5af6d093fa4bbf39c4694a5fdc64fce4b865a0d0c4f64c4d292"
+    },
+    "maps/bonk_makkon.lit": {
+     "bytes": 8063420,
+     "sha256": "d1f8d499dc03ed19f10d8af7ea4c8c7bdad2277f13eb6f49bc43b5bf48107532"
+    },
+    "maps/bonk_milestone.bsp": {
+     "bytes": 47421608,
+     "sha256": "b00b71993062b47ecf4caeaeb440469caf3f600d338642b6baf65c6a2e26bcc7"
+    },
+    "maps/bonk_milestone.lit": {
+     "bytes": 3631664,
+     "sha256": "858751fc66a846f017cd89da23890361aaae573b20fce0d44f5ee7a05e1631f2"
+    },
+    "maps/bonk_nickster.bsp": {
+     "bytes": 36441780,
+     "sha256": "e48f7ace7637f47f2818fdde8a74f7e1714afd196dbd374e1a9796958fe27ef1"
+    },
+    "maps/bonk_nickster.lit": {
+     "bytes": 3901877,
+     "sha256": "25a9c71b937e874b8138e92897565ae0b0b677e3bf532e1b795ea7029ded0515"
+    },
+    "maps/bonk_pinchy.bsp": {
+     "bytes": 20126800,
+     "sha256": "4d0ecce294d288e01013b111791b21368d3cd7a934aa948710133802880f9079"
+    },
+    "maps/bonk_pinchy.lit": {
+     "bytes": 4969472,
+     "sha256": "0970750ffdc30ddfab5831a6a83ccffcb7e995ffc657491089823711555cc960"
+    },
+    "maps/bonk_rabbit.bsp": {
+     "bytes": 18072540,
+     "sha256": "f2fb9425d1dc7a54acbd7cca02dafdb7e2155dbef0bbaa7a6a75a0b3c561e5ff"
+    },
+    "maps/bonk_rabbit.lit": {
+     "bytes": 4280504,
+     "sha256": "6ca8479f10b6e7fc8388506125bc268d8350a2f7a5205de173a35d6ad3de84b0"
+    },
+    "maps/bonk_rabbit2.bsp": {
+     "bytes": 3741124,
+     "sha256": "212cba23ea14d6adab1792972495296640d3fe2ca7f2d23006a63b10edc34eb8"
+    },
+    "maps/bonk_rabbit2.lit": {
+     "bytes": 2243456,
+     "sha256": "7f1ec23ef611a9fd62138187a05de0b1c03a10445e590b4a2e43b28d951e999d"
+    },
+    "maps/bonk_roj.bsp": {
+     "bytes": 4734444,
+     "sha256": "4dd3ab0460e241e102f2bc0f7e3f46cc12097f8645a46a689f372dd35a1bdf1e"
+    },
+    "maps/bonk_shades.bsp": {
+     "bytes": 3667912,
+     "sha256": "00b1ec212a8bbcb7bfec508a81a2e1b2e088f40372c53feb5716a0b51ea3d5c6"
+    },
+    "maps/bonk_shades.lit": {
+     "bytes": 526694,
+     "sha256": "5c02fdd4a59b46b3f19b2a3101f0335a6bd5959cd3cacaacd8f673968b89e9de"
+    },
+    "maps/bonk_simonn.bsp": {
+     "bytes": 32826912,
+     "sha256": "17813d6fc7619bb65a45bc68ae2d42d561fcc406dcbce3a07751c5db7338939e"
+    },
+    "maps/bonk_simonn.lit": {
+     "bytes": 1724756,
+     "sha256": "89cbdc2f56221e3be57cd5b900d4f03fa5c7b2d63a1011b57b4ca0c90f6e7f3d"
+    },
+    "maps/bonk_spoot.bsp": {
+     "bytes": 6672784,
+     "sha256": "55c8dd4e67f31cf600323c6b2cebc3c740111835cdb05af9988e3d3fc0e06c1a"
+    },
+    "maps/bonk_spoot.lit": {
+     "bytes": 6768680,
+     "sha256": "fab6ee9ff728c1b04f3cc794524c0cee5b96199ded0e9b0bb35c58872a9c8f6c"
+    },
+    "maps/bonk_sze.bsp": {
+     "bytes": 13966448,
+     "sha256": "b252e8301867f2fbe5fae358488c353d01e26834ac713b617502100e999cc69d"
+    },
+    "maps/bonk_sze.lit": {
+     "bytes": 7566356,
+     "sha256": "29a0e92830d98323c67262fddea32eb0f9b0234c84bca0c04c228759f2a463d0"
+    },
+    "maps/bonk_test.bsp": {
+     "bytes": 1495848,
+     "sha256": "546ebaf046d6d436eefc5db839e9a561bedd1824b10c34952fa2df7ac80192f4"
+    },
+    "maps/bonk_test.map": {
+     "bytes": 586367,
+     "sha256": "156f9bd4a0498b91ea122debe235b7c31070e88986fbc235bccd26664c3b633a"
+    },
+    "maps/bonk_thatspacepirate.bsp": {
+     "bytes": 2091404,
+     "sha256": "e9437598665ac23ab95113c9824e775545d695871cd9281081bdbb3f58b6f94d"
+    },
+    "maps/bonk_thatspacepirate.lit": {
+     "bytes": 1000493,
+     "sha256": "02f8f31e46ee277fa3967288c06dc2a494b12322ddddbe462eb1b59b2f99876b"
+    },
+    "maps/brkpinchy/makkonstonegrey1.bsp": {
+     "bytes": 698740,
+     "sha256": "2ba15df3b996c11b2b846afce1035385be2514da54750d0ea99ee55e955d69c7"
+    },
+    "maps/brkpinchy/makkonstonegrey1.map": {
+     "bytes": 763,
+     "sha256": "e0ae09cf375eb37af0bf15a991c63adcbbc9151858d79e01fe824c1b63eb26e8"
+    },
+    "maps/brkpinchy/makkonstonegrey2.bsp": {
+     "bytes": 698928,
+     "sha256": "5944678583069e18f76550736798753985a7bfdda41359e0e5e37af13897e2a4"
+    },
+    "maps/brkpinchy/makkonstonegrey2.map": {
+     "bytes": 838,
+     "sha256": "b231548603fc304dd8b238620bf85855fa0a339708e06998960deb4b091b4b66"
+    },
+    "maps/brkpinchy/makkonstonegrey3.bsp": {
+     "bytes": 698992,
+     "sha256": "183a975044aff61c3a52e15a9d3a9de782ec4fa5c6a7c4b8649728ccd49b49a8"
+    },
+    "maps/brkpinchy/makkonstonegrey3.map": {
+     "bytes": 812,
+     "sha256": "117e1611ed239ef3ea98013971f75e49e5940cebddcee2222935f9cc54709faa"
+    },
+    "maps/brkpinchy/stucco1.bsp": {
+     "bytes": 25084,
+     "sha256": "fc0cebd4edd4a97ed07f30ae7724fd5b348daad77cec9477b083322d78e0c05f"
+    },
+    "maps/brkpinchy/stucco1.map": {
+     "bytes": 990,
+     "sha256": "89a5e5111034ac1fde79f48e1db5f57e602843674544b82c4659205e9afa461b"
+    },
+    "maps/brkpinchy/stucco2.bsp": {
+     "bytes": 26396,
+     "sha256": "95daf51511ba7be0d912579ef3dc68bbf65ed5c5c860364c049ad909597d7e15"
+    },
+    "maps/brkpinchy/stucco2.map": {
+     "bytes": 1715,
+     "sha256": "32903bf5596e5ae1c89ad0b16900e7959b95003626715798c38235a8c6cae2e8"
+    },
+    "maps/brkpinchy/stucco3.bsp": {
+     "bytes": 25744,
+     "sha256": "6b393af05c337cb79eb7452c68aabd23e27ebbfdc4b95f06569039c538256581"
+    },
+    "maps/brkpinchy/stucco3.map": {
+     "bytes": 1193,
+     "sha256": "6a74c3cd63f52071eb70804c7a2cbad5eb8a607dfca3a26934530c428b026017"
+    },
+    "maps/brkpinchy/woodknave1.bsp": {
+     "bytes": 24396,
+     "sha256": "3b5a0997856a37546e9321c06985557959c658197775c315d12f51dc2d7bdd59"
+    },
+    "maps/brkpinchy/woodknave1.map": {
+     "bytes": 785,
+     "sha256": "28386ffecc4b837013a3bb29659ad07ccf2c9e1171e99d2a01f2cbc9c2a26e9d"
+    },
+    "maps/brkpinchy/woodknave2.bsp": {
+     "bytes": 24364,
+     "sha256": "f2f880b9816f45d0a578517dd1a6fd2af24db05947eb9c7d1abac343d7bfeb43"
+    },
+    "maps/brkpinchy/woodknave2.map": {
+     "bytes": 745,
+     "sha256": "c1e8f62d5bbdf1caae3166dfa10ef1ab69b3195b27dca37e676f3155cb74c2cd"
+    },
+    "maps/brkpinchy/woodknave3.bsp": {
+     "bytes": 24312,
+     "sha256": "bec8f5b44e0158aeea99e4bc4944d6d6426b87a760823294edb831a61bee0a7e"
+    },
+    "maps/brkpinchy/woodknave3.map": {
+     "bytes": 702,
+     "sha256": "6faccaf1b21eec9a9781ada8ac1f889ea7802d0fb935cc3549a02257f7114577"
+    },
+    "maps/start.bsp": {
+     "bytes": 15740044,
+     "sha256": "5658ed1c13c67be3dabcb01bba21bfe556dc2ef1612bcdc58a6dfc32dfbee514"
+    },
+    "maps/start.lit": {
+     "bytes": 27090272,
+     "sha256": "611793b472c1f15941f98334f3e98a69eda35109dc267213c17c678de81767a9"
+    },
+    "maps/start/purp/shop/tele1.bsp": {
+     "bytes": 32504,
+     "sha256": "a5001e370c39d0cfb7d7e81f89773ffabdac63f2d5e6213c9c36f4eb850b0555"
+    },
+    "maps/start/purp/shop/tele1.lit": {
+     "bytes": 9608,
+     "sha256": "b0dce5568c3b692421c351b6e05875e3dc90321f8f0d3a72b148e975908723b8"
+    },
+    "maps/start/purp/shop/tele1.map": {
+     "bytes": 1420,
+     "sha256": "3ef17fef134186554e57ee27ad34224ab61dbb3206fe410642acc9d7ab0073f8"
+    },
+    "maps/start/purp/shop/tele2.bsp": {
+     "bytes": 32184,
+     "sha256": "dd83662e299c8647c6f256f4c7ba7a19b58036da65bad33c3eaf1e3bd0385dfb"
+    },
+    "maps/start/purp/shop/tele2.lit": {
+     "bytes": 8648,
+     "sha256": "6504e8b1af7528a8351fbc6f09c6120971cc13988e88661ccd23dd6ae6606f78"
+    },
+    "maps/start/purp/shop/tele2.map": {
+     "bytes": 2423,
+     "sha256": "c1a595b830127248dfa608ea1066333f3822d41b04cc20f8345b708279404c6c"
+    },
+    "maps/start/purp/shop/tele3.bsp": {
+     "bytes": 31352,
+     "sha256": "ebd8576e798e638dcfe296afffe21172606fb80addce9e5b107f6b4d8528218c"
+    },
+    "maps/start/purp/shop/tele3.lit": {
+     "bytes": 6152,
+     "sha256": "c867955a51f27772512fc186bcaac0f8621b1e5d8f319daff1a58eccaf31540c"
+    },
+    "maps/start/purp/shop/tele3.map": {
+     "bytes": 1769,
+     "sha256": "a5ffc7e11ff2c2797ac3640dab5dbe7594f10b2cdea4bc0a04181db86685cb43"
+    },
+    "maps/start/purp/shop/tele4.bsp": {
+     "bytes": 31096,
+     "sha256": "b76c1f868e10a4aed511a43e1f4421298759c41c5d2233fb9f2f1b434a5a5a6f"
+    },
+    "maps/start/purp/shop/tele4.lit": {
+     "bytes": 5384,
+     "sha256": "93497d3104c1dcad24195b45a36a5ed00f17cafe4d988ef6b45afdde67470b5e"
+    },
+    "maps/start/purp/shop/tele4.map": {
+     "bytes": 2429,
+     "sha256": "08a67c847fb86c580ac9e3af550e7756b72381b9778528e0c5e1c0b2d5af1421"
+    },
+    "maps/start/purp/shop/tele5.bsp": {
+     "bytes": 30264,
+     "sha256": "b20b90033a05b81469c52d7b0facbc525ae5e3dbf1e5ada001c46034783d06ee"
+    },
+    "maps/start/purp/shop/tele5.lit": {
+     "bytes": 2888,
+     "sha256": "74131d178098385c7cb489de4061cc837bc51cd895369e8e8fd57175f82fb6f9"
+    },
+    "maps/start/purp/shop/tele5.map": {
+     "bytes": 2439,
+     "sha256": "d598fe5919a7ba7df17744bd55ce6acf3208b57fbd82d295186ce945075c5d7e"
+    },
+    "maps/start/purp/shop/tele6.bsp": {
+     "bytes": 30136,
+     "sha256": "1a5264ae676992ac800535559b207c3fea3379e0a6c449ae6eba66facb7963ca"
+    },
+    "maps/start/purp/shop/tele6.lit": {
+     "bytes": 2504,
+     "sha256": "ce95857f144528765fdbff874cdc66621156607f95e52a65e397a67bddd84de1"
+    },
+    "maps/start/purp/shop/tele6.map": {
+     "bytes": 2384,
+     "sha256": "ea3d00d12a0c9587dd17aa31d81fbff4fa57c1c3ab880e34d1f6149a3a943ad5"
+    },
+    "maps/start/purp/tele1.bsp": {
+     "bytes": 16140,
+     "sha256": "063a52e558efe6703f582ff2518d1a8bcc02f3257786932eb69d8bf16518d351"
+    },
+    "maps/start/purp/tele1.lit": {
+     "bytes": 9608,
+     "sha256": "cdc0603498c4a95fc34b312aa4e8c7592626b074b46a9ae7cc7987ba6f296852"
+    },
+    "maps/start/purp/tele1.map": {
+     "bytes": 1337,
+     "sha256": "14eaf5f2518419af362d10b4b80c523419b121d2b2b3926c6a5f9a5fc508a96d"
+    },
+    "maps/start/purp/tele2.bsp": {
+     "bytes": 15820,
+     "sha256": "ebdaf63fd0fb10cc6fdb7983efa4c8d2b38bd21c9a1f2e891f75b7100045986a"
+    },
+    "maps/start/purp/tele2.lit": {
+     "bytes": 8648,
+     "sha256": "035db8a070b017930d61fe09a27895e93ec02e8e8ebb482bf7bf528605e0f96b"
+    },
+    "maps/start/purp/tele2.map": {
+     "bytes": 2340,
+     "sha256": "cf7695252e077bbcdfdd0548af54b9d6621b4705955d97747a93e4628ab4a58d"
+    },
+    "maps/start/purp/tele3.bsp": {
+     "bytes": 14988,
+     "sha256": "f946bbde301d000dc8d004666a516ff53f690906e9ffc73a93699db7a4bf2a73"
+    },
+    "maps/start/purp/tele3.lit": {
+     "bytes": 6152,
+     "sha256": "b1e7c7fafdc22c35691ed8038463066089d5f4909b4dfff98e7bed6250478644"
+    },
+    "maps/start/purp/tele3.map": {
+     "bytes": 1686,
+     "sha256": "c18c94de9770ecaf3d1dc953e2749ba2f07fd1ab4ffd46a6f1918dd6b4fd1a65"
+    },
+    "maps/start/purp/tele4.bsp": {
+     "bytes": 14732,
+     "sha256": "282c824502aae0be42919cd558090376f2a51dac5e56cc560278157bd5fc98a9"
+    },
+    "maps/start/purp/tele4.lit": {
+     "bytes": 5384,
+     "sha256": "1d52d9161c4cee48cfbf5fbbc7a3fe5cb633a42a6e6543f24599204cac0035b0"
+    },
+    "maps/start/purp/tele4.map": {
+     "bytes": 2346,
+     "sha256": "28e38c45be13ae5cd6f78c53680cc4179f81cbfee02cc1b1891e33a3ee8a5560"
+    },
+    "maps/start/purp/tele5.bsp": {
+     "bytes": 13900,
+     "sha256": "ef6e2a8c86492c1d4e10ae00435939f7acd5fc1ee97acc34d1245f833d0239df"
+    },
+    "maps/start/purp/tele5.lit": {
+     "bytes": 2888,
+     "sha256": "ef1b889517c80e072efc33a9321d577d1703a9f9dd1c47b6e5b7f00f593d63e5"
+    },
+    "maps/start/purp/tele5.map": {
+     "bytes": 2356,
+     "sha256": "94fdc0bb1c0ccfa9382dc8a64338f5a33ed288266519944eb0937472e89a8e25"
+    },
+    "maps/start/purp/tele6.bsp": {
+     "bytes": 13772,
+     "sha256": "e7db4a9d7aef7dce89dcc12cc54001f51da66991f9f9decca0d1c77b4af792bb"
+    },
+    "maps/start/purp/tele6.lit": {
+     "bytes": 2504,
+     "sha256": "7e2a121d4636e60f724e208dfcc147b65b814a8cbd3cba7013e3b577b81e73eb"
+    },
+    "maps/start/purp/tele6.map": {
+     "bytes": 2301,
+     "sha256": "e6d7914cd1c72e9bbbb28befb46a9cea2706e88419afd5b98923d7bfa6875f2c"
+    },
+    "maps/start/tele1.bsp": {
+     "bytes": 16108,
+     "sha256": "e32b3e0c1257447fbdba6bea775d242b176946abb76c2e296497d428c441d334"
+    },
+    "maps/start/tele1.lit": {
+     "bytes": 9608,
+     "sha256": "90bdc6ee0e0ade4bc579e906a81c6dc40e53042509d526dcf8cbd489293a744e"
+    },
+    "maps/start/tele1.map": {
+     "bytes": 1297,
+     "sha256": "b312a32a6c1d403acf94dc7eac23839d1a6a022891ed88c90b21cddd3fa15c0f"
+    },
+    "maps/start/tele2.bsp": {
+     "bytes": 15788,
+     "sha256": "8508cb35a9266168f05f28609c693bff03ea228c848b7de608d13f9767155964"
+    },
+    "maps/start/tele2.lit": {
+     "bytes": 8648,
+     "sha256": "da5941757e99fb617e92a1a3570a35f01b91c7d16ea01316d7db548141ee77a8"
+    },
+    "maps/start/tele2.map": {
+     "bytes": 2300,
+     "sha256": "990afd8f799cd2d4b3f1b8d66cbacfccc57e554fe583da470f8a710d4fab301b"
+    },
+    "maps/start/tele3.bsp": {
+     "bytes": 14956,
+     "sha256": "eda4864080c540730b27d718ace5ae4eecf820c8947b4c3e8ce3e7355584ca32"
+    },
+    "maps/start/tele3.lit": {
+     "bytes": 6152,
+     "sha256": "3bb2bbfecec9d0306be1f76a5e404418df8eeba9b3a5d597886a393dc240fe7f"
+    },
+    "maps/start/tele3.map": {
+     "bytes": 1646,
+     "sha256": "282416b1cdbb4e1ae1699b4e39b23297694db20851d2a7cf6756ac920d80390b"
+    },
+    "maps/start/tele4.bsp": {
+     "bytes": 14700,
+     "sha256": "8ec56a61e3c3ee35e33afb000a20ace74f802475e262f69fe2a5b3c6519bbb2d"
+    },
+    "maps/start/tele4.lit": {
+     "bytes": 5384,
+     "sha256": "d127698d93f633351d53f38c7fd5deb420665175332244ea2085fa5000158c26"
+    },
+    "maps/start/tele4.map": {
+     "bytes": 2306,
+     "sha256": "8d443ce7450412ace62c97c0a2beae4d01b0893b7b918e424028384cfc35c4e9"
+    },
+    "maps/start/tele5.bsp": {
+     "bytes": 13868,
+     "sha256": "4534e3dbe06a90b8d33e0a07ce100e53717db7c10038f7ca0b7b555b7ee9a937"
+    },
+    "maps/start/tele5.lit": {
+     "bytes": 2888,
+     "sha256": "5d9c9337b4f1472b36dae1d48bf81378b6f322c55c701dade412c1d2fa821063"
+    },
+    "maps/start/tele5.map": {
+     "bytes": 2316,
+     "sha256": "2912aa9798414c317be63111b51bcbf632ac45459d8f53d9861ec5cab1655fcb"
+    },
+    "maps/start/tele6.bsp": {
+     "bytes": 13740,
+     "sha256": "79fc7740398cbb7350bbc0069c8b73cce9b4090444dcc67586c7ad13764a5a2d"
+    },
+    "maps/start/tele6.lit": {
+     "bytes": 2504,
+     "sha256": "f6c0eda3231e9c4a4acfe8279b8b32383fd53a7dea8153dfcb9e4f0d2579f3b5"
+    },
+    "maps/start/tele6.map": {
+     "bytes": 2261,
+     "sha256": "99ca171b71c8002115b0bc523e8948b15272a56a3f6967b99d45ab3de52f1dc6"
+    },
+    "music/track120.ogg": {
+     "bytes": 5697225,
+     "sha256": "4ffa311eb16781fe7cbd7b366fb2cb29ac9303fdaf3d6742a0f73b4200b832cc"
+    },
+    "music/track125.ogg": {
+     "bytes": 11758014,
+     "sha256": "45a43c47fd05eeafedd1a509a25e8059c6273969611dcee61ef81ac5311b9e46"
+    },
+    "music/track27.ogg": {
+     "bytes": 3204681,
+     "sha256": "90423f61355555717010be12da1e1aa7e331c00f3f0c6838f700a83bc7f88e3f"
+    },
+    "music/track36.ogg": {
+     "bytes": 8609705,
+     "sha256": "488b86ad7b5d7c8f3b79b49c394c29ffdc903c9820c562a26abfa82046edb5f9"
+    },
+    "music/track44.ogg": {
+     "bytes": 6170616,
+     "sha256": "3d3bb23b93b9f4a501e0ba34a2c68b80ad50dc7e4d9d6c54c576b7b3f5177ef5"
+    },
+    "music/track45.ogg": {
+     "bytes": 10125346,
+     "sha256": "bd249281d5a75cf88635e596fbbdf32dd5d91fe8c08f247b86063586da389a20"
+    },
+    "music/track66.mp3": {
+     "bytes": 13421284,
+     "sha256": "9c05f986a9c86059733e8861df0095d457610cd24e5e37b04988d529ad5b91e9"
+    },
+    "music/track66.ogg": {
+     "bytes": 7530433,
+     "sha256": "cf80d520d5475a14092c39e9e5252a4348ae4b237506088758ca694ced91005a"
+    },
+    "music/track69.mp3": {
+     "bytes": 13483005,
+     "sha256": "55f52c6d19233dba50bdc84d513abba05da0f080655c2fcc88b61b72542d5098"
+    },
+    "music/track70.ogg": {
+     "bytes": 7204634,
+     "sha256": "dcfa02f9584d0112deafd2050cc0c6b9254bca49e4752c7cecc1dee0412bedfd"
+    },
+    "music/track80.mp3": {
+     "bytes": 3206713,
+     "sha256": "b2a236079cbb8fad16a3ce7e4d67a7967b0d59fc2a6852fccd9c53179d321bc2"
+    },
+    "music/track81.mp3": {
+     "bytes": 8165169,
+     "sha256": "c14001e0ae50c8510ded5b5e66e39142fa3b4ddff6a1b3a605ddad43f383577d"
+    },
+    "music/track82.ogg": {
+     "bytes": 6111723,
+     "sha256": "9d38ad6ecf902d65405cd138861825eea0fe01365020c96a6332cae824737d91"
+    },
+    "music/track84.ogg": {
+     "bytes": 3305779,
+     "sha256": "bc243f07254ec8940f3f6023787aabb088ac777fd50599b3839cca4ed8874ebb"
+    },
+    "progs.dat": {
+     "bytes": 684974,
+     "sha256": "b54e33e50ad06d5628132a26bb6b089534d091bd2b6756799a15b61e7af49811"
+    },
+    "progs/bonk_shard.mdl": {
+     "bytes": 23572,
+     "sha256": "26aeffa72655670da33288f3d348e1242cffa973127048ce5937b8ec92ad54d0"
+    },
+    "progs/brute/h_brute.mdl": {
+     "bytes": 182968,
+     "sha256": "e28f8727d88931178521f188e748f79c286e45d1f56cc33e6f36d6543736608d"
+    },
+    "progs/brute/mon_brute.mdl": {
+     "bytes": 991068,
+     "sha256": "6d4642ad73cdf22362e17ba24002f92f9436c06491214b0af5e5777222225615"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 39028,
+     "sha256": "6a23999e3ad1d2d5d9838b322b953c2a914cc5bff8d76ddefa1a90113638a66d"
+    },
+    "progs/g_hammer_alkaline_axe.mdl": {
+     "bytes": 73412,
+     "sha256": "50163da065f3cf3954983af542f29f1cc389d3679223ba3b02b7da012ddf8262"
+    },
+    "progs/g_hammer_baseball.mdl": {
+     "bytes": 87268,
+     "sha256": "5eb97dc66970a50ff34c9a279773bdddc8254a9d7a3dfdb92b6a2e730ed90443"
+    },
+    "progs/g_hammer_baseball_bat.mdl": {
+     "bytes": 87268,
+     "sha256": "9c0a5779182319bcf16d904573334a239d22e88bc2962714be8d7aa48c5dc0f4"
+    },
+    "progs/g_hammer_baseball_bat_bloody.mdl": {
+     "bytes": 87268,
+     "sha256": "5eb97dc66970a50ff34c9a279773bdddc8254a9d7a3dfdb92b6a2e730ed90443"
+    },
+    "progs/g_hammer_blocky_axe.mdl": {
+     "bytes": 83796,
+     "sha256": "1ba8252d4d209c3fbb6a262acee9f274e09f86dc3991c6ed41fc881f9dd22fe5"
+    },
+    "progs/g_hammer_blocky_brown_brick.mdl": {
+     "bytes": 151252,
+     "sha256": "833d0d4d9e42c23cd407074dce823843c444947e8729dd0fe362895bf453134e"
+    },
+    "progs/g_hammer_brown_brick.mdl": {
+     "bytes": 151252,
+     "sha256": "833d0d4d9e42c23cd407074dce823843c444947e8729dd0fe362895bf453134e"
+    },
+    "progs/g_hammer_burger.mdl": {
+     "bytes": 151636,
+     "sha256": "3e75d266b07faa72a74eb5e1d0020a2fe4d9be91cb48ee2ab0f9b6a30456c28c"
+    },
+    "progs/g_hammer_buster_sword.mdl": {
+     "bytes": 141076,
+     "sha256": "5a5d547cf131ccff7241930fad4b368a853a0c7c4bdc1bafa4bc99ee9f65a59c"
+    },
+    "progs/g_hammer_copper_axe.mdl": {
+     "bytes": 17812,
+     "sha256": "9265f7867f2d81f5bc778ba0f14b70d10b44e11b7a242032c536fd2f98250c8b"
+    },
+    "progs/g_hammer_default.mdl": {
+     "bytes": 71796,
+     "sha256": "e161bf81eec4ab871fbe7fc6c53ffa9b014e2570d89b293614063c725fceb770"
+    },
+    "progs/g_hammer_default_bloody.mdl": {
+     "bytes": 71796,
+     "sha256": "b99306233d2d0384d0597646d75b21ca7f3f073bdb606deb81d7dc1383d16765"
+    },
+    "progs/g_hammer_default_gold.mdl": {
+     "bytes": 71796,
+     "sha256": "bc1d2cd466469f1d222e8ea10c2eb71a5958ca58f2d7e02a6c5b471d30e2bcf2"
+    },
+    "progs/g_hammer_default_gold_bloody.mdl": {
+     "bytes": 71796,
+     "sha256": "bf1f33ea9c87fbbc4260896e694d4dfdd5ffe4bd140a006bff3a0c0acb72c184"
+    },
+    "progs/g_hammer_dwarven.mdl": {
+     "bytes": 78388,
+     "sha256": "3308d9c3af6f67e81356a2e6f75b83151354ac69e67a97182e52cb7ac9e42a71"
+    },
+    "progs/g_hammer_error.mdl": {
+     "bytes": 111860,
+     "sha256": "16fbe4bdcc3498c0e2913ac96c305d97c2d1a68fabd4b7dadfe1bfdc91d13658"
+    },
+    "progs/g_hammer_floyd.mdl": {
+     "bytes": 142244,
+     "sha256": "ea58a7bce25ec9ad352e9706a63de455bd9e447ee79e1822f9f158f6e81114c7"
+    },
+    "progs/g_hammer_guitar.mdl": {
+     "bytes": 73332,
+     "sha256": "99689467c986502bf35b5ad15d577c8887be478086412564c13e393be05476bf"
+    },
+    "progs/g_hammer_heavy_rocket.mdl": {
+     "bytes": 151028,
+     "sha256": "5ff13af63586413d7af5e54ddc70cff5251f0ecf43a7d40e95cfffd4df787b5c"
+    },
+    "progs/g_hammer_jester_mallet.mdl": {
+     "bytes": 144308,
+     "sha256": "95f9fd0274b0cf16b76a06769b1c9f65fa5f0e43698570e0f1a92584124a6b79"
+    },
+    "progs/g_hammer_katana.mdl": {
+     "bytes": 71540,
+     "sha256": "915b9310500626794ba7d894188f513664dc7c1cd624a56321efdcc4847451c9"
+    },
+    "progs/g_hammer_kebby_gears.mdl": {
+     "bytes": 158708,
+     "sha256": "515215ada512b72113fe6ce7722ac6b3ed2acc36ac6fc634a4be7937e3b8cc43"
+    },
+    "progs/g_hammer_mace.mdl": {
+     "bytes": 73236,
+     "sha256": "39c2a88deadc9510a62bd116d3c148f85b39588bc766480560ba04aacbf009d0"
+    },
+    "progs/g_hammer_mailbox.mdl": {
+     "bytes": 73396,
+     "sha256": "c259d8f39672bb1dcc1221d5f856d58dc22cb9b3711c0c8ed3fbbe302cf6daeb"
+    },
+    "progs/g_hammer_moving_past_it.mdl": {
+     "bytes": 70500,
+     "sha256": "112e59069a42ba5a17cfbaa81c9b9555c92bf848cf9d8af73e98289284f4630e"
+    },
+    "progs/g_hammer_pickaxe.mdl": {
+     "bytes": 80660,
+     "sha256": "a16d7107d91f3b00ab65f5b05c61b31365effd035f1451255b410640d056db45"
+    },
+    "progs/g_hammer_pirate_skull.mdl": {
+     "bytes": 99572,
+     "sha256": "9936e7157434678d6b47666e58cd4db3438fc78dae908ecfe4c66ff9fcd419e6"
+    },
+    "progs/g_hammer_sailor_sceptre.mdl": {
+     "bytes": 84852,
+     "sha256": "f7c428a3367f46782acb6d0a57550c963762cdaaf4c1f2de547bbf8bcca6d8e7"
+    },
+    "progs/g_hammer_sblade.mdl": {
+     "bytes": 74260,
+     "sha256": "60fb7f7b36006b00694082e0c4fccc4c1ac16274eb877d89486f716f5cbe0b64"
+    },
+    "progs/g_hammer_sentinel.mdl": {
+     "bytes": 83988,
+     "sha256": "6aae635349aa5fd7e8d5d5e28debe999c527d69d360c9f7b7e54a4653d919d1b"
+    },
+    "progs/g_hammer_squeaky.mdl": {
+     "bytes": 80548,
+     "sha256": "ea6d9d0e8dd84ef4ed2ff8473af5de97951b2d594fd39078d09b6bddff75cc44"
+    },
+    "progs/g_hammer_stop_sign.mdl": {
+     "bytes": 69684,
+     "sha256": "a43b45244358cd95e0ed2eec10dd6544dc0e776e8732b43e9d447084a1666152"
+    },
+    "progs/gaunt/g_fx.mdl": {
+     "bytes": 32260,
+     "sha256": "ac99d4e641af0bb1495ed38ba9f3a7c1195bda19e5cf0d3a68f04defe6178ab8"
+    },
+    "progs/gaunt/gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/gaunt/h_gaunt.mdl": {
+     "bytes": 61251,
+     "sha256": "dec5afe666eba8db6e32d7535fffa3d0e4ed9344ba107b73418526ebebac574b"
+    },
+    "progs/jumpboots.mdl": {
+     "bytes": 96180,
+     "sha256": "74fa27f5580474bc57be595aff60ba342d3877fa3abb7901c26944c9cf228a22"
+    },
+    "progs/kanji.mdl": {
+     "bytes": 158704,
+     "sha256": "dcb6b4d3f1514f01176526d1a87115c5c13f47c702d68ffdbaef768e0079ed95"
+    },
+    "progs/megashambler.mdl": {
+     "bytes": 335552,
+     "sha256": "16f6d2502b84d8d4b33469976f32f6537bb27e239f0d9b09d374c8ab28dab8e0"
+    },
+    "progs/player.mdl": {
+     "bytes": 754644,
+     "sha256": "fdabb2114f3f1ed98af1e90503deb19d71644a67fe10addc9c8647f0924f1f8f"
+    },
+    "progs/player_mace.mdl": {
+     "bytes": 422804,
+     "sha256": "70623c63bd9df5f6e9e0e73fb7891ddd593f58f93d6dc7200c3cc792f528c711"
+    },
+    "progs/s_blood_128x.spr": {
+     "bytes": 246096,
+     "sha256": "594fba70e8c23357cad424393091cdb3ed6264aabbee5943ebeba8e2bea8a492"
+    },
+    "progs/s_blood_32x.spr": {
+     "bytes": 15696,
+     "sha256": "fd39b54c5da142ddf83892cff40fbb5e0436588aa8e7f3d669bcf5dbd8038cac"
+    },
+    "progs/s_blood_64x.spr": {
+     "bytes": 61776,
+     "sha256": "4658921f645875be2e36415658f65ce389c40500cc9f4929b1445f6bd808cba6"
+    },
+    "progs/s_blood_96x.spr": {
+     "bytes": 138576,
+     "sha256": "214d0587d2b1009151c8bba51a97b829af5ebf6c90c15ea20507e6c6ae6a7b90"
+    },
+    "progs/spark_blue.mdl": {
+     "bytes": 23460,
+     "sha256": "4781151723448f5f929f2b0d64d5cac2fbcd93e495b63b3b1c95af87d97ef0b0"
+    },
+    "progs/spark_red.mdl": {
+     "bytes": 12900,
+     "sha256": "eb2bd332b016ebd32c7bcf2b044c4f9e62122bf47bdb591b71b991b4609ae605"
+    },
+    "progs/spark_yellow.mdl": {
+     "bytes": 23460,
+     "sha256": "310882dc63b18b2a506a8bc08884eaf23d3ae621b8dcc6c679968bcb00781eb1"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 1325884,
+     "sha256": "f02aacc444c638ddc5271d69b76e6db02b5a9f7d59e2ac8f14e4999c215bebb5"
+    },
+    "progs/v_hammer_alkaline_axe.mdl": {
+     "bytes": 1542372,
+     "sha256": "6c4ab3ce7b668c2631401a279b57db1ae9392ddb76c69c61da1c52f884437f30"
+    },
+    "progs/v_hammer_baseball.mdl": {
+     "bytes": 1820532,
+     "sha256": "fb4163cda833431d47378fc59be1cfef5b1ecdfcdca374fdb5f49c00df163bec"
+    },
+    "progs/v_hammer_baseball_bat.mdl": {
+     "bytes": 1820532,
+     "sha256": "e745d8760338b2ac78166e84a7f74c3b296b8bf16e2193fd0c6c28cab6fbf96c"
+    },
+    "progs/v_hammer_baseball_bat_bloody.mdl": {
+     "bytes": 1820532,
+     "sha256": "fb4163cda833431d47378fc59be1cfef5b1ecdfcdca374fdb5f49c00df163bec"
+    },
+    "progs/v_hammer_blocky_axe.mdl": {
+     "bytes": 1941884,
+     "sha256": "0434b4a60781e72ba43fcab224a9b57f150b28a079146665fbf10428d6eea1ce"
+    },
+    "progs/v_hammer_blocky_brown_brick.mdl": {
+     "bytes": 1891484,
+     "sha256": "bfcb8cb3c061e259df9cb8841da2d870c0b8c734ee269562f73429dc65a26ea6"
+    },
+    "progs/v_hammer_brown_brick.mdl": {
+     "bytes": 1891484,
+     "sha256": "bfcb8cb3c061e259df9cb8841da2d870c0b8c734ee269562f73429dc65a26ea6"
+    },
+    "progs/v_hammer_burger.mdl": {
+     "bytes": 2090844,
+     "sha256": "caaf0c6d2837cfaef9574bbcfe43fb9ef287681ff5fa75c48c3f35e3c074c010"
+    },
+    "progs/v_hammer_buster_sword.mdl": {
+     "bytes": 1624380,
+     "sha256": "5516fd4e96bad6bdc9557bcc0657cd381af279d4c2fa480c630d31d7cb37d637"
+    },
+    "progs/v_hammer_copper_axe.mdl": {
+     "bytes": 1108748,
+     "sha256": "54a1be810924085b6e3eaed306404b3d6d9e6a2d591133f9df52e0088e350e20"
+    },
+    "progs/v_hammer_default.mdl": {
+     "bytes": 1325884,
+     "sha256": "fef8c2ec7c3c31264f86d39cb785c223a2bb2558a79b3aa3ab3b3765c502cdff"
+    },
+    "progs/v_hammer_default_bloody.mdl": {
+     "bytes": 1325884,
+     "sha256": "75bd972e8d104b36c398df0dfbb0051b00a7cd610d7e3d986e651e284ff447b0"
+    },
+    "progs/v_hammer_default_gold.mdl": {
+     "bytes": 1325884,
+     "sha256": "4bd1ae85b04b535a0ac3975b099a3d99fd0a4d2ed3ff86edd5e33520ea87e1dc"
+    },
+    "progs/v_hammer_default_gold_bloody.mdl": {
+     "bytes": 1325884,
+     "sha256": "40ae37a9fafcba8b3cdddc85b0f378d4580ad64b8b854ce7e2a9409317c9f232"
+    },
+    "progs/v_hammer_dwarven.mdl": {
+     "bytes": 1693132,
+     "sha256": "de56594658f837812b4208500d2f1ff879d9d6415a10797c9b1359e76a5b9cbd"
+    },
+    "progs/v_hammer_error.mdl": {
+     "bytes": 2235116,
+     "sha256": "97b01e96d0429c9ea9cdfe36c79cb14f81ac8d5bb0972db8989c2c48cdf68e8f"
+    },
+    "progs/v_hammer_floyd.mdl": {
+     "bytes": 1757156,
+     "sha256": "003d27180377f51d81067e0531099f0ff18537b9d4f6bdeecc80388377833117"
+    },
+    "progs/v_hammer_guitar.mdl": {
+     "bytes": 1451324,
+     "sha256": "2541cf9b7e8a547f829a98a0aff0d5cd58e2fa6b1fe312372f95998fe9bc01ef"
+    },
+    "progs/v_hammer_heavy_rocket.mdl": {
+     "bytes": 2162924,
+     "sha256": "4d40a247d750d7a76ce815614446e4a1ae6ccd7ef20ff1dbe3cbba6e72f1a175"
+    },
+    "progs/v_hammer_jester_mallet.mdl": {
+     "bytes": 1874876,
+     "sha256": "c6ef08fb2dfeb07723281577a7bd357160331a7ab467c559c099864483de5050"
+    },
+    "progs/v_hammer_katana.mdl": {
+     "bytes": 1285356,
+     "sha256": "13473bcd57d84305499dba53045fccab9ce82e41a7d3f662d1731f31d43ad916"
+    },
+    "progs/v_hammer_kebby_gears.mdl": {
+     "bytes": 2441980,
+     "sha256": "3fd311806a631b426c69c29314e553b2f3185921ea8cf33c4164fbea9a3cea6e"
+    },
+    "progs/v_hammer_mace.mdl": {
+     "bytes": 1499004,
+     "sha256": "9f36583a4fdd694449919b0c7eb26a2bed1f1ff8683b6b35563f060773e08917"
+    },
+    "progs/v_hammer_mailbox.mdl": {
+     "bytes": 1357756,
+     "sha256": "ba2c170a010df7d6190d37d8eaf2fab67e4360de78119692bc59b41aa13f4714"
+    },
+    "progs/v_hammer_moving_past_it.mdl": {
+     "bytes": 1325556,
+     "sha256": "d8bc4d88e9f36964807b45391b2674355d81b79d9bae3b32708e35ccd2c8be0a"
+    },
+    "progs/v_hammer_pickaxe.mdl": {
+     "bytes": 1645708,
+     "sha256": "0653219a86223f36b3720ed49bab8f70e8f810ec28e62553d76f48f6d18fc4fc"
+    },
+    "progs/v_hammer_pirate_skull.mdl": {
+     "bytes": 2268780,
+     "sha256": "35fb1bb182e87c9a8aa7862d28dabce13fefc7ade1a4c340b6bdce893b93b4f2"
+    },
+    "progs/v_hammer_sailor_sceptre.mdl": {
+     "bytes": 1715036,
+     "sha256": "5c7e85fa8c0252103caae690ceeaa5ac126995a5ebd45f944160c9241d3d56a1"
+    },
+    "progs/v_hammer_sblade.mdl": {
+     "bytes": 1543404,
+     "sha256": "e11218965fd17530f13c3978d98df9ecf6ba433b803f9d069c38ff501848479b"
+    },
+    "progs/v_hammer_sentinel.mdl": {
+     "bytes": 2039260,
+     "sha256": "2b881b4f45c04e901c2438eea39baab0c80617142dad8c923d2364a4a2ba0f31"
+    },
+    "progs/v_hammer_squeaky.mdl": {
+     "bytes": 1493556,
+     "sha256": "c113e6fd7f9a339b0b5d8680f01a38cd7d55cdc502d6f982bc762d2045cf8a4e"
+    },
+    "progs/v_hammer_stop_sign.mdl": {
+     "bytes": 1219548,
+     "sha256": "b83c0ec4dcd60e4057ef1467a247960b291e5c7d2c8e5be433903a6d3621532f"
+    },
+    "qcsrc/ai.qc": {
+     "bytes": 40288,
+     "sha256": "7814a98d314797a34766e731501a0fc5fadf2fb45070f886dd8820cf53c80fcb"
+    },
+    "qcsrc/buttons.qc": {
+     "bytes": 14737,
+     "sha256": "8c5d4304a882b42fd50dd3ae6ce54e23be80733ff96aafed93f6c40fa8960475"
+    },
+    "qcsrc/client.qc": {
+     "bytes": 52946,
+     "sha256": "3b37d1af8b40d889c188eb4685b6e2b870e4ee974a6b787f7e2393342aa99e9c"
+    },
+    "qcsrc/combat.qc": {
+     "bytes": 17950,
+     "sha256": "cf1d95ed7026c630ea2e2a729eabde41f01b5f161303685e772282ab0a81a0eb"
+    },
+    "qcsrc/constants.qc": {
+     "bytes": 13374,
+     "sha256": "9b2f3281d77305e2f77513e2ed0d0143d830eb9f4acae16a4ae4aebe4b06eb43"
+    },
+    "qcsrc/csdefs.qc": {
+     "bytes": 42891,
+     "sha256": "e7ae286995262dc42ec74809483894a6c82bfe4e487f4a20f1256d528ea8c0d1"
+    },
+    "qcsrc/csprogs.src": {
+     "bytes": 68,
+     "sha256": "694f993105db7187e507bf4c7a187aeece0da5fa1fa426713c2179549afeecf0"
+    },
+    "qcsrc/defs.qc": {
+     "bytes": 19087,
+     "sha256": "1f2302e92176f5d03ba75c676908f108318e8f928e846498cd9679315fa11c96"
+    },
+    "qcsrc/dev.qc": {
+     "bytes": 11605,
+     "sha256": "d6eb905e91da53316ff2673bc7fe0d636597142a0a3ac0cbf96ab09f18306ddf"
+    },
+    "qcsrc/doors.qc": {
+     "bytes": 35917,
+     "sha256": "4481b811eb32dafb44e9e9e28831dde65c166612833382060ff51452af2b0a29"
+    },
+    "qcsrc/explobox.qc": {
+     "bytes": 8309,
+     "sha256": "8a2dc22319521da9f560a5c1d6c7298ecca80a8872ee95ea68c7f8ceeb8a5d60"
+    },
+    "qcsrc/fly.qc": {
+     "bytes": 5659,
+     "sha256": "c7a48dce5fc451d0cbfab36caa88380be3b7015a55bb956745af77a99b8121ff"
+    },
+    "qcsrc/fog.qc": {
+     "bytes": 14857,
+     "sha256": "a5d851330a0429ac2495c70cde62c775236c9581d41b941a891cd9244d55ed74"
+    },
+    "qcsrc/fx.qc": {
+     "bytes": 42148,
+     "sha256": "221da3c98ed8b2f9518e41c78ad9673a2dfc076225894507db66baf80e068937"
+    },
+    "qcsrc/hud.qc": {
+     "bytes": 26728,
+     "sha256": "0e979c59c8e3bbec8c50ead813640e92e514725b6bbe5c5cc1c8196a6b31e7ec"
+    },
+    "qcsrc/impulse.qc": {
+     "bytes": 6068,
+     "sha256": "668f5ceae7c3f3ff2eecc3f693cdb4be945285931cebe8cd827b0d412dd634a4"
+    },
+    "qcsrc/item_backpack.qc": {
+     "bytes": 8866,
+     "sha256": "04786fd5a93abe2bd2e71dd0a9aacfda1a473c4379fe0cb2ca9ae20f981fea58"
+    },
+    "qcsrc/item_health_armor.qc": {
+     "bytes": 9064,
+     "sha256": "026fe3577d26ff2409d9746dbc614f5ae8dac1ce8119c248f308b9a3335d1326"
+    },
+    "qcsrc/item_keys_runes.qc": {
+     "bytes": 21995,
+     "sha256": "f08dde412d090004d91b75642d9743188f0dfd1f748ec4d33b0857bb324160a2"
+    },
+    "qcsrc/item_powerups.qc": {
+     "bytes": 10176,
+     "sha256": "aaee4f37c10b8674d4556daa81e9abc5117217102df1057d6f7091d2b1dee3a2"
+    },
+    "qcsrc/item_weap_ammo.qc": {
+     "bytes": 14460,
+     "sha256": "b4a11de1b5ffc67c63543a274738fe3c9a2d3cc2609abd2acfac4540798e5bb9"
+    },
+    "qcsrc/items.qc": {
+     "bytes": 26193,
+     "sha256": "81868dd27c5e70225f820faec7a268b74fa0a5111492425b6b87231199eeac13"
+    },
+    "qcsrc/lights.qc": {
+     "bytes": 29314,
+     "sha256": "0b803042f2a4152f1fbd553e48cc85120eb943153cf4d430d27150bd14c03e47"
+    },
+    "qcsrc/m_boss.qc": {
+     "bytes": 17863,
+     "sha256": "406245d8663bcc89e1a51876efbbe9b9f97b23ddeea8d6edeb53689d6d273f64"
+    },
+    "qcsrc/m_brute.qc": {
+     "bytes": 28745,
+     "sha256": "fcfc9da2c5fedce5a188136067590c8c1133865d78ac813e6bd02f2061e89e35"
+    },
+    "qcsrc/m_demon.qc": {
+     "bytes": 19502,
+     "sha256": "cc035c3c87afe929dea44e71ac7647b0d7cb160cdc1d113fe73a3e53fb722435"
+    },
+    "qcsrc/m_dog.qc": {
+     "bytes": 12240,
+     "sha256": "cf267b0604c67948891568eadf16a74179ce9fd68b6814e35a3609be02957a3b"
+    },
+    "qcsrc/m_enforcer.qc": {
+     "bytes": 12682,
+     "sha256": "bbbdcd5ffb801f1b160a79ad2074ddd1fc68ceccea150edd0c2a2dec36d84d97"
+    },
+    "qcsrc/m_fish.qc": {
+     "bytes": 13058,
+     "sha256": "c3cb58376fec30fe4d20e097bb5ac4e8f37e187a5c01741198e3787a5e2731e5"
+    },
+    "qcsrc/m_gaunt.qc": {
+     "bytes": 16426,
+     "sha256": "ba4101c6f45b0ebcdd3d46f83f0d5e98eac59cbc4b13e7bd96aaa65a119834e4"
+    },
+    "qcsrc/m_hknight.qc": {
+     "bytes": 23764,
+     "sha256": "bab8f82ae07631b568503379d15b5d753ab45325889ba652da6a188029d1b78c"
+    },
+    "qcsrc/m_knight.qc": {
+     "bytes": 11957,
+     "sha256": "c9b1d8b7123b0acf0dc615423b224ca6810eafd6d03f7afbd46e03374264f056"
+    },
+    "qcsrc/m_ogre.qc": {
+     "bytes": 17676,
+     "sha256": "0cf81262a8e26d494186ffc9479d9e740957edeac1258999ac2d36598b4fb329"
+    },
+    "qcsrc/m_oldone.qc": {
+     "bytes": 13905,
+     "sha256": "76536a7149f8685f55bbb45dc5ec9a063b1e5948ff70c1dbd49ef51170be1f0e"
+    },
+    "qcsrc/m_shalrath.qc": {
+     "bytes": 13331,
+     "sha256": "8e66a8e0229d58d0a480e0b25b34a0077ea73bd0b4b1d9add020ce30630d3f36"
+    },
+    "qcsrc/m_shambler.qc": {
+     "bytes": 17419,
+     "sha256": "53402e83c12f8d6a00bd7df1bd315f4a7d0f93962aca8fc154c91516c5beb316"
+    },
+    "qcsrc/m_soldier.qc": {
+     "bytes": 12742,
+     "sha256": "0de032d2d2f89fec92414d6977d82839737c75251811f17fbe8a5893d36f5b7e"
+    },
+    "qcsrc/m_tarbaby.qc": {
+     "bytes": 10963,
+     "sha256": "ebd9d97db66cabfabb49e95a70c08087d3f53bb03b384d51e35aafd17fb8266f"
+    },
+    "qcsrc/m_wizard.qc": {
+     "bytes": 13679,
+     "sha256": "23a639ee8ea2e4b3bb05bed8689473078a3975f0c513e08195c01120872c3466"
+    },
+    "qcsrc/m_zombie.qc": {
+     "bytes": 27924,
+     "sha256": "e3ef049e21782d4f0fdd5cf91229d03130eb74823e7d22e488a5a83ed73da28f"
+    },
+    "qcsrc/maths.qc": {
+     "bytes": 6538,
+     "sha256": "8df959bf2947abae7941dbbf214f4ed4f0cc313bdcbc3eed50dfe65b427a8d2e"
+    },
+    "qcsrc/meat.qc": {
+     "bytes": 8163,
+     "sha256": "f1f0e3c83beaacb4ff46457437d83dc2829bebc869f6e046b636fdfc3a1cfc99"
+    },
+    "qcsrc/misc.qc": {
+     "bytes": 24062,
+     "sha256": "67f3a1b91960fb5fda45807a51063ab017e06aa64edb5973385a0d06fcb181b8"
+    },
+    "qcsrc/monsters.qc": {
+     "bytes": 21790,
+     "sha256": "e2107decb5a996a88b7f3e2e486155701810aa1778c787fad2cd7fe3a9658102"
+    },
+    "qcsrc/plats.qc": {
+     "bytes": 43195,
+     "sha256": "7d463cfd116c4df9fdccc0752c3ecb15e8f152687bc3f2373ce37b7ea0a10bcf"
+    },
+    "qcsrc/player.qc": {
+     "bytes": 18842,
+     "sha256": "2116467ee31ea338e1b36b3b30b965a686265b765cca924e4bc9e7a2b1336e2d"
+    },
+    "qcsrc/progs.src": {
+     "bytes": 1171,
+     "sha256": "e3192163150183c02348eafbe67ef171e6b6f39e1a52b4d152327bbe222cc5a8"
+    },
+    "qcsrc/projectiles.qc": {
+     "bytes": 15014,
+     "sha256": "6931759849013fbfbcfce539a17f3a537a43b73c3dd581392f805a1a34f676d2"
+    },
+    "qcsrc/qc2def.py": {
+     "bytes": 2064,
+     "sha256": "59df45642d042a9f98a08b4103a9a26cfbbbab13ef601f1ba3a119337e7516f5"
+    },
+    "qcsrc/qc2fgd.py": {
+     "bytes": 2138,
+     "sha256": "c7380a27cf55974d0b5727a0f528f997dcbabe081b9368054d86b06ebe2441bc"
+    },
+    "qcsrc/shooters.qc": {
+     "bytes": 13663,
+     "sha256": "e95cfb87780fe0973cb284d0bb0b2f0586d8cb46bc5dbfb50565c2728cffc5b3"
+    },
+    "qcsrc/sound.qc": {
+     "bytes": 14026,
+     "sha256": "535a5b7f80a93054e603ac6aed38b0e370b849c63a9e2d776f7a18708bcb4498"
+    },
+    "qcsrc/subs.qc": {
+     "bytes": 3456,
+     "sha256": "ea2a1d96baa0f9991794472e5eea1ddb299d43104a190ce3b4ae031000437c5f"
+    },
+    "qcsrc/subs_move.qc": {
+     "bytes": 5662,
+     "sha256": "8a495c020bab7e58affe85de8bb84ccccd59cb57082d3d30b013e6760a76faac"
+    },
+    "qcsrc/subs_tgt.qc": {
+     "bytes": 13170,
+     "sha256": "cea0244f1b7aa92326c2775bfa7185f21ddc1c2c28a35d58c4534a8147a8c894"
+    },
+    "qcsrc/t_ctrl.qc": {
+     "bytes": 20252,
+     "sha256": "2d1a04c7bac2b55b2a2eaf255706dd7b06b3a4ca88a375440ca9ae2823009ba6"
+    },
+    "qcsrc/t_level.qc": {
+     "bytes": 15057,
+     "sha256": "24c8c4fce54b623f28dfa518748171574b6ef4bb56ee5e6b457cfce79f53146a"
+    },
+    "qcsrc/t_tele.qc": {
+     "bytes": 22124,
+     "sha256": "a184a2e8265bb384e2716299d80bfdbe3480d3b00999f7cfda8f29991ea87ed0"
+    },
+    "qcsrc/t_void.qc": {
+     "bytes": 19847,
+     "sha256": "cc95c4ae5cebdb1bec2cc46ba18e2c785210ac806ce28b2bf38bbd9bc02beae0"
+    },
+    "qcsrc/test.qc": {
+     "bytes": 329,
+     "sha256": "1db99110de27d9e6fe20330cbfefde0d443455a85a12ae8443d9ea295e66c3f1"
+    },
+    "qcsrc/triggers.qc": {
+     "bytes": 42325,
+     "sha256": "9d6787b3f8b3a8dbeaf43fac9fc1a8da1b81e6b81c6f2498e96d966bad348c9f"
+    },
+    "qcsrc/utility.qc": {
+     "bytes": 19105,
+     "sha256": "5c75fba033346fc3841924c3614c4efbf74fa3d7a2e90acb26d4b1d50f35b031"
+    },
+    "qcsrc/w_axe.qc": {
+     "bytes": 3346,
+     "sha256": "3ebccb0ef8093f879e4618f982a827f9af441300304c6413d2b1297401252194"
+    },
+    "qcsrc/w_hammer.qc": {
+     "bytes": 44188,
+     "sha256": "949048e99a8ca21b222ff7cb00a987f694b96604cb754bff43f2f7a5d0b705fa"
+    },
+    "qcsrc/w_lightning.qc": {
+     "bytes": 10493,
+     "sha256": "f9fe37bff29278d069e9ba64cf724d647b046d2f4b66086d3f2268d15af6f7be"
+    },
+    "qcsrc/w_nails.qc": {
+     "bytes": 4799,
+     "sha256": "7bdd6a079efa97babae3867e2e697d0ff9a0f424c58a07c5ac65c7c3a137b1e7"
+    },
+    "qcsrc/w_rockets.qc": {
+     "bytes": 3622,
+     "sha256": "ac0faf3e7ed5ae469b57bbcc753113939100856eef851cbe5f165e1ad1085f3b"
+    },
+    "qcsrc/w_shotguns.qc": {
+     "bytes": 4508,
+     "sha256": "14cccead121592a9e69d389d7b45771dd8e78e9ab046bc930dbbcb0d54e37d6d"
+    },
+    "qcsrc/walls.qc": {
+     "bytes": 14327,
+     "sha256": "711ec396adc3eff44a1cf99e26f55e9abed1d7c58a2a4ff3a6537b4d71051327"
+    },
+    "qcsrc/weapons.qc": {
+     "bytes": 21191,
+     "sha256": "e6318afda988cc91a2e08f1475588b4b4971815f7a69b848ac2918677ba388eb"
+    },
+    "qcsrc/world.qc": {
+     "bytes": 15805,
+     "sha256": "fea0dd28ab5c35d8ca8388dbd6996c3d5fbf36b933361a450a5b6c0d3cce0ddc"
+    },
+    "quake.rc": {
+     "bytes": 1169,
+     "sha256": "6e65da076ca9a3b946357faf873bd21428c48585485aca4c306e362b5806d6bf"
+    },
+    "sound/brute/death1.wav": {
+     "bytes": 22144,
+     "sha256": "45f001ffe6357e1600b5e7041ce7f29ae4c55c0e6c27a6bad566c4c284f21119"
+    },
+    "sound/brute/death2.wav": {
+     "bytes": 18028,
+     "sha256": "2263b9499a1d7f419fcb1a028db1d34cb4d0b1db257707847730b7f975051fb6"
+    },
+    "sound/brute/deaththump.wav": {
+     "bytes": 34994,
+     "sha256": "e704d883d0b4618ff721922b5bcc72c10cb5c22069823e18ee76d3a0047498e6"
+    },
+    "sound/brute/idle1.wav": {
+     "bytes": 46670,
+     "sha256": "778afa05b143e3a1035bab1718c166bcce27f863d2d45ef9b1bb817e363e836b"
+    },
+    "sound/brute/idle2.wav": {
+     "bytes": 44366,
+     "sha256": "e79e103fd3923e549569e55c2dc5348218fe9cc793e86d3d24e692db031be4f7"
+    },
+    "sound/brute/injure1.wav": {
+     "bytes": 11152,
+     "sha256": "97b3535ee21f8ebb54585a19a544d43aea45e3c56fa05b8b88a75281b347d38b"
+    },
+    "sound/brute/injure2.wav": {
+     "bytes": 7814,
+     "sha256": "b7bb89734f0dadd928522ad97209b311dcb872f47f9ed46dfed09ea548c46c06"
+    },
+    "sound/brute/meleeswing.wav": {
+     "bytes": 6400,
+     "sha256": "e8e571aadac62cb75b88099954fcb9d277cb60a6f9d160930d99ad81548e92b9"
+    },
+    "sound/brute/shoot.wav": {
+     "bytes": 48128,
+     "sha256": "9d1918ad3ff81f85f7ff4bd1f92a5163d1461785e495002f0e272f13a25383a8"
+    },
+    "sound/brute/sight1.wav": {
+     "bytes": 18378,
+     "sha256": "48e8d359ae63446b935dfa240cc8fa82ddaa152212ec939721e71266791ae3d5"
+    },
+    "sound/brute/sight2.wav": {
+     "bytes": 21830,
+     "sha256": "86ad465863325659873300ed964474b00e8b69924c0c97097804ee848718844e"
+    },
+    "sound/brute/walk1.wav": {
+     "bytes": 11984,
+     "sha256": "4a27fc4ce1c1663c124fd4b2aa440850f75a1848d096ef535095d790f1f6383b"
+    },
+    "sound/brute/walk2.wav": {
+     "bytes": 12160,
+     "sha256": "6d67b13902fe615cef6d2851a18b795dc8941456f2f6d882ec8faf8ccd12853f"
+    },
+    "sound/commoncold/ext1.wav": {
+     "bytes": 5051808,
+     "sha256": "9bbb98a5837b75202ed021acf7d4fc9732b015f36781952e932bd29e13f78f17"
+    },
+    "sound/commoncold/ext2.wav": {
+     "bytes": 5494844,
+     "sha256": "641eba344c0f208b3ca95c644fd3e2f16a77dde3f621367a491cd16ea9eb9f60"
+    },
+    "sound/commoncold/ext3.wav": {
+     "bytes": 11453828,
+     "sha256": "b79407d3f2f94fbb26c00ca3d514055677312c809a20e42714452fbe1c48d16a"
+    },
+    "sound/commoncold/ext4.wav": {
+     "bytes": 1003734,
+     "sha256": "4996491652cb9250d1c588337b2a0c74757c503887e7853806030f9c0b9cfb7a"
+    },
+    "sound/commoncold/vo1.wav": {
+     "bytes": 2395478,
+     "sha256": "fb5feb74ed86464b99e7f07936b3f64e9b58edbc8bf52c0c5a05a8eb24c6f550"
+    },
+    "sound/commoncold/vo2.wav": {
+     "bytes": 1990700,
+     "sha256": "33f5a581633de4d5812c6b34d724bbed7ca1b3b40b1255d3a5cfb7d6c21938f8"
+    },
+    "sound/commoncold/vo3.wav": {
+     "bytes": 1813646,
+     "sha256": "d10cccd9f23282b537a2c91e2cc9e08f4a72a3f0fb2f9202dee856bf7fd7add8"
+    },
+    "sound/commoncold/vo4.wav": {
+     "bytes": 1745882,
+     "sha256": "34c427cac22cca06c05b6fed90d6441938b7887ba906f733c8b6864a8887604f"
+    },
+    "sound/commoncold/vo5.wav": {
+     "bytes": 2169900,
+     "sha256": "2f75eedae6bd4471081f10ef23ad5346ccb5fc1938994cc07744d801742ed68a"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 83982,
+     "sha256": "4b0d8db882ab1c9fc2109effeaf125ec46fb23a91ac2242201103e0d3da96944"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/hammer/axhit1_error.wav": {
+     "bytes": 50996,
+     "sha256": "0eb60b4c56a1d52b5e505b8bf06eebf9b1b481d7bec64149b8fd78ecdacf3c91"
+    },
+    "sound/hammer/axhit1_ff7.wav": {
+     "bytes": 12302,
+     "sha256": "d8be990702d5b9c6e62a468c210000688332ab875fefb8f32d1f6496a52e6646"
+    },
+    "sound/hammer/axhit1_floyd.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/hammer/axhit1_guitar.wav": {
+     "bytes": 29924,
+     "sha256": "c43e2ad3775147518f13ccd73d1f4c900f500279d0b5b4f88a9ae9c5eb0b00ff"
+    },
+    "sound/hammer/axhit1_katana.wav": {
+     "bytes": 23724,
+     "sha256": "bef02f06fcb791ce28630563bcd51a142f105ffb83b5735c89784e24f0e962c3"
+    },
+    "sound/hammer/axhit1_squeaky.wav": {
+     "bytes": 17586,
+     "sha256": "1820cafe254f5ad1ec31f089c0b5d6fffc1d3a869eb6e79210023b48495eef7b"
+    },
+    "sound/hammer/axhit2_error.wav": {
+     "bytes": 39960,
+     "sha256": "029b4d9024f2115d7c5d1901f54ad57b098afc1ff898293a5663ec2af08a70d6"
+    },
+    "sound/hammer/axhit2_guitar.wav": {
+     "bytes": 43932,
+     "sha256": "d9cad9916a27785870b081d8bb56123eec8a276310099a57bf9da4deac6ef5a6"
+    },
+    "sound/hammer/axhit2_katana.wav": {
+     "bytes": 24046,
+     "sha256": "55609017b5800ccc4b067ca3a3e4dcff64c07046cdeb8ffb1bc630f19da1e8b1"
+    },
+    "sound/hammer/axhit2_squeaky.wav": {
+     "bytes": 14672,
+     "sha256": "6dcc45c3b5c4f68c50c9105a78970be3d39b487e90e76475023bb160779d9c58"
+    },
+    "sound/hammer/axhit_squeaky.wav": {
+     "bytes": 21042,
+     "sha256": "e3d5fc7ef9daef101a0c2148495db27ab00e6a215898afd0866225afbb24d0b4"
+    },
+    "sound/hammer/charge_full.wav": {
+     "bytes": 69420,
+     "sha256": "961b4d110387ef514b25d4062e2635913fe179683b32824e0944d3292a0ff320"
+    },
+    "sound/hammer/charge_full_error.wav": {
+     "bytes": 14538,
+     "sha256": "064972cfa55c2e4e40ca9a67e6c8a992bde4048be74cb131df034a666b0cadeb"
+    },
+    "sound/hammer/charge_full_ff7.wav": {
+     "bytes": 16374,
+     "sha256": "2850ba728ab9d099b82b617af007f09ab5d87c054ec36775a3f00f39a08da8f7"
+    },
+    "sound/hammer/charge_full_floyd.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/hammer/charge_full_guitar.wav": {
+     "bytes": 17202,
+     "sha256": "49b00541f3f6392d3f764c7f75073c47f9709bed0c6fdb2198d97cbcd80b4c9a"
+    },
+    "sound/hammer/charge_full_katana.wav": {
+     "bytes": 32300,
+     "sha256": "b233e11dd39522108016898ec07391742d7573995ae16db26c03eeb2fab4fa82"
+    },
+    "sound/hammer/charge_full_sceptre.wav": {
+     "bytes": 113452,
+     "sha256": "0e0b002ec2bd317b23d21d0b68287aa8fc2b9a9d63e00037d31df69c498ef50b"
+    },
+    "sound/hammer/charge_full_squeaky.wav": {
+     "bytes": 23814,
+     "sha256": "75177d11d8e477a7933ed09d9175f4bd49e997a07879d4767f509f68b1900536"
+    },
+    "sound/hammer/charge_med.wav": {
+     "bytes": 24108,
+     "sha256": "dd7de8af6c24217fa7fca1d4d0d28131e2d52a48313d5a3f43fefe3fd2aa7cfe"
+    },
+    "sound/hammer/charge_med_error.wav": {
+     "bytes": 14228,
+     "sha256": "b0d02364ea65a1a7c63d1ac8a30aec7424852895e1428258198e128e8bee6bec"
+    },
+    "sound/hammer/charge_med_ff7.wav": {
+     "bytes": 4158,
+     "sha256": "2ec220806a834485b7dd65898ee28a51c4eb3b903a6d4447a29c1a69b1653700"
+    },
+    "sound/hammer/charge_med_floyd.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/hammer/charge_med_guitar.wav": {
+     "bytes": 17632,
+     "sha256": "d01e6a4071ebb51f7cc4c00dbe0e3ac3e5d9dc2d88a0fa123c2b6daf8106e328"
+    },
+    "sound/hammer/charge_med_katana.wav": {
+     "bytes": 40972,
+     "sha256": "e5330d94a28e77666ec0aa8f7696e08a7053a08bf518173b3e9dec7a60eba4ca"
+    },
+    "sound/hammer/charge_med_sceptre.wav": {
+     "bytes": 41132,
+     "sha256": "31c89c0a5ede3f6828662b96473ff28f555673225493c54555a283bdffc5dfb1"
+    },
+    "sound/hammer/charge_med_squeaky.wav": {
+     "bytes": 25046,
+     "sha256": "5a254061e033c6193216fc04488cf2e238ec52c51ef6d1d1437992ba17f70e18"
+    },
+    "sound/hammer/error_kill.wav": {
+     "bytes": 63174,
+     "sha256": "ee7daeb475bc2e2d8f703c4d9f2a7c96a09372205bde92620b902a78cebe1641"
+    },
+    "sound/hammer/ff7_kill.wav": {
+     "bytes": 20446,
+     "sha256": "d97532f49865bc6dfda51c04597f6f6df9411ad504f9fec182b8e0e190710f8c"
+    },
+    "sound/hammer/floyd_kill.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/hammer/frying_pan.wav": {
+     "bytes": 61484,
+     "sha256": "3dad623719f285ed94455e551c5756259e088467852648b2c4e11011e33dddb6"
+    },
+    "sound/hammer/guitar_a.wav": {
+     "bytes": 213096,
+     "sha256": "ab084d63b54e22072461bda0b4095f5ecd3f16c967145b87ff846e176ed12466"
+    },
+    "sound/hammer/guitar_b.wav": {
+     "bytes": 194664,
+     "sha256": "14c3f311bec1efa9c8665f4344f87f555de1f47d72d0717d6a4bbd9952a437fb"
+    },
+    "sound/hammer/guitar_d.wav": {
+     "bytes": 173160,
+     "sha256": "9d9e6cbae33f5854cd2abb1391c89f754f56860935cb6e3a787a6220ace46f0f"
+    },
+    "sound/hammer/guitar_e.wav": {
+     "bytes": 204332,
+     "sha256": "ff9814788aee5e58bbfb4aab74db72a86351cef8d3d4724b3211b6e7dde6401c"
+    },
+    "sound/hammer/hammer_clang.wav": {
+     "bytes": 222252,
+     "sha256": "0aab43d6565a34d6f6ba9c3626fbdaf0c15a4c21e2644a1f178e17ac7a4cf834"
+    },
+    "sound/hammer/hammer_clang2.wav": {
+     "bytes": 50220,
+     "sha256": "098549f0978b16e685d3ccaf0837c5dbad045626980629a21edf464b2b49d871"
+    },
+    "sound/hammer/hammer_clang2_error.wav": {
+     "bytes": 40034,
+     "sha256": "16641cec3afdddd998b40cc5806ba8bbae7e5c44e835591b048b658e217aaa3d"
+    },
+    "sound/hammer/hammer_clang2_ff7.wav": {
+     "bytes": 20446,
+     "sha256": "2df574087a15fffe9f3b0d556dd27c4b64270bcc9b8d3af110aa59eef0ee28a7"
+    },
+    "sound/hammer/hammer_clang2_floyd.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/hammer/hammer_clang2_guitar.wav": {
+     "bytes": 34904,
+     "sha256": "02b9e9ac4c4473086970b4c89b0c25989a6a323fb5c6cd2d42a6723ffa6d3b87"
+    },
+    "sound/hammer/hammer_clang2_katana.wav": {
+     "bytes": 13996,
+     "sha256": "26056f0ed4b700cfdfc335ed303968c48d124398e62e0079fc823fbc2defd57e"
+    },
+    "sound/hammer/hammer_clang2_squeaky.wav": {
+     "bytes": 10738,
+     "sha256": "2191ac2cd7cb0b594bf77e791f0d2ab25ea115b46e3cb04805457955c3387742"
+    },
+    "sound/hammer/hammer_clang_error.wav": {
+     "bytes": 39362,
+     "sha256": "2376dd047957249cc7f934cde50b8f88cc02cc2bc00dea839b0a734ccf10ce36"
+    },
+    "sound/hammer/hammer_clang_ff7.wav": {
+     "bytes": 20446,
+     "sha256": "4b85f755e4c89f9fdbbfbab9847d0a735628a97c8651e67aec03ee031920ad0f"
+    },
+    "sound/hammer/hammer_clang_floyd.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/hammer/hammer_clang_guitar.wav": {
+     "bytes": 101020,
+     "sha256": "ba7014a0bddcdd0350478389b4ae301043862fafeca18338d84f68abcad967c5"
+    },
+    "sound/hammer/hammer_clang_katana.wav": {
+     "bytes": 42784,
+     "sha256": "811ce03a86a70494cf188a8e3108256cd2fd7fab493e0f7f64c4cbd0acdaba14"
+    },
+    "sound/hammer/hammer_clang_squeaky.wav": {
+     "bytes": 34526,
+     "sha256": "5d428919122eed39103ea954066c1d5ea24626b4f7cd189f50459580ced1f974"
+    },
+    "sound/hammer/hammer_unlock.wav": {
+     "bytes": 95756,
+     "sha256": "6f26159b9f71d36198d9b1571460f7424fed9a8fb46f1514ca774acad93e85de"
+    },
+    "sound/hammer/katana_kill1.wav": {
+     "bytes": 65486,
+     "sha256": "213cba5925ebf3ae0427179d7db5fed5841343e8b172a1cc38fc2e55be095d94"
+    },
+    "sound/hammer/katana_kill2.wav": {
+     "bytes": 63976,
+     "sha256": "7c9906df9d4fe2002a70e969009b164e5897b2955d24fb5dbf486eaec5871da6"
+    },
+    "sound/hammer/katana_secret.wav": {
+     "bytes": 120414,
+     "sha256": "5895b98c11d1a81b22731b2bd07f389d287b0ea5c4822ea78ea31721c6d2a677"
+    },
+    "sound/hammer/slice1.wav": {
+     "bytes": 44836,
+     "sha256": "6049393e32aacb60e2393da6557ec992350631ebcf948824ede22e749d3a7eba"
+    },
+    "sound/hammer/slice2.wav": {
+     "bytes": 44836,
+     "sha256": "8ad23cfe0c9f3dc555287dd9923faf794c8ad8be82effa2f11863d76c8344e71"
+    },
+    "sound/hammer/slice3.wav": {
+     "bytes": 44836,
+     "sha256": "ae202290d52822864bc145c754913a53745aa880be021eacc25202e479bc1b05"
+    },
+    "sound/hammer/slice_hit1.wav": {
+     "bytes": 49440,
+     "sha256": "b55eea3e9f4a2aa6cac0965f0f11a001047f75cb3d599f0ea4cf840314fe89c7"
+    },
+    "sound/hammer/slice_hit2.wav": {
+     "bytes": 55326,
+     "sha256": "688270bc26b420053c98d94869efb39eb4950dab623584888eb4ed87fe7517cc"
+    },
+    "sound/hammer/slice_hit3.wav": {
+     "bytes": 48970,
+     "sha256": "aafb92ce9b4e58cd3ccbd89ab41602d31c72ce64b7bd937ac7b547141668feeb"
+    },
+    "sound/hammer/squeaky_kill.wav": {
+     "bytes": 24994,
+     "sha256": "d8d69076c3e2924f5225f00b08370371233780324eb96e50b7340def94fae82c"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_g_charge.wav": {
+     "bytes": 28358,
+     "sha256": "db3b36d46abcf402002bdfa10cdc03d19e8d51c25115310b8842546fce4d8070"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/items/shard.wav": {
+     "bytes": 38934,
+     "sha256": "bb6a69c5cadfa4128886815e429812977e82de5ca2db59fe6fe1faa57be658c3"
+    },
+    "sound/megashambler/msawake.wav": {
+     "bytes": 37520,
+     "sha256": "63b71cc3adc3b57d9041f0507482f2eb64941190c41839fc504ffe8ebba7338b"
+    },
+    "sound/megashambler/msdeath.wav": {
+     "bytes": 61164,
+     "sha256": "05ed0537a8125f76036452067669562a81abb7f1de8f44a8db25e852a711b3a3"
+    },
+    "sound/megashambler/mshurt2.wav": {
+     "bytes": 4302,
+     "sha256": "64e930df679789e6d2cd9a2b4e9300ea02f17cb8926777db9c31b6c79e03ca76"
+    },
+    "sound/megashambler/msidle.wav": {
+     "bytes": 76934,
+     "sha256": "51945b4d89a8c608ccfbbb0da0795b4b68e94ef9066ac9a4ca5df9b04f103d79"
+    },
+    "sound/megashambler/msidle1.wav": {
+     "bytes": 12116,
+     "sha256": "6aa0a2cf1d80bb85f24ce5fbecbfdb67472698e79a5ba52cd344440690eec56e"
+    },
+    "sound/megashambler/msidle2.wav": {
+     "bytes": 39802,
+     "sha256": "82e505bb1ad777f701437f17931589c0167cdf5ff1edf5ebd77651e41914dcad"
+    },
+    "sound/megashambler/msidle3.wav": {
+     "bytes": 11742,
+     "sha256": "8d1c1f8196481d676f26c492ace6342e8f9e976679a9933ccf897f49cdf10b26"
+    },
+    "sound/megashambler/mslightning.wav": {
+     "bytes": 8036,
+     "sha256": "efa18dec8f6d5066b8d494a232ca9c98c27a4a9130130086a9b0a27ffccb34ed"
+    },
+    "sound/megashambler/msmack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/megashambler/mspain.wav": {
+     "bytes": 37520,
+     "sha256": "63b71cc3adc3b57d9041f0507482f2eb64941190c41839fc504ffe8ebba7338b"
+    },
+    "sound/megashambler/mssight.wav": {
+     "bytes": 15420,
+     "sha256": "9aff3b6cdac49976a4fe97b88ca14bc928ef55a14929fc796ae2b23148422f3b"
+    },
+    "sound/megashambler/mssmack.wav": {
+     "bytes": 10560,
+     "sha256": "6684ae6e141f5ced5e305682f4f9b7b1b2cad017ac02ac08371c061883cb88c4"
+    },
+    "sound/megashambler/sattck1.wav": {
+     "bytes": 8036,
+     "sha256": "efa18dec8f6d5066b8d494a232ca9c98c27a4a9130130086a9b0a27ffccb34ed"
+    },
+    "sound/megashambler/sboom.wav": {
+     "bytes": 11672,
+     "sha256": "6c64dafb52536ae35f9d50cd5f6c5c636f3403b83cac4d1e55e62e913e2ca79b"
+    },
+    "sound/megashambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/misc/baah.wav": {
+     "bytes": 66794,
+     "sha256": "5da2b4f07c308aef0d6fcaad4fcfb16c0a783238911e0a7d5343b3272d053d24"
+    },
+    "sound/misc/ms_waterdrain.wav": {
+     "bytes": 1802020,
+     "sha256": "15154f4bfc348fddd064c484cc2a4616ddcf420a1fee7449ebb5ebbd1e608bd7"
+    },
+    "sound/pinchy/bridge-break.wav": {
+     "bytes": 33446,
+     "sha256": "9d3fe8ff92dbc726bd3d8bb123ef2a09d73584a05510ea0367d09a167fc8414e"
+    },
+    "sound/pinchy/wall-break.wav": {
+     "bytes": 22656,
+     "sha256": "1b336e22926b17c1b103b0b6dbc95ba35eb1066af24bc9426b0797597ca6e830"
+    },
+    "sound/roj/waterocean1.wav": {
+     "bytes": 308916,
+     "sha256": "b1cf4f77a54d45db71b17a8daf35cf738c9dbecdcc55ebe569bbfaec60917752"
+    }
+   },
+   "sha256": "6989578c0107bab790f8da46ebab94f4c884f3125410ff716c64eb012ae3caf0",
+   "timestamp": "2024-07-30T01:33:06.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/bonkjam/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "notes": [
+  "This file was repackaged for Quake Injector compatibility.",
+  "May require a source port with increased limits / BSP2 support."
+ ],
+ "sha256": "7f4321465335b8b145cb7a1b5bc5fd7eda19ec4803927bcf49a6094180ee6563",
+ "tags": [
+  "author=4LT",
+  "author=ChadQuad",
+  "author=Chuma",
+  "author=CommonCold",
+  "author=Indigo",
+  "author=Makkon",
+  "author=Milestone",
+  "author=Nickster",
+  "author=Pinchy",
+  "author=Rabbit",
+  "author=Recycled OJ",
+  "author=Shadesmaster",
+  "author=Simon Novak",
+  "author=Spootnik",
+  "author=Sze",
+  "author=ThatSpacePirate",
+  "author=iYago",
+  "commandline=-game bonkjam",
+  "exceeds_quake_limits=yes",
+  "filename=bonkjam.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/bonk-jam.373/)",
+  "release_date=2024-07-30",
+  "startmap=start",
+  "title=Bonk Jam",
+  "type=mapjam",
+  "type=mod",
+  "zipbasedir=bonkjam/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/bonkjam.zip"
+ ]
+}

--- a/json/by-sha256/9a/9a9b793d4e574e1c301173ae9e842cfda791cdaa02234a6def193609bf13be19.json
+++ b/json/by-sha256/9a/9a9b793d4e574e1c301173ae9e842cfda791cdaa02234a6def193609bf13be19.json
@@ -1,0 +1,48 @@
+{
+ "bytes": 703767,
+ "description": "Metal map set in a mountain crypt. The author's first finished map.",
+ "files": {
+  "hiddencrypt.bsp": {
+   "bytes": 1104268,
+   "sha256": "e39178bf4c1002eaed131961ea21b481d1e9d60c7a7f79e81feb750bcec0f5e1",
+   "timestamp": "2024-07-29T17:30:20.000Z"
+  },
+  "hiddencrypt.lit": {
+   "bytes": 410075,
+   "sha256": "f05176652092bc3709b9ed5422d7608dd22452a3832aa55cbc21414bc2657f28",
+   "timestamp": "2024-07-29T17:30:20.000Z"
+  },
+  "hiddencrypt.txt": {
+   "bytes": 1298,
+   "sha256": "91cdd9c8f073455868ceb5608e0851f7da76448a4fccf869b96ef70c4e2ac0e5",
+   "timestamp": "2024-07-30T01:01:14.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/copper/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "notes": [
+  "This map requires <a href=\"2932bdfda11224125c3f7207701bed8c4b7a765a2370a581589a5e17337b7eb8\">Copper</a>."
+ ],
+ "sha256": "9a9b793d4e574e1c301173ae9e842cfda791cdaa02234a6def193609bf13be19",
+ "tags": [
+  "author=lumisynth",
+  "commandline=-game copper",
+  "dependency=copper_v1_30",
+  "depends=('copper=1.30')",
+  "filename=hiddencrypt_1.2.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/hidden-cursed-crypt.376/)",
+  "mod=copper",
+  "release_date=2024-07-29",
+  "startmap=hiddencrypt",
+  "title=Hidden Cursed Crypt",
+  "type=map",
+  "zipbasedir=copper/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/hiddencrypt_1.2.zip"
+ ]
+}

--- a/json/by-sha256/a0/a04aee22a146df6dd97db37932c7c96028307dab4f6f96e15944bd0e5006bd5b.json
+++ b/json/by-sha256/a0/a04aee22a146df6dd97db37932c7c96028307dab4f6f96e15944bd0e5006bd5b.json
@@ -1,0 +1,2214 @@
+{
+ "bytes": 374178433,
+ "description": "Giant map with over 5000 enemies and an estimated 7-8 hours of playtime. Dressed in a mixture of themes with a strong bloody/organic motif and featuring a detailed story, custom entities from the Quoth mod (included) and lots of intense, difficult gameplay, even on skill 0.",
+ "files": {
+  "immortal/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-06-28T11:51:46.000Z"
+  },
+  "immortal/descript.ion": {
+   "bytes": 17,
+   "sha256": "4172e9e8053778d3cd8b999514492bc7a5f1d3af1307ac2db9a79ec7d8f084d7",
+   "timestamp": "2024-05-31T00:45:48.000Z"
+  },
+  "immortal/gfx/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-06-28T00:40:20.000Z"
+  },
+  "immortal/gfx/env/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-06-28T00:40:20.000Z"
+  },
+  "immortal/gfx/env/eve1_bk.tga": {
+   "bytes": 4194854,
+   "sha256": "38b415eab0a6bbf149a884f22a9ec4dfd65ab8c1cd36e5a9f4242fe7f313746c",
+   "timestamp": "2022-09-07T17:33:18.000Z"
+  },
+  "immortal/gfx/env/eve1_dn.tga": {
+   "bytes": 4194854,
+   "sha256": "9239194ef6472474616b00118c7675f4f31d736a9b930abb065332a799a641a9",
+   "timestamp": "2022-09-07T17:33:32.000Z"
+  },
+  "immortal/gfx/env/eve1_ft.tga": {
+   "bytes": 4194854,
+   "sha256": "34489ff45e17c32bbba227da9f24d6f1e07be9551df790c1c722678bb46ff896",
+   "timestamp": "2022-09-07T17:34:56.000Z"
+  },
+  "immortal/gfx/env/eve1_lf.tga": {
+   "bytes": 4194854,
+   "sha256": "12c677cc7ec883d4a014856f79e493bdd4c81739b9018d268fc652d88aa5ab0c",
+   "timestamp": "2022-09-07T17:35:00.000Z"
+  },
+  "immortal/gfx/env/eve1_rt.tga": {
+   "bytes": 4194854,
+   "sha256": "d68dac94072b0dda921e2a7d8a520ea3b3ea9a668af0305b15f4361a901a7447",
+   "timestamp": "2022-09-07T17:35:06.000Z"
+  },
+  "immortal/gfx/env/eve1_up.tga": {
+   "bytes": 4194854,
+   "sha256": "a7c728bfa81dd7d41a9ffdc432713c22be6787decb989a5a8eb035c5ca8cd149",
+   "timestamp": "2022-09-07T17:35:12.000Z"
+  },
+  "immortal/gfx/env/eve7_bk.tga": {
+   "bytes": 4194854,
+   "sha256": "ab06f7ee3642db244db7ed2066ef4fbfcc83a1a3b2e95aa6ec7fdf9bb01281aa",
+   "timestamp": "2022-09-07T17:41:32.000Z"
+  },
+  "immortal/gfx/env/eve7_dn.tga": {
+   "bytes": 4194854,
+   "sha256": "502af7fb3a6b61013018984a2e8359b4c2e08c4a35d723232513431d79e96af7",
+   "timestamp": "2022-09-07T17:41:42.000Z"
+  },
+  "immortal/gfx/env/eve7_ft.tga": {
+   "bytes": 4194854,
+   "sha256": "aebe426a260624cdfad82be916a201dd4c9a227047295da03b8b20ea37a57035",
+   "timestamp": "2022-09-07T17:41:48.000Z"
+  },
+  "immortal/gfx/env/eve7_lf.tga": {
+   "bytes": 4194854,
+   "sha256": "65c28598542d3cd0356636459d4c4ccc397e6cbcb1f02460b2043f783c56194c",
+   "timestamp": "2022-09-07T17:41:52.000Z"
+  },
+  "immortal/gfx/env/eve7_rt.tga": {
+   "bytes": 4194854,
+   "sha256": "0b2bab9e893f525845152514afeac771cf2cc529ab5a5d050679c2e269ad226f",
+   "timestamp": "2022-09-07T17:41:56.000Z"
+  },
+  "immortal/gfx/env/eve7_up.tga": {
+   "bytes": 4194854,
+   "sha256": "203036d9a125baa357182dd17c361e21c447524cf48f9d2ce8edaa8c699bdd40",
+   "timestamp": "2022-09-07T17:42:00.000Z"
+  },
+  "immortal/gfx/env/mak_aurora2_bk.tga": {
+   "bytes": 3145772,
+   "sha256": "1d028cb8ac83c70a442e3f5b424f8c5fbc559b68dc12584b8e3349f289332306",
+   "timestamp": "2022-10-21T21:07:18.000Z"
+  },
+  "immortal/gfx/env/mak_aurora2_dn.tga": {
+   "bytes": 3145772,
+   "sha256": "d63c67b2b7eaf547df463d790c756aeeed12e0a4ed702cf8ff41dd247897d76c",
+   "timestamp": "2022-10-21T21:07:18.000Z"
+  },
+  "immortal/gfx/env/mak_aurora2_ft.tga": {
+   "bytes": 3145772,
+   "sha256": "5d999a1a7b8666bf35502dedb4ff463a293f04c7b25514c198438bec8f6f6664",
+   "timestamp": "2022-10-21T21:07:16.000Z"
+  },
+  "immortal/gfx/env/mak_aurora2_lf.tga": {
+   "bytes": 3145772,
+   "sha256": "c25a5766cffd68d79812ab7c9f398872925a2ba2de8f7c167d72b346254fa413",
+   "timestamp": "2022-10-21T21:07:14.000Z"
+  },
+  "immortal/gfx/env/mak_aurora2_rt.tga": {
+   "bytes": 3145772,
+   "sha256": "80a71dac693d0a01e82d49f3994afeacde4122ff574dc6650fb7480a02afdfa8",
+   "timestamp": "2022-10-21T21:07:10.000Z"
+  },
+  "immortal/gfx/env/mak_aurora2_up.tga": {
+   "bytes": 3145772,
+   "sha256": "9f380585afbb9a2e5bd0f6b4daee7fe2c044586ef1ac4160c8104532ec934cc3",
+   "timestamp": "2022-10-21T21:07:12.000Z"
+  },
+  "immortal/gfx/env/mak_nebulapink_bk.tga": {
+   "bytes": 3145772,
+   "sha256": "3b4e9ab246fec49303caddd4f286db5c634cb437c75139938d7c262fd2d8cc5d",
+   "timestamp": "2021-07-03T00:38:08.000Z"
+  },
+  "immortal/gfx/env/mak_nebulapink_dn.tga": {
+   "bytes": 3145772,
+   "sha256": "7b55d0304c99a18d0dfe55bae4039574b9a0afd6a8c8901ef9966b29389c9df0",
+   "timestamp": "2021-07-03T00:38:00.000Z"
+  },
+  "immortal/gfx/env/mak_nebulapink_ft.tga": {
+   "bytes": 3145772,
+   "sha256": "214b457b8291469c8211537b571c9866e5fbe9f8e72993cae561486899cbc95f",
+   "timestamp": "2021-07-03T00:37:58.000Z"
+  },
+  "immortal/gfx/env/mak_nebulapink_lf.tga": {
+   "bytes": 3145772,
+   "sha256": "f7d026b3f44c4bf9459af763c768f92e740ec4edf12dcba836eae5d10daebe36",
+   "timestamp": "2021-07-03T00:37:54.000Z"
+  },
+  "immortal/gfx/env/mak_nebulapink_rt.tga": {
+   "bytes": 3145772,
+   "sha256": "3368416c8d380b50598e7f7a67038b5d621cf2742e913f9f13672c9734ff04e1",
+   "timestamp": "2021-07-03T00:37:50.000Z"
+  },
+  "immortal/gfx/env/mak_nebulapink_up.tga": {
+   "bytes": 3145772,
+   "sha256": "61c4eaa8c261955754fc163c2d0451e48e250c457540d0ba8400cc573e4feb40",
+   "timestamp": "2021-07-03T00:37:40.000Z"
+  },
+  "immortal/gfx/env/mak_nebularteal2_bk.tga": {
+   "bytes": 3145772,
+   "sha256": "3deb3f912877ede9b2008db1ac1e957082cd60788b7fb8b2b03ab9593afc152d",
+   "timestamp": "2021-08-13T20:17:20.000Z"
+  },
+  "immortal/gfx/env/mak_nebularteal2_dn.tga": {
+   "bytes": 3145772,
+   "sha256": "52b8fa69606bc4a6cafe63ebeacd8108748ddca25645a19416966c68bb9a2b21",
+   "timestamp": "2021-08-13T20:17:18.000Z"
+  },
+  "immortal/gfx/env/mak_nebularteal2_ft.tga": {
+   "bytes": 3145772,
+   "sha256": "aa38a6ddbdbe5cb69bd43b614b0da32236b07b925c83600269b4a2de92d5014b",
+   "timestamp": "2021-08-13T20:17:16.000Z"
+  },
+  "immortal/gfx/env/mak_nebularteal2_lf.tga": {
+   "bytes": 3145772,
+   "sha256": "e1bd41c54e31c37e40cf3124ce99bcecfe22a9d5f19a192c7aa2e7ad89f23ea8",
+   "timestamp": "2021-08-13T20:17:14.000Z"
+  },
+  "immortal/gfx/env/mak_nebularteal2_rt.tga": {
+   "bytes": 3145772,
+   "sha256": "f7957288cf7972b4403cbd68c8f8fc8754af61c3d3a18194073adf9323b9a55f",
+   "timestamp": "2021-08-13T20:17:10.000Z"
+  },
+  "immortal/gfx/env/mak_nebularteal2_up.tga": {
+   "bytes": 3145772,
+   "sha256": "b46d51f3ca3e272f75dc16140a6648bd8965f35f00a156e26442b476764d5fde",
+   "timestamp": "2021-08-13T20:17:08.000Z"
+  },
+  "immortal/gfx/env/skyspace01_bk.tga": {
+   "bytes": 3145772,
+   "sha256": "b787192cdfb25994c3fbf41ea751fa94528a27a587130d6b738c778c8b5f7156",
+   "timestamp": "2023-04-03T00:53:36.000Z"
+  },
+  "immortal/gfx/env/skyspace01_dn.tga": {
+   "bytes": 3145772,
+   "sha256": "25ae194183ac29b84fc9f1e3629ce834aa2b909ed57eff0b9170fa167930ff4e",
+   "timestamp": "2023-04-03T00:53:36.000Z"
+  },
+  "immortal/gfx/env/skyspace01_ft.tga": {
+   "bytes": 3145772,
+   "sha256": "cd2d0fb2f1aa24ed775c0601c62780c7f242fc9fdb3e9f7fc73f554d0091b845",
+   "timestamp": "2023-04-03T00:53:36.000Z"
+  },
+  "immortal/gfx/env/skyspace01_lf.tga": {
+   "bytes": 3145772,
+   "sha256": "7b36150fea030383819e4c01e8fc11e0dc5ba542ad5a335ba68338e9592a3954",
+   "timestamp": "2023-04-03T00:53:36.000Z"
+  },
+  "immortal/gfx/env/skyspace01_rt.tga": {
+   "bytes": 3145772,
+   "sha256": "d685c80fb51114591219ae543ced2979fcd194f413097161f1614fc02dbe844c",
+   "timestamp": "2023-04-03T00:53:36.000Z"
+  },
+  "immortal/gfx/env/skyspace01_up.tga": {
+   "bytes": 3145772,
+   "sha256": "647a1d8cf320e4bcc745c86783d38b06507e31e1c21afe17fb0c176ece6c1254",
+   "timestamp": "2023-04-03T00:53:36.000Z"
+  },
+  "immortal/gfx/env/violentdays_bk.tga": {
+   "bytes": 786971,
+   "sha256": "c4c105a9a9bdc08ad7ec4b721739bf377cacad20a2fac711a4f0fc266fb6f941",
+   "timestamp": "2008-12-25T16:02:28.000Z"
+  },
+  "immortal/gfx/env/violentdays_dn.tga": {
+   "bytes": 786971,
+   "sha256": "72fc27d51584b3d9a3cd56729995a60e538a1ac512e9cff748a4545c2ffc4138",
+   "timestamp": "2008-12-25T16:02:28.000Z"
+  },
+  "immortal/gfx/env/violentdays_ft.tga": {
+   "bytes": 786971,
+   "sha256": "49c5c73825150b82b9eb43f9c478a9f12cf559c2c2bdb019dd5063334d053264",
+   "timestamp": "2008-12-25T16:02:30.000Z"
+  },
+  "immortal/gfx/env/violentdays_lf.tga": {
+   "bytes": 786971,
+   "sha256": "f4af292865265d17841653b46361c427ba3d0f180b28dfa65f8d61f5abf91c13",
+   "timestamp": "2008-12-25T16:02:30.000Z"
+  },
+  "immortal/gfx/env/violentdays_rt.tga": {
+   "bytes": 786971,
+   "sha256": "59a7ad25f288ea959e53607e15ef3044cbc1b91dac9c6a1f1b295bff733c8f54",
+   "timestamp": "2008-12-25T16:02:32.000Z"
+  },
+  "immortal/gfx/env/violentdays_up.tga": {
+   "bytes": 786971,
+   "sha256": "fbed710e25cd758b614c9156ce1772abd24c4f1365675fe37efde16773ff6445",
+   "timestamp": "2008-12-25T16:02:26.000Z"
+  },
+  "immortal/gfx/env/void_bk.tga": {
+   "bytes": 786476,
+   "sha256": "b70ecf153b0281c1ad7ef2de9105997922f7202140ab30d7b93fdde480a4bb34",
+   "timestamp": "2024-05-12T17:43:36.000Z"
+  },
+  "immortal/gfx/env/void_dn.tga": {
+   "bytes": 786476,
+   "sha256": "b70ecf153b0281c1ad7ef2de9105997922f7202140ab30d7b93fdde480a4bb34",
+   "timestamp": "2024-05-12T17:43:34.000Z"
+  },
+  "immortal/gfx/env/void_ft.tga": {
+   "bytes": 786476,
+   "sha256": "b70ecf153b0281c1ad7ef2de9105997922f7202140ab30d7b93fdde480a4bb34",
+   "timestamp": "2024-05-12T17:43:34.000Z"
+  },
+  "immortal/gfx/env/void_lf.tga": {
+   "bytes": 786476,
+   "sha256": "b70ecf153b0281c1ad7ef2de9105997922f7202140ab30d7b93fdde480a4bb34",
+   "timestamp": "2024-05-12T17:43:32.000Z"
+  },
+  "immortal/gfx/env/void_rt.tga": {
+   "bytes": 786476,
+   "sha256": "b70ecf153b0281c1ad7ef2de9105997922f7202140ab30d7b93fdde480a4bb34",
+   "timestamp": "2024-05-12T17:43:32.000Z"
+  },
+  "immortal/gfx/env/void_up.tga": {
+   "bytes": 786476,
+   "sha256": "b70ecf153b0281c1ad7ef2de9105997922f7202140ab30d7b93fdde480a4bb34",
+   "timestamp": "2024-05-12T17:43:32.000Z"
+  },
+  "immortal/immortal_readme.txt": {
+   "bytes": 7807,
+   "sha256": "8e78436f004adf6d33e48045c00698aa873c5a6a5155aecc6524d97a599e3d6c",
+   "timestamp": "2024-08-03T17:56:42.000Z"
+  },
+  "immortal/mapdb.json": {
+   "bytes": 684,
+   "sha256": "cc346d6c127edb8fe5c1a8382aafcb98aca8ce4978a19d1855606dcb71403f92",
+   "timestamp": "2024-07-10T13:37:42.000Z"
+  },
+  "immortal/maps/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-07-17T10:55:12.000Z"
+  },
+  "immortal/maps/immortal.bsp": {
+   "bytes": 504079340,
+   "sha256": "633243c45594c9a4b4b583638d7f71cee98c4784fdee76691d23aa8a2befd71a",
+   "timestamp": "2024-08-03T12:13:56.000Z"
+  },
+  "immortal/maps/immortal.lit": {
+   "bytes": 99302552,
+   "sha256": "db373e1009a0bd9c589fa135ae5651bde85247e86dc088aaae85c4bd06aa8d2c",
+   "timestamp": "2024-08-03T12:13:56.000Z"
+  },
+  "immortal/maps/spinny.bsp": {
+   "bytes": 2067944,
+   "sha256": "04d1ef1818217a47f648b6c0fb8e124e0eb4e79d8b9018ad86d903114c417269",
+   "timestamp": "2023-08-26T11:56:48.000Z"
+  },
+  "immortal/maps/start.bsp": {
+   "bytes": 47868092,
+   "sha256": "6d5401956c2fb0aca7081559324267effd8e1a9746a63a5e673b0d54bbe28e35",
+   "timestamp": "2024-07-26T13:25:04.000Z"
+  },
+  "immortal/maps/start.lit": {
+   "bytes": 4495088,
+   "sha256": "981bdbdee531ff82a09122beb1fe5ccccf8c6e67687945335d4ebc777c838b9f",
+   "timestamp": "2024-07-26T13:25:04.000Z"
+  },
+  "immortal/music/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-06-28T00:40:34.000Z"
+  },
+  "immortal/music/track02.mp3": {
+   "bytes": 3790888,
+   "sha256": "8cc6084b8adc6e60d8376aed19babd909c59104fdcd662a2a8587805d6164988",
+   "timestamp": "2024-05-28T13:17:44.000Z"
+  },
+  "immortal/music/track03.mp3": {
+   "bytes": 3790888,
+   "sha256": "8cc6084b8adc6e60d8376aed19babd909c59104fdcd662a2a8587805d6164988",
+   "timestamp": "2024-05-28T13:17:44.000Z"
+  },
+  "immortal/music/track42.mp3": {
+   "bytes": 10974562,
+   "sha256": "36108dc8ad5cc3315bd64c402024c3e9b56ff8c4299921dce7238b855ef3a3f2",
+   "timestamp": "2024-06-13T23:07:46.000Z"
+  },
+  "immortal/music/track69.mp3": {
+   "bytes": 42592129,
+   "sha256": "12c196e14cefec0764875d0b34d8846fdbb70bf007aeb3a05164e72c229ea2b0",
+   "timestamp": "2023-12-28T03:09:58.000Z"
+  },
+  "immortal/music/track96.mp3": {
+   "bytes": 9762480,
+   "sha256": "034050d53395d12310d46d57fba213a3c0423531b1b7a83f46d6c20829f19a57",
+   "timestamp": "2023-07-16T01:27:44.000Z"
+  },
+  "immortal/pak0.pak": {
+   "bytes": 17730124,
+   "files": {
+    "gfx.wad": {
+     "bytes": 128932,
+     "sha256": "6f7878b23deb09b151a58b8357f8a5b966cc87dce24a52407d931ceef885fbc5"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 921608,
+     "sha256": "1202e3013a0e94db8d629ba330127d9cc741e77ebc9f0bb9f8a2ff2f28f12ab4"
+    },
+    "progs/air.mdl": {
+     "bytes": 5076,
+     "sha256": "930e21887f0c482f353d5009efe1f5ef3f88e18d7a4f2e1232978cb2e8f73932"
+    },
+    "progs/beam.mdl": {
+     "bytes": 3307,
+     "sha256": "18295a66ab4a4da70b5dc0558d5cac7622afd65e9937ebe8d2c5321a67a418ee"
+    },
+    "progs/bigexp.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/bilebomb.mdl": {
+     "bytes": 13469,
+     "sha256": "2f77d07f24b62edc095facdee8c670711cc189a85258a631ada71cd4746e26ac"
+    },
+    "progs/bilefrag.mdl": {
+     "bytes": 9216,
+     "sha256": "34e6ed3456aef2c89d4ab9d857a173bfa98c17381be380f9665d496791f6f814"
+    },
+    "progs/bob.mdl": {
+     "bytes": 177959,
+     "sha256": "173f9aa590a0b23e0525c86b6945f3b8d565b865f2376daea00ac8f88791abc1"
+    },
+    "progs/bobblaster.mdl": {
+     "bytes": 27556,
+     "sha256": "3aa3e956183dc641fe601edaae52b7f2d5c92d90d00e8994e106dde4c0c25092"
+    },
+    "progs/boom.mdl": {
+     "bytes": 77388,
+     "sha256": "c0b2d8695564dbb1ef37aef9a9e226160ff8f5ab40de7a6d7129a66675096179"
+    },
+    "progs/brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "0287c3e7886bd2d6d1cbb504529d9e11038d0f8232ee624528eb0ccb78733c53"
+    },
+    "progs/corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "22f82f29d0a88af204f7b97eef887b963bd940e7277b6f5cef5e6f3610f2ea51"
+    },
+    "progs/corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "41e90f1a84e9779eb12541d923ab0a66e69deef3a9dbc82259ab84cb71b68dcc"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/dguard.mdl": {
+     "bytes": 176648,
+     "sha256": "f2f92ef84411d83c7e8c158f62b1415d8fc6aa56d77f21760dcd3080424cf6c8"
+    },
+    "progs/drlbomb.mdl": {
+     "bytes": 20355,
+     "sha256": "5c1db489f43cba73fce265db642267775245d044866cdd48396b1f1260a28237"
+    },
+    "progs/drole.mdl": {
+     "bytes": 241648,
+     "sha256": "5067b7ca5323754fe563d6696025525645a2cbd3aaf7f79232634608f9fb987a"
+    },
+    "progs/dspike.mdl": {
+     "bytes": 13684,
+     "sha256": "05bc998adf950efaeba0f0216e008ec8d6fa732d5eb726dbe70ff07e088275c6"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 333860,
+     "sha256": "230181ce6ea00c8e80c7d59189340424424ba5d99d71230b309907e206e07682"
+    },
+    "progs/fireball.mdl": {
+     "bytes": 12660,
+     "sha256": "ba5cba46edc108572d78e66166f5ed0405a48dcf672e7a569d14a4397f85f285"
+    },
+    "progs/fish.mdl": {
+     "bytes": 90636,
+     "sha256": "037ebaf6566f8fed7609b4e2c79eb36c4c78c49d914b225e7aa37fd4e3d6fa17"
+    },
+    "progs/g_bomb.mdl": {
+     "bytes": 50176,
+     "sha256": "33bc7cbf807cdae850d42cd11af0d332a7ca140741a3d29353e558bd8468aaa3"
+    },
+    "progs/g_fx.mdl": {
+     "bytes": 32260,
+     "sha256": "ac99d4e641af0bb1495ed38ba9f3a7c1195bda19e5cf0d3a68f04defe6178ab8"
+    },
+    "progs/g_ham.mdl": {
+     "bytes": 71639,
+     "sha256": "424bd4ecf03e0f364f57448b7c426924e1e0ccd06dad40294c00a23a645b8c0a"
+    },
+    "progs/g_lance.mdl": {
+     "bytes": 32906,
+     "sha256": "6eab37228d67437eccd9735de6e7933c79576a921c23479ad317e7c3db5b1f0d"
+    },
+    "progs/gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/greenexp.spr": {
+     "bytes": 24732,
+     "sha256": "8cd2c8f20214cc1f8de491785a27d3aafa924819c9f56078d2bdb219d4f16f5e"
+    },
+    "progs/gug.mdl": {
+     "bytes": 482020,
+     "sha256": "2cd097236a235aedf717a86b7312bd7d1b3caa6f0b25980c82eee2463fee2274"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 4920,
+     "sha256": "337f2723daab9d1375b78cb017512ce8281087ff8df9c33b04a6c613cea3590c"
+    },
+    "progs/h_dlord.mdl": {
+     "bytes": 18699,
+     "sha256": "bc5a92be1c5f3d06dc0238ec7bafe6a3c25826cc50edc6214ed5aa19b0075987"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 16854,
+     "sha256": "00f3263f1c3e0daadaaf03eea447080d727ea7d9ee1a88f2b42e060d748e1566"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 61251,
+     "sha256": "dec5afe666eba8db6e32d7535fffa3d0e4ed9344ba107b73418526ebebac574b"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 10663,
+     "sha256": "819b7cd0c4c38edb9725dffa46913ed89d75276aac3ea34b2bc683daedd5db0e"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 32629,
+     "sha256": "d69f21f26e13276272bb6b59352e66082a224534e8a0e46753037136927e0929"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 23239,
+     "sha256": "00117347d1acc46beb4972853572e14ce3e9d6dca25b883540896fcd873f3e3a"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 1142583,
+     "sha256": "2c3d4002e7c5f1682367c3f649e67333303d1763e6da0b3cfdce8c7519dfc2dc"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 8356,
+     "sha256": "b00951cd72bb5fb03c19a1d60943162652fe149b9ee60fd2e630a076d52956fb"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/keybase.mdl": {
+     "bytes": 11407,
+     "sha256": "5fed79622ad6f6751b2c771ddff06b88dcf049719336c228520bc84f0db441cd"
+    },
+    "progs/keyeye.mdl": {
+     "bytes": 37528,
+     "sha256": "a4612e183f026ea63161377682c1001b178b9e0f94f6b9a801b983962162dbbc"
+    },
+    "progs/keymed.mdl": {
+     "bytes": 13247,
+     "sha256": "e147a4e527b9b797680732c33cc0ebe3503bcd6e2c8a5b0917701cdd41f99297"
+    },
+    "progs/keyrune.mdl": {
+     "bytes": 25643,
+     "sha256": "f06fafe1b92a172a2cebcbc68ad5e2a8aafdfc99d13ce6d5bf5b36f25ca48f73"
+    },
+    "progs/knight.mdl": {
+     "bytes": 342850,
+     "sha256": "9e23eca66dbe332f49a1a82ceef197d5ee980abb24145050ea3088e05468dd4b"
+    },
+    "progs/longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/marsh.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/marshsm.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 3542,
+     "sha256": "2f3efa19a64b60d480fbef7c10e8f2a56e90d656e8fcb8bcd656932f8686f482"
+    },
+    "progs/polyp.mdl": {
+     "bytes": 211928,
+     "sha256": "36268021903129e7e0e81600072ff3b38229cb6851cc6800945d9810510fad0b"
+    },
+    "progs/polyp_t1.mdl": {
+     "bytes": 66925,
+     "sha256": "82f5f86f210e8cfc541259a3a9efe7b0b4a046f5b5240c5d39ab08a021a4e2ee"
+    },
+    "progs/polyp_t2.mdl": {
+     "bytes": 65473,
+     "sha256": "130699464f89836047b7bf6b4ad0ac7feee810dd31da5add2892e1f61ed07a30"
+    },
+    "progs/polyp_t3.mdl": {
+     "bytes": 64069,
+     "sha256": "72a5a60e71e09a4a0e73dba0658b301540b3d871ec4ea88e24ace135db19d046"
+    },
+    "progs/polypgib.mdl": {
+     "bytes": 5716,
+     "sha256": "dc2aae40f92f8c75057a664b583f9d790d010289e858b218adfc92de6d6be878"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/s_bubble.spr": {
+     "bytes": 396,
+     "sha256": "f7efaea9964c8ad347f170dcfd2a6dbe5bfcf8dc074cffc385cfbf28f991c13d"
+    },
+    "progs/s_light.spr": {
+     "bytes": 7344,
+     "sha256": "45ae7c364a43b76d834476f49fe6c35423330cce41d8f3dbc90780f561bb51e7"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/s_plas.spr": {
+     "bytes": 5256,
+     "sha256": "ed01b728b6656a68acffe258d644712eba3b786434ab6b3e6d90434031e90d96"
+    },
+    "progs/shockwave.mdl": {
+     "bytes": 167520,
+     "sha256": "861ee3b0ab6edd5233740a609c4367c5ebe4108ffb03124861bf85047a314f5e"
+    },
+    "progs/smlexp.spr": {
+     "bytes": 105148,
+     "sha256": "ce4938c9e813e648404b25b82245cad4400682d885d044b9d353a8039cfdceb7"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 565441,
+     "sha256": "9d3da38ea15726d8543413120414d4178efd900fd131a7fd84eff5a305df21f5"
+    },
+    "progs/spore.mdl": {
+     "bytes": 13469,
+     "sha256": "fc9fbb97f0d4f1a9f843769cd43fb7270ba2b351cdf3b4b624d27616980457c4"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 313448,
+     "sha256": "fc63e6f62c83975ab2756f0a844d012b887491a6c73d9350dfcb04a6e0355b3c"
+    },
+    "progs/trinity.mdl": {
+     "bytes": 13249,
+     "sha256": "3e0d4636dfd20112bd5415e92c1d8f85fdda65a9a33b09111cca2bbf4561f349"
+    },
+    "progs/v_bomb.mdl": {
+     "bytes": 80804,
+     "sha256": "48c2393efb079787f56be5ab6fd0dc3e748b5ef009ba15830fe0f9898ad94b7b"
+    },
+    "progs/v_ham.mdl": {
+     "bytes": 84563,
+     "sha256": "76f03b4e5d8222c2c3b3d2f0e1156ac90708a42f4997f6a4555c01073dab49dd"
+    },
+    "progs/v_lance.mdl": {
+     "bytes": 87209,
+     "sha256": "5c50ded5952ab06ca91ff413edf17a167b21bed88b027571e643ffc515a71560"
+    },
+    "progs/vermis.mdl": {
+     "bytes": 656752,
+     "sha256": "d7060475e290482c61c122b3a477085b1aad002fd71d8293cc4a4f8bde1baec9"
+    },
+    "progs/vleg.mdl": {
+     "bytes": 4904,
+     "sha256": "cc9ac24012d342ed54eb1a3241bcc6baf16e40fb95a904a789845ed76b8606ba"
+    },
+    "progs/voreling.mdl": {
+     "bytes": 41852,
+     "sha256": "b10f3623291b5182ab6b987cef1c40abc362aae41638b8481709660e923cc46b"
+    },
+    "sound/ambience/nightmare.wav": {
+     "bytes": 34284,
+     "sha256": "2caac27dfee5758eb293e0c76bf86baf82b0522c6f71281160e805c6ec282f96"
+    },
+    "sound/ambience/thrum.wav": {
+     "bytes": 220542,
+     "sha256": "c925d73ef744b0a8c56507ff6fb18888de7ab803ea1f743060f8f9782180dcc7"
+    },
+    "sound/bob/death.wav": {
+     "bytes": 14348,
+     "sha256": "7f97f27dfda78f9fe6fc5265e512b651e57ae466752d56cfe0dccd6d08478ed8"
+    },
+    "sound/bob/explode.wav": {
+     "bytes": 36898,
+     "sha256": "e00cd6cf71662de858fd0b8f63409217c957d6e3dea571b759fe97aec9d58724"
+    },
+    "sound/bob/fire.wav": {
+     "bytes": 36040,
+     "sha256": "5f39b9f60c5de5c9c3ac25a5149f1fef557e66c09d7d1a760ed6770082c5a914"
+    },
+    "sound/bob/hover.wav": {
+     "bytes": 13260,
+     "sha256": "46441335fe896cb993368bb12cedc1ddd4886b5933298bb6a0d6b7ba430cdfe5"
+    },
+    "sound/bob/idle1.wav": {
+     "bytes": 44460,
+     "sha256": "de548d73ab2d96ea9d550b86e264d430b8c0429cd99dd10404f52780bda6c683"
+    },
+    "sound/bob/pain.wav": {
+     "bytes": 27006,
+     "sha256": "d5d07123eb3c15917dc265cfa6df8971ab215f4408847225827359e1c175ee6b"
+    },
+    "sound/bob/s_explode.wav": {
+     "bytes": 30700,
+     "sha256": "94f9b780d25154f8c04cbe297a4aeda13fb0669c0a21e48e2b46f0102c35375e"
+    },
+    "sound/bob/sight.wav": {
+     "bytes": 14892,
+     "sha256": "1a0db2b8c8d763f9aae09913d1cd3548fa0e30eb03949e24ef511a70acfda303"
+    },
+    "sound/defender/blip.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/defender/breathe.wav": {
+     "bytes": 32676,
+     "sha256": "7b673b07828790504caca013c18bf697fd53b758a3638b949b433cf2d72f03f3"
+    },
+    "sound/defender/sight1.wav": {
+     "bytes": 14026,
+     "sha256": "7a059f5c95936c1e51e96c28b9f30fbe6d66c27b1271b6f077eddd6611e15882"
+    },
+    "sound/defender/sight2.wav": {
+     "bytes": 8192,
+     "sha256": "780230c4697dea0189ff81f731394696893d321ce7f3600370cca5ae2e81822d"
+    },
+    "sound/defender/sight3.wav": {
+     "bytes": 10442,
+     "sha256": "cc71b100be0fb44e58b396e5e7e3d602e646545d8b368e804469ff083ed687c1"
+    },
+    "sound/defender/sight4.wav": {
+     "bytes": 9918,
+     "sha256": "bd959168eff294104f04b5b1b736c722518fbf0d8f13fdbd8c4b695f14838aea"
+    },
+    "sound/defender/ssg.wav": {
+     "bytes": 38828,
+     "sha256": "5c4e3a9baeec3f714ed00f2585d04256ac33582db911a026fdc56dea7f0a7dfa"
+    },
+    "sound/dguard/death1.wav": {
+     "bytes": 30610,
+     "sha256": "af3809501261ec4d0afa6ea7301c11a5c7bbc1cc3e06b8c88172ee0214c30969"
+    },
+    "sound/dguard/death2.wav": {
+     "bytes": 43636,
+     "sha256": "93a70fc0d6fee819c723a435a3954b3fd3be86e358698ce85db1062990d1575e"
+    },
+    "sound/dguard/fire.wav": {
+     "bytes": 60820,
+     "sha256": "f5e5d4f6ccc0778c1396c66d327564a0b1892773f2c23d2e30590abf0c758bd2"
+    },
+    "sound/dguard/hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/dguard/idle.wav": {
+     "bytes": 20498,
+     "sha256": "45b2f208b9796d19d7aeb0cba64e4b0e5fd2ed7c980123f7c41ca10d17785021"
+    },
+    "sound/dguard/pain1.wav": {
+     "bytes": 10380,
+     "sha256": "9a367afb7cde241099c58c999e225ba939be39f21be818b16444f5a810049960"
+    },
+    "sound/dguard/pain2.wav": {
+     "bytes": 14892,
+     "sha256": "827a1e4d3c9983f61fffd61de33054274c144bddd9a68460b496fd6281cf9406"
+    },
+    "sound/dguard/sight1.wav": {
+     "bytes": 18124,
+     "sha256": "9cb3d960261d90ec16c9883f4326c905356b6ff4e99cdf48ab5913b098588016"
+    },
+    "sound/dguard/sight2.wav": {
+     "bytes": 18022,
+     "sha256": "35ee4b7ec6715c8c9fdc24f90ad0b5d90a0ae7a4986168cf40670e87c325d5db"
+    },
+    "sound/dguard/sight3.wav": {
+     "bytes": 19948,
+     "sha256": "c6818770267626dea27f4a72ce2249771f6968924022c2275a5a96abfa485044"
+    },
+    "sound/dguard/sight4.wav": {
+     "bytes": 20332,
+     "sha256": "7affcdbdc62f13e492a15b54fe642fe045641f5551f570cc3c8d5f7ee29521fd"
+    },
+    "sound/dguard/slash.wav": {
+     "bytes": 22942,
+     "sha256": "44b60d785ff03f033e183b6fbce69e526351187d28efdeb308f6f8bea930d450"
+    },
+    "sound/dguard/slhit.wav": {
+     "bytes": 31956,
+     "sha256": "0f07a131640f21337cd89a772588ecfc707d6a729f96b54c21920b809cd620e4"
+    },
+    "sound/dguard/slmiss1.wav": {
+     "bytes": 10458,
+     "sha256": "e32d5cb070a13fad979b021e84a727f71242305ade1af7bfe18c255f0f6dd548"
+    },
+    "sound/dguard/slmiss2.wav": {
+     "bytes": 13840,
+     "sha256": "f6b3aee08c25434d2fda7468cacf35a0912b182653a45991149b54a0fc4be537"
+    },
+    "sound/dlord/death.wav": {
+     "bytes": 32022,
+     "sha256": "0188f6a3dd88686e15311f8c39c4277078e55bc0ec75497e2eb534af717abcdb"
+    },
+    "sound/dlord/idle.wav": {
+     "bytes": 9906,
+     "sha256": "c0ee37f80013dad1aaeb285a11a33c4d7c2ff2de0b2a94c2943d3fbe1c241bcd"
+    },
+    "sound/dlord/pain.wav": {
+     "bytes": 8632,
+     "sha256": "230ed5c7d024bfa90b973649aa79d9e9327eaf401b1632e4a1334fb4a9eb075c"
+    },
+    "sound/dlord/sight.wav": {
+     "bytes": 28028,
+     "sha256": "d82aa0028754e826705961040e1ab27f007c572a28c63dbcaeefeb681bc3ca85"
+    },
+    "sound/doors/eldertry.wav": {
+     "bytes": 76358,
+     "sha256": "769f4e43083dfa153a2cfdfb11c09920757a407c871f82957dbc9120de140230"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/explode3.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/sight2.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 14026,
+     "sha256": "7a059f5c95936c1e51e96c28b9f30fbe6d66c27b1271b6f077eddd6611e15882"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 8192,
+     "sha256": "780230c4697dea0189ff81f731394696893d321ce7f3600370cca5ae2e81822d"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 10442,
+     "sha256": "cc71b100be0fb44e58b396e5e7e3d602e646545d8b368e804469ff083ed687c1"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 9918,
+     "sha256": "bd959168eff294104f04b5b1b736c722518fbf0d8f13fdbd8c4b695f14838aea"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 83982,
+     "sha256": "4b0d8db882ab1c9fc2109effeaf125ec46fb23a91ac2242201103e0d3da96944"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gug/bile.wav": {
+     "bytes": 54572,
+     "sha256": "e06787585ef0369798a938a1a9585d24b60aa7b5c65acda3a5fb6f2c7ab65aca"
+    },
+    "sound/gug/bileatk.wav": {
+     "bytes": 50040,
+     "sha256": "b4b05e2907789a78391ccfe8ced3902821f1097ecd1f894b12ba9278d31a8717"
+    },
+    "sound/gug/death.wav": {
+     "bytes": 132396,
+     "sha256": "20bf209a832381b77d37c54a84ab1819b6c71e2147c5d122ac62668c070167a5"
+    },
+    "sound/gug/gquake.wav": {
+     "bytes": 43350,
+     "sha256": "d232ae13b55cb5b10b8903db43c037a5c6c4cdfea1f84f9399133484df6e0175"
+    },
+    "sound/gug/idle.wav": {
+     "bytes": 50580,
+     "sha256": "ff33c63696dec5c582ff9a4537814299b47ce2480d6cc53c116721d793576fda"
+    },
+    "sound/gug/pain.wav": {
+     "bytes": 22064,
+     "sha256": "e559f2b372fe771207aeef4b1c3a71baca542863493776558ae3f933f3878c29"
+    },
+    "sound/gug/quakeatk.wav": {
+     "bytes": 65882,
+     "sha256": "2c07b7690356bd9233a79c1f8b5f4e146cbabc367a19c138d6719a1e0d09328e"
+    },
+    "sound/gug/sight.wav": {
+     "bytes": 76426,
+     "sha256": "210ed86a5d6f9d4e791954fc3a4e4b4b6dc5839d02f7c19d468493a2f87dca64"
+    },
+    "sound/gug/step1.wav": {
+     "bytes": 15494,
+     "sha256": "4e2ce285991bc0d4337c77fdbb029507697ecb4dbf6543ddefe976ea114c4214"
+    },
+    "sound/gug/step2.wav": {
+     "bytes": 15502,
+     "sha256": "27f6f770a52fce5ae04836706e63ef455555de086019a2f9e44d4da1fc99b03d"
+    },
+    "sound/gug/step3.wav": {
+     "bytes": 15502,
+     "sha256": "fcc7ab38a8ec28509d0aa062a3cb93aee6da6a0ae364e4fe0dfad791f54558af"
+    },
+    "sound/gug/step4.wav": {
+     "bytes": 15502,
+     "sha256": "fc52cad29cca2e1fc36f5c6ac7f955ed897d6da4fb5dcf4eefd052e0652d93e7"
+    },
+    "sound/gug/swipe.wav": {
+     "bytes": 16064,
+     "sha256": "90bb5831dfd19f65df19e97f76d858ec940d8e33e0a2ed8fad89a23947e430e5"
+    },
+    "sound/gug/throw.wav": {
+     "bytes": 23180,
+     "sha256": "5e901b94e7be364536603273f18791ab571c46c2fc74263774c0e312f873a281"
+    },
+    "sound/items2/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items2/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items2/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items2/trinend.wav": {
+     "bytes": 79450,
+     "sha256": "6edc4b653c671187012e5ad6a95f777a861ab18a1d27b69a10912b459dab2577"
+    },
+    "sound/items2/trintake.wav": {
+     "bytes": 73428,
+     "sha256": "b26c0f0af98016163bf1fc7c4376ca90dfa4ad447e31a04fff9d8c9d820cda86"
+    },
+    "sound/items2/trinuse.wav": {
+     "bytes": 16990,
+     "sha256": "ea0b2b20b8137da8388bab00812218a47049183a7d4eb031449b975289de4ed4"
+    },
+    "sound/misc/elderkey.wav": {
+     "bytes": 55212,
+     "sha256": "70af94f89ca397badfe01eadc36b1375f3d219ecd8c19f691a4a6cd257cf9e7b"
+    },
+    "sound/necros/dias.wav": {
+     "bytes": 412204,
+     "sha256": "2de75ccc9f971c3c56b87c145ac96cfc7d3e13a758c89081133389d13399606f"
+    },
+    "sound/necros/drivshft.wav": {
+     "bytes": 385808,
+     "sha256": "a84800586cff4027335aa94cc05e0f5a0d88ab2404cba7a5ccc40c3581ffb981"
+    },
+    "sound/necros/forebode.wav": {
+     "bytes": 97960,
+     "sha256": "5dc4a7a6c7c2444595c0a7511ec8e1d5913211591202cd9a0e478588e1939c0e"
+    },
+    "sound/necros/gen.wav": {
+     "bytes": 136482,
+     "sha256": "f0d4932c1bc41d8701dee215fe04ec5f8667ac1de980d9d6158eef7f9e3e7fe0"
+    },
+    "sound/necros/gen_fire.wav": {
+     "bytes": 182316,
+     "sha256": "da244c2acc4a6b496330f1b7202a3f3d68ff61bc0e7e1c0a66a4208fdb66e9db"
+    },
+    "sound/necros/highwind.wav": {
+     "bytes": 158882,
+     "sha256": "41decf2ffe971f07420ab67deb227a285246d92eb01f77284920f01cc3652284"
+    },
+    "sound/necros/irulan.wav": {
+     "bytes": 196396,
+     "sha256": "52fc652f8b7814d4d28252f421e7ecebad629dd4c613e73adc643d67dabab3d5"
+    },
+    "sound/necros/sgatehum.wav": {
+     "bytes": 128670,
+     "sha256": "1a06f2e664cf213248990ee27ec117a46a4ba6ea6067b114c896cc9500f4fa99"
+    },
+    "sound/necros/strongwind.wav": {
+     "bytes": 133538,
+     "sha256": "fbc3ce4f537ebaf9603c6c4de350f06b2373f420e5c47a300668942ecd1a9064"
+    },
+    "sound/necros/tld_stop.wav": {
+     "bytes": 72304,
+     "sha256": "b58180629cb28e31b5fa0e00fc74c2c75841dbdcb778674509877d40abdf51df"
+    },
+    "sound/necros/tld_strt.wav": {
+     "bytes": 101584,
+     "sha256": "66ae791b7a06a8aa233d59bafb63d7b4ecb71be8b6ffc50c6794ea71807fbefa"
+    },
+    "sound/necros/tshaft.wav": {
+     "bytes": 221356,
+     "sha256": "95690f3dca8be51dcf789f5cb8977f37c20257b9b7bc84a4c57caa3aba0316a7"
+    },
+    "sound/necros/wat_amb.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/necros/water6.wav": {
+     "bytes": 45870,
+     "sha256": "d7505b517d6573f661739d765222c33d9ac1a86da362328d5635fc8634c9d823"
+    },
+    "sound/necros/woodmve.wav": {
+     "bytes": 70716,
+     "sha256": "bc27833a4d5b60b2212311cfefa7e8e04333e7a0c1efec939048a050bef4ab15"
+    },
+    "sound/necros/woodstp.wav": {
+     "bytes": 58554,
+     "sha256": "a86696cbcc070443f939497ba76c1e2c101bea2534dcc0993523031c6f500a2e"
+    },
+    "sound/polyp/blast.wav": {
+     "bytes": 25036,
+     "sha256": "0c3942daeedfa438ba36bd31481f7b24b067cab3d167c9e5cfd1cf3c498bf367"
+    },
+    "sound/polyp/cloak.wav": {
+     "bytes": 46252,
+     "sha256": "31cb79048b0c511ad0d40989785d835584c4c808025b8eb8060a74b36c9bca39"
+    },
+    "sound/polyp/decloak.wav": {
+     "bytes": 91152,
+     "sha256": "e2ee4693b0e466c5bc229db186257254c381c6a6985e71b02b20838859bcb5ae"
+    },
+    "sound/polyp/gibsplt1.wav": {
+     "bytes": 19580,
+     "sha256": "e9b7b73242aa04fdb6aed5de1c343ced81b15d6f78dde07097826b78bb1f87a0"
+    },
+    "sound/polyp/idle.wav": {
+     "bytes": 17750,
+     "sha256": "4edd47fe2508cb818ce36916a16c6e4c7cea4f61ff0310b7195e74bccc4f5d2b"
+    },
+    "sound/polyp/idle2.wav": {
+     "bytes": 22210,
+     "sha256": "b07894dd93545ed0c54fabae04f139c371a8b36ab84fc399f870f813b535000c"
+    },
+    "sound/polyp/sight.wav": {
+     "bytes": 11664,
+     "sha256": "a9c414ba4ca74fa3e08018af695674ede79a2f63aab26be0566dda9426eaef43"
+    },
+    "sound/soldier/load.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/soldier/rocket.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/vermis/death.wav": {
+     "bytes": 148016,
+     "sha256": "44b26a9dca5ec8d5e8a7ef2b5e38196b74e4f606cd37b906ee2b2e5b5a85b08f"
+    },
+    "sound/vermis/grab.wav": {
+     "bytes": 88122,
+     "sha256": "09528bd0d49d5cac0c03fe7994b57e572eb89aa8bce63cd0a591130e4b2126ae"
+    },
+    "sound/vermis/grabbed.wav": {
+     "bytes": 51630,
+     "sha256": "99583c88b8ec2959a0d69448aee16ec86b3d9feee6df7841fc32759598349376"
+    },
+    "sound/vermis/grndhit.wav": {
+     "bytes": 36428,
+     "sha256": "1f0e78fa08efb4617b6967a6cc218c56af227c7fd6bf039420d8f106d74fca72"
+    },
+    "sound/vermis/pop.wav": {
+     "bytes": 131420,
+     "sha256": "6284ab02e604b44c5b07225b2a0544c8707517d5fec0024c127bdafef2704f70"
+    },
+    "sound/vermis/sight.wav": {
+     "bytes": 137772,
+     "sha256": "d892117e4602595b6dfb65563b8fa7a3ad2171851791f7c6f47ea4bfece76296"
+    },
+    "sound/vermis/sight2.wav": {
+     "bytes": 106780,
+     "sha256": "6132e2d0db5cfb7a1a064e708d97f7258e2c6ac15c6f4ea8d520641e0ad10f9d"
+    },
+    "sound/vermis/splash1.wav": {
+     "bytes": 30710,
+     "sha256": "f931a2927c13cdb2523dde4550c0af993cc08cbea6e332739f9cf6fe3bd1ff8b"
+    },
+    "sound/vermis/splash2.wav": {
+     "bytes": 25332,
+     "sha256": "b91c69ee695bd71537ed018800f7d89e5e7d95332124f69adee39261d84d7c13"
+    },
+    "sound/vermis/splash3.wav": {
+     "bytes": 25590,
+     "sha256": "99fad2f3815a30ef645a2162ea24e54b4302ba00d7551af9299fde74ecce98e8"
+    },
+    "sound/vermis/spore.wav": {
+     "bytes": 44204,
+     "sha256": "d01a27af99745725dae124d30af18458b2ef323bce93c3cad939310e0f47f6c7"
+    },
+    "sound/voreling/bite.wav": {
+     "bytes": 8920,
+     "sha256": "a5bbebd7178205c400115846314709fa22c4db390fafbf3abaee2e33342e1a0c"
+    },
+    "sound/voreling/bitestrt.wav": {
+     "bytes": 11132,
+     "sha256": "be72b6a15a73bda266331309046229fd6f94b0856f4dfc306204e6266ad1cb59"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 19584,
+     "sha256": "e5bc7634816b927c305679e9b0ff3e4f33a2d09cb5e80db3c5dd04373ba452e5"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28378,
+     "sha256": "b9daf80e6bc998d521cd35f6d8ef74295f39fafbb71f6d6cfe8f0e7c1fb3f0ba"
+    },
+    "sound/voreling/land.wav": {
+     "bytes": 6154,
+     "sha256": "92f08d203711dbd3bc2049ba61a62938b4eb34a9c7285c26406da3b29bbdfba2"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "0b6c021bc7301757918201ad1175387eabfc0af4f6e8b94e273ba22a2aa6c53c"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 55972,
+     "sha256": "9aaaebf47f82cd7a521800aa9d81d14bd2747735481cb15b88ce104cf1568b6f"
+    },
+    "sound/weapons/bomb.wav": {
+     "bytes": 141228,
+     "sha256": "6fa171d6bbb3dc07f9c0fb422ceb2e3e20934e9a0465589717dfdc14c92b016c"
+    },
+    "sound/weapons/bombfar.wav": {
+     "bytes": 246316,
+     "sha256": "12334d1af40522f124564f354acf44f419d1e1477cdef97d0f790ab52a38d765"
+    },
+    "sound/weapons/dryfire.wav": {
+     "bytes": 47872,
+     "sha256": "d119284b7e97ab626587b20349eb5c2a90489b37df85a1fec52c98962185da06"
+    },
+    "sound/weapons/expl1.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/hamhit.wav": {
+     "bytes": 2434,
+     "sha256": "7754c2ab32c5d34473e4fe4977f9aa1b326a622431b44b599c798c7a0fbe2b60"
+    },
+    "sound/weapons/lancfire.wav": {
+     "bytes": 6520,
+     "sha256": "be8d154ba1404462776ec3f5fbbda0e974970dd5d61d97cf296c3711ede5bb84"
+    },
+    "sound/weapons/lhit.wav": {
+     "bytes": 149718,
+     "sha256": "1261ce565a67862e00a611789482feefebfd97340c03ec4f7eeaffb50adab57d"
+    },
+    "sound/weapons/lstart.wav": {
+     "bytes": 338900,
+     "sha256": "6cb11e08faa41a99e1223875f2f465b97304e9fa04efbbe4a2213634069fdb09"
+    },
+    "sound/weapons/plasexpl.wav": {
+     "bytes": 54406,
+     "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 164,
+     "sha256": "ba0d9dbe33691183ef2549fdd006a02e21ac209f1d51271018e9bf565793c1cf"
+    },
+    "sound/weapons/shotgn2.wav": {
+     "bytes": 75024,
+     "sha256": "248a021818f578ec3d96b9fe59d8f839242f4d5f8140a66a500b523b137d1977"
+    }
+   },
+   "sha256": "0ad2132bced06216d27060ae5bcb39747b47dbc90ccd2b2cc0c1a55807551693",
+   "timestamp": "2024-06-28T11:51:30.000Z"
+  },
+  "immortal/pak1.pak": {
+   "bytes": 8293265,
+   "files": {
+    "gfx.wad": {
+     "bytes": 128932,
+     "sha256": "b9b298830f1c48cdc378d83b84e3b308f0ca3052c278d6b4afeb70fa4035ab7d"
+    },
+    "progs.dat": {
+     "bytes": 761082,
+     "sha256": "028ee957df11e12c26c6bb8bcf2f58e4b099a59797b78beebbce65a4f41d4cc6"
+    },
+    "progs/b_bio_l.bsp": {
+     "bytes": 11572,
+     "sha256": "e076780538e320d1a5ffcac210668e95edf63fce95edba192acdbbf0f634649a"
+    },
+    "progs/b_bio_s.bsp": {
+     "bytes": 6028,
+     "sha256": "1609a5f827eef414efe184ef62e8a7a7191208bef9e1593bd67724f19948b84d"
+    },
+    "progs/b_plas_l.bsp": {
+     "bytes": 11572,
+     "sha256": "5ab7b0e25b37c65ea87743bcbfdb482f5556d0595bae15eecb95ab8f1c8c2edf"
+    },
+    "progs/b_plas_s.bsp": {
+     "bytes": 6028,
+     "sha256": "58adae5e3ec3f32d65abbf74fb7fdad9bf19d6f33f2a4f2fe621b46867261322"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 331328,
+     "sha256": "046d34a681439138dca323f54e54d358e225d2d958b21b36ee564fe6d4be7b82"
+    },
+    "progs/brick.mdl": {
+     "bytes": 108308,
+     "sha256": "b566efdd77a56bc38866eb95d167b2e53b8453d4194dd641efe6a15a6d22a6ad"
+    },
+    "progs/c_ham.mdl": {
+     "bytes": 78908,
+     "sha256": "3ef97f78252e0c2aec063649102aad9765eb320fe172c24db29d8c08fac5951c"
+    },
+    "progs/c_lance.mdl": {
+     "bytes": 48404,
+     "sha256": "03d923d70944814497b47312137221bec8ed46c2e8f6681ebac07dfb5b5517c7"
+    },
+    "progs/c_light.mdl": {
+     "bytes": 63500,
+     "sha256": "d0c16e23a406b1833408e216e34759a5060b202e603889ac8c39cac92d6d9434"
+    },
+    "progs/c_nail.mdl": {
+     "bytes": 63324,
+     "sha256": "b98d0281f8958d5b7a50e795711cb9e7b04d73e417dfae13f64f17d1ffc52228"
+    },
+    "progs/c_nail2.mdl": {
+     "bytes": 79328,
+     "sha256": "088e8d8994344e46918df796a38e87d0dbe2ba0baf1ad9359e072ee538902551"
+    },
+    "progs/c_rock.mdl": {
+     "bytes": 67924,
+     "sha256": "c0d3b99d6edde1329011a6754f65caa55888421c94669cee26beda3c1525bb63"
+    },
+    "progs/c_rock2.mdl": {
+     "bytes": 65932,
+     "sha256": "6fa52810c7164815d909085f80d27e3cf60f2a9dc48547c877947ebfc045fd4e"
+    },
+    "progs/c_shot2.mdl": {
+     "bytes": 58572,
+     "sha256": "381c796447399a343a4dff310ba58942eb45168708ef3899a2043ceaefc86c14"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/flame_pyre.mdl": {
+     "bytes": 85180,
+     "sha256": "9df2ae13e72ffe5a305a6ce877b0284023520d5d34df751498a2003c3e420ebc"
+    },
+    "progs/flashlight.mdl": {
+     "bytes": 35596,
+     "sha256": "8442b889437acf210587a7d567ad71c839b978e7dcf27a580503a05983368c70"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41908,
+     "sha256": "52eeb2cb3923bccdf6960abbea3f39cee9c8e504c984c5ccaa7e218627fdb882"
+    },
+    "progs/glass.mdl": {
+     "bytes": 127788,
+     "sha256": "f1e6a01f984e742bfd4d6428878e356e736251b7d18ac65e84aae63fa807fc69"
+    },
+    "progs/greenexp.spr": {
+     "bytes": 24732,
+     "sha256": "52b354786534248048d517a16fea53ad54c39ff7c82185c45067daba31dbb522"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/grill128.spr": {
+     "bytes": 492156,
+     "sha256": "c1ffd3a6680099e228605480d83bc5929ecd5730c01d24cfbcff3f195b509b51"
+    },
+    "progs/grill64.spr": {
+     "bytes": 123516,
+     "sha256": "c8d559303231ce4a7a1c246bea0a24c322d249f3b1cea61114fc0816a73cc781"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 43931,
+     "sha256": "f87f4d5b690c6ca434e5ff904d02f33cae0ac9e44bac4350b9631f47e29f6287"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 28501,
+     "sha256": "24f0d69fa8e5aa9cf70fd2653dab9bbd59fff7985b895234f8b07d1a4546998a"
+    },
+    "progs/lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/medexp.spr": {
+     "bytes": 72892,
+     "sha256": "d9887be2c9837d713d3aef856c1fc9245a4628b76ecd9e4e50a28d0deee1a679"
+    },
+    "progs/metal.mdl": {
+     "bytes": 246933,
+     "sha256": "07c0bb9ff1aa1639a62e5a84fca28d48c0fc738f4d22f8e3d8a5a029790d870e"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "e0bd8b2d3da7f2d8bdd59c4664b9202f00fa6dbe8c6321fd3651b3e857edd6c3"
+    },
+    "progs/pickup.mdl": {
+     "bytes": 36332,
+     "sha256": "7d0e5cac5f2a9f5ce879d81499c770b246ce5fcce049e2661fb35d2b15cbd2b1"
+    },
+    "progs/plank.mdl": {
+     "bytes": 19967,
+     "sha256": "d0fd70c3bd6dc93d13b229d4e0fa804a32a6688ef9640b4cc6340d9dab5fbd3d"
+    },
+    "progs/plasmabox.spr": {
+     "bytes": 14472,
+     "sha256": "89432660fdfbbdd90c72639152666f38ea6e7016a1d13171bf2d2e63bd2f4e89"
+    },
+    "progs/reed1.mdl": {
+     "bytes": 95281,
+     "sha256": "65773f37e26d41dd72ec1cf9849c663c1475923cb77d0f4c599bc3301368373f"
+    },
+    "progs/rock.mdl": {
+     "bytes": 136476,
+     "sha256": "0f80e53002bee59dad6dfe6f73b1ba2287700bea1cdade8e1dd4c35ec9d212a8"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "0350089b0bcf3a63a5d7b1e0bd070ac993be60f652f9bf9e3cf48957d31d561b"
+    },
+    "progs/sentinel.mdl": {
+     "bytes": 290664,
+     "sha256": "573efd78767922b2bbb3e5dab2b16cd8f90c2cb1709ecf4a315a141f4df77d09"
+    },
+    "progs/smlexp.spr": {
+     "bytes": 105148,
+     "sha256": "ce4938c9e813e648404b25b82245cad4400682d885d044b9d353a8039cfdceb7"
+    },
+    "progs/tree1.mdl": {
+     "bytes": 57621,
+     "sha256": "8e450cd50b8dac1912e96ec78ff4a16e0b9065138d181fa58257973c2ee96578"
+    },
+    "progs/veg.spr": {
+     "bytes": 8340,
+     "sha256": "4248f027adca723fb0101abf5c51b604ca6aabf80d4ccd9aa305cd34e072a682"
+    },
+    "progs/wreckage.mdl": {
+     "bytes": 71364,
+     "sha256": "13763a8cec3b643acb9b8165f1850ffae003131c84a2ac225777822a88462498"
+    },
+    "quake.rc": {
+     "bytes": 1184,
+     "sha256": "ab29f4784413223ea5fd84a2f983eded94275051dc132bbe0ddf8debc9d2b97e"
+    },
+    "sound/defender/ssgcock.wav": {
+     "bytes": 5274,
+     "sha256": "db4f62f8d76a68f2e4d3e7a29a22d3ddc5d6ae9bb296e6e800e937b73b5a4dea"
+    },
+    "sound/defender/ssgfire.wav": {
+     "bytes": 14206,
+     "sha256": "494a6d493c3c298c1b9cc0051ce4c1f9e129293ea7ec283b62915c49d8c249c3"
+    },
+    "sound/doors/blocks2.wav": {
+     "bytes": 38638,
+     "sha256": "12df7d5a55311ad33e5d3cf1efbad53f2209b7598c59d4e4715ef18d9e4532e0"
+    },
+    "sound/doors/blockse1m2.wav": {
+     "bytes": 91858,
+     "sha256": "12e39c7592dc01f13b7be34306c6b77c13e8d0429219fa46402752e5e6f62ca8"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eliminator/acknow.wav": {
+     "bytes": 77318,
+     "sha256": "5eceea3e5c2d77b919ad0e05375f7c891e6a7192192b5c1f7bde3f999adf8649"
+    },
+    "sound/eliminator/hesdown.wav": {
+     "bytes": 188790,
+     "sha256": "43688ea2cda3a2edb9f9d575eea9e8b2bb8e962bcd989bdfa5a8962eb2c74480"
+    },
+    "sound/eliminator/hostile.wav": {
+     "bytes": 100856,
+     "sha256": "03ee39ba5581da66909d721f4f40a259ccea095501dcbaeff47ab9d2e8044bc2"
+    },
+    "sound/eliminator/idle1.wav": {
+     "bytes": 39084,
+     "sha256": "2ccaa3ba4f987d031a22b8048ca23e97900fca9def362ff92943b73a99ed7844"
+    },
+    "sound/eliminator/idle2.wav": {
+     "bytes": 36204,
+     "sha256": "9232028e1a93c409c7000348bfadc269c49a333e8d65d904973efb547c7af805"
+    },
+    "sound/eliminator/idle3.wav": {
+     "bytes": 38222,
+     "sha256": "93034d568db5c304a165c3d89cb03ffe5d97e8157755e944a863697007eb27fc"
+    },
+    "sound/eliminator/sight.wav": {
+     "bytes": 31468,
+     "sha256": "2268ee0ad0c77a081b289a550a1dae24b274b2e3f06d156a67beca80df8ee919"
+    },
+    "sound/eliminator/target.wav": {
+     "bytes": 159480,
+     "sha256": "f2c8c4e9f515d682387ec9b4ba40102917355cffc58ad95dcc935b9805742cbe"
+    },
+    "sound/impact/gib_i2.wav": {
+     "bytes": 19252,
+     "sha256": "6a5ddcd321e9543960098d000255abc76b2f502e0e2da798dba4dc6fdd076e3b"
+    },
+    "sound/impact/gib_i3.wav": {
+     "bytes": 14956,
+     "sha256": "e6a2eb024a5101846479865d49ea5ba551d3972567eee70f1a9db3bc6687ccbc"
+    },
+    "sound/impact/gib_i4.wav": {
+     "bytes": 32782,
+     "sha256": "59b447c5e03b7ebc2914704f0e3caaa6b65e393e25d6f19b0a14f2f570676caa"
+    },
+    "sound/impact/glass_bk.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/impact/glass_i1.wav": {
+     "bytes": 13526,
+     "sha256": "e57ff2304e1ed3b85bca5803ab3309f74b115669527ad7c54371bc4377aa3f60"
+    },
+    "sound/impact/glass_i2.wav": {
+     "bytes": 34624,
+     "sha256": "1e403adc1d18b90440d2b10793c0c356617b138be309ed7b9774b9de86d23a8e"
+    },
+    "sound/impact/glass_i3.wav": {
+     "bytes": 9520,
+     "sha256": "250f438c593fed13a5493edc2b4a88c6a4cb22034f81dd7571ba2db7bfee9fa5"
+    },
+    "sound/impact/glass_i4.wav": {
+     "bytes": 6192,
+     "sha256": "05b2dcf83bdcf50f0ac1b6a341d85380293bb519948da38a07a842df53e8e774"
+    },
+    "sound/impact/mach_bk.wav": {
+     "bytes": 124920,
+     "sha256": "642a3ef399d357428f0800ac39557a6e841301aa47263f2f0f3e1b719a4d3923"
+    },
+    "sound/impact/metal_bk.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/impact/metal_i1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/impact/metal_i2.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/impact/metal_i3.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/impact/metal_i4.wav": {
+     "bytes": 79928,
+     "sha256": "d2b35ba352f32ceae469acf9cfa04f7dcc0a462ff69e3649f5c0adf55ae2ea78"
+    },
+    "sound/impact/rock1.wav": {
+     "bytes": 30534,
+     "sha256": "5cb61e93ebcf9bbcd3be1f6e282b51e9102d56b6650cffc0db93918b11b42322"
+    },
+    "sound/impact/rock2.wav": {
+     "bytes": 29254,
+     "sha256": "9fdf4f489834452fce33b1fbe69bce9d4920a117c3d0d93b4fb530a7117bf160"
+    },
+    "sound/impact/rock3.wav": {
+     "bytes": 25264,
+     "sha256": "59b506a84e018b11e9ba30a6ad299c2d8cf24d5907dc95cf30e578cd386e28bf"
+    },
+    "sound/impact/rock4.wav": {
+     "bytes": 27244,
+     "sha256": "7a2c24ce52e272998ca035c967860873c92fbb14227a190ac82b761843680ffd"
+    },
+    "sound/impact/rockbrk.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/impact/wood_bk.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/impact/wood_bk_old.wav": {
+     "bytes": 61250,
+     "sha256": "f9cff6955830b4219b3cfa01e04f41f311f7fbbadbc2738c92bf21808f1e7800"
+    },
+    "sound/impact/wood_i1.wav": {
+     "bytes": 28074,
+     "sha256": "6249449664f5ae509164ae3fd8588c905bea9daf5b1d919d9917b91aadf675bb"
+    },
+    "sound/impact/wood_i2.wav": {
+     "bytes": 25158,
+     "sha256": "d51e731bdf895c84ec9927c496fc0a7fb6e7a37cbfbc2f6b55f54f716d804d08"
+    },
+    "sound/impact/wood_i3.wav": {
+     "bytes": 17644,
+     "sha256": "8e1967cf42a7e31668d94e1b0cb7c6de4d36c6ec735d67ab01ac4e00dfb0853c"
+    },
+    "sound/impact/wood_i4.wav": {
+     "bytes": 11516,
+     "sha256": "fb0908f1a2bdff824d27fa92f15690cb9f86805185119fbc7f7876547495bf45"
+    },
+    "sound/items/click.wav": {
+     "bytes": 6534,
+     "sha256": "fab804dd505a2d823b062b348f126788bb3ce6c6399e8e76b1b7e39ffc8c82e3"
+    },
+    "sound/ogre/flakfire.wav": {
+     "bytes": 25932,
+     "sha256": "d00213964c69abe9c1661aa2cd2ae9305b0bdacb46a3e0945763883fb2d991b6"
+    },
+    "sound/ogre/flakhit.wav": {
+     "bytes": 11846,
+     "sha256": "a7c4a0b04c8c39de0bfb560283ac872e6bb6b240fdeef9a1565d314eb99cbefb"
+    },
+    "sound/player/ftladmet.wav": {
+     "bytes": 67720,
+     "sha256": "7cd7028d84b16700661848a36a866a2602bcf50185b79ca94d5a2eb541fb1294"
+    },
+    "sound/player/ftladwd.wav": {
+     "bytes": 35760,
+     "sha256": "b09b57b7da9ae84b359260d7c600b70a05ed2314597af6cfd38999f664568d65"
+    },
+    "sound/pyro/death1.wav": {
+     "bytes": 18468,
+     "sha256": "f69cb5d6086c78c8e7bdb9d8fcb9365e6500ece5156810b568a2cf2d0acdc126"
+    },
+    "sound/pyro/flame.wav": {
+     "bytes": 44268,
+     "sha256": "44aa350cb7efbe578f785820ba28bf6aec29561a7d150072ebe841966adcc45d"
+    },
+    "sound/pyro/fstop.wav": {
+     "bytes": 44268,
+     "sha256": "50a724e76295283a5cca503ac1b46d5ca97a33055e0c8e85bcfdfc0c90d5169d"
+    },
+    "sound/pyro/sight.wav": {
+     "bytes": 88918,
+     "sha256": "39d9c5460096478952c203bfc358ee52c5f2147e742b937f2e8517b45843c360"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sentinel/laser.wav": {
+     "bytes": 9712,
+     "sha256": "c5f90e1823a04b48f7f24ac5b8792e1b42030a8b07970db5847dc1e74be094c2"
+    },
+    "sound/sentinel/nail.wav": {
+     "bytes": 13750,
+     "sha256": "7acc3ac05b7218abc6fef2d2397771d90fce6fa39415e33824be7e771d30e288"
+    },
+    "sound/sentinel/widle1.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/widle2.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/wpain.wav": {
+     "bytes": 19596,
+     "sha256": "bc7b6536a1c67aa89295eeacea2d9b36cb0bf783b5fb7cc6aaf4fa01a0edb3fd"
+    },
+    "sound/sentinel/wsight.wav": {
+     "bytes": 27322,
+     "sha256": "83bca2103d60c68435e27f0660e3ecd5bffb058e796382e7bdb43efabdfb9889"
+    },
+    "sound/weapons/dryfire.wav": {
+     "bytes": 11268,
+     "sha256": "43e10c707d097c577f465c89fe9444c59b5ff4cdaf7c8d6619bcf61568d39bf2"
+    },
+    "sound/weapons/plasexp2.wav": {
+     "bytes": 112340,
+     "sha256": "92ea6112b21e65d625d34fbe1ec6abc592c2cf7c28f1b55c5999a8a56daebe8b"
+    },
+    "sound/weapons/slime.wav": {
+     "bytes": 57132,
+     "sha256": "88ce5f10c8acb0e51d54a4066ef8faf1643c5baf75edeafb82d350c733131215"
+    }
+   },
+   "sha256": "7f71aba85e7d160bbff4e195f9a992d52cc99ec685954418f55b920319b60b9b",
+   "timestamp": "2024-06-22T19:50:56.000Z"
+  },
+  "immortal/pak2.pak": {
+   "bytes": 3806519,
+   "files": {
+    "default.cfg": {
+     "bytes": 2025,
+     "sha256": "3227f12ce7edbb4235d5b8b4d3f69206a9b8fd8715f939ca0601325e52ea15a4"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "faa7c77704959d1ad9bb5280449b22e8c4b9425fc628b4f2037900c49e73fc9e"
+    },
+    "optout.cfg": {
+     "bytes": 1564,
+     "sha256": "51efd87218e766df5c8b5c643ccabcecacfa855ee60deaf8dde8420a02c157c8"
+    },
+    "progs.dat": {
+     "bytes": 737572,
+     "sha256": "988aea9295972e13bc2b7ceabf2c72e4eda5e3ff095090701beb65f697647a96"
+    },
+    "progs/bolt3.mdl": {
+     "bytes": 15772,
+     "sha256": "6fabed3901bab1b145e418300d333c30016070e57ede07476884283a5ef7e380"
+    },
+    "progs/box_l.bsp": {
+     "bytes": 21639,
+     "sha256": "9a20404c31446ffc497113892dc293b0e59c6bb2cd9ab4a1f0bee11cc1f61a5c"
+    },
+    "progs/box_s.bsp": {
+     "bytes": 21541,
+     "sha256": "47b3f0a947272241184b9f65aa46d694fdd8facb8a9a36509d6f11f844f3917f"
+    },
+    "progs/c_ham.mdl": {
+     "bytes": 76800,
+     "sha256": "6bdd3e6b4c8253e6aeb6e293093b88fe6b3a9254135d285c8574acb6be9de9e1"
+    },
+    "progs/c_lance.mdl": {
+     "bytes": 44164,
+     "sha256": "6925fa7f462edb6c863bef65dcbe7d5c69544454c6fc1435a98c2890b08cc757"
+    },
+    "progs/c_light.mdl": {
+     "bytes": 76388,
+     "sha256": "9f0cdcc8e56d0614e058a3e922f3f64b0de33ab2ba6fe390c4154a3cbeceff5b"
+    },
+    "progs/c_nail.mdl": {
+     "bytes": 45336,
+     "sha256": "afe38a23bd9d6ec01a386047c3030f95732a986211eb0c6aafa83e12eb300a53"
+    },
+    "progs/c_nail2.mdl": {
+     "bytes": 81136,
+     "sha256": "c2e9e328af078538722ba4894801b5e4c5334a4629faff83b11510aa0a987b21"
+    },
+    "progs/c_rock.mdl": {
+     "bytes": 74404,
+     "sha256": "058de704ba8b0c2a47c2b83fd1b767a8220b9af87460bf114b14528db57ce096"
+    },
+    "progs/c_rock2.mdl": {
+     "bytes": 73544,
+     "sha256": "c922fdbfcd8175d196cc16f2134c8d9852c788ca76c198337aa71bf0bfde5e56"
+    },
+    "progs/c_shot2.mdl": {
+     "bytes": 42636,
+     "sha256": "02226bf370133fb1c4479c56a9a3c544cb89a0e87ba4cabe3247f9ddc9994b9a"
+    },
+    "progs/dspike.mdl": {
+     "bytes": 25324,
+     "sha256": "c2c89f690e21e34bee37db5011493f3457240e22fcaa3cdcdf04ef4bf9f44ae1"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51272,
+     "sha256": "0244bf38ec29f251b425bc1cc4f1a0e003316b3699c869cea38ec553e1f96acc"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "d45e10e4002fb17b2a1aa4077d1d4e599babd5083c0f7da914f8e98b61cb2537"
+    },
+    "progs/polyp.mdl": {
+     "bytes": 343144,
+     "sha256": "a135ee3b29dd230d06babc0e80c691b35e33599a48eb152d2c2c4902d424d4ec"
+    },
+    "progs/s_vp_pll.spr": {
+     "bytes": 272700,
+     "sha256": "024935ca88793c432ac5d6c6f52a51cb82638c86e9c27cac8d87e926673012db"
+    },
+    "progs/slime.mdl": {
+     "bytes": 25976,
+     "sha256": "53b07ceca49f5c637dc5bbe1cf1393db74e3d057624039efb8d7fd2341b5466a"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "aa9165056656a1d0810d741c91e5e14b1aebf3020a95ebc0dc1f48a3a1243074"
+    },
+    "progs/waterfall.mdl": {
+     "bytes": 43588,
+     "sha256": "c4bf6157c6f3a580a6cc7a76c8d5ea6a9af00f9c53b0615bf47b6574dc5bd54c"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 845237,
+     "sha256": "ee9db9fb4e224227574067dffb1b9c49af5b9536f8cea0527282d851aab81e73"
+    },
+    "quake.rc": {
+     "bytes": 1261,
+     "sha256": "27e799866073f0b3d8431b2826693a4e91b2c86e3d4046f8cea0df26f406450f"
+    },
+    "sound/ambience/grinder.wav": {
+     "bytes": 264572,
+     "sha256": "70789db5c6e505292dd6031241aff19bd7b327677033cac5f98c1dcfeed5c6db"
+    },
+    "sound/ambience/teeth.wav": {
+     "bytes": 51600,
+     "sha256": "9649cc3a15c66b851da286bfbfe085196e851a9a493c299b03d9874dc04431e4"
+    },
+    "sound/doors/er_stop.wav": {
+     "bytes": 51846,
+     "sha256": "f674272aa55db0cb05651c5edfa76422370d138c44789b179bc6e943a22f0d28"
+    },
+    "sound/doors/er_strt.wav": {
+     "bytes": 99372,
+     "sha256": "afb23446ab200aa3bd540bc1ac517713dbf2d7fc099283254f7b8a4480a90092"
+    },
+    "sound/doors/ir_stop.wav": {
+     "bytes": 81054,
+     "sha256": "c5ae31d19bb638cd61771f365beca5998d5795ff035929863a19148d39907904"
+    },
+    "sound/doors/ir_strt.wav": {
+     "bytes": 86616,
+     "sha256": "8e2767cf7d483ab898c7eb561834b0a7af90669976499dfe42c8f7e09560aeb9"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/wfend.wav": {
+     "bytes": 9060,
+     "sha256": "1d8381b51b40e54a47ee76a9115b95a49285fc59385ff20b941b0fc8b7cd16b7"
+    },
+    "sound/misc/wfstart.wav": {
+     "bytes": 77838,
+     "sha256": "c85b517926832c1a7ef3a04de2995a7bd58a161620b4341a3f57d556c50d7ea0"
+    }
+   },
+   "sha256": "84dbc0e70d6140017eae03349595f04569a54569655b4cde92aeb069bc46f091",
+   "timestamp": "2024-06-22T19:51:02.000Z"
+  },
+  "immortal/progs/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-07-16T00:31:34.000Z"
+  },
+  "immortal/progs/plasma.mdl": {
+   "bytes": 3542,
+   "sha256": "2f3efa19a64b60d480fbef7c10e8f2a56e90d656e8fcb8bcd656932f8686f482",
+   "timestamp": "2024-07-15T23:47:54.000Z"
+  },
+  "immortal/progs/zombie2.mdl": {
+   "bytes": 59012,
+   "sha256": "d6c2612c04acefb06e2f7e628c1186800dd90b972ad35f1ecec097645ff28b76",
+   "timestamp": "2021-10-07T17:43:48.000Z"
+  },
+  "immortal/quoth.cfg": {
+   "bytes": 497,
+   "sha256": "8072e43b97422c300245370247c246ff94afa4c2e15b308bc37d9be638d5cd24",
+   "timestamp": "2024-07-17T00:44:08.000Z"
+  },
+  "immortal/sound/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-07-16T00:31:42.000Z"
+  },
+  "immortal/sound/ambient_radio5.wav": {
+   "bytes": 304084,
+   "sha256": "398d91e99724c4674f03891eadeea66bbb0445f298bb40a3d2e23daea8480c6b",
+   "timestamp": "2023-02-19T23:09:42.000Z"
+  },
+  "immortal/sound/ambient_radio6.wav": {
+   "bytes": 124078,
+   "sha256": "b92d4be71958676ae7d4a4b326966f31a84f066978ba8529a3d514b282403171",
+   "timestamp": "2023-02-19T23:09:50.000Z"
+  },
+  "immortal/sound/ambient_radio7.wav": {
+   "bytes": 155410,
+   "sha256": "c33403d815e7b230d7a4ce5113a6b0747b70293e8611c483b210d628c7fbce47",
+   "timestamp": "2023-02-19T23:10:04.000Z"
+  },
+  "immortal/sound/ambient_radio8.wav": {
+   "bytes": 148382,
+   "sha256": "c64783ba48f9bf902af91ec540e8ca4356c978f18bbb4f8b839024dd15cf7e32",
+   "timestamp": "2023-02-19T23:10:14.000Z"
+  },
+  "immortal/sound/explosion.wav": {
+   "bytes": 139072,
+   "sha256": "9c955432887b8601021477cca9bdba995f10acf3955bb1789971b7fb9cd8f459",
+   "timestamp": "2022-11-10T19:36:02.000Z"
+  },
+  "immortal/sound/gore_ambient1.wav": {
+   "bytes": 1653966,
+   "sha256": "162cb797ec878f97831f85adb92c573d610b5b3ecce11ae8f1cd8441bc43b0db",
+   "timestamp": "2023-05-19T01:28:32.000Z"
+  },
+  "immortal/sound/gore_bite1.wav": {
+   "bytes": 233322,
+   "sha256": "40bedf9ba20f4815d083279731663e5038b74b864cf033f562508d4d16aac988",
+   "timestamp": "2023-05-17T22:16:40.000Z"
+  },
+  "immortal/sound/gore_bite2.wav": {
+   "bytes": 171880,
+   "sha256": "baa0edb5e0110287b97c476cd8be670cc11666accca6e5721815ba5773f845d5",
+   "timestamp": "2023-05-17T22:17:12.000Z"
+  },
+  "immortal/sound/gore_bitecont1.wav": {
+   "bytes": 528900,
+   "sha256": "50f39fb750af8449c0ca6982d1e64c0b7fcfea51e7a35962790bc53dcfc7ff4e",
+   "timestamp": "2023-05-19T01:39:02.000Z"
+  },
+  "immortal/sound/gore_breathe1.wav": {
+   "bytes": 1805386,
+   "sha256": "a81d82fd29b684ba9338ad370ed915b3db003dc55d772eb53c90ace8bc516517",
+   "timestamp": "2024-05-29T13:10:10.000Z"
+  },
+  "immortal/sound/gore_chew1.wav": {
+   "bytes": 472560,
+   "sha256": "7ca1c3e50c430cf9e8ee0bf98a539164d30b49f498085e0cd1e087631022da78",
+   "timestamp": "2024-05-29T13:08:12.000Z"
+  },
+  "immortal/sound/gore_guts1.wav": {
+   "bytes": 568698,
+   "sha256": "7d39dc17fa6e9777df1b4f4a9cfe951ace6a21a6755c8bed876a0d8cd3afefb2",
+   "timestamp": "2024-05-29T13:07:58.000Z"
+  },
+  "immortal/sound/gore_move1.wav": {
+   "bytes": 361410,
+   "sha256": "4650167fce8a4437feafdeeb3473023168a1326e74b23b46c380bf31c009e0be",
+   "timestamp": "2024-05-29T13:07:16.000Z"
+  },
+  "immortal/sound/gore_pierce1.wav": {
+   "bytes": 233458,
+   "sha256": "8dc0950700c054f1116ee21f58261d0c9ecbfc621d7be4c18ec879001234ae7d",
+   "timestamp": "2023-05-19T13:13:16.000Z"
+  },
+  "immortal/sound/gore_scream1.wav": {
+   "bytes": 492392,
+   "sha256": "869537c2c6721f6a6eb87878bab70116044b9dcfe70b9f76205626c1384cc6c8",
+   "timestamp": "2023-05-17T22:19:22.000Z"
+  },
+  "immortal/sound/gore_scream2.wav": {
+   "bytes": 1016970,
+   "sha256": "4f5a76c02c52385eb14e8a2a7efa57f9c4e2d55f9ecacc577d718d03e5658e99",
+   "timestamp": "2023-07-16T11:26:02.000Z"
+  },
+  "immortal/sound/gore_scream3.wav": {
+   "bytes": 4388668,
+   "sha256": "21f404480feb96bfba1347a6ca94d4697f8cae8a43541b9f506f39e084a422eb",
+   "timestamp": "2024-05-29T13:06:22.000Z"
+  },
+  "immortal/sound/gore_teleport1.wav": {
+   "bytes": 2117490,
+   "sha256": "12fd3f904f9436a59046ef3b5da9326799e301252ebbc4b409bcbe53ff64963b",
+   "timestamp": "2024-05-29T13:04:24.000Z"
+  },
+  "immortal/sound/lancfire.wav": {
+   "bytes": 6520,
+   "sha256": "be8d154ba1404462776ec3f5fbbda0e974970dd5d61d97cf296c3711ede5bb84",
+   "timestamp": "2024-07-16T00:02:28.000Z"
+  },
+  "immortal/sound/machine_active2.wav": {
+   "bytes": 1242782,
+   "sha256": "b05583886c024dcd650bd44d99d41d7906dd1414fa9dc2b56af80ed4d1c228d2",
+   "timestamp": "2024-05-29T13:03:24.000Z"
+  },
+  "immortal/sound/machine_active3.wav": {
+   "bytes": 561172,
+   "sha256": "c8c85b2e63d247d9cab269950f2a03a3fdebedcaa10299886e90cc131674d80e",
+   "timestamp": "2024-05-29T13:03:12.000Z"
+  },
+  "immortal/sound/machine_active4.wav": {
+   "bytes": 1024640,
+   "sha256": "c93df2573348bc56c06b31b5b66ade295795c89fac35e0d5045d967372b411fd",
+   "timestamp": "2024-05-29T13:02:58.000Z"
+  },
+  "immortal/sound/machine_broken1.wav": {
+   "bytes": 99220,
+   "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c",
+   "timestamp": "2023-02-19T22:56:42.000Z"
+  },
+  "immortal/sound/machine_door1.wav": {
+   "bytes": 563994,
+   "sha256": "6db963458887f6ff46769fe8733004ae62fb5cbe0c6f11bf46bdb2a9fd70dc82",
+   "timestamp": "2024-05-29T12:58:50.000Z"
+  },
+  "immortal/sound/machine_door2.wav": {
+   "bytes": 434718,
+   "sha256": "202ab1b8e715e06371ce24f0fc0b78fa51e53cb7e09c23dfadea979276f2695a",
+   "timestamp": "2024-05-29T12:58:08.000Z"
+  },
+  "immortal/sound/machine_door4.wav": {
+   "bytes": 850054,
+   "sha256": "1354a10e363236231ced081e9e33925cd6f430097df44b5e25e1aefcb8ba2ba9",
+   "timestamp": "2024-05-29T12:57:56.000Z"
+  },
+  "immortal/sound/machine_elevator1.wav": {
+   "bytes": 277516,
+   "sha256": "c854dd78b784e3f19611820c725fa39cabb1e14efe8e597019ba4e11e4225435",
+   "timestamp": "2024-06-15T00:09:08.000Z"
+  },
+  "immortal/sound/machine_elevatorstop1.wav": {
+   "bytes": 500674,
+   "sha256": "1245e5fe6823b5903a29cc80107a7554a1408a2904b006c0d0ab3c70f57fc6dc",
+   "timestamp": "2024-05-29T12:56:02.000Z"
+  },
+  "immortal/sound/machine_error1.wav": {
+   "bytes": 18260,
+   "sha256": "a5ff727f86b82d4c8bd805308a8108d1d6ac7075ecccd8f0dd424477d28c0656",
+   "timestamp": "2023-02-19T22:59:02.000Z"
+  },
+  "immortal/sound/machine_fan1.wav": {
+   "bytes": 607762,
+   "sha256": "156541e9b72d9a77ed4923d02f4b32646e7309ac1e7bf08ae7a6fb78f14922aa",
+   "timestamp": "2024-05-29T12:53:30.000Z"
+  },
+  "immortal/sound/machine_flyby1.wav": {
+   "bytes": 981820,
+   "sha256": "a00ab1e98d70ab7a1e462aef1a1872490021c4f525603569ccb306c4819a48d1",
+   "timestamp": "2024-05-30T14:23:54.000Z"
+  },
+  "immortal/sound/machine_flyby2.wav": {
+   "bytes": 1235490,
+   "sha256": "53a00c4d7b6434e86646cf4c33db35503a896e575831846bad3b469e94e0170d",
+   "timestamp": "2024-05-30T21:40:14.000Z"
+  },
+  "immortal/sound/machine_flyby3.wav": {
+   "bytes": 260406,
+   "sha256": "3fb54dce36de4164173ff68f2eed3a5b24a81c784b7d0758c29ba27620c11378",
+   "timestamp": "2020-01-17T15:59:16.000Z"
+  },
+  "immortal/sound/machine_forcefield1.wav": {
+   "bytes": 497334,
+   "sha256": "462b5f79ef064f5b2d6bb74040684fa1f4a44e635774de2283f0ad1e9f3cbb97",
+   "timestamp": "2024-05-29T12:50:44.000Z"
+  },
+  "immortal/sound/machine_jumppad3.wav": {
+   "bytes": 315198,
+   "sha256": "9265b1a1aef356b896d26b8fa7d36ec26e48eec3f2ddb1f4f6a3c9804f518acc",
+   "timestamp": "2023-05-06T14:26:38.000Z"
+  },
+  "immortal/sound/machine_laser1.wav": {
+   "bytes": 171144,
+   "sha256": "27c103347b9463906c3b439712e1fcba4f7fd8e811d50eda5311f5425a46c9f3",
+   "timestamp": "2023-07-12T15:17:14.000Z"
+  },
+  "immortal/sound/machine_laser2.wav": {
+   "bytes": 1323754,
+   "sha256": "8f87978eb44c5777bf0a5c35cf90e9bb087a8023c886741b19a6aa1713c8766a",
+   "timestamp": "2024-06-21T23:34:00.000Z"
+  },
+  "immortal/sound/machine_lift1.wav": {
+   "bytes": 583014,
+   "sha256": "2efe24977d1f4a66ad02c98179ffbc0368b139c6157f5104ca1e26760aa04c22",
+   "timestamp": "2024-05-29T12:49:38.000Z"
+  },
+  "immortal/sound/machine_liftbell1.wav": {
+   "bytes": 193792,
+   "sha256": "675ce2ead49c1b499a92d498300fd70ae315f1a1b1b9a05e4d9edae0ea6cca04",
+   "timestamp": "2023-07-19T19:31:24.000Z"
+  },
+  "immortal/sound/machine_nukeexplosion1.wav": {
+   "bytes": 1823418,
+   "sha256": "2717685d07e8384e9d406b9e339c89313702d453b43bf0f71b38bf774356c44f",
+   "timestamp": "2024-05-30T02:18:58.000Z"
+  },
+  "immortal/sound/machine_nukelaunch1.wav": {
+   "bytes": 4498890,
+   "sha256": "890a5cf09c78ed26bb4e13b1ad44b54e91083147caffd04831b4dcc74e0199e7",
+   "timestamp": "2024-05-30T02:00:54.000Z"
+  },
+  "immortal/sound/machine_pa1.wav": {
+   "bytes": 838636,
+   "sha256": "173620725618482de94aee512f14a8b14e06f9ee8e77498b72cc387eae894402",
+   "timestamp": "2023-07-16T01:43:04.000Z"
+  },
+  "immortal/sound/machine_pa10retreattofreightsix.wav": {
+   "bytes": 557394,
+   "sha256": "9f41b420125bd71ed3e1860473abaef0248b90ed3fe94a3e30d38e321cd8378c",
+   "timestamp": "2024-06-24T13:27:58.000Z"
+  },
+  "immortal/sound/machine_pa11reporttosilofour.wav": {
+   "bytes": 675142,
+   "sha256": "74faf1a5aaf26f2c23b1885f77b482bd27ed49819dbffc3cf3d30c9fefa499b1",
+   "timestamp": "2024-06-24T13:33:02.000Z"
+  },
+  "immortal/sound/machine_pa12reactorteleportoverload.wav": {
+   "bytes": 662972,
+   "sha256": "46cfefc0687e3f49fa409cba2a0e7fe452dd2bad9f48d16ebc641cb888108400",
+   "timestamp": "2024-06-24T13:38:40.000Z"
+  },
+  "immortal/sound/machine_pa2.wav": {
+   "bytes": 1103236,
+   "sha256": "5d8e816eec2be40ec0584b514d7a8df73b97f2835c33c0826d03e3272bfb9be6",
+   "timestamp": "2023-07-16T01:42:32.000Z"
+  },
+  "immortal/sound/machine_pa3slipgate.wav": {
+   "bytes": 706336,
+   "sha256": "6f58365272314aaea353e1acf38d9e2d41e5d639b262c4c6988964f508c50e58",
+   "timestamp": "2023-08-14T21:54:20.000Z"
+  },
+  "immortal/sound/machine_pa4nukeready.wav": {
+   "bytes": 662236,
+   "sha256": "c19a924c9acf24d0ab382856aa4b9d0e91d927eabfe6fe3befa374d479a04b51",
+   "timestamp": "2023-08-14T21:55:20.000Z"
+  },
+  "immortal/sound/machine_pa5nukelaunch.wav": {
+   "bytes": 1103236,
+   "sha256": "9e0416361f98f78bff5736283b65a96ef9fa485c258a634aabdf0d17c37ea52b",
+   "timestamp": "2023-08-14T21:55:38.000Z"
+  },
+  "immortal/sound/machine_pa6report.wav": {
+   "bytes": 930282,
+   "sha256": "3b33aa667aebbe97179a1cf6499b11dbaaa993ecea66f474bcf545e0c4287de1",
+   "timestamp": "2024-06-21T02:04:00.000Z"
+  },
+  "immortal/sound/machine_pa7scan.wav": {
+   "bytes": 1041560,
+   "sha256": "7fc8a67f48ef99456d2c02bd3286c046360fca7e77216c948c66b2c63d9e0936",
+   "timestamp": "2024-06-21T02:05:08.000Z"
+  },
+  "immortal/sound/machine_pa8authorized.wav": {
+   "bytes": 1008424,
+   "sha256": "27013f028802d2393600fe335b32dfd2d2495a1ec8f2031983ef3a1e74ad60c6",
+   "timestamp": "2024-06-21T02:06:14.000Z"
+  },
+  "immortal/sound/machine_pa9detonatecharges.wav": {
+   "bytes": 541926,
+   "sha256": "ce2748f172baedb6b59eb068b19cf211b971a80ae1412b02344411084db109fe",
+   "timestamp": "2024-06-24T13:22:30.000Z"
+  },
+  "immortal/sound/machine_pilot1.wav": {
+   "bytes": 465806,
+   "sha256": "76557fc63375c3f29dc7e86194abe29d4fa3fb49e74b1e76a198d7c3e487384c",
+   "timestamp": "2024-05-29T12:46:34.000Z"
+  },
+  "immortal/sound/machine_pilot2.wav": {
+   "bytes": 275242,
+   "sha256": "63e28f48ea8ccfb7c0aa15fb02051d79b739f2917ff887817eb6326e27d319c1",
+   "timestamp": "2019-11-01T17:54:10.000Z"
+  },
+  "immortal/sound/machine_powershutdown1.wav": {
+   "bytes": 1119156,
+   "sha256": "d1249afd2eb467f927dd37bce7467727d6c9d5ec4cc374c7ff93ff59a73cb7e1",
+   "timestamp": "2023-07-15T13:31:12.000Z"
+  },
+  "immortal/sound/machine_servo1.wav": {
+   "bytes": 322822,
+   "sha256": "f5f2a224aacead3bd3953410bb1f1e4075469311b4127fc694e42652a26bbe49",
+   "timestamp": "2024-06-21T23:04:58.000Z"
+  },
+  "immortal/sound/machine_sirentornado.wav": {
+   "bytes": 409132,
+   "sha256": "793bb573cfa13890fed938c1e8259b2218480f2e4769c56e9060010d5d5c4270",
+   "timestamp": "2022-05-20T01:39:08.000Z"
+  },
+  "immortal/sound/machine_smoosh2.wav": {
+   "bytes": 156726,
+   "sha256": "b97987d279ad3e1cf534f5d5965df742c92e65805af591f42d7cfa7eaad75804",
+   "timestamp": "2023-07-26T23:54:26.000Z"
+  },
+  "immortal/sound/machine_static1.wav": {
+   "bytes": 407892,
+   "sha256": "cb8d8c453b24ff09d8c5a4a831fe000cac660370633cc9f3cec3da22b85f2e85",
+   "timestamp": "2023-07-27T00:59:06.000Z"
+  },
+  "immortal/sound/machine_steam1.wav": {
+   "bytes": 330762,
+   "sha256": "4e4192b5e4c12efe8bc0623e286469592e60e33aaadd9b4d5cced93ab62606a0",
+   "timestamp": "2024-05-29T12:45:32.000Z"
+  },
+  "immortal/sound/machine_steam2.wav": {
+   "bytes": 407594,
+   "sha256": "325d71d27d3f140f81180386437657fc0c0b0cec815bfc972c5d198b89ad0d1d",
+   "timestamp": "2024-05-29T12:45:18.000Z"
+  },
+  "immortal/sound/machine_switch1.wav": {
+   "bytes": 397942,
+   "sha256": "4f6ae4524f5c2c3773ea35add05124f45c8ec36dca5299ecf220c5c0491368a1",
+   "timestamp": "2024-05-29T12:44:50.000Z"
+  },
+  "immortal/sound/machine_switch2.wav": {
+   "bytes": 441438,
+   "sha256": "1807ee379cc75d0b80d624ffbaa66daf0983a6524c3270aab8bf5ed5d42800d4",
+   "timestamp": "2024-05-29T12:43:08.000Z"
+  },
+  "immortal/sound/machine_teleport1.wav": {
+   "bytes": 276932,
+   "sha256": "92f12f797c8e58373cadaa6f3393de357715e4bf544dc84743547b37b483078b",
+   "timestamp": "2023-07-26T22:44:18.000Z"
+  },
+  "immortal/sound/null.wav": {
+   "bytes": 28300,
+   "sha256": "2d3a34bd365f8c9001bcc04f5c8ccff48de47a3ab866065437d881ea2a88a10f",
+   "timestamp": "2022-04-20T11:10:24.000Z"
+  },
+  "immortal/sound/occult_active1.wav": {
+   "bytes": 1074378,
+   "sha256": "cb68ee1b0d5354fa746c128484e7ef9afbbaf70727e8922ae9a2e2a175ab680f",
+   "timestamp": "2024-05-29T12:41:50.000Z"
+  },
+  "immortal/sound/occult_active3.wav": {
+   "bytes": 299466,
+   "sha256": "65dd43a57b93e7350705003374b4b55c2e9bd55635a4725a54e49ec9fbbec8c4",
+   "timestamp": "2024-05-29T12:41:34.000Z"
+  },
+  "immortal/sound/occult_active4.wav": {
+   "bytes": 706290,
+   "sha256": "2fd70f5b526170cfd11d27b969f314b464e47fbbae0c8b6cae56ba6eaee5b218",
+   "timestamp": "2024-05-29T12:41:22.000Z"
+  },
+  "immortal/sound/occult_drone1.wav": {
+   "bytes": 2216980,
+   "sha256": "16958b3276893f50df87abe0d2ced1ff8ffd0cfc197c502ffd67450de9304a4e",
+   "timestamp": "2024-05-29T12:40:40.000Z"
+  },
+  "immortal/sound/occult_laugh1.wav": {
+   "bytes": 477186,
+   "sha256": "2d87e643cf69efecbd195115b798a54256d20da854b1603b944753417ff1085b",
+   "timestamp": "2023-07-16T11:26:52.000Z"
+  },
+  "immortal/sound/occult_portalwhispers.wav": {
+   "bytes": 3288894,
+   "sha256": "1418774bf4467c3857f89060908dd77b30cd7319697c3abe8c43c637dc8b15d4",
+   "timestamp": "2024-06-21T22:14:48.000Z"
+  },
+  "immortal/sound/plasexpl.wav": {
+   "bytes": 54406,
+   "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b",
+   "timestamp": "2024-07-15T23:57:44.000Z"
+  },
+  "immortal/sound/runekey.wav": {
+   "bytes": 154850,
+   "sha256": "b93b5693313839fa8b07dcb33e2f73c10bf23b362e456a22a9d84a1ec2d52278",
+   "timestamp": "2024-06-05T23:14:48.000Z"
+  },
+  "immortal/sound/scream1.wav": {
+   "bytes": 135674,
+   "sha256": "f5875323ffa9f7d0db3d690bc8b1fbfff820143c5aa2ab5ebc52496116eb3235",
+   "timestamp": "2022-04-03T16:58:56.000Z"
+  },
+  "immortal/sound/stone_door3.wav": {
+   "bytes": 272570,
+   "sha256": "d551b0451f3fee3b69770cb9e4c2adde8f74d9e84630009cc125719a09bdbd6a",
+   "timestamp": "2024-05-29T12:39:42.000Z"
+  },
+  "immortal/sound/stone_smash2.wav": {
+   "bytes": 135482,
+   "sha256": "a17107bf0ff3c3a0c8806e937d0ae23d0f4432dc335a454a46e7ac7af8ba2720",
+   "timestamp": "2024-05-29T12:38:48.000Z"
+  },
+  "immortal/sound/weapon_railcharge1.wav": {
+   "bytes": 280134,
+   "sha256": "dd15bd98743ce68c510a3985c2e755f4452d6108217a154636039243b87b237f",
+   "timestamp": "2024-05-29T12:36:44.000Z"
+  },
+  "immortal/sound/weapon_railfire1.wav": {
+   "bytes": 221322,
+   "sha256": "83753a3e666c97bc176829f28ebaf6db01c31bc1c0ce3b75760ae4e95c0d9aa1",
+   "timestamp": "2024-05-29T12:35:50.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "notes": [
+  "This map has specific technical requirements, please see the included readme for details."
+ ],
+ "sha256": "a04aee22a146df6dd97db37932c7c96028307dab4f6f96e15944bd0e5006bd5b",
+ "tags": [
+  "author=ComfyByTheFire",
+  "commandline=-game immortal",
+  "exceeds_quake_limits=yes",
+  "filename=immortal_v1_9.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/the-immortal-lock.371/)",
+  "release_date=2024-08-04",
+  "startmap=start",
+  "title=The Immortal Lock",
+  "type=map",
+  "type=mod"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/immortal_v1_9.zip"
+ ]
+}

--- a/json/by-sha256/aa/aa592ef23cc6d51ef4f5a8435239475f2e719e30e1cf3797eb7ae1ce7fddbd3a.json
+++ b/json/by-sha256/aa/aa592ef23cc6d51ef4f5a8435239475f2e719e30e1cf3797eb7ae1ce7fddbd3a.json
@@ -1,0 +1,41 @@
+{
+ "bytes": 1112573,
+ "description": "Small, bright map in a temple/metal style.",
+ "files": {
+  "dltomb.bsp": {
+   "bytes": 2667952,
+   "sha256": "28b1d7d2dfdf4dfe2384be4c4f5686d548ef8c15636e946f41322f85135fbca9",
+   "timestamp": "2024-08-26T13:45:48.000Z"
+  },
+  "dltomb.pts": {
+   "bytes": 79388,
+   "sha256": "78ec7872938caea23d4cafa6c067faacc85442c21611a8fa3bc4ca98a83a222b",
+   "timestamp": "2024-08-25T22:00:56.000Z"
+  },
+  "dltomb.txt": {
+   "bytes": 400,
+   "sha256": "5b07a17eb27b99f5130e91cfca9813e1032036a5231a9ef9333f5cef94b337b3",
+   "timestamp": "2024-08-26T13:51:18.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/id1/maps/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "sha256": "aa592ef23cc6d51ef4f5a8435239475f2e719e30e1cf3797eb7ae1ce7fddbd3a",
+ "tags": [
+  "author=GraveyardKaiser",
+  "filename=dltomb.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/dimensionless-tomb.389/)",
+  "release_date=2024-08-26",
+  "startmap=dltomb",
+  "title=Dimensionless Tomb",
+  "type=map",
+  "zipbasedir=id1/maps/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/dltomb.zip"
+ ]
+}

--- a/json/by-sha256/ad/ad4680243ca40c96a1d91548f7c611ddbffe1c74ff7c95b64d8caac27d03b643.json
+++ b/json/by-sha256/ad/ad4680243ca40c96a1d91548f7c611ddbffe1c74ff7c95b64d8caac27d03b643.json
@@ -1,0 +1,41 @@
+{
+ "bytes": 2582171,
+ "description": "A map set in a medieval village.",
+ "files": {
+  "vill.bsp": {
+   "bytes": 4331064,
+   "sha256": "5e5e7a5c33e32dddffb7a58b4382fccc2be4428b93406b3ef265cb78d853ad27",
+   "timestamp": "2024-07-29T20:38:32.000Z"
+  },
+  "vill.prt": {
+   "bytes": 1878186,
+   "sha256": "dfa13c6ec0c09c95a0c069ea0033cd1dfe13c87552e0da7f0c13c669d460a8f0",
+   "timestamp": "2024-07-29T20:38:28.000Z"
+  },
+  "vill.vis": {
+   "bytes": 6847051,
+   "sha256": "f5340b4c8886b8aa30fea220b4a00ea94ec0bdc456c6019c9c6cc2f7506bbf34",
+   "timestamp": "2024-07-29T20:21:20.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/id1/maps/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "sha256": "ad4680243ca40c96a1d91548f7c611ddbffe1c74ff7c95b64d8caac27d03b643",
+ "tags": [
+  "author=GraveyardKaiser",
+  "filename=vill.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/decomposed-village.377/)",
+  "release_date=2024-07-29",
+  "startmap=vill",
+  "title=Decomposed Village",
+  "type=map",
+  "zipbasedir=id1/maps/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/vill.zip"
+ ]
+}

--- a/json/by-sha256/af/af15a52a05724e7a2885572c37e3b37967a942e03a8a357b7731eeb3da0be773.json
+++ b/json/by-sha256/af/af15a52a05724e7a2885572c37e3b37967a942e03a8a357b7731eeb3da0be773.json
@@ -1,0 +1,41 @@
+{
+ "bytes": 842415,
+ "description": "Small metal map set in a 'space station'.",
+ "files": {
+  "fbkmor.bsp": {
+   "bytes": 1790436,
+   "sha256": "f51fb22f0d808898388e34a129dd7926daf3a0e8e79105591d58d0532c156641",
+   "timestamp": "2024-08-08T14:26:40.000Z"
+  },
+  "fbkmor.pts": {
+   "bytes": 192440,
+   "sha256": "3c568430b93e954cdd35c66f87db1c7aee7c9ca755a4c8914ed9fdee7e4c391f",
+   "timestamp": "2024-08-08T14:26:40.000Z"
+  },
+  "fbkmor.txt": {
+   "bytes": 395,
+   "sha256": "54a739391ed47ab584b1a0f236679b0069a9f42fdd4c46d2066d9e0934f4dd62",
+   "timestamp": "2024-08-08T14:29:22.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/id1/maps/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "sha256": "af15a52a05724e7a2885572c37e3b37967a942e03a8a357b7731eeb3da0be773",
+ "tags": [
+  "author=GraveyardKaiser",
+  "filename=fbkmor.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/fabrika-mortis.382/)",
+  "release_date=2024-08-08",
+  "startmap=fbkmor",
+  "title=Fabrika Mortis",
+  "type=map",
+  "zipbasedir=id1/maps/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/fbkmor.zip"
+ ]
+}

--- a/json/by-sha256/bf/bf58cae9e7863f4de259d46cc91bad8fa5256d2489113f65826e67fa4e485372.json
+++ b/json/by-sha256/bf/bf58cae9e7863f4de259d46cc91bad8fa5256d2489113f65826e67fa4e485372.json
@@ -1,0 +1,41 @@
+{
+ "bytes": 3625274,
+ "description": "Small map with abstract designs and mainly outdoor settings, with nightmare difficulty automatically enabled. The author's first map.",
+ "files": {
+  "rcavup.bsp": {
+   "bytes": 9549632,
+   "sha256": "ac7687987322130a32f0d313cfb01c8c2be62b883bb4f9c97d2a632d525522ba",
+   "timestamp": "2024-07-24T21:02:10.000Z"
+  },
+  "rcavup.pts": {
+   "bytes": 370377,
+   "sha256": "6a2e63156c74760afa5c3e171a7dcec7785d32513ecbd9fc6dc28a8a5bc0999d",
+   "timestamp": "2024-07-24T21:01:34.000Z"
+  },
+  "rcavup.txt": {
+   "bytes": 750,
+   "sha256": "a03b0f2b30e5165486cba4c0c8760f5ccd6d5ee708b4fc88f3a6adfe16451d15",
+   "timestamp": "2024-07-24T21:06:52.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/id1/maps/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "sha256": "bf58cae9e7863f4de259d46cc91bad8fa5256d2489113f65826e67fa4e485372",
+ "tags": [
+  "author=GraveyardKaiser",
+  "filename=recavup.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/rotten-caverns-my-first-map-skill-selector-added-some-sealing-fixes.374/)",
+  "release_date=2024-07-24",
+  "startmap=rcavup",
+  "title=Rotten Caverns",
+  "type=map",
+  "zipbasedir=id1/maps/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/recavup.zip"
+ ]
+}

--- a/json/by-sha256/c2/c2aeb0d8ef632f3c66d48244270058d20029bf3c97a3f96ada67f47d20c3b3b3.json
+++ b/json/by-sha256/c2/c2aeb0d8ef632f3c66d48244270058d20029bf3c97a3f96ada67f47d20c3b3b3.json
@@ -1,0 +1,41 @@
+{
+ "bytes": 1386770,
+ "description": "Small, story-driven map where you refuel a plane to escape from a facility.",
+ "files": {
+  "acidni.bsp": {
+   "bytes": 3045728,
+   "sha256": "a262a74b539e28a82ceed127d8c93dfd89072689762ee3cf3a2a5f00cd24d9ed",
+   "timestamp": "2024-07-24T00:05:20.000Z"
+  },
+  "acidni.pts": {
+   "bytes": 152213,
+   "sha256": "f9ae0fe93382e68dfa8b18cfe04a469d0b000126c81cd3ea7fe08cced0facf6c",
+   "timestamp": "2024-07-24T00:05:16.000Z"
+  },
+  "acidni.txt": {
+   "bytes": 613,
+   "sha256": "3704a0f6da8dc27bf17a73129ed10f660077833b0d83f423add74aac8ed0c2d5",
+   "timestamp": "2024-07-24T00:09:14.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/id1/maps/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "sha256": "c2aeb0d8ef632f3c66d48244270058d20029bf3c97a3f96ada67f47d20c3b3b3",
+ "tags": [
+  "author=GraveyardKaiser",
+  "filename=acidni.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/acid-plane.375/)",
+  "release_date=2024-07-24",
+  "startmap=acidni",
+  "title=Acid Plane",
+  "type=map",
+  "zipbasedir=id1/maps/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/acidni.zip"
+ ]
+}

--- a/json/by-sha256/d8/d811423b06f1fa6a02f23f8c502d8bb766189521d11ad02c2adcf870f035adc0.json
+++ b/json/by-sha256/d8/d811423b06f1fa6a02f23f8c502d8bb766189521d11ad02c2adcf870f035adc0.json
@@ -1,0 +1,260 @@
+{
+ "bytes": 103067109,
+ "description": "Five map episode (plus start map) in a minimal, brutalist style with heavy use of fog and intense combat.",
+ "files": {
+  "gfx/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-06-17T23:59:04.000Z"
+  },
+  "gfx/env/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-06-17T23:59:04.000Z"
+  },
+  "gfx/env/plainwhite_bk.tga": {
+   "bytes": 8731,
+   "sha256": "f7131e686a81c2d08c03bcc9bc7b7e6cb0d8aff1c962e8d0f9403e65f6fbd84e",
+   "timestamp": "2023-10-11T17:01:18.000Z"
+  },
+  "gfx/env/plainwhite_dn.tga": {
+   "bytes": 8731,
+   "sha256": "11c7b68110ab9cc7fb6c4e252eabd13b8d13bd0f4ceecb2a76c5082b53761d10",
+   "timestamp": "2023-10-11T17:01:12.000Z"
+  },
+  "gfx/env/plainwhite_ft.tga": {
+   "bytes": 8731,
+   "sha256": "345976356193f988d7b8989614df0b9023d411c22b6c4cb2a721f5bd6f4e84af",
+   "timestamp": "2023-10-11T17:01:26.000Z"
+  },
+  "gfx/env/plainwhite_lf.tga": {
+   "bytes": 8731,
+   "sha256": "3a7e524c6bfe8c76b6b9fe8231a2bb8f14e0798727a9afbae4ea465b19eb8647",
+   "timestamp": "2023-10-11T17:01:36.000Z"
+  },
+  "gfx/env/plainwhite_rt.tga": {
+   "bytes": 8731,
+   "sha256": "c5076bb64e37015ab2e78c2fe2f96cba422907b538bde27c20a2d728570f7103",
+   "timestamp": "2023-10-11T17:01:48.000Z"
+  },
+  "gfx/env/plainwhite_up.tga": {
+   "bytes": 8731,
+   "sha256": "ce96f32346d0901a24cf456a1ef7645b6695b8150d6257550e5e47331724457f",
+   "timestamp": "2023-10-11T17:01:54.000Z"
+  },
+  "maps/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-07-29T22:47:24.000Z"
+  },
+  "maps/null1.bsp": {
+   "bytes": 12146872,
+   "sha256": "e7df1d26f286cd0f7e006848540af8d18bb576f98a663d3a80c560fbb9ebfae8",
+   "timestamp": "2024-07-28T21:49:22.000Z"
+  },
+  "maps/null1.lit": {
+   "bytes": 2452205,
+   "sha256": "fdf650988ebe9073fd43ad334897cf11fecfd55f5ddeb0f3aa9e713eebfa417e",
+   "timestamp": "2024-07-28T21:49:22.000Z"
+  },
+  "maps/null2.bsp": {
+   "bytes": 8065596,
+   "sha256": "de7737440978920a8b01c9cc2c99ebb9e2e3ad4b2a4976e00362e728a023e050",
+   "timestamp": "2024-07-18T19:47:56.000Z"
+  },
+  "maps/null2.lit": {
+   "bytes": 2895779,
+   "sha256": "a815d60ab76f7338378c28511f85f7d46f12f1cc86999547cb253f8ee7a847cf",
+   "timestamp": "2024-07-18T19:47:56.000Z"
+  },
+  "maps/null3.bsp": {
+   "bytes": 8886488,
+   "sha256": "6220a8b223723248363f128cd19b0556efbf24a1e7d4a6cb2ac2cf38cf9e27e6",
+   "timestamp": "2024-07-19T16:29:24.000Z"
+  },
+  "maps/null3.lit": {
+   "bytes": 2902052,
+   "sha256": "c4c2a1aaf35d903080f1f8840326294a266fe75ad1c35b352800e23a27585f3b",
+   "timestamp": "2024-07-19T16:29:24.000Z"
+  },
+  "maps/null4.bsp": {
+   "bytes": 16351472,
+   "sha256": "2ed71998dde11973f228cdb1d1cd10288ad6dde4e5a01a60ad9dcd90e57b4a4d",
+   "timestamp": "2024-07-29T22:45:44.000Z"
+  },
+  "maps/null4.lit": {
+   "bytes": 4210445,
+   "sha256": "9bdf2a4ce182ffe7b69537bd9d71f6587fe2896514554369a23a6af98d8a9259",
+   "timestamp": "2024-07-29T22:45:44.000Z"
+  },
+  "maps/null5.bsp": {
+   "bytes": 5944240,
+   "sha256": "97a641ee64aa37e6e268cd41056c29e96f42fb0840e08bf74aa1b5dd0d6eb3e6",
+   "timestamp": "2024-07-20T14:16:02.000Z"
+  },
+  "maps/null5.lit": {
+   "bytes": 2152319,
+   "sha256": "a825575a7374ecc868c612f8c9c4ffc9c873ccf5b478bc2f8474bcc74046bbb5",
+   "timestamp": "2024-07-20T14:16:02.000Z"
+  },
+  "maps/start.bsp": {
+   "bytes": 8484508,
+   "sha256": "60c6be061442aa25696aaa3b7e519f4f9aa8b6c8d488e68f238ec7ad18c969b8",
+   "timestamp": "2024-07-29T01:51:24.000Z"
+  },
+  "maps/start.lit": {
+   "bytes": 2174720,
+   "sha256": "ffaf5e0cfec9aa79bf35e12bab72b6cfa54803208ed681d0f21b82f961982d69",
+   "timestamp": "2024-07-29T01:51:24.000Z"
+  },
+  "mapsrc/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-07-29T22:47:26.000Z"
+  },
+  "mapsrc/null1.map": {
+   "bytes": 1503316,
+   "sha256": "d0dc5be63af8411beceb23a47fa8d72555f1ca4e87dfbf7e02fff5d6a75e48ad",
+   "timestamp": "2024-07-28T21:48:30.000Z"
+  },
+  "mapsrc/null2.map": {
+   "bytes": 725951,
+   "sha256": "97bdf36181760fceb9dfd3381623640f917087c89cf9e81743231068b013a3d3",
+   "timestamp": "2024-07-18T19:32:38.000Z"
+  },
+  "mapsrc/null3.map": {
+   "bytes": 1180019,
+   "sha256": "850e58b77612d07de11107fc11038f8aac30096d153ebd9553f5853251acafe0",
+   "timestamp": "2024-07-19T16:27:56.000Z"
+  },
+  "mapsrc/null4.map": {
+   "bytes": 2374493,
+   "sha256": "13c9486ccc19d31818df7f6f9d3c568cf9405dc4167e1847bc76ad3761fdf3d9",
+   "timestamp": "2024-07-29T22:43:44.000Z"
+  },
+  "mapsrc/null5.map": {
+   "bytes": 1205643,
+   "sha256": "fa95f9379ee3c8462c5bfc95cd66c7d17886179fdb0eb8e2dd30d62d37dc2d63",
+   "timestamp": "2024-07-20T14:14:52.000Z"
+  },
+  "mapsrc/nullstart.map": {
+   "bytes": 833310,
+   "sha256": "077e5d67d91e93e0d03c938200627197527b57b7242d1d3224a41217c1baa322",
+   "timestamp": "2024-07-29T01:50:18.000Z"
+  },
+  "models/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-06-30T02:42:22.000Z"
+  },
+  "models/rune_n3.mdl": {
+   "bytes": 21812,
+   "sha256": "38cb7486bdc99c2f0c8e9f194293db248e67c26afc3ee5ed6f6822f9d8eab745",
+   "timestamp": "2021-10-23T05:19:56.000Z"
+  },
+  "music/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-07-31T15:35:20.000Z"
+  },
+  "music/track03.ogg": {
+   "bytes": 8953691,
+   "sha256": "ebf5e01ccd297bc02bc9ebbcf73e1e08ae984ceb169ad4311499b78567193ef4",
+   "timestamp": "2024-06-28T03:25:20.000Z"
+  },
+  "music/track15.ogg": {
+   "bytes": 8540013,
+   "sha256": "d4962a1db3c2e8a96397bb24b32bb43ce84437e88b4edacf2f27bb22d2afb65f",
+   "timestamp": "2023-12-09T20:07:02.000Z"
+  },
+  "music/track16.ogg": {
+   "bytes": 11034650,
+   "sha256": "0c6313ebb7d52faabc069081cbd03f46c254e4a944b849c6adcc352037afafcf",
+   "timestamp": "2024-02-03T10:58:28.000Z"
+  },
+  "music/track17.ogg": {
+   "bytes": 7934367,
+   "sha256": "6fab0945db5106060587865a122787092256ba27b770015a76082c34b0ac9cc5",
+   "timestamp": "2023-12-09T20:07:06.000Z"
+  },
+  "music/track18.ogg": {
+   "bytes": 3983750,
+   "sha256": "d78dfa5b9f09b36fbde3d70df17da723426848c5b195618819cbc8593ad3c70e",
+   "timestamp": "2024-03-02T04:47:20.000Z"
+  },
+  "music/track19.ogg": {
+   "bytes": 15775072,
+   "sha256": "3d347d9cc6f93305b80be71295f62d8b92d5836368d7ec160759164d854271bd",
+   "timestamp": "2023-12-09T20:08:12.000Z"
+  },
+  "music/track20.ogg": {
+   "bytes": 13896181,
+   "sha256": "b9990ef3f56297166a496a09d3224d7b6568893bfbe559530a0816688fdf430f",
+   "timestamp": "2024-06-28T03:26:32.000Z"
+  },
+  "txt/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-07-29T03:20:30.000Z"
+  },
+  "txt/Nullspace I (readme).txt": {
+   "bytes": 7932,
+   "sha256": "18b364673ccba801798dd585dd9a5aab4e6d2a55d355a7cd36c76d459320228f",
+   "timestamp": "2024-07-31T15:42:36.000Z"
+  },
+  "txt/Nullspace II (readme).txt": {
+   "bytes": 8057,
+   "sha256": "c78401f6763fdf5ab090bc9255038d8ce0542ae960ab31172429a1c3e343f740",
+   "timestamp": "2024-07-12T04:50:02.000Z"
+  },
+  "txt/Nullspace III (readme).txt": {
+   "bytes": 8305,
+   "sha256": "bf662679d7d849dbd1a0f5ade9614d92c217c66ec2b5796e9a875fd88446b53d",
+   "timestamp": "2024-07-12T04:50:30.000Z"
+  },
+  "txt/Nullspace IV (readme).txt": {
+   "bytes": 7695,
+   "sha256": "ecee539338acca0b11b4ccd261f556bacc7b68b9806d5f0af8c901d632ddaafd",
+   "timestamp": "2024-07-12T05:49:02.000Z"
+  },
+  "txt/Nullspace V (readme).txt": {
+   "bytes": 10139,
+   "sha256": "96acfec3538541a9b12356182596a5e567ef7c17526050e622b2cf1f5676c4f6",
+   "timestamp": "2024-07-28T21:51:16.000Z"
+  },
+  "txt/The Nullspace (Startmap and Episode Readme).txt": {
+   "bytes": 19770,
+   "sha256": "b650338b5a5e0d58813f19c916ec43d0fc0e8319016f5bb73608b61d6deb7fab",
+   "timestamp": "2024-07-29T03:20:06.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/copper/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "notes": [
+  "This map requires <a href=\"2932bdfda11224125c3f7207701bed8c4b7a765a2370a581589a5e17337b7eb8\">Copper</a>.",
+  "May require a source port with increased limits / BSP2 support."
+ ],
+ "sha256": "d811423b06f1fa6a02f23f8c502d8bb766189521d11ad02c2adcf870f035adc0",
+ "tags": [
+  "author=ExaByt",
+  "commandline=-game copper",
+  "dependency=copper_v1_30",
+  "depends=('copper=1.30')",
+  "exceeds_quake_limits=yes",
+  "filename=nullspace_v1.0.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/the-nullspace.379/)",
+  "mod=copper",
+  "release_date=2024-07-31",
+  "startmap=start",
+  "title=The Nullspace",
+  "type=episode",
+  "zipbasedir=copper/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/nullspace_v1.0.zip"
+ ]
+}

--- a/json/by-sha256/de/dee9623f95eff90701883a0b96d6b3a6adf2feae77e0c74f0864b3258c76a933.json
+++ b/json/by-sha256/de/dee9623f95eff90701883a0b96d6b3a6adf2feae77e0c74f0864b3258c76a933.json
@@ -1,0 +1,2526 @@
+{
+ "bytes": 154219071,
+ "description": "Episode of five increasingly large main maps (plus start, end and secret level) progressing from an industrial theme through to a gothic/temple finale. Includes several new monsters and weapons.",
+ "files": {
+  "tombofthunder/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-10-02T22:55:38.000Z"
+  },
+  "tombofthunder/LibreQuake docs.zip": {
+   "bytes": 14973,
+   "files": {
+    "docs/COPYING": {
+     "bytes": 1697,
+     "sha256": "c3426ae10fd52ab1a3c3d4de4f2fae60543403e3cfd09ae5dc2ec16ae4717d28",
+     "timestamp": "2024-05-15T17:33:40.000Z"
+    },
+    "docs/CREDITS": {
+     "bytes": 3254,
+     "sha256": "60b632851de3e5d02cb96ed158ff06700ced1c9fb6425f2d5d10509392021bd0",
+     "timestamp": "2024-05-15T17:33:40.000Z"
+    },
+    "docs/freedoom-docs/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2024-05-15T17:33:40.000Z"
+    },
+    "docs/freedoom-docs/COPYING.adoc": {
+     "bytes": 1611,
+     "sha256": "07b1d04bb498dfcce23bc186bf72ae0356f67c1f90361e9d2394e54b296facc8",
+     "timestamp": "2024-05-15T17:33:40.000Z"
+    },
+    "docs/freedoom-docs/CREDITS": {
+     "bytes": 14715,
+     "sha256": "dc39ff7086cffed47aabe8dbfff160916f8043c4aa9f6156310d5d9cf2dd69ee",
+     "timestamp": "2024-05-15T17:33:40.000Z"
+    },
+    "docs/freedoom-docs/README.adoc": {
+     "bytes": 11713,
+     "sha256": "67a9250b25fb2313cbf4c76295df6f9483a7370fbc59e2db222ab59edbf2a75e",
+     "timestamp": "2024-05-15T17:33:40.000Z"
+    }
+   },
+   "sha256": "1c93d84804a35349a2e09f21c3ef2fa5ef732aa10c756b882d3caf18a7f974ae",
+   "timestamp": "2024-05-18T23:14:36.000Z"
+  },
+  "tombofthunder/TOMBOFTHUNDER2024_README.txt": {
+   "bytes": 12973,
+   "sha256": "25e7abc6c335179e43f8331c5c9e7d88794513e62b4687310836e838ecf7a283",
+   "timestamp": "2024-07-24T10:00:00.000Z"
+  },
+  "tombofthunder/Tomb of Thunder - Secrets guide.docx": {
+   "bytes": 10513,
+   "sha256": "b6488194509e47ffa2feba1f4e5becc818f641cd3f5ea5cfda309dafe4f31807",
+   "timestamp": "2024-07-01T11:26:24.000Z"
+  },
+  "tombofthunder/autoconfig.cfg": {
+   "bytes": 7,
+   "sha256": "52808d039973d98b4c74d9b20728ae1d4d6a427a3ce72289f7c8943e80a1a0a2",
+   "timestamp": "2024-05-15T08:22:00.000Z"
+  },
+  "tombofthunder/demo1.dem": {
+   "bytes": 11026362,
+   "sha256": "2046f664a8b89e6039d38954091b801930b69153935b37df9f0d8cb0612bf015",
+   "timestamp": "2024-05-16T16:57:42.000Z"
+  },
+  "tombofthunder/demo2.dem": {
+   "bytes": 9506290,
+   "sha256": "c13198472600ab08cc8d90e9036defdedd2a47b9f5dd05bb3f8de19372b628fd",
+   "timestamp": "2024-05-16T16:59:38.000Z"
+  },
+  "tombofthunder/demo3.dem": {
+   "bytes": 12504719,
+   "sha256": "63b76764eb1cff4f3f4cb3b624955ad25ae8caf5c7950f94c5da1d2cc237c887",
+   "timestamp": "2024-05-16T17:02:18.000Z"
+  },
+  "tombofthunder/gfx/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2022-10-19T22:00:04.000Z"
+  },
+  "tombofthunder/gfx/conback.lmp": {
+   "bytes": 307208,
+   "sha256": "8d3814bcbfa7168685dd1044504d3a422b8619b2ff6d87208203b79cd8f970db",
+   "timestamp": "2021-01-27T16:33:50.000Z"
+  },
+  "tombofthunder/gfx/conbackog.lmp": {
+   "bytes": 307208,
+   "sha256": "799d1ce56f3d54d13f58663325cc687e777cd8c4cb82c63f43c874a5eb793767",
+   "timestamp": "2021-01-27T16:05:48.000Z"
+  },
+  "tombofthunder/gfx/env/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2023-12-21T17:21:18.000Z"
+  },
+  "tombofthunder/gfx/env/atsea_bk.tga": {
+   "bytes": 632859,
+   "sha256": "0170bac6e1114edec6fd9add7dd474b24dc047d4a1e05518b9bd5eb03444e827",
+   "timestamp": "2003-02-09T11:02:52.000Z"
+  },
+  "tombofthunder/gfx/env/atsea_dn.tga": {
+   "bytes": 574894,
+   "sha256": "0c1498451cd053afe41d6409ba14b156608623d316708d6a7e49383355b93fbd",
+   "timestamp": "2003-02-09T11:02:56.000Z"
+  },
+  "tombofthunder/gfx/env/atsea_ft.tga": {
+   "bytes": 578784,
+   "sha256": "9542abd9f7b51885b945f184e779caf83722f49dcbd1d623aba5424302fc07eb",
+   "timestamp": "2003-02-09T11:02:50.000Z"
+  },
+  "tombofthunder/gfx/env/atsea_lf.tga": {
+   "bytes": 603631,
+   "sha256": "a97250f90147c6633efdfe4a81234cf488a8e4b67f64352e8b009f3542be94e5",
+   "timestamp": "2003-02-09T11:02:50.000Z"
+  },
+  "tombofthunder/gfx/env/atsea_rt.tga": {
+   "bytes": 661491,
+   "sha256": "171aff8c805afccb39a373b4b41263650313082e00d8c1e9b6370b5a7b535e9f",
+   "timestamp": "2003-02-09T11:02:54.000Z"
+  },
+  "tombofthunder/gfx/env/atsea_up.tga": {
+   "bytes": 634513,
+   "sha256": "1bad6c1b80666490aefcedbc46821cbecec2c2c766197fb15b90954a0be21b0e",
+   "timestamp": "2003-02-09T11:02:58.000Z"
+  },
+  "tombofthunder/gfx/env/ofelas_bk.tga": {
+   "bytes": 478922,
+   "sha256": "3f92c428da1353c3d28ef05162cdfcc57c79cbda679196b7f2eb4d9430d4f835",
+   "timestamp": "2004-09-06T17:01:36.000Z"
+  },
+  "tombofthunder/gfx/env/ofelas_dn.tga": {
+   "bytes": 643000,
+   "sha256": "bee478075b3909db7f7f2b1ef4b4ccc621a9ef587edfe790ecc92f718ca80230",
+   "timestamp": "2004-09-06T17:01:36.000Z"
+  },
+  "tombofthunder/gfx/env/ofelas_ft.tga": {
+   "bytes": 515988,
+   "sha256": "ac6ee09da7578713d91d261d4667bbe580df55a487c30726f05bb75e89839b5c",
+   "timestamp": "2004-09-06T17:01:36.000Z"
+  },
+  "tombofthunder/gfx/env/ofelas_lf.tga": {
+   "bytes": 413651,
+   "sha256": "0377e4985a3babcc9baa8a2b1aa4fe755bbea46ec57c50efd2e7f5628cf1a619",
+   "timestamp": "2004-09-06T17:01:36.000Z"
+  },
+  "tombofthunder/gfx/env/ofelas_rt.tga": {
+   "bytes": 587061,
+   "sha256": "dc0bf02b9ee7a8463546d29eeddcad0e191a5b0d0f8086f522301956b60db51b",
+   "timestamp": "2004-09-06T17:01:36.000Z"
+  },
+  "tombofthunder/gfx/env/ofelas_up.tga": {
+   "bytes": 22362,
+   "sha256": "cd74413cbf0113173ed742802a7c663d348cffe0dee40defd997377b067eb18f",
+   "timestamp": "2004-09-06T17:01:36.000Z"
+  },
+  "tombofthunder/gfx/env/shol_bk.tga": {
+   "bytes": 286426,
+   "sha256": "afc656e21fdba58ec0df854cd4f0a8681257a993bec6b5185b24821b9b3e73be",
+   "timestamp": "2003-01-22T20:26:38.000Z"
+  },
+  "tombofthunder/gfx/env/shol_dn.tga": {
+   "bytes": 139320,
+   "sha256": "aa4b3cf9005975c47096fbacd3041439ab0492025c0756df7d5098192043d53e",
+   "timestamp": "2003-02-20T17:28:00.000Z"
+  },
+  "tombofthunder/gfx/env/shol_ft.tga": {
+   "bytes": 280100,
+   "sha256": "9334cced4dfe72e3be40a86f830c6d39444d4bd4aa1df0f26b4fbf359f369520",
+   "timestamp": "2003-01-22T20:26:28.000Z"
+  },
+  "tombofthunder/gfx/env/shol_lf.tga": {
+   "bytes": 305263,
+   "sha256": "84e81f9c3d29722d40b2dc3f9bc934d610a1bc7a05903265546e33d3c201383a",
+   "timestamp": "2003-01-22T20:26:34.000Z"
+  },
+  "tombofthunder/gfx/env/shol_rt.tga": {
+   "bytes": 303582,
+   "sha256": "b407a22b61b77bd86e1eecdfbb2a64c25acc004b25020318e67e9a179d07c533",
+   "timestamp": "2003-01-22T20:26:42.000Z"
+  },
+  "tombofthunder/gfx/env/shol_up.tga": {
+   "bytes": 344881,
+   "sha256": "3eff1076ea76b963355452aefddb7afcee5d75a41a65d1560a375f24f9715660",
+   "timestamp": "2004-02-05T17:30:48.000Z"
+  },
+  "tombofthunder/maps/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-07-23T14:25:14.000Z"
+  },
+  "tombofthunder/maps/discipletest.bsp": {
+   "bytes": 165112,
+   "sha256": "f36b372897c0c1df758743869c41d73a3bb9cd4e608ab2f7420dfec78e79a1e6",
+   "timestamp": "2023-09-07T12:43:48.000Z"
+  },
+  "tombofthunder/maps/seeyou.bsp": {
+   "bytes": 1354236,
+   "sha256": "f34b0ea88dc175a9ca8f620b4ebead3553bfbaa8841d1f65dd4a559d4e0cc884",
+   "timestamp": "2024-06-02T10:12:38.000Z"
+  },
+  "tombofthunder/maps/seeyou.lit": {
+   "bytes": 275780,
+   "sha256": "01ff24fee75ef39e0e1e9946e246808381a6ca80afbb3332716017cc5fd0b00e",
+   "timestamp": "2024-06-02T10:12:38.000Z"
+  },
+  "tombofthunder/maps/start.bsp": {
+   "bytes": 5019516,
+   "sha256": "9b0037d2ef1cc7fb02b0f7e3122b2c3946ee502db43b2981faa20cbd7bef1064",
+   "timestamp": "2024-06-02T10:12:30.000Z"
+  },
+  "tombofthunder/maps/start.lit": {
+   "bytes": 1677932,
+   "sha256": "928ec852f4ec279bf76232aba33699638e3b0a6c0970b13e1755507988400116",
+   "timestamp": "2024-06-02T10:12:28.000Z"
+  },
+  "tombofthunder/maps/test1.bsp": {
+   "bytes": 190776,
+   "sha256": "6910d4fd79322fe1061b49e4a7aa329c35883f058516cef7f83e85b88e16f4e1",
+   "timestamp": "2020-12-09T17:20:46.000Z"
+  },
+  "tombofthunder/maps/testsham.bsp": {
+   "bytes": 105688,
+   "sha256": "e0cb05b1b66a35828dd316844b192ac61a76b7def8b01da9acfa38514574aef8",
+   "timestamp": "2021-02-11T11:11:50.000Z"
+  },
+  "tombofthunder/maps/tot1.bsp": {
+   "bytes": 13496744,
+   "sha256": "54c94f72293f649846351c08c79b38dc3e509f02971af5bf00b76062f160bab0",
+   "timestamp": "2024-06-01T22:12:36.000Z"
+  },
+  "tombofthunder/maps/tot1.lit": {
+   "bytes": 4423124,
+   "sha256": "bc323e97de6f9cdee09897da47f2b7e971ec6ca0bb1580fe62d4d039e0aa54d7",
+   "timestamp": "2024-06-01T22:12:34.000Z"
+  },
+  "tombofthunder/maps/tot2.bsp": {
+   "bytes": 20933656,
+   "sha256": "4e2c0db214706a0635f8f21575ff4ffd5187f9096acb02e03b42b37e3e4c14f0",
+   "timestamp": "2024-06-01T22:09:04.000Z"
+  },
+  "tombofthunder/maps/tot2.lit": {
+   "bytes": 12336176,
+   "sha256": "8d814fa01bc7fb7df0270e0934424f8afe6ee5beb18e1d9c72abedf125f6b796",
+   "timestamp": "2024-06-01T22:08:52.000Z"
+  },
+  "tombofthunder/maps/tot3.bsp": {
+   "bytes": 18941040,
+   "sha256": "7af08969d26f55335d7d5218bece6d57e31b4775bc16fce6cb2c74ff2a1b05e4",
+   "timestamp": "2024-07-01T11:27:24.000Z"
+  },
+  "tombofthunder/maps/tot3.lit": {
+   "bytes": 6759200,
+   "sha256": "a3ee2e2972968bc0dff47214ec7385b453094a2c3fca798bae1c5afe3d3fdfcd",
+   "timestamp": "2024-07-01T11:27:18.000Z"
+  },
+  "tombofthunder/maps/tot4a.bsp": {
+   "bytes": 21577920,
+   "sha256": "70dd194f7fb8266181e88dde2352927d3e2f250f6eb9a4857564979ff9945063",
+   "timestamp": "2024-07-24T09:26:14.000Z"
+  },
+  "tombofthunder/maps/tot4a.lit": {
+   "bytes": 12336056,
+   "sha256": "1dcf6a8a92d4ee1607de8dd770f5ae9b1ed6a7a3890aa8d91c336d1865b68bf9",
+   "timestamp": "2024-07-24T09:25:54.000Z"
+  },
+  "tombofthunder/maps/tot4b.bsp": {
+   "bytes": 21577448,
+   "sha256": "40533ce1fee444e69a8247c9adb55bb467b002e50ca922dff656dc2f054b58f1",
+   "timestamp": "2024-07-24T09:43:06.000Z"
+  },
+  "tombofthunder/maps/tot4b.lit": {
+   "bytes": 12336056,
+   "sha256": "96985572c8c605226e47dd367f6dcb5c9b606e9e5fc87ba01a388bc7383f5afe",
+   "timestamp": "2024-07-24T09:42:46.000Z"
+  },
+  "tombofthunder/maps/tot4c.bsp": {
+   "bytes": 21581368,
+   "sha256": "1964787fc503b3b30d3ab57515b69383c05f1a688aca2e2513c7f57e716f5843",
+   "timestamp": "2024-07-24T09:58:08.000Z"
+  },
+  "tombofthunder/maps/tot4c.lit": {
+   "bytes": 12337112,
+   "sha256": "5a10f8bff843c1ff701ad6789070def2958c15121761de7f363c7259cbcd0a88",
+   "timestamp": "2024-07-24T09:57:48.000Z"
+  },
+  "tombofthunder/maps/tot5.bsp": {
+   "bytes": 23201000,
+   "sha256": "f36b7c776c1d97a78ac5a7816a7479e660a3c04aecb08664aa7e8778331a3be5",
+   "timestamp": "2024-07-08T08:28:58.000Z"
+  },
+  "tombofthunder/maps/tot5.lit": {
+   "bytes": 9687932,
+   "sha256": "53c1436cbe4e99e24ea0d585a06a591b56205bac6ddf8ecce9fb467ba5c904e8",
+   "timestamp": "2024-07-08T08:28:44.000Z"
+  },
+  "tombofthunder/maps/tot6.bsp": {
+   "bytes": 7983864,
+   "sha256": "f0b974887fb341f0662a94e71ed66f694c8efa6ff4abcfea0c1c95b78c9f2607",
+   "timestamp": "2024-05-20T11:42:42.000Z"
+  },
+  "tombofthunder/maps/tot6.lit": {
+   "bytes": 3668252,
+   "sha256": "2587e3a1f536535e0ce4eda92b6ed89025c26b75325091f8558410d689fed330",
+   "timestamp": "2024-05-20T11:42:42.000Z"
+  },
+  "tombofthunder/maps/tot7.bsp": {
+   "bytes": 24527588,
+   "sha256": "bdfe21e70e48ad3039c6bf8eec501e749dba7694e15cc114bba3a32f00c45c04",
+   "timestamp": "2024-07-01T12:46:54.000Z"
+  },
+  "tombofthunder/maps/tot7.lit": {
+   "bytes": 14776928,
+   "sha256": "979ff0ffc17d3e0e027764fa525336e9504986d7fac91cd4a79a6de3f82d6d09",
+   "timestamp": "2024-07-01T12:46:34.000Z"
+  },
+  "tombofthunder/music/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2023-12-14T22:55:00.000Z"
+  },
+  "tombofthunder/music/track12.ogg": {
+   "bytes": 1750132,
+   "sha256": "c321c68fcea1a8d9247f7d2f61c6423b75cee37bf7979b14518d36a9c3fb204f",
+   "timestamp": "2021-10-07T10:42:38.000Z"
+  },
+  "tombofthunder/music/track13.ogg": {
+   "bytes": 5475071,
+   "sha256": "43cb8ba8e7865ff27cd2c7b21f7cf6825395b670f7ff5015a9bc481cfb7e49f4",
+   "timestamp": "2021-10-07T10:52:02.000Z"
+  },
+  "tombofthunder/music/track14.ogg": {
+   "bytes": 3849154,
+   "sha256": "6408f2a9c7ea9c43c98cee348097917cfe91803dd6648167699837d62462522c",
+   "timestamp": "2021-10-07T10:55:10.000Z"
+  },
+  "tombofthunder/music/track15.ogg": {
+   "bytes": 4628309,
+   "sha256": "d61e8e5fff53154335dad555b15610e23090d711c9744f30400a3c910e0cf3b5",
+   "timestamp": "2021-10-07T10:56:10.000Z"
+  },
+  "tombofthunder/music/track16.ogg": {
+   "bytes": 4205436,
+   "sha256": "49e8500cdf10331c40e2e425cd5b8a45d073bb9c3e706a9a083b7980bf28d40a",
+   "timestamp": "2021-10-07T10:57:06.000Z"
+  },
+  "tombofthunder/music/track17.ogg": {
+   "bytes": 6337428,
+   "sha256": "c728ac295b5be0bba7b4bc0a4edb4585eda3d4a8c41db44bf31e964bf1a48d72",
+   "timestamp": "2021-10-07T11:00:30.000Z"
+  },
+  "tombofthunder/music/track18.ogg": {
+   "bytes": 6958538,
+   "sha256": "af33e96ed2ae137ade2483228c2cabc7f153202f3a213206318c32ffae8e23c0",
+   "timestamp": "2021-10-07T11:03:32.000Z"
+  },
+  "tombofthunder/music/track19.ogg": {
+   "bytes": 4543868,
+   "sha256": "852f0143536a21a19e6d81c639e6523ee07f493b4e5c0a5a319603b364b5b5c0",
+   "timestamp": "2023-12-14T22:55:02.000Z"
+  },
+  "tombofthunder/pak0.pak": {
+   "bytes": 8014300,
+   "files": {
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "9aea834c381c925104dab6aaa818f6c4bee9ea625c47cb912b9b71a602b7470c"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 307208,
+     "sha256": "8d3814bcbfa7168685dd1044504d3a422b8619b2ff6d87208203b79cd8f970db"
+    },
+    "gfx/temp.tmp": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "gfx1.wad": {
+     "bytes": 118996,
+     "sha256": "fb6c53211df13506775e876e48eee64bbedd4db68d90805c0bbf6885639aa8d2"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/alarm.wav": {
+     "bytes": 83564,
+     "sha256": "62025f4871e7433bdff0ba4385a49305a31074bd77e916b7be823ccbdb517fac"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/fusein.wav": {
+     "bytes": 54542,
+     "sha256": "0cc8a1c6176c7c26dfbd03631c74bf25a5cfe99c03d402188c9f0a5ff5a4fcac"
+    },
+    "sound/ambience/fuseout.wav": {
+     "bytes": 61382,
+     "sha256": "59809909620202a8d10f0495ab314e6f052c8a18479846bc4487b766f593faef"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/klaxon1.wav": {
+     "bytes": 97624,
+     "sha256": "aba8baa9c677e02d8d08994b33cd24210fa6767d778db779a2e572e64aa076e6"
+    },
+    "sound/ambience/klaxon2.wav": {
+     "bytes": 53056,
+     "sha256": "3ae3bf58b9a45dbf51243555b04d2d6776cd708c4dc8c13ba4e1e2b2daa8f8cf"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/lite_on.wav": {
+     "bytes": 92362,
+     "sha256": "ca329bad63910f68b603c3cd9eea0b8cd9d7428f96ebb27032a066808637e8bc"
+    },
+    "sound/ambience/lite_out.wav": {
+     "bytes": 80906,
+     "sha256": "d5e5747ec548eb9118c2190a59b9dcdcbe5335a2987726d7768415eb7e1fe573"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/radio.wav": {
+     "bytes": 235522,
+     "sha256": "fa0c9d92d9705e11d60b5964d67c23853d99904d98e202f361ef6c8d989e4b5f"
+    },
+    "sound/ambience/rain00.wav": {
+     "bytes": 54948,
+     "sha256": "60d957454e6802d90ed163b20f9729d1cb2455bb8ab9b6f8964105e876b3793b"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/vent.wav": {
+     "bytes": 75816,
+     "sha256": "f7092e792f7e9d8f57c3417bacda4f445b4f24cf5076071cb0eb23490b71fb31"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/enforcer/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/glad/flak.wav": {
+     "bytes": 19658,
+     "sha256": "de2bd26b99e767c13e6aece83ff6790b46abe27e91f4bd20b2646b0428786f76"
+    },
+    "sound/glad/ogdrag.wav": {
+     "bytes": 12396,
+     "sha256": "e7cf55df89c831567f8bf7b02e57b987e3b57eb34bfe48225167f2af6b640c11"
+    },
+    "sound/glad/ogdth.wav": {
+     "bytes": 12052,
+     "sha256": "0587d14849b0fec40eeea6dc4d61db548a8d760e17cbee07f572e5de081c5a5b"
+    },
+    "sound/glad/ogidle.wav": {
+     "bytes": 61810,
+     "sha256": "40ecc9597a7c2fa5d65f203dd022379bf3b85bfe4a19612181f5dd29f831d1f8"
+    },
+    "sound/glad/ogidle2.wav": {
+     "bytes": 12292,
+     "sha256": "14d217d02c7a3898d835cda4ee00c80afe722943d0d538a0b7b95e7b3cb8230d"
+    },
+    "sound/glad/ogpain1.wav": {
+     "bytes": 7730,
+     "sha256": "c8f157894e5651a2f599994d489520c539549dc5cb51d803e0ad60364b0c205a"
+    },
+    "sound/glad/ogpain2.wav": {
+     "bytes": 9108,
+     "sha256": "77a09d54447b3ce0b3a304545f613da813b29365de2d0c168c07ccdc1d6b04e7"
+    },
+    "sound/glad/ogpain3.wav": {
+     "bytes": 10930,
+     "sha256": "041d603a4c53633324dc28f937d80e51c70fb3f80fbd18f41a8b160ef7596f2a"
+    },
+    "sound/glad/ogsawatk.wav": {
+     "bytes": 16154,
+     "sha256": "f24f86055999053273798d54f646064f3053414dfb14167d611aa1cb6dbbb51b"
+    },
+    "sound/glad/ogwake.wav": {
+     "bytes": 8420,
+     "sha256": "fd327b2b1f56656b3573262486b2756494d6812dbf5bf6b1e5bd939da3ed4297"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 6494,
+     "sha256": "259c57ed9a96e2794933fb1e5ddabddbdc87069968590d6e3ac69895c18282d3"
+    },
+    "sound/items/armor2.wav": {
+     "bytes": 7704,
+     "sha256": "081c3f62f9a94969f75947b51c785d40a6d24b16d39f529804b5c85404f7cae6"
+    },
+    "sound/items/armor3.wav": {
+     "bytes": 9252,
+     "sha256": "c51e305d5a2b42f6b9b9dfd82fc1870e086a0b2ab8c04dbe3c00a1e04784f98f"
+    },
+    "sound/items/clock1.wav": {
+     "bytes": 38168,
+     "sha256": "ee475af2135a5c9d8b2afab199c2131d95070b9e3a56e3571adf3f00b95c50b9"
+    },
+    "sound/items/clock2.wav": {
+     "bytes": 70976,
+     "sha256": "8b40b62f88303d16cfc6fef6b7ad1be584c50764c2883075eab77bd220fb155b"
+    },
+    "sound/items/clock3.wav": {
+     "bytes": 130248,
+     "sha256": "a04c45553280fbb992308fb0aade8ac8e74ec4e4c2ab8400a69de8bad642fc25"
+    },
+    "sound/items/drop.wav": {
+     "bytes": 11888,
+     "sha256": "fc7a1d39fb54ace150dab785d0e9e642f8f710ea3d425c7799daf223542a3b58"
+    },
+    "sound/items/haste1.wav": {
+     "bytes": 13420,
+     "sha256": "267bcedfe84a50bc1f5257d5cc7cd401465bd012682b328546e5af61f8fc29cb"
+    },
+    "sound/items/haste2.wav": {
+     "bytes": 31622,
+     "sha256": "c8e298dab6c215bffc237cd6681dae38c803250e1c199db9b61f523500ce3e13"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/items/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/misc/nuke1.wav": {
+     "bytes": 203012,
+     "sha256": "d79e18f8f3dec7f83cceeb8d273bad68457690c876069f03c64d4e194dfedc04"
+    },
+    "sound/misc/nuke2.wav": {
+     "bytes": 504160,
+     "sha256": "42edcbb094427ec9adaaa6e7a853296abfa35bb5e9fd38081f71c5c72179f755"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/zeus.wav": {
+     "bytes": 68308,
+     "sha256": "59947806a8313f276a873fd0f7c1265a671f74e04e3b35217f6f8728cf8d2fc5"
+    },
+    "sound/nailinf/death.wav": {
+     "bytes": 18898,
+     "sha256": "b9bbb261c4f58c7857f368e7482a6706b1a4105b3ad4e41a700d1025d29d38c6"
+    },
+    "sound/nailinf/idle1.wav": {
+     "bytes": 28822,
+     "sha256": "c5dcd7bf900ad11e204beaf05f3db54d4c9f23f33358c0bb34e063fd41900390"
+    },
+    "sound/nailinf/nailshrd.wav": {
+     "bytes": 19178,
+     "sha256": "fd948e19c399a4b157601acbd875b1f2b4f5da8e000cd3c688d1e6ee0dc76a47"
+    },
+    "sound/nailinf/pain1.wav": {
+     "bytes": 5118,
+     "sha256": "81038879b6d933fe59d29059b5d0655b6e9bbd96c11f902c5d6fd5e3acb0a333"
+    },
+    "sound/nailinf/pain2.wav": {
+     "bytes": 5680,
+     "sha256": "a8eba9496de56151703e9a8b93dc9f0ab7e161ae351acd0082feda567959ebb1"
+    },
+    "sound/nailinf/prepfire.wav": {
+     "bytes": 6390,
+     "sha256": "eec07407720f84a37e600f22eb0265549d350add8af972dc507ed0306c20a121"
+    },
+    "sound/nailinf/sight1.wav": {
+     "bytes": 18618,
+     "sha256": "6f6f9f5c2d92b87abae4c2fc78c92b3e96f20a5d9e53eacf9eebb283bd4558da"
+    },
+    "sound/nailinf/sight2.wav": {
+     "bytes": 15670,
+     "sha256": "42dbf9e02a96ba2e6cd2bee0adf9dae22292c572d9c00bc499a699e6ea4da9cf"
+    },
+    "sound/nailinf/sight3.wav": {
+     "bytes": 14522,
+     "sha256": "38851d768386b7096548b082235da9921966905678ca84027567e59b6e603bc1"
+    },
+    "sound/nailinf/sight4.wav": {
+     "bytes": 19798,
+     "sha256": "0583212c3dd33bede0fd9e2963a04c8320add72c523305dafc6f3dd3b28cda59"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "sound/progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "sound/progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "sound/progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "sound/progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "sound/progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "sound/progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "sound/progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "sound/progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "sound/progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "sound/progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "sound/progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "sound/progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "sound/progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "sound/progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "sound/progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "sound/progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "sound/progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "sound/progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "sound/progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "sound/progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "sound/progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "sound/progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "sound/progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "sound/progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "sound/progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "sound/progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "sound/progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "sound/progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "sound/progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/weapons/acell1.wav": {
+     "bytes": 46444,
+     "sha256": "36effe01dee2f868809118ef297e9a210ccdc1ba6b1bafdce31b508b8431a5c2"
+    },
+    "sound/weapons/acell2.wav": {
+     "bytes": 49860,
+     "sha256": "12fb19410492c42e0f97ec3c33ebe75c9128b2b5bce29cae1b21c5d110c127cd"
+    },
+    "sound/weapons/anail1.wav": {
+     "bytes": 4950,
+     "sha256": "ee61c5455fc13216173e44a58ce13a522ba74d354bbb5707177131daec2376c1"
+    },
+    "sound/weapons/anail2.wav": {
+     "bytes": 7300,
+     "sha256": "fdb33dade14269d4d5e7de03e30c087b057e00f9635a1411a12fca70b7bc91db"
+    },
+    "sound/weapons/arocket1.wav": {
+     "bytes": 11626,
+     "sha256": "094f39f68641a9deea4b101c1cb88beb1ea35b81354daf84aebe9949bf48f36f"
+    },
+    "sound/weapons/arocket2.wav": {
+     "bytes": 14462,
+     "sha256": "6cb040193e0bb7042f119839205b153f2312328602a9b969fa319bc45b521a39"
+    },
+    "sound/weapons/ashell1.wav": {
+     "bytes": 4970,
+     "sha256": "110caa401cbad16cf3fc78b0d60c27c11640d355a425cf4a18dbcb58954c13e3"
+    },
+    "sound/weapons/ashell2.wav": {
+     "bytes": 8308,
+     "sha256": "e7f7c5545944f2c8ca518ffbf6af542be4bbb22ff0aa2d039c5f64bef6e83f57"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 9552,
+     "sha256": "655018e0b1ebd61283db23ff324574948295e3a9ca43337e49c8d49938666210"
+    },
+    "sound/weapons/chain2.wav": {
+     "bytes": 19022,
+     "sha256": "bbc5dcc50a31fb7c44d8c8f3cfa1c919e0c15875140f9ab3a9768ecfab0ebb8a"
+    },
+    "sound/weapons/chain2z.wav": {
+     "bytes": 19090,
+     "sha256": "b4be4c88effc6d0605b34cbcb772d79b7dbccf8c902f5bc76a17bf3131b32e95"
+    },
+    "sound/weapons/chain3.wav": {
+     "bytes": 2676,
+     "sha256": "61183aad8e0f3c4716f4243a74728fee29fde7db9ca08b522ddc98834c10998a"
+    },
+    "sound/weapons/expl.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/guncock1.wav": {
+     "bytes": 20384,
+     "sha256": "7d399ac16f8740afa3abef1ced4f2793ec280c3a9cdc7e44c4cf66c2da3e979a"
+    },
+    "sound/weapons/hot1.wav": {
+     "bytes": 3252,
+     "sha256": "2b21217fbc4d5f4f862f69f31a58473dd29f23110d321a1a3afcaf7e504d672a"
+    },
+    "sound/weapons/hot2.wav": {
+     "bytes": 29170,
+     "sha256": "25cd7092c9b4987f923f534957a312852b920f185af63c73e84b765e7889d3bc"
+    },
+    "sound/weapons/hot3.wav": {
+     "bytes": 50978,
+     "sha256": "c6b312455b7678b0ebf0f55753cc39b9e07178ec5d5fea2605310eca6e52a915"
+    },
+    "sound/weapons/hot4.wav": {
+     "bytes": 10698,
+     "sha256": "254ba8798743618faf4d4738ff779cbd686dcda7c0da1a3d639290aa88dd02a0"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    },
+    "sound/weapons/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/weapons/noammo.wav": {
+     "bytes": 5410,
+     "sha256": "30f367e95cf5193d4c6d964b642d7b10d49fdaf354afdfb686e4661256c3db56"
+    },
+    "sound/weapons/pkup2.wav": {
+     "bytes": 10118,
+     "sha256": "3be3ba31de2818cb915a4a4cf4721b1271a0983f1e9ad3df1142793809dd5570"
+    },
+    "sound/weapons/pkup3.wav": {
+     "bytes": 9276,
+     "sha256": "13098a619b250590b51cc0a609e18a396a3fa79576abb3c72742534c9083cfb5"
+    },
+    "sound/weapons/pkup4.wav": {
+     "bytes": 8090,
+     "sha256": "5f2e794af6199386e7bbfdd5961a3cb67ecac41b87e5d2336f15f95f09f1b865"
+    },
+    "sound/weapons/pkup5.wav": {
+     "bytes": 23018,
+     "sha256": "c3131e35745097fd1ab966e3334544f3af49e2a96c2ca0dd428e960de5562b28"
+    },
+    "sound/weapons/pkup6.wav": {
+     "bytes": 11140,
+     "sha256": "a23f96837b00b8ba574d6edfe7421f47e2115b6a6b5dedc9761eea0cece0f823"
+    },
+    "sound/weapons/pkup7.wav": {
+     "bytes": 9594,
+     "sha256": "a1b429e7759d70fb68fb90561ebb7a3addb0291628e225c8650bf9a52ff2882c"
+    },
+    "sound/weapons/pkup8.wav": {
+     "bytes": 15798,
+     "sha256": "2b8e586ae22b5138b7e2d46d76ed4c47dedd3bda14e0e1a64dd8a6a734fe0745"
+    },
+    "sound/weapons/pkup81.wav": {
+     "bytes": 10040,
+     "sha256": "708f7935c4b5d291703697400be66776417a19cd4a6db7871db85875d904e605"
+    },
+    "sound/weapons/pkup9.wav": {
+     "bytes": 33732,
+     "sha256": "cc2a7dcc1d16b17a598e2472b69f941c603dec77131853d8884d20a1ccea8046"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/weapons/rail1.wav": {
+     "bytes": 28566,
+     "sha256": "837b5d892f618e74178c0dbf455c3cd24c3d067d28b56d785e4c8e08302251b7"
+    },
+    "sound/weapons/rail2.wav": {
+     "bytes": 19078,
+     "sha256": "b2ad37e275ce2857b2ddc52a8d7f537eb02bbf2f7239b857d12d87fcfa5b4793"
+    },
+    "sound/weapons/shotcyc1.wav": {
+     "bytes": 18242,
+     "sha256": "c069f126338f166129ce9eb8065999dc4348028f92ac5af72075843885b8ff48"
+    },
+    "sound/weapons/shotcyc2.wav": {
+     "bytes": 3372,
+     "sha256": "8446a93c88c9574d63f3d4c3c395894da50343b55b7a1a97354f93e75eb7a122"
+    },
+    "sound/weapons/shotcyc3.wav": {
+     "bytes": 6190,
+     "sha256": "8fcfb6080be436f6ffb5b1310ba100d39a184e20aac1588050a6d62001334f68"
+    },
+    "sound/weapons/switch.wav": {
+     "bytes": 6238,
+     "sha256": "149f95b9a0a2711ff1578419efa367f384ae50311ca0b9e928f12f806501799c"
+    }
+   },
+   "sha256": "9397cfeeabcc3f90c92255a84defef7b2cfb4b09841549fd8100b6932819bada",
+   "timestamp": "2024-05-17T10:43:02.000Z"
+  },
+  "tombofthunder/progs.dat": {
+   "bytes": 719850,
+   "sha256": "264c422664d5779e5fe55d435c7c4bff16c512afe4b21f8c2454e6c88325f73f",
+   "timestamp": "2024-06-10T22:43:04.000Z"
+  },
+  "tombofthunder/progs.lno": {
+   "bytes": 217076,
+   "sha256": "5edee8475391ee9e1407cd92bb45391dc523a315b8e9eb054084787bc572bbdb",
+   "timestamp": "2024-06-10T22:43:04.000Z"
+  },
+  "tombofthunder/progs/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-05-07T10:58:56.000Z"
+  },
+  "tombofthunder/progs/armor.mdl": {
+   "bytes": 44076,
+   "sha256": "b49ad06f36124bfedfaf02c18f81e860100711bc2fd30125600b928c628214cd",
+   "timestamp": "2023-04-21T13:52:34.000Z"
+  },
+  "tombofthunder/progs/backpack.mdl": {
+   "bytes": 72688,
+   "sha256": "24bede5ea77c90c07b95b14e085b7b9a6c985a2a13dee0e14933a748e895a41c",
+   "timestamp": "2023-04-21T13:52:38.000Z"
+  },
+  "tombofthunder/progs/bfgblst.spr": {
+   "bytes": 16500,
+   "sha256": "99fecb098e3061cce071cc7ca377347b8090baeb15bccecfd0016580118c7395",
+   "timestamp": "2023-09-02T14:15:40.000Z"
+  },
+  "tombofthunder/progs/bfgexpl.spr": {
+   "bytes": 393372,
+   "sha256": "38d8cb6ae5722ae601e0359e47aa7ab2550e21ce2be2a2b95cf8bbafc80062e4",
+   "timestamp": "2023-04-21T10:34:28.000Z"
+  },
+  "tombofthunder/progs/bfgshot.spr": {
+   "bytes": 4684,
+   "sha256": "27140aa4fb5298977b1bdd7b3356b6b04c375cd9a9734d0e0b2e163dc07bdc93",
+   "timestamp": "2016-05-21T15:22:24.000Z"
+  },
+  "tombofthunder/progs/diam2.mdl": {
+   "bytes": 2748,
+   "sha256": "b23586b1d570a9f516f6b83ea0af6ec1d8fe5693f8cd1279b251b031ba142d8c",
+   "timestamp": "2023-04-21T13:52:40.000Z"
+  },
+  "tombofthunder/progs/disciple.mdl": {
+   "bytes": 186068,
+   "sha256": "1aab1bd145ddd75478601fb9a31f15ef1aa2bc907653efd51efafa8368ec3f47",
+   "timestamp": "2023-08-22T16:54:20.000Z"
+  },
+  "tombofthunder/progs/dsc_imp.spr": {
+   "bytes": 16500,
+   "sha256": "026350a7024318e15396089416e72ab388d5e1e9d6fa51853261432d5096f696",
+   "timestamp": "2023-09-02T14:16:18.000Z"
+  },
+  "tombofthunder/progs/dsc_proj.spr": {
+   "bytes": 8268,
+   "sha256": "9d81a7741bd1ed09cf49bf09edb925f1cf3532c3ee7e5ee27d6fecc8c6cb7882",
+   "timestamp": "2023-09-02T14:16:12.000Z"
+  },
+  "tombofthunder/progs/dscgib1.mdl": {
+   "bytes": 5300,
+   "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229",
+   "timestamp": "2023-08-22T17:38:14.000Z"
+  },
+  "tombofthunder/progs/dscgib2.mdl": {
+   "bytes": 6292,
+   "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142",
+   "timestamp": "2023-08-22T17:38:14.000Z"
+  },
+  "tombofthunder/progs/dscgib3.mdl": {
+   "bytes": 2516,
+   "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3",
+   "timestamp": "2023-08-22T17:38:14.000Z"
+  },
+  "tombofthunder/progs/g_chain.mdl": {
+   "bytes": 144596,
+   "sha256": "948321d44088f667dc6007ec11fecf4b48c6fdca5c63a9ebdecaef56f07d07f7",
+   "timestamp": "2023-04-21T13:52:46.000Z"
+  },
+  "tombofthunder/progs/g_hot.mdl": {
+   "bytes": 57156,
+   "sha256": "61ba4d39a0dbfa184b4fd3b675ea5a44c5ce75a276a8b1ccd71a3ca536b12997",
+   "timestamp": "2023-04-21T13:52:48.000Z"
+  },
+  "tombofthunder/progs/g_rail.mdl": {
+   "bytes": 168120,
+   "sha256": "2ab32e3b97f1e59c79d0afa0425adfe9cc18597e36fa2242278a2ee737400e62",
+   "timestamp": "2023-04-21T13:52:56.000Z"
+  },
+  "tombofthunder/progs/g_shotcl.mdl": {
+   "bytes": 335236,
+   "sha256": "0ef790f704aef08f0febc495bf0c70a6345333fa7b1030217faaf4d4980d520a",
+   "timestamp": "2023-04-21T13:53:02.000Z"
+  },
+  "tombofthunder/progs/glad.mdl": {
+   "bytes": 504484,
+   "sha256": "1226d1a78a123ff5d74695dd73d95bd9a20aad528f4da244e14775950901d824",
+   "timestamp": "2024-03-11T16:30:56.000Z"
+  },
+  "tombofthunder/progs/gspawn.mdl": {
+   "bytes": 7380,
+   "sha256": "e34c64cd6391b2da112b4e7d11515c27722e77e5cc52d0601d92472b3bdea085",
+   "timestamp": "2023-04-21T13:53:10.000Z"
+  },
+  "tombofthunder/progs/h_glad.mdl": {
+   "bytes": 70404,
+   "sha256": "5b00bd6842e470ceaa910d06d2c403ea1b7ece159c6e65c0e536492e4cc43abd",
+   "timestamp": "2024-03-11T10:44:58.000Z"
+  },
+  "tombofthunder/progs/h_nail.mdl": {
+   "bytes": 12084,
+   "sha256": "e1ef22fa39bc48fe386dd027310760884b9a618c9693ab05ca4ae1ae72b599e8",
+   "timestamp": "2024-02-05T12:02:10.000Z"
+  },
+  "tombofthunder/progs/h_nail1.mdl": {
+   "bytes": 11828,
+   "sha256": "6b8222563698bb2a5759322fc1fd03713ce59fb4c62847abedfe5c626c985e4e",
+   "timestamp": "2023-01-03T15:07:40.000Z"
+  },
+  "tombofthunder/progs/h_shell.mdl": {
+   "bytes": 11828,
+   "sha256": "15c3f8c45a52d866981ba1ebd3c5ed2797e91d149acc5852dd7642a43d4d7a84",
+   "timestamp": "2023-01-03T15:07:40.000Z"
+  },
+  "tombofthunder/progs/hermes.mdl": {
+   "bytes": 62276,
+   "sha256": "6677b4b0599558ce7e824a65c1465565784f7028be2165042e0afd99fdf1bf38",
+   "timestamp": "2023-04-21T13:53:14.000Z"
+  },
+  "tombofthunder/progs/kronos.mdl": {
+   "bytes": 62276,
+   "sha256": "864e24c95a73cccb08d2926a3c39fd0d8e9920632f1fc21d1d2487afe4465eba",
+   "timestamp": "2023-04-21T13:53:16.000Z"
+  },
+  "tombofthunder/progs/kronos1.mdl": {
+   "bytes": 62276,
+   "sha256": "cbe39df3b92958bab8495c5459079e789e2fc6019eecb886be7419efef1d282a",
+   "timestamp": "2023-04-21T13:53:18.000Z"
+  },
+  "tombofthunder/progs/lavaman.mdl": {
+   "bytes": 190588,
+   "sha256": "cb39ecc86f002c99b48e4d1c673949414b58f142288edfc9f281dbc3567b7368",
+   "timestamp": "2023-04-21T13:53:24.000Z"
+  },
+  "tombofthunder/progs/lspike.mdl": {
+   "bytes": 1684,
+   "sha256": "4b1a7b7fe9108cf16b2b46c2b595884244b7027bfb002da7cd05689a82e4847f",
+   "timestamp": "2023-04-21T13:53:26.000Z"
+  },
+  "tombofthunder/progs/nailinf.mdl": {
+   "bytes": 375964,
+   "sha256": "336c759107ee68ca8e407da0fd76e9362fd862231a60471e03bf50b6d6770d78",
+   "timestamp": "2024-02-04T17:18:32.000Z"
+  },
+  "tombofthunder/progs/nailinf1.mdl": {
+   "bytes": 160688,
+   "sha256": "b1aaf07445f84ff7f4a80d7918f674e1c276372e8302b9b5db68d9facaeff0e8",
+   "timestamp": "2023-04-21T15:17:12.000Z"
+  },
+  "tombofthunder/progs/p_light.mdl": {
+   "bytes": 11860,
+   "sha256": "c9cebc8d6f4836e7c302d51d0f942fde3da0960dae38733ccc3a851776e71520",
+   "timestamp": "2023-01-03T15:07:40.000Z"
+  },
+  "tombofthunder/progs/pshot.spr": {
+   "bytes": 4212,
+   "sha256": "1a6731351a45c00a52be9c8c2389b1b1b049814dfd2d35aea7d28ea6804c177e",
+   "timestamp": "2023-04-21T10:34:32.000Z"
+  },
+  "tombofthunder/progs/shelltrp.mdl": {
+   "bytes": 399572,
+   "sha256": "bbe121edec66a5796b2854d62f5bd3e7b86bd5e401099c8ad126a9267ca0c817",
+   "timestamp": "2023-04-21T13:52:24.000Z"
+  },
+  "tombofthunder/progs/spikmine.mdl": {
+   "bytes": 55572,
+   "sha256": "4f999a45a3d96087facc86283f92129be7c0f0cb212f448f2a0eab5c947a6832",
+   "timestamp": "2023-04-21T13:52:26.000Z"
+  },
+  "tombofthunder/progs/test.mdl": {
+   "bytes": 18694,
+   "sha256": "fd078f0c5ecc0adca1e7d8bd3ca9ef64f7d46b0121bae19a37324d79f0bc1c58",
+   "timestamp": "2023-04-21T13:52:28.000Z"
+  },
+  "tombofthunder/progs/v_chain.mdl": {
+   "bytes": 83380,
+   "sha256": "7fd4336939e36d79a64732ff68b954484b8355c7a84475c4dedd9080b942c0d4",
+   "timestamp": "2023-04-21T13:52:30.000Z"
+  },
+  "tombofthunder/progs/v_hot.mdl": {
+   "bytes": 60228,
+   "sha256": "7d51ecfbd37d7bbc6f9702f8a9a4766261a9a9d537880ac6c0450ad0c4ce054f",
+   "timestamp": "2023-01-03T15:07:40.000Z"
+  },
+  "tombofthunder/progs/v_rail.mdl": {
+   "bytes": 420536,
+   "sha256": "f712acc06212e509f9d7f033b505e02e30670408b7b4cc3a51c6a1847fbb454d",
+   "timestamp": "2023-01-03T15:07:40.000Z"
+  },
+  "tombofthunder/progs/v_shotcl.mdl": {
+   "bytes": 76404,
+   "sha256": "f7287125aa5d5c03fa1d7dca0ccde80b9a537f67c1f1d8a8e805424e6d4fb44c",
+   "timestamp": "2023-01-03T15:07:40.000Z"
+  },
+  "tombofthunder/progs/zeus.mdl": {
+   "bytes": 335016,
+   "sha256": "7d5a2f1f01c50cff7f630240405241594483928b0f02ef42725c86c804f1d75b",
+   "timestamp": "2024-05-07T10:58:30.000Z"
+  },
+  "tombofthunder/sound/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-04-24T08:24:54.000Z"
+  },
+  "tombofthunder/sound/ambience/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2023-12-15T15:11:16.000Z"
+  },
+  "tombofthunder/sound/ambience/alarm.wav": {
+   "bytes": 83564,
+   "sha256": "62025f4871e7433bdff0ba4385a49305a31074bd77e916b7be823ccbdb517fac",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/ambience/ancientdrone.wav": {
+   "bytes": 296188,
+   "sha256": "d6ad63754b56275da381c81ed17603a41923e9f585097e167a26f69468e08305",
+   "timestamp": "2023-01-05T10:34:10.000Z"
+  },
+  "tombofthunder/sound/ambience/choir1.wav": {
+   "bytes": 179738,
+   "sha256": "e9d55b682eaf8523dc9b6fb76a690f60288b933d66f84aac7476027a510e8cd8",
+   "timestamp": "2023-01-05T10:33:58.000Z"
+  },
+  "tombofthunder/sound/ambience/choir2.wav": {
+   "bytes": 240162,
+   "sha256": "6b9c22a2e94a290795d71dd984484f7fded93b633923829a58435f71f53d5270",
+   "timestamp": "2023-01-03T14:59:40.000Z"
+  },
+  "tombofthunder/sound/ambience/choirbig.wav": {
+   "bytes": 661650,
+   "sha256": "efe97f0777654c4fc6ac9ae1a555b5eed8926df0bb99abb21c7baab40ecca3cb",
+   "timestamp": "2023-01-05T00:40:12.000Z"
+  },
+  "tombofthunder/sound/ambience/comp.wav": {
+   "bytes": 12164,
+   "sha256": "ab8e3b13981bb432cca44ad4b7467734f52d01927018e72c99e7c4d052dc7874",
+   "timestamp": "2019-08-30T01:24:52.000Z"
+  },
+  "tombofthunder/sound/ambience/evil.wav": {
+   "bytes": 148502,
+   "sha256": "b996f237f6809ac4b5d8ceb8246e6ad26a3ad9ccbaa61cfcb36b97ea1aae2071",
+   "timestamp": "2023-01-03T14:58:10.000Z"
+  },
+  "tombofthunder/sound/ambience/forbidden.wav": {
+   "bytes": 296198,
+   "sha256": "864b86ff5db702a3e2f01a923773c8f4f7c76c2f02ff0b673b4ee70f1de77bf1",
+   "timestamp": "2023-01-05T10:33:40.000Z"
+  },
+  "tombofthunder/sound/ambience/fusein.wav": {
+   "bytes": 54542,
+   "sha256": "0cc8a1c6176c7c26dfbd03631c74bf25a5cfe99c03d402188c9f0a5ff5a4fcac",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/ambience/fuseout.wav": {
+   "bytes": 61382,
+   "sha256": "59809909620202a8d10f0495ab314e6f052c8a18479846bc4487b766f593faef",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/ambience/greg1.wav": {
+   "bytes": 377388,
+   "sha256": "9940ad80076fbc1915868191bdd973a56de4910207f5ecc2907828304ed9d24d",
+   "timestamp": "2023-01-03T14:52:38.000Z"
+  },
+  "tombofthunder/sound/ambience/greg2.wav": {
+   "bytes": 379302,
+   "sha256": "d7c63195029cb913f68a920fb904fa161626bb7b0ba9999a67a1d9da0ed76479",
+   "timestamp": "2023-01-03T14:54:10.000Z"
+  },
+  "tombofthunder/sound/ambience/guts.wav": {
+   "bytes": 1631820,
+   "sha256": "7ead76a809d2cfaf33f5431322df2d5131a078a7f5538b6291dae36e89b63c5c",
+   "timestamp": "2019-06-16T05:44:56.000Z"
+  },
+  "tombofthunder/sound/ambience/humming.wav": {
+   "bytes": 7672,
+   "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/ambience/klaxon1.wav": {
+   "bytes": 97624,
+   "sha256": "aba8baa9c677e02d8d08994b33cd24210fa6767d778db779a2e572e64aa076e6",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/ambience/klaxon2.wav": {
+   "bytes": 53056,
+   "sha256": "3ae3bf58b9a45dbf51243555b04d2d6776cd708c4dc8c13ba4e1e2b2daa8f8cf",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/ambience/lite_on.wav": {
+   "bytes": 92362,
+   "sha256": "ca329bad63910f68b603c3cd9eea0b8cd9d7428f96ebb27032a066808637e8bc",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/ambience/lite_out.wav": {
+   "bytes": 80906,
+   "sha256": "d5e5747ec548eb9118c2190a59b9dcdcbe5335a2987726d7768415eb7e1fe573",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/ambience/moans1.wav": {
+   "bytes": 521252,
+   "sha256": "ff855990d8045da766b5aba28dcf50086222b47ef175a03439df8f82b0c20dc1",
+   "timestamp": "2023-01-03T14:46:48.000Z"
+  },
+  "tombofthunder/sound/ambience/moans2.wav": {
+   "bytes": 621316,
+   "sha256": "9fc4fa14f37664d1805a66b4b5bc5b8db52485a18817fcbeaee94b083319be2b",
+   "timestamp": "2023-01-03T14:47:14.000Z"
+  },
+  "tombofthunder/sound/ambience/radio.wav": {
+   "bytes": 235522,
+   "sha256": "fa0c9d92d9705e11d60b5964d67c23853d99904d98e202f361ef6c8d989e4b5f",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/ambience/rain00.wav": {
+   "bytes": 54948,
+   "sha256": "60d957454e6802d90ed163b20f9729d1cb2455bb8ab9b6f8964105e876b3793b",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/ambience/riftpowr.wav": {
+   "bytes": 3822,
+   "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f",
+   "timestamp": "2023-01-03T15:03:26.000Z"
+  },
+  "tombofthunder/sound/ambience/shub.wav": {
+   "bytes": 227644,
+   "sha256": "ac5c7a89117d397749160442c2f0fca1c89ffa638943dbd1f13aa1b0ee6d56ac",
+   "timestamp": "2023-01-06T00:39:06.000Z"
+  },
+  "tombofthunder/sound/ambience/suffer.wav": {
+   "bytes": 176790,
+   "sha256": "50ab6b3e9f95e0559bc065beefdda1a5f7272ede840bef0c60f8be314907df53",
+   "timestamp": "2023-01-04T00:50:36.000Z"
+  },
+  "tombofthunder/sound/ambience/vent.wav": {
+   "bytes": 75816,
+   "sha256": "f7092e792f7e9d8f57c3417bacda4f445b4f24cf5076071cb0eb23490b71fb31",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/ambience/waterfal.wav": {
+   "bytes": 19330,
+   "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/ambience/wind3.wav": {
+   "bytes": 120938,
+   "sha256": "e0e3b455179913cf61254a454030fa48f5eb4a4bbedbc29ec4b5d79785f48d43",
+   "timestamp": "2023-01-08T18:17:24.000Z"
+  },
+  "tombofthunder/sound/disciple/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2023-09-05T16:57:40.000Z"
+  },
+  "tombofthunder/sound/disciple/d_atk.wav": {
+   "bytes": 30580,
+   "sha256": "d290d8a6835b57a7cd9fc935fb91c9751456e258cce185788abc38fa30182571",
+   "timestamp": "2023-09-07T12:20:36.000Z"
+  },
+  "tombofthunder/sound/disciple/d_death.wav": {
+   "bytes": 40762,
+   "sha256": "baf0a4504cbbe692498b0f587bca844624a4d7092e2e4ab447e85fea0ea58b93",
+   "timestamp": "2023-08-22T17:11:54.000Z"
+  },
+  "tombofthunder/sound/disciple/d_idle1.wav": {
+   "bytes": 25142,
+   "sha256": "a8f9d3cd872b9132f424c39e57584e185be1621d3a59a8f0dca5deee98cec0b3",
+   "timestamp": "2023-08-22T17:16:16.000Z"
+  },
+  "tombofthunder/sound/disciple/d_idle2.wav": {
+   "bytes": 19924,
+   "sha256": "95aed8a9189a3aacbd793a978501029a96ce91c11a4184341b79b13c8f27d89e",
+   "timestamp": "2023-08-22T17:11:30.000Z"
+  },
+  "tombofthunder/sound/disciple/d_pain1.wav": {
+   "bytes": 20080,
+   "sha256": "a61387e3eb4d4d2674f5a68c96e37705bc56b7032f117463398faa51a4e802b2",
+   "timestamp": "2023-08-22T17:10:36.000Z"
+  },
+  "tombofthunder/sound/disciple/d_pain2.wav": {
+   "bytes": 17826,
+   "sha256": "3a34b98817cfd28f9d7621a81422584f31956821a375046ce895b0cd3d6bfa47",
+   "timestamp": "2023-08-22T17:10:54.000Z"
+  },
+  "tombofthunder/sound/disciple/d_prep.wav": {
+   "bytes": 19178,
+   "sha256": "6f0c8bde2dc435c65627490e01b45a354b975905fd5c84c4201674f8474502aa",
+   "timestamp": "2023-09-02T16:28:14.000Z"
+  },
+  "tombofthunder/sound/disciple/d_sight.wav": {
+   "bytes": 37234,
+   "sha256": "ad8fb25658c7c8fc5ebe840efffc9cbaaeb61fa1d5324787bf66bf4e48343932",
+   "timestamp": "2023-08-22T17:10:14.000Z"
+  },
+  "tombofthunder/sound/enforcer/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/enforcer/laserric.wav": {
+   "bytes": 13340,
+   "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/glad/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-03-11T15:15:36.000Z"
+  },
+  "tombofthunder/sound/glad/flak.wav": {
+   "bytes": 19658,
+   "sha256": "de2bd26b99e767c13e6aece83ff6790b46abe27e91f4bd20b2646b0428786f76",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/glad/ogdth.wav": {
+   "bytes": 12052,
+   "sha256": "0587d14849b0fec40eeea6dc4d61db548a8d760e17cbee07f572e5de081c5a5b",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/glad/ogidle.wav": {
+   "bytes": 61810,
+   "sha256": "40ecc9597a7c2fa5d65f203dd022379bf3b85bfe4a19612181f5dd29f831d1f8",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/glad/ogidle2.wav": {
+   "bytes": 12292,
+   "sha256": "14d217d02c7a3898d835cda4ee00c80afe722943d0d538a0b7b95e7b3cb8230d",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/glad/ogpain1.wav": {
+   "bytes": 7730,
+   "sha256": "c8f157894e5651a2f599994d489520c539549dc5cb51d803e0ad60364b0c205a",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/glad/ogpain2.wav": {
+   "bytes": 9108,
+   "sha256": "77a09d54447b3ce0b3a304545f613da813b29365de2d0c168c07ccdc1d6b04e7",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/glad/ogpain3.wav": {
+   "bytes": 10930,
+   "sha256": "041d603a4c53633324dc28f937d80e51c70fb3f80fbd18f41a8b160ef7596f2a",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/glad/ogsawatk.wav": {
+   "bytes": 16154,
+   "sha256": "f24f86055999053273798d54f646064f3053414dfb14167d611aa1cb6dbbb51b",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/glad/ogwake.wav": {
+   "bytes": 8420,
+   "sha256": "fd327b2b1f56656b3573262486b2756494d6812dbf5bf6b1e5bd939da3ed4297",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/glad/trident.wav": {
+   "bytes": 10286,
+   "sha256": "7c9162f454e9736644d249105afae05ff0f8a4efe8dc8f3d1fa4745d1d6275ac",
+   "timestamp": "2024-03-11T15:06:20.000Z"
+  },
+  "tombofthunder/sound/hknight/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2023-09-05T16:57:40.000Z"
+  },
+  "tombofthunder/sound/hknight/attack2.wav": {
+   "bytes": 11680,
+   "sha256": "a571287ca30a429a90bd807d67b903f6f837d030527e3c1f2fb8fe45e5bc4aa1",
+   "timestamp": "2023-08-29T14:39:26.000Z"
+  },
+  "tombofthunder/sound/hknight/attack2HQ.wav": {
+   "bytes": 23290,
+   "sha256": "dd40dd4f7a785e077169acc84a007d843ad03d1d5bc66de9b8cfe348a632a981",
+   "timestamp": "2023-08-29T14:37:52.000Z"
+  },
+  "tombofthunder/sound/items/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2023-01-03T15:06:38.000Z"
+  },
+  "tombofthunder/sound/items/armor1.wav": {
+   "bytes": 6494,
+   "sha256": "259c57ed9a96e2794933fb1e5ddabddbdc87069968590d6e3ac69895c18282d3",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/items/armor2.wav": {
+   "bytes": 7704,
+   "sha256": "081c3f62f9a94969f75947b51c785d40a6d24b16d39f529804b5c85404f7cae6",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/items/armor3.wav": {
+   "bytes": 9252,
+   "sha256": "c51e305d5a2b42f6b9b9dfd82fc1870e086a0b2ab8c04dbe3c00a1e04784f98f",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/items/clock1.wav": {
+   "bytes": 38168,
+   "sha256": "ee475af2135a5c9d8b2afab199c2131d95070b9e3a56e3571adf3f00b95c50b9",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/items/clock2.wav": {
+   "bytes": 70976,
+   "sha256": "8b40b62f88303d16cfc6fef6b7ad1be584c50764c2883075eab77bd220fb155b",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/items/clock3.wav": {
+   "bytes": 130248,
+   "sha256": "a04c45553280fbb992308fb0aade8ac8e74ec4e4c2ab8400a69de8bad642fc25",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/items/drop.wav": {
+   "bytes": 11888,
+   "sha256": "fc7a1d39fb54ace150dab785d0e9e642f8f710ea3d425c7799daf223542a3b58",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/items/haste1.wav": {
+   "bytes": 13420,
+   "sha256": "267bcedfe84a50bc1f5257d5cc7cd401465bd012682b328546e5af61f8fc29cb",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/items/haste2.wav": {
+   "bytes": 31622,
+   "sha256": "c8e298dab6c215bffc237cd6681dae38c803250e1c199db9b61f523500ce3e13",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/items/spikmine.wav": {
+   "bytes": 15566,
+   "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/misc/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-04-24T08:24:56.000Z"
+  },
+  "tombofthunder/sound/misc/bigexpl.wav": {
+   "bytes": 145132,
+   "sha256": "06128688eeaefb1c49e91967f53abf49ee9f9967fd6162234876652b57fb798e",
+   "timestamp": "2023-01-16T16:48:24.000Z"
+  },
+  "tombofthunder/sound/misc/demwhis.wav": {
+   "bytes": 42688,
+   "sha256": "2727d14e5d68da35d0dc3bfed0358e0ce754cec89c809aa3e9e99d37af190c45",
+   "timestamp": "2023-06-10T23:04:40.000Z"
+  },
+  "tombofthunder/sound/misc/meat1.wav": {
+   "bytes": 50644,
+   "sha256": "8b8d18e73e3bb8b6e8a8f59b78778b278b18c3f30636ad13ac7774b5a8e11893",
+   "timestamp": "2023-05-11T09:10:40.000Z"
+  },
+  "tombofthunder/sound/misc/meat2.wav": {
+   "bytes": 101244,
+   "sha256": "74f8bfa1867e3a290546f14049ba992623cff9ea7ce106eee7b62a157d70dcc8",
+   "timestamp": "2023-05-19T09:34:38.000Z"
+  },
+  "tombofthunder/sound/misc/meatsplosion.wav": {
+   "bytes": 32242,
+   "sha256": "182a3c0f20188547af4827f3387020aae6c7377ec45a4de8a55dbab4552e69cf",
+   "timestamp": "2023-05-11T09:21:32.000Z"
+  },
+  "tombofthunder/sound/misc/nuke1.wav": {
+   "bytes": 203012,
+   "sha256": "d79e18f8f3dec7f83cceeb8d273bad68457690c876069f03c64d4e194dfedc04",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/misc/nuke2.wav": {
+   "bytes": 504160,
+   "sha256": "42edcbb094427ec9adaaa6e7a853296abfa35bb5e9fd38081f71c5c72179f755",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/misc/quake.wav": {
+   "bytes": 103452,
+   "sha256": "36da07e95984a68c52df559f13c571f26b77cf51767f9fcebe6015510b4e2976",
+   "timestamp": "2023-05-19T10:31:18.000Z"
+  },
+  "tombofthunder/sound/misc/shub.wav": {
+   "bytes": 225484,
+   "sha256": "de2a73c974756bdacd966714ac9fa36a47f8a9840c6c04a8cd84c07030d8cca2",
+   "timestamp": "2023-01-09T13:57:32.000Z"
+  },
+  "tombofthunder/sound/misc/tim_hole.wav": {
+   "bytes": 110696,
+   "sha256": "f5ea084bd197925b925f78dca300c3c359f35f3ba5ac855c7d4a6c70205def93",
+   "timestamp": "1999-11-21T21:42:58.000Z"
+  },
+  "tombofthunder/sound/nailinf/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/nailinf/death.wav": {
+   "bytes": 18898,
+   "sha256": "b9bbb261c4f58c7857f368e7482a6706b1a4105b3ad4e41a700d1025d29d38c6",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/nailinf/idle1.wav": {
+   "bytes": 28822,
+   "sha256": "c5dcd7bf900ad11e204beaf05f3db54d4c9f23f33358c0bb34e063fd41900390",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/nailinf/nailshrd.wav": {
+   "bytes": 19178,
+   "sha256": "3a8fcd83a76416ba8af3957575184805b4f7f0dfea37d07a542eac8935efde2d",
+   "timestamp": "2023-08-03T00:53:00.000Z"
+  },
+  "tombofthunder/sound/nailinf/pain1.wav": {
+   "bytes": 5118,
+   "sha256": "81038879b6d933fe59d29059b5d0655b6e9bbd96c11f902c5d6fd5e3acb0a333",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/nailinf/pain2.wav": {
+   "bytes": 5680,
+   "sha256": "a8eba9496de56151703e9a8b93dc9f0ab7e161ae351acd0082feda567959ebb1",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/nailinf/prepfire.wav": {
+   "bytes": 6390,
+   "sha256": "eec07407720f84a37e600f22eb0265549d350add8af972dc507ed0306c20a121",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/nailinf/sight1.wav": {
+   "bytes": 18618,
+   "sha256": "6f6f9f5c2d92b87abae4c2fc78c92b3e96f20a5d9e53eacf9eebb283bd4558da",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/nailinf/sight2.wav": {
+   "bytes": 15670,
+   "sha256": "42dbf9e02a96ba2e6cd2bee0adf9dae22292c572d9c00bc499a699e6ea4da9cf",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/nailinf/sight3.wav": {
+   "bytes": 14522,
+   "sha256": "38851d768386b7096548b082235da9921966905678ca84027567e59b6e603bc1",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/nailinf/sight4.wav": {
+   "bytes": 19798,
+   "sha256": "0583212c3dd33bede0fd9e2963a04c8320add72c523305dafc6f3dd3b28cda59",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/player/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-04-29T15:51:58.000Z"
+  },
+  "tombofthunder/sound/player/healthgain.wav": {
+   "bytes": 46092,
+   "sha256": "d9c8cacdc298a4bc367f62b1c3d99cc9be806cb787db3345705355ae98c10b42",
+   "timestamp": "2024-04-29T15:51:50.000Z"
+  },
+  "tombofthunder/sound/player/healthrot.wav": {
+   "bytes": 22100,
+   "sha256": "4f7192c2a1c9969cadc5cbd2c75eed8ce7a95598591f1b8e929dc9ed4c2fa19c",
+   "timestamp": "2024-04-24T08:19:48.000Z"
+  },
+  "tombofthunder/sound/voc/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-04-16T10:22:58.000Z"
+  },
+  "tombofthunder/sound/voc/1.wav": {
+   "bytes": 10200,
+   "sha256": "5c75d090104edcae60e1c93948a8afac2de1768ef912d3b99cb3808659d38947",
+   "timestamp": "2023-11-28T23:03:46.000Z"
+  },
+  "tombofthunder/sound/voc/10.wav": {
+   "bytes": 9270,
+   "sha256": "d6bedaf81c87cf36917e6ee7fd7823c30082bd0443b2e93e4245878aea6d4b0f",
+   "timestamp": "2023-11-28T23:02:06.000Z"
+  },
+  "tombofthunder/sound/voc/2.wav": {
+   "bytes": 11310,
+   "sha256": "9047d9f74bee9e1f882c37e1ac2f5eab3df22ec132be3924788472b0d35bab73",
+   "timestamp": "2023-11-28T23:03:36.000Z"
+  },
+  "tombofthunder/sound/voc/2min.wav": {
+   "bytes": 44090,
+   "sha256": "c9cc81f01cf34926c44ed6a863c70a2e9c0a683c2256c937e082fc7bb69c7121",
+   "timestamp": "2023-11-28T23:01:54.000Z"
+  },
+  "tombofthunder/sound/voc/3.wav": {
+   "bytes": 12500,
+   "sha256": "98fc402df492dd9bab8b8200e5064300d8ff7efe3d161400c37917f3d494b8e4",
+   "timestamp": "2023-11-28T23:03:26.000Z"
+  },
+  "tombofthunder/sound/voc/30sec.wav": {
+   "bytes": 45110,
+   "sha256": "1d8418dc8217ca568e7ac27091db1f3b4562f3ae81f824f9fc3825aeb47a3fe8",
+   "timestamp": "2023-11-28T23:01:18.000Z"
+  },
+  "tombofthunder/sound/voc/3min.wav": {
+   "bytes": 42042,
+   "sha256": "2de0d56d45beb699c27e00268f1cb49780ad65b7b79fe47c61e7d009369b67b8",
+   "timestamp": "2023-11-28T23:01:30.000Z"
+  },
+  "tombofthunder/sound/voc/4.wav": {
+   "bytes": 15612,
+   "sha256": "3fe901998135f2dbb086ceabd26c53e05886ea08a94396113f0310e563f0e8e6",
+   "timestamp": "2023-11-28T23:03:10.000Z"
+  },
+  "tombofthunder/sound/voc/5.wav": {
+   "bytes": 20178,
+   "sha256": "33df34362616f89ce4cebc4efbf62f15158e2ed2c634257d0a6ed033d6712051",
+   "timestamp": "2023-11-28T23:02:50.000Z"
+  },
+  "tombofthunder/sound/voc/6.wav": {
+   "bytes": 11110,
+   "sha256": "5872872dc470fbabc2c164c0a139603d5ef0be2b86dc16d4a458aa42f3789447",
+   "timestamp": "2023-11-28T23:02:42.000Z"
+  },
+  "tombofthunder/sound/voc/60sec.wav": {
+   "bytes": 47162,
+   "sha256": "dc748b16475aadad2c53074f16c2999b902d73e33d0c64ec8b67ba6ae05b43d5",
+   "timestamp": "2023-11-28T23:01:00.000Z"
+  },
+  "tombofthunder/sound/voc/7.wav": {
+   "bytes": 12308,
+   "sha256": "26ccfdfc0594906dd2e51667cf313aa771758351e8b9a90f8d9ba1456a0d059f",
+   "timestamp": "2023-11-28T23:02:34.000Z"
+  },
+  "tombofthunder/sound/voc/8.wav": {
+   "bytes": 11052,
+   "sha256": "b5f7a623955ee01f91fe69b9ddd8b74d5f2ca9f4da9ca4c20f09a765c6b61ce9",
+   "timestamp": "2023-11-28T23:02:24.000Z"
+  },
+  "tombofthunder/sound/voc/9.wav": {
+   "bytes": 11158,
+   "sha256": "75ae44ff3823daca03082af1ee9cbfd6824ad47b98d915e82853d01bb4d9a44c",
+   "timestamp": "2023-11-28T23:02:14.000Z"
+  },
+  "tombofthunder/sound/voc/offline.wav": {
+   "bytes": 63370,
+   "sha256": "26bd65a9a0195b9a77a57cc2a76373850648f9b60e3fd149211db47178b10d86",
+   "timestamp": "2023-11-28T23:00:46.000Z"
+  },
+  "tombofthunder/sound/voc/online.wav": {
+   "bytes": 39990,
+   "sha256": "7c77ba3878dc484840797a93d5c9a734376126b268f16a5f68bdaedd6d541178",
+   "timestamp": "2023-11-28T23:00:32.000Z"
+  },
+  "tombofthunder/sound/voc/warning.wav": {
+   "bytes": 14970,
+   "sha256": "9a059ab991cef0e54f0d7b979955f51194831fc5f91691dadf9aec163b936307",
+   "timestamp": "2023-11-28T22:59:38.000Z"
+  },
+  "tombofthunder/sound/voc/welcome.wav": {
+   "bytes": 42962,
+   "sha256": "6bf5c120f61ae589c8257decda89509e0ca86e1a3bbd0a79c69291a8cbca2583",
+   "timestamp": "2023-11-28T22:59:28.000Z"
+  },
+  "tombofthunder/sound/weapons/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-05-07T09:12:18.000Z"
+  },
+  "tombofthunder/sound/weapons/acell1.wav": {
+   "bytes": 46444,
+   "sha256": "36effe01dee2f868809118ef297e9a210ccdc1ba6b1bafdce31b508b8431a5c2",
+   "timestamp": "2024-05-07T09:01:02.000Z"
+  },
+  "tombofthunder/sound/weapons/acell2.wav": {
+   "bytes": 49860,
+   "sha256": "12fb19410492c42e0f97ec3c33ebe75c9128b2b5bce29cae1b21c5d110c127cd",
+   "timestamp": "2024-05-07T09:01:28.000Z"
+  },
+  "tombofthunder/sound/weapons/anail1.wav": {
+   "bytes": 4950,
+   "sha256": "ee61c5455fc13216173e44a58ce13a522ba74d354bbb5707177131daec2376c1",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/anail2.wav": {
+   "bytes": 7300,
+   "sha256": "fdb33dade14269d4d5e7de03e30c087b057e00f9635a1411a12fca70b7bc91db",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/arocket1.wav": {
+   "bytes": 11626,
+   "sha256": "094f39f68641a9deea4b101c1cb88beb1ea35b81354daf84aebe9949bf48f36f",
+   "timestamp": "2024-05-07T09:20:22.000Z"
+  },
+  "tombofthunder/sound/weapons/arocket2.wav": {
+   "bytes": 14462,
+   "sha256": "6cb040193e0bb7042f119839205b153f2312328602a9b969fa319bc45b521a39",
+   "timestamp": "2024-05-07T09:20:28.000Z"
+  },
+  "tombofthunder/sound/weapons/ashell1.wav": {
+   "bytes": 4970,
+   "sha256": "110caa401cbad16cf3fc78b0d60c27c11640d355a425cf4a18dbcb58954c13e3",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/ashell2.wav": {
+   "bytes": 8308,
+   "sha256": "e7f7c5545944f2c8ca518ffbf6af542be4bbb22ff0aa2d039c5f64bef6e83f57",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/chain1.wav": {
+   "bytes": 9552,
+   "sha256": "655018e0b1ebd61283db23ff324574948295e3a9ca43337e49c8d49938666210",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/chain2.wav": {
+   "bytes": 19022,
+   "sha256": "bbc5dcc50a31fb7c44d8c8f3cfa1c919e0c15875140f9ab3a9768ecfab0ebb8a",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/chain3.wav": {
+   "bytes": 2676,
+   "sha256": "61183aad8e0f3c4716f4243a74728fee29fde7db9ca08b522ddc98834c10998a",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/expl.wav": {
+   "bytes": 17478,
+   "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/weapons/hot1.wav": {
+   "bytes": 3252,
+   "sha256": "2b21217fbc4d5f4f862f69f31a58473dd29f23110d321a1a3afcaf7e504d672a",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/hot2.wav": {
+   "bytes": 29170,
+   "sha256": "25cd7092c9b4987f923f534957a312852b920f185af63c73e84b765e7889d3bc",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/hot3.wav": {
+   "bytes": 50978,
+   "sha256": "c6b312455b7678b0ebf0f55753cc39b9e07178ec5d5fea2605310eca6e52a915",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/hot4.wav": {
+   "bytes": 10698,
+   "sha256": "254ba8798743618faf4d4738ff779cbd686dcda7c0da1a3d639290aa88dd02a0",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/weapons/noammo.wav": {
+   "bytes": 5410,
+   "sha256": "30f367e95cf5193d4c6d964b642d7b10d49fdaf354afdfb686e4661256c3db56",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/weapons/pkup2.wav": {
+   "bytes": 10118,
+   "sha256": "3be3ba31de2818cb915a4a4cf4721b1271a0983f1e9ad3df1142793809dd5570",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/pkup3.wav": {
+   "bytes": 9276,
+   "sha256": "13098a619b250590b51cc0a609e18a396a3fa79576abb3c72742534c9083cfb5",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/pkup4.wav": {
+   "bytes": 8090,
+   "sha256": "5f2e794af6199386e7bbfdd5961a3cb67ecac41b87e5d2336f15f95f09f1b865",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/pkup5.wav": {
+   "bytes": 23018,
+   "sha256": "c3131e35745097fd1ab966e3334544f3af49e2a96c2ca0dd428e960de5562b28",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/pkup6.wav": {
+   "bytes": 11140,
+   "sha256": "a23f96837b00b8ba574d6edfe7421f47e2115b6a6b5dedc9761eea0cece0f823",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/pkup7.wav": {
+   "bytes": 9594,
+   "sha256": "a1b429e7759d70fb68fb90561ebb7a3addb0291628e225c8650bf9a52ff2882c",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/pkup8.wav": {
+   "bytes": 15798,
+   "sha256": "2b8e586ae22b5138b7e2d46d76ed4c47dedd3bda14e0e1a64dd8a6a734fe0745",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/pkup81.wav": {
+   "bytes": 10040,
+   "sha256": "708f7935c4b5d291703697400be66776417a19cd4a6db7871db85875d904e605",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/pkup9.wav": {
+   "bytes": 33732,
+   "sha256": "cc2a7dcc1d16b17a598e2472b69f941c603dec77131853d8884d20a1ccea8046",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/r_exp3.wav": {
+   "bytes": 1244,
+   "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/weapons/rail1.wav": {
+   "bytes": 28566,
+   "sha256": "837b5d892f618e74178c0dbf455c3cd24c3d067d28b56d785e4c8e08302251b7",
+   "timestamp": "2024-05-07T09:09:18.000Z"
+  },
+  "tombofthunder/sound/weapons/rail2.wav": {
+   "bytes": 19078,
+   "sha256": "b2ad37e275ce2857b2ddc52a8d7f537eb02bbf2f7239b857d12d87fcfa5b4793",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/weapons/shotcyc1.wav": {
+   "bytes": 18242,
+   "sha256": "c069f126338f166129ce9eb8065999dc4348028f92ac5af72075843885b8ff48",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/shotcyc2.wav": {
+   "bytes": 3372,
+   "sha256": "8446a93c88c9574d63f3d4c3c395894da50343b55b7a1a97354f93e75eb7a122",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/shotcyc3.wav": {
+   "bytes": 6190,
+   "sha256": "8fcfb6080be436f6ffb5b1310ba100d39a184e20aac1588050a6d62001334f68",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/weapons/switch.wav": {
+   "bytes": 6238,
+   "sha256": "149f95b9a0a2711ff1578419efa367f384ae50311ca0b9e928f12f806501799c",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/zeus/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2023-05-14T14:26:38.000Z"
+  },
+  "tombofthunder/sound/zeus/bfg_expl.wav": {
+   "bytes": 36998,
+   "sha256": "4653599f6e0743a559627a7d8fa67768160a89d70bb1cd9709ba905d6dcff663",
+   "timestamp": "2023-04-23T15:19:44.000Z"
+  },
+  "tombofthunder/sound/zeus/bfg_fire.wav": {
+   "bytes": 16640,
+   "sha256": "04b57be20cafe3b321fa5a99ee9046df78a0011809daba72129aa7ddd333fd21",
+   "timestamp": "2023-04-23T15:19:12.000Z"
+  },
+  "tombofthunder/sound/zeus/bfg_fly.wav": {
+   "bytes": 44318,
+   "sha256": "9caff5d6db918f21766bbf59de4d4b5577b6980f9d2418c485291a38a8515f52",
+   "timestamp": "2023-04-23T15:19:26.000Z"
+  },
+  "tombofthunder/sound/zeus/bigbolt.wav": {
+   "bytes": 41304,
+   "sha256": "eab617f12c5511793c66fcf65bf306f11ec4f0d9303666e964ce48dfd669edda",
+   "timestamp": "2023-03-27T10:24:16.000Z"
+  },
+  "tombofthunder/sound/zeus/bolt1.wav": {
+   "bytes": 29170,
+   "sha256": "25cd7092c9b4987f923f534957a312852b920f185af63c73e84b765e7889d3bc",
+   "timestamp": "2023-01-03T15:00:58.000Z"
+  },
+  "tombofthunder/sound/zeus/boltxpl.wav": {
+   "bytes": 10698,
+   "sha256": "254ba8798743618faf4d4738ff779cbd686dcda7c0da1a3d639290aa88dd02a0",
+   "timestamp": "2023-01-03T15:01:00.000Z"
+  },
+  "tombofthunder/sound/zeus/fall.wav": {
+   "bytes": 68420,
+   "sha256": "c3e026f7cc7568145e3d3aa106237022b2d67785b3c33d0a957f3c460fad1660",
+   "timestamp": "2023-05-05T09:24:28.000Z"
+  },
+  "tombofthunder/sound/zeus/fall_phase2.wav": {
+   "bytes": 67180,
+   "sha256": "6a9779213bb5cd962415b200bfdd18e53e800f571865fc74142d447b4056f13b",
+   "timestamp": "2023-05-09T15:54:18.000Z"
+  },
+  "tombofthunder/sound/zeus/hurt.wav": {
+   "bytes": 38338,
+   "sha256": "995af62004dee252071343b11d358f7d363688f66d20fb8e274c738aad8594bd",
+   "timestamp": "2023-05-05T09:24:04.000Z"
+  },
+  "tombofthunder/sound/zeus/hurt_phase2.wav": {
+   "bytes": 33344,
+   "sha256": "70cecba23ab4d907213f45976b57433c1d8e801aeb76489a23b3b0106a82816e",
+   "timestamp": "2023-05-09T15:52:50.000Z"
+  },
+  "tombofthunder/sound/zeus/hurt_phase3.wav": {
+   "bytes": 84278,
+   "sha256": "3aca8e49def243015217c27aec197eac7112e4e370641b4a9beb11bbb5c82445",
+   "timestamp": "2023-05-14T14:26:30.000Z"
+  },
+  "tombofthunder/sound/zeus/lilbolt.wav": {
+   "bytes": 56378,
+   "sha256": "407e74833048b1d0032fa73d30cd69f4e686867afc780a4a562a49c914f2a408",
+   "timestamp": "2023-04-02T14:35:02.000Z"
+  },
+  "tombofthunder/sound/zeus/plasma_expl.wav": {
+   "bytes": 13912,
+   "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f",
+   "timestamp": "2013-08-07T10:57:38.000Z"
+  },
+  "tombofthunder/sound/zeus/plasma_hit.wav": {
+   "bytes": 54406,
+   "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b",
+   "timestamp": "2015-08-28T00:39:36.000Z"
+  },
+  "tombofthunder/sound/zeus/rise.wav": {
+   "bytes": 73786,
+   "sha256": "37b5f44aabff02b164c7e7f82c0e75047c3b9a6147c5de544f195b224fddf91c",
+   "timestamp": "2023-05-05T09:23:38.000Z"
+  },
+  "tombofthunder/sound/zeus/rise_phase2.wav": {
+   "bytes": 77868,
+   "sha256": "a539bacfd6c28bccaacae3dbf8c0cb76c015ee0545f0826a7ab04083e22e5008",
+   "timestamp": "2023-05-09T15:52:18.000Z"
+  },
+  "tombofthunder/sound/zeus/sattck1.wav": {
+   "bytes": 8036,
+   "sha256": "efa18dec8f6d5066b8d494a232ca9c98c27a4a9130130086a9b0a27ffccb34ed",
+   "timestamp": "2023-02-09T10:26:08.000Z"
+  },
+  "tombofthunder/sound/zeus/sboom.wav": {
+   "bytes": 11672,
+   "sha256": "6c64dafb52536ae35f9d50cd5f6c5c636f3403b83cac4d1e55e62e913e2ca79b",
+   "timestamp": "2023-02-09T10:26:08.000Z"
+  },
+  "tombofthunder/srcGIT/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-04-26T09:14:12.000Z"
+  },
+  "tombofthunder/srcGIT/ai.qc": {
+   "bytes": 36111,
+   "sha256": "b51cf156f62e8469bd59226b181c8a1781877c06ca534b334d368f7b95f38123",
+   "timestamp": "2023-09-07T12:23:56.000Z"
+  },
+  "tombofthunder/srcGIT/buttons.qc": {
+   "bytes": 6249,
+   "sha256": "e3dc154eb3e1b90713c64a6e01860363aea515154136ba22c8c94ac498e9934e",
+   "timestamp": "2021-02-05T01:27:00.000Z"
+  },
+  "tombofthunder/srcGIT/client.qc": {
+   "bytes": 48287,
+   "sha256": "281ac2eb8d5e860b31fb15853677dfa413cd683fd775beba151bf83ced7fb8c8",
+   "timestamp": "2024-06-04T10:01:20.000Z"
+  },
+  "tombofthunder/srcGIT/combat.qc": {
+   "bytes": 17174,
+   "sha256": "1431b532801ace5dc75866758ab1adb00f08a996ac4bac4dbcd6270313fc0e88",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/constants.qc": {
+   "bytes": 8405,
+   "sha256": "484f4e3f1a0eeac3b84421ef3e30258db2462992cf11b4874de31ae0843b7e19",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/defs.qc": {
+   "bytes": 17269,
+   "sha256": "973906e2001d137f1d76bc7f5d1d590a79c1af6f8e8f4da02480d66e9b09a331",
+   "timestamp": "2024-06-04T10:19:42.000Z"
+  },
+  "tombofthunder/srcGIT/dev.qc": {
+   "bytes": 6685,
+   "sha256": "4e15c447d4cad247e17e4559f9db93fd233a6f94a5ac9746fe6308e6fded03fb",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/doors.qc": {
+   "bytes": 27063,
+   "sha256": "ab4d5154d7922e4d1a659bbb3493e187a33382eeae7ada6d08241b50f6f2a549",
+   "timestamp": "2024-05-17T15:05:36.000Z"
+  },
+  "tombofthunder/srcGIT/explobox.qc": {
+   "bytes": 6607,
+   "sha256": "0ee22739695a3a349bfb3e61aef3ca4383ccef066c3927b349fe75cce8cfe46f",
+   "timestamp": "2022-06-05T21:12:34.000Z"
+  },
+  "tombofthunder/srcGIT/fly.qc": {
+   "bytes": 4968,
+   "sha256": "03a1695d77b67e654d60005594cccd9763c5232880c4e57a969199f912bbfa78",
+   "timestamp": "2020-09-02T21:18:28.000Z"
+  },
+  "tombofthunder/srcGIT/fog.qc": {
+   "bytes": 10164,
+   "sha256": "301fc00e06a126960d2da61e866c06f04c1ba1bee49f3d36118b55ebe838f038",
+   "timestamp": "2023-06-10T13:15:30.000Z"
+  },
+  "tombofthunder/srcGIT/fx.qc": {
+   "bytes": 24526,
+   "sha256": "fc9d309192646c7987a8bb2c389ec1caf010f1f88f095fa655c36909c6460c56",
+   "timestamp": "2022-06-13T00:09:34.000Z"
+  },
+  "tombofthunder/srcGIT/impulse.qc": {
+   "bytes": 6025,
+   "sha256": "fe8b58fe5fe05356e0cce7b90f916c78e7518e23c44a9428a8525cd7b0416743",
+   "timestamp": "2024-04-26T08:32:46.000Z"
+  },
+  "tombofthunder/srcGIT/item_backpack.qc": {
+   "bytes": 8857,
+   "sha256": "7e76703896a514c54853a4dcd0c81e449e369344d8d56fac837112bdab4ee3e8",
+   "timestamp": "2024-05-14T13:14:08.000Z"
+  },
+  "tombofthunder/srcGIT/item_health_armor.qc": {
+   "bytes": 8272,
+   "sha256": "f17cd374907f8d01e1137533102700e4fa362c92df86a2e2e4f3efad54dae311",
+   "timestamp": "2021-02-10T23:44:46.000Z"
+  },
+  "tombofthunder/srcGIT/item_keys_runes.qc": {
+   "bytes": 10551,
+   "sha256": "04b07d2db7a0f04725d4be32c9a618403902b769b6cbd4253ed1da3e5b2677ad",
+   "timestamp": "2024-06-04T10:20:58.000Z"
+  },
+  "tombofthunder/srcGIT/item_powerups.qc": {
+   "bytes": 9112,
+   "sha256": "4483508b2d3ddcc870c033fb44b6d0df4a3b9a8d6fb4ff94e0bfd42d4df5bc0a",
+   "timestamp": "2024-05-06T16:29:02.000Z"
+  },
+  "tombofthunder/srcGIT/item_weap_ammo.qc": {
+   "bytes": 16108,
+   "sha256": "1816adedca5c55b52dea79eeda749e41f7347d174e597cc97a652e93cc7f1c12",
+   "timestamp": "2021-03-02T09:40:46.000Z"
+  },
+  "tombofthunder/srcGIT/items.qc": {
+   "bytes": 26167,
+   "sha256": "bd39ac0ea40efeae3fc4ce8f9257f685d166fb63df2a469f0296a6fae3a928d1",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/lights.qc": {
+   "bytes": 25841,
+   "sha256": "1f902d3957aa60d0c4045bf7dca3af75c37e0b0375ab3105363f48335d218f00",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/m_boss.qc": {
+   "bytes": 19742,
+   "sha256": "1afc14aa8557c5efbd91a305b967d6d09126a89824bff9ec4de7bb8b2f3a2fa1",
+   "timestamp": "2023-04-04T14:33:12.000Z"
+  },
+  "tombofthunder/srcGIT/m_demon.qc": {
+   "bytes": 25389,
+   "sha256": "7fff490c1aadb9475d7608993508e12866e662abe8db7ea4d31ee30b11c83b07",
+   "timestamp": "2024-06-01T22:40:50.000Z"
+  },
+  "tombofthunder/srcGIT/m_disciple.qc": {
+   "bytes": 20974,
+   "sha256": "21aaa9a6e303ca2e112b999d20443e6f7b4deb20db7e7effeee0bb9d82030c31",
+   "timestamp": "2024-05-31T15:25:02.000Z"
+  },
+  "tombofthunder/srcGIT/m_dog.qc": {
+   "bytes": 14695,
+   "sha256": "0b508110e25c4ecf7ed2ddf0df6135f974174a87c46d5fdbe5faa96cbae4fb8f",
+   "timestamp": "2021-02-12T16:44:12.000Z"
+  },
+  "tombofthunder/srcGIT/m_enforcer.qc": {
+   "bytes": 17471,
+   "sha256": "e3699de776f4225589f87605984af17d5b4673df96c0f0afc147e82718bfdccd",
+   "timestamp": "2023-08-03T00:57:08.000Z"
+  },
+  "tombofthunder/srcGIT/m_fish.qc": {
+   "bytes": 14182,
+   "sha256": "d9d486b4df46f0238bb2e66a11afc419f973f29a84e2190722cb5f5c707cd697",
+   "timestamp": "2021-02-16T16:32:30.000Z"
+  },
+  "tombofthunder/srcGIT/m_glad.qc": {
+   "bytes": 22288,
+   "sha256": "0286b6463996d8f2f9de4baede2c2c3b79485627cc68dad8b6574e3793ff0051",
+   "timestamp": "2024-04-22T15:06:18.000Z"
+  },
+  "tombofthunder/srcGIT/m_hknight.qc": {
+   "bytes": 28361,
+   "sha256": "c4a5ee9da7ddb14fb288a47eb4b353efce9a0b5f3d57f39a5d2461faa3219e0f",
+   "timestamp": "2023-08-29T16:35:30.000Z"
+  },
+  "tombofthunder/srcGIT/m_knight.qc": {
+   "bytes": 16888,
+   "sha256": "2982547d0938f0937028942337ecbac94d4b095ff4405e370c13d1d5ae59acaa",
+   "timestamp": "2024-05-12T21:15:02.000Z"
+  },
+  "tombofthunder/srcGIT/m_nailinf.qc": {
+   "bytes": 18400,
+   "sha256": "d300a2b0d7144d9a5097dbc9fcb8e53859f16056c9c7db1bc1ac3d69de0c7982",
+   "timestamp": "2024-05-22T21:53:14.000Z"
+  },
+  "tombofthunder/srcGIT/m_ogre.qc": {
+   "bytes": 22343,
+   "sha256": "c91c2dca6a2f1f9059eca7d484cca14525117a4329213a979ad1f369ccfa065e",
+   "timestamp": "2022-06-05T21:12:58.000Z"
+  },
+  "tombofthunder/srcGIT/m_oldone.qc": {
+   "bytes": 14371,
+   "sha256": "9bfe9e9bb32289a8e936658b5f939312f40bb34196e000f508ec65538ac2d646",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/m_shalrath.qc": {
+   "bytes": 17427,
+   "sha256": "bfd68b148f45dfd41b0910bad1c3afc9a91db55f5dfac44b787beaaf9a375c64",
+   "timestamp": "2023-11-29T11:02:28.000Z"
+  },
+  "tombofthunder/srcGIT/m_shambler.qc": {
+   "bytes": 24399,
+   "sha256": "63587d4554a346bb6d0ed3dc7ebd85d54324e4ad808496790ae22eee8c866a67",
+   "timestamp": "2022-01-13T00:44:38.000Z"
+  },
+  "tombofthunder/srcGIT/m_soldier.qc": {
+   "bytes": 17571,
+   "sha256": "57ba75f5b324df0d949282dce707ae0cfa1dfa7f68216b5692ade165f537830a",
+   "timestamp": "2021-02-11T11:11:32.000Z"
+  },
+  "tombofthunder/srcGIT/m_tarbaby.qc": {
+   "bytes": 14912,
+   "sha256": "8364fe13fc56ed414ce308af872e0904b6a2c8de29bbc04fdde5c0b1c0755c90",
+   "timestamp": "2024-05-10T15:27:38.000Z"
+  },
+  "tombofthunder/srcGIT/m_wizard.qc": {
+   "bytes": 15956,
+   "sha256": "0e65d9ee7ee06ea83a4c3152d7dd3e9a819cf7c5f10bd14b3605524a926d1006",
+   "timestamp": "2023-09-07T12:38:32.000Z"
+  },
+  "tombofthunder/srcGIT/m_zeus.qc": {
+   "bytes": 52662,
+   "sha256": "b3a9a3d74877a83d27533cdba36f8578e091e88d604817453f79f4191bc2bfa0",
+   "timestamp": "2024-05-07T22:04:10.000Z"
+  },
+  "tombofthunder/srcGIT/m_zeus1.qc": {
+   "bytes": 26727,
+   "sha256": "e477aaeea4853fb62cfa3b4d32d2954c6d600b49a5a33b82182b5a71f25c6681",
+   "timestamp": "2023-04-19T22:11:16.000Z"
+  },
+  "tombofthunder/srcGIT/m_zombie.qc": {
+   "bytes": 31672,
+   "sha256": "3c67102205b349e70c15cb40423af422ffebc17082a2b2ea599ae5183f884dd3",
+   "timestamp": "2021-02-11T16:26:20.000Z"
+  },
+  "tombofthunder/srcGIT/maths.qc": {
+   "bytes": 5909,
+   "sha256": "4d098463c26f795cfd6b6fec621ffb6716580f85a19f808d2e0e293fccf8702f",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/meat.qc": {
+   "bytes": 7115,
+   "sha256": "3a8884572adb434267f1c68e5f6cba826d42ca886362a9db443fe3bf0d4ffbb6",
+   "timestamp": "2021-02-05T10:37:54.000Z"
+  },
+  "tombofthunder/srcGIT/misc.qc": {
+   "bytes": 18799,
+   "sha256": "959a70c758b051b4b1f689f9e7ce3b3111bd1d8a367e0300805f7232973272f4",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/monsters.qc": {
+   "bytes": 18172,
+   "sha256": "cab47815fbf2810ab0648b8ed6e3ad257b43c51afefa7acb76301b29665816ba",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/plats.qc": {
+   "bytes": 26730,
+   "sha256": "976f6b24fa8c64082ebfe4f3a054fa5b20e99074e65682d37464620b01b75502",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/player.qc": {
+   "bytes": 25058,
+   "sha256": "b18db6f52ce74dab5e7fc97ec4076693fc5052feb49c4cdab16a6fd345edcdf5",
+   "timestamp": "2024-06-10T22:41:50.000Z"
+  },
+  "tombofthunder/srcGIT/progs.dat": {
+   "bytes": 644710,
+   "sha256": "cfbe75e02f7c7bc6b2e6ee46831492d21b1c6981ab03224557e1e5547eedb835",
+   "timestamp": "2021-02-11T11:11:28.000Z"
+  },
+  "tombofthunder/srcGIT/progs.src": {
+   "bytes": 1190,
+   "sha256": "67889ce46b999fee829e0f3c2c321fd99369fb6e27e2926352d8a0015d7bb640",
+   "timestamp": "2024-04-26T09:13:46.000Z"
+  },
+  "tombofthunder/srcGIT/projectiles.qc": {
+   "bytes": 19297,
+   "sha256": "0cf3e562f9220db0ed092e86bb3e3e487682dd4b72e845a6e90f9be2724a1942",
+   "timestamp": "2024-05-12T21:38:24.000Z"
+  },
+  "tombofthunder/srcGIT/shooters.qc": {
+   "bytes": 16519,
+   "sha256": "e12b49bb89bd843db51331591b95473cf8914e8c9b89f02831ce993608a842ab",
+   "timestamp": "2024-05-12T21:39:52.000Z"
+  },
+  "tombofthunder/srcGIT/sound.qc": {
+   "bytes": 11331,
+   "sha256": "de07adea2bc818cc73859ca2f3fd688bc55a9f6b6e253e0cb5e346d931888f47",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/subs.qc": {
+   "bytes": 2671,
+   "sha256": "496742036a27163cce27f3139c44910067fa8eb3eca37f834c74359253bdac99",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/subs_move.qc": {
+   "bytes": 4141,
+   "sha256": "1b0ade230265325e64604500f9e86bd8e583a0cb6fd50b50f079da0ded099c8b",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/subs_tgt.qc": {
+   "bytes": 12226,
+   "sha256": "82cd975041dbf267f2ed2652b6c08cd00d633f3f8241d741b5d646765e5f9669",
+   "timestamp": "2020-09-02T21:18:28.000Z"
+  },
+  "tombofthunder/srcGIT/t_ctrl.qc": {
+   "bytes": 15757,
+   "sha256": "cc610ae62d11e05a2f4255296a95b17e62e8fd751faa69c33a99acb4f7882ffe",
+   "timestamp": "2024-05-17T15:06:24.000Z"
+  },
+  "tombofthunder/srcGIT/t_level.qc": {
+   "bytes": 15123,
+   "sha256": "c12c2d74459b2f8c5b5006f3ca7edeb798f82d1172386f974627636acbd43a40",
+   "timestamp": "2023-06-10T13:14:20.000Z"
+  },
+  "tombofthunder/srcGIT/t_supermonsters.qc": {
+   "bytes": 1004,
+   "sha256": "0ed82b517909070df8961710954e291e3cf1b34714839d18e613c01c9a19f682",
+   "timestamp": "2024-05-31T16:50:58.000Z"
+  },
+  "tombofthunder/srcGIT/t_tele.qc": {
+   "bytes": 18330,
+   "sha256": "10bee91dffc8bbf853e2d86865077671aa26b39f1ed2554cab4f9a62f6a9fc7d",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/t_void.qc": {
+   "bytes": 15357,
+   "sha256": "31bf6b5fdeba6aa0d2ff14ca0e496c9049805c962070dbe53545ad5e70fcf17e",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/test.qc": {
+   "bytes": 329,
+   "sha256": "1db99110de27d9e6fe20330cbfefde0d443455a85a12ae8443d9ea295e66c3f1",
+   "timestamp": "2020-09-02T21:18:28.000Z"
+  },
+  "tombofthunder/srcGIT/triggers.qc": {
+   "bytes": 34282,
+   "sha256": "9d626024d7066692c34ab4e5a083de08b85befb34d9e0579f36ba972b9d88532",
+   "timestamp": "2024-04-26T15:14:16.000Z"
+  },
+  "tombofthunder/srcGIT/utility.qc": {
+   "bytes": 16599,
+   "sha256": "d439cd81f20557134a595fdffecd2d9e33c528866a6f701bf6f04b4192cdea8e",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/w_axe.qc": {
+   "bytes": 4593,
+   "sha256": "2f43bc92e06c18456b8104c00f6f2327e28c686955fa83ede1bae69ef697a3f8",
+   "timestamp": "2024-05-23T16:00:12.000Z"
+  },
+  "tombofthunder/srcGIT/w_lightning.qc": {
+   "bytes": 14999,
+   "sha256": "abd1ad058e495b94575ecd71fc5ff2e06cd52c0549acc1b0d892ba79a4bb58c2",
+   "timestamp": "2024-05-18T22:45:50.000Z"
+  },
+  "tombofthunder/srcGIT/w_nails.qc": {
+   "bytes": 6945,
+   "sha256": "f154436be6ad4b9f56acca98294a8a11cd4cb7be7852da09f81c22b95eb644e3",
+   "timestamp": "2024-06-10T22:42:12.000Z"
+  },
+  "tombofthunder/srcGIT/w_rockets.qc": {
+   "bytes": 4462,
+   "sha256": "e0a78d7ec754d9a67af91f9799d5684eaa6bad6e2de2a1aa871f0663293d7d9b",
+   "timestamp": "2023-10-06T15:02:34.000Z"
+  },
+  "tombofthunder/srcGIT/w_shotguns.qc": {
+   "bytes": 5012,
+   "sha256": "2a724f881e7602f738c3203ae097e68e77b629d7028179ae79994e4528b34a8a",
+   "timestamp": "2024-04-23T07:43:10.000Z"
+  },
+  "tombofthunder/srcGIT/walls.qc": {
+   "bytes": 8919,
+   "sha256": "cc39643c82d4607b8300325a3221a75dec828a4f0c47739840a6c2aee30b06d9",
+   "timestamp": "2020-11-26T12:54:32.000Z"
+  },
+  "tombofthunder/srcGIT/weapons.qc": {
+   "bytes": 12682,
+   "sha256": "f349cc1d0b0391867e900ff3dae61cec2348ccea82376c08b1ee40229218e703",
+   "timestamp": "2024-06-10T22:41:56.000Z"
+  },
+  "tombofthunder/srcGIT/world.qc": {
+   "bytes": 13234,
+   "sha256": "56a28d29b91bb241cc30f39c56780ff9d4e651d4ecfc626649bfab8d5a95c37f",
+   "timestamp": "2024-04-24T09:34:36.000Z"
+  },
+  "tombofthunder/srcMAP/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-07-23T14:25:14.000Z"
+  },
+  "tombofthunder/srcMAP/seeyou.map": {
+   "bytes": 277131,
+   "sha256": "92f8ca09cd9e4843ca6f24aaa2e98f0b9151a3a8d3a7fa071b7bcc4d22aa2c7e",
+   "timestamp": "2024-05-31T14:23:54.000Z"
+  },
+  "tombofthunder/srcMAP/start.map": {
+   "bytes": 1152784,
+   "sha256": "0999a527635945a1135c996a0d729595c4a97f467306c0d88fcf45da5736635f",
+   "timestamp": "2024-05-31T13:19:16.000Z"
+  },
+  "tombofthunder/srcMAP/tot1.map": {
+   "bytes": 6190375,
+   "sha256": "0198cf4cd9b79e6ad6b6fb06d90ef24b2532b444a9a7e4ab4d015f6fbc22c09d",
+   "timestamp": "2024-05-30T08:14:52.000Z"
+  },
+  "tombofthunder/srcMAP/tot2.map": {
+   "bytes": 6461775,
+   "sha256": "a8379d494bffcbd90932e19e26d83f066055078ba0c6b01b50b3f78de9898fcd",
+   "timestamp": "2024-05-31T08:40:38.000Z"
+  },
+  "tombofthunder/srcMAP/tot3.map": {
+   "bytes": 6143820,
+   "sha256": "8f6460c98297c0b2a878a5811e1e796c5126934886700883f50667f8d95b2bfd",
+   "timestamp": "2024-07-01T11:20:32.000Z"
+  },
+  "tombofthunder/srcMAP/tot4a.map": {
+   "bytes": 13120502,
+   "sha256": "27b27b546100df9d945e2a7ec91caba3508217189b53d72c8b354729b95d293a",
+   "timestamp": "2024-07-24T09:13:24.000Z"
+  },
+  "tombofthunder/srcMAP/tot4b.map": {
+   "bytes": 13119938,
+   "sha256": "81ec78d2ceeca33958fbf3adc7428a5296388135b7cc01275c272367eeb342bd",
+   "timestamp": "2024-07-24T09:13:16.000Z"
+  },
+  "tombofthunder/srcMAP/tot4c.map": {
+   "bytes": 13120507,
+   "sha256": "4ef9809c317a0e69bc8fad152d4285d35fbfee6a064ed1768c63399b073c3948",
+   "timestamp": "2024-07-24T09:13:10.000Z"
+  },
+  "tombofthunder/srcMAP/tot5.map": {
+   "bytes": 13028554,
+   "sha256": "af84cfef9c0845844e2b57815a377466cb637fd98657c682706867c4c201614e",
+   "timestamp": "2024-07-08T08:15:34.000Z"
+  },
+  "tombofthunder/srcMAP/tot6.map": {
+   "bytes": 3307526,
+   "sha256": "fd22d44e5be8054d9c5dd095c2d127d887447b894864259a1980842f8fce073d",
+   "timestamp": "2024-05-31T14:19:52.000Z"
+  },
+  "tombofthunder/srcMAP/tot7.map": {
+   "bytes": 14852057,
+   "sha256": "41a781759166421df71a550d966ba6a167c6fe6d57acf3bd1569251837b6242e",
+   "timestamp": "2024-07-01T10:53:10.000Z"
+  },
+  "tombofthunder/tombofthunder.fgd": {
+   "bytes": 48456,
+   "sha256": "9d38928ca23e9dd38641584a29f0e9c0114ef3913586cc4aa9bd1c9678593ed3",
+   "timestamp": "2024-05-16T17:18:46.000Z"
+  },
+  "tombofthunder/tombofthunder_poster.png": {
+   "bytes": 1785636,
+   "sha256": "2d1ca1ffd6d3423097a564260884f479813d5a16676951071fcc9cf1a9fbf6fb",
+   "timestamp": "2024-05-16T07:57:38.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "notes": [
+  "This file was repackaged for Quake Injector compatibility.",
+  "May require a source port with increased limits / BSP2 support."
+ ],
+ "sha256": "dee9623f95eff90701883a0b96d6b3a6adf2feae77e0c74f0864b3258c76a933",
+ "tags": [
+  "author=aDaya",
+  "commandline=-game tombofthunder",
+  "current_main_group_package=yes",
+  "exceeds_quake_limits=yes",
+  "filename=tombofthunder_mod_2024_v1032b.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/tomb-of-thunder.357/)",
+  "provides='tombofthunder=1032b'",
+  "release_date=2024-07-24",
+  "release_group=tombofthunder",
+  "startmap=start",
+  "title=Tomb of Thunder",
+  "type=episode",
+  "type=mod",
+  "version=1032b"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/tombofthunder_mod_2024_v1032b.zip"
+ ]
+}

--- a/json/by-sha256/ea/ea4f0f538eb7f690b57c8d234620ae2986aad8216a3d1b6d132343a96344d19c.json
+++ b/json/by-sha256/ea/ea4f0f538eb7f690b57c8d234620ae2986aad8216a3d1b6d132343a96344d19c.json
@@ -1,0 +1,46 @@
+{
+ "bytes": 3736007,
+ "description": "Short map with simple gameplay, set in a rocky cavern.",
+ "files": {
+  "potluck_scampie.bsp": {
+   "bytes": 5491184,
+   "sha256": "084d4b8fc47c9398b639bac1a3ebcd54617ad4ca1f6bca759aeaccbcae8e8dda",
+   "timestamp": "2024-07-30T21:40:48.000Z"
+  },
+  "potluck_scampie.lit": {
+   "bytes": 711776,
+   "sha256": "76b8f0f9d252bfe88993e22db4b41d33542016a61973c3bd6f45bc12f2573ec8",
+   "timestamp": "2024-07-30T21:40:48.000Z"
+  },
+  "potluck_scampie.map": {
+   "bytes": 251647,
+   "sha256": "8fce46c8117d23ab61f7ef639c27ddc259c53732a2b9eb82e3f39932f9709359",
+   "timestamp": "2024-07-30T22:02:20.000Z"
+  },
+  "potluck_scampie.txt": {
+   "bytes": 537,
+   "sha256": "9e0a1d5829bd905f06318a6a7bfecc6e588fb45f3f3ce086020d6e4f2fdb13d0",
+   "timestamp": "2024-07-31T17:31:56.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/id1/maps/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "sha256": "ea4f0f538eb7f690b57c8d234620ae2986aad8216a3d1b6d132343a96344d19c",
+ "tags": [
+  "author=Scampie",
+  "filename=potluck_scampie.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/ruin-of-the-fae-realm.380/)",
+  "release_date=2024-07-31",
+  "startmap=potluck_scampie",
+  "title=ruin of the fae realm",
+  "type=map",
+  "zipbasedir=id1/maps/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/potluck_scampie.zip"
+ ]
+}

--- a/json/by-sha256/f0/f01bd4cbd7753871e456fd754d583f81b20adb7f468f92aa6adf0f18999565f2.json
+++ b/json/by-sha256/f0/f01bd4cbd7753871e456fd754d583f81b20adb7f468f92aa6adf0f18999565f2.json
@@ -1,0 +1,41 @@
+{
+ "bytes": 777656,
+ "description": "Short, abstract gothic-themed map based in a castle.",
+ "files": {
+  "intruder.bsp": {
+   "bytes": 1839588,
+   "sha256": "4fc66035d9e5fece47230a8611b97483dc0fc1a1f40f3aa143f2d37409c5276d",
+   "timestamp": "2024-08-29T00:09:46.000Z"
+  },
+  "intruder.pts": {
+   "bytes": 17580,
+   "sha256": "8271b34b72c79c6d1a8e2ea0adb7c6a40fda2720fd1bfd3b29e86d01bfc97d1e",
+   "timestamp": "2024-08-28T23:50:58.000Z"
+  },
+  "intruder.txt": {
+   "bytes": 398,
+   "sha256": "51a830ed1cb165ea591387cc8fb61fc44a96f9b8d1bf15ca524465566d5fc1c2",
+   "timestamp": "2024-08-29T00:15:10.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/id1/maps/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "sha256": "f01bd4cbd7753871e456fd754d583f81b20adb7f468f92aa6adf0f18999565f2",
+ "tags": [
+  "author=GraveyardKaiser",
+  "filename=intruder.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/gothic-intruder.391/)",
+  "release_date=2024-08-29",
+  "startmap=intruder",
+  "title=Gothic Intruder",
+  "type=map",
+  "zipbasedir=id1/maps/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/intruder.zip"
+ ]
+}

--- a/json/by-sha256/f4/f4c2cb39caa3d50a1c8378dd4da8eb413219d45ca8979ca9b594599c990e8073.json
+++ b/json/by-sha256/f4/f4c2cb39caa3d50a1c8378dd4da8eb413219d45ca8979ca9b594599c990e8073.json
@@ -1,0 +1,146 @@
+{
+ "bytes": 77121790,
+ "description": "Episode of eight maps (plus start + secret) by various authors, made using ID and mission pack textures, keeping to original Quake entity limits.",
+ "files": {
+  "seiven/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-08-16T19:53:28.000Z"
+  },
+  "seiven/pak0.pak": {
+   "bytes": 91890020,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "ab4774e93eb7711c384d0dbe8e2afb81e233eafefdd103b770f09920587427be"
+    },
+    "maps/start.bsp": {
+     "bytes": 1313312,
+     "sha256": "a3ac3a6f0aec16270dfaf6a4f8058a15f95c33f88ebd627ebf2b4650f3e23595"
+    },
+    "maps/vm1.bsp": {
+     "bytes": 2426976,
+     "sha256": "b7db4e573a669cb33cc2103c6806ab66214fc73d829346ffbe501942b01811e0"
+    },
+    "maps/vm2.bsp": {
+     "bytes": 4512112,
+     "sha256": "1a4c0cc5a30861ce44be99e1a876dd38c4a6f1a9b78510d53fa821e61f818e84"
+    },
+    "maps/vm3.bsp": {
+     "bytes": 1707884,
+     "sha256": "2f390fe9b7e0f15fbf20acf95891be4efd511a7c42d58e5604d7b928fcac9a86"
+    },
+    "maps/vm4.bsp": {
+     "bytes": 2715984,
+     "sha256": "6d7a0a76128870c7214fc4f0c442541bcd06fc8c2f55e669462701d150323e3f"
+    },
+    "maps/vm5.bsp": {
+     "bytes": 2357984,
+     "sha256": "dc0374b1e05ab061a692f5aa6ce7a7e642bb7547ba9fb6aef8ab0c4a2b4b4498"
+    },
+    "maps/vm6.bsp": {
+     "bytes": 1911844,
+     "sha256": "6ed0385437ae93439d01dc514398224a7bc25b5f5e9cb71138b2731cd4f4f791"
+    },
+    "maps/vm7.bsp": {
+     "bytes": 1763828,
+     "sha256": "9858c7155e15dde22b87156caf18adc2efa7e787385e2e7ed7d3b602670741d8"
+    },
+    "maps/vm8.bsp": {
+     "bytes": 7906200,
+     "sha256": "f737d928dacb45d05cc95dee9b9f97a34bf66e08f9cbabf8c34202752523a2e1"
+    },
+    "maps/vm9.bsp": {
+     "bytes": 2482068,
+     "sha256": "a5a2db85c4e1739f8a96b3d5afb25205693af9a15e7b25d6c92872da7efbfa27"
+    },
+    "music/track03.ogg": {
+     "bytes": 4659994,
+     "sha256": "49a94c28e3c9eabbcb6679c547d194bb903cd848112f1cefde3c43e1ea9fa641"
+    },
+    "music/track20.ogg": {
+     "bytes": 5776436,
+     "sha256": "77850fdb471f254f63a2649c1d22ccd76103ddd249166cc82302c69169bfc8f2"
+    },
+    "music/track21.ogg": {
+     "bytes": 4920753,
+     "sha256": "15a4741f95641cf42d5de9ccd6f32da57d20efcd527fa39203379ee07d1d7a07"
+    },
+    "music/track22.ogg": {
+     "bytes": 5882227,
+     "sha256": "8b90f90960c834fdacd087a1f9865360c0f654814812020770dc20543b03c0a8"
+    },
+    "music/track23.ogg": {
+     "bytes": 4302730,
+     "sha256": "11fbd9432fbc0a0cc0446b790e44042a6b4b8389861a8392fd7000cfaf859180"
+    },
+    "music/track24.ogg": {
+     "bytes": 5768767,
+     "sha256": "159800ef5eb99546a73b582981c3afbb471690d2250912ea70322bb234d62143"
+    },
+    "music/track25.ogg": {
+     "bytes": 6901132,
+     "sha256": "c8cef6680974357499feaf3823bf2c3a08b65be90a31cedeeee7d171f3faaa7e"
+    },
+    "music/track26.ogg": {
+     "bytes": 8920144,
+     "sha256": "49bd3e4c609c4decbfc1110aa5de6a950d27b3202b3fcab595378a11a111901c"
+    },
+    "music/track27.ogg": {
+     "bytes": 4708835,
+     "sha256": "38fb73aa155c8cea018252b4f27bd450353805844ee9e4c92bfbadd28610e3fc"
+    },
+    "music/track28.ogg": {
+     "bytes": 6008196,
+     "sha256": "de42c280d3281a40a123bb7b357d3042b1702bf7ca3eaa1f399d4acf70b6ccd0"
+    },
+    "music/track29.ogg": {
+     "bytes": 4546696,
+     "sha256": "d550d111d4c26d25c9d24780dd93b1e22e8dccddcaa6a70df10520352580284e"
+    },
+    "progs.dat": {
+     "bytes": 330426,
+     "sha256": "d009e79f43e89896888d5b0478ea8f55192acfcefd432e0a0ba3eeb8602d263a"
+    }
+   },
+   "sha256": "6e2b420de1a96ac2e3eeb582e8f2571433f0ed772a2b6f3cc64970e8b2fa9368",
+   "timestamp": "2024-08-16T19:53:08.000Z"
+  },
+  "seiven/seiven.txt": {
+   "bytes": 1687,
+   "sha256": "e087d2e327267eaf80fe809798c976bca9ace45926c6cc52483ec54521101435",
+   "timestamp": "2024-08-07T19:23:34.000Z"
+  },
+  "seiven/seiven_jullari.png": {
+   "bytes": 2407793,
+   "sha256": "013e6eca2d0dfc92c267d4e77efd264b34e923df64d9cde36c096d59f6d525d4",
+   "timestamp": "2024-08-05T11:28:24.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "sha256": "f4c2cb39caa3d50a1c8378dd4da8eb413219d45ca8979ca9b594599c990e8073",
+ "tags": [
+  "author=Greenwood",
+  "author=Newhouse",
+  "author=Spootnik",
+  "author=VuRkka",
+  "author=alexUnder",
+  "author=bmFbr",
+  "author=zigi",
+  "commandline=-game seiven",
+  "filename=seiven.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/seismic-ventures.384/)",
+  "release_date=2024-08-16",
+  "startmap=start",
+  "title=Seismic Ventures",
+  "type=episode"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/seiven.zip"
+ ]
+}

--- a/json/by-sha256/fc/fc393ba9cb0b194c74e5f1976aef336de060116b9b5a63231f4e776da6f7bdf8.json
+++ b/json/by-sha256/fc/fc393ba9cb0b194c74e5f1976aef336de060116b9b5a63231f4e776da6f7bdf8.json
@@ -1,0 +1,41 @@
+{
+ "bytes": 1085304,
+ "description": "Small, abstract-themed wizard/castle map.",
+ "files": {
+  "anawiz.bsp": {
+   "bytes": 2735212,
+   "sha256": "d4ad729fbb1509d1298a0e6f5c142ee8b70edd026f55f66159b8e491e570210f",
+   "timestamp": "2024-08-18T16:00:06.000Z"
+  },
+  "anawiz.pts": {
+   "bytes": 63646,
+   "sha256": "af1e4d1cafd0629554c4d955b3fe0dbf4b665d58c351a116bf4230191cfc77d3",
+   "timestamp": "2024-08-13T19:19:56.000Z"
+  },
+  "anawiz.txt": {
+   "bytes": 400,
+   "sha256": "0ed2446481954c6264e82467cef99188ec872bb1e8a58225c84ee5d94d2b931a",
+   "timestamp": "2024-08-18T16:03:24.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/id1/maps/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "sha256": "fc393ba9cb0b194c74e5f1976aef336de060116b9b5a63231f4e776da6f7bdf8",
+ "tags": [
+  "author=GraveyardKaiser",
+  "filename=anawiz.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/anatomy-of-a-wizard.388/)",
+  "release_date=2024-08-18",
+  "startmap=anawiz",
+  "title=Anatomy of a Wizard",
+  "type=map",
+  "zipbasedir=id1/maps/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/anawiz.zip"
+ ]
+}

--- a/json/by-sha256/ff/ff5c3a9b6b98bd547ed2f2dba776f3ec0a7b221fb393a9ba5675d0f110b8bfb9.json
+++ b/json/by-sha256/ff/ff5c3a9b6b98bd547ed2f2dba776f3ec0a7b221fb393a9ba5675d0f110b8bfb9.json
@@ -1,0 +1,1373 @@
+{
+ "bytes": 18541705,
+ "description": "Detailed but tiny map set in a fog-covered town.",
+ "files": {
+  "old_town/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:02.000Z"
+  },
+  "old_town/QMLDescription.txt": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-08-29T08:05:46.000Z"
+  },
+  "old_town/QMLInstalledArchive.dat": {
+   "bytes": 11,
+   "sha256": "e40bf4b5545ba26f35e9dbb06304103869b011a1c701e3990b55ebefd4b8a584",
+   "timestamp": "2024-09-04T09:34:04.000Z"
+  },
+  "old_town/QMLMapLabel.dat": {
+   "bytes": 5,
+   "sha256": "f01a374e9c81e3db89b3a42940c4d6a5447684986a1296e42bf13f196eed6295",
+   "timestamp": "2024-08-29T08:05:46.000Z"
+  },
+  "old_town/QMLModData.dat": {
+   "bytes": 112,
+   "sha256": "3d7810634f29b9b24af084a83bae7c268a2bd436529a23db81123ed6ef3f3169",
+   "timestamp": "2024-08-29T08:05:46.000Z"
+  },
+  "old_town/autosave/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:02.000Z"
+  },
+  "old_town/autosave/prehevil_alone.sav": {
+   "bytes": 48810,
+   "sha256": "a728ccc5fbd3055202baae88eae93e54774993e316f56c1e283837a3335130be",
+   "timestamp": "2024-09-05T01:37:44.000Z"
+  },
+  "old_town/darkplaces_history.txt": {
+   "bytes": 1258,
+   "sha256": "2f3be74371dcc6cef2dab1e2e854e27bce5973db061ac082014adbb19d88666f",
+   "timestamp": "2024-08-29T08:14:36.000Z"
+  },
+  "old_town/development/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T03:04:46.000Z"
+  },
+  "old_town/development/fgd_def/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:02.000Z"
+  },
+  "old_town/development/fgd_def/pd_300.def": {
+   "bytes": 167787,
+   "sha256": "de019b3465633d7be97f6f699ce7e2470fb1d57cfb87c408553286b33946b5d6",
+   "timestamp": "2024-08-20T15:53:18.000Z"
+  },
+  "old_town/development/fgd_def/pd_300.fgd": {
+   "bytes": 151834,
+   "sha256": "5d8e0bb83c0e2ff7353d9c032e3bb332fcd29e04d99737ba45a94627e90683db",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/fgd_def/pd_300_JACK.fgd": {
+   "bytes": 141825,
+   "sha256": "c1176b1ca29a372e09ed149adebd133501c5ecb64d9cddb3436588f1d4cec7a1",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:04.000Z"
+  },
+  "old_town/development/map src/debris/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:04.000Z"
+  },
+  "old_town/development/map src/debris/brick01.map": {
+   "bytes": 650,
+   "sha256": "5bd3faee3310606630d453062708374eb925e5f52c6b2fce823da1d867832a1e",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/map src/debris/wood1.map": {
+   "bytes": 666,
+   "sha256": "d2ceb4b829254388f9bd3a5c618e8d37cee2eaaaeda56383225d8506b3b60d12",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/map src/pd_bosses.map": {
+   "bytes": 336640,
+   "sha256": "a6ada94c095440b01d686f24f6492f2ccaca0e8a3111967c64f64b458b78c75c",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/pd_breakables.map": {
+   "bytes": 62470,
+   "sha256": "1c8aa8c1e026598b4c7f651dfa3c66c5892d750954c13bb1a6626a2bbbbf3b3a",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/pd_change_dest.map": {
+   "bytes": 128871,
+   "sha256": "63224db2deed5393f39ca50ad2769b47ae8690a42f576dae92b2688e6ac52272",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/pd_counter.map": {
+   "bytes": 179783,
+   "sha256": "d8181e5fbd418e538afa919cf4bcf0d6292c95664dc011db98d70ffe167adb99",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/pd_cutscenes.map": {
+   "bytes": 577632,
+   "sha256": "887ad454ec2c0d171e0edaa0714c5153360277c7df6f225a71b6b341f57381ac",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/pd_cutscn_cuts.map": {
+   "bytes": 9331,
+   "sha256": "f43695e0cb1ee45025fd2241982396f2b977721982fdda713be7b1d0d4778dc0",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/pd_cutscn_simple.map": {
+   "bytes": 7287,
+   "sha256": "6b5ba73144ce9064285b18f6f4b4a7b9f3c2ad393d9e90d4154c9be59d26df6d",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/pd_cutscn_tracking.map": {
+   "bytes": 8449,
+   "sha256": "f59516819769d2de1fad79c4e9b038945ce1dc161895b8d8a6bd813500e9958e",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/pd_elevator.map": {
+   "bytes": 119446,
+   "sha256": "bf396400de142fecba83e37b6f9f4db743a69165281300229c1f1c9ed9d91dc6",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/pd_gallery.map": {
+   "bytes": 512470,
+   "sha256": "6646abd523cdddaf9866924114b94318c91dd687372ef5d425e52b5fa017d987",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/pd_gravity.map": {
+   "bytes": 665869,
+   "sha256": "6e43f81988efd5c51b27b6080f249790c2428de1a311eb912a60caca03ebca5a",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/pd_ionous.map": {
+   "bytes": 1477670,
+   "sha256": "1abfdc9af48ce42ff0f2febb05ed95ac16f3724a127f12eca60d67c2e384bd1f",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/pd_keys.map": {
+   "bytes": 100921,
+   "sha256": "29010ccc745dcb05014a30870779fdd10ede8ebbf26319b0655a83a7b12e4e89",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/pd_ladders.map": {
+   "bytes": 221833,
+   "sha256": "f701d706228770e1937b362474746715d43b2c7fe4f8616d26d3a1111260274d",
+   "timestamp": "2024-08-20T15:53:20.000Z"
+  },
+  "old_town/development/map src/pd_lasers.map": {
+   "bytes": 359757,
+   "sha256": "23e84fb47b9408591c874ca29e6b1b63053706b7b0b87f166513e9636360c3c2",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/pd_lava.map": {
+   "bytes": 103304,
+   "sha256": "55534ae3ffbc0c657302eb640cd599675583b3c894f71057a8c7ec950a8faceb",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/pd_lightning.map": {
+   "bytes": 210754,
+   "sha256": "448de9156c66a63400c5e6baa60f475a77b62bb715f058db7c64aec65e20e865",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/pd_meat.map": {
+   "bytes": 274823,
+   "sha256": "27a8bc7bdd122f28b39b3abdadf9b0c07f0978b9c2baccc51bca9a4f9d862492",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/pd_rotate.map": {
+   "bytes": 62893,
+   "sha256": "1f23a1daf1093d9e8090bf282aada837f56e9809dc13cc04548d4d3f1ea7b52f",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/pd_turrets.map": {
+   "bytes": 385149,
+   "sha256": "bb5c817e3bcb66cb22262d82e3f586921e210595a188212c1671a59973a83b31",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/pd_void.map": {
+   "bytes": 71854,
+   "sha256": "855609f6b69ae09c01ecc8775e2c08cf80dd5cdab5dbae8e75ebc4935131985b",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/pd_yoder.map": {
+   "bytes": 428262,
+   "sha256": "3e03ed380befbb7b618c13c0076c107df9e155508d70e8d0bd3b7c287d6db69a",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/pd_zombies.map": {
+   "bytes": 178679,
+   "sha256": "cb2bd9621f1727c2ff001d40c77993b21105fe20ea4d573045733c41832c3ee9",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/prefab_ammo_backpack.map": {
+   "bytes": 7518,
+   "sha256": "817f4c424215d69c0cbbc1176b71fc02397547474f66325378587b27ff962c58",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/prefab_assets.map": {
+   "bytes": 34150,
+   "sha256": "c20297cdd24d5147f0bd98bba7d98d6bc909639d50f4f61ce413680d7616ca7e",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/prefab_estate.map": {
+   "bytes": 95441,
+   "sha256": "1e4fa1b1509bf0b979c609526f23ceb62fee78ecce28f91c91f190d9ebc41837",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/prefab_fog.map": {
+   "bytes": 100883,
+   "sha256": "c8dcbac6b6594efa35d36f1c571cb7e3bbdac1af592386796fe13a4e320d778e",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/prefab_func_fall2.map": {
+   "bytes": 114836,
+   "sha256": "62a2dc6e137858f19b8c348d8a469c1a91e1b69631c6bd71ecb558df12c5afae",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/prefab_homing.map": {
+   "bytes": 13633,
+   "sha256": "bdf1e1fc134da5112fbe3c779faeac1ac77bb4783cf37c738fefe18a9245c0e6",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/prefab_infighting.map": {
+   "bytes": 8957,
+   "sha256": "81e53ae7c19f7b7dee4fedc05bda23eb1410c96dd95070a1733520a333d10c81",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/prefab_info_intermissiontext.map": {
+   "bytes": 7678,
+   "sha256": "46a427a159df517c857dff2d2d523bbaf2a260ad49c3d67a2e959460144b5213",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/prefab_monsterface.map": {
+   "bytes": 11238,
+   "sha256": "0cfd94581f215d5ba07af3ccb501e749ef78ce3fbfb89603fb626ee835f44481",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/prefab_shadows.map": {
+   "bytes": 33038,
+   "sha256": "bc03744a37728590aa6eac4227fa77fdd3752075efd9bf14e59d51b5c3cde38a",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/prefab_spawner.map": {
+   "bytes": 8761,
+   "sha256": "a9c86cacc4f0999d78cb874e41978bcb8f97cba7fca23a57b113d808b9cf6cf2",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/prefab_styles.map": {
+   "bytes": 120363,
+   "sha256": "906531b089791a90de7badf5a9a2c7a572009a2e3d0435b0362ff550f4395670",
+   "timestamp": "2024-08-20T15:53:22.000Z"
+  },
+  "old_town/development/map src/prefab_textstory.map": {
+   "bytes": 10541,
+   "sha256": "80df00f7121d4d1fdaee642891f45a1c8c8ba9f73b36c60065ff4efa6be83eac",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/map src/prefab_trains.map": {
+   "bytes": 9573,
+   "sha256": "69deb4e4f92059cc16f60ea8e8faf111c02f5efd16770335ac25746b105f51c5",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/map src/prefab_trig_filter.map": {
+   "bytes": 13494,
+   "sha256": "ae309c0e8b452fabb61d89f43594e2d7e9e141da817c64e937ba550b93986b3e",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/map src/start.map": {
+   "bytes": 631458,
+   "sha256": "451f372dd3d91163cce4fb6efc1f183c8835429903c3c5a3f1cc399f37da8b07",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/quakec src/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:06.000Z"
+  },
+  "old_town/development/quakec src/LICENSE": {
+   "bytes": 18431,
+   "sha256": "189b1af95d661151e054cea10c91b3d754e4de4d3fecfb074c1fb29476f7167b",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/ai.qc": {
+   "bytes": 18597,
+   "sha256": "bcd2d7de7ce600d39bbc9b189a2d9a6bde75cdcd0800e46bb14994424b287b26",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/quakec src/boss.qc": {
+   "bytes": 13803,
+   "sha256": "41ca279d62544cdb718df7bc2905e7bb5df06706c54ef348d2d478470a4d5515",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/quakec src/boss2.qc": {
+   "bytes": 16431,
+   "sha256": "d495677614d54635fe5f12d0f0d3fd88b88486d42ff2cc1cb467111390e79a84",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/quakec src/buttons.qc": {
+   "bytes": 4446,
+   "sha256": "58ff5453eac2d012d5514d6c10babe85187744e1bd293720b2c1bda1109ebe04",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/quakec src/changelog.txt": {
+   "bytes": 14317,
+   "sha256": "392ca6557e6c056f260904e815143403d98ecb8b6dde96d34cd98fc5504995fb",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/quakec src/client.qc": {
+   "bytes": 35005,
+   "sha256": "84ad056d736b796c3ca4000c41c5dc9cd487489bc4fd35eb2914c3c65f19c63b",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/quakec src/combat.qc": {
+   "bytes": 9118,
+   "sha256": "287c8d9d90a5dae838f6e2ced580bd306e545f255484a94308331a20d1c01d9b",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/quakec src/cshift.qc": {
+   "bytes": 1747,
+   "sha256": "b3442a5eb8b04cfdcd2020dcc0099883e22f04153560308f793d0fcad8b3efbb",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/quakec src/custom_mdls.qc": {
+   "bytes": 2275,
+   "sha256": "74f7e0e8bb25b8a70d54f1168ee90c773ee1bd909b15e045128f61e018716cc4",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/quakec src/customsounds.qc": {
+   "bytes": 5564,
+   "sha256": "26bce1b876f3a8a709a2b61298d1f65de5f568f24ac66db713e8585afc694f5d",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/quakec src/cutscene.qc": {
+   "bytes": 30738,
+   "sha256": "7b4d2fd6a7ffd2c2da115447e9f348a552d20c59728a072c7ced6308d31c0130",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/quakec src/defs.qc": {
+   "bytes": 28880,
+   "sha256": "7cabf435fd377fcdce5895ee1d0a27e91c46a002a4b1689df712dc8b06546a57",
+   "timestamp": "2024-08-20T15:53:24.000Z"
+  },
+  "old_town/development/quakec src/demon.qc": {
+   "bytes": 15607,
+   "sha256": "14a99a3a771dfb5c0ddc4393a3cb520994a98fd16573f8ac6d6056a5b336f4f6",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/doelightning.qc": {
+   "bytes": 4955,
+   "sha256": "4b6233156f3792d7529d714de7f992c066a927d5f9109d9947caa2a7a2341c57",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/doeplats.qc": {
+   "bytes": 15495,
+   "sha256": "754e13c54f3d8ffc76ba80a1a7fbb3825ad5b300d9ff7f48195a7c6773036e80",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/dog.qc": {
+   "bytes": 15129,
+   "sha256": "3434cfe57a78759e0295ba717cafee2514ac01ae737732be046b7708e23da988",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/doors.qc": {
+   "bytes": 21714,
+   "sha256": "123edcc73083fd893140f1f4e5c337ca5925b923aa8f46862d1029ea1142afbe",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/dtmisc.qc": {
+   "bytes": 30024,
+   "sha256": "f383fb5017b305923ddbe5a71868e20567128c1fd4b66d5a9a761d7e3ee1e510",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/dtquake.qc": {
+   "bytes": 2654,
+   "sha256": "170b5464e0092f6a2f261910108381fd93fdb7fb5dd7bc047863f7bcc462dd9a",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/elevatr.qc": {
+   "bytes": 3624,
+   "sha256": "eb6a260d53ca8f7b69f20a8cc42341c597d5e06ea18bca86e6aabff71bbc892b",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/enforcer.qc": {
+   "bytes": 32786,
+   "sha256": "42de3a45a987bf7cf1921cc27d1d2a94129a43a4f8bb8b1de361e68968983ed7",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/fight.qc": {
+   "bytes": 9867,
+   "sha256": "0c2b4e3afe48260206e086c9742bf99c34f4c83993a368c0cfca764a84813add",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/fish.qc": {
+   "bytes": 11993,
+   "sha256": "d360b27d2e57192c2ebbaacd8532cdf7cd0330d63592032671c3b2efe5e41276",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/fog.qc": {
+   "bytes": 15746,
+   "sha256": "8e89fb2fa6a035620617bf155a531cff3261c60711a5c8237283970383ab2727",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/func_bob.qc": {
+   "bytes": 5676,
+   "sha256": "5fe11638fd89f509759c83748c519b98dc5fe5856b09fab1f6247518b9836143",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/func_brush.qc": {
+   "bytes": 1471,
+   "sha256": "cec99401fbecf0b4b07c81d79f13f3ea05a0f13296e75ddc3fcab4fff0dbd1f8",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/func_fall2.qc": {
+   "bytes": 8668,
+   "sha256": "eed5a376c5bc5a9262d2a6d08d46c67b3cae39a89830912a37d015e02e52d692",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/hipcount.qc": {
+   "bytes": 5217,
+   "sha256": "da5c096495966fa9ef5315ba00b315987349a817c889b974d8a91f506e6aee1d",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/hippart.qc": {
+   "bytes": 7983,
+   "sha256": "730ed584b4de9dd49283502419a8bcafb99e2f1a3d146e05afee0ab2547751c3",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/hiptrig.qc": {
+   "bytes": 6589,
+   "sha256": "4a5b1c58309c0a2c2d44d6d1a455263decba46bd965d71dd4e600aebb07c47e9",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/hknight.qc": {
+   "bytes": 30265,
+   "sha256": "1588171c8243cb9b71676cc35bb26cbfebe05e6577ea7a38c4cab8b7107ff3d0",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/intermission.qc": {
+   "bytes": 11029,
+   "sha256": "a3f031f373dffa837a1988445fffd7d9b979af9a675d2cba7f4e2bccc8f0a486",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/items.qc": {
+   "bytes": 66714,
+   "sha256": "85e2b7e7afcf5b0dab8db0f88187c5858c5790bffd98c44abd4269799e813c3d",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/keydata.qc": {
+   "bytes": 5639,
+   "sha256": "5902993c9755a2851ef424e48572a9806d20d3aae67a8f9d01446c4aad09a91a",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/keylock.qc": {
+   "bytes": 5884,
+   "sha256": "26751c63554a6e73da84138ee45871f501d3bb5250cbfa137a524087bc204e39",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/knight.qc": {
+   "bytes": 14999,
+   "sha256": "b03ffc882929eece408722163dd9c5d25f34d8096417c3288c276c5e6778dde9",
+   "timestamp": "2024-08-20T15:53:26.000Z"
+  },
+  "old_town/development/quakec src/lights.qc": {
+   "bytes": 16031,
+   "sha256": "5dc78d48aaafe3abdc220c3db75be4828bfba85fc25bbd62e799a29f4532a173",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/math.qc": {
+   "bytes": 4317,
+   "sha256": "961dd24bcc4b1941fc249a6d148e2a562e24fda4efc9e47e1040b516f8d86c2f",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/misc.qc": {
+   "bytes": 55326,
+   "sha256": "68871a011e43233445b6753cbceff302be8e570b8fb9049eeab2c032f1204681",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/misc_model.qc": {
+   "bytes": 5082,
+   "sha256": "9b7e616256997b563c1e5ab44918cd4b936606e2d26d2cb79f7e3b270623546c",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/mobot.qc": {
+   "bytes": 14723,
+   "sha256": "4d60beb5060a27a82d33ad6bcb5977e116bb9b93d9311aa7a30f925283b29be8",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/monsters.qc": {
+   "bytes": 12877,
+   "sha256": "4f5e2c7356a11bbd1465e1148b554fd732c249360c68f32efd6baa3bec0a1114",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/newflags.qc": {
+   "bytes": 5870,
+   "sha256": "192bf31eb0f13e6e55342801a42608caf797bfdfbdf27750c78ae67b1c1c5568",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/ogre.qc": {
+   "bytes": 48366,
+   "sha256": "ac649ea8a41b1d4b4246f2e9c14bbc1cb7439381eba1b588c57545980f161930",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/oldone.qc": {
+   "bytes": 10467,
+   "sha256": "33ce6342a7c06ab06af995f235ab8170917db359a956d6fd96d00709c54a08c6",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/oldone2.qc": {
+   "bytes": 15136,
+   "sha256": "bad10c7974544972a4cdf8821eb745ea32a61de8bfa26c31b445ff1f619557c1",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/plats.qc": {
+   "bytes": 22678,
+   "sha256": "6ce695f58b859c09c7d79ae741b31246ca49a322515bbad54898dc19e0a5e448",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/player.qc": {
+   "bytes": 21779,
+   "sha256": "4c3935e710456c022c681ccf312109337616157bdebb7a72152f2ba37ec4cdce",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/progs.src": {
+   "bytes": 2033,
+   "sha256": "539b2dd5c36d69491e26a508c772d2f751529753f44465f48c52ce73cd8402d0",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/rotate.qc": {
+   "bytes": 31520,
+   "sha256": "ad5eee063eafd078f60ed3d247c19be9fc88887fd4c5aa307953c72089b53c6a",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/rubicon2.qc": {
+   "bytes": 29182,
+   "sha256": "aef0904a68af683fb3002effa918306ddfbe4230a18fd3470af107bd34105357",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/shalrath.qc": {
+   "bytes": 15839,
+   "sha256": "032b2f1eae78332de56603af833af57d78fa47ac29bf6eaf0a72c588b9e5c5df",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/shambler.qc": {
+   "bytes": 26084,
+   "sha256": "782cdf07726bb5c9b63fe93d880b39b9a6657463d4b145b53d26fb21290e8453",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/soldier.qc": {
+   "bytes": 21847,
+   "sha256": "28e94fd02188befb535bd16512cd6e7f4af3bdb5ef4a4cd6431965d8caf82474",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/spawn.qc": {
+   "bytes": 10642,
+   "sha256": "51571dd7851c2daf9d657b19350e05f5d10f85a212afcdd06757e1a27df7ef83",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/subs.qc": {
+   "bytes": 18016,
+   "sha256": "a7636b244cf1b7b8646feff48300c0ba8dd2d4e4169e18f14971de6904169880",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/triggers.qc": {
+   "bytes": 51080,
+   "sha256": "0fa737b126deb2e312b3f42bbd7f82281fbcf1f35df6faf4f19d6a0259f07bf5",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/utility.qc": {
+   "bytes": 4842,
+   "sha256": "a29fb47736072ad009a77ac4e063f9f7f4f854327b6c829a8e0403f4756c9994",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/weapons.qc": {
+   "bytes": 41766,
+   "sha256": "faceddfc37e7b414656a4660b9f951d2eb90424a01599ec02c9f7e912cc693a8",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/wizard.qc": {
+   "bytes": 16699,
+   "sha256": "02e4dfd2e264fd5901aaa3bb0a0ceb6381fc67027ddbba795c3702056a83cda2",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/world.qc": {
+   "bytes": 21577,
+   "sha256": "37578572550ac480bf0ace9d44b0082768115490950dee14731782dfc41cde16",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/quakec src/zombie.qc": {
+   "bytes": 39679,
+   "sha256": "f2f4e0d2328c396087f9c4a06823861e5095f1c1ed7ec7a4163c8de350126fa4",
+   "timestamp": "2024-08-20T15:53:28.000Z"
+  },
+  "old_town/development/wads/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:06.000Z"
+  },
+  "old_town/development/wads/pd_300.wad": {
+   "bytes": 5318172,
+   "sha256": "8b690e008ebd6fac13ca430a00201bd93d04eaf6404420ebefbe65f5d2677865",
+   "timestamp": "2024-08-20T15:53:30.000Z"
+  },
+  "old_town/gfx/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T03:04:46.000Z"
+  },
+  "old_town/gfx/env/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:06.000Z"
+  },
+  "old_town/gfx/env/nottingham_bk.tga": {
+   "bytes": 786476,
+   "sha256": "489312e45d80a925fb2e39d333de680e4d05dafd46ea1c405e5f25a01bee2c3a",
+   "timestamp": "2024-08-24T18:51:10.000Z"
+  },
+  "old_town/gfx/env/nottingham_dn.tga": {
+   "bytes": 786476,
+   "sha256": "994b72e5aa3fd87306def61459b83e7a0eb60e368617351f213e0a57dc89acbe",
+   "timestamp": "2024-08-24T18:51:10.000Z"
+  },
+  "old_town/gfx/env/nottingham_ft.tga": {
+   "bytes": 786476,
+   "sha256": "66aba7ef56429cce5ff83f171af4da562b040772829978f0c24d2b82b1790ef7",
+   "timestamp": "2024-08-24T18:51:10.000Z"
+  },
+  "old_town/gfx/env/nottingham_lf.tga": {
+   "bytes": 786476,
+   "sha256": "cf6ed9373d79b43aa1a67d01fa7d0f54cbebb6b6219dc50469203983698c5f57",
+   "timestamp": "2024-08-24T18:51:10.000Z"
+  },
+  "old_town/gfx/env/nottingham_rt.tga": {
+   "bytes": 786476,
+   "sha256": "509f76432293b80cca89973a6c5a52ec30a2787917d2d69200ed4bb76a707e52",
+   "timestamp": "2024-08-24T18:51:10.000Z"
+  },
+  "old_town/gfx/env/nottingham_up.tga": {
+   "bytes": 786476,
+   "sha256": "a1cb380c2b0832907041de4c1eff15f1bf598b2b7667bfe7369b2b06de648ccc",
+   "timestamp": "2024-08-24T18:51:10.000Z"
+  },
+  "old_town/maps/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:24:00.000Z"
+  },
+  "old_town/maps/debris/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:06.000Z"
+  },
+  "old_town/maps/debris/brick01.bsp": {
+   "bytes": 7912,
+   "sha256": "c11880924b195ed38908cbf50f9cd16f071918df0a94a19c7254b93dddb1e62d",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/maps/debris/wood1.bsp": {
+   "bytes": 7584,
+   "sha256": "c39390e3757553352941fcc255da6498be4c25a87575871e360a0166fac592bc",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/maps/prehevil_alone.bsp": {
+   "bytes": 1320600,
+   "sha256": "d076d436aa1c6d89dad4d98b8449bddb75c75b9707920f0a07fa89ff56630b3c",
+   "timestamp": "2024-09-05T01:39:28.000Z"
+  },
+  "old_town/maps/prehevil_alone.lit": {
+   "bytes": 215306,
+   "sha256": "a9b2d702d01c19b2bab01a85e515fce99e263df5d025be2fb2fbfd3a41a2b6c4",
+   "timestamp": "2024-09-05T01:39:28.000Z"
+  },
+  "old_town/music/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:06.000Z"
+  },
+  "old_town/music/track13.ogg": {
+   "bytes": 3474765,
+   "sha256": "087b6184f82d623422b827c05641a9ded438ede4232aebf11a7ac9c6d7e549be",
+   "timestamp": "2024-08-25T10:47:22.000Z"
+  },
+  "old_town/music/track99.ogg": {
+   "bytes": 50630,
+   "sha256": "74a294d5c958f9284d68ce2c667f233e87c9f57ef0abe3e7471bea257823c0b7",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs.dat": {
+   "bytes": 749842,
+   "sha256": "cf5045e62b6668ef38eece435e868c67dcc3051212d1fab442c2413a71e57f41",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:06.000Z"
+  },
+  "old_town/progs/a_mdls/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:06.000Z"
+  },
+  "old_town/progs/a_mdls/m_cells1.mdl": {
+   "bytes": 3252,
+   "sha256": "1cdfc2b54dd883efe9215499603e341bfa72e800740a2e874e9bcf3b0afc68ba",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/a_mdls/m_cells2.mdl": {
+   "bytes": 4532,
+   "sha256": "8cb54159eeaa410b98478e9190bd2d33340d3a2e98a61d32ce1afaf4e99031a0",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/a_mdls/m_nails1.mdl": {
+   "bytes": 3252,
+   "sha256": "ac361970fb1cbbb87ad4593afecd6d8973a65ea4f14e5f7b565c8f38c181fa9d",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/a_mdls/m_nails2.mdl": {
+   "bytes": 4532,
+   "sha256": "0870b633f95bda895074e8d423631ee8805c3923f36a1c7f09938710783e8f99",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/a_mdls/m_rock1.mdl": {
+   "bytes": 3252,
+   "sha256": "146955794f29c02f6570eed83e1d4b0013b0b4341897bcbc91cc9ffea6957ff4",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/a_mdls/m_rock2.mdl": {
+   "bytes": 4532,
+   "sha256": "59988afc3603b83ccfadf0a9af423a113bf15ed969d4a62db9073e3061bc0fdc",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/a_mdls/m_shell1.mdl": {
+   "bytes": 3252,
+   "sha256": "696594c11dd6dbd2e60ac6923d82a55f8f5b16e93b93f7914abe5fd4df74299f",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/a_mdls/m_shell2.mdl": {
+   "bytes": 4532,
+   "sha256": "b558ee2dfd0078c7e3075079fb40368f53e7dfb162aaefcd20e53f562e405b1b",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/armshr.mdl": {
+   "bytes": 20012,
+   "sha256": "1873523424395b404ffafeb447383185e033826e33bf0a001efc34604ece95da",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs/candle.mdl": {
+   "bytes": 24135,
+   "sha256": "5027f8712c36de87b3967e4e623fbc64d4e99644f5b805f7e21ec38b1532cc74",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs/debris.mdl": {
+   "bytes": 263072,
+   "sha256": "2b60cba9cbb454e3524d174edc0e1a540f2b2e91fa0b35fc2ab20ccb7fabd8d1",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs/enforcer.mdl": {
+   "bytes": 472208,
+   "sha256": "3345599ba081d346c163f5c239815bd65b134ccf342601f42a31e60a45044f39",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs/g_shotgu.mdl": {
+   "bytes": 29076,
+   "sha256": "4a8866ab410a93522a3d3221e0f3b45889a488b54c0551329f09493273e09840",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs/h_boss.mdl": {
+   "bytes": 24028,
+   "sha256": "b41e2302e15d7cb47bf1eb4ee1df29e7e8d773a3dfc6059f5b1f8ce18685bba6",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs/h_mdls/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:06.000Z"
+  },
+  "old_town/progs/h_mdls/m_h100.mdl": {
+   "bytes": 17992,
+   "sha256": "2e7fac7418838a721d80e80370000f3e400b21248b22c8d3555588d4f8437a5b",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/h_mdls/m_h15.mdl": {
+   "bytes": 3252,
+   "sha256": "1f4b0791be3156763c15521fbf2e747744ce3355d90d630b01c2227770314771",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/h_mdls/m_h25.mdl": {
+   "bytes": 14792,
+   "sha256": "6f792b9a80f34e31bceb4258e1d2c8f22d405a7ae1198b31bb285f502c720cfe",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/h_mdls/pd_vial.mdl": {
+   "bytes": 8292,
+   "sha256": "035673048c98991e790abe484c2403b56dfe5ea1f5fb185c1b7a657d918668e8",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/h_ogre.mdl": {
+   "bytes": 42048,
+   "sha256": "52760ce1f6e8f657e782846571baf9fde80859f5342d07a684fa8218f96f68db",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs/k_spike2.mdl": {
+   "bytes": 444704,
+   "sha256": "e466e7afa95868ec1a3b3bfc770573d93dc20c2d881a73d2b9b0e35f1dfa6d9b",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs/lspike.mdl": {
+   "bytes": 1684,
+   "sha256": "59264317258f19955b967177f0dbc5be1733e4ca07c4c7b3cc333bb88bc0c46e",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs/mervup.mdl": {
+   "bytes": 32948,
+   "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs/nuflak.mdl": {
+   "bytes": 1780,
+   "sha256": "ba2f2fba4b6965a1e1f2133a1ed4534383299a30b87477828c530458a392288b",
+   "timestamp": "2024-08-27T06:56:30.000Z"
+  },
+  "old_town/progs/ogre.mdl": {
+   "bytes": 366916,
+   "sha256": "29fa9866dd4862b99ebb9944ddb0bf24a6d0bb4bf00e26a94d3622cead9b6315",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs/ogrealls.mdl": {
+   "bytes": 319244,
+   "sha256": "ee1e9e6a71f8acc35e7bd4356330f094b350d757ab89218a72b41f691e5c31b1",
+   "timestamp": "2024-09-04T05:50:24.000Z"
+  },
+  "old_town/progs/pd_b_key.mdl": {
+   "bytes": 128440,
+   "sha256": "c5aff23b766037ab550636516d7fe0235dacf566ddb966541d640092bcb62349",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs/pd_bpack.mdl": {
+   "bytes": 216724,
+   "sha256": "1839c92899197344935eca44d7b4c70e903af84ab633259786f8c12c39905149",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs/pd_r_key.mdl": {
+   "bytes": 269528,
+   "sha256": "7ef6894b955c4ca34bf3e2ebdc6288f55cc3b1285478444a81ca769866e1a119",
+   "timestamp": "2024-08-24T17:44:08.000Z"
+  },
+  "old_town/progs/pd_w_key.mdl": {
+   "bytes": 170680,
+   "sha256": "73f06fc10a53c93db25d67f20bad7672bc5f4e14bf3a6b5115d68f00696b536a",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/s_flame.spr": {
+   "bytes": 47856,
+   "sha256": "99fc3f91856aa6df2f25494a945e17b64b59ddc3faed424a6fcd73062a677fcc",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/s_null.spr": {
+   "bytes": 1080,
+   "sha256": "e306ec0fbf0f5e4306c6683f7c7b87674bb0a168ef32a2b1118dcffb083deeff",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/soldier.mdl": {
+   "bytes": 320900,
+   "sha256": "e3321220ed34292da63fac94af63360c6544c055edd1eceed35d75eb26685e9b",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/spark.mdl": {
+   "bytes": 2544,
+   "sha256": "77d081c51af9bd6c82d2d51dcb955a2fca5189cda4eb09a138bfa2e2b521fb05",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/spike.mdl": {
+   "bytes": 4416,
+   "sha256": "8c70353304b2d111260102565745a5504144568f932787906eaf50de742aa62c",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/teleport.mdl": {
+   "bytes": 1058800,
+   "sha256": "98eeb63a1ded2d7a1d3788562478aff891af1be4ef1c552bcdb913cb338387b6",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/v_spike.mdl": {
+   "bytes": 1058816,
+   "sha256": "ac4d47130af263cb6fd861d70ac09ebf758ab1a76da0b697e268382c65ae1a16",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs/w_spike.mdl": {
+   "bytes": 311493,
+   "sha256": "add013a5a6686ffd76ec0f2b2b3413757432ba4a8564ffd81aeb7eb2c5a98398",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/progs_dump-devkit-readme.txt": {
+   "bytes": 9360,
+   "sha256": "c8eb11121c42e133e391a016cae91abbd3766508d4108bf5a74ce61e6d8f2723",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quake.rc": {
+   "bytes": 469,
+   "sha256": "490877c3d81446c26fd36f25b358a0e0e109e6b3566f23a6a2d41c8319849750",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:08.000Z"
+  },
+  "old_town/quakec src/LICENSE": {
+   "bytes": 18431,
+   "sha256": "189b1af95d661151e054cea10c91b3d754e4de4d3fecfb074c1fb29476f7167b",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/ai.qc": {
+   "bytes": 18597,
+   "sha256": "bcd2d7de7ce600d39bbc9b189a2d9a6bde75cdcd0800e46bb14994424b287b26",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/boss.qc": {
+   "bytes": 13803,
+   "sha256": "41ca279d62544cdb718df7bc2905e7bb5df06706c54ef348d2d478470a4d5515",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/boss2.qc": {
+   "bytes": 16431,
+   "sha256": "d495677614d54635fe5f12d0f0d3fd88b88486d42ff2cc1cb467111390e79a84",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/buttons.qc": {
+   "bytes": 4446,
+   "sha256": "58ff5453eac2d012d5514d6c10babe85187744e1bd293720b2c1bda1109ebe04",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/changelog.txt": {
+   "bytes": 14317,
+   "sha256": "392ca6557e6c056f260904e815143403d98ecb8b6dde96d34cd98fc5504995fb",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/client.qc": {
+   "bytes": 35005,
+   "sha256": "84ad056d736b796c3ca4000c41c5dc9cd487489bc4fd35eb2914c3c65f19c63b",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/combat.qc": {
+   "bytes": 9118,
+   "sha256": "287c8d9d90a5dae838f6e2ced580bd306e545f255484a94308331a20d1c01d9b",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/cshift.qc": {
+   "bytes": 1747,
+   "sha256": "b3442a5eb8b04cfdcd2020dcc0099883e22f04153560308f793d0fcad8b3efbb",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/custom_mdls.qc": {
+   "bytes": 2275,
+   "sha256": "74f7e0e8bb25b8a70d54f1168ee90c773ee1bd909b15e045128f61e018716cc4",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/customsounds.qc": {
+   "bytes": 5564,
+   "sha256": "26bce1b876f3a8a709a2b61298d1f65de5f568f24ac66db713e8585afc694f5d",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/cutscene.qc": {
+   "bytes": 30738,
+   "sha256": "7b4d2fd6a7ffd2c2da115447e9f348a552d20c59728a072c7ced6308d31c0130",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/defs.qc": {
+   "bytes": 28880,
+   "sha256": "7cabf435fd377fcdce5895ee1d0a27e91c46a002a4b1689df712dc8b06546a57",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/demon.qc": {
+   "bytes": 15607,
+   "sha256": "14a99a3a771dfb5c0ddc4393a3cb520994a98fd16573f8ac6d6056a5b336f4f6",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/doelightning.qc": {
+   "bytes": 4955,
+   "sha256": "4b6233156f3792d7529d714de7f992c066a927d5f9109d9947caa2a7a2341c57",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/doeplats.qc": {
+   "bytes": 15495,
+   "sha256": "754e13c54f3d8ffc76ba80a1a7fbb3825ad5b300d9ff7f48195a7c6773036e80",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/dog.qc": {
+   "bytes": 15129,
+   "sha256": "3434cfe57a78759e0295ba717cafee2514ac01ae737732be046b7708e23da988",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/doors.qc": {
+   "bytes": 21714,
+   "sha256": "123edcc73083fd893140f1f4e5c337ca5925b923aa8f46862d1029ea1142afbe",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/dtmisc.qc": {
+   "bytes": 30024,
+   "sha256": "f383fb5017b305923ddbe5a71868e20567128c1fd4b66d5a9a761d7e3ee1e510",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/dtquake.qc": {
+   "bytes": 2654,
+   "sha256": "170b5464e0092f6a2f261910108381fd93fdb7fb5dd7bc047863f7bcc462dd9a",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/elevatr.qc": {
+   "bytes": 3624,
+   "sha256": "eb6a260d53ca8f7b69f20a8cc42341c597d5e06ea18bca86e6aabff71bbc892b",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/enforcer.qc": {
+   "bytes": 32786,
+   "sha256": "42de3a45a987bf7cf1921cc27d1d2a94129a43a4f8bb8b1de361e68968983ed7",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/fight.qc": {
+   "bytes": 9867,
+   "sha256": "0c2b4e3afe48260206e086c9742bf99c34f4c83993a368c0cfca764a84813add",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/fish.qc": {
+   "bytes": 11993,
+   "sha256": "d360b27d2e57192c2ebbaacd8532cdf7cd0330d63592032671c3b2efe5e41276",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/fog.qc": {
+   "bytes": 15746,
+   "sha256": "8e89fb2fa6a035620617bf155a531cff3261c60711a5c8237283970383ab2727",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/func_bob.qc": {
+   "bytes": 5676,
+   "sha256": "5fe11638fd89f509759c83748c519b98dc5fe5856b09fab1f6247518b9836143",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/func_brush.qc": {
+   "bytes": 1471,
+   "sha256": "cec99401fbecf0b4b07c81d79f13f3ea05a0f13296e75ddc3fcab4fff0dbd1f8",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/func_fall2.qc": {
+   "bytes": 8668,
+   "sha256": "eed5a376c5bc5a9262d2a6d08d46c67b3cae39a89830912a37d015e02e52d692",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/hipcount.qc": {
+   "bytes": 5217,
+   "sha256": "da5c096495966fa9ef5315ba00b315987349a817c889b974d8a91f506e6aee1d",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/hippart.qc": {
+   "bytes": 7983,
+   "sha256": "730ed584b4de9dd49283502419a8bcafb99e2f1a3d146e05afee0ab2547751c3",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/hiptrig.qc": {
+   "bytes": 6589,
+   "sha256": "4a5b1c58309c0a2c2d44d6d1a455263decba46bd965d71dd4e600aebb07c47e9",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/hknight.qc": {
+   "bytes": 30265,
+   "sha256": "1588171c8243cb9b71676cc35bb26cbfebe05e6577ea7a38c4cab8b7107ff3d0",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/intermission.qc": {
+   "bytes": 11029,
+   "sha256": "a3f031f373dffa837a1988445fffd7d9b979af9a675d2cba7f4e2bccc8f0a486",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/items.qc": {
+   "bytes": 66714,
+   "sha256": "85e2b7e7afcf5b0dab8db0f88187c5858c5790bffd98c44abd4269799e813c3d",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/keydata.qc": {
+   "bytes": 5639,
+   "sha256": "5902993c9755a2851ef424e48572a9806d20d3aae67a8f9d01446c4aad09a91a",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/keylock.qc": {
+   "bytes": 5884,
+   "sha256": "26751c63554a6e73da84138ee45871f501d3bb5250cbfa137a524087bc204e39",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/knight.qc": {
+   "bytes": 14999,
+   "sha256": "b03ffc882929eece408722163dd9c5d25f34d8096417c3288c276c5e6778dde9",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/lights.qc": {
+   "bytes": 16031,
+   "sha256": "5dc78d48aaafe3abdc220c3db75be4828bfba85fc25bbd62e799a29f4532a173",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/math.qc": {
+   "bytes": 4317,
+   "sha256": "961dd24bcc4b1941fc249a6d148e2a562e24fda4efc9e47e1040b516f8d86c2f",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/misc.qc": {
+   "bytes": 55326,
+   "sha256": "68871a011e43233445b6753cbceff302be8e570b8fb9049eeab2c032f1204681",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/misc_model.qc": {
+   "bytes": 5082,
+   "sha256": "9b7e616256997b563c1e5ab44918cd4b936606e2d26d2cb79f7e3b270623546c",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/mobot.qc": {
+   "bytes": 14723,
+   "sha256": "4d60beb5060a27a82d33ad6bcb5977e116bb9b93d9311aa7a30f925283b29be8",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/monsters.qc": {
+   "bytes": 12877,
+   "sha256": "4f5e2c7356a11bbd1465e1148b554fd732c249360c68f32efd6baa3bec0a1114",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/newflags.qc": {
+   "bytes": 5870,
+   "sha256": "192bf31eb0f13e6e55342801a42608caf797bfdfbdf27750c78ae67b1c1c5568",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/ogre.qc": {
+   "bytes": 48366,
+   "sha256": "ac649ea8a41b1d4b4246f2e9c14bbc1cb7439381eba1b588c57545980f161930",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/oldone.qc": {
+   "bytes": 10467,
+   "sha256": "33ce6342a7c06ab06af995f235ab8170917db359a956d6fd96d00709c54a08c6",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/oldone2.qc": {
+   "bytes": 15136,
+   "sha256": "bad10c7974544972a4cdf8821eb745ea32a61de8bfa26c31b445ff1f619557c1",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/plats.qc": {
+   "bytes": 22678,
+   "sha256": "6ce695f58b859c09c7d79ae741b31246ca49a322515bbad54898dc19e0a5e448",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/player.qc": {
+   "bytes": 21779,
+   "sha256": "4c3935e710456c022c681ccf312109337616157bdebb7a72152f2ba37ec4cdce",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/progs.src": {
+   "bytes": 2033,
+   "sha256": "539b2dd5c36d69491e26a508c772d2f751529753f44465f48c52ce73cd8402d0",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/rotate.qc": {
+   "bytes": 31520,
+   "sha256": "ad5eee063eafd078f60ed3d247c19be9fc88887fd4c5aa307953c72089b53c6a",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/rubicon2.qc": {
+   "bytes": 29182,
+   "sha256": "aef0904a68af683fb3002effa918306ddfbe4230a18fd3470af107bd34105357",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/shalrath.qc": {
+   "bytes": 15839,
+   "sha256": "032b2f1eae78332de56603af833af57d78fa47ac29bf6eaf0a72c588b9e5c5df",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/shambler.qc": {
+   "bytes": 26084,
+   "sha256": "782cdf07726bb5c9b63fe93d880b39b9a6657463d4b145b53d26fb21290e8453",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/soldier.qc": {
+   "bytes": 21847,
+   "sha256": "28e94fd02188befb535bd16512cd6e7f4af3bdb5ef4a4cd6431965d8caf82474",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/spawn.qc": {
+   "bytes": 10642,
+   "sha256": "51571dd7851c2daf9d657b19350e05f5d10f85a212afcdd06757e1a27df7ef83",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/subs.qc": {
+   "bytes": 18016,
+   "sha256": "a7636b244cf1b7b8646feff48300c0ba8dd2d4e4169e18f14971de6904169880",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/triggers.qc": {
+   "bytes": 51080,
+   "sha256": "0fa737b126deb2e312b3f42bbd7f82281fbcf1f35df6faf4f19d6a0259f07bf5",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/utility.qc": {
+   "bytes": 4842,
+   "sha256": "a29fb47736072ad009a77ac4e063f9f7f4f854327b6c829a8e0403f4756c9994",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/weapons.qc": {
+   "bytes": 41766,
+   "sha256": "faceddfc37e7b414656a4660b9f951d2eb90424a01599ec02c9f7e912cc693a8",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/wizard.qc": {
+   "bytes": 16699,
+   "sha256": "02e4dfd2e264fd5901aaa3bb0a0ceb6381fc67027ddbba795c3702056a83cda2",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/world.qc": {
+   "bytes": 21577,
+   "sha256": "37578572550ac480bf0ace9d44b0082768115490950dee14731782dfc41cde16",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quakec src/zombie.qc": {
+   "bytes": 39679,
+   "sha256": "f2f4e0d2328c396087f9c4a06823861e5095f1c1ed7ec7a4163c8de350126fa4",
+   "timestamp": "2024-08-24T17:44:10.000Z"
+  },
+  "old_town/quick.sav": {
+   "bytes": 31425,
+   "sha256": "542a73016c75c136a93bcf837993e29cabe8d739a7c66d1c830c5c10782ec44b",
+   "timestamp": "2024-08-27T10:21:44.000Z"
+  },
+  "old_town/screenshots/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:08.000Z"
+  },
+  "old_town/screenshots/prehevil_alone_2024-09-05_01-47-05.png": {
+   "bytes": 2116400,
+   "sha256": "a715ee0bf549fb0e2dfe1b9c8b465c14889c0dc6c4a1095cf2c5e54b88b2b0c2",
+   "timestamp": "2024-09-05T01:47:04.000Z"
+  },
+  "old_town/screenshots/prehevil_alone_2024-09-05_01-47-13.png": {
+   "bytes": 2339818,
+   "sha256": "b0c574f587dae8d61cf3cd4958d87a6c3fd2c28536b93abded0f587852fb2643",
+   "timestamp": "2024-09-05T01:47:12.000Z"
+  },
+  "old_town/screenshots/prehevil_alone_2024-09-05_01-47-20.png": {
+   "bytes": 2264250,
+   "sha256": "ee0449b8b53839d06e941da437f82e422423bc8e96b418e3e0b061c437773cae",
+   "timestamp": "2024-09-05T01:47:20.000Z"
+  },
+  "old_town/sound/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T03:04:46.000Z"
+  },
+  "old_town/sound/break/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:08.000Z"
+  },
+  "old_town/sound/break/bricks1.wav": {
+   "bytes": 49956,
+   "sha256": "302547c290609bc311098f9f63643199bee0164e907edf0e2b9289ccbce2a4e2",
+   "timestamp": "2024-08-24T17:44:14.000Z"
+  },
+  "old_town/sound/break/metal1.wav": {
+   "bytes": 70054,
+   "sha256": "c178f8f52631b1ff353fbeb3557e04e8bd574646ed47f78a3003350b67540979",
+   "timestamp": "2024-08-24T17:44:14.000Z"
+  },
+  "old_town/sound/break/metal2.wav": {
+   "bytes": 65948,
+   "sha256": "7438b112d81fb92c285a507ebfbde5b15dbddcd90a85f51ecaae2df3ef83480c",
+   "timestamp": "2024-08-24T17:44:14.000Z"
+  },
+  "old_town/sound/break/stones1.wav": {
+   "bytes": 69380,
+   "sha256": "1b58b722e55c4e2d25f65e820e279699a7b236a02685fbc6a41a40e573df1928",
+   "timestamp": "2024-08-24T17:44:14.000Z"
+  },
+  "old_town/sound/break/wood1.wav": {
+   "bytes": 53720,
+   "sha256": "026e35d7108347603453765f66311fec99097ff9f82e2d2703f69b7d80ae07c9",
+   "timestamp": "2024-08-24T17:44:14.000Z"
+  },
+  "old_town/sound/break/wood2.wav": {
+   "bytes": 59252,
+   "sha256": "4488c91dc44e526beb95d33ad200e07e484a6f2fea59578784f3417a00df81f7",
+   "timestamp": "2024-08-24T17:44:14.000Z"
+  },
+  "old_town/sound/dump/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:08.000Z"
+  },
+  "old_town/sound/dump/armsh1.wav": {
+   "bytes": 22610,
+   "sha256": "46801976a87d548c2cb7b1548f12dfd0b3f1d246aa9d86944574fa3216c6d6d1",
+   "timestamp": "2024-08-24T17:44:14.000Z"
+  },
+  "old_town/sound/dump/elec22k.wav": {
+   "bytes": 178736,
+   "sha256": "d56ff98d1d41511833c35b5a8b5311f00b7e13932591eee53f9e2adf788569e1",
+   "timestamp": "2024-08-24T17:44:14.000Z"
+  },
+  "old_town/sound/dump/magic_01.wav": {
+   "bytes": 125944,
+   "sha256": "3ea2bab80feccbe0f0b518ec613f45093aa76b0128752f454e239c75175cb4e0",
+   "timestamp": "2024-08-24T17:44:14.000Z"
+  },
+  "old_town/sound/dump/pd_water.wav": {
+   "bytes": 92708,
+   "sha256": "0402b1fb2501dafb33bd43fa9c49c0f6a3fff615a200693cb7953852305c49f4",
+   "timestamp": "2024-08-24T17:44:14.000Z"
+  },
+  "old_town/sound/dump/rumble.wav": {
+   "bytes": 53068,
+   "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a",
+   "timestamp": "2024-08-24T17:44:14.000Z"
+  },
+  "old_town/sound/oldone2/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:08.000Z"
+  },
+  "old_town/sound/oldone2/pd_pop2.wav": {
+   "bytes": 42108,
+   "sha256": "1eec3103cd2eb70fa8ba63ce8ce721842a64a99e9c373f5a8abe5508273ce285",
+   "timestamp": "2024-08-24T17:44:14.000Z"
+  },
+  "old_town/sound/sogre/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2024-09-05T15:23:08.000Z"
+  },
+  "old_town/sound/sogre/axeswing.wav": {
+   "bytes": 19208,
+   "sha256": "08dee7e869b657f9431f49d975c95e775dd554c30056607963b2f5cce1918507",
+   "timestamp": "2024-08-27T04:51:30.000Z"
+  }
+ },
+ "install": {
+  "extract": "{base}/old_town/"
+ },
+ "json_version": "2023.11.06-23.20",
+ "sha256": "ff5c3a9b6b98bd547ed2f2dba776f3ec0a7b221fb393a9ba5675d0f110b8bfb9",
+ "tags": [
+  "author=Eternal_Summer",
+  "commandline=-game old_town",
+  "filename=old_town.zip",
+  "game=quake",
+  "game_mode=singleplayer",
+  "link=[Slipseer page](https://www.slipseer.com/index.php?resources/old-town.394/)",
+  "release_date=2024-09-06",
+  "startmap=prehevil_alone",
+  "title=Old Town",
+  "type=map",
+  "type=mod",
+  "zipbasedir=old_town/"
+ ],
+ "urls": [
+  "https://x901.net/quaddictedfiles/old_town.zip"
+ ]
+}


### PR DESCRIPTION
I'm resubmitting this. I've actioned some of the issues you raised but not all of them:

- Technical errors like empty tags have hopefully been fixed, trailing newlines from pastes were the main culprit here. I checked the new file in notepad before running the json script.
- I have not made any changes to generic notes, they aren't perfect but can be removed in bulk once proper functionality is added to the pages to highlight dependencies/increased limit/bsp2.
- I changed the handwritten note for Immortal Lock to something a bit more generic. I would argue a gentle nudge towards the readme is courteous for this map in particular.
- I have tweaked a number of descriptions that had some possibly-subjective wording. Immortal Lock & Tomb of Thunder in particular.
- I have not improved the short, lazy descriptions for GraveYardKaiser's maps as imho they are entirely consistent with the amount of effort put into the maps. 'Unsealed map in a variety of textures' is literally all I can say about two of them. If you object to them then I would ask you to just edit them to 'No description added'.
- I removed one use of the word 'new' you objected to but there are others I didn't, e.g. referring to 'new monsters and weapons', I like to think people wouldn't interpret the word as temporal but as 'custom created for this pack'. I figure if I was telling someone about, say, Scourge of Armagon, I'd probably still describe it as having 'new monsters', despite them being currently 27 years old!

On descriptions in general, I would personally prefer them as despite the DB going in a more machine-readable direction, the website is still used a lot by humans. Maybe a disclaimer could be added saying descriptions have been added by voluntary contributors and are do not necessarily reflect the views of Quaddicted? And a note that amendments can be made upon request? I think a lot of the flak can probably be avoided by just appearing to be flexible and valuing feedback.

But yeah, in the long run creators will hopefully be submitting their own descriptions. So like the notes, this is probably just a temporary thing in the name of consistency. At some point in the future there probably needs to be a big exercise in taking excerpts from readmes to use as user descriptions for all the stuff currently there, and the official descriptions slowly retired. Kicking that down the line though :D

On tags, I think when I started doing these batch updates I thought 'descriptive tags can just be added by users later on' like they were on the old site. Hopefully the new one gets to that point eventually and this job can be farmed out a bit.