### PR TITLE
Add more specific type tags

### DIFF
--- a/json/by-sha256/7c/7c3c3248aad0ed208ea072fc595220627d403f158a82884b0b6630f0f06229d9.json
+++ b/json/by-sha256/7c/7c3c3248aad0ed208ea072fc595220627d403f158a82884b0b6630f0f06229d9.json
@@ -505,6 +505,7 @@
   "release_date=2024-08-08",
   "startmap=start",
   "title=Map-Center Quake Retrojam 1",
+  "type=map",
   "type=mapjam"
  ],
  "urls": [

--- a/json/by-sha256/d8/d811423b06f1fa6a02f23f8c502d8bb766189521d11ad02c2adcf870f035adc0.json
+++ b/json/by-sha256/d8/d811423b06f1fa6a02f23f8c502d8bb766189521d11ad02c2adcf870f035adc0.json
@@ -252,6 +252,7 @@
   "startmap=start",
   "title=The Nullspace",
   "type=episode",
+  "type=map",
   "zipbasedir=copper/"
  ],
  "urls": [

--- a/json/by-sha256/f4/f4c2cb39caa3d50a1c8378dd4da8eb413219d45ca8979ca9b594599c990e8073.json
+++ b/json/by-sha256/f4/f4c2cb39caa3d50a1c8378dd4da8eb413219d45ca8979ca9b594599c990e8073.json
@@ -138,7 +138,8 @@
   "release_date=2024-08-16",
   "startmap=start",
   "title=Seismic Ventures",
-  "type=episode"
+  "type=episode",
+  "type=mod"
  ],
  "urls": [
   "https://www.quaddicted.com/files/by-sha256/f4/f4c2cb39caa3d50a1c8378dd4da8eb413219d45ca8979ca9b594599c990e8073/seiven.zip",


### PR DESCRIPTION
The backend is currently configured to list `map`, `mod` or `speedmap` releases. It's a bit arbitrary, but hey.