### PR TITLE
Replace unicode characters with escape sequences

### DIFF
--- a/json/by-sha256/1f/1ff3937d052673a84959fec8f1247ec415fe7904c3a4b1decd4fb4932fa1e386.json
+++ b/json/by-sha256/1f/1ff3937d052673a84959fec8f1247ec415fe7904c3a4b1decd4fb4932fa1e386.json
@@ -1,6 +1,6 @@
 {
  "bytes": 4520938,
- "description": "A pack of turtlemaps for the <a href=\"e1f7b48e210e56c793105497439c88dc2ada1bd2bbb8be5947ec2f99f0965797\">Zerstörer</a> mod made by efdat, HeadThump and neg!ke.<br><ul><br><li>Love in a bunker, baby! by efdat</li><br><li>Hold of the Troglodyte by HeadThump</li><br><li>Aderlass by neg!ke</li><br></ul>",
+ "description": "A pack of turtlemaps for the <a href=\"e1f7b48e210e56c793105497439c88dc2ada1bd2bbb8be5947ec2f99f0965797\">Zerst\u00f6rer</a> mod made by efdat, HeadThump and neg!ke.<br><ul><br><li>Love in a bunker, baby! by efdat</li><br><li>Hold of the Troglodyte by HeadThump</li><br><li>Aderlass by neg!ke</li><br></ul>",
  "files": {
   "ZerTM_ht.bsp": {
    "bytes": 1850708,

--- a/json/by-sha256/24/247c9aa4469bf4155c965ed9b6a1bd2829afd21b11786a6e49f85183bce3b9cd.json
+++ b/json/by-sha256/24/247c9aa4469bf4155c965ed9b6a1bd2829afd21b11786a6e49f85183bce3b9cd.json
@@ -1,6 +1,6 @@
 {
  "bytes": 20843086,
- "description": "Huge hellish fortress using a combination of Apocrypha/Ogro/Zerstörer textures. Features a high monster count, a couple of technical additions, and a custom music track.",
+ "description": "Huge hellish fortress using a combination of Apocrypha/Ogro/Zerst\u00f6rer textures. Features a high monster count, a couple of technical additions, and a custom music track.",
  "files": {
   "loc/": {
    "bytes": 0,

--- a/json/by-sha256/34/34593690339b0b57471830ff5db5627ba6d08ce0207beec723ecce2744d24da0.json
+++ b/json/by-sha256/34/34593690339b0b57471830ff5db5627ba6d08ce0207beec723ecce2744d24da0.json
@@ -1,6 +1,6 @@
 {
  "bytes": 14148792,
- "description": "Industrial-themed 1024³ level with a lava-flooded foundry, a humid cave system and an icy outside area; originally started for the <a href=\"007c1cf0bc552e656e852a902a89f0867ca87e4b7c93341b335ae90a04816716\">Xmas Jam 2019</a>. It uses custom textures from various sources and comes with a new skybox. The map source is included.",
+ "description": "Industrial-themed 1024\u00b3 level with a lava-flooded foundry, a humid cave system and an icy outside area; originally started for the <a href=\"007c1cf0bc552e656e852a902a89f0867ca87e4b7c93341b335ae90a04816716\">Xmas Jam 2019</a>. It uses custom textures from various sources and comes with a new skybox. The map source is included.",
  "files": {
   "biome-pritchard.txt": {
    "bytes": 2705,

--- a/json/by-sha256/46/46545a2e684a8ac839fd5059a5fcfdf8d0c0ce79da2eda50fd201a690329aaa4.json
+++ b/json/by-sha256/46/46545a2e684a8ac839fd5059a5fcfdf8d0c0ce79da2eda50fd201a690329aaa4.json
@@ -1,6 +1,6 @@
 {
  "bytes": 274130,
- "description": "<a href=\"e1f7b48e210e56c793105497439c88dc2ada1bd2bbb8be5947ec2f99f0965797\">Zerstörer</a> patch: progs.dat / qwprogs.dat <b>version 1.1</b>.",
+ "description": "<a href=\"e1f7b48e210e56c793105497439c88dc2ada1bd2bbb8be5947ec2f99f0965797\">Zerst\u00f6rer</a> patch: progs.dat / qwprogs.dat <b>version 1.1</b>.",
  "files": {
   "progs.dat": {
    "bytes": 588276,

--- a/json/by-sha256/56/565e37a0a76b8956534ca1273d98222f01a79bd9e9af7a408519a3cb1442dc4a.json
+++ b/json/by-sha256/56/565e37a0a76b8956534ca1273d98222f01a79bd9e9af7a408519a3cb1442dc4a.json
@@ -1,6 +1,6 @@
 {
  "bytes": 3980320,
- "description": "Late entry for <a href=\"6755b682db4d2fcd3e92dee61b7975468a2807abc2a93f29051835e7e33aec69\">Xmas Jam 2020</a>: a small Knave-themed level built inside a 1024³ units space. It comes with a custom sky box. The map source is included.",
+ "description": "Late entry for <a href=\"6755b682db4d2fcd3e92dee61b7975468a2807abc2a93f29051835e7e33aec69\">Xmas Jam 2020</a>: a small Knave-themed level built inside a 1024\u00b3 units space. It comes with a custom sky box. The map source is included.",
  "files": {
   "ad_bmfbr_xm.txt": {
    "bytes": 2276,

--- a/json/by-sha256/5d/5d3c46d81f79d079ec6bde27aeb2b0f0dc5412dd64735e831c530c57eaa65b66.json
+++ b/json/by-sha256/5d/5d3c46d81f79d079ec6bde27aeb2b0f0dc5412dd64735e831c530c57eaa65b66.json
@@ -1,6 +1,6 @@
 {
  "bytes": 34542644,
- "description": "Map jam #3 - a community project at Func_Msgboard. The pack features 6 small to large <a href=\"e1f7b48e210e56c793105497439c88dc2ada1bd2bbb8be5947ec2f99f0965797\">Zerstörer</a>-themed maps. The complete Zer mod is included in this release, and so are the map sources.",
+ "description": "Map jam #3 - a community project at Func_Msgboard. The pack features 6 small to large <a href=\"e1f7b48e210e56c793105497439c88dc2ada1bd2bbb8be5947ec2f99f0965797\">Zerst\u00f6rer</a>-themed maps. The complete Zer mod is included in this release, and so are the map sources.",
  "files": {
   "PAK0.PAK": {
    "bytes": 25138967,

--- a/json/by-sha256/5e/5e28e1bf5bbeffe5cfaf6429f163dded2f5c2780d9561c696033139eb1afa816.json
+++ b/json/by-sha256/5e/5e28e1bf5bbeffe5cfaf6429f163dded2f5c2780d9561c696033139eb1afa816.json
@@ -1,6 +1,6 @@
 {
  "bytes": 22024945,
- "description": "Medium / large runic base map with \"void vibes\", built on progs_dump 3.0 (already included). Some sounds from Arcane Dimensions, custom music \"Yss Éskiuth\" by Immorpher. Map source is included.",
+ "description": "Medium / large runic base map with \"void vibes\", built on progs_dump 3.0 (already included). Some sounds from Arcane Dimensions, custom music \"Yss \u00c9skiuth\" by Immorpher. Map source is included.",
  "files": {
   "jpqm12/README - jpqm12 - The Rust Forge.txt": {
    "bytes": 3133,

--- a/json/by-sha256/5f/5fb88470e8e3e625d7861ba10066938b387efe3a4d0c4b8e6a3333677422abc5.json
+++ b/json/by-sha256/5f/5fb88470e8e3e625d7861ba10066938b387efe3a4d0c4b8e6a3333677422abc5.json
@@ -1,6 +1,6 @@
 {
  "bytes": 1563830,
- "description": "Medium-to-large interconnected IKBase map. Features the Mega Enforcer from Zerstörer.",
+ "description": "Medium-to-large interconnected IKBase map. Features the Mega Enforcer from Zerst\u00f6rer.",
  "files": {
   "apsp1.bat": {
    "bytes": 1595,

--- a/json/by-sha256/6c/6c2b951eaaa5f26334f240332b8a63037cf590fa4523d86552df7c05555acae7.json
+++ b/json/by-sha256/6c/6c2b951eaaa5f26334f240332b8a63037cf590fa4523d86552df7c05555acae7.json
@@ -1,6 +1,6 @@
 {
  "bytes": 494845,
- "description": "Small, weird base map with a few textures from Zerstörer (no exit).",
+ "description": "Small, weird base map with a few textures from Zerst\u00f6rer (no exit).",
  "files": {
   "logs.zip": {
    "bytes": 1501,

--- a/json/by-sha256/9c/9ce540fd323883be24958a2443e19040ae5def6958183edfb5174e871f5833db.json
+++ b/json/by-sha256/9c/9ce540fd323883be24958a2443e19040ae5def6958183edfb5174e871f5833db.json
@@ -23,7 +23,7 @@
  },
  "json_version": "2023.11.06-23.20",
  "notes": [
-  "Requires the <a href=\"e1f7b48e210e56c793105497439c88dc2ada1bd2bbb8be5947ec2f99f0965797\">Zerstörer </a> mod to run as intended."
+  "Requires the <a href=\"e1f7b48e210e56c793105497439c88dc2ada1bd2bbb8be5947ec2f99f0965797\">Zerst\u00f6rer </a> mod to run as intended."
  ],
  "sha256": "9ce540fd323883be24958a2443e19040ae5def6958183edfb5174e871f5833db",
  "tags": [

--- a/json/by-sha256/a4/a4bfe55888c006e18782f9bdb99d136765296e291dff5979acc7af057cab3768.json
+++ b/json/by-sha256/a4/a4bfe55888c006e18782f9bdb99d136765296e291dff5979acc7af057cab3768.json
@@ -1,6 +1,6 @@
 {
  "bytes": 19246082,
- "description": "Small sized palace/catacomb map with a lot of close combat and strong Zerstörer vibes. A foretaste of an upcoming the upcoming \"Arcanum\" project.",
+ "description": "Small sized palace/catacomb map with a lot of close combat and strong Zerst\u00f6rer vibes. A foretaste of an upcoming the upcoming \"Arcanum\" project.",
  "files": {
   "arcdemo.txt": {
    "bytes": 853,

--- a/json/by-sha256/bb/bba95d077c180f8f518cb88aab8faf7d42723c0cb290bd0725ea1d76507b1927.json
+++ b/json/by-sha256/bb/bba95d077c180f8f518cb88aab8faf7d42723c0cb290bd0725ea1d76507b1927.json
@@ -1,6 +1,6 @@
 {
  "bytes": 1773463,
- "description": "1024³ / 6 SP maps / efdat, Hrimfaxi, neg!ke, Spirit",
+ "description": "1024\u00b3 / 6 SP maps / efdat, Hrimfaxi, neg!ke, Spirit",
  "files": {
   "sm127_efdat.bsp": {
    "bytes": 988584,

--- a/json/by-sha256/bf/bfcec076b0434c1dcadb2bd596a2aa8171688e73713c2fc8aa420c6ed8ebb13b.json
+++ b/json/by-sha256/bf/bfcec076b0434c1dcadb2bd596a2aa8171688e73713c2fc8aa420c6ed8ebb13b.json
@@ -1,6 +1,6 @@
 {
  "bytes": 409816,
- "description": "Zerstörer / 1 SP map / neg!ke",
+ "description": "Zerst\u00f6rer / 1 SP map / neg!ke",
  "files": {
   "sm108_neg!ke.bsp": {
    "bytes": 1025400,

--- a/json/by-sha256/ce/cebfbab9db68954e505b7775f1769dd107a7ee19e932cc5ef022d7cf1ae5aa70.json
+++ b/json/by-sha256/ce/cebfbab9db68954e505b7775f1769dd107a7ee19e932cc5ef022d7cf1ae5aa70.json
@@ -1,6 +1,6 @@
 {
  "bytes": 896187,
- "description": "A short non-interactive demo setting the tone of the events about to unfold in <a href=\"e1f7b48e210e56c793105497439c88dc2ada1bd2bbb8be5947ec2f99f0965797\">Zerstörer - Testament of the Destroyer</a>.",
+ "description": "A short non-interactive demo setting the tone of the events about to unfold in <a href=\"e1f7b48e210e56c793105497439c88dc2ada1bd2bbb8be5947ec2f99f0965797\">Zerst\u00f6rer - Testament of the Destroyer</a>.",
  "files": {
   "zerdem/pak0.pak": {
    "bytes": 2105521,

--- a/json/by-sha256/d8/d8499cb2c12bf22b4802590b6ccda561394ce98e450461a940d4e1433e353016.json
+++ b/json/by-sha256/d8/d8499cb2c12bf22b4802590b6ccda561394ce98e450461a940d4e1433e353016.json
@@ -1,6 +1,6 @@
 {
  "bytes": 3478428,
- "description": "Small Zerstörer-themed level.",
+ "description": "Small Zerst\u00f6rer-themed level.",
  "files": {
   "ad_shamsp4.txt": {
    "bytes": 1450,

--- a/json/by-sha256/d8/d8666c21f5130f3df5d882328cf26f11abd5d050bde2227dd4d9346e562d14a8.json
+++ b/json/by-sha256/d8/d8666c21f5130f3df5d882328cf26f11abd5d050bde2227dd4d9346e562d14a8.json
@@ -1,6 +1,6 @@
 {
  "bytes": 3934516,
- "description": "Small submarine base; features some material ripped from other mods, e.g. Scourge of Armagon and Zerstörer.",
+ "description": "Small submarine base; features some material ripped from other mods, e.g. Scourge of Armagon and Zerst\u00f6rer.",
  "files": {
   "pak0.pak": {
    "bytes": 8112672,


### PR DESCRIPTION
Would be nice to have UTF-8 JSON documents but that would require changes in the repository afaik so for now, let's just use the escaped characters.