### PR TITLE
Adding extractmapping for bad dir structures - batch 3 (via rjthorne)

### DIFF
--- a/json/by-sha256/35/357a85c2900043c234e873ddee2acd535156a10ae2b24f58119ae18413c5255e.json
+++ b/json/by-sha256/35/357a85c2900043c234e873ddee2acd535156a10ae2b24f58119ae18413c5255e.json
@@ -32,12 +32,14 @@
   }
  },
  "install": {
-  "extract": "{base}/id1/maps/"
+  "extract": "{base}/id1/maps/",
+  "extractmapping": {
+   "/plowing_through/": "/id1/maps/"
+  }
  },
  "json_version": "2025.09.27",
  "notes": [
-  "This map requires a source port with increased limits + BSP2 support.",
-  "Cannot be run through the Quake Injector."
+  "This map requires a source port with increased limits + BSP2 support."
  ],
  "release_date": "2021-07-27",
  "sha256": "357a85c2900043c234e873ddee2acd535156a10ae2b24f58119ae18413c5255e",

--- a/json/by-sha256/43/435e7691dbf74222dfe73c8ec5481b30a5f5f58e66eeb47564202110c324bed1.json
+++ b/json/by-sha256/43/435e7691dbf74222dfe73c8ec5481b30a5f5f58e66eeb47564202110c324bed1.json
@@ -47,7 +47,11 @@
   }
  },
  "install": {
-  "extract": "{base}/id1/maps/"
+  "extract": "{base}/id1/maps/",
+  "extractmapping": {
+   "/first_maps/": "/id1/maps/",
+   "/first_maps/maps_readme.txt": "/id1/maps/first_maps_readme.txt"
+  }
  },
  "json_version": "2025.09.27",
  "release_date": "2021-07-15",

--- a/json/by-sha256/72/7241073496b0a50bd4610daa432ccdb67a21c241e4cd0b57af5b8821e71ac232.json
+++ b/json/by-sha256/72/7241073496b0a50bd4610daa432ccdb67a21c241e4cd0b57af5b8821e71ac232.json
@@ -100,12 +100,15 @@
   }
  },
  "install": {
-  "extract": "{base}/ad/"
+  "extract": "{base}/ad/",
+  "extractmapping": {
+   "/put-in-ad/": "/ad/",
+   "/xalanoth.txt": "/ad/maps/xalanoth.txt"
+  }
  },
  "json_version": "2025.09.27",
  "notes": [
-  "This map requires <a href=\"5bf3c5d2e46284e0ad9515ed5ff2ab87d6edd1d8dbb2454c53248642ad515999\">Arcane Dimensions 1.70+</a> and a source port with increased limits.",
-  "Cannot be run from the Quake Injecto!."
+  "This map requires <a href=\"5bf3c5d2e46284e0ad9515ed5ff2ab87d6edd1d8dbb2454c53248642ad515999\">Arcane Dimensions 1.70+</a> and a source port with increased limits."
  ],
  "release_date": "2020-01-12",
  "sha256": "7241073496b0a50bd4610daa432ccdb67a21c241e4cd0b57af5b8821e71ac232",
@@ -128,7 +131,6 @@
   "nonspecific_tag=gothicdm",
   "nonspecific_tag=skybox",
   "release_date=2020-01-12",
-  "startmap=xalanoth1",
   "startmap=xalanothstart",
   "theme=arcane dimensions",
   "theme=doom",

--- a/json/by-sha256/87/87636e947871103077f21ad39444b9b1cd3ac1983953b516f621ab768eff52f2.json
+++ b/json/by-sha256/87/87636e947871103077f21ad39444b9b1cd3ac1983953b516f621ab768eff52f2.json
@@ -57,12 +57,14 @@
   }
  },
  "install": {
-  "extract": "{base}/"
+  "extract": "{base}/",
+  "extractmapping": {
+   "/tntmap01/": "/",
+   "/tntmap01/Extra files/": null,
+   "/tntmap01/tntmap01.txt": "/id1/maps/tntmap01.txt"
+  }
  },
  "json_version": "2025.09.27",
