### PR TITLE
release date, quaddicted mirror, no top level tags

### DIFF
--- a/json/by-sha256/82/8297cb7f82348b6fae2ff9cbc87aa8517f2e40c8fee59b1115892e1cb86e7b7e.json
+++ b/json/by-sha256/82/8297cb7f82348b6fae2ff9cbc87aa8517f2e40c8fee59b1115892e1cb86e7b7e.json
@@ -3,7 +3,6 @@
   "MadFox"
  ],
  "bytes": 4513392,
- "current_main_group_package": true,
  "description": "Large map with a mixture of base and medieval elements. This is a new version released in August 2025 that fixes a previous technical issue, the original can be found <a href=\"https://www.quaddicted.com/db/v2/maps/06fac556f9eed6eeaef312c2979a4e54a219470bc7da771a5cbf15ef2a14b24c\">here</a>.",
  "files": [
   {
@@ -38,18 +37,18 @@
   }
  },
  "json_version": "2025.03.20",
- "release_date": "2006-07-28",
  "sha256": "8297cb7f82348b6fae2ff9cbc87aa8517f2e40c8fee59b1115892e1cb86e7b7e",
  "tags": [
   "author=MadFox",
   "current_main_group_package=yes",
   "filename=grunt_grenadin.zip",
+  "filename=Grunt_Grenadin.zip",
   "game=quake",
   "game_mode=singleplayer",
   "link:homepage=http://members.home.nl/gimli/gimli20.htm",
   "link:review=[Underworldfan's](https://www.quaddicted.com/webarchive/underworld.planetquake.gamespy.com/quakerev060727.html)",
   "map_size=large",
-  "release_date=2006-07-28",
+  "release_date=2025-08-06",
   "release_group=grunt_grenadin",
   "startmap=grenedin",
   "theme=base",
@@ -60,8 +59,8 @@
   "type=map",
   "version=1.1"
  ],
- "title": "Grunt Grenadin",
  "urls": [
-  "https://mad-red.com/wp-content/uploads/2025/08/grunt_grenadin.zip"
+  "https://mad-red.com/wp-content/uploads/2025/08/grunt_grenadin.zip",
+  "https://www.quaddicted.com/files/by-sha256/82/8297cb7f82348b6fae2ff9cbc87aa8517f2e40c8fee59b1115892e1cb86e7b7e/Grunt_Grenadin.zip"
  ]
 }


### PR DESCRIPTION
Mirrored the file from dropbox, there it was available in Title_Case so we get a new filename.

Release date adjusted to be current, not the original date.

Removed redundant top-level tags, let's see what happens :D