- "notes": [
-  "This cannot be installed with the Quake Injector because extracting the ZIP archive contains an extra root directory."
- ],
  "release_date": "2023-07-26",
  "sha256": "87636e947871103077f21ad39444b9b1cd3ac1983953b516f621ab768eff52f2",
  "tags": [
@@ -72,6 +74,7 @@
   "game_mode=singleplayer",
   "map_size=small",
   "release_date=2023-07-26",
+  "startmap=tntmap01",
   "theme=conversion",
   "theme=doom",
   "title=System Control (tntmap01)  / Snartroom (snartroom)",

--- a/json/by-sha256/87/8769d2a9785f2ec4e9232ce0b3bd595b1243cdb5a6bf47e697eb71698252ff6a.json
+++ b/json/by-sha256/87/8769d2a9785f2ec4e9232ce0b3bd595b1243cdb5a6bf47e697eb71698252ff6a.json
@@ -104,12 +104,14 @@
   }
  },
  "install": {
-  "extract": "{base}/"
+  "extract": "{base}/",
+  "extractmapping": {
+   "/24h_jam/": "/24h_jam/maps/",
+   "/24h_jam/24hjam.png": "/24h_jam/24hjam.png",
+   "/24h_jam/env/": "/24h_jam/gfx/env/"
+  }
  },
  "json_version": "2025.09.27",
- "notes": [
-  "Due to improper packaging these maps cannot be run from the Quake Injector."
- ],
  "release_date": "2017-01-11",
  "sha256": "8769d2a9785f2ec4e9232ce0b3bd595b1243cdb5a6bf47e697eb71698252ff6a",
  "tags": [

--- a/json/by-sha256/af/affddf257e57f1e34e0d600226875eab52362bb0dabb14775c7138e2acce1d98.json
+++ b/json/by-sha256/af/affddf257e57f1e34e0d600226875eab52362bb0dabb14775c7138e2acce1d98.json
@@ -27,12 +27,12 @@
   }
  },
  "install": {
-  "extract": "{base}/id1/maps/"
+  "extract": "{base}/id1/maps/",
+  "extractmapping": {
+   "/xl3/": "/id1/maps/"
+  }
  },
  "json_version": "2025.09.27",
- "notes": [
-  "Does not work with the Quake Injector."
- ],
  "release_date": "2018-05-25",
  "sha256": "affddf257e57f1e34e0d600226875eab52362bb0dabb14775c7138e2acce1d98",
  "tags": [
@@ -43,6 +43,7 @@
   "link=[Func_Msgboard](http://celephais.net/board/view_thread.php?id=61574)",
   "map_size=large",
   "release_date=2018-05-25",
+  "startmap=xl3"
   "theme=base",
   "theme=dungeon",
   "theme=metal",

--- a/json/by-sha256/c8/c849d7d59b951d80d745ba25caf923e22144a9f65b73a9055ccd300efaa01e10.json
+++ b/json/by-sha256/c8/c849d7d59b951d80d745ba25caf923e22144a9f65b73a9055ccd300efaa01e10.json
@@ -2195,12 +2195,14 @@
   }
  },
  "install": {
-  "extract": "{base}/"
+  "extract": "{base}/",
+  "extractmapping": {
+   "/qbj_1.05/": "/"
+  }
  },
  "json_version": "2025.09.27",
  "notes": [
-  "Requires a modern engine / source port with increased limits. Tested on IronWail, Quakespasm, and vkQuake. But there have been issues reported with Quakespasm Spiked.",
-  "Note: does not work in Quake Injector until https://github.com/hrehfeld/QuakeInjector/issues/146 is fixed."
+  "Requires a modern engine / source port with increased limits. Tested on IronWail, Quakespasm, and vkQuake. But there have been issues reported with Quakespasm Spiked."
  ],
  "release_date": "2022-09-28",
  "sha256": "c849d7d59b951d80d745ba25caf923e22144a9f65b73a9055ccd300efaa01e10",

--- a/json/by-sha256/c8/c8ab0db09c1e22f9f05b9f4923ab9ee1dac0dc513c592fedbd46556509be3c16.json
+++ b/json/by-sha256/c8/c8ab0db09c1e22f9f05b9f4923ab9ee1dac0dc513c592fedbd46556509be3c16.json
@@ -437,7 +437,11 @@
   }
  },
  "install": {
-  "extract": "{base}/"
+  "extract": "{base}/",
+  "extractmapping": {
+   "/": "/",
+   "/teuthis.txt": "/teuthis/teuthis.txt"
+  }
  },
  "json_version": "2025.09.27",
  "notes": [

--- a/json/by-sha256/df/dfe5e376f3db0ea4741ad34ce384678aa4a203c2f29fda996f2ff1029e64580a.json
+++ b/json/by-sha256/df/dfe5e376f3db0ea4741ad34ce384678aa4a203c2f29fda996f2ff1029e64580a.json
@@ -27,12 +27,14 @@
   }
  },
  "install": {
-  "extract": "{base}/"
+  "extract": "{base}/",
+  "extractmapping": {
+   "/FortressOfSecrets/": "/id1/maps/",
+   "/FortressOfSecrets/Read me.txt": "/id1/maps/fortressofsecrets.txt",
+   "/FortressOfSecrets/music/": "/id1/music/"
+  }
  },
  "json_version": "2025.09.27",
- "notes": [
-  "This map must be manually installed and will not work in Quake Injector."
- ],
  "release_date": "2022-10-20",
  "sha256": "dfe5e376f3db0ea4741ad34ce384678aa4a203c2f29fda996f2ff1029e64580a",
  "tags": [
@@ -45,6 +47,7 @@
   "map_size=small",
   "nonspecific_tag=vanilla",
   "release_date=2022-10-20",
+  "startmap=fortressofsecrets",
   "theme=castle",
   "theme=medieval",
   "theme=wizard",

--- a/json/by-sha256/f1/f13e4684599a8a58892a07d5cdd42c0395a3b574fd4ab1c18a55e53070cb4240.json
+++ b/json/by-sha256/f1/f13e4684599a8a58892a07d5cdd42c0395a3b574fd4ab1c18a55e53070cb4240.json
@@ -32,7 +32,12 @@
   }
  },
  "install": {
-  "extract": "{base}/aard100/maps/"
+  "extract": "{base}/aard100/maps/",
+  "extractmapping": {
+   "/": "/aard100/maps/",
+   "/progs.dat": "/aard100/progs.dat",
+   "/progs_readme.txt": "/aard100/progs_readme.txt"
+  }
  },
  "json_version": "2025.09.27",
  "release_date": "2001-04-26",

--- a/json/by-sha256/fd/fd3fc91a788d61ba996de3f92102ffdc96c944968396c97c8aa8ae48b4ace416.json
+++ b/json/by-sha256/fd/fd3fc91a788d61ba996de3f92102ffdc96c944968396c97c8aa8ae48b4ace416.json
@@ -27,11 +27,15 @@
   }
  },
  "install": {
-  "extract": "{base}/id1/maps/"
+  "extract": "{base}/id1/maps/",
+  "extractmapping": {
+   "/": "/id1/maps/",
+   "/music/": "/id1/maps/music/"
+  }
  },
  "json_version": "2025.09.27",
  "notes": [
-  "This version has the music misplaced so that upon extraction it needs manual placement. Use <a href=\"e61b81f64a8f23289a241d734280841b8cc13f2bdfec4d4854cd8303808bb80a\">1916_v2</a> for a fixed release.",
+  "Use <a href=\"e61b81f64a8f23289a241d734280841b8cc13f2bdfec4d4854cd8303808bb80a\">1916_v2</a> for a fixed release.",
   "This map requires a source port with increased limits."
  ],
  "provides": {


### PR DESCRIPTION
Just the new commit from https://github.com/Quaddicted/quaddicted-data/pull/63

@rjthorne wrote:

> Adding extractmapping for bad dir structures - batch 3
> Checked a bit more carefully than last time but shout if issues spotted. I kept the note pointing to the updated 1916 package as it might be 'fixed' in other ways

Thank you!

You had older commits in the branch again and there were some merge conflicts because I had updated the `json_version` to `2025.09.27` (sorry for being sneaky). I quickly snatched the commit into a new branch and fixed the issues.