### PR TITLE
Add files in files again

### DIFF
--- a/json/by-sha256/00/008aeeb3d1f7ff8553f7c185ffbd68aa4fdeba63ab9171cd931865da1877fdd6.json
+++ b/json/by-sha256/00/008aeeb3d1f7ff8553f7c185ffbd68aa4fdeba63ab9171cd931865da1877fdd6.json
@@ -25,6 +25,258 @@
   },
   "RotCS_mapsrc.zip": {
    "bytes": 2425413,
+   "files": {
+    "map/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2011-12-03T14:57:38.000Z"
+    },
+    "map/forest1.map": {
+     "bytes": 102174,
+     "sha256": "d039851b62f4b51e143a1285e4b7dbca201c6437d1b760e69d55003467a2400b",
+     "timestamp": "2007-05-07T23:33:50.000Z"
+    },
+    "map/forest2.map": {
+     "bytes": 102872,
+     "sha256": "6bdb6becddac8ca21a3a0f2ba52db55e21f2b5de5db92024b08963b624ae83d8",
+     "timestamp": "2007-05-07T23:34:44.000Z"
+    },
+    "map/forest3.map": {
+     "bytes": 105094,
+     "sha256": "8ed8b63c85545f5306a0ba65ead96b5b2a32254162c648279d281da356257651",
+     "timestamp": "2007-05-07T13:11:48.000Z"
+    },
+    "map/prelude.map": {
+     "bytes": 21679,
+     "sha256": "5f89eb1ac7e3d67bfefe49b8d8c6eb87c024a264882a37e4acac7d10f648cd41",
+     "timestamp": "2007-05-07T16:39:44.000Z"
+    },
+    "map/puzzle.map": {
+     "bytes": 97288,
+     "sha256": "703174fb61a8c75f3b6f9144b4afe3040bad0f8720eedec7ccfdcc0a39a7aea1",
+     "timestamp": "2007-05-07T23:14:18.000Z"
+    },
+    "map/rod.map": {
+     "bytes": 321846,
+     "sha256": "7a0d8b3348113534d01db28a0c858d068a282a9a928ed1e23ce2d0c6533a6e2e",
+     "timestamp": "2007-05-07T13:13:10.000Z"
+    },
+    "map/rol1.map": {
+     "bytes": 150031,
+     "sha256": "b8fb66d5c2e26ef3d4601c7f649ca37bf6324348951310ac31686206492cd0c9",
+     "timestamp": "2007-05-07T13:38:02.000Z"
+    },
+    "map/rol2.map": {
+     "bytes": 243888,
+     "sha256": "e19362dd7b5b0c673ed8625f3c1d4e9a341ba13e5d16bde41ad794887fa589ae",
+     "timestamp": "2007-05-07T13:43:38.000Z"
+    },
+    "map/rol3.map": {
+     "bytes": 226349,
+     "sha256": "3b542897f8950901702508f3ef5927f9251c8825d1507937ab71b67f5dea473f",
+     "timestamp": "2007-05-07T13:55:10.000Z"
+    },
+    "map/rom.map": {
+     "bytes": 635092,
+     "sha256": "adb924876f9109b81381e42b2b96ec5b440903d83b36656d2a012a74cdc9c812",
+     "timestamp": "2007-05-07T13:57:24.000Z"
+    },
+    "map/rot1.map": {
+     "bytes": 451720,
+     "sha256": "d0284c983fb406306af239952c425accf4243d15b8075f23b26e3efe2e639da9",
+     "timestamp": "2007-05-07T15:08:28.000Z"
+    },
+    "map/rot2.map": {
+     "bytes": 924525,
+     "sha256": "113cde1ec5a159843801384628227eaef53979d215a2ec8649bb0eb479edfc10",
+     "timestamp": "2007-05-07T15:05:52.000Z"
+    },
+    "map/rot3.map": {
+     "bytes": 155192,
+     "sha256": "68bc78259425318a57a6830fd3e6bfe196fd5385c9a3f620171ca0d5b1f42113",
+     "timestamp": "2007-05-07T15:11:22.000Z"
+    },
+    "map/ttown1.map": {
+     "bytes": 1819422,
+     "sha256": "f7a245698a1dbe8ef2660ae05bd045f2ea24b61b1f3e73fdc28fcad3caa7b79c",
+     "timestamp": "2007-05-13T13:46:52.000Z"
+    },
+    "map/ttown2.map": {
+     "bytes": 1811782,
+     "sha256": "97367049fcc46453446631e7b816480680bd430360da2b8afc94371b98833d71",
+     "timestamp": "2007-05-07T23:02:32.000Z"
+    },
+    "map/ttowns.map": {
+     "bytes": 1828660,
+     "sha256": "b6369a3989e07e5895c9a47f677082a3ada89f9d2df77c22b37c8c75ff4f5aa1",
+     "timestamp": "2007-05-13T22:21:18.000Z"
+    },
+    "qkm/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2011-12-03T14:57:38.000Z"
+    },
+    "qkm/Forest1.qkm": {
+     "bytes": 95362,
+     "sha256": "767f7bf39776d7edc88156fe1818c65358c4c7aefba7f310e208f03494e8679a",
+     "timestamp": "2007-05-07T23:33:06.000Z"
+    },
+    "qkm/Forest2.qkm": {
+     "bytes": 95969,
+     "sha256": "7ad2c0863c2c951d043940cfdc59bdc784d6bc89695e21457afac0a143d32685",
+     "timestamp": "2007-05-07T23:34:40.000Z"
+    },
+    "qkm/Forest3.qkm": {
+     "bytes": 98454,
+     "sha256": "6010e03776e01e585aa2b1e4f99bc6d9b05e8ca68d7cdcaffdc17430dfe8cfdc",
+     "timestamp": "2007-05-04T21:40:06.000Z"
+    },
+    "qkm/NotUsed/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2011-12-03T14:57:38.000Z"
+    },
+    "qkm/NotUsed/PlayerHouse.qkm": {
+     "bytes": 42712,
+     "sha256": "e7a16c34c311789d78426c6c30e321b972ea1ca393e969e5aff85586a6f3ddcd",
+     "timestamp": "2007-04-07T16:02:28.000Z"
+    },
+    "qkm/NotUsed/RoL1-1.qkm": {
+     "bytes": 44046,
+     "sha256": "df7e21e88190b41d4cd9170c197a7c3a949681dec559b69a2c18664a95bdcdeb",
+     "timestamp": "2007-04-14T13:42:20.000Z"
+    },
+    "qkm/Prelude.qkm": {
+     "bytes": 20344,
+     "sha256": "9fb5137dff69bc26e43fdfdd58f5690f7077194002ce08b7a1f75eb87fa15ae4",
+     "timestamp": "2007-05-07T16:39:54.000Z"
+    },
+    "qkm/Puzzle.qkm": {
+     "bytes": 84111,
+     "sha256": "4ba33612372bdbc80861c4d04a668f7323fac7885aad0acf05b427442b42cf8c",
+     "timestamp": "2007-05-07T23:14:16.000Z"
+    },
+    "qkm/RoD.qkm": {
+     "bytes": 251154,
+     "sha256": "0996ee049df50ebbbc14f40f2c7e7debb0d1ab2f2b155eee43fb3d780decc347",
+     "timestamp": "2007-05-04T21:57:54.000Z"
+    },
+    "qkm/RoL1.qkm": {
+     "bytes": 107181,
+     "sha256": "60185bf917ec151f43b2f50366af43e34eeba5b706dba2bcfbd52632d19792c9",
+     "timestamp": "2007-05-06T15:22:02.000Z"
+    },
+    "qkm/RoL2.qkm": {
+     "bytes": 208590,
+     "sha256": "633578288a4a721913f8e85867da91eb72595de43af3ef00203795f22ead94a9",
+     "timestamp": "2007-05-07T13:43:24.000Z"
+    },
+    "qkm/RoL3.qkm": {
+     "bytes": 162150,
+     "sha256": "0004202d1086def21d3a91680907b191ac78e833b4adccb871635e2bfe46dae7",
+     "timestamp": "2007-05-06T15:24:14.000Z"
+    },
+    "qkm/RoM.qkm": {
+     "bytes": 409080,
+     "sha256": "6ddd8a1f22b1653514ed4f339de8da60e07a05cf1b7fe7ced61c1402e15cd3c9",
+     "timestamp": "2007-05-04T22:21:00.000Z"
+    },
+    "qkm/RoT1.qkm": {
+     "bytes": 295264,
+     "sha256": "7419dc3db9b536bc47ea482c08219c82396d03e3e48b4b7b628e27afd907b957",
+     "timestamp": "2007-05-06T21:47:02.000Z"
+    },
+    "qkm/RoT2.qkm": {
+     "bytes": 526106,
+     "sha256": "b6364e6b629feb94959e5d824ba411b1882ad81974ecb984fe0c508e14310c30",
+     "timestamp": "2007-05-06T16:30:36.000Z"
+    },
+    "qkm/RoT3.qkm": {
+     "bytes": 104506,
+     "sha256": "aba7307be32e802fc1e850eef227efa2a05ebeaa30c89a150059cf778b5e7c9f",
+     "timestamp": "2007-05-04T22:53:52.000Z"
+    },
+    "qkm/Signs/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2011-12-03T14:57:38.000Z"
+    },
+    "qkm/Signs/Defense.jpg": {
+     "bytes": 9323,
+     "sha256": "8d2d042bdea5f90b7f8d1b384535c62e710d0479d82a475105da465238043730",
+     "timestamp": "2007-04-06T17:29:32.000Z"
+    },
+    "qkm/Signs/Inn.jpg": {
+     "bytes": 9215,
+     "sha256": "af32adf2663ac2b6699c57d92cbaccc70d381e97bf047461aa20b34e3887a253",
+     "timestamp": "2007-04-06T17:39:58.000Z"
+    },
+    "qkm/Signs/RoLDSIGN.jpg": {
+     "bytes": 9284,
+     "sha256": "e4bcb3756f590e9b82d9a58781d9e5aa2c7faca6d0c97dc413a0cf262faad48a",
+     "timestamp": "2007-04-09T21:23:38.000Z"
+    },
+    "qkm/Signs/RoMSIGN.jpg": {
+     "bytes": 8520,
+     "sha256": "075168b8a3fc550c534d7c838abea160e1ab33f9fa17126322d3af8f7185975c",
+     "timestamp": "2007-04-09T21:25:14.000Z"
+    },
+    "qkm/Signs/RoTSIGN.jpg": {
+     "bytes": 8793,
+     "sha256": "0e7dbea75cd6ecb50f479fb118ef4c01fb2bba3686b6146e31c107e763a60feb",
+     "timestamp": "2007-04-09T21:22:30.000Z"
+    },
+    "qkm/Signs/Weapon.jpg": {
+     "bytes": 9444,
+     "sha256": "a62383114dfddd9716c91a012a6cf7703d5d95b7f248b6487f28f14e3f77a1f5",
+     "timestamp": "2007-04-06T17:34:00.000Z"
+    },
+    "qkm/TTown1.qkm": {
+     "bytes": 929361,
+     "sha256": "2518e3c4a389de620667cf4c5b486f7800b758e60ea48093a7fad02741f1c75b",
+     "timestamp": "2007-05-13T13:46:08.000Z"
+    },
+    "qkm/TTown2.qkm": {
+     "bytes": 924658,
+     "sha256": "4d053b5ea5e40a624163cba5ba9f4891f74a19fef9bf9ebb2267a9c8c308eb44",
+     "timestamp": "2007-05-07T23:00:44.000Z"
+    },
+    "qkm/TTownS.qkm": {
+     "bytes": 936104,
+     "sha256": "945ee782bc8990246aa1bf1c15f136c21bed755be281cb130033cbb22a109a0b",
+     "timestamp": "2007-05-13T22:29:20.000Z"
+    },
+    "qkm/TradersTown/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2011-12-03T14:57:38.000Z"
+    },
+    "qkm/TradersTown/TTmap#1-1.qkm": {
+     "bytes": 158382,
+     "sha256": "fa3a7f69bf68e9abc5ec16f22794654fd13bacecd8b35eff795fbc73f4a27609",
+     "timestamp": "2007-04-09T22:33:56.000Z"
+    },
+    "qkm/TradersTown/TTmap#1-2.qkm": {
+     "bytes": 125710,
+     "sha256": "a80422b64349ce28d7645431693871a6e0631e29fd683de85c5a1561a02775df",
+     "timestamp": "2007-04-09T22:52:46.000Z"
+    },
+    "qkm/TradersTown/TTmap#1-3.qkm": {
+     "bytes": 87215,
+     "sha256": "3286e6a48807c9a4eea63d3c0ad11a05d82037a5de7c39f9961db9c902067248",
+     "timestamp": "2007-04-09T23:10:52.000Z"
+    },
+    "qkm/TradersTown/TTmap#1-4.qkm": {
+     "bytes": 84983,
+     "sha256": "2c31a4b01a2d4707eff799ff165f934ca17b9b6d6372bc3413c93182faa6887e",
+     "timestamp": "2007-04-09T23:17:42.000Z"
+    },
+    "qkm/TradersTown/TTmap#1-5.qkm": {
+     "bytes": 111156,
+     "sha256": "2a9e560f3e8a585d3a638bb990aee655b86ccfbb26e94834df833391fe3fd1ea",
+     "timestamp": "2007-04-09T22:13:32.000Z"
+    }
+   },
    "sha256": "69c5a7ff022c8ed7da23b54cded2f0db9ab07935dd76decc10f7b773adac6fd4",
    "timestamp": "2011-12-03T14:57:46.000Z"
   },

--- a/json/by-sha256/02/02db7a514bc0516efc7c71814067c1e3abff4199bd4f2249ca2f7b586cf76026.json
+++ b/json/by-sha256/02/02db7a514bc0516efc7c71814067c1e3abff4199bd4f2249ca2f7b586cf76026.json
@@ -48,6 +48,292 @@
   },
   "lth/pak0.pak": {
    "bytes": 42788182,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "c9af72fed7396787351158954f48043c795ef5d1ffe96e62bd16f1e9055e1176"
+    },
+    "gfx/env/nebular_bk.tga": {
+     "bytes": 786450,
+     "sha256": "7ebe91c3b421e478c3228a2cb9bb2da8c91866c6f8703cea851c387266e2828d"
+    },
+    "gfx/env/nebular_dn.tga": {
+     "bytes": 786450,
+     "sha256": "94f69c27a34c90686c1fd14b9b8c30df49012a081811235503e92bd850947627"
+    },
+    "gfx/env/nebular_ft.tga": {
+     "bytes": 786476,
+     "sha256": "ae2a0d607d3c0f110bafd7c139cba7c23ad88b3a03493b1b4bef4138e7455660"
+    },
+    "gfx/env/nebular_lf.tga": {
+     "bytes": 786450,
+     "sha256": "e9c59c4f9899b98067b74dd9ece2de9cac7387cc8943f301d4923475bf9bd086"
+    },
+    "gfx/env/nebular_rt.tga": {
+     "bytes": 786450,
+     "sha256": "43a09dcc4ba500ee2f271bc8d2f3b64d287e10b685bf1790c7e02dabc71c414c"
+    },
+    "gfx/env/nebular_up.tga": {
+     "bytes": 786450,
+     "sha256": "56bea787128a56439becea05dff1ccf5125ecc8274b982735707fb4db01aaf5e"
+    },
+    "maps/lthsp1.bsp": {
+     "bytes": 1104892,
+     "sha256": "081ce422f07d0276d297edf7209ec9a34efa449627500250eadab7d30fafe874"
+    },
+    "maps/lthsp2.bsp": {
+     "bytes": 1226052,
+     "sha256": "e91649d7c44a62a889ad4c697fe81233330ba764d9f22d33869d593ef0f9ecd0"
+    },
+    "maps/lthsp3.bsp": {
+     "bytes": 1353376,
+     "sha256": "0a9b8ea8d169e4543cab221c0dd744bebf82b2044192fcdd809b93813413d54d"
+    },
+    "maps/lthsp3.lit": {
+     "bytes": 811487,
+     "sha256": "fa71031a48e5f377219be8dd18722d3ff2b5f1adef4edeb6df0a8e11d96c4529"
+    },
+    "maps/lthsp4.bsp": {
+     "bytes": 1391788,
+     "sha256": "4557850ba63104eaf3abf715e00fc4113f44453e7f2042ed26c6ac1a12b37535"
+    },
+    "maps/lthsp4.lit": {
+     "bytes": 876119,
+     "sha256": "a10a1aae70b61be4ac2c2c1e56f693f15285f23160d95ae03a178af079143c38"
+    },
+    "maps/lthsp5.bsp": {
+     "bytes": 659676,
+     "sha256": "4f994b7e846fe74b0b69ab9efaead9c9d49218e7dfaa9b10db2e370d00b75956"
+    },
+    "maps/lthsp5.lit": {
+     "bytes": 412811,
+     "sha256": "3dc563065f4a71f198642426dbd784643b582ee1254892e36cde12b9006a84e4"
+    },
+    "maps/lthsp6.bsp": {
+     "bytes": 3307920,
+     "sha256": "f75736ba2ef6d528a2f03d373a6622e744a188f2a65833306274b53f923f9fbd"
+    },
+    "maps/lthsp6.lit": {
+     "bytes": 1279856,
+     "sha256": "e4a21aa0fa2b50381c09de73c52755eac90048d4eff0600378e40322fbd99903"
+    },
+    "maps/start.bsp": {
+     "bytes": 670980,
+     "sha256": "afc677dc90c138311b814696d1b3ea31cdf7e085f18f0c10fcbcf139a38b2507"
+    },
+    "maps/start.lit": {
+     "bytes": 227276,
+     "sha256": "ab9dace844bf2a11ef74ae8400d119b9b0b7eababc127489d1cc763daaca6c23"
+    },
+    "music/track01.ogg": {
+     "bytes": 2290360,
+     "sha256": "11a45a41a65a0dcb60a123e351c3116a1034554cfa10546f1b4d94fa54f28f51"
+    },
+    "music/track02.ogg": {
+     "bytes": 3089741,
+     "sha256": "91cb1a5669fb94692a629b116705a215c5717fb1b5dbffcc5a906c1217feeb32"
+    },
+    "music/track03.ogg": {
+     "bytes": 1149733,
+     "sha256": "eaf87788e9f5b39350da8c608159e1e308d16378b8eadd32abe8af26e54aab51"
+    },
+    "music/track05.ogg": {
+     "bytes": 4877264,
+     "sha256": "d012b82c3bb9b3a567038bca72e85ad22bdde857fc7246e4ca2a9258b8615747"
+    },
+    "music/track07.ogg": {
+     "bytes": 6374897,
+     "sha256": "7782b630a3bd2c887d483635bec3d5b7c2f0ba44f93308ec15872a92ae1a71a1"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 21739,
+     "sha256": "711571c64f104b6670dc602dcde08ec66b472861f8def49c3d1257008c0d6dbc"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bowman.mdl": {
+     "bytes": 437468,
+     "sha256": "a336e6817f07a636bcf678e04c8592f50def86bc90b3fecbeae20836e01449df"
+    },
+    "progs/demon.mdl": {
+     "bytes": 400888,
+     "sha256": "24920a90be6a94d91978174aa06813e7942772ad8e373fe268c7bc88f6adfea9"
+    },
+    "progs/dog.mdl": {
+     "bytes": 173720,
+     "sha256": "a9b6aa0d4b2a9b5d6b8de3f8be19fd8162834325f1b59277f709bdf74be9f05c"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 603309,
+     "sha256": "ddcf759804fffd97e62c55f67f962e24e8cd646fd982215ac8aefd3e49f67660"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 649023,
+     "sha256": "b0152745d3692706e99a05750c0cf9dd99dc9ac9faba41a57596030819c04b18"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 25316,
+     "sha256": "261a8479de0d5df9aea9931a62b1b93dbb7bfcff4f4467920cbebcc9c2c25381"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 64664,
+     "sha256": "573d8dcd3c00dfb18073637bcd252d9e9aec2bc5c8fcf2f4520514f52af77075"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_player.mdl": {
+     "bytes": 14708,
+     "sha256": "9840c0f31e9f568545732f980928ade3fe3b79fe8ebab47f5238de7df1c1c789"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 228400,
+     "sha256": "78d0273de6850f92d059fa90969f66ee57435330b3c4954c836a7204bc7a9d5a"
+    },
+    "progs/hknight2.mdl": {
+     "bytes": 909361,
+     "sha256": "9e3d1f85853864fe252099a2a5f780a1e7914f4be525301df5e2f0c0bac712ad"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 7092,
+     "sha256": "4d69cfc6343baa8bdc8660428e646abf9ad66b1460ea766cc2e231e7d3c9508e"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/k2_spk.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/knight.mdl": {
+     "bytes": 342844,
+     "sha256": "7c70855270badea8e147f3ecbbdbc934745e67db0468716ae07b098394732859"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 675996,
+     "sha256": "d80340e6d3914b55024098a2bd20f17759b9c7d58d2f3a98bf21ffe8f5342591"
+    },
+    "progs/player.mdl": {
+     "bytes": 517652,
+     "sha256": "eaead3d31f963cfe79aebf26b11377be2427701fca9d490503e0e7233e331a0d"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 186184,
+     "sha256": "accfb31cb38984ab4f871070181968610c5accd245b425dd2243de75394a58a8"
+    },
+    "progs/shamrock.mdl": {
+     "bytes": 45732,
+     "sha256": "0a8f6b6d751a8bcaf25a44f48f0dd88bb6c06efc0cadb7ae12d844e496522cb9"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 576720,
+     "sha256": "f3bb35f9dfb3f040fb02053874535478483af0aa15084c7f00aecb907938262d"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 77332,
+     "sha256": "e2a8a92ebbe86069de925f733567738ac67624a913cb8c1fe15a6946536d58e7"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 48964,
+     "sha256": "98a239b4fcfcf78c68079de14984bb8c30b251418044f63c9097c5c16f64da09"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 95124,
+     "sha256": "986246477d8779ebcda7c58cbf90fdb88b39666cff4fcfb18a2cade0a6f303d8"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 21908,
+     "sha256": "ade58867dac49427ce1a66c498f5dd7327685db0daac1409b80e0a341df59283"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 21804,
+     "sha256": "06a1f7cef5d1d3f8c377addc4026523b656b8f77986495f96048a1a6ea94549c"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "sound/bowman/a-fire.wav": {
+     "bytes": 16380,
+     "sha256": "6fcce60fdaefd5b1a061186ebd8b573445ed44719e46a39b157047e9489a5c13"
+    },
+    "sound/bowman/a-hit.wav": {
+     "bytes": 75580,
+     "sha256": "057e64dc03c73dcc6b95377217a9a64d0984074b0f61e6727fc878f5ee38b449"
+    }
+   },
    "sha256": "221d13b60ccfa341955fc1ea2e522b354bb7a7ed2be8848f74e47e687d46ab6c",
    "timestamp": "2023-12-26T18:52:12.000Z"
   },

--- a/json/by-sha256/03/0346be6c490ddd6f3cddaa1443557b2c9415ec97e4173a4d9755122092328839.json
+++ b/json/by-sha256/03/0346be6c490ddd6f3cddaa1443557b2c9415ec97e4173a4d9755122092328839.json
@@ -17,6 +17,212 @@
   },
   "PAK0.PAK": {
    "bytes": 64022464,
+   "files": {
+    "maps/end.bsp": {
+     "bytes": 2395264,
+     "sha256": "e70fbf4bff03631eb79dd637b94574af76284d8fc8dd97cd35b0e810340df16b"
+    },
+    "maps/r1b1.bsp": {
+     "bytes": 2186420,
+     "sha256": "5995c5bd70d1394744159506abf999af5122e6776c442a0f1b91670facf25029"
+    },
+    "maps/r1b2.bsp": {
+     "bytes": 2030424,
+     "sha256": "f88aea9de8b11310ab64f0bc39bdc89e4f8d94fc17c6bbf042c2de68eb80b34c"
+    },
+    "maps/r1b3.bsp": {
+     "bytes": 2785652,
+     "sha256": "4f172ff818415aedee1b1da9a1dc4803f6e13bc8b0b5178b1d157753559a6794"
+    },
+    "maps/r1b4.bsp": {
+     "bytes": 3051900,
+     "sha256": "e8066164cf336099cb56872f5bf27bc33e8455df8cb130a361ec2cb74f71a953"
+    },
+    "maps/r1b5.bsp": {
+     "bytes": 2673400,
+     "sha256": "510379ccc53d9031a5c8b405072d80f62dfb1ce9c220786e59fb2a1c25f35369"
+    },
+    "maps/r1b6.bsp": {
+     "bytes": 2413328,
+     "sha256": "7a4c5f1d0a58e471356b308d321afdd4c851abe04dd313ea4af9ec735ce41da2"
+    },
+    "maps/r1b7.bsp": {
+     "bytes": 2569404,
+     "sha256": "b10938ef673fffcc77b105c6d55bf3a5076bf98982b1ca22337b312478ca2d42"
+    },
+    "maps/r1b8.bsp": {
+     "bytes": 1452052,
+     "sha256": "9df70876bcdb77dbf974c46554de06376deb650b709a37273545e77e72bb2c3e"
+    },
+    "maps/r1b9.bsp": {
+     "bytes": 2350972,
+     "sha256": "867d4ec2c6829bcd8278574185d9d76eb1890802de53972b6b6ae47d863ae5d4"
+    },
+    "maps/r2b1.bsp": {
+     "bytes": 2600696,
+     "sha256": "bd527ca21f8711001e66f23fc1616529aa73ef4fd7f99751e1daa111355b2de6"
+    },
+    "maps/r2b2.bsp": {
+     "bytes": 2323140,
+     "sha256": "db1cf2cbfc8c180b205ee64bdfc3d5d766eeb315c349b4bbb25b62056fe0c24b"
+    },
+    "maps/r2b3.bsp": {
+     "bytes": 1841364,
+     "sha256": "a610d355979dde9b8e41911503171e2ebd7f21f6792f1415c05c5567c7ce0dac"
+    },
+    "maps/r2b4.bsp": {
+     "bytes": 1807760,
+     "sha256": "febfe60c387bff49ff4e544fc8e4bddd34f15446c879cb98187cd877ba3f577a"
+    },
+    "maps/r2b5.bsp": {
+     "bytes": 2086304,
+     "sha256": "7fe0d5693ce547bb127541c36fa391dc4b8ab693da425c106e19ff70578936c9"
+    },
+    "maps/r2b6.bsp": {
+     "bytes": 1770040,
+     "sha256": "262becd50c7da9d755e2aa78de992b1a7d299e112aa70b3ac465b3f099965a5d"
+    },
+    "maps/r2b7.bsp": {
+     "bytes": 2285496,
+     "sha256": "7e9576b1e2d9857b30756b714c3312e728649f6a90a3998e40003b091903661b"
+    },
+    "maps/r2b8.bsp": {
+     "bytes": 2246352,
+     "sha256": "2c00e25c2092c5f8c5e201f9fcf2ad864a669cd014a2d8b6c254ebb063918270"
+    },
+    "maps/r2b9.bsp": {
+     "bytes": 1988644,
+     "sha256": "ad8874bef04adc7ac1003a055a543b106bb55e15b2ec9a690caad7f665750d7d"
+    },
+    "maps/r3b1.bsp": {
+     "bytes": 3140780,
+     "sha256": "8ee9a85eb9d73d9985f71b68fab1b0f23d664ca9750a93cc9a2fd26767bc32b7"
+    },
+    "maps/r3b2.bsp": {
+     "bytes": 2195872,
+     "sha256": "40ad631dd617da04e89293ba8f97cf068bbfbbc4c6f894122da4df9d6205dcda"
+    },
+    "maps/r3b3.bsp": {
+     "bytes": 2217484,
+     "sha256": "27d523f8b3f6ebc0483b9aa5d3cd2452d4ed5eefe005da50122c9849bcdb4fa3"
+    },
+    "maps/r3b4.bsp": {
+     "bytes": 2940888,
+     "sha256": "3d2a485bd413c7a0aaa76a478fb4ad02535897a34d5dd7fc7fedee3780b0bf57"
+    },
+    "maps/r3b5.bsp": {
+     "bytes": 2387980,
+     "sha256": "d057259a7d552dcb37a501c48a9ca597591d9535be2109dbf38bf6cf2735b14e"
+    },
+    "maps/r3b6.bsp": {
+     "bytes": 2429632,
+     "sha256": "d21fd1c5dc389edb594ded80372cd3174edc5614f834789107fcd4e590eee317"
+    },
+    "maps/r3b7.bsp": {
+     "bytes": 1815400,
+     "sha256": "54355ab41514af0e2b1ae1b6d3a7103fea1430e5598f94e43a44d8672b8342db"
+    },
+    "maps/start.bsp": {
+     "bytes": 1859020,
+     "sha256": "772c338a91c152f1bb4e774a45c8d3105a3248782d10abeb377a0205acc7935c"
+    },
+    "progs.dat": {
+     "bytes": 415300,
+     "sha256": "cb22b88bc7aac42a41ab3587526e999f1b604cc7363f871bd69a787cb18956bc"
+    },
+    "progs.qc": {
+     "bytes": 429,
+     "sha256": "7c42248d5e195eda49c9bfd8b64dbaf3ae7c19f42b6989491ce6dbadf6b808e1"
+    },
+    "progs/h_gib1.mdl": {
+     "bytes": 34788,
+     "sha256": "bdaba0fc14661803edcd1bb4bb0334a766fad3db156fdf083e1e97c84fc9384b"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 42172,
+     "sha256": "7e02baca3563fa418f4c7fb2b442ea52538f232ff4335098084a7f3f9713a110"
+    },
+    "progs/h_stego.mdl": {
+     "bytes": 81732,
+     "sha256": "8bb81b2f508d04682b40e095e7d7a226ff8b11a40d3dd2318df53683e88f6e46"
+    },
+    "progs/orb.mdl": {
+     "bytes": 761589,
+     "sha256": "a6ca5612949442504715097c6e7a12ee958ced257e095f746ad5c8de3d5de7a4"
+    },
+    "progs/stego.mdl": {
+     "bytes": 452883,
+     "sha256": "1766a5e5e8438f0f7c1826072dd0909381f785893f715893bba08ed5689231cc"
+    },
+    "sound/orb/death1.wav": {
+     "bytes": 30362,
+     "sha256": "f484be93304290fb1ae135df047cfe1f15e9c65e9e81c8c771c708d98a86934f"
+    },
+    "sound/orb/en_orb.wav": {
+     "bytes": 67018,
+     "sha256": "53685269020f20bf0f04db230e58620cf42fe43373fe94ad9bbe11f65ee5e4cd"
+    },
+    "sound/orb/enfire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/orb/enfstop.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/orb/idle1.wav": {
+     "bytes": 67018,
+     "sha256": "53685269020f20bf0f04db230e58620cf42fe43373fe94ad9bbe11f65ee5e4cd"
+    },
+    "sound/orb/pain1.wav": {
+     "bytes": 7872,
+     "sha256": "11c8918750c1082f9d404469b95a57fd460f05fd8647e4c2f3a1472af7ff4149"
+    },
+    "sound/orb/pain2.wav": {
+     "bytes": 6062,
+     "sha256": "180c720c4126f985d002858489b3174c0f22554e0bcf1add69d20f1da0a5b67e"
+    },
+    "sound/orb/pain3.wav": {
+     "bytes": 6062,
+     "sha256": "bc29697980e68ea47ee73cda67fd49e65161481d4eacf199633ee7298a189bae"
+    },
+    "sound/orb/sight1.wav": {
+     "bytes": 16094,
+     "sha256": "50329bcfdb093cdedd72fbbc598d7a1760f051509e0f44442e0fe32b7c36d45c"
+    },
+    "sound/orb/sight2.wav": {
+     "bytes": 3488,
+     "sha256": "867eb15b2a24561dcb185a2d57ac1c62cf7772e758b8b5a481fd83723b0fa3cb"
+    },
+    "sound/orb/sight3.wav": {
+     "bytes": 7872,
+     "sha256": "e27f0aa6fde35cd0bec62b7238db1f680993402341a663e1ccbedbff62b85047"
+    },
+    "sound/orb/sight4.wav": {
+     "bytes": 6062,
+     "sha256": "180c720c4126f985d002858489b3174c0f22554e0bcf1add69d20f1da0a5b67e"
+    },
+    "sound/stego/dattack1.wav": {
+     "bytes": 31484,
+     "sha256": "2ce7cb785f01b5ce7040cc26a62f3cbb64001190ec33ba3abe2960ced4f11c03"
+    },
+    "sound/stego/ddeath.wav": {
+     "bytes": 36464,
+     "sha256": "8710a30e5bb5052edf160163aeea3f2870e15c9b406643293b7ab7c4fe18c693"
+    },
+    "sound/stego/dpain1.wav": {
+     "bytes": 16820,
+     "sha256": "73c51e89272a7a411075f937a82862b8cb73c303f51b1cba3e75e2f990fd8615"
+    },
+    "sound/stego/dsight.wav": {
+     "bytes": 37108,
+     "sha256": "7d4d1bf3ddadebd2f7aed72c4bd3725a15acbd894ccae672cfb794fdb366b89e"
+    },
+    "sound/stego/idle.wav": {
+     "bytes": 33028,
+     "sha256": "ac3cc928242e8de52dc9c07ac3e259cc4759391829dcaac56b55c9f2cd105ada"
+    }
+   },
    "sha256": "689c458e547f6d8184f389c210174727f9eb969552fc3d3f5af988bc9bc9ec14",
    "timestamp": "2007-01-11T07:38:58.000Z"
   },

--- a/json/by-sha256/03/0389e3ae4a9fd2b6f7d8e58800546bb28d805069b7d38f4a1947b05a0a10ed65.json
+++ b/json/by-sha256/03/0389e3ae4a9fd2b6f7d8e58800546bb28d805069b7d38f4a1947b05a0a10ed65.json
@@ -13,6 +13,208 @@
   },
   "e1m1red-src.zip": {
    "bytes": 343675,
+   "files": {
+    "e1m1red-src.txt": {
+     "bytes": 3317,
+     "sha256": "c689dd261d55c404c092991a09484f701e5f808fb2a6d70af4859bd6b1eb039c",
+     "timestamp": "2008-09-12T06:38:12.000Z"
+    },
+    "e1m1red.map": {
+     "bytes": 1690154,
+     "sha256": "10faae3f20ad2b847d21da26a802d682f0b556e792c89338949b742e88fad04c",
+     "timestamp": "2008-09-11T23:52:18.000Z"
+    },
+    "qc/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2008-09-12T04:17:14.000Z"
+    },
+    "qc/ai.qc": {
+     "bytes": 14521,
+     "sha256": "54a6329a086391d2f1296fd30afd5db9ca676f7f15911c703b15e440b4e5778c",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "qc/amtest.qc": {
+     "bytes": 1697,
+     "sha256": "8dd158020b8c0be6988b0f1fbe03990372fb769442dbaf85248ef8c0e18645ee",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "qc/boss.qc": {
+     "bytes": 12411,
+     "sha256": "674893303bff9280f134066f168b06dd2dd1d58591c42acc2c70c6e2a4b9ba82",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "qc/buttons.qc": {
+     "bytes": 6557,
+     "sha256": "8245790668278d8db700177e025e38cfe12df982f41abeddbb211ae6e03e89b9",
+     "timestamp": "2008-09-12T03:18:04.000Z"
+    },
+    "qc/client.qc": {
+     "bytes": 32354,
+     "sha256": "892fd14c0aa34f10328e04074c7dab3092ddb4e30991280a56a7c0398bdfb763",
+     "timestamp": "1996-09-29T23:29:00.000Z"
+    },
+    "qc/combat.qc": {
+     "bytes": 6130,
+     "sha256": "9e55bcbbb486d6c396ba9ee797de982be4cc79a94ffe2c40fba89bf3f72a5c4c",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "qc/defs.qc": {
+     "bytes": 17965,
+     "sha256": "6fb1b2b443e5cff10ad84c58523738398972bdaf93cf580fa4a7673a490e98a5",
+     "timestamp": "2008-09-12T02:54:42.000Z"
+    },
+    "qc/demon.qc": {
+     "bytes": 10027,
+     "sha256": "52c8816aade95e7d01139c6f1ce3047c365b818cda01609acbe26a647a24738f",
+     "timestamp": "2008-09-09T21:23:46.000Z"
+    },
+    "qc/dog.qc": {
+     "bytes": 9661,
+     "sha256": "ebe16c5e6b856102fd5d30b0519ba5c00402e31f98899714d412142f45a707d1",
+     "timestamp": "2008-09-10T06:20:46.000Z"
+    },
+    "qc/doors.qc": {
+     "bytes": 16965,
+     "sha256": "74353d68a738f7694e6f92b8ec8801de64efbf0408863aaecae4de70506a79a0",
+     "timestamp": "2008-09-12T03:18:04.000Z"
+    },
+    "qc/enforcer.qc": {
+     "bytes": 10954,
+     "sha256": "7564094ca81c56684440abd32a0efc6cb7d6447e53c215b201afa2acd2bc5b36",
+     "timestamp": "2008-09-10T04:24:54.000Z"
+    },
+    "qc/fight.qc": {
+     "bytes": 7208,
+     "sha256": "c68c3310e794200ef61c79ed9665490b3e893ff7d2d6243e5f6aeda7d9885925",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "qc/fish.qc": {
+     "bytes": 8125,
+     "sha256": "72333d58ebac7eb6be78e457e4f0d546f14efd71283332e1133d281372b04f3f",
+     "timestamp": "2008-09-09T21:23:48.000Z"
+    },
+    "qc/flag.qc": {
+     "bytes": 141,
+     "sha256": "143f0b896c7515dcdaaf5b436d130fe1ffb6fa67cad2a34ad4639724201b3445",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "qc/hknight.qc": {
+     "bytes": 18418,
+     "sha256": "a250f923c896251aa30ea242babbf97420e9770a3c109e6786192df26b977248",
+     "timestamp": "2008-09-09T21:23:48.000Z"
+    },
+    "qc/items.qc": {
+     "bytes": 30274,
+     "sha256": "bf8494ff4140430f278611c2dbcace3863afb3a20313cad7c804784038e4b7f9",
+     "timestamp": "2008-09-12T03:47:02.000Z"
+    },
+    "qc/jctest.qc": {
+     "bytes": 222,
+     "sha256": "0b356238bdae38139e36fb7f9ed5a72e65accee92b48f25035b79ec315a7da06",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "qc/knight.qc": {
+     "bytes": 9806,
+     "sha256": "aee2e639ad5e3532f29b7c6e84cba33e001cdbd9341883496d741f0910206831",
+     "timestamp": "2008-09-09T21:23:48.000Z"
+    },
+    "qc/misc.qc": {
+     "bytes": 15382,
+     "sha256": "98c8a9ece1ea352eecc2536e6901642e3eb8abcc1ea113d69e76dec7faf25c46",
+     "timestamp": "2008-09-10T05:05:04.000Z"
+    },
+    "qc/models.qc": {
+     "bytes": 8996,
+     "sha256": "d11fd0939293244962c5a40766e1dce246bde98eb0d42c87eb530a58d6eca64d",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "qc/monsters.qc": {
+     "bytes": 5416,
+     "sha256": "fe74b4d507f77be6635ecd4b59aed9323259632cc266be607b8b0f063cf419ec",
+     "timestamp": "2008-09-09T04:16:20.000Z"
+    },
+    "qc/ogre.qc": {
+     "bytes": 14883,
+     "sha256": "52d73c13b53441d86866068203f2fbfcf69239dcbd6df863debfa8605f41db11",
+     "timestamp": "2008-09-10T04:44:42.000Z"
+    },
+    "qc/oldone.qc": {
+     "bytes": 9537,
+     "sha256": "3ebf15cec4adf547d8859cb54772e9c1c331fd30cb3c82bccb328bb945e5f834",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "qc/plats.qc": {
+     "bytes": 7693,
+     "sha256": "a5338b5e69814d193d06685e9c24a417fe1b94d46e996f87c7788218791901b1",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "qc/player.qc": {
+     "bytes": 17554,
+     "sha256": "659665c41b4cc226055e037fc9d2b89f9ad3836a2c9a7517e1655ad18338b380",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "qc/progs.src": {
+     "bytes": 406,
+     "sha256": "e09745b7291991022ec2bb82f6bb7e6688e88ee0738db66d26a5695c4be95879",
+     "timestamp": "2008-09-09T05:34:38.000Z"
+    },
+    "qc/shalrath.qc": {
+     "bytes": 8001,
+     "sha256": "1a5dbd0ed205e6d728924f5f5c3e91e57ed19c253414ebd41c4eee8963a8212d",
+     "timestamp": "2008-09-09T21:23:48.000Z"
+    },
+    "qc/shambler.qc": {
+     "bytes": 12849,
+     "sha256": "69bab66091848fa1257399b48214ac087d3912a60ab58c914ca00a13f4f81bcd",
+     "timestamp": "2008-09-09T21:23:48.000Z"
+    },
+    "qc/soldier.qc": {
+     "bytes": 10030,
+     "sha256": "91851ce38712c684fba0a5b89867c8bf02a1cd06259341a2efb62ca09097be25",
+     "timestamp": "2008-09-10T04:27:50.000Z"
+    },
+    "qc/sprites.qc": {
+     "bytes": 450,
+     "sha256": "c00564e7ca0ab70d7891931ff333461ff90aa6052f46e8ebb02f59de6e03787d",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "qc/subs.qc": {
+     "bytes": 6062,
+     "sha256": "8fa013564dcf7be1df26888fbc304159b29be25ed43c4599333c9d8de809b356",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "qc/tarbaby.qc": {
+     "bytes": 7238,
+     "sha256": "816e0658408f3575dc934ca9ea27384dc43a48457a3351a382c9cbff09c938ae",
+     "timestamp": "2008-09-09T21:23:48.000Z"
+    },
+    "qc/triggers.qc": {
+     "bytes": 23832,
+     "sha256": "5db916e68584ebe37a1fae1ba7470b3aaa9b477ef916430695fc3e17c2077cb2",
+     "timestamp": "2008-09-12T03:47:58.000Z"
+    },
+    "qc/weapons.qc": {
+     "bytes": 26275,
+     "sha256": "202bd7d4a4ecdce058469134fc5c78c5a5d8284e1c3681bbedc629c693358033",
+     "timestamp": "2008-09-12T03:46:40.000Z"
+    },
+    "qc/wizard.qc": {
+     "bytes": 10785,
+     "sha256": "5e3bec77f84d719a57b32c930cd9d181014749dd34a42a4c14e6547e3b86919d",
+     "timestamp": "2008-09-09T21:23:46.000Z"
+    },
+    "qc/world.qc": {
+     "bytes": 11994,
+     "sha256": "568b78f4b1fafe16225d49e879e834b1f62a6b7bb4975dcc03e8a678cefc5fe3",
+     "timestamp": "2008-09-12T02:45:20.000Z"
+    },
+    "qc/zombie.qc": {
+     "bytes": 20790,
+     "sha256": "4ed7e3915f0c23c94365930923012516f27e3be1609fd9b8eec2c3913ccdf8c3",
+     "timestamp": "2008-09-09T21:23:46.000Z"
+    }
+   },
    "sha256": "8a8527857251a5be5f6089d106cb8c613ff9853c15ea48238a57defeaf740d40",
    "timestamp": "2008-09-12T06:38:28.000Z"
   },

--- a/json/by-sha256/04/04061cf28476eed1eb26d103483531bdfc6efc678eb5833b5b1ad3ba1994f321.json
+++ b/json/by-sha256/04/04061cf28476eed1eb26d103483531bdfc6efc678eb5833b5b1ad3ba1994f321.json
@@ -12,6 +12,288 @@
   },
   "pak0.pak": {
    "bytes": 11403029,
+   "files": {
+    "maps/let.bsp": {
+     "bytes": 1841352,
+     "sha256": "7b0ed84dd90454b53becf3829f08200a95ac25527c054a65120a506f17c5c4dd"
+    },
+    "maps/pow.bsp": {
+     "bytes": 3305152,
+     "sha256": "40a69eb588df31a950d060e62f211d7b2d0b0a641ae84954bc87f1e8c77e5b89"
+    },
+    "progs.dat": {
+     "bytes": 768132,
+     "sha256": "d5c8483f9186fd89bc4e4ddf1fbc416899b36d8f920928fce3199cbfc706e9d4"
+    },
+    "progs/Rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/Rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/Rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/beam.mdl": {
+     "bytes": 10608,
+     "sha256": "2165a66ba1d40fa378df735835b014791e769cb8bc56e06977aefdf134bb61d5"
+    },
+    "progs/beamhit.spr": {
+     "bytes": 5320,
+     "sha256": "bdfe3464c0bea904c3d35135b6d242f486298447ea45c3f96cce7ac6b71a3e54"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 1364,
+     "sha256": "eb7ed9439d34fcdc6c8a04a0bf57d344a75d208d65b8e3ab455ddda5965bf0b9"
+    },
+    "progs/bs_light.mdl": {
+     "bytes": 28707,
+     "sha256": "6c646ab4291d12aecdad5d9af4c44f4d68fc207c730dbf3ac04e07103cdd2c12"
+    },
+    "progs/csm_cpit.mdl": {
+     "bytes": 4424,
+     "sha256": "17c3aefc3c13035e45aec9befe0bf6722d163637aa56f18c3bec23c838dd5978"
+    },
+    "progs/dedturet.mdl": {
+     "bytes": 362892,
+     "sha256": "7342c6001cae61fb798f99150a06dce16f020af0d939a549e59b291c161b1e65"
+    },
+    "progs/dring.spr": {
+     "bytes": 387832,
+     "sha256": "94adc8ada163983eae9ccb924bd4ef4d8ebb2613bd23705d2e8a7bb73e7657d1"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 224812,
+     "sha256": "af9095cffbc74edc9d98d4e4e341736e304404df52983be33616da84d6463c87"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 218412,
+     "sha256": "f83402d6602ce9f39a85033e010f9b66edde2633155c51d671acd7bb76c90faa"
+    },
+    "progs/expl.spr": {
+     "bytes": 127672,
+     "sha256": "553b80901ee3d765c147ecce187a53989ded3991532e02f53c5b0cbb42aad5d4"
+    },
+    "progs/g_beam.mdl": {
+     "bytes": 68996,
+     "sha256": "db2566d26863472c6176c91b2256c12b5fdd28b5e1ba0a3ff2aa9e122ed0cacb"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 21704,
+     "sha256": "2d9b59874c12ad00e9a0c235e2cd461a45bce1638354fa1eda7430997695390c"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 12416,
+     "sha256": "2fff2f36173080827a298870a956fb11ad30f34aa0342ba5ca2c8bd6509edf57"
+    },
+    "progs/h_servo.mdl": {
+     "bytes": 159656,
+     "sha256": "f6e00f1d618c3586d96984737a6175688b1b8943f0e5c6a0be4cfb59ccbdca3c"
+    },
+    "progs/h_turret.mdl": {
+     "bytes": 142220,
+     "sha256": "cf7d688939f637832e00d70fb6c4e2f2f11a10b55cfe85197283d86fca536418"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 59078,
+     "sha256": "6a7022fa8210771be206034a2b0ebeb59f6fc79719d499ac01811a4ff32eb08a"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/servobod.mdl": {
+     "bytes": 271588,
+     "sha256": "c0c6f29d2f972eae2346a4155060f388ba7a4e6dde1511d86ccbcee1e1350b60"
+    },
+    "progs/servodie.mdl": {
+     "bytes": 444399,
+     "sha256": "b3d6a14916980c85d232c675a0b38b3487ba599b023249aecdc94cac702327a5"
+    },
+    "progs/servoleg.mdl": {
+     "bytes": 178044,
+     "sha256": "27b588b8c7ca9e56fb3d71c62d3886d7aaa0f3e9d9e757f855d2d762dd192efc"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 320900,
+     "sha256": "29d578cf1a503aa933f50d03ceaa4143a7b6a8319cc422a9b59f5be39a51e8fa"
+    },
+    "progs/turetgib.mdl": {
+     "bytes": 9172,
+     "sha256": "01caa25c4d2ebcfd4bde7d8db73331001f9d3c4d61504529f9f405c70800c906"
+    },
+    "progs/turret.mdl": {
+     "bytes": 753016,
+     "sha256": "5ceb4d4ac9b14d77698de75969e2233c834c0b0c6affc4c4f5788fa465853268"
+    },
+    "progs/v_beam.mdl": {
+     "bytes": 75588,
+     "sha256": "c00fe7872cb2c88626e63d99c3cc00b83f9968803344cd2021e8fc26bd25ccba"
+    },
+    "progs/v_beam2.mdl": {
+     "bytes": 75588,
+     "sha256": "95b3a260450ca784bda0885da994a5a857cf9948581ed1e68c4b202c51dae670"
+    },
+    "sound/ambient/Mosh.wav": {
+     "bytes": 67542,
+     "sha256": "f170d2f0e34fd4f2a6ecf593e73cb2fa70bff1aaa2de8e8c26cca6e8e04f3148"
+    },
+    "sound/ambient/amb14.wav": {
+     "bytes": 55320,
+     "sha256": "187b28d66dc1a05ea64502be9c6bbab4d1ea7b7465b988262cbddce8defc94cc"
+    },
+    "sound/ambient/amb19.wav": {
+     "bytes": 47188,
+     "sha256": "3ed17a7e847a6e184e2945e7603ee0a992862e66255403b2702a86267cc2338b"
+    },
+    "sound/ambient/amb4.wav": {
+     "bytes": 60158,
+     "sha256": "2133a96270404754f03c5a39fbfd0e7424d58768c59a890fefdeb40c40a9c3e8"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 107854,
+     "sha256": "3ff43e368ce72c82cca539acdcb3390cbbd62224b6f76f154fe7cd3eae55381b"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/mech/mechstep.wav": {
+     "bytes": 11310,
+     "sha256": "253862ad17886c0c0467f2600f185e11fdb49156500919258c7bdf1f51f5bb98"
+    },
+    "sound/mech/metal.wav": {
+     "bytes": 5442,
+     "sha256": "12f478674e401a0e8b3fa696dc87239bd25c75d543eab4cdc7dcb846cd62731f"
+    },
+    "sound/mech/pow_dn.wav": {
+     "bytes": 42904,
+     "sha256": "bcbbdf2a6c196dd3d21cb552e00cd903bde38b94d79860804b5d00f88dc05c3b"
+    },
+    "sound/mech/pow_up.wav": {
+     "bytes": 32670,
+     "sha256": "e0b232135f7db271c3f6e5f6f49eae7d948cfa3afc20d372d5cccb4fa7481663"
+    },
+    "sound/misc/Longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/Quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/Quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/Shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/Tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/rublexp.wav": {
+     "bytes": 42422,
+     "sha256": "85063f2a4baed6f0944ed41e346959da06472368702e5e458867fc8a755928ba"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/shatter.wav": {
+     "bytes": 41084,
+     "sha256": "eb288a2c0c1781a01af7d0cc73f096e216861bd77ee0d88b8bab5156a9963513"
+    },
+    "sound/turret/beamchrg.wav": {
+     "bytes": 3962,
+     "sha256": "d02bd7d2c4754fe3159fac83b4f0898f8b2e1f8996ce7e6cfdaa4a9d75a24fb1"
+    },
+    "sound/turret/beamhit.wav": {
+     "bytes": 8644,
+     "sha256": "35e5e5f28a3695ed27c2b0887a1bf118643d769c457d3642016e887248fa8ca9"
+    },
+    "sound/turret/beammode.wav": {
+     "bytes": 3664,
+     "sha256": "1589cc75daf6c3838ed7e926c205e50ceb4c21338fc1ddacae98d53a37acfbf2"
+    },
+    "sound/turret/plasbult.wav": {
+     "bytes": 18038,
+     "sha256": "dfb145c600c2d447fee8ab89a3afe8e44cf7ae46d770c8eb42903d83a687b122"
+    },
+    "sound/weapons/Arrowhit.wav": {
+     "bytes": 3644,
+     "sha256": "7348632798578416b240951489cf027abcaa04ac7f1190a22581349c8b06ede3"
+    },
+    "sound/weapons/Lncharow.wav": {
+     "bytes": 2872,
+     "sha256": "546ef60ffa1d6f311f24093af551514ef4f4b9832d4481e4ae78fd0bf6e273b2"
+    },
+    "sound/zombie/raised.wav": {
+     "bytes": 18860,
+     "sha256": "a876ebae07f1cd642c980bad864ba8177898d545f8750c57bda24ccece0e2209"
+    },
+    "sound/zombie/trick.wav": {
+     "bytes": 20946,
+     "sha256": "ff4f2c8f9070d76a519c07b7df811c49557319be6e7883944927ad4135cc0fb8"
+    }
+   },
    "sha256": "a28b449a89793b4ace5640d93032034f4613fbe2b63e67a52f4d37e4716fc39b",
    "timestamp": "2003-07-07T20:52:02.000Z"
   }

--- a/json/by-sha256/04/041adbd966527e302b7ec9790409f5d093a5a1709069c515f591695f8a0c6bc7.json
+++ b/json/by-sha256/04/041adbd966527e302b7ec9790409f5d093a5a1709069c515f591695f8a0c6bc7.json
@@ -7,6 +7,136 @@
  "files": {
   "PAK0.PAK": {
    "bytes": 6523712,
+   "files": {
+    "autoexec.cfg": {
+     "bytes": 27,
+     "sha256": "141bbb404d0c3a79fc8da08b51c0e5777ac7d046cd99cfef831361ea2eee9f12"
+    },
+    "maps/_mapfort.bsp": {
+     "bytes": 539304,
+     "sha256": "0d54e618ccd936a3e928668c032fb1941f97765f93a11c30ac71e32ae9f5f5ec"
+    },
+    "maps/_maplhse.bsp": {
+     "bytes": 1288836,
+     "sha256": "6c9ecadcfd1866ab239ba15059d958d6f88845b67e881641af8f1831f4d40a09"
+    },
+    "maps/_mapstge.bsp": {
+     "bytes": 1406744,
+     "sha256": "56c3fb551cafa1c5e80e5d220382909c6115c996bf38b43048ad694ddfe8a477"
+    },
+    "maps/lighthse.bsp": {
+     "bytes": 795916,
+     "sha256": "319d695825f7f1b235b2126b67e01b696655f0daa58549cdd608408def23f871"
+    },
+    "progs.dat": {
+     "bytes": 598280,
+     "sha256": "ca589753f5516959280cb431b7709d70bbadf6bc3af755b3a3af35b76cb5c1f8"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 12161,
+     "sha256": "41339f3222ee6fc0cd85a58a7b2a6c4330e284ea39ecb7002d97927244c5250a"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/dog.mdl": {
+     "bytes": 198788,
+     "sha256": "a21422a57486dc5b730ecc82e09b64042427c16668c1f9a63821c1775383d6bc"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 228400,
+     "sha256": "5cdbeb83f4d92049ab22423d66fb20b783fa4a99590a4e67817c91d28979826e"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 12564,
+     "sha256": "88665ef5fed74dbeed1bf90d0a34250322924020d22ac8d24f1f6434c4b609aa"
+    },
+    "progs/knight.mdl": {
+     "bytes": 153400,
+     "sha256": "644ab730461f07200980cf3af02f7a06d5298070747351d6aa852fdb905556ce"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 15092,
+     "sha256": "362ff3c50031d80b46a11c3d1902fe1cc3d442cd13b7db59f6d46c5655fc9351"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "ce484a3df3d4bb1ddb2b39683cb4a68c902b4d353f4c208cb67c6a25356fe13d"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/s_null.spr": {
+     "bytes": 56,
+     "sha256": "29e9c18546413f0abc9c6f507c61952f33afa6507b52d1c2197b57e3be7870a9"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 12564,
+     "sha256": "ec96b9167c1776488dc8044d0a310aac9ad3da915a65eb02f11fa636073cd932"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 106596,
+     "sha256": "ba43caeb0942d291175d200edf8990624e1d9f99f2b76e3120d0de75c46c0692"
+    },
+    "quake.rc": {
+     "bytes": 388,
+     "sha256": "2516c50bb7da57d5560d097509c0ed4377bd9030d606c9883cd3d0296c921cd7"
+    },
+    "sound/ambient/whale.wav": {
+     "bytes": 102638,
+     "sha256": "368925d4c8c76ffd4bc1eb71cd8a079ecfb6f5416fcd0077a6d71b52b0d9e665"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/weapons/arrowhit.wav": {
+     "bytes": 3644,
+     "sha256": "7348632798578416b240951489cf027abcaa04ac7f1190a22581349c8b06ede3"
+    },
+    "sound/weapons/lncharow.wav": {
+     "bytes": 2872,
+     "sha256": "546ef60ffa1d6f311f24093af551514ef4f4b9832d4481e4ae78fd0bf6e273b2"
+    },
+    "sound/wizard/statue.wav": {
+     "bytes": 13090,
+     "sha256": "f6b45dbd4eb98365f738ff83335956974a491b9c5b385f201f4dda4b08397d40"
+    }
+   },
    "sha256": "3dbfc5676c986f5f86ba92cbe7aafa56411af747805a2027168b891cfbb1c38e",
    "timestamp": "1997-10-01T00:21:04.000Z"
   },

--- a/json/by-sha256/06/06c39be7886934d4d94d517de0a8428525cc0d436a7ec91ba142ece3fdae3cdc.json
+++ b/json/by-sha256/06/06c39be7886934d4d94d517de0a8428525cc0d436a7ec91ba142ece3fdae3cdc.json
@@ -565,11 +565,2075 @@
   },
   "jjj2/pak0.pak": {
    "bytes": 26721972,
+   "files": {
+    "gfx.wad": {
+     "bytes": 204788,
+     "sha256": "231ee3aaec405032e496c58381ea0a12c720cb67f9170776fa207f5c9fa0cf76"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "6072bd63a691625de201f3f3da060b5df433753d7ac2878c48b87e9d0dd08b94"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "ac11a967228e1c7d1a936859b82807cea239d80380fb6204d67af7a86c5c82e3"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "4cb99cf1b515b6547f012b6e44174c245261b058168a8bc4303d08b98e1805b6"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2c37b7697aebedb5bbf6637d4b8e158f70da6b7245195ff0e91a6ba7aa24e828"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "219002fe962a017600a37dcdcaaa0f777aad42044619f945cb70c68007763a97"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "e251893ed49aeb677096d380d4246907a039e0e21a4849f97f343b0b13faead2"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "64ec646cbab7ebca11f6af4f0b75d9706f438baa7b23059de87f8685f4686640"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "03c7cdc618e4404e2b9364c690b0a447b4be99dc5af112c66e6e2079902c76cd"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "9cf2683f2a6d22693a8c0cf35898bc5900a96afc771878df9f8a8a88f3d581c9"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "f232da5cf35acc557f3f312911e6a856cffaaf9f8078ca2ac5ef7e6f6e5e3515"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "b57ad9ad9d6240a0e035ca7a64e706e3031b8293c27355c9a95495a84972af4a"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "873af58b7244d6e82feb1af26ac044c9beb43c2865bc51d0485054a562ce861e"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "ba75badfe057b499d33168032dd5dc5a4fd0dcbaef9cbbd27efdb3f056cbfc00"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "55ac1377921460aeb691f86e7a5051e3a5481f24b93cc8578cffdab2854ba0c3"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "9600a66391996cff88d48890adfa516660fce6a32397ba4f54973159785cff4b"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9f03351fa7f31a23b63e6c13d2a643ed1ae3fd3df0cf2b0db336424eb17016dd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b7617428e8d1d74be7b770ef24c744d16c2503efce9c17facf1107cce08f5ed9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3036afb422cd299cb09532a20847ef35aaf87bb36e34ce9ce75b5e7aaf9a1ec3"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "7aa61257bd3083c00959776eb36aac86a7ca8da2bacbb4c8a41d9a5fb0b1ab97"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "cfe83953875acfe9afda11b75407ed9883eeb284b0a67b9ff6e07df85d50d9fe"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "d3b4091b83837da5a45445cd00b90267c62050e010e2a045461034ac9c48be33"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "de004dcecdff1973597a977ab63c671ad7d3f52387bdcff4be560924e3d4d17e"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "078c56d685ff1fb84b322f7a76e485c2637fb09efc61f4e44d5d067b3ef9a42d"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "9df9672c8da61ae769409e9ea741a1b8f9a4f108b5f0fa6637ff65601c535843"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "fef6b9be45d5b384d061a47f133075d1cfe0b60d93cf7e3da9ee5529f661964c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "1b1254c1f5764affca85448c4a3c2fefdb938f35bc50f44142a8e9b692ba7d64"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "39a06ff92831e1e2fd20c1bdd20e0f234cd0b3aed94e6c9909d059a20479ce3e"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "def061c922fb91a7e58850e89bb6baa9e09dcf93de7a94288a90511ecd9a114d"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "f897535531fe4b821d41d859a4085fd7d25c679493645a2ef7448f62073523c4"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d070636562a967d1abff330dcd1ea504ac7b9b29099a98994add1d9ae47e44e9"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6d92547a27d839f3c9d7a1da786fb33547cd93b7f19560b6c4bcdc12064545bd"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "e932416c58fc5de16e6d05aa737e56d3811e540bfd9e6acd1bf114ccd8bf34ac"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "bda55d4b2d7bc3f180dafd62424ee5830896563f5a5ac576dfa08894f5e17e44"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "513955ecc96eb1f0d44b340b47f79c02bb7bfa7f3b0a884a65fe111429ddb2b4"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "2faa4c1f61d175ad28b7f54540af3f87abc6e56dc20f2da5fc8a7737a0302c97"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "dcfe5287432b3a1124d032250ccc4bf25c73540521c77601ab746287ef3a0179"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "00654b7bec9981508cd9ae8eac167637926c023e7bca011a3cf37585b7e168a8"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "74c50b895f1e71ec6a569fba0e991fde8cf136ea734d6914435aaf9b2735d7fe"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "aecab7a199a4db72242659e6d1ced192d39b2619f67c7e5eaafa72a5efef3aef"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "d075eb0c8c00d30b01eae539720c20b73bb57066c6ea5e8180a4d851d9167add"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "d03aa05e24552d961ea9ca278d743860e34a97e2ffcee52fded05ad4b4740bd9"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 20040,
+     "sha256": "61c46ac5672c1e671c0c38a6498158176feaa62b074621c2a3d74e5dfc68e2f3"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "progs/arachnofloyd.mdl": {
+     "bytes": 741212,
+     "sha256": "554bd2ad34a830fa01a61dd4972f432812fb61f7815ec81d8a8d7e87bfad6b02"
+    },
+    "progs/arm_foot.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 164224,
+     "sha256": "35314143b9c7a9a0e26e52a865072a6e73862466e640c6bbd58be3075c4d93ff"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 364136,
+     "sha256": "1b8f642154d81d3e5c758a8cf3fc9a18e3d2c2e78ba5ee57d59f66d871d4dfa2"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bambler.mdl": {
+     "bytes": 128044,
+     "sha256": "c8ac9dbcf99f0e6efd30496ac414383c26b8d241fbaff56cfa81dfb545dfb0c8"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "698bf740683ad182feae2246526361948be6da2e144f1bd0202eafa748213ec2"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "b662513bc3a8e0e967344c55b536bd33012340dbeb79a8db1281d2c84e36d338"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b2cf62d8e989789bd76e27193b2f5205a93d4172a4e25c89aa1b30f75bebe60e"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigcranea1.mdl": {
+     "bytes": 92792,
+     "sha256": "81f6a5b55d3a585d5e9c73b088d1d20e0fb328707c1539ef41e52c460555f651"
+    },
+    "progs/bigcraneb1.mdl": {
+     "bytes": 21940,
+     "sha256": "e02faff0bb6c84c781f6b534a5a06ac1f977a028fbdcca176be2932f91e9e8ec"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/brz_saw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 575288,
+     "sha256": "f571bdf504537ce01ca2b6a78b57575a36c391f9c786625d880d956fb17390a7"
+    },
+    "progs/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/chain2.mdl": {
+     "bytes": 141764,
+     "sha256": "9334a3ec04716ce0068154bf7abb4c1e3ee6de14fb159982dd547314935d7854"
+    },
+    "progs/cyberscrag.mdl": {
+     "bytes": 311084,
+     "sha256": "307e8133ce4f48d4c3dad5ef1b9d32900a3457e91aade778b7fbbc6d8a4741e1"
+    },
+    "progs/cyberscrag_gib1.mdl": {
+     "bytes": 60500,
+     "sha256": "3db8b13bfa5a5eda07acea695cae6ffb92354053da9bed199ef29cd445317faf"
+    },
+    "progs/cyberscrag_gib2.mdl": {
+     "bytes": 58932,
+     "sha256": "ef20c0de15fe2fc2514c10b0023d14009a4871ed40311077ba107350c313f7ce"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon_alk.mdl": {
+     "bytes": 191716,
+     "sha256": "11f33f19ae0a46d3dcc6c1fee46235fb6ad201456120502b603fe4fb7cee14ac"
+    },
+    "progs/dog_alk.mdl": {
+     "bytes": 199324,
+     "sha256": "a16e350fcd247908c75ecd0c93e94d3b700b67bb0f66dd45d665d171a55d42b6"
+    },
+    "progs/dread.mdl": {
+     "bytes": 415072,
+     "sha256": "dcea570331c5cf4348c40451c6242bf35ecaaea2a348f12254a13c1b76b13d7c"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "3a2df91993fd0447d87bc26da842a359df862a12d9993ec7dc1d7aa79c6565ec"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 5172,
+     "sha256": "b0951de4d869e0b779aeb3f7a96f56b22a82a58d267a56b1247f0c3e667c25ad"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 6036,
+     "sha256": "88f8a1f941e38f8528ec27a168559946cc0b69f2abce1cbf6858b813e09c5f51"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bcc6396dc638003480dba8c36cafaf32df2cfcf49bd460b001d0d74a164f9011"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/enf_gun.mdl": {
+     "bytes": 58684,
+     "sha256": "39ef1788b39a15f86c8d54b81c43f4126e8361ff80d386c44358f17ddc93769f"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 450424,
+     "sha256": "ecf603c4ebc56438e96d1706a451af8bbe9b090db9c48e38e758ec630a393570"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "ddcf759804fffd97e62c55f67f962e24e8cd646fd982215ac8aefd3e49f67660"
+    },
+    "progs/enforcer_alk.mdl": {
+     "bytes": 333860,
+     "sha256": "85fb5cb9eb1435da65ce0aa6940241b7b4b5fa13e7444713a75c6ec301cc8b97"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f6c43a5d21e1675e4ad95acbc1a47a3be07ccb74fffcb53574f00945d5b06cf9"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flag2.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flagbig.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 451032,
+     "sha256": "1a311e7e74f9a67c9f7468252aedc8c19804f65375d229e90afbec2f93849823"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/fromitz_still.mdl": {
+     "bytes": 6964,
+     "sha256": "63204597e828e001c957e9316878995e161da0502764276b90285accadf6a222"
+    },
+    "progs/g_axe_alk.mdl": {
+     "bytes": 50460,
+     "sha256": "92988e970870f2b977f7490d2ea4ee040d338fa4bdc470e8d68f2e5a856a7a28"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_mine.mdl": {
+     "bytes": 37780,
+     "sha256": "67495e6183f1d689c52659837138a2a2a145feec9c7c69ac60d083c8704cb6af"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "15f390e39e02c8524e575ca8fadf63187b641c58210ee9587b13a0ca94c29cc2"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 199076,
+     "sha256": "7ddca6fb95082d0cc7ffe5aa3ba896ea987a80b1bd5867db97b2a84b9d8da9f6"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "8b05b8ca87ea867c2a2397d238311fda2441f5c0e1cde130ba487b0dbd17a8e5"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_arach.mdl": {
+     "bytes": 60292,
+     "sha256": "daca6412383bec28809cee42c4ebf01085cf83ed6ff289114ba0f842b4005251"
+    },
+    "progs/h_bams.mdl": {
+     "bytes": 37316,
+     "sha256": "58c4644a2ed3e5f10741dff2ad1a8bb161f7eb205ba3fd8c5fc9b7e4ffc571dc"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_cyberscrag.mdl": {
+     "bytes": 62036,
+     "sha256": "df7d6bccc97bd5c184d9d6160005b370175aacc16a34bd06ab14c7d69ff60419"
+    },
+    "progs/h_demon_alk.mdl": {
+     "bytes": 72644,
+     "sha256": "22a9e01cdccb2e274c63c277e6dcd61986fa7556426ee3562fe11af2babea289"
+    },
+    "progs/h_dog_alk.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_mutant.mdl": {
+     "bytes": 110240,
+     "sha256": "f1f9c665b659a8c145550605ef9abddf27779d0917c897baa344d65673770875"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/h_sabrkn.mdl": {
+     "bytes": 11828,
+     "sha256": "050fcc93189211aba943674a326ddd898dc980b83fb551ee11fec3dd39973483"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shams_alk.mdl": {
+     "bytes": 37268,
+     "sha256": "9fcace6cfb38473763a5cf96007ccc5e0ec4786352d4d1063410d63157298b45"
+    },
+    "progs/h_torm.mdl": {
+     "bytes": 62056,
+     "sha256": "db0ddda0c4d2283cd3c58eb45397cfb57095acba1eb6dd38571ca23ebffe9946"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 37012,
+     "sha256": "e3c6cbabfe6c6723101f2e59f50fc99ee0e360571c95885d2d56c85eefade15d"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/jumpblue.mdl": {
+     "bytes": 37428,
+     "sha256": "be4e85e5fc643e91377d69794b997ad4dc927ae3866dfef5288d704dbc0f16d7"
+    },
+    "progs/jumpgold.mdl": {
+     "bytes": 37428,
+     "sha256": "4c543d82c88009cab7fcf6230feea0a21518a98f430636194fdbf5c1e526cc13"
+    },
+    "progs/k_laserspike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "63220c0ebb6e266576cb3107a44be16bda10d69fa524d0462514edff9d80328c"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "29bc55efafbea3e15a385598750ba4d9242d0a87803a6bc3430ed772ec1785c3"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "f1e799e7feac3c340676bb60f6cc7a2a7d1e121b196d1f6d0e23edea3a614ed6"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "92370f5b196dc00460d73697975d14279ef659c87c7fc1613b9cbfb68e6c299c"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "4c5db792da6876f935f8a98a74f51708d52ca03f04975f28518051494660bf65"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "781837a3557c1a8b89c15fa8f477989cb4b77d8cff09c8c13d071090a4df9c1b"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "2feb7ce08070b314d163cbc7f2e2eae0986400c482f752d305ddba268639b3d8"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "04f7fc8b0c2be7ea93021819770145eaf828b2313c4fc591a5f2aa783ca97e61"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 8372,
+     "sha256": "9b6a8f7a49fb7a1f5d4d409b708663c579d433e978d898b9bdf00291a59b4e6c"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "fa5d7a5e2410ac7faa5dd0a8e17873c972c6e5cfeacc94118f22db1b4b17477c"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/mutant.mdl": {
+     "bytes": 352720,
+     "sha256": "262ffca22e0c7308950076c2789436a891399862ea25afbd06040158ec9f7984"
+    },
+    "progs/nsoldier_alk.mdl": {
+     "bytes": 563108,
+     "sha256": "6071d7cecf231f0a83f2e1c7df533b4a32beb6e75969d17703446a67d011695a"
+    },
+    "progs/ogr_gun.mdl": {
+     "bytes": 52452,
+     "sha256": "eaa6e0fe01255450d578f151c06c5aeb6a9cd5ed90edbbe4f52d305069ed6825"
+    },
+    "progs/ogre_alk.mdl": {
+     "bytes": 315696,
+     "sha256": "31e9986373dc1a8cba00e09ba9b0278cf766bbd074524a891ed22329f697d643"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 487968,
+     "sha256": "ae0abff3ea3fc7ca8c7f80c5d8825553795a1c1ebb80127d46fa52b20905abc4"
+    },
+    "progs/ogrem.mdl": {
+     "bytes": 315696,
+     "sha256": "a46b1fff7c6c446da81a734ec6bfdffbb7db315a59745feb7349fd9a73c248ac"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/probegren_body.mdl": {
+     "bytes": 139044,
+     "sha256": "da0ddf337c3e2515688f2b143adf55d4ecbbfa32955a78aea01ed16e067b0065"
+    },
+    "progs/probegren_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "4f292b6f157d226e763ff28dad682ce95cfb8a3a21b4badf0ca48db4900cdd70"
+    },
+    "progs/probegren_gib1.mdl": {
+     "bytes": 63788,
+     "sha256": "0efb081efa87c9db990d984f9974f10078890a51894a3e0a6fbe76cc3c4cb5a7"
+    },
+    "progs/probegren_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "7843ddefa22b7d5beb37f889c606c6361792508c2bea202f3dadf9f3ffce73de"
+    },
+    "progs/probegren_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "7baac250aa8c27ef3158de59b536ebf59509e39b1f7bf6be1c24fd5b1e29cae0"
+    },
+    "progs/probelasr_body.mdl": {
+     "bytes": 84296,
+     "sha256": "ac545d0f545488628c864df6e464d10fbd51cb41a2cb76c46dd91233ecd11a6f"
+    },
+    "progs/probelasr_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "cec7b847c9b05f2653113454348799b9bf09c2a74c8e1760cca0ff52c1dfc18c"
+    },
+    "progs/probelasr_gib1.mdl": {
+     "bytes": 58700,
+     "sha256": "ae9f298abc0bb1d09cea3c04bf02216b0a1c3749f8c8a822d973b4c2091cd649"
+    },
+    "progs/probelasr_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "07d6defee5ce4e747daf8b397a5d207a1a42e3c3acffbdfc18d6720c88ec635c"
+    },
+    "progs/probelasr_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "8b8f376afa56e7a9f311e58a076f1fa3a52c88064887a8e0960fdb6daaf5265e"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12653,
+     "sha256": "162632bc16838f66f29e0b788845a6421b7fce708003e9fa6f4eb8ae7aa8e5be"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/rail.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 200152,
+     "sha256": "a564fba381d24e3084bc9aa0a026381c83e6b889632c8bebdf69c08c8a6bb9f2"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "f65ba83d82e90808af589ded17378f1baf37f105fa14f2b157227ee22583d25d"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 288,
+     "sha256": "6ff2797f9dc4e66f2113475a5f3e0e96f23dacbddd18fe47c8b5e12e712f0e75"
+    },
+    "progs/s_bullet_new.spr": {
+     "bytes": 708,
+     "sha256": "a07fa61f4a838ac9ad8ec85ae525d70fb934d383effd1948c0775497be713043"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_plasma_new.spr": {
+     "bytes": 13980,
+     "sha256": "5474060e55af3c462d0ef7aad043f331c1f5b642915d906c1785bb94595cc68c"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shambler_alk.mdl": {
+     "bytes": 502148,
+     "sha256": "bcf685fcd1f4062dc382924d39eae073fc4d44cd2dcb5bc4ca3797fe0b342b71"
+    },
+    "progs/shard.mdl": {
+     "bytes": 10132,
+     "sha256": "0f756f280c09f44ef1e9f36fdd678566b4a5782b349a3e9fe1309c3fcd9ab19b"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "662d6a7cd68bca7a9c5e88838d190de6a501252a14b6994a191d0bc91f1f331c"
+    },
+    "progs/sknight.mdl": {
+     "bytes": 460932,
+     "sha256": "9213f6898a60cdc20a7a144c61c13f8d64f1432382dca44b636524edf737dac8"
+    },
+    "progs/soldier_alk.mdl": {
+     "bytes": 359276,
+     "sha256": "623374e5a553c3d886738c9cc0b22c0b3f3435b3dc1b3f473079a1dd1661fc8a"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spiderbot.mdl": {
+     "bytes": 82476,
+     "sha256": "e85556a194664a5f69e70b42aa863d9e67689a418a3afa51e50816174a6fe8ac"
+    },
+    "progs/spiderbot_gib.mdl": {
+     "bytes": 19444,
+     "sha256": "96ee732ac1199a89c675880700c24e1f09521c35ad478f73aaf4278a398454f6"
+    },
+    "progs/spike.mdl": {
+     "bytes": 1684,
+     "sha256": "5e3be5dff13ec94951aacbd4a453dcbd9c2aebe7e4e6bded2dd70d49d1ddd695"
+    },
+    "progs/supbkpack.mdl": {
+     "bytes": 44408,
+     "sha256": "781c6b5f424fb58e06b2a84b1fb7e980778decde6b3ed257e224db0b1f250173"
+    },
+    "progs/torm_largeshot.mdl": {
+     "bytes": 37852,
+     "sha256": "ce3a87be213e39b48bc71a6fbf5e1fe9e3f5209901ca45801f27d8f297e04a01"
+    },
+    "progs/tormentor.mdl": {
+     "bytes": 461080,
+     "sha256": "df302dea113f54df908f97c26de844d1235004c08aefcf5c349f3af4b0957d41"
+    },
+    "progs/trifecta.mdl": {
+     "bytes": 25460,
+     "sha256": "2c9196af0806c48354f5522a8b7f6fa57e6390f8dfb51718fb71b8a2d4d7447a"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/v_alkaxe20fps.mdl": {
+     "bytes": 96428,
+     "sha256": "4405242db772d86c66f1012b140ba409bee86682fa5f4a6ca12c3e6f94eb9fcc"
+    },
+    "progs/v_axe_alk.mdl": {
+     "bytes": 55820,
+     "sha256": "80ad34cf2612f8fa9121f2be0ada92c1e05613ae2b35b2a1be25a4c694dd2147"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 141180,
+     "sha256": "bf682cf5cd5fcf5bbfd880cc9c30d395afbec00d8a8c10554c3498fca6b90cb6"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_mine.mdl": {
+     "bytes": 164860,
+     "sha256": "f3bd45a52c8ea00e77d1e633fdfc6eb1ad2557a076d527f4045a69fd54ec7c31"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail3.mdl": {
+     "bytes": 124944,
+     "sha256": "19045e9a5154299b68377744ad946fc3e7f2bd290497c8291a2247ed8cc572ad"
+    },
+    "progs/v_nail_alk40fps.mdl": {
+     "bytes": 44692,
+     "sha256": "402b3dc06f1e5e756cfd50cab17cca49e17e261994c5007cfd46c466a08d3dad"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "c9b1d92376ee404102776c630a4fc6fda972c9130fb0f461983c1b6e217a14ce"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 95124,
+     "sha256": "986246477d8779ebcda7c58cbf90fdb88b39666cff4fcfb18a2cade0a6f303d8"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 326464,
+     "sha256": "dd389cc337d8b7675d9a7b983fd9f53f0c59d597a9759367bd1e1beba375eaaa"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 21908,
+     "sha256": "ade58867dac49427ce1a66c498f5dd7327685db0daac1409b80e0a341df59283"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 21804,
+     "sha256": "06a1f7cef5d1d3f8c377addc4026523b656b8f77986495f96048a1a6ea94549c"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "quake.rc": {
+     "bytes": 1015,
+     "sha256": "c4066ca34a63afa64ac62d7bab29bd9ecd2103ff94e8a564531a7f8f284db4c2"
+    },
+    "sound/arachnofloyd/death1.wav": {
+     "bytes": 119460,
+     "sha256": "d16c7ff30e9df62fbcda102befbd61fe234532f6aef30d0b34c25330679682bc"
+    },
+    "sound/arachnofloyd/death2.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/arachnofloyd/idle1.wav": {
+     "bytes": 34254,
+     "sha256": "35d6991a10637251ec0d6b830f7f57f394e4eed06e7a9dced86f0128ba5bc49e"
+    },
+    "sound/arachnofloyd/idle2.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/arachnofloyd/leap.wav": {
+     "bytes": 70884,
+     "sha256": "f47323f618db14755c57e9e25213267dcffc501fbaa9a201176ab99db6cda928"
+    },
+    "sound/arachnofloyd/pain1.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/arachnofloyd/pain2.wav": {
+     "bytes": 15906,
+     "sha256": "9c4bdc81c73787cb67677e0021b71d9e24734ef3ce272d9020dc6611a1d87842"
+    },
+    "sound/arachnofloyd/sight.wav": {
+     "bytes": 48620,
+     "sha256": "97a055dbb8e5935190348b2c2d50c6d99ab35c29f3ebcd0f66d6263bdb5485e4"
+    },
+    "sound/arachnofloyd/step1.wav": {
+     "bytes": 74932,
+     "sha256": "a8744a3e50dccf9ee391da2f381c2ecf6701a76441406929ee4581c7717b880f"
+    },
+    "sound/arachnofloyd/step2.wav": {
+     "bytes": 34478,
+     "sha256": "22ce43aa18537f7b04e31263a46dd02e181d538fdf5918d55f8ce0acbb930676"
+    },
+    "sound/arachnofloyd/whirr1.wav": {
+     "bytes": 19762,
+     "sha256": "9e2029071248e6d45f1b0d518983bad5bc5f841cda6bcfba09486e111add10de"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/bambler/melee1.wav": {
+     "bytes": 4175,
+     "sha256": "4e0e2567b9d64b3ff86b33d95fa0158bf72372aeb4968a0c2489df942f9f7c4d"
+    },
+    "sound/bambler/melee2.wav": {
+     "bytes": 5283,
+     "sha256": "4bb91991bccfc33576eff19037e12666e9825348272d3dca40199e208bc00700"
+    },
+    "sound/bambler/sdeath.wav": {
+     "bytes": 14048,
+     "sha256": "c5253af82d203e75d132a00bbb555de055d2e356106d460f34cb8c9a2ee5e643"
+    },
+    "sound/bambler/shurt2.wav": {
+     "bytes": 3736,
+     "sha256": "0f1a51e0ff72f23a4de7684d4408344b7b7bd2cb805609168d2f2459e1b8660d"
+    },
+    "sound/bambler/sidle.wav": {
+     "bytes": 4907,
+     "sha256": "ea2232ba791e306cc86f58303413d8f3fbc7dd38091281698f4d846b6cafa483"
+    },
+    "sound/bambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/bambler/ssight.wav": {
+     "bytes": 11376,
+     "sha256": "de766aa056ca5f7dc6d179e6a220ef906ceacc0341b5cb3d91a4d0e75ff55338"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/cyberscrag/hit.wav": {
+     "bytes": 22334,
+     "sha256": "a16ef33d94d56fb6984b2a3d06104a3cc292bdb38ec6ee22c8b10457b2cb415f"
+    },
+    "sound/cyberscrag/wattack.wav": {
+     "bytes": 25912,
+     "sha256": "6bed724b7ef9bdd480448396ed4498c75f848bf2a1e6d2879cb2b2484cdd1a7b"
+    },
+    "sound/cyberscrag/wdeath.wav": {
+     "bytes": 20684,
+     "sha256": "24602233cca209122250ba7c284933992aa2393795ea5c528a57b9986e2fc319"
+    },
+    "sound/cyberscrag/widle1.wav": {
+     "bytes": 13465,
+     "sha256": "8902628d2201eda9396c0dc134ebda8b8d5c37dabddcd286f8387aadc6532750"
+    },
+    "sound/cyberscrag/widle2.wav": {
+     "bytes": 23094,
+     "sha256": "76af020e5c25f40ab3020bbd065a9b83b9b0a51120d47d137a7abff4eb43e193"
+    },
+    "sound/cyberscrag/wpain.wav": {
+     "bytes": 8687,
+     "sha256": "af2e8589d381e634f607048ce71200df832c9e3a32147891b5bdd2efe2ff5bf0"
+    },
+    "sound/cyberscrag/wsight.wav": {
+     "bytes": 13079,
+     "sha256": "2f9178f6515eb4cd518b418441c40d1376aeaf6f42f7791533f5f4b6da87fd68"
+    },
+    "sound/doors/alka_doorlocked.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/doors/q2door1.wav": {
+     "bytes": 30572,
+     "sha256": "3f05bddf76379933970c532656b6350bc53820319ce1cb9d4ea9288210427eee"
+    },
+    "sound/doors/q2door2.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/dread/dread_death.wav": {
+     "bytes": 49692,
+     "sha256": "22000ff613ff52eab0605418681affaf7aeef4acc420d3dddd50a9031ac1ca38"
+    },
+    "sound/dread/dread_pain1.wav": {
+     "bytes": 29220,
+     "sha256": "67e443f78043cb9fc4213bbfbc3cd847785a66849fb7b36dd6467494487e0aec"
+    },
+    "sound/dread/dread_pain2.wav": {
+     "bytes": 23380,
+     "sha256": "914fffe3ad6c02fb78be873ee96405a40df22cd321beee2d673d0b6ebbafcde4"
+    },
+    "sound/dread/dread_sight.wav": {
+     "bytes": 70792,
+     "sha256": "50449a772b2ac778b810a69de58cb63c8bbdea529091720a41a1052b7196632e"
+    },
+    "sound/dread/dread_sight2.wav": {
+     "bytes": 58420,
+     "sha256": "f7952137b648f6376a1ba4e968679abb17fc648ede87bb0dd32f633271ad80ee"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 110256,
+     "sha256": "895cfb57c0d27369530fd5e9b29abd491a989ad0a63ddb00f05dd9e4777a5cdb"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/frogman/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 32638,
+     "sha256": "3cf3933f34c7baef52df54d5b03db40424e9f7ee72e5aa5a4dba489d71be2af7"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 27662,
+     "sha256": "ec38e73fd1ffc33cd25aa065e5f5897c21a494e380763ff80b6be482689b5e33"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 44186,
+     "sha256": "7600cd32fe980646fddcf5a9077d8d43df1bca1f2ed05bd92ce8cca273ad6636"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/items/shard_pickup.wav": {
+     "bytes": 18260,
+     "sha256": "388923a63b48720647b9e0f2862c35bb1d5cad2e162ace343845b3fe36b48af4"
+    },
+    "sound/items/trifecta.wav": {
+     "bytes": 16412,
+     "sha256": "00baad51adaa3f5d6664e85ae5442221db6818bfd85124c164324d22f6723ab2"
+    },
+    "sound/items/trifecta2.wav": {
+     "bytes": 32778,
+     "sha256": "f742a9cee4a53ef52fce55d5e9ddaae9c6b20d2127e16c0def6cd11b3d2d6380"
+    },
+    "sound/items/trifecta3.wav": {
+     "bytes": 10728,
+     "sha256": "a78bfc9fa4fbf0c3c1e85bee273ee053598989a09146bd29e97dda811c49a473"
+    },
+    "sound/items/trifecta_sounds_v2.zip": {
+     "bytes": 29483,
+     "sha256": "693e53f4d59daa0df6448a8d3b5f23ce2a99047689e0071c0986ae6d008d1ebb"
+    },
+    "sound/lieut/alert.wav": {
+     "bytes": 8700,
+     "sha256": "7ebbe83ae1b5d159c9f0a0ae5f3dea126650ed5d6f98a22d1512dcfcb19a23ca"
+    },
+    "sound/lieut/objective.wav": {
+     "bytes": 10052,
+     "sha256": "aa7d6726a458eaa48bf2e20446c57360b82ac23bfbd06bad7b6e01ae95ca8b0d"
+    },
+    "sound/lieut/target.wav": {
+     "bytes": 6754,
+     "sha256": "eebd50c75585894c7d5305f6c066aaef1efaca9a59e27b80d03e8ae4d69caa69"
+    },
+    "sound/lieut/you.wav": {
+     "bytes": 7126,
+     "sha256": "6bfb031b0d69b8ae4ef2e9b201da43c523ae88de344907648d4064e07477ee1c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/conc_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/misc/door_closed.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/misc/ebell.wav": {
+     "bytes": 15220,
+     "sha256": "1693337ed8873f1159e56c2925afaa210f5c28bee4e2c42d27e29bee8e06cb5f"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 4054,
+     "sha256": "b9c44f73c8bdbc900af4f06600e0d6456a040b296612b7d0fe53391285976a44"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 4098,
+     "sha256": "4fad66341514c9aa2b31b4c2fde7563369090da9b0b3a51e08bca3100f2ec282"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5054,
+     "sha256": "d158ddc35360bc43934b7a8a9b7cc830f7510e6bb3a640813157822b27b5217a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 9726,
+     "sha256": "73b74099c8cb43ab2fb09b28b72ddd9f73f2d2a4f8a00a8e835490f366680c92"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 3226,
+     "sha256": "48551cc717e5011df78a38c6a71bb001e4f62a1858a3952311499653ff423a07"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 5802,
+     "sha256": "751050f97456a0c07e88a249d40dde96c2d14640e21670ccdde983502998dbba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/mutant/mutatck1.wav": {
+     "bytes": 6116,
+     "sha256": "410f926534f21705e78a804ce048b0c15e62fe0c68a45aae1b3741fb227551f7"
+    },
+    "sound/mutant/mutatck2.wav": {
+     "bytes": 18260,
+     "sha256": "66009d09adf71f10117c74f5004c995fd48362b2f4fcfaaa3bc2da01e66d115f"
+    },
+    "sound/mutant/mutatck3.wav": {
+     "bytes": 28840,
+     "sha256": "2dd8a615ca2be248c8370d7480f5a8ca9375d31e6af41bba603df660d31883a1"
+    },
+    "sound/mutant/mutdeth1.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/mutant/mutidle1.wav": {
+     "bytes": 81004,
+     "sha256": "8c7e8ad544d7e2470bd61d88c5cd8be1a0eb66f57aaf113f82d990ee00450073"
+    },
+    "sound/mutant/mutpain1.wav": {
+     "bytes": 56716,
+     "sha256": "49ff5f97fedc87c1ac06dc43d4ff0a0fd09fb481354b6373d607bfabc9a57a6a"
+    },
+    "sound/mutant/mutpain2.wav": {
+     "bytes": 58740,
+     "sha256": "b79f1cce60226daa3e3ca8c134da968d54ad51abd9c37ffebdf3d46c5d9f91c6"
+    },
+    "sound/mutant/mutsght1.wav": {
+     "bytes": 107316,
+     "sha256": "7e15e392edc3f2d5ae9e3bde3dfe65595a85728022245f74b81f072d75dce798"
+    },
+    "sound/mutant/mutsrch1.wav": {
+     "bytes": 101244,
+     "sha256": "44484ef4c189511fb0a8d0f2bea83e443e1f1bd51cef04f518f3820e58e88a69"
+    },
+    "sound/mutant/step1.wav": {
+     "bytes": 8140,
+     "sha256": "0d9af35156c84213ac7ffbde54d0f2518fe9d39bba4edc48c94e71bed4f7ec4d"
+    },
+    "sound/mutant/step2.wav": {
+     "bytes": 14212,
+     "sha256": "f7c81df1bff56c8aeb49891fa822c37ddcb019e97a654738a9fb8ee351d19eac"
+    },
+    "sound/mutant/step3.wav": {
+     "bytes": 4092,
+     "sha256": "89856afec31f800219c45253514d0fdf5b5bd800c32f87ba74dd0c21df181550"
+    },
+    "sound/mutant/thud1.wav": {
+     "bytes": 32428,
+     "sha256": "20ed5f20729a068801d06904365e46c9d692dec835710a9b8090d0a1956d6919"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    },
+    "sound/player/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/player/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/player/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/player/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/player/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/player/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/player/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/rail.wav": {
+     "bytes": 97196,
+     "sha256": "396a85e1e2083f2b1eaae89a3f33a21145a643f3f50419523497719ef8e7598a"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/rider/sight.wav": {
+     "bytes": 26356,
+     "sha256": "40ace6f3beeb920ba1bbdb197f8ece18d312762a71e494726289e16703d75d91"
+    },
+    "sound/rider/step.wav": {
+     "bytes": 40524,
+     "sha256": "a43e24ecbc62d44bce466b1e682ebf64c230e03f4d79449406ce021dc8276a9a"
+    },
+    "sound/rider/thump.wav": {
+     "bytes": 15444,
+     "sha256": "af29f4e8f6debb1223aeb5d840add4ae01cb5e9f6bd9a26efeadff518f34380d"
+    },
+    "sound/scientist/allnominal.wav": {
+     "bytes": 23778,
+     "sha256": "e26f9bb3c24d9a9e0da38395048f6dacffe82d800da49d56378027250393d69a"
+    },
+    "sound/scientist/alright.wav": {
+     "bytes": 9666,
+     "sha256": "372c1aa91e6841bec2441215c894b7d149bdeaef33f907d23bb7eaf637520ce3"
+    },
+    "sound/scientist/asexpected.wav": {
+     "bytes": 15982,
+     "sha256": "306933848b673bd14d7074d59e45a8c97bc00a2897601509e52e5835e2ffc997"
+    },
+    "sound/scientist/c1a0_sci_crit2a.wav": {
+     "bytes": 28364,
+     "sha256": "f972684c74eeb51872873cc2b7053448c6cdd716b8c3535929fdbcc508d62ef5"
+    },
+    "sound/scientist/c1a0_sci_stall.wav": {
+     "bytes": 13704,
+     "sha256": "541c192ad5e8a68c76706ec17b3deceafbdc607bfc372ddfd300532f8aa1eaef"
+    },
+    "sound/scientist/cantbeserious.wav": {
+     "bytes": 13236,
+     "sha256": "fc4a8a379f70e33db79a49c667dcd9f1622de29d7b32ef3973c4ffdb5d80ee44"
+    },
+    "sound/scientist/cough.wav": {
+     "bytes": 14878,
+     "sha256": "b4e620259623347a5be3f7eaf3c531e6ea9ef2e97ac42997dd78cfee9327f7bf"
+    },
+    "sound/scientist/sci_die1.wav": {
+     "bytes": 15558,
+     "sha256": "c2306d7f9fa58f99961c347b06ef26305b99ac43ec27b2b222962e1f3a9ccce9"
+    },
+    "sound/scientist/sci_die2.wav": {
+     "bytes": 5402,
+     "sha256": "14deecb570d1e315b772713d54b7250043bb0dd5f3d5538cd0636e39a523c54f"
+    },
+    "sound/scientist/sci_die3.wav": {
+     "bytes": 3104,
+     "sha256": "075cdbc5837d91b61ad7599cdb3abf9323872816f8966c83deab9c0a6e04d7d2"
+    },
+    "sound/scientist/sci_die4.wav": {
+     "bytes": 4024,
+     "sha256": "e6ca0d4f18ac6c1246926646568618057cb70b5cee995c1c2dd69f0179b892ad"
+    },
+    "sound/scientist/sci_dragoff.wav": {
+     "bytes": 8986,
+     "sha256": "0c6a21cd5edf01e495e1258e9a76c05d62c0e3cd697e787fd43fd4bd9126483b"
+    },
+    "sound/scientist/sci_fear13.wav": {
+     "bytes": 4534,
+     "sha256": "dabce7a6c12980f947f7504da264fabb67a804d2e478b7f252ab527fb21a92d0"
+    },
+    "sound/scientist/sci_fear15.wav": {
+     "bytes": 4764,
+     "sha256": "f0d23c680ad138c3cc12da78a3e45cbf3daa47e5da9bc62a1dbb3b27389565a5"
+    },
+    "sound/scientist/sci_fear6.wav": {
+     "bytes": 5588,
+     "sha256": "ff2702b2b9e517b90ea0c2853775a4a95160edfae5af0a7f9208f07624d84281"
+    },
+    "sound/scientist/sci_fear7.wav": {
+     "bytes": 8458,
+     "sha256": "f2a39185c2d39a03b39afd7fe6f942b2f35fd17135ade8ceb4c31968c768aafa"
+    },
+    "sound/scientist/sci_fear8.wav": {
+     "bytes": 5804,
+     "sha256": "4455a29590d5f42ebbf06e600d8ba3f45acfd5000a6b8045891cbecf1d937970"
+    },
+    "sound/scientist/scream01.wav": {
+     "bytes": 14666,
+     "sha256": "b738de99aefbe3a45724914dd6eb79c0f8c219aaf733554a8a5eb94836c22320"
+    },
+    "sound/scientist/scream06.wav": {
+     "bytes": 13938,
+     "sha256": "dee8ac2058635d00458e2e74402d1cfcb5362c64259fc2c4f3b6bba31bdf6337"
+    },
+    "sound/scientist/scream08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/scientist/scream09.wav": {
+     "bytes": 6130,
+     "sha256": "85947649f5fb1491732365849a3025bf5c76c791b395cfdf421fbbd6ec58d351"
+    },
+    "sound/scientist/scream10.wav": {
+     "bytes": 5392,
+     "sha256": "fff4c0735f9c312be7cda848fc2867590437ffe9758fe685e3b4c94678ca1f48"
+    },
+    "sound/scientist/scream14.wav": {
+     "bytes": 4824,
+     "sha256": "dcb7dfb0e307b813476b2e55dceb59d8ae2b9514b1ef02034ea255fa5f086b05"
+    },
+    "sound/scientist/scream15.wav": {
+     "bytes": 3048,
+     "sha256": "37d26fe2d2b8a39d0fec0eceec0ca974ec3dd7fed33bae0d3230a934954105f0"
+    },
+    "sound/scientist/scream16.wav": {
+     "bytes": 2328,
+     "sha256": "4ff04ce8ff07af708c84dacc8df114b68620d47e8e4e4c78dfc4fd33a8a9b98d"
+    },
+    "sound/scientist/scream17.wav": {
+     "bytes": 3836,
+     "sha256": "82fb51224e06db5022adfa58f0b02353c333229ed3312f86dd9ec4f04813c37c"
+    },
+    "sound/scientist/scream18.wav": {
+     "bytes": 3066,
+     "sha256": "bfefcf745ab8d30db11f9113ecf9ba1c5bc6d9b2351c53f3f46d66e03cbea3fe"
+    },
+    "sound/scientist/scream19.wav": {
+     "bytes": 2504,
+     "sha256": "47cc414d201aadb7ba2fe0ce0567ff5360e90fd9de4a167520988513f358ed41"
+    },
+    "sound/scientist/scream20.wav": {
+     "bytes": 21310,
+     "sha256": "124cb45d3d5533572e3cfe4b42bddad2a03dc0d8de1c89a42ea57433432e3a6e"
+    },
+    "sound/scientist/scream22.wav": {
+     "bytes": 15206,
+     "sha256": "6e0a509eb2468466591622e74724c31103b8b60f5d8f29514fb57e9d9d12c9d4"
+    },
+    "sound/scientist/scream23.wav": {
+     "bytes": 21988,
+     "sha256": "8521907e8cecc22e6924d23295a5e8d31333d265ca27a9533b083b68e9da6d12"
+    },
+    "sound/scientist/scream24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/scientist/scream25.wav": {
+     "bytes": 8122,
+     "sha256": "38281749deffb4e567896f71e7bcb75d7b2e253e404a953a5eea6eeb989f156a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/spiderbot/sactiv.wav": {
+     "bytes": 17066,
+     "sha256": "f21587ba9bfd159e48c5b3aa1c6e94eac7157053e4e5699459233fb28c2631c8"
+    },
+    "sound/spiderbot/scharge.wav": {
+     "bytes": 7300,
+     "sha256": "b58064dac4e12bd6685edbfe61417a530cde1e5175336193b2fa7a292aca8ef7"
+    },
+    "sound/spiderbot/swalk.wav": {
+     "bytes": 12636,
+     "sha256": "5534fe1b11fea5406aada214681dba031ec4a01e4b660c405b679131ba07a7cc"
+    },
+    "sound/tormentor/angry1.wav": {
+     "bytes": 88890,
+     "sha256": "60f757f523a9cbb3a57c335bbeda8cedbf990b9d20a5b359e610b712a1344b4b"
+    },
+    "sound/tormentor/angry2.wav": {
+     "bytes": 90912,
+     "sha256": "2f38dddb69cf0df2c1e5b028ca06ea22d979e637afa927919e9a93876dc955d6"
+    },
+    "sound/tormentor/death.wav": {
+     "bytes": 176628,
+     "sha256": "7060ecdadac0b1c9eb3574284444932573e4af13082f01374ed8a4633387bb66"
+    },
+    "sound/tormentor/fire2.wav": {
+     "bytes": 52092,
+     "sha256": "4133a00c7ef157d291d800524a148c188a314eb5ca14246958b8ddfeb0d4fe41"
+    },
+    "sound/tormentor/idle1.wav": {
+     "bytes": 115740,
+     "sha256": "78feebc847dccab66478718b66971870f11246c416e2f2c1e9830c459e4c0347"
+    },
+    "sound/tormentor/idle2.wav": {
+     "bytes": 122218,
+     "sha256": "0270712fe40851bb21d959932b4f8f75bbe8b985e2ff383319059c656ac0ce56"
+    },
+    "sound/tormentor/pain1.wav": {
+     "bytes": 67334,
+     "sha256": "03f255d6ee0d6fb83f2a643491f4cd24d9c5ff86444a51b3cf8b5a0de3d86bbc"
+    },
+    "sound/tormentor/punch_hit.wav": {
+     "bytes": 76614,
+     "sha256": "e524d16b000237615bae3b8fed7b74726823cd4258561196f4641728047aaa26"
+    },
+    "sound/tormentor/punch_swoosh.wav": {
+     "bytes": 33044,
+     "sha256": "d0ef38ef4bf33d0c2f92b22c2a767c4efd66eefaa724df50b394958a7be5a705"
+    },
+    "sound/tormentor/sight.wav": {
+     "bytes": 94334,
+     "sha256": "34a13e6469c5e0ce2f6d18721b0cdd634731b9a9f8910a8bb8b685f63dadfaac"
+    },
+    "sound/tormentor/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/tormentor/sting2.wav": {
+     "bytes": 21674,
+     "sha256": "dd2d40459c7aa9d374efe2f219c34773f390df9f5177a83dbfa5fd638a13c542"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 43820,
+     "sha256": "32082cd1d44903409e97de782e5d9295272840e13280665a0ef3ff862b187f0f"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 47570,
+     "sha256": "0dd8defb8ecfb1ea72e6ac70ab182573775812e2d7990dd2897d02d3c38464f5"
+    },
+    "sound/weapons/spindn_click.wav": {
+     "bytes": 9986,
+     "sha256": "b84866cddb7e61eea9ca49208d427c2289d63e6e3e2f59d4d51e302573079bc7"
+    }
+   },
    "sha256": "996666ce16880ca08fe5c682af80e18745c97995fa7fb86ef90acafa60405d6c",
    "timestamp": "2022-01-17T00:13:46.000Z"
   },
   "jjj2/pak1.pak": {
    "bytes": 1031532,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 42330,
+     "sha256": "01a0bd85dac07e730d3d9122943f08710d8ab3113dadd45b7538cbf6adeaba3f"
+    },
+    "progs.dat": {
+     "bytes": 989062,
+     "sha256": "2a77bd1da73ad4c19ac152cb1786112ba1df87584160b04c8a2477f35251620a"
+    }
+   },
    "sha256": "e6d3692880889fd39038b157a56b0383298418515d3ddcb33cdce8bc0b8c6eb8",
    "timestamp": "2022-01-22T17:05:56.000Z"
   },

--- a/json/by-sha256/07/070dafc66792e8abd3d605e3ad4705b5f53e117cfb816f7dd28370f53f32c25a.json
+++ b/json/by-sha256/07/070dafc66792e8abd3d605e3ad4705b5f53e117cfb816f7dd28370f53f32c25a.json
@@ -17,6 +17,32 @@
   },
   "alk07/pak0.pak": {
    "bytes": 2489448,
+   "files": {
+    "maps/alk07.bsp": {
+     "bytes": 1705964,
+     "sha256": "f89a7f50e9ddc0a12828312b5f082320e56fb54e939d5de1a85546f2a34a7b9f"
+    },
+    "progs.dat": {
+     "bytes": 496952,
+     "sha256": "b1f0b4cbe2652106d3eb33ec24b183b6ac0d0d7651219aa47065840d727399f2"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 132028,
+     "sha256": "8824603b325f37bbba424f55c3ff900c21ccf61c77ba97e636e91ef99202364a"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "744af1fafaacb751cf2e5ce4bb15a0fc1fb938ae519469de6f0dccfe9f320414"
+    },
+    "sound/snakeman/sdeath.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/snakeman/spain.wav": {
+     "bytes": 34452,
+     "sha256": "15b84d6adb80e4ceace4226b5185c578a752adb36f213f2488e80ad2192378aa"
+    }
+   },
    "sha256": "c0395cacc0001484d45340c43d9bc95999bddeb7f599bdbf85484cac483a7b19",
    "timestamp": "2000-06-17T20:00:36.000Z"
   }

--- a/json/by-sha256/08/081bb3b575a674fd844ea571957260e68eb795631f87474b8bae2bec981418c3.json
+++ b/json/by-sha256/08/081bb3b575a674fd844ea571957260e68eb795631f87474b8bae2bec981418c3.json
@@ -13,16 +13,2142 @@
   },
   "pak0.pak": {
    "bytes": 13096879,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "e8bafd0bcd003efb3c797025e9a8b26769e6facf7202673fcec23fe8b1350528"
+    },
+    "maps/b_barrel.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/b_wbh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_wbh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "progs/acidbal1.mdl": {
+     "bytes": 8788,
+     "sha256": "8a9c956f1952fb8d9ea51119c1c8c758d3ca3b3bf3bb0e8b63131bf88325f5a9"
+    },
+    "progs/acidbal2.mdl": {
+     "bytes": 8788,
+     "sha256": "eceba377145b62b4721927e55de75423daaac83f9667852b16dd1bfff3beff01"
+    },
+    "progs/akarrow.mdl": {
+     "bytes": 17412,
+     "sha256": "89b66b045f1442e32d48b0df53b82499da1956380cb1e417a20b94f8cf55ee5a"
+    },
+    "progs/archer.mdl": {
+     "bytes": 581920,
+     "sha256": "f25f30a912f3722f9b239ad5809e9361348f90bb45c15102c92e7f513c27d598"
+    },
+    "progs/armor.mdl": {
+     "bytes": 58064,
+     "sha256": "de3f2cfbc7996fc517e0d43b427c1e12d2b5614ac4ce8eeddb6fd6f4074e77b0"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 11832,
+     "sha256": "57afdeb4fd43578faa70fc409a7560b9bec6fca7753a3d76c500e8a701f62730"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 226892,
+     "sha256": "b5c2dfe7a6b304d4e0e8e8e71610c4b30b12f686c4f5d5c559087ac27d028eeb"
+    },
+    "progs/bandit.mdl": {
+     "bytes": 217020,
+     "sha256": "87cf5d2f979f1a5fd4446e7af34b3c568521980e458e0bd4ce510c4fcccbe40e"
+    },
+    "progs/baron.mdl": {
+     "bytes": 426204,
+     "sha256": "09a4b10b43c2cb4847330ce3660eab93c16a97a7db0c9e1c1447e938689627d1"
+    },
+    "progs/beam.mdl": {
+     "bytes": 11860,
+     "sha256": "ca23070ca0ad64fe7ced7db0dd8226db51bdc46e30cb3b33c7eb3aeaa17c5c16"
+    },
+    "progs/bellring.mdl": {
+     "bytes": 74016,
+     "sha256": "9a8131071ca927803140ce6478b8912c6eb52856861250d6b6bfa1d32cfb9cd9"
+    },
+    "progs/blood.mdl": {
+     "bytes": 184,
+     "sha256": "06825646d627df610b374a31c9265a88c9c1c45864c6e3b9d273a14dc4d745a5"
+    },
+    "progs/blood_gr.mdl": {
+     "bytes": 184,
+     "sha256": "84caed23ff1b8cabec8c5d9e5c6792c30a6d9cc57c36a9746369012015462208"
+    },
+    "progs/bloodcb.mdl": {
+     "bytes": 28036,
+     "sha256": "83f0de29aa0f9e9f1d383895da374a5313aa2252edb306eb7bd69bd71660321c"
+    },
+    "progs/bookopen.mdl": {
+     "bytes": 6188,
+     "sha256": "c02484d2b0cde19c2110f474f4809fc4cd24dae5e7b5ce1f3a59aeaa5779005b"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/chest1.mdl": {
+     "bytes": 19352,
+     "sha256": "239f897e3a390ad44acc5ffd19784f8b78232c5af2be67165581c2f6073ecc9f"
+    },
+    "progs/coin.mdl": {
+     "bytes": 44036,
+     "sha256": "c3d65aac43713c9102f8924ef7ed1cf90297ff17cfe8aface7936e9579b4ec57"
+    },
+    "progs/courage.mdl": {
+     "bytes": 14940,
+     "sha256": "4141933fbb8682ee28277826bd0f882580025def71b96c02cb9b53aa412906c0"
+    },
+    "progs/demon.mdl": {
+     "bytes": 238760,
+     "sha256": "1fbba988a470cd8d4c7eb69d9609dac7d354a13931a387f95d042b3c7e578f68"
+    },
+    "progs/dog.mdl": {
+     "bytes": 216284,
+     "sha256": "2d07d2fdd773f0fed85809c276204d41ee787c959637fca5f86bfeb2eddf2ce2"
+    },
+    "progs/doll03.mdl": {
+     "bytes": 52064,
+     "sha256": "b2962f3954740ad7f9b5ee329d3a189ed5c95ccbb279bb63dc77508c94e4fb28"
+    },
+    "progs/dr2_head.mdl": {
+     "bytes": 7476,
+     "sha256": "da102d7a3f21f70e3ccf279b97abe8b1058796b09b915005d26091b2d2004b21"
+    },
+    "progs/dr2_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "e32b0928b23597108eeb56597e05f513642d6c4ee01044eaecd63fc6d4418720"
+    },
+    "progs/dr2_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "edae4f51e177cd19315b70d63a4d82fb9c474f38959c1c9647f53684e8d05c11"
+    },
+    "progs/dr2_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "056b44bd4a2ea382f89a631b63ce8189dcdaad04232da16db278a5535e3ba4c4"
+    },
+    "progs/dr_head.mdl": {
+     "bytes": 7812,
+     "sha256": "dc6fab1ce2e377c849342ffa384cf6d34c0a4f8cb5407023739bf54dbc4061d7"
+    },
+    "progs/dr_lw.mdl": {
+     "bytes": 33712,
+     "sha256": "e85dca7b023ddf93d10843f876041d81ea582314170aea2896e998b9b4b3bed3"
+    },
+    "progs/dr_rw.mdl": {
+     "bytes": 38412,
+     "sha256": "e2ea525bf7a7cba3cfe23fd6049acf401c0cb5ec2ce190035969dac1bcbbebaa"
+    },
+    "progs/dr_tail.mdl": {
+     "bytes": 9416,
+     "sha256": "26da767ef55c73bdc31d0f2fd68b35b99c131f631336e96820cbc15d050453f8"
+    },
+    "progs/draco.mdl": {
+     "bytes": 190024,
+     "sha256": "f609368df6aa2cade0882de6bb708dcec286df6c1b5ecf89a2f38ceef1cc5705"
+    },
+    "progs/dragon1.mdl": {
+     "bytes": 323724,
+     "sha256": "d74d2832c40007350d5e6f8e8733f8bcbf21c5c0940a84285f516e5763c28b2a"
+    },
+    "progs/dragon2.mdl": {
+     "bytes": 253164,
+     "sha256": "1a2a161f43d885dcdf42eece7c9cdb65ca3e9c451aa3e1449b971a19467b81b7"
+    },
+    "progs/ember.mdl": {
+     "bytes": 8788,
+     "sha256": "91d6f4dfbeba0711d0864b94bb372b602959644c5c841fd659ddedb8f8e6980c"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/end_bane.mdl": {
+     "bytes": 52980,
+     "sha256": "4a86fd7bd59c4ecea934e3adcec4b17d627cdfac5223976a52b5739143c37f27"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 68804,
+     "sha256": "f3c760ecdbb530ff651c46f516228c588f37585315acdab199408911c2c8414b"
+    },
+    "progs/flame2a.mdl": {
+     "bytes": 68804,
+     "sha256": "e02210f2f6851cea4b9520476cfe36c31745dc2d84248f6a75132358d6d43035"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 56532,
+     "sha256": "2addf62820ff03b8f85042874c82e908907995187b372c7a7ef0dc305b96e154"
+    },
+    "progs/g_gun.mdl": {
+     "bytes": 24344,
+     "sha256": "f6aa476d8352bf5b7010c68387fe53121f886b26e331d8dc32b9cfabf52067b9"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 38004,
+     "sha256": "cf67c0a7ad3e853fa4af7544d0399fc0a3795a61d625f5e78104e659e2db0eed"
+    },
+    "progs/g_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "3e4a1e9dc2bff162612e218a25e2040b57d063d198df2e301eaa8fa9542af098"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 91928,
+     "sha256": "6fa67872d8519cacb20e6c48986a674b82d91a5cfd39ac03c667c6bf46a0fade"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 158116,
+     "sha256": "127e4fefafc5015f03a6cd1288cab9da325ed5b5a93c9f6b90b6da9d8273ef9f"
+    },
+    "progs/g_sword.mdl": {
+     "bytes": 26920,
+     "sha256": "c9e576e2a9269e402209bdda6a3f745ad50bce1d65e130a1c9846fa59fe5e3c8"
+    },
+    "progs/gem1.mdl": {
+     "bytes": 42612,
+     "sha256": "0b71e525b19e25f98dad53ce766751de8e0c9f18434582bb86242296bb7a402e"
+    },
+    "progs/gem2.mdl": {
+     "bytes": 62672,
+     "sha256": "721459e22aab0d2cece430053734b889918bde4db879ffc94084289a7b6d4d8c"
+    },
+    "progs/gem3.mdl": {
+     "bytes": 42072,
+     "sha256": "3bc3a1018cc432b694f9ec45de06775776ef55d21b4e117dd1b2c7c0d7b850a2"
+    },
+    "progs/gemini.mdl": {
+     "bytes": 35188,
+     "sha256": "01ab3574c3edfe45b927dd842ae2016407b895e4072126e72f30af3987a0979e"
+    },
+    "progs/gr_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "3f5b6d67b80e5f2e5bb7c129500c79dc345141133f8d415005f9384b0d2d9661"
+    },
+    "progs/gr_gib1.mdl": {
+     "bytes": 6501,
+     "sha256": "3f715cbfdcd77caef11b904aa12d2063cbb973d4a9d61c27492690344c14fb1b"
+    },
+    "progs/gr_gib2.mdl": {
+     "bytes": 17553,
+     "sha256": "c6166eb6132a3e87f51fcf48f4e9eebb719b3f1819d22640582b23d61bde4a16"
+    },
+    "progs/gr_gib3.mdl": {
+     "bytes": 22933,
+     "sha256": "0e40e5b960924ca642690c26b239c89aea6bae18badcb945e96d2102cad69622"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_archer.mdl": {
+     "bytes": 22128,
+     "sha256": "d537366677c6348012792a358117da9257f7e00cda2ccf7a6d4ba535e3699dfe"
+    },
+    "progs/h_axeman.mdl": {
+     "bytes": 14076,
+     "sha256": "edf2955a4efc0e529e79c589b4b699341047e604010b01f9ed9c5e68c1ac15f3"
+    },
+    "progs/h_bandit.mdl": {
+     "bytes": 9752,
+     "sha256": "1841a8ac85a03cb826dc5b2db5e45c3041eff66d147c690966c35839c3754b3e"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 7444,
+     "sha256": "68bc1db4875fe84f25ff3d6c53e4e9e2c023ef52bf3c89b439493f2e5c5c0e19"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 100492,
+     "sha256": "91201d4628cec7ea434747972c1183eb677c1395099895fb45ba328cc245631b"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 46616,
+     "sha256": "d94fa089c97f569dc6099f1e886ff958e4b7883ea07a1648599c2020fcaa0520"
+    },
+    "progs/h_drake.mdl": {
+     "bytes": 28792,
+     "sha256": "5b7e9be660dac24f32679c8563cd273a9ff6bb6974fdc8bedf31ec8e73319238"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 86248,
+     "sha256": "52dd50c6796dc1f0c9997d2f876ce027701bc0896ecf50b354b5495b10845bd7"
+    },
+    "progs/h_hkolem.mdl": {
+     "bytes": 30552,
+     "sha256": "38b2082ead97b90f59a5fdcf24d4077ab067c55655598d023f8ec38818c914b1"
+    },
+    "progs/h_imp.mdl": {
+     "bytes": 73284,
+     "sha256": "d8146383fe6d31374c67718ff235e83d3891ebee5a0e44539b536ce049c9ce70"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 19644,
+     "sha256": "1accd89ba95db3627cee4f06f94ab3bc9d146ebf566da24b570c733f2f902c1a"
+    },
+    "progs/h_necro.mdl": {
+     "bytes": 8052,
+     "sha256": "610bf9c83b1bb97de5bf5b159da9f624d7b9f85427e43f6d52cdeb4df346c002"
+    },
+    "progs/h_nemes.mdl": {
+     "bytes": 78156,
+     "sha256": "6f350692b44907984c02779d0114576bbafb6a3ada673e1f55d1cf02fd062c18"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/h_rebel.mdl": {
+     "bytes": 5428,
+     "sha256": "b189ff3ae1596da7596f21d8f555603951fadf8e7884e96f89c8b2b5789028a5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 53096,
+     "sha256": "985c18b99e44bea0837fc4e982a9b696f43bc2eee408cfc85fc915ef11e97c18"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 108204,
+     "sha256": "dd7dc5c90255da868b96ac553d8a8f68b6723da6b25114bc087fd019966a023f"
+    },
+    "progs/h_vomit.mdl": {
+     "bytes": 16952,
+     "sha256": "9822885036229871594a21643f4acd3a9b4c27d141b9021464b5062dfaf410f9"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "4d028c6b3a3b5c9df4d9ca8561b7da70857980b8688fbf3607cbdc65fed3ccc7"
+    },
+    "progs/hero.mdl": {
+     "bytes": 66388,
+     "sha256": "ea4f359a328b6416588e5debe13a87fc2eccd8a65263ae23683d71a58b39a116"
+    },
+    "progs/hk_golem.mdl": {
+     "bytes": 179204,
+     "sha256": "972f27eb2bf8a6cc4433e1f904097ca5393312d47a75e396b0323723beff58fa"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 487168,
+     "sha256": "1df51fb0a79b1e4f27ac4c25a373ed62c516ec38e07945a2252dace91e16d006"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/ice.mdl": {
+     "bytes": 5812,
+     "sha256": "772eb399b9f9567e7e8f8b51e3749a67b58237321554272e94875a05261a124e"
+    },
+    "progs/ice4.mdl": {
+     "bytes": 7624,
+     "sha256": "656b632c178967b2be121932419e252b2a900b543d06c0389c6c73c32ba1ba4e"
+    },
+    "progs/iceball.mdl": {
+     "bytes": 13684,
+     "sha256": "8f71e71ff2a3a1306cca60e758c1179abc15ffa8d32eac706118f82254b1b1b5"
+    },
+    "progs/imp.mdl": {
+     "bytes": 583036,
+     "sha256": "0010c831c9d39406a2db6496f62786fd2e60a2ea7f80e18b486f27145dcbb0ff"
+    },
+    "progs/imp_rock.mdl": {
+     "bytes": 2352,
+     "sha256": "dbe190f471f5738779e103b496117ec40e2adc9e5f593d2470172bcbd7ade0f6"
+    },
+    "progs/imp_wing.mdl": {
+     "bytes": 93932,
+     "sha256": "d727c88da33bdcd3875509f8bf96af0cbcb31b25aa5f5b03ce1584aa0cec2047"
+    },
+    "progs/k_ball.mdl": {
+     "bytes": 31300,
+     "sha256": "f93346ffeed3fd5d9866fb80d1a08216759bb27757d49a1851e471aadf757ec1"
+    },
+    "progs/key_b.mdl": {
+     "bytes": 10616,
+     "sha256": "d1333d74b7e194f6587d0f5ed1fca28887cd0414734b4bd4cbb7e715ab897629"
+    },
+    "progs/key_m.mdl": {
+     "bytes": 23160,
+     "sha256": "ea2feb6eb54823668dcb112f42c3441e563e18e3cc1806b5ce509044e6c0b448"
+    },
+    "progs/key_w.mdl": {
+     "bytes": 11576,
+     "sha256": "72da64d2b29d69605c453e9ee0e5fa8ecef91a94cc541103cb24fbad96c7946d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 232536,
+     "sha256": "e3e618799612c6e521f68234a061d9a46036ef556677b0c1651e7647258ffb56"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 27960,
+     "sha256": "5877b37cc4f98a53467c412e7d06d1f7ec6b60f5c0f2088514aa51c9d2c51769"
+    },
+    "progs/laser.mdl": {
+     "bytes": 33240,
+     "sha256": "bd223621645a4167668a833cf531cce0a56ffc4afe921decfb791b1d69b83310"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/levitate.mdl": {
+     "bytes": 15876,
+     "sha256": "03e77b0d4b8ee7b3b224cbe0cfba63e8bd27d0391bd5069981e5435287f66645"
+    },
+    "progs/life_up.mdl": {
+     "bytes": 34676,
+     "sha256": "502716aa1b0f6cb8f929fe7ee2a74024a5fa007898256e15ca495e126888c584"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 57796,
+     "sha256": "e8b38ca8f28a89f65ffc652e082e8a9aaf6a1a9db8302e961b9ceac1c8f60e8c"
+    },
+    "progs/nec_rune.mdl": {
+     "bytes": 19524,
+     "sha256": "cea5c89dd0034465a54a8434bc9367554f0244c2e38ec9220cd28a5a53a444a9"
+    },
+    "progs/necro.mdl": {
+     "bytes": 475588,
+     "sha256": "84a5aa52a22dbf1fb3442b4114eb0640ddbd324c21a669d29d5a56d7fd496725"
+    },
+    "progs/nemesant.mdl": {
+     "bytes": 202492,
+     "sha256": "099c26752c7160144a25716e0af0f30f8ff179766db4a05371a0392166f85c42"
+    },
+    "progs/null_256.spr": {
+     "bytes": 5412,
+     "sha256": "c52813b634ef1ab641fdd4c3a9739ad758f1b5c39ba5e10acbbf034ee0ff850b"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 230152,
+     "sha256": "b7c88ae295ef8fc8d17b4fd6facedbb8e464ee665039a884af8e215a3929f24a"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 55676,
+     "sha256": "c9810eaac822215e7c84f11e55bb614121d17a79a02aa162fb430b5f37664ade"
+    },
+    "progs/player.mdl": {
+     "bytes": 277024,
+     "sha256": "c673ff0f6639671000c7415e27ef1355fb5c8278b19641d5b9f5e45d3cfba0ca"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/playham0.mdl": {
+     "bytes": 99756,
+     "sha256": "1016d24c984994843af5d086e36e548c55590018f1f6b2d78799e25a40271ec4"
+    },
+    "progs/playsaw.mdl": {
+     "bytes": 87340,
+     "sha256": "b53cffd1807a3710f03b350370d78dfdbb2b057455fcac9f00d1b0baaabbf8c9"
+    },
+    "progs/potion.mdl": {
+     "bytes": 6316,
+     "sha256": "0e66a6ced7f31e5eb23459433908995241e78835776b02037109b8aef6dad2a0"
+    },
+    "progs/potion2.mdl": {
+     "bytes": 16228,
+     "sha256": "30a97f9d1e82eccfaa88396a82ae2e21fcff08ae095b2eb17941aa1a66e69353"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/pur_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "dbc2bf835db1c1789c329504f86802990a19288f67d9560f32cfe5a8d5a62885"
+    },
+    "progs/r_bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "2d776e4acdf20cd117f3f4d6be3647fb9d0e117756069cbfc52ece716fdbb251"
+    },
+    "progs/rebel.mdl": {
+     "bytes": 215292,
+     "sha256": "433596df8d06be0882f00a2c1fad0ea49a8ae42ef148d32e0ae7c06c420322aa"
+    },
+    "progs/red_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/reflect.mdl": {
+     "bytes": 10224,
+     "sha256": "72da6cffa3556503bf43f4ccdcc9f3bc8329b20dc70f38d20fedbabc3fa280ca"
+    },
+    "progs/regen.mdl": {
+     "bytes": 25460,
+     "sha256": "7f4c06f4a7046908317a61bee2a5810eae03fe99f09018455f1fa0a62f45c5e0"
+    },
+    "progs/rocket1.mdl": {
+     "bytes": 34260,
+     "sha256": "c9412482647d681e08f74eb0c0260ffded91dfc67378996b86b720ef3cd2fd47"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 17204,
+     "sha256": "0dab5b94c60d92d55df3e44a8d8ea2dc0f949e98897a6525ee0be3f49a019b08"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/s_exp32.spr": {
+     "bytes": 62676,
+     "sha256": "935287995f6ee03093d3a5f6a6ae22ad14aa6ce70490bc437c3816a491904543"
+    },
+    "progs/s_exp56.spr": {
+     "bytes": 198864,
+     "sha256": "f14f5ef9d7af83244bd124c8c5efb79d387e9039922a1a08eaa4d190d3112374"
+    },
+    "progs/s_rain.spr": {
+     "bytes": 32824,
+     "sha256": "0aa4667092e2c3a38d136f4f61a9c4f063fcdcdd69a9f880b9306f8646a2b752"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 7596,
+     "sha256": "00e2bd1686ba0f4abaae1157c2c2b75373a9a7ddad94326aa3584bebfdfd2129"
+    },
+    "progs/s_wave.spr": {
+     "bytes": 376636,
+     "sha256": "0a005a2b76f9a39045cd205c15487456d51e258c8a1e1373e848d3b45e088966"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 200848,
+     "sha256": "4c0653e3adba99be4d581c92a928fd6e8c27b0a2159a97f7ec5e885478249b8d"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shade.mdl": {
+     "bytes": 140876,
+     "sha256": "a6d06987dc6e55f7f39c4d25fb3e38876a75354d84621b2dff2b2c4fcef7593a"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 128012,
+     "sha256": "74f51581c3bd90ebfa5345f8cc0b92cf354b6ce99f401898ddb96dfc4453d063"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 176048,
+     "sha256": "7ea0c1007179eb7a45112aaf38d8042213e8b644e6e79b9b1a8d4402c3843b47"
+    },
+    "progs/smartbal.mdl": {
+     "bytes": 27924,
+     "sha256": "288e2d54afcbdc5242ab831f3ef611710317c52432e4585a938a12df80b7a07d"
+    },
+    "progs/smoke.mdl": {
+     "bytes": 184,
+     "sha256": "2086abd9950bc643446309a80d9df86b4ebe3f2086f75e799ce943a8454c77d7"
+    },
+    "progs/soe_coin.mdl": {
+     "bytes": 26364,
+     "sha256": "5769371db409969600bd51d573162c663fb75d358c507fcff9a4aaea95fed4dc"
+    },
+    "progs/soe_gem.mdl": {
+     "bytes": 165236,
+     "sha256": "788f32633f1f3a9f6dd2e0c2dccb76871e02fc6e002db82a219f077dcc493c3f"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "078b774958c598bdf1503934d51a1393aeb9aadebcde806db2272b04b233c6a2"
+    },
+    "progs/st_gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "813d52c557a1eb519d801652b4bd63acdc4ec18d62db53d843ca3dcaa88e87e8"
+    },
+    "progs/st_gib2.mdl": {
+     "bytes": 16228,
+     "sha256": "2d40c1eb75eeb6f5e1781ee9db7a0be10e0d07297d563f9035a8965c4c8c3d01"
+    },
+    "progs/st_gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "d44a77787c5ff633593ad9741ddfbe28809431daf3d32fbe92f8512871b9018a"
+    },
+    "progs/tar_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "1ef69998430a54ba662abb46a0ef303b3bf0066f53e84b166065e79d58a72bef"
+    },
+    "progs/throwaxe.mdl": {
+     "bytes": 56532,
+     "sha256": "0ebedab9ab397ba15dc3f0d90df703af2984d1c070eabc08ba781c308968150e"
+    },
+    "progs/throwham.mdl": {
+     "bytes": 7072,
+     "sha256": "f161fedb096a34db55fe57e84acd2bc42295ffea688549235c762b9a70430b35"
+    },
+    "progs/tree.mdl": {
+     "bytes": 126509,
+     "sha256": "7705f8b4e337bd370dbd0392d33da437f08768723e6d43725ddbb07ac3662b9b"
+    },
+    "progs/tree_zer.mdl": {
+     "bytes": 101704,
+     "sha256": "f5dad886e64ef946b0ad0aba3a06da419579911c5248ee856d2d503e40c4beab"
+    },
+    "progs/treetall.mdl": {
+     "bytes": 120532,
+     "sha256": "e74e7c38099ccc833fadf3c7b7e97f746878d07102dad8cc5926546b344cb982"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 94756,
+     "sha256": "6012df07132210842fd7ec6415abbfa40b7818a02aeb8f15bc0254de006b82ca"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserb.mdl": {
+     "bytes": 43852,
+     "sha256": "67e854c43efe348faffcc1aed8415a8e68fe2069ec94447a3610b580b72f3f88"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 47252,
+     "sha256": "86cb778c5e84f2523a8d47a8d1d021e46e9a6af343fd69b84805e783c800b033"
+    },
+    "progs/v_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "a2d573bdf52015bce7a571a2263a3e8d938daf0bc1b5e4589f84580cab7da2d4"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 165540,
+     "sha256": "abd6787fff37c452fa01f4bbc9eb9594311eaf4a794f161caeb5a501ab9e103f"
+    },
+    "progs/vomitus.mdl": {
+     "bytes": 79724,
+     "sha256": "ca5efecc53259a52ae6e6e1ecd15c8c66b0ddf8d3056ee6f5ee983918461f4af"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "7758aaf42d0d1617e4fb172ce842be4316073f63250aba46dad441327cccb2e6"
+    },
+    "progs/wanted.mdl": {
+     "bytes": 27860,
+     "sha256": "03337a468db14377fcd36842037d2a27dfb97c3d5d5f45fcfe408e79050a5839"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 67956,
+     "sha256": "39c4a5daef1cfafc1bbfff1ca8eebb5c75d27f953f31d29f249205762605a56f"
+    },
+    "progs/wings2.mdl": {
+     "bytes": 28980,
+     "sha256": "5342d6191f59e69eb830a5e833473ac253b3a7750063d5519f6d2da2b82f5573"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 109380,
+     "sha256": "c82780f930af561c4a839a00a32d0d1e77352b385d236d04b9536ab40f996b8e"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 133676,
+     "sha256": "0a57ee912df3142c5e17183d5f6bd461021b141d53f7534014d59eda97e6bfa6"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    }
+   },
    "sha256": "82f72fe66ad0ad33e18cea570a543ffe2adada5bcb943ba986dd0803611949f8",
    "timestamp": "2008-12-22T12:40:44.000Z"
   },
   "pak1.pak": {
    "bytes": 9199198,
+   "files": {
+    "sound/ambience/amb21.wav": {
+     "bytes": 80716,
+     "sha256": "d664ea08d9df7e7dd135eb0726c1bc142878dcc53d13564dd3dcc5562180201a"
+    },
+    "sound/ambience/amb22.wav": {
+     "bytes": 92716,
+     "sha256": "f444289984b285a1497f55e566fbbf1896a04fa38e291efaa3ec1a0720204811"
+    },
+    "sound/ambience/amb23.wav": {
+     "bytes": 40180,
+     "sha256": "e451997ac7f37d08bd8434d708f45ee2967693317684b947ce511c9df84828b3"
+    },
+    "sound/ambience/amb24.wav": {
+     "bytes": 42282,
+     "sha256": "ead78c8507a7a6a7d6c61e913a2319964f6a8f70b5f7f720c162725edd9cd5aa"
+    },
+    "sound/ambience/current1.wav": {
+     "bytes": 50906,
+     "sha256": "dabe357d48586dccb8e1ed18c49828797c9f7a8c02c7a588ddc76a62c9b1d3e4"
+    },
+    "sound/ambience/drip_amb.wav": {
+     "bytes": 105444,
+     "sha256": "b282bc6082754011ee21a82aedb490a856c0f694f57991992296554c13149b02"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/heart.wav": {
+     "bytes": 8190,
+     "sha256": "a5b42c46cca24da59c324bb28ce6887b3a2a3baafcc18b0db2b2485f1189a4e0"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 177840,
+     "sha256": "9daec0732dcc821670b8910a1371153e3829e604b6957bf95931bea416af6074"
+    },
+    "sound/ambience/mov_watr.wav": {
+     "bytes": 44432,
+     "sha256": "9d6721844fd5559ab4f53902e70ad9789a90710dde082d222bd814a36c00ab67"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/spark2.wav": {
+     "bytes": 61640,
+     "sha256": "7eb18b00cd5e7913fea7a85ec5b1db159d1d001d24d4f687bfdb5685cb163c8e"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 106286,
+     "sha256": "056f37dfd1d5f4eba1d1911245dc0930bb0c46a84d72d867a286e5a9540248a0"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 87710,
+     "sha256": "2bb46f7c8f70fd28f0ca47b294824bcca7689047291b6c5259eebe76ad6aecfa"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 140630,
+     "sha256": "5a4dccd168cbd9f759ac468d7aa879dbcdbe5637e0fd0521f641ba1d60f61817"
+    },
+    "sound/ambience/th_clap.wav": {
+     "bytes": 72062,
+     "sha256": "1fc3146d501953545b2f2f261cd2fc398959a79c753a291702609b4cdd2e8682"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 28798,
+     "sha256": "f66c76f07eef275e904fcc76d7ca9fc2011f3de8c61ce0b3ad035464beb7a86c"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 110578,
+     "sha256": "c3e1ccb091b9d8a06b83530b5e29b9f26f5ad8b9dcd082f3da976c3d44944b87"
+    },
+    "sound/ambience/wingend.wav": {
+     "bytes": 90874,
+     "sha256": "63e435d896b097d4dc413fb1afccc2078f1d101a4f7bfc18c4e593ca9e8b344f"
+    },
+    "sound/ambience/wingget.wav": {
+     "bytes": 65148,
+     "sha256": "533bdbd7beffa4c71c66239e3ac417f2177b20a60ed39c379c59a10b2222b367"
+    },
+    "sound/ambience/wings1.wav": {
+     "bytes": 6028,
+     "sha256": "c9e05f66a1d728a88289bc213c9f3551f1e54a4f3e8ef23ab03f8d5019e7b2c5"
+    },
+    "sound/archer/arr2flsh.wav": {
+     "bytes": 5464,
+     "sha256": "e9a0c059430744c6546a6be4be3a1e4ac775ea6c5e6440d14611ecd8c8447d19"
+    },
+    "sound/archer/arr2wood.wav": {
+     "bytes": 5458,
+     "sha256": "97c5106007e703618291242bf1c6db9853a9d625189fc26ec9c4864436b560e3"
+    },
+    "sound/archer/arrow1.wav": {
+     "bytes": 2296,
+     "sha256": "4aeac8630ff6036f095a251a018eea5baad7a59bd7e46f624dbfec793e44d7b4"
+    },
+    "sound/archer/arrow2.wav": {
+     "bytes": 3196,
+     "sha256": "0a2734df5a69f6407ffc34ab05d8655da5d7dc0e487627932390fa6cec022083"
+    },
+    "sound/archer/arrow3.wav": {
+     "bytes": 2156,
+     "sha256": "1b866280829cb7ac051f90609baa8db285f3bfa3a27b5814e72b021b7cc05785"
+    },
+    "sound/archer/arrowbrk.wav": {
+     "bytes": 5002,
+     "sha256": "f72e35d5232f40e503192ff0ee26fe152eb42e5ee7141b2bea33a9f12f38aa2b"
+    },
+    "sound/archer/arrowg.wav": {
+     "bytes": 15132,
+     "sha256": "8ec5ee520f81c69ba367ae549a06d5ea1643b43f81dea7d8345561c94c8412ed"
+    },
+    "sound/archer/arrowmet1.wav": {
+     "bytes": 2638,
+     "sha256": "87e6ef50bfe4dabf48a1fba18ad0138bbd298965f1a9d06e2b059019e6f74b60"
+    },
+    "sound/archer/arrowmet2.wav": {
+     "bytes": 3118,
+     "sha256": "2797466dafd51473b8b6b5fd3d02a5baa4fe92a1bf9342fb038a299230037138"
+    },
+    "sound/archer/arrowmet3.wav": {
+     "bytes": 2804,
+     "sha256": "1e77951ec2218add2a8bc1633a925e4a96d2ca247d7b5dfaaaefd7a9a4f2363f"
+    },
+    "sound/archer/arrowr.wav": {
+     "bytes": 9458,
+     "sha256": "10e4bef745e55fddd004ea78d24edb9d3d9edc1ce3053c377be07be27a4da144"
+    },
+    "sound/archer/crash.wav": {
+     "bytes": 11069,
+     "sha256": "60e704bdfdb0a97863b00f3514130a172b95a86bebbf89642b65a6e757a74259"
+    },
+    "sound/archer/death.wav": {
+     "bytes": 9526,
+     "sha256": "e824b3d7d66e8bfc3ce30cc3116eab1b2d2dbc09c6311f91ff25d3e7eaef19f5"
+    },
+    "sound/archer/death1.wav": {
+     "bytes": 16680,
+     "sha256": "f409bd2b5624bab561a8846939fbf7194628ceef5831211bb6fed8802f06c2d1"
+    },
+    "sound/archer/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/archer/death3.wav": {
+     "bytes": 33694,
+     "sha256": "990920962c449b0a41548df21f03f22488a60a6f5c45ffba142a943c345162ab"
+    },
+    "sound/archer/draw.wav": {
+     "bytes": 6874,
+     "sha256": "c94e5cec38dc40102beebd067554c91e63b86e5c1ef11dc17976733bd9f08ce3"
+    },
+    "sound/archer/growl.wav": {
+     "bytes": 9240,
+     "sha256": "7bdbbd23b3fe056cd1d904124824aa0044acf3aa19ec88f65e092fd13e4b9437"
+    },
+    "sound/archer/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/archer/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/archer/pain.wav": {
+     "bytes": 5082,
+     "sha256": "5347daf1a9263320f25b2a191895fbf6c85278f1fde6ca5962c09ed38e0b37b0"
+    },
+    "sound/archer/pain1.wav": {
+     "bytes": 12158,
+     "sha256": "4a2d4fc161d8838176ce17fc2e5ab75501bf82afffb0b0a0ee594fbac26447fe"
+    },
+    "sound/archer/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/archer/pain3.wav": {
+     "bytes": 11212,
+     "sha256": "cccdbb98396bface238dfe958f44dec4630714a7b545d30877324c0dcbedaf64"
+    },
+    "sound/archer/sight.wav": {
+     "bytes": 16866,
+     "sha256": "bcd12d078e7bc34f0bdea7ae9a34ccd2c9bacb049617329b44f8301c34fffeb0"
+    },
+    "sound/archer/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/axeman/adeath1.wav": {
+     "bytes": 18785,
+     "sha256": "4040e419ba190d233419f588541f75f0289d713a1e2f7cbf83708d08edb7885d"
+    },
+    "sound/axeman/adeath2.wav": {
+     "bytes": 27882,
+     "sha256": "b5311af0d046a805ab9ce9d79b2af3037047e52e94349a1ccace928041c9f99d"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/apain1.wav": {
+     "bytes": 10374,
+     "sha256": "781160b1fbb66a61a3ee173100c69ece38a65ed13ae49a9341c5ff5c16e7c8d7"
+    },
+    "sound/axeman/apain2.wav": {
+     "bytes": 11947,
+     "sha256": "0b8281501c240cfe13ee22de6f1c177e285251cff3dc0148b3095e5200b030f9"
+    },
+    "sound/axeman/apain3.wav": {
+     "bytes": 13155,
+     "sha256": "18e1ba9a8a1cdd9b4339011ff85a1a322e4aab2f93cc7e721038d0746765bbfe"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/axeman/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/axeman/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/axeman/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/axeman/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/axeman/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/axeman/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/axeman/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/bane/death.wav": {
+     "bytes": 10935,
+     "sha256": "7e4775bc543acfb421a446a00efff6d9d5669fafb2387464cb1e1ae3db91efe8"
+    },
+    "sound/bane/death2.wav": {
+     "bytes": 17999,
+     "sha256": "40dd4806e413a9156e442b9889cd42de6959bf56f81207deee0625d002d3a83c"
+    },
+    "sound/bane/growl.wav": {
+     "bytes": 9045,
+     "sha256": "86e7b3d2e685d7c20e503bdffe676727426b606ef069f4b70f182601e910ec4e"
+    },
+    "sound/bane/hit.wav": {
+     "bytes": 3884,
+     "sha256": "228faf88857d697f4d5fb9b9c03f000af4dbc8b254791e18e973fd48cc96db9b"
+    },
+    "sound/bane/laugh.wav": {
+     "bytes": 22108,
+     "sha256": "ae8e8d13e00f41bce729977f09a92806c8451ebe5cb4e8618a6b79df4d70296c"
+    },
+    "sound/bane/laugh2.wav": {
+     "bytes": 31560,
+     "sha256": "5cc5ff4c3be35eec90eaaa6579a55fa843843ad658e2e4bbb258a77f6e410020"
+    },
+    "sound/bane/pain.wav": {
+     "bytes": 9325,
+     "sha256": "1d4cfac1f9dfa1ec6958b18014ec7be18dc2615e64888d3c584d50bb48e51013"
+    },
+    "sound/bane/pain2.wav": {
+     "bytes": 16389,
+     "sha256": "7764f31eaf8e12a8384b7fccf3f0b771b51dcdfb4b6dd4228a861c7aece254c2"
+    },
+    "sound/bane/sight.wav": {
+     "bytes": 22962,
+     "sha256": "fbaabe115d9ca4b985c4481ccc71e6b6f55931394a29a6c51ec97e752ed3d5be"
+    },
+    "sound/bane/thunder.wav": {
+     "bytes": 43130,
+     "sha256": "cb355478e38df678e859557a0f983120a4d4275272d8ebedcae7c9cccf659bc4"
+    },
+    "sound/baron/bpain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/bpain2.wav": {
+     "bytes": 18272,
+     "sha256": "44ec1f0c3119d5da84c8d54c24112b3f36d85ecf05002c8c129e825749314daa"
+    },
+    "sound/baron/death.wav": {
+     "bytes": 8576,
+     "sha256": "3dd3a23d5a913548d0d0aa6ee1b455017648fcd4830f204539a1626c2ec8e1c9"
+    },
+    "sound/baron/death2.wav": {
+     "bytes": 15716,
+     "sha256": "b677476939515151475e195215980cb416cc52fcb5dec3df0c1d48cedb5e0aea"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/fireball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/icefire.wav": {
+     "bytes": 8858,
+     "sha256": "b529a958de192b59438989c6b98eb50f858273febab53a238b651c70a3c92098"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/shard.wav": {
+     "bytes": 14324,
+     "sha256": "313428dd2cb681a38ad89983ab39b18979f64b3e398104b1ad80f3dc9726616c"
+    },
+    "sound/baron/sight.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/bishop/conjure.wav": {
+     "bytes": 54627,
+     "sha256": "532d4b7d5db6a654aa73dfe18fa0f6a71623acfd804a848f106b0af699022bc4"
+    },
+    "sound/bishop/journey.wav": {
+     "bytes": 42051,
+     "sha256": "0995e55661447c53c3a36ae4552ea2e0bb7ec8b178bf52cdabe9d28b4deaa50c"
+    },
+    "sound/bishop/rip.wav": {
+     "bytes": 31906,
+     "sha256": "7070871da7ec08da6260a65f1a98ed1bf9682b1c95c51cea262a4b88a63fb6ca"
+    },
+    "sound/bishop/rot.wav": {
+     "bytes": 22463,
+     "sha256": "866b836874ba611d70675e5e3b83eac059c927bef0e0d1396f2183ea01bcc203"
+    },
+    "sound/bishop/skull.wav": {
+     "bytes": 34293,
+     "sha256": "48836a4d60ed8962ed0f11bffdcca95a200645e3b2cfa49a598d6392e10dc153"
+    },
+    "sound/cube/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/cube/bc_attck.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/cube/bc_gulp.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/cube/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/dragon/acid.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/death1.wav": {
+     "bytes": 18358,
+     "sha256": "645baa1cccaf1dfbcd628d17fd8ea290f42f1bc40903e26c79a536a6d1528a2a"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/fly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/flywater.wav": {
+     "bytes": 11034,
+     "sha256": "68cac399467a55df3c80331696869309eea2339467df0ba94408be4fa2afeb3e"
+    },
+    "sound/dragon/ice.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/icehit.wav": {
+     "bytes": 9370,
+     "sha256": "089c07d0352678106aaa1c47f015792393d5aa01b4bd64fa35e798c4ee09108b"
+    },
+    "sound/dragon/idle1.wav": {
+     "bytes": 34068,
+     "sha256": "3a125f0bcf2908e4ba3af298b117f71c0efa43be4077e53c791b2805cce6a038"
+    },
+    "sound/dragon/idle2.wav": {
+     "bytes": 21474,
+     "sha256": "e1101ff0121687511a9c978d0a30a945421d0a2a30b7d139e4427d41dcc17628"
+    },
+    "sound/dragon/pain1.wav": {
+     "bytes": 6524,
+     "sha256": "6cdce2fde3a1eb328007e0667c5dfe705e87bcd526e416ac948fa11a36448ac0"
+    },
+    "sound/dragon/pain2.wav": {
+     "bytes": 6875,
+     "sha256": "3238b77aafcc60c634cbdbd47ae1eec99bb969e2161b72ce5623398e6a451d2a"
+    },
+    "sound/dragon/sight1.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/sight2.wav": {
+     "bytes": 15205,
+     "sha256": "197238a35261e6792c40a4da38ba7b3827116ac1af5f143e092768346605b470"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/goblin/death1.wav": {
+     "bytes": 13890,
+     "sha256": "bed0d074d9aeee8f046ec7b3a9d33e02d157374ddf6af1296bd1ca7bebf30f10"
+    },
+    "sound/goblin/death2.wav": {
+     "bytes": 10280,
+     "sha256": "9cc07020579d50185ea401835e41edbd1c8f007065e39a6306c7aab4f32e7781"
+    },
+    "sound/goblin/idle1.wav": {
+     "bytes": 9802,
+     "sha256": "6c5a8c36eedb0ac5bddacfdf68250c36fe472f9d87e8969b4f95a863a99b77ce"
+    },
+    "sound/goblin/idle2.wav": {
+     "bytes": 9242,
+     "sha256": "5850c885e59ef04ae90be0579dd6f6b7cc26c282045ccb163dab2c9e19fea704"
+    },
+    "sound/goblin/pain1.wav": {
+     "bytes": 5118,
+     "sha256": "8afd94fcaa2d20e7c6626eda0c6cd5463670a1dbed0eeea36da588b28196c8a2"
+    },
+    "sound/goblin/pain2.wav": {
+     "bytes": 7898,
+     "sha256": "ad1f3b63b4ae35e4bfe010447bbd18bb85cd2bbf966ea7e1370afb0e924e699c"
+    },
+    "sound/goblin/sight1.wav": {
+     "bytes": 12716,
+     "sha256": "1c20028239d217f31af57649da5d1a6def576569ef5fc7e7033c2acbef7f9345"
+    },
+    "sound/goblin/sight2.wav": {
+     "bytes": 19356,
+     "sha256": "c9182325cacd9734bfedd48cb5d8076d5823b7a94baa40d32b02de9504474b48"
+    },
+    "sound/goblin/sight3.wav": {
+     "bytes": 8526,
+     "sha256": "796b2f9f0a1c20d672382c6681e9a6ea200fee2cfcacb5b3d3faa72c8e2537d4"
+    },
+    "sound/goblin/sight4.wav": {
+     "bytes": 8668,
+     "sha256": "c0a60baf2b9918a6df5fc32cd8b58c9fa7cfed923a4cb21c841f04f7a544782e"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 27521,
+     "sha256": "424ceef852229e94dbbbc879f1546a8dfda90db93c6263700cf4973805e4bea7"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 16192,
+     "sha256": "98d55bc63eff48521faeed1046064569e932986e734168ba0973c184aa2f5d12"
+    },
+    "sound/golem/step.wav": {
+     "bytes": 11226,
+     "sha256": "851e243a2e6ecf4cb637f8c4368b0f25443d4f9d104733eecfa886c40ee92bcc"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hkboss/iceball.wav": {
+     "bytes": 14990,
+     "sha256": "6aec96fda55dfb0120f106064cd324ea6e059bab3fdbb2d81cda297f9a82e02b"
+    },
+    "sound/hknight/death2.wav": {
+     "bytes": 15468,
+     "sha256": "b0e9cfdd68223d49820d03c2f8e5f59ab94e0f284d6865f492ae1a9d4fb13473"
+    },
+    "sound/hknight/pain2.wav": {
+     "bytes": 14568,
+     "sha256": "a069f8260f241acecc313dd0d2e688763052cf65c32597c5779d4776497fd6fd"
+    },
+    "sound/imp/die.wav": {
+     "bytes": 8448,
+     "sha256": "a8b0e037b88829b978d3dbd3d5e657c7f775c73662d554f6247a387ba333d4bb"
+    },
+    "sound/imp/fireball.wav": {
+     "bytes": 5492,
+     "sha256": "6362b59ded89655fa8b8877ed2639eca1a7aae1847306bbc3843fa98bedcbdaf"
+    },
+    "sound/imp/fly.wav": {
+     "bytes": 9204,
+     "sha256": "8036ccb256978c17234aa171267fb0332f1911b5f0dad7b9f74bba9378c39a37"
+    },
+    "sound/imp/flywater.wav": {
+     "bytes": 9800,
+     "sha256": "c80045609b62ceb61bd8fb1a18a53c0f2fd5443502a802b0d6d3c61e9a1db4c0"
+    },
+    "sound/imp/shard.wav": {
+     "bytes": 10678,
+     "sha256": "f806167fe23f37826964c0cc345c438ff0e79c3ffb1fed2c85451c675448cae4"
+    },
+    "sound/imp/swoop.wav": {
+     "bytes": 10842,
+     "sha256": "100eacded51635de912cee171f093e869d24589c44f68887497fe751cf9b1e4d"
+    },
+    "sound/imp/up.wav": {
+     "bytes": 12500,
+     "sha256": "874b533da43f713a1be27fbccadda8b6392fa8e689c8c4d17dac4b0d380f5822"
+    },
+    "sound/items/equalize.wav": {
+     "bytes": 13008,
+     "sha256": "933046049bae4d866250ad9a6e0a4b2a9385caffb4156daaca39ff7110a71126"
+    },
+    "sound/items/levitate.wav": {
+     "bytes": 44236,
+     "sha256": "8a04ce4a97dc22d095bc52d08111bcaaf5f57482f580ccbe0c61bdf8fd18913f"
+    },
+    "sound/items/life_up.wav": {
+     "bytes": 8660,
+     "sha256": "2712bd978343d4170bc1757706597d4de3940a07b6847977cbf117fa92f14c31"
+    },
+    "sound/items/money.wav": {
+     "bytes": 5100,
+     "sha256": "e4ac299499340c1be250f5d5e0824440d9e539de8a1d5b01e303056719cf822f"
+    },
+    "sound/items/quaff.wav": {
+     "bytes": 3748,
+     "sha256": "ebaa4ecc17dc67d3fbc5fe1a7541e4e19769ce941d043922f8572cb2da8d3cdd"
+    },
+    "sound/items/reflect.wav": {
+     "bytes": 14936,
+     "sha256": "90dd50b25175c8d514a52165429e9ca6b90c45dddbb0f301e5873146b4a4a06c"
+    },
+    "sound/items/reflect2.wav": {
+     "bytes": 33119,
+     "sha256": "5fb5afe50e0f5fa24f1c4481b3060ae222f40138ca81052cea047a57aa6b03e8"
+    },
+    "sound/items/reflect3.wav": {
+     "bytes": 7804,
+     "sha256": "a079e5aef6ed9fb7d5c992b0ef8e11932a9efa192eedac2bc530098e0550984a"
+    },
+    "sound/items/regen.wav": {
+     "bytes": 7984,
+     "sha256": "1e125e8e7c19f29eaf09b7ad301fdfe5126d922dfa84ba2af267cdf3351b6498"
+    },
+    "sound/items/shambler.wav": {
+     "bytes": 20182,
+     "sha256": "f0cdf78367b770c97b3b89abedb7c4fb0a9ee10d742acc8c98b3daba46cfc215"
+    },
+    "sound/items/treasure.wav": {
+     "bytes": 5554,
+     "sha256": "c86f66148e8dc99af2c8e877d64d06dc1c35d0caa9c6dc5c8092b268960b8edd"
+    },
+    "sound/knight/clang.wav": {
+     "bytes": 7198,
+     "sha256": "634a88cf26b4de688bed392cf108d5468749f212ce67015c71baa942e8e88502"
+    },
+    "sound/knight/kdeath2.wav": {
+     "bytes": 17854,
+     "sha256": "b712871a7316df7f6341719d488d67e65344f20d8561c97ae3115dde67cf0bfe"
+    },
+    "sound/lord/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/lord/death3.wav": {
+     "bytes": 33694,
+     "sha256": "990920962c449b0a41548df21f03f22488a60a6f5c45ffba142a943c345162ab"
+    },
+    "sound/lord/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/lord/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/lord/idle.wav": {
+     "bytes": 4700,
+     "sha256": "d9d7e5003fb23f3891e25a94e91d8755691d08331dc80dd0319a875766644a6b"
+    },
+    "sound/lord/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/lord/pain3.wav": {
+     "bytes": 11212,
+     "sha256": "cccdbb98396bface238dfe958f44dec4630714a7b545d30877324c0dcbedaf64"
+    },
+    "sound/lord/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/bellring.wav": {
+     "bytes": 27600,
+     "sha256": "fe3b2972c722171144eaba160757803292a42342e737d6acdbd0b14802e686f2"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/dsslop.wav": {
+     "bytes": 11163,
+     "sha256": "b6a9f6e74b222169c87e6c56b47d2e7995b23b8b045f16be968f43290f22cf9d"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/met2wd.wav": {
+     "bytes": 3968,
+     "sha256": "a3ce3e10b609f7ae28fc6f39f1f5d55a7c99a41143fb161de7e4e47b7f40f100"
+    },
+    "sound/misc/pushmetl.wav": {
+     "bytes": 14042,
+     "sha256": "2657b0006f51ecb7077b5861b1b282e0bb8bef3bdd5ccb68b3bdd6794361099e"
+    },
+    "sound/misc/pushston.wav": {
+     "bytes": 11490,
+     "sha256": "f457b95dad6131472475ab22d9c260adf5d389e74629cd8ea36ca05ad7d4e749"
+    },
+    "sound/misc/pushwood.wav": {
+     "bytes": 13602,
+     "sha256": "7c3fa06978f8c7b632d12bbf1031a5ac316b44fdc5efd93338ab0a0a162bdf3a"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/secret.wav": {
+     "bytes": 87440,
+     "sha256": "36e9d9617a14daefd510e72308b9e85718a473e2b25a06b66026d463d6bbb519"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/misc/woodbrk.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/music/halo.wav": {
+     "bytes": 860502,
+     "sha256": "20f314c0cbf1191e71b8e28e29a26ec3e118427648001363a197b4672cd7e35a"
+    },
+    "sound/music/pkdream.wav": {
+     "bytes": 154898,
+     "sha256": "df8857901002ce9dde3c558743c94967db11cae4af3d9a0cdc00c8cc09e6a910"
+    },
+    "sound/music/shadows.wav": {
+     "bytes": 550938,
+     "sha256": "5f3ee07c7954b9acce2eba6a633c6a5c72f30a8e68de51a393680f3eb737e49e"
+    },
+    "sound/music/soultrap.wav": {
+     "bytes": 868386,
+     "sha256": "15d35788ce7bd8f5c8c761ce94568c9da8cd1bfefb3fd4d3d69b610f489b7a5e"
+    },
+    "sound/necro/att_a.wav": {
+     "bytes": 8522,
+     "sha256": "a946c060cab5ee1bfff2d1af87cd71c9ccf63840a2751fd46fd32f387bee2c35"
+    },
+    "sound/necro/att_a2.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/necro/att_w.wav": {
+     "bytes": 26298,
+     "sha256": "9ae481ad41d16610b597989e82a8bbf9c35a74fe03a8e27900d72ff8b52e3c94"
+    },
+    "sound/necro/death1.wav": {
+     "bytes": 24010,
+     "sha256": "302e58b0f701ad07ade4a46d5cd3bd9c2186b2df3eb39e36c361918a72ccd24d"
+    },
+    "sound/necro/death2.wav": {
+     "bytes": 23594,
+     "sha256": "05f15a8430885b6688587eba5e249107c3e6df36d7937a3ddd2411d275e8842b"
+    },
+    "sound/necro/idle1.wav": {
+     "bytes": 49212,
+     "sha256": "737f382e89a40fc098214b77e9165e16f2a06323c07e910f336f2616b6ca87b4"
+    },
+    "sound/necro/idle2.wav": {
+     "bytes": 47120,
+     "sha256": "18893e7b31ff448831a7b7a5aa9a5d31b2dcd6e49ae8b58d5eea8b44683415dc"
+    },
+    "sound/necro/pain1.wav": {
+     "bytes": 19412,
+     "sha256": "f37e247a9e1436e4a86b78fe71e1ea6da43323e60943e86784ac87fc4393333b"
+    },
+    "sound/necro/sight1.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/nemesant/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/nemesant/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/nemesant/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/nemesant/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/nemesant/push.wav": {
+     "bytes": 8812,
+     "sha256": "91398e953b648ab23c037940fb7996f3d77727003a60757ea50686328c05cd69"
+    },
+    "sound/nemesant/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/nemesant/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/nemesant/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/nemesant/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/nemesant/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/nemesant/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/nemesant/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    },
+    "sound/ra/1.wav": {
+     "bytes": 7098,
+     "sha256": "6f41307a1d8a57f67917520d9c517df7b5e403f6e4f27b8c4b464ae1a57a4945"
+    },
+    "sound/ra/2.wav": {
+     "bytes": 6138,
+     "sha256": "6db176165cca16a7bd0538b77cf5dc6a68343ce13be3c5e716b61c7e5fc8840f"
+    },
+    "sound/ra/3.wav": {
+     "bytes": 8298,
+     "sha256": "bb0395f548fff802c76a113a521f0fc7a31029f7c701cd4ac4c6b954452286f3"
+    },
+    "sound/ra/fight.wav": {
+     "bytes": 10218,
+     "sha256": "69b9e0165290de5760a4ade9cba2b412d2a8f5777ece37f1f80a82e6cdf2b979"
+    },
+    "sound/random/thump/thump_1.wav": {
+     "bytes": 17013,
+     "sha256": "6aaee6ee956e9244265227e67fc4ab824b2d2612738edf8905945110cf2a755f"
+    },
+    "sound/random/thump/thump_2.wav": {
+     "bytes": 15660,
+     "sha256": "defb723191cd6d20024c9a8699d7673958512fb0437aa844347883cc8a50dd05"
+    },
+    "sound/random/thump/thump_3.wav": {
+     "bytes": 14523,
+     "sha256": "ee06b736825729a1dba77a62f3c9f7c8771ad5a8481b42f5af3b35755bfacd18"
+    },
+    "sound/random/thump/thump_4.wav": {
+     "bytes": 16877,
+     "sha256": "f0b02c1e1173f484a7b622598df6f18ffcebe0a9711c96ca0804d3e0d5ffa821"
+    },
+    "sound/random/thump/thump_5.wav": {
+     "bytes": 12775,
+     "sha256": "2373758e7bc591df02a09dc35d5f4b2a1cab2ce1e150121665e3797e1fb14d03"
+    },
+    "sound/random/thump/thump_6.wav": {
+     "bytes": 21820,
+     "sha256": "77ad075668ba72853c2615eab006042279e1a88dff8ca8fd286d291bb6b789eb"
+    },
+    "sound/random/thump/thump_7.wav": {
+     "bytes": 10836,
+     "sha256": "f7fd6a4ade0a8dba076304e1454a41da2bb770f9a34dd94b1de3ff1a361c6cf9"
+    },
+    "sound/random/thump/thump_8.wav": {
+     "bytes": 13386,
+     "sha256": "75ccfea9a0728abd0857df8630d1f12d02f43b6d9fcc5588848336420a050215"
+    },
+    "sound/random/wind_1.wav": {
+     "bytes": 36758,
+     "sha256": "219f0637ec3e1e86ae0f8c63f12567f50806e4c3786f7e8807da5313f9d63ff8"
+    },
+    "sound/random/wind_2.wav": {
+     "bytes": 108304,
+     "sha256": "c655fcd037be380d8313f13d4743ff4ab17300df79ab5801dffdafdb6a95268e"
+    },
+    "sound/random/wind_3.wav": {
+     "bytes": 121514,
+     "sha256": "e055a33413cbb5872b8df2095bdf89ef1b8dc2b3fd218782facc506d19f336f2"
+    },
+    "sound/random/wind_4.wav": {
+     "bytes": 155492,
+     "sha256": "582fe3b2019b052f563ef2c0c41045b3068b8f0ee8282be4c9db1759e93f8079"
+    },
+    "sound/random/wind_5.wav": {
+     "bytes": 22188,
+     "sha256": "27a7d6eae7ea84a7cee3baf45e4e3debaa0532610a05dae3126601870e658bad"
+    },
+    "sound/ranger/idle.wav": {
+     "bytes": 10819,
+     "sha256": "644fbbc14e20684fa31abc7f04969943ac950c33435271b0fa646aa324be4400"
+    },
+    "sound/ranger/sight1.wav": {
+     "bytes": 5379,
+     "sha256": "5023e2483fe5c1c37cd661d382e34c0b68eafe4bae0e35e8f3f7e516e78dcf51"
+    },
+    "sound/ranger/sight2.wav": {
+     "bytes": 11323,
+     "sha256": "3574f035e1a261b9a001d99a54bdb502da31da2639d95e7fc06f96b547c1ac44"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain1.wav": {
+     "bytes": 14234,
+     "sha256": "b4c9f9f3e15af1024db6471220a0b173b234cc13877de73584d25359ee117c6e"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/pain3.wav": {
+     "bytes": 18656,
+     "sha256": "030431779b201dc6a543a0a9afeb2e5f22c743452fc3f459bf632355f4ada2ac"
+    },
+    "sound/scourge/sight1.wav": {
+     "bytes": 35068,
+     "sha256": "48db878a4eae15b37ee0ca333aae74d310103a9eaf2e4b35eecd43a89f626b9a"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk1.wav": {
+     "bytes": 19372,
+     "sha256": "42e41297df70202ec9965af7af5fcdabcab7fde43ba515c8ba0a1ee2e4429554"
+    },
+    "sound/shade/death.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/shade/death2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/shade/idle.wav": {
+     "bytes": 37192,
+     "sha256": "57b0a0a7a0e75a17df8c4bb68740b23325bd0bf3475d908ee92fa0522c71edf7"
+    },
+    "sound/shade/moan.wav": {
+     "bytes": 33684,
+     "sha256": "3a6644f2c0a6ead5992fa9752ec9b0d898f4c40f5a32b12fd61aa991f75fa0c7"
+    },
+    "sound/shade/pain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/shade/pain2.wav": {
+     "bytes": 8918,
+     "sha256": "c6fa3ba7c659faf38b00af9c9867c37ba730cbc662125f5307f755515243dc4c"
+    },
+    "sound/shade/screech.wav": {
+     "bytes": 28244,
+     "sha256": "55ef2615baa6ce39733892fc9538f702acc567f65250223329f15b191d9b1a47"
+    },
+    "sound/shade/sing.wav": {
+     "bytes": 35654,
+     "sha256": "9de82a1d3124c391466004aea5e8ad066bcc6ede2715e7978a92a2c8f66e3f6b"
+    },
+    "sound/shade/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/shade/taunt.wav": {
+     "bytes": 36418,
+     "sha256": "f556cad612249e63690ac28b17405eba70e3df43560c3a087062b9f330811720"
+    },
+    "sound/shade/taunt2.wav": {
+     "bytes": 28160,
+     "sha256": "a68174008206b79794d8d52fd027daf08767ce005189860c815cda021080363c"
+    },
+    "sound/shambler/sboom.wav": {
+     "bytes": 56376,
+     "sha256": "1df051b49aaec9b19e1f49348aaf6d9c19aad3e4591c12b18c4fcbf3c0a73218"
+    },
+    "sound/shamvile/burn.wav": {
+     "bytes": 11316,
+     "sha256": "239c51d5cfb82ee7683075f6cd53d8a16fcc2da608c9db87c27fd7491160a627"
+    },
+    "sound/shamvile/melee1.wav": {
+     "bytes": 4700,
+     "sha256": "f418a627faa0b4630588914ecdd466c387e1d7d5ac2e09acecafa13baf33f10c"
+    },
+    "sound/shamvile/melee2.wav": {
+     "bytes": 6252,
+     "sha256": "dfeb5bcd8be8d9f1fcf52f89cf0af533ec28066eb0bf74e3ac4b588ca810f372"
+    },
+    "sound/shamvile/melee3.wav": {
+     "bytes": 13236,
+     "sha256": "7102a987921e4c291175ba252628613c2c6ecdb70e9a33e174b6bcf7addc239c"
+    },
+    "sound/shamvile/melee4.wav": {
+     "bytes": 9211,
+     "sha256": "da31a8531703998c06bc33c94639d5dd291c9ba24e6752599ec8e6113d3753b5"
+    },
+    "sound/shamvile/sdeath.wav": {
+     "bytes": 20996,
+     "sha256": "e27d5870c37ce74877a2681b5e9cef437d14b05c501fb93733c8e93d2d2b0931"
+    },
+    "sound/shamvile/shurt2.wav": {
+     "bytes": 3924,
+     "sha256": "541c66bfaf5f30c55d24c4013f4a8859159ebfdf2f054c681eb8b8200dba1c85"
+    },
+    "sound/shamvile/sidle.wav": {
+     "bytes": 5476,
+     "sha256": "ca3edcb476f3992027989a2a79ef21a7f8951965c8a0e77f89f0a0505f2d2b52"
+    },
+    "sound/shamvile/sidle2.wav": {
+     "bytes": 21511,
+     "sha256": "0e46d4e53c003136881723f59de4d706151b845d57608cd87361018acb7ef050"
+    },
+    "sound/shamvile/ssight.wav": {
+     "bytes": 15564,
+     "sha256": "5a5343f95ee503f1b481ef05499e023b681402b922600979367788f2fb91397c"
+    },
+    "sound/shamvile/ssight2.wav": {
+     "bytes": 27204,
+     "sha256": "2b22c0912485569f7ec87a32a29c88563c0cb8261b4428335540fc96f7e7cb52"
+    },
+    "sound/vomitus/death.wav": {
+     "bytes": 13236,
+     "sha256": "fa2cad86ac0ce1326132c5e378aed6a9ff5615d043df1d4d48e0b2691f8d3bde"
+    },
+    "sound/vomitus/flesh1.wav": {
+     "bytes": 8412,
+     "sha256": "9ac5a8ac2155e7d9b65144e7f65525c4660ff5959fe3a0277fab347e202b6f46"
+    },
+    "sound/vomitus/flesh2.wav": {
+     "bytes": 12788,
+     "sha256": "3fc22e2aa2c3c0bdc6501388ac18abb5e58c5fd5deba39d1cc2f7e8d48fcc869"
+    },
+    "sound/vomitus/groan.wav": {
+     "bytes": 13224,
+     "sha256": "3632e43615714e5fc1be8277881a913bf1bd79b276544418cbf1b159016f0d03"
+    },
+    "sound/weapons/axhit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/weapons/axhitwal.wav": {
+     "bytes": 6694,
+     "sha256": "0f14ba18076b25a7b8ee510b38adb282eb5c4f2fc94168baf1f8a658e1da684f"
+    },
+    "sound/weapons/block1.wav": {
+     "bytes": 5484,
+     "sha256": "ccb284becb454f395de702a263bfda1561b8bd38117893d33b5ebbb9eb7b6865"
+    },
+    "sound/weapons/block2.wav": {
+     "bytes": 5612,
+     "sha256": "62da8e44f3b1200b99f76a3bdb31d9d09a9e74c04a449c0afc482c6677a94bc2"
+    },
+    "sound/weapons/discharg.wav": {
+     "bytes": 18810,
+     "sha256": "4793e9b786b7a06b6f0d0698fba954ff205a9bb5a06150de7806c1388b85ba5a"
+    },
+    "sound/weapons/fwall.wav": {
+     "bytes": 40140,
+     "sha256": "e269c07608f322518e709925d5b13daded150460d19d3091f15152ce4c06c9bf"
+    },
+    "sound/weapons/fwallhit.wav": {
+     "bytes": 9426,
+     "sha256": "7b9f4da432e6fa44fbf721ed9ef753e6ceb41df59b8265b58f73764b2901224a"
+    },
+    "sound/weapons/fwalltap.wav": {
+     "bytes": 8316,
+     "sha256": "879b9970dfc3bc609ff384a0edea13b594ea6a82b5c56d33c8549cd36cccda0b"
+    },
+    "sound/weapons/mirv1.wav": {
+     "bytes": 89538,
+     "sha256": "7d60062f61d5929f5f927526d81920f24684520d230a5f2611c128b832d3357e"
+    },
+    "sound/weapons/mirv2.wav": {
+     "bytes": 18478,
+     "sha256": "67311180da390517f2ef71d161a0cf7b770548dcd4a7dda7e679cb9b58025b4b"
+    },
+    "sound/weapons/nova.wav": {
+     "bytes": 10020,
+     "sha256": "d41c8433fa1b964fafa1cdb2fec301fb4d398f1fce201b4d80b29fab7a59d7e7"
+    },
+    "sound/weapons/pkup2.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/weapons/rg_fire.wav": {
+     "bytes": 66260,
+     "sha256": "a3a7edd9c470077682bde595f95d88546d416f300202ae96bd6c6371ec19cf09"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/sheath.wav": {
+     "bytes": 7031,
+     "sha256": "8f28a1daa16db234ce77d91e688c7acbc9541c296d30af9e1f940b6d45eaf72d"
+    },
+    "sound/weapons/sword1.wav": {
+     "bytes": 3532,
+     "sha256": "572074b68af2132285aa9fd2ac6852f52ffb6c5e56eed44b1af21e0e78171e17"
+    },
+    "sound/weapons/sword2.wav": {
+     "bytes": 3055,
+     "sha256": "b176a257409b659d80df90560bbac4da5539971576aaf1107bb88bc016558085"
+    },
+    "sound/weapons/sword3.wav": {
+     "bytes": 3012,
+     "sha256": "eaca19c8a10b7942d4a279974df6e1cf076c362d5408e439b26286126852bedf"
+    },
+    "sound/weapons/unsheath.wav": {
+     "bytes": 8060,
+     "sha256": "45d9bc6b9dcaf8e0dc9b2ede7da69a872f50f7819462a71bc16b9d76a70be06b"
+    },
+    "sound/weapons/vorpal.wav": {
+     "bytes": 27002,
+     "sha256": "6af2615620041033f74621d26e594a2c35c7b96a2349b3a3407bfc3eb86b6a1b"
+    },
+    "sound/weapons/zap1.wav": {
+     "bytes": 7648,
+     "sha256": "1ee462bf6169537cc96fa7f95ef30b782fa1be473bd6ddc297fb3a7a6aa21ad0"
+    },
+    "sound/weapons/zap2.wav": {
+     "bytes": 7178,
+     "sha256": "8ece0064dc470a86c00906c1c50a54afd3a64eb13582071b9960581a1b72f4ff"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    }
+   },
    "sha256": "aebb2a448c35931241e028d97c953ca5fe8e3e845586152b53668e8a34d2824f",
    "timestamp": "2008-12-22T12:40:56.000Z"
   },
   "pak2.pak": {
    "bytes": 40678953,
+   "files": {
+    "demo1.dem": {
+     "bytes": 427800,
+     "sha256": "a269d805d37fe490932acc6791cb2e6d2818cf18cfe774c799b4636488d7fd92"
+    },
+    "demo2.dem": {
+     "bytes": 1073284,
+     "sha256": "16e7f8c2495ad468c6fc81be03b722ed6bfbc72d8f402930f62575a1e047ae57"
+    },
+    "gfx/env/duske_bk.tga": {
+     "bytes": 606420,
+     "sha256": "06796e1fc73783f1dccb748b4a05703e3454623439727168c47f370e358b0656"
+    },
+    "gfx/env/duske_dn.tga": {
+     "bytes": 787184,
+     "sha256": "9794d0b1b7bf571ff247baeebae5897be3cc0c6bf3428edbcf2782c1f34610c2"
+    },
+    "gfx/env/duske_ft.tga": {
+     "bytes": 594909,
+     "sha256": "e3967e5143dfc8ffaba3dc0fe0c83d0da8d56174de9da0ea09d450a0d62e6742"
+    },
+    "gfx/env/duske_lf.tga": {
+     "bytes": 585541,
+     "sha256": "0b7331135116c4e184df4d9e4824dbf5b435d045718db20a81b0d30ce91cb64a"
+    },
+    "gfx/env/duske_rt.tga": {
+     "bytes": 688109,
+     "sha256": "20d94245588988fb390440c531d787c25c2f4b97151bfbd1526fdc3c90e1320a"
+    },
+    "gfx/env/duske_up.tga": {
+     "bytes": 470425,
+     "sha256": "eba18d5e259e973c649bf16495a34ada1c523faa14ef6462b723476e820d8766"
+    },
+    "gfx/env/heather.jpg": {
+     "bytes": 11054,
+     "sha256": "b0b757b622fa013fa7b52165d4d8f0f88fdf2269fcf60a0c07e1661a6ca1c2ff"
+    },
+    "gfx/env/heatherbk.tga": {
+     "bytes": 694322,
+     "sha256": "14f7d88bd6c5e0f3790bdc5c520545524f7b11795f5bc87ff0ea67ea63a5ab75"
+    },
+    "gfx/env/heatherdn.tga": {
+     "bytes": 781498,
+     "sha256": "82c47aeacbc4e3b6879065d270254e72136185d192d07865dfcc59fa2feafbad"
+    },
+    "gfx/env/heatherft.tga": {
+     "bytes": 693479,
+     "sha256": "39b7c219b0532fba1ec7587884c02813715194c11663c3a18a84dff04fd93180"
+    },
+    "gfx/env/heatherlf.tga": {
+     "bytes": 699839,
+     "sha256": "e785c45e8af30992c5c1ec0ea65d3b620c02156d452182cef3e216c8c022f797"
+    },
+    "gfx/env/heatherrt.tga": {
+     "bytes": 710593,
+     "sha256": "fd021a77a15684c4071cc62223f867c942efb9754a8e11e60e37d216d163bbc2"
+    },
+    "gfx/env/heatherup.tga": {
+     "bytes": 669991,
+     "sha256": "19cf35346190864b570a820117dc222e284425b02cf84ee5955943ffafd05a7a"
+    },
+    "gfx/env/tramonto.jpg": {
+     "bytes": 12158,
+     "sha256": "685565601c89457af298badf3b1dbd114e977f5353ef9e35e96123ef5ddfdf24"
+    },
+    "gfx/env/tramontobk.tga": {
+     "bytes": 721740,
+     "sha256": "b742ef4e4d35085e04bb94e051e4ebca69961d48885f0e9afd2650b69013db58"
+    },
+    "gfx/env/tramontodn.tga": {
+     "bytes": 786291,
+     "sha256": "91f7a1847be8b5adcce0f5f2c9d9da8614b5ee14d29e84056a9b51066d2abd25"
+    },
+    "gfx/env/tramontoft.tga": {
+     "bytes": 701996,
+     "sha256": "315d06acd66c60cc06a8033be07328e5e0d13e3b00c7ed4e90f3b82879a98054"
+    },
+    "gfx/env/tramontolf.tga": {
+     "bytes": 640140,
+     "sha256": "e7478aa0deab77b93ea6642e525932ede3088ca875442ccd25d44cbe87d1893a"
+    },
+    "gfx/env/tramontort.tga": {
+     "bytes": 710845,
+     "sha256": "55b3c37de07bb6ba1f854678ca7d3bc9852cdc0f7b3230cc1efbcaa2bf3b30ab"
+    },
+    "gfx/env/tramontoup.tga": {
+     "bytes": 673371,
+     "sha256": "058e0cd4dbe23743f9b98e504515ede7014bb0866bf574652167a7ad53bb1349"
+    },
+    "maps/b_barrel.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/b_wbh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_wbh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "maps/nsoe1.bsp": {
+     "bytes": 1092452,
+     "sha256": "f594c8e75f4039b3abd69b558024473287bc90ab2bf801d6f1787df89bf0f42b"
+    },
+    "maps/nsoe2.bsp": {
+     "bytes": 2993424,
+     "sha256": "2011ac10315f86abdd7299667dd6353fbfee981ced19294e4463ab32ccd2f2ad"
+    },
+    "maps/nsoe3.bsp": {
+     "bytes": 7196464,
+     "sha256": "3bee3503846ae90751d606a9fd57434fb04a5120d8f294963f0dea6cdc7458fa"
+    },
+    "maps/nsoe4.bsp": {
+     "bytes": 4506280,
+     "sha256": "23244dcaa347da1f0b79708a69d384ec7f7a6ee5aa3731b8b5311a7632121709"
+    },
+    "maps/nsoe5.bsp": {
+     "bytes": 3845488,
+     "sha256": "13259183b17e8543b14e7e051ca214b6509baf9c58a7420fe57c91f584fa5545"
+    },
+    "maps/nsoe6.bsp": {
+     "bytes": 5698484,
+     "sha256": "6e793af8f7224bfc06b296209bcffd3326e6b78bb5f49344a325527605fd7803"
+    },
+    "maps/start.bsp": {
+     "bytes": 1578020,
+     "sha256": "f445624f6f8e70f8e988bfd3d848f1551f1b42a48c97ec669f58f6c0752b293b"
+    }
+   },
    "sha256": "1078a31fa9342fbae5a8a1e57b33d435281456e6c501080d596c209d0929c739",
    "timestamp": "2008-12-24T15:03:20.000Z"
   },

--- a/json/by-sha256/08/08b5e4dde36a924734149e0ee96664b9369590afa51262f48514b7524bfd0e0b.json
+++ b/json/by-sha256/08/08b5e4dde36a924734149e0ee96664b9369590afa51262f48514b7524bfd0e0b.json
@@ -12,6 +12,40 @@
   },
   "fracture/pak0.pak": {
    "bytes": 2616544,
+   "files": {
+    "maps/01.bsp": {
+     "bytes": 1098868,
+     "sha256": "2d13657fddf42310970092cdc52d0bb7d54f5d69a05f6dd1adcb64a99f7032bc"
+    },
+    "maps/start.bsp": {
+     "bytes": 952548,
+     "sha256": "f66ab759dac170e541844103e587a3df91526245c8494ad838f0ada65dd9677a"
+    },
+    "progs.dat": {
+     "bytes": 390700,
+     "sha256": "49052790d48e942f9dc261cc23e2f525508ddc41ab8c1893533f05c32a5535dd"
+    },
+    "sound/ambience/machine1.wav": {
+     "bytes": 57182,
+     "sha256": "e6adc6207b2c36e5335a2249eb7f74982af99aba0754078a205e589d4638060c"
+    },
+    "sound/ambience/machine2.wav": {
+     "bytes": 22442,
+     "sha256": "9df6c20b13f1b286159fac92cc27ce29e0b88e71cfa24294ca55075be38df5a6"
+    },
+    "sound/ambience/machine3.wav": {
+     "bytes": 19882,
+     "sha256": "bc0427417aaca5a5c336bda80fbe2b3064282faa2c258d5417e56de7a30e9fd0"
+    },
+    "sound/ambience/whoosh.wav": {
+     "bytes": 43990,
+     "sha256": "d3acc701d59c33d12e6b905a07e4f02443625571219426c248379d8aa1626c8b"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 30408,
+     "sha256": "34248569bb7ab66f5e1d874e15c7a91d89fd2b70d27e5521456b2589581fe1e6"
+    }
+   },
    "sha256": "c8f96459113c7ecb06f2fd487aa24dccdf91e86d4a556f94d22df8910b32fe58",
    "timestamp": "1999-05-13T16:59:26.000Z"
   },

--- a/json/by-sha256/09/09cdcfffe130229d77f339c31557747411509218e9e16c478216f47ad46a7c28.json
+++ b/json/by-sha256/09/09cdcfffe130229d77f339c31557747411509218e9e16c478216f47ad46a7c28.json
@@ -7,6 +7,132 @@
  "files": {
   "pak0.pak": {
    "bytes": 5596480,
+   "files": {
+    "maps/tefad.bsp": {
+     "bytes": 1767040,
+     "sha256": "0a86c8a2bfa97709013eab417448cdc0aec86442577b73881457766b1480aae3"
+    },
+    "maps/tefhoa.bsp": {
+     "bytes": 1286600,
+     "sha256": "697eb2985a40b51c0c55e49a238d7805d6be15e1bb8097e7f72440c797a016c7"
+    },
+    "progs.dat": {
+     "bytes": 602236,
+     "sha256": "c173f9b34e9e7b4ec2461c7b6542680fffea757852669762b041270df3b30d05"
+    },
+    "progs/lavaman.mdl": {
+     "bytes": 190588,
+     "sha256": "b81bb7f5cebb2889cfd2f431f743200f672d0195b05fe3faa98b50163fed7fb1"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/morph_az.mdl": {
+     "bytes": 300592,
+     "sha256": "98d86ad428b5ab5643e12921f3f41572eb84c2025a8f05c7b882ccce6bdc4a5f"
+    },
+    "progs/morph_eg.mdl": {
+     "bytes": 300592,
+     "sha256": "14468fccffaa1508c03610dd58fb51cd9058ca3bab036bca18f7a41cb37c195b"
+    },
+    "progs/morph_gr.mdl": {
+     "bytes": 300592,
+     "sha256": "662aa03785b4a6d2689670bebc5a9d081c36541347e324fac3957f599eab3be8"
+    },
+    "progs/redback.mdl": {
+     "bytes": 82664,
+     "sha256": "0d142a1f84016078c0053d5e6a4d483cd371203aa24f4c06c2f19224dcf5a46b"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 200848,
+     "sha256": "4c0653e3adba99be4d581c92a928fd6e8c27b0a2159a97f7ec5e885478249b8d"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/shield.mdl": {
+     "bytes": 54612,
+     "sha256": "6cebe03621614d8508ce3e8203ad151ad4b3ea5da9003650165e896b032545fd"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "ba9f52e66ac380306d443e07ee4f1fac92793cba55394c01590c3dd088042e78"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 133676,
+     "sha256": "0a57ee912df3142c5e17183d5f6bd461021b141d53f7534014d59eda97e6bfa6"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 47176,
+     "sha256": "87f013eb50cb30a967a183f0cfa41b4848f9269afd13dbe1ab5053458bfc5f0e"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 10768,
+     "sha256": "c48f2415db3a5067dfbd99ad580e3f4809532743d653eafe2fdb924fb0bb832e"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 47502,
+     "sha256": "a0c0bd639af614c7714388009c9388f6db9a694e7ecd8fac38653609d6958f61"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/s_wrath/swrath1.wav": {
+     "bytes": 6028,
+     "sha256": "7d2290479c4b8fe3cbf14b8e1bddbd6a874b5e9d5f436233eec562f35ca8cfb3"
+    },
+    "sound/s_wrath/swrath2.wav": {
+     "bytes": 4052,
+     "sha256": "7f9ae2dcb54b6e59c67705c20179a963bb8218d4c96db4323d1fedfb4ad39afb"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    }
+   },
    "sha256": "69ced02204a0c86178c68282d36d65c606ae0271f88500063a34e8f266705f5a",
    "timestamp": "1997-10-31T00:49:46.000Z"
   },

--- a/json/by-sha256/09/09d6220fadda818989ab8eedd45371c70aaa6c135fa9b65ea756dad3a8141d21.json
+++ b/json/by-sha256/09/09d6220fadda818989ab8eedd45371c70aaa6c135fa9b65ea756dad3a8141d21.json
@@ -72,6 +72,340 @@
   },
   "purifier/pak0.pak": {
    "bytes": 4085208,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "b1deebb2268d373683100cc9df4c9dcbf817f9bdb0e3f2cd13edde0037609b53"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "11454a7ec41855cc66adc9b80e60b1c76b0af873656d46cc20543ea4d2a7ef8c"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "d2a59d07042577c9c5a5ceace5ad0e3893ba3ac2d206f039f11cf282ead3945e"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "63f869e1e553ccae238279e4b78c902463505a3d1dd7c5d21d4f4acbb56857ee"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "6e3d8ed0cf22d78c0e05bf75837214a12f647fda33da1fa1ad1195cff3cb9681"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "35db83f82066ac1db85f4094dc9710e313b638e019d8e4d6fb5abf0457d506af"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "7b3838322dc860c3ea5dec5e246e9ecac4b0f75182edeff7b719e16f4f33d874",
    "timestamp": "2020-11-15T08:48:56.000Z"
   },

--- a/json/by-sha256/0b/0b05cec439031b2debb2c85d3535b493239a7b76e1eed8731b2bcdcb042f6bcf.json
+++ b/json/by-sha256/0b/0b05cec439031b2debb2c85d3535b493239a7b76e1eed8731b2bcdcb042f6bcf.json
@@ -13,6 +13,32 @@
   },
   "pak0.pak": {
    "bytes": 2524294,
+   "files": {
+    "maps/alba02.bsp": {
+     "bytes": 1430836,
+     "sha256": "fa6f1fd9b46e9cbb6ca32a88e08b365be97683af75a40d3c62613b23379d7a69"
+    },
+    "progs.dat": {
+     "bytes": 671664,
+     "sha256": "17bd79fcd4cc0715f2c596f15ce17710a433855b81e26d6cfa5284c99c52b06e"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 186084,
+     "sha256": "6fb69a1f5a5a177f370c12af89a018a67c4d6afff392c26635c8d067d4e80285"
+    },
+    "sound/ambience/buzz1.wav": {
+     "bytes": 40354,
+     "sha256": "3627176107ac11de4b0c08332ac3d95650fcfcdc0c2432b25646c6e5b19f40f2"
+    },
+    "sound/ambience/comp1.wav": {
+     "bytes": 159396,
+     "sha256": "9c64cac96e19351634cb8d612756970a6c9aac87062c7fcd16368e5fffa60925"
+    },
+    "sound/ambience/thunder1.wav": {
+     "bytes": 35564,
+     "sha256": "0bfbb1629a5002958926f057c8361effbe83f8f2cd5350a17e0f21d091231de9"
+    }
+   },
    "sha256": "94b37c4e7ed96fd001308874b1dffa7783bdcb22a1517a6d24127cf5a8533e4b",
    "timestamp": "1997-07-16T19:53:54.000Z"
   }

--- a/json/by-sha256/0b/0bbd5d63f08afbc5375526bd8407ba57a98ba49e00d388bbadea758843d20859.json
+++ b/json/by-sha256/0b/0bbd5d63f08afbc5375526bd8407ba57a98ba49e00d388bbadea758843d20859.json
@@ -7,6 +7,145 @@
  "files": {
   "Quakespasm-0.92.2.zip": {
    "bytes": 1563707,
+   "files": {
+    "LICENSE.txt": {
+     "bytes": 18092,
+     "sha256": "8177f97513213526df2cf6184d8ff986c675afb514d4e68a404010521b880643",
+     "timestamp": "2017-06-12T23:05:20.000Z"
+    },
+    "SDL2.dll": {
+     "bytes": 684032,
+     "sha256": "e8fdddf40edac5acea257cb3d33979682953b14ef44de86411fe9cf3cad1ca2c",
+     "timestamp": "2017-06-12T21:59:30.000Z"
+    },
+    "history.txt": {
+     "bytes": 351,
+     "sha256": "fa7ad3b53496c03615ae27912c3b44a6bdf38b1f5251514bff118e3e6b67e58d",
+     "timestamp": "2017-08-16T14:40:06.000Z"
+    },
+    "libFLAC-8.dll": {
+     "bytes": 67584,
+     "sha256": "0c01e3d322d4560e1893128e0852768095929595b8c47baa021dd3e4f4bde020",
+     "timestamp": "2017-06-12T21:59:30.000Z"
+    },
+    "libmad-0.dll": {
+     "bytes": 82432,
+     "sha256": "dec6207c07ac6bdaabef2a9dfde11831b030395fccc29ba532a001fe6318b215",
+     "timestamp": "2017-06-12T21:59:30.000Z"
+    },
+    "libmikmod-3.dll": {
+     "bytes": 176128,
+     "sha256": "0ff5da0a9ed605797aee011d05a42476854d9cac66c5a075aced3dd31cf7d28b",
+     "timestamp": "2017-06-12T21:59:30.000Z"
+    },
+    "libmpg123-0.dll": {
+     "bytes": 178688,
+     "sha256": "db3fd1b67cfd5328b6c55958f69d4029fecf4120d78415b0cfad06d508e93b68",
+     "timestamp": "2017-06-12T21:59:30.000Z"
+    },
+    "libogg-0.dll": {
+     "bytes": 18944,
+     "sha256": "36c4811444eaae0369429c8606801755d16f08817283deca2a29e06abf012f23",
+     "timestamp": "2017-06-12T21:59:30.000Z"
+    },
+    "libopus-0.dll": {
+     "bytes": 108544,
+     "sha256": "bc1ca4202143c94f760974593c3f94f255dd4b640db4d5dd38d328bca573d2ab",
+     "timestamp": "2017-06-12T21:59:30.000Z"
+    },
+    "libopusfile-0.dll": {
+     "bytes": 43008,
+     "sha256": "afc653b4b7f1ff0cf4bb03b066faaae861fc2eb924e9c494c04a229539d8598c",
+     "timestamp": "2017-06-12T21:59:30.000Z"
+    },
+    "libvorbis-0.dll": {
+     "bytes": 152576,
+     "sha256": "8f3ec9c42136e31dc8d9bbd299c3218ec8992df342f2bf25a2e0b9ca9de64762",
+     "timestamp": "2017-06-12T21:59:30.000Z"
+    },
+    "libvorbisfile-3.dll": {
+     "bytes": 28160,
+     "sha256": "f6ef6b671c4bfa037d5ea5ad0b410a513f3adaddfa0434d9284145b95da50ba5",
+     "timestamp": "2017-06-12T21:59:30.000Z"
+    },
+    "libxmp.dll": {
+     "bytes": 113664,
+     "sha256": "364346a2e0c7a91120e05ac121e72a728130de0a447beaca367da771b63a08e0",
+     "timestamp": "2017-06-12T21:59:30.000Z"
+    },
+    "qconsole.log": {
+     "bytes": 3257,
+     "sha256": "0c766109b72d7edb7217b9b4bd8ad13a0e77dd9ca12ed775dcde3ba1064b9028",
+     "timestamp": "2017-08-16T14:40:06.000Z"
+    },
+    "quakespasm-admod-readme.txt": {
+     "bytes": 1190,
+     "sha256": "2b2cade1df61ec70a0ea123fa37975b045a0478ad2d3b53b54bf9663f0842e12",
+     "timestamp": "2017-06-14T15:43:28.000Z"
+    },
+    "quakespasm-admod.bat": {
+     "bytes": 126,
+     "sha256": "91bd20f61a0f8c55454c4b500bf34f41c8c5f5fbf6944a2634c4eb2e1d1a0257",
+     "timestamp": "2017-09-01T13:09:54.000Z"
+    },
+    "quakespasm-admod.exe": {
+     "bytes": 504832,
+     "sha256": "d0b61913a467e8f7c8b755caa5037748830be30fef2d998361cbede3dd5e2aec",
+     "timestamp": "2017-06-13T00:58:20.000Z"
+    },
+    "quakespasm-spike-admod.exe": {
+     "bytes": 759296,
+     "sha256": "67d3f67f036f5309fbbf28de38c77426dbc37098d97b9ac7d55a59c6723ac48f",
+     "timestamp": "2017-06-14T17:39:50.000Z"
+    },
+    "quakespasm.pak": {
+     "bytes": 591944,
+     "files": {
+      "default.cfg": {
+       "bytes": 2289,
+       "sha256": "abb74400bd1b46e8eee9780a777b81483a29ecd786732d91b3e57c95a20f6783"
+      },
+      "gfx/conback.lmp": {
+       "bytes": 327688,
+       "sha256": "b14c295d790e9a8c86ff29c46b0e5b4de8e6d390c60f62b9395fc956563a9938"
+      },
+      "gfx/mainmenu2.lmp": {
+       "bytes": 30728,
+       "sha256": "a3fd168c6454eeaeea9e248df568e5942a7f850bc5478f8946a0b6516a2ce6c4"
+      },
+      "gfx/p_mod.lmp": {
+       "bytes": 2504,
+       "sha256": "56234ed3e4e4fe95f8a4a1f9a52d4a73890ea653aa88ec992e6777bf3e99b445"
+      },
+      "maps/e1m1.ent": {
+       "bytes": 26334,
+       "sha256": "7cd55e44f9585160c7d0308c5af4d7e23a0db0bcaf81a9d1d590ba981380e4dc"
+      },
+      "maps/e1m2.ent": {
+       "bytes": 41287,
+       "sha256": "30409975f8f94e20667538ec225b639570789f775b0199eef1206515ce58fad7"
+      },
+      "maps/e1m4.ent": {
+       "bytes": 43735,
+       "sha256": "3766674493c625884402dabf9fd961dbc462cc43fd735ae72db0baa3e3cfb1e2"
+      },
+      "maps/e2m2.ent": {
+       "bytes": 27179,
+       "sha256": "a65a882e6a95452cd9a43254eea67a3fdc161c92ac68c7f0a3b8ef9eb0f7118d"
+      },
+      "maps/e2m3.ent": {
+       "bytes": 38973,
+       "sha256": "46477248d62e4894013b993cc60ee0b84942f6eae6f7af761f8e1cca0a1259c0"
+      },
+      "maps/e2m7.ent": {
+       "bytes": 50561,
+       "sha256": "cb63389052b75db30df5835be05e53641880965d1f743db416e8fb2eea4f7203"
+      }
+     },
+     "sha256": "a163c4ad6e2b4369dbcff1b77c556447da167c4c4577582df8b61c05cad9e012",
+     "timestamp": "2017-06-12T21:59:30.000Z"
+    }
+   },
    "sha256": "ef9c2b03d270973434711691e9c9f62259d4a19310a5e5c92b496bffa0913c7a",
    "timestamp": "2017-09-01T13:10:44.000Z"
   },

--- a/json/by-sha256/0c/0cbcf6681952c51e44aecac54b57466a094d7b7701062d364291b5976874b721.json
+++ b/json/by-sha256/0c/0cbcf6681952c51e44aecac54b57466a094d7b7701062d364291b5976874b721.json
@@ -27,6 +27,64 @@
   },
   "PAK0.PAK": {
    "bytes": 17298379,
+   "files": {
+    "demo1.dem": {
+     "bytes": 166103,
+     "sha256": "fea9ed46a94441d256082808fd1aceda524a1b5188b45d85cc2317d0e1d0b469"
+    },
+    "demo2.dem": {
+     "bytes": 178886,
+     "sha256": "ba157fd96382a24ebee7e1032f3da7e54e0e103b8bdb0a6eeb1df5dded522f7f"
+    },
+    "demo3.dem": {
+     "bytes": 131174,
+     "sha256": "5e4f3a3f162668ba33b11e4a9dc4d175cbd1ca58332c0a9b508255dc63ef5ee5"
+    },
+    "maps/bbelief1.bsp": {
+     "bytes": 2037516,
+     "sha256": "2c8015cf955dc210a83dbf24ee8ccabd0ec0ab441a170b0d587dafcea039800c"
+    },
+    "maps/bbelief2.bsp": {
+     "bytes": 1791488,
+     "sha256": "86d7203cb8be48f15b567c2e629e9c47739c7da4f70dd9d57c4076370c8e81e0"
+    },
+    "maps/bbelief3.bsp": {
+     "bytes": 2209196,
+     "sha256": "b29c780a9a7988ac11e6d0057a3493f3473f972f1e3d0ba7d195f0fef9fcaacb"
+    },
+    "maps/bbelief4.bsp": {
+     "bytes": 1730992,
+     "sha256": "cde688cfb615ef32c6b2ee64f6ce44f9b0d25f252d459f9b1f27bf6ce35e48b7"
+    },
+    "maps/bbelief5.bsp": {
+     "bytes": 2423300,
+     "sha256": "482bccbdd953d7e9ecc093f6cf188d66721c5fa42920ef460adf7a89eaeee4bf"
+    },
+    "maps/bbelief6.bsp": {
+     "bytes": 2061232,
+     "sha256": "4f04706d726ab96d13b41c5d1359941e95dd2efdeba2b3482d410723b628b111"
+    },
+    "maps/bbelief7.bsp": {
+     "bytes": 909844,
+     "sha256": "6bf5fe1a692c77972e86f485fd58cff9179eb9269789fbb576f4b01a6f3c02b0"
+    },
+    "maps/bbsecret.bsp": {
+     "bytes": 1409052,
+     "sha256": "0b115ff281ddbcb9dcd16e34af65cc02e7165354fd05c17c086f26ffe0e6e4f5"
+    },
+    "maps/bbstart.bsp": {
+     "bytes": 1766880,
+     "sha256": "08e3dc852a2e5c1f4a85b6a4c094636fcd241a5c033e8251a591d71e5b4e9e1b"
+    },
+    "progs.dat": {
+     "bytes": 420748,
+     "sha256": "464658a87ae0d8181c80d45941670f8f9d2e518ccc181649a09ed8b3af43c3e2"
+    },
+    "progs/h_boss.mdl": {
+     "bytes": 61060,
+     "sha256": "30bf06acfcb3b32bf8f940187e712e87355fc7d8cc5ba8f36c128774cf20846d"
+    }
+   },
    "sha256": "8497ebdb33e0f58c7e8335f4a7bd7d6e9b8c9b7f21e673de3367b35f2bdce4b7",
    "timestamp": "1997-05-15T16:48:50.000Z"
   }

--- a/json/by-sha256/0d/0d8d13f3c728852fea02b642aeb7367223d31eec259fbaeb01071874b592371b.json
+++ b/json/by-sha256/0d/0d8d13f3c728852fea02b642aeb7367223d31eec259fbaeb01071874b592371b.json
@@ -82,6 +82,376 @@
   },
   "reliq/pak0.pak": {
    "bytes": 4792452,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "098cca7d3794e8e556920156e826cdab1425662c65e8affefd6f1398d11519e0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "b1deebb2268d373683100cc9df4c9dcbf817f9bdb0e3f2cd13edde0037609b53"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "11454a7ec41855cc66adc9b80e60b1c76b0af873656d46cc20543ea4d2a7ef8c"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "d2a59d07042577c9c5a5ceace5ad0e3893ba3ac2d206f039f11cf282ead3945e"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "63f869e1e553ccae238279e4b78c902463505a3d1dd7c5d21d4f4acbb56857ee"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "6e3d8ed0cf22d78c0e05bf75837214a12f647fda33da1fa1ad1195cff3cb9681"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "35db83f82066ac1db85f4094dc9710e313b638e019d8e4d6fb5abf0457d506af"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "396e9ca8e4e84166a453bf39eb081c26769f114cab87a9681ac42fb0dda91230"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 156216,
+     "sha256": "8a602686e322d7357a102e0c8e91907c8b3975a8b6d36ba19f3c645e450285da"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 70756,
+     "sha256": "2c4e50c32f7a60122c5fb4aa553de82faa013ea50cd232ea9bed8fd0b3b120bc"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 10552,
+     "sha256": "06d4f0235faedd3430e57d602ec29a2a91c0b23bdc30debc069212264a0faf54"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 10552,
+     "sha256": "0cee39ac60c3eda7b5f1d1efde52f8be19c9e4f425972f16ba6d6362d646afb6"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 14072,
+     "sha256": "1090a9c50a943c2bf04302914f69b835ecf79fbf3013f259a12668ebd57aad5a"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 15976,
+     "sha256": "8dd339507f4e18953ceefe3922d04ca513728bf2b0745813723873427843213b"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 24836,
+     "sha256": "9f272b2f1cb52fcf38983f63052db653e8208b2ee1eedf053e99dca6e439c7d8"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 27672,
+     "sha256": "46d85f10a260cf13d6711420f11a235089536a3725363be0717c2ee3e7e8a18b"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 14072,
+     "sha256": "053e466f1666314cbfc0cd6f67821850ad39505a6a0bbf37c80b127e6887e5c5"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 15976,
+     "sha256": "6183880b36171b6784cecf74b50aea2e1fdbc17b1b0b304a89125e964d63fd1f"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 2820,
+     "sha256": "1b0494b274aee493b2f60161f27a6d795800d55eef99996816385fde019af271"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 48964,
+     "sha256": "98a239b4fcfcf78c68079de14984bb8c30b251418044f63c9097c5c16f64da09"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 39668,
+     "sha256": "68e38e54cf4aad130c6b3ad2d8ce12ba20e4ffcd4c5a866aae85b69e56ce50c3"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 72316,
+     "sha256": "a92d2999b119af00143afaad9ca6e10249e474ca0fa76f3b712823fe55bab1c2"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 131164,
+     "sha256": "fe6439a01a4e1e82668c77a795e7d890806d8015af1cbcdde59cd9b982851939"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "88edf246555f1a2ba3b0aabed28218c36ab63befd6c9b8bae4896b18a4e07bcc",
    "timestamp": "2021-06-28T23:46:10.000Z"
   },

--- a/json/by-sha256/0f/0f305a53a6c386bd472157921e169d7f07f517fef65a83448b1a324095533c2f.json
+++ b/json/by-sha256/0f/0f305a53a6c386bd472157921e169d7f07f517fef65a83448b1a324095533c2f.json
@@ -13,6 +13,112 @@
   },
   "Pak0.pak": {
    "bytes": 2890715,
+   "files": {
+    "config.cfg": {
+     "bytes": 2157,
+     "sha256": "671d0c87bed390c6472429e2fcd16e33a2f731598e73924fea336a3dd5ca3bf5"
+    },
+    "maps.zip": {
+     "bytes": 386980,
+     "sha256": "c3ab4c7a4a1d0513fbd5bfbc5ced521fff16c7a6b87830985fc2f70560b64f6a"
+    },
+    "maps/borg.bsp": {
+     "bytes": 950292,
+     "sha256": "73e27aefa594b4504277c4720e2bdcb8c9b4a455c07f002432277dda5db3320c"
+    },
+    "progs.zip": {
+     "bytes": 290486,
+     "sha256": "215685a92f84e66a0ca0bc1571cccfa064d9f8bfb396428f2b24cfa3500f79af"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 160688,
+     "sha256": "51344e15b4f31af1abc9883ab3a094f8fac7551f68e6caafeebddbd0607c0a7f"
+    },
+    "progs/player.mdl": {
+     "bytes": 191852,
+     "sha256": "be5dc5498f67842bbfd52aee8fff37539a73ff634e1b99a452d4826cc6264128"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 146288,
+     "sha256": "5e00c959c231513f55ee7ca2a7cfa9726cab71e0d14f0b020d71d50f6f8357c2"
+    },
+    "sound.zip": {
+     "bytes": 19992,
+     "sha256": "fbafa41ed9f5ac9cfda4cd69ca377435dfd18c146dea6a79ade2eb39fad24e22"
+    },
+    "sound/ambience/2010.wav": {
+     "bytes": 29948,
+     "sha256": "dd3308495ba8e4a6b1bd94e9cc59040a524d046988a101647fb6fb9ed9034e9e"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 253748,
+     "sha256": "ff6f7ae79a9f28d0b60bd4fbb8f965fff145174a9c827c678202b4d4180e4fee"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 135268,
+     "sha256": "7f0a6bfb374a80527b0b1593101b2bb820cdf4a135c4d89149768a3fb359a381"
+    },
+    "sound/enforcer/death1.wav": {
+     "bytes": 9290,
+     "sha256": "f62aad2ae903808a0caecfc6bdfe13e5fdebb1df14d330c6ac4eda9b577b25bf"
+    },
+    "sound/enforcer/enfstop.wav": {
+     "bytes": 8642,
+     "sha256": "3f967a5e85b705e1bff8c91e34e3d6263aa3fdb96d7db9df9891b7774d7b779c"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 5870,
+     "sha256": "92dc64154602e29e95d40aa68d3544fe21cb21ce24192f1e8ffefc6b5d31b8cc"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 15188,
+     "sha256": "923b1306fa0e4bfa837c79d6b3ba522f60da2ec3c14ad56ffc361b420000dfca"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 16746,
+     "sha256": "8e7b85016feb13a32c426c42679fd4afe84c474ef8a4adf3a5dfc46199b3a36d"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 5166,
+     "sha256": "815e05c3b14858209fee01316848c117ad89af9f0aab190fc0ca0239367373ac"
+    },
+    "sound/extra/borg07.wav": {
+     "bytes": 24176,
+     "sha256": "a4f16f6615a0a371513825545c95cdc87aaa8a7557a8a34b2be086eeaac762cf"
+    },
+    "sound/extra/death2.wav": {
+     "bytes": 16010,
+     "sha256": "c0647da55a224bbca4429b80d2c707c4095869b7ec0eaf54b4291560f4f2028a"
+    },
+    "sound/extra/obey2.wav": {
+     "bytes": 55810,
+     "sha256": "47f766a6e76cdcba2a3c160697f1695c26a25042fbd5aaccb5c3b5fb53c66e08"
+    },
+    "sound/extra/sight4.wav": {
+     "bytes": 15106,
+     "sha256": "6e6759de79e8b263a32fe48560c24d5e684e694504afd3e38b8d6d978940590b"
+    },
+    "sound/misc/r_tele1.wav": {
+     "bytes": 34215,
+     "sha256": "790cb1c4f8d48310f62b4fa8e316bd437fe6536514e42a755f3aa4faae309da7"
+    },
+    "sound/misc/r_tele2.wav": {
+     "bytes": 15120,
+     "sha256": "3d9fae26422150cb7114b84a397988d2b318a89f20d5a5d4a6428c5b36d8c0f1"
+    },
+    "sound/misc/r_tele3.wav": {
+     "bytes": 21027,
+     "sha256": "0dcf033325869e889d5426ccd0fb3beecdbdd054d20b377b6c31ffb137ced8a9"
+    },
+    "sound/misc/water1.wav": {
+     "bytes": 66258,
+     "sha256": "4ab83731ca2cd47606681f5da5af283136af88d829c49b7e890734519df57a0c"
+    },
+    "sound/soldier/sight1.wav": {
+     "bytes": 12716,
+     "sha256": "d897e69d6669fed4ecd6bfd24a05fba80b450ec4da1cfca157d7916da3a6f8e0"
+    }
+   },
    "sha256": "e0e7d8fb574b50d03455830a3a743b7707cce8e9cd270152ff6d18d14ce7b939",
    "timestamp": "1997-05-29T22:21:28.000Z"
   }

--- a/json/by-sha256/0f/0fc6729bd92eee7a2a93834a2f96ff891fb625455b93c680917bd0e2e22007ad.json
+++ b/json/by-sha256/0f/0fc6729bd92eee7a2a93834a2f96ff891fb625455b93c680917bd0e2e22007ad.json
@@ -12,6 +12,580 @@
   },
   "pak0.pak": {
    "bytes": 47280476,
+   "files": {
+    "gfx/env/dembk.tga": {
+     "bytes": 708332,
+     "sha256": "0e4f847805d1841601e5a0b39d02d26e7a87707ed4c0ffdfd1d1acceae055107"
+    },
+    "gfx/env/demdn.tga": {
+     "bytes": 695653,
+     "sha256": "4fcfc6f4bcd7051e681b560bf8950dd7281cfb2dd9b35684d04347e10cc9fb70"
+    },
+    "gfx/env/demft.tga": {
+     "bytes": 740119,
+     "sha256": "52d9d566af5251108a443c9c8abe3b5cea9e1a211653db9f7fa52d69778fd802"
+    },
+    "gfx/env/demlf.tga": {
+     "bytes": 757975,
+     "sha256": "f57452ee2aee4b78a0f2c0403ea8b5dd5f63f84f0573ebde56b2bc66ef000f8f"
+    },
+    "gfx/env/demrt.tga": {
+     "bytes": 693510,
+     "sha256": "83435d4a5eee2f27dd7d707d28dbbfd882e2adaa09485761d97f6ebe06c113be"
+    },
+    "gfx/env/demup.tga": {
+     "bytes": 552002,
+     "sha256": "a2718f9d1730806596f835160c2c6a48daa6c434b05ace2b713af90a2a08bfa2"
+    },
+    "maps/fourfeather.bsp": {
+     "bytes": 6912732,
+     "sha256": "f75384ab9081293e65fc1d76756385a16f9335b715183fbac25825cf293772c3"
+    },
+    "maps/fourfeather.lit": {
+     "bytes": 2559764,
+     "sha256": "4264a740837d45b0c1170b90922bd18149e75253e70c51d0fbfdc2eff8d051d8"
+    },
+    "progs/bender.mdl": {
+     "bytes": 509948,
+     "sha256": "8c09b11701fe47b850aacd26392c46f2bb60a444b2b9f051b2d7fdc4bc7bd620"
+    },
+    "progs/bfish.mdl": {
+     "bytes": 2367865,
+     "sha256": "15000ab9aad96445dd4e08d544044750c774e06836d95d47d8110527207e90de"
+    },
+    "progs/bigy.mdl": {
+     "bytes": 1464644,
+     "sha256": "381fdcf5176a808cb0532169bc96466c4171e74a7d3783c4a83c0c6717c5a8b0"
+    },
+    "progs/bout2.mdl": {
+     "bytes": 74717,
+     "sha256": "3118bda6530cc52d6ca8a0838d28617add593296173e2a7201bf3b8958726d43"
+    },
+    "progs/bridge.mdl": {
+     "bytes": 446767,
+     "sha256": "a092919eafce3bcee7f122a928805de771c9e8b7ea390cd32213ebdc5b5f4b4e"
+    },
+    "progs/byz04.mdl": {
+     "bytes": 239501,
+     "sha256": "f3c755907b72bc0e9c33e55ee4e1930e9081920c54f01338f008eeeb34438390"
+    },
+    "progs/claw.mdl": {
+     "bytes": 535662,
+     "sha256": "6aef5c27cd3bb656ecbcc9e57238cab849034274412c74b26b1562fd8d20ffdc"
+    },
+    "progs/crow.mdl": {
+     "bytes": 205393,
+     "sha256": "6fafe6fe9af0f37115055dcebcef7948ac587b77f4289fcffcb847d51fe5b7fc"
+    },
+    "progs/dragonite.mdl": {
+     "bytes": 497632,
+     "sha256": "6e1145a8d7404e69c0ae4fe8a43df8619f65a05702463ea36d9a93a05e7c0aee"
+    },
+    "progs/dyong.mdl": {
+     "bytes": 2881576,
+     "sha256": "2081d82cf030e4aa4889d6eac3bcb0fb60c6b06a9319d88d44d3217790874c56"
+    },
+    "progs/fenc.mdl": {
+     "bytes": 57448,
+     "sha256": "6997c02d790f8b574e0a6ec8bea6f27ea2314ad5919bebc2a4bb6418a71004fa"
+    },
+    "progs/fens.mdl": {
+     "bytes": 41992,
+     "sha256": "5c96a11706b1bbae621fce3c924ec007be1edf0ecbe89e7de9d9d9ba0010df1c"
+    },
+    "progs/forg.mdl": {
+     "bytes": 1401047,
+     "sha256": "5ad0b30d7336fcc506e3f00df6e869258998745a1cd19aa9b044eb3df826c03e"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib_tarbaby.mdl": {
+     "bytes": 8788,
+     "sha256": "4b5a5d09ce93ddaf4574e01b514d23c6c12d83b149a942343403f42913cb6bad"
+    },
+    "progs/h_bender.mdl": {
+     "bytes": 68124,
+     "sha256": "682705eeb51d052e08efd3fc4fa54d2878a2578f5c11fae72b09af00240e7a08"
+    },
+    "progs/h_dyong.mdl": {
+     "bytes": 130440,
+     "sha256": "474d4cc5771d19b9e510c148efd724f0f0c460e89b4f038743ebe278e3e21a3d"
+    },
+    "progs/h_hbig.mdl": {
+     "bytes": 290200,
+     "sha256": "d36800d6fd1a0cb42921d09e54401261e72f8299ec04b46ff2600458fa2e81ac"
+    },
+    "progs/h_norb.mdl": {
+     "bytes": 141156,
+     "sha256": "e0cb56e5552b274d936470d33c8385c295940136ef3e86908347abb0313956a9"
+    },
+    "progs/h_serp.mdl": {
+     "bytes": 52932,
+     "sha256": "b967e75a518679ccace2f3376bdfca41606fa1bb72cf34f81092313dc4edf652"
+    },
+    "progs/h_xogre.mdl": {
+     "bytes": 80360,
+     "sha256": "0c8c77798823d2a481bdcbc13afbf3c009182e763268e42950b1e464583087d1"
+    },
+    "progs/h_zomby.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/huit.mdl": {
+     "bytes": 569185,
+     "sha256": "388fe8cd041c7266b25859a58cd388139ddbe3b3c7d5250a843d6f8c2724bb41"
+    },
+    "progs/korb.mdl": {
+     "bytes": 4357861,
+     "sha256": "32b5dae87b8d8543a513c990b6b9f9d2efc7754f3244ef9237305096d8cca1a3"
+    },
+    "progs/meto.mdl": {
+     "bytes": 958517,
+     "sha256": "144cebb3b708cd7d3650622403f656d7ecb0955f2118ca8788d2a5a37680a85a"
+    },
+    "progs/norb.mdl": {
+     "bytes": 6107044,
+     "sha256": "c135ff66bc16176480fab5361c8b9a09b13d68a57d9ad7d210564804676adedd"
+    },
+    "progs/pclaw.mdl": {
+     "bytes": 1187080,
+     "sha256": "8e1204c3f30f9105820a2495e12423151de93d72a5c66d8d79bdaed2e1e1c89e"
+    },
+    "progs/puls.mdl": {
+     "bytes": 417477,
+     "sha256": "41760f10360ab20090d14a746ba43a811248f412ec85ad940464e37533ecb5ff"
+    },
+    "progs/qtree.mdl": {
+     "bytes": 176844,
+     "sha256": "68932efcf0b1071c16491b769dcb9a3ecced0d5abd9904f24d0e3c225a42dfbc"
+    },
+    "progs/quakflag.mdl": {
+     "bytes": 823382,
+     "sha256": "ab53236dddd597cb33ace636342d61778451bbcb1686129f1dac922eb78a403f"
+    },
+    "progs/rota.mdl": {
+     "bytes": 189662,
+     "sha256": "fd47e770d21268888eb55b07e1e9ba732ecfba2274e81a84bb0c60af8939a689"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/serpent.mdl": {
+     "bytes": 289592,
+     "sha256": "fcea953b6b44500f1196de6fdf3ecb7e1ef910eec3e212c907b54571ac0c26ac"
+    },
+    "progs/sprog.mdl": {
+     "bytes": 378220,
+     "sha256": "88168b153fb37e279aaf9b040487daf90d2dc3ee5d50b64d15fca99701ae0c43"
+    },
+    "progs/squad.mdl": {
+     "bytes": 144696,
+     "sha256": "370cd785f810916bfed5bf017d18114771b943ed8d1714c2e05c19f9843ae726"
+    },
+    "progs/swarm.mdl": {
+     "bytes": 397712,
+     "sha256": "e27b6b5d0c02c823e8058a81768bda3fd8c13ebc7fe9e019714469273657e184"
+    },
+    "progs/taxe.mdl": {
+     "bytes": 56532,
+     "sha256": "a687d45b857873943d24dbd2a7b8892a0bc86bed6816e63c9a93d6340e8683ac"
+    },
+    "progs/trens.mdl": {
+     "bytes": 746088,
+     "sha256": "880403b0d521e991b5c7600536b846b84ecae1d014608f5c3779fab5205f5a1f"
+    },
+    "progs/trins.mdl": {
+     "bytes": 746088,
+     "sha256": "0c472157374ae70875320c68236c3aeecd1f02de377fd860733b4b2695cd6801"
+    },
+    "progs/trons.mdl": {
+     "bytes": 538006,
+     "sha256": "7720e2a4b0de2787dd598d84daba5c104c39015fe43ff01589d62e948eaf07ce"
+    },
+    "progs/truns.mdl": {
+     "bytes": 811738,
+     "sha256": "dcd91746b402c88d2a23a6524c2ddefc3bdb91dc90998d75fee833f2ec598a42"
+    },
+    "progs/venc.mdl": {
+     "bytes": 63873,
+     "sha256": "01f4ea1068eb4af824858c68bc8e96f0d77c7c8502fad1231435f4f7d12ec3e7"
+    },
+    "progs/vinc.mdl": {
+     "bytes": 61437,
+     "sha256": "fb2f80c4ada2b4840d19f8283de74c316cbdddf21103f00e085b53792c4ea074"
+    },
+    "progs/vonk.spr": {
+     "bytes": 72892,
+     "sha256": "b5cb4b39074216d6b0c105bf8c38636fc21eae40170e60a39f7155c1134b11f9"
+    },
+    "progs/wrad.mdl": {
+     "bytes": 212876,
+     "sha256": "f5103ea12fd56ed19c094168e0f3fb0d337ea32ba634ce917be92f71b60fc928"
+    },
+    "progs/xogre.mdl": {
+     "bytes": 350696,
+     "sha256": "81ed4b9041ea21520e13c7ea32debc69bb134df1b1b23286a96bb183ac3c07e5"
+    },
+    "progs/zom_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "55cf7733462c0fd3aa35849678d7a7eae6b705ff5be316fcaa44690ae38515ff"
+    },
+    "progs/zomby.mdl": {
+     "bytes": 186084,
+     "sha256": "76430f4aebfb39e918f524d81d5012051e49d0749f6f9a692ae7445a15cc8dfe"
+    },
+    "sound/ambience/buzz1.wav": {
+     "bytes": 36308,
+     "sha256": "363061f3c61966a71357a65dcae2505c24b826c88c5258dc14d74ba2e8c300b8"
+    },
+    "sound/ambience/fl_hum1.wav": {
+     "bytes": 50154,
+     "sha256": "48fc01e24f7636aca87b342fb11ca05f903fe4c3bd0a8021ad160144884a0db6"
+    },
+    "sound/ambience/hum1.wav": {
+     "bytes": 40166,
+     "sha256": "fe588142678ccf1a87c5b2455748e7c0e7c2890d76e67825df086c87aa99b87f"
+    },
+    "sound/ambience/thunder1.wav": {
+     "bytes": 15668,
+     "sha256": "0169c43ef5ff7935a21c8271051630c3ad8e34313150e72bdc43a9cb8d8ac908"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 79322,
+     "sha256": "3eb5a97ade738aefdcaffb529d4c94c893f050361d30407b33adddd0895eaa6f"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/bend/atk1.wav": {
+     "bytes": 24124,
+     "sha256": "19ea81bd24531ffe2550f7ece60f445dad92928433f4ed9b849047d987e73cf4"
+    },
+    "sound/bend/auw.wav": {
+     "bytes": 35520,
+     "sha256": "648afec7b316420367db969b9c5033f6a0005e594f7c68007f8c525c73a82952"
+    },
+    "sound/bend/auw2.wav": {
+     "bytes": 25172,
+     "sha256": "219469b3859c31ee61fc4563b75d6b3b3e25611c25b9e4c74218b479fe36cce6"
+    },
+    "sound/bend/beat.wav": {
+     "bytes": 11482,
+     "sha256": "56a866907196b51ad83bd676432a93b832a78fdff590ea17f31f4a50112ec695"
+    },
+    "sound/bend/die.wav": {
+     "bytes": 40770,
+     "sha256": "0504366f866fa60aed9d9d5b0736d62ee92fb6a0d287f8ecdd5b3e2abb519bb0"
+    },
+    "sound/bend/die1.wav": {
+     "bytes": 11798,
+     "sha256": "701911ae00c86f1fcdc30f99a1fc999c27f6ecec337cd7dbb1af55f62837f4a2"
+    },
+    "sound/bend/gun.wav": {
+     "bytes": 10958,
+     "sha256": "8a62ddc631d85b6ab21ada3c801fb9eb4718b534f9a67df615d324582988de11"
+    },
+    "sound/bend/idle.wav": {
+     "bytes": 87918,
+     "sha256": "b88d049ab023f4e75956417c8fd24533d9f71441fc1cb84f8443d8252344f934"
+    },
+    "sound/bend/idle0.wav": {
+     "bytes": 65206,
+     "sha256": "5fc30ed5ef8abfb48297a99185bc7f66975f89b38050b578342ff989ee8b5ce9"
+    },
+    "sound/bend/idle1.wav": {
+     "bytes": 19456,
+     "sha256": "70d1224a6ab04c491344aa1462b2f7b9438cea80e490708ae9d8debb3275693b"
+    },
+    "sound/bend/idle2.wav": {
+     "bytes": 46320,
+     "sha256": "6528c0794537af612dde7f8b407f890656b2d50ceb851a01b3d70cceb0dc8030"
+    },
+    "sound/blob/shoot1.wav": {
+     "bytes": 7180,
+     "sha256": "c511dae17bb6adc80a3cfc9d12d1a968063777576e0ab797a518e1f7c7ce76ba"
+    },
+    "sound/dragonite/death1.wav": {
+     "bytes": 101590,
+     "sha256": "598507f8e5c7c84cba2d267473002d215196e8f3c7c02a340b5bc484685ac5af"
+    },
+    "sound/dragonite/death2.wav": {
+     "bytes": 64062,
+     "sha256": "48fe173740669e42e6249e9c43eb9f6001722ac8b089deed9ec4d7d293fa56bd"
+    },
+    "sound/dragonite/idle1.wav": {
+     "bytes": 122810,
+     "sha256": "3f12e2a679d5b9e2d837632ff4a0017e7f678d52fff5a9609a1e4aff579af3fc"
+    },
+    "sound/dragonite/idle2.wav": {
+     "bytes": 49558,
+     "sha256": "07158364edebcdd36af7d1d1d4fcc7c33add450dddef9b00cb5c7713ab7c43ee"
+    },
+    "sound/dragonite/pain1.wav": {
+     "bytes": 56972,
+     "sha256": "143d2abf7ae697582bdaa0976fc8e6385025a556c7a7c4e3c90c3b947e82523f"
+    },
+    "sound/dragonite/pain2.wav": {
+     "bytes": 47152,
+     "sha256": "cb198ebb4eb82bfbc1bc775bbba3696e9fb1fd6b3322ff2e8b64a286d1b592ee"
+    },
+    "sound/dyong/idle.wav": {
+     "bytes": 33212,
+     "sha256": "0e878de67d5e72ed8516a3856bf6220f028e7efbbd1cd7bd6e2c4e44861c9193"
+    },
+    "sound/dyong/kdie.wav": {
+     "bytes": 20692,
+     "sha256": "565a18def420075f7d5163e4d79b3a85b9f6076b0b65fbddf07c5f3eed03f2c7"
+    },
+    "sound/dyong/khurt.wav": {
+     "bytes": 40388,
+     "sha256": "0fb6badec1b2f94c40de224db06e4816eabf37d68ad57fd3d13c4d6558a398b4"
+    },
+    "sound/dyong/sword1.wav": {
+     "bytes": 25750,
+     "sha256": "ad90d66cbe6eea3cce11f23be10dc24344681e80fdc193c1dc75497646c304b4"
+    },
+    "sound/dyong/throw.wav": {
+     "bytes": 11526,
+     "sha256": "92a3b559e30903f90b6bf7315b95cbbfb3082854d5c5418c200cf7682dc2eaa1"
+    },
+    "sound/hbig/0idle.wav": {
+     "bytes": 12780,
+     "sha256": "b1a2495414490b4021a4f087c86416987ebd2e272afeb3f89c696cef55a5f8fd"
+    },
+    "sound/hbig/hbig.wav": {
+     "bytes": 2350,
+     "sha256": "1dc897141575a9ca7a6bfd3a3623c0b39ca63f65dec546a15ce5b8e5fc95cb01"
+    },
+    "sound/hbig/idle.wav": {
+     "bytes": 11254,
+     "sha256": "0b3609995ae89dc2078ee24e79962b7560bcab2dd0b9b3a7b362d950955d710d"
+    },
+    "sound/hbig/kdeath.wav": {
+     "bytes": 13892,
+     "sha256": "56e2b297f7f6f2cc0771b2ceb598da4fae860dd837e1bdda838ed1f120097865"
+    },
+    "sound/hbig/khurt.wav": {
+     "bytes": 7898,
+     "sha256": "0f92efc994d4cdefaece746d03b74d980f5d693e518a9134f2bc2f43bb6cfe94"
+    },
+    "sound/hbig/sword1.wav": {
+     "bytes": 15032,
+     "sha256": "e4d7d3a4913860ed3073f10320bf579c26ba089ba51965aa607a0bd1afc9ad21"
+    },
+    "sound/hbig/sword2.wav": {
+     "bytes": 9098,
+     "sha256": "204f6b9aeab6207780ef1da1ffd2d73373021e2dd8ac2693c101d72c495cff1b"
+    },
+    "sound/meteo/met0.wav": {
+     "bytes": 43782,
+     "sha256": "5cd081b419cbf03fd511e210018f6db376431e0d9de93bb2de2ae2c536f47464"
+    },
+    "sound/meteo/met1.wav": {
+     "bytes": 37536,
+     "sha256": "f687216adf7bf0daab0cc99a860cd46b3c84bd6795792167c91caa75a6deb2de"
+    },
+    "sound/meteo/met2.wav": {
+     "bytes": 33290,
+     "sha256": "ae927bdb2cfe3eb8236df4990df14639d68571db87fa9185ef937c84308cd235"
+    },
+    "sound/meteo/met3.wav": {
+     "bytes": 69070,
+     "sha256": "173190f7845deb05a96f785f34aa05b1ccd18efcb0ce76da67aab34cce7b1a83"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/orb/death1.wav": {
+     "bytes": 30362,
+     "sha256": "f484be93304290fb1ae135df047cfe1f15e9c65e9e81c8c771c708d98a86934f"
+    },
+    "sound/orb/enfire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/orb/enfstop.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/orb/idle.wav": {
+     "bytes": 20858,
+     "sha256": "71fa418ed42114c9819d931511f30ff7324f06dbb8523bb5f3d418a288b356e1"
+    },
+    "sound/orb/idle1.wav": {
+     "bytes": 67018,
+     "sha256": "53685269020f20bf0f04db230e58620cf42fe43373fe94ad9bbe11f65ee5e4cd"
+    },
+    "sound/orb/pain1.wav": {
+     "bytes": 7872,
+     "sha256": "11c8918750c1082f9d404469b95a57fd460f05fd8647e4c2f3a1472af7ff4149"
+    },
+    "sound/orb/pain2.wav": {
+     "bytes": 6062,
+     "sha256": "180c720c4126f985d002858489b3174c0f22554e0bcf1add69d20f1da0a5b67e"
+    },
+    "sound/orb/pain3.wav": {
+     "bytes": 6062,
+     "sha256": "bc29697980e68ea47ee73cda67fd49e65161481d4eacf199633ee7298a189bae"
+    },
+    "sound/orb/sight1.wav": {
+     "bytes": 16094,
+     "sha256": "50329bcfdb093cdedd72fbbc598d7a1760f051509e0f44442e0fe32b7c36d45c"
+    },
+    "sound/orb/sight2.wav": {
+     "bytes": 3488,
+     "sha256": "867eb15b2a24561dcb185a2d57ac1c62cf7772e758b8b5a481fd83723b0fa3cb"
+    },
+    "sound/orb/sight3.wav": {
+     "bytes": 7872,
+     "sha256": "e27f0aa6fde35cd0bec62b7238db1f680993402341a663e1ccbedbff62b85047"
+    },
+    "sound/orb/sight4.wav": {
+     "bytes": 6062,
+     "sha256": "180c720c4126f985d002858489b3174c0f22554e0bcf1add69d20f1da0a5b67e"
+    },
+    "sound/serpent/0atk1.wav": {
+     "bytes": 15730,
+     "sha256": "4e839d9db32215b408e185dbae706c570f484b936687e0e09995da3fa12c7878"
+    },
+    "sound/serpent/atk0.wav": {
+     "bytes": 45352,
+     "sha256": "17fa814da78162b7d9e863fee40cb9e696a7e6025cb47c087c08df9237b394f7"
+    },
+    "sound/serpent/atk01.wav": {
+     "bytes": 8688,
+     "sha256": "907426060ed8aef68c9768d16485e76bee62875712387b2018c38daf67b32157"
+    },
+    "sound/serpent/atk1.wav": {
+     "bytes": 12564,
+     "sha256": "6ba4d88077c273c4e3329c3c6956ff1c8a42ccd00df10413d186ac3810b193b0"
+    },
+    "sound/serpent/dth0.wav": {
+     "bytes": 26618,
+     "sha256": "9c8e7f518458090d0b52d2aad7ca41ff18ecdad114089d38a1f6590b4d811e0b"
+    },
+    "sound/serpent/idle0.wav": {
+     "bytes": 40116,
+     "sha256": "b11524c2f63b307d56f8e207a89c217d5200e2d46f7948acc52695d197674df2"
+    },
+    "sound/serpent/natk1.wav": {
+     "bytes": 15730,
+     "sha256": "4e839d9db32215b408e185dbae706c570f484b936687e0e09995da3fa12c7878"
+    },
+    "sound/swarm/bee.wav": {
+     "bytes": 22248,
+     "sha256": "3e65648b578ad13127eeb031588f3a29831a411b126a2452cdc1302f9202472a"
+    },
+    "sound/swarm/bee1.wav": {
+     "bytes": 53436,
+     "sha256": "ded24de4fd98bcfd4351504c522b9778255d3131cea1ebded5a3fa0ac24b1a20"
+    },
+    "sound/swarm/bee2.wav": {
+     "bytes": 33410,
+     "sha256": "cbec8e0bc1b898a78fc503dfecf164031a3a4364c2aa07b5fc09df5d3cec28d5"
+    },
+    "sound/weapons/tink1.wav": {
+     "bytes": 1252,
+     "sha256": "6fc708278f5300f47e5096729d9a4889384689ecb1e2f0e5d1dfe93f1ceab5f6"
+    },
+    "sound/xogre/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/xogre/swish1.wav": {
+     "bytes": 2306,
+     "sha256": "18b58b934e798a2e35e7460f58b7d542a805490f6f9e8da50f1bb7bdb7b26c4a"
+    },
+    "sound/xogre/swish2.wav": {
+     "bytes": 2784,
+     "sha256": "5fe8e31c24d70cb172c792f88e78cebc3329d90990b7bb98a3c0c6654d8636ca"
+    },
+    "sound/xogre/xogdth.wav": {
+     "bytes": 13892,
+     "sha256": "56e2b297f7f6f2cc0771b2ceb598da4fae860dd837e1bdda838ed1f120097865"
+    },
+    "sound/xogre/xogidle1.wav": {
+     "bytes": 12894,
+     "sha256": "a08332f6f13e3b5c6b2f1ff84b1d6af740d7c47c369e93bb67f933041bec8399"
+    },
+    "sound/xogre/xogidle2.wav": {
+     "bytes": 11254,
+     "sha256": "0b3609995ae89dc2078ee24e79962b7560bcab2dd0b9b3a7b362d950955d710d"
+    },
+    "sound/xogre/xogpain1.wav": {
+     "bytes": 7898,
+     "sha256": "0f92efc994d4cdefaece746d03b74d980f5d693e518a9134f2bc2f43bb6cfe94"
+    },
+    "sound/xogre/xogwake.wav": {
+     "bytes": 19356,
+     "sha256": "e3d42db0b52479e21d58855760e9689c6a30a5337fc4209511d880bfbe43ddf7"
+    },
+    "sound/zomby/idle_w2.wav": {
+     "bytes": 17192,
+     "sha256": "ed9dc100255cc72c57505a4600875edf6668c2c7ced68854f7e83d8c0e1f6de0"
+    },
+    "sound/zomby/z_fall.wav": {
+     "bytes": 3062,
+     "sha256": "0ec168e08ca88f901f7fd02e58a8e981efe33d22be5e9768a7b4dcfffc49ce08"
+    },
+    "sound/zomby/z_gib.wav": {
+     "bytes": 16226,
+     "sha256": "0d7ac92106f50954044c3f7b48df087e2e678571c1e6c23f16cfead1d1b455a4"
+    },
+    "sound/zomby/z_hit.wav": {
+     "bytes": 6166,
+     "sha256": "b8e00283b9622e349478f169f3eccc16c7b101221e9f89a354b6d1de51a44bfd"
+    },
+    "sound/zomby/z_idle.wav": {
+     "bytes": 16734,
+     "sha256": "ca021c8a549717cd0a47b982ed8be6faa9ea43311f9c8866c8179a0fa13c243c"
+    },
+    "sound/zomby/z_idle1.wav": {
+     "bytes": 13244,
+     "sha256": "89aca032cfd88c52b13e91e50b3b1fae68936fd133d4e56aa66c8326989c601a"
+    },
+    "sound/zomby/z_miss.wav": {
+     "bytes": 10734,
+     "sha256": "010c17212ab6612d8f04a62c8884c9242ab3517e7919190041eed522ca90c481"
+    },
+    "sound/zomby/z_pain.wav": {
+     "bytes": 12218,
+     "sha256": "3340c9c704e46745600075b7331bacf8dfd12412756400b8ef0e2b7016060cf5"
+    },
+    "sound/zomby/z_pain1.wav": {
+     "bytes": 15374,
+     "sha256": "7dbf4797d16951ce8a25d8c467b291db01f674062a6f6841de2740dbc91a298c"
+    },
+    "sound/zomby/z_shot1.wav": {
+     "bytes": 3068,
+     "sha256": "341e107da7104e6f7be9a0771b28d342cb9ada44a70803564e3f949962ce40b5"
+    }
+   },
    "sha256": "019df411253909ca531e576ca399e33ce21384ef2eed456668ca6a04f49506fc",
    "timestamp": "2016-03-06T10:08:10.000Z"
   },

--- a/json/by-sha256/0f/0fc8f530297f27b1360f05ae59d8facd3a9aedf153ac4d02dc7af882f0b78e1e.json
+++ b/json/by-sha256/0f/0fc8f530297f27b1360f05ae59d8facd3a9aedf153ac4d02dc7af882f0b78e1e.json
@@ -534,16 +534,10322 @@
   },
   "tcj/pak0.pak": {
    "bytes": 254810855,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 94990,
+     "sha256": "1fddba1dadd3adef5e0f13d716e514c131455c51b26c2291f71dea0eada7b97e"
+    },
+    "effectinfo.txt": {
+     "bytes": 157535,
+     "sha256": "8dbc7cf30b0bef166f0ce58a59c0f3ce1dcadd9a13867f8430541793fd723cf8"
+    },
+    "effectvanilla.txt": {
+     "bytes": 4612,
+     "sha256": "efd47c12bf71b377f3e750f46d5e242b3337ece446ba9a44cc0750a9bbf9c758"
+    },
+    "gfx/ad_blank.lmp": {
+     "bytes": 584,
+     "sha256": "37b5a1e7d0b3882eb7504e3626f8040a19a6d403e0e761dccd65db935401144f"
+    },
+    "gfx/ad_ibar0a.lmp": {
+     "bytes": 2568,
+     "sha256": "7a66fbbaa742e59d3fdd939ce35befa0f633492482912f4fa91f16d0788276e6"
+    },
+    "gfx/ad_ibar0b.lmp": {
+     "bytes": 5128,
+     "sha256": "5a955a32f0227e4d3e90e908e650c7dc53138b5db2d5bcb3eb4a14fe5c568760"
+    },
+    "gfx/ad_ibar1a.lmp": {
+     "bytes": 4616,
+     "sha256": "eb1c6337becc5c245b873b3d9a6ba5e9c458147f48826a4580ea0ffdf57e9759"
+    },
+    "gfx/ad_ibar1b.lmp": {
+     "bytes": 3080,
+     "sha256": "34e3eec992a3f567d4ac83c98d5fc53ca0a90c02764d45a40eea08d2f94c733b"
+    },
+    "gfx/ad_ibar2a.lmp": {
+     "bytes": 4616,
+     "sha256": "eec2d035f2857fc03083ccf0384ac6446f71b1aa45ed0e2409b8d4ba42c135f6"
+    },
+    "gfx/ad_ibar2b.lmp": {
+     "bytes": 3080,
+     "sha256": "17c35d1d02833d1fe900b1c2beaf77ffe1948a3f17ae790e9f0da1c1057b460c"
+    },
+    "gfx/ad_ibar4a.lmp": {
+     "bytes": 3080,
+     "sha256": "2507c6ce0a53ed62ce73b1bb0ee7e76e9c245757dee54415aeef78767bace887"
+    },
+    "gfx/ad_ibar4b.lmp": {
+     "bytes": 3080,
+     "sha256": "d977ecb360eff9b19827e956d32687234bed64f830adc5e506334a597daa7eaa"
+    },
+    "gfx/ad_ibar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "9d0d2c1eb7e665d0a28130bed09fb8bd698a6a1b246842fa353e3b0e1f5b445d"
+    },
+    "gfx/ad_ibar5b.lmp": {
+     "bytes": 4616,
+     "sha256": "26902c5879207315a7b732e8799f95bdcd45801a8086a902371808a594fa5515"
+    },
+    "gfx/ad_ibar6a.lmp": {
+     "bytes": 7688,
+     "sha256": "cfcce1c48cda88ccd405b1398576476bae52b3cdf7154a0b902a47655dd282cd"
+    },
+    "gfx/ad_ibar6b.lmp": {
+     "bytes": 7688,
+     "sha256": "49487400a56db767d37656f8ccb9e1660f470d8f989619a86bec5c296dcb77f9"
+    },
+    "gfx/ad_ibar7a.lmp": {
+     "bytes": 6152,
+     "sha256": "0d4ababef9a115ca7f6739a01d288d237e22a859ee16c5682d97dcabc4d7aa0b"
+    },
+    "gfx/ad_ibar7b.lmp": {
+     "bytes": 5832,
+     "sha256": "f9292e8d1fff09bde28baf932f11617e27247d4e9af191b89c30811e92110bca"
+    },
+    "gfx/ad_ibar7c.lmp": {
+     "bytes": 4104,
+     "sha256": "0e77dc6602c4945d5d4ec2a12f8003173430945bf7891d979c3c80b0c9212b40"
+    },
+    "gfx/ad_ibar_cell1.lmp": {
+     "bytes": 392,
+     "sha256": "5a4409731e4302bca5245f385a1cab9b91e0a2677d52336bbe3650fdcf070b05"
+    },
+    "gfx/ad_ibar_cell2.lmp": {
+     "bytes": 72,
+     "sha256": "6a519b1e8eed1d7a5365231162fcf1beaf31a6fd1c39b07de09bb0e66dc38303"
+    },
+    "gfx/ad_ibar_nail1.lmp": {
+     "bytes": 392,
+     "sha256": "850189c70ac92f3e8ee79ed9ff6e31ee73d33b5616964461373b37e3a29e60b6"
+    },
+    "gfx/ad_ibar_nail2.lmp": {
+     "bytes": 72,
+     "sha256": "b36d5196c807c6325816db9efad9a16fd7e38433f277b0ad9e6d3551f95c0ceb"
+    },
+    "gfx/ad_ibar_rock1.lmp": {
+     "bytes": 392,
+     "sha256": "f74ce0037116022557ec3a50d368442e73cb48492990a07e93503ad9aeeaa225"
+    },
+    "gfx/ad_ibar_rock2.lmp": {
+     "bytes": 72,
+     "sha256": "081911a352b3d75a4be7812082eee782c41127e70bc4a06585b163d385230a65"
+    },
+    "gfx/ad_ibar_shell1.lmp": {
+     "bytes": 392,
+     "sha256": "733750fbc8235b236f7a2a4246d6112c0a09ce2f75529e359382e25dab92ee10"
+    },
+    "gfx/ad_ibar_shell2.lmp": {
+     "bytes": 72,
+     "sha256": "22fc2a46e85e76836fa38db9868820322833b45e0473407d69378dc09b43e9a5"
+    },
+    "gfx/ad_sbar0.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar1.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar4a.lmp": {
+     "bytes": 4616,
+     "sha256": "5ecbd1e480e4c04e2efe956dcd49e609f0c5a2038f03759b9af848b3cf7dd613"
+    },
+    "gfx/ad_sbar4b.lmp": {
+     "bytes": 4616,
+     "sha256": "8fdfe5e6ffba2c209386580adc196acce9d5601fb529f651267e7186610cc392"
+    },
+    "gfx/ad_sbar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "40c7f9e7ba975d500d3861d0c5a7e592da1ce09fdc31583488fd4c78d823e20e"
+    },
+    "gfx/ad_sbar5b.lmp": {
+     "bytes": 2312,
+     "sha256": "86ff0d9678a52e5428089afe0bb9cdddc9f7688798cee45a396e4d13bf00b60d"
+    },
+    "gfx/ad_sbar6.lmp": {
+     "bytes": 9992,
+     "sha256": "5b47dbc1ae645c429627f563355c43b1fb9145d195d02606d0a7a49791034a28"
+    },
+    "gfx/ad_sbar7a.lmp": {
+     "bytes": 3464,
+     "sha256": "8773683e2edb20dfdea61775d6f955a766a15b7b733ae07212dec922d853f6ba"
+    },
+    "gfx/ad_sbar7b.lmp": {
+     "bytes": 3528,
+     "sha256": "1103f097b9896700ef5a722df927cbe71c76531a09eda9e55e5702d3b4d3b370"
+    },
+    "gfx/ad_scorebar0.lmp": {
+     "bytes": 7688,
+     "sha256": "7c479c4969b9f437c57d710edbdd6b2ce1936aa95adb559c9dd3048680868cdb"
+    },
+    "gfx/adf_1.lmp": {
+     "bytes": 584,
+     "sha256": "5b1b35dc96ad9c2f62602caab6be13d8698fe6cc14865293d11c6b9eee64dd51"
+    },
+    "gfx/adf_2.lmp": {
+     "bytes": 584,
+     "sha256": "8cbc05801d49423bd5f14bd459e8ed5cff7841e7f2d5e44d0f4dfe0f0f7ee851"
+    },
+    "gfx/adf_3.lmp": {
+     "bytes": 584,
+     "sha256": "f0155a41ad9290c8df9fabe0faae6dde4d04772dd2a425653766ec36da76140f"
+    },
+    "gfx/adf_4.lmp": {
+     "bytes": 584,
+     "sha256": "d74c9370ce323ffdc9c3dd124dcbbf9c15fc94e58e20d15789975dd8701a74da"
+    },
+    "gfx/adf_5.lmp": {
+     "bytes": 584,
+     "sha256": "f97a78ede874ff45176e5bb85abdbed93e22dab28bc0965065927c7b215ea36f"
+    },
+    "gfx/adf_evil.lmp": {
+     "bytes": 584,
+     "sha256": "42445b083abae6e9f4ff009efd7a38d2ddd664ac5e47f97ad30c88a603c64c35"
+    },
+    "gfx/adf_evilinv.lmp": {
+     "bytes": 584,
+     "sha256": "ff0d8b9203d7cfae6d075ef5bfad60cdcf66b1e24bb6fd02be0cada1b7f1c82f"
+    },
+    "gfx/adf_evilpent.lmp": {
+     "bytes": 584,
+     "sha256": "0b0029bc964ed68f1b46ccf0b4bd5e527e33e76c0904a1d06e623c47ca589e56"
+    },
+    "gfx/adf_evilquad.lmp": {
+     "bytes": 584,
+     "sha256": "a511796cca84df8149ea6d3d280880e425fdd486315159462168d32f06a17822"
+    },
+    "gfx/adf_inv2.lmp": {
+     "bytes": 584,
+     "sha256": "a6caf84d4e2c125e80aefb51aaa1af707ccf689e641141dd3736f101a66c8fa0"
+    },
+    "gfx/adf_invis.lmp": {
+     "bytes": 584,
+     "sha256": "70117297f381fd1778e5d26e5b832af86c6013ca9a55632c24c057e0aaa1e48f"
+    },
+    "gfx/adf_invul1.lmp": {
+     "bytes": 584,
+     "sha256": "453b67ccc01b32101e1051a9407b84b5c93416ae30c3b3200e25b96868c3f6e5"
+    },
+    "gfx/adf_invul2.lmp": {
+     "bytes": 584,
+     "sha256": "c70f600538aa1d1cc121ea76602e564d0af5ce5ea67a2c1ba01ac5fe44439bd4"
+    },
+    "gfx/adf_p1.lmp": {
+     "bytes": 584,
+     "sha256": "f6da35fd9699239c060f034738615ecead6111294a419a82e503bdbdd9ed46b1"
+    },
+    "gfx/adf_p2.lmp": {
+     "bytes": 584,
+     "sha256": "431539dd9656e09c6d4007c86bad37c30447e596575d803619b14371329f9acb"
+    },
+    "gfx/adf_p3.lmp": {
+     "bytes": 584,
+     "sha256": "b832a2d2143805f8701eec7eec465d67fa692e2e87714e87fa3ac3a2c2682659"
+    },
+    "gfx/adf_p4.lmp": {
+     "bytes": 584,
+     "sha256": "40f6d70d3ebf248c1c38e90b95cec42516b3a61fd17bd866df964af8e657487f"
+    },
+    "gfx/adf_p5.lmp": {
+     "bytes": 584,
+     "sha256": "d7d4768f7324d1eca2b8cb95fd250d8c6065dcfc5c392c6f2bc6adc8c2a7579a"
+    },
+    "gfx/adf_quad.lmp": {
+     "bytes": 584,
+     "sha256": "da9a83f464049832cd049205a22d832a228b00cbd0d1e7e24d347d5ed34c4ffb"
+    },
+    "gfx/adib_atank.lmp": {
+     "bytes": 264,
+     "sha256": "8d963c818c0554d73d14b251eeed0321cf854777f29eddf5a82ee3fb3fde8035"
+    },
+    "gfx/adib_axe1.lmp": {
+     "bytes": 264,
+     "sha256": "90b6817aa64570e9bfc36a13e6dd1930e81468f931ceac9f2ae3790f99f2dca2"
+    },
+    "gfx/adib_axe2.lmp": {
+     "bytes": 264,
+     "sha256": "2b0821038185e41c711e399dcfff37fd54aa8f7473ba81754c379fae558a5a1d"
+    },
+    "gfx/adib_bbelt.lmp": {
+     "bytes": 264,
+     "sha256": "8b50ea739ca8ab52baefe65f90ea5943fcc4f05b63b214a36b3ae6fa4feb55a8"
+    },
+    "gfx/adib_ckey1.lmp": {
+     "bytes": 136,
+     "sha256": "8525e145fdc72947ac6d4599ae0304b84793475d44f0113c925905d715c2da8e"
+    },
+    "gfx/adib_ckey10.lmp": {
+     "bytes": 136,
+     "sha256": "a2e14b68c10109e48e86bd095775beb68f03640dfdb12d1c28b6d32abd1fa329"
+    },
+    "gfx/adib_ckey11.lmp": {
+     "bytes": 136,
+     "sha256": "2b9191d85075d6a6c06d8b295c48546ecc0bd1c91a860308f6f953dcf324604c"
+    },
+    "gfx/adib_ckey12.lmp": {
+     "bytes": 136,
+     "sha256": "9b04f101468d96f4c39d97da0be44f7152179e4a8d6a05762ca693c9f84db317"
+    },
+    "gfx/adib_ckey13.lmp": {
+     "bytes": 136,
+     "sha256": "35fa377dbf162d691de012a61458b5ec29c28b776cd3ee0e0f9ab0ad57b67c8f"
+    },
+    "gfx/adib_ckey14.lmp": {
+     "bytes": 136,
+     "sha256": "ea6b831467c97fb0ba18d97a549c54304b133830e1567ae300e83514bdbb2919"
+    },
+    "gfx/adib_ckey2.lmp": {
+     "bytes": 136,
+     "sha256": "5c80cec0c7808ed141fff4f6863eccfa71b06a7405e871c75912d5d065b4ff21"
+    },
+    "gfx/adib_ckey3.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adib_ckey4.lmp": {
+     "bytes": 136,
+     "sha256": "51ea09fa8db26de3ce6ea6c1a5abecf4c31c3877ab6c508811ea9b271f40f1fc"
+    },
+    "gfx/adib_ckey5.lmp": {
+     "bytes": 136,
+     "sha256": "e03ed662e981530264f6dcf6f6dda91fd8406c0941d0f7c4370a89e0c4f467bc"
+    },
+    "gfx/adib_ckey6.lmp": {
+     "bytes": 136,
+     "sha256": "6f4f61addc77e3492c08cd382291eaf3f8c28a7499137591dcd2c6706bb1ec57"
+    },
+    "gfx/adib_ckey7.lmp": {
+     "bytes": 136,
+     "sha256": "38c3473948f4769e4309bdbb390afd0663fc093f1f76c9fbf10d818c6f89c72b"
+    },
+    "gfx/adib_ckey8.lmp": {
+     "bytes": 136,
+     "sha256": "d0c43a81abfb623b7c3392a07b484b6bf9137fede67d78dc67864848ecbc1c12"
+    },
+    "gfx/adib_ckey9.lmp": {
+     "bytes": 136,
+     "sha256": "042cdb7aef3e06a5679158b4f33fc66ca2d97dd6cf9e7e2657b1e85e444ed006"
+    },
+    "gfx/adib_invis.lmp": {
+     "bytes": 264,
+     "sha256": "f4f1be9a2ef88b75fd9971d72796a35f7de1ed04fc2cfc3a4c35225976f21eca"
+    },
+    "gfx/adib_invuln.lmp": {
+     "bytes": 264,
+     "sha256": "87b8312e4d7fc20d6ae9df6d1f8cb616392f3a2adaf7208dd2372eefc19888a3"
+    },
+    "gfx/adib_jboots.lmp": {
+     "bytes": 264,
+     "sha256": "206ad9d67636b46418e6afa6b6e75a12df76bd3ad84b0178e86b8d140b9c3afc"
+    },
+    "gfx/adib_lshield.lmp": {
+     "bytes": 264,
+     "sha256": "79a78f4402a301d381bef260b895ba56757b779ae89b7ae5a49f8146f2a7a54a"
+    },
+    "gfx/adib_nailp.lmp": {
+     "bytes": 264,
+     "sha256": "fe59667c80612fd2e7f5d95dd0a208f3909d93eeaaab7e4580405fe153469fde"
+    },
+    "gfx/adib_quad.lmp": {
+     "bytes": 264,
+     "sha256": "915832c8c822daf8cfa1c5d88548f24da7d182be6746b265e7ae6e1d735082cd"
+    },
+    "gfx/adib_sharp.lmp": {
+     "bytes": 264,
+     "sha256": "18987634aa43dced4e06e1d5a9a3f9b1f51c7738f59fae64168bd94ab9cd6198"
+    },
+    "gfx/adib_sigil1.lmp": {
+     "bytes": 136,
+     "sha256": "34b11b26dcdf5b91f3e6e08bbe6edb83f62ba054e9eef28459cef09b742e1456"
+    },
+    "gfx/adib_sigil10.lmp": {
+     "bytes": 136,
+     "sha256": "af31a42ef81449aa656327dfe00fc1e1d744f90212ac228bd05a6d79f5048683"
+    },
+    "gfx/adib_sigil11.lmp": {
+     "bytes": 136,
+     "sha256": "9fb90ba79d5c34e2b0afdbcec8bc528fd7d3d8f2645191d95a67a65e242bd3c6"
+    },
+    "gfx/adib_sigil12.lmp": {
+     "bytes": 136,
+     "sha256": "d7c9c3c7c1167ea0791b2790d678d6bd25144adcba79d6f7c5d93302fc28119d"
+    },
+    "gfx/adib_sigil13.lmp": {
+     "bytes": 136,
+     "sha256": "0003389cd694c55fa36f1d18d38261d279c5c7ef23dd5d41c3852ad8c95e5a49"
+    },
+    "gfx/adib_sigil14.lmp": {
+     "bytes": 136,
+     "sha256": "8ac47a2e1d45d94fb1f222811320c5f07e39e65698b7436515afa29de6e1204e"
+    },
+    "gfx/adib_sigil15.lmp": {
+     "bytes": 136,
+     "sha256": "153627403fd3e3856aa34e8740fdebb5ddb26e201cd590dd76cbfc12c36e49c6"
+    },
+    "gfx/adib_sigil16.lmp": {
+     "bytes": 136,
+     "sha256": "fa95a1a372ce30516252fff8dbcda8f8f55e3cc558b4a1e7015b79838ff0cda1"
+    },
+    "gfx/adib_sigil2.lmp": {
+     "bytes": 136,
+     "sha256": "0a0c22f027e980014a246daa629b6f84f425ccfd828f75a93ef777d9616c9191"
+    },
+    "gfx/adib_sigil3.lmp": {
+     "bytes": 136,
+     "sha256": "9e5daafbe4cc032824f732ebdac3897d804df43efaff9901c315ae661af8cd31"
+    },
+    "gfx/adib_sigil4.lmp": {
+     "bytes": 136,
+     "sha256": "fd1d3791d53ab40881a2d86a0bc67b3b532ef10b201a166a3937b105c63e3c9b"
+    },
+    "gfx/adib_sigil5.lmp": {
+     "bytes": 136,
+     "sha256": "947d5088b18a12d06a93fe66a0500e5b6ae93e04cebc748858139d569693d42d"
+    },
+    "gfx/adib_sigil6.lmp": {
+     "bytes": 136,
+     "sha256": "5a2356a7479f887b20f10e03ee2f42478bdfa75febe2d802b3dbfcd25b39d744"
+    },
+    "gfx/adib_sigil7.lmp": {
+     "bytes": 136,
+     "sha256": "507011b2a191e096fadcd678590636e4033de2ffcf35cef31785539bf3f9fb4f"
+    },
+    "gfx/adib_sigil8.lmp": {
+     "bytes": 136,
+     "sha256": "2a49a4653b2ed11353c6aaca950420c38c8e7b2aa8cc82ecd746a4e73fb7aa00"
+    },
+    "gfx/adib_sigil9.lmp": {
+     "bytes": 136,
+     "sha256": "df168192d5c065c7247cff03b10da51eba431bdc4f76d2c913646bb23084d639"
+    },
+    "gfx/adib_suit.lmp": {
+     "bytes": 264,
+     "sha256": "030bf62f7f45667310f1a74bd88881e2aa8d6c7ba5355bda4bc7c87d64a3d082"
+    },
+    "gfx/adn_0.lmp": {
+     "bytes": 584,
+     "sha256": "0895fe0acba04a4e17ef64fe62c56765c4fef5933c4af09dfcb242e984e8d163"
+    },
+    "gfx/adn_1.lmp": {
+     "bytes": 584,
+     "sha256": "fc0391c514808f9cb54e0bb0bbd63edccb0bea66a7620b81d04497edd099f5b1"
+    },
+    "gfx/adn_2.lmp": {
+     "bytes": 584,
+     "sha256": "d70ca75a162f7203067f314eee6460dc9180383e5bd1a19c69a984d8f4c699ae"
+    },
+    "gfx/adn_3.lmp": {
+     "bytes": 584,
+     "sha256": "40fbf34b86a4e5d264fac3c875ad74a52b62f5868d01a7580107a52998cbe4ac"
+    },
+    "gfx/adn_4.lmp": {
+     "bytes": 584,
+     "sha256": "5c9f781b8fb46cff0bb69db9817936be10cc4e34d677a5a49f117baa1d414aef"
+    },
+    "gfx/adn_5.lmp": {
+     "bytes": 584,
+     "sha256": "f2b1a90d1f4e1e3c6eb04dd1d87f084b2bc932b76b6eabcc5a4ee12db939971e"
+    },
+    "gfx/adn_6.lmp": {
+     "bytes": 584,
+     "sha256": "ec90a75650252feb45f325815498caf518058d141c7660e594397e0e05e35cfc"
+    },
+    "gfx/adn_7.lmp": {
+     "bytes": 584,
+     "sha256": "c292389fee1e91c2c4178099a8c9b2ad193f74346adec126ae10a4383f96c6de"
+    },
+    "gfx/adn_8.lmp": {
+     "bytes": 584,
+     "sha256": "4df870d66977eddbb7c4f87ffe4b94a032f2f13ad8fa38a98fde607d7aa7b06d"
+    },
+    "gfx/adn_9.lmp": {
+     "bytes": 584,
+     "sha256": "fd7f393a0fea9c0bc9fec90492a8f074a75275fde2ce211379b098176729622d"
+    },
+    "gfx/adn_a0.lmp": {
+     "bytes": 584,
+     "sha256": "7221532ee9af2c3a2fa3d19e4ccae78458d7a1f3025627e6da45dcb4aefd6820"
+    },
+    "gfx/adn_a1.lmp": {
+     "bytes": 584,
+     "sha256": "8f594ea65757fdaa62105b5eb68d4519b96b93e12dba110a723c4bf99470d408"
+    },
+    "gfx/adn_a2.lmp": {
+     "bytes": 584,
+     "sha256": "738cd71a2344da4b1733b639e6cdef1fb412104c388d2edee0b4539655ed9fec"
+    },
+    "gfx/adn_a3.lmp": {
+     "bytes": 584,
+     "sha256": "00c7040d33a445656f33c373077564116a764142f4625b5df7fae6516817f893"
+    },
+    "gfx/adn_a4.lmp": {
+     "bytes": 584,
+     "sha256": "7fbde831e189692c1c5d048873e7098a7d017ff7e22fc57a724a2c2fcbcc8db4"
+    },
+    "gfx/adn_a5.lmp": {
+     "bytes": 584,
+     "sha256": "ecb1a8036b03abc3c95a145081762ebf8b04516bc438053e570b989195687615"
+    },
+    "gfx/adn_a6.lmp": {
+     "bytes": 584,
+     "sha256": "8495247be5584836815824b182f448348d3de924236e254c5ebffd8132a1b7ae"
+    },
+    "gfx/adn_a7.lmp": {
+     "bytes": 584,
+     "sha256": "76a1b4a37c14cf3c53047129e14bb3f2217142ca5405ebceb95b892bed49cb77"
+    },
+    "gfx/adn_a8.lmp": {
+     "bytes": 584,
+     "sha256": "943ae9da4710dfb8a8b7b22eb8ecc6131e7c4586f279701323997f931bdd486f"
+    },
+    "gfx/adn_a9.lmp": {
+     "bytes": 584,
+     "sha256": "4381c6e590644e7c7e3d64e89adb1d438802e1a81380de8f08b31669780f07ed"
+    },
+    "gfx/adn_aminus.lmp": {
+     "bytes": 584,
+     "sha256": "903c3e6081e934fb4a9b0ae4564265b0339d2289fea17720c7bac77d00155258"
+    },
+    "gfx/adn_colon.lmp": {
+     "bytes": 392,
+     "sha256": "a06510a33f355c24fc16d7591323523f13920ae6fa903c3155b5edef9e4059a9"
+    },
+    "gfx/adn_minus.lmp": {
+     "bytes": 584,
+     "sha256": "1e04325b97c5052e64187e0882b8c2f87473bd66f3e70b5a419d983b0a62ed81"
+    },
+    "gfx/adn_s0.lmp": {
+     "bytes": 264,
+     "sha256": "6a5cac8d7c8076aa42055c3b64f3fde4b1e7750b2bb143b12af07dec892c9ccc"
+    },
+    "gfx/adn_s1.lmp": {
+     "bytes": 264,
+     "sha256": "723ec3e0b6225419fa5fb8010896674d91d19eeafd8e2c9bbbec2d23fbb85792"
+    },
+    "gfx/adn_s2.lmp": {
+     "bytes": 264,
+     "sha256": "cff9bff09933ccbf43a1419d6f566807c2aee9a4aca448a86bf261394b3ca7b3"
+    },
+    "gfx/adn_s3.lmp": {
+     "bytes": 264,
+     "sha256": "8d7cf6b3f2db7463e962fd7b70b2ef7c36b0882b1e80d90b02fa1a609d09513f"
+    },
+    "gfx/adn_s4.lmp": {
+     "bytes": 264,
+     "sha256": "2bc5fa316cc366f4d1a4f1831ac3b8ced65caf89157e796ff5d673fa3955ac1c"
+    },
+    "gfx/adn_s5.lmp": {
+     "bytes": 264,
+     "sha256": "98cbff3f1b98977b8fc19523fc2e644e763fc52dba708fc5024dfbeaa1f00d6d"
+    },
+    "gfx/adn_s6.lmp": {
+     "bytes": 264,
+     "sha256": "1578d854415aaf5b68a25a0fb37057b019d12055b61c3d7402eae811a9359e1f"
+    },
+    "gfx/adn_s7.lmp": {
+     "bytes": 264,
+     "sha256": "609059534b0a59c9d5ab1180f25f0b2a952719a0ccade29d05559dfc6223f1d9"
+    },
+    "gfx/adn_s8.lmp": {
+     "bytes": 264,
+     "sha256": "7327dd480225a52c642320336ade17100228d2c1ade5f1b640cbff18e37fbe2d"
+    },
+    "gfx/adn_s9.lmp": {
+     "bytes": 264,
+     "sha256": "b8ad416098543b34c286565e3a0d7756eea7ab18c8b50145e7ddbc45fd28851a"
+    },
+    "gfx/adn_slash.lmp": {
+     "bytes": 392,
+     "sha256": "2500358f0d4bf9856c04b7be940ab41012faad597005837c99dfef93da1f3ca6"
+    },
+    "gfx/adsb_armor0.lmp": {
+     "bytes": 584,
+     "sha256": "01228bb8947103a70c9f536b168eefacda9dc5a08e1fa64ee963be44d4a9af9c"
+    },
+    "gfx/adsb_armor1.lmp": {
+     "bytes": 584,
+     "sha256": "85956c2a17460229a374e8a6e1cf22ad4ff663929dba06c9daa9d95d1582ba53"
+    },
+    "gfx/adsb_armor2.lmp": {
+     "bytes": 584,
+     "sha256": "e8e64ea8d90241677315bb9a9e25714856827642a0e331077dc6fa2b827036fc"
+    },
+    "gfx/adsb_armor3.lmp": {
+     "bytes": 584,
+     "sha256": "db6523d7c99bb15c14ad9fd1d665a24e4eab985dfa095d316f20fe5e96e9c320"
+    },
+    "gfx/adsb_axe1.lmp": {
+     "bytes": 584,
+     "sha256": "ebcafdd02b84a9bd21658a349205a09e5e242fa39013207fe6aab9697df2884f"
+    },
+    "gfx/adsb_axe2.lmp": {
+     "bytes": 584,
+     "sha256": "12caae98c176f1176a5222f7730709dcb9164a5db63984fe6f8982e8b17915e6"
+    },
+    "gfx/adsb_cells.lmp": {
+     "bytes": 584,
+     "sha256": "08da91ae0bca3d7bd546d92f7688061b7fbc8d86b84e309510ee3feeb3f63e92"
+    },
+    "gfx/adsb_key0.lmp": {
+     "bytes": 392,
+     "sha256": "49e4cda132ff7237a4b7244892fa1e059ff2d77698ec855cb4c02e08867899e2"
+    },
+    "gfx/adsb_key1.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adsb_key2.lmp": {
+     "bytes": 136,
+     "sha256": "46a6561c191c47e9445ef85c2bebdc881f330ca49afe562d7bb2a59c5442c73e"
+    },
+    "gfx/adsb_nails.lmp": {
+     "bytes": 584,
+     "sha256": "77fb4c0c61d824fafba54e91d6b23e702ae54565d7708ee0e404aff804555b73"
+    },
+    "gfx/adsb_pent.lmp": {
+     "bytes": 584,
+     "sha256": "8066cd0ef3d3ed9add280937fa51d6dd13a7eaf606ad0567366e86c51ddb7d62"
+    },
+    "gfx/adsb_rocks.lmp": {
+     "bytes": 584,
+     "sha256": "2e79b7c3e3fb6b4118a3ddedd7d9a1186f12c2df2efdbcf5300cacc51fe64744"
+    },
+    "gfx/adsb_shells.lmp": {
+     "bytes": 584,
+     "sha256": "f185cb1b1a48a8499d110e6371f2bb102ad89fda9875a267adcc6f3c8a5e613c"
+    },
+    "gfx/adw_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "ee32ef4cb14c02b9516f245fe9eae50021962ebdee3ef843076b9dbe20f038fb"
+    },
+    "gfx/adw_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "0f8884976f5ef05d5c3d7ab7c7b22bddeba9ee922664d23c6dfe835c5673ad9f"
+    },
+    "gfx/adw_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "2c1f7b1b0a5c27da9f01c84a38571901fb3636a04485102f44cb19d715e7f627"
+    },
+    "gfx/adw_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "a9802bea98b2fb57ab97784caeebf1ab2312fab73146503459c7c8021249ccef"
+    },
+    "gfx/adw_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "0c92aaf91afe914f4d06e5d2fa91bf926a0b43294d49021755b93c049e15a99d"
+    },
+    "gfx/adw_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "155eeca532e2f6d08b7575697020eebd4f492987392c68f09c66bb6522c0336b"
+    },
+    "gfx/adw_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "02d55707616bd6eae995c93d5eca3e788f227811001e2e8137c07cafe85409a4"
+    },
+    "gfx/adw_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "0d4cba204d9ea74665e164d46ead9167095cceb64a795861dfb21fcfd2b3e9ac"
+    },
+    "gfx/adw_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "3d354bd9336125ea758f2b5b56b1ecdf2a2afea4e8bb8d6edeb058448f9627e7"
+    },
+    "gfx/adws_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "457f6682e5a8b3d7b1075148c05093df1ec96c59e85057dfca80f66f4ad25815"
+    },
+    "gfx/adws_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "127d3759679f91a8633557a27abcb8425b3f8fd8b9888e029f761cff9fa20e47"
+    },
+    "gfx/adws_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd1e14b26cfa3915c23502e22413328d37749e0a77ac75508238fbaa375c7555"
+    },
+    "gfx/adws_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "424a425e24162a3a1a23e7308b8b46f4d25f1c9f11ac3b427117c596dafeb006"
+    },
+    "gfx/adws_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "41dc9eb1fb806500b41d832786a0bce0c6863c6caa3bcc7491892e25d04a81d4"
+    },
+    "gfx/adws_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "30a22fc8975b5a696ff31e859290fd780553f1857e424b1d5ecfa057277d155a"
+    },
+    "gfx/adws_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "50c5e9c358023dbbb65cc79346d99af6797af556faded31df95e2b7191aeb3f0"
+    },
+    "gfx/adws_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "94cef7136e718532b4d00b9ed8804da60be979206bde676a328270321286851a"
+    },
+    "gfx/adws_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "8259db2f3f7ddd075e6192d6e0581a2321c108232d67980fab85059fcbfe47df"
+    },
+    "gfx/adx1_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx1_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "e4d0714014c5a1c0d9874bf1ce2c0232352be1e0c90ffe927dc2d86d448f7e47"
+    },
+    "gfx/adx1_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx1_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "9da68076978e9bc4d35e2b40e972c578e0839c379c86d44bf15c033f164fc9e9"
+    },
+    "gfx/adx1_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx1_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx1_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx1_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx1_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "9341894f953061deffb42e12370fd05b7f8008e2a1caee149630a8bcd40fac10"
+    },
+    "gfx/adx2_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "c5f2e4352837eca0a67b1fe6eb5d437672f365efffd7c297848dcdbfca6fea7f"
+    },
+    "gfx/adx2_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "b627ea70b6a7a5debddd4710f31ca137c3baf01dd6109cc2cee7da968a020049"
+    },
+    "gfx/adx2_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd7a15d826f6565c97f638ff541d76e409b9cc69febbb78906c5ddbbad2e0f02"
+    },
+    "gfx/adx2_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "8239bfd1d494fae52f97d5f620bf6c9cace057a27975cddf7d0f557b5a797cb6"
+    },
+    "gfx/adx2_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "6adf5220508ec39cedaf8cc8208c8b7bff5f44f18401bc5ee7a39e91419376ab"
+    },
+    "gfx/adx2_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "f300febb1aad7dc16d592f1e1aef2cc5a8870ad08ebbb2bc15b43009122259ae"
+    },
+    "gfx/adx2_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "e15bf6fb56eca5640d521dfdbe0c20f9e3ce6fb6fc7a2e39922f0fc8cfc7d002"
+    },
+    "gfx/adx2_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "c781852ce141a1d5fb84451e1bef2b021c937d0658d7ca8f8b2a1d5cc3737a66"
+    },
+    "gfx/adx2_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "aaaac2a8b4dfaae3d02705c2fbffa38621187cc28f4246a591f38b2bec79f693"
+    },
+    "gfx/adx3_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "20209da4ccb0dbeffc6520aee7958b33bcfa728ed376b1f5f987c8305fb70d3e"
+    },
+    "gfx/adx3_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "eb13bcc843d95abf3c90c140c95aa95803a42a6afeb100e11a5e0d80c72caf8b"
+    },
+    "gfx/adx3_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "483f85f7e5a0e881f6511f2b16a25d1945dcc2fa5365e4417cb58ec6a87f062d"
+    },
+    "gfx/adx3_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5e1f15716b826a8a25e61415e675a6c94888ae4030462e1190653c4d93768743"
+    },
+    "gfx/adx3_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "99d58b01e578c88924699f85614b021dcc5ce32798c96680fb5120e8d58837c2"
+    },
+    "gfx/adx3_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "4eae7b9a7119e883d3b6d3b8b336398beca8b7cf4ed2b9b498e13d90b7743ccc"
+    },
+    "gfx/adx3_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "8568e0c106e3155b9cef3dc3bd55ce821ed151560abab4080fcf6534850b153c"
+    },
+    "gfx/adx3_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "b8764c3198aa863d67e4f7c3c19db89aab6aa4f4076abe83d50b88710eb85446"
+    },
+    "gfx/adx3_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "fbb92c8a0853070604e84da82a5232c93747f3571ba05e88ecb4e59649125838"
+    },
+    "gfx/adx4_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "4e8da401756d091a913d4a0a5618aee7eeddad1bcd8c78774bc229195bd96943"
+    },
+    "gfx/adx4_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "c68cec0c6064b7ceaad60028ed1e8f7834a6484d9fde249649d7b94addc6544a"
+    },
+    "gfx/adx4_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "386eadd2ee00c5a53179729c2b23cf56f0629c3e7ad8e5b3a739f1fd8d489d34"
+    },
+    "gfx/adx4_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5179dcb2b82032c81d02dfb35d130ed8196d5b726c7a8265c2823c3f2edde2a8"
+    },
+    "gfx/adx4_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1156e8a090be24e24605153b059646bd7d8b9d33c6e175bc9b05843eb626ce38"
+    },
+    "gfx/adx4_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "8881a5fe764d90c1113e1df7215c6520988c23601a969ea3e7b9abf8d7d4ef0c"
+    },
+    "gfx/adx4_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "7b55d6f2071d101db2a87c5958aadcdcf618f8f0eab53b19691125c1e8b6d8ad"
+    },
+    "gfx/adx4_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "199a6be6977bbebfe0aac0005466b10bfcdd9d26a764d18e56e28ee6f6f8f5ee"
+    },
+    "gfx/adx4_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "924cd9a6ac66660db99821b558a21e8dd0b02e85bb2a5415c2e24daace249663"
+    },
+    "gfx/adx5_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx5_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "9405034666f0f1247a58a97b86e5c451f0b2a315501389f43043da55493db8de"
+    },
+    "gfx/adx5_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx5_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "6c529185a7cc6dc8d066080c4246f80c7bf1fd0ea808fc0be5be63c8cff7c2b3"
+    },
+    "gfx/adx5_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx5_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx5_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx5_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx5_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "bb8e065bc9d9935d7fab8e9d0d0554948e2ab2622a54e86f70c1d8c3c9a0f178"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "b941e3ec692b990d1dbe0fd69c1e043b9d504374d791c8c981cb091324072826"
+    },
+    "gfx/community.lmp": {
+     "bytes": 256,
+     "sha256": "7d425f7678b30e94f816c93391c3322ed354c9657ef2563c964b2abb0d57d933"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4424,
+     "sha256": "b4554a7ef6de5831198626fef9431582d3c17ed56c55853f1ce979be31df8dcd"
+    },
+    "gfx/conchars.lmp": {
+     "bytes": 16392,
+     "sha256": "045ea49c02bc0e51336e84fb19f4c445ece3c0d8c6ec4aba3cac0fcbf4306c15"
+    },
+    "gfx/conchars.png": {
+     "bytes": 14283,
+     "sha256": "1b63b3d252a0d234553153910c6d5384de0bbe050f095ebe00d253ffab2db8b9"
+    },
+    "gfx/conchars.tga": {
+     "bytes": 65580,
+     "sha256": "6dbfcc084e12e7c053c49f257f0a2276014a46ee92d194008893a39416e9e486"
+    },
+    "gfx/env/adgreenskybk.tga": {
+     "bytes": 1520289,
+     "sha256": "6a7fa2cdc97237658a3f2c73a8a5d879feadf4a31e84fb8585aeba96f3f8fb61"
+    },
+    "gfx/env/adgreenskydn.tga": {
+     "bytes": 1565620,
+     "sha256": "d4fabe617a431169df1bbc37e48404fc34718a1bbf5a1ee45d5b3a0ddda5cc6c"
+    },
+    "gfx/env/adgreenskyft.tga": {
+     "bytes": 1704063,
+     "sha256": "c6cfbbd8b09846eaea719a5e65744cdd4fddced0c277f4584c743f2639882d50"
+    },
+    "gfx/env/adgreenskylf.tga": {
+     "bytes": 1576943,
+     "sha256": "c83f24917ccb67af83602236d03e57096f73b36b7fc64da6206afe989944b4a4"
+    },
+    "gfx/env/adgreenskyrt.tga": {
+     "bytes": 1706213,
+     "sha256": "7b85287d2ce5e4d3a9ce63a560183086e812ceca9232d07eb61f63a24d678e10"
+    },
+    "gfx/env/adgreenskyup.tga": {
+     "bytes": 1798684,
+     "sha256": "703e4449b5b9ff967610dbc81d7e27c089788927d82fdb31267490cfb30ed0e3"
+    },
+    "gfx/env/asap_bk.tga": {
+     "bytes": 786476,
+     "sha256": "9f6daf48061bdc132ec28062c494d4a6abe2eeda2c86b575ac7df472a97b2c80"
+    },
+    "gfx/env/asap_dn.tga": {
+     "bytes": 786476,
+     "sha256": "a8aa31d47f7537150c1023713588b87cceff0072036ea64c895129fccfd9fa9a"
+    },
+    "gfx/env/asap_ft.tga": {
+     "bytes": 786476,
+     "sha256": "067cca994d96dcc95903ea1d3c023c479d66a655b2d3412116d462dff4e155d7"
+    },
+    "gfx/env/asap_lf.tga": {
+     "bytes": 786476,
+     "sha256": "761640856a2500019db4c3fae214fe2043fbc0edffa3e6c508d964a86b98ecf5"
+    },
+    "gfx/env/asap_rt.tga": {
+     "bytes": 786476,
+     "sha256": "08d03cf9826300c6d283028f60663f5bd3f6564a7deb5e15078440e18e1433cb"
+    },
+    "gfx/env/asap_up.tga": {
+     "bytes": 786476,
+     "sha256": "d98b750d0908addc2b0c9d513bc0bfc5d28935c9536f437cfcc3796fc0f5ce82"
+    },
+    "gfx/env/black_bk.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_dn.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_ft.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_lf.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_rt.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_up.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/interstellar_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "861352b7f4dc030af28b483d09ad88b4cbb7b8e23e5cd3cf512d2feae9640b22"
+    },
+    "gfx/env/interstellar_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "b16b2e272b7e74513f6a1961d68270dd82fa0667d6ea267a2d22c45a2bdc2fcc"
+    },
+    "gfx/env/interstellar_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "11730f0982cbadc7691ea38e57510b2b7e77484e108d591aece8f970cfdca08f"
+    },
+    "gfx/env/interstellar_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "5bf0a5999e7ea85e68291ab7b36d7f6be5104f8932a2fe46d257484e84dab4fc"
+    },
+    "gfx/env/interstellar_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "051204c9fb8a430c17fb337d84132e0d7058b88f070e457278be99d78a73e5c2"
+    },
+    "gfx/env/interstellar_up.tga": {
+     "bytes": 3145772,
+     "sha256": "d8b19a66cb5dad2f34c9059860ac24a8632ba5575ac06ca3076d57a70c47b5b0"
+    },
+    "gfx/env/l_swampn_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b83c2aeccb2ec2b6a7e7de05e4eb1f120437c575769b93533708093be6d7acb"
+    },
+    "gfx/env/l_swampn_dn.tga": {
+     "bytes": 3146268,
+     "sha256": "64ea5b085c2758138760da154c77e3c90eb0831c68e75bac4c03cd03ae2e28c1"
+    },
+    "gfx/env/l_swampn_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "f8149a22f17e241f3cc50ddc2587b3d8d6e72bb26f7a47d5045b08ed436863af"
+    },
+    "gfx/env/l_swampn_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "fdf2a49932e8ee9c06b9a50fa6dcff3d29bdde55aa209d1658346cf236ca1dd8"
+    },
+    "gfx/env/l_swampn_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "a2c65a9eafab955cfe898aa28e3563714354a08725068df84f390eebfc6ca20d"
+    },
+    "gfx/env/l_swampn_up.tga": {
+     "bytes": 3146269,
+     "sha256": "aa5c65d4c106b17e695629023db1e6b304ec5b4f15e646a1a94b38c47ef9017e"
+    },
+    "gfx/env/moonhigh_bk.tga": {
+     "bytes": 1048620,
+     "sha256": "5f361bf5a352c1df5a6caef9cf42bd35fed8406c6949af480b0425c193c18b3a"
+    },
+    "gfx/env/moonhigh_dn.tga": {
+     "bytes": 1048620,
+     "sha256": "02e2b36863c1181a85aa675c53fc14a301f38dc6e0c6735098bb6d8723af02b3"
+    },
+    "gfx/env/moonhigh_ft.tga": {
+     "bytes": 1048620,
+     "sha256": "3158735bdd6f4f467a5b29639aa4f622d1136ea463967684b739b0002bec6526"
+    },
+    "gfx/env/moonhigh_lf.tga": {
+     "bytes": 1048620,
+     "sha256": "5cdaabd99655152689e40832643690d7b1c5f8e414f3126a7c0c9224f2250704"
+    },
+    "gfx/env/moonhigh_rt.tga": {
+     "bytes": 1048620,
+     "sha256": "e08a374ac19c8b8cffa6c939515cde9570b44bbc044c12d06b0c5d94aa7469bc"
+    },
+    "gfx/env/moonhigh_up.tga": {
+     "bytes": 1048620,
+     "sha256": "c0465fd6a0b069e5ff78f3e561084bf3e23b796cac9b5214a6cd4045310d36fe"
+    },
+    "gfx/env/moonrise_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b4e85116e3999d5cded25ca0a5d6fb9c297b3d69749a63daf5af6c37fe21959"
+    },
+    "gfx/env/moonrise_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a7be41496d25bc9e505b959b08a950c1bb61acc6c8c44ec4e1dd428faeac4ccd"
+    },
+    "gfx/env/moonrise_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "7381c46aa4f5c916f3bc8f82a442a4582834563c0bb0127580053bb274609180"
+    },
+    "gfx/env/moonrise_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "871df5eed200970b8c3246ca10a039f5915c95e8f48bf0692fc22f2f7e5450cd"
+    },
+    "gfx/env/moonrise_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "2cc00bb935ee2f4019f4d99170d38ef3f51c72ff80150cd74911b1038a0cb269"
+    },
+    "gfx/env/moonrise_up.tga": {
+     "bytes": 3145772,
+     "sha256": "0296084074d726170fdc85d2c1176ee64845b6805c174c08aaa63f514fd9cb65"
+    },
+    "gfx/env/snowmoon_bk.tga": {
+     "bytes": 707878,
+     "sha256": "f4c61c3a622a2dabfc2aa2748c3bba9ab52bf018c5c24b5aac6bd682b6d938de"
+    },
+    "gfx/env/snowmoon_dn.tga": {
+     "bytes": 754863,
+     "sha256": "a6f29123dc3da6df244c6878d1a355b9ba7c093b9a38b94e8f9253d317de846c"
+    },
+    "gfx/env/snowmoon_ft.tga": {
+     "bytes": 630095,
+     "sha256": "c10f65b43cff087a7044946f8105d24072bbcb33668bb485f501fc0bdcb7e293"
+    },
+    "gfx/env/snowmoon_lf.tga": {
+     "bytes": 671066,
+     "sha256": "8025d6d72582a374583dc4c80d15de546b1ebea3f378cc55b084483778d8f985"
+    },
+    "gfx/env/snowmoon_rt.tga": {
+     "bytes": 636559,
+     "sha256": "339a1a1a36ffafa6bb49ae5bffcb73c81d4304f0f6d40d5fe470654c0db56037"
+    },
+    "gfx/env/snowmoon_up.tga": {
+     "bytes": 410341,
+     "sha256": "f08c76ef2c7c2338b64615543ffa1217edab3ca41bc79cb74b20bc42d329e82c"
+    },
+    "gfx/env/stormydays_bk.tga": {
+     "bytes": 786971,
+     "sha256": "d82eac0c4f574d74ff5fee6ececd1d5f0b1bd94c349cb7c9af30d3ce79bf6b2e"
+    },
+    "gfx/env/stormydays_dn.tga": {
+     "bytes": 786971,
+     "sha256": "915f33dcae63765c49252b65a58f9d4359c7a36ea99352a013e58e660b71f160"
+    },
+    "gfx/env/stormydays_ft.tga": {
+     "bytes": 786971,
+     "sha256": "4906e45ebc2760dad5faf2e6f8a0be7c280bf7525a96364376155f3d001fba99"
+    },
+    "gfx/env/stormydays_lf.tga": {
+     "bytes": 786971,
+     "sha256": "d7cc6cbaa37481b3902673d717aae7f31e0170e2226a4efe88811f6bac3f8ca6"
+    },
+    "gfx/env/stormydays_rt.tga": {
+     "bytes": 786971,
+     "sha256": "ab40bc26b750a421c95948e7f215d51e831163fd478841c30f685a2b006b8c3c"
+    },
+    "gfx/env/stormydays_up.tga": {
+     "bytes": 786971,
+     "sha256": "8ff85257da02eb361ab8127e4425b9177842f17016724beb5c3058ae460aa52b"
+    },
+    "gfx/env/violent180_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "cf1d0a870b38e4889ad4ce18f22bf894771a8c91477c0338e837880df061db31"
+    },
+    "gfx/env/violent180_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a3b344abf47fae67c831aaa8d8b2ab7ff56ff1ed93091c6869139902060777ff"
+    },
+    "gfx/env/violent180_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "964ce0226b139a1af96de0c422e927d35917ad30f0c4027c1c386c7c32cc30db"
+    },
+    "gfx/env/violent180_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "b9cc1ef464535f9a911d56fb503a2e1aa68e6d07c7091cb62c42442a7d62ceaa"
+    },
+    "gfx/env/violent180_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "263af4a0d5b2e61303d8165d6b8a8b7e55d0c8dd79157ff133a5d50128d5f21b"
+    },
+    "gfx/env/violent180_up.tga": {
+     "bytes": 3145772,
+     "sha256": "3a9aae357ac1a8e8767e151024dab60845283422f204a354913282873f181413"
+    },
+    "gfx/env/voidsmoke_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "d274189cd63786e9d86fbd3cafda0cbfd054ccd527e30aeec921a8d6f10866a7"
+    },
+    "gfx/env/voidsmoke_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "47392d93a23946a28533cf759d6aea245a2647d58bf153d2845ac0899ab8d400"
+    },
+    "gfx/env/voidsmoke_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "ced1991fffdc46e2bf156e1d89e06e1362e0e394808b74bc7aa40e6d90fde55d"
+    },
+    "gfx/env/voidsmoke_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "4d1b843a9fc61c4125262a9a95fc084cea61eb4b125288f7a7cd0c2f2e53f4ab"
+    },
+    "gfx/env/voidsmoke_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "389ae84f29901e349a266d707f62beab9de3eb607b901bcb4245028b8edaa3b1"
+    },
+    "gfx/env/voidsmoke_up.tga": {
+     "bytes": 3145772,
+     "sha256": "138e9386728cdd98935a0c484d5693db2e60375d8d770ad754fe6616906591a1"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "a878796ad2dbab6a64e1eba47605d124170d5b4a7ce476b9d0087c2e302c00f1"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "381ec91a75cacad94d2a4d5a3b1cd6f9b22cce507fe95f980ebaabdb21bbe440"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9e9568b56059e74e621ad564b51cb0b886fcf800fd8d35a06df1aa79ac2aa823"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "52164e93b333dfe09a33d7ad1905796d7e7578a036b2fb2ddf35c4bf3381f30f"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "240a13f778cc7ec7ebbc67b23a977a54099e1996fd868f51c18f81aa3606d179"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "fae9345c9eeb43a56a14e9e681f9e9dadc05ba6e35f44197fca5873dbd52904b"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3272,
+     "sha256": "ba61bec9eaf837bddef9a1320c0acfe026a130bc078836abf971095157ee395f"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "fc226280c4948249790f00f97dd9b39e912131fc904ec75adb90308ba8763afc"
+    },
+    "gfx/mainmenu2.lmp": {
+     "bytes": 30728,
+     "sha256": "a3fd168c6454eeaeea9e248df568e5942a7f850bc5478f8946a0b6516a2ce6c4"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 6920,
+     "sha256": "5a84111e70bf277960853bca69a0dff9093d00d817ffab6fed96f33751435ae6"
+    },
+    "gfx/p_mod.lmp": {
+     "bytes": 6920,
+     "sha256": "3080226ebf497787e7ee1d7bc2917ae220340b7da4af58ff1a0f89f02b5c03d0"
+    },
+    "gfx/p_mod_idver.lmp": {
+     "bytes": 2504,
+     "sha256": "56234ed3e4e4fe95f8a4a1f9a52d4a73890ea653aa88ec992e6777bf3e99b445"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 6728,
+     "sha256": "493a3ae8e9553de87c49d356e916adab7c87e3b25a44c1d1ac46e37de4df800b"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 6728,
+     "sha256": "d79623e26bed9db65257e3c0bf43b085d2419fc6e5277ff357350556882456d9"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 6920,
+     "sha256": "f51c8bd49d699f08322b734f281d7e626c24844aec09099877fbceb1884cb705"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3272,
+     "sha256": "788da2d0f96ed9f0822fff406f364a912179e33f6f4d068aa7b772f2747cbc85"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "f8ee0991ff6faaef3b4d2230364776effe6a1d4b47588b98e39c1d0b4199fd9c"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "a6ccb48f7e1d00ec64e5154a0a47b433f017341b8e23ba4f7f7fef6fe9a27b3a"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 6920,
+     "sha256": "bce2792bc38f1f097336ebdedff2029b21f4cebc523684738f7e10e086d33661"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 6728,
+     "sha256": "904d617b5b97aa6b1631e7b5dfab9b4092c488fefd94ec093c98595b38789b7d"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 6728,
+     "sha256": "5eeeea42e3f429aae7f907145b88376805346ebe3ce932259bdfc43399f960ff"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 4808,
+     "sha256": "5ae8a3fd789e7ddf6d7791ee89cb79ef989cb000c086e9269349aa623f1f6438"
+    },
+    "my_progs/ai_ammoresist.qc": {
+     "bytes": 7444,
+     "sha256": "d530fec92f23ed0c3d09560abb9a89bdc160ce1aefdfbe4f4771f9897ae3fc4d"
+    },
+    "my_progs/ai_checkattack.qc": {
+     "bytes": 106456,
+     "sha256": "7971ca5a87666c89b56ab0fcc102e6f551f3cd3b03bdfc0bfb73f5f8d5aed7fb"
+    },
+    "my_progs/ai_combat.qc": {
+     "bytes": 24318,
+     "sha256": "a8cc4b28f82babe8ef8fc627a3c16efb25775ea736d3ee99709ed675196c2d66"
+    },
+    "my_progs/ai_enemytarget.qc": {
+     "bytes": 8409,
+     "sha256": "f4b0a35306d50e71fd9043ae949a421158ee9fcc4e311baf7b8fa2d345c4d46e"
+    },
+    "my_progs/ai_explosion.qc": {
+     "bytes": 12162,
+     "sha256": "7df941a7cf93b814ae9d90f646a5b0243a51db67872f621df73d43c6000ba3ab"
+    },
+    "my_progs/ai_gibs.qc": {
+     "bytes": 32373,
+     "sha256": "65e202300882ba8f0c980f65820b2d2e0bd06846073168f4bd7e37f2357f47d4"
+    },
+    "my_progs/ai_hazards.qc": {
+     "bytes": 26832,
+     "sha256": "81aace80121408f64369bc2bbfd5654650276ddd75217333d2a52364415acaa5"
+    },
+    "my_progs/ai_minions.qc": {
+     "bytes": 10236,
+     "sha256": "3e7bd34dfe0e73a11e6907d5ac69cb609eee19dff533689ea7c8eabe52500136"
+    },
+    "my_progs/ai_passive.qc": {
+     "bytes": 8224,
+     "sha256": "44473544d0da0dc778c2800a16172ab49b548286b604c9d6361f4bc4cfc1f076"
+    },
+    "my_progs/ai_pathcorner.qc": {
+     "bytes": 20921,
+     "sha256": "b3d6ed2434e0b995da51a71715647096e36e02d8cf920e18e024f920ed69238a"
+    },
+    "my_progs/ai_projectiles.qc": {
+     "bytes": 86235,
+     "sha256": "b28c04e84c97febe9e5a8e921a8e230755f9641d4bf5d74b4a59caaaa247dfc8"
+    },
+    "my_progs/ai_states.qc": {
+     "bytes": 7480,
+     "sha256": "76fae861132b0e50006ef88ea94a953e718b661defad2ea58a4ecad5cab92dee"
+    },
+    "my_progs/ai_subs.qc": {
+     "bytes": 50952,
+     "sha256": "9d2e356f0dba7842956ceb4e766fff9da25dc72a0b408baa3e19c4a146cbafdf"
+    },
+    "my_progs/ai_tether.qc": {
+     "bytes": 6470,
+     "sha256": "2229c0ea1b76e45f5707a3eca9e7626e33f8ea91d6b292da63c81723e1ae8521"
+    },
+    "my_progs/breakable.qc": {
+     "bytes": 79687,
+     "sha256": "754831599eec85a774501d9fd0a1ec7d5722ea6a6e01655b5ad74988145045af"
+    },
+    "my_progs/chaosmode.qc": {
+     "bytes": 81481,
+     "sha256": "01561dc4f1949716eba4d08f83efe27b71add80f923c1e2d89194c238772a646"
+    },
+    "my_progs/client.qc": {
+     "bytes": 70441,
+     "sha256": "00e2d4aff96ea28b0532ab0b03de0a8cdcf15750164ec82bdc8f43b9f2347447"
+    },
+    "my_progs/client_advinfo.qc": {
+     "bytes": 59677,
+     "sha256": "87aaca8bfd15935e1cd29a807bf77a2779d95418af631a6b456c6605710694fe"
+    },
+    "my_progs/client_camera.qc": {
+     "bytes": 13007,
+     "sha256": "ff4748b04c15d9a3b44dd8069f9347c12487ef353d5401a13542166576097889"
+    },
+    "my_progs/client_cshift.qc": {
+     "bytes": 725,
+     "sha256": "da1e321fe01bae486ffcdd987a942a4b0d5b2f603efb663d52c55e882f129685"
+    },
+    "my_progs/client_debuff.qc": {
+     "bytes": 15761,
+     "sha256": "0e0c9123697241ab3a366dbc46fcb90b8553b65c94cffe1442254a74a2753efd"
+    },
+    "my_progs/client_evilmode.qc": {
+     "bytes": 6982,
+     "sha256": "2cfa3bbeb36ab623c3bb137028ec5f549a2e5d2198fa2ab7fd8a445e14f4fc10"
+    },
+    "my_progs/client_ghook.qc": {
+     "bytes": 51884,
+     "sha256": "43d071195a70caa66b57cca1778679d772478fd1f71cbad7ee267e254e79a29a"
+    },
+    "my_progs/client_info.qc": {
+     "bytes": 13693,
+     "sha256": "55653ddc2b9f3cf2ca3cf1b0afdc4c1685baf1ab3c3830eb9f8b1b2d51b3ff31"
+    },
+    "my_progs/client_mapvar.qc": {
+     "bytes": 13177,
+     "sha256": "c692fa41644e6d21c945493dd891af945a072a4b39e687d1b59c86d14ee804a0"
+    },
+    "my_progs/client_power.qc": {
+     "bytes": 20026,
+     "sha256": "68457e8f99d3967babe95d4db3539388e95d294fa65a6190773e75951fed9ef9"
+    },
+    "my_progs/csqc_defs.qc": {
+     "bytes": 21072,
+     "sha256": "eddc5f194845e78a1633807d32b1da4425bdbe7bcce193e3868bc3995e2dee9b"
+    },
+    "my_progs/csqc_defsclient.qc": {
+     "bytes": 35002,
+     "sha256": "b6674acae135dfbc5e3dbb147e69acdc6b3564b766792359bed3e4eb800705e9"
+    },
+    "my_progs/csqc_hudad.qc": {
+     "bytes": 104391,
+     "sha256": "1ca012e489dc5f6026bdae469f411b5bb25afa00e00d5169cbd35b578a7ad9f2"
+    },
+    "my_progs/csqc_hudvanilla.qc": {
+     "bytes": 37074,
+     "sha256": "c5caa6ba176185c05903d383f3ae41907129d859419a0c0bf909b0e8d3e8af5a"
+    },
+    "my_progs/csqc_progs.src": {
+     "bytes": 113,
+     "sha256": "e383fc0920e9676d92e0be81d69cd8017ed5baf9fc0616a05773de68208ce434"
+    },
+    "my_progs/defs.qc": {
+     "bytes": 31974,
+     "sha256": "1534874cf4d70c5614dedecb70f6d428fc32832ce3345c2cb51fd6058a514902"
+    },
+    "my_progs/defsclass.qc": {
+     "bytes": 24401,
+     "sha256": "811c390be7b31fd4b276410ef1a75406bbca8fb84dc195484835a6100e9cddb4"
+    },
+    "my_progs/defscustom.qc": {
+     "bytes": 95914,
+     "sha256": "180ebe8c3fbbd4f78815c94d62f6ac0ad0c3cefe427664fdf4685adcf2c8a699"
+    },
+    "my_progs/dpextensions.qc": {
+     "bytes": 122912,
+     "sha256": "3758f58ebaa4186e9112da89f7ea53087eef5058a32ebc373a1ffda76c1d67a2"
+    },
+    "my_progs/estate.qc": {
+     "bytes": 7745,
+     "sha256": "9cceb71ae54b331c2702f5580094f9055d007b9e710dd5e61c7c632724022626"
+    },
+    "my_progs/fteextensions.qc": {
+     "bytes": 215531,
+     "sha256": "beb86ad10bb0726de10dd2557d6285f7bf40f08f9d30e06315c3772f8c256571"
+    },
+    "my_progs/func.qc": {
+     "bytes": 47039,
+     "sha256": "81cd56475c6c34a744d84c2b223e66dd1c83a1b525b4c42f3389d4ff4cca5601"
+    },
+    "my_progs/func_buttons.qc": {
+     "bytes": 13271,
+     "sha256": "9e1bd197b2367ab2b8f1c776c214a0c51120559e8d8f0b4888b262b7a1e746f0"
+    },
+    "my_progs/func_doors.qc": {
+     "bytes": 35874,
+     "sha256": "58dbdf05f0044aefdd13ee21d17045a681d255efaca6d129fbd1cec4ae516fc9"
+    },
+    "my_progs/func_doorsecret.qc": {
+     "bytes": 14379,
+     "sha256": "769a3142ccaf18060ff77b0eab57d901585202fbfe63a54ce25d4987b80f92d3"
+    },
+    "my_progs/func_insvolume.qc": {
+     "bytes": 10573,
+     "sha256": "1deaf4623a6fae80585d2d2b1978b1cd217b6f8a683ef3bbc3a77a2897e9a207"
+    },
+    "my_progs/func_plats.qc": {
+     "bytes": 11685,
+     "sha256": "5086c9aba8bbf83d29c3e1897c7867cb24220712007044792928f474216b7ea4"
+    },
+    "my_progs/func_pswitch.qc": {
+     "bytes": 8373,
+     "sha256": "b3a205176d80801216a930241508b3c5718f4be9e1b947932ace2851c34271d8"
+    },
+    "my_progs/func_trains.qc": {
+     "bytes": 26553,
+     "sha256": "81d8de4f3dff80b8523584fb5e37d8d4812a6f7f95a559edff320682217ad123"
+    },
+    "my_progs/globalfog.qc": {
+     "bytes": 18397,
+     "sha256": "84ec244a475ac41b9da772042123f58f4005130590f170f85f1b23ad53629f27"
+    },
+    "my_progs/hiprot.qc": {
+     "bytes": 31978,
+     "sha256": "82875db9fecd8bacd2c42232fb980e6a510a6863103273e2c9078dfe7c6759c5"
+    },
+    "my_progs/hipspawn.qc": {
+     "bytes": 2752,
+     "sha256": "6df8450b85821c1a76f5ccb3c807ac9b94e92f413f16f2ba618f922abf85148f"
+    },
+    "my_progs/items.qc": {
+     "bytes": 164855,
+     "sha256": "ffa38fa915821151c7dbfae3507bf804052db0f5c13eecac462400680cabcf3e"
+    },
+    "my_progs/items_progspn.qc": {
+     "bytes": 20628,
+     "sha256": "2f4824cb28192145a8fabc2da6575db3398e8f81522ab1e026d696ec87313650"
+    },
+    "my_progs/lights.qc": {
+     "bytes": 43912,
+     "sha256": "d0e0c373bb3cc68c7c9121a62c68085ff9cc290daa6faf0adab02323d8ef92bb"
+    },
+    "my_progs/mathlib.qc": {
+     "bytes": 22355,
+     "sha256": "b161ebb89a11f302427c4f124731ec38def8eb01347beb5d748a9ba4afb886f8"
+    },
+    "my_progs/misc.qc": {
+     "bytes": 85890,
+     "sha256": "6b3e8a0882d47f16ff7f54fb37a48e3a7853647f8895718e6428739c4207099a"
+    },
+    "my_progs/misc_camera.qc": {
+     "bytes": 43852,
+     "sha256": "61448a8f0354f39dd26371ae56dadbc903b08282293145a27088ac6c151ea547"
+    },
+    "my_progs/misc_model.qc": {
+     "bytes": 31793,
+     "sha256": "04774e0bab5cb0ccc5bd01e36ae7d6f449248484d0cb203eb435fb267cc8bdda"
+    },
+    "my_progs/misc_targetdummy.qc": {
+     "bytes": 15123,
+     "sha256": "bcd0a0ae806ce20a8c8cfcc27178ce1b4ead3a546d927b6a261ce51a6086c253"
+    },
+    "my_progs/misc_textbook.qc": {
+     "bytes": 26321,
+     "sha256": "14bf42536a5cc75990d938a79d7bd21bde1c166245d94d8e662f9e6fd66e0ae8"
+    },
+    "my_progs/mon_baron.qc": {
+     "bytes": 31318,
+     "sha256": "b76a10da34dabf3411ddf650abcdbc77e3ebcdfebace6191a39e7c0b13a0fad5"
+    },
+    "my_progs/mon_boil.qc": {
+     "bytes": 19821,
+     "sha256": "050b21bda5341a3f81dcb21e6d7d82d458a415fd8f1cfa12435228246229a323"
+    },
+    "my_progs/mon_bossboglord.qc": {
+     "bytes": 24005,
+     "sha256": "e67081b7a5218b361c62bf4b201a18db16f3e75716ad2729c11a0616b137975a"
+    },
+    "my_progs/mon_bosseidolon.qc": {
+     "bytes": 40134,
+     "sha256": "c51eb9b9d67cadfa7178891a238329a60ad57edc3f6ef645060695b451833115"
+    },
+    "my_progs/mon_bossfiretop.qc": {
+     "bytes": 14734,
+     "sha256": "26672c9c2d1577f8caf9894b8eb5eecacac89f64251257bc25db48b1bf43a7bb"
+    },
+    "my_progs/mon_bossicegolem.qc": {
+     "bytes": 47205,
+     "sha256": "5b888302a6af24ce823919d1349c1c92e1ee709d72e79042425349368a4d65fb"
+    },
+    "my_progs/mon_bossidchthon.qc": {
+     "bytes": 20247,
+     "sha256": "65d955fb1434f806962fadc088aa5933e96ed8aa9f1211d0709a3f462ffa3027"
+    },
+    "my_progs/mon_bossidshub.qc": {
+     "bytes": 14639,
+     "sha256": "fdd0e8f8fa374ea0164f79ef1bf74ca942f04c63159f360c7a43011673774fe6"
+    },
+    "my_progs/mon_bossjudicator.qc": {
+     "bytes": 81432,
+     "sha256": "f5092f376eeef22f0a552c846f50175680c15a5c37d9603c6e3d2635661127b3"
+    },
+    "my_progs/mon_bossmammoth.qc": {
+     "bytes": 84963,
+     "sha256": "6cda415b846b2aeb215c0eebc7cdfa6a5560255df9aa014f77b48aa7073b8d34"
+    },
+    "my_progs/mon_bossnour.qc": {
+     "bytes": 45558,
+     "sha256": "def8a1a46f3a266028df3d1a0b7c31a9ad98450f6601e176495f11d929041452"
+    },
+    "my_progs/mon_bossxxchthon.qc": {
+     "bytes": 22614,
+     "sha256": "2c1c0446b0f6a5b7a7921e8f8830c71c174d30c6f176d228a94afd9a05fdc25a"
+    },
+    "my_progs/mon_bossxxshub.qc": {
+     "bytes": 19006,
+     "sha256": "043ebc852ba7f0a06812cb0afd72d32a3da643df1dea45c87fb821f60fbcc332"
+    },
+    "my_progs/mon_centurion.qc": {
+     "bytes": 13734,
+     "sha256": "641e1c09c6df27b033e331140d242f25d27bf7f9bb83733a6b5b3469a5c7ffee"
+    },
+    "my_progs/mon_dcrossbow.qc": {
+     "bytes": 38069,
+     "sha256": "3296618a4b803fb6f1b44c1d32c17692a5bed13cf63102c6dcc58481223197a8"
+    },
+    "my_progs/mon_deflector.qc": {
+     "bytes": 32107,
+     "sha256": "d7a9344878a3a846a7e720ce704820d424362281a1675c40be7b670eca9fe342"
+    },
+    "my_progs/mon_demon.qc": {
+     "bytes": 14601,
+     "sha256": "d77f128e3f91737228c5a24b7ca146f6b4f8e87dbaac31b1ad4e79779884d0d7"
+    },
+    "my_progs/mon_dfury.qc": {
+     "bytes": 39867,
+     "sha256": "a016db202f2a418aee50cb7cce2155a24a6b807e8c98fc49a5f9273ce79c6da8"
+    },
+    "my_progs/mon_dguard.qc": {
+     "bytes": 28414,
+     "sha256": "0a2b964034559f4ca772f9f29be2c56684fd39290277046a6f7642ba934836eb"
+    },
+    "my_progs/mon_dguardquoth.qc": {
+     "bytes": 18932,
+     "sha256": "4caeb17520104cba42476ff7757f38ba6d72e941674b851f55a5c9780ce4de17"
+    },
+    "my_progs/mon_dknight.qc": {
+     "bytes": 36867,
+     "sha256": "68008427374e9ab670b6ad915c7a0f8eaf6a6699efa927a3748ae6cde86458e6"
+    },
+    "my_progs/mon_dlord.qc": {
+     "bytes": 22859,
+     "sha256": "09ca1edd4e65a166a66ba17e682aae9a1be09b05371a72dd1bc447389693bfa5"
+    },
+    "my_progs/mon_dog.qc": {
+     "bytes": 18431,
+     "sha256": "1b345447176aec54f18c31f5da215e80cb2de19f51d353c63a98507d881c2a9b"
+    },
+    "my_progs/mon_dprince.qc": {
+     "bytes": 33590,
+     "sha256": "5114caa7b6152e562e548096e41da68f43c910a5016ddaed408272a97a8320c1"
+    },
+    "my_progs/mon_drole.qc": {
+     "bytes": 25472,
+     "sha256": "36a510e910ce4ffa26d2d2ad336872c07537077ea920132a4cfd63d9133fb6af"
+    },
+    "my_progs/mon_dsergeant.qc": {
+     "bytes": 33493,
+     "sha256": "ada0cc4359a863c4e8d433c605a1c04ec6f7fd17ec852f5c4847443d3adaff1d"
+    },
+    "my_progs/mon_eel.qc": {
+     "bytes": 8252,
+     "sha256": "15c1f2fedba7077d352595e1be4a90f764354e4cf1875b40e1685d3ce81feb54"
+    },
+    "my_progs/mon_enforcer.qc": {
+     "bytes": 20146,
+     "sha256": "d453651d488afa789d0cea87ce99d9684329bbabdd17aa1625591f5a4b4ac90b"
+    },
+    "my_progs/mon_fish.qc": {
+     "bytes": 9705,
+     "sha256": "ff7d84db2c7917861ff5d81fe0e28f69d51143d27c4fba90dfcda11057222df0"
+    },
+    "my_progs/mon_floyd.qc": {
+     "bytes": 20332,
+     "sha256": "3ac2f0b0be94e311ff2fc4eee9cf66d5987af0e5c25fc06b8cc7b9efa6f581df"
+    },
+    "my_progs/mon_freddie.qc": {
+     "bytes": 25384,
+     "sha256": "4409a33e819f125852d0a4ada21a8fed2713012daec00922446f313031c845d1"
+    },
+    "my_progs/mon_gargoyle.qc": {
+     "bytes": 24293,
+     "sha256": "9e1f78b2364024efa6ec4142c1ecf4aff52cdf32f38031c34cf19e9cd74143d6"
+    },
+    "my_progs/mon_gaunt.qc": {
+     "bytes": 24111,
+     "sha256": "45be98ae0bdd32e0884280e18f867af037f2fcbf515914827c5f9107a87e52d7"
+    },
+    "my_progs/mon_golem.qc": {
+     "bytes": 35297,
+     "sha256": "dbaf3d1c0fec3166b0eb064a3c027dd3a0c907bed72b8e4581ffd74dad5ab5d1"
+    },
+    "my_progs/mon_hknight.qc": {
+     "bytes": 37618,
+     "sha256": "bac7d4b7832b95cea0f6890de66fbd0f7c4fcc7ce9051ef16ac042de465ddcb3"
+    },
+    "my_progs/mon_hogre.qc": {
+     "bytes": 24021,
+     "sha256": "8781ea9aaaa1d0f7ffb1fd8ec8b5981187eee6fdb8193160a1eb38770dffcfe0"
+    },
+    "my_progs/mon_hogreham.qc": {
+     "bytes": 23076,
+     "sha256": "b2ab6b830ce3aae7d6b033e8455de5011ded82e451ca171ea09940d9a3ec7740"
+    },
+    "my_progs/mon_hogremac.qc": {
+     "bytes": 23941,
+     "sha256": "9111c040ab1e5487936cce6ef1170e408c6d297d582702d202bbd27b0919d843"
+    },
+    "my_progs/mon_invsword.qc": {
+     "bytes": 9214,
+     "sha256": "f7287867cc6043eb7cd3fa3e1ecd5ae7115a84e5ef7021b2d5129afdb6ba6f46"
+    },
+    "my_progs/mon_jim.qc": {
+     "bytes": 22091,
+     "sha256": "55353984ad822dfd8c32f3b8ad9a06e8bfaab7bc5ff6f2a2326674ad4acd26be"
+    },
+    "my_progs/mon_knight.qc": {
+     "bytes": 24772,
+     "sha256": "d254abf88162436b9db48885ae8e59315c24c1e7f72a91d027a1d69fe9baf5b7"
+    },
+    "my_progs/mon_lostsoul.qc": {
+     "bytes": 23261,
+     "sha256": "2cdbf656c6b34164711fa88016542f4e3d2bd0555417ad00bab5ca7039f212ef"
+    },
+    "my_progs/mon_minotaur.qc": {
+     "bytes": 35316,
+     "sha256": "fbcef276ee3e2f1eeea8483303538190875e959b43efbf4f703be10fc72fc564"
+    },
+    "my_progs/mon_ogre.qc": {
+     "bytes": 24123,
+     "sha256": "d287d3b9024025237dbc68380f486572828a5114f9543599ba86b8bc35e9e25e"
+    },
+    "my_progs/mon_ogrextra.qc": {
+     "bytes": 9387,
+     "sha256": "41a9243c6006326195197a4dfba6ea4c1f1fbd729ec10adc48cfd7badd7a18de"
+    },
+    "my_progs/mon_pyro.qc": {
+     "bytes": 18235,
+     "sha256": "bd35f02c63af315ddf4820e388d0248cf065f1170bd7306957a1e86fa7e47306"
+    },
+    "my_progs/mon_scorpion.qc": {
+     "bytes": 22136,
+     "sha256": "0432d7c5e1b6a30a5452aba12b9fb6a3c2c7f3c582b1392d420414e66b8fb257"
+    },
+    "my_progs/mon_seeker.qc": {
+     "bytes": 29703,
+     "sha256": "d33939357840eedbfc63c56d6415d8fefd21de2c477b24b3165cdadcca2acd2c"
+    },
+    "my_progs/mon_sentinel.qc": {
+     "bytes": 10217,
+     "sha256": "946232c7169bf3fa966ce875523dd45402772f8045c51a96dced04f2f5f5788f"
+    },
+    "my_progs/mon_shalrath.qc": {
+     "bytes": 16434,
+     "sha256": "1b6fdf2447d7fa281d126118a9bc0e097de7b4dd4d10a33e60d5cf0ca785c58b"
+    },
+    "my_progs/mon_shambler.qc": {
+     "bytes": 23050,
+     "sha256": "576f71a38d75eedbdf58c291055674be8da5f0d04540e26311d65f70b58ee842"
+    },
+    "my_progs/mon_skullwiz.qc": {
+     "bytes": 36245,
+     "sha256": "6d3c2242bffe6eabe3f9cc59e881cb2296213cfbff809e1be045a80ca46aac53"
+    },
+    "my_progs/mon_soldier.qc": {
+     "bytes": 21645,
+     "sha256": "704c534062b11c4fc16416154c7706c125221660cdd4d9b02e00575b94c04103"
+    },
+    "my_progs/mon_spider.qc": {
+     "bytes": 30593,
+     "sha256": "4d0bbb7e38e51cef07912e6071e6bb9739e019a2d93129d38dbab9492bf43aee"
+    },
+    "my_progs/mon_steelclaw.qc": {
+     "bytes": 17126,
+     "sha256": "78dd4bb46dd76b2ff1f7d4a9f0b0902f25d94ebe13ace6b997a7f604c3718700"
+    },
+    "my_progs/mon_swampling.qc": {
+     "bytes": 25637,
+     "sha256": "fb5ed328cd3d5c09704bb84f39138463a7d26b8b1d45771e55e9ae952b1d2470"
+    },
+    "my_progs/mon_sweeper.qc": {
+     "bytes": 27025,
+     "sha256": "8f7a1d077779d88d542a325c1ae4ba4ff59d48bfcb334150ae3f024525bb725e"
+    },
+    "my_progs/mon_tarbaby.qc": {
+     "bytes": 11866,
+     "sha256": "88c9481ab7fe0cbe97d2b836492ff51b368aeae8d4ff3e5852734bb9f63a1b2d"
+    },
+    "my_progs/mon_turretbal.qc": {
+     "bytes": 38519,
+     "sha256": "fdcf915248dda5fb6a744d284233d46a2e6d62c8e4fd02fdd5bafe4f46167d30"
+    },
+    "my_progs/mon_voreling.qc": {
+     "bytes": 27678,
+     "sha256": "7734614fa6b2da2195bf3804415c06a2d10f35825e86abf4f85613a182cf21c2"
+    },
+    "my_progs/mon_wizard.qc": {
+     "bytes": 15155,
+     "sha256": "3101ca37b57343697b3d3c7637fdc84c842f78ec9081e401dcaa6df0a9b1df83"
+    },
+    "my_progs/mon_wraith.qc": {
+     "bytes": 35464,
+     "sha256": "6a28a205cb8ac574e98c8d34a01ea859922e38d55c66346a7aa867ebf84bdb5b"
+    },
+    "my_progs/mon_xmas_elf.qc": {
+     "bytes": 17589,
+     "sha256": "053eec412485090ee1ebeac25887382db40e2ba7ca456050ba4407be3ec8bc1a"
+    },
+    "my_progs/mon_xmas_raindeer.qc": {
+     "bytes": 12189,
+     "sha256": "abbe1dd5c96c25b631231d4db2f17e8243075ad08c082e0448b7cbff34f1ae0c"
+    },
+    "my_progs/mon_xmas_santa.qc": {
+     "bytes": 17853,
+     "sha256": "cc60c6de17bc3321f9b1cf75b3229e387592c9eb7fc4bb57c1de0a8d2c0e62e6"
+    },
+    "my_progs/mon_xmas_snowman.qc": {
+     "bytes": 11486,
+     "sha256": "65928bb70cb2e9352c2f5e036eda2a6bd97aea09d459d0af563a82aa5a2f2673"
+    },
+    "my_progs/mon_zombie.qc": {
+     "bytes": 33988,
+     "sha256": "83f56482374c3a79fcc64058989bd210af3add006b7388d89c92e90543ec56a0"
+    },
+    "my_progs/mon_zombiek.qc": {
+     "bytes": 42214,
+     "sha256": "2b9926454484e93f5c053bf4fd35b2a97cf7e835c26c3b30061f1ff391af9f5e"
+    },
+    "my_progs/monsters.qc": {
+     "bytes": 56573,
+     "sha256": "c2c75832e6d5e83e929214ba5c1aa9a4661bcaf7754c20b3e9648171bf804a58"
+    },
+    "my_progs/part_emitter.qc": {
+     "bytes": 82744,
+     "sha256": "fca7491171d58974ef6b15550b9a7f0474641e9eac7ee5de52c6980c96445518"
+    },
+    "my_progs/part_generate.qc": {
+     "bytes": 42914,
+     "sha256": "83b9718a85418143d92ea8311cc8cce69c1002eb7563710dfe7010ac52e15d50"
+    },
+    "my_progs/part_manage.qc": {
+     "bytes": 27407,
+     "sha256": "86eb791f4bba08fc0c965e9f81c90e7412ed2c910104d66a56cce1f3152808fe"
+    },
+    "my_progs/player.qc": {
+     "bytes": 27811,
+     "sha256": "1f0cc3eaf577c2af642495466c573cd6e226a4754902d9de9cbfc9c9ba28af0f"
+    },
+    "my_progs/progs.src": {
+     "bytes": 2482,
+     "sha256": "c773f107c562f731fbb30158422226bdc4576dd32aea0f02c122195e08eac96f"
+    },
+    "my_progs/pushable.qc": {
+     "bytes": 19823,
+     "sha256": "03b3bf9240db6e9532e45a3efc159129709f9ce095c3238daae32daddd5b07ec"
+    },
+    "my_progs/qc_highlight.xml": {
+     "bytes": 6348,
+     "sha256": "a7b326723cc1e4025e867ea5da00f54c944705600d740538aeb52f63cd027ab5"
+    },
+    "my_progs/settings.qc": {
+     "bytes": 61298,
+     "sha256": "7a1ae40ba7fa97ff7e7019017bc7640fd49d22943a2ca57c7a7e48702bbe7158"
+    },
+    "my_progs/sounds.qc": {
+     "bytes": 19389,
+     "sha256": "bb74ecc36a241db5a79b010f61200687c6db6e46297db39c8a2a8ce1d512bad5"
+    },
+    "my_progs/sprites.qc": {
+     "bytes": 476,
+     "sha256": "579f48b397914b02f8fb86dc24f23d4e63a4cd857df1f0eaefd6c83e9c49e238"
+    },
+    "my_progs/subs.qc": {
+     "bytes": 23545,
+     "sha256": "123ca7120e7ea4e4ca63bfd081caf46c7acd1560af4702c1bff40821d7f6ef44"
+    },
+    "my_progs/subs_soc.qc": {
+     "bytes": 28453,
+     "sha256": "679112275e8b3597daac962074f69b6d9fd5614fc3dbff036815b9365e1413c5"
+    },
+    "my_progs/switchshad.qc": {
+     "bytes": 7054,
+     "sha256": "92a2fd4e5c41f21f46502781322ab87584bf0999d733db50e0e19b8bbea793b3"
+    },
+    "my_progs/targets.qc": {
+     "bytes": 58758,
+     "sha256": "e39b45bf6740be40c2899376e92d30d7d227a4762091d7b63e382c79fe6822e7"
+    },
+    "my_progs/traps.qc": {
+     "bytes": 24071,
+     "sha256": "9e4e822a36113bc73958fa45ab0b8c290a5148c95f3a4da7125676c984ebd202"
+    },
+    "my_progs/traps_pendulum.qc": {
+     "bytes": 17049,
+     "sha256": "b421f26fd80eb74715172e25f3ac992faa95397dd67d5f7ede286fd78384a468"
+    },
+    "my_progs/traps_sawblade.qc": {
+     "bytes": 9783,
+     "sha256": "9a6e82a05f09001c0a9cffdf6b9d6399691846c5b1ab1fbfb470e5772a87f44b"
+    },
+    "my_progs/triggers.qc": {
+     "bytes": 139586,
+     "sha256": "2e5819bf11fecf01856bd7547af63b7c4927dec59237419dbf3dc79bc023f54d"
+    },
+    "my_progs/triggers_states.qc": {
+     "bytes": 17475,
+     "sha256": "2c4d25c11de0319cd54d81e67e651c8d29d22aca851988d21080ba5976137f14"
+    },
+    "my_progs/weapons.qc": {
+     "bytes": 44346,
+     "sha256": "f23d0cc07bab402da965ec3fa91d7de86ccabcb03c9019cd7b217fbca7fb4279"
+    },
+    "my_progs/world.qc": {
+     "bytes": 39815,
+     "sha256": "b933caca23d5a45e5d9368627b3d651af244af0aa345b91017d263be4bad7b77"
+    },
+    "particles/fte_weather.cfg": {
+     "bytes": 2758,
+     "sha256": "e0d383b0222f14edbd2bc04c1269206bbcdca22cdeac6840b5d831c042ff698e"
+    },
+    "particles/particlefont.tga": {
+     "bytes": 4194348,
+     "sha256": "bf90d469b3b41c2393f5ed0f58b4411cc8825f452341bbe3ba848c3cc855639e"
+    },
+    "particles/particlefont.txt": {
+     "bytes": 9872,
+     "sha256": "9e84ef35b813211196f8dfc8f89a420fd9d847ea514e43d0c3246ee666000b88"
+    },
+    "progs.dat": {
+     "bytes": 2345354,
+     "sha256": "f3c4218216ea0d3b00db35eef9e72945ee6687006b3e82c37ea2ae33a0eea922"
+    },
+    "progs/ammo_battery0.mdl": {
+     "bytes": 10552,
+     "sha256": "06d4f0235faedd3430e57d602ec29a2a91c0b23bdc30debc069212264a0faf54"
+    },
+    "progs/ammo_battery1.mdl": {
+     "bytes": 10552,
+     "sha256": "0cee39ac60c3eda7b5f1d1efde52f8be19c9e4f425972f16ba6d6362d646afb6"
+    },
+    "progs/ammo_cells0.mdl": {
+     "bytes": 27228,
+     "sha256": "b6f5a07c9fd48cf27f0873320589dda1e20afe7d64cd40b6c950e5f892a34fa2"
+    },
+    "progs/ammo_cells0_edit.mdl": {
+     "bytes": 27228,
+     "sha256": "47ffc9eb8ec352ab2fa479f35ee5b6ec0e0ac8f472a06fbe00e8298e9d683ed5"
+    },
+    "progs/ammo_cells1.mdl": {
+     "bytes": 29836,
+     "sha256": "c23b4e85e9edd68fec2d751af85cff391a11848bd4338a3c59a2c055508cfce9"
+    },
+    "progs/ammo_lidlarge.mdl": {
+     "bytes": 25252,
+     "sha256": "d941a1c520e49694d66598f3430420541b318cea3e1cf02d3957e06d010681a7"
+    },
+    "progs/ammo_lidsmall.mdl": {
+     "bytes": 25252,
+     "sha256": "221b3aaa2324bea668276d3de521c4945004a71368983fc74c50c4b53425c436"
+    },
+    "progs/ammo_nails0.mdl": {
+     "bytes": 14072,
+     "sha256": "1090a9c50a943c2bf04302914f69b835ecf79fbf3013f259a12668ebd57aad5a"
+    },
+    "progs/ammo_nails1.mdl": {
+     "bytes": 15976,
+     "sha256": "8dd339507f4e18953ceefe3922d04ca513728bf2b0745813723873427843213b"
+    },
+    "progs/ammo_rockets0.mdl": {
+     "bytes": 24836,
+     "sha256": "9f272b2f1cb52fcf38983f63052db653e8208b2ee1eedf053e99dca6e439c7d8"
+    },
+    "progs/ammo_rockets1.mdl": {
+     "bytes": 27672,
+     "sha256": "46d85f10a260cf13d6711420f11a235089536a3725363be0717c2ee3e7e8a18b"
+    },
+    "progs/ammo_shells0.mdl": {
+     "bytes": 14072,
+     "sha256": "053e466f1666314cbfc0cd6f67821850ad39505a6a0bbf37c80b127e6887e5c5"
+    },
+    "progs/ammo_shells1.mdl": {
+     "bytes": 15976,
+     "sha256": "6183880b36171b6784cecf74b50aea2e1fdbc17b1b0b304a89125e964d63fd1f"
+    },
+    "progs/armour.mdl": {
+     "bytes": 76144,
+     "sha256": "b6e297062cffd435d6ce5cc17854e25a49ff09750ee1eaec6d5004266884099a"
+    },
+    "progs/artifact_airtank.mdl": {
+     "bytes": 50184,
+     "sha256": "4702b7be1baa517669edd24f5b67377f532382bfedebd77b5d77f9a499f3f08b"
+    },
+    "progs/artifact_blastbelt.mdl": {
+     "bytes": 28436,
+     "sha256": "a935de1300f6fc4f03b6fc57bf43791ac32b74d55c5509eda84339dc33f0bf48"
+    },
+    "progs/artifact_envsuit.mdl": {
+     "bytes": 260844,
+     "sha256": "09192fca32cf5b7632cf0fe9cccd9b4b1313c0e92708e85f840b0971aca5d274"
+    },
+    "progs/artifact_invis.mdl": {
+     "bytes": 7108,
+     "sha256": "f6b0b925b584402d85a623e1924c50a4fb3f3a4994cb1d2f05a169a3af2e39dc"
+    },
+    "progs/artifact_jumpboots.mdl": {
+     "bytes": 37428,
+     "sha256": "668d649addf958be26f2bcff31baf3afa5ff176a178ef15073c87cc7cb57e2b8"
+    },
+    "progs/artifact_lavashield.mdl": {
+     "bytes": 469773,
+     "sha256": "2e3027df661ca197750df97599084442afda131fbf1b545ea38d40e93afff908"
+    },
+    "progs/artifact_pent.mdl": {
+     "bytes": 21412,
+     "sha256": "7ae90fc895f23f57952dacf4d8af125f99347e09edf6f0287c7e508faad67b46"
+    },
+    "progs/artifact_piercer.mdl": {
+     "bytes": 19012,
+     "sha256": "fd73ca18d93904647df923f2d0383958386c7deb9cf27547beda74c61a9f8831"
+    },
+    "progs/artifact_quad.mdl": {
+     "bytes": 22052,
+     "sha256": "bf6d2253210784391ee1ab9b38d2b6fd661a520434bb127d293f4d202040d1b5"
+    },
+    "progs/artifact_sharp.mdl": {
+     "bytes": 49248,
+     "sha256": "505fc06618d7cecb83c03ad7d7762011ff8cff025eecf007b200d87fcc2483cf"
+    },
+    "progs/artifact_tome.mdl": {
+     "bytes": 21412,
+     "sha256": "ee8cf94e2c87ff6c0d4aa8777da2f0ddb79605bf790fb8f9ed2f49c6c1f9b9cf"
+    },
+    "progs/beam.mdl": {
+     "bytes": 26020,
+     "sha256": "bd06e42c7f0d911a4ef1077c95d474b86f62bca4da02183449687c23879e8c6d"
+    },
+    "progs/brk_pot1a.mdl": {
+     "bytes": 93352,
+     "sha256": "5612b9539e9663e06397f315968674b1de6ab50db7cdf673baadcd4652cedcd5"
+    },
+    "progs/brk_pot1aflr.mdl": {
+     "bytes": 93352,
+     "sha256": "02fd1feb7dc24b456e31f26f142aafb9adf491a16ea4caf2c4ec237e465260a5"
+    },
+    "progs/brk_pot1b.mdl": {
+     "bytes": 93352,
+     "sha256": "47c4053f0c0c941674a9d7c15a07e05c7ed648b2bf8ffbd1defb7264c151b47a"
+    },
+    "progs/brk_pot1c.mdl": {
+     "bytes": 83968,
+     "sha256": "a408707cc6793c337d0e76d86c5362de39a1f2109c23affe5def6e8194e0f4e8"
+    },
+    "progs/brk_pot1d.mdl": {
+     "bytes": 74024,
+     "sha256": "c31abc1e9e5af2cb86614f68a8be55f6192e05baba8b93479e2b2590b1e0ef1d"
+    },
+    "progs/brk_pot1part1.mdl": {
+     "bytes": 33768,
+     "sha256": "2dd32863b6006dda74b60f05a43df13e7df052ddcdb652309ba0ab29fa5352e5"
+    },
+    "progs/brk_pot1part2.mdl": {
+     "bytes": 34072,
+     "sha256": "550cae5c8893c63520c324610950eeb5b9fe842dc8ea1f07f6a217953f6e743e"
+    },
+    "progs/brk_pot1part3.mdl": {
+     "bytes": 33464,
+     "sha256": "819cf0e720637e7c5e187ccc67ae032eca217ee2f07076aefee1a8b7de894852"
+    },
+    "progs/brk_pot1part4.mdl": {
+     "bytes": 33496,
+     "sha256": "a3cc47c7f7410bb0ca2308e45144b29bc3b678600e0f288b15d8e64525585e43"
+    },
+    "progs/brk_pot2a.mdl": {
+     "bytes": 77348,
+     "sha256": "ffcf5e5f3d0b81143e2b2b387cde7b13b2d36b71345d63456f288eb036993a2b"
+    },
+    "progs/brk_pot2aflr.mdl": {
+     "bytes": 77348,
+     "sha256": "37420048a9f72abc5982f5f6813602dbc4b82ef8e788a0e309df7ff13066ea62"
+    },
+    "progs/brk_pot2b.mdl": {
+     "bytes": 77348,
+     "sha256": "40eb2c849cd06d9b985b0efc2b9d1090ec1648b0de53d0a07bd6fd5fe2af6733"
+    },
+    "progs/brk_pot2c.mdl": {
+     "bytes": 77348,
+     "sha256": "3774ade6790fc2b597c44c5206deeb3d5d3d20a23331e3fb622e1e90f833c7d4"
+    },
+    "progs/brk_pot2d.mdl": {
+     "bytes": 79004,
+     "sha256": "2af25d81ae0f1d8724f3047e95ff2f1d1700061a536b3f9ffda5522cf7e8dd13"
+    },
+    "progs/brk_pot2part1.mdl": {
+     "bytes": 34456,
+     "sha256": "13547d9ca8c36bbcc95354df03dfbdc14f19f74251ff1dc8c417436846b396bc"
+    },
+    "progs/brk_pot2part2.mdl": {
+     "bytes": 34680,
+     "sha256": "7f9824c52b01664c2dd1ccc5c1dc9e7ff2a5567dd2d0a8e9c3bf1a8bd00400e7"
+    },
+    "progs/brk_pot2part3.mdl": {
+     "bytes": 34008,
+     "sha256": "52fdc17879e0b6fb8697e1e9fffba092f1b5aa8d3cee5d657b405eb4119e8e87"
+    },
+    "progs/brk_pot2part4.mdl": {
+     "bytes": 33304,
+     "sha256": "b40cf2b029a4bfac52a80f5aef6587f3eb66e08be1fe5f40cd3f97e93133ad3b"
+    },
+    "progs/brk_vase1.mdl": {
+     "bytes": 27992,
+     "sha256": "28a8b9a0d367f17c2c265271d99b019f1762831a11ba794e2884fc7f7a8a2368"
+    },
+    "progs/brk_vase1part1.mdl": {
+     "bytes": 5524,
+     "sha256": "b8c0bef8f5d6a427f57282f086a75f39e91ad6ab035d4f1d437da97794e52f9e"
+    },
+    "progs/brk_vase1part2.mdl": {
+     "bytes": 5556,
+     "sha256": "8e1df7795140732953af83a1ef2158299a2cc393163041b6d3243478b6b644e1"
+    },
+    "progs/brk_vase1part3.mdl": {
+     "bytes": 5556,
+     "sha256": "c2e3da479defb1c3bd5130555e33dd47afc6a3b4ef7f74d4f0184cb02a02a46d"
+    },
+    "progs/brk_vase1part4.mdl": {
+     "bytes": 5524,
+     "sha256": "986c51c2cb3832f597f9dac89c6044d090b10933306814acc36a0c4ab5a04b93"
+    },
+    "progs/corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "839b70bb6be7fac8c25e6069b999e076b04bdd3dbc7a9320924713cf75c2cadb"
+    },
+    "progs/corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "cb994b390584e1776ad1f0e60d95186a0dc54cd160a2cb8284d1a15b4fe1a35d"
+    },
+    "progs/corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "b19faa9afe7cf957ae7abf6439799e5001ff42817290f4b464aa3f7ae4e3377f"
+    },
+    "progs/dance_player.mdl": {
+     "bytes": 465924,
+     "sha256": "d07f23e6a40743aeac01084a1da9670ea9a635339d86be46149e9f0ee74661e0"
+    },
+    "progs/explode_box1.mdl": {
+     "bytes": 49888,
+     "sha256": "c8a7e667c5e20735db9a816b7a11b5a1c67bf4e176d1553a79cc56bcaa9ff35b"
+    },
+    "progs/explode_box2.mdl": {
+     "bytes": 49888,
+     "sha256": "649dbfabde0a875a0c35b0109261515dc9eb287d0cc7f41ca3712283e62509c1"
+    },
+    "progs/flame.mdl": {
+     "bytes": 41668,
+     "sha256": "d6cb4dc28d5101538b44ed53fe1cf84c9d5f8547a91eb74fc6c6bdd3645ffa17"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 74548,
+     "sha256": "f03dd3b7f94a86c4d91ffb002723a16f30321a0c2189b673dd4f12f547245816"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 71268,
+     "sha256": "b1e734caec73b941b1c033fbb49ffc0f947aa8e1d47250c2d8cec0f244870fc8"
+    },
+    "progs/g_ghook.mdl": {
+     "bytes": 64684,
+     "sha256": "9cdd8bccab5f11ea7f8ea6480a4ea05c9d749bc4746cc19a6452a2e0356edfc6"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 32404,
+     "sha256": "b195b37f7e96274ea7db8e70dcf5971275bafdd0c9c10c29f2dc540c38641953"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 35876,
+     "sha256": "8ee090222c89209eec97120d5542d69a9f75b8a8aa896cd4df256d438ce83495"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 25316,
+     "sha256": "261a8479de0d5df9aea9931a62b1b93dbb7bfcff4f4467920cbebcc9c2c25381"
+    },
+    "progs/g_shadaxe.mdl": {
+     "bytes": 398968,
+     "sha256": "19d6f210a771748da589282e63a222c6c9c41a21085ed3f57f70d7f5aa20bd66"
+    },
+    "progs/g_shot1.mdl": {
+     "bytes": 24580,
+     "sha256": "72913fa948f1618347adaa91ceb98203186d2fc7bd3b9c84af00f7f637928058"
+    },
+    "progs/g_shot2.mdl": {
+     "bytes": 15876,
+     "sha256": "8ae318a3e697e4c85f60a4e5997b673e8e48f17e295551c2b0b5d0c643b3ac24"
+    },
+    "progs/g_shot3.mdl": {
+     "bytes": 156216,
+     "sha256": "8a602686e322d7357a102e0c8e91907c8b3975a8b6d36ba19f3c645e450285da"
+    },
+    "progs/g_zershot.mdl": {
+     "bytes": 68020,
+     "sha256": "3439ce2faa846bd2b3ca50e33b55092454ed83caaf8fe654d8381e107aa3520a"
+    },
+    "progs/gib_1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib_2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib_3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/gib_4.mdl": {
+     "bytes": 7468,
+     "sha256": "29f9cfa3d86121e1e349de9c3a39e620b9d6ba2cd98640536923e581f7ae28bd"
+    },
+    "progs/gib_5.mdl": {
+     "bytes": 85308,
+     "sha256": "2023ae2fd305843640266ec6679511d134e1b84ac54de245a390e483557050bd"
+    },
+    "progs/gib_blclaw1.mdl": {
+     "bytes": 32860,
+     "sha256": "303c38aea48534d4ce34f3c2082a21c7408c1e4a4cd848bc7e4acadfaaddbdc0"
+    },
+    "progs/gib_blclaw1b.mdl": {
+     "bytes": 32860,
+     "sha256": "c22db765c594ee28a0863cf70e354c651a2b9282e1df7e3a57b35ce62932920d"
+    },
+    "progs/gib_blclaw2.mdl": {
+     "bytes": 32860,
+     "sha256": "c7d70c4c067aa297fbebc3d26a2068a62f307c7f00f8d15d0bf76ed9519967c8"
+    },
+    "progs/gib_blclaw2b.mdl": {
+     "bytes": 32860,
+     "sha256": "96a96606a74eb3093d88f1f946d66caf77bd57fde0a4ec44840c95fa12130551"
+    },
+    "progs/gib_blfoot1.mdl": {
+     "bytes": 32860,
+     "sha256": "74e05efa33fc9036399a1f1d484a3816129fe0e379aee579b923cf3316e5ab84"
+    },
+    "progs/gib_blfoot1b.mdl": {
+     "bytes": 32860,
+     "sha256": "2d23324414f3f1a25ee24afe914679d07df244c9c0e48139331f084b8c369054"
+    },
+    "progs/gib_blfoot2.mdl": {
+     "bytes": 32860,
+     "sha256": "c2ce3b46d8762b042d201608271c3441b975b93e6329790ca5cba61294f71e45"
+    },
+    "progs/gib_blfoot2b.mdl": {
+     "bytes": 32860,
+     "sha256": "de945be28e0b05dc380a0a2cfff6907f14a5e4b9756385874fddd712df095bb6"
+    },
+    "progs/gib_dmclaw1.mdl": {
+     "bytes": 49248,
+     "sha256": "be5f2bb9174ce47f6d3df06685ac728c852c3a028f6aeb1632e709eb69c20ee2"
+    },
+    "progs/gib_dmclaw2.mdl": {
+     "bytes": 49248,
+     "sha256": "ff6cc88ef9123812b9d8e09235074f4c7fcad47077e6fffee334f15e3f71eb27"
+    },
+    "progs/gib_dmleg1.mdl": {
+     "bytes": 49248,
+     "sha256": "106990e4d9e2746303d09ae6c481914702af0242d8cf0fc9d430d0fa5329813c"
+    },
+    "progs/gib_dmleg2.mdl": {
+     "bytes": 49248,
+     "sha256": "8308124b7c4dca218af9e8ef7042ddcb0ca2fcb30e7f86866b1a28a73ab94db2"
+    },
+    "progs/gib_dmtail.mdl": {
+     "bytes": 49248,
+     "sha256": "6b60c464ee0e7ace54313550ac5be2f4949cc6f8dd539b38459c4a6c395e6704"
+    },
+    "progs/gib_drolearm1.mdl": {
+     "bytes": 18324,
+     "sha256": "a6b0f55da1b1d8e519b3cb9a53afe229279c760ffab3862866d8c4e7a52f267e"
+    },
+    "progs/gib_drolearm2.mdl": {
+     "bytes": 18212,
+     "sha256": "aff67984dc3198d24d2184c35748e829d7f867c38227f1fa898a1986f12ac767"
+    },
+    "progs/gib_droleleg1.mdl": {
+     "bytes": 18436,
+     "sha256": "ab69d8c271f44998ccdfd10d70ccd06caa3c2674f46e4cf94285b380d08db501"
+    },
+    "progs/gib_floyd1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/gib_freddiejunk.mdl": {
+     "bytes": 71364,
+     "sha256": "13763a8cec3b643acb9b8165f1850ffae003131c84a2ac225777822a88462498"
+    },
+    "progs/gib_gargwing1.mdl": {
+     "bytes": 92088,
+     "sha256": "3979718d2403ca7cf75aad4004a56100c1bf358f2cb9ae68595e5d69f6774f47"
+    },
+    "progs/gib_gargwing2.mdl": {
+     "bytes": 92024,
+     "sha256": "7554ef45a88db1f2e457dd7071770e42bf864123827b9819435a628b412ecb32"
+    },
+    "progs/gib_judgeboot.mdl": {
+     "bytes": 199308,
+     "sha256": "557eadb703666c4868e1b231cb1c21fbff5e59e2ec0cb8ade85cd3839fd714cb"
+    },
+    "progs/gib_judgeshould.mdl": {
+     "bytes": 199132,
+     "sha256": "69e4958866a47d5c63a6385db4843a6a5011f149b25e67720291d2db63945ed8"
+    },
+    "progs/gib_justiceboot.mdl": {
+     "bytes": 264848,
+     "sha256": "b727239a7bf232c7c6164d0f9fc0961a6c692cb0c0919b17429ade6f62bdd71c"
+    },
+    "progs/gib_justiceshould.mdl": {
+     "bytes": 264672,
+     "sha256": "2fcafb2b2a19b8ae16009e827f13fea14cb389317ec476b7f58fb2fef1163180"
+    },
+    "progs/gib_knfoot_l.mdl": {
+     "bytes": 18288,
+     "sha256": "8ffcc7ce931662f2eefa0703642b140e18a99c02252ffa3ddeb71f6ebbbe360f"
+    },
+    "progs/gib_knfoot_r.mdl": {
+     "bytes": 18288,
+     "sha256": "4d503f422ac01a8565453ba4bd8268338c3a9802480785eebd27fc0487e46753"
+    },
+    "progs/gib_metal1.mdl": {
+     "bytes": 5172,
+     "sha256": "b0951de4d869e0b779aeb3f7a96f56b22a82a58d267a56b1247f0c3e667c25ad"
+    },
+    "progs/gib_metal2.mdl": {
+     "bytes": 6292,
+     "sha256": "3df78c49abb572095d3b70efbb99bccb63caf2ffd30bb3ee434c945084acb5a0"
+    },
+    "progs/gib_metal3.mdl": {
+     "bytes": 6036,
+     "sha256": "88f8a1f941e38f8528ec27a168559946cc0b69f2abce1cbf6858b813e09c5f51"
+    },
+    "progs/gib_metal4.mdl": {
+     "bytes": 6580,
+     "sha256": "fbde734f29a6691d51c58a40a89e45f81dece2f20218353a6137a2362acbe3a9"
+    },
+    "progs/gib_minoclaw1.mdl": {
+     "bytes": 135544,
+     "sha256": "1188f73d5a6319bef5e506ca994bfcf63074a4267a5a189cb92db94160310fca"
+    },
+    "progs/gib_minoclaw2.mdl": {
+     "bytes": 135544,
+     "sha256": "511bb72c8382f4cc3cc9fa3bea4adf2390dcca1e2dcd42ef8f8287765875fa99"
+    },
+    "progs/gib_minoleg1.mdl": {
+     "bytes": 135448,
+     "sha256": "f07ce357d83d3ab0f39109d93f2f6996ded4ff19a4372fd5ddc9d9fa1a0ce8d3"
+    },
+    "progs/gib_minoleg2.mdl": {
+     "bytes": 136392,
+     "sha256": "7ba78149bc60a05ceff9090ecc2bdf013ff2d55420dfdebc553a254ac0bd08fb"
+    },
+    "progs/gib_ogfoot1.mdl": {
+     "bytes": 5956,
+     "sha256": "144e2fdfbccceee039243ef343df02ce181b666070e2d0a1825c056634f2a632"
+    },
+    "progs/gib_ogfoot2.mdl": {
+     "bytes": 5956,
+     "sha256": "9997dff0bdb2622ef6ee2530c27835fd249aee04437e70486e76255f979bec25"
+    },
+    "progs/gib_p1.mdl": {
+     "bytes": 7712,
+     "sha256": "709c49c205b27793f589eab17e8356a108345069716f9095dc07dd6447be7894"
+    },
+    "progs/gib_p2.mdl": {
+     "bytes": 21216,
+     "sha256": "50d99c7fec3b8ef01bbb19c32c88dac40a372cb6a7d39c349e0ff4909360626f"
+    },
+    "progs/gib_p3.mdl": {
+     "bytes": 18176,
+     "sha256": "d53659aa99de418793337b7e878db7bd7836883ad43528d648475589aa30d85d"
+    },
+    "progs/gib_p4.mdl": {
+     "bytes": 7468,
+     "sha256": "71ad4dcc06038f0a175605a3906b1506d0144b56b238e7df178160d9ab876b8d"
+    },
+    "progs/gib_p5.mdl": {
+     "bytes": 19756,
+     "sha256": "adf63c881ff5703b8112f714140929375b5c10be957f01cfdfa131d89af3cacf"
+    },
+    "progs/gib_s1.mdl": {
+     "bytes": 7712,
+     "sha256": "31faee0daaf399feccc1ec942ff7fe85a1a790ebd93c3b8a1fcfde9bcc06da1d"
+    },
+    "progs/gib_s2.mdl": {
+     "bytes": 21216,
+     "sha256": "c85f7dbc8eec508951893253bba5eec169a87865c995ba1d0e5c083fed9e03ca"
+    },
+    "progs/gib_s3.mdl": {
+     "bytes": 18176,
+     "sha256": "ec23effca60ef407bf294a814003213928f21f05e6da501fbe996345b6171013"
+    },
+    "progs/gib_s4.mdl": {
+     "bytes": 7468,
+     "sha256": "5001ef206e1a36cc792d7b94054b2bab4c6dfbed60e0ee0d3afd240d1af88d13"
+    },
+    "progs/gib_s5.mdl": {
+     "bytes": 19756,
+     "sha256": "9e1a112412d38c559974c628649a7773ad445ba7d24a1804c5f3fe5f50ecef7f"
+    },
+    "progs/gib_scorpclaw.mdl": {
+     "bytes": 66816,
+     "sha256": "ecaf582e92d77a1722eded2c5564d2fb9575065510ff1bc9632538345ed18329"
+    },
+    "progs/gib_scorpleg.mdl": {
+     "bytes": 66304,
+     "sha256": "399067acf8f082301f6629d2b124b0d34a7d934db55c922205a96772a85a8a1c"
+    },
+    "progs/gib_scorptail.mdl": {
+     "bytes": 66864,
+     "sha256": "0831c04d7a73c6f58329b0be0f6d371f727ea880b49e5b6e16f7cdc56c124df2"
+    },
+    "progs/gib_seekarm.mdl": {
+     "bytes": 265688,
+     "sha256": "6ee70b2f4f39d8a1fd99113c7c8df5481c421960f160afea4e622ed5b3113014"
+    },
+    "progs/gib_seekchunk.mdl": {
+     "bytes": 265420,
+     "sha256": "a70331a8e43075b026cf21d364cf2341e79e7e60c5fca4777d10aabd57ce0323"
+    },
+    "progs/gib_shclaw1.mdl": {
+     "bytes": 22964,
+     "sha256": "20b29bf40dd02dce0204c14c34b0b5806d8eef580406851d73383a631ac8f2a7"
+    },
+    "progs/gib_shclaw2.mdl": {
+     "bytes": 23060,
+     "sha256": "8dcf777d5ffd2e83edf5b6f936881eaf9d384fe8fc980721c9f5881d3e6da0c3"
+    },
+    "progs/gib_shfoot1.mdl": {
+     "bytes": 23268,
+     "sha256": "634d7cbb9e2b718167fe74112e6dd4f53cfe1cffc32f75cd80e711a24cd2f983"
+    },
+    "progs/gib_shfoot2.mdl": {
+     "bytes": 23124,
+     "sha256": "aaa2393cb65fb33a8885bfdd9b808732c0aa17f0dd461d3b04e84eb27f0fe61d"
+    },
+    "progs/gib_soldfoot1.mdl": {
+     "bytes": 51148,
+     "sha256": "09357cfed1e6c9c25e0d133d95f2c2b36693cbed1010146a982bca685cb370ed"
+    },
+    "progs/gib_soldfoot2.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/gib_spidbodyb.mdl": {
+     "bytes": 17652,
+     "sha256": "313dc78de70f02de9a49c71a1fd5ddb5ae4247f90a1a04f0ab84f44797be1946"
+    },
+    "progs/gib_spidbodyg.mdl": {
+     "bytes": 17652,
+     "sha256": "5439ca0812bc2627f22fd995237607755708f7615782785093793c11497973e5"
+    },
+    "progs/gib_spidlegb.mdl": {
+     "bytes": 18560,
+     "sha256": "66dc12710dec1bd4827497e4ed28b6a4965e1f68b48d5f0903a96ecf632e7f4e"
+    },
+    "progs/gib_spidlegg.mdl": {
+     "bytes": 18560,
+     "sha256": "3474de5b97c2b424f8ec4b8d93a1457f13adca106bdbe15234492376708810f9"
+    },
+    "progs/gib_steelbody.mdl": {
+     "bytes": 17652,
+     "sha256": "2a833de4b00f439041d27d97b3660d4df1cc9e3b454dba5ac5533e5c855e8d90"
+    },
+    "progs/gib_steelleg.mdl": {
+     "bytes": 18560,
+     "sha256": "ae926ada1c4ef7b695764f2daa0b4704102bf5eebc103b9f6a56813337f43165"
+    },
+    "progs/gib_swampleg.mdl": {
+     "bytes": 4820,
+     "sha256": "2b549fd3a74b0fd6b94c71c9e397b466e2c7f823917ffe717ce1af43769e1961"
+    },
+    "progs/gib_swamplegp.mdl": {
+     "bytes": 4820,
+     "sha256": "b5cf22240bf6474cc8ea57c40ddb70f80e792c23cb87835bee94825cb645578a"
+    },
+    "progs/gib_voreleg.mdl": {
+     "bytes": 4820,
+     "sha256": "19ec59cb3436d66a8ac9d8f40480a9c83aef879f0f1e58ddb834710e2bbc4d9d"
+    },
+    "progs/gib_vorelegp.mdl": {
+     "bytes": 4820,
+     "sha256": "341679c553a719be40022fc4a3573ff68116fee7ae05df511b9083a410af5e7f"
+    },
+    "progs/gib_wraith1.mdl": {
+     "bytes": 5300,
+     "sha256": "a0642c84b36288a3d0cef22ac32e0c681c422a034204932671729624f19d0b2b"
+    },
+    "progs/gib_wraith2.mdl": {
+     "bytes": 6292,
+     "sha256": "d20a17e624d16e4c8552ac9a291cd735aeae670effc2c9865b37fbc7bcd22220"
+    },
+    "progs/gib_wraith3.mdl": {
+     "bytes": 2516,
+     "sha256": "63f10b068c6df0a80729362c094f72d0bcf90f74de97636bc5e4a630c13e741b"
+    },
+    "progs/gib_wzarm1.mdl": {
+     "bytes": 12384,
+     "sha256": "9b6f5469bfc6ae49d2bd51fb6d35e686c4e79e5691e2fb80fa7ee556bf547e04"
+    },
+    "progs/gib_wzarm2.mdl": {
+     "bytes": 12384,
+     "sha256": "2ff539f467ca9b0f23c40cb2547221a484afbe7e07a812558ec1595e5cbd0217"
+    },
+    "progs/gib_wztail.mdl": {
+     "bytes": 12384,
+     "sha256": "fb90123980ff4510e744ea2b21509492b7ff9c131527ffe5c7b80bbbf881bf41"
+    },
+    "progs/h_boglord.mdl": {
+     "bytes": 98400,
+     "sha256": "119279b2ffdf928d34ef1470ae6c14f875cb59edc6d8b107a90bbea122c9acdc"
+    },
+    "progs/h_boglordb.mdl": {
+     "bytes": 98400,
+     "sha256": "25af0d0ea45857e64549686bb58e5f69a0754ff6e43c26ce735e58aaac3d534e"
+    },
+    "progs/h_centurion.mdl": {
+     "bytes": 63592,
+     "sha256": "2e64af530a4f5f36001ad922bb56a941738e7fe2c67c0ad0e3f06fa5854c4b08"
+    },
+    "progs/h_dcrossbow.mdl": {
+     "bytes": 25700,
+     "sha256": "0354fdb96bd5490bc18527d68813a43a41f943a05f7edca26c1aea7b943185be"
+    },
+    "progs/h_deflector.mdl": {
+     "bytes": 22232,
+     "sha256": "56de00c315543073bfda7e8a5ad3c3996f549351fa1e660e676516f4122cdeac"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 67688,
+     "sha256": "ff73d5f8fcab46a806c47377679ec5473cdc0ea93a0fda6dda8b5dba8cfa4b97"
+    },
+    "progs/h_dfury.mdl": {
+     "bytes": 14036,
+     "sha256": "3753a68126ff7caee3219c31533a1731ae9a80623c6af69315c7526f5c92669d"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 19296,
+     "sha256": "6b0867e61635543a7bb3b02647855f1384961095cd06dfc786a537b11eb926ae"
+    },
+    "progs/h_dguardq.mdl": {
+     "bytes": 4920,
+     "sha256": "337f2723daab9d1375b78cb017512ce8281087ff8df9c33b04a6c613cea3590c"
+    },
+    "progs/h_dknight.mdl": {
+     "bytes": 32144,
+     "sha256": "30af2418019b946f3582f70d2356357a97dff0391f86a9fb0abd5218cc799020"
+    },
+    "progs/h_dlord.mdl": {
+     "bytes": 18699,
+     "sha256": "bc5a92be1c5f3d06dc0238ec7bafe6a3c25826cc50edc6214ed5aa19b0075987"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 27652,
+     "sha256": "49f28b9a13867ed4a88fcac541b8a9cbabddcc594557b3490951179b3d479509"
+    },
+    "progs/h_dprince.mdl": {
+     "bytes": 19336,
+     "sha256": "77855cfc2667ed68c61d389a44ed312abc3ad1e029ea003d03e78e7131fb803c"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 14032,
+     "sha256": "bd5da6afddc520999d9c572a679c3bc8c43635ce2c73f8789603eb6a83c15aa1"
+    },
+    "progs/h_eel.mdl": {
+     "bytes": 156904,
+     "sha256": "a859ee09044d9afcd05ee2af3f1ea8c7b4ae3abc01273922dbebd5aa67b12d74"
+    },
+    "progs/h_enforcer.mdl": {
+     "bytes": 94612,
+     "sha256": "21046f6878f5f4173206debcb912d9fdee0b1f5c66d820a4355c7df8e2eb1860"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_gargoyle.mdl": {
+     "bytes": 30152,
+     "sha256": "bbcf207c44814f5e665944db03800934eab9046a0d0d86f4c982a3116f855791"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 59888,
+     "sha256": "f57daa1ab6a721a9feb696aaeeb597c720b639cd0a027a1b1da8cdd68ad1d1f0"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 30552,
+     "sha256": "edf8a4ccc52bfd9545fda8da9360e536c026079f8d2fd9756191fc934bd55683"
+    },
+    "progs/h_hogre.mdl": {
+     "bytes": 23688,
+     "sha256": "6f21e95518cd085d20b1023951ddf4d738285210bc95c6e2b3d2e82566478776"
+    },
+    "progs/h_hogreham.mdl": {
+     "bytes": 22776,
+     "sha256": "3d3e43d16c4babcbca358b44dc03ad1a212e22ea3a10ee9e639b5f4c2e95f670"
+    },
+    "progs/h_judge.mdl": {
+     "bytes": 203276,
+     "sha256": "be57ef7327fbf3ea6fb55c02bcccc4ec207b3781bb9d2e383939f3840e1ef91a"
+    },
+    "progs/h_justice.mdl": {
+     "bytes": 268816,
+     "sha256": "01d3011001c297b85a139ecb2861f188d15b96cd1ae02f08cb1604565f2d2ee3"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 42068,
+     "sha256": "aa979e22745c960cd100e814bce62018f2b992481e57838548f0ddf4816c27a8"
+    },
+    "progs/h_minotaur.mdl": {
+     "bytes": 138264,
+     "sha256": "c5e13818c813680fd29a94b408518731aa4e9007c23d004ec874f099c9ced6b1"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "4967d418f4810e9273732bbd4c690a1f9478243f7fe3807497134eb2994da0eb"
+    },
+    "progs/h_pyro.mdl": {
+     "bytes": 42912,
+     "sha256": "5359fd85e71cde1ab716d8d50a8618a347dd42b4ad4692805bf41c1903d55c18"
+    },
+    "progs/h_scorpion.mdl": {
+     "bytes": 67408,
+     "sha256": "d68d09c35c00d9bafb302fb7f3baeef90ee5d60de1ad8a7627f979c3561f5965"
+    },
+    "progs/h_seeker.mdl": {
+     "bytes": 9060,
+     "sha256": "9e9d601441532e16aee253b5e94ea9c32563f880782794d16ce496a580698bd8"
+    },
+    "progs/h_shalrath.mdl": {
+     "bytes": 78156,
+     "sha256": "f478f17ea9ee6843be2ebe3c487d0036657c94ace52a800fa44e0160d02a522d"
+    },
+    "progs/h_shambler.mdl": {
+     "bytes": 98400,
+     "sha256": "6508f7b05b65f230b7f1280d2023e9ed200663715db1709c43e7e187e3ed841c"
+    },
+    "progs/h_skullwiz.mdl": {
+     "bytes": 234304,
+     "sha256": "625c991e231d6836c36ae0c6651ec06f05541e9a7be605654fb43fba65bcc3d4"
+    },
+    "progs/h_soldier.mdl": {
+     "bytes": 166488,
+     "sha256": "0a4e322fbac8f98755adb9a4bf5ecff24d58aab30fcb1c9def3e97a0f686445e"
+    },
+    "progs/h_spiderb.mdl": {
+     "bytes": 18564,
+     "sha256": "d51c7764fccc4512db6d79ddcf03ffe42cf2817a66d6be02be0cba6551ee1206"
+    },
+    "progs/h_spiderg.mdl": {
+     "bytes": 18564,
+     "sha256": "70bec9669f3a7f3662320e32d29c38d535092db56617d5033e11669038472e2b"
+    },
+    "progs/h_steelclaw.mdl": {
+     "bytes": 18564,
+     "sha256": "be9adcdf9cf9407a729cfa9abcd692f46a55ffcf25c1878a7b2f5572fd591f8c"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "63b8a0b90691ae9a3c50a94f02943a1b94946f89402cc4e1da74c6806bd953ba"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 23516,
+     "sha256": "5a933ecbc067b8d6cbb57f71ae1614844b6e55170a206d278b3d15fe619c9cfd"
+    },
+    "progs/h_zombiek.mdl": {
+     "bytes": 4920,
+     "sha256": "9b8b3af67bdec6160ecd3880acc072b833886f7fc11d1e64ffcf06184f9ba80e"
+    },
+    "progs/health_100.mdl": {
+     "bytes": 6948,
+     "sha256": "6c6646f6081ab00ed1c309de3b697009c825d64360b06c741a533b718e0ab8d7"
+    },
+    "progs/health_100b.mdl": {
+     "bytes": 23248,
+     "sha256": "d82148af4482e3c0ff07389ebb5b09cdefda373e31105aeb7308b4126b353a97"
+    },
+    "progs/health_15.mdl": {
+     "bytes": 6788,
+     "sha256": "838b0cb6fd11ff7fdf268b1607a1999e5dce0dea11386afe5ff207e6ff734aeb"
+    },
+    "progs/health_15b.mdl": {
+     "bytes": 10948,
+     "sha256": "eb1bb584805aea34a0f0ab846a758cdc359b730e144e141dcd756da23b5831e1"
+    },
+    "progs/health_25.mdl": {
+     "bytes": 7332,
+     "sha256": "ce8260929500cac3b57617345b2c6b5a75e763afdbd10120982e7d7fa55be27a"
+    },
+    "progs/health_25b.mdl": {
+     "bytes": 23248,
+     "sha256": "7aba68839958035319b2167369f3fcd08c9d49140969cff7fb523b7023362e00"
+    },
+    "progs/health_5.mdl": {
+     "bytes": 6164,
+     "sha256": "a8ba7ece01b3cb58b2f94ca20a9f4511871d26ec894b54c04e433f29fc7c3bef"
+    },
+    "progs/key_base.mdl": {
+     "bytes": 54436,
+     "sha256": "fb25488fa2fc16c7c4df260a20fd905a821607a675fd0907a6e65f9d534fd367"
+    },
+    "progs/key_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "2632cb327c1175b351d026e88a4e456c45779a0dcdae01381b24200769c8743f"
+    },
+    "progs/key_gold.mdl": {
+     "bytes": 9332,
+     "sha256": "e93ed2c4263bf7631efcbace2c36ed6f240bfcc2b49491751f6d6ce55db8c098"
+    },
+    "progs/key_medieval.mdl": {
+     "bytes": 58532,
+     "sha256": "0810c558e40c5833c19283eb849ba80ac5dd3499e0f077b724057c51730ee097"
+    },
+    "progs/key_rune1.mdl": {
+     "bytes": 18900,
+     "sha256": "90ac269965d42da0205307eeeaddfa5b282598b5218af8650d2d8854621ca950"
+    },
+    "progs/key_rune2.mdl": {
+     "bytes": 19828,
+     "sha256": "4a6644f0b583c85aa41362fb4533cda5f8f762bd4429e5007b3ab57e5e24ae57"
+    },
+    "progs/key_rune3.mdl": {
+     "bytes": 19700,
+     "sha256": "9b33cc0feed9fc27ea647f6d127941933aa5378b52a3f75b9331714fa9d2ff31"
+    },
+    "progs/key_rune4.mdl": {
+     "bytes": 19220,
+     "sha256": "515534b8fdaa0ef99621f0f7d59d268c0c244562372e23c13e9ce05a44e0a68a"
+    },
+    "progs/key_runic.mdl": {
+     "bytes": 57444,
+     "sha256": "e0e31948c1e172c3c9117a8ccd72900c6ebd7a7e73882ae525dd116230f054e2"
+    },
+    "progs/key_silver.mdl": {
+     "bytes": 9332,
+     "sha256": "dd54032e82de32cf1b78a25f862a82a73e9dc0926d89ca7a4279b45d367a8478"
+    },
+    "progs/misc_bmkdigit.mdl": {
+     "bytes": 3328,
+     "sha256": "1a7f2f762ef3a052a91db7c74cf8d980db47a56685fc61184a15be2152e843b8"
+    },
+    "progs/misc_bmkdigit2.mdl": {
+     "bytes": 3328,
+     "sha256": "2e690ffe1af05f5ad88fe90c180785adeeffdb2b330aa34c6f4fb9885285cd1e"
+    },
+    "progs/misc_bonepile.mdl": {
+     "bytes": 110796,
+     "sha256": "0f8061359681f3c11660e472c517599590447c7631edfe5a36debd9645acdec6"
+    },
+    "progs/misc_book1c.mdl": {
+     "bytes": 40096,
+     "sha256": "92b976437673f56cb890f0e1b90a550ea00939d01ee12b0df0f218b35b42953e"
+    },
+    "progs/misc_brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/misc_braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/misc_broken.mdl": {
+     "bytes": 744,
+     "sha256": "828998b238e1c5471461edc3b9d2d7fada2beab6229272041dff13a94c1d73ec"
+    },
+    "progs/misc_cable.mdl": {
+     "bytes": 57780,
+     "sha256": "bed2cca38ef4cbefa9e645eb5e9ffadffac6ebb4f2ac5f6da4bb8f354de22a48"
+    },
+    "progs/misc_candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/misc_candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/misc_candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/misc_chain.mdl": {
+     "bytes": 231184,
+     "sha256": "845fc3117f7d9860f2d0aa4a398103a13f327516144a96db508189ae1be5788c"
+    },
+    "progs/misc_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "3337f2cfe739c22d50edde7bff18c026d4336bceb207dacf8b0284ab0a5366cf"
+    },
+    "progs/misc_corner1.mdl": {
+     "bytes": 21668,
+     "sha256": "7abf8d5ca497d5e8c8ddcc09c710c0401edb71b11f9de77a2daa81b1267e5698"
+    },
+    "progs/misc_corner2.mdl": {
+     "bytes": 21348,
+     "sha256": "369c874a37ef1da8c9a79432ba2ab9484a5be0df120131b8cbac81e1786adf47"
+    },
+    "progs/misc_deadtree.mdl": {
+     "bytes": 195728,
+     "sha256": "d267db8cfc35b01430590cec643570b38f8df5872c9c3e43df31dc0f3a954e5b"
+    },
+    "progs/misc_digit.mdl": {
+     "bytes": 3328,
+     "sha256": "60f16b89c1e9b8fb8bea0c0aeb96d2dbcfc14a719c130aaa34a581b26e653416"
+    },
+    "progs/misc_doomhelm.mdl": {
+     "bytes": 70104,
+     "sha256": "1b801d032daa163fab361a39631a16c501b86cc9e9b1a52a3f1454e50cdb8c8d"
+    },
+    "progs/misc_dpull_s.mdl": {
+     "bytes": 12900,
+     "sha256": "77fed0a028829fc7120db625131f855faf9b35f97f6ce0591e224bfae0fa78e6"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_fixture1.mdl": {
+     "bytes": 9768,
+     "sha256": "c10980d00e0479f8e65ab633f19ee62ace4c0697c2193f7aea8d266e2be5fc2d"
+    },
+    "progs/misc_flag.mdl": {
+     "bytes": 16052,
+     "sha256": "f2670312a8d16dd16e42fd02a39dfd285e6ffea624e729597b773c86140631d1"
+    },
+    "progs/misc_flame_big.mdl": {
+     "bytes": 244895,
+     "sha256": "09adba1308cdf22d2f07e226cb13a35e51f4d54866f84f41e2074dc7a40371d5"
+    },
+    "progs/misc_flame_med.mdl": {
+     "bytes": 175400,
+     "sha256": "31c94bc48e6c6d6bc31bd14b8e257c4e74d45aaec3a4d5d5bf83587a08ac7c00"
+    },
+    "progs/misc_giantbell.mdl": {
+     "bytes": 74016,
+     "sha256": "0d1b0e150de4ac59c599deae96d6b21e4ceb2300e7d410a1d802385dad99560b"
+    },
+    "progs/misc_heart.mdl": {
+     "bytes": 3512,
+     "sha256": "827ce2bbf2037aa26259901f4152d114cdf38312652e65e53f64ebbad9ea0849"
+    },
+    "progs/misc_impact.mdl": {
+     "bytes": 880,
+     "sha256": "93029307003bd0437071e0a89d0d4c2b699f2cde6ba34242c321cba8243f36b9"
+    },
+    "progs/misc_jstatue_01.mdl": {
+     "bytes": 1057632,
+     "sha256": "c583186f8bd56fd5ac356a8ed34956090eaad6e78506884bd520307e8f5e5698"
+    },
+    "progs/misc_jstatue_02.mdl": {
+     "bytes": 100260,
+     "sha256": "e4f3e702073a7f76ffddb79921a2bbb880d25edc0bdd6a6f115dfebcf99dbae2"
+    },
+    "progs/misc_jstatue_03.mdl": {
+     "bytes": 100244,
+     "sha256": "587cbce564e4da156a0ae20a87bd551046427f894f34959590573ce96fdf5c31"
+    },
+    "progs/misc_lantern.mdl": {
+     "bytes": 28836,
+     "sha256": "d84e36232543a053f2772b1070b221dc23da1b34cd08ea551a982b5e9f168ea5"
+    },
+    "progs/misc_levels.mdl": {
+     "bytes": 35732,
+     "sha256": "7cf9a4c1e556e60dd4e593cad4a2be0b45bea8893d9b5232ecc7febca4bbf5fe"
+    },
+    "progs/misc_lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/misc_lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/misc_longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/misc_madfish.mdl": {
+     "bytes": 84104,
+     "sha256": "30c19dadb42a53c7ccd35f992c5841aee13a86796157ea5e0453a4cb1586a1be"
+    },
+    "progs/misc_mooring.mdl": {
+     "bytes": 6676,
+     "sha256": "29b20cf17c62dddb4f0c1be758add7b15d6b22fd738fd9e2cd7533ac5d5475f8"
+    },
+    "progs/misc_mushroom.mdl": {
+     "bytes": 10804,
+     "sha256": "5570faa6e7828e4e12f568656226b0756a87d633cbdc461af472e0982a88a549"
+    },
+    "progs/misc_oscill.mdl": {
+     "bytes": 50660,
+     "sha256": "cdc96265a646f9e9fb4c1717fa90edb13e42130fadc4dc774b60aeb94b89eac4"
+    },
+    "progs/misc_player.mdl": {
+     "bytes": 562960,
+     "sha256": "83bbcf4cb5858aa9ac03323b461b3e3b09a28f56e212645472219d7d0b0979d8"
+    },
+    "progs/misc_plinth1.mdl": {
+     "bytes": 6196,
+     "sha256": "1ce0b7f49153f717e04436b27863c75f90a73b027c4cb7e36ce094fa037eded4"
+    },
+    "progs/misc_plinth2.mdl": {
+     "bytes": 6164,
+     "sha256": "e06edd50af1748235b251fe6e4217551c58d45c1f73161014dc0e9fd40099249"
+    },
+    "progs/misc_qwindow.mdl": {
+     "bytes": 77168,
+     "sha256": "facf489ac59158a3013118ca196f11a25a543f26559d5b72eef44968aa05008f"
+    },
+    "progs/misc_radar128.mdl": {
+     "bytes": 19492,
+     "sha256": "ef004e28e51e3227121a92432375531fca26d1e44894696f3d2a950fa65aef28"
+    },
+    "progs/misc_radar64.mdl": {
+     "bytes": 19492,
+     "sha256": "b9468012707ad484c1292cbe984c54811cb8fa43542e68e18a52ef93cb37d52a"
+    },
+    "progs/misc_radar96.mdl": {
+     "bytes": 19492,
+     "sha256": "6239d117263f49b79a2a66e62f2dbd6a7f0cd15ce412c1939dd69b4a1d8fce78"
+    },
+    "progs/misc_seaweed.mdl": {
+     "bytes": 16100,
+     "sha256": "dfbd38a439d392870c7c4c7ebea4475827b716004ca47bfa7f13b47daf07d774"
+    },
+    "progs/misc_shard.mdl": {
+     "bytes": 22388,
+     "sha256": "06c126f77ad931084d38f0e04d8f4341a5db3e3fa827e30de7d05bc60afd1c1d"
+    },
+    "progs/misc_skull.mdl": {
+     "bytes": 59892,
+     "sha256": "94600327093fe22acc113b8e89c8863a5548b170c9c9897bd2af8a4ff63beb5a"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 31792,
+     "sha256": "8d39b97460c9967ee36b33ea1ef1e92e89277fc410b44f054c5e06b8dc8a079c"
+    },
+    "progs/misc_spark.mdl": {
+     "bytes": 12672,
+     "sha256": "42afca9aeac1b05590b4821872cb79ebfbb4ee7264e914316d880e13f69c2b41"
+    },
+    "progs/misc_starfield.mdl": {
+     "bytes": 23548,
+     "sha256": "5b3563017939382680228e933a2a87d3edb030e75e65c51fe42c4a6889e42e15"
+    },
+    "progs/misc_stickskull1.mdl": {
+     "bytes": 87900,
+     "sha256": "38e63e10bc351ba5a48dfb6195ac5f78e5d61e67ae851f2ba50ba20255d7a37e"
+    },
+    "progs/misc_stickskull2.mdl": {
+     "bytes": 116364,
+     "sha256": "464fbee370b512d1c8057ea5a1dc3ecff69378474593919f0bbd8970419d69a5"
+    },
+    "progs/misc_tape.mdl": {
+     "bytes": 9240,
+     "sha256": "2b6a08ca3be4dd7a669e5b6d1585276759e1fb0edbe0691dd7ecbc7e41f0b189"
+    },
+    "progs/misc_textbook.mdl": {
+     "bytes": 74212,
+     "sha256": "e17e39efdf252a3da8c0574fdf272a800095671f42e71a17a3733673202dbfab"
+    },
+    "progs/misc_tree.mdl": {
+     "bytes": 120248,
+     "sha256": "888eca3c464ac068c7cdc5d7cf8f67fbcc70eb13c0079202a4f8d347f5f3bcd3"
+    },
+    "progs/misc_tree2.mdl": {
+     "bytes": 404432,
+     "sha256": "f14f3b046b58e5485afd11d396b4d358eb0598ea8cca1cbc6a70a8e629aee3f3"
+    },
+    "progs/misc_tutstatue.mdl": {
+     "bytes": 178480,
+     "sha256": "d178ba96d99b02113fe70d32f1672c1490d5f570aecf11d168e58f1bb7e8c17e"
+    },
+    "progs/misc_xmastree.mdl": {
+     "bytes": 479516,
+     "sha256": "59a89b398caa908ff6dd777cb42d0d7dfde930ac5569fdab4bc4f10dd8137584"
+    },
+    "progs/mon_boil.mdl": {
+     "bytes": 307068,
+     "sha256": "b8a79df258bf71f273dc29887c3782377bf890d43e32b690ebf2ef707eead6de"
+    },
+    "progs/mon_bossboglord.mdl": {
+     "bytes": 401092,
+     "sha256": "6fb5e0aa99fc9269b21e3a7c86e7ed70bf1f7e0150b629a39a4cf6647d0c9a1f"
+    },
+    "progs/mon_bosschthon.mdl": {
+     "bytes": 328244,
+     "sha256": "7fc4005959377598747d3accec535b52c81154b17b00221e2cd5410670223538"
+    },
+    "progs/mon_bosseidolon.mdl": {
+     "bytes": 1847180,
+     "sha256": "e08c763865b25851703f71e973755d5a7b446c8004f7d97c09fab04175373c10"
+    },
+    "progs/mon_bossicegolem.mdl": {
+     "bytes": 632584,
+     "sha256": "2a03c71a0451c389dc29374fa3a465fb0d8e9366309cbaeffb68057c928562ec"
+    },
+    "progs/mon_bossnour.mdl": {
+     "bytes": 200036,
+     "sha256": "732041ff70ec350c664194f90a9545b23b6736e729dd128f4482a0cca3ab7966"
+    },
+    "progs/mon_centurion.mdl": {
+     "bytes": 824572,
+     "sha256": "e638ad3021c5c77a1ad78fd798017fbb7a0ffa49ca2fc4a60570ba00e349d532"
+    },
+    "progs/mon_dcrossbow.mdl": {
+     "bytes": 1335168,
+     "sha256": "b38a7967cf800fdb45f9df9aa717ebc1c069fc8686a8e3e414f1c81d51f81d14"
+    },
+    "progs/mon_deflector.mdl": {
+     "bytes": 300016,
+     "sha256": "2bba37156abcde4ad2e7fc532a92b8139d4fc8041b565cd1e487829dc581341f"
+    },
+    "progs/mon_demon.mdl": {
+     "bytes": 156640,
+     "sha256": "9f1714fe997a78c9d3948e593a73fa3fe5704e11809ba095b8f564fca36b36c0"
+    },
+    "progs/mon_dfury.mdl": {
+     "bytes": 1495580,
+     "sha256": "0cb312b27bc1c9a7f9ac3d8c14e1e0d422d9968d4a9db0853d73185a19d6839d"
+    },
+    "progs/mon_dfury_glow.mdl": {
+     "bytes": 155140,
+     "sha256": "f743168f636c9e56475d73b3f8e139e5391e2abf0da4a6657174a7adc0f74238"
+    },
+    "progs/mon_dguard.mdl": {
+     "bytes": 724744,
+     "sha256": "1babb2976f1f86c2e499d3b8e83f4e4c04e434151bcb96a932a99a89b2bf3699"
+    },
+    "progs/mon_dguardq.mdl": {
+     "bytes": 176648,
+     "sha256": "f2f92ef84411d83c7e8c158f62b1415d8fc6aa56d77f21760dcd3080424cf6c8"
+    },
+    "progs/mon_dknight.mdl": {
+     "bytes": 1124632,
+     "sha256": "437c54ecfed53e34891b981a565c9b4f772c19702e1c099bba5ac40aabbed917"
+    },
+    "progs/mon_dknight_glow.mdl": {
+     "bytes": 971020,
+     "sha256": "22888d6171fc8df336fe686f4ffdfb0683bdb744e59cf81af9484b700666f6cf"
+    },
+    "progs/mon_dlord.mdl": {
+     "bytes": 1142583,
+     "sha256": "fb2ce7f5fbe369307f3eaefe0a74fffb2004657bec058dae50db651bc2fbc70f"
+    },
+    "progs/mon_dog.mdl": {
+     "bytes": 460652,
+     "sha256": "52cf8cb501f4b1ed457961b798eccd86974720af29f559723be82a0886824fd9"
+    },
+    "progs/mon_dprince.mdl": {
+     "bytes": 1022224,
+     "sha256": "aadd9ea12f307f0ef2b600a4a78d73082b8ea2eadd408f1fbe298082f4d03374"
+    },
+    "progs/mon_drole.mdl": {
+     "bytes": 241648,
+     "sha256": "2d5524d75cd52f12b42a5dfdd37bb33af27233394ec60bc234f79545d1cf13b4"
+    },
+    "progs/mon_dsergeant.mdl": {
+     "bytes": 1431784,
+     "sha256": "1affce6e3cbae9b5df1986672030fd869aa020972872767518f18ccc495c7432"
+    },
+    "progs/mon_eel.mdl": {
+     "bytes": 177368,
+     "sha256": "6acb4804e51e7de33404a4519d7f12b2413c921f61e33107345cb111ff156f96"
+    },
+    "progs/mon_enforcer.mdl": {
+     "bytes": 622480,
+     "sha256": "0e32f70f205a74995936d56e22259d1ccde591ed8a533577cd276419c5f60013"
+    },
+    "progs/mon_fish.mdl": {
+     "bytes": 311132,
+     "sha256": "40351e57dec8fad0aa34e5e5da233274e007a3beb80a291c9a2aa40ed43f8f00"
+    },
+    "progs/mon_floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/mon_freddie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/mon_fumigator.mdl": {
+     "bytes": 415072,
+     "sha256": "31bb90976e7489693c68fd6713ed5f1baf9645e3d7871922901dd093e8243da3"
+    },
+    "progs/mon_gargoyle.mdl": {
+     "bytes": 388132,
+     "sha256": "fe8134f2305858519445eb513b22f1f3382a1a6f334cf9549ddf1efe0b88435c"
+    },
+    "progs/mon_gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/mon_gaunt_elec.mdl": {
+     "bytes": 7164,
+     "sha256": "05129692bea7b62f2f5b7285cf133590e9356bfa0f6162ef6e3fc44508b29d8b"
+    },
+    "progs/mon_golem.mdl": {
+     "bytes": 632584,
+     "sha256": "c345c57eca380796f5dbcbdf7df80975c24e856d6d70ed1e9c11678f5d162c44"
+    },
+    "progs/mon_hknight.mdl": {
+     "bytes": 275836,
+     "sha256": "e32a90ca707224a389b7b0d3ecde76220e23f7746c2bc4e6397fe0d3a601844a"
+    },
+    "progs/mon_hknight_glow.mdl": {
+     "bytes": 212112,
+     "sha256": "60c24cb1dceeda2c64efb66e03cb8337717402c8070c0a19e1d9a6b5e0363d89"
+    },
+    "progs/mon_hogre.mdl": {
+     "bytes": 897896,
+     "sha256": "f8e0d054c44cf83bde03ee51ca8eb558dad7da336be8caf1383cf51d5b813da9"
+    },
+    "progs/mon_hogreham.mdl": {
+     "bytes": 979960,
+     "sha256": "d4ffb64b6112d48696002baf1bf8df0c686f404d1523ae409a9d01d237573e90"
+    },
+    "progs/mon_hogremac.mdl": {
+     "bytes": 901388,
+     "sha256": "daeed66878bbe85c45d2415de4270a8526be175ac74734ff55cf9750bf7c4875"
+    },
+    "progs/mon_jim.mdl": {
+     "bytes": 331872,
+     "sha256": "a49a51562fc5875509e39b62de550c4cebba65569708e1f63d0a54a6b8497448"
+    },
+    "progs/mon_jimrock.mdl": {
+     "bytes": 357748,
+     "sha256": "6c7e4a4f9b1b4392cf6e465be50e0a637a2a9b9b44b41e97a62acfc7b889f662"
+    },
+    "progs/mon_judge.mdl": {
+     "bytes": 1184920,
+     "sha256": "4e281291b8b6728bc6801c775defa987698a0f402a3a5553a32cf61865857040"
+    },
+    "progs/mon_justice.mdl": {
+     "bytes": 1287408,
+     "sha256": "bdd6b6ad28da26701dcef14503d148e96251575e04f583bef1f362455ab12497"
+    },
+    "progs/mon_knight.mdl": {
+     "bytes": 474244,
+     "sha256": "b279d87d180d237a71beddad02ecfaa87be42c990b91ee823f15f905fbb19b55"
+    },
+    "progs/mon_lostsoul.mdl": {
+     "bytes": 172216,
+     "sha256": "51c6d042ac9c670926d11743a09b294cbc992204077eae28b7b440570a7b0b4c"
+    },
+    "progs/mon_minotaur.mdl": {
+     "bytes": 669648,
+     "sha256": "3016ee951f60eb90a659c641546bc6aee80b1e2e9500b125c9c1343d625deb54"
+    },
+    "progs/mon_ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "ca0b6aee92201fa3ebeb226e7767c7a0f29495496d86bd384c327ff897b3557b"
+    },
+    "progs/mon_ogrefish.mdl": {
+     "bytes": 560428,
+     "sha256": "25edf562fbf71533ae0102832d92b7e138d056e1f90c9c681e5387659cd3160e"
+    },
+    "progs/mon_pyro.mdl": {
+     "bytes": 415072,
+     "sha256": "11a7efe7358b1477867a1263fd6e13a8531f557d1a8d0e0bfc5a1e9e6eab273a"
+    },
+    "progs/mon_scorpion.mdl": {
+     "bytes": 338288,
+     "sha256": "5d8a1b194cfc741b8dd194694dce305c35b0dca0bdf1c8d96897a085ad0eaf85"
+    },
+    "progs/mon_seeker.mdl": {
+     "bytes": 594628,
+     "sha256": "ab23bfb0c8b22c67b8d4b7b1658b445fb546fcc4f1ddb1f5c4990eb860434f3a"
+    },
+    "progs/mon_seeker_glow.mdl": {
+     "bytes": 594628,
+     "sha256": "122441a3be654d0198ba368ff9fd24d7f3fecb71fbafad6edfe80e3f57103ca8"
+    },
+    "progs/mon_sentinel.mdl": {
+     "bytes": 290664,
+     "sha256": "573efd78767922b2bbb3e5dab2b16cd8f90c2cb1709ecf4a315a141f4df77d09"
+    },
+    "progs/mon_shalrath.mdl": {
+     "bytes": 163336,
+     "sha256": "50b11e859246abf75af63b858d00b436690c9ed02562c0a7a3f434ed350c3a79"
+    },
+    "progs/mon_shambler.mdl": {
+     "bytes": 401092,
+     "sha256": "8f29b2ceddebcb9e69adbf12eb36c3924468cfaa1ff54cea31e6f289ab30e54a"
+    },
+    "progs/mon_skullwiz.mdl": {
+     "bytes": 980064,
+     "sha256": "c7637f2310ae9f173de872ea4aaf4380332f3d8d32782a8523f1d5d0a5ee3e45"
+    },
+    "progs/mon_soldier.mdl": {
+     "bytes": 931376,
+     "sha256": "8a67babdf47ecc69739e067d18b2629814469aec923851bd6c1133feae6ac56b"
+    },
+    "progs/mon_spiderb.mdl": {
+     "bytes": 228508,
+     "sha256": "209ee4dabf0f9b5619408cedcd8eaec7f8d4e48a8e1b51ca667bf5f8fea02dd6"
+    },
+    "progs/mon_spiderg.mdl": {
+     "bytes": 228508,
+     "sha256": "ffac4cf5b2d42df5b8a9674dc87c30ec925d6013d9ff0d29cb109c30047bcbd6"
+    },
+    "progs/mon_steelclaw.mdl": {
+     "bytes": 228508,
+     "sha256": "06fae126b984b1ed7b0ffa029b64e9b3df3a6269f01e8aba4b953bbafaa2c536"
+    },
+    "progs/mon_stinger.mdl": {
+     "bytes": 203428,
+     "sha256": "9d867b8a3d69a94d9a049c6cfcf0fa808b200ea3befe3b2518f1165881b9ad23"
+    },
+    "progs/mon_swampling.mdl": {
+     "bytes": 45332,
+     "sha256": "c7b379fcc17af3fbfaff1976ea8c14e9562093495dac01cd647c50863c4dec50"
+    },
+    "progs/mon_swamplingp.mdl": {
+     "bytes": 45332,
+     "sha256": "f1bd1496b4b9c90493f469bf81c6da0a1697290cd6374db15fd459ebab649cea"
+    },
+    "progs/mon_tarbaby.mdl": {
+     "bytes": 511008,
+     "sha256": "a9b9b6a49090bbf7d7d3a23618c3c21b2123e007488702d96b80531c563cdd4c"
+    },
+    "progs/mon_voreling.mdl": {
+     "bytes": 45332,
+     "sha256": "af233d21d6f0ea66267ba1c562ba223e1077bd07894333327ce12a6202938411"
+    },
+    "progs/mon_vorelingp.mdl": {
+     "bytes": 45332,
+     "sha256": "dadf32a61ef1ec6361606fc7173bab53f6c42e62dea9a3100a2073ffc5afaa58"
+    },
+    "progs/mon_wizard.mdl": {
+     "bytes": 106596,
+     "sha256": "aa93bbe4e7fd1686fcea4d6c49a982bb8b3defea2ca85c3177b86000ba8ba8e4"
+    },
+    "progs/mon_wraith.mdl": {
+     "bytes": 374256,
+     "sha256": "f2ec454f0e2896252204a99b18c16a5e61ae783220503a6b0ec75e149d1b25f7"
+    },
+    "progs/mon_wraith_glow.mdl": {
+     "bytes": 133676,
+     "sha256": "bc630a16b46ae0ef1fba35acaf4e41bc46dee4070305d32e9215692a18ae5705"
+    },
+    "progs/mon_youngone.mdl": {
+     "bytes": 103208,
+     "sha256": "de6f7f98d021ae2839cc81490886e6f29dfa31b5b45216d15ffb7f74edf1eb36"
+    },
+    "progs/mon_zombie.mdl": {
+     "bytes": 381660,
+     "sha256": "2dfc9832316861cff07f1c86da0f8809de95395a9dac718155bdbd06f739acaf"
+    },
+    "progs/mon_zombiek.mdl": {
+     "bytes": 228232,
+     "sha256": "431f57d3241b1253a1346ff1aa2bd7135f67c3e6fd5031140e07a7b4a0e861a2"
+    },
+    "progs/player.mdl": {
+     "bytes": 976432,
+     "sha256": "137eab1a3853f9a6f7f84c05442f7066268cac430bf73053cc7f806555a98925"
+    },
+    "progs/proj_balllava.mdl": {
+     "bytes": 18356,
+     "sha256": "f2a1de49bd215b4c7a1f424f1c644fe5cdb52df3c2d664c24b75cd2f389ae559"
+    },
+    "progs/proj_ballslime.mdl": {
+     "bytes": 18356,
+     "sha256": "d17f20cd8db385b724d58beaac1c3ed6b2597d51d00f1996b8b02bdb8a5e3ba1"
+    },
+    "progs/proj_blord1b.mdl": {
+     "bytes": 11472,
+     "sha256": "6c05b0f8790b77d3362166b2b304379942f56d498ae8fc365dbee6fcd6031f67"
+    },
+    "progs/proj_blord1s.mdl": {
+     "bytes": 8284,
+     "sha256": "5527dd12f00911fb333c2424994c0a95881caa72612d5e8236c8ce75530f6ae0"
+    },
+    "progs/proj_blord2b.mdl": {
+     "bytes": 11472,
+     "sha256": "fce6943e84bac672bf110d986ce2ed1ccb511128cb28508fb6aca53c7655806b"
+    },
+    "progs/proj_blord2s.mdl": {
+     "bytes": 8284,
+     "sha256": "a0d0ac315e46f784c35a0eac902f625e0337e79275b9f02ecb56002848202734"
+    },
+    "progs/proj_blordbeam1.mdl": {
+     "bytes": 12244,
+     "sha256": "e01c569bf66e75acdcbbfdbb50062eb24dd09f0415e6cb79148eab960f6a6f0f"
+    },
+    "progs/proj_blordbeam2.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/proj_blordbolt1.mdl": {
+     "bytes": 7868,
+     "sha256": "2ea0a49a8a75d1174151c36851ae21212b4df2df3473be5e73cc4cf293332d0f"
+    },
+    "progs/proj_blordbolt2.mdl": {
+     "bytes": 7868,
+     "sha256": "919dda70fe618cd37f57ef1e0dbc00b339ed082e2661ca024febee3ed49576f2"
+    },
+    "progs/proj_bolt1.mdl": {
+     "bytes": 1556,
+     "sha256": "890f6cd6faf7c36954185c4566a2cca619e627d5b365f05e1bffc7e12ac00ace"
+    },
+    "progs/proj_bolt2.mdl": {
+     "bytes": 1748,
+     "sha256": "ba4a6ffa3785b0e41c15045df9621a5a33f094eae2161064d472ea939654e229"
+    },
+    "progs/proj_bolt3.mdl": {
+     "bytes": 1748,
+     "sha256": "cf255497525c53162b019fe3df536314c4661a2d270f6bb847fe39a158b7f4e8"
+    },
+    "progs/proj_chthon1.mdl": {
+     "bytes": 65636,
+     "sha256": "92a964527d72ef1c40bbcfe0e915b56df81a0dcc2165ca4be47db44a8d644eb1"
+    },
+    "progs/proj_dguardq.mdl": {
+     "bytes": 12660,
+     "sha256": "ba5cba46edc108572d78e66166f5ed0405a48dcf672e7a569d14a4397f85f285"
+    },
+    "progs/proj_diam1.mdl": {
+     "bytes": 3292,
+     "sha256": "e7cbd736a84791c5234caa14713b3e0f6077409509845ae0b1993f38c2f1e1b9"
+    },
+    "progs/proj_diam2.mdl": {
+     "bytes": 2748,
+     "sha256": "b23586b1d570a9f516f6b83ea0af6ec1d8fe5693f8cd1279b251b031ba142d8c"
+    },
+    "progs/proj_dk.mdl": {
+     "bytes": 5172,
+     "sha256": "e861a125a60c82b88c7b3c23184a1485c967d0e127b4536213b7f46a97a6430e"
+    },
+    "progs/proj_dkgrn.mdl": {
+     "bytes": 5172,
+     "sha256": "820d2dac7255db7220889f6d8c3a2c97a7f77f75cd9ffbec6319b0ee257b3984"
+    },
+    "progs/proj_dlord1.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_dprince1b.mdl": {
+     "bytes": 6644,
+     "sha256": "7bcea6065d9f6c4e8a3a7c8a1dcd61252ff8baee01b7c04ecce0a7cfbc6d690d"
+    },
+    "progs/proj_dprince1r.mdl": {
+     "bytes": 6644,
+     "sha256": "5e3cc794f6b980e5e22adf011eead8768c88dcd84d74be9a8d34caebf33bf2ba"
+    },
+    "progs/proj_dprince2b.mdl": {
+     "bytes": 7468,
+     "sha256": "e81b4f767d1bba042464f1d35314ef4f2d30f7c552aaada2f772aba61fc5d62a"
+    },
+    "progs/proj_dprince2r.mdl": {
+     "bytes": 7468,
+     "sha256": "b967299e12983dacd0fcca1672818281483e6f89746422de285002cb043e1e24"
+    },
+    "progs/proj_drole.mdl": {
+     "bytes": 20796,
+     "sha256": "fbe9acdd31f7be2321df29b6add3d287d4e86ea2581e56ace5d7e9d185e28127"
+    },
+    "progs/proj_drolegrn.mdl": {
+     "bytes": 20796,
+     "sha256": "efbede1f5d565c56a535bb6392b5e638133c99b1df8bf93b1a1918d01c790123"
+    },
+    "progs/proj_eidolonrock1.mdl": {
+     "bytes": 14084,
+     "sha256": "e085fa791a83489e41c19c623ae84f80c7bc5f767cbbf691baa4665d3f85b273"
+    },
+    "progs/proj_flesh.mdl": {
+     "bytes": 19768,
+     "sha256": "8ff3f0f61001ac8e67317e4e01d03d905f15ef4104c141ba07b5ddb0c972390e"
+    },
+    "progs/proj_fleshp.mdl": {
+     "bytes": 10196,
+     "sha256": "3def912801c4b1b9b4c0f8ceea0690241493a5dd5f17e098cd6c37cefd927893"
+    },
+    "progs/proj_fury1.mdl": {
+     "bytes": 6644,
+     "sha256": "ce55af61fbd87b8daeb14151b3f77ac64713c4b53fcca89b2150d7f5cdfe886d"
+    },
+    "progs/proj_fury2.mdl": {
+     "bytes": 5748,
+     "sha256": "deb557248017e92f5501698355577cebb91c0d825b77a79f828589769a41ece7"
+    },
+    "progs/proj_gaplasma.mdl": {
+     "bytes": 2328,
+     "sha256": "dd3b4559cb4e4439ae87255ab2958c6c2cd3796ebbd27aaf1c6abc768ad4f8ad"
+    },
+    "progs/proj_gaplasmagrn.mdl": {
+     "bytes": 2328,
+     "sha256": "ecd2fdf0eb904f8be43c41821b06443d32a581b768ce8f776b07670b49cdd9af"
+    },
+    "progs/proj_gargball.mdl": {
+     "bytes": 18184,
+     "sha256": "b4b6bd7646bf80aa6f481616ba2b531dbccd3568cacc54885ebf020a166dbadd"
+    },
+    "progs/proj_gargballgrn.mdl": {
+     "bytes": 18184,
+     "sha256": "467a44838d83a94d5716c9af6f8c860cd8ec583ddb5f260cb0dd16e9bd04b957"
+    },
+    "progs/proj_gargoyle.mdl": {
+     "bytes": 5748,
+     "sha256": "774f52126fe6598f6a01a032691a36de26a0669e93d47508689d08fe85f46c21"
+    },
+    "progs/proj_gargoylegrn.mdl": {
+     "bytes": 5748,
+     "sha256": "b293b5e8696098e77602eb065f68f8a8e15c82af1c9890d36de48f29afbf43fe"
+    },
+    "progs/proj_ghook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/proj_golemrock1.mdl": {
+     "bytes": 7468,
+     "sha256": "5a2f0435dbcbfea724fe6bd8f6a76296359dbf4d874d15feec82b50a9275da74"
+    },
+    "progs/proj_golemrock2.mdl": {
+     "bytes": 19756,
+     "sha256": "41cc9bc49d6ae2018b7cf5345bbfe52517db2da060fce23fe57300ebcf643f98"
+    },
+    "progs/proj_golemshard.mdl": {
+     "bytes": 8596,
+     "sha256": "4a4a59362f5c5ecc2c4ce56419088982d5ed79a02d3c5b5a49bafd4c21c85e42"
+    },
+    "progs/proj_grenade.mdl": {
+     "bytes": 3508,
+     "sha256": "a7916ab1f9872689a0cfbea62543974b37dae5b3ec7ae3165eecd81c2c0d6617"
+    },
+    "progs/proj_grenadegrn.mdl": {
+     "bytes": 3508,
+     "sha256": "896f7a740acb59351891e752e6cc92725fcc6e26ea4bd5d1eb3219c8443db743"
+    },
+    "progs/proj_judger.mdl": {
+     "bytes": 7868,
+     "sha256": "a12f1f0bf494bc027c43e5aa89e54e055a571226499fbddce0f6b9e2bdb63766"
+    },
+    "progs/proj_laz.mdl": {
+     "bytes": 4724,
+     "sha256": "94e8c7d09857559ad9e5aaf6361b596afbcf100cf0ce8abf0107318af28c7943"
+    },
+    "progs/proj_lazblue.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/proj_lazgrn.mdl": {
+     "bytes": 4724,
+     "sha256": "d07d736b788aa512a5e57f39596c187644e69491026382800994378d3e849a6f"
+    },
+    "progs/proj_lightning2.mdl": {
+     "bytes": 11860,
+     "sha256": "c9cebc8d6f4836e7c302d51d0f942fde3da0960dae38733ccc3a851776e71520"
+    },
+    "progs/proj_minoball.mdl": {
+     "bytes": 18184,
+     "sha256": "756d8e9ecd60abc23954a792833c565ee1b5c905106ad2bd98143f56b0410391"
+    },
+    "progs/proj_minoblood.mdl": {
+     "bytes": 8284,
+     "sha256": "badd72734b86dd9bc11c5469bef944b6aea6b84071b07b44703c1ca62dd4dee2"
+    },
+    "progs/proj_minoplasma.mdl": {
+     "bytes": 8284,
+     "sha256": "cd79d0dce08293ded22b08b3a7134d8e52fc4cff10e07ee691e6ab53011a9ea9"
+    },
+    "progs/proj_minopoison.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_ng.mdl": {
+     "bytes": 1364,
+     "sha256": "cff312dd07f629847dd5e37b6ab00243d51ff7e40fc795f3612e68614cfbbe24"
+    },
+    "progs/proj_ngred.mdl": {
+     "bytes": 1364,
+     "sha256": "a1ec22733cc292a470c23990b8d0929bf5ee88844190d7174d9053109443d0dd"
+    },
+    "progs/proj_nour1.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_nour2b.mdl": {
+     "bytes": 14084,
+     "sha256": "9c7650dba595e8f8b2bacf3141252a5a2917e0204d3326661d6b9608fc8df2b3"
+    },
+    "progs/proj_nour2p.mdl": {
+     "bytes": 13152,
+     "sha256": "4051fc3dec1155a9efbc6bc5aab947447cebff83bec38d8c1e43dd1bd51f4611"
+    },
+    "progs/proj_nour2s.mdl": {
+     "bytes": 7468,
+     "sha256": "285570bdd658dfed133399c16f1586e2b2389f537a9d4b54d2dd5c1f8f6f1aa9"
+    },
+    "progs/proj_pgplasma.mdl": {
+     "bytes": 13152,
+     "sha256": "3c04f32bbf6f0623fc4101a31a0ce2d40c93354430433d91c2caed263284531e"
+    },
+    "progs/proj_plasma.mdl": {
+     "bytes": 4724,
+     "sha256": "6c4399ddc7653a9aa7834162d38dce6368dc271fec46a7830b73939351d7142a"
+    },
+    "progs/proj_plasmagrn.mdl": {
+     "bytes": 4724,
+     "sha256": "b2941e69d90a5e97c98a03a98bd52c4e047aa23dd2a1abd9ab6d3938f595732f"
+    },
+    "progs/proj_ringblast.mdl": {
+     "bytes": 135704,
+     "sha256": "e6de9bfd15db4bbf16fdd41b50204c5090ce09adbe132b1453435d3c8646cb4d"
+    },
+    "progs/proj_ringshock.mdl": {
+     "bytes": 18928,
+     "sha256": "f1a0a77edc79f2466b866a5486b29f92b696368137eb7eff9b137b6b66d65952"
+    },
+    "progs/proj_rocket.mdl": {
+     "bytes": 7812,
+     "sha256": "52d549b217c6f34e1d68248899ec5f5f550ef729929910e5953e114a53b3c251"
+    },
+    "progs/proj_rocketgrn.mdl": {
+     "bytes": 7812,
+     "sha256": "313f381553df0d8468ccb981441bf415130c9c730377d877e397511b8cc864f7"
+    },
+    "progs/proj_scorpion.mdl": {
+     "bytes": 6612,
+     "sha256": "1a2fa47a30a7e8026bacefa1f52580a04e10c48571318effab3e0623ebcc919e"
+    },
+    "progs/proj_serg.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_shal.mdl": {
+     "bytes": 6644,
+     "sha256": "dc62e9641d1328b1cfd20ac4f4df7e56b2f42bd40a22eea186f2784d1f5bc4ba"
+    },
+    "progs/proj_shalball.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalegg.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalgrn.mdl": {
+     "bytes": 6644,
+     "sha256": "6dfdef0a204aded86ef24730985f13acc5076d1bbb4b9ec1140b7333a70f4d0e"
+    },
+    "progs/proj_shalhome.mdl": {
+     "bytes": 8632,
+     "sha256": "e882b1dc5d01882f429b3a88f752431d3b38dad297861209b589330e3507f37e"
+    },
+    "progs/proj_shalhomegrn.mdl": {
+     "bytes": 8632,
+     "sha256": "d84be851bd87603186bf907506eabb9ce110c5a265c1cc884d18923361fdf4d9"
+    },
+    "progs/proj_shalshell.mdl": {
+     "bytes": 7468,
+     "sha256": "8c1591cc767fadabad655bfaf3a80362b264f51e0a1be67476b9272c2401afbd"
+    },
+    "progs/proj_shamlit.mdl": {
+     "bytes": 35240,
+     "sha256": "787c23ca986d469080879953e49b193cf0b2d22dff050a1d781ba039fcc594e4"
+    },
+    "progs/proj_shellcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/proj_shub1.mdl": {
+     "bytes": 18932,
+     "sha256": "c1a04846b791a123ecb367f11b35f4c1cc1e7e62e1d0f62ff1dd75978a712495"
+    },
+    "progs/proj_shub2.mdl": {
+     "bytes": 32860,
+     "sha256": "3d22df8151caf23c1ad7f3e28f83f97ca7503164977f1994dca2cc2ee54f84b9"
+    },
+    "progs/proj_skullball.mdl": {
+     "bytes": 9984,
+     "sha256": "41b3c1225070dcfca79f1bf19a2833e3d68144945fba51c8ce44d8029379906b"
+    },
+    "progs/proj_skullwiz.mdl": {
+     "bytes": 33588,
+     "sha256": "ff00ce3fbf9d0d55f6488a3a0a6bf15d2105b6e94489eec296a5851bf9f4f890"
+    },
+    "progs/proj_skullwizp.mdl": {
+     "bytes": 33588,
+     "sha256": "45fe8396037d88852d3e6937749bade4ef7c00d3c8240eeb0ecba4b56e831df3"
+    },
+    "progs/proj_smoke.mdl": {
+     "bytes": 244,
+     "sha256": "816e888f8242af86812bd581c9e93212c28f108699b70eb10d3e025f27a2818e"
+    },
+    "progs/proj_sng.mdl": {
+     "bytes": 1396,
+     "sha256": "b2a8656aee7ff508737afe1fdbf1a93d6958b33a0c31bae247a3979c616bdfe1"
+    },
+    "progs/proj_spider.mdl": {
+     "bytes": 7468,
+     "sha256": "76be6023b50a3b57c73f08c5758a693098ce8762eb92b55540d8bff2680fde4d"
+    },
+    "progs/proj_swampling.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_voreling.mdl": {
+     "bytes": 7468,
+     "sha256": "ab16a7fc8bf36827f4944ebe6919876acb5b2eaf869ff59f89ed237565a7ca9a"
+    },
+    "progs/proj_wiz.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_wraithball.mdl": {
+     "bytes": 22284,
+     "sha256": "24d62690c6347f9ab71ef5900c70d256346c2dfdc26e5488c3b91f220224c923"
+    },
+    "progs/proj_wraithbone.mdl": {
+     "bytes": 6612,
+     "sha256": "8fa994dd2c7a5e9d7140ae394d07d368d083f4cee6808f6d9d026ec464804503"
+    },
+    "progs/proj_wraithegg.mdl": {
+     "bytes": 9984,
+     "sha256": "5b888e26f90cfe26800cd50d422b4ef75487dde61d63fd34965506591b326a8f"
+    },
+    "progs/proj_wraithpoison.mdl": {
+     "bytes": 6612,
+     "sha256": "02a06fdccb8f7ba595ea71f227e5b256995e782bcc9ce75bcb85a31ed0333256"
+    },
+    "progs/proj_wraithshell.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_wraithtrail.mdl": {
+     "bytes": 24544,
+     "sha256": "23ee065ea4a542ee7348d9bc08e052ffca4e272418b81937105d14730aab705e"
+    },
+    "progs/s_bookrune1.spr": {
+     "bytes": 1140,
+     "sha256": "b9fc52d2ca728fffa4c282d818b68aeec3555a0dbad3cd1507199d534db1f047"
+    },
+    "progs/s_bookrune2.spr": {
+     "bytes": 1140,
+     "sha256": "400a620928e3581891e8a71b338c8a53b6387e0acdc3fda3f10ae27596ae6bbc"
+    },
+    "progs/s_bubble_blue1.spr": {
+     "bytes": 1140,
+     "sha256": "27cb0d1f52e3ecd4b7ae0d9dc96078a7554bde09839f1a2ee2d9772ac5d67981"
+    },
+    "progs/s_bubble_blue2.spr": {
+     "bytes": 1140,
+     "sha256": "d540bb04a7835ec3bd7490904fbafde0f3aa64ba559bb6bd99ab538568ec0cae"
+    },
+    "progs/s_bubble_brnd1.spr": {
+     "bytes": 1140,
+     "sha256": "43591346d87a547454b387220b3c32693e7f1563b6ae4152ff7ee96c24936b84"
+    },
+    "progs/s_bubble_brnd2.spr": {
+     "bytes": 1140,
+     "sha256": "2f185b37bd1cd5a8d6b472885469dbdb3f1b0fdeba2a6d620de09b17646b4fc2"
+    },
+    "progs/s_bubble_brnl1.spr": {
+     "bytes": 1140,
+     "sha256": "370ed3a9f77291522c31ac1d0ce414078d9b3eb40a9157c08ad5cf87d6428897"
+    },
+    "progs/s_bubble_brnl2.spr": {
+     "bytes": 1140,
+     "sha256": "1b3d4f0ac00fa7cbce076d334f4b210b9059afbf2c4b07a0e98e88fe57356351"
+    },
+    "progs/s_bubble_grey.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_grn1.spr": {
+     "bytes": 1140,
+     "sha256": "efa8692bb74428af2753b415f8f08edbfc2b2cbe75cc59f6545985d289d6016f"
+    },
+    "progs/s_bubble_grn2.spr": {
+     "bytes": 1140,
+     "sha256": "3062ba1064da37ecf7dad074a9b0437352865fa43aecf783e4afe8a6c8c104c2"
+    },
+    "progs/s_bubble_pinkyel.spr": {
+     "bytes": 312,
+     "sha256": "5376726ffdf2132d3ab712ba23b408e8068500485f11adff85d0fd90c08248c6"
+    },
+    "progs/s_bubble_purp1.spr": {
+     "bytes": 1140,
+     "sha256": "2e4b7b23b08b6e89d2dc46f26b12b9ad1ee8f91ea868aeb9916d2adb42e00b75"
+    },
+    "progs/s_bubble_purp2.spr": {
+     "bytes": 1140,
+     "sha256": "ae21a26ad7897b9c5d201a1eb248e1358ee84eafdbfd899d679558e9aa5a1a66"
+    },
+    "progs/s_bubble_red1.spr": {
+     "bytes": 1140,
+     "sha256": "2a52f2c4dfdae381deeca608e5d007afe9dc245bbe16fea88c88f39c10ff7dc6"
+    },
+    "progs/s_bubble_red2.spr": {
+     "bytes": 1140,
+     "sha256": "fffcc0e03f9acc75e05636ab67f5f647568c81d0bcf4623e64d487c04d9cd5eb"
+    },
+    "progs/s_bubble_wht.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_yell.spr": {
+     "bytes": 1140,
+     "sha256": "9dcce864ad255b17d7d45e5c5531114f6a66c4e9cb549fc8b31aef0af5a9157f"
+    },
+    "progs/s_burst_flame.spr": {
+     "bytes": 22128,
+     "sha256": "66511ada8a299b0882e2939c09d3fb726d3ce52ecb93a884584a9ce11915a6c0"
+    },
+    "progs/s_burst_flamedp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_poison.spr": {
+     "bytes": 22128,
+     "sha256": "d8245e0460efc4e939a187912126f44422c39b1fe4b553c2c15da91833e8549d"
+    },
+    "progs/s_burst_poisondp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_burst_steam.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_dotmed_blue.spr": {
+     "bytes": 1140,
+     "sha256": "0b3160c5a4ae42216ddb7aaa7ae4726f6b2507c914328abe3c69f2d12fd921f8"
+    },
+    "progs/s_dotmed_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "6e28b69544f8aa13ccbb9a66893e4ab86b83639ee3f81dbbe1b94290ca9b03ef"
+    },
+    "progs/s_dotmed_grey.spr": {
+     "bytes": 1140,
+     "sha256": "77c226763e90a54b4d6835bd877c08c501605e516e64177c915c422e7b36c207"
+    },
+    "progs/s_dotmed_grn.spr": {
+     "bytes": 1140,
+     "sha256": "d1a9800a8b5cad01fa1dc93e57162e9960c4a8478e7e427d66cdbfe6a6797266"
+    },
+    "progs/s_dotmed_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "6113140f371b08cda9addcf68282c1fc16692da7498fa2fdfe2b99662e345d67"
+    },
+    "progs/s_dotmed_purp.spr": {
+     "bytes": 1140,
+     "sha256": "8b2cfa67ac86841f59409e184b4f3a253218e5930a5e3f241caef39dc1baa8de"
+    },
+    "progs/s_dotmed_red.spr": {
+     "bytes": 1140,
+     "sha256": "4ae92a280e0df01c0acd0a904214af485bb60919e5ded4573aa12f86875182d4"
+    },
+    "progs/s_dotmed_tor1.spr": {
+     "bytes": 1140,
+     "sha256": "eddd46a4818dfa92a9817df82e893d6bf6513160164a74b95bdd42fb7cac2f75"
+    },
+    "progs/s_dotmed_tor2.spr": {
+     "bytes": 1140,
+     "sha256": "dcb87897de0f54a6d8f78e9194a15c11261eb88455f058b334f8648a363159a9"
+    },
+    "progs/s_dotmed_yell.spr": {
+     "bytes": 1140,
+     "sha256": "e6b72aac439291d7719ee78d9520c1a1def36212ac7f61ba333fa87d5265c63f"
+    },
+    "progs/s_dotsml_black.spr": {
+     "bytes": 632,
+     "sha256": "2ae7fa13584d12f04b337fbbd774e74fbe54a6fcbd354239e97fecce931bd377"
+    },
+    "progs/s_dotsml_blue.spr": {
+     "bytes": 1140,
+     "sha256": "c0149109ae73a72da49bfaf9ba00cf2edadbe0f053928d09319083e6247883ad"
+    },
+    "progs/s_dotsml_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "f95fe813ecce2c69d2b72e5bf870d045037519c89f3da9a300e7453754cd1503"
+    },
+    "progs/s_dotsml_gold.spr": {
+     "bytes": 1140,
+     "sha256": "3833e80c32da39063b5069638ade52c4aee51b7db7206b4911cb48f321e25bdc"
+    },
+    "progs/s_dotsml_grey.spr": {
+     "bytes": 1140,
+     "sha256": "2e16d9ff8ceca2994a609703f405b1efbb7b49e02c8dbb9e77d0cdcaf3318b98"
+    },
+    "progs/s_dotsml_grn.spr": {
+     "bytes": 1140,
+     "sha256": "a2735123addacfa03f2666969e476af0d9f1cfefbef75a7ac9599d48f86226b1"
+    },
+    "progs/s_dotsml_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "ebf62caae17163587aaa3652300f1003c008ed21041b838a14cfff7672f87d90"
+    },
+    "progs/s_dotsml_purp.spr": {
+     "bytes": 1140,
+     "sha256": "476042db782f7f81cb53d91e9518881f28eb34d3a2a535c11d9c22f65518bce4"
+    },
+    "progs/s_dotsml_red.spr": {
+     "bytes": 1140,
+     "sha256": "94c0403ee7f1e6f6c4d6bc9b99e73e48143845fe35d0d6b3de246842241b12cb"
+    },
+    "progs/s_dotsml_wht.spr": {
+     "bytes": 1140,
+     "sha256": "7ac2d5b9b1e14a1799b951ace16bcc1addb7fefc2470dec23ef2ca110a934bf5"
+    },
+    "progs/s_dotsml_yell.spr": {
+     "bytes": 1140,
+     "sha256": "686f220b937040b91b6ff4f05efd41525d40eb80a61ff8138809d550bfa99959"
+    },
+    "progs/s_dripblue.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/s_dripgreen.spr": {
+     "bytes": 60,
+     "sha256": "805935ef90e14eda0f0ec89cc7e03acf52df768eb9e09140629bc1067a658774"
+    },
+    "progs/s_dripred.spr": {
+     "bytes": 60,
+     "sha256": "2dc81cd44438e124dedef0b656c31a066b7879940fcdbc39a0cfd57a6d2985e5"
+    },
+    "progs/s_dripsplblue.spr": {
+     "bytes": 828,
+     "sha256": "6b960ccc7a877bf2b4b67467400c0eaa1bb88d8c8a524458b9bf8d1aa1a6e29f"
+    },
+    "progs/s_dripsplgreen.spr": {
+     "bytes": 828,
+     "sha256": "397ac392598027c27240d71079f79eb9c90306724bc54c5d9854e14939059b6c"
+    },
+    "progs/s_dripsplred.spr": {
+     "bytes": 828,
+     "sha256": "268b48b87a0f352b671c04a1f7325af43372578a6d73269356389280eb7ef232"
+    },
+    "progs/s_exp_big.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_exp_electric.spr": {
+     "bytes": 5256,
+     "sha256": "ed01b728b6656a68acffe258d644712eba3b786434ab6b3e6d90434031e90d96"
+    },
+    "progs/s_exp_ice_big.spr": {
+     "bytes": 164076,
+     "sha256": "bf7317d811349602db7a020da3e77065ffd8158a3104e83ddca3b166566df18c"
+    },
+    "progs/s_exp_med.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_exp_plasma_big.spr": {
+     "bytes": 213288,
+     "sha256": "fe99a489e169ccf56f0412c2e83a7c5aea7b75b7cee0501402c62fcbd7ca969c"
+    },
+    "progs/s_exp_plasma_small.spr": {
+     "bytes": 53544,
+     "sha256": "555e39e88cedaf9e9dd1215ad1325b32019a6bf2654d53736b1f362506548150"
+    },
+    "progs/s_exp_poison_med.spr": {
+     "bytes": 72892,
+     "sha256": "60b7a8c194f3a6cd2241edd6223ac1da1f57811d7f5416216c70a2797d1baf20"
+    },
+    "progs/s_exp_poison_small.spr": {
+     "bytes": 53544,
+     "sha256": "2a54104dec9381afe338574d66bcc19bd2776caa0d46031c743cd24782098d3f"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "a9476d95ea10fbd2317c174272864efa4bb6e939893f3a3de520aeea3e3522d9"
+    },
+    "progs/s_flamemed.spr": {
+     "bytes": 43324,
+     "sha256": "3c645e305673693089fe48cc7a22f694eeaf7881cfc94ff7b1c4b05b718342cc"
+    },
+    "progs/s_flamesml.spr": {
+     "bytes": 21820,
+     "sha256": "5e60165461c34a3a25cbe6b0bb5e36131bb4a81fef384f1db4a7236f30e7ba95"
+    },
+    "progs/s_flametiny.spr": {
+     "bytes": 11068,
+     "sha256": "9d2c0af6139f3d194e73dbcb7880aa0a6f2a04019f94818ce9844691399b551b"
+    },
+    "progs/s_judgemagic.spr": {
+     "bytes": 12564,
+     "sha256": "6d08d5ada6bac219927edb39a93302f98b7b1a357e6648fc1abb49fd5cc3bd4c"
+    },
+    "progs/s_marsh_med.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/s_marsh_small.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/targd_hull2.mdl": {
+     "bytes": 3380,
+     "sha256": "520c82906942d582c6b64da4dca32ca8ed236694607c3a19ec71b89136e0c757"
+    },
+    "progs/targd_massive.mdl": {
+     "bytes": 17076,
+     "sha256": "099ed67733ea3a461c2247d6f07d3dadcc5a6968bcd6a03398507c653d174395"
+    },
+    "progs/targd_short.mdl": {
+     "bytes": 4788,
+     "sha256": "c883300477d3978469aabc35ef3969c14645c1111997c64452634fc8b4a978e1"
+    },
+    "progs/targd_tall.mdl": {
+     "bytes": 4788,
+     "sha256": "bab77599f9cbbe1cf0856a642612ae30b08fed9ae27a209abda30f6dc8c07129"
+    },
+    "progs/targd_wide.mdl": {
+     "bytes": 17076,
+     "sha256": "d40a00625196f67fe26f3611cd91dd33484ddbf3db273766f8a5fac38db07b07"
+    },
+    "progs/trap_pendlong.mdl": {
+     "bytes": 44900,
+     "sha256": "62d3b86fea6e2336dfc5c7b93514e096eba05992a3bd3e0c6571e4c4a27be684"
+    },
+    "progs/trap_pendshort.mdl": {
+     "bytes": 44900,
+     "sha256": "efb3e395093e34d7b16c92ed73abb199a28d0bc653522c13d4e720030f547713"
+    },
+    "progs/trap_sawblade.mdl": {
+     "bytes": 28716,
+     "sha256": "759bd7e1f7629b4d87ecb9e53a9f2d66e3e81b9103bc4eab3f85bd598eba36f6"
+    },
+    "progs/v_ghook.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "5b6b84edc6e6c58128a6e830ec35424cc83e69fab7b1337c4c681d8d0ed81e74"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 48964,
+     "sha256": "d073c7fad7dee2c4664aa401d744024b623abcd65e60a4c7066721b988838aff"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 54940,
+     "sha256": "c0a6b7d9664b0ab5a0c77732b22592dedfefbf65c624c05bec7aa8d60835f74d"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 39668,
+     "sha256": "78fc36ddbd33fb77192ef100547f1a1a0f70a38fdaac7094df67f2df33ca9237"
+    },
+    "progs/v_shadaxe0.mdl": {
+     "bytes": 97860,
+     "sha256": "598f555a854590a749eee83870a869ebfa8dfd3c84ad447b7fe3fb796ea1da80"
+    },
+    "progs/v_shadaxe1.mdl": {
+     "bytes": 97860,
+     "sha256": "2ffbb3026a21d70a73a091222cc4f2ea2ba6abd706fbffc276f027b9475abfaa"
+    },
+    "progs/v_shadaxe2.mdl": {
+     "bytes": 97860,
+     "sha256": "cd2a7a188f73c5b841183885663470c53c3af5646491f44811a4a0f192381ed7"
+    },
+    "progs/v_shadaxe3.mdl": {
+     "bytes": 97860,
+     "sha256": "b1c0dd11ce314003de5051f8a3b9581ee3eda5ea347d3d3371eea43051820197"
+    },
+    "progs/v_shadaxe4.mdl": {
+     "bytes": 97860,
+     "sha256": "81108f8b2484d24e54e9ab3ee5b707be5ea28adb142159412aa773ae01e593c1"
+    },
+    "progs/v_shadaxe5.mdl": {
+     "bytes": 97860,
+     "sha256": "0d3ca1664ee82ab2aed6261c262fdc455db981ecd2d62371595e520756d7bb22"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 22260,
+     "sha256": "bf79b703708665b9e65556bf68c0fe9d177097b2b96b11563d7b8bf84485a81b"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 22764,
+     "sha256": "5a51ba87bcdf37463bb8f34dd7259ea2be54d540fbc59798bb62dc24b2d3e777"
+    },
+    "progs/v_shot3.mdl": {
+     "bytes": 77868,
+     "sha256": "5b08bebaeb2fa054e6bb37d51c716cfac0e4da843b0db158a4a9769fa04ad13f"
+    },
+    "progs/v_zershot.mdl": {
+     "bytes": 62604,
+     "sha256": "4173bb2b84f9adce1957a87251cca591d968c3a54e801b170a87aae82539a2b1"
+    },
+    "progs/w_backpack.mdl": {
+     "bytes": 138832,
+     "sha256": "78d86e7bc605746990a1b10644b12542f3380375693d4fb015884e42269314a0"
+    },
+    "progs/w_blueflail.mdl": {
+     "bytes": 17236,
+     "sha256": "3b645ebcb5d2249c9cf904e17006b85aa05963efda33f45f5b6f6fc3ea188d26"
+    },
+    "progs/w_chainsaw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/w_dcrossbow.mdl": {
+     "bytes": 14388,
+     "sha256": "52b14c48ec77acb261f18e1d7903e360eb96acb5c22a0702dfde90c66b103064"
+    },
+    "progs/w_dfurysword1.mdl": {
+     "bytes": 8916,
+     "sha256": "16521de90d0e71090ef4e6b5904252f3ae2d4a38ebe99eff9dc758ea009b0f90"
+    },
+    "progs/w_dfurysword2.mdl": {
+     "bytes": 8916,
+     "sha256": "2e42b37254cf8d85b098e58143fd77d86bed2f3568f630196326841298d07187"
+    },
+    "progs/w_dguardsword.mdl": {
+     "bytes": 8404,
+     "sha256": "74b884b8fd0a785fc2c1dcc29428b8d4c8725de6963bccf7ec80c396e002fa38"
+    },
+    "progs/w_dknightsword.mdl": {
+     "bytes": 8404,
+     "sha256": "1e6729ae15dd1520fff7f4c1c30260c35b637bd0b23b8fb3a5a476b175a39165"
+    },
+    "progs/w_dprincesword.mdl": {
+     "bytes": 19296,
+     "sha256": "89e5ef1382e980b68e812f7e8f6a9b6fba34af42bb2def457b7a2f6f8d7388b7"
+    },
+    "progs/w_enforcergun.mdl": {
+     "bytes": 42612,
+     "sha256": "fbbfd121a3d085d654aab512cfebb0b6890daf3c403f25ca372edc3c53039375"
+    },
+    "progs/w_hknightsword.mdl": {
+     "bytes": 20504,
+     "sha256": "a8dffdc9e400d45fcea617255a8731d752cfa83df40b923128d5dbae6839492c"
+    },
+    "progs/w_judgesword.mdl": {
+     "bytes": 199388,
+     "sha256": "c822984ba5a12948ca389f4b8536c3aa6644993242362b10ac7f6ff2e2332590"
+    },
+    "progs/w_justicesword.mdl": {
+     "bytes": 264928,
+     "sha256": "0fc111a637bdaf5372c02c53439497c2adfc0914845b947ecc9ad70ace1e1b3d"
+    },
+    "progs/w_knightsword.mdl": {
+     "bytes": 14328,
+     "sha256": "4740ee2b171380cd9481ba07f284fe720c5b49b0980dc19cb145b2356205fc0a"
+    },
+    "progs/w_ogregl.mdl": {
+     "bytes": 8260,
+     "sha256": "8071cb814b6158c8af563494687e3994192818ccc2aa80f4766bbf6912d559ee"
+    },
+    "progs/w_ogreham.mdl": {
+     "bytes": 29996,
+     "sha256": "11c1ec322889a971b7f930a7c653f13e69714e6de77b7afa4ded1fdec39145de"
+    },
+    "progs/w_ogremac.mdl": {
+     "bytes": 29324,
+     "sha256": "2f9086da6b43becab1d54e47bcb299421b1bdc1e1e71c41e581b367a75f52919"
+    },
+    "progs/w_skullbook.mdl": {
+     "bytes": 25580,
+     "sha256": "e99379e980169501931eb029f36d05b41ba52f8597a6022bf195b08dba88c70e"
+    },
+    "progs/w_soldiergun.mdl": {
+     "bytes": 36120,
+     "sha256": "9c89a19d7c5fa69783d8bcf59b46b18a0c80c37e280b18731564952faf1d6523"
+    },
+    "progs/w_zombiesword.mdl": {
+     "bytes": 14328,
+     "sha256": "e4ac73fc149fa581e64fb5f2016ce58c99ab1c9a76502ede78a525ab7f344b0c"
+    },
+    "sound/ambience/bell_ring1.wav": {
+     "bytes": 61586,
+     "sha256": "b9169a48fd032d7c2b0cadb61540ac5db42ca6384cb2c74818bd46bae3fc7db1"
+    },
+    "sound/ambience/bigmachine_loop_02.wav": {
+     "bytes": 92760,
+     "sha256": "4d6dd03883ac4462c7f1741c022a3e8fd9e2c65cd54d5d126f58c00b3bfe7df3"
+    },
+    "sound/ambience/chimes.wav": {
+     "bytes": 250476,
+     "sha256": "d1060cd75d8a520b748047790d33c9a4ab5fd626330ebf1242d318d308c165db"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/distant_gears.wav": {
+     "bytes": 72502,
+     "sha256": "760d34131249ff3c4bccdab0cd3df69874728a6db3e1b4545177e5ce381e5e80"
+    },
+    "sound/ambience/drone6.wav": {
+     "bytes": 36820,
+     "sha256": "ab0cc1d617b06169d20b42bddc31078c0c7a1b8b15793fe6cfea6dbc96b4129e"
+    },
+    "sound/ambience/fan_finish.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/fan_loop.wav": {
+     "bytes": 288110,
+     "sha256": "d7459b4f1087aa1e002f41fc0274e4cb2f313dff5af2eecaa9de5225bcdcd729"
+    },
+    "sound/ambience/fan_start1s.wav": {
+     "bytes": 96044,
+     "sha256": "b0bad8ae3cd81dc4bbd76591e29f9c43610cb6e0311d4822213e400a6b99dd9f"
+    },
+    "sound/ambience/fan_start2s.wav": {
+     "bytes": 192044,
+     "sha256": "6716a803f246e44416fc414ca2f51744fc1ed79178f79fe3baf7a986c820c020"
+    },
+    "sound/ambience/fan_stop.wav": {
+     "bytes": 192044,
+     "sha256": "ee8607922387eeb594c18096ef6dd4003990a5fe47414dee331921f6d03be6b7"
+    },
+    "sound/ambience/fire1.wav": {
+     "bytes": 47906,
+     "sha256": "c1370a7c177aa21de219578cc64716bc800007e2ac86ae106affac01f8edc470"
+    },
+    "sound/ambience/flames1.wav": {
+     "bytes": 132406,
+     "sha256": "8ac99a7ace2ec9cc98a38fd5777973eb484e9193cf93dfcd6a51ea4f0f9d0f00"
+    },
+    "sound/ambience/flames2.wav": {
+     "bytes": 132406,
+     "sha256": "31e76d131cb4ad3c0602e2559c949feb7a8749c639363f1fd7df53136616fdd1"
+    },
+    "sound/ambience/flames3.wav": {
+     "bytes": 132406,
+     "sha256": "b4008d1da182bc0886f8bad53e5a700d8e04050920aa27ceb0922be938eb7c96"
+    },
+    "sound/ambience/flames4.wav": {
+     "bytes": 132406,
+     "sha256": "222222e080566c899a48df9e40006d0ee36575c03250c44845fb10a94c5cead9"
+    },
+    "sound/ambience/gargoyles.wav": {
+     "bytes": 136816,
+     "sha256": "16f09404b6043aaacb4b6b2bb00143ab72b5e185f02e610d780ea7d311d2df6c"
+    },
+    "sound/ambience/gearopen.wav": {
+     "bytes": 49708,
+     "sha256": "39b73c8ada1b06c7ba07099447b9b0d75911f08df09ced3826bcff136af5b0ee"
+    },
+    "sound/ambience/generator_gas.wav": {
+     "bytes": 529314,
+     "sha256": "6710075453fde424951171823e87f3711d53fd434149ddecc14a14ce721de04a"
+    },
+    "sound/ambience/ind_lift1.wav": {
+     "bytes": 158906,
+     "sha256": "c722fa19c7851d2c7b4307489911b885527e31fd3e4de44d5a184bd786714049"
+    },
+    "sound/ambience/ind_lift2.wav": {
+     "bytes": 156008,
+     "sha256": "c404881a9758f839fd055dd69a82f04bf7e5d5b98538a4a87b2ee741d8b4956d"
+    },
+    "sound/ambience/light_hum1.wav": {
+     "bytes": 100022,
+     "sha256": "cb2f04b81297621ffddbfb028dc5021a665e3285deb7c80757a47add8294f032"
+    },
+    "sound/ambience/liquid_bubble.wav": {
+     "bytes": 129688,
+     "sha256": "838ec1e72b2c433408a342a48518987edcb2124932eeb477d59653540b13d6ea"
+    },
+    "sound/ambience/liquid_burnlong.wav": {
+     "bytes": 710182,
+     "sha256": "9c9c77941f88416e3f20dfc4f028cc6c9719dd7f58a15dfc6124f1bb5a17f61a"
+    },
+    "sound/ambience/liquid_burnshort.wav": {
+     "bytes": 89464,
+     "sha256": "4ea16997389f1aa35549869a338f2093f40d14df030c381a7659cc7e3cbf8bfc"
+    },
+    "sound/ambience/liquid_drain.wav": {
+     "bytes": 220464,
+     "sha256": "e86a6012c8fc3a795791fc344ef636bb1854a602cd609e2df751531e89277cf9"
+    },
+    "sound/ambience/lowboom.wav": {
+     "bytes": 666640,
+     "sha256": "ad591a6f574f48e654e32dacee6b7d862df8b47e20ef116f84415ad9aa515559"
+    },
+    "sound/ambience/machine_loop1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/ambience/machine_loop2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/moo.wav": {
+     "bytes": 265502,
+     "sha256": "35b7924115bc4cdf94e9cbb274a4d9ca251d6878817834bec08aaa176f2ddc9b"
+    },
+    "sound/ambience/mystery_drone.wav": {
+     "bytes": 1350258,
+     "sha256": "eb3fbb28dda2a6204af07d08fa993ed09513f9915142dd6f4af808204b6b8c9e"
+    },
+    "sound/ambience/power_drone.wav": {
+     "bytes": 36700,
+     "sha256": "4307c01076cb5e076d27546b17bd6b11e2369a67b59dbbd64f2607d8b262a8c2"
+    },
+    "sound/ambience/power_off.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/ambience/power_on.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/ambience/power_shutdown.wav": {
+     "bytes": 1118464,
+     "sha256": "e0ab1a0f67a2d37a525f7a73e8ee8c3a26f746e027fa1501f6648f5586ea2048"
+    },
+    "sound/ambience/power_switch.wav": {
+     "bytes": 66382,
+     "sha256": "5c006bb7315e6eb6d2367ae30a78f0abec8ae2a1e2b6a2c9af88354962b0f33f"
+    },
+    "sound/ambience/rain1_nl.wav": {
+     "bytes": 154394,
+     "sha256": "45d8c08ff4a9a2dd6ff8362fea7c22f9c3ea64a3a8d7b6c81c8cad88265f327a"
+    },
+    "sound/ambience/rain2_fade.wav": {
+     "bytes": 198550,
+     "sha256": "3cf300a4f785d416656838bd3a68120bf6a48d16f928ca74e2e0890ec9f8b426"
+    },
+    "sound/ambience/rain2_nl.wav": {
+     "bytes": 66250,
+     "sha256": "f2735ae8a7b1ae5ab5ce3b8ed66d8c61d00a65f2e66d8c565f4abe718d57ab67"
+    },
+    "sound/ambience/rain2_org.wav": {
+     "bytes": 132400,
+     "sha256": "4c1f820b2c8f4bea08b8357fb8409e9f30a98fd0faf1413a1953ea697b84b507"
+    },
+    "sound/ambience/rumble1.wav": {
+     "bytes": 403620,
+     "sha256": "47afe820548bcf248b7760f7a66a61ea65b5fb79f70d47e3b03cf8211bb4c5f3"
+    },
+    "sound/ambience/rumble2.wav": {
+     "bytes": 99104,
+     "sha256": "9c3d5418c7e5bac60c365f0e8b7ea496dd2b51c72c13b0e5a6640e2ef880433a"
+    },
+    "sound/ambience/rumble3.wav": {
+     "bytes": 209242,
+     "sha256": "864f373dbd75172e1c8f31373188f38c31a80af46592f6b2e92cf5f576e5e0e1"
+    },
+    "sound/ambience/s1_stop.wav": {
+     "bytes": 16162,
+     "sha256": "9a35adf9361aa033b413762fea7d04b2cf7392b363f2aa187a81905f65a44b61"
+    },
+    "sound/ambience/switch_1.wav": {
+     "bytes": 35324,
+     "sha256": "9f73f07313ba4995247d82901111b5aea4200c48de6641dddb145dfadcac40c9"
+    },
+    "sound/ambience/switch_2.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/switch_3.wav": {
+     "bytes": 17576,
+     "sha256": "33b6ed57b0255840415df4db607f86b1183b564f4b1f2dcab6d45d4d75231b8c"
+    },
+    "sound/ambience/switch_4.wav": {
+     "bytes": 44348,
+     "sha256": "bfebdf2afdbab57bd5be3fe0996ce19ff46d983eea4d1511d85af2e4f7d0db00"
+    },
+    "sound/ambience/switch_5.wav": {
+     "bytes": 79992,
+     "sha256": "78bb8cb9ab7202657495a0ca14340886af901912850b9951b0da159f55c2cb20"
+    },
+    "sound/ambience/switch_6off.wav": {
+     "bytes": 141466,
+     "sha256": "999d3b02b7224586d5c487c2666981f054aa091f0569671c72455bff458c9a2a"
+    },
+    "sound/ambience/switch_6on.wav": {
+     "bytes": 176192,
+     "sha256": "7a67fa5d4ee042c6afd271868682a1a34908c2593e5ea9e868ecb6d3e154b55b"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 220548,
+     "sha256": "2cec0b03aa7047110862de21f8f6c77e4d98901ecaf5e405a473c2ddc922528a"
+    },
+    "sound/ambience/thunder2b.wav": {
+     "bytes": 286716,
+     "sha256": "44095eceb307b5f2f1093051597ea0e48bc7abe165accd5badf99c4ad692c6df"
+    },
+    "sound/ambience/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/ambience/windgust2.wav": {
+     "bytes": 110284,
+     "sha256": "b818f61172795942402ff0ca0d1295a91c36a245edc80689c35fe64a8ac1a4e2"
+    },
+    "sound/ambience/windgust3.wav": {
+     "bytes": 110030,
+     "sha256": "fdbb85f091cd9447f1500173aff70236abcdb947ba0758711816da59c5293344"
+    },
+    "sound/ambience/windgust4.wav": {
+     "bytes": 198502,
+     "sha256": "9a5c5a3da44f981c9deb8b437f57b3e3a35f2bcab318a1a3223f0a18fa4d2101"
+    },
+    "sound/ambience/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/ambience/windgust6.wav": {
+     "bytes": 396944,
+     "sha256": "27a19679e7164a6e7bb8e4d6bc42cc8c12a5cd56bba45218e2ec5f1dc528da0d"
+    },
+    "sound/ambience/woodcreak2a.wav": {
+     "bytes": 352834,
+     "sha256": "24d3f57839910934eb61b74a91cf47ee4ab48b38f58f060ca05bde7547e8813c"
+    },
+    "sound/ambience/woodcreak2b.wav": {
+     "bytes": 352838,
+     "sha256": "574401233bff93169d452f4af748a289cfaff5d4e6319884e3cfb4dbd205d0a4"
+    },
+    "sound/ambience/woodcreak2c.wav": {
+     "bytes": 308746,
+     "sha256": "02deb62b856b7be5c3304a0bf745f79019b0b408a8cfcc4e1edede397ba09c7d"
+    },
+    "sound/ambience/woodcreak2d.wav": {
+     "bytes": 352856,
+     "sha256": "6d35975964b2fa32ece681a9d0cfa13202cde02bc315f32af0690f7437352452"
+    },
+    "sound/ambience/woodcreak2e.wav": {
+     "bytes": 308766,
+     "sha256": "54eb41e3f5c2a0103d07e70e83cf82b51014da3673fb770cf6ada3df669c328e"
+    },
+    "sound/bal/bc7_waterfall.wav": {
+     "bytes": 137846,
+     "sha256": "51dcfb96c94678cbb01e0c985240e853a01c6fc3c4f2376de177c0be59bfcfe6"
+    },
+    "sound/boglord/attack2.wav": {
+     "bytes": 8036,
+     "sha256": "efa18dec8f6d5066b8d494a232ca9c98c27a4a9130130086a9b0a27ffccb34ed"
+    },
+    "sound/boglord/bangdoor1.wav": {
+     "bytes": 30968,
+     "sha256": "b267e602e76fe1d8e854e2873e06008af15612ed1a31ec41feeb4461d52fc478"
+    },
+    "sound/boglord/bangdoor2.wav": {
+     "bytes": 39828,
+     "sha256": "f904a5423580c118de1d732fff714565f1dd8d8d1556b3b58bf39d2c59fa4272"
+    },
+    "sound/boglord/bolt_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/boglord/death1.wav": {
+     "bytes": 39758,
+     "sha256": "a9e0e36b1a51d88a5b542dd2c1f79f1dbea402b3ceb18ee13606c03126f1a874"
+    },
+    "sound/boglord/idle1.wav": {
+     "bytes": 15532,
+     "sha256": "5339e3429b0510f7e8016e6ece9895df6f202b5809f739b317211a081401f202"
+    },
+    "sound/boglord/idle2.wav": {
+     "bytes": 18586,
+     "sha256": "52f8bddb2d5095f4077eb1f753d75bce94f906f1b3064067a54c875ae16d1a5c"
+    },
+    "sound/boglord/melee1.wav": {
+     "bytes": 9326,
+     "sha256": "e2f5808115d0a93dde1063db6f2d38f6ab7ff333f83d95741a8948f44ae4ace9"
+    },
+    "sound/boglord/melee2.wav": {
+     "bytes": 11746,
+     "sha256": "e299e39467c9f94730c21d1321455fdccf3aefbb0352d528b6d413639210e715"
+    },
+    "sound/boglord/melee3.wav": {
+     "bytes": 18776,
+     "sha256": "c066200b5ddb81aa0c0cc0462939681703549ac15dd6aa83db8a23ae54ce6317"
+    },
+    "sound/boglord/pain1.wav": {
+     "bytes": 11094,
+     "sha256": "6ca5a44043add6b389827e5aca8bc0c9e9c7b0cc0c7b4a5d3df292a78da0064f"
+    },
+    "sound/boglord/pain2.wav": {
+     "bytes": 11094,
+     "sha256": "7e11818fbae5354177add1e236b6f3e0f4665d50193154fbb15fead4bb4d7908"
+    },
+    "sound/boglord/sboom.wav": {
+     "bytes": 22172,
+     "sha256": "89899521eac11f922cdd4606a0fe08bc080a63a73ec4b4a502027e33f08b225b"
+    },
+    "sound/boglord/sight.wav": {
+     "bytes": 28734,
+     "sha256": "8b020b0f07a7461f5f520b8385e38828d66b3cb1fc46d7db08b845fa8ff62ad8"
+    },
+    "sound/boglord/slime_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/boglord/slime_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/boglord/thud.wav": {
+     "bytes": 22140,
+     "sha256": "f5d7b5f65e24d6a5edd04404b93a8c5a2db45cc6c142012638f050158bb783ba"
+    },
+    "sound/boglord/thud2.wav": {
+     "bytes": 105882,
+     "sha256": "7e8826a38df07d0d2b85d6d39b8b664bb2ef8a0686846573802b77811682e957"
+    },
+    "sound/break/ceramic_i1.wav": {
+     "bytes": 11106,
+     "sha256": "ed731319eb09044fe672f5d8681395a11a7449fe7b57b9a46040c717e714cf40"
+    },
+    "sound/break/ceramic_i2.wav": {
+     "bytes": 11126,
+     "sha256": "88c29d649471f031aa1049ee087cf866e1d9ea53183effd14cfabc81ecff9502"
+    },
+    "sound/break/ceramic_i3.wav": {
+     "bytes": 11144,
+     "sha256": "420d00d7884a22dd2baf9cdd1e059689858b47fb3adb2ad5ae29c80bd74b5dc5"
+    },
+    "sound/break/ceramic_i4.wav": {
+     "bytes": 17678,
+     "sha256": "0b7da87d046aeb3a52de305da60b2400c8cbf3480364235fb0bba3a0595f13dd"
+    },
+    "sound/break/ceramic_impact.wav": {
+     "bytes": 37584,
+     "sha256": "e6d2ada5c51a2787548468ad393e2497ef84b47ca487cd523f3ef6b283626226"
+    },
+    "sound/break/ceramic_impact2.wav": {
+     "bytes": 35380,
+     "sha256": "508725e20a999c339501dddb045a2ca6a51032905dccc68fe2a3fb9e9e1d0649"
+    },
+    "sound/break/ceramic_impact3.wav": {
+     "bytes": 26560,
+     "sha256": "ca4d7876a6e33cc285186d1432670878b54cc62c01e3dc4c650727069bfdb8ee"
+    },
+    "sound/break/ceramic_impact4.wav": {
+     "bytes": 37584,
+     "sha256": "e71b0559ac5d76dcd2016d07f8999ae1200d82ca7b658509339cf303c918f777"
+    },
+    "sound/break/ceramic_impact5.wav": {
+     "bytes": 37584,
+     "sha256": "1c6b3457c9d3aab209cd3b8977df579cdbe01158c1b4e5c07c2b5b227c96fb6d"
+    },
+    "sound/break/ceramic_impact6.wav": {
+     "bytes": 37584,
+     "sha256": "fac4857865a750a03f74e556f44186381315068ec1975c775fcd14ae4a7b3c7b"
+    },
+    "sound/break/flesh_impact.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/break/glass_i1.wav": {
+     "bytes": 13268,
+     "sha256": "63ec32f660d085c64274747b704bcbeb7261062b5fcbb570598d64e742dc7164"
+    },
+    "sound/break/glass_i2.wav": {
+     "bytes": 30950,
+     "sha256": "8b2ae028e6237cf06241739e3533ef3bf651194dfbef028fd648a6f06e8996de"
+    },
+    "sound/break/glass_i3.wav": {
+     "bytes": 8848,
+     "sha256": "ec97346c02431717927e2dd3712bd82428ea05960ffa027422fbaafab96b4170"
+    },
+    "sound/break/glass_i4.wav": {
+     "bytes": 4442,
+     "sha256": "b4144a008122e52aed45339e11ccf7cb1cd2e92f07e4169d029059a4ca01f5fa"
+    },
+    "sound/break/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/break/metal_i1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/break/metal_i2.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/break/metal_i3.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/break/metal_i4.wav": {
+     "bytes": 79928,
+     "sha256": "d2b35ba352f32ceae469acf9cfa04f7dcc0a462ff69e3649f5c0adf55ae2ea78"
+    },
+    "sound/break/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/break/rock_i1.wav": {
+     "bytes": 30534,
+     "sha256": "5cb61e93ebcf9bbcd3be1f6e282b51e9102d56b6650cffc0db93918b11b42322"
+    },
+    "sound/break/rock_i2.wav": {
+     "bytes": 29254,
+     "sha256": "9fdf4f489834452fce33b1fbe69bce9d4920a117c3d0d93b4fb530a7117bf160"
+    },
+    "sound/break/rock_i3.wav": {
+     "bytes": 25264,
+     "sha256": "59b506a84e018b11e9ba30a6ad299c2d8cf24d5907dc95cf30e578cd386e28bf"
+    },
+    "sound/break/rock_i4.wav": {
+     "bytes": 27244,
+     "sha256": "7a2c24ce52e272998ca035c967860873c92fbb14227a190ac82b761843680ffd"
+    },
+    "sound/break/rock_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/break/wood_i1.wav": {
+     "bytes": 28074,
+     "sha256": "6249449664f5ae509164ae3fd8588c905bea9daf5b1d919d9917b91aadf675bb"
+    },
+    "sound/break/wood_i2.wav": {
+     "bytes": 25158,
+     "sha256": "d51e731bdf895c84ec9927c496fc0a7fb6e7a37cbfbc2f6b55f54f716d804d08"
+    },
+    "sound/break/wood_i3.wav": {
+     "bytes": 17644,
+     "sha256": "8e1967cf42a7e31668d94e1b0cb7c6de4d36c6ec735d67ab01ac4e00dfb0853c"
+    },
+    "sound/break/wood_i4.wav": {
+     "bytes": 11516,
+     "sha256": "fb0908f1a2bdff824d27fa92f15690cb9f86805185119fbc7f7876547495bf45"
+    },
+    "sound/break/wood_impact.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/chthon/attack1.wav": {
+     "bytes": 22116,
+     "sha256": "91df4f5be21c6a80d31a050192b04a760f25c7f88a4b0ceeb2802fe8b8499d21"
+    },
+    "sound/chthon/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/chthon/death1.wav": {
+     "bytes": 55120,
+     "sha256": "b6eeee788b9aa49ca9698d2d7977748f142053fd3f47e2828d1781d7db7ec986"
+    },
+    "sound/chthon/idle1.wav": {
+     "bytes": 24322,
+     "sha256": "6a0a9b5a0b2e74fce8cbfa9ede97c2059884c0db81b2c68fc0ec7bb1da2a4009"
+    },
+    "sound/chthon/lavasplash.wav": {
+     "bytes": 100546,
+     "sha256": "a533653ff77e2dfc443377a1f055b6abd7af3c639f0e5634b0a47fd1f040ed76"
+    },
+    "sound/chthon/pain1.wav": {
+     "bytes": 35320,
+     "sha256": "f964bdd08ffc66f9f229aacb3b584ffefdcfbacf7da0f0075a9af752569c641c"
+    },
+    "sound/chthon/sight1.wav": {
+     "bytes": 49454,
+     "sha256": "533adf244fa2c2dca72765560e823ceead8d5a0f3832ba18d4fa2928154b12c8"
+    },
+    "sound/deflector/death1.wav": {
+     "bytes": 22150,
+     "sha256": "593140594353d4d25fe6b5e455afc0f3c2cdd6874bc1d545ea03f779454cd799"
+    },
+    "sound/deflector/death2.wav": {
+     "bytes": 41334,
+     "sha256": "4295a9a79fec3bf611c25f97553420d0e42b987ad8091930db9137b93a3e8f06"
+    },
+    "sound/deflector/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/deflector/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/deflector/idle1.wav": {
+     "bytes": 7668,
+     "sha256": "76455fc9d5fc53cf5a70900a9d875ba3ac839e1c3179eccc5287619a70523e6e"
+    },
+    "sound/deflector/melee_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/deflector/pain1.wav": {
+     "bytes": 6452,
+     "sha256": "e0905dc6c945663a97119f2c1522d5a8ebd1596ed26f33650fcb63b185959517"
+    },
+    "sound/deflector/pain2.wav": {
+     "bytes": 9598,
+     "sha256": "011d69ef5153dca029bcb1c3d60b3c3f0e1263bd9ca34a02d4d14e6ab508a0d4"
+    },
+    "sound/deflector/pain3.wav": {
+     "bytes": 12014,
+     "sha256": "08f5ac27626e862b7193f101a6d0b77dc6568c4e93ef3000199934769666b1ec"
+    },
+    "sound/deflector/rocket_fire.wav": {
+     "bytes": 15482,
+     "sha256": "a08e5f83d20b5d1eb585cf782f08a4a692b0f8c95e461b9a321814d099a89d79"
+    },
+    "sound/deflector/rocket_hit.wav": {
+     "bytes": 13274,
+     "sha256": "4dbcd0bad68272848a32a997bb235c4324cd55b1df0b96b1876fb96ea8ca6a90"
+    },
+    "sound/deflector/rocket_load.wav": {
+     "bytes": 6882,
+     "sha256": "1dbddae67f93c586ea3290ed65e1234cf8ccfd076847b1b418693e97fb5768d1"
+    },
+    "sound/deflector/shield_off.wav": {
+     "bytes": 10684,
+     "sha256": "5c3ea84c12abf632d777f90972966c4a50dde4ee7363d257e3c0f89e68027b5f"
+    },
+    "sound/deflector/shield_on.wav": {
+     "bytes": 10464,
+     "sha256": "340196ba32a9d3f672cbc3db86765eb1517550b00f2f97ed76cb519da1b93962"
+    },
+    "sound/deflector/sight1.wav": {
+     "bytes": 16106,
+     "sha256": "3ec7f00e859c52846b244e69cc3ed7321175746a44eb373fe4bd3cb07612dcf3"
+    },
+    "sound/deflector/sight2.wav": {
+     "bytes": 14432,
+     "sha256": "e8c0c1367969b0346bf5fdc94665a10480636629a71a6a35e47da3d7fb7cb463"
+    },
+    "sound/deflector/sight3.wav": {
+     "bytes": 17184,
+     "sha256": "11748c58e67305ad4e1cd7a2e2c084f9c41184cd2b4f756adfd18adcc22dbc2d"
+    },
+    "sound/dguard/death1.wav": {
+     "bytes": 30610,
+     "sha256": "af3809501261ec4d0afa6ea7301c11a5c7bbc1cc3e06b8c88172ee0214c30969"
+    },
+    "sound/dguard/death2.wav": {
+     "bytes": 43636,
+     "sha256": "93a70fc0d6fee819c723a435a3954b3fd3be86e358698ce85db1062990d1575e"
+    },
+    "sound/dguard/fire.wav": {
+     "bytes": 60820,
+     "sha256": "f5e5d4f6ccc0778c1396c66d327564a0b1892773f2c23d2e30590abf0c758bd2"
+    },
+    "sound/dguard/hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/dguard/idle.wav": {
+     "bytes": 20498,
+     "sha256": "45b2f208b9796d19d7aeb0cba64e4b0e5fd2ed7c980123f7c41ca10d17785021"
+    },
+    "sound/dguard/pain1.wav": {
+     "bytes": 10380,
+     "sha256": "9a367afb7cde241099c58c999e225ba939be39f21be818b16444f5a810049960"
+    },
+    "sound/dguard/pain2.wav": {
+     "bytes": 14892,
+     "sha256": "827a1e4d3c9983f61fffd61de33054274c144bddd9a68460b496fd6281cf9406"
+    },
+    "sound/dguard/sight1.wav": {
+     "bytes": 18124,
+     "sha256": "9cb3d960261d90ec16c9883f4326c905356b6ff4e99cdf48ab5913b098588016"
+    },
+    "sound/dguard/sight2.wav": {
+     "bytes": 18022,
+     "sha256": "35ee4b7ec6715c8c9fdc24f90ad0b5d90a0ae7a4986168cf40670e87c325d5db"
+    },
+    "sound/dguard/sight3.wav": {
+     "bytes": 19948,
+     "sha256": "c6818770267626dea27f4a72ce2249771f6968924022c2275a5a96abfa485044"
+    },
+    "sound/dguard/sight4.wav": {
+     "bytes": 20332,
+     "sha256": "7affcdbdc62f13e492a15b54fe642fe045641f5551f570cc3c8d5f7ee29521fd"
+    },
+    "sound/dguard/slash.wav": {
+     "bytes": 22942,
+     "sha256": "44b60d785ff03f033e183b6fbce69e526351187d28efdeb308f6f8bea930d450"
+    },
+    "sound/dguard/slhit.wav": {
+     "bytes": 31956,
+     "sha256": "0f07a131640f21337cd89a772588ecfc707d6a729f96b54c21920b809cd620e4"
+    },
+    "sound/dguard/slmiss1.wav": {
+     "bytes": 10458,
+     "sha256": "e32d5cb070a13fad979b021e84a727f71242305ade1af7bfe18c255f0f6dd548"
+    },
+    "sound/dguard/slmiss2.wav": {
+     "bytes": 13840,
+     "sha256": "f6b3aee08c25434d2fda7468cacf35a0912b182653a45991149b54a0fc4be537"
+    },
+    "sound/dknight/dcross_idle.wav": {
+     "bytes": 176610,
+     "sha256": "a7eba673532dad555f879ba77091e3cb9e44558608b83c36d8639e51d71b660a"
+    },
+    "sound/dknight/dcross_idlecom.wav": {
+     "bytes": 58910,
+     "sha256": "bba45bd9fc02e1d580a80596d6a1744bb8fb993ed73a7bfdf3b712670cccf989"
+    },
+    "sound/dknight/dfury_grunt1.wav": {
+     "bytes": 19702,
+     "sha256": "8d3709e913b8e26d8e094fddd9c60d74cc71b742e16276d4982c9636db05209e"
+    },
+    "sound/dknight/dfury_grunt2.wav": {
+     "bytes": 54294,
+     "sha256": "f7ca0d5970322629cc47f8c26489d5c916a570525ded20c73823c27f2834609c"
+    },
+    "sound/dknight/dfury_grunt3.wav": {
+     "bytes": 62054,
+     "sha256": "6eae53c32568ce90083dab528c18475ef840f9f684c43cdba7bfcc1c63435ba6"
+    },
+    "sound/dknight/dfury_grunt4.wav": {
+     "bytes": 28914,
+     "sha256": "0def63c77d0f116eabb77cc462ba6a57bc6523fad469946c6f1f11d786100819"
+    },
+    "sound/dknight/dfury_leap.wav": {
+     "bytes": 102756,
+     "sha256": "f288dc9324b2ccace32ce86cffaf0c042a59bf5b56b20657c018859f1038243a"
+    },
+    "sound/dknight/dfury_sight.wav": {
+     "bytes": 69602,
+     "sha256": "443887e91ca71dbba299b37a81bdbd3bb34b491c6c3e13fe73bb5c921019d1ea"
+    },
+    "sound/dknight/dprince_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/dknight/dserg_hbreath.wav": {
+     "bytes": 185884,
+     "sha256": "c8181d4844ac4b2bb7dc47bbc28bd2ae9fc2737120d6745292de4d594f40d406"
+    },
+    "sound/dknight/dserg_magic.wav": {
+     "bytes": 34768,
+     "sha256": "adcb0810b7e8b23d91d31f5727c480b35c7b59a90d9f7933f69c00e7eccd1f3e"
+    },
+    "sound/dknight/dserg_sight.wav": {
+     "bytes": 15210,
+     "sha256": "d4f7c5b6f64d48606d1d3e1889794a22107f3d5914b37c81c405fdfb1133a7eb"
+    },
+    "sound/dknight/ghost_idle1.wav": {
+     "bytes": 110292,
+     "sha256": "878416a0151a1a71891a84db2565d1e8a2b2e37f03f1822d7f9411a98b42b528"
+    },
+    "sound/dknight/ghost_idle2.wav": {
+     "bytes": 110290,
+     "sha256": "048f79f7fa8f9e49f97dad9f5cb468933be1713726ba95d3ab10d9811cbb5f2f"
+    },
+    "sound/dlord/death.wav": {
+     "bytes": 32022,
+     "sha256": "0188f6a3dd88686e15311f8c39c4277078e55bc0ec75497e2eb534af717abcdb"
+    },
+    "sound/dlord/idle.wav": {
+     "bytes": 9906,
+     "sha256": "c0ee37f80013dad1aaeb285a11a33c4d7c2ff2de0b2a94c2943d3fbe1c241bcd"
+    },
+    "sound/dlord/pain.wav": {
+     "bytes": 8632,
+     "sha256": "230ed5c7d024bfa90b973649aa79d9e9327eaf401b1632e4a1334fb4a9eb075c"
+    },
+    "sound/dlord/sight.wav": {
+     "bytes": 28028,
+     "sha256": "d82aa0028754e826705961040e1ab27f007c572a28c63dbcaeefeb681bc3ca85"
+    },
+    "sound/doors/rattle1.wav": {
+     "bytes": 88274,
+     "sha256": "c524d12100f1067bb30ecdf83e18e5d85124fef834929cfd2a2ade14f83ad730"
+    },
+    "sound/doors/rattle2.wav": {
+     "bytes": 123526,
+     "sha256": "e8decabe8df10f704814bf2f432b3fc6d5542022d465af336b0680793f6163ea"
+    },
+    "sound/doors/rattle6.wav": {
+     "bytes": 97072,
+     "sha256": "0aef6aac51a4e3528e5f2019bf113ee2f0e5096a708d31483a526c447ebdb00c"
+    },
+    "sound/doors/rattle_tech1.wav": {
+     "bytes": 61784,
+     "sha256": "18610e64612241e6936f2d0ebe746c957652c4ce8e37c668515281712f6a1e39"
+    },
+    "sound/doors/rattle_tech2.wav": {
+     "bytes": 88244,
+     "sha256": "de39aa8b59c988b02bf6c13a716e225b7ee029f2553357b8646aef92a2792c3e"
+    },
+    "sound/doors/rattle_tech3.wav": {
+     "bytes": 52844,
+     "sha256": "a29e8144cdab34467250f040feaad044aff784a2775b50bd220e967b39f39b3c"
+    },
+    "sound/doors/rattle_tech4.wav": {
+     "bytes": 76844,
+     "sha256": "ba34a641758a2e2cb9ef5358a398482c2b34526fc4b0c49db590c9679c732ef4"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/enrage.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/r_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/eel/attack1.wav": {
+     "bytes": 27740,
+     "sha256": "8c84b2a5e7fd0754dca3611a8300a8cc9656295ea73617ff0c85d167b28459df"
+    },
+    "sound/eel/death1.wav": {
+     "bytes": 34264,
+     "sha256": "a0f8eab92db10e8fa9342f725743297fd8384e2aca1decc1189109196f3b960e"
+    },
+    "sound/eel/idle1.wav": {
+     "bytes": 53110,
+     "sha256": "c059a4f2bee33543b377803f2af1fc7e2ee205cd02d987859af18087246ae46c"
+    },
+    "sound/eel/impact1.wav": {
+     "bytes": 70632,
+     "sha256": "13cea2f7d66f40511add17d846ab6142345497ddd7cff5ebfc5e2e70a7eb1fbe"
+    },
+    "sound/eel/pain1.wav": {
+     "bytes": 13316,
+     "sha256": "569a6bf9383820e90e431db5c0b82cd0201e10fd2081d228f81a0c76a0e88d1b"
+    },
+    "sound/eel/sight1.wav": {
+     "bytes": 32074,
+     "sha256": "90786a043f5ec1bd0b761c5c8378dc2783e3b1d8e3ac95a9312f55a7c5b3baea"
+    },
+    "sound/eidolon/attacka.wav": {
+     "bytes": 27660,
+     "sha256": "a7bb5c16014c814d379585eb4c6752a91240a5856ad7f3af5f86af037bef91e6"
+    },
+    "sound/eidolon/attackc.wav": {
+     "bytes": 220544,
+     "sha256": "9815d26814c687618b7bbae4a5353570afe497c5d57fb77c083f695d102234c9"
+    },
+    "sound/eidolon/attacke.wav": {
+     "bytes": 46400,
+     "sha256": "39ad467257004bc6d2a17003abe4ef8df89d0668ec03fc8570aa755cbdf94c6c"
+    },
+    "sound/eidolon/death.wav": {
+     "bytes": 264696,
+     "sha256": "bc055e1315073c78e5571c99d29894bc89abfd64b6a258bdabc79849f81c50a0"
+    },
+    "sound/eidolon/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/eidolon/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/eidolon/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/eidolon/footstep1.wav": {
+     "bytes": 52384,
+     "sha256": "e228c0503d89118be55eafaf3a3bfa0a13e3bdcbe4a043f4a9bb31c9e96cf3dc"
+    },
+    "sound/eidolon/footstep2.wav": {
+     "bytes": 46128,
+     "sha256": "1a3b867c93932411f1c3dedf4a8f1553f19caabae438cb7989095307d1a6c5c5"
+    },
+    "sound/eidolon/footstep3.wav": {
+     "bytes": 43774,
+     "sha256": "4119d9c31e359bd48b52bff2842e51c441064896289194f04db44e2d7860cccc"
+    },
+    "sound/eidolon/footstep4.wav": {
+     "bytes": 41758,
+     "sha256": "6b97f80545d9587580a7b445f13e5a38300627e497ed85357f9448c7a910864b"
+    },
+    "sound/eidolon/growl.wav": {
+     "bytes": 44380,
+     "sha256": "f9f404c4590f2af8fa9a1cd0de34e1d031e66d88ccf553dba228396f0d8fb012"
+    },
+    "sound/eidolon/idle1.wav": {
+     "bytes": 28778,
+     "sha256": "61f423068b79bba82fb3ae3fca3957a8f059802068edf272f2695e6caab89271"
+    },
+    "sound/eidolon/idle2.wav": {
+     "bytes": 33172,
+     "sha256": "1bdd3d6862ed0b74aecae1917f09a65acf4db7fca49a0ccd21a7fbc2eea5f02b"
+    },
+    "sound/eidolon/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/eidolon/pain.wav": {
+     "bytes": 17744,
+     "sha256": "6a308180389e3fb98cc00c70dad1c6600988778b34628e04363e7ca54e5bf679"
+    },
+    "sound/eidolon/rock_hit1.wav": {
+     "bytes": 97066,
+     "sha256": "d31741c09309b240d294ba9b310b694aae1d71f823ac9ef28b27a8b5fff14405"
+    },
+    "sound/eidolon/rock_hit2.wav": {
+     "bytes": 123526,
+     "sha256": "a3d1247db98535829392172110a40fde19113dd493ab603c4b6a9a36dd743150"
+    },
+    "sound/eidolon/sight.wav": {
+     "bytes": 53044,
+     "sha256": "04c124f683e75e4d14374b7a044eeea288dd02a845ccab3ffd670f1c15799ebb"
+    },
+    "sound/enforcer/cent_hover.wav": {
+     "bytes": 103796,
+     "sha256": "a5616566072a5cdc9339e3722d6fee9e652796e9cc8f76e27dbd9aee13986f4e"
+    },
+    "sound/enforcer/death1.wav": {
+     "bytes": 9290,
+     "sha256": "f62aad2ae903808a0caecfc6bdfe13e5fdebb1df14d330c6ac4eda9b577b25bf"
+    },
+    "sound/enforcer/def_idle1.wav": {
+     "bytes": 32676,
+     "sha256": "7b673b07828790504caca013c18bf697fd53b758a3638b949b433cf2d72f03f3"
+    },
+    "sound/enforcer/def_idle2.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/enforcer/def_sight1.wav": {
+     "bytes": 18260,
+     "sha256": "7d57825c28cf4f93189261d76cccab676aeba097920114d5d3f48d7eddaaa1cd"
+    },
+    "sound/enforcer/def_ssg_fire.wav": {
+     "bytes": 14206,
+     "sha256": "494a6d493c3c298c1b9cc0051ce4c1f9e129293ea7ec283b62915c49d8c249c3"
+    },
+    "sound/enforcer/def_ssg_load.wav": {
+     "bytes": 5274,
+     "sha256": "db4f62f8d76a68f2e4d3e7a29a22d3ddc5d6ae9bb296e6e800e937b73b5a4dea"
+    },
+    "sound/enforcer/elim_idle1.wav": {
+     "bytes": 39084,
+     "sha256": "2ccaa3ba4f987d031a22b8048ca23e97900fca9def362ff92943b73a99ed7844"
+    },
+    "sound/enforcer/elim_idle2.wav": {
+     "bytes": 36204,
+     "sha256": "9232028e1a93c409c7000348bfadc269c49a333e8d65d904973efb547c7af805"
+    },
+    "sound/enforcer/elim_idle3.wav": {
+     "bytes": 38222,
+     "sha256": "93034d568db5c304a165c3d89cb03ffe5d97e8157755e944a863697007eb27fc"
+    },
+    "sound/enforcer/elim_pg_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/enforcer/elim_sight1.wav": {
+     "bytes": 31468,
+     "sha256": "2268ee0ad0c77a081b289a550a1dae24b274b2e3f06d156a67beca80df8ee919"
+    },
+    "sound/enforcer/enfire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/enforcer/enfstop.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/enforcer/fum_poisonoff.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/enforcer/fum_poisonon.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/enforcer/idle1.wav": {
+     "bytes": 15810,
+     "sha256": "cec388af73dff076ea3af7c754ef0939f989f3412b0359c0fb668cd91bd4abaf"
+    },
+    "sound/enforcer/pain1.wav": {
+     "bytes": 5478,
+     "sha256": "d8692021777495825974f8406e23c74ed249f9a80a9bc944c79b1722c35f64e0"
+    },
+    "sound/enforcer/pain2.wav": {
+     "bytes": 4580,
+     "sha256": "e48a524482ce67ff94ce00fe4d8a1190aed38e9c7c24cfee3607f0f2827049e6"
+    },
+    "sound/enforcer/pyro_flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/enforcer/pyro_flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 5870,
+     "sha256": "92dc64154602e29e95d40aa68d3544fe21cb21ce24192f1e8ffefc6b5d31b8cc"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 6574,
+     "sha256": "52b1991141ed9452fe6c7ebe219cc544fba443058f179b8eec5a5cbfb9aacf3d"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 6158,
+     "sha256": "d3b9e689b2b43ae74ae14fdb26680d3646d658107664965db97420ae032d74b0"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 5166,
+     "sha256": "815e05c3b14858209fee01316848c117ad89af9f0aab190fc0ca0239367373ac"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/freddie/death.wav": {
+     "bytes": 88244,
+     "sha256": "2e3de0875dd3245a98614829ab848cc1dfc34a95827aa4cfc174884977ecddf0"
+    },
+    "sound/freddie/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/freddie/idle1.wav": {
+     "bytes": 88280,
+     "sha256": "673ac7c26a9be2b1ea37b152ce48442ff40089cc7dc015c014eb42534db2c306"
+    },
+    "sound/freddie/mangle.wav": {
+     "bytes": 48548,
+     "sha256": "ee318d6849ca9dda4569db6009210a6909279bd2ffe9b31543d47134b51c1533"
+    },
+    "sound/freddie/pain.wav": {
+     "bytes": 38640,
+     "sha256": "ffe05b43444a209084c95c166b0776d33f9ba8af15ef998d3ed5c09aa0b03c3d"
+    },
+    "sound/freddie/painshrt.wav": {
+     "bytes": 8868,
+     "sha256": "31e08c51909022a6b0ad7f01f1f8dae196269b8b105e57e555025393cdc278d9"
+    },
+    "sound/freddie/sawstart.wav": {
+     "bytes": 41938,
+     "sha256": "90f83017a7ff5f2bd2824be1e122eab7d8171ab63a9025adf1fc03ee3e7a44aa"
+    },
+    "sound/freddie/sight.wav": {
+     "bytes": 55170,
+     "sha256": "3f73e5b30cef3038102ffa9ab0faf89e71af43ed2ee5a0758319c072c151c123"
+    },
+    "sound/freddie/step.wav": {
+     "bytes": 19898,
+     "sha256": "121818aa6200c770a70c2c02844bbc0351a62f166c31f9d85765896b426f610e"
+    },
+    "sound/freddie/step2.wav": {
+     "bytes": 19870,
+     "sha256": "7e33eb621ee356cbe4affe6218b988f477259dae705d57eea12d7fe10b5d4510"
+    },
+    "sound/freddie/step3.wav": {
+     "bytes": 19898,
+     "sha256": "a005232c4c0608092c7d697c6d24566892b74adfe7566030360c96996bd39357"
+    },
+    "sound/freddie/stfire.wav": {
+     "bytes": 27598,
+     "sha256": "597fa6e0e8c4da4fd85e9e26ecd7f95f3dc242846ec9b962cf2beb324e5a4fdc"
+    },
+    "sound/gargoyle/attack1.wav": {
+     "bytes": 28712,
+     "sha256": "cab70a44f7ec34343a1608ca8c13dd2b501065cade08e94b574f98436aabeadf"
+    },
+    "sound/gargoyle/death1.wav": {
+     "bytes": 41662,
+     "sha256": "07043eb3fcbcc9c8cf53b07c10b349a9f3beb471dc240a6d70d8f2b5a57e85b0"
+    },
+    "sound/gargoyle/death2.wav": {
+     "bytes": 28768,
+     "sha256": "c363613cd476d5099dbdced656244db0d704da5eeb54fe5b880f2202f6f465b2"
+    },
+    "sound/gargoyle/idle1.wav": {
+     "bytes": 72868,
+     "sha256": "90885fa6cae946ecfedec8a150911bcfdad8ef326254e1fb1bf44ca5c5af4eb0"
+    },
+    "sound/gargoyle/pain100.wav": {
+     "bytes": 26510,
+     "sha256": "d53f1e64f4c9f5e13e03cfee2681ef6dff370e95e9dd8668c7c06b79762e7773"
+    },
+    "sound/gargoyle/pain75.wav": {
+     "bytes": 28720,
+     "sha256": "78d5d0f1c5df4e1a565eeda076d5f8b3bb3582e551909b31fa8e36c292903826"
+    },
+    "sound/gargoyle/perch1.wav": {
+     "bytes": 26506,
+     "sha256": "5eab54a566e4c1136c40fbfbd636188a7a9c4aa6b278e51fb965e1761764cbff"
+    },
+    "sound/gargoyle/perch2.wav": {
+     "bytes": 30924,
+     "sha256": "745b5c5f1fd04a73a7581373925aa70cd3f35ab899df5f5fd2c610d07bf95bdd"
+    },
+    "sound/gargoyle/sight1.wav": {
+     "bytes": 35142,
+     "sha256": "1097300e4bca9ef61a7041e7f4ff403fe67c4fc0e687b30892a6bdf35bf45c09"
+    },
+    "sound/gargoyle/swoop1.wav": {
+     "bytes": 21056,
+     "sha256": "ef6b4b672dd984e846294e0be57d81df3abcb521b1f88f6afaf2f5cc2d4e91d4"
+    },
+    "sound/gargoyle/swoop1hit.wav": {
+     "bytes": 11078,
+     "sha256": "6a624e3f46e2c45f5e2d6f42ee18643a17268a6b0df2493fe6ffdba4be0c9057"
+    },
+    "sound/gargoyle/swoop2.wav": {
+     "bytes": 24364,
+     "sha256": "f98d41f9df7244e8f77c435ae4071a4e4595ec7005b7c72e44456fe7baca425e"
+    },
+    "sound/gargoyle/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 22094,
+     "sha256": "142b725ff5515cb438a592288a69e01331b3fd0bbb7311abf1dbaf90f95417ef"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/plasma_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/gaunt/plasma_start.wav": {
+     "bytes": 66270,
+     "sha256": "ad404715612b802a7d4f72f2d14abb47c338ac414af56c19ffc8dc2873f33452"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gaunt/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gibs/gib1.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/gibs/gib3.wav": {
+     "bytes": 33256,
+     "sha256": "10a19291ed8af8893b6cdbd80416425b27e5a197d39aa8d0557320752d78cf11"
+    },
+    "sound/gibs/gib5.wav": {
+     "bytes": 15490,
+     "sha256": "2d7603a9fc0c055ed3529bd4dfd511984c71b93f4719b605813eb5139d02c6d9"
+    },
+    "sound/gibs/gibacid.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/gibs/gibchain.wav": {
+     "bytes": 15938,
+     "sha256": "c6b2a37424a51810017bd5ee4764a014329467686f73bb2f48ad2704592176f3"
+    },
+    "sound/gibs/gibheavy.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/gibs/gibheavy1.wav": {
+     "bytes": 11110,
+     "sha256": "0a1313f08fa22e4df8a1beb15ffdb6e7b1906187f63042357e4a43631ef5e93a"
+    },
+    "sound/gibs/gibheavy2.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/gibs/gibhit1.wav": {
+     "bytes": 22150,
+     "sha256": "d2a73e2f9e31b9fefda789e49b17ec9bd18df0335c31f871514a282cf550829a"
+    },
+    "sound/gibs/gibhit2.wav": {
+     "bytes": 22150,
+     "sha256": "210477e93743dc6c0541bc158032d46251c6aeff551efcf515d6e7db87bb8a53"
+    },
+    "sound/gibs/gibhit3.wav": {
+     "bytes": 22150,
+     "sha256": "40db6dbb033d59dd458e5fb6102dba6d6ecf5bc5739d9fc35a3be68cc977da53"
+    },
+    "sound/gibs/gibhit4.wav": {
+     "bytes": 22150,
+     "sha256": "0bd1e29d68e41cbf2d753730df678918a38fc886b4690991fbd7e8fb3e13e055"
+    },
+    "sound/gibs/gibhit5.wav": {
+     "bytes": 22150,
+     "sha256": "4adf7a8249ee913aeb9e91120b1f6b9e529b1e1a3eadb75185589cf7c3ff910e"
+    },
+    "sound/gibs/gibmetal1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/gibs/gibmetal3.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/gibs/gibmetal5.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/gibs/gibmetala.wav": {
+     "bytes": 18474,
+     "sha256": "2c057e772307ef647b4313975cec75bacfd522bbc5dd27ae83a867065562635f"
+    },
+    "sound/gibs/gibmetalb.wav": {
+     "bytes": 30756,
+     "sha256": "fbcfa9e6cd5aa68c6fffd6699c8dc87ec3707a4281358f229afce57f3278c800"
+    },
+    "sound/gibs/gibstone1.wav": {
+     "bytes": 52956,
+     "sha256": "962dd735a1823905243700eb3f4e0caacc1be71a1f367ccad4f21dd82b4e99e1"
+    },
+    "sound/gibs/gibstone2.wav": {
+     "bytes": 22104,
+     "sha256": "04f070fa9873f382ded03a5139ce2c7da2013d8ef9221a8d10a64c3b5f912591"
+    },
+    "sound/gibs/gibstone3.wav": {
+     "bytes": 35344,
+     "sha256": "16262de5a0b703468f2c3f1e49ffa0c225eb81b89984b468b7bc95948ed890c0"
+    },
+    "sound/gibs/gibstone4.wav": {
+     "bytes": 8832,
+     "sha256": "75179beed6fb6f581944f5e7db153bea4d9ecc65899628468efd48710a392013"
+    },
+    "sound/gibs/gibstone5.wav": {
+     "bytes": 22130,
+     "sha256": "0aaff5c363ac29a9b50d83b4b04fcd7264c614a93d0c9bc7941c9704a6b4b499"
+    },
+    "sound/gibs/gibwood.wav": {
+     "bytes": 61708,
+     "sha256": "d9b53ab4d53f1265dd2083d341cd92f19729694946ff00ad15fa6d96965e63e8"
+    },
+    "sound/gibs/stonedeath.wav": {
+     "bytes": 76750,
+     "sha256": "26d0eb67357d292043fd494b1646f8ce005ba692d98610429bceedfc831d2325"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 374654,
+     "sha256": "de356a2581884e9008ef798775f82049c465aec242cad0f6024b510d33e11764"
+    },
+    "sound/golem/groundslam.wav": {
+     "bytes": 132412,
+     "sha256": "f557ad378642a77a2f31433db5fe9315cf33f5fc350018e2bd26d32359ec8617"
+    },
+    "sound/golem/iceshard1.wav": {
+     "bytes": 53022,
+     "sha256": "41e523122aa4168298b247748bbe4201928582e974e673a83e717ea33f8656a8"
+    },
+    "sound/golem/iceshard2.wav": {
+     "bytes": 53012,
+     "sha256": "4b4e457f75d051a7aa3525bf82338f8b6d2f9460583c09e63d82b202cb11d03f"
+    },
+    "sound/golem/iceshard3.wav": {
+     "bytes": 53038,
+     "sha256": "8134080a7c6478463f9ea8c368eb6e0563dacb35bb3941b1e08e2cf0763d83ab"
+    },
+    "sound/golem/iceshard_impact.wav": {
+     "bytes": 176470,
+     "sha256": "ac850565ac7cfaa8ec2e55f535603aaf131605b9399f08f1b17f7c08920f7bda"
+    },
+    "sound/golem/icestorm.wav": {
+     "bytes": 61802,
+     "sha256": "2e8129333bc1a677591f9c4838a5f8c8e9ff63050fe6a47f212380f2497ae706"
+    },
+    "sound/golem/idle1a.wav": {
+     "bytes": 88238,
+     "sha256": "d238c43b6e83c044ba70352ed9362e50d68caf606f500c7d79f5c03d1e6a432e"
+    },
+    "sound/golem/idle1b.wav": {
+     "bytes": 88242,
+     "sha256": "93e3ca1ec51345da6e06a53f71bcd1271c911c9a6272246de9f58bef93c904dc"
+    },
+    "sound/golem/idle2a.wav": {
+     "bytes": 44166,
+     "sha256": "d0ceeb0ee1681127f9f426ccaa0ddb75c6ef32594618c972536871544e8d5748"
+    },
+    "sound/golem/idle2b.wav": {
+     "bytes": 44178,
+     "sha256": "94fb43b50445dbe7a8fe6cc06ea745b729cf5bf61c33cc543123f751e4a9cdf7"
+    },
+    "sound/golem/melee_pound.wav": {
+     "bytes": 17672,
+     "sha256": "23ff4f485f3adb3ba5227ba59824e226e91005846d2879077ffbe04141bab78b"
+    },
+    "sound/golem/melee_punch.wav": {
+     "bytes": 17702,
+     "sha256": "21cbd6ca5b9c8d95a43c39b360b12ee8033dca1aaf11d4c1164d4bc9ce83b7d3"
+    },
+    "sound/golem/melee_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/golem/pain1.wav": {
+     "bytes": 27948,
+     "sha256": "388150975b33e271db5402f502c6a36899731ec85cb9b16cdcc4b427b206a3f2"
+    },
+    "sound/golem/pain2.wav": {
+     "bytes": 32940,
+     "sha256": "b3908c02406bcb8c379f345f80a825aa270a54ae02fe0356e02330620d9cf437"
+    },
+    "sound/golem/rockstorm.wav": {
+     "bytes": 264676,
+     "sha256": "c57be8195f675560b879c3fc4e23c49f021d0c45aa81f2a84b74303f111d7c7a"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 76762,
+     "sha256": "965d1107adbc9a068d1d2af16fc783855833569dcc3a6030fa920019c30a4083"
+    },
+    "sound/golem/wakestatue.wav": {
+     "bytes": 250454,
+     "sha256": "630505eb8c9c84511f39d2e77096cafcbab044f73569934cda127a4b6f37f138"
+    },
+    "sound/items/airtank.wav": {
+     "bytes": 22160,
+     "sha256": "9b8f5c5deb886800c91d46809ecf82fb114467eb8a395b9c980d47c6b35f6b17"
+    },
+    "sound/items/airtank2.wav": {
+     "bytes": 66286,
+     "sha256": "76156f8f89e2bedbfaee9ee3340adb6bfe8639f242051178c2655e04cdab5198"
+    },
+    "sound/items/airtank3.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/items/airtank3out.wav": {
+     "bytes": 176494,
+     "sha256": "672a866c27c64f7eda1e05775cea6b4373c289c39fd423a519d39198d10a9c89"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 15122,
+     "sha256": "54c25fca46991ea142e9fdf5309e690ce3ff977df89aa7d14a8938ff386a237e"
+    },
+    "sound/items/backpack_ammo.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/backpack_armour.wav": {
+     "bytes": 20612,
+     "sha256": "438a08f094f47fac5f0b959fdde0f941be50bac12abdaa159f6f727975021aec"
+    },
+    "sound/items/blastbelt1.wav": {
+     "bytes": 43442,
+     "sha256": "a85924de58caed8e32d2849838afa0f248ec26eb295c9fc82eff818bc292f28b"
+    },
+    "sound/items/blastbelt2.wav": {
+     "bytes": 74978,
+     "sha256": "e4747a55ed0d66b6ce3bfe4ad0a4cfa75308657a155ebd9396ada78e0fd46bac"
+    },
+    "sound/items/blastbelt3.wav": {
+     "bytes": 49028,
+     "sha256": "4a2f6e7f65cbbc19c4bd5facf821017f7e60c41b9c164575de5255a40de2ba53"
+    },
+    "sound/items/health0.wav": {
+     "bytes": 8718,
+     "sha256": "cd277cc4fc98dbf9d5b0ba3ab784e468ba77a5aec78fe6086bd125512b6d1dbc"
+    },
+    "sound/items/health1.wav": {
+     "bytes": 13316,
+     "sha256": "ed9a43a3506afd8073e0d5225f3fa43116bb922b84d2216c2053d58f597544e6"
+    },
+    "sound/items/itembk2.wav": {
+     "bytes": 18884,
+     "sha256": "2b5601380dcc36753327eea905d15d2e0fd0f016d9559a2f8924f6f34b8045d5"
+    },
+    "sound/items/jumpboots1.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jumpboots2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/jumpboots3a.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jumpboots3b.wav": {
+     "bytes": 85590,
+     "sha256": "8eda0e57fdadfb61a414b4dae8c567a2bf10d9dabc44db7cf5589f00bba16250"
+    },
+    "sound/items/jumpboots3c.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/lavashield1.wav": {
+     "bytes": 30884,
+     "sha256": "e79050c462eeefcdbe6be0d79ff3042e80e5654c4060cf5377eee366cb4d6b43"
+    },
+    "sound/items/lavashield2.wav": {
+     "bytes": 49190,
+     "sha256": "17e93e45d150704bab8debd86ee8e9c600e9b08fefa70b16e1fe712dfdbd0c23"
+    },
+    "sound/items/lavashield3.wav": {
+     "bytes": 22094,
+     "sha256": "d94735d5df3c5850d2308972cb2495a9c9ec87e57c434c3ff0c160da659b051f"
+    },
+    "sound/items/nailp.wav": {
+     "bytes": 97394,
+     "sha256": "eb786846675412ba7bfb892fa0d5d356b67ec83ad3a551de8b423a874c3608d1"
+    },
+    "sound/items/nailp2.wav": {
+     "bytes": 132454,
+     "sha256": "2a01a3beb92154c7275c3c2ad39f648f8ecad7fd32ef7264d7404b917e0147dc"
+    },
+    "sound/items/nailp3.wav": {
+     "bytes": 45268,
+     "sha256": "0ea4502763119419b226d830b5b0147d6cfbe78996749e330d652d5b538dbb7b"
+    },
+    "sound/items/protect.wav": {
+     "bytes": 44176,
+     "sha256": "1bc5895a71225e8a385ebc900952d3b41f3d9541eefb8affcf15804ca96e5ab4"
+    },
+    "sound/items/protect2.wav": {
+     "bytes": 66286,
+     "sha256": "80b2a47fb1158f252e888bc692d352f224170c2d18177163dfea5c8110688e65"
+    },
+    "sound/items/protect3.wav": {
+     "bytes": 44176,
+     "sha256": "4aab23bd1683c733c5c85e7d55a93b27746860bd3c1a707e8c5a6439e35b5fd2"
+    },
+    "sound/items/r_item1.wav": {
+     "bytes": 12272,
+     "sha256": "3b569e1a8210563a64045dc1629a243b382c49cf24722cbddbdae348d5fa75d7"
+    },
+    "sound/items/r_item2.wav": {
+     "bytes": 14462,
+     "sha256": "088bb9013c0d2201997d3c566b95cc91f0419ba0bc89173c9e532659ccb4e886"
+    },
+    "sound/items/sharp.wav": {
+     "bytes": 100592,
+     "sha256": "c86d353daa830fffcf5ded77b73d6b8871d15a47a857a977ebaf7cbddb6cb587"
+    },
+    "sound/items/sharp2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/sharp3.wav": {
+     "bytes": 46584,
+     "sha256": "6318f7079e79929ff0439a570c5f806ec9c2cce8a8447eddb666dee0c2211336"
+    },
+    "sound/items/sharpa.wav": {
+     "bytes": 97394,
+     "sha256": "cd0d8dc72f736b38ab9c4a473798f0dd32e2074c14a310892c3fdf6515ff53be"
+    },
+    "sound/items/sharpa2.wav": {
+     "bytes": 132454,
+     "sha256": "2545c58a3682c1e8459389dc728a39fe0d76e6ce14a9c816a4826e327ab9bddc"
+    },
+    "sound/items/sharpa3.wav": {
+     "bytes": 45268,
+     "sha256": "083cc822d4cd6819d2dfd6e125ea4ca8ef3230c1ac1c4a5f5e3fe22e4d3d36d9"
+    },
+    "sound/items/suit.wav": {
+     "bytes": 31568,
+     "sha256": "a9b13127acef0c8e617cf5e510d5654227db9049a2b06b7544eb9e3030146ee7"
+    },
+    "sound/items/suit2.wav": {
+     "bytes": 66368,
+     "sha256": "34f0ba1b415ab62f2eb3b7a59bda6fe6fbbf3e519c7d2fab29a42ce29eb073c3"
+    },
+    "sound/jim/death1.wav": {
+     "bytes": 14348,
+     "sha256": "7f97f27dfda78f9fe6fc5265e512b651e57ae466752d56cfe0dccd6d08478ed8"
+    },
+    "sound/jim/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/jim/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/jim/gunidle.wav": {
+     "bytes": 13260,
+     "sha256": "46441335fe896cb993368bb12cedc1ddd4886b5933298bb6a0d6b7ba430cdfe5"
+    },
+    "sound/jim/gunidle2.wav": {
+     "bytes": 48540,
+     "sha256": "08d3577b66ab4b4c65ae7b01e4590e8d985605cc51a939bae0b43967472208c6"
+    },
+    "sound/jim/idle1.wav": {
+     "bytes": 44460,
+     "sha256": "7bc2df6cdd0f9a06cc441c656664edb3c686ab5803dab70948cc27bbba968494"
+    },
+    "sound/jim/idle1r.wav": {
+     "bytes": 44460,
+     "sha256": "7549a540858b1a829ac010930b848474c2f2200b910371368c99e35641f24644"
+    },
+    "sound/jim/idle2.wav": {
+     "bytes": 44460,
+     "sha256": "90d55e9ac8db5523255ec80384abd2508f005890f4fb66a654f4d783435afb4d"
+    },
+    "sound/jim/idle3.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/jim/laser_load.wav": {
+     "bytes": 36040,
+     "sha256": "5f39b9f60c5de5c9c3ac25a5149f1fef557e66c09d7d1a760ed6770082c5a914"
+    },
+    "sound/jim/pain1.wav": {
+     "bytes": 27006,
+     "sha256": "27522940f1db4eb098388e049a63d3a608e4beb2fa248d1232ae45d38a944e85"
+    },
+    "sound/jim/pain2.wav": {
+     "bytes": 30850,
+     "sha256": "6d1988d75f430287ad3e8766e9aafa8c8c85e2f2ebf53395b0fc2eb0fb26d788"
+    },
+    "sound/jim/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/jim/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/jim/rocket_load.wav": {
+     "bytes": 23416,
+     "sha256": "e3820aad09060be13927e56fc0e21112c22161b50b7d5be9cf59b98f84c5a231"
+    },
+    "sound/jim/sight1.wav": {
+     "bytes": 14892,
+     "sha256": "1a0db2b8c8d763f9aae09913d1cd3548fa0e30eb03949e24ef511a70acfda303"
+    },
+    "sound/judge/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/judge/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/judge/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/judge/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/judge/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/judge/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/judge/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/judge/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/judge/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/judge/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/judge/smash_ground.wav": {
+     "bytes": 66250,
+     "sha256": "f29f17426d2bd961d4f166e25fb951c8e12a37314bbc49722f0ae34c2beae233"
+    },
+    "sound/judge/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/judge/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/judge/smash_roar.wav": {
+     "bytes": 61784,
+     "sha256": "24b26a6b00a8731693bafd8ef67a5f0e2a4bbad20e722ec14f6fefd13047dc78"
+    },
+    "sound/judge/summon.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/judge/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/justice/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/justice/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/justice/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/justice/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/justice/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/justice/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/justice/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/justice/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/justice/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/justice/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/justice/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/justice/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/justice/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/lostsoul/bite.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/lostsoul/charge.wav": {
+     "bytes": 114682,
+     "sha256": "327cf4f521c92b3af6ff7cf50d1bfa6d101d06dee52350f123473e56e72626e3"
+    },
+    "sound/lostsoul/death.wav": {
+     "bytes": 151916,
+     "sha256": "08b6f8d3a50465e7deb346bc8902605bfc8bafc134cfac38aeb1d9fa5d1d2863"
+    },
+    "sound/lostsoul/idle1.wav": {
+     "bytes": 132332,
+     "sha256": "aac9bd66ea75d4778a20ba07b248baaa4f446beb60e5b5be76d04be36df1a1db"
+    },
+    "sound/lostsoul/idle2.wav": {
+     "bytes": 132332,
+     "sha256": "963c18a04a41d49ced0c820fd6ec51c885e7828a2a09bd47c15227555b6d4ada"
+    },
+    "sound/lostsoul/pain1.wav": {
+     "bytes": 14948,
+     "sha256": "baccaed4fd7c4e504214eb7241d3e8ea3e187739a781c30de57c8b5af6dbe6d0"
+    },
+    "sound/markie/dronebell1.wav": {
+     "bytes": 410346,
+     "sha256": "c7b65065ba9279c8131a83b642523e4193b8611f7b14430af2d52c831082340a"
+    },
+    "sound/markie/dronehum1.wav": {
+     "bytes": 156754,
+     "sha256": "9542c51342398a1281476da03114adb01012367dac58d2a08b50c684a1a98093"
+    },
+    "sound/markie/dronehum2.wav": {
+     "bytes": 183654,
+     "sha256": "03545ae0f88b788e69e09c0aae2cccfa727a2609ef224c7d1d3451f0e6172709"
+    },
+    "sound/markie/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/markie/dronespace1.wav": {
+     "bytes": 151808,
+     "sha256": "2c9c7f38a2023d3452a48db3e5f98d11fa218315991d907f8e3fa95d128d4f76"
+    },
+    "sound/markie/dronewind1.wav": {
+     "bytes": 110328,
+     "sha256": "f65fd70b6c398e1a17975eff7d92bde89ac17bc8d5cf0e9c6dcb17934311e3a6"
+    },
+    "sound/markie/morte1.wav": {
+     "bytes": 529280,
+     "sha256": "c338e404901bbf094c5946e50cbd922580c077dc3f3e5369ab962cb07a70d855"
+    },
+    "sound/markie/morte2.wav": {
+     "bytes": 529280,
+     "sha256": "58e598c9da2ced85f6973eb897f578e0f29a13fa0eaefebfe14c8942a33c77ed"
+    },
+    "sound/markie/ritual1.wav": {
+     "bytes": 273266,
+     "sha256": "fe9b4b53f899a88321707330bb2454442d74e5098328e35549b9f0a8ff840cba"
+    },
+    "sound/markie/ritual2.wav": {
+     "bytes": 273246,
+     "sha256": "d38ee880af55413aa7c180b8c1935df71177502081ee1c376c37b572af3d9352"
+    },
+    "sound/markie/stingwhisper1.wav": {
+     "bytes": 132380,
+     "sha256": "fc6eebd33c0c99c0f4537a9727698181acb4d23d077f06b3da1ebbcb104c870c"
+    },
+    "sound/markie/stingwhisper2.wav": {
+     "bytes": 132380,
+     "sha256": "ae7319c28e0a4e492623b7ddb48634978da043c16d4450f86b8edf7e60fa283c"
+    },
+    "sound/markie/stingwhisper3.wav": {
+     "bytes": 151672,
+     "sha256": "e5dd9dcfd44dedf7b0cd4a0a94a519a0bbd84477e54293548a37aa16d3f1e428"
+    },
+    "sound/markie/watercreek1.wav": {
+     "bytes": 184884,
+     "sha256": "f0c3ac87d6f073cea0d1a9218c4e53327be7af07a8c8be00cd73f254f6c0ba03"
+    },
+    "sound/minotaur/attack1end.wav": {
+     "bytes": 19936,
+     "sha256": "eceb47163a0f495037bd067fcfe852dbd0cf8cc7c376c536f5e4bda8569d3f5c"
+    },
+    "sound/minotaur/attack1expl.wav": {
+     "bytes": 15554,
+     "sha256": "a8344e4036b9377a6c8e3d69c2e86c7f5fc157fb0034d6e0e190d5b9fc444ca7"
+    },
+    "sound/minotaur/attack1long.wav": {
+     "bytes": 42000,
+     "sha256": "bb901880112ff159b380b8bfaf19fc511f4b1217f08d55a05276a3500f6cd4c7"
+    },
+    "sound/minotaur/attack1start.wav": {
+     "bytes": 19944,
+     "sha256": "33dafc2b20be70d6da51321f9910a392535e6a31cbbd3c8d0d880307a18adb3a"
+    },
+    "sound/minotaur/bolt_fire.wav": {
+     "bytes": 17738,
+     "sha256": "2f8ea56413270eef58b56ae4c4f7af2506ee89fda82aab90c0426f4560baa80a"
+    },
+    "sound/minotaur/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/minotaur/idle1.wav": {
+     "bytes": 17686,
+     "sha256": "d213130ad4b58b5b55553da46d358526411916210e90caf082c5a93b499e2f81"
+    },
+    "sound/minotaur/idle1com.wav": {
+     "bytes": 15564,
+     "sha256": "0f8054eb2c16284a098f680dcdc65f5a4b8b971f8cceaca6adebe8c377d6117f"
+    },
+    "sound/minotaur/idle2.wav": {
+     "bytes": 15470,
+     "sha256": "390c82c79532878751bcddca11aa37dbd86018757860e46d0c950a09fee347d9"
+    },
+    "sound/minotaur/idle2com.wav": {
+     "bytes": 17764,
+     "sha256": "8369884de2f4f144b9e323f11e95f47723834b529b62100c908fef5e74391a93"
+    },
+    "sound/minotaur/jump1.wav": {
+     "bytes": 22160,
+     "sha256": "1aa935c4c76818dbe7faed7aee0d9acb9e98ad553a747bf00b83b811d141e886"
+    },
+    "sound/minotaur/pain1.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/minotaur/pain2.wav": {
+     "bytes": 41488,
+     "sha256": "bc9ffeb193379c6738ad2897ab582aa92e278a11d7f1fbb77563ca367987ff76"
+    },
+    "sound/minotaur/sight1.wav": {
+     "bytes": 48610,
+     "sha256": "8d0a5c1a31e525416430f8d45b8482b091d3bb9f6030ac2656bdeb231ddab5e9"
+    },
+    "sound/minotaur/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/minotaur/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    },
+    "sound/minotaur/strike1.wav": {
+     "bytes": 11142,
+     "sha256": "69b1419eed136c384deac99d31827825d3d57fc965ba80604faf9de3e85fd9b8"
+    },
+    "sound/minotaur/strike2.wav": {
+     "bytes": 11142,
+     "sha256": "ab12dc8ab3c9dc603e2ecd58a99beb9c1f551fb79eb6124bdba493efe7595a92"
+    },
+    "sound/minotaur/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 19940,
+     "sha256": "0798d1a1122171f06fd6b92e3f91881725c05f40e1eeb3494a5a1a1aa8a86e58"
+    },
+    "sound/misc/drip1.wav": {
+     "bytes": 12172,
+     "sha256": "9499c277eab2210ba491b61263b71410e5e8f4b2a68403ec6eb81bef687da04a"
+    },
+    "sound/misc/drip2.wav": {
+     "bytes": 15596,
+     "sha256": "410c25c5c459362849c7d3d0ad736e006b65a949e77c094fe248e803b357d5e0"
+    },
+    "sound/misc/drip3.wav": {
+     "bytes": 15164,
+     "sha256": "9ddf50265efafde7736fb7d03419988caab691245b32d986549ef6d643d2768c"
+    },
+    "sound/misc/flies1.wav": {
+     "bytes": 44168,
+     "sha256": "ca5cf0a4d661bf7440cd81dcd45ad7118c54c8ae58672755ee958ec6e50f7152"
+    },
+    "sound/misc/flies2.wav": {
+     "bytes": 44166,
+     "sha256": "09e6d74986b0f0ec9503d9e111f8d1436d7d6c5c4c0c87ec7808e3fca5b964b1"
+    },
+    "sound/misc/flies3.wav": {
+     "bytes": 44182,
+     "sha256": "2b5fb337ba88bd25e10c86bb6355723aea160b0ef6a6d43b30cbbd446444ed8e"
+    },
+    "sound/misc/gibf_fire1.wav": {
+     "bytes": 14376,
+     "sha256": "804f8524135d058d3a635e6567e3369b8b9ef2ecc808bf6e216c4d65609b86a3"
+    },
+    "sound/misc/gibf_fire2.wav": {
+     "bytes": 25842,
+     "sha256": "354b551ac38a19370126f67e3975ab795953bd7beb2c597f0a01a0de6286b7c1"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/laseron.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/misc/poweroff.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/misc/poweron.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/misc/rumbleloop.wav": {
+     "bytes": 106060,
+     "sha256": "fafcaa92b4a2174045e3826885d14e434a409bf559d1a1d519c4d50ec8939789"
+    },
+    "sound/misc/rumbleoff.wav": {
+     "bytes": 105990,
+     "sha256": "46728daf18b142575d50049188030a153c0e3e994dc83ea375c43ba6da171b3c"
+    },
+    "sound/misc/secret3.wav": {
+     "bytes": 302444,
+     "sha256": "75682a08b790af46c2b9f746e5772999ba1de333b567832f4a3a8414c6a0185a"
+    },
+    "sound/misc/spaceship_fadein.wav": {
+     "bytes": 231712,
+     "sha256": "d6c905eb002532087273eadb5a577db443068532795fd509571179a354c56a9f"
+    },
+    "sound/misc/spaceship_fadeout.wav": {
+     "bytes": 495982,
+     "sha256": "9e5286b29adeb9cf7b3af489bb2ea539c8eed7b26a28ec1f34cd5f78c33e521c"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 13270,
+     "sha256": "14d74e6c01df6db6f92b8684527b31a7544de8d4dd9d123ebae554989e76facc"
+    },
+    "sound/misc/torchoff.wav": {
+     "bytes": 54160,
+     "sha256": "d49cf5f2100d9b5afbf76a662019a9e3a66fcd5fb40c2b2600ceab107227cbf3"
+    },
+    "sound/misc/torchon1.wav": {
+     "bytes": 88680,
+     "sha256": "ecb211c777393fe3c7012bf0a35cc157af94ccb4742cac3ca7ab6daa5546a4ac"
+    },
+    "sound/misc/torchon2.wav": {
+     "bytes": 84764,
+     "sha256": "b7d885df1c70b226a77a3cc8842565fa9ebf51561158daec4b12e9629a515986"
+    },
+    "sound/misc/torchon3.wav": {
+     "bytes": 97484,
+     "sha256": "25058a3354df07a90b8660640682f7091fa40da6f8abf178c7de71d547a8b0c1"
+    },
+    "sound/nour/attack1.wav": {
+     "bytes": 50794,
+     "sha256": "7f22a1569d59bcd406efd7828ed605d71bfbc8cea01606eedb78d33037655f77"
+    },
+    "sound/nour/attack2.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/nour/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/nour/death.wav": {
+     "bytes": 39772,
+     "sha256": "2e2d15b95fc35738108d83a2b5aefded93772134d2a8124d1b937b6bfcfd74c5"
+    },
+    "sound/nour/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/nour/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/nour/explode2.wav": {
+     "bytes": 22168,
+     "sha256": "654a50eb01d1c6c64bb8df4b85669448cc08b580ffc44616da854bd3cb339ea1"
+    },
+    "sound/nour/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/nour/idle1.wav": {
+     "bytes": 24332,
+     "sha256": "c77ef8ce85720e3bf0ea97937992b5aa7cc6b63149c951e71b4d3ead14fc21af"
+    },
+    "sound/nour/idle2.wav": {
+     "bytes": 44176,
+     "sha256": "e87bd537a35c005b06ffd28f66adde24d52af338d3956d4fab455d682e78eec9"
+    },
+    "sound/nour/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/nour/pain.wav": {
+     "bytes": 8686,
+     "sha256": "073044c582c2de6f336130aeb9503fa6edf1da4eed216a4b407b2cd18d5f9995"
+    },
+    "sound/nour/projbomb_burn.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/nour/reveal.wav": {
+     "bytes": 39780,
+     "sha256": "6dd892d207fa31eb93c5a033ab44bba4952b3aed892aa409e6a49e2059381cdb"
+    },
+    "sound/nour/sight.wav": {
+     "bytes": 48612,
+     "sha256": "252c0bf76b928f7fe998f82bf148816e88cdc24f812bd8c8d3a591c1c4ec3d7d"
+    },
+    "sound/nour/sight2.wav": {
+     "bytes": 48612,
+     "sha256": "18b8e9450c00d6a9308adffa2046e747b8ed7bb5547f868ed146cca75b260b87"
+    },
+    "sound/ogre/ham_hit.wav": {
+     "bytes": 52014,
+     "sha256": "20f7ec214fdf8a342ac8c3be7d3ed04c7b7b3479f9c74138a8a052ba7674ee46"
+    },
+    "sound/ogre/ham_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/ogre/ham_wave.wav": {
+     "bytes": 132316,
+     "sha256": "d957285dc74a4e067f600465112ed41d69d14554f8e87ad6b0372b9ca8af4b25"
+    },
+    "sound/ogre/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/ogre/ogidle.wav": {
+     "bytes": 25706,
+     "sha256": "54915681452970c56f1ef405b182e90fa7ee3c4d4d80e32583a38abc7c1db713"
+    },
+    "sound/ogre/ogidle2.wav": {
+     "bytes": 22426,
+     "sha256": "2ed241e576a709285f7ea8a9671f6032da5a8db96e094e9007f60617cad491fa"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 28742,
+     "sha256": "738af1bbf36d5b3287c45e7815d87ea7f5c1a0487c804de7272091fdbb7faac2"
+    },
+    "sound/ogre/ogpull.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/ogre/ogrefish_flappy.wav": {
+     "bytes": 51262,
+     "sha256": "79a9eafef5edf45851a1c391e301c6f515536922c297b904e148b337e7f54a08"
+    },
+    "sound/ogre/ogrefish_idle.wav": {
+     "bytes": 27552,
+     "sha256": "5abf50694e67aa1e805a598a464d5d3b1f0625677a2873761cae139c4b21d524"
+    },
+    "sound/ogre/ogrefish_in.wav": {
+     "bytes": 6678,
+     "sha256": "dd5fc9aecb5b6933252739047aa5d3f775797ad7bf6ddb5652ffd26ea9ead3e2"
+    },
+    "sound/ogre/ogrefish_out.wav": {
+     "bytes": 15502,
+     "sha256": "2610f025057ee0a6682b574567b7400f83ba9f6665b9f7f3b9e76cff75b8be53"
+    },
+    "sound/player/h2ojump.wav": {
+     "bytes": 22126,
+     "sha256": "dd2d3629970814e719be6c9650a497edd219f31fb1554927b9770a1b0dfcdc60"
+    },
+    "sound/player/heartbeat.wav": {
+     "bytes": 70640,
+     "sha256": "a68fd895a3212f967a4686e94df2749fa3f58392ab2228aa880697e25b548147"
+    },
+    "sound/player/inh2o.wav": {
+     "bytes": 22126,
+     "sha256": "4c4d55502ab63ddbc9beb64b0459ad4d7a2992fe41e76144d3bbd3333af4a570"
+    },
+    "sound/player/ladmetal1.wav": {
+     "bytes": 95952,
+     "sha256": "6cd990509a965ff251ffb33ff7c22b6eb708cec5f7b7b82e2196b1fb3d3cb1c2"
+    },
+    "sound/player/ladmetal2.wav": {
+     "bytes": 96116,
+     "sha256": "a477162fc355efc88568b9e18d668b7b0e8e99af460b88c755bd1ed57da35006"
+    },
+    "sound/player/ladmetal3.wav": {
+     "bytes": 96008,
+     "sha256": "20ea0c70bcc3c951bb067cb65b938c63267bba0a1eda3a335df525dc9432d234"
+    },
+    "sound/player/ladmetal4.wav": {
+     "bytes": 96126,
+     "sha256": "d2a6bede3a9c499d01a0b0b9620d4bd1935f9477ecb9c59a8d73f3133699ea45"
+    },
+    "sound/player/ladrope1.wav": {
+     "bytes": 70706,
+     "sha256": "6713acc390790d4723df21b0702796958132af34ce5ec0a85fca5edc36ccd728"
+    },
+    "sound/player/ladrope2.wav": {
+     "bytes": 70792,
+     "sha256": "384b8c3ad3749fa9963ff3210d7cb312858771cca85082b6a8ad13179ad92da3"
+    },
+    "sound/player/ladrope3.wav": {
+     "bytes": 70760,
+     "sha256": "ed397a0308ecacd0ba9774f082aec5e681bcffb219c8d9127b7d7606a6fbb02d"
+    },
+    "sound/player/ladrope4.wav": {
+     "bytes": 70758,
+     "sha256": "e1a4327f1c458f408abd6ff713d11e0aee8daaa9c876002b693135d8e64b68fe"
+    },
+    "sound/player/ladwood1.wav": {
+     "bytes": 48084,
+     "sha256": "bd68f3af0f6cd429d08aa44168e14435ed9e2e2ec0d6a038f83e2dd683cb7e74"
+    },
+    "sound/player/ladwood2.wav": {
+     "bytes": 48086,
+     "sha256": "bb687ec2183f460ac4240acfcd2f3da2f8bd9da043ba705f6e32c3439e4845b9"
+    },
+    "sound/player/ladwood3.wav": {
+     "bytes": 48088,
+     "sha256": "7271136b6398602c7b4bdbd610a37b5a82a66195842030a21de08a89808b4026"
+    },
+    "sound/player/ladwood4.wav": {
+     "bytes": 48086,
+     "sha256": "3b7580b31dee8a86e636c5fd17d92566d147417f98764d51097ad53ff0d19d29"
+    },
+    "sound/pushable/brick_m1.wav": {
+     "bytes": 44144,
+     "sha256": "7572ac5d03045552dfee673293722da8c663d072cc7b57e44adb2e3884ea33c9"
+    },
+    "sound/pushable/brick_m2.wav": {
+     "bytes": 44144,
+     "sha256": "209e22e4693184c7b0c022e650b156e255cfa76b18c1066fe20255e285b4e80b"
+    },
+    "sound/pushable/brick_m3.wav": {
+     "bytes": 44144,
+     "sha256": "edafb8bf0915badb97edd078aa129c10a29e8fc428f4e9143f5926f9aa336e43"
+    },
+    "sound/pushable/glass_m1.wav": {
+     "bytes": 48044,
+     "sha256": "66a5944b16e3fe59cf9f8632f92bd85f81b79dc8711337558c45078c91a13c46"
+    },
+    "sound/pushable/glass_m2.wav": {
+     "bytes": 48044,
+     "sha256": "d462bac59390f89facc7c00d8aaee6e71b529ae9f177514a5f2f0533c78d5a0e"
+    },
+    "sound/pushable/glass_m3.wav": {
+     "bytes": 48044,
+     "sha256": "1a2efd7875486d15df811135d589135c807ba0149c877085f165932eb2770320"
+    },
+    "sound/pushable/metal_m1.wav": {
+     "bytes": 44144,
+     "sha256": "91420caf0e2de995681ac09b2be26cc9d0759edc06498571527528419de407d1"
+    },
+    "sound/pushable/metal_m2.wav": {
+     "bytes": 44144,
+     "sha256": "72f018c79b343538fd90de944ed54e8e3351b3da0a6c198f28403d25fc8fb140"
+    },
+    "sound/pushable/metal_m3.wav": {
+     "bytes": 44144,
+     "sha256": "c26b3aff129d573a1175fb618186db3b7ede8976e134c563c1678f48eaf8e302"
+    },
+    "sound/pushable/rock_m1.wav": {
+     "bytes": 48044,
+     "sha256": "9fb6ebeae45b4c47b1e42af1f00441d0e0bb88fbb53f85ea875341f9db55efb4"
+    },
+    "sound/pushable/rock_m2.wav": {
+     "bytes": 48044,
+     "sha256": "b57d0f760bb318b1159293e38811e5607bae8ff244d8bbf56223b355ef7c5b39"
+    },
+    "sound/pushable/rock_m3.wav": {
+     "bytes": 48044,
+     "sha256": "5e6514c241bb11d6194d9762d5369fb2a8da287b3d4c08e67f23da84fdb26b04"
+    },
+    "sound/pushable/wood_m1.wav": {
+     "bytes": 48044,
+     "sha256": "e672209779ee47996ca93e60d30e572da3cced5381db3f34c14a709629a5f4d2"
+    },
+    "sound/pushable/wood_m2.wav": {
+     "bytes": 48044,
+     "sha256": "c76b7db5faf1cbf21c07dacec615436a95f34c0e16e68628b62ec89a89b12f83"
+    },
+    "sound/pushable/wood_m3.wav": {
+     "bytes": 48044,
+     "sha256": "d6751d9e67c49458df6c076d9b6be9619f845213a263cb76330f51700f8a632c"
+    },
+    "sound/scorpion/clawattack1.wav": {
+     "bytes": 13360,
+     "sha256": "b0daf0605690db89f34a19936f1c20ad25676a4e6cd9dfad0e5757cf81dc4f7d"
+    },
+    "sound/scorpion/clawattack2.wav": {
+     "bytes": 13360,
+     "sha256": "06da85e6d6035704932fdc1ef449de529e17853571d017c5a42b253b5ed71a94"
+    },
+    "sound/scorpion/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/scorpion/hiss.wav": {
+     "bytes": 26664,
+     "sha256": "9d9fae97f3996ff3c0616f7acda952166d5eced9227d15a8fbe9d285095e7936"
+    },
+    "sound/scorpion/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/scorpion/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/scorpion/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/scorpion/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/scorpion/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/scorpion/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/scorpion/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/scorpion/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/scorpion/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/scorpion/tailattack1.wav": {
+     "bytes": 25858,
+     "sha256": "61e6c65b4c68813925e594b96ebad8a945c87d51f2cd23f301e80e231e53033d"
+    },
+    "sound/scorpion/tailattack2.wav": {
+     "bytes": 19650,
+     "sha256": "aab86f97eed636ebfb79ae7b92e4b7f7a3436b0146ad75519edd4358716169c7"
+    },
+    "sound/scorpion/tailfire1.wav": {
+     "bytes": 8924,
+     "sha256": "1f41bd184aa58b9f2f1b2f1197f3b7827c55d523d03a354dd1fb6d469cf129c8"
+    },
+    "sound/scorpion/tailfire2.wav": {
+     "bytes": 8948,
+     "sha256": "40a126ab5cba6c291d69606eddb7e2ab63ab640b1347b2e78ab4b0f7aca90c5c"
+    },
+    "sound/scorpion/warning1.wav": {
+     "bytes": 76930,
+     "sha256": "ae19faeebc0d3ec8c9f136bba205e634a29425ec86c3036016e5f2d9cd550817"
+    },
+    "sound/scorpion/warning2.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/seeker/death1.wav": {
+     "bytes": 397272,
+     "sha256": "35d8a1091032f24ed6a65efa99a7618f32bc0def24779efb51752b75a9e31ca1"
+    },
+    "sound/seeker/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/seeker/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/seeker/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/seeker/footstep1.wav": {
+     "bytes": 96092,
+     "sha256": "e5cd4f907a1b70ec72048b2dd5a5062022e7058676c3d90d05b7426e189a5073"
+    },
+    "sound/seeker/footstep2.wav": {
+     "bytes": 96076,
+     "sha256": "f3c8ba8d65257ddfa73e3e54c737c49de5dcc5c17bb088feb3511c3d69d21ac4"
+    },
+    "sound/seeker/footstep3.wav": {
+     "bytes": 96092,
+     "sha256": "c6fa111be092592a253815826c499b9b1f18a0c536910e2a82eebec7fb7f817d"
+    },
+    "sound/seeker/idle1.wav": {
+     "bytes": 141126,
+     "sha256": "10693a1d5fc1d710e54a0d57ce10d71400de192b874d6776ffe176c2b399a6b5"
+    },
+    "sound/seeker/idle2.wav": {
+     "bytes": 97420,
+     "sha256": "c24b439701d9ec3cf055702f23a3eb23623320ae89b9d46ab98a791f08898573"
+    },
+    "sound/seeker/melee1.wav": {
+     "bytes": 106252,
+     "sha256": "addfb5fab225a77f08d5c126b13f929fa31aa1c9094fc79202121ca891933fb9"
+    },
+    "sound/seeker/pain1.wav": {
+     "bytes": 19884,
+     "sha256": "ccaca64b8c1ab87d7d70896333cbec22c3b61c443a36cd8f253ad0eafc2d7ae1"
+    },
+    "sound/seeker/pain2.wav": {
+     "bytes": 19884,
+     "sha256": "8c3be23111a5ef53a7b66c7b74e32404ff0e6989d7de835543e0a65645e3f793"
+    },
+    "sound/seeker/punch1.wav": {
+     "bytes": 19940,
+     "sha256": "e4bf6b7deb14b5d614b4d5b7d4eeee36059372c913cc906589e1048d4484259d"
+    },
+    "sound/seeker/range_laser.wav": {
+     "bytes": 88246,
+     "sha256": "ee9f13af042a2a98fb75fa33873a1e861f3418f598ddb390f15ab44fcf93fcbf"
+    },
+    "sound/seeker/range_plasma.wav": {
+     "bytes": 79782,
+     "sha256": "9b1d38a4e1937023536d5ab5de035c97e1ef69131d58822b194cab2a3aa340b3"
+    },
+    "sound/seeker/range_rocket.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/seeker/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/seeker/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/seeker/sight1.wav": {
+     "bytes": 163526,
+     "sha256": "ca06541f54bcc297ab19ee133de5c782e978cf7afc2fab34b3789c4c56044d30"
+    },
+    "sound/sentinel/laser.wav": {
+     "bytes": 9712,
+     "sha256": "c5f90e1823a04b48f7f24ac5b8792e1b42030a8b07970db5847dc1e74be094c2"
+    },
+    "sound/sentinel/nail.wav": {
+     "bytes": 13750,
+     "sha256": "7acc3ac05b7218abc6fef2d2397771d90fce6fa39415e33824be7e771d30e288"
+    },
+    "sound/sentinel/widle1.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/widle2.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/wpain.wav": {
+     "bytes": 19596,
+     "sha256": "bc7b6536a1c67aa89295eeacea2d9b36cb0bf783b5fb7cc6aaf4fa01a0edb3fd"
+    },
+    "sound/sentinel/wsight.wav": {
+     "bytes": 27322,
+     "sha256": "83bca2103d60c68435e27f0660e3ecd5bffb058e796382e7bdb43efabdfb9889"
+    },
+    "sound/shalrath/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/shalrath/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/attack1.wav": {
+     "bytes": 44184,
+     "sha256": "91f50e3b69909213e23149b6a3e9622c4367d77f871da5f01e6e4aea3badf648"
+    },
+    "sound/shub/attack2.wav": {
+     "bytes": 33174,
+     "sha256": "d4928f711f7e8fc1d8ba050a87b4e1c2d48ffc24af6a454637629dfae8902e3f"
+    },
+    "sound/shub/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/death1.wav": {
+     "bytes": 107440,
+     "sha256": "1551554be1b7896ee39156ce258bf68ac5dace891994788020ee95083ae33e77"
+    },
+    "sound/shub/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/shub/idle1.wav": {
+     "bytes": 75072,
+     "sha256": "9d33c61470d0c4269c8d113b4476b84236fa00e6ee3be061865e242c988093af"
+    },
+    "sound/shub/idle2.wav": {
+     "bytes": 75000,
+     "sha256": "21b063438744def5f79a50709c567cc9f3e3a28c39e58456068a3d4ae362617f"
+    },
+    "sound/shub/idle3.wav": {
+     "bytes": 75096,
+     "sha256": "310c4ff969da63c77e7ebb5b319aca0f17a10802ee942b21174349d5e5a79d72"
+    },
+    "sound/shub/pain1.wav": {
+     "bytes": 83880,
+     "sha256": "1d1536a51822b67106ea72bcb537efbf5f69e4a4592904f6feedee06ef5084df"
+    },
+    "sound/shub/pain2.wav": {
+     "bytes": 83886,
+     "sha256": "71c30d3f41e0f99cffcf5037b482c1da7bf028b477051219f6e605ceef28ae38"
+    },
+    "sound/shub/sight0.wav": {
+     "bytes": 83880,
+     "sha256": "6d4d96fc663db248cf9279c0b028c11b451b133c6e2c38364c13e105f8fa377f"
+    },
+    "sound/shub/sight1.wav": {
+     "bytes": 83880,
+     "sha256": "ecaf1595f3acbfe2e771a193c69bd6de5e6e3bd957405fdf4bcf59a2288bdb05"
+    },
+    "sound/skullwiz/attack.wav": {
+     "bytes": 15484,
+     "sha256": "ca662d909cb3b96bdfb93197092ed8e8a5d1ed27772a91a4a6ae5e9d3063017a"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 33166,
+     "sha256": "5d1ccd5b97bd38eaf46d1e0798009765d46d58ba17e7e6efc36350b0adaa22f7"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 33178,
+     "sha256": "dd77e90760bd85fc872a96c2eaa808b094a461ab2871bd8ab6a5372861560512"
+    },
+    "sound/skullwiz/blinkspk1.wav": {
+     "bytes": 44200,
+     "sha256": "ade109f32810094922f77bc3c03f02d33e98d855d3dcaf79ceab4cb200efaa65"
+    },
+    "sound/skullwiz/blinkspk2.wav": {
+     "bytes": 44204,
+     "sha256": "16d3b1296e1ed9c3bdc06dd25f5d9db3569cf3486794d29858d5ad227741dd1a"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 33166,
+     "sha256": "bc83800a91fad273e7f84f3cec2fa2787c902f4cd97fd5495f73dc9fb6d2c368"
+    },
+    "sound/skullwiz/fadeaway.wav": {
+     "bytes": 43092,
+     "sha256": "dd67d3ffe5a592b4e449d6bb00eee3c525ede786b0a2d9089832981311bfd61e"
+    },
+    "sound/skullwiz/idle1.wav": {
+     "bytes": 88252,
+     "sha256": "1834b946ff68aab07ade01b68d95d822d0b2a1baa51c1ceba7e66c73b8b6211e"
+    },
+    "sound/skullwiz/idle2.wav": {
+     "bytes": 88240,
+     "sha256": "57c49c7fd4f52b870a658e2e854e16c67389e9d79f9a1db5928f12d74741a1da"
+    },
+    "sound/skullwiz/pain1.wav": {
+     "bytes": 11132,
+     "sha256": "125e06cdfacd6aa78a90034d3f94086736734dd1dd9d170fef3a512b42e34cd0"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 15540,
+     "sha256": "ac5a56dbff28fa4724bd8766d8443090e3026007f6f4051cfecd2869b3f5ecb9"
+    },
+    "sound/skullwiz/poison_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/skullwiz/sight.wav": {
+     "bytes": 36484,
+     "sha256": "3051df89bfdce6b80c49c3513cfcbd679bf1f71c5562430d7738737e44f04f26"
+    },
+    "sound/skullwiz/skull1.wav": {
+     "bytes": 22144,
+     "sha256": "3a43bc5e1079740b61199ff21518f75cc1e4db7cdc9e25b57631b38b04d651a2"
+    },
+    "sound/skullwiz/skull2.wav": {
+     "bytes": 22158,
+     "sha256": "fed613207dc7691118ea5b62626df8773bda59816b008bfd2aeaa4d2f26a4b7b"
+    },
+    "sound/skullwiz/summon.wav": {
+     "bytes": 97022,
+     "sha256": "bf74e3dfbb330f481790f7bbc2b88e74b1654f7d5b327235c3d00bee3f62a06a"
+    },
+    "sound/soldier/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/soldier/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/soldier/rocket_load.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/spider/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/spider/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/spider/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/hiss1.wav": {
+     "bytes": 17802,
+     "sha256": "c56fcae8a01af94c07807730857b4b367f2c70c35869505528504faa29a17ade"
+    },
+    "sound/spider/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/spider/hiss3.wav": {
+     "bytes": 22582,
+     "sha256": "1a3c71b1e4ac2389c98c4af9db88e81b51a602c681bd00a1812995654863e2d4"
+    },
+    "sound/spider/idle1.wav": {
+     "bytes": 20922,
+     "sha256": "8a6d25359bbbc1f5e4f6962f4ce1742160537c6bb8bf8b806a0df96adfae819d"
+    },
+    "sound/spider/jumpland.wav": {
+     "bytes": 6038,
+     "sha256": "3c46bc58c52a61480c1a8dc2034aa240545521baf5e0027372992a9458796919"
+    },
+    "sound/spider/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/spider/pain1.wav": {
+     "bytes": 6108,
+     "sha256": "728cd94a64b27dea4d845a9e27e1ba09cfb286bff80128a67d1da0431b6b0c20"
+    },
+    "sound/spider/pain2.wav": {
+     "bytes": 10460,
+     "sha256": "736f0a768c0f52b22a301fc6a15f18f2f60e5579d3b27c2b78bcb7bed8e0c577"
+    },
+    "sound/statue/comidle.wav": {
+     "bytes": 17722,
+     "sha256": "3567914304c8fcf224e31bc302039432cd17833daabc2ed9f83053b01fef4f7c"
+    },
+    "sound/statue/death.wav": {
+     "bytes": 13472,
+     "sha256": "b030aeac3d806bc77fddaed4bb32684cfd2bbd707fe85e2500a3346c5931ec68"
+    },
+    "sound/statue/hurt.wav": {
+     "bytes": 8012,
+     "sha256": "9193f4e976675042409db103f7e3b26f667a56e913e96a37f223f1c606323246"
+    },
+    "sound/statue/idle1.wav": {
+     "bytes": 13304,
+     "sha256": "0b5d3bcbd00e846d38986f8919ff4fa7bcce92e45e5ba5949edd0e81b741b69c"
+    },
+    "sound/statue/idle2.wav": {
+     "bytes": 13316,
+     "sha256": "45469f14a25fd434ba1ed987fd20835ac058496d41df5a6aa543dec454670f36"
+    },
+    "sound/statue/sight.wav": {
+     "bytes": 9584,
+     "sha256": "84ab06d320f9953eebda7c4dd25a0e0de3369957de01c64af10a8b3ca886241e"
+    },
+    "sound/steelclaw/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/steelclaw/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/steelclaw/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/steelclaw/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/steelclaw/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/steelclaw/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/steelclaw/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/steelclaw/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/steelclaw/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/steelclaw/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/steelclaw/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/steelclaw/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/steps/drag1.wav": {
+     "bytes": 13586,
+     "sha256": "db069e08b7de4c5074cc4dd56f3b1cd2b6d77fe7869e1e03f5dddddcf9aad530"
+    },
+    "sound/steps/drag2.wav": {
+     "bytes": 13572,
+     "sha256": "b2ac07fe014e7c5afd4a5974c5d290b34a880a52f33668030a97a345d5811db9"
+    },
+    "sound/steps/drag3.wav": {
+     "bytes": 14690,
+     "sha256": "a29ee6f0977b205d146f81ee5be2f9b2f12ca76f177aaab9e35e556c4f555fa9"
+    },
+    "sound/steps/drag4.wav": {
+     "bytes": 13584,
+     "sha256": "1b5628a4272837ccf9c4044371a1d45eef23439b164be445b6f2ca90952e3487"
+    },
+    "sound/steps/drag5.wav": {
+     "bytes": 13584,
+     "sha256": "6dec9033ece2a02ce65c437e1b7e58512fd04d41a327487704de71cdf39b99dd"
+    },
+    "sound/steps/giant1.wav": {
+     "bytes": 33140,
+     "sha256": "d28f78c1514f215c64b6a3de38b5ffb5b891341ed95dc0277b1b3dba498cc64a"
+    },
+    "sound/steps/giant2.wav": {
+     "bytes": 33138,
+     "sha256": "7936f32a0ae371e216a195c3110b24db372a15091ea5c80e78875951f874d3b0"
+    },
+    "sound/steps/giant3.wav": {
+     "bytes": 33126,
+     "sha256": "58f79749cbdaaa608e6aacc368b74e0ac1e2ecf2ef45967c7f1f7b7a3e99c8fd"
+    },
+    "sound/steps/giant4.wav": {
+     "bytes": 33136,
+     "sha256": "4ffa741a70225aa31078f73a5612cf7d5ad9f9007163f0a5aeda749da099f9bd"
+    },
+    "sound/steps/giant5.wav": {
+     "bytes": 33138,
+     "sha256": "a2706d4dd9856cccdc3980156a77702883e36d86df54221b31a781c8e5e767e3"
+    },
+    "sound/steps/heavy1.wav": {
+     "bytes": 13282,
+     "sha256": "603679f83cc5095d2fa81d945285b2980195ba50ee2615fed85487493f0a536d"
+    },
+    "sound/steps/heavy2.wav": {
+     "bytes": 10870,
+     "sha256": "384f160ad4816b6984ef6b3b59c4bc1e8a2a3e05f9aaa80ee8b30ada2645669f"
+    },
+    "sound/steps/heavy3.wav": {
+     "bytes": 12828,
+     "sha256": "936417bc5ec9d30db8a74a9798328436259ffd704b11e1155d3fa79dc829e462"
+    },
+    "sound/steps/heavy4.wav": {
+     "bytes": 11050,
+     "sha256": "8d4879d40eda9182ff45fb18130c7979997d326581c14edeedc9cab440531e00"
+    },
+    "sound/steps/heavy5.wav": {
+     "bytes": 10198,
+     "sha256": "4e2e9892dee74d3472a45ecda889ae8d2f836786b44a55e5d1436690c7dadd5e"
+    },
+    "sound/steps/large1.wav": {
+     "bytes": 33118,
+     "sha256": "c387d084a10b28329610d8e3ad3e377f43087013e802be42af79f254276d00dd"
+    },
+    "sound/steps/large2.wav": {
+     "bytes": 24960,
+     "sha256": "ab91b4605671dd16da59963959cda3368a065612d8ed1776847da310b1e7b5fd"
+    },
+    "sound/steps/large3.wav": {
+     "bytes": 24280,
+     "sha256": "3e6a5ef0d8cbaba2e976f199d8d1ffa073fe8e83dacee709137335d42ddd7558"
+    },
+    "sound/steps/large4.wav": {
+     "bytes": 22092,
+     "sha256": "f2bde1b715f679cf814c2cd1375442170cf9f6e56d8ea1756900f81f1d1df453"
+    },
+    "sound/steps/large5.wav": {
+     "bytes": 24320,
+     "sha256": "c15b388bbed461461bac2c22b3a88ff272c04ad070e4791b7ce35c1559d16f77"
+    },
+    "sound/steps/light1.wav": {
+     "bytes": 8872,
+     "sha256": "f034fe2692c0fceb6de1c00e15facbcbd31ccd1fcf72510fd1e3cb6bdcc28795"
+    },
+    "sound/steps/light2.wav": {
+     "bytes": 6654,
+     "sha256": "998f665b4a7ccbc995096697606a91d208db024b0882df75ebaaac015f0d4ef6"
+    },
+    "sound/steps/light3.wav": {
+     "bytes": 6670,
+     "sha256": "b25e020a10ac6a7883fd584cff4895d6d785f8577daea15a30d2b745e146c1c6"
+    },
+    "sound/steps/light4.wav": {
+     "bytes": 4472,
+     "sha256": "a111052881024eef6e97393c1388e8ae538227b85c9b8cf0a73704abb2a504b1"
+    },
+    "sound/steps/light5.wav": {
+     "bytes": 3588,
+     "sha256": "55fb54e5ba2f8ec6249761ae6f07c12de6133457b51c584759e8841fb14cb46f"
+    },
+    "sound/steps/medium1.wav": {
+     "bytes": 8872,
+     "sha256": "38e731803a49be7d8018dd7b44060b578b5418f2f7aefb04d1c74c968ced187a"
+    },
+    "sound/steps/medium2.wav": {
+     "bytes": 8852,
+     "sha256": "e8701598e07f43a20aebebd1d1a5043213018199d50472dea37672e6dce4a2b3"
+    },
+    "sound/steps/medium3.wav": {
+     "bytes": 11068,
+     "sha256": "3ed07795c2363552554e6da1da5749be08e460fc6cd4c7266b9fa514732abb2f"
+    },
+    "sound/steps/medium4.wav": {
+     "bytes": 8872,
+     "sha256": "008992cd7972e7e1e6f0b785b40e398a8efe744a3f3f57e47370936796c3d6b5"
+    },
+    "sound/steps/medium5.wav": {
+     "bytes": 8864,
+     "sha256": "ccd26430fd354c0e87750e02d92c40071ef9dccadae5bdeebc7e0d2a2ec4eba7"
+    },
+    "sound/steps/slow1.wav": {
+     "bytes": 8878,
+     "sha256": "15614044d9d277fa3359edb07e7af74b9d7875150fddde5ab1fdceb0143337bb"
+    },
+    "sound/steps/slow2.wav": {
+     "bytes": 8856,
+     "sha256": "a8b16b688d12812a61127a885bf43c360adc2b84ae7806cc107b433c6f4635ee"
+    },
+    "sound/steps/slow3.wav": {
+     "bytes": 8852,
+     "sha256": "3a2a57e1a37d378c1ee73d5732840f6d20e588d794216c33896bf25879807600"
+    },
+    "sound/steps/slow4.wav": {
+     "bytes": 8868,
+     "sha256": "78bdea66991184043001262cc6ef5f1148cf0eb11b5f88fc51ff948311156e5f"
+    },
+    "sound/steps/slow5.wav": {
+     "bytes": 11076,
+     "sha256": "f63c868bd87926f017bec092749bd61c763b0b18635456ed56b660e53bf581af"
+    },
+    "sound/steps/water1.wav": {
+     "bytes": 63814,
+     "sha256": "01ed631b0d92dab11086b1106acc278ffd92522e2e46d21a0650fd29a79780f2"
+    },
+    "sound/steps/water2.wav": {
+     "bytes": 71994,
+     "sha256": "1b53561f02f60da1e1b6c8b72f722ba12e549c318725b974745b38666efa8e56"
+    },
+    "sound/steps/water3.wav": {
+     "bytes": 71802,
+     "sha256": "bbc0778017ccb579a9d531316b8af46585e91a100a251707ac34f4dbddf6922d"
+    },
+    "sound/steps/water4.wav": {
+     "bytes": 61448,
+     "sha256": "d3604afcb7751d987a78a0ee8ee4ca3593315cc6cf2f1909a9f7748535ccea50"
+    },
+    "sound/swampling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/swampling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/swampling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/swampling/idle1.wav": {
+     "bytes": 132044,
+     "sha256": "418eae21e001c1ae065df9357ebf2ad331f761062d75f345f12e99d9aec8cfb5"
+    },
+    "sound/swampling/idle2.wav": {
+     "bytes": 70444,
+     "sha256": "4026b4b56ffa9a207e1457e03ec94a8eb9042cfebf1c042fa291ba2bbbf1c4b5"
+    },
+    "sound/swampling/idle3.wav": {
+     "bytes": 171644,
+     "sha256": "fa54eaf040baf965f994b328bfb1a55cd90d1741d57ed580c1d44c51e9c125f8"
+    },
+    "sound/swampling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/swampling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/swampling/pain3.wav": {
+     "bytes": 67244,
+     "sha256": "4b186834bbec7d2ef9873f55d5df980da3b3fd2f19f76e54fd835d1aaf40fedd"
+    },
+    "sound/swampling/sight2.wav": {
+     "bytes": 88044,
+     "sha256": "6989ba3aca0c5f5e12d30d9958c6ab169f5c6c96f36f4843a9a19bab0e5d0c4c"
+    },
+    "sound/swampling/spit4.wav": {
+     "bytes": 76848,
+     "sha256": "6855555e2a188ed9ae0a1cd307c7715e54c6f3c10ac0fee9edbba2edf1a48d16"
+    },
+    "sound/traps/flame_loop.wav": {
+     "bytes": 28560,
+     "sha256": "661d8325af92fb37235952e2668578dbf57d844b7359627b4a2c25d15127bff7"
+    },
+    "sound/traps/flame_off.wav": {
+     "bytes": 28496,
+     "sha256": "ebc40d62265aad20813acd189511be0bac063ecc00d7ae712863de3dbdb84c94"
+    },
+    "sound/traps/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/traps/laser_hit.wav": {
+     "bytes": 4358,
+     "sha256": "0840d9fa27bfd2bcb86c2f0174810ae3eb9baa6a43867d27de1e074f7cd75e2c"
+    },
+    "sound/traps/pend_hit.wav": {
+     "bytes": 11908,
+     "sha256": "6fec8fd4edb67e8905d9ad0d7dce5ee5a9b4f43b724b75cb449e88b508384e11"
+    },
+    "sound/traps/pend_swing.wav": {
+     "bytes": 22142,
+     "sha256": "d20bbaf323c5aa0ee2aa21222f2a9f5fc956c0317e65c05e9d003bb08d80a9ae"
+    },
+    "sound/traps/saw_end2.wav": {
+     "bytes": 99808,
+     "sha256": "2a129f2d5fe3c9fd60873c336e2eed799b3d2ebc91bc8bf5a0860b45a6b83ceb"
+    },
+    "sound/traps/saw_loop2.wav": {
+     "bytes": 173082,
+     "sha256": "b4ca1bfeaab62c73bfc10f7daa2750738874d721af9e637479e8242f5220294c"
+    },
+    "sound/traps/saw_loop2f.wav": {
+     "bytes": 132748,
+     "sha256": "03a3e77feb8775a7b486363ed1d46d04fb9294f5507040e458ed8a05c37f0de8"
+    },
+    "sound/traps/saw_start2.wav": {
+     "bytes": 217184,
+     "sha256": "49f1dd84a7be0c4d0b1293aa587ab786d69f4cb463ce5a03f09da816eb22d384"
+    },
+    "sound/traps/sawblade_off.wav": {
+     "bytes": 15276,
+     "sha256": "44924313561cf32ea95c50ef80366ba79a2c86ff2f218fc89404c82617ce2c84"
+    },
+    "sound/traps/sawblade_on.wav": {
+     "bytes": 37582,
+     "sha256": "097635d29859ce28ea37da2d51ec346b8d5239435bb6be0bf5f094a555c110e8"
+    },
+    "sound/traps/sawstrike1.wav": {
+     "bytes": 30836,
+     "sha256": "489d8cdea78b2c333771b316741d7960d5c0da6845ea15b94991ece94837367a"
+    },
+    "sound/traps/steam_loop.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/traps/steam_off.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/voreling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/voreling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/voreling/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28354,
+     "sha256": "8c9ef55e309a43b1df1f08b66192b4ab262ba07e9315d3a70f4a9cf9dee9d51a"
+    },
+    "sound/voreling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/voreling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "5035bd555e9a6439c87e6b661a2da86633f7234503d52551e68f61e9504af86d"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 44162,
+     "sha256": "ccca790ed18e3705c083259f48db7d46d26310cf80c16cd2bad191d333fec5ba"
+    },
+    "sound/weapons/axe_ceramic.wav": {
+     "bytes": 24620,
+     "sha256": "53b6e873318f84424129f1486f0a715c9b1f46e9521c97858d3ddbd94ef4dc10"
+    },
+    "sound/weapons/axe_flesh.wav": {
+     "bytes": 7754,
+     "sha256": "8d0046355ea843f56d5260f581c89d2f885b553c97cfc7e01a93f6da487e03de"
+    },
+    "sound/weapons/axe_glass.wav": {
+     "bytes": 13306,
+     "sha256": "7fd4f7f02edf972c17cf64fea9ecfecca2e0a2d69da9828c1a1e2ce726dd9a79"
+    },
+    "sound/weapons/axe_metal.wav": {
+     "bytes": 28844,
+     "sha256": "d77bc0204c9f406f50ddf01241ff3a3cb34bd571f8a038a483fe49fba81fb160"
+    },
+    "sound/weapons/axe_swoosh1.wav": {
+     "bytes": 26524,
+     "sha256": "1ee4079e691b1e3e8eca8e6fe3098ee053f99b2a0028e725442771c84dc07e49"
+    },
+    "sound/weapons/axe_swoosh2.wav": {
+     "bytes": 13284,
+     "sha256": "a28435309759dd35576099d23a36dc378d9703db9f0778fba63efa3558cfc19d"
+    },
+    "sound/weapons/axe_wood.wav": {
+     "bytes": 7776,
+     "sha256": "ce5bd1465d66aa4aad5249c387f7f537b45b4f8a0e4bf76f37f8efc2a22bd9d9"
+    },
+    "sound/weapons/bolt_hit1.wav": {
+     "bytes": 12698,
+     "sha256": "07d2b6078f7936781a641f88e6ed02ab84f248da8f19e73713c1a71ac56cf42c"
+    },
+    "sound/weapons/bolt_hit2.wav": {
+     "bytes": 10658,
+     "sha256": "27ef878b7dfc0878140a19e3a0227ba389e5d0dc2b86df386852e2da2ebc5c93"
+    },
+    "sound/weapons/bolt_hit3.wav": {
+     "bytes": 11600,
+     "sha256": "06298d7bc8d7bce64f9473ae9530e0b42ea3de0ca5895f3476f9b00b5ed566f9"
+    },
+    "sound/weapons/bolt_hit4.wav": {
+     "bytes": 15460,
+     "sha256": "814b1a71efc9b58c90ad7f116c47e6f3dceeb8eae6d0ecbca5f1cd02dd247cb6"
+    },
+    "sound/weapons/crossbow_fire.wav": {
+     "bytes": 26536,
+     "sha256": "2a6ba54090412a53471c59b3edf6e8559d424dab25729e67a78f9ada5e13e8ac"
+    },
+    "sound/weapons/crossbow_hit1.wav": {
+     "bytes": 60782,
+     "sha256": "be1e78c92c13749e988d26912fba6c23f3700df0d7cc48d724f0da1f2608d006"
+    },
+    "sound/weapons/crossbow_hit2.wav": {
+     "bytes": 32472,
+     "sha256": "30a4ef9f23b2239371d32385e55487b279ca4f8f91366d4251cf4d9abdce200a"
+    },
+    "sound/weapons/crossbow_rdy.wav": {
+     "bytes": 37532,
+     "sha256": "321eac310a291cd9cdcbd2dcafb27687a12057e778e12704d8b4388d4eb6e4df"
+    },
+    "sound/weapons/crossbow_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/weapons/ghook_fire.wav": {
+     "bytes": 11526,
+     "sha256": "6e29f4524c0be70d8bf3b1201e737712b271c9bc963ad46c1815972b6addc22e"
+    },
+    "sound/weapons/gl_loadlong.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/weapons/gl_loadshort.wav": {
+     "bytes": 7758,
+     "sha256": "c97236bbfd211dfcad8130974413a8666cdbcf646d364abd8801b3d6ba5bf9c4"
+    },
+    "sound/weapons/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/weapons/laser_hit.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/weapons/laser_richotet.wav": {
+     "bytes": 12888,
+     "sha256": "bcc0498060e71b059d1d6ec45628048b0f29a7a0509b736a519196338b5df20d"
+    },
+    "sound/weapons/nofire.wav": {
+     "bytes": 1400,
+     "sha256": "217c42718548de32b5df972d117ffc1a0e1dde5f03a7a173bd91d0b4551248c9"
+    },
+    "sound/weapons/plasma_expl.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/plasma_fire.wav": {
+     "bytes": 88288,
+     "sha256": "6a0ad4930da39ff590c79f9d26b434bb1001536d33d880735df76e9354f90e94"
+    },
+    "sound/weapons/plasma_hit.wav": {
+     "bytes": 54406,
+     "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b"
+    },
+    "sound/weapons/plasma_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/weapons/r_exp3b.wav": {
+     "bytes": 34830,
+     "sha256": "a1abb7cedfa6576205f043c2e5f562606b039f65f6f996f5ffbb758d7855f2a2"
+    },
+    "sound/weapons/resist_rocket.wav": {
+     "bytes": 19938,
+     "sha256": "1e5170aaf1d6f144e7ea77c251d15ee85c9a70eb1f50b12e4ba5a93971ad1955"
+    },
+    "sound/weapons/ric1.wav": {
+     "bytes": 5650,
+     "sha256": "49223498fbf29b97f712537e6417917befc4e4f5c725bbf2e3d463580c15454d"
+    },
+    "sound/weapons/ric2.wav": {
+     "bytes": 11146,
+     "sha256": "5fa462f4ab3184cf70bf33f923a2b7e4392db517d34f8531a381864d78c352a6"
+    },
+    "sound/weapons/ric3.wav": {
+     "bytes": 11138,
+     "sha256": "1761926b96108fd0b0ee55270ee711fbd2f394f1b5e93da4af96e42c69fa3946"
+    },
+    "sound/weapons/riotgun.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "sound/weapons/sg1.wav": {
+     "bytes": 28718,
+     "sha256": "49074c95da2a619d82dee9d45e28dc910f9a8e16141270a76c81b396a41a6a3e"
+    },
+    "sound/weapons/sg2.wav": {
+     "bytes": 28718,
+     "sha256": "279b1bb969837073c46c176fe62782e60658a6614a8e094b9722cbabdca81fe6"
+    },
+    "sound/weapons/sgun1.wav": {
+     "bytes": 45840,
+     "sha256": "3ac6c4b3ded00fa48810f09afc95b4a8375dc3e8d52e04cd9cba18dfeee20087"
+    },
+    "sound/weapons/shellc.wav": {
+     "bytes": 21006,
+     "sha256": "45a2f8bd652307b9ebd37115c27166d03a4d7055f3054a215036fbc342e22f6d"
+    },
+    "sound/weapons/ssg1.wav": {
+     "bytes": 17244,
+     "sha256": "3e5b9cc1cd0cb86602391e4ddedbc98bb020e44b937eec4d3c5b053ff98c98f2"
+    },
+    "sound/weapons/ssg2.wav": {
+     "bytes": 75024,
+     "sha256": "248a021818f578ec3d96b9fe59d8f839242f4d5f8140a66a500b523b137d1977"
+    },
+    "sound/weapons/sword1a.wav": {
+     "bytes": 11184,
+     "sha256": "22bc8b25a67f1ab0752f9fbc68c2eb0958d2807c9e95bc8ee35d1d1bc9c6552d"
+    },
+    "sound/weapons/sword1b.wav": {
+     "bytes": 13272,
+     "sha256": "dca39f0c4776994c1bbe5255893d50dd86a634a370ea6046fd4e851117dec726"
+    },
+    "sound/weapons/sword2a.wav": {
+     "bytes": 11150,
+     "sha256": "aa381f8c68f5753cecbd889bc184a784c934c78c8fefe3b1ba4026a99112da51"
+    },
+    "sound/weapons/sword2b.wav": {
+     "bytes": 13232,
+     "sha256": "9460973ef948f8712be967d412774d32aeefb8e68b11959c28909eb16d9e8afc"
+    },
+    "sound/weapons/widow1a.wav": {
+     "bytes": 64644,
+     "sha256": "b4ccd6b235784f7ff53ccf0d726ecbbc789d2ddcca057b40df769b7925e3b32d"
+    },
+    "sound/weapons/widow1b.wav": {
+     "bytes": 66186,
+     "sha256": "0da0346e80cdcb405ffb8f9dbe048197cd9d303130f35b2546b4f7652bd06ca6"
+    },
+    "sound/weapons/widow1c.wav": {
+     "bytes": 66186,
+     "sha256": "eb054b4b1b2784bb098e24574ced6b8c2114e3344fc73e9beb23285adfa086a8"
+    },
+    "sound/wraith/attack1.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/wraith/attack1_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/wraith/attack2.wav": {
+     "bytes": 88200,
+     "sha256": "bdf849b4e138fa587df136a327c71ceed1176cbbb4ecb873434766d53da35a3b"
+    },
+    "sound/wraith/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/wraith/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/wraith/death1.wav": {
+     "bytes": 19960,
+     "sha256": "c0e5e05b46e4cf4afebfe5d0ef1801fc16fe8308a7f859ff347a77871b0a9339"
+    },
+    "sound/wraith/idle1.wav": {
+     "bytes": 51556,
+     "sha256": "e91f12463417df25badbbdfe817560362370d9e1e31712766bccb086e06d966f"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 82792,
+     "sha256": "b843d1124acc61be2aae27a7c8a9aca8f6bd471689703b41d59f1450e70e360c"
+    },
+    "sound/wraith/idle3.wav": {
+     "bytes": 55228,
+     "sha256": "3393943b38a0760c2b048c87c6b11ef743b0c968397ae7e434434b8b21fe12f9"
+    },
+    "sound/wraith/pain1.wav": {
+     "bytes": 18184,
+     "sha256": "a448cf5aed2909700e4da1f3ea3158b55e288198eee771eddacf211f4b274dbe"
+    },
+    "sound/wraith/sight1.wav": {
+     "bytes": 34390,
+     "sha256": "91494295e94c54c8da0307df8a51ea10d166fb18a78ede909a710f72ffe81c4f"
+    },
+    "sound/xmas/elf/attack1.wav": {
+     "bytes": 176492,
+     "sha256": "80e3faa699aec6d20015c1070087964de5ba39f83a978388b9fadc184f9fb6c2"
+    },
+    "sound/xmas/elf/attack2.wav": {
+     "bytes": 88292,
+     "sha256": "a364c82cb932bddb438c957e88a7ea67142777dfffd0f553d00e2b04b3af0f9f"
+    },
+    "sound/xmas/elf/cane_hit1.wav": {
+     "bytes": 4536,
+     "sha256": "2686bea9533633cb6c1a5e3e5bcf0016e3fe228cd278b7b1d11a02868cdd5095"
+    },
+    "sound/xmas/elf/cane_hit2.wav": {
+     "bytes": 5638,
+     "sha256": "6e470e241f37fb38ea55adf4bd0d6f1f5a2d5adfee5d5ddac8cb9adc824cb954"
+    },
+    "sound/xmas/elf/cane_swipe1.wav": {
+     "bytes": 1670,
+     "sha256": "2dbf81b3813376cb8bea2fa916dc0d03f1fbaaa499d4fcdf845de8929f82dc47"
+    },
+    "sound/xmas/elf/cane_swipe2.wav": {
+     "bytes": 1890,
+     "sha256": "404864c7d5008b79daed226566a2e4e78f2de92de06c64da67b8bf6224ae3e88"
+    },
+    "sound/xmas/elf/death1.wav": {
+     "bytes": 14284,
+     "sha256": "d1a7063d4ed39cdb59864a2a6fe6109f844caa9ada54ed4456de0bcd056f0034"
+    },
+    "sound/xmas/elf/death2.wav": {
+     "bytes": 10888,
+     "sha256": "4e0344a1bd3fa3d3c4d9e9647203cac0c449d5a5d8e7b1c8319f8402a4b7571c"
+    },
+    "sound/xmas/elf/idle.wav": {
+     "bytes": 57016,
+     "sha256": "a824467247797aa1ecc58f1716b18d390629804eebc413f01067646c64cde87e"
+    },
+    "sound/xmas/elf/jump1.wav": {
+     "bytes": 17766,
+     "sha256": "8023110b27a70758166f710e52188b8d03b8bfd81d9c985eb7f7d326acdb05a2"
+    },
+    "sound/xmas/elf/jump2.wav": {
+     "bytes": 8946,
+     "sha256": "a60763886b743d06ffd0c90e70de304ec8002a500947a684646c227d0bbb3c4d"
+    },
+    "sound/xmas/elf/magic.wav": {
+     "bytes": 15560,
+     "sha256": "6a270540819dddf140b0387d92c914b4f4b1c88c5f37a05c8fa0efd95901f2ab"
+    },
+    "sound/xmas/elf/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/xmas/elf/pain.wav": {
+     "bytes": 11126,
+     "sha256": "4e27a8f38e07e9b69db186d5c609740814ab86c5fda57058b1e05c56b85c6fd4"
+    },
+    "sound/xmas/elf/sight1.wav": {
+     "bytes": 21048,
+     "sha256": "c57eb4fec86922cb8a0499d7dae72eba66b067b89f14ff079ce0caf3dc23a23b"
+    },
+    "sound/xmas/elf/sight2.wav": {
+     "bytes": 30996,
+     "sha256": "8cd5eed3b8e098dfd70cbf90081b38e198bf64d8edf1b76bcc98c42e177635f8"
+    },
+    "sound/xmas/elf/sight3.wav": {
+     "bytes": 10050,
+     "sha256": "e88ae556a28352c319bf5500b29008384a5c53c47480defa81795d8891f14ff8"
+    },
+    "sound/xmas/elf/sight4.wav": {
+     "bytes": 6742,
+     "sha256": "7c6120d242cbbbfd2e0cc77b1428e206accd1ab8073885d52177b0fd4c75c7ed"
+    },
+    "sound/xmas/raindeer/attack1.wav": {
+     "bytes": 5582,
+     "sha256": "bcf78087eab53e8ed0bdde2f29088a89b321a79c3b104da380dd85bd5bdb6ec1"
+    },
+    "sound/xmas/raindeer/attack2.wav": {
+     "bytes": 6274,
+     "sha256": "2ba043cce4a2f22e7743812c0fa40e9f0888d5089362264c768352c347af5089"
+    },
+    "sound/xmas/raindeer/death.wav": {
+     "bytes": 9672,
+     "sha256": "68266e96ec1be80a55f48b76c2bedd6503273245153d96269947c7fc12ae96b3"
+    },
+    "sound/xmas/raindeer/hit.wav": {
+     "bytes": 5218,
+     "sha256": "72127151c2b05cc22a812fe9e38909c8bdcaae6a369e8756d2be67d392b91223"
+    },
+    "sound/xmas/raindeer/idle.wav": {
+     "bytes": 7890,
+     "sha256": "d3ef885d0b6163a3046dc9d514b07886c33809fbb6332e7db0514c648787a9bb"
+    },
+    "sound/xmas/raindeer/sight.wav": {
+     "bytes": 23796,
+     "sha256": "aafabb6fc46c1c72c34af1baea1c59a8ec04803c26faa4310072096481f31a4f"
+    },
+    "sound/xmas/santa/death.wav": {
+     "bytes": 99352,
+     "sha256": "b63273a2574f7def133aa438926a6def025aa64d8c3c636fc6a5594268e391d7"
+    },
+    "sound/xmas/santa/death2.wav": {
+     "bytes": 99352,
+     "sha256": "24fcf23117ec31347f640aa27e6feb4a46a634aa5e1eb48344b1feb7c377f6f1"
+    },
+    "sound/xmas/santa/fire.wav": {
+     "bytes": 22176,
+     "sha256": "3a9bb42661b75287a698b6e16033158f20c59c481d37c0f176dc213205d22dcd"
+    },
+    "sound/xmas/santa/good_hohoho.wav": {
+     "bytes": 55250,
+     "sha256": "51f4d5d656032de08b95689fa55a2e7aa26ec99cf4312b0f6153d0fd57fc1fa3"
+    },
+    "sound/xmas/santa/good_saved.wav": {
+     "bytes": 77302,
+     "sha256": "51e62df5942e2a72fd48311c61ee73b6f51dc4aa3c0cc85af000cdc8d7627d21"
+    },
+    "sound/xmas/santa/hohoho.wav": {
+     "bytes": 50840,
+     "sha256": "091a28236362cab1ce3b7bd55de25010d105db3bf644825c47b91725d8a613a0"
+    },
+    "sound/xmas/santa/laugh1.wav": {
+     "bytes": 57374,
+     "sha256": "ac069694d6c41e5e0afab50d9928b8768a19fb647bb249201648874d4150c976"
+    },
+    "sound/xmas/santa/laugh2.wav": {
+     "bytes": 117440,
+     "sha256": "c726d7d86d2d7cad0a75a2d0b387f4f96218ef232b6c78437e1c83bb96286441"
+    },
+    "sound/xmas/santa/laugh3.wav": {
+     "bytes": 40256,
+     "sha256": "4dd710eee601ab81c4beb5413d95244dee58b886b8265ab9cec35df06b560591"
+    },
+    "sound/xmas/santa/laugh3_com.wav": {
+     "bytes": 44226,
+     "sha256": "4099895e037cfecb4dc3595b3b18db62ed2f3cf096384f3aa1fe1d96a7b43da2"
+    },
+    "sound/xmas/santa/pain1.wav": {
+     "bytes": 6825,
+     "sha256": "79eed9346e0954fd53a6fdb9aa9708b8c29e8c5c256e9fd7c06f449e9cb6c00d"
+    },
+    "sound/xmas/santa/pain2.wav": {
+     "bytes": 9259,
+     "sha256": "f750328d74f545a658b0b190399595687c3d9b8766b2652ad6c2a34add3cc420"
+    },
+    "sound/xmas/santa/sack_hit.wav": {
+     "bytes": 13356,
+     "sha256": "c23a04ed5134f76d1f44d2e61eeb446a569c2bcbccf79f16f472807aae3df53a"
+    },
+    "sound/xmas/santa/sack_swing.wav": {
+     "bytes": 8940,
+     "sha256": "96972ba473b6a7d28645cdc621eb3011729a53eb4acb40d1f097768291a70850"
+    },
+    "sound/xmas/santa/sight.wav": {
+     "bytes": 100144,
+     "sha256": "e29696370a0d40546a49ef0f39b1e0038d8e067ef2da1dcc5084d7683a25d5d7"
+    },
+    "sound/xmas/santa/smack.wav": {
+     "bytes": 22176,
+     "sha256": "606c0a4b634d82a1d9846f654db8a52e7f2438ba28a235f782a23ff2720c767c"
+    },
+    "sound/xmas/snowman/claw.wav": {
+     "bytes": 8292,
+     "sha256": "7857f3526fb39e722a09ebe569f2b76facab765d82f97c0caa7da2ff9b750e9e"
+    },
+    "sound/xmas/snowman/death1.wav": {
+     "bytes": 11267,
+     "sha256": "0a09776ed8e45bbfe403f1cdb50302361f5596d9027c476409d6acf5402e763e"
+    },
+    "sound/xmas/snowman/death2.wav": {
+     "bytes": 13613,
+     "sha256": "e5e3a9619a153f0c6259abdb0d45f4eb4a547f736e37951556d29c6b715ec8f6"
+    },
+    "sound/xmas/snowman/icehit.wav": {
+     "bytes": 3090,
+     "sha256": "e03f61550bafc53ab47acdc23bcd481c35e75e6eccdad5e61e6dd7b372ba07c0"
+    },
+    "sound/xmas/snowman/icemiss.wav": {
+     "bytes": 3074,
+     "sha256": "f8b86f83d9adaaee1c84e1ac2acbcf652204842f2bf6f351ec1443a998574058"
+    },
+    "sound/xmas/snowman/idle.wav": {
+     "bytes": 58582,
+     "sha256": "a0d7af1cd6246f08176f24c5591cfb6ec89cff55dc5c18766ef1b16c64429541"
+    },
+    "sound/xmas/snowman/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/xmas/snowman/pain1.wav": {
+     "bytes": 7685,
+     "sha256": "7f829300a30cb6cb4d17f8c8327bd62ae5b5dacc892d28a956d6ecd2acf5f1c2"
+    },
+    "sound/xmas/snowman/pain2.wav": {
+     "bytes": 7661,
+     "sha256": "3747d77583aa4edb3509e89ea651ea41a8e8a92cd96c34d4e00257e7371fb0e6"
+    },
+    "sound/xmas/snowman/shotg_fire.wav": {
+     "bytes": 6572,
+     "sha256": "3d54870c0f643b1e7ee5307641bb3fc4a94efdaffc2e4ecd196556b930167ef2"
+    },
+    "sound/xmas/snowman/sight1.wav": {
+     "bytes": 10042,
+     "sha256": "ce1cddbb6e85fad23231ac1fc4c04c19ec7276acb2aa86e023c117db4b8edd68"
+    },
+    "sound/xmas/snowman/sight2.wav": {
+     "bytes": 15418,
+     "sha256": "5d4e994c30a7c3f2e1f1a5cde9a56115bcb32c350e4a0ad8e339a1a46ed19707"
+    },
+    "sound/zombie/boil_explode.wav": {
+     "bytes": 38012,
+     "sha256": "210dac94ab0e4efb5eb3bdbfa5d7100094b1bfef917a8d5abb2ae186252c0a27"
+    },
+    "sound/zombie/boil_idle1.wav": {
+     "bytes": 33204,
+     "sha256": "e2b717040d436ba2a659ceb1e5b74dfeaad57577297a9827957733e00ce7cb34"
+    },
+    "sound/zombie/boil_idle2.wav": {
+     "bytes": 33206,
+     "sha256": "8bd584597f2c54e6f8ecca5c0a83e44b0b5a09a745026e41cc2cad8ded6f729a"
+    },
+    "sound/zombie/boil_sight.wav": {
+     "bytes": 33192,
+     "sha256": "0e285e98dc66cd49af507dae9ab5281aaec55eaf9d401810a8d230d93539123a"
+    },
+    "sound/zombie/boil_squirt.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/zombie/boil_windup.wav": {
+     "bytes": 22094,
+     "sha256": "3790791943ea03add95bc303df34470c534f9c2c76e4343831609eaee761633d"
+    },
+    "sound/zombie/zk_sight.wav": {
+     "bytes": 26916,
+     "sha256": "8fe4d5fea16bd7c3661a968d26782ea8c4741157e16e22f33317619229b10637"
+    },
+    "textures/#bmk_water01a.tga": {
+     "bytes": 12332,
+     "sha256": "904f50c3a1de65dd5045f128d03ed8cdc86fcbc15cce295d94304b389ca5ed7c"
+    },
+    "textures/#bmk_water01b.tga": {
+     "bytes": 12332,
+     "sha256": "904f50c3a1de65dd5045f128d03ed8cdc86fcbc15cce295d94304b389ca5ed7c"
+    },
+    "textures/#bmk_water02a.tga": {
+     "bytes": 12332,
+     "sha256": "1123b4f4df8d75a1d8fc2a00d4d19fb279035771f7440b1506d0a95648123766"
+    },
+    "textures/+0bmk_fgopen02.tga": {
+     "bytes": 3145772,
+     "sha256": "1c7e70671a9a98473b3fb3926e1672d5a1712a011caba937097d5bc8c96099de"
+    },
+    "textures/+0bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "f2f139ae3d91bf3aa7c89181b87c1c645acb7be673eca5d56d804889e24f1e50"
+    },
+    "textures/+0bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "f2f139ae3d91bf3aa7c89181b87c1c645acb7be673eca5d56d804889e24f1e50"
+    },
+    "textures/+1bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "6941909c4574fb66f59f7a797f3dd0c696651e117c583f102d255e6bef4fe0ef"
+    },
+    "textures/+1bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "6941909c4574fb66f59f7a797f3dd0c696651e117c583f102d255e6bef4fe0ef"
+    },
+    "textures/+2bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "b78fb050de863bd84616c224de600521738a84ce172346bb783ba3a8708449da"
+    },
+    "textures/+2bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "b78fb050de863bd84616c224de600521738a84ce172346bb783ba3a8708449da"
+    },
+    "textures/+3bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "bf6815a6df5fe67c40ec3e46362a04c5ba15dc8a76de975a3d90a0caeec5e88c"
+    },
+    "textures/+3bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "bf6815a6df5fe67c40ec3e46362a04c5ba15dc8a76de975a3d90a0caeec5e88c"
+    },
+    "textures/+4bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "031bd453f18757388aa700fbae39e6c446959b8e38bee9fbbb53d8639f29deea"
+    },
+    "textures/+4bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "031bd453f18757388aa700fbae39e6c446959b8e38bee9fbbb53d8639f29deea"
+    },
+    "textures/+5bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "873c6b31fcaab54e309e663d23748cc5595b80e1432559761fd92a03f0d41d32"
+    },
+    "textures/+5bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "873c6b31fcaab54e309e663d23748cc5595b80e1432559761fd92a03f0d41d32"
+    },
+    "textures/+6bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "33492aebd47cc69737a2cd8460423103a76ff59b1d6bd39b750f19d6c72efc6d"
+    },
+    "textures/+6bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "33492aebd47cc69737a2cd8460423103a76ff59b1d6bd39b750f19d6c72efc6d"
+    },
+    "textures/+7bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "60741f2766db4f0eb6d622b132d2fc60d9e453d9f847661d3eca641fbf2b64f1"
+    },
+    "textures/+7bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "60741f2766db4f0eb6d622b132d2fc60d9e453d9f847661d3eca641fbf2b64f1"
+    },
+    "textures/window_blue1_2.tga": {
+     "bytes": 786476,
+     "sha256": "583f28b004c5de047037798524681ed2e7914bf1f54ac3d774c8da2880c80282"
+    },
+    "textures/{cop1_7.tga": {
+     "bytes": 16402,
+     "sha256": "464c149a2b2c9f624e7b1f8c2388117022425f058a946f0232c51def845b8bb5"
+    },
+    "textures/{cweb1.tga": {
+     "bytes": 262162,
+     "sha256": "bb0aa80709a1705199ed83bd0cad683a928cb29064eb32263fcb8bdb3999c2f5"
+    },
+    "textures/{cweb2.tga": {
+     "bytes": 262162,
+     "sha256": "64be3598db71729d4a4376c5f4e02bf0e586fc5ceca09196d71befde3265424e"
+    },
+    "textures/{cweb3.tga": {
+     "bytes": 131090,
+     "sha256": "d7b67dfdb1c80946f0de21128ddc3cda61906619ab8ed185611ef2a2a8f936b5"
+    },
+    "textures/{cweb5.tga": {
+     "bytes": 131090,
+     "sha256": "9cf5dd24994b1dc2f8f07ac5f76410fea9bdb7cb925962e1977e6aeb6ce23b02"
+    },
+    "textures/{dutcweb1.tga": {
+     "bytes": 131090,
+     "sha256": "8922bb11d99fc05d2ffeab2c2d99b04dba9d0fc5165fdd9a0ccd921f066f668c"
+    },
+    "textures/{dutcweb2.tga": {
+     "bytes": 131090,
+     "sha256": "a0377ffeac458bf27bbd86d2bc22ff17d973bd0328a4d048fb3136573c12723d"
+    },
+    "textures/{dutcweb3.tga": {
+     "bytes": 131090,
+     "sha256": "61710c94a64a506b75f36578904dbece6f666bc25ad2665333fe00b1c4b04f70"
+    },
+    "textures/{dutcweb5.tga": {
+     "bytes": 131090,
+     "sha256": "a0959d05f9bd1f4aa632b1642885261a2cbbef7d6d6d7ab677bb803ac1a00ef8"
+    },
+    "textures/{dweb1b.tga": {
+     "bytes": 65554,
+     "sha256": "7f2f310b5393519fbfdf70e07cab318504ad88c67dcce1e9988e376d5fc9c94a"
+    },
+    "textures/{dweb2b.tga": {
+     "bytes": 65554,
+     "sha256": "d95f6ebbcc21b2cb7164743b517aa69287101aa2640d5a8b249c409dcdc20333"
+    },
+    "textures/{dweb3b.tga": {
+     "bytes": 65554,
+     "sha256": "24cde40cf3791f0e054ccd2ad81353ec711bd95a7de1af58a1ad561d9d104ef1"
+    },
+    "textures/{dweb5b.tga": {
+     "bytes": 65554,
+     "sha256": "5b1fc4683289a850f5c16afa56660b710212bf18d4c047bf134529dac784d2c9"
+    },
+    "textures/{gen_gr8.tga": {
+     "bytes": 65554,
+     "sha256": "8dacb17cbbb6bb2f4dd95856dd46905a9c335f0a98dc3e8e700fac0a9c529163"
+    },
+    "textures/{kjwintex_ad.tga": {
+     "bytes": 262162,
+     "sha256": "3a2583e19c17e05877e489972b85593d9fca1e57ffd4fa02f1475e6fb3d59c34"
+    },
+    "textures/{ladder5th.tga": {
+     "bytes": 49170,
+     "sha256": "ed742e4b7072c1b11b1b801393bbfc641f96920ecabc5600c213b354313f89f0"
+    },
+    "textures/{lweb1.tga": {
+     "bytes": 262162,
+     "sha256": "e4edd91fdd0031064bd6157574ae5f81b44611424f7357daf8fd4e426c960399"
+    },
+    "textures/{lweb2.tga": {
+     "bytes": 262162,
+     "sha256": "4d2f26192388bf65091b0d5afb934bede4f07e89d002bbdbaeeba29d459fd5d7"
+    },
+    "textures/{rtex158_.tga": {
+     "bytes": 21522,
+     "sha256": "cd10217f3e5cd47b32bde516d4b36cf7995913e306f7415d25dcd7da6ccb4673"
+    },
+    "textures/{speedbz_grid1.tga": {
+     "bytes": 16402,
+     "sha256": "109e52491dda6d4968c99004296ccd503db6d6af9aad9aa6f21cca02fd2b299f"
+    },
+    "textures/{swvine.tga": {
+     "bytes": 65554,
+     "sha256": "c23639e3bd8aacd226695c913384e9c67d509b28fb9597d56f120cfea56a4006"
+    },
+    "textures/{utcweb1.tga": {
+     "bytes": 131090,
+     "sha256": "edae90ba1151fb6adc65def85d4dd7be01c3d2a18bd93ef0f26ff44d07f6c4b0"
+    },
+    "textures/{utcweb2.tga": {
+     "bytes": 131090,
+     "sha256": "829cfe898d9aa4c3ddd12a51f9ccc16a66b2ca5671d9bfd2339f402d49db3267"
+    },
+    "textures/{utcweb3.tga": {
+     "bytes": 262162,
+     "sha256": "026680576034c959e840aa4b39917497c38df12c1331a0c7a1486912e26a91f7"
+    },
+    "textures/{vinehang1.tga": {
+     "bytes": 65554,
+     "sha256": "c23639e3bd8aacd226695c913384e9c67d509b28fb9597d56f120cfea56a4006"
+    },
+    "textures/{vinehang2b.tga": {
+     "bytes": 262162,
+     "sha256": "4268dc2a183582d00c363a9fcd1965c026632150383d40b520fbd54f8751eaa7"
+    },
+    "textures/{vines3.tga": {
+     "bytes": 25618,
+     "sha256": "550b6ca0c768db472fbc970836516506034b30f0a5ca4b4b11df34d7dce8dc82"
+    },
+    "textures/{vinogrande2.tga": {
+     "bytes": 262162,
+     "sha256": "7c2d4aad4d34457ab1674bc1eaaa4ea38e4c4af384877af631cde258167fbb72"
+    },
+    "textures/{web1b.tga": {
+     "bytes": 65554,
+     "sha256": "41bb1244128013ff09f1965339ef505a7b0757bea91fcc0f77ed97cd38c8a145"
+    },
+    "textures/{web2b.tga": {
+     "bytes": 65554,
+     "sha256": "e2fbcb154962a9189614aecc7f6833e60d24709583a970d6cca0adf948df2331"
+    },
+    "textures/{web3b.tga": {
+     "bytes": 65554,
+     "sha256": "e4cfcd4c4e94ed647ef9af822d0df5ee573bd20d9f3bcf45ef8701a3102ae3ef"
+    },
+    "textures/{web5b.tga": {
+     "bytes": 65554,
+     "sha256": "dfdad98b5b62765b24abccd2ff77e85ec1c002060d6634d2593ac0fe10a4c718"
+    },
+    "textures/{win01_1brk1.tga": {
+     "bytes": 49170,
+     "sha256": "dae89ad198e0f4b1a63e37d9145084e947f7e88cb1c2e5d9ef32f25f3e0fb484"
+    },
+    "textures/{win01_1brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "88d9f8700eb9d14f9cfa6ac2e3df1bb25eae9a46553b6e46da7b225316862cb9"
+    },
+    "textures/{win01_1brk2.tga": {
+     "bytes": 49170,
+     "sha256": "2416e34e1ebdefa0cd01ea595b68ae86d2a35a4329b8853a489b1058dea44a90"
+    },
+    "textures/{win01_1brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "921ecb3434e9bd56d97ad57d10c67ace5a0f4bce79bf1b4c8c68aad4cf6ed10f"
+    },
+    "textures/{win01_1brk3.tga": {
+     "bytes": 49170,
+     "sha256": "59a6b2dc874758693574f15affea0be9c2e92e32328f81db78e5d72f488be7cb"
+    },
+    "textures/{win01_1brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "a3dcd6d471d8c65781a69c73a9fa449da02bc01a58a0a97c7313d30587611516"
+    },
+    "textures/{win01_2brk1.tga": {
+     "bytes": 49170,
+     "sha256": "589cf84c790b3165fa60e4441223da48c3df4275099fcc27bc5a8b9502579c15"
+    },
+    "textures/{win01_2brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "a0a80d249ff32c2e0a480801b721657244380732db3bdd9645dbece347d3190c"
+    },
+    "textures/{win01_2brk2.tga": {
+     "bytes": 49170,
+     "sha256": "0dc35f6a8b8b83596d127791f32f59b4a7445cb2529777555a93b9f329b7b537"
+    },
+    "textures/{win01_2brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "b313a11eb9017f0be604b673c0df88e94f94d552a7a132241f80883e68f4905f"
+    },
+    "textures/{win01_2brk3.tga": {
+     "bytes": 49170,
+     "sha256": "0fd4d13eb067aa17be299b48d500c245554fc3a6c1f5f11e10cbec1195a35273"
+    },
+    "textures/{win01_2brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "7ad6db65f6c0190a9ec569cce3b4780d21a90baf9baa728128f278807f1ba780"
+    },
+    "textures/{win01_3brk1.tga": {
+     "bytes": 49170,
+     "sha256": "ee6084ebe49ce367fd68039d548b1c960e55b136412bb00b8094dc1c545307bf"
+    },
+    "textures/{win01_3brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "afa5f0475b733a0ee1829b76598acd37cb1f28ed7f2faaf128593a13e702f5fa"
+    },
+    "textures/{win01_3brk2.tga": {
+     "bytes": 49170,
+     "sha256": "54c3abca2e42bbc4626823d4ad8081797e295bbdd07942484142d8a1c5395474"
+    },
+    "textures/{win01_3brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "0e0fc8daffc3ec8e07028904e3e55946270b8346f32efa341d64d6d1c0bcfcb5"
+    },
+    "textures/{win01_3brk3.tga": {
+     "bytes": 49170,
+     "sha256": "c1c7752039d97f7b92ec36408ffe456ff96c2a27c725c432e677a4f22e893d46"
+    },
+    "textures/{win01_3brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "0b627faae78e0d01eee393b58f978bf1a46b653001e1d1c56589d822245f86df"
+    },
+    "textures/{win01_4brk1.tga": {
+     "bytes": 49170,
+     "sha256": "af0f20f39e53d82cda8fca18e2918c1a2df2e6cf94e4d636e50c01686b3291b8"
+    },
+    "textures/{win01_4brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "4522e8d89c78119e9ff517ad64571c17c3ca750ac820142a700809620e894942"
+    },
+    "textures/{win01_4brk2.tga": {
+     "bytes": 49170,
+     "sha256": "4696f9c8ca59937230f40a3135b6c02e54b9b912eb62ba1401cbd5cccd1a9ae4"
+    },
+    "textures/{win01_4brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "a7a978f76a01a53dca360914519a8b1a93272aaad8a57c54e32ec74d4d9f1b96"
+    },
+    "textures/{win01_4brk3.tga": {
+     "bytes": 49170,
+     "sha256": "66dfc1bbe57f20c766653ab71cb339b6bff4e10b33cf66f5ed070bc0be75156f"
+    },
+    "textures/{win01_4brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "fb047a212d30b7fd140331df80d03dc718ba4237df73bf3cd74c918cc91daddf"
+    },
+    "textures/{win02_1brk1.tga": {
+     "bytes": 49170,
+     "sha256": "cb2711c7dc2ee9b77aded814296c1b1bb124ff5d2db2e248af7d7d0d882f422d"
+    },
+    "textures/{win02_1brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "9391e42b0fe2e55689e7104984fc1b5fd199cd8821e562fc4538fe2eb73825e9"
+    },
+    "textures/{win02_1brk2.tga": {
+     "bytes": 49170,
+     "sha256": "4fb71ced0a5388e41896b3b71b9c48d157eb72d229db04bbdcca45ce58658adc"
+    },
+    "textures/{win02_1brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "ed18da9a408653915554b0918a0f720cb76257231fc8ff9d465003e98fb371ab"
+    },
+    "textures/{win02_1brk3.tga": {
+     "bytes": 49170,
+     "sha256": "3b1f9bdbd53db1fa6d6920045cf4da45064dac48f7f66870e003860514804e99"
+    },
+    "textures/{win02_1brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "f1e10e37f7f2e71ddd6165607e59d39f95ec59c904017a8fa6b7b33a3adf40c1"
+    }
+   },
    "sha256": "a313e68f29bfd2accac58b5ca9d4a886b0555b42e215a9d49e05117c29e674d6",
    "timestamp": "2022-12-19T15:15:26.000Z"
   },
   "tcj/pak1.pak": {
    "bytes": 5468494,
+   "files": {
+    "maps/ad_brk/all_brick.map": {
+     "bytes": 22738,
+     "sha256": "e0859c71d8a3d5d4b140757e4fcd2ab4e92674bbb71979d6b9d6d2deb5d2390a"
+    },
+    "maps/ad_brk/all_glassa.map": {
+     "bytes": 8834,
+     "sha256": "f4e1c7c1444b3b2d8a3463e8950c0a6a3aed8d39144a6b1fc2a69bdbf376f444"
+    },
+    "maps/ad_brk/all_metal.map": {
+     "bytes": 12297,
+     "sha256": "447c74022bea3ae89d3a4412afcf4bcd384ea725b344b987fb2e7bb37adfabe1"
+    },
+    "maps/ad_brk/all_rocka.map": {
+     "bytes": 10235,
+     "sha256": "52edb0d5b9f79e8b89a58353098316e81be31c3e289d6f96e450ea01c4bbeb62"
+    },
+    "maps/ad_brk/all_wood.map": {
+     "bytes": 8397,
+     "sha256": "93697129156d662c18391564e26c5d5ceec8bac244209496290b8e9a516a5bfb"
+    },
+    "maps/ad_brk/brick01.bsp": {
+     "bytes": 7912,
+     "sha256": "c11880924b195ed38908cbf50f9cd16f071918df0a94a19c7254b93dddb1e62d"
+    },
+    "maps/ad_brk/brick01.map": {
+     "bytes": 717,
+     "sha256": "3f87d06eb46f67efa678ddd5ddf274e9c595c4a5236d8f111d8a0ea999972e09"
+    },
+    "maps/ad_brk/brick02.bsp": {
+     "bytes": 8072,
+     "sha256": "9ec52c7441f570d2a793035ebc2128d7f7f91f71b44b4418fd01e6b3e6d503e2"
+    },
+    "maps/ad_brk/brick02.map": {
+     "bytes": 861,
+     "sha256": "616d1c5b6f3e476453e8b9b57dd59deb285c6c0482680ca5d6da358ee808c619"
+    },
+    "maps/ad_brk/brick03.bsp": {
+     "bytes": 8280,
+     "sha256": "aa55feca84b80282851ca55c71deb3d54f02a6668af820f5ac4f9c1a0514e5e1"
+    },
+    "maps/ad_brk/brick03.map": {
+     "bytes": 935,
+     "sha256": "4359e78daaac0b8d4ff58dc68301bba4cd423e81284bcd360ce1480862c19d91"
+    },
+    "maps/ad_brk/brick04.bsp": {
+     "bytes": 8052,
+     "sha256": "b1fa14c188a8ad31cf58c7ebd495fbe8ed153819015d4e97c82e01ee052081e3"
+    },
+    "maps/ad_brk/brick04.map": {
+     "bytes": 815,
+     "sha256": "2bda60cc50886dc430a053f509f2376dcd9bd4d09666cf7960a96484fa369903"
+    },
+    "maps/ad_brk/brick05.bsp": {
+     "bytes": 7952,
+     "sha256": "e137a3ea0f33a83b8717dcb9d6e2ab79876112121dc21fe2e625d24d5d251384"
+    },
+    "maps/ad_brk/brick05.map": {
+     "bytes": 770,
+     "sha256": "8ebf395096050f65a3a370971d65deb0926af70f6cbd75c6579a53b68f676793"
+    },
+    "maps/ad_brk/brick06.bsp": {
+     "bytes": 9184,
+     "sha256": "32cee0a2c668160e07568ae08b4de5beae87d74e94a347cd431c90005bf49e24"
+    },
+    "maps/ad_brk/brick06.map": {
+     "bytes": 1709,
+     "sha256": "289f58cad70a88e8a8d986644faf539dd38cf52a884aa7f85513db5df0cc438c"
+    },
+    "maps/ad_brk/brick07.bsp": {
+     "bytes": 10377,
+     "sha256": "df07446f9f6a118f11451de5d7817f582c11dcc81ca3f83c8fa72c9d95e8df9c"
+    },
+    "maps/ad_brk/brick07.map": {
+     "bytes": 1942,
+     "sha256": "fe440636e5354fb553708f3b6859023d0a520f315050dc11a564e31a7b72d5e4"
+    },
+    "maps/ad_brk/brick08.bsp": {
+     "bytes": 13964,
+     "sha256": "2abbbc958d752e742df9d1f7152c4cc8c0de6373f20e628a762e2a22f5d6b3f7"
+    },
+    "maps/ad_brk/brick08.map": {
+     "bytes": 3286,
+     "sha256": "72174f573416102bb4e087e2025b3dbdfc669ab7cafc8b354f7b1a4485af1f5b"
+    },
+    "maps/ad_brk/brick09.bsp": {
+     "bytes": 7952,
+     "sha256": "28d7162b4af3f4ce184a31a14e3a9777383f29b63920d9d62ff136ae96e3a2fd"
+    },
+    "maps/ad_brk/brick09.map": {
+     "bytes": 770,
+     "sha256": "62f11ef3e3033dea82eb6062e5b5301474dd014f889a980383891e689be2a352"
+    },
+    "maps/ad_brk/brick10.bsp": {
+     "bytes": 9184,
+     "sha256": "7d6f8e3fd1b65880bb767ab5d488ef11bbb01ec4ce14c7b747ee75b8a8238c4e"
+    },
+    "maps/ad_brk/brick10.map": {
+     "bytes": 1709,
+     "sha256": "276f975d99dfe982bf71104889f65a248d719778db89591e7193ecc46b13d645"
+    },
+    "maps/ad_brk/brick11.bsp": {
+     "bytes": 10377,
+     "sha256": "f65cbdb642220611e89725187f47427031c4b18c21cc04ae3f6cfb4dffd149a2"
+    },
+    "maps/ad_brk/brick11.map": {
+     "bytes": 1942,
+     "sha256": "3b9d73d400e29fba3c82d8b2ccdad26e03b128c7771427497d4740c2d34cd63d"
+    },
+    "maps/ad_brk/brick12.bsp": {
+     "bytes": 13918,
+     "sha256": "1e1e8191c5ebdd1f0fed27edaa04a82a6aabd5c41723cf590781ff00f7300a02"
+    },
+    "maps/ad_brk/brick12.map": {
+     "bytes": 3286,
+     "sha256": "d2b89c83f1ff95d6fe577cf4a166e7bec6e02ab85f48c51316908d7d80068156"
+    },
+    "maps/ad_brk/brick13.bsp": {
+     "bytes": 7912,
+     "sha256": "4b5ac4eb6ea5a9ec049c27082d800cb981902965a4b652f86e1753bfa1eb7c94"
+    },
+    "maps/ad_brk/brick13.map": {
+     "bytes": 690,
+     "sha256": "253425ec201a354cd1b4c93c78d740e2a17c7d946d911efffa63d522e95f9f0b"
+    },
+    "maps/ad_brk/brick14.bsp": {
+     "bytes": 8072,
+     "sha256": "afe8797d2172a5b4b06be3e2a69038346d62938f3d9da6ea224074cee5bb1669"
+    },
+    "maps/ad_brk/brick14.map": {
+     "bytes": 828,
+     "sha256": "a500705a328cafa28159ee107cbe80003848ee241c3544a73dea1432f67b4042"
+    },
+    "maps/ad_brk/brick15.bsp": {
+     "bytes": 8280,
+     "sha256": "58ddb31ce4108a70872444022369154529c532983dbc58698cd88f217f8947a0"
+    },
+    "maps/ad_brk/brick15.map": {
+     "bytes": 899,
+     "sha256": "589f256e02b66051ede4f2fe136e69313a7e01402f1caa43bada4d605a046b8e"
+    },
+    "maps/ad_brk/brick16.bsp": {
+     "bytes": 8052,
+     "sha256": "d5c15593d0d776d5f76919100602d893973cd59b7ca88af55e1ae3cc2fb56967"
+    },
+    "maps/ad_brk/brick16.map": {
+     "bytes": 785,
+     "sha256": "a15682c168f0a7128c83bf7bd38688ae1d2507873687e815c690b08d44f14a37"
+    },
+    "maps/ad_brk/brick17.bsp": {
+     "bytes": 7952,
+     "sha256": "738d902046d73e14b8a552529dd8306864661fd0469efb52b3c81329135e8372"
+    },
+    "maps/ad_brk/brick17.map": {
+     "bytes": 770,
+     "sha256": "699fa7055fa88f309fe4a4a2af24b5d61af91365d81074e44cbdf399d36939c9"
+    },
+    "maps/ad_brk/brick18.bsp": {
+     "bytes": 9184,
+     "sha256": "67ad693c292448f73ea0b3ab6ee22883709c7deb006cecd19c0dda5c9d4fa131"
+    },
+    "maps/ad_brk/brick18.map": {
+     "bytes": 1709,
+     "sha256": "849749000a41ecfc60aa4607c890e140bcd78ef26858512f56494efdc5873bcd"
+    },
+    "maps/ad_brk/brick19.bsp": {
+     "bytes": 10321,
+     "sha256": "721c3237db8c026a03e01e387bb95fe5ed8fbc49b3c527220f164d77a2f3a4f2"
+    },
+    "maps/ad_brk/brick19.map": {
+     "bytes": 1942,
+     "sha256": "1760c2c74d0b894814c89152062f2f55a8635a17559828c27532a7e913949af6"
+    },
+    "maps/ad_brk/brick20.bsp": {
+     "bytes": 13306,
+     "sha256": "bbecee9c1ac726743e6cc49d18246c650f762f577dc108ffed2a6807ff665052"
+    },
+    "maps/ad_brk/brick20.map": {
+     "bytes": 3286,
+     "sha256": "121d4fe62c07953f11a04a41577769a38cae8852af78bbd40fc44f598eee91d7"
+    },
+    "maps/ad_brk/brick21.bsp": {
+     "bytes": 7972,
+     "sha256": "e65c1df9d5f02efc9475a53d1127d7899f69d23d8a0ea20deab384fcd3351d29"
+    },
+    "maps/ad_brk/brick21.map": {
+     "bytes": 789,
+     "sha256": "8c12d093245c3937afcf62916fce9e6b2d181d72d433b879112b27e0f168ccc7"
+    },
+    "maps/ad_brk/brick22.bsp": {
+     "bytes": 9204,
+     "sha256": "b8efe5f130accf1e8704202dbaa44215259e1209b9b81bf79461ff5e5f725596"
+    },
+    "maps/ad_brk/brick22.map": {
+     "bytes": 1728,
+     "sha256": "403525bf264890c5d9adef370847749cbeec481337f284618810057e697cddde"
+    },
+    "maps/ad_brk/brick23.bsp": {
+     "bytes": 10340,
+     "sha256": "79bac69a44c7e83343bd69c2360176046e048257ecfb7ac27f3c989b42af92e9"
+    },
+    "maps/ad_brk/brick23.map": {
+     "bytes": 1961,
+     "sha256": "f25e7a514eb15637b7dedc41ec5c34e2d8b9e4dd3b584a41a1b1d7c166b362ef"
+    },
+    "maps/ad_brk/brick24.bsp": {
+     "bytes": 13312,
+     "sha256": "2e0728a16ebe0fa868d8bd0ffe0f54e013afac41c77ee7516f385d7a6718b07f"
+    },
+    "maps/ad_brk/brick24.map": {
+     "bytes": 3305,
+     "sha256": "481d21e7e07a312e894f71a8118035457164f17d48032bad54bdc62644e7e8a4"
+    },
+    "maps/ad_brk/brick25.bsp": {
+     "bytes": 7924,
+     "sha256": "8e33245bde92e94d9dddca1b61059fee1eb19aed0613945c1dffe3145fd51d78"
+    },
+    "maps/ad_brk/brick25.map": {
+     "bytes": 715,
+     "sha256": "cf6042585a2347f8ae4de546e2fa9aa905aa7ee4d9607a12dfd778d0084ba9d1"
+    },
+    "maps/ad_brk/brick26.bsp": {
+     "bytes": 8084,
+     "sha256": "4ddb5d2ca4adbc32f905a0340b26a174c25af7f6de5ad9408c4e0f4ca2816a55"
+    },
+    "maps/ad_brk/brick26.map": {
+     "bytes": 855,
+     "sha256": "baaf133d5c5c90b295855bb03a0a30340db324ddc82ed119a9d025e8ddb22724"
+    },
+    "maps/ad_brk/brick27.bsp": {
+     "bytes": 8296,
+     "sha256": "9084778144864d4167d270dd825e99d18d7ea7fc2dfb799f7e0eb12f1d236688"
+    },
+    "maps/ad_brk/brick27.map": {
+     "bytes": 927,
+     "sha256": "4e3b59df2a5b8efe85460f114baa795c36c8b410407e0752a69efc525d49e9b0"
+    },
+    "maps/ad_brk/brick28.bsp": {
+     "bytes": 8068,
+     "sha256": "42b4fe7f99032b3292996bcfe8b72e1c5e3b637357e376f8502a202a3816bcf0"
+    },
+    "maps/ad_brk/brick28.map": {
+     "bytes": 811,
+     "sha256": "c088828bbe9cdca1bb55ea4ceca9f46e03217f1643189a93d70a83eeb11f72bc"
+    },
+    "maps/ad_brk/brick29.bsp": {
+     "bytes": 24232,
+     "sha256": "463ff6bed92dfab082f13876187c506572dd3d18727e13fb708e24afd02aa7ef"
+    },
+    "maps/ad_brk/brick29.map": {
+     "bytes": 711,
+     "sha256": "1a4ff9d041df15cfd229666a9b32c24a96577ef6f249f33d89dc88cdfbe5540a"
+    },
+    "maps/ad_brk/brick30.bsp": {
+     "bytes": 24392,
+     "sha256": "a82a0d709c367d8ecf359142d99d0ad09d97b674ef1575beeb78dbbe93025c59"
+    },
+    "maps/ad_brk/brick30.map": {
+     "bytes": 853,
+     "sha256": "803c896037b5cc971e932219b5f06e363724a25de693ef6800d1332c6df4f8d1"
+    },
+    "maps/ad_brk/brick31.bsp": {
+     "bytes": 24604,
+     "sha256": "deb8a0278e043c6510e7f7d17ec708bdc7f37fa884f869ccbfc9ef9a95b6a8ac"
+    },
+    "maps/ad_brk/brick31.map": {
+     "bytes": 926,
+     "sha256": "9a3502125d9a995f10052ed6a9971bfe148a4e8fd7561a082e8bbecff5b39d56"
+    },
+    "maps/ad_brk/brick32.bsp": {
+     "bytes": 24376,
+     "sha256": "c8961b003f231b13a74bc247ce13ada38850707d443aa98dbad98b9f2ecf276b"
+    },
+    "maps/ad_brk/brick32.map": {
+     "bytes": 808,
+     "sha256": "aa96dda4508d2e98b5827ac42d8230f11969457f63022bf488dac06d2783910e"
+    },
+    "maps/ad_brk/glass01.bsp": {
+     "bytes": 8095,
+     "sha256": "d5d9b8df7fc4db671e180fbc60253ea809b61819bd77a9072d1cf1b1c9c11888"
+    },
+    "maps/ad_brk/glass01.map": {
+     "bytes": 961,
+     "sha256": "04b6721fc35e7a43fa921075bc2184bbbb2791570ea781ee6351b0cf01936456"
+    },
+    "maps/ad_brk/glass02.bsp": {
+     "bytes": 7035,
+     "sha256": "b2e6ba1e674f6a93e01ada15700b98624eae9c242a30eba9ea032d2e7d9fc555"
+    },
+    "maps/ad_brk/glass02.map": {
+     "bytes": 447,
+     "sha256": "6bf3cce568e830dd03830bb2e7225329490dae01e33806eec6a594313a8daa9e"
+    },
+    "maps/ad_brk/glass03.bsp": {
+     "bytes": 7922,
+     "sha256": "02661d1e724d41c02c977f8b869a23e6fc883303b66298c98ebddf752f365a1b"
+    },
+    "maps/ad_brk/glass03.map": {
+     "bytes": 963,
+     "sha256": "cb5245e54bc27d999bd643370557f8e766ae94e10358993951084e6ca87d087c"
+    },
+    "maps/ad_brk/glass04.bsp": {
+     "bytes": 7223,
+     "sha256": "a41bddb2d6a0ef53b96097a6e4d9731bf100b695a7a1c11091f054f746c7bf2a"
+    },
+    "maps/ad_brk/glass04.map": {
+     "bytes": 512,
+     "sha256": "f8e9f41266f3cd0017c19f7d3a29e0c738b497fb539cec2583c4eda6d509965c"
+    },
+    "maps/ad_brk/glass05.bsp": {
+     "bytes": 24436,
+     "sha256": "10fd2ef7f24bda233c3b4433e4ed64b8feb7273f09c0da5d93190ced61f20779"
+    },
+    "maps/ad_brk/glass05.map": {
+     "bytes": 999,
+     "sha256": "c8e2039929909b608ac0ddf36562443caf7052a15e8b0e39a73e0869c15930c1"
+    },
+    "maps/ad_brk/glass06.bsp": {
+     "bytes": 24300,
+     "sha256": "60f08ebc3d967dbe1b6062a59679a3e89e199a305f51bb9bc7dbada44c66fe5e"
+    },
+    "maps/ad_brk/glass06.map": {
+     "bytes": 976,
+     "sha256": "73346b8cc46166371a6e7f220ebe78f2cde29f29d8d705e1e4b0c60e153b52df"
+    },
+    "maps/ad_brk/glass07.bsp": {
+     "bytes": 23365,
+     "sha256": "ccebafe1a97953e91b64694783a1989c8e8ba440fd3c136b09785131b54c75cf"
+    },
+    "maps/ad_brk/glass07.map": {
+     "bytes": 458,
+     "sha256": "6d79a332d308ed3746c8f2fd13227b44a1cc66f0b2fd471eb6de1cbf695d81c9"
+    },
+    "maps/ad_brk/glass08.bsp": {
+     "bytes": 23602,
+     "sha256": "82c1bfe3d83c87c908d6dac76a255843cbbaededeaf644eeec5b9b9a794e0bdf"
+    },
+    "maps/ad_brk/glass08.map": {
+     "bytes": 530,
+     "sha256": "65dba1b71881c49b29d288720f43c457c838b93aa9e522953bac885443944c04"
+    },
+    "maps/ad_brk/glass09.bsp": {
+     "bytes": 24436,
+     "sha256": "34e317a5652fcc4a3aaf517ebc178c8d8fad6738b536a6c06eff2800bf7fefba"
+    },
+    "maps/ad_brk/glass09.map": {
+     "bytes": 999,
+     "sha256": "ca9b91b38fa600b7dfa80e9a257dc15f2f2dda9e1d2c1d002ea90cbdcc0e0279"
+    },
+    "maps/ad_brk/glass10.bsp": {
+     "bytes": 24300,
+     "sha256": "6e06c140e0916cd35235bd7e6970ca3250c6c36a2ee6d4632d805da67215818a"
+    },
+    "maps/ad_brk/glass10.map": {
+     "bytes": 976,
+     "sha256": "2043f7646edcfa088a76b6104b136ff9ca0f90bffe6efb955f951a4bfe16643d"
+    },
+    "maps/ad_brk/glass11.bsp": {
+     "bytes": 23365,
+     "sha256": "caae0c47ae097f4cb1055a3f5eecd5d407b71c975b35d992f3048993b1ac7e97"
+    },
+    "maps/ad_brk/glass11.map": {
+     "bytes": 458,
+     "sha256": "5bea1bbcee409674f58a1fd26cf0c983e11f8ffd5f20c829f5c3df6a4c28b1c9"
+    },
+    "maps/ad_brk/glass12.bsp": {
+     "bytes": 23602,
+     "sha256": "526018b31a9b02b1c9e1b5123b2c936677d6fd7b6c014ea14dfe4905271e419f"
+    },
+    "maps/ad_brk/glass12.map": {
+     "bytes": 530,
+     "sha256": "499ed4ce1a1ebbd9347a2a4dc6413f2f79d203bbce293a79a5b2bde49ade0a3f"
+    },
+    "maps/ad_brk/glass13.bsp": {
+     "bytes": 24108,
+     "sha256": "fdb97447ffe9e4769f35a3e1e7bd9d6b0e2e6b555d60102991bf57f06e8b3d83"
+    },
+    "maps/ad_brk/glass13.map": {
+     "bytes": 979,
+     "sha256": "073661c415a2568c45a90cc9baa471cde9a02a975d4d4fd7596bb96d272d3934"
+    },
+    "maps/ad_brk/glass14.bsp": {
+     "bytes": 23296,
+     "sha256": "e3517bb79e2561150c4641ab3650e0697adcaa2f281c5209cacdc12d9c4023a7"
+    },
+    "maps/ad_brk/glass14.map": {
+     "bytes": 462,
+     "sha256": "066d5bade73c399cf10a9dcafecec9d65ac3c6045644988cbefb104fb8e7d8c3"
+    },
+    "maps/ad_brk/glass15.bsp": {
+     "bytes": 23892,
+     "sha256": "6abc82aca32e6c8312884db42891753c8d2ad8e1d4ae9218022604eadb08708b"
+    },
+    "maps/ad_brk/glass15.map": {
+     "bytes": 993,
+     "sha256": "5c24e1763bd26d34539bc7ee527842810e4ddb6ac80f683a7b3b35ee326360d3"
+    },
+    "maps/ad_brk/glass16.bsp": {
+     "bytes": 23532,
+     "sha256": "13725c14b226297090c4f1e9949c476f601a52247bc8f6abb937a57b964462c6"
+    },
+    "maps/ad_brk/glass16.map": {
+     "bytes": 528,
+     "sha256": "03dbc7feb833831d413e7f87ed0e79625da0800659ab65ea8d3deb63de09a27d"
+    },
+    "maps/ad_brk/kn_mtrim2_1.bsp": {
+     "bytes": 25264,
+     "sha256": "99b67eeed7ece0f46b1d7b4b2309331e655eb9c1b412d3ac4bc362acb4dd8606"
+    },
+    "maps/ad_brk/kn_mtrim2_1.map": {
+     "bytes": 1455,
+     "sha256": "51018fd4ff6d00c9c2c449e32a83b8521fdc3babb2937adf6800d8e67e38b976"
+    },
+    "maps/ad_brk/kn_mtrim2_2.bsp": {
+     "bytes": 24460,
+     "sha256": "a98bdee68b3a222af0f44fc978d09e092a08953539929a6a53f1bf0e97568e74"
+    },
+    "maps/ad_brk/kn_mtrim2_2.map": {
+     "bytes": 1103,
+     "sha256": "2880a3f7becf48ae79c27ef9a05faa5c774df20a53ec5d892304bf67bc06cbbe"
+    },
+    "maps/ad_brk/kn_mtrim2_3.bsp": {
+     "bytes": 24632,
+     "sha256": "967e89f57bc011cd3b38d60d45272633cc0f773c91045b7938766ac0436ae803"
+    },
+    "maps/ad_brk/kn_mtrim2_3.map": {
+     "bytes": 1171,
+     "sha256": "40ef38fd45c3e9c750d311bb8920b938fcd9f647f2dabc58509b327514f44907"
+    },
+    "maps/ad_brk/kn_mtrim2_4.bsp": {
+     "bytes": 24452,
+     "sha256": "e4559e1e5a3118f2c949daccb96f887d64821511f5850cfa72133f84a8e04901"
+    },
+    "maps/ad_brk/kn_mtrim2_4.map": {
+     "bytes": 1036,
+     "sha256": "595513bc0fe2441cb6aa88af41d9afd7de8b94421ac6c32c546113f83be6577c"
+    },
+    "maps/ad_brk/metal01.bsp": {
+     "bytes": 8122,
+     "sha256": "11e8e340455c487150951fb4dccaf7da72d0243892948d5c22b478221ffcca23"
+    },
+    "maps/ad_brk/metal01.map": {
+     "bytes": 780,
+     "sha256": "902c31c661df8bbc1b0c410b6a8745f680e85cf91bbdb14d85244b6937be5239"
+    },
+    "maps/ad_brk/metal02.bsp": {
+     "bytes": 10022,
+     "sha256": "59b56266e73b4246c54d8cd9c4769d7345c53ae5133c45d1db94f5c771350d94"
+    },
+    "maps/ad_brk/metal02.map": {
+     "bytes": 1414,
+     "sha256": "171bfe727b6c80a4c0350fb4c87090d30c3fb1a21962b8fc9c638c47027e1fea"
+    },
+    "maps/ad_brk/metal03.bsp": {
+     "bytes": 9386,
+     "sha256": "13e3ea83c5bdbf81075328cc14543d1ab6301378cc9af56b59b67b1cc22e3a53"
+    },
+    "maps/ad_brk/metal03.map": {
+     "bytes": 1179,
+     "sha256": "89ac4002203958a9f971601586f4e4e6bdcaab7cbde62ca7fb58cf705fbdae56"
+    },
+    "maps/ad_brk/metal04.bsp": {
+     "bytes": 10655,
+     "sha256": "785ab6aed41e60072083aeee571d76796f60ec5e24d249736575007d558c10ae"
+    },
+    "maps/ad_brk/metal04.map": {
+     "bytes": 1599,
+     "sha256": "aecd2de4ce9cdb49922c58f640f3df4c48b8dc45f5e611f5d0c75a6a96bf705e"
+    },
+    "maps/ad_brk/metal05.bsp": {
+     "bytes": 8337,
+     "sha256": "82da98a887a0101d1a638d266db3c9913090b3fcaca6af5869e7063529b3066e"
+    },
+    "maps/ad_brk/metal05.map": {
+     "bytes": 905,
+     "sha256": "541a5d633be51d32bbd6580cf3fb4fcc7e9b3c38107eaffdd88896a01d249b71"
+    },
+    "maps/ad_brk/metal06.bsp": {
+     "bytes": 7898,
+     "sha256": "3fe3f66ff336ede9d9a6f4fc0f7df16b62504b25a8dea1c8adce2113e927428e"
+    },
+    "maps/ad_brk/metal06.map": {
+     "bytes": 697,
+     "sha256": "30bfd29315a3c0d8654aa1842b7f2a2a7bcdc7a5a81ff96f359a86d57a289ce9"
+    },
+    "maps/ad_brk/metal07.bsp": {
+     "bytes": 8439,
+     "sha256": "8f8a722ae0d3350bf4331fbd4a492dd4c18b3c44006289fd7c6d393282f280a1"
+    },
+    "maps/ad_brk/metal07.map": {
+     "bytes": 1508,
+     "sha256": "f2c7442255c68ae30186692cdf49bca0f1e5769587d5d2392baf3ec4708679b2"
+    },
+    "maps/ad_brk/metal08.bsp": {
+     "bytes": 8150,
+     "sha256": "028675fecfd419e8852cabe821fac1941c914bdf43110291d7a07509e77f4d26"
+    },
+    "maps/ad_brk/metal08.map": {
+     "bytes": 847,
+     "sha256": "797217e143857e0b27e1654449a5dbdc0b1a3dc46c8cafdea5ee9c5ac0cbf16c"
+    },
+    "maps/ad_brk/metal09.bsp": {
+     "bytes": 7456,
+     "sha256": "4d6fb8a19ce5a331ceb68fcfa952fa61ed3ad336002eedd788921b0daa2a7877"
+    },
+    "maps/ad_brk/metal09.map": {
+     "bytes": 649,
+     "sha256": "1fde976a2f1372d9d55350caa3285776eee897d9786f9118d5a6988010efaeca"
+    },
+    "maps/ad_brk/metal10.bsp": {
+     "bytes": 7785,
+     "sha256": "c25084ae2f159ba73e6c43041a2e050d30af70a862a9c4846b2241848a33b55f"
+    },
+    "maps/ad_brk/metal10.map": {
+     "bytes": 709,
+     "sha256": "856390903976512f1b5372f374b5c7444238a173abbedbbfeccbb675cf93ed66"
+    },
+    "maps/ad_brk/metal11.bsp": {
+     "bytes": 7918,
+     "sha256": "e939c6c80e11479887b68bb39a97e0b877514c4e9dc9b2a4a9e18303caa317f1"
+    },
+    "maps/ad_brk/metal11.map": {
+     "bytes": 797,
+     "sha256": "74528d15a51708fdca65c900096411f1d56d6472a5058458577ac04d820e9895"
+    },
+    "maps/ad_brk/metal12.bsp": {
+     "bytes": 8226,
+     "sha256": "3ceccd7aa24fc353e0ac3ccb15531c2f243c0ed246c73c44bdd8897dbdd6537e"
+    },
+    "maps/ad_brk/metal12.map": {
+     "bytes": 872,
+     "sha256": "a95f34c46729c7849e6d45d9cdf57bb49289561b6551bd2e4a39659c272343fd"
+    },
+    "maps/ad_brk/metal13.bsp": {
+     "bytes": 8121,
+     "sha256": "e02aa4c824f5d8fcdfe302a0a194cee6fcf44e2fee844c492f434bf2b7763209"
+    },
+    "maps/ad_brk/metal13.map": {
+     "bytes": 760,
+     "sha256": "bae8879296237bea635d054428a536c0297420ff3ff61f681d569b30a984e7d0"
+    },
+    "maps/ad_brk/metal14.bsp": {
+     "bytes": 10022,
+     "sha256": "4b66b133fe892c6ae6ead0c6726638e98637d71a3a9afdc4ac0546be0f2d0292"
+    },
+    "maps/ad_brk/metal14.map": {
+     "bytes": 1376,
+     "sha256": "197bd6c01b5ffc4c9e0f27e319b25b882af4f20db36612f41b006dd6db0833e1"
+    },
+    "maps/ad_brk/metal15.bsp": {
+     "bytes": 9386,
+     "sha256": "8cf7545aa3464814908c3987f51e9693f154f690ec526ed228b37b1590730e0b"
+    },
+    "maps/ad_brk/metal15.map": {
+     "bytes": 1147,
+     "sha256": "73aef82251f5b4a9548135aedb926aad6b7cff94cb3656fc8216a594a8a9f6dc"
+    },
+    "maps/ad_brk/metal16.bsp": {
+     "bytes": 10719,
+     "sha256": "af64c13135b1e1eb6d8e09607c34d6cec57a3cbf624dd76b136b505f097ecf65"
+    },
+    "maps/ad_brk/metal16.map": {
+     "bytes": 1555,
+     "sha256": "d7220fbbb33a630d03ed2514b9ee33a9d3a424f819b4977e093863ca8568b645"
+    },
+    "maps/ad_brk/metal17.bsp": {
+     "bytes": 8347,
+     "sha256": "0d21cbf9b5bc65391e00bad35368530d3d4b5f59993e2ac7d45a7edc9a2edf73"
+    },
+    "maps/ad_brk/metal17.map": {
+     "bytes": 911,
+     "sha256": "7be91013d0e57e41aff314398634043cebf8f250691b3ebc583bf373df400c2c"
+    },
+    "maps/ad_brk/metal18.bsp": {
+     "bytes": 7907,
+     "sha256": "ef0dee9c63d7bbced8c04ea40523d47fd99638905aa20a61779820b5aebd5aab"
+    },
+    "maps/ad_brk/metal18.map": {
+     "bytes": 703,
+     "sha256": "b610432a51ac6b57f19fee9df89fc7b80d5cbffa972e539d9c5f3aded3359434"
+    },
+    "maps/ad_brk/metal19.bsp": {
+     "bytes": 8450,
+     "sha256": "2796007e11c0a1b2a3430edc4e0f7edb0e721a6d906e783233c0feb54b0482e5"
+    },
+    "maps/ad_brk/metal19.map": {
+     "bytes": 1514,
+     "sha256": "9ed741344b3c651f3b8fbda1d8ee8e779bd12315feea397e938522c9750dc214"
+    },
+    "maps/ad_brk/metal20.bsp": {
+     "bytes": 8160,
+     "sha256": "38013cdb360356827ab6c296791434c537183d082feed6944665a882e622ed84"
+    },
+    "maps/ad_brk/metal20.map": {
+     "bytes": 853,
+     "sha256": "a3b28328bb043206bc048e82dba12d91c56c464b5e4e1452c6740f0df44223bf"
+    },
+    "maps/ad_brk/rock01.bsp": {
+     "bytes": 24238,
+     "sha256": "5f2c0a6ce3c58eed53c86789ff1685551cff53ca1f239bf75e3a9bc59aa95a56"
+    },
+    "maps/ad_brk/rock01.map": {
+     "bytes": 680,
+     "sha256": "db0b6a72833e12a35f518b32920fccf4fbc45120e7ab8ca3afc6e255b5d51334"
+    },
+    "maps/ad_brk/rock02.bsp": {
+     "bytes": 24250,
+     "sha256": "c6196e82e7b3e22cb687e2d6c0780f163929b5ea42b868eedcaadd40f35927f9"
+    },
+    "maps/ad_brk/rock02.map": {
+     "bytes": 760,
+     "sha256": "49531f0a1a38e03e3b46af53cfc35845878fcc171c2579f0f13d2a000ca82829"
+    },
+    "maps/ad_brk/rock03.bsp": {
+     "bytes": 24669,
+     "sha256": "9f7ab133399a3681f0b97276c7cb9883b479995c3420e5643eaedd11c88f0a0d"
+    },
+    "maps/ad_brk/rock03.map": {
+     "bytes": 929,
+     "sha256": "4158321d447c3b323f44389661ba6c763b23e26fb9541a786c3b544ad56321d9"
+    },
+    "maps/ad_brk/rock04.bsp": {
+     "bytes": 24600,
+     "sha256": "3c8b114e8ff86b8abcba235230445d885d4c28553d83e153676b2755b0300292"
+    },
+    "maps/ad_brk/rock04.map": {
+     "bytes": 878,
+     "sha256": "229d94f5f5bd81a83be5463035d30c8838d1de092923c3281e7a3a9ec4c7e9aa"
+    },
+    "maps/ad_brk/rock05.bsp": {
+     "bytes": 24254,
+     "sha256": "6bdc990b90f24ddd77034a4cbdd4d7158e05df70e6db5e793ca990a40cd29709"
+    },
+    "maps/ad_brk/rock05.map": {
+     "bytes": 684,
+     "sha256": "708a6ad98116a72ddc862c6c99cbd59342446636c9579a00bd6c34efa1ac855b"
+    },
+    "maps/ad_brk/rock06.bsp": {
+     "bytes": 24462,
+     "sha256": "e2e3688c3cb66e2c9d738d211ad328d86963e1d67881354363696698a07be32b"
+    },
+    "maps/ad_brk/rock06.map": {
+     "bytes": 816,
+     "sha256": "5e1a399ac2e6a179a84004539f15172012db93477e5544309b01ed24cbc59f34"
+    },
+    "maps/ad_brk/rock07.bsp": {
+     "bytes": 24281,
+     "sha256": "ea3569e42b755fd1b9fde50e2740f6aa95d1dabb1911f8a4ab5b1c5028a4e1e3"
+    },
+    "maps/ad_brk/rock07.map": {
+     "bytes": 777,
+     "sha256": "02f61c60083f5007fa9d4d7a38adf2901e928a96adbfeaa7646711f21cc75409"
+    },
+    "maps/ad_brk/rock08.bsp": {
+     "bytes": 25096,
+     "sha256": "5468a365153fc7f160d7e1792b9bc9164b828a51851bd1e9744eb0cf3a7a842d"
+    },
+    "maps/ad_brk/rock08.map": {
+     "bytes": 1060,
+     "sha256": "b285f3a79407366944213b3d8eef311c662bf2eb0cf3df0ee3104e747a3c9150"
+    },
+    "maps/ad_brk/rock09.bsp": {
+     "bytes": 8314,
+     "sha256": "4320c73f55d67e4db7e596614b74b05b0c086cd57186ecaf183c96fca51106bf"
+    },
+    "maps/ad_brk/rock09.map": {
+     "bytes": 913,
+     "sha256": "629fab0d0f8022138ff5d5e573f0e3ab0f75397f120015b3f8a95a297c857911"
+    },
+    "maps/ad_brk/rock10.bsp": {
+     "bytes": 7930,
+     "sha256": "7657ad82fbdeaceb354e04f60fa76cfd3d8a7a819607a413afaa6fc16253a009"
+    },
+    "maps/ad_brk/rock10.map": {
+     "bytes": 780,
+     "sha256": "833bc2f2460f5f5ef444630b398a59974831031e408f986125a5241fab52ba99"
+    },
+    "maps/ad_brk/rock11.bsp": {
+     "bytes": 8565,
+     "sha256": "e19573b67e5dedba499da8f6d0d63ca0e829593417a1ce66e1aeb1fd2b2d1e76"
+    },
+    "maps/ad_brk/rock11.map": {
+     "bytes": 1016,
+     "sha256": "040c31d22159743b28e9f20946b34db390ef15bbe530882342638b9325542801"
+    },
+    "maps/ad_brk/rock12.bsp": {
+     "bytes": 8284,
+     "sha256": "f03a3a0184b2fa8809154754f85d81d30777261714976bdd64340b0549d3ca35"
+    },
+    "maps/ad_brk/rock12.map": {
+     "bytes": 898,
+     "sha256": "b7d2b1bba22ad5b621e699a8233a83d23415e5c6e88fec8e1525a9c84a494bf0"
+    },
+    "maps/ad_brk/rock13.bsp": {
+     "bytes": 7917,
+     "sha256": "6710c24df905df9ede31faf75fdf9a070efbdc471e58a295740092863dcb50fa"
+    },
+    "maps/ad_brk/rock13.map": {
+     "bytes": 680,
+     "sha256": "369735b7ebd630e6407371d3ab7195ef368c2f8d8d3469943b2c5e46b8e24fa5"
+    },
+    "maps/ad_brk/rock14.bsp": {
+     "bytes": 7929,
+     "sha256": "a17329c593e306d1aa4084cd2651983f53258b3e5759443efe3bb3b4daecc5f8"
+    },
+    "maps/ad_brk/rock14.map": {
+     "bytes": 760,
+     "sha256": "f86556e799f3a0240294537aa487526c674486afb7190bb705d72453cade7e68"
+    },
+    "maps/ad_brk/rock15.bsp": {
+     "bytes": 8349,
+     "sha256": "d64f11606da6b94024382315eead25dbfe19c8cc90844f60e755e2bd106c7fc0"
+    },
+    "maps/ad_brk/rock15.map": {
+     "bytes": 929,
+     "sha256": "23defe1bddcc8db664c819b60657fd536b1c44b118299495d42f7c54f740e7b0"
+    },
+    "maps/ad_brk/rock16.bsp": {
+     "bytes": 8280,
+     "sha256": "87e60c650a672c5ffe57b64c7ae3c5413799972a2ca5b73935cb0d1dad16f62c"
+    },
+    "maps/ad_brk/rock16.map": {
+     "bytes": 878,
+     "sha256": "d3616ad7b423be757f6f7873791f4c452a09243b53569347bd36e87f1a942947"
+    },
+    "maps/ad_brk/rock17.bsp": {
+     "bytes": 8340,
+     "sha256": "b317f3432532e6f6f327852fa0c7f546726c8b23c44cfc3e86869d64eb33235c"
+    },
+    "maps/ad_brk/rock17.map": {
+     "bytes": 913,
+     "sha256": "a534b032b611965c86cd81fda18d53186c474d55184f9c4c74cd292b4b207f27"
+    },
+    "maps/ad_brk/rock18.bsp": {
+     "bytes": 7924,
+     "sha256": "e5fc24e393828bdd2c24e3cb341e0c21e81511881e65424293206fe20ff54c4e"
+    },
+    "maps/ad_brk/rock18.map": {
+     "bytes": 701,
+     "sha256": "bf5974bf04067482dde83a2fd73e58a011de04220b32866fa7913e901a0e944c"
+    },
+    "maps/ad_brk/rock19.bsp": {
+     "bytes": 8620,
+     "sha256": "4a1d3e4e37f29438981f419f5a5f076fcf53227a4da544e919061d6c6bf8702e"
+    },
+    "maps/ad_brk/rock19.map": {
+     "bytes": 919,
+     "sha256": "c2626204acbd33e3299c29cd1f8a5279bbe8cd07a621f6b40b14b74b7808f444"
+    },
+    "maps/ad_brk/rock20.bsp": {
+     "bytes": 8785,
+     "sha256": "87bfda54a9f0711eedcefc6d8e691b6cac8123958db03735bd0364067445de69"
+    },
+    "maps/ad_brk/rock20.map": {
+     "bytes": 1118,
+     "sha256": "225800378c3183d5ba423140d7f5d510cf387df3df795fda69294fcb0e4bec4c"
+    },
+    "maps/ad_brk/rock21.bsp": {
+     "bytes": 24244,
+     "sha256": "161b5893f3f413969ced051a7e7aa3d816a1da9f74bffa5d0642830713d83031"
+    },
+    "maps/ad_brk/rock21.map": {
+     "bytes": 674,
+     "sha256": "db86b019086636ec085b3690bc4b252d8bac2443c0ff138a6f3b6c79e522a94b"
+    },
+    "maps/ad_brk/rock22.bsp": {
+     "bytes": 24256,
+     "sha256": "b41069e88c74ef3bfb7c5f2817c31d9d374cd1725b7270b9ac7d93c58dd34a11"
+    },
+    "maps/ad_brk/rock22.map": {
+     "bytes": 753,
+     "sha256": "aa059dd13499512fdda512b68e79068f390d1870726763958a81a54c91aeb254"
+    },
+    "maps/ad_brk/rock23.bsp": {
+     "bytes": 24676,
+     "sha256": "aac7fc5557dd385c52043d206d39d83b48e0b2f6db2822de2060f2a978be4a9d"
+    },
+    "maps/ad_brk/rock23.map": {
+     "bytes": 920,
+     "sha256": "744ccf1456c3b19318289586238b1d36e4968dbfe444f5a489e1d2202f1965d4"
+    },
+    "maps/ad_brk/rock24.bsp": {
+     "bytes": 24612,
+     "sha256": "90553422561893d50030520bcf796da9290933e53570e313d1a423aec01c8ac6"
+    },
+    "maps/ad_brk/rock24.map": {
+     "bytes": 939,
+     "sha256": "3f8f5c2053315577eda81360a9ed9a095e96f7d9a6288eed876400a91bc0922b"
+    },
+    "maps/ad_brk/rock25.bsp": {
+     "bytes": 89516,
+     "sha256": "ef87b49e322fd2a2251f0ee7ecedec32bae141ea7a589769c6fba6a3176da0d4"
+    },
+    "maps/ad_brk/rock25.map": {
+     "bytes": 737,
+     "sha256": "3cad88a720acc4d7db1666ab0d865e013717776a256c999e1b417690679f4f0b"
+    },
+    "maps/ad_brk/rock26.bsp": {
+     "bytes": 89532,
+     "sha256": "a6f46aa8183937dfe19eb1cfde621bac8f3f08721effcbbd195ba251b3b1467f"
+    },
+    "maps/ad_brk/rock26.map": {
+     "bytes": 823,
+     "sha256": "27c411424182d3e6d611f2eff2dd9a7c75ef2135f2019d4aca40b2dee2d134b5"
+    },
+    "maps/ad_brk/rock27.bsp": {
+     "bytes": 89952,
+     "sha256": "f55dc66117c856efee1dae5e311492f2aae2839ef4588af45ac0818307ad564c"
+    },
+    "maps/ad_brk/rock27.map": {
+     "bytes": 1004,
+     "sha256": "7368f6cbd051aa3ac71237b5c8d3da2ef73fc3017024ef42af6ac8af9ddc1139"
+    },
+    "maps/ad_brk/rock28.bsp": {
+     "bytes": 89880,
+     "sha256": "2132d7f311c90f8c43b4630a55f7fa0b15141fa0e9c26c0309c8023437377961"
+    },
+    "maps/ad_brk/rock28.map": {
+     "bytes": 947,
+     "sha256": "b1571df2e370ca2d51f19b3608726552f10a6f6da64f69929a2ea2c1884e51dc"
+    },
+    "maps/ad_brk/rock29.bsp": {
+     "bytes": 89516,
+     "sha256": "a179ac329768d445bfbc36bb9c3e47ce3c7506c31337730a93c9a58f96ea5399"
+    },
+    "maps/ad_brk/rock29.map": {
+     "bytes": 737,
+     "sha256": "260d08f376c81869c1f9a0c0cfd677bded9022f79bbe4e607d12128b7ad7c746"
+    },
+    "maps/ad_brk/rock30.bsp": {
+     "bytes": 89532,
+     "sha256": "febc6ed2ec191f8dcbae1ee9df9d13bbd8fff830e28e051236fa24fd211829ee"
+    },
+    "maps/ad_brk/rock30.map": {
+     "bytes": 823,
+     "sha256": "da6a3224e060f6413f70ac9f6f25bf96f3784f690084d602d63805dc8b43e7e8"
+    },
+    "maps/ad_brk/rock31.bsp": {
+     "bytes": 89952,
+     "sha256": "7a38ed8a7dd80c2f2dab17342bfdde51300c9225f4e93be78ca9b63d3a7f1e99"
+    },
+    "maps/ad_brk/rock31.map": {
+     "bytes": 1004,
+     "sha256": "3fb04740e6da6c00670536ccbcb92e7a9a5b5e3072e78af96d6dd5c79d39f984"
+    },
+    "maps/ad_brk/rock32.bsp": {
+     "bytes": 89880,
+     "sha256": "41789fbb095ef6d7b09ba6f50bea0503f73e612808f37bbb71f4a7e9fea00ae2"
+    },
+    "maps/ad_brk/rock32.map": {
+     "bytes": 947,
+     "sha256": "37e272ad3f235bb182666e46d3b087bee4ec23ebdc716647c5b0ffb671a9ee1d"
+    },
+    "maps/ad_brk/rock33.bsp": {
+     "bytes": 7916,
+     "sha256": "af3e313ba1c7013b7bd2234e9988a2b6bc451d123e7d6dab1692ae0727d40bec"
+    },
+    "maps/ad_brk/rock33.map": {
+     "bytes": 683,
+     "sha256": "de08059147e865be402e6dac4c6d8a0bea1de05bb65cf0455153386afdde2bdb"
+    },
+    "maps/ad_brk/rock34.bsp": {
+     "bytes": 7932,
+     "sha256": "392125c9afaf18c3084c1b13a0a55dcda7e2294da37f84fb73983826271dea27"
+    },
+    "maps/ad_brk/rock34.map": {
+     "bytes": 763,
+     "sha256": "dc402e2573ee3e94f3ed96274d5b6f8d0177d9745716ea96d0ffce8e0be5c943"
+    },
+    "maps/ad_brk/rock35.bsp": {
+     "bytes": 8352,
+     "sha256": "0352c35aa723330a3c05126d24a8e6b84403bf8b71d406f3fa5a2ff3fc0da39a"
+    },
+    "maps/ad_brk/rock35.map": {
+     "bytes": 932,
+     "sha256": "9841ed50187bbdfb3a7122d3b0890b0245d64dd4919485686fdf5ce61bdae3e6"
+    },
+    "maps/ad_brk/rock36.bsp": {
+     "bytes": 8280,
+     "sha256": "f1871698ef7597c51fed5d54b582df2ea70cf72e2fa7db643182e59f7e7f6ca7"
+    },
+    "maps/ad_brk/rock36.map": {
+     "bytes": 881,
+     "sha256": "974aaec9003dd3e1457582b1f770d67e07fc8e9d11a6b639981fbb753c6a6484"
+    },
+    "maps/ad_brk/sandstone01.bsp": {
+     "bytes": 24239,
+     "sha256": "ebb374110d88805e1b0b45cdaf33e5e570a9092da549facaf9f5ddcd995eb607"
+    },
+    "maps/ad_brk/sandstone01.map": {
+     "bytes": 702,
+     "sha256": "9ea9ab63b8c6a2d90fba029c4d4b768beb0d4342cf255bb5005185b61b1bcfd2"
+    },
+    "maps/ad_brk/sandstone02.bsp": {
+     "bytes": 24399,
+     "sha256": "2fa799b0a08ca2fdd9bef3ecb9d6ea4c16e8f66181d29913cdc5a9205bafe98f"
+    },
+    "maps/ad_brk/sandstone02.map": {
+     "bytes": 842,
+     "sha256": "5228b0a958ef571f33838366ef1f2b69a10f6e0c53a3269dba683b5326a95e5f"
+    },
+    "maps/ad_brk/sandstone03.bsp": {
+     "bytes": 24607,
+     "sha256": "671b8f740ba9deaeac681c703f87d61c2a3f8107d0f72b8fd636c53436555110"
+    },
+    "maps/ad_brk/sandstone03.map": {
+     "bytes": 914,
+     "sha256": "7523ff7908eb3e47154155d0448fa05d4d9b6081525069a131e7d44ea9b13c0c"
+    },
+    "maps/ad_brk/sandstone04.bsp": {
+     "bytes": 24379,
+     "sha256": "56bda0f4bf4958dc243fa9b4ab79e9e3bd6fad5f794af7beb024a6cbe7f9a0cb"
+    },
+    "maps/ad_brk/sandstone04.map": {
+     "bytes": 798,
+     "sha256": "d01584bd00868a0a69ae7513834f776566fce273d8919d9c78d0bdafbb07a799"
+    },
+    "maps/ad_brk/wood01.bsp": {
+     "bytes": 7553,
+     "sha256": "c1764181bae4852804097143fe16a4c230bd5886574125cb33d5349bbc63dc21"
+    },
+    "maps/ad_brk/wood01.map": {
+     "bytes": 1040,
+     "sha256": "05f1ebaa57c4b55e6c3da9c5440c180aa96c719f9cddc80c780ed11415ad6bd7"
+    },
+    "maps/ad_brk/wood02.bsp": {
+     "bytes": 7079,
+     "sha256": "26fc67e4e47eae3a13a449d876deabe35d50aa1b70e63060d27cb365eadecbe0"
+    },
+    "maps/ad_brk/wood02.map": {
+     "bytes": 521,
+     "sha256": "8dee7615c9e9696420331668edeccd9ff1dd874ad844e289f049391be5e61345"
+    },
+    "maps/ad_brk/wood03.bsp": {
+     "bytes": 7135,
+     "sha256": "ca17df0f61a11bd37749587e361ca404f2e5bec07c248491d86c07803fafb732"
+    },
+    "maps/ad_brk/wood03.map": {
+     "bytes": 522,
+     "sha256": "0fb4cdb1ffeda8c97026d40842d5fcb0beced0f84dae4b10a8284044875cf0c2"
+    },
+    "maps/ad_brk/wood04.bsp": {
+     "bytes": 7951,
+     "sha256": "e2d9f42bf3256be2dd38648dbd962458bdad3992b33e8d688e42a0acba5d7c3f"
+    },
+    "maps/ad_brk/wood04.map": {
+     "bytes": 912,
+     "sha256": "071556b1cac3bd95a176762302e6a60ddbbfb07cf6c9e4b2f8cf2e259e23402a"
+    },
+    "maps/ad_brk/wood05.bsp": {
+     "bytes": 7553,
+     "sha256": "5bdb275ae2c39b41d71a17244681cda9cc2008df088f4da73f547a8bf1966069"
+    },
+    "maps/ad_brk/wood05.map": {
+     "bytes": 1040,
+     "sha256": "ada27de98972730676a2d040fd284893fabfe71acd6fcbce1f2ba12da7d14632"
+    },
+    "maps/ad_brk/wood06.bsp": {
+     "bytes": 7079,
+     "sha256": "f27b0f1970f6065255b5f7a27abfc4e749f40321f6fdef4c3f9ac6bb64d46098"
+    },
+    "maps/ad_brk/wood06.map": {
+     "bytes": 521,
+     "sha256": "17c93b1c1c65a7507d794013078a1d12a67c3a24ae7202739fcd8a1108d52419"
+    },
+    "maps/ad_brk/wood07.bsp": {
+     "bytes": 7135,
+     "sha256": "8e07e7e5f5b641c644d28c9c4026efc95aa50345074f5c42acd39a3b94261344"
+    },
+    "maps/ad_brk/wood07.map": {
+     "bytes": 522,
+     "sha256": "55f1bb5f18ed30f28ac88349aee9ea5563b1e938bafebffb25c9ab5a1c918b33"
+    },
+    "maps/ad_brk/wood08.bsp": {
+     "bytes": 7951,
+     "sha256": "d26222458ba6e7fee06670021e64c1661d99a8c098581936af943891c9583858"
+    },
+    "maps/ad_brk/wood08.map": {
+     "bytes": 912,
+     "sha256": "2582987129d34bbee73594a236c4c09ce6ae1092eec649ef3957b892e125624c"
+    },
+    "maps/ad_brk/wood09.bsp": {
+     "bytes": 7282,
+     "sha256": "2735e78b25b0feb640f27eddae47104b0acba9f017c6d025e3a8dbdfcc755778"
+    },
+    "maps/ad_brk/wood09.map": {
+     "bytes": 541,
+     "sha256": "84d9789b4d79b41347fd082b0ab75c016553c03bfb952cf4b9c7dd18c85944ce"
+    },
+    "maps/ad_brk/wood10.bsp": {
+     "bytes": 7214,
+     "sha256": "43b59e9b0cb02fb1ac15afb5c782e71b4ce0661db295949b5188cc5accd1733a"
+    },
+    "maps/ad_brk/wood10.map": {
+     "bytes": 533,
+     "sha256": "365f949e19e2606cf2d7a354c3e4368a5e17c3eef94e2558ed9cef276e987d35"
+    },
+    "maps/ad_brk/wood11.bsp": {
+     "bytes": 7196,
+     "sha256": "cce8b312c4be49810f4cf90f0dcdeb1a82dfa623de1ba44c55ec83475f9e9e49"
+    },
+    "maps/ad_brk/wood11.map": {
+     "bytes": 542,
+     "sha256": "790cd93cb271402698ad7f005b908847fddbb30d3c8c3d11fa8c2f327ca8e48e"
+    },
+    "maps/ad_brk/wood12.bsp": {
+     "bytes": 7978,
+     "sha256": "6a227f92bf3b6f1120efd6179bfb3de977e4be2e59495c5d757cbe1c835e3f03"
+    },
+    "maps/ad_brk/wood12.map": {
+     "bytes": 986,
+     "sha256": "01ed96a5ce6545b334dfac7dc0196472dd6c06df09ed557cec7dc820d35c1132"
+    },
+    "maps/ad_brk/wood13.bsp": {
+     "bytes": 7284,
+     "sha256": "09325ca10ebcfeb88f688c9f4521259c3c3426e9befc06c99ba405c7e20595c9"
+    },
+    "maps/ad_brk/wood13.map": {
+     "bytes": 526,
+     "sha256": "b16b33b2a46b72a4ee235674780298eac0ed27631def07a28058a775aba7078e"
+    },
+    "maps/ad_brk/wood14.bsp": {
+     "bytes": 7216,
+     "sha256": "4c9dc5afd7b51119e5c22ad36eb77d07881c454ff47ed060521172cfc3950e2c"
+    },
+    "maps/ad_brk/wood14.map": {
+     "bytes": 518,
+     "sha256": "41b51f20630df3c046ed9ca0f7d97ca403ce8c1487074fc80caf603e763e6ac1"
+    },
+    "maps/ad_brk/wood15.bsp": {
+     "bytes": 7196,
+     "sha256": "373f6e5c5da44b7c8d1a01fb701f074bbcfc52d21bb080dd04e986ffe9e1088c"
+    },
+    "maps/ad_brk/wood15.map": {
+     "bytes": 527,
+     "sha256": "eb07eae6f0afdb4b03af57bcb589e3b385632912f12d4c55257b3031270f0421"
+    },
+    "maps/ad_brk/wood16.bsp": {
+     "bytes": 7612,
+     "sha256": "05959d3486eb43afc8959f6923156a1a83ead4dad544f8caf90ba0e1c7e2bc80"
+    },
+    "maps/ad_brk/wood16.map": {
+     "bytes": 953,
+     "sha256": "c7e804e781c95336cc91a50bc246baf4fda7172ecf36ccf24f02c5f919710ab3"
+    },
+    "maps/base_brk/baserub1.bsp": {
+     "bytes": 23612,
+     "sha256": "b5320b798366587d20ab541af06babd9575e89870fb003d56a17fdf2f7f22b0c"
+    },
+    "maps/base_brk/baserub1.map": {
+     "bytes": 637,
+     "sha256": "0a5357fb3b12d9286b4d9e6e54316cfd0a33f9fda4c661b8fcd1c461d06ae73f"
+    },
+    "maps/base_brk/bz8_brk.bsp": {
+     "bytes": 12808,
+     "sha256": "219e4371cd0b22d690c6e6660ca2fca3b526618d4ccd9f37799135d2dc6dea02"
+    },
+    "maps/base_brk/bz8_brk.map": {
+     "bytes": 692,
+     "sha256": "fae1ac45d74b2a9f482eb034e0838fe5914affb57204c5215d97ebaf7199e5c8"
+    },
+    "maps/base_brk/crate_r1.bsp": {
+     "bytes": 29110,
+     "sha256": "5dd3afab4a3ad5cf4466e272324e4afad5075ca2e662cc8b1932e277a2db73a2"
+    },
+    "maps/base_brk/crate_r1.map": {
+     "bytes": 664,
+     "sha256": "ee7ce39ec0650d3cbde924b99efc91ba884778db11a961037d4493bf587fa33e"
+    },
+    "maps/base_brk/explodebox_1.bsp": {
+     "bytes": 7707,
+     "sha256": "28bfab37e5cbe722348b753de3bd9f66f47f4a9f5b80bd5c5c1659e6eae7e6c4"
+    },
+    "maps/base_brk/explodebox_1.map": {
+     "bytes": 544,
+     "sha256": "96376f1185f158bf69d6bb0c5baf347bbad27f0ccd6fccd3096da6dd7f89540b"
+    },
+    "maps/base_brk/explodebox_2.bsp": {
+     "bytes": 7107,
+     "sha256": "59d5ba28bc049f691bf28d421327e4aecf5eedaec46599d58328f0074ce0934f"
+    },
+    "maps/base_brk/explodebox_2.map": {
+     "bytes": 375,
+     "sha256": "f906dbea8598f0290af9e224a70eb71f26f3c93c10e922b2fade3f1c63e4ddd5"
+    },
+    "maps/base_brk/explodebox_3.bsp": {
+     "bytes": 10449,
+     "sha256": "0daebb987f48b5dde145998e748ab2eecf63ec69318a6b752924e4cfb6639261"
+    },
+    "maps/base_brk/explodebox_3.map": {
+     "bytes": 1698,
+     "sha256": "538e12e7706df3b8f539bf2473e7517e737657380137de1655193843210dbf3f"
+    },
+    "maps/base_brk/glass01.bsp": {
+     "bytes": 7427,
+     "sha256": "bf3f3938ab3596b6095fb58f66c0a36042e5950169dbb86b1cf3cb9076fd5bdd"
+    },
+    "maps/base_brk/glass01.map": {
+     "bytes": 907,
+     "sha256": "6f47c3ffec4cb28d3447dbf96f0b3d6e4264accd31e10b68ad83b3e30e4e32a7"
+    },
+    "maps/base_brk/grate_r1.bsp": {
+     "bytes": 32796,
+     "sha256": "a8eac6a49f8c49c4f9f1b443c9ca5c6a5f8d03d30ce240daaeee8d150f9c5067"
+    },
+    "maps/base_brk/grate_r1.map": {
+     "bytes": 2106,
+     "sha256": "e5cac190d45b0d14901947e489622680d1b9436955b18e2a0e8cb2f92e9aa011"
+    },
+    "maps/base_brk/pbt04.bsp": {
+     "bytes": 18286,
+     "sha256": "0a3321e606857ebb78d047be51c92036b53175dc392c021891cdeabd28597c3c"
+    },
+    "maps/base_brk/pbt04.map": {
+     "bytes": 699,
+     "sha256": "a8b2d3feef56b8cad384a88a9646b596d21017cb9d26278c0b3585ef589b578d"
+    },
+    "maps/base_brk/phk_03brk.bsp": {
+     "bytes": 90417,
+     "sha256": "46efed3a00ce885798ca568563a04472200359c6111682e91fc701c37d8df143"
+    },
+    "maps/base_brk/phk_03brk.map": {
+     "bytes": 1509,
+     "sha256": "29549a0e23b3651110beae8f8697c85e1e3eeb8752dcc8c253a2756e11189209"
+    },
+    "maps/base_brk/rock_sw01.bsp": {
+     "bytes": 8843,
+     "sha256": "a3acc4f42ca89efb30d5f9d7ed7c694d59ab6003bd3c665cfa4db480550fd92d"
+    },
+    "maps/base_brk/rock_sw02.bsp": {
+     "bytes": 9179,
+     "sha256": "4b3d68587a69daa68093d32195a786e8040fed763855acb94f50d02875a8ec44"
+    },
+    "maps/base_brk/rock_sw03.bsp": {
+     "bytes": 9766,
+     "sha256": "59d2841166f7ecb216df970963b3e425da20566f2fb56a7e5472f4e3c9fcfb24"
+    },
+    "maps/base_brk/sfloor4_2.bsp": {
+     "bytes": 7431,
+     "sha256": "d4f7ee45638e0f338c96cf43779410a112bb10be26a200e24187749a80b01332"
+    },
+    "maps/base_brk/sfloor4_2.map": {
+     "bytes": 833,
+     "sha256": "f285b9a96b32420f24bccb267b268e65afd50dd03fb106fad90783aa5d82c1d4"
+    },
+    "maps/base_brk/tech10_2d1.bsp": {
+     "bytes": 45558,
+     "sha256": "272aa49909de27f7b4722848497e5da38aa50b7bef17ef2ee81a1b1240c1b8b2"
+    },
+    "maps/base_brk/tech10_2d1.map": {
+     "bytes": 740,
+     "sha256": "a3766904240cbe7603e967eb3ebdd0dc895b035f0db8758a6ad217749a332904"
+    },
+    "maps/base_brk/tech10_2d2.bsp": {
+     "bytes": 45552,
+     "sha256": "71e5e52660e4aa84f56aa7b51bad024384acb69699bcec431ae3fe6c8d16fc42"
+    },
+    "maps/base_brk/tech10_2d2.map": {
+     "bytes": 733,
+     "sha256": "9d6c4dae495d96bf4b2bbf5f7e01900f16274173c63eb2e4acfb8f8e757a399f"
+    },
+    "maps/medieval_brk/ad_column1.bsp": {
+     "bytes": 14800,
+     "sha256": "f94c99425b3987ebb9eea08dd8c1b3c0e0215cc8afcd1099f7283324ff566712"
+    },
+    "maps/medieval_brk/ad_column1.lit": {
+     "bytes": 578,
+     "sha256": "c30b5af83ab23db6614ad13aff712a15971a6b35ae29ddd49f0cd3da1c1f4919"
+    },
+    "maps/medieval_brk/ad_column1.map": {
+     "bytes": 1541,
+     "sha256": "d71326b819e902d9a32f4a1961565f6ebb10d90069ba2ae0dc0be381a4c1b764"
+    },
+    "maps/medieval_brk/ad_rock1.bsp": {
+     "bytes": 352852,
+     "sha256": "9333d2d2d848e3a4490634aa4f1cc1ee3281c57ac9a498c85b043e5856ce2578"
+    },
+    "maps/medieval_brk/ad_rock1.lit": {
+     "bytes": 920,
+     "sha256": "6d2b33cbd7b3ce1a35c25a6e006a0786fe0bd0ea8be34b1911e2663ac33ea910"
+    },
+    "maps/medieval_brk/ad_rock1.map": {
+     "bytes": 2163,
+     "sha256": "d00049f1c1bdf04d98e768ece39b7d7442e34b719ec991e5715df588d6493d8b"
+    },
+    "maps/medieval_brk/ad_rock2.bsp": {
+     "bytes": 14728,
+     "sha256": "52675efa81ecae4bb87524c97148d7da60916f0e0dc3c65e99b73745aea70fec"
+    },
+    "maps/medieval_brk/ad_rock2.lit": {
+     "bytes": 383,
+     "sha256": "306d2df8cbd9d7ad755fe7e4a6734e0089b38eefa2e2e4fccacfb68c96dd8d90"
+    },
+    "maps/medieval_brk/ad_rock2.map": {
+     "bytes": 1528,
+     "sha256": "891f208f7fdae3fcf1defe7a4cdcda7a6084fbde663ed4e2ab015af18911cb96"
+    },
+    "maps/medieval_brk/ad_rock3.bsp": {
+     "bytes": 352160,
+     "sha256": "bf041a139ed9be638cd1c548139fffca3ceeddefdad2334fcc2639018833110a"
+    },
+    "maps/medieval_brk/ad_rock3.lit": {
+     "bytes": 356,
+     "sha256": "19a61c05d08dd726a9d00174eb3eb1dbdd16da3e0e62ab93d691620aa71add83"
+    },
+    "maps/medieval_brk/ad_rock3.map": {
+     "bytes": 1878,
+     "sha256": "d0049b763f7fd8f25b2176984341421d704f9b50571b24168c60889fdbad5e20"
+    },
+    "maps/medieval_brk/ad_rock4.bsp": {
+     "bytes": 352704,
+     "sha256": "578e7d2dc0eff7bf5ac21b04919d1e137296824182d4809991a27a83addeba75"
+    },
+    "maps/medieval_brk/ad_rock4.lit": {
+     "bytes": 311,
+     "sha256": "3af5d5c9613dd5a1fa09a40b02891bf7153892db8505528b7d3315ce251bfff7"
+    },
+    "maps/medieval_brk/ad_rock4.map": {
+     "bytes": 1889,
+     "sha256": "472f41679eedc00096e8042935ad5287f4598940ef294b8175cccd196dcb6f86"
+    },
+    "maps/medieval_brk/az_ice05.bsp": {
+     "bytes": 98664,
+     "sha256": "b8b2aa063250f6dcc388ead43ff66133c8fa14b1c30afa17c2fce8f2b2c9fd81"
+    },
+    "maps/medieval_brk/az_ice05.lit": {
+     "bytes": 617,
+     "sha256": "e3e8aa044b60a26d643ff87937f83602cdffcebb948ea7ae22148e7952faa18b"
+    },
+    "maps/medieval_brk/az_ice05.map": {
+     "bytes": 3094,
+     "sha256": "dbca0fea0a986137f9b4a6fbb916cf3de830ba4a60738830cc6e1bd554f561f1"
+    },
+    "maps/medieval_brk/az_kbr1.bsp": {
+     "bytes": 7476,
+     "sha256": "2a2cd33b87f511d4c7fc25a812c632fb07c385b372e89fa900fd0f8ce8146076"
+    },
+    "maps/medieval_brk/az_kbr1.lit": {
+     "bytes": 92,
+     "sha256": "580ff7adf91b63bcd7f35e27059295b0a5fc404468e32e5d5f3323b5a822fb27"
+    },
+    "maps/medieval_brk/az_kbr1.map": {
+     "bytes": 863,
+     "sha256": "3b9d9842f17fb140b23337b452cfc8d49151410640384868a0003bd472dd0d5c"
+    },
+    "maps/medieval_brk/az_kbr1.pts": {
+     "bytes": 178,
+     "sha256": "22cf782552b8a3da946cfa0fa044cffd08f2b0ab50e588c9b68d89a373f026b0"
+    },
+    "maps/medieval_brk/az_kjw1.bsp": {
+     "bytes": 9424,
+     "sha256": "06f271813935ecb90a425d6c943bd53b207fb9d370ec42bb1228af92fe4413d1"
+    },
+    "maps/medieval_brk/az_kjw1.lit": {
+     "bytes": 380,
+     "sha256": "30e6270550b5a78bfaa31df0c6e477d6980eefd380abc2e2aaf7003dbe544f77"
+    },
+    "maps/medieval_brk/az_kjw1.map": {
+     "bytes": 1825,
+     "sha256": "61e8f8f45b2fb0e0766b125bae58b54b36cb45b6d856c7c06814681f52eb91aa"
+    },
+    "maps/medieval_brk/az_kjw1.pts": {
+     "bytes": 120,
+     "sha256": "f7d0f45d90befed57df8dd476bcd10293481eb932925853e3fdbc93a55991a49"
+    },
+    "maps/medieval_brk/az_rtex01.bsp": {
+     "bytes": 97932,
+     "sha256": "ce36fbfdd6f46f5aa7740598689fb2c7de50fa58adda9d4a8a3023ad31194367"
+    },
+    "maps/medieval_brk/az_rtex01.lit": {
+     "bytes": 692,
+     "sha256": "5fe28d309679e9871f14a9c3833184c9ad711fa2bd93adc330a34fd599032a6d"
+    },
+    "maps/medieval_brk/az_rtex01.map": {
+     "bytes": 2875,
+     "sha256": "6cc8f787b54565b3c9dffe9eec20c44d66a68b12fd555bad65bb25f03a2aa7e9"
+    },
+    "maps/medieval_brk/az_wood1.bsp": {
+     "bytes": 7560,
+     "sha256": "373c0b96905055b6b036272c954d7eaf3557d79d62b056ab9a472fb0cd27de83"
+    },
+    "maps/medieval_brk/az_wood1.lit": {
+     "bytes": 176,
+     "sha256": "67ce559200158ce198e5a93a94dd4a440ae607fedc5b3093c288049ce5f50151"
+    },
+    "maps/medieval_brk/az_wood1.map": {
+     "bytes": 950,
+     "sha256": "4fb7eae852ba72528b34d6a0947497eeeab1e1307aa1c4be552628432007c86e"
+    },
+    "maps/medieval_brk/azr1.bsp": {
+     "bytes": 13842,
+     "sha256": "e00518c5ad3beee852a6135184423d4ca985b17b2f1d2cfebc60e82f91582f26"
+    },
+    "maps/medieval_brk/azr1.map": {
+     "bytes": 1193,
+     "sha256": "ef3affe9788b130826f2b1632b5461eaaf15d630587c12c5a875f6042b0ae99c"
+    },
+    "maps/medieval_brk/azr2.bsp": {
+     "bytes": 13571,
+     "sha256": "687097f4773430ca297db9c1d8133b035c8ca1e5d574943a4caa34eef262f003"
+    },
+    "maps/medieval_brk/azr2.map": {
+     "bytes": 1319,
+     "sha256": "22b2084665b2882c976da1dc840a19b151cd44daa524955ddab9ec64e9c3233e"
+    },
+    "maps/medieval_brk/azr3.bsp": {
+     "bytes": 13571,
+     "sha256": "187a6607641c00aa6ee662af52f1b2899d5ca606e469408dd2c94d67dd2ab465"
+    },
+    "maps/medieval_brk/azr3.map": {
+     "bytes": 1338,
+     "sha256": "5e551a8ebefc386b1336e814a44e29ae6781e6da5bc929cb232674853c46a143"
+    },
+    "maps/medieval_brk/booksh1w_brk1.bsp": {
+     "bytes": 23869,
+     "sha256": "dbc342e95245a12598aade308195a3234829225944692c45c8fec792d03f17c3"
+    },
+    "maps/medieval_brk/booksh1w_brk1.map": {
+     "bytes": 793,
+     "sha256": "a9d2fe494267551f3d1638c7963bab47d292be250417f78286b39059af836af5"
+    },
+    "maps/medieval_brk/booksh1w_brk2.bsp": {
+     "bytes": 23663,
+     "sha256": "4b8cd15ae7812d581064800bbcf64cab62c3d5ecfb03c23ff2b498694a0cb708"
+    },
+    "maps/medieval_brk/booksh1w_brk2.map": {
+     "bytes": 661,
+     "sha256": "19c13935f0b045fadd9c739680de7155f0e4d29c86ef3e6950d07f265b1ef1a3"
+    },
+    "maps/medieval_brk/booksh1w_brk3.bsp": {
+     "bytes": 23700,
+     "sha256": "1fc3c7a685f5662779f4c6ad0fb02099396504dcf55eef09474183aff69861c1"
+    },
+    "maps/medieval_brk/booksh1w_brk3.map": {
+     "bytes": 746,
+     "sha256": "bd10960b3af925cf2a33bb0629d1a522de5f54ec05938b36378871fd7de0b9f3"
+    },
+    "maps/medieval_brk/booksh1w_brk5.bsp": {
+     "bytes": 23639,
+     "sha256": "851a02aced76ba77894ba744c5c781ff350a42b93216e095f75938fc95ee39a8"
+    },
+    "maps/medieval_brk/booksh1w_brk5.map": {
+     "bytes": 759,
+     "sha256": "c92ec0ad3d3a5c6588557b5f3c9c000cd1c141a4d9c3b35333d859e75c677568"
+    },
+    "maps/medieval_brk/brick2_4brk1.bsp": {
+     "bytes": 9004,
+     "sha256": "86fb182b011385225d5be8b2a2ba0763286a5a2a5880fdda6fc238d8e6a5212f"
+    },
+    "maps/medieval_brk/brick2_4brk1.map": {
+     "bytes": 1375,
+     "sha256": "208cf3d2a51b0aa4a45cd237786a9303b70a63a85e991a7f8675634bea6295ed"
+    },
+    "maps/medieval_brk/brick2_4brk2.bsp": {
+     "bytes": 7265,
+     "sha256": "151471ef184c02141716225e4403e97a69190bd8a3e9645cf2d52aeb5dce591d"
+    },
+    "maps/medieval_brk/brick2_4brk2.map": {
+     "bytes": 603,
+     "sha256": "cdd5762f851cec464b27e9bfc91c0eab8cb26e69a8b050ac1bd9b0eb662dbf7b"
+    },
+    "maps/medieval_brk/brick2_brk2.bsp": {
+     "bytes": 25323,
+     "sha256": "0d8c4dc3202bcc9f26dfd42ca555b99d0010c63b977cd058646a8e8ad4486eea"
+    },
+    "maps/medieval_brk/brick2_brk2.map": {
+     "bytes": 1378,
+     "sha256": "daeae48ab2f6fca712da2413b65c80c6a944e537571def2d153976b0175d8768"
+    },
+    "maps/medieval_brk/brick2_brk3.bsp": {
+     "bytes": 24310,
+     "sha256": "5f94a5e271bb5b921e4534be8690f005bc258e484cb842a6ead0af9aac29fcfb"
+    },
+    "maps/medieval_brk/brick2_brk3.map": {
+     "bytes": 905,
+     "sha256": "1639469c5fe31540811a8bb95d959844d200102cd19f60d1d5e9c3472477e2d2"
+    },
+    "maps/medieval_brk/brick2_brk4.bsp": {
+     "bytes": 23548,
+     "sha256": "e2049e826c103f2afbb5d0a4b69d45089d0bdcf6bd60646d6ae79c99e9a9a976"
+    },
+    "maps/medieval_brk/brick2_brk4.map": {
+     "bytes": 582,
+     "sha256": "b3528f92f4ecf8099a7bfbf3285f21312c501536b66e02b566a7e38474aa608c"
+    },
+    "maps/medieval_brk/city2_3d1.bsp": {
+     "bytes": 7358,
+     "sha256": "efc80ba0aab1284e2bcec652cc3a2748890c45d6905335f61483eab2851f7c81"
+    },
+    "maps/medieval_brk/city2_3d1.map": {
+     "bytes": 739,
+     "sha256": "ff9c2ebe0034d188443e3a72753d4ecad2a69706a4a06c114f9147f507d10b30"
+    },
+    "maps/medieval_brk/city2_3rd.bsp": {
+     "bytes": 7156,
+     "sha256": "6146e0e5961857308f2ef550213ec647ad810a97359d0946cc07f610e0f03006"
+    },
+    "maps/medieval_brk/city4_2_brk1.bsp": {
+     "bytes": 7435,
+     "sha256": "42a4cbd73804a8458a8369fdbd19ee6b3b4597b18583c242bf77b0122ddc9c1a"
+    },
+    "maps/medieval_brk/city4_2_brk1.map": {
+     "bytes": 648,
+     "sha256": "50b744f4af85aa3c0158ae0330808840710c7ee95c1bda8155cb81b4b247fc74"
+    },
+    "maps/medieval_brk/city4_2_brk2.bsp": {
+     "bytes": 7179,
+     "sha256": "cc2ddcb8877dc1b49ec2c408d6b869a35dd7b6590782525af567905d75a3ada0"
+    },
+    "maps/medieval_brk/city4_2_brk2.map": {
+     "bytes": 520,
+     "sha256": "e9309b8ec24126fd952443ae6bee72df46ba04fb4d0925b33d41c603af9ac5b3"
+    },
+    "maps/medieval_brk/city4_2_brk3.bsp": {
+     "bytes": 10009,
+     "sha256": "7f9a27098101f70090c3aff7fd6731effd2750e8c2b7fdbbb0a9f3146be94045"
+    },
+    "maps/medieval_brk/city4_2_brk3.map": {
+     "bytes": 1575,
+     "sha256": "c352d889a3bed731b7c54e38d7ed35e6fa860d2f6f69eb91319f4043423d7aa8"
+    },
+    "maps/medieval_brk/city6_8brk1.bsp": {
+     "bytes": 7187,
+     "sha256": "bcf4b2815c96308ffc1ab3467ac8b2dd4c25be47d618fd82536ba83bf74a05fc"
+    },
+    "maps/medieval_brk/city6_8brk1.map": {
+     "bytes": 529,
+     "sha256": "2db1be71ce1b1e8bf1e8a5c4c7f2802345aa19c281fd43f2b18d205cbd06bfca"
+    },
+    "maps/medieval_brk/city6_8brk2.bsp": {
+     "bytes": 7298,
+     "sha256": "3b7fd08defa832be1c3f3e40efc6d54d13af6714180be810f6527188f332fbff"
+    },
+    "maps/medieval_brk/city6_8brk2.map": {
+     "bytes": 611,
+     "sha256": "ed29b0773cb700d4b8212f9e28b23edac2d212f469b4a1406538df2b066fcbb2"
+    },
+    "maps/medieval_brk/floor015_brk1.bsp": {
+     "bytes": 12862,
+     "sha256": "5bfae9b09777fad7f26f80b5acc27e187e2259ac5c79ad32ab2a30d154e5889b"
+    },
+    "maps/medieval_brk/floor015_brk1.lit": {
+     "bytes": 179,
+     "sha256": "5d64872b2341768efce6c27686555200246e03d346a2e15089e002d53b1b348f"
+    },
+    "maps/medieval_brk/floor015_brk1.map": {
+     "bytes": 827,
+     "sha256": "08f5b26ee0ebb26416e6a1ed660e197b1ea113a553f5c7a1d26a6070b5cbdac8"
+    },
+    "maps/medieval_brk/floor015_brk2.bsp": {
+     "bytes": 12861,
+     "sha256": "377b50dac34c3789fe8a7bcf6a5b3cedda0f3ba91225135ffc9a2f41abe41e35"
+    },
+    "maps/medieval_brk/floor015_brk2.lit": {
+     "bytes": 188,
+     "sha256": "402bfba12b94cd1b3a40f1052830d4e4fa3b4cb103b196c089f4965e94766bd5"
+    },
+    "maps/medieval_brk/floor015_brk2.map": {
+     "bytes": 828,
+     "sha256": "a45245e0f19cc98f29bcc88c9173118b65058d25ff1c043aaca876353bc67531"
+    },
+    "maps/medieval_brk/floor015_brk3.bsp": {
+     "bytes": 13185,
+     "sha256": "52e2b8d426e479bffc8d518a4d8aa5d5a5dc437dbd761c7074992838ccfd070b"
+    },
+    "maps/medieval_brk/floor015_brk3.lit": {
+     "bytes": 218,
+     "sha256": "dabacc9c3ffdc3bae8c008bedfb683babaca23f6e5b0ca5e35b9c39f9d86f402"
+    },
+    "maps/medieval_brk/floor015_brk3.map": {
+     "bytes": 1078,
+     "sha256": "5235ba02c52ba6dc678f052e4efbad43b9f7d63f858c5f732519f6436246733d"
+    },
+    "maps/medieval_brk/plat_brk.bsp": {
+     "bytes": 59896,
+     "sha256": "367ec651b3cded1ecdf22305a3b48490d3df3078d556d4c7fadfb392ae12ad33"
+    },
+    "maps/medieval_brk/plat_brk.map": {
+     "bytes": 2052,
+     "sha256": "fe52fffba97e8df9acfe4607c9b08d9eb5f4559b44d8c0f6fdbd3af6a0cbf8d6"
+    },
+    "maps/medieval_brk/rock_sw01.bsp": {
+     "bytes": 8843,
+     "sha256": "a3acc4f42ca89efb30d5f9d7ed7c694d59ab6003bd3c665cfa4db480550fd92d"
+    },
+    "maps/medieval_brk/rock_sw01.map": {
+     "bytes": 1371,
+     "sha256": "0e4d621fba3a9806ffdf2bffda89e4d05231513b6f7986d504722d1b99c21a91"
+    },
+    "maps/medieval_brk/rock_sw02.bsp": {
+     "bytes": 9179,
+     "sha256": "4b3d68587a69daa68093d32195a786e8040fed763855acb94f50d02875a8ec44"
+    },
+    "maps/medieval_brk/rock_sw02.map": {
+     "bytes": 1631,
+     "sha256": "82bbf3c701301a80f55619bdac2680d9713432d8fe991838bfb7559830225322"
+    },
+    "maps/medieval_brk/rock_sw03.bsp": {
+     "bytes": 9766,
+     "sha256": "59d2841166f7ecb216df970963b3e425da20566f2fb56a7e5472f4e3c9fcfb24"
+    },
+    "maps/medieval_brk/rock_sw03.map": {
+     "bytes": 1526,
+     "sha256": "300f4c4f56cc9f6425cc8999484e18326555c57b8f53d9f42c36a4345b850d2c"
+    },
+    "maps/medieval_brk/rock_sw04.bsp": {
+     "bytes": 9836,
+     "sha256": "72854269a33665022dee9c30e53e6124bc2bba25ad34d2a3d86302e50ad795c1"
+    },
+    "maps/medieval_brk/rock_sw04.map": {
+     "bytes": 1605,
+     "sha256": "e2b3e6e53c11de10d0de4b7374d43a09be1622766cb3ff60c9e9cec8688747f9"
+    },
+    "maps/medieval_brk/rot_p.bsp": {
+     "bytes": 13554,
+     "sha256": "afcc7dc6512bba89ceec9e10bfa8256ecd043d34c1af57f33a199509500164ff"
+    },
+    "maps/medieval_brk/rot_p.map": {
+     "bytes": 2518,
+     "sha256": "c60e36e827e052cea6ca5c6c2d022b5da051090ee2accf8807f5703ec8acc79a"
+    },
+    "maps/medieval_brk/waa1.bsp": {
+     "bytes": 23869,
+     "sha256": "739aa8d0753e691020013539356d2c2e10b9d0b82c63bcc694080afe33bc585e"
+    },
+    "maps/medieval_brk/waa1.map": {
+     "bytes": 765,
+     "sha256": "f2e7bbba974ffde1e4178be825034e555ca491fffedbf007e62589214af82f0f"
+    },
+    "maps/medieval_brk/wbrick15_brk.bsp": {
+     "bytes": 7969,
+     "sha256": "0dcbd483c300f1be58a216b6d64ea385dd489babdc70868e483fb496c4dd4c38"
+    },
+    "maps/medieval_brk/wbrick15_brk.map": {
+     "bytes": 899,
+     "sha256": "43789ad5bb908aa7fb8e8893db766ce0e479cc547e31aa8de6fe1b4bd6093015"
+    },
+    "maps/medieval_brk/win1ah_brk.bsp": {
+     "bytes": 34981,
+     "sha256": "d549b60245213678c222499299e43654c25f838ed42898a25ec284d933f56b64"
+    },
+    "maps/medieval_brk/win1ah_brk.map": {
+     "bytes": 897,
+     "sha256": "da6859a14f291bef23c990977c0fce7e21ee2c790318cce46e36a8388e87fb39"
+    },
+    "maps/medieval_brk/win1ah_brk2.bsp": {
+     "bytes": 34873,
+     "sha256": "87416124f6e04adaaa5ed9144fa60e048dc03606bc294d89d99295a7c8cb2487"
+    },
+    "maps/medieval_brk/win1ah_brk2.map": {
+     "bytes": 901,
+     "sha256": "5d9a1aefeca5acfdbb25cad5489f5bcb41c89f3c9b92a3d305da0f462c439ec2"
+    },
+    "maps/medieval_brk/wiz14_brk1.bsp": {
+     "bytes": 8961,
+     "sha256": "cb45306588dc69d44422d475c0481f67a76638fe2502c16c28a8f87fa43f6787"
+    },
+    "maps/medieval_brk/wiz14_brk1.map": {
+     "bytes": 1262,
+     "sha256": "46200a77c401035e45d339d8106263e7210ed66e373be74f65687c5d1eb83124"
+    },
+    "maps/medieval_brk/wiz14_brk2.bsp": {
+     "bytes": 7338,
+     "sha256": "871684ecf4507da9773ca5568ccdd0a27173d2f35922b379a19f95e9252a777f"
+    },
+    "maps/medieval_brk/wiz14_brk2.map": {
+     "bytes": 652,
+     "sha256": "97a58529ea21e8127050b0f1e3305e4616b1970232e6517aa652061f49ffc9e0"
+    },
+    "maps/medieval_brk/ws14_brk1.bsp": {
+     "bytes": 7987,
+     "sha256": "ee96dcf614d940d9f887035be0781ad941fc5f76a0f0e553ec3592ae00af1794"
+    },
+    "maps/medieval_brk/ws14_brk1.map": {
+     "bytes": 948,
+     "sha256": "022d130b741c8976f529288f6030fabd2040991efd8bb0a6542dc1508c0b061c"
+    },
+    "maps/medieval_brk/ws14_brk2.bsp": {
+     "bytes": 9003,
+     "sha256": "6aa46294d8fffe55db6f2e6a9d30341fe07a9252b0066ff575c692d0b149f7af"
+    },
+    "maps/medieval_brk/ws14_brk2.map": {
+     "bytes": 1375,
+     "sha256": "8f175f2e3ac8a760fcb7d25da5a30cea149b55349fa0e0d20b2a8c0b080aa5b0"
+    },
+    "maps/medieval_brk/ws14_brk3.bsp": {
+     "bytes": 8944,
+     "sha256": "282944bfbd49b6dcc0aa0d67253432d88c63212ea564a9c6b8909a9b96f8946a"
+    },
+    "maps/medieval_brk/ws14_brk3.map": {
+     "bytes": 1282,
+     "sha256": "6ecd83ba25e15f363f271078c73f6c460babf95ea63340a855dfa182ec47e4b4"
+    },
+    "maps/rtex_brk/022a.bsp": {
+     "bytes": 17448,
+     "sha256": "3557f9518ca0982c871dd344ea5069e5128645029ea428de26ef991881170a59"
+    },
+    "maps/rtex_brk/022a.map": {
+     "bytes": 691,
+     "sha256": "50e0375bf596265b893e56996dbddfad26af2e50bb9af473dc2115e18b11dc02"
+    },
+    "maps/rtex_brk/022b.bsp": {
+     "bytes": 17608,
+     "sha256": "083fdbd34b34b47c5dd9dd58f4e3e0fa3debbedd554db4ce81791033349451fa"
+    },
+    "maps/rtex_brk/022b.map": {
+     "bytes": 825,
+     "sha256": "26d8800f4cfb0706ad363e958846d87755b4871792d1ac1f00b5b51fd7550777"
+    },
+    "maps/rtex_brk/022c.bsp": {
+     "bytes": 17820,
+     "sha256": "8c6b933d2cd323eba623727226ea6cb1f968e0401093f93d229d229a7a5b225d"
+    },
+    "maps/rtex_brk/022c.map": {
+     "bytes": 894,
+     "sha256": "835d4d09490552859dc79ad527bcd08af8afedfa7a863148c62f2f58742e9014"
+    },
+    "maps/rtex_brk/022d.bsp": {
+     "bytes": 17592,
+     "sha256": "0580ec01633972b2fff28c5d4b9a71766d3f1ed6fae387dff34ca691ff829e38"
+    },
+    "maps/rtex_brk/022d.map": {
+     "bytes": 784,
+     "sha256": "238fc24be385d3994586c34555e74ecbb7677aa7567bbf317947276c14b62107"
+    },
+    "maps/rtex_brk/330a.bsp": {
+     "bytes": 7928,
+     "sha256": "a446db4116b8c33f46745cf815ba9309e69591d919838006c81a9b0a5b00c7d4"
+    },
+    "maps/rtex_brk/330a.map": {
+     "bytes": 691,
+     "sha256": "964103ee6422dd3b815472c9f29126741e06517623dad050fba18a9867451903"
+    },
+    "maps/rtex_brk/330b.bsp": {
+     "bytes": 8088,
+     "sha256": "727d22fad028bac645a53ac5a425618e30575735958496b7a1ac86cfbc562e1a"
+    },
+    "maps/rtex_brk/330b.map": {
+     "bytes": 825,
+     "sha256": "807bdb97ab58709fd96cfa0e7b65cb5d377257b862eef2673606901d70b84108"
+    },
+    "maps/rtex_brk/330c.bsp": {
+     "bytes": 8300,
+     "sha256": "b25471a1f0e7fdd066dda47860ae956db2b2c4758a426b39b8a82e6b4c6d1b72"
+    },
+    "maps/rtex_brk/330c.map": {
+     "bytes": 894,
+     "sha256": "13241951b0d3cd61a71e0fe80071a1df65e369eba44aabdf3401f3ba5aa55a7f"
+    },
+    "maps/rtex_brk/330d.bsp": {
+     "bytes": 8072,
+     "sha256": "8f83245e973c42e9908b6215c5effc0f0581d654e5e8e67a6e77493f79de3e6d"
+    },
+    "maps/rtex_brk/330d.map": {
+     "bytes": 784,
+     "sha256": "f0e46c1efc3d5a814675f5760a33a2e6bc4163974ff64a4c1f88ab70c50fbb68"
+    },
+    "maps/rtex_brk/340a.bsp": {
+     "bytes": 13368,
+     "sha256": "e8a605fdff44ef59b4657a43a67cfb24d2d62f150b210a0761f69ed5f559215c"
+    },
+    "maps/rtex_brk/340a.map": {
+     "bytes": 691,
+     "sha256": "3678f5058497a6067c7ffb4d452e706af588e0aedfd30bfa2d43f1902333e7ec"
+    },
+    "maps/rtex_brk/340b.bsp": {
+     "bytes": 13528,
+     "sha256": "d92cc6afb7ae74965a8bb2a753909e2dc6c064b5fb2c9c463c95123531ba337d"
+    },
+    "maps/rtex_brk/340b.map": {
+     "bytes": 825,
+     "sha256": "29f243aa1c347358e34383f4ffb2d129f710829022524237585041c7840a02cb"
+    },
+    "maps/rtex_brk/340c.bsp": {
+     "bytes": 13740,
+     "sha256": "882a110b1a7e26481e5dd37858d5229c0273bc98ab8a2ab59f318e2b76080fac"
+    },
+    "maps/rtex_brk/340c.map": {
+     "bytes": 894,
+     "sha256": "069e17115ae35cf0fdaa9ceb8b3a67065360d4fc03f91036ba453b6b6745d77b"
+    },
+    "maps/rtex_brk/340d.bsp": {
+     "bytes": 13512,
+     "sha256": "96a6133331679ad8eb75d8581e8be12c6822d2048c18a1e704281a6e4cc0737c"
+    },
+    "maps/rtex_brk/340d.map": {
+     "bytes": 784,
+     "sha256": "b8197ea047f14d175e5b9234dcc9b625f04124b175bb0fd80da7ceffe056b00c"
+    },
+    "maps/rtex_brk/413ra.bsp": {
+     "bytes": 7972,
+     "sha256": "a3cc5962750f55c398dfaf53cb4d8394f1100c752ca9797f053ec2710acd995d"
+    },
+    "maps/rtex_brk/413ra.map": {
+     "bytes": 769,
+     "sha256": "b0a3052bfb352684f97fb7bca8fdc3d7b135ae5e3fca491d190d09423836da46"
+    },
+    "maps/rtex_brk/413rb.bsp": {
+     "bytes": 9204,
+     "sha256": "e36bf5d23b3dcaf96075b1b441ebf6424da62cb2d04ff14f04da4e9956711094"
+    },
+    "maps/rtex_brk/413rb.map": {
+     "bytes": 1682,
+     "sha256": "6be0d7cbae08ffccbb1ea9dedf03bc6f8c9b6be93c6c27d5e964e3b4f4538a52"
+    },
+    "maps/rtex_brk/413rc.bsp": {
+     "bytes": 10340,
+     "sha256": "4d57717cc2fb9db560e724df4937f7c496d77d1df6d70e6619ba686338152e79"
+    },
+    "maps/rtex_brk/413rc.map": {
+     "bytes": 1909,
+     "sha256": "71c9812cdf0647bb89fcd2a911a664b7a8dea382b0fe58e4e834a24354a23b38"
+    },
+    "maps/rtex_brk/413rd.bsp": {
+     "bytes": 13356,
+     "sha256": "573149ae9d1f687b0ddc0a702116357b4556e20ae8d62b7b32b3c5b41f227088"
+    },
+    "maps/rtex_brk/413rd.map": {
+     "bytes": 3217,
+     "sha256": "f40b142b102fefefdaf6594c2d1410f370fd8491a009ecfc6dada46c55f262d2"
+    },
+    "maps/rtex_brk/wood3_1a.bsp": {
+     "bytes": 7552,
+     "sha256": "8884a645d6193052aeba7043c139b3eb4cf8ace2e62ed6e9181d51f90cae4806"
+    },
+    "maps/rtex_brk/wood3_1a.map": {
+     "bytes": 1007,
+     "sha256": "5322a91b2aad8cf58095fb513e58317d738469c168b78f770307c3ece580fbf9"
+    },
+    "maps/rtex_brk/wood3_1b.bsp": {
+     "bytes": 7096,
+     "sha256": "9d7d44ba1c929fae0bf702ec834394c9da23c199cf742f9c7021bec00f33c056"
+    },
+    "maps/rtex_brk/wood3_1b.map": {
+     "bytes": 516,
+     "sha256": "158e6d102aaeb8dd7add01eecd7e05b4c711a20d7d7134d1bdce417fbe1b2072"
+    },
+    "maps/rtex_brk/wood3_1c.bsp": {
+     "bytes": 7144,
+     "sha256": "f292d3b9cabaa0332d7c3f6abd66420ad9ef80217f32223bd67315fa8967d908"
+    },
+    "maps/rtex_brk/wood3_1c.map": {
+     "bytes": 517,
+     "sha256": "f853df961fdcebd569943bad596dceb464c6317e44f3d77ce4def17295b37c00"
+    },
+    "maps/rtex_brk/wood3_1d.bsp": {
+     "bytes": 7804,
+     "sha256": "8e6ffa915db57d7cb958c7210e0abc35ff552713a5aa19a1ccb531a7d45bd504"
+    },
+    "maps/rtex_brk/wood3_1d.map": {
+     "bytes": 883,
+     "sha256": "d370c44a047023843caf08a41098bd3852526b614ae074c228cc6ad4e76d4aa9"
+    },
+    "maps/speedbz_brk/crate_r1.bsp": {
+     "bytes": 29110,
+     "sha256": "5dd3afab4a3ad5cf4466e272324e4afad5075ca2e662cc8b1932e277a2db73a2"
+    },
+    "maps/speedbz_brk/crate_r1.map": {
+     "bytes": 664,
+     "sha256": "ee7ce39ec0650d3cbde924b99efc91ba884778db11a961037d4493bf587fa33e"
+    },
+    "maps/speedbz_brk/door1.bsp": {
+     "bytes": 31200,
+     "sha256": "6df38f4db1bfd725dd7384b45e38d070fd4b514139a8e649aea3e640377a073d"
+    },
+    "maps/speedbz_brk/door1.map": {
+     "bytes": 1419,
+     "sha256": "17bf053113ed5cc14e99ef2880e5478ebace7d59de4797fc6cbfe3586d688494"
+    },
+    "maps/speedbz_brk/door2.bsp": {
+     "bytes": 29732,
+     "sha256": "8f58cd2f2e76fbb36a007ed7986671092b880d01dfcb9a087e93cd11240d2baf"
+    },
+    "maps/speedbz_brk/door2.map": {
+     "bytes": 726,
+     "sha256": "3fac703869c9ebb4eabfbe8f180fec752812eea0aa68c5f5574c5cf2496c3931"
+    },
+    "maps/speedbz_brk/door3.bsp": {
+     "bytes": 26516,
+     "sha256": "77f003456362f2b7ca424491485ad2d20b162598527765e5e78628ee7e6ad172"
+    },
+    "maps/speedbz_brk/door3.map": {
+     "bytes": 1247,
+     "sha256": "e56d45f63dcb0d86a0039ea443109d8c8d116fa18331a2328e90f74a891ab9d2"
+    },
+    "maps/speedbz_brk/door4.bsp": {
+     "bytes": 24020,
+     "sha256": "930881a45210317dd3550b04b20d2446cf92c8c613d4aa295a5c77810b77b3f2"
+    },
+    "maps/speedbz_brk/door4.map": {
+     "bytes": 611,
+     "sha256": "f4a68b8f4d081ff0febc276c51b5484c96e4b044eab6e20069ae84ac7c5a0ac2"
+    },
+    "maps/speedbz_brk/rock1.bsp": {
+     "bytes": 89984,
+     "sha256": "c87f60de56cfd5a932cf33d23d6e83b0fd16518001dd8fa7be84da9c3176b5b5"
+    },
+    "maps/speedbz_brk/rock1.map": {
+     "bytes": 980,
+     "sha256": "29e5bd54316e6f325d71a33051ee3a5b6c213f927222931bb35cdcc1820cc87a"
+    },
+    "maps/speedbz_brk/rock2.bsp": {
+     "bytes": 90012,
+     "sha256": "443e51be48da3594545d347ee056f3973b0360268eb6c03653d7b3af622c553e"
+    },
+    "maps/speedbz_brk/rock2.map": {
+     "bytes": 991,
+     "sha256": "40b6b9f23f788c08f362f2336048bbe1260f181d7e76de2591ea7aefa03f4b09"
+    },
+    "maps/speedbz_brk/spdcrate_r1.bsp": {
+     "bytes": 12844,
+     "sha256": "30fa3f373efefcf7db68a9acbb0eb282a0b2ea54d26db92eaaad444035462791"
+    },
+    "maps/speedbz_brk/spdcrate_r1.map": {
+     "bytes": 807,
+     "sha256": "c18735f305c2496a4801ed1a5bc1297f2d72e55824f7222a265ac5788552fc68"
+    },
+    "maps/speedbz_brk/speedbzvent1.bsp": {
+     "bytes": 15248,
+     "sha256": "bcfe36bf57cb82e5188b86af3e5bf568038ef5a50d0ebce43024155b7276008d"
+    },
+    "maps/speedbz_brk/speedbzvent1.map": {
+     "bytes": 2053,
+     "sha256": "7d447bc22e440e685648d8b39e051bce7c1b847e3f777ac092ab1104b79242a1"
+    },
+    "maps/speedbz_brk/speedbzvent2.bsp": {
+     "bytes": 14104,
+     "sha256": "8fb1e76688e27767ce77c5d7b3486048adfa284e011b91007730d424eb55ca61"
+    },
+    "maps/speedbz_brk/speedbzvent2.map": {
+     "bytes": 1381,
+     "sha256": "44cfc0509c9455865df334c1ca5bdfca49cf0fae4dab372cac99e6eeb76b438c"
+    }
+   },
    "sha256": "6ca3099935998e8678b388cd5bb1e1c601f1035da378141b6e800303b8737f02",
    "timestamp": "2022-12-19T15:15:26.000Z"
   },
   "tcj/pak2.pak": {
    "bytes": 13867395,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 94990,
+     "sha256": "e790b189b1df23f116097b45f5ed391fd210319ecfa000d029b367a7c3d32ab5"
+    },
+    "maps/bmodels/az_chain1.bsp": {
+     "bytes": 219668,
+     "sha256": "4d2648c6dd850b04d48e9631ad02756ecf78d85f56810ff7b9db131a6fe641a3"
+    },
+    "maps/bmodels/az_chain1.lit": {
+     "bytes": 33272,
+     "sha256": "1daab5bb58dbf2c73968dc9db26cf0b0bd78652d491788d0a6124aaa9a9b6f4a"
+    },
+    "maps/bmodels/az_chain1.map": {
+     "bytes": 96430,
+     "sha256": "2b6c77f844eaf5a371b36c13cf512a24d8cd39095cdc04eddd64cd571060d098"
+    },
+    "maps/bmodels/az_chain2.bsp": {
+     "bytes": 333820,
+     "sha256": "746e38bbb4cebb63ac3344e944f24b874b9fd3ed584017bb599e027508cc6187"
+    },
+    "maps/bmodels/az_chain2.lit": {
+     "bytes": 22130,
+     "sha256": "c6ebc72f8dcaa06422eaf71e08771f76105ddd39c3ee6784d40083df67d1cf32"
+    },
+    "maps/bmodels/az_chain2.map": {
+     "bytes": 148314,
+     "sha256": "e9cb3cddd08835aed7b1eed8867a67b06fee9db20dd7584830b8918d4af169ea"
+    },
+    "maps/bmodels/az_chain3.bsp": {
+     "bytes": 308800,
+     "sha256": "6b78b5a83f2f71a316e85086e12b7a1f66abaf28b02a53076433e3b2b3a20fee"
+    },
+    "maps/bmodels/az_chain3.lit": {
+     "bytes": 20684,
+     "sha256": "28870bf7c7f011206290fe69c7b6e2501c27fba21bea2ae6767e8d85a4ff56e7"
+    },
+    "maps/bmodels/az_chain3.map": {
+     "bytes": 110405,
+     "sha256": "64eee084713fdb7da2ec9f9dbc7c482930d9a871d86fd0912d32ddf52063b1aa"
+    },
+    "maps/bmodels/m_bchains1.bsp": {
+     "bytes": 74963,
+     "sha256": "73beb2dc0b953e096e69a4e049af380e99c98ce1872b4da00c858be36d4e973a"
+    },
+    "maps/bmodels/m_bchains1.map": {
+     "bytes": 43470,
+     "sha256": "ecd781a6601c6fca262909cb2e116a222de2e5aa5417dd36d4475d5c433459af"
+    },
+    "maps/bmodels/m_bchains2.bsp": {
+     "bytes": 83651,
+     "sha256": "e23fad6717790c08e661748398754e60944527eb6e48c0f2c0ffbdba73cf95db"
+    },
+    "maps/bmodels/m_bchains2.map": {
+     "bytes": 42484,
+     "sha256": "e92865750499de9117e5bf19719052109179ebcc37ddbd40f2d91d914b86fa63"
+    },
+    "maps/bmodels/m_bridge1.bsp": {
+     "bytes": 431144,
+     "sha256": "ac4d490408f7ad9068a09c4c89f82a65b8573bc4ba810fe5f16418b1d2684f66"
+    },
+    "maps/bmodels/m_bridge1.lit": {
+     "bytes": 47240,
+     "sha256": "30601eb0d533bbe0f72631b77630c3922a46f34b38687aa184b7776e48e63164"
+    },
+    "maps/bmodels/m_bridge1.map": {
+     "bytes": 120280,
+     "sha256": "3ddec67bb95d788b2fecb0e4c6d09781a6a27ba79d322a637f3a03e84a8f6ac7"
+    },
+    "maps/bmodels/m_bridge2.bsp": {
+     "bytes": 201392,
+     "sha256": "4fec9b73e50ba0608d2b5f2fd5c4957324c4cb609becf3be979aedf644281845"
+    },
+    "maps/bmodels/m_bridge2.lit": {
+     "bytes": 21902,
+     "sha256": "c1fa88042c3fde27bd608d3829c8c4a142e70617087970ec7535d48847ac435a"
+    },
+    "maps/bmodels/m_bridge2.map": {
+     "bytes": 52004,
+     "sha256": "58943dc439d4d4c8e65773c12e361c3336488a94f0a53a54c06366675517b850"
+    },
+    "maps/bmodels/m_bridge2b.bsp": {
+     "bytes": 201398,
+     "sha256": "096dcacf528d2784b79a4c0dd19c445102778f2a053fde3a2a43540a4a621c73"
+    },
+    "maps/bmodels/m_bridge2b.lit": {
+     "bytes": 21902,
+     "sha256": "1c7bdad93866cabb97e4565bf41d2b8a8d4c8237e11b0965fd05fc954b6c2c64"
+    },
+    "maps/bmodels/m_bridge2b.map": {
+     "bytes": 52268,
+     "sha256": "d361d0c3dcfec2ae5d109075bf437d013762328ee48b8fc25f779267d7b1bfb1"
+    },
+    "maps/bmodels/m_bridge3.bsp": {
+     "bytes": 309343,
+     "sha256": "12d2199af263464d48455c2e5cd7bf2abf2085841fbc7e027a4cc96b04eec2d8"
+    },
+    "maps/bmodels/m_bridge3.lit": {
+     "bytes": 46964,
+     "sha256": "b783061b14bb4caf3cf9df9a6b8be9ea1d2a367339fa09ffe01506022b21a4c5"
+    },
+    "maps/bmodels/m_bridge3.map": {
+     "bytes": 138104,
+     "sha256": "33c8835d256fd00e65da818c4d43b86033bb8104897712b824014a035c2628e0"
+    },
+    "maps/bmodels/m_chains1.bsp": {
+     "bytes": 249145,
+     "sha256": "1f51d881982d8602c0da29c1f105ab07a41977bdab4fbf4598922563373f4a98"
+    },
+    "maps/bmodels/m_chains1.map": {
+     "bytes": 170858,
+     "sha256": "e1855a52ab0ae70c382876eb74fcafe5a065fefeb2e49a6956184637b9edc1bd"
+    },
+    "maps/bmodels/m_chains2.bsp": {
+     "bytes": 134457,
+     "sha256": "57a765e0ec315eca93927ad64e11b9b3ec8adae0c405de55d86c30b30ef51e5a"
+    },
+    "maps/bmodels/m_chains2.lit": {
+     "bytes": 15698,
+     "sha256": "c858c4c47488df5cac3ed19736c1aee29f4c7add0dfb45deeb7416c4c7af1f21"
+    },
+    "maps/bmodels/m_chains2.map": {
+     "bytes": 60423,
+     "sha256": "575ae8d717a2352ac8726b3bc0f11f6e0a83f548dd471a544a62f519bb71f692"
+    },
+    "maps/bmodels/m_chains2l.bsp": {
+     "bytes": 156552,
+     "sha256": "ff04a994c83f27104d6ef126ef2d08ce894ebe0a812c49f0d2ae79ce8808e8b9"
+    },
+    "maps/bmodels/m_chains2l.lit": {
+     "bytes": 15698,
+     "sha256": "9ebbd1a675e167d9a3be233cd65654728f2f1e0259dee00f55e3da02802abfa2"
+    },
+    "maps/bmodels/m_chains2l.map": {
+     "bytes": 61112,
+     "sha256": "346320204a3413bd6654018e37e42c442c21d88e15da513395c73e6daee26bed"
+    },
+    "maps/bmodels/m_chains2p.bsp": {
+     "bytes": 156555,
+     "sha256": "f0778b1608dbb058f1f492848ae3b64f66be0fef54e32bddfd6fe09f7b0e7a74"
+    },
+    "maps/bmodels/m_chains2p.lit": {
+     "bytes": 15704,
+     "sha256": "d2e7187908b4d3823091a9d69cce5ac807507372132b4162e48a6b027ecad53a"
+    },
+    "maps/bmodels/m_chains2p.map": {
+     "bytes": 61117,
+     "sha256": "7d1acdf4240cd91b158bbc23dfab846388efa7d20431f5a9c8dba8ab421102ff"
+    },
+    "maps/bmodels/m_chains2r.bsp": {
+     "bytes": 222620,
+     "sha256": "0e1ad04fd73c4bc183331471a3406665660fd8f030d14404b7c43b31309118e0"
+    },
+    "maps/bmodels/m_chains2r.lit": {
+     "bytes": 17552,
+     "sha256": "605d297ff2ece6796c064e3dd47e1c48e4fdc87324f059f2c1721e369de23a97"
+    },
+    "maps/bmodels/m_chains2r.map": {
+     "bytes": 61788,
+     "sha256": "749cc23346335d05a53b3399f49adb157fe29fe24512a65d3ab976bc811b5818"
+    },
+    "maps/bmodels/m_chains2rl.bsp": {
+     "bytes": 151968,
+     "sha256": "653185afe2384bf68c0e6d35bdd3404196404243a1b8d16cb730de9f7a45b4b0"
+    },
+    "maps/bmodels/m_chains2rl.lit": {
+     "bytes": 17552,
+     "sha256": "ef313b8c77329539ca8bbe6831e7d5b372e4e3f3cc807e6b66901b53f83d82d4"
+    },
+    "maps/bmodels/m_chains2rl.map": {
+     "bytes": 62332,
+     "sha256": "f5961359ef0867c6ecd501231f63912bf4066bb4d65685021efcd0d51d637f95"
+    },
+    "maps/bmodels/m_chains3.bsp": {
+     "bytes": 121996,
+     "sha256": "535075d6549167b5bf61ae91abf2c407ee009e64aa4222be35692478151feab1"
+    },
+    "maps/bmodels/m_chains3.map": {
+     "bytes": 57540,
+     "sha256": "08f7d97d9e8cd45c353d1141905c93d3327d8f77984790d9e952bd91a5247803"
+    },
+    "maps/bmodels/m_chains4.bsp": {
+     "bytes": 203735,
+     "sha256": "2840e2b604d571081a2b13ba2d340f596123b53213aaec8cd695e7a4d668e774"
+    },
+    "maps/bmodels/m_chains4.map": {
+     "bytes": 113061,
+     "sha256": "6727d20079382f7f2a76391d72e6b6bc3136cc6396ef4661b679f5c8f82d8427"
+    },
+    "maps/bmodels/m_chains4p.bsp": {
+     "bytes": 205127,
+     "sha256": "20183038acde1a46c9fae81e86837f876dc6e0bb7cc7a556457d4162264d7358"
+    },
+    "maps/bmodels/m_chains4p.lit": {
+     "bytes": 35897,
+     "sha256": "0dfb9177bd73b903703f0f4630c4941467a452ee676d568e7f32b2099699659d"
+    },
+    "maps/bmodels/m_chains4p.map": {
+     "bytes": 112283,
+     "sha256": "09d773ef730e9b4d81cdf23f4ac3b0efcb365771569638e7f5574407c5560146"
+    },
+    "maps/bmodels/m_chains5.bsp": {
+     "bytes": 94806,
+     "sha256": "04c40fce5016a3d26092812be589344740b29be788921f8ce354461d77943817"
+    },
+    "maps/bmodels/m_chains5.map": {
+     "bytes": 44835,
+     "sha256": "1e897fc203a12a480c1d3dfc13bf7653a06edb8132f98a3fedae50614c3ebb34"
+    },
+    "maps/bmodels/m_chains5l.bsp": {
+     "bytes": 117061,
+     "sha256": "f01c9c1e6f87c0588be0df3f8768f563acea6735451efa41366aa0acb63851db"
+    },
+    "maps/bmodels/m_chains5l.map": {
+     "bytes": 45411,
+     "sha256": "64691e385435777a920358775cb18e7ac6ee5290a34488103753a338500b6db5"
+    },
+    "maps/bmodels/m_chains5p.bsp": {
+     "bytes": 117214,
+     "sha256": "555df3c945155f7b820fde49c3e37d114f3c52bb63c4edb647dbc19161cb13d5"
+    },
+    "maps/bmodels/m_chains5p.lit": {
+     "bytes": 9152,
+     "sha256": "f78aaec615854b6382b6802298f42ac42dcdfdfb9c638b417257876fa83200d9"
+    },
+    "maps/bmodels/m_chains5p.map": {
+     "bytes": 45566,
+     "sha256": "1969841b81be135b7cb383f84bf7d38694d012b35b17ef3e2c630afbf5d6e64d"
+    },
+    "maps/bmodels/m_thanshelf.bsp": {
+     "bytes": 140335,
+     "sha256": "8319f2ba87d5a8ed864941fe9c7341744476be658ce211aaafc1ba0747afeac4"
+    },
+    "maps/bmodels/m_thanshelf.lit": {
+     "bytes": 3134,
+     "sha256": "04fd93ccf6b864bd9226faa29db923bc093200ed3f4fc8a8f6cce29b324a9743"
+    },
+    "maps/bmodels/m_thanshelf.map": {
+     "bytes": 10306,
+     "sha256": "811e75bc34627545ff7513dc658e937195b98b7839bad409bf21da4975fb7e03"
+    },
+    "maps/bmodels/misc_radar.map": {
+     "bytes": 5314,
+     "sha256": "7ca088f70d4421b994f1852dd17de1427a2b6401b19d8f464ecf2024f5025418"
+    },
+    "maps/bmodels/sep_chain2.bsp": {
+     "bytes": 130276,
+     "sha256": "eff6d1868abd6355f4858f41657262ebb87fa9093579eb8abe8ac6f8c8880ee6"
+    },
+    "maps/bmodels/sep_chain2.lit": {
+     "bytes": 15716,
+     "sha256": "311947b14d5363ccc34fd6e32205100b612c8a77c66196dc616192b011375b59"
+    },
+    "maps/bmodels/sep_chain2.map": {
+     "bytes": 80569,
+     "sha256": "7d86dc46adc6a01b96b811021484c1e6cbfb61424f1037be59525d6f1ff2c420"
+    },
+    "maps/bmodels/sep_chain3.bsp": {
+     "bytes": 80956,
+     "sha256": "8a811a3fc8f85373d64fb3840bda3a3af63a138498bc051ddb2b0d1e0cfa9e88"
+    },
+    "maps/bmodels/sep_chain3.lit": {
+     "bytes": 10802,
+     "sha256": "50d0f90c43a132a5cb360cbb25521040632f07726c6ccfb482d3740ec940ad05"
+    },
+    "maps/bmodels/sep_chain3.map": {
+     "bytes": 41124,
+     "sha256": "ef40d6b17d8b9fc880e4a8180336554f37dabfbc8a30b78c485793aaa5dd753b"
+    },
+    "my_progs/ai_ammoresist.qc": {
+     "bytes": 7444,
+     "sha256": "d530fec92f23ed0c3d09560abb9a89bdc160ce1aefdfbe4f4771f9897ae3fc4d"
+    },
+    "my_progs/ai_checkattack.qc": {
+     "bytes": 106456,
+     "sha256": "7971ca5a87666c89b56ab0fcc102e6f551f3cd3b03bdfc0bfb73f5f8d5aed7fb"
+    },
+    "my_progs/ai_combat.qc": {
+     "bytes": 24324,
+     "sha256": "30c07395259db46836e544a68a37527f107e9010e4d64e937476ceafa58c82b8"
+    },
+    "my_progs/ai_enemytarget.qc": {
+     "bytes": 8409,
+     "sha256": "f4b0a35306d50e71fd9043ae949a421158ee9fcc4e311baf7b8fa2d345c4d46e"
+    },
+    "my_progs/ai_explosion.qc": {
+     "bytes": 12162,
+     "sha256": "7df941a7cf93b814ae9d90f646a5b0243a51db67872f621df73d43c6000ba3ab"
+    },
+    "my_progs/ai_gibs.qc": {
+     "bytes": 32373,
+     "sha256": "65e202300882ba8f0c980f65820b2d2e0bd06846073168f4bd7e37f2357f47d4"
+    },
+    "my_progs/ai_hazards.qc": {
+     "bytes": 26832,
+     "sha256": "81aace80121408f64369bc2bbfd5654650276ddd75217333d2a52364415acaa5"
+    },
+    "my_progs/ai_minions.qc": {
+     "bytes": 10236,
+     "sha256": "3e7bd34dfe0e73a11e6907d5ac69cb609eee19dff533689ea7c8eabe52500136"
+    },
+    "my_progs/ai_passive.qc": {
+     "bytes": 8224,
+     "sha256": "44473544d0da0dc778c2800a16172ab49b548286b604c9d6361f4bc4cfc1f076"
+    },
+    "my_progs/ai_pathcorner.qc": {
+     "bytes": 20921,
+     "sha256": "b3d6ed2434e0b995da51a71715647096e36e02d8cf920e18e024f920ed69238a"
+    },
+    "my_progs/ai_projectiles.qc": {
+     "bytes": 86253,
+     "sha256": "d0885ed945602af45d7db1d98be5938412cd750154ed06710b6b781b6c49abc3"
+    },
+    "my_progs/ai_states.qc": {
+     "bytes": 7480,
+     "sha256": "76fae861132b0e50006ef88ea94a953e718b661defad2ea58a4ecad5cab92dee"
+    },
+    "my_progs/ai_subs.qc": {
+     "bytes": 51485,
+     "sha256": "41a23217543056b1ea447fcf2e0dc2c06a87bdf70dc3f6f699454d7c3c900377"
+    },
+    "my_progs/ai_tether.qc": {
+     "bytes": 6470,
+     "sha256": "2229c0ea1b76e45f5707a3eca9e7626e33f8ea91d6b292da63c81723e1ae8521"
+    },
+    "my_progs/breakable.qc": {
+     "bytes": 79687,
+     "sha256": "754831599eec85a774501d9fd0a1ec7d5722ea6a6e01655b5ad74988145045af"
+    },
+    "my_progs/chaosmode.qc": {
+     "bytes": 81481,
+     "sha256": "01561dc4f1949716eba4d08f83efe27b71add80f923c1e2d89194c238772a646"
+    },
+    "my_progs/client.qc": {
+     "bytes": 70441,
+     "sha256": "00e2d4aff96ea28b0532ab0b03de0a8cdcf15750164ec82bdc8f43b9f2347447"
+    },
+    "my_progs/client_advinfo.qc": {
+     "bytes": 59677,
+     "sha256": "87aaca8bfd15935e1cd29a807bf77a2779d95418af631a6b456c6605710694fe"
+    },
+    "my_progs/client_camera.qc": {
+     "bytes": 13007,
+     "sha256": "ff4748b04c15d9a3b44dd8069f9347c12487ef353d5401a13542166576097889"
+    },
+    "my_progs/client_cshift.qc": {
+     "bytes": 725,
+     "sha256": "da1e321fe01bae486ffcdd987a942a4b0d5b2f603efb663d52c55e882f129685"
+    },
+    "my_progs/client_debuff.qc": {
+     "bytes": 15761,
+     "sha256": "0e0c9123697241ab3a366dbc46fcb90b8553b65c94cffe1442254a74a2753efd"
+    },
+    "my_progs/client_evilmode.qc": {
+     "bytes": 6982,
+     "sha256": "2cfa3bbeb36ab623c3bb137028ec5f549a2e5d2198fa2ab7fd8a445e14f4fc10"
+    },
+    "my_progs/client_ghook.qc": {
+     "bytes": 51884,
+     "sha256": "43d071195a70caa66b57cca1778679d772478fd1f71cbad7ee267e254e79a29a"
+    },
+    "my_progs/client_info.qc": {
+     "bytes": 13693,
+     "sha256": "55653ddc2b9f3cf2ca3cf1b0afdc4c1685baf1ab3c3830eb9f8b1b2d51b3ff31"
+    },
+    "my_progs/client_mapvar.qc": {
+     "bytes": 13177,
+     "sha256": "c692fa41644e6d21c945493dd891af945a072a4b39e687d1b59c86d14ee804a0"
+    },
+    "my_progs/client_power.qc": {
+     "bytes": 20157,
+     "sha256": "0309073577003ae832b259ede75ba53c49bd89985b08d98000d03e1a44893705"
+    },
+    "my_progs/csqc_defs.qc": {
+     "bytes": 21072,
+     "sha256": "eddc5f194845e78a1633807d32b1da4425bdbe7bcce193e3868bc3995e2dee9b"
+    },
+    "my_progs/csqc_defsclient.qc": {
+     "bytes": 35002,
+     "sha256": "b6674acae135dfbc5e3dbb147e69acdc6b3564b766792359bed3e4eb800705e9"
+    },
+    "my_progs/csqc_hudad.qc": {
+     "bytes": 104391,
+     "sha256": "1ca012e489dc5f6026bdae469f411b5bb25afa00e00d5169cbd35b578a7ad9f2"
+    },
+    "my_progs/csqc_hudvanilla.qc": {
+     "bytes": 37074,
+     "sha256": "c5caa6ba176185c05903d383f3ae41907129d859419a0c0bf909b0e8d3e8af5a"
+    },
+    "my_progs/csqc_progs.src": {
+     "bytes": 113,
+     "sha256": "e383fc0920e9676d92e0be81d69cd8017ed5baf9fc0616a05773de68208ce434"
+    },
+    "my_progs/defs.qc": {
+     "bytes": 31974,
+     "sha256": "1534874cf4d70c5614dedecb70f6d428fc32832ce3345c2cb51fd6058a514902"
+    },
+    "my_progs/defsclass.qc": {
+     "bytes": 24401,
+     "sha256": "811c390be7b31fd4b276410ef1a75406bbca8fb84dc195484835a6100e9cddb4"
+    },
+    "my_progs/defscustom.qc": {
+     "bytes": 95932,
+     "sha256": "c8e66698b225cac3821bf4b098e7c8b16d0babaf7f5c1a5a32006c0c1dd96eee"
+    },
+    "my_progs/dpextensions.qc": {
+     "bytes": 122912,
+     "sha256": "3758f58ebaa4186e9112da89f7ea53087eef5058a32ebc373a1ffda76c1d67a2"
+    },
+    "my_progs/estate.qc": {
+     "bytes": 7745,
+     "sha256": "9cceb71ae54b331c2702f5580094f9055d007b9e710dd5e61c7c632724022626"
+    },
+    "my_progs/fteextensions.qc": {
+     "bytes": 215531,
+     "sha256": "beb86ad10bb0726de10dd2557d6285f7bf40f08f9d30e06315c3772f8c256571"
+    },
+    "my_progs/func.qc": {
+     "bytes": 47039,
+     "sha256": "3102c5ce52ec7a15c329079fc7ca97fa249dca32c4124bad49c2853d38e5c741"
+    },
+    "my_progs/func_buttons.qc": {
+     "bytes": 13271,
+     "sha256": "9e1bd197b2367ab2b8f1c776c214a0c51120559e8d8f0b4888b262b7a1e746f0"
+    },
+    "my_progs/func_doors.qc": {
+     "bytes": 35874,
+     "sha256": "58dbdf05f0044aefdd13ee21d17045a681d255efaca6d129fbd1cec4ae516fc9"
+    },
+    "my_progs/func_doorsecret.qc": {
+     "bytes": 14379,
+     "sha256": "769a3142ccaf18060ff77b0eab57d901585202fbfe63a54ce25d4987b80f92d3"
+    },
+    "my_progs/func_insvolume.qc": {
+     "bytes": 10573,
+     "sha256": "1deaf4623a6fae80585d2d2b1978b1cd217b6f8a683ef3bbc3a77a2897e9a207"
+    },
+    "my_progs/func_plats.qc": {
+     "bytes": 11685,
+     "sha256": "5086c9aba8bbf83d29c3e1897c7867cb24220712007044792928f474216b7ea4"
+    },
+    "my_progs/func_pswitch.qc": {
+     "bytes": 8373,
+     "sha256": "b3a205176d80801216a930241508b3c5718f4be9e1b947932ace2851c34271d8"
+    },
+    "my_progs/func_trains.qc": {
+     "bytes": 26553,
+     "sha256": "81d8de4f3dff80b8523584fb5e37d8d4812a6f7f95a559edff320682217ad123"
+    },
+    "my_progs/globalfog.qc": {
+     "bytes": 18397,
+     "sha256": "84ec244a475ac41b9da772042123f58f4005130590f170f85f1b23ad53629f27"
+    },
+    "my_progs/hiprot.qc": {
+     "bytes": 31978,
+     "sha256": "82875db9fecd8bacd2c42232fb980e6a510a6863103273e2c9078dfe7c6759c5"
+    },
+    "my_progs/hipspawn.qc": {
+     "bytes": 2752,
+     "sha256": "6df8450b85821c1a76f5ccb3c807ac9b94e92f413f16f2ba618f922abf85148f"
+    },
+    "my_progs/items.qc": {
+     "bytes": 165150,
+     "sha256": "fbcc57975032c97ffea723870e39ebc2d2c4bbd9650fb5d20b3dfcecc6f6f93a"
+    },
+    "my_progs/items_progspn.qc": {
+     "bytes": 20628,
+     "sha256": "2f4824cb28192145a8fabc2da6575db3398e8f81522ab1e026d696ec87313650"
+    },
+    "my_progs/lights.qc": {
+     "bytes": 43912,
+     "sha256": "d0e0c373bb3cc68c7c9121a62c68085ff9cc290daa6faf0adab02323d8ef92bb"
+    },
+    "my_progs/mathlib.qc": {
+     "bytes": 22355,
+     "sha256": "b161ebb89a11f302427c4f124731ec38def8eb01347beb5d748a9ba4afb886f8"
+    },
+    "my_progs/misc.qc": {
+     "bytes": 85890,
+     "sha256": "6b3e8a0882d47f16ff7f54fb37a48e3a7853647f8895718e6428739c4207099a"
+    },
+    "my_progs/misc_camera.qc": {
+     "bytes": 43852,
+     "sha256": "61448a8f0354f39dd26371ae56dadbc903b08282293145a27088ac6c151ea547"
+    },
+    "my_progs/misc_model.qc": {
+     "bytes": 32157,
+     "sha256": "9afc9d440672288ffada6256a20aa0f969464907e942fab0c1556cdb28162237"
+    },
+    "my_progs/misc_targetdummy.qc": {
+     "bytes": 15123,
+     "sha256": "bcd0a0ae806ce20a8c8cfcc27178ce1b4ead3a546d927b6a261ce51a6086c253"
+    },
+    "my_progs/misc_textbook.qc": {
+     "bytes": 26321,
+     "sha256": "14bf42536a5cc75990d938a79d7bd21bde1c166245d94d8e662f9e6fd66e0ae8"
+    },
+    "my_progs/mon_baron.qc": {
+     "bytes": 31318,
+     "sha256": "b76a10da34dabf3411ddf650abcdbc77e3ebcdfebace6191a39e7c0b13a0fad5"
+    },
+    "my_progs/mon_boil.qc": {
+     "bytes": 19821,
+     "sha256": "050b21bda5341a3f81dcb21e6d7d82d458a415fd8f1cfa12435228246229a323"
+    },
+    "my_progs/mon_bossboglord.qc": {
+     "bytes": 24005,
+     "sha256": "e67081b7a5218b361c62bf4b201a18db16f3e75716ad2729c11a0616b137975a"
+    },
+    "my_progs/mon_bosseidolon.qc": {
+     "bytes": 40134,
+     "sha256": "c51eb9b9d67cadfa7178891a238329a60ad57edc3f6ef645060695b451833115"
+    },
+    "my_progs/mon_bossfiretop.qc": {
+     "bytes": 14734,
+     "sha256": "26672c9c2d1577f8caf9894b8eb5eecacac89f64251257bc25db48b1bf43a7bb"
+    },
+    "my_progs/mon_bossicegolem.qc": {
+     "bytes": 47205,
+     "sha256": "5b888302a6af24ce823919d1349c1c92e1ee709d72e79042425349368a4d65fb"
+    },
+    "my_progs/mon_bossidchthon.qc": {
+     "bytes": 20247,
+     "sha256": "65d955fb1434f806962fadc088aa5933e96ed8aa9f1211d0709a3f462ffa3027"
+    },
+    "my_progs/mon_bossidshub.qc": {
+     "bytes": 14639,
+     "sha256": "fdd0e8f8fa374ea0164f79ef1bf74ca942f04c63159f360c7a43011673774fe6"
+    },
+    "my_progs/mon_bossjudicator.qc": {
+     "bytes": 81432,
+     "sha256": "f5092f376eeef22f0a552c846f50175680c15a5c37d9603c6e3d2635661127b3"
+    },
+    "my_progs/mon_bossmammoth.qc": {
+     "bytes": 84963,
+     "sha256": "6cda415b846b2aeb215c0eebc7cdfa6a5560255df9aa014f77b48aa7073b8d34"
+    },
+    "my_progs/mon_bossnour.qc": {
+     "bytes": 45682,
+     "sha256": "d3aa7e0c62e9001887b1b0895607b512f6d9aeeb44bca544f6c900c86adbc03c"
+    },
+    "my_progs/mon_bossxxchthon.qc": {
+     "bytes": 22614,
+     "sha256": "2c1c0446b0f6a5b7a7921e8f8830c71c174d30c6f176d228a94afd9a05fdc25a"
+    },
+    "my_progs/mon_bossxxshub.qc": {
+     "bytes": 19006,
+     "sha256": "043ebc852ba7f0a06812cb0afd72d32a3da643df1dea45c87fb821f60fbcc332"
+    },
+    "my_progs/mon_centurion.qc": {
+     "bytes": 13734,
+     "sha256": "641e1c09c6df27b033e331140d242f25d27bf7f9bb83733a6b5b3469a5c7ffee"
+    },
+    "my_progs/mon_dcrossbow.qc": {
+     "bytes": 38069,
+     "sha256": "3296618a4b803fb6f1b44c1d32c17692a5bed13cf63102c6dcc58481223197a8"
+    },
+    "my_progs/mon_deflector.qc": {
+     "bytes": 32107,
+     "sha256": "d7a9344878a3a846a7e720ce704820d424362281a1675c40be7b670eca9fe342"
+    },
+    "my_progs/mon_demon.qc": {
+     "bytes": 14601,
+     "sha256": "d77f128e3f91737228c5a24b7ca146f6b4f8e87dbaac31b1ad4e79779884d0d7"
+    },
+    "my_progs/mon_dfury.qc": {
+     "bytes": 39867,
+     "sha256": "a016db202f2a418aee50cb7cce2155a24a6b807e8c98fc49a5f9273ce79c6da8"
+    },
+    "my_progs/mon_dguard.qc": {
+     "bytes": 28414,
+     "sha256": "0a2b964034559f4ca772f9f29be2c56684fd39290277046a6f7642ba934836eb"
+    },
+    "my_progs/mon_dguardquoth.qc": {
+     "bytes": 18932,
+     "sha256": "4caeb17520104cba42476ff7757f38ba6d72e941674b851f55a5c9780ce4de17"
+    },
+    "my_progs/mon_dknight.qc": {
+     "bytes": 36867,
+     "sha256": "68008427374e9ab670b6ad915c7a0f8eaf6a6699efa927a3748ae6cde86458e6"
+    },
+    "my_progs/mon_dlord.qc": {
+     "bytes": 22859,
+     "sha256": "09ca1edd4e65a166a66ba17e682aae9a1be09b05371a72dd1bc447389693bfa5"
+    },
+    "my_progs/mon_dog.qc": {
+     "bytes": 18431,
+     "sha256": "1b345447176aec54f18c31f5da215e80cb2de19f51d353c63a98507d881c2a9b"
+    },
+    "my_progs/mon_dprince.qc": {
+     "bytes": 33590,
+     "sha256": "5114caa7b6152e562e548096e41da68f43c910a5016ddaed408272a97a8320c1"
+    },
+    "my_progs/mon_drole.qc": {
+     "bytes": 25472,
+     "sha256": "36a510e910ce4ffa26d2d2ad336872c07537077ea920132a4cfd63d9133fb6af"
+    },
+    "my_progs/mon_dsergeant.qc": {
+     "bytes": 33493,
+     "sha256": "ada0cc4359a863c4e8d433c605a1c04ec6f7fd17ec852f5c4847443d3adaff1d"
+    },
+    "my_progs/mon_eel.qc": {
+     "bytes": 8252,
+     "sha256": "15c1f2fedba7077d352595e1be4a90f764354e4cf1875b40e1685d3ce81feb54"
+    },
+    "my_progs/mon_enforcer.qc": {
+     "bytes": 20146,
+     "sha256": "d453651d488afa789d0cea87ce99d9684329bbabdd17aa1625591f5a4b4ac90b"
+    },
+    "my_progs/mon_fish.qc": {
+     "bytes": 9705,
+     "sha256": "ff7d84db2c7917861ff5d81fe0e28f69d51143d27c4fba90dfcda11057222df0"
+    },
+    "my_progs/mon_floyd.qc": {
+     "bytes": 20332,
+     "sha256": "3ac2f0b0be94e311ff2fc4eee9cf66d5987af0e5c25fc06b8cc7b9efa6f581df"
+    },
+    "my_progs/mon_freddie.qc": {
+     "bytes": 25384,
+     "sha256": "4409a33e819f125852d0a4ada21a8fed2713012daec00922446f313031c845d1"
+    },
+    "my_progs/mon_gargoyle.qc": {
+     "bytes": 24293,
+     "sha256": "9e1f78b2364024efa6ec4142c1ecf4aff52cdf32f38031c34cf19e9cd74143d6"
+    },
+    "my_progs/mon_gaunt.qc": {
+     "bytes": 24111,
+     "sha256": "45be98ae0bdd32e0884280e18f867af037f2fcbf515914827c5f9107a87e52d7"
+    },
+    "my_progs/mon_golem.qc": {
+     "bytes": 35297,
+     "sha256": "dbaf3d1c0fec3166b0eb064a3c027dd3a0c907bed72b8e4581ffd74dad5ab5d1"
+    },
+    "my_progs/mon_hknight.qc": {
+     "bytes": 37618,
+     "sha256": "bac7d4b7832b95cea0f6890de66fbd0f7c4fcc7ce9051ef16ac042de465ddcb3"
+    },
+    "my_progs/mon_hogre.qc": {
+     "bytes": 24021,
+     "sha256": "8781ea9aaaa1d0f7ffb1fd8ec8b5981187eee6fdb8193160a1eb38770dffcfe0"
+    },
+    "my_progs/mon_hogreham.qc": {
+     "bytes": 23076,
+     "sha256": "b2ab6b830ce3aae7d6b033e8455de5011ded82e451ca171ea09940d9a3ec7740"
+    },
+    "my_progs/mon_hogremac.qc": {
+     "bytes": 23941,
+     "sha256": "9111c040ab1e5487936cce6ef1170e408c6d297d582702d202bbd27b0919d843"
+    },
+    "my_progs/mon_invsword.qc": {
+     "bytes": 9214,
+     "sha256": "f7287867cc6043eb7cd3fa3e1ecd5ae7115a84e5ef7021b2d5129afdb6ba6f46"
+    },
+    "my_progs/mon_jim.qc": {
+     "bytes": 22091,
+     "sha256": "55353984ad822dfd8c32f3b8ad9a06e8bfaab7bc5ff6f2a2326674ad4acd26be"
+    },
+    "my_progs/mon_knight.qc": {
+     "bytes": 24772,
+     "sha256": "d254abf88162436b9db48885ae8e59315c24c1e7f72a91d027a1d69fe9baf5b7"
+    },
+    "my_progs/mon_lostsoul.qc": {
+     "bytes": 23261,
+     "sha256": "2cdbf656c6b34164711fa88016542f4e3d2bd0555417ad00bab5ca7039f212ef"
+    },
+    "my_progs/mon_minotaur.qc": {
+     "bytes": 35316,
+     "sha256": "fbcef276ee3e2f1eeea8483303538190875e959b43efbf4f703be10fc72fc564"
+    },
+    "my_progs/mon_ogre.qc": {
+     "bytes": 24123,
+     "sha256": "d287d3b9024025237dbc68380f486572828a5114f9543599ba86b8bc35e9e25e"
+    },
+    "my_progs/mon_ogrextra.qc": {
+     "bytes": 9387,
+     "sha256": "41a9243c6006326195197a4dfba6ea4c1f1fbd729ec10adc48cfd7badd7a18de"
+    },
+    "my_progs/mon_pyro.qc": {
+     "bytes": 18235,
+     "sha256": "bd35f02c63af315ddf4820e388d0248cf065f1170bd7306957a1e86fa7e47306"
+    },
+    "my_progs/mon_scorpion.qc": {
+     "bytes": 22136,
+     "sha256": "0432d7c5e1b6a30a5452aba12b9fb6a3c2c7f3c582b1392d420414e66b8fb257"
+    },
+    "my_progs/mon_seeker.qc": {
+     "bytes": 29703,
+     "sha256": "d33939357840eedbfc63c56d6415d8fefd21de2c477b24b3165cdadcca2acd2c"
+    },
+    "my_progs/mon_sentinel.qc": {
+     "bytes": 10217,
+     "sha256": "946232c7169bf3fa966ce875523dd45402772f8045c51a96dced04f2f5f5788f"
+    },
+    "my_progs/mon_shalrath.qc": {
+     "bytes": 16434,
+     "sha256": "1b6fdf2447d7fa281d126118a9bc0e097de7b4dd4d10a33e60d5cf0ca785c58b"
+    },
+    "my_progs/mon_shambler.qc": {
+     "bytes": 23050,
+     "sha256": "576f71a38d75eedbdf58c291055674be8da5f0d04540e26311d65f70b58ee842"
+    },
+    "my_progs/mon_skullwiz.qc": {
+     "bytes": 36245,
+     "sha256": "6d3c2242bffe6eabe3f9cc59e881cb2296213cfbff809e1be045a80ca46aac53"
+    },
+    "my_progs/mon_soldier.qc": {
+     "bytes": 21645,
+     "sha256": "704c534062b11c4fc16416154c7706c125221660cdd4d9b02e00575b94c04103"
+    },
+    "my_progs/mon_spider.qc": {
+     "bytes": 30593,
+     "sha256": "4d0bbb7e38e51cef07912e6071e6bb9739e019a2d93129d38dbab9492bf43aee"
+    },
+    "my_progs/mon_steelclaw.qc": {
+     "bytes": 17126,
+     "sha256": "78dd4bb46dd76b2ff1f7d4a9f0b0902f25d94ebe13ace6b997a7f604c3718700"
+    },
+    "my_progs/mon_swampling.qc": {
+     "bytes": 25637,
+     "sha256": "fb5ed328cd3d5c09704bb84f39138463a7d26b8b1d45771e55e9ae952b1d2470"
+    },
+    "my_progs/mon_sweeper.qc": {
+     "bytes": 27025,
+     "sha256": "8f7a1d077779d88d542a325c1ae4ba4ff59d48bfcb334150ae3f024525bb725e"
+    },
+    "my_progs/mon_tarbaby.qc": {
+     "bytes": 11866,
+     "sha256": "88c9481ab7fe0cbe97d2b836492ff51b368aeae8d4ff3e5852734bb9f63a1b2d"
+    },
+    "my_progs/mon_turretbal.qc": {
+     "bytes": 38519,
+     "sha256": "fdcf915248dda5fb6a744d284233d46a2e6d62c8e4fd02fdd5bafe4f46167d30"
+    },
+    "my_progs/mon_voreling.qc": {
+     "bytes": 27678,
+     "sha256": "7734614fa6b2da2195bf3804415c06a2d10f35825e86abf4f85613a182cf21c2"
+    },
+    "my_progs/mon_wizard.qc": {
+     "bytes": 15155,
+     "sha256": "3101ca37b57343697b3d3c7637fdc84c842f78ec9081e401dcaa6df0a9b1df83"
+    },
+    "my_progs/mon_wraith.qc": {
+     "bytes": 35464,
+     "sha256": "6a28a205cb8ac574e98c8d34a01ea859922e38d55c66346a7aa867ebf84bdb5b"
+    },
+    "my_progs/mon_xmas_elf.qc": {
+     "bytes": 17589,
+     "sha256": "053eec412485090ee1ebeac25887382db40e2ba7ca456050ba4407be3ec8bc1a"
+    },
+    "my_progs/mon_xmas_raindeer.qc": {
+     "bytes": 12189,
+     "sha256": "abbe1dd5c96c25b631231d4db2f17e8243075ad08c082e0448b7cbff34f1ae0c"
+    },
+    "my_progs/mon_xmas_santa.qc": {
+     "bytes": 17853,
+     "sha256": "cc60c6de17bc3321f9b1cf75b3229e387592c9eb7fc4bb57c1de0a8d2c0e62e6"
+    },
+    "my_progs/mon_xmas_snowman.qc": {
+     "bytes": 11486,
+     "sha256": "65928bb70cb2e9352c2f5e036eda2a6bd97aea09d459d0af563a82aa5a2f2673"
+    },
+    "my_progs/mon_zombie.qc": {
+     "bytes": 33988,
+     "sha256": "83f56482374c3a79fcc64058989bd210af3add006b7388d89c92e90543ec56a0"
+    },
+    "my_progs/mon_zombiek.qc": {
+     "bytes": 42214,
+     "sha256": "2b9926454484e93f5c053bf4fd35b2a97cf7e835c26c3b30061f1ff391af9f5e"
+    },
+    "my_progs/monsters.qc": {
+     "bytes": 56573,
+     "sha256": "c2c75832e6d5e83e929214ba5c1aa9a4661bcaf7754c20b3e9648171bf804a58"
+    },
+    "my_progs/part_emitter.qc": {
+     "bytes": 82744,
+     "sha256": "fca7491171d58974ef6b15550b9a7f0474641e9eac7ee5de52c6980c96445518"
+    },
+    "my_progs/part_generate.qc": {
+     "bytes": 42914,
+     "sha256": "83b9718a85418143d92ea8311cc8cce69c1002eb7563710dfe7010ac52e15d50"
+    },
+    "my_progs/part_manage.qc": {
+     "bytes": 27407,
+     "sha256": "86eb791f4bba08fc0c965e9f81c90e7412ed2c910104d66a56cce1f3152808fe"
+    },
+    "my_progs/player.qc": {
+     "bytes": 27811,
+     "sha256": "1f0cc3eaf577c2af642495466c573cd6e226a4754902d9de9cbfc9c9ba28af0f"
+    },
+    "my_progs/progs.src": {
+     "bytes": 2482,
+     "sha256": "c773f107c562f731fbb30158422226bdc4576dd32aea0f02c122195e08eac96f"
+    },
+    "my_progs/pushable.qc": {
+     "bytes": 19823,
+     "sha256": "03b3bf9240db6e9532e45a3efc159129709f9ce095c3238daae32daddd5b07ec"
+    },
+    "my_progs/qc_highlight.xml": {
+     "bytes": 6348,
+     "sha256": "a7b326723cc1e4025e867ea5da00f54c944705600d740538aeb52f63cd027ab5"
+    },
+    "my_progs/settings.qc": {
+     "bytes": 62244,
+     "sha256": "78d9b19077028f9fd72f271aaae3d75b43e995ef95b7679df83a06fcdfbaf4f5"
+    },
+    "my_progs/sounds.qc": {
+     "bytes": 19389,
+     "sha256": "bb74ecc36a241db5a79b010f61200687c6db6e46297db39c8a2a8ce1d512bad5"
+    },
+    "my_progs/sprites.qc": {
+     "bytes": 476,
+     "sha256": "579f48b397914b02f8fb86dc24f23d4e63a4cd857df1f0eaefd6c83e9c49e238"
+    },
+    "my_progs/subs.qc": {
+     "bytes": 24000,
+     "sha256": "48832d667d7a932661ac914bc8e471843f2cd8a0985fc0458d7e1a2796e21d16"
+    },
+    "my_progs/subs_soc.qc": {
+     "bytes": 28453,
+     "sha256": "679112275e8b3597daac962074f69b6d9fd5614fc3dbff036815b9365e1413c5"
+    },
+    "my_progs/switchshad.qc": {
+     "bytes": 7054,
+     "sha256": "92a2fd4e5c41f21f46502781322ab87584bf0999d733db50e0e19b8bbea793b3"
+    },
+    "my_progs/targets.qc": {
+     "bytes": 58758,
+     "sha256": "e39b45bf6740be40c2899376e92d30d7d227a4762091d7b63e382c79fe6822e7"
+    },
+    "my_progs/traps.qc": {
+     "bytes": 24071,
+     "sha256": "9e4e822a36113bc73958fa45ab0b8c290a5148c95f3a4da7125676c984ebd202"
+    },
+    "my_progs/traps_pendulum.qc": {
+     "bytes": 17049,
+     "sha256": "b421f26fd80eb74715172e25f3ac992faa95397dd67d5f7ede286fd78384a468"
+    },
+    "my_progs/traps_sawblade.qc": {
+     "bytes": 9783,
+     "sha256": "9a6e82a05f09001c0a9cffdf6b9d6399691846c5b1ab1fbfb470e5772a87f44b"
+    },
+    "my_progs/triggers.qc": {
+     "bytes": 139722,
+     "sha256": "0ead1e997492dfe79a8c811a48b902217aafcd4bf3c49acea7101c99892886f3"
+    },
+    "my_progs/triggers_states.qc": {
+     "bytes": 17475,
+     "sha256": "2c4d25c11de0319cd54d81e67e651c8d29d22aca851988d21080ba5976137f14"
+    },
+    "my_progs/weapons.qc": {
+     "bytes": 44884,
+     "sha256": "d22ff6c46a101964e5e8e334a8d91ae8854e2eb6ca2c4565fcfc748acfcfd9e6"
+    },
+    "my_progs/world.qc": {
+     "bytes": 39815,
+     "sha256": "c160b7b050cc7a718fbc6ffe3dbfad85514936522bbabeb8ee4fb1a3c30b79d3"
+    },
+    "progs.dat": {
+     "bytes": 2347206,
+     "sha256": "5e69fece92fb4323609c8e1209a39eecf4f70c3161ae17beb53063fe3e06c340"
+    }
+   },
    "sha256": "49bb1a23ffda3e24edba1f4094ab4e031f570e8dccba7ca363b7096bbf0b84c1",
    "timestamp": "2022-12-19T15:15:26.000Z"
   },

--- a/json/by-sha256/11/117844ed26d81c7d40e6faf45cfad4787a71b864707290b6584bfcc625637765.json
+++ b/json/by-sha256/11/117844ed26d81c7d40e6faf45cfad4787a71b864707290b6584bfcc625637765.json
@@ -7,6 +7,24 @@
  "files": {
   "PAK0.PAK": {
    "bytes": 2382294,
+   "files": {
+    "demo1.dem": {
+     "bytes": 587024,
+     "sha256": "fa48d670f66cb656f63e5592216875ddc79e590b1caffbc075e3f5c548d51001"
+    },
+    "maps/temple.bsp": {
+     "bytes": 1333028,
+     "sha256": "e53470a29f5605d2c49856081e6800a4c08dd13cf8933f5ea0a37f29a0eb2275"
+    },
+    "progs.dat": {
+     "bytes": 420484,
+     "sha256": "a1ffbc1eabb64322ad691c141da09e21429b87cc4893f6f6984470849f8472bf"
+    },
+    "sound/ambience/thunder1.wav": {
+     "bytes": 41490,
+     "sha256": "c91c0ed95b95ec4341936f03f8958ac22475e38ce57be77ba839efe90925c3a5"
+    }
+   },
    "sha256": "5a6cb17190ae456b6e2a2e93f38617574e8892918bf2582e6a0c9559eed44585",
    "timestamp": "1997-10-21T14:15:16.000Z"
   },

--- a/json/by-sha256/11/11837c6bc4f279e7d8e755f1d7fbec9099b81668cb0c676c90ce0276c0c1361c.json
+++ b/json/by-sha256/11/11837c6bc4f279e7d8e755f1d7fbec9099b81668cb0c676c90ce0276c0c1361c.json
@@ -12,6 +12,112 @@
   },
   "pak0.pak": {
    "bytes": 6957786,
+   "files": {
+    "lunsp1.txt": {
+     "bytes": 5768,
+     "sha256": "30ead361ec5717d1aa83a49dbe183e12183f2bd8baed19d150c4b5428568ca41"
+    },
+    "maps/lunsp1.bsp": {
+     "bytes": 4799520,
+     "sha256": "579ea0636572e2ffe623f458d6f14101b53e215bd0cf50743aebec95b23526b0"
+    },
+    "progs.dat": {
+     "bytes": 444692,
+     "sha256": "545ba489dab65cba938b9cda7795878ed80e7218db000a30fb7f91f4a46ed6dd"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 191852,
+     "sha256": "9a1094db9a9a1018fef5103ac9641ea2ade6fe493bd9b44fe59576ae5f51a2b2"
+    },
+    "progs/boss.mdl": {
+     "bytes": 211836,
+     "sha256": "7b823975ab3765f5f490f175c33c26df9350e862a820e50255b2f81621ca5e7c"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 276136,
+     "sha256": "82bdcd3b2bba43872e2d0488118df4bde6b0122c8ceb489c1d90008431c792d6"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 32508,
+     "sha256": "499672202f3c38a8ab706d213d484adf2788b32d22c4fd8c2d61009786befa4e"
+    },
+    "progs/laser2.mdl": {
+     "bytes": 11348,
+     "sha256": "bf2a07924612bc136d63d881fddb82926dbb66af12ecd3716389e96ffde90759"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 8788,
+     "sha256": "6abc446260a90c3c2a0182f510f42a19a6f4da2c721f70201f4dc9a576b28e1a"
+    },
+    "sound/ambience/buzz1.wav": {
+     "bytes": 253670,
+     "sha256": "07d1ca11d700121413f62993b477de5d29435c1d407d024a6778b60775df0fb7"
+    },
+    "sound/ambience/fl_hum1.wav": {
+     "bytes": 50152,
+     "sha256": "c531b57b6859ba0a2ced84325a5b8845877557e84b26a59938f33bdbc9160e91"
+    },
+    "sound/doors/lundoor1.wav": {
+     "bytes": 124748,
+     "sha256": "763bf8b16a79eff3a1dcc11eaed7581fe7c8d963f1ec0ed102fad3ea130b8fcf"
+    },
+    "sound/doors/lundoor2.wav": {
+     "bytes": 80232,
+     "sha256": "44c0c99f81b4a047e6cb7260e41871018c9d4e7fcb9fe5b4bf33ef5f5e6db0c1"
+    },
+    "sound/enforcer/me_fire1.wav": {
+     "bytes": 35136,
+     "sha256": "eb601f114e636ae62c255d9b6567dd83682400e428d20f9f9087967bebf88e1f"
+    },
+    "sound/enforcer/ue_die1.wav": {
+     "bytes": 50988,
+     "sha256": "df6fa72f6b54f58c03430a2f9de837cd752c3e2090d52e5a3574759fb94e501d"
+    },
+    "sound/enforcer/ue_die2.wav": {
+     "bytes": 43192,
+     "sha256": "6b606f051603226c71df2f5f699c5b1f2041febb9da9aedc2366ce2c5f058cc8"
+    },
+    "sound/enforcer/ue_die3.wav": {
+     "bytes": 45058,
+     "sha256": "3e2267a6996e7b80e7f590c3219a46665ef68c3652d428d6e757d76d62fd1505"
+    },
+    "sound/enforcer/ue_fire1.wav": {
+     "bytes": 26306,
+     "sha256": "04fc98e42709c9a5d1a8bbd52aff9114b4922da324e30d21859bcf8209e55b4f"
+    },
+    "sound/enforcer/ue_pain1.wav": {
+     "bytes": 33530,
+     "sha256": "1c253421e2e841f0c5ae0b53167c21260fffeebda2d5eadbcf2e24417668f98f"
+    },
+    "sound/enforcer/ue_pain2.wav": {
+     "bytes": 36056,
+     "sha256": "6c04ce0b1340bad65a2a032c021cc94b9a55645adb0f4789dab9611c559f2db6"
+    },
+    "sound/enforcer/ue_pain3.wav": {
+     "bytes": 27162,
+     "sha256": "3fa2c91e936e493a2ac5dc8e625b027d0024144f176174c0264a6a538fd91ed6"
+    },
+    "sound/enforcer/ue_site1.wav": {
+     "bytes": 46266,
+     "sha256": "d57a6987bcd84ad008c41299a58ce7b84cd82fdfac929f37101e484829a12742"
+    },
+    "sound/enforcer/ue_site2.wav": {
+     "bytes": 22662,
+     "sha256": "c4308c42f3e35c98753c47ed5be6b6e2f76631e8e3b6951d1bb535ea030db18a"
+    },
+    "sound/enforcer/ue_site3.wav": {
+     "bytes": 32432,
+     "sha256": "fab4607eb2d36c3e6bb947e348a8c7c0ea4729da65c1c953a7c00060124c79be"
+    },
+    "sound/enforcer/ue_site4.wav": {
+     "bytes": 33640,
+     "sha256": "fbd7ee02ccc2dd3ed093c1b31bfc7199b7d8c93490fe6709da31e18e1a969639"
+    },
+    "sound/enforcer/ue_site5.wav": {
+     "bytes": 32432,
+     "sha256": "4bfc80e04d56996b8b4c1929bb14b8d0b2916db9750106525159b9bd930d0ea6"
+    }
+   },
    "sha256": "efb787f75257996a3fc85ae6bcf6c563c57b2db9f0fb1b5d8d0c8e41cf15ce64",
    "timestamp": "2005-06-27T02:35:26.000Z"
   },

--- a/json/by-sha256/12/12daa6efad4287376b450014509b1c31a9147113d4e2ec407a03b5c577b061d6.json
+++ b/json/by-sha256/12/12daa6efad4287376b450014509b1c31a9147113d4e2ec407a03b5c577b061d6.json
@@ -12,11 +12,199 @@
   },
   "pak0.pak": {
    "bytes": 30963231,
+   "files": {
+    "dont_readme.txt": {
+     "bytes": 3761,
+     "sha256": "4b7eaad4c36b2a10018d2a72e645661cf0e6ea4686ae8c85314d5b8dfe861757"
+    },
+    "gfx/env/devpun_bk.tga": {
+     "bytes": 616542,
+     "sha256": "496e85d5ee0f21a226ac0aed4e7ab28e99930433274df458daa78e28d795633c"
+    },
+    "gfx/env/devpun_dn.tga": {
+     "bytes": 685386,
+     "sha256": "42b9b44cd4794d963ed043e078adf0eb7e264f43d3f6245f52adca78d37d59a3"
+    },
+    "gfx/env/devpun_ft.tga": {
+     "bytes": 533032,
+     "sha256": "bb52543bac27f22119dacbc7e53ba4d5d7ac13e288bc22e060367ce2f1955e91"
+    },
+    "gfx/env/devpun_lf.tga": {
+     "bytes": 636276,
+     "sha256": "18557045511a0b6dc179c72da475f3ca8f7af1997477642e4bc6844a5c67f680"
+    },
+    "gfx/env/devpun_rt.tga": {
+     "bytes": 549569,
+     "sha256": "71eb8fe46e6cb8180b0c97b8e7359c1e3ee3babca3131515de73d3412f45f87e"
+    },
+    "gfx/env/devpun_up.tga": {
+     "bytes": 409899,
+     "sha256": "4aed27836328f399de4eac321ec87e640b33c34817818c24ad611e7c615e92f2"
+    },
+    "gfx/env/nightzen_bk.tga": {
+     "bytes": 505093,
+     "sha256": "0176f518ad1fff1fc5326589da5ddcd30cb7598f787f7c531cf921ee5f9e369e"
+    },
+    "gfx/env/nightzen_dn.tga": {
+     "bytes": 488801,
+     "sha256": "12ab5bfb82651c2a551259870f6f8afd152d6f7c9fd208fd9a932da8f61b7ec4"
+    },
+    "gfx/env/nightzen_ft.tga": {
+     "bytes": 385599,
+     "sha256": "32aa17db6421fe771223aa27be3943f18e7ac5c05b13d23309e2a100b859b4c9"
+    },
+    "gfx/env/nightzen_lf.tga": {
+     "bytes": 485058,
+     "sha256": "4faa4ededd3767adfc1cb545b0258dbf251662974c14fde9f91ffb30726a7e0e"
+    },
+    "gfx/env/nightzen_rt.tga": {
+     "bytes": 500886,
+     "sha256": "2b3a747a23855bc6c6f389304947400e54c72f9c2cd0ec8bd4cb05209ba92a75"
+    },
+    "gfx/env/nightzen_up.tga": {
+     "bytes": 448166,
+     "sha256": "c10bdca66aab106e2e5d56046bd375205eae06dca75df74cd444ec01ce39bb05"
+    },
+    "maps/zendar.bsp": {
+     "bytes": 11900904,
+     "sha256": "846101ecdad6528677d405ab3e560a7fa2959b15f0465ce4b8ee7b8cd226f1b8"
+    },
+    "maps/zendar.lit": {
+     "bytes": 2631950,
+     "sha256": "d48681f367f21c31fcef36a81a66e978d93cbd83e6e129383d0f375d89dc7e4c"
+    },
+    "source/zendar.wad": {
+     "bytes": 1497536,
+     "sha256": "9aa1f3b431b45ecae240d4c412f9fa5830c35699393e391f77af43b65e6e3e90"
+    },
+    "source/zendar1d.map": {
+     "bytes": 8671045,
+     "sha256": "71aa35b1eb9ba1c58a511b9a64a814c545b2f4b2d7ec6f47547455abd8836a22"
+    },
+    "zendar1d_readme.txt": {
+     "bytes": 12564,
+     "sha256": "493f0fae885f37f79a4b36471c1bfb21b4907cec3137d931d2014e28410f9973"
+    }
+   },
    "sha256": "76fff155c3b163f272752c039012a48c6e035ddf74242b4a6a1ccb1f00f4b7bd",
    "timestamp": "2013-12-19T00:30:18.000Z"
   },
   "pak1.pak": {
    "bytes": 273011,
+   "files": {
+    "maps/b_batt0.bsp": {
+     "bytes": 6980,
+     "sha256": "0d481a2e2cd7a23e4ef19c19622195007bd6c9a67135ef739b0944a02d46fcd7"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6964,
+     "sha256": "34709c1c06ca34305a8ba1d4799d1cdc07e44ff33f3c7fa11c3d5933cb942579"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 7124,
+     "sha256": "d3371655bed274070fa98fb32b408bab4a22fe754f5158c8c94a072749a5d24d"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 7764,
+     "sha256": "abdfe383c13da6d5dd7a9409fa5d3db2c4bac78482eb75c2c2b42da7811ec3ca"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 8788,
+     "sha256": "2343448faac29720e3a690650b70623852710dcae002917ae5772fa597117e17"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 5604,
+     "sha256": "66ea23f1cdd6225afdd1b7cf1247b93d174562193e0807561b96b659429f2bf0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6820,
+     "sha256": "366ece777ae71ecfebaa9f4bebafe2074b5336e7939900f46bd9521886f9f42d"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 7092,
+     "sha256": "56a66aa3d1364a0436ff8ce880268b2a9c2c396ab02f0c6277535d5b99eae31a"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 7636,
+     "sha256": "ddd60cec57d8e3954c1ffce616ae862edb784417a6b6622cc001d408383a6cb9"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 5396,
+     "sha256": "fe60bd7880da73571e29fa4075968cccb06e913bd2b9475868ce31c69b1a8c19"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 8436,
+     "sha256": "6a2c2c3fa6f88d425ae5b9568e5d8224ee901a1d8faa8363b88fff569b7d0e5f"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 25812,
+     "sha256": "1ba9d3176bb2e03a0457427fd9394d8c15eb9ebae8af9462e955e9c6c6068513"
+    },
+    "progs/end3.mdl": {
+     "bytes": 19700,
+     "sha256": "445af16e28fff506ad65fac16b09dad1672e218ffe0183880aff565578b315b8"
+    },
+    "progs/end4.mdl": {
+     "bytes": 19220,
+     "sha256": "cf52525422a102760bfcabd6e8dd5c5df7c2028daea5baa2a1b1717648dd143e"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 3860,
+     "sha256": "256412b0d88c020fb03efc5e914c5dd721c9dfe8d6a36ce4a7b01e7597d7e7d5"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 7108,
+     "sha256": "d4c5b6316aa02d600951c6a8ec1f4682568b9e877e988cf4cedd77c0e95cf663"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 21412,
+     "sha256": "1274fcabffa89a786b29c9238cf84e95a8557369239b4a9eb813e3dbe37d35ac"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 5492,
+     "sha256": "ecf293b2e8146a33de7bc8bb3cded80bb785b931012b40dca204db3dad50e776"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 22052,
+     "sha256": "c5657b558522e46f0833b7827520c1a5c1f1674dffd52c12609779d5bcd75462"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 1396,
+     "sha256": "945ad552ad86e5193ef9c007dbe23686fbe89be1060063f57ea693b89e5df229"
+    },
+    "progs/spike.mdl": {
+     "bytes": 1396,
+     "sha256": "c5e6afcfbfe35ffde5bda7eaf91e2a583c3f20cf8f3175b4f4e0ad03b358983c"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 9012,
+     "sha256": "06e8f32092cbc0b5ba4d26227df9ac2d10f3a76d9a63bc7928af147b4ade12d7"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 6356,
+     "sha256": "40d9d29c58df57ece6892d71d0464022eb5939aa45699e98eae22136b973c4c8"
+    },
+    "progs/zom_gib.mdl": {
+     "bytes": 19768,
+     "sha256": "2175cca881b4a73adf3742933a5d3e91116c774ddd3db9b6ac2a7f863194d4a8"
+    },
+    "quake.rc": {
+     "bytes": 1319,
+     "sha256": "23d89f55c4aeec778b24e215ce38088b1ad23525c006f09a18ea433d93a03380"
+    }
+   },
    "sha256": "b1f60d3240e39106bef8e314f045e84c1bb26120900a4c41c33865707a98fe99",
    "timestamp": "2013-12-19T00:30:22.000Z"
   },

--- a/json/by-sha256/12/12f23892afa818ab5b10ad0c76ee2e9304196e74415f49345e0cfba0504826ed.json
+++ b/json/by-sha256/12/12f23892afa818ab5b10ad0c76ee2e9304196e74415f49345e0cfba0504826ed.json
@@ -20,6 +20,16 @@
   },
   "pak0.pak": {
    "bytes": 11592708,
+   "files": {
+    "maps/e1.bsp": {
+     "bytes": 11174880,
+     "sha256": "005c2bb880294ce8d054c1e93f4ee9d9c215ecf1e0eeaa6728c053e3dd45c0b3"
+    },
+    "progs.dat": {
+     "bytes": 417688,
+     "sha256": "ec35dfdbf01285be58a5fbe9b487fee73c499fa8e5d6ed6e4ee4a2c7fa115011"
+    }
+   },
    "sha256": "4ea053b4116500253f3c9ce790a5bdadbbfd855881b519d9b016d0cb7ac528dd",
    "timestamp": "2024-06-20T22:39:18.000Z"
   }

--- a/json/by-sha256/14/1482cbde05aceac0890b5ac021ab16da3299aa1f64bb012a6de793d75b80ecaa.json
+++ b/json/by-sha256/14/1482cbde05aceac0890b5ac021ab16da3299aa1f64bb012a6de793d75b80ecaa.json
@@ -7,6 +7,152 @@
  "files": {
   "Pak0.PAK": {
    "bytes": 13568209,
+   "files": {
+    "demo1.dem": {
+     "bytes": 202768,
+     "sha256": "f06aca6276a107b75f75f05d7fe098b1499d864e2dbedfff5e3ed22db62a9523"
+    },
+    "demo2.dem": {
+     "bytes": 204550,
+     "sha256": "05d6943309acc0ca4847494df89c897f5e08f4a13dd0f3ec490a41a51b7a50b6"
+    },
+    "demo3.dem": {
+     "bytes": 241561,
+     "sha256": "01d08c37276fe4d758004be6224c12970901d973f8a1ab804b674b256d554ccd"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "2766ce5ce91556f9b67d8723b3adf5540c21aae8f0e522af067fccc41d57cd6b"
+    },
+    "maps/end.bsp": {
+     "bytes": 639692,
+     "sha256": "34a307843721a0e0699076be73400d4703534fe23a97af973e40e8688a89a3fe"
+    },
+    "maps/schist1.bsp": {
+     "bytes": 2102068,
+     "sha256": "3573f75dcf513193f67d8e1bbb99bd96c24041f103068b8a7045483432afe194"
+    },
+    "maps/schist2.bsp": {
+     "bytes": 2303316,
+     "sha256": "b4d36f26f1b3437d5d7e705c94de0df8fbee32e3300ca6d5a35f0b486d5e8bca"
+    },
+    "maps/schist3.bsp": {
+     "bytes": 2399484,
+     "sha256": "dd9ebab15810b78d9ef90c587c3b840c58709ce8d59d326441bbe9e137edb977"
+    },
+    "maps/schist4.bsp": {
+     "bytes": 1939240,
+     "sha256": "d2da5a61dc70716b1b4087fc892085da483e3d6035266939293490dc9ad869b1"
+    },
+    "maps/schistdm.bsp": {
+     "bytes": 965520,
+     "sha256": "e3d88b5d321603a307196479169e21f7d31d0771836e278da5a6c0aca77c64af"
+    },
+    "maps/start.bsp": {
+     "bytes": 852116,
+     "sha256": "57e55129b3ccf50fefc86213f64df0568bb9c36ebe77c710e5c5bfd78631ba0a"
+    },
+    "progs.dat": {
+     "bytes": 554104,
+     "sha256": "17f98436e60eda75974c493c2fa90e3fdba52d4eccd21a385f7c44a58c5d5edc"
+    },
+    "progs/candle.mdl": {
+     "bytes": 35908,
+     "sha256": "61b882f3d9d8306aa12117290370d86128d2e9413940fd40c8c1fe63f8bef8d1"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 74488,
+     "sha256": "8df8fca0d877692b450c0a6bd8202368b7d9e3d2365b2a161cac6f4ceb26efce"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/s_null.spr": {
+     "bytes": 56,
+     "sha256": "29e9c18546413f0abc9c6f507c61952f33afa6507b52d1c2197b57e3be7870a9"
+    },
+    "sound/electro.wav": {
+     "bytes": 15023,
+     "sha256": "013d6ce1d6ad55aaa077e4bd622d182193c713ea019eb7c62b242e943062b6b9"
+    },
+    "sound/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/hum1.wav": {
+     "bytes": 16688,
+     "sha256": "d6d54c5e878a6f2bfe73676b8bf2108ce0f47edb44529d85cb1c4a6a80d4fbdb"
+    },
+    "sound/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/newhum1.wav": {
+     "bytes": 35258,
+     "sha256": "d2c07398d1a6ecada4987780bdac04460d4faa578a2e829f7bca8f5edf8100a3"
+    },
+    "sound/player/pain1.wav": {
+     "bytes": 38956,
+     "sha256": "f69ee57b5cea2f9eefcffaa945b7219257db701a909e7f1b2b7e9ab715d58d29"
+    },
+    "sound/player/pain6.wav": {
+     "bytes": 23468,
+     "sha256": "de4071f8b44b9dda2c6723adfacfae0fff2eda86cfbf4e8925fb39bc112e80dc"
+    },
+    "sound/player/udeath.wav": {
+     "bytes": 18733,
+     "sha256": "1526ce953f9d6785d2072559b7016b524f7727df47556395653e0f66314b74c6"
+    },
+    "sound/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/soldier/sattck1.wav": {
+     "bytes": 30413,
+     "sha256": "36d251252367ce80a8547002dd2efef84087100781d4e9947efdd6a4e0f0a342"
+    },
+    "sound/swing.wav": {
+     "bytes": 12960,
+     "sha256": "68da54f9541808bdaa1f070218bd53ffce0cfccee46b460fd9181a366440952a"
+    },
+    "sound/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    }
+   },
    "sha256": "917bf534ababb16f3d3e363341f07a9a7149c3baf637e76a5168f4ee68758ee9",
    "timestamp": "1997-11-10T16:46:44.000Z"
   },

--- a/json/by-sha256/15/15bbc5dc0eb3fee5763835cea1aa62ab263545ca8c04aaa019982d45d1e8d11d.json
+++ b/json/by-sha256/15/15bbc5dc0eb3fee5763835cea1aa62ab263545ca8c04aaa019982d45d1e8d11d.json
@@ -875,6 +875,356 @@
   },
   "dwellv2p2/pak0.pak": {
    "bytes": 4329592,
+   "files": {
+    "gfx.wad": {
+     "bytes": 121132,
+     "sha256": "482ed0a636d66e8f3acc54feadd5b297b7f70e29365474429866024bd94328e0"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "898d694265db0f933feecfd2a843557a6954a5f2aea05ecf9a852314119dab61"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "03e0973ee5d434c037699f9568228ab80be0df882ca77c88a9835b2d2edf0649"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "294c8e954889546f1b39bdb3815affbdee6d5a20f97df5bfe7d944cb0047efd0",
    "timestamp": "2023-02-04T01:14:38.000Z"
   },

--- a/json/by-sha256/16/16b3a02b2d201cbd87bb07b135f1689b600a9b4ea61aea52d2ac980c5708db4f.json
+++ b/json/by-sha256/16/16b3a02b2d201cbd87bb07b135f1689b600a9b4ea61aea52d2ac980c5708db4f.json
@@ -17,6 +17,620 @@
   },
   "flesh/pak0.pak": {
    "bytes": 16435171,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 307208,
+     "sha256": "fccce475e4f3bf7503c95c7f4767ae7f207dc1a2eb342a3898e8dc5f0604afcb"
+    },
+    "maps/flesh.bsp": {
+     "bytes": 2396004,
+     "sha256": "5e885ce99fe8f68e4decccf8ee5743d667fb43607159cb8f83287ffc862fc80f"
+    },
+    "maps/flesh2.bsp": {
+     "bytes": 2853776,
+     "sha256": "9a4af1028d0940204a97028b18048772b0b6a015b869035bbedb1155169b143e"
+    },
+    "maps/flesh3.bsp": {
+     "bytes": 1814724,
+     "sha256": "2347a0e3bfbac0937f127bd996484ff1b84cc8fe1f18a39450a8b098f81fd61f"
+    },
+    "progs.dat": {
+     "bytes": 876624,
+     "sha256": "ddf2cbb9f6157466a76db210ac7229fa841efa5528d9810566afa43dd65bce46"
+    },
+    "progs/armor.mdl": {
+     "bytes": 44076,
+     "sha256": "0e16c3f0ba370dbb172af676540ce2f4a58b151d8a6dd10c1c353748257c82d3"
+    },
+    "progs/b_earth1.mdl": {
+     "bytes": 16325,
+     "sha256": "f8721a42dd05178200b3de8fb73502ef46284f7e4e48076fb353980dfea997a2"
+    },
+    "progs/b_earth2.mdl": {
+     "bytes": 65436,
+     "sha256": "59933ccbe1fda467ca4de97ae80587eb85904779e9aa612a3621859bc474dfdc"
+    },
+    "progs/b_ice.mdl": {
+     "bytes": 17584,
+     "sha256": "7805429534fa39fc6be4016eccacdac51fd0b4c2183723e7cc8dbab2aeada925"
+    },
+    "progs/baron.mdl": {
+     "bytes": 405612,
+     "sha256": "68bb69841d1246882360b8e243bd34dc5534989dce1eda8974938ebf7acae652"
+    },
+    "progs/bball.mdl": {
+     "bytes": 130008,
+     "sha256": "6fc43ee5d3e26268cb4e9be521b4b514f21bfe3556f8189ccb8c96a44c71b115"
+    },
+    "progs/bolt2.mdl": {
+     "bytes": 20971,
+     "sha256": "ca530afb1e205749ca625e37c75656523ec8c1a5320fcf934585dec7eea03966"
+    },
+    "progs/demon2.mdl": {
+     "bytes": 155440,
+     "sha256": "924209ba021a283609dd0aab718116b34f1fec7ed9031b9c67bfcc462d5d604f"
+    },
+    "progs/demon3.mdl": {
+     "bytes": 102120,
+     "sha256": "a15f94c4d204a4fd9e46932e0dea8a104196a0129cd8553af6e93aca9555438e"
+    },
+    "progs/f_gib1.mdl": {
+     "bytes": 5900,
+     "sha256": "7684e5b71c188455fef23f6c5296118c6e6097244e130f19a7baaa8624d01d94"
+    },
+    "progs/f_gib2.mdl": {
+     "bytes": 16628,
+     "sha256": "87c71727daa0b117fa69cbbe28e74dda48709da3f9efee09cce42d4c72120c5d"
+    },
+    "progs/f_gib3.mdl": {
+     "bytes": 23038,
+     "sha256": "8def0f3a19c2cfa2a7dc8f6367c0ef1f367d5be4dd339a6d2a13b7c199254054"
+    },
+    "progs/f_head.mdl": {
+     "bytes": 15264,
+     "sha256": "6a08ff3fe11c8adda90dd126b9f4321e1777aaac7d53612515c161c0ec2a0341"
+    },
+    "progs/fireball.mdl": {
+     "bytes": 14336,
+     "sha256": "749b11c5d8e61ca4b9ba2e8907a713c3fb683760f2e81113426f5826e817409e"
+    },
+    "progs/freezem.mdl": {
+     "bytes": 38589,
+     "sha256": "1a7b293eba8a6f0cf6481583de89c0f93bc734affbe968e8e9ebd1d66f974513"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 34700,
+     "sha256": "427b48f83493956b49e32024333d4db51b78cf1f79a45f130f98f1e99783e42a"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 30720,
+     "sha256": "708ee4afc78acc2ac37487e8714e7761de6a49b192524cbb41437c1e52e31685"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 48244,
+     "sha256": "90bb98719c5b3d509a1df75600e3f308edc7a463531889504888727b0cd6e138"
+    },
+    "progs/gib.mdl": {
+     "bytes": 22228,
+     "sha256": "43da76f68a5340755391c2ffec44b3dfa5f271754d509fd9e6292de6281111a8"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 22228,
+     "sha256": "d8f920e51e1cded370a45e9e7c7d3e928194817a9f8037830c62fcdc2ce50a82"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 5349,
+     "sha256": "b1c731745089418075fb565c13db5992d7dd54df6d5ffd38f93e146caa508561"
+    },
+    "progs/hkboss.mdl": {
+     "bytes": 228400,
+     "sha256": "2cf03ef0c70ac4999559a9e3ec2518384f636fcdda62f32cf67a6953303e3c5e"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 228400,
+     "sha256": "f96150ef6e364beb401cf9993398cd7065c9a0d7807d403a1eec098ea8acd369"
+    },
+    "progs/ice.mdl": {
+     "bytes": 10712,
+     "sha256": "b8b1e2bc3acbef197f1a824189a5545906b927410ded34ede6aee4c70260f4e4"
+    },
+    "progs/knight.mdl": {
+     "bytes": 101404,
+     "sha256": "8049534559a69e840ddfb3b6c1a8d2cdce1f526142460997c48c4c62e12bc382"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/manga3.mdl": {
+     "bytes": 96256,
+     "sha256": "99ab9beb24e1f5fefc2a99025943c225c17a0216e82b7a359483c8b19622fb10"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "fd5407cde15b79e1d5b2d5bc78366cac4ea1d436308e6740608b8e2440d9a0da"
+    },
+    "progs/oknight.mdl": {
+     "bytes": 221448,
+     "sha256": "f648d62f1c6bc202103fcb20dad7c56574a4994a3ad563b24426572a8473a0e1"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/pt_beam.mdl": {
+     "bytes": 64436,
+     "sha256": "4a5c7e27e8a05cb98e007df414dea795887eac4d441b194d676202b47ea35f07"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 200848,
+     "sha256": "4c0653e3adba99be4d581c92a928fd6e8c27b0a2159a97f7ec5e885478249b8d"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/sphere.mdl": {
+     "bytes": 95481,
+     "sha256": "c5b8f8bcbdff20c19f0237b01cd391d746dd45996890a5eae7982c621e422a45"
+    },
+    "progs/v_freeze.mdl": {
+     "bytes": 76847,
+     "sha256": "cfcc74d7b6e3dbe6cba270f97c495c04c766d9f2d1cd813a889c7c8998ed5836"
+    },
+    "progs/v_gib.mdl": {
+     "bytes": 9172,
+     "sha256": "fe66c04aceb3b8ab14bcb03ecc9fd5ffcf01e2679e3372bbef5c52e2ee52e768"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_lava.mdl": {
+     "bytes": 126644,
+     "sha256": "3eac7f583062c719975fc834ffa645586e43b1c5adca2d07ac7845262317bf81"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 128952,
+     "sha256": "b94788b9eb67a3e35e0f8f1563e1308c3ead46aa14882d5afbb2bb60b7995eff"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/v_ptron.mdl": {
+     "bytes": 103038,
+     "sha256": "e7eed8d4fc4bec47557e5fe2d017979230a306329ee12d845dd37e056888bc2a"
+    },
+    "progs/vile.mdl": {
+     "bytes": 98556,
+     "sha256": "b5ad89ea645a94d8f07f4a812cd63bb9914747418c675170583cae503446e3f3"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "7758aaf42d0d1617e4fb172ce842be4316073f63250aba46dad441327cccb2e6"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 133676,
+     "sha256": "0a57ee912df3142c5e17183d5f6bd461021b141d53f7534014d59eda97e6bfa6"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "sound/alkamb/creepywind1.wav": {
+     "bytes": 149550,
+     "sha256": "de80fc2c4171bb542d9ffa5b40cb31eea2fef8311c4f9ebc15b7d9a28bf3e610"
+    },
+    "sound/alkamb/demonwind01.wav": {
+     "bytes": 89228,
+     "sha256": "1a44a8cf17be9fe6e8aaecfc9c65ec0ef761eb27ea6df77e016cebf01cf62216"
+    },
+    "sound/alkamb/drips.wav": {
+     "bytes": 80712,
+     "sha256": "96f7890d2fea2f1f6443d0e75bb6084f39931e7c5399a6e75787dec4eaba5033"
+    },
+    "sound/alkamb/heavy2.wav": {
+     "bytes": 231772,
+     "sha256": "f542ac63733311617fd1974cb04f75ec5c8e9f8e9053a126e695751abbb8da5f"
+    },
+    "sound/alkamb/moans1.wav": {
+     "bytes": 312472,
+     "sha256": "87d2dd817fbf578bb94a22aaa20c6a0daa28dbb0b78f6ccc0b7f0f6d17ffc04f"
+    },
+    "sound/alkamb/moans2.wav": {
+     "bytes": 275802,
+     "sha256": "279a5b7190aa28d598930d7cfef6f5fd611dac51fb5297058b7714e1f6fdd0e9"
+    },
+    "sound/alkamb/moans3.wav": {
+     "bytes": 162450,
+     "sha256": "6b46ddb6560b63b16a7493abeea49c7bff4afe430830a7115959e8db89a91bdb"
+    },
+    "sound/alkamb/scaryswamp1.wav": {
+     "bytes": 201212,
+     "sha256": "c6fded08f1da1020a0a13ef5f5be9c99b7cbeda8f51746e156389bd859279791"
+    },
+    "sound/alkamb/scaryswamp2.wav": {
+     "bytes": 261302,
+     "sha256": "7a1a1e01cae8293d1cafce426580cb34641ac0c6ed379c4ab64e2307fa25ab94"
+    },
+    "sound/alkamb/scaryswamp4.wav": {
+     "bytes": 252754,
+     "sha256": "e71d7791f2340b1824247c940f7b8ea9934db493ed564fbedfb68775d9799bab"
+    },
+    "sound/alkamb/suck1.wav": {
+     "bytes": 51436,
+     "sha256": "3d99d5630e91c603fef397453136634562f7877f42379ae744ffe57570d3eb42"
+    },
+    "sound/alkamb/underground1.wav": {
+     "bytes": 114950,
+     "sha256": "989203aa820c170f5813441d665c193977eca0562b7eee60a5dc8133fc503dfa"
+    },
+    "sound/alkamb/wind_deep.wav": {
+     "bytes": 35606,
+     "sha256": "2ebb1e71f3283c7c15d3770f46a244a35de0c448d46f058d1d662ca06d31d1cf"
+    },
+    "sound/alkamb/wind_med.wav": {
+     "bytes": 32212,
+     "sha256": "005616904ebfec049860ca33b790903e76c75615f3048dba17ce8d85cd6c65f5"
+    },
+    "sound/alkamb/wind_rumb.wav": {
+     "bytes": 63234,
+     "sha256": "24760cbf8622bb933fcd59e847067de3581f6a3d54db72bcb3f864d2cf508a36"
+    },
+    "sound/alkamb/wind_rumb2.wav": {
+     "bytes": 32872,
+     "sha256": "9c77014eb35b692af657a524f1e7eb82b1b1ebe9d95c62462e6f6925baf4153a"
+    },
+    "sound/alkamb/windeerie.wav": {
+     "bytes": 58476,
+     "sha256": "0759ad526d301c3bb14c467818bacdbe3a64237657c45a435e06cb166b570b85"
+    },
+    "sound/alkamb/windnoisy.wav": {
+     "bytes": 25852,
+     "sha256": "02d097f0a58cc65826bde1ebe5c3450a4ab92d09b16e85ad916f62dca82936c9"
+    },
+    "sound/baron/death1.wav": {
+     "bytes": 68188,
+     "sha256": "0785bad4b7b721f2bb989fa74f7186552ef9bbca016fb2f1a3fe9b52650fe3cb"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/e_nail.wav": {
+     "bytes": 26306,
+     "sha256": "04fc98e42709c9a5d1a8bbd52aff9114b4922da324e30d21859bcf8209e55b4f"
+    },
+    "sound/baron/e_shower.wav": {
+     "bytes": 10178,
+     "sha256": "6c50b5da79aa99295f9bc3de1445ef76c6e6306b413b9a934122393b6b3a633b"
+    },
+    "sound/baron/f_ball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/pain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/sight1.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/demon2/ddeath.wav": {
+     "bytes": 119852,
+     "sha256": "2e5c590d68b6b17c224e0362b1b174812412cc3de817e57ec36bd495259e0b72"
+    },
+    "sound/demon2/dpain1.wav": {
+     "bytes": 68012,
+     "sha256": "6bce074ba79a267f90f1eaec23952a1b67fb9ccc84e0652af3998b965a8a7f78"
+    },
+    "sound/demon2/idle1.wav": {
+     "bytes": 109484,
+     "sha256": "a9c13339e4303ed281f9a653fc6718aa8da31f004e687c506838ca2f678e0b40"
+    },
+    "sound/demon2/sight2.wav": {
+     "bytes": 87596,
+     "sha256": "3bbeef3faab854f2725cbe833c4c9628592d823f25a94686a27660c25e2955c0"
+    },
+    "sound/demon3/ddeath.wav": {
+     "bytes": 16453,
+     "sha256": "4674e8017812c77fe47b75e49751373f8e541f12b1516d8cb6e258e74fc23d2d"
+    },
+    "sound/demon3/djump.wav": {
+     "bytes": 13360,
+     "sha256": "cebb2a78470818d5e8d80b7061d756337b046dbea925d9efb9dfeadb0e6c6046"
+    },
+    "sound/demon3/dland2.wav": {
+     "bytes": 4398,
+     "sha256": "0828634696cad5557833d51f2ed9745567b2f80ce55b3bfa8a21a7cf518ba56e"
+    },
+    "sound/demon3/dpain1.wav": {
+     "bytes": 15679,
+     "sha256": "0624bcdb408f3963ff01680d05d0c6d6c815e0d0e32617e1c5eb02b69311b7a8"
+    },
+    "sound/demon3/idle1.wav": {
+     "bytes": 6521,
+     "sha256": "5fa6854795867f42272ea1d7d4f212c760ab7a2e6ed369c729ff59fcd7382ee5"
+    },
+    "sound/demon3/sight2.wav": {
+     "bytes": 8770,
+     "sha256": "a9c22263c7be78f32c54417cf0ded45007d3e0d03d87e2793343493526006faf"
+    },
+    "sound/hknight/fireballsound.wav": {
+     "bytes": 33230,
+     "sha256": "98911278ad588279697aa84092c33366577e3e4e700c19668baecf154fa27fa3"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 12202,
+     "sha256": "2e0f2a66e528175f8636b4b832b1f5241c09237fc09081e46e6ec3e536e69162"
+    },
+    "sound/lhit.wav": {
+     "bytes": 9552,
+     "sha256": "f66fdec000ae50bbc32110030ab2071ebf43e659f3bef4c0d275b16267c5c4ac"
+    },
+    "sound/lstart.wav": {
+     "bytes": 9552,
+     "sha256": "f66fdec000ae50bbc32110030ab2071ebf43e659f3bef4c0d275b16267c5c4ac"
+    },
+    "sound/manga/died.wav": {
+     "bytes": 71468,
+     "sha256": "5c4b4cf74f73e053cfb042fa8e69535a2454ceae39f35bac2762d8ebe8460a25"
+    },
+    "sound/manga/ha.wav": {
+     "bytes": 17324,
+     "sha256": "15575f8f3e16f6a466edb9e6016d76c1d148be8b4f1d983958085bbcf5085bfd"
+    },
+    "sound/manga/hiyaa.wav": {
+     "bytes": 24236,
+     "sha256": "7fd511e453b5ce84ba9787f1586b0648ef122934324b5e2ece8bb4ff08ce5aaf"
+    },
+    "sound/manga/kungfu.wav": {
+     "bytes": 61100,
+     "sha256": "d170f81971005d4e687d67cf162372132a7ef07d6d73086d53803a3ad61290b2"
+    },
+    "sound/manga/ohdju.wav": {
+     "bytes": 18476,
+     "sha256": "15ac78885fc53d156381ee1fb0310c469cc597ab747b87b6295afa14dd32c3f5"
+    },
+    "sound/manga/tchak.wav": {
+     "bytes": 34604,
+     "sha256": "8a4067a528ee8895aa7dd1da922677e91973cb60ef4e5f8b0ecbb75bb1cabd24"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/oknight/ogdth.wav": {
+     "bytes": 78380,
+     "sha256": "45497ebb89998ec93f02fc2a8d66c62392475de72fe4729d85bd5bfa3d2758e7"
+    },
+    "sound/oknight/ogidle.wav": {
+     "bytes": 5056,
+     "sha256": "542c206c55627911b29371b210f5d5daad5ebd202b7aca8718743d705d0f4fda"
+    },
+    "sound/oknight/ogpain1.wav": {
+     "bytes": 29996,
+     "sha256": "90e139a7abf0197c378cea36bcfa4c8842394fc21bce4df579d29b00fadfdd4f"
+    },
+    "sound/oknight/ogwake.wav": {
+     "bytes": 85292,
+     "sha256": "c0719580bd8bdb0679b2d913fac3def68bcea5e1d848a31ebab0a0a2cd92165d"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/s_wrath/swrath1.wav": {
+     "bytes": 6028,
+     "sha256": "7d2290479c4b8fe3cbf14b8e1bddbd6a874b5e9d5f436233eec562f35ca8cfb3"
+    },
+    "sound/s_wrath/swrath2.wav": {
+     "bytes": 4052,
+     "sha256": "7f9ae2dcb54b6e59c67705c20179a963bb8218d4c96db4323d1fedfb4ad39afb"
+    },
+    "sound/weapons/blaze/flhiss1.wav": {
+     "bytes": 13484,
+     "sha256": "e44b1a5029b339a00c3682d9f79f7f813b4ddbe033710bec7ef0cd20a496983a"
+    },
+    "sound/weapons/blaze/flhit1.wav": {
+     "bytes": 10586,
+     "sha256": "26b113f15390071f4585f0859b1aae738ac8c692531e3e4e638b4eb3836aca84"
+    },
+    "sound/weapons/blaze/flshot1.wav": {
+     "bytes": 3914,
+     "sha256": "a5b7ef9dba11d0cf67d263a8c70a9783f1a2599ac49601ccedd10a0f2e2204e9"
+    },
+    "sound/weapons/frozen.wav": {
+     "bytes": 20618,
+     "sha256": "05a489de35594542a929ce87087a2755fc630097292eedde6d50a18893223e90"
+    },
+    "sound/weapons/icefire.wav": {
+     "bytes": 8940,
+     "sha256": "7b818fba135a1c5535c21584134125bf44a071715711abf277b2fc9a067637ef"
+    },
+    "sound/weapons/pt_blast.wav": {
+     "bytes": 20448,
+     "sha256": "b5bafb4758dff4ea092079935a55ef8725beebd986be806e795f49de7109244e"
+    },
+    "sound/weapons/pt_fire.wav": {
+     "bytes": 12580,
+     "sha256": "a4535e2d594995d08a8c69fb75454963070145ec01b798371b09a1b668942daf"
+    },
+    "sound/weapons/shatter.wav": {
+     "bytes": 20898,
+     "sha256": "5d30558f24773771d980c4796f4cf28646a98cdfc3baadb3b3491c7d170dfa77"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    }
+   },
    "sha256": "85470aca5655783e5739bb2fd8f02e806e449e7265388c43b4a5024a07547521",
    "timestamp": "2002-10-17T11:00:38.000Z"
   }

--- a/json/by-sha256/18/18491ac361db001e8b14f03aed52d50538e781b63e057f94fbb7a0544e935432.json
+++ b/json/by-sha256/18/18491ac361db001e8b14f03aed52d50538e781b63e057f94fbb7a0544e935432.json
@@ -12,6 +12,408 @@
   },
   "marine/pak0.pak": {
    "bytes": 5815214,
+   "files": {
+    "maps/marine.bsp": {
+     "bytes": 1665060,
+     "sha256": "bb038fcde0f179db2bf5a25700b4a63cf1d072312ae385cc2cdfae41ab43441f"
+    },
+    "progs.dat": {
+     "bytes": 742448,
+     "sha256": "d631241d0b18c7fae0f28755fe3a2ca22cbe166cb150158f28ac801ca30209dc"
+    },
+    "progs/armor.mdl": {
+     "bytes": 44076,
+     "sha256": "0e16c3f0ba370dbb172af676540ce2f4a58b151d8a6dd10c1c353748257c82d3"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 106244,
+     "sha256": "2ca415ec913b3c05038c6db21f9235edf7eefe7cf41120edead53efb90ff0ef4"
+    },
+    "progs/b_earth1.mdl": {
+     "bytes": 16325,
+     "sha256": "f8721a42dd05178200b3de8fb73502ef46284f7e4e48076fb353980dfea997a2"
+    },
+    "progs/b_earth2.mdl": {
+     "bytes": 65436,
+     "sha256": "59933ccbe1fda467ca4de97ae80587eb85904779e9aa612a3621859bc474dfdc"
+    },
+    "progs/b_ice.mdl": {
+     "bytes": 17584,
+     "sha256": "7805429534fa39fc6be4016eccacdac51fd0b4c2183723e7cc8dbab2aeada925"
+    },
+    "progs/baron.mdl": {
+     "bytes": 405612,
+     "sha256": "68bb69841d1246882360b8e243bd34dc5534989dce1eda8974938ebf7acae652"
+    },
+    "progs/bball.mdl": {
+     "bytes": 130008,
+     "sha256": "6fc43ee5d3e26268cb4e9be521b4b514f21bfe3556f8189ccb8c96a44c71b115"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 5349,
+     "sha256": "b1c731745089418075fb565c13db5992d7dd54df6d5ffd38f93e146caa508561"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 34884,
+     "sha256": "bb00e3b94ff9d97964cf206f8b099c2fb4ba2bba82f9c524f9041b866a81d875"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/knight.mdl": {
+     "bytes": 153400,
+     "sha256": "26576f139d258b3c236faa6552d8ba09ef6e14480d4a2e2dc9e3e2c4df5177b6"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "33e3928a16b08245e80175db5a13f7f0423359f870bea539d5be94a5c31cb738"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "sound/alkamb/demonwind01.wav": {
+     "bytes": 89228,
+     "sha256": "1a44a8cf17be9fe6e8aaecfc9c65ec0ef761eb27ea6df77e016cebf01cf62216"
+    },
+    "sound/alkamb/drips.wav": {
+     "bytes": 80712,
+     "sha256": "96f7890d2fea2f1f6443d0e75bb6084f39931e7c5399a6e75787dec4eaba5033"
+    },
+    "sound/alkamb/wind_deep.wav": {
+     "bytes": 35606,
+     "sha256": "2ebb1e71f3283c7c15d3770f46a244a35de0c448d46f058d1d662ca06d31d1cf"
+    },
+    "sound/alkamb/wind_med.wav": {
+     "bytes": 32212,
+     "sha256": "005616904ebfec049860ca33b790903e76c75615f3048dba17ce8d85cd6c65f5"
+    },
+    "sound/alkamb/wind_xen.wav": {
+     "bytes": 91138,
+     "sha256": "ffc3f8d7386db7766c885706a1247926f870957d4a3e55cd51dbe4d55416338f"
+    },
+    "sound/alkamb/windeerie.wav": {
+     "bytes": 58476,
+     "sha256": "0759ad526d301c3bb14c467818bacdbe3a64237657c45a435e06cb166b570b85"
+    },
+    "sound/alkamb/windnoisy.wav": {
+     "bytes": 25852,
+     "sha256": "02d097f0a58cc65826bde1ebe5c3450a4ab92d09b16e85ad916f62dca82936c9"
+    },
+    "sound/axeman/adeath.wav": {
+     "bytes": 11714,
+     "sha256": "c6d2e6a1107eddcb49ca41776da1c7f8a3b27766b66dbf4bd9186fba2780cb2c"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/apain.wav": {
+     "bytes": 3302,
+     "sha256": "788466ee8cc368bcac8b07c4eeca5509ccddc30addf5a322b31a605d90bf0392"
+    },
+    "sound/axeman/asight.wav": {
+     "bytes": 8528,
+     "sha256": "d5d1a9125b9a015186d6d5e9fbd9f9d9db3fb220bdf9139f5aa73b9019d37126"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/baron/death1.wav": {
+     "bytes": 68188,
+     "sha256": "0785bad4b7b721f2bb989fa74f7186552ef9bbca016fb2f1a3fe9b52650fe3cb"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/e_nail.wav": {
+     "bytes": 26306,
+     "sha256": "04fc98e42709c9a5d1a8bbd52aff9114b4922da324e30d21859bcf8209e55b4f"
+    },
+    "sound/baron/e_shower.wav": {
+     "bytes": 10178,
+     "sha256": "6c50b5da79aa99295f9bc3de1445ef76c6e6306b413b9a934122393b6b3a633b"
+    },
+    "sound/baron/f_ball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/pain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/sight1.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 12202,
+     "sha256": "2e0f2a66e528175f8636b4b832b1f5241c09237fc09081e46e6ec3e536e69162"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    }
+   },
    "sha256": "8a1845492e44c0b74933bf683ebcb9c6bfc5cdcf52de3e8ab2534968b8c8fc29",
    "timestamp": "2002-02-16T19:32:48.000Z"
   },

--- a/json/by-sha256/19/1987c20fc0859ed013c5b3d6ee9c4184b7634333c2d7e9b8abcce568fa428a6c.json
+++ b/json/by-sha256/19/1987c20fc0859ed013c5b3d6ee9c4184b7634333c2d7e9b8abcce568fa428a6c.json
@@ -12,6 +12,352 @@
   },
   "Pak0.pak": {
    "bytes": 6519389,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "7223a897f19a4ff76e6bc2aa2156b24a64749d2460fb33bcf882136b4ed6800a"
+    },
+    "maps/arbol.bsp": {
+     "bytes": 41608,
+     "sha256": "4af5e211703d8a9cc4585fd72a687622dfb7b07e5ce315c13014194de532b2ba"
+    },
+    "maps/start.bsp": {
+     "bytes": 758836,
+     "sha256": "83f8afde77e70e4aba8fc3ee69aaad760487c6b8e783b4f1356cefd0b3eb5307"
+    },
+    "maps/utem.bsp": {
+     "bytes": 2491238,
+     "sha256": "162decff47570b66bb14294d481cd591eddde6933e18064c89159a4281bfcfa2"
+    },
+    "progs.dat": {
+     "bytes": 542456,
+     "sha256": "9651158587d7dbd6059a192bf153341fe22f8d3b4ef98d6c1e8dadc8b1a00600"
+    },
+    "progs/bazooka.mdl": {
+     "bytes": 143952,
+     "sha256": "47772f91909c6d23ba031fb2faa2941ed427affea3c22a5d1b31b5e6b53ff98f"
+    },
+    "progs/beam.mdl": {
+     "bytes": 11348,
+     "sha256": "4e42c53fa58ed775a4f331b46fc31cfe537e28179cbefe579e9d9309e3a0afe7"
+    },
+    "progs/end6.mdl": {
+     "bytes": 178608,
+     "sha256": "c3e4467c2b0e2261cd8495b2563b51ea38fc9e62d1ae3e4b0d837cb3dcb3d939"
+    },
+    "progs/fem.mdl": {
+     "bytes": 252188,
+     "sha256": "ba8de6d4c3f504e33f46e6ae4d32d5034f4d49753640433b34685a94eb56fa24"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 9186,
+     "sha256": "a24a9e187b6ae44bb336e65741637cb230f719488888c2d25fc265a6bedf3925"
+    },
+    "progs/h_babe.mdl": {
+     "bytes": 26804,
+     "sha256": "9adecc483c26658401d441592a92f19337a13c65b59aa64c14a6ee21afed9d63"
+    },
+    "progs/h_fem.mdl": {
+     "bytes": 12311,
+     "sha256": "2cca1ecff95e6f62ac26991360919412957c89176ba89d367db3ed3fb7b67dd7"
+    },
+    "progs/h_pino.mdl": {
+     "bytes": 15613,
+     "sha256": "31c7c684cdc2444585256889b8d2eaa33ac2798c13e7f2e7957225560e8e297f"
+    },
+    "progs/hgren.mdl": {
+     "bytes": 1997,
+     "sha256": "61e33e422d011b5e838e19f9b04f4c40bb78e617c06a2ff566119535946337f1"
+    },
+    "progs/laserp.mdl": {
+     "bytes": 11973,
+     "sha256": "b1e9adcfe1db54c57e3ad23cab182ba70ff4f87bfa60739a4950c39ce1bf6eaa"
+    },
+    "progs/manga3.mdl": {
+     "bytes": 93928,
+     "sha256": "dbf6701a6a122d24586e2a31e72e9458a1738ed85257b0e5c335ea5aaebe8f45"
+    },
+    "progs/pino.mdl": {
+     "bytes": 148160,
+     "sha256": "5bbb2a377c1d001632f4599f49fd6d401d30c757f69135908e03b3503bbbe2fc"
+    },
+    "progs/pulse.mdl": {
+     "bytes": 15988,
+     "sha256": "a1d14c7171de546fba12a05de679b65f3106320c412269ebd16240fa83b0f93e"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_arbol.spr": {
+     "bytes": 25382,
+     "sha256": "ac41ea0df153438a64baee3ce21e51b215887059882aebf4b0a28753764127e9"
+    },
+    "progs/s_arbol3.spr": {
+     "bytes": 28028,
+     "sha256": "0cef3c604b3577916eb712d8f8a204d040001d7daf75d0de9d4445633824b9fe"
+    },
+    "progs/s_bur.spr": {
+     "bytes": 864,
+     "sha256": "6d6f512675fe19a5120f50a390bcc3e3c365b1903ba3283a06068ccb069bc164"
+    },
+    "progs/s_explo.spr": {
+     "bytes": 21885,
+     "sha256": "f5039571da0e57cb6a640bfa78a42fd8d8b5909e6838f336d2018bfecf3802d2"
+    },
+    "progs/s_humo.spr": {
+     "bytes": 113666,
+     "sha256": "849ab86bb554e4a4a8c49703bd33cc3da7b7fe331ae1605f1d1d0c10ab70d03f"
+    },
+    "progs/s_rain.spr": {
+     "bytes": 37196,
+     "sha256": "b799b259604498fc19a7f1b12e6742b0bd9c399733ea539a390394d80e88b448"
+    },
+    "progs/scrap.mdl": {
+     "bytes": 1332,
+     "sha256": "9c3ce43ddec1e72ec3612f41281599362c9292b7dab1fe4faa0e491d4ccbf2ee"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 132028,
+     "sha256": "72537f19dbc62657f16f73692fd80c96b4ed96939ad831bce447d97e5db8e59c"
+    },
+    "progs/trophy3.mdl": {
+     "bytes": 43227,
+     "sha256": "24d04eef49299feeaf1609b3c9afe106227a62e3448a7f3afe673cc64d61f88e"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "557619cf8ab2fab1e56786fc372db32d9ac6e8b8041a48bfb7eb272e944a4880"
+    },
+    "progs/v_laser.mdl": {
+     "bytes": 68732,
+     "sha256": "8e42db3ff82923040b712e82c3ef09d28e4357609a8f1c2c71f6c1c2c1a98a7d"
+    },
+    "sound/ambience/amb10.wav": {
+     "bytes": 7810,
+     "sha256": "96d8e11d7e47754736c1900b009fb85a82035474dc8491bdad64b1ac12f9f505"
+    },
+    "sound/ambience/birds.wav": {
+     "bytes": 3338,
+     "sha256": "ecf7664e89aa92bc49735b1f4bc425feb40eae20ddd41f48782406ecec24fcd7"
+    },
+    "sound/ambience/comp_3.wav": {
+     "bytes": 116227,
+     "sha256": "44713b99b38620cecbd1a9bff944ae42bae09c7b3d7cc25008a070d7de215cf6"
+    },
+    "sound/ambience/eagle.wav": {
+     "bytes": 37218,
+     "sha256": "1d38ea8d0218bd6a07a1a55d476ea027cc2e53a4c8312a98cd1ffd8df94a6939"
+    },
+    "sound/ambience/newhum1.wav": {
+     "bytes": 35258,
+     "sha256": "d2c07398d1a6ecada4987780bdac04460d4faa578a2e829f7bca8f5edf8100a3"
+    },
+    "sound/ambience/rain_2.wav": {
+     "bytes": 91230,
+     "sha256": "570ecb8b1ae06fe70ca06a268259f3207e2e081c114bd0ad40d700a366d65017"
+    },
+    "sound/ambience/raven.wav": {
+     "bytes": 4410,
+     "sha256": "e676a2c5fb3b5e0783e4efe596d3a95a6ae253e767d866fdc5bd43da12c14bb5"
+    },
+    "sound/ambience/thunder1.wav": {
+     "bytes": 41492,
+     "sha256": "f7061fe3e19eaf1cea5216d0d3c776e79224e938bde1b6124a2f115eb421969d"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 41490,
+     "sha256": "3d28310c759e38414f8794beee6e7e7cf073cb089c7a3625acf1543bf522ca60"
+    },
+    "sound/ambience/wind3.wav": {
+     "bytes": 35606,
+     "sha256": "3ea692e4d550a82dc9e815836a8772a25043edb9536e8c794f4ad9032fd5a5bc"
+    },
+    "sound/bazooka/ahaia.wav": {
+     "bytes": 7748,
+     "sha256": "b9a2527347e2272a676390b3a6bce4cf623f233a11b27d932e340ed67e72823d"
+    },
+    "sound/bazooka/die.wav": {
+     "bytes": 9260,
+     "sha256": "0bae4e5baa31c64ba4fc94df64e0dca08c06a732baea03ae4167b75e00318e9b"
+    },
+    "sound/bazooka/dies1.wav": {
+     "bytes": 8856,
+     "sha256": "663fcd16df6c845fc318a6181b2eece0678f9f3980a90ea3d34f0592e61e6087"
+    },
+    "sound/bazooka/dies2.wav": {
+     "bytes": 9212,
+     "sha256": "93f2868e3bbda78b74970a8912e8bad6f50e130692c4ce066aacdb5d51811e48"
+    },
+    "sound/bazooka/dies3.wav": {
+     "bytes": 9752,
+     "sha256": "439d327515f423fe662a8930b6a1d07d693f43331996119e05d32efc5d44457c"
+    },
+    "sound/bazooka/grrr.wav": {
+     "bytes": 11356,
+     "sha256": "8c6609a6ea9d85f10cda8dd2aa2d0fb77f5e9690698cbafbc213eb5d4f2b6f5d"
+    },
+    "sound/bazooka/ooaa.wav": {
+     "bytes": 4872,
+     "sha256": "76d5ae6f0532eb1a43493330c90966be651e05ba9eed2a994a9afaf28c73de78"
+    },
+    "sound/bazooka/step1.wav": {
+     "bytes": 27042,
+     "sha256": "fc485f8365abf042f2abb94ba4a21f077f688419e252a50fe9cfba2f55fd280a"
+    },
+    "sound/bazooka/stepstop.wav": {
+     "bytes": 6102,
+     "sha256": "79ec338698b2f8bfde44e0b5e8e31ca3d34e140ca88a45eb81c7c72b7ca31134"
+    },
+    "sound/bazooka/when.wav": {
+     "bytes": 23194,
+     "sha256": "af1c2534c69cfb3f07e160cd39f66fcfbe9d64580cb9fcfc43520637c6931532"
+    },
+    "sound/bazooka/yeow.wav": {
+     "bytes": 6474,
+     "sha256": "776a81059bc7fd0f8c998f5e8e05837686d1578c8860aad77901665c31370caf"
+    },
+    "sound/female/die.wav": {
+     "bytes": 8950,
+     "sha256": "6cf8516d992c87def74648c412187398bbca5a38ebabf87b847132ab2c6a37f3"
+    },
+    "sound/female/fire1.wav": {
+     "bytes": 3486,
+     "sha256": "5e441dcff0bc7072c47d16c6fdb7240da5c37515bb16a9f65ba92e6fef626f68"
+    },
+    "sound/female/hurt1.wav": {
+     "bytes": 3386,
+     "sha256": "44203f7119bb5b1659c02fb687f43cd6639629ffd3b6ece9c2b31bb6d6b34e8b"
+    },
+    "sound/female/hurt2.wav": {
+     "bytes": 5650,
+     "sha256": "3750428ae5b2e114a5ef2ca9d604bf69c28c4eb976870d6ba0d02d7bc77d38e7"
+    },
+    "sound/manga/died.wav": {
+     "bytes": 24492,
+     "sha256": "3ce14cdac970a150f567dbd07cf1763f695245c34f5bf4e31ec07bfeb232db30"
+    },
+    "sound/manga/ha.wav": {
+     "bytes": 2708,
+     "sha256": "ba2108ad5070860873887308293efd3a9635a6c4dcb3fb39357a9e16f89f97b5"
+    },
+    "sound/manga/hiyaa.wav": {
+     "bytes": 36876,
+     "sha256": "1446e8afbfdf48a08ca6727604b33585efdd67a6d14b4b1c96bb05c6ccd5ac3a"
+    },
+    "sound/manga/kungfu.wav": {
+     "bytes": 29008,
+     "sha256": "025b6eed19d193bd6be4c4f8f2bc7b9fb14e5c127257e570fd9fc98fd464f2a3"
+    },
+    "sound/manga/ohdju.wav": {
+     "bytes": 12588,
+     "sha256": "346d38c12edad612ec4915d3361ebfbb81b06bee9cdb73eb9b9e0d2cc2ea6d10"
+    },
+    "sound/manga/tchak.wav": {
+     "bytes": 10166,
+     "sha256": "f77d88ab76f7a092a7a5d40fb0aaf9530dc6da8e45559fcf1a1b5ea2aa88029b"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/pino/alto.wav": {
+     "bytes": 6836,
+     "sha256": "7a4cec339d65a495130adb00eaf0d1629149e3d0ec8b5b1486dea10d0d5b1aa6"
+    },
+    "sound/pino/blnkspk.wav": {
+     "bytes": 31420,
+     "sha256": "48a4dbd2add9021727d4572af9ac4c6f333a9e2ace5fe7127ddd42c84a2ae1f4"
+    },
+    "sound/pino/blnkspk2.wav": {
+     "bytes": 41834,
+     "sha256": "fc2602275102b7e1a577c30b7ab3ac2709881eb3a8798664577f8a65a9132754"
+    },
+    "sound/pino/death2.wav": {
+     "bytes": 32314,
+     "sha256": "3b1d2ed146a334ba5cf77027faa47addbf45c51159ff9c7278a97dda8ed7ef82"
+    },
+    "sound/pino/heytu.wav": {
+     "bytes": 9388,
+     "sha256": "84a0a779e3cf41908d5786eefc401898967e74c4c4b715b4e3cc82dd793f7893"
+    },
+    "sound/pino/mcruli.wav": {
+     "bytes": 8286,
+     "sha256": "27e43463bf237b8dc471cdaa2ae3e2354a1677302659ca460463f356b86e4a4d"
+    },
+    "sound/pino/pain1.wav": {
+     "bytes": 6106,
+     "sha256": "0f85b6180cbfe8d26f8d174f25c109b9d8b78d0fa53735e0494280bc8a19803b"
+    },
+    "sound/pino/pain2.wav": {
+     "bytes": 8890,
+     "sha256": "6d48429e7fc4b80be16afd80097b7096a94cb1a88922a62bdfdff64172526a0f"
+    },
+    "sound/player/plyrjmp8.wav": {
+     "bytes": 2600,
+     "sha256": "bffac30d99fefc63cd0659a6ad207bd65698915bd47aade1f1726c9f971ec2ba"
+    },
+    "sound/ruli/amb1.wav": {
+     "bytes": 28160,
+     "sha256": "a68174008206b79794d8d52fd027daf08767ce005189860c815cda021080363c"
+    },
+    "sound/ruli/cruli.wav": {
+     "bytes": 4370,
+     "sha256": "3ddc6ae41d79f5e23120add257593c035c0832e9d8668678f16b89575a47fa27"
+    },
+    "sound/ruli/fuego.wav": {
+     "bytes": 22758,
+     "sha256": "c2159ed015cf92024dd06efb5fd583004e7641205be9fc8e037bb61caea209d8"
+    },
+    "sound/ruli/he.wav": {
+     "bytes": 28379,
+     "sha256": "07c09a5732a220cf69c12804e51453e9d6b243614da1812bbfa75a45d066038f"
+    },
+    "sound/ruli/plaser.wav": {
+     "bytes": 8132,
+     "sha256": "f1e6a07551f17c2bec0b8b9dc2afc27207629a2bede43849ea828802a6caaaf3"
+    },
+    "sound/ruli/vd.wav": {
+     "bytes": 41584,
+     "sha256": "ba92783bfcb887e68af3bb57c1d3fb4071674a17066a3685ea2187dae61bf850"
+    },
+    "sound/weapons/rocket1i.wav": {
+     "bytes": 9660,
+     "sha256": "ae31e4201514b3777671ee7c3c4b83d46464c67c1b9bd8b6b32aa43af25355c7"
+    },
+    "sound/weapons/s2-011.wav": {
+     "bytes": 10051,
+     "sha256": "ce4cecd907ade67777da3fc07f4734f117f1743ece02ce9404aa61745d2351ab"
+    },
+    "sound/weapons/s2-019.wav": {
+     "bytes": 12708,
+     "sha256": "9e87e3cbe74a63898f4e56155e088b1638074a846f2f1fdce0d6e29b59900796"
+    },
+    "sound/weapons/s2-028.wav": {
+     "bytes": 3827,
+     "sha256": "f0892d94a48edb518951074396a53d6c8329ff3a99b4a830bfb16f101abc8d6d"
+    },
+    "sound/weapons/s2-029.wav": {
+     "bytes": 3064,
+     "sha256": "8e17bfb237bdbc350d7fc29c739a55f431555dc09af71cc117fc5801a378ddc6"
+    },
+    "sound/weapons/s2-053.wav": {
+     "bytes": 14829,
+     "sha256": "919d6b3ce829e7aba06cab5c1be7eabcb476a54656cd47c4a2aedbf6442063d3"
+    }
+   },
    "sha256": "696cee22c83c2ac3febe0a4e9be5ba72964f4a6f2304a0d7d562f8a0bd91f1d8",
    "timestamp": "1997-10-27T04:37:02.000Z"
   }

--- a/json/by-sha256/19/19f47d229df571e473a33c6d33e27d9702bf34d1983d7dc523773ca0028f022a.json
+++ b/json/by-sha256/19/19f47d229df571e473a33c6d33e27d9702bf34d1983d7dc523773ca0028f022a.json
@@ -13,16 +13,2950 @@
   },
   "pak0.pak": {
    "bytes": 22728286,
+   "files": {
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "ca1f749a989a7ae7517464f60da05d58e43bfdb18694b08533aff2eea47c8d54"
+    },
+    "maps/b_barrel.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/b_wbh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_wbh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "progs/aagba.mdl": {
+     "bytes": 47520,
+     "sha256": "3d241c4ef67ff5f72727a47f2a0dbd47e458eb1dadda598a2a51d6a7e317c254"
+    },
+    "progs/aagtb.mdl": {
+     "bytes": 65761,
+     "sha256": "dce6af4135b595aeaa53d8afddb55d5fce2d1f249a9a0511492f5905d170c769"
+    },
+    "progs/acidbal1.mdl": {
+     "bytes": 8788,
+     "sha256": "8a9c956f1952fb8d9ea51119c1c8c758d3ca3b3bf3bb0e8b63131bf88325f5a9"
+    },
+    "progs/acidbal2.mdl": {
+     "bytes": 8788,
+     "sha256": "eceba377145b62b4721927e55de75423daaac83f9667852b16dd1bfff3beff01"
+    },
+    "progs/akarrow.mdl": {
+     "bytes": 23072,
+     "sha256": "4e0e1c007453dbc432533dab09dfbafa943c4f43f7897848c91a516bf0de43a0"
+    },
+    "progs/am_super.mdl": {
+     "bytes": 8976,
+     "sha256": "55d561bf2f73b2c6482dcb5649da1b31d4bbf40aef6e21cca3518dc6a0c5709b"
+    },
+    "progs/amgba.mdl": {
+     "bytes": 49912,
+     "sha256": "6bae1615f796fea252e0dee7f7fd1c1198e7051b6efa27b573bda7f32983be3d"
+    },
+    "progs/amgtb.mdl": {
+     "bytes": 56468,
+     "sha256": "d6ead6677454299061d0d5c031ab86ee2bc8a110e5a3b0318e08ba6171c6625c"
+    },
+    "progs/anglstat.mdl": {
+     "bytes": 164396,
+     "sha256": "ce4644a5e22e0ff39790a293754501add2a4ad8afa26cfbdd13205c3b833e923"
+    },
+    "progs/archer.mdl": {
+     "bytes": 581920,
+     "sha256": "858ad8a4d0d27e1a9989ad7d87a9a4404ff8adbde33b07868725d34fd2146f6d"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 58064,
+     "sha256": "db1681b9fa142d49137b665aa3b39d94de6df271dfe500569c3e93027aba98a0"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 25752,
+     "sha256": "57518dd89a3dbf6e712ad204b0a6f41fd7fdc9bfc03cf4c17e222f9d31d72b93"
+    },
+    "progs/arrow2.mdl": {
+     "bytes": 68764,
+     "sha256": "0bc41c13a4332f6d13e7884248b2d1a83b487bc2f4e1d5cbbdcd1c81512a4579"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 293732,
+     "sha256": "19dcb60f0fe1927f344e82a68e2ba38e180824a37d07c7bb8a3fe2e2b5b18128"
+    },
+    "progs/bandit.mdl": {
+     "bytes": 226380,
+     "sha256": "7cc68b0c9a4950b4d3b97353227a6b8845104417efebfd00348b7fb24986d557"
+    },
+    "progs/baron.mdl": {
+     "bytes": 426204,
+     "sha256": "09a4b10b43c2cb4847330ce3660eab93c16a97a7db0c9e1c1447e938689627d1"
+    },
+    "progs/bbg.mdl": {
+     "bytes": 190836,
+     "sha256": "3bac35175b2808bad33e3b7e7c2c54b3d9181c5b3743aa68d803dbe58edf0eea"
+    },
+    "progs/beam.mdl": {
+     "bytes": 1460,
+     "sha256": "9e9531de6f4e6f2f6274ea6612ef00bd0642c0cc05a7fdc866805fa1be851b73"
+    },
+    "progs/bellring.mdl": {
+     "bytes": 74016,
+     "sha256": "9a8131071ca927803140ce6478b8912c6eb52856861250d6b6bfa1d32cfb9cd9"
+    },
+    "progs/blood.mdl": {
+     "bytes": 184,
+     "sha256": "06825646d627df610b374a31c9265a88c9c1c45864c6e3b9d273a14dc4d745a5"
+    },
+    "progs/blood_gr.mdl": {
+     "bytes": 184,
+     "sha256": "84caed23ff1b8cabec8c5d9e5c6792c30a6d9cc57c36a9746369012015462208"
+    },
+    "progs/bloodcb.mdl": {
+     "bytes": 28036,
+     "sha256": "83f0de29aa0f9e9f1d383895da374a5313aa2252edb306eb7bd69bd71660321c"
+    },
+    "progs/bookclos.mdl": {
+     "bytes": 3420,
+     "sha256": "a129ba5428a5fbef209010b893b4407c99a3d3a9e936d9d41247af5a75fc922b"
+    },
+    "progs/bookopen.mdl": {
+     "bytes": 6188,
+     "sha256": "d57ab7e96181b3fe70bc9c0c002ed6671fe14adfd454b680cd39be10b2315a05"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/chest1.mdl": {
+     "bytes": 19352,
+     "sha256": "239f897e3a390ad44acc5ffd19784f8b78232c5af2be67165581c2f6073ecc9f"
+    },
+    "progs/coin.mdl": {
+     "bytes": 44036,
+     "sha256": "c3d65aac43713c9102f8924ef7ed1cf90297ff17cfe8aface7936e9579b4ec57"
+    },
+    "progs/courage.mdl": {
+     "bytes": 14940,
+     "sha256": "4141933fbb8682ee28277826bd0f882580025def71b96c02cb9b53aa412906c0"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "7829e2cbaa4816577c77ba12a91933eee5dcf9d899f3f4d9717f6f8fc0319a23"
+    },
+    "progs/demon.mdl": {
+     "bytes": 245960,
+     "sha256": "b24014d5f453a854793b2753c11bda3130dd63c26edf12324bc376ecc9feb71a"
+    },
+    "progs/dog.mdl": {
+     "bytes": 269016,
+     "sha256": "9a60157b0504891c71fbaece5a729e9b954a5e2dffe92e1e1a1ab51c6d912b77"
+    },
+    "progs/doll03.mdl": {
+     "bytes": 52064,
+     "sha256": "b2962f3954740ad7f9b5ee329d3a189ed5c95ccbb279bb63dc77508c94e4fb28"
+    },
+    "progs/doomcube.mdl": {
+     "bytes": 8884,
+     "sha256": "c4d31e7a4f2a9c01c1c502fec3653d8e0b14fc6ec790d8edebb1737a6116a471"
+    },
+    "progs/dr1_head.mdl": {
+     "bytes": 7476,
+     "sha256": "06f28a6f55ba29f12965e7ca10d99147a9432c851a2747d1e861cd45c07d958f"
+    },
+    "progs/dr1_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "c208f5473b2954fb4af094119b5a63b3a205e7a26e94c0c122b1f06870db6f78"
+    },
+    "progs/dr1_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "258da574e4de9d144d4f6a71db72a8bd566ecc6b0672efeb5cacaf59c7dd969d"
+    },
+    "progs/dr1_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "698d06c98e8e9ab99b6ddf808bb32a4994299c9596354bf8f811cda0f4042588"
+    },
+    "progs/dr2_head.mdl": {
+     "bytes": 7476,
+     "sha256": "551d47f807e21d11aba52f66207515e0988e8a424012f204e517c8c6720514d0"
+    },
+    "progs/dr2_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "f636b0786ab159a368b9fa580f1a0a31dc7873f21edb1bc454eb9e64c2c27a14"
+    },
+    "progs/dr2_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "533c0d631c78c22f5ff7632e7dc19f5da1acee56225a5a1497bf34d10fc07344"
+    },
+    "progs/dr2_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "5f5eace00eef74eeaa9db48887636e08ab43c85ad0d05816745c04a4710f34d3"
+    },
+    "progs/draco.mdl": {
+     "bytes": 235148,
+     "sha256": "0b51fd9b782891c4b8b410db6ac1361dfa0f53d634366709434a926e0c7285b5"
+    },
+    "progs/dragon1.mdl": {
+     "bytes": 258260,
+     "sha256": "4dbf09c018ea9f703d4daf48c0a5e504208547d5d172bf26187b8eeac8a94a02"
+    },
+    "progs/dragon2.mdl": {
+     "bytes": 258260,
+     "sha256": "fa2b5d9467299634cddcff9c7ca87c2006c8c9631f45cbf66f74a8abfd5df347"
+    },
+    "progs/dragonpl.mdl": {
+     "bytes": 77764,
+     "sha256": "57db3cbef92a0f96cd8ef1be17ce77586f9541bbffcea2e7747e43b35c50effa"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "718b8c2842877345426247148dd6ce1ebe7fecc13e969a0fa0ed6dbebc388099"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "0a386b6381824b01852910519490ac3f6e3309a96091820384ee6b9a5b452e7a"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bef43e6c7bc067d3b35dd05a793c08d7d700fbb2013606ac9ffeac8772d0997e"
+    },
+    "progs/drp_head.mdl": {
+     "bytes": 2340,
+     "sha256": "b87cb902d796dd76c03e9fc79576f368d23022fbd5b5155c8910cd315046e32a"
+    },
+    "progs/drp_lw.mdl": {
+     "bytes": 7116,
+     "sha256": "ad483731fddede05ebf1a9a3c20f735f6ec341f156669833ed1077460dac8e5c"
+    },
+    "progs/drp_rw.mdl": {
+     "bytes": 8056,
+     "sha256": "b57363de0be61e45b355d1cceccadd42fdd1b8f91fc4380847dacf186d7560df"
+    },
+    "progs/drp_tail.mdl": {
+     "bytes": 2604,
+     "sha256": "b8ad65168755d4f31b657a80c78e2e0f51316c48f4ebd10ddae0b6971c7c6e89"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/ember.mdl": {
+     "bytes": 8788,
+     "sha256": "91d6f4dfbeba0711d0864b94bb372b602959644c5c841fd659ddedb8f8e6980c"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "13d14261d863f5170fb8e64e57b8ef344c435183313ffb1127ab6ce51176d262"
+    },
+    "progs/end_bane.mdl": {
+     "bytes": 52980,
+     "sha256": "4a86fd7bd59c4ecea934e3adcec4b17d627cdfac5223976a52b5739143c37f27"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 241252,
+     "sha256": "9ae37ced89200daf2d44795bef4230c5b725226a820c28cda7908f43bbdaa747"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 356760,
+     "sha256": "6ed7909a7a193f7e25bc623f1919d5c4cd45d5bd0fb5de1c13e9636a68cd9dcc"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 68804,
+     "sha256": "f3c760ecdbb530ff651c46f516228c588f37585315acdab199408911c2c8414b"
+    },
+    "progs/flame2a.mdl": {
+     "bytes": 68804,
+     "sha256": "e02210f2f6851cea4b9520476cfe36c31745dc2d84248f6a75132358d6d43035"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 56532,
+     "sha256": "36d304e1442ede2048036d832d36ef4624fe4e90ba16628c20c819e7b4477da5"
+    },
+    "progs/g_dshot.mdl": {
+     "bytes": 71894,
+     "sha256": "9f5973b2db81e67569d498ae880c4ebdf1f886fac695df50ebd93cfe5b79da0c"
+    },
+    "progs/g_grpple.mdl": {
+     "bytes": 78456,
+     "sha256": "6062e2038ad83c0427a57c832af3e95f3385bd2fdc0af3635bbd83d20edf49d4"
+    },
+    "progs/g_gun.mdl": {
+     "bytes": 24344,
+     "sha256": "f6aa476d8352bf5b7010c68387fe53121f886b26e331d8dc32b9cfabf52067b9"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 38004,
+     "sha256": "cf67c0a7ad3e853fa4af7544d0399fc0a3795a61d625f5e78104e659e2db0eed"
+    },
+    "progs/g_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "3e4a1e9dc2bff162612e218a25e2040b57d063d198df2e301eaa8fa9542af098"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 158116,
+     "sha256": "127e4fefafc5015f03a6cd1288cab9da325ed5b5a93c9f6b90b6da9d8273ef9f"
+    },
+    "progs/g_wand.mdl": {
+     "bytes": 13684,
+     "sha256": "99212b7901c31b723704e7c62b1c5f70b6a2f7320c349605a3943f3091e962de"
+    },
+    "progs/g_xbow.mdl": {
+     "bytes": 22476,
+     "sha256": "bf1cd180a66f74da4e625a2167bf66527cebd0d4009fabeed48297018db8a4fe"
+    },
+    "progs/gem1.mdl": {
+     "bytes": 42612,
+     "sha256": "0b71e525b19e25f98dad53ce766751de8e0c9f18434582bb86242296bb7a402e"
+    },
+    "progs/gem2.mdl": {
+     "bytes": 62672,
+     "sha256": "721459e22aab0d2cece430053734b889918bde4db879ffc94084289a7b6d4d8c"
+    },
+    "progs/gem3.mdl": {
+     "bytes": 42072,
+     "sha256": "3bc3a1018cc432b694f9ec45de06775776ef55d21b4e117dd1b2c7c0d7b850a2"
+    },
+    "progs/gemini.mdl": {
+     "bytes": 35188,
+     "sha256": "fa05498ce8034d51377953db7c650f9367b072a9d614812f4f67ad15eace909e"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/gr_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "3f5b6d67b80e5f2e5bb7c129500c79dc345141133f8d415005f9384b0d2d9661"
+    },
+    "progs/gr_gib1.mdl": {
+     "bytes": 6501,
+     "sha256": "3f715cbfdcd77caef11b904aa12d2063cbb973d4a9d61c27492690344c14fb1b"
+    },
+    "progs/gr_gib2.mdl": {
+     "bytes": 17553,
+     "sha256": "c6166eb6132a3e87f51fcf48f4e9eebb719b3f1819d22640582b23d61bde4a16"
+    },
+    "progs/gr_gib3.mdl": {
+     "bytes": 22933,
+     "sha256": "0e40e5b960924ca642690c26b239c89aea6bae18badcb945e96d2102cad69622"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_archer.mdl": {
+     "bytes": 22128,
+     "sha256": "034d829e2ad34eeff8f5d60b8e2064f08caee64fb7f064900298f9405e9399d8"
+    },
+    "progs/h_axeman.mdl": {
+     "bytes": 18400,
+     "sha256": "e15391056ec618b412d1341914d2e6f05a759de92500ef249cc5d1789b3ab6d6"
+    },
+    "progs/h_bandit.mdl": {
+     "bytes": 9752,
+     "sha256": "cc79629b169c0560905eae7ea9a02e5ec546af8cfa07743922e0b1dc829b29ca"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 7444,
+     "sha256": "68bc1db4875fe84f25ff3d6c53e4e9e2c023ef52bf3c89b439493f2e5c5c0e19"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "53539bc39fc87627a46b75b0d86ade5e6116a0079b032b1df137b2425b7186cc"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 100492,
+     "sha256": "863b321eb07bf0de1e7ec85b948542ace35199ac55a19ced113a6d56412244a9"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 68796,
+     "sha256": "57a646b291c29b490faa38e3b72d7f074d9d071946d9b9c6068095999a11ce77"
+    },
+    "progs/h_drake.mdl": {
+     "bytes": 28792,
+     "sha256": "be0bcf5fc725dbb09a82becc2339d91824a14a547ce3013deabeece662658dcf"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 9752,
+     "sha256": "8974b166a431397d09b393ddc08dbd30a9e5bd1fb3421145d5b819984967d6ea"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 100172,
+     "sha256": "27311a59a95ab735d79e5198318d0507da7e377584702ba9e5bf673c0972e065"
+    },
+    "progs/h_hkolem.mdl": {
+     "bytes": 30552,
+     "sha256": "38b2082ead97b90f59a5fdcf24d4077ab067c55655598d023f8ec38818c914b1"
+    },
+    "progs/h_imp.mdl": {
+     "bytes": 73284,
+     "sha256": "d8146383fe6d31374c67718ff235e83d3891ebee5a0e44539b536ce049c9ce70"
+    },
+    "progs/h_imp2.mdl": {
+     "bytes": 73284,
+     "sha256": "8d41d426350d60fe2779154a4ff240c54b56e408fae7701a1e2904a210baebb3"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 19644,
+     "sha256": "1accd89ba95db3627cee4f06f94ab3bc9d146ebf566da24b570c733f2f902c1a"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "72455aab2067fd8f887e8a8e9c61d2b943699ce90fbcb85937fbb358c9e5678e"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 42848,
+     "sha256": "8f8c58d63873025f157eb37951d2a02c9d2d0cfeabaace76db7bdba303e35d18"
+    },
+    "progs/h_necro.mdl": {
+     "bytes": 14296,
+     "sha256": "fc9c468465d0e8982fc2d6207ce94b2f400f0f37cbe88cff2a4aa64719b91f40"
+    },
+    "progs/h_nemes.mdl": {
+     "bytes": 78156,
+     "sha256": "6f350692b44907984c02779d0114576bbafb6a3ada673e1f55d1cf02fd062c18"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/h_rebel.mdl": {
+     "bytes": 5428,
+     "sha256": "b189ff3ae1596da7596f21d8f555603951fadf8e7884e96f89c8b2b5789028a5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 53096,
+     "sha256": "ff1d940222f28765b975828528016332b04423a4001a507e07cde6414847add5"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 108204,
+     "sha256": "dd7dc5c90255da868b96ac553d8a8f68b6723da6b25114bc087fd019966a023f"
+    },
+    "progs/h_snake.mdl": {
+     "bytes": 7220,
+     "sha256": "56202130d5c6cde3b652db91ceae45a2448421b5237cbf4fe5838849fe296f9f"
+    },
+    "progs/h_vomit.mdl": {
+     "bytes": 16952,
+     "sha256": "9822885036229871594a21643f4acd3a9b4c27d141b9021464b5062dfaf410f9"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "7ff66f881f85884aea56396da7b756da32c04df163a1e1f739485e77e61279df"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "2f6fd7256662a5a4b4b907b0ac68bf7d787ebd55cf54e352da5f1b363a2b2397"
+    },
+    "progs/hero.mdl": {
+     "bytes": 66388,
+     "sha256": "ea4f359a328b6416588e5debe13a87fc2eccd8a65263ae23683d71a58b39a116"
+    },
+    "progs/hk_golem.mdl": {
+     "bytes": 179204,
+     "sha256": "972f27eb2bf8a6cc4433e1f904097ca5393312d47a75e396b0323723beff58fa"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 534604,
+     "sha256": "10058c95eca9a063c7990d919d353d3573d252eb39f00c5f471a7f22f0b5fefa"
+    },
+    "progs/hook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/ice.mdl": {
+     "bytes": 2580,
+     "sha256": "30c4853e26d51d0ca4d3df5a40ec6d8861f48e9420f10560b5de0c19e6c15ab0"
+    },
+    "progs/ice_cube.mdl": {
+     "bytes": 3192,
+     "sha256": "bf96c8c1533fa537582bd4cf7bddadb7f5ddeebafbce9ef29007a5acd5a909b0"
+    },
+    "progs/iceball.mdl": {
+     "bytes": 24632,
+     "sha256": "802fa6260e9af5abb74bab0a76f35ae3e2af2373e61091c725325aa41051be7a"
+    },
+    "progs/imp.mdl": {
+     "bytes": 583036,
+     "sha256": "ca8746396a834b96eb3b6a5a2f7fe7d3930d1341a32aa528e58fc81053713a18"
+    },
+    "progs/imp_lord.mdl": {
+     "bytes": 583036,
+     "sha256": "6186f04775a695540a60543f48aad03b1d280c575399b8b68a9f69d799df74e7"
+    },
+    "progs/imp_rock.mdl": {
+     "bytes": 2352,
+     "sha256": "dbe190f471f5738779e103b496117ec40e2adc9e5f593d2470172bcbd7ade0f6"
+    },
+    "progs/imp_wing.mdl": {
+     "bytes": 93932,
+     "sha256": "d727c88da33bdcd3875509f8bf96af0cbcb31b25aa5f5b03ce1584aa0cec2047"
+    },
+    "progs/impwing2.mdl": {
+     "bytes": 93932,
+     "sha256": "6efe1dfb3290a80bc02bd47c1726a8aefc7956fa22d2e1867fbbd0557cc8ffd2"
+    },
+    "progs/k_ball.mdl": {
+     "bytes": 31300,
+     "sha256": "f93346ffeed3fd5d9866fb80d1a08216759bb27757d49a1851e471aadf757ec1"
+    },
+    "progs/key_b.mdl": {
+     "bytes": 10616,
+     "sha256": "d1333d74b7e194f6587d0f5ed1fca28887cd0414734b4bd4cbb7e715ab897629"
+    },
+    "progs/key_m.mdl": {
+     "bytes": 23160,
+     "sha256": "ea2feb6eb54823668dcb112f42c3441e563e18e3cc1806b5ce509044e6c0b448"
+    },
+    "progs/key_w.mdl": {
+     "bytes": 11576,
+     "sha256": "72da64d2b29d69605c453e9ee0e5fa8ecef91a94cc541103cb24fbad96c7946d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 232536,
+     "sha256": "e3e618799612c6e521f68234a061d9a46036ef556677b0c1651e7647258ffb56"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 27960,
+     "sha256": "5877b37cc4f98a53467c412e7d06d1f7ec6b60f5c0f2088514aa51c9d2c51769"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "210e159ea4c9bf1f2431213fd95902f4ea75ecee6a67a22bed7e93366f1f2732"
+    },
+    "progs/levitate.mdl": {
+     "bytes": 15876,
+     "sha256": "03e77b0d4b8ee7b3b224cbe0cfba63e8bd27d0391bd5069981e5435287f66645"
+    },
+    "progs/life_up.mdl": {
+     "bytes": 34676,
+     "sha256": "502716aa1b0f6cb8f929fe7ee2a74024a5fa007898256e15ca495e126888c584"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 57796,
+     "sha256": "e8b38ca8f28a89f65ffc652e082e8a9aaf6a1a9db8302e961b9ceac1c8f60e8c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/morph_eg.mdl": {
+     "bytes": 300592,
+     "sha256": "14468fccffaa1508c03610dd58fb51cd9058ca3bab036bca18f7a41cb37c195b"
+    },
+    "progs/nec_rod1.mdl": {
+     "bytes": 16072,
+     "sha256": "2eded5df9441aca7a243bf6c2a831c62374cabf7bba1acd64a84803441d77fc2"
+    },
+    "progs/nec_rod2.mdl": {
+     "bytes": 4564,
+     "sha256": "60b0923cade4c8ab9a476cae75c7c73f71c1d13799ac7901d0be4db5d5038895"
+    },
+    "progs/nec_rod3.mdl": {
+     "bytes": 4132,
+     "sha256": "459edf5ee6ecf0c52ec83e055a2c12ad39d3d3a42a4774c442ccc686e298da47"
+    },
+    "progs/nec_rune.mdl": {
+     "bytes": 19524,
+     "sha256": "cea5c89dd0034465a54a8434bc9367554f0244c2e38ec9220cd28a5a53a444a9"
+    },
+    "progs/necro.mdl": {
+     "bytes": 577208,
+     "sha256": "a0e43517f3cb579e38baf9ee4b5058ed59036b69599c0fe3ffeff9c00ba843f8"
+    },
+    "progs/needle.mdl": {
+     "bytes": 16688,
+     "sha256": "5f714f6b43cc28ca1de1246cc0175ea2e07040f73c9d0a623dbe4b4577559c14"
+    },
+    "progs/nehjet.mdl": {
+     "bytes": 19956,
+     "sha256": "fd0346c9c37d2ca7d3e696a9ce0694652722f63326376ad3b8189fb81a68f5c3"
+    },
+    "progs/nemesant.mdl": {
+     "bytes": 202492,
+     "sha256": "099c26752c7160144a25716e0af0f30f8ff179766db4a05371a0392166f85c42"
+    },
+    "progs/null_256.spr": {
+     "bytes": 5412,
+     "sha256": "c52813b634ef1ab641fdd4c3a9739ad758f1b5c39ba5e10acbbf034ee0ff850b"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 230152,
+     "sha256": "b7c88ae295ef8fc8d17b4fd6facedbb8e464ee665039a884af8e215a3929f24a"
+    },
+    "progs/oldone.mdl": {
+     "bytes": 560224,
+     "sha256": "5690a29cb0ae1a4889bc398676db8477275b0953e2ab7bbb75b717509d93c985"
+    },
+    "progs/pl_oum.mdl": {
+     "bytes": 331236,
+     "sha256": "6939a925af5510ecece22c3cee3de418d3ba532f4eb17409ca1453d253de328c"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 55676,
+     "sha256": "c9810eaac822215e7c84f11e55bb614121d17a79a02aa162fb430b5f37664ade"
+    },
+    "progs/plasma1.mdl": {
+     "bytes": 9120,
+     "sha256": "78a81a8eaaf95f85cd0fb7bc31dfa45c30e660fc5265168178b50776afc96563"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/playham0.mdl": {
+     "bytes": 99756,
+     "sha256": "1016d24c984994843af5d086e36e548c55590018f1f6b2d78799e25a40271ec4"
+    },
+    "progs/playsaw.mdl": {
+     "bytes": 87340,
+     "sha256": "b53cffd1807a3710f03b350370d78dfdbb2b057455fcac9f00d1b0baaabbf8c9"
+    },
+    "progs/potion.mdl": {
+     "bytes": 53272,
+     "sha256": "6ee1b1294f1ff41bdf265d06d80fa22a89ff579acb70bd2544986a0235ebd6e7"
+    },
+    "progs/potion2.mdl": {
+     "bytes": 195484,
+     "sha256": "c4f0f920521bd6e1caa6072b19d11ba57f4d493ffc2d6a395190170c9bec702a"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 47008,
+     "sha256": "e7ba606cf1cc11d9ad5baef5aef9dfa9239b7550a1c12937965a562bc815e6a0"
+    },
+    "progs/pur_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "dbc2bf835db1c1789c329504f86802990a19288f67d9560f32cfe5a8d5a62885"
+    },
+    "progs/r_bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "2d776e4acdf20cd117f3f4d6be3647fb9d0e117756069cbfc52ece716fdbb251"
+    },
+    "progs/rain.mdl": {
+     "bytes": 39276,
+     "sha256": "9a13a2ff68c8d8eb27426cee38330a6237de8ceb9ba9ecb9b71071512b190a94"
+    },
+    "progs/rain20.mdl": {
+     "bytes": 42620,
+     "sha256": "192d3d8197976f98eb053e54a00536ca9ccc8769692e9c483990b64afa4e1d8d"
+    },
+    "progs/ranger.mdl": {
+     "bytes": 232148,
+     "sha256": "21e690b07a7d3b2b0fb630480a5fd52ea23b41a8571c3618d16ea1ab7508e52f"
+    },
+    "progs/rebel.mdl": {
+     "bytes": 215292,
+     "sha256": "433596df8d06be0882f00a2c1fad0ea49a8ae42ef148d32e0ae7c06c420322aa"
+    },
+    "progs/red_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/reflect.mdl": {
+     "bytes": 10224,
+     "sha256": "3e8b08d02c11ee9e5546c96c014c8e698ca9097046ff3873012033c0bcac8df9"
+    },
+    "progs/regen.mdl": {
+     "bytes": 50040,
+     "sha256": "9f887be71c06ab25ada96cf8c1c2a6abb68ac9610378d9e3a2abaf2fab16af86"
+    },
+    "progs/rocket1.mdl": {
+     "bytes": 34260,
+     "sha256": "c9412482647d681e08f74eb0c0260ffded91dfc67378996b86b720ef3cd2fd47"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 17204,
+     "sha256": "0dab5b94c60d92d55df3e44a8d8ea2dc0f949e98897a6525ee0be3f49a019b08"
+    },
+    "progs/s_expbig.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 165212,
+     "sha256": "5b78b324e252f95ef8f4a9fd4fb19f855c40f74fd1f93aae9b84ed822e9c3585"
+    },
+    "progs/s_fancy.spr": {
+     "bytes": 432120,
+     "sha256": "2dcb35ecb5312709ae4b295ebcf209e74a34e385823f54603e6fe0eb8999556b"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 8016,
+     "sha256": "fa366e4076268de137e0eecd88d02e3aac99f38c48c6ad0d0a74c88c95e8d4d4"
+    },
+    "progs/s_wave.spr": {
+     "bytes": 373212,
+     "sha256": "c2a3b258b2809f22247596b6e0505829853e9a5fd60fed7c471fd663cf9e9402"
+    },
+    "progs/s_wave2.spr": {
+     "bytes": 39480,
+     "sha256": "a0fbc773e66385a8bc3c16195ce14215050cbec7caa118fecae1a0c2a2c59d50"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 333284,
+     "sha256": "90757e506c9f0e49e4e9897708df4825e1b27774ff46abd9c113738380dfde62"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/samba.mdl": {
+     "bytes": 43020,
+     "sha256": "39dba9d8cffde787d988a9754fe5bdb174ac95a4828dc3ad8db3d28501bee056"
+    },
+    "progs/samtb.mdl": {
+     "bytes": 46340,
+     "sha256": "b9b0bc86545710de58d86ea5367bd1fd2040a3670b4dc89321d56024ad92aa82"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shade.mdl": {
+     "bytes": 83644,
+     "sha256": "080ad2839fafadfdbbe5412ac53061a917af3158f33e16f5df4b4f3dbe422ccb"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 128012,
+     "sha256": "94aca4b876e4794684f4f2b9e66f1c34f7b3935b0d35d406311b63aba17ea3c2"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 176048,
+     "sha256": "7ea0c1007179eb7a45112aaf38d8042213e8b644e6e79b9b1a8d4402c3843b47"
+    },
+    "progs/shubdome.mdl": {
+     "bytes": 97512,
+     "sha256": "3b92e43bc942b2cfba8c7b4e1206ad858484564d86bd7faa069db592f98c7232"
+    },
+    "progs/shubstar.mdl": {
+     "bytes": 14760,
+     "sha256": "ee5f914d7f3f930db06b1ead8d314dec0413e5182b7de24cc808076d117f3cda"
+    },
+    "progs/skulbook.mdl": {
+     "bytes": 15572,
+     "sha256": "794768c4237a3efedf0c13026213aa417dec5be7eba7971f6e1113b5167fb904"
+    },
+    "progs/skulhead.mdl": {
+     "bytes": 50688,
+     "sha256": "d0733746c8b7cfccdb8d0f30f9454c8863a470e6d56e8359828dbb450aade77a"
+    },
+    "progs/skullwiz.mdl": {
+     "bytes": 726948,
+     "sha256": "e6c5d266321455b7bb09834646d3dd6b6e212406aca999eddb666da9ccc7212b"
+    },
+    "progs/skullwz2.mdl": {
+     "bytes": 726948,
+     "sha256": "3df14137a65ec782657de1820320b8e5377fd89859ffd44d5f566cd9845c311f"
+    },
+    "progs/skulshot.mdl": {
+     "bytes": 63400,
+     "sha256": "73d6d8e5411b9ae3cf815c3b0cf695a5633cedd5d586565880a9146a1a5db5c2"
+    },
+    "progs/smartbal.mdl": {
+     "bytes": 27924,
+     "sha256": "288e2d54afcbdc5242ab831f3ef611710317c52432e4585a938a12df80b7a07d"
+    },
+    "progs/smoke.mdl": {
+     "bytes": 184,
+     "sha256": "2086abd9950bc643446309a80d9df86b4ebe3f2086f75e799ce943a8454c77d7"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 143668,
+     "sha256": "d91fe049aaeec7fee2ce0f11795889a872d7743df773aa5cf3b9be4d817a3fd5"
+    },
+    "progs/soe_coin.mdl": {
+     "bytes": 26364,
+     "sha256": "5769371db409969600bd51d573162c663fb75d358c507fcff9a4aaea95fed4dc"
+    },
+    "progs/soe_gem.mdl": {
+     "bytes": 165236,
+     "sha256": "788f32633f1f3a9f6dd2e0c2dccb76871e02fc6e002db82a219f077dcc493c3f"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 234936,
+     "sha256": "c5900e7784535c5eda950cfdfe2cbf3d2d304b8902c2f8bd4987df87d7039cc3"
+    },
+    "progs/soul.mdl": {
+     "bytes": 8436,
+     "sha256": "eb4dc0dae8aed7c92d328096fd9633566b658c9cc65777211ade1e67c6e0ff64"
+    },
+    "progs/sp_gib.mdl": {
+     "bytes": 22228,
+     "sha256": "e902ce3a5e4be26cb781d29178b6e808c480f9e898bc50ecfa78ddf12d774238"
+    },
+    "progs/sp_gib2.mdl": {
+     "bytes": 22228,
+     "sha256": "be98f64e7c2cffce98e28d99b36856762cc15caf761015067fde234390e6b302"
+    },
+    "progs/spider.mdl": {
+     "bytes": 355540,
+     "sha256": "b7ba038ebfab94718a5aa328f0cdeda14040ecc7de70c080caba58ee1ad84a07"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "078b774958c598bdf1503934d51a1393aeb9aadebcde806db2272b04b233c6a2"
+    },
+    "progs/spikes32.mdl": {
+     "bytes": 7668,
+     "sha256": "983176e5f12571f9b38c9c5d100841e480fe8ccf143889a0e48292a5bca8bf63"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/st_gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "813d52c557a1eb519d801652b4bd63acdc4ec18d62db53d843ca3dcaa88e87e8"
+    },
+    "progs/st_gib2.mdl": {
+     "bytes": 16228,
+     "sha256": "2d40c1eb75eeb6f5e1781ee9db7a0be10e0d07297d563f9035a8965c4c8c3d01"
+    },
+    "progs/st_gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "d44a77787c5ff633593ad9741ddfbe28809431daf3d32fbe92f8512871b9018a"
+    },
+    "progs/t_coin.mdl": {
+     "bytes": 35040,
+     "sha256": "ed7a18cfce56a630c9adaa37757e270419fca318b3fa655fea18002b089441b0"
+    },
+    "progs/t_gem.mdl": {
+     "bytes": 165364,
+     "sha256": "955761ccf88ef8f6adcd635fb70ae5d8e434b19394a15124acc4370e614f2409"
+    },
+    "progs/tar_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "1ef69998430a54ba662abb46a0ef303b3bf0066f53e84b166065e79d58a72bef"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 313448,
+     "sha256": "fc63e6f62c83975ab2756f0a844d012b887491a6c73d9350dfcb04a6e0355b3c"
+    },
+    "progs/throwax2.mdl": {
+     "bytes": 34872,
+     "sha256": "11a22371cc72adf001e21d04e1b8b65e01497f56410867aa42ea21c0ff304e48"
+    },
+    "progs/throwaxe.mdl": {
+     "bytes": 56532,
+     "sha256": "0ebedab9ab397ba15dc3f0d90df703af2984d1c070eabc08ba781c308968150e"
+    },
+    "progs/throwham.mdl": {
+     "bytes": 7072,
+     "sha256": "f161fedb096a34db55fe57e84acd2bc42295ffea688549235c762b9a70430b35"
+    },
+    "progs/tome_pow.mdl": {
+     "bytes": 2612,
+     "sha256": "40a792071152640897de449d672a693229a87a11bf5e37ab05fd1656be22b6cb"
+    },
+    "progs/tree.mdl": {
+     "bytes": 126509,
+     "sha256": "7705f8b4e337bd370dbd0392d33da437f08768723e6d43725ddbb07ac3662b9b"
+    },
+    "progs/tree_zer.mdl": {
+     "bytes": 101704,
+     "sha256": "f5dad886e64ef946b0ad0aba3a06da419579911c5248ee856d2d503e40c4beab"
+    },
+    "progs/treetall.mdl": {
+     "bytes": 120532,
+     "sha256": "e74e7c38099ccc833fadf3c7b7e97f746878d07102dad8cc5926546b344cb982"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "92a88337ebfbbb81ae0ffb96e97ad9c859422db93f59e2e220578baaa6caf446"
+    },
+    "progs/v_dshot.mdl": {
+     "bytes": 77102,
+     "sha256": "8b54bab3a0fc20bbe27ed1ef204fc4dc21c8c6ab0d9a6efa82038d570de5aacf"
+    },
+    "progs/v_grpple.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserb.mdl": {
+     "bytes": 43852,
+     "sha256": "67e854c43efe348faffcc1aed8415a8e68fe2069ec94447a3610b580b72f3f88"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 47252,
+     "sha256": "86cb778c5e84f2523a8d47a8d1d021e46e9a6af343fd69b84805e783c800b033"
+    },
+    "progs/v_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "a2d573bdf52015bce7a571a2263a3e8d938daf0bc1b5e4589f84580cab7da2d4"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 165540,
+     "sha256": "abd6787fff37c452fa01f4bbc9eb9594311eaf4a794f161caeb5a501ab9e103f"
+    },
+    "progs/v_wand.mdl": {
+     "bytes": 27388,
+     "sha256": "b46ba82a45a24fe4833dfdfd3c9457b98096a5800d6620d6eae11895653a6698"
+    },
+    "progs/v_xbow.mdl": {
+     "bytes": 95168,
+     "sha256": "e65f7cfe84cfa7c84c34147dadcc8b5ceea9416c7e378bd2110961fd76348e70"
+    },
+    "progs/vomitus.mdl": {
+     "bytes": 79724,
+     "sha256": "03dffcc3405c63f0e0c11301a74da5403d957b66171a6f34eaf8998e4ba31550"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "7758aaf42d0d1617e4fb172ce842be4316073f63250aba46dad441327cccb2e6"
+    },
+    "progs/wanted.mdl": {
+     "bytes": 27860,
+     "sha256": "03337a468db14377fcd36842037d2a27dfb97c3d5d5f45fcfe408e79050a5839"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 67956,
+     "sha256": "39c4a5daef1cfafc1bbfff1ca8eebb5c75d27f953f31d29f249205762605a56f"
+    },
+    "progs/wings2.mdl": {
+     "bytes": 28980,
+     "sha256": "5342d6191f59e69eb830a5e833473ac253b3a7750063d5519f6d2da2b82f5573"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 109380,
+     "sha256": "d78cd5ac1d667ec808fc7664071e060cea40179a0ba094e2f4c119d5ef7a79ba"
+    },
+    "progs/wr_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "1bfb049cf920973e32d78cbf7cf8b6c0c18f8dde55006ee43798ead4b99af9a7"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 238732,
+     "sha256": "5d0f3d6b32bfec300894dbf066a15bd9e34b985919423446232ad85d2ad6d6b7"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 226776,
+     "sha256": "f4d35645fa47d159cf7dee47a1652ff239cbe7a7b3df8567b865c6d44536abf4"
+    }
+   },
    "sha256": "0a75ac261184e66ce629178062ebe6109425e1a477a568c5774e1f9ddcfbca3e",
    "timestamp": "2009-12-11T21:02:54.000Z"
   },
   "pak1.pak": {
    "bytes": 15442231,
+   "files": {
+    "sound/ambience/amb21.wav": {
+     "bytes": 80716,
+     "sha256": "d664ea08d9df7e7dd135eb0726c1bc142878dcc53d13564dd3dcc5562180201a"
+    },
+    "sound/ambience/amb22.wav": {
+     "bytes": 92716,
+     "sha256": "f444289984b285a1497f55e566fbbf1896a04fa38e291efaa3ec1a0720204811"
+    },
+    "sound/ambience/amb23.wav": {
+     "bytes": 40180,
+     "sha256": "e451997ac7f37d08bd8434d708f45ee2967693317684b947ce511c9df84828b3"
+    },
+    "sound/ambience/amb24.wav": {
+     "bytes": 42282,
+     "sha256": "ead78c8507a7a6a7d6c61e913a2319964f6a8f70b5f7f720c162725edd9cd5aa"
+    },
+    "sound/ambience/brik_hit.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/brikhit2.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/chant3.wav": {
+     "bytes": 116346,
+     "sha256": "5d71f12940688414ab8cabc0d88e323dc961b60aac66f17887712133f1cb8b29"
+    },
+    "sound/ambience/current1.wav": {
+     "bytes": 50906,
+     "sha256": "dabe357d48586dccb8e1ed18c49828797c9f7a8c02c7a588ddc76a62c9b1d3e4"
+    },
+    "sound/ambience/drip_amb.wav": {
+     "bytes": 105444,
+     "sha256": "b282bc6082754011ee21a82aedb490a856c0f694f57991992296554c13149b02"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/heart.wav": {
+     "bytes": 8190,
+     "sha256": "a5b42c46cca24da59c324bb28ce6887b3a2a3baafcc18b0db2b2485f1189a4e0"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 177840,
+     "sha256": "9daec0732dcc821670b8910a1371153e3829e604b6957bf95931bea416af6074"
+    },
+    "sound/ambience/mov_watr.wav": {
+     "bytes": 44432,
+     "sha256": "9d6721844fd5559ab4f53902e70ad9789a90710dde082d222bd814a36c00ab67"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/spark2.wav": {
+     "bytes": 61640,
+     "sha256": "7eb18b00cd5e7913fea7a85ec5b1db159d1d001d24d4f687bfdb5685cb163c8e"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 106286,
+     "sha256": "056f37dfd1d5f4eba1d1911245dc0930bb0c46a84d72d867a286e5a9540248a0"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 87710,
+     "sha256": "2bb46f7c8f70fd28f0ca47b294824bcca7689047291b6c5259eebe76ad6aecfa"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 140630,
+     "sha256": "5a4dccd168cbd9f759ac468d7aa879dbcdbe5637e0fd0521f641ba1d60f61817"
+    },
+    "sound/ambience/th_clap.wav": {
+     "bytes": 570992,
+     "sha256": "5b93e5d878621c2a92e66d6214b0fa8acf8ad5a35f4120f456ddf5678e941d94"
+    },
+    "sound/ambience/th_clap1.wav": {
+     "bytes": 72062,
+     "sha256": "1fc3146d501953545b2f2f261cd2fc398959a79c753a291702609b4cdd2e8682"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/wall01.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 28798,
+     "sha256": "f66c76f07eef275e904fcc76d7ca9fc2011f3de8c61ce0b3ad035464beb7a86c"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 110578,
+     "sha256": "c3e1ccb091b9d8a06b83530b5e29b9f26f5ad8b9dcd082f3da976c3d44944b87"
+    },
+    "sound/ambience/wingend.wav": {
+     "bytes": 90874,
+     "sha256": "63e435d896b097d4dc413fb1afccc2078f1d101a4f7bfc18c4e593ca9e8b344f"
+    },
+    "sound/ambience/wingget.wav": {
+     "bytes": 65148,
+     "sha256": "533bdbd7beffa4c71c66239e3ac417f2177b20a60ed39c379c59a10b2222b367"
+    },
+    "sound/ambience/wings1.wav": {
+     "bytes": 6028,
+     "sha256": "c9e05f66a1d728a88289bc213c9f3551f1e54a4f3e8ef23ab03f8d5019e7b2c5"
+    },
+    "sound/ambience/z1m2mus.wav": {
+     "bytes": 103768,
+     "sha256": "d54261d4c9a4a8a9fe0c51eeae343c6a5b381727af88d0bae6f9b40605b8e5d3"
+    },
+    "sound/ambience/zend1.wav": {
+     "bytes": 123618,
+     "sha256": "2df6c267197b2e82241e47ce4985b04d14e1ce3cff46cebf3177369057302bb6"
+    },
+    "sound/ambience/zend2.wav": {
+     "bytes": 73742,
+     "sha256": "0ea00395004f11d41ab60352517bf5ff5c88a73b8ff2ddb3f32b5085967e3003"
+    },
+    "sound/ambience/zend6.wav": {
+     "bytes": 252626,
+     "sha256": "3f3c412e55bc7534c423c0d1bec2d817e3aea06338b4d6c3f78c4b80e55d509f"
+    },
+    "sound/ambience/zend8.wav": {
+     "bytes": 112122,
+     "sha256": "27cef28aa3d6c3ea86f0c54168db07055abfc7af284bc5a35bf53a0e53f8d677"
+    },
+    "sound/ambient/amb2.wav": {
+     "bytes": 38416,
+     "sha256": "21a4f41fb5efb52587e60395f23824ef330674a8d9499fe2cda1c91603093bfc"
+    },
+    "sound/ambient/amb7.wav": {
+     "bytes": 43020,
+     "sha256": "de7f4a0d15c711c9ca63f74ee38acf78e4ce41800900e0193a43c3e55e4efde6"
+    },
+    "sound/ambient/comphum1.wav": {
+     "bytes": 20456,
+     "sha256": "af10cad0f193d07be9c98f0dd889840fad0f54f40a61d12a1325b78033a68c8e"
+    },
+    "sound/ambient/comphum2.wav": {
+     "bytes": 72367,
+     "sha256": "fbf1ff8677cf36d78e381437f3b8e758a589a108a50c92f24c514eda06ede3f2"
+    },
+    "sound/ambient/comphum3.wav": {
+     "bytes": 116441,
+     "sha256": "62d9624940b93bcd1897abb809cb9d6f2cb3872cfd6af9a792260fb17f800150"
+    },
+    "sound/ambient/fan.wav": {
+     "bytes": 54275,
+     "sha256": "6cdc6a19b0c740d5607fa9076f749dc485483362445630877c6b59ec67085a2d"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/l_hum1.wav": {
+     "bytes": 20790,
+     "sha256": "f1b8bb19b32258ca1b126d52eb98b17c2753a255eba60864f8ad325f564681c7"
+    },
+    "sound/ambient/music1.wav": {
+     "bytes": 213944,
+     "sha256": "bf498e0cf6541b3559abd978ac420c5cb19d6542d89f19f59bdba8019dc46688"
+    },
+    "sound/ambient/pump3.wav": {
+     "bytes": 40435,
+     "sha256": "ae8ca71a1ce41bb3fa02d993930b4f100db3827ef5768326a91e61f7857370bf"
+    },
+    "sound/archer/arr2flsh.wav": {
+     "bytes": 5464,
+     "sha256": "e9a0c059430744c6546a6be4be3a1e4ac775ea6c5e6440d14611ecd8c8447d19"
+    },
+    "sound/archer/arr2wood.wav": {
+     "bytes": 5458,
+     "sha256": "97c5106007e703618291242bf1c6db9853a9d625189fc26ec9c4864436b560e3"
+    },
+    "sound/archer/arrow1.wav": {
+     "bytes": 2296,
+     "sha256": "4aeac8630ff6036f095a251a018eea5baad7a59bd7e46f624dbfec793e44d7b4"
+    },
+    "sound/archer/arrow2.wav": {
+     "bytes": 3196,
+     "sha256": "0a2734df5a69f6407ffc34ab05d8655da5d7dc0e487627932390fa6cec022083"
+    },
+    "sound/archer/arrow3.wav": {
+     "bytes": 2156,
+     "sha256": "1b866280829cb7ac051f90609baa8db285f3bfa3a27b5814e72b021b7cc05785"
+    },
+    "sound/archer/arrowbrk.wav": {
+     "bytes": 5002,
+     "sha256": "f72e35d5232f40e503192ff0ee26fe152eb42e5ee7141b2bea33a9f12f38aa2b"
+    },
+    "sound/archer/arrowg.wav": {
+     "bytes": 15132,
+     "sha256": "8ec5ee520f81c69ba367ae549a06d5ea1643b43f81dea7d8345561c94c8412ed"
+    },
+    "sound/archer/arrowmet1.wav": {
+     "bytes": 2638,
+     "sha256": "87e6ef50bfe4dabf48a1fba18ad0138bbd298965f1a9d06e2b059019e6f74b60"
+    },
+    "sound/archer/arrowmet2.wav": {
+     "bytes": 3118,
+     "sha256": "2797466dafd51473b8b6b5fd3d02a5baa4fe92a1bf9342fb038a299230037138"
+    },
+    "sound/archer/arrowmet3.wav": {
+     "bytes": 2804,
+     "sha256": "1e77951ec2218add2a8bc1633a925e4a96d2ca247d7b5dfaaaefd7a9a4f2363f"
+    },
+    "sound/archer/arrowr.wav": {
+     "bytes": 9458,
+     "sha256": "10e4bef745e55fddd004ea78d24edb9d3d9edc1ce3053c377be07be27a4da144"
+    },
+    "sound/archer/crash.wav": {
+     "bytes": 11069,
+     "sha256": "60e704bdfdb0a97863b00f3514130a172b95a86bebbf89642b65a6e757a74259"
+    },
+    "sound/archer/death.wav": {
+     "bytes": 9526,
+     "sha256": "e824b3d7d66e8bfc3ce30cc3116eab1b2d2dbc09c6311f91ff25d3e7eaef19f5"
+    },
+    "sound/archer/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/archer/draw.wav": {
+     "bytes": 6874,
+     "sha256": "c94e5cec38dc40102beebd067554c91e63b86e5c1ef11dc17976733bd9f08ce3"
+    },
+    "sound/archer/explode.wav": {
+     "bytes": 17788,
+     "sha256": "1f7d6debef492f0861ee24049ad637a11b85d595cdf3f6d6aac422b7a0376d14"
+    },
+    "sound/archer/growl.wav": {
+     "bytes": 9240,
+     "sha256": "7bdbbd23b3fe056cd1d904124824aa0044acf3aa19ec88f65e092fd13e4b9437"
+    },
+    "sound/archer/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/archer/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/archer/pain.wav": {
+     "bytes": 5082,
+     "sha256": "5347daf1a9263320f25b2a191895fbf6c85278f1fde6ca5962c09ed38e0b37b0"
+    },
+    "sound/archer/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/archer/sight.wav": {
+     "bytes": 16866,
+     "sha256": "bcd12d078e7bc34f0bdea7ae9a34ccd2c9bacb049617329b44f8301c34fffeb0"
+    },
+    "sound/archer/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/bane/death.wav": {
+     "bytes": 10935,
+     "sha256": "7e4775bc543acfb421a446a00efff6d9d5669fafb2387464cb1e1ae3db91efe8"
+    },
+    "sound/bane/growl.wav": {
+     "bytes": 9045,
+     "sha256": "86e7b3d2e685d7c20e503bdffe676727426b606ef069f4b70f182601e910ec4e"
+    },
+    "sound/bane/hit.wav": {
+     "bytes": 3884,
+     "sha256": "228faf88857d697f4d5fb9b9c03f000af4dbc8b254791e18e973fd48cc96db9b"
+    },
+    "sound/bane/laugh.wav": {
+     "bytes": 22108,
+     "sha256": "ae8e8d13e00f41bce729977f09a92806c8451ebe5cb4e8618a6b79df4d70296c"
+    },
+    "sound/bane/laugh2.wav": {
+     "bytes": 31560,
+     "sha256": "5cc5ff4c3be35eec90eaaa6579a55fa843843ad658e2e4bbb258a77f6e410020"
+    },
+    "sound/bane/pain.wav": {
+     "bytes": 9325,
+     "sha256": "1d4cfac1f9dfa1ec6958b18014ec7be18dc2615e64888d3c584d50bb48e51013"
+    },
+    "sound/bane/sight.wav": {
+     "bytes": 22962,
+     "sha256": "fbaabe115d9ca4b985c4481ccc71e6b6f55931394a29a6c51ec97e752ed3d5be"
+    },
+    "sound/bane/thunder.wav": {
+     "bytes": 43130,
+     "sha256": "cb355478e38df678e859557a0f983120a4d4275272d8ebedcae7c9cccf659bc4"
+    },
+    "sound/baron/bpain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/death.wav": {
+     "bytes": 8576,
+     "sha256": "3dd3a23d5a913548d0d0aa6ee1b455017648fcd4830f204539a1626c2ec8e1c9"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/fireball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/icefire.wav": {
+     "bytes": 8858,
+     "sha256": "b529a958de192b59438989c6b98eb50f858273febab53a238b651c70a3c92098"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/shard.wav": {
+     "bytes": 14324,
+     "sha256": "313428dd2cb681a38ad89983ab39b18979f64b3e398104b1ad80f3dc9726616c"
+    },
+    "sound/baron/sight.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/bishop/conjure.wav": {
+     "bytes": 54627,
+     "sha256": "532d4b7d5db6a654aa73dfe18fa0f6a71623acfd804a848f106b0af699022bc4"
+    },
+    "sound/bishop/journey.wav": {
+     "bytes": 42051,
+     "sha256": "0995e55661447c53c3a36ae4552ea2e0bb7ec8b178bf52cdabe9d28b4deaa50c"
+    },
+    "sound/bishop/rip.wav": {
+     "bytes": 31906,
+     "sha256": "7070871da7ec08da6260a65f1a98ed1bf9682b1c95c51cea262a4b88a63fb6ca"
+    },
+    "sound/bishop/rot.wav": {
+     "bytes": 22463,
+     "sha256": "866b836874ba611d70675e5e3b83eac059c927bef0e0d1396f2183ea01bcc203"
+    },
+    "sound/bishop/skull.wav": {
+     "bytes": 34293,
+     "sha256": "48836a4d60ed8962ed0f11bffdcca95a200645e3b2cfa49a598d6392e10dc153"
+    },
+    "sound/boss1/explode.wav": {
+     "bytes": 27690,
+     "sha256": "b7eebbb64696612ee18d8d1e25b9c5cc334a4562cb99758a446a22490215f349"
+    },
+    "sound/boss1/explode2.wav": {
+     "bytes": 14798,
+     "sha256": "4c6b14b163905823f629644fbec088f37f712cf7f76e10e2f91ef23f2b573ae6"
+    },
+    "sound/boss1/explode3.wav": {
+     "bytes": 19028,
+     "sha256": "69ef0c65811704d8996b726d6e2cbcf70528d3ca7b2f28ec8814c20e7ab76ad7"
+    },
+    "sound/boss2/pain.wav": {
+     "bytes": 84796,
+     "sha256": "b9c255890f61771966327ad49994306a1e3de4b702163a079b5a733b4016810a"
+    },
+    "sound/cube/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/cube/bc_attck.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/cube/bc_gulp.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/cube/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15692,
+     "sha256": "72e737f04f1d34044dfd812c6b0e233cd38a91e6b089633e312678756952de87"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16625,
+     "sha256": "bd4cd7902712282ef8f2f749e6fcf805c2ac5212994fbb1c22fc0fe0ea5d08e2"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15527,
+     "sha256": "0b472a984137667f4788336a4f7c60e07a8893f47317b2a158aeea39920d729f"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4107,
+     "sha256": "8fe56b192838dafdf7ff4737cf1e5555d3295cbca49c1ab83568281ee188153c"
+    },
+    "sound/cyber/cybidle.wav": {
+     "bytes": 11894,
+     "sha256": "af7b96ed2eb5bc55900957b3e4136bd5dd93a72dcebca3bc2eb67cdc5186d32c"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8122,
+     "sha256": "3ea23b8d7a68e754211a10a5338b0c8d65df6e2138d4cfe06cc053b9a0f601ae"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13081,
+     "sha256": "a5ec6d4eaa707ad0246b7a7e7737b1007043ea5e5634f6f63661ecc20c27c459"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48508,
+     "sha256": "b7aac875623f8dca7597eff3dcab5910453d043fd1f9df20da89232ce8bf9306"
+    },
+    "sound/darklord/death.wav": {
+     "bytes": 10761,
+     "sha256": "7f32e12c649aa4fc4c2edb773c45b6b4258d048176d95e060390834ee7b52493"
+    },
+    "sound/darklord/idle1.wav": {
+     "bytes": 5632,
+     "sha256": "c151a3cf537f5c3668fc116e6ef5c70c9286e8a12097f376ecdf8a04774926a1"
+    },
+    "sound/darklord/pain.wav": {
+     "bytes": 12684,
+     "sha256": "f332a8cdf67fe414966f59d46714154c94de7ebcca3880a47ef5bbdad2c03ef0"
+    },
+    "sound/darklord/sight.wav": {
+     "bytes": 16832,
+     "sha256": "9710267844facf1c627ea0a8f0df458d847eb899dccd9c570e9d967acc64fa07"
+    },
+    "sound/darklord/sword1.wav": {
+     "bytes": 15982,
+     "sha256": "d36670980603c18a67d500707de9db5a8d54128601d6a6c67f7f29677244aebc"
+    },
+    "sound/darklord/sword2.wav": {
+     "bytes": 12434,
+     "sha256": "f7730881c690e0ee6a440756f74630a21241239fd1fd3bbdfd88000c7e57d1cc"
+    },
+    "sound/doomcube/dsbospit.wav": {
+     "bytes": 43719,
+     "sha256": "97f61cb588bb405cd235e242bfca6fe1108171625a7aa4f2573d63682ac42e32"
+    },
+    "sound/doomcube/dsbossit.wav": {
+     "bytes": 57109,
+     "sha256": "5843548ad38c8eea72548481b5833590fbb7fb990daebd0ede4aaac93475f461"
+    },
+    "sound/dragon/acid.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/death1.wav": {
+     "bytes": 18358,
+     "sha256": "645baa1cccaf1dfbcd628d17fd8ea290f42f1bc40903e26c79a536a6d1528a2a"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/fly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/flywater.wav": {
+     "bytes": 11034,
+     "sha256": "68cac399467a55df3c80331696869309eea2339467df0ba94408be4fa2afeb3e"
+    },
+    "sound/dragon/ice.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/icehit.wav": {
+     "bytes": 9370,
+     "sha256": "089c07d0352678106aaa1c47f015792393d5aa01b4bd64fa35e798c4ee09108b"
+    },
+    "sound/dragon/idle1.wav": {
+     "bytes": 34068,
+     "sha256": "3a125f0bcf2908e4ba3af298b117f71c0efa43be4077e53c791b2805cce6a038"
+    },
+    "sound/dragon/idle2.wav": {
+     "bytes": 21474,
+     "sha256": "e1101ff0121687511a9c978d0a30a945421d0a2a30b7d139e4427d41dcc17628"
+    },
+    "sound/dragon/pain1.wav": {
+     "bytes": 6524,
+     "sha256": "6cdce2fde3a1eb328007e0667c5dfe705e87bcd526e416ac948fa11a36448ac0"
+    },
+    "sound/dragon/pain2.wav": {
+     "bytes": 6875,
+     "sha256": "3238b77aafcc60c634cbdbd47ae1eec99bb969e2161b72ce5623398e6a451d2a"
+    },
+    "sound/dragon/sight1.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/sight2.wav": {
+     "bytes": 15205,
+     "sha256": "197238a35261e6792c40a4da38ba7b3827116ac1af5f143e092768346605b470"
+    },
+    "sound/drone/drnblip.wav": {
+     "bytes": 2106,
+     "sha256": "b372ece13de5edfb22d88ff147a9eccfddfe446c9403607d89daae09fc7c8b68"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/force/force1.wav": {
+     "bytes": 30022,
+     "sha256": "b609981695694648cab0f2ed521dbf3d6f31b6c2e8c3e8502ab4740c7a105557"
+    },
+    "sound/force/force2.wav": {
+     "bytes": 10252,
+     "sha256": "32c0342dbc9e63220db18fa706ac0fc1afe9a86f4d488e509e1f52bee955e3cd"
+    },
+    "sound/force/force3.wav": {
+     "bytes": 10252,
+     "sha256": "0317e18dab002184b5ce11a2b86f3263d2606c40f2dc435c824bbd075c1b621b"
+    },
+    "sound/force/fusein.wav": {
+     "bytes": 13669,
+     "sha256": "53192c25adab70ebcf471204aa194ef9d34c4161138c728d95f84cf08310a879"
+    },
+    "sound/force/fuseout.wav": {
+     "bytes": 15379,
+     "sha256": "f515c6b48204f2ba158e99c10a9da60cc45756ea5dca716e256ffbe54a017512"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/goblin/death1.wav": {
+     "bytes": 13890,
+     "sha256": "bed0d074d9aeee8f046ec7b3a9d33e02d157374ddf6af1296bd1ca7bebf30f10"
+    },
+    "sound/goblin/death2.wav": {
+     "bytes": 10280,
+     "sha256": "9cc07020579d50185ea401835e41edbd1c8f007065e39a6306c7aab4f32e7781"
+    },
+    "sound/goblin/idle1.wav": {
+     "bytes": 9802,
+     "sha256": "6c5a8c36eedb0ac5bddacfdf68250c36fe472f9d87e8969b4f95a863a99b77ce"
+    },
+    "sound/goblin/idle2.wav": {
+     "bytes": 9242,
+     "sha256": "5850c885e59ef04ae90be0579dd6f6b7cc26c282045ccb163dab2c9e19fea704"
+    },
+    "sound/goblin/pain1.wav": {
+     "bytes": 5118,
+     "sha256": "8afd94fcaa2d20e7c6626eda0c6cd5463670a1dbed0eeea36da588b28196c8a2"
+    },
+    "sound/goblin/pain2.wav": {
+     "bytes": 7898,
+     "sha256": "ad1f3b63b4ae35e4bfe010447bbd18bb85cd2bbf966ea7e1370afb0e924e699c"
+    },
+    "sound/goblin/sight1.wav": {
+     "bytes": 12716,
+     "sha256": "1c20028239d217f31af57649da5d1a6def576569ef5fc7e7033c2acbef7f9345"
+    },
+    "sound/goblin/sight2.wav": {
+     "bytes": 19356,
+     "sha256": "c9182325cacd9734bfedd48cb5d8076d5823b7a94baa40d32b02de9504474b48"
+    },
+    "sound/goblin/sight3.wav": {
+     "bytes": 8526,
+     "sha256": "796b2f9f0a1c20d672382c6681e9a6ea200fee2cfcacb5b3d3faa72c8e2537d4"
+    },
+    "sound/goblin/sight4.wav": {
+     "bytes": 8668,
+     "sha256": "c0a60baf2b9918a6df5fc32cd8b58c9fa7cfed923a4cb21c841f04f7a544782e"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 27521,
+     "sha256": "424ceef852229e94dbbbc879f1546a8dfda90db93c6263700cf4973805e4bea7"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 16192,
+     "sha256": "98d55bc63eff48521faeed1046064569e932986e734168ba0973c184aa2f5d12"
+    },
+    "sound/golem/step.wav": {
+     "bytes": 11226,
+     "sha256": "851e243a2e6ecf4cb637f8c4368b0f25443d4f9d104733eecfa886c40ee92bcc"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 47176,
+     "sha256": "87f013eb50cb30a967a183f0cfa41b4848f9269afd13dbe1ab5053458bfc5f0e"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 10768,
+     "sha256": "c48f2415db3a5067dfbd99ad580e3f4809532743d653eafe2fdb924fb0bb832e"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 47502,
+     "sha256": "a0c0bd639af614c7714388009c9388f6db9a694e7ecd8fac38653609d6958f61"
+    },
+    "sound/gunner/death1.wav": {
+     "bytes": 67190,
+     "sha256": "14f89744b8f7225e0eefd9e291aee533fd9f759b6351b57d357d9597dba90956"
+    },
+    "sound/gunner/death2.wav": {
+     "bytes": 48066,
+     "sha256": "693d0d1142dfa12ce2dd1d7b959094c201f3bf783114064c29a572dffe2fcfe0"
+    },
+    "sound/gunner/idle.wav": {
+     "bytes": 18376,
+     "sha256": "6c5b1f1d39f1cc78e87cdbf584b8a508fadc99fc2b8b85d21d0e088d134a8b2b"
+    },
+    "sound/gunner/pain1.wav": {
+     "bytes": 17292,
+     "sha256": "afee7d4ac4f872716fe3deb5adced9a99bd3744784329bd12608d051b81ebfc7"
+    },
+    "sound/gunner/pain2.wav": {
+     "bytes": 20282,
+     "sha256": "38d472d2eaaa7638f7980a06a36043353e86d99aa7e86e0132c52639738c87b2"
+    },
+    "sound/gunner/sight.wav": {
+     "bytes": 22572,
+     "sha256": "395e28b6a4684ce2fa10f085f67d58d025421c594e65a0c2a1b67aeab2ee2569"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hkboss/iceball.wav": {
+     "bytes": 14990,
+     "sha256": "6aec96fda55dfb0120f106064cd324ea6e059bab3fdbb2d81cda297f9a82e02b"
+    },
+    "sound/imp/die.wav": {
+     "bytes": 8448,
+     "sha256": "a8b0e037b88829b978d3dbd3d5e657c7f775c73662d554f6247a387ba333d4bb"
+    },
+    "sound/imp/diebig.wav": {
+     "bytes": 14956,
+     "sha256": "d44d390ba11f8850105fd9601f026cb66525a415de7fc363d3574c86b72d22c4"
+    },
+    "sound/imp/fireball.wav": {
+     "bytes": 5492,
+     "sha256": "6362b59ded89655fa8b8877ed2639eca1a7aae1847306bbc3843fa98bedcbdaf"
+    },
+    "sound/imp/fly.wav": {
+     "bytes": 9204,
+     "sha256": "8036ccb256978c17234aa171267fb0332f1911b5f0dad7b9f74bba9378c39a37"
+    },
+    "sound/imp/flybig.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/imp/flywater.wav": {
+     "bytes": 9800,
+     "sha256": "c80045609b62ceb61bd8fb1a18a53c0f2fd5443502a802b0d6d3c61e9a1db4c0"
+    },
+    "sound/imp/shard.wav": {
+     "bytes": 10678,
+     "sha256": "f806167fe23f37826964c0cc345c438ff0e79c3ffb1fed2c85451c675448cae4"
+    },
+    "sound/imp/swoop.wav": {
+     "bytes": 10842,
+     "sha256": "100eacded51635de912cee171f093e869d24589c44f68887497fe751cf9b1e4d"
+    },
+    "sound/imp/swoopbig.wav": {
+     "bytes": 14012,
+     "sha256": "65d4de49684f2f9e2655abf8e4bf042a08bd706ec4971e6397f264f7274e2b63"
+    },
+    "sound/imp/swoophit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/imp/up.wav": {
+     "bytes": 12500,
+     "sha256": "874b533da43f713a1be27fbccadda8b6392fa8e689c8c4d17dac4b0d380f5822"
+    },
+    "sound/imp/upbig.wav": {
+     "bytes": 21472,
+     "sha256": "36c7bc087935cf7cd33482a50a75df75fc2bfbe53ca0ebcd9797a8bdbde73652"
+    },
+    "sound/items/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items/equalize.wav": {
+     "bytes": 13008,
+     "sha256": "933046049bae4d866250ad9a6e0a4b2a9385caffb4156daaca39ff7110a71126"
+    },
+    "sound/items/levitate.wav": {
+     "bytes": 44236,
+     "sha256": "8a04ce4a97dc22d095bc52d08111bcaaf5f57482f580ccbe0c61bdf8fd18913f"
+    },
+    "sound/items/life_up.wav": {
+     "bytes": 8660,
+     "sha256": "2712bd978343d4170bc1757706597d4de3940a07b6847977cbf117fa92f14c31"
+    },
+    "sound/items/money.wav": {
+     "bytes": 5100,
+     "sha256": "e4ac299499340c1be250f5d5e0824440d9e539de8a1d5b01e303056719cf822f"
+    },
+    "sound/items/quaff.wav": {
+     "bytes": 3748,
+     "sha256": "ebaa4ecc17dc67d3fbc5fe1a7541e4e19769ce941d043922f8572cb2da8d3cdd"
+    },
+    "sound/items/reflect.wav": {
+     "bytes": 14936,
+     "sha256": "90dd50b25175c8d514a52165429e9ca6b90c45dddbb0f301e5873146b4a4a06c"
+    },
+    "sound/items/reflect2.wav": {
+     "bytes": 33119,
+     "sha256": "5fb5afe50e0f5fa24f1c4481b3060ae222f40138ca81052cea047a57aa6b03e8"
+    },
+    "sound/items/reflect3.wav": {
+     "bytes": 7804,
+     "sha256": "a079e5aef6ed9fb7d5c992b0ef8e11932a9efa192eedac2bc530098e0550984a"
+    },
+    "sound/items/regen.wav": {
+     "bytes": 7984,
+     "sha256": "1e125e8e7c19f29eaf09b7ad301fdfe5126d922dfa84ba2af267cdf3351b6498"
+    },
+    "sound/items/shambler.wav": {
+     "bytes": 20182,
+     "sha256": "f0cdf78367b770c97b3b89abedb7c4fb0a9ee10d742acc8c98b3daba46cfc215"
+    },
+    "sound/items/tomepow.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/items/tomepow2.wav": {
+     "bytes": 33119,
+     "sha256": "1e2e62a6f251722741b7f0adeb38c59a1d05917d0f84c8f48922efece97f02e2"
+    },
+    "sound/items/treasure.wav": {
+     "bytes": 5554,
+     "sha256": "c86f66148e8dc99af2c8e877d64d06dc1c35d0caa9c6dc5c8092b268960b8edd"
+    },
+    "sound/laugh.wav": {
+     "bytes": 71573,
+     "sha256": "cb8e1381c70240a93233b8571d792e21950d00b1285f867cbc0ed1237dac1df7"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/b_rot2.wav": {
+     "bytes": 15436,
+     "sha256": "62c86077b7a29f48f5c872c68d262c03b73b57f876b718a05f2fc6b24b9a9ef4"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/bellring.wav": {
+     "bytes": 27600,
+     "sha256": "fe3b2972c722171144eaba160757803292a42342e737d6acdbd0b14802e686f2"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/dsslop.wav": {
+     "bytes": 11163,
+     "sha256": "b6a9f6e74b222169c87e6c56b47d2e7995b23b8b045f16be968f43290f22cf9d"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/met2wd.wav": {
+     "bytes": 3968,
+     "sha256": "a3ce3e10b609f7ae28fc6f39f1f5d55a7c99a41143fb161de7e4e47b7f40f100"
+    },
+    "sound/misc/metalbrk.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/mgboat.wav": {
+     "bytes": 26866,
+     "sha256": "666016e2aa958ea621ba03bee4339518f2ccc72aa3ee2d0838ef9032e8ffc981"
+    },
+    "sound/misc/pushmetl.wav": {
+     "bytes": 14042,
+     "sha256": "2657b0006f51ecb7077b5861b1b282e0bb8bef3bdd5ccb68b3bdd6794361099e"
+    },
+    "sound/misc/pushston.wav": {
+     "bytes": 11490,
+     "sha256": "f457b95dad6131472475ab22d9c260adf5d389e74629cd8ea36ca05ad7d4e749"
+    },
+    "sound/misc/pushwood.wav": {
+     "bytes": 13602,
+     "sha256": "7c3fa06978f8c7b632d12bbf1031a5ac316b44fdc5efd93338ab0a0a162bdf3a"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/rublexp.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/secret2.wav": {
+     "bytes": 87440,
+     "sha256": "36e9d9617a14daefd510e72308b9e85718a473e2b25a06b66026d463d6bbb519"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/misc/woodbrk.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/music/halo.wav": {
+     "bytes": 1522062,
+     "sha256": "5dde19894415ba65ccd34f9454333d6a11fd7fbdba8cf7c818c5ae38842ef40f"
+    },
+    "sound/music/pkdream.wav": {
+     "bytes": 154898,
+     "sha256": "df8857901002ce9dde3c558743c94967db11cae4af3d9a0cdc00c8cc09e6a910"
+    },
+    "sound/music/shadows.wav": {
+     "bytes": 1212498,
+     "sha256": "ac887a1b24be48922bf617ddcd4d4c13177ab60c0b9afe575f91ada4adf684e0"
+    },
+    "sound/music/soultrap.wav": {
+     "bytes": 1529946,
+     "sha256": "cd71eeed7769c926e3c7d977123c8d73c14e5968891765dc67351e47c6cd4450"
+    },
+    "sound/necro/att_a.wav": {
+     "bytes": 8522,
+     "sha256": "a946c060cab5ee1bfff2d1af87cd71c9ccf63840a2751fd46fd32f387bee2c35"
+    },
+    "sound/necro/att_a2.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/necro/att_w.wav": {
+     "bytes": 26298,
+     "sha256": "9ae481ad41d16610b597989e82a8bbf9c35a74fe03a8e27900d72ff8b52e3c94"
+    },
+    "sound/necro/curse.wav": {
+     "bytes": 16852,
+     "sha256": "d3729c83c468d9320cf1f8914c8b52d446e818852c955d8d86a093c35c196b58"
+    },
+    "sound/necro/death1.wav": {
+     "bytes": 24010,
+     "sha256": "302e58b0f701ad07ade4a46d5cd3bd9c2186b2df3eb39e36c361918a72ccd24d"
+    },
+    "sound/necro/death2.wav": {
+     "bytes": 23594,
+     "sha256": "05f15a8430885b6688587eba5e249107c3e6df36d7937a3ddd2411d275e8842b"
+    },
+    "sound/necro/idle1.wav": {
+     "bytes": 49212,
+     "sha256": "737f382e89a40fc098214b77e9165e16f2a06323c07e910f336f2616b6ca87b4"
+    },
+    "sound/necro/idle2.wav": {
+     "bytes": 47120,
+     "sha256": "18893e7b31ff448831a7b7a5aa9a5d31b2dcd6e49ae8b58d5eea8b44683415dc"
+    },
+    "sound/necro/pain1.wav": {
+     "bytes": 19412,
+     "sha256": "f37e247a9e1436e4a86b78fe71e1ea6da43323e60943e86784ac87fc4393333b"
+    },
+    "sound/necro/pop.wav": {
+     "bytes": 18996,
+     "sha256": "22aff5a83ec82e759004d82308b2e210f824ac59bd3180d6b688c9d0134ca18e"
+    },
+    "sound/necro/pop1.wav": {
+     "bytes": 10836,
+     "sha256": "d5e9b7ce5a638a419eef07bba492ce75fb3d8002bd66b40d36b4dd89ad859e1c"
+    },
+    "sound/necro/pop2.wav": {
+     "bytes": 11228,
+     "sha256": "10947cad6cd5bcc0e0bc00fdbeccccd53b70bff1fda1a220c72ddc7e2b152b08"
+    },
+    "sound/necro/pop3.wav": {
+     "bytes": 11228,
+     "sha256": "56c4219dc0ecfb7ee8ff6d31fdf6c8c53c2b6990ce1b94ed956caee3c7cf83db"
+    },
+    "sound/necro/pop4.wav": {
+     "bytes": 10836,
+     "sha256": "451b660c65ebd2c7c89134896ed882d738c685f787810e1245587c0c28c38141"
+    },
+    "sound/necro/raise.wav": {
+     "bytes": 9688,
+     "sha256": "1c841e33f22cdcd5276bba9018aec5dae8c0f842da07eb261f48f1a6cc4c8314"
+    },
+    "sound/necro/sight1.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/necro/summon.wav": {
+     "bytes": 16308,
+     "sha256": "b7fc855d38431ac04e09389d7caf04bf0032d2b4edf86ebd795f1ab38d9feaf5"
+    },
+    "sound/necro/x_armor.wav": {
+     "bytes": 17988,
+     "sha256": "61b518c8ad8410a17eaca28ee190d96a0c3d1dc755593872d7ec5429c8c19157"
+    },
+    "sound/necro/x_damage.wav": {
+     "bytes": 14772,
+     "sha256": "f74f64e3f47cee7c9b424b94a426f93c133d8acc1e6cb15551a72ab361fe95c4"
+    },
+    "sound/necro/x_leech.wav": {
+     "bytes": 16692,
+     "sha256": "78aacf297df09e21645c2e04ccf181266c35c8e52303ecb498c90db33e8c7b27"
+    },
+    "sound/necro/x_muddle.wav": {
+     "bytes": 18932,
+     "sha256": "b85810135fb3eca3f141047a08cd42a0e527d6da6e9fcfca3887a15f89edad6b"
+    },
+    "sound/necro/x_weaken.wav": {
+     "bytes": 15946,
+     "sha256": "f98441764b5f258ee875090c73e5841f4c8f97decbfbd8d9da836a7aac30f430"
+    },
+    "sound/nemesant/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/nemesant/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/nemesant/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/nemesant/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/nemesant/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/nemesant/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/nemesant/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/nemesant/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/nemesant/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/nemesant/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/nemesant/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    },
+    "sound/pendulum/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/plasma/explode.wav": {
+     "bytes": 29598,
+     "sha256": "7a95a8337c7ad87faccc1cae98ad7840352b08608fba08aff87a1b33610f9190"
+    },
+    "sound/plasma/fire.wav": {
+     "bytes": 22422,
+     "sha256": "7350d1e99f93a79bee84e94561e080dcb8448a3549a42742633cf604377a5097"
+    },
+    "sound/plasma/flight.wav": {
+     "bytes": 17494,
+     "sha256": "a03b46f31df3495a1b7a2b2f1a09f3e5223d4c0ab65aa0ed936e1445e893adeb"
+    },
+    "sound/ranger/idle.wav": {
+     "bytes": 10819,
+     "sha256": "644fbbc14e20684fa31abc7f04969943ac950c33435271b0fa646aa324be4400"
+    },
+    "sound/ranger/sight1.wav": {
+     "bytes": 5379,
+     "sha256": "5023e2483fe5c1c37cd661d382e34c0b68eafe4bae0e35e8f3f7e516e78dcf51"
+    },
+    "sound/ranger/sight2.wav": {
+     "bytes": 11323,
+     "sha256": "3574f035e1a261b9a001d99a54bdb502da31da2639d95e7fc06f96b547c1ac44"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight1.wav": {
+     "bytes": 35068,
+     "sha256": "48db878a4eae15b37ee0ca333aae74d310103a9eaf2e4b35eecd43a89f626b9a"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk1.wav": {
+     "bytes": 19372,
+     "sha256": "42e41297df70202ec9965af7af5fcdabcab7fde43ba515c8ba0a1ee2e4429554"
+    },
+    "sound/shade/death.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/shade/death2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/shade/fly.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/shade/idle.wav": {
+     "bytes": 37192,
+     "sha256": "57b0a0a7a0e75a17df8c4bb68740b23325bd0bf3475d908ee92fa0522c71edf7"
+    },
+    "sound/shade/moan.wav": {
+     "bytes": 33684,
+     "sha256": "3a6644f2c0a6ead5992fa9752ec9b0d898f4c40f5a32b12fd61aa991f75fa0c7"
+    },
+    "sound/shade/pain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/shade/pain2.wav": {
+     "bytes": 8918,
+     "sha256": "c6fa3ba7c659faf38b00af9c9867c37ba730cbc662125f5307f755515243dc4c"
+    },
+    "sound/shade/screech.wav": {
+     "bytes": 28244,
+     "sha256": "55ef2615baa6ce39733892fc9538f702acc567f65250223329f15b191d9b1a47"
+    },
+    "sound/shade/sing.wav": {
+     "bytes": 35654,
+     "sha256": "9de82a1d3124c391466004aea5e8ad066bcc6ede2715e7978a92a2c8f66e3f6b"
+    },
+    "sound/shade/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/shade/taunt.wav": {
+     "bytes": 36418,
+     "sha256": "f556cad612249e63690ac28b17405eba70e3df43560c3a087062b9f330811720"
+    },
+    "sound/shade/taunt2.wav": {
+     "bytes": 28160,
+     "sha256": "a68174008206b79794d8d52fd027daf08767ce005189860c815cda021080363c"
+    },
+    "sound/shamvile/burn.wav": {
+     "bytes": 11316,
+     "sha256": "239c51d5cfb82ee7683075f6cd53d8a16fcc2da608c9db87c27fd7491160a627"
+    },
+    "sound/shamvile/melee1.wav": {
+     "bytes": 4700,
+     "sha256": "f418a627faa0b4630588914ecdd466c387e1d7d5ac2e09acecafa13baf33f10c"
+    },
+    "sound/shamvile/melee2.wav": {
+     "bytes": 6252,
+     "sha256": "dfeb5bcd8be8d9f1fcf52f89cf0af533ec28066eb0bf74e3ac4b588ca810f372"
+    },
+    "sound/shamvile/melee3.wav": {
+     "bytes": 13236,
+     "sha256": "7102a987921e4c291175ba252628613c2c6ecdb70e9a33e174b6bcf7addc239c"
+    },
+    "sound/shamvile/melee4.wav": {
+     "bytes": 9211,
+     "sha256": "da31a8531703998c06bc33c94639d5dd291c9ba24e6752599ec8e6113d3753b5"
+    },
+    "sound/shamvile/sdeath.wav": {
+     "bytes": 20996,
+     "sha256": "e27d5870c37ce74877a2681b5e9cef437d14b05c501fb93733c8e93d2d2b0931"
+    },
+    "sound/shamvile/shurt2.wav": {
+     "bytes": 3924,
+     "sha256": "541c66bfaf5f30c55d24c4013f4a8859159ebfdf2f054c681eb8b8200dba1c85"
+    },
+    "sound/shamvile/sidle.wav": {
+     "bytes": 5476,
+     "sha256": "ca3edcb476f3992027989a2a79ef21a7f8951965c8a0e77f89f0a0505f2d2b52"
+    },
+    "sound/shamvile/sidle2.wav": {
+     "bytes": 21511,
+     "sha256": "0e46d4e53c003136881723f59de4d706151b845d57608cd87361018acb7ef050"
+    },
+    "sound/shamvile/ssight.wav": {
+     "bytes": 15564,
+     "sha256": "5a5343f95ee503f1b481ef05499e023b681402b922600979367788f2fb91397c"
+    },
+    "sound/shamvile/ssight2.wav": {
+     "bytes": 27204,
+     "sha256": "2b22c0912485569f7ec87a32a29c88563c0cb8261b4428335540fc96f7e7cb52"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 19642,
+     "sha256": "91eba6c478e8475696f07079502af32d1817e3fb86418c32801846582f27561d"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 18166,
+     "sha256": "91301f18c459286798989dd164ae08f5e77433ac7a0b5c71522cf59e49bf1a30"
+    },
+    "sound/skullwiz/blinkspk.wav": {
+     "bytes": 31420,
+     "sha256": "48a4dbd2add9021727d4572af9ac4c6f333a9e2ace5fe7127ddd42c84a2ae1f4"
+    },
+    "sound/skullwiz/blnkspk2.wav": {
+     "bytes": 41834,
+     "sha256": "fc2602275102b7e1a577c30b7ab3ac2709881eb3a8798664577f8a65a9132754"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 23034,
+     "sha256": "0eb20419acddee8a5814ecad8888348f90a14db997af1045b02b6052dccd5fd1"
+    },
+    "sound/skullwiz/death2.wav": {
+     "bytes": 32314,
+     "sha256": "3b1d2ed146a334ba5cf77027faa47addbf45c51159ff9c7278a97dda8ed7ef82"
+    },
+    "sound/skullwiz/firemisl.wav": {
+     "bytes": 12186,
+     "sha256": "3583544b6d7105d5b029a490cb0730190ae9e8dc5ca8f9da1deae4ea0335e964"
+    },
+    "sound/skullwiz/gate.wav": {
+     "bytes": 16156,
+     "sha256": "5797c6450d14f363133be23d93c829a660f9b7692c07f905b5a723cda8075c55"
+    },
+    "sound/skullwiz/gatespk.wav": {
+     "bytes": 30092,
+     "sha256": "f9fc90ba497d650acfad76c42ed531314828093f114c69c28fd1611d326fab2e"
+    },
+    "sound/skullwiz/growl.wav": {
+     "bytes": 18944,
+     "sha256": "de58ed34dd69dc3e871d09ac6a5db81ef26d69e234f0834e72c6cd68501ead21"
+    },
+    "sound/skullwiz/growl2.wav": {
+     "bytes": 24954,
+     "sha256": "0cf747c71a6fad9a085c39456cd14ffd972d2d454b4bafc2781ce4464917cfa4"
+    },
+    "sound/skullwiz/pain.wav": {
+     "bytes": 6106,
+     "sha256": "0f85b6180cbfe8d26f8d174f25c109b9d8b78d0fa53735e0494280bc8a19803b"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 8890,
+     "sha256": "6d48429e7fc4b80be16afd80097b7096a94cb1a88922a62bdfdff64172526a0f"
+    },
+    "sound/skullwiz/push.wav": {
+     "bytes": 8812,
+     "sha256": "91398e953b648ab23c037940fb7996f3d77727003a60757ea50686328c05cd69"
+    },
+    "sound/skullwiz/scream.wav": {
+     "bytes": 31734,
+     "sha256": "6df299b2a59aa94a9640c83684b65259e4619e0ed2a2fd1ce518dffaa060fd43"
+    },
+    "sound/skullwiz/scream2.wav": {
+     "bytes": 13980,
+     "sha256": "adca10198e279db0789a1a026124387c40e36fc1914f3f3da315b49b6e290386"
+    },
+    "sound/snake/death.wav": {
+     "bytes": 17578,
+     "sha256": "7d8e2f12369ad5fe3eb025d6ce4fefdfa10fbcff2b5b87974a1c8ddde4f851bc"
+    },
+    "sound/snake/idle.wav": {
+     "bytes": 27111,
+     "sha256": "6a69f3635136303676e168088af4a55442cb77f914e2e82f77e06e07339f0f4e"
+    },
+    "sound/snake/pain.wav": {
+     "bytes": 13882,
+     "sha256": "3737842df2079f4a2af87787bc8c4d34642249fb891a2bf3ee4d4ac95f97a182"
+    },
+    "sound/snake/sight.wav": {
+     "bytes": 13808,
+     "sha256": "296c74493be791f96b3676551df7ec4ad4c13cbb1eb484509c46fb44ee6f76b1"
+    },
+    "sound/spider/attack.wav": {
+     "bytes": 6576,
+     "sha256": "82593fdd5be8198a9774c163872f89a088d8d0ca10e91f1c8f846ecac92b2d81"
+    },
+    "sound/spider/bite.wav": {
+     "bytes": 4552,
+     "sha256": "abd0b64743c825661f4598b7d5b70b781452a6b7747f9eb8b53f7239b0f9b9cb"
+    },
+    "sound/spider/death.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/gib1.wav": {
+     "bytes": 10516,
+     "sha256": "bbe1a437bd05a71f9d7bba953a79886891bfc526399c67cfc8964308c91786d0"
+    },
+    "sound/spider/pain.wav": {
+     "bytes": 7576,
+     "sha256": "386e11cfd8063b6bb692ab4b90246be98288f72f29614f2e38765df9e6eaad79"
+    },
+    "sound/spider/step1.wav": {
+     "bytes": 2780,
+     "sha256": "06ee408dace817630645b0d390c496e692844fb42cc85adcaa021efeb60fae9b"
+    },
+    "sound/spider/step2.wav": {
+     "bytes": 2620,
+     "sha256": "66e802d6361a17e637f5e38366e4b0912dbb0f65e647041bed57cfda772c0770"
+    },
+    "sound/spider/step3.wav": {
+     "bytes": 1786,
+     "sha256": "418b2c536f19a5bcd0b1a8ff4aae13febc8c4f8fa6787372e9e869c45a17f54c"
+    },
+    "sound/trog/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/tur_arm.wav": {
+     "bytes": 23794,
+     "sha256": "24b428117ebd7e82865b41dcfc74a75a048c4d126d7505a6c23dd243bc054a05"
+    },
+    "sound/vomitus/death.wav": {
+     "bytes": 13236,
+     "sha256": "fa2cad86ac0ce1326132c5e378aed6a9ff5615d043df1d4d48e0b2691f8d3bde"
+    },
+    "sound/vomitus/flesh1.wav": {
+     "bytes": 8412,
+     "sha256": "9ac5a8ac2155e7d9b65144e7f65525c4660ff5959fe3a0277fab347e202b6f46"
+    },
+    "sound/vomitus/flesh2.wav": {
+     "bytes": 12788,
+     "sha256": "3fc22e2aa2c3c0bdc6501388ac18abb5e58c5fd5deba39d1cc2f7e8d48fcc869"
+    },
+    "sound/vomitus/groan.wav": {
+     "bytes": 13224,
+     "sha256": "3632e43615714e5fc1be8277881a913bf1bd79b276544418cbf1b159016f0d03"
+    },
+    "sound/weapons/axhit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/weapons/axhitwal.wav": {
+     "bytes": 6694,
+     "sha256": "0f14ba18076b25a7b8ee510b38adb282eb5c4f2fc94168baf1f8a658e1da684f"
+    },
+    "sound/weapons/block1.wav": {
+     "bytes": 5484,
+     "sha256": "ccb284becb454f395de702a263bfda1561b8bd38117893d33b5ebbb9eb7b6865"
+    },
+    "sound/weapons/block2.wav": {
+     "bytes": 5612,
+     "sha256": "62da8e44f3b1200b99f76a3bdb31d9d09a9e74c04a449c0afc482c6677a94bc2"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/weapons/clang.wav": {
+     "bytes": 7198,
+     "sha256": "634a88cf26b4de688bed392cf108d5468749f212ce67015c71baa942e8e88502"
+    },
+    "sound/weapons/dsshotgn.wav": {
+     "bytes": 6418,
+     "sha256": "452efbbaafcb29edde6f5d089fb2389e046635b1f715201ae750b3b7e849f378"
+    },
+    "sound/weapons/freeze.wav": {
+     "bytes": 20619,
+     "sha256": "48689ba550c116dd8b10a138bc0f78eb6f169d6828a49aaafe12f807930eb934"
+    },
+    "sound/weapons/fwall.wav": {
+     "bytes": 40140,
+     "sha256": "e269c07608f322518e709925d5b13daded150460d19d3091f15152ce4c06c9bf"
+    },
+    "sound/weapons/fwallhit.wav": {
+     "bytes": 9426,
+     "sha256": "7b9f4da432e6fa44fbf721ed9ef753e6ceb41df59b8265b58f73764b2901224a"
+    },
+    "sound/weapons/fwalltap.wav": {
+     "bytes": 8316,
+     "sha256": "879b9970dfc3bc609ff384a0edea13b594ea6a82b5c56d33c8549cd36cccda0b"
+    },
+    "sound/weapons/gldhit.wav": {
+     "bytes": 5842,
+     "sha256": "e19a73febbcafb1f3fc8774ea07fa51e8716c1ad29285a4d3cb5c6aeb4c1d5f7"
+    },
+    "sound/weapons/icehit.wav": {
+     "bytes": 10710,
+     "sha256": "9ed8ed177a6cfcad97f8adcf94b9f3114a955e7b3abb397c6b17c44073c07b19"
+    },
+    "sound/weapons/icewall.wav": {
+     "bytes": 6124,
+     "sha256": "9668486027e07f525a27830dc3217cde36bcbcc956b21437d2637e00df368dd4"
+    },
+    "sound/weapons/mirv1.wav": {
+     "bytes": 89538,
+     "sha256": "7d60062f61d5929f5f927526d81920f24684520d230a5f2611c128b832d3357e"
+    },
+    "sound/weapons/mirv2.wav": {
+     "bytes": 18478,
+     "sha256": "67311180da390517f2ef71d161a0cf7b770548dcd4a7dda7e679cb9b58025b4b"
+    },
+    "sound/weapons/nova.wav": {
+     "bytes": 10020,
+     "sha256": "d41c8433fa1b964fafa1cdb2fec301fb4d398f1fce201b4d80b29fab7a59d7e7"
+    },
+    "sound/weapons/pkup2.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/weapons/r_exp3a.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/rc1.wav": {
+     "bytes": 9138,
+     "sha256": "9ae6db1e39fd88810ca19d4618fa89fc4e09054ed05009e3adf3643da9418f09"
+    },
+    "sound/weapons/rg_fire.wav": {
+     "bytes": 66260,
+     "sha256": "a3a7edd9c470077682bde595f95d88546d416f300202ae96bd6c6371ec19cf09"
+    },
+    "sound/weapons/rg_hum.wav": {
+     "bytes": 51244,
+     "sha256": "84b348b10921b5f7c6539a20ead4de132e0f7988ab8f1464669fbe6ce0a20c2e"
+    },
+    "sound/weapons/rg_power.wav": {
+     "bytes": 51566,
+     "sha256": "40ce379a835e11561573be1dfdf1806a9bcb27192b94333a126cc721e38bbde4"
+    },
+    "sound/weapons/riotgun.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/shatter.wav": {
+     "bytes": 20899,
+     "sha256": "31ddbef0dc746eabea23cd7cd2fb97a1f949a014b664630d7f04e6c237aafc03"
+    },
+    "sound/weapons/sheath.wav": {
+     "bytes": 7031,
+     "sha256": "8f28a1daa16db234ce77d91e688c7acbc9541c296d30af9e1f940b6d45eaf72d"
+    },
+    "sound/weapons/stunfire.wav": {
+     "bytes": 9902,
+     "sha256": "7214cc44e4c0bfb801209f025b591d838542a3110f770e5614b0f549a055286a"
+    },
+    "sound/weapons/sword1.wav": {
+     "bytes": 3532,
+     "sha256": "572074b68af2132285aa9fd2ac6852f52ffb6c5e56eed44b1af21e0e78171e17"
+    },
+    "sound/weapons/sword2.wav": {
+     "bytes": 3055,
+     "sha256": "b176a257409b659d80df90560bbac4da5539971576aaf1107bb88bc016558085"
+    },
+    "sound/weapons/sword3.wav": {
+     "bytes": 3012,
+     "sha256": "eaca19c8a10b7942d4a279974df6e1cf076c362d5408e439b26286126852bedf"
+    },
+    "sound/weapons/unsheath.wav": {
+     "bytes": 8060,
+     "sha256": "45d9bc6b9dcaf8e0dc9b2ede7da69a872f50f7819462a71bc16b9d76a70be06b"
+    },
+    "sound/weapons/xbowdraw.wav": {
+     "bytes": 19114,
+     "sha256": "4bb73eb7161ba561970e8f2e7f5aad0e42b3419fe2b02a5953a7289c46d1442b"
+    },
+    "sound/weapons/zap1.wav": {
+     "bytes": 7648,
+     "sha256": "1ee462bf6169537cc96fa7f95ef30b782fa1be473bd6ddc297fb3a7a6aa21ad0"
+    },
+    "sound/weapons/zap2.wav": {
+     "bytes": 7178,
+     "sha256": "8ece0064dc470a86c00906c1c50a54afd3a64eb13582071b9960581a1b72f4ff"
+    },
+    "sound/wraith/call.wav": {
+     "bytes": 12328,
+     "sha256": "9ace8a0ff79d035d36b6bdfb8726054ceaf8f852d25f3c1b235616abf4646ef2"
+    },
+    "sound/wraith/die.wav": {
+     "bytes": 14024,
+     "sha256": "3f166e024c07124cc5b5c5469904f5a8b3e48d4cb50fd949be8d79b4df2e375c"
+    },
+    "sound/wraith/drain.wav": {
+     "bytes": 14094,
+     "sha256": "d767951e9630b6179fb05a80136acbdeeb530f350b1953bea62e8493f3fe67ce"
+    },
+    "sound/wraith/growl2.wav": {
+     "bytes": 24966,
+     "sha256": "1c757955bb103e0f589ec373d1517dbacb8fe7e274f7aa0928503c9f5b009b10"
+    },
+    "sound/wraith/idle.wav": {
+     "bytes": 23702,
+     "sha256": "760a4a215fa2adb6f531b15acc06a4b46daa84c85fc08691ff4fe13f17e09ee8"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 20442,
+     "sha256": "d55cb931cef7d9c336fb7bbc3fa0408ea23eff69f46e25ac377ebbc880fa5025"
+    },
+    "sound/wraith/return.wav": {
+     "bytes": 39162,
+     "sha256": "0439588ad2003732fe7f946a5597bf80b2b89d6395476671b0e050b91c49cca7"
+    },
+    "sound/wraith/rych1.wav": {
+     "bytes": 24482,
+     "sha256": "baec568f339f688ea475e37ef3fc51a36de78a52a553e85aaa3f8011e1240d13"
+    },
+    "sound/wraith/select.wav": {
+     "bytes": 29326,
+     "sha256": "1e86b92dd1d82f4f74cd7fe14a75484e6cddb4fe968d2bb3dbaf850414c6dacb"
+    },
+    "sound/wraith/soul.wav": {
+     "bytes": 70524,
+     "sha256": "612bf73a6ebe0526efa2ef3d22915bcd87bed0b0eb5e52fc4eb0e62c5e4a3039"
+    },
+    "sound/wraith/soul2.wav": {
+     "bytes": 20562,
+     "sha256": "d3701420c157109793576ac7af7c7b132ffd0897375ec99701f4cd54798d9579"
+    },
+    "sound/wraith/speak.wav": {
+     "bytes": 25630,
+     "sha256": "6d1e5b395938692d57de3ec8ef9a8b5e4ccdab920a1f247e5bcdc1f0906dfcb8"
+    },
+    "sound/wraith/talk1.wav": {
+     "bytes": 16654,
+     "sha256": "6a625383c12f7fb5979ca8977a51d40f183051d551bd0b1b4ccc8a3f43a0322a"
+    },
+    "sound/wraith/talk3.wav": {
+     "bytes": 9832,
+     "sha256": "28ecc66c85bc722059b147a1354d226fbaf3022b79aed937a4759958d52c0fab"
+    },
+    "sound/wraith/weird.wav": {
+     "bytes": 3028,
+     "sha256": "1cfcd24daeb0665dce9d68ec353377ef84a88c78d1fdfcb429f2d0cc2b7f4b78"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    }
+   },
    "sha256": "6e2bbb4eeb05e83355ed5b0534ca5336ec93c339e3181f6ee9aa89d4c7eb4912",
    "timestamp": "2009-12-24T09:37:48.000Z"
   },
   "pak2.pak": {
    "bytes": 40121110,
+   "files": {
+    "demo1.dem": {
+     "bytes": 8505256,
+     "sha256": "9161ca15df8bb5f38210ab5b324f645e2a9a32ed6c066bf35a2ffba45fdfa7a5"
+    },
+    "gfx/env/ozymandias_bk.tga": {
+     "bytes": 786971,
+     "sha256": "05b092662bed6b02fc122ca43be907ac87461e7cd9116661f962b8dfac1328c9"
+    },
+    "gfx/env/ozymandias_dn.tga": {
+     "bytes": 786971,
+     "sha256": "2354852349f537cc4eb1567f1e7c71b8b5891bbfa03d4350708296cab505abc2"
+    },
+    "gfx/env/ozymandias_ft.tga": {
+     "bytes": 786971,
+     "sha256": "ee011c4f2f619b6a1dd5868608ed79407ead9d6665d219e1020d0c5dd7b070d0"
+    },
+    "gfx/env/ozymandias_lf.tga": {
+     "bytes": 786971,
+     "sha256": "05af28566a788dbe40fa0a0470fc27fd45477c29be9c5f4ba114cee88f3622fc"
+    },
+    "gfx/env/ozymandias_rt.tga": {
+     "bytes": 786971,
+     "sha256": "923b4df98f15b40aad478b8b8cf340ca2b33e17053dc134d9ff6cd688ddef956"
+    },
+    "gfx/env/ozymandias_up.tga": {
+     "bytes": 786971,
+     "sha256": "88a59bff68e1ba4cd29e66ff25c88d3cfbbcf2f5089fb82e9addae1edf2c5566"
+    },
+    "maps/roman1.bsp": {
+     "bytes": 8189904,
+     "sha256": "5d8ff0f09c7b73b1305379f58e66e4c70ae017e241da1c0bdfc5b5844e828077"
+    },
+    "maps/roman2.bsp": {
+     "bytes": 4244088,
+     "sha256": "276866fcd5f14f9684d7a0f8fbc165a7517f01273ea82214c5da9564c7d692d0"
+    },
+    "maps/roman3.bsp": {
+     "bytes": 6674404,
+     "sha256": "ba1e917536a7c10d7f620a1cc4df4a13f96809566c047a33e5eda1fdc2b097c9"
+    },
+    "maps/start.bsp": {
+     "bytes": 1171396,
+     "sha256": "7ced5767babcc1032ecc4d141229613f7e892f743c3a8f51b10c0f3b208f9bfd"
+    },
+    "sound/music/craters.wav": {
+     "bytes": 555704,
+     "sha256": "910c17b50db3670b6861636213e7892d1e1cf4fb081d2fb403f19ed84bcd70dc"
+    },
+    "sound/music/end.wav": {
+     "bytes": 1610600,
+     "sha256": "f6de8e1e106292c3c2cdf028dc8584d0c4b869ecb8905afef5333a030c045935"
+    },
+    "sound/music/psychopomp.wav": {
+     "bytes": 3123480,
+     "sha256": "7fa21cd7ab87873834462b4baf2d734d8df873d4ce319ef28a92ae3e6d8e9769"
+    },
+    "sound/music/signofevil.wav": {
+     "bytes": 1323480,
+     "sha256": "213e0bdab0a2810459a0f70c05e46cab74affa648a020f04fcb6f680826778c3"
+    }
+   },
    "sha256": "26026c0dfdebe56ba368b4d271e294a172b5b09ea98cb06a4e658b934d9d4d90",
    "timestamp": "2009-12-25T06:44:54.000Z"
   },

--- a/json/by-sha256/1b/1b0abee2da830f78fe6d34a44eab218355f4e2a87a65aadba9d4cc465e7cf66f.json
+++ b/json/by-sha256/1b/1b0abee2da830f78fe6d34a44eab218355f4e2a87a65aadba9d4cc465e7cf66f.json
@@ -7,6 +7,16 @@
  "files": {
   "pak0.pak": {
    "bytes": 2503064,
+   "files": {
+    "maps/start.bsp": {
+     "bytes": 2089140,
+     "sha256": "024f56f3b84a26354fed3abba0bee23e2545c452455e081a0a746aeffefbbfbc"
+    },
+    "progs.dat": {
+     "bytes": 413784,
+     "sha256": "138d1b2d0219f05539c925ed21db3b965ea8bd61da00fe5b68d4c69a80de57ab"
+    }
+   },
    "sha256": "4024f475e6c7d9721bda272ff23ec7ec9e1ef3b2acf17790f3450a6eec00a801",
    "timestamp": "1997-11-25T14:25:22.000Z"
   },

--- a/json/by-sha256/1b/1b79c362d3f33e61762142cf9ffdb56fd3b1ec16e540a8384e6d466a785a976a.json
+++ b/json/by-sha256/1b/1b79c362d3f33e61762142cf9ffdb56fd3b1ec16e540a8384e6d466a785a976a.json
@@ -13,6 +13,608 @@
   },
   "spiritworld/pak0.pak": {
    "bytes": 284918463,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "8bdc643fb75eb7d61f3e7c11eca8354d91952719c5d2562c8a3548dbea501ed0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "898d694265db0f933feecfd2a843557a6954a5f2aea05ecf9a852314119dab61"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "03e0973ee5d434c037699f9568228ab80be0df882ca77c88a9835b2d2edf0649"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/elders1.bsp": {
+     "bytes": 4826112,
+     "sha256": "9ed448f5c6d25bda2eace66482f8acc72bd16b181bd0294d75f9c80d77b55e59"
+    },
+    "maps/elders1.lit": {
+     "bytes": 1246319,
+     "sha256": "cd633cd2f08df6721ea57e0cc5968c7a57d6dd0911442343ad4f4c232525333b"
+    },
+    "maps/elders2.bsp": {
+     "bytes": 3637544,
+     "sha256": "0aece59f7d57bc940f8575790da36afa681ebb36780d01d828e6c8eb34ea0e44"
+    },
+    "maps/elders2.lit": {
+     "bytes": 1040744,
+     "sha256": "302e48a5655f27026b8fd974b0d9f97a87e2db649910a684aa0e4cebb832e303"
+    },
+    "maps/elders3.bsp": {
+     "bytes": 8327108,
+     "sha256": "e62efe1084ecb624bea128cccb1fe31e0e03ce77ce741c74968486bb3a9a7c84"
+    },
+    "maps/elders3.lit": {
+     "bytes": 2386802,
+     "sha256": "19d6d71e080ee8a05ab725da9f63518af1d82a29743b84676bcfa97dc7d0b24f"
+    },
+    "maps/elders4.bsp": {
+     "bytes": 12638280,
+     "sha256": "4454915c793ed99baf44c7fec4ed69a1bcb681c6badea8e8fd138af7ccf11fce"
+    },
+    "maps/elders4.lit": {
+     "bytes": 4769267,
+     "sha256": "f6a7604e07867c843e37fc7c5fa55c89ef35cd903673eedc10723c4a3c74f481"
+    },
+    "maps/elders5.bsp": {
+     "bytes": 14886096,
+     "sha256": "3b5a432fe7a3468afbabcd894b950b7cf1a3395ca2515f0f8925badbf0a9492a"
+    },
+    "maps/elders5.lit": {
+     "bytes": 6345062,
+     "sha256": "3d4403565752a529bbc1c059fc3a2c917e48829dce7837a636592b0b46526b23"
+    },
+    "maps/elders6.bsp": {
+     "bytes": 38814524,
+     "sha256": "08d2dad0caacbf8ed576ca077511adda1b7a5bc3faee6cf6fc342a83430a40bc"
+    },
+    "maps/elders6.lit": {
+     "bytes": 17731460,
+     "sha256": "fdd2bec4f9598f9fb3142c88bd583482b28e3043b3180ad0d2326ee029960cd7"
+    },
+    "maps/elders7.bsp": {
+     "bytes": 12789032,
+     "sha256": "b85120d71f4d8d6bbfa1353bc38dc9417d07600be12741cd245be8ce8127a5b8"
+    },
+    "maps/elders7.lit": {
+     "bytes": 4010372,
+     "sha256": "c7a5eaa2eb4a4597a35dae8de4d3e7347971ee346b75394f21610d65461cd88f"
+    },
+    "maps/elders8.bsp": {
+     "bytes": 7047664,
+     "sha256": "4b6ae19c265cb18e965d965aeb2b0a6ce1bc26b154d1dda515b9a7fae13e391e"
+    },
+    "maps/elders8.lit": {
+     "bytes": 2206070,
+     "sha256": "70db625dd3b4fc34c890da2c67b7c9d74a268d8d42965e87b51efb683e384930"
+    },
+    "maps/elders9.bsp": {
+     "bytes": 17761764,
+     "sha256": "295ee07aa53ce00f85ab802df5fcd103311627a829b9ee50902f4a4183e21af7"
+    },
+    "maps/elders9.lit": {
+     "bytes": 9859808,
+     "sha256": "6e2038d1bb47c6d2a15723c8b506fdaf1f1bff305e789c04fee4f682fd8ad88e"
+    },
+    "maps/eldersend.bsp": {
+     "bytes": 2079460,
+     "sha256": "279b602cb613c331677867a78fb9d9ae18db4cd643261b41d9360afccfda7447"
+    },
+    "maps/eldersend.lit": {
+     "bytes": 1105172,
+     "sha256": "0b7ff626dc7da294064b4839020923c8fb3433fabd77170dad54170364949140"
+    },
+    "maps/eldersx.bsp": {
+     "bytes": 1401860,
+     "sha256": "d9c5968bbf14d27a9b062ae712e3cfdcd26abad25128756a907b9fa4eb338ab2"
+    },
+    "maps/eldersx.lit": {
+     "bytes": 583784,
+     "sha256": "daeb4d38b856c8af2fb11dc92ec37c9f876f8de8e7e1b3e45eda522311fcab9d"
+    },
+    "maps/start.bsp": {
+     "bytes": 2309312,
+     "sha256": "8a5a1a91e6f91b4f6324c6ee04c00d21dbb14945959c5174131969c4e0630eaa"
+    },
+    "maps/start.lit": {
+     "bytes": 679544,
+     "sha256": "b1999fa252f4094a2bf62f023d8c0087fa438950432ff89e4c3716a942bb05eb"
+    },
+    "music/track03.ogg": {
+     "bytes": 3625599,
+     "sha256": "5e50dd223c988ab6e13842230644bff9d013226aba831bf31a004c5872416381"
+    },
+    "music/track20.mp3": {
+     "bytes": 6656576,
+     "sha256": "db16b291a4267928fd5cc91cad3f009cfd9841ad4e0dede2eb6af63ce6d8c28c"
+    },
+    "music/track21.mp3": {
+     "bytes": 18371630,
+     "sha256": "03d582ab7df06e7801aacd5698dbec6513f217b290d7205e5a6ff9406ff2dc4f"
+    },
+    "music/track22.ogg": {
+     "bytes": 7166282,
+     "sha256": "fb73e40979928e1eefff51a8d8bc1626ca59110436ee035423858132099b3d22"
+    },
+    "music/track23.mp3": {
+     "bytes": 10365324,
+     "sha256": "86ff86c848489dbecef9e1509e25a9e6e73174c5742039cf445cdc9d9341174f"
+    },
+    "music/track24.mp3": {
+     "bytes": 7425762,
+     "sha256": "186b2824de7a043747bdef5430be47aa4683fd55107cc248f3bb7b7dae48227e"
+    },
+    "music/track25.ogg": {
+     "bytes": 7148277,
+     "sha256": "fefa81f21e77b7130752f9a279400948493dd045f372f9f955b3cec61f0f5ddd"
+    },
+    "music/track26.mp3": {
+     "bytes": 7315392,
+     "sha256": "89bbd9e32c4c907ddae6da7041e10663dac9e45800f6f1c7807811492540a6c3"
+    },
+    "music/track27.mp3": {
+     "bytes": 6502498,
+     "sha256": "245e236079224e521d9ece157df111e115bbb2e619d25241cb47941dbea5fa42"
+    },
+    "music/track28.ogg": {
+     "bytes": 7172610,
+     "sha256": "7e34a03855268b5722c2a7c96c743c067adb45b330babded7d228db37eb1dfa9"
+    },
+    "music/track29.mp3": {
+     "bytes": 10754912,
+     "sha256": "098a2f444cc2ceb513934fd604bfc2c1610fc4d3212beb0a1e89ef70c73bf9b4"
+    },
+    "music/track30.ogg": {
+     "bytes": 4334988,
+     "sha256": "38666584812b846fccfc42d05e94d1b56a7fef3cb9013cf94e3de3291634a3aa"
+    },
+    "progs.dat": {
+     "bytes": 604226,
+     "sha256": "61115b3abb2c14502256494799d4b136031c96690d2ed1e88dc49eb37adf997c"
+    },
+    "progs.lno": {
+     "bytes": 159488,
+     "sha256": "a3a92b87d281751bd35f4ecd3c827072dd5e8e4bb154c32384c44608b8ffcaa6"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/goldking.mdl": {
+     "bytes": 313384,
+     "sha256": "df0cffbe5b93e04a5b56ea9945e23fb5a58984ed17bd86d32a55013743ec6f31"
+    },
+    "progs/goldking_scale_x1.5.mdl": {
+     "bytes": 321012,
+     "sha256": "0a284676c70a5a21b1fc69cdf22ba98f0b99dadd6bf446e68a0f7e8791782ad4"
+    },
+    "progs/goldking_scale_x1.666.mdl": {
+     "bytes": 321012,
+     "sha256": "2f80e615e5ac1c83a6a00afa1f4568a27bf0dca225b92ca93cbc43f7a0b002cb"
+    },
+    "progs/goldking_scale_x1.mdl": {
+     "bytes": 321012,
+     "sha256": "c3f66e8f851bad14799cc7b0a0c95ea85a63c072b714fe837fd3bbe40575f53b"
+    },
+    "progs/goldking_scale_x2.mdl": {
+     "bytes": 321012,
+     "sha256": "974f6b1eb17c0e5b92c0d7db6e0e4d56866b6b86d2c923347e9509b3180a3ed6"
+    },
+    "progs/goldking_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "0d270ba9fbc704dad647ab4ec46f7bb1f1238f0e3ac4bea680479a45042e39d1"
+    },
+    "progs/goldking_swole.mdl": {
+     "bytes": 313384,
+     "sha256": "703f408af65e9d86f5b2d0f0f6313f16a8f82f81833f7e2605a40ce3fff324c6"
+    },
+    "progs/goldking_swole_fixed_horns.mdl": {
+     "bytes": 313384,
+     "sha256": "df0cffbe5b93e04a5b56ea9945e23fb5a58984ed17bd86d32a55013743ec6f31"
+    },
+    "progs/h_goldking.mdl": {
+     "bytes": 16628,
+     "sha256": "f266534072e8246eee7f79015ee3609b0f1daac0ed169ec42d0357e167848fad"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 32052,
+     "sha256": "783c734d5dd05b550ef73231a618352903d8de203ced5a892ce868db18a121b4"
+    },
+    "progs/proj_blue.mdl": {
+     "bytes": 6644,
+     "sha256": "7bcea6065d9f6c4e8a3a7c8a1dcd61252ff8baee01b7c04ecce0a7cfbc6d690d"
+    },
+    "progs/proj_dprince1b.mdl": {
+     "bytes": 6644,
+     "sha256": "7bcea6065d9f6c4e8a3a7c8a1dcd61252ff8baee01b7c04ecce0a7cfbc6d690d"
+    },
+    "progs/proj_dprince1r.mdl": {
+     "bytes": 6644,
+     "sha256": "5e3cc794f6b980e5e22adf011eead8768c88dcd84d74be9a8d34caebf33bf2ba"
+    },
+    "progs/proj_golden.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/test_fire_arrow.mdl": {
+     "bytes": 58340,
+     "sha256": "247e7c1b45cc997dde49d9602e62436ebeb5144ef5f1fbe5de8b7188fcabb879"
+    },
+    "progs/test_fire_spike.mdl": {
+     "bytes": 57940,
+     "sha256": "1673eaf73023514b5b5dbbfb7cb9fe0fb303d33eb031102feab8ba917ab13620"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "progs/vflame.mdl": {
+     "bytes": 93543,
+     "sha256": "a455bb2b503d7b54e03e12cfd0b1fa6b2fbb6dd86ded307d2e28e51b1a96e7a6"
+    },
+    "progs/vk_spike.mdl": {
+     "bytes": 17584,
+     "sha256": "fd90dadf930fa820cb792b207fc863954603bd6e62ad6ff569188aba5eb6963d"
+    },
+    "progs/zigirune.mdl": {
+     "bytes": 70932,
+     "sha256": "2de423febd94aeca133dbcf7a32ca564aa2fd67ea7225bf5ce5eac9bd2aec935"
+    },
+    "progs/zigirune_no_rotate.mdl": {
+     "bytes": 70932,
+     "sha256": "c895f817096cb9ce73fc3d93ca75c03b1098b80ea5daedb5c1d960dbecca29f3"
+    },
+    "quake.rc": {
+     "bytes": 1098,
+     "sha256": "602205b45e5f2ddc62d230b3e2c5f028ffb24cce5652a17b4da8e4210a887d05"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/goldking/attack1.wav": {
+     "bytes": 84010,
+     "sha256": "bf15ad6846ba2d2f92a8ca7119a5e9140bb5b885c2e3c8370f1dd7a106d18b1f"
+    },
+    "sound/goldking/death1.wav": {
+     "bytes": 280874,
+     "sha256": "c7889a906ab60e0bf4a3d9e68c201d81b79d169a2fb0397eecba5ac7956b3be8"
+    },
+    "sound/goldking/grunt.wav": {
+     "bytes": 44114,
+     "sha256": "053bdb30077495b640edc388baba5825ed8b86c889f4f5bd9b7808277cb027a9"
+    },
+    "sound/goldking/hit.wav": {
+     "bytes": 56222,
+     "sha256": "0b3a95e660ce078d4960660c5cded86af962fcdea8689b74ee9debf94d5c3257"
+    },
+    "sound/goldking/idle.wav": {
+     "bytes": 66260,
+     "sha256": "90c15225e2c15d48459f29ca87fead8b47ec84c4115653c7ad1b8bab66bc9bca"
+    },
+    "sound/goldking/pain1.wav": {
+     "bytes": 69996,
+     "sha256": "e755f5709e767e69f653adf82cdd0b88029bc63bf196ab31cbdc5224bfebf4ab"
+    },
+    "sound/goldking/sight1.wav": {
+     "bytes": 177540,
+     "sha256": "c3a7469aa372561f70d0e4b57d0eb82bc2aedb10f26ae098f8be7f12fbe04c48"
+    },
+    "sound/goldking/slash1.wav": {
+     "bytes": 23782,
+     "sha256": "33a88aff6c556418b5c8e5b7a8bfc0391f6b5da2cde4f1c7b18a87afa43f0b5d"
+    },
+    "sound/goldking/sword1.wav": {
+     "bytes": 24982,
+     "sha256": "48a24e6f91055e9b39ddace699637c2541578b660b5981fc165becfe2ef9769d"
+    },
+    "sound/goldking/sword2.wav": {
+     "bytes": 27272,
+     "sha256": "148872bc11bbcf9e1a696e589fd9a8a48d6ac495248a28a77af64ba593e88322"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/rumble/rumble.wav": {
+     "bytes": 66200,
+     "sha256": "b2ca38e13253361aa1780c05269652c4aed4094f274948e865be6849d4a3b908"
+    },
+    "sound/rune/rune.wav": {
+     "bytes": 29076,
+     "sha256": "2c96372f8687dad6edee2a2280384c086e81bab6549a9a16206a244d96882e59"
+    },
+    "sound/skull/skull_idle.wav": {
+     "bytes": 756212,
+     "sha256": "95514363ac20bb0dbcccff25615c905b499226e2622422395b80a349649e8a37"
+    },
+    "sound/skull/skull_screams.wav": {
+     "bytes": 176618,
+     "sha256": "6923c93ae3d263a37fe7d53f60ba2398a33f08d5139e01ea23ad0fe75b1565da"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "6c75a5eaca3b6852978ea309a39a33b08ce16bcf9d8e82694c9a6c6e1cd58201",
    "timestamp": "2023-04-13T10:07:26.000Z"
   },

--- a/json/by-sha256/1c/1cbbad91902333adfc70f8a7ba21811eee5aaee6ce933983db72f086cc2535f9.json
+++ b/json/by-sha256/1c/1cbbad91902333adfc70f8a7ba21811eee5aaee6ce933983db72f086cc2535f9.json
@@ -87,6 +87,1840 @@
   },
   "pak0.pak": {
    "bytes": 43769480,
+   "files": {
+    "demo1.dem": {
+     "bytes": 1744639,
+     "sha256": "650b66ea831f1d2a168873d1384ab09d0ecbfeba91daab98cca9b4d2b8f07519"
+    },
+    "demo2.dem": {
+     "bytes": 611091,
+     "sha256": "c72dd103c09aceae505f7b2005e02651b0719e863edeae182fcd3871492f3705"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "e8bafd0bcd003efb3c797025e9a8b26769e6facf7202673fcec23fe8b1350528"
+    },
+    "maps/b_barrel.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/b_wbh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_wbh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "maps/nsoe1.bsp": {
+     "bytes": 1092452,
+     "sha256": "f594c8e75f4039b3abd69b558024473287bc90ab2bf801d6f1787df89bf0f42b"
+    },
+    "maps/nsoe2.bsp": {
+     "bytes": 2993424,
+     "sha256": "2011ac10315f86abdd7299667dd6353fbfee981ced19294e4463ab32ccd2f2ad"
+    },
+    "maps/nsoe3.bsp": {
+     "bytes": 7196200,
+     "sha256": "c4278fbf494a1f6f395c9cf0e44d1029bb91b1c9cfee2b21aac35810ccc4f62b"
+    },
+    "maps/nsoe4.bsp": {
+     "bytes": 4505820,
+     "sha256": "b29f265c6ce32933ea22fd550eb0b3a73d92767b013048a31e6fd581939e5bc7"
+    },
+    "maps/nsoe5.bsp": {
+     "bytes": 3845236,
+     "sha256": "e7fbf8cfc54ded36c863472891384903b9313f69f5c3b2a45df4fd7a4ce406bd"
+    },
+    "maps/start.bsp": {
+     "bytes": 1578020,
+     "sha256": "f445624f6f8e70f8e988bfd3d848f1551f1b42a48c97ec669f58f6c0752b293b"
+    },
+    "progs/archer.mdl": {
+     "bytes": 581920,
+     "sha256": "f25f30a912f3722f9b239ad5809e9361348f90bb45c15102c92e7f513c27d598"
+    },
+    "progs/armor.mdl": {
+     "bytes": 58064,
+     "sha256": "357f7e96d1a30b9aadd14891944529dfbda38a7aa7f76355da430304c9a4db46"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 15472,
+     "sha256": "aa881a687e934ced2c66da0a8fca91b7ee213b2e8a00414a242b344c68997675"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 226892,
+     "sha256": "b5c2dfe7a6b304d4e0e8e8e71610c4b30b12f686c4f5d5c559087ac27d028eeb"
+    },
+    "progs/baron.mdl": {
+     "bytes": 426204,
+     "sha256": "09a4b10b43c2cb4847330ce3660eab93c16a97a7db0c9e1c1447e938689627d1"
+    },
+    "progs/beam.mdl": {
+     "bytes": 11860,
+     "sha256": "ca23070ca0ad64fe7ced7db0dd8226db51bdc46e30cb3b33c7eb3aeaa17c5c16"
+    },
+    "progs/bellring.mdl": {
+     "bytes": 74016,
+     "sha256": "9a8131071ca927803140ce6478b8912c6eb52856861250d6b6bfa1d32cfb9cd9"
+    },
+    "progs/blood.mdl": {
+     "bytes": 184,
+     "sha256": "06825646d627df610b374a31c9265a88c9c1c45864c6e3b9d273a14dc4d745a5"
+    },
+    "progs/blood_gr.mdl": {
+     "bytes": 184,
+     "sha256": "84caed23ff1b8cabec8c5d9e5c6792c30a6d9cc57c36a9746369012015462208"
+    },
+    "progs/bloodcb.mdl": {
+     "bytes": 28036,
+     "sha256": "83f0de29aa0f9e9f1d383895da374a5313aa2252edb306eb7bd69bd71660321c"
+    },
+    "progs/bookopen.mdl": {
+     "bytes": 6188,
+     "sha256": "c02484d2b0cde19c2110f474f4809fc4cd24dae5e7b5ce1f3a59aeaa5779005b"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/chest1.mdl": {
+     "bytes": 19352,
+     "sha256": "239f897e3a390ad44acc5ffd19784f8b78232c5af2be67165581c2f6073ecc9f"
+    },
+    "progs/coin.mdl": {
+     "bytes": 44036,
+     "sha256": "c3d65aac43713c9102f8924ef7ed1cf90297ff17cfe8aface7936e9579b4ec57"
+    },
+    "progs/demon.mdl": {
+     "bytes": 238760,
+     "sha256": "1fbba988a470cd8d4c7eb69d9609dac7d354a13931a387f95d042b3c7e578f68"
+    },
+    "progs/dog.mdl": {
+     "bytes": 216284,
+     "sha256": "2d07d2fdd773f0fed85809c276204d41ee787c959637fca5f86bfeb2eddf2ce2"
+    },
+    "progs/doll03.mdl": {
+     "bytes": 52064,
+     "sha256": "b2962f3954740ad7f9b5ee329d3a189ed5c95ccbb279bb63dc77508c94e4fb28"
+    },
+    "progs/dr_head.mdl": {
+     "bytes": 7812,
+     "sha256": "dc6fab1ce2e377c849342ffa384cf6d34c0a4f8cb5407023739bf54dbc4061d7"
+    },
+    "progs/dr_lw.mdl": {
+     "bytes": 33712,
+     "sha256": "e85dca7b023ddf93d10843f876041d81ea582314170aea2896e998b9b4b3bed3"
+    },
+    "progs/dr_rw.mdl": {
+     "bytes": 38412,
+     "sha256": "e2ea525bf7a7cba3cfe23fd6049acf401c0cb5ec2ce190035969dac1bcbbebaa"
+    },
+    "progs/dr_tail.mdl": {
+     "bytes": 9416,
+     "sha256": "26da767ef55c73bdc31d0f2fd68b35b99c131f631336e96820cbc15d050453f8"
+    },
+    "progs/draco.mdl": {
+     "bytes": 190024,
+     "sha256": "f609368df6aa2cade0882de6bb708dcec286df6c1b5ecf89a2f38ceef1cc5705"
+    },
+    "progs/dragon1.mdl": {
+     "bytes": 323724,
+     "sha256": "2611402e9e68b29fbe6fe028805d7ec849a0d148a9c87e593d5a1785ab732eb7"
+    },
+    "progs/ember.mdl": {
+     "bytes": 8788,
+     "sha256": "91d6f4dfbeba0711d0864b94bb372b602959644c5c841fd659ddedb8f8e6980c"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 68804,
+     "sha256": "f3c760ecdbb530ff651c46f516228c588f37585315acdab199408911c2c8414b"
+    },
+    "progs/flame2a.mdl": {
+     "bytes": 68804,
+     "sha256": "e02210f2f6851cea4b9520476cfe36c31745dc2d84248f6a75132358d6d43035"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 56532,
+     "sha256": "2addf62820ff03b8f85042874c82e908907995187b372c7a7ef0dc305b96e154"
+    },
+    "progs/g_gun.mdl": {
+     "bytes": 24344,
+     "sha256": "f6aa476d8352bf5b7010c68387fe53121f886b26e331d8dc32b9cfabf52067b9"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 38004,
+     "sha256": "cf67c0a7ad3e853fa4af7544d0399fc0a3795a61d625f5e78104e659e2db0eed"
+    },
+    "progs/g_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "3e4a1e9dc2bff162612e218a25e2040b57d063d198df2e301eaa8fa9542af098"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 91928,
+     "sha256": "6fa67872d8519cacb20e6c48986a674b82d91a5cfd39ac03c667c6bf46a0fade"
+    },
+    "progs/g_sword.mdl": {
+     "bytes": 26920,
+     "sha256": "c9e576e2a9269e402209bdda6a3f745ad50bce1d65e130a1c9846fa59fe5e3c8"
+    },
+    "progs/gem1.mdl": {
+     "bytes": 42612,
+     "sha256": "0b71e525b19e25f98dad53ce766751de8e0c9f18434582bb86242296bb7a402e"
+    },
+    "progs/gem2.mdl": {
+     "bytes": 62672,
+     "sha256": "721459e22aab0d2cece430053734b889918bde4db879ffc94084289a7b6d4d8c"
+    },
+    "progs/gem3.mdl": {
+     "bytes": 42072,
+     "sha256": "3bc3a1018cc432b694f9ec45de06775776ef55d21b4e117dd1b2c7c0d7b850a2"
+    },
+    "progs/gemini.mdl": {
+     "bytes": 35188,
+     "sha256": "01ab3574c3edfe45b927dd842ae2016407b895e4072126e72f30af3987a0979e"
+    },
+    "progs/goblin.mdl": {
+     "bytes": 217020,
+     "sha256": "87cf5d2f979f1a5fd4446e7af34b3c568521980e458e0bd4ce510c4fcccbe40e"
+    },
+    "progs/gr_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "3f5b6d67b80e5f2e5bb7c129500c79dc345141133f8d415005f9384b0d2d9661"
+    },
+    "progs/gr_gib1.mdl": {
+     "bytes": 6501,
+     "sha256": "3f715cbfdcd77caef11b904aa12d2063cbb973d4a9d61c27492690344c14fb1b"
+    },
+    "progs/gr_gib2.mdl": {
+     "bytes": 17553,
+     "sha256": "c6166eb6132a3e87f51fcf48f4e9eebb719b3f1819d22640582b23d61bde4a16"
+    },
+    "progs/gr_gib3.mdl": {
+     "bytes": 22933,
+     "sha256": "0e40e5b960924ca642690c26b239c89aea6bae18badcb945e96d2102cad69622"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_archer.mdl": {
+     "bytes": 22128,
+     "sha256": "d537366677c6348012792a358117da9257f7e00cda2ccf7a6d4ba535e3699dfe"
+    },
+    "progs/h_axeman.mdl": {
+     "bytes": 14076,
+     "sha256": "edf2955a4efc0e529e79c589b4b699341047e604010b01f9ed9c5e68c1ac15f3"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 7444,
+     "sha256": "68bc1db4875fe84f25ff3d6c53e4e9e2c023ef52bf3c89b439493f2e5c5c0e19"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 100492,
+     "sha256": "91201d4628cec7ea434747972c1183eb677c1395099895fb45ba328cc245631b"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 46616,
+     "sha256": "d94fa089c97f569dc6099f1e886ff958e4b7883ea07a1648599c2020fcaa0520"
+    },
+    "progs/h_drake.mdl": {
+     "bytes": 28792,
+     "sha256": "5b7e9be660dac24f32679c8563cd273a9ff6bb6974fdc8bedf31ec8e73319238"
+    },
+    "progs/h_goblin.mdl": {
+     "bytes": 9752,
+     "sha256": "1841a8ac85a03cb826dc5b2db5e45c3041eff66d147c690966c35839c3754b3e"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 72324,
+     "sha256": "71977ded3744ece5d3893affeded4b257efaee53a8f16444c212f0b837627de8"
+    },
+    "progs/h_imp.mdl": {
+     "bytes": 73284,
+     "sha256": "d8146383fe6d31374c67718ff235e83d3891ebee5a0e44539b536ce049c9ce70"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 19644,
+     "sha256": "1accd89ba95db3627cee4f06f94ab3bc9d146ebf566da24b570c733f2f902c1a"
+    },
+    "progs/h_necro.mdl": {
+     "bytes": 8052,
+     "sha256": "610bf9c83b1bb97de5bf5b159da9f624d7b9f85427e43f6d52cdeb4df346c002"
+    },
+    "progs/h_nemes.mdl": {
+     "bytes": 78156,
+     "sha256": "6f350692b44907984c02779d0114576bbafb6a3ada673e1f55d1cf02fd062c18"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/h_rebel.mdl": {
+     "bytes": 5428,
+     "sha256": "b189ff3ae1596da7596f21d8f555603951fadf8e7884e96f89c8b2b5789028a5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 53096,
+     "sha256": "985c18b99e44bea0837fc4e982a9b696f43bc2eee408cfc85fc915ef11e97c18"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 108204,
+     "sha256": "dd7dc5c90255da868b96ac553d8a8f68b6723da6b25114bc087fd019966a023f"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "4d028c6b3a3b5c9df4d9ca8561b7da70857980b8688fbf3607cbdc65fed3ccc7"
+    },
+    "progs/hero.mdl": {
+     "bytes": 66388,
+     "sha256": "ea4f359a328b6416588e5debe13a87fc2eccd8a65263ae23683d71a58b39a116"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 439732,
+     "sha256": "11a8cfbbe104ad9ef11c05012a218c7be8bf0d2cf9b7f9dee148c8a65e302ea0"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/ice.mdl": {
+     "bytes": 5812,
+     "sha256": "772eb399b9f9567e7e8f8b51e3749a67b58237321554272e94875a05261a124e"
+    },
+    "progs/imp.mdl": {
+     "bytes": 583036,
+     "sha256": "0010c831c9d39406a2db6496f62786fd2e60a2ea7f80e18b486f27145dcbb0ff"
+    },
+    "progs/imp_rock.mdl": {
+     "bytes": 2352,
+     "sha256": "dbe190f471f5738779e103b496117ec40e2adc9e5f593d2470172bcbd7ade0f6"
+    },
+    "progs/imp_wing.mdl": {
+     "bytes": 93932,
+     "sha256": "d727c88da33bdcd3875509f8bf96af0cbcb31b25aa5f5b03ce1584aa0cec2047"
+    },
+    "progs/k_ball.mdl": {
+     "bytes": 31300,
+     "sha256": "f93346ffeed3fd5d9866fb80d1a08216759bb27757d49a1851e471aadf757ec1"
+    },
+    "progs/key_b.mdl": {
+     "bytes": 10616,
+     "sha256": "d1333d74b7e194f6587d0f5ed1fca28887cd0414734b4bd4cbb7e715ab897629"
+    },
+    "progs/key_m.mdl": {
+     "bytes": 23160,
+     "sha256": "ea2feb6eb54823668dcb112f42c3441e563e18e3cc1806b5ce509044e6c0b448"
+    },
+    "progs/key_w.mdl": {
+     "bytes": 11576,
+     "sha256": "72da64d2b29d69605c453e9ee0e5fa8ecef91a94cc541103cb24fbad96c7946d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 232536,
+     "sha256": "e3e618799612c6e521f68234a061d9a46036ef556677b0c1651e7647258ffb56"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 27960,
+     "sha256": "5877b37cc4f98a53467c412e7d06d1f7ec6b60f5c0f2088514aa51c9d2c51769"
+    },
+    "progs/laser.mdl": {
+     "bytes": 33240,
+     "sha256": "bd223621645a4167668a833cf531cce0a56ffc4afe921decfb791b1d69b83310"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/levitate.mdl": {
+     "bytes": 15876,
+     "sha256": "03e77b0d4b8ee7b3b224cbe0cfba63e8bd27d0391bd5069981e5435287f66645"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 57796,
+     "sha256": "e8b38ca8f28a89f65ffc652e082e8a9aaf6a1a9db8302e961b9ceac1c8f60e8c"
+    },
+    "progs/nec_rune.mdl": {
+     "bytes": 19524,
+     "sha256": "cea5c89dd0034465a54a8434bc9367554f0244c2e38ec9220cd28a5a53a444a9"
+    },
+    "progs/necro.mdl": {
+     "bytes": 475588,
+     "sha256": "84a5aa52a22dbf1fb3442b4114eb0640ddbd324c21a669d29d5a56d7fd496725"
+    },
+    "progs/nemesant.mdl": {
+     "bytes": 202492,
+     "sha256": "099c26752c7160144a25716e0af0f30f8ff179766db4a05371a0392166f85c42"
+    },
+    "progs/null_256.spr": {
+     "bytes": 5412,
+     "sha256": "c52813b634ef1ab641fdd4c3a9739ad758f1b5c39ba5e10acbbf034ee0ff850b"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 230152,
+     "sha256": "b7c88ae295ef8fc8d17b4fd6facedbb8e464ee665039a884af8e215a3929f24a"
+    },
+    "progs/player.mdl": {
+     "bytes": 277024,
+     "sha256": "c673ff0f6639671000c7415e27ef1355fb5c8278b19641d5b9f5e45d3cfba0ca"
+    },
+    "progs/potion.mdl": {
+     "bytes": 6316,
+     "sha256": "0e66a6ced7f31e5eb23459433908995241e78835776b02037109b8aef6dad2a0"
+    },
+    "progs/potion2.mdl": {
+     "bytes": 16228,
+     "sha256": "30a97f9d1e82eccfaa88396a82ae2e21fcff08ae095b2eb17941aa1a66e69353"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/pur_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "dbc2bf835db1c1789c329504f86802990a19288f67d9560f32cfe5a8d5a62885"
+    },
+    "progs/r_bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "2d776e4acdf20cd117f3f4d6be3647fb9d0e117756069cbfc52ece716fdbb251"
+    },
+    "progs/rebel.mdl": {
+     "bytes": 215292,
+     "sha256": "433596df8d06be0882f00a2c1fad0ea49a8ae42ef148d32e0ae7c06c420322aa"
+    },
+    "progs/reflect.mdl": {
+     "bytes": 10224,
+     "sha256": "72da6cffa3556503bf43f4ccdcc9f3bc8329b20dc70f38d20fedbabc3fa280ca"
+    },
+    "progs/regen.mdl": {
+     "bytes": 25460,
+     "sha256": "7f4c06f4a7046908317a61bee2a5810eae03fe99f09018455f1fa0a62f45c5e0"
+    },
+    "progs/rocket1.mdl": {
+     "bytes": 34260,
+     "sha256": "c9412482647d681e08f74eb0c0260ffded91dfc67378996b86b720ef3cd2fd47"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 17204,
+     "sha256": "0dab5b94c60d92d55df3e44a8d8ea2dc0f949e98897a6525ee0be3f49a019b08"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/s_exp32.spr": {
+     "bytes": 62676,
+     "sha256": "935287995f6ee03093d3a5f6a6ae22ad14aa6ce70490bc437c3816a491904543"
+    },
+    "progs/s_exp56.spr": {
+     "bytes": 189396,
+     "sha256": "b60788e69ee0f3ef0582d088625d6506ed0d8efa5067a93845bd94631dbb5e76"
+    },
+    "progs/s_rain.spr": {
+     "bytes": 32824,
+     "sha256": "0aa4667092e2c3a38d136f4f61a9c4f063fcdcdd69a9f880b9306f8646a2b752"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 7596,
+     "sha256": "00e2bd1686ba0f4abaae1157c2c2b75373a9a7ddad94326aa3584bebfdfd2129"
+    },
+    "progs/s_wave.spr": {
+     "bytes": 239892,
+     "sha256": "62a101fa0d47aa8e1c7154893ea1a79a2dd8de60e1d4c2e9eaf48191d843de02"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 200848,
+     "sha256": "4c0653e3adba99be4d581c92a928fd6e8c27b0a2159a97f7ec5e885478249b8d"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shade.mdl": {
+     "bytes": 140876,
+     "sha256": "a6d06987dc6e55f7f39c4d25fb3e38876a75354d84621b2dff2b2c4fcef7593a"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 128012,
+     "sha256": "74f51581c3bd90ebfa5345f8cc0b92cf354b6ce99f401898ddb96dfc4453d063"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 176048,
+     "sha256": "7ea0c1007179eb7a45112aaf38d8042213e8b644e6e79b9b1a8d4402c3843b47"
+    },
+    "progs/smartbal.mdl": {
+     "bytes": 27924,
+     "sha256": "288e2d54afcbdc5242ab831f3ef611710317c52432e4585a938a12df80b7a07d"
+    },
+    "progs/smoke.mdl": {
+     "bytes": 184,
+     "sha256": "2086abd9950bc643446309a80d9df86b4ebe3f2086f75e799ce943a8454c77d7"
+    },
+    "progs/soe_coin.mdl": {
+     "bytes": 26364,
+     "sha256": "cfa664c588fb71f886e7001a2682abb8db61a191b98be0ec1242803bb10c8169"
+    },
+    "progs/soe_gem.mdl": {
+     "bytes": 165236,
+     "sha256": "788f32633f1f3a9f6dd2e0c2dccb76871e02fc6e002db82a219f077dcc493c3f"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "078b774958c598bdf1503934d51a1393aeb9aadebcde806db2272b04b233c6a2"
+    },
+    "progs/throwaxe.mdl": {
+     "bytes": 56532,
+     "sha256": "0ebedab9ab397ba15dc3f0d90df703af2984d1c070eabc08ba781c308968150e"
+    },
+    "progs/tree.mdl": {
+     "bytes": 126509,
+     "sha256": "7705f8b4e337bd370dbd0392d33da437f08768723e6d43725ddbb07ac3662b9b"
+    },
+    "progs/tree_zer.mdl": {
+     "bytes": 101704,
+     "sha256": "f5dad886e64ef946b0ad0aba3a06da419579911c5248ee856d2d503e40c4beab"
+    },
+    "progs/treetall.mdl": {
+     "bytes": 120532,
+     "sha256": "e74e7c38099ccc833fadf3c7b7e97f746878d07102dad8cc5926546b344cb982"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 94756,
+     "sha256": "6012df07132210842fd7ec6415abbfa40b7818a02aeb8f15bc0254de006b82ca"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserb.mdl": {
+     "bytes": 43852,
+     "sha256": "67e854c43efe348faffcc1aed8415a8e68fe2069ec94447a3610b580b72f3f88"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 47252,
+     "sha256": "86cb778c5e84f2523a8d47a8d1d021e46e9a6af343fd69b84805e783c800b033"
+    },
+    "progs/v_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "a2d573bdf52015bce7a571a2263a3e8d938daf0bc1b5e4589f84580cab7da2d4"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "7758aaf42d0d1617e4fb172ce842be4316073f63250aba46dad441327cccb2e6"
+    },
+    "progs/wanted.mdl": {
+     "bytes": 27860,
+     "sha256": "03337a468db14377fcd36842037d2a27dfb97c3d5d5f45fcfe408e79050a5839"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 67956,
+     "sha256": "39c4a5daef1cfafc1bbfff1ca8eebb5c75d27f953f31d29f249205762605a56f"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 109380,
+     "sha256": "c82780f930af561c4a839a00a32d0d1e77352b385d236d04b9536ab40f996b8e"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 133676,
+     "sha256": "0a57ee912df3142c5e17183d5f6bd461021b141d53f7534014d59eda97e6bfa6"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "sound/ambience/amb21.wav": {
+     "bytes": 80716,
+     "sha256": "d664ea08d9df7e7dd135eb0726c1bc142878dcc53d13564dd3dcc5562180201a"
+    },
+    "sound/ambience/amb22.wav": {
+     "bytes": 92716,
+     "sha256": "f444289984b285a1497f55e566fbbf1896a04fa38e291efaa3ec1a0720204811"
+    },
+    "sound/ambience/amb23.wav": {
+     "bytes": 40180,
+     "sha256": "e451997ac7f37d08bd8434d708f45ee2967693317684b947ce511c9df84828b3"
+    },
+    "sound/ambience/amb24.wav": {
+     "bytes": 42282,
+     "sha256": "ead78c8507a7a6a7d6c61e913a2319964f6a8f70b5f7f720c162725edd9cd5aa"
+    },
+    "sound/ambience/current1.wav": {
+     "bytes": 50906,
+     "sha256": "dabe357d48586dccb8e1ed18c49828797c9f7a8c02c7a588ddc76a62c9b1d3e4"
+    },
+    "sound/ambience/drip_amb.wav": {
+     "bytes": 105444,
+     "sha256": "b282bc6082754011ee21a82aedb490a856c0f694f57991992296554c13149b02"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/heart.wav": {
+     "bytes": 8190,
+     "sha256": "a5b42c46cca24da59c324bb28ce6887b3a2a3baafcc18b0db2b2485f1189a4e0"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 177840,
+     "sha256": "9daec0732dcc821670b8910a1371153e3829e604b6957bf95931bea416af6074"
+    },
+    "sound/ambience/mov_watr.wav": {
+     "bytes": 44432,
+     "sha256": "9d6721844fd5559ab4f53902e70ad9789a90710dde082d222bd814a36c00ab67"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/spark2.wav": {
+     "bytes": 61640,
+     "sha256": "7eb18b00cd5e7913fea7a85ec5b1db159d1d001d24d4f687bfdb5685cb163c8e"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 106286,
+     "sha256": "056f37dfd1d5f4eba1d1911245dc0930bb0c46a84d72d867a286e5a9540248a0"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 87710,
+     "sha256": "2bb46f7c8f70fd28f0ca47b294824bcca7689047291b6c5259eebe76ad6aecfa"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 140630,
+     "sha256": "5a4dccd168cbd9f759ac468d7aa879dbcdbe5637e0fd0521f641ba1d60f61817"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 28798,
+     "sha256": "f66c76f07eef275e904fcc76d7ca9fc2011f3de8c61ce0b3ad035464beb7a86c"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 110578,
+     "sha256": "c3e1ccb091b9d8a06b83530b5e29b9f26f5ad8b9dcd082f3da976c3d44944b87"
+    },
+    "sound/ambience/wingend.wav": {
+     "bytes": 90874,
+     "sha256": "63e435d896b097d4dc413fb1afccc2078f1d101a4f7bfc18c4e593ca9e8b344f"
+    },
+    "sound/ambience/wingget.wav": {
+     "bytes": 65148,
+     "sha256": "533bdbd7beffa4c71c66239e3ac417f2177b20a60ed39c379c59a10b2222b367"
+    },
+    "sound/ambience/wings1.wav": {
+     "bytes": 6028,
+     "sha256": "c9e05f66a1d728a88289bc213c9f3551f1e54a4f3e8ef23ab03f8d5019e7b2c5"
+    },
+    "sound/archer/arr2flsh.wav": {
+     "bytes": 5464,
+     "sha256": "e9a0c059430744c6546a6be4be3a1e4ac775ea6c5e6440d14611ecd8c8447d19"
+    },
+    "sound/archer/arr2wood.wav": {
+     "bytes": 5458,
+     "sha256": "97c5106007e703618291242bf1c6db9853a9d625189fc26ec9c4864436b560e3"
+    },
+    "sound/archer/arrow1.wav": {
+     "bytes": 2296,
+     "sha256": "4aeac8630ff6036f095a251a018eea5baad7a59bd7e46f624dbfec793e44d7b4"
+    },
+    "sound/archer/arrow2.wav": {
+     "bytes": 3196,
+     "sha256": "0a2734df5a69f6407ffc34ab05d8655da5d7dc0e487627932390fa6cec022083"
+    },
+    "sound/archer/arrow3.wav": {
+     "bytes": 2156,
+     "sha256": "1b866280829cb7ac051f90609baa8db285f3bfa3a27b5814e72b021b7cc05785"
+    },
+    "sound/archer/arrowbrk.wav": {
+     "bytes": 5002,
+     "sha256": "f72e35d5232f40e503192ff0ee26fe152eb42e5ee7141b2bea33a9f12f38aa2b"
+    },
+    "sound/archer/arrowg.wav": {
+     "bytes": 15132,
+     "sha256": "8ec5ee520f81c69ba367ae549a06d5ea1643b43f81dea7d8345561c94c8412ed"
+    },
+    "sound/archer/arrowmet1.wav": {
+     "bytes": 2638,
+     "sha256": "87e6ef50bfe4dabf48a1fba18ad0138bbd298965f1a9d06e2b059019e6f74b60"
+    },
+    "sound/archer/arrowmet2.wav": {
+     "bytes": 3118,
+     "sha256": "2797466dafd51473b8b6b5fd3d02a5baa4fe92a1bf9342fb038a299230037138"
+    },
+    "sound/archer/arrowmet3.wav": {
+     "bytes": 2804,
+     "sha256": "1e77951ec2218add2a8bc1633a925e4a96d2ca247d7b5dfaaaefd7a9a4f2363f"
+    },
+    "sound/archer/arrowr.wav": {
+     "bytes": 9458,
+     "sha256": "10e4bef745e55fddd004ea78d24edb9d3d9edc1ce3053c377be07be27a4da144"
+    },
+    "sound/archer/crash.wav": {
+     "bytes": 11069,
+     "sha256": "60e704bdfdb0a97863b00f3514130a172b95a86bebbf89642b65a6e757a74259"
+    },
+    "sound/archer/death.wav": {
+     "bytes": 9526,
+     "sha256": "e824b3d7d66e8bfc3ce30cc3116eab1b2d2dbc09c6311f91ff25d3e7eaef19f5"
+    },
+    "sound/archer/death1.wav": {
+     "bytes": 16680,
+     "sha256": "f409bd2b5624bab561a8846939fbf7194628ceef5831211bb6fed8802f06c2d1"
+    },
+    "sound/archer/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/archer/death3.wav": {
+     "bytes": 33694,
+     "sha256": "990920962c449b0a41548df21f03f22488a60a6f5c45ffba142a943c345162ab"
+    },
+    "sound/archer/draw.wav": {
+     "bytes": 6874,
+     "sha256": "c94e5cec38dc40102beebd067554c91e63b86e5c1ef11dc17976733bd9f08ce3"
+    },
+    "sound/archer/growl.wav": {
+     "bytes": 9240,
+     "sha256": "7bdbbd23b3fe056cd1d904124824aa0044acf3aa19ec88f65e092fd13e4b9437"
+    },
+    "sound/archer/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/archer/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/archer/pain.wav": {
+     "bytes": 5082,
+     "sha256": "5347daf1a9263320f25b2a191895fbf6c85278f1fde6ca5962c09ed38e0b37b0"
+    },
+    "sound/archer/pain1.wav": {
+     "bytes": 12158,
+     "sha256": "4a2d4fc161d8838176ce17fc2e5ab75501bf82afffb0b0a0ee594fbac26447fe"
+    },
+    "sound/archer/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/archer/pain3.wav": {
+     "bytes": 11212,
+     "sha256": "cccdbb98396bface238dfe958f44dec4630714a7b545d30877324c0dcbedaf64"
+    },
+    "sound/archer/sight.wav": {
+     "bytes": 16866,
+     "sha256": "bcd12d078e7bc34f0bdea7ae9a34ccd2c9bacb049617329b44f8301c34fffeb0"
+    },
+    "sound/archer/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/axeman/adeath1.wav": {
+     "bytes": 18785,
+     "sha256": "4040e419ba190d233419f588541f75f0289d713a1e2f7cbf83708d08edb7885d"
+    },
+    "sound/axeman/adeath2.wav": {
+     "bytes": 27882,
+     "sha256": "b5311af0d046a805ab9ce9d79b2af3037047e52e94349a1ccace928041c9f99d"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/apain1.wav": {
+     "bytes": 10374,
+     "sha256": "781160b1fbb66a61a3ee173100c69ece38a65ed13ae49a9341c5ff5c16e7c8d7"
+    },
+    "sound/axeman/apain2.wav": {
+     "bytes": 11947,
+     "sha256": "0b8281501c240cfe13ee22de6f1c177e285251cff3dc0148b3095e5200b030f9"
+    },
+    "sound/axeman/apain3.wav": {
+     "bytes": 13155,
+     "sha256": "18e1ba9a8a1cdd9b4339011ff85a1a322e4aab2f93cc7e721038d0746765bbfe"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/axeman/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/axeman/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/axeman/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/axeman/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/axeman/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/axeman/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/axeman/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/bane/death.wav": {
+     "bytes": 10935,
+     "sha256": "7e4775bc543acfb421a446a00efff6d9d5669fafb2387464cb1e1ae3db91efe8"
+    },
+    "sound/bane/death2.wav": {
+     "bytes": 17999,
+     "sha256": "40dd4806e413a9156e442b9889cd42de6959bf56f81207deee0625d002d3a83c"
+    },
+    "sound/bane/growl.wav": {
+     "bytes": 9045,
+     "sha256": "86e7b3d2e685d7c20e503bdffe676727426b606ef069f4b70f182601e910ec4e"
+    },
+    "sound/bane/hit.wav": {
+     "bytes": 3884,
+     "sha256": "228faf88857d697f4d5fb9b9c03f000af4dbc8b254791e18e973fd48cc96db9b"
+    },
+    "sound/bane/laugh.wav": {
+     "bytes": 22108,
+     "sha256": "ae8e8d13e00f41bce729977f09a92806c8451ebe5cb4e8618a6b79df4d70296c"
+    },
+    "sound/bane/laugh2.wav": {
+     "bytes": 31560,
+     "sha256": "5cc5ff4c3be35eec90eaaa6579a55fa843843ad658e2e4bbb258a77f6e410020"
+    },
+    "sound/bane/pain.wav": {
+     "bytes": 9325,
+     "sha256": "1d4cfac1f9dfa1ec6958b18014ec7be18dc2615e64888d3c584d50bb48e51013"
+    },
+    "sound/bane/pain2.wav": {
+     "bytes": 16389,
+     "sha256": "7764f31eaf8e12a8384b7fccf3f0b771b51dcdfb4b6dd4228a861c7aece254c2"
+    },
+    "sound/bane/sight.wav": {
+     "bytes": 22962,
+     "sha256": "fbaabe115d9ca4b985c4481ccc71e6b6f55931394a29a6c51ec97e752ed3d5be"
+    },
+    "sound/bane/thunder.wav": {
+     "bytes": 43130,
+     "sha256": "cb355478e38df678e859557a0f983120a4d4275272d8ebedcae7c9cccf659bc4"
+    },
+    "sound/baron/bpain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/bpain2.wav": {
+     "bytes": 18272,
+     "sha256": "44ec1f0c3119d5da84c8d54c24112b3f36d85ecf05002c8c129e825749314daa"
+    },
+    "sound/baron/death.wav": {
+     "bytes": 8576,
+     "sha256": "3dd3a23d5a913548d0d0aa6ee1b455017648fcd4830f204539a1626c2ec8e1c9"
+    },
+    "sound/baron/death2.wav": {
+     "bytes": 15716,
+     "sha256": "b677476939515151475e195215980cb416cc52fcb5dec3df0c1d48cedb5e0aea"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/fireball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/icefire.wav": {
+     "bytes": 8858,
+     "sha256": "b529a958de192b59438989c6b98eb50f858273febab53a238b651c70a3c92098"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/shard.wav": {
+     "bytes": 14324,
+     "sha256": "313428dd2cb681a38ad89983ab39b18979f64b3e398104b1ad80f3dc9726616c"
+    },
+    "sound/baron/sight.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/bishop/conjure.wav": {
+     "bytes": 54627,
+     "sha256": "532d4b7d5db6a654aa73dfe18fa0f6a71623acfd804a848f106b0af699022bc4"
+    },
+    "sound/bishop/journey.wav": {
+     "bytes": 42051,
+     "sha256": "0995e55661447c53c3a36ae4552ea2e0bb7ec8b178bf52cdabe9d28b4deaa50c"
+    },
+    "sound/bishop/rip.wav": {
+     "bytes": 31906,
+     "sha256": "7070871da7ec08da6260a65f1a98ed1bf9682b1c95c51cea262a4b88a63fb6ca"
+    },
+    "sound/bishop/rot.wav": {
+     "bytes": 22463,
+     "sha256": "866b836874ba611d70675e5e3b83eac059c927bef0e0d1396f2183ea01bcc203"
+    },
+    "sound/bishop/skull.wav": {
+     "bytes": 34293,
+     "sha256": "48836a4d60ed8962ed0f11bffdcca95a200645e3b2cfa49a598d6392e10dc153"
+    },
+    "sound/cube/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/cube/bc_attck.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/cube/bc_gulp.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/cube/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/dragon/acid.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/death1.wav": {
+     "bytes": 18358,
+     "sha256": "645baa1cccaf1dfbcd628d17fd8ea290f42f1bc40903e26c79a536a6d1528a2a"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/fly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/flywater.wav": {
+     "bytes": 11034,
+     "sha256": "68cac399467a55df3c80331696869309eea2339467df0ba94408be4fa2afeb3e"
+    },
+    "sound/dragon/ice.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/icehit.wav": {
+     "bytes": 9370,
+     "sha256": "089c07d0352678106aaa1c47f015792393d5aa01b4bd64fa35e798c4ee09108b"
+    },
+    "sound/dragon/idle1.wav": {
+     "bytes": 34068,
+     "sha256": "3a125f0bcf2908e4ba3af298b117f71c0efa43be4077e53c791b2805cce6a038"
+    },
+    "sound/dragon/idle2.wav": {
+     "bytes": 21474,
+     "sha256": "e1101ff0121687511a9c978d0a30a945421d0a2a30b7d139e4427d41dcc17628"
+    },
+    "sound/dragon/pain1.wav": {
+     "bytes": 6524,
+     "sha256": "6cdce2fde3a1eb328007e0667c5dfe705e87bcd526e416ac948fa11a36448ac0"
+    },
+    "sound/dragon/pain2.wav": {
+     "bytes": 6875,
+     "sha256": "3238b77aafcc60c634cbdbd47ae1eec99bb969e2161b72ce5623398e6a451d2a"
+    },
+    "sound/dragon/sight1.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/sight2.wav": {
+     "bytes": 15205,
+     "sha256": "197238a35261e6792c40a4da38ba7b3827116ac1af5f143e092768346605b470"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/goblin/death1.wav": {
+     "bytes": 13890,
+     "sha256": "bed0d074d9aeee8f046ec7b3a9d33e02d157374ddf6af1296bd1ca7bebf30f10"
+    },
+    "sound/goblin/death2.wav": {
+     "bytes": 10280,
+     "sha256": "9cc07020579d50185ea401835e41edbd1c8f007065e39a6306c7aab4f32e7781"
+    },
+    "sound/goblin/idle1.wav": {
+     "bytes": 9802,
+     "sha256": "6c5a8c36eedb0ac5bddacfdf68250c36fe472f9d87e8969b4f95a863a99b77ce"
+    },
+    "sound/goblin/idle2.wav": {
+     "bytes": 9242,
+     "sha256": "5850c885e59ef04ae90be0579dd6f6b7cc26c282045ccb163dab2c9e19fea704"
+    },
+    "sound/goblin/pain1.wav": {
+     "bytes": 5118,
+     "sha256": "8afd94fcaa2d20e7c6626eda0c6cd5463670a1dbed0eeea36da588b28196c8a2"
+    },
+    "sound/goblin/pain2.wav": {
+     "bytes": 7898,
+     "sha256": "ad1f3b63b4ae35e4bfe010447bbd18bb85cd2bbf966ea7e1370afb0e924e699c"
+    },
+    "sound/goblin/sight1.wav": {
+     "bytes": 12716,
+     "sha256": "1c20028239d217f31af57649da5d1a6def576569ef5fc7e7033c2acbef7f9345"
+    },
+    "sound/goblin/sight2.wav": {
+     "bytes": 19356,
+     "sha256": "c9182325cacd9734bfedd48cb5d8076d5823b7a94baa40d32b02de9504474b48"
+    },
+    "sound/goblin/sight3.wav": {
+     "bytes": 8526,
+     "sha256": "796b2f9f0a1c20d672382c6681e9a6ea200fee2cfcacb5b3d3faa72c8e2537d4"
+    },
+    "sound/goblin/sight4.wav": {
+     "bytes": 8668,
+     "sha256": "c0a60baf2b9918a6df5fc32cd8b58c9fa7cfed923a4cb21c841f04f7a544782e"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hknight/death2.wav": {
+     "bytes": 15468,
+     "sha256": "b0e9cfdd68223d49820d03c2f8e5f59ab94e0f284d6865f492ae1a9d4fb13473"
+    },
+    "sound/hknight/pain2.wav": {
+     "bytes": 14568,
+     "sha256": "a069f8260f241acecc313dd0d2e688763052cf65c32597c5779d4776497fd6fd"
+    },
+    "sound/imp/die.wav": {
+     "bytes": 8448,
+     "sha256": "a8b0e037b88829b978d3dbd3d5e657c7f775c73662d554f6247a387ba333d4bb"
+    },
+    "sound/imp/fireball.wav": {
+     "bytes": 5492,
+     "sha256": "6362b59ded89655fa8b8877ed2639eca1a7aae1847306bbc3843fa98bedcbdaf"
+    },
+    "sound/imp/fly.wav": {
+     "bytes": 9204,
+     "sha256": "8036ccb256978c17234aa171267fb0332f1911b5f0dad7b9f74bba9378c39a37"
+    },
+    "sound/imp/flywater.wav": {
+     "bytes": 9800,
+     "sha256": "c80045609b62ceb61bd8fb1a18a53c0f2fd5443502a802b0d6d3c61e9a1db4c0"
+    },
+    "sound/imp/shard.wav": {
+     "bytes": 10678,
+     "sha256": "f806167fe23f37826964c0cc345c438ff0e79c3ffb1fed2c85451c675448cae4"
+    },
+    "sound/imp/swoop.wav": {
+     "bytes": 10842,
+     "sha256": "100eacded51635de912cee171f093e869d24589c44f68887497fe751cf9b1e4d"
+    },
+    "sound/imp/up.wav": {
+     "bytes": 12500,
+     "sha256": "874b533da43f713a1be27fbccadda8b6392fa8e689c8c4d17dac4b0d380f5822"
+    },
+    "sound/items/equalize.wav": {
+     "bytes": 13008,
+     "sha256": "933046049bae4d866250ad9a6e0a4b2a9385caffb4156daaca39ff7110a71126"
+    },
+    "sound/items/levitate.wav": {
+     "bytes": 44236,
+     "sha256": "8a04ce4a97dc22d095bc52d08111bcaaf5f57482f580ccbe0c61bdf8fd18913f"
+    },
+    "sound/items/money.wav": {
+     "bytes": 5100,
+     "sha256": "e4ac299499340c1be250f5d5e0824440d9e539de8a1d5b01e303056719cf822f"
+    },
+    "sound/items/quaff.wav": {
+     "bytes": 3748,
+     "sha256": "ebaa4ecc17dc67d3fbc5fe1a7541e4e19769ce941d043922f8572cb2da8d3cdd"
+    },
+    "sound/items/reflect.wav": {
+     "bytes": 14936,
+     "sha256": "90dd50b25175c8d514a52165429e9ca6b90c45dddbb0f301e5873146b4a4a06c"
+    },
+    "sound/items/reflect2.wav": {
+     "bytes": 33119,
+     "sha256": "5fb5afe50e0f5fa24f1c4481b3060ae222f40138ca81052cea047a57aa6b03e8"
+    },
+    "sound/items/reflect3.wav": {
+     "bytes": 7804,
+     "sha256": "a079e5aef6ed9fb7d5c992b0ef8e11932a9efa192eedac2bc530098e0550984a"
+    },
+    "sound/items/regen.wav": {
+     "bytes": 7984,
+     "sha256": "1e125e8e7c19f29eaf09b7ad301fdfe5126d922dfa84ba2af267cdf3351b6498"
+    },
+    "sound/items/shambler.wav": {
+     "bytes": 20182,
+     "sha256": "f0cdf78367b770c97b3b89abedb7c4fb0a9ee10d742acc8c98b3daba46cfc215"
+    },
+    "sound/items/treasure.wav": {
+     "bytes": 5554,
+     "sha256": "c86f66148e8dc99af2c8e877d64d06dc1c35d0caa9c6dc5c8092b268960b8edd"
+    },
+    "sound/knight/clang.wav": {
+     "bytes": 7198,
+     "sha256": "634a88cf26b4de688bed392cf108d5468749f212ce67015c71baa942e8e88502"
+    },
+    "sound/knight/kdeath2.wav": {
+     "bytes": 17854,
+     "sha256": "b712871a7316df7f6341719d488d67e65344f20d8561c97ae3115dde67cf0bfe"
+    },
+    "sound/lord/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/lord/death3.wav": {
+     "bytes": 33694,
+     "sha256": "990920962c449b0a41548df21f03f22488a60a6f5c45ffba142a943c345162ab"
+    },
+    "sound/lord/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/lord/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/lord/idle.wav": {
+     "bytes": 4700,
+     "sha256": "d9d7e5003fb23f3891e25a94e91d8755691d08331dc80dd0319a875766644a6b"
+    },
+    "sound/lord/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/lord/pain3.wav": {
+     "bytes": 11212,
+     "sha256": "cccdbb98396bface238dfe958f44dec4630714a7b545d30877324c0dcbedaf64"
+    },
+    "sound/lord/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/bellring.wav": {
+     "bytes": 27600,
+     "sha256": "fe3b2972c722171144eaba160757803292a42342e737d6acdbd0b14802e686f2"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/dsslop.wav": {
+     "bytes": 11163,
+     "sha256": "b6a9f6e74b222169c87e6c56b47d2e7995b23b8b045f16be968f43290f22cf9d"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/met2wd.wav": {
+     "bytes": 3968,
+     "sha256": "a3ce3e10b609f7ae28fc6f39f1f5d55a7c99a41143fb161de7e4e47b7f40f100"
+    },
+    "sound/misc/pushmetl.wav": {
+     "bytes": 14042,
+     "sha256": "2657b0006f51ecb7077b5861b1b282e0bb8bef3bdd5ccb68b3bdd6794361099e"
+    },
+    "sound/misc/pushston.wav": {
+     "bytes": 11490,
+     "sha256": "f457b95dad6131472475ab22d9c260adf5d389e74629cd8ea36ca05ad7d4e749"
+    },
+    "sound/misc/pushwood.wav": {
+     "bytes": 13602,
+     "sha256": "7c3fa06978f8c7b632d12bbf1031a5ac316b44fdc5efd93338ab0a0a162bdf3a"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/secret.wav": {
+     "bytes": 87440,
+     "sha256": "36e9d9617a14daefd510e72308b9e85718a473e2b25a06b66026d463d6bbb519"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/misc/woodbrk.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/music/halo.wav": {
+     "bytes": 860502,
+     "sha256": "20f314c0cbf1191e71b8e28e29a26ec3e118427648001363a197b4672cd7e35a"
+    },
+    "sound/music/pkdream.wav": {
+     "bytes": 154898,
+     "sha256": "df8857901002ce9dde3c558743c94967db11cae4af3d9a0cdc00c8cc09e6a910"
+    },
+    "sound/music/shadows.wav": {
+     "bytes": 550938,
+     "sha256": "5f3ee07c7954b9acce2eba6a633c6a5c72f30a8e68de51a393680f3eb737e49e"
+    },
+    "sound/music/soultrap.wav": {
+     "bytes": 868386,
+     "sha256": "15d35788ce7bd8f5c8c761ce94568c9da8cd1bfefb3fd4d3d69b610f489b7a5e"
+    },
+    "sound/necro/att_a.wav": {
+     "bytes": 8522,
+     "sha256": "a946c060cab5ee1bfff2d1af87cd71c9ccf63840a2751fd46fd32f387bee2c35"
+    },
+    "sound/necro/att_a2.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/necro/att_w.wav": {
+     "bytes": 26298,
+     "sha256": "9ae481ad41d16610b597989e82a8bbf9c35a74fe03a8e27900d72ff8b52e3c94"
+    },
+    "sound/necro/death1.wav": {
+     "bytes": 24010,
+     "sha256": "302e58b0f701ad07ade4a46d5cd3bd9c2186b2df3eb39e36c361918a72ccd24d"
+    },
+    "sound/necro/death2.wav": {
+     "bytes": 23594,
+     "sha256": "05f15a8430885b6688587eba5e249107c3e6df36d7937a3ddd2411d275e8842b"
+    },
+    "sound/necro/idle1.wav": {
+     "bytes": 49212,
+     "sha256": "737f382e89a40fc098214b77e9165e16f2a06323c07e910f336f2616b6ca87b4"
+    },
+    "sound/necro/idle2.wav": {
+     "bytes": 47120,
+     "sha256": "18893e7b31ff448831a7b7a5aa9a5d31b2dcd6e49ae8b58d5eea8b44683415dc"
+    },
+    "sound/necro/pain1.wav": {
+     "bytes": 19412,
+     "sha256": "f37e247a9e1436e4a86b78fe71e1ea6da43323e60943e86784ac87fc4393333b"
+    },
+    "sound/necro/sight1.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/nemesant/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/nemesant/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/nemesant/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/nemesant/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/nemesant/push.wav": {
+     "bytes": 8812,
+     "sha256": "91398e953b648ab23c037940fb7996f3d77727003a60757ea50686328c05cd69"
+    },
+    "sound/nemesant/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/nemesant/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/nemesant/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/nemesant/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/nemesant/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/nemesant/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/nemesant/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    },
+    "sound/ra/1.wav": {
+     "bytes": 7098,
+     "sha256": "6f41307a1d8a57f67917520d9c517df7b5e403f6e4f27b8c4b464ae1a57a4945"
+    },
+    "sound/ra/2.wav": {
+     "bytes": 6138,
+     "sha256": "6db176165cca16a7bd0538b77cf5dc6a68343ce13be3c5e716b61c7e5fc8840f"
+    },
+    "sound/ra/3.wav": {
+     "bytes": 8298,
+     "sha256": "bb0395f548fff802c76a113a521f0fc7a31029f7c701cd4ac4c6b954452286f3"
+    },
+    "sound/ra/fight.wav": {
+     "bytes": 10218,
+     "sha256": "69b9e0165290de5760a4ade9cba2b412d2a8f5777ece37f1f80a82e6cdf2b979"
+    },
+    "sound/random/thump/thump_1.wav": {
+     "bytes": 17013,
+     "sha256": "6aaee6ee956e9244265227e67fc4ab824b2d2612738edf8905945110cf2a755f"
+    },
+    "sound/random/thump/thump_2.wav": {
+     "bytes": 15660,
+     "sha256": "defb723191cd6d20024c9a8699d7673958512fb0437aa844347883cc8a50dd05"
+    },
+    "sound/random/thump/thump_3.wav": {
+     "bytes": 14523,
+     "sha256": "ee06b736825729a1dba77a62f3c9f7c8771ad5a8481b42f5af3b35755bfacd18"
+    },
+    "sound/random/thump/thump_4.wav": {
+     "bytes": 16877,
+     "sha256": "f0b02c1e1173f484a7b622598df6f18ffcebe0a9711c96ca0804d3e0d5ffa821"
+    },
+    "sound/random/thump/thump_5.wav": {
+     "bytes": 12775,
+     "sha256": "2373758e7bc591df02a09dc35d5f4b2a1cab2ce1e150121665e3797e1fb14d03"
+    },
+    "sound/random/thump/thump_6.wav": {
+     "bytes": 21820,
+     "sha256": "77ad075668ba72853c2615eab006042279e1a88dff8ca8fd286d291bb6b789eb"
+    },
+    "sound/random/thump/thump_7.wav": {
+     "bytes": 10836,
+     "sha256": "f7fd6a4ade0a8dba076304e1454a41da2bb770f9a34dd94b1de3ff1a361c6cf9"
+    },
+    "sound/random/thump/thump_8.wav": {
+     "bytes": 13386,
+     "sha256": "75ccfea9a0728abd0857df8630d1f12d02f43b6d9fcc5588848336420a050215"
+    },
+    "sound/random/wind_1.wav": {
+     "bytes": 36758,
+     "sha256": "219f0637ec3e1e86ae0f8c63f12567f50806e4c3786f7e8807da5313f9d63ff8"
+    },
+    "sound/random/wind_2.wav": {
+     "bytes": 108304,
+     "sha256": "c655fcd037be380d8313f13d4743ff4ab17300df79ab5801dffdafdb6a95268e"
+    },
+    "sound/random/wind_3.wav": {
+     "bytes": 121514,
+     "sha256": "e055a33413cbb5872b8df2095bdf89ef1b8dc2b3fd218782facc506d19f336f2"
+    },
+    "sound/random/wind_4.wav": {
+     "bytes": 155492,
+     "sha256": "582fe3b2019b052f563ef2c0c41045b3068b8f0ee8282be4c9db1759e93f8079"
+    },
+    "sound/random/wind_5.wav": {
+     "bytes": 22188,
+     "sha256": "27a7d6eae7ea84a7cee3baf45e4e3debaa0532610a05dae3126601870e658bad"
+    },
+    "sound/ranger/idle.wav": {
+     "bytes": 10819,
+     "sha256": "644fbbc14e20684fa31abc7f04969943ac950c33435271b0fa646aa324be4400"
+    },
+    "sound/ranger/sight1.wav": {
+     "bytes": 5379,
+     "sha256": "5023e2483fe5c1c37cd661d382e34c0b68eafe4bae0e35e8f3f7e516e78dcf51"
+    },
+    "sound/ranger/sight2.wav": {
+     "bytes": 11323,
+     "sha256": "3574f035e1a261b9a001d99a54bdb502da31da2639d95e7fc06f96b547c1ac44"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain1.wav": {
+     "bytes": 14234,
+     "sha256": "b4c9f9f3e15af1024db6471220a0b173b234cc13877de73584d25359ee117c6e"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/pain3.wav": {
+     "bytes": 18656,
+     "sha256": "030431779b201dc6a543a0a9afeb2e5f22c743452fc3f459bf632355f4ada2ac"
+    },
+    "sound/scourge/sight1.wav": {
+     "bytes": 35068,
+     "sha256": "48db878a4eae15b37ee0ca333aae74d310103a9eaf2e4b35eecd43a89f626b9a"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk1.wav": {
+     "bytes": 19372,
+     "sha256": "42e41297df70202ec9965af7af5fcdabcab7fde43ba515c8ba0a1ee2e4429554"
+    },
+    "sound/shade/death.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/shade/death2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/shade/idle.wav": {
+     "bytes": 37192,
+     "sha256": "57b0a0a7a0e75a17df8c4bb68740b23325bd0bf3475d908ee92fa0522c71edf7"
+    },
+    "sound/shade/moan.wav": {
+     "bytes": 33684,
+     "sha256": "3a6644f2c0a6ead5992fa9752ec9b0d898f4c40f5a32b12fd61aa991f75fa0c7"
+    },
+    "sound/shade/pain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/shade/pain2.wav": {
+     "bytes": 8918,
+     "sha256": "c6fa3ba7c659faf38b00af9c9867c37ba730cbc662125f5307f755515243dc4c"
+    },
+    "sound/shade/screech.wav": {
+     "bytes": 28244,
+     "sha256": "55ef2615baa6ce39733892fc9538f702acc567f65250223329f15b191d9b1a47"
+    },
+    "sound/shade/sing.wav": {
+     "bytes": 35654,
+     "sha256": "9de82a1d3124c391466004aea5e8ad066bcc6ede2715e7978a92a2c8f66e3f6b"
+    },
+    "sound/shade/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/shade/taunt.wav": {
+     "bytes": 36418,
+     "sha256": "f556cad612249e63690ac28b17405eba70e3df43560c3a087062b9f330811720"
+    },
+    "sound/shade/taunt2.wav": {
+     "bytes": 28160,
+     "sha256": "a68174008206b79794d8d52fd027daf08767ce005189860c815cda021080363c"
+    },
+    "sound/shambler/sboom.wav": {
+     "bytes": 56376,
+     "sha256": "1df051b49aaec9b19e1f49348aaf6d9c19aad3e4591c12b18c4fcbf3c0a73218"
+    },
+    "sound/shamvile/melee1.wav": {
+     "bytes": 4700,
+     "sha256": "f418a627faa0b4630588914ecdd466c387e1d7d5ac2e09acecafa13baf33f10c"
+    },
+    "sound/shamvile/melee2.wav": {
+     "bytes": 6252,
+     "sha256": "dfeb5bcd8be8d9f1fcf52f89cf0af533ec28066eb0bf74e3ac4b588ca810f372"
+    },
+    "sound/shamvile/melee3.wav": {
+     "bytes": 13236,
+     "sha256": "7102a987921e4c291175ba252628613c2c6ecdb70e9a33e174b6bcf7addc239c"
+    },
+    "sound/shamvile/melee4.wav": {
+     "bytes": 9211,
+     "sha256": "da31a8531703998c06bc33c94639d5dd291c9ba24e6752599ec8e6113d3753b5"
+    },
+    "sound/shamvile/sdeath.wav": {
+     "bytes": 20996,
+     "sha256": "e27d5870c37ce74877a2681b5e9cef437d14b05c501fb93733c8e93d2d2b0931"
+    },
+    "sound/shamvile/shurt2.wav": {
+     "bytes": 3924,
+     "sha256": "541c66bfaf5f30c55d24c4013f4a8859159ebfdf2f054c681eb8b8200dba1c85"
+    },
+    "sound/shamvile/sidle.wav": {
+     "bytes": 5476,
+     "sha256": "ca3edcb476f3992027989a2a79ef21a7f8951965c8a0e77f89f0a0505f2d2b52"
+    },
+    "sound/shamvile/sidle2.wav": {
+     "bytes": 21511,
+     "sha256": "0e46d4e53c003136881723f59de4d706151b845d57608cd87361018acb7ef050"
+    },
+    "sound/shamvile/ssight.wav": {
+     "bytes": 15564,
+     "sha256": "5a5343f95ee503f1b481ef05499e023b681402b922600979367788f2fb91397c"
+    },
+    "sound/shamvile/ssight2.wav": {
+     "bytes": 27204,
+     "sha256": "2b22c0912485569f7ec87a32a29c88563c0cb8261b4428335540fc96f7e7cb52"
+    },
+    "sound/weapons/axhit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/weapons/axhitwal.wav": {
+     "bytes": 6694,
+     "sha256": "0f14ba18076b25a7b8ee510b38adb282eb5c4f2fc94168baf1f8a658e1da684f"
+    },
+    "sound/weapons/block1.wav": {
+     "bytes": 5484,
+     "sha256": "ccb284becb454f395de702a263bfda1561b8bd38117893d33b5ebbb9eb7b6865"
+    },
+    "sound/weapons/block2.wav": {
+     "bytes": 5612,
+     "sha256": "62da8e44f3b1200b99f76a3bdb31d9d09a9e74c04a449c0afc482c6677a94bc2"
+    },
+    "sound/weapons/discharg.wav": {
+     "bytes": 18810,
+     "sha256": "4793e9b786b7a06b6f0d0698fba954ff205a9bb5a06150de7806c1388b85ba5a"
+    },
+    "sound/weapons/fwall.wav": {
+     "bytes": 40140,
+     "sha256": "e269c07608f322518e709925d5b13daded150460d19d3091f15152ce4c06c9bf"
+    },
+    "sound/weapons/fwallhit.wav": {
+     "bytes": 11226,
+     "sha256": "301ddef8286ddd079a2c8088d9df64ccf1318bda6e2254415ad28239506392d8"
+    },
+    "sound/weapons/fwalltap.wav": {
+     "bytes": 8316,
+     "sha256": "879b9970dfc3bc609ff384a0edea13b594ea6a82b5c56d33c8549cd36cccda0b"
+    },
+    "sound/weapons/mirv1.wav": {
+     "bytes": 89538,
+     "sha256": "7d60062f61d5929f5f927526d81920f24684520d230a5f2611c128b832d3357e"
+    },
+    "sound/weapons/mirv2.wav": {
+     "bytes": 18478,
+     "sha256": "67311180da390517f2ef71d161a0cf7b770548dcd4a7dda7e679cb9b58025b4b"
+    },
+    "sound/weapons/pkup2.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/weapons/rg_fire.wav": {
+     "bytes": 66260,
+     "sha256": "a3a7edd9c470077682bde595f95d88546d416f300202ae96bd6c6371ec19cf09"
+    },
+    "sound/weapons/sheath.wav": {
+     "bytes": 7031,
+     "sha256": "8f28a1daa16db234ce77d91e688c7acbc9541c296d30af9e1f940b6d45eaf72d"
+    },
+    "sound/weapons/sword1.wav": {
+     "bytes": 3532,
+     "sha256": "572074b68af2132285aa9fd2ac6852f52ffb6c5e56eed44b1af21e0e78171e17"
+    },
+    "sound/weapons/sword2.wav": {
+     "bytes": 3055,
+     "sha256": "b176a257409b659d80df90560bbac4da5539971576aaf1107bb88bc016558085"
+    },
+    "sound/weapons/sword3.wav": {
+     "bytes": 3012,
+     "sha256": "eaca19c8a10b7942d4a279974df6e1cf076c362d5408e439b26286126852bedf"
+    },
+    "sound/weapons/unsheath.wav": {
+     "bytes": 8060,
+     "sha256": "45d9bc6b9dcaf8e0dc9b2ede7da69a872f50f7819462a71bc16b9d76a70be06b"
+    },
+    "sound/weapons/vorpal.wav": {
+     "bytes": 27002,
+     "sha256": "6af2615620041033f74621d26e594a2c35c7b96a2349b3a3407bfc3eb86b6a1b"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    }
+   },
    "sha256": "68735030662444d6d2baf6786cce975d1885eff289196e9c494ed7bae92114b4",
    "timestamp": "2008-08-15T01:34:52.000Z"
   },

--- a/json/by-sha256/1c/1cf1a41bf90ae84bc0ad5c29b0201133789734a72c9c0ea425fde9979643fc8a.json
+++ b/json/by-sha256/1c/1cf1a41bf90ae84bc0ad5c29b0201133789734a72c9c0ea425fde9979643fc8a.json
@@ -7,6 +7,148 @@
  "files": {
   "Pak0.PAK": {
    "bytes": 8388180,
+   "files": {
+    "maps/b_bh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "maps/b_explob.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/pg1.bsp": {
+     "bytes": 1525488,
+     "sha256": "f26e28cd52c276a7d78f0b13e6027f8bd37cd3b827802c93e28af271c46affe3"
+    },
+    "maps/pg2.bsp": {
+     "bytes": 1684184,
+     "sha256": "d146c6f9b685a64bc299ce47a6677126e0512da2cf7146125a07468130b1bbab"
+    },
+    "maps/pg3.bsp": {
+     "bytes": 1142800,
+     "sha256": "d19f06f710074f1aaf299118e2bca4dfe5e5e91a91436ef47cc9007729794c5c"
+    },
+    "maps/pg4.bsp": {
+     "bytes": 593628,
+     "sha256": "9c1b15f8d8e126062eb0f81f8abed0dc64b2a4221227d10df0a1878c40c4f8c2"
+    },
+    "maps/pgexit.bsp": {
+     "bytes": 264728,
+     "sha256": "6a12a56a56e5589055716aadca64e2f5fc3f146910c4b60be817c88a018d3033"
+    },
+    "maps/pgstart.bsp": {
+     "bytes": 777908,
+     "sha256": "5c919455636d7b427c564c799d59ae926ecfd14eb4deb71b5d1b049c2510ba88"
+    },
+    "progs.dat": {
+     "bytes": 732772,
+     "sha256": "7ecb258dbb08fbb624f3ec5c47fdcd5495c9d720aa4f45aa0b29a0ac24a266cd"
+    },
+    "progs/draco.mdl": {
+     "bytes": 304349,
+     "sha256": "64e40155f84454d762d82f2a48d09828b6dcd103f2b5c897bec86bd59d81efcf"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 372833,
+     "sha256": "684472851e482cc3ec2b918580eab45ae75e90883e38a42dc9dd78c4fc776ab4"
+    },
+    "progs/dragon2.mdl": {
+     "bytes": 372833,
+     "sha256": "0db34a97dc57e84b3059017d9688a08d6833615112a5b23e7eae5a89418a4750"
+    },
+    "progs/dragon3.mdl": {
+     "bytes": 192313,
+     "sha256": "83e4792c9276bf6be9e359e3ff5076f3926aee9372cbf964121318116a05320b"
+    },
+    "progs/finale.mdl": {
+     "bytes": 78699,
+     "sha256": "edb0de8c2d26fc9c524dd3724b2afe27c756236f665fa2b15ca0499733e4ec1f"
+    },
+    "progs/lwing.mdl": {
+     "bytes": 34993,
+     "sha256": "a85dbe6a7afc15eee80fb0d5d516632fced04b93a45aa9d875c02e0199c085f4"
+    },
+    "progs/rwing.mdl": {
+     "bytes": 39693,
+     "sha256": "f3f2f1580a400be3b9503f4c4862eff3860c97f47213774d46182d3a15efe66e"
+    },
+    "progs/tail.mdl": {
+     "bytes": 11177,
+     "sha256": "129c99ca5c3fcc971533ee5476a62cebc0d6d6f03fc15e609d703021e61d4bcb"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 18358,
+     "sha256": "645baa1cccaf1dfbcd628d17fd8ea290f42f1bc40903e26c79a536a6d1528a2a"
+    },
+    "sound/dragon/death2.wav": {
+     "bytes": 16944,
+     "sha256": "0fe255bd36c64acf75a53b97851b995517e70468b3818ff0ccecc4c7be5fc055"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/idle.wav": {
+     "bytes": 12252,
+     "sha256": "161fccc2acb1040d7dcad116f18eb795cc03f4d96ee8a94ba37440cde33e6f24"
+    },
+    "sound/dragon/idle2.wav": {
+     "bytes": 13848,
+     "sha256": "e71858c4de3e9ddcad1cba4ec0a6f5ec437b06c813b263ec73f853846d15a984"
+    },
+    "sound/dragon/idlefly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/niteact.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/dragon/niteact2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/dragon/nitepain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 8376,
+     "sha256": "5c41f639d3d59cb12cf8c37f2f80279ed4268ce9afadd7f36d26b4fa40664ada"
+    },
+    "sound/dragon/pain2.wav": {
+     "bytes": 6496,
+     "sha256": "0017ddb63a5dc282982c7459099c810d7c6d9bc3ecb9acef5b5228795a92cc7d"
+    },
+    "sound/dragon/sight.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/sight2.wav": {
+     "bytes": 15205,
+     "sha256": "197238a35261e6792c40a4da38ba7b3827116ac1af5f143e092768346605b470"
+    },
+    "sound/dragon/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/spit.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/thunder.wav": {
+     "bytes": 14764,
+     "sha256": "b30e18bbc0a12db2032fa95d5d0504ea63eaa13b3bea34e3b42ec59f3ca4d815"
+    }
+   },
    "sha256": "c93c2820e7e590e899c8b627621feabb8abb5466593f8a2b4f69ac9e70e0b98f",
    "timestamp": "2000-05-13T19:56:34.000Z"
   },

--- a/json/by-sha256/1d/1d3a61aecc05c905d50b648851f81ff6c36cc8dd678a387d949ebc2b27ab3f23.json
+++ b/json/by-sha256/1d/1d3a61aecc05c905d50b648851f81ff6c36cc8dd678a387d949ebc2b27ab3f23.json
@@ -10,6 +10,96 @@
  "files": {
   "pak0.PAK": {
    "bytes": 4746020,
+   "files": {
+    "maps/sm36.bsp": {
+     "bytes": 3637380,
+     "sha256": "81e1841dc4aaa9191b416cc0244b138c0ca1433bbd584e9ab908ca88198601f2"
+    },
+    "progs.dat": {
+     "bytes": 442892,
+     "sha256": "d1e13b81c71ce1b7dd6c1186b0b50f22611c3259b9aa9460c5b6cd8114c3b91e"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 224812,
+     "sha256": "af9095cffbc74edc9d98d4e4e341736e304404df52983be33616da84d6463c87"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 12416,
+     "sha256": "2fff2f36173080827a298870a956fb11ad30f34aa0342ba5ca2c8bd6509edf57"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 59078,
+     "sha256": "6a7022fa8210771be206034a2b0ebeb59f6fc79719d499ac01811a4ff32eb08a"
+    },
+    "sound/ambient/amb14.wav": {
+     "bytes": 55320,
+     "sha256": "187b28d66dc1a05ea64502be9c6bbab4d1ea7b7465b988262cbddce8defc94cc"
+    },
+    "sound/ambient/amb19.wav": {
+     "bytes": 47188,
+     "sha256": "3ed17a7e847a6e184e2945e7603ee0a992862e66255403b2702a86267cc2338b"
+    },
+    "sound/ambient/amb4.wav": {
+     "bytes": 60158,
+     "sha256": "2133a96270404754f03c5a39fbfd0e7424d58768c59a890fefdeb40c40a9c3e8"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 107854,
+     "sha256": "3ff43e368ce72c82cca539acdcb3390cbbd62224b6f76f154fe7cd3eae55381b"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    }
+   },
    "sha256": "d5e967aaa7cd3afec886489a2080b5a9e19bd0cf91b880dda529761266c25ea9",
    "timestamp": "2002-10-08T00:28:32.000Z"
   },
@@ -20,6 +110,53 @@
   },
   "sm36_source.zip": {
    "bytes": 450831,
+   "files": {
+    "sm36_bear.map": {
+     "bytes": 107542,
+     "sha256": "59eac903a848d601eac62bb0329c5f8ae3ceff6d9d2ac534f8b02a7936d1171b",
+     "timestamp": "2001-09-30T04:34:26.000Z"
+    },
+    "sm36_misyu.map": {
+     "bytes": 177861,
+     "sha256": "c3fb22352870c257ec4fbd8447832263a083178f1a55aaa0fd6b52c3ae67e13a",
+     "timestamp": "2001-09-29T23:43:46.000Z"
+    },
+    "sm36_necros.map": {
+     "bytes": 117448,
+     "sha256": "3cc591e27aab644fb1ce807187f266613aa6da6a7969d3c6b629d99c6d6f7a2b",
+     "timestamp": "2001-09-30T19:10:04.000Z"
+    },
+    "sm36_ray.map": {
+     "bytes": 179477,
+     "sha256": "981ad165b181f31eb1abd6aede0217058cdc506b627da914ba224bf62980ed75",
+     "timestamp": "2001-09-30T15:10:30.000Z"
+    },
+    "sm36_source.txt": {
+     "bytes": 182,
+     "sha256": "989aed98adeae52c22e7cec1d6e63175c62d41d1ff7d77f8ee858f574510d708",
+     "timestamp": "2002-10-07T23:45:22.000Z"
+    },
+    "sm36_vig.map": {
+     "bytes": 124344,
+     "sha256": "0890fc33813d0ec32848ffa5e4bf532a29c6a730e74e5c008536f0d66ef0cabe",
+     "timestamp": "2001-10-03T00:00:00.000Z"
+    },
+    "sm36_xenon.map": {
+     "bytes": 44119,
+     "sha256": "6f2fb1187606e8254f75f29985fb907fbe2fe1dd81621b0e78fe07458a9ae02a",
+     "timestamp": "2002-10-07T23:38:22.000Z"
+    },
+    "sm36b.map": {
+     "bytes": 1609487,
+     "sha256": "7b2d4e0762ad8bc3c9ba7204b16a05417ecfe198cf2a87161852fd84603d0320",
+     "timestamp": "2001-12-23T18:14:02.000Z"
+    },
+    "sm36c.map": {
+     "bytes": 1864456,
+     "sha256": "c07d7a80d0d7826daf2e9b315c4693aba7f2a23b3490b8b410915cbced43f8ae",
+     "timestamp": "2002-10-07T23:34:48.000Z"
+    }
+   },
    "sha256": "745965a882e6aca5c47deb757f5753142c391d6d87969df211afde1b778a3cd6",
    "timestamp": "2002-10-07T23:45:36.000Z"
   }

--- a/json/by-sha256/1d/1d7f3016b23b486b1a8c2ccb96cbfdb2c961ac89c9d6aad7c1b1e8236eaa6a56.json
+++ b/json/by-sha256/1d/1d7f3016b23b486b1a8c2ccb96cbfdb2c961ac89c9d6aad7c1b1e8236eaa6a56.json
@@ -13,6 +13,452 @@
   },
   "circulation/pak0.pak": {
    "bytes": 34986439,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "b7a7384ad313151e9a8a982734ac4e3d8f6063690534c92d5b7200c52df04e81"
+    },
+    "gfx/env/titanbk.tga": {
+     "bytes": 3145772,
+     "sha256": "f1bec0f5fca61e0aa38c0bfefc735a5f467c026b80f1c5c30afddb947156979d"
+    },
+    "gfx/env/titandn.tga": {
+     "bytes": 3145772,
+     "sha256": "1c99590f1ddf7b57869207492c2e2b154d3b554a32dc22ab259cab05bb291ca6"
+    },
+    "gfx/env/titanft.tga": {
+     "bytes": 3145772,
+     "sha256": "978806bbb9c5c22898dc8c23f78f06f63438a89109f03caa8a81c3aa14340ed6"
+    },
+    "gfx/env/titanlf.tga": {
+     "bytes": 3145772,
+     "sha256": "94e8b8d1cdd39db025e3f24c3be11a19c641794512950cc0e52938e612fe516e"
+    },
+    "gfx/env/titanrt.tga": {
+     "bytes": 3145772,
+     "sha256": "930e85c98df23c9a4a400561b206fee3e6de2ce1947609416d3a31524ed5cd4a"
+    },
+    "gfx/env/titanup.tga": {
+     "bytes": 3145772,
+     "sha256": "8f42929d4c744fc8e07dae7b342e6dde9d3b77637dd79463d5ddb4e865743c36"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 20040,
+     "sha256": "61c46ac5672c1e671c0c38a6498158176feaa62b074621c2a3d74e5dfc68e2f3"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/circshad.bsp": {
+     "bytes": 4813716,
+     "sha256": "b1c1a3ef793b1839b7fa5c9e2ae9dd5328ece1974775bcf4efd71a31b8c664bb"
+    },
+    "maps/circshad.lit": {
+     "bytes": 1967930,
+     "sha256": "cbab6f5efe976ca1711131d9579d4f42623e4b8933d079b3d4647e97ef2edd29"
+    },
+    "maps/start.bsp": {
+     "bytes": 693656,
+     "sha256": "7d9db609a0e197ee56295e4d793d269fa6ecef56db9fd8cb00c0a70d2381460e"
+    },
+    "maps/start.lit": {
+     "bytes": 189575,
+     "sha256": "2423b61c44b21daba5c403ba3a144c9756c8719bb72c7f9ff10dd72ffde08824"
+    },
+    "music/track13.ogg": {
+     "bytes": 1445065,
+     "sha256": "12cb7ffd706ae9c61b161ee01a43f8ae744bc2c182bd15988c13c299b8f3119f"
+    },
+    "progs.dat": {
+     "bytes": 514160,
+     "sha256": "a336c39333de50a761f29fad445d32c5a241a03ecd894426b7975a0566aada92"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 221936,
+     "sha256": "6e8e12db297f9f70cbe00fe2087be79a0011dc31344e642d8f309947e63cad8d"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon.mdl": {
+     "bytes": 102120,
+     "sha256": "2635e03bd1e78e3e6d3f9f78c2dd4dda7614a3eb4dabd750a772ed80565ebdb2"
+    },
+    "progs/dog.mdl": {
+     "bytes": 317660,
+     "sha256": "d5615d6d0c3b7fe4f284d0fd153a6ea831f5b723ad3df815e10b942533ef6d0e"
+    },
+    "progs/dread.mdl": {
+     "bytes": 183400,
+     "sha256": "efb1827edaced94142bb040b179cff11de98c097aab7fe13c80efadadc742314"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 102656,
+     "sha256": "9dc737185928f080758e5a662ea8fd189fcad1aed4fe4547f76d73983bec9c72"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 35488,
+     "sha256": "4a04aaea3b65ef8be1e9ae5e2448bf5fcb530492241a739b689f7380ba509de5"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 25316,
+     "sha256": "261a8479de0d5df9aea9931a62b1b93dbb7bfcff4f4467920cbebcc9c2c25381"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "77ef7027b6c0b5a6c96c6740896bc016412e60c3098cc0d0077a284f2b3708b6"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 16308,
+     "sha256": "97f17422aefc3d80a4942be5990c9784b17731a31fb9559e5bbde5ec0fe8b6a9"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "8f9824990808ebf06e86d3bf245321cae87a0b98bca2caaacb598f9ecdee85c3"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 27652,
+     "sha256": "6ad407e4117bdd615009d4918d32094d9a8b65c04bb1c0abda9a42d288e59153"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 17040,
+     "sha256": "c5ae9580cca2b965abaa1f8d5351a178b985c6410ebef754bc23963a0470e8e5"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 11828,
+     "sha256": "2472f8139353f10017eb9a5cfa1edcdf0d8a42b419213a14deefd3f34556a1ac"
+    },
+    "progs/h_player.mdl": {
+     "bytes": 14708,
+     "sha256": "9840c0f31e9f568545732f980928ade3fe3b79fe8ebab47f5238de7df1c1c789"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 909361,
+     "sha256": "f8ad2dc18653e36630eae567633d84b2e03a52a6cd8c125edafce1c87ff18c8c"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 7092,
+     "sha256": "4d69cfc6343baa8bdc8660428e646abf9ad66b1460ea766cc2e231e7d3c9508e"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 162036,
+     "sha256": "3de16efabfa80692984c0f8f742157d28991abf664d80d9250b3fdd4b0d5e9b2"
+    },
+    "progs/player.mdl": {
+     "bytes": 517652,
+     "sha256": "eaead3d31f963cfe79aebf26b11377be2427701fca9d490503e0e7233e331a0d"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 2820,
+     "sha256": "1b0494b274aee493b2f60161f27a6d795800d55eef99996816385fde019af271"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 1136082,
+     "sha256": "e35508029967577dd3f9e22816108711a8820ad51b7cb5a66ec13433c1d0a708"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spike.mdl": {
+     "bytes": 2820,
+     "sha256": "783d711b408498dbb34581c9a0ae74ed325dc5c68fa67873745b02c8a926a201"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 77332,
+     "sha256": "e2a8a92ebbe86069de925f733567738ac67624a913cb8c1fe15a6946536d58e7"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 29316,
+     "sha256": "181eb35f0540faa018f3395607f049f3c0ef310894b2bc5edc341ab646fb5458"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 39668,
+     "sha256": "68e38e54cf4aad130c6b3ad2d8ce12ba20e4ffcd4c5a866aae85b69e56ce50c3"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 21908,
+     "sha256": "ade58867dac49427ce1a66c498f5dd7327685db0daac1409b80e0a341df59283"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 21804,
+     "sha256": "06a1f7cef5d1d3f8c377addc4026523b656b8f77986495f96048a1a6ea94549c"
+    },
+    "sound/ambient/chatter.wav": {
+     "bytes": 190760,
+     "sha256": "59197f823b479c66c41163d82fed6dc13a715aef429b5e551ba80ca6f7c229fb"
+    },
+    "sound/ambient/comp.wav": {
+     "bytes": 12164,
+     "sha256": "ab8e3b13981bb432cca44ad4b7467734f52d01927018e72c99e7c4d052dc7874"
+    },
+    "sound/ambient/crickets.wav": {
+     "bytes": 12236,
+     "sha256": "d5cf6e56884a8e43469408d4788ec6e573167901586df259a938cd088c998ef9"
+    },
+    "sound/ambient/drone.wav": {
+     "bytes": 30902,
+     "sha256": "81993d96ab337f78c2778cecffe4767605fed210e0ac2303a46ac898979eea13"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/hum02.wav": {
+     "bytes": 37836,
+     "sha256": "8b2ee1b91fa663b6111de9251011142475831ece70ee091022b800b715f1bfa2"
+    },
+    "sound/ambient/intake.wav": {
+     "bytes": 25682,
+     "sha256": "e6d13169ce4680dd83903473897fd6e7ce1e51fab00c6df2127ea993321c05b0"
+    },
+    "sound/ambient/lonoise.wav": {
+     "bytes": 32876,
+     "sha256": "1e0f99ffadead8460a7a4bed1c6b2c16cddd70050e1524e9cdaf6724a9dc81b5"
+    },
+    "sound/ambient/motor1.wav": {
+     "bytes": 52340,
+     "sha256": "c48511a37143e9ed50ae7c1d1f28235b007762949d3d18549fc545cc670c0a24"
+    },
+    "sound/ambient/motor2.wav": {
+     "bytes": 52014,
+     "sha256": "7f36cda5c01aea4e6b356ae4d0b31b68ca15d7606eefd30f4739a64fc4e86e6c"
+    },
+    "sound/ambient/rain.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/hknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    }
+   },
    "sha256": "5509d9cc7e34ff179b392af40334f21752601d883421eec361525ee4139b3232",
    "timestamp": "2021-01-13T11:32:16.000Z"
   },

--- a/json/by-sha256/1d/1dc0b1728cf819b9a9361d4e24136699ed259bb5ba8d09ada0e41d8d36d3d798.json
+++ b/json/by-sha256/1d/1dc0b1728cf819b9a9361d4e24136699ed259bb5ba8d09ada0e41d8d36d3d798.json
@@ -7,6 +7,16 @@
  "files": {
   "pak0.pak": {
    "bytes": 1157568,
+   "files": {
+    "maps/epoch.bsp": {
+     "bytes": 124420,
+     "sha256": "6896c1fd4517d174c7acc8bc9ee874815fa4b21865fb37a02e4d29fe4f057447"
+    },
+    "maps/epoch1m2.bsp": {
+     "bytes": 1033008,
+     "sha256": "e70094b770cf221e8af0dc88aad759ef0099fd259e96d8cddb433e7d85fee1fa"
+    }
+   },
    "sha256": "b86298702b13b925c15f386c46872e9eace8939beb13b75cd2aac3830ad22458",
    "timestamp": "1996-11-17T03:40:16.000Z"
   },

--- a/json/by-sha256/1d/1dfa085d7217fa17f3803f8a45bfb8c163420d807d0a15de14217f055ddf6b54.json
+++ b/json/by-sha256/1d/1dfa085d7217fa17f3803f8a45bfb8c163420d807d0a15de14217f055ddf6b54.json
@@ -232,6 +232,308 @@
   },
   "pak0.pak": {
    "bytes": 3657650,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "0756ede2a4c80c74289bc51445a009b572631f7da0e63a4ad206dc7e8056bb4a"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 23658,
+     "sha256": "82b46faae4c0f08e8edc2fa9bcba0f1f49dadc8e0beaf78746304f3ce0e686db"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 6424,
+     "sha256": "a846a94e5db77d8b3bf36e62befe363fec54c07233398378c115745d34b7b1a3"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "bcfea1fd1a0effd7252097e487957ab45858e14ccc248c61dc48483bfac966fe",
    "timestamp": "2020-11-09T13:18:24.000Z"
   },

--- a/json/by-sha256/1f/1f5f81a14eac45557d7a8687f0e737fe8b3f5f287b29146a7fc3d8b85a52406d.json
+++ b/json/by-sha256/1f/1f5f81a14eac45557d7a8687f0e737fe8b3f5f287b29146a7fc3d8b85a52406d.json
@@ -60,21 +60,3465 @@
   },
   "pak0.pak": {
    "bytes": 25051624,
+   "files": {
+    "maps/b_barrel.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/b_wbh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_wbh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "progs/acidbal1.mdl": {
+     "bytes": 8788,
+     "sha256": "8a9c956f1952fb8d9ea51119c1c8c758d3ca3b3bf3bb0e8b63131bf88325f5a9"
+    },
+    "progs/acidbal2.mdl": {
+     "bytes": 8788,
+     "sha256": "eceba377145b62b4721927e55de75423daaac83f9667852b16dd1bfff3beff01"
+    },
+    "progs/akarrow.mdl": {
+     "bytes": 23072,
+     "sha256": "4e0e1c007453dbc432533dab09dfbafa943c4f43f7897848c91a516bf0de43a0"
+    },
+    "progs/am_super.mdl": {
+     "bytes": 8976,
+     "sha256": "55d561bf2f73b2c6482dcb5649da1b31d4bbf40aef6e21cca3518dc6a0c5709b"
+    },
+    "progs/anglstat.mdl": {
+     "bytes": 164396,
+     "sha256": "ce4644a5e22e0ff39790a293754501add2a4ad8afa26cfbdd13205c3b833e923"
+    },
+    "progs/archer.mdl": {
+     "bytes": 581920,
+     "sha256": "858ad8a4d0d27e1a9989ad7d87a9a4404ff8adbde33b07868725d34fd2146f6d"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 141992,
+     "sha256": "9a3c9afb3c47ed9c683ce6b0fdaef6ee6d1cf74c60509f1a82f8599318e71d08"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 25752,
+     "sha256": "57518dd89a3dbf6e712ad204b0a6f41fd7fdc9bfc03cf4c17e222f9d31d72b93"
+    },
+    "progs/arrow2.mdl": {
+     "bytes": 68764,
+     "sha256": "0bc41c13a4332f6d13e7884248b2d1a83b487bc2f4e1d5cbbdcd1c81512a4579"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 290592,
+     "sha256": "f0d1dc967de929d0f0faaa61aa51239d1f262c63da83013be094a4ed99e3028c"
+    },
+    "progs/bandit.mdl": {
+     "bytes": 226380,
+     "sha256": "7cc68b0c9a4950b4d3b97353227a6b8845104417efebfd00348b7fb24986d557"
+    },
+    "progs/baron.mdl": {
+     "bytes": 426204,
+     "sha256": "09a4b10b43c2cb4847330ce3660eab93c16a97a7db0c9e1c1447e938689627d1"
+    },
+    "progs/bbg.mdl": {
+     "bytes": 190836,
+     "sha256": "3bac35175b2808bad33e3b7e7c2c54b3d9181c5b3743aa68d803dbe58edf0eea"
+    },
+    "progs/beam.mdl": {
+     "bytes": 1460,
+     "sha256": "9e9531de6f4e6f2f6274ea6612ef00bd0642c0cc05a7fdc866805fa1be851b73"
+    },
+    "progs/bellring.mdl": {
+     "bytes": 74016,
+     "sha256": "9a8131071ca927803140ce6478b8912c6eb52856861250d6b6bfa1d32cfb9cd9"
+    },
+    "progs/blood.mdl": {
+     "bytes": 184,
+     "sha256": "06825646d627df610b374a31c9265a88c9c1c45864c6e3b9d273a14dc4d745a5"
+    },
+    "progs/blood_gr.mdl": {
+     "bytes": 184,
+     "sha256": "84caed23ff1b8cabec8c5d9e5c6792c30a6d9cc57c36a9746369012015462208"
+    },
+    "progs/bloodcb.mdl": {
+     "bytes": 28036,
+     "sha256": "83f0de29aa0f9e9f1d383895da374a5313aa2252edb306eb7bd69bd71660321c"
+    },
+    "progs/bookclos.mdl": {
+     "bytes": 3420,
+     "sha256": "a129ba5428a5fbef209010b893b4407c99a3d3a9e936d9d41247af5a75fc922b"
+    },
+    "progs/bookopen.mdl": {
+     "bytes": 6188,
+     "sha256": "d57ab7e96181b3fe70bc9c0c002ed6671fe14adfd454b680cd39be10b2315a05"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/chest1.mdl": {
+     "bytes": 19352,
+     "sha256": "239f897e3a390ad44acc5ffd19784f8b78232c5af2be67165581c2f6073ecc9f"
+    },
+    "progs/coin.mdl": {
+     "bytes": 44036,
+     "sha256": "c3d65aac43713c9102f8924ef7ed1cf90297ff17cfe8aface7936e9579b4ec57"
+    },
+    "progs/courage.mdl": {
+     "bytes": 14940,
+     "sha256": "4141933fbb8682ee28277826bd0f882580025def71b96c02cb9b53aa412906c0"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "7829e2cbaa4816577c77ba12a91933eee5dcf9d899f3f4d9717f6f8fc0319a23"
+    },
+    "progs/demon.mdl": {
+     "bytes": 355000,
+     "sha256": "3bb7fc1b1f89de1d66f99de4065d71e35dec87940d47c98b24d3be074d8bf70a"
+    },
+    "progs/dog.mdl": {
+     "bytes": 269016,
+     "sha256": "9a60157b0504891c71fbaece5a729e9b954a5e2dffe92e1e1a1ab51c6d912b77"
+    },
+    "progs/doll03.mdl": {
+     "bytes": 52064,
+     "sha256": "b2962f3954740ad7f9b5ee329d3a189ed5c95ccbb279bb63dc77508c94e4fb28"
+    },
+    "progs/doomcube.mdl": {
+     "bytes": 8884,
+     "sha256": "c4d31e7a4f2a9c01c1c502fec3653d8e0b14fc6ec790d8edebb1737a6116a471"
+    },
+    "progs/dr1_head.mdl": {
+     "bytes": 7476,
+     "sha256": "06f28a6f55ba29f12965e7ca10d99147a9432c851a2747d1e861cd45c07d958f"
+    },
+    "progs/dr1_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "c208f5473b2954fb4af094119b5a63b3a205e7a26e94c0c122b1f06870db6f78"
+    },
+    "progs/dr1_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "258da574e4de9d144d4f6a71db72a8bd566ecc6b0672efeb5cacaf59c7dd969d"
+    },
+    "progs/dr1_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "698d06c98e8e9ab99b6ddf808bb32a4994299c9596354bf8f811cda0f4042588"
+    },
+    "progs/dr2_head.mdl": {
+     "bytes": 7476,
+     "sha256": "551d47f807e21d11aba52f66207515e0988e8a424012f204e517c8c6720514d0"
+    },
+    "progs/dr2_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "f636b0786ab159a368b9fa580f1a0a31dc7873f21edb1bc454eb9e64c2c27a14"
+    },
+    "progs/dr2_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "533c0d631c78c22f5ff7632e7dc19f5da1acee56225a5a1497bf34d10fc07344"
+    },
+    "progs/dr2_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "5f5eace00eef74eeaa9db48887636e08ab43c85ad0d05816745c04a4710f34d3"
+    },
+    "progs/draco.mdl": {
+     "bytes": 235148,
+     "sha256": "0b51fd9b782891c4b8b410db6ac1361dfa0f53d634366709434a926e0c7285b5"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 262688,
+     "sha256": "d27bb0ed21b8f0e8161f347cb5bba89c8c5223324f462596f972478efdacb366"
+    },
+    "progs/dragon1.mdl": {
+     "bytes": 258260,
+     "sha256": "4dbf09c018ea9f703d4daf48c0a5e504208547d5d172bf26187b8eeac8a94a02"
+    },
+    "progs/dragon2.mdl": {
+     "bytes": 258260,
+     "sha256": "fa2b5d9467299634cddcff9c7ca87c2006c8c9631f45cbf66f74a8abfd5df347"
+    },
+    "progs/dragonpl.mdl": {
+     "bytes": 77764,
+     "sha256": "57db3cbef92a0f96cd8ef1be17ce77586f9541bbffcea2e7747e43b35c50effa"
+    },
+    "progs/drggib01.mdl": {
+     "bytes": 63320,
+     "sha256": "0a2571dc74871a4d43c8c780a62d36ce4d17dd83b6819c773bfb22a247b8bcbb"
+    },
+    "progs/drggib02.mdl": {
+     "bytes": 83352,
+     "sha256": "c3ec2317e0f0f156237b7ed36d1ab3329a874a11f7a2fb343afac021a50f777b"
+    },
+    "progs/drggib03.mdl": {
+     "bytes": 58824,
+     "sha256": "9dfdc32e9616b40b82c410ca75f007bc11a9b18697d4edc82745bcda1b3313ed"
+    },
+    "progs/drilbomb.mdl": {
+     "bytes": 5396,
+     "sha256": "6615fa32cb3b464b665093296ff63fd0c624eea5ec595247d8c66941e1c8d071"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "718b8c2842877345426247148dd6ce1ebe7fecc13e969a0fa0ed6dbebc388099"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "0a386b6381824b01852910519490ac3f6e3309a96091820384ee6b9a5b452e7a"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bef43e6c7bc067d3b35dd05a793c08d7d700fbb2013606ac9ffeac8772d0997e"
+    },
+    "progs/drp_head.mdl": {
+     "bytes": 2340,
+     "sha256": "b87cb902d796dd76c03e9fc79576f368d23022fbd5b5155c8910cd315046e32a"
+    },
+    "progs/drp_lw.mdl": {
+     "bytes": 7116,
+     "sha256": "ad483731fddede05ebf1a9a3c20f735f6ec341f156669833ed1077460dac8e5c"
+    },
+    "progs/drp_rw.mdl": {
+     "bytes": 8056,
+     "sha256": "b57363de0be61e45b355d1cceccadd42fdd1b8f91fc4380847dacf186d7560df"
+    },
+    "progs/drp_tail.mdl": {
+     "bytes": 2604,
+     "sha256": "b8ad65168755d4f31b657a80c78e2e0f51316c48f4ebd10ddae0b6971c7c6e89"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/ember.mdl": {
+     "bytes": 8788,
+     "sha256": "91d6f4dfbeba0711d0864b94bb372b602959644c5c841fd659ddedb8f8e6980c"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "13d14261d863f5170fb8e64e57b8ef344c435183313ffb1127ab6ce51176d262"
+    },
+    "progs/end_bane.mdl": {
+     "bytes": 52980,
+     "sha256": "4a86fd7bd59c4ecea934e3adcec4b17d627cdfac5223976a52b5739143c37f27"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 241252,
+     "sha256": "9ae37ced89200daf2d44795bef4230c5b725226a820c28cda7908f43bbdaa747"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 414484,
+     "sha256": "3d146be46cd90ce477006354b3ed627541fc4ecdb52ff6de2b4f3159c61e1390"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 68804,
+     "sha256": "f3c760ecdbb530ff651c46f516228c588f37585315acdab199408911c2c8414b"
+    },
+    "progs/flame2a.mdl": {
+     "bytes": 68804,
+     "sha256": "e02210f2f6851cea4b9520476cfe36c31745dc2d84248f6a75132358d6d43035"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 56532,
+     "sha256": "36d304e1442ede2048036d832d36ef4624fe4e90ba16628c20c819e7b4477da5"
+    },
+    "progs/g_grpple.mdl": {
+     "bytes": 149440,
+     "sha256": "fc148b3a840b84b65488658ec26a27621a86a196feb90723269534929ee0352e"
+    },
+    "progs/g_gun.mdl": {
+     "bytes": 35580,
+     "sha256": "0d6cbc684d5c5f1112d0111e29405e73721993ad57854c936e676025b7bfbc1c"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 38004,
+     "sha256": "cf67c0a7ad3e853fa4af7544d0399fc0a3795a61d625f5e78104e659e2db0eed"
+    },
+    "progs/g_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "3e4a1e9dc2bff162612e218a25e2040b57d063d198df2e301eaa8fa9542af098"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/g_rocks.mdl": {
+     "bytes": 47732,
+     "sha256": "d6539141be1597673eb1f8c78286d6efdeefa91f9723926d61b9a81e2f433c71"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 158116,
+     "sha256": "127e4fefafc5015f03a6cd1288cab9da325ed5b5a93c9f6b90b6da9d8273ef9f"
+    },
+    "progs/g_wand.mdl": {
+     "bytes": 13684,
+     "sha256": "99212b7901c31b723704e7c62b1c5f70b6a2f7320c349605a3943f3091e962de"
+    },
+    "progs/g_xbow.mdl": {
+     "bytes": 22476,
+     "sha256": "bf1cd180a66f74da4e625a2167bf66527cebd0d4009fabeed48297018db8a4fe"
+    },
+    "progs/gem1.mdl": {
+     "bytes": 42612,
+     "sha256": "0b71e525b19e25f98dad53ce766751de8e0c9f18434582bb86242296bb7a402e"
+    },
+    "progs/gem2.mdl": {
+     "bytes": 62672,
+     "sha256": "721459e22aab0d2cece430053734b889918bde4db879ffc94084289a7b6d4d8c"
+    },
+    "progs/gem3.mdl": {
+     "bytes": 42072,
+     "sha256": "3bc3a1018cc432b694f9ec45de06775776ef55d21b4e117dd1b2c7c0d7b850a2"
+    },
+    "progs/gemini.mdl": {
+     "bytes": 35188,
+     "sha256": "fa05498ce8034d51377953db7c650f9367b072a9d614812f4f67ad15eace909e"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/gr_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "3f5b6d67b80e5f2e5bb7c129500c79dc345141133f8d415005f9384b0d2d9661"
+    },
+    "progs/gr_gib1.mdl": {
+     "bytes": 6501,
+     "sha256": "3f715cbfdcd77caef11b904aa12d2063cbb973d4a9d61c27492690344c14fb1b"
+    },
+    "progs/gr_gib2.mdl": {
+     "bytes": 17553,
+     "sha256": "c6166eb6132a3e87f51fcf48f4e9eebb719b3f1819d22640582b23d61bde4a16"
+    },
+    "progs/gr_gib3.mdl": {
+     "bytes": 22933,
+     "sha256": "0e40e5b960924ca642690c26b239c89aea6bae18badcb945e96d2102cad69622"
+    },
+    "progs/grem.mdl": {
+     "bytes": 202672,
+     "sha256": "3df027b9f674f1f3d3cd775c877fe225029f1b814ff3358f98f932cf8bb0a604"
+    },
+    "progs/h_archer.mdl": {
+     "bytes": 22128,
+     "sha256": "034d829e2ad34eeff8f5d60b8e2064f08caee64fb7f064900298f9405e9399d8"
+    },
+    "progs/h_axeman.mdl": {
+     "bytes": 18400,
+     "sha256": "e15391056ec618b412d1341914d2e6f05a759de92500ef249cc5d1789b3ab6d6"
+    },
+    "progs/h_bandit.mdl": {
+     "bytes": 9752,
+     "sha256": "cc79629b169c0560905eae7ea9a02e5ec546af8cfa07743922e0b1dc829b29ca"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 7444,
+     "sha256": "68bc1db4875fe84f25ff3d6c53e4e9e2c023ef52bf3c89b439493f2e5c5c0e19"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "53539bc39fc87627a46b75b0d86ade5e6116a0079b032b1df137b2425b7186cc"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 166100,
+     "sha256": "0484f334f5722736248531a726e9a91c69e708a882e6d581db3d4e2a54d6db94"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 68796,
+     "sha256": "57a646b291c29b490faa38e3b72d7f074d9d071946d9b9c6068095999a11ce77"
+    },
+    "progs/h_drake.mdl": {
+     "bytes": 28792,
+     "sha256": "be0bcf5fc725dbb09a82becc2339d91824a14a547ce3013deabeece662658dcf"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 30072,
+     "sha256": "e88bac12b670f6790f3e053e1547569e88f0befa7a07abfc6a3fd2ad33b9d9a3"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 22724,
+     "sha256": "905ed9f78c83e29a31b6283b5a377053763469ae048bdcc3aede9213bda80873"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 100172,
+     "sha256": "27311a59a95ab735d79e5198318d0507da7e377584702ba9e5bf673c0972e065"
+    },
+    "progs/h_hkolem.mdl": {
+     "bytes": 30552,
+     "sha256": "38b2082ead97b90f59a5fdcf24d4077ab067c55655598d023f8ec38818c914b1"
+    },
+    "progs/h_imp.mdl": {
+     "bytes": 73564,
+     "sha256": "24944207a9867d67fa24961516dc2810a5d1b33d341d5190ac1666d58c8252f4"
+    },
+    "progs/h_imp2.mdl": {
+     "bytes": 73284,
+     "sha256": "f01cd8331b8774495258e3ab85ba6434a0deef19b1b953b6ccf93252649e01fc"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 19644,
+     "sha256": "1accd89ba95db3627cee4f06f94ab3bc9d146ebf566da24b570c733f2f902c1a"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "72455aab2067fd8f887e8a8e9c61d2b943699ce90fbcb85937fbb358c9e5678e"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 53188,
+     "sha256": "6e1c28d5c53f24901ebd0aa199a1003ef4fe3c8306c5ab28191cccd14bf25f45"
+    },
+    "progs/h_necro.mdl": {
+     "bytes": 14296,
+     "sha256": "fc9c468465d0e8982fc2d6207ce94b2f400f0f37cbe88cff2a4aa64719b91f40"
+    },
+    "progs/h_nemes.mdl": {
+     "bytes": 78156,
+     "sha256": "6f350692b44907984c02779d0114576bbafb6a3ada673e1f55d1cf02fd062c18"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/h_rebel.mdl": {
+     "bytes": 5428,
+     "sha256": "b189ff3ae1596da7596f21d8f555603951fadf8e7884e96f89c8b2b5789028a5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 53096,
+     "sha256": "ff1d940222f28765b975828528016332b04423a4001a507e07cde6414847add5"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 108204,
+     "sha256": "dd7dc5c90255da868b96ac553d8a8f68b6723da6b25114bc087fd019966a023f"
+    },
+    "progs/h_vomit.mdl": {
+     "bytes": 16952,
+     "sha256": "9822885036229871594a21643f4acd3a9b4c27d141b9021464b5062dfaf410f9"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "7ff66f881f85884aea56396da7b756da32c04df163a1e1f739485e77e61279df"
+    },
+    "progs/h_yak.mdl": {
+     "bytes": 73116,
+     "sha256": "eb2cf314618ef6dbc44ab46807237e59b68470edf24780e4ccd4c5b513f91196"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "2f6fd7256662a5a4b4b907b0ac68bf7d787ebd55cf54e352da5f1b363a2b2397"
+    },
+    "progs/hero.mdl": {
+     "bytes": 66388,
+     "sha256": "ea4f359a328b6416588e5debe13a87fc2eccd8a65263ae23683d71a58b39a116"
+    },
+    "progs/hk_golem.mdl": {
+     "bytes": 179204,
+     "sha256": "972f27eb2bf8a6cc4433e1f904097ca5393312d47a75e396b0323723beff58fa"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 534604,
+     "sha256": "10058c95eca9a063c7990d919d353d3573d252eb39f00c5f471a7f22f0b5fefa"
+    },
+    "progs/hook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/ice.mdl": {
+     "bytes": 2580,
+     "sha256": "30c4853e26d51d0ca4d3df5a40ec6d8861f48e9420f10560b5de0c19e6c15ab0"
+    },
+    "progs/ice_cube.mdl": {
+     "bytes": 3192,
+     "sha256": "bf96c8c1533fa537582bd4cf7bddadb7f5ddeebafbce9ef29007a5acd5a909b0"
+    },
+    "progs/iceball.mdl": {
+     "bytes": 24632,
+     "sha256": "802fa6260e9af5abb74bab0a76f35ae3e2af2373e61091c725325aa41051be7a"
+    },
+    "progs/imp.mdl": {
+     "bytes": 583036,
+     "sha256": "299777bbf58641a6674c0877423efd9f0995421a1bfb946fe21d1f2bdb41714f"
+    },
+    "progs/imp_lord.mdl": {
+     "bytes": 583036,
+     "sha256": "0b26574642cc72b73d349881543752a1f7d7f34f00561c4b039bef83e7191b10"
+    },
+    "progs/imp_rock.mdl": {
+     "bytes": 2352,
+     "sha256": "dbe190f471f5738779e103b496117ec40e2adc9e5f593d2470172bcbd7ade0f6"
+    },
+    "progs/imp_wing.mdl": {
+     "bytes": 93932,
+     "sha256": "a0100af8c072112afde45cc2f69e40de4aacffbdb4515de107892c39a00f5eb5"
+    },
+    "progs/impwing.mdl": {
+     "bytes": 93932,
+     "sha256": "5b986189f2f28ffe6c3fc23d40bc194bda2ab636826a9d41ffc9199727cc2f49"
+    },
+    "progs/impwing2.mdl": {
+     "bytes": 93932,
+     "sha256": "0d08640bcd5c6e6336b9cedb635a6152ba479065a56b296557476a6f5e9b1e4c"
+    },
+    "progs/k_ball.mdl": {
+     "bytes": 31300,
+     "sha256": "f93346ffeed3fd5d9866fb80d1a08216759bb27757d49a1851e471aadf757ec1"
+    },
+    "progs/key_b.mdl": {
+     "bytes": 10616,
+     "sha256": "d1333d74b7e194f6587d0f5ed1fca28887cd0414734b4bd4cbb7e715ab897629"
+    },
+    "progs/key_m.mdl": {
+     "bytes": 23160,
+     "sha256": "ea2feb6eb54823668dcb112f42c3441e563e18e3cc1806b5ce509044e6c0b448"
+    },
+    "progs/key_w.mdl": {
+     "bytes": 11576,
+     "sha256": "72da64d2b29d69605c453e9ee0e5fa8ecef91a94cc541103cb24fbad96c7946d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 232536,
+     "sha256": "e3e618799612c6e521f68234a061d9a46036ef556677b0c1651e7647258ffb56"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 27960,
+     "sha256": "5877b37cc4f98a53467c412e7d06d1f7ec6b60f5c0f2088514aa51c9d2c51769"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "210e159ea4c9bf1f2431213fd95902f4ea75ecee6a67a22bed7e93366f1f2732"
+    },
+    "progs/levitate.mdl": {
+     "bytes": 15876,
+     "sha256": "03e77b0d4b8ee7b3b224cbe0cfba63e8bd27d0391bd5069981e5435287f66645"
+    },
+    "progs/life_up.mdl": {
+     "bytes": 34676,
+     "sha256": "502716aa1b0f6cb8f929fe7ee2a74024a5fa007898256e15ca495e126888c584"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 57796,
+     "sha256": "e8b38ca8f28a89f65ffc652e082e8a9aaf6a1a9db8302e961b9ceac1c8f60e8c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/morph_eg.mdl": {
+     "bytes": 300592,
+     "sha256": "14468fccffaa1508c03610dd58fb51cd9058ca3bab036bca18f7a41cb37c195b"
+    },
+    "progs/nec_rod1.mdl": {
+     "bytes": 16072,
+     "sha256": "2eded5df9441aca7a243bf6c2a831c62374cabf7bba1acd64a84803441d77fc2"
+    },
+    "progs/nec_rod2.mdl": {
+     "bytes": 4564,
+     "sha256": "60b0923cade4c8ab9a476cae75c7c73f71c1d13799ac7901d0be4db5d5038895"
+    },
+    "progs/nec_rod3.mdl": {
+     "bytes": 4132,
+     "sha256": "459edf5ee6ecf0c52ec83e055a2c12ad39d3d3a42a4774c442ccc686e298da47"
+    },
+    "progs/nec_rune.mdl": {
+     "bytes": 19524,
+     "sha256": "cea5c89dd0034465a54a8434bc9367554f0244c2e38ec9220cd28a5a53a444a9"
+    },
+    "progs/necro.mdl": {
+     "bytes": 577208,
+     "sha256": "a0e43517f3cb579e38baf9ee4b5058ed59036b69599c0fe3ffeff9c00ba843f8"
+    },
+    "progs/needle.mdl": {
+     "bytes": 16688,
+     "sha256": "5f714f6b43cc28ca1de1246cc0175ea2e07040f73c9d0a623dbe4b4577559c14"
+    },
+    "progs/nehjet.mdl": {
+     "bytes": 19956,
+     "sha256": "fd0346c9c37d2ca7d3e696a9ce0694652722f63326376ad3b8189fb81a68f5c3"
+    },
+    "progs/nemesant.mdl": {
+     "bytes": 202492,
+     "sha256": "099c26752c7160144a25716e0af0f30f8ff179766db4a05371a0392166f85c42"
+    },
+    "progs/null_256.spr": {
+     "bytes": 5412,
+     "sha256": "c52813b634ef1ab641fdd4c3a9739ad758f1b5c39ba5e10acbbf034ee0ff850b"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 230152,
+     "sha256": "b7c88ae295ef8fc8d17b4fd6facedbb8e464ee665039a884af8e215a3929f24a"
+    },
+    "progs/oldone.mdl": {
+     "bytes": 560224,
+     "sha256": "5690a29cb0ae1a4889bc398676db8477275b0953e2ab7bbb75b717509d93c985"
+    },
+    "progs/pl_oum.mdl": {
+     "bytes": 331236,
+     "sha256": "6939a925af5510ecece22c3cee3de418d3ba532f4eb17409ca1453d253de328c"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 55676,
+     "sha256": "c9810eaac822215e7c84f11e55bb614121d17a79a02aa162fb430b5f37664ade"
+    },
+    "progs/plasma1.mdl": {
+     "bytes": 9120,
+     "sha256": "78a81a8eaaf95f85cd0fb7bc31dfa45c30e660fc5265168178b50776afc96563"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/playham0.mdl": {
+     "bytes": 99756,
+     "sha256": "1016d24c984994843af5d086e36e548c55590018f1f6b2d78799e25a40271ec4"
+    },
+    "progs/playsaw.mdl": {
+     "bytes": 87340,
+     "sha256": "b53cffd1807a3710f03b350370d78dfdbb2b057455fcac9f00d1b0baaabbf8c9"
+    },
+    "progs/potion.mdl": {
+     "bytes": 53272,
+     "sha256": "6ee1b1294f1ff41bdf265d06d80fa22a89ff579acb70bd2544986a0235ebd6e7"
+    },
+    "progs/potion2.mdl": {
+     "bytes": 195484,
+     "sha256": "c4f0f920521bd6e1caa6072b19d11ba57f4d493ffc2d6a395190170c9bec702a"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 47008,
+     "sha256": "e7ba606cf1cc11d9ad5baef5aef9dfa9239b7550a1c12937965a562bc815e6a0"
+    },
+    "progs/pur_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "dbc2bf835db1c1789c329504f86802990a19288f67d9560f32cfe5a8d5a62885"
+    },
+    "progs/r_bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "2d776e4acdf20cd117f3f4d6be3647fb9d0e117756069cbfc52ece716fdbb251"
+    },
+    "progs/rain.mdl": {
+     "bytes": 39276,
+     "sha256": "9a13a2ff68c8d8eb27426cee38330a6237de8ceb9ba9ecb9b71071512b190a94"
+    },
+    "progs/rain20.mdl": {
+     "bytes": 42620,
+     "sha256": "192d3d8197976f98eb053e54a00536ca9ccc8769692e9c483990b64afa4e1d8d"
+    },
+    "progs/ranger.mdl": {
+     "bytes": 232148,
+     "sha256": "21e690b07a7d3b2b0fb630480a5fd52ea23b41a8571c3618d16ea1ab7508e52f"
+    },
+    "progs/rebel.mdl": {
+     "bytes": 215292,
+     "sha256": "433596df8d06be0882f00a2c1fad0ea49a8ae42ef148d32e0ae7c06c420322aa"
+    },
+    "progs/red_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/reflect.mdl": {
+     "bytes": 10224,
+     "sha256": "3e8b08d02c11ee9e5546c96c014c8e698ca9097046ff3873012033c0bcac8df9"
+    },
+    "progs/regen.mdl": {
+     "bytes": 50808,
+     "sha256": "1c2422c4124c235e29570580b0c1bfeb55613d6c8152c78dfb6d073ea316f122"
+    },
+    "progs/regen2.mdl": {
+     "bytes": 50040,
+     "sha256": "b8da16335e855c502b7ff0c5b6875050b73c01ff0eb5b5627fc890d155cbe013"
+    },
+    "progs/rocket1.mdl": {
+     "bytes": 34260,
+     "sha256": "c9412482647d681e08f74eb0c0260ffded91dfc67378996b86b720ef3cd2fd47"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 17204,
+     "sha256": "0dab5b94c60d92d55df3e44a8d8ea2dc0f949e98897a6525ee0be3f49a019b08"
+    },
+    "progs/s_expbig.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 165212,
+     "sha256": "5b78b324e252f95ef8f4a9fd4fb19f855c40f74fd1f93aae9b84ed822e9c3585"
+    },
+    "progs/s_fancy.spr": {
+     "bytes": 432120,
+     "sha256": "2dcb35ecb5312709ae4b295ebcf209e74a34e385823f54603e6fe0eb8999556b"
+    },
+    "progs/s_kinn.spr": {
+     "bytes": 45624,
+     "sha256": "c6412ac75ec56533cbf0487223c2c8a23a3d3518b0e3f7ed8af73b81cb6ecbba"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 8016,
+     "sha256": "fa366e4076268de137e0eecd88d02e3aac99f38c48c6ad0d0a74c88c95e8d4d4"
+    },
+    "progs/s_wave.spr": {
+     "bytes": 373212,
+     "sha256": "c2a3b258b2809f22247596b6e0505829853e9a5fd60fed7c471fd663cf9e9402"
+    },
+    "progs/s_wave2.spr": {
+     "bytes": 39480,
+     "sha256": "a0fbc773e66385a8bc3c16195ce14215050cbec7caa118fecae1a0c2a2c59d50"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 333284,
+     "sha256": "90757e506c9f0e49e4e9897708df4825e1b27774ff46abd9c113738380dfde62"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shade.mdl": {
+     "bytes": 83644,
+     "sha256": "080ad2839fafadfdbbe5412ac53061a917af3158f33e16f5df4b4f3dbe422ccb"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 128012,
+     "sha256": "94aca4b876e4794684f4f2b9e66f1c34f7b3935b0d35d406311b63aba17ea3c2"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 176048,
+     "sha256": "7ea0c1007179eb7a45112aaf38d8042213e8b644e6e79b9b1a8d4402c3843b47"
+    },
+    "progs/shotty.mdl": {
+     "bytes": 16984,
+     "sha256": "42f2e1a71e00db26092b7fb9c633daff43bfebdcb46ced46526bee057464cc88"
+    },
+    "progs/shubdome.mdl": {
+     "bytes": 97512,
+     "sha256": "3b92e43bc942b2cfba8c7b4e1206ad858484564d86bd7faa069db592f98c7232"
+    },
+    "progs/shubstar.mdl": {
+     "bytes": 14760,
+     "sha256": "ee5f914d7f3f930db06b1ead8d314dec0413e5182b7de24cc808076d117f3cda"
+    },
+    "progs/skulbook.mdl": {
+     "bytes": 15572,
+     "sha256": "794768c4237a3efedf0c13026213aa417dec5be7eba7971f6e1113b5167fb904"
+    },
+    "progs/skulhead.mdl": {
+     "bytes": 50688,
+     "sha256": "d0733746c8b7cfccdb8d0f30f9454c8863a470e6d56e8359828dbb450aade77a"
+    },
+    "progs/skullwiz.mdl": {
+     "bytes": 726948,
+     "sha256": "0736c202c56cde1cfeaa10b62ca3747f85f08ae3a9cb5daa924456166664e4c4"
+    },
+    "progs/skullwz2.mdl": {
+     "bytes": 726948,
+     "sha256": "ba9f6f478a92ef3f6eec11a1d9c72e4bacf01e755e7f68dae4f6cf2856ff5504"
+    },
+    "progs/skulshot.mdl": {
+     "bytes": 63400,
+     "sha256": "73d6d8e5411b9ae3cf815c3b0cf695a5633cedd5d586565880a9146a1a5db5c2"
+    },
+    "progs/smartbal.mdl": {
+     "bytes": 27924,
+     "sha256": "288e2d54afcbdc5242ab831f3ef611710317c52432e4585a938a12df80b7a07d"
+    },
+    "progs/smoke.mdl": {
+     "bytes": 184,
+     "sha256": "2086abd9950bc643446309a80d9df86b4ebe3f2086f75e799ce943a8454c77d7"
+    },
+    "progs/smoke2.mdl": {
+     "bytes": 184,
+     "sha256": "cdae24fb7cf8efc6ec5271c297f18b04e8c69554ac4c4aedbccd7d3dd39089be"
+    },
+    "progs/soe_coin.mdl": {
+     "bytes": 26364,
+     "sha256": "5769371db409969600bd51d573162c663fb75d358c507fcff9a4aaea95fed4dc"
+    },
+    "progs/soe_gem.mdl": {
+     "bytes": 165236,
+     "sha256": "788f32633f1f3a9f6dd2e0c2dccb76871e02fc6e002db82a219f077dcc493c3f"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 409548,
+     "sha256": "8127b55dec92682e7de27ce1619b5fc8a727413b3cdf2125510138be249a1281"
+    },
+    "progs/soul.mdl": {
+     "bytes": 8436,
+     "sha256": "eb4dc0dae8aed7c92d328096fd9633566b658c9cc65777211ade1e67c6e0ff64"
+    },
+    "progs/sp_gib.mdl": {
+     "bytes": 22228,
+     "sha256": "e902ce3a5e4be26cb781d29178b6e808c480f9e898bc50ecfa78ddf12d774238"
+    },
+    "progs/sp_gib2.mdl": {
+     "bytes": 22228,
+     "sha256": "be98f64e7c2cffce98e28d99b36856762cc15caf761015067fde234390e6b302"
+    },
+    "progs/spider.mdl": {
+     "bytes": 355540,
+     "sha256": "6b32cacff38987b0b4a5efe585dce71ce64ee03e12c4bb1243b1be350f1f3b03"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "078b774958c598bdf1503934d51a1393aeb9aadebcde806db2272b04b233c6a2"
+    },
+    "progs/spikes32.mdl": {
+     "bytes": 7668,
+     "sha256": "983176e5f12571f9b38c9c5d100841e480fe8ccf143889a0e48292a5bca8bf63"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/st_baron.mdl": {
+     "bytes": 185964,
+     "sha256": "7c00af263c1349b9dda2b1a6706bcce7034e9b0793697d67a1bfa83963ba127f"
+    },
+    "progs/st_gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "813d52c557a1eb519d801652b4bd63acdc4ec18d62db53d843ca3dcaa88e87e8"
+    },
+    "progs/st_gib2.mdl": {
+     "bytes": 16228,
+     "sha256": "2d40c1eb75eeb6f5e1781ee9db7a0be10e0d07297d563f9035a8965c4c8c3d01"
+    },
+    "progs/st_gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "d44a77787c5ff633593ad9741ddfbe28809431daf3d32fbe92f8512871b9018a"
+    },
+    "progs/t_coin.mdl": {
+     "bytes": 35040,
+     "sha256": "ed7a18cfce56a630c9adaa37757e270419fca318b3fa655fea18002b089441b0"
+    },
+    "progs/t_gem.mdl": {
+     "bytes": 165364,
+     "sha256": "955761ccf88ef8f6adcd635fb70ae5d8e434b19394a15124acc4370e614f2409"
+    },
+    "progs/tar_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "1ef69998430a54ba662abb46a0ef303b3bf0066f53e84b166065e79d58a72bef"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 313448,
+     "sha256": "fc63e6f62c83975ab2756f0a844d012b887491a6c73d9350dfcb04a6e0355b3c"
+    },
+    "progs/throwax2.mdl": {
+     "bytes": 34872,
+     "sha256": "11a22371cc72adf001e21d04e1b8b65e01497f56410867aa42ea21c0ff304e48"
+    },
+    "progs/throwaxe.mdl": {
+     "bytes": 56532,
+     "sha256": "0ebedab9ab397ba15dc3f0d90df703af2984d1c070eabc08ba781c308968150e"
+    },
+    "progs/throwham.mdl": {
+     "bytes": 7072,
+     "sha256": "f161fedb096a34db55fe57e84acd2bc42295ffea688549235c762b9a70430b35"
+    },
+    "progs/tome_pow.mdl": {
+     "bytes": 2612,
+     "sha256": "40a792071152640897de449d672a693229a87a11bf5e37ab05fd1656be22b6cb"
+    },
+    "progs/tree.mdl": {
+     "bytes": 237576,
+     "sha256": "f1f85524e4018552188aa58979154ce5544381d7bfd5ae05da521e55efdc25e5"
+    },
+    "progs/tree_zer.mdl": {
+     "bytes": 145444,
+     "sha256": "e87574f4e067fe99704d235ec155118736e0e69d9554f8622a1f1ee1c4f831cf"
+    },
+    "progs/treetall.mdl": {
+     "bytes": 120532,
+     "sha256": "e74e7c38099ccc833fadf3c7b7e97f746878d07102dad8cc5926546b344cb982"
+    },
+    "progs/uberpack.mdl": {
+     "bytes": 19348,
+     "sha256": "810cd3f895ef65e11f70fe00e195026308af02248b0f1442da5e816b7d6a7d9a"
+    },
+    "progs/v_grpple.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserb.mdl": {
+     "bytes": 35492,
+     "sha256": "cd2dcfa0fc848499235735fc5c7c5efdc631a779747f71441ff05403272bd9ea"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 93080,
+     "sha256": "05655920347b597feff05a74725b20cb88693ac78fdccb3730918a01cc4e6811"
+    },
+    "progs/v_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "a2d573bdf52015bce7a571a2263a3e8d938daf0bc1b5e4589f84580cab7da2d4"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 35492,
+     "sha256": "2f5a6e74998e4783d9b3d458d167aed31f32cd49b362f01b8d9ec0e94f90de63"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/v_rocks.mdl": {
+     "bytes": 58548,
+     "sha256": "87d0958027fadf417616cc48367b19ef6f9215a0685edc239c751b59e2b6368d"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 165540,
+     "sha256": "abd6787fff37c452fa01f4bbc9eb9594311eaf4a794f161caeb5a501ab9e103f"
+    },
+    "progs/v_sword.mdl": {
+     "bytes": 94416,
+     "sha256": "74b2fd6983cfb317ce136eeef6029d0cda063efe4706abc12057ba32cb0e988a"
+    },
+    "progs/v_wand.mdl": {
+     "bytes": 27388,
+     "sha256": "b46ba82a45a24fe4833dfdfd3c9457b98096a5800d6620d6eae11895653a6698"
+    },
+    "progs/v_xbow.mdl": {
+     "bytes": 95168,
+     "sha256": "e65f7cfe84cfa7c84c34147dadcc8b5ceea9416c7e378bd2110961fd76348e70"
+    },
+    "progs/vomitus.mdl": {
+     "bytes": 79724,
+     "sha256": "03dffcc3405c63f0e0c11301a74da5403d957b66171a6f34eaf8998e4ba31550"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "7758aaf42d0d1617e4fb172ce842be4316073f63250aba46dad441327cccb2e6"
+    },
+    "progs/wanted.mdl": {
+     "bytes": 27860,
+     "sha256": "03337a468db14377fcd36842037d2a27dfb97c3d5d5f45fcfe408e79050a5839"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 67956,
+     "sha256": "39c4a5daef1cfafc1bbfff1ca8eebb5c75d27f953f31d29f249205762605a56f"
+    },
+    "progs/wings2.mdl": {
+     "bytes": 28980,
+     "sha256": "5342d6191f59e69eb830a5e833473ac253b3a7750063d5519f6d2da2b82f5573"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 109380,
+     "sha256": "d78cd5ac1d667ec808fc7664071e060cea40179a0ba094e2f4c119d5ef7a79ba"
+    },
+    "progs/wr_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "1bfb049cf920973e32d78cbf7cf8b6c0c18f8dde55006ee43798ead4b99af9a7"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 238732,
+     "sha256": "5d0f3d6b32bfec300894dbf066a15bd9e34b985919423446232ad85d2ad6d6b7"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "progs/yakman.mdl": {
+     "bytes": 736212,
+     "sha256": "91595b5866d8f85fe67f349d22fb0c4735a4255894ca7368b10bc06618b98a3c"
+    },
+    "progs/yakman2.mdl": {
+     "bytes": 265228,
+     "sha256": "caba3ad0554bc09c10855592447424ac93beff1665803b2e5c605bd36b28cbdb"
+    },
+    "progs/zerkhelm.mdl": {
+     "bytes": 47604,
+     "sha256": "07fe43e56af442776c52da95902eda56c0bb197783fc5279ca350fc0dd34c4c5"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 226776,
+     "sha256": "f4d35645fa47d159cf7dee47a1652ff239cbe7a7b3df8567b865c6d44536abf4"
+    }
+   },
    "sha256": "9a229082e446dc3991778b3364ec5aeba9b6767e5905406767f753862997295a",
    "timestamp": "2011-06-12T20:18:08.000Z"
   },
   "pak1.pak": {
    "bytes": 11698993,
+   "files": {
+    "sound/ambience/amb21.wav": {
+     "bytes": 80716,
+     "sha256": "d664ea08d9df7e7dd135eb0726c1bc142878dcc53d13564dd3dcc5562180201a"
+    },
+    "sound/ambience/amb22.wav": {
+     "bytes": 92716,
+     "sha256": "f444289984b285a1497f55e566fbbf1896a04fa38e291efaa3ec1a0720204811"
+    },
+    "sound/ambience/amb23.wav": {
+     "bytes": 40180,
+     "sha256": "e451997ac7f37d08bd8434d708f45ee2967693317684b947ce511c9df84828b3"
+    },
+    "sound/ambience/amb24.wav": {
+     "bytes": 42282,
+     "sha256": "ead78c8507a7a6a7d6c61e913a2319964f6a8f70b5f7f720c162725edd9cd5aa"
+    },
+    "sound/ambience/brik_hit.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/brikhit2.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/chant3.wav": {
+     "bytes": 116346,
+     "sha256": "5d71f12940688414ab8cabc0d88e323dc961b60aac66f17887712133f1cb8b29"
+    },
+    "sound/ambience/current1.wav": {
+     "bytes": 50906,
+     "sha256": "dabe357d48586dccb8e1ed18c49828797c9f7a8c02c7a588ddc76a62c9b1d3e4"
+    },
+    "sound/ambience/drip_amb.wav": {
+     "bytes": 105444,
+     "sha256": "b282bc6082754011ee21a82aedb490a856c0f694f57991992296554c13149b02"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/heart.wav": {
+     "bytes": 8190,
+     "sha256": "a5b42c46cca24da59c324bb28ce6887b3a2a3baafcc18b0db2b2485f1189a4e0"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 177840,
+     "sha256": "9daec0732dcc821670b8910a1371153e3829e604b6957bf95931bea416af6074"
+    },
+    "sound/ambience/mov_watr.wav": {
+     "bytes": 44432,
+     "sha256": "9d6721844fd5559ab4f53902e70ad9789a90710dde082d222bd814a36c00ab67"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/spark2.wav": {
+     "bytes": 61640,
+     "sha256": "7eb18b00cd5e7913fea7a85ec5b1db159d1d001d24d4f687bfdb5685cb163c8e"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 106286,
+     "sha256": "056f37dfd1d5f4eba1d1911245dc0930bb0c46a84d72d867a286e5a9540248a0"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 87710,
+     "sha256": "2bb46f7c8f70fd28f0ca47b294824bcca7689047291b6c5259eebe76ad6aecfa"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 140630,
+     "sha256": "5a4dccd168cbd9f759ac468d7aa879dbcdbe5637e0fd0521f641ba1d60f61817"
+    },
+    "sound/ambience/th_clap.wav": {
+     "bytes": 570992,
+     "sha256": "5b93e5d878621c2a92e66d6214b0fa8acf8ad5a35f4120f456ddf5678e941d94"
+    },
+    "sound/ambience/th_clap1.wav": {
+     "bytes": 72062,
+     "sha256": "1fc3146d501953545b2f2f261cd2fc398959a79c753a291702609b4cdd2e8682"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/wall01.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 28798,
+     "sha256": "f66c76f07eef275e904fcc76d7ca9fc2011f3de8c61ce0b3ad035464beb7a86c"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 110578,
+     "sha256": "c3e1ccb091b9d8a06b83530b5e29b9f26f5ad8b9dcd082f3da976c3d44944b87"
+    },
+    "sound/ambience/wingend.wav": {
+     "bytes": 90874,
+     "sha256": "63e435d896b097d4dc413fb1afccc2078f1d101a4f7bfc18c4e593ca9e8b344f"
+    },
+    "sound/ambience/wingget.wav": {
+     "bytes": 65148,
+     "sha256": "533bdbd7beffa4c71c66239e3ac417f2177b20a60ed39c379c59a10b2222b367"
+    },
+    "sound/ambience/wings1.wav": {
+     "bytes": 6028,
+     "sha256": "c9e05f66a1d728a88289bc213c9f3551f1e54a4f3e8ef23ab03f8d5019e7b2c5"
+    },
+    "sound/ambience/z1m2mus.wav": {
+     "bytes": 103768,
+     "sha256": "d54261d4c9a4a8a9fe0c51eeae343c6a5b381727af88d0bae6f9b40605b8e5d3"
+    },
+    "sound/ambience/zend1.wav": {
+     "bytes": 123618,
+     "sha256": "2df6c267197b2e82241e47ce4985b04d14e1ce3cff46cebf3177369057302bb6"
+    },
+    "sound/ambience/zend2.wav": {
+     "bytes": 73742,
+     "sha256": "0ea00395004f11d41ab60352517bf5ff5c88a73b8ff2ddb3f32b5085967e3003"
+    },
+    "sound/ambience/zend6.wav": {
+     "bytes": 252626,
+     "sha256": "3f3c412e55bc7534c423c0d1bec2d817e3aea06338b4d6c3f78c4b80e55d509f"
+    },
+    "sound/ambience/zend8.wav": {
+     "bytes": 112122,
+     "sha256": "27cef28aa3d6c3ea86f0c54168db07055abfc7af284bc5a35bf53a0e53f8d677"
+    },
+    "sound/ambient/amb2.wav": {
+     "bytes": 38416,
+     "sha256": "21a4f41fb5efb52587e60395f23824ef330674a8d9499fe2cda1c91603093bfc"
+    },
+    "sound/ambient/amb7.wav": {
+     "bytes": 43020,
+     "sha256": "de7f4a0d15c711c9ca63f74ee38acf78e4ce41800900e0193a43c3e55e4efde6"
+    },
+    "sound/ambient/comphum1.wav": {
+     "bytes": 20456,
+     "sha256": "af10cad0f193d07be9c98f0dd889840fad0f54f40a61d12a1325b78033a68c8e"
+    },
+    "sound/ambient/comphum2.wav": {
+     "bytes": 72367,
+     "sha256": "fbf1ff8677cf36d78e381437f3b8e758a589a108a50c92f24c514eda06ede3f2"
+    },
+    "sound/ambient/comphum3.wav": {
+     "bytes": 116441,
+     "sha256": "62d9624940b93bcd1897abb809cb9d6f2cb3872cfd6af9a792260fb17f800150"
+    },
+    "sound/ambient/fan.wav": {
+     "bytes": 54275,
+     "sha256": "6cdc6a19b0c740d5607fa9076f749dc485483362445630877c6b59ec67085a2d"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/l_hum1.wav": {
+     "bytes": 20790,
+     "sha256": "f1b8bb19b32258ca1b126d52eb98b17c2753a255eba60864f8ad325f564681c7"
+    },
+    "sound/ambient/music1.wav": {
+     "bytes": 213944,
+     "sha256": "bf498e0cf6541b3559abd978ac420c5cb19d6542d89f19f59bdba8019dc46688"
+    },
+    "sound/ambient/pump3.wav": {
+     "bytes": 40435,
+     "sha256": "ae8ca71a1ce41bb3fa02d993930b4f100db3827ef5768326a91e61f7857370bf"
+    },
+    "sound/archer/arr2flsh.wav": {
+     "bytes": 5464,
+     "sha256": "e9a0c059430744c6546a6be4be3a1e4ac775ea6c5e6440d14611ecd8c8447d19"
+    },
+    "sound/archer/arr2wood.wav": {
+     "bytes": 5458,
+     "sha256": "97c5106007e703618291242bf1c6db9853a9d625189fc26ec9c4864436b560e3"
+    },
+    "sound/archer/arrow1.wav": {
+     "bytes": 2296,
+     "sha256": "4aeac8630ff6036f095a251a018eea5baad7a59bd7e46f624dbfec793e44d7b4"
+    },
+    "sound/archer/arrow2.wav": {
+     "bytes": 3196,
+     "sha256": "0a2734df5a69f6407ffc34ab05d8655da5d7dc0e487627932390fa6cec022083"
+    },
+    "sound/archer/arrow3.wav": {
+     "bytes": 2156,
+     "sha256": "1b866280829cb7ac051f90609baa8db285f3bfa3a27b5814e72b021b7cc05785"
+    },
+    "sound/archer/arrowbrk.wav": {
+     "bytes": 5002,
+     "sha256": "f72e35d5232f40e503192ff0ee26fe152eb42e5ee7141b2bea33a9f12f38aa2b"
+    },
+    "sound/archer/arrowg.wav": {
+     "bytes": 15132,
+     "sha256": "8ec5ee520f81c69ba367ae549a06d5ea1643b43f81dea7d8345561c94c8412ed"
+    },
+    "sound/archer/arrowmet1.wav": {
+     "bytes": 2638,
+     "sha256": "87e6ef50bfe4dabf48a1fba18ad0138bbd298965f1a9d06e2b059019e6f74b60"
+    },
+    "sound/archer/arrowmet2.wav": {
+     "bytes": 3118,
+     "sha256": "2797466dafd51473b8b6b5fd3d02a5baa4fe92a1bf9342fb038a299230037138"
+    },
+    "sound/archer/arrowmet3.wav": {
+     "bytes": 2804,
+     "sha256": "1e77951ec2218add2a8bc1633a925e4a96d2ca247d7b5dfaaaefd7a9a4f2363f"
+    },
+    "sound/archer/arrowr.wav": {
+     "bytes": 9458,
+     "sha256": "10e4bef745e55fddd004ea78d24edb9d3d9edc1ce3053c377be07be27a4da144"
+    },
+    "sound/archer/crash.wav": {
+     "bytes": 11069,
+     "sha256": "60e704bdfdb0a97863b00f3514130a172b95a86bebbf89642b65a6e757a74259"
+    },
+    "sound/archer/death.wav": {
+     "bytes": 9526,
+     "sha256": "e824b3d7d66e8bfc3ce30cc3116eab1b2d2dbc09c6311f91ff25d3e7eaef19f5"
+    },
+    "sound/archer/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/archer/draw.wav": {
+     "bytes": 6874,
+     "sha256": "c94e5cec38dc40102beebd067554c91e63b86e5c1ef11dc17976733bd9f08ce3"
+    },
+    "sound/archer/explode.wav": {
+     "bytes": 17788,
+     "sha256": "1f7d6debef492f0861ee24049ad637a11b85d595cdf3f6d6aac422b7a0376d14"
+    },
+    "sound/archer/growl.wav": {
+     "bytes": 9240,
+     "sha256": "7bdbbd23b3fe056cd1d904124824aa0044acf3aa19ec88f65e092fd13e4b9437"
+    },
+    "sound/archer/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/archer/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/archer/pain.wav": {
+     "bytes": 5082,
+     "sha256": "5347daf1a9263320f25b2a191895fbf6c85278f1fde6ca5962c09ed38e0b37b0"
+    },
+    "sound/archer/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/archer/sight.wav": {
+     "bytes": 16866,
+     "sha256": "bcd12d078e7bc34f0bdea7ae9a34ccd2c9bacb049617329b44f8301c34fffeb0"
+    },
+    "sound/archer/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/bane/death.wav": {
+     "bytes": 10935,
+     "sha256": "7e4775bc543acfb421a446a00efff6d9d5669fafb2387464cb1e1ae3db91efe8"
+    },
+    "sound/bane/growl.wav": {
+     "bytes": 9045,
+     "sha256": "86e7b3d2e685d7c20e503bdffe676727426b606ef069f4b70f182601e910ec4e"
+    },
+    "sound/bane/hit.wav": {
+     "bytes": 3884,
+     "sha256": "228faf88857d697f4d5fb9b9c03f000af4dbc8b254791e18e973fd48cc96db9b"
+    },
+    "sound/bane/laugh.wav": {
+     "bytes": 22108,
+     "sha256": "ae8e8d13e00f41bce729977f09a92806c8451ebe5cb4e8618a6b79df4d70296c"
+    },
+    "sound/bane/laugh2.wav": {
+     "bytes": 31560,
+     "sha256": "5cc5ff4c3be35eec90eaaa6579a55fa843843ad658e2e4bbb258a77f6e410020"
+    },
+    "sound/bane/pain.wav": {
+     "bytes": 9325,
+     "sha256": "1d4cfac1f9dfa1ec6958b18014ec7be18dc2615e64888d3c584d50bb48e51013"
+    },
+    "sound/bane/sight.wav": {
+     "bytes": 22962,
+     "sha256": "fbaabe115d9ca4b985c4481ccc71e6b6f55931394a29a6c51ec97e752ed3d5be"
+    },
+    "sound/bane/thunder.wav": {
+     "bytes": 43130,
+     "sha256": "cb355478e38df678e859557a0f983120a4d4275272d8ebedcae7c9cccf659bc4"
+    },
+    "sound/baron/bpain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/death.wav": {
+     "bytes": 8576,
+     "sha256": "3dd3a23d5a913548d0d0aa6ee1b455017648fcd4830f204539a1626c2ec8e1c9"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/fireball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/icefire.wav": {
+     "bytes": 8858,
+     "sha256": "b529a958de192b59438989c6b98eb50f858273febab53a238b651c70a3c92098"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/shard.wav": {
+     "bytes": 14324,
+     "sha256": "313428dd2cb681a38ad89983ab39b18979f64b3e398104b1ad80f3dc9726616c"
+    },
+    "sound/baron/sight.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/tornado.wav": {
+     "bytes": 11469,
+     "sha256": "9ede270665956ce33daf9d3b49447c09e198275f640ccaf77af4f44273bd3f64"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/bishop/conjure.wav": {
+     "bytes": 54627,
+     "sha256": "532d4b7d5db6a654aa73dfe18fa0f6a71623acfd804a848f106b0af699022bc4"
+    },
+    "sound/bishop/journey.wav": {
+     "bytes": 42051,
+     "sha256": "0995e55661447c53c3a36ae4552ea2e0bb7ec8b178bf52cdabe9d28b4deaa50c"
+    },
+    "sound/bishop/rip.wav": {
+     "bytes": 31906,
+     "sha256": "7070871da7ec08da6260a65f1a98ed1bf9682b1c95c51cea262a4b88a63fb6ca"
+    },
+    "sound/bishop/rot.wav": {
+     "bytes": 22463,
+     "sha256": "866b836874ba611d70675e5e3b83eac059c927bef0e0d1396f2183ea01bcc203"
+    },
+    "sound/bishop/skull.wav": {
+     "bytes": 34293,
+     "sha256": "48836a4d60ed8962ed0f11bffdcca95a200645e3b2cfa49a598d6392e10dc153"
+    },
+    "sound/boss1/explode.wav": {
+     "bytes": 27690,
+     "sha256": "b7eebbb64696612ee18d8d1e25b9c5cc334a4562cb99758a446a22490215f349"
+    },
+    "sound/boss1/explode2.wav": {
+     "bytes": 14798,
+     "sha256": "4c6b14b163905823f629644fbec088f37f712cf7f76e10e2f91ef23f2b573ae6"
+    },
+    "sound/boss1/explode3.wav": {
+     "bytes": 19028,
+     "sha256": "69ef0c65811704d8996b726d6e2cbcf70528d3ca7b2f28ec8814c20e7ab76ad7"
+    },
+    "sound/boss2/pain.wav": {
+     "bytes": 84796,
+     "sha256": "b9c255890f61771966327ad49994306a1e3de4b702163a079b5a733b4016810a"
+    },
+    "sound/cube/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/cube/bc_attck.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/cube/bc_gulp.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/cube/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/curse/x_armor.wav": {
+     "bytes": 17988,
+     "sha256": "61b518c8ad8410a17eaca28ee190d96a0c3d1dc755593872d7ec5429c8c19157"
+    },
+    "sound/curse/x_damage.wav": {
+     "bytes": 14772,
+     "sha256": "f74f64e3f47cee7c9b424b94a426f93c133d8acc1e6cb15551a72ab361fe95c4"
+    },
+    "sound/curse/x_leech.wav": {
+     "bytes": 16692,
+     "sha256": "78aacf297df09e21645c2e04ccf181266c35c8e52303ecb498c90db33e8c7b27"
+    },
+    "sound/curse/x_muddle.wav": {
+     "bytes": 18932,
+     "sha256": "b85810135fb3eca3f141047a08cd42a0e527d6da6e9fcfca3887a15f89edad6b"
+    },
+    "sound/curse/x_slow.wav": {
+     "bytes": 16728,
+     "sha256": "0477b046f163d36e9e41c8686ca7538659d0327668d938c0b2405f3a1e6dab3c"
+    },
+    "sound/curse/x_weaken.wav": {
+     "bytes": 15946,
+     "sha256": "f98441764b5f258ee875090c73e5841f4c8f97decbfbd8d9da836a7aac30f430"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15692,
+     "sha256": "72e737f04f1d34044dfd812c6b0e233cd38a91e6b089633e312678756952de87"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16625,
+     "sha256": "bd4cd7902712282ef8f2f749e6fcf805c2ac5212994fbb1c22fc0fe0ea5d08e2"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15527,
+     "sha256": "0b472a984137667f4788336a4f7c60e07a8893f47317b2a158aeea39920d729f"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4107,
+     "sha256": "8fe56b192838dafdf7ff4737cf1e5555d3295cbca49c1ab83568281ee188153c"
+    },
+    "sound/cyber/cybidle.wav": {
+     "bytes": 11894,
+     "sha256": "af7b96ed2eb5bc55900957b3e4136bd5dd93a72dcebca3bc2eb67cdc5186d32c"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8122,
+     "sha256": "3ea23b8d7a68e754211a10a5338b0c8d65df6e2138d4cfe06cc053b9a0f601ae"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13081,
+     "sha256": "a5ec6d4eaa707ad0246b7a7e7737b1007043ea5e5634f6f63661ecc20c27c459"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48508,
+     "sha256": "b7aac875623f8dca7597eff3dcab5910453d043fd1f9df20da89232ce8bf9306"
+    },
+    "sound/darklord/death.wav": {
+     "bytes": 10761,
+     "sha256": "7f32e12c649aa4fc4c2edb773c45b6b4258d048176d95e060390834ee7b52493"
+    },
+    "sound/darklord/idle1.wav": {
+     "bytes": 5632,
+     "sha256": "c151a3cf537f5c3668fc116e6ef5c70c9286e8a12097f376ecdf8a04774926a1"
+    },
+    "sound/darklord/pain.wav": {
+     "bytes": 12684,
+     "sha256": "f332a8cdf67fe414966f59d46714154c94de7ebcca3880a47ef5bbdad2c03ef0"
+    },
+    "sound/darklord/sight.wav": {
+     "bytes": 16832,
+     "sha256": "9710267844facf1c627ea0a8f0df458d847eb899dccd9c570e9d967acc64fa07"
+    },
+    "sound/darklord/sword1.wav": {
+     "bytes": 15982,
+     "sha256": "d36670980603c18a67d500707de9db5a8d54128601d6a6c67f7f29677244aebc"
+    },
+    "sound/darklord/sword2.wav": {
+     "bytes": 12434,
+     "sha256": "f7730881c690e0ee6a440756f74630a21241239fd1fd3bbdfd88000c7e57d1cc"
+    },
+    "sound/doomcube/dsbospit.wav": {
+     "bytes": 43719,
+     "sha256": "97f61cb588bb405cd235e242bfca6fe1108171625a7aa4f2573d63682ac42e32"
+    },
+    "sound/doomcube/dsbossit.wav": {
+     "bytes": 57109,
+     "sha256": "5843548ad38c8eea72548481b5833590fbb7fb990daebd0ede4aaac93475f461"
+    },
+    "sound/dragon/acid.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/active.wav": {
+     "bytes": 16118,
+     "sha256": "5c8762ad62bcb65e1a6fa3362393141a8564fca3ad28ea896a18545c5ebfe6ad"
+    },
+    "sound/dragon/attack1.wav": {
+     "bytes": 25054,
+     "sha256": "c96520801f27bc933928d7f793c2c28ff2dc7b36a86450f6372a9c8a668b4f58"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 63766,
+     "sha256": "55eb476a990e479c06b4c9a12b71c595d8ada35e813e512986709650ef0e54d1"
+    },
+    "sound/dragon/death1.wav": {
+     "bytes": 18358,
+     "sha256": "645baa1cccaf1dfbcd628d17fd8ea290f42f1bc40903e26c79a536a6d1528a2a"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/fly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/fly1.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/dragon/flywater.wav": {
+     "bytes": 11034,
+     "sha256": "68cac399467a55df3c80331696869309eea2339467df0ba94408be4fa2afeb3e"
+    },
+    "sound/dragon/ice.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/icehit.wav": {
+     "bytes": 9370,
+     "sha256": "089c07d0352678106aaa1c47f015792393d5aa01b4bd64fa35e798c4ee09108b"
+    },
+    "sound/dragon/idle1.wav": {
+     "bytes": 34068,
+     "sha256": "3a125f0bcf2908e4ba3af298b117f71c0efa43be4077e53c791b2805cce6a038"
+    },
+    "sound/dragon/idle2.wav": {
+     "bytes": 21474,
+     "sha256": "e1101ff0121687511a9c978d0a30a945421d0a2a30b7d139e4427d41dcc17628"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 28302,
+     "sha256": "60a99d79b6922a14e27ed63313e82ff17b127bda008bd614d8e9ed86f0f2cc3a"
+    },
+    "sound/dragon/pain1.wav": {
+     "bytes": 6524,
+     "sha256": "6cdce2fde3a1eb328007e0667c5dfe705e87bcd526e416ac948fa11a36448ac0"
+    },
+    "sound/dragon/pain2.wav": {
+     "bytes": 6875,
+     "sha256": "3238b77aafcc60c634cbdbd47ae1eec99bb969e2161b72ce5623398e6a451d2a"
+    },
+    "sound/dragon/see.wav": {
+     "bytes": 39640,
+     "sha256": "e8202c360287700da28f96d6a14fef6bdea04374ea911f2b3e41183cd8a136ba"
+    },
+    "sound/dragon/sight1.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/sight2.wav": {
+     "bytes": 15205,
+     "sha256": "197238a35261e6792c40a4da38ba7b3827116ac1af5f143e092768346605b470"
+    },
+    "sound/drone/drnblip.wav": {
+     "bytes": 2106,
+     "sha256": "b372ece13de5edfb22d88ff147a9eccfddfe446c9403607d89daae09fc7c8b68"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/force/force1.wav": {
+     "bytes": 30022,
+     "sha256": "b609981695694648cab0f2ed521dbf3d6f31b6c2e8c3e8502ab4740c7a105557"
+    },
+    "sound/force/force2.wav": {
+     "bytes": 10252,
+     "sha256": "32c0342dbc9e63220db18fa706ac0fc1afe9a86f4d488e509e1f52bee955e3cd"
+    },
+    "sound/force/force3.wav": {
+     "bytes": 10252,
+     "sha256": "0317e18dab002184b5ce11a2b86f3263d2606c40f2dc435c824bbd075c1b621b"
+    },
+    "sound/force/fusein.wav": {
+     "bytes": 13669,
+     "sha256": "53192c25adab70ebcf471204aa194ef9d34c4161138c728d95f84cf08310a879"
+    },
+    "sound/force/fuseout.wav": {
+     "bytes": 15379,
+     "sha256": "f515c6b48204f2ba158e99c10a9da60cc45756ea5dca716e256ffbe54a017512"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/goblin/death1.wav": {
+     "bytes": 13890,
+     "sha256": "bed0d074d9aeee8f046ec7b3a9d33e02d157374ddf6af1296bd1ca7bebf30f10"
+    },
+    "sound/goblin/death2.wav": {
+     "bytes": 10280,
+     "sha256": "9cc07020579d50185ea401835e41edbd1c8f007065e39a6306c7aab4f32e7781"
+    },
+    "sound/goblin/idle1.wav": {
+     "bytes": 9802,
+     "sha256": "6c5a8c36eedb0ac5bddacfdf68250c36fe472f9d87e8969b4f95a863a99b77ce"
+    },
+    "sound/goblin/idle2.wav": {
+     "bytes": 9242,
+     "sha256": "5850c885e59ef04ae90be0579dd6f6b7cc26c282045ccb163dab2c9e19fea704"
+    },
+    "sound/goblin/pain1.wav": {
+     "bytes": 5118,
+     "sha256": "8afd94fcaa2d20e7c6626eda0c6cd5463670a1dbed0eeea36da588b28196c8a2"
+    },
+    "sound/goblin/pain2.wav": {
+     "bytes": 7898,
+     "sha256": "ad1f3b63b4ae35e4bfe010447bbd18bb85cd2bbf966ea7e1370afb0e924e699c"
+    },
+    "sound/goblin/sight1.wav": {
+     "bytes": 12716,
+     "sha256": "1c20028239d217f31af57649da5d1a6def576569ef5fc7e7033c2acbef7f9345"
+    },
+    "sound/goblin/sight2.wav": {
+     "bytes": 19356,
+     "sha256": "c9182325cacd9734bfedd48cb5d8076d5823b7a94baa40d32b02de9504474b48"
+    },
+    "sound/goblin/sight3.wav": {
+     "bytes": 8526,
+     "sha256": "796b2f9f0a1c20d672382c6681e9a6ea200fee2cfcacb5b3d3faa72c8e2537d4"
+    },
+    "sound/goblin/sight4.wav": {
+     "bytes": 8668,
+     "sha256": "c0a60baf2b9918a6df5fc32cd8b58c9fa7cfed923a4cb21c841f04f7a544782e"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 27521,
+     "sha256": "424ceef852229e94dbbbc879f1546a8dfda90db93c6263700cf4973805e4bea7"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 16192,
+     "sha256": "98d55bc63eff48521faeed1046064569e932986e734168ba0973c184aa2f5d12"
+    },
+    "sound/golem/step.wav": {
+     "bytes": 11226,
+     "sha256": "851e243a2e6ecf4cb637f8c4368b0f25443d4f9d104733eecfa886c40ee92bcc"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 47176,
+     "sha256": "87f013eb50cb30a967a183f0cfa41b4848f9269afd13dbe1ab5053458bfc5f0e"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 10768,
+     "sha256": "c48f2415db3a5067dfbd99ad580e3f4809532743d653eafe2fdb924fb0bb832e"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 47502,
+     "sha256": "a0c0bd639af614c7714388009c9388f6db9a694e7ecd8fac38653609d6958f61"
+    },
+    "sound/gunner/death1.wav": {
+     "bytes": 67190,
+     "sha256": "14f89744b8f7225e0eefd9e291aee533fd9f759b6351b57d357d9597dba90956"
+    },
+    "sound/gunner/death2.wav": {
+     "bytes": 48066,
+     "sha256": "693d0d1142dfa12ce2dd1d7b959094c201f3bf783114064c29a572dffe2fcfe0"
+    },
+    "sound/gunner/idle.wav": {
+     "bytes": 18376,
+     "sha256": "6c5b1f1d39f1cc78e87cdbf584b8a508fadc99fc2b8b85d21d0e088d134a8b2b"
+    },
+    "sound/gunner/pain1.wav": {
+     "bytes": 17292,
+     "sha256": "afee7d4ac4f872716fe3deb5adced9a99bd3744784329bd12608d051b81ebfc7"
+    },
+    "sound/gunner/pain2.wav": {
+     "bytes": 20282,
+     "sha256": "38d472d2eaaa7638f7980a06a36043353e86d99aa7e86e0132c52639738c87b2"
+    },
+    "sound/gunner/sight.wav": {
+     "bytes": 22572,
+     "sha256": "395e28b6a4684ce2fa10f085f67d58d025421c594e65a0c2a1b67aeab2ee2569"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hkboss/iceball.wav": {
+     "bytes": 14990,
+     "sha256": "6aec96fda55dfb0120f106064cd324ea6e059bab3fdbb2d81cda297f9a82e02b"
+    },
+    "sound/imp/die.wav": {
+     "bytes": 8448,
+     "sha256": "a8b0e037b88829b978d3dbd3d5e657c7f775c73662d554f6247a387ba333d4bb"
+    },
+    "sound/imp/diebig.wav": {
+     "bytes": 14956,
+     "sha256": "d44d390ba11f8850105fd9601f026cb66525a415de7fc363d3574c86b72d22c4"
+    },
+    "sound/imp/fireball.wav": {
+     "bytes": 5492,
+     "sha256": "6362b59ded89655fa8b8877ed2639eca1a7aae1847306bbc3843fa98bedcbdaf"
+    },
+    "sound/imp/fly.wav": {
+     "bytes": 9204,
+     "sha256": "8036ccb256978c17234aa171267fb0332f1911b5f0dad7b9f74bba9378c39a37"
+    },
+    "sound/imp/flybig.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/imp/flywater.wav": {
+     "bytes": 9800,
+     "sha256": "c80045609b62ceb61bd8fb1a18a53c0f2fd5443502a802b0d6d3c61e9a1db4c0"
+    },
+    "sound/imp/shard.wav": {
+     "bytes": 10678,
+     "sha256": "f806167fe23f37826964c0cc345c438ff0e79c3ffb1fed2c85451c675448cae4"
+    },
+    "sound/imp/swoop.wav": {
+     "bytes": 10842,
+     "sha256": "100eacded51635de912cee171f093e869d24589c44f68887497fe751cf9b1e4d"
+    },
+    "sound/imp/swoopbig.wav": {
+     "bytes": 14012,
+     "sha256": "65d4de49684f2f9e2655abf8e4bf042a08bd706ec4971e6397f264f7274e2b63"
+    },
+    "sound/imp/swoophit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/imp/up.wav": {
+     "bytes": 12500,
+     "sha256": "874b533da43f713a1be27fbccadda8b6392fa8e689c8c4d17dac4b0d380f5822"
+    },
+    "sound/imp/upbig.wav": {
+     "bytes": 21472,
+     "sha256": "36c7bc087935cf7cd33482a50a75df75fc2bfbe53ca0ebcd9797a8bdbde73652"
+    },
+    "sound/items/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items/equalize.wav": {
+     "bytes": 13008,
+     "sha256": "933046049bae4d866250ad9a6e0a4b2a9385caffb4156daaca39ff7110a71126"
+    },
+    "sound/items/levitate.wav": {
+     "bytes": 44236,
+     "sha256": "8a04ce4a97dc22d095bc52d08111bcaaf5f57482f580ccbe0c61bdf8fd18913f"
+    },
+    "sound/items/life_up.wav": {
+     "bytes": 8660,
+     "sha256": "2712bd978343d4170bc1757706597d4de3940a07b6847977cbf117fa92f14c31"
+    },
+    "sound/items/money.wav": {
+     "bytes": 5100,
+     "sha256": "e4ac299499340c1be250f5d5e0824440d9e539de8a1d5b01e303056719cf822f"
+    },
+    "sound/items/optimize.wav": {
+     "bytes": 14854,
+     "sha256": "508d89890db17f828cde9511ebd97241ecfe07bbb6e5cba8c7538ab02e31b19f"
+    },
+    "sound/items/quaff.wav": {
+     "bytes": 3748,
+     "sha256": "ebaa4ecc17dc67d3fbc5fe1a7541e4e19769ce941d043922f8572cb2da8d3cdd"
+    },
+    "sound/items/reflect.wav": {
+     "bytes": 14936,
+     "sha256": "90dd50b25175c8d514a52165429e9ca6b90c45dddbb0f301e5873146b4a4a06c"
+    },
+    "sound/items/reflect2.wav": {
+     "bytes": 33119,
+     "sha256": "5fb5afe50e0f5fa24f1c4481b3060ae222f40138ca81052cea047a57aa6b03e8"
+    },
+    "sound/items/reflect3.wav": {
+     "bytes": 7804,
+     "sha256": "a079e5aef6ed9fb7d5c992b0ef8e11932a9efa192eedac2bc530098e0550984a"
+    },
+    "sound/items/regen.wav": {
+     "bytes": 7984,
+     "sha256": "1e125e8e7c19f29eaf09b7ad301fdfe5126d922dfa84ba2af267cdf3351b6498"
+    },
+    "sound/items/shambler.wav": {
+     "bytes": 20182,
+     "sha256": "f0cdf78367b770c97b3b89abedb7c4fb0a9ee10d742acc8c98b3daba46cfc215"
+    },
+    "sound/items/tomepow.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/items/tomepow2.wav": {
+     "bytes": 33119,
+     "sha256": "1e2e62a6f251722741b7f0adeb38c59a1d05917d0f84c8f48922efece97f02e2"
+    },
+    "sound/items/treasure.wav": {
+     "bytes": 5554,
+     "sha256": "c86f66148e8dc99af2c8e877d64d06dc1c35d0caa9c6dc5c8092b268960b8edd"
+    },
+    "sound/items/zerkhelm.wav": {
+     "bytes": 8298,
+     "sha256": "ef7b98bd965660df91ee34920806b48428a8b5c17c0ec4fdecb48d7fe28e3ba2"
+    },
+    "sound/laugh.wav": {
+     "bytes": 71573,
+     "sha256": "cb8e1381c70240a93233b8571d792e21950d00b1285f867cbc0ed1237dac1df7"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/b_rot2.wav": {
+     "bytes": 15436,
+     "sha256": "62c86077b7a29f48f5c872c68d262c03b73b57f876b718a05f2fc6b24b9a9ef4"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/bellring.wav": {
+     "bytes": 27600,
+     "sha256": "fe3b2972c722171144eaba160757803292a42342e737d6acdbd0b14802e686f2"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/dsslop.wav": {
+     "bytes": 11163,
+     "sha256": "b6a9f6e74b222169c87e6c56b47d2e7995b23b8b045f16be968f43290f22cf9d"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/met2wd.wav": {
+     "bytes": 3968,
+     "sha256": "a3ce3e10b609f7ae28fc6f39f1f5d55a7c99a41143fb161de7e4e47b7f40f100"
+    },
+    "sound/misc/metalbrk.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/mgboat.wav": {
+     "bytes": 26866,
+     "sha256": "666016e2aa958ea621ba03bee4339518f2ccc72aa3ee2d0838ef9032e8ffc981"
+    },
+    "sound/misc/pushmetl.wav": {
+     "bytes": 14042,
+     "sha256": "2657b0006f51ecb7077b5861b1b282e0bb8bef3bdd5ccb68b3bdd6794361099e"
+    },
+    "sound/misc/pushston.wav": {
+     "bytes": 11490,
+     "sha256": "f457b95dad6131472475ab22d9c260adf5d389e74629cd8ea36ca05ad7d4e749"
+    },
+    "sound/misc/pushwood.wav": {
+     "bytes": 13602,
+     "sha256": "7c3fa06978f8c7b632d12bbf1031a5ac316b44fdc5efd93338ab0a0a162bdf3a"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/rublexp.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/secret2.wav": {
+     "bytes": 87440,
+     "sha256": "36e9d9617a14daefd510e72308b9e85718a473e2b25a06b66026d463d6bbb519"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/misc/woodbrk.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/music/pkdream.wav": {
+     "bytes": 154898,
+     "sha256": "df8857901002ce9dde3c558743c94967db11cae4af3d9a0cdc00c8cc09e6a910"
+    },
+    "sound/necro/att_a.wav": {
+     "bytes": 8522,
+     "sha256": "a946c060cab5ee1bfff2d1af87cd71c9ccf63840a2751fd46fd32f387bee2c35"
+    },
+    "sound/necro/att_a2.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/necro/att_w.wav": {
+     "bytes": 26298,
+     "sha256": "9ae481ad41d16610b597989e82a8bbf9c35a74fe03a8e27900d72ff8b52e3c94"
+    },
+    "sound/necro/curse.wav": {
+     "bytes": 16852,
+     "sha256": "d3729c83c468d9320cf1f8914c8b52d446e818852c955d8d86a093c35c196b58"
+    },
+    "sound/necro/death1.wav": {
+     "bytes": 24010,
+     "sha256": "302e58b0f701ad07ade4a46d5cd3bd9c2186b2df3eb39e36c361918a72ccd24d"
+    },
+    "sound/necro/death2.wav": {
+     "bytes": 23594,
+     "sha256": "05f15a8430885b6688587eba5e249107c3e6df36d7937a3ddd2411d275e8842b"
+    },
+    "sound/necro/idle1.wav": {
+     "bytes": 49212,
+     "sha256": "737f382e89a40fc098214b77e9165e16f2a06323c07e910f336f2616b6ca87b4"
+    },
+    "sound/necro/idle2.wav": {
+     "bytes": 47120,
+     "sha256": "18893e7b31ff448831a7b7a5aa9a5d31b2dcd6e49ae8b58d5eea8b44683415dc"
+    },
+    "sound/necro/pain1.wav": {
+     "bytes": 19412,
+     "sha256": "f37e247a9e1436e4a86b78fe71e1ea6da43323e60943e86784ac87fc4393333b"
+    },
+    "sound/necro/pop.wav": {
+     "bytes": 18996,
+     "sha256": "22aff5a83ec82e759004d82308b2e210f824ac59bd3180d6b688c9d0134ca18e"
+    },
+    "sound/necro/pop1.wav": {
+     "bytes": 10836,
+     "sha256": "d5e9b7ce5a638a419eef07bba492ce75fb3d8002bd66b40d36b4dd89ad859e1c"
+    },
+    "sound/necro/pop2.wav": {
+     "bytes": 11228,
+     "sha256": "10947cad6cd5bcc0e0bc00fdbeccccd53b70bff1fda1a220c72ddc7e2b152b08"
+    },
+    "sound/necro/pop3.wav": {
+     "bytes": 11228,
+     "sha256": "56c4219dc0ecfb7ee8ff6d31fdf6c8c53c2b6990ce1b94ed956caee3c7cf83db"
+    },
+    "sound/necro/pop4.wav": {
+     "bytes": 10836,
+     "sha256": "451b660c65ebd2c7c89134896ed882d738c685f787810e1245587c0c28c38141"
+    },
+    "sound/necro/raise.wav": {
+     "bytes": 9688,
+     "sha256": "1c841e33f22cdcd5276bba9018aec5dae8c0f842da07eb261f48f1a6cc4c8314"
+    },
+    "sound/necro/sight1.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/necro/summon.wav": {
+     "bytes": 16308,
+     "sha256": "b7fc855d38431ac04e09389d7caf04bf0032d2b4edf86ebd795f1ab38d9feaf5"
+    },
+    "sound/nemesant/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/nemesant/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/nemesant/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/nemesant/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/nemesant/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/nemesant/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/nemesant/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/nemesant/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/nemesant/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/nemesant/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/nemesant/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    },
+    "sound/pendulum/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/plasma/explode.wav": {
+     "bytes": 29598,
+     "sha256": "7a95a8337c7ad87faccc1cae98ad7840352b08608fba08aff87a1b33610f9190"
+    },
+    "sound/plasma/fire.wav": {
+     "bytes": 22422,
+     "sha256": "7350d1e99f93a79bee84e94561e080dcb8448a3549a42742633cf604377a5097"
+    },
+    "sound/plasma/flight.wav": {
+     "bytes": 17494,
+     "sha256": "a03b46f31df3495a1b7a2b2f1a09f3e5223d4c0ab65aa0ed936e1445e893adeb"
+    },
+    "sound/player/boot1.wav": {
+     "bytes": 25624,
+     "sha256": "9b730ff4f811472514297921c78ea3080424c57b57ce7fa30c6c10f94bd8ccc3"
+    },
+    "sound/player/boot2.wav": {
+     "bytes": 25640,
+     "sha256": "23a3cd545ffa3c5c1e4a4c9549aff81dadd2f1ab451e397d5292c97024fc5026"
+    },
+    "sound/player/boot3.wav": {
+     "bytes": 25652,
+     "sha256": "004d267ae3fcce21aa66e566efa34e39e85915f202e3b55922b314cfd6efa2d7"
+    },
+    "sound/player/boot4.wav": {
+     "bytes": 25628,
+     "sha256": "9beb96d9a183cd6a13693961a216b4402350fc076c7a1ff98854d28c30a9f8be"
+    },
+    "sound/power1.wav": {
+     "bytes": 44370,
+     "sha256": "68f9d490b390a2510ff660917ac02fa1620893770a68a1188e06f94c57922523"
+    },
+    "sound/power2.wav": {
+     "bytes": 44370,
+     "sha256": "773aca5e1e60540b2abdc4b9b29c4281a04f6fad3bfc6bea1c029b42a7f0fe9e"
+    },
+    "sound/ranger/idle.wav": {
+     "bytes": 10819,
+     "sha256": "644fbbc14e20684fa31abc7f04969943ac950c33435271b0fa646aa324be4400"
+    },
+    "sound/ranger/sight1.wav": {
+     "bytes": 5379,
+     "sha256": "5023e2483fe5c1c37cd661d382e34c0b68eafe4bae0e35e8f3f7e516e78dcf51"
+    },
+    "sound/ranger/sight2.wav": {
+     "bytes": 11323,
+     "sha256": "3574f035e1a261b9a001d99a54bdb502da31da2639d95e7fc06f96b547c1ac44"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight1.wav": {
+     "bytes": 35068,
+     "sha256": "48db878a4eae15b37ee0ca333aae74d310103a9eaf2e4b35eecd43a89f626b9a"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk1.wav": {
+     "bytes": 19372,
+     "sha256": "42e41297df70202ec9965af7af5fcdabcab7fde43ba515c8ba0a1ee2e4429554"
+    },
+    "sound/shade/death.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/shade/death2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/shade/fly.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/shade/idle.wav": {
+     "bytes": 37192,
+     "sha256": "57b0a0a7a0e75a17df8c4bb68740b23325bd0bf3475d908ee92fa0522c71edf7"
+    },
+    "sound/shade/moan.wav": {
+     "bytes": 33684,
+     "sha256": "3a6644f2c0a6ead5992fa9752ec9b0d898f4c40f5a32b12fd61aa991f75fa0c7"
+    },
+    "sound/shade/pain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/shade/pain2.wav": {
+     "bytes": 8918,
+     "sha256": "c6fa3ba7c659faf38b00af9c9867c37ba730cbc662125f5307f755515243dc4c"
+    },
+    "sound/shade/screech.wav": {
+     "bytes": 28244,
+     "sha256": "55ef2615baa6ce39733892fc9538f702acc567f65250223329f15b191d9b1a47"
+    },
+    "sound/shade/sing.wav": {
+     "bytes": 35654,
+     "sha256": "9de82a1d3124c391466004aea5e8ad066bcc6ede2715e7978a92a2c8f66e3f6b"
+    },
+    "sound/shade/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/shade/taunt.wav": {
+     "bytes": 36418,
+     "sha256": "f556cad612249e63690ac28b17405eba70e3df43560c3a087062b9f330811720"
+    },
+    "sound/shade/taunt2.wav": {
+     "bytes": 28160,
+     "sha256": "a68174008206b79794d8d52fd027daf08767ce005189860c815cda021080363c"
+    },
+    "sound/shamvile/burn.wav": {
+     "bytes": 11316,
+     "sha256": "239c51d5cfb82ee7683075f6cd53d8a16fcc2da608c9db87c27fd7491160a627"
+    },
+    "sound/shamvile/dsvilatk.wav": {
+     "bytes": 16978,
+     "sha256": "f4fc290f121fafbc1d8e5e992b9454b404f9ebbf3c95bc376419ee8ca58425bd"
+    },
+    "sound/shamvile/melee1.wav": {
+     "bytes": 4700,
+     "sha256": "f418a627faa0b4630588914ecdd466c387e1d7d5ac2e09acecafa13baf33f10c"
+    },
+    "sound/shamvile/melee2.wav": {
+     "bytes": 6252,
+     "sha256": "dfeb5bcd8be8d9f1fcf52f89cf0af533ec28066eb0bf74e3ac4b588ca810f372"
+    },
+    "sound/shamvile/melee3.wav": {
+     "bytes": 13236,
+     "sha256": "7102a987921e4c291175ba252628613c2c6ecdb70e9a33e174b6bcf7addc239c"
+    },
+    "sound/shamvile/melee4.wav": {
+     "bytes": 9211,
+     "sha256": "da31a8531703998c06bc33c94639d5dd291c9ba24e6752599ec8e6113d3753b5"
+    },
+    "sound/shamvile/sdeath.wav": {
+     "bytes": 20996,
+     "sha256": "e27d5870c37ce74877a2681b5e9cef437d14b05c501fb93733c8e93d2d2b0931"
+    },
+    "sound/shamvile/shurt2.wav": {
+     "bytes": 3924,
+     "sha256": "541c66bfaf5f30c55d24c4013f4a8859159ebfdf2f054c681eb8b8200dba1c85"
+    },
+    "sound/shamvile/sidle.wav": {
+     "bytes": 5476,
+     "sha256": "ca3edcb476f3992027989a2a79ef21a7f8951965c8a0e77f89f0a0505f2d2b52"
+    },
+    "sound/shamvile/sidle2.wav": {
+     "bytes": 21511,
+     "sha256": "0e46d4e53c003136881723f59de4d706151b845d57608cd87361018acb7ef050"
+    },
+    "sound/shamvile/ssight.wav": {
+     "bytes": 15564,
+     "sha256": "5a5343f95ee503f1b481ef05499e023b681402b922600979367788f2fb91397c"
+    },
+    "sound/shamvile/ssight2.wav": {
+     "bytes": 27204,
+     "sha256": "2b22c0912485569f7ec87a32a29c88563c0cb8261b4428335540fc96f7e7cb52"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 19642,
+     "sha256": "91eba6c478e8475696f07079502af32d1817e3fb86418c32801846582f27561d"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 18166,
+     "sha256": "91301f18c459286798989dd164ae08f5e77433ac7a0b5c71522cf59e49bf1a30"
+    },
+    "sound/skullwiz/blinkspk.wav": {
+     "bytes": 31420,
+     "sha256": "48a4dbd2add9021727d4572af9ac4c6f333a9e2ace5fe7127ddd42c84a2ae1f4"
+    },
+    "sound/skullwiz/blnkspk2.wav": {
+     "bytes": 41834,
+     "sha256": "fc2602275102b7e1a577c30b7ab3ac2709881eb3a8798664577f8a65a9132754"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 23034,
+     "sha256": "0eb20419acddee8a5814ecad8888348f90a14db997af1045b02b6052dccd5fd1"
+    },
+    "sound/skullwiz/death2.wav": {
+     "bytes": 32314,
+     "sha256": "3b1d2ed146a334ba5cf77027faa47addbf45c51159ff9c7278a97dda8ed7ef82"
+    },
+    "sound/skullwiz/firemisl.wav": {
+     "bytes": 12186,
+     "sha256": "3583544b6d7105d5b029a490cb0730190ae9e8dc5ca8f9da1deae4ea0335e964"
+    },
+    "sound/skullwiz/gate.wav": {
+     "bytes": 16156,
+     "sha256": "5797c6450d14f363133be23d93c829a660f9b7692c07f905b5a723cda8075c55"
+    },
+    "sound/skullwiz/gatespk.wav": {
+     "bytes": 30092,
+     "sha256": "f9fc90ba497d650acfad76c42ed531314828093f114c69c28fd1611d326fab2e"
+    },
+    "sound/skullwiz/growl.wav": {
+     "bytes": 18944,
+     "sha256": "de58ed34dd69dc3e871d09ac6a5db81ef26d69e234f0834e72c6cd68501ead21"
+    },
+    "sound/skullwiz/growl2.wav": {
+     "bytes": 24954,
+     "sha256": "0cf747c71a6fad9a085c39456cd14ffd972d2d454b4bafc2781ce4464917cfa4"
+    },
+    "sound/skullwiz/pain.wav": {
+     "bytes": 6106,
+     "sha256": "0f85b6180cbfe8d26f8d174f25c109b9d8b78d0fa53735e0494280bc8a19803b"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 8890,
+     "sha256": "6d48429e7fc4b80be16afd80097b7096a94cb1a88922a62bdfdff64172526a0f"
+    },
+    "sound/skullwiz/push.wav": {
+     "bytes": 8812,
+     "sha256": "91398e953b648ab23c037940fb7996f3d77727003a60757ea50686328c05cd69"
+    },
+    "sound/skullwiz/scream.wav": {
+     "bytes": 31734,
+     "sha256": "6df299b2a59aa94a9640c83684b65259e4619e0ed2a2fd1ce518dffaa060fd43"
+    },
+    "sound/skullwiz/scream2.wav": {
+     "bytes": 13980,
+     "sha256": "adca10198e279db0789a1a026124387c40e36fc1914f3f3da315b49b6e290386"
+    },
+    "sound/spider/attack.wav": {
+     "bytes": 6576,
+     "sha256": "82593fdd5be8198a9774c163872f89a088d8d0ca10e91f1c8f846ecac92b2d81"
+    },
+    "sound/spider/bite.wav": {
+     "bytes": 4552,
+     "sha256": "abd0b64743c825661f4598b7d5b70b781452a6b7747f9eb8b53f7239b0f9b9cb"
+    },
+    "sound/spider/death.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/gib1.wav": {
+     "bytes": 10516,
+     "sha256": "bbe1a437bd05a71f9d7bba953a79886891bfc526399c67cfc8964308c91786d0"
+    },
+    "sound/spider/pain.wav": {
+     "bytes": 7576,
+     "sha256": "386e11cfd8063b6bb692ab4b90246be98288f72f29614f2e38765df9e6eaad79"
+    },
+    "sound/spider/step1.wav": {
+     "bytes": 2780,
+     "sha256": "06ee408dace817630645b0d390c496e692844fb42cc85adcaa021efeb60fae9b"
+    },
+    "sound/spider/step2.wav": {
+     "bytes": 2620,
+     "sha256": "66e802d6361a17e637f5e38366e4b0912dbb0f65e647041bed57cfda772c0770"
+    },
+    "sound/spider/step3.wav": {
+     "bytes": 1786,
+     "sha256": "418b2c536f19a5bcd0b1a8ff4aae13febc8c4f8fa6787372e9e869c45a17f54c"
+    },
+    "sound/trog/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/tur_arm.wav": {
+     "bytes": 23794,
+     "sha256": "24b428117ebd7e82865b41dcfc74a75a048c4d126d7505a6c23dd243bc054a05"
+    },
+    "sound/vomitus/death.wav": {
+     "bytes": 13236,
+     "sha256": "fa2cad86ac0ce1326132c5e378aed6a9ff5615d043df1d4d48e0b2691f8d3bde"
+    },
+    "sound/vomitus/flesh1.wav": {
+     "bytes": 8412,
+     "sha256": "9ac5a8ac2155e7d9b65144e7f65525c4660ff5959fe3a0277fab347e202b6f46"
+    },
+    "sound/vomitus/flesh2.wav": {
+     "bytes": 12788,
+     "sha256": "3fc22e2aa2c3c0bdc6501388ac18abb5e58c5fd5deba39d1cc2f7e8d48fcc869"
+    },
+    "sound/vomitus/groan.wav": {
+     "bytes": 13224,
+     "sha256": "3632e43615714e5fc1be8277881a913bf1bd79b276544418cbf1b159016f0d03"
+    },
+    "sound/weapons/axhit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/weapons/axhitwal.wav": {
+     "bytes": 6694,
+     "sha256": "0f14ba18076b25a7b8ee510b38adb282eb5c4f2fc94168baf1f8a658e1da684f"
+    },
+    "sound/weapons/block1.wav": {
+     "bytes": 5484,
+     "sha256": "ccb284becb454f395de702a263bfda1561b8bd38117893d33b5ebbb9eb7b6865"
+    },
+    "sound/weapons/block2.wav": {
+     "bytes": 5612,
+     "sha256": "62da8e44f3b1200b99f76a3bdb31d9d09a9e74c04a449c0afc482c6677a94bc2"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/weapons/clang.wav": {
+     "bytes": 7198,
+     "sha256": "634a88cf26b4de688bed392cf108d5468749f212ce67015c71baa942e8e88502"
+    },
+    "sound/weapons/dsshotgn.wav": {
+     "bytes": 9490,
+     "sha256": "98c228b3549d4908c313c783d5b0aec38b93efea1c6a65d7355767bdbb4b87e8"
+    },
+    "sound/weapons/freeze.wav": {
+     "bytes": 20619,
+     "sha256": "48689ba550c116dd8b10a138bc0f78eb6f169d6828a49aaafe12f807930eb934"
+    },
+    "sound/weapons/fwall.wav": {
+     "bytes": 40140,
+     "sha256": "e269c07608f322518e709925d5b13daded150460d19d3091f15152ce4c06c9bf"
+    },
+    "sound/weapons/fwallhit.wav": {
+     "bytes": 9426,
+     "sha256": "7b9f4da432e6fa44fbf721ed9ef753e6ceb41df59b8265b58f73764b2901224a"
+    },
+    "sound/weapons/fwalltap.wav": {
+     "bytes": 8316,
+     "sha256": "879b9970dfc3bc609ff384a0edea13b594ea6a82b5c56d33c8549cd36cccda0b"
+    },
+    "sound/weapons/icehit.wav": {
+     "bytes": 10710,
+     "sha256": "9ed8ed177a6cfcad97f8adcf94b9f3114a955e7b3abb397c6b17c44073c07b19"
+    },
+    "sound/weapons/icewall.wav": {
+     "bytes": 6124,
+     "sha256": "9668486027e07f525a27830dc3217cde36bcbcc956b21437d2637e00df368dd4"
+    },
+    "sound/weapons/mirv1.wav": {
+     "bytes": 89538,
+     "sha256": "7d60062f61d5929f5f927526d81920f24684520d230a5f2611c128b832d3357e"
+    },
+    "sound/weapons/mirv2.wav": {
+     "bytes": 18478,
+     "sha256": "67311180da390517f2ef71d161a0cf7b770548dcd4a7dda7e679cb9b58025b4b"
+    },
+    "sound/weapons/nova.wav": {
+     "bytes": 10020,
+     "sha256": "d41c8433fa1b964fafa1cdb2fec301fb4d398f1fce201b4d80b29fab7a59d7e7"
+    },
+    "sound/weapons/pkup2.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/weapons/plasma1.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/plasma2.wav": {
+     "bytes": 8350,
+     "sha256": "de03da8d300ddaf56b063584226f5673b0033a8258209e4c8c5f82a4d40b630a"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/weapons/r_exp3a.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/shatter.wav": {
+     "bytes": 20899,
+     "sha256": "31ddbef0dc746eabea23cd7cd2fb97a1f949a014b664630d7f04e6c237aafc03"
+    },
+    "sound/weapons/sheath.wav": {
+     "bytes": 7031,
+     "sha256": "8f28a1daa16db234ce77d91e688c7acbc9541c296d30af9e1f940b6d45eaf72d"
+    },
+    "sound/weapons/sprocket.wav": {
+     "bytes": 7126,
+     "sha256": "8b5c3bdc625b4954c6b504ee242591f0121d1ab64f2aceab54dd85fecadef8a4"
+    },
+    "sound/weapons/ssg.wav": {
+     "bytes": 17176,
+     "sha256": "c3307bb283499155691c01fe783d86992946475fd3b9a4839ba37cdca7ede6a4"
+    },
+    "sound/weapons/stunfire.wav": {
+     "bytes": 9902,
+     "sha256": "7214cc44e4c0bfb801209f025b591d838542a3110f770e5614b0f549a055286a"
+    },
+    "sound/weapons/sword1.wav": {
+     "bytes": 3532,
+     "sha256": "572074b68af2132285aa9fd2ac6852f52ffb6c5e56eed44b1af21e0e78171e17"
+    },
+    "sound/weapons/sword2.wav": {
+     "bytes": 3055,
+     "sha256": "b176a257409b659d80df90560bbac4da5539971576aaf1107bb88bc016558085"
+    },
+    "sound/weapons/sword3.wav": {
+     "bytes": 3012,
+     "sha256": "eaca19c8a10b7942d4a279974df6e1cf076c362d5408e439b26286126852bedf"
+    },
+    "sound/weapons/thump.wav": {
+     "bytes": 30904,
+     "sha256": "ef0aa85fbc7ff6915aa5382c80e6f571ddacd50116faff495e3d5638bace8a49"
+    },
+    "sound/weapons/unsheath.wav": {
+     "bytes": 8060,
+     "sha256": "45d9bc6b9dcaf8e0dc9b2ede7da69a872f50f7819462a71bc16b9d76a70be06b"
+    },
+    "sound/weapons/xbowdraw.wav": {
+     "bytes": 19114,
+     "sha256": "4bb73eb7161ba561970e8f2e7f5aad0e42b3419fe2b02a5953a7289c46d1442b"
+    },
+    "sound/weapons/zap1.wav": {
+     "bytes": 7648,
+     "sha256": "1ee462bf6169537cc96fa7f95ef30b782fa1be473bd6ddc297fb3a7a6aa21ad0"
+    },
+    "sound/weapons/zap2.wav": {
+     "bytes": 7178,
+     "sha256": "8ece0064dc470a86c00906c1c50a54afd3a64eb13582071b9960581a1b72f4ff"
+    },
+    "sound/wraith/call.wav": {
+     "bytes": 12328,
+     "sha256": "9ace8a0ff79d035d36b6bdfb8726054ceaf8f852d25f3c1b235616abf4646ef2"
+    },
+    "sound/wraith/die.wav": {
+     "bytes": 14024,
+     "sha256": "3f166e024c07124cc5b5c5469904f5a8b3e48d4cb50fd949be8d79b4df2e375c"
+    },
+    "sound/wraith/drain.wav": {
+     "bytes": 14094,
+     "sha256": "d767951e9630b6179fb05a80136acbdeeb530f350b1953bea62e8493f3fe67ce"
+    },
+    "sound/wraith/growl2.wav": {
+     "bytes": 24966,
+     "sha256": "1c757955bb103e0f589ec373d1517dbacb8fe7e274f7aa0928503c9f5b009b10"
+    },
+    "sound/wraith/idle.wav": {
+     "bytes": 23702,
+     "sha256": "760a4a215fa2adb6f531b15acc06a4b46daa84c85fc08691ff4fe13f17e09ee8"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 20442,
+     "sha256": "d55cb931cef7d9c336fb7bbc3fa0408ea23eff69f46e25ac377ebbc880fa5025"
+    },
+    "sound/wraith/return.wav": {
+     "bytes": 39162,
+     "sha256": "0439588ad2003732fe7f946a5597bf80b2b89d6395476671b0e050b91c49cca7"
+    },
+    "sound/wraith/rych1.wav": {
+     "bytes": 24482,
+     "sha256": "baec568f339f688ea475e37ef3fc51a36de78a52a553e85aaa3f8011e1240d13"
+    },
+    "sound/wraith/select.wav": {
+     "bytes": 29326,
+     "sha256": "1e86b92dd1d82f4f74cd7fe14a75484e6cddb4fe968d2bb3dbaf850414c6dacb"
+    },
+    "sound/wraith/soul.wav": {
+     "bytes": 70524,
+     "sha256": "612bf73a6ebe0526efa2ef3d22915bcd87bed0b0eb5e52fc4eb0e62c5e4a3039"
+    },
+    "sound/wraith/soul2.wav": {
+     "bytes": 20562,
+     "sha256": "d3701420c157109793576ac7af7c7b132ffd0897375ec99701f4cd54798d9579"
+    },
+    "sound/wraith/speak.wav": {
+     "bytes": 25630,
+     "sha256": "6d1e5b395938692d57de3ec8ef9a8b5e4ccdab920a1f247e5bcdc1f0906dfcb8"
+    },
+    "sound/wraith/talk1.wav": {
+     "bytes": 16654,
+     "sha256": "6a625383c12f7fb5979ca8977a51d40f183051d551bd0b1b4ccc8a3f43a0322a"
+    },
+    "sound/wraith/talk3.wav": {
+     "bytes": 9832,
+     "sha256": "28ecc66c85bc722059b147a1354d226fbaf3022b79aed937a4759958d52c0fab"
+    },
+    "sound/wraith/weird.wav": {
+     "bytes": 3028,
+     "sha256": "1cfcd24daeb0665dce9d68ec353377ef84a88c78d1fdfcb429f2d0cc2b7f4b78"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    },
+    "sound/yakman/big1.wav": {
+     "bytes": 21636,
+     "sha256": "16c1632682aeb4b4075006d5b8b13a7e3f8821b6f59f8eb61ad78308b0d68366"
+    },
+    "sound/yakman/big3.wav": {
+     "bytes": 25096,
+     "sha256": "2cbbc5dc1249a92b9a31a6f3fa7ff654dd6339511fc99e4c552ad6a34218a4c2"
+    },
+    "sound/yakman/breathe1.wav": {
+     "bytes": 45712,
+     "sha256": "53730dabf839c183028fbdf909df8ae7ef936828c51c58a957617444872224d4"
+    },
+    "sound/yakman/breathe3.wav": {
+     "bytes": 50728,
+     "sha256": "fd923c891934046d9770c089dfe16021373a392b429531ef9698fbd2f759c42a"
+    },
+    "sound/yakman/crash.wav": {
+     "bytes": 17808,
+     "sha256": "068f6ea04f13016615f9534e74e969a62eda98c7def921df76731c5afbd73cf2"
+    },
+    "sound/yakman/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/yakman/expsmall.wav": {
+     "bytes": 8732,
+     "sha256": "18825b9644c01ff0a488887185ac14d6fb4fd983254620009ba3ecc96c44d465"
+    },
+    "sound/yakman/firefblt.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/yakman/pain.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/yakman/slam.wav": {
+     "bytes": 6372,
+     "sha256": "2c6ff4782b389777c98f09fa6ac86e6c75a848ad800db6dc32f8ea9362706e96"
+    },
+    "sound/yakman/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/yakman/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    }
+   },
    "sha256": "22d57e211cdb714ba3df19083c1514b08e5c84650545bc1a4092b383fb72a3f9",
    "timestamp": "2011-06-12T19:56:02.000Z"
   },
   "pak2.pak": {
    "bytes": 4813402,
+   "files": {
+    "progs/brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/drlbomb.mdl": {
+     "bytes": 20355,
+     "sha256": "5c1db489f43cba73fce265db642267775245d044866cdd48396b1f1260a28237"
+    },
+    "progs/drole.mdl": {
+     "bytes": 241648,
+     "sha256": "5067b7ca5323754fe563d6696025525645a2cbd3aaf7f79232634608f9fb987a"
+    },
+    "progs/g_fx.mdl": {
+     "bytes": 32260,
+     "sha256": "ac99d4e641af0bb1495ed38ba9f3a7c1195bda19e5cf0d3a68f04defe6178ab8"
+    },
+    "progs/gaunt.mdl": {
+     "bytes": 222024,
+     "sha256": "d805c09223a651d6650ad75464cba53ae0fb7f8de1066307efd21d0079c14f5c"
+    },
+    "progs/gug.mdl": {
+     "bytes": 482020,
+     "sha256": "2cd097236a235aedf717a86b7312bd7d1b3caa6f0b25980c82eee2463fee2274"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 16854,
+     "sha256": "00f3263f1c3e0daadaaf03eea447080d727ea7d9ee1a88f2b42e060d748e1566"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 61251,
+     "sha256": "dec5afe666eba8db6e32d7535fffa3d0e4ed9344ba107b73418526ebebac574b"
+    },
+    "progs/longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/marsh.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/marshsm.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/snowflak.mdl": {
+     "bytes": 36372,
+     "sha256": "d7cdcca5767160408a43bd6b51313f9b68b696aa06eafdb0af4762513325d1a9"
+    },
+    "progs/spore.mdl": {
+     "bytes": 13469,
+     "sha256": "fc9fbb97f0d4f1a9f843769cd43fb7270ba2b351cdf3b4b624d27616980457c4"
+    },
+    "progs/vermis.mdl": {
+     "bytes": 656752,
+     "sha256": "d7060475e290482c61c122b3a477085b1aad002fd71d8293cc4a4f8bde1baec9"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/explode3.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/sight2.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 83982,
+     "sha256": "4b0d8db882ab1c9fc2109effeaf125ec46fb23a91ac2242201103e0d3da96944"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gug/bile.wav": {
+     "bytes": 54572,
+     "sha256": "e06787585ef0369798a938a1a9585d24b60aa7b5c65acda3a5fb6f2c7ab65aca"
+    },
+    "sound/gug/bileatk.wav": {
+     "bytes": 50040,
+     "sha256": "b4b05e2907789a78391ccfe8ced3902821f1097ecd1f894b12ba9278d31a8717"
+    },
+    "sound/gug/death.wav": {
+     "bytes": 132396,
+     "sha256": "20bf209a832381b77d37c54a84ab1819b6c71e2147c5d122ac62668c070167a5"
+    },
+    "sound/gug/gquake.wav": {
+     "bytes": 43350,
+     "sha256": "d232ae13b55cb5b10b8903db43c037a5c6c4cdfea1f84f9399133484df6e0175"
+    },
+    "sound/gug/idle.wav": {
+     "bytes": 50580,
+     "sha256": "ff33c63696dec5c582ff9a4537814299b47ce2480d6cc53c116721d793576fda"
+    },
+    "sound/gug/pain.wav": {
+     "bytes": 22064,
+     "sha256": "e559f2b372fe771207aeef4b1c3a71baca542863493776558ae3f933f3878c29"
+    },
+    "sound/gug/quakeatk.wav": {
+     "bytes": 65882,
+     "sha256": "2c07b7690356bd9233a79c1f8b5f4e146cbabc367a19c138d6719a1e0d09328e"
+    },
+    "sound/gug/sight.wav": {
+     "bytes": 76426,
+     "sha256": "210ed86a5d6f9d4e791954fc3a4e4b4b6dc5839d02f7c19d468493a2f87dca64"
+    },
+    "sound/gug/step1.wav": {
+     "bytes": 15494,
+     "sha256": "4e2ce285991bc0d4337c77fdbb029507697ecb4dbf6543ddefe976ea114c4214"
+    },
+    "sound/gug/step2.wav": {
+     "bytes": 15502,
+     "sha256": "27f6f770a52fce5ae04836706e63ef455555de086019a2f9e44d4da1fc99b03d"
+    },
+    "sound/gug/step3.wav": {
+     "bytes": 15502,
+     "sha256": "fcc7ab38a8ec28509d0aa062a3cb93aee6da6a0ae364e4fe0dfad791f54558af"
+    },
+    "sound/gug/step4.wav": {
+     "bytes": 15502,
+     "sha256": "fc52cad29cca2e1fc36f5c6ac7f955ed897d6da4fb5dcf4eefd052e0652d93e7"
+    },
+    "sound/gug/swipe.wav": {
+     "bytes": 16064,
+     "sha256": "90bb5831dfd19f65df19e97f76d858ec940d8e33e0a2ed8fad89a23947e430e5"
+    },
+    "sound/gug/throw.wav": {
+     "bytes": 23180,
+     "sha256": "5e901b94e7be364536603273f18791ab571c46c2fc74263774c0e312f873a281"
+    },
+    "sound/vermis/death.wav": {
+     "bytes": 148016,
+     "sha256": "44b26a9dca5ec8d5e8a7ef2b5e38196b74e4f606cd37b906ee2b2e5b5a85b08f"
+    },
+    "sound/vermis/grab.wav": {
+     "bytes": 88122,
+     "sha256": "09528bd0d49d5cac0c03fe7994b57e572eb89aa8bce63cd0a591130e4b2126ae"
+    },
+    "sound/vermis/grabbed.wav": {
+     "bytes": 51630,
+     "sha256": "99583c88b8ec2959a0d69448aee16ec86b3d9feee6df7841fc32759598349376"
+    },
+    "sound/vermis/grndhit.wav": {
+     "bytes": 36428,
+     "sha256": "1f0e78fa08efb4617b6967a6cc218c56af227c7fd6bf039420d8f106d74fca72"
+    },
+    "sound/vermis/pop.wav": {
+     "bytes": 131420,
+     "sha256": "6284ab02e604b44c5b07225b2a0544c8707517d5fec0024c127bdafef2704f70"
+    },
+    "sound/vermis/sight.wav": {
+     "bytes": 137772,
+     "sha256": "d892117e4602595b6dfb65563b8fa7a3ad2171851791f7c6f47ea4bfece76296"
+    },
+    "sound/vermis/sight2.wav": {
+     "bytes": 106780,
+     "sha256": "6132e2d0db5cfb7a1a064e708d97f7258e2c6ac15c6f4ea8d520641e0ad10f9d"
+    },
+    "sound/vermis/splash1.wav": {
+     "bytes": 30710,
+     "sha256": "f931a2927c13cdb2523dde4550c0af993cc08cbea6e332739f9cf6fe3bd1ff8b"
+    },
+    "sound/vermis/splash2.wav": {
+     "bytes": 25332,
+     "sha256": "b91c69ee695bd71537ed018800f7d89e5e7d95332124f69adee39261d84d7c13"
+    },
+    "sound/vermis/splash3.wav": {
+     "bytes": 25590,
+     "sha256": "99fad2f3815a30ef645a2162ea24e54b4302ba00d7551af9299fde74ecce98e8"
+    },
+    "sound/vermis/spore.wav": {
+     "bytes": 44204,
+     "sha256": "d01a27af99745725dae124d30af18458b2ef323bce93c3cad939310e0f47f6c7"
+    },
+    "sound/weapons/railgf1a.wav": {
+     "bytes": 66260,
+     "sha256": "a3a7edd9c470077682bde595f95d88546d416f300202ae96bd6c6371ec19cf09"
+    },
+    "sound/weapons/railgr1a.wav": {
+     "bytes": 51566,
+     "sha256": "40ce379a835e11561573be1dfdf1806a9bcb27192b94333a126cc721e38bbde4"
+    }
+   },
    "sha256": "8bf25c19172e0f7a63ad30fa14b1a93d335e50270bb1d3bd110d63adae53a3b5",
    "timestamp": "2012-12-11T07:04:08.000Z"
   },
   "pak3.pak": {
    "bytes": 6506790,
+   "files": {
+    "progs/bone1.mdl": {
+     "bytes": 6328,
+     "sha256": "9a00fdc313c40d06b9bb936c5ed0f97b2174cfc6494598cba42fb212d80dfcfd"
+    },
+    "progs/bone2.mdl": {
+     "bytes": 2940,
+     "sha256": "fc25694231ef3cb7567db44cbd080e416526fba73509781eb45c5e9841aa542e"
+    },
+    "progs/bone3.mdl": {
+     "bytes": 34368,
+     "sha256": "9f7a6f1d708b1efe687d675b459c4274143a7da6dd551ed8db83e01700375e17"
+    },
+    "progs/bone4.mdl": {
+     "bytes": 6676,
+     "sha256": "4587bdd40928b25698e89c437624c77cc2c77f32af929ca51a2122d069c8c8b2"
+    },
+    "progs/hive.mdl": {
+     "bytes": 9576,
+     "sha256": "24d505825f72178d41174d481b4ddc1981871a25f5a8d2a6bb12800dbfb57b81"
+    },
+    "progs/rider1.mdl": {
+     "bytes": 1595708,
+     "sha256": "207bb926fefd34b57bb14ec3d9d9a3106bfd58cce3201f1cb5b0d754140f79ff"
+    },
+    "progs/rider2.mdl": {
+     "bytes": 545600,
+     "sha256": "8414d8d62214848b26da3e56e3bb0ac0fc59792e9e473a9f9a4c62bfc0ae3699"
+    },
+    "progs/rider3.mdl": {
+     "bytes": 1110232,
+     "sha256": "6ca363430c2dd5a7484020cdc1e5c0936f544f51bee05d6a569c41efb6ca478e"
+    },
+    "progs/rider4.mdl": {
+     "bytes": 1454524,
+     "sha256": "14c64b22aaec0069b201982e3f126bde71683876ed80f737047f87a4dec6e86a"
+    },
+    "progs/swarm.mdl": {
+     "bytes": 127844,
+     "sha256": "eac005f0b9ff31650bfc81963b0cc3291732fa8366e31c56c5b0d809c880cc17"
+    },
+    "progs/waraxe.mdl": {
+     "bytes": 35856,
+     "sha256": "8b18a468baac0ff4201c63aea1bb2caf4a9f4a327f818567dcdb1c2cf395e570"
+    },
+    "sound/rider/death/clop.wav": {
+     "bytes": 4580,
+     "sha256": "6028b9d195ad93a68ceefcb8aec4370e950a897981989de0b665069c486a281a"
+    },
+    "sound/rider/death/clop1.wav": {
+     "bytes": 4580,
+     "sha256": "28696cdc4d6b356c6ffc1cac5d002bc651aab5b589394883e36d3ccf7f631ffd"
+    },
+    "sound/rider/death/clop2.wav": {
+     "bytes": 4580,
+     "sha256": "b2b9cc8663468d85eebbf71c404b708bed34924e9ca3271b827bc52cca67f20e"
+    },
+    "sound/rider/death/clop3.wav": {
+     "bytes": 4580,
+     "sha256": "b7bb0249d011f6dc154528919a16439a9ded749854b6d6c48bff3e1bc0c1f506"
+    },
+    "sound/rider/death/dthdie.wav": {
+     "bytes": 83066,
+     "sha256": "6625da36c6812b89e44fc5233f919cdb043e975ba63c28e432e6cc98d4d4093f"
+    },
+    "sound/rider/death/dthfire.wav": {
+     "bytes": 70778,
+     "sha256": "c9e9a417835472e4c27063b19f83e051d7311f0cce9321bd5c247f381db1a2cd"
+    },
+    "sound/rider/death/dthlaugh.wav": {
+     "bytes": 25658,
+     "sha256": "86f355417fc2e8bd9609847546ee20163dd0ce9fc9cfb3d153dcb96f212ad188"
+    },
+    "sound/rider/death/fout.wav": {
+     "bytes": 9820,
+     "sha256": "2cdb50e8f08ad8bcf06f49e853ab0ca1fb5cc98b5dd5f3aa008fdc62f2f047a3"
+    },
+    "sound/rider/death/shot.wav": {
+     "bytes": 30278,
+     "sha256": "e563c20fe5cbc6ac4b38775efc4f970d6e8ce3fa62cc2da94b6c2b91e8c196d5"
+    },
+    "sound/rider/death/victory.wav": {
+     "bytes": 38298,
+     "sha256": "d023b32dff8c6c6b4d95649eab7a3ffbaf4b1e05c9e3175ee4f112761e07e3ef"
+    },
+    "sound/rider/famine/_pull.wav": {
+     "bytes": 57686,
+     "sha256": "52106aee04a0248ca5276c8a8e1c82f416c591f2dac08083add05e5218b74e30"
+    },
+    "sound/rider/famine/clop1.wav": {
+     "bytes": 4580,
+     "sha256": "6028b9d195ad93a68ceefcb8aec4370e950a897981989de0b665069c486a281a"
+    },
+    "sound/rider/famine/clop2.wav": {
+     "bytes": 4580,
+     "sha256": "03b337ea1a348380e148ad03e99179fab0dbd1efc7820d45a74e863cdcf36cb1"
+    },
+    "sound/rider/famine/clop3.wav": {
+     "bytes": 4580,
+     "sha256": "afd07556f44f35222216a90235beccb149d74ac6a7cfcd7fbccd77cd76d8534c"
+    },
+    "sound/rider/famine/die.wav": {
+     "bytes": 57028,
+     "sha256": "9abd0716561549eae9b2ab444be276049c530a77e9c087dc9292fc18e0afb285"
+    },
+    "sound/rider/famine/flashdie.wav": {
+     "bytes": 248954,
+     "sha256": "2d8942ef8b88dd64239cddc8b4957d76d647543e50b95115bd76ddbec1f11a2b"
+    },
+    "sound/rider/famine/laugh.wav": {
+     "bytes": 45050,
+     "sha256": "efe0051a1e53d8328ae47901778f0cd19f1db793ef2a8d1c98c92bb71662fb7f"
+    },
+    "sound/rider/famine/pull.wav": {
+     "bytes": 58064,
+     "sha256": "998853d60e5f97150e266e97671c71328bb2dbf8659f9d3653a5684d05158132"
+    },
+    "sound/rider/famine/shot.wav": {
+     "bytes": 30278,
+     "sha256": "e563c20fe5cbc6ac4b38775efc4f970d6e8ce3fa62cc2da94b6c2b91e8c196d5"
+    },
+    "sound/rider/famine/snort.wav": {
+     "bytes": 25850,
+     "sha256": "06f92fc701f8f071c2892cdaf2a1d2ac94c5429033de326a46ef5523cc9d2b50"
+    },
+    "sound/rider/famine/whinny.wav": {
+     "bytes": 26362,
+     "sha256": "404de44803c2ec34721ae2fd6b0bc22b6baaa9d3c27ef88c896a1275846c7cae"
+    },
+    "sound/rider/moan1.wav": {
+     "bytes": 37224,
+     "sha256": "e86190319c4ed1fc539497e010874070b0920ee45abe960baaafabe74df09db1"
+    },
+    "sound/rider/moan2.wav": {
+     "bytes": 33598,
+     "sha256": "aa9dc4112e9343941f146d955227a1114f1d1911556db66e73fed4e39e981832"
+    },
+    "sound/rider/moan3.wav": {
+     "bytes": 35436,
+     "sha256": "b398a3f40b10b73cf63d041ad2de34e83a6c006ef5c50485c377e855fe373e65"
+    },
+    "sound/rider/pest/buzz.wav": {
+     "bytes": 21754,
+     "sha256": "957f1781514ab8e37909ea16813763357839c3d78e6eba2e5b630d3c92c389c4"
+    },
+    "sound/rider/pest/charge.wav": {
+     "bytes": 22844,
+     "sha256": "8c2a74463d2f5c6b32a5ad7f4c4654ca9f786556eafbf7e558b45c6b703415c0"
+    },
+    "sound/rider/pest/clop1.wav": {
+     "bytes": 4580,
+     "sha256": "6028b9d195ad93a68ceefcb8aec4370e950a897981989de0b665069c486a281a"
+    },
+    "sound/rider/pest/clop2.wav": {
+     "bytes": 4580,
+     "sha256": "03b337ea1a348380e148ad03e99179fab0dbd1efc7820d45a74e863cdcf36cb1"
+    },
+    "sound/rider/pest/clop3.wav": {
+     "bytes": 4580,
+     "sha256": "afd07556f44f35222216a90235beccb149d74ac6a7cfcd7fbccd77cd76d8534c"
+    },
+    "sound/rider/pest/die.wav": {
+     "bytes": 50746,
+     "sha256": "aa792d7d708de73ebe752c073376b40528ea2ab955d7b286cd8cdf933a4896ce"
+    },
+    "sound/rider/pest/gallop.wav": {
+     "bytes": 21114,
+     "sha256": "c8e5b5fbe216bcd1a59d5946ca3852302956fd5a6b4d1a7f97a73fc6859376a8"
+    },
+    "sound/rider/pest/hivehit.wav": {
+     "bytes": 16098,
+     "sha256": "ce85b2ec50191cd32697a24ef3afb62a70163116de8c185c2de4d219e2d3f26d"
+    },
+    "sound/rider/pest/laugh.wav": {
+     "bytes": 32980,
+     "sha256": "ba8aaa258dc7b21b52a2aa8316392f9f1edd8429b14253203ca0bbba128eac30"
+    },
+    "sound/rider/pest/sight.wav": {
+     "bytes": 22252,
+     "sha256": "6b4cb4b209546f52a749843ddb18767689159117e9e29f8eb7f1706c3811f022"
+    },
+    "sound/rider/pest/snort.wav": {
+     "bytes": 7150,
+     "sha256": "5af4c6e77675a0f27bcb62779205538e2e6ce4971a84361a494840c555c6b408"
+    },
+    "sound/rider/pest/snort2.wav": {
+     "bytes": 16376,
+     "sha256": "c8df6c3268bd3f2c8ddf0f9db33b410e61b550b2b6c1fc5ad0b4d20383dabe83"
+    },
+    "sound/rider/pest/sting1.wav": {
+     "bytes": 12218,
+     "sha256": "d37886f958b95e15096315a6b83bcf5f735ff5c7bf49c6654d4080978531687a"
+    },
+    "sound/rider/pest/sting2.wav": {
+     "bytes": 11482,
+     "sha256": "185692d83e0565bd5d6e7a15d533ea9032895c7863140275f4d2009e79ff6ad7"
+    },
+    "sound/rider/pest/sting3.wav": {
+     "bytes": 9758,
+     "sha256": "e6f4f6bb9742a7220d06b38c8068d7efbd9708ced0455473840e30a5c0bab740"
+    },
+    "sound/rider/pest/xbowfire.wav": {
+     "bytes": 15450,
+     "sha256": "548adc1347e3f72e83fe31bac1d3ad02efe912d49e96512afbc94ca377d0ac0e"
+    },
+    "sound/rider/pest/xbowhit.wav": {
+     "bytes": 10066,
+     "sha256": "03d93c412e226d7e71077be790ff62afff9fa4306b5335f4e0338b6fd3dc47dd"
+    },
+    "sound/rider/war/die.wav": {
+     "bytes": 75642,
+     "sha256": "16185e29265e20db7fc35836b2adc2ff5ca7ed203a25139f7656244aa8abe238"
+    },
+    "sound/rider/war/fire.wav": {
+     "bytes": 84474,
+     "sha256": "48bddc52358fb6ae4fd362ba0efb103638f9f8ab7776dd0461fd33546b50b3ed"
+    },
+    "sound/rider/war/fire_big.wav": {
+     "bytes": 32762,
+     "sha256": "2fb163e76fe46d966326879399155e045fc35063b2b8a2e55746e082e4bfbee7"
+    },
+    "sound/rider/war/laugh.wav": {
+     "bytes": 31012,
+     "sha256": "a80094ae1273615c5683e4a949a3adbdfce927635af5f5132cc46403a11d9596"
+    },
+    "sound/rider/war/laugh_sm.wav": {
+     "bytes": 20328,
+     "sha256": "9c515335988177e563d7fffb8f77c99790fdaed6631566e94ad0cd3dc74819fc"
+    },
+    "sound/rider/war/whinbig.wav": {
+     "bytes": 50940,
+     "sha256": "871b0b4b5bd3346747587cc435090d6afc978da07711cd819858b911358b1b6a"
+    },
+    "sound/rider/war/whinny.wav": {
+     "bytes": 20762,
+     "sha256": "a6b16598912d06b03c6e1f974c2b8ab4d8e1486f8785e25d68336d2e22ec55ca"
+    },
+    "sound/rider/wartrot1.wav": {
+     "bytes": 7478,
+     "sha256": "abac0cfb4bf02364e795b83197ca563c2e158d93eb9f6999cc258c12fc8a1ecb"
+    },
+    "sound/rider/wartrot2.wav": {
+     "bytes": 8920,
+     "sha256": "83f6abaced3124b50f760c666c5902abcb57309f951308ad30d0fbc7f8cf562e"
+    },
+    "sound/rider/wartrot3.wav": {
+     "bytes": 11324,
+     "sha256": "42af6fefd6b10d38f42d9987be5ccb71d595440a881fca4f492a5562f50e4bda"
+    }
+   },
    "sha256": "9a58d294e79806fc15293163ba9954f7d842238c3040aa753f497c5fec2e8473",
    "timestamp": "2012-12-11T07:01:28.000Z"
   },

--- a/json/by-sha256/1f/1fc580568b0d3de845e2c43961ba659dd8a32ff8c7b0606ad5e56280f80e2fb1.json
+++ b/json/by-sha256/1f/1fc580568b0d3de845e2c43961ba659dd8a32ff8c7b0606ad5e56280f80e2fb1.json
@@ -22,6 +22,48 @@
   },
   "pak0.PAK": {
    "bytes": 9722508,
+   "files": {
+    "gfx/env/dragonheart_bk.tga": {
+     "bytes": 637657,
+     "sha256": "3e59851504695b76177984e70ac5486c6d73e79e12aa5c6d1541186ddfb64e35"
+    },
+    "gfx/env/dragonheart_dn.tga": {
+     "bytes": 788950,
+     "sha256": "06bf487a9aea1259912f723e8ca6424039403515bad5ef0335297f000b70fb46"
+    },
+    "gfx/env/dragonheart_ft.tga": {
+     "bytes": 734137,
+     "sha256": "6accd2b017d77be2202a5a0076eb59b6bf92277e73c340f03ec82a74e5ee62ce"
+    },
+    "gfx/env/dragonheart_lf.tga": {
+     "bytes": 642705,
+     "sha256": "b722bf077a38460b05113b378dc7bf927d2100cac45692e8fa0b1644f51a465c"
+    },
+    "gfx/env/dragonheart_rt.tga": {
+     "bytes": 677781,
+     "sha256": "01092ba73021ef5ebf75d4287ee791f577faed09f2cbbdd5bc4b0bf5278c3c65"
+    },
+    "gfx/env/dragonheart_up.tga": {
+     "bytes": 349636,
+     "sha256": "4869b405ad06d8721e75dc9ec2b2035fa6d5ee7b3c53718d48b3cc3cbe5f4261"
+    },
+    "maps/e2m5rmx.bsp": {
+     "bytes": 5031272,
+     "sha256": "ca4432d8eaf746744661e6a53c9cafa377bf6c2806f597599411287b16e25a58"
+    },
+    "progs.dat": {
+     "bytes": 416660,
+     "sha256": "966219afd9f7021b2f3839562fc10d170c35af5ff8a8bf79fb6095f14e745f0d"
+    },
+    "sound/ambience/evilwind_2b.wav": {
+     "bytes": 71232,
+     "sha256": "fc0f5ca2fe935e3f053123bc3b773c3aea0ef0fd7a8ce5834ccbe77340a1c9c7"
+    },
+    "sound/ambience/maydn2.wav": {
+     "bytes": 371826,
+     "sha256": "5ee52baf8266d29d648722d405cee8f029b057749bd7d67b8e3f35fe3925432e"
+    }
+   },
    "sha256": "b79ef3035c34ec7394618ab50e15faa1f3411c1049144eb0771d4a9e86d7f6a4",
    "timestamp": "2008-07-01T02:24:10.000Z"
   }

--- a/json/by-sha256/20/206eebfe1d533ec1e119a2af64bb79432db31de31bcdae17752cc2aa4a218c73.json
+++ b/json/by-sha256/20/206eebfe1d533ec1e119a2af64bb79432db31de31bcdae17752cc2aa4a218c73.json
@@ -16,6 +16,60 @@
   },
   "pak0.pak": {
    "bytes": 13717976,
+   "files": {
+    "maps/coagula.bsp": {
+     "bytes": 956912,
+     "sha256": "82466c6cbb7b452172e1c210028bcd690aa8ddd7532c5e090d04542b53b4076b"
+    },
+    "maps/coagula2.bsp": {
+     "bytes": 933028,
+     "sha256": "1bdbc039a48c5230f7aa84cf60de6c2f5461b934b4d8af3e8cd04de4a6500337"
+    },
+    "maps/coagula3.bsp": {
+     "bytes": 1763840,
+     "sha256": "59c9ab420456cdf5190c4ddd75399595d13722ba65542fc63ce0ea76b34ab02c"
+    },
+    "maps/cogstart(2).bsp": {
+     "bytes": 1021380,
+     "sha256": "02eccde7276d3e4902c5665499db9c2b62ab158acc5be2182d1d3eaf3a0c1202"
+    },
+    "maps/cogstart.bsp": {
+     "bytes": 1021120,
+     "sha256": "a8789034bd1286db08339190681fb2d0be83fbc3132f9189aa3e0dd457731697"
+    },
+    "maps/dilcoa.bsp": {
+     "bytes": 913160,
+     "sha256": "642ec01148fdcdf1339a0c7e4b09a4e23bd0942e8431212660ada5bf18acc0c2"
+    },
+    "maps/fc_coag.bsp": {
+     "bytes": 722692,
+     "sha256": "3b4a5cf33ba9db8242c10b75cdca06048a581663bbdc275c2e5c4851dbd5629b"
+    },
+    "maps/ne_empty.bsp": {
+     "bytes": 2973436,
+     "sha256": "4309b9566b384a50cd4f9cb9a88042fb3bcefe82d51daf85e312c902b9ba771a"
+    },
+    "maps/scream.bsp": {
+     "bytes": 905796,
+     "sha256": "7d30a5a049cd21675967f088b03383b82373e8e5a0f9719db7594dc6a9a9071c"
+    },
+    "maps/terror.bsp": {
+     "bytes": 2009572,
+     "sha256": "04283256bb024ba6a09204c0b818592180b1ca0876b134c2d23355b6e739b006"
+    },
+    "progs.dat": {
+     "bytes": 416464,
+     "sha256": "a7a768e63bbab6943896727666a99312d0e8ff6963888d9071a4f7be7e166709"
+    },
+    "sound/trains/lock.wav": {
+     "bytes": 30522,
+     "sha256": "87b4dc7084ed54d67da50b13571567ffc5ee707ebcbd83d82f09abad5b77aeb8"
+    },
+    "sound/trains/release.wav": {
+     "bytes": 49210,
+     "sha256": "1339b779920c9c8f3393b591b339c9b90bb61499c31f4ef66541170f59b87605"
+    }
+   },
    "sha256": "7d525badc159dd529407f31026ecf0a37a1b5340b2408fbff913b7b45c9bb90a",
    "timestamp": "2002-01-22T20:42:20.000Z"
   }

--- a/json/by-sha256/20/20964bc862cb18ecfe6a341c39ed1efa8b919fdd32894b97991a9d6ba6dbf469.json
+++ b/json/by-sha256/20/20964bc862cb18ecfe6a341c39ed1efa8b919fdd32894b97991a9d6ba6dbf469.json
@@ -18,6 +18,16 @@
   },
   "fmb100/pak0.pak": {
    "bytes": 6163984,
+   "files": {
+    "maps/fmb100.bsp": {
+     "bytes": 5747944,
+     "sha256": "94af7eed16f438cbc90aec39f21687a085d3ff16f82eafa0683d37858c6f8636"
+    },
+    "progs.dat": {
+     "bytes": 415900,
+     "sha256": "2176d4d1abc10be59625a195a57848cfb1196c1a8e1e986c3460589c57a6e377"
+    }
+   },
    "sha256": "ac369f0f58a62ab10bfda47b02d11ecf280ddfd89b957f4d70e52f406135c4ec",
    "timestamp": "2004-10-14T18:32:06.000Z"
   },

--- a/json/by-sha256/21/21298b607b18a815273ffa93d010d31ca1ea71bf62d66ab7c888bdd38d2d845b.json
+++ b/json/by-sha256/21/21298b607b18a815273ffa93d010d31ca1ea71bf62d66ab7c888bdd38d2d845b.json
@@ -12,11 +12,171 @@
   },
   "pak0.pak": {
    "bytes": 26464393,
+   "files": {
+    "gfx/env/grimmnight_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "59be3026e6030ebcb4f301dc27569da94866569bd264990d5b68c0c0470be470"
+    },
+    "gfx/env/grimmnight_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "6d9b33f83ccf56f92abdf2b1197ce5fa8a3979f8b40793a73219618b8f46c33d"
+    },
+    "gfx/env/grimmnight_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "0e1892d4675a0630cde9a1a1453fb936b5fd4f62c97a91fde60778d94bced01f"
+    },
+    "gfx/env/grimmnight_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "c69dca07d21151d7ea43527494687f3951715d692ed616af3a059f01481204cc"
+    },
+    "gfx/env/grimmnight_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "bf2c9897af366d36efc11de39c051f3345ceeb6d38845be71b712c9403d726e7"
+    },
+    "gfx/env/grimmnight_up.tga": {
+     "bytes": 3145772,
+     "sha256": "e4e35e286d93770157119d60889ff0d2df08fa13ccafa32ea26884e31a1344bc"
+    },
+    "maps/fallen.bsp": {
+     "bytes": 2987760,
+     "sha256": "79e02e2b70d5501b3d0d5ee85ff7b10cb222e84c8b4a722f635ce93dba853224"
+    },
+    "maps/fallen.lit": {
+     "bytes": 1263296,
+     "sha256": "17e9ef7912157fefc5b662c55019c9d8c2eb860a468a7d8e4f7d11f7709cadea"
+    },
+    "source/fallen.map": {
+     "bytes": 2421159,
+     "sha256": "a4a29d3871b8d3e60818b18b6c9f50862a1c6ed11b95a052923451360b6a34b5"
+    },
+    "source/retrojam1.wad": {
+     "bytes": 916972,
+     "sha256": "20c642029b76d6a86c02ec8cbc4a1dc1a5e2bf0332a9aff1809153733b9a79d9"
+    }
+   },
    "sha256": "35bc5a81429b5da1403fb9b6e4007cd17331127fb477f1e2cf3389e10f3e3f3d",
    "timestamp": "2014-11-29T18:57:24.000Z"
   },
   "pak1.pak": {
    "bytes": 733727,
+   "files": {
+    "maps/b_batt0.bsp": {
+     "bytes": 6980,
+     "sha256": "0d481a2e2cd7a23e4ef19c19622195007bd6c9a67135ef739b0944a02d46fcd7"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6964,
+     "sha256": "34709c1c06ca34305a8ba1d4799d1cdc07e44ff33f3c7fa11c3d5933cb942579"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 7124,
+     "sha256": "d3371655bed274070fa98fb32b408bab4a22fe754f5158c8c94a072749a5d24d"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 7764,
+     "sha256": "abdfe383c13da6d5dd7a9409fa5d3db2c4bac78482eb75c2c2b42da7811ec3ca"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 8788,
+     "sha256": "2343448faac29720e3a690650b70623852710dcae002917ae5772fa597117e17"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 5604,
+     "sha256": "66ea23f1cdd6225afdd1b7cf1247b93d174562193e0807561b96b659429f2bf0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6820,
+     "sha256": "366ece777ae71ecfebaa9f4bebafe2074b5336e7939900f46bd9521886f9f42d"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 7092,
+     "sha256": "56a66aa3d1364a0436ff8ce880268b2a9c2c396ab02f0c6277535d5b99eae31a"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 7636,
+     "sha256": "ddd60cec57d8e3954c1ffce616ae862edb784417a6b6622cc001d408383a6cb9"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 5396,
+     "sha256": "fe60bd7880da73571e29fa4075968cccb06e913bd2b9475868ce31c69b1a8c19"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 8436,
+     "sha256": "6a2c2c3fa6f88d425ae5b9568e5d8224ee901a1d8faa8363b88fff569b7d0e5f"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 25812,
+     "sha256": "1ba9d3176bb2e03a0457427fd9394d8c15eb9ebae8af9462e955e9c6c6068513"
+    },
+    "progs/dog.mdl": {
+     "bytes": 460652,
+     "sha256": "52cf8cb501f4b1ed457961b798eccd86974720af29f559723be82a0886824fd9"
+    },
+    "progs/end3.mdl": {
+     "bytes": 19700,
+     "sha256": "445af16e28fff506ad65fac16b09dad1672e218ffe0183880aff565578b315b8"
+    },
+    "progs/end4.mdl": {
+     "bytes": 19220,
+     "sha256": "cf52525422a102760bfcabd6e8dd5c5df7c2028daea5baa2a1b1717648dd143e"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 3860,
+     "sha256": "256412b0d88c020fb03efc5e914c5dd721c9dfe8d6a36ce4a7b01e7597d7e7d5"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 7108,
+     "sha256": "d4c5b6316aa02d600951c6a8ec1f4682568b9e877e988cf4cedd77c0e95cf663"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 21412,
+     "sha256": "1274fcabffa89a786b29c9238cf84e95a8557369239b4a9eb813e3dbe37d35ac"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 5492,
+     "sha256": "ecf293b2e8146a33de7bc8bb3cded80bb785b931012b40dca204db3dad50e776"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 22052,
+     "sha256": "c5657b558522e46f0833b7827520c1a5c1f1674dffd52c12609779d5bcd75462"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 1396,
+     "sha256": "945ad552ad86e5193ef9c007dbe23686fbe89be1060063f57ea693b89e5df229"
+    },
+    "progs/spike.mdl": {
+     "bytes": 1396,
+     "sha256": "c5e6afcfbfe35ffde5bda7eaf91e2a583c3f20cf8f3175b4f4e0ad03b358983c"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 9012,
+     "sha256": "06e8f32092cbc0b5ba4d26227df9ac2d10f3a76d9a63bc7928af147b4ade12d7"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 6356,
+     "sha256": "40d9d29c58df57ece6892d71d0464022eb5939aa45699e98eae22136b973c4c8"
+    },
+    "progs/zom_gib.mdl": {
+     "bytes": 19768,
+     "sha256": "2175cca881b4a73adf3742933a5d3e91116c774ddd3db9b6ac2a7f863194d4a8"
+    },
+    "quake.rc": {
+     "bytes": 1319,
+     "sha256": "23d89f55c4aeec778b24e215ce38088b1ad23525c006f09a18ea433d93a03380"
+    }
+   },
    "sha256": "3187c1ca1a70b1a57c64d69c6d04237eca38722b8281200bb9cc209b5c77b9b8",
    "timestamp": "2014-11-29T18:38:26.000Z"
   }

--- a/json/by-sha256/21/21b208d26a7d87a50a8c2644d236ccd58a92af7294bd44c59edac9a3d8cec40a.json
+++ b/json/by-sha256/21/21b208d26a7d87a50a8c2644d236ccd58a92af7294bd44c59edac9a3d8cec40a.json
@@ -27,6 +27,500 @@
   },
   "alk13/pak0.pak": {
    "bytes": 7225027,
+   "files": {
+    "maps/alk13.bsp": {
+     "bytes": 2354476,
+     "sha256": "36c09c2c5465129d22c2fc4bebfaf6ddb9b59a5147f20ddee256dbd725149b62"
+    },
+    "progs.dat": {
+     "bytes": 705964,
+     "sha256": "2b7d653d553e5c6122b2b1a8f6fe0f869c1a83ec6950163acc7a19d360414d12"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 106244,
+     "sha256": "2ca415ec913b3c05038c6db21f9235edf7eefe7cf41120edead53efb90ff0ef4"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/hkboss.mdl": {
+     "bytes": 323272,
+     "sha256": "75666ba526027224aa6304af2737a5e957184f4522e12a0476940744d24c5a85"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/knight.mdl": {
+     "bytes": 153400,
+     "sha256": "26576f139d258b3c236faa6552d8ba09ef6e14480d4a2e2dc9e3e2c4df5177b6"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "fae8fac60b899d78a929ada720c591b7356e78cdea074f1b128f465d47fc4d8a"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 132028,
+     "sha256": "8824603b325f37bbba424f55c3ff900c21ccf61c77ba97e636e91ef99202364a"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "744af1fafaacb751cf2e5ce4bb15a0fc1fb938ae519469de6f0dccfe9f320414"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "ba9f52e66ac380306d443e07ee4f1fac92793cba55394c01590c3dd088042e78"
+    },
+    "progs/wetsuit.mdl": {
+     "bytes": 55156,
+     "sha256": "4e4dc7331c374d2345c3d755ff34b61850c289741314b10fa36c461db3844e99"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "sound/ambience/drips.wav": {
+     "bytes": 80712,
+     "sha256": "96f7890d2fea2f1f6443d0e75bb6084f39931e7c5399a6e75787dec4eaba5033"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 25852,
+     "sha256": "02d097f0a58cc65826bde1ebe5c3450a4ab92d09b16e85ad916f62dca82936c9"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 91138,
+     "sha256": "ffc3f8d7386db7766c885706a1247926f870957d4a3e55cd51dbe4d55416338f"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind.wav": {
+     "bytes": 44582,
+     "sha256": "1b0b9f054d82c238128b821c41bdeba0e81a436f37c1aec92d2e1dfd7be61c6a"
+    },
+    "sound/ambience/wind_high2.wav": {
+     "bytes": 91138,
+     "sha256": "ffc3f8d7386db7766c885706a1247926f870957d4a3e55cd51dbe4d55416338f"
+    },
+    "sound/ambience/wind_low.wav": {
+     "bytes": 58476,
+     "sha256": "0759ad526d301c3bb14c467818bacdbe3a64237657c45a435e06cb166b570b85"
+    },
+    "sound/ambience/wind_med.wav": {
+     "bytes": 32212,
+     "sha256": "005616904ebfec049860ca33b790903e76c75615f3048dba17ce8d85cd6c65f5"
+    },
+    "sound/ambience/wind_rumb.wav": {
+     "bytes": 63234,
+     "sha256": "24760cbf8622bb933fcd59e847067de3581f6a3d54db72bcb3f864d2cf508a36"
+    },
+    "sound/ambience/wind_rumb2.wav": {
+     "bytes": 32872,
+     "sha256": "9c77014eb35b692af657a524f1e7eb82b1b1ebe9d95c62462e6f6925baf4153a"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/adeath.wav": {
+     "bytes": 11714,
+     "sha256": "c6d2e6a1107eddcb49ca41776da1c7f8a3b27766b66dbf4bd9186fba2780cb2c"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/apain.wav": {
+     "bytes": 3302,
+     "sha256": "788466ee8cc368bcac8b07c4eeca5509ccddc30addf5a322b31a605d90bf0392"
+    },
+    "sound/axeman/asight.wav": {
+     "bytes": 8528,
+     "sha256": "d5d1a9125b9a015186d6d5e9fbd9f9d9db3fb220bdf9139f5aa73b9019d37126"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/snakeman/sdeath.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/snakeman/spain.wav": {
+     "bytes": 34452,
+     "sha256": "15b84d6adb80e4ceace4226b5185c578a752adb36f213f2488e80ad2192378aa"
+    }
+   },
    "sha256": "e7dd8bec306499398c7e806846d37233d047c4be83687d10cb57241f087e9d37",
    "timestamp": "2001-08-07T21:01:28.000Z"
   }

--- a/json/by-sha256/21/21d33c8a494b6c569696e156f36ce43485c3ed1db4ae38f2f7722e71db83404b.json
+++ b/json/by-sha256/21/21d33c8a494b6c569696e156f36ce43485c3ed1db4ae38f2f7722e71db83404b.json
@@ -579,11 +579,63 @@
   },
   "pak0.pak": {
    "bytes": 376996,
+   "files": {
+    "progs/end1.mdl": {
+     "bytes": 20820,
+     "sha256": "2155d92a5244e4ddb237e46e64e38f09bb47141fcacf4ac1a06df1553f830858"
+    },
+    "progs/end2.mdl": {
+     "bytes": 40980,
+     "sha256": "f46f9a8f6f036fb66210ade338f9e76729d286fe8f73e1ae23a065382567de9a"
+    },
+    "progs/end3.mdl": {
+     "bytes": 19924,
+     "sha256": "c35c0c65e52b5de27175137fafb68751e3132675db529a1e80707eceb5dd6aec"
+    },
+    "progs/end4.mdl": {
+     "bytes": 26932,
+     "sha256": "001a69b25785d05678348ff2edea63e125c8ee07cb379fd03fe66bd720d5962e"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 39992,
+     "sha256": "33aa3cb25d9dd2a40fa6082e7a8bcb3102c79fecdef2d945566b28ca6bbc3869"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 98148,
+     "sha256": "4936d42d121421090e8353010e0eb9ed89a53871a8e440a960b7cff049f948dc"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 57040,
+     "sha256": "7641643c47254d8bc72331ff90dee511cddfcbf03aaaa43f0cc7f35a4329ecdb"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5570,
+     "sha256": "c404a7d2f09b9e269a9df6d19396efe57b281f8eb79457b69ea4ab88a7d0f55a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 33108,
+     "sha256": "1504f451e4b8e02b8080014f79b11a34bdbcaab0b8e11a0427c0c5a7572ed796"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 16288,
+     "sha256": "1ef4281197016a2025b5471143ae5f5b8fd98c0fa8def4ebd6e89fa362753ae9"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    }
+   },
    "sha256": "55718198120ef8e4f226ac017c36525bfe32d03598f7212a4fa55fba9e68a865",
    "timestamp": "2017-07-31T08:08:02.000Z"
   },
   "pak1.pak": {
    "bytes": 28792,
+   "files": {
+    "sound/misc/h2ohit1.wav": {
+     "bytes": 28716,
+     "sha256": "6c09801196face40592eff614d26a38dfbc86dccb37ea537c59f7eadc3eddd15"
+    }
+   },
    "sha256": "d2edc44497ada4184e15640035bbe965cb579c7eda880816b5300fd7342f2187",
    "timestamp": "2017-07-30T23:50:16.000Z"
   },

--- a/json/by-sha256/22/2286bf5979843f36a6ba20440e9f897abe02e4b5cc65299b36f55599363afd25.json
+++ b/json/by-sha256/22/2286bf5979843f36a6ba20440e9f897abe02e4b5cc65299b36f55599363afd25.json
@@ -476,16 +476,10342 @@
   },
   "pak0.pak": {
    "bytes": 270100152,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 94990,
+     "sha256": "1fddba1dadd3adef5e0f13d716e514c131455c51b26c2291f71dea0eada7b97e"
+    },
+    "effectinfo.txt": {
+     "bytes": 157535,
+     "sha256": "8dbc7cf30b0bef166f0ce58a59c0f3ce1dcadd9a13867f8430541793fd723cf8"
+    },
+    "effectvanilla.txt": {
+     "bytes": 4612,
+     "sha256": "efd47c12bf71b377f3e750f46d5e242b3337ece446ba9a44cc0750a9bbf9c758"
+    },
+    "gfx/ad_blank.lmp": {
+     "bytes": 584,
+     "sha256": "37b5a1e7d0b3882eb7504e3626f8040a19a6d403e0e761dccd65db935401144f"
+    },
+    "gfx/ad_ibar0a.lmp": {
+     "bytes": 2568,
+     "sha256": "7a66fbbaa742e59d3fdd939ce35befa0f633492482912f4fa91f16d0788276e6"
+    },
+    "gfx/ad_ibar0b.lmp": {
+     "bytes": 5128,
+     "sha256": "5a955a32f0227e4d3e90e908e650c7dc53138b5db2d5bcb3eb4a14fe5c568760"
+    },
+    "gfx/ad_ibar1a.lmp": {
+     "bytes": 4616,
+     "sha256": "eb1c6337becc5c245b873b3d9a6ba5e9c458147f48826a4580ea0ffdf57e9759"
+    },
+    "gfx/ad_ibar1b.lmp": {
+     "bytes": 3080,
+     "sha256": "34e3eec992a3f567d4ac83c98d5fc53ca0a90c02764d45a40eea08d2f94c733b"
+    },
+    "gfx/ad_ibar2a.lmp": {
+     "bytes": 4616,
+     "sha256": "eec2d035f2857fc03083ccf0384ac6446f71b1aa45ed0e2409b8d4ba42c135f6"
+    },
+    "gfx/ad_ibar2b.lmp": {
+     "bytes": 3080,
+     "sha256": "17c35d1d02833d1fe900b1c2beaf77ffe1948a3f17ae790e9f0da1c1057b460c"
+    },
+    "gfx/ad_ibar4a.lmp": {
+     "bytes": 3080,
+     "sha256": "2507c6ce0a53ed62ce73b1bb0ee7e76e9c245757dee54415aeef78767bace887"
+    },
+    "gfx/ad_ibar4b.lmp": {
+     "bytes": 3080,
+     "sha256": "d977ecb360eff9b19827e956d32687234bed64f830adc5e506334a597daa7eaa"
+    },
+    "gfx/ad_ibar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "9d0d2c1eb7e665d0a28130bed09fb8bd698a6a1b246842fa353e3b0e1f5b445d"
+    },
+    "gfx/ad_ibar5b.lmp": {
+     "bytes": 4616,
+     "sha256": "26902c5879207315a7b732e8799f95bdcd45801a8086a902371808a594fa5515"
+    },
+    "gfx/ad_ibar6a.lmp": {
+     "bytes": 7688,
+     "sha256": "cfcce1c48cda88ccd405b1398576476bae52b3cdf7154a0b902a47655dd282cd"
+    },
+    "gfx/ad_ibar6b.lmp": {
+     "bytes": 7688,
+     "sha256": "49487400a56db767d37656f8ccb9e1660f470d8f989619a86bec5c296dcb77f9"
+    },
+    "gfx/ad_ibar7a.lmp": {
+     "bytes": 6152,
+     "sha256": "0d4ababef9a115ca7f6739a01d288d237e22a859ee16c5682d97dcabc4d7aa0b"
+    },
+    "gfx/ad_ibar7b.lmp": {
+     "bytes": 5832,
+     "sha256": "f9292e8d1fff09bde28baf932f11617e27247d4e9af191b89c30811e92110bca"
+    },
+    "gfx/ad_ibar7c.lmp": {
+     "bytes": 4104,
+     "sha256": "0e77dc6602c4945d5d4ec2a12f8003173430945bf7891d979c3c80b0c9212b40"
+    },
+    "gfx/ad_ibar_cell1.lmp": {
+     "bytes": 392,
+     "sha256": "5a4409731e4302bca5245f385a1cab9b91e0a2677d52336bbe3650fdcf070b05"
+    },
+    "gfx/ad_ibar_cell2.lmp": {
+     "bytes": 72,
+     "sha256": "6a519b1e8eed1d7a5365231162fcf1beaf31a6fd1c39b07de09bb0e66dc38303"
+    },
+    "gfx/ad_ibar_nail1.lmp": {
+     "bytes": 392,
+     "sha256": "850189c70ac92f3e8ee79ed9ff6e31ee73d33b5616964461373b37e3a29e60b6"
+    },
+    "gfx/ad_ibar_nail2.lmp": {
+     "bytes": 72,
+     "sha256": "b36d5196c807c6325816db9efad9a16fd7e38433f277b0ad9e6d3551f95c0ceb"
+    },
+    "gfx/ad_ibar_rock1.lmp": {
+     "bytes": 392,
+     "sha256": "f74ce0037116022557ec3a50d368442e73cb48492990a07e93503ad9aeeaa225"
+    },
+    "gfx/ad_ibar_rock2.lmp": {
+     "bytes": 72,
+     "sha256": "081911a352b3d75a4be7812082eee782c41127e70bc4a06585b163d385230a65"
+    },
+    "gfx/ad_ibar_shell1.lmp": {
+     "bytes": 392,
+     "sha256": "733750fbc8235b236f7a2a4246d6112c0a09ce2f75529e359382e25dab92ee10"
+    },
+    "gfx/ad_ibar_shell2.lmp": {
+     "bytes": 72,
+     "sha256": "22fc2a46e85e76836fa38db9868820322833b45e0473407d69378dc09b43e9a5"
+    },
+    "gfx/ad_sbar0.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar1.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar4a.lmp": {
+     "bytes": 4616,
+     "sha256": "5ecbd1e480e4c04e2efe956dcd49e609f0c5a2038f03759b9af848b3cf7dd613"
+    },
+    "gfx/ad_sbar4b.lmp": {
+     "bytes": 4616,
+     "sha256": "8fdfe5e6ffba2c209386580adc196acce9d5601fb529f651267e7186610cc392"
+    },
+    "gfx/ad_sbar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "40c7f9e7ba975d500d3861d0c5a7e592da1ce09fdc31583488fd4c78d823e20e"
+    },
+    "gfx/ad_sbar5b.lmp": {
+     "bytes": 2312,
+     "sha256": "86ff0d9678a52e5428089afe0bb9cdddc9f7688798cee45a396e4d13bf00b60d"
+    },
+    "gfx/ad_sbar6.lmp": {
+     "bytes": 9992,
+     "sha256": "5b47dbc1ae645c429627f563355c43b1fb9145d195d02606d0a7a49791034a28"
+    },
+    "gfx/ad_sbar7a.lmp": {
+     "bytes": 3464,
+     "sha256": "8773683e2edb20dfdea61775d6f955a766a15b7b733ae07212dec922d853f6ba"
+    },
+    "gfx/ad_sbar7b.lmp": {
+     "bytes": 3528,
+     "sha256": "1103f097b9896700ef5a722df927cbe71c76531a09eda9e55e5702d3b4d3b370"
+    },
+    "gfx/ad_scorebar0.lmp": {
+     "bytes": 7688,
+     "sha256": "7c479c4969b9f437c57d710edbdd6b2ce1936aa95adb559c9dd3048680868cdb"
+    },
+    "gfx/adf_1.lmp": {
+     "bytes": 584,
+     "sha256": "5b1b35dc96ad9c2f62602caab6be13d8698fe6cc14865293d11c6b9eee64dd51"
+    },
+    "gfx/adf_2.lmp": {
+     "bytes": 584,
+     "sha256": "8cbc05801d49423bd5f14bd459e8ed5cff7841e7f2d5e44d0f4dfe0f0f7ee851"
+    },
+    "gfx/adf_3.lmp": {
+     "bytes": 584,
+     "sha256": "f0155a41ad9290c8df9fabe0faae6dde4d04772dd2a425653766ec36da76140f"
+    },
+    "gfx/adf_4.lmp": {
+     "bytes": 584,
+     "sha256": "d74c9370ce323ffdc9c3dd124dcbbf9c15fc94e58e20d15789975dd8701a74da"
+    },
+    "gfx/adf_5.lmp": {
+     "bytes": 584,
+     "sha256": "f97a78ede874ff45176e5bb85abdbed93e22dab28bc0965065927c7b215ea36f"
+    },
+    "gfx/adf_evil.lmp": {
+     "bytes": 584,
+     "sha256": "42445b083abae6e9f4ff009efd7a38d2ddd664ac5e47f97ad30c88a603c64c35"
+    },
+    "gfx/adf_evilinv.lmp": {
+     "bytes": 584,
+     "sha256": "ff0d8b9203d7cfae6d075ef5bfad60cdcf66b1e24bb6fd02be0cada1b7f1c82f"
+    },
+    "gfx/adf_evilpent.lmp": {
+     "bytes": 584,
+     "sha256": "0b0029bc964ed68f1b46ccf0b4bd5e527e33e76c0904a1d06e623c47ca589e56"
+    },
+    "gfx/adf_evilquad.lmp": {
+     "bytes": 584,
+     "sha256": "a511796cca84df8149ea6d3d280880e425fdd486315159462168d32f06a17822"
+    },
+    "gfx/adf_inv2.lmp": {
+     "bytes": 584,
+     "sha256": "a6caf84d4e2c125e80aefb51aaa1af707ccf689e641141dd3736f101a66c8fa0"
+    },
+    "gfx/adf_invis.lmp": {
+     "bytes": 584,
+     "sha256": "70117297f381fd1778e5d26e5b832af86c6013ca9a55632c24c057e0aaa1e48f"
+    },
+    "gfx/adf_invul1.lmp": {
+     "bytes": 584,
+     "sha256": "453b67ccc01b32101e1051a9407b84b5c93416ae30c3b3200e25b96868c3f6e5"
+    },
+    "gfx/adf_invul2.lmp": {
+     "bytes": 584,
+     "sha256": "c70f600538aa1d1cc121ea76602e564d0af5ce5ea67a2c1ba01ac5fe44439bd4"
+    },
+    "gfx/adf_p1.lmp": {
+     "bytes": 584,
+     "sha256": "f6da35fd9699239c060f034738615ecead6111294a419a82e503bdbdd9ed46b1"
+    },
+    "gfx/adf_p2.lmp": {
+     "bytes": 584,
+     "sha256": "431539dd9656e09c6d4007c86bad37c30447e596575d803619b14371329f9acb"
+    },
+    "gfx/adf_p3.lmp": {
+     "bytes": 584,
+     "sha256": "b832a2d2143805f8701eec7eec465d67fa692e2e87714e87fa3ac3a2c2682659"
+    },
+    "gfx/adf_p4.lmp": {
+     "bytes": 584,
+     "sha256": "40f6d70d3ebf248c1c38e90b95cec42516b3a61fd17bd866df964af8e657487f"
+    },
+    "gfx/adf_p5.lmp": {
+     "bytes": 584,
+     "sha256": "d7d4768f7324d1eca2b8cb95fd250d8c6065dcfc5c392c6f2bc6adc8c2a7579a"
+    },
+    "gfx/adf_quad.lmp": {
+     "bytes": 584,
+     "sha256": "da9a83f464049832cd049205a22d832a228b00cbd0d1e7e24d347d5ed34c4ffb"
+    },
+    "gfx/adib_atank.lmp": {
+     "bytes": 264,
+     "sha256": "8d963c818c0554d73d14b251eeed0321cf854777f29eddf5a82ee3fb3fde8035"
+    },
+    "gfx/adib_axe1.lmp": {
+     "bytes": 264,
+     "sha256": "90b6817aa64570e9bfc36a13e6dd1930e81468f931ceac9f2ae3790f99f2dca2"
+    },
+    "gfx/adib_axe2.lmp": {
+     "bytes": 264,
+     "sha256": "2b0821038185e41c711e399dcfff37fd54aa8f7473ba81754c379fae558a5a1d"
+    },
+    "gfx/adib_bbelt.lmp": {
+     "bytes": 264,
+     "sha256": "8b50ea739ca8ab52baefe65f90ea5943fcc4f05b63b214a36b3ae6fa4feb55a8"
+    },
+    "gfx/adib_ckey1.lmp": {
+     "bytes": 136,
+     "sha256": "8525e145fdc72947ac6d4599ae0304b84793475d44f0113c925905d715c2da8e"
+    },
+    "gfx/adib_ckey10.lmp": {
+     "bytes": 136,
+     "sha256": "a2e14b68c10109e48e86bd095775beb68f03640dfdb12d1c28b6d32abd1fa329"
+    },
+    "gfx/adib_ckey11.lmp": {
+     "bytes": 136,
+     "sha256": "2b9191d85075d6a6c06d8b295c48546ecc0bd1c91a860308f6f953dcf324604c"
+    },
+    "gfx/adib_ckey12.lmp": {
+     "bytes": 136,
+     "sha256": "9b04f101468d96f4c39d97da0be44f7152179e4a8d6a05762ca693c9f84db317"
+    },
+    "gfx/adib_ckey13.lmp": {
+     "bytes": 136,
+     "sha256": "35fa377dbf162d691de012a61458b5ec29c28b776cd3ee0e0f9ab0ad57b67c8f"
+    },
+    "gfx/adib_ckey14.lmp": {
+     "bytes": 136,
+     "sha256": "ea6b831467c97fb0ba18d97a549c54304b133830e1567ae300e83514bdbb2919"
+    },
+    "gfx/adib_ckey2.lmp": {
+     "bytes": 136,
+     "sha256": "5c80cec0c7808ed141fff4f6863eccfa71b06a7405e871c75912d5d065b4ff21"
+    },
+    "gfx/adib_ckey3.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adib_ckey4.lmp": {
+     "bytes": 136,
+     "sha256": "51ea09fa8db26de3ce6ea6c1a5abecf4c31c3877ab6c508811ea9b271f40f1fc"
+    },
+    "gfx/adib_ckey5.lmp": {
+     "bytes": 136,
+     "sha256": "e03ed662e981530264f6dcf6f6dda91fd8406c0941d0f7c4370a89e0c4f467bc"
+    },
+    "gfx/adib_ckey6.lmp": {
+     "bytes": 136,
+     "sha256": "6f4f61addc77e3492c08cd382291eaf3f8c28a7499137591dcd2c6706bb1ec57"
+    },
+    "gfx/adib_ckey7.lmp": {
+     "bytes": 136,
+     "sha256": "38c3473948f4769e4309bdbb390afd0663fc093f1f76c9fbf10d818c6f89c72b"
+    },
+    "gfx/adib_ckey8.lmp": {
+     "bytes": 136,
+     "sha256": "d0c43a81abfb623b7c3392a07b484b6bf9137fede67d78dc67864848ecbc1c12"
+    },
+    "gfx/adib_ckey9.lmp": {
+     "bytes": 136,
+     "sha256": "042cdb7aef3e06a5679158b4f33fc66ca2d97dd6cf9e7e2657b1e85e444ed006"
+    },
+    "gfx/adib_invis.lmp": {
+     "bytes": 264,
+     "sha256": "f4f1be9a2ef88b75fd9971d72796a35f7de1ed04fc2cfc3a4c35225976f21eca"
+    },
+    "gfx/adib_invuln.lmp": {
+     "bytes": 264,
+     "sha256": "87b8312e4d7fc20d6ae9df6d1f8cb616392f3a2adaf7208dd2372eefc19888a3"
+    },
+    "gfx/adib_jboots.lmp": {
+     "bytes": 264,
+     "sha256": "206ad9d67636b46418e6afa6b6e75a12df76bd3ad84b0178e86b8d140b9c3afc"
+    },
+    "gfx/adib_lshield.lmp": {
+     "bytes": 264,
+     "sha256": "79a78f4402a301d381bef260b895ba56757b779ae89b7ae5a49f8146f2a7a54a"
+    },
+    "gfx/adib_nailp.lmp": {
+     "bytes": 264,
+     "sha256": "fe59667c80612fd2e7f5d95dd0a208f3909d93eeaaab7e4580405fe153469fde"
+    },
+    "gfx/adib_quad.lmp": {
+     "bytes": 264,
+     "sha256": "915832c8c822daf8cfa1c5d88548f24da7d182be6746b265e7ae6e1d735082cd"
+    },
+    "gfx/adib_sharp.lmp": {
+     "bytes": 264,
+     "sha256": "18987634aa43dced4e06e1d5a9a3f9b1f51c7738f59fae64168bd94ab9cd6198"
+    },
+    "gfx/adib_sigil1.lmp": {
+     "bytes": 136,
+     "sha256": "34b11b26dcdf5b91f3e6e08bbe6edb83f62ba054e9eef28459cef09b742e1456"
+    },
+    "gfx/adib_sigil10.lmp": {
+     "bytes": 136,
+     "sha256": "af31a42ef81449aa656327dfe00fc1e1d744f90212ac228bd05a6d79f5048683"
+    },
+    "gfx/adib_sigil11.lmp": {
+     "bytes": 136,
+     "sha256": "9fb90ba79d5c34e2b0afdbcec8bc528fd7d3d8f2645191d95a67a65e242bd3c6"
+    },
+    "gfx/adib_sigil12.lmp": {
+     "bytes": 136,
+     "sha256": "d7c9c3c7c1167ea0791b2790d678d6bd25144adcba79d6f7c5d93302fc28119d"
+    },
+    "gfx/adib_sigil13.lmp": {
+     "bytes": 136,
+     "sha256": "0003389cd694c55fa36f1d18d38261d279c5c7ef23dd5d41c3852ad8c95e5a49"
+    },
+    "gfx/adib_sigil14.lmp": {
+     "bytes": 136,
+     "sha256": "8ac47a2e1d45d94fb1f222811320c5f07e39e65698b7436515afa29de6e1204e"
+    },
+    "gfx/adib_sigil15.lmp": {
+     "bytes": 136,
+     "sha256": "153627403fd3e3856aa34e8740fdebb5ddb26e201cd590dd76cbfc12c36e49c6"
+    },
+    "gfx/adib_sigil16.lmp": {
+     "bytes": 136,
+     "sha256": "fa95a1a372ce30516252fff8dbcda8f8f55e3cc558b4a1e7015b79838ff0cda1"
+    },
+    "gfx/adib_sigil2.lmp": {
+     "bytes": 136,
+     "sha256": "0a0c22f027e980014a246daa629b6f84f425ccfd828f75a93ef777d9616c9191"
+    },
+    "gfx/adib_sigil3.lmp": {
+     "bytes": 136,
+     "sha256": "9e5daafbe4cc032824f732ebdac3897d804df43efaff9901c315ae661af8cd31"
+    },
+    "gfx/adib_sigil4.lmp": {
+     "bytes": 136,
+     "sha256": "fd1d3791d53ab40881a2d86a0bc67b3b532ef10b201a166a3937b105c63e3c9b"
+    },
+    "gfx/adib_sigil5.lmp": {
+     "bytes": 136,
+     "sha256": "947d5088b18a12d06a93fe66a0500e5b6ae93e04cebc748858139d569693d42d"
+    },
+    "gfx/adib_sigil6.lmp": {
+     "bytes": 136,
+     "sha256": "5a2356a7479f887b20f10e03ee2f42478bdfa75febe2d802b3dbfcd25b39d744"
+    },
+    "gfx/adib_sigil7.lmp": {
+     "bytes": 136,
+     "sha256": "507011b2a191e096fadcd678590636e4033de2ffcf35cef31785539bf3f9fb4f"
+    },
+    "gfx/adib_sigil8.lmp": {
+     "bytes": 136,
+     "sha256": "2a49a4653b2ed11353c6aaca950420c38c8e7b2aa8cc82ecd746a4e73fb7aa00"
+    },
+    "gfx/adib_sigil9.lmp": {
+     "bytes": 136,
+     "sha256": "df168192d5c065c7247cff03b10da51eba431bdc4f76d2c913646bb23084d639"
+    },
+    "gfx/adib_suit.lmp": {
+     "bytes": 264,
+     "sha256": "030bf62f7f45667310f1a74bd88881e2aa8d6c7ba5355bda4bc7c87d64a3d082"
+    },
+    "gfx/adn_0.lmp": {
+     "bytes": 584,
+     "sha256": "0895fe0acba04a4e17ef64fe62c56765c4fef5933c4af09dfcb242e984e8d163"
+    },
+    "gfx/adn_1.lmp": {
+     "bytes": 584,
+     "sha256": "fc0391c514808f9cb54e0bb0bbd63edccb0bea66a7620b81d04497edd099f5b1"
+    },
+    "gfx/adn_2.lmp": {
+     "bytes": 584,
+     "sha256": "d70ca75a162f7203067f314eee6460dc9180383e5bd1a19c69a984d8f4c699ae"
+    },
+    "gfx/adn_3.lmp": {
+     "bytes": 584,
+     "sha256": "40fbf34b86a4e5d264fac3c875ad74a52b62f5868d01a7580107a52998cbe4ac"
+    },
+    "gfx/adn_4.lmp": {
+     "bytes": 584,
+     "sha256": "5c9f781b8fb46cff0bb69db9817936be10cc4e34d677a5a49f117baa1d414aef"
+    },
+    "gfx/adn_5.lmp": {
+     "bytes": 584,
+     "sha256": "f2b1a90d1f4e1e3c6eb04dd1d87f084b2bc932b76b6eabcc5a4ee12db939971e"
+    },
+    "gfx/adn_6.lmp": {
+     "bytes": 584,
+     "sha256": "ec90a75650252feb45f325815498caf518058d141c7660e594397e0e05e35cfc"
+    },
+    "gfx/adn_7.lmp": {
+     "bytes": 584,
+     "sha256": "c292389fee1e91c2c4178099a8c9b2ad193f74346adec126ae10a4383f96c6de"
+    },
+    "gfx/adn_8.lmp": {
+     "bytes": 584,
+     "sha256": "4df870d66977eddbb7c4f87ffe4b94a032f2f13ad8fa38a98fde607d7aa7b06d"
+    },
+    "gfx/adn_9.lmp": {
+     "bytes": 584,
+     "sha256": "fd7f393a0fea9c0bc9fec90492a8f074a75275fde2ce211379b098176729622d"
+    },
+    "gfx/adn_a0.lmp": {
+     "bytes": 584,
+     "sha256": "7221532ee9af2c3a2fa3d19e4ccae78458d7a1f3025627e6da45dcb4aefd6820"
+    },
+    "gfx/adn_a1.lmp": {
+     "bytes": 584,
+     "sha256": "8f594ea65757fdaa62105b5eb68d4519b96b93e12dba110a723c4bf99470d408"
+    },
+    "gfx/adn_a2.lmp": {
+     "bytes": 584,
+     "sha256": "738cd71a2344da4b1733b639e6cdef1fb412104c388d2edee0b4539655ed9fec"
+    },
+    "gfx/adn_a3.lmp": {
+     "bytes": 584,
+     "sha256": "00c7040d33a445656f33c373077564116a764142f4625b5df7fae6516817f893"
+    },
+    "gfx/adn_a4.lmp": {
+     "bytes": 584,
+     "sha256": "7fbde831e189692c1c5d048873e7098a7d017ff7e22fc57a724a2c2fcbcc8db4"
+    },
+    "gfx/adn_a5.lmp": {
+     "bytes": 584,
+     "sha256": "ecb1a8036b03abc3c95a145081762ebf8b04516bc438053e570b989195687615"
+    },
+    "gfx/adn_a6.lmp": {
+     "bytes": 584,
+     "sha256": "8495247be5584836815824b182f448348d3de924236e254c5ebffd8132a1b7ae"
+    },
+    "gfx/adn_a7.lmp": {
+     "bytes": 584,
+     "sha256": "76a1b4a37c14cf3c53047129e14bb3f2217142ca5405ebceb95b892bed49cb77"
+    },
+    "gfx/adn_a8.lmp": {
+     "bytes": 584,
+     "sha256": "943ae9da4710dfb8a8b7b22eb8ecc6131e7c4586f279701323997f931bdd486f"
+    },
+    "gfx/adn_a9.lmp": {
+     "bytes": 584,
+     "sha256": "4381c6e590644e7c7e3d64e89adb1d438802e1a81380de8f08b31669780f07ed"
+    },
+    "gfx/adn_aminus.lmp": {
+     "bytes": 584,
+     "sha256": "903c3e6081e934fb4a9b0ae4564265b0339d2289fea17720c7bac77d00155258"
+    },
+    "gfx/adn_colon.lmp": {
+     "bytes": 392,
+     "sha256": "a06510a33f355c24fc16d7591323523f13920ae6fa903c3155b5edef9e4059a9"
+    },
+    "gfx/adn_minus.lmp": {
+     "bytes": 584,
+     "sha256": "1e04325b97c5052e64187e0882b8c2f87473bd66f3e70b5a419d983b0a62ed81"
+    },
+    "gfx/adn_s0.lmp": {
+     "bytes": 264,
+     "sha256": "6a5cac8d7c8076aa42055c3b64f3fde4b1e7750b2bb143b12af07dec892c9ccc"
+    },
+    "gfx/adn_s1.lmp": {
+     "bytes": 264,
+     "sha256": "723ec3e0b6225419fa5fb8010896674d91d19eeafd8e2c9bbbec2d23fbb85792"
+    },
+    "gfx/adn_s2.lmp": {
+     "bytes": 264,
+     "sha256": "cff9bff09933ccbf43a1419d6f566807c2aee9a4aca448a86bf261394b3ca7b3"
+    },
+    "gfx/adn_s3.lmp": {
+     "bytes": 264,
+     "sha256": "8d7cf6b3f2db7463e962fd7b70b2ef7c36b0882b1e80d90b02fa1a609d09513f"
+    },
+    "gfx/adn_s4.lmp": {
+     "bytes": 264,
+     "sha256": "2bc5fa316cc366f4d1a4f1831ac3b8ced65caf89157e796ff5d673fa3955ac1c"
+    },
+    "gfx/adn_s5.lmp": {
+     "bytes": 264,
+     "sha256": "98cbff3f1b98977b8fc19523fc2e644e763fc52dba708fc5024dfbeaa1f00d6d"
+    },
+    "gfx/adn_s6.lmp": {
+     "bytes": 264,
+     "sha256": "1578d854415aaf5b68a25a0fb37057b019d12055b61c3d7402eae811a9359e1f"
+    },
+    "gfx/adn_s7.lmp": {
+     "bytes": 264,
+     "sha256": "609059534b0a59c9d5ab1180f25f0b2a952719a0ccade29d05559dfc6223f1d9"
+    },
+    "gfx/adn_s8.lmp": {
+     "bytes": 264,
+     "sha256": "7327dd480225a52c642320336ade17100228d2c1ade5f1b640cbff18e37fbe2d"
+    },
+    "gfx/adn_s9.lmp": {
+     "bytes": 264,
+     "sha256": "b8ad416098543b34c286565e3a0d7756eea7ab18c8b50145e7ddbc45fd28851a"
+    },
+    "gfx/adn_slash.lmp": {
+     "bytes": 392,
+     "sha256": "2500358f0d4bf9856c04b7be940ab41012faad597005837c99dfef93da1f3ca6"
+    },
+    "gfx/adsb_armor0.lmp": {
+     "bytes": 584,
+     "sha256": "01228bb8947103a70c9f536b168eefacda9dc5a08e1fa64ee963be44d4a9af9c"
+    },
+    "gfx/adsb_armor1.lmp": {
+     "bytes": 584,
+     "sha256": "85956c2a17460229a374e8a6e1cf22ad4ff663929dba06c9daa9d95d1582ba53"
+    },
+    "gfx/adsb_armor2.lmp": {
+     "bytes": 584,
+     "sha256": "e8e64ea8d90241677315bb9a9e25714856827642a0e331077dc6fa2b827036fc"
+    },
+    "gfx/adsb_armor3.lmp": {
+     "bytes": 584,
+     "sha256": "db6523d7c99bb15c14ad9fd1d665a24e4eab985dfa095d316f20fe5e96e9c320"
+    },
+    "gfx/adsb_axe1.lmp": {
+     "bytes": 584,
+     "sha256": "ebcafdd02b84a9bd21658a349205a09e5e242fa39013207fe6aab9697df2884f"
+    },
+    "gfx/adsb_axe2.lmp": {
+     "bytes": 584,
+     "sha256": "12caae98c176f1176a5222f7730709dcb9164a5db63984fe6f8982e8b17915e6"
+    },
+    "gfx/adsb_cells.lmp": {
+     "bytes": 584,
+     "sha256": "08da91ae0bca3d7bd546d92f7688061b7fbc8d86b84e309510ee3feeb3f63e92"
+    },
+    "gfx/adsb_key0.lmp": {
+     "bytes": 392,
+     "sha256": "49e4cda132ff7237a4b7244892fa1e059ff2d77698ec855cb4c02e08867899e2"
+    },
+    "gfx/adsb_key1.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adsb_key2.lmp": {
+     "bytes": 136,
+     "sha256": "46a6561c191c47e9445ef85c2bebdc881f330ca49afe562d7bb2a59c5442c73e"
+    },
+    "gfx/adsb_nails.lmp": {
+     "bytes": 584,
+     "sha256": "77fb4c0c61d824fafba54e91d6b23e702ae54565d7708ee0e404aff804555b73"
+    },
+    "gfx/adsb_pent.lmp": {
+     "bytes": 584,
+     "sha256": "8066cd0ef3d3ed9add280937fa51d6dd13a7eaf606ad0567366e86c51ddb7d62"
+    },
+    "gfx/adsb_rocks.lmp": {
+     "bytes": 584,
+     "sha256": "2e79b7c3e3fb6b4118a3ddedd7d9a1186f12c2df2efdbcf5300cacc51fe64744"
+    },
+    "gfx/adsb_shells.lmp": {
+     "bytes": 584,
+     "sha256": "f185cb1b1a48a8499d110e6371f2bb102ad89fda9875a267adcc6f3c8a5e613c"
+    },
+    "gfx/adw_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "ee32ef4cb14c02b9516f245fe9eae50021962ebdee3ef843076b9dbe20f038fb"
+    },
+    "gfx/adw_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "0f8884976f5ef05d5c3d7ab7c7b22bddeba9ee922664d23c6dfe835c5673ad9f"
+    },
+    "gfx/adw_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "2c1f7b1b0a5c27da9f01c84a38571901fb3636a04485102f44cb19d715e7f627"
+    },
+    "gfx/adw_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "a9802bea98b2fb57ab97784caeebf1ab2312fab73146503459c7c8021249ccef"
+    },
+    "gfx/adw_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "0c92aaf91afe914f4d06e5d2fa91bf926a0b43294d49021755b93c049e15a99d"
+    },
+    "gfx/adw_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "155eeca532e2f6d08b7575697020eebd4f492987392c68f09c66bb6522c0336b"
+    },
+    "gfx/adw_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "02d55707616bd6eae995c93d5eca3e788f227811001e2e8137c07cafe85409a4"
+    },
+    "gfx/adw_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "0d4cba204d9ea74665e164d46ead9167095cceb64a795861dfb21fcfd2b3e9ac"
+    },
+    "gfx/adw_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "3d354bd9336125ea758f2b5b56b1ecdf2a2afea4e8bb8d6edeb058448f9627e7"
+    },
+    "gfx/adws_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "457f6682e5a8b3d7b1075148c05093df1ec96c59e85057dfca80f66f4ad25815"
+    },
+    "gfx/adws_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "127d3759679f91a8633557a27abcb8425b3f8fd8b9888e029f761cff9fa20e47"
+    },
+    "gfx/adws_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd1e14b26cfa3915c23502e22413328d37749e0a77ac75508238fbaa375c7555"
+    },
+    "gfx/adws_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "424a425e24162a3a1a23e7308b8b46f4d25f1c9f11ac3b427117c596dafeb006"
+    },
+    "gfx/adws_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "41dc9eb1fb806500b41d832786a0bce0c6863c6caa3bcc7491892e25d04a81d4"
+    },
+    "gfx/adws_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "30a22fc8975b5a696ff31e859290fd780553f1857e424b1d5ecfa057277d155a"
+    },
+    "gfx/adws_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "50c5e9c358023dbbb65cc79346d99af6797af556faded31df95e2b7191aeb3f0"
+    },
+    "gfx/adws_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "94cef7136e718532b4d00b9ed8804da60be979206bde676a328270321286851a"
+    },
+    "gfx/adws_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "8259db2f3f7ddd075e6192d6e0581a2321c108232d67980fab85059fcbfe47df"
+    },
+    "gfx/adx1_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx1_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "e4d0714014c5a1c0d9874bf1ce2c0232352be1e0c90ffe927dc2d86d448f7e47"
+    },
+    "gfx/adx1_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx1_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "9da68076978e9bc4d35e2b40e972c578e0839c379c86d44bf15c033f164fc9e9"
+    },
+    "gfx/adx1_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx1_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx1_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx1_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx1_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "9341894f953061deffb42e12370fd05b7f8008e2a1caee149630a8bcd40fac10"
+    },
+    "gfx/adx2_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "c5f2e4352837eca0a67b1fe6eb5d437672f365efffd7c297848dcdbfca6fea7f"
+    },
+    "gfx/adx2_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "b627ea70b6a7a5debddd4710f31ca137c3baf01dd6109cc2cee7da968a020049"
+    },
+    "gfx/adx2_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd7a15d826f6565c97f638ff541d76e409b9cc69febbb78906c5ddbbad2e0f02"
+    },
+    "gfx/adx2_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "8239bfd1d494fae52f97d5f620bf6c9cace057a27975cddf7d0f557b5a797cb6"
+    },
+    "gfx/adx2_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "6adf5220508ec39cedaf8cc8208c8b7bff5f44f18401bc5ee7a39e91419376ab"
+    },
+    "gfx/adx2_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "f300febb1aad7dc16d592f1e1aef2cc5a8870ad08ebbb2bc15b43009122259ae"
+    },
+    "gfx/adx2_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "e15bf6fb56eca5640d521dfdbe0c20f9e3ce6fb6fc7a2e39922f0fc8cfc7d002"
+    },
+    "gfx/adx2_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "c781852ce141a1d5fb84451e1bef2b021c937d0658d7ca8f8b2a1d5cc3737a66"
+    },
+    "gfx/adx2_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "aaaac2a8b4dfaae3d02705c2fbffa38621187cc28f4246a591f38b2bec79f693"
+    },
+    "gfx/adx3_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "20209da4ccb0dbeffc6520aee7958b33bcfa728ed376b1f5f987c8305fb70d3e"
+    },
+    "gfx/adx3_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "eb13bcc843d95abf3c90c140c95aa95803a42a6afeb100e11a5e0d80c72caf8b"
+    },
+    "gfx/adx3_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "483f85f7e5a0e881f6511f2b16a25d1945dcc2fa5365e4417cb58ec6a87f062d"
+    },
+    "gfx/adx3_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5e1f15716b826a8a25e61415e675a6c94888ae4030462e1190653c4d93768743"
+    },
+    "gfx/adx3_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "99d58b01e578c88924699f85614b021dcc5ce32798c96680fb5120e8d58837c2"
+    },
+    "gfx/adx3_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "4eae7b9a7119e883d3b6d3b8b336398beca8b7cf4ed2b9b498e13d90b7743ccc"
+    },
+    "gfx/adx3_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "8568e0c106e3155b9cef3dc3bd55ce821ed151560abab4080fcf6534850b153c"
+    },
+    "gfx/adx3_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "b8764c3198aa863d67e4f7c3c19db89aab6aa4f4076abe83d50b88710eb85446"
+    },
+    "gfx/adx3_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "fbb92c8a0853070604e84da82a5232c93747f3571ba05e88ecb4e59649125838"
+    },
+    "gfx/adx4_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "4e8da401756d091a913d4a0a5618aee7eeddad1bcd8c78774bc229195bd96943"
+    },
+    "gfx/adx4_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "c68cec0c6064b7ceaad60028ed1e8f7834a6484d9fde249649d7b94addc6544a"
+    },
+    "gfx/adx4_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "386eadd2ee00c5a53179729c2b23cf56f0629c3e7ad8e5b3a739f1fd8d489d34"
+    },
+    "gfx/adx4_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5179dcb2b82032c81d02dfb35d130ed8196d5b726c7a8265c2823c3f2edde2a8"
+    },
+    "gfx/adx4_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1156e8a090be24e24605153b059646bd7d8b9d33c6e175bc9b05843eb626ce38"
+    },
+    "gfx/adx4_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "8881a5fe764d90c1113e1df7215c6520988c23601a969ea3e7b9abf8d7d4ef0c"
+    },
+    "gfx/adx4_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "7b55d6f2071d101db2a87c5958aadcdcf618f8f0eab53b19691125c1e8b6d8ad"
+    },
+    "gfx/adx4_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "199a6be6977bbebfe0aac0005466b10bfcdd9d26a764d18e56e28ee6f6f8f5ee"
+    },
+    "gfx/adx4_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "924cd9a6ac66660db99821b558a21e8dd0b02e85bb2a5415c2e24daace249663"
+    },
+    "gfx/adx5_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx5_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "9405034666f0f1247a58a97b86e5c451f0b2a315501389f43043da55493db8de"
+    },
+    "gfx/adx5_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx5_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "6c529185a7cc6dc8d066080c4246f80c7bf1fd0ea808fc0be5be63c8cff7c2b3"
+    },
+    "gfx/adx5_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx5_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx5_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx5_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx5_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "bb8e065bc9d9935d7fab8e9d0d0554948e2ab2622a54e86f70c1d8c3c9a0f178"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "b941e3ec692b990d1dbe0fd69c1e043b9d504374d791c8c981cb091324072826"
+    },
+    "gfx/community.lmp": {
+     "bytes": 256,
+     "sha256": "7d425f7678b30e94f816c93391c3322ed354c9657ef2563c964b2abb0d57d933"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4424,
+     "sha256": "b4554a7ef6de5831198626fef9431582d3c17ed56c55853f1ce979be31df8dcd"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "9287c799b570f08922179627269d7a97c0ed587b8a9ac53c664ea9b116bfe3ed"
+    },
+    "gfx/conchars.lmp": {
+     "bytes": 16392,
+     "sha256": "045ea49c02bc0e51336e84fb19f4c445ece3c0d8c6ec4aba3cac0fcbf4306c15"
+    },
+    "gfx/conchars.png": {
+     "bytes": 14283,
+     "sha256": "1b63b3d252a0d234553153910c6d5384de0bbe050f095ebe00d253ffab2db8b9"
+    },
+    "gfx/conchars.tga": {
+     "bytes": 65580,
+     "sha256": "6dbfcc084e12e7c053c49f257f0a2276014a46ee92d194008893a39416e9e486"
+    },
+    "gfx/env/adgreenskybk.tga": {
+     "bytes": 1520289,
+     "sha256": "6a7fa2cdc97237658a3f2c73a8a5d879feadf4a31e84fb8585aeba96f3f8fb61"
+    },
+    "gfx/env/adgreenskydn.tga": {
+     "bytes": 1565620,
+     "sha256": "d4fabe617a431169df1bbc37e48404fc34718a1bbf5a1ee45d5b3a0ddda5cc6c"
+    },
+    "gfx/env/adgreenskyft.tga": {
+     "bytes": 1704063,
+     "sha256": "c6cfbbd8b09846eaea719a5e65744cdd4fddced0c277f4584c743f2639882d50"
+    },
+    "gfx/env/adgreenskylf.tga": {
+     "bytes": 1576943,
+     "sha256": "c83f24917ccb67af83602236d03e57096f73b36b7fc64da6206afe989944b4a4"
+    },
+    "gfx/env/adgreenskyrt.tga": {
+     "bytes": 1706213,
+     "sha256": "7b85287d2ce5e4d3a9ce63a560183086e812ceca9232d07eb61f63a24d678e10"
+    },
+    "gfx/env/adgreenskyup.tga": {
+     "bytes": 1798684,
+     "sha256": "703e4449b5b9ff967610dbc81d7e27c089788927d82fdb31267490cfb30ed0e3"
+    },
+    "gfx/env/asap_bk.tga": {
+     "bytes": 786476,
+     "sha256": "9f6daf48061bdc132ec28062c494d4a6abe2eeda2c86b575ac7df472a97b2c80"
+    },
+    "gfx/env/asap_dn.tga": {
+     "bytes": 786476,
+     "sha256": "a8aa31d47f7537150c1023713588b87cceff0072036ea64c895129fccfd9fa9a"
+    },
+    "gfx/env/asap_ft.tga": {
+     "bytes": 786476,
+     "sha256": "067cca994d96dcc95903ea1d3c023c479d66a655b2d3412116d462dff4e155d7"
+    },
+    "gfx/env/asap_lf.tga": {
+     "bytes": 786476,
+     "sha256": "761640856a2500019db4c3fae214fe2043fbc0edffa3e6c508d964a86b98ecf5"
+    },
+    "gfx/env/asap_rt.tga": {
+     "bytes": 786476,
+     "sha256": "08d03cf9826300c6d283028f60663f5bd3f6564a7deb5e15078440e18e1433cb"
+    },
+    "gfx/env/asap_up.tga": {
+     "bytes": 786476,
+     "sha256": "d98b750d0908addc2b0c9d513bc0bfc5d28935c9536f437cfcc3796fc0f5ce82"
+    },
+    "gfx/env/black_bk.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_dn.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_ft.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_lf.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_rt.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_up.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/interstellar_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "861352b7f4dc030af28b483d09ad88b4cbb7b8e23e5cd3cf512d2feae9640b22"
+    },
+    "gfx/env/interstellar_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "b16b2e272b7e74513f6a1961d68270dd82fa0667d6ea267a2d22c45a2bdc2fcc"
+    },
+    "gfx/env/interstellar_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "11730f0982cbadc7691ea38e57510b2b7e77484e108d591aece8f970cfdca08f"
+    },
+    "gfx/env/interstellar_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "5bf0a5999e7ea85e68291ab7b36d7f6be5104f8932a2fe46d257484e84dab4fc"
+    },
+    "gfx/env/interstellar_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "051204c9fb8a430c17fb337d84132e0d7058b88f070e457278be99d78a73e5c2"
+    },
+    "gfx/env/interstellar_up.tga": {
+     "bytes": 3145772,
+     "sha256": "d8b19a66cb5dad2f34c9059860ac24a8632ba5575ac06ca3076d57a70c47b5b0"
+    },
+    "gfx/env/l_swampn_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b83c2aeccb2ec2b6a7e7de05e4eb1f120437c575769b93533708093be6d7acb"
+    },
+    "gfx/env/l_swampn_dn.tga": {
+     "bytes": 3146268,
+     "sha256": "64ea5b085c2758138760da154c77e3c90eb0831c68e75bac4c03cd03ae2e28c1"
+    },
+    "gfx/env/l_swampn_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "f8149a22f17e241f3cc50ddc2587b3d8d6e72bb26f7a47d5045b08ed436863af"
+    },
+    "gfx/env/l_swampn_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "fdf2a49932e8ee9c06b9a50fa6dcff3d29bdde55aa209d1658346cf236ca1dd8"
+    },
+    "gfx/env/l_swampn_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "a2c65a9eafab955cfe898aa28e3563714354a08725068df84f390eebfc6ca20d"
+    },
+    "gfx/env/l_swampn_up.tga": {
+     "bytes": 3146269,
+     "sha256": "aa5c65d4c106b17e695629023db1e6b304ec5b4f15e646a1a94b38c47ef9017e"
+    },
+    "gfx/env/moonhigh_bk.tga": {
+     "bytes": 1048620,
+     "sha256": "5f361bf5a352c1df5a6caef9cf42bd35fed8406c6949af480b0425c193c18b3a"
+    },
+    "gfx/env/moonhigh_dn.tga": {
+     "bytes": 1048620,
+     "sha256": "02e2b36863c1181a85aa675c53fc14a301f38dc6e0c6735098bb6d8723af02b3"
+    },
+    "gfx/env/moonhigh_ft.tga": {
+     "bytes": 1048620,
+     "sha256": "3158735bdd6f4f467a5b29639aa4f622d1136ea463967684b739b0002bec6526"
+    },
+    "gfx/env/moonhigh_lf.tga": {
+     "bytes": 1048620,
+     "sha256": "5cdaabd99655152689e40832643690d7b1c5f8e414f3126a7c0c9224f2250704"
+    },
+    "gfx/env/moonhigh_rt.tga": {
+     "bytes": 1048620,
+     "sha256": "e08a374ac19c8b8cffa6c939515cde9570b44bbc044c12d06b0c5d94aa7469bc"
+    },
+    "gfx/env/moonhigh_up.tga": {
+     "bytes": 1048620,
+     "sha256": "c0465fd6a0b069e5ff78f3e561084bf3e23b796cac9b5214a6cd4045310d36fe"
+    },
+    "gfx/env/moonrise_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b4e85116e3999d5cded25ca0a5d6fb9c297b3d69749a63daf5af6c37fe21959"
+    },
+    "gfx/env/moonrise_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a7be41496d25bc9e505b959b08a950c1bb61acc6c8c44ec4e1dd428faeac4ccd"
+    },
+    "gfx/env/moonrise_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "7381c46aa4f5c916f3bc8f82a442a4582834563c0bb0127580053bb274609180"
+    },
+    "gfx/env/moonrise_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "871df5eed200970b8c3246ca10a039f5915c95e8f48bf0692fc22f2f7e5450cd"
+    },
+    "gfx/env/moonrise_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "2cc00bb935ee2f4019f4d99170d38ef3f51c72ff80150cd74911b1038a0cb269"
+    },
+    "gfx/env/moonrise_up.tga": {
+     "bytes": 3145772,
+     "sha256": "0296084074d726170fdc85d2c1176ee64845b6805c174c08aaa63f514fd9cb65"
+    },
+    "gfx/env/snowmoon_bk.tga": {
+     "bytes": 707878,
+     "sha256": "f4c61c3a622a2dabfc2aa2748c3bba9ab52bf018c5c24b5aac6bd682b6d938de"
+    },
+    "gfx/env/snowmoon_dn.tga": {
+     "bytes": 754863,
+     "sha256": "a6f29123dc3da6df244c6878d1a355b9ba7c093b9a38b94e8f9253d317de846c"
+    },
+    "gfx/env/snowmoon_ft.tga": {
+     "bytes": 630095,
+     "sha256": "c10f65b43cff087a7044946f8105d24072bbcb33668bb485f501fc0bdcb7e293"
+    },
+    "gfx/env/snowmoon_lf.tga": {
+     "bytes": 671066,
+     "sha256": "8025d6d72582a374583dc4c80d15de546b1ebea3f378cc55b084483778d8f985"
+    },
+    "gfx/env/snowmoon_rt.tga": {
+     "bytes": 636559,
+     "sha256": "339a1a1a36ffafa6bb49ae5bffcb73c81d4304f0f6d40d5fe470654c0db56037"
+    },
+    "gfx/env/snowmoon_up.tga": {
+     "bytes": 410341,
+     "sha256": "f08c76ef2c7c2338b64615543ffa1217edab3ca41bc79cb74b20bc42d329e82c"
+    },
+    "gfx/env/stormydays_bk.tga": {
+     "bytes": 786971,
+     "sha256": "d82eac0c4f574d74ff5fee6ececd1d5f0b1bd94c349cb7c9af30d3ce79bf6b2e"
+    },
+    "gfx/env/stormydays_dn.tga": {
+     "bytes": 786971,
+     "sha256": "915f33dcae63765c49252b65a58f9d4359c7a36ea99352a013e58e660b71f160"
+    },
+    "gfx/env/stormydays_ft.tga": {
+     "bytes": 786971,
+     "sha256": "4906e45ebc2760dad5faf2e6f8a0be7c280bf7525a96364376155f3d001fba99"
+    },
+    "gfx/env/stormydays_lf.tga": {
+     "bytes": 786971,
+     "sha256": "d7cc6cbaa37481b3902673d717aae7f31e0170e2226a4efe88811f6bac3f8ca6"
+    },
+    "gfx/env/stormydays_rt.tga": {
+     "bytes": 786971,
+     "sha256": "ab40bc26b750a421c95948e7f215d51e831163fd478841c30f685a2b006b8c3c"
+    },
+    "gfx/env/stormydays_up.tga": {
+     "bytes": 786971,
+     "sha256": "8ff85257da02eb361ab8127e4425b9177842f17016724beb5c3058ae460aa52b"
+    },
+    "gfx/env/violent180_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "cf1d0a870b38e4889ad4ce18f22bf894771a8c91477c0338e837880df061db31"
+    },
+    "gfx/env/violent180_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a3b344abf47fae67c831aaa8d8b2ab7ff56ff1ed93091c6869139902060777ff"
+    },
+    "gfx/env/violent180_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "964ce0226b139a1af96de0c422e927d35917ad30f0c4027c1c386c7c32cc30db"
+    },
+    "gfx/env/violent180_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "b9cc1ef464535f9a911d56fb503a2e1aa68e6d07c7091cb62c42442a7d62ceaa"
+    },
+    "gfx/env/violent180_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "263af4a0d5b2e61303d8165d6b8a8b7e55d0c8dd79157ff133a5d50128d5f21b"
+    },
+    "gfx/env/violent180_up.tga": {
+     "bytes": 3145772,
+     "sha256": "3a9aae357ac1a8e8767e151024dab60845283422f204a354913282873f181413"
+    },
+    "gfx/env/voidsmoke_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "d274189cd63786e9d86fbd3cafda0cbfd054ccd527e30aeec921a8d6f10866a7"
+    },
+    "gfx/env/voidsmoke_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "47392d93a23946a28533cf759d6aea245a2647d58bf153d2845ac0899ab8d400"
+    },
+    "gfx/env/voidsmoke_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "ced1991fffdc46e2bf156e1d89e06e1362e0e394808b74bc7aa40e6d90fde55d"
+    },
+    "gfx/env/voidsmoke_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "4d1b843a9fc61c4125262a9a95fc084cea61eb4b125288f7a7cd0c2f2e53f4ab"
+    },
+    "gfx/env/voidsmoke_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "389ae84f29901e349a266d707f62beab9de3eb607b901bcb4245028b8edaa3b1"
+    },
+    "gfx/env/voidsmoke_up.tga": {
+     "bytes": 3145772,
+     "sha256": "138e9386728cdd98935a0c484d5693db2e60375d8d770ad754fe6616906591a1"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "a878796ad2dbab6a64e1eba47605d124170d5b4a7ce476b9d0087c2e302c00f1"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "381ec91a75cacad94d2a4d5a3b1cd6f9b22cce507fe95f980ebaabdb21bbe440"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9e9568b56059e74e621ad564b51cb0b886fcf800fd8d35a06df1aa79ac2aa823"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "52164e93b333dfe09a33d7ad1905796d7e7578a036b2fb2ddf35c4bf3381f30f"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "240a13f778cc7ec7ebbc67b23a977a54099e1996fd868f51c18f81aa3606d179"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "fae9345c9eeb43a56a14e9e681f9e9dadc05ba6e35f44197fca5873dbd52904b"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3272,
+     "sha256": "ba61bec9eaf837bddef9a1320c0acfe026a130bc078836abf971095157ee395f"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "fc226280c4948249790f00f97dd9b39e912131fc904ec75adb90308ba8763afc"
+    },
+    "gfx/mainmenu2.lmp": {
+     "bytes": 30728,
+     "sha256": "a3fd168c6454eeaeea9e248df568e5942a7f850bc5478f8946a0b6516a2ce6c4"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 6920,
+     "sha256": "5a84111e70bf277960853bca69a0dff9093d00d817ffab6fed96f33751435ae6"
+    },
+    "gfx/p_mod.lmp": {
+     "bytes": 6920,
+     "sha256": "3080226ebf497787e7ee1d7bc2917ae220340b7da4af58ff1a0f89f02b5c03d0"
+    },
+    "gfx/p_mod_idver.lmp": {
+     "bytes": 2504,
+     "sha256": "56234ed3e4e4fe95f8a4a1f9a52d4a73890ea653aa88ec992e6777bf3e99b445"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 6728,
+     "sha256": "493a3ae8e9553de87c49d356e916adab7c87e3b25a44c1d1ac46e37de4df800b"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 6728,
+     "sha256": "d79623e26bed9db65257e3c0bf43b085d2419fc6e5277ff357350556882456d9"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 6920,
+     "sha256": "f51c8bd49d699f08322b734f281d7e626c24844aec09099877fbceb1884cb705"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3272,
+     "sha256": "788da2d0f96ed9f0822fff406f364a912179e33f6f4d068aa7b772f2747cbc85"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "67c343d280b96557f3a4432fb5be6d70c13b5be1b88d0d286fcde087d1d4282b"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "f8ee0991ff6faaef3b4d2230364776effe6a1d4b47588b98e39c1d0b4199fd9c"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "a6ccb48f7e1d00ec64e5154a0a47b433f017341b8e23ba4f7f7fef6fe9a27b3a"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 6920,
+     "sha256": "bce2792bc38f1f097336ebdedff2029b21f4cebc523684738f7e10e086d33661"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 6728,
+     "sha256": "904d617b5b97aa6b1631e7b5dfab9b4092c488fefd94ec093c98595b38789b7d"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 6728,
+     "sha256": "5eeeea42e3f429aae7f907145b88376805346ebe3ce932259bdfc43399f960ff"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 4808,
+     "sha256": "5ae8a3fd789e7ddf6d7791ee89cb79ef989cb000c086e9269349aa623f1f6438"
+    },
+    "music/track180.mp3": {
+     "bytes": 9774601,
+     "sha256": "2e3f447c7e7f0b7a02013e8259cc72bc035f8689686cfa1c301591cc34dbe4e8"
+    },
+    "music/track180.ogg": {
+     "bytes": 5092750,
+     "sha256": "1b48947672b05ebb5755d97122f28c0598a5fefe724d8b4cc3301497aba94f81"
+    },
+    "music/track35.wav": {
+     "bytes": 353002,
+     "sha256": "9b006ae5f5b2ae5c2ad84062d9bc288cee744e63301721838d70bec434178b95"
+    },
+    "my_progs/ai_ammoresist.qc": {
+     "bytes": 7444,
+     "sha256": "d530fec92f23ed0c3d09560abb9a89bdc160ce1aefdfbe4f4771f9897ae3fc4d"
+    },
+    "my_progs/ai_checkattack.qc": {
+     "bytes": 106456,
+     "sha256": "7971ca5a87666c89b56ab0fcc102e6f551f3cd3b03bdfc0bfb73f5f8d5aed7fb"
+    },
+    "my_progs/ai_combat.qc": {
+     "bytes": 24318,
+     "sha256": "a8cc4b28f82babe8ef8fc627a3c16efb25775ea736d3ee99709ed675196c2d66"
+    },
+    "my_progs/ai_enemytarget.qc": {
+     "bytes": 8409,
+     "sha256": "f4b0a35306d50e71fd9043ae949a421158ee9fcc4e311baf7b8fa2d345c4d46e"
+    },
+    "my_progs/ai_explosion.qc": {
+     "bytes": 12162,
+     "sha256": "7df941a7cf93b814ae9d90f646a5b0243a51db67872f621df73d43c6000ba3ab"
+    },
+    "my_progs/ai_gibs.qc": {
+     "bytes": 32373,
+     "sha256": "65e202300882ba8f0c980f65820b2d2e0bd06846073168f4bd7e37f2357f47d4"
+    },
+    "my_progs/ai_hazards.qc": {
+     "bytes": 26832,
+     "sha256": "81aace80121408f64369bc2bbfd5654650276ddd75217333d2a52364415acaa5"
+    },
+    "my_progs/ai_minions.qc": {
+     "bytes": 10236,
+     "sha256": "3e7bd34dfe0e73a11e6907d5ac69cb609eee19dff533689ea7c8eabe52500136"
+    },
+    "my_progs/ai_passive.qc": {
+     "bytes": 8224,
+     "sha256": "44473544d0da0dc778c2800a16172ab49b548286b604c9d6361f4bc4cfc1f076"
+    },
+    "my_progs/ai_pathcorner.qc": {
+     "bytes": 20921,
+     "sha256": "b3d6ed2434e0b995da51a71715647096e36e02d8cf920e18e024f920ed69238a"
+    },
+    "my_progs/ai_projectiles.qc": {
+     "bytes": 86235,
+     "sha256": "b28c04e84c97febe9e5a8e921a8e230755f9641d4bf5d74b4a59caaaa247dfc8"
+    },
+    "my_progs/ai_states.qc": {
+     "bytes": 7480,
+     "sha256": "76fae861132b0e50006ef88ea94a953e718b661defad2ea58a4ecad5cab92dee"
+    },
+    "my_progs/ai_subs.qc": {
+     "bytes": 50952,
+     "sha256": "9d2e356f0dba7842956ceb4e766fff9da25dc72a0b408baa3e19c4a146cbafdf"
+    },
+    "my_progs/ai_tether.qc": {
+     "bytes": 6470,
+     "sha256": "2229c0ea1b76e45f5707a3eca9e7626e33f8ea91d6b292da63c81723e1ae8521"
+    },
+    "my_progs/breakable.qc": {
+     "bytes": 79687,
+     "sha256": "754831599eec85a774501d9fd0a1ec7d5722ea6a6e01655b5ad74988145045af"
+    },
+    "my_progs/chaosmode.qc": {
+     "bytes": 81481,
+     "sha256": "01561dc4f1949716eba4d08f83efe27b71add80f923c1e2d89194c238772a646"
+    },
+    "my_progs/client.qc": {
+     "bytes": 70441,
+     "sha256": "00e2d4aff96ea28b0532ab0b03de0a8cdcf15750164ec82bdc8f43b9f2347447"
+    },
+    "my_progs/client_advinfo.qc": {
+     "bytes": 59677,
+     "sha256": "87aaca8bfd15935e1cd29a807bf77a2779d95418af631a6b456c6605710694fe"
+    },
+    "my_progs/client_camera.qc": {
+     "bytes": 13007,
+     "sha256": "ff4748b04c15d9a3b44dd8069f9347c12487ef353d5401a13542166576097889"
+    },
+    "my_progs/client_cshift.qc": {
+     "bytes": 725,
+     "sha256": "da1e321fe01bae486ffcdd987a942a4b0d5b2f603efb663d52c55e882f129685"
+    },
+    "my_progs/client_debuff.qc": {
+     "bytes": 15761,
+     "sha256": "0e0c9123697241ab3a366dbc46fcb90b8553b65c94cffe1442254a74a2753efd"
+    },
+    "my_progs/client_evilmode.qc": {
+     "bytes": 6982,
+     "sha256": "2cfa3bbeb36ab623c3bb137028ec5f549a2e5d2198fa2ab7fd8a445e14f4fc10"
+    },
+    "my_progs/client_ghook.qc": {
+     "bytes": 51884,
+     "sha256": "43d071195a70caa66b57cca1778679d772478fd1f71cbad7ee267e254e79a29a"
+    },
+    "my_progs/client_info.qc": {
+     "bytes": 13693,
+     "sha256": "55653ddc2b9f3cf2ca3cf1b0afdc4c1685baf1ab3c3830eb9f8b1b2d51b3ff31"
+    },
+    "my_progs/client_mapvar.qc": {
+     "bytes": 13177,
+     "sha256": "c692fa41644e6d21c945493dd891af945a072a4b39e687d1b59c86d14ee804a0"
+    },
+    "my_progs/client_power.qc": {
+     "bytes": 20026,
+     "sha256": "68457e8f99d3967babe95d4db3539388e95d294fa65a6190773e75951fed9ef9"
+    },
+    "my_progs/csqc_defs.qc": {
+     "bytes": 21072,
+     "sha256": "eddc5f194845e78a1633807d32b1da4425bdbe7bcce193e3868bc3995e2dee9b"
+    },
+    "my_progs/csqc_defsclient.qc": {
+     "bytes": 35002,
+     "sha256": "b6674acae135dfbc5e3dbb147e69acdc6b3564b766792359bed3e4eb800705e9"
+    },
+    "my_progs/csqc_hudad.qc": {
+     "bytes": 104391,
+     "sha256": "1ca012e489dc5f6026bdae469f411b5bb25afa00e00d5169cbd35b578a7ad9f2"
+    },
+    "my_progs/csqc_hudvanilla.qc": {
+     "bytes": 37074,
+     "sha256": "c5caa6ba176185c05903d383f3ae41907129d859419a0c0bf909b0e8d3e8af5a"
+    },
+    "my_progs/csqc_progs.src": {
+     "bytes": 113,
+     "sha256": "e383fc0920e9676d92e0be81d69cd8017ed5baf9fc0616a05773de68208ce434"
+    },
+    "my_progs/defs.qc": {
+     "bytes": 31974,
+     "sha256": "1534874cf4d70c5614dedecb70f6d428fc32832ce3345c2cb51fd6058a514902"
+    },
+    "my_progs/defsclass.qc": {
+     "bytes": 24401,
+     "sha256": "811c390be7b31fd4b276410ef1a75406bbca8fb84dc195484835a6100e9cddb4"
+    },
+    "my_progs/defscustom.qc": {
+     "bytes": 95914,
+     "sha256": "180ebe8c3fbbd4f78815c94d62f6ac0ad0c3cefe427664fdf4685adcf2c8a699"
+    },
+    "my_progs/dpextensions.qc": {
+     "bytes": 122912,
+     "sha256": "3758f58ebaa4186e9112da89f7ea53087eef5058a32ebc373a1ffda76c1d67a2"
+    },
+    "my_progs/estate.qc": {
+     "bytes": 7745,
+     "sha256": "9cceb71ae54b331c2702f5580094f9055d007b9e710dd5e61c7c632724022626"
+    },
+    "my_progs/fteextensions.qc": {
+     "bytes": 215531,
+     "sha256": "beb86ad10bb0726de10dd2557d6285f7bf40f08f9d30e06315c3772f8c256571"
+    },
+    "my_progs/func.qc": {
+     "bytes": 47039,
+     "sha256": "81cd56475c6c34a744d84c2b223e66dd1c83a1b525b4c42f3389d4ff4cca5601"
+    },
+    "my_progs/func_buttons.qc": {
+     "bytes": 13271,
+     "sha256": "9e1bd197b2367ab2b8f1c776c214a0c51120559e8d8f0b4888b262b7a1e746f0"
+    },
+    "my_progs/func_doors.qc": {
+     "bytes": 35874,
+     "sha256": "58dbdf05f0044aefdd13ee21d17045a681d255efaca6d129fbd1cec4ae516fc9"
+    },
+    "my_progs/func_doorsecret.qc": {
+     "bytes": 14379,
+     "sha256": "769a3142ccaf18060ff77b0eab57d901585202fbfe63a54ce25d4987b80f92d3"
+    },
+    "my_progs/func_insvolume.qc": {
+     "bytes": 10573,
+     "sha256": "1deaf4623a6fae80585d2d2b1978b1cd217b6f8a683ef3bbc3a77a2897e9a207"
+    },
+    "my_progs/func_plats.qc": {
+     "bytes": 11685,
+     "sha256": "5086c9aba8bbf83d29c3e1897c7867cb24220712007044792928f474216b7ea4"
+    },
+    "my_progs/func_pswitch.qc": {
+     "bytes": 8373,
+     "sha256": "b3a205176d80801216a930241508b3c5718f4be9e1b947932ace2851c34271d8"
+    },
+    "my_progs/func_trains.qc": {
+     "bytes": 26553,
+     "sha256": "81d8de4f3dff80b8523584fb5e37d8d4812a6f7f95a559edff320682217ad123"
+    },
+    "my_progs/globalfog.qc": {
+     "bytes": 18397,
+     "sha256": "84ec244a475ac41b9da772042123f58f4005130590f170f85f1b23ad53629f27"
+    },
+    "my_progs/hiprot.qc": {
+     "bytes": 31978,
+     "sha256": "82875db9fecd8bacd2c42232fb980e6a510a6863103273e2c9078dfe7c6759c5"
+    },
+    "my_progs/hipspawn.qc": {
+     "bytes": 2752,
+     "sha256": "6df8450b85821c1a76f5ccb3c807ac9b94e92f413f16f2ba618f922abf85148f"
+    },
+    "my_progs/items.qc": {
+     "bytes": 164855,
+     "sha256": "ffa38fa915821151c7dbfae3507bf804052db0f5c13eecac462400680cabcf3e"
+    },
+    "my_progs/items_progspn.qc": {
+     "bytes": 20628,
+     "sha256": "2f4824cb28192145a8fabc2da6575db3398e8f81522ab1e026d696ec87313650"
+    },
+    "my_progs/lights.qc": {
+     "bytes": 43912,
+     "sha256": "d0e0c373bb3cc68c7c9121a62c68085ff9cc290daa6faf0adab02323d8ef92bb"
+    },
+    "my_progs/mathlib.qc": {
+     "bytes": 22355,
+     "sha256": "b161ebb89a11f302427c4f124731ec38def8eb01347beb5d748a9ba4afb886f8"
+    },
+    "my_progs/misc.qc": {
+     "bytes": 85890,
+     "sha256": "6b3e8a0882d47f16ff7f54fb37a48e3a7853647f8895718e6428739c4207099a"
+    },
+    "my_progs/misc_camera.qc": {
+     "bytes": 43852,
+     "sha256": "61448a8f0354f39dd26371ae56dadbc903b08282293145a27088ac6c151ea547"
+    },
+    "my_progs/misc_model.qc": {
+     "bytes": 31793,
+     "sha256": "04774e0bab5cb0ccc5bd01e36ae7d6f449248484d0cb203eb435fb267cc8bdda"
+    },
+    "my_progs/misc_targetdummy.qc": {
+     "bytes": 15123,
+     "sha256": "bcd0a0ae806ce20a8c8cfcc27178ce1b4ead3a546d927b6a261ce51a6086c253"
+    },
+    "my_progs/misc_textbook.qc": {
+     "bytes": 26321,
+     "sha256": "14bf42536a5cc75990d938a79d7bd21bde1c166245d94d8e662f9e6fd66e0ae8"
+    },
+    "my_progs/mon_baron.qc": {
+     "bytes": 31318,
+     "sha256": "b76a10da34dabf3411ddf650abcdbc77e3ebcdfebace6191a39e7c0b13a0fad5"
+    },
+    "my_progs/mon_boil.qc": {
+     "bytes": 19821,
+     "sha256": "050b21bda5341a3f81dcb21e6d7d82d458a415fd8f1cfa12435228246229a323"
+    },
+    "my_progs/mon_bossboglord.qc": {
+     "bytes": 24005,
+     "sha256": "e67081b7a5218b361c62bf4b201a18db16f3e75716ad2729c11a0616b137975a"
+    },
+    "my_progs/mon_bosseidolon.qc": {
+     "bytes": 40134,
+     "sha256": "c51eb9b9d67cadfa7178891a238329a60ad57edc3f6ef645060695b451833115"
+    },
+    "my_progs/mon_bossfiretop.qc": {
+     "bytes": 14734,
+     "sha256": "26672c9c2d1577f8caf9894b8eb5eecacac89f64251257bc25db48b1bf43a7bb"
+    },
+    "my_progs/mon_bossicegolem.qc": {
+     "bytes": 47205,
+     "sha256": "5b888302a6af24ce823919d1349c1c92e1ee709d72e79042425349368a4d65fb"
+    },
+    "my_progs/mon_bossidchthon.qc": {
+     "bytes": 20247,
+     "sha256": "65d955fb1434f806962fadc088aa5933e96ed8aa9f1211d0709a3f462ffa3027"
+    },
+    "my_progs/mon_bossidshub.qc": {
+     "bytes": 14639,
+     "sha256": "fdd0e8f8fa374ea0164f79ef1bf74ca942f04c63159f360c7a43011673774fe6"
+    },
+    "my_progs/mon_bossjudicator.qc": {
+     "bytes": 81432,
+     "sha256": "f5092f376eeef22f0a552c846f50175680c15a5c37d9603c6e3d2635661127b3"
+    },
+    "my_progs/mon_bossmammoth.qc": {
+     "bytes": 84963,
+     "sha256": "6cda415b846b2aeb215c0eebc7cdfa6a5560255df9aa014f77b48aa7073b8d34"
+    },
+    "my_progs/mon_bossnour.qc": {
+     "bytes": 45558,
+     "sha256": "def8a1a46f3a266028df3d1a0b7c31a9ad98450f6601e176495f11d929041452"
+    },
+    "my_progs/mon_bossxxchthon.qc": {
+     "bytes": 22614,
+     "sha256": "2c1c0446b0f6a5b7a7921e8f8830c71c174d30c6f176d228a94afd9a05fdc25a"
+    },
+    "my_progs/mon_bossxxshub.qc": {
+     "bytes": 19006,
+     "sha256": "043ebc852ba7f0a06812cb0afd72d32a3da643df1dea45c87fb821f60fbcc332"
+    },
+    "my_progs/mon_centurion.qc": {
+     "bytes": 13734,
+     "sha256": "641e1c09c6df27b033e331140d242f25d27bf7f9bb83733a6b5b3469a5c7ffee"
+    },
+    "my_progs/mon_dcrossbow.qc": {
+     "bytes": 38069,
+     "sha256": "3296618a4b803fb6f1b44c1d32c17692a5bed13cf63102c6dcc58481223197a8"
+    },
+    "my_progs/mon_deflector.qc": {
+     "bytes": 32107,
+     "sha256": "d7a9344878a3a846a7e720ce704820d424362281a1675c40be7b670eca9fe342"
+    },
+    "my_progs/mon_demon.qc": {
+     "bytes": 14601,
+     "sha256": "d77f128e3f91737228c5a24b7ca146f6b4f8e87dbaac31b1ad4e79779884d0d7"
+    },
+    "my_progs/mon_dfury.qc": {
+     "bytes": 39867,
+     "sha256": "a016db202f2a418aee50cb7cce2155a24a6b807e8c98fc49a5f9273ce79c6da8"
+    },
+    "my_progs/mon_dguard.qc": {
+     "bytes": 28414,
+     "sha256": "0a2b964034559f4ca772f9f29be2c56684fd39290277046a6f7642ba934836eb"
+    },
+    "my_progs/mon_dguardquoth.qc": {
+     "bytes": 18932,
+     "sha256": "4caeb17520104cba42476ff7757f38ba6d72e941674b851f55a5c9780ce4de17"
+    },
+    "my_progs/mon_dknight.qc": {
+     "bytes": 36867,
+     "sha256": "68008427374e9ab670b6ad915c7a0f8eaf6a6699efa927a3748ae6cde86458e6"
+    },
+    "my_progs/mon_dlord.qc": {
+     "bytes": 22859,
+     "sha256": "09ca1edd4e65a166a66ba17e682aae9a1be09b05371a72dd1bc447389693bfa5"
+    },
+    "my_progs/mon_dog.qc": {
+     "bytes": 18431,
+     "sha256": "1b345447176aec54f18c31f5da215e80cb2de19f51d353c63a98507d881c2a9b"
+    },
+    "my_progs/mon_dprince.qc": {
+     "bytes": 33590,
+     "sha256": "5114caa7b6152e562e548096e41da68f43c910a5016ddaed408272a97a8320c1"
+    },
+    "my_progs/mon_drole.qc": {
+     "bytes": 25472,
+     "sha256": "36a510e910ce4ffa26d2d2ad336872c07537077ea920132a4cfd63d9133fb6af"
+    },
+    "my_progs/mon_dsergeant.qc": {
+     "bytes": 33493,
+     "sha256": "ada0cc4359a863c4e8d433c605a1c04ec6f7fd17ec852f5c4847443d3adaff1d"
+    },
+    "my_progs/mon_eel.qc": {
+     "bytes": 8252,
+     "sha256": "15c1f2fedba7077d352595e1be4a90f764354e4cf1875b40e1685d3ce81feb54"
+    },
+    "my_progs/mon_enforcer.qc": {
+     "bytes": 20146,
+     "sha256": "d453651d488afa789d0cea87ce99d9684329bbabdd17aa1625591f5a4b4ac90b"
+    },
+    "my_progs/mon_fish.qc": {
+     "bytes": 9705,
+     "sha256": "ff7d84db2c7917861ff5d81fe0e28f69d51143d27c4fba90dfcda11057222df0"
+    },
+    "my_progs/mon_floyd.qc": {
+     "bytes": 20332,
+     "sha256": "3ac2f0b0be94e311ff2fc4eee9cf66d5987af0e5c25fc06b8cc7b9efa6f581df"
+    },
+    "my_progs/mon_freddie.qc": {
+     "bytes": 25384,
+     "sha256": "4409a33e819f125852d0a4ada21a8fed2713012daec00922446f313031c845d1"
+    },
+    "my_progs/mon_gargoyle.qc": {
+     "bytes": 24293,
+     "sha256": "9e1f78b2364024efa6ec4142c1ecf4aff52cdf32f38031c34cf19e9cd74143d6"
+    },
+    "my_progs/mon_gaunt.qc": {
+     "bytes": 24111,
+     "sha256": "45be98ae0bdd32e0884280e18f867af037f2fcbf515914827c5f9107a87e52d7"
+    },
+    "my_progs/mon_golem.qc": {
+     "bytes": 35297,
+     "sha256": "dbaf3d1c0fec3166b0eb064a3c027dd3a0c907bed72b8e4581ffd74dad5ab5d1"
+    },
+    "my_progs/mon_hknight.qc": {
+     "bytes": 37618,
+     "sha256": "bac7d4b7832b95cea0f6890de66fbd0f7c4fcc7ce9051ef16ac042de465ddcb3"
+    },
+    "my_progs/mon_hogre.qc": {
+     "bytes": 24021,
+     "sha256": "8781ea9aaaa1d0f7ffb1fd8ec8b5981187eee6fdb8193160a1eb38770dffcfe0"
+    },
+    "my_progs/mon_hogreham.qc": {
+     "bytes": 23076,
+     "sha256": "b2ab6b830ce3aae7d6b033e8455de5011ded82e451ca171ea09940d9a3ec7740"
+    },
+    "my_progs/mon_hogremac.qc": {
+     "bytes": 23941,
+     "sha256": "9111c040ab1e5487936cce6ef1170e408c6d297d582702d202bbd27b0919d843"
+    },
+    "my_progs/mon_invsword.qc": {
+     "bytes": 9214,
+     "sha256": "f7287867cc6043eb7cd3fa3e1ecd5ae7115a84e5ef7021b2d5129afdb6ba6f46"
+    },
+    "my_progs/mon_jim.qc": {
+     "bytes": 22091,
+     "sha256": "55353984ad822dfd8c32f3b8ad9a06e8bfaab7bc5ff6f2a2326674ad4acd26be"
+    },
+    "my_progs/mon_knight.qc": {
+     "bytes": 24772,
+     "sha256": "d254abf88162436b9db48885ae8e59315c24c1e7f72a91d027a1d69fe9baf5b7"
+    },
+    "my_progs/mon_lostsoul.qc": {
+     "bytes": 23261,
+     "sha256": "2cdbf656c6b34164711fa88016542f4e3d2bd0555417ad00bab5ca7039f212ef"
+    },
+    "my_progs/mon_minotaur.qc": {
+     "bytes": 35316,
+     "sha256": "fbcef276ee3e2f1eeea8483303538190875e959b43efbf4f703be10fc72fc564"
+    },
+    "my_progs/mon_ogre.qc": {
+     "bytes": 24123,
+     "sha256": "d287d3b9024025237dbc68380f486572828a5114f9543599ba86b8bc35e9e25e"
+    },
+    "my_progs/mon_ogrextra.qc": {
+     "bytes": 9387,
+     "sha256": "41a9243c6006326195197a4dfba6ea4c1f1fbd729ec10adc48cfd7badd7a18de"
+    },
+    "my_progs/mon_pyro.qc": {
+     "bytes": 18235,
+     "sha256": "bd35f02c63af315ddf4820e388d0248cf065f1170bd7306957a1e86fa7e47306"
+    },
+    "my_progs/mon_scorpion.qc": {
+     "bytes": 22136,
+     "sha256": "0432d7c5e1b6a30a5452aba12b9fb6a3c2c7f3c582b1392d420414e66b8fb257"
+    },
+    "my_progs/mon_seeker.qc": {
+     "bytes": 29703,
+     "sha256": "d33939357840eedbfc63c56d6415d8fefd21de2c477b24b3165cdadcca2acd2c"
+    },
+    "my_progs/mon_sentinel.qc": {
+     "bytes": 10217,
+     "sha256": "946232c7169bf3fa966ce875523dd45402772f8045c51a96dced04f2f5f5788f"
+    },
+    "my_progs/mon_shalrath.qc": {
+     "bytes": 16434,
+     "sha256": "1b6fdf2447d7fa281d126118a9bc0e097de7b4dd4d10a33e60d5cf0ca785c58b"
+    },
+    "my_progs/mon_shambler.qc": {
+     "bytes": 23050,
+     "sha256": "576f71a38d75eedbdf58c291055674be8da5f0d04540e26311d65f70b58ee842"
+    },
+    "my_progs/mon_skullwiz.qc": {
+     "bytes": 36245,
+     "sha256": "6d3c2242bffe6eabe3f9cc59e881cb2296213cfbff809e1be045a80ca46aac53"
+    },
+    "my_progs/mon_soldier.qc": {
+     "bytes": 21645,
+     "sha256": "704c534062b11c4fc16416154c7706c125221660cdd4d9b02e00575b94c04103"
+    },
+    "my_progs/mon_spider.qc": {
+     "bytes": 30593,
+     "sha256": "4d0bbb7e38e51cef07912e6071e6bb9739e019a2d93129d38dbab9492bf43aee"
+    },
+    "my_progs/mon_steelclaw.qc": {
+     "bytes": 17126,
+     "sha256": "78dd4bb46dd76b2ff1f7d4a9f0b0902f25d94ebe13ace6b997a7f604c3718700"
+    },
+    "my_progs/mon_swampling.qc": {
+     "bytes": 25637,
+     "sha256": "fb5ed328cd3d5c09704bb84f39138463a7d26b8b1d45771e55e9ae952b1d2470"
+    },
+    "my_progs/mon_sweeper.qc": {
+     "bytes": 27025,
+     "sha256": "8f7a1d077779d88d542a325c1ae4ba4ff59d48bfcb334150ae3f024525bb725e"
+    },
+    "my_progs/mon_tarbaby.qc": {
+     "bytes": 11866,
+     "sha256": "88c9481ab7fe0cbe97d2b836492ff51b368aeae8d4ff3e5852734bb9f63a1b2d"
+    },
+    "my_progs/mon_turretbal.qc": {
+     "bytes": 38519,
+     "sha256": "fdcf915248dda5fb6a744d284233d46a2e6d62c8e4fd02fdd5bafe4f46167d30"
+    },
+    "my_progs/mon_voreling.qc": {
+     "bytes": 27678,
+     "sha256": "7734614fa6b2da2195bf3804415c06a2d10f35825e86abf4f85613a182cf21c2"
+    },
+    "my_progs/mon_wizard.qc": {
+     "bytes": 15155,
+     "sha256": "3101ca37b57343697b3d3c7637fdc84c842f78ec9081e401dcaa6df0a9b1df83"
+    },
+    "my_progs/mon_wraith.qc": {
+     "bytes": 35464,
+     "sha256": "6a28a205cb8ac574e98c8d34a01ea859922e38d55c66346a7aa867ebf84bdb5b"
+    },
+    "my_progs/mon_xmas_elf.qc": {
+     "bytes": 17589,
+     "sha256": "053eec412485090ee1ebeac25887382db40e2ba7ca456050ba4407be3ec8bc1a"
+    },
+    "my_progs/mon_xmas_raindeer.qc": {
+     "bytes": 12189,
+     "sha256": "abbe1dd5c96c25b631231d4db2f17e8243075ad08c082e0448b7cbff34f1ae0c"
+    },
+    "my_progs/mon_xmas_santa.qc": {
+     "bytes": 17853,
+     "sha256": "cc60c6de17bc3321f9b1cf75b3229e387592c9eb7fc4bb57c1de0a8d2c0e62e6"
+    },
+    "my_progs/mon_xmas_snowman.qc": {
+     "bytes": 11486,
+     "sha256": "65928bb70cb2e9352c2f5e036eda2a6bd97aea09d459d0af563a82aa5a2f2673"
+    },
+    "my_progs/mon_zombie.qc": {
+     "bytes": 33988,
+     "sha256": "83f56482374c3a79fcc64058989bd210af3add006b7388d89c92e90543ec56a0"
+    },
+    "my_progs/mon_zombiek.qc": {
+     "bytes": 42214,
+     "sha256": "2b9926454484e93f5c053bf4fd35b2a97cf7e835c26c3b30061f1ff391af9f5e"
+    },
+    "my_progs/monsters.qc": {
+     "bytes": 56573,
+     "sha256": "c2c75832e6d5e83e929214ba5c1aa9a4661bcaf7754c20b3e9648171bf804a58"
+    },
+    "my_progs/part_emitter.qc": {
+     "bytes": 82744,
+     "sha256": "fca7491171d58974ef6b15550b9a7f0474641e9eac7ee5de52c6980c96445518"
+    },
+    "my_progs/part_generate.qc": {
+     "bytes": 42914,
+     "sha256": "83b9718a85418143d92ea8311cc8cce69c1002eb7563710dfe7010ac52e15d50"
+    },
+    "my_progs/part_manage.qc": {
+     "bytes": 27407,
+     "sha256": "86eb791f4bba08fc0c965e9f81c90e7412ed2c910104d66a56cce1f3152808fe"
+    },
+    "my_progs/player.qc": {
+     "bytes": 27811,
+     "sha256": "1f0cc3eaf577c2af642495466c573cd6e226a4754902d9de9cbfc9c9ba28af0f"
+    },
+    "my_progs/progs.src": {
+     "bytes": 2482,
+     "sha256": "c773f107c562f731fbb30158422226bdc4576dd32aea0f02c122195e08eac96f"
+    },
+    "my_progs/pushable.qc": {
+     "bytes": 19823,
+     "sha256": "03b3bf9240db6e9532e45a3efc159129709f9ce095c3238daae32daddd5b07ec"
+    },
+    "my_progs/qc_highlight.xml": {
+     "bytes": 6348,
+     "sha256": "a7b326723cc1e4025e867ea5da00f54c944705600d740538aeb52f63cd027ab5"
+    },
+    "my_progs/settings.qc": {
+     "bytes": 61298,
+     "sha256": "7a1ae40ba7fa97ff7e7019017bc7640fd49d22943a2ca57c7a7e48702bbe7158"
+    },
+    "my_progs/sounds.qc": {
+     "bytes": 19389,
+     "sha256": "bb74ecc36a241db5a79b010f61200687c6db6e46297db39c8a2a8ce1d512bad5"
+    },
+    "my_progs/sprites.qc": {
+     "bytes": 476,
+     "sha256": "579f48b397914b02f8fb86dc24f23d4e63a4cd857df1f0eaefd6c83e9c49e238"
+    },
+    "my_progs/subs.qc": {
+     "bytes": 23545,
+     "sha256": "123ca7120e7ea4e4ca63bfd081caf46c7acd1560af4702c1bff40821d7f6ef44"
+    },
+    "my_progs/subs_soc.qc": {
+     "bytes": 28453,
+     "sha256": "679112275e8b3597daac962074f69b6d9fd5614fc3dbff036815b9365e1413c5"
+    },
+    "my_progs/switchshad.qc": {
+     "bytes": 7054,
+     "sha256": "92a2fd4e5c41f21f46502781322ab87584bf0999d733db50e0e19b8bbea793b3"
+    },
+    "my_progs/targets.qc": {
+     "bytes": 58758,
+     "sha256": "e39b45bf6740be40c2899376e92d30d7d227a4762091d7b63e382c79fe6822e7"
+    },
+    "my_progs/traps.qc": {
+     "bytes": 24071,
+     "sha256": "9e4e822a36113bc73958fa45ab0b8c290a5148c95f3a4da7125676c984ebd202"
+    },
+    "my_progs/traps_pendulum.qc": {
+     "bytes": 17049,
+     "sha256": "b421f26fd80eb74715172e25f3ac992faa95397dd67d5f7ede286fd78384a468"
+    },
+    "my_progs/traps_sawblade.qc": {
+     "bytes": 9783,
+     "sha256": "9a6e82a05f09001c0a9cffdf6b9d6399691846c5b1ab1fbfb470e5772a87f44b"
+    },
+    "my_progs/triggers.qc": {
+     "bytes": 139586,
+     "sha256": "2e5819bf11fecf01856bd7547af63b7c4927dec59237419dbf3dc79bc023f54d"
+    },
+    "my_progs/triggers_states.qc": {
+     "bytes": 17475,
+     "sha256": "2c4d25c11de0319cd54d81e67e651c8d29d22aca851988d21080ba5976137f14"
+    },
+    "my_progs/weapons.qc": {
+     "bytes": 44346,
+     "sha256": "f23d0cc07bab402da965ec3fa91d7de86ccabcb03c9019cd7b217fbca7fb4279"
+    },
+    "my_progs/world.qc": {
+     "bytes": 39815,
+     "sha256": "b933caca23d5a45e5d9368627b3d651af244af0aa345b91017d263be4bad7b77"
+    },
+    "particles/fte_weather.cfg": {
+     "bytes": 2758,
+     "sha256": "e0d383b0222f14edbd2bc04c1269206bbcdca22cdeac6840b5d831c042ff698e"
+    },
+    "particles/particlefont.tga": {
+     "bytes": 4194348,
+     "sha256": "bf90d469b3b41c2393f5ed0f58b4411cc8825f452341bbe3ba848c3cc855639e"
+    },
+    "particles/particlefont.txt": {
+     "bytes": 9872,
+     "sha256": "9e84ef35b813211196f8dfc8f89a420fd9d847ea514e43d0c3246ee666000b88"
+    },
+    "progs.dat": {
+     "bytes": 2345354,
+     "sha256": "f3c4218216ea0d3b00db35eef9e72945ee6687006b3e82c37ea2ae33a0eea922"
+    },
+    "progs/ammo_battery0.mdl": {
+     "bytes": 10552,
+     "sha256": "06d4f0235faedd3430e57d602ec29a2a91c0b23bdc30debc069212264a0faf54"
+    },
+    "progs/ammo_battery1.mdl": {
+     "bytes": 10552,
+     "sha256": "0cee39ac60c3eda7b5f1d1efde52f8be19c9e4f425972f16ba6d6362d646afb6"
+    },
+    "progs/ammo_cells0.mdl": {
+     "bytes": 27228,
+     "sha256": "b6f5a07c9fd48cf27f0873320589dda1e20afe7d64cd40b6c950e5f892a34fa2"
+    },
+    "progs/ammo_cells0_edit.mdl": {
+     "bytes": 27228,
+     "sha256": "47ffc9eb8ec352ab2fa479f35ee5b6ec0e0ac8f472a06fbe00e8298e9d683ed5"
+    },
+    "progs/ammo_cells1.mdl": {
+     "bytes": 29836,
+     "sha256": "c23b4e85e9edd68fec2d751af85cff391a11848bd4338a3c59a2c055508cfce9"
+    },
+    "progs/ammo_lidlarge.mdl": {
+     "bytes": 25252,
+     "sha256": "d941a1c520e49694d66598f3430420541b318cea3e1cf02d3957e06d010681a7"
+    },
+    "progs/ammo_lidsmall.mdl": {
+     "bytes": 25252,
+     "sha256": "221b3aaa2324bea668276d3de521c4945004a71368983fc74c50c4b53425c436"
+    },
+    "progs/ammo_nails0.mdl": {
+     "bytes": 14072,
+     "sha256": "1090a9c50a943c2bf04302914f69b835ecf79fbf3013f259a12668ebd57aad5a"
+    },
+    "progs/ammo_nails1.mdl": {
+     "bytes": 15976,
+     "sha256": "8dd339507f4e18953ceefe3922d04ca513728bf2b0745813723873427843213b"
+    },
+    "progs/ammo_rockets0.mdl": {
+     "bytes": 24836,
+     "sha256": "9f272b2f1cb52fcf38983f63052db653e8208b2ee1eedf053e99dca6e439c7d8"
+    },
+    "progs/ammo_rockets1.mdl": {
+     "bytes": 27672,
+     "sha256": "46d85f10a260cf13d6711420f11a235089536a3725363be0717c2ee3e7e8a18b"
+    },
+    "progs/ammo_shells0.mdl": {
+     "bytes": 14072,
+     "sha256": "053e466f1666314cbfc0cd6f67821850ad39505a6a0bbf37c80b127e6887e5c5"
+    },
+    "progs/ammo_shells1.mdl": {
+     "bytes": 15976,
+     "sha256": "6183880b36171b6784cecf74b50aea2e1fdbc17b1b0b304a89125e964d63fd1f"
+    },
+    "progs/armour.mdl": {
+     "bytes": 76144,
+     "sha256": "b6e297062cffd435d6ce5cc17854e25a49ff09750ee1eaec6d5004266884099a"
+    },
+    "progs/artifact_airtank.mdl": {
+     "bytes": 50184,
+     "sha256": "4702b7be1baa517669edd24f5b67377f532382bfedebd77b5d77f9a499f3f08b"
+    },
+    "progs/artifact_blastbelt.mdl": {
+     "bytes": 28436,
+     "sha256": "a935de1300f6fc4f03b6fc57bf43791ac32b74d55c5509eda84339dc33f0bf48"
+    },
+    "progs/artifact_envsuit.mdl": {
+     "bytes": 260844,
+     "sha256": "09192fca32cf5b7632cf0fe9cccd9b4b1313c0e92708e85f840b0971aca5d274"
+    },
+    "progs/artifact_invis.mdl": {
+     "bytes": 7108,
+     "sha256": "f6b0b925b584402d85a623e1924c50a4fb3f3a4994cb1d2f05a169a3af2e39dc"
+    },
+    "progs/artifact_jumpboots.mdl": {
+     "bytes": 37428,
+     "sha256": "668d649addf958be26f2bcff31baf3afa5ff176a178ef15073c87cc7cb57e2b8"
+    },
+    "progs/artifact_lavashield.mdl": {
+     "bytes": 469773,
+     "sha256": "2e3027df661ca197750df97599084442afda131fbf1b545ea38d40e93afff908"
+    },
+    "progs/artifact_pent.mdl": {
+     "bytes": 21412,
+     "sha256": "7ae90fc895f23f57952dacf4d8af125f99347e09edf6f0287c7e508faad67b46"
+    },
+    "progs/artifact_piercer.mdl": {
+     "bytes": 19012,
+     "sha256": "fd73ca18d93904647df923f2d0383958386c7deb9cf27547beda74c61a9f8831"
+    },
+    "progs/artifact_quad.mdl": {
+     "bytes": 22052,
+     "sha256": "bf6d2253210784391ee1ab9b38d2b6fd661a520434bb127d293f4d202040d1b5"
+    },
+    "progs/artifact_sharp.mdl": {
+     "bytes": 49248,
+     "sha256": "505fc06618d7cecb83c03ad7d7762011ff8cff025eecf007b200d87fcc2483cf"
+    },
+    "progs/artifact_tome.mdl": {
+     "bytes": 21412,
+     "sha256": "ee8cf94e2c87ff6c0d4aa8777da2f0ddb79605bf790fb8f9ed2f49c6c1f9b9cf"
+    },
+    "progs/beam.mdl": {
+     "bytes": 26020,
+     "sha256": "bd06e42c7f0d911a4ef1077c95d474b86f62bca4da02183449687c23879e8c6d"
+    },
+    "progs/brk_pot1a.mdl": {
+     "bytes": 93352,
+     "sha256": "5612b9539e9663e06397f315968674b1de6ab50db7cdf673baadcd4652cedcd5"
+    },
+    "progs/brk_pot1aflr.mdl": {
+     "bytes": 93352,
+     "sha256": "02fd1feb7dc24b456e31f26f142aafb9adf491a16ea4caf2c4ec237e465260a5"
+    },
+    "progs/brk_pot1b.mdl": {
+     "bytes": 93352,
+     "sha256": "47c4053f0c0c941674a9d7c15a07e05c7ed648b2bf8ffbd1defb7264c151b47a"
+    },
+    "progs/brk_pot1c.mdl": {
+     "bytes": 83968,
+     "sha256": "a408707cc6793c337d0e76d86c5362de39a1f2109c23affe5def6e8194e0f4e8"
+    },
+    "progs/brk_pot1d.mdl": {
+     "bytes": 74024,
+     "sha256": "c31abc1e9e5af2cb86614f68a8be55f6192e05baba8b93479e2b2590b1e0ef1d"
+    },
+    "progs/brk_pot1part1.mdl": {
+     "bytes": 33768,
+     "sha256": "2dd32863b6006dda74b60f05a43df13e7df052ddcdb652309ba0ab29fa5352e5"
+    },
+    "progs/brk_pot1part2.mdl": {
+     "bytes": 34072,
+     "sha256": "550cae5c8893c63520c324610950eeb5b9fe842dc8ea1f07f6a217953f6e743e"
+    },
+    "progs/brk_pot1part3.mdl": {
+     "bytes": 33464,
+     "sha256": "819cf0e720637e7c5e187ccc67ae032eca217ee2f07076aefee1a8b7de894852"
+    },
+    "progs/brk_pot1part4.mdl": {
+     "bytes": 33496,
+     "sha256": "a3cc47c7f7410bb0ca2308e45144b29bc3b678600e0f288b15d8e64525585e43"
+    },
+    "progs/brk_pot2a.mdl": {
+     "bytes": 77348,
+     "sha256": "ffcf5e5f3d0b81143e2b2b387cde7b13b2d36b71345d63456f288eb036993a2b"
+    },
+    "progs/brk_pot2aflr.mdl": {
+     "bytes": 77348,
+     "sha256": "37420048a9f72abc5982f5f6813602dbc4b82ef8e788a0e309df7ff13066ea62"
+    },
+    "progs/brk_pot2b.mdl": {
+     "bytes": 77348,
+     "sha256": "40eb2c849cd06d9b985b0efc2b9d1090ec1648b0de53d0a07bd6fd5fe2af6733"
+    },
+    "progs/brk_pot2c.mdl": {
+     "bytes": 77348,
+     "sha256": "3774ade6790fc2b597c44c5206deeb3d5d3d20a23331e3fb622e1e90f833c7d4"
+    },
+    "progs/brk_pot2d.mdl": {
+     "bytes": 79004,
+     "sha256": "2af25d81ae0f1d8724f3047e95ff2f1d1700061a536b3f9ffda5522cf7e8dd13"
+    },
+    "progs/brk_pot2part1.mdl": {
+     "bytes": 34456,
+     "sha256": "13547d9ca8c36bbcc95354df03dfbdc14f19f74251ff1dc8c417436846b396bc"
+    },
+    "progs/brk_pot2part2.mdl": {
+     "bytes": 34680,
+     "sha256": "7f9824c52b01664c2dd1ccc5c1dc9e7ff2a5567dd2d0a8e9c3bf1a8bd00400e7"
+    },
+    "progs/brk_pot2part3.mdl": {
+     "bytes": 34008,
+     "sha256": "52fdc17879e0b6fb8697e1e9fffba092f1b5aa8d3cee5d657b405eb4119e8e87"
+    },
+    "progs/brk_pot2part4.mdl": {
+     "bytes": 33304,
+     "sha256": "b40cf2b029a4bfac52a80f5aef6587f3eb66e08be1fe5f40cd3f97e93133ad3b"
+    },
+    "progs/brk_vase1.mdl": {
+     "bytes": 27992,
+     "sha256": "28a8b9a0d367f17c2c265271d99b019f1762831a11ba794e2884fc7f7a8a2368"
+    },
+    "progs/brk_vase1part1.mdl": {
+     "bytes": 5524,
+     "sha256": "b8c0bef8f5d6a427f57282f086a75f39e91ad6ab035d4f1d437da97794e52f9e"
+    },
+    "progs/brk_vase1part2.mdl": {
+     "bytes": 5556,
+     "sha256": "8e1df7795140732953af83a1ef2158299a2cc393163041b6d3243478b6b644e1"
+    },
+    "progs/brk_vase1part3.mdl": {
+     "bytes": 5556,
+     "sha256": "c2e3da479defb1c3bd5130555e33dd47afc6a3b4ef7f74d4f0184cb02a02a46d"
+    },
+    "progs/brk_vase1part4.mdl": {
+     "bytes": 5524,
+     "sha256": "986c51c2cb3832f597f9dac89c6044d090b10933306814acc36a0c4ab5a04b93"
+    },
+    "progs/corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "839b70bb6be7fac8c25e6069b999e076b04bdd3dbc7a9320924713cf75c2cadb"
+    },
+    "progs/corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "cb994b390584e1776ad1f0e60d95186a0dc54cd160a2cb8284d1a15b4fe1a35d"
+    },
+    "progs/corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "b19faa9afe7cf957ae7abf6439799e5001ff42817290f4b464aa3f7ae4e3377f"
+    },
+    "progs/dance_player.mdl": {
+     "bytes": 465924,
+     "sha256": "d07f23e6a40743aeac01084a1da9670ea9a635339d86be46149e9f0ee74661e0"
+    },
+    "progs/explode_box1.mdl": {
+     "bytes": 49888,
+     "sha256": "c8a7e667c5e20735db9a816b7a11b5a1c67bf4e176d1553a79cc56bcaa9ff35b"
+    },
+    "progs/explode_box2.mdl": {
+     "bytes": 49888,
+     "sha256": "649dbfabde0a875a0c35b0109261515dc9eb287d0cc7f41ca3712283e62509c1"
+    },
+    "progs/flame.mdl": {
+     "bytes": 41668,
+     "sha256": "d6cb4dc28d5101538b44ed53fe1cf84c9d5f8547a91eb74fc6c6bdd3645ffa17"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 74548,
+     "sha256": "f03dd3b7f94a86c4d91ffb002723a16f30321a0c2189b673dd4f12f547245816"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 71268,
+     "sha256": "b1e734caec73b941b1c033fbb49ffc0f947aa8e1d47250c2d8cec0f244870fc8"
+    },
+    "progs/g_ghook.mdl": {
+     "bytes": 64684,
+     "sha256": "9cdd8bccab5f11ea7f8ea6480a4ea05c9d749bc4746cc19a6452a2e0356edfc6"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 32404,
+     "sha256": "b195b37f7e96274ea7db8e70dcf5971275bafdd0c9c10c29f2dc540c38641953"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 35876,
+     "sha256": "8ee090222c89209eec97120d5542d69a9f75b8a8aa896cd4df256d438ce83495"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 25316,
+     "sha256": "261a8479de0d5df9aea9931a62b1b93dbb7bfcff4f4467920cbebcc9c2c25381"
+    },
+    "progs/g_shadaxe.mdl": {
+     "bytes": 398968,
+     "sha256": "19d6f210a771748da589282e63a222c6c9c41a21085ed3f57f70d7f5aa20bd66"
+    },
+    "progs/g_shot1.mdl": {
+     "bytes": 24580,
+     "sha256": "72913fa948f1618347adaa91ceb98203186d2fc7bd3b9c84af00f7f637928058"
+    },
+    "progs/g_shot2.mdl": {
+     "bytes": 15876,
+     "sha256": "8ae318a3e697e4c85f60a4e5997b673e8e48f17e295551c2b0b5d0c643b3ac24"
+    },
+    "progs/g_shot3.mdl": {
+     "bytes": 156216,
+     "sha256": "8a602686e322d7357a102e0c8e91907c8b3975a8b6d36ba19f3c645e450285da"
+    },
+    "progs/g_zershot.mdl": {
+     "bytes": 68020,
+     "sha256": "3439ce2faa846bd2b3ca50e33b55092454ed83caaf8fe654d8381e107aa3520a"
+    },
+    "progs/gib_1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib_2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib_3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/gib_4.mdl": {
+     "bytes": 7468,
+     "sha256": "29f9cfa3d86121e1e349de9c3a39e620b9d6ba2cd98640536923e581f7ae28bd"
+    },
+    "progs/gib_5.mdl": {
+     "bytes": 85308,
+     "sha256": "2023ae2fd305843640266ec6679511d134e1b84ac54de245a390e483557050bd"
+    },
+    "progs/gib_blclaw1.mdl": {
+     "bytes": 32860,
+     "sha256": "303c38aea48534d4ce34f3c2082a21c7408c1e4a4cd848bc7e4acadfaaddbdc0"
+    },
+    "progs/gib_blclaw1b.mdl": {
+     "bytes": 32860,
+     "sha256": "c22db765c594ee28a0863cf70e354c651a2b9282e1df7e3a57b35ce62932920d"
+    },
+    "progs/gib_blclaw2.mdl": {
+     "bytes": 32860,
+     "sha256": "c7d70c4c067aa297fbebc3d26a2068a62f307c7f00f8d15d0bf76ed9519967c8"
+    },
+    "progs/gib_blclaw2b.mdl": {
+     "bytes": 32860,
+     "sha256": "96a96606a74eb3093d88f1f946d66caf77bd57fde0a4ec44840c95fa12130551"
+    },
+    "progs/gib_blfoot1.mdl": {
+     "bytes": 32860,
+     "sha256": "74e05efa33fc9036399a1f1d484a3816129fe0e379aee579b923cf3316e5ab84"
+    },
+    "progs/gib_blfoot1b.mdl": {
+     "bytes": 32860,
+     "sha256": "2d23324414f3f1a25ee24afe914679d07df244c9c0e48139331f084b8c369054"
+    },
+    "progs/gib_blfoot2.mdl": {
+     "bytes": 32860,
+     "sha256": "c2ce3b46d8762b042d201608271c3441b975b93e6329790ca5cba61294f71e45"
+    },
+    "progs/gib_blfoot2b.mdl": {
+     "bytes": 32860,
+     "sha256": "de945be28e0b05dc380a0a2cfff6907f14a5e4b9756385874fddd712df095bb6"
+    },
+    "progs/gib_dmclaw1.mdl": {
+     "bytes": 49248,
+     "sha256": "be5f2bb9174ce47f6d3df06685ac728c852c3a028f6aeb1632e709eb69c20ee2"
+    },
+    "progs/gib_dmclaw2.mdl": {
+     "bytes": 49248,
+     "sha256": "ff6cc88ef9123812b9d8e09235074f4c7fcad47077e6fffee334f15e3f71eb27"
+    },
+    "progs/gib_dmleg1.mdl": {
+     "bytes": 49248,
+     "sha256": "106990e4d9e2746303d09ae6c481914702af0242d8cf0fc9d430d0fa5329813c"
+    },
+    "progs/gib_dmleg2.mdl": {
+     "bytes": 49248,
+     "sha256": "8308124b7c4dca218af9e8ef7042ddcb0ca2fcb30e7f86866b1a28a73ab94db2"
+    },
+    "progs/gib_dmtail.mdl": {
+     "bytes": 49248,
+     "sha256": "6b60c464ee0e7ace54313550ac5be2f4949cc6f8dd539b38459c4a6c395e6704"
+    },
+    "progs/gib_drolearm1.mdl": {
+     "bytes": 18324,
+     "sha256": "a6b0f55da1b1d8e519b3cb9a53afe229279c760ffab3862866d8c4e7a52f267e"
+    },
+    "progs/gib_drolearm2.mdl": {
+     "bytes": 18212,
+     "sha256": "aff67984dc3198d24d2184c35748e829d7f867c38227f1fa898a1986f12ac767"
+    },
+    "progs/gib_droleleg1.mdl": {
+     "bytes": 18436,
+     "sha256": "ab69d8c271f44998ccdfd10d70ccd06caa3c2674f46e4cf94285b380d08db501"
+    },
+    "progs/gib_floyd1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/gib_freddiejunk.mdl": {
+     "bytes": 71364,
+     "sha256": "13763a8cec3b643acb9b8165f1850ffae003131c84a2ac225777822a88462498"
+    },
+    "progs/gib_gargwing1.mdl": {
+     "bytes": 92088,
+     "sha256": "3979718d2403ca7cf75aad4004a56100c1bf358f2cb9ae68595e5d69f6774f47"
+    },
+    "progs/gib_gargwing2.mdl": {
+     "bytes": 92024,
+     "sha256": "7554ef45a88db1f2e457dd7071770e42bf864123827b9819435a628b412ecb32"
+    },
+    "progs/gib_judgeboot.mdl": {
+     "bytes": 199308,
+     "sha256": "557eadb703666c4868e1b231cb1c21fbff5e59e2ec0cb8ade85cd3839fd714cb"
+    },
+    "progs/gib_judgeshould.mdl": {
+     "bytes": 199132,
+     "sha256": "69e4958866a47d5c63a6385db4843a6a5011f149b25e67720291d2db63945ed8"
+    },
+    "progs/gib_justiceboot.mdl": {
+     "bytes": 264848,
+     "sha256": "b727239a7bf232c7c6164d0f9fc0961a6c692cb0c0919b17429ade6f62bdd71c"
+    },
+    "progs/gib_justiceshould.mdl": {
+     "bytes": 264672,
+     "sha256": "2fcafb2b2a19b8ae16009e827f13fea14cb389317ec476b7f58fb2fef1163180"
+    },
+    "progs/gib_knfoot_l.mdl": {
+     "bytes": 18288,
+     "sha256": "8ffcc7ce931662f2eefa0703642b140e18a99c02252ffa3ddeb71f6ebbbe360f"
+    },
+    "progs/gib_knfoot_r.mdl": {
+     "bytes": 18288,
+     "sha256": "4d503f422ac01a8565453ba4bd8268338c3a9802480785eebd27fc0487e46753"
+    },
+    "progs/gib_metal1.mdl": {
+     "bytes": 5172,
+     "sha256": "b0951de4d869e0b779aeb3f7a96f56b22a82a58d267a56b1247f0c3e667c25ad"
+    },
+    "progs/gib_metal2.mdl": {
+     "bytes": 6292,
+     "sha256": "3df78c49abb572095d3b70efbb99bccb63caf2ffd30bb3ee434c945084acb5a0"
+    },
+    "progs/gib_metal3.mdl": {
+     "bytes": 6036,
+     "sha256": "88f8a1f941e38f8528ec27a168559946cc0b69f2abce1cbf6858b813e09c5f51"
+    },
+    "progs/gib_metal4.mdl": {
+     "bytes": 6580,
+     "sha256": "fbde734f29a6691d51c58a40a89e45f81dece2f20218353a6137a2362acbe3a9"
+    },
+    "progs/gib_minoclaw1.mdl": {
+     "bytes": 135544,
+     "sha256": "1188f73d5a6319bef5e506ca994bfcf63074a4267a5a189cb92db94160310fca"
+    },
+    "progs/gib_minoclaw2.mdl": {
+     "bytes": 135544,
+     "sha256": "511bb72c8382f4cc3cc9fa3bea4adf2390dcca1e2dcd42ef8f8287765875fa99"
+    },
+    "progs/gib_minoleg1.mdl": {
+     "bytes": 135448,
+     "sha256": "f07ce357d83d3ab0f39109d93f2f6996ded4ff19a4372fd5ddc9d9fa1a0ce8d3"
+    },
+    "progs/gib_minoleg2.mdl": {
+     "bytes": 136392,
+     "sha256": "7ba78149bc60a05ceff9090ecc2bdf013ff2d55420dfdebc553a254ac0bd08fb"
+    },
+    "progs/gib_ogfoot1.mdl": {
+     "bytes": 5956,
+     "sha256": "144e2fdfbccceee039243ef343df02ce181b666070e2d0a1825c056634f2a632"
+    },
+    "progs/gib_ogfoot2.mdl": {
+     "bytes": 5956,
+     "sha256": "9997dff0bdb2622ef6ee2530c27835fd249aee04437e70486e76255f979bec25"
+    },
+    "progs/gib_p1.mdl": {
+     "bytes": 7712,
+     "sha256": "709c49c205b27793f589eab17e8356a108345069716f9095dc07dd6447be7894"
+    },
+    "progs/gib_p2.mdl": {
+     "bytes": 21216,
+     "sha256": "50d99c7fec3b8ef01bbb19c32c88dac40a372cb6a7d39c349e0ff4909360626f"
+    },
+    "progs/gib_p3.mdl": {
+     "bytes": 18176,
+     "sha256": "d53659aa99de418793337b7e878db7bd7836883ad43528d648475589aa30d85d"
+    },
+    "progs/gib_p4.mdl": {
+     "bytes": 7468,
+     "sha256": "71ad4dcc06038f0a175605a3906b1506d0144b56b238e7df178160d9ab876b8d"
+    },
+    "progs/gib_p5.mdl": {
+     "bytes": 19756,
+     "sha256": "adf63c881ff5703b8112f714140929375b5c10be957f01cfdfa131d89af3cacf"
+    },
+    "progs/gib_s1.mdl": {
+     "bytes": 7712,
+     "sha256": "31faee0daaf399feccc1ec942ff7fe85a1a790ebd93c3b8a1fcfde9bcc06da1d"
+    },
+    "progs/gib_s2.mdl": {
+     "bytes": 21216,
+     "sha256": "c85f7dbc8eec508951893253bba5eec169a87865c995ba1d0e5c083fed9e03ca"
+    },
+    "progs/gib_s3.mdl": {
+     "bytes": 18176,
+     "sha256": "ec23effca60ef407bf294a814003213928f21f05e6da501fbe996345b6171013"
+    },
+    "progs/gib_s4.mdl": {
+     "bytes": 7468,
+     "sha256": "5001ef206e1a36cc792d7b94054b2bab4c6dfbed60e0ee0d3afd240d1af88d13"
+    },
+    "progs/gib_s5.mdl": {
+     "bytes": 19756,
+     "sha256": "9e1a112412d38c559974c628649a7773ad445ba7d24a1804c5f3fe5f50ecef7f"
+    },
+    "progs/gib_scorpclaw.mdl": {
+     "bytes": 66816,
+     "sha256": "ecaf582e92d77a1722eded2c5564d2fb9575065510ff1bc9632538345ed18329"
+    },
+    "progs/gib_scorpleg.mdl": {
+     "bytes": 66304,
+     "sha256": "399067acf8f082301f6629d2b124b0d34a7d934db55c922205a96772a85a8a1c"
+    },
+    "progs/gib_scorptail.mdl": {
+     "bytes": 66864,
+     "sha256": "0831c04d7a73c6f58329b0be0f6d371f727ea880b49e5b6e16f7cdc56c124df2"
+    },
+    "progs/gib_seekarm.mdl": {
+     "bytes": 265688,
+     "sha256": "6ee70b2f4f39d8a1fd99113c7c8df5481c421960f160afea4e622ed5b3113014"
+    },
+    "progs/gib_seekchunk.mdl": {
+     "bytes": 265420,
+     "sha256": "a70331a8e43075b026cf21d364cf2341e79e7e60c5fca4777d10aabd57ce0323"
+    },
+    "progs/gib_shclaw1.mdl": {
+     "bytes": 22964,
+     "sha256": "20b29bf40dd02dce0204c14c34b0b5806d8eef580406851d73383a631ac8f2a7"
+    },
+    "progs/gib_shclaw2.mdl": {
+     "bytes": 23060,
+     "sha256": "8dcf777d5ffd2e83edf5b6f936881eaf9d384fe8fc980721c9f5881d3e6da0c3"
+    },
+    "progs/gib_shfoot1.mdl": {
+     "bytes": 23268,
+     "sha256": "634d7cbb9e2b718167fe74112e6dd4f53cfe1cffc32f75cd80e711a24cd2f983"
+    },
+    "progs/gib_shfoot2.mdl": {
+     "bytes": 23124,
+     "sha256": "aaa2393cb65fb33a8885bfdd9b808732c0aa17f0dd461d3b04e84eb27f0fe61d"
+    },
+    "progs/gib_soldfoot1.mdl": {
+     "bytes": 51148,
+     "sha256": "09357cfed1e6c9c25e0d133d95f2c2b36693cbed1010146a982bca685cb370ed"
+    },
+    "progs/gib_soldfoot2.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/gib_spidbodyb.mdl": {
+     "bytes": 17652,
+     "sha256": "313dc78de70f02de9a49c71a1fd5ddb5ae4247f90a1a04f0ab84f44797be1946"
+    },
+    "progs/gib_spidbodyg.mdl": {
+     "bytes": 17652,
+     "sha256": "5439ca0812bc2627f22fd995237607755708f7615782785093793c11497973e5"
+    },
+    "progs/gib_spidlegb.mdl": {
+     "bytes": 18560,
+     "sha256": "66dc12710dec1bd4827497e4ed28b6a4965e1f68b48d5f0903a96ecf632e7f4e"
+    },
+    "progs/gib_spidlegg.mdl": {
+     "bytes": 18560,
+     "sha256": "3474de5b97c2b424f8ec4b8d93a1457f13adca106bdbe15234492376708810f9"
+    },
+    "progs/gib_steelbody.mdl": {
+     "bytes": 17652,
+     "sha256": "2a833de4b00f439041d27d97b3660d4df1cc9e3b454dba5ac5533e5c855e8d90"
+    },
+    "progs/gib_steelleg.mdl": {
+     "bytes": 18560,
+     "sha256": "ae926ada1c4ef7b695764f2daa0b4704102bf5eebc103b9f6a56813337f43165"
+    },
+    "progs/gib_swampleg.mdl": {
+     "bytes": 4820,
+     "sha256": "2b549fd3a74b0fd6b94c71c9e397b466e2c7f823917ffe717ce1af43769e1961"
+    },
+    "progs/gib_swamplegp.mdl": {
+     "bytes": 4820,
+     "sha256": "b5cf22240bf6474cc8ea57c40ddb70f80e792c23cb87835bee94825cb645578a"
+    },
+    "progs/gib_voreleg.mdl": {
+     "bytes": 4820,
+     "sha256": "19ec59cb3436d66a8ac9d8f40480a9c83aef879f0f1e58ddb834710e2bbc4d9d"
+    },
+    "progs/gib_vorelegp.mdl": {
+     "bytes": 4820,
+     "sha256": "341679c553a719be40022fc4a3573ff68116fee7ae05df511b9083a410af5e7f"
+    },
+    "progs/gib_wraith1.mdl": {
+     "bytes": 5300,
+     "sha256": "a0642c84b36288a3d0cef22ac32e0c681c422a034204932671729624f19d0b2b"
+    },
+    "progs/gib_wraith2.mdl": {
+     "bytes": 6292,
+     "sha256": "d20a17e624d16e4c8552ac9a291cd735aeae670effc2c9865b37fbc7bcd22220"
+    },
+    "progs/gib_wraith3.mdl": {
+     "bytes": 2516,
+     "sha256": "63f10b068c6df0a80729362c094f72d0bcf90f74de97636bc5e4a630c13e741b"
+    },
+    "progs/gib_wzarm1.mdl": {
+     "bytes": 12384,
+     "sha256": "9b6f5469bfc6ae49d2bd51fb6d35e686c4e79e5691e2fb80fa7ee556bf547e04"
+    },
+    "progs/gib_wzarm2.mdl": {
+     "bytes": 12384,
+     "sha256": "2ff539f467ca9b0f23c40cb2547221a484afbe7e07a812558ec1595e5cbd0217"
+    },
+    "progs/gib_wztail.mdl": {
+     "bytes": 12384,
+     "sha256": "fb90123980ff4510e744ea2b21509492b7ff9c131527ffe5c7b80bbbf881bf41"
+    },
+    "progs/h_boglord.mdl": {
+     "bytes": 98400,
+     "sha256": "119279b2ffdf928d34ef1470ae6c14f875cb59edc6d8b107a90bbea122c9acdc"
+    },
+    "progs/h_boglordb.mdl": {
+     "bytes": 98400,
+     "sha256": "25af0d0ea45857e64549686bb58e5f69a0754ff6e43c26ce735e58aaac3d534e"
+    },
+    "progs/h_centurion.mdl": {
+     "bytes": 63592,
+     "sha256": "2e64af530a4f5f36001ad922bb56a941738e7fe2c67c0ad0e3f06fa5854c4b08"
+    },
+    "progs/h_dcrossbow.mdl": {
+     "bytes": 25700,
+     "sha256": "0354fdb96bd5490bc18527d68813a43a41f943a05f7edca26c1aea7b943185be"
+    },
+    "progs/h_deflector.mdl": {
+     "bytes": 22232,
+     "sha256": "56de00c315543073bfda7e8a5ad3c3996f549351fa1e660e676516f4122cdeac"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 67688,
+     "sha256": "ff73d5f8fcab46a806c47377679ec5473cdc0ea93a0fda6dda8b5dba8cfa4b97"
+    },
+    "progs/h_dfury.mdl": {
+     "bytes": 14036,
+     "sha256": "3753a68126ff7caee3219c31533a1731ae9a80623c6af69315c7526f5c92669d"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 19296,
+     "sha256": "6b0867e61635543a7bb3b02647855f1384961095cd06dfc786a537b11eb926ae"
+    },
+    "progs/h_dguardq.mdl": {
+     "bytes": 4920,
+     "sha256": "337f2723daab9d1375b78cb017512ce8281087ff8df9c33b04a6c613cea3590c"
+    },
+    "progs/h_dknight.mdl": {
+     "bytes": 32144,
+     "sha256": "30af2418019b946f3582f70d2356357a97dff0391f86a9fb0abd5218cc799020"
+    },
+    "progs/h_dlord.mdl": {
+     "bytes": 18699,
+     "sha256": "bc5a92be1c5f3d06dc0238ec7bafe6a3c25826cc50edc6214ed5aa19b0075987"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 27652,
+     "sha256": "49f28b9a13867ed4a88fcac541b8a9cbabddcc594557b3490951179b3d479509"
+    },
+    "progs/h_dprince.mdl": {
+     "bytes": 19336,
+     "sha256": "77855cfc2667ed68c61d389a44ed312abc3ad1e029ea003d03e78e7131fb803c"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 14032,
+     "sha256": "bd5da6afddc520999d9c572a679c3bc8c43635ce2c73f8789603eb6a83c15aa1"
+    },
+    "progs/h_eel.mdl": {
+     "bytes": 156904,
+     "sha256": "a859ee09044d9afcd05ee2af3f1ea8c7b4ae3abc01273922dbebd5aa67b12d74"
+    },
+    "progs/h_enforcer.mdl": {
+     "bytes": 94612,
+     "sha256": "21046f6878f5f4173206debcb912d9fdee0b1f5c66d820a4355c7df8e2eb1860"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_gargoyle.mdl": {
+     "bytes": 30152,
+     "sha256": "bbcf207c44814f5e665944db03800934eab9046a0d0d86f4c982a3116f855791"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 59888,
+     "sha256": "f57daa1ab6a721a9feb696aaeeb597c720b639cd0a027a1b1da8cdd68ad1d1f0"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 30552,
+     "sha256": "edf8a4ccc52bfd9545fda8da9360e536c026079f8d2fd9756191fc934bd55683"
+    },
+    "progs/h_hogre.mdl": {
+     "bytes": 23688,
+     "sha256": "6f21e95518cd085d20b1023951ddf4d738285210bc95c6e2b3d2e82566478776"
+    },
+    "progs/h_hogreham.mdl": {
+     "bytes": 22776,
+     "sha256": "3d3e43d16c4babcbca358b44dc03ad1a212e22ea3a10ee9e639b5f4c2e95f670"
+    },
+    "progs/h_judge.mdl": {
+     "bytes": 203276,
+     "sha256": "be57ef7327fbf3ea6fb55c02bcccc4ec207b3781bb9d2e383939f3840e1ef91a"
+    },
+    "progs/h_justice.mdl": {
+     "bytes": 268816,
+     "sha256": "01d3011001c297b85a139ecb2861f188d15b96cd1ae02f08cb1604565f2d2ee3"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 42068,
+     "sha256": "aa979e22745c960cd100e814bce62018f2b992481e57838548f0ddf4816c27a8"
+    },
+    "progs/h_minotaur.mdl": {
+     "bytes": 138264,
+     "sha256": "c5e13818c813680fd29a94b408518731aa4e9007c23d004ec874f099c9ced6b1"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "4967d418f4810e9273732bbd4c690a1f9478243f7fe3807497134eb2994da0eb"
+    },
+    "progs/h_pyro.mdl": {
+     "bytes": 42912,
+     "sha256": "5359fd85e71cde1ab716d8d50a8618a347dd42b4ad4692805bf41c1903d55c18"
+    },
+    "progs/h_scorpion.mdl": {
+     "bytes": 67408,
+     "sha256": "d68d09c35c00d9bafb302fb7f3baeef90ee5d60de1ad8a7627f979c3561f5965"
+    },
+    "progs/h_seeker.mdl": {
+     "bytes": 9060,
+     "sha256": "9e9d601441532e16aee253b5e94ea9c32563f880782794d16ce496a580698bd8"
+    },
+    "progs/h_shalrath.mdl": {
+     "bytes": 78156,
+     "sha256": "f478f17ea9ee6843be2ebe3c487d0036657c94ace52a800fa44e0160d02a522d"
+    },
+    "progs/h_shambler.mdl": {
+     "bytes": 98400,
+     "sha256": "6508f7b05b65f230b7f1280d2023e9ed200663715db1709c43e7e187e3ed841c"
+    },
+    "progs/h_skullwiz.mdl": {
+     "bytes": 234304,
+     "sha256": "625c991e231d6836c36ae0c6651ec06f05541e9a7be605654fb43fba65bcc3d4"
+    },
+    "progs/h_soldier.mdl": {
+     "bytes": 166488,
+     "sha256": "0a4e322fbac8f98755adb9a4bf5ecff24d58aab30fcb1c9def3e97a0f686445e"
+    },
+    "progs/h_spiderb.mdl": {
+     "bytes": 18564,
+     "sha256": "d51c7764fccc4512db6d79ddcf03ffe42cf2817a66d6be02be0cba6551ee1206"
+    },
+    "progs/h_spiderg.mdl": {
+     "bytes": 18564,
+     "sha256": "70bec9669f3a7f3662320e32d29c38d535092db56617d5033e11669038472e2b"
+    },
+    "progs/h_steelclaw.mdl": {
+     "bytes": 18564,
+     "sha256": "be9adcdf9cf9407a729cfa9abcd692f46a55ffcf25c1878a7b2f5572fd591f8c"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "63b8a0b90691ae9a3c50a94f02943a1b94946f89402cc4e1da74c6806bd953ba"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 23516,
+     "sha256": "5a933ecbc067b8d6cbb57f71ae1614844b6e55170a206d278b3d15fe619c9cfd"
+    },
+    "progs/h_zombiek.mdl": {
+     "bytes": 4920,
+     "sha256": "9b8b3af67bdec6160ecd3880acc072b833886f7fc11d1e64ffcf06184f9ba80e"
+    },
+    "progs/health_100.mdl": {
+     "bytes": 6948,
+     "sha256": "6c6646f6081ab00ed1c309de3b697009c825d64360b06c741a533b718e0ab8d7"
+    },
+    "progs/health_100b.mdl": {
+     "bytes": 23248,
+     "sha256": "d82148af4482e3c0ff07389ebb5b09cdefda373e31105aeb7308b4126b353a97"
+    },
+    "progs/health_15.mdl": {
+     "bytes": 6788,
+     "sha256": "838b0cb6fd11ff7fdf268b1607a1999e5dce0dea11386afe5ff207e6ff734aeb"
+    },
+    "progs/health_15b.mdl": {
+     "bytes": 10948,
+     "sha256": "eb1bb584805aea34a0f0ab846a758cdc359b730e144e141dcd756da23b5831e1"
+    },
+    "progs/health_25.mdl": {
+     "bytes": 7332,
+     "sha256": "ce8260929500cac3b57617345b2c6b5a75e763afdbd10120982e7d7fa55be27a"
+    },
+    "progs/health_25b.mdl": {
+     "bytes": 23248,
+     "sha256": "7aba68839958035319b2167369f3fcd08c9d49140969cff7fb523b7023362e00"
+    },
+    "progs/health_5.mdl": {
+     "bytes": 6164,
+     "sha256": "a8ba7ece01b3cb58b2f94ca20a9f4511871d26ec894b54c04e433f29fc7c3bef"
+    },
+    "progs/key_base.mdl": {
+     "bytes": 54436,
+     "sha256": "fb25488fa2fc16c7c4df260a20fd905a821607a675fd0907a6e65f9d534fd367"
+    },
+    "progs/key_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "2632cb327c1175b351d026e88a4e456c45779a0dcdae01381b24200769c8743f"
+    },
+    "progs/key_gold.mdl": {
+     "bytes": 9332,
+     "sha256": "e93ed2c4263bf7631efcbace2c36ed6f240bfcc2b49491751f6d6ce55db8c098"
+    },
+    "progs/key_medieval.mdl": {
+     "bytes": 58532,
+     "sha256": "0810c558e40c5833c19283eb849ba80ac5dd3499e0f077b724057c51730ee097"
+    },
+    "progs/key_rune1.mdl": {
+     "bytes": 18900,
+     "sha256": "90ac269965d42da0205307eeeaddfa5b282598b5218af8650d2d8854621ca950"
+    },
+    "progs/key_rune2.mdl": {
+     "bytes": 19828,
+     "sha256": "4a6644f0b583c85aa41362fb4533cda5f8f762bd4429e5007b3ab57e5e24ae57"
+    },
+    "progs/key_rune3.mdl": {
+     "bytes": 19700,
+     "sha256": "9b33cc0feed9fc27ea647f6d127941933aa5378b52a3f75b9331714fa9d2ff31"
+    },
+    "progs/key_rune4.mdl": {
+     "bytes": 19220,
+     "sha256": "515534b8fdaa0ef99621f0f7d59d268c0c244562372e23c13e9ce05a44e0a68a"
+    },
+    "progs/key_runic.mdl": {
+     "bytes": 57444,
+     "sha256": "e0e31948c1e172c3c9117a8ccd72900c6ebd7a7e73882ae525dd116230f054e2"
+    },
+    "progs/key_silver.mdl": {
+     "bytes": 9332,
+     "sha256": "dd54032e82de32cf1b78a25f862a82a73e9dc0926d89ca7a4279b45d367a8478"
+    },
+    "progs/misc_bmkdigit.mdl": {
+     "bytes": 3328,
+     "sha256": "1a7f2f762ef3a052a91db7c74cf8d980db47a56685fc61184a15be2152e843b8"
+    },
+    "progs/misc_bmkdigit2.mdl": {
+     "bytes": 3328,
+     "sha256": "2e690ffe1af05f5ad88fe90c180785adeeffdb2b330aa34c6f4fb9885285cd1e"
+    },
+    "progs/misc_bonepile.mdl": {
+     "bytes": 110796,
+     "sha256": "0f8061359681f3c11660e472c517599590447c7631edfe5a36debd9645acdec6"
+    },
+    "progs/misc_book1c.mdl": {
+     "bytes": 40096,
+     "sha256": "92b976437673f56cb890f0e1b90a550ea00939d01ee12b0df0f218b35b42953e"
+    },
+    "progs/misc_brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/misc_braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/misc_broken.mdl": {
+     "bytes": 744,
+     "sha256": "828998b238e1c5471461edc3b9d2d7fada2beab6229272041dff13a94c1d73ec"
+    },
+    "progs/misc_cable.mdl": {
+     "bytes": 57780,
+     "sha256": "bed2cca38ef4cbefa9e645eb5e9ffadffac6ebb4f2ac5f6da4bb8f354de22a48"
+    },
+    "progs/misc_candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/misc_candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/misc_candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/misc_chain.mdl": {
+     "bytes": 231184,
+     "sha256": "845fc3117f7d9860f2d0aa4a398103a13f327516144a96db508189ae1be5788c"
+    },
+    "progs/misc_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "3337f2cfe739c22d50edde7bff18c026d4336bceb207dacf8b0284ab0a5366cf"
+    },
+    "progs/misc_corner1.mdl": {
+     "bytes": 21668,
+     "sha256": "7abf8d5ca497d5e8c8ddcc09c710c0401edb71b11f9de77a2daa81b1267e5698"
+    },
+    "progs/misc_corner2.mdl": {
+     "bytes": 21348,
+     "sha256": "369c874a37ef1da8c9a79432ba2ab9484a5be0df120131b8cbac81e1786adf47"
+    },
+    "progs/misc_deadtree.mdl": {
+     "bytes": 195728,
+     "sha256": "d267db8cfc35b01430590cec643570b38f8df5872c9c3e43df31dc0f3a954e5b"
+    },
+    "progs/misc_digit.mdl": {
+     "bytes": 3328,
+     "sha256": "60f16b89c1e9b8fb8bea0c0aeb96d2dbcfc14a719c130aaa34a581b26e653416"
+    },
+    "progs/misc_doomhelm.mdl": {
+     "bytes": 70104,
+     "sha256": "1b801d032daa163fab361a39631a16c501b86cc9e9b1a52a3f1454e50cdb8c8d"
+    },
+    "progs/misc_dpull_s.mdl": {
+     "bytes": 12900,
+     "sha256": "77fed0a028829fc7120db625131f855faf9b35f97f6ce0591e224bfae0fa78e6"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_fixture1.mdl": {
+     "bytes": 9768,
+     "sha256": "c10980d00e0479f8e65ab633f19ee62ace4c0697c2193f7aea8d266e2be5fc2d"
+    },
+    "progs/misc_flag.mdl": {
+     "bytes": 16052,
+     "sha256": "f2670312a8d16dd16e42fd02a39dfd285e6ffea624e729597b773c86140631d1"
+    },
+    "progs/misc_flame_big.mdl": {
+     "bytes": 244895,
+     "sha256": "09adba1308cdf22d2f07e226cb13a35e51f4d54866f84f41e2074dc7a40371d5"
+    },
+    "progs/misc_flame_med.mdl": {
+     "bytes": 175400,
+     "sha256": "31c94bc48e6c6d6bc31bd14b8e257c4e74d45aaec3a4d5d5bf83587a08ac7c00"
+    },
+    "progs/misc_giantbell.mdl": {
+     "bytes": 74016,
+     "sha256": "0d1b0e150de4ac59c599deae96d6b21e4ceb2300e7d410a1d802385dad99560b"
+    },
+    "progs/misc_heart.mdl": {
+     "bytes": 3512,
+     "sha256": "827ce2bbf2037aa26259901f4152d114cdf38312652e65e53f64ebbad9ea0849"
+    },
+    "progs/misc_impact.mdl": {
+     "bytes": 880,
+     "sha256": "93029307003bd0437071e0a89d0d4c2b699f2cde6ba34242c321cba8243f36b9"
+    },
+    "progs/misc_jstatue_01.mdl": {
+     "bytes": 1057632,
+     "sha256": "c583186f8bd56fd5ac356a8ed34956090eaad6e78506884bd520307e8f5e5698"
+    },
+    "progs/misc_jstatue_02.mdl": {
+     "bytes": 100260,
+     "sha256": "e4f3e702073a7f76ffddb79921a2bbb880d25edc0bdd6a6f115dfebcf99dbae2"
+    },
+    "progs/misc_jstatue_03.mdl": {
+     "bytes": 100244,
+     "sha256": "587cbce564e4da156a0ae20a87bd551046427f894f34959590573ce96fdf5c31"
+    },
+    "progs/misc_lantern.mdl": {
+     "bytes": 28836,
+     "sha256": "d84e36232543a053f2772b1070b221dc23da1b34cd08ea551a982b5e9f168ea5"
+    },
+    "progs/misc_levels.mdl": {
+     "bytes": 35732,
+     "sha256": "7cf9a4c1e556e60dd4e593cad4a2be0b45bea8893d9b5232ecc7febca4bbf5fe"
+    },
+    "progs/misc_lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/misc_lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/misc_longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/misc_madfish.mdl": {
+     "bytes": 84104,
+     "sha256": "30c19dadb42a53c7ccd35f992c5841aee13a86796157ea5e0453a4cb1586a1be"
+    },
+    "progs/misc_mooring.mdl": {
+     "bytes": 6676,
+     "sha256": "29b20cf17c62dddb4f0c1be758add7b15d6b22fd738fd9e2cd7533ac5d5475f8"
+    },
+    "progs/misc_mushroom.mdl": {
+     "bytes": 10804,
+     "sha256": "5570faa6e7828e4e12f568656226b0756a87d633cbdc461af472e0982a88a549"
+    },
+    "progs/misc_oscill.mdl": {
+     "bytes": 50660,
+     "sha256": "cdc96265a646f9e9fb4c1717fa90edb13e42130fadc4dc774b60aeb94b89eac4"
+    },
+    "progs/misc_player.mdl": {
+     "bytes": 562960,
+     "sha256": "83bbcf4cb5858aa9ac03323b461b3e3b09a28f56e212645472219d7d0b0979d8"
+    },
+    "progs/misc_plinth1.mdl": {
+     "bytes": 6196,
+     "sha256": "1ce0b7f49153f717e04436b27863c75f90a73b027c4cb7e36ce094fa037eded4"
+    },
+    "progs/misc_plinth2.mdl": {
+     "bytes": 6164,
+     "sha256": "e06edd50af1748235b251fe6e4217551c58d45c1f73161014dc0e9fd40099249"
+    },
+    "progs/misc_qwindow.mdl": {
+     "bytes": 77168,
+     "sha256": "facf489ac59158a3013118ca196f11a25a543f26559d5b72eef44968aa05008f"
+    },
+    "progs/misc_radar128.mdl": {
+     "bytes": 19492,
+     "sha256": "ef004e28e51e3227121a92432375531fca26d1e44894696f3d2a950fa65aef28"
+    },
+    "progs/misc_radar64.mdl": {
+     "bytes": 19492,
+     "sha256": "b9468012707ad484c1292cbe984c54811cb8fa43542e68e18a52ef93cb37d52a"
+    },
+    "progs/misc_radar96.mdl": {
+     "bytes": 19492,
+     "sha256": "6239d117263f49b79a2a66e62f2dbd6a7f0cd15ce412c1939dd69b4a1d8fce78"
+    },
+    "progs/misc_seaweed.mdl": {
+     "bytes": 16100,
+     "sha256": "dfbd38a439d392870c7c4c7ebea4475827b716004ca47bfa7f13b47daf07d774"
+    },
+    "progs/misc_shard.mdl": {
+     "bytes": 22388,
+     "sha256": "06c126f77ad931084d38f0e04d8f4341a5db3e3fa827e30de7d05bc60afd1c1d"
+    },
+    "progs/misc_skull.mdl": {
+     "bytes": 59892,
+     "sha256": "94600327093fe22acc113b8e89c8863a5548b170c9c9897bd2af8a4ff63beb5a"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 31792,
+     "sha256": "8d39b97460c9967ee36b33ea1ef1e92e89277fc410b44f054c5e06b8dc8a079c"
+    },
+    "progs/misc_spark.mdl": {
+     "bytes": 12672,
+     "sha256": "42afca9aeac1b05590b4821872cb79ebfbb4ee7264e914316d880e13f69c2b41"
+    },
+    "progs/misc_starfield.mdl": {
+     "bytes": 23548,
+     "sha256": "5b3563017939382680228e933a2a87d3edb030e75e65c51fe42c4a6889e42e15"
+    },
+    "progs/misc_stickskull1.mdl": {
+     "bytes": 87900,
+     "sha256": "38e63e10bc351ba5a48dfb6195ac5f78e5d61e67ae851f2ba50ba20255d7a37e"
+    },
+    "progs/misc_stickskull2.mdl": {
+     "bytes": 116364,
+     "sha256": "464fbee370b512d1c8057ea5a1dc3ecff69378474593919f0bbd8970419d69a5"
+    },
+    "progs/misc_tape.mdl": {
+     "bytes": 9240,
+     "sha256": "2b6a08ca3be4dd7a669e5b6d1585276759e1fb0edbe0691dd7ecbc7e41f0b189"
+    },
+    "progs/misc_textbook.mdl": {
+     "bytes": 74212,
+     "sha256": "e17e39efdf252a3da8c0574fdf272a800095671f42e71a17a3733673202dbfab"
+    },
+    "progs/misc_tree.mdl": {
+     "bytes": 120248,
+     "sha256": "888eca3c464ac068c7cdc5d7cf8f67fbcc70eb13c0079202a4f8d347f5f3bcd3"
+    },
+    "progs/misc_tree2.mdl": {
+     "bytes": 404432,
+     "sha256": "f14f3b046b58e5485afd11d396b4d358eb0598ea8cca1cbc6a70a8e629aee3f3"
+    },
+    "progs/misc_tutstatue.mdl": {
+     "bytes": 178480,
+     "sha256": "d178ba96d99b02113fe70d32f1672c1490d5f570aecf11d168e58f1bb7e8c17e"
+    },
+    "progs/misc_xmastree.mdl": {
+     "bytes": 479516,
+     "sha256": "59a89b398caa908ff6dd777cb42d0d7dfde930ac5569fdab4bc4f10dd8137584"
+    },
+    "progs/mon_boil.mdl": {
+     "bytes": 307068,
+     "sha256": "b8a79df258bf71f273dc29887c3782377bf890d43e32b690ebf2ef707eead6de"
+    },
+    "progs/mon_bossboglord.mdl": {
+     "bytes": 401092,
+     "sha256": "6fb5e0aa99fc9269b21e3a7c86e7ed70bf1f7e0150b629a39a4cf6647d0c9a1f"
+    },
+    "progs/mon_bosschthon.mdl": {
+     "bytes": 328244,
+     "sha256": "7fc4005959377598747d3accec535b52c81154b17b00221e2cd5410670223538"
+    },
+    "progs/mon_bosseidolon.mdl": {
+     "bytes": 1847180,
+     "sha256": "e08c763865b25851703f71e973755d5a7b446c8004f7d97c09fab04175373c10"
+    },
+    "progs/mon_bossicegolem.mdl": {
+     "bytes": 632584,
+     "sha256": "2a03c71a0451c389dc29374fa3a465fb0d8e9366309cbaeffb68057c928562ec"
+    },
+    "progs/mon_bossnour.mdl": {
+     "bytes": 200036,
+     "sha256": "732041ff70ec350c664194f90a9545b23b6736e729dd128f4482a0cca3ab7966"
+    },
+    "progs/mon_centurion.mdl": {
+     "bytes": 824572,
+     "sha256": "e638ad3021c5c77a1ad78fd798017fbb7a0ffa49ca2fc4a60570ba00e349d532"
+    },
+    "progs/mon_dcrossbow.mdl": {
+     "bytes": 1335168,
+     "sha256": "b38a7967cf800fdb45f9df9aa717ebc1c069fc8686a8e3e414f1c81d51f81d14"
+    },
+    "progs/mon_deflector.mdl": {
+     "bytes": 300016,
+     "sha256": "2bba37156abcde4ad2e7fc532a92b8139d4fc8041b565cd1e487829dc581341f"
+    },
+    "progs/mon_demon.mdl": {
+     "bytes": 156640,
+     "sha256": "9f1714fe997a78c9d3948e593a73fa3fe5704e11809ba095b8f564fca36b36c0"
+    },
+    "progs/mon_dfury.mdl": {
+     "bytes": 1495580,
+     "sha256": "0cb312b27bc1c9a7f9ac3d8c14e1e0d422d9968d4a9db0853d73185a19d6839d"
+    },
+    "progs/mon_dfury_glow.mdl": {
+     "bytes": 155140,
+     "sha256": "f743168f636c9e56475d73b3f8e139e5391e2abf0da4a6657174a7adc0f74238"
+    },
+    "progs/mon_dguard.mdl": {
+     "bytes": 724744,
+     "sha256": "1babb2976f1f86c2e499d3b8e83f4e4c04e434151bcb96a932a99a89b2bf3699"
+    },
+    "progs/mon_dguardq.mdl": {
+     "bytes": 176648,
+     "sha256": "f2f92ef84411d83c7e8c158f62b1415d8fc6aa56d77f21760dcd3080424cf6c8"
+    },
+    "progs/mon_dknight.mdl": {
+     "bytes": 1124632,
+     "sha256": "437c54ecfed53e34891b981a565c9b4f772c19702e1c099bba5ac40aabbed917"
+    },
+    "progs/mon_dknight_glow.mdl": {
+     "bytes": 971020,
+     "sha256": "22888d6171fc8df336fe686f4ffdfb0683bdb744e59cf81af9484b700666f6cf"
+    },
+    "progs/mon_dlord.mdl": {
+     "bytes": 1142583,
+     "sha256": "fb2ce7f5fbe369307f3eaefe0a74fffb2004657bec058dae50db651bc2fbc70f"
+    },
+    "progs/mon_dog.mdl": {
+     "bytes": 460652,
+     "sha256": "52cf8cb501f4b1ed457961b798eccd86974720af29f559723be82a0886824fd9"
+    },
+    "progs/mon_dprince.mdl": {
+     "bytes": 1022224,
+     "sha256": "aadd9ea12f307f0ef2b600a4a78d73082b8ea2eadd408f1fbe298082f4d03374"
+    },
+    "progs/mon_drole.mdl": {
+     "bytes": 241648,
+     "sha256": "2d5524d75cd52f12b42a5dfdd37bb33af27233394ec60bc234f79545d1cf13b4"
+    },
+    "progs/mon_dsergeant.mdl": {
+     "bytes": 1431784,
+     "sha256": "1affce6e3cbae9b5df1986672030fd869aa020972872767518f18ccc495c7432"
+    },
+    "progs/mon_eel.mdl": {
+     "bytes": 177368,
+     "sha256": "6acb4804e51e7de33404a4519d7f12b2413c921f61e33107345cb111ff156f96"
+    },
+    "progs/mon_enforcer.mdl": {
+     "bytes": 622480,
+     "sha256": "0e32f70f205a74995936d56e22259d1ccde591ed8a533577cd276419c5f60013"
+    },
+    "progs/mon_fish.mdl": {
+     "bytes": 311132,
+     "sha256": "40351e57dec8fad0aa34e5e5da233274e007a3beb80a291c9a2aa40ed43f8f00"
+    },
+    "progs/mon_floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/mon_freddie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/mon_fumigator.mdl": {
+     "bytes": 415072,
+     "sha256": "31bb90976e7489693c68fd6713ed5f1baf9645e3d7871922901dd093e8243da3"
+    },
+    "progs/mon_gargoyle.mdl": {
+     "bytes": 388132,
+     "sha256": "fe8134f2305858519445eb513b22f1f3382a1a6f334cf9549ddf1efe0b88435c"
+    },
+    "progs/mon_gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/mon_gaunt_elec.mdl": {
+     "bytes": 7164,
+     "sha256": "05129692bea7b62f2f5b7285cf133590e9356bfa0f6162ef6e3fc44508b29d8b"
+    },
+    "progs/mon_golem.mdl": {
+     "bytes": 632584,
+     "sha256": "c345c57eca380796f5dbcbdf7df80975c24e856d6d70ed1e9c11678f5d162c44"
+    },
+    "progs/mon_hknight.mdl": {
+     "bytes": 275836,
+     "sha256": "e32a90ca707224a389b7b0d3ecde76220e23f7746c2bc4e6397fe0d3a601844a"
+    },
+    "progs/mon_hknight_glow.mdl": {
+     "bytes": 212112,
+     "sha256": "60c24cb1dceeda2c64efb66e03cb8337717402c8070c0a19e1d9a6b5e0363d89"
+    },
+    "progs/mon_hogre.mdl": {
+     "bytes": 897896,
+     "sha256": "f8e0d054c44cf83bde03ee51ca8eb558dad7da336be8caf1383cf51d5b813da9"
+    },
+    "progs/mon_hogreham.mdl": {
+     "bytes": 979960,
+     "sha256": "d4ffb64b6112d48696002baf1bf8df0c686f404d1523ae409a9d01d237573e90"
+    },
+    "progs/mon_hogremac.mdl": {
+     "bytes": 901388,
+     "sha256": "daeed66878bbe85c45d2415de4270a8526be175ac74734ff55cf9750bf7c4875"
+    },
+    "progs/mon_jim.mdl": {
+     "bytes": 331872,
+     "sha256": "a49a51562fc5875509e39b62de550c4cebba65569708e1f63d0a54a6b8497448"
+    },
+    "progs/mon_jimrock.mdl": {
+     "bytes": 357748,
+     "sha256": "6c7e4a4f9b1b4392cf6e465be50e0a637a2a9b9b44b41e97a62acfc7b889f662"
+    },
+    "progs/mon_judge.mdl": {
+     "bytes": 1184920,
+     "sha256": "4e281291b8b6728bc6801c775defa987698a0f402a3a5553a32cf61865857040"
+    },
+    "progs/mon_justice.mdl": {
+     "bytes": 1287408,
+     "sha256": "bdd6b6ad28da26701dcef14503d148e96251575e04f583bef1f362455ab12497"
+    },
+    "progs/mon_knight.mdl": {
+     "bytes": 474244,
+     "sha256": "b279d87d180d237a71beddad02ecfaa87be42c990b91ee823f15f905fbb19b55"
+    },
+    "progs/mon_lostsoul.mdl": {
+     "bytes": 172216,
+     "sha256": "51c6d042ac9c670926d11743a09b294cbc992204077eae28b7b440570a7b0b4c"
+    },
+    "progs/mon_minotaur.mdl": {
+     "bytes": 669648,
+     "sha256": "3016ee951f60eb90a659c641546bc6aee80b1e2e9500b125c9c1343d625deb54"
+    },
+    "progs/mon_ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "ca0b6aee92201fa3ebeb226e7767c7a0f29495496d86bd384c327ff897b3557b"
+    },
+    "progs/mon_ogrefish.mdl": {
+     "bytes": 560428,
+     "sha256": "25edf562fbf71533ae0102832d92b7e138d056e1f90c9c681e5387659cd3160e"
+    },
+    "progs/mon_pyro.mdl": {
+     "bytes": 415072,
+     "sha256": "11a7efe7358b1477867a1263fd6e13a8531f557d1a8d0e0bfc5a1e9e6eab273a"
+    },
+    "progs/mon_scorpion.mdl": {
+     "bytes": 338288,
+     "sha256": "5d8a1b194cfc741b8dd194694dce305c35b0dca0bdf1c8d96897a085ad0eaf85"
+    },
+    "progs/mon_seeker.mdl": {
+     "bytes": 594628,
+     "sha256": "ab23bfb0c8b22c67b8d4b7b1658b445fb546fcc4f1ddb1f5c4990eb860434f3a"
+    },
+    "progs/mon_seeker_glow.mdl": {
+     "bytes": 594628,
+     "sha256": "122441a3be654d0198ba368ff9fd24d7f3fecb71fbafad6edfe80e3f57103ca8"
+    },
+    "progs/mon_sentinel.mdl": {
+     "bytes": 290664,
+     "sha256": "573efd78767922b2bbb3e5dab2b16cd8f90c2cb1709ecf4a315a141f4df77d09"
+    },
+    "progs/mon_shalrath.mdl": {
+     "bytes": 163336,
+     "sha256": "50b11e859246abf75af63b858d00b436690c9ed02562c0a7a3f434ed350c3a79"
+    },
+    "progs/mon_shambler.mdl": {
+     "bytes": 401092,
+     "sha256": "8f29b2ceddebcb9e69adbf12eb36c3924468cfaa1ff54cea31e6f289ab30e54a"
+    },
+    "progs/mon_skullwiz.mdl": {
+     "bytes": 980064,
+     "sha256": "c7637f2310ae9f173de872ea4aaf4380332f3d8d32782a8523f1d5d0a5ee3e45"
+    },
+    "progs/mon_soldier.mdl": {
+     "bytes": 931376,
+     "sha256": "8a67babdf47ecc69739e067d18b2629814469aec923851bd6c1133feae6ac56b"
+    },
+    "progs/mon_spiderb.mdl": {
+     "bytes": 228508,
+     "sha256": "209ee4dabf0f9b5619408cedcd8eaec7f8d4e48a8e1b51ca667bf5f8fea02dd6"
+    },
+    "progs/mon_spiderg.mdl": {
+     "bytes": 228508,
+     "sha256": "ffac4cf5b2d42df5b8a9674dc87c30ec925d6013d9ff0d29cb109c30047bcbd6"
+    },
+    "progs/mon_steelclaw.mdl": {
+     "bytes": 228508,
+     "sha256": "06fae126b984b1ed7b0ffa029b64e9b3df3a6269f01e8aba4b953bbafaa2c536"
+    },
+    "progs/mon_stinger.mdl": {
+     "bytes": 203428,
+     "sha256": "9d867b8a3d69a94d9a049c6cfcf0fa808b200ea3befe3b2518f1165881b9ad23"
+    },
+    "progs/mon_swampling.mdl": {
+     "bytes": 45332,
+     "sha256": "c7b379fcc17af3fbfaff1976ea8c14e9562093495dac01cd647c50863c4dec50"
+    },
+    "progs/mon_swamplingp.mdl": {
+     "bytes": 45332,
+     "sha256": "f1bd1496b4b9c90493f469bf81c6da0a1697290cd6374db15fd459ebab649cea"
+    },
+    "progs/mon_tarbaby.mdl": {
+     "bytes": 511008,
+     "sha256": "a9b9b6a49090bbf7d7d3a23618c3c21b2123e007488702d96b80531c563cdd4c"
+    },
+    "progs/mon_voreling.mdl": {
+     "bytes": 45332,
+     "sha256": "af233d21d6f0ea66267ba1c562ba223e1077bd07894333327ce12a6202938411"
+    },
+    "progs/mon_vorelingp.mdl": {
+     "bytes": 45332,
+     "sha256": "dadf32a61ef1ec6361606fc7173bab53f6c42e62dea9a3100a2073ffc5afaa58"
+    },
+    "progs/mon_wizard.mdl": {
+     "bytes": 106596,
+     "sha256": "aa93bbe4e7fd1686fcea4d6c49a982bb8b3defea2ca85c3177b86000ba8ba8e4"
+    },
+    "progs/mon_wraith.mdl": {
+     "bytes": 374256,
+     "sha256": "f2ec454f0e2896252204a99b18c16a5e61ae783220503a6b0ec75e149d1b25f7"
+    },
+    "progs/mon_wraith_glow.mdl": {
+     "bytes": 133676,
+     "sha256": "bc630a16b46ae0ef1fba35acaf4e41bc46dee4070305d32e9215692a18ae5705"
+    },
+    "progs/mon_youngone.mdl": {
+     "bytes": 103208,
+     "sha256": "de6f7f98d021ae2839cc81490886e6f29dfa31b5b45216d15ffb7f74edf1eb36"
+    },
+    "progs/mon_zombie.mdl": {
+     "bytes": 381660,
+     "sha256": "2dfc9832316861cff07f1c86da0f8809de95395a9dac718155bdbd06f739acaf"
+    },
+    "progs/mon_zombiek.mdl": {
+     "bytes": 228232,
+     "sha256": "431f57d3241b1253a1346ff1aa2bd7135f67c3e6fd5031140e07a7b4a0e861a2"
+    },
+    "progs/player.mdl": {
+     "bytes": 976432,
+     "sha256": "137eab1a3853f9a6f7f84c05442f7066268cac430bf73053cc7f806555a98925"
+    },
+    "progs/proj_balllava.mdl": {
+     "bytes": 18356,
+     "sha256": "f2a1de49bd215b4c7a1f424f1c644fe5cdb52df3c2d664c24b75cd2f389ae559"
+    },
+    "progs/proj_ballslime.mdl": {
+     "bytes": 18356,
+     "sha256": "d17f20cd8db385b724d58beaac1c3ed6b2597d51d00f1996b8b02bdb8a5e3ba1"
+    },
+    "progs/proj_blord1b.mdl": {
+     "bytes": 11472,
+     "sha256": "6c05b0f8790b77d3362166b2b304379942f56d498ae8fc365dbee6fcd6031f67"
+    },
+    "progs/proj_blord1s.mdl": {
+     "bytes": 8284,
+     "sha256": "5527dd12f00911fb333c2424994c0a95881caa72612d5e8236c8ce75530f6ae0"
+    },
+    "progs/proj_blord2b.mdl": {
+     "bytes": 11472,
+     "sha256": "fce6943e84bac672bf110d986ce2ed1ccb511128cb28508fb6aca53c7655806b"
+    },
+    "progs/proj_blord2s.mdl": {
+     "bytes": 8284,
+     "sha256": "a0d0ac315e46f784c35a0eac902f625e0337e79275b9f02ecb56002848202734"
+    },
+    "progs/proj_blordbeam1.mdl": {
+     "bytes": 12244,
+     "sha256": "e01c569bf66e75acdcbbfdbb50062eb24dd09f0415e6cb79148eab960f6a6f0f"
+    },
+    "progs/proj_blordbeam2.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/proj_blordbolt1.mdl": {
+     "bytes": 7868,
+     "sha256": "2ea0a49a8a75d1174151c36851ae21212b4df2df3473be5e73cc4cf293332d0f"
+    },
+    "progs/proj_blordbolt2.mdl": {
+     "bytes": 7868,
+     "sha256": "919dda70fe618cd37f57ef1e0dbc00b339ed082e2661ca024febee3ed49576f2"
+    },
+    "progs/proj_bolt1.mdl": {
+     "bytes": 1556,
+     "sha256": "890f6cd6faf7c36954185c4566a2cca619e627d5b365f05e1bffc7e12ac00ace"
+    },
+    "progs/proj_bolt2.mdl": {
+     "bytes": 1748,
+     "sha256": "ba4a6ffa3785b0e41c15045df9621a5a33f094eae2161064d472ea939654e229"
+    },
+    "progs/proj_bolt3.mdl": {
+     "bytes": 1748,
+     "sha256": "cf255497525c53162b019fe3df536314c4661a2d270f6bb847fe39a158b7f4e8"
+    },
+    "progs/proj_chthon1.mdl": {
+     "bytes": 65636,
+     "sha256": "92a964527d72ef1c40bbcfe0e915b56df81a0dcc2165ca4be47db44a8d644eb1"
+    },
+    "progs/proj_dguardq.mdl": {
+     "bytes": 12660,
+     "sha256": "ba5cba46edc108572d78e66166f5ed0405a48dcf672e7a569d14a4397f85f285"
+    },
+    "progs/proj_diam1.mdl": {
+     "bytes": 3292,
+     "sha256": "e7cbd736a84791c5234caa14713b3e0f6077409509845ae0b1993f38c2f1e1b9"
+    },
+    "progs/proj_diam2.mdl": {
+     "bytes": 2748,
+     "sha256": "b23586b1d570a9f516f6b83ea0af6ec1d8fe5693f8cd1279b251b031ba142d8c"
+    },
+    "progs/proj_dk.mdl": {
+     "bytes": 5172,
+     "sha256": "e861a125a60c82b88c7b3c23184a1485c967d0e127b4536213b7f46a97a6430e"
+    },
+    "progs/proj_dkgrn.mdl": {
+     "bytes": 5172,
+     "sha256": "820d2dac7255db7220889f6d8c3a2c97a7f77f75cd9ffbec6319b0ee257b3984"
+    },
+    "progs/proj_dlord1.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_dprince1b.mdl": {
+     "bytes": 6644,
+     "sha256": "7bcea6065d9f6c4e8a3a7c8a1dcd61252ff8baee01b7c04ecce0a7cfbc6d690d"
+    },
+    "progs/proj_dprince1r.mdl": {
+     "bytes": 6644,
+     "sha256": "5e3cc794f6b980e5e22adf011eead8768c88dcd84d74be9a8d34caebf33bf2ba"
+    },
+    "progs/proj_dprince2b.mdl": {
+     "bytes": 7468,
+     "sha256": "e81b4f767d1bba042464f1d35314ef4f2d30f7c552aaada2f772aba61fc5d62a"
+    },
+    "progs/proj_dprince2r.mdl": {
+     "bytes": 7468,
+     "sha256": "b967299e12983dacd0fcca1672818281483e6f89746422de285002cb043e1e24"
+    },
+    "progs/proj_drole.mdl": {
+     "bytes": 20796,
+     "sha256": "fbe9acdd31f7be2321df29b6add3d287d4e86ea2581e56ace5d7e9d185e28127"
+    },
+    "progs/proj_drolegrn.mdl": {
+     "bytes": 20796,
+     "sha256": "efbede1f5d565c56a535bb6392b5e638133c99b1df8bf93b1a1918d01c790123"
+    },
+    "progs/proj_eidolonrock1.mdl": {
+     "bytes": 14084,
+     "sha256": "e085fa791a83489e41c19c623ae84f80c7bc5f767cbbf691baa4665d3f85b273"
+    },
+    "progs/proj_flesh.mdl": {
+     "bytes": 19768,
+     "sha256": "8ff3f0f61001ac8e67317e4e01d03d905f15ef4104c141ba07b5ddb0c972390e"
+    },
+    "progs/proj_fleshp.mdl": {
+     "bytes": 10196,
+     "sha256": "3def912801c4b1b9b4c0f8ceea0690241493a5dd5f17e098cd6c37cefd927893"
+    },
+    "progs/proj_fury1.mdl": {
+     "bytes": 6644,
+     "sha256": "ce55af61fbd87b8daeb14151b3f77ac64713c4b53fcca89b2150d7f5cdfe886d"
+    },
+    "progs/proj_fury2.mdl": {
+     "bytes": 5748,
+     "sha256": "deb557248017e92f5501698355577cebb91c0d825b77a79f828589769a41ece7"
+    },
+    "progs/proj_gaplasma.mdl": {
+     "bytes": 2328,
+     "sha256": "dd3b4559cb4e4439ae87255ab2958c6c2cd3796ebbd27aaf1c6abc768ad4f8ad"
+    },
+    "progs/proj_gaplasmagrn.mdl": {
+     "bytes": 2328,
+     "sha256": "ecd2fdf0eb904f8be43c41821b06443d32a581b768ce8f776b07670b49cdd9af"
+    },
+    "progs/proj_gargball.mdl": {
+     "bytes": 18184,
+     "sha256": "b4b6bd7646bf80aa6f481616ba2b531dbccd3568cacc54885ebf020a166dbadd"
+    },
+    "progs/proj_gargballgrn.mdl": {
+     "bytes": 18184,
+     "sha256": "467a44838d83a94d5716c9af6f8c860cd8ec583ddb5f260cb0dd16e9bd04b957"
+    },
+    "progs/proj_gargoyle.mdl": {
+     "bytes": 5748,
+     "sha256": "774f52126fe6598f6a01a032691a36de26a0669e93d47508689d08fe85f46c21"
+    },
+    "progs/proj_gargoylegrn.mdl": {
+     "bytes": 5748,
+     "sha256": "b293b5e8696098e77602eb065f68f8a8e15c82af1c9890d36de48f29afbf43fe"
+    },
+    "progs/proj_ghook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/proj_golemrock1.mdl": {
+     "bytes": 7468,
+     "sha256": "5a2f0435dbcbfea724fe6bd8f6a76296359dbf4d874d15feec82b50a9275da74"
+    },
+    "progs/proj_golemrock2.mdl": {
+     "bytes": 19756,
+     "sha256": "41cc9bc49d6ae2018b7cf5345bbfe52517db2da060fce23fe57300ebcf643f98"
+    },
+    "progs/proj_golemshard.mdl": {
+     "bytes": 8596,
+     "sha256": "4a4a59362f5c5ecc2c4ce56419088982d5ed79a02d3c5b5a49bafd4c21c85e42"
+    },
+    "progs/proj_grenade.mdl": {
+     "bytes": 3508,
+     "sha256": "a7916ab1f9872689a0cfbea62543974b37dae5b3ec7ae3165eecd81c2c0d6617"
+    },
+    "progs/proj_grenadegrn.mdl": {
+     "bytes": 3508,
+     "sha256": "896f7a740acb59351891e752e6cc92725fcc6e26ea4bd5d1eb3219c8443db743"
+    },
+    "progs/proj_judger.mdl": {
+     "bytes": 7868,
+     "sha256": "a12f1f0bf494bc027c43e5aa89e54e055a571226499fbddce0f6b9e2bdb63766"
+    },
+    "progs/proj_laz.mdl": {
+     "bytes": 4724,
+     "sha256": "94e8c7d09857559ad9e5aaf6361b596afbcf100cf0ce8abf0107318af28c7943"
+    },
+    "progs/proj_lazblue.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/proj_lazgrn.mdl": {
+     "bytes": 4724,
+     "sha256": "d07d736b788aa512a5e57f39596c187644e69491026382800994378d3e849a6f"
+    },
+    "progs/proj_lightning2.mdl": {
+     "bytes": 11860,
+     "sha256": "c9cebc8d6f4836e7c302d51d0f942fde3da0960dae38733ccc3a851776e71520"
+    },
+    "progs/proj_minoball.mdl": {
+     "bytes": 18184,
+     "sha256": "756d8e9ecd60abc23954a792833c565ee1b5c905106ad2bd98143f56b0410391"
+    },
+    "progs/proj_minoblood.mdl": {
+     "bytes": 8284,
+     "sha256": "badd72734b86dd9bc11c5469bef944b6aea6b84071b07b44703c1ca62dd4dee2"
+    },
+    "progs/proj_minoplasma.mdl": {
+     "bytes": 8284,
+     "sha256": "cd79d0dce08293ded22b08b3a7134d8e52fc4cff10e07ee691e6ab53011a9ea9"
+    },
+    "progs/proj_minopoison.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_ng.mdl": {
+     "bytes": 1364,
+     "sha256": "cff312dd07f629847dd5e37b6ab00243d51ff7e40fc795f3612e68614cfbbe24"
+    },
+    "progs/proj_ngred.mdl": {
+     "bytes": 1364,
+     "sha256": "a1ec22733cc292a470c23990b8d0929bf5ee88844190d7174d9053109443d0dd"
+    },
+    "progs/proj_nour1.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_nour2b.mdl": {
+     "bytes": 14084,
+     "sha256": "9c7650dba595e8f8b2bacf3141252a5a2917e0204d3326661d6b9608fc8df2b3"
+    },
+    "progs/proj_nour2p.mdl": {
+     "bytes": 13152,
+     "sha256": "4051fc3dec1155a9efbc6bc5aab947447cebff83bec38d8c1e43dd1bd51f4611"
+    },
+    "progs/proj_nour2s.mdl": {
+     "bytes": 7468,
+     "sha256": "285570bdd658dfed133399c16f1586e2b2389f537a9d4b54d2dd5c1f8f6f1aa9"
+    },
+    "progs/proj_pgplasma.mdl": {
+     "bytes": 13152,
+     "sha256": "3c04f32bbf6f0623fc4101a31a0ce2d40c93354430433d91c2caed263284531e"
+    },
+    "progs/proj_plasma.mdl": {
+     "bytes": 4724,
+     "sha256": "6c4399ddc7653a9aa7834162d38dce6368dc271fec46a7830b73939351d7142a"
+    },
+    "progs/proj_plasmagrn.mdl": {
+     "bytes": 4724,
+     "sha256": "b2941e69d90a5e97c98a03a98bd52c4e047aa23dd2a1abd9ab6d3938f595732f"
+    },
+    "progs/proj_ringblast.mdl": {
+     "bytes": 135704,
+     "sha256": "e6de9bfd15db4bbf16fdd41b50204c5090ce09adbe132b1453435d3c8646cb4d"
+    },
+    "progs/proj_ringshock.mdl": {
+     "bytes": 18928,
+     "sha256": "f1a0a77edc79f2466b866a5486b29f92b696368137eb7eff9b137b6b66d65952"
+    },
+    "progs/proj_rocket.mdl": {
+     "bytes": 7812,
+     "sha256": "52d549b217c6f34e1d68248899ec5f5f550ef729929910e5953e114a53b3c251"
+    },
+    "progs/proj_rocketgrn.mdl": {
+     "bytes": 7812,
+     "sha256": "313f381553df0d8468ccb981441bf415130c9c730377d877e397511b8cc864f7"
+    },
+    "progs/proj_scorpion.mdl": {
+     "bytes": 6612,
+     "sha256": "1a2fa47a30a7e8026bacefa1f52580a04e10c48571318effab3e0623ebcc919e"
+    },
+    "progs/proj_serg.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_shal.mdl": {
+     "bytes": 6644,
+     "sha256": "dc62e9641d1328b1cfd20ac4f4df7e56b2f42bd40a22eea186f2784d1f5bc4ba"
+    },
+    "progs/proj_shalball.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalegg.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalgrn.mdl": {
+     "bytes": 6644,
+     "sha256": "6dfdef0a204aded86ef24730985f13acc5076d1bbb4b9ec1140b7333a70f4d0e"
+    },
+    "progs/proj_shalhome.mdl": {
+     "bytes": 8632,
+     "sha256": "e882b1dc5d01882f429b3a88f752431d3b38dad297861209b589330e3507f37e"
+    },
+    "progs/proj_shalhomegrn.mdl": {
+     "bytes": 8632,
+     "sha256": "d84be851bd87603186bf907506eabb9ce110c5a265c1cc884d18923361fdf4d9"
+    },
+    "progs/proj_shalshell.mdl": {
+     "bytes": 7468,
+     "sha256": "8c1591cc767fadabad655bfaf3a80362b264f51e0a1be67476b9272c2401afbd"
+    },
+    "progs/proj_shamlit.mdl": {
+     "bytes": 35240,
+     "sha256": "787c23ca986d469080879953e49b193cf0b2d22dff050a1d781ba039fcc594e4"
+    },
+    "progs/proj_shellcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/proj_shub1.mdl": {
+     "bytes": 18932,
+     "sha256": "c1a04846b791a123ecb367f11b35f4c1cc1e7e62e1d0f62ff1dd75978a712495"
+    },
+    "progs/proj_shub2.mdl": {
+     "bytes": 32860,
+     "sha256": "3d22df8151caf23c1ad7f3e28f83f97ca7503164977f1994dca2cc2ee54f84b9"
+    },
+    "progs/proj_skullball.mdl": {
+     "bytes": 9984,
+     "sha256": "41b3c1225070dcfca79f1bf19a2833e3d68144945fba51c8ce44d8029379906b"
+    },
+    "progs/proj_skullwiz.mdl": {
+     "bytes": 33588,
+     "sha256": "ff00ce3fbf9d0d55f6488a3a0a6bf15d2105b6e94489eec296a5851bf9f4f890"
+    },
+    "progs/proj_skullwizp.mdl": {
+     "bytes": 33588,
+     "sha256": "45fe8396037d88852d3e6937749bade4ef7c00d3c8240eeb0ecba4b56e831df3"
+    },
+    "progs/proj_smoke.mdl": {
+     "bytes": 244,
+     "sha256": "816e888f8242af86812bd581c9e93212c28f108699b70eb10d3e025f27a2818e"
+    },
+    "progs/proj_sng.mdl": {
+     "bytes": 1396,
+     "sha256": "b2a8656aee7ff508737afe1fdbf1a93d6958b33a0c31bae247a3979c616bdfe1"
+    },
+    "progs/proj_spider.mdl": {
+     "bytes": 7468,
+     "sha256": "76be6023b50a3b57c73f08c5758a693098ce8762eb92b55540d8bff2680fde4d"
+    },
+    "progs/proj_swampling.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_voreling.mdl": {
+     "bytes": 7468,
+     "sha256": "ab16a7fc8bf36827f4944ebe6919876acb5b2eaf869ff59f89ed237565a7ca9a"
+    },
+    "progs/proj_wiz.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_wraithball.mdl": {
+     "bytes": 22284,
+     "sha256": "24d62690c6347f9ab71ef5900c70d256346c2dfdc26e5488c3b91f220224c923"
+    },
+    "progs/proj_wraithbone.mdl": {
+     "bytes": 6612,
+     "sha256": "8fa994dd2c7a5e9d7140ae394d07d368d083f4cee6808f6d9d026ec464804503"
+    },
+    "progs/proj_wraithegg.mdl": {
+     "bytes": 9984,
+     "sha256": "5b888e26f90cfe26800cd50d422b4ef75487dde61d63fd34965506591b326a8f"
+    },
+    "progs/proj_wraithpoison.mdl": {
+     "bytes": 6612,
+     "sha256": "02a06fdccb8f7ba595ea71f227e5b256995e782bcc9ce75bcb85a31ed0333256"
+    },
+    "progs/proj_wraithshell.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_wraithtrail.mdl": {
+     "bytes": 24544,
+     "sha256": "23ee065ea4a542ee7348d9bc08e052ffca4e272418b81937105d14730aab705e"
+    },
+    "progs/s_bookrune1.spr": {
+     "bytes": 1140,
+     "sha256": "b9fc52d2ca728fffa4c282d818b68aeec3555a0dbad3cd1507199d534db1f047"
+    },
+    "progs/s_bookrune2.spr": {
+     "bytes": 1140,
+     "sha256": "400a620928e3581891e8a71b338c8a53b6387e0acdc3fda3f10ae27596ae6bbc"
+    },
+    "progs/s_bubble_blue1.spr": {
+     "bytes": 1140,
+     "sha256": "27cb0d1f52e3ecd4b7ae0d9dc96078a7554bde09839f1a2ee2d9772ac5d67981"
+    },
+    "progs/s_bubble_blue2.spr": {
+     "bytes": 1140,
+     "sha256": "d540bb04a7835ec3bd7490904fbafde0f3aa64ba559bb6bd99ab538568ec0cae"
+    },
+    "progs/s_bubble_brnd1.spr": {
+     "bytes": 1140,
+     "sha256": "43591346d87a547454b387220b3c32693e7f1563b6ae4152ff7ee96c24936b84"
+    },
+    "progs/s_bubble_brnd2.spr": {
+     "bytes": 1140,
+     "sha256": "2f185b37bd1cd5a8d6b472885469dbdb3f1b0fdeba2a6d620de09b17646b4fc2"
+    },
+    "progs/s_bubble_brnl1.spr": {
+     "bytes": 1140,
+     "sha256": "370ed3a9f77291522c31ac1d0ce414078d9b3eb40a9157c08ad5cf87d6428897"
+    },
+    "progs/s_bubble_brnl2.spr": {
+     "bytes": 1140,
+     "sha256": "1b3d4f0ac00fa7cbce076d334f4b210b9059afbf2c4b07a0e98e88fe57356351"
+    },
+    "progs/s_bubble_grey.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_grn1.spr": {
+     "bytes": 1140,
+     "sha256": "efa8692bb74428af2753b415f8f08edbfc2b2cbe75cc59f6545985d289d6016f"
+    },
+    "progs/s_bubble_grn2.spr": {
+     "bytes": 1140,
+     "sha256": "3062ba1064da37ecf7dad074a9b0437352865fa43aecf783e4afe8a6c8c104c2"
+    },
+    "progs/s_bubble_pinkyel.spr": {
+     "bytes": 312,
+     "sha256": "5376726ffdf2132d3ab712ba23b408e8068500485f11adff85d0fd90c08248c6"
+    },
+    "progs/s_bubble_purp1.spr": {
+     "bytes": 1140,
+     "sha256": "2e4b7b23b08b6e89d2dc46f26b12b9ad1ee8f91ea868aeb9916d2adb42e00b75"
+    },
+    "progs/s_bubble_purp2.spr": {
+     "bytes": 1140,
+     "sha256": "ae21a26ad7897b9c5d201a1eb248e1358ee84eafdbfd899d679558e9aa5a1a66"
+    },
+    "progs/s_bubble_red1.spr": {
+     "bytes": 1140,
+     "sha256": "2a52f2c4dfdae381deeca608e5d007afe9dc245bbe16fea88c88f39c10ff7dc6"
+    },
+    "progs/s_bubble_red2.spr": {
+     "bytes": 1140,
+     "sha256": "fffcc0e03f9acc75e05636ab67f5f647568c81d0bcf4623e64d487c04d9cd5eb"
+    },
+    "progs/s_bubble_wht.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_yell.spr": {
+     "bytes": 1140,
+     "sha256": "9dcce864ad255b17d7d45e5c5531114f6a66c4e9cb549fc8b31aef0af5a9157f"
+    },
+    "progs/s_burst_flame.spr": {
+     "bytes": 22128,
+     "sha256": "66511ada8a299b0882e2939c09d3fb726d3ce52ecb93a884584a9ce11915a6c0"
+    },
+    "progs/s_burst_flamedp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_poison.spr": {
+     "bytes": 22128,
+     "sha256": "d8245e0460efc4e939a187912126f44422c39b1fe4b553c2c15da91833e8549d"
+    },
+    "progs/s_burst_poisondp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_burst_steam.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_dotmed_blue.spr": {
+     "bytes": 1140,
+     "sha256": "0b3160c5a4ae42216ddb7aaa7ae4726f6b2507c914328abe3c69f2d12fd921f8"
+    },
+    "progs/s_dotmed_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "6e28b69544f8aa13ccbb9a66893e4ab86b83639ee3f81dbbe1b94290ca9b03ef"
+    },
+    "progs/s_dotmed_grey.spr": {
+     "bytes": 1140,
+     "sha256": "77c226763e90a54b4d6835bd877c08c501605e516e64177c915c422e7b36c207"
+    },
+    "progs/s_dotmed_grn.spr": {
+     "bytes": 1140,
+     "sha256": "d1a9800a8b5cad01fa1dc93e57162e9960c4a8478e7e427d66cdbfe6a6797266"
+    },
+    "progs/s_dotmed_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "6113140f371b08cda9addcf68282c1fc16692da7498fa2fdfe2b99662e345d67"
+    },
+    "progs/s_dotmed_purp.spr": {
+     "bytes": 1140,
+     "sha256": "8b2cfa67ac86841f59409e184b4f3a253218e5930a5e3f241caef39dc1baa8de"
+    },
+    "progs/s_dotmed_red.spr": {
+     "bytes": 1140,
+     "sha256": "4ae92a280e0df01c0acd0a904214af485bb60919e5ded4573aa12f86875182d4"
+    },
+    "progs/s_dotmed_tor1.spr": {
+     "bytes": 1140,
+     "sha256": "eddd46a4818dfa92a9817df82e893d6bf6513160164a74b95bdd42fb7cac2f75"
+    },
+    "progs/s_dotmed_tor2.spr": {
+     "bytes": 1140,
+     "sha256": "dcb87897de0f54a6d8f78e9194a15c11261eb88455f058b334f8648a363159a9"
+    },
+    "progs/s_dotmed_yell.spr": {
+     "bytes": 1140,
+     "sha256": "e6b72aac439291d7719ee78d9520c1a1def36212ac7f61ba333fa87d5265c63f"
+    },
+    "progs/s_dotsml_black.spr": {
+     "bytes": 632,
+     "sha256": "2ae7fa13584d12f04b337fbbd774e74fbe54a6fcbd354239e97fecce931bd377"
+    },
+    "progs/s_dotsml_blue.spr": {
+     "bytes": 1140,
+     "sha256": "c0149109ae73a72da49bfaf9ba00cf2edadbe0f053928d09319083e6247883ad"
+    },
+    "progs/s_dotsml_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "f95fe813ecce2c69d2b72e5bf870d045037519c89f3da9a300e7453754cd1503"
+    },
+    "progs/s_dotsml_gold.spr": {
+     "bytes": 1140,
+     "sha256": "3833e80c32da39063b5069638ade52c4aee51b7db7206b4911cb48f321e25bdc"
+    },
+    "progs/s_dotsml_grey.spr": {
+     "bytes": 1140,
+     "sha256": "2e16d9ff8ceca2994a609703f405b1efbb7b49e02c8dbb9e77d0cdcaf3318b98"
+    },
+    "progs/s_dotsml_grn.spr": {
+     "bytes": 1140,
+     "sha256": "a2735123addacfa03f2666969e476af0d9f1cfefbef75a7ac9599d48f86226b1"
+    },
+    "progs/s_dotsml_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "ebf62caae17163587aaa3652300f1003c008ed21041b838a14cfff7672f87d90"
+    },
+    "progs/s_dotsml_purp.spr": {
+     "bytes": 1140,
+     "sha256": "476042db782f7f81cb53d91e9518881f28eb34d3a2a535c11d9c22f65518bce4"
+    },
+    "progs/s_dotsml_red.spr": {
+     "bytes": 1140,
+     "sha256": "94c0403ee7f1e6f6c4d6bc9b99e73e48143845fe35d0d6b3de246842241b12cb"
+    },
+    "progs/s_dotsml_wht.spr": {
+     "bytes": 1140,
+     "sha256": "7ac2d5b9b1e14a1799b951ace16bcc1addb7fefc2470dec23ef2ca110a934bf5"
+    },
+    "progs/s_dotsml_yell.spr": {
+     "bytes": 1140,
+     "sha256": "686f220b937040b91b6ff4f05efd41525d40eb80a61ff8138809d550bfa99959"
+    },
+    "progs/s_dripblue.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/s_dripgreen.spr": {
+     "bytes": 60,
+     "sha256": "805935ef90e14eda0f0ec89cc7e03acf52df768eb9e09140629bc1067a658774"
+    },
+    "progs/s_dripred.spr": {
+     "bytes": 60,
+     "sha256": "2dc81cd44438e124dedef0b656c31a066b7879940fcdbc39a0cfd57a6d2985e5"
+    },
+    "progs/s_dripsplblue.spr": {
+     "bytes": 828,
+     "sha256": "6b960ccc7a877bf2b4b67467400c0eaa1bb88d8c8a524458b9bf8d1aa1a6e29f"
+    },
+    "progs/s_dripsplgreen.spr": {
+     "bytes": 828,
+     "sha256": "397ac392598027c27240d71079f79eb9c90306724bc54c5d9854e14939059b6c"
+    },
+    "progs/s_dripsplred.spr": {
+     "bytes": 828,
+     "sha256": "268b48b87a0f352b671c04a1f7325af43372578a6d73269356389280eb7ef232"
+    },
+    "progs/s_exp_big.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_exp_electric.spr": {
+     "bytes": 5256,
+     "sha256": "ed01b728b6656a68acffe258d644712eba3b786434ab6b3e6d90434031e90d96"
+    },
+    "progs/s_exp_ice_big.spr": {
+     "bytes": 164076,
+     "sha256": "bf7317d811349602db7a020da3e77065ffd8158a3104e83ddca3b166566df18c"
+    },
+    "progs/s_exp_med.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_exp_plasma_big.spr": {
+     "bytes": 213288,
+     "sha256": "fe99a489e169ccf56f0412c2e83a7c5aea7b75b7cee0501402c62fcbd7ca969c"
+    },
+    "progs/s_exp_plasma_small.spr": {
+     "bytes": 53544,
+     "sha256": "555e39e88cedaf9e9dd1215ad1325b32019a6bf2654d53736b1f362506548150"
+    },
+    "progs/s_exp_poison_med.spr": {
+     "bytes": 72892,
+     "sha256": "60b7a8c194f3a6cd2241edd6223ac1da1f57811d7f5416216c70a2797d1baf20"
+    },
+    "progs/s_exp_poison_small.spr": {
+     "bytes": 53544,
+     "sha256": "2a54104dec9381afe338574d66bcc19bd2776caa0d46031c743cd24782098d3f"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "a9476d95ea10fbd2317c174272864efa4bb6e939893f3a3de520aeea3e3522d9"
+    },
+    "progs/s_flamemed.spr": {
+     "bytes": 43324,
+     "sha256": "3c645e305673693089fe48cc7a22f694eeaf7881cfc94ff7b1c4b05b718342cc"
+    },
+    "progs/s_flamesml.spr": {
+     "bytes": 21820,
+     "sha256": "5e60165461c34a3a25cbe6b0bb5e36131bb4a81fef384f1db4a7236f30e7ba95"
+    },
+    "progs/s_flametiny.spr": {
+     "bytes": 11068,
+     "sha256": "9d2c0af6139f3d194e73dbcb7880aa0a6f2a04019f94818ce9844691399b551b"
+    },
+    "progs/s_judgemagic.spr": {
+     "bytes": 12564,
+     "sha256": "6d08d5ada6bac219927edb39a93302f98b7b1a357e6648fc1abb49fd5cc3bd4c"
+    },
+    "progs/s_marsh_med.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/s_marsh_small.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/targd_hull2.mdl": {
+     "bytes": 3380,
+     "sha256": "520c82906942d582c6b64da4dca32ca8ed236694607c3a19ec71b89136e0c757"
+    },
+    "progs/targd_massive.mdl": {
+     "bytes": 17076,
+     "sha256": "099ed67733ea3a461c2247d6f07d3dadcc5a6968bcd6a03398507c653d174395"
+    },
+    "progs/targd_short.mdl": {
+     "bytes": 4788,
+     "sha256": "c883300477d3978469aabc35ef3969c14645c1111997c64452634fc8b4a978e1"
+    },
+    "progs/targd_tall.mdl": {
+     "bytes": 4788,
+     "sha256": "bab77599f9cbbe1cf0856a642612ae30b08fed9ae27a209abda30f6dc8c07129"
+    },
+    "progs/targd_wide.mdl": {
+     "bytes": 17076,
+     "sha256": "d40a00625196f67fe26f3611cd91dd33484ddbf3db273766f8a5fac38db07b07"
+    },
+    "progs/trap_pendlong.mdl": {
+     "bytes": 44900,
+     "sha256": "62d3b86fea6e2336dfc5c7b93514e096eba05992a3bd3e0c6571e4c4a27be684"
+    },
+    "progs/trap_pendshort.mdl": {
+     "bytes": 44900,
+     "sha256": "efb3e395093e34d7b16c92ed73abb199a28d0bc653522c13d4e720030f547713"
+    },
+    "progs/trap_sawblade.mdl": {
+     "bytes": 28716,
+     "sha256": "759bd7e1f7629b4d87ecb9e53a9f2d66e3e81b9103bc4eab3f85bd598eba36f6"
+    },
+    "progs/v_ghook.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "5b6b84edc6e6c58128a6e830ec35424cc83e69fab7b1337c4c681d8d0ed81e74"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 48964,
+     "sha256": "d073c7fad7dee2c4664aa401d744024b623abcd65e60a4c7066721b988838aff"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 54940,
+     "sha256": "c0a6b7d9664b0ab5a0c77732b22592dedfefbf65c624c05bec7aa8d60835f74d"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 39668,
+     "sha256": "78fc36ddbd33fb77192ef100547f1a1a0f70a38fdaac7094df67f2df33ca9237"
+    },
+    "progs/v_shadaxe0.mdl": {
+     "bytes": 97860,
+     "sha256": "598f555a854590a749eee83870a869ebfa8dfd3c84ad447b7fe3fb796ea1da80"
+    },
+    "progs/v_shadaxe1.mdl": {
+     "bytes": 97860,
+     "sha256": "2ffbb3026a21d70a73a091222cc4f2ea2ba6abd706fbffc276f027b9475abfaa"
+    },
+    "progs/v_shadaxe2.mdl": {
+     "bytes": 97860,
+     "sha256": "cd2a7a188f73c5b841183885663470c53c3af5646491f44811a4a0f192381ed7"
+    },
+    "progs/v_shadaxe3.mdl": {
+     "bytes": 97860,
+     "sha256": "b1c0dd11ce314003de5051f8a3b9581ee3eda5ea347d3d3371eea43051820197"
+    },
+    "progs/v_shadaxe4.mdl": {
+     "bytes": 97860,
+     "sha256": "81108f8b2484d24e54e9ab3ee5b707be5ea28adb142159412aa773ae01e593c1"
+    },
+    "progs/v_shadaxe5.mdl": {
+     "bytes": 97860,
+     "sha256": "0d3ca1664ee82ab2aed6261c262fdc455db981ecd2d62371595e520756d7bb22"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 22260,
+     "sha256": "bf79b703708665b9e65556bf68c0fe9d177097b2b96b11563d7b8bf84485a81b"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 22764,
+     "sha256": "5a51ba87bcdf37463bb8f34dd7259ea2be54d540fbc59798bb62dc24b2d3e777"
+    },
+    "progs/v_shot3.mdl": {
+     "bytes": 77868,
+     "sha256": "5b08bebaeb2fa054e6bb37d51c716cfac0e4da843b0db158a4a9769fa04ad13f"
+    },
+    "progs/v_zershot.mdl": {
+     "bytes": 62604,
+     "sha256": "4173bb2b84f9adce1957a87251cca591d968c3a54e801b170a87aae82539a2b1"
+    },
+    "progs/w_backpack.mdl": {
+     "bytes": 138832,
+     "sha256": "78d86e7bc605746990a1b10644b12542f3380375693d4fb015884e42269314a0"
+    },
+    "progs/w_blueflail.mdl": {
+     "bytes": 17236,
+     "sha256": "3b645ebcb5d2249c9cf904e17006b85aa05963efda33f45f5b6f6fc3ea188d26"
+    },
+    "progs/w_chainsaw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/w_dcrossbow.mdl": {
+     "bytes": 14388,
+     "sha256": "52b14c48ec77acb261f18e1d7903e360eb96acb5c22a0702dfde90c66b103064"
+    },
+    "progs/w_dfurysword1.mdl": {
+     "bytes": 8916,
+     "sha256": "16521de90d0e71090ef4e6b5904252f3ae2d4a38ebe99eff9dc758ea009b0f90"
+    },
+    "progs/w_dfurysword2.mdl": {
+     "bytes": 8916,
+     "sha256": "2e42b37254cf8d85b098e58143fd77d86bed2f3568f630196326841298d07187"
+    },
+    "progs/w_dguardsword.mdl": {
+     "bytes": 8404,
+     "sha256": "74b884b8fd0a785fc2c1dcc29428b8d4c8725de6963bccf7ec80c396e002fa38"
+    },
+    "progs/w_dknightsword.mdl": {
+     "bytes": 8404,
+     "sha256": "1e6729ae15dd1520fff7f4c1c30260c35b637bd0b23b8fb3a5a476b175a39165"
+    },
+    "progs/w_dprincesword.mdl": {
+     "bytes": 19296,
+     "sha256": "89e5ef1382e980b68e812f7e8f6a9b6fba34af42bb2def457b7a2f6f8d7388b7"
+    },
+    "progs/w_enforcergun.mdl": {
+     "bytes": 42612,
+     "sha256": "fbbfd121a3d085d654aab512cfebb0b6890daf3c403f25ca372edc3c53039375"
+    },
+    "progs/w_hknightsword.mdl": {
+     "bytes": 20504,
+     "sha256": "a8dffdc9e400d45fcea617255a8731d752cfa83df40b923128d5dbae6839492c"
+    },
+    "progs/w_judgesword.mdl": {
+     "bytes": 199388,
+     "sha256": "c822984ba5a12948ca389f4b8536c3aa6644993242362b10ac7f6ff2e2332590"
+    },
+    "progs/w_justicesword.mdl": {
+     "bytes": 264928,
+     "sha256": "0fc111a637bdaf5372c02c53439497c2adfc0914845b947ecc9ad70ace1e1b3d"
+    },
+    "progs/w_knightsword.mdl": {
+     "bytes": 14328,
+     "sha256": "4740ee2b171380cd9481ba07f284fe720c5b49b0980dc19cb145b2356205fc0a"
+    },
+    "progs/w_ogregl.mdl": {
+     "bytes": 8260,
+     "sha256": "8071cb814b6158c8af563494687e3994192818ccc2aa80f4766bbf6912d559ee"
+    },
+    "progs/w_ogreham.mdl": {
+     "bytes": 29996,
+     "sha256": "11c1ec322889a971b7f930a7c653f13e69714e6de77b7afa4ded1fdec39145de"
+    },
+    "progs/w_ogremac.mdl": {
+     "bytes": 29324,
+     "sha256": "2f9086da6b43becab1d54e47bcb299421b1bdc1e1e71c41e581b367a75f52919"
+    },
+    "progs/w_skullbook.mdl": {
+     "bytes": 25580,
+     "sha256": "e99379e980169501931eb029f36d05b41ba52f8597a6022bf195b08dba88c70e"
+    },
+    "progs/w_soldiergun.mdl": {
+     "bytes": 36120,
+     "sha256": "9c89a19d7c5fa69783d8bcf59b46b18a0c80c37e280b18731564952faf1d6523"
+    },
+    "progs/w_zombiesword.mdl": {
+     "bytes": 14328,
+     "sha256": "e4ac73fc149fa581e64fb5f2016ce58c99ab1c9a76502ede78a525ab7f344b0c"
+    },
+    "sound/ambience/bell_ring1.wav": {
+     "bytes": 61586,
+     "sha256": "b9169a48fd032d7c2b0cadb61540ac5db42ca6384cb2c74818bd46bae3fc7db1"
+    },
+    "sound/ambience/bigmachine_loop_02.wav": {
+     "bytes": 92760,
+     "sha256": "4d6dd03883ac4462c7f1741c022a3e8fd9e2c65cd54d5d126f58c00b3bfe7df3"
+    },
+    "sound/ambience/chimes.wav": {
+     "bytes": 250476,
+     "sha256": "d1060cd75d8a520b748047790d33c9a4ab5fd626330ebf1242d318d308c165db"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/distant_gears.wav": {
+     "bytes": 72502,
+     "sha256": "760d34131249ff3c4bccdab0cd3df69874728a6db3e1b4545177e5ce381e5e80"
+    },
+    "sound/ambience/drone6.wav": {
+     "bytes": 36820,
+     "sha256": "ab0cc1d617b06169d20b42bddc31078c0c7a1b8b15793fe6cfea6dbc96b4129e"
+    },
+    "sound/ambience/fan_finish.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/fan_loop.wav": {
+     "bytes": 288110,
+     "sha256": "d7459b4f1087aa1e002f41fc0274e4cb2f313dff5af2eecaa9de5225bcdcd729"
+    },
+    "sound/ambience/fan_start1s.wav": {
+     "bytes": 96044,
+     "sha256": "b0bad8ae3cd81dc4bbd76591e29f9c43610cb6e0311d4822213e400a6b99dd9f"
+    },
+    "sound/ambience/fan_start2s.wav": {
+     "bytes": 192044,
+     "sha256": "6716a803f246e44416fc414ca2f51744fc1ed79178f79fe3baf7a986c820c020"
+    },
+    "sound/ambience/fan_stop.wav": {
+     "bytes": 192044,
+     "sha256": "ee8607922387eeb594c18096ef6dd4003990a5fe47414dee331921f6d03be6b7"
+    },
+    "sound/ambience/fire1.wav": {
+     "bytes": 47906,
+     "sha256": "c1370a7c177aa21de219578cc64716bc800007e2ac86ae106affac01f8edc470"
+    },
+    "sound/ambience/flames1.wav": {
+     "bytes": 132406,
+     "sha256": "8ac99a7ace2ec9cc98a38fd5777973eb484e9193cf93dfcd6a51ea4f0f9d0f00"
+    },
+    "sound/ambience/flames2.wav": {
+     "bytes": 132406,
+     "sha256": "31e76d131cb4ad3c0602e2559c949feb7a8749c639363f1fd7df53136616fdd1"
+    },
+    "sound/ambience/flames3.wav": {
+     "bytes": 132406,
+     "sha256": "b4008d1da182bc0886f8bad53e5a700d8e04050920aa27ceb0922be938eb7c96"
+    },
+    "sound/ambience/flames4.wav": {
+     "bytes": 132406,
+     "sha256": "222222e080566c899a48df9e40006d0ee36575c03250c44845fb10a94c5cead9"
+    },
+    "sound/ambience/gargoyles.wav": {
+     "bytes": 136816,
+     "sha256": "16f09404b6043aaacb4b6b2bb00143ab72b5e185f02e610d780ea7d311d2df6c"
+    },
+    "sound/ambience/gearopen.wav": {
+     "bytes": 49708,
+     "sha256": "39b73c8ada1b06c7ba07099447b9b0d75911f08df09ced3826bcff136af5b0ee"
+    },
+    "sound/ambience/generator_gas.wav": {
+     "bytes": 529314,
+     "sha256": "6710075453fde424951171823e87f3711d53fd434149ddecc14a14ce721de04a"
+    },
+    "sound/ambience/ind_lift1.wav": {
+     "bytes": 158906,
+     "sha256": "c722fa19c7851d2c7b4307489911b885527e31fd3e4de44d5a184bd786714049"
+    },
+    "sound/ambience/ind_lift2.wav": {
+     "bytes": 156008,
+     "sha256": "c404881a9758f839fd055dd69a82f04bf7e5d5b98538a4a87b2ee741d8b4956d"
+    },
+    "sound/ambience/light_hum1.wav": {
+     "bytes": 100022,
+     "sha256": "cb2f04b81297621ffddbfb028dc5021a665e3285deb7c80757a47add8294f032"
+    },
+    "sound/ambience/liquid_bubble.wav": {
+     "bytes": 129688,
+     "sha256": "838ec1e72b2c433408a342a48518987edcb2124932eeb477d59653540b13d6ea"
+    },
+    "sound/ambience/liquid_burnlong.wav": {
+     "bytes": 710182,
+     "sha256": "9c9c77941f88416e3f20dfc4f028cc6c9719dd7f58a15dfc6124f1bb5a17f61a"
+    },
+    "sound/ambience/liquid_burnshort.wav": {
+     "bytes": 89464,
+     "sha256": "4ea16997389f1aa35549869a338f2093f40d14df030c381a7659cc7e3cbf8bfc"
+    },
+    "sound/ambience/liquid_drain.wav": {
+     "bytes": 220464,
+     "sha256": "e86a6012c8fc3a795791fc344ef636bb1854a602cd609e2df751531e89277cf9"
+    },
+    "sound/ambience/lowboom.wav": {
+     "bytes": 666640,
+     "sha256": "ad591a6f574f48e654e32dacee6b7d862df8b47e20ef116f84415ad9aa515559"
+    },
+    "sound/ambience/machine_loop1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/ambience/machine_loop2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/moo.wav": {
+     "bytes": 265502,
+     "sha256": "35b7924115bc4cdf94e9cbb274a4d9ca251d6878817834bec08aaa176f2ddc9b"
+    },
+    "sound/ambience/mystery_drone.wav": {
+     "bytes": 1350258,
+     "sha256": "eb3fbb28dda2a6204af07d08fa993ed09513f9915142dd6f4af808204b6b8c9e"
+    },
+    "sound/ambience/power_drone.wav": {
+     "bytes": 36700,
+     "sha256": "4307c01076cb5e076d27546b17bd6b11e2369a67b59dbbd64f2607d8b262a8c2"
+    },
+    "sound/ambience/power_off.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/ambience/power_on.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/ambience/power_shutdown.wav": {
+     "bytes": 1118464,
+     "sha256": "e0ab1a0f67a2d37a525f7a73e8ee8c3a26f746e027fa1501f6648f5586ea2048"
+    },
+    "sound/ambience/power_switch.wav": {
+     "bytes": 66382,
+     "sha256": "5c006bb7315e6eb6d2367ae30a78f0abec8ae2a1e2b6a2c9af88354962b0f33f"
+    },
+    "sound/ambience/rain1_nl.wav": {
+     "bytes": 154394,
+     "sha256": "45d8c08ff4a9a2dd6ff8362fea7c22f9c3ea64a3a8d7b6c81c8cad88265f327a"
+    },
+    "sound/ambience/rain2_fade.wav": {
+     "bytes": 198550,
+     "sha256": "3cf300a4f785d416656838bd3a68120bf6a48d16f928ca74e2e0890ec9f8b426"
+    },
+    "sound/ambience/rain2_nl.wav": {
+     "bytes": 66250,
+     "sha256": "f2735ae8a7b1ae5ab5ce3b8ed66d8c61d00a65f2e66d8c565f4abe718d57ab67"
+    },
+    "sound/ambience/rain2_org.wav": {
+     "bytes": 132400,
+     "sha256": "4c1f820b2c8f4bea08b8357fb8409e9f30a98fd0faf1413a1953ea697b84b507"
+    },
+    "sound/ambience/rumble1.wav": {
+     "bytes": 403620,
+     "sha256": "47afe820548bcf248b7760f7a66a61ea65b5fb79f70d47e3b03cf8211bb4c5f3"
+    },
+    "sound/ambience/rumble2.wav": {
+     "bytes": 99104,
+     "sha256": "9c3d5418c7e5bac60c365f0e8b7ea496dd2b51c72c13b0e5a6640e2ef880433a"
+    },
+    "sound/ambience/rumble3.wav": {
+     "bytes": 209242,
+     "sha256": "864f373dbd75172e1c8f31373188f38c31a80af46592f6b2e92cf5f576e5e0e1"
+    },
+    "sound/ambience/s1_stop.wav": {
+     "bytes": 16162,
+     "sha256": "9a35adf9361aa033b413762fea7d04b2cf7392b363f2aa187a81905f65a44b61"
+    },
+    "sound/ambience/switch_1.wav": {
+     "bytes": 35324,
+     "sha256": "9f73f07313ba4995247d82901111b5aea4200c48de6641dddb145dfadcac40c9"
+    },
+    "sound/ambience/switch_2.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/switch_3.wav": {
+     "bytes": 17576,
+     "sha256": "33b6ed57b0255840415df4db607f86b1183b564f4b1f2dcab6d45d4d75231b8c"
+    },
+    "sound/ambience/switch_4.wav": {
+     "bytes": 44348,
+     "sha256": "bfebdf2afdbab57bd5be3fe0996ce19ff46d983eea4d1511d85af2e4f7d0db00"
+    },
+    "sound/ambience/switch_5.wav": {
+     "bytes": 79992,
+     "sha256": "78bb8cb9ab7202657495a0ca14340886af901912850b9951b0da159f55c2cb20"
+    },
+    "sound/ambience/switch_6off.wav": {
+     "bytes": 141466,
+     "sha256": "999d3b02b7224586d5c487c2666981f054aa091f0569671c72455bff458c9a2a"
+    },
+    "sound/ambience/switch_6on.wav": {
+     "bytes": 176192,
+     "sha256": "7a67fa5d4ee042c6afd271868682a1a34908c2593e5ea9e868ecb6d3e154b55b"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 220548,
+     "sha256": "2cec0b03aa7047110862de21f8f6c77e4d98901ecaf5e405a473c2ddc922528a"
+    },
+    "sound/ambience/thunder2b.wav": {
+     "bytes": 286716,
+     "sha256": "44095eceb307b5f2f1093051597ea0e48bc7abe165accd5badf99c4ad692c6df"
+    },
+    "sound/ambience/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/ambience/windgust2.wav": {
+     "bytes": 110284,
+     "sha256": "b818f61172795942402ff0ca0d1295a91c36a245edc80689c35fe64a8ac1a4e2"
+    },
+    "sound/ambience/windgust3.wav": {
+     "bytes": 110030,
+     "sha256": "fdbb85f091cd9447f1500173aff70236abcdb947ba0758711816da59c5293344"
+    },
+    "sound/ambience/windgust4.wav": {
+     "bytes": 198502,
+     "sha256": "9a5c5a3da44f981c9deb8b437f57b3e3a35f2bcab318a1a3223f0a18fa4d2101"
+    },
+    "sound/ambience/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/ambience/windgust6.wav": {
+     "bytes": 396944,
+     "sha256": "27a19679e7164a6e7bb8e4d6bc42cc8c12a5cd56bba45218e2ec5f1dc528da0d"
+    },
+    "sound/ambience/woodcreak2a.wav": {
+     "bytes": 352834,
+     "sha256": "24d3f57839910934eb61b74a91cf47ee4ab48b38f58f060ca05bde7547e8813c"
+    },
+    "sound/ambience/woodcreak2b.wav": {
+     "bytes": 352838,
+     "sha256": "574401233bff93169d452f4af748a289cfaff5d4e6319884e3cfb4dbd205d0a4"
+    },
+    "sound/ambience/woodcreak2c.wav": {
+     "bytes": 308746,
+     "sha256": "02deb62b856b7be5c3304a0bf745f79019b0b408a8cfcc4e1edede397ba09c7d"
+    },
+    "sound/ambience/woodcreak2d.wav": {
+     "bytes": 352856,
+     "sha256": "6d35975964b2fa32ece681a9d0cfa13202cde02bc315f32af0690f7437352452"
+    },
+    "sound/ambience/woodcreak2e.wav": {
+     "bytes": 308766,
+     "sha256": "54eb41e3f5c2a0103d07e70e83cf82b51014da3673fb770cf6ada3df669c328e"
+    },
+    "sound/bal/bc7_waterfall.wav": {
+     "bytes": 137846,
+     "sha256": "51dcfb96c94678cbb01e0c985240e853a01c6fc3c4f2376de177c0be59bfcfe6"
+    },
+    "sound/boglord/attack2.wav": {
+     "bytes": 8036,
+     "sha256": "efa18dec8f6d5066b8d494a232ca9c98c27a4a9130130086a9b0a27ffccb34ed"
+    },
+    "sound/boglord/bangdoor1.wav": {
+     "bytes": 30968,
+     "sha256": "b267e602e76fe1d8e854e2873e06008af15612ed1a31ec41feeb4461d52fc478"
+    },
+    "sound/boglord/bangdoor2.wav": {
+     "bytes": 39828,
+     "sha256": "f904a5423580c118de1d732fff714565f1dd8d8d1556b3b58bf39d2c59fa4272"
+    },
+    "sound/boglord/bolt_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/boglord/death1.wav": {
+     "bytes": 39758,
+     "sha256": "a9e0e36b1a51d88a5b542dd2c1f79f1dbea402b3ceb18ee13606c03126f1a874"
+    },
+    "sound/boglord/idle1.wav": {
+     "bytes": 15532,
+     "sha256": "5339e3429b0510f7e8016e6ece9895df6f202b5809f739b317211a081401f202"
+    },
+    "sound/boglord/idle2.wav": {
+     "bytes": 18586,
+     "sha256": "52f8bddb2d5095f4077eb1f753d75bce94f906f1b3064067a54c875ae16d1a5c"
+    },
+    "sound/boglord/melee1.wav": {
+     "bytes": 9326,
+     "sha256": "e2f5808115d0a93dde1063db6f2d38f6ab7ff333f83d95741a8948f44ae4ace9"
+    },
+    "sound/boglord/melee2.wav": {
+     "bytes": 11746,
+     "sha256": "e299e39467c9f94730c21d1321455fdccf3aefbb0352d528b6d413639210e715"
+    },
+    "sound/boglord/melee3.wav": {
+     "bytes": 18776,
+     "sha256": "c066200b5ddb81aa0c0cc0462939681703549ac15dd6aa83db8a23ae54ce6317"
+    },
+    "sound/boglord/pain1.wav": {
+     "bytes": 11094,
+     "sha256": "6ca5a44043add6b389827e5aca8bc0c9e9c7b0cc0c7b4a5d3df292a78da0064f"
+    },
+    "sound/boglord/pain2.wav": {
+     "bytes": 11094,
+     "sha256": "7e11818fbae5354177add1e236b6f3e0f4665d50193154fbb15fead4bb4d7908"
+    },
+    "sound/boglord/sboom.wav": {
+     "bytes": 22172,
+     "sha256": "89899521eac11f922cdd4606a0fe08bc080a63a73ec4b4a502027e33f08b225b"
+    },
+    "sound/boglord/sight.wav": {
+     "bytes": 28734,
+     "sha256": "8b020b0f07a7461f5f520b8385e38828d66b3cb1fc46d7db08b845fa8ff62ad8"
+    },
+    "sound/boglord/slime_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/boglord/slime_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/boglord/thud.wav": {
+     "bytes": 22140,
+     "sha256": "f5d7b5f65e24d6a5edd04404b93a8c5a2db45cc6c142012638f050158bb783ba"
+    },
+    "sound/boglord/thud2.wav": {
+     "bytes": 105882,
+     "sha256": "7e8826a38df07d0d2b85d6d39b8b664bb2ef8a0686846573802b77811682e957"
+    },
+    "sound/break/ceramic_i1.wav": {
+     "bytes": 11106,
+     "sha256": "ed731319eb09044fe672f5d8681395a11a7449fe7b57b9a46040c717e714cf40"
+    },
+    "sound/break/ceramic_i2.wav": {
+     "bytes": 11126,
+     "sha256": "88c29d649471f031aa1049ee087cf866e1d9ea53183effd14cfabc81ecff9502"
+    },
+    "sound/break/ceramic_i3.wav": {
+     "bytes": 11144,
+     "sha256": "420d00d7884a22dd2baf9cdd1e059689858b47fb3adb2ad5ae29c80bd74b5dc5"
+    },
+    "sound/break/ceramic_i4.wav": {
+     "bytes": 17678,
+     "sha256": "0b7da87d046aeb3a52de305da60b2400c8cbf3480364235fb0bba3a0595f13dd"
+    },
+    "sound/break/ceramic_impact.wav": {
+     "bytes": 37584,
+     "sha256": "e6d2ada5c51a2787548468ad393e2497ef84b47ca487cd523f3ef6b283626226"
+    },
+    "sound/break/ceramic_impact2.wav": {
+     "bytes": 35380,
+     "sha256": "508725e20a999c339501dddb045a2ca6a51032905dccc68fe2a3fb9e9e1d0649"
+    },
+    "sound/break/ceramic_impact3.wav": {
+     "bytes": 26560,
+     "sha256": "ca4d7876a6e33cc285186d1432670878b54cc62c01e3dc4c650727069bfdb8ee"
+    },
+    "sound/break/ceramic_impact4.wav": {
+     "bytes": 37584,
+     "sha256": "e71b0559ac5d76dcd2016d07f8999ae1200d82ca7b658509339cf303c918f777"
+    },
+    "sound/break/ceramic_impact5.wav": {
+     "bytes": 37584,
+     "sha256": "1c6b3457c9d3aab209cd3b8977df579cdbe01158c1b4e5c07c2b5b227c96fb6d"
+    },
+    "sound/break/ceramic_impact6.wav": {
+     "bytes": 37584,
+     "sha256": "fac4857865a750a03f74e556f44186381315068ec1975c775fcd14ae4a7b3c7b"
+    },
+    "sound/break/flesh_impact.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/break/glass_i1.wav": {
+     "bytes": 13268,
+     "sha256": "63ec32f660d085c64274747b704bcbeb7261062b5fcbb570598d64e742dc7164"
+    },
+    "sound/break/glass_i2.wav": {
+     "bytes": 30950,
+     "sha256": "8b2ae028e6237cf06241739e3533ef3bf651194dfbef028fd648a6f06e8996de"
+    },
+    "sound/break/glass_i3.wav": {
+     "bytes": 8848,
+     "sha256": "ec97346c02431717927e2dd3712bd82428ea05960ffa027422fbaafab96b4170"
+    },
+    "sound/break/glass_i4.wav": {
+     "bytes": 4442,
+     "sha256": "b4144a008122e52aed45339e11ccf7cb1cd2e92f07e4169d029059a4ca01f5fa"
+    },
+    "sound/break/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/break/metal_i1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/break/metal_i2.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/break/metal_i3.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/break/metal_i4.wav": {
+     "bytes": 79928,
+     "sha256": "d2b35ba352f32ceae469acf9cfa04f7dcc0a462ff69e3649f5c0adf55ae2ea78"
+    },
+    "sound/break/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/break/rock_i1.wav": {
+     "bytes": 30534,
+     "sha256": "5cb61e93ebcf9bbcd3be1f6e282b51e9102d56b6650cffc0db93918b11b42322"
+    },
+    "sound/break/rock_i2.wav": {
+     "bytes": 29254,
+     "sha256": "9fdf4f489834452fce33b1fbe69bce9d4920a117c3d0d93b4fb530a7117bf160"
+    },
+    "sound/break/rock_i3.wav": {
+     "bytes": 25264,
+     "sha256": "59b506a84e018b11e9ba30a6ad299c2d8cf24d5907dc95cf30e578cd386e28bf"
+    },
+    "sound/break/rock_i4.wav": {
+     "bytes": 27244,
+     "sha256": "7a2c24ce52e272998ca035c967860873c92fbb14227a190ac82b761843680ffd"
+    },
+    "sound/break/rock_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/break/wood_i1.wav": {
+     "bytes": 28074,
+     "sha256": "6249449664f5ae509164ae3fd8588c905bea9daf5b1d919d9917b91aadf675bb"
+    },
+    "sound/break/wood_i2.wav": {
+     "bytes": 25158,
+     "sha256": "d51e731bdf895c84ec9927c496fc0a7fb6e7a37cbfbc2f6b55f54f716d804d08"
+    },
+    "sound/break/wood_i3.wav": {
+     "bytes": 17644,
+     "sha256": "8e1967cf42a7e31668d94e1b0cb7c6de4d36c6ec735d67ab01ac4e00dfb0853c"
+    },
+    "sound/break/wood_i4.wav": {
+     "bytes": 11516,
+     "sha256": "fb0908f1a2bdff824d27fa92f15690cb9f86805185119fbc7f7876547495bf45"
+    },
+    "sound/break/wood_impact.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/chthon/attack1.wav": {
+     "bytes": 22116,
+     "sha256": "91df4f5be21c6a80d31a050192b04a760f25c7f88a4b0ceeb2802fe8b8499d21"
+    },
+    "sound/chthon/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/chthon/death1.wav": {
+     "bytes": 55120,
+     "sha256": "b6eeee788b9aa49ca9698d2d7977748f142053fd3f47e2828d1781d7db7ec986"
+    },
+    "sound/chthon/idle1.wav": {
+     "bytes": 24322,
+     "sha256": "6a0a9b5a0b2e74fce8cbfa9ede97c2059884c0db81b2c68fc0ec7bb1da2a4009"
+    },
+    "sound/chthon/lavasplash.wav": {
+     "bytes": 100546,
+     "sha256": "a533653ff77e2dfc443377a1f055b6abd7af3c639f0e5634b0a47fd1f040ed76"
+    },
+    "sound/chthon/pain1.wav": {
+     "bytes": 35320,
+     "sha256": "f964bdd08ffc66f9f229aacb3b584ffefdcfbacf7da0f0075a9af752569c641c"
+    },
+    "sound/chthon/sight1.wav": {
+     "bytes": 49454,
+     "sha256": "533adf244fa2c2dca72765560e823ceead8d5a0f3832ba18d4fa2928154b12c8"
+    },
+    "sound/deflector/death1.wav": {
+     "bytes": 22150,
+     "sha256": "593140594353d4d25fe6b5e455afc0f3c2cdd6874bc1d545ea03f779454cd799"
+    },
+    "sound/deflector/death2.wav": {
+     "bytes": 41334,
+     "sha256": "4295a9a79fec3bf611c25f97553420d0e42b987ad8091930db9137b93a3e8f06"
+    },
+    "sound/deflector/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/deflector/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/deflector/idle1.wav": {
+     "bytes": 7668,
+     "sha256": "76455fc9d5fc53cf5a70900a9d875ba3ac839e1c3179eccc5287619a70523e6e"
+    },
+    "sound/deflector/melee_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/deflector/pain1.wav": {
+     "bytes": 6452,
+     "sha256": "e0905dc6c945663a97119f2c1522d5a8ebd1596ed26f33650fcb63b185959517"
+    },
+    "sound/deflector/pain2.wav": {
+     "bytes": 9598,
+     "sha256": "011d69ef5153dca029bcb1c3d60b3c3f0e1263bd9ca34a02d4d14e6ab508a0d4"
+    },
+    "sound/deflector/pain3.wav": {
+     "bytes": 12014,
+     "sha256": "08f5ac27626e862b7193f101a6d0b77dc6568c4e93ef3000199934769666b1ec"
+    },
+    "sound/deflector/rocket_fire.wav": {
+     "bytes": 15482,
+     "sha256": "a08e5f83d20b5d1eb585cf782f08a4a692b0f8c95e461b9a321814d099a89d79"
+    },
+    "sound/deflector/rocket_hit.wav": {
+     "bytes": 13274,
+     "sha256": "4dbcd0bad68272848a32a997bb235c4324cd55b1df0b96b1876fb96ea8ca6a90"
+    },
+    "sound/deflector/rocket_load.wav": {
+     "bytes": 6882,
+     "sha256": "1dbddae67f93c586ea3290ed65e1234cf8ccfd076847b1b418693e97fb5768d1"
+    },
+    "sound/deflector/shield_off.wav": {
+     "bytes": 10684,
+     "sha256": "5c3ea84c12abf632d777f90972966c4a50dde4ee7363d257e3c0f89e68027b5f"
+    },
+    "sound/deflector/shield_on.wav": {
+     "bytes": 10464,
+     "sha256": "340196ba32a9d3f672cbc3db86765eb1517550b00f2f97ed76cb519da1b93962"
+    },
+    "sound/deflector/sight1.wav": {
+     "bytes": 16106,
+     "sha256": "3ec7f00e859c52846b244e69cc3ed7321175746a44eb373fe4bd3cb07612dcf3"
+    },
+    "sound/deflector/sight2.wav": {
+     "bytes": 14432,
+     "sha256": "e8c0c1367969b0346bf5fdc94665a10480636629a71a6a35e47da3d7fb7cb463"
+    },
+    "sound/deflector/sight3.wav": {
+     "bytes": 17184,
+     "sha256": "11748c58e67305ad4e1cd7a2e2c084f9c41184cd2b4f756adfd18adcc22dbc2d"
+    },
+    "sound/dguard/death1.wav": {
+     "bytes": 30610,
+     "sha256": "af3809501261ec4d0afa6ea7301c11a5c7bbc1cc3e06b8c88172ee0214c30969"
+    },
+    "sound/dguard/death2.wav": {
+     "bytes": 43636,
+     "sha256": "93a70fc0d6fee819c723a435a3954b3fd3be86e358698ce85db1062990d1575e"
+    },
+    "sound/dguard/fire.wav": {
+     "bytes": 60820,
+     "sha256": "f5e5d4f6ccc0778c1396c66d327564a0b1892773f2c23d2e30590abf0c758bd2"
+    },
+    "sound/dguard/hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/dguard/idle.wav": {
+     "bytes": 20498,
+     "sha256": "45b2f208b9796d19d7aeb0cba64e4b0e5fd2ed7c980123f7c41ca10d17785021"
+    },
+    "sound/dguard/pain1.wav": {
+     "bytes": 10380,
+     "sha256": "9a367afb7cde241099c58c999e225ba939be39f21be818b16444f5a810049960"
+    },
+    "sound/dguard/pain2.wav": {
+     "bytes": 14892,
+     "sha256": "827a1e4d3c9983f61fffd61de33054274c144bddd9a68460b496fd6281cf9406"
+    },
+    "sound/dguard/sight1.wav": {
+     "bytes": 18124,
+     "sha256": "9cb3d960261d90ec16c9883f4326c905356b6ff4e99cdf48ab5913b098588016"
+    },
+    "sound/dguard/sight2.wav": {
+     "bytes": 18022,
+     "sha256": "35ee4b7ec6715c8c9fdc24f90ad0b5d90a0ae7a4986168cf40670e87c325d5db"
+    },
+    "sound/dguard/sight3.wav": {
+     "bytes": 19948,
+     "sha256": "c6818770267626dea27f4a72ce2249771f6968924022c2275a5a96abfa485044"
+    },
+    "sound/dguard/sight4.wav": {
+     "bytes": 20332,
+     "sha256": "7affcdbdc62f13e492a15b54fe642fe045641f5551f570cc3c8d5f7ee29521fd"
+    },
+    "sound/dguard/slash.wav": {
+     "bytes": 22942,
+     "sha256": "44b60d785ff03f033e183b6fbce69e526351187d28efdeb308f6f8bea930d450"
+    },
+    "sound/dguard/slhit.wav": {
+     "bytes": 31956,
+     "sha256": "0f07a131640f21337cd89a772588ecfc707d6a729f96b54c21920b809cd620e4"
+    },
+    "sound/dguard/slmiss1.wav": {
+     "bytes": 10458,
+     "sha256": "e32d5cb070a13fad979b021e84a727f71242305ade1af7bfe18c255f0f6dd548"
+    },
+    "sound/dguard/slmiss2.wav": {
+     "bytes": 13840,
+     "sha256": "f6b3aee08c25434d2fda7468cacf35a0912b182653a45991149b54a0fc4be537"
+    },
+    "sound/dknight/dcross_idle.wav": {
+     "bytes": 176610,
+     "sha256": "a7eba673532dad555f879ba77091e3cb9e44558608b83c36d8639e51d71b660a"
+    },
+    "sound/dknight/dcross_idlecom.wav": {
+     "bytes": 58910,
+     "sha256": "bba45bd9fc02e1d580a80596d6a1744bb8fb993ed73a7bfdf3b712670cccf989"
+    },
+    "sound/dknight/dfury_grunt1.wav": {
+     "bytes": 19702,
+     "sha256": "8d3709e913b8e26d8e094fddd9c60d74cc71b742e16276d4982c9636db05209e"
+    },
+    "sound/dknight/dfury_grunt2.wav": {
+     "bytes": 54294,
+     "sha256": "f7ca0d5970322629cc47f8c26489d5c916a570525ded20c73823c27f2834609c"
+    },
+    "sound/dknight/dfury_grunt3.wav": {
+     "bytes": 62054,
+     "sha256": "6eae53c32568ce90083dab528c18475ef840f9f684c43cdba7bfcc1c63435ba6"
+    },
+    "sound/dknight/dfury_grunt4.wav": {
+     "bytes": 28914,
+     "sha256": "0def63c77d0f116eabb77cc462ba6a57bc6523fad469946c6f1f11d786100819"
+    },
+    "sound/dknight/dfury_leap.wav": {
+     "bytes": 102756,
+     "sha256": "f288dc9324b2ccace32ce86cffaf0c042a59bf5b56b20657c018859f1038243a"
+    },
+    "sound/dknight/dfury_sight.wav": {
+     "bytes": 69602,
+     "sha256": "443887e91ca71dbba299b37a81bdbd3bb34b491c6c3e13fe73bb5c921019d1ea"
+    },
+    "sound/dknight/dprince_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/dknight/dserg_hbreath.wav": {
+     "bytes": 185884,
+     "sha256": "c8181d4844ac4b2bb7dc47bbc28bd2ae9fc2737120d6745292de4d594f40d406"
+    },
+    "sound/dknight/dserg_magic.wav": {
+     "bytes": 34768,
+     "sha256": "adcb0810b7e8b23d91d31f5727c480b35c7b59a90d9f7933f69c00e7eccd1f3e"
+    },
+    "sound/dknight/dserg_sight.wav": {
+     "bytes": 15210,
+     "sha256": "d4f7c5b6f64d48606d1d3e1889794a22107f3d5914b37c81c405fdfb1133a7eb"
+    },
+    "sound/dknight/ghost_idle1.wav": {
+     "bytes": 110292,
+     "sha256": "878416a0151a1a71891a84db2565d1e8a2b2e37f03f1822d7f9411a98b42b528"
+    },
+    "sound/dknight/ghost_idle2.wav": {
+     "bytes": 110290,
+     "sha256": "048f79f7fa8f9e49f97dad9f5cb468933be1713726ba95d3ab10d9811cbb5f2f"
+    },
+    "sound/dlord/death.wav": {
+     "bytes": 32022,
+     "sha256": "0188f6a3dd88686e15311f8c39c4277078e55bc0ec75497e2eb534af717abcdb"
+    },
+    "sound/dlord/idle.wav": {
+     "bytes": 9906,
+     "sha256": "c0ee37f80013dad1aaeb285a11a33c4d7c2ff2de0b2a94c2943d3fbe1c241bcd"
+    },
+    "sound/dlord/pain.wav": {
+     "bytes": 8632,
+     "sha256": "230ed5c7d024bfa90b973649aa79d9e9327eaf401b1632e4a1334fb4a9eb075c"
+    },
+    "sound/dlord/sight.wav": {
+     "bytes": 28028,
+     "sha256": "d82aa0028754e826705961040e1ab27f007c572a28c63dbcaeefeb681bc3ca85"
+    },
+    "sound/doors/rattle1.wav": {
+     "bytes": 88274,
+     "sha256": "c524d12100f1067bb30ecdf83e18e5d85124fef834929cfd2a2ade14f83ad730"
+    },
+    "sound/doors/rattle2.wav": {
+     "bytes": 123526,
+     "sha256": "e8decabe8df10f704814bf2f432b3fc6d5542022d465af336b0680793f6163ea"
+    },
+    "sound/doors/rattle6.wav": {
+     "bytes": 97072,
+     "sha256": "0aef6aac51a4e3528e5f2019bf113ee2f0e5096a708d31483a526c447ebdb00c"
+    },
+    "sound/doors/rattle_tech1.wav": {
+     "bytes": 61784,
+     "sha256": "18610e64612241e6936f2d0ebe746c957652c4ce8e37c668515281712f6a1e39"
+    },
+    "sound/doors/rattle_tech2.wav": {
+     "bytes": 88244,
+     "sha256": "de39aa8b59c988b02bf6c13a716e225b7ee029f2553357b8646aef92a2792c3e"
+    },
+    "sound/doors/rattle_tech3.wav": {
+     "bytes": 52844,
+     "sha256": "a29e8144cdab34467250f040feaad044aff784a2775b50bd220e967b39f39b3c"
+    },
+    "sound/doors/rattle_tech4.wav": {
+     "bytes": 76844,
+     "sha256": "ba34a641758a2e2cb9ef5358a398482c2b34526fc4b0c49db590c9679c732ef4"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/enrage.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/r_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/eel/attack1.wav": {
+     "bytes": 27740,
+     "sha256": "8c84b2a5e7fd0754dca3611a8300a8cc9656295ea73617ff0c85d167b28459df"
+    },
+    "sound/eel/death1.wav": {
+     "bytes": 34264,
+     "sha256": "a0f8eab92db10e8fa9342f725743297fd8384e2aca1decc1189109196f3b960e"
+    },
+    "sound/eel/idle1.wav": {
+     "bytes": 53110,
+     "sha256": "c059a4f2bee33543b377803f2af1fc7e2ee205cd02d987859af18087246ae46c"
+    },
+    "sound/eel/impact1.wav": {
+     "bytes": 70632,
+     "sha256": "13cea2f7d66f40511add17d846ab6142345497ddd7cff5ebfc5e2e70a7eb1fbe"
+    },
+    "sound/eel/pain1.wav": {
+     "bytes": 13316,
+     "sha256": "569a6bf9383820e90e431db5c0b82cd0201e10fd2081d228f81a0c76a0e88d1b"
+    },
+    "sound/eel/sight1.wav": {
+     "bytes": 32074,
+     "sha256": "90786a043f5ec1bd0b761c5c8378dc2783e3b1d8e3ac95a9312f55a7c5b3baea"
+    },
+    "sound/eidolon/attacka.wav": {
+     "bytes": 27660,
+     "sha256": "a7bb5c16014c814d379585eb4c6752a91240a5856ad7f3af5f86af037bef91e6"
+    },
+    "sound/eidolon/attackc.wav": {
+     "bytes": 220544,
+     "sha256": "9815d26814c687618b7bbae4a5353570afe497c5d57fb77c083f695d102234c9"
+    },
+    "sound/eidolon/attacke.wav": {
+     "bytes": 46400,
+     "sha256": "39ad467257004bc6d2a17003abe4ef8df89d0668ec03fc8570aa755cbdf94c6c"
+    },
+    "sound/eidolon/death.wav": {
+     "bytes": 264696,
+     "sha256": "bc055e1315073c78e5571c99d29894bc89abfd64b6a258bdabc79849f81c50a0"
+    },
+    "sound/eidolon/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/eidolon/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/eidolon/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/eidolon/footstep1.wav": {
+     "bytes": 52384,
+     "sha256": "e228c0503d89118be55eafaf3a3bfa0a13e3bdcbe4a043f4a9bb31c9e96cf3dc"
+    },
+    "sound/eidolon/footstep2.wav": {
+     "bytes": 46128,
+     "sha256": "1a3b867c93932411f1c3dedf4a8f1553f19caabae438cb7989095307d1a6c5c5"
+    },
+    "sound/eidolon/footstep3.wav": {
+     "bytes": 43774,
+     "sha256": "4119d9c31e359bd48b52bff2842e51c441064896289194f04db44e2d7860cccc"
+    },
+    "sound/eidolon/footstep4.wav": {
+     "bytes": 41758,
+     "sha256": "6b97f80545d9587580a7b445f13e5a38300627e497ed85357f9448c7a910864b"
+    },
+    "sound/eidolon/growl.wav": {
+     "bytes": 44380,
+     "sha256": "f9f404c4590f2af8fa9a1cd0de34e1d031e66d88ccf553dba228396f0d8fb012"
+    },
+    "sound/eidolon/idle1.wav": {
+     "bytes": 28778,
+     "sha256": "61f423068b79bba82fb3ae3fca3957a8f059802068edf272f2695e6caab89271"
+    },
+    "sound/eidolon/idle2.wav": {
+     "bytes": 33172,
+     "sha256": "1bdd3d6862ed0b74aecae1917f09a65acf4db7fca49a0ccd21a7fbc2eea5f02b"
+    },
+    "sound/eidolon/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/eidolon/pain.wav": {
+     "bytes": 17744,
+     "sha256": "6a308180389e3fb98cc00c70dad1c6600988778b34628e04363e7ca54e5bf679"
+    },
+    "sound/eidolon/rock_hit1.wav": {
+     "bytes": 97066,
+     "sha256": "d31741c09309b240d294ba9b310b694aae1d71f823ac9ef28b27a8b5fff14405"
+    },
+    "sound/eidolon/rock_hit2.wav": {
+     "bytes": 123526,
+     "sha256": "a3d1247db98535829392172110a40fde19113dd493ab603c4b6a9a36dd743150"
+    },
+    "sound/eidolon/sight.wav": {
+     "bytes": 53044,
+     "sha256": "04c124f683e75e4d14374b7a044eeea288dd02a845ccab3ffd670f1c15799ebb"
+    },
+    "sound/enforcer/cent_hover.wav": {
+     "bytes": 103796,
+     "sha256": "a5616566072a5cdc9339e3722d6fee9e652796e9cc8f76e27dbd9aee13986f4e"
+    },
+    "sound/enforcer/death1.wav": {
+     "bytes": 9290,
+     "sha256": "f62aad2ae903808a0caecfc6bdfe13e5fdebb1df14d330c6ac4eda9b577b25bf"
+    },
+    "sound/enforcer/def_idle1.wav": {
+     "bytes": 32676,
+     "sha256": "7b673b07828790504caca013c18bf697fd53b758a3638b949b433cf2d72f03f3"
+    },
+    "sound/enforcer/def_idle2.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/enforcer/def_sight1.wav": {
+     "bytes": 18260,
+     "sha256": "7d57825c28cf4f93189261d76cccab676aeba097920114d5d3f48d7eddaaa1cd"
+    },
+    "sound/enforcer/def_ssg_fire.wav": {
+     "bytes": 14206,
+     "sha256": "494a6d493c3c298c1b9cc0051ce4c1f9e129293ea7ec283b62915c49d8c249c3"
+    },
+    "sound/enforcer/def_ssg_load.wav": {
+     "bytes": 5274,
+     "sha256": "db4f62f8d76a68f2e4d3e7a29a22d3ddc5d6ae9bb296e6e800e937b73b5a4dea"
+    },
+    "sound/enforcer/elim_idle1.wav": {
+     "bytes": 39084,
+     "sha256": "2ccaa3ba4f987d031a22b8048ca23e97900fca9def362ff92943b73a99ed7844"
+    },
+    "sound/enforcer/elim_idle2.wav": {
+     "bytes": 36204,
+     "sha256": "9232028e1a93c409c7000348bfadc269c49a333e8d65d904973efb547c7af805"
+    },
+    "sound/enforcer/elim_idle3.wav": {
+     "bytes": 38222,
+     "sha256": "93034d568db5c304a165c3d89cb03ffe5d97e8157755e944a863697007eb27fc"
+    },
+    "sound/enforcer/elim_pg_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/enforcer/elim_sight1.wav": {
+     "bytes": 31468,
+     "sha256": "2268ee0ad0c77a081b289a550a1dae24b274b2e3f06d156a67beca80df8ee919"
+    },
+    "sound/enforcer/enfire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/enforcer/enfstop.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/enforcer/fum_poisonoff.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/enforcer/fum_poisonon.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/enforcer/idle1.wav": {
+     "bytes": 15810,
+     "sha256": "cec388af73dff076ea3af7c754ef0939f989f3412b0359c0fb668cd91bd4abaf"
+    },
+    "sound/enforcer/pain1.wav": {
+     "bytes": 5478,
+     "sha256": "d8692021777495825974f8406e23c74ed249f9a80a9bc944c79b1722c35f64e0"
+    },
+    "sound/enforcer/pain2.wav": {
+     "bytes": 4580,
+     "sha256": "e48a524482ce67ff94ce00fe4d8a1190aed38e9c7c24cfee3607f0f2827049e6"
+    },
+    "sound/enforcer/pyro_flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/enforcer/pyro_flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 5870,
+     "sha256": "92dc64154602e29e95d40aa68d3544fe21cb21ce24192f1e8ffefc6b5d31b8cc"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 6574,
+     "sha256": "52b1991141ed9452fe6c7ebe219cc544fba443058f179b8eec5a5cbfb9aacf3d"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 6158,
+     "sha256": "d3b9e689b2b43ae74ae14fdb26680d3646d658107664965db97420ae032d74b0"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 5166,
+     "sha256": "815e05c3b14858209fee01316848c117ad89af9f0aab190fc0ca0239367373ac"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/freddie/death.wav": {
+     "bytes": 88244,
+     "sha256": "2e3de0875dd3245a98614829ab848cc1dfc34a95827aa4cfc174884977ecddf0"
+    },
+    "sound/freddie/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/freddie/idle1.wav": {
+     "bytes": 88280,
+     "sha256": "673ac7c26a9be2b1ea37b152ce48442ff40089cc7dc015c014eb42534db2c306"
+    },
+    "sound/freddie/mangle.wav": {
+     "bytes": 48548,
+     "sha256": "ee318d6849ca9dda4569db6009210a6909279bd2ffe9b31543d47134b51c1533"
+    },
+    "sound/freddie/pain.wav": {
+     "bytes": 38640,
+     "sha256": "ffe05b43444a209084c95c166b0776d33f9ba8af15ef998d3ed5c09aa0b03c3d"
+    },
+    "sound/freddie/painshrt.wav": {
+     "bytes": 8868,
+     "sha256": "31e08c51909022a6b0ad7f01f1f8dae196269b8b105e57e555025393cdc278d9"
+    },
+    "sound/freddie/sawstart.wav": {
+     "bytes": 41938,
+     "sha256": "90f83017a7ff5f2bd2824be1e122eab7d8171ab63a9025adf1fc03ee3e7a44aa"
+    },
+    "sound/freddie/sight.wav": {
+     "bytes": 55170,
+     "sha256": "3f73e5b30cef3038102ffa9ab0faf89e71af43ed2ee5a0758319c072c151c123"
+    },
+    "sound/freddie/step.wav": {
+     "bytes": 19898,
+     "sha256": "121818aa6200c770a70c2c02844bbc0351a62f166c31f9d85765896b426f610e"
+    },
+    "sound/freddie/step2.wav": {
+     "bytes": 19870,
+     "sha256": "7e33eb621ee356cbe4affe6218b988f477259dae705d57eea12d7fe10b5d4510"
+    },
+    "sound/freddie/step3.wav": {
+     "bytes": 19898,
+     "sha256": "a005232c4c0608092c7d697c6d24566892b74adfe7566030360c96996bd39357"
+    },
+    "sound/freddie/stfire.wav": {
+     "bytes": 27598,
+     "sha256": "597fa6e0e8c4da4fd85e9e26ecd7f95f3dc242846ec9b962cf2beb324e5a4fdc"
+    },
+    "sound/gargoyle/attack1.wav": {
+     "bytes": 28712,
+     "sha256": "cab70a44f7ec34343a1608ca8c13dd2b501065cade08e94b574f98436aabeadf"
+    },
+    "sound/gargoyle/death1.wav": {
+     "bytes": 41662,
+     "sha256": "07043eb3fcbcc9c8cf53b07c10b349a9f3beb471dc240a6d70d8f2b5a57e85b0"
+    },
+    "sound/gargoyle/death2.wav": {
+     "bytes": 28768,
+     "sha256": "c363613cd476d5099dbdced656244db0d704da5eeb54fe5b880f2202f6f465b2"
+    },
+    "sound/gargoyle/idle1.wav": {
+     "bytes": 72868,
+     "sha256": "90885fa6cae946ecfedec8a150911bcfdad8ef326254e1fb1bf44ca5c5af4eb0"
+    },
+    "sound/gargoyle/pain100.wav": {
+     "bytes": 26510,
+     "sha256": "d53f1e64f4c9f5e13e03cfee2681ef6dff370e95e9dd8668c7c06b79762e7773"
+    },
+    "sound/gargoyle/pain75.wav": {
+     "bytes": 28720,
+     "sha256": "78d5d0f1c5df4e1a565eeda076d5f8b3bb3582e551909b31fa8e36c292903826"
+    },
+    "sound/gargoyle/perch1.wav": {
+     "bytes": 26506,
+     "sha256": "5eab54a566e4c1136c40fbfbd636188a7a9c4aa6b278e51fb965e1761764cbff"
+    },
+    "sound/gargoyle/perch2.wav": {
+     "bytes": 30924,
+     "sha256": "745b5c5f1fd04a73a7581373925aa70cd3f35ab899df5f5fd2c610d07bf95bdd"
+    },
+    "sound/gargoyle/sight1.wav": {
+     "bytes": 35142,
+     "sha256": "1097300e4bca9ef61a7041e7f4ff403fe67c4fc0e687b30892a6bdf35bf45c09"
+    },
+    "sound/gargoyle/swoop1.wav": {
+     "bytes": 21056,
+     "sha256": "ef6b4b672dd984e846294e0be57d81df3abcb521b1f88f6afaf2f5cc2d4e91d4"
+    },
+    "sound/gargoyle/swoop1hit.wav": {
+     "bytes": 11078,
+     "sha256": "6a624e3f46e2c45f5e2d6f42ee18643a17268a6b0df2493fe6ffdba4be0c9057"
+    },
+    "sound/gargoyle/swoop2.wav": {
+     "bytes": 24364,
+     "sha256": "f98d41f9df7244e8f77c435ae4071a4e4595ec7005b7c72e44456fe7baca425e"
+    },
+    "sound/gargoyle/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 22094,
+     "sha256": "142b725ff5515cb438a592288a69e01331b3fd0bbb7311abf1dbaf90f95417ef"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/plasma_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/gaunt/plasma_start.wav": {
+     "bytes": 66270,
+     "sha256": "ad404715612b802a7d4f72f2d14abb47c338ac414af56c19ffc8dc2873f33452"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gaunt/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gibs/gib1.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/gibs/gib3.wav": {
+     "bytes": 33256,
+     "sha256": "10a19291ed8af8893b6cdbd80416425b27e5a197d39aa8d0557320752d78cf11"
+    },
+    "sound/gibs/gib5.wav": {
+     "bytes": 15490,
+     "sha256": "2d7603a9fc0c055ed3529bd4dfd511984c71b93f4719b605813eb5139d02c6d9"
+    },
+    "sound/gibs/gibacid.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/gibs/gibchain.wav": {
+     "bytes": 15938,
+     "sha256": "c6b2a37424a51810017bd5ee4764a014329467686f73bb2f48ad2704592176f3"
+    },
+    "sound/gibs/gibheavy.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/gibs/gibheavy1.wav": {
+     "bytes": 11110,
+     "sha256": "0a1313f08fa22e4df8a1beb15ffdb6e7b1906187f63042357e4a43631ef5e93a"
+    },
+    "sound/gibs/gibheavy2.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/gibs/gibhit1.wav": {
+     "bytes": 22150,
+     "sha256": "d2a73e2f9e31b9fefda789e49b17ec9bd18df0335c31f871514a282cf550829a"
+    },
+    "sound/gibs/gibhit2.wav": {
+     "bytes": 22150,
+     "sha256": "210477e93743dc6c0541bc158032d46251c6aeff551efcf515d6e7db87bb8a53"
+    },
+    "sound/gibs/gibhit3.wav": {
+     "bytes": 22150,
+     "sha256": "40db6dbb033d59dd458e5fb6102dba6d6ecf5bc5739d9fc35a3be68cc977da53"
+    },
+    "sound/gibs/gibhit4.wav": {
+     "bytes": 22150,
+     "sha256": "0bd1e29d68e41cbf2d753730df678918a38fc886b4690991fbd7e8fb3e13e055"
+    },
+    "sound/gibs/gibhit5.wav": {
+     "bytes": 22150,
+     "sha256": "4adf7a8249ee913aeb9e91120b1f6b9e529b1e1a3eadb75185589cf7c3ff910e"
+    },
+    "sound/gibs/gibmetal1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/gibs/gibmetal3.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/gibs/gibmetal5.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/gibs/gibmetala.wav": {
+     "bytes": 18474,
+     "sha256": "2c057e772307ef647b4313975cec75bacfd522bbc5dd27ae83a867065562635f"
+    },
+    "sound/gibs/gibmetalb.wav": {
+     "bytes": 30756,
+     "sha256": "fbcfa9e6cd5aa68c6fffd6699c8dc87ec3707a4281358f229afce57f3278c800"
+    },
+    "sound/gibs/gibstone1.wav": {
+     "bytes": 52956,
+     "sha256": "962dd735a1823905243700eb3f4e0caacc1be71a1f367ccad4f21dd82b4e99e1"
+    },
+    "sound/gibs/gibstone2.wav": {
+     "bytes": 22104,
+     "sha256": "04f070fa9873f382ded03a5139ce2c7da2013d8ef9221a8d10a64c3b5f912591"
+    },
+    "sound/gibs/gibstone3.wav": {
+     "bytes": 35344,
+     "sha256": "16262de5a0b703468f2c3f1e49ffa0c225eb81b89984b468b7bc95948ed890c0"
+    },
+    "sound/gibs/gibstone4.wav": {
+     "bytes": 8832,
+     "sha256": "75179beed6fb6f581944f5e7db153bea4d9ecc65899628468efd48710a392013"
+    },
+    "sound/gibs/gibstone5.wav": {
+     "bytes": 22130,
+     "sha256": "0aaff5c363ac29a9b50d83b4b04fcd7264c614a93d0c9bc7941c9704a6b4b499"
+    },
+    "sound/gibs/gibwood.wav": {
+     "bytes": 61708,
+     "sha256": "d9b53ab4d53f1265dd2083d341cd92f19729694946ff00ad15fa6d96965e63e8"
+    },
+    "sound/gibs/stonedeath.wav": {
+     "bytes": 76750,
+     "sha256": "26d0eb67357d292043fd494b1646f8ce005ba692d98610429bceedfc831d2325"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 374654,
+     "sha256": "de356a2581884e9008ef798775f82049c465aec242cad0f6024b510d33e11764"
+    },
+    "sound/golem/groundslam.wav": {
+     "bytes": 132412,
+     "sha256": "f557ad378642a77a2f31433db5fe9315cf33f5fc350018e2bd26d32359ec8617"
+    },
+    "sound/golem/iceshard1.wav": {
+     "bytes": 53022,
+     "sha256": "41e523122aa4168298b247748bbe4201928582e974e673a83e717ea33f8656a8"
+    },
+    "sound/golem/iceshard2.wav": {
+     "bytes": 53012,
+     "sha256": "4b4e457f75d051a7aa3525bf82338f8b6d2f9460583c09e63d82b202cb11d03f"
+    },
+    "sound/golem/iceshard3.wav": {
+     "bytes": 53038,
+     "sha256": "8134080a7c6478463f9ea8c368eb6e0563dacb35bb3941b1e08e2cf0763d83ab"
+    },
+    "sound/golem/iceshard_impact.wav": {
+     "bytes": 176470,
+     "sha256": "ac850565ac7cfaa8ec2e55f535603aaf131605b9399f08f1b17f7c08920f7bda"
+    },
+    "sound/golem/icestorm.wav": {
+     "bytes": 61802,
+     "sha256": "2e8129333bc1a677591f9c4838a5f8c8e9ff63050fe6a47f212380f2497ae706"
+    },
+    "sound/golem/idle1a.wav": {
+     "bytes": 88238,
+     "sha256": "d238c43b6e83c044ba70352ed9362e50d68caf606f500c7d79f5c03d1e6a432e"
+    },
+    "sound/golem/idle1b.wav": {
+     "bytes": 88242,
+     "sha256": "93e3ca1ec51345da6e06a53f71bcd1271c911c9a6272246de9f58bef93c904dc"
+    },
+    "sound/golem/idle2a.wav": {
+     "bytes": 44166,
+     "sha256": "d0ceeb0ee1681127f9f426ccaa0ddb75c6ef32594618c972536871544e8d5748"
+    },
+    "sound/golem/idle2b.wav": {
+     "bytes": 44178,
+     "sha256": "94fb43b50445dbe7a8fe6cc06ea745b729cf5bf61c33cc543123f751e4a9cdf7"
+    },
+    "sound/golem/melee_pound.wav": {
+     "bytes": 17672,
+     "sha256": "23ff4f485f3adb3ba5227ba59824e226e91005846d2879077ffbe04141bab78b"
+    },
+    "sound/golem/melee_punch.wav": {
+     "bytes": 17702,
+     "sha256": "21cbd6ca5b9c8d95a43c39b360b12ee8033dca1aaf11d4c1164d4bc9ce83b7d3"
+    },
+    "sound/golem/melee_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/golem/pain1.wav": {
+     "bytes": 27948,
+     "sha256": "388150975b33e271db5402f502c6a36899731ec85cb9b16cdcc4b427b206a3f2"
+    },
+    "sound/golem/pain2.wav": {
+     "bytes": 32940,
+     "sha256": "b3908c02406bcb8c379f345f80a825aa270a54ae02fe0356e02330620d9cf437"
+    },
+    "sound/golem/rockstorm.wav": {
+     "bytes": 264676,
+     "sha256": "c57be8195f675560b879c3fc4e23c49f021d0c45aa81f2a84b74303f111d7c7a"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 76762,
+     "sha256": "965d1107adbc9a068d1d2af16fc783855833569dcc3a6030fa920019c30a4083"
+    },
+    "sound/golem/wakestatue.wav": {
+     "bytes": 250454,
+     "sha256": "630505eb8c9c84511f39d2e77096cafcbab044f73569934cda127a4b6f37f138"
+    },
+    "sound/items/airtank.wav": {
+     "bytes": 22160,
+     "sha256": "9b8f5c5deb886800c91d46809ecf82fb114467eb8a395b9c980d47c6b35f6b17"
+    },
+    "sound/items/airtank2.wav": {
+     "bytes": 66286,
+     "sha256": "76156f8f89e2bedbfaee9ee3340adb6bfe8639f242051178c2655e04cdab5198"
+    },
+    "sound/items/airtank3.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/items/airtank3out.wav": {
+     "bytes": 176494,
+     "sha256": "672a866c27c64f7eda1e05775cea6b4373c289c39fd423a519d39198d10a9c89"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 15122,
+     "sha256": "54c25fca46991ea142e9fdf5309e690ce3ff977df89aa7d14a8938ff386a237e"
+    },
+    "sound/items/backpack_ammo.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/backpack_armour.wav": {
+     "bytes": 20612,
+     "sha256": "438a08f094f47fac5f0b959fdde0f941be50bac12abdaa159f6f727975021aec"
+    },
+    "sound/items/blastbelt1.wav": {
+     "bytes": 43442,
+     "sha256": "a85924de58caed8e32d2849838afa0f248ec26eb295c9fc82eff818bc292f28b"
+    },
+    "sound/items/blastbelt2.wav": {
+     "bytes": 74978,
+     "sha256": "e4747a55ed0d66b6ce3bfe4ad0a4cfa75308657a155ebd9396ada78e0fd46bac"
+    },
+    "sound/items/blastbelt3.wav": {
+     "bytes": 49028,
+     "sha256": "4a2f6e7f65cbbc19c4bd5facf821017f7e60c41b9c164575de5255a40de2ba53"
+    },
+    "sound/items/health0.wav": {
+     "bytes": 8718,
+     "sha256": "cd277cc4fc98dbf9d5b0ba3ab784e468ba77a5aec78fe6086bd125512b6d1dbc"
+    },
+    "sound/items/health1.wav": {
+     "bytes": 13316,
+     "sha256": "ed9a43a3506afd8073e0d5225f3fa43116bb922b84d2216c2053d58f597544e6"
+    },
+    "sound/items/itembk2.wav": {
+     "bytes": 18884,
+     "sha256": "2b5601380dcc36753327eea905d15d2e0fd0f016d9559a2f8924f6f34b8045d5"
+    },
+    "sound/items/jumpboots1.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jumpboots2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/jumpboots3a.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jumpboots3b.wav": {
+     "bytes": 85590,
+     "sha256": "8eda0e57fdadfb61a414b4dae8c567a2bf10d9dabc44db7cf5589f00bba16250"
+    },
+    "sound/items/jumpboots3c.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/lavashield1.wav": {
+     "bytes": 30884,
+     "sha256": "e79050c462eeefcdbe6be0d79ff3042e80e5654c4060cf5377eee366cb4d6b43"
+    },
+    "sound/items/lavashield2.wav": {
+     "bytes": 49190,
+     "sha256": "17e93e45d150704bab8debd86ee8e9c600e9b08fefa70b16e1fe712dfdbd0c23"
+    },
+    "sound/items/lavashield3.wav": {
+     "bytes": 22094,
+     "sha256": "d94735d5df3c5850d2308972cb2495a9c9ec87e57c434c3ff0c160da659b051f"
+    },
+    "sound/items/nailp.wav": {
+     "bytes": 97394,
+     "sha256": "eb786846675412ba7bfb892fa0d5d356b67ec83ad3a551de8b423a874c3608d1"
+    },
+    "sound/items/nailp2.wav": {
+     "bytes": 132454,
+     "sha256": "2a01a3beb92154c7275c3c2ad39f648f8ecad7fd32ef7264d7404b917e0147dc"
+    },
+    "sound/items/nailp3.wav": {
+     "bytes": 45268,
+     "sha256": "0ea4502763119419b226d830b5b0147d6cfbe78996749e330d652d5b538dbb7b"
+    },
+    "sound/items/protect.wav": {
+     "bytes": 44176,
+     "sha256": "1bc5895a71225e8a385ebc900952d3b41f3d9541eefb8affcf15804ca96e5ab4"
+    },
+    "sound/items/protect2.wav": {
+     "bytes": 66286,
+     "sha256": "80b2a47fb1158f252e888bc692d352f224170c2d18177163dfea5c8110688e65"
+    },
+    "sound/items/protect3.wav": {
+     "bytes": 44176,
+     "sha256": "4aab23bd1683c733c5c85e7d55a93b27746860bd3c1a707e8c5a6439e35b5fd2"
+    },
+    "sound/items/r_item1.wav": {
+     "bytes": 12272,
+     "sha256": "3b569e1a8210563a64045dc1629a243b382c49cf24722cbddbdae348d5fa75d7"
+    },
+    "sound/items/r_item2.wav": {
+     "bytes": 14462,
+     "sha256": "088bb9013c0d2201997d3c566b95cc91f0419ba0bc89173c9e532659ccb4e886"
+    },
+    "sound/items/sharp.wav": {
+     "bytes": 100592,
+     "sha256": "c86d353daa830fffcf5ded77b73d6b8871d15a47a857a977ebaf7cbddb6cb587"
+    },
+    "sound/items/sharp2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/sharp3.wav": {
+     "bytes": 46584,
+     "sha256": "6318f7079e79929ff0439a570c5f806ec9c2cce8a8447eddb666dee0c2211336"
+    },
+    "sound/items/sharpa.wav": {
+     "bytes": 97394,
+     "sha256": "cd0d8dc72f736b38ab9c4a473798f0dd32e2074c14a310892c3fdf6515ff53be"
+    },
+    "sound/items/sharpa2.wav": {
+     "bytes": 132454,
+     "sha256": "2545c58a3682c1e8459389dc728a39fe0d76e6ce14a9c816a4826e327ab9bddc"
+    },
+    "sound/items/sharpa3.wav": {
+     "bytes": 45268,
+     "sha256": "083cc822d4cd6819d2dfd6e125ea4ca8ef3230c1ac1c4a5f5e3fe22e4d3d36d9"
+    },
+    "sound/items/suit.wav": {
+     "bytes": 31568,
+     "sha256": "a9b13127acef0c8e617cf5e510d5654227db9049a2b06b7544eb9e3030146ee7"
+    },
+    "sound/items/suit2.wav": {
+     "bytes": 66368,
+     "sha256": "34f0ba1b415ab62f2eb3b7a59bda6fe6fbbf3e519c7d2fab29a42ce29eb073c3"
+    },
+    "sound/jim/death1.wav": {
+     "bytes": 14348,
+     "sha256": "7f97f27dfda78f9fe6fc5265e512b651e57ae466752d56cfe0dccd6d08478ed8"
+    },
+    "sound/jim/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/jim/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/jim/gunidle.wav": {
+     "bytes": 13260,
+     "sha256": "46441335fe896cb993368bb12cedc1ddd4886b5933298bb6a0d6b7ba430cdfe5"
+    },
+    "sound/jim/gunidle2.wav": {
+     "bytes": 48540,
+     "sha256": "08d3577b66ab4b4c65ae7b01e4590e8d985605cc51a939bae0b43967472208c6"
+    },
+    "sound/jim/idle1.wav": {
+     "bytes": 44460,
+     "sha256": "7bc2df6cdd0f9a06cc441c656664edb3c686ab5803dab70948cc27bbba968494"
+    },
+    "sound/jim/idle1r.wav": {
+     "bytes": 44460,
+     "sha256": "7549a540858b1a829ac010930b848474c2f2200b910371368c99e35641f24644"
+    },
+    "sound/jim/idle2.wav": {
+     "bytes": 44460,
+     "sha256": "90d55e9ac8db5523255ec80384abd2508f005890f4fb66a654f4d783435afb4d"
+    },
+    "sound/jim/idle3.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/jim/laser_load.wav": {
+     "bytes": 36040,
+     "sha256": "5f39b9f60c5de5c9c3ac25a5149f1fef557e66c09d7d1a760ed6770082c5a914"
+    },
+    "sound/jim/pain1.wav": {
+     "bytes": 27006,
+     "sha256": "27522940f1db4eb098388e049a63d3a608e4beb2fa248d1232ae45d38a944e85"
+    },
+    "sound/jim/pain2.wav": {
+     "bytes": 30850,
+     "sha256": "6d1988d75f430287ad3e8766e9aafa8c8c85e2f2ebf53395b0fc2eb0fb26d788"
+    },
+    "sound/jim/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/jim/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/jim/rocket_load.wav": {
+     "bytes": 23416,
+     "sha256": "e3820aad09060be13927e56fc0e21112c22161b50b7d5be9cf59b98f84c5a231"
+    },
+    "sound/jim/sight1.wav": {
+     "bytes": 14892,
+     "sha256": "1a0db2b8c8d763f9aae09913d1cd3548fa0e30eb03949e24ef511a70acfda303"
+    },
+    "sound/judge/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/judge/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/judge/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/judge/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/judge/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/judge/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/judge/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/judge/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/judge/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/judge/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/judge/smash_ground.wav": {
+     "bytes": 66250,
+     "sha256": "f29f17426d2bd961d4f166e25fb951c8e12a37314bbc49722f0ae34c2beae233"
+    },
+    "sound/judge/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/judge/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/judge/smash_roar.wav": {
+     "bytes": 61784,
+     "sha256": "24b26a6b00a8731693bafd8ef67a5f0e2a4bbad20e722ec14f6fefd13047dc78"
+    },
+    "sound/judge/summon.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/judge/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/justice/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/justice/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/justice/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/justice/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/justice/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/justice/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/justice/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/justice/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/justice/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/justice/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/justice/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/justice/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/justice/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/lostsoul/bite.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/lostsoul/charge.wav": {
+     "bytes": 114682,
+     "sha256": "327cf4f521c92b3af6ff7cf50d1bfa6d101d06dee52350f123473e56e72626e3"
+    },
+    "sound/lostsoul/death.wav": {
+     "bytes": 151916,
+     "sha256": "08b6f8d3a50465e7deb346bc8902605bfc8bafc134cfac38aeb1d9fa5d1d2863"
+    },
+    "sound/lostsoul/idle1.wav": {
+     "bytes": 132332,
+     "sha256": "aac9bd66ea75d4778a20ba07b248baaa4f446beb60e5b5be76d04be36df1a1db"
+    },
+    "sound/lostsoul/idle2.wav": {
+     "bytes": 132332,
+     "sha256": "963c18a04a41d49ced0c820fd6ec51c885e7828a2a09bd47c15227555b6d4ada"
+    },
+    "sound/lostsoul/pain1.wav": {
+     "bytes": 14948,
+     "sha256": "baccaed4fd7c4e504214eb7241d3e8ea3e187739a781c30de57c8b5af6dbe6d0"
+    },
+    "sound/markie/dronebell1.wav": {
+     "bytes": 410346,
+     "sha256": "c7b65065ba9279c8131a83b642523e4193b8611f7b14430af2d52c831082340a"
+    },
+    "sound/markie/dronehum1.wav": {
+     "bytes": 156754,
+     "sha256": "9542c51342398a1281476da03114adb01012367dac58d2a08b50c684a1a98093"
+    },
+    "sound/markie/dronehum2.wav": {
+     "bytes": 183654,
+     "sha256": "03545ae0f88b788e69e09c0aae2cccfa727a2609ef224c7d1d3451f0e6172709"
+    },
+    "sound/markie/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/markie/dronespace1.wav": {
+     "bytes": 151808,
+     "sha256": "2c9c7f38a2023d3452a48db3e5f98d11fa218315991d907f8e3fa95d128d4f76"
+    },
+    "sound/markie/dronewind1.wav": {
+     "bytes": 110328,
+     "sha256": "f65fd70b6c398e1a17975eff7d92bde89ac17bc8d5cf0e9c6dcb17934311e3a6"
+    },
+    "sound/markie/morte1.wav": {
+     "bytes": 529280,
+     "sha256": "c338e404901bbf094c5946e50cbd922580c077dc3f3e5369ab962cb07a70d855"
+    },
+    "sound/markie/morte2.wav": {
+     "bytes": 529280,
+     "sha256": "58e598c9da2ced85f6973eb897f578e0f29a13fa0eaefebfe14c8942a33c77ed"
+    },
+    "sound/markie/ritual1.wav": {
+     "bytes": 273266,
+     "sha256": "fe9b4b53f899a88321707330bb2454442d74e5098328e35549b9f0a8ff840cba"
+    },
+    "sound/markie/ritual2.wav": {
+     "bytes": 273246,
+     "sha256": "d38ee880af55413aa7c180b8c1935df71177502081ee1c376c37b572af3d9352"
+    },
+    "sound/markie/stingwhisper1.wav": {
+     "bytes": 132380,
+     "sha256": "fc6eebd33c0c99c0f4537a9727698181acb4d23d077f06b3da1ebbcb104c870c"
+    },
+    "sound/markie/stingwhisper2.wav": {
+     "bytes": 132380,
+     "sha256": "ae7319c28e0a4e492623b7ddb48634978da043c16d4450f86b8edf7e60fa283c"
+    },
+    "sound/markie/stingwhisper3.wav": {
+     "bytes": 151672,
+     "sha256": "e5dd9dcfd44dedf7b0cd4a0a94a519a0bbd84477e54293548a37aa16d3f1e428"
+    },
+    "sound/markie/watercreek1.wav": {
+     "bytes": 184884,
+     "sha256": "f0c3ac87d6f073cea0d1a9218c4e53327be7af07a8c8be00cd73f254f6c0ba03"
+    },
+    "sound/minotaur/attack1end.wav": {
+     "bytes": 19936,
+     "sha256": "eceb47163a0f495037bd067fcfe852dbd0cf8cc7c376c536f5e4bda8569d3f5c"
+    },
+    "sound/minotaur/attack1expl.wav": {
+     "bytes": 15554,
+     "sha256": "a8344e4036b9377a6c8e3d69c2e86c7f5fc157fb0034d6e0e190d5b9fc444ca7"
+    },
+    "sound/minotaur/attack1long.wav": {
+     "bytes": 42000,
+     "sha256": "bb901880112ff159b380b8bfaf19fc511f4b1217f08d55a05276a3500f6cd4c7"
+    },
+    "sound/minotaur/attack1start.wav": {
+     "bytes": 19944,
+     "sha256": "33dafc2b20be70d6da51321f9910a392535e6a31cbbd3c8d0d880307a18adb3a"
+    },
+    "sound/minotaur/bolt_fire.wav": {
+     "bytes": 17738,
+     "sha256": "2f8ea56413270eef58b56ae4c4f7af2506ee89fda82aab90c0426f4560baa80a"
+    },
+    "sound/minotaur/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/minotaur/idle1.wav": {
+     "bytes": 17686,
+     "sha256": "d213130ad4b58b5b55553da46d358526411916210e90caf082c5a93b499e2f81"
+    },
+    "sound/minotaur/idle1com.wav": {
+     "bytes": 15564,
+     "sha256": "0f8054eb2c16284a098f680dcdc65f5a4b8b971f8cceaca6adebe8c377d6117f"
+    },
+    "sound/minotaur/idle2.wav": {
+     "bytes": 15470,
+     "sha256": "390c82c79532878751bcddca11aa37dbd86018757860e46d0c950a09fee347d9"
+    },
+    "sound/minotaur/idle2com.wav": {
+     "bytes": 17764,
+     "sha256": "8369884de2f4f144b9e323f11e95f47723834b529b62100c908fef5e74391a93"
+    },
+    "sound/minotaur/jump1.wav": {
+     "bytes": 22160,
+     "sha256": "1aa935c4c76818dbe7faed7aee0d9acb9e98ad553a747bf00b83b811d141e886"
+    },
+    "sound/minotaur/pain1.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/minotaur/pain2.wav": {
+     "bytes": 41488,
+     "sha256": "bc9ffeb193379c6738ad2897ab582aa92e278a11d7f1fbb77563ca367987ff76"
+    },
+    "sound/minotaur/sight1.wav": {
+     "bytes": 48610,
+     "sha256": "8d0a5c1a31e525416430f8d45b8482b091d3bb9f6030ac2656bdeb231ddab5e9"
+    },
+    "sound/minotaur/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/minotaur/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    },
+    "sound/minotaur/strike1.wav": {
+     "bytes": 11142,
+     "sha256": "69b1419eed136c384deac99d31827825d3d57fc965ba80604faf9de3e85fd9b8"
+    },
+    "sound/minotaur/strike2.wav": {
+     "bytes": 11142,
+     "sha256": "ab12dc8ab3c9dc603e2ecd58a99beb9c1f551fb79eb6124bdba493efe7595a92"
+    },
+    "sound/minotaur/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 19940,
+     "sha256": "0798d1a1122171f06fd6b92e3f91881725c05f40e1eeb3494a5a1a1aa8a86e58"
+    },
+    "sound/misc/drip1.wav": {
+     "bytes": 12172,
+     "sha256": "9499c277eab2210ba491b61263b71410e5e8f4b2a68403ec6eb81bef687da04a"
+    },
+    "sound/misc/drip2.wav": {
+     "bytes": 15596,
+     "sha256": "410c25c5c459362849c7d3d0ad736e006b65a949e77c094fe248e803b357d5e0"
+    },
+    "sound/misc/drip3.wav": {
+     "bytes": 15164,
+     "sha256": "9ddf50265efafde7736fb7d03419988caab691245b32d986549ef6d643d2768c"
+    },
+    "sound/misc/flies1.wav": {
+     "bytes": 44168,
+     "sha256": "ca5cf0a4d661bf7440cd81dcd45ad7118c54c8ae58672755ee958ec6e50f7152"
+    },
+    "sound/misc/flies2.wav": {
+     "bytes": 44166,
+     "sha256": "09e6d74986b0f0ec9503d9e111f8d1436d7d6c5c4c0c87ec7808e3fca5b964b1"
+    },
+    "sound/misc/flies3.wav": {
+     "bytes": 44182,
+     "sha256": "2b5fb337ba88bd25e10c86bb6355723aea160b0ef6a6d43b30cbbd446444ed8e"
+    },
+    "sound/misc/gibf_fire1.wav": {
+     "bytes": 14376,
+     "sha256": "804f8524135d058d3a635e6567e3369b8b9ef2ecc808bf6e216c4d65609b86a3"
+    },
+    "sound/misc/gibf_fire2.wav": {
+     "bytes": 25842,
+     "sha256": "354b551ac38a19370126f67e3975ab795953bd7beb2c597f0a01a0de6286b7c1"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/laseron.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/misc/poweroff.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/misc/poweron.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/misc/rumbleloop.wav": {
+     "bytes": 106060,
+     "sha256": "fafcaa92b4a2174045e3826885d14e434a409bf559d1a1d519c4d50ec8939789"
+    },
+    "sound/misc/rumbleoff.wav": {
+     "bytes": 105990,
+     "sha256": "46728daf18b142575d50049188030a153c0e3e994dc83ea375c43ba6da171b3c"
+    },
+    "sound/misc/secret3.wav": {
+     "bytes": 302444,
+     "sha256": "75682a08b790af46c2b9f746e5772999ba1de333b567832f4a3a8414c6a0185a"
+    },
+    "sound/misc/spaceship_fadein.wav": {
+     "bytes": 231712,
+     "sha256": "d6c905eb002532087273eadb5a577db443068532795fd509571179a354c56a9f"
+    },
+    "sound/misc/spaceship_fadeout.wav": {
+     "bytes": 495982,
+     "sha256": "9e5286b29adeb9cf7b3af489bb2ea539c8eed7b26a28ec1f34cd5f78c33e521c"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 13270,
+     "sha256": "14d74e6c01df6db6f92b8684527b31a7544de8d4dd9d123ebae554989e76facc"
+    },
+    "sound/misc/torchoff.wav": {
+     "bytes": 54160,
+     "sha256": "d49cf5f2100d9b5afbf76a662019a9e3a66fcd5fb40c2b2600ceab107227cbf3"
+    },
+    "sound/misc/torchon1.wav": {
+     "bytes": 88680,
+     "sha256": "ecb211c777393fe3c7012bf0a35cc157af94ccb4742cac3ca7ab6daa5546a4ac"
+    },
+    "sound/misc/torchon2.wav": {
+     "bytes": 84764,
+     "sha256": "b7d885df1c70b226a77a3cc8842565fa9ebf51561158daec4b12e9629a515986"
+    },
+    "sound/misc/torchon3.wav": {
+     "bytes": 97484,
+     "sha256": "25058a3354df07a90b8660640682f7091fa40da6f8abf178c7de71d547a8b0c1"
+    },
+    "sound/nour/attack1.wav": {
+     "bytes": 50794,
+     "sha256": "7f22a1569d59bcd406efd7828ed605d71bfbc8cea01606eedb78d33037655f77"
+    },
+    "sound/nour/attack2.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/nour/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/nour/death.wav": {
+     "bytes": 39772,
+     "sha256": "2e2d15b95fc35738108d83a2b5aefded93772134d2a8124d1b937b6bfcfd74c5"
+    },
+    "sound/nour/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/nour/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/nour/explode2.wav": {
+     "bytes": 22168,
+     "sha256": "654a50eb01d1c6c64bb8df4b85669448cc08b580ffc44616da854bd3cb339ea1"
+    },
+    "sound/nour/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/nour/idle1.wav": {
+     "bytes": 24332,
+     "sha256": "c77ef8ce85720e3bf0ea97937992b5aa7cc6b63149c951e71b4d3ead14fc21af"
+    },
+    "sound/nour/idle2.wav": {
+     "bytes": 44176,
+     "sha256": "e87bd537a35c005b06ffd28f66adde24d52af338d3956d4fab455d682e78eec9"
+    },
+    "sound/nour/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/nour/pain.wav": {
+     "bytes": 8686,
+     "sha256": "073044c582c2de6f336130aeb9503fa6edf1da4eed216a4b407b2cd18d5f9995"
+    },
+    "sound/nour/projbomb_burn.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/nour/reveal.wav": {
+     "bytes": 39780,
+     "sha256": "6dd892d207fa31eb93c5a033ab44bba4952b3aed892aa409e6a49e2059381cdb"
+    },
+    "sound/nour/sight.wav": {
+     "bytes": 48612,
+     "sha256": "252c0bf76b928f7fe998f82bf148816e88cdc24f812bd8c8d3a591c1c4ec3d7d"
+    },
+    "sound/nour/sight2.wav": {
+     "bytes": 48612,
+     "sha256": "18b8e9450c00d6a9308adffa2046e747b8ed7bb5547f868ed146cca75b260b87"
+    },
+    "sound/ogre/ham_hit.wav": {
+     "bytes": 52014,
+     "sha256": "20f7ec214fdf8a342ac8c3be7d3ed04c7b7b3479f9c74138a8a052ba7674ee46"
+    },
+    "sound/ogre/ham_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/ogre/ham_wave.wav": {
+     "bytes": 132316,
+     "sha256": "d957285dc74a4e067f600465112ed41d69d14554f8e87ad6b0372b9ca8af4b25"
+    },
+    "sound/ogre/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/ogre/ogidle.wav": {
+     "bytes": 25706,
+     "sha256": "54915681452970c56f1ef405b182e90fa7ee3c4d4d80e32583a38abc7c1db713"
+    },
+    "sound/ogre/ogidle2.wav": {
+     "bytes": 22426,
+     "sha256": "2ed241e576a709285f7ea8a9671f6032da5a8db96e094e9007f60617cad491fa"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 28742,
+     "sha256": "738af1bbf36d5b3287c45e7815d87ea7f5c1a0487c804de7272091fdbb7faac2"
+    },
+    "sound/ogre/ogpull.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/ogre/ogrefish_flappy.wav": {
+     "bytes": 51262,
+     "sha256": "79a9eafef5edf45851a1c391e301c6f515536922c297b904e148b337e7f54a08"
+    },
+    "sound/ogre/ogrefish_idle.wav": {
+     "bytes": 27552,
+     "sha256": "5abf50694e67aa1e805a598a464d5d3b1f0625677a2873761cae139c4b21d524"
+    },
+    "sound/ogre/ogrefish_in.wav": {
+     "bytes": 6678,
+     "sha256": "dd5fc9aecb5b6933252739047aa5d3f775797ad7bf6ddb5652ffd26ea9ead3e2"
+    },
+    "sound/ogre/ogrefish_out.wav": {
+     "bytes": 15502,
+     "sha256": "2610f025057ee0a6682b574567b7400f83ba9f6665b9f7f3b9e76cff75b8be53"
+    },
+    "sound/player/h2ojump.wav": {
+     "bytes": 22126,
+     "sha256": "dd2d3629970814e719be6c9650a497edd219f31fb1554927b9770a1b0dfcdc60"
+    },
+    "sound/player/heartbeat.wav": {
+     "bytes": 70640,
+     "sha256": "a68fd895a3212f967a4686e94df2749fa3f58392ab2228aa880697e25b548147"
+    },
+    "sound/player/inh2o.wav": {
+     "bytes": 22126,
+     "sha256": "4c4d55502ab63ddbc9beb64b0459ad4d7a2992fe41e76144d3bbd3333af4a570"
+    },
+    "sound/player/ladmetal1.wav": {
+     "bytes": 95952,
+     "sha256": "6cd990509a965ff251ffb33ff7c22b6eb708cec5f7b7b82e2196b1fb3d3cb1c2"
+    },
+    "sound/player/ladmetal2.wav": {
+     "bytes": 96116,
+     "sha256": "a477162fc355efc88568b9e18d668b7b0e8e99af460b88c755bd1ed57da35006"
+    },
+    "sound/player/ladmetal3.wav": {
+     "bytes": 96008,
+     "sha256": "20ea0c70bcc3c951bb067cb65b938c63267bba0a1eda3a335df525dc9432d234"
+    },
+    "sound/player/ladmetal4.wav": {
+     "bytes": 96126,
+     "sha256": "d2a6bede3a9c499d01a0b0b9620d4bd1935f9477ecb9c59a8d73f3133699ea45"
+    },
+    "sound/player/ladrope1.wav": {
+     "bytes": 70706,
+     "sha256": "6713acc390790d4723df21b0702796958132af34ce5ec0a85fca5edc36ccd728"
+    },
+    "sound/player/ladrope2.wav": {
+     "bytes": 70792,
+     "sha256": "384b8c3ad3749fa9963ff3210d7cb312858771cca85082b6a8ad13179ad92da3"
+    },
+    "sound/player/ladrope3.wav": {
+     "bytes": 70760,
+     "sha256": "ed397a0308ecacd0ba9774f082aec5e681bcffb219c8d9127b7d7606a6fbb02d"
+    },
+    "sound/player/ladrope4.wav": {
+     "bytes": 70758,
+     "sha256": "e1a4327f1c458f408abd6ff713d11e0aee8daaa9c876002b693135d8e64b68fe"
+    },
+    "sound/player/ladwood1.wav": {
+     "bytes": 48084,
+     "sha256": "bd68f3af0f6cd429d08aa44168e14435ed9e2e2ec0d6a038f83e2dd683cb7e74"
+    },
+    "sound/player/ladwood2.wav": {
+     "bytes": 48086,
+     "sha256": "bb687ec2183f460ac4240acfcd2f3da2f8bd9da043ba705f6e32c3439e4845b9"
+    },
+    "sound/player/ladwood3.wav": {
+     "bytes": 48088,
+     "sha256": "7271136b6398602c7b4bdbd610a37b5a82a66195842030a21de08a89808b4026"
+    },
+    "sound/player/ladwood4.wav": {
+     "bytes": 48086,
+     "sha256": "3b7580b31dee8a86e636c5fd17d92566d147417f98764d51097ad53ff0d19d29"
+    },
+    "sound/pushable/brick_m1.wav": {
+     "bytes": 44144,
+     "sha256": "7572ac5d03045552dfee673293722da8c663d072cc7b57e44adb2e3884ea33c9"
+    },
+    "sound/pushable/brick_m2.wav": {
+     "bytes": 44144,
+     "sha256": "209e22e4693184c7b0c022e650b156e255cfa76b18c1066fe20255e285b4e80b"
+    },
+    "sound/pushable/brick_m3.wav": {
+     "bytes": 44144,
+     "sha256": "edafb8bf0915badb97edd078aa129c10a29e8fc428f4e9143f5926f9aa336e43"
+    },
+    "sound/pushable/glass_m1.wav": {
+     "bytes": 48044,
+     "sha256": "66a5944b16e3fe59cf9f8632f92bd85f81b79dc8711337558c45078c91a13c46"
+    },
+    "sound/pushable/glass_m2.wav": {
+     "bytes": 48044,
+     "sha256": "d462bac59390f89facc7c00d8aaee6e71b529ae9f177514a5f2f0533c78d5a0e"
+    },
+    "sound/pushable/glass_m3.wav": {
+     "bytes": 48044,
+     "sha256": "1a2efd7875486d15df811135d589135c807ba0149c877085f165932eb2770320"
+    },
+    "sound/pushable/metal_m1.wav": {
+     "bytes": 44144,
+     "sha256": "91420caf0e2de995681ac09b2be26cc9d0759edc06498571527528419de407d1"
+    },
+    "sound/pushable/metal_m2.wav": {
+     "bytes": 44144,
+     "sha256": "72f018c79b343538fd90de944ed54e8e3351b3da0a6c198f28403d25fc8fb140"
+    },
+    "sound/pushable/metal_m3.wav": {
+     "bytes": 44144,
+     "sha256": "c26b3aff129d573a1175fb618186db3b7ede8976e134c563c1678f48eaf8e302"
+    },
+    "sound/pushable/rock_m1.wav": {
+     "bytes": 48044,
+     "sha256": "9fb6ebeae45b4c47b1e42af1f00441d0e0bb88fbb53f85ea875341f9db55efb4"
+    },
+    "sound/pushable/rock_m2.wav": {
+     "bytes": 48044,
+     "sha256": "b57d0f760bb318b1159293e38811e5607bae8ff244d8bbf56223b355ef7c5b39"
+    },
+    "sound/pushable/rock_m3.wav": {
+     "bytes": 48044,
+     "sha256": "5e6514c241bb11d6194d9762d5369fb2a8da287b3d4c08e67f23da84fdb26b04"
+    },
+    "sound/pushable/wood_m1.wav": {
+     "bytes": 48044,
+     "sha256": "e672209779ee47996ca93e60d30e572da3cced5381db3f34c14a709629a5f4d2"
+    },
+    "sound/pushable/wood_m2.wav": {
+     "bytes": 48044,
+     "sha256": "c76b7db5faf1cbf21c07dacec615436a95f34c0e16e68628b62ec89a89b12f83"
+    },
+    "sound/pushable/wood_m3.wav": {
+     "bytes": 48044,
+     "sha256": "d6751d9e67c49458df6c076d9b6be9619f845213a263cb76330f51700f8a632c"
+    },
+    "sound/scorpion/clawattack1.wav": {
+     "bytes": 13360,
+     "sha256": "b0daf0605690db89f34a19936f1c20ad25676a4e6cd9dfad0e5757cf81dc4f7d"
+    },
+    "sound/scorpion/clawattack2.wav": {
+     "bytes": 13360,
+     "sha256": "06da85e6d6035704932fdc1ef449de529e17853571d017c5a42b253b5ed71a94"
+    },
+    "sound/scorpion/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/scorpion/hiss.wav": {
+     "bytes": 26664,
+     "sha256": "9d9fae97f3996ff3c0616f7acda952166d5eced9227d15a8fbe9d285095e7936"
+    },
+    "sound/scorpion/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/scorpion/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/scorpion/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/scorpion/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/scorpion/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/scorpion/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/scorpion/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/scorpion/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/scorpion/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/scorpion/tailattack1.wav": {
+     "bytes": 25858,
+     "sha256": "61e6c65b4c68813925e594b96ebad8a945c87d51f2cd23f301e80e231e53033d"
+    },
+    "sound/scorpion/tailattack2.wav": {
+     "bytes": 19650,
+     "sha256": "aab86f97eed636ebfb79ae7b92e4b7f7a3436b0146ad75519edd4358716169c7"
+    },
+    "sound/scorpion/tailfire1.wav": {
+     "bytes": 8924,
+     "sha256": "1f41bd184aa58b9f2f1b2f1197f3b7827c55d523d03a354dd1fb6d469cf129c8"
+    },
+    "sound/scorpion/tailfire2.wav": {
+     "bytes": 8948,
+     "sha256": "40a126ab5cba6c291d69606eddb7e2ab63ab640b1347b2e78ab4b0f7aca90c5c"
+    },
+    "sound/scorpion/warning1.wav": {
+     "bytes": 76930,
+     "sha256": "ae19faeebc0d3ec8c9f136bba205e634a29425ec86c3036016e5f2d9cd550817"
+    },
+    "sound/scorpion/warning2.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/seeker/death1.wav": {
+     "bytes": 397272,
+     "sha256": "35d8a1091032f24ed6a65efa99a7618f32bc0def24779efb51752b75a9e31ca1"
+    },
+    "sound/seeker/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/seeker/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/seeker/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/seeker/footstep1.wav": {
+     "bytes": 96092,
+     "sha256": "e5cd4f907a1b70ec72048b2dd5a5062022e7058676c3d90d05b7426e189a5073"
+    },
+    "sound/seeker/footstep2.wav": {
+     "bytes": 96076,
+     "sha256": "f3c8ba8d65257ddfa73e3e54c737c49de5dcc5c17bb088feb3511c3d69d21ac4"
+    },
+    "sound/seeker/footstep3.wav": {
+     "bytes": 96092,
+     "sha256": "c6fa111be092592a253815826c499b9b1f18a0c536910e2a82eebec7fb7f817d"
+    },
+    "sound/seeker/idle1.wav": {
+     "bytes": 141126,
+     "sha256": "10693a1d5fc1d710e54a0d57ce10d71400de192b874d6776ffe176c2b399a6b5"
+    },
+    "sound/seeker/idle2.wav": {
+     "bytes": 97420,
+     "sha256": "c24b439701d9ec3cf055702f23a3eb23623320ae89b9d46ab98a791f08898573"
+    },
+    "sound/seeker/melee1.wav": {
+     "bytes": 106252,
+     "sha256": "addfb5fab225a77f08d5c126b13f929fa31aa1c9094fc79202121ca891933fb9"
+    },
+    "sound/seeker/pain1.wav": {
+     "bytes": 19884,
+     "sha256": "ccaca64b8c1ab87d7d70896333cbec22c3b61c443a36cd8f253ad0eafc2d7ae1"
+    },
+    "sound/seeker/pain2.wav": {
+     "bytes": 19884,
+     "sha256": "8c3be23111a5ef53a7b66c7b74e32404ff0e6989d7de835543e0a65645e3f793"
+    },
+    "sound/seeker/punch1.wav": {
+     "bytes": 19940,
+     "sha256": "e4bf6b7deb14b5d614b4d5b7d4eeee36059372c913cc906589e1048d4484259d"
+    },
+    "sound/seeker/range_laser.wav": {
+     "bytes": 88246,
+     "sha256": "ee9f13af042a2a98fb75fa33873a1e861f3418f598ddb390f15ab44fcf93fcbf"
+    },
+    "sound/seeker/range_plasma.wav": {
+     "bytes": 79782,
+     "sha256": "9b1d38a4e1937023536d5ab5de035c97e1ef69131d58822b194cab2a3aa340b3"
+    },
+    "sound/seeker/range_rocket.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/seeker/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/seeker/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/seeker/sight1.wav": {
+     "bytes": 163526,
+     "sha256": "ca06541f54bcc297ab19ee133de5c782e978cf7afc2fab34b3789c4c56044d30"
+    },
+    "sound/sentinel/laser.wav": {
+     "bytes": 9712,
+     "sha256": "c5f90e1823a04b48f7f24ac5b8792e1b42030a8b07970db5847dc1e74be094c2"
+    },
+    "sound/sentinel/nail.wav": {
+     "bytes": 13750,
+     "sha256": "7acc3ac05b7218abc6fef2d2397771d90fce6fa39415e33824be7e771d30e288"
+    },
+    "sound/sentinel/widle1.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/widle2.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/wpain.wav": {
+     "bytes": 19596,
+     "sha256": "bc7b6536a1c67aa89295eeacea2d9b36cb0bf783b5fb7cc6aaf4fa01a0edb3fd"
+    },
+    "sound/sentinel/wsight.wav": {
+     "bytes": 27322,
+     "sha256": "83bca2103d60c68435e27f0660e3ecd5bffb058e796382e7bdb43efabdfb9889"
+    },
+    "sound/shalrath/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/shalrath/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/attack1.wav": {
+     "bytes": 44184,
+     "sha256": "91f50e3b69909213e23149b6a3e9622c4367d77f871da5f01e6e4aea3badf648"
+    },
+    "sound/shub/attack2.wav": {
+     "bytes": 33174,
+     "sha256": "d4928f711f7e8fc1d8ba050a87b4e1c2d48ffc24af6a454637629dfae8902e3f"
+    },
+    "sound/shub/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/death1.wav": {
+     "bytes": 107440,
+     "sha256": "1551554be1b7896ee39156ce258bf68ac5dace891994788020ee95083ae33e77"
+    },
+    "sound/shub/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/shub/idle1.wav": {
+     "bytes": 75072,
+     "sha256": "9d33c61470d0c4269c8d113b4476b84236fa00e6ee3be061865e242c988093af"
+    },
+    "sound/shub/idle2.wav": {
+     "bytes": 75000,
+     "sha256": "21b063438744def5f79a50709c567cc9f3e3a28c39e58456068a3d4ae362617f"
+    },
+    "sound/shub/idle3.wav": {
+     "bytes": 75096,
+     "sha256": "310c4ff969da63c77e7ebb5b319aca0f17a10802ee942b21174349d5e5a79d72"
+    },
+    "sound/shub/pain1.wav": {
+     "bytes": 83880,
+     "sha256": "1d1536a51822b67106ea72bcb537efbf5f69e4a4592904f6feedee06ef5084df"
+    },
+    "sound/shub/pain2.wav": {
+     "bytes": 83886,
+     "sha256": "71c30d3f41e0f99cffcf5037b482c1da7bf028b477051219f6e605ceef28ae38"
+    },
+    "sound/shub/sight0.wav": {
+     "bytes": 83880,
+     "sha256": "6d4d96fc663db248cf9279c0b028c11b451b133c6e2c38364c13e105f8fa377f"
+    },
+    "sound/shub/sight1.wav": {
+     "bytes": 83880,
+     "sha256": "ecaf1595f3acbfe2e771a193c69bd6de5e6e3bd957405fdf4bcf59a2288bdb05"
+    },
+    "sound/skullwiz/attack.wav": {
+     "bytes": 15484,
+     "sha256": "ca662d909cb3b96bdfb93197092ed8e8a5d1ed27772a91a4a6ae5e9d3063017a"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 33166,
+     "sha256": "5d1ccd5b97bd38eaf46d1e0798009765d46d58ba17e7e6efc36350b0adaa22f7"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 33178,
+     "sha256": "dd77e90760bd85fc872a96c2eaa808b094a461ab2871bd8ab6a5372861560512"
+    },
+    "sound/skullwiz/blinkspk1.wav": {
+     "bytes": 44200,
+     "sha256": "ade109f32810094922f77bc3c03f02d33e98d855d3dcaf79ceab4cb200efaa65"
+    },
+    "sound/skullwiz/blinkspk2.wav": {
+     "bytes": 44204,
+     "sha256": "16d3b1296e1ed9c3bdc06dd25f5d9db3569cf3486794d29858d5ad227741dd1a"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 33166,
+     "sha256": "bc83800a91fad273e7f84f3cec2fa2787c902f4cd97fd5495f73dc9fb6d2c368"
+    },
+    "sound/skullwiz/fadeaway.wav": {
+     "bytes": 43092,
+     "sha256": "dd67d3ffe5a592b4e449d6bb00eee3c525ede786b0a2d9089832981311bfd61e"
+    },
+    "sound/skullwiz/idle1.wav": {
+     "bytes": 88252,
+     "sha256": "1834b946ff68aab07ade01b68d95d822d0b2a1baa51c1ceba7e66c73b8b6211e"
+    },
+    "sound/skullwiz/idle2.wav": {
+     "bytes": 88240,
+     "sha256": "57c49c7fd4f52b870a658e2e854e16c67389e9d79f9a1db5928f12d74741a1da"
+    },
+    "sound/skullwiz/pain1.wav": {
+     "bytes": 11132,
+     "sha256": "125e06cdfacd6aa78a90034d3f94086736734dd1dd9d170fef3a512b42e34cd0"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 15540,
+     "sha256": "ac5a56dbff28fa4724bd8766d8443090e3026007f6f4051cfecd2869b3f5ecb9"
+    },
+    "sound/skullwiz/poison_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/skullwiz/sight.wav": {
+     "bytes": 36484,
+     "sha256": "3051df89bfdce6b80c49c3513cfcbd679bf1f71c5562430d7738737e44f04f26"
+    },
+    "sound/skullwiz/skull1.wav": {
+     "bytes": 22144,
+     "sha256": "3a43bc5e1079740b61199ff21518f75cc1e4db7cdc9e25b57631b38b04d651a2"
+    },
+    "sound/skullwiz/skull2.wav": {
+     "bytes": 22158,
+     "sha256": "fed613207dc7691118ea5b62626df8773bda59816b008bfd2aeaa4d2f26a4b7b"
+    },
+    "sound/skullwiz/summon.wav": {
+     "bytes": 97022,
+     "sha256": "bf74e3dfbb330f481790f7bbc2b88e74b1654f7d5b327235c3d00bee3f62a06a"
+    },
+    "sound/soldier/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/soldier/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/soldier/rocket_load.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/spider/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/spider/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/spider/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/hiss1.wav": {
+     "bytes": 17802,
+     "sha256": "c56fcae8a01af94c07807730857b4b367f2c70c35869505528504faa29a17ade"
+    },
+    "sound/spider/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/spider/hiss3.wav": {
+     "bytes": 22582,
+     "sha256": "1a3c71b1e4ac2389c98c4af9db88e81b51a602c681bd00a1812995654863e2d4"
+    },
+    "sound/spider/idle1.wav": {
+     "bytes": 20922,
+     "sha256": "8a6d25359bbbc1f5e4f6962f4ce1742160537c6bb8bf8b806a0df96adfae819d"
+    },
+    "sound/spider/jumpland.wav": {
+     "bytes": 6038,
+     "sha256": "3c46bc58c52a61480c1a8dc2034aa240545521baf5e0027372992a9458796919"
+    },
+    "sound/spider/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/spider/pain1.wav": {
+     "bytes": 6108,
+     "sha256": "728cd94a64b27dea4d845a9e27e1ba09cfb286bff80128a67d1da0431b6b0c20"
+    },
+    "sound/spider/pain2.wav": {
+     "bytes": 10460,
+     "sha256": "736f0a768c0f52b22a301fc6a15f18f2f60e5579d3b27c2b78bcb7bed8e0c577"
+    },
+    "sound/statue/comidle.wav": {
+     "bytes": 17722,
+     "sha256": "3567914304c8fcf224e31bc302039432cd17833daabc2ed9f83053b01fef4f7c"
+    },
+    "sound/statue/death.wav": {
+     "bytes": 13472,
+     "sha256": "b030aeac3d806bc77fddaed4bb32684cfd2bbd707fe85e2500a3346c5931ec68"
+    },
+    "sound/statue/hurt.wav": {
+     "bytes": 8012,
+     "sha256": "9193f4e976675042409db103f7e3b26f667a56e913e96a37f223f1c606323246"
+    },
+    "sound/statue/idle1.wav": {
+     "bytes": 13304,
+     "sha256": "0b5d3bcbd00e846d38986f8919ff4fa7bcce92e45e5ba5949edd0e81b741b69c"
+    },
+    "sound/statue/idle2.wav": {
+     "bytes": 13316,
+     "sha256": "45469f14a25fd434ba1ed987fd20835ac058496d41df5a6aa543dec454670f36"
+    },
+    "sound/statue/sight.wav": {
+     "bytes": 9584,
+     "sha256": "84ab06d320f9953eebda7c4dd25a0e0de3369957de01c64af10a8b3ca886241e"
+    },
+    "sound/steelclaw/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/steelclaw/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/steelclaw/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/steelclaw/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/steelclaw/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/steelclaw/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/steelclaw/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/steelclaw/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/steelclaw/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/steelclaw/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/steelclaw/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/steelclaw/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/steps/drag1.wav": {
+     "bytes": 13586,
+     "sha256": "db069e08b7de4c5074cc4dd56f3b1cd2b6d77fe7869e1e03f5dddddcf9aad530"
+    },
+    "sound/steps/drag2.wav": {
+     "bytes": 13572,
+     "sha256": "b2ac07fe014e7c5afd4a5974c5d290b34a880a52f33668030a97a345d5811db9"
+    },
+    "sound/steps/drag3.wav": {
+     "bytes": 14690,
+     "sha256": "a29ee6f0977b205d146f81ee5be2f9b2f12ca76f177aaab9e35e556c4f555fa9"
+    },
+    "sound/steps/drag4.wav": {
+     "bytes": 13584,
+     "sha256": "1b5628a4272837ccf9c4044371a1d45eef23439b164be445b6f2ca90952e3487"
+    },
+    "sound/steps/drag5.wav": {
+     "bytes": 13584,
+     "sha256": "6dec9033ece2a02ce65c437e1b7e58512fd04d41a327487704de71cdf39b99dd"
+    },
+    "sound/steps/giant1.wav": {
+     "bytes": 33140,
+     "sha256": "d28f78c1514f215c64b6a3de38b5ffb5b891341ed95dc0277b1b3dba498cc64a"
+    },
+    "sound/steps/giant2.wav": {
+     "bytes": 33138,
+     "sha256": "7936f32a0ae371e216a195c3110b24db372a15091ea5c80e78875951f874d3b0"
+    },
+    "sound/steps/giant3.wav": {
+     "bytes": 33126,
+     "sha256": "58f79749cbdaaa608e6aacc368b74e0ac1e2ecf2ef45967c7f1f7b7a3e99c8fd"
+    },
+    "sound/steps/giant4.wav": {
+     "bytes": 33136,
+     "sha256": "4ffa741a70225aa31078f73a5612cf7d5ad9f9007163f0a5aeda749da099f9bd"
+    },
+    "sound/steps/giant5.wav": {
+     "bytes": 33138,
+     "sha256": "a2706d4dd9856cccdc3980156a77702883e36d86df54221b31a781c8e5e767e3"
+    },
+    "sound/steps/heavy1.wav": {
+     "bytes": 13282,
+     "sha256": "603679f83cc5095d2fa81d945285b2980195ba50ee2615fed85487493f0a536d"
+    },
+    "sound/steps/heavy2.wav": {
+     "bytes": 10870,
+     "sha256": "384f160ad4816b6984ef6b3b59c4bc1e8a2a3e05f9aaa80ee8b30ada2645669f"
+    },
+    "sound/steps/heavy3.wav": {
+     "bytes": 12828,
+     "sha256": "936417bc5ec9d30db8a74a9798328436259ffd704b11e1155d3fa79dc829e462"
+    },
+    "sound/steps/heavy4.wav": {
+     "bytes": 11050,
+     "sha256": "8d4879d40eda9182ff45fb18130c7979997d326581c14edeedc9cab440531e00"
+    },
+    "sound/steps/heavy5.wav": {
+     "bytes": 10198,
+     "sha256": "4e2e9892dee74d3472a45ecda889ae8d2f836786b44a55e5d1436690c7dadd5e"
+    },
+    "sound/steps/large1.wav": {
+     "bytes": 33118,
+     "sha256": "c387d084a10b28329610d8e3ad3e377f43087013e802be42af79f254276d00dd"
+    },
+    "sound/steps/large2.wav": {
+     "bytes": 24960,
+     "sha256": "ab91b4605671dd16da59963959cda3368a065612d8ed1776847da310b1e7b5fd"
+    },
+    "sound/steps/large3.wav": {
+     "bytes": 24280,
+     "sha256": "3e6a5ef0d8cbaba2e976f199d8d1ffa073fe8e83dacee709137335d42ddd7558"
+    },
+    "sound/steps/large4.wav": {
+     "bytes": 22092,
+     "sha256": "f2bde1b715f679cf814c2cd1375442170cf9f6e56d8ea1756900f81f1d1df453"
+    },
+    "sound/steps/large5.wav": {
+     "bytes": 24320,
+     "sha256": "c15b388bbed461461bac2c22b3a88ff272c04ad070e4791b7ce35c1559d16f77"
+    },
+    "sound/steps/light1.wav": {
+     "bytes": 8872,
+     "sha256": "f034fe2692c0fceb6de1c00e15facbcbd31ccd1fcf72510fd1e3cb6bdcc28795"
+    },
+    "sound/steps/light2.wav": {
+     "bytes": 6654,
+     "sha256": "998f665b4a7ccbc995096697606a91d208db024b0882df75ebaaac015f0d4ef6"
+    },
+    "sound/steps/light3.wav": {
+     "bytes": 6670,
+     "sha256": "b25e020a10ac6a7883fd584cff4895d6d785f8577daea15a30d2b745e146c1c6"
+    },
+    "sound/steps/light4.wav": {
+     "bytes": 4472,
+     "sha256": "a111052881024eef6e97393c1388e8ae538227b85c9b8cf0a73704abb2a504b1"
+    },
+    "sound/steps/light5.wav": {
+     "bytes": 3588,
+     "sha256": "55fb54e5ba2f8ec6249761ae6f07c12de6133457b51c584759e8841fb14cb46f"
+    },
+    "sound/steps/medium1.wav": {
+     "bytes": 8872,
+     "sha256": "38e731803a49be7d8018dd7b44060b578b5418f2f7aefb04d1c74c968ced187a"
+    },
+    "sound/steps/medium2.wav": {
+     "bytes": 8852,
+     "sha256": "e8701598e07f43a20aebebd1d1a5043213018199d50472dea37672e6dce4a2b3"
+    },
+    "sound/steps/medium3.wav": {
+     "bytes": 11068,
+     "sha256": "3ed07795c2363552554e6da1da5749be08e460fc6cd4c7266b9fa514732abb2f"
+    },
+    "sound/steps/medium4.wav": {
+     "bytes": 8872,
+     "sha256": "008992cd7972e7e1e6f0b785b40e398a8efe744a3f3f57e47370936796c3d6b5"
+    },
+    "sound/steps/medium5.wav": {
+     "bytes": 8864,
+     "sha256": "ccd26430fd354c0e87750e02d92c40071ef9dccadae5bdeebc7e0d2a2ec4eba7"
+    },
+    "sound/steps/slow1.wav": {
+     "bytes": 8878,
+     "sha256": "15614044d9d277fa3359edb07e7af74b9d7875150fddde5ab1fdceb0143337bb"
+    },
+    "sound/steps/slow2.wav": {
+     "bytes": 8856,
+     "sha256": "a8b16b688d12812a61127a885bf43c360adc2b84ae7806cc107b433c6f4635ee"
+    },
+    "sound/steps/slow3.wav": {
+     "bytes": 8852,
+     "sha256": "3a2a57e1a37d378c1ee73d5732840f6d20e588d794216c33896bf25879807600"
+    },
+    "sound/steps/slow4.wav": {
+     "bytes": 8868,
+     "sha256": "78bdea66991184043001262cc6ef5f1148cf0eb11b5f88fc51ff948311156e5f"
+    },
+    "sound/steps/slow5.wav": {
+     "bytes": 11076,
+     "sha256": "f63c868bd87926f017bec092749bd61c763b0b18635456ed56b660e53bf581af"
+    },
+    "sound/steps/water1.wav": {
+     "bytes": 63814,
+     "sha256": "01ed631b0d92dab11086b1106acc278ffd92522e2e46d21a0650fd29a79780f2"
+    },
+    "sound/steps/water2.wav": {
+     "bytes": 71994,
+     "sha256": "1b53561f02f60da1e1b6c8b72f722ba12e549c318725b974745b38666efa8e56"
+    },
+    "sound/steps/water3.wav": {
+     "bytes": 71802,
+     "sha256": "bbc0778017ccb579a9d531316b8af46585e91a100a251707ac34f4dbddf6922d"
+    },
+    "sound/steps/water4.wav": {
+     "bytes": 61448,
+     "sha256": "d3604afcb7751d987a78a0ee8ee4ca3593315cc6cf2f1909a9f7748535ccea50"
+    },
+    "sound/swampling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/swampling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/swampling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/swampling/idle1.wav": {
+     "bytes": 132044,
+     "sha256": "418eae21e001c1ae065df9357ebf2ad331f761062d75f345f12e99d9aec8cfb5"
+    },
+    "sound/swampling/idle2.wav": {
+     "bytes": 70444,
+     "sha256": "4026b4b56ffa9a207e1457e03ec94a8eb9042cfebf1c042fa291ba2bbbf1c4b5"
+    },
+    "sound/swampling/idle3.wav": {
+     "bytes": 171644,
+     "sha256": "fa54eaf040baf965f994b328bfb1a55cd90d1741d57ed580c1d44c51e9c125f8"
+    },
+    "sound/swampling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/swampling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/swampling/pain3.wav": {
+     "bytes": 67244,
+     "sha256": "4b186834bbec7d2ef9873f55d5df980da3b3fd2f19f76e54fd835d1aaf40fedd"
+    },
+    "sound/swampling/sight2.wav": {
+     "bytes": 88044,
+     "sha256": "6989ba3aca0c5f5e12d30d9958c6ab169f5c6c96f36f4843a9a19bab0e5d0c4c"
+    },
+    "sound/swampling/spit4.wav": {
+     "bytes": 76848,
+     "sha256": "6855555e2a188ed9ae0a1cd307c7715e54c6f3c10ac0fee9edbba2edf1a48d16"
+    },
+    "sound/traps/flame_loop.wav": {
+     "bytes": 28560,
+     "sha256": "661d8325af92fb37235952e2668578dbf57d844b7359627b4a2c25d15127bff7"
+    },
+    "sound/traps/flame_off.wav": {
+     "bytes": 28496,
+     "sha256": "ebc40d62265aad20813acd189511be0bac063ecc00d7ae712863de3dbdb84c94"
+    },
+    "sound/traps/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/traps/laser_hit.wav": {
+     "bytes": 4358,
+     "sha256": "0840d9fa27bfd2bcb86c2f0174810ae3eb9baa6a43867d27de1e074f7cd75e2c"
+    },
+    "sound/traps/pend_hit.wav": {
+     "bytes": 11908,
+     "sha256": "6fec8fd4edb67e8905d9ad0d7dce5ee5a9b4f43b724b75cb449e88b508384e11"
+    },
+    "sound/traps/pend_swing.wav": {
+     "bytes": 22142,
+     "sha256": "d20bbaf323c5aa0ee2aa21222f2a9f5fc956c0317e65c05e9d003bb08d80a9ae"
+    },
+    "sound/traps/saw_end2.wav": {
+     "bytes": 99808,
+     "sha256": "2a129f2d5fe3c9fd60873c336e2eed799b3d2ebc91bc8bf5a0860b45a6b83ceb"
+    },
+    "sound/traps/saw_loop2.wav": {
+     "bytes": 173082,
+     "sha256": "b4ca1bfeaab62c73bfc10f7daa2750738874d721af9e637479e8242f5220294c"
+    },
+    "sound/traps/saw_loop2f.wav": {
+     "bytes": 132748,
+     "sha256": "03a3e77feb8775a7b486363ed1d46d04fb9294f5507040e458ed8a05c37f0de8"
+    },
+    "sound/traps/saw_start2.wav": {
+     "bytes": 217184,
+     "sha256": "49f1dd84a7be0c4d0b1293aa587ab786d69f4cb463ce5a03f09da816eb22d384"
+    },
+    "sound/traps/sawblade_off.wav": {
+     "bytes": 15276,
+     "sha256": "44924313561cf32ea95c50ef80366ba79a2c86ff2f218fc89404c82617ce2c84"
+    },
+    "sound/traps/sawblade_on.wav": {
+     "bytes": 37582,
+     "sha256": "097635d29859ce28ea37da2d51ec346b8d5239435bb6be0bf5f094a555c110e8"
+    },
+    "sound/traps/sawstrike1.wav": {
+     "bytes": 30836,
+     "sha256": "489d8cdea78b2c333771b316741d7960d5c0da6845ea15b94991ece94837367a"
+    },
+    "sound/traps/steam_loop.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/traps/steam_off.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/voreling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/voreling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/voreling/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28354,
+     "sha256": "8c9ef55e309a43b1df1f08b66192b4ab262ba07e9315d3a70f4a9cf9dee9d51a"
+    },
+    "sound/voreling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/voreling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "5035bd555e9a6439c87e6b661a2da86633f7234503d52551e68f61e9504af86d"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 44162,
+     "sha256": "ccca790ed18e3705c083259f48db7d46d26310cf80c16cd2bad191d333fec5ba"
+    },
+    "sound/weapons/axe_ceramic.wav": {
+     "bytes": 24620,
+     "sha256": "53b6e873318f84424129f1486f0a715c9b1f46e9521c97858d3ddbd94ef4dc10"
+    },
+    "sound/weapons/axe_flesh.wav": {
+     "bytes": 7754,
+     "sha256": "8d0046355ea843f56d5260f581c89d2f885b553c97cfc7e01a93f6da487e03de"
+    },
+    "sound/weapons/axe_glass.wav": {
+     "bytes": 13306,
+     "sha256": "7fd4f7f02edf972c17cf64fea9ecfecca2e0a2d69da9828c1a1e2ce726dd9a79"
+    },
+    "sound/weapons/axe_metal.wav": {
+     "bytes": 28844,
+     "sha256": "d77bc0204c9f406f50ddf01241ff3a3cb34bd571f8a038a483fe49fba81fb160"
+    },
+    "sound/weapons/axe_swoosh1.wav": {
+     "bytes": 26524,
+     "sha256": "1ee4079e691b1e3e8eca8e6fe3098ee053f99b2a0028e725442771c84dc07e49"
+    },
+    "sound/weapons/axe_swoosh2.wav": {
+     "bytes": 13284,
+     "sha256": "a28435309759dd35576099d23a36dc378d9703db9f0778fba63efa3558cfc19d"
+    },
+    "sound/weapons/axe_wood.wav": {
+     "bytes": 7776,
+     "sha256": "ce5bd1465d66aa4aad5249c387f7f537b45b4f8a0e4bf76f37f8efc2a22bd9d9"
+    },
+    "sound/weapons/bolt_hit1.wav": {
+     "bytes": 12698,
+     "sha256": "07d2b6078f7936781a641f88e6ed02ab84f248da8f19e73713c1a71ac56cf42c"
+    },
+    "sound/weapons/bolt_hit2.wav": {
+     "bytes": 10658,
+     "sha256": "27ef878b7dfc0878140a19e3a0227ba389e5d0dc2b86df386852e2da2ebc5c93"
+    },
+    "sound/weapons/bolt_hit3.wav": {
+     "bytes": 11600,
+     "sha256": "06298d7bc8d7bce64f9473ae9530e0b42ea3de0ca5895f3476f9b00b5ed566f9"
+    },
+    "sound/weapons/bolt_hit4.wav": {
+     "bytes": 15460,
+     "sha256": "814b1a71efc9b58c90ad7f116c47e6f3dceeb8eae6d0ecbca5f1cd02dd247cb6"
+    },
+    "sound/weapons/crossbow_fire.wav": {
+     "bytes": 26536,
+     "sha256": "2a6ba54090412a53471c59b3edf6e8559d424dab25729e67a78f9ada5e13e8ac"
+    },
+    "sound/weapons/crossbow_hit1.wav": {
+     "bytes": 60782,
+     "sha256": "be1e78c92c13749e988d26912fba6c23f3700df0d7cc48d724f0da1f2608d006"
+    },
+    "sound/weapons/crossbow_hit2.wav": {
+     "bytes": 32472,
+     "sha256": "30a4ef9f23b2239371d32385e55487b279ca4f8f91366d4251cf4d9abdce200a"
+    },
+    "sound/weapons/crossbow_rdy.wav": {
+     "bytes": 37532,
+     "sha256": "321eac310a291cd9cdcbd2dcafb27687a12057e778e12704d8b4388d4eb6e4df"
+    },
+    "sound/weapons/crossbow_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/weapons/ghook_fire.wav": {
+     "bytes": 11526,
+     "sha256": "6e29f4524c0be70d8bf3b1201e737712b271c9bc963ad46c1815972b6addc22e"
+    },
+    "sound/weapons/gl_loadlong.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/weapons/gl_loadshort.wav": {
+     "bytes": 7758,
+     "sha256": "c97236bbfd211dfcad8130974413a8666cdbcf646d364abd8801b3d6ba5bf9c4"
+    },
+    "sound/weapons/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/weapons/laser_hit.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/weapons/laser_richotet.wav": {
+     "bytes": 12888,
+     "sha256": "bcc0498060e71b059d1d6ec45628048b0f29a7a0509b736a519196338b5df20d"
+    },
+    "sound/weapons/nofire.wav": {
+     "bytes": 1400,
+     "sha256": "217c42718548de32b5df972d117ffc1a0e1dde5f03a7a173bd91d0b4551248c9"
+    },
+    "sound/weapons/plasma_expl.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/plasma_fire.wav": {
+     "bytes": 88288,
+     "sha256": "6a0ad4930da39ff590c79f9d26b434bb1001536d33d880735df76e9354f90e94"
+    },
+    "sound/weapons/plasma_hit.wav": {
+     "bytes": 54406,
+     "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b"
+    },
+    "sound/weapons/plasma_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/weapons/r_exp3b.wav": {
+     "bytes": 34830,
+     "sha256": "a1abb7cedfa6576205f043c2e5f562606b039f65f6f996f5ffbb758d7855f2a2"
+    },
+    "sound/weapons/resist_rocket.wav": {
+     "bytes": 19938,
+     "sha256": "1e5170aaf1d6f144e7ea77c251d15ee85c9a70eb1f50b12e4ba5a93971ad1955"
+    },
+    "sound/weapons/ric1.wav": {
+     "bytes": 5650,
+     "sha256": "49223498fbf29b97f712537e6417917befc4e4f5c725bbf2e3d463580c15454d"
+    },
+    "sound/weapons/ric2.wav": {
+     "bytes": 11146,
+     "sha256": "5fa462f4ab3184cf70bf33f923a2b7e4392db517d34f8531a381864d78c352a6"
+    },
+    "sound/weapons/ric3.wav": {
+     "bytes": 11138,
+     "sha256": "1761926b96108fd0b0ee55270ee711fbd2f394f1b5e93da4af96e42c69fa3946"
+    },
+    "sound/weapons/riotgun.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "sound/weapons/sg1.wav": {
+     "bytes": 28718,
+     "sha256": "49074c95da2a619d82dee9d45e28dc910f9a8e16141270a76c81b396a41a6a3e"
+    },
+    "sound/weapons/sg2.wav": {
+     "bytes": 28718,
+     "sha256": "279b1bb969837073c46c176fe62782e60658a6614a8e094b9722cbabdca81fe6"
+    },
+    "sound/weapons/sgun1.wav": {
+     "bytes": 45840,
+     "sha256": "3ac6c4b3ded00fa48810f09afc95b4a8375dc3e8d52e04cd9cba18dfeee20087"
+    },
+    "sound/weapons/shellc.wav": {
+     "bytes": 21006,
+     "sha256": "45a2f8bd652307b9ebd37115c27166d03a4d7055f3054a215036fbc342e22f6d"
+    },
+    "sound/weapons/ssg1.wav": {
+     "bytes": 17244,
+     "sha256": "3e5b9cc1cd0cb86602391e4ddedbc98bb020e44b937eec4d3c5b053ff98c98f2"
+    },
+    "sound/weapons/ssg2.wav": {
+     "bytes": 75024,
+     "sha256": "248a021818f578ec3d96b9fe59d8f839242f4d5f8140a66a500b523b137d1977"
+    },
+    "sound/weapons/sword1a.wav": {
+     "bytes": 11184,
+     "sha256": "22bc8b25a67f1ab0752f9fbc68c2eb0958d2807c9e95bc8ee35d1d1bc9c6552d"
+    },
+    "sound/weapons/sword1b.wav": {
+     "bytes": 13272,
+     "sha256": "dca39f0c4776994c1bbe5255893d50dd86a634a370ea6046fd4e851117dec726"
+    },
+    "sound/weapons/sword2a.wav": {
+     "bytes": 11150,
+     "sha256": "aa381f8c68f5753cecbd889bc184a784c934c78c8fefe3b1ba4026a99112da51"
+    },
+    "sound/weapons/sword2b.wav": {
+     "bytes": 13232,
+     "sha256": "9460973ef948f8712be967d412774d32aeefb8e68b11959c28909eb16d9e8afc"
+    },
+    "sound/weapons/widow1a.wav": {
+     "bytes": 64644,
+     "sha256": "b4ccd6b235784f7ff53ccf0d726ecbbc789d2ddcca057b40df769b7925e3b32d"
+    },
+    "sound/weapons/widow1b.wav": {
+     "bytes": 66186,
+     "sha256": "0da0346e80cdcb405ffb8f9dbe048197cd9d303130f35b2546b4f7652bd06ca6"
+    },
+    "sound/weapons/widow1c.wav": {
+     "bytes": 66186,
+     "sha256": "eb054b4b1b2784bb098e24574ced6b8c2114e3344fc73e9beb23285adfa086a8"
+    },
+    "sound/wraith/attack1.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/wraith/attack1_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/wraith/attack2.wav": {
+     "bytes": 88200,
+     "sha256": "bdf849b4e138fa587df136a327c71ceed1176cbbb4ecb873434766d53da35a3b"
+    },
+    "sound/wraith/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/wraith/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/wraith/death1.wav": {
+     "bytes": 19960,
+     "sha256": "c0e5e05b46e4cf4afebfe5d0ef1801fc16fe8308a7f859ff347a77871b0a9339"
+    },
+    "sound/wraith/idle1.wav": {
+     "bytes": 51556,
+     "sha256": "e91f12463417df25badbbdfe817560362370d9e1e31712766bccb086e06d966f"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 82792,
+     "sha256": "b843d1124acc61be2aae27a7c8a9aca8f6bd471689703b41d59f1450e70e360c"
+    },
+    "sound/wraith/idle3.wav": {
+     "bytes": 55228,
+     "sha256": "3393943b38a0760c2b048c87c6b11ef743b0c968397ae7e434434b8b21fe12f9"
+    },
+    "sound/wraith/pain1.wav": {
+     "bytes": 18184,
+     "sha256": "a448cf5aed2909700e4da1f3ea3158b55e288198eee771eddacf211f4b274dbe"
+    },
+    "sound/wraith/sight1.wav": {
+     "bytes": 34390,
+     "sha256": "91494295e94c54c8da0307df8a51ea10d166fb18a78ede909a710f72ffe81c4f"
+    },
+    "sound/xmas/elf/attack1.wav": {
+     "bytes": 176492,
+     "sha256": "80e3faa699aec6d20015c1070087964de5ba39f83a978388b9fadc184f9fb6c2"
+    },
+    "sound/xmas/elf/attack2.wav": {
+     "bytes": 88292,
+     "sha256": "a364c82cb932bddb438c957e88a7ea67142777dfffd0f553d00e2b04b3af0f9f"
+    },
+    "sound/xmas/elf/cane_hit1.wav": {
+     "bytes": 4536,
+     "sha256": "2686bea9533633cb6c1a5e3e5bcf0016e3fe228cd278b7b1d11a02868cdd5095"
+    },
+    "sound/xmas/elf/cane_hit2.wav": {
+     "bytes": 5638,
+     "sha256": "6e470e241f37fb38ea55adf4bd0d6f1f5a2d5adfee5d5ddac8cb9adc824cb954"
+    },
+    "sound/xmas/elf/cane_swipe1.wav": {
+     "bytes": 1670,
+     "sha256": "2dbf81b3813376cb8bea2fa916dc0d03f1fbaaa499d4fcdf845de8929f82dc47"
+    },
+    "sound/xmas/elf/cane_swipe2.wav": {
+     "bytes": 1890,
+     "sha256": "404864c7d5008b79daed226566a2e4e78f2de92de06c64da67b8bf6224ae3e88"
+    },
+    "sound/xmas/elf/death1.wav": {
+     "bytes": 14284,
+     "sha256": "d1a7063d4ed39cdb59864a2a6fe6109f844caa9ada54ed4456de0bcd056f0034"
+    },
+    "sound/xmas/elf/death2.wav": {
+     "bytes": 10888,
+     "sha256": "4e0344a1bd3fa3d3c4d9e9647203cac0c449d5a5d8e7b1c8319f8402a4b7571c"
+    },
+    "sound/xmas/elf/idle.wav": {
+     "bytes": 57016,
+     "sha256": "a824467247797aa1ecc58f1716b18d390629804eebc413f01067646c64cde87e"
+    },
+    "sound/xmas/elf/jump1.wav": {
+     "bytes": 17766,
+     "sha256": "8023110b27a70758166f710e52188b8d03b8bfd81d9c985eb7f7d326acdb05a2"
+    },
+    "sound/xmas/elf/jump2.wav": {
+     "bytes": 8946,
+     "sha256": "a60763886b743d06ffd0c90e70de304ec8002a500947a684646c227d0bbb3c4d"
+    },
+    "sound/xmas/elf/magic.wav": {
+     "bytes": 15560,
+     "sha256": "6a270540819dddf140b0387d92c914b4f4b1c88c5f37a05c8fa0efd95901f2ab"
+    },
+    "sound/xmas/elf/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/xmas/elf/pain.wav": {
+     "bytes": 11126,
+     "sha256": "4e27a8f38e07e9b69db186d5c609740814ab86c5fda57058b1e05c56b85c6fd4"
+    },
+    "sound/xmas/elf/sight1.wav": {
+     "bytes": 21048,
+     "sha256": "c57eb4fec86922cb8a0499d7dae72eba66b067b89f14ff079ce0caf3dc23a23b"
+    },
+    "sound/xmas/elf/sight2.wav": {
+     "bytes": 30996,
+     "sha256": "8cd5eed3b8e098dfd70cbf90081b38e198bf64d8edf1b76bcc98c42e177635f8"
+    },
+    "sound/xmas/elf/sight3.wav": {
+     "bytes": 10050,
+     "sha256": "e88ae556a28352c319bf5500b29008384a5c53c47480defa81795d8891f14ff8"
+    },
+    "sound/xmas/elf/sight4.wav": {
+     "bytes": 6742,
+     "sha256": "7c6120d242cbbbfd2e0cc77b1428e206accd1ab8073885d52177b0fd4c75c7ed"
+    },
+    "sound/xmas/raindeer/attack1.wav": {
+     "bytes": 5582,
+     "sha256": "bcf78087eab53e8ed0bdde2f29088a89b321a79c3b104da380dd85bd5bdb6ec1"
+    },
+    "sound/xmas/raindeer/attack2.wav": {
+     "bytes": 6274,
+     "sha256": "2ba043cce4a2f22e7743812c0fa40e9f0888d5089362264c768352c347af5089"
+    },
+    "sound/xmas/raindeer/death.wav": {
+     "bytes": 9672,
+     "sha256": "68266e96ec1be80a55f48b76c2bedd6503273245153d96269947c7fc12ae96b3"
+    },
+    "sound/xmas/raindeer/hit.wav": {
+     "bytes": 5218,
+     "sha256": "72127151c2b05cc22a812fe9e38909c8bdcaae6a369e8756d2be67d392b91223"
+    },
+    "sound/xmas/raindeer/idle.wav": {
+     "bytes": 7890,
+     "sha256": "d3ef885d0b6163a3046dc9d514b07886c33809fbb6332e7db0514c648787a9bb"
+    },
+    "sound/xmas/raindeer/sight.wav": {
+     "bytes": 23796,
+     "sha256": "aafabb6fc46c1c72c34af1baea1c59a8ec04803c26faa4310072096481f31a4f"
+    },
+    "sound/xmas/santa/death.wav": {
+     "bytes": 99352,
+     "sha256": "b63273a2574f7def133aa438926a6def025aa64d8c3c636fc6a5594268e391d7"
+    },
+    "sound/xmas/santa/death2.wav": {
+     "bytes": 99352,
+     "sha256": "24fcf23117ec31347f640aa27e6feb4a46a634aa5e1eb48344b1feb7c377f6f1"
+    },
+    "sound/xmas/santa/fire.wav": {
+     "bytes": 22176,
+     "sha256": "3a9bb42661b75287a698b6e16033158f20c59c481d37c0f176dc213205d22dcd"
+    },
+    "sound/xmas/santa/good_hohoho.wav": {
+     "bytes": 55250,
+     "sha256": "51f4d5d656032de08b95689fa55a2e7aa26ec99cf4312b0f6153d0fd57fc1fa3"
+    },
+    "sound/xmas/santa/good_saved.wav": {
+     "bytes": 77302,
+     "sha256": "51e62df5942e2a72fd48311c61ee73b6f51dc4aa3c0cc85af000cdc8d7627d21"
+    },
+    "sound/xmas/santa/hohoho.wav": {
+     "bytes": 50840,
+     "sha256": "091a28236362cab1ce3b7bd55de25010d105db3bf644825c47b91725d8a613a0"
+    },
+    "sound/xmas/santa/laugh1.wav": {
+     "bytes": 57374,
+     "sha256": "ac069694d6c41e5e0afab50d9928b8768a19fb647bb249201648874d4150c976"
+    },
+    "sound/xmas/santa/laugh2.wav": {
+     "bytes": 117440,
+     "sha256": "c726d7d86d2d7cad0a75a2d0b387f4f96218ef232b6c78437e1c83bb96286441"
+    },
+    "sound/xmas/santa/laugh3.wav": {
+     "bytes": 40256,
+     "sha256": "4dd710eee601ab81c4beb5413d95244dee58b886b8265ab9cec35df06b560591"
+    },
+    "sound/xmas/santa/laugh3_com.wav": {
+     "bytes": 44226,
+     "sha256": "4099895e037cfecb4dc3595b3b18db62ed2f3cf096384f3aa1fe1d96a7b43da2"
+    },
+    "sound/xmas/santa/pain1.wav": {
+     "bytes": 6825,
+     "sha256": "79eed9346e0954fd53a6fdb9aa9708b8c29e8c5c256e9fd7c06f449e9cb6c00d"
+    },
+    "sound/xmas/santa/pain2.wav": {
+     "bytes": 9259,
+     "sha256": "f750328d74f545a658b0b190399595687c3d9b8766b2652ad6c2a34add3cc420"
+    },
+    "sound/xmas/santa/sack_hit.wav": {
+     "bytes": 13356,
+     "sha256": "c23a04ed5134f76d1f44d2e61eeb446a569c2bcbccf79f16f472807aae3df53a"
+    },
+    "sound/xmas/santa/sack_swing.wav": {
+     "bytes": 8940,
+     "sha256": "96972ba473b6a7d28645cdc621eb3011729a53eb4acb40d1f097768291a70850"
+    },
+    "sound/xmas/santa/sight.wav": {
+     "bytes": 100144,
+     "sha256": "e29696370a0d40546a49ef0f39b1e0038d8e067ef2da1dcc5084d7683a25d5d7"
+    },
+    "sound/xmas/santa/smack.wav": {
+     "bytes": 22176,
+     "sha256": "606c0a4b634d82a1d9846f654db8a52e7f2438ba28a235f782a23ff2720c767c"
+    },
+    "sound/xmas/snowman/claw.wav": {
+     "bytes": 8292,
+     "sha256": "7857f3526fb39e722a09ebe569f2b76facab765d82f97c0caa7da2ff9b750e9e"
+    },
+    "sound/xmas/snowman/death1.wav": {
+     "bytes": 11267,
+     "sha256": "0a09776ed8e45bbfe403f1cdb50302361f5596d9027c476409d6acf5402e763e"
+    },
+    "sound/xmas/snowman/death2.wav": {
+     "bytes": 13613,
+     "sha256": "e5e3a9619a153f0c6259abdb0d45f4eb4a547f736e37951556d29c6b715ec8f6"
+    },
+    "sound/xmas/snowman/icehit.wav": {
+     "bytes": 3090,
+     "sha256": "e03f61550bafc53ab47acdc23bcd481c35e75e6eccdad5e61e6dd7b372ba07c0"
+    },
+    "sound/xmas/snowman/icemiss.wav": {
+     "bytes": 3074,
+     "sha256": "f8b86f83d9adaaee1c84e1ac2acbcf652204842f2bf6f351ec1443a998574058"
+    },
+    "sound/xmas/snowman/idle.wav": {
+     "bytes": 58582,
+     "sha256": "a0d7af1cd6246f08176f24c5591cfb6ec89cff55dc5c18766ef1b16c64429541"
+    },
+    "sound/xmas/snowman/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/xmas/snowman/pain1.wav": {
+     "bytes": 7685,
+     "sha256": "7f829300a30cb6cb4d17f8c8327bd62ae5b5dacc892d28a956d6ecd2acf5f1c2"
+    },
+    "sound/xmas/snowman/pain2.wav": {
+     "bytes": 7661,
+     "sha256": "3747d77583aa4edb3509e89ea651ea41a8e8a92cd96c34d4e00257e7371fb0e6"
+    },
+    "sound/xmas/snowman/shotg_fire.wav": {
+     "bytes": 6572,
+     "sha256": "3d54870c0f643b1e7ee5307641bb3fc4a94efdaffc2e4ecd196556b930167ef2"
+    },
+    "sound/xmas/snowman/sight1.wav": {
+     "bytes": 10042,
+     "sha256": "ce1cddbb6e85fad23231ac1fc4c04c19ec7276acb2aa86e023c117db4b8edd68"
+    },
+    "sound/xmas/snowman/sight2.wav": {
+     "bytes": 15418,
+     "sha256": "5d4e994c30a7c3f2e1f1a5cde9a56115bcb32c350e4a0ad8e339a1a46ed19707"
+    },
+    "sound/zombie/boil_explode.wav": {
+     "bytes": 38012,
+     "sha256": "210dac94ab0e4efb5eb3bdbfa5d7100094b1bfef917a8d5abb2ae186252c0a27"
+    },
+    "sound/zombie/boil_idle1.wav": {
+     "bytes": 33204,
+     "sha256": "e2b717040d436ba2a659ceb1e5b74dfeaad57577297a9827957733e00ce7cb34"
+    },
+    "sound/zombie/boil_idle2.wav": {
+     "bytes": 33206,
+     "sha256": "8bd584597f2c54e6f8ecca5c0a83e44b0b5a09a745026e41cc2cad8ded6f729a"
+    },
+    "sound/zombie/boil_sight.wav": {
+     "bytes": 33192,
+     "sha256": "0e285e98dc66cd49af507dae9ab5281aaec55eaf9d401810a8d230d93539123a"
+    },
+    "sound/zombie/boil_squirt.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/zombie/boil_windup.wav": {
+     "bytes": 22094,
+     "sha256": "3790791943ea03add95bc303df34470c534f9c2c76e4343831609eaee761633d"
+    },
+    "sound/zombie/zk_sight.wav": {
+     "bytes": 26916,
+     "sha256": "8fe4d5fea16bd7c3661a968d26782ea8c4741157e16e22f33317619229b10637"
+    },
+    "textures/#bmk_water01a.tga": {
+     "bytes": 12332,
+     "sha256": "904f50c3a1de65dd5045f128d03ed8cdc86fcbc15cce295d94304b389ca5ed7c"
+    },
+    "textures/#bmk_water01b.tga": {
+     "bytes": 12332,
+     "sha256": "904f50c3a1de65dd5045f128d03ed8cdc86fcbc15cce295d94304b389ca5ed7c"
+    },
+    "textures/#bmk_water02a.tga": {
+     "bytes": 12332,
+     "sha256": "1123b4f4df8d75a1d8fc2a00d4d19fb279035771f7440b1506d0a95648123766"
+    },
+    "textures/+0bmk_fgopen02.tga": {
+     "bytes": 3145772,
+     "sha256": "1c7e70671a9a98473b3fb3926e1672d5a1712a011caba937097d5bc8c96099de"
+    },
+    "textures/+0bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "f2f139ae3d91bf3aa7c89181b87c1c645acb7be673eca5d56d804889e24f1e50"
+    },
+    "textures/+0bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "f2f139ae3d91bf3aa7c89181b87c1c645acb7be673eca5d56d804889e24f1e50"
+    },
+    "textures/+1bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "6941909c4574fb66f59f7a797f3dd0c696651e117c583f102d255e6bef4fe0ef"
+    },
+    "textures/+1bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "6941909c4574fb66f59f7a797f3dd0c696651e117c583f102d255e6bef4fe0ef"
+    },
+    "textures/+2bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "b78fb050de863bd84616c224de600521738a84ce172346bb783ba3a8708449da"
+    },
+    "textures/+2bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "b78fb050de863bd84616c224de600521738a84ce172346bb783ba3a8708449da"
+    },
+    "textures/+3bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "bf6815a6df5fe67c40ec3e46362a04c5ba15dc8a76de975a3d90a0caeec5e88c"
+    },
+    "textures/+3bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "bf6815a6df5fe67c40ec3e46362a04c5ba15dc8a76de975a3d90a0caeec5e88c"
+    },
+    "textures/+4bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "031bd453f18757388aa700fbae39e6c446959b8e38bee9fbbb53d8639f29deea"
+    },
+    "textures/+4bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "031bd453f18757388aa700fbae39e6c446959b8e38bee9fbbb53d8639f29deea"
+    },
+    "textures/+5bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "873c6b31fcaab54e309e663d23748cc5595b80e1432559761fd92a03f0d41d32"
+    },
+    "textures/+5bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "873c6b31fcaab54e309e663d23748cc5595b80e1432559761fd92a03f0d41d32"
+    },
+    "textures/+6bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "33492aebd47cc69737a2cd8460423103a76ff59b1d6bd39b750f19d6c72efc6d"
+    },
+    "textures/+6bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "33492aebd47cc69737a2cd8460423103a76ff59b1d6bd39b750f19d6c72efc6d"
+    },
+    "textures/+7bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "60741f2766db4f0eb6d622b132d2fc60d9e453d9f847661d3eca641fbf2b64f1"
+    },
+    "textures/+7bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "60741f2766db4f0eb6d622b132d2fc60d9e453d9f847661d3eca641fbf2b64f1"
+    },
+    "textures/window_blue1_2.tga": {
+     "bytes": 786476,
+     "sha256": "583f28b004c5de047037798524681ed2e7914bf1f54ac3d774c8da2880c80282"
+    },
+    "textures/{cop1_7.tga": {
+     "bytes": 16402,
+     "sha256": "464c149a2b2c9f624e7b1f8c2388117022425f058a946f0232c51def845b8bb5"
+    },
+    "textures/{cweb1.tga": {
+     "bytes": 262162,
+     "sha256": "bb0aa80709a1705199ed83bd0cad683a928cb29064eb32263fcb8bdb3999c2f5"
+    },
+    "textures/{cweb2.tga": {
+     "bytes": 262162,
+     "sha256": "64be3598db71729d4a4376c5f4e02bf0e586fc5ceca09196d71befde3265424e"
+    },
+    "textures/{cweb3.tga": {
+     "bytes": 131090,
+     "sha256": "d7b67dfdb1c80946f0de21128ddc3cda61906619ab8ed185611ef2a2a8f936b5"
+    },
+    "textures/{cweb5.tga": {
+     "bytes": 131090,
+     "sha256": "9cf5dd24994b1dc2f8f07ac5f76410fea9bdb7cb925962e1977e6aeb6ce23b02"
+    },
+    "textures/{dutcweb1.tga": {
+     "bytes": 131090,
+     "sha256": "8922bb11d99fc05d2ffeab2c2d99b04dba9d0fc5165fdd9a0ccd921f066f668c"
+    },
+    "textures/{dutcweb2.tga": {
+     "bytes": 131090,
+     "sha256": "a0377ffeac458bf27bbd86d2bc22ff17d973bd0328a4d048fb3136573c12723d"
+    },
+    "textures/{dutcweb3.tga": {
+     "bytes": 131090,
+     "sha256": "61710c94a64a506b75f36578904dbece6f666bc25ad2665333fe00b1c4b04f70"
+    },
+    "textures/{dutcweb5.tga": {
+     "bytes": 131090,
+     "sha256": "a0959d05f9bd1f4aa632b1642885261a2cbbef7d6d6d7ab677bb803ac1a00ef8"
+    },
+    "textures/{dweb1b.tga": {
+     "bytes": 65554,
+     "sha256": "7f2f310b5393519fbfdf70e07cab318504ad88c67dcce1e9988e376d5fc9c94a"
+    },
+    "textures/{dweb2b.tga": {
+     "bytes": 65554,
+     "sha256": "d95f6ebbcc21b2cb7164743b517aa69287101aa2640d5a8b249c409dcdc20333"
+    },
+    "textures/{dweb3b.tga": {
+     "bytes": 65554,
+     "sha256": "24cde40cf3791f0e054ccd2ad81353ec711bd95a7de1af58a1ad561d9d104ef1"
+    },
+    "textures/{dweb5b.tga": {
+     "bytes": 65554,
+     "sha256": "5b1fc4683289a850f5c16afa56660b710212bf18d4c047bf134529dac784d2c9"
+    },
+    "textures/{gen_gr8.tga": {
+     "bytes": 65554,
+     "sha256": "8dacb17cbbb6bb2f4dd95856dd46905a9c335f0a98dc3e8e700fac0a9c529163"
+    },
+    "textures/{kjwintex_ad.tga": {
+     "bytes": 262162,
+     "sha256": "3a2583e19c17e05877e489972b85593d9fca1e57ffd4fa02f1475e6fb3d59c34"
+    },
+    "textures/{ladder5th.tga": {
+     "bytes": 49170,
+     "sha256": "ed742e4b7072c1b11b1b801393bbfc641f96920ecabc5600c213b354313f89f0"
+    },
+    "textures/{lweb1.tga": {
+     "bytes": 262162,
+     "sha256": "e4edd91fdd0031064bd6157574ae5f81b44611424f7357daf8fd4e426c960399"
+    },
+    "textures/{lweb2.tga": {
+     "bytes": 262162,
+     "sha256": "4d2f26192388bf65091b0d5afb934bede4f07e89d002bbdbaeeba29d459fd5d7"
+    },
+    "textures/{rtex158_.tga": {
+     "bytes": 21522,
+     "sha256": "cd10217f3e5cd47b32bde516d4b36cf7995913e306f7415d25dcd7da6ccb4673"
+    },
+    "textures/{speedbz_grid1.tga": {
+     "bytes": 16402,
+     "sha256": "109e52491dda6d4968c99004296ccd503db6d6af9aad9aa6f21cca02fd2b299f"
+    },
+    "textures/{swvine.tga": {
+     "bytes": 65554,
+     "sha256": "c23639e3bd8aacd226695c913384e9c67d509b28fb9597d56f120cfea56a4006"
+    },
+    "textures/{utcweb1.tga": {
+     "bytes": 131090,
+     "sha256": "edae90ba1151fb6adc65def85d4dd7be01c3d2a18bd93ef0f26ff44d07f6c4b0"
+    },
+    "textures/{utcweb2.tga": {
+     "bytes": 131090,
+     "sha256": "829cfe898d9aa4c3ddd12a51f9ccc16a66b2ca5671d9bfd2339f402d49db3267"
+    },
+    "textures/{utcweb3.tga": {
+     "bytes": 262162,
+     "sha256": "026680576034c959e840aa4b39917497c38df12c1331a0c7a1486912e26a91f7"
+    },
+    "textures/{vinehang1.tga": {
+     "bytes": 65554,
+     "sha256": "c23639e3bd8aacd226695c913384e9c67d509b28fb9597d56f120cfea56a4006"
+    },
+    "textures/{vinehang2b.tga": {
+     "bytes": 262162,
+     "sha256": "4268dc2a183582d00c363a9fcd1965c026632150383d40b520fbd54f8751eaa7"
+    },
+    "textures/{vines3.tga": {
+     "bytes": 25618,
+     "sha256": "550b6ca0c768db472fbc970836516506034b30f0a5ca4b4b11df34d7dce8dc82"
+    },
+    "textures/{vinogrande2.tga": {
+     "bytes": 262162,
+     "sha256": "7c2d4aad4d34457ab1674bc1eaaa4ea38e4c4af384877af631cde258167fbb72"
+    },
+    "textures/{web1b.tga": {
+     "bytes": 65554,
+     "sha256": "41bb1244128013ff09f1965339ef505a7b0757bea91fcc0f77ed97cd38c8a145"
+    },
+    "textures/{web2b.tga": {
+     "bytes": 65554,
+     "sha256": "e2fbcb154962a9189614aecc7f6833e60d24709583a970d6cca0adf948df2331"
+    },
+    "textures/{web3b.tga": {
+     "bytes": 65554,
+     "sha256": "e4cfcd4c4e94ed647ef9af822d0df5ee573bd20d9f3bcf45ef8701a3102ae3ef"
+    },
+    "textures/{web5b.tga": {
+     "bytes": 65554,
+     "sha256": "dfdad98b5b62765b24abccd2ff77e85ec1c002060d6634d2593ac0fe10a4c718"
+    },
+    "textures/{win01_1brk1.tga": {
+     "bytes": 49170,
+     "sha256": "dae89ad198e0f4b1a63e37d9145084e947f7e88cb1c2e5d9ef32f25f3e0fb484"
+    },
+    "textures/{win01_1brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "88d9f8700eb9d14f9cfa6ac2e3df1bb25eae9a46553b6e46da7b225316862cb9"
+    },
+    "textures/{win01_1brk2.tga": {
+     "bytes": 49170,
+     "sha256": "2416e34e1ebdefa0cd01ea595b68ae86d2a35a4329b8853a489b1058dea44a90"
+    },
+    "textures/{win01_1brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "921ecb3434e9bd56d97ad57d10c67ace5a0f4bce79bf1b4c8c68aad4cf6ed10f"
+    },
+    "textures/{win01_1brk3.tga": {
+     "bytes": 49170,
+     "sha256": "59a6b2dc874758693574f15affea0be9c2e92e32328f81db78e5d72f488be7cb"
+    },
+    "textures/{win01_1brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "a3dcd6d471d8c65781a69c73a9fa449da02bc01a58a0a97c7313d30587611516"
+    },
+    "textures/{win01_2brk1.tga": {
+     "bytes": 49170,
+     "sha256": "589cf84c790b3165fa60e4441223da48c3df4275099fcc27bc5a8b9502579c15"
+    },
+    "textures/{win01_2brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "a0a80d249ff32c2e0a480801b721657244380732db3bdd9645dbece347d3190c"
+    },
+    "textures/{win01_2brk2.tga": {
+     "bytes": 49170,
+     "sha256": "0dc35f6a8b8b83596d127791f32f59b4a7445cb2529777555a93b9f329b7b537"
+    },
+    "textures/{win01_2brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "b313a11eb9017f0be604b673c0df88e94f94d552a7a132241f80883e68f4905f"
+    },
+    "textures/{win01_2brk3.tga": {
+     "bytes": 49170,
+     "sha256": "0fd4d13eb067aa17be299b48d500c245554fc3a6c1f5f11e10cbec1195a35273"
+    },
+    "textures/{win01_2brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "7ad6db65f6c0190a9ec569cce3b4780d21a90baf9baa728128f278807f1ba780"
+    },
+    "textures/{win01_3brk1.tga": {
+     "bytes": 49170,
+     "sha256": "ee6084ebe49ce367fd68039d548b1c960e55b136412bb00b8094dc1c545307bf"
+    },
+    "textures/{win01_3brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "afa5f0475b733a0ee1829b76598acd37cb1f28ed7f2faaf128593a13e702f5fa"
+    },
+    "textures/{win01_3brk2.tga": {
+     "bytes": 49170,
+     "sha256": "54c3abca2e42bbc4626823d4ad8081797e295bbdd07942484142d8a1c5395474"
+    },
+    "textures/{win01_3brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "0e0fc8daffc3ec8e07028904e3e55946270b8346f32efa341d64d6d1c0bcfcb5"
+    },
+    "textures/{win01_3brk3.tga": {
+     "bytes": 49170,
+     "sha256": "c1c7752039d97f7b92ec36408ffe456ff96c2a27c725c432e677a4f22e893d46"
+    },
+    "textures/{win01_3brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "0b627faae78e0d01eee393b58f978bf1a46b653001e1d1c56589d822245f86df"
+    },
+    "textures/{win01_4brk1.tga": {
+     "bytes": 49170,
+     "sha256": "af0f20f39e53d82cda8fca18e2918c1a2df2e6cf94e4d636e50c01686b3291b8"
+    },
+    "textures/{win01_4brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "4522e8d89c78119e9ff517ad64571c17c3ca750ac820142a700809620e894942"
+    },
+    "textures/{win01_4brk2.tga": {
+     "bytes": 49170,
+     "sha256": "4696f9c8ca59937230f40a3135b6c02e54b9b912eb62ba1401cbd5cccd1a9ae4"
+    },
+    "textures/{win01_4brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "a7a978f76a01a53dca360914519a8b1a93272aaad8a57c54e32ec74d4d9f1b96"
+    },
+    "textures/{win01_4brk3.tga": {
+     "bytes": 49170,
+     "sha256": "66dfc1bbe57f20c766653ab71cb339b6bff4e10b33cf66f5ed070bc0be75156f"
+    },
+    "textures/{win01_4brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "fb047a212d30b7fd140331df80d03dc718ba4237df73bf3cd74c918cc91daddf"
+    },
+    "textures/{win02_1brk1.tga": {
+     "bytes": 49170,
+     "sha256": "cb2711c7dc2ee9b77aded814296c1b1bb124ff5d2db2e248af7d7d0d882f422d"
+    },
+    "textures/{win02_1brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "9391e42b0fe2e55689e7104984fc1b5fd199cd8821e562fc4538fe2eb73825e9"
+    },
+    "textures/{win02_1brk2.tga": {
+     "bytes": 49170,
+     "sha256": "4fb71ced0a5388e41896b3b71b9c48d157eb72d229db04bbdcca45ce58658adc"
+    },
+    "textures/{win02_1brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "ed18da9a408653915554b0918a0f720cb76257231fc8ff9d465003e98fb371ab"
+    },
+    "textures/{win02_1brk3.tga": {
+     "bytes": 49170,
+     "sha256": "3b1f9bdbd53db1fa6d6920045cf4da45064dac48f7f66870e003860514804e99"
+    },
+    "textures/{win02_1brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "f1e10e37f7f2e71ddd6165607e59d39f95ec59c904017a8fa6b7b33a3adf40c1"
+    }
+   },
    "sha256": "cfd2ae7a458fc12ce5fa7f2041e4d9fefe9cc893faf5386a95bd87c84e558830",
    "timestamp": "2020-10-27T05:50:12.000Z"
   },
   "pak1.pak": {
    "bytes": 5468494,
+   "files": {
+    "maps/ad_brk/all_brick.map": {
+     "bytes": 22738,
+     "sha256": "e0859c71d8a3d5d4b140757e4fcd2ab4e92674bbb71979d6b9d6d2deb5d2390a"
+    },
+    "maps/ad_brk/all_glassa.map": {
+     "bytes": 8834,
+     "sha256": "f4e1c7c1444b3b2d8a3463e8950c0a6a3aed8d39144a6b1fc2a69bdbf376f444"
+    },
+    "maps/ad_brk/all_metal.map": {
+     "bytes": 12297,
+     "sha256": "447c74022bea3ae89d3a4412afcf4bcd384ea725b344b987fb2e7bb37adfabe1"
+    },
+    "maps/ad_brk/all_rocka.map": {
+     "bytes": 10235,
+     "sha256": "52edb0d5b9f79e8b89a58353098316e81be31c3e289d6f96e450ea01c4bbeb62"
+    },
+    "maps/ad_brk/all_wood.map": {
+     "bytes": 8397,
+     "sha256": "93697129156d662c18391564e26c5d5ceec8bac244209496290b8e9a516a5bfb"
+    },
+    "maps/ad_brk/brick01.bsp": {
+     "bytes": 7912,
+     "sha256": "c11880924b195ed38908cbf50f9cd16f071918df0a94a19c7254b93dddb1e62d"
+    },
+    "maps/ad_brk/brick01.map": {
+     "bytes": 717,
+     "sha256": "3f87d06eb46f67efa678ddd5ddf274e9c595c4a5236d8f111d8a0ea999972e09"
+    },
+    "maps/ad_brk/brick02.bsp": {
+     "bytes": 8072,
+     "sha256": "9ec52c7441f570d2a793035ebc2128d7f7f91f71b44b4418fd01e6b3e6d503e2"
+    },
+    "maps/ad_brk/brick02.map": {
+     "bytes": 861,
+     "sha256": "616d1c5b6f3e476453e8b9b57dd59deb285c6c0482680ca5d6da358ee808c619"
+    },
+    "maps/ad_brk/brick03.bsp": {
+     "bytes": 8280,
+     "sha256": "aa55feca84b80282851ca55c71deb3d54f02a6668af820f5ac4f9c1a0514e5e1"
+    },
+    "maps/ad_brk/brick03.map": {
+     "bytes": 935,
+     "sha256": "4359e78daaac0b8d4ff58dc68301bba4cd423e81284bcd360ce1480862c19d91"
+    },
+    "maps/ad_brk/brick04.bsp": {
+     "bytes": 8052,
+     "sha256": "b1fa14c188a8ad31cf58c7ebd495fbe8ed153819015d4e97c82e01ee052081e3"
+    },
+    "maps/ad_brk/brick04.map": {
+     "bytes": 815,
+     "sha256": "2bda60cc50886dc430a053f509f2376dcd9bd4d09666cf7960a96484fa369903"
+    },
+    "maps/ad_brk/brick05.bsp": {
+     "bytes": 7952,
+     "sha256": "e137a3ea0f33a83b8717dcb9d6e2ab79876112121dc21fe2e625d24d5d251384"
+    },
+    "maps/ad_brk/brick05.map": {
+     "bytes": 770,
+     "sha256": "8ebf395096050f65a3a370971d65deb0926af70f6cbd75c6579a53b68f676793"
+    },
+    "maps/ad_brk/brick06.bsp": {
+     "bytes": 9184,
+     "sha256": "32cee0a2c668160e07568ae08b4de5beae87d74e94a347cd431c90005bf49e24"
+    },
+    "maps/ad_brk/brick06.map": {
+     "bytes": 1709,
+     "sha256": "289f58cad70a88e8a8d986644faf539dd38cf52a884aa7f85513db5df0cc438c"
+    },
+    "maps/ad_brk/brick07.bsp": {
+     "bytes": 10377,
+     "sha256": "df07446f9f6a118f11451de5d7817f582c11dcc81ca3f83c8fa72c9d95e8df9c"
+    },
+    "maps/ad_brk/brick07.map": {
+     "bytes": 1942,
+     "sha256": "fe440636e5354fb553708f3b6859023d0a520f315050dc11a564e31a7b72d5e4"
+    },
+    "maps/ad_brk/brick08.bsp": {
+     "bytes": 13964,
+     "sha256": "2abbbc958d752e742df9d1f7152c4cc8c0de6373f20e628a762e2a22f5d6b3f7"
+    },
+    "maps/ad_brk/brick08.map": {
+     "bytes": 3286,
+     "sha256": "72174f573416102bb4e087e2025b3dbdfc669ab7cafc8b354f7b1a4485af1f5b"
+    },
+    "maps/ad_brk/brick09.bsp": {
+     "bytes": 7952,
+     "sha256": "28d7162b4af3f4ce184a31a14e3a9777383f29b63920d9d62ff136ae96e3a2fd"
+    },
+    "maps/ad_brk/brick09.map": {
+     "bytes": 770,
+     "sha256": "62f11ef3e3033dea82eb6062e5b5301474dd014f889a980383891e689be2a352"
+    },
+    "maps/ad_brk/brick10.bsp": {
+     "bytes": 9184,
+     "sha256": "7d6f8e3fd1b65880bb767ab5d488ef11bbb01ec4ce14c7b747ee75b8a8238c4e"
+    },
+    "maps/ad_brk/brick10.map": {
+     "bytes": 1709,
+     "sha256": "276f975d99dfe982bf71104889f65a248d719778db89591e7193ecc46b13d645"
+    },
+    "maps/ad_brk/brick11.bsp": {
+     "bytes": 10377,
+     "sha256": "f65cbdb642220611e89725187f47427031c4b18c21cc04ae3f6cfb4dffd149a2"
+    },
+    "maps/ad_brk/brick11.map": {
+     "bytes": 1942,
+     "sha256": "3b9d73d400e29fba3c82d8b2ccdad26e03b128c7771427497d4740c2d34cd63d"
+    },
+    "maps/ad_brk/brick12.bsp": {
+     "bytes": 13918,
+     "sha256": "1e1e8191c5ebdd1f0fed27edaa04a82a6aabd5c41723cf590781ff00f7300a02"
+    },
+    "maps/ad_brk/brick12.map": {
+     "bytes": 3286,
+     "sha256": "d2b89c83f1ff95d6fe577cf4a166e7bec6e02ab85f48c51316908d7d80068156"
+    },
+    "maps/ad_brk/brick13.bsp": {
+     "bytes": 7912,
+     "sha256": "4b5ac4eb6ea5a9ec049c27082d800cb981902965a4b652f86e1753bfa1eb7c94"
+    },
+    "maps/ad_brk/brick13.map": {
+     "bytes": 690,
+     "sha256": "253425ec201a354cd1b4c93c78d740e2a17c7d946d911efffa63d522e95f9f0b"
+    },
+    "maps/ad_brk/brick14.bsp": {
+     "bytes": 8072,
+     "sha256": "afe8797d2172a5b4b06be3e2a69038346d62938f3d9da6ea224074cee5bb1669"
+    },
+    "maps/ad_brk/brick14.map": {
+     "bytes": 828,
+     "sha256": "a500705a328cafa28159ee107cbe80003848ee241c3544a73dea1432f67b4042"
+    },
+    "maps/ad_brk/brick15.bsp": {
+     "bytes": 8280,
+     "sha256": "58ddb31ce4108a70872444022369154529c532983dbc58698cd88f217f8947a0"
+    },
+    "maps/ad_brk/brick15.map": {
+     "bytes": 899,
+     "sha256": "589f256e02b66051ede4f2fe136e69313a7e01402f1caa43bada4d605a046b8e"
+    },
+    "maps/ad_brk/brick16.bsp": {
+     "bytes": 8052,
+     "sha256": "d5c15593d0d776d5f76919100602d893973cd59b7ca88af55e1ae3cc2fb56967"
+    },
+    "maps/ad_brk/brick16.map": {
+     "bytes": 785,
+     "sha256": "a15682c168f0a7128c83bf7bd38688ae1d2507873687e815c690b08d44f14a37"
+    },
+    "maps/ad_brk/brick17.bsp": {
+     "bytes": 7952,
+     "sha256": "738d902046d73e14b8a552529dd8306864661fd0469efb52b3c81329135e8372"
+    },
+    "maps/ad_brk/brick17.map": {
+     "bytes": 770,
+     "sha256": "699fa7055fa88f309fe4a4a2af24b5d61af91365d81074e44cbdf399d36939c9"
+    },
+    "maps/ad_brk/brick18.bsp": {
+     "bytes": 9184,
+     "sha256": "67ad693c292448f73ea0b3ab6ee22883709c7deb006cecd19c0dda5c9d4fa131"
+    },
+    "maps/ad_brk/brick18.map": {
+     "bytes": 1709,
+     "sha256": "849749000a41ecfc60aa4607c890e140bcd78ef26858512f56494efdc5873bcd"
+    },
+    "maps/ad_brk/brick19.bsp": {
+     "bytes": 10321,
+     "sha256": "721c3237db8c026a03e01e387bb95fe5ed8fbc49b3c527220f164d77a2f3a4f2"
+    },
+    "maps/ad_brk/brick19.map": {
+     "bytes": 1942,
+     "sha256": "1760c2c74d0b894814c89152062f2f55a8635a17559828c27532a7e913949af6"
+    },
+    "maps/ad_brk/brick20.bsp": {
+     "bytes": 13306,
+     "sha256": "bbecee9c1ac726743e6cc49d18246c650f762f577dc108ffed2a6807ff665052"
+    },
+    "maps/ad_brk/brick20.map": {
+     "bytes": 3286,
+     "sha256": "121d4fe62c07953f11a04a41577769a38cae8852af78bbd40fc44f598eee91d7"
+    },
+    "maps/ad_brk/brick21.bsp": {
+     "bytes": 7972,
+     "sha256": "e65c1df9d5f02efc9475a53d1127d7899f69d23d8a0ea20deab384fcd3351d29"
+    },
+    "maps/ad_brk/brick21.map": {
+     "bytes": 789,
+     "sha256": "8c12d093245c3937afcf62916fce9e6b2d181d72d433b879112b27e0f168ccc7"
+    },
+    "maps/ad_brk/brick22.bsp": {
+     "bytes": 9204,
+     "sha256": "b8efe5f130accf1e8704202dbaa44215259e1209b9b81bf79461ff5e5f725596"
+    },
+    "maps/ad_brk/brick22.map": {
+     "bytes": 1728,
+     "sha256": "403525bf264890c5d9adef370847749cbeec481337f284618810057e697cddde"
+    },
+    "maps/ad_brk/brick23.bsp": {
+     "bytes": 10340,
+     "sha256": "79bac69a44c7e83343bd69c2360176046e048257ecfb7ac27f3c989b42af92e9"
+    },
+    "maps/ad_brk/brick23.map": {
+     "bytes": 1961,
+     "sha256": "f25e7a514eb15637b7dedc41ec5c34e2d8b9e4dd3b584a41a1b1d7c166b362ef"
+    },
+    "maps/ad_brk/brick24.bsp": {
+     "bytes": 13312,
+     "sha256": "2e0728a16ebe0fa868d8bd0ffe0f54e013afac41c77ee7516f385d7a6718b07f"
+    },
+    "maps/ad_brk/brick24.map": {
+     "bytes": 3305,
+     "sha256": "481d21e7e07a312e894f71a8118035457164f17d48032bad54bdc62644e7e8a4"
+    },
+    "maps/ad_brk/brick25.bsp": {
+     "bytes": 7924,
+     "sha256": "8e33245bde92e94d9dddca1b61059fee1eb19aed0613945c1dffe3145fd51d78"
+    },
+    "maps/ad_brk/brick25.map": {
+     "bytes": 715,
+     "sha256": "cf6042585a2347f8ae4de546e2fa9aa905aa7ee4d9607a12dfd778d0084ba9d1"
+    },
+    "maps/ad_brk/brick26.bsp": {
+     "bytes": 8084,
+     "sha256": "4ddb5d2ca4adbc32f905a0340b26a174c25af7f6de5ad9408c4e0f4ca2816a55"
+    },
+    "maps/ad_brk/brick26.map": {
+     "bytes": 855,
+     "sha256": "baaf133d5c5c90b295855bb03a0a30340db324ddc82ed119a9d025e8ddb22724"
+    },
+    "maps/ad_brk/brick27.bsp": {
+     "bytes": 8296,
+     "sha256": "9084778144864d4167d270dd825e99d18d7ea7fc2dfb799f7e0eb12f1d236688"
+    },
+    "maps/ad_brk/brick27.map": {
+     "bytes": 927,
+     "sha256": "4e3b59df2a5b8efe85460f114baa795c36c8b410407e0752a69efc525d49e9b0"
+    },
+    "maps/ad_brk/brick28.bsp": {
+     "bytes": 8068,
+     "sha256": "42b4fe7f99032b3292996bcfe8b72e1c5e3b637357e376f8502a202a3816bcf0"
+    },
+    "maps/ad_brk/brick28.map": {
+     "bytes": 811,
+     "sha256": "c088828bbe9cdca1bb55ea4ceca9f46e03217f1643189a93d70a83eeb11f72bc"
+    },
+    "maps/ad_brk/brick29.bsp": {
+     "bytes": 24232,
+     "sha256": "463ff6bed92dfab082f13876187c506572dd3d18727e13fb708e24afd02aa7ef"
+    },
+    "maps/ad_brk/brick29.map": {
+     "bytes": 711,
+     "sha256": "1a4ff9d041df15cfd229666a9b32c24a96577ef6f249f33d89dc88cdfbe5540a"
+    },
+    "maps/ad_brk/brick30.bsp": {
+     "bytes": 24392,
+     "sha256": "a82a0d709c367d8ecf359142d99d0ad09d97b674ef1575beeb78dbbe93025c59"
+    },
+    "maps/ad_brk/brick30.map": {
+     "bytes": 853,
+     "sha256": "803c896037b5cc971e932219b5f06e363724a25de693ef6800d1332c6df4f8d1"
+    },
+    "maps/ad_brk/brick31.bsp": {
+     "bytes": 24604,
+     "sha256": "deb8a0278e043c6510e7f7d17ec708bdc7f37fa884f869ccbfc9ef9a95b6a8ac"
+    },
+    "maps/ad_brk/brick31.map": {
+     "bytes": 926,
+     "sha256": "9a3502125d9a995f10052ed6a9971bfe148a4e8fd7561a082e8bbecff5b39d56"
+    },
+    "maps/ad_brk/brick32.bsp": {
+     "bytes": 24376,
+     "sha256": "c8961b003f231b13a74bc247ce13ada38850707d443aa98dbad98b9f2ecf276b"
+    },
+    "maps/ad_brk/brick32.map": {
+     "bytes": 808,
+     "sha256": "aa96dda4508d2e98b5827ac42d8230f11969457f63022bf488dac06d2783910e"
+    },
+    "maps/ad_brk/glass01.bsp": {
+     "bytes": 8095,
+     "sha256": "d5d9b8df7fc4db671e180fbc60253ea809b61819bd77a9072d1cf1b1c9c11888"
+    },
+    "maps/ad_brk/glass01.map": {
+     "bytes": 961,
+     "sha256": "04b6721fc35e7a43fa921075bc2184bbbb2791570ea781ee6351b0cf01936456"
+    },
+    "maps/ad_brk/glass02.bsp": {
+     "bytes": 7035,
+     "sha256": "b2e6ba1e674f6a93e01ada15700b98624eae9c242a30eba9ea032d2e7d9fc555"
+    },
+    "maps/ad_brk/glass02.map": {
+     "bytes": 447,
+     "sha256": "6bf3cce568e830dd03830bb2e7225329490dae01e33806eec6a594313a8daa9e"
+    },
+    "maps/ad_brk/glass03.bsp": {
+     "bytes": 7922,
+     "sha256": "02661d1e724d41c02c977f8b869a23e6fc883303b66298c98ebddf752f365a1b"
+    },
+    "maps/ad_brk/glass03.map": {
+     "bytes": 963,
+     "sha256": "cb5245e54bc27d999bd643370557f8e766ae94e10358993951084e6ca87d087c"
+    },
+    "maps/ad_brk/glass04.bsp": {
+     "bytes": 7223,
+     "sha256": "a41bddb2d6a0ef53b96097a6e4d9731bf100b695a7a1c11091f054f746c7bf2a"
+    },
+    "maps/ad_brk/glass04.map": {
+     "bytes": 512,
+     "sha256": "f8e9f41266f3cd0017c19f7d3a29e0c738b497fb539cec2583c4eda6d509965c"
+    },
+    "maps/ad_brk/glass05.bsp": {
+     "bytes": 24436,
+     "sha256": "10fd2ef7f24bda233c3b4433e4ed64b8feb7273f09c0da5d93190ced61f20779"
+    },
+    "maps/ad_brk/glass05.map": {
+     "bytes": 999,
+     "sha256": "c8e2039929909b608ac0ddf36562443caf7052a15e8b0e39a73e0869c15930c1"
+    },
+    "maps/ad_brk/glass06.bsp": {
+     "bytes": 24300,
+     "sha256": "60f08ebc3d967dbe1b6062a59679a3e89e199a305f51bb9bc7dbada44c66fe5e"
+    },
+    "maps/ad_brk/glass06.map": {
+     "bytes": 976,
+     "sha256": "73346b8cc46166371a6e7f220ebe78f2cde29f29d8d705e1e4b0c60e153b52df"
+    },
+    "maps/ad_brk/glass07.bsp": {
+     "bytes": 23365,
+     "sha256": "ccebafe1a97953e91b64694783a1989c8e8ba440fd3c136b09785131b54c75cf"
+    },
+    "maps/ad_brk/glass07.map": {
+     "bytes": 458,
+     "sha256": "6d79a332d308ed3746c8f2fd13227b44a1cc66f0b2fd471eb6de1cbf695d81c9"
+    },
+    "maps/ad_brk/glass08.bsp": {
+     "bytes": 23602,
+     "sha256": "82c1bfe3d83c87c908d6dac76a255843cbbaededeaf644eeec5b9b9a794e0bdf"
+    },
+    "maps/ad_brk/glass08.map": {
+     "bytes": 530,
+     "sha256": "65dba1b71881c49b29d288720f43c457c838b93aa9e522953bac885443944c04"
+    },
+    "maps/ad_brk/glass09.bsp": {
+     "bytes": 24436,
+     "sha256": "34e317a5652fcc4a3aaf517ebc178c8d8fad6738b536a6c06eff2800bf7fefba"
+    },
+    "maps/ad_brk/glass09.map": {
+     "bytes": 999,
+     "sha256": "ca9b91b38fa600b7dfa80e9a257dc15f2f2dda9e1d2c1d002ea90cbdcc0e0279"
+    },
+    "maps/ad_brk/glass10.bsp": {
+     "bytes": 24300,
+     "sha256": "6e06c140e0916cd35235bd7e6970ca3250c6c36a2ee6d4632d805da67215818a"
+    },
+    "maps/ad_brk/glass10.map": {
+     "bytes": 976,
+     "sha256": "2043f7646edcfa088a76b6104b136ff9ca0f90bffe6efb955f951a4bfe16643d"
+    },
+    "maps/ad_brk/glass11.bsp": {
+     "bytes": 23365,
+     "sha256": "caae0c47ae097f4cb1055a3f5eecd5d407b71c975b35d992f3048993b1ac7e97"
+    },
+    "maps/ad_brk/glass11.map": {
+     "bytes": 458,
+     "sha256": "5bea1bbcee409674f58a1fd26cf0c983e11f8ffd5f20c829f5c3df6a4c28b1c9"
+    },
+    "maps/ad_brk/glass12.bsp": {
+     "bytes": 23602,
+     "sha256": "526018b31a9b02b1c9e1b5123b2c936677d6fd7b6c014ea14dfe4905271e419f"
+    },
+    "maps/ad_brk/glass12.map": {
+     "bytes": 530,
+     "sha256": "499ed4ce1a1ebbd9347a2a4dc6413f2f79d203bbce293a79a5b2bde49ade0a3f"
+    },
+    "maps/ad_brk/glass13.bsp": {
+     "bytes": 24108,
+     "sha256": "fdb97447ffe9e4769f35a3e1e7bd9d6b0e2e6b555d60102991bf57f06e8b3d83"
+    },
+    "maps/ad_brk/glass13.map": {
+     "bytes": 979,
+     "sha256": "073661c415a2568c45a90cc9baa471cde9a02a975d4d4fd7596bb96d272d3934"
+    },
+    "maps/ad_brk/glass14.bsp": {
+     "bytes": 23296,
+     "sha256": "e3517bb79e2561150c4641ab3650e0697adcaa2f281c5209cacdc12d9c4023a7"
+    },
+    "maps/ad_brk/glass14.map": {
+     "bytes": 462,
+     "sha256": "066d5bade73c399cf10a9dcafecec9d65ac3c6045644988cbefb104fb8e7d8c3"
+    },
+    "maps/ad_brk/glass15.bsp": {
+     "bytes": 23892,
+     "sha256": "6abc82aca32e6c8312884db42891753c8d2ad8e1d4ae9218022604eadb08708b"
+    },
+    "maps/ad_brk/glass15.map": {
+     "bytes": 993,
+     "sha256": "5c24e1763bd26d34539bc7ee527842810e4ddb6ac80f683a7b3b35ee326360d3"
+    },
+    "maps/ad_brk/glass16.bsp": {
+     "bytes": 23532,
+     "sha256": "13725c14b226297090c4f1e9949c476f601a52247bc8f6abb937a57b964462c6"
+    },
+    "maps/ad_brk/glass16.map": {
+     "bytes": 528,
+     "sha256": "03dbc7feb833831d413e7f87ed0e79625da0800659ab65ea8d3deb63de09a27d"
+    },
+    "maps/ad_brk/kn_mtrim2_1.bsp": {
+     "bytes": 25264,
+     "sha256": "99b67eeed7ece0f46b1d7b4b2309331e655eb9c1b412d3ac4bc362acb4dd8606"
+    },
+    "maps/ad_brk/kn_mtrim2_1.map": {
+     "bytes": 1455,
+     "sha256": "51018fd4ff6d00c9c2c449e32a83b8521fdc3babb2937adf6800d8e67e38b976"
+    },
+    "maps/ad_brk/kn_mtrim2_2.bsp": {
+     "bytes": 24460,
+     "sha256": "a98bdee68b3a222af0f44fc978d09e092a08953539929a6a53f1bf0e97568e74"
+    },
+    "maps/ad_brk/kn_mtrim2_2.map": {
+     "bytes": 1103,
+     "sha256": "2880a3f7becf48ae79c27ef9a05faa5c774df20a53ec5d892304bf67bc06cbbe"
+    },
+    "maps/ad_brk/kn_mtrim2_3.bsp": {
+     "bytes": 24632,
+     "sha256": "967e89f57bc011cd3b38d60d45272633cc0f773c91045b7938766ac0436ae803"
+    },
+    "maps/ad_brk/kn_mtrim2_3.map": {
+     "bytes": 1171,
+     "sha256": "40ef38fd45c3e9c750d311bb8920b938fcd9f647f2dabc58509b327514f44907"
+    },
+    "maps/ad_brk/kn_mtrim2_4.bsp": {
+     "bytes": 24452,
+     "sha256": "e4559e1e5a3118f2c949daccb96f887d64821511f5850cfa72133f84a8e04901"
+    },
+    "maps/ad_brk/kn_mtrim2_4.map": {
+     "bytes": 1036,
+     "sha256": "595513bc0fe2441cb6aa88af41d9afd7de8b94421ac6c32c546113f83be6577c"
+    },
+    "maps/ad_brk/metal01.bsp": {
+     "bytes": 8122,
+     "sha256": "11e8e340455c487150951fb4dccaf7da72d0243892948d5c22b478221ffcca23"
+    },
+    "maps/ad_brk/metal01.map": {
+     "bytes": 780,
+     "sha256": "902c31c661df8bbc1b0c410b6a8745f680e85cf91bbdb14d85244b6937be5239"
+    },
+    "maps/ad_brk/metal02.bsp": {
+     "bytes": 10022,
+     "sha256": "59b56266e73b4246c54d8cd9c4769d7345c53ae5133c45d1db94f5c771350d94"
+    },
+    "maps/ad_brk/metal02.map": {
+     "bytes": 1414,
+     "sha256": "171bfe727b6c80a4c0350fb4c87090d30c3fb1a21962b8fc9c638c47027e1fea"
+    },
+    "maps/ad_brk/metal03.bsp": {
+     "bytes": 9386,
+     "sha256": "13e3ea83c5bdbf81075328cc14543d1ab6301378cc9af56b59b67b1cc22e3a53"
+    },
+    "maps/ad_brk/metal03.map": {
+     "bytes": 1179,
+     "sha256": "89ac4002203958a9f971601586f4e4e6bdcaab7cbde62ca7fb58cf705fbdae56"
+    },
+    "maps/ad_brk/metal04.bsp": {
+     "bytes": 10655,
+     "sha256": "785ab6aed41e60072083aeee571d76796f60ec5e24d249736575007d558c10ae"
+    },
+    "maps/ad_brk/metal04.map": {
+     "bytes": 1599,
+     "sha256": "aecd2de4ce9cdb49922c58f640f3df4c48b8dc45f5e611f5d0c75a6a96bf705e"
+    },
+    "maps/ad_brk/metal05.bsp": {
+     "bytes": 8337,
+     "sha256": "82da98a887a0101d1a638d266db3c9913090b3fcaca6af5869e7063529b3066e"
+    },
+    "maps/ad_brk/metal05.map": {
+     "bytes": 905,
+     "sha256": "541a5d633be51d32bbd6580cf3fb4fcc7e9b3c38107eaffdd88896a01d249b71"
+    },
+    "maps/ad_brk/metal06.bsp": {
+     "bytes": 7898,
+     "sha256": "3fe3f66ff336ede9d9a6f4fc0f7df16b62504b25a8dea1c8adce2113e927428e"
+    },
+    "maps/ad_brk/metal06.map": {
+     "bytes": 697,
+     "sha256": "30bfd29315a3c0d8654aa1842b7f2a2a7bcdc7a5a81ff96f359a86d57a289ce9"
+    },
+    "maps/ad_brk/metal07.bsp": {
+     "bytes": 8439,
+     "sha256": "8f8a722ae0d3350bf4331fbd4a492dd4c18b3c44006289fd7c6d393282f280a1"
+    },
+    "maps/ad_brk/metal07.map": {
+     "bytes": 1508,
+     "sha256": "f2c7442255c68ae30186692cdf49bca0f1e5769587d5d2392baf3ec4708679b2"
+    },
+    "maps/ad_brk/metal08.bsp": {
+     "bytes": 8150,
+     "sha256": "028675fecfd419e8852cabe821fac1941c914bdf43110291d7a07509e77f4d26"
+    },
+    "maps/ad_brk/metal08.map": {
+     "bytes": 847,
+     "sha256": "797217e143857e0b27e1654449a5dbdc0b1a3dc46c8cafdea5ee9c5ac0cbf16c"
+    },
+    "maps/ad_brk/metal09.bsp": {
+     "bytes": 7456,
+     "sha256": "4d6fb8a19ce5a331ceb68fcfa952fa61ed3ad336002eedd788921b0daa2a7877"
+    },
+    "maps/ad_brk/metal09.map": {
+     "bytes": 649,
+     "sha256": "1fde976a2f1372d9d55350caa3285776eee897d9786f9118d5a6988010efaeca"
+    },
+    "maps/ad_brk/metal10.bsp": {
+     "bytes": 7785,
+     "sha256": "c25084ae2f159ba73e6c43041a2e050d30af70a862a9c4846b2241848a33b55f"
+    },
+    "maps/ad_brk/metal10.map": {
+     "bytes": 709,
+     "sha256": "856390903976512f1b5372f374b5c7444238a173abbedbbfeccbb675cf93ed66"
+    },
+    "maps/ad_brk/metal11.bsp": {
+     "bytes": 7918,
+     "sha256": "e939c6c80e11479887b68bb39a97e0b877514c4e9dc9b2a4a9e18303caa317f1"
+    },
+    "maps/ad_brk/metal11.map": {
+     "bytes": 797,
+     "sha256": "74528d15a51708fdca65c900096411f1d56d6472a5058458577ac04d820e9895"
+    },
+    "maps/ad_brk/metal12.bsp": {
+     "bytes": 8226,
+     "sha256": "3ceccd7aa24fc353e0ac3ccb15531c2f243c0ed246c73c44bdd8897dbdd6537e"
+    },
+    "maps/ad_brk/metal12.map": {
+     "bytes": 872,
+     "sha256": "a95f34c46729c7849e6d45d9cdf57bb49289561b6551bd2e4a39659c272343fd"
+    },
+    "maps/ad_brk/metal13.bsp": {
+     "bytes": 8121,
+     "sha256": "e02aa4c824f5d8fcdfe302a0a194cee6fcf44e2fee844c492f434bf2b7763209"
+    },
+    "maps/ad_brk/metal13.map": {
+     "bytes": 760,
+     "sha256": "bae8879296237bea635d054428a536c0297420ff3ff61f681d569b30a984e7d0"
+    },
+    "maps/ad_brk/metal14.bsp": {
+     "bytes": 10022,
+     "sha256": "4b66b133fe892c6ae6ead0c6726638e98637d71a3a9afdc4ac0546be0f2d0292"
+    },
+    "maps/ad_brk/metal14.map": {
+     "bytes": 1376,
+     "sha256": "197bd6c01b5ffc4c9e0f27e319b25b882af4f20db36612f41b006dd6db0833e1"
+    },
+    "maps/ad_brk/metal15.bsp": {
+     "bytes": 9386,
+     "sha256": "8cf7545aa3464814908c3987f51e9693f154f690ec526ed228b37b1590730e0b"
+    },
+    "maps/ad_brk/metal15.map": {
+     "bytes": 1147,
+     "sha256": "73aef82251f5b4a9548135aedb926aad6b7cff94cb3656fc8216a594a8a9f6dc"
+    },
+    "maps/ad_brk/metal16.bsp": {
+     "bytes": 10719,
+     "sha256": "af64c13135b1e1eb6d8e09607c34d6cec57a3cbf624dd76b136b505f097ecf65"
+    },
+    "maps/ad_brk/metal16.map": {
+     "bytes": 1555,
+     "sha256": "d7220fbbb33a630d03ed2514b9ee33a9d3a424f819b4977e093863ca8568b645"
+    },
+    "maps/ad_brk/metal17.bsp": {
+     "bytes": 8347,
+     "sha256": "0d21cbf9b5bc65391e00bad35368530d3d4b5f59993e2ac7d45a7edc9a2edf73"
+    },
+    "maps/ad_brk/metal17.map": {
+     "bytes": 911,
+     "sha256": "7be91013d0e57e41aff314398634043cebf8f250691b3ebc583bf373df400c2c"
+    },
+    "maps/ad_brk/metal18.bsp": {
+     "bytes": 7907,
+     "sha256": "ef0dee9c63d7bbced8c04ea40523d47fd99638905aa20a61779820b5aebd5aab"
+    },
+    "maps/ad_brk/metal18.map": {
+     "bytes": 703,
+     "sha256": "b610432a51ac6b57f19fee9df89fc7b80d5cbffa972e539d9c5f3aded3359434"
+    },
+    "maps/ad_brk/metal19.bsp": {
+     "bytes": 8450,
+     "sha256": "2796007e11c0a1b2a3430edc4e0f7edb0e721a6d906e783233c0feb54b0482e5"
+    },
+    "maps/ad_brk/metal19.map": {
+     "bytes": 1514,
+     "sha256": "9ed741344b3c651f3b8fbda1d8ee8e779bd12315feea397e938522c9750dc214"
+    },
+    "maps/ad_brk/metal20.bsp": {
+     "bytes": 8160,
+     "sha256": "38013cdb360356827ab6c296791434c537183d082feed6944665a882e622ed84"
+    },
+    "maps/ad_brk/metal20.map": {
+     "bytes": 853,
+     "sha256": "a3b28328bb043206bc048e82dba12d91c56c464b5e4e1452c6740f0df44223bf"
+    },
+    "maps/ad_brk/rock01.bsp": {
+     "bytes": 24238,
+     "sha256": "5f2c0a6ce3c58eed53c86789ff1685551cff53ca1f239bf75e3a9bc59aa95a56"
+    },
+    "maps/ad_brk/rock01.map": {
+     "bytes": 680,
+     "sha256": "db0b6a72833e12a35f518b32920fccf4fbc45120e7ab8ca3afc6e255b5d51334"
+    },
+    "maps/ad_brk/rock02.bsp": {
+     "bytes": 24250,
+     "sha256": "c6196e82e7b3e22cb687e2d6c0780f163929b5ea42b868eedcaadd40f35927f9"
+    },
+    "maps/ad_brk/rock02.map": {
+     "bytes": 760,
+     "sha256": "49531f0a1a38e03e3b46af53cfc35845878fcc171c2579f0f13d2a000ca82829"
+    },
+    "maps/ad_brk/rock03.bsp": {
+     "bytes": 24669,
+     "sha256": "9f7ab133399a3681f0b97276c7cb9883b479995c3420e5643eaedd11c88f0a0d"
+    },
+    "maps/ad_brk/rock03.map": {
+     "bytes": 929,
+     "sha256": "4158321d447c3b323f44389661ba6c763b23e26fb9541a786c3b544ad56321d9"
+    },
+    "maps/ad_brk/rock04.bsp": {
+     "bytes": 24600,
+     "sha256": "3c8b114e8ff86b8abcba235230445d885d4c28553d83e153676b2755b0300292"
+    },
+    "maps/ad_brk/rock04.map": {
+     "bytes": 878,
+     "sha256": "229d94f5f5bd81a83be5463035d30c8838d1de092923c3281e7a3a9ec4c7e9aa"
+    },
+    "maps/ad_brk/rock05.bsp": {
+     "bytes": 24254,
+     "sha256": "6bdc990b90f24ddd77034a4cbdd4d7158e05df70e6db5e793ca990a40cd29709"
+    },
+    "maps/ad_brk/rock05.map": {
+     "bytes": 684,
+     "sha256": "708a6ad98116a72ddc862c6c99cbd59342446636c9579a00bd6c34efa1ac855b"
+    },
+    "maps/ad_brk/rock06.bsp": {
+     "bytes": 24462,
+     "sha256": "e2e3688c3cb66e2c9d738d211ad328d86963e1d67881354363696698a07be32b"
+    },
+    "maps/ad_brk/rock06.map": {
+     "bytes": 816,
+     "sha256": "5e1a399ac2e6a179a84004539f15172012db93477e5544309b01ed24cbc59f34"
+    },
+    "maps/ad_brk/rock07.bsp": {
+     "bytes": 24281,
+     "sha256": "ea3569e42b755fd1b9fde50e2740f6aa95d1dabb1911f8a4ab5b1c5028a4e1e3"
+    },
+    "maps/ad_brk/rock07.map": {
+     "bytes": 777,
+     "sha256": "02f61c60083f5007fa9d4d7a38adf2901e928a96adbfeaa7646711f21cc75409"
+    },
+    "maps/ad_brk/rock08.bsp": {
+     "bytes": 25096,
+     "sha256": "5468a365153fc7f160d7e1792b9bc9164b828a51851bd1e9744eb0cf3a7a842d"
+    },
+    "maps/ad_brk/rock08.map": {
+     "bytes": 1060,
+     "sha256": "b285f3a79407366944213b3d8eef311c662bf2eb0cf3df0ee3104e747a3c9150"
+    },
+    "maps/ad_brk/rock09.bsp": {
+     "bytes": 8314,
+     "sha256": "4320c73f55d67e4db7e596614b74b05b0c086cd57186ecaf183c96fca51106bf"
+    },
+    "maps/ad_brk/rock09.map": {
+     "bytes": 913,
+     "sha256": "629fab0d0f8022138ff5d5e573f0e3ab0f75397f120015b3f8a95a297c857911"
+    },
+    "maps/ad_brk/rock10.bsp": {
+     "bytes": 7930,
+     "sha256": "7657ad82fbdeaceb354e04f60fa76cfd3d8a7a819607a413afaa6fc16253a009"
+    },
+    "maps/ad_brk/rock10.map": {
+     "bytes": 780,
+     "sha256": "833bc2f2460f5f5ef444630b398a59974831031e408f986125a5241fab52ba99"
+    },
+    "maps/ad_brk/rock11.bsp": {
+     "bytes": 8565,
+     "sha256": "e19573b67e5dedba499da8f6d0d63ca0e829593417a1ce66e1aeb1fd2b2d1e76"
+    },
+    "maps/ad_brk/rock11.map": {
+     "bytes": 1016,
+     "sha256": "040c31d22159743b28e9f20946b34db390ef15bbe530882342638b9325542801"
+    },
+    "maps/ad_brk/rock12.bsp": {
+     "bytes": 8284,
+     "sha256": "f03a3a0184b2fa8809154754f85d81d30777261714976bdd64340b0549d3ca35"
+    },
+    "maps/ad_brk/rock12.map": {
+     "bytes": 898,
+     "sha256": "b7d2b1bba22ad5b621e699a8233a83d23415e5c6e88fec8e1525a9c84a494bf0"
+    },
+    "maps/ad_brk/rock13.bsp": {
+     "bytes": 7917,
+     "sha256": "6710c24df905df9ede31faf75fdf9a070efbdc471e58a295740092863dcb50fa"
+    },
+    "maps/ad_brk/rock13.map": {
+     "bytes": 680,
+     "sha256": "369735b7ebd630e6407371d3ab7195ef368c2f8d8d3469943b2c5e46b8e24fa5"
+    },
+    "maps/ad_brk/rock14.bsp": {
+     "bytes": 7929,
+     "sha256": "a17329c593e306d1aa4084cd2651983f53258b3e5759443efe3bb3b4daecc5f8"
+    },
+    "maps/ad_brk/rock14.map": {
+     "bytes": 760,
+     "sha256": "f86556e799f3a0240294537aa487526c674486afb7190bb705d72453cade7e68"
+    },
+    "maps/ad_brk/rock15.bsp": {
+     "bytes": 8349,
+     "sha256": "d64f11606da6b94024382315eead25dbfe19c8cc90844f60e755e2bd106c7fc0"
+    },
+    "maps/ad_brk/rock15.map": {
+     "bytes": 929,
+     "sha256": "23defe1bddcc8db664c819b60657fd536b1c44b118299495d42f7c54f740e7b0"
+    },
+    "maps/ad_brk/rock16.bsp": {
+     "bytes": 8280,
+     "sha256": "87e60c650a672c5ffe57b64c7ae3c5413799972a2ca5b73935cb0d1dad16f62c"
+    },
+    "maps/ad_brk/rock16.map": {
+     "bytes": 878,
+     "sha256": "d3616ad7b423be757f6f7873791f4c452a09243b53569347bd36e87f1a942947"
+    },
+    "maps/ad_brk/rock17.bsp": {
+     "bytes": 8340,
+     "sha256": "b317f3432532e6f6f327852fa0c7f546726c8b23c44cfc3e86869d64eb33235c"
+    },
+    "maps/ad_brk/rock17.map": {
+     "bytes": 913,
+     "sha256": "a534b032b611965c86cd81fda18d53186c474d55184f9c4c74cd292b4b207f27"
+    },
+    "maps/ad_brk/rock18.bsp": {
+     "bytes": 7924,
+     "sha256": "e5fc24e393828bdd2c24e3cb341e0c21e81511881e65424293206fe20ff54c4e"
+    },
+    "maps/ad_brk/rock18.map": {
+     "bytes": 701,
+     "sha256": "bf5974bf04067482dde83a2fd73e58a011de04220b32866fa7913e901a0e944c"
+    },
+    "maps/ad_brk/rock19.bsp": {
+     "bytes": 8620,
+     "sha256": "4a1d3e4e37f29438981f419f5a5f076fcf53227a4da544e919061d6c6bf8702e"
+    },
+    "maps/ad_brk/rock19.map": {
+     "bytes": 919,
+     "sha256": "c2626204acbd33e3299c29cd1f8a5279bbe8cd07a621f6b40b14b74b7808f444"
+    },
+    "maps/ad_brk/rock20.bsp": {
+     "bytes": 8785,
+     "sha256": "87bfda54a9f0711eedcefc6d8e691b6cac8123958db03735bd0364067445de69"
+    },
+    "maps/ad_brk/rock20.map": {
+     "bytes": 1118,
+     "sha256": "225800378c3183d5ba423140d7f5d510cf387df3df795fda69294fcb0e4bec4c"
+    },
+    "maps/ad_brk/rock21.bsp": {
+     "bytes": 24244,
+     "sha256": "161b5893f3f413969ced051a7e7aa3d816a1da9f74bffa5d0642830713d83031"
+    },
+    "maps/ad_brk/rock21.map": {
+     "bytes": 674,
+     "sha256": "db86b019086636ec085b3690bc4b252d8bac2443c0ff138a6f3b6c79e522a94b"
+    },
+    "maps/ad_brk/rock22.bsp": {
+     "bytes": 24256,
+     "sha256": "b41069e88c74ef3bfb7c5f2817c31d9d374cd1725b7270b9ac7d93c58dd34a11"
+    },
+    "maps/ad_brk/rock22.map": {
+     "bytes": 753,
+     "sha256": "aa059dd13499512fdda512b68e79068f390d1870726763958a81a54c91aeb254"
+    },
+    "maps/ad_brk/rock23.bsp": {
+     "bytes": 24676,
+     "sha256": "aac7fc5557dd385c52043d206d39d83b48e0b2f6db2822de2060f2a978be4a9d"
+    },
+    "maps/ad_brk/rock23.map": {
+     "bytes": 920,
+     "sha256": "744ccf1456c3b19318289586238b1d36e4968dbfe444f5a489e1d2202f1965d4"
+    },
+    "maps/ad_brk/rock24.bsp": {
+     "bytes": 24612,
+     "sha256": "90553422561893d50030520bcf796da9290933e53570e313d1a423aec01c8ac6"
+    },
+    "maps/ad_brk/rock24.map": {
+     "bytes": 939,
+     "sha256": "3f8f5c2053315577eda81360a9ed9a095e96f7d9a6288eed876400a91bc0922b"
+    },
+    "maps/ad_brk/rock25.bsp": {
+     "bytes": 89516,
+     "sha256": "ef87b49e322fd2a2251f0ee7ecedec32bae141ea7a589769c6fba6a3176da0d4"
+    },
+    "maps/ad_brk/rock25.map": {
+     "bytes": 737,
+     "sha256": "3cad88a720acc4d7db1666ab0d865e013717776a256c999e1b417690679f4f0b"
+    },
+    "maps/ad_brk/rock26.bsp": {
+     "bytes": 89532,
+     "sha256": "a6f46aa8183937dfe19eb1cfde621bac8f3f08721effcbbd195ba251b3b1467f"
+    },
+    "maps/ad_brk/rock26.map": {
+     "bytes": 823,
+     "sha256": "27c411424182d3e6d611f2eff2dd9a7c75ef2135f2019d4aca40b2dee2d134b5"
+    },
+    "maps/ad_brk/rock27.bsp": {
+     "bytes": 89952,
+     "sha256": "f55dc66117c856efee1dae5e311492f2aae2839ef4588af45ac0818307ad564c"
+    },
+    "maps/ad_brk/rock27.map": {
+     "bytes": 1004,
+     "sha256": "7368f6cbd051aa3ac71237b5c8d3da2ef73fc3017024ef42af6ac8af9ddc1139"
+    },
+    "maps/ad_brk/rock28.bsp": {
+     "bytes": 89880,
+     "sha256": "2132d7f311c90f8c43b4630a55f7fa0b15141fa0e9c26c0309c8023437377961"
+    },
+    "maps/ad_brk/rock28.map": {
+     "bytes": 947,
+     "sha256": "b1571df2e370ca2d51f19b3608726552f10a6f6da64f69929a2ea2c1884e51dc"
+    },
+    "maps/ad_brk/rock29.bsp": {
+     "bytes": 89516,
+     "sha256": "a179ac329768d445bfbc36bb9c3e47ce3c7506c31337730a93c9a58f96ea5399"
+    },
+    "maps/ad_brk/rock29.map": {
+     "bytes": 737,
+     "sha256": "260d08f376c81869c1f9a0c0cfd677bded9022f79bbe4e607d12128b7ad7c746"
+    },
+    "maps/ad_brk/rock30.bsp": {
+     "bytes": 89532,
+     "sha256": "febc6ed2ec191f8dcbae1ee9df9d13bbd8fff830e28e051236fa24fd211829ee"
+    },
+    "maps/ad_brk/rock30.map": {
+     "bytes": 823,
+     "sha256": "da6a3224e060f6413f70ac9f6f25bf96f3784f690084d602d63805dc8b43e7e8"
+    },
+    "maps/ad_brk/rock31.bsp": {
+     "bytes": 89952,
+     "sha256": "7a38ed8a7dd80c2f2dab17342bfdde51300c9225f4e93be78ca9b63d3a7f1e99"
+    },
+    "maps/ad_brk/rock31.map": {
+     "bytes": 1004,
+     "sha256": "3fb04740e6da6c00670536ccbcb92e7a9a5b5e3072e78af96d6dd5c79d39f984"
+    },
+    "maps/ad_brk/rock32.bsp": {
+     "bytes": 89880,
+     "sha256": "41789fbb095ef6d7b09ba6f50bea0503f73e612808f37bbb71f4a7e9fea00ae2"
+    },
+    "maps/ad_brk/rock32.map": {
+     "bytes": 947,
+     "sha256": "37e272ad3f235bb182666e46d3b087bee4ec23ebdc716647c5b0ffb671a9ee1d"
+    },
+    "maps/ad_brk/rock33.bsp": {
+     "bytes": 7916,
+     "sha256": "af3e313ba1c7013b7bd2234e9988a2b6bc451d123e7d6dab1692ae0727d40bec"
+    },
+    "maps/ad_brk/rock33.map": {
+     "bytes": 683,
+     "sha256": "de08059147e865be402e6dac4c6d8a0bea1de05bb65cf0455153386afdde2bdb"
+    },
+    "maps/ad_brk/rock34.bsp": {
+     "bytes": 7932,
+     "sha256": "392125c9afaf18c3084c1b13a0a55dcda7e2294da37f84fb73983826271dea27"
+    },
+    "maps/ad_brk/rock34.map": {
+     "bytes": 763,
+     "sha256": "dc402e2573ee3e94f3ed96274d5b6f8d0177d9745716ea96d0ffce8e0be5c943"
+    },
+    "maps/ad_brk/rock35.bsp": {
+     "bytes": 8352,
+     "sha256": "0352c35aa723330a3c05126d24a8e6b84403bf8b71d406f3fa5a2ff3fc0da39a"
+    },
+    "maps/ad_brk/rock35.map": {
+     "bytes": 932,
+     "sha256": "9841ed50187bbdfb3a7122d3b0890b0245d64dd4919485686fdf5ce61bdae3e6"
+    },
+    "maps/ad_brk/rock36.bsp": {
+     "bytes": 8280,
+     "sha256": "f1871698ef7597c51fed5d54b582df2ea70cf72e2fa7db643182e59f7e7f6ca7"
+    },
+    "maps/ad_brk/rock36.map": {
+     "bytes": 881,
+     "sha256": "974aaec9003dd3e1457582b1f770d67e07fc8e9d11a6b639981fbb753c6a6484"
+    },
+    "maps/ad_brk/sandstone01.bsp": {
+     "bytes": 24239,
+     "sha256": "ebb374110d88805e1b0b45cdaf33e5e570a9092da549facaf9f5ddcd995eb607"
+    },
+    "maps/ad_brk/sandstone01.map": {
+     "bytes": 702,
+     "sha256": "9ea9ab63b8c6a2d90fba029c4d4b768beb0d4342cf255bb5005185b61b1bcfd2"
+    },
+    "maps/ad_brk/sandstone02.bsp": {
+     "bytes": 24399,
+     "sha256": "2fa799b0a08ca2fdd9bef3ecb9d6ea4c16e8f66181d29913cdc5a9205bafe98f"
+    },
+    "maps/ad_brk/sandstone02.map": {
+     "bytes": 842,
+     "sha256": "5228b0a958ef571f33838366ef1f2b69a10f6e0c53a3269dba683b5326a95e5f"
+    },
+    "maps/ad_brk/sandstone03.bsp": {
+     "bytes": 24607,
+     "sha256": "671b8f740ba9deaeac681c703f87d61c2a3f8107d0f72b8fd636c53436555110"
+    },
+    "maps/ad_brk/sandstone03.map": {
+     "bytes": 914,
+     "sha256": "7523ff7908eb3e47154155d0448fa05d4d9b6081525069a131e7d44ea9b13c0c"
+    },
+    "maps/ad_brk/sandstone04.bsp": {
+     "bytes": 24379,
+     "sha256": "56bda0f4bf4958dc243fa9b4ab79e9e3bd6fad5f794af7beb024a6cbe7f9a0cb"
+    },
+    "maps/ad_brk/sandstone04.map": {
+     "bytes": 798,
+     "sha256": "d01584bd00868a0a69ae7513834f776566fce273d8919d9c78d0bdafbb07a799"
+    },
+    "maps/ad_brk/wood01.bsp": {
+     "bytes": 7553,
+     "sha256": "c1764181bae4852804097143fe16a4c230bd5886574125cb33d5349bbc63dc21"
+    },
+    "maps/ad_brk/wood01.map": {
+     "bytes": 1040,
+     "sha256": "05f1ebaa57c4b55e6c3da9c5440c180aa96c719f9cddc80c780ed11415ad6bd7"
+    },
+    "maps/ad_brk/wood02.bsp": {
+     "bytes": 7079,
+     "sha256": "26fc67e4e47eae3a13a449d876deabe35d50aa1b70e63060d27cb365eadecbe0"
+    },
+    "maps/ad_brk/wood02.map": {
+     "bytes": 521,
+     "sha256": "8dee7615c9e9696420331668edeccd9ff1dd874ad844e289f049391be5e61345"
+    },
+    "maps/ad_brk/wood03.bsp": {
+     "bytes": 7135,
+     "sha256": "ca17df0f61a11bd37749587e361ca404f2e5bec07c248491d86c07803fafb732"
+    },
+    "maps/ad_brk/wood03.map": {
+     "bytes": 522,
+     "sha256": "0fb4cdb1ffeda8c97026d40842d5fcb0beced0f84dae4b10a8284044875cf0c2"
+    },
+    "maps/ad_brk/wood04.bsp": {
+     "bytes": 7951,
+     "sha256": "e2d9f42bf3256be2dd38648dbd962458bdad3992b33e8d688e42a0acba5d7c3f"
+    },
+    "maps/ad_brk/wood04.map": {
+     "bytes": 912,
+     "sha256": "071556b1cac3bd95a176762302e6a60ddbbfb07cf6c9e4b2f8cf2e259e23402a"
+    },
+    "maps/ad_brk/wood05.bsp": {
+     "bytes": 7553,
+     "sha256": "5bdb275ae2c39b41d71a17244681cda9cc2008df088f4da73f547a8bf1966069"
+    },
+    "maps/ad_brk/wood05.map": {
+     "bytes": 1040,
+     "sha256": "ada27de98972730676a2d040fd284893fabfe71acd6fcbce1f2ba12da7d14632"
+    },
+    "maps/ad_brk/wood06.bsp": {
+     "bytes": 7079,
+     "sha256": "f27b0f1970f6065255b5f7a27abfc4e749f40321f6fdef4c3f9ac6bb64d46098"
+    },
+    "maps/ad_brk/wood06.map": {
+     "bytes": 521,
+     "sha256": "17c93b1c1c65a7507d794013078a1d12a67c3a24ae7202739fcd8a1108d52419"
+    },
+    "maps/ad_brk/wood07.bsp": {
+     "bytes": 7135,
+     "sha256": "8e07e7e5f5b641c644d28c9c4026efc95aa50345074f5c42acd39a3b94261344"
+    },
+    "maps/ad_brk/wood07.map": {
+     "bytes": 522,
+     "sha256": "55f1bb5f18ed30f28ac88349aee9ea5563b1e938bafebffb25c9ab5a1c918b33"
+    },
+    "maps/ad_brk/wood08.bsp": {
+     "bytes": 7951,
+     "sha256": "d26222458ba6e7fee06670021e64c1661d99a8c098581936af943891c9583858"
+    },
+    "maps/ad_brk/wood08.map": {
+     "bytes": 912,
+     "sha256": "2582987129d34bbee73594a236c4c09ce6ae1092eec649ef3957b892e125624c"
+    },
+    "maps/ad_brk/wood09.bsp": {
+     "bytes": 7282,
+     "sha256": "2735e78b25b0feb640f27eddae47104b0acba9f017c6d025e3a8dbdfcc755778"
+    },
+    "maps/ad_brk/wood09.map": {
+     "bytes": 541,
+     "sha256": "84d9789b4d79b41347fd082b0ab75c016553c03bfb952cf4b9c7dd18c85944ce"
+    },
+    "maps/ad_brk/wood10.bsp": {
+     "bytes": 7214,
+     "sha256": "43b59e9b0cb02fb1ac15afb5c782e71b4ce0661db295949b5188cc5accd1733a"
+    },
+    "maps/ad_brk/wood10.map": {
+     "bytes": 533,
+     "sha256": "365f949e19e2606cf2d7a354c3e4368a5e17c3eef94e2558ed9cef276e987d35"
+    },
+    "maps/ad_brk/wood11.bsp": {
+     "bytes": 7196,
+     "sha256": "cce8b312c4be49810f4cf90f0dcdeb1a82dfa623de1ba44c55ec83475f9e9e49"
+    },
+    "maps/ad_brk/wood11.map": {
+     "bytes": 542,
+     "sha256": "790cd93cb271402698ad7f005b908847fddbb30d3c8c3d11fa8c2f327ca8e48e"
+    },
+    "maps/ad_brk/wood12.bsp": {
+     "bytes": 7978,
+     "sha256": "6a227f92bf3b6f1120efd6179bfb3de977e4be2e59495c5d757cbe1c835e3f03"
+    },
+    "maps/ad_brk/wood12.map": {
+     "bytes": 986,
+     "sha256": "01ed96a5ce6545b334dfac7dc0196472dd6c06df09ed557cec7dc820d35c1132"
+    },
+    "maps/ad_brk/wood13.bsp": {
+     "bytes": 7284,
+     "sha256": "09325ca10ebcfeb88f688c9f4521259c3c3426e9befc06c99ba405c7e20595c9"
+    },
+    "maps/ad_brk/wood13.map": {
+     "bytes": 526,
+     "sha256": "b16b33b2a46b72a4ee235674780298eac0ed27631def07a28058a775aba7078e"
+    },
+    "maps/ad_brk/wood14.bsp": {
+     "bytes": 7216,
+     "sha256": "4c9dc5afd7b51119e5c22ad36eb77d07881c454ff47ed060521172cfc3950e2c"
+    },
+    "maps/ad_brk/wood14.map": {
+     "bytes": 518,
+     "sha256": "41b51f20630df3c046ed9ca0f7d97ca403ce8c1487074fc80caf603e763e6ac1"
+    },
+    "maps/ad_brk/wood15.bsp": {
+     "bytes": 7196,
+     "sha256": "373f6e5c5da44b7c8d1a01fb701f074bbcfc52d21bb080dd04e986ffe9e1088c"
+    },
+    "maps/ad_brk/wood15.map": {
+     "bytes": 527,
+     "sha256": "eb07eae6f0afdb4b03af57bcb589e3b385632912f12d4c55257b3031270f0421"
+    },
+    "maps/ad_brk/wood16.bsp": {
+     "bytes": 7612,
+     "sha256": "05959d3486eb43afc8959f6923156a1a83ead4dad544f8caf90ba0e1c7e2bc80"
+    },
+    "maps/ad_brk/wood16.map": {
+     "bytes": 953,
+     "sha256": "c7e804e781c95336cc91a50bc246baf4fda7172ecf36ccf24f02c5f919710ab3"
+    },
+    "maps/base_brk/baserub1.bsp": {
+     "bytes": 23612,
+     "sha256": "b5320b798366587d20ab541af06babd9575e89870fb003d56a17fdf2f7f22b0c"
+    },
+    "maps/base_brk/baserub1.map": {
+     "bytes": 637,
+     "sha256": "0a5357fb3b12d9286b4d9e6e54316cfd0a33f9fda4c661b8fcd1c461d06ae73f"
+    },
+    "maps/base_brk/bz8_brk.bsp": {
+     "bytes": 12808,
+     "sha256": "219e4371cd0b22d690c6e6660ca2fca3b526618d4ccd9f37799135d2dc6dea02"
+    },
+    "maps/base_brk/bz8_brk.map": {
+     "bytes": 692,
+     "sha256": "fae1ac45d74b2a9f482eb034e0838fe5914affb57204c5215d97ebaf7199e5c8"
+    },
+    "maps/base_brk/crate_r1.bsp": {
+     "bytes": 29110,
+     "sha256": "5dd3afab4a3ad5cf4466e272324e4afad5075ca2e662cc8b1932e277a2db73a2"
+    },
+    "maps/base_brk/crate_r1.map": {
+     "bytes": 664,
+     "sha256": "ee7ce39ec0650d3cbde924b99efc91ba884778db11a961037d4493bf587fa33e"
+    },
+    "maps/base_brk/explodebox_1.bsp": {
+     "bytes": 7707,
+     "sha256": "28bfab37e5cbe722348b753de3bd9f66f47f4a9f5b80bd5c5c1659e6eae7e6c4"
+    },
+    "maps/base_brk/explodebox_1.map": {
+     "bytes": 544,
+     "sha256": "96376f1185f158bf69d6bb0c5baf347bbad27f0ccd6fccd3096da6dd7f89540b"
+    },
+    "maps/base_brk/explodebox_2.bsp": {
+     "bytes": 7107,
+     "sha256": "59d5ba28bc049f691bf28d421327e4aecf5eedaec46599d58328f0074ce0934f"
+    },
+    "maps/base_brk/explodebox_2.map": {
+     "bytes": 375,
+     "sha256": "f906dbea8598f0290af9e224a70eb71f26f3c93c10e922b2fade3f1c63e4ddd5"
+    },
+    "maps/base_brk/explodebox_3.bsp": {
+     "bytes": 10449,
+     "sha256": "0daebb987f48b5dde145998e748ab2eecf63ec69318a6b752924e4cfb6639261"
+    },
+    "maps/base_brk/explodebox_3.map": {
+     "bytes": 1698,
+     "sha256": "538e12e7706df3b8f539bf2473e7517e737657380137de1655193843210dbf3f"
+    },
+    "maps/base_brk/glass01.bsp": {
+     "bytes": 7427,
+     "sha256": "bf3f3938ab3596b6095fb58f66c0a36042e5950169dbb86b1cf3cb9076fd5bdd"
+    },
+    "maps/base_brk/glass01.map": {
+     "bytes": 907,
+     "sha256": "6f47c3ffec4cb28d3447dbf96f0b3d6e4264accd31e10b68ad83b3e30e4e32a7"
+    },
+    "maps/base_brk/grate_r1.bsp": {
+     "bytes": 32796,
+     "sha256": "a8eac6a49f8c49c4f9f1b443c9ca5c6a5f8d03d30ce240daaeee8d150f9c5067"
+    },
+    "maps/base_brk/grate_r1.map": {
+     "bytes": 2106,
+     "sha256": "e5cac190d45b0d14901947e489622680d1b9436955b18e2a0e8cb2f92e9aa011"
+    },
+    "maps/base_brk/pbt04.bsp": {
+     "bytes": 18286,
+     "sha256": "0a3321e606857ebb78d047be51c92036b53175dc392c021891cdeabd28597c3c"
+    },
+    "maps/base_brk/pbt04.map": {
+     "bytes": 699,
+     "sha256": "a8b2d3feef56b8cad384a88a9646b596d21017cb9d26278c0b3585ef589b578d"
+    },
+    "maps/base_brk/phk_03brk.bsp": {
+     "bytes": 90417,
+     "sha256": "46efed3a00ce885798ca568563a04472200359c6111682e91fc701c37d8df143"
+    },
+    "maps/base_brk/phk_03brk.map": {
+     "bytes": 1509,
+     "sha256": "29549a0e23b3651110beae8f8697c85e1e3eeb8752dcc8c253a2756e11189209"
+    },
+    "maps/base_brk/rock_sw01.bsp": {
+     "bytes": 8843,
+     "sha256": "a3acc4f42ca89efb30d5f9d7ed7c694d59ab6003bd3c665cfa4db480550fd92d"
+    },
+    "maps/base_brk/rock_sw02.bsp": {
+     "bytes": 9179,
+     "sha256": "4b3d68587a69daa68093d32195a786e8040fed763855acb94f50d02875a8ec44"
+    },
+    "maps/base_brk/rock_sw03.bsp": {
+     "bytes": 9766,
+     "sha256": "59d2841166f7ecb216df970963b3e425da20566f2fb56a7e5472f4e3c9fcfb24"
+    },
+    "maps/base_brk/sfloor4_2.bsp": {
+     "bytes": 7431,
+     "sha256": "d4f7ee45638e0f338c96cf43779410a112bb10be26a200e24187749a80b01332"
+    },
+    "maps/base_brk/sfloor4_2.map": {
+     "bytes": 833,
+     "sha256": "f285b9a96b32420f24bccb267b268e65afd50dd03fb106fad90783aa5d82c1d4"
+    },
+    "maps/base_brk/tech10_2d1.bsp": {
+     "bytes": 45558,
+     "sha256": "272aa49909de27f7b4722848497e5da38aa50b7bef17ef2ee81a1b1240c1b8b2"
+    },
+    "maps/base_brk/tech10_2d1.map": {
+     "bytes": 740,
+     "sha256": "a3766904240cbe7603e967eb3ebdd0dc895b035f0db8758a6ad217749a332904"
+    },
+    "maps/base_brk/tech10_2d2.bsp": {
+     "bytes": 45552,
+     "sha256": "71e5e52660e4aa84f56aa7b51bad024384acb69699bcec431ae3fe6c8d16fc42"
+    },
+    "maps/base_brk/tech10_2d2.map": {
+     "bytes": 733,
+     "sha256": "9d6c4dae495d96bf4b2bbf5f7e01900f16274173c63eb2e4acfb8f8e757a399f"
+    },
+    "maps/medieval_brk/ad_column1.bsp": {
+     "bytes": 14800,
+     "sha256": "f94c99425b3987ebb9eea08dd8c1b3c0e0215cc8afcd1099f7283324ff566712"
+    },
+    "maps/medieval_brk/ad_column1.lit": {
+     "bytes": 578,
+     "sha256": "c30b5af83ab23db6614ad13aff712a15971a6b35ae29ddd49f0cd3da1c1f4919"
+    },
+    "maps/medieval_brk/ad_column1.map": {
+     "bytes": 1541,
+     "sha256": "d71326b819e902d9a32f4a1961565f6ebb10d90069ba2ae0dc0be381a4c1b764"
+    },
+    "maps/medieval_brk/ad_rock1.bsp": {
+     "bytes": 352852,
+     "sha256": "9333d2d2d848e3a4490634aa4f1cc1ee3281c57ac9a498c85b043e5856ce2578"
+    },
+    "maps/medieval_brk/ad_rock1.lit": {
+     "bytes": 920,
+     "sha256": "6d2b33cbd7b3ce1a35c25a6e006a0786fe0bd0ea8be34b1911e2663ac33ea910"
+    },
+    "maps/medieval_brk/ad_rock1.map": {
+     "bytes": 2163,
+     "sha256": "d00049f1c1bdf04d98e768ece39b7d7442e34b719ec991e5715df588d6493d8b"
+    },
+    "maps/medieval_brk/ad_rock2.bsp": {
+     "bytes": 14728,
+     "sha256": "52675efa81ecae4bb87524c97148d7da60916f0e0dc3c65e99b73745aea70fec"
+    },
+    "maps/medieval_brk/ad_rock2.lit": {
+     "bytes": 383,
+     "sha256": "306d2df8cbd9d7ad755fe7e4a6734e0089b38eefa2e2e4fccacfb68c96dd8d90"
+    },
+    "maps/medieval_brk/ad_rock2.map": {
+     "bytes": 1528,
+     "sha256": "891f208f7fdae3fcf1defe7a4cdcda7a6084fbde663ed4e2ab015af18911cb96"
+    },
+    "maps/medieval_brk/ad_rock3.bsp": {
+     "bytes": 352160,
+     "sha256": "bf041a139ed9be638cd1c548139fffca3ceeddefdad2334fcc2639018833110a"
+    },
+    "maps/medieval_brk/ad_rock3.lit": {
+     "bytes": 356,
+     "sha256": "19a61c05d08dd726a9d00174eb3eb1dbdd16da3e0e62ab93d691620aa71add83"
+    },
+    "maps/medieval_brk/ad_rock3.map": {
+     "bytes": 1878,
+     "sha256": "d0049b763f7fd8f25b2176984341421d704f9b50571b24168c60889fdbad5e20"
+    },
+    "maps/medieval_brk/ad_rock4.bsp": {
+     "bytes": 352704,
+     "sha256": "578e7d2dc0eff7bf5ac21b04919d1e137296824182d4809991a27a83addeba75"
+    },
+    "maps/medieval_brk/ad_rock4.lit": {
+     "bytes": 311,
+     "sha256": "3af5d5c9613dd5a1fa09a40b02891bf7153892db8505528b7d3315ce251bfff7"
+    },
+    "maps/medieval_brk/ad_rock4.map": {
+     "bytes": 1889,
+     "sha256": "472f41679eedc00096e8042935ad5287f4598940ef294b8175cccd196dcb6f86"
+    },
+    "maps/medieval_brk/az_ice05.bsp": {
+     "bytes": 98664,
+     "sha256": "b8b2aa063250f6dcc388ead43ff66133c8fa14b1c30afa17c2fce8f2b2c9fd81"
+    },
+    "maps/medieval_brk/az_ice05.lit": {
+     "bytes": 617,
+     "sha256": "e3e8aa044b60a26d643ff87937f83602cdffcebb948ea7ae22148e7952faa18b"
+    },
+    "maps/medieval_brk/az_ice05.map": {
+     "bytes": 3094,
+     "sha256": "dbca0fea0a986137f9b4a6fbb916cf3de830ba4a60738830cc6e1bd554f561f1"
+    },
+    "maps/medieval_brk/az_kbr1.bsp": {
+     "bytes": 7476,
+     "sha256": "2a2cd33b87f511d4c7fc25a812c632fb07c385b372e89fa900fd0f8ce8146076"
+    },
+    "maps/medieval_brk/az_kbr1.lit": {
+     "bytes": 92,
+     "sha256": "580ff7adf91b63bcd7f35e27059295b0a5fc404468e32e5d5f3323b5a822fb27"
+    },
+    "maps/medieval_brk/az_kbr1.map": {
+     "bytes": 863,
+     "sha256": "3b9d9842f17fb140b23337b452cfc8d49151410640384868a0003bd472dd0d5c"
+    },
+    "maps/medieval_brk/az_kbr1.pts": {
+     "bytes": 178,
+     "sha256": "22cf782552b8a3da946cfa0fa044cffd08f2b0ab50e588c9b68d89a373f026b0"
+    },
+    "maps/medieval_brk/az_kjw1.bsp": {
+     "bytes": 9424,
+     "sha256": "06f271813935ecb90a425d6c943bd53b207fb9d370ec42bb1228af92fe4413d1"
+    },
+    "maps/medieval_brk/az_kjw1.lit": {
+     "bytes": 380,
+     "sha256": "30e6270550b5a78bfaa31df0c6e477d6980eefd380abc2e2aaf7003dbe544f77"
+    },
+    "maps/medieval_brk/az_kjw1.map": {
+     "bytes": 1825,
+     "sha256": "61e8f8f45b2fb0e0766b125bae58b54b36cb45b6d856c7c06814681f52eb91aa"
+    },
+    "maps/medieval_brk/az_kjw1.pts": {
+     "bytes": 120,
+     "sha256": "f7d0f45d90befed57df8dd476bcd10293481eb932925853e3fdbc93a55991a49"
+    },
+    "maps/medieval_brk/az_rtex01.bsp": {
+     "bytes": 97932,
+     "sha256": "ce36fbfdd6f46f5aa7740598689fb2c7de50fa58adda9d4a8a3023ad31194367"
+    },
+    "maps/medieval_brk/az_rtex01.lit": {
+     "bytes": 692,
+     "sha256": "5fe28d309679e9871f14a9c3833184c9ad711fa2bd93adc330a34fd599032a6d"
+    },
+    "maps/medieval_brk/az_rtex01.map": {
+     "bytes": 2875,
+     "sha256": "6cc8f787b54565b3c9dffe9eec20c44d66a68b12fd555bad65bb25f03a2aa7e9"
+    },
+    "maps/medieval_brk/az_wood1.bsp": {
+     "bytes": 7560,
+     "sha256": "373c0b96905055b6b036272c954d7eaf3557d79d62b056ab9a472fb0cd27de83"
+    },
+    "maps/medieval_brk/az_wood1.lit": {
+     "bytes": 176,
+     "sha256": "67ce559200158ce198e5a93a94dd4a440ae607fedc5b3093c288049ce5f50151"
+    },
+    "maps/medieval_brk/az_wood1.map": {
+     "bytes": 950,
+     "sha256": "4fb7eae852ba72528b34d6a0947497eeeab1e1307aa1c4be552628432007c86e"
+    },
+    "maps/medieval_brk/azr1.bsp": {
+     "bytes": 13842,
+     "sha256": "e00518c5ad3beee852a6135184423d4ca985b17b2f1d2cfebc60e82f91582f26"
+    },
+    "maps/medieval_brk/azr1.map": {
+     "bytes": 1193,
+     "sha256": "ef3affe9788b130826f2b1632b5461eaaf15d630587c12c5a875f6042b0ae99c"
+    },
+    "maps/medieval_brk/azr2.bsp": {
+     "bytes": 13571,
+     "sha256": "687097f4773430ca297db9c1d8133b035c8ca1e5d574943a4caa34eef262f003"
+    },
+    "maps/medieval_brk/azr2.map": {
+     "bytes": 1319,
+     "sha256": "22b2084665b2882c976da1dc840a19b151cd44daa524955ddab9ec64e9c3233e"
+    },
+    "maps/medieval_brk/azr3.bsp": {
+     "bytes": 13571,
+     "sha256": "187a6607641c00aa6ee662af52f1b2899d5ca606e469408dd2c94d67dd2ab465"
+    },
+    "maps/medieval_brk/azr3.map": {
+     "bytes": 1338,
+     "sha256": "5e551a8ebefc386b1336e814a44e29ae6781e6da5bc929cb232674853c46a143"
+    },
+    "maps/medieval_brk/booksh1w_brk1.bsp": {
+     "bytes": 23869,
+     "sha256": "dbc342e95245a12598aade308195a3234829225944692c45c8fec792d03f17c3"
+    },
+    "maps/medieval_brk/booksh1w_brk1.map": {
+     "bytes": 793,
+     "sha256": "a9d2fe494267551f3d1638c7963bab47d292be250417f78286b39059af836af5"
+    },
+    "maps/medieval_brk/booksh1w_brk2.bsp": {
+     "bytes": 23663,
+     "sha256": "4b8cd15ae7812d581064800bbcf64cab62c3d5ecfb03c23ff2b498694a0cb708"
+    },
+    "maps/medieval_brk/booksh1w_brk2.map": {
+     "bytes": 661,
+     "sha256": "19c13935f0b045fadd9c739680de7155f0e4d29c86ef3e6950d07f265b1ef1a3"
+    },
+    "maps/medieval_brk/booksh1w_brk3.bsp": {
+     "bytes": 23700,
+     "sha256": "1fc3c7a685f5662779f4c6ad0fb02099396504dcf55eef09474183aff69861c1"
+    },
+    "maps/medieval_brk/booksh1w_brk3.map": {
+     "bytes": 746,
+     "sha256": "bd10960b3af925cf2a33bb0629d1a522de5f54ec05938b36378871fd7de0b9f3"
+    },
+    "maps/medieval_brk/booksh1w_brk5.bsp": {
+     "bytes": 23639,
+     "sha256": "851a02aced76ba77894ba744c5c781ff350a42b93216e095f75938fc95ee39a8"
+    },
+    "maps/medieval_brk/booksh1w_brk5.map": {
+     "bytes": 759,
+     "sha256": "c92ec0ad3d3a5c6588557b5f3c9c000cd1c141a4d9c3b35333d859e75c677568"
+    },
+    "maps/medieval_brk/brick2_4brk1.bsp": {
+     "bytes": 9004,
+     "sha256": "86fb182b011385225d5be8b2a2ba0763286a5a2a5880fdda6fc238d8e6a5212f"
+    },
+    "maps/medieval_brk/brick2_4brk1.map": {
+     "bytes": 1375,
+     "sha256": "208cf3d2a51b0aa4a45cd237786a9303b70a63a85e991a7f8675634bea6295ed"
+    },
+    "maps/medieval_brk/brick2_4brk2.bsp": {
+     "bytes": 7265,
+     "sha256": "151471ef184c02141716225e4403e97a69190bd8a3e9645cf2d52aeb5dce591d"
+    },
+    "maps/medieval_brk/brick2_4brk2.map": {
+     "bytes": 603,
+     "sha256": "cdd5762f851cec464b27e9bfc91c0eab8cb26e69a8b050ac1bd9b0eb662dbf7b"
+    },
+    "maps/medieval_brk/brick2_brk2.bsp": {
+     "bytes": 25323,
+     "sha256": "0d8c4dc3202bcc9f26dfd42ca555b99d0010c63b977cd058646a8e8ad4486eea"
+    },
+    "maps/medieval_brk/brick2_brk2.map": {
+     "bytes": 1378,
+     "sha256": "daeae48ab2f6fca712da2413b65c80c6a944e537571def2d153976b0175d8768"
+    },
+    "maps/medieval_brk/brick2_brk3.bsp": {
+     "bytes": 24310,
+     "sha256": "5f94a5e271bb5b921e4534be8690f005bc258e484cb842a6ead0af9aac29fcfb"
+    },
+    "maps/medieval_brk/brick2_brk3.map": {
+     "bytes": 905,
+     "sha256": "1639469c5fe31540811a8bb95d959844d200102cd19f60d1d5e9c3472477e2d2"
+    },
+    "maps/medieval_brk/brick2_brk4.bsp": {
+     "bytes": 23548,
+     "sha256": "e2049e826c103f2afbb5d0a4b69d45089d0bdcf6bd60646d6ae79c99e9a9a976"
+    },
+    "maps/medieval_brk/brick2_brk4.map": {
+     "bytes": 582,
+     "sha256": "b3528f92f4ecf8099a7bfbf3285f21312c501536b66e02b566a7e38474aa608c"
+    },
+    "maps/medieval_brk/city2_3d1.bsp": {
+     "bytes": 7358,
+     "sha256": "efc80ba0aab1284e2bcec652cc3a2748890c45d6905335f61483eab2851f7c81"
+    },
+    "maps/medieval_brk/city2_3d1.map": {
+     "bytes": 739,
+     "sha256": "ff9c2ebe0034d188443e3a72753d4ecad2a69706a4a06c114f9147f507d10b30"
+    },
+    "maps/medieval_brk/city2_3rd.bsp": {
+     "bytes": 7156,
+     "sha256": "6146e0e5961857308f2ef550213ec647ad810a97359d0946cc07f610e0f03006"
+    },
+    "maps/medieval_brk/city4_2_brk1.bsp": {
+     "bytes": 7435,
+     "sha256": "42a4cbd73804a8458a8369fdbd19ee6b3b4597b18583c242bf77b0122ddc9c1a"
+    },
+    "maps/medieval_brk/city4_2_brk1.map": {
+     "bytes": 648,
+     "sha256": "50b744f4af85aa3c0158ae0330808840710c7ee95c1bda8155cb81b4b247fc74"
+    },
+    "maps/medieval_brk/city4_2_brk2.bsp": {
+     "bytes": 7179,
+     "sha256": "cc2ddcb8877dc1b49ec2c408d6b869a35dd7b6590782525af567905d75a3ada0"
+    },
+    "maps/medieval_brk/city4_2_brk2.map": {
+     "bytes": 520,
+     "sha256": "e9309b8ec24126fd952443ae6bee72df46ba04fb4d0925b33d41c603af9ac5b3"
+    },
+    "maps/medieval_brk/city4_2_brk3.bsp": {
+     "bytes": 10009,
+     "sha256": "7f9a27098101f70090c3aff7fd6731effd2750e8c2b7fdbbb0a9f3146be94045"
+    },
+    "maps/medieval_brk/city4_2_brk3.map": {
+     "bytes": 1575,
+     "sha256": "c352d889a3bed731b7c54e38d7ed35e6fa860d2f6f69eb91319f4043423d7aa8"
+    },
+    "maps/medieval_brk/city6_8brk1.bsp": {
+     "bytes": 7187,
+     "sha256": "bcf4b2815c96308ffc1ab3467ac8b2dd4c25be47d618fd82536ba83bf74a05fc"
+    },
+    "maps/medieval_brk/city6_8brk1.map": {
+     "bytes": 529,
+     "sha256": "2db1be71ce1b1e8bf1e8a5c4c7f2802345aa19c281fd43f2b18d205cbd06bfca"
+    },
+    "maps/medieval_brk/city6_8brk2.bsp": {
+     "bytes": 7298,
+     "sha256": "3b7fd08defa832be1c3f3e40efc6d54d13af6714180be810f6527188f332fbff"
+    },
+    "maps/medieval_brk/city6_8brk2.map": {
+     "bytes": 611,
+     "sha256": "ed29b0773cb700d4b8212f9e28b23edac2d212f469b4a1406538df2b066fcbb2"
+    },
+    "maps/medieval_brk/floor015_brk1.bsp": {
+     "bytes": 12862,
+     "sha256": "5bfae9b09777fad7f26f80b5acc27e187e2259ac5c79ad32ab2a30d154e5889b"
+    },
+    "maps/medieval_brk/floor015_brk1.lit": {
+     "bytes": 179,
+     "sha256": "5d64872b2341768efce6c27686555200246e03d346a2e15089e002d53b1b348f"
+    },
+    "maps/medieval_brk/floor015_brk1.map": {
+     "bytes": 827,
+     "sha256": "08f5b26ee0ebb26416e6a1ed660e197b1ea113a553f5c7a1d26a6070b5cbdac8"
+    },
+    "maps/medieval_brk/floor015_brk2.bsp": {
+     "bytes": 12861,
+     "sha256": "377b50dac34c3789fe8a7bcf6a5b3cedda0f3ba91225135ffc9a2f41abe41e35"
+    },
+    "maps/medieval_brk/floor015_brk2.lit": {
+     "bytes": 188,
+     "sha256": "402bfba12b94cd1b3a40f1052830d4e4fa3b4cb103b196c089f4965e94766bd5"
+    },
+    "maps/medieval_brk/floor015_brk2.map": {
+     "bytes": 828,
+     "sha256": "a45245e0f19cc98f29bcc88c9173118b65058d25ff1c043aaca876353bc67531"
+    },
+    "maps/medieval_brk/floor015_brk3.bsp": {
+     "bytes": 13185,
+     "sha256": "52e2b8d426e479bffc8d518a4d8aa5d5a5dc437dbd761c7074992838ccfd070b"
+    },
+    "maps/medieval_brk/floor015_brk3.lit": {
+     "bytes": 218,
+     "sha256": "dabacc9c3ffdc3bae8c008bedfb683babaca23f6e5b0ca5e35b9c39f9d86f402"
+    },
+    "maps/medieval_brk/floor015_brk3.map": {
+     "bytes": 1078,
+     "sha256": "5235ba02c52ba6dc678f052e4efbad43b9f7d63f858c5f732519f6436246733d"
+    },
+    "maps/medieval_brk/plat_brk.bsp": {
+     "bytes": 59896,
+     "sha256": "367ec651b3cded1ecdf22305a3b48490d3df3078d556d4c7fadfb392ae12ad33"
+    },
+    "maps/medieval_brk/plat_brk.map": {
+     "bytes": 2052,
+     "sha256": "fe52fffba97e8df9acfe4607c9b08d9eb5f4559b44d8c0f6fdbd3af6a0cbf8d6"
+    },
+    "maps/medieval_brk/rock_sw01.bsp": {
+     "bytes": 8843,
+     "sha256": "a3acc4f42ca89efb30d5f9d7ed7c694d59ab6003bd3c665cfa4db480550fd92d"
+    },
+    "maps/medieval_brk/rock_sw01.map": {
+     "bytes": 1371,
+     "sha256": "0e4d621fba3a9806ffdf2bffda89e4d05231513b6f7986d504722d1b99c21a91"
+    },
+    "maps/medieval_brk/rock_sw02.bsp": {
+     "bytes": 9179,
+     "sha256": "4b3d68587a69daa68093d32195a786e8040fed763855acb94f50d02875a8ec44"
+    },
+    "maps/medieval_brk/rock_sw02.map": {
+     "bytes": 1631,
+     "sha256": "82bbf3c701301a80f55619bdac2680d9713432d8fe991838bfb7559830225322"
+    },
+    "maps/medieval_brk/rock_sw03.bsp": {
+     "bytes": 9766,
+     "sha256": "59d2841166f7ecb216df970963b3e425da20566f2fb56a7e5472f4e3c9fcfb24"
+    },
+    "maps/medieval_brk/rock_sw03.map": {
+     "bytes": 1526,
+     "sha256": "300f4c4f56cc9f6425cc8999484e18326555c57b8f53d9f42c36a4345b850d2c"
+    },
+    "maps/medieval_brk/rock_sw04.bsp": {
+     "bytes": 9836,
+     "sha256": "72854269a33665022dee9c30e53e6124bc2bba25ad34d2a3d86302e50ad795c1"
+    },
+    "maps/medieval_brk/rock_sw04.map": {
+     "bytes": 1605,
+     "sha256": "e2b3e6e53c11de10d0de4b7374d43a09be1622766cb3ff60c9e9cec8688747f9"
+    },
+    "maps/medieval_brk/rot_p.bsp": {
+     "bytes": 13554,
+     "sha256": "afcc7dc6512bba89ceec9e10bfa8256ecd043d34c1af57f33a199509500164ff"
+    },
+    "maps/medieval_brk/rot_p.map": {
+     "bytes": 2518,
+     "sha256": "c60e36e827e052cea6ca5c6c2d022b5da051090ee2accf8807f5703ec8acc79a"
+    },
+    "maps/medieval_brk/waa1.bsp": {
+     "bytes": 23869,
+     "sha256": "739aa8d0753e691020013539356d2c2e10b9d0b82c63bcc694080afe33bc585e"
+    },
+    "maps/medieval_brk/waa1.map": {
+     "bytes": 765,
+     "sha256": "f2e7bbba974ffde1e4178be825034e555ca491fffedbf007e62589214af82f0f"
+    },
+    "maps/medieval_brk/wbrick15_brk.bsp": {
+     "bytes": 7969,
+     "sha256": "0dcbd483c300f1be58a216b6d64ea385dd489babdc70868e483fb496c4dd4c38"
+    },
+    "maps/medieval_brk/wbrick15_brk.map": {
+     "bytes": 899,
+     "sha256": "43789ad5bb908aa7fb8e8893db766ce0e479cc547e31aa8de6fe1b4bd6093015"
+    },
+    "maps/medieval_brk/win1ah_brk.bsp": {
+     "bytes": 34981,
+     "sha256": "d549b60245213678c222499299e43654c25f838ed42898a25ec284d933f56b64"
+    },
+    "maps/medieval_brk/win1ah_brk.map": {
+     "bytes": 897,
+     "sha256": "da6859a14f291bef23c990977c0fce7e21ee2c790318cce46e36a8388e87fb39"
+    },
+    "maps/medieval_brk/win1ah_brk2.bsp": {
+     "bytes": 34873,
+     "sha256": "87416124f6e04adaaa5ed9144fa60e048dc03606bc294d89d99295a7c8cb2487"
+    },
+    "maps/medieval_brk/win1ah_brk2.map": {
+     "bytes": 901,
+     "sha256": "5d9a1aefeca5acfdbb25cad5489f5bcb41c89f3c9b92a3d305da0f462c439ec2"
+    },
+    "maps/medieval_brk/wiz14_brk1.bsp": {
+     "bytes": 8961,
+     "sha256": "cb45306588dc69d44422d475c0481f67a76638fe2502c16c28a8f87fa43f6787"
+    },
+    "maps/medieval_brk/wiz14_brk1.map": {
+     "bytes": 1262,
+     "sha256": "46200a77c401035e45d339d8106263e7210ed66e373be74f65687c5d1eb83124"
+    },
+    "maps/medieval_brk/wiz14_brk2.bsp": {
+     "bytes": 7338,
+     "sha256": "871684ecf4507da9773ca5568ccdd0a27173d2f35922b379a19f95e9252a777f"
+    },
+    "maps/medieval_brk/wiz14_brk2.map": {
+     "bytes": 652,
+     "sha256": "97a58529ea21e8127050b0f1e3305e4616b1970232e6517aa652061f49ffc9e0"
+    },
+    "maps/medieval_brk/ws14_brk1.bsp": {
+     "bytes": 7987,
+     "sha256": "ee96dcf614d940d9f887035be0781ad941fc5f76a0f0e553ec3592ae00af1794"
+    },
+    "maps/medieval_brk/ws14_brk1.map": {
+     "bytes": 948,
+     "sha256": "022d130b741c8976f529288f6030fabd2040991efd8bb0a6542dc1508c0b061c"
+    },
+    "maps/medieval_brk/ws14_brk2.bsp": {
+     "bytes": 9003,
+     "sha256": "6aa46294d8fffe55db6f2e6a9d30341fe07a9252b0066ff575c692d0b149f7af"
+    },
+    "maps/medieval_brk/ws14_brk2.map": {
+     "bytes": 1375,
+     "sha256": "8f175f2e3ac8a760fcb7d25da5a30cea149b55349fa0e0d20b2a8c0b080aa5b0"
+    },
+    "maps/medieval_brk/ws14_brk3.bsp": {
+     "bytes": 8944,
+     "sha256": "282944bfbd49b6dcc0aa0d67253432d88c63212ea564a9c6b8909a9b96f8946a"
+    },
+    "maps/medieval_brk/ws14_brk3.map": {
+     "bytes": 1282,
+     "sha256": "6ecd83ba25e15f363f271078c73f6c460babf95ea63340a855dfa182ec47e4b4"
+    },
+    "maps/rtex_brk/022a.bsp": {
+     "bytes": 17448,
+     "sha256": "3557f9518ca0982c871dd344ea5069e5128645029ea428de26ef991881170a59"
+    },
+    "maps/rtex_brk/022a.map": {
+     "bytes": 691,
+     "sha256": "50e0375bf596265b893e56996dbddfad26af2e50bb9af473dc2115e18b11dc02"
+    },
+    "maps/rtex_brk/022b.bsp": {
+     "bytes": 17608,
+     "sha256": "083fdbd34b34b47c5dd9dd58f4e3e0fa3debbedd554db4ce81791033349451fa"
+    },
+    "maps/rtex_brk/022b.map": {
+     "bytes": 825,
+     "sha256": "26d8800f4cfb0706ad363e958846d87755b4871792d1ac1f00b5b51fd7550777"
+    },
+    "maps/rtex_brk/022c.bsp": {
+     "bytes": 17820,
+     "sha256": "8c6b933d2cd323eba623727226ea6cb1f968e0401093f93d229d229a7a5b225d"
+    },
+    "maps/rtex_brk/022c.map": {
+     "bytes": 894,
+     "sha256": "835d4d09490552859dc79ad527bcd08af8afedfa7a863148c62f2f58742e9014"
+    },
+    "maps/rtex_brk/022d.bsp": {
+     "bytes": 17592,
+     "sha256": "0580ec01633972b2fff28c5d4b9a71766d3f1ed6fae387dff34ca691ff829e38"
+    },
+    "maps/rtex_brk/022d.map": {
+     "bytes": 784,
+     "sha256": "238fc24be385d3994586c34555e74ecbb7677aa7567bbf317947276c14b62107"
+    },
+    "maps/rtex_brk/330a.bsp": {
+     "bytes": 7928,
+     "sha256": "a446db4116b8c33f46745cf815ba9309e69591d919838006c81a9b0a5b00c7d4"
+    },
+    "maps/rtex_brk/330a.map": {
+     "bytes": 691,
+     "sha256": "964103ee6422dd3b815472c9f29126741e06517623dad050fba18a9867451903"
+    },
+    "maps/rtex_brk/330b.bsp": {
+     "bytes": 8088,
+     "sha256": "727d22fad028bac645a53ac5a425618e30575735958496b7a1ac86cfbc562e1a"
+    },
+    "maps/rtex_brk/330b.map": {
+     "bytes": 825,
+     "sha256": "807bdb97ab58709fd96cfa0e7b65cb5d377257b862eef2673606901d70b84108"
+    },
+    "maps/rtex_brk/330c.bsp": {
+     "bytes": 8300,
+     "sha256": "b25471a1f0e7fdd066dda47860ae956db2b2c4758a426b39b8a82e6b4c6d1b72"
+    },
+    "maps/rtex_brk/330c.map": {
+     "bytes": 894,
+     "sha256": "13241951b0d3cd61a71e0fe80071a1df65e369eba44aabdf3401f3ba5aa55a7f"
+    },
+    "maps/rtex_brk/330d.bsp": {
+     "bytes": 8072,
+     "sha256": "8f83245e973c42e9908b6215c5effc0f0581d654e5e8e67a6e77493f79de3e6d"
+    },
+    "maps/rtex_brk/330d.map": {
+     "bytes": 784,
+     "sha256": "f0e46c1efc3d5a814675f5760a33a2e6bc4163974ff64a4c1f88ab70c50fbb68"
+    },
+    "maps/rtex_brk/340a.bsp": {
+     "bytes": 13368,
+     "sha256": "e8a605fdff44ef59b4657a43a67cfb24d2d62f150b210a0761f69ed5f559215c"
+    },
+    "maps/rtex_brk/340a.map": {
+     "bytes": 691,
+     "sha256": "3678f5058497a6067c7ffb4d452e706af588e0aedfd30bfa2d43f1902333e7ec"
+    },
+    "maps/rtex_brk/340b.bsp": {
+     "bytes": 13528,
+     "sha256": "d92cc6afb7ae74965a8bb2a753909e2dc6c064b5fb2c9c463c95123531ba337d"
+    },
+    "maps/rtex_brk/340b.map": {
+     "bytes": 825,
+     "sha256": "29f243aa1c347358e34383f4ffb2d129f710829022524237585041c7840a02cb"
+    },
+    "maps/rtex_brk/340c.bsp": {
+     "bytes": 13740,
+     "sha256": "882a110b1a7e26481e5dd37858d5229c0273bc98ab8a2ab59f318e2b76080fac"
+    },
+    "maps/rtex_brk/340c.map": {
+     "bytes": 894,
+     "sha256": "069e17115ae35cf0fdaa9ceb8b3a67065360d4fc03f91036ba453b6b6745d77b"
+    },
+    "maps/rtex_brk/340d.bsp": {
+     "bytes": 13512,
+     "sha256": "96a6133331679ad8eb75d8581e8be12c6822d2048c18a1e704281a6e4cc0737c"
+    },
+    "maps/rtex_brk/340d.map": {
+     "bytes": 784,
+     "sha256": "b8197ea047f14d175e5b9234dcc9b625f04124b175bb0fd80da7ceffe056b00c"
+    },
+    "maps/rtex_brk/413ra.bsp": {
+     "bytes": 7972,
+     "sha256": "a3cc5962750f55c398dfaf53cb4d8394f1100c752ca9797f053ec2710acd995d"
+    },
+    "maps/rtex_brk/413ra.map": {
+     "bytes": 769,
+     "sha256": "b0a3052bfb352684f97fb7bca8fdc3d7b135ae5e3fca491d190d09423836da46"
+    },
+    "maps/rtex_brk/413rb.bsp": {
+     "bytes": 9204,
+     "sha256": "e36bf5d23b3dcaf96075b1b441ebf6424da62cb2d04ff14f04da4e9956711094"
+    },
+    "maps/rtex_brk/413rb.map": {
+     "bytes": 1682,
+     "sha256": "6be0d7cbae08ffccbb1ea9dedf03bc6f8c9b6be93c6c27d5e964e3b4f4538a52"
+    },
+    "maps/rtex_brk/413rc.bsp": {
+     "bytes": 10340,
+     "sha256": "4d57717cc2fb9db560e724df4937f7c496d77d1df6d70e6619ba686338152e79"
+    },
+    "maps/rtex_brk/413rc.map": {
+     "bytes": 1909,
+     "sha256": "71c9812cdf0647bb89fcd2a911a664b7a8dea382b0fe58e4e834a24354a23b38"
+    },
+    "maps/rtex_brk/413rd.bsp": {
+     "bytes": 13356,
+     "sha256": "573149ae9d1f687b0ddc0a702116357b4556e20ae8d62b7b32b3c5b41f227088"
+    },
+    "maps/rtex_brk/413rd.map": {
+     "bytes": 3217,
+     "sha256": "f40b142b102fefefdaf6594c2d1410f370fd8491a009ecfc6dada46c55f262d2"
+    },
+    "maps/rtex_brk/wood3_1a.bsp": {
+     "bytes": 7552,
+     "sha256": "8884a645d6193052aeba7043c139b3eb4cf8ace2e62ed6e9181d51f90cae4806"
+    },
+    "maps/rtex_brk/wood3_1a.map": {
+     "bytes": 1007,
+     "sha256": "5322a91b2aad8cf58095fb513e58317d738469c168b78f770307c3ece580fbf9"
+    },
+    "maps/rtex_brk/wood3_1b.bsp": {
+     "bytes": 7096,
+     "sha256": "9d7d44ba1c929fae0bf702ec834394c9da23c199cf742f9c7021bec00f33c056"
+    },
+    "maps/rtex_brk/wood3_1b.map": {
+     "bytes": 516,
+     "sha256": "158e6d102aaeb8dd7add01eecd7e05b4c711a20d7d7134d1bdce417fbe1b2072"
+    },
+    "maps/rtex_brk/wood3_1c.bsp": {
+     "bytes": 7144,
+     "sha256": "f292d3b9cabaa0332d7c3f6abd66420ad9ef80217f32223bd67315fa8967d908"
+    },
+    "maps/rtex_brk/wood3_1c.map": {
+     "bytes": 517,
+     "sha256": "f853df961fdcebd569943bad596dceb464c6317e44f3d77ce4def17295b37c00"
+    },
+    "maps/rtex_brk/wood3_1d.bsp": {
+     "bytes": 7804,
+     "sha256": "8e6ffa915db57d7cb958c7210e0abc35ff552713a5aa19a1ccb531a7d45bd504"
+    },
+    "maps/rtex_brk/wood3_1d.map": {
+     "bytes": 883,
+     "sha256": "d370c44a047023843caf08a41098bd3852526b614ae074c228cc6ad4e76d4aa9"
+    },
+    "maps/speedbz_brk/crate_r1.bsp": {
+     "bytes": 29110,
+     "sha256": "5dd3afab4a3ad5cf4466e272324e4afad5075ca2e662cc8b1932e277a2db73a2"
+    },
+    "maps/speedbz_brk/crate_r1.map": {
+     "bytes": 664,
+     "sha256": "ee7ce39ec0650d3cbde924b99efc91ba884778db11a961037d4493bf587fa33e"
+    },
+    "maps/speedbz_brk/door1.bsp": {
+     "bytes": 31200,
+     "sha256": "6df38f4db1bfd725dd7384b45e38d070fd4b514139a8e649aea3e640377a073d"
+    },
+    "maps/speedbz_brk/door1.map": {
+     "bytes": 1419,
+     "sha256": "17bf053113ed5cc14e99ef2880e5478ebace7d59de4797fc6cbfe3586d688494"
+    },
+    "maps/speedbz_brk/door2.bsp": {
+     "bytes": 29732,
+     "sha256": "8f58cd2f2e76fbb36a007ed7986671092b880d01dfcb9a087e93cd11240d2baf"
+    },
+    "maps/speedbz_brk/door2.map": {
+     "bytes": 726,
+     "sha256": "3fac703869c9ebb4eabfbe8f180fec752812eea0aa68c5f5574c5cf2496c3931"
+    },
+    "maps/speedbz_brk/door3.bsp": {
+     "bytes": 26516,
+     "sha256": "77f003456362f2b7ca424491485ad2d20b162598527765e5e78628ee7e6ad172"
+    },
+    "maps/speedbz_brk/door3.map": {
+     "bytes": 1247,
+     "sha256": "e56d45f63dcb0d86a0039ea443109d8c8d116fa18331a2328e90f74a891ab9d2"
+    },
+    "maps/speedbz_brk/door4.bsp": {
+     "bytes": 24020,
+     "sha256": "930881a45210317dd3550b04b20d2446cf92c8c613d4aa295a5c77810b77b3f2"
+    },
+    "maps/speedbz_brk/door4.map": {
+     "bytes": 611,
+     "sha256": "f4a68b8f4d081ff0febc276c51b5484c96e4b044eab6e20069ae84ac7c5a0ac2"
+    },
+    "maps/speedbz_brk/rock1.bsp": {
+     "bytes": 89984,
+     "sha256": "c87f60de56cfd5a932cf33d23d6e83b0fd16518001dd8fa7be84da9c3176b5b5"
+    },
+    "maps/speedbz_brk/rock1.map": {
+     "bytes": 980,
+     "sha256": "29e5bd54316e6f325d71a33051ee3a5b6c213f927222931bb35cdcc1820cc87a"
+    },
+    "maps/speedbz_brk/rock2.bsp": {
+     "bytes": 90012,
+     "sha256": "443e51be48da3594545d347ee056f3973b0360268eb6c03653d7b3af622c553e"
+    },
+    "maps/speedbz_brk/rock2.map": {
+     "bytes": 991,
+     "sha256": "40b6b9f23f788c08f362f2336048bbe1260f181d7e76de2591ea7aefa03f4b09"
+    },
+    "maps/speedbz_brk/spdcrate_r1.bsp": {
+     "bytes": 12844,
+     "sha256": "30fa3f373efefcf7db68a9acbb0eb282a0b2ea54d26db92eaaad444035462791"
+    },
+    "maps/speedbz_brk/spdcrate_r1.map": {
+     "bytes": 807,
+     "sha256": "c18735f305c2496a4801ed1a5bc1297f2d72e55824f7222a265ac5788552fc68"
+    },
+    "maps/speedbz_brk/speedbzvent1.bsp": {
+     "bytes": 15248,
+     "sha256": "bcfe36bf57cb82e5188b86af3e5bf568038ef5a50d0ebce43024155b7276008d"
+    },
+    "maps/speedbz_brk/speedbzvent1.map": {
+     "bytes": 2053,
+     "sha256": "7d447bc22e440e685648d8b39e051bce7c1b847e3f777ac092ab1104b79242a1"
+    },
+    "maps/speedbz_brk/speedbzvent2.bsp": {
+     "bytes": 14104,
+     "sha256": "8fb1e76688e27767ce77c5d7b3486048adfa284e011b91007730d424eb55ca61"
+    },
+    "maps/speedbz_brk/speedbzvent2.map": {
+     "bytes": 1381,
+     "sha256": "44cfc0509c9455865df334c1ca5bdfca49cf0fae4dab372cac99e6eeb76b438c"
+    }
+   },
    "sha256": "6ca3099935998e8678b388cd5bb1e1c601f1035da378141b6e800303b8737f02",
    "timestamp": "2020-10-27T05:35:46.000Z"
   },
   "pak2.pak": {
    "bytes": 22309070,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 94990,
+     "sha256": "e790b189b1df23f116097b45f5ed391fd210319ecfa000d029b367a7c3d32ab5"
+    },
+    "maps/bmodels/az_chain1.bsp": {
+     "bytes": 219668,
+     "sha256": "4d2648c6dd850b04d48e9631ad02756ecf78d85f56810ff7b9db131a6fe641a3"
+    },
+    "maps/bmodels/az_chain1.lit": {
+     "bytes": 33272,
+     "sha256": "1daab5bb58dbf2c73968dc9db26cf0b0bd78652d491788d0a6124aaa9a9b6f4a"
+    },
+    "maps/bmodels/az_chain1.map": {
+     "bytes": 96430,
+     "sha256": "2b6c77f844eaf5a371b36c13cf512a24d8cd39095cdc04eddd64cd571060d098"
+    },
+    "maps/bmodels/az_chain2.bsp": {
+     "bytes": 333820,
+     "sha256": "746e38bbb4cebb63ac3344e944f24b874b9fd3ed584017bb599e027508cc6187"
+    },
+    "maps/bmodels/az_chain2.lit": {
+     "bytes": 22130,
+     "sha256": "c6ebc72f8dcaa06422eaf71e08771f76105ddd39c3ee6784d40083df67d1cf32"
+    },
+    "maps/bmodels/az_chain2.map": {
+     "bytes": 148314,
+     "sha256": "e9cb3cddd08835aed7b1eed8867a67b06fee9db20dd7584830b8918d4af169ea"
+    },
+    "maps/bmodels/az_chain3.bsp": {
+     "bytes": 308800,
+     "sha256": "6b78b5a83f2f71a316e85086e12b7a1f66abaf28b02a53076433e3b2b3a20fee"
+    },
+    "maps/bmodels/az_chain3.lit": {
+     "bytes": 20684,
+     "sha256": "28870bf7c7f011206290fe69c7b6e2501c27fba21bea2ae6767e8d85a4ff56e7"
+    },
+    "maps/bmodels/az_chain3.map": {
+     "bytes": 110405,
+     "sha256": "64eee084713fdb7da2ec9f9dbc7c482930d9a871d86fd0912d32ddf52063b1aa"
+    },
+    "maps/bmodels/m_bchains1.bsp": {
+     "bytes": 74963,
+     "sha256": "73beb2dc0b953e096e69a4e049af380e99c98ce1872b4da00c858be36d4e973a"
+    },
+    "maps/bmodels/m_bchains1.map": {
+     "bytes": 43470,
+     "sha256": "ecd781a6601c6fca262909cb2e116a222de2e5aa5417dd36d4475d5c433459af"
+    },
+    "maps/bmodels/m_bchains2.bsp": {
+     "bytes": 83651,
+     "sha256": "e23fad6717790c08e661748398754e60944527eb6e48c0f2c0ffbdba73cf95db"
+    },
+    "maps/bmodels/m_bchains2.map": {
+     "bytes": 42484,
+     "sha256": "e92865750499de9117e5bf19719052109179ebcc37ddbd40f2d91d914b86fa63"
+    },
+    "maps/bmodels/m_bridge1.bsp": {
+     "bytes": 431144,
+     "sha256": "ac4d490408f7ad9068a09c4c89f82a65b8573bc4ba810fe5f16418b1d2684f66"
+    },
+    "maps/bmodels/m_bridge1.lit": {
+     "bytes": 47240,
+     "sha256": "30601eb0d533bbe0f72631b77630c3922a46f34b38687aa184b7776e48e63164"
+    },
+    "maps/bmodels/m_bridge1.map": {
+     "bytes": 120280,
+     "sha256": "3ddec67bb95d788b2fecb0e4c6d09781a6a27ba79d322a637f3a03e84a8f6ac7"
+    },
+    "maps/bmodels/m_bridge2.bsp": {
+     "bytes": 201392,
+     "sha256": "4fec9b73e50ba0608d2b5f2fd5c4957324c4cb609becf3be979aedf644281845"
+    },
+    "maps/bmodels/m_bridge2.lit": {
+     "bytes": 21902,
+     "sha256": "c1fa88042c3fde27bd608d3829c8c4a142e70617087970ec7535d48847ac435a"
+    },
+    "maps/bmodels/m_bridge2.map": {
+     "bytes": 52004,
+     "sha256": "58943dc439d4d4c8e65773c12e361c3336488a94f0a53a54c06366675517b850"
+    },
+    "maps/bmodels/m_bridge2b.bsp": {
+     "bytes": 201398,
+     "sha256": "096dcacf528d2784b79a4c0dd19c445102778f2a053fde3a2a43540a4a621c73"
+    },
+    "maps/bmodels/m_bridge2b.lit": {
+     "bytes": 21902,
+     "sha256": "1c7bdad93866cabb97e4565bf41d2b8a8d4c8237e11b0965fd05fc954b6c2c64"
+    },
+    "maps/bmodels/m_bridge2b.map": {
+     "bytes": 52268,
+     "sha256": "d361d0c3dcfec2ae5d109075bf437d013762328ee48b8fc25f779267d7b1bfb1"
+    },
+    "maps/bmodels/m_bridge3.bsp": {
+     "bytes": 309343,
+     "sha256": "12d2199af263464d48455c2e5cd7bf2abf2085841fbc7e027a4cc96b04eec2d8"
+    },
+    "maps/bmodels/m_bridge3.lit": {
+     "bytes": 46964,
+     "sha256": "b783061b14bb4caf3cf9df9a6b8be9ea1d2a367339fa09ffe01506022b21a4c5"
+    },
+    "maps/bmodels/m_bridge3.map": {
+     "bytes": 138104,
+     "sha256": "33c8835d256fd00e65da818c4d43b86033bb8104897712b824014a035c2628e0"
+    },
+    "maps/bmodels/m_chains1.bsp": {
+     "bytes": 249145,
+     "sha256": "1f51d881982d8602c0da29c1f105ab07a41977bdab4fbf4598922563373f4a98"
+    },
+    "maps/bmodels/m_chains1.map": {
+     "bytes": 170858,
+     "sha256": "e1855a52ab0ae70c382876eb74fcafe5a065fefeb2e49a6956184637b9edc1bd"
+    },
+    "maps/bmodels/m_chains2.bsp": {
+     "bytes": 134457,
+     "sha256": "57a765e0ec315eca93927ad64e11b9b3ec8adae0c405de55d86c30b30ef51e5a"
+    },
+    "maps/bmodels/m_chains2.lit": {
+     "bytes": 15698,
+     "sha256": "c858c4c47488df5cac3ed19736c1aee29f4c7add0dfb45deeb7416c4c7af1f21"
+    },
+    "maps/bmodels/m_chains2.map": {
+     "bytes": 60423,
+     "sha256": "575ae8d717a2352ac8726b3bc0f11f6e0a83f548dd471a544a62f519bb71f692"
+    },
+    "maps/bmodels/m_chains2l.bsp": {
+     "bytes": 156552,
+     "sha256": "ff04a994c83f27104d6ef126ef2d08ce894ebe0a812c49f0d2ae79ce8808e8b9"
+    },
+    "maps/bmodels/m_chains2l.lit": {
+     "bytes": 15698,
+     "sha256": "9ebbd1a675e167d9a3be233cd65654728f2f1e0259dee00f55e3da02802abfa2"
+    },
+    "maps/bmodels/m_chains2l.map": {
+     "bytes": 61112,
+     "sha256": "346320204a3413bd6654018e37e42c442c21d88e15da513395c73e6daee26bed"
+    },
+    "maps/bmodels/m_chains2p.bsp": {
+     "bytes": 156555,
+     "sha256": "f0778b1608dbb058f1f492848ae3b64f66be0fef54e32bddfd6fe09f7b0e7a74"
+    },
+    "maps/bmodels/m_chains2p.lit": {
+     "bytes": 15704,
+     "sha256": "d2e7187908b4d3823091a9d69cce5ac807507372132b4162e48a6b027ecad53a"
+    },
+    "maps/bmodels/m_chains2p.map": {
+     "bytes": 61117,
+     "sha256": "7d1acdf4240cd91b158bbc23dfab846388efa7d20431f5a9c8dba8ab421102ff"
+    },
+    "maps/bmodels/m_chains2r.bsp": {
+     "bytes": 222620,
+     "sha256": "0e1ad04fd73c4bc183331471a3406665660fd8f030d14404b7c43b31309118e0"
+    },
+    "maps/bmodels/m_chains2r.lit": {
+     "bytes": 17552,
+     "sha256": "605d297ff2ece6796c064e3dd47e1c48e4fdc87324f059f2c1721e369de23a97"
+    },
+    "maps/bmodels/m_chains2r.map": {
+     "bytes": 61788,
+     "sha256": "749cc23346335d05a53b3399f49adb157fe29fe24512a65d3ab976bc811b5818"
+    },
+    "maps/bmodels/m_chains2rl.bsp": {
+     "bytes": 151968,
+     "sha256": "653185afe2384bf68c0e6d35bdd3404196404243a1b8d16cb730de9f7a45b4b0"
+    },
+    "maps/bmodels/m_chains2rl.lit": {
+     "bytes": 17552,
+     "sha256": "ef313b8c77329539ca8bbe6831e7d5b372e4e3f3cc807e6b66901b53f83d82d4"
+    },
+    "maps/bmodels/m_chains2rl.map": {
+     "bytes": 62332,
+     "sha256": "f5961359ef0867c6ecd501231f63912bf4066bb4d65685021efcd0d51d637f95"
+    },
+    "maps/bmodels/m_chains3.bsp": {
+     "bytes": 121996,
+     "sha256": "535075d6549167b5bf61ae91abf2c407ee009e64aa4222be35692478151feab1"
+    },
+    "maps/bmodels/m_chains3.map": {
+     "bytes": 57540,
+     "sha256": "08f7d97d9e8cd45c353d1141905c93d3327d8f77984790d9e952bd91a5247803"
+    },
+    "maps/bmodels/m_chains4.bsp": {
+     "bytes": 203735,
+     "sha256": "2840e2b604d571081a2b13ba2d340f596123b53213aaec8cd695e7a4d668e774"
+    },
+    "maps/bmodels/m_chains4.map": {
+     "bytes": 113061,
+     "sha256": "6727d20079382f7f2a76391d72e6b6bc3136cc6396ef4661b679f5c8f82d8427"
+    },
+    "maps/bmodels/m_chains4p.bsp": {
+     "bytes": 205127,
+     "sha256": "20183038acde1a46c9fae81e86837f876dc6e0bb7cc7a556457d4162264d7358"
+    },
+    "maps/bmodels/m_chains4p.lit": {
+     "bytes": 35897,
+     "sha256": "0dfb9177bd73b903703f0f4630c4941467a452ee676d568e7f32b2099699659d"
+    },
+    "maps/bmodels/m_chains4p.map": {
+     "bytes": 112283,
+     "sha256": "09d773ef730e9b4d81cdf23f4ac3b0efcb365771569638e7f5574407c5560146"
+    },
+    "maps/bmodels/m_chains5.bsp": {
+     "bytes": 94806,
+     "sha256": "04c40fce5016a3d26092812be589344740b29be788921f8ce354461d77943817"
+    },
+    "maps/bmodels/m_chains5.map": {
+     "bytes": 44835,
+     "sha256": "1e897fc203a12a480c1d3dfc13bf7653a06edb8132f98a3fedae50614c3ebb34"
+    },
+    "maps/bmodels/m_chains5l.bsp": {
+     "bytes": 117061,
+     "sha256": "f01c9c1e6f87c0588be0df3f8768f563acea6735451efa41366aa0acb63851db"
+    },
+    "maps/bmodels/m_chains5l.map": {
+     "bytes": 45411,
+     "sha256": "64691e385435777a920358775cb18e7ac6ee5290a34488103753a338500b6db5"
+    },
+    "maps/bmodels/m_chains5p.bsp": {
+     "bytes": 117214,
+     "sha256": "555df3c945155f7b820fde49c3e37d114f3c52bb63c4edb647dbc19161cb13d5"
+    },
+    "maps/bmodels/m_chains5p.lit": {
+     "bytes": 9152,
+     "sha256": "f78aaec615854b6382b6802298f42ac42dcdfdfb9c638b417257876fa83200d9"
+    },
+    "maps/bmodels/m_chains5p.map": {
+     "bytes": 45566,
+     "sha256": "1969841b81be135b7cb383f84bf7d38694d012b35b17ef3e2c630afbf5d6e64d"
+    },
+    "maps/bmodels/m_thanshelf.bsp": {
+     "bytes": 140335,
+     "sha256": "8319f2ba87d5a8ed864941fe9c7341744476be658ce211aaafc1ba0747afeac4"
+    },
+    "maps/bmodels/m_thanshelf.lit": {
+     "bytes": 3134,
+     "sha256": "04fd93ccf6b864bd9226faa29db923bc093200ed3f4fc8a8f6cce29b324a9743"
+    },
+    "maps/bmodels/m_thanshelf.map": {
+     "bytes": 10306,
+     "sha256": "811e75bc34627545ff7513dc658e937195b98b7839bad409bf21da4975fb7e03"
+    },
+    "maps/bmodels/misc_radar.map": {
+     "bytes": 5314,
+     "sha256": "7ca088f70d4421b994f1852dd17de1427a2b6401b19d8f464ecf2024f5025418"
+    },
+    "maps/bmodels/sep_chain2.bsp": {
+     "bytes": 130276,
+     "sha256": "eff6d1868abd6355f4858f41657262ebb87fa9093579eb8abe8ac6f8c8880ee6"
+    },
+    "maps/bmodels/sep_chain2.lit": {
+     "bytes": 15716,
+     "sha256": "311947b14d5363ccc34fd6e32205100b612c8a77c66196dc616192b011375b59"
+    },
+    "maps/bmodels/sep_chain2.map": {
+     "bytes": 80569,
+     "sha256": "7d86dc46adc6a01b96b811021484c1e6cbfb61424f1037be59525d6f1ff2c420"
+    },
+    "maps/bmodels/sep_chain3.bsp": {
+     "bytes": 80956,
+     "sha256": "8a811a3fc8f85373d64fb3840bda3a3af63a138498bc051ddb2b0d1e0cfa9e88"
+    },
+    "maps/bmodels/sep_chain3.lit": {
+     "bytes": 10802,
+     "sha256": "50d0f90c43a132a5cb360cbb25521040632f07726c6ccfb482d3740ec940ad05"
+    },
+    "maps/bmodels/sep_chain3.map": {
+     "bytes": 41124,
+     "sha256": "ef40d6b17d8b9fc880e4a8180336554f37dabfbc8a30b78c485793aaa5dd753b"
+    },
+    "my_progs/ai_ammoresist.qc": {
+     "bytes": 7444,
+     "sha256": "d530fec92f23ed0c3d09560abb9a89bdc160ce1aefdfbe4f4771f9897ae3fc4d"
+    },
+    "my_progs/ai_checkattack.qc": {
+     "bytes": 106456,
+     "sha256": "7971ca5a87666c89b56ab0fcc102e6f551f3cd3b03bdfc0bfb73f5f8d5aed7fb"
+    },
+    "my_progs/ai_combat.qc": {
+     "bytes": 24324,
+     "sha256": "30c07395259db46836e544a68a37527f107e9010e4d64e937476ceafa58c82b8"
+    },
+    "my_progs/ai_enemytarget.qc": {
+     "bytes": 8409,
+     "sha256": "f4b0a35306d50e71fd9043ae949a421158ee9fcc4e311baf7b8fa2d345c4d46e"
+    },
+    "my_progs/ai_explosion.qc": {
+     "bytes": 12162,
+     "sha256": "7df941a7cf93b814ae9d90f646a5b0243a51db67872f621df73d43c6000ba3ab"
+    },
+    "my_progs/ai_gibs.qc": {
+     "bytes": 32373,
+     "sha256": "65e202300882ba8f0c980f65820b2d2e0bd06846073168f4bd7e37f2357f47d4"
+    },
+    "my_progs/ai_hazards.qc": {
+     "bytes": 26832,
+     "sha256": "81aace80121408f64369bc2bbfd5654650276ddd75217333d2a52364415acaa5"
+    },
+    "my_progs/ai_minions.qc": {
+     "bytes": 10236,
+     "sha256": "3e7bd34dfe0e73a11e6907d5ac69cb609eee19dff533689ea7c8eabe52500136"
+    },
+    "my_progs/ai_passive.qc": {
+     "bytes": 8224,
+     "sha256": "44473544d0da0dc778c2800a16172ab49b548286b604c9d6361f4bc4cfc1f076"
+    },
+    "my_progs/ai_pathcorner.qc": {
+     "bytes": 20921,
+     "sha256": "b3d6ed2434e0b995da51a71715647096e36e02d8cf920e18e024f920ed69238a"
+    },
+    "my_progs/ai_projectiles.qc": {
+     "bytes": 86253,
+     "sha256": "d0885ed945602af45d7db1d98be5938412cd750154ed06710b6b781b6c49abc3"
+    },
+    "my_progs/ai_states.qc": {
+     "bytes": 7480,
+     "sha256": "76fae861132b0e50006ef88ea94a953e718b661defad2ea58a4ecad5cab92dee"
+    },
+    "my_progs/ai_subs.qc": {
+     "bytes": 51485,
+     "sha256": "41a23217543056b1ea447fcf2e0dc2c06a87bdf70dc3f6f699454d7c3c900377"
+    },
+    "my_progs/ai_tether.qc": {
+     "bytes": 6470,
+     "sha256": "2229c0ea1b76e45f5707a3eca9e7626e33f8ea91d6b292da63c81723e1ae8521"
+    },
+    "my_progs/breakable.qc": {
+     "bytes": 79687,
+     "sha256": "754831599eec85a774501d9fd0a1ec7d5722ea6a6e01655b5ad74988145045af"
+    },
+    "my_progs/chaosmode.qc": {
+     "bytes": 81481,
+     "sha256": "01561dc4f1949716eba4d08f83efe27b71add80f923c1e2d89194c238772a646"
+    },
+    "my_progs/client.qc": {
+     "bytes": 70441,
+     "sha256": "00e2d4aff96ea28b0532ab0b03de0a8cdcf15750164ec82bdc8f43b9f2347447"
+    },
+    "my_progs/client_advinfo.qc": {
+     "bytes": 59677,
+     "sha256": "87aaca8bfd15935e1cd29a807bf77a2779d95418af631a6b456c6605710694fe"
+    },
+    "my_progs/client_camera.qc": {
+     "bytes": 13007,
+     "sha256": "ff4748b04c15d9a3b44dd8069f9347c12487ef353d5401a13542166576097889"
+    },
+    "my_progs/client_cshift.qc": {
+     "bytes": 725,
+     "sha256": "da1e321fe01bae486ffcdd987a942a4b0d5b2f603efb663d52c55e882f129685"
+    },
+    "my_progs/client_debuff.qc": {
+     "bytes": 15761,
+     "sha256": "0e0c9123697241ab3a366dbc46fcb90b8553b65c94cffe1442254a74a2753efd"
+    },
+    "my_progs/client_evilmode.qc": {
+     "bytes": 6982,
+     "sha256": "2cfa3bbeb36ab623c3bb137028ec5f549a2e5d2198fa2ab7fd8a445e14f4fc10"
+    },
+    "my_progs/client_ghook.qc": {
+     "bytes": 51884,
+     "sha256": "43d071195a70caa66b57cca1778679d772478fd1f71cbad7ee267e254e79a29a"
+    },
+    "my_progs/client_info.qc": {
+     "bytes": 13693,
+     "sha256": "55653ddc2b9f3cf2ca3cf1b0afdc4c1685baf1ab3c3830eb9f8b1b2d51b3ff31"
+    },
+    "my_progs/client_mapvar.qc": {
+     "bytes": 13177,
+     "sha256": "c692fa41644e6d21c945493dd891af945a072a4b39e687d1b59c86d14ee804a0"
+    },
+    "my_progs/client_power.qc": {
+     "bytes": 20157,
+     "sha256": "0309073577003ae832b259ede75ba53c49bd89985b08d98000d03e1a44893705"
+    },
+    "my_progs/csqc_defs.qc": {
+     "bytes": 21072,
+     "sha256": "eddc5f194845e78a1633807d32b1da4425bdbe7bcce193e3868bc3995e2dee9b"
+    },
+    "my_progs/csqc_defsclient.qc": {
+     "bytes": 35002,
+     "sha256": "b6674acae135dfbc5e3dbb147e69acdc6b3564b766792359bed3e4eb800705e9"
+    },
+    "my_progs/csqc_hudad.qc": {
+     "bytes": 104391,
+     "sha256": "1ca012e489dc5f6026bdae469f411b5bb25afa00e00d5169cbd35b578a7ad9f2"
+    },
+    "my_progs/csqc_hudvanilla.qc": {
+     "bytes": 37074,
+     "sha256": "c5caa6ba176185c05903d383f3ae41907129d859419a0c0bf909b0e8d3e8af5a"
+    },
+    "my_progs/csqc_progs.src": {
+     "bytes": 113,
+     "sha256": "e383fc0920e9676d92e0be81d69cd8017ed5baf9fc0616a05773de68208ce434"
+    },
+    "my_progs/defs.qc": {
+     "bytes": 31974,
+     "sha256": "1534874cf4d70c5614dedecb70f6d428fc32832ce3345c2cb51fd6058a514902"
+    },
+    "my_progs/defsclass.qc": {
+     "bytes": 24401,
+     "sha256": "811c390be7b31fd4b276410ef1a75406bbca8fb84dc195484835a6100e9cddb4"
+    },
+    "my_progs/defscustom.qc": {
+     "bytes": 95932,
+     "sha256": "c8e66698b225cac3821bf4b098e7c8b16d0babaf7f5c1a5a32006c0c1dd96eee"
+    },
+    "my_progs/dpextensions.qc": {
+     "bytes": 122912,
+     "sha256": "3758f58ebaa4186e9112da89f7ea53087eef5058a32ebc373a1ffda76c1d67a2"
+    },
+    "my_progs/estate.qc": {
+     "bytes": 7745,
+     "sha256": "9cceb71ae54b331c2702f5580094f9055d007b9e710dd5e61c7c632724022626"
+    },
+    "my_progs/fteextensions.qc": {
+     "bytes": 215531,
+     "sha256": "beb86ad10bb0726de10dd2557d6285f7bf40f08f9d30e06315c3772f8c256571"
+    },
+    "my_progs/func.qc": {
+     "bytes": 47039,
+     "sha256": "3102c5ce52ec7a15c329079fc7ca97fa249dca32c4124bad49c2853d38e5c741"
+    },
+    "my_progs/func_buttons.qc": {
+     "bytes": 13271,
+     "sha256": "9e1bd197b2367ab2b8f1c776c214a0c51120559e8d8f0b4888b262b7a1e746f0"
+    },
+    "my_progs/func_doors.qc": {
+     "bytes": 35874,
+     "sha256": "58dbdf05f0044aefdd13ee21d17045a681d255efaca6d129fbd1cec4ae516fc9"
+    },
+    "my_progs/func_doorsecret.qc": {
+     "bytes": 14379,
+     "sha256": "769a3142ccaf18060ff77b0eab57d901585202fbfe63a54ce25d4987b80f92d3"
+    },
+    "my_progs/func_insvolume.qc": {
+     "bytes": 10573,
+     "sha256": "1deaf4623a6fae80585d2d2b1978b1cd217b6f8a683ef3bbc3a77a2897e9a207"
+    },
+    "my_progs/func_plats.qc": {
+     "bytes": 11685,
+     "sha256": "5086c9aba8bbf83d29c3e1897c7867cb24220712007044792928f474216b7ea4"
+    },
+    "my_progs/func_pswitch.qc": {
+     "bytes": 8373,
+     "sha256": "b3a205176d80801216a930241508b3c5718f4be9e1b947932ace2851c34271d8"
+    },
+    "my_progs/func_trains.qc": {
+     "bytes": 26553,
+     "sha256": "81d8de4f3dff80b8523584fb5e37d8d4812a6f7f95a559edff320682217ad123"
+    },
+    "my_progs/globalfog.qc": {
+     "bytes": 18397,
+     "sha256": "84ec244a475ac41b9da772042123f58f4005130590f170f85f1b23ad53629f27"
+    },
+    "my_progs/hiprot.qc": {
+     "bytes": 31978,
+     "sha256": "82875db9fecd8bacd2c42232fb980e6a510a6863103273e2c9078dfe7c6759c5"
+    },
+    "my_progs/hipspawn.qc": {
+     "bytes": 2752,
+     "sha256": "6df8450b85821c1a76f5ccb3c807ac9b94e92f413f16f2ba618f922abf85148f"
+    },
+    "my_progs/items.qc": {
+     "bytes": 165150,
+     "sha256": "fbcc57975032c97ffea723870e39ebc2d2c4bbd9650fb5d20b3dfcecc6f6f93a"
+    },
+    "my_progs/items_progspn.qc": {
+     "bytes": 20628,
+     "sha256": "2f4824cb28192145a8fabc2da6575db3398e8f81522ab1e026d696ec87313650"
+    },
+    "my_progs/lights.qc": {
+     "bytes": 43912,
+     "sha256": "d0e0c373bb3cc68c7c9121a62c68085ff9cc290daa6faf0adab02323d8ef92bb"
+    },
+    "my_progs/mathlib.qc": {
+     "bytes": 22355,
+     "sha256": "b161ebb89a11f302427c4f124731ec38def8eb01347beb5d748a9ba4afb886f8"
+    },
+    "my_progs/misc.qc": {
+     "bytes": 85890,
+     "sha256": "6b3e8a0882d47f16ff7f54fb37a48e3a7853647f8895718e6428739c4207099a"
+    },
+    "my_progs/misc_camera.qc": {
+     "bytes": 43852,
+     "sha256": "61448a8f0354f39dd26371ae56dadbc903b08282293145a27088ac6c151ea547"
+    },
+    "my_progs/misc_model.qc": {
+     "bytes": 32157,
+     "sha256": "9afc9d440672288ffada6256a20aa0f969464907e942fab0c1556cdb28162237"
+    },
+    "my_progs/misc_targetdummy.qc": {
+     "bytes": 15123,
+     "sha256": "bcd0a0ae806ce20a8c8cfcc27178ce1b4ead3a546d927b6a261ce51a6086c253"
+    },
+    "my_progs/misc_textbook.qc": {
+     "bytes": 26321,
+     "sha256": "14bf42536a5cc75990d938a79d7bd21bde1c166245d94d8e662f9e6fd66e0ae8"
+    },
+    "my_progs/mon_baron.qc": {
+     "bytes": 31318,
+     "sha256": "b76a10da34dabf3411ddf650abcdbc77e3ebcdfebace6191a39e7c0b13a0fad5"
+    },
+    "my_progs/mon_boil.qc": {
+     "bytes": 19821,
+     "sha256": "050b21bda5341a3f81dcb21e6d7d82d458a415fd8f1cfa12435228246229a323"
+    },
+    "my_progs/mon_bossboglord.qc": {
+     "bytes": 24005,
+     "sha256": "e67081b7a5218b361c62bf4b201a18db16f3e75716ad2729c11a0616b137975a"
+    },
+    "my_progs/mon_bosseidolon.qc": {
+     "bytes": 40134,
+     "sha256": "c51eb9b9d67cadfa7178891a238329a60ad57edc3f6ef645060695b451833115"
+    },
+    "my_progs/mon_bossfiretop.qc": {
+     "bytes": 14734,
+     "sha256": "26672c9c2d1577f8caf9894b8eb5eecacac89f64251257bc25db48b1bf43a7bb"
+    },
+    "my_progs/mon_bossicegolem.qc": {
+     "bytes": 47205,
+     "sha256": "5b888302a6af24ce823919d1349c1c92e1ee709d72e79042425349368a4d65fb"
+    },
+    "my_progs/mon_bossidchthon.qc": {
+     "bytes": 20247,
+     "sha256": "65d955fb1434f806962fadc088aa5933e96ed8aa9f1211d0709a3f462ffa3027"
+    },
+    "my_progs/mon_bossidshub.qc": {
+     "bytes": 14639,
+     "sha256": "fdd0e8f8fa374ea0164f79ef1bf74ca942f04c63159f360c7a43011673774fe6"
+    },
+    "my_progs/mon_bossjudicator.qc": {
+     "bytes": 81432,
+     "sha256": "f5092f376eeef22f0a552c846f50175680c15a5c37d9603c6e3d2635661127b3"
+    },
+    "my_progs/mon_bossmammoth.qc": {
+     "bytes": 84963,
+     "sha256": "6cda415b846b2aeb215c0eebc7cdfa6a5560255df9aa014f77b48aa7073b8d34"
+    },
+    "my_progs/mon_bossnour.qc": {
+     "bytes": 45682,
+     "sha256": "d3aa7e0c62e9001887b1b0895607b512f6d9aeeb44bca544f6c900c86adbc03c"
+    },
+    "my_progs/mon_bossxxchthon.qc": {
+     "bytes": 22614,
+     "sha256": "2c1c0446b0f6a5b7a7921e8f8830c71c174d30c6f176d228a94afd9a05fdc25a"
+    },
+    "my_progs/mon_bossxxshub.qc": {
+     "bytes": 19006,
+     "sha256": "043ebc852ba7f0a06812cb0afd72d32a3da643df1dea45c87fb821f60fbcc332"
+    },
+    "my_progs/mon_centurion.qc": {
+     "bytes": 13734,
+     "sha256": "641e1c09c6df27b033e331140d242f25d27bf7f9bb83733a6b5b3469a5c7ffee"
+    },
+    "my_progs/mon_dcrossbow.qc": {
+     "bytes": 38069,
+     "sha256": "3296618a4b803fb6f1b44c1d32c17692a5bed13cf63102c6dcc58481223197a8"
+    },
+    "my_progs/mon_deflector.qc": {
+     "bytes": 32107,
+     "sha256": "d7a9344878a3a846a7e720ce704820d424362281a1675c40be7b670eca9fe342"
+    },
+    "my_progs/mon_demon.qc": {
+     "bytes": 14601,
+     "sha256": "d77f128e3f91737228c5a24b7ca146f6b4f8e87dbaac31b1ad4e79779884d0d7"
+    },
+    "my_progs/mon_dfury.qc": {
+     "bytes": 39867,
+     "sha256": "a016db202f2a418aee50cb7cce2155a24a6b807e8c98fc49a5f9273ce79c6da8"
+    },
+    "my_progs/mon_dguard.qc": {
+     "bytes": 28414,
+     "sha256": "0a2b964034559f4ca772f9f29be2c56684fd39290277046a6f7642ba934836eb"
+    },
+    "my_progs/mon_dguardquoth.qc": {
+     "bytes": 18932,
+     "sha256": "4caeb17520104cba42476ff7757f38ba6d72e941674b851f55a5c9780ce4de17"
+    },
+    "my_progs/mon_dknight.qc": {
+     "bytes": 36867,
+     "sha256": "68008427374e9ab670b6ad915c7a0f8eaf6a6699efa927a3748ae6cde86458e6"
+    },
+    "my_progs/mon_dlord.qc": {
+     "bytes": 22859,
+     "sha256": "09ca1edd4e65a166a66ba17e682aae9a1be09b05371a72dd1bc447389693bfa5"
+    },
+    "my_progs/mon_dog.qc": {
+     "bytes": 18431,
+     "sha256": "1b345447176aec54f18c31f5da215e80cb2de19f51d353c63a98507d881c2a9b"
+    },
+    "my_progs/mon_dprince.qc": {
+     "bytes": 33590,
+     "sha256": "5114caa7b6152e562e548096e41da68f43c910a5016ddaed408272a97a8320c1"
+    },
+    "my_progs/mon_drole.qc": {
+     "bytes": 25472,
+     "sha256": "36a510e910ce4ffa26d2d2ad336872c07537077ea920132a4cfd63d9133fb6af"
+    },
+    "my_progs/mon_dsergeant.qc": {
+     "bytes": 33493,
+     "sha256": "ada0cc4359a863c4e8d433c605a1c04ec6f7fd17ec852f5c4847443d3adaff1d"
+    },
+    "my_progs/mon_eel.qc": {
+     "bytes": 8252,
+     "sha256": "15c1f2fedba7077d352595e1be4a90f764354e4cf1875b40e1685d3ce81feb54"
+    },
+    "my_progs/mon_enforcer.qc": {
+     "bytes": 20146,
+     "sha256": "d453651d488afa789d0cea87ce99d9684329bbabdd17aa1625591f5a4b4ac90b"
+    },
+    "my_progs/mon_fish.qc": {
+     "bytes": 9705,
+     "sha256": "ff7d84db2c7917861ff5d81fe0e28f69d51143d27c4fba90dfcda11057222df0"
+    },
+    "my_progs/mon_floyd.qc": {
+     "bytes": 20332,
+     "sha256": "3ac2f0b0be94e311ff2fc4eee9cf66d5987af0e5c25fc06b8cc7b9efa6f581df"
+    },
+    "my_progs/mon_freddie.qc": {
+     "bytes": 25384,
+     "sha256": "4409a33e819f125852d0a4ada21a8fed2713012daec00922446f313031c845d1"
+    },
+    "my_progs/mon_gargoyle.qc": {
+     "bytes": 24293,
+     "sha256": "9e1f78b2364024efa6ec4142c1ecf4aff52cdf32f38031c34cf19e9cd74143d6"
+    },
+    "my_progs/mon_gaunt.qc": {
+     "bytes": 24111,
+     "sha256": "45be98ae0bdd32e0884280e18f867af037f2fcbf515914827c5f9107a87e52d7"
+    },
+    "my_progs/mon_golem.qc": {
+     "bytes": 35297,
+     "sha256": "dbaf3d1c0fec3166b0eb064a3c027dd3a0c907bed72b8e4581ffd74dad5ab5d1"
+    },
+    "my_progs/mon_hknight.qc": {
+     "bytes": 37618,
+     "sha256": "bac7d4b7832b95cea0f6890de66fbd0f7c4fcc7ce9051ef16ac042de465ddcb3"
+    },
+    "my_progs/mon_hogre.qc": {
+     "bytes": 24021,
+     "sha256": "8781ea9aaaa1d0f7ffb1fd8ec8b5981187eee6fdb8193160a1eb38770dffcfe0"
+    },
+    "my_progs/mon_hogreham.qc": {
+     "bytes": 23076,
+     "sha256": "b2ab6b830ce3aae7d6b033e8455de5011ded82e451ca171ea09940d9a3ec7740"
+    },
+    "my_progs/mon_hogremac.qc": {
+     "bytes": 23941,
+     "sha256": "9111c040ab1e5487936cce6ef1170e408c6d297d582702d202bbd27b0919d843"
+    },
+    "my_progs/mon_invsword.qc": {
+     "bytes": 9214,
+     "sha256": "f7287867cc6043eb7cd3fa3e1ecd5ae7115a84e5ef7021b2d5129afdb6ba6f46"
+    },
+    "my_progs/mon_jim.qc": {
+     "bytes": 22091,
+     "sha256": "55353984ad822dfd8c32f3b8ad9a06e8bfaab7bc5ff6f2a2326674ad4acd26be"
+    },
+    "my_progs/mon_knight.qc": {
+     "bytes": 24772,
+     "sha256": "d254abf88162436b9db48885ae8e59315c24c1e7f72a91d027a1d69fe9baf5b7"
+    },
+    "my_progs/mon_lostsoul.qc": {
+     "bytes": 23261,
+     "sha256": "2cdbf656c6b34164711fa88016542f4e3d2bd0555417ad00bab5ca7039f212ef"
+    },
+    "my_progs/mon_minotaur.qc": {
+     "bytes": 35316,
+     "sha256": "fbcef276ee3e2f1eeea8483303538190875e959b43efbf4f703be10fc72fc564"
+    },
+    "my_progs/mon_ogre.qc": {
+     "bytes": 24123,
+     "sha256": "d287d3b9024025237dbc68380f486572828a5114f9543599ba86b8bc35e9e25e"
+    },
+    "my_progs/mon_ogrextra.qc": {
+     "bytes": 9387,
+     "sha256": "41a9243c6006326195197a4dfba6ea4c1f1fbd729ec10adc48cfd7badd7a18de"
+    },
+    "my_progs/mon_pyro.qc": {
+     "bytes": 18235,
+     "sha256": "bd35f02c63af315ddf4820e388d0248cf065f1170bd7306957a1e86fa7e47306"
+    },
+    "my_progs/mon_scorpion.qc": {
+     "bytes": 22136,
+     "sha256": "0432d7c5e1b6a30a5452aba12b9fb6a3c2c7f3c582b1392d420414e66b8fb257"
+    },
+    "my_progs/mon_seeker.qc": {
+     "bytes": 29703,
+     "sha256": "d33939357840eedbfc63c56d6415d8fefd21de2c477b24b3165cdadcca2acd2c"
+    },
+    "my_progs/mon_sentinel.qc": {
+     "bytes": 10217,
+     "sha256": "946232c7169bf3fa966ce875523dd45402772f8045c51a96dced04f2f5f5788f"
+    },
+    "my_progs/mon_shalrath.qc": {
+     "bytes": 16434,
+     "sha256": "1b6fdf2447d7fa281d126118a9bc0e097de7b4dd4d10a33e60d5cf0ca785c58b"
+    },
+    "my_progs/mon_shambler.qc": {
+     "bytes": 23050,
+     "sha256": "576f71a38d75eedbdf58c291055674be8da5f0d04540e26311d65f70b58ee842"
+    },
+    "my_progs/mon_skullwiz.qc": {
+     "bytes": 36245,
+     "sha256": "6d3c2242bffe6eabe3f9cc59e881cb2296213cfbff809e1be045a80ca46aac53"
+    },
+    "my_progs/mon_soldier.qc": {
+     "bytes": 21645,
+     "sha256": "704c534062b11c4fc16416154c7706c125221660cdd4d9b02e00575b94c04103"
+    },
+    "my_progs/mon_spider.qc": {
+     "bytes": 30593,
+     "sha256": "4d0bbb7e38e51cef07912e6071e6bb9739e019a2d93129d38dbab9492bf43aee"
+    },
+    "my_progs/mon_steelclaw.qc": {
+     "bytes": 17126,
+     "sha256": "78dd4bb46dd76b2ff1f7d4a9f0b0902f25d94ebe13ace6b997a7f604c3718700"
+    },
+    "my_progs/mon_swampling.qc": {
+     "bytes": 25637,
+     "sha256": "fb5ed328cd3d5c09704bb84f39138463a7d26b8b1d45771e55e9ae952b1d2470"
+    },
+    "my_progs/mon_sweeper.qc": {
+     "bytes": 27025,
+     "sha256": "8f7a1d077779d88d542a325c1ae4ba4ff59d48bfcb334150ae3f024525bb725e"
+    },
+    "my_progs/mon_tarbaby.qc": {
+     "bytes": 11866,
+     "sha256": "88c9481ab7fe0cbe97d2b836492ff51b368aeae8d4ff3e5852734bb9f63a1b2d"
+    },
+    "my_progs/mon_turretbal.qc": {
+     "bytes": 38519,
+     "sha256": "fdcf915248dda5fb6a744d284233d46a2e6d62c8e4fd02fdd5bafe4f46167d30"
+    },
+    "my_progs/mon_voreling.qc": {
+     "bytes": 27678,
+     "sha256": "7734614fa6b2da2195bf3804415c06a2d10f35825e86abf4f85613a182cf21c2"
+    },
+    "my_progs/mon_wizard.qc": {
+     "bytes": 15155,
+     "sha256": "3101ca37b57343697b3d3c7637fdc84c842f78ec9081e401dcaa6df0a9b1df83"
+    },
+    "my_progs/mon_wraith.qc": {
+     "bytes": 35464,
+     "sha256": "6a28a205cb8ac574e98c8d34a01ea859922e38d55c66346a7aa867ebf84bdb5b"
+    },
+    "my_progs/mon_xmas_elf.qc": {
+     "bytes": 17589,
+     "sha256": "053eec412485090ee1ebeac25887382db40e2ba7ca456050ba4407be3ec8bc1a"
+    },
+    "my_progs/mon_xmas_raindeer.qc": {
+     "bytes": 12189,
+     "sha256": "abbe1dd5c96c25b631231d4db2f17e8243075ad08c082e0448b7cbff34f1ae0c"
+    },
+    "my_progs/mon_xmas_santa.qc": {
+     "bytes": 17853,
+     "sha256": "cc60c6de17bc3321f9b1cf75b3229e387592c9eb7fc4bb57c1de0a8d2c0e62e6"
+    },
+    "my_progs/mon_xmas_snowman.qc": {
+     "bytes": 11486,
+     "sha256": "65928bb70cb2e9352c2f5e036eda2a6bd97aea09d459d0af563a82aa5a2f2673"
+    },
+    "my_progs/mon_zombie.qc": {
+     "bytes": 33988,
+     "sha256": "83f56482374c3a79fcc64058989bd210af3add006b7388d89c92e90543ec56a0"
+    },
+    "my_progs/mon_zombiek.qc": {
+     "bytes": 42214,
+     "sha256": "2b9926454484e93f5c053bf4fd35b2a97cf7e835c26c3b30061f1ff391af9f5e"
+    },
+    "my_progs/monsters.qc": {
+     "bytes": 56573,
+     "sha256": "c2c75832e6d5e83e929214ba5c1aa9a4661bcaf7754c20b3e9648171bf804a58"
+    },
+    "my_progs/part_emitter.qc": {
+     "bytes": 82744,
+     "sha256": "fca7491171d58974ef6b15550b9a7f0474641e9eac7ee5de52c6980c96445518"
+    },
+    "my_progs/part_generate.qc": {
+     "bytes": 42914,
+     "sha256": "83b9718a85418143d92ea8311cc8cce69c1002eb7563710dfe7010ac52e15d50"
+    },
+    "my_progs/part_manage.qc": {
+     "bytes": 27407,
+     "sha256": "86eb791f4bba08fc0c965e9f81c90e7412ed2c910104d66a56cce1f3152808fe"
+    },
+    "my_progs/player.qc": {
+     "bytes": 27811,
+     "sha256": "1f0cc3eaf577c2af642495466c573cd6e226a4754902d9de9cbfc9c9ba28af0f"
+    },
+    "my_progs/progs.src": {
+     "bytes": 2482,
+     "sha256": "c773f107c562f731fbb30158422226bdc4576dd32aea0f02c122195e08eac96f"
+    },
+    "my_progs/pushable.qc": {
+     "bytes": 19823,
+     "sha256": "03b3bf9240db6e9532e45a3efc159129709f9ce095c3238daae32daddd5b07ec"
+    },
+    "my_progs/qc_highlight.xml": {
+     "bytes": 6348,
+     "sha256": "a7b326723cc1e4025e867ea5da00f54c944705600d740538aeb52f63cd027ab5"
+    },
+    "my_progs/settings.qc": {
+     "bytes": 62244,
+     "sha256": "78d9b19077028f9fd72f271aaae3d75b43e995ef95b7679df83a06fcdfbaf4f5"
+    },
+    "my_progs/sounds.qc": {
+     "bytes": 19389,
+     "sha256": "bb74ecc36a241db5a79b010f61200687c6db6e46297db39c8a2a8ce1d512bad5"
+    },
+    "my_progs/sprites.qc": {
+     "bytes": 476,
+     "sha256": "579f48b397914b02f8fb86dc24f23d4e63a4cd857df1f0eaefd6c83e9c49e238"
+    },
+    "my_progs/subs.qc": {
+     "bytes": 24000,
+     "sha256": "48832d667d7a932661ac914bc8e471843f2cd8a0985fc0458d7e1a2796e21d16"
+    },
+    "my_progs/subs_soc.qc": {
+     "bytes": 28453,
+     "sha256": "679112275e8b3597daac962074f69b6d9fd5614fc3dbff036815b9365e1413c5"
+    },
+    "my_progs/switchshad.qc": {
+     "bytes": 7054,
+     "sha256": "92a2fd4e5c41f21f46502781322ab87584bf0999d733db50e0e19b8bbea793b3"
+    },
+    "my_progs/targets.qc": {
+     "bytes": 58758,
+     "sha256": "e39b45bf6740be40c2899376e92d30d7d227a4762091d7b63e382c79fe6822e7"
+    },
+    "my_progs/traps.qc": {
+     "bytes": 24071,
+     "sha256": "9e4e822a36113bc73958fa45ab0b8c290a5148c95f3a4da7125676c984ebd202"
+    },
+    "my_progs/traps_pendulum.qc": {
+     "bytes": 17049,
+     "sha256": "b421f26fd80eb74715172e25f3ac992faa95397dd67d5f7ede286fd78384a468"
+    },
+    "my_progs/traps_sawblade.qc": {
+     "bytes": 9783,
+     "sha256": "9a6e82a05f09001c0a9cffdf6b9d6399691846c5b1ab1fbfb470e5772a87f44b"
+    },
+    "my_progs/triggers.qc": {
+     "bytes": 139722,
+     "sha256": "0ead1e997492dfe79a8c811a48b902217aafcd4bf3c49acea7101c99892886f3"
+    },
+    "my_progs/triggers_states.qc": {
+     "bytes": 17475,
+     "sha256": "2c4d25c11de0319cd54d81e67e651c8d29d22aca851988d21080ba5976137f14"
+    },
+    "my_progs/weapons.qc": {
+     "bytes": 44884,
+     "sha256": "d22ff6c46a101964e5e8e334a8d91ae8854e2eb6ca2c4565fcfc748acfcfd9e6"
+    },
+    "my_progs/world.qc": {
+     "bytes": 39815,
+     "sha256": "c160b7b050cc7a718fbc6ffe3dbfad85514936522bbabeb8ee4fb1a3c30b79d3"
+    },
+    "progs.dat": {
+     "bytes": 2347206,
+     "sha256": "5e69fece92fb4323609c8e1209a39eecf4f70c3161ae17beb53063fe3e06c340"
+    }
+   },
    "sha256": "3593cb2a95bc953107f49ea81e2527c1cc274d46892b22b902b0fd7669f02f0a",
    "timestamp": "2020-10-27T04:30:18.000Z"
   },

--- a/json/by-sha256/24/246403b4ff06f88c0255ee9f15a0206a261abb54a5247915be9213ded2508b29.json
+++ b/json/by-sha256/24/246403b4ff06f88c0255ee9f15a0206a261abb54a5247915be9213ded2508b29.json
@@ -373,6 +373,296 @@
   },
   "pak0.pak": {
    "bytes": 3563368,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "896bcddcd05bda4e9ad139f814079bf78410ff45719bbdfc955be8270c8a7dc2",
    "timestamp": "2020-10-01T18:45:32.000Z"
   },

--- a/json/by-sha256/24/247c9aa4469bf4155c965ed9b6a1bd2829afd21b11786a6e49f85183bce3b9cd.json
+++ b/json/by-sha256/24/247c9aa4469bf4155c965ed9b6a1bd2829afd21b11786a6e49f85183bce3b9cd.json
@@ -17,6 +17,140 @@
   },
   "loc/pak0.pak": {
    "bytes": 44306788,
+   "files": {
+    "maps/lordsofchaos.bsp": {
+     "bytes": 26962820,
+     "sha256": "7a825212a056a8c8559d2fc840113bd8d1794bcf2bf5b26fac030fed315c4de2"
+    },
+    "maps/lordsofchaos.lit": {
+     "bytes": 9207887,
+     "sha256": "3693169f0672cd02e31fe41397e4c443f6165303acbdee14e9dfe1017cf1041f"
+    },
+    "music/track10.ogg": {
+     "bytes": 5685103,
+     "sha256": "7ee860c5be2ef8720fec054b357e229ee72c66a598896764d48fbbe520050919"
+    },
+    "progs.dat": {
+     "bytes": 428138,
+     "sha256": "7acafa119d3fc11be39bb2c49cdbdd4fd1a3e970a4cc35db8b4dc6761c656777"
+    },
+    "progs/candle.mdl": {
+     "bytes": 24135,
+     "sha256": "5027f8712c36de87b3967e4e623fbc64d4e99644f5b805f7e21ec38b1532cc74"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/g_shotty.mdl": {
+     "bytes": 23380,
+     "sha256": "b919bbcba3f7f03fb8b82fa6d3b1464ca41e81cf29417cfea0de09658c698cfb"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 59539,
+     "sha256": "c66cc4f2c8aee10b9b9dfde86a12819eea6df55880763bf6e0e0fc312cde016b"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 29224,
+     "sha256": "a9c150fb5c19e6e0bf7ead5dcf6ae87d8e9745f4a439779266d0a258e16b6890"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "sound/ambience/chant3.wav": {
+     "bytes": 58328,
+     "sha256": "c9198518dae84f7b32fdceec07a73d2cc631465cdde52af8b15d5031b93abc42"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/hell1.wav": {
+     "bytes": 394346,
+     "sha256": "6ac948556b4b573b0e1b08cb42f59bc7f3f73059eb576e5e88b4759d923fdada"
+    },
+    "sound/ambience/horror1.wav": {
+     "bytes": 219508,
+     "sha256": "a7c88ce51c34b065ed16a5c1392949785b6065bdca616f054cf1f227216e01cc"
+    },
+    "sound/ambience/ritual3.wav": {
+     "bytes": 165420,
+     "sha256": "0cc3659ac5744852d1583cc39eeec9117ac320b764b7368e61a78fb7ff514f7d"
+    },
+    "sound/ambience/scary1.wav": {
+     "bytes": 190000,
+     "sha256": "d4c3fe916d9b55c9fa18dc2f31dedae9b2644fa57009ab45f5dcbf9b8031500e"
+    },
+    "sound/ambience/stingwhisper2.wav": {
+     "bytes": 132380,
+     "sha256": "ae7319c28e0a4e492623b7ddb48634978da043c16d4450f86b8edf7e60fa283c"
+    },
+    "sound/ambience/stingwhisper3.wav": {
+     "bytes": 75840,
+     "sha256": "a8cacb8aa3f57b53ea0b61913e9d9e2f888fcc3018d542038a44ea561456d86f"
+    },
+    "sound/break/pd_bricks1.wav": {
+     "bytes": 61786,
+     "sha256": "3829842a9cb395f99d07546be38263eaf0ee5bbed71841aa8c93864d55a7fb94"
+    },
+    "sound/break/pd_metal1.wav": {
+     "bytes": 44146,
+     "sha256": "c0111b94231bc3870cbb95ec03f13b2b44ac407a5d18b35668ccf231303cc8aa"
+    },
+    "sound/break/pd_metal2.wav": {
+     "bytes": 70722,
+     "sha256": "ce8250482e831c270cc3c8e9211b74a627b3e29159c2c8ee720dd11cafd365c1"
+    },
+    "sound/break/pd_stones1.wav": {
+     "bytes": 75150,
+     "sha256": "632d15db23ff70c23c199595b41a153ded67f664de46b7d0cbfa0228f071156e"
+    },
+    "sound/break/pd_wood1.wav": {
+     "bytes": 34526,
+     "sha256": "621865f52fc27fb10108027ce3eea18aaf17181751a3ba1ceee0c9c99da9f375"
+    },
+    "sound/break/pd_wood2.wav": {
+     "bytes": 33342,
+     "sha256": "77282f2c533b9aec72b232aace9078534db3f255f418efafdf769c7361a28e05"
+    },
+    "sound/dump/elec22k.wav": {
+     "bytes": 82784,
+     "sha256": "dd63a8517e33bbe7a75cd0d6ccb16835b73f83af8d31c0ae0277b7304f7d502b"
+    },
+    "sound/dump/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/dump/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/dump/water_59_02.wav": {
+     "bytes": 47588,
+     "sha256": "497d1f4ed49567058da6e2618097a06c947f8131a8205f2c9c09219296780cad"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    }
+   },
    "sha256": "3f06e93feb062f242ca76077bbba8e7b9ad06a71a8a4bf507e3104802c01103c",
    "timestamp": "2020-02-16T14:03:30.000Z"
   }

--- a/json/by-sha256/24/24a93f05c7c71af8993229ad5446ce45ae47d176b02cc27b71fdd85dde69afa8.json
+++ b/json/by-sha256/24/24a93f05c7c71af8993229ad5446ce45ae47d176b02cc27b71fdd85dde69afa8.json
@@ -76,6 +76,38 @@
   },
   "qbj2/gfx/env/black.zip": {
    "bytes": 844,
+   "files": {
+    "black_bk.tga": {
+     "bytes": 812,
+     "sha256": "da2ba52cadaebc206417ec2e0eae8aed3814481701f73ab868c13e6df87eb03a",
+     "timestamp": "2023-09-25T03:41:32.000Z"
+    },
+    "black_dn.tga": {
+     "bytes": 812,
+     "sha256": "da2ba52cadaebc206417ec2e0eae8aed3814481701f73ab868c13e6df87eb03a",
+     "timestamp": "2023-09-25T03:41:32.000Z"
+    },
+    "black_ft.tga": {
+     "bytes": 812,
+     "sha256": "da2ba52cadaebc206417ec2e0eae8aed3814481701f73ab868c13e6df87eb03a",
+     "timestamp": "2023-09-25T03:41:32.000Z"
+    },
+    "black_lf.tga": {
+     "bytes": 812,
+     "sha256": "da2ba52cadaebc206417ec2e0eae8aed3814481701f73ab868c13e6df87eb03a",
+     "timestamp": "2023-09-25T03:41:32.000Z"
+    },
+    "black_rt.tga": {
+     "bytes": 812,
+     "sha256": "da2ba52cadaebc206417ec2e0eae8aed3814481701f73ab868c13e6df87eb03a",
+     "timestamp": "2023-09-25T03:41:32.000Z"
+    },
+    "black_up.tga": {
+     "bytes": 812,
+     "sha256": "da2ba52cadaebc206417ec2e0eae8aed3814481701f73ab868c13e6df87eb03a",
+     "timestamp": "2023-09-25T03:41:32.000Z"
+    }
+   },
    "sha256": "fc4be16661e42f6c2956fab23353c01f96510ce21b22337bef8630b531dc4a6a",
    "timestamp": "2023-09-25T10:42:36.000Z"
   },
@@ -721,6 +753,38 @@
   },
   "qbj2/gfx/env/white.zip": {
    "bytes": 856,
+   "files": {
+    "white_bk.tga": {
+     "bytes": 812,
+     "sha256": "fe811d05291fb913145eb1574e06444c813fb15b78bc5d9fd52e2a62c89d72b9",
+     "timestamp": "2023-09-25T03:39:02.000Z"
+    },
+    "white_dn.tga": {
+     "bytes": 812,
+     "sha256": "fe811d05291fb913145eb1574e06444c813fb15b78bc5d9fd52e2a62c89d72b9",
+     "timestamp": "2023-09-25T03:39:02.000Z"
+    },
+    "white_ft.tga": {
+     "bytes": 812,
+     "sha256": "fe811d05291fb913145eb1574e06444c813fb15b78bc5d9fd52e2a62c89d72b9",
+     "timestamp": "2023-09-25T03:39:02.000Z"
+    },
+    "white_lf.tga": {
+     "bytes": 812,
+     "sha256": "fe811d05291fb913145eb1574e06444c813fb15b78bc5d9fd52e2a62c89d72b9",
+     "timestamp": "2023-09-25T03:39:02.000Z"
+    },
+    "white_rt.tga": {
+     "bytes": 812,
+     "sha256": "fe811d05291fb913145eb1574e06444c813fb15b78bc5d9fd52e2a62c89d72b9",
+     "timestamp": "2023-09-25T03:39:02.000Z"
+    },
+    "white_up.tga": {
+     "bytes": 812,
+     "sha256": "fe811d05291fb913145eb1574e06444c813fb15b78bc5d9fd52e2a62c89d72b9",
+     "timestamp": "2023-09-25T03:39:02.000Z"
+    }
+   },
    "sha256": "667e407f4a6d10669712e244d77139639d3a869c2a4b01cb304f1f55b5c1f3ec",
    "timestamp": "2023-09-25T10:40:24.000Z"
   },
@@ -1341,6 +1405,360 @@
   },
   "qbj2/pak0.pak": {
    "bytes": 4739584,
+   "files": {
+    "gfx.wad": {
+     "bytes": 121132,
+     "sha256": "fdcc42f0dad313b297845f4a4daa79dffb541dc7fdfd13c6e8610df9fd614f72"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 409928,
+     "sha256": "09a74450da43c473e8a1fb6619e5c2e624162a995136643cec55ddf6fd102dd4"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "898d694265db0f933feecfd2a843557a6954a5f2aea05ecf9a852314119dab61"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "03e0973ee5d434c037699f9568228ab80be0df882ca77c88a9835b2d2edf0649"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "eaa6d0215df9c68ad98737f1ee24acdd34b27b734fc8173778066d742452ce99",
    "timestamp": "2023-10-24T03:04:16.000Z"
   },

--- a/json/by-sha256/25/25600d067aa318a670bfa3f00541e49cc9c237f9070a2ce037e517ac50c09cbc.json
+++ b/json/by-sha256/25/25600d067aa318a670bfa3f00541e49cc9c237f9070a2ce037e517ac50c09cbc.json
@@ -122,6 +122,348 @@
   },
   "bored/pak0.pak": {
    "bytes": 4121856,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 84008,
+     "sha256": "71ca4520d72ce40ba3a2992254aa6c2e87cd116b929fd87cb7e5c89fd41d9a44"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "b1deebb2268d373683100cc9df4c9dcbf817f9bdb0e3f2cd13edde0037609b53"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "11454a7ec41855cc66adc9b80e60b1c76b0af873656d46cc20543ea4d2a7ef8c"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "d2a59d07042577c9c5a5ceace5ad0e3893ba3ac2d206f039f11cf282ead3945e"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "63f869e1e553ccae238279e4b78c902463505a3d1dd7c5d21d4f4acbb56857ee"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "6e3d8ed0cf22d78c0e05bf75837214a12f647fda33da1fa1ad1195cff3cb9681"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "35db83f82066ac1db85f4094dc9710e313b638e019d8e4d6fb5abf0457d506af"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5972,
+     "sha256": "7cc986fb36b049b6535ff30bf00422c8b0c8b9d1b748da758521bba2d7a2e693"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 10548,
+     "sha256": "a434dec81d8f7c558bf1afbeaff564872948ea94602aac68cc60037e30d98eb9"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "921783f3e7fa793f8aaf8ec1de4a927722d70c3f42d3d550abcf53d4f1ee2bae",
    "timestamp": "2021-01-05T02:34:34.000Z"
   },

--- a/json/by-sha256/25/2599f2952d2e21d64bbd6a978c30c146ee2ad1599c2072210f33352feee694b5.json
+++ b/json/by-sha256/25/2599f2952d2e21d64bbd6a978c30c146ee2ad1599c2072210f33352feee694b5.json
@@ -33,6 +33,2488 @@
   },
   "alkaline/pak0.pak": {
    "bytes": 369038894,
+   "files": {
+    "gfx.wad": {
+     "bytes": 112836,
+     "sha256": "adcfd1a8eb006ae223c555b119939012e2ee8748ab9fff490405a783b5d17586"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "27b15708c82632b61e383cfe4628cde02f8c2660552ab3e0e90a9a7222751733"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "b9f4ae962a6faa9b6fc69cfad3bdb08b17aa2d00cc29efcb7089c80f14236ee7"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "937a27ae44a93b86c49c0ece1f6830218aa634107eea89cf47bb7dfd248ac678"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "8fc3dac00b9a391c908ffc8a7a627c04fb420aef32958ffee72bdc85b7badf9a"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "a83bbd7b2e60ed478895c21b5e9d2ddb9f45cd89f109fb1f46d5d2a811288e93"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "b4044d9deee01bfbf4b220a5f84499e4e1de1341ef35a0ccd476de0d0bda483d"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "b4044d9deee01bfbf4b220a5f84499e4e1de1341ef35a0ccd476de0d0bda483d"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "8603e7809a482020b379047fa1cca98565a560b498bb52e2f07315468f9b59a5"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "18dac4ae3446aced17a9ce312c2a17291c2c22594f29f5f61e94cb63cc1b2dfc"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "4fcea0bced124c5ec1615d4e847fc5e82991ae7ec21182ef5d8735e2d7e355fe"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "fed5b9fb144a5b6147a283da96bf4f568fb123ee4f51b2209d54b96a0813775b"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "4b3d75dec2f6e2e968e46f824e985cc60b5fdf28526eef03b75b05004f255cd9"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "462ee7001b43512dcf58dbd59f418d67f007c5ead8de36a7d45e3ad9f864d7b6"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "873af58b7244d6e82feb1af26ac044c9beb43c2865bc51d0485054a562ce861e"
+    },
+    "gfx/env/abrut1_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "ffc96027930f197262bf224619f4f793b3f9792ca5ed0ad4a810de0469146bb4"
+    },
+    "gfx/env/abrut1_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "12aba296663e41f26d229f62baf24161fca2d06874944fdd738d452cfed12e22"
+    },
+    "gfx/env/abrut1_ft.tga": {
+     "bytes": 2216388,
+     "sha256": "1ffb28d2baf5809ff3ddd4dac1123e39568af6060f33671cbaa5b9366eb093f1"
+    },
+    "gfx/env/abrut1_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "40610c9f33267572a0979b37d1d01fe214254045adb80cda9303d1c4fd09d77d"
+    },
+    "gfx/env/abrut1_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "26df0c46008298c0570712f5a62fd8208dc3e319bca4bcc849a4fcdd61d9e52c"
+    },
+    "gfx/env/abrut1_up.tga": {
+     "bytes": 3145746,
+     "sha256": "8155aa7bb051a2887d74ff4a94cea6007ecd20fd5dfc33856d43dae7547ee77e"
+    },
+    "gfx/env/ares_bk.tga": {
+     "bytes": 481498,
+     "sha256": "907a96e8feaada0ea37d72d99070961883ccdfba8a6b3914dcbb9afc472d18a8"
+    },
+    "gfx/env/ares_dn.tga": {
+     "bytes": 763001,
+     "sha256": "fcc51de57b71899ef969b8380ebd22269aa1e9957bba845413cb4f5394cbe49a"
+    },
+    "gfx/env/ares_ft.tga": {
+     "bytes": 490443,
+     "sha256": "8c109f48b7240f7138353a19017921660ccef0260945ae4a4792ba12c7bf3730"
+    },
+    "gfx/env/ares_lf.tga": {
+     "bytes": 503381,
+     "sha256": "ce0a40f558e72dba7653fe7f693d7e0406afa50aed1fcaac6cda2e857ac55a46"
+    },
+    "gfx/env/ares_rt.tga": {
+     "bytes": 497671,
+     "sha256": "a8033bcdb9db86386582caa29e8aa53946821266da730e17b775869a5458cbbf"
+    },
+    "gfx/env/ares_up.tga": {
+     "bytes": 106191,
+     "sha256": "d0489c8c9606a31fa3d929c1f2c561a162116333edda74f9236203eeadb1a74b"
+    },
+    "gfx/env/bal_goldensun01_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "8dd0cf560f2de9833865050d4fa50c486273ecf2db7168cac9cd2f1166cdb806"
+    },
+    "gfx/env/bal_goldensun01_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "611e10e6e603f6ea3734cd9316b8d3698e25cac289beb48b3e76c13cb4f79066"
+    },
+    "gfx/env/bal_goldensun01_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "612c6bfe6d6a3d395b46e3e2626e1b23a4b3ae92ed167fd0191236671a0bf3cb"
+    },
+    "gfx/env/bal_goldensun01_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "09583bed6543dfa818632ae73c9afd3dea4b0bc9547db6feef0d421dc7f8f243"
+    },
+    "gfx/env/bal_goldensun01_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "95792a9157b001f70c55bd3904ae370db3a9b96201616b4e57dc8cc67c5bc1f3"
+    },
+    "gfx/env/bal_goldensun01_up.tga": {
+     "bytes": 3145772,
+     "sha256": "54697cce6de2daf89657816d2f8f6ceffe2008c329b1e8fc726b82e28d726955"
+    },
+    "gfx/env/cloudedsunglow_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "bad4922c68c66ceadfbe265a9f1963cd665273884c1c9e8937afbfc06f638c08"
+    },
+    "gfx/env/cloudedsunglow_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "4b4734557cc066c27d4a1ce2ce0cfe4bf77046f6d0faaa33b2ee80f3c97da4cc"
+    },
+    "gfx/env/cloudedsunglow_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "7a7712db51baecce806e5685611bf870adfe4ab52077a91b955f17f052d6edb0"
+    },
+    "gfx/env/cloudedsunglow_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "ee6c2afb805bda6280fbfacbe512487032e5056b54c4a1032f5cd24e281edbbd"
+    },
+    "gfx/env/cloudedsunglow_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "1122c6e10b539b2bba2f906a10e54a116e34e10959714d5e6266a574eaa74ade"
+    },
+    "gfx/env/cloudedsunglow_up.tga": {
+     "bytes": 3145772,
+     "sha256": "38d210fc9dafc0cb375831c139b618020a26603bc6170cea88aa51e35fda738e"
+    },
+    "gfx/env/nebulabk.tga": {
+     "bytes": 786476,
+     "sha256": "9f39d79a62c92fa382872342bab06b300b7db15e337acd2c97ae8f2f629173e6"
+    },
+    "gfx/env/nebuladn.tga": {
+     "bytes": 786476,
+     "sha256": "283ccd8776d60b0f5241033ef905914c58888270bd9cbd4c49115fc6055bffc4"
+    },
+    "gfx/env/nebulaft.tga": {
+     "bytes": 786476,
+     "sha256": "abb8ed2d7664344f053231f1be6311eba3f4319d801ae4218a235c8e6cd4b67d"
+    },
+    "gfx/env/nebulalf.tga": {
+     "bytes": 786476,
+     "sha256": "c5be0fd1bb66ae32f2063811a2fd0dac080aa61838d7588e1ef5552f6c348674"
+    },
+    "gfx/env/nebulart.tga": {
+     "bytes": 786476,
+     "sha256": "f5acb0f7e12b10242ef98d9ffe07bb3bf68016ab68d6f80208f528e689ab5cbc"
+    },
+    "gfx/env/nebulaup.tga": {
+     "bytes": 786476,
+     "sha256": "7a7c9424022598d8d74f68aad4f0b73f0858ae57a5725fd53a860a9f6aae050f"
+    },
+    "gfx/env/oz/ozymandias_bk.tga": {
+     "bytes": 786476,
+     "sha256": "98b447eb25cd2cc53362f7900c4452ce9ceb4901ec263df56a4520a4e39bddae"
+    },
+    "gfx/env/oz/ozymandias_dn.tga": {
+     "bytes": 786971,
+     "sha256": "2354852349f537cc4eb1567f1e7c71b8b5891bbfa03d4350708296cab505abc2"
+    },
+    "gfx/env/oz/ozymandias_ft.tga": {
+     "bytes": 786476,
+     "sha256": "cda9321e88d17c9e8d8ed9295d9047e8b3dabb290e2fe90af05321bf6b05c973"
+    },
+    "gfx/env/oz/ozymandias_lf.tga": {
+     "bytes": 786476,
+     "sha256": "4a8ae725bdea8a0355cdcc09b690d0d556c31240344232bc90fcae71ab605599"
+    },
+    "gfx/env/oz/ozymandias_rt.tga": {
+     "bytes": 786476,
+     "sha256": "16fe8a636eafd70c8d5833ca54b9c4da7f6d4a196f1126c781d79805b87e268d"
+    },
+    "gfx/env/oz/ozymandias_up.tga": {
+     "bytes": 786971,
+     "sha256": "88a59bff68e1ba4cd29e66ff25c88d3cfbbcf2f5089fb82e9addae1edf2c5566"
+    },
+    "gfx/env/yellowozymandias_bk.tga": {
+     "bytes": 786971,
+     "sha256": "8a35fde493dc59cf93bbffe5be0009f4ad55f5d308b89fdcf1bc5eb576e437be"
+    },
+    "gfx/env/yellowozymandias_dn.tga": {
+     "bytes": 786971,
+     "sha256": "74a6578af6cabf5ca00ded9140507df3e2381d2ffa6a3c4248b6c9251d931108"
+    },
+    "gfx/env/yellowozymandias_ft.tga": {
+     "bytes": 786971,
+     "sha256": "c3a5318ec7d8a342fe8d740926d83a1b6c8e13fb138cba854addbe8fdb36ec82"
+    },
+    "gfx/env/yellowozymandias_lf.tga": {
+     "bytes": 786971,
+     "sha256": "b316cf00da8bd01752d04b53c093467490a31d964cf33c1b50eae11e942a3003"
+    },
+    "gfx/env/yellowozymandias_rt.tga": {
+     "bytes": 786971,
+     "sha256": "0eb644c5c01e47da3b70aed3dad8873cb9e39ac4b4893adfa564f7a7a8ad1e5f"
+    },
+    "gfx/env/yellowozymandias_up.tga": {
+     "bytes": 786971,
+     "sha256": "9806eb94899fede2fabaa6474e98ee43c73d83e3df8ace7046e0041a537d0ece"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "72def5acc71e30f5c46d88776f104d597a75889320cbc71ac5f5083bb019f4ee"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "cd0c745e596620b3789c9486e492e08a2cdbf912f43a80424bf4d82c410e7f81"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "eb12c35ba4d943aad8e43a69d86163dd7fb4da7e480527d8eb015c2ef44dc7c5"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "b843c2f32f815fbe26e17e704c82e12b3dbd8382286708e2e08954dc4fd0699f"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "f7f541249e0b6289ea213241dd363818900de9271eacb5efe1f895283525f193"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "1d7ce06832c260437630fa578dc385ee406eb6447707642b363b5aee5981a1d0"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "30ea068bf066f07f3490e969b954f513cf12d02b4a3ea9b66b2a41ad0f4714c4"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "1fb31ebefd39b956f3cd464cf06ea6dd7f433ec19a11ab28ee2f9670f8ab78db"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "a23ba60ea8c81d9aa4d287ae490fc608363b44ea7554c01a31c023101807d9ee"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "f787ebe1dfdb3621f7f8506f3d931d9cdb26b24923ee3fbf69e84078aaf64500"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "fb127ad952f3ab2e9e4a99308fb39a632cfa396a4a9b81007673a3219f4b6a9c"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "f787ebe1dfdb3621f7f8506f3d931d9cdb26b24923ee3fbf69e84078aaf64500"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "49d02859701c2abfe63c9ae82175ffc1a62f1774887ee536aa6bf946ded53ea9"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "eaa63f0a8e3bedaa9239535bae85ab3db5414568802a839c262b11e8cbdfe0f7"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "b5fb1ea7c6b588ddf94110afb087cef3a641538b4f3fee7db7eea856a3c4fc56"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "540ec25ff6f38717d2434c05c306f4cdebd89ac730c4f0c174d09c41b08566d2"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "1f9085ca6ecc5486eb8032eebffd7c0a49f9c32cc23f5b22d4ef1f36a1fc5f78"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "35dfa9a1f517ee5df2074ac296b3fb6a9973e79174070e8a84e1d45aa3f48df7"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "6387ad33d67c174986dc050c71d2f9bbf8a9326707a1c7ec727e82fbe7744452"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "7155644edee5239dfe33b0d66234a8c6a5ba76bffa34b35726d0e5a3d1c2f1ec"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "3952e0a4b7cb59dc0b6a0a2a7b0c852984ee95e1e64748edd7d8f26285609c04"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "7e83a9af3ef1d8a3752214f23be944f7eb271c97277b0b0dd8695f68e727a2d6"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "b963dbc6e2865a6d6f6e7b3918530de8e09ea0f27074e899111ef5047f0924ff"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "93852ef12d6ded4394a63917a7aac405f074a7d2b9c60c92bc56f90c6e461f15"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "1d91189c168d0635376bf3b389b5948400e097648b889f0520b8ecf5adcee175"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "b407974a969c49d894c01621e921860942ad7d15fee0d964471cdccd670fe01a"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "aeac141117ab82eae94068d9c304d8023d5496ecdbef97c69e9744a1d482d4b2"
+    },
+    "maps/alk_bdown.bsp": {
+     "bytes": 12025688,
+     "sha256": "6a723ec9fc45c3a5d7f14598fc015b2d3afa7cce72f49273edb737b53455a491"
+    },
+    "maps/alk_bdown.lit": {
+     "bytes": 4455224,
+     "sha256": "6439335977166aae0885ce8bd816d7e66712b4b17c7d0957051f44a0a8d036b7"
+    },
+    "maps/alk_core.bsp": {
+     "bytes": 8861344,
+     "sha256": "d580937b77c67ce2c335461d385565199a8f198ae5e5e581d8a8c3b12cd39b34"
+    },
+    "maps/alk_core.lit": {
+     "bytes": 4184984,
+     "sha256": "00af1b4cc1529348744666a15a1b4f31283a3b7290eaed6640fce2afe4c56066"
+    },
+    "maps/alk_corrupt.bsp": {
+     "bytes": 17491232,
+     "sha256": "b40827ce3fd926ca9a2124c3926b045739012246310277d64dfe3a65ac24aa31"
+    },
+    "maps/alk_corrupt.lit": {
+     "bytes": 10774796,
+     "sha256": "6725e52f0417e8d960ecbb0615d2395bd376a91756f385eddcc944e46921e626"
+    },
+    "maps/alk_dancing.bsp": {
+     "bytes": 22618452,
+     "sha256": "e611dedc66b00c0376dee2bfd7eb3d5a6e13df3042967926b217b71a465a3c4f"
+    },
+    "maps/alk_dancing.lit": {
+     "bytes": 6881552,
+     "sha256": "41b45f9f12bce963e34dfdbc02efe5163065cf822322143920ce803196208eac"
+    },
+    "maps/alk_eclipse.bsp": {
+     "bytes": 9670156,
+     "sha256": "fe4afc064ba2d1bad7c7cc4f4a387f18b74beface53f0405fc4c93e85fa75166"
+    },
+    "maps/alk_eclipse.lit": {
+     "bytes": 3090644,
+     "sha256": "039200960a1d9d9d1895a3b798b6e3a735be9b5d19ca32e3c5c3f37b61ee0854"
+    },
+    "maps/alk_geo.bsp": {
+     "bytes": 13965748,
+     "sha256": "f19b3703532702d26c330143aa17cc75da2f3dc61639eed46d0640b7037ef458"
+    },
+    "maps/alk_geo.lit": {
+     "bytes": 5853773,
+     "sha256": "992e901246303d3880c4151d6b472eee2e0fcb679c4889cc462dd9fb166c1eea"
+    },
+    "maps/alk_pipes.bsp": {
+     "bytes": 7516420,
+     "sha256": "79f624b1efbcfe04bf8822dab7a47c8a210bc84899081e8fdf1de28aad672f82"
+    },
+    "maps/alk_pipes.lit": {
+     "bytes": 2407547,
+     "sha256": "c65db48a15500e0f2510c691cbb8907ab4d20b2c4aff06a04c10c3fa6589ebbc"
+    },
+    "maps/alk_sickness.bsp": {
+     "bytes": 1799200,
+     "sha256": "ffc5a9cd48f2f6ea2267b30d36016b55ee1d9cb7e9d953829c26a5fca16deb1d"
+    },
+    "maps/alk_sickness.lit": {
+     "bytes": 588482,
+     "sha256": "3b9eeb625c7fd3d6f8d83c99b4e415e12dedd561f6619b03d0cad7b30548b07f"
+    },
+    "maps/alk_tellus.bsp": {
+     "bytes": 21314324,
+     "sha256": "dd0284e2405889b15d2f529c006624b7411e4093ea4ae231e3d51d2b411130fd"
+    },
+    "maps/alk_tellus.lit": {
+     "bytes": 7701911,
+     "sha256": "8f67dd0241b68392bae40b66f8fa488e955668557ced3fd98d122799d75e7313"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 20040,
+     "sha256": "61c46ac5672c1e671c0c38a6498158176feaa62b074621c2a3d74e5dfc68e2f3"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/enemytest.bsp": {
+     "bytes": 663076,
+     "sha256": "2f315bf648b83be0fbe07a12399ef8ba5c4c2c06e7c9a57b0c48d18beb788e99"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "maps/start.bsp": {
+     "bytes": 23112888,
+     "sha256": "1eb0afbf89deabe104bd87973eb5c80bd77266e64f116a57e2250aa0f855e76d"
+    },
+    "maps/start.lit": {
+     "bytes": 1807172,
+     "sha256": "328534a6998417739b8f3863ca265d506d9eb4bd71b5079e40e2dfc2e6513c7a"
+    },
+    "music/track03.mp3": {
+     "bytes": 3334103,
+     "sha256": "301569d9acb6ea22a7f70399bd8dc7492b3a37460639f8a81f216c870f5e38f7"
+    },
+    "music/track111.mp3": {
+     "bytes": 6863436,
+     "sha256": "e7a3d6839901658fe526d417b35702aa033ac5c9b4fff75171ff195d873e70b9"
+    },
+    "music/track17.mp3": {
+     "bytes": 7796677,
+     "sha256": "12b2d8f4f204cfef4483f57e6372918da4ac3ab802b8181dec503b44017c26e1"
+    },
+    "music/track23.mp3": {
+     "bytes": 3058688,
+     "sha256": "1314c567643e49671286452ef38a6d6fbd1b6f848bcfa4b8cdc2448d4fe580c1"
+    },
+    "music/track24.mp3": {
+     "bytes": 2108561,
+     "sha256": "c6aa56c8c6a71e3e5b6701661d1ef472fa57bc51db328ea79fcd6df92805e8cc"
+    },
+    "music/track37.mp3": {
+     "bytes": 6798568,
+     "sha256": "e1ffc4653ae8449219b97e601a66a109f6c96a01d276699ab1ad87b0830b0021"
+    },
+    "music/track44.mp3": {
+     "bytes": 4594207,
+     "sha256": "3046432076ac4fbe4e695a2a0d5f0b153aa787554e289e89370e053e867b9aa3"
+    },
+    "music/track51.mp3": {
+     "bytes": 6497719,
+     "sha256": "78c733c8c23c4608cc7ef1ce741a20c3c9242a474d00660b97ee1f6176a8424c"
+    },
+    "music/track68.mp3": {
+     "bytes": 7361558,
+     "sha256": "5e09f36665f9a7fb53c58ac8a96345e1d1ae79c80df1f277651126471ee205e9"
+    },
+    "music/track69.mp3": {
+     "bytes": 3236804,
+     "sha256": "d2524feaec61240504fdfcffe9a3f1988c7dbf33c11e085ae97f9130c7fd39d3"
+    },
+    "music/track87.mp3": {
+     "bytes": 7425506,
+     "sha256": "b570d9d8a1b442b7f98ef56f0bb6966192e404c9e593ce91df108d6077f780e2"
+    },
+    "music/track90.mp3": {
+     "bytes": 6567853,
+     "sha256": "357d4bf36b7cf453900354aa1f4617a4847039acfa00baed80a54272cdcfd913"
+    },
+    "progs/arachnofloyd.mdl": {
+     "bytes": 741212,
+     "sha256": "554bd2ad34a830fa01a61dd4972f432812fb61f7815ec81d8a8d7e87bfad6b02"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 164224,
+     "sha256": "35314143b9c7a9a0e26e52a865072a6e73862466e640c6bbd58be3075c4d93ff"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 191852,
+     "sha256": "01dbaa1f54fff28ce64d70aab05f73853332952b76deb2f7f48fb137fce3ff27"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bambler.mdl": {
+     "bytes": 128044,
+     "sha256": "c8ac9dbcf99f0e6efd30496ac414383c26b8d241fbaff56cfa81dfb545dfb0c8"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "698bf740683ad182feae2246526361948be6da2e144f1bd0202eafa748213ec2"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "b662513bc3a8e0e967344c55b536bd33012340dbeb79a8db1281d2c84e36d338"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b2cf62d8e989789bd76e27193b2f5205a93d4172a4e25c89aa1b30f75bebe60e"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigcranea1.mdl": {
+     "bytes": 92792,
+     "sha256": "81f6a5b55d3a585d5e9c73b088d1d20e0fb328707c1539ef41e52c460555f651"
+    },
+    "progs/bigcraneb1.mdl": {
+     "bytes": 21940,
+     "sha256": "e02faff0bb6c84c781f6b534a5a06ac1f977a028fbdcca176be2932f91e9e8ec"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/bloodshot/energy_beam.mdl": {
+     "bytes": 11244,
+     "sha256": "f318ce49a12ef1cabf5ce0eedf1cd3319e11a15fd1aeca1e1ddbde5d591a8e22"
+    },
+    "progs/bloodshot/turbine.mdl": {
+     "bytes": 48692,
+     "sha256": "68a5c5860542617cd93541509e0d7fe17d18eb3e9453e217566909daea5ddfe1"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 221936,
+     "sha256": "6e8e12db297f9f70cbe00fe2087be79a0011dc31344e642d8f309947e63cad8d"
+    },
+    "progs/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/chain2.mdl": {
+     "bytes": 141764,
+     "sha256": "9334a3ec04716ce0068154bf7abb4c1e3ee6de14fb159982dd547314935d7854"
+    },
+    "progs/chinok.mdl": {
+     "bytes": 43544,
+     "sha256": "861cbe8bcf369e55d9687fd791b5b3e5813c1511522e594b9094f7614559af0d"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon.mdl": {
+     "bytes": 102120,
+     "sha256": "2635e03bd1e78e3e6d3f9f78c2dd4dda7614a3eb4dabd750a772ed80565ebdb2"
+    },
+    "progs/dog.mdl": {
+     "bytes": 317660,
+     "sha256": "d5615d6d0c3b7fe4f284d0fd153a6ea831f5b723ad3df815e10b942533ef6d0e"
+    },
+    "progs/dread.mdl": {
+     "bytes": 183400,
+     "sha256": "efb1827edaced94142bb040b179cff11de98c097aab7fe13c80efadadc742314"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "4709f92753b0b4864478f3fda8d3dd1f56f1044b925c7c389c74c1ae1d5d9f99"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "c71f668f610ab60da14a388ac15061a129b49b51c83425c9b2ae110faa14d67d"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bcc6396dc638003480dba8c36cafaf32df2cfcf49bd460b001d0d74a164f9011"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 224812,
+     "sha256": "a0853d62de481a565d4757e32c9159494019574f4660c8f0af9898f54dc5ef89"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "d7fc256175268c45b18039d475c19297329c07cafb952c72dd4964d2730537b3"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 1292110,
+     "sha256": "9744b245843ac280c21345ef83642bdd9dd36c8f5a91e6b50f6462209a226fae"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f6c43a5d21e1675e4ad95acbc1a47a3be07ccb74fffcb53574f00945d5b06cf9"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flag2.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flagbig.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 133216,
+     "sha256": "3dc8399722b957bd7afeac28b7b01985d2fbc08ce127a739a9cac1dc945a875f"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/fromitz_still.mdl": {
+     "bytes": 6964,
+     "sha256": "63204597e828e001c957e9316878995e161da0502764276b90285accadf6a222"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 35488,
+     "sha256": "4a04aaea3b65ef8be1e9ae5e2448bf5fcb530492241a739b689f7380ba509de5"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "15f390e39e02c8524e575ca8fadf63187b641c58210ee9587b13a0ca94c29cc2"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 48244,
+     "sha256": "da03e8ee6c7cc410bb47b3137346cc7dff151770f7f41a42bf6c445fff473c02"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 199076,
+     "sha256": "8e2c3987f1aaf87b1181fcd975ce4cdc8a36738a2802d3535e2cce465fb55975"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "8b05b8ca87ea867c2a2397d238311fda2441f5c0e1cde130ba487b0dbd17a8e5"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "77ef7027b6c0b5a6c96c6740896bc016412e60c3098cc0d0077a284f2b3708b6"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 16308,
+     "sha256": "97f17422aefc3d80a4942be5990c9784b17731a31fb9559e5bbde5ec0fe8b6a9"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "8f9824990808ebf06e86d3bf245321cae87a0b98bca2caaacb598f9ecdee85c3"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_arach.mdl": {
+     "bytes": 60292,
+     "sha256": "daca6412383bec28809cee42c4ebf01085cf83ed6ff289114ba0f842b4005251"
+    },
+    "progs/h_bams.mdl": {
+     "bytes": 37316,
+     "sha256": "58c4644a2ed3e5f10741dff2ad1a8bb161f7eb205ba3fd8c5fc9b7e4ffc571dc"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 27652,
+     "sha256": "6ad407e4117bdd615009d4918d32094d9a8b65c04bb1c0abda9a42d288e59153"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 14868,
+     "sha256": "f6f5024acefedb0c431fc0b5b05f4c9777eccbf26b8c51337e212aff0e66db64"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 11828,
+     "sha256": "2472f8139353f10017eb9a5cfa1edcdf0d8a42b419213a14deefd3f34556a1ac"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 909361,
+     "sha256": "f8ad2dc18653e36630eae567633d84b2e03a52a6cd8c125edafce1c87ff18c8c"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 37012,
+     "sha256": "e3c6cbabfe6c6723101f2e59f50fc99ee0e360571c95885d2d56c85eefade15d"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 8372,
+     "sha256": "9b6a8f7a49fb7a1f5d4d409b708663c579d433e978d898b9bdf00291a59b4e6c"
+    },
+    "progs/misc_barrel.mdl": {
+     "bytes": 43684,
+     "sha256": "8382db232b9a8a6cf6f11009bd8d1806b52ee840c520cea72cfbf5b57c240f26"
+    },
+    "progs/misc_barrel2.mdl": {
+     "bytes": 130972,
+     "sha256": "cc8ebfd0da975358077a6933cdcb4f7ab627ad02c7bd8612f05eb1c873926c23"
+    },
+    "progs/misc_barrelq2.mdl": {
+     "bytes": 60380,
+     "sha256": "04c87c0210d772c53ffc134a5a2a065394dc32f5b36b30c5f24d927bacc24633"
+    },
+    "progs/misc_bigflag.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/misc_cable.mdl": {
+     "bytes": 57780,
+     "sha256": "bed2cca38ef4cbefa9e645eb5e9ffadffac6ebb4f2ac5f6da4bb8f354de22a48"
+    },
+    "progs/misc_cables.mdl": {
+     "bytes": 433607,
+     "sha256": "03c41af692903bb854cc5c05c0a8a665f312a04955737ecbac1a65a4113f6d50"
+    },
+    "progs/misc_chain.mdl": {
+     "bytes": 231184,
+     "sha256": "845fc3117f7d9860f2d0aa4a398103a13f327516144a96db508189ae1be5788c"
+    },
+    "progs/misc_charger.mdl": {
+     "bytes": 117672,
+     "sha256": "a64a62cd67894222e1b2ed25332db70961c18d0cbdffe32b17f0dbac93bb2ceb"
+    },
+    "progs/misc_corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "0287c3e7886bd2d6d1cbb504529d9e11038d0f8232ee624528eb0ccb78733c53"
+    },
+    "progs/misc_corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "22f82f29d0a88af204f7b97eef887b963bd940e7277b6f5cef5e6f3610f2ea51"
+    },
+    "progs/misc_corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "41e90f1a84e9779eb12541d923ab0a66e69deef3a9dbc82259ab84cb71b68dcc"
+    },
+    "progs/misc_deadplayer.mdl": {
+     "bytes": 562960,
+     "sha256": "83bbcf4cb5858aa9ac03323b461b3e3b09a28f56e212645472219d7d0b0979d8"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_extngshr.mdl": {
+     "bytes": 25732,
+     "sha256": "fc8dec001f22c4666f6c5ca65e8aba18d5b22ed8aabbf0534d03913e821e3120"
+    },
+    "progs/misc_flame_big.mdl": {
+     "bytes": 244895,
+     "sha256": "09adba1308cdf22d2f07e226cb13a35e51f4d54866f84f41e2074dc7a40371d5"
+    },
+    "progs/misc_flame_med.mdl": {
+     "bytes": 175400,
+     "sha256": "31c94bc48e6c6d6bc31bd14b8e257c4e74d45aaec3a4d5d5bf83587a08ac7c00"
+    },
+    "progs/misc_gen1.mdl": {
+     "bytes": 256884,
+     "sha256": "7a9124bf7628dfcfc1c43ab6624bd8cef4ac5ecbdd8a00a00e8f957f0d177ec5"
+    },
+    "progs/misc_gen2.mdl": {
+     "bytes": 74708,
+     "sha256": "c93a3f7fbda97841c0c9c7c9b2603d9e388390ab30861c4b1553285985f761a2"
+    },
+    "progs/misc_gen3.mdl": {
+     "bytes": 472728,
+     "sha256": "29032f4dcf60216906ef601d5a6bf20dba71ed5b7ff8260e7f61159b6b8ea1e0"
+    },
+    "progs/misc_hangman.mdl": {
+     "bytes": 96500,
+     "sha256": "feb2473a29e56ee278e4cdc9676306fdf3aa609b527ea4aff23bb86e3900a2d3"
+    },
+    "progs/misc_heating.mdl": {
+     "bytes": 243876,
+     "sha256": "a6ab88ce55f16b670b9ba8e42e96c9ea49acc71f124ce20c0de5fc2c0232e2f0"
+    },
+    "progs/misc_helijet.mdl": {
+     "bytes": 102656,
+     "sha256": "9dc737185928f080758e5a662ea8fd189fcad1aed4fe4547f76d73983bec9c72"
+    },
+    "progs/misc_helijet_pilot.mdl": {
+     "bytes": 105556,
+     "sha256": "8ee41a7ac244289b007921b70fd34f322b4451172f35b0c5b33400064d1c3a2f"
+    },
+    "progs/misc_hummer.mdl": {
+     "bytes": 180541,
+     "sha256": "c41208ecff2f7ea0b037f378aad5fa309af5d946eae009ace2478a294aea9b45"
+    },
+    "progs/misc_levels.mdl": {
+     "bytes": 35732,
+     "sha256": "7cf9a4c1e556e60dd4e593cad4a2be0b45bea8893d9b5232ecc7febca4bbf5fe"
+    },
+    "progs/misc_lightpod.mdl": {
+     "bytes": 81780,
+     "sha256": "e16ac3a669ace065c4cd1806ea0a21a59510d936a3a4c9d74c3ef2ef56e9d4f3"
+    },
+    "progs/misc_lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/misc_lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/misc_metal.mdl": {
+     "bytes": 246933,
+     "sha256": "07c0bb9ff1aa1639a62e5a84fca28d48c0fc738f4d22f8e3d8a5a029790d870e"
+    },
+    "progs/misc_oscill.mdl": {
+     "bytes": 50660,
+     "sha256": "cdc96265a646f9e9fb4c1717fa90edb13e42130fadc4dc774b60aeb94b89eac4"
+    },
+    "progs/misc_pallet.mdl": {
+     "bytes": 509927,
+     "sha256": "1b9c50111cedb48559424870b46a3d19cb1ac5b43ef3f165fbe928a3f7e90883"
+    },
+    "progs/misc_player_legs.mdl": {
+     "bytes": 76918,
+     "sha256": "8e54ec3002d5b0f70408f17941087e595cb20933a08c40eb934cb25e8804d5a0"
+    },
+    "progs/misc_puddle.mdl": {
+     "bytes": 38164,
+     "sha256": "ddb936aa0192e06767d1c1d1407c6ca0145011ebf985c7cc77a49796416cf119"
+    },
+    "progs/misc_radar128.mdl": {
+     "bytes": 19492,
+     "sha256": "ef004e28e51e3227121a92432375531fca26d1e44894696f3d2a950fa65aef28"
+    },
+    "progs/misc_radar64.mdl": {
+     "bytes": 19492,
+     "sha256": "b9468012707ad484c1292cbe984c54811cb8fa43542e68e18a52ef93cb37d52a"
+    },
+    "progs/misc_radar96.mdl": {
+     "bytes": 19492,
+     "sha256": "6239d117263f49b79a2a66e62f2dbd6a7f0cd15ce412c1939dd69b4a1d8fce78"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "cb378259d9ee3b622e52bf1aed10595a8eeb77a9e7873ef8e8bf92e166184c9a"
+    },
+    "progs/misc_seaweed.mdl": {
+     "bytes": 16100,
+     "sha256": "dfbd38a439d392870c7c4c7ebea4475827b716004ca47bfa7f13b47daf07d774"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 31792,
+     "sha256": "8d39b97460c9967ee36b33ea1ef1e92e89277fc410b44f054c5e06b8dc8a079c"
+    },
+    "progs/misc_starfield.mdl": {
+     "bytes": 23548,
+     "sha256": "5b3563017939382680228e933a2a87d3edb030e75e65c51fe42c4a6889e42e15"
+    },
+    "progs/misc_stool.mdl": {
+     "bytes": 85612,
+     "sha256": "12914ff8acc41ef1656aef291edef6d3b0975e994808b8e4e921edcc4927e517"
+    },
+    "progs/misc_tape.mdl": {
+     "bytes": 9240,
+     "sha256": "2b6a08ca3be4dd7a669e5b6d1585276759e1fb0edbe0691dd7ecbc7e41f0b189"
+    },
+    "progs/misc_turbine.mdl": {
+     "bytes": 53615,
+     "sha256": "57cf73dbf14b5b22795033f5b597b30b978aeb6ee037e09648d0cebd029f987e"
+    },
+    "progs/misc_victim.mdl": {
+     "bytes": 1432944,
+     "sha256": "c5d2a99ba39e82bef21cdff5f682b6b80d601f9b54fe0d58d94aae3544b5303b"
+    },
+    "progs/misc_workbench.mdl": {
+     "bytes": 87092,
+     "sha256": "89cb978aaabc4372bacc88ce577c9aefa2a5a4597aada45aa499861150bfe07e"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/nsoldier.mdl": {
+     "bytes": 146288,
+     "sha256": "346728a302961730fca382ea915d2590702e59220eee5a9345326089cca9626b"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 162036,
+     "sha256": "5792430724562eaf1df08f8d18db34a6e62b27b1836931f2269febe17caa9e52"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 192180,
+     "sha256": "ed04d7428d2947bad6f32d0e2c482161866d58ef5c09ba0447aa02f4be83d4cb"
+    },
+    "progs/ogrem.mdl": {
+     "bytes": 162036,
+     "sha256": "3de16efabfa80692984c0f8f742157d28991abf664d80d9250b3fdd4b0d5e9b2"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/probebod.mdl": {
+     "bytes": 84296,
+     "sha256": "0afcb661e2091077c6c573b63a270c808f374038d1b29ecddb621f841adb5c79"
+    },
+    "progs/probedom.mdl": {
+     "bytes": 77148,
+     "sha256": "6a386663a961708f1084453e2ca5135dbf4b7dd18a172f8dd146ddc81edc4c08"
+    },
+    "progs/progib1.mdl": {
+     "bytes": 67240,
+     "sha256": "86bb66a12935e910f21a938f7f17c341b399ab4b299693273e4b12d9cee3a4e1"
+    },
+    "progs/progib2.mdl": {
+     "bytes": 61448,
+     "sha256": "d5da8c749192c87e3dc5eb3c365ea2a4e30cc1ca1179f9740598ea28edb8fab4"
+    },
+    "progs/progib3.mdl": {
+     "bytes": 60744,
+     "sha256": "3d5d5da002f8a86eddd3df5f2fbb3b83535f8982ea99bce984d851be7bb1172a"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/rail.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/regen2.mdl": {
+     "bytes": 25460,
+     "sha256": "7f4c06f4a7046908317a61bee2a5810eae03fe99f09018455f1fa0a62f45c5e0"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 200152,
+     "sha256": "a564fba381d24e3084bc9aa0a026381c83e6b889632c8bebdf69c08c8a6bb9f2"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "f65ba83d82e90808af589ded17378f1baf37f105fa14f2b157227ee22583d25d"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "662d6a7cd68bca7a9c5e88838d190de6a501252a14b6994a191d0bc91f1f331c"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 1136082,
+     "sha256": "e9b86f2dc68475194eed99fa59f2b2933329f713b1317ed29feff8f4a77ef30f"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/supbkpack.mdl": {
+     "bytes": 44408,
+     "sha256": "781c6b5f424fb58e06b2a84b1fb7e980778decde6b3ed257e224db0b1f250173"
+    },
+    "progs/trifecta.mdl": {
+     "bytes": 25460,
+     "sha256": "2c9196af0806c48354f5522a8b7f6fa57e6390f8dfb51718fb71b8a2d4d7447a"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 77332,
+     "sha256": "e2a8a92ebbe86069de925f733567738ac67624a913cb8c1fe15a6946536d58e7"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 141180,
+     "sha256": "bf682cf5cd5fcf5bbfd880cc9c30d395afbec00d8a8c10554c3498fca6b90cb6"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 48964,
+     "sha256": "98a239b4fcfcf78c68079de14984bb8c30b251418044f63c9097c5c16f64da09"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "c9b1d92376ee404102776c630a4fc6fda972c9130fb0f461983c1b6e217a14ce"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 39668,
+     "sha256": "68e38e54cf4aad130c6b3ad2d8ce12ba20e4ffcd4c5a866aae85b69e56ce50c3"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 326464,
+     "sha256": "c015e3606a6ffea0daf3c16481ec1c4b00d167cc8805f21dfb5e989783141018"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 21908,
+     "sha256": "ade58867dac49427ce1a66c498f5dd7327685db0daac1409b80e0a341df59283"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 21804,
+     "sha256": "06a1f7cef5d1d3f8c377addc4026523b656b8f77986495f96048a1a6ea94549c"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "quake.rc": {
+     "bytes": 279,
+     "sha256": "7cd954548e97830f3f3506d5a8b6b50be51a77c2e0061d9cc964809adc3d5a23"
+    },
+    "sound/alk_grome/alarm_et.wav": {
+     "bytes": 438392,
+     "sha256": "0d33440f3daf79f42f888a18e2eeaaeba4862b7968d734b58754e237020a9bf3"
+    },
+    "sound/alk_grome/alarm_et2.wav": {
+     "bytes": 876644,
+     "sha256": "35f1ff6583478db5d0173a51b5274285815b841249384e5fde277b3b20e1eb5c"
+    },
+    "sound/alk_grome/aramb_windup.wav": {
+     "bytes": 118068,
+     "sha256": "00184ed2487eb79fce6a41833b0c3deb0c12db4bf75cd30680eda900ad42e1c3"
+    },
+    "sound/alk_grome/arpump1.wav": {
+     "bytes": 18262,
+     "sha256": "11ae2c08c7d5f7f777eade75770a1623386d0e0096a19076fff13e9ddec6318c"
+    },
+    "sound/alk_grome/base_ambientloop1.wav": {
+     "bytes": 3480328,
+     "sha256": "e4970d2e679e7ddfdb6da696ceabb9d2ab0d6005d17ef2e56dd61eb6370f58d2"
+    },
+    "sound/alk_grome/basetry.wav": {
+     "bytes": 10518,
+     "sha256": "9f180f7bb823b1e7138fbe6f2d6acc9e9055a736223535c8dcb0f3e2e32a3c0f"
+    },
+    "sound/alk_grome/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/alk_grome/default_stop_hl2.wav": {
+     "bytes": 98836,
+     "sha256": "3dfe2f3c4e1c450ce6bbbd401a0d22f9829ffc39da7883f69019484d07298f8c"
+    },
+    "sound/alk_grome/demonwind.wav": {
+     "bytes": 357574,
+     "sha256": "8bca3e8f399d9b6e2b8a7c4e0a21c462e8a5bb1ff5044fc4e0255d6081cecbec"
+    },
+    "sound/alk_grome/drone.wav": {
+     "bytes": 30902,
+     "sha256": "81993d96ab337f78c2778cecffe4767605fed210e0ac2303a46ac898979eea13"
+    },
+    "sound/alk_grome/drone6.wav": {
+     "bytes": 18522,
+     "sha256": "dccccac054680ac00f16dd87a2f303bd9653578736ba18a56311fe55256c1176"
+    },
+    "sound/alk_grome/keyboard.wav": {
+     "bytes": 66850,
+     "sha256": "2dddfabc3ca827a9f908a00cdc6b35784b18ca1912c86337dbdd39900bbf686a"
+    },
+    "sound/alk_grome/ma1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/alk_grome/power_on.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/alk_grome/power_shutdown.wav": {
+     "bytes": 1118464,
+     "sha256": "e0ab1a0f67a2d37a525f7a73e8ee8c3a26f746e027fa1501f6648f5586ea2048"
+    },
+    "sound/alk_grome/rumble2loop.wav": {
+     "bytes": 99166,
+     "sha256": "d2247f41caa1b7540e883c7f6bd8abb59c05ef9269d5aa963469e903940a5915"
+    },
+    "sound/alk_grome/suck1.wav": {
+     "bytes": 110392,
+     "sha256": "99fec7fb4632a06fe033df49b65eefc1426dce1e4d23adc7d8788d4e9065280c"
+    },
+    "sound/alk_grome/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/alk_grome/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/alk_gw/choppa.wav": {
+     "bytes": 82726,
+     "sha256": "caf182035ddb397a69755780032ff46e39b34111e13015dad38b0f3015ca96c1"
+    },
+    "sound/alk_gw/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/alk_gw/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/alk_juz/dronehum2.wav": {
+     "bytes": 183654,
+     "sha256": "03545ae0f88b788e69e09c0aae2cccfa727a2609ef224c7d1d3451f0e6172709"
+    },
+    "sound/alk_juz/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/alk_juz/flyby1.wav": {
+     "bytes": 260406,
+     "sha256": "3fb54dce36de4164173ff68f2eed3a5b24a81c784b7d0758c29ba27620c11378"
+    },
+    "sound/alk_juz/radiostatic1.wav": {
+     "bytes": 102196,
+     "sha256": "3f1a71599802c66c63e53f5bafc8b660734fd8b623b41eb1870f26adf96a1146"
+    },
+    "sound/alk_mh/alarm.wav": {
+     "bytes": 4198,
+     "sha256": "79094546244d3b2672134d40970512cbc9c260ba6501939f90623dcfa7836042"
+    },
+    "sound/alk_mh/cranemove.wav": {
+     "bytes": 7710,
+     "sha256": "64cac7908811572bda114bcfa66d8b1470b894df1a5c6074f246ce5477666bc3"
+    },
+    "sound/alk_mh/cranestop.wav": {
+     "bytes": 10278,
+     "sha256": "92ecc69bba538b1f624cdce0c0e45c663c6e070320546123519bc3622b0a0196"
+    },
+    "sound/alk_mh/drone.wav": {
+     "bytes": 34230,
+     "sha256": "042fd60360482b1aed17df4ae5a5bfe096282ddc173b4f47e82384c4c5ed1782"
+    },
+    "sound/alk_mh/emove.wav": {
+     "bytes": 33182,
+     "sha256": "0f9de23e794e7fcff8dcfd0397c92404d51dd0e299d0b909ef16afcc4615b00e"
+    },
+    "sound/alk_mh/industrial.wav": {
+     "bytes": 32030,
+     "sha256": "c994aced4e1a944e04653e6d3a3f284d11f9974528dda2f0918a3b62791d1f64"
+    },
+    "sound/alk_mh/rotor.wav": {
+     "bytes": 84212,
+     "sha256": "6cd09e076bca0871c75e13a9c73f9d3b172c3d36e8ed979bf680b035c3b724fd"
+    },
+    "sound/alk_zigi/amb16test.wav": {
+     "bytes": 184128,
+     "sha256": "5c029ad6bc9c66c2f6d4c45a43b1bc15cf11d1b12a68276711e60865e4fea814"
+    },
+    "sound/alk_zigi/forcefield.wav": {
+     "bytes": 67928,
+     "sha256": "feb389e023228507b3c8e1718a57ebabec36af1f474d051b9ee950c4c6a806f4"
+    },
+    "sound/alk_zigi/huuto08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/alk_zigi/huuto24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/alk_zigi/kone.wav": {
+     "bytes": 190760,
+     "sha256": "59197f823b479c66c41163d82fed6dc13a715aef429b5e551ba80ca6f7c229fb"
+    },
+    "sound/alk_zigi/laf1.wav": {
+     "bytes": 126074,
+     "sha256": "a320badd6eb1189349ca484ae7f0dd005fb3f86be89618f22fcaca61f46e9b55"
+    },
+    "sound/alk_zigi/rumble2.wav": {
+     "bytes": 66200,
+     "sha256": "b2ca38e13253361aa1780c05269652c4aed4094f274948e865be6849d4a3b908"
+    },
+    "sound/alk_zigi/rumble7.wav": {
+     "bytes": 639494,
+     "sha256": "e19851eeca4d295a1e42cfece3fcced40779f14f73a4e923e3768f2cb0553a76"
+    },
+    "sound/alk_zigi/tuuletin.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/alk_zigi/valo.wav": {
+     "bytes": 26356,
+     "sha256": "c8203b1d67aa1e2458a5ac8e3edb9e7b79498b04251abd01c33356e65ad1681f"
+    },
+    "sound/alk_zigi/vent1.wav": {
+     "bytes": 153876,
+     "sha256": "0ac26f5ec7c080562c73ca3dae0fe0a705136912b641919f91f3f701875a76bb"
+    },
+    "sound/alk_zigi/ventsu.wav": {
+     "bytes": 32876,
+     "sha256": "1e0f99ffadead8460a7a4bed1c6b2c16cddd70050e1524e9cdaf6724a9dc81b5"
+    },
+    "sound/ambient/aramb1.wav": {
+     "bytes": 44476,
+     "sha256": "4c6440672b87575dd8ac5a267621881b9c70e48722cf9a4aa75a4a9b384fea5b"
+    },
+    "sound/ambient/arcohum1.wav": {
+     "bytes": 20418,
+     "sha256": "3b42cb1b62f62acabdc8ef8612ab4343b71b165c3525552701ef769f90020960"
+    },
+    "sound/ambient/arhum1.wav": {
+     "bytes": 20740,
+     "sha256": "e374f3d90564808e019abe09f4464b704512cf85ff0f3b4bb3c955b4153184e3"
+    },
+    "sound/ambient/arpump1.wav": {
+     "bytes": 18262,
+     "sha256": "11ae2c08c7d5f7f777eade75770a1623386d0e0096a19076fff13e9ddec6318c"
+    },
+    "sound/ambient/arwind.wav": {
+     "bytes": 30408,
+     "sha256": "34248569bb7ab66f5e1d874e15c7a91d89fd2b70d27e5521456b2589581fe1e6"
+    },
+    "sound/ambient/chatter.wav": {
+     "bytes": 190760,
+     "sha256": "59197f823b479c66c41163d82fed6dc13a715aef429b5e551ba80ca6f7c229fb"
+    },
+    "sound/ambient/comp.wav": {
+     "bytes": 12164,
+     "sha256": "ab8e3b13981bb432cca44ad4b7467734f52d01927018e72c99e7c4d052dc7874"
+    },
+    "sound/ambient/crickets.wav": {
+     "bytes": 12236,
+     "sha256": "d5cf6e56884a8e43469408d4788ec6e573167901586df259a938cd088c998ef9"
+    },
+    "sound/ambient/drone.wav": {
+     "bytes": 30902,
+     "sha256": "81993d96ab337f78c2778cecffe4767605fed210e0ac2303a46ac898979eea13"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/hum02.wav": {
+     "bytes": 37836,
+     "sha256": "8b2ee1b91fa663b6111de9251011142475831ece70ee091022b800b715f1bfa2"
+    },
+    "sound/ambient/intake.wav": {
+     "bytes": 25682,
+     "sha256": "e6d13169ce4680dd83903473897fd6e7ce1e51fab00c6df2127ea993321c05b0"
+    },
+    "sound/ambient/lonoise.wav": {
+     "bytes": 32876,
+     "sha256": "1e0f99ffadead8460a7a4bed1c6b2c16cddd70050e1524e9cdaf6724a9dc81b5"
+    },
+    "sound/ambient/motor1.wav": {
+     "bytes": 52340,
+     "sha256": "c48511a37143e9ed50ae7c1d1f28235b007762949d3d18549fc545cc670c0a24"
+    },
+    "sound/ambient/motor2.wav": {
+     "bytes": 52014,
+     "sha256": "7f36cda5c01aea4e6b356ae4d0b31b68ca15d7606eefd30f4739a64fc4e86e6c"
+    },
+    "sound/ambient/rain.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/arachnofloyd/death1.wav": {
+     "bytes": 119460,
+     "sha256": "d16c7ff30e9df62fbcda102befbd61fe234532f6aef30d0b34c25330679682bc"
+    },
+    "sound/arachnofloyd/death2.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/arachnofloyd/idle1.wav": {
+     "bytes": 34254,
+     "sha256": "35d6991a10637251ec0d6b830f7f57f394e4eed06e7a9dced86f0128ba5bc49e"
+    },
+    "sound/arachnofloyd/idle2.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/arachnofloyd/leap.wav": {
+     "bytes": 70884,
+     "sha256": "f47323f618db14755c57e9e25213267dcffc501fbaa9a201176ab99db6cda928"
+    },
+    "sound/arachnofloyd/pain1.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/arachnofloyd/pain2.wav": {
+     "bytes": 15906,
+     "sha256": "9c4bdc81c73787cb67677e0021b71d9e24734ef3ce272d9020dc6611a1d87842"
+    },
+    "sound/arachnofloyd/sight.wav": {
+     "bytes": 48620,
+     "sha256": "97a055dbb8e5935190348b2c2d50c6d99ab35c29f3ebcd0f66d6263bdb5485e4"
+    },
+    "sound/arachnofloyd/step1.wav": {
+     "bytes": 74932,
+     "sha256": "a8744a3e50dccf9ee391da2f381c2ecf6701a76441406929ee4581c7717b880f"
+    },
+    "sound/arachnofloyd/step2.wav": {
+     "bytes": 34478,
+     "sha256": "22ce43aa18537f7b04e31263a46dd02e181d538fdf5918d55f8ce0acbb930676"
+    },
+    "sound/arachnofloyd/whirr1.wav": {
+     "bytes": 19762,
+     "sha256": "9e2029071248e6d45f1b0d518983bad5bc5f841cda6bcfba09486e111add10de"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/bal/markiejumppad.wav": {
+     "bytes": 20045,
+     "sha256": "6b2743edcbc6325a93aec78c15d209829d92d75fc9535f88fafc437380bc6b57"
+    },
+    "sound/bambler/melee1.wav": {
+     "bytes": 4175,
+     "sha256": "4e0e2567b9d64b3ff86b33d95fa0158bf72372aeb4968a0c2489df942f9f7c4d"
+    },
+    "sound/bambler/melee2.wav": {
+     "bytes": 5283,
+     "sha256": "4bb91991bccfc33576eff19037e12666e9825348272d3dca40199e208bc00700"
+    },
+    "sound/bambler/sdeath.wav": {
+     "bytes": 14048,
+     "sha256": "c5253af82d203e75d132a00bbb555de055d2e356106d460f34cb8c9a2ee5e643"
+    },
+    "sound/bambler/shurt2.wav": {
+     "bytes": 3736,
+     "sha256": "0f1a51e0ff72f23a4de7684d4408344b7b7bd2cb805609168d2f2459e1b8660d"
+    },
+    "sound/bambler/sidle.wav": {
+     "bytes": 4907,
+     "sha256": "ea2232ba791e306cc86f58303413d8f3fbc7dd38091281698f4d846b6cafa483"
+    },
+    "sound/bambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/bambler/ssight.wav": {
+     "bytes": 11376,
+     "sha256": "de766aa056ca5f7dc6d179e6a220ef906ceacc0341b5cb3d91a4d0e75ff55338"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/bloodshot/bomb.wav": {
+     "bytes": 141228,
+     "sha256": "6fa171d6bbb3dc07f9c0fb422ceb2e3e20934e9a0465589717dfdc14c92b016c"
+    },
+    "sound/bloodshot/doormv1.wav": {
+     "bytes": 43818,
+     "sha256": "729ad30245f7b9036d197f742c067c741ab4513992322f1e844a8bc5411d54d6"
+    },
+    "sound/bloodshot/drclos4.wav": {
+     "bytes": 5582,
+     "sha256": "99c4e2100335a5c217d370277dd218602a2419e12afc6f2fd9974ae81b7cc9ca"
+    },
+    "sound/bloodshot/error.wav": {
+     "bytes": 6516,
+     "sha256": "316c201dd7a44b79f6bf07db8d03003bc07d61b754a8d940c733e3dca58fcbf3"
+    },
+    "sound/bloodshot/fan4.wav": {
+     "bytes": 19502,
+     "sha256": "5bde811e4ffba54790ec5f4d4fbc922c0d2bd5f7b0b229d21233f83c39b80e5c"
+    },
+    "sound/bloodshot/hydro2.wav": {
+     "bytes": 18420,
+     "sha256": "1d3a8e3151c52582d9f1032a6756dbd8d62f0974f3b95386265bdbc426a36eef"
+    },
+    "sound/bloodshot/liquid_bubble.wav": {
+     "bytes": 129688,
+     "sha256": "838ec1e72b2c433408a342a48518987edcb2124932eeb477d59653540b13d6ea"
+    },
+    "sound/bloodshot/liquid_burnshort.wav": {
+     "bytes": 89464,
+     "sha256": "4ea16997389f1aa35549869a338f2093f40d14df030c381a7659cc7e3cbf8bfc"
+    },
+    "sound/bloodshot/plat1y.wav": {
+     "bytes": 38690,
+     "sha256": "2c691a78650dec47a2ea0e3ef697a1af06ed86019e0756b7df3b9ca9d4135dbc"
+    },
+    "sound/bloodshot/plat2y.wav": {
+     "bytes": 11602,
+     "sha256": "0e8585808da24f28484f56a28c89a0e5938fe4044d5a8d796ed6fc3cfa7f79ff"
+    },
+    "sound/bloodshot/power_switch.wav": {
+     "bytes": 66382,
+     "sha256": "5c006bb7315e6eb6d2367ae30a78f0abec8ae2a1e2b6a2c9af88354962b0f33f"
+    },
+    "sound/bloodshot/reactor.wav": {
+     "bytes": 204254,
+     "sha256": "2fb09312579dbb219eea83d2320a0ab8bf8b8aaa93a449a05a9d60c6e393ecbd"
+    },
+    "sound/bloodshot/slimepump.wav": {
+     "bytes": 92716,
+     "sha256": "248e6507a0ef5aa3dd166df7aa2e6254cb4fbfff6f4f1eca7fca4738e9f05e10"
+    },
+    "sound/bloodshot/truck1.wav": {
+     "bytes": 6908,
+     "sha256": "2daf8d56e43cccae533efc5b8c1dfaa14eb3327cb8e5d4ab542fdbc7683aa1d1"
+    },
+    "sound/bloodshot/truck_drive.wav": {
+     "bytes": 1245432,
+     "sha256": "9516a14cd76e18dfe12d8766015344bb810961e0e12747674efde43c9f607c37"
+    },
+    "sound/bmfbr/alarm.wav": {
+     "bytes": 21058,
+     "sha256": "539cb807f9fdd4c93c24ad09f57249d600c109dfdd78a7f90f294ffb4c7e8b6b"
+    },
+    "sound/bmfbr/barmusic.wav": {
+     "bytes": 77898,
+     "sha256": "af57a7b9b00323f6395f9f81af4fb5971657ad764665552036b057442c7c18e7"
+    },
+    "sound/bmfbr/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/bmfbr/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/bmfbr/dronesewer1.wav": {
+     "bytes": 345280,
+     "sha256": "ee8cd803398a007f2f3b412dd2401098586e1d38f558daa748ea4e86f10267ad"
+    },
+    "sound/bmfbr/farambient_l.wav": {
+     "bytes": 330958,
+     "sha256": "4c65d4dd9c8111a0b13d625a86a30f1a6ff97b0acfb03423009fc57100981547"
+    },
+    "sound/bmfbr/farambient_r.wav": {
+     "bytes": 330890,
+     "sha256": "a843e4b6958b198fa7de5f54fc8902040c7257f151df89f23dadae77920da960"
+    },
+    "sound/bmfbr/industrialbuzz.wav": {
+     "bytes": 57112,
+     "sha256": "ac872a81a917704e4e418d7f83f2b7cdb35d3f35671e11261634727dfb7cfca9"
+    },
+    "sound/bmfbr/machine_loop1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/bmfbr/machine_loop2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/bmfbr/rain1_nl.wav": {
+     "bytes": 154490,
+     "sha256": "ab83161b01f9299cad8af7142f688c4f2f36e16e973eb42fa6faa13a7a6cc51d"
+    },
+    "sound/bmfbr/reactor1.wav": {
+     "bytes": 207486,
+     "sha256": "71b3bb44e623638db55b899c9847ca8c05d5c9c16c0897c28044b64c8060dc25"
+    },
+    "sound/bmfbr/rumblelong.wav": {
+     "bytes": 105990,
+     "sha256": "46728daf18b142575d50049188030a153c0e3e994dc83ea375c43ba6da171b3c"
+    },
+    "sound/bmfbr/rumbleshort.wav": {
+     "bytes": 33500,
+     "sha256": "6b389aa1afcebdd8838bb0e900c2bbd32e409a7cfcc19553e1d007d89404310c"
+    },
+    "sound/doors/q2door1.wav": {
+     "bytes": 30572,
+     "sha256": "3f05bddf76379933970c532656b6350bc53820319ce1cb9d4ea9288210427eee"
+    },
+    "sound/doors/q2door2.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 110256,
+     "sha256": "895cfb57c0d27369530fd5e9b29abd491a989ad0a63ddb00f05dd9e4777a5cdb"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/frogman/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 32638,
+     "sha256": "3cf3933f34c7baef52df54d5b03db40424e9f7ee72e5aa5a4dba489d71be2af7"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 27662,
+     "sha256": "ec38e73fd1ffc33cd25aa065e5f5897c21a494e380763ff80b6be482689b5e33"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 44186,
+     "sha256": "7600cd32fe980646fddcf5a9077d8d43df1bca1f2ed05bd92ce8cca273ad6636"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/trifecta.wav": {
+     "bytes": 16412,
+     "sha256": "00baad51adaa3f5d6664e85ae5442221db6818bfd85124c164324d22f6723ab2"
+    },
+    "sound/items/trifecta2.wav": {
+     "bytes": 32778,
+     "sha256": "f742a9cee4a53ef52fce55d5e9ddaae9c6b20d2127e16c0def6cd11b3d2d6380"
+    },
+    "sound/items/trifecta3.wav": {
+     "bytes": 10728,
+     "sha256": "a78bfc9fa4fbf0c3c1e85bee273ee053598989a09146bd29e97dda811c49a473"
+    },
+    "sound/lieut/alert.wav": {
+     "bytes": 8700,
+     "sha256": "7ebbe83ae1b5d159c9f0a0ae5f3dea126650ed5d6f98a22d1512dcfcb19a23ca"
+    },
+    "sound/lieut/objective.wav": {
+     "bytes": 10052,
+     "sha256": "aa7d6726a458eaa48bf2e20446c57360b82ac23bfbd06bad7b6e01ae95ca8b0d"
+    },
+    "sound/lieut/target.wav": {
+     "bytes": 6754,
+     "sha256": "eebd50c75585894c7d5305f6c066aaef1efaca9a59e27b80d03e8ae4d69caa69"
+    },
+    "sound/lieut/you.wav": {
+     "bytes": 7126,
+     "sha256": "6bfb031b0d69b8ae4ef2e9b201da43c523ae88de344907648d4064e07477ee1c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/conc_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/misc/door_closed.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/misc/ebell.wav": {
+     "bytes": 15220,
+     "sha256": "1693337ed8873f1159e56c2925afaa210f5c28bee4e2c42d27e29bee8e06cb5f"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 4054,
+     "sha256": "b9c44f73c8bdbc900af4f06600e0d6456a040b296612b7d0fe53391285976a44"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 4098,
+     "sha256": "4fad66341514c9aa2b31b4c2fde7563369090da9b0b3a51e08bca3100f2ec282"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 8420,
+     "sha256": "81fda4244918f83411dee71f34ced1e7ad2249a9614ed22188c6c2243fe2e241"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 19600,
+     "sha256": "52a67eb4ed70d9d845f07a898f88553e4c1f712b7214a2c7614e9911cbe46652"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 4836,
+     "sha256": "d0878250b2d878f3d12d87a00b627cc12fbf51e185b964e96b5f149e7603f6f7"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 5802,
+     "sha256": "751050f97456a0c07e88a249d40dde96c2d14640e21670ccdde983502998dbba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/rail.wav": {
+     "bytes": 97196,
+     "sha256": "396a85e1e2083f2b1eaae89a3f33a21145a643f3f50419523497719ef8e7598a"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/rider/sight.wav": {
+     "bytes": 26356,
+     "sha256": "40ace6f3beeb920ba1bbdb197f8ece18d312762a71e494726289e16703d75d91"
+    },
+    "sound/rider/step.wav": {
+     "bytes": 40524,
+     "sha256": "a43e24ecbc62d44bce466b1e682ebf64c230e03f4d79449406ce021dc8276a9a"
+    },
+    "sound/scientist/allnominal.wav": {
+     "bytes": 23778,
+     "sha256": "e26f9bb3c24d9a9e0da38395048f6dacffe82d800da49d56378027250393d69a"
+    },
+    "sound/scientist/alright.wav": {
+     "bytes": 9666,
+     "sha256": "372c1aa91e6841bec2441215c894b7d149bdeaef33f907d23bb7eaf637520ce3"
+    },
+    "sound/scientist/asexpected.wav": {
+     "bytes": 15982,
+     "sha256": "306933848b673bd14d7074d59e45a8c97bc00a2897601509e52e5835e2ffc997"
+    },
+    "sound/scientist/c1a0_sci_crit2a.wav": {
+     "bytes": 28364,
+     "sha256": "f972684c74eeb51872873cc2b7053448c6cdd716b8c3535929fdbcc508d62ef5"
+    },
+    "sound/scientist/c1a0_sci_stall.wav": {
+     "bytes": 13704,
+     "sha256": "541c192ad5e8a68c76706ec17b3deceafbdc607bfc372ddfd300532f8aa1eaef"
+    },
+    "sound/scientist/cantbeserious.wav": {
+     "bytes": 13236,
+     "sha256": "fc4a8a379f70e33db79a49c667dcd9f1622de29d7b32ef3973c4ffdb5d80ee44"
+    },
+    "sound/scientist/cough.wav": {
+     "bytes": 14878,
+     "sha256": "b4e620259623347a5be3f7eaf3c531e6ea9ef2e97ac42997dd78cfee9327f7bf"
+    },
+    "sound/scientist/sci_die1.wav": {
+     "bytes": 15558,
+     "sha256": "c2306d7f9fa58f99961c347b06ef26305b99ac43ec27b2b222962e1f3a9ccce9"
+    },
+    "sound/scientist/sci_die2.wav": {
+     "bytes": 5402,
+     "sha256": "14deecb570d1e315b772713d54b7250043bb0dd5f3d5538cd0636e39a523c54f"
+    },
+    "sound/scientist/sci_die3.wav": {
+     "bytes": 3104,
+     "sha256": "075cdbc5837d91b61ad7599cdb3abf9323872816f8966c83deab9c0a6e04d7d2"
+    },
+    "sound/scientist/sci_die4.wav": {
+     "bytes": 4024,
+     "sha256": "e6ca0d4f18ac6c1246926646568618057cb70b5cee995c1c2dd69f0179b892ad"
+    },
+    "sound/scientist/sci_dragoff.wav": {
+     "bytes": 8986,
+     "sha256": "0c6a21cd5edf01e495e1258e9a76c05d62c0e3cd697e787fd43fd4bd9126483b"
+    },
+    "sound/scientist/sci_fear13.wav": {
+     "bytes": 4534,
+     "sha256": "dabce7a6c12980f947f7504da264fabb67a804d2e478b7f252ab527fb21a92d0"
+    },
+    "sound/scientist/sci_fear15.wav": {
+     "bytes": 4764,
+     "sha256": "f0d23c680ad138c3cc12da78a3e45cbf3daa47e5da9bc62a1dbb3b27389565a5"
+    },
+    "sound/scientist/sci_fear6.wav": {
+     "bytes": 5588,
+     "sha256": "ff2702b2b9e517b90ea0c2853775a4a95160edfae5af0a7f9208f07624d84281"
+    },
+    "sound/scientist/sci_fear7.wav": {
+     "bytes": 8458,
+     "sha256": "f2a39185c2d39a03b39afd7fe6f942b2f35fd17135ade8ceb4c31968c768aafa"
+    },
+    "sound/scientist/sci_fear8.wav": {
+     "bytes": 5804,
+     "sha256": "4455a29590d5f42ebbf06e600d8ba3f45acfd5000a6b8045891cbecf1d937970"
+    },
+    "sound/scientist/scream01.wav": {
+     "bytes": 14666,
+     "sha256": "b738de99aefbe3a45724914dd6eb79c0f8c219aaf733554a8a5eb94836c22320"
+    },
+    "sound/scientist/scream06.wav": {
+     "bytes": 13938,
+     "sha256": "dee8ac2058635d00458e2e74402d1cfcb5362c64259fc2c4f3b6bba31bdf6337"
+    },
+    "sound/scientist/scream08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/scientist/scream09.wav": {
+     "bytes": 6130,
+     "sha256": "85947649f5fb1491732365849a3025bf5c76c791b395cfdf421fbbd6ec58d351"
+    },
+    "sound/scientist/scream10.wav": {
+     "bytes": 5392,
+     "sha256": "fff4c0735f9c312be7cda848fc2867590437ffe9758fe685e3b4c94678ca1f48"
+    },
+    "sound/scientist/scream14.wav": {
+     "bytes": 4824,
+     "sha256": "dcb7dfb0e307b813476b2e55dceb59d8ae2b9514b1ef02034ea255fa5f086b05"
+    },
+    "sound/scientist/scream15.wav": {
+     "bytes": 3048,
+     "sha256": "37d26fe2d2b8a39d0fec0eceec0ca974ec3dd7fed33bae0d3230a934954105f0"
+    },
+    "sound/scientist/scream16.wav": {
+     "bytes": 2328,
+     "sha256": "4ff04ce8ff07af708c84dacc8df114b68620d47e8e4e4c78dfc4fd33a8a9b98d"
+    },
+    "sound/scientist/scream17.wav": {
+     "bytes": 3836,
+     "sha256": "82fb51224e06db5022adfa58f0b02353c333229ed3312f86dd9ec4f04813c37c"
+    },
+    "sound/scientist/scream18.wav": {
+     "bytes": 3066,
+     "sha256": "bfefcf745ab8d30db11f9113ecf9ba1c5bc6d9b2351c53f3f46d66e03cbea3fe"
+    },
+    "sound/scientist/scream19.wav": {
+     "bytes": 2504,
+     "sha256": "47cc414d201aadb7ba2fe0ce0567ff5360e90fd9de4a167520988513f358ed41"
+    },
+    "sound/scientist/scream20.wav": {
+     "bytes": 21310,
+     "sha256": "124cb45d3d5533572e3cfe4b42bddad2a03dc0d8de1c89a42ea57433432e3a6e"
+    },
+    "sound/scientist/scream22.wav": {
+     "bytes": 15206,
+     "sha256": "6e0a509eb2468466591622e74724c31103b8b60f5d8f29514fb57e9d9d12c9d4"
+    },
+    "sound/scientist/scream23.wav": {
+     "bytes": 21988,
+     "sha256": "8521907e8cecc22e6924d23295a5e8d31333d265ca27a9533b083b68e9da6d12"
+    },
+    "sound/scientist/scream24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/scientist/scream25.wav": {
+     "bytes": 8122,
+     "sha256": "38281749deffb4e567896f71e7bcb75d7b2e253e404a953a5eea6eeb989f156a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    }
+   },
    "sha256": "853047f8c2851191f0875c1d926205c337290622ed467185655016ec9b5030f3",
    "timestamp": "2021-06-12T22:39:32.000Z"
   },

--- a/json/by-sha256/27/272c13208fc5c03dc5f69f7fb9bb07dd4e553588d3f4ab994d0b437bd8e7a3ba.json
+++ b/json/by-sha256/27/272c13208fc5c03dc5f69f7fb9bb07dd4e553588d3f4ab994d0b437bd8e7a3ba.json
@@ -7,6 +7,140 @@
  "files": {
   "pak0.pak": {
    "bytes": 3541423,
+   "files": {
+    "maps/starshp2.bsp": {
+     "bytes": 1249648,
+     "sha256": "72f8bd8981eed985109e9a00f2958feec2f4e7a06f40517e8214af28f50e6a40"
+    },
+    "progs.dat": {
+     "bytes": 673220,
+     "sha256": "01e0f7b5828474e762d40c7dff77df5fb03093ef2ba0499f72ea410d3e87791b"
+    },
+    "progs/dog.mdl": {
+     "bytes": 146056,
+     "sha256": "c0ae9afa29568eec824b5451d5e2f05c8327edf0b2482466fe2473b1ce714fa6"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 160688,
+     "sha256": "7961e469c6f39801f130138017154f7a540dde070139b171ad7c81d1bead9195"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "01b24f3d56ae5d598dba8ba698fa35e78adb76393c0b1528de51321d5794d039"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 16628,
+     "sha256": "03dfa47ede5906070227b2b8073087c1afcf164eb92529b1f04a003c346a0359"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 7156,
+     "sha256": "132824d5bb17b4f373ca42e55a20db19b222f921eb38244f58ae6d0ee2dafa11"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 11828,
+     "sha256": "82681993f08183d62bcde765d5378f84eaa9b22f653a8826361db02462f565f0"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 14900,
+     "sha256": "68ff71bde6e544d8a9b31e23ccf44a6340c4c914404027c7efc855c76270abfe"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 228400,
+     "sha256": "448a39ca9c63447ad5a859e2e3aeafc4c2d64e7f8ce3ff46bb086cafa7cb83f0"
+    },
+    "progs/knight.mdl": {
+     "bytes": 101404,
+     "sha256": "bf4a676e5b8d07a48585ee9bca07acd88974900326a904b83cf7ddc4958bcb14"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 162036,
+     "sha256": "44832fbc4f21a22f8ef7fe97e713d0f32ee290c6f4866229362181c1ef7dfd01"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 98556,
+     "sha256": "f4f95ccd8c647ef9c83aac6519ed54c3ea11151a398f358c586679d6d5e23711"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 146288,
+     "sha256": "20a99e9cb14f2f954740a72350452a08e575a022e8ba8b01c31f33e899f7b972"
+    },
+    "sound/ambience/thunder1.wav": {
+     "bytes": 67944,
+     "sha256": "9a0ddb4b1541f66d0baf0550b7fafe2ebccbdc4cbc97d5e26170a01d4ad94bd2"
+    },
+    "sound/dog/ddeath.wav": {
+     "bytes": 21317,
+     "sha256": "2a49398424a014fcbee0e4003d49b62aed172f039f79d903f63b39836b6c80b4"
+    },
+    "sound/dog/dpain1.wav": {
+     "bytes": 10318,
+     "sha256": "7bc7a89f5f9cde0b7dbd7f6561b7ba141e3b31d044b4ec811e17b8985375ff9c"
+    },
+    "sound/dog/idle.wav": {
+     "bytes": 10319,
+     "sha256": "3864c49637c10f3d4cc0c3e362c02ba1bc375f7864b8dd5e81236c0114ba7b07"
+    },
+    "sound/knight/ksight.wav": {
+     "bytes": 12075,
+     "sha256": "02caa75821e39ceb404647a764abbe3955d0139165aa0ec48e956e027c22bb7c"
+    },
+    "sound/knight/sword1.wav": {
+     "bytes": 3541,
+     "sha256": "689077f95be77350ab37a456b3b4a20d889e860db8d73b37f7b64c3fe4d04024"
+    },
+    "sound/knight/sword2.wav": {
+     "bytes": 6862,
+     "sha256": "cd73388fdb044b6bad42713d7b74f4914a5172229df0d6dc3290f35011012949"
+    },
+    "sound/misc/bubbles.wav": {
+     "bytes": 18358,
+     "sha256": "963626e3a7c94501dc35f49366c5f07aaa1b452e606f97733138e6abe84338bf"
+    },
+    "sound/misc/burghit.wav": {
+     "bytes": 1900,
+     "sha256": "b3cdf59faa1085c9305e1366099518564d06cbd4edac56c6cf6bfed647d6823f"
+    },
+    "sound/misc/explo3.wav": {
+     "bytes": 20421,
+     "sha256": "303add67bc345b9d2d5c5ccce8cb0927377c66bb13a80f30bd5313380a801594"
+    },
+    "sound/misc/funny.wav": {
+     "bytes": 2780,
+     "sha256": "1e9b992b7e34c82faf6182d3e0dd005f4d39a5bccc6aa34d02e96479d15a7d8c"
+    },
+    "sound/misc/glass.wav": {
+     "bytes": 31602,
+     "sha256": "31ed1a84b918350a680fd71bb6c4e8948afe690593cc0b29c9e2f70bac631935"
+    },
+    "sound/misc/machine.wav": {
+     "bytes": 42955,
+     "sha256": "8b8748eb75c3de745c993bc45b319b6dd594aa14790d402e48b8dc469cc17e86"
+    },
+    "sound/misc/mover.wav": {
+     "bytes": 16983,
+     "sha256": "c85dc5a092c7ed66e453c4614400c586513ff5830f92f30cdd1e21e0e3ebc310"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 49438,
+     "sha256": "d91434f754543be1ef3d743b6a9c639461fae8198983fa05b1c8af2b1018c2f2"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8077,
+     "sha256": "58a62fd7ffdc4bce9d377454fb25b4b87ded2094fe61055afa54df8623769f8c"
+    },
+    "sound/misc/rocket.wav": {
+     "bytes": 143980,
+     "sha256": "929036469bebd163b3c8814a780a8c85512c51efb077c30087f83170d996f67e"
+    },
+    "sound/misc/stop.wav": {
+     "bytes": 17780,
+     "sha256": "e5078f98c3c28dff9c2750008b0923c0f7cee1ad34000cbe5679ec5a5ea38110"
+    },
+    "sound/soldier/sattck1.wav": {
+     "bytes": 30413,
+     "sha256": "36d251252367ce80a8547002dd2efef84087100781d4e9947efdd6a4e0f0a342"
+    }
+   },
    "sha256": "b269c0fe74e60c26e008a3388854922658bc66985acfbe48222696cb80bd4f4e",
    "timestamp": "1997-11-22T21:00:40.000Z"
   },

--- a/json/by-sha256/28/28104f86767901f6c461a8b4e98e4dc0f27b860e49bce12a87640025ed6362eb.json
+++ b/json/by-sha256/28/28104f86767901f6c461a8b4e98e4dc0f27b860e49bce12a87640025ed6362eb.json
@@ -12,6 +12,56 @@
   },
   "pak0.pak": {
    "bytes": 3999142,
+   "files": {
+    "maps/med.bsp": {
+     "bytes": 2645152,
+     "sha256": "5116c1c40f787eadc2c8bb3364e48ce8f6394883dbef5f03880259388c5a520e"
+    },
+    "maps/temp.tmp": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "progs.dat": {
+     "bytes": 413236,
+     "sha256": "4c2378e32c7a276246aa4fc35f6f2a1c6df573cbac241eae20cab4f506c8eff2"
+    },
+    "sound/ambience/jungle1.wav": {
+     "bytes": 23830,
+     "sha256": "d73382a6e607eab8f643a2cd53fcc0975d5ef8c4f799993d0ae3f0f5c043ef66"
+    },
+    "sound/ambience/jungle2.wav": {
+     "bytes": 37530,
+     "sha256": "9514e93629a3e9a253fa46ec3753de495486607dcc950ff9acab16e5b63166dc"
+    },
+    "sound/ambience/jungle3.wav": {
+     "bytes": 43810,
+     "sha256": "e9d71720ae96b57527a11aba9b5cc808e44055376c576d7269182ae95d50b59b"
+    },
+    "sound/ambience/jungle4.wav": {
+     "bytes": 20058,
+     "sha256": "7455ce3be8a0ee26d5f947bc4e33a2b7adf78da376a25c2f5e28b5833a0dc618"
+    },
+    "sound/ambience/jungle5.wav": {
+     "bytes": 199148,
+     "sha256": "43eb9e320b62744174c346bff579df9f2db9063ace1ee97864d8d1d0b06d42cd"
+    },
+    "sound/ambience/jungle6.wav": {
+     "bytes": 49990,
+     "sha256": "f4849e1dfb32032b8492d11ec99092cb1a5e98910c31c5fe1126cf9b402bf436"
+    },
+    "sound/ambience/jungle7.wav": {
+     "bytes": 420996,
+     "sha256": "38078a257e32b43bce750446732ee4badaadbc3679b777831ba9fad1711681f0"
+    },
+    "sound/ambience/light1.wav": {
+     "bytes": 78602,
+     "sha256": "6e6dd73760e70648b759fbd1f859017268475e76ffe66b4764d6ec90f7d29e95"
+    },
+    "sound/ambience/light2.wav": {
+     "bytes": 66010,
+     "sha256": "3d4a06d6df05dffc49e3c2ba1b256d055fb7e8700310b36525f84e14aaf34048"
+    }
+   },
    "sha256": "cb8bbea6af8f6d07a2a62516f396db253929126ec11227d1a9b4e055773581bc",
    "timestamp": "1997-11-03T13:54:02.000Z"
   }

--- a/json/by-sha256/29/292e2c2f8ecbc58c0cd3ba24192e6cea93cda099331a38eda2aa18a15482ca28.json
+++ b/json/by-sha256/29/292e2c2f8ecbc58c0cd3ba24192e6cea93cda099331a38eda2aa18a15482ca28.json
@@ -12,11 +12,187 @@
   },
   "pak0.pak": {
    "bytes": 37161438,
+   "files": {
+    "1000cuts1a_readme.txt": {
+     "bytes": 3206,
+     "sha256": "0a8dbd908c23e3d7a665ee30af4e38eaecb83b5a326b051c64883078d23b2251"
+    },
+    "gfx/env/bluedays_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "10b816e9b056ba7a5d96be73db31259be206e8e574a72821315cc06770827a68"
+    },
+    "gfx/env/bluedays_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "67f906fbd7bac242e23566d4f3e0e14d858eae1c44520bdf09546c713ff5b128"
+    },
+    "gfx/env/bluedays_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "2a10cc0187221aecb30e703937594d4b7d6255c484235f07dee9b6aedd100048"
+    },
+    "gfx/env/bluedays_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "b7ec93661fc3375667e1307125453328a4a07923a47d69efa14028fdf20b941d"
+    },
+    "gfx/env/bluedays_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "fffedb036cf3b554c6e12f9336d2139688a418032f93954110c714358793fc01"
+    },
+    "gfx/env/bluedays_up.tga": {
+     "bytes": 3145772,
+     "sha256": "835c5a17f5d1a0de984a9485d5126f1797acd5a598fe00667c62bde0bffb0519"
+    },
+    "maps/start.bsp": {
+     "bytes": 8143064,
+     "sha256": "54597e259b1c2fb8b5bc579dd83087be2a98a9bb81743a8252ff1c5436a14135"
+    },
+    "maps/start.lit": {
+     "bytes": 2351396,
+     "sha256": "a7a6324d45c5426edf9db4b9c70c7879f27334054c5e1a12d925bb0b30c49b46"
+    },
+    "source/1000cuts.map": {
+     "bytes": 6242856,
+     "sha256": "5d27e71a17cc5c7f36a15a9b73b3e5451f575ca5b06fef8ea5363013b409d592"
+    },
+    "source/soc_ikblue.wad": {
+     "bytes": 1545568,
+     "sha256": "64e16735a9848456c166d36b276f9e72bd3af9dc581c8e40eec32f9bca6dc301"
+    }
+   },
    "sha256": "c2f563ca3c0cd30dd3092048b99224828865c46e830a7997bcff01161ed5633d",
    "timestamp": "2014-08-15T19:31:50.000Z"
   },
   "pak1.pak": {
    "bytes": 389691,
+   "files": {
+    "1000cuts1a_readme.txt": {
+     "bytes": 3206,
+     "sha256": "0a8dbd908c23e3d7a665ee30af4e38eaecb83b5a326b051c64883078d23b2251"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6980,
+     "sha256": "0d481a2e2cd7a23e4ef19c19622195007bd6c9a67135ef739b0944a02d46fcd7"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6964,
+     "sha256": "34709c1c06ca34305a8ba1d4799d1cdc07e44ff33f3c7fa11c3d5933cb942579"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 7124,
+     "sha256": "d3371655bed274070fa98fb32b408bab4a22fe754f5158c8c94a072749a5d24d"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 7764,
+     "sha256": "abdfe383c13da6d5dd7a9409fa5d3db2c4bac78482eb75c2c2b42da7811ec3ca"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 8788,
+     "sha256": "2343448faac29720e3a690650b70623852710dcae002917ae5772fa597117e17"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 5604,
+     "sha256": "66ea23f1cdd6225afdd1b7cf1247b93d174562193e0807561b96b659429f2bf0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6820,
+     "sha256": "366ece777ae71ecfebaa9f4bebafe2074b5336e7939900f46bd9521886f9f42d"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 7092,
+     "sha256": "56a66aa3d1364a0436ff8ce880268b2a9c2c396ab02f0c6277535d5b99eae31a"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 7636,
+     "sha256": "ddd60cec57d8e3954c1ffce616ae862edb784417a6b6622cc001d408383a6cb9"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 5396,
+     "sha256": "fe60bd7880da73571e29fa4075968cccb06e913bd2b9475868ce31c69b1a8c19"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 8436,
+     "sha256": "6a2c2c3fa6f88d425ae5b9568e5d8224ee901a1d8faa8363b88fff569b7d0e5f"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 25812,
+     "sha256": "1ba9d3176bb2e03a0457427fd9394d8c15eb9ebae8af9462e955e9c6c6068513"
+    },
+    "progs/end1.mdl": {
+     "bytes": 18900,
+     "sha256": "0d5bacc295ef6386b360dd017f0d047316e57bb056bff9242142c1ebac83565a"
+    },
+    "progs/end2.mdl": {
+     "bytes": 19828,
+     "sha256": "ee5855b02abe8de6d1a51187c298a3628abf073ea571de6967da08ccb57bc58d"
+    },
+    "progs/end3.mdl": {
+     "bytes": 19700,
+     "sha256": "445af16e28fff506ad65fac16b09dad1672e218ffe0183880aff565578b315b8"
+    },
+    "progs/end4.mdl": {
+     "bytes": 19220,
+     "sha256": "cf52525422a102760bfcabd6e8dd5c5df7c2028daea5baa2a1b1717648dd143e"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 74548,
+     "sha256": "e7e43f79a05fa23bfddb23e26234f15622bcce9a1966df2e165d90d0dffca6e5"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 3860,
+     "sha256": "256412b0d88c020fb03efc5e914c5dd721c9dfe8d6a36ce4a7b01e7597d7e7d5"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 7108,
+     "sha256": "d4c5b6316aa02d600951c6a8ec1f4682568b9e877e988cf4cedd77c0e95cf663"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 21412,
+     "sha256": "1274fcabffa89a786b29c9238cf84e95a8557369239b4a9eb813e3dbe37d35ac"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 5492,
+     "sha256": "ecf293b2e8146a33de7bc8bb3cded80bb785b931012b40dca204db3dad50e776"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 22052,
+     "sha256": "c5657b558522e46f0833b7827520c1a5c1f1674dffd52c12609779d5bcd75462"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 1396,
+     "sha256": "945ad552ad86e5193ef9c007dbe23686fbe89be1060063f57ea693b89e5df229"
+    },
+    "progs/spike.mdl": {
+     "bytes": 1396,
+     "sha256": "c5e6afcfbfe35ffde5bda7eaf91e2a583c3f20cf8f3175b4f4e0ad03b358983c"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 9012,
+     "sha256": "06e8f32092cbc0b5ba4d26227df9ac2d10f3a76d9a63bc7928af147b4ade12d7"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 6356,
+     "sha256": "40d9d29c58df57ece6892d71d0464022eb5939aa45699e98eae22136b973c4c8"
+    },
+    "progs/zom_gib.mdl": {
+     "bytes": 19768,
+     "sha256": "2175cca881b4a73adf3742933a5d3e91116c774ddd3db9b6ac2a7f863194d4a8"
+    },
+    "quake.rc": {
+     "bytes": 1261,
+     "sha256": "a22c886fc5c573004a4764878a9512a52895b03fe94eb823a397ff5f4b35fafe"
+    }
+   },
    "sha256": "47fd2f834ed72a33af822acedeb24c297539d88c57f7ef7fef55572f625c10f1",
    "timestamp": "2014-08-15T17:59:06.000Z"
   }

--- a/json/by-sha256/29/2932bdfda11224125c3f7207701bed8c4b7a765a2370a581589a5e17337b7eb8.json
+++ b/json/by-sha256/29/2932bdfda11224125c3f7207701bed8c4b7a765a2370a581589a5e17337b7eb8.json
@@ -38,6 +38,420 @@
   },
   "copper/pak0.pak": {
    "bytes": 11231782,
+   "files": {
+    "demo_c1.dem": {
+     "bytes": 1854820,
+     "sha256": "8b93e0384ac1505dde19d24a2e337686c065a43da8c8a476bfdadbfdc621928a"
+    },
+    "demo_c2.dem": {
+     "bytes": 2445116,
+     "sha256": "4e4ab2f099e5746565cd19e5695a35cc1252c24d8817b5c8670c1792c187097f"
+    },
+    "demo_c3.dem": {
+     "bytes": 1808204,
+     "sha256": "71476830e6d475ff8bb66fc8f07da76c89f407160ac26ad1ccfced0d6e7e80e2"
+    },
+    "gfx.wad": {
+     "bytes": 152468,
+     "sha256": "50d94651f3e0b0b6a29e0110ce9ff260c9f3114060b08b6d1ae19054b8024335"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "31c4858fe496187dc1bac21c02aff8cf83cbc51e0b4ee5738d6118c328b299d2"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "ed0f79285d93d0ef35644ecaf9ab36f3b2c6ffd223c577b25fff2ea17f90080d"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "e9c210ab88f6e98965cd2f8470f084e32ef15b3ad3912cb1e9eb0363c6204eb7"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b56880e2f720a89dcd055f5278abb21a21514322d4a31b77b46c8b509b9f3be3"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "89c3ac6fd91cdcf15c20b0d15b4c01c153e0a820c660f9222b5c8f63d43af5b2"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "8b83ffaf6b5309d371f0107ebb1340a8a09cd1a52c6a5581b7c9c4a7afcefa77"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/debris1.mdl": {
+     "bytes": 33768,
+     "sha256": "3498dffa0c3522b011a76ada880dfae64de3ca1583c94474e1e07adbc220d981"
+    },
+    "progs/debris2.mdl": {
+     "bytes": 33944,
+     "sha256": "d6d535173bb4a3a2d469be9c63bf36a01b1e2b80dd6a71636d20178d813e443c"
+    },
+    "progs/debris3.mdl": {
+     "bytes": 34136,
+     "sha256": "d6b0a2b6353c4462196d2af116652b47d464a7bc1f161509aa8ee5dbe859f98b"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 17812,
+     "sha256": "74cd41d8d5a67570cdaca34a08e9868f3476d8c4ac4a645cfaf9e91cf778c793"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "4f5ca2553db07d5cc93987b11e9f9ff054d51b96488e2bcc35c9f03ed3040d42"
+    },
+    "progs/h_zombnm.mdl": {
+     "bytes": 3220,
+     "sha256": "45d9dfe5683264edf6f6eb7b8e8d794f84caeb8701e65e8ebe9add2192bbb6fc"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "b00951cd72bb5fb03c19a1d60943162652fe149b9ee60fd2e630a076d52956fb"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/k_spike2.mdl": {
+     "bytes": 17716,
+     "sha256": "e456eb93934dab43a83305988db82ab1954e66491c256fad3ef1451d0ecf97c2"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 36496,
+     "sha256": "a001c379917628354adfb62b698856b33f4eea5f22e7d8e232e640faf15d8465"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133936,
+     "sha256": "e2d6b9de9b879327f72d97ef3c07e0b7e35cf844747208f6e615015be84157e5"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "f414f3fd07b0278bd59dd90954770f81a5ffad7f46af5f5d0abee124905dcc17"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "progs/w_spike2.mdl": {
+     "bytes": 5816,
+     "sha256": "b07808c532059133c31be2ed2bc4e9bb9b01b75d5d23401768058cacc3192068"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 74976,
+     "sha256": "545d70abb8d44be8e12da24a3d09fb56f87ff960c41963148682fbbd9d47e417"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 218680,
+     "sha256": "6782603eadacc7cb4bd09c11d3b6326e0d2e69205f724fe2f6e533ee398f5a16"
+    },
+    "progs/zombienm.mdl": {
+     "bytes": 224900,
+     "sha256": "f4d1ce9667ebb36088bfb59a12c9a8d93c1aefa36515b51f388cffec5132f5b2"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    },
+    "sound/zombie/z_res.wav": {
+     "bytes": 23266,
+     "sha256": "10b2962ce2817fa8a250811313307cf0dfa93ad5257a669452fe3fc834ced976"
+    }
+   },
    "sha256": "14a746abb95d03032dcf07202d9470cbc450c69a2a713d3a80bcdaeabe4262af",
    "timestamp": "2023-10-31T11:50:00.000Z"
   },

--- a/json/by-sha256/2a/2a9f127cb005a5c0845a6169dfcc7c59527dcfbbc88e0619650d3393e0eaf59a.json
+++ b/json/by-sha256/2a/2a9f127cb005a5c0845a6169dfcc7c59527dcfbbc88e0619650d3393e0eaf59a.json
@@ -47,6 +47,76 @@
   },
   "pak0.PAK": {
    "bytes": 3513227,
+   "files": {
+    "config(2).cfg": {
+     "bytes": 1810,
+     "sha256": "ec72216e302e4f64746e364bbd85a4433c427209d3a367176c80a07f396263dd"
+    },
+    "config.cfg": {
+     "bytes": 2138,
+     "sha256": "89ec66d84e87a333a5044833fdbdae66eac6ef36f825e3cfefccf1d6264a2673"
+    },
+    "drone.txt": {
+     "bytes": 3282,
+     "sha256": "78cc4b700db62b830ac700afc9a12602a941c18ec4ff0e68ad78b6129fb10ad9"
+    },
+    "maps/infectn.bsp": {
+     "bytes": 2536708,
+     "sha256": "0fee0f12e69db3ec2016254fc5a3d82f798533014d1f145e1f3e0b6c6edda902"
+    },
+    "progs.dat": {
+     "bytes": 411720,
+     "sha256": "3422c8b0d134ac3fbe2332fbe9967191cde98908dde7244a101ae7b68b0ccfe6"
+    },
+    "progs/demon.mdl": {
+     "bytes": 102120,
+     "sha256": "e1adf9a41616ab2ad4707a6c5b71e23c7874733bc41c065d2d0cfe8f303c8679"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "718b8c2842877345426247148dd6ce1ebe7fecc13e969a0fa0ed6dbebc388099"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "0a386b6381824b01852910519490ac3f6e3309a96091820384ee6b9a5b452e7a"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "ebd3e614ca2afdead497209fcf79f304218f4cff2bd3bca7d3e3a6c542f63362"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 34884,
+     "sha256": "cc06660e15c44f5e82778350d46979572f98597965b1f38a2b76622c3c3b8e5f"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 132028,
+     "sha256": "4ef0d99288c76da96935102ff09fc678bf5bfdca3d2f939018ed39e3beae89a5"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "744af1fafaacb751cf2e5ce4bb15a0fc1fb938ae519469de6f0dccfe9f320414"
+    },
+    "scr/ai.qc": {
+     "bytes": 15467,
+     "sha256": "f048842d382e5bb033c143214cfa2a00aaaf5758b48466f6af01bd2f7664eb64"
+    },
+    "scr/client.qc": {
+     "bytes": 34010,
+     "sha256": "8e48b053e3c8ba725b93c728f6ebf78d8027f6471e8e779e9e9649b1ff306e4a"
+    },
+    "scr/drone1.qc": {
+     "bytes": 11213,
+     "sha256": "a0b5682287f3cdd1350b8a9303dc4de4a8b6bb40b746732831ded92aefbf01ff"
+    },
+    "scr/snakeman.qc": {
+     "bytes": 9899,
+     "sha256": "c6078ffb73bbbdc17d81cbf83b11507e79efc5b642e7d19ba1e05ec57d5e05ac"
+    }
+   },
    "sha256": "13f5a2172078d3ee56fd7c3f667243592f49ee35bd964d559fbd2d37d8bccf58",
    "timestamp": "1997-12-18T23:50:30.000Z"
   }

--- a/json/by-sha256/2c/2c3f6ad7cdb0add0d2293ee80b09a308f20a204e5b0d80fb4d0fe58728a42491.json
+++ b/json/by-sha256/2c/2c3f6ad7cdb0add0d2293ee80b09a308f20a204e5b0d80fb4d0fe58728a42491.json
@@ -12,6 +12,96 @@
   },
   "torro/pak0.pak": {
    "bytes": 14076624,
+   "files": {
+    "gfx/env/satbk.tga": {
+     "bytes": 786971,
+     "sha256": "0b4a792847376df7350fada08c9788fd7e345f176b79a725b0128ec913bd4e09"
+    },
+    "gfx/env/satdn.tga": {
+     "bytes": 786450,
+     "sha256": "096cc0e7bcbef18e3aedcb637aec067831d37372a1e7efc00a007e9e5a22c38a"
+    },
+    "gfx/env/satft.tga": {
+     "bytes": 786971,
+     "sha256": "b46edeb1ebd3173f82c87af6a115395bb00a132bca1217de1d70d67b7ff65c05"
+    },
+    "gfx/env/satlf.tga": {
+     "bytes": 786971,
+     "sha256": "d6156589706bf2448dbdcf10820aaed11b8f3b63ef82f98a843a40a2f8e89bb1"
+    },
+    "gfx/env/satrt.tga": {
+     "bytes": 786971,
+     "sha256": "d1063a365100d9e0502c7044bf9fe5e69e3b21590d4c4c1103229cc2926fa70e"
+    },
+    "gfx/env/satup.tga": {
+     "bytes": 786971,
+     "sha256": "1e8c52ff8687dc4524adfecea4928cbc410693c70c54acf7ff9449c5bcf17b19"
+    },
+    "maps/tormentarium.bsp": {
+     "bytes": 5034492,
+     "sha256": "09fc061774cb4e57529af84c74359d3c186cadc56a793d5de528135ca06e735f"
+    },
+    "maps/tormentarium.lit": {
+     "bytes": 1702151,
+     "sha256": "1875660311020ea61eb6c5bc78b2b4c34f3a1ba7fc49a07efde4a63383ec4069"
+    },
+    "progs/cable.mdl": {
+     "bytes": 103672,
+     "sha256": "e6c6290a5933ff42b0dd6619ce04c7971012c9d100676add881d0aceaa633616"
+    },
+    "progs/coil.mdl": {
+     "bytes": 407561,
+     "sha256": "032c4e0c2f5e7356a4b314d884e2f74f6696b6d7c9cf7a06f8683227161f3f9d"
+    },
+    "progs/crow.mdl": {
+     "bytes": 189444,
+     "sha256": "49221bc5c74cfe9761a093ceca304423403d0cb38a577ee332fe9d0e2bfac58b"
+    },
+    "progs/gener.mdl": {
+     "bytes": 96589,
+     "sha256": "f6395ba76a8d30a3865d2512d5bd7114520b10113f637bb119c0fdb6b2332768"
+    },
+    "progs/huit.mdl": {
+     "bytes": 135222,
+     "sha256": "23ee0ee6bc0dc5827531ebb692f2f48e7ccf97cacd24d6f8858fabd8974509e0"
+    },
+    "progs/phak.mdl": {
+     "bytes": 63389,
+     "sha256": "58f66a24f66695850dadd711c86c0902fe02151050a78e83f6358442467f8cfc"
+    },
+    "progs/phak0.mdl": {
+     "bytes": 63389,
+     "sha256": "91ae9c00c02d864c07614b3bca37d36b1fb9aab6bc94a9aea958cfbcb89f72c8"
+    },
+    "progs/pipe.mdl": {
+     "bytes": 15977,
+     "sha256": "5fd9a632b538e2885eb5c4d2ac800ab4e83d725ea58b84919a4bb9b074aceb3d"
+    },
+    "progs/plug.mdl": {
+     "bytes": 622896,
+     "sha256": "dff221a3f6c61d36d6d49ec176f5a616587ad6e8b5f01cb6f220e62d854d2bb9"
+    },
+    "progs/rota.mdl": {
+     "bytes": 478313,
+     "sha256": "539fe7c7b03e31ad0f624f1e5bde852a3f0e55f97dbe8b3202174f31869230e2"
+    },
+    "progs/tank.mdl": {
+     "bytes": 90205,
+     "sha256": "5a1602b225c14b0354d2c809961929d83739ead60d6b914bff04ccfd4f04cd70"
+    },
+    "progs/tanks.mdl": {
+     "bytes": 60547,
+     "sha256": "19915f6418a177cc25c05ba5507d72a0d750405a6c408fb10e74398561b00933"
+    },
+    "progs/tessla.mdl": {
+     "bytes": 282784,
+     "sha256": "ea5a3092be2b82aaa851101df86505a40e8458e7868985cf51ff8de84cbe7e4e"
+    },
+    "sound/misc/electric.wav": {
+     "bytes": 7234,
+     "sha256": "b8f41a9919eb354177c352198a37c9d4ef3aa42b897898bb92a5ea015a2ffbc4"
+    }
+   },
    "sha256": "7e3ca720f6a47d937dfb1669352fa00c6b07142ea7b38e38d82f1ec1bc627f53",
    "timestamp": "2012-09-16T10:10:06.000Z"
   },

--- a/json/by-sha256/2c/2cf4e79e52213e74daa72407a76f3ed8871eaea36d6fe8d1cf46c17792bfd580.json
+++ b/json/by-sha256/2c/2cf4e79e52213e74daa72407a76f3ed8871eaea36d6fe8d1cf46c17792bfd580.json
@@ -8,6 +8,276 @@
  "files": {
   "PAK0.PAK": {
    "bytes": 7328862,
+   "files": {
+    "conbak4.bmp": {
+     "bytes": 65078,
+     "sha256": "967d67e9ca3f8e610ea9b17a58055a98a5b5d7f93ea0e490e1b74aceac1bd072"
+    },
+    "demo1.dem": {
+     "bytes": 579840,
+     "sha256": "3ad43e52e1ef1c3553431b2800d4663584f2ba248691dd45a2dd31ae67ecf86f"
+    },
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "5a05c731464fcb0c49bf3ce8d958aebf65375ad2cc654f7de5fe445016f69214"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "de3f5506c2f38372c714ffb9bf5a006fa44e1c2c81c9ba9f691e5abb5df076be"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "652a64f503dd18d107affd42d2b14f2bcbd7bfd491f8da39b8f1ce340bc04540"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "03cd7b70fbbb24730f6ab7f0d3743734f1d9deb7929385900bf60a477d49acd8"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2d88a3ddbc51c2e9fd764d2229156b51974af607cab93b6983658ef3adf8f386"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "0741983bea08669e755611d8e7ab81c1aa35ee0663081829b61ce3618b91f1bb"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "67e0a13ea28f7c469bc1c98b277da0ff776805da9aec2ecb9ba41fc5cb78673c"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "520c8764f9885771d24677c2ac29d494124389d8129ed6d4f8386e7631cfda57"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "6b90710a7ba4ad47023be22e82190b821d11a5cde8438c188989b5008ba28436"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "540a3ad5d0e674737cc89b4900ca1a3dcea62132b2ddcd562ffced075461505b"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "535922ac16f460da936ea5f7ac148b1dabc1e98b76f0a162b7192591867b5bc3"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "e1b40601df0fd9d6742d799cf80fb4089901334c1c859028a398be31853186ca"
+    },
+    "gfx/colormap.lmp": {
+     "bytes": 16385,
+     "sha256": "046b550293b21725cf2df16bf7c31a7adf1c3f710fd39bc1f2bb1ecb356cf54e"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "4ce8254127ecbce046a93d8ae07f46095a9d694645ed69830909b110b248bc17"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "4e9cd74ef7c608b7c0fe42fe51161ec1b3856f4e08f11b08792acd717f97f1f4"
+    },
+    "gfx/dim_drct.lmp": {
+     "bytes": 3352,
+     "sha256": "95aef5fed25bb354e44b802f9a712adaaa42c559c0860a2418bb56387b185054"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "14f86cf1e7d2926b08b3071c934ec1d1c587aeca8f9da5b823240eccd18eded7"
+    },
+    "gfx/dim_modm.lmp": {
+     "bytes": 3352,
+     "sha256": "88ebd8435a6a17e80793fba2c3cfb6592f068b1beac1d4b76c4130b5edeea5b9"
+    },
+    "gfx/dim_mult.lmp": {
+     "bytes": 3352,
+     "sha256": "ac133a9af68ba07c40b611213101360dd4ff8343f6ac999a941ecb1d292fb415"
+    },
+    "gfx/dim_tcp.lmp": {
+     "bytes": 3352,
+     "sha256": "df0f1515ee85aa26838ec217f39eccfb6eeea106402362c81805dfe62f9b178f"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "609fde2e31eba5c85bb54113093c6101bd70819ce847fef023e21b60395a0c32"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "bf7d7b6764ae21c63035582e14d285ca66490db8db543308ce02cdf7b8ff5a83"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "eb3c8025813eae1170c8fae129ba511bcc52a0c874bea3da457f29ef35be60f4"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "a4ee1c2c26d2450c6760c51ef8ecbd22278bcd0e4becf7bf5dc0cbd1a370ae9f"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "f0981b3dc50ea21a7f5c5bc6bb7fc22d82a19ad65f0396bb3c91dd949b5aafdc"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "5b2d58fd196c3c9d39ea05d2106934b1aeb11e7f8460fc985ce9730da01c82a9"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "fba5e52a3f7f9c873a86c5bc0a124eb3523b8a2230e7162270fc2d715a357d74"
+    },
+    "gfx/ibar.lmp": {
+     "bytes": 7688,
+     "sha256": "53fad489bc82683fa28154198a909dc412bbbb804c312d0906b518930391505f"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "a7679e7898b233a737bca7ae8a77e58a04ee9be0f2e9994740073efb65706631"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "2dfe0332f7585f6fa9237125935569222a454bb73a1c6a7028efa20f05d5ffa4"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "488058a12f22609f0723aac94b14e853edb79112b920c5ff93adb84ee505f7a2"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "f30535dcaef7573da52eee14e341be401498cabe5fe74149141351188e46c3cc"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "126c8b6b975ed8fc27b53ef31f1fc60f7dfc78136cc25decc37211de0b8539b1"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "c918e55c8045603d57b1f78ab65f0c2aad962494e112835587eb4d9bd0817fbb"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "5e813f713d605d71f98b3bafdf908ef43193da0f459e4d55b967c335bc3760a8"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "f87b0d237d2fe3292cd3f1e191e5920800648affc9b1f8d219f9d7d96b27a70f"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "68cf435d3d4c29cb95318bcc0d450a2be578659048fbb89af61eedb0c1f70666"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "38aafc0e2ebc205cb3ebcfc8f410779d837a17c395e718c62594482d2bf9fa33"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "10e6e44f74c17cf41ca3171b5dc30102a2e37ad2a310f80fe0fb2074b8f00429"
+    },
+    "gfx/netmen1.lmp": {
+     "bytes": 3352,
+     "sha256": "378852aa6c0ced84192a31f549f8204cf34003a3b51417fa8061f4e70ff6fc5c"
+    },
+    "gfx/netmen2.lmp": {
+     "bytes": 3352,
+     "sha256": "19a324fdff8f2c716beeb9da110b52ed6f9388b4b2744d69cf1fbd4d36c72f46"
+    },
+    "gfx/netmen3.lmp": {
+     "bytes": 3352,
+     "sha256": "90b2f08d1ec391bccac1d4e80ce92eb8ae0385880a26f7789742d89d32874bde"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "e7ef108bc8a7233b2a22d9c19a40078e5b23f65099f259811ceff4d7e184c01f"
+    },
+    "gfx/netmen5.lmp": {
+     "bytes": 3352,
+     "sha256": "e16f2ce2d4e76de19f9b7b3e2670454b33b889eb8e1236c406537c5d8d86b434"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "cb53d9c1a820f5f0c1b250e06825d5f035241a989774897e66039182d2efb094"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "82feb405dd07aca7c2dc42c70aca3d7cbe5d7c17dad38ff446120252328442b3"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "ada9765b9ceb38535bc169157aa97a88e95660bedaf936f33261131f7166f17a"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "ec2373d71c1631a7bc8ff6ce51c0136b1e90cc7d14859081193e2da70ee2d99f"
+    },
+    "gfx/palette.lmp": {
+     "bytes": 768,
+     "sha256": "f0a27d70d486537bc23d06c6a843900d2ab49d55abb92615da74dfddbe768fd3"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "81a58d90842ba263e30fafcdb1c41bf9e908bd615a570bb84337a59430d4f036"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 5384,
+     "sha256": "65b8629ad2538f6d71d8822651a22c62043f9499c71b3b6883889627749d630b"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "1940bc99abed2409ac4687bcc80e78ec9dde5b2ac984d1d7bb5906ae0f0d9e3a"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "7f5fefbedf883ae22bacba9c5ba28acab5fd71ca014e48e1e542561a478bf782"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d38bec76d161c072027421f7c8f3838d3f45bf309d0489e69bad5989afc8e6f7"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "9390cdc020f19ba246b91a0bd94ff1629eed8461137f3061b514a6a36f505e0d"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 5192,
+     "sha256": "e07df843f8687777ec0fc2ed5a081ca8e9ab210c765c0c0685dc1ba6f3938d66"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "9fde77a8593512211ee1117c016510d2b4325ac921bad67c7ab797516e71b4e7"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "cc5d4b36999a0efe41cbc5e2364487eaf65446f74190417250e527d275313266"
+    },
+    "maps/db_cath2.bsp": {
+     "bytes": 807316,
+     "sha256": "faabc785449465af99cf4c9047ad6b1f361f0d5543d40adf939a63546cb6c675"
+    },
+    "maps/db_mine3.bsp": {
+     "bytes": 1186380,
+     "sha256": "be70c4c7ccd4e93ccbf010bc3b6a1744e60ca5ecab8c88cd82080b56c3c7c2b4"
+    },
+    "maps/db_tech.bsp": {
+     "bytes": 1322960,
+     "sha256": "a878d2d23ca301e640180ffe1139b0947db1725ae0979397d154a1776d2deb16"
+    },
+    "maps/lomdm2.bsp": {
+     "bytes": 938740,
+     "sha256": "84fbaed7d7aaa203e9b32299f616c31e100c525b75f6bb0c445dfeb7e6b30806"
+    },
+    "maps/start.bsp": {
+     "bytes": 160764,
+     "sha256": "8fe10bf17888c84e97d452b6fef282bbcd02c04b479512b9ba8b7bbfc2c41030"
+    },
+    "progs/progs.zip": {
+     "bytes": 1428909,
+     "sha256": "8f82f39b07825c0f2e46e8414d9612543bdba9954095a4cc4673072853f3706f"
+    },
+    "readme.txt": {
+     "bytes": 1786,
+     "sha256": "e79f5d0a605abae60acf075603a8bfed802ce85712cecb1339ce416fc68a13c6"
+    }
+   },
    "sha256": "9c09049f1472531d6d153aace2db3924a46f73d5bb5d43751923019215903991",
    "timestamp": "1998-02-14T11:05:38.000Z"
   },

--- a/json/by-sha256/2d/2daef0b47ab254902563e4302439a34819887a7aa672db811e7b0ded185707a4.json
+++ b/json/by-sha256/2d/2daef0b47ab254902563e4302439a34819887a7aa672db811e7b0ded185707a4.json
@@ -126,6 +126,13 @@
   },
   "dkt1000/source_maps/zooloo-source.zip": {
    "bytes": 62340,
+   "files": {
+    "zooloo.map": {
+     "bytes": 475045,
+     "sha256": "3bedfc6dc821d896f45cd5d61a7ea256932dab03a8aba228a07f115a32374b10",
+     "timestamp": "2004-12-05T22:35:10.000Z"
+    }
+   },
    "sha256": "adbbcdf23125fd192cf0528b5624010c7bd153728b38be9eb6d741a09655141a",
    "timestamp": "2004-12-05T22:49:06.000Z"
   }

--- a/json/by-sha256/2e/2eebc5aa1b4c019e38ce9c5d1f51cb072b3bdb9b995b8dd361ffd896f1d4a3ab.json
+++ b/json/by-sha256/2e/2eebc5aa1b4c019e38ce9c5d1f51cb072b3bdb9b995b8dd361ffd896f1d4a3ab.json
@@ -7,6 +7,72 @@
  "files": {
   "Pak0.pak": {
    "bytes": 2262816,
+   "files": {
+    "maps/b_bh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "maps/b_explob.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/shadow.bsp": {
+     "bytes": 1476780,
+     "sha256": "68b8c3bc4cf17c2daaab077dec68e0f307545473e12aa4d35c0aa06bb671788e"
+    },
+    "progs/demon.mdl": {
+     "bytes": 102120,
+     "sha256": "fc86ed76ee03cbc80ad963999341d5a634c9421739ec20d7ce9367c04d3ea4b4"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 34884,
+     "sha256": "8d48117d355ffd648d1b8498966f2ae61ded8d6e0a695b7f296564d8cf235ae0"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 7156,
+     "sha256": "2df7b7aa12e4a497327473c4ee07fe7d46ade3c7232454c774aaa48dfee2df62"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 28036,
+     "sha256": "f3ddd93b167bae4528364e5b23c3c06aa95dce81bf3f7c801c8f27d2fc3e10b1"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 37060,
+     "sha256": "a5fe96718d348b02299fcf04d1e02e0bb973df1519a493b8ee50eda297bf536b"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 14804,
+     "sha256": "a4e5899509bc262decc152a6756df8e457d7e6bcf49886cda55a7d62d5acdf23"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "d53ae9fa2b43f4150756734011e85639a5d428a2539f7a3e39f01c6353445f7d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 101404,
+     "sha256": "2688f53741a21c1a5d0520b21d99257d884e293175d2707ceeae3823d8848f63"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 80648,
+     "sha256": "aca8e867c6fb3b3ef8ed5c8fb84629375393b0d7cab9e6a5c0852f8d003f1959"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 98556,
+     "sha256": "2a7ba1a647d15522eccfbc7586ad20128d250eb63055854bbfbf817496c0d25a"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 64472,
+     "sha256": "b2f9a9897231521ef6b4087c81d1018468c50073dacce5f424f83a11e36e5ca3"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 186084,
+     "sha256": "05b8bcaa335c50ad9f74f511767ac2016fdc96cfd60071e2c66d294487be6c2c"
+    }
+   },
    "sha256": "813417dbe003713fc9e67eec330912b15515edea37f0b0dfb925c959da9183db",
    "timestamp": "1997-03-06T09:09:10.000Z"
   },

--- a/json/by-sha256/30/302c9cd6d3414fa8919e9d4787af9aa26662eafb1617e107483320a706429649.json
+++ b/json/by-sha256/30/302c9cd6d3414fa8919e9d4787af9aa26662eafb1617e107483320a706429649.json
@@ -7,6 +7,512 @@
  "files": {
   "Pak0.PAK": {
    "bytes": 7117925,
+   "files": {
+    "maps/add.bsp": {
+     "bytes": 2104812,
+     "sha256": "8e78a61008b36812b2571061a02bfcb6a13efb86e55530c506f3b9c5b43ba2af"
+    },
+    "progs.dat": {
+     "bytes": 705964,
+     "sha256": "2b7d653d553e5c6122b2b1a8f6fe0f869c1a83ec6950163acc7a19d360414d12"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 106244,
+     "sha256": "2ca415ec913b3c05038c6db21f9235edf7eefe7cf41120edead53efb90ff0ef4"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/hkboss.mdl": {
+     "bytes": 323272,
+     "sha256": "75666ba526027224aa6304af2737a5e957184f4522e12a0476940744d24c5a85"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/knight.mdl": {
+     "bytes": 153400,
+     "sha256": "26576f139d258b3c236faa6552d8ba09ef6e14480d4a2e2dc9e3e2c4df5177b6"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "fae8fac60b899d78a929ada720c591b7356e78cdea074f1b128f465d47fc4d8a"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 132028,
+     "sha256": "8824603b325f37bbba424f55c3ff900c21ccf61c77ba97e636e91ef99202364a"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "744af1fafaacb751cf2e5ce4bb15a0fc1fb938ae519469de6f0dccfe9f320414"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "ba9f52e66ac380306d443e07ee4f1fac92793cba55394c01590c3dd088042e78"
+    },
+    "progs/wetsuit.mdl": {
+     "bytes": 55156,
+     "sha256": "4e4dc7331c374d2345c3d755ff34b61850c289741314b10fa36c461db3844e99"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "sound/ambience/comp1.wav": {
+     "bytes": 62734,
+     "sha256": "023903bd93bebc49b2a9c66b17f1f32e533d14fe111d93ea36b362f2e0437b22"
+    },
+    "sound/ambience/drips.wav": {
+     "bytes": 80712,
+     "sha256": "96f7890d2fea2f1f6443d0e75bb6084f39931e7c5399a6e75787dec4eaba5033"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/fire1.wav": {
+     "bytes": 24064,
+     "sha256": "db160193d1db0e65b3f014291bba7c10ec2a11dc1844ac1a0288ab30ac3adf22"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 25852,
+     "sha256": "02d097f0a58cc65826bde1ebe5c3450a4ab92d09b16e85ad916f62dca82936c9"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 91138,
+     "sha256": "ffc3f8d7386db7766c885706a1247926f870957d4a3e55cd51dbe4d55416338f"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind.wav": {
+     "bytes": 44582,
+     "sha256": "1b0b9f054d82c238128b821c41bdeba0e81a436f37c1aec92d2e1dfd7be61c6a"
+    },
+    "sound/ambience/wind_high2.wav": {
+     "bytes": 91138,
+     "sha256": "ffc3f8d7386db7766c885706a1247926f870957d4a3e55cd51dbe4d55416338f"
+    },
+    "sound/ambience/wind_low.wav": {
+     "bytes": 58476,
+     "sha256": "0759ad526d301c3bb14c467818bacdbe3a64237657c45a435e06cb166b570b85"
+    },
+    "sound/ambience/wind_med.wav": {
+     "bytes": 32212,
+     "sha256": "005616904ebfec049860ca33b790903e76c75615f3048dba17ce8d85cd6c65f5"
+    },
+    "sound/ambience/wind_rumb.wav": {
+     "bytes": 63234,
+     "sha256": "24760cbf8622bb933fcd59e847067de3581f6a3d54db72bcb3f864d2cf508a36"
+    },
+    "sound/ambience/wind_rumb2.wav": {
+     "bytes": 32872,
+     "sha256": "9c77014eb35b692af657a524f1e7eb82b1b1ebe9d95c62462e6f6925baf4153a"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/adeath.wav": {
+     "bytes": 11714,
+     "sha256": "c6d2e6a1107eddcb49ca41776da1c7f8a3b27766b66dbf4bd9186fba2780cb2c"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/apain.wav": {
+     "bytes": 3302,
+     "sha256": "788466ee8cc368bcac8b07c4eeca5509ccddc30addf5a322b31a605d90bf0392"
+    },
+    "sound/axeman/asight.wav": {
+     "bytes": 8528,
+     "sha256": "d5d1a9125b9a015186d6d5e9fbd9f9d9db3fb220bdf9139f5aa73b9019d37126"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/snakeman/sdeath.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/snakeman/spain.wav": {
+     "bytes": 34452,
+     "sha256": "15b84d6adb80e4ceace4226b5185c578a752adb36f213f2488e80ad2192378aa"
+    }
+   },
    "sha256": "55b9f78669b8c0fe68c76a7984ce7ce99702fbd1754834c541444f4f26e57899",
    "timestamp": "2003-05-07T17:51:54.000Z"
   },

--- a/json/by-sha256/30/3042f86e1177d2c506fbd415bc8702567a934f9b20c27285ed02b988bfb00bb4.json
+++ b/json/by-sha256/30/3042f86e1177d2c506fbd415bc8702567a934f9b20c27285ed02b988bfb00bb4.json
@@ -27,6 +27,460 @@
   },
   "alk11/pak0.pak": {
    "bytes": 5739649,
+   "files": {
+    "maps/alk11.bsp": {
+     "bytes": 1484520,
+     "sha256": "943c7929196abc992ea2d8cae5a92039f121aa53e25468c72ecab009a7dacc46"
+    },
+    "progs.dat": {
+     "bytes": 705356,
+     "sha256": "7f866af4ae80e59e3d2a0579f57fef1390f533e616fb33cda7d0f5b9d7560713"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 106244,
+     "sha256": "2ca415ec913b3c05038c6db21f9235edf7eefe7cf41120edead53efb90ff0ef4"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/hkboss.mdl": {
+     "bytes": 323272,
+     "sha256": "75666ba526027224aa6304af2737a5e957184f4522e12a0476940744d24c5a85"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/knight.mdl": {
+     "bytes": 153400,
+     "sha256": "26576f139d258b3c236faa6552d8ba09ef6e14480d4a2e2dc9e3e2c4df5177b6"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "fae8fac60b899d78a929ada720c591b7356e78cdea074f1b128f465d47fc4d8a"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.qc": {
+     "bytes": 7330,
+     "sha256": "60b9b2f830d359825647aa829bd0566f3fd8b6727df89926133898512cb10f1b"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 132028,
+     "sha256": "8824603b325f37bbba424f55c3ff900c21ccf61c77ba97e636e91ef99202364a"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "744af1fafaacb751cf2e5ce4bb15a0fc1fb938ae519469de6f0dccfe9f320414"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "ba9f52e66ac380306d443e07ee4f1fac92793cba55394c01590c3dd088042e78"
+    },
+    "progs/wetsuit.mdl": {
+     "bytes": 55156,
+     "sha256": "4e4dc7331c374d2345c3d755ff34b61850c289741314b10fa36c461db3844e99"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "sound/ambient/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambient/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambient/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambient/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambient/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/adeath.wav": {
+     "bytes": 11714,
+     "sha256": "c6d2e6a1107eddcb49ca41776da1c7f8a3b27766b66dbf4bd9186fba2780cb2c"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/apain.wav": {
+     "bytes": 3302,
+     "sha256": "788466ee8cc368bcac8b07c4eeca5509ccddc30addf5a322b31a605d90bf0392"
+    },
+    "sound/axeman/asight.wav": {
+     "bytes": 8528,
+     "sha256": "d5d1a9125b9a015186d6d5e9fbd9f9d9db3fb220bdf9139f5aa73b9019d37126"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    }
+   },
    "sha256": "fa9cdbccccc1daaab607d60680c35f2876712dfeb9188aad0576163b41d8c69e",
    "timestamp": "2001-05-26T14:06:56.000Z"
   }

--- a/json/by-sha256/30/30b92311e31ae20c4bd3bfb06a5bfc9e1888de655b92d8e86a6352319a201972.json
+++ b/json/by-sha256/30/30b92311e31ae20c4bd3bfb06a5bfc9e1888de655b92d8e86a6352319a201972.json
@@ -17,6 +17,180 @@
   },
   "pak2.pak": {
    "bytes": 8021749,
+   "files": {
+    "base.dem": {
+     "bytes": 1166121,
+     "sha256": "f861f97f1575aa21efb675f8477fe96313f2ceec270273044fc34bdb8277c098"
+    },
+    "default.cfg": {
+     "bytes": 2025,
+     "sha256": "3227f12ce7edbb4235d5b8b4d3f69206a9b8fd8715f939ca0601325e52ea15a4"
+    },
+    "gfx/env/moonbk.tga": {
+     "bytes": 440145,
+     "sha256": "215264c71fcfdcda4fd9470adb3b1e1e803cd5af1d8df035c3244646dbfeac2f"
+    },
+    "gfx/env/moondn.tga": {
+     "bytes": 603,
+     "sha256": "4a83e798c3d0637f03b1effe28df9998bf249831b3dccecef074ff5cd8b631df"
+    },
+    "gfx/env/moonft.tga": {
+     "bytes": 410588,
+     "sha256": "4fbbdf05866d78de6ab4bfc9867227007fc87073cc96678e0c08bbc6d9717ce5"
+    },
+    "gfx/env/moonlf.tga": {
+     "bytes": 421955,
+     "sha256": "ea304d8972653bd38c0aee88e6dd434d719360c423344d16b5db9c398af260d7"
+    },
+    "gfx/env/moonrt.tga": {
+     "bytes": 453367,
+     "sha256": "8ee2a2b97267326d4831d96c879c6238a63c485fc8865d91503adb6d7da878bd"
+    },
+    "gfx/env/moonup.tga": {
+     "bytes": 1335652,
+     "sha256": "91e764d1d7780818e58f1c30d7c8825df2adbf17c7da630acfa3dd70b29d27db"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "faa7c77704959d1ad9bb5280449b22e8c4b9425fc628b4f2037900c49e73fc9e"
+    },
+    "optout.cfg": {
+     "bytes": 1564,
+     "sha256": "51efd87218e766df5c8b5c643ccabcecacfa855ee60deaf8dde8420a02c157c8"
+    },
+    "progs.dat": {
+     "bytes": 723936,
+     "sha256": "940b86822b2ff00d4488839e61de516fbc381f1ac19d132356b1c00d3ee4bcf9"
+    },
+    "progs/bolt3.mdl": {
+     "bytes": 15772,
+     "sha256": "6fabed3901bab1b145e418300d333c30016070e57ede07476884283a5ef7e380"
+    },
+    "progs/box_l.bsp": {
+     "bytes": 21639,
+     "sha256": "9a20404c31446ffc497113892dc293b0e59c6bb2cd9ab4a1f0bee11cc1f61a5c"
+    },
+    "progs/box_s.bsp": {
+     "bytes": 21541,
+     "sha256": "47b3f0a947272241184b9f65aa46d694fdd8facb8a9a36509d6f11f844f3917f"
+    },
+    "progs/c_ham.mdl": {
+     "bytes": 76800,
+     "sha256": "6bdd3e6b4c8253e6aeb6e293093b88fe6b3a9254135d285c8574acb6be9de9e1"
+    },
+    "progs/c_lance.mdl": {
+     "bytes": 44164,
+     "sha256": "6925fa7f462edb6c863bef65dcbe7d5c69544454c6fc1435a98c2890b08cc757"
+    },
+    "progs/c_light.mdl": {
+     "bytes": 76388,
+     "sha256": "9f0cdcc8e56d0614e058a3e922f3f64b0de33ab2ba6fe390c4154a3cbeceff5b"
+    },
+    "progs/c_nail.mdl": {
+     "bytes": 45336,
+     "sha256": "afe38a23bd9d6ec01a386047c3030f95732a986211eb0c6aafa83e12eb300a53"
+    },
+    "progs/c_nail2.mdl": {
+     "bytes": 81136,
+     "sha256": "c2e9e328af078538722ba4894801b5e4c5334a4629faff83b11510aa0a987b21"
+    },
+    "progs/c_rock.mdl": {
+     "bytes": 74404,
+     "sha256": "058de704ba8b0c2a47c2b83fd1b767a8220b9af87460bf114b14528db57ce096"
+    },
+    "progs/c_rock2.mdl": {
+     "bytes": 73544,
+     "sha256": "c922fdbfcd8175d196cc16f2134c8d9852c788ca76c198337aa71bf0bfde5e56"
+    },
+    "progs/c_shot2.mdl": {
+     "bytes": 42636,
+     "sha256": "02226bf370133fb1c4479c56a9a3c544cb89a0e87ba4cabe3247f9ddc9994b9a"
+    },
+    "progs/dspike.mdl": {
+     "bytes": 25324,
+     "sha256": "c2c89f690e21e34bee37db5011493f3457240e22fcaa3cdcdf04ef4bf9f44ae1"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51272,
+     "sha256": "0244bf38ec29f251b425bc1cc4f1a0e003316b3699c869cea38ec553e1f96acc"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "d45e10e4002fb17b2a1aa4077d1d4e599babd5083c0f7da914f8e98b61cb2537"
+    },
+    "progs/polyp.mdl": {
+     "bytes": 343144,
+     "sha256": "a135ee3b29dd230d06babc0e80c691b35e33599a48eb152d2c2c4902d424d4ec"
+    },
+    "progs/s_vp_pll.spr": {
+     "bytes": 272700,
+     "sha256": "024935ca88793c432ac5d6c6f52a51cb82638c86e9c27cac8d87e926673012db"
+    },
+    "progs/slime.mdl": {
+     "bytes": 25976,
+     "sha256": "53b07ceca49f5c637dc5bbe1cf1393db74e3d057624039efb8d7fd2341b5466a"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "aa9165056656a1d0810d741c91e5e14b1aebf3020a95ebc0dc1f48a3a1243074"
+    },
+    "progs/waterfall.mdl": {
+     "bytes": 43588,
+     "sha256": "c4bf6157c6f3a580a6cc7a76c8d5ea6a9af00f9c53b0615bf47b6574dc5bd54c"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 845237,
+     "sha256": "ee9db9fb4e224227574067dffb1b9c49af5b9536f8cea0527282d851aab81e73"
+    },
+    "quake.rc": {
+     "bytes": 1248,
+     "sha256": "dac6aec78b770451be757493c744ffd4a3ef9fb64be379044d1de57936a746be"
+    },
+    "sound/ambience/grinder.wav": {
+     "bytes": 264572,
+     "sha256": "70789db5c6e505292dd6031241aff19bd7b327677033cac5f98c1dcfeed5c6db"
+    },
+    "sound/ambience/teeth.wav": {
+     "bytes": 51600,
+     "sha256": "9649cc3a15c66b851da286bfbfe085196e851a9a493c299b03d9874dc04431e4"
+    },
+    "sound/doors/er_stop.wav": {
+     "bytes": 51846,
+     "sha256": "f674272aa55db0cb05651c5edfa76422370d138c44789b179bc6e943a22f0d28"
+    },
+    "sound/doors/er_strt.wav": {
+     "bytes": 99372,
+     "sha256": "afb23446ab200aa3bd540bc1ac517713dbf2d7fc099283254f7b8a4480a90092"
+    },
+    "sound/doors/ir_stop.wav": {
+     "bytes": 81054,
+     "sha256": "c5ae31d19bb638cd61771f365beca5998d5795ff035929863a19148d39907904"
+    },
+    "sound/doors/ir_strt.wav": {
+     "bytes": 86616,
+     "sha256": "8e2767cf7d483ab898c7eb561834b0a7af90669976499dfe42c8f7e09560aeb9"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/wfend.wav": {
+     "bytes": 9060,
+     "sha256": "1d8381b51b40e54a47ee76a9115b95a49285fc59385ff20b941b0fc8b7cd16b7"
+    },
+    "sound/misc/wfstart.wav": {
+     "bytes": 77838,
+     "sha256": "c85b517926832c1a7ef3a04de2995a7bd58a161620b4341a3f57d556c50d7ea0"
+    }
+   },
    "sha256": "be17936386a4f842d59cb8f509348acce924e6da64ec4b999f7079cdca9cbd83",
    "timestamp": "2014-05-03T11:24:10.000Z"
   },

--- a/json/by-sha256/31/31d7d0a692bae955d28578cfdcb1fd4d51cdf9b892bcaed0eddb1e8969b3e52d.json
+++ b/json/by-sha256/31/31d7d0a692bae955d28578cfdcb1fd4d51cdf9b892bcaed0eddb1e8969b3e52d.json
@@ -7,6 +7,23 @@
  "files": {
   "RMQEngine_0.85.3.zip": {
    "bytes": 391535,
+   "files": {
+    "RMQEngine-Win32.exe": {
+     "bytes": 510464,
+     "sha256": "f9935ea5bc390b3d7162ce6d5377a810c3df9aa430cdea6ee85230245a0e89cc",
+     "timestamp": "2011-12-28T15:52:20.000Z"
+    },
+    "SDL.dll": {
+     "bytes": 323691,
+     "sha256": "9b149543f3d63d40a4b92d2313af5f3e8af55bb37f2e247e9ba9f54b1864ef77",
+     "timestamp": "2011-03-01T21:36:48.000Z"
+    },
+    "SDL_net.dll": {
+     "bytes": 13312,
+     "sha256": "ab2747959774add5d6676f5a570b0cf74a43deb1e6e2af8413007796c6af1030",
+     "timestamp": "2010-08-24T13:13:22.000Z"
+    }
+   },
    "sha256": "74c755661a3acd71b661a987aaa7da2c514266fcc32c402797745f450cd74a55",
    "timestamp": "2013-11-14T10:39:40.000Z"
   },

--- a/json/by-sha256/32/323d08307455a302ace09f33d47e558c73e35c5e0409e81531ad0b27d561b0d9.json
+++ b/json/by-sha256/32/323d08307455a302ace09f33d47e558c73e35c5e0409e81531ad0b27d561b0d9.json
@@ -157,6 +157,348 @@
   },
   "honey/src.zip": {
    "bytes": 3489846,
+   "files": {
+    "maps_src/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2012-03-30T18:48:56.000Z"
+    },
+    "maps_src/bm_brkceil.map": {
+     "bytes": 10371,
+     "sha256": "c800b3168b4100b15185ba70c05bc3ece29de232ff803ee23ab1590cf73b136d",
+     "timestamp": "2011-09-14T17:45:22.000Z"
+    },
+    "maps_src/bm_brkceil.xmp": {
+     "bytes": 7067,
+     "sha256": "48fd199e88c660c50ec9b333bb8c47d555e9f885a450050e17f66d3677e29366",
+     "timestamp": "2011-09-14T17:41:32.000Z"
+    },
+    "maps_src/bm_brkceil2.map": {
+     "bytes": 9332,
+     "sha256": "51bd3e59aed823b0fb2131233497ffb0dea8896e692a657a285f99c2c7db9125",
+     "timestamp": "2011-09-15T20:55:36.000Z"
+    },
+    "maps_src/bm_brkceil2.xmp": {
+     "bytes": 7236,
+     "sha256": "92b48b80ede0a3c4375ac06ee32bf0374562eb3883160cf2245c5e97e018bfca",
+     "timestamp": "2011-09-15T20:55:24.000Z"
+    },
+    "maps_src/bm_chain.map": {
+     "bytes": 116594,
+     "sha256": "358302cac8e06ddda4d2aca2c11b9ecbccde17848c3aec6f22602425815c8d2b",
+     "timestamp": "2012-03-06T00:57:46.000Z"
+    },
+    "maps_src/bm_chain.xmp": {
+     "bytes": 81928,
+     "sha256": "7311db476287bf45880fa7d1b57d41751c2c9737ef3c22f3db659c7188f9421b",
+     "timestamp": "2012-02-28T22:48:18.000Z"
+    },
+    "maps_src/bm_chain2.map": {
+     "bytes": 64969,
+     "sha256": "3f4bcd937aac08d9f2c6bf892a6fb018ca76c6fda890d86979dea3d42bb9bb1f",
+     "timestamp": "2012-03-06T00:57:48.000Z"
+    },
+    "maps_src/bm_chain2.xmp": {
+     "bytes": 36490,
+     "sha256": "f665ef3cd58808c8e9063a544500cf3f88f2ba65fc3cc2b7bd31496fd81e2fb0",
+     "timestamp": "2012-03-06T00:57:38.000Z"
+    },
+    "maps_src/credits.map": {
+     "bytes": 928222,
+     "sha256": "7a0bec488f2bc1444a46175d8a451b5c9b998741d3555316cc0a3046398ad2e4",
+     "timestamp": "2012-03-20T22:34:38.000Z"
+    },
+    "maps_src/credits.xmp": {
+     "bytes": 538784,
+     "sha256": "50a22d633972da76e92069e408cdbdc5a91969318f2ece734820e91a007fc21c",
+     "timestamp": "2012-02-09T20:21:40.000Z"
+    },
+    "maps_src/h_end.map": {
+     "bytes": 3624426,
+     "sha256": "b5b0dbb224d19c74c3cb0a5c19827ea8f21f6b1550e388d1682be3ae649b1dd8",
+     "timestamp": "2012-03-19T21:25:36.000Z"
+    },
+    "maps_src/h_end.xmp": {
+     "bytes": 2127300,
+     "sha256": "00eeb5ffdea906ba1ce11bb076954a2cafa9b613beb59d6d398160791b8c3a11",
+     "timestamp": "2012-03-19T21:24:04.000Z"
+    },
+    "maps_src/h_hub1.map": {
+     "bytes": 2374900,
+     "sha256": "6d7d55d4caca4a7b6293606e2f654c476e393143c961bb9a87aacfc70876123d",
+     "timestamp": "2012-03-15T01:59:22.000Z"
+    },
+    "maps_src/h_hub1.xmp": {
+     "bytes": 1396979,
+     "sha256": "35e2715012670ad9cac8b47d9b6b2907ec7841d06f9feaa7d11c27d505398418",
+     "timestamp": "2012-03-14T23:43:56.000Z"
+    },
+    "maps_src/h_hub2.map": {
+     "bytes": 2059420,
+     "sha256": "1038b48b731e338c020e072ad336b56d2fd3acb3b249ad17671fcfb701408f4b",
+     "timestamp": "2012-03-15T01:57:40.000Z"
+    },
+    "maps_src/h_hub2.xmp": {
+     "bytes": 1200900,
+     "sha256": "d9151f4b3d88fbd88fdff1f583b830dfc2ed947aa0d2b7ef656aae09a9f7523f",
+     "timestamp": "2012-02-04T17:39:02.000Z"
+    },
+    "maps_src/honey-mapsrc-license.txt": {
+     "bytes": 754,
+     "sha256": "feb0ebfcd93b854fe6366f59fc76cde21e36717ea31137e4c5049d80fb7d1696",
+     "timestamp": "2012-02-28T01:00:28.000Z"
+    },
+    "maps_src/honey.map": {
+     "bytes": 8455911,
+     "sha256": "b3f91a6d602b0325c2f6b80e8ccb9aa28b43bf46ac158a5e605e5f1937b1a137",
+     "timestamp": "2012-03-30T09:09:32.000Z"
+    },
+    "maps_src/honey.xmp": {
+     "bytes": 4877161,
+     "sha256": "a8e4a76b900cd48aa93a54e62d53f16ae6b702a24e3dfbb551d12c4b0ac2c261",
+     "timestamp": "2012-03-30T09:09:06.000Z"
+    },
+    "maps_src/saint.map": {
+     "bytes": 9318028,
+     "sha256": "914fe2e19cf7a305e89435f4ff2bc612dcb7e53bc038dc347f907f795252bce6",
+     "timestamp": "2012-03-30T09:24:02.000Z"
+    },
+    "maps_src/saint.xmp": {
+     "bytes": 5675756,
+     "sha256": "bab9d2acede2fba37249a9735cf928df40a18001c181972fa263a015693ff5c5",
+     "timestamp": "2012-03-30T09:08:16.000Z"
+    },
+    "maps_src/start.map": {
+     "bytes": 4529211,
+     "sha256": "f535148cf09bd2bf1986003adcca90c4682524cf22e7b842671fb37005cd506c",
+     "timestamp": "2012-03-29T19:24:28.000Z"
+    },
+    "maps_src/start.xmp": {
+     "bytes": 2671292,
+     "sha256": "0de1fa73c779427e40a43dbf48d0d4e29b1d9795061089a7f2adccd2d71d4b65",
+     "timestamp": "2012-03-29T19:23:50.000Z"
+    },
+    "src/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2012-03-30T18:43:06.000Z"
+    },
+    "src/ai.qc": {
+     "bytes": 17088,
+     "sha256": "2305d443ea79d56637b34bf3f9b7bf806da721815e685802e7ed208354dfbb0d",
+     "timestamp": "2012-03-20T21:56:42.000Z"
+    },
+    "src/boss.qc": {
+     "bytes": 12445,
+     "sha256": "9d52785c9ce962b9aaf38874b30c2cf6f92e148f8ded9bbfd7a04fbafae14fba",
+     "timestamp": "2012-02-12T19:11:30.000Z"
+    },
+    "src/buttons.qc": {
+     "bytes": 4458,
+     "sha256": "0eb69da8b204510d2125dfb317018a2e25e76354e3af40cd2d0ca785cd62d794",
+     "timestamp": "2012-02-05T02:27:52.000Z"
+    },
+    "src/client.qc": {
+     "bytes": 33935,
+     "sha256": "077a37445fbe4708159b1d3d125c5e5b2faddf923574d9f950b60908e6f3583c",
+     "timestamp": "2012-03-20T21:04:38.000Z"
+    },
+    "src/combat.qc": {
+     "bytes": 6325,
+     "sha256": "fff7fa911b960bc54e0941231e55cc780df76a80dc3993c1163de15404baad88",
+     "timestamp": "2012-03-20T21:02:46.000Z"
+    },
+    "src/defs.qc": {
+     "bytes": 19072,
+     "sha256": "8a8f34621f9e869359a418e6eea8839ed31497554f88fa404b9f697522ee1fef",
+     "timestamp": "2012-03-28T19:22:18.000Z"
+    },
+    "src/demon.qc": {
+     "bytes": 11084,
+     "sha256": "e8ce2877230fc8fca3ba220e79d1eba7fd65b9b01c94725ed776610177bfa2da",
+     "timestamp": "2012-03-20T21:06:14.000Z"
+    },
+    "src/dog.qc": {
+     "bytes": 10708,
+     "sha256": "8fc9ded9588ef78913de19971be3c79d2771335191a5dd699c5c7ea2d3ba4135",
+     "timestamp": "2012-03-20T21:09:08.000Z"
+    },
+    "src/doors.qc": {
+     "bytes": 18421,
+     "sha256": "881dd8765c3711b1d34c73464b2cf45b1d3858b46f3ec55c1ea8493c2a267ca6",
+     "timestamp": "2012-03-18T17:00:12.000Z"
+    },
+    "src/endcam.qc": {
+     "bytes": 5436,
+     "sha256": "580fd9f8571a7af58d92f10a76700dad2b5896d62804227ec29956c27d50f68d",
+     "timestamp": "2012-03-20T22:47:44.000Z"
+    },
+    "src/enforcer.qc": {
+     "bytes": 11890,
+     "sha256": "315c51e8a1d0934ebcd1901a9853bd3ca373c4c8387318bed818a81ee1e8118d",
+     "timestamp": "2012-03-20T21:09:36.000Z"
+    },
+    "src/fight.qc": {
+     "bytes": 8258,
+     "sha256": "e832ef236b2702026aa465a05b902e0f2debc070db6516f4e4c94074b4a83e48",
+     "timestamp": "2011-09-21T17:41:34.000Z"
+    },
+    "src/fish.qc": {
+     "bytes": 8857,
+     "sha256": "d19c8da356f56380e7c401eb02d86d54510de3ecc5cb0c30375c4dadcd8227ec",
+     "timestamp": "2012-03-20T21:10:10.000Z"
+    },
+    "src/hknight.qc": {
+     "bytes": 19560,
+     "sha256": "0ad0a6bf231ba3c1bac97354af2425624b6732a01836e6009bb285c6672a70b0",
+     "timestamp": "2012-03-20T21:33:08.000Z"
+    },
+    "src/honey_fog.qc": {
+     "bytes": 9878,
+     "sha256": "7c70a256e6c2d7b5345cd02b9b5c9eb6373ea1af5925e5cdd262bf711c248201",
+     "timestamp": "2012-02-28T23:10:30.000Z"
+    },
+    "src/honey_fog_debug.qc": {
+     "bytes": 2738,
+     "sha256": "0527f944d9118d353485367df11af97fd65bc737648c0019d806f099f6f3a54b",
+     "timestamp": "2012-03-28T18:37:46.000Z"
+    },
+    "src/honey_misc.qc": {
+     "bytes": 26391,
+     "sha256": "b4a3e3b70f039cc475b702e77f12d2ebc9e241a920ea26997678db3f21bbab03",
+     "timestamp": "2012-03-14T23:29:58.000Z"
+    },
+    "src/items.qc": {
+     "bytes": 29473,
+     "sha256": "6de5d0f21f94c76aca93f5c0791e2b140f7fc835fe705b5b7687d66b45b59c56",
+     "timestamp": "2012-03-18T17:11:20.000Z"
+    },
+    "src/knight.qc": {
+     "bytes": 10858,
+     "sha256": "660d393ac0298401e0724e6e761e89f2ee5f5cb5b7998f80a957fd3b0a50459e",
+     "timestamp": "2012-03-20T21:32:56.000Z"
+    },
+    "src/misc.qc": {
+     "bytes": 19397,
+     "sha256": "1fcd8d61d28a1f85615a4d0718f295eb67129cea153ed1936bf3da5c3c649229",
+     "timestamp": "2012-03-14T23:25:00.000Z"
+    },
+    "src/models.qc": {
+     "bytes": 8996,
+     "sha256": "d11fd0939293244962c5a40766e1dce246bde98eb0d42c87eb530a58d6eca64d",
+     "timestamp": "1996-09-26T12:15:40.000Z"
+    },
+    "src/monsters.qc": {
+     "bytes": 7666,
+     "sha256": "53990bedcd3f9bca09be3470a5bb90eae58e862965ac8f456ad28efce5208843",
+     "timestamp": "2012-03-26T20:09:14.000Z"
+    },
+    "src/newSubs.qc": {
+     "bytes": 20773,
+     "sha256": "fb29622535f9e885e15003b9071ac4099c34e08bdf4e4d4aa08eb7ee1b9643bc",
+     "timestamp": "2012-03-23T22:02:38.000Z"
+    },
+    "src/ogre.qc": {
+     "bytes": 19672,
+     "sha256": "24eb0885f9d387c20872541d74085f1ddb883861ab892a25aeba7e7efc4efd7d",
+     "timestamp": "2012-03-26T21:27:50.000Z"
+    },
+    "src/oldone.qc": {
+     "bytes": 9529,
+     "sha256": "0deecf87b5cef98a5365fa335a17ff81ce6ad2eb80f4335e677f9df0d6de49d9",
+     "timestamp": "2008-08-16T21:38:40.000Z"
+    },
+    "src/plats.qc": {
+     "bytes": 7761,
+     "sha256": "c45b40391be71bec65b7fc0a4181507e8ddc18333c2a0cf986080c212e51699d",
+     "timestamp": "2010-01-31T12:44:18.000Z"
+    },
+    "src/player.qc": {
+     "bytes": 17689,
+     "sha256": "1ccedc311078d47aac26d46a9bbe35ec63cfaf4972950cc73abd2cbb79966e0f",
+     "timestamp": "2012-03-09T22:37:28.000Z"
+    },
+    "src/progs.src": {
+     "bytes": 428,
+     "sha256": "1e1ef456621a6753b7d1f95bf5cb7deec39bcbd877b52d7b790536ab0f6a1f9e",
+     "timestamp": "2012-03-28T18:11:14.000Z"
+    },
+    "src/readme.txt": {
+     "bytes": 1121,
+     "sha256": "d2535b966181ae2c2b37ad7ae55e1a5a1f9d127d0395da93f42364594a59c3a3",
+     "timestamp": "2012-03-28T18:46:38.000Z"
+    },
+    "src/shalrath.qc": {
+     "bytes": 8979,
+     "sha256": "ba6a453da2105f6229d6decae36f5e81a0bb90cf8205e8a1132cd5b843e16e2a",
+     "timestamp": "2012-03-20T21:34:06.000Z"
+    },
+    "src/shambler.qc": {
+     "bytes": 13896,
+     "sha256": "10396bd8c51ef11bbc1755945eee23d8ecf03054408e7e312f4b59dfcbcd6d91",
+     "timestamp": "2012-03-20T21:35:46.000Z"
+    },
+    "src/sknight.qc": {
+     "bytes": 9164,
+     "sha256": "a993e477d22c71681661d3958548280cdf031d6862e3aa630a57867f964757b3",
+     "timestamp": "2012-03-20T21:40:12.000Z"
+    },
+    "src/sknight_debug.qc": {
+     "bytes": 5637,
+     "sha256": "cc768515520cea22ed8d33d9f8a8d889cc24e447703100717e2f61a32805777b",
+     "timestamp": "2011-07-30T16:33:06.000Z"
+    },
+    "src/sknight_tbl.qc": {
+     "bytes": 2373,
+     "sha256": "184e4703c3c8de1429fa78168b2534bedea0bc7a0bf14ace7b9541529b0d8eab",
+     "timestamp": "2011-07-30T16:42:56.000Z"
+    },
+    "src/soldier.qc": {
+     "bytes": 11020,
+     "sha256": "8fa0f2c378bfda1ab802b8c13c3fd995460af4d8b57b182951f946007b994bc8",
+     "timestamp": "2012-03-26T20:09:22.000Z"
+    },
+    "src/sprites.qc": {
+     "bytes": 450,
+     "sha256": "c00564e7ca0ab70d7891931ff333461ff90aa6052f46e8ebb02f59de6e03787d",
+     "timestamp": "1996-09-26T12:15:40.000Z"
+    },
+    "src/subs.qc": {
+     "bytes": 9070,
+     "sha256": "8a4b33e05d0dc2ba52923de72f1e0a8dbe6459214b91db6b325cbab35b57b79b",
+     "timestamp": "2012-03-23T22:02:16.000Z"
+    },
+    "src/tarbaby.qc": {
+     "bytes": 8777,
+     "sha256": "0ad48b14e7313beda1e66536888f0903ffad17a780ba58b02baba8204203ae52",
+     "timestamp": "2012-03-20T21:37:08.000Z"
+    },
+    "src/triggers.qc": {
+     "bytes": 17020,
+     "sha256": "1abf9ea1e76f20e85e1bff99385114d1831e3943db7682b6f44b6f282c9ad6b0",
+     "timestamp": "2012-03-15T18:22:12.000Z"
+    },
+    "src/weapons.qc": {
+     "bytes": 28884,
+     "sha256": "ca51c059db8fec044db62361a4b18775eaf52466c836d670d8994cc1ddd336d3",
+     "timestamp": "2012-03-28T18:37:48.000Z"
+    },
+    "src/wizard.qc": {
+     "bytes": 11912,
+     "sha256": "40217bcbfa50cca863579c1e4f6411ad1a7b370ab485285bf5446c029248ca29",
+     "timestamp": "2012-03-20T21:37:52.000Z"
+    },
+    "src/world.qc": {
+     "bytes": 11345,
+     "sha256": "eb71f4a8c9368bfc60e52211a5eddf5e49704d71bdf357e0b98ba6ebc8d829a2",
+     "timestamp": "2012-02-10T00:38:20.000Z"
+    },
+    "src/zombie.qc": {
+     "bytes": 21420,
+     "sha256": "be830c56f323ede59dde17208a448be9f5c42fa4cb0a90cca366d7f5b4201513",
+     "timestamp": "2012-03-20T21:39:00.000Z"
+    }
+   },
    "sha256": "4c8a3b06c43a0e931bdad87b66c132cb1649f7f07f427f760329f5bdba80825c",
    "timestamp": "2012-03-30T18:48:58.000Z"
   }

--- a/json/by-sha256/32/327e411d4ad66fcf98e47f1496f42a7b4b5daec828f98b4ef03b636b5cdc9b6e.json
+++ b/json/by-sha256/32/327e411d4ad66fcf98e47f1496f42a7b4b5daec828f98b4ef03b636b5cdc9b6e.json
@@ -7,6 +7,388 @@
  "files": {
   "PAK0.PAK": {
    "bytes": 7153435,
+   "files": {
+    "autoexec.cfg": {
+     "bytes": 9,
+     "sha256": "ff5f25161131956e64f47cbe6f08315b4f061ce06efbaa285ee5f136360a6878"
+    },
+    "default.cfg": {
+     "bytes": 1914,
+     "sha256": "8a749a09561a2b453458a1a5d98917a3cbc3d00b49ac94ede96a8e9f58a83824"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "124cd8ebef7bea3852a848fed3684964abfb93f0b868b9f80a68d4d29c2961dd"
+    },
+    "maps/start.bsp": {
+     "bytes": 2978548,
+     "sha256": "73e77546b677443861ec9ca2d49842ed0f9adaa82ca145ca0d16853458ac6a51"
+    },
+    "notice.txt": {
+     "bytes": 250,
+     "sha256": "0fa7cda24b9092dfd43e5756f16e75812969d91e94618f909ce5b9d70412c46a"
+    },
+    "progs.dat": {
+     "bytes": 307472,
+     "sha256": "2aebb1bec274ea9064cc48ecaa0978642bc34cf54231798d7e20e7093ea652b4"
+    },
+    "progs/cane_elf.mdl": {
+     "bytes": 21456,
+     "sha256": "2a6b8b156d0074e2eff57b9d45a67d49d148fde5f87551c3a9b619f639b6504d"
+    },
+    "progs/deer.mdl": {
+     "bytes": 133476,
+     "sha256": "0242e916026a965edfc8fdbfb1829276e15443ca0f23d26edf78f26f0e3387fb"
+    },
+    "progs/elfling.mdl": {
+     "bytes": 320344,
+     "sha256": "60dbe614b1080a72c932003400057cd7ee846b57bf0b4f8e0a09359e2fe8545f"
+    },
+    "progs/gib_s1.mdl": {
+     "bytes": 4760,
+     "sha256": "926fd324c9ec96ef0eb808d9118a927c79846284a13ad57204b3eec83b665aca"
+    },
+    "progs/h_deer.mdl": {
+     "bytes": 33484,
+     "sha256": "e4c49f5d78bde9fe32d7782eb6b922006001c80c36586e03adae0f6c142c373f"
+    },
+    "progs/h_elf.mdl": {
+     "bytes": 119264,
+     "sha256": "949e63205a5af9c430c3ba5c8ed8037b1025e71be0dbd869244dc4fab851ec44"
+    },
+    "progs/h_santa.mdl": {
+     "bytes": 50660,
+     "sha256": "99c5d21cf9acbceb0248543ee1dc9878afe70300e44add3af5436e964035842b"
+    },
+    "progs/h_sman.mdl": {
+     "bytes": 49863,
+     "sha256": "668718a996fac792c268cf36ce01771049afc1c6d36977310b6c01968f4cc1e0"
+    },
+    "progs/icicle.mdl": {
+     "bytes": 15780,
+     "sha256": "51279a492494adbd8afef4c089d034f49eb74c4484ca0f39a3cdeab26121e2fe"
+    },
+    "progs/minigib1.mdl": {
+     "bytes": 5716,
+     "sha256": "52ad77f6ebada2cea755ad58dc2e952df9f918489334b8739d9149b2f88f6a57"
+    },
+    "progs/minigib2.mdl": {
+     "bytes": 16228,
+     "sha256": "e5c8f2c4ceb8204462af787ad08f9b1b10c1468bb3f2ca5cbf1580f08d5cf9a9"
+    },
+    "progs/minigib3.mdl": {
+     "bytes": 22228,
+     "sha256": "fbe778b6c6d649024803cb3e180e333abfa8a418b929ee928e1a806723471d2c"
+    },
+    "progs/rd_gib1.mdl": {
+     "bytes": 24988,
+     "sha256": "b3f01267b96ce530e5aaf151e5e9f1097a4a385abd3958e7eae303900932f850"
+    },
+    "progs/rd_gib2.mdl": {
+     "bytes": 38823,
+     "sha256": "ebe0ddbe504e50aaa1630da3be272f32cc8a78421ec6444e10b3dd199571f4b6"
+    },
+    "progs/rdrocket.mdl": {
+     "bytes": 3476,
+     "sha256": "58ed6db094b34062e15fbedf583a5557fb2810ee33f2b2b44a11167d3a679c26"
+    },
+    "progs/santa.mdl": {
+     "bytes": 252352,
+     "sha256": "9be640a5952a9642e8490dec6a4575ab68c27341cd8491155df6862f7a497d08"
+    },
+    "progs/sm_gib1.mdl": {
+     "bytes": 12440,
+     "sha256": "bd3a6caeb4dc5078042f545e8e6b2bbd624f28a1ecafcb1c2ec46c61ffc7fa9e"
+    },
+    "progs/sm_gib2.mdl": {
+     "bytes": 20639,
+     "sha256": "33b2e459cd1194a5e33db83858e598952ad7d9bd06439d3cede986b8050e2816"
+    },
+    "progs/snowball.mdl": {
+     "bytes": 5066,
+     "sha256": "6bab7bbcf58113f3c38ce6d59493b2e535d53d34e8783d2cdc6d5b8b4d20e282"
+    },
+    "progs/snowman.mdl": {
+     "bytes": 59828,
+     "sha256": "6a93adbeefa846aec1cbe63826ea054f34e326277ce84a8c91cb83c50e1ea3d1"
+    },
+    "quake.rc": {
+     "bytes": 477,
+     "sha256": "c29db06570c7052332b31028d86b6134f47c19a0020bde8c7a3aa35ade9a5871"
+    },
+    "readme.txt": {
+     "bytes": 5552,
+     "sha256": "7ebdaaf3e5fddfbc62330c004b6a5e4e2a04dbccafab92339d96321a87e5c15c"
+    },
+    "sound/ambience/bloodpip.wav": {
+     "bytes": 33972,
+     "sha256": "80ec70bb0960cbb2a63cf13b33aa42b4a86c848282c6cd31078f7bff9989032a"
+    },
+    "sound/ambience/bloodpol.wav": {
+     "bytes": 57580,
+     "sha256": "e6dad38306eda4e07d95ff35d5b75ba524020be0a60a3ab393b2f2e1b489f598"
+    },
+    "sound/ambience/bloodstr.wav": {
+     "bytes": 29756,
+     "sha256": "163c7a559d3de271141bbc72ffcc1d8e1e508d4eef4e71cba24e9a04971561f5"
+    },
+    "sound/ambience/chrlerr.wav": {
+     "bytes": 87382,
+     "sha256": "74796ccbb97e463be0360fea4a47873f5fa59d6c94643c906fd8c5048907241a"
+    },
+    "sound/ambience/chrlnice.wav": {
+     "bytes": 49912,
+     "sha256": "9ea6dd40df1003e452305543ded398528d3e266175fd24be6f929e4240958a34"
+    },
+    "sound/ambience/chrltm.wav": {
+     "bytes": 144010,
+     "sha256": "6be753f83e721c5c8f58990fd14de7fc7bfa64d5b3b02bb4a56af785f44c1f47"
+    },
+    "sound/ambience/fsgib.wav": {
+     "bytes": 26180,
+     "sha256": "8cbc64887360e6b69f31f8d9dc408b5c449d5715f273eefa805714ee41f057e5"
+    },
+    "sound/ambience/heatsys.wav": {
+     "bytes": 24142,
+     "sha256": "23712cfdb3fa46882be12f9c01ad29ce9f19915dfef7a179daaff17ffcfa35b3"
+    },
+    "sound/ambience/liftmov.wav": {
+     "bytes": 17598,
+     "sha256": "6d023962354a1afab5d19d0ad54da89941afe9a9d91423ba8885bc6df2bdacea"
+    },
+    "sound/ambience/liftmus.wav": {
+     "bytes": 63382,
+     "sha256": "efa1b97c1b92c788a13ab5556aea80cffe7cdc6a075648c1918bef6cc62ea60d"
+    },
+    "sound/ambience/lightbuz.wav": {
+     "bytes": 33290,
+     "sha256": "8bc1be6571c0d2644026cc988a68b619053f60e7aefebb09e523132c985c6896"
+    },
+    "sound/ambience/outorder.wav": {
+     "bytes": 11430,
+     "sha256": "0e5d5191c831f02f8972c98a84afd4646471b032f91f2c5e0a807c709f319697"
+    },
+    "sound/ambience/outside.wav": {
+     "bytes": 96120,
+     "sha256": "7aaa40359140d8448a0f20ecee6ff203839e90b0f985a7857c23218e895f70cd"
+    },
+    "sound/ambience/radiotne.wav": {
+     "bytes": 37552,
+     "sha256": "bd023ff65bcae7231851365c8c22fc04d86a10adb586af723d302030846dccce"
+    },
+    "sound/ambience/strobo.wav": {
+     "bytes": 6524,
+     "sha256": "6d0d81c1834587ebb383b89061f05fb85b95a50b9538c4abb718507a39555088"
+    },
+    "sound/ambience/ventsys.wav": {
+     "bytes": 44976,
+     "sha256": "6c7440fcf28cc76815e3ede2ae37207f8792d37b4ea017446ea6ee9c0e10b894"
+    },
+    "sound/deer/attack1.wav": {
+     "bytes": 5582,
+     "sha256": "bcf78087eab53e8ed0bdde2f29088a89b321a79c3b104da380dd85bd5bdb6ec1"
+    },
+    "sound/deer/attack2.wav": {
+     "bytes": 6274,
+     "sha256": "2ba043cce4a2f22e7743812c0fa40e9f0888d5089362264c768352c347af5089"
+    },
+    "sound/deer/death.wav": {
+     "bytes": 9672,
+     "sha256": "68266e96ec1be80a55f48b76c2bedd6503273245153d96269947c7fc12ae96b3"
+    },
+    "sound/deer/hit.wav": {
+     "bytes": 5218,
+     "sha256": "72127151c2b05cc22a812fe9e38909c8bdcaae6a369e8756d2be67d392b91223"
+    },
+    "sound/deer/idle.wav": {
+     "bytes": 7890,
+     "sha256": "d3ef885d0b6163a3046dc9d514b07886c33809fbb6332e7db0514c648787a9bb"
+    },
+    "sound/deer/spot.wav": {
+     "bytes": 23796,
+     "sha256": "aafabb6fc46c1c72c34af1baea1c59a8ec04803c26faa4310072096481f31a4f"
+    },
+    "sound/doors/door1.wav": {
+     "bytes": 6686,
+     "sha256": "7fa7764bb3d6b41479a52eb95c8ec81f4916754f86101b0f71a56ea913c8bf56"
+    },
+    "sound/doors/door2.wav": {
+     "bytes": 9868,
+     "sha256": "92fadc2fc4b1f40dab22db8cb4b433827955738ee5828eecdc67c00489dd43e3"
+    },
+    "sound/doors/door3.wav": {
+     "bytes": 9566,
+     "sha256": "c3a4c3621b5b2d7e177e6a1dbd36c822c6f688c63a8ed2bd2c81c4bb186c4015"
+    },
+    "sound/doors/door4.wav": {
+     "bytes": 12810,
+     "sha256": "d9c8c705721114a24dce00ee00885ddad7dadcee55f6255221a93bf20eae15e2"
+    },
+    "sound/doors/doorclos.wav": {
+     "bytes": 9350,
+     "sha256": "99af295644fb284129dc7699181e27d1d81f153c8551fffd43b33d7356db4548"
+    },
+    "sound/elf/cane1.wav": {
+     "bytes": 3454,
+     "sha256": "f89236c9bdcea748a01c946668f3f8233d199152860bc583cb08bd26687cb01c"
+    },
+    "sound/elf/cane2.wav": {
+     "bytes": 4794,
+     "sha256": "e40921d4a9f1068d43f46483f8c21c9e0d44c7e030eabb9ecf59d4dfd908e76d"
+    },
+    "sound/elf/death1.wav": {
+     "bytes": 14284,
+     "sha256": "d1a7063d4ed39cdb59864a2a6fe6109f844caa9ada54ed4456de0bcd056f0034"
+    },
+    "sound/elf/death2.wav": {
+     "bytes": 10888,
+     "sha256": "4e0344a1bd3fa3d3c4d9e9647203cac0c449d5a5d8e7b1c8319f8402a4b7571c"
+    },
+    "sound/elf/idle.wav": {
+     "bytes": 29166,
+     "sha256": "46cc3b3cb874cae26dc22a883bf7084d489ba5b739400aaae2e9aedce3fca65c"
+    },
+    "sound/elf/jump.wav": {
+     "bytes": 10182,
+     "sha256": "2c20efb8846ec2e5924e91813ead928c644d68aeefe768986347f7bd660ac73f"
+    },
+    "sound/elf/pain.wav": {
+     "bytes": 6204,
+     "sha256": "a82ad7bcb0540ae8976ba3b6927987f0e3df15784da7fb8bd9a87d4ea8ade045"
+    },
+    "sound/elf/prepare.wav": {
+     "bytes": 7924,
+     "sha256": "0fc5690e5fde53d18af0683dbd4580be97e9d975dce0e3785d2e0c859b58e7f8"
+    },
+    "sound/elf/skip1.wav": {
+     "bytes": 5506,
+     "sha256": "73ac4f7050121ac461aa28c15095adc51e9d9c698134dd659246bbecadeafe40"
+    },
+    "sound/elf/skip2.wav": {
+     "bytes": 6182,
+     "sha256": "55f5acd73b81f9aeb91f31c355c53e3b25e3bd1cb6b8843d92c46344cf3aee4e"
+    },
+    "sound/elf/skip3.wav": {
+     "bytes": 8808,
+     "sha256": "a31361690637f4ef0f69eb640c3e7c81b3ed1a82a4a574435456a6354d86c008"
+    },
+    "sound/elf/spot1.wav": {
+     "bytes": 10798,
+     "sha256": "c7e2262fc796ae60d4ad31d52ec561a3424ccf2d29f4139641f05da787717dd7"
+    },
+    "sound/elf/spot2.wav": {
+     "bytes": 15654,
+     "sha256": "68ffc77403421df2ebddd58ed17bd45dcf149bc99d91f9eba592b59613ed8733"
+    },
+    "sound/misc/h2ohit1.wav": {
+     "bytes": 12970,
+     "sha256": "93c25c1aff83ac99ea4a9b100291577580cae0f43792321e072dec55ed266869"
+    },
+    "sound/plats/ding.wav": {
+     "bytes": 14680,
+     "sha256": "0af04003304edc753378f0be49c55188879b53d2fff455644baf66c94ebacf48"
+    },
+    "sound/plats/liftmove.wav": {
+     "bytes": 17598,
+     "sha256": "d505ee70c8fb65ad230c47fb2deff2557b6696b2e871f2dbc753f15ad2d1d90a"
+    },
+    "sound/plats/lifttune.wav": {
+     "bytes": 63382,
+     "sha256": "dfe8667182aaa8e2e041386b43ae3a4682226bb2955e2cefe2fdad8f05ea070a"
+    },
+    "sound/santa/death.wav": {
+     "bytes": 51516,
+     "sha256": "a05a1002fd7b8607e04aae3f2488011630fef8d2a6c14186942e9c0a44d0ab8a"
+    },
+    "sound/santa/fire.wav": {
+     "bytes": 11114,
+     "sha256": "0cb418185bc40d107f07ab42880ea9643ad09276c527ea45a27dc36a0b704ec1"
+    },
+    "sound/santa/hohoho.wav": {
+     "bytes": 31012,
+     "sha256": "7b757fcbe5b0e92cd9c3ec348805686888c50652f7d3ca560746934d371df9a3"
+    },
+    "sound/santa/laugh1.wav": {
+     "bytes": 29073,
+     "sha256": "5394be02d87bbcbaa879787933890e5dcaddbd18f630bc177893f7e9c2e3858b"
+    },
+    "sound/santa/laugh2.wav": {
+     "bytes": 58784,
+     "sha256": "00e945347d165e1d501720e04773c523b7250becb2fbf7f7feccbc332774fd3d"
+    },
+    "sound/santa/laugh3.wav": {
+     "bytes": 40256,
+     "sha256": "4dd710eee601ab81c4beb5413d95244dee58b886b8265ab9cec35df06b560591"
+    },
+    "sound/santa/pain1.wav": {
+     "bytes": 6825,
+     "sha256": "79eed9346e0954fd53a6fdb9aa9708b8c29e8c5c256e9fd7c06f449e9cb6c00d"
+    },
+    "sound/santa/pain2.wav": {
+     "bytes": 9259,
+     "sha256": "f750328d74f545a658b0b190399595687c3d9b8766b2652ad6c2a34add3cc420"
+    },
+    "sound/santa/saved.wav": {
+     "bytes": 70870,
+     "sha256": "4aa0e89b75d25c9dfc640d7aae62b8ad315e423617b081db412bbeedd7f109fe"
+    },
+    "sound/santa/smack.wav": {
+     "bytes": 11316,
+     "sha256": "8ee241491f7c3b802613afb21d9f5eb9993ff1617cf9376a65af6575c164a7c8"
+    },
+    "sound/santa/spot.wav": {
+     "bytes": 50136,
+     "sha256": "eab26c9c8b2fc231d832cbbb4918c38fa155b0b2c942477033cfc7681dc5315b"
+    },
+    "sound/snowman/claw.wav": {
+     "bytes": 8292,
+     "sha256": "7857f3526fb39e722a09ebe569f2b76facab765d82f97c0caa7da2ff9b750e9e"
+    },
+    "sound/snowman/death1.wav": {
+     "bytes": 11267,
+     "sha256": "0a09776ed8e45bbfe403f1cdb50302361f5596d9027c476409d6acf5402e763e"
+    },
+    "sound/snowman/death2.wav": {
+     "bytes": 13613,
+     "sha256": "e5e3a9619a153f0c6259abdb0d45f4eb4a547f736e37951556d29c6b715ec8f6"
+    },
+    "sound/snowman/fire.wav": {
+     "bytes": 6572,
+     "sha256": "3d54870c0f643b1e7ee5307641bb3fc4a94efdaffc2e4ecd196556b930167ef2"
+    },
+    "sound/snowman/icehit.wav": {
+     "bytes": 3090,
+     "sha256": "e03f61550bafc53ab47acdc23bcd481c35e75e6eccdad5e61e6dd7b372ba07c0"
+    },
+    "sound/snowman/icemiss.wav": {
+     "bytes": 3074,
+     "sha256": "f8b86f83d9adaaee1c84e1ac2acbcf652204842f2bf6f351ec1443a998574058"
+    },
+    "sound/snowman/pain1.wav": {
+     "bytes": 7685,
+     "sha256": "7f829300a30cb6cb4d17f8c8327bd62ae5b5dacc892d28a956d6ecd2acf5f1c2"
+    },
+    "sound/snowman/pain2.wav": {
+     "bytes": 7661,
+     "sha256": "3747d77583aa4edb3509e89ea651ea41a8e8a92cd96c34d4e00257e7371fb0e6"
+    },
+    "sound/snowman/sight1.wav": {
+     "bytes": 10042,
+     "sha256": "ce1cddbb6e85fad23231ac1fc4c04c19ec7276acb2aa86e023c117db4b8edd68"
+    },
+    "sound/snowman/sight2.wav": {
+     "bytes": 15418,
+     "sha256": "5d4e994c30a7c3f2e1f1a5cde9a56115bcb32c350e4a0ad8e339a1a46ed19707"
+    },
+    "xmas1.dem": {
+     "bytes": 596091,
+     "sha256": "e0760f58048266bf6450221d0453e05b9a62af51e130d4b85433104591e506c0"
+    },
+    "xmas2.dem": {
+     "bytes": 412284,
+     "sha256": "fdec4994f234d735f885e0560edd5a4ec308b8bc4a280dd93e981ec07a166b60"
+    }
+   },
    "sha256": "0d9bc921e9c09ecf1894cda78da0455b96df28415ccd80b42bfcd0efada52db0",
    "timestamp": "1997-12-22T19:37:06.000Z"
   },

--- a/json/by-sha256/32/32b9c8bea95cc768be72f6d6810336b5a26454c4083d445c44f6c266752ffc7f.json
+++ b/json/by-sha256/32/32b9c8bea95cc768be72f6d6810336b5a26454c4083d445c44f6c266752ffc7f.json
@@ -320,16 +320,9998 @@
   },
   "pak0.pak": {
    "bytes": 243860159,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 94990,
+     "sha256": "1fddba1dadd3adef5e0f13d716e514c131455c51b26c2291f71dea0eada7b97e"
+    },
+    "effectinfo.txt": {
+     "bytes": 157535,
+     "sha256": "8dbc7cf30b0bef166f0ce58a59c0f3ce1dcadd9a13867f8430541793fd723cf8"
+    },
+    "effectvanilla.txt": {
+     "bytes": 4612,
+     "sha256": "efd47c12bf71b377f3e750f46d5e242b3337ece446ba9a44cc0750a9bbf9c758"
+    },
+    "gfx/ad_blank.lmp": {
+     "bytes": 584,
+     "sha256": "37b5a1e7d0b3882eb7504e3626f8040a19a6d403e0e761dccd65db935401144f"
+    },
+    "gfx/ad_ibar0a.lmp": {
+     "bytes": 2568,
+     "sha256": "7a66fbbaa742e59d3fdd939ce35befa0f633492482912f4fa91f16d0788276e6"
+    },
+    "gfx/ad_ibar0b.lmp": {
+     "bytes": 5128,
+     "sha256": "5a955a32f0227e4d3e90e908e650c7dc53138b5db2d5bcb3eb4a14fe5c568760"
+    },
+    "gfx/ad_ibar1a.lmp": {
+     "bytes": 4616,
+     "sha256": "eb1c6337becc5c245b873b3d9a6ba5e9c458147f48826a4580ea0ffdf57e9759"
+    },
+    "gfx/ad_ibar1b.lmp": {
+     "bytes": 3080,
+     "sha256": "34e3eec992a3f567d4ac83c98d5fc53ca0a90c02764d45a40eea08d2f94c733b"
+    },
+    "gfx/ad_ibar2a.lmp": {
+     "bytes": 4616,
+     "sha256": "eec2d035f2857fc03083ccf0384ac6446f71b1aa45ed0e2409b8d4ba42c135f6"
+    },
+    "gfx/ad_ibar2b.lmp": {
+     "bytes": 3080,
+     "sha256": "17c35d1d02833d1fe900b1c2beaf77ffe1948a3f17ae790e9f0da1c1057b460c"
+    },
+    "gfx/ad_ibar4a.lmp": {
+     "bytes": 3080,
+     "sha256": "2507c6ce0a53ed62ce73b1bb0ee7e76e9c245757dee54415aeef78767bace887"
+    },
+    "gfx/ad_ibar4b.lmp": {
+     "bytes": 3080,
+     "sha256": "d977ecb360eff9b19827e956d32687234bed64f830adc5e506334a597daa7eaa"
+    },
+    "gfx/ad_ibar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "9d0d2c1eb7e665d0a28130bed09fb8bd698a6a1b246842fa353e3b0e1f5b445d"
+    },
+    "gfx/ad_ibar5b.lmp": {
+     "bytes": 4616,
+     "sha256": "26902c5879207315a7b732e8799f95bdcd45801a8086a902371808a594fa5515"
+    },
+    "gfx/ad_ibar6a.lmp": {
+     "bytes": 7688,
+     "sha256": "cfcce1c48cda88ccd405b1398576476bae52b3cdf7154a0b902a47655dd282cd"
+    },
+    "gfx/ad_ibar6b.lmp": {
+     "bytes": 7688,
+     "sha256": "49487400a56db767d37656f8ccb9e1660f470d8f989619a86bec5c296dcb77f9"
+    },
+    "gfx/ad_ibar7a.lmp": {
+     "bytes": 6152,
+     "sha256": "0d4ababef9a115ca7f6739a01d288d237e22a859ee16c5682d97dcabc4d7aa0b"
+    },
+    "gfx/ad_ibar7b.lmp": {
+     "bytes": 5832,
+     "sha256": "f9292e8d1fff09bde28baf932f11617e27247d4e9af191b89c30811e92110bca"
+    },
+    "gfx/ad_ibar7c.lmp": {
+     "bytes": 4104,
+     "sha256": "0e77dc6602c4945d5d4ec2a12f8003173430945bf7891d979c3c80b0c9212b40"
+    },
+    "gfx/ad_ibar_cell1.lmp": {
+     "bytes": 392,
+     "sha256": "5a4409731e4302bca5245f385a1cab9b91e0a2677d52336bbe3650fdcf070b05"
+    },
+    "gfx/ad_ibar_cell2.lmp": {
+     "bytes": 72,
+     "sha256": "6a519b1e8eed1d7a5365231162fcf1beaf31a6fd1c39b07de09bb0e66dc38303"
+    },
+    "gfx/ad_ibar_nail1.lmp": {
+     "bytes": 392,
+     "sha256": "850189c70ac92f3e8ee79ed9ff6e31ee73d33b5616964461373b37e3a29e60b6"
+    },
+    "gfx/ad_ibar_nail2.lmp": {
+     "bytes": 72,
+     "sha256": "b36d5196c807c6325816db9efad9a16fd7e38433f277b0ad9e6d3551f95c0ceb"
+    },
+    "gfx/ad_ibar_rock1.lmp": {
+     "bytes": 392,
+     "sha256": "f74ce0037116022557ec3a50d368442e73cb48492990a07e93503ad9aeeaa225"
+    },
+    "gfx/ad_ibar_rock2.lmp": {
+     "bytes": 72,
+     "sha256": "081911a352b3d75a4be7812082eee782c41127e70bc4a06585b163d385230a65"
+    },
+    "gfx/ad_ibar_shell1.lmp": {
+     "bytes": 392,
+     "sha256": "733750fbc8235b236f7a2a4246d6112c0a09ce2f75529e359382e25dab92ee10"
+    },
+    "gfx/ad_ibar_shell2.lmp": {
+     "bytes": 72,
+     "sha256": "22fc2a46e85e76836fa38db9868820322833b45e0473407d69378dc09b43e9a5"
+    },
+    "gfx/ad_sbar0.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar1.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar4a.lmp": {
+     "bytes": 4616,
+     "sha256": "5ecbd1e480e4c04e2efe956dcd49e609f0c5a2038f03759b9af848b3cf7dd613"
+    },
+    "gfx/ad_sbar4b.lmp": {
+     "bytes": 4616,
+     "sha256": "8fdfe5e6ffba2c209386580adc196acce9d5601fb529f651267e7186610cc392"
+    },
+    "gfx/ad_sbar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "40c7f9e7ba975d500d3861d0c5a7e592da1ce09fdc31583488fd4c78d823e20e"
+    },
+    "gfx/ad_sbar5b.lmp": {
+     "bytes": 2312,
+     "sha256": "86ff0d9678a52e5428089afe0bb9cdddc9f7688798cee45a396e4d13bf00b60d"
+    },
+    "gfx/ad_sbar6.lmp": {
+     "bytes": 9992,
+     "sha256": "5b47dbc1ae645c429627f563355c43b1fb9145d195d02606d0a7a49791034a28"
+    },
+    "gfx/ad_sbar7a.lmp": {
+     "bytes": 3464,
+     "sha256": "8773683e2edb20dfdea61775d6f955a766a15b7b733ae07212dec922d853f6ba"
+    },
+    "gfx/ad_sbar7b.lmp": {
+     "bytes": 3528,
+     "sha256": "1103f097b9896700ef5a722df927cbe71c76531a09eda9e55e5702d3b4d3b370"
+    },
+    "gfx/ad_scorebar0.lmp": {
+     "bytes": 7688,
+     "sha256": "7c479c4969b9f437c57d710edbdd6b2ce1936aa95adb559c9dd3048680868cdb"
+    },
+    "gfx/adf_1.lmp": {
+     "bytes": 584,
+     "sha256": "5b1b35dc96ad9c2f62602caab6be13d8698fe6cc14865293d11c6b9eee64dd51"
+    },
+    "gfx/adf_2.lmp": {
+     "bytes": 584,
+     "sha256": "8cbc05801d49423bd5f14bd459e8ed5cff7841e7f2d5e44d0f4dfe0f0f7ee851"
+    },
+    "gfx/adf_3.lmp": {
+     "bytes": 584,
+     "sha256": "f0155a41ad9290c8df9fabe0faae6dde4d04772dd2a425653766ec36da76140f"
+    },
+    "gfx/adf_4.lmp": {
+     "bytes": 584,
+     "sha256": "d74c9370ce323ffdc9c3dd124dcbbf9c15fc94e58e20d15789975dd8701a74da"
+    },
+    "gfx/adf_5.lmp": {
+     "bytes": 584,
+     "sha256": "f97a78ede874ff45176e5bb85abdbed93e22dab28bc0965065927c7b215ea36f"
+    },
+    "gfx/adf_evil.lmp": {
+     "bytes": 584,
+     "sha256": "42445b083abae6e9f4ff009efd7a38d2ddd664ac5e47f97ad30c88a603c64c35"
+    },
+    "gfx/adf_evilinv.lmp": {
+     "bytes": 584,
+     "sha256": "ff0d8b9203d7cfae6d075ef5bfad60cdcf66b1e24bb6fd02be0cada1b7f1c82f"
+    },
+    "gfx/adf_evilpent.lmp": {
+     "bytes": 584,
+     "sha256": "0b0029bc964ed68f1b46ccf0b4bd5e527e33e76c0904a1d06e623c47ca589e56"
+    },
+    "gfx/adf_evilquad.lmp": {
+     "bytes": 584,
+     "sha256": "a511796cca84df8149ea6d3d280880e425fdd486315159462168d32f06a17822"
+    },
+    "gfx/adf_inv2.lmp": {
+     "bytes": 584,
+     "sha256": "a6caf84d4e2c125e80aefb51aaa1af707ccf689e641141dd3736f101a66c8fa0"
+    },
+    "gfx/adf_invis.lmp": {
+     "bytes": 584,
+     "sha256": "70117297f381fd1778e5d26e5b832af86c6013ca9a55632c24c057e0aaa1e48f"
+    },
+    "gfx/adf_invul1.lmp": {
+     "bytes": 584,
+     "sha256": "453b67ccc01b32101e1051a9407b84b5c93416ae30c3b3200e25b96868c3f6e5"
+    },
+    "gfx/adf_invul2.lmp": {
+     "bytes": 584,
+     "sha256": "c70f600538aa1d1cc121ea76602e564d0af5ce5ea67a2c1ba01ac5fe44439bd4"
+    },
+    "gfx/adf_p1.lmp": {
+     "bytes": 584,
+     "sha256": "f6da35fd9699239c060f034738615ecead6111294a419a82e503bdbdd9ed46b1"
+    },
+    "gfx/adf_p2.lmp": {
+     "bytes": 584,
+     "sha256": "431539dd9656e09c6d4007c86bad37c30447e596575d803619b14371329f9acb"
+    },
+    "gfx/adf_p3.lmp": {
+     "bytes": 584,
+     "sha256": "b832a2d2143805f8701eec7eec465d67fa692e2e87714e87fa3ac3a2c2682659"
+    },
+    "gfx/adf_p4.lmp": {
+     "bytes": 584,
+     "sha256": "40f6d70d3ebf248c1c38e90b95cec42516b3a61fd17bd866df964af8e657487f"
+    },
+    "gfx/adf_p5.lmp": {
+     "bytes": 584,
+     "sha256": "d7d4768f7324d1eca2b8cb95fd250d8c6065dcfc5c392c6f2bc6adc8c2a7579a"
+    },
+    "gfx/adf_quad.lmp": {
+     "bytes": 584,
+     "sha256": "da9a83f464049832cd049205a22d832a228b00cbd0d1e7e24d347d5ed34c4ffb"
+    },
+    "gfx/adib_atank.lmp": {
+     "bytes": 264,
+     "sha256": "8d963c818c0554d73d14b251eeed0321cf854777f29eddf5a82ee3fb3fde8035"
+    },
+    "gfx/adib_axe1.lmp": {
+     "bytes": 264,
+     "sha256": "90b6817aa64570e9bfc36a13e6dd1930e81468f931ceac9f2ae3790f99f2dca2"
+    },
+    "gfx/adib_axe2.lmp": {
+     "bytes": 264,
+     "sha256": "2b0821038185e41c711e399dcfff37fd54aa8f7473ba81754c379fae558a5a1d"
+    },
+    "gfx/adib_bbelt.lmp": {
+     "bytes": 264,
+     "sha256": "8b50ea739ca8ab52baefe65f90ea5943fcc4f05b63b214a36b3ae6fa4feb55a8"
+    },
+    "gfx/adib_ckey1.lmp": {
+     "bytes": 136,
+     "sha256": "8525e145fdc72947ac6d4599ae0304b84793475d44f0113c925905d715c2da8e"
+    },
+    "gfx/adib_ckey10.lmp": {
+     "bytes": 136,
+     "sha256": "a2e14b68c10109e48e86bd095775beb68f03640dfdb12d1c28b6d32abd1fa329"
+    },
+    "gfx/adib_ckey11.lmp": {
+     "bytes": 136,
+     "sha256": "2b9191d85075d6a6c06d8b295c48546ecc0bd1c91a860308f6f953dcf324604c"
+    },
+    "gfx/adib_ckey12.lmp": {
+     "bytes": 136,
+     "sha256": "9b04f101468d96f4c39d97da0be44f7152179e4a8d6a05762ca693c9f84db317"
+    },
+    "gfx/adib_ckey13.lmp": {
+     "bytes": 136,
+     "sha256": "35fa377dbf162d691de012a61458b5ec29c28b776cd3ee0e0f9ab0ad57b67c8f"
+    },
+    "gfx/adib_ckey14.lmp": {
+     "bytes": 136,
+     "sha256": "ea6b831467c97fb0ba18d97a549c54304b133830e1567ae300e83514bdbb2919"
+    },
+    "gfx/adib_ckey2.lmp": {
+     "bytes": 136,
+     "sha256": "5c80cec0c7808ed141fff4f6863eccfa71b06a7405e871c75912d5d065b4ff21"
+    },
+    "gfx/adib_ckey3.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adib_ckey4.lmp": {
+     "bytes": 136,
+     "sha256": "51ea09fa8db26de3ce6ea6c1a5abecf4c31c3877ab6c508811ea9b271f40f1fc"
+    },
+    "gfx/adib_ckey5.lmp": {
+     "bytes": 136,
+     "sha256": "e03ed662e981530264f6dcf6f6dda91fd8406c0941d0f7c4370a89e0c4f467bc"
+    },
+    "gfx/adib_ckey6.lmp": {
+     "bytes": 136,
+     "sha256": "6f4f61addc77e3492c08cd382291eaf3f8c28a7499137591dcd2c6706bb1ec57"
+    },
+    "gfx/adib_ckey7.lmp": {
+     "bytes": 136,
+     "sha256": "38c3473948f4769e4309bdbb390afd0663fc093f1f76c9fbf10d818c6f89c72b"
+    },
+    "gfx/adib_ckey8.lmp": {
+     "bytes": 136,
+     "sha256": "d0c43a81abfb623b7c3392a07b484b6bf9137fede67d78dc67864848ecbc1c12"
+    },
+    "gfx/adib_ckey9.lmp": {
+     "bytes": 136,
+     "sha256": "042cdb7aef3e06a5679158b4f33fc66ca2d97dd6cf9e7e2657b1e85e444ed006"
+    },
+    "gfx/adib_invis.lmp": {
+     "bytes": 264,
+     "sha256": "f4f1be9a2ef88b75fd9971d72796a35f7de1ed04fc2cfc3a4c35225976f21eca"
+    },
+    "gfx/adib_invuln.lmp": {
+     "bytes": 264,
+     "sha256": "87b8312e4d7fc20d6ae9df6d1f8cb616392f3a2adaf7208dd2372eefc19888a3"
+    },
+    "gfx/adib_jboots.lmp": {
+     "bytes": 264,
+     "sha256": "206ad9d67636b46418e6afa6b6e75a12df76bd3ad84b0178e86b8d140b9c3afc"
+    },
+    "gfx/adib_lshield.lmp": {
+     "bytes": 264,
+     "sha256": "79a78f4402a301d381bef260b895ba56757b779ae89b7ae5a49f8146f2a7a54a"
+    },
+    "gfx/adib_nailp.lmp": {
+     "bytes": 264,
+     "sha256": "fe59667c80612fd2e7f5d95dd0a208f3909d93eeaaab7e4580405fe153469fde"
+    },
+    "gfx/adib_quad.lmp": {
+     "bytes": 264,
+     "sha256": "915832c8c822daf8cfa1c5d88548f24da7d182be6746b265e7ae6e1d735082cd"
+    },
+    "gfx/adib_sharp.lmp": {
+     "bytes": 264,
+     "sha256": "18987634aa43dced4e06e1d5a9a3f9b1f51c7738f59fae64168bd94ab9cd6198"
+    },
+    "gfx/adib_sigil1.lmp": {
+     "bytes": 136,
+     "sha256": "34b11b26dcdf5b91f3e6e08bbe6edb83f62ba054e9eef28459cef09b742e1456"
+    },
+    "gfx/adib_sigil10.lmp": {
+     "bytes": 136,
+     "sha256": "af31a42ef81449aa656327dfe00fc1e1d744f90212ac228bd05a6d79f5048683"
+    },
+    "gfx/adib_sigil11.lmp": {
+     "bytes": 136,
+     "sha256": "9fb90ba79d5c34e2b0afdbcec8bc528fd7d3d8f2645191d95a67a65e242bd3c6"
+    },
+    "gfx/adib_sigil12.lmp": {
+     "bytes": 136,
+     "sha256": "d7c9c3c7c1167ea0791b2790d678d6bd25144adcba79d6f7c5d93302fc28119d"
+    },
+    "gfx/adib_sigil13.lmp": {
+     "bytes": 136,
+     "sha256": "0003389cd694c55fa36f1d18d38261d279c5c7ef23dd5d41c3852ad8c95e5a49"
+    },
+    "gfx/adib_sigil14.lmp": {
+     "bytes": 136,
+     "sha256": "8ac47a2e1d45d94fb1f222811320c5f07e39e65698b7436515afa29de6e1204e"
+    },
+    "gfx/adib_sigil15.lmp": {
+     "bytes": 136,
+     "sha256": "153627403fd3e3856aa34e8740fdebb5ddb26e201cd590dd76cbfc12c36e49c6"
+    },
+    "gfx/adib_sigil16.lmp": {
+     "bytes": 136,
+     "sha256": "fa95a1a372ce30516252fff8dbcda8f8f55e3cc558b4a1e7015b79838ff0cda1"
+    },
+    "gfx/adib_sigil2.lmp": {
+     "bytes": 136,
+     "sha256": "0a0c22f027e980014a246daa629b6f84f425ccfd828f75a93ef777d9616c9191"
+    },
+    "gfx/adib_sigil3.lmp": {
+     "bytes": 136,
+     "sha256": "9e5daafbe4cc032824f732ebdac3897d804df43efaff9901c315ae661af8cd31"
+    },
+    "gfx/adib_sigil4.lmp": {
+     "bytes": 136,
+     "sha256": "fd1d3791d53ab40881a2d86a0bc67b3b532ef10b201a166a3937b105c63e3c9b"
+    },
+    "gfx/adib_sigil5.lmp": {
+     "bytes": 136,
+     "sha256": "947d5088b18a12d06a93fe66a0500e5b6ae93e04cebc748858139d569693d42d"
+    },
+    "gfx/adib_sigil6.lmp": {
+     "bytes": 136,
+     "sha256": "5a2356a7479f887b20f10e03ee2f42478bdfa75febe2d802b3dbfcd25b39d744"
+    },
+    "gfx/adib_sigil7.lmp": {
+     "bytes": 136,
+     "sha256": "507011b2a191e096fadcd678590636e4033de2ffcf35cef31785539bf3f9fb4f"
+    },
+    "gfx/adib_sigil8.lmp": {
+     "bytes": 136,
+     "sha256": "2a49a4653b2ed11353c6aaca950420c38c8e7b2aa8cc82ecd746a4e73fb7aa00"
+    },
+    "gfx/adib_sigil9.lmp": {
+     "bytes": 136,
+     "sha256": "df168192d5c065c7247cff03b10da51eba431bdc4f76d2c913646bb23084d639"
+    },
+    "gfx/adib_suit.lmp": {
+     "bytes": 264,
+     "sha256": "030bf62f7f45667310f1a74bd88881e2aa8d6c7ba5355bda4bc7c87d64a3d082"
+    },
+    "gfx/adn_0.lmp": {
+     "bytes": 584,
+     "sha256": "0895fe0acba04a4e17ef64fe62c56765c4fef5933c4af09dfcb242e984e8d163"
+    },
+    "gfx/adn_1.lmp": {
+     "bytes": 584,
+     "sha256": "fc0391c514808f9cb54e0bb0bbd63edccb0bea66a7620b81d04497edd099f5b1"
+    },
+    "gfx/adn_2.lmp": {
+     "bytes": 584,
+     "sha256": "d70ca75a162f7203067f314eee6460dc9180383e5bd1a19c69a984d8f4c699ae"
+    },
+    "gfx/adn_3.lmp": {
+     "bytes": 584,
+     "sha256": "40fbf34b86a4e5d264fac3c875ad74a52b62f5868d01a7580107a52998cbe4ac"
+    },
+    "gfx/adn_4.lmp": {
+     "bytes": 584,
+     "sha256": "5c9f781b8fb46cff0bb69db9817936be10cc4e34d677a5a49f117baa1d414aef"
+    },
+    "gfx/adn_5.lmp": {
+     "bytes": 584,
+     "sha256": "f2b1a90d1f4e1e3c6eb04dd1d87f084b2bc932b76b6eabcc5a4ee12db939971e"
+    },
+    "gfx/adn_6.lmp": {
+     "bytes": 584,
+     "sha256": "ec90a75650252feb45f325815498caf518058d141c7660e594397e0e05e35cfc"
+    },
+    "gfx/adn_7.lmp": {
+     "bytes": 584,
+     "sha256": "c292389fee1e91c2c4178099a8c9b2ad193f74346adec126ae10a4383f96c6de"
+    },
+    "gfx/adn_8.lmp": {
+     "bytes": 584,
+     "sha256": "4df870d66977eddbb7c4f87ffe4b94a032f2f13ad8fa38a98fde607d7aa7b06d"
+    },
+    "gfx/adn_9.lmp": {
+     "bytes": 584,
+     "sha256": "fd7f393a0fea9c0bc9fec90492a8f074a75275fde2ce211379b098176729622d"
+    },
+    "gfx/adn_a0.lmp": {
+     "bytes": 584,
+     "sha256": "7221532ee9af2c3a2fa3d19e4ccae78458d7a1f3025627e6da45dcb4aefd6820"
+    },
+    "gfx/adn_a1.lmp": {
+     "bytes": 584,
+     "sha256": "8f594ea65757fdaa62105b5eb68d4519b96b93e12dba110a723c4bf99470d408"
+    },
+    "gfx/adn_a2.lmp": {
+     "bytes": 584,
+     "sha256": "738cd71a2344da4b1733b639e6cdef1fb412104c388d2edee0b4539655ed9fec"
+    },
+    "gfx/adn_a3.lmp": {
+     "bytes": 584,
+     "sha256": "00c7040d33a445656f33c373077564116a764142f4625b5df7fae6516817f893"
+    },
+    "gfx/adn_a4.lmp": {
+     "bytes": 584,
+     "sha256": "7fbde831e189692c1c5d048873e7098a7d017ff7e22fc57a724a2c2fcbcc8db4"
+    },
+    "gfx/adn_a5.lmp": {
+     "bytes": 584,
+     "sha256": "ecb1a8036b03abc3c95a145081762ebf8b04516bc438053e570b989195687615"
+    },
+    "gfx/adn_a6.lmp": {
+     "bytes": 584,
+     "sha256": "8495247be5584836815824b182f448348d3de924236e254c5ebffd8132a1b7ae"
+    },
+    "gfx/adn_a7.lmp": {
+     "bytes": 584,
+     "sha256": "76a1b4a37c14cf3c53047129e14bb3f2217142ca5405ebceb95b892bed49cb77"
+    },
+    "gfx/adn_a8.lmp": {
+     "bytes": 584,
+     "sha256": "943ae9da4710dfb8a8b7b22eb8ecc6131e7c4586f279701323997f931bdd486f"
+    },
+    "gfx/adn_a9.lmp": {
+     "bytes": 584,
+     "sha256": "4381c6e590644e7c7e3d64e89adb1d438802e1a81380de8f08b31669780f07ed"
+    },
+    "gfx/adn_aminus.lmp": {
+     "bytes": 584,
+     "sha256": "903c3e6081e934fb4a9b0ae4564265b0339d2289fea17720c7bac77d00155258"
+    },
+    "gfx/adn_colon.lmp": {
+     "bytes": 392,
+     "sha256": "a06510a33f355c24fc16d7591323523f13920ae6fa903c3155b5edef9e4059a9"
+    },
+    "gfx/adn_minus.lmp": {
+     "bytes": 584,
+     "sha256": "1e04325b97c5052e64187e0882b8c2f87473bd66f3e70b5a419d983b0a62ed81"
+    },
+    "gfx/adn_s0.lmp": {
+     "bytes": 264,
+     "sha256": "6a5cac8d7c8076aa42055c3b64f3fde4b1e7750b2bb143b12af07dec892c9ccc"
+    },
+    "gfx/adn_s1.lmp": {
+     "bytes": 264,
+     "sha256": "723ec3e0b6225419fa5fb8010896674d91d19eeafd8e2c9bbbec2d23fbb85792"
+    },
+    "gfx/adn_s2.lmp": {
+     "bytes": 264,
+     "sha256": "cff9bff09933ccbf43a1419d6f566807c2aee9a4aca448a86bf261394b3ca7b3"
+    },
+    "gfx/adn_s3.lmp": {
+     "bytes": 264,
+     "sha256": "8d7cf6b3f2db7463e962fd7b70b2ef7c36b0882b1e80d90b02fa1a609d09513f"
+    },
+    "gfx/adn_s4.lmp": {
+     "bytes": 264,
+     "sha256": "2bc5fa316cc366f4d1a4f1831ac3b8ced65caf89157e796ff5d673fa3955ac1c"
+    },
+    "gfx/adn_s5.lmp": {
+     "bytes": 264,
+     "sha256": "98cbff3f1b98977b8fc19523fc2e644e763fc52dba708fc5024dfbeaa1f00d6d"
+    },
+    "gfx/adn_s6.lmp": {
+     "bytes": 264,
+     "sha256": "1578d854415aaf5b68a25a0fb37057b019d12055b61c3d7402eae811a9359e1f"
+    },
+    "gfx/adn_s7.lmp": {
+     "bytes": 264,
+     "sha256": "609059534b0a59c9d5ab1180f25f0b2a952719a0ccade29d05559dfc6223f1d9"
+    },
+    "gfx/adn_s8.lmp": {
+     "bytes": 264,
+     "sha256": "7327dd480225a52c642320336ade17100228d2c1ade5f1b640cbff18e37fbe2d"
+    },
+    "gfx/adn_s9.lmp": {
+     "bytes": 264,
+     "sha256": "b8ad416098543b34c286565e3a0d7756eea7ab18c8b50145e7ddbc45fd28851a"
+    },
+    "gfx/adn_slash.lmp": {
+     "bytes": 392,
+     "sha256": "2500358f0d4bf9856c04b7be940ab41012faad597005837c99dfef93da1f3ca6"
+    },
+    "gfx/adsb_armor0.lmp": {
+     "bytes": 584,
+     "sha256": "01228bb8947103a70c9f536b168eefacda9dc5a08e1fa64ee963be44d4a9af9c"
+    },
+    "gfx/adsb_armor1.lmp": {
+     "bytes": 584,
+     "sha256": "85956c2a17460229a374e8a6e1cf22ad4ff663929dba06c9daa9d95d1582ba53"
+    },
+    "gfx/adsb_armor2.lmp": {
+     "bytes": 584,
+     "sha256": "e8e64ea8d90241677315bb9a9e25714856827642a0e331077dc6fa2b827036fc"
+    },
+    "gfx/adsb_armor3.lmp": {
+     "bytes": 584,
+     "sha256": "db6523d7c99bb15c14ad9fd1d665a24e4eab985dfa095d316f20fe5e96e9c320"
+    },
+    "gfx/adsb_axe1.lmp": {
+     "bytes": 584,
+     "sha256": "ebcafdd02b84a9bd21658a349205a09e5e242fa39013207fe6aab9697df2884f"
+    },
+    "gfx/adsb_axe2.lmp": {
+     "bytes": 584,
+     "sha256": "12caae98c176f1176a5222f7730709dcb9164a5db63984fe6f8982e8b17915e6"
+    },
+    "gfx/adsb_cells.lmp": {
+     "bytes": 584,
+     "sha256": "08da91ae0bca3d7bd546d92f7688061b7fbc8d86b84e309510ee3feeb3f63e92"
+    },
+    "gfx/adsb_key0.lmp": {
+     "bytes": 392,
+     "sha256": "49e4cda132ff7237a4b7244892fa1e059ff2d77698ec855cb4c02e08867899e2"
+    },
+    "gfx/adsb_key1.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adsb_key2.lmp": {
+     "bytes": 136,
+     "sha256": "46a6561c191c47e9445ef85c2bebdc881f330ca49afe562d7bb2a59c5442c73e"
+    },
+    "gfx/adsb_nails.lmp": {
+     "bytes": 584,
+     "sha256": "77fb4c0c61d824fafba54e91d6b23e702ae54565d7708ee0e404aff804555b73"
+    },
+    "gfx/adsb_pent.lmp": {
+     "bytes": 584,
+     "sha256": "8066cd0ef3d3ed9add280937fa51d6dd13a7eaf606ad0567366e86c51ddb7d62"
+    },
+    "gfx/adsb_rocks.lmp": {
+     "bytes": 584,
+     "sha256": "2e79b7c3e3fb6b4118a3ddedd7d9a1186f12c2df2efdbcf5300cacc51fe64744"
+    },
+    "gfx/adsb_shells.lmp": {
+     "bytes": 584,
+     "sha256": "f185cb1b1a48a8499d110e6371f2bb102ad89fda9875a267adcc6f3c8a5e613c"
+    },
+    "gfx/adw_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "ee32ef4cb14c02b9516f245fe9eae50021962ebdee3ef843076b9dbe20f038fb"
+    },
+    "gfx/adw_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "0f8884976f5ef05d5c3d7ab7c7b22bddeba9ee922664d23c6dfe835c5673ad9f"
+    },
+    "gfx/adw_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "2c1f7b1b0a5c27da9f01c84a38571901fb3636a04485102f44cb19d715e7f627"
+    },
+    "gfx/adw_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "a9802bea98b2fb57ab97784caeebf1ab2312fab73146503459c7c8021249ccef"
+    },
+    "gfx/adw_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "0c92aaf91afe914f4d06e5d2fa91bf926a0b43294d49021755b93c049e15a99d"
+    },
+    "gfx/adw_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "155eeca532e2f6d08b7575697020eebd4f492987392c68f09c66bb6522c0336b"
+    },
+    "gfx/adw_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "02d55707616bd6eae995c93d5eca3e788f227811001e2e8137c07cafe85409a4"
+    },
+    "gfx/adw_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "0d4cba204d9ea74665e164d46ead9167095cceb64a795861dfb21fcfd2b3e9ac"
+    },
+    "gfx/adw_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "3d354bd9336125ea758f2b5b56b1ecdf2a2afea4e8bb8d6edeb058448f9627e7"
+    },
+    "gfx/adws_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "457f6682e5a8b3d7b1075148c05093df1ec96c59e85057dfca80f66f4ad25815"
+    },
+    "gfx/adws_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "127d3759679f91a8633557a27abcb8425b3f8fd8b9888e029f761cff9fa20e47"
+    },
+    "gfx/adws_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd1e14b26cfa3915c23502e22413328d37749e0a77ac75508238fbaa375c7555"
+    },
+    "gfx/adws_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "424a425e24162a3a1a23e7308b8b46f4d25f1c9f11ac3b427117c596dafeb006"
+    },
+    "gfx/adws_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "41dc9eb1fb806500b41d832786a0bce0c6863c6caa3bcc7491892e25d04a81d4"
+    },
+    "gfx/adws_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "30a22fc8975b5a696ff31e859290fd780553f1857e424b1d5ecfa057277d155a"
+    },
+    "gfx/adws_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "50c5e9c358023dbbb65cc79346d99af6797af556faded31df95e2b7191aeb3f0"
+    },
+    "gfx/adws_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "94cef7136e718532b4d00b9ed8804da60be979206bde676a328270321286851a"
+    },
+    "gfx/adws_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "8259db2f3f7ddd075e6192d6e0581a2321c108232d67980fab85059fcbfe47df"
+    },
+    "gfx/adx1_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx1_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "e4d0714014c5a1c0d9874bf1ce2c0232352be1e0c90ffe927dc2d86d448f7e47"
+    },
+    "gfx/adx1_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx1_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "9da68076978e9bc4d35e2b40e972c578e0839c379c86d44bf15c033f164fc9e9"
+    },
+    "gfx/adx1_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx1_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx1_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx1_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx1_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "9341894f953061deffb42e12370fd05b7f8008e2a1caee149630a8bcd40fac10"
+    },
+    "gfx/adx2_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "c5f2e4352837eca0a67b1fe6eb5d437672f365efffd7c297848dcdbfca6fea7f"
+    },
+    "gfx/adx2_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "b627ea70b6a7a5debddd4710f31ca137c3baf01dd6109cc2cee7da968a020049"
+    },
+    "gfx/adx2_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd7a15d826f6565c97f638ff541d76e409b9cc69febbb78906c5ddbbad2e0f02"
+    },
+    "gfx/adx2_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "8239bfd1d494fae52f97d5f620bf6c9cace057a27975cddf7d0f557b5a797cb6"
+    },
+    "gfx/adx2_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "6adf5220508ec39cedaf8cc8208c8b7bff5f44f18401bc5ee7a39e91419376ab"
+    },
+    "gfx/adx2_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "f300febb1aad7dc16d592f1e1aef2cc5a8870ad08ebbb2bc15b43009122259ae"
+    },
+    "gfx/adx2_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "e15bf6fb56eca5640d521dfdbe0c20f9e3ce6fb6fc7a2e39922f0fc8cfc7d002"
+    },
+    "gfx/adx2_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "c781852ce141a1d5fb84451e1bef2b021c937d0658d7ca8f8b2a1d5cc3737a66"
+    },
+    "gfx/adx2_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "aaaac2a8b4dfaae3d02705c2fbffa38621187cc28f4246a591f38b2bec79f693"
+    },
+    "gfx/adx3_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "20209da4ccb0dbeffc6520aee7958b33bcfa728ed376b1f5f987c8305fb70d3e"
+    },
+    "gfx/adx3_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "eb13bcc843d95abf3c90c140c95aa95803a42a6afeb100e11a5e0d80c72caf8b"
+    },
+    "gfx/adx3_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "483f85f7e5a0e881f6511f2b16a25d1945dcc2fa5365e4417cb58ec6a87f062d"
+    },
+    "gfx/adx3_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5e1f15716b826a8a25e61415e675a6c94888ae4030462e1190653c4d93768743"
+    },
+    "gfx/adx3_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "99d58b01e578c88924699f85614b021dcc5ce32798c96680fb5120e8d58837c2"
+    },
+    "gfx/adx3_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "4eae7b9a7119e883d3b6d3b8b336398beca8b7cf4ed2b9b498e13d90b7743ccc"
+    },
+    "gfx/adx3_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "8568e0c106e3155b9cef3dc3bd55ce821ed151560abab4080fcf6534850b153c"
+    },
+    "gfx/adx3_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "b8764c3198aa863d67e4f7c3c19db89aab6aa4f4076abe83d50b88710eb85446"
+    },
+    "gfx/adx3_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "fbb92c8a0853070604e84da82a5232c93747f3571ba05e88ecb4e59649125838"
+    },
+    "gfx/adx4_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "4e8da401756d091a913d4a0a5618aee7eeddad1bcd8c78774bc229195bd96943"
+    },
+    "gfx/adx4_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "c68cec0c6064b7ceaad60028ed1e8f7834a6484d9fde249649d7b94addc6544a"
+    },
+    "gfx/adx4_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "386eadd2ee00c5a53179729c2b23cf56f0629c3e7ad8e5b3a739f1fd8d489d34"
+    },
+    "gfx/adx4_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5179dcb2b82032c81d02dfb35d130ed8196d5b726c7a8265c2823c3f2edde2a8"
+    },
+    "gfx/adx4_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1156e8a090be24e24605153b059646bd7d8b9d33c6e175bc9b05843eb626ce38"
+    },
+    "gfx/adx4_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "8881a5fe764d90c1113e1df7215c6520988c23601a969ea3e7b9abf8d7d4ef0c"
+    },
+    "gfx/adx4_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "7b55d6f2071d101db2a87c5958aadcdcf618f8f0eab53b19691125c1e8b6d8ad"
+    },
+    "gfx/adx4_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "199a6be6977bbebfe0aac0005466b10bfcdd9d26a764d18e56e28ee6f6f8f5ee"
+    },
+    "gfx/adx4_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "924cd9a6ac66660db99821b558a21e8dd0b02e85bb2a5415c2e24daace249663"
+    },
+    "gfx/adx5_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx5_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "9405034666f0f1247a58a97b86e5c451f0b2a315501389f43043da55493db8de"
+    },
+    "gfx/adx5_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx5_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "6c529185a7cc6dc8d066080c4246f80c7bf1fd0ea808fc0be5be63c8cff7c2b3"
+    },
+    "gfx/adx5_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx5_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx5_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx5_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx5_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "bb8e065bc9d9935d7fab8e9d0d0554948e2ab2622a54e86f70c1d8c3c9a0f178"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "b941e3ec692b990d1dbe0fd69c1e043b9d504374d791c8c981cb091324072826"
+    },
+    "gfx/community.lmp": {
+     "bytes": 256,
+     "sha256": "7d425f7678b30e94f816c93391c3322ed354c9657ef2563c964b2abb0d57d933"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4424,
+     "sha256": "b4554a7ef6de5831198626fef9431582d3c17ed56c55853f1ce979be31df8dcd"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "a0e7d5ec57b819a0c6ad269e777ea123f767c6d53d47cec3cecd8f25dd27b04a"
+    },
+    "gfx/conchars.lmp": {
+     "bytes": 16392,
+     "sha256": "045ea49c02bc0e51336e84fb19f4c445ece3c0d8c6ec4aba3cac0fcbf4306c15"
+    },
+    "gfx/conchars.png": {
+     "bytes": 14283,
+     "sha256": "1b63b3d252a0d234553153910c6d5384de0bbe050f095ebe00d253ffab2db8b9"
+    },
+    "gfx/conchars.tga": {
+     "bytes": 65580,
+     "sha256": "6dbfcc084e12e7c053c49f257f0a2276014a46ee92d194008893a39416e9e486"
+    },
+    "gfx/env/adgreenskybk.tga": {
+     "bytes": 1520289,
+     "sha256": "6a7fa2cdc97237658a3f2c73a8a5d879feadf4a31e84fb8585aeba96f3f8fb61"
+    },
+    "gfx/env/adgreenskydn.tga": {
+     "bytes": 1565620,
+     "sha256": "d4fabe617a431169df1bbc37e48404fc34718a1bbf5a1ee45d5b3a0ddda5cc6c"
+    },
+    "gfx/env/adgreenskyft.tga": {
+     "bytes": 1704063,
+     "sha256": "c6cfbbd8b09846eaea719a5e65744cdd4fddced0c277f4584c743f2639882d50"
+    },
+    "gfx/env/adgreenskylf.tga": {
+     "bytes": 1576943,
+     "sha256": "c83f24917ccb67af83602236d03e57096f73b36b7fc64da6206afe989944b4a4"
+    },
+    "gfx/env/adgreenskyrt.tga": {
+     "bytes": 1706213,
+     "sha256": "7b85287d2ce5e4d3a9ce63a560183086e812ceca9232d07eb61f63a24d678e10"
+    },
+    "gfx/env/adgreenskyup.tga": {
+     "bytes": 1798684,
+     "sha256": "703e4449b5b9ff967610dbc81d7e27c089788927d82fdb31267490cfb30ed0e3"
+    },
+    "gfx/env/asap_bk.tga": {
+     "bytes": 786476,
+     "sha256": "9f6daf48061bdc132ec28062c494d4a6abe2eeda2c86b575ac7df472a97b2c80"
+    },
+    "gfx/env/asap_dn.tga": {
+     "bytes": 786476,
+     "sha256": "a8aa31d47f7537150c1023713588b87cceff0072036ea64c895129fccfd9fa9a"
+    },
+    "gfx/env/asap_ft.tga": {
+     "bytes": 786476,
+     "sha256": "067cca994d96dcc95903ea1d3c023c479d66a655b2d3412116d462dff4e155d7"
+    },
+    "gfx/env/asap_lf.tga": {
+     "bytes": 786476,
+     "sha256": "761640856a2500019db4c3fae214fe2043fbc0edffa3e6c508d964a86b98ecf5"
+    },
+    "gfx/env/asap_rt.tga": {
+     "bytes": 786476,
+     "sha256": "08d03cf9826300c6d283028f60663f5bd3f6564a7deb5e15078440e18e1433cb"
+    },
+    "gfx/env/asap_up.tga": {
+     "bytes": 786476,
+     "sha256": "d98b750d0908addc2b0c9d513bc0bfc5d28935c9536f437cfcc3796fc0f5ce82"
+    },
+    "gfx/env/black_bk.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_dn.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_ft.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_lf.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_rt.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_up.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/interstellar_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "861352b7f4dc030af28b483d09ad88b4cbb7b8e23e5cd3cf512d2feae9640b22"
+    },
+    "gfx/env/interstellar_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "b16b2e272b7e74513f6a1961d68270dd82fa0667d6ea267a2d22c45a2bdc2fcc"
+    },
+    "gfx/env/interstellar_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "11730f0982cbadc7691ea38e57510b2b7e77484e108d591aece8f970cfdca08f"
+    },
+    "gfx/env/interstellar_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "5bf0a5999e7ea85e68291ab7b36d7f6be5104f8932a2fe46d257484e84dab4fc"
+    },
+    "gfx/env/interstellar_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "051204c9fb8a430c17fb337d84132e0d7058b88f070e457278be99d78a73e5c2"
+    },
+    "gfx/env/interstellar_up.tga": {
+     "bytes": 3145772,
+     "sha256": "d8b19a66cb5dad2f34c9059860ac24a8632ba5575ac06ca3076d57a70c47b5b0"
+    },
+    "gfx/env/l_swampn_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b83c2aeccb2ec2b6a7e7de05e4eb1f120437c575769b93533708093be6d7acb"
+    },
+    "gfx/env/l_swampn_dn.tga": {
+     "bytes": 3146268,
+     "sha256": "64ea5b085c2758138760da154c77e3c90eb0831c68e75bac4c03cd03ae2e28c1"
+    },
+    "gfx/env/l_swampn_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "f8149a22f17e241f3cc50ddc2587b3d8d6e72bb26f7a47d5045b08ed436863af"
+    },
+    "gfx/env/l_swampn_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "fdf2a49932e8ee9c06b9a50fa6dcff3d29bdde55aa209d1658346cf236ca1dd8"
+    },
+    "gfx/env/l_swampn_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "a2c65a9eafab955cfe898aa28e3563714354a08725068df84f390eebfc6ca20d"
+    },
+    "gfx/env/l_swampn_up.tga": {
+     "bytes": 3146269,
+     "sha256": "aa5c65d4c106b17e695629023db1e6b304ec5b4f15e646a1a94b38c47ef9017e"
+    },
+    "gfx/env/moonhigh_bk.tga": {
+     "bytes": 1048620,
+     "sha256": "5f361bf5a352c1df5a6caef9cf42bd35fed8406c6949af480b0425c193c18b3a"
+    },
+    "gfx/env/moonhigh_dn.tga": {
+     "bytes": 1048620,
+     "sha256": "02e2b36863c1181a85aa675c53fc14a301f38dc6e0c6735098bb6d8723af02b3"
+    },
+    "gfx/env/moonhigh_ft.tga": {
+     "bytes": 1048620,
+     "sha256": "3158735bdd6f4f467a5b29639aa4f622d1136ea463967684b739b0002bec6526"
+    },
+    "gfx/env/moonhigh_lf.tga": {
+     "bytes": 1048620,
+     "sha256": "5cdaabd99655152689e40832643690d7b1c5f8e414f3126a7c0c9224f2250704"
+    },
+    "gfx/env/moonhigh_rt.tga": {
+     "bytes": 1048620,
+     "sha256": "e08a374ac19c8b8cffa6c939515cde9570b44bbc044c12d06b0c5d94aa7469bc"
+    },
+    "gfx/env/moonhigh_up.tga": {
+     "bytes": 1048620,
+     "sha256": "c0465fd6a0b069e5ff78f3e561084bf3e23b796cac9b5214a6cd4045310d36fe"
+    },
+    "gfx/env/moonrise_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b4e85116e3999d5cded25ca0a5d6fb9c297b3d69749a63daf5af6c37fe21959"
+    },
+    "gfx/env/moonrise_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a7be41496d25bc9e505b959b08a950c1bb61acc6c8c44ec4e1dd428faeac4ccd"
+    },
+    "gfx/env/moonrise_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "7381c46aa4f5c916f3bc8f82a442a4582834563c0bb0127580053bb274609180"
+    },
+    "gfx/env/moonrise_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "871df5eed200970b8c3246ca10a039f5915c95e8f48bf0692fc22f2f7e5450cd"
+    },
+    "gfx/env/moonrise_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "2cc00bb935ee2f4019f4d99170d38ef3f51c72ff80150cd74911b1038a0cb269"
+    },
+    "gfx/env/moonrise_up.tga": {
+     "bytes": 3145772,
+     "sha256": "0296084074d726170fdc85d2c1176ee64845b6805c174c08aaa63f514fd9cb65"
+    },
+    "gfx/env/snowmoon_bk.tga": {
+     "bytes": 707878,
+     "sha256": "f4c61c3a622a2dabfc2aa2748c3bba9ab52bf018c5c24b5aac6bd682b6d938de"
+    },
+    "gfx/env/snowmoon_dn.tga": {
+     "bytes": 754863,
+     "sha256": "a6f29123dc3da6df244c6878d1a355b9ba7c093b9a38b94e8f9253d317de846c"
+    },
+    "gfx/env/snowmoon_ft.tga": {
+     "bytes": 630095,
+     "sha256": "c10f65b43cff087a7044946f8105d24072bbcb33668bb485f501fc0bdcb7e293"
+    },
+    "gfx/env/snowmoon_lf.tga": {
+     "bytes": 671066,
+     "sha256": "8025d6d72582a374583dc4c80d15de546b1ebea3f378cc55b084483778d8f985"
+    },
+    "gfx/env/snowmoon_rt.tga": {
+     "bytes": 636559,
+     "sha256": "339a1a1a36ffafa6bb49ae5bffcb73c81d4304f0f6d40d5fe470654c0db56037"
+    },
+    "gfx/env/snowmoon_up.tga": {
+     "bytes": 410341,
+     "sha256": "f08c76ef2c7c2338b64615543ffa1217edab3ca41bc79cb74b20bc42d329e82c"
+    },
+    "gfx/env/stormydays_bk.tga": {
+     "bytes": 786971,
+     "sha256": "d82eac0c4f574d74ff5fee6ececd1d5f0b1bd94c349cb7c9af30d3ce79bf6b2e"
+    },
+    "gfx/env/stormydays_dn.tga": {
+     "bytes": 786971,
+     "sha256": "915f33dcae63765c49252b65a58f9d4359c7a36ea99352a013e58e660b71f160"
+    },
+    "gfx/env/stormydays_ft.tga": {
+     "bytes": 786971,
+     "sha256": "4906e45ebc2760dad5faf2e6f8a0be7c280bf7525a96364376155f3d001fba99"
+    },
+    "gfx/env/stormydays_lf.tga": {
+     "bytes": 786971,
+     "sha256": "d7cc6cbaa37481b3902673d717aae7f31e0170e2226a4efe88811f6bac3f8ca6"
+    },
+    "gfx/env/stormydays_rt.tga": {
+     "bytes": 786971,
+     "sha256": "ab40bc26b750a421c95948e7f215d51e831163fd478841c30f685a2b006b8c3c"
+    },
+    "gfx/env/stormydays_up.tga": {
+     "bytes": 786971,
+     "sha256": "8ff85257da02eb361ab8127e4425b9177842f17016724beb5c3058ae460aa52b"
+    },
+    "gfx/env/violent180_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "cf1d0a870b38e4889ad4ce18f22bf894771a8c91477c0338e837880df061db31"
+    },
+    "gfx/env/violent180_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a3b344abf47fae67c831aaa8d8b2ab7ff56ff1ed93091c6869139902060777ff"
+    },
+    "gfx/env/violent180_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "964ce0226b139a1af96de0c422e927d35917ad30f0c4027c1c386c7c32cc30db"
+    },
+    "gfx/env/violent180_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "b9cc1ef464535f9a911d56fb503a2e1aa68e6d07c7091cb62c42442a7d62ceaa"
+    },
+    "gfx/env/violent180_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "263af4a0d5b2e61303d8165d6b8a8b7e55d0c8dd79157ff133a5d50128d5f21b"
+    },
+    "gfx/env/violent180_up.tga": {
+     "bytes": 3145772,
+     "sha256": "3a9aae357ac1a8e8767e151024dab60845283422f204a354913282873f181413"
+    },
+    "gfx/env/voidsmoke_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "d274189cd63786e9d86fbd3cafda0cbfd054ccd527e30aeec921a8d6f10866a7"
+    },
+    "gfx/env/voidsmoke_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "47392d93a23946a28533cf759d6aea245a2647d58bf153d2845ac0899ab8d400"
+    },
+    "gfx/env/voidsmoke_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "ced1991fffdc46e2bf156e1d89e06e1362e0e394808b74bc7aa40e6d90fde55d"
+    },
+    "gfx/env/voidsmoke_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "4d1b843a9fc61c4125262a9a95fc084cea61eb4b125288f7a7cd0c2f2e53f4ab"
+    },
+    "gfx/env/voidsmoke_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "389ae84f29901e349a266d707f62beab9de3eb607b901bcb4245028b8edaa3b1"
+    },
+    "gfx/env/voidsmoke_up.tga": {
+     "bytes": 3145772,
+     "sha256": "138e9386728cdd98935a0c484d5693db2e60375d8d770ad754fe6616906591a1"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "a878796ad2dbab6a64e1eba47605d124170d5b4a7ce476b9d0087c2e302c00f1"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "381ec91a75cacad94d2a4d5a3b1cd6f9b22cce507fe95f980ebaabdb21bbe440"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9e9568b56059e74e621ad564b51cb0b886fcf800fd8d35a06df1aa79ac2aa823"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "52164e93b333dfe09a33d7ad1905796d7e7578a036b2fb2ddf35c4bf3381f30f"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "240a13f778cc7ec7ebbc67b23a977a54099e1996fd868f51c18f81aa3606d179"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "fae9345c9eeb43a56a14e9e681f9e9dadc05ba6e35f44197fca5873dbd52904b"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3272,
+     "sha256": "ba61bec9eaf837bddef9a1320c0acfe026a130bc078836abf971095157ee395f"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "fc226280c4948249790f00f97dd9b39e912131fc904ec75adb90308ba8763afc"
+    },
+    "gfx/mainmenu2.lmp": {
+     "bytes": 30728,
+     "sha256": "a3fd168c6454eeaeea9e248df568e5942a7f850bc5478f8946a0b6516a2ce6c4"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 6920,
+     "sha256": "5a84111e70bf277960853bca69a0dff9093d00d817ffab6fed96f33751435ae6"
+    },
+    "gfx/p_mod.lmp": {
+     "bytes": 6920,
+     "sha256": "3080226ebf497787e7ee1d7bc2917ae220340b7da4af58ff1a0f89f02b5c03d0"
+    },
+    "gfx/p_mod_idver.lmp": {
+     "bytes": 2504,
+     "sha256": "56234ed3e4e4fe95f8a4a1f9a52d4a73890ea653aa88ec992e6777bf3e99b445"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 6728,
+     "sha256": "493a3ae8e9553de87c49d356e916adab7c87e3b25a44c1d1ac46e37de4df800b"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 6728,
+     "sha256": "d79623e26bed9db65257e3c0bf43b085d2419fc6e5277ff357350556882456d9"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 6920,
+     "sha256": "f51c8bd49d699f08322b734f281d7e626c24844aec09099877fbceb1884cb705"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3272,
+     "sha256": "788da2d0f96ed9f0822fff406f364a912179e33f6f4d068aa7b772f2747cbc85"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "e433f3f5b535d3157ec0feeb91804959ff671b88a04c9785a02ec3acf5539af7"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "f8ee0991ff6faaef3b4d2230364776effe6a1d4b47588b98e39c1d0b4199fd9c"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "a6ccb48f7e1d00ec64e5154a0a47b433f017341b8e23ba4f7f7fef6fe9a27b3a"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 6920,
+     "sha256": "bce2792bc38f1f097336ebdedff2029b21f4cebc523684738f7e10e086d33661"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 6728,
+     "sha256": "904d617b5b97aa6b1631e7b5dfab9b4092c488fefd94ec093c98595b38789b7d"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 6728,
+     "sha256": "5eeeea42e3f429aae7f907145b88376805346ebe3ce932259bdfc43399f960ff"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 4808,
+     "sha256": "5ae8a3fd789e7ddf6d7791ee89cb79ef989cb000c086e9269349aa623f1f6438"
+    },
+    "my_progs/ai_ammoresist.qc": {
+     "bytes": 7444,
+     "sha256": "d530fec92f23ed0c3d09560abb9a89bdc160ce1aefdfbe4f4771f9897ae3fc4d"
+    },
+    "my_progs/ai_checkattack.qc": {
+     "bytes": 106456,
+     "sha256": "7971ca5a87666c89b56ab0fcc102e6f551f3cd3b03bdfc0bfb73f5f8d5aed7fb"
+    },
+    "my_progs/ai_combat.qc": {
+     "bytes": 24318,
+     "sha256": "a8cc4b28f82babe8ef8fc627a3c16efb25775ea736d3ee99709ed675196c2d66"
+    },
+    "my_progs/ai_enemytarget.qc": {
+     "bytes": 8409,
+     "sha256": "f4b0a35306d50e71fd9043ae949a421158ee9fcc4e311baf7b8fa2d345c4d46e"
+    },
+    "my_progs/ai_explosion.qc": {
+     "bytes": 12162,
+     "sha256": "7df941a7cf93b814ae9d90f646a5b0243a51db67872f621df73d43c6000ba3ab"
+    },
+    "my_progs/ai_gibs.qc": {
+     "bytes": 32373,
+     "sha256": "65e202300882ba8f0c980f65820b2d2e0bd06846073168f4bd7e37f2357f47d4"
+    },
+    "my_progs/ai_hazards.qc": {
+     "bytes": 26832,
+     "sha256": "81aace80121408f64369bc2bbfd5654650276ddd75217333d2a52364415acaa5"
+    },
+    "my_progs/ai_minions.qc": {
+     "bytes": 10236,
+     "sha256": "3e7bd34dfe0e73a11e6907d5ac69cb609eee19dff533689ea7c8eabe52500136"
+    },
+    "my_progs/ai_passive.qc": {
+     "bytes": 8224,
+     "sha256": "44473544d0da0dc778c2800a16172ab49b548286b604c9d6361f4bc4cfc1f076"
+    },
+    "my_progs/ai_pathcorner.qc": {
+     "bytes": 20921,
+     "sha256": "b3d6ed2434e0b995da51a71715647096e36e02d8cf920e18e024f920ed69238a"
+    },
+    "my_progs/ai_projectiles.qc": {
+     "bytes": 86235,
+     "sha256": "b28c04e84c97febe9e5a8e921a8e230755f9641d4bf5d74b4a59caaaa247dfc8"
+    },
+    "my_progs/ai_states.qc": {
+     "bytes": 7480,
+     "sha256": "76fae861132b0e50006ef88ea94a953e718b661defad2ea58a4ecad5cab92dee"
+    },
+    "my_progs/ai_subs.qc": {
+     "bytes": 50952,
+     "sha256": "9d2e356f0dba7842956ceb4e766fff9da25dc72a0b408baa3e19c4a146cbafdf"
+    },
+    "my_progs/ai_tether.qc": {
+     "bytes": 6470,
+     "sha256": "2229c0ea1b76e45f5707a3eca9e7626e33f8ea91d6b292da63c81723e1ae8521"
+    },
+    "my_progs/breakable.qc": {
+     "bytes": 79687,
+     "sha256": "754831599eec85a774501d9fd0a1ec7d5722ea6a6e01655b5ad74988145045af"
+    },
+    "my_progs/chaosmode.qc": {
+     "bytes": 81481,
+     "sha256": "01561dc4f1949716eba4d08f83efe27b71add80f923c1e2d89194c238772a646"
+    },
+    "my_progs/client.qc": {
+     "bytes": 70441,
+     "sha256": "00e2d4aff96ea28b0532ab0b03de0a8cdcf15750164ec82bdc8f43b9f2347447"
+    },
+    "my_progs/client_advinfo.qc": {
+     "bytes": 59677,
+     "sha256": "87aaca8bfd15935e1cd29a807bf77a2779d95418af631a6b456c6605710694fe"
+    },
+    "my_progs/client_camera.qc": {
+     "bytes": 13007,
+     "sha256": "ff4748b04c15d9a3b44dd8069f9347c12487ef353d5401a13542166576097889"
+    },
+    "my_progs/client_cshift.qc": {
+     "bytes": 725,
+     "sha256": "da1e321fe01bae486ffcdd987a942a4b0d5b2f603efb663d52c55e882f129685"
+    },
+    "my_progs/client_debuff.qc": {
+     "bytes": 15761,
+     "sha256": "0e0c9123697241ab3a366dbc46fcb90b8553b65c94cffe1442254a74a2753efd"
+    },
+    "my_progs/client_evilmode.qc": {
+     "bytes": 6982,
+     "sha256": "2cfa3bbeb36ab623c3bb137028ec5f549a2e5d2198fa2ab7fd8a445e14f4fc10"
+    },
+    "my_progs/client_ghook.qc": {
+     "bytes": 51884,
+     "sha256": "43d071195a70caa66b57cca1778679d772478fd1f71cbad7ee267e254e79a29a"
+    },
+    "my_progs/client_info.qc": {
+     "bytes": 13693,
+     "sha256": "55653ddc2b9f3cf2ca3cf1b0afdc4c1685baf1ab3c3830eb9f8b1b2d51b3ff31"
+    },
+    "my_progs/client_mapvar.qc": {
+     "bytes": 13177,
+     "sha256": "c692fa41644e6d21c945493dd891af945a072a4b39e687d1b59c86d14ee804a0"
+    },
+    "my_progs/client_power.qc": {
+     "bytes": 20026,
+     "sha256": "68457e8f99d3967babe95d4db3539388e95d294fa65a6190773e75951fed9ef9"
+    },
+    "my_progs/csqc_defs.qc": {
+     "bytes": 21072,
+     "sha256": "eddc5f194845e78a1633807d32b1da4425bdbe7bcce193e3868bc3995e2dee9b"
+    },
+    "my_progs/csqc_defsclient.qc": {
+     "bytes": 35002,
+     "sha256": "b6674acae135dfbc5e3dbb147e69acdc6b3564b766792359bed3e4eb800705e9"
+    },
+    "my_progs/csqc_hudad.qc": {
+     "bytes": 104391,
+     "sha256": "1ca012e489dc5f6026bdae469f411b5bb25afa00e00d5169cbd35b578a7ad9f2"
+    },
+    "my_progs/csqc_hudvanilla.qc": {
+     "bytes": 37074,
+     "sha256": "c5caa6ba176185c05903d383f3ae41907129d859419a0c0bf909b0e8d3e8af5a"
+    },
+    "my_progs/csqc_progs.src": {
+     "bytes": 113,
+     "sha256": "e383fc0920e9676d92e0be81d69cd8017ed5baf9fc0616a05773de68208ce434"
+    },
+    "my_progs/defs.qc": {
+     "bytes": 31974,
+     "sha256": "1534874cf4d70c5614dedecb70f6d428fc32832ce3345c2cb51fd6058a514902"
+    },
+    "my_progs/defsclass.qc": {
+     "bytes": 24401,
+     "sha256": "811c390be7b31fd4b276410ef1a75406bbca8fb84dc195484835a6100e9cddb4"
+    },
+    "my_progs/defscustom.qc": {
+     "bytes": 95914,
+     "sha256": "180ebe8c3fbbd4f78815c94d62f6ac0ad0c3cefe427664fdf4685adcf2c8a699"
+    },
+    "my_progs/dpextensions.qc": {
+     "bytes": 122912,
+     "sha256": "3758f58ebaa4186e9112da89f7ea53087eef5058a32ebc373a1ffda76c1d67a2"
+    },
+    "my_progs/estate.qc": {
+     "bytes": 7745,
+     "sha256": "9cceb71ae54b331c2702f5580094f9055d007b9e710dd5e61c7c632724022626"
+    },
+    "my_progs/fteextensions.qc": {
+     "bytes": 215531,
+     "sha256": "beb86ad10bb0726de10dd2557d6285f7bf40f08f9d30e06315c3772f8c256571"
+    },
+    "my_progs/func.qc": {
+     "bytes": 47039,
+     "sha256": "81cd56475c6c34a744d84c2b223e66dd1c83a1b525b4c42f3389d4ff4cca5601"
+    },
+    "my_progs/func_buttons.qc": {
+     "bytes": 13271,
+     "sha256": "9e1bd197b2367ab2b8f1c776c214a0c51120559e8d8f0b4888b262b7a1e746f0"
+    },
+    "my_progs/func_doors.qc": {
+     "bytes": 35874,
+     "sha256": "58dbdf05f0044aefdd13ee21d17045a681d255efaca6d129fbd1cec4ae516fc9"
+    },
+    "my_progs/func_doorsecret.qc": {
+     "bytes": 14379,
+     "sha256": "769a3142ccaf18060ff77b0eab57d901585202fbfe63a54ce25d4987b80f92d3"
+    },
+    "my_progs/func_insvolume.qc": {
+     "bytes": 10573,
+     "sha256": "1deaf4623a6fae80585d2d2b1978b1cd217b6f8a683ef3bbc3a77a2897e9a207"
+    },
+    "my_progs/func_plats.qc": {
+     "bytes": 11685,
+     "sha256": "5086c9aba8bbf83d29c3e1897c7867cb24220712007044792928f474216b7ea4"
+    },
+    "my_progs/func_pswitch.qc": {
+     "bytes": 8373,
+     "sha256": "b3a205176d80801216a930241508b3c5718f4be9e1b947932ace2851c34271d8"
+    },
+    "my_progs/func_trains.qc": {
+     "bytes": 26553,
+     "sha256": "81d8de4f3dff80b8523584fb5e37d8d4812a6f7f95a559edff320682217ad123"
+    },
+    "my_progs/globalfog.qc": {
+     "bytes": 18397,
+     "sha256": "84ec244a475ac41b9da772042123f58f4005130590f170f85f1b23ad53629f27"
+    },
+    "my_progs/hiprot.qc": {
+     "bytes": 31978,
+     "sha256": "82875db9fecd8bacd2c42232fb980e6a510a6863103273e2c9078dfe7c6759c5"
+    },
+    "my_progs/hipspawn.qc": {
+     "bytes": 2752,
+     "sha256": "6df8450b85821c1a76f5ccb3c807ac9b94e92f413f16f2ba618f922abf85148f"
+    },
+    "my_progs/items.qc": {
+     "bytes": 164855,
+     "sha256": "ffa38fa915821151c7dbfae3507bf804052db0f5c13eecac462400680cabcf3e"
+    },
+    "my_progs/items_progspn.qc": {
+     "bytes": 20628,
+     "sha256": "2f4824cb28192145a8fabc2da6575db3398e8f81522ab1e026d696ec87313650"
+    },
+    "my_progs/lights.qc": {
+     "bytes": 43912,
+     "sha256": "d0e0c373bb3cc68c7c9121a62c68085ff9cc290daa6faf0adab02323d8ef92bb"
+    },
+    "my_progs/mathlib.qc": {
+     "bytes": 22355,
+     "sha256": "b161ebb89a11f302427c4f124731ec38def8eb01347beb5d748a9ba4afb886f8"
+    },
+    "my_progs/misc.qc": {
+     "bytes": 85890,
+     "sha256": "6b3e8a0882d47f16ff7f54fb37a48e3a7853647f8895718e6428739c4207099a"
+    },
+    "my_progs/misc_camera.qc": {
+     "bytes": 43852,
+     "sha256": "61448a8f0354f39dd26371ae56dadbc903b08282293145a27088ac6c151ea547"
+    },
+    "my_progs/misc_model.qc": {
+     "bytes": 31793,
+     "sha256": "04774e0bab5cb0ccc5bd01e36ae7d6f449248484d0cb203eb435fb267cc8bdda"
+    },
+    "my_progs/misc_targetdummy.qc": {
+     "bytes": 15123,
+     "sha256": "bcd0a0ae806ce20a8c8cfcc27178ce1b4ead3a546d927b6a261ce51a6086c253"
+    },
+    "my_progs/misc_textbook.qc": {
+     "bytes": 26321,
+     "sha256": "14bf42536a5cc75990d938a79d7bd21bde1c166245d94d8e662f9e6fd66e0ae8"
+    },
+    "my_progs/mon_baron.qc": {
+     "bytes": 31318,
+     "sha256": "b76a10da34dabf3411ddf650abcdbc77e3ebcdfebace6191a39e7c0b13a0fad5"
+    },
+    "my_progs/mon_boil.qc": {
+     "bytes": 19821,
+     "sha256": "050b21bda5341a3f81dcb21e6d7d82d458a415fd8f1cfa12435228246229a323"
+    },
+    "my_progs/mon_bossboglord.qc": {
+     "bytes": 24005,
+     "sha256": "e67081b7a5218b361c62bf4b201a18db16f3e75716ad2729c11a0616b137975a"
+    },
+    "my_progs/mon_bosseidolon.qc": {
+     "bytes": 40134,
+     "sha256": "c51eb9b9d67cadfa7178891a238329a60ad57edc3f6ef645060695b451833115"
+    },
+    "my_progs/mon_bossfiretop.qc": {
+     "bytes": 14734,
+     "sha256": "26672c9c2d1577f8caf9894b8eb5eecacac89f64251257bc25db48b1bf43a7bb"
+    },
+    "my_progs/mon_bossicegolem.qc": {
+     "bytes": 47205,
+     "sha256": "5b888302a6af24ce823919d1349c1c92e1ee709d72e79042425349368a4d65fb"
+    },
+    "my_progs/mon_bossidchthon.qc": {
+     "bytes": 20247,
+     "sha256": "65d955fb1434f806962fadc088aa5933e96ed8aa9f1211d0709a3f462ffa3027"
+    },
+    "my_progs/mon_bossidshub.qc": {
+     "bytes": 14639,
+     "sha256": "fdd0e8f8fa374ea0164f79ef1bf74ca942f04c63159f360c7a43011673774fe6"
+    },
+    "my_progs/mon_bossjudicator.qc": {
+     "bytes": 81432,
+     "sha256": "f5092f376eeef22f0a552c846f50175680c15a5c37d9603c6e3d2635661127b3"
+    },
+    "my_progs/mon_bossmammoth.qc": {
+     "bytes": 84963,
+     "sha256": "6cda415b846b2aeb215c0eebc7cdfa6a5560255df9aa014f77b48aa7073b8d34"
+    },
+    "my_progs/mon_bossnour.qc": {
+     "bytes": 45558,
+     "sha256": "def8a1a46f3a266028df3d1a0b7c31a9ad98450f6601e176495f11d929041452"
+    },
+    "my_progs/mon_bossxxchthon.qc": {
+     "bytes": 22614,
+     "sha256": "2c1c0446b0f6a5b7a7921e8f8830c71c174d30c6f176d228a94afd9a05fdc25a"
+    },
+    "my_progs/mon_bossxxshub.qc": {
+     "bytes": 19006,
+     "sha256": "043ebc852ba7f0a06812cb0afd72d32a3da643df1dea45c87fb821f60fbcc332"
+    },
+    "my_progs/mon_centurion.qc": {
+     "bytes": 13734,
+     "sha256": "641e1c09c6df27b033e331140d242f25d27bf7f9bb83733a6b5b3469a5c7ffee"
+    },
+    "my_progs/mon_dcrossbow.qc": {
+     "bytes": 38069,
+     "sha256": "3296618a4b803fb6f1b44c1d32c17692a5bed13cf63102c6dcc58481223197a8"
+    },
+    "my_progs/mon_deflector.qc": {
+     "bytes": 32107,
+     "sha256": "d7a9344878a3a846a7e720ce704820d424362281a1675c40be7b670eca9fe342"
+    },
+    "my_progs/mon_demon.qc": {
+     "bytes": 14601,
+     "sha256": "d77f128e3f91737228c5a24b7ca146f6b4f8e87dbaac31b1ad4e79779884d0d7"
+    },
+    "my_progs/mon_dfury.qc": {
+     "bytes": 39867,
+     "sha256": "a016db202f2a418aee50cb7cce2155a24a6b807e8c98fc49a5f9273ce79c6da8"
+    },
+    "my_progs/mon_dguard.qc": {
+     "bytes": 28414,
+     "sha256": "0a2b964034559f4ca772f9f29be2c56684fd39290277046a6f7642ba934836eb"
+    },
+    "my_progs/mon_dguardquoth.qc": {
+     "bytes": 18932,
+     "sha256": "4caeb17520104cba42476ff7757f38ba6d72e941674b851f55a5c9780ce4de17"
+    },
+    "my_progs/mon_dknight.qc": {
+     "bytes": 36867,
+     "sha256": "68008427374e9ab670b6ad915c7a0f8eaf6a6699efa927a3748ae6cde86458e6"
+    },
+    "my_progs/mon_dlord.qc": {
+     "bytes": 22859,
+     "sha256": "09ca1edd4e65a166a66ba17e682aae9a1be09b05371a72dd1bc447389693bfa5"
+    },
+    "my_progs/mon_dog.qc": {
+     "bytes": 18431,
+     "sha256": "1b345447176aec54f18c31f5da215e80cb2de19f51d353c63a98507d881c2a9b"
+    },
+    "my_progs/mon_dprince.qc": {
+     "bytes": 33590,
+     "sha256": "5114caa7b6152e562e548096e41da68f43c910a5016ddaed408272a97a8320c1"
+    },
+    "my_progs/mon_drole.qc": {
+     "bytes": 25472,
+     "sha256": "36a510e910ce4ffa26d2d2ad336872c07537077ea920132a4cfd63d9133fb6af"
+    },
+    "my_progs/mon_dsergeant.qc": {
+     "bytes": 33493,
+     "sha256": "ada0cc4359a863c4e8d433c605a1c04ec6f7fd17ec852f5c4847443d3adaff1d"
+    },
+    "my_progs/mon_eel.qc": {
+     "bytes": 8252,
+     "sha256": "15c1f2fedba7077d352595e1be4a90f764354e4cf1875b40e1685d3ce81feb54"
+    },
+    "my_progs/mon_enforcer.qc": {
+     "bytes": 20146,
+     "sha256": "d453651d488afa789d0cea87ce99d9684329bbabdd17aa1625591f5a4b4ac90b"
+    },
+    "my_progs/mon_fish.qc": {
+     "bytes": 9705,
+     "sha256": "ff7d84db2c7917861ff5d81fe0e28f69d51143d27c4fba90dfcda11057222df0"
+    },
+    "my_progs/mon_floyd.qc": {
+     "bytes": 20332,
+     "sha256": "3ac2f0b0be94e311ff2fc4eee9cf66d5987af0e5c25fc06b8cc7b9efa6f581df"
+    },
+    "my_progs/mon_freddie.qc": {
+     "bytes": 25384,
+     "sha256": "4409a33e819f125852d0a4ada21a8fed2713012daec00922446f313031c845d1"
+    },
+    "my_progs/mon_gargoyle.qc": {
+     "bytes": 24293,
+     "sha256": "9e1f78b2364024efa6ec4142c1ecf4aff52cdf32f38031c34cf19e9cd74143d6"
+    },
+    "my_progs/mon_gaunt.qc": {
+     "bytes": 24111,
+     "sha256": "45be98ae0bdd32e0884280e18f867af037f2fcbf515914827c5f9107a87e52d7"
+    },
+    "my_progs/mon_golem.qc": {
+     "bytes": 35297,
+     "sha256": "dbaf3d1c0fec3166b0eb064a3c027dd3a0c907bed72b8e4581ffd74dad5ab5d1"
+    },
+    "my_progs/mon_hknight.qc": {
+     "bytes": 37618,
+     "sha256": "bac7d4b7832b95cea0f6890de66fbd0f7c4fcc7ce9051ef16ac042de465ddcb3"
+    },
+    "my_progs/mon_hogre.qc": {
+     "bytes": 24021,
+     "sha256": "8781ea9aaaa1d0f7ffb1fd8ec8b5981187eee6fdb8193160a1eb38770dffcfe0"
+    },
+    "my_progs/mon_hogreham.qc": {
+     "bytes": 23076,
+     "sha256": "b2ab6b830ce3aae7d6b033e8455de5011ded82e451ca171ea09940d9a3ec7740"
+    },
+    "my_progs/mon_hogremac.qc": {
+     "bytes": 23941,
+     "sha256": "9111c040ab1e5487936cce6ef1170e408c6d297d582702d202bbd27b0919d843"
+    },
+    "my_progs/mon_invsword.qc": {
+     "bytes": 9214,
+     "sha256": "f7287867cc6043eb7cd3fa3e1ecd5ae7115a84e5ef7021b2d5129afdb6ba6f46"
+    },
+    "my_progs/mon_jim.qc": {
+     "bytes": 22091,
+     "sha256": "55353984ad822dfd8c32f3b8ad9a06e8bfaab7bc5ff6f2a2326674ad4acd26be"
+    },
+    "my_progs/mon_knight.qc": {
+     "bytes": 24772,
+     "sha256": "d254abf88162436b9db48885ae8e59315c24c1e7f72a91d027a1d69fe9baf5b7"
+    },
+    "my_progs/mon_lostsoul.qc": {
+     "bytes": 23261,
+     "sha256": "2cdbf656c6b34164711fa88016542f4e3d2bd0555417ad00bab5ca7039f212ef"
+    },
+    "my_progs/mon_minotaur.qc": {
+     "bytes": 35316,
+     "sha256": "fbcef276ee3e2f1eeea8483303538190875e959b43efbf4f703be10fc72fc564"
+    },
+    "my_progs/mon_ogre.qc": {
+     "bytes": 24123,
+     "sha256": "d287d3b9024025237dbc68380f486572828a5114f9543599ba86b8bc35e9e25e"
+    },
+    "my_progs/mon_ogrextra.qc": {
+     "bytes": 9387,
+     "sha256": "41a9243c6006326195197a4dfba6ea4c1f1fbd729ec10adc48cfd7badd7a18de"
+    },
+    "my_progs/mon_pyro.qc": {
+     "bytes": 18235,
+     "sha256": "bd35f02c63af315ddf4820e388d0248cf065f1170bd7306957a1e86fa7e47306"
+    },
+    "my_progs/mon_scorpion.qc": {
+     "bytes": 22136,
+     "sha256": "0432d7c5e1b6a30a5452aba12b9fb6a3c2c7f3c582b1392d420414e66b8fb257"
+    },
+    "my_progs/mon_seeker.qc": {
+     "bytes": 29703,
+     "sha256": "d33939357840eedbfc63c56d6415d8fefd21de2c477b24b3165cdadcca2acd2c"
+    },
+    "my_progs/mon_sentinel.qc": {
+     "bytes": 10217,
+     "sha256": "946232c7169bf3fa966ce875523dd45402772f8045c51a96dced04f2f5f5788f"
+    },
+    "my_progs/mon_shalrath.qc": {
+     "bytes": 16434,
+     "sha256": "1b6fdf2447d7fa281d126118a9bc0e097de7b4dd4d10a33e60d5cf0ca785c58b"
+    },
+    "my_progs/mon_shambler.qc": {
+     "bytes": 23050,
+     "sha256": "576f71a38d75eedbdf58c291055674be8da5f0d04540e26311d65f70b58ee842"
+    },
+    "my_progs/mon_skullwiz.qc": {
+     "bytes": 36245,
+     "sha256": "6d3c2242bffe6eabe3f9cc59e881cb2296213cfbff809e1be045a80ca46aac53"
+    },
+    "my_progs/mon_soldier.qc": {
+     "bytes": 21645,
+     "sha256": "704c534062b11c4fc16416154c7706c125221660cdd4d9b02e00575b94c04103"
+    },
+    "my_progs/mon_spider.qc": {
+     "bytes": 30593,
+     "sha256": "4d0bbb7e38e51cef07912e6071e6bb9739e019a2d93129d38dbab9492bf43aee"
+    },
+    "my_progs/mon_steelclaw.qc": {
+     "bytes": 17126,
+     "sha256": "78dd4bb46dd76b2ff1f7d4a9f0b0902f25d94ebe13ace6b997a7f604c3718700"
+    },
+    "my_progs/mon_swampling.qc": {
+     "bytes": 25637,
+     "sha256": "fb5ed328cd3d5c09704bb84f39138463a7d26b8b1d45771e55e9ae952b1d2470"
+    },
+    "my_progs/mon_sweeper.qc": {
+     "bytes": 27025,
+     "sha256": "8f7a1d077779d88d542a325c1ae4ba4ff59d48bfcb334150ae3f024525bb725e"
+    },
+    "my_progs/mon_tarbaby.qc": {
+     "bytes": 11866,
+     "sha256": "88c9481ab7fe0cbe97d2b836492ff51b368aeae8d4ff3e5852734bb9f63a1b2d"
+    },
+    "my_progs/mon_turretbal.qc": {
+     "bytes": 38519,
+     "sha256": "fdcf915248dda5fb6a744d284233d46a2e6d62c8e4fd02fdd5bafe4f46167d30"
+    },
+    "my_progs/mon_voreling.qc": {
+     "bytes": 27678,
+     "sha256": "7734614fa6b2da2195bf3804415c06a2d10f35825e86abf4f85613a182cf21c2"
+    },
+    "my_progs/mon_wizard.qc": {
+     "bytes": 15155,
+     "sha256": "3101ca37b57343697b3d3c7637fdc84c842f78ec9081e401dcaa6df0a9b1df83"
+    },
+    "my_progs/mon_wraith.qc": {
+     "bytes": 35464,
+     "sha256": "6a28a205cb8ac574e98c8d34a01ea859922e38d55c66346a7aa867ebf84bdb5b"
+    },
+    "my_progs/mon_xmas_elf.qc": {
+     "bytes": 17589,
+     "sha256": "053eec412485090ee1ebeac25887382db40e2ba7ca456050ba4407be3ec8bc1a"
+    },
+    "my_progs/mon_xmas_raindeer.qc": {
+     "bytes": 12189,
+     "sha256": "abbe1dd5c96c25b631231d4db2f17e8243075ad08c082e0448b7cbff34f1ae0c"
+    },
+    "my_progs/mon_xmas_santa.qc": {
+     "bytes": 17853,
+     "sha256": "cc60c6de17bc3321f9b1cf75b3229e387592c9eb7fc4bb57c1de0a8d2c0e62e6"
+    },
+    "my_progs/mon_xmas_snowman.qc": {
+     "bytes": 11486,
+     "sha256": "65928bb70cb2e9352c2f5e036eda2a6bd97aea09d459d0af563a82aa5a2f2673"
+    },
+    "my_progs/mon_zombie.qc": {
+     "bytes": 33988,
+     "sha256": "83f56482374c3a79fcc64058989bd210af3add006b7388d89c92e90543ec56a0"
+    },
+    "my_progs/mon_zombiek.qc": {
+     "bytes": 42214,
+     "sha256": "2b9926454484e93f5c053bf4fd35b2a97cf7e835c26c3b30061f1ff391af9f5e"
+    },
+    "my_progs/monsters.qc": {
+     "bytes": 56573,
+     "sha256": "c2c75832e6d5e83e929214ba5c1aa9a4661bcaf7754c20b3e9648171bf804a58"
+    },
+    "my_progs/part_emitter.qc": {
+     "bytes": 82744,
+     "sha256": "fca7491171d58974ef6b15550b9a7f0474641e9eac7ee5de52c6980c96445518"
+    },
+    "my_progs/part_generate.qc": {
+     "bytes": 42914,
+     "sha256": "83b9718a85418143d92ea8311cc8cce69c1002eb7563710dfe7010ac52e15d50"
+    },
+    "my_progs/part_manage.qc": {
+     "bytes": 27407,
+     "sha256": "86eb791f4bba08fc0c965e9f81c90e7412ed2c910104d66a56cce1f3152808fe"
+    },
+    "my_progs/player.qc": {
+     "bytes": 27811,
+     "sha256": "1f0cc3eaf577c2af642495466c573cd6e226a4754902d9de9cbfc9c9ba28af0f"
+    },
+    "my_progs/progs.src": {
+     "bytes": 2482,
+     "sha256": "c773f107c562f731fbb30158422226bdc4576dd32aea0f02c122195e08eac96f"
+    },
+    "my_progs/pushable.qc": {
+     "bytes": 19823,
+     "sha256": "03b3bf9240db6e9532e45a3efc159129709f9ce095c3238daae32daddd5b07ec"
+    },
+    "my_progs/qc_highlight.xml": {
+     "bytes": 6348,
+     "sha256": "a7b326723cc1e4025e867ea5da00f54c944705600d740538aeb52f63cd027ab5"
+    },
+    "my_progs/settings.qc": {
+     "bytes": 61298,
+     "sha256": "7a1ae40ba7fa97ff7e7019017bc7640fd49d22943a2ca57c7a7e48702bbe7158"
+    },
+    "my_progs/sounds.qc": {
+     "bytes": 19389,
+     "sha256": "bb74ecc36a241db5a79b010f61200687c6db6e46297db39c8a2a8ce1d512bad5"
+    },
+    "my_progs/sprites.qc": {
+     "bytes": 476,
+     "sha256": "579f48b397914b02f8fb86dc24f23d4e63a4cd857df1f0eaefd6c83e9c49e238"
+    },
+    "my_progs/subs.qc": {
+     "bytes": 23545,
+     "sha256": "123ca7120e7ea4e4ca63bfd081caf46c7acd1560af4702c1bff40821d7f6ef44"
+    },
+    "my_progs/subs_soc.qc": {
+     "bytes": 28453,
+     "sha256": "679112275e8b3597daac962074f69b6d9fd5614fc3dbff036815b9365e1413c5"
+    },
+    "my_progs/switchshad.qc": {
+     "bytes": 7054,
+     "sha256": "92a2fd4e5c41f21f46502781322ab87584bf0999d733db50e0e19b8bbea793b3"
+    },
+    "my_progs/targets.qc": {
+     "bytes": 58758,
+     "sha256": "e39b45bf6740be40c2899376e92d30d7d227a4762091d7b63e382c79fe6822e7"
+    },
+    "my_progs/traps.qc": {
+     "bytes": 24071,
+     "sha256": "9e4e822a36113bc73958fa45ab0b8c290a5148c95f3a4da7125676c984ebd202"
+    },
+    "my_progs/traps_pendulum.qc": {
+     "bytes": 17049,
+     "sha256": "b421f26fd80eb74715172e25f3ac992faa95397dd67d5f7ede286fd78384a468"
+    },
+    "my_progs/traps_sawblade.qc": {
+     "bytes": 9783,
+     "sha256": "9a6e82a05f09001c0a9cffdf6b9d6399691846c5b1ab1fbfb470e5772a87f44b"
+    },
+    "my_progs/triggers.qc": {
+     "bytes": 139586,
+     "sha256": "2e5819bf11fecf01856bd7547af63b7c4927dec59237419dbf3dc79bc023f54d"
+    },
+    "my_progs/triggers_states.qc": {
+     "bytes": 17475,
+     "sha256": "2c4d25c11de0319cd54d81e67e651c8d29d22aca851988d21080ba5976137f14"
+    },
+    "my_progs/weapons.qc": {
+     "bytes": 44346,
+     "sha256": "f23d0cc07bab402da965ec3fa91d7de86ccabcb03c9019cd7b217fbca7fb4279"
+    },
+    "my_progs/world.qc": {
+     "bytes": 39815,
+     "sha256": "b933caca23d5a45e5d9368627b3d651af244af0aa345b91017d263be4bad7b77"
+    },
+    "particles/fte_weather.cfg": {
+     "bytes": 2758,
+     "sha256": "e0d383b0222f14edbd2bc04c1269206bbcdca22cdeac6840b5d831c042ff698e"
+    },
+    "particles/particlefont.tga": {
+     "bytes": 4194348,
+     "sha256": "bf90d469b3b41c2393f5ed0f58b4411cc8825f452341bbe3ba848c3cc855639e"
+    },
+    "particles/particlefont.txt": {
+     "bytes": 9872,
+     "sha256": "9e84ef35b813211196f8dfc8f89a420fd9d847ea514e43d0c3246ee666000b88"
+    },
+    "progs.dat": {
+     "bytes": 2345354,
+     "sha256": "f3c4218216ea0d3b00db35eef9e72945ee6687006b3e82c37ea2ae33a0eea922"
+    },
+    "progs/ammo_battery0.mdl": {
+     "bytes": 10552,
+     "sha256": "06d4f0235faedd3430e57d602ec29a2a91c0b23bdc30debc069212264a0faf54"
+    },
+    "progs/ammo_battery1.mdl": {
+     "bytes": 10552,
+     "sha256": "0cee39ac60c3eda7b5f1d1efde52f8be19c9e4f425972f16ba6d6362d646afb6"
+    },
+    "progs/ammo_cells0.mdl": {
+     "bytes": 27228,
+     "sha256": "b6f5a07c9fd48cf27f0873320589dda1e20afe7d64cd40b6c950e5f892a34fa2"
+    },
+    "progs/ammo_cells0_edit.mdl": {
+     "bytes": 27228,
+     "sha256": "47ffc9eb8ec352ab2fa479f35ee5b6ec0e0ac8f472a06fbe00e8298e9d683ed5"
+    },
+    "progs/ammo_cells1.mdl": {
+     "bytes": 29836,
+     "sha256": "c23b4e85e9edd68fec2d751af85cff391a11848bd4338a3c59a2c055508cfce9"
+    },
+    "progs/ammo_lidlarge.mdl": {
+     "bytes": 25252,
+     "sha256": "d941a1c520e49694d66598f3430420541b318cea3e1cf02d3957e06d010681a7"
+    },
+    "progs/ammo_lidsmall.mdl": {
+     "bytes": 25252,
+     "sha256": "221b3aaa2324bea668276d3de521c4945004a71368983fc74c50c4b53425c436"
+    },
+    "progs/ammo_nails0.mdl": {
+     "bytes": 14072,
+     "sha256": "1090a9c50a943c2bf04302914f69b835ecf79fbf3013f259a12668ebd57aad5a"
+    },
+    "progs/ammo_nails1.mdl": {
+     "bytes": 15976,
+     "sha256": "8dd339507f4e18953ceefe3922d04ca513728bf2b0745813723873427843213b"
+    },
+    "progs/ammo_rockets0.mdl": {
+     "bytes": 24836,
+     "sha256": "9f272b2f1cb52fcf38983f63052db653e8208b2ee1eedf053e99dca6e439c7d8"
+    },
+    "progs/ammo_rockets1.mdl": {
+     "bytes": 27672,
+     "sha256": "46d85f10a260cf13d6711420f11a235089536a3725363be0717c2ee3e7e8a18b"
+    },
+    "progs/ammo_shells0.mdl": {
+     "bytes": 14072,
+     "sha256": "053e466f1666314cbfc0cd6f67821850ad39505a6a0bbf37c80b127e6887e5c5"
+    },
+    "progs/ammo_shells1.mdl": {
+     "bytes": 15976,
+     "sha256": "6183880b36171b6784cecf74b50aea2e1fdbc17b1b0b304a89125e964d63fd1f"
+    },
+    "progs/armour.mdl": {
+     "bytes": 76144,
+     "sha256": "b6e297062cffd435d6ce5cc17854e25a49ff09750ee1eaec6d5004266884099a"
+    },
+    "progs/artifact_airtank.mdl": {
+     "bytes": 50184,
+     "sha256": "4702b7be1baa517669edd24f5b67377f532382bfedebd77b5d77f9a499f3f08b"
+    },
+    "progs/artifact_blastbelt.mdl": {
+     "bytes": 28436,
+     "sha256": "a935de1300f6fc4f03b6fc57bf43791ac32b74d55c5509eda84339dc33f0bf48"
+    },
+    "progs/artifact_envsuit.mdl": {
+     "bytes": 260844,
+     "sha256": "09192fca32cf5b7632cf0fe9cccd9b4b1313c0e92708e85f840b0971aca5d274"
+    },
+    "progs/artifact_invis.mdl": {
+     "bytes": 7108,
+     "sha256": "f6b0b925b584402d85a623e1924c50a4fb3f3a4994cb1d2f05a169a3af2e39dc"
+    },
+    "progs/artifact_jumpboots.mdl": {
+     "bytes": 37428,
+     "sha256": "668d649addf958be26f2bcff31baf3afa5ff176a178ef15073c87cc7cb57e2b8"
+    },
+    "progs/artifact_lavashield.mdl": {
+     "bytes": 469773,
+     "sha256": "2e3027df661ca197750df97599084442afda131fbf1b545ea38d40e93afff908"
+    },
+    "progs/artifact_pent.mdl": {
+     "bytes": 21412,
+     "sha256": "7ae90fc895f23f57952dacf4d8af125f99347e09edf6f0287c7e508faad67b46"
+    },
+    "progs/artifact_piercer.mdl": {
+     "bytes": 19012,
+     "sha256": "fd73ca18d93904647df923f2d0383958386c7deb9cf27547beda74c61a9f8831"
+    },
+    "progs/artifact_quad.mdl": {
+     "bytes": 22052,
+     "sha256": "bf6d2253210784391ee1ab9b38d2b6fd661a520434bb127d293f4d202040d1b5"
+    },
+    "progs/artifact_sharp.mdl": {
+     "bytes": 49248,
+     "sha256": "505fc06618d7cecb83c03ad7d7762011ff8cff025eecf007b200d87fcc2483cf"
+    },
+    "progs/artifact_tome.mdl": {
+     "bytes": 21412,
+     "sha256": "ee8cf94e2c87ff6c0d4aa8777da2f0ddb79605bf790fb8f9ed2f49c6c1f9b9cf"
+    },
+    "progs/beam.mdl": {
+     "bytes": 26020,
+     "sha256": "bd06e42c7f0d911a4ef1077c95d474b86f62bca4da02183449687c23879e8c6d"
+    },
+    "progs/brk_pot1a.mdl": {
+     "bytes": 93352,
+     "sha256": "5612b9539e9663e06397f315968674b1de6ab50db7cdf673baadcd4652cedcd5"
+    },
+    "progs/brk_pot1aflr.mdl": {
+     "bytes": 93352,
+     "sha256": "02fd1feb7dc24b456e31f26f142aafb9adf491a16ea4caf2c4ec237e465260a5"
+    },
+    "progs/brk_pot1b.mdl": {
+     "bytes": 93352,
+     "sha256": "47c4053f0c0c941674a9d7c15a07e05c7ed648b2bf8ffbd1defb7264c151b47a"
+    },
+    "progs/brk_pot1c.mdl": {
+     "bytes": 83968,
+     "sha256": "a408707cc6793c337d0e76d86c5362de39a1f2109c23affe5def6e8194e0f4e8"
+    },
+    "progs/brk_pot1d.mdl": {
+     "bytes": 74024,
+     "sha256": "c31abc1e9e5af2cb86614f68a8be55f6192e05baba8b93479e2b2590b1e0ef1d"
+    },
+    "progs/brk_pot1part1.mdl": {
+     "bytes": 33768,
+     "sha256": "2dd32863b6006dda74b60f05a43df13e7df052ddcdb652309ba0ab29fa5352e5"
+    },
+    "progs/brk_pot1part2.mdl": {
+     "bytes": 34072,
+     "sha256": "550cae5c8893c63520c324610950eeb5b9fe842dc8ea1f07f6a217953f6e743e"
+    },
+    "progs/brk_pot1part3.mdl": {
+     "bytes": 33464,
+     "sha256": "819cf0e720637e7c5e187ccc67ae032eca217ee2f07076aefee1a8b7de894852"
+    },
+    "progs/brk_pot1part4.mdl": {
+     "bytes": 33496,
+     "sha256": "a3cc47c7f7410bb0ca2308e45144b29bc3b678600e0f288b15d8e64525585e43"
+    },
+    "progs/brk_pot2a.mdl": {
+     "bytes": 77348,
+     "sha256": "ffcf5e5f3d0b81143e2b2b387cde7b13b2d36b71345d63456f288eb036993a2b"
+    },
+    "progs/brk_pot2aflr.mdl": {
+     "bytes": 77348,
+     "sha256": "37420048a9f72abc5982f5f6813602dbc4b82ef8e788a0e309df7ff13066ea62"
+    },
+    "progs/brk_pot2b.mdl": {
+     "bytes": 77348,
+     "sha256": "40eb2c849cd06d9b985b0efc2b9d1090ec1648b0de53d0a07bd6fd5fe2af6733"
+    },
+    "progs/brk_pot2c.mdl": {
+     "bytes": 77348,
+     "sha256": "3774ade6790fc2b597c44c5206deeb3d5d3d20a23331e3fb622e1e90f833c7d4"
+    },
+    "progs/brk_pot2d.mdl": {
+     "bytes": 79004,
+     "sha256": "2af25d81ae0f1d8724f3047e95ff2f1d1700061a536b3f9ffda5522cf7e8dd13"
+    },
+    "progs/brk_pot2part1.mdl": {
+     "bytes": 34456,
+     "sha256": "13547d9ca8c36bbcc95354df03dfbdc14f19f74251ff1dc8c417436846b396bc"
+    },
+    "progs/brk_pot2part2.mdl": {
+     "bytes": 34680,
+     "sha256": "7f9824c52b01664c2dd1ccc5c1dc9e7ff2a5567dd2d0a8e9c3bf1a8bd00400e7"
+    },
+    "progs/brk_pot2part3.mdl": {
+     "bytes": 34008,
+     "sha256": "52fdc17879e0b6fb8697e1e9fffba092f1b5aa8d3cee5d657b405eb4119e8e87"
+    },
+    "progs/brk_pot2part4.mdl": {
+     "bytes": 33304,
+     "sha256": "b40cf2b029a4bfac52a80f5aef6587f3eb66e08be1fe5f40cd3f97e93133ad3b"
+    },
+    "progs/brk_vase1.mdl": {
+     "bytes": 27992,
+     "sha256": "28a8b9a0d367f17c2c265271d99b019f1762831a11ba794e2884fc7f7a8a2368"
+    },
+    "progs/brk_vase1part1.mdl": {
+     "bytes": 5524,
+     "sha256": "b8c0bef8f5d6a427f57282f086a75f39e91ad6ab035d4f1d437da97794e52f9e"
+    },
+    "progs/brk_vase1part2.mdl": {
+     "bytes": 5556,
+     "sha256": "8e1df7795140732953af83a1ef2158299a2cc393163041b6d3243478b6b644e1"
+    },
+    "progs/brk_vase1part3.mdl": {
+     "bytes": 5556,
+     "sha256": "c2e3da479defb1c3bd5130555e33dd47afc6a3b4ef7f74d4f0184cb02a02a46d"
+    },
+    "progs/brk_vase1part4.mdl": {
+     "bytes": 5524,
+     "sha256": "986c51c2cb3832f597f9dac89c6044d090b10933306814acc36a0c4ab5a04b93"
+    },
+    "progs/corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "839b70bb6be7fac8c25e6069b999e076b04bdd3dbc7a9320924713cf75c2cadb"
+    },
+    "progs/corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "cb994b390584e1776ad1f0e60d95186a0dc54cd160a2cb8284d1a15b4fe1a35d"
+    },
+    "progs/corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "b19faa9afe7cf957ae7abf6439799e5001ff42817290f4b464aa3f7ae4e3377f"
+    },
+    "progs/dance_player.mdl": {
+     "bytes": 465924,
+     "sha256": "d07f23e6a40743aeac01084a1da9670ea9a635339d86be46149e9f0ee74661e0"
+    },
+    "progs/explode_box1.mdl": {
+     "bytes": 49888,
+     "sha256": "c8a7e667c5e20735db9a816b7a11b5a1c67bf4e176d1553a79cc56bcaa9ff35b"
+    },
+    "progs/explode_box2.mdl": {
+     "bytes": 49888,
+     "sha256": "649dbfabde0a875a0c35b0109261515dc9eb287d0cc7f41ca3712283e62509c1"
+    },
+    "progs/flame.mdl": {
+     "bytes": 41668,
+     "sha256": "d6cb4dc28d5101538b44ed53fe1cf84c9d5f8547a91eb74fc6c6bdd3645ffa17"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 74548,
+     "sha256": "f03dd3b7f94a86c4d91ffb002723a16f30321a0c2189b673dd4f12f547245816"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 71268,
+     "sha256": "b1e734caec73b941b1c033fbb49ffc0f947aa8e1d47250c2d8cec0f244870fc8"
+    },
+    "progs/g_ghook.mdl": {
+     "bytes": 64684,
+     "sha256": "9cdd8bccab5f11ea7f8ea6480a4ea05c9d749bc4746cc19a6452a2e0356edfc6"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 32404,
+     "sha256": "b195b37f7e96274ea7db8e70dcf5971275bafdd0c9c10c29f2dc540c38641953"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 35876,
+     "sha256": "8ee090222c89209eec97120d5542d69a9f75b8a8aa896cd4df256d438ce83495"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 25316,
+     "sha256": "261a8479de0d5df9aea9931a62b1b93dbb7bfcff4f4467920cbebcc9c2c25381"
+    },
+    "progs/g_shadaxe.mdl": {
+     "bytes": 398968,
+     "sha256": "19d6f210a771748da589282e63a222c6c9c41a21085ed3f57f70d7f5aa20bd66"
+    },
+    "progs/g_shot1.mdl": {
+     "bytes": 24580,
+     "sha256": "72913fa948f1618347adaa91ceb98203186d2fc7bd3b9c84af00f7f637928058"
+    },
+    "progs/g_shot2.mdl": {
+     "bytes": 15876,
+     "sha256": "8ae318a3e697e4c85f60a4e5997b673e8e48f17e295551c2b0b5d0c643b3ac24"
+    },
+    "progs/g_shot3.mdl": {
+     "bytes": 156216,
+     "sha256": "8a602686e322d7357a102e0c8e91907c8b3975a8b6d36ba19f3c645e450285da"
+    },
+    "progs/g_zershot.mdl": {
+     "bytes": 68020,
+     "sha256": "3439ce2faa846bd2b3ca50e33b55092454ed83caaf8fe654d8381e107aa3520a"
+    },
+    "progs/gib_1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib_2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib_3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/gib_4.mdl": {
+     "bytes": 7468,
+     "sha256": "29f9cfa3d86121e1e349de9c3a39e620b9d6ba2cd98640536923e581f7ae28bd"
+    },
+    "progs/gib_5.mdl": {
+     "bytes": 85308,
+     "sha256": "2023ae2fd305843640266ec6679511d134e1b84ac54de245a390e483557050bd"
+    },
+    "progs/gib_blclaw1.mdl": {
+     "bytes": 32860,
+     "sha256": "303c38aea48534d4ce34f3c2082a21c7408c1e4a4cd848bc7e4acadfaaddbdc0"
+    },
+    "progs/gib_blclaw1b.mdl": {
+     "bytes": 32860,
+     "sha256": "c22db765c594ee28a0863cf70e354c651a2b9282e1df7e3a57b35ce62932920d"
+    },
+    "progs/gib_blclaw2.mdl": {
+     "bytes": 32860,
+     "sha256": "c7d70c4c067aa297fbebc3d26a2068a62f307c7f00f8d15d0bf76ed9519967c8"
+    },
+    "progs/gib_blclaw2b.mdl": {
+     "bytes": 32860,
+     "sha256": "96a96606a74eb3093d88f1f946d66caf77bd57fde0a4ec44840c95fa12130551"
+    },
+    "progs/gib_blfoot1.mdl": {
+     "bytes": 32860,
+     "sha256": "74e05efa33fc9036399a1f1d484a3816129fe0e379aee579b923cf3316e5ab84"
+    },
+    "progs/gib_blfoot1b.mdl": {
+     "bytes": 32860,
+     "sha256": "2d23324414f3f1a25ee24afe914679d07df244c9c0e48139331f084b8c369054"
+    },
+    "progs/gib_blfoot2.mdl": {
+     "bytes": 32860,
+     "sha256": "c2ce3b46d8762b042d201608271c3441b975b93e6329790ca5cba61294f71e45"
+    },
+    "progs/gib_blfoot2b.mdl": {
+     "bytes": 32860,
+     "sha256": "de945be28e0b05dc380a0a2cfff6907f14a5e4b9756385874fddd712df095bb6"
+    },
+    "progs/gib_dmclaw1.mdl": {
+     "bytes": 49248,
+     "sha256": "be5f2bb9174ce47f6d3df06685ac728c852c3a028f6aeb1632e709eb69c20ee2"
+    },
+    "progs/gib_dmclaw2.mdl": {
+     "bytes": 49248,
+     "sha256": "ff6cc88ef9123812b9d8e09235074f4c7fcad47077e6fffee334f15e3f71eb27"
+    },
+    "progs/gib_dmleg1.mdl": {
+     "bytes": 49248,
+     "sha256": "106990e4d9e2746303d09ae6c481914702af0242d8cf0fc9d430d0fa5329813c"
+    },
+    "progs/gib_dmleg2.mdl": {
+     "bytes": 49248,
+     "sha256": "8308124b7c4dca218af9e8ef7042ddcb0ca2fcb30e7f86866b1a28a73ab94db2"
+    },
+    "progs/gib_dmtail.mdl": {
+     "bytes": 49248,
+     "sha256": "6b60c464ee0e7ace54313550ac5be2f4949cc6f8dd539b38459c4a6c395e6704"
+    },
+    "progs/gib_drolearm1.mdl": {
+     "bytes": 18324,
+     "sha256": "a6b0f55da1b1d8e519b3cb9a53afe229279c760ffab3862866d8c4e7a52f267e"
+    },
+    "progs/gib_drolearm2.mdl": {
+     "bytes": 18212,
+     "sha256": "aff67984dc3198d24d2184c35748e829d7f867c38227f1fa898a1986f12ac767"
+    },
+    "progs/gib_droleleg1.mdl": {
+     "bytes": 18436,
+     "sha256": "ab69d8c271f44998ccdfd10d70ccd06caa3c2674f46e4cf94285b380d08db501"
+    },
+    "progs/gib_floyd1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/gib_freddiejunk.mdl": {
+     "bytes": 71364,
+     "sha256": "13763a8cec3b643acb9b8165f1850ffae003131c84a2ac225777822a88462498"
+    },
+    "progs/gib_gargwing1.mdl": {
+     "bytes": 92088,
+     "sha256": "3979718d2403ca7cf75aad4004a56100c1bf358f2cb9ae68595e5d69f6774f47"
+    },
+    "progs/gib_gargwing2.mdl": {
+     "bytes": 92024,
+     "sha256": "7554ef45a88db1f2e457dd7071770e42bf864123827b9819435a628b412ecb32"
+    },
+    "progs/gib_judgeboot.mdl": {
+     "bytes": 199308,
+     "sha256": "557eadb703666c4868e1b231cb1c21fbff5e59e2ec0cb8ade85cd3839fd714cb"
+    },
+    "progs/gib_judgeshould.mdl": {
+     "bytes": 199132,
+     "sha256": "69e4958866a47d5c63a6385db4843a6a5011f149b25e67720291d2db63945ed8"
+    },
+    "progs/gib_justiceboot.mdl": {
+     "bytes": 264848,
+     "sha256": "b727239a7bf232c7c6164d0f9fc0961a6c692cb0c0919b17429ade6f62bdd71c"
+    },
+    "progs/gib_justiceshould.mdl": {
+     "bytes": 264672,
+     "sha256": "2fcafb2b2a19b8ae16009e827f13fea14cb389317ec476b7f58fb2fef1163180"
+    },
+    "progs/gib_knfoot_l.mdl": {
+     "bytes": 18288,
+     "sha256": "8ffcc7ce931662f2eefa0703642b140e18a99c02252ffa3ddeb71f6ebbbe360f"
+    },
+    "progs/gib_knfoot_r.mdl": {
+     "bytes": 18288,
+     "sha256": "4d503f422ac01a8565453ba4bd8268338c3a9802480785eebd27fc0487e46753"
+    },
+    "progs/gib_metal1.mdl": {
+     "bytes": 5172,
+     "sha256": "b0951de4d869e0b779aeb3f7a96f56b22a82a58d267a56b1247f0c3e667c25ad"
+    },
+    "progs/gib_metal2.mdl": {
+     "bytes": 6292,
+     "sha256": "3df78c49abb572095d3b70efbb99bccb63caf2ffd30bb3ee434c945084acb5a0"
+    },
+    "progs/gib_metal3.mdl": {
+     "bytes": 6036,
+     "sha256": "88f8a1f941e38f8528ec27a168559946cc0b69f2abce1cbf6858b813e09c5f51"
+    },
+    "progs/gib_metal4.mdl": {
+     "bytes": 6580,
+     "sha256": "fbde734f29a6691d51c58a40a89e45f81dece2f20218353a6137a2362acbe3a9"
+    },
+    "progs/gib_minoclaw1.mdl": {
+     "bytes": 135544,
+     "sha256": "1188f73d5a6319bef5e506ca994bfcf63074a4267a5a189cb92db94160310fca"
+    },
+    "progs/gib_minoclaw2.mdl": {
+     "bytes": 135544,
+     "sha256": "511bb72c8382f4cc3cc9fa3bea4adf2390dcca1e2dcd42ef8f8287765875fa99"
+    },
+    "progs/gib_minoleg1.mdl": {
+     "bytes": 135448,
+     "sha256": "f07ce357d83d3ab0f39109d93f2f6996ded4ff19a4372fd5ddc9d9fa1a0ce8d3"
+    },
+    "progs/gib_minoleg2.mdl": {
+     "bytes": 136392,
+     "sha256": "7ba78149bc60a05ceff9090ecc2bdf013ff2d55420dfdebc553a254ac0bd08fb"
+    },
+    "progs/gib_ogfoot1.mdl": {
+     "bytes": 5956,
+     "sha256": "144e2fdfbccceee039243ef343df02ce181b666070e2d0a1825c056634f2a632"
+    },
+    "progs/gib_ogfoot2.mdl": {
+     "bytes": 5956,
+     "sha256": "9997dff0bdb2622ef6ee2530c27835fd249aee04437e70486e76255f979bec25"
+    },
+    "progs/gib_p1.mdl": {
+     "bytes": 7712,
+     "sha256": "709c49c205b27793f589eab17e8356a108345069716f9095dc07dd6447be7894"
+    },
+    "progs/gib_p2.mdl": {
+     "bytes": 21216,
+     "sha256": "50d99c7fec3b8ef01bbb19c32c88dac40a372cb6a7d39c349e0ff4909360626f"
+    },
+    "progs/gib_p3.mdl": {
+     "bytes": 18176,
+     "sha256": "d53659aa99de418793337b7e878db7bd7836883ad43528d648475589aa30d85d"
+    },
+    "progs/gib_p4.mdl": {
+     "bytes": 7468,
+     "sha256": "71ad4dcc06038f0a175605a3906b1506d0144b56b238e7df178160d9ab876b8d"
+    },
+    "progs/gib_p5.mdl": {
+     "bytes": 19756,
+     "sha256": "adf63c881ff5703b8112f714140929375b5c10be957f01cfdfa131d89af3cacf"
+    },
+    "progs/gib_s1.mdl": {
+     "bytes": 7712,
+     "sha256": "31faee0daaf399feccc1ec942ff7fe85a1a790ebd93c3b8a1fcfde9bcc06da1d"
+    },
+    "progs/gib_s2.mdl": {
+     "bytes": 21216,
+     "sha256": "c85f7dbc8eec508951893253bba5eec169a87865c995ba1d0e5c083fed9e03ca"
+    },
+    "progs/gib_s3.mdl": {
+     "bytes": 18176,
+     "sha256": "ec23effca60ef407bf294a814003213928f21f05e6da501fbe996345b6171013"
+    },
+    "progs/gib_s4.mdl": {
+     "bytes": 7468,
+     "sha256": "5001ef206e1a36cc792d7b94054b2bab4c6dfbed60e0ee0d3afd240d1af88d13"
+    },
+    "progs/gib_s5.mdl": {
+     "bytes": 19756,
+     "sha256": "9e1a112412d38c559974c628649a7773ad445ba7d24a1804c5f3fe5f50ecef7f"
+    },
+    "progs/gib_scorpclaw.mdl": {
+     "bytes": 66816,
+     "sha256": "ecaf582e92d77a1722eded2c5564d2fb9575065510ff1bc9632538345ed18329"
+    },
+    "progs/gib_scorpleg.mdl": {
+     "bytes": 66304,
+     "sha256": "399067acf8f082301f6629d2b124b0d34a7d934db55c922205a96772a85a8a1c"
+    },
+    "progs/gib_scorptail.mdl": {
+     "bytes": 66864,
+     "sha256": "0831c04d7a73c6f58329b0be0f6d371f727ea880b49e5b6e16f7cdc56c124df2"
+    },
+    "progs/gib_seekarm.mdl": {
+     "bytes": 265688,
+     "sha256": "6ee70b2f4f39d8a1fd99113c7c8df5481c421960f160afea4e622ed5b3113014"
+    },
+    "progs/gib_seekchunk.mdl": {
+     "bytes": 265420,
+     "sha256": "a70331a8e43075b026cf21d364cf2341e79e7e60c5fca4777d10aabd57ce0323"
+    },
+    "progs/gib_shclaw1.mdl": {
+     "bytes": 22964,
+     "sha256": "20b29bf40dd02dce0204c14c34b0b5806d8eef580406851d73383a631ac8f2a7"
+    },
+    "progs/gib_shclaw2.mdl": {
+     "bytes": 23060,
+     "sha256": "8dcf777d5ffd2e83edf5b6f936881eaf9d384fe8fc980721c9f5881d3e6da0c3"
+    },
+    "progs/gib_shfoot1.mdl": {
+     "bytes": 23268,
+     "sha256": "634d7cbb9e2b718167fe74112e6dd4f53cfe1cffc32f75cd80e711a24cd2f983"
+    },
+    "progs/gib_shfoot2.mdl": {
+     "bytes": 23124,
+     "sha256": "aaa2393cb65fb33a8885bfdd9b808732c0aa17f0dd461d3b04e84eb27f0fe61d"
+    },
+    "progs/gib_soldfoot1.mdl": {
+     "bytes": 51148,
+     "sha256": "09357cfed1e6c9c25e0d133d95f2c2b36693cbed1010146a982bca685cb370ed"
+    },
+    "progs/gib_soldfoot2.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/gib_spidbodyb.mdl": {
+     "bytes": 17652,
+     "sha256": "313dc78de70f02de9a49c71a1fd5ddb5ae4247f90a1a04f0ab84f44797be1946"
+    },
+    "progs/gib_spidbodyg.mdl": {
+     "bytes": 17652,
+     "sha256": "5439ca0812bc2627f22fd995237607755708f7615782785093793c11497973e5"
+    },
+    "progs/gib_spidlegb.mdl": {
+     "bytes": 18560,
+     "sha256": "66dc12710dec1bd4827497e4ed28b6a4965e1f68b48d5f0903a96ecf632e7f4e"
+    },
+    "progs/gib_spidlegg.mdl": {
+     "bytes": 18560,
+     "sha256": "3474de5b97c2b424f8ec4b8d93a1457f13adca106bdbe15234492376708810f9"
+    },
+    "progs/gib_steelbody.mdl": {
+     "bytes": 17652,
+     "sha256": "2a833de4b00f439041d27d97b3660d4df1cc9e3b454dba5ac5533e5c855e8d90"
+    },
+    "progs/gib_steelleg.mdl": {
+     "bytes": 18560,
+     "sha256": "ae926ada1c4ef7b695764f2daa0b4704102bf5eebc103b9f6a56813337f43165"
+    },
+    "progs/gib_swampleg.mdl": {
+     "bytes": 4820,
+     "sha256": "2b549fd3a74b0fd6b94c71c9e397b466e2c7f823917ffe717ce1af43769e1961"
+    },
+    "progs/gib_swamplegp.mdl": {
+     "bytes": 4820,
+     "sha256": "b5cf22240bf6474cc8ea57c40ddb70f80e792c23cb87835bee94825cb645578a"
+    },
+    "progs/gib_voreleg.mdl": {
+     "bytes": 4820,
+     "sha256": "19ec59cb3436d66a8ac9d8f40480a9c83aef879f0f1e58ddb834710e2bbc4d9d"
+    },
+    "progs/gib_vorelegp.mdl": {
+     "bytes": 4820,
+     "sha256": "341679c553a719be40022fc4a3573ff68116fee7ae05df511b9083a410af5e7f"
+    },
+    "progs/gib_wraith1.mdl": {
+     "bytes": 5300,
+     "sha256": "a0642c84b36288a3d0cef22ac32e0c681c422a034204932671729624f19d0b2b"
+    },
+    "progs/gib_wraith2.mdl": {
+     "bytes": 6292,
+     "sha256": "d20a17e624d16e4c8552ac9a291cd735aeae670effc2c9865b37fbc7bcd22220"
+    },
+    "progs/gib_wraith3.mdl": {
+     "bytes": 2516,
+     "sha256": "63f10b068c6df0a80729362c094f72d0bcf90f74de97636bc5e4a630c13e741b"
+    },
+    "progs/gib_wzarm1.mdl": {
+     "bytes": 12384,
+     "sha256": "9b6f5469bfc6ae49d2bd51fb6d35e686c4e79e5691e2fb80fa7ee556bf547e04"
+    },
+    "progs/gib_wzarm2.mdl": {
+     "bytes": 12384,
+     "sha256": "2ff539f467ca9b0f23c40cb2547221a484afbe7e07a812558ec1595e5cbd0217"
+    },
+    "progs/gib_wztail.mdl": {
+     "bytes": 12384,
+     "sha256": "fb90123980ff4510e744ea2b21509492b7ff9c131527ffe5c7b80bbbf881bf41"
+    },
+    "progs/h_boglord.mdl": {
+     "bytes": 98400,
+     "sha256": "119279b2ffdf928d34ef1470ae6c14f875cb59edc6d8b107a90bbea122c9acdc"
+    },
+    "progs/h_boglordb.mdl": {
+     "bytes": 98400,
+     "sha256": "25af0d0ea45857e64549686bb58e5f69a0754ff6e43c26ce735e58aaac3d534e"
+    },
+    "progs/h_centurion.mdl": {
+     "bytes": 63592,
+     "sha256": "2e64af530a4f5f36001ad922bb56a941738e7fe2c67c0ad0e3f06fa5854c4b08"
+    },
+    "progs/h_dcrossbow.mdl": {
+     "bytes": 25700,
+     "sha256": "0354fdb96bd5490bc18527d68813a43a41f943a05f7edca26c1aea7b943185be"
+    },
+    "progs/h_deflector.mdl": {
+     "bytes": 22232,
+     "sha256": "56de00c315543073bfda7e8a5ad3c3996f549351fa1e660e676516f4122cdeac"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 67688,
+     "sha256": "ff73d5f8fcab46a806c47377679ec5473cdc0ea93a0fda6dda8b5dba8cfa4b97"
+    },
+    "progs/h_dfury.mdl": {
+     "bytes": 14036,
+     "sha256": "3753a68126ff7caee3219c31533a1731ae9a80623c6af69315c7526f5c92669d"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 19296,
+     "sha256": "6b0867e61635543a7bb3b02647855f1384961095cd06dfc786a537b11eb926ae"
+    },
+    "progs/h_dguardq.mdl": {
+     "bytes": 4920,
+     "sha256": "337f2723daab9d1375b78cb017512ce8281087ff8df9c33b04a6c613cea3590c"
+    },
+    "progs/h_dknight.mdl": {
+     "bytes": 32144,
+     "sha256": "30af2418019b946f3582f70d2356357a97dff0391f86a9fb0abd5218cc799020"
+    },
+    "progs/h_dlord.mdl": {
+     "bytes": 18699,
+     "sha256": "bc5a92be1c5f3d06dc0238ec7bafe6a3c25826cc50edc6214ed5aa19b0075987"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 27652,
+     "sha256": "49f28b9a13867ed4a88fcac541b8a9cbabddcc594557b3490951179b3d479509"
+    },
+    "progs/h_dprince.mdl": {
+     "bytes": 19336,
+     "sha256": "77855cfc2667ed68c61d389a44ed312abc3ad1e029ea003d03e78e7131fb803c"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 14032,
+     "sha256": "bd5da6afddc520999d9c572a679c3bc8c43635ce2c73f8789603eb6a83c15aa1"
+    },
+    "progs/h_eel.mdl": {
+     "bytes": 156904,
+     "sha256": "a859ee09044d9afcd05ee2af3f1ea8c7b4ae3abc01273922dbebd5aa67b12d74"
+    },
+    "progs/h_enforcer.mdl": {
+     "bytes": 94612,
+     "sha256": "21046f6878f5f4173206debcb912d9fdee0b1f5c66d820a4355c7df8e2eb1860"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_gargoyle.mdl": {
+     "bytes": 30152,
+     "sha256": "bbcf207c44814f5e665944db03800934eab9046a0d0d86f4c982a3116f855791"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 59888,
+     "sha256": "f57daa1ab6a721a9feb696aaeeb597c720b639cd0a027a1b1da8cdd68ad1d1f0"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 30552,
+     "sha256": "edf8a4ccc52bfd9545fda8da9360e536c026079f8d2fd9756191fc934bd55683"
+    },
+    "progs/h_hogre.mdl": {
+     "bytes": 23688,
+     "sha256": "6f21e95518cd085d20b1023951ddf4d738285210bc95c6e2b3d2e82566478776"
+    },
+    "progs/h_hogreham.mdl": {
+     "bytes": 22776,
+     "sha256": "3d3e43d16c4babcbca358b44dc03ad1a212e22ea3a10ee9e639b5f4c2e95f670"
+    },
+    "progs/h_judge.mdl": {
+     "bytes": 203276,
+     "sha256": "be57ef7327fbf3ea6fb55c02bcccc4ec207b3781bb9d2e383939f3840e1ef91a"
+    },
+    "progs/h_justice.mdl": {
+     "bytes": 268816,
+     "sha256": "01d3011001c297b85a139ecb2861f188d15b96cd1ae02f08cb1604565f2d2ee3"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 42068,
+     "sha256": "aa979e22745c960cd100e814bce62018f2b992481e57838548f0ddf4816c27a8"
+    },
+    "progs/h_minotaur.mdl": {
+     "bytes": 138264,
+     "sha256": "c5e13818c813680fd29a94b408518731aa4e9007c23d004ec874f099c9ced6b1"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "4967d418f4810e9273732bbd4c690a1f9478243f7fe3807497134eb2994da0eb"
+    },
+    "progs/h_pyro.mdl": {
+     "bytes": 42912,
+     "sha256": "5359fd85e71cde1ab716d8d50a8618a347dd42b4ad4692805bf41c1903d55c18"
+    },
+    "progs/h_scorpion.mdl": {
+     "bytes": 67408,
+     "sha256": "d68d09c35c00d9bafb302fb7f3baeef90ee5d60de1ad8a7627f979c3561f5965"
+    },
+    "progs/h_seeker.mdl": {
+     "bytes": 9060,
+     "sha256": "9e9d601441532e16aee253b5e94ea9c32563f880782794d16ce496a580698bd8"
+    },
+    "progs/h_shalrath.mdl": {
+     "bytes": 78156,
+     "sha256": "f478f17ea9ee6843be2ebe3c487d0036657c94ace52a800fa44e0160d02a522d"
+    },
+    "progs/h_shambler.mdl": {
+     "bytes": 98400,
+     "sha256": "6508f7b05b65f230b7f1280d2023e9ed200663715db1709c43e7e187e3ed841c"
+    },
+    "progs/h_skullwiz.mdl": {
+     "bytes": 234304,
+     "sha256": "625c991e231d6836c36ae0c6651ec06f05541e9a7be605654fb43fba65bcc3d4"
+    },
+    "progs/h_soldier.mdl": {
+     "bytes": 166488,
+     "sha256": "0a4e322fbac8f98755adb9a4bf5ecff24d58aab30fcb1c9def3e97a0f686445e"
+    },
+    "progs/h_spiderb.mdl": {
+     "bytes": 18564,
+     "sha256": "d51c7764fccc4512db6d79ddcf03ffe42cf2817a66d6be02be0cba6551ee1206"
+    },
+    "progs/h_spiderg.mdl": {
+     "bytes": 18564,
+     "sha256": "70bec9669f3a7f3662320e32d29c38d535092db56617d5033e11669038472e2b"
+    },
+    "progs/h_steelclaw.mdl": {
+     "bytes": 18564,
+     "sha256": "be9adcdf9cf9407a729cfa9abcd692f46a55ffcf25c1878a7b2f5572fd591f8c"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "63b8a0b90691ae9a3c50a94f02943a1b94946f89402cc4e1da74c6806bd953ba"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 23516,
+     "sha256": "5a933ecbc067b8d6cbb57f71ae1614844b6e55170a206d278b3d15fe619c9cfd"
+    },
+    "progs/h_zombiek.mdl": {
+     "bytes": 4920,
+     "sha256": "9b8b3af67bdec6160ecd3880acc072b833886f7fc11d1e64ffcf06184f9ba80e"
+    },
+    "progs/health_100.mdl": {
+     "bytes": 6948,
+     "sha256": "6c6646f6081ab00ed1c309de3b697009c825d64360b06c741a533b718e0ab8d7"
+    },
+    "progs/health_100b.mdl": {
+     "bytes": 23248,
+     "sha256": "d82148af4482e3c0ff07389ebb5b09cdefda373e31105aeb7308b4126b353a97"
+    },
+    "progs/health_15.mdl": {
+     "bytes": 6788,
+     "sha256": "838b0cb6fd11ff7fdf268b1607a1999e5dce0dea11386afe5ff207e6ff734aeb"
+    },
+    "progs/health_15b.mdl": {
+     "bytes": 10948,
+     "sha256": "eb1bb584805aea34a0f0ab846a758cdc359b730e144e141dcd756da23b5831e1"
+    },
+    "progs/health_25.mdl": {
+     "bytes": 7332,
+     "sha256": "ce8260929500cac3b57617345b2c6b5a75e763afdbd10120982e7d7fa55be27a"
+    },
+    "progs/health_25b.mdl": {
+     "bytes": 23248,
+     "sha256": "7aba68839958035319b2167369f3fcd08c9d49140969cff7fb523b7023362e00"
+    },
+    "progs/health_5.mdl": {
+     "bytes": 6164,
+     "sha256": "a8ba7ece01b3cb58b2f94ca20a9f4511871d26ec894b54c04e433f29fc7c3bef"
+    },
+    "progs/key_base.mdl": {
+     "bytes": 54436,
+     "sha256": "fb25488fa2fc16c7c4df260a20fd905a821607a675fd0907a6e65f9d534fd367"
+    },
+    "progs/key_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "2632cb327c1175b351d026e88a4e456c45779a0dcdae01381b24200769c8743f"
+    },
+    "progs/key_gold.mdl": {
+     "bytes": 9332,
+     "sha256": "e93ed2c4263bf7631efcbace2c36ed6f240bfcc2b49491751f6d6ce55db8c098"
+    },
+    "progs/key_medieval.mdl": {
+     "bytes": 58532,
+     "sha256": "0810c558e40c5833c19283eb849ba80ac5dd3499e0f077b724057c51730ee097"
+    },
+    "progs/key_rune1.mdl": {
+     "bytes": 18900,
+     "sha256": "90ac269965d42da0205307eeeaddfa5b282598b5218af8650d2d8854621ca950"
+    },
+    "progs/key_rune2.mdl": {
+     "bytes": 19828,
+     "sha256": "4a6644f0b583c85aa41362fb4533cda5f8f762bd4429e5007b3ab57e5e24ae57"
+    },
+    "progs/key_rune3.mdl": {
+     "bytes": 19700,
+     "sha256": "9b33cc0feed9fc27ea647f6d127941933aa5378b52a3f75b9331714fa9d2ff31"
+    },
+    "progs/key_rune4.mdl": {
+     "bytes": 19220,
+     "sha256": "515534b8fdaa0ef99621f0f7d59d268c0c244562372e23c13e9ce05a44e0a68a"
+    },
+    "progs/key_runic.mdl": {
+     "bytes": 57444,
+     "sha256": "e0e31948c1e172c3c9117a8ccd72900c6ebd7a7e73882ae525dd116230f054e2"
+    },
+    "progs/key_silver.mdl": {
+     "bytes": 9332,
+     "sha256": "dd54032e82de32cf1b78a25f862a82a73e9dc0926d89ca7a4279b45d367a8478"
+    },
+    "progs/misc_bmkdigit.mdl": {
+     "bytes": 3328,
+     "sha256": "1a7f2f762ef3a052a91db7c74cf8d980db47a56685fc61184a15be2152e843b8"
+    },
+    "progs/misc_bmkdigit2.mdl": {
+     "bytes": 3328,
+     "sha256": "2e690ffe1af05f5ad88fe90c180785adeeffdb2b330aa34c6f4fb9885285cd1e"
+    },
+    "progs/misc_bonepile.mdl": {
+     "bytes": 110796,
+     "sha256": "0f8061359681f3c11660e472c517599590447c7631edfe5a36debd9645acdec6"
+    },
+    "progs/misc_book1c.mdl": {
+     "bytes": 40096,
+     "sha256": "92b976437673f56cb890f0e1b90a550ea00939d01ee12b0df0f218b35b42953e"
+    },
+    "progs/misc_brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/misc_braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/misc_broken.mdl": {
+     "bytes": 744,
+     "sha256": "828998b238e1c5471461edc3b9d2d7fada2beab6229272041dff13a94c1d73ec"
+    },
+    "progs/misc_cable.mdl": {
+     "bytes": 57780,
+     "sha256": "bed2cca38ef4cbefa9e645eb5e9ffadffac6ebb4f2ac5f6da4bb8f354de22a48"
+    },
+    "progs/misc_candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/misc_candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/misc_candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/misc_chain.mdl": {
+     "bytes": 231184,
+     "sha256": "845fc3117f7d9860f2d0aa4a398103a13f327516144a96db508189ae1be5788c"
+    },
+    "progs/misc_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "3337f2cfe739c22d50edde7bff18c026d4336bceb207dacf8b0284ab0a5366cf"
+    },
+    "progs/misc_corner1.mdl": {
+     "bytes": 21668,
+     "sha256": "7abf8d5ca497d5e8c8ddcc09c710c0401edb71b11f9de77a2daa81b1267e5698"
+    },
+    "progs/misc_corner2.mdl": {
+     "bytes": 21348,
+     "sha256": "369c874a37ef1da8c9a79432ba2ab9484a5be0df120131b8cbac81e1786adf47"
+    },
+    "progs/misc_deadtree.mdl": {
+     "bytes": 195728,
+     "sha256": "d267db8cfc35b01430590cec643570b38f8df5872c9c3e43df31dc0f3a954e5b"
+    },
+    "progs/misc_digit.mdl": {
+     "bytes": 3328,
+     "sha256": "60f16b89c1e9b8fb8bea0c0aeb96d2dbcfc14a719c130aaa34a581b26e653416"
+    },
+    "progs/misc_doomhelm.mdl": {
+     "bytes": 70104,
+     "sha256": "1b801d032daa163fab361a39631a16c501b86cc9e9b1a52a3f1454e50cdb8c8d"
+    },
+    "progs/misc_dpull_s.mdl": {
+     "bytes": 12900,
+     "sha256": "77fed0a028829fc7120db625131f855faf9b35f97f6ce0591e224bfae0fa78e6"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_fixture1.mdl": {
+     "bytes": 9768,
+     "sha256": "c10980d00e0479f8e65ab633f19ee62ace4c0697c2193f7aea8d266e2be5fc2d"
+    },
+    "progs/misc_flag.mdl": {
+     "bytes": 16052,
+     "sha256": "f2670312a8d16dd16e42fd02a39dfd285e6ffea624e729597b773c86140631d1"
+    },
+    "progs/misc_flame_big.mdl": {
+     "bytes": 244895,
+     "sha256": "09adba1308cdf22d2f07e226cb13a35e51f4d54866f84f41e2074dc7a40371d5"
+    },
+    "progs/misc_flame_med.mdl": {
+     "bytes": 175400,
+     "sha256": "31c94bc48e6c6d6bc31bd14b8e257c4e74d45aaec3a4d5d5bf83587a08ac7c00"
+    },
+    "progs/misc_giantbell.mdl": {
+     "bytes": 74016,
+     "sha256": "0d1b0e150de4ac59c599deae96d6b21e4ceb2300e7d410a1d802385dad99560b"
+    },
+    "progs/misc_heart.mdl": {
+     "bytes": 3512,
+     "sha256": "827ce2bbf2037aa26259901f4152d114cdf38312652e65e53f64ebbad9ea0849"
+    },
+    "progs/misc_impact.mdl": {
+     "bytes": 880,
+     "sha256": "93029307003bd0437071e0a89d0d4c2b699f2cde6ba34242c321cba8243f36b9"
+    },
+    "progs/misc_jstatue_01.mdl": {
+     "bytes": 1057632,
+     "sha256": "c583186f8bd56fd5ac356a8ed34956090eaad6e78506884bd520307e8f5e5698"
+    },
+    "progs/misc_jstatue_02.mdl": {
+     "bytes": 100260,
+     "sha256": "e4f3e702073a7f76ffddb79921a2bbb880d25edc0bdd6a6f115dfebcf99dbae2"
+    },
+    "progs/misc_jstatue_03.mdl": {
+     "bytes": 100244,
+     "sha256": "587cbce564e4da156a0ae20a87bd551046427f894f34959590573ce96fdf5c31"
+    },
+    "progs/misc_lantern.mdl": {
+     "bytes": 28836,
+     "sha256": "d84e36232543a053f2772b1070b221dc23da1b34cd08ea551a982b5e9f168ea5"
+    },
+    "progs/misc_levels.mdl": {
+     "bytes": 35732,
+     "sha256": "7cf9a4c1e556e60dd4e593cad4a2be0b45bea8893d9b5232ecc7febca4bbf5fe"
+    },
+    "progs/misc_lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/misc_lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/misc_longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/misc_madfish.mdl": {
+     "bytes": 84104,
+     "sha256": "30c19dadb42a53c7ccd35f992c5841aee13a86796157ea5e0453a4cb1586a1be"
+    },
+    "progs/misc_mooring.mdl": {
+     "bytes": 6676,
+     "sha256": "29b20cf17c62dddb4f0c1be758add7b15d6b22fd738fd9e2cd7533ac5d5475f8"
+    },
+    "progs/misc_mushroom.mdl": {
+     "bytes": 10804,
+     "sha256": "5570faa6e7828e4e12f568656226b0756a87d633cbdc461af472e0982a88a549"
+    },
+    "progs/misc_oscill.mdl": {
+     "bytes": 50660,
+     "sha256": "cdc96265a646f9e9fb4c1717fa90edb13e42130fadc4dc774b60aeb94b89eac4"
+    },
+    "progs/misc_player.mdl": {
+     "bytes": 562960,
+     "sha256": "83bbcf4cb5858aa9ac03323b461b3e3b09a28f56e212645472219d7d0b0979d8"
+    },
+    "progs/misc_plinth1.mdl": {
+     "bytes": 6196,
+     "sha256": "1ce0b7f49153f717e04436b27863c75f90a73b027c4cb7e36ce094fa037eded4"
+    },
+    "progs/misc_plinth2.mdl": {
+     "bytes": 6164,
+     "sha256": "e06edd50af1748235b251fe6e4217551c58d45c1f73161014dc0e9fd40099249"
+    },
+    "progs/misc_qwindow.mdl": {
+     "bytes": 77168,
+     "sha256": "facf489ac59158a3013118ca196f11a25a543f26559d5b72eef44968aa05008f"
+    },
+    "progs/misc_radar128.mdl": {
+     "bytes": 19492,
+     "sha256": "ef004e28e51e3227121a92432375531fca26d1e44894696f3d2a950fa65aef28"
+    },
+    "progs/misc_radar64.mdl": {
+     "bytes": 19492,
+     "sha256": "b9468012707ad484c1292cbe984c54811cb8fa43542e68e18a52ef93cb37d52a"
+    },
+    "progs/misc_radar96.mdl": {
+     "bytes": 19492,
+     "sha256": "6239d117263f49b79a2a66e62f2dbd6a7f0cd15ce412c1939dd69b4a1d8fce78"
+    },
+    "progs/misc_seaweed.mdl": {
+     "bytes": 16100,
+     "sha256": "dfbd38a439d392870c7c4c7ebea4475827b716004ca47bfa7f13b47daf07d774"
+    },
+    "progs/misc_shard.mdl": {
+     "bytes": 22388,
+     "sha256": "06c126f77ad931084d38f0e04d8f4341a5db3e3fa827e30de7d05bc60afd1c1d"
+    },
+    "progs/misc_skull.mdl": {
+     "bytes": 59892,
+     "sha256": "94600327093fe22acc113b8e89c8863a5548b170c9c9897bd2af8a4ff63beb5a"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 31792,
+     "sha256": "8d39b97460c9967ee36b33ea1ef1e92e89277fc410b44f054c5e06b8dc8a079c"
+    },
+    "progs/misc_spark.mdl": {
+     "bytes": 12672,
+     "sha256": "42afca9aeac1b05590b4821872cb79ebfbb4ee7264e914316d880e13f69c2b41"
+    },
+    "progs/misc_starfield.mdl": {
+     "bytes": 23548,
+     "sha256": "5b3563017939382680228e933a2a87d3edb030e75e65c51fe42c4a6889e42e15"
+    },
+    "progs/misc_stickskull1.mdl": {
+     "bytes": 87900,
+     "sha256": "38e63e10bc351ba5a48dfb6195ac5f78e5d61e67ae851f2ba50ba20255d7a37e"
+    },
+    "progs/misc_stickskull2.mdl": {
+     "bytes": 116364,
+     "sha256": "464fbee370b512d1c8057ea5a1dc3ecff69378474593919f0bbd8970419d69a5"
+    },
+    "progs/misc_tape.mdl": {
+     "bytes": 9240,
+     "sha256": "2b6a08ca3be4dd7a669e5b6d1585276759e1fb0edbe0691dd7ecbc7e41f0b189"
+    },
+    "progs/misc_textbook.mdl": {
+     "bytes": 74212,
+     "sha256": "e17e39efdf252a3da8c0574fdf272a800095671f42e71a17a3733673202dbfab"
+    },
+    "progs/misc_tree.mdl": {
+     "bytes": 120248,
+     "sha256": "888eca3c464ac068c7cdc5d7cf8f67fbcc70eb13c0079202a4f8d347f5f3bcd3"
+    },
+    "progs/misc_tree2.mdl": {
+     "bytes": 404432,
+     "sha256": "f14f3b046b58e5485afd11d396b4d358eb0598ea8cca1cbc6a70a8e629aee3f3"
+    },
+    "progs/misc_tutstatue.mdl": {
+     "bytes": 178480,
+     "sha256": "d178ba96d99b02113fe70d32f1672c1490d5f570aecf11d168e58f1bb7e8c17e"
+    },
+    "progs/misc_xmastree.mdl": {
+     "bytes": 479516,
+     "sha256": "59a89b398caa908ff6dd777cb42d0d7dfde930ac5569fdab4bc4f10dd8137584"
+    },
+    "progs/mon_boil.mdl": {
+     "bytes": 307068,
+     "sha256": "b8a79df258bf71f273dc29887c3782377bf890d43e32b690ebf2ef707eead6de"
+    },
+    "progs/mon_bossboglord.mdl": {
+     "bytes": 401092,
+     "sha256": "6fb5e0aa99fc9269b21e3a7c86e7ed70bf1f7e0150b629a39a4cf6647d0c9a1f"
+    },
+    "progs/mon_bosschthon.mdl": {
+     "bytes": 328244,
+     "sha256": "7fc4005959377598747d3accec535b52c81154b17b00221e2cd5410670223538"
+    },
+    "progs/mon_bosseidolon.mdl": {
+     "bytes": 1847180,
+     "sha256": "e08c763865b25851703f71e973755d5a7b446c8004f7d97c09fab04175373c10"
+    },
+    "progs/mon_bossicegolem.mdl": {
+     "bytes": 632584,
+     "sha256": "2a03c71a0451c389dc29374fa3a465fb0d8e9366309cbaeffb68057c928562ec"
+    },
+    "progs/mon_bossnour.mdl": {
+     "bytes": 200036,
+     "sha256": "732041ff70ec350c664194f90a9545b23b6736e729dd128f4482a0cca3ab7966"
+    },
+    "progs/mon_centurion.mdl": {
+     "bytes": 824572,
+     "sha256": "e638ad3021c5c77a1ad78fd798017fbb7a0ffa49ca2fc4a60570ba00e349d532"
+    },
+    "progs/mon_dcrossbow.mdl": {
+     "bytes": 1335168,
+     "sha256": "b38a7967cf800fdb45f9df9aa717ebc1c069fc8686a8e3e414f1c81d51f81d14"
+    },
+    "progs/mon_deflector.mdl": {
+     "bytes": 300016,
+     "sha256": "2bba37156abcde4ad2e7fc532a92b8139d4fc8041b565cd1e487829dc581341f"
+    },
+    "progs/mon_demon.mdl": {
+     "bytes": 156640,
+     "sha256": "9f1714fe997a78c9d3948e593a73fa3fe5704e11809ba095b8f564fca36b36c0"
+    },
+    "progs/mon_dfury.mdl": {
+     "bytes": 1495580,
+     "sha256": "0cb312b27bc1c9a7f9ac3d8c14e1e0d422d9968d4a9db0853d73185a19d6839d"
+    },
+    "progs/mon_dfury_glow.mdl": {
+     "bytes": 155140,
+     "sha256": "f743168f636c9e56475d73b3f8e139e5391e2abf0da4a6657174a7adc0f74238"
+    },
+    "progs/mon_dguard.mdl": {
+     "bytes": 724744,
+     "sha256": "1babb2976f1f86c2e499d3b8e83f4e4c04e434151bcb96a932a99a89b2bf3699"
+    },
+    "progs/mon_dguardq.mdl": {
+     "bytes": 176648,
+     "sha256": "f2f92ef84411d83c7e8c158f62b1415d8fc6aa56d77f21760dcd3080424cf6c8"
+    },
+    "progs/mon_dknight.mdl": {
+     "bytes": 1124632,
+     "sha256": "437c54ecfed53e34891b981a565c9b4f772c19702e1c099bba5ac40aabbed917"
+    },
+    "progs/mon_dknight_glow.mdl": {
+     "bytes": 971020,
+     "sha256": "22888d6171fc8df336fe686f4ffdfb0683bdb744e59cf81af9484b700666f6cf"
+    },
+    "progs/mon_dlord.mdl": {
+     "bytes": 1142583,
+     "sha256": "fb2ce7f5fbe369307f3eaefe0a74fffb2004657bec058dae50db651bc2fbc70f"
+    },
+    "progs/mon_dog.mdl": {
+     "bytes": 460652,
+     "sha256": "52cf8cb501f4b1ed457961b798eccd86974720af29f559723be82a0886824fd9"
+    },
+    "progs/mon_dprince.mdl": {
+     "bytes": 1022224,
+     "sha256": "aadd9ea12f307f0ef2b600a4a78d73082b8ea2eadd408f1fbe298082f4d03374"
+    },
+    "progs/mon_drole.mdl": {
+     "bytes": 241648,
+     "sha256": "2d5524d75cd52f12b42a5dfdd37bb33af27233394ec60bc234f79545d1cf13b4"
+    },
+    "progs/mon_dsergeant.mdl": {
+     "bytes": 1431784,
+     "sha256": "1affce6e3cbae9b5df1986672030fd869aa020972872767518f18ccc495c7432"
+    },
+    "progs/mon_eel.mdl": {
+     "bytes": 177368,
+     "sha256": "6acb4804e51e7de33404a4519d7f12b2413c921f61e33107345cb111ff156f96"
+    },
+    "progs/mon_enforcer.mdl": {
+     "bytes": 622480,
+     "sha256": "0e32f70f205a74995936d56e22259d1ccde591ed8a533577cd276419c5f60013"
+    },
+    "progs/mon_fish.mdl": {
+     "bytes": 311132,
+     "sha256": "40351e57dec8fad0aa34e5e5da233274e007a3beb80a291c9a2aa40ed43f8f00"
+    },
+    "progs/mon_floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/mon_freddie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/mon_fumigator.mdl": {
+     "bytes": 415072,
+     "sha256": "31bb90976e7489693c68fd6713ed5f1baf9645e3d7871922901dd093e8243da3"
+    },
+    "progs/mon_gargoyle.mdl": {
+     "bytes": 388132,
+     "sha256": "fe8134f2305858519445eb513b22f1f3382a1a6f334cf9549ddf1efe0b88435c"
+    },
+    "progs/mon_gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/mon_gaunt_elec.mdl": {
+     "bytes": 7164,
+     "sha256": "05129692bea7b62f2f5b7285cf133590e9356bfa0f6162ef6e3fc44508b29d8b"
+    },
+    "progs/mon_golem.mdl": {
+     "bytes": 632584,
+     "sha256": "c345c57eca380796f5dbcbdf7df80975c24e856d6d70ed1e9c11678f5d162c44"
+    },
+    "progs/mon_hknight.mdl": {
+     "bytes": 275836,
+     "sha256": "e32a90ca707224a389b7b0d3ecde76220e23f7746c2bc4e6397fe0d3a601844a"
+    },
+    "progs/mon_hknight_glow.mdl": {
+     "bytes": 212112,
+     "sha256": "60c24cb1dceeda2c64efb66e03cb8337717402c8070c0a19e1d9a6b5e0363d89"
+    },
+    "progs/mon_hogre.mdl": {
+     "bytes": 897896,
+     "sha256": "f8e0d054c44cf83bde03ee51ca8eb558dad7da336be8caf1383cf51d5b813da9"
+    },
+    "progs/mon_hogreham.mdl": {
+     "bytes": 979960,
+     "sha256": "d4ffb64b6112d48696002baf1bf8df0c686f404d1523ae409a9d01d237573e90"
+    },
+    "progs/mon_hogremac.mdl": {
+     "bytes": 901388,
+     "sha256": "daeed66878bbe85c45d2415de4270a8526be175ac74734ff55cf9750bf7c4875"
+    },
+    "progs/mon_jim.mdl": {
+     "bytes": 331872,
+     "sha256": "a49a51562fc5875509e39b62de550c4cebba65569708e1f63d0a54a6b8497448"
+    },
+    "progs/mon_jimrock.mdl": {
+     "bytes": 357748,
+     "sha256": "6c7e4a4f9b1b4392cf6e465be50e0a637a2a9b9b44b41e97a62acfc7b889f662"
+    },
+    "progs/mon_judge.mdl": {
+     "bytes": 1184920,
+     "sha256": "4e281291b8b6728bc6801c775defa987698a0f402a3a5553a32cf61865857040"
+    },
+    "progs/mon_justice.mdl": {
+     "bytes": 1287408,
+     "sha256": "bdd6b6ad28da26701dcef14503d148e96251575e04f583bef1f362455ab12497"
+    },
+    "progs/mon_knight.mdl": {
+     "bytes": 474244,
+     "sha256": "b279d87d180d237a71beddad02ecfaa87be42c990b91ee823f15f905fbb19b55"
+    },
+    "progs/mon_lostsoul.mdl": {
+     "bytes": 172216,
+     "sha256": "51c6d042ac9c670926d11743a09b294cbc992204077eae28b7b440570a7b0b4c"
+    },
+    "progs/mon_minotaur.mdl": {
+     "bytes": 669648,
+     "sha256": "3016ee951f60eb90a659c641546bc6aee80b1e2e9500b125c9c1343d625deb54"
+    },
+    "progs/mon_ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "ca0b6aee92201fa3ebeb226e7767c7a0f29495496d86bd384c327ff897b3557b"
+    },
+    "progs/mon_ogrefish.mdl": {
+     "bytes": 560428,
+     "sha256": "25edf562fbf71533ae0102832d92b7e138d056e1f90c9c681e5387659cd3160e"
+    },
+    "progs/mon_pyro.mdl": {
+     "bytes": 415072,
+     "sha256": "11a7efe7358b1477867a1263fd6e13a8531f557d1a8d0e0bfc5a1e9e6eab273a"
+    },
+    "progs/mon_scorpion.mdl": {
+     "bytes": 338288,
+     "sha256": "5d8a1b194cfc741b8dd194694dce305c35b0dca0bdf1c8d96897a085ad0eaf85"
+    },
+    "progs/mon_seeker.mdl": {
+     "bytes": 594628,
+     "sha256": "ab23bfb0c8b22c67b8d4b7b1658b445fb546fcc4f1ddb1f5c4990eb860434f3a"
+    },
+    "progs/mon_seeker_glow.mdl": {
+     "bytes": 594628,
+     "sha256": "122441a3be654d0198ba368ff9fd24d7f3fecb71fbafad6edfe80e3f57103ca8"
+    },
+    "progs/mon_sentinel.mdl": {
+     "bytes": 290664,
+     "sha256": "573efd78767922b2bbb3e5dab2b16cd8f90c2cb1709ecf4a315a141f4df77d09"
+    },
+    "progs/mon_shalrath.mdl": {
+     "bytes": 163336,
+     "sha256": "50b11e859246abf75af63b858d00b436690c9ed02562c0a7a3f434ed350c3a79"
+    },
+    "progs/mon_shambler.mdl": {
+     "bytes": 401092,
+     "sha256": "8f29b2ceddebcb9e69adbf12eb36c3924468cfaa1ff54cea31e6f289ab30e54a"
+    },
+    "progs/mon_skullwiz.mdl": {
+     "bytes": 980064,
+     "sha256": "c7637f2310ae9f173de872ea4aaf4380332f3d8d32782a8523f1d5d0a5ee3e45"
+    },
+    "progs/mon_soldier.mdl": {
+     "bytes": 931376,
+     "sha256": "8a67babdf47ecc69739e067d18b2629814469aec923851bd6c1133feae6ac56b"
+    },
+    "progs/mon_spiderb.mdl": {
+     "bytes": 228508,
+     "sha256": "209ee4dabf0f9b5619408cedcd8eaec7f8d4e48a8e1b51ca667bf5f8fea02dd6"
+    },
+    "progs/mon_spiderg.mdl": {
+     "bytes": 228508,
+     "sha256": "ffac4cf5b2d42df5b8a9674dc87c30ec925d6013d9ff0d29cb109c30047bcbd6"
+    },
+    "progs/mon_steelclaw.mdl": {
+     "bytes": 228508,
+     "sha256": "06fae126b984b1ed7b0ffa029b64e9b3df3a6269f01e8aba4b953bbafaa2c536"
+    },
+    "progs/mon_stinger.mdl": {
+     "bytes": 203428,
+     "sha256": "9d867b8a3d69a94d9a049c6cfcf0fa808b200ea3befe3b2518f1165881b9ad23"
+    },
+    "progs/mon_swampling.mdl": {
+     "bytes": 45332,
+     "sha256": "c7b379fcc17af3fbfaff1976ea8c14e9562093495dac01cd647c50863c4dec50"
+    },
+    "progs/mon_swamplingp.mdl": {
+     "bytes": 45332,
+     "sha256": "f1bd1496b4b9c90493f469bf81c6da0a1697290cd6374db15fd459ebab649cea"
+    },
+    "progs/mon_tarbaby.mdl": {
+     "bytes": 511008,
+     "sha256": "a9b9b6a49090bbf7d7d3a23618c3c21b2123e007488702d96b80531c563cdd4c"
+    },
+    "progs/mon_voreling.mdl": {
+     "bytes": 45332,
+     "sha256": "af233d21d6f0ea66267ba1c562ba223e1077bd07894333327ce12a6202938411"
+    },
+    "progs/mon_vorelingp.mdl": {
+     "bytes": 45332,
+     "sha256": "dadf32a61ef1ec6361606fc7173bab53f6c42e62dea9a3100a2073ffc5afaa58"
+    },
+    "progs/mon_wizard.mdl": {
+     "bytes": 106596,
+     "sha256": "aa93bbe4e7fd1686fcea4d6c49a982bb8b3defea2ca85c3177b86000ba8ba8e4"
+    },
+    "progs/mon_wraith.mdl": {
+     "bytes": 374256,
+     "sha256": "f2ec454f0e2896252204a99b18c16a5e61ae783220503a6b0ec75e149d1b25f7"
+    },
+    "progs/mon_wraith_glow.mdl": {
+     "bytes": 133676,
+     "sha256": "bc630a16b46ae0ef1fba35acaf4e41bc46dee4070305d32e9215692a18ae5705"
+    },
+    "progs/mon_youngone.mdl": {
+     "bytes": 103208,
+     "sha256": "de6f7f98d021ae2839cc81490886e6f29dfa31b5b45216d15ffb7f74edf1eb36"
+    },
+    "progs/mon_zombie.mdl": {
+     "bytes": 381660,
+     "sha256": "2dfc9832316861cff07f1c86da0f8809de95395a9dac718155bdbd06f739acaf"
+    },
+    "progs/mon_zombiek.mdl": {
+     "bytes": 228232,
+     "sha256": "431f57d3241b1253a1346ff1aa2bd7135f67c3e6fd5031140e07a7b4a0e861a2"
+    },
+    "progs/player.mdl": {
+     "bytes": 976432,
+     "sha256": "137eab1a3853f9a6f7f84c05442f7066268cac430bf73053cc7f806555a98925"
+    },
+    "progs/proj_balllava.mdl": {
+     "bytes": 18356,
+     "sha256": "f2a1de49bd215b4c7a1f424f1c644fe5cdb52df3c2d664c24b75cd2f389ae559"
+    },
+    "progs/proj_ballslime.mdl": {
+     "bytes": 18356,
+     "sha256": "d17f20cd8db385b724d58beaac1c3ed6b2597d51d00f1996b8b02bdb8a5e3ba1"
+    },
+    "progs/proj_blord1b.mdl": {
+     "bytes": 11472,
+     "sha256": "6c05b0f8790b77d3362166b2b304379942f56d498ae8fc365dbee6fcd6031f67"
+    },
+    "progs/proj_blord1s.mdl": {
+     "bytes": 8284,
+     "sha256": "5527dd12f00911fb333c2424994c0a95881caa72612d5e8236c8ce75530f6ae0"
+    },
+    "progs/proj_blord2b.mdl": {
+     "bytes": 11472,
+     "sha256": "fce6943e84bac672bf110d986ce2ed1ccb511128cb28508fb6aca53c7655806b"
+    },
+    "progs/proj_blord2s.mdl": {
+     "bytes": 8284,
+     "sha256": "a0d0ac315e46f784c35a0eac902f625e0337e79275b9f02ecb56002848202734"
+    },
+    "progs/proj_blordbeam1.mdl": {
+     "bytes": 12244,
+     "sha256": "e01c569bf66e75acdcbbfdbb50062eb24dd09f0415e6cb79148eab960f6a6f0f"
+    },
+    "progs/proj_blordbeam2.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/proj_blordbolt1.mdl": {
+     "bytes": 7868,
+     "sha256": "2ea0a49a8a75d1174151c36851ae21212b4df2df3473be5e73cc4cf293332d0f"
+    },
+    "progs/proj_blordbolt2.mdl": {
+     "bytes": 7868,
+     "sha256": "919dda70fe618cd37f57ef1e0dbc00b339ed082e2661ca024febee3ed49576f2"
+    },
+    "progs/proj_bolt1.mdl": {
+     "bytes": 1556,
+     "sha256": "890f6cd6faf7c36954185c4566a2cca619e627d5b365f05e1bffc7e12ac00ace"
+    },
+    "progs/proj_bolt2.mdl": {
+     "bytes": 1748,
+     "sha256": "ba4a6ffa3785b0e41c15045df9621a5a33f094eae2161064d472ea939654e229"
+    },
+    "progs/proj_bolt3.mdl": {
+     "bytes": 1748,
+     "sha256": "cf255497525c53162b019fe3df536314c4661a2d270f6bb847fe39a158b7f4e8"
+    },
+    "progs/proj_chthon1.mdl": {
+     "bytes": 65636,
+     "sha256": "92a964527d72ef1c40bbcfe0e915b56df81a0dcc2165ca4be47db44a8d644eb1"
+    },
+    "progs/proj_dguardq.mdl": {
+     "bytes": 12660,
+     "sha256": "ba5cba46edc108572d78e66166f5ed0405a48dcf672e7a569d14a4397f85f285"
+    },
+    "progs/proj_diam1.mdl": {
+     "bytes": 3292,
+     "sha256": "e7cbd736a84791c5234caa14713b3e0f6077409509845ae0b1993f38c2f1e1b9"
+    },
+    "progs/proj_diam2.mdl": {
+     "bytes": 2748,
+     "sha256": "b23586b1d570a9f516f6b83ea0af6ec1d8fe5693f8cd1279b251b031ba142d8c"
+    },
+    "progs/proj_dk.mdl": {
+     "bytes": 5172,
+     "sha256": "e861a125a60c82b88c7b3c23184a1485c967d0e127b4536213b7f46a97a6430e"
+    },
+    "progs/proj_dkgrn.mdl": {
+     "bytes": 5172,
+     "sha256": "820d2dac7255db7220889f6d8c3a2c97a7f77f75cd9ffbec6319b0ee257b3984"
+    },
+    "progs/proj_dlord1.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_dprince1b.mdl": {
+     "bytes": 6644,
+     "sha256": "7bcea6065d9f6c4e8a3a7c8a1dcd61252ff8baee01b7c04ecce0a7cfbc6d690d"
+    },
+    "progs/proj_dprince1r.mdl": {
+     "bytes": 6644,
+     "sha256": "5e3cc794f6b980e5e22adf011eead8768c88dcd84d74be9a8d34caebf33bf2ba"
+    },
+    "progs/proj_dprince2b.mdl": {
+     "bytes": 7468,
+     "sha256": "e81b4f767d1bba042464f1d35314ef4f2d30f7c552aaada2f772aba61fc5d62a"
+    },
+    "progs/proj_dprince2r.mdl": {
+     "bytes": 7468,
+     "sha256": "b967299e12983dacd0fcca1672818281483e6f89746422de285002cb043e1e24"
+    },
+    "progs/proj_drole.mdl": {
+     "bytes": 20796,
+     "sha256": "fbe9acdd31f7be2321df29b6add3d287d4e86ea2581e56ace5d7e9d185e28127"
+    },
+    "progs/proj_drolegrn.mdl": {
+     "bytes": 20796,
+     "sha256": "efbede1f5d565c56a535bb6392b5e638133c99b1df8bf93b1a1918d01c790123"
+    },
+    "progs/proj_eidolonrock1.mdl": {
+     "bytes": 14084,
+     "sha256": "e085fa791a83489e41c19c623ae84f80c7bc5f767cbbf691baa4665d3f85b273"
+    },
+    "progs/proj_flesh.mdl": {
+     "bytes": 19768,
+     "sha256": "8ff3f0f61001ac8e67317e4e01d03d905f15ef4104c141ba07b5ddb0c972390e"
+    },
+    "progs/proj_fleshp.mdl": {
+     "bytes": 10196,
+     "sha256": "3def912801c4b1b9b4c0f8ceea0690241493a5dd5f17e098cd6c37cefd927893"
+    },
+    "progs/proj_fury1.mdl": {
+     "bytes": 6644,
+     "sha256": "ce55af61fbd87b8daeb14151b3f77ac64713c4b53fcca89b2150d7f5cdfe886d"
+    },
+    "progs/proj_fury2.mdl": {
+     "bytes": 5748,
+     "sha256": "deb557248017e92f5501698355577cebb91c0d825b77a79f828589769a41ece7"
+    },
+    "progs/proj_gaplasma.mdl": {
+     "bytes": 2328,
+     "sha256": "dd3b4559cb4e4439ae87255ab2958c6c2cd3796ebbd27aaf1c6abc768ad4f8ad"
+    },
+    "progs/proj_gaplasmagrn.mdl": {
+     "bytes": 2328,
+     "sha256": "ecd2fdf0eb904f8be43c41821b06443d32a581b768ce8f776b07670b49cdd9af"
+    },
+    "progs/proj_gargball.mdl": {
+     "bytes": 18184,
+     "sha256": "b4b6bd7646bf80aa6f481616ba2b531dbccd3568cacc54885ebf020a166dbadd"
+    },
+    "progs/proj_gargballgrn.mdl": {
+     "bytes": 18184,
+     "sha256": "467a44838d83a94d5716c9af6f8c860cd8ec583ddb5f260cb0dd16e9bd04b957"
+    },
+    "progs/proj_gargoyle.mdl": {
+     "bytes": 5748,
+     "sha256": "774f52126fe6598f6a01a032691a36de26a0669e93d47508689d08fe85f46c21"
+    },
+    "progs/proj_gargoylegrn.mdl": {
+     "bytes": 5748,
+     "sha256": "b293b5e8696098e77602eb065f68f8a8e15c82af1c9890d36de48f29afbf43fe"
+    },
+    "progs/proj_ghook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/proj_golemrock1.mdl": {
+     "bytes": 7468,
+     "sha256": "5a2f0435dbcbfea724fe6bd8f6a76296359dbf4d874d15feec82b50a9275da74"
+    },
+    "progs/proj_golemrock2.mdl": {
+     "bytes": 19756,
+     "sha256": "41cc9bc49d6ae2018b7cf5345bbfe52517db2da060fce23fe57300ebcf643f98"
+    },
+    "progs/proj_golemshard.mdl": {
+     "bytes": 8596,
+     "sha256": "4a4a59362f5c5ecc2c4ce56419088982d5ed79a02d3c5b5a49bafd4c21c85e42"
+    },
+    "progs/proj_grenade.mdl": {
+     "bytes": 3508,
+     "sha256": "a7916ab1f9872689a0cfbea62543974b37dae5b3ec7ae3165eecd81c2c0d6617"
+    },
+    "progs/proj_grenadegrn.mdl": {
+     "bytes": 3508,
+     "sha256": "896f7a740acb59351891e752e6cc92725fcc6e26ea4bd5d1eb3219c8443db743"
+    },
+    "progs/proj_judger.mdl": {
+     "bytes": 7868,
+     "sha256": "a12f1f0bf494bc027c43e5aa89e54e055a571226499fbddce0f6b9e2bdb63766"
+    },
+    "progs/proj_laz.mdl": {
+     "bytes": 4724,
+     "sha256": "94e8c7d09857559ad9e5aaf6361b596afbcf100cf0ce8abf0107318af28c7943"
+    },
+    "progs/proj_lazblue.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/proj_lazgrn.mdl": {
+     "bytes": 4724,
+     "sha256": "d07d736b788aa512a5e57f39596c187644e69491026382800994378d3e849a6f"
+    },
+    "progs/proj_lightning2.mdl": {
+     "bytes": 11860,
+     "sha256": "c9cebc8d6f4836e7c302d51d0f942fde3da0960dae38733ccc3a851776e71520"
+    },
+    "progs/proj_minoball.mdl": {
+     "bytes": 18184,
+     "sha256": "756d8e9ecd60abc23954a792833c565ee1b5c905106ad2bd98143f56b0410391"
+    },
+    "progs/proj_minoblood.mdl": {
+     "bytes": 8284,
+     "sha256": "badd72734b86dd9bc11c5469bef944b6aea6b84071b07b44703c1ca62dd4dee2"
+    },
+    "progs/proj_minoplasma.mdl": {
+     "bytes": 8284,
+     "sha256": "cd79d0dce08293ded22b08b3a7134d8e52fc4cff10e07ee691e6ab53011a9ea9"
+    },
+    "progs/proj_minopoison.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_ng.mdl": {
+     "bytes": 1364,
+     "sha256": "cff312dd07f629847dd5e37b6ab00243d51ff7e40fc795f3612e68614cfbbe24"
+    },
+    "progs/proj_ngred.mdl": {
+     "bytes": 1364,
+     "sha256": "a1ec22733cc292a470c23990b8d0929bf5ee88844190d7174d9053109443d0dd"
+    },
+    "progs/proj_nour1.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_nour2b.mdl": {
+     "bytes": 14084,
+     "sha256": "9c7650dba595e8f8b2bacf3141252a5a2917e0204d3326661d6b9608fc8df2b3"
+    },
+    "progs/proj_nour2p.mdl": {
+     "bytes": 13152,
+     "sha256": "4051fc3dec1155a9efbc6bc5aab947447cebff83bec38d8c1e43dd1bd51f4611"
+    },
+    "progs/proj_nour2s.mdl": {
+     "bytes": 7468,
+     "sha256": "285570bdd658dfed133399c16f1586e2b2389f537a9d4b54d2dd5c1f8f6f1aa9"
+    },
+    "progs/proj_pgplasma.mdl": {
+     "bytes": 13152,
+     "sha256": "3c04f32bbf6f0623fc4101a31a0ce2d40c93354430433d91c2caed263284531e"
+    },
+    "progs/proj_plasma.mdl": {
+     "bytes": 4724,
+     "sha256": "6c4399ddc7653a9aa7834162d38dce6368dc271fec46a7830b73939351d7142a"
+    },
+    "progs/proj_plasmagrn.mdl": {
+     "bytes": 4724,
+     "sha256": "b2941e69d90a5e97c98a03a98bd52c4e047aa23dd2a1abd9ab6d3938f595732f"
+    },
+    "progs/proj_ringblast.mdl": {
+     "bytes": 135704,
+     "sha256": "e6de9bfd15db4bbf16fdd41b50204c5090ce09adbe132b1453435d3c8646cb4d"
+    },
+    "progs/proj_ringshock.mdl": {
+     "bytes": 18928,
+     "sha256": "f1a0a77edc79f2466b866a5486b29f92b696368137eb7eff9b137b6b66d65952"
+    },
+    "progs/proj_rocket.mdl": {
+     "bytes": 7812,
+     "sha256": "52d549b217c6f34e1d68248899ec5f5f550ef729929910e5953e114a53b3c251"
+    },
+    "progs/proj_rocketgrn.mdl": {
+     "bytes": 7812,
+     "sha256": "313f381553df0d8468ccb981441bf415130c9c730377d877e397511b8cc864f7"
+    },
+    "progs/proj_scorpion.mdl": {
+     "bytes": 6612,
+     "sha256": "1a2fa47a30a7e8026bacefa1f52580a04e10c48571318effab3e0623ebcc919e"
+    },
+    "progs/proj_serg.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_shal.mdl": {
+     "bytes": 6644,
+     "sha256": "dc62e9641d1328b1cfd20ac4f4df7e56b2f42bd40a22eea186f2784d1f5bc4ba"
+    },
+    "progs/proj_shalball.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalegg.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalgrn.mdl": {
+     "bytes": 6644,
+     "sha256": "6dfdef0a204aded86ef24730985f13acc5076d1bbb4b9ec1140b7333a70f4d0e"
+    },
+    "progs/proj_shalhome.mdl": {
+     "bytes": 8632,
+     "sha256": "e882b1dc5d01882f429b3a88f752431d3b38dad297861209b589330e3507f37e"
+    },
+    "progs/proj_shalhomegrn.mdl": {
+     "bytes": 8632,
+     "sha256": "d84be851bd87603186bf907506eabb9ce110c5a265c1cc884d18923361fdf4d9"
+    },
+    "progs/proj_shalshell.mdl": {
+     "bytes": 7468,
+     "sha256": "8c1591cc767fadabad655bfaf3a80362b264f51e0a1be67476b9272c2401afbd"
+    },
+    "progs/proj_shamlit.mdl": {
+     "bytes": 35240,
+     "sha256": "787c23ca986d469080879953e49b193cf0b2d22dff050a1d781ba039fcc594e4"
+    },
+    "progs/proj_shellcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/proj_shub1.mdl": {
+     "bytes": 18932,
+     "sha256": "c1a04846b791a123ecb367f11b35f4c1cc1e7e62e1d0f62ff1dd75978a712495"
+    },
+    "progs/proj_shub2.mdl": {
+     "bytes": 32860,
+     "sha256": "3d22df8151caf23c1ad7f3e28f83f97ca7503164977f1994dca2cc2ee54f84b9"
+    },
+    "progs/proj_skullball.mdl": {
+     "bytes": 9984,
+     "sha256": "41b3c1225070dcfca79f1bf19a2833e3d68144945fba51c8ce44d8029379906b"
+    },
+    "progs/proj_skullwiz.mdl": {
+     "bytes": 33588,
+     "sha256": "ff00ce3fbf9d0d55f6488a3a0a6bf15d2105b6e94489eec296a5851bf9f4f890"
+    },
+    "progs/proj_skullwizp.mdl": {
+     "bytes": 33588,
+     "sha256": "45fe8396037d88852d3e6937749bade4ef7c00d3c8240eeb0ecba4b56e831df3"
+    },
+    "progs/proj_smoke.mdl": {
+     "bytes": 244,
+     "sha256": "816e888f8242af86812bd581c9e93212c28f108699b70eb10d3e025f27a2818e"
+    },
+    "progs/proj_sng.mdl": {
+     "bytes": 1396,
+     "sha256": "b2a8656aee7ff508737afe1fdbf1a93d6958b33a0c31bae247a3979c616bdfe1"
+    },
+    "progs/proj_spider.mdl": {
+     "bytes": 7468,
+     "sha256": "76be6023b50a3b57c73f08c5758a693098ce8762eb92b55540d8bff2680fde4d"
+    },
+    "progs/proj_swampling.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_voreling.mdl": {
+     "bytes": 7468,
+     "sha256": "ab16a7fc8bf36827f4944ebe6919876acb5b2eaf869ff59f89ed237565a7ca9a"
+    },
+    "progs/proj_wiz.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_wraithball.mdl": {
+     "bytes": 22284,
+     "sha256": "24d62690c6347f9ab71ef5900c70d256346c2dfdc26e5488c3b91f220224c923"
+    },
+    "progs/proj_wraithbone.mdl": {
+     "bytes": 6612,
+     "sha256": "8fa994dd2c7a5e9d7140ae394d07d368d083f4cee6808f6d9d026ec464804503"
+    },
+    "progs/proj_wraithegg.mdl": {
+     "bytes": 9984,
+     "sha256": "5b888e26f90cfe26800cd50d422b4ef75487dde61d63fd34965506591b326a8f"
+    },
+    "progs/proj_wraithpoison.mdl": {
+     "bytes": 6612,
+     "sha256": "02a06fdccb8f7ba595ea71f227e5b256995e782bcc9ce75bcb85a31ed0333256"
+    },
+    "progs/proj_wraithshell.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_wraithtrail.mdl": {
+     "bytes": 24544,
+     "sha256": "23ee065ea4a542ee7348d9bc08e052ffca4e272418b81937105d14730aab705e"
+    },
+    "progs/s_bookrune1.spr": {
+     "bytes": 1140,
+     "sha256": "b9fc52d2ca728fffa4c282d818b68aeec3555a0dbad3cd1507199d534db1f047"
+    },
+    "progs/s_bookrune2.spr": {
+     "bytes": 1140,
+     "sha256": "400a620928e3581891e8a71b338c8a53b6387e0acdc3fda3f10ae27596ae6bbc"
+    },
+    "progs/s_bubble_blue1.spr": {
+     "bytes": 1140,
+     "sha256": "27cb0d1f52e3ecd4b7ae0d9dc96078a7554bde09839f1a2ee2d9772ac5d67981"
+    },
+    "progs/s_bubble_blue2.spr": {
+     "bytes": 1140,
+     "sha256": "d540bb04a7835ec3bd7490904fbafde0f3aa64ba559bb6bd99ab538568ec0cae"
+    },
+    "progs/s_bubble_brnd1.spr": {
+     "bytes": 1140,
+     "sha256": "43591346d87a547454b387220b3c32693e7f1563b6ae4152ff7ee96c24936b84"
+    },
+    "progs/s_bubble_brnd2.spr": {
+     "bytes": 1140,
+     "sha256": "2f185b37bd1cd5a8d6b472885469dbdb3f1b0fdeba2a6d620de09b17646b4fc2"
+    },
+    "progs/s_bubble_brnl1.spr": {
+     "bytes": 1140,
+     "sha256": "370ed3a9f77291522c31ac1d0ce414078d9b3eb40a9157c08ad5cf87d6428897"
+    },
+    "progs/s_bubble_brnl2.spr": {
+     "bytes": 1140,
+     "sha256": "1b3d4f0ac00fa7cbce076d334f4b210b9059afbf2c4b07a0e98e88fe57356351"
+    },
+    "progs/s_bubble_grey.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_grn1.spr": {
+     "bytes": 1140,
+     "sha256": "efa8692bb74428af2753b415f8f08edbfc2b2cbe75cc59f6545985d289d6016f"
+    },
+    "progs/s_bubble_grn2.spr": {
+     "bytes": 1140,
+     "sha256": "3062ba1064da37ecf7dad074a9b0437352865fa43aecf783e4afe8a6c8c104c2"
+    },
+    "progs/s_bubble_pinkyel.spr": {
+     "bytes": 312,
+     "sha256": "5376726ffdf2132d3ab712ba23b408e8068500485f11adff85d0fd90c08248c6"
+    },
+    "progs/s_bubble_purp1.spr": {
+     "bytes": 1140,
+     "sha256": "2e4b7b23b08b6e89d2dc46f26b12b9ad1ee8f91ea868aeb9916d2adb42e00b75"
+    },
+    "progs/s_bubble_purp2.spr": {
+     "bytes": 1140,
+     "sha256": "ae21a26ad7897b9c5d201a1eb248e1358ee84eafdbfd899d679558e9aa5a1a66"
+    },
+    "progs/s_bubble_red1.spr": {
+     "bytes": 1140,
+     "sha256": "2a52f2c4dfdae381deeca608e5d007afe9dc245bbe16fea88c88f39c10ff7dc6"
+    },
+    "progs/s_bubble_red2.spr": {
+     "bytes": 1140,
+     "sha256": "fffcc0e03f9acc75e05636ab67f5f647568c81d0bcf4623e64d487c04d9cd5eb"
+    },
+    "progs/s_bubble_wht.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_yell.spr": {
+     "bytes": 1140,
+     "sha256": "9dcce864ad255b17d7d45e5c5531114f6a66c4e9cb549fc8b31aef0af5a9157f"
+    },
+    "progs/s_burst_flame.spr": {
+     "bytes": 22128,
+     "sha256": "66511ada8a299b0882e2939c09d3fb726d3ce52ecb93a884584a9ce11915a6c0"
+    },
+    "progs/s_burst_flamedp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_poison.spr": {
+     "bytes": 22128,
+     "sha256": "d8245e0460efc4e939a187912126f44422c39b1fe4b553c2c15da91833e8549d"
+    },
+    "progs/s_burst_poisondp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_burst_steam.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_dotmed_blue.spr": {
+     "bytes": 1140,
+     "sha256": "0b3160c5a4ae42216ddb7aaa7ae4726f6b2507c914328abe3c69f2d12fd921f8"
+    },
+    "progs/s_dotmed_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "6e28b69544f8aa13ccbb9a66893e4ab86b83639ee3f81dbbe1b94290ca9b03ef"
+    },
+    "progs/s_dotmed_grey.spr": {
+     "bytes": 1140,
+     "sha256": "77c226763e90a54b4d6835bd877c08c501605e516e64177c915c422e7b36c207"
+    },
+    "progs/s_dotmed_grn.spr": {
+     "bytes": 1140,
+     "sha256": "d1a9800a8b5cad01fa1dc93e57162e9960c4a8478e7e427d66cdbfe6a6797266"
+    },
+    "progs/s_dotmed_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "6113140f371b08cda9addcf68282c1fc16692da7498fa2fdfe2b99662e345d67"
+    },
+    "progs/s_dotmed_purp.spr": {
+     "bytes": 1140,
+     "sha256": "8b2cfa67ac86841f59409e184b4f3a253218e5930a5e3f241caef39dc1baa8de"
+    },
+    "progs/s_dotmed_red.spr": {
+     "bytes": 1140,
+     "sha256": "4ae92a280e0df01c0acd0a904214af485bb60919e5ded4573aa12f86875182d4"
+    },
+    "progs/s_dotmed_tor1.spr": {
+     "bytes": 1140,
+     "sha256": "eddd46a4818dfa92a9817df82e893d6bf6513160164a74b95bdd42fb7cac2f75"
+    },
+    "progs/s_dotmed_tor2.spr": {
+     "bytes": 1140,
+     "sha256": "dcb87897de0f54a6d8f78e9194a15c11261eb88455f058b334f8648a363159a9"
+    },
+    "progs/s_dotmed_yell.spr": {
+     "bytes": 1140,
+     "sha256": "e6b72aac439291d7719ee78d9520c1a1def36212ac7f61ba333fa87d5265c63f"
+    },
+    "progs/s_dotsml_black.spr": {
+     "bytes": 632,
+     "sha256": "2ae7fa13584d12f04b337fbbd774e74fbe54a6fcbd354239e97fecce931bd377"
+    },
+    "progs/s_dotsml_blue.spr": {
+     "bytes": 1140,
+     "sha256": "c0149109ae73a72da49bfaf9ba00cf2edadbe0f053928d09319083e6247883ad"
+    },
+    "progs/s_dotsml_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "f95fe813ecce2c69d2b72e5bf870d045037519c89f3da9a300e7453754cd1503"
+    },
+    "progs/s_dotsml_gold.spr": {
+     "bytes": 1140,
+     "sha256": "3833e80c32da39063b5069638ade52c4aee51b7db7206b4911cb48f321e25bdc"
+    },
+    "progs/s_dotsml_grey.spr": {
+     "bytes": 1140,
+     "sha256": "2e16d9ff8ceca2994a609703f405b1efbb7b49e02c8dbb9e77d0cdcaf3318b98"
+    },
+    "progs/s_dotsml_grn.spr": {
+     "bytes": 1140,
+     "sha256": "a2735123addacfa03f2666969e476af0d9f1cfefbef75a7ac9599d48f86226b1"
+    },
+    "progs/s_dotsml_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "ebf62caae17163587aaa3652300f1003c008ed21041b838a14cfff7672f87d90"
+    },
+    "progs/s_dotsml_purp.spr": {
+     "bytes": 1140,
+     "sha256": "476042db782f7f81cb53d91e9518881f28eb34d3a2a535c11d9c22f65518bce4"
+    },
+    "progs/s_dotsml_red.spr": {
+     "bytes": 1140,
+     "sha256": "94c0403ee7f1e6f6c4d6bc9b99e73e48143845fe35d0d6b3de246842241b12cb"
+    },
+    "progs/s_dotsml_wht.spr": {
+     "bytes": 1140,
+     "sha256": "7ac2d5b9b1e14a1799b951ace16bcc1addb7fefc2470dec23ef2ca110a934bf5"
+    },
+    "progs/s_dotsml_yell.spr": {
+     "bytes": 1140,
+     "sha256": "686f220b937040b91b6ff4f05efd41525d40eb80a61ff8138809d550bfa99959"
+    },
+    "progs/s_dripblue.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/s_dripgreen.spr": {
+     "bytes": 60,
+     "sha256": "805935ef90e14eda0f0ec89cc7e03acf52df768eb9e09140629bc1067a658774"
+    },
+    "progs/s_dripred.spr": {
+     "bytes": 60,
+     "sha256": "2dc81cd44438e124dedef0b656c31a066b7879940fcdbc39a0cfd57a6d2985e5"
+    },
+    "progs/s_dripsplblue.spr": {
+     "bytes": 828,
+     "sha256": "6b960ccc7a877bf2b4b67467400c0eaa1bb88d8c8a524458b9bf8d1aa1a6e29f"
+    },
+    "progs/s_dripsplgreen.spr": {
+     "bytes": 828,
+     "sha256": "397ac392598027c27240d71079f79eb9c90306724bc54c5d9854e14939059b6c"
+    },
+    "progs/s_dripsplred.spr": {
+     "bytes": 828,
+     "sha256": "268b48b87a0f352b671c04a1f7325af43372578a6d73269356389280eb7ef232"
+    },
+    "progs/s_exp_big.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_exp_electric.spr": {
+     "bytes": 5256,
+     "sha256": "ed01b728b6656a68acffe258d644712eba3b786434ab6b3e6d90434031e90d96"
+    },
+    "progs/s_exp_ice_big.spr": {
+     "bytes": 164076,
+     "sha256": "bf7317d811349602db7a020da3e77065ffd8158a3104e83ddca3b166566df18c"
+    },
+    "progs/s_exp_med.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_exp_plasma_big.spr": {
+     "bytes": 213288,
+     "sha256": "fe99a489e169ccf56f0412c2e83a7c5aea7b75b7cee0501402c62fcbd7ca969c"
+    },
+    "progs/s_exp_plasma_small.spr": {
+     "bytes": 53544,
+     "sha256": "555e39e88cedaf9e9dd1215ad1325b32019a6bf2654d53736b1f362506548150"
+    },
+    "progs/s_exp_poison_med.spr": {
+     "bytes": 72892,
+     "sha256": "60b7a8c194f3a6cd2241edd6223ac1da1f57811d7f5416216c70a2797d1baf20"
+    },
+    "progs/s_exp_poison_small.spr": {
+     "bytes": 53544,
+     "sha256": "2a54104dec9381afe338574d66bcc19bd2776caa0d46031c743cd24782098d3f"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "a9476d95ea10fbd2317c174272864efa4bb6e939893f3a3de520aeea3e3522d9"
+    },
+    "progs/s_flamemed.spr": {
+     "bytes": 43324,
+     "sha256": "3c645e305673693089fe48cc7a22f694eeaf7881cfc94ff7b1c4b05b718342cc"
+    },
+    "progs/s_flamesml.spr": {
+     "bytes": 21820,
+     "sha256": "5e60165461c34a3a25cbe6b0bb5e36131bb4a81fef384f1db4a7236f30e7ba95"
+    },
+    "progs/s_flametiny.spr": {
+     "bytes": 11068,
+     "sha256": "9d2c0af6139f3d194e73dbcb7880aa0a6f2a04019f94818ce9844691399b551b"
+    },
+    "progs/s_judgemagic.spr": {
+     "bytes": 12564,
+     "sha256": "6d08d5ada6bac219927edb39a93302f98b7b1a357e6648fc1abb49fd5cc3bd4c"
+    },
+    "progs/s_marsh_med.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/s_marsh_small.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/targd_hull2.mdl": {
+     "bytes": 3380,
+     "sha256": "520c82906942d582c6b64da4dca32ca8ed236694607c3a19ec71b89136e0c757"
+    },
+    "progs/targd_massive.mdl": {
+     "bytes": 17076,
+     "sha256": "099ed67733ea3a461c2247d6f07d3dadcc5a6968bcd6a03398507c653d174395"
+    },
+    "progs/targd_short.mdl": {
+     "bytes": 4788,
+     "sha256": "c883300477d3978469aabc35ef3969c14645c1111997c64452634fc8b4a978e1"
+    },
+    "progs/targd_tall.mdl": {
+     "bytes": 4788,
+     "sha256": "bab77599f9cbbe1cf0856a642612ae30b08fed9ae27a209abda30f6dc8c07129"
+    },
+    "progs/targd_wide.mdl": {
+     "bytes": 17076,
+     "sha256": "d40a00625196f67fe26f3611cd91dd33484ddbf3db273766f8a5fac38db07b07"
+    },
+    "progs/trap_pendlong.mdl": {
+     "bytes": 44900,
+     "sha256": "62d3b86fea6e2336dfc5c7b93514e096eba05992a3bd3e0c6571e4c4a27be684"
+    },
+    "progs/trap_pendshort.mdl": {
+     "bytes": 44900,
+     "sha256": "efb3e395093e34d7b16c92ed73abb199a28d0bc653522c13d4e720030f547713"
+    },
+    "progs/trap_sawblade.mdl": {
+     "bytes": 28716,
+     "sha256": "759bd7e1f7629b4d87ecb9e53a9f2d66e3e81b9103bc4eab3f85bd598eba36f6"
+    },
+    "progs/v_ghook.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "5b6b84edc6e6c58128a6e830ec35424cc83e69fab7b1337c4c681d8d0ed81e74"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 48964,
+     "sha256": "d073c7fad7dee2c4664aa401d744024b623abcd65e60a4c7066721b988838aff"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 54940,
+     "sha256": "c0a6b7d9664b0ab5a0c77732b22592dedfefbf65c624c05bec7aa8d60835f74d"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 39668,
+     "sha256": "78fc36ddbd33fb77192ef100547f1a1a0f70a38fdaac7094df67f2df33ca9237"
+    },
+    "progs/v_shadaxe0.mdl": {
+     "bytes": 97860,
+     "sha256": "598f555a854590a749eee83870a869ebfa8dfd3c84ad447b7fe3fb796ea1da80"
+    },
+    "progs/v_shadaxe1.mdl": {
+     "bytes": 97860,
+     "sha256": "2ffbb3026a21d70a73a091222cc4f2ea2ba6abd706fbffc276f027b9475abfaa"
+    },
+    "progs/v_shadaxe2.mdl": {
+     "bytes": 97860,
+     "sha256": "cd2a7a188f73c5b841183885663470c53c3af5646491f44811a4a0f192381ed7"
+    },
+    "progs/v_shadaxe3.mdl": {
+     "bytes": 97860,
+     "sha256": "b1c0dd11ce314003de5051f8a3b9581ee3eda5ea347d3d3371eea43051820197"
+    },
+    "progs/v_shadaxe4.mdl": {
+     "bytes": 97860,
+     "sha256": "81108f8b2484d24e54e9ab3ee5b707be5ea28adb142159412aa773ae01e593c1"
+    },
+    "progs/v_shadaxe5.mdl": {
+     "bytes": 97860,
+     "sha256": "0d3ca1664ee82ab2aed6261c262fdc455db981ecd2d62371595e520756d7bb22"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 22260,
+     "sha256": "bf79b703708665b9e65556bf68c0fe9d177097b2b96b11563d7b8bf84485a81b"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 22764,
+     "sha256": "5a51ba87bcdf37463bb8f34dd7259ea2be54d540fbc59798bb62dc24b2d3e777"
+    },
+    "progs/v_shot3.mdl": {
+     "bytes": 77868,
+     "sha256": "5b08bebaeb2fa054e6bb37d51c716cfac0e4da843b0db158a4a9769fa04ad13f"
+    },
+    "progs/v_zershot.mdl": {
+     "bytes": 62604,
+     "sha256": "4173bb2b84f9adce1957a87251cca591d968c3a54e801b170a87aae82539a2b1"
+    },
+    "progs/w_backpack.mdl": {
+     "bytes": 138832,
+     "sha256": "78d86e7bc605746990a1b10644b12542f3380375693d4fb015884e42269314a0"
+    },
+    "progs/w_blueflail.mdl": {
+     "bytes": 17236,
+     "sha256": "3b645ebcb5d2249c9cf904e17006b85aa05963efda33f45f5b6f6fc3ea188d26"
+    },
+    "progs/w_chainsaw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/w_dcrossbow.mdl": {
+     "bytes": 14388,
+     "sha256": "52b14c48ec77acb261f18e1d7903e360eb96acb5c22a0702dfde90c66b103064"
+    },
+    "progs/w_dfurysword1.mdl": {
+     "bytes": 8916,
+     "sha256": "16521de90d0e71090ef4e6b5904252f3ae2d4a38ebe99eff9dc758ea009b0f90"
+    },
+    "progs/w_dfurysword2.mdl": {
+     "bytes": 8916,
+     "sha256": "2e42b37254cf8d85b098e58143fd77d86bed2f3568f630196326841298d07187"
+    },
+    "progs/w_dguardsword.mdl": {
+     "bytes": 8404,
+     "sha256": "74b884b8fd0a785fc2c1dcc29428b8d4c8725de6963bccf7ec80c396e002fa38"
+    },
+    "progs/w_dknightsword.mdl": {
+     "bytes": 8404,
+     "sha256": "1e6729ae15dd1520fff7f4c1c30260c35b637bd0b23b8fb3a5a476b175a39165"
+    },
+    "progs/w_dprincesword.mdl": {
+     "bytes": 19296,
+     "sha256": "89e5ef1382e980b68e812f7e8f6a9b6fba34af42bb2def457b7a2f6f8d7388b7"
+    },
+    "progs/w_enforcergun.mdl": {
+     "bytes": 42612,
+     "sha256": "fbbfd121a3d085d654aab512cfebb0b6890daf3c403f25ca372edc3c53039375"
+    },
+    "progs/w_hknightsword.mdl": {
+     "bytes": 20504,
+     "sha256": "a8dffdc9e400d45fcea617255a8731d752cfa83df40b923128d5dbae6839492c"
+    },
+    "progs/w_judgesword.mdl": {
+     "bytes": 199388,
+     "sha256": "c822984ba5a12948ca389f4b8536c3aa6644993242362b10ac7f6ff2e2332590"
+    },
+    "progs/w_justicesword.mdl": {
+     "bytes": 264928,
+     "sha256": "0fc111a637bdaf5372c02c53439497c2adfc0914845b947ecc9ad70ace1e1b3d"
+    },
+    "progs/w_knightsword.mdl": {
+     "bytes": 14328,
+     "sha256": "4740ee2b171380cd9481ba07f284fe720c5b49b0980dc19cb145b2356205fc0a"
+    },
+    "progs/w_ogregl.mdl": {
+     "bytes": 8260,
+     "sha256": "8071cb814b6158c8af563494687e3994192818ccc2aa80f4766bbf6912d559ee"
+    },
+    "progs/w_ogreham.mdl": {
+     "bytes": 29996,
+     "sha256": "11c1ec322889a971b7f930a7c653f13e69714e6de77b7afa4ded1fdec39145de"
+    },
+    "progs/w_ogremac.mdl": {
+     "bytes": 29324,
+     "sha256": "2f9086da6b43becab1d54e47bcb299421b1bdc1e1e71c41e581b367a75f52919"
+    },
+    "progs/w_skullbook.mdl": {
+     "bytes": 25580,
+     "sha256": "e99379e980169501931eb029f36d05b41ba52f8597a6022bf195b08dba88c70e"
+    },
+    "progs/w_soldiergun.mdl": {
+     "bytes": 36120,
+     "sha256": "9c89a19d7c5fa69783d8bcf59b46b18a0c80c37e280b18731564952faf1d6523"
+    },
+    "progs/w_zombiesword.mdl": {
+     "bytes": 14328,
+     "sha256": "e4ac73fc149fa581e64fb5f2016ce58c99ab1c9a76502ede78a525ab7f344b0c"
+    },
+    "sound/ambience/bell_ring1.wav": {
+     "bytes": 61586,
+     "sha256": "b9169a48fd032d7c2b0cadb61540ac5db42ca6384cb2c74818bd46bae3fc7db1"
+    },
+    "sound/ambience/bigmachine_loop_02.wav": {
+     "bytes": 92760,
+     "sha256": "4d6dd03883ac4462c7f1741c022a3e8fd9e2c65cd54d5d126f58c00b3bfe7df3"
+    },
+    "sound/ambience/chimes.wav": {
+     "bytes": 250476,
+     "sha256": "d1060cd75d8a520b748047790d33c9a4ab5fd626330ebf1242d318d308c165db"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/distant_gears.wav": {
+     "bytes": 72502,
+     "sha256": "760d34131249ff3c4bccdab0cd3df69874728a6db3e1b4545177e5ce381e5e80"
+    },
+    "sound/ambience/drone6.wav": {
+     "bytes": 36820,
+     "sha256": "ab0cc1d617b06169d20b42bddc31078c0c7a1b8b15793fe6cfea6dbc96b4129e"
+    },
+    "sound/ambience/fan_finish.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/fan_loop.wav": {
+     "bytes": 288110,
+     "sha256": "d7459b4f1087aa1e002f41fc0274e4cb2f313dff5af2eecaa9de5225bcdcd729"
+    },
+    "sound/ambience/fan_start1s.wav": {
+     "bytes": 96044,
+     "sha256": "b0bad8ae3cd81dc4bbd76591e29f9c43610cb6e0311d4822213e400a6b99dd9f"
+    },
+    "sound/ambience/fan_start2s.wav": {
+     "bytes": 192044,
+     "sha256": "6716a803f246e44416fc414ca2f51744fc1ed79178f79fe3baf7a986c820c020"
+    },
+    "sound/ambience/fan_stop.wav": {
+     "bytes": 192044,
+     "sha256": "ee8607922387eeb594c18096ef6dd4003990a5fe47414dee331921f6d03be6b7"
+    },
+    "sound/ambience/fire1.wav": {
+     "bytes": 47906,
+     "sha256": "c1370a7c177aa21de219578cc64716bc800007e2ac86ae106affac01f8edc470"
+    },
+    "sound/ambience/flames1.wav": {
+     "bytes": 132406,
+     "sha256": "8ac99a7ace2ec9cc98a38fd5777973eb484e9193cf93dfcd6a51ea4f0f9d0f00"
+    },
+    "sound/ambience/flames2.wav": {
+     "bytes": 132406,
+     "sha256": "31e76d131cb4ad3c0602e2559c949feb7a8749c639363f1fd7df53136616fdd1"
+    },
+    "sound/ambience/flames3.wav": {
+     "bytes": 132406,
+     "sha256": "b4008d1da182bc0886f8bad53e5a700d8e04050920aa27ceb0922be938eb7c96"
+    },
+    "sound/ambience/flames4.wav": {
+     "bytes": 132406,
+     "sha256": "222222e080566c899a48df9e40006d0ee36575c03250c44845fb10a94c5cead9"
+    },
+    "sound/ambience/gargoyles.wav": {
+     "bytes": 136816,
+     "sha256": "16f09404b6043aaacb4b6b2bb00143ab72b5e185f02e610d780ea7d311d2df6c"
+    },
+    "sound/ambience/gearopen.wav": {
+     "bytes": 49708,
+     "sha256": "39b73c8ada1b06c7ba07099447b9b0d75911f08df09ced3826bcff136af5b0ee"
+    },
+    "sound/ambience/generator_gas.wav": {
+     "bytes": 529314,
+     "sha256": "6710075453fde424951171823e87f3711d53fd434149ddecc14a14ce721de04a"
+    },
+    "sound/ambience/ind_lift1.wav": {
+     "bytes": 158906,
+     "sha256": "c722fa19c7851d2c7b4307489911b885527e31fd3e4de44d5a184bd786714049"
+    },
+    "sound/ambience/ind_lift2.wav": {
+     "bytes": 156008,
+     "sha256": "c404881a9758f839fd055dd69a82f04bf7e5d5b98538a4a87b2ee741d8b4956d"
+    },
+    "sound/ambience/light_hum1.wav": {
+     "bytes": 100022,
+     "sha256": "cb2f04b81297621ffddbfb028dc5021a665e3285deb7c80757a47add8294f032"
+    },
+    "sound/ambience/liquid_bubble.wav": {
+     "bytes": 129688,
+     "sha256": "838ec1e72b2c433408a342a48518987edcb2124932eeb477d59653540b13d6ea"
+    },
+    "sound/ambience/liquid_burnlong.wav": {
+     "bytes": 710182,
+     "sha256": "9c9c77941f88416e3f20dfc4f028cc6c9719dd7f58a15dfc6124f1bb5a17f61a"
+    },
+    "sound/ambience/liquid_burnshort.wav": {
+     "bytes": 89464,
+     "sha256": "4ea16997389f1aa35549869a338f2093f40d14df030c381a7659cc7e3cbf8bfc"
+    },
+    "sound/ambience/liquid_drain.wav": {
+     "bytes": 220464,
+     "sha256": "e86a6012c8fc3a795791fc344ef636bb1854a602cd609e2df751531e89277cf9"
+    },
+    "sound/ambience/lowboom.wav": {
+     "bytes": 666640,
+     "sha256": "ad591a6f574f48e654e32dacee6b7d862df8b47e20ef116f84415ad9aa515559"
+    },
+    "sound/ambience/machine_loop1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/ambience/machine_loop2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/moo.wav": {
+     "bytes": 265502,
+     "sha256": "35b7924115bc4cdf94e9cbb274a4d9ca251d6878817834bec08aaa176f2ddc9b"
+    },
+    "sound/ambience/mystery_drone.wav": {
+     "bytes": 1350258,
+     "sha256": "eb3fbb28dda2a6204af07d08fa993ed09513f9915142dd6f4af808204b6b8c9e"
+    },
+    "sound/ambience/power_drone.wav": {
+     "bytes": 36700,
+     "sha256": "4307c01076cb5e076d27546b17bd6b11e2369a67b59dbbd64f2607d8b262a8c2"
+    },
+    "sound/ambience/power_off.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/ambience/power_on.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/ambience/power_shutdown.wav": {
+     "bytes": 1118464,
+     "sha256": "e0ab1a0f67a2d37a525f7a73e8ee8c3a26f746e027fa1501f6648f5586ea2048"
+    },
+    "sound/ambience/power_switch.wav": {
+     "bytes": 66382,
+     "sha256": "5c006bb7315e6eb6d2367ae30a78f0abec8ae2a1e2b6a2c9af88354962b0f33f"
+    },
+    "sound/ambience/rain1_nl.wav": {
+     "bytes": 154394,
+     "sha256": "45d8c08ff4a9a2dd6ff8362fea7c22f9c3ea64a3a8d7b6c81c8cad88265f327a"
+    },
+    "sound/ambience/rain2_fade.wav": {
+     "bytes": 198550,
+     "sha256": "3cf300a4f785d416656838bd3a68120bf6a48d16f928ca74e2e0890ec9f8b426"
+    },
+    "sound/ambience/rain2_nl.wav": {
+     "bytes": 66250,
+     "sha256": "f2735ae8a7b1ae5ab5ce3b8ed66d8c61d00a65f2e66d8c565f4abe718d57ab67"
+    },
+    "sound/ambience/rain2_org.wav": {
+     "bytes": 132400,
+     "sha256": "4c1f820b2c8f4bea08b8357fb8409e9f30a98fd0faf1413a1953ea697b84b507"
+    },
+    "sound/ambience/rumble1.wav": {
+     "bytes": 403620,
+     "sha256": "47afe820548bcf248b7760f7a66a61ea65b5fb79f70d47e3b03cf8211bb4c5f3"
+    },
+    "sound/ambience/rumble2.wav": {
+     "bytes": 99104,
+     "sha256": "9c3d5418c7e5bac60c365f0e8b7ea496dd2b51c72c13b0e5a6640e2ef880433a"
+    },
+    "sound/ambience/rumble3.wav": {
+     "bytes": 209242,
+     "sha256": "864f373dbd75172e1c8f31373188f38c31a80af46592f6b2e92cf5f576e5e0e1"
+    },
+    "sound/ambience/s1_stop.wav": {
+     "bytes": 16162,
+     "sha256": "9a35adf9361aa033b413762fea7d04b2cf7392b363f2aa187a81905f65a44b61"
+    },
+    "sound/ambience/switch_1.wav": {
+     "bytes": 35324,
+     "sha256": "9f73f07313ba4995247d82901111b5aea4200c48de6641dddb145dfadcac40c9"
+    },
+    "sound/ambience/switch_2.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/switch_3.wav": {
+     "bytes": 17576,
+     "sha256": "33b6ed57b0255840415df4db607f86b1183b564f4b1f2dcab6d45d4d75231b8c"
+    },
+    "sound/ambience/switch_4.wav": {
+     "bytes": 44348,
+     "sha256": "bfebdf2afdbab57bd5be3fe0996ce19ff46d983eea4d1511d85af2e4f7d0db00"
+    },
+    "sound/ambience/switch_5.wav": {
+     "bytes": 79992,
+     "sha256": "78bb8cb9ab7202657495a0ca14340886af901912850b9951b0da159f55c2cb20"
+    },
+    "sound/ambience/switch_6off.wav": {
+     "bytes": 141466,
+     "sha256": "999d3b02b7224586d5c487c2666981f054aa091f0569671c72455bff458c9a2a"
+    },
+    "sound/ambience/switch_6on.wav": {
+     "bytes": 176192,
+     "sha256": "7a67fa5d4ee042c6afd271868682a1a34908c2593e5ea9e868ecb6d3e154b55b"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 220548,
+     "sha256": "2cec0b03aa7047110862de21f8f6c77e4d98901ecaf5e405a473c2ddc922528a"
+    },
+    "sound/ambience/thunder2b.wav": {
+     "bytes": 286716,
+     "sha256": "44095eceb307b5f2f1093051597ea0e48bc7abe165accd5badf99c4ad692c6df"
+    },
+    "sound/ambience/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/ambience/windgust2.wav": {
+     "bytes": 110284,
+     "sha256": "b818f61172795942402ff0ca0d1295a91c36a245edc80689c35fe64a8ac1a4e2"
+    },
+    "sound/ambience/windgust3.wav": {
+     "bytes": 110030,
+     "sha256": "fdbb85f091cd9447f1500173aff70236abcdb947ba0758711816da59c5293344"
+    },
+    "sound/ambience/windgust4.wav": {
+     "bytes": 198502,
+     "sha256": "9a5c5a3da44f981c9deb8b437f57b3e3a35f2bcab318a1a3223f0a18fa4d2101"
+    },
+    "sound/ambience/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/ambience/windgust6.wav": {
+     "bytes": 396944,
+     "sha256": "27a19679e7164a6e7bb8e4d6bc42cc8c12a5cd56bba45218e2ec5f1dc528da0d"
+    },
+    "sound/ambience/woodcreak2a.wav": {
+     "bytes": 352834,
+     "sha256": "24d3f57839910934eb61b74a91cf47ee4ab48b38f58f060ca05bde7547e8813c"
+    },
+    "sound/ambience/woodcreak2b.wav": {
+     "bytes": 352838,
+     "sha256": "574401233bff93169d452f4af748a289cfaff5d4e6319884e3cfb4dbd205d0a4"
+    },
+    "sound/ambience/woodcreak2c.wav": {
+     "bytes": 308746,
+     "sha256": "02deb62b856b7be5c3304a0bf745f79019b0b408a8cfcc4e1edede397ba09c7d"
+    },
+    "sound/ambience/woodcreak2d.wav": {
+     "bytes": 352856,
+     "sha256": "6d35975964b2fa32ece681a9d0cfa13202cde02bc315f32af0690f7437352452"
+    },
+    "sound/ambience/woodcreak2e.wav": {
+     "bytes": 308766,
+     "sha256": "54eb41e3f5c2a0103d07e70e83cf82b51014da3673fb770cf6ada3df669c328e"
+    },
+    "sound/bal/bc7_waterfall.wav": {
+     "bytes": 137846,
+     "sha256": "51dcfb96c94678cbb01e0c985240e853a01c6fc3c4f2376de177c0be59bfcfe6"
+    },
+    "sound/boglord/attack2.wav": {
+     "bytes": 8036,
+     "sha256": "efa18dec8f6d5066b8d494a232ca9c98c27a4a9130130086a9b0a27ffccb34ed"
+    },
+    "sound/boglord/bangdoor1.wav": {
+     "bytes": 30968,
+     "sha256": "b267e602e76fe1d8e854e2873e06008af15612ed1a31ec41feeb4461d52fc478"
+    },
+    "sound/boglord/bangdoor2.wav": {
+     "bytes": 39828,
+     "sha256": "f904a5423580c118de1d732fff714565f1dd8d8d1556b3b58bf39d2c59fa4272"
+    },
+    "sound/boglord/bolt_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/boglord/death1.wav": {
+     "bytes": 39758,
+     "sha256": "a9e0e36b1a51d88a5b542dd2c1f79f1dbea402b3ceb18ee13606c03126f1a874"
+    },
+    "sound/boglord/idle1.wav": {
+     "bytes": 15532,
+     "sha256": "5339e3429b0510f7e8016e6ece9895df6f202b5809f739b317211a081401f202"
+    },
+    "sound/boglord/idle2.wav": {
+     "bytes": 18586,
+     "sha256": "52f8bddb2d5095f4077eb1f753d75bce94f906f1b3064067a54c875ae16d1a5c"
+    },
+    "sound/boglord/melee1.wav": {
+     "bytes": 9326,
+     "sha256": "e2f5808115d0a93dde1063db6f2d38f6ab7ff333f83d95741a8948f44ae4ace9"
+    },
+    "sound/boglord/melee2.wav": {
+     "bytes": 11746,
+     "sha256": "e299e39467c9f94730c21d1321455fdccf3aefbb0352d528b6d413639210e715"
+    },
+    "sound/boglord/melee3.wav": {
+     "bytes": 18776,
+     "sha256": "c066200b5ddb81aa0c0cc0462939681703549ac15dd6aa83db8a23ae54ce6317"
+    },
+    "sound/boglord/pain1.wav": {
+     "bytes": 11094,
+     "sha256": "6ca5a44043add6b389827e5aca8bc0c9e9c7b0cc0c7b4a5d3df292a78da0064f"
+    },
+    "sound/boglord/pain2.wav": {
+     "bytes": 11094,
+     "sha256": "7e11818fbae5354177add1e236b6f3e0f4665d50193154fbb15fead4bb4d7908"
+    },
+    "sound/boglord/sboom.wav": {
+     "bytes": 22172,
+     "sha256": "89899521eac11f922cdd4606a0fe08bc080a63a73ec4b4a502027e33f08b225b"
+    },
+    "sound/boglord/sight.wav": {
+     "bytes": 28734,
+     "sha256": "8b020b0f07a7461f5f520b8385e38828d66b3cb1fc46d7db08b845fa8ff62ad8"
+    },
+    "sound/boglord/slime_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/boglord/slime_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/boglord/thud.wav": {
+     "bytes": 22140,
+     "sha256": "f5d7b5f65e24d6a5edd04404b93a8c5a2db45cc6c142012638f050158bb783ba"
+    },
+    "sound/boglord/thud2.wav": {
+     "bytes": 105882,
+     "sha256": "7e8826a38df07d0d2b85d6d39b8b664bb2ef8a0686846573802b77811682e957"
+    },
+    "sound/break/ceramic_i1.wav": {
+     "bytes": 11106,
+     "sha256": "ed731319eb09044fe672f5d8681395a11a7449fe7b57b9a46040c717e714cf40"
+    },
+    "sound/break/ceramic_i2.wav": {
+     "bytes": 11126,
+     "sha256": "88c29d649471f031aa1049ee087cf866e1d9ea53183effd14cfabc81ecff9502"
+    },
+    "sound/break/ceramic_i3.wav": {
+     "bytes": 11144,
+     "sha256": "420d00d7884a22dd2baf9cdd1e059689858b47fb3adb2ad5ae29c80bd74b5dc5"
+    },
+    "sound/break/ceramic_i4.wav": {
+     "bytes": 17678,
+     "sha256": "0b7da87d046aeb3a52de305da60b2400c8cbf3480364235fb0bba3a0595f13dd"
+    },
+    "sound/break/ceramic_impact.wav": {
+     "bytes": 37584,
+     "sha256": "e6d2ada5c51a2787548468ad393e2497ef84b47ca487cd523f3ef6b283626226"
+    },
+    "sound/break/ceramic_impact2.wav": {
+     "bytes": 35380,
+     "sha256": "508725e20a999c339501dddb045a2ca6a51032905dccc68fe2a3fb9e9e1d0649"
+    },
+    "sound/break/ceramic_impact3.wav": {
+     "bytes": 26560,
+     "sha256": "ca4d7876a6e33cc285186d1432670878b54cc62c01e3dc4c650727069bfdb8ee"
+    },
+    "sound/break/ceramic_impact4.wav": {
+     "bytes": 37584,
+     "sha256": "e71b0559ac5d76dcd2016d07f8999ae1200d82ca7b658509339cf303c918f777"
+    },
+    "sound/break/ceramic_impact5.wav": {
+     "bytes": 37584,
+     "sha256": "1c6b3457c9d3aab209cd3b8977df579cdbe01158c1b4e5c07c2b5b227c96fb6d"
+    },
+    "sound/break/ceramic_impact6.wav": {
+     "bytes": 37584,
+     "sha256": "fac4857865a750a03f74e556f44186381315068ec1975c775fcd14ae4a7b3c7b"
+    },
+    "sound/break/flesh_impact.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/break/glass_i1.wav": {
+     "bytes": 13268,
+     "sha256": "63ec32f660d085c64274747b704bcbeb7261062b5fcbb570598d64e742dc7164"
+    },
+    "sound/break/glass_i2.wav": {
+     "bytes": 30950,
+     "sha256": "8b2ae028e6237cf06241739e3533ef3bf651194dfbef028fd648a6f06e8996de"
+    },
+    "sound/break/glass_i3.wav": {
+     "bytes": 8848,
+     "sha256": "ec97346c02431717927e2dd3712bd82428ea05960ffa027422fbaafab96b4170"
+    },
+    "sound/break/glass_i4.wav": {
+     "bytes": 4442,
+     "sha256": "b4144a008122e52aed45339e11ccf7cb1cd2e92f07e4169d029059a4ca01f5fa"
+    },
+    "sound/break/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/break/metal_i1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/break/metal_i2.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/break/metal_i3.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/break/metal_i4.wav": {
+     "bytes": 79928,
+     "sha256": "d2b35ba352f32ceae469acf9cfa04f7dcc0a462ff69e3649f5c0adf55ae2ea78"
+    },
+    "sound/break/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/break/rock_i1.wav": {
+     "bytes": 30534,
+     "sha256": "5cb61e93ebcf9bbcd3be1f6e282b51e9102d56b6650cffc0db93918b11b42322"
+    },
+    "sound/break/rock_i2.wav": {
+     "bytes": 29254,
+     "sha256": "9fdf4f489834452fce33b1fbe69bce9d4920a117c3d0d93b4fb530a7117bf160"
+    },
+    "sound/break/rock_i3.wav": {
+     "bytes": 25264,
+     "sha256": "59b506a84e018b11e9ba30a6ad299c2d8cf24d5907dc95cf30e578cd386e28bf"
+    },
+    "sound/break/rock_i4.wav": {
+     "bytes": 27244,
+     "sha256": "7a2c24ce52e272998ca035c967860873c92fbb14227a190ac82b761843680ffd"
+    },
+    "sound/break/rock_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/break/wood_i1.wav": {
+     "bytes": 28074,
+     "sha256": "6249449664f5ae509164ae3fd8588c905bea9daf5b1d919d9917b91aadf675bb"
+    },
+    "sound/break/wood_i2.wav": {
+     "bytes": 25158,
+     "sha256": "d51e731bdf895c84ec9927c496fc0a7fb6e7a37cbfbc2f6b55f54f716d804d08"
+    },
+    "sound/break/wood_i3.wav": {
+     "bytes": 17644,
+     "sha256": "8e1967cf42a7e31668d94e1b0cb7c6de4d36c6ec735d67ab01ac4e00dfb0853c"
+    },
+    "sound/break/wood_i4.wav": {
+     "bytes": 11516,
+     "sha256": "fb0908f1a2bdff824d27fa92f15690cb9f86805185119fbc7f7876547495bf45"
+    },
+    "sound/break/wood_impact.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/chthon/attack1.wav": {
+     "bytes": 22116,
+     "sha256": "91df4f5be21c6a80d31a050192b04a760f25c7f88a4b0ceeb2802fe8b8499d21"
+    },
+    "sound/chthon/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/chthon/death1.wav": {
+     "bytes": 55120,
+     "sha256": "b6eeee788b9aa49ca9698d2d7977748f142053fd3f47e2828d1781d7db7ec986"
+    },
+    "sound/chthon/idle1.wav": {
+     "bytes": 24322,
+     "sha256": "6a0a9b5a0b2e74fce8cbfa9ede97c2059884c0db81b2c68fc0ec7bb1da2a4009"
+    },
+    "sound/chthon/lavasplash.wav": {
+     "bytes": 100546,
+     "sha256": "a533653ff77e2dfc443377a1f055b6abd7af3c639f0e5634b0a47fd1f040ed76"
+    },
+    "sound/chthon/pain1.wav": {
+     "bytes": 35320,
+     "sha256": "f964bdd08ffc66f9f229aacb3b584ffefdcfbacf7da0f0075a9af752569c641c"
+    },
+    "sound/chthon/sight1.wav": {
+     "bytes": 49454,
+     "sha256": "533adf244fa2c2dca72765560e823ceead8d5a0f3832ba18d4fa2928154b12c8"
+    },
+    "sound/deflector/death1.wav": {
+     "bytes": 22150,
+     "sha256": "593140594353d4d25fe6b5e455afc0f3c2cdd6874bc1d545ea03f779454cd799"
+    },
+    "sound/deflector/death2.wav": {
+     "bytes": 41334,
+     "sha256": "4295a9a79fec3bf611c25f97553420d0e42b987ad8091930db9137b93a3e8f06"
+    },
+    "sound/deflector/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/deflector/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/deflector/idle1.wav": {
+     "bytes": 7668,
+     "sha256": "76455fc9d5fc53cf5a70900a9d875ba3ac839e1c3179eccc5287619a70523e6e"
+    },
+    "sound/deflector/melee_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/deflector/pain1.wav": {
+     "bytes": 6452,
+     "sha256": "e0905dc6c945663a97119f2c1522d5a8ebd1596ed26f33650fcb63b185959517"
+    },
+    "sound/deflector/pain2.wav": {
+     "bytes": 9598,
+     "sha256": "011d69ef5153dca029bcb1c3d60b3c3f0e1263bd9ca34a02d4d14e6ab508a0d4"
+    },
+    "sound/deflector/pain3.wav": {
+     "bytes": 12014,
+     "sha256": "08f5ac27626e862b7193f101a6d0b77dc6568c4e93ef3000199934769666b1ec"
+    },
+    "sound/deflector/rocket_fire.wav": {
+     "bytes": 15482,
+     "sha256": "a08e5f83d20b5d1eb585cf782f08a4a692b0f8c95e461b9a321814d099a89d79"
+    },
+    "sound/deflector/rocket_hit.wav": {
+     "bytes": 13274,
+     "sha256": "4dbcd0bad68272848a32a997bb235c4324cd55b1df0b96b1876fb96ea8ca6a90"
+    },
+    "sound/deflector/rocket_load.wav": {
+     "bytes": 6882,
+     "sha256": "1dbddae67f93c586ea3290ed65e1234cf8ccfd076847b1b418693e97fb5768d1"
+    },
+    "sound/deflector/shield_off.wav": {
+     "bytes": 10684,
+     "sha256": "5c3ea84c12abf632d777f90972966c4a50dde4ee7363d257e3c0f89e68027b5f"
+    },
+    "sound/deflector/shield_on.wav": {
+     "bytes": 10464,
+     "sha256": "340196ba32a9d3f672cbc3db86765eb1517550b00f2f97ed76cb519da1b93962"
+    },
+    "sound/deflector/sight1.wav": {
+     "bytes": 16106,
+     "sha256": "3ec7f00e859c52846b244e69cc3ed7321175746a44eb373fe4bd3cb07612dcf3"
+    },
+    "sound/deflector/sight2.wav": {
+     "bytes": 14432,
+     "sha256": "e8c0c1367969b0346bf5fdc94665a10480636629a71a6a35e47da3d7fb7cb463"
+    },
+    "sound/deflector/sight3.wav": {
+     "bytes": 17184,
+     "sha256": "11748c58e67305ad4e1cd7a2e2c084f9c41184cd2b4f756adfd18adcc22dbc2d"
+    },
+    "sound/dguard/death1.wav": {
+     "bytes": 30610,
+     "sha256": "af3809501261ec4d0afa6ea7301c11a5c7bbc1cc3e06b8c88172ee0214c30969"
+    },
+    "sound/dguard/death2.wav": {
+     "bytes": 43636,
+     "sha256": "93a70fc0d6fee819c723a435a3954b3fd3be86e358698ce85db1062990d1575e"
+    },
+    "sound/dguard/fire.wav": {
+     "bytes": 60820,
+     "sha256": "f5e5d4f6ccc0778c1396c66d327564a0b1892773f2c23d2e30590abf0c758bd2"
+    },
+    "sound/dguard/hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/dguard/idle.wav": {
+     "bytes": 20498,
+     "sha256": "45b2f208b9796d19d7aeb0cba64e4b0e5fd2ed7c980123f7c41ca10d17785021"
+    },
+    "sound/dguard/pain1.wav": {
+     "bytes": 10380,
+     "sha256": "9a367afb7cde241099c58c999e225ba939be39f21be818b16444f5a810049960"
+    },
+    "sound/dguard/pain2.wav": {
+     "bytes": 14892,
+     "sha256": "827a1e4d3c9983f61fffd61de33054274c144bddd9a68460b496fd6281cf9406"
+    },
+    "sound/dguard/sight1.wav": {
+     "bytes": 18124,
+     "sha256": "9cb3d960261d90ec16c9883f4326c905356b6ff4e99cdf48ab5913b098588016"
+    },
+    "sound/dguard/sight2.wav": {
+     "bytes": 18022,
+     "sha256": "35ee4b7ec6715c8c9fdc24f90ad0b5d90a0ae7a4986168cf40670e87c325d5db"
+    },
+    "sound/dguard/sight3.wav": {
+     "bytes": 19948,
+     "sha256": "c6818770267626dea27f4a72ce2249771f6968924022c2275a5a96abfa485044"
+    },
+    "sound/dguard/sight4.wav": {
+     "bytes": 20332,
+     "sha256": "7affcdbdc62f13e492a15b54fe642fe045641f5551f570cc3c8d5f7ee29521fd"
+    },
+    "sound/dguard/slash.wav": {
+     "bytes": 22942,
+     "sha256": "44b60d785ff03f033e183b6fbce69e526351187d28efdeb308f6f8bea930d450"
+    },
+    "sound/dguard/slhit.wav": {
+     "bytes": 31956,
+     "sha256": "0f07a131640f21337cd89a772588ecfc707d6a729f96b54c21920b809cd620e4"
+    },
+    "sound/dguard/slmiss1.wav": {
+     "bytes": 10458,
+     "sha256": "e32d5cb070a13fad979b021e84a727f71242305ade1af7bfe18c255f0f6dd548"
+    },
+    "sound/dguard/slmiss2.wav": {
+     "bytes": 13840,
+     "sha256": "f6b3aee08c25434d2fda7468cacf35a0912b182653a45991149b54a0fc4be537"
+    },
+    "sound/dknight/dcross_idle.wav": {
+     "bytes": 176610,
+     "sha256": "a7eba673532dad555f879ba77091e3cb9e44558608b83c36d8639e51d71b660a"
+    },
+    "sound/dknight/dcross_idlecom.wav": {
+     "bytes": 58910,
+     "sha256": "bba45bd9fc02e1d580a80596d6a1744bb8fb993ed73a7bfdf3b712670cccf989"
+    },
+    "sound/dknight/dfury_grunt1.wav": {
+     "bytes": 19702,
+     "sha256": "8d3709e913b8e26d8e094fddd9c60d74cc71b742e16276d4982c9636db05209e"
+    },
+    "sound/dknight/dfury_grunt2.wav": {
+     "bytes": 54294,
+     "sha256": "f7ca0d5970322629cc47f8c26489d5c916a570525ded20c73823c27f2834609c"
+    },
+    "sound/dknight/dfury_grunt3.wav": {
+     "bytes": 62054,
+     "sha256": "6eae53c32568ce90083dab528c18475ef840f9f684c43cdba7bfcc1c63435ba6"
+    },
+    "sound/dknight/dfury_grunt4.wav": {
+     "bytes": 28914,
+     "sha256": "0def63c77d0f116eabb77cc462ba6a57bc6523fad469946c6f1f11d786100819"
+    },
+    "sound/dknight/dfury_leap.wav": {
+     "bytes": 102756,
+     "sha256": "f288dc9324b2ccace32ce86cffaf0c042a59bf5b56b20657c018859f1038243a"
+    },
+    "sound/dknight/dfury_sight.wav": {
+     "bytes": 69602,
+     "sha256": "443887e91ca71dbba299b37a81bdbd3bb34b491c6c3e13fe73bb5c921019d1ea"
+    },
+    "sound/dknight/dprince_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/dknight/dserg_hbreath.wav": {
+     "bytes": 185884,
+     "sha256": "c8181d4844ac4b2bb7dc47bbc28bd2ae9fc2737120d6745292de4d594f40d406"
+    },
+    "sound/dknight/dserg_magic.wav": {
+     "bytes": 34768,
+     "sha256": "adcb0810b7e8b23d91d31f5727c480b35c7b59a90d9f7933f69c00e7eccd1f3e"
+    },
+    "sound/dknight/dserg_sight.wav": {
+     "bytes": 15210,
+     "sha256": "d4f7c5b6f64d48606d1d3e1889794a22107f3d5914b37c81c405fdfb1133a7eb"
+    },
+    "sound/dknight/ghost_idle1.wav": {
+     "bytes": 110292,
+     "sha256": "878416a0151a1a71891a84db2565d1e8a2b2e37f03f1822d7f9411a98b42b528"
+    },
+    "sound/dknight/ghost_idle2.wav": {
+     "bytes": 110290,
+     "sha256": "048f79f7fa8f9e49f97dad9f5cb468933be1713726ba95d3ab10d9811cbb5f2f"
+    },
+    "sound/dlord/death.wav": {
+     "bytes": 32022,
+     "sha256": "0188f6a3dd88686e15311f8c39c4277078e55bc0ec75497e2eb534af717abcdb"
+    },
+    "sound/dlord/idle.wav": {
+     "bytes": 9906,
+     "sha256": "c0ee37f80013dad1aaeb285a11a33c4d7c2ff2de0b2a94c2943d3fbe1c241bcd"
+    },
+    "sound/dlord/pain.wav": {
+     "bytes": 8632,
+     "sha256": "230ed5c7d024bfa90b973649aa79d9e9327eaf401b1632e4a1334fb4a9eb075c"
+    },
+    "sound/dlord/sight.wav": {
+     "bytes": 28028,
+     "sha256": "d82aa0028754e826705961040e1ab27f007c572a28c63dbcaeefeb681bc3ca85"
+    },
+    "sound/doors/rattle1.wav": {
+     "bytes": 88274,
+     "sha256": "c524d12100f1067bb30ecdf83e18e5d85124fef834929cfd2a2ade14f83ad730"
+    },
+    "sound/doors/rattle2.wav": {
+     "bytes": 123526,
+     "sha256": "e8decabe8df10f704814bf2f432b3fc6d5542022d465af336b0680793f6163ea"
+    },
+    "sound/doors/rattle6.wav": {
+     "bytes": 97072,
+     "sha256": "0aef6aac51a4e3528e5f2019bf113ee2f0e5096a708d31483a526c447ebdb00c"
+    },
+    "sound/doors/rattle_tech1.wav": {
+     "bytes": 61784,
+     "sha256": "18610e64612241e6936f2d0ebe746c957652c4ce8e37c668515281712f6a1e39"
+    },
+    "sound/doors/rattle_tech2.wav": {
+     "bytes": 88244,
+     "sha256": "de39aa8b59c988b02bf6c13a716e225b7ee029f2553357b8646aef92a2792c3e"
+    },
+    "sound/doors/rattle_tech3.wav": {
+     "bytes": 52844,
+     "sha256": "a29e8144cdab34467250f040feaad044aff784a2775b50bd220e967b39f39b3c"
+    },
+    "sound/doors/rattle_tech4.wav": {
+     "bytes": 76844,
+     "sha256": "ba34a641758a2e2cb9ef5358a398482c2b34526fc4b0c49db590c9679c732ef4"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/enrage.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/r_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/eel/attack1.wav": {
+     "bytes": 27740,
+     "sha256": "8c84b2a5e7fd0754dca3611a8300a8cc9656295ea73617ff0c85d167b28459df"
+    },
+    "sound/eel/death1.wav": {
+     "bytes": 34264,
+     "sha256": "a0f8eab92db10e8fa9342f725743297fd8384e2aca1decc1189109196f3b960e"
+    },
+    "sound/eel/idle1.wav": {
+     "bytes": 53110,
+     "sha256": "c059a4f2bee33543b377803f2af1fc7e2ee205cd02d987859af18087246ae46c"
+    },
+    "sound/eel/impact1.wav": {
+     "bytes": 70632,
+     "sha256": "13cea2f7d66f40511add17d846ab6142345497ddd7cff5ebfc5e2e70a7eb1fbe"
+    },
+    "sound/eel/pain1.wav": {
+     "bytes": 13316,
+     "sha256": "569a6bf9383820e90e431db5c0b82cd0201e10fd2081d228f81a0c76a0e88d1b"
+    },
+    "sound/eel/sight1.wav": {
+     "bytes": 32074,
+     "sha256": "90786a043f5ec1bd0b761c5c8378dc2783e3b1d8e3ac95a9312f55a7c5b3baea"
+    },
+    "sound/eidolon/attacka.wav": {
+     "bytes": 27660,
+     "sha256": "a7bb5c16014c814d379585eb4c6752a91240a5856ad7f3af5f86af037bef91e6"
+    },
+    "sound/eidolon/attackc.wav": {
+     "bytes": 220544,
+     "sha256": "9815d26814c687618b7bbae4a5353570afe497c5d57fb77c083f695d102234c9"
+    },
+    "sound/eidolon/attacke.wav": {
+     "bytes": 46400,
+     "sha256": "39ad467257004bc6d2a17003abe4ef8df89d0668ec03fc8570aa755cbdf94c6c"
+    },
+    "sound/eidolon/death.wav": {
+     "bytes": 264696,
+     "sha256": "bc055e1315073c78e5571c99d29894bc89abfd64b6a258bdabc79849f81c50a0"
+    },
+    "sound/eidolon/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/eidolon/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/eidolon/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/eidolon/footstep1.wav": {
+     "bytes": 52384,
+     "sha256": "e228c0503d89118be55eafaf3a3bfa0a13e3bdcbe4a043f4a9bb31c9e96cf3dc"
+    },
+    "sound/eidolon/footstep2.wav": {
+     "bytes": 46128,
+     "sha256": "1a3b867c93932411f1c3dedf4a8f1553f19caabae438cb7989095307d1a6c5c5"
+    },
+    "sound/eidolon/footstep3.wav": {
+     "bytes": 43774,
+     "sha256": "4119d9c31e359bd48b52bff2842e51c441064896289194f04db44e2d7860cccc"
+    },
+    "sound/eidolon/footstep4.wav": {
+     "bytes": 41758,
+     "sha256": "6b97f80545d9587580a7b445f13e5a38300627e497ed85357f9448c7a910864b"
+    },
+    "sound/eidolon/growl.wav": {
+     "bytes": 44380,
+     "sha256": "f9f404c4590f2af8fa9a1cd0de34e1d031e66d88ccf553dba228396f0d8fb012"
+    },
+    "sound/eidolon/idle1.wav": {
+     "bytes": 28778,
+     "sha256": "61f423068b79bba82fb3ae3fca3957a8f059802068edf272f2695e6caab89271"
+    },
+    "sound/eidolon/idle2.wav": {
+     "bytes": 33172,
+     "sha256": "1bdd3d6862ed0b74aecae1917f09a65acf4db7fca49a0ccd21a7fbc2eea5f02b"
+    },
+    "sound/eidolon/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/eidolon/pain.wav": {
+     "bytes": 17744,
+     "sha256": "6a308180389e3fb98cc00c70dad1c6600988778b34628e04363e7ca54e5bf679"
+    },
+    "sound/eidolon/rock_hit1.wav": {
+     "bytes": 97066,
+     "sha256": "d31741c09309b240d294ba9b310b694aae1d71f823ac9ef28b27a8b5fff14405"
+    },
+    "sound/eidolon/rock_hit2.wav": {
+     "bytes": 123526,
+     "sha256": "a3d1247db98535829392172110a40fde19113dd493ab603c4b6a9a36dd743150"
+    },
+    "sound/eidolon/sight.wav": {
+     "bytes": 53044,
+     "sha256": "04c124f683e75e4d14374b7a044eeea288dd02a845ccab3ffd670f1c15799ebb"
+    },
+    "sound/enforcer/cent_hover.wav": {
+     "bytes": 103796,
+     "sha256": "a5616566072a5cdc9339e3722d6fee9e652796e9cc8f76e27dbd9aee13986f4e"
+    },
+    "sound/enforcer/death1.wav": {
+     "bytes": 9290,
+     "sha256": "f62aad2ae903808a0caecfc6bdfe13e5fdebb1df14d330c6ac4eda9b577b25bf"
+    },
+    "sound/enforcer/def_idle1.wav": {
+     "bytes": 32676,
+     "sha256": "7b673b07828790504caca013c18bf697fd53b758a3638b949b433cf2d72f03f3"
+    },
+    "sound/enforcer/def_idle2.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/enforcer/def_sight1.wav": {
+     "bytes": 18260,
+     "sha256": "7d57825c28cf4f93189261d76cccab676aeba097920114d5d3f48d7eddaaa1cd"
+    },
+    "sound/enforcer/def_ssg_fire.wav": {
+     "bytes": 14206,
+     "sha256": "494a6d493c3c298c1b9cc0051ce4c1f9e129293ea7ec283b62915c49d8c249c3"
+    },
+    "sound/enforcer/def_ssg_load.wav": {
+     "bytes": 5274,
+     "sha256": "db4f62f8d76a68f2e4d3e7a29a22d3ddc5d6ae9bb296e6e800e937b73b5a4dea"
+    },
+    "sound/enforcer/elim_idle1.wav": {
+     "bytes": 39084,
+     "sha256": "2ccaa3ba4f987d031a22b8048ca23e97900fca9def362ff92943b73a99ed7844"
+    },
+    "sound/enforcer/elim_idle2.wav": {
+     "bytes": 36204,
+     "sha256": "9232028e1a93c409c7000348bfadc269c49a333e8d65d904973efb547c7af805"
+    },
+    "sound/enforcer/elim_idle3.wav": {
+     "bytes": 38222,
+     "sha256": "93034d568db5c304a165c3d89cb03ffe5d97e8157755e944a863697007eb27fc"
+    },
+    "sound/enforcer/elim_pg_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/enforcer/elim_sight1.wav": {
+     "bytes": 31468,
+     "sha256": "2268ee0ad0c77a081b289a550a1dae24b274b2e3f06d156a67beca80df8ee919"
+    },
+    "sound/enforcer/enfire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/enforcer/enfstop.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/enforcer/fum_poisonoff.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/enforcer/fum_poisonon.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/enforcer/idle1.wav": {
+     "bytes": 15810,
+     "sha256": "cec388af73dff076ea3af7c754ef0939f989f3412b0359c0fb668cd91bd4abaf"
+    },
+    "sound/enforcer/pain1.wav": {
+     "bytes": 5478,
+     "sha256": "d8692021777495825974f8406e23c74ed249f9a80a9bc944c79b1722c35f64e0"
+    },
+    "sound/enforcer/pain2.wav": {
+     "bytes": 4580,
+     "sha256": "e48a524482ce67ff94ce00fe4d8a1190aed38e9c7c24cfee3607f0f2827049e6"
+    },
+    "sound/enforcer/pyro_flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/enforcer/pyro_flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 5870,
+     "sha256": "92dc64154602e29e95d40aa68d3544fe21cb21ce24192f1e8ffefc6b5d31b8cc"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 6574,
+     "sha256": "52b1991141ed9452fe6c7ebe219cc544fba443058f179b8eec5a5cbfb9aacf3d"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 6158,
+     "sha256": "d3b9e689b2b43ae74ae14fdb26680d3646d658107664965db97420ae032d74b0"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 5166,
+     "sha256": "815e05c3b14858209fee01316848c117ad89af9f0aab190fc0ca0239367373ac"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/freddie/death.wav": {
+     "bytes": 88244,
+     "sha256": "2e3de0875dd3245a98614829ab848cc1dfc34a95827aa4cfc174884977ecddf0"
+    },
+    "sound/freddie/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/freddie/idle1.wav": {
+     "bytes": 88280,
+     "sha256": "673ac7c26a9be2b1ea37b152ce48442ff40089cc7dc015c014eb42534db2c306"
+    },
+    "sound/freddie/mangle.wav": {
+     "bytes": 48548,
+     "sha256": "ee318d6849ca9dda4569db6009210a6909279bd2ffe9b31543d47134b51c1533"
+    },
+    "sound/freddie/pain.wav": {
+     "bytes": 38640,
+     "sha256": "ffe05b43444a209084c95c166b0776d33f9ba8af15ef998d3ed5c09aa0b03c3d"
+    },
+    "sound/freddie/painshrt.wav": {
+     "bytes": 8868,
+     "sha256": "31e08c51909022a6b0ad7f01f1f8dae196269b8b105e57e555025393cdc278d9"
+    },
+    "sound/freddie/sawstart.wav": {
+     "bytes": 41938,
+     "sha256": "90f83017a7ff5f2bd2824be1e122eab7d8171ab63a9025adf1fc03ee3e7a44aa"
+    },
+    "sound/freddie/sight.wav": {
+     "bytes": 55170,
+     "sha256": "3f73e5b30cef3038102ffa9ab0faf89e71af43ed2ee5a0758319c072c151c123"
+    },
+    "sound/freddie/step.wav": {
+     "bytes": 19898,
+     "sha256": "121818aa6200c770a70c2c02844bbc0351a62f166c31f9d85765896b426f610e"
+    },
+    "sound/freddie/step2.wav": {
+     "bytes": 19870,
+     "sha256": "7e33eb621ee356cbe4affe6218b988f477259dae705d57eea12d7fe10b5d4510"
+    },
+    "sound/freddie/step3.wav": {
+     "bytes": 19898,
+     "sha256": "a005232c4c0608092c7d697c6d24566892b74adfe7566030360c96996bd39357"
+    },
+    "sound/freddie/stfire.wav": {
+     "bytes": 27598,
+     "sha256": "597fa6e0e8c4da4fd85e9e26ecd7f95f3dc242846ec9b962cf2beb324e5a4fdc"
+    },
+    "sound/gargoyle/attack1.wav": {
+     "bytes": 28712,
+     "sha256": "cab70a44f7ec34343a1608ca8c13dd2b501065cade08e94b574f98436aabeadf"
+    },
+    "sound/gargoyle/death1.wav": {
+     "bytes": 41662,
+     "sha256": "07043eb3fcbcc9c8cf53b07c10b349a9f3beb471dc240a6d70d8f2b5a57e85b0"
+    },
+    "sound/gargoyle/death2.wav": {
+     "bytes": 28768,
+     "sha256": "c363613cd476d5099dbdced656244db0d704da5eeb54fe5b880f2202f6f465b2"
+    },
+    "sound/gargoyle/idle1.wav": {
+     "bytes": 72868,
+     "sha256": "90885fa6cae946ecfedec8a150911bcfdad8ef326254e1fb1bf44ca5c5af4eb0"
+    },
+    "sound/gargoyle/pain100.wav": {
+     "bytes": 26510,
+     "sha256": "d53f1e64f4c9f5e13e03cfee2681ef6dff370e95e9dd8668c7c06b79762e7773"
+    },
+    "sound/gargoyle/pain75.wav": {
+     "bytes": 28720,
+     "sha256": "78d5d0f1c5df4e1a565eeda076d5f8b3bb3582e551909b31fa8e36c292903826"
+    },
+    "sound/gargoyle/perch1.wav": {
+     "bytes": 26506,
+     "sha256": "5eab54a566e4c1136c40fbfbd636188a7a9c4aa6b278e51fb965e1761764cbff"
+    },
+    "sound/gargoyle/perch2.wav": {
+     "bytes": 30924,
+     "sha256": "745b5c5f1fd04a73a7581373925aa70cd3f35ab899df5f5fd2c610d07bf95bdd"
+    },
+    "sound/gargoyle/sight1.wav": {
+     "bytes": 35142,
+     "sha256": "1097300e4bca9ef61a7041e7f4ff403fe67c4fc0e687b30892a6bdf35bf45c09"
+    },
+    "sound/gargoyle/swoop1.wav": {
+     "bytes": 21056,
+     "sha256": "ef6b4b672dd984e846294e0be57d81df3abcb521b1f88f6afaf2f5cc2d4e91d4"
+    },
+    "sound/gargoyle/swoop1hit.wav": {
+     "bytes": 11078,
+     "sha256": "6a624e3f46e2c45f5e2d6f42ee18643a17268a6b0df2493fe6ffdba4be0c9057"
+    },
+    "sound/gargoyle/swoop2.wav": {
+     "bytes": 24364,
+     "sha256": "f98d41f9df7244e8f77c435ae4071a4e4595ec7005b7c72e44456fe7baca425e"
+    },
+    "sound/gargoyle/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 22094,
+     "sha256": "142b725ff5515cb438a592288a69e01331b3fd0bbb7311abf1dbaf90f95417ef"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/plasma_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/gaunt/plasma_start.wav": {
+     "bytes": 66270,
+     "sha256": "ad404715612b802a7d4f72f2d14abb47c338ac414af56c19ffc8dc2873f33452"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gaunt/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gibs/gib1.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/gibs/gib3.wav": {
+     "bytes": 33256,
+     "sha256": "10a19291ed8af8893b6cdbd80416425b27e5a197d39aa8d0557320752d78cf11"
+    },
+    "sound/gibs/gib5.wav": {
+     "bytes": 15490,
+     "sha256": "2d7603a9fc0c055ed3529bd4dfd511984c71b93f4719b605813eb5139d02c6d9"
+    },
+    "sound/gibs/gibacid.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/gibs/gibchain.wav": {
+     "bytes": 15938,
+     "sha256": "c6b2a37424a51810017bd5ee4764a014329467686f73bb2f48ad2704592176f3"
+    },
+    "sound/gibs/gibheavy.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/gibs/gibheavy1.wav": {
+     "bytes": 11110,
+     "sha256": "0a1313f08fa22e4df8a1beb15ffdb6e7b1906187f63042357e4a43631ef5e93a"
+    },
+    "sound/gibs/gibheavy2.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/gibs/gibhit1.wav": {
+     "bytes": 22150,
+     "sha256": "d2a73e2f9e31b9fefda789e49b17ec9bd18df0335c31f871514a282cf550829a"
+    },
+    "sound/gibs/gibhit2.wav": {
+     "bytes": 22150,
+     "sha256": "210477e93743dc6c0541bc158032d46251c6aeff551efcf515d6e7db87bb8a53"
+    },
+    "sound/gibs/gibhit3.wav": {
+     "bytes": 22150,
+     "sha256": "40db6dbb033d59dd458e5fb6102dba6d6ecf5bc5739d9fc35a3be68cc977da53"
+    },
+    "sound/gibs/gibhit4.wav": {
+     "bytes": 22150,
+     "sha256": "0bd1e29d68e41cbf2d753730df678918a38fc886b4690991fbd7e8fb3e13e055"
+    },
+    "sound/gibs/gibhit5.wav": {
+     "bytes": 22150,
+     "sha256": "4adf7a8249ee913aeb9e91120b1f6b9e529b1e1a3eadb75185589cf7c3ff910e"
+    },
+    "sound/gibs/gibmetal1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/gibs/gibmetal3.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/gibs/gibmetal5.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/gibs/gibmetala.wav": {
+     "bytes": 18474,
+     "sha256": "2c057e772307ef647b4313975cec75bacfd522bbc5dd27ae83a867065562635f"
+    },
+    "sound/gibs/gibmetalb.wav": {
+     "bytes": 30756,
+     "sha256": "fbcfa9e6cd5aa68c6fffd6699c8dc87ec3707a4281358f229afce57f3278c800"
+    },
+    "sound/gibs/gibstone1.wav": {
+     "bytes": 52956,
+     "sha256": "962dd735a1823905243700eb3f4e0caacc1be71a1f367ccad4f21dd82b4e99e1"
+    },
+    "sound/gibs/gibstone2.wav": {
+     "bytes": 22104,
+     "sha256": "04f070fa9873f382ded03a5139ce2c7da2013d8ef9221a8d10a64c3b5f912591"
+    },
+    "sound/gibs/gibstone3.wav": {
+     "bytes": 35344,
+     "sha256": "16262de5a0b703468f2c3f1e49ffa0c225eb81b89984b468b7bc95948ed890c0"
+    },
+    "sound/gibs/gibstone4.wav": {
+     "bytes": 8832,
+     "sha256": "75179beed6fb6f581944f5e7db153bea4d9ecc65899628468efd48710a392013"
+    },
+    "sound/gibs/gibstone5.wav": {
+     "bytes": 22130,
+     "sha256": "0aaff5c363ac29a9b50d83b4b04fcd7264c614a93d0c9bc7941c9704a6b4b499"
+    },
+    "sound/gibs/gibwood.wav": {
+     "bytes": 61708,
+     "sha256": "d9b53ab4d53f1265dd2083d341cd92f19729694946ff00ad15fa6d96965e63e8"
+    },
+    "sound/gibs/stonedeath.wav": {
+     "bytes": 76750,
+     "sha256": "26d0eb67357d292043fd494b1646f8ce005ba692d98610429bceedfc831d2325"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 374654,
+     "sha256": "de356a2581884e9008ef798775f82049c465aec242cad0f6024b510d33e11764"
+    },
+    "sound/golem/groundslam.wav": {
+     "bytes": 132412,
+     "sha256": "f557ad378642a77a2f31433db5fe9315cf33f5fc350018e2bd26d32359ec8617"
+    },
+    "sound/golem/iceshard1.wav": {
+     "bytes": 53022,
+     "sha256": "41e523122aa4168298b247748bbe4201928582e974e673a83e717ea33f8656a8"
+    },
+    "sound/golem/iceshard2.wav": {
+     "bytes": 53012,
+     "sha256": "4b4e457f75d051a7aa3525bf82338f8b6d2f9460583c09e63d82b202cb11d03f"
+    },
+    "sound/golem/iceshard3.wav": {
+     "bytes": 53038,
+     "sha256": "8134080a7c6478463f9ea8c368eb6e0563dacb35bb3941b1e08e2cf0763d83ab"
+    },
+    "sound/golem/iceshard_impact.wav": {
+     "bytes": 176470,
+     "sha256": "ac850565ac7cfaa8ec2e55f535603aaf131605b9399f08f1b17f7c08920f7bda"
+    },
+    "sound/golem/icestorm.wav": {
+     "bytes": 61802,
+     "sha256": "2e8129333bc1a677591f9c4838a5f8c8e9ff63050fe6a47f212380f2497ae706"
+    },
+    "sound/golem/idle1a.wav": {
+     "bytes": 88238,
+     "sha256": "d238c43b6e83c044ba70352ed9362e50d68caf606f500c7d79f5c03d1e6a432e"
+    },
+    "sound/golem/idle1b.wav": {
+     "bytes": 88242,
+     "sha256": "93e3ca1ec51345da6e06a53f71bcd1271c911c9a6272246de9f58bef93c904dc"
+    },
+    "sound/golem/idle2a.wav": {
+     "bytes": 44166,
+     "sha256": "d0ceeb0ee1681127f9f426ccaa0ddb75c6ef32594618c972536871544e8d5748"
+    },
+    "sound/golem/idle2b.wav": {
+     "bytes": 44178,
+     "sha256": "94fb43b50445dbe7a8fe6cc06ea745b729cf5bf61c33cc543123f751e4a9cdf7"
+    },
+    "sound/golem/melee_pound.wav": {
+     "bytes": 17672,
+     "sha256": "23ff4f485f3adb3ba5227ba59824e226e91005846d2879077ffbe04141bab78b"
+    },
+    "sound/golem/melee_punch.wav": {
+     "bytes": 17702,
+     "sha256": "21cbd6ca5b9c8d95a43c39b360b12ee8033dca1aaf11d4c1164d4bc9ce83b7d3"
+    },
+    "sound/golem/melee_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/golem/pain1.wav": {
+     "bytes": 27948,
+     "sha256": "388150975b33e271db5402f502c6a36899731ec85cb9b16cdcc4b427b206a3f2"
+    },
+    "sound/golem/pain2.wav": {
+     "bytes": 32940,
+     "sha256": "b3908c02406bcb8c379f345f80a825aa270a54ae02fe0356e02330620d9cf437"
+    },
+    "sound/golem/rockstorm.wav": {
+     "bytes": 264676,
+     "sha256": "c57be8195f675560b879c3fc4e23c49f021d0c45aa81f2a84b74303f111d7c7a"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 76762,
+     "sha256": "965d1107adbc9a068d1d2af16fc783855833569dcc3a6030fa920019c30a4083"
+    },
+    "sound/golem/wakestatue.wav": {
+     "bytes": 250454,
+     "sha256": "630505eb8c9c84511f39d2e77096cafcbab044f73569934cda127a4b6f37f138"
+    },
+    "sound/items/airtank.wav": {
+     "bytes": 22160,
+     "sha256": "9b8f5c5deb886800c91d46809ecf82fb114467eb8a395b9c980d47c6b35f6b17"
+    },
+    "sound/items/airtank2.wav": {
+     "bytes": 66286,
+     "sha256": "76156f8f89e2bedbfaee9ee3340adb6bfe8639f242051178c2655e04cdab5198"
+    },
+    "sound/items/airtank3.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/items/airtank3out.wav": {
+     "bytes": 176494,
+     "sha256": "672a866c27c64f7eda1e05775cea6b4373c289c39fd423a519d39198d10a9c89"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 15122,
+     "sha256": "54c25fca46991ea142e9fdf5309e690ce3ff977df89aa7d14a8938ff386a237e"
+    },
+    "sound/items/backpack_ammo.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/backpack_armour.wav": {
+     "bytes": 20612,
+     "sha256": "438a08f094f47fac5f0b959fdde0f941be50bac12abdaa159f6f727975021aec"
+    },
+    "sound/items/blastbelt1.wav": {
+     "bytes": 43442,
+     "sha256": "a85924de58caed8e32d2849838afa0f248ec26eb295c9fc82eff818bc292f28b"
+    },
+    "sound/items/blastbelt2.wav": {
+     "bytes": 74978,
+     "sha256": "e4747a55ed0d66b6ce3bfe4ad0a4cfa75308657a155ebd9396ada78e0fd46bac"
+    },
+    "sound/items/blastbelt3.wav": {
+     "bytes": 49028,
+     "sha256": "4a2f6e7f65cbbc19c4bd5facf821017f7e60c41b9c164575de5255a40de2ba53"
+    },
+    "sound/items/health0.wav": {
+     "bytes": 8718,
+     "sha256": "cd277cc4fc98dbf9d5b0ba3ab784e468ba77a5aec78fe6086bd125512b6d1dbc"
+    },
+    "sound/items/health1.wav": {
+     "bytes": 13316,
+     "sha256": "ed9a43a3506afd8073e0d5225f3fa43116bb922b84d2216c2053d58f597544e6"
+    },
+    "sound/items/itembk2.wav": {
+     "bytes": 18884,
+     "sha256": "2b5601380dcc36753327eea905d15d2e0fd0f016d9559a2f8924f6f34b8045d5"
+    },
+    "sound/items/jumpboots1.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jumpboots2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/jumpboots3a.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jumpboots3b.wav": {
+     "bytes": 85590,
+     "sha256": "8eda0e57fdadfb61a414b4dae8c567a2bf10d9dabc44db7cf5589f00bba16250"
+    },
+    "sound/items/jumpboots3c.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/lavashield1.wav": {
+     "bytes": 30884,
+     "sha256": "e79050c462eeefcdbe6be0d79ff3042e80e5654c4060cf5377eee366cb4d6b43"
+    },
+    "sound/items/lavashield2.wav": {
+     "bytes": 49190,
+     "sha256": "17e93e45d150704bab8debd86ee8e9c600e9b08fefa70b16e1fe712dfdbd0c23"
+    },
+    "sound/items/lavashield3.wav": {
+     "bytes": 22094,
+     "sha256": "d94735d5df3c5850d2308972cb2495a9c9ec87e57c434c3ff0c160da659b051f"
+    },
+    "sound/items/nailp.wav": {
+     "bytes": 97394,
+     "sha256": "eb786846675412ba7bfb892fa0d5d356b67ec83ad3a551de8b423a874c3608d1"
+    },
+    "sound/items/nailp2.wav": {
+     "bytes": 132454,
+     "sha256": "2a01a3beb92154c7275c3c2ad39f648f8ecad7fd32ef7264d7404b917e0147dc"
+    },
+    "sound/items/nailp3.wav": {
+     "bytes": 45268,
+     "sha256": "0ea4502763119419b226d830b5b0147d6cfbe78996749e330d652d5b538dbb7b"
+    },
+    "sound/items/protect.wav": {
+     "bytes": 44176,
+     "sha256": "1bc5895a71225e8a385ebc900952d3b41f3d9541eefb8affcf15804ca96e5ab4"
+    },
+    "sound/items/protect2.wav": {
+     "bytes": 66286,
+     "sha256": "80b2a47fb1158f252e888bc692d352f224170c2d18177163dfea5c8110688e65"
+    },
+    "sound/items/protect3.wav": {
+     "bytes": 44176,
+     "sha256": "4aab23bd1683c733c5c85e7d55a93b27746860bd3c1a707e8c5a6439e35b5fd2"
+    },
+    "sound/items/r_item1.wav": {
+     "bytes": 12272,
+     "sha256": "3b569e1a8210563a64045dc1629a243b382c49cf24722cbddbdae348d5fa75d7"
+    },
+    "sound/items/r_item2.wav": {
+     "bytes": 14462,
+     "sha256": "088bb9013c0d2201997d3c566b95cc91f0419ba0bc89173c9e532659ccb4e886"
+    },
+    "sound/items/sharp.wav": {
+     "bytes": 100592,
+     "sha256": "c86d353daa830fffcf5ded77b73d6b8871d15a47a857a977ebaf7cbddb6cb587"
+    },
+    "sound/items/sharp2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/sharp3.wav": {
+     "bytes": 46584,
+     "sha256": "6318f7079e79929ff0439a570c5f806ec9c2cce8a8447eddb666dee0c2211336"
+    },
+    "sound/items/sharpa.wav": {
+     "bytes": 97394,
+     "sha256": "cd0d8dc72f736b38ab9c4a473798f0dd32e2074c14a310892c3fdf6515ff53be"
+    },
+    "sound/items/sharpa2.wav": {
+     "bytes": 132454,
+     "sha256": "2545c58a3682c1e8459389dc728a39fe0d76e6ce14a9c816a4826e327ab9bddc"
+    },
+    "sound/items/sharpa3.wav": {
+     "bytes": 45268,
+     "sha256": "083cc822d4cd6819d2dfd6e125ea4ca8ef3230c1ac1c4a5f5e3fe22e4d3d36d9"
+    },
+    "sound/items/suit.wav": {
+     "bytes": 31568,
+     "sha256": "a9b13127acef0c8e617cf5e510d5654227db9049a2b06b7544eb9e3030146ee7"
+    },
+    "sound/items/suit2.wav": {
+     "bytes": 66368,
+     "sha256": "34f0ba1b415ab62f2eb3b7a59bda6fe6fbbf3e519c7d2fab29a42ce29eb073c3"
+    },
+    "sound/jim/death1.wav": {
+     "bytes": 14348,
+     "sha256": "7f97f27dfda78f9fe6fc5265e512b651e57ae466752d56cfe0dccd6d08478ed8"
+    },
+    "sound/jim/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/jim/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/jim/gunidle.wav": {
+     "bytes": 13260,
+     "sha256": "46441335fe896cb993368bb12cedc1ddd4886b5933298bb6a0d6b7ba430cdfe5"
+    },
+    "sound/jim/gunidle2.wav": {
+     "bytes": 48540,
+     "sha256": "08d3577b66ab4b4c65ae7b01e4590e8d985605cc51a939bae0b43967472208c6"
+    },
+    "sound/jim/idle1.wav": {
+     "bytes": 44460,
+     "sha256": "7bc2df6cdd0f9a06cc441c656664edb3c686ab5803dab70948cc27bbba968494"
+    },
+    "sound/jim/idle1r.wav": {
+     "bytes": 44460,
+     "sha256": "7549a540858b1a829ac010930b848474c2f2200b910371368c99e35641f24644"
+    },
+    "sound/jim/idle2.wav": {
+     "bytes": 44460,
+     "sha256": "90d55e9ac8db5523255ec80384abd2508f005890f4fb66a654f4d783435afb4d"
+    },
+    "sound/jim/idle3.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/jim/laser_load.wav": {
+     "bytes": 36040,
+     "sha256": "5f39b9f60c5de5c9c3ac25a5149f1fef557e66c09d7d1a760ed6770082c5a914"
+    },
+    "sound/jim/pain1.wav": {
+     "bytes": 27006,
+     "sha256": "27522940f1db4eb098388e049a63d3a608e4beb2fa248d1232ae45d38a944e85"
+    },
+    "sound/jim/pain2.wav": {
+     "bytes": 30850,
+     "sha256": "6d1988d75f430287ad3e8766e9aafa8c8c85e2f2ebf53395b0fc2eb0fb26d788"
+    },
+    "sound/jim/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/jim/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/jim/rocket_load.wav": {
+     "bytes": 23416,
+     "sha256": "e3820aad09060be13927e56fc0e21112c22161b50b7d5be9cf59b98f84c5a231"
+    },
+    "sound/jim/sight1.wav": {
+     "bytes": 14892,
+     "sha256": "1a0db2b8c8d763f9aae09913d1cd3548fa0e30eb03949e24ef511a70acfda303"
+    },
+    "sound/judge/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/judge/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/judge/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/judge/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/judge/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/judge/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/judge/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/judge/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/judge/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/judge/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/judge/smash_ground.wav": {
+     "bytes": 66250,
+     "sha256": "f29f17426d2bd961d4f166e25fb951c8e12a37314bbc49722f0ae34c2beae233"
+    },
+    "sound/judge/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/judge/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/judge/smash_roar.wav": {
+     "bytes": 61784,
+     "sha256": "24b26a6b00a8731693bafd8ef67a5f0e2a4bbad20e722ec14f6fefd13047dc78"
+    },
+    "sound/judge/summon.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/judge/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/justice/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/justice/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/justice/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/justice/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/justice/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/justice/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/justice/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/justice/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/justice/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/justice/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/justice/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/justice/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/justice/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/lostsoul/bite.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/lostsoul/charge.wav": {
+     "bytes": 114682,
+     "sha256": "327cf4f521c92b3af6ff7cf50d1bfa6d101d06dee52350f123473e56e72626e3"
+    },
+    "sound/lostsoul/death.wav": {
+     "bytes": 151916,
+     "sha256": "08b6f8d3a50465e7deb346bc8902605bfc8bafc134cfac38aeb1d9fa5d1d2863"
+    },
+    "sound/lostsoul/idle1.wav": {
+     "bytes": 132332,
+     "sha256": "aac9bd66ea75d4778a20ba07b248baaa4f446beb60e5b5be76d04be36df1a1db"
+    },
+    "sound/lostsoul/idle2.wav": {
+     "bytes": 132332,
+     "sha256": "963c18a04a41d49ced0c820fd6ec51c885e7828a2a09bd47c15227555b6d4ada"
+    },
+    "sound/lostsoul/pain1.wav": {
+     "bytes": 14948,
+     "sha256": "baccaed4fd7c4e504214eb7241d3e8ea3e187739a781c30de57c8b5af6dbe6d0"
+    },
+    "sound/markie/dronebell1.wav": {
+     "bytes": 410346,
+     "sha256": "c7b65065ba9279c8131a83b642523e4193b8611f7b14430af2d52c831082340a"
+    },
+    "sound/markie/dronehum1.wav": {
+     "bytes": 156754,
+     "sha256": "9542c51342398a1281476da03114adb01012367dac58d2a08b50c684a1a98093"
+    },
+    "sound/markie/dronehum2.wav": {
+     "bytes": 183654,
+     "sha256": "03545ae0f88b788e69e09c0aae2cccfa727a2609ef224c7d1d3451f0e6172709"
+    },
+    "sound/markie/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/markie/dronespace1.wav": {
+     "bytes": 151808,
+     "sha256": "2c9c7f38a2023d3452a48db3e5f98d11fa218315991d907f8e3fa95d128d4f76"
+    },
+    "sound/markie/dronewind1.wav": {
+     "bytes": 110328,
+     "sha256": "f65fd70b6c398e1a17975eff7d92bde89ac17bc8d5cf0e9c6dcb17934311e3a6"
+    },
+    "sound/markie/morte1.wav": {
+     "bytes": 529280,
+     "sha256": "c338e404901bbf094c5946e50cbd922580c077dc3f3e5369ab962cb07a70d855"
+    },
+    "sound/markie/morte2.wav": {
+     "bytes": 529280,
+     "sha256": "58e598c9da2ced85f6973eb897f578e0f29a13fa0eaefebfe14c8942a33c77ed"
+    },
+    "sound/markie/ritual1.wav": {
+     "bytes": 273266,
+     "sha256": "fe9b4b53f899a88321707330bb2454442d74e5098328e35549b9f0a8ff840cba"
+    },
+    "sound/markie/ritual2.wav": {
+     "bytes": 273246,
+     "sha256": "d38ee880af55413aa7c180b8c1935df71177502081ee1c376c37b572af3d9352"
+    },
+    "sound/markie/stingwhisper1.wav": {
+     "bytes": 132380,
+     "sha256": "fc6eebd33c0c99c0f4537a9727698181acb4d23d077f06b3da1ebbcb104c870c"
+    },
+    "sound/markie/stingwhisper2.wav": {
+     "bytes": 132380,
+     "sha256": "ae7319c28e0a4e492623b7ddb48634978da043c16d4450f86b8edf7e60fa283c"
+    },
+    "sound/markie/stingwhisper3.wav": {
+     "bytes": 151672,
+     "sha256": "e5dd9dcfd44dedf7b0cd4a0a94a519a0bbd84477e54293548a37aa16d3f1e428"
+    },
+    "sound/markie/watercreek1.wav": {
+     "bytes": 184884,
+     "sha256": "f0c3ac87d6f073cea0d1a9218c4e53327be7af07a8c8be00cd73f254f6c0ba03"
+    },
+    "sound/minotaur/attack1end.wav": {
+     "bytes": 19936,
+     "sha256": "eceb47163a0f495037bd067fcfe852dbd0cf8cc7c376c536f5e4bda8569d3f5c"
+    },
+    "sound/minotaur/attack1expl.wav": {
+     "bytes": 15554,
+     "sha256": "a8344e4036b9377a6c8e3d69c2e86c7f5fc157fb0034d6e0e190d5b9fc444ca7"
+    },
+    "sound/minotaur/attack1long.wav": {
+     "bytes": 42000,
+     "sha256": "bb901880112ff159b380b8bfaf19fc511f4b1217f08d55a05276a3500f6cd4c7"
+    },
+    "sound/minotaur/attack1start.wav": {
+     "bytes": 19944,
+     "sha256": "33dafc2b20be70d6da51321f9910a392535e6a31cbbd3c8d0d880307a18adb3a"
+    },
+    "sound/minotaur/bolt_fire.wav": {
+     "bytes": 17738,
+     "sha256": "2f8ea56413270eef58b56ae4c4f7af2506ee89fda82aab90c0426f4560baa80a"
+    },
+    "sound/minotaur/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/minotaur/idle1.wav": {
+     "bytes": 17686,
+     "sha256": "d213130ad4b58b5b55553da46d358526411916210e90caf082c5a93b499e2f81"
+    },
+    "sound/minotaur/idle1com.wav": {
+     "bytes": 15564,
+     "sha256": "0f8054eb2c16284a098f680dcdc65f5a4b8b971f8cceaca6adebe8c377d6117f"
+    },
+    "sound/minotaur/idle2.wav": {
+     "bytes": 15470,
+     "sha256": "390c82c79532878751bcddca11aa37dbd86018757860e46d0c950a09fee347d9"
+    },
+    "sound/minotaur/idle2com.wav": {
+     "bytes": 17764,
+     "sha256": "8369884de2f4f144b9e323f11e95f47723834b529b62100c908fef5e74391a93"
+    },
+    "sound/minotaur/jump1.wav": {
+     "bytes": 22160,
+     "sha256": "1aa935c4c76818dbe7faed7aee0d9acb9e98ad553a747bf00b83b811d141e886"
+    },
+    "sound/minotaur/pain1.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/minotaur/pain2.wav": {
+     "bytes": 41488,
+     "sha256": "bc9ffeb193379c6738ad2897ab582aa92e278a11d7f1fbb77563ca367987ff76"
+    },
+    "sound/minotaur/sight1.wav": {
+     "bytes": 48610,
+     "sha256": "8d0a5c1a31e525416430f8d45b8482b091d3bb9f6030ac2656bdeb231ddab5e9"
+    },
+    "sound/minotaur/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/minotaur/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    },
+    "sound/minotaur/strike1.wav": {
+     "bytes": 11142,
+     "sha256": "69b1419eed136c384deac99d31827825d3d57fc965ba80604faf9de3e85fd9b8"
+    },
+    "sound/minotaur/strike2.wav": {
+     "bytes": 11142,
+     "sha256": "ab12dc8ab3c9dc603e2ecd58a99beb9c1f551fb79eb6124bdba493efe7595a92"
+    },
+    "sound/minotaur/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 19940,
+     "sha256": "0798d1a1122171f06fd6b92e3f91881725c05f40e1eeb3494a5a1a1aa8a86e58"
+    },
+    "sound/misc/drip1.wav": {
+     "bytes": 12172,
+     "sha256": "9499c277eab2210ba491b61263b71410e5e8f4b2a68403ec6eb81bef687da04a"
+    },
+    "sound/misc/drip2.wav": {
+     "bytes": 15596,
+     "sha256": "410c25c5c459362849c7d3d0ad736e006b65a949e77c094fe248e803b357d5e0"
+    },
+    "sound/misc/drip3.wav": {
+     "bytes": 15164,
+     "sha256": "9ddf50265efafde7736fb7d03419988caab691245b32d986549ef6d643d2768c"
+    },
+    "sound/misc/flies1.wav": {
+     "bytes": 44168,
+     "sha256": "ca5cf0a4d661bf7440cd81dcd45ad7118c54c8ae58672755ee958ec6e50f7152"
+    },
+    "sound/misc/flies2.wav": {
+     "bytes": 44166,
+     "sha256": "09e6d74986b0f0ec9503d9e111f8d1436d7d6c5c4c0c87ec7808e3fca5b964b1"
+    },
+    "sound/misc/flies3.wav": {
+     "bytes": 44182,
+     "sha256": "2b5fb337ba88bd25e10c86bb6355723aea160b0ef6a6d43b30cbbd446444ed8e"
+    },
+    "sound/misc/gibf_fire1.wav": {
+     "bytes": 14376,
+     "sha256": "804f8524135d058d3a635e6567e3369b8b9ef2ecc808bf6e216c4d65609b86a3"
+    },
+    "sound/misc/gibf_fire2.wav": {
+     "bytes": 25842,
+     "sha256": "354b551ac38a19370126f67e3975ab795953bd7beb2c597f0a01a0de6286b7c1"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/laseron.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/misc/poweroff.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/misc/poweron.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/misc/rumbleloop.wav": {
+     "bytes": 106060,
+     "sha256": "fafcaa92b4a2174045e3826885d14e434a409bf559d1a1d519c4d50ec8939789"
+    },
+    "sound/misc/rumbleoff.wav": {
+     "bytes": 105990,
+     "sha256": "46728daf18b142575d50049188030a153c0e3e994dc83ea375c43ba6da171b3c"
+    },
+    "sound/misc/secret3.wav": {
+     "bytes": 302444,
+     "sha256": "75682a08b790af46c2b9f746e5772999ba1de333b567832f4a3a8414c6a0185a"
+    },
+    "sound/misc/spaceship_fadein.wav": {
+     "bytes": 231712,
+     "sha256": "d6c905eb002532087273eadb5a577db443068532795fd509571179a354c56a9f"
+    },
+    "sound/misc/spaceship_fadeout.wav": {
+     "bytes": 495982,
+     "sha256": "9e5286b29adeb9cf7b3af489bb2ea539c8eed7b26a28ec1f34cd5f78c33e521c"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 13270,
+     "sha256": "14d74e6c01df6db6f92b8684527b31a7544de8d4dd9d123ebae554989e76facc"
+    },
+    "sound/misc/torchoff.wav": {
+     "bytes": 54160,
+     "sha256": "d49cf5f2100d9b5afbf76a662019a9e3a66fcd5fb40c2b2600ceab107227cbf3"
+    },
+    "sound/misc/torchon1.wav": {
+     "bytes": 88680,
+     "sha256": "ecb211c777393fe3c7012bf0a35cc157af94ccb4742cac3ca7ab6daa5546a4ac"
+    },
+    "sound/misc/torchon2.wav": {
+     "bytes": 84764,
+     "sha256": "b7d885df1c70b226a77a3cc8842565fa9ebf51561158daec4b12e9629a515986"
+    },
+    "sound/misc/torchon3.wav": {
+     "bytes": 97484,
+     "sha256": "25058a3354df07a90b8660640682f7091fa40da6f8abf178c7de71d547a8b0c1"
+    },
+    "sound/nour/attack1.wav": {
+     "bytes": 50794,
+     "sha256": "7f22a1569d59bcd406efd7828ed605d71bfbc8cea01606eedb78d33037655f77"
+    },
+    "sound/nour/attack2.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/nour/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/nour/death.wav": {
+     "bytes": 39772,
+     "sha256": "2e2d15b95fc35738108d83a2b5aefded93772134d2a8124d1b937b6bfcfd74c5"
+    },
+    "sound/nour/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/nour/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/nour/explode2.wav": {
+     "bytes": 22168,
+     "sha256": "654a50eb01d1c6c64bb8df4b85669448cc08b580ffc44616da854bd3cb339ea1"
+    },
+    "sound/nour/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/nour/idle1.wav": {
+     "bytes": 24332,
+     "sha256": "c77ef8ce85720e3bf0ea97937992b5aa7cc6b63149c951e71b4d3ead14fc21af"
+    },
+    "sound/nour/idle2.wav": {
+     "bytes": 44176,
+     "sha256": "e87bd537a35c005b06ffd28f66adde24d52af338d3956d4fab455d682e78eec9"
+    },
+    "sound/nour/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/nour/pain.wav": {
+     "bytes": 8686,
+     "sha256": "073044c582c2de6f336130aeb9503fa6edf1da4eed216a4b407b2cd18d5f9995"
+    },
+    "sound/nour/projbomb_burn.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/nour/reveal.wav": {
+     "bytes": 39780,
+     "sha256": "6dd892d207fa31eb93c5a033ab44bba4952b3aed892aa409e6a49e2059381cdb"
+    },
+    "sound/nour/sight.wav": {
+     "bytes": 48612,
+     "sha256": "252c0bf76b928f7fe998f82bf148816e88cdc24f812bd8c8d3a591c1c4ec3d7d"
+    },
+    "sound/nour/sight2.wav": {
+     "bytes": 48612,
+     "sha256": "18b8e9450c00d6a9308adffa2046e747b8ed7bb5547f868ed146cca75b260b87"
+    },
+    "sound/ogre/ham_hit.wav": {
+     "bytes": 52014,
+     "sha256": "20f7ec214fdf8a342ac8c3be7d3ed04c7b7b3479f9c74138a8a052ba7674ee46"
+    },
+    "sound/ogre/ham_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/ogre/ham_wave.wav": {
+     "bytes": 132316,
+     "sha256": "d957285dc74a4e067f600465112ed41d69d14554f8e87ad6b0372b9ca8af4b25"
+    },
+    "sound/ogre/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/ogre/ogidle.wav": {
+     "bytes": 25706,
+     "sha256": "54915681452970c56f1ef405b182e90fa7ee3c4d4d80e32583a38abc7c1db713"
+    },
+    "sound/ogre/ogidle2.wav": {
+     "bytes": 22426,
+     "sha256": "2ed241e576a709285f7ea8a9671f6032da5a8db96e094e9007f60617cad491fa"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 28742,
+     "sha256": "738af1bbf36d5b3287c45e7815d87ea7f5c1a0487c804de7272091fdbb7faac2"
+    },
+    "sound/ogre/ogpull.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/ogre/ogrefish_flappy.wav": {
+     "bytes": 51262,
+     "sha256": "79a9eafef5edf45851a1c391e301c6f515536922c297b904e148b337e7f54a08"
+    },
+    "sound/ogre/ogrefish_idle.wav": {
+     "bytes": 27552,
+     "sha256": "5abf50694e67aa1e805a598a464d5d3b1f0625677a2873761cae139c4b21d524"
+    },
+    "sound/ogre/ogrefish_in.wav": {
+     "bytes": 6678,
+     "sha256": "dd5fc9aecb5b6933252739047aa5d3f775797ad7bf6ddb5652ffd26ea9ead3e2"
+    },
+    "sound/ogre/ogrefish_out.wav": {
+     "bytes": 15502,
+     "sha256": "2610f025057ee0a6682b574567b7400f83ba9f6665b9f7f3b9e76cff75b8be53"
+    },
+    "sound/player/h2ojump.wav": {
+     "bytes": 22126,
+     "sha256": "dd2d3629970814e719be6c9650a497edd219f31fb1554927b9770a1b0dfcdc60"
+    },
+    "sound/player/heartbeat.wav": {
+     "bytes": 70640,
+     "sha256": "a68fd895a3212f967a4686e94df2749fa3f58392ab2228aa880697e25b548147"
+    },
+    "sound/player/inh2o.wav": {
+     "bytes": 22126,
+     "sha256": "4c4d55502ab63ddbc9beb64b0459ad4d7a2992fe41e76144d3bbd3333af4a570"
+    },
+    "sound/player/ladmetal1.wav": {
+     "bytes": 95952,
+     "sha256": "6cd990509a965ff251ffb33ff7c22b6eb708cec5f7b7b82e2196b1fb3d3cb1c2"
+    },
+    "sound/player/ladmetal2.wav": {
+     "bytes": 96116,
+     "sha256": "a477162fc355efc88568b9e18d668b7b0e8e99af460b88c755bd1ed57da35006"
+    },
+    "sound/player/ladmetal3.wav": {
+     "bytes": 96008,
+     "sha256": "20ea0c70bcc3c951bb067cb65b938c63267bba0a1eda3a335df525dc9432d234"
+    },
+    "sound/player/ladmetal4.wav": {
+     "bytes": 96126,
+     "sha256": "d2a6bede3a9c499d01a0b0b9620d4bd1935f9477ecb9c59a8d73f3133699ea45"
+    },
+    "sound/player/ladrope1.wav": {
+     "bytes": 70706,
+     "sha256": "6713acc390790d4723df21b0702796958132af34ce5ec0a85fca5edc36ccd728"
+    },
+    "sound/player/ladrope2.wav": {
+     "bytes": 70792,
+     "sha256": "384b8c3ad3749fa9963ff3210d7cb312858771cca85082b6a8ad13179ad92da3"
+    },
+    "sound/player/ladrope3.wav": {
+     "bytes": 70760,
+     "sha256": "ed397a0308ecacd0ba9774f082aec5e681bcffb219c8d9127b7d7606a6fbb02d"
+    },
+    "sound/player/ladrope4.wav": {
+     "bytes": 70758,
+     "sha256": "e1a4327f1c458f408abd6ff713d11e0aee8daaa9c876002b693135d8e64b68fe"
+    },
+    "sound/player/ladwood1.wav": {
+     "bytes": 48084,
+     "sha256": "bd68f3af0f6cd429d08aa44168e14435ed9e2e2ec0d6a038f83e2dd683cb7e74"
+    },
+    "sound/player/ladwood2.wav": {
+     "bytes": 48086,
+     "sha256": "bb687ec2183f460ac4240acfcd2f3da2f8bd9da043ba705f6e32c3439e4845b9"
+    },
+    "sound/player/ladwood3.wav": {
+     "bytes": 48088,
+     "sha256": "7271136b6398602c7b4bdbd610a37b5a82a66195842030a21de08a89808b4026"
+    },
+    "sound/player/ladwood4.wav": {
+     "bytes": 48086,
+     "sha256": "3b7580b31dee8a86e636c5fd17d92566d147417f98764d51097ad53ff0d19d29"
+    },
+    "sound/pushable/brick_m1.wav": {
+     "bytes": 44144,
+     "sha256": "7572ac5d03045552dfee673293722da8c663d072cc7b57e44adb2e3884ea33c9"
+    },
+    "sound/pushable/brick_m2.wav": {
+     "bytes": 44144,
+     "sha256": "209e22e4693184c7b0c022e650b156e255cfa76b18c1066fe20255e285b4e80b"
+    },
+    "sound/pushable/brick_m3.wav": {
+     "bytes": 44144,
+     "sha256": "edafb8bf0915badb97edd078aa129c10a29e8fc428f4e9143f5926f9aa336e43"
+    },
+    "sound/pushable/glass_m1.wav": {
+     "bytes": 48044,
+     "sha256": "66a5944b16e3fe59cf9f8632f92bd85f81b79dc8711337558c45078c91a13c46"
+    },
+    "sound/pushable/glass_m2.wav": {
+     "bytes": 48044,
+     "sha256": "d462bac59390f89facc7c00d8aaee6e71b529ae9f177514a5f2f0533c78d5a0e"
+    },
+    "sound/pushable/glass_m3.wav": {
+     "bytes": 48044,
+     "sha256": "1a2efd7875486d15df811135d589135c807ba0149c877085f165932eb2770320"
+    },
+    "sound/pushable/metal_m1.wav": {
+     "bytes": 44144,
+     "sha256": "91420caf0e2de995681ac09b2be26cc9d0759edc06498571527528419de407d1"
+    },
+    "sound/pushable/metal_m2.wav": {
+     "bytes": 44144,
+     "sha256": "72f018c79b343538fd90de944ed54e8e3351b3da0a6c198f28403d25fc8fb140"
+    },
+    "sound/pushable/metal_m3.wav": {
+     "bytes": 44144,
+     "sha256": "c26b3aff129d573a1175fb618186db3b7ede8976e134c563c1678f48eaf8e302"
+    },
+    "sound/pushable/rock_m1.wav": {
+     "bytes": 48044,
+     "sha256": "9fb6ebeae45b4c47b1e42af1f00441d0e0bb88fbb53f85ea875341f9db55efb4"
+    },
+    "sound/pushable/rock_m2.wav": {
+     "bytes": 48044,
+     "sha256": "b57d0f760bb318b1159293e38811e5607bae8ff244d8bbf56223b355ef7c5b39"
+    },
+    "sound/pushable/rock_m3.wav": {
+     "bytes": 48044,
+     "sha256": "5e6514c241bb11d6194d9762d5369fb2a8da287b3d4c08e67f23da84fdb26b04"
+    },
+    "sound/pushable/wood_m1.wav": {
+     "bytes": 48044,
+     "sha256": "e672209779ee47996ca93e60d30e572da3cced5381db3f34c14a709629a5f4d2"
+    },
+    "sound/pushable/wood_m2.wav": {
+     "bytes": 48044,
+     "sha256": "c76b7db5faf1cbf21c07dacec615436a95f34c0e16e68628b62ec89a89b12f83"
+    },
+    "sound/pushable/wood_m3.wav": {
+     "bytes": 48044,
+     "sha256": "d6751d9e67c49458df6c076d9b6be9619f845213a263cb76330f51700f8a632c"
+    },
+    "sound/scorpion/clawattack1.wav": {
+     "bytes": 13360,
+     "sha256": "b0daf0605690db89f34a19936f1c20ad25676a4e6cd9dfad0e5757cf81dc4f7d"
+    },
+    "sound/scorpion/clawattack2.wav": {
+     "bytes": 13360,
+     "sha256": "06da85e6d6035704932fdc1ef449de529e17853571d017c5a42b253b5ed71a94"
+    },
+    "sound/scorpion/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/scorpion/hiss.wav": {
+     "bytes": 26664,
+     "sha256": "9d9fae97f3996ff3c0616f7acda952166d5eced9227d15a8fbe9d285095e7936"
+    },
+    "sound/scorpion/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/scorpion/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/scorpion/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/scorpion/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/scorpion/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/scorpion/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/scorpion/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/scorpion/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/scorpion/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/scorpion/tailattack1.wav": {
+     "bytes": 25858,
+     "sha256": "61e6c65b4c68813925e594b96ebad8a945c87d51f2cd23f301e80e231e53033d"
+    },
+    "sound/scorpion/tailattack2.wav": {
+     "bytes": 19650,
+     "sha256": "aab86f97eed636ebfb79ae7b92e4b7f7a3436b0146ad75519edd4358716169c7"
+    },
+    "sound/scorpion/tailfire1.wav": {
+     "bytes": 8924,
+     "sha256": "1f41bd184aa58b9f2f1b2f1197f3b7827c55d523d03a354dd1fb6d469cf129c8"
+    },
+    "sound/scorpion/tailfire2.wav": {
+     "bytes": 8948,
+     "sha256": "40a126ab5cba6c291d69606eddb7e2ab63ab640b1347b2e78ab4b0f7aca90c5c"
+    },
+    "sound/scorpion/warning1.wav": {
+     "bytes": 76930,
+     "sha256": "ae19faeebc0d3ec8c9f136bba205e634a29425ec86c3036016e5f2d9cd550817"
+    },
+    "sound/scorpion/warning2.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/seeker/death1.wav": {
+     "bytes": 397272,
+     "sha256": "35d8a1091032f24ed6a65efa99a7618f32bc0def24779efb51752b75a9e31ca1"
+    },
+    "sound/seeker/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/seeker/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/seeker/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/seeker/footstep1.wav": {
+     "bytes": 96092,
+     "sha256": "e5cd4f907a1b70ec72048b2dd5a5062022e7058676c3d90d05b7426e189a5073"
+    },
+    "sound/seeker/footstep2.wav": {
+     "bytes": 96076,
+     "sha256": "f3c8ba8d65257ddfa73e3e54c737c49de5dcc5c17bb088feb3511c3d69d21ac4"
+    },
+    "sound/seeker/footstep3.wav": {
+     "bytes": 96092,
+     "sha256": "c6fa111be092592a253815826c499b9b1f18a0c536910e2a82eebec7fb7f817d"
+    },
+    "sound/seeker/idle1.wav": {
+     "bytes": 141126,
+     "sha256": "10693a1d5fc1d710e54a0d57ce10d71400de192b874d6776ffe176c2b399a6b5"
+    },
+    "sound/seeker/idle2.wav": {
+     "bytes": 97420,
+     "sha256": "c24b439701d9ec3cf055702f23a3eb23623320ae89b9d46ab98a791f08898573"
+    },
+    "sound/seeker/melee1.wav": {
+     "bytes": 106252,
+     "sha256": "addfb5fab225a77f08d5c126b13f929fa31aa1c9094fc79202121ca891933fb9"
+    },
+    "sound/seeker/pain1.wav": {
+     "bytes": 19884,
+     "sha256": "ccaca64b8c1ab87d7d70896333cbec22c3b61c443a36cd8f253ad0eafc2d7ae1"
+    },
+    "sound/seeker/pain2.wav": {
+     "bytes": 19884,
+     "sha256": "8c3be23111a5ef53a7b66c7b74e32404ff0e6989d7de835543e0a65645e3f793"
+    },
+    "sound/seeker/punch1.wav": {
+     "bytes": 19940,
+     "sha256": "e4bf6b7deb14b5d614b4d5b7d4eeee36059372c913cc906589e1048d4484259d"
+    },
+    "sound/seeker/range_laser.wav": {
+     "bytes": 88246,
+     "sha256": "ee9f13af042a2a98fb75fa33873a1e861f3418f598ddb390f15ab44fcf93fcbf"
+    },
+    "sound/seeker/range_plasma.wav": {
+     "bytes": 79782,
+     "sha256": "9b1d38a4e1937023536d5ab5de035c97e1ef69131d58822b194cab2a3aa340b3"
+    },
+    "sound/seeker/range_rocket.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/seeker/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/seeker/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/seeker/sight1.wav": {
+     "bytes": 163526,
+     "sha256": "ca06541f54bcc297ab19ee133de5c782e978cf7afc2fab34b3789c4c56044d30"
+    },
+    "sound/sentinel/laser.wav": {
+     "bytes": 9712,
+     "sha256": "c5f90e1823a04b48f7f24ac5b8792e1b42030a8b07970db5847dc1e74be094c2"
+    },
+    "sound/sentinel/nail.wav": {
+     "bytes": 13750,
+     "sha256": "7acc3ac05b7218abc6fef2d2397771d90fce6fa39415e33824be7e771d30e288"
+    },
+    "sound/sentinel/widle1.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/widle2.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/wpain.wav": {
+     "bytes": 19596,
+     "sha256": "bc7b6536a1c67aa89295eeacea2d9b36cb0bf783b5fb7cc6aaf4fa01a0edb3fd"
+    },
+    "sound/sentinel/wsight.wav": {
+     "bytes": 27322,
+     "sha256": "83bca2103d60c68435e27f0660e3ecd5bffb058e796382e7bdb43efabdfb9889"
+    },
+    "sound/shalrath/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/shalrath/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/attack1.wav": {
+     "bytes": 44184,
+     "sha256": "91f50e3b69909213e23149b6a3e9622c4367d77f871da5f01e6e4aea3badf648"
+    },
+    "sound/shub/attack2.wav": {
+     "bytes": 33174,
+     "sha256": "d4928f711f7e8fc1d8ba050a87b4e1c2d48ffc24af6a454637629dfae8902e3f"
+    },
+    "sound/shub/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/death1.wav": {
+     "bytes": 107440,
+     "sha256": "1551554be1b7896ee39156ce258bf68ac5dace891994788020ee95083ae33e77"
+    },
+    "sound/shub/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/shub/idle1.wav": {
+     "bytes": 75072,
+     "sha256": "9d33c61470d0c4269c8d113b4476b84236fa00e6ee3be061865e242c988093af"
+    },
+    "sound/shub/idle2.wav": {
+     "bytes": 75000,
+     "sha256": "21b063438744def5f79a50709c567cc9f3e3a28c39e58456068a3d4ae362617f"
+    },
+    "sound/shub/idle3.wav": {
+     "bytes": 75096,
+     "sha256": "310c4ff969da63c77e7ebb5b319aca0f17a10802ee942b21174349d5e5a79d72"
+    },
+    "sound/shub/pain1.wav": {
+     "bytes": 83880,
+     "sha256": "1d1536a51822b67106ea72bcb537efbf5f69e4a4592904f6feedee06ef5084df"
+    },
+    "sound/shub/pain2.wav": {
+     "bytes": 83886,
+     "sha256": "71c30d3f41e0f99cffcf5037b482c1da7bf028b477051219f6e605ceef28ae38"
+    },
+    "sound/shub/sight0.wav": {
+     "bytes": 83880,
+     "sha256": "6d4d96fc663db248cf9279c0b028c11b451b133c6e2c38364c13e105f8fa377f"
+    },
+    "sound/shub/sight1.wav": {
+     "bytes": 83880,
+     "sha256": "ecaf1595f3acbfe2e771a193c69bd6de5e6e3bd957405fdf4bcf59a2288bdb05"
+    },
+    "sound/skullwiz/attack.wav": {
+     "bytes": 15484,
+     "sha256": "ca662d909cb3b96bdfb93197092ed8e8a5d1ed27772a91a4a6ae5e9d3063017a"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 33166,
+     "sha256": "5d1ccd5b97bd38eaf46d1e0798009765d46d58ba17e7e6efc36350b0adaa22f7"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 33178,
+     "sha256": "dd77e90760bd85fc872a96c2eaa808b094a461ab2871bd8ab6a5372861560512"
+    },
+    "sound/skullwiz/blinkspk1.wav": {
+     "bytes": 44200,
+     "sha256": "ade109f32810094922f77bc3c03f02d33e98d855d3dcaf79ceab4cb200efaa65"
+    },
+    "sound/skullwiz/blinkspk2.wav": {
+     "bytes": 44204,
+     "sha256": "16d3b1296e1ed9c3bdc06dd25f5d9db3569cf3486794d29858d5ad227741dd1a"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 33166,
+     "sha256": "bc83800a91fad273e7f84f3cec2fa2787c902f4cd97fd5495f73dc9fb6d2c368"
+    },
+    "sound/skullwiz/fadeaway.wav": {
+     "bytes": 43092,
+     "sha256": "dd67d3ffe5a592b4e449d6bb00eee3c525ede786b0a2d9089832981311bfd61e"
+    },
+    "sound/skullwiz/idle1.wav": {
+     "bytes": 88252,
+     "sha256": "1834b946ff68aab07ade01b68d95d822d0b2a1baa51c1ceba7e66c73b8b6211e"
+    },
+    "sound/skullwiz/idle2.wav": {
+     "bytes": 88240,
+     "sha256": "57c49c7fd4f52b870a658e2e854e16c67389e9d79f9a1db5928f12d74741a1da"
+    },
+    "sound/skullwiz/pain1.wav": {
+     "bytes": 11132,
+     "sha256": "125e06cdfacd6aa78a90034d3f94086736734dd1dd9d170fef3a512b42e34cd0"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 15540,
+     "sha256": "ac5a56dbff28fa4724bd8766d8443090e3026007f6f4051cfecd2869b3f5ecb9"
+    },
+    "sound/skullwiz/poison_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/skullwiz/sight.wav": {
+     "bytes": 36484,
+     "sha256": "3051df89bfdce6b80c49c3513cfcbd679bf1f71c5562430d7738737e44f04f26"
+    },
+    "sound/skullwiz/skull1.wav": {
+     "bytes": 22144,
+     "sha256": "3a43bc5e1079740b61199ff21518f75cc1e4db7cdc9e25b57631b38b04d651a2"
+    },
+    "sound/skullwiz/skull2.wav": {
+     "bytes": 22158,
+     "sha256": "fed613207dc7691118ea5b62626df8773bda59816b008bfd2aeaa4d2f26a4b7b"
+    },
+    "sound/skullwiz/summon.wav": {
+     "bytes": 97022,
+     "sha256": "bf74e3dfbb330f481790f7bbc2b88e74b1654f7d5b327235c3d00bee3f62a06a"
+    },
+    "sound/soldier/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/soldier/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/soldier/rocket_load.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/spider/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/spider/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/spider/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/hiss1.wav": {
+     "bytes": 17802,
+     "sha256": "c56fcae8a01af94c07807730857b4b367f2c70c35869505528504faa29a17ade"
+    },
+    "sound/spider/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/spider/hiss3.wav": {
+     "bytes": 22582,
+     "sha256": "1a3c71b1e4ac2389c98c4af9db88e81b51a602c681bd00a1812995654863e2d4"
+    },
+    "sound/spider/idle1.wav": {
+     "bytes": 20922,
+     "sha256": "8a6d25359bbbc1f5e4f6962f4ce1742160537c6bb8bf8b806a0df96adfae819d"
+    },
+    "sound/spider/jumpland.wav": {
+     "bytes": 6038,
+     "sha256": "3c46bc58c52a61480c1a8dc2034aa240545521baf5e0027372992a9458796919"
+    },
+    "sound/spider/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/spider/pain1.wav": {
+     "bytes": 6108,
+     "sha256": "728cd94a64b27dea4d845a9e27e1ba09cfb286bff80128a67d1da0431b6b0c20"
+    },
+    "sound/spider/pain2.wav": {
+     "bytes": 10460,
+     "sha256": "736f0a768c0f52b22a301fc6a15f18f2f60e5579d3b27c2b78bcb7bed8e0c577"
+    },
+    "sound/statue/comidle.wav": {
+     "bytes": 17722,
+     "sha256": "3567914304c8fcf224e31bc302039432cd17833daabc2ed9f83053b01fef4f7c"
+    },
+    "sound/statue/death.wav": {
+     "bytes": 13472,
+     "sha256": "b030aeac3d806bc77fddaed4bb32684cfd2bbd707fe85e2500a3346c5931ec68"
+    },
+    "sound/statue/hurt.wav": {
+     "bytes": 8012,
+     "sha256": "9193f4e976675042409db103f7e3b26f667a56e913e96a37f223f1c606323246"
+    },
+    "sound/statue/idle1.wav": {
+     "bytes": 13304,
+     "sha256": "0b5d3bcbd00e846d38986f8919ff4fa7bcce92e45e5ba5949edd0e81b741b69c"
+    },
+    "sound/statue/idle2.wav": {
+     "bytes": 13316,
+     "sha256": "45469f14a25fd434ba1ed987fd20835ac058496d41df5a6aa543dec454670f36"
+    },
+    "sound/statue/sight.wav": {
+     "bytes": 9584,
+     "sha256": "84ab06d320f9953eebda7c4dd25a0e0de3369957de01c64af10a8b3ca886241e"
+    },
+    "sound/steelclaw/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/steelclaw/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/steelclaw/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/steelclaw/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/steelclaw/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/steelclaw/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/steelclaw/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/steelclaw/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/steelclaw/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/steelclaw/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/steelclaw/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/steelclaw/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/steps/drag1.wav": {
+     "bytes": 13586,
+     "sha256": "db069e08b7de4c5074cc4dd56f3b1cd2b6d77fe7869e1e03f5dddddcf9aad530"
+    },
+    "sound/steps/drag2.wav": {
+     "bytes": 13572,
+     "sha256": "b2ac07fe014e7c5afd4a5974c5d290b34a880a52f33668030a97a345d5811db9"
+    },
+    "sound/steps/drag3.wav": {
+     "bytes": 14690,
+     "sha256": "a29ee6f0977b205d146f81ee5be2f9b2f12ca76f177aaab9e35e556c4f555fa9"
+    },
+    "sound/steps/drag4.wav": {
+     "bytes": 13584,
+     "sha256": "1b5628a4272837ccf9c4044371a1d45eef23439b164be445b6f2ca90952e3487"
+    },
+    "sound/steps/drag5.wav": {
+     "bytes": 13584,
+     "sha256": "6dec9033ece2a02ce65c437e1b7e58512fd04d41a327487704de71cdf39b99dd"
+    },
+    "sound/steps/giant1.wav": {
+     "bytes": 33140,
+     "sha256": "d28f78c1514f215c64b6a3de38b5ffb5b891341ed95dc0277b1b3dba498cc64a"
+    },
+    "sound/steps/giant2.wav": {
+     "bytes": 33138,
+     "sha256": "7936f32a0ae371e216a195c3110b24db372a15091ea5c80e78875951f874d3b0"
+    },
+    "sound/steps/giant3.wav": {
+     "bytes": 33126,
+     "sha256": "58f79749cbdaaa608e6aacc368b74e0ac1e2ecf2ef45967c7f1f7b7a3e99c8fd"
+    },
+    "sound/steps/giant4.wav": {
+     "bytes": 33136,
+     "sha256": "4ffa741a70225aa31078f73a5612cf7d5ad9f9007163f0a5aeda749da099f9bd"
+    },
+    "sound/steps/giant5.wav": {
+     "bytes": 33138,
+     "sha256": "a2706d4dd9856cccdc3980156a77702883e36d86df54221b31a781c8e5e767e3"
+    },
+    "sound/steps/heavy1.wav": {
+     "bytes": 13282,
+     "sha256": "603679f83cc5095d2fa81d945285b2980195ba50ee2615fed85487493f0a536d"
+    },
+    "sound/steps/heavy2.wav": {
+     "bytes": 10870,
+     "sha256": "384f160ad4816b6984ef6b3b59c4bc1e8a2a3e05f9aaa80ee8b30ada2645669f"
+    },
+    "sound/steps/heavy3.wav": {
+     "bytes": 12828,
+     "sha256": "936417bc5ec9d30db8a74a9798328436259ffd704b11e1155d3fa79dc829e462"
+    },
+    "sound/steps/heavy4.wav": {
+     "bytes": 11050,
+     "sha256": "8d4879d40eda9182ff45fb18130c7979997d326581c14edeedc9cab440531e00"
+    },
+    "sound/steps/heavy5.wav": {
+     "bytes": 10198,
+     "sha256": "4e2e9892dee74d3472a45ecda889ae8d2f836786b44a55e5d1436690c7dadd5e"
+    },
+    "sound/steps/large1.wav": {
+     "bytes": 33118,
+     "sha256": "c387d084a10b28329610d8e3ad3e377f43087013e802be42af79f254276d00dd"
+    },
+    "sound/steps/large2.wav": {
+     "bytes": 24960,
+     "sha256": "ab91b4605671dd16da59963959cda3368a065612d8ed1776847da310b1e7b5fd"
+    },
+    "sound/steps/large3.wav": {
+     "bytes": 24280,
+     "sha256": "3e6a5ef0d8cbaba2e976f199d8d1ffa073fe8e83dacee709137335d42ddd7558"
+    },
+    "sound/steps/large4.wav": {
+     "bytes": 22092,
+     "sha256": "f2bde1b715f679cf814c2cd1375442170cf9f6e56d8ea1756900f81f1d1df453"
+    },
+    "sound/steps/large5.wav": {
+     "bytes": 24320,
+     "sha256": "c15b388bbed461461bac2c22b3a88ff272c04ad070e4791b7ce35c1559d16f77"
+    },
+    "sound/steps/light1.wav": {
+     "bytes": 8872,
+     "sha256": "f034fe2692c0fceb6de1c00e15facbcbd31ccd1fcf72510fd1e3cb6bdcc28795"
+    },
+    "sound/steps/light2.wav": {
+     "bytes": 6654,
+     "sha256": "998f665b4a7ccbc995096697606a91d208db024b0882df75ebaaac015f0d4ef6"
+    },
+    "sound/steps/light3.wav": {
+     "bytes": 6670,
+     "sha256": "b25e020a10ac6a7883fd584cff4895d6d785f8577daea15a30d2b745e146c1c6"
+    },
+    "sound/steps/light4.wav": {
+     "bytes": 4472,
+     "sha256": "a111052881024eef6e97393c1388e8ae538227b85c9b8cf0a73704abb2a504b1"
+    },
+    "sound/steps/light5.wav": {
+     "bytes": 3588,
+     "sha256": "55fb54e5ba2f8ec6249761ae6f07c12de6133457b51c584759e8841fb14cb46f"
+    },
+    "sound/steps/medium1.wav": {
+     "bytes": 8872,
+     "sha256": "38e731803a49be7d8018dd7b44060b578b5418f2f7aefb04d1c74c968ced187a"
+    },
+    "sound/steps/medium2.wav": {
+     "bytes": 8852,
+     "sha256": "e8701598e07f43a20aebebd1d1a5043213018199d50472dea37672e6dce4a2b3"
+    },
+    "sound/steps/medium3.wav": {
+     "bytes": 11068,
+     "sha256": "3ed07795c2363552554e6da1da5749be08e460fc6cd4c7266b9fa514732abb2f"
+    },
+    "sound/steps/medium4.wav": {
+     "bytes": 8872,
+     "sha256": "008992cd7972e7e1e6f0b785b40e398a8efe744a3f3f57e47370936796c3d6b5"
+    },
+    "sound/steps/medium5.wav": {
+     "bytes": 8864,
+     "sha256": "ccd26430fd354c0e87750e02d92c40071ef9dccadae5bdeebc7e0d2a2ec4eba7"
+    },
+    "sound/steps/slow1.wav": {
+     "bytes": 8878,
+     "sha256": "15614044d9d277fa3359edb07e7af74b9d7875150fddde5ab1fdceb0143337bb"
+    },
+    "sound/steps/slow2.wav": {
+     "bytes": 8856,
+     "sha256": "a8b16b688d12812a61127a885bf43c360adc2b84ae7806cc107b433c6f4635ee"
+    },
+    "sound/steps/slow3.wav": {
+     "bytes": 8852,
+     "sha256": "3a2a57e1a37d378c1ee73d5732840f6d20e588d794216c33896bf25879807600"
+    },
+    "sound/steps/slow4.wav": {
+     "bytes": 8868,
+     "sha256": "78bdea66991184043001262cc6ef5f1148cf0eb11b5f88fc51ff948311156e5f"
+    },
+    "sound/steps/slow5.wav": {
+     "bytes": 11076,
+     "sha256": "f63c868bd87926f017bec092749bd61c763b0b18635456ed56b660e53bf581af"
+    },
+    "sound/steps/water1.wav": {
+     "bytes": 63814,
+     "sha256": "01ed631b0d92dab11086b1106acc278ffd92522e2e46d21a0650fd29a79780f2"
+    },
+    "sound/steps/water2.wav": {
+     "bytes": 71994,
+     "sha256": "1b53561f02f60da1e1b6c8b72f722ba12e549c318725b974745b38666efa8e56"
+    },
+    "sound/steps/water3.wav": {
+     "bytes": 71802,
+     "sha256": "bbc0778017ccb579a9d531316b8af46585e91a100a251707ac34f4dbddf6922d"
+    },
+    "sound/steps/water4.wav": {
+     "bytes": 61448,
+     "sha256": "d3604afcb7751d987a78a0ee8ee4ca3593315cc6cf2f1909a9f7748535ccea50"
+    },
+    "sound/swampling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/swampling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/swampling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/swampling/idle1.wav": {
+     "bytes": 132044,
+     "sha256": "418eae21e001c1ae065df9357ebf2ad331f761062d75f345f12e99d9aec8cfb5"
+    },
+    "sound/swampling/idle2.wav": {
+     "bytes": 70444,
+     "sha256": "4026b4b56ffa9a207e1457e03ec94a8eb9042cfebf1c042fa291ba2bbbf1c4b5"
+    },
+    "sound/swampling/idle3.wav": {
+     "bytes": 171644,
+     "sha256": "fa54eaf040baf965f994b328bfb1a55cd90d1741d57ed580c1d44c51e9c125f8"
+    },
+    "sound/swampling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/swampling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/swampling/pain3.wav": {
+     "bytes": 67244,
+     "sha256": "4b186834bbec7d2ef9873f55d5df980da3b3fd2f19f76e54fd835d1aaf40fedd"
+    },
+    "sound/swampling/sight2.wav": {
+     "bytes": 88044,
+     "sha256": "6989ba3aca0c5f5e12d30d9958c6ab169f5c6c96f36f4843a9a19bab0e5d0c4c"
+    },
+    "sound/swampling/spit4.wav": {
+     "bytes": 76848,
+     "sha256": "6855555e2a188ed9ae0a1cd307c7715e54c6f3c10ac0fee9edbba2edf1a48d16"
+    },
+    "sound/traps/flame_loop.wav": {
+     "bytes": 28560,
+     "sha256": "661d8325af92fb37235952e2668578dbf57d844b7359627b4a2c25d15127bff7"
+    },
+    "sound/traps/flame_off.wav": {
+     "bytes": 28496,
+     "sha256": "ebc40d62265aad20813acd189511be0bac063ecc00d7ae712863de3dbdb84c94"
+    },
+    "sound/traps/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/traps/laser_hit.wav": {
+     "bytes": 4358,
+     "sha256": "0840d9fa27bfd2bcb86c2f0174810ae3eb9baa6a43867d27de1e074f7cd75e2c"
+    },
+    "sound/traps/pend_hit.wav": {
+     "bytes": 11908,
+     "sha256": "6fec8fd4edb67e8905d9ad0d7dce5ee5a9b4f43b724b75cb449e88b508384e11"
+    },
+    "sound/traps/pend_swing.wav": {
+     "bytes": 22142,
+     "sha256": "d20bbaf323c5aa0ee2aa21222f2a9f5fc956c0317e65c05e9d003bb08d80a9ae"
+    },
+    "sound/traps/saw_end2.wav": {
+     "bytes": 99808,
+     "sha256": "2a129f2d5fe3c9fd60873c336e2eed799b3d2ebc91bc8bf5a0860b45a6b83ceb"
+    },
+    "sound/traps/saw_loop2.wav": {
+     "bytes": 173082,
+     "sha256": "b4ca1bfeaab62c73bfc10f7daa2750738874d721af9e637479e8242f5220294c"
+    },
+    "sound/traps/saw_loop2f.wav": {
+     "bytes": 132748,
+     "sha256": "03a3e77feb8775a7b486363ed1d46d04fb9294f5507040e458ed8a05c37f0de8"
+    },
+    "sound/traps/saw_start2.wav": {
+     "bytes": 217184,
+     "sha256": "49f1dd84a7be0c4d0b1293aa587ab786d69f4cb463ce5a03f09da816eb22d384"
+    },
+    "sound/traps/sawblade_off.wav": {
+     "bytes": 15276,
+     "sha256": "44924313561cf32ea95c50ef80366ba79a2c86ff2f218fc89404c82617ce2c84"
+    },
+    "sound/traps/sawblade_on.wav": {
+     "bytes": 37582,
+     "sha256": "097635d29859ce28ea37da2d51ec346b8d5239435bb6be0bf5f094a555c110e8"
+    },
+    "sound/traps/sawstrike1.wav": {
+     "bytes": 30836,
+     "sha256": "489d8cdea78b2c333771b316741d7960d5c0da6845ea15b94991ece94837367a"
+    },
+    "sound/traps/steam_loop.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/traps/steam_off.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/voreling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/voreling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/voreling/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28354,
+     "sha256": "8c9ef55e309a43b1df1f08b66192b4ab262ba07e9315d3a70f4a9cf9dee9d51a"
+    },
+    "sound/voreling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/voreling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "5035bd555e9a6439c87e6b661a2da86633f7234503d52551e68f61e9504af86d"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 44162,
+     "sha256": "ccca790ed18e3705c083259f48db7d46d26310cf80c16cd2bad191d333fec5ba"
+    },
+    "sound/weapons/axe_ceramic.wav": {
+     "bytes": 24620,
+     "sha256": "53b6e873318f84424129f1486f0a715c9b1f46e9521c97858d3ddbd94ef4dc10"
+    },
+    "sound/weapons/axe_flesh.wav": {
+     "bytes": 7754,
+     "sha256": "8d0046355ea843f56d5260f581c89d2f885b553c97cfc7e01a93f6da487e03de"
+    },
+    "sound/weapons/axe_glass.wav": {
+     "bytes": 13306,
+     "sha256": "7fd4f7f02edf972c17cf64fea9ecfecca2e0a2d69da9828c1a1e2ce726dd9a79"
+    },
+    "sound/weapons/axe_metal.wav": {
+     "bytes": 28844,
+     "sha256": "d77bc0204c9f406f50ddf01241ff3a3cb34bd571f8a038a483fe49fba81fb160"
+    },
+    "sound/weapons/axe_swoosh1.wav": {
+     "bytes": 26524,
+     "sha256": "1ee4079e691b1e3e8eca8e6fe3098ee053f99b2a0028e725442771c84dc07e49"
+    },
+    "sound/weapons/axe_swoosh2.wav": {
+     "bytes": 13284,
+     "sha256": "a28435309759dd35576099d23a36dc378d9703db9f0778fba63efa3558cfc19d"
+    },
+    "sound/weapons/axe_wood.wav": {
+     "bytes": 7776,
+     "sha256": "ce5bd1465d66aa4aad5249c387f7f537b45b4f8a0e4bf76f37f8efc2a22bd9d9"
+    },
+    "sound/weapons/bolt_hit1.wav": {
+     "bytes": 12698,
+     "sha256": "07d2b6078f7936781a641f88e6ed02ab84f248da8f19e73713c1a71ac56cf42c"
+    },
+    "sound/weapons/bolt_hit2.wav": {
+     "bytes": 10658,
+     "sha256": "27ef878b7dfc0878140a19e3a0227ba389e5d0dc2b86df386852e2da2ebc5c93"
+    },
+    "sound/weapons/bolt_hit3.wav": {
+     "bytes": 11600,
+     "sha256": "06298d7bc8d7bce64f9473ae9530e0b42ea3de0ca5895f3476f9b00b5ed566f9"
+    },
+    "sound/weapons/bolt_hit4.wav": {
+     "bytes": 15460,
+     "sha256": "814b1a71efc9b58c90ad7f116c47e6f3dceeb8eae6d0ecbca5f1cd02dd247cb6"
+    },
+    "sound/weapons/crossbow_fire.wav": {
+     "bytes": 26536,
+     "sha256": "2a6ba54090412a53471c59b3edf6e8559d424dab25729e67a78f9ada5e13e8ac"
+    },
+    "sound/weapons/crossbow_hit1.wav": {
+     "bytes": 60782,
+     "sha256": "be1e78c92c13749e988d26912fba6c23f3700df0d7cc48d724f0da1f2608d006"
+    },
+    "sound/weapons/crossbow_hit2.wav": {
+     "bytes": 32472,
+     "sha256": "30a4ef9f23b2239371d32385e55487b279ca4f8f91366d4251cf4d9abdce200a"
+    },
+    "sound/weapons/crossbow_rdy.wav": {
+     "bytes": 37532,
+     "sha256": "321eac310a291cd9cdcbd2dcafb27687a12057e778e12704d8b4388d4eb6e4df"
+    },
+    "sound/weapons/crossbow_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/weapons/ghook_fire.wav": {
+     "bytes": 11526,
+     "sha256": "6e29f4524c0be70d8bf3b1201e737712b271c9bc963ad46c1815972b6addc22e"
+    },
+    "sound/weapons/gl_loadlong.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/weapons/gl_loadshort.wav": {
+     "bytes": 7758,
+     "sha256": "c97236bbfd211dfcad8130974413a8666cdbcf646d364abd8801b3d6ba5bf9c4"
+    },
+    "sound/weapons/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/weapons/laser_hit.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/weapons/laser_richotet.wav": {
+     "bytes": 12888,
+     "sha256": "bcc0498060e71b059d1d6ec45628048b0f29a7a0509b736a519196338b5df20d"
+    },
+    "sound/weapons/nofire.wav": {
+     "bytes": 1400,
+     "sha256": "217c42718548de32b5df972d117ffc1a0e1dde5f03a7a173bd91d0b4551248c9"
+    },
+    "sound/weapons/plasma_expl.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/plasma_fire.wav": {
+     "bytes": 88288,
+     "sha256": "6a0ad4930da39ff590c79f9d26b434bb1001536d33d880735df76e9354f90e94"
+    },
+    "sound/weapons/plasma_hit.wav": {
+     "bytes": 54406,
+     "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b"
+    },
+    "sound/weapons/plasma_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/weapons/r_exp3b.wav": {
+     "bytes": 34830,
+     "sha256": "a1abb7cedfa6576205f043c2e5f562606b039f65f6f996f5ffbb758d7855f2a2"
+    },
+    "sound/weapons/resist_rocket.wav": {
+     "bytes": 19938,
+     "sha256": "1e5170aaf1d6f144e7ea77c251d15ee85c9a70eb1f50b12e4ba5a93971ad1955"
+    },
+    "sound/weapons/ric1.wav": {
+     "bytes": 5650,
+     "sha256": "49223498fbf29b97f712537e6417917befc4e4f5c725bbf2e3d463580c15454d"
+    },
+    "sound/weapons/ric2.wav": {
+     "bytes": 11146,
+     "sha256": "5fa462f4ab3184cf70bf33f923a2b7e4392db517d34f8531a381864d78c352a6"
+    },
+    "sound/weapons/ric3.wav": {
+     "bytes": 11138,
+     "sha256": "1761926b96108fd0b0ee55270ee711fbd2f394f1b5e93da4af96e42c69fa3946"
+    },
+    "sound/weapons/riotgun.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "sound/weapons/sg1.wav": {
+     "bytes": 28718,
+     "sha256": "49074c95da2a619d82dee9d45e28dc910f9a8e16141270a76c81b396a41a6a3e"
+    },
+    "sound/weapons/sg2.wav": {
+     "bytes": 28718,
+     "sha256": "279b1bb969837073c46c176fe62782e60658a6614a8e094b9722cbabdca81fe6"
+    },
+    "sound/weapons/sgun1.wav": {
+     "bytes": 45840,
+     "sha256": "3ac6c4b3ded00fa48810f09afc95b4a8375dc3e8d52e04cd9cba18dfeee20087"
+    },
+    "sound/weapons/shellc.wav": {
+     "bytes": 21006,
+     "sha256": "45a2f8bd652307b9ebd37115c27166d03a4d7055f3054a215036fbc342e22f6d"
+    },
+    "sound/weapons/ssg1.wav": {
+     "bytes": 17244,
+     "sha256": "3e5b9cc1cd0cb86602391e4ddedbc98bb020e44b937eec4d3c5b053ff98c98f2"
+    },
+    "sound/weapons/ssg2.wav": {
+     "bytes": 75024,
+     "sha256": "248a021818f578ec3d96b9fe59d8f839242f4d5f8140a66a500b523b137d1977"
+    },
+    "sound/weapons/sword1a.wav": {
+     "bytes": 11184,
+     "sha256": "22bc8b25a67f1ab0752f9fbc68c2eb0958d2807c9e95bc8ee35d1d1bc9c6552d"
+    },
+    "sound/weapons/sword1b.wav": {
+     "bytes": 13272,
+     "sha256": "dca39f0c4776994c1bbe5255893d50dd86a634a370ea6046fd4e851117dec726"
+    },
+    "sound/weapons/sword2a.wav": {
+     "bytes": 11150,
+     "sha256": "aa381f8c68f5753cecbd889bc184a784c934c78c8fefe3b1ba4026a99112da51"
+    },
+    "sound/weapons/sword2b.wav": {
+     "bytes": 13232,
+     "sha256": "9460973ef948f8712be967d412774d32aeefb8e68b11959c28909eb16d9e8afc"
+    },
+    "sound/weapons/widow1a.wav": {
+     "bytes": 64644,
+     "sha256": "b4ccd6b235784f7ff53ccf0d726ecbbc789d2ddcca057b40df769b7925e3b32d"
+    },
+    "sound/weapons/widow1b.wav": {
+     "bytes": 66186,
+     "sha256": "0da0346e80cdcb405ffb8f9dbe048197cd9d303130f35b2546b4f7652bd06ca6"
+    },
+    "sound/weapons/widow1c.wav": {
+     "bytes": 66186,
+     "sha256": "eb054b4b1b2784bb098e24574ced6b8c2114e3344fc73e9beb23285adfa086a8"
+    },
+    "sound/wraith/attack1.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/wraith/attack1_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/wraith/attack2.wav": {
+     "bytes": 88200,
+     "sha256": "bdf849b4e138fa587df136a327c71ceed1176cbbb4ecb873434766d53da35a3b"
+    },
+    "sound/wraith/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/wraith/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/wraith/death1.wav": {
+     "bytes": 19960,
+     "sha256": "c0e5e05b46e4cf4afebfe5d0ef1801fc16fe8308a7f859ff347a77871b0a9339"
+    },
+    "sound/wraith/idle1.wav": {
+     "bytes": 51556,
+     "sha256": "e91f12463417df25badbbdfe817560362370d9e1e31712766bccb086e06d966f"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 82792,
+     "sha256": "b843d1124acc61be2aae27a7c8a9aca8f6bd471689703b41d59f1450e70e360c"
+    },
+    "sound/wraith/idle3.wav": {
+     "bytes": 55228,
+     "sha256": "3393943b38a0760c2b048c87c6b11ef743b0c968397ae7e434434b8b21fe12f9"
+    },
+    "sound/wraith/pain1.wav": {
+     "bytes": 18184,
+     "sha256": "a448cf5aed2909700e4da1f3ea3158b55e288198eee771eddacf211f4b274dbe"
+    },
+    "sound/wraith/sight1.wav": {
+     "bytes": 34390,
+     "sha256": "91494295e94c54c8da0307df8a51ea10d166fb18a78ede909a710f72ffe81c4f"
+    },
+    "sound/xmas/elf/attack1.wav": {
+     "bytes": 176492,
+     "sha256": "80e3faa699aec6d20015c1070087964de5ba39f83a978388b9fadc184f9fb6c2"
+    },
+    "sound/xmas/elf/attack2.wav": {
+     "bytes": 88292,
+     "sha256": "a364c82cb932bddb438c957e88a7ea67142777dfffd0f553d00e2b04b3af0f9f"
+    },
+    "sound/xmas/elf/cane_hit1.wav": {
+     "bytes": 4536,
+     "sha256": "2686bea9533633cb6c1a5e3e5bcf0016e3fe228cd278b7b1d11a02868cdd5095"
+    },
+    "sound/xmas/elf/cane_hit2.wav": {
+     "bytes": 5638,
+     "sha256": "6e470e241f37fb38ea55adf4bd0d6f1f5a2d5adfee5d5ddac8cb9adc824cb954"
+    },
+    "sound/xmas/elf/cane_swipe1.wav": {
+     "bytes": 1670,
+     "sha256": "2dbf81b3813376cb8bea2fa916dc0d03f1fbaaa499d4fcdf845de8929f82dc47"
+    },
+    "sound/xmas/elf/cane_swipe2.wav": {
+     "bytes": 1890,
+     "sha256": "404864c7d5008b79daed226566a2e4e78f2de92de06c64da67b8bf6224ae3e88"
+    },
+    "sound/xmas/elf/death1.wav": {
+     "bytes": 14284,
+     "sha256": "d1a7063d4ed39cdb59864a2a6fe6109f844caa9ada54ed4456de0bcd056f0034"
+    },
+    "sound/xmas/elf/death2.wav": {
+     "bytes": 10888,
+     "sha256": "4e0344a1bd3fa3d3c4d9e9647203cac0c449d5a5d8e7b1c8319f8402a4b7571c"
+    },
+    "sound/xmas/elf/idle.wav": {
+     "bytes": 57016,
+     "sha256": "a824467247797aa1ecc58f1716b18d390629804eebc413f01067646c64cde87e"
+    },
+    "sound/xmas/elf/jump1.wav": {
+     "bytes": 17766,
+     "sha256": "8023110b27a70758166f710e52188b8d03b8bfd81d9c985eb7f7d326acdb05a2"
+    },
+    "sound/xmas/elf/jump2.wav": {
+     "bytes": 8946,
+     "sha256": "a60763886b743d06ffd0c90e70de304ec8002a500947a684646c227d0bbb3c4d"
+    },
+    "sound/xmas/elf/magic.wav": {
+     "bytes": 15560,
+     "sha256": "6a270540819dddf140b0387d92c914b4f4b1c88c5f37a05c8fa0efd95901f2ab"
+    },
+    "sound/xmas/elf/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/xmas/elf/pain.wav": {
+     "bytes": 11126,
+     "sha256": "4e27a8f38e07e9b69db186d5c609740814ab86c5fda57058b1e05c56b85c6fd4"
+    },
+    "sound/xmas/elf/sight1.wav": {
+     "bytes": 21048,
+     "sha256": "c57eb4fec86922cb8a0499d7dae72eba66b067b89f14ff079ce0caf3dc23a23b"
+    },
+    "sound/xmas/elf/sight2.wav": {
+     "bytes": 30996,
+     "sha256": "8cd5eed3b8e098dfd70cbf90081b38e198bf64d8edf1b76bcc98c42e177635f8"
+    },
+    "sound/xmas/elf/sight3.wav": {
+     "bytes": 10050,
+     "sha256": "e88ae556a28352c319bf5500b29008384a5c53c47480defa81795d8891f14ff8"
+    },
+    "sound/xmas/elf/sight4.wav": {
+     "bytes": 6742,
+     "sha256": "7c6120d242cbbbfd2e0cc77b1428e206accd1ab8073885d52177b0fd4c75c7ed"
+    },
+    "sound/xmas/raindeer/attack1.wav": {
+     "bytes": 5582,
+     "sha256": "bcf78087eab53e8ed0bdde2f29088a89b321a79c3b104da380dd85bd5bdb6ec1"
+    },
+    "sound/xmas/raindeer/attack2.wav": {
+     "bytes": 6274,
+     "sha256": "2ba043cce4a2f22e7743812c0fa40e9f0888d5089362264c768352c347af5089"
+    },
+    "sound/xmas/raindeer/death.wav": {
+     "bytes": 9672,
+     "sha256": "68266e96ec1be80a55f48b76c2bedd6503273245153d96269947c7fc12ae96b3"
+    },
+    "sound/xmas/raindeer/hit.wav": {
+     "bytes": 5218,
+     "sha256": "72127151c2b05cc22a812fe9e38909c8bdcaae6a369e8756d2be67d392b91223"
+    },
+    "sound/xmas/raindeer/idle.wav": {
+     "bytes": 7890,
+     "sha256": "d3ef885d0b6163a3046dc9d514b07886c33809fbb6332e7db0514c648787a9bb"
+    },
+    "sound/xmas/raindeer/sight.wav": {
+     "bytes": 23796,
+     "sha256": "aafabb6fc46c1c72c34af1baea1c59a8ec04803c26faa4310072096481f31a4f"
+    },
+    "sound/xmas/santa/death.wav": {
+     "bytes": 99352,
+     "sha256": "b63273a2574f7def133aa438926a6def025aa64d8c3c636fc6a5594268e391d7"
+    },
+    "sound/xmas/santa/death2.wav": {
+     "bytes": 99352,
+     "sha256": "24fcf23117ec31347f640aa27e6feb4a46a634aa5e1eb48344b1feb7c377f6f1"
+    },
+    "sound/xmas/santa/fire.wav": {
+     "bytes": 22176,
+     "sha256": "3a9bb42661b75287a698b6e16033158f20c59c481d37c0f176dc213205d22dcd"
+    },
+    "sound/xmas/santa/good_hohoho.wav": {
+     "bytes": 55250,
+     "sha256": "51f4d5d656032de08b95689fa55a2e7aa26ec99cf4312b0f6153d0fd57fc1fa3"
+    },
+    "sound/xmas/santa/good_saved.wav": {
+     "bytes": 77302,
+     "sha256": "51e62df5942e2a72fd48311c61ee73b6f51dc4aa3c0cc85af000cdc8d7627d21"
+    },
+    "sound/xmas/santa/hohoho.wav": {
+     "bytes": 50840,
+     "sha256": "091a28236362cab1ce3b7bd55de25010d105db3bf644825c47b91725d8a613a0"
+    },
+    "sound/xmas/santa/laugh1.wav": {
+     "bytes": 57374,
+     "sha256": "ac069694d6c41e5e0afab50d9928b8768a19fb647bb249201648874d4150c976"
+    },
+    "sound/xmas/santa/laugh2.wav": {
+     "bytes": 117440,
+     "sha256": "c726d7d86d2d7cad0a75a2d0b387f4f96218ef232b6c78437e1c83bb96286441"
+    },
+    "sound/xmas/santa/laugh3.wav": {
+     "bytes": 40256,
+     "sha256": "4dd710eee601ab81c4beb5413d95244dee58b886b8265ab9cec35df06b560591"
+    },
+    "sound/xmas/santa/laugh3_com.wav": {
+     "bytes": 44226,
+     "sha256": "4099895e037cfecb4dc3595b3b18db62ed2f3cf096384f3aa1fe1d96a7b43da2"
+    },
+    "sound/xmas/santa/pain1.wav": {
+     "bytes": 6825,
+     "sha256": "79eed9346e0954fd53a6fdb9aa9708b8c29e8c5c256e9fd7c06f449e9cb6c00d"
+    },
+    "sound/xmas/santa/pain2.wav": {
+     "bytes": 9259,
+     "sha256": "f750328d74f545a658b0b190399595687c3d9b8766b2652ad6c2a34add3cc420"
+    },
+    "sound/xmas/santa/sack_hit.wav": {
+     "bytes": 13356,
+     "sha256": "c23a04ed5134f76d1f44d2e61eeb446a569c2bcbccf79f16f472807aae3df53a"
+    },
+    "sound/xmas/santa/sack_swing.wav": {
+     "bytes": 8940,
+     "sha256": "96972ba473b6a7d28645cdc621eb3011729a53eb4acb40d1f097768291a70850"
+    },
+    "sound/xmas/santa/sight.wav": {
+     "bytes": 100144,
+     "sha256": "e29696370a0d40546a49ef0f39b1e0038d8e067ef2da1dcc5084d7683a25d5d7"
+    },
+    "sound/xmas/santa/smack.wav": {
+     "bytes": 22176,
+     "sha256": "606c0a4b634d82a1d9846f654db8a52e7f2438ba28a235f782a23ff2720c767c"
+    },
+    "sound/xmas/snowman/claw.wav": {
+     "bytes": 8292,
+     "sha256": "7857f3526fb39e722a09ebe569f2b76facab765d82f97c0caa7da2ff9b750e9e"
+    },
+    "sound/xmas/snowman/death1.wav": {
+     "bytes": 11267,
+     "sha256": "0a09776ed8e45bbfe403f1cdb50302361f5596d9027c476409d6acf5402e763e"
+    },
+    "sound/xmas/snowman/death2.wav": {
+     "bytes": 13613,
+     "sha256": "e5e3a9619a153f0c6259abdb0d45f4eb4a547f736e37951556d29c6b715ec8f6"
+    },
+    "sound/xmas/snowman/icehit.wav": {
+     "bytes": 3090,
+     "sha256": "e03f61550bafc53ab47acdc23bcd481c35e75e6eccdad5e61e6dd7b372ba07c0"
+    },
+    "sound/xmas/snowman/icemiss.wav": {
+     "bytes": 3074,
+     "sha256": "f8b86f83d9adaaee1c84e1ac2acbcf652204842f2bf6f351ec1443a998574058"
+    },
+    "sound/xmas/snowman/idle.wav": {
+     "bytes": 58582,
+     "sha256": "a0d7af1cd6246f08176f24c5591cfb6ec89cff55dc5c18766ef1b16c64429541"
+    },
+    "sound/xmas/snowman/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/xmas/snowman/pain1.wav": {
+     "bytes": 7685,
+     "sha256": "7f829300a30cb6cb4d17f8c8327bd62ae5b5dacc892d28a956d6ecd2acf5f1c2"
+    },
+    "sound/xmas/snowman/pain2.wav": {
+     "bytes": 7661,
+     "sha256": "3747d77583aa4edb3509e89ea651ea41a8e8a92cd96c34d4e00257e7371fb0e6"
+    },
+    "sound/xmas/snowman/shotg_fire.wav": {
+     "bytes": 6572,
+     "sha256": "3d54870c0f643b1e7ee5307641bb3fc4a94efdaffc2e4ecd196556b930167ef2"
+    },
+    "sound/xmas/snowman/sight1.wav": {
+     "bytes": 10042,
+     "sha256": "ce1cddbb6e85fad23231ac1fc4c04c19ec7276acb2aa86e023c117db4b8edd68"
+    },
+    "sound/xmas/snowman/sight2.wav": {
+     "bytes": 15418,
+     "sha256": "5d4e994c30a7c3f2e1f1a5cde9a56115bcb32c350e4a0ad8e339a1a46ed19707"
+    },
+    "sound/zombie/boil_explode.wav": {
+     "bytes": 38012,
+     "sha256": "210dac94ab0e4efb5eb3bdbfa5d7100094b1bfef917a8d5abb2ae186252c0a27"
+    },
+    "sound/zombie/boil_idle1.wav": {
+     "bytes": 33204,
+     "sha256": "e2b717040d436ba2a659ceb1e5b74dfeaad57577297a9827957733e00ce7cb34"
+    },
+    "sound/zombie/boil_idle2.wav": {
+     "bytes": 33206,
+     "sha256": "8bd584597f2c54e6f8ecca5c0a83e44b0b5a09a745026e41cc2cad8ded6f729a"
+    },
+    "sound/zombie/boil_sight.wav": {
+     "bytes": 33192,
+     "sha256": "0e285e98dc66cd49af507dae9ab5281aaec55eaf9d401810a8d230d93539123a"
+    },
+    "sound/zombie/boil_squirt.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/zombie/boil_windup.wav": {
+     "bytes": 22094,
+     "sha256": "3790791943ea03add95bc303df34470c534f9c2c76e4343831609eaee761633d"
+    },
+    "sound/zombie/zk_sight.wav": {
+     "bytes": 26916,
+     "sha256": "8fe4d5fea16bd7c3661a968d26782ea8c4741157e16e22f33317619229b10637"
+    }
+   },
    "sha256": "7e53a350942e1767fe7a545b90c3fb1b4cb26e455053a3263b75a6cd38c4399c",
    "timestamp": "2021-10-31T23:13:56.000Z"
   },
   "pak1.pak": {
    "bytes": 5468494,
+   "files": {
+    "maps/ad_brk/all_brick.map": {
+     "bytes": 22738,
+     "sha256": "e0859c71d8a3d5d4b140757e4fcd2ab4e92674bbb71979d6b9d6d2deb5d2390a"
+    },
+    "maps/ad_brk/all_glassa.map": {
+     "bytes": 8834,
+     "sha256": "f4e1c7c1444b3b2d8a3463e8950c0a6a3aed8d39144a6b1fc2a69bdbf376f444"
+    },
+    "maps/ad_brk/all_metal.map": {
+     "bytes": 12297,
+     "sha256": "447c74022bea3ae89d3a4412afcf4bcd384ea725b344b987fb2e7bb37adfabe1"
+    },
+    "maps/ad_brk/all_rocka.map": {
+     "bytes": 10235,
+     "sha256": "52edb0d5b9f79e8b89a58353098316e81be31c3e289d6f96e450ea01c4bbeb62"
+    },
+    "maps/ad_brk/all_wood.map": {
+     "bytes": 8397,
+     "sha256": "93697129156d662c18391564e26c5d5ceec8bac244209496290b8e9a516a5bfb"
+    },
+    "maps/ad_brk/brick01.bsp": {
+     "bytes": 7912,
+     "sha256": "c11880924b195ed38908cbf50f9cd16f071918df0a94a19c7254b93dddb1e62d"
+    },
+    "maps/ad_brk/brick01.map": {
+     "bytes": 717,
+     "sha256": "3f87d06eb46f67efa678ddd5ddf274e9c595c4a5236d8f111d8a0ea999972e09"
+    },
+    "maps/ad_brk/brick02.bsp": {
+     "bytes": 8072,
+     "sha256": "9ec52c7441f570d2a793035ebc2128d7f7f91f71b44b4418fd01e6b3e6d503e2"
+    },
+    "maps/ad_brk/brick02.map": {
+     "bytes": 861,
+     "sha256": "616d1c5b6f3e476453e8b9b57dd59deb285c6c0482680ca5d6da358ee808c619"
+    },
+    "maps/ad_brk/brick03.bsp": {
+     "bytes": 8280,
+     "sha256": "aa55feca84b80282851ca55c71deb3d54f02a6668af820f5ac4f9c1a0514e5e1"
+    },
+    "maps/ad_brk/brick03.map": {
+     "bytes": 935,
+     "sha256": "4359e78daaac0b8d4ff58dc68301bba4cd423e81284bcd360ce1480862c19d91"
+    },
+    "maps/ad_brk/brick04.bsp": {
+     "bytes": 8052,
+     "sha256": "b1fa14c188a8ad31cf58c7ebd495fbe8ed153819015d4e97c82e01ee052081e3"
+    },
+    "maps/ad_brk/brick04.map": {
+     "bytes": 815,
+     "sha256": "2bda60cc50886dc430a053f509f2376dcd9bd4d09666cf7960a96484fa369903"
+    },
+    "maps/ad_brk/brick05.bsp": {
+     "bytes": 7952,
+     "sha256": "e137a3ea0f33a83b8717dcb9d6e2ab79876112121dc21fe2e625d24d5d251384"
+    },
+    "maps/ad_brk/brick05.map": {
+     "bytes": 770,
+     "sha256": "8ebf395096050f65a3a370971d65deb0926af70f6cbd75c6579a53b68f676793"
+    },
+    "maps/ad_brk/brick06.bsp": {
+     "bytes": 9184,
+     "sha256": "32cee0a2c668160e07568ae08b4de5beae87d74e94a347cd431c90005bf49e24"
+    },
+    "maps/ad_brk/brick06.map": {
+     "bytes": 1709,
+     "sha256": "289f58cad70a88e8a8d986644faf539dd38cf52a884aa7f85513db5df0cc438c"
+    },
+    "maps/ad_brk/brick07.bsp": {
+     "bytes": 10377,
+     "sha256": "df07446f9f6a118f11451de5d7817f582c11dcc81ca3f83c8fa72c9d95e8df9c"
+    },
+    "maps/ad_brk/brick07.map": {
+     "bytes": 1942,
+     "sha256": "fe440636e5354fb553708f3b6859023d0a520f315050dc11a564e31a7b72d5e4"
+    },
+    "maps/ad_brk/brick08.bsp": {
+     "bytes": 13964,
+     "sha256": "2abbbc958d752e742df9d1f7152c4cc8c0de6373f20e628a762e2a22f5d6b3f7"
+    },
+    "maps/ad_brk/brick08.map": {
+     "bytes": 3286,
+     "sha256": "72174f573416102bb4e087e2025b3dbdfc669ab7cafc8b354f7b1a4485af1f5b"
+    },
+    "maps/ad_brk/brick09.bsp": {
+     "bytes": 7952,
+     "sha256": "28d7162b4af3f4ce184a31a14e3a9777383f29b63920d9d62ff136ae96e3a2fd"
+    },
+    "maps/ad_brk/brick09.map": {
+     "bytes": 770,
+     "sha256": "62f11ef3e3033dea82eb6062e5b5301474dd014f889a980383891e689be2a352"
+    },
+    "maps/ad_brk/brick10.bsp": {
+     "bytes": 9184,
+     "sha256": "7d6f8e3fd1b65880bb767ab5d488ef11bbb01ec4ce14c7b747ee75b8a8238c4e"
+    },
+    "maps/ad_brk/brick10.map": {
+     "bytes": 1709,
+     "sha256": "276f975d99dfe982bf71104889f65a248d719778db89591e7193ecc46b13d645"
+    },
+    "maps/ad_brk/brick11.bsp": {
+     "bytes": 10377,
+     "sha256": "f65cbdb642220611e89725187f47427031c4b18c21cc04ae3f6cfb4dffd149a2"
+    },
+    "maps/ad_brk/brick11.map": {
+     "bytes": 1942,
+     "sha256": "3b9d73d400e29fba3c82d8b2ccdad26e03b128c7771427497d4740c2d34cd63d"
+    },
+    "maps/ad_brk/brick12.bsp": {
+     "bytes": 13918,
+     "sha256": "1e1e8191c5ebdd1f0fed27edaa04a82a6aabd5c41723cf590781ff00f7300a02"
+    },
+    "maps/ad_brk/brick12.map": {
+     "bytes": 3286,
+     "sha256": "d2b89c83f1ff95d6fe577cf4a166e7bec6e02ab85f48c51316908d7d80068156"
+    },
+    "maps/ad_brk/brick13.bsp": {
+     "bytes": 7912,
+     "sha256": "4b5ac4eb6ea5a9ec049c27082d800cb981902965a4b652f86e1753bfa1eb7c94"
+    },
+    "maps/ad_brk/brick13.map": {
+     "bytes": 690,
+     "sha256": "253425ec201a354cd1b4c93c78d740e2a17c7d946d911efffa63d522e95f9f0b"
+    },
+    "maps/ad_brk/brick14.bsp": {
+     "bytes": 8072,
+     "sha256": "afe8797d2172a5b4b06be3e2a69038346d62938f3d9da6ea224074cee5bb1669"
+    },
+    "maps/ad_brk/brick14.map": {
+     "bytes": 828,
+     "sha256": "a500705a328cafa28159ee107cbe80003848ee241c3544a73dea1432f67b4042"
+    },
+    "maps/ad_brk/brick15.bsp": {
+     "bytes": 8280,
+     "sha256": "58ddb31ce4108a70872444022369154529c532983dbc58698cd88f217f8947a0"
+    },
+    "maps/ad_brk/brick15.map": {
+     "bytes": 899,
+     "sha256": "589f256e02b66051ede4f2fe136e69313a7e01402f1caa43bada4d605a046b8e"
+    },
+    "maps/ad_brk/brick16.bsp": {
+     "bytes": 8052,
+     "sha256": "d5c15593d0d776d5f76919100602d893973cd59b7ca88af55e1ae3cc2fb56967"
+    },
+    "maps/ad_brk/brick16.map": {
+     "bytes": 785,
+     "sha256": "a15682c168f0a7128c83bf7bd38688ae1d2507873687e815c690b08d44f14a37"
+    },
+    "maps/ad_brk/brick17.bsp": {
+     "bytes": 7952,
+     "sha256": "738d902046d73e14b8a552529dd8306864661fd0469efb52b3c81329135e8372"
+    },
+    "maps/ad_brk/brick17.map": {
+     "bytes": 770,
+     "sha256": "699fa7055fa88f309fe4a4a2af24b5d61af91365d81074e44cbdf399d36939c9"
+    },
+    "maps/ad_brk/brick18.bsp": {
+     "bytes": 9184,
+     "sha256": "67ad693c292448f73ea0b3ab6ee22883709c7deb006cecd19c0dda5c9d4fa131"
+    },
+    "maps/ad_brk/brick18.map": {
+     "bytes": 1709,
+     "sha256": "849749000a41ecfc60aa4607c890e140bcd78ef26858512f56494efdc5873bcd"
+    },
+    "maps/ad_brk/brick19.bsp": {
+     "bytes": 10321,
+     "sha256": "721c3237db8c026a03e01e387bb95fe5ed8fbc49b3c527220f164d77a2f3a4f2"
+    },
+    "maps/ad_brk/brick19.map": {
+     "bytes": 1942,
+     "sha256": "1760c2c74d0b894814c89152062f2f55a8635a17559828c27532a7e913949af6"
+    },
+    "maps/ad_brk/brick20.bsp": {
+     "bytes": 13306,
+     "sha256": "bbecee9c1ac726743e6cc49d18246c650f762f577dc108ffed2a6807ff665052"
+    },
+    "maps/ad_brk/brick20.map": {
+     "bytes": 3286,
+     "sha256": "121d4fe62c07953f11a04a41577769a38cae8852af78bbd40fc44f598eee91d7"
+    },
+    "maps/ad_brk/brick21.bsp": {
+     "bytes": 7972,
+     "sha256": "e65c1df9d5f02efc9475a53d1127d7899f69d23d8a0ea20deab384fcd3351d29"
+    },
+    "maps/ad_brk/brick21.map": {
+     "bytes": 789,
+     "sha256": "8c12d093245c3937afcf62916fce9e6b2d181d72d433b879112b27e0f168ccc7"
+    },
+    "maps/ad_brk/brick22.bsp": {
+     "bytes": 9204,
+     "sha256": "b8efe5f130accf1e8704202dbaa44215259e1209b9b81bf79461ff5e5f725596"
+    },
+    "maps/ad_brk/brick22.map": {
+     "bytes": 1728,
+     "sha256": "403525bf264890c5d9adef370847749cbeec481337f284618810057e697cddde"
+    },
+    "maps/ad_brk/brick23.bsp": {
+     "bytes": 10340,
+     "sha256": "79bac69a44c7e83343bd69c2360176046e048257ecfb7ac27f3c989b42af92e9"
+    },
+    "maps/ad_brk/brick23.map": {
+     "bytes": 1961,
+     "sha256": "f25e7a514eb15637b7dedc41ec5c34e2d8b9e4dd3b584a41a1b1d7c166b362ef"
+    },
+    "maps/ad_brk/brick24.bsp": {
+     "bytes": 13312,
+     "sha256": "2e0728a16ebe0fa868d8bd0ffe0f54e013afac41c77ee7516f385d7a6718b07f"
+    },
+    "maps/ad_brk/brick24.map": {
+     "bytes": 3305,
+     "sha256": "481d21e7e07a312e894f71a8118035457164f17d48032bad54bdc62644e7e8a4"
+    },
+    "maps/ad_brk/brick25.bsp": {
+     "bytes": 7924,
+     "sha256": "8e33245bde92e94d9dddca1b61059fee1eb19aed0613945c1dffe3145fd51d78"
+    },
+    "maps/ad_brk/brick25.map": {
+     "bytes": 715,
+     "sha256": "cf6042585a2347f8ae4de546e2fa9aa905aa7ee4d9607a12dfd778d0084ba9d1"
+    },
+    "maps/ad_brk/brick26.bsp": {
+     "bytes": 8084,
+     "sha256": "4ddb5d2ca4adbc32f905a0340b26a174c25af7f6de5ad9408c4e0f4ca2816a55"
+    },
+    "maps/ad_brk/brick26.map": {
+     "bytes": 855,
+     "sha256": "baaf133d5c5c90b295855bb03a0a30340db324ddc82ed119a9d025e8ddb22724"
+    },
+    "maps/ad_brk/brick27.bsp": {
+     "bytes": 8296,
+     "sha256": "9084778144864d4167d270dd825e99d18d7ea7fc2dfb799f7e0eb12f1d236688"
+    },
+    "maps/ad_brk/brick27.map": {
+     "bytes": 927,
+     "sha256": "4e3b59df2a5b8efe85460f114baa795c36c8b410407e0752a69efc525d49e9b0"
+    },
+    "maps/ad_brk/brick28.bsp": {
+     "bytes": 8068,
+     "sha256": "42b4fe7f99032b3292996bcfe8b72e1c5e3b637357e376f8502a202a3816bcf0"
+    },
+    "maps/ad_brk/brick28.map": {
+     "bytes": 811,
+     "sha256": "c088828bbe9cdca1bb55ea4ceca9f46e03217f1643189a93d70a83eeb11f72bc"
+    },
+    "maps/ad_brk/brick29.bsp": {
+     "bytes": 24232,
+     "sha256": "463ff6bed92dfab082f13876187c506572dd3d18727e13fb708e24afd02aa7ef"
+    },
+    "maps/ad_brk/brick29.map": {
+     "bytes": 711,
+     "sha256": "1a4ff9d041df15cfd229666a9b32c24a96577ef6f249f33d89dc88cdfbe5540a"
+    },
+    "maps/ad_brk/brick30.bsp": {
+     "bytes": 24392,
+     "sha256": "a82a0d709c367d8ecf359142d99d0ad09d97b674ef1575beeb78dbbe93025c59"
+    },
+    "maps/ad_brk/brick30.map": {
+     "bytes": 853,
+     "sha256": "803c896037b5cc971e932219b5f06e363724a25de693ef6800d1332c6df4f8d1"
+    },
+    "maps/ad_brk/brick31.bsp": {
+     "bytes": 24604,
+     "sha256": "deb8a0278e043c6510e7f7d17ec708bdc7f37fa884f869ccbfc9ef9a95b6a8ac"
+    },
+    "maps/ad_brk/brick31.map": {
+     "bytes": 926,
+     "sha256": "9a3502125d9a995f10052ed6a9971bfe148a4e8fd7561a082e8bbecff5b39d56"
+    },
+    "maps/ad_brk/brick32.bsp": {
+     "bytes": 24376,
+     "sha256": "c8961b003f231b13a74bc247ce13ada38850707d443aa98dbad98b9f2ecf276b"
+    },
+    "maps/ad_brk/brick32.map": {
+     "bytes": 808,
+     "sha256": "aa96dda4508d2e98b5827ac42d8230f11969457f63022bf488dac06d2783910e"
+    },
+    "maps/ad_brk/glass01.bsp": {
+     "bytes": 8095,
+     "sha256": "d5d9b8df7fc4db671e180fbc60253ea809b61819bd77a9072d1cf1b1c9c11888"
+    },
+    "maps/ad_brk/glass01.map": {
+     "bytes": 961,
+     "sha256": "04b6721fc35e7a43fa921075bc2184bbbb2791570ea781ee6351b0cf01936456"
+    },
+    "maps/ad_brk/glass02.bsp": {
+     "bytes": 7035,
+     "sha256": "b2e6ba1e674f6a93e01ada15700b98624eae9c242a30eba9ea032d2e7d9fc555"
+    },
+    "maps/ad_brk/glass02.map": {
+     "bytes": 447,
+     "sha256": "6bf3cce568e830dd03830bb2e7225329490dae01e33806eec6a594313a8daa9e"
+    },
+    "maps/ad_brk/glass03.bsp": {
+     "bytes": 7922,
+     "sha256": "02661d1e724d41c02c977f8b869a23e6fc883303b66298c98ebddf752f365a1b"
+    },
+    "maps/ad_brk/glass03.map": {
+     "bytes": 963,
+     "sha256": "cb5245e54bc27d999bd643370557f8e766ae94e10358993951084e6ca87d087c"
+    },
+    "maps/ad_brk/glass04.bsp": {
+     "bytes": 7223,
+     "sha256": "a41bddb2d6a0ef53b96097a6e4d9731bf100b695a7a1c11091f054f746c7bf2a"
+    },
+    "maps/ad_brk/glass04.map": {
+     "bytes": 512,
+     "sha256": "f8e9f41266f3cd0017c19f7d3a29e0c738b497fb539cec2583c4eda6d509965c"
+    },
+    "maps/ad_brk/glass05.bsp": {
+     "bytes": 24436,
+     "sha256": "10fd2ef7f24bda233c3b4433e4ed64b8feb7273f09c0da5d93190ced61f20779"
+    },
+    "maps/ad_brk/glass05.map": {
+     "bytes": 999,
+     "sha256": "c8e2039929909b608ac0ddf36562443caf7052a15e8b0e39a73e0869c15930c1"
+    },
+    "maps/ad_brk/glass06.bsp": {
+     "bytes": 24300,
+     "sha256": "60f08ebc3d967dbe1b6062a59679a3e89e199a305f51bb9bc7dbada44c66fe5e"
+    },
+    "maps/ad_brk/glass06.map": {
+     "bytes": 976,
+     "sha256": "73346b8cc46166371a6e7f220ebe78f2cde29f29d8d705e1e4b0c60e153b52df"
+    },
+    "maps/ad_brk/glass07.bsp": {
+     "bytes": 23365,
+     "sha256": "ccebafe1a97953e91b64694783a1989c8e8ba440fd3c136b09785131b54c75cf"
+    },
+    "maps/ad_brk/glass07.map": {
+     "bytes": 458,
+     "sha256": "6d79a332d308ed3746c8f2fd13227b44a1cc66f0b2fd471eb6de1cbf695d81c9"
+    },
+    "maps/ad_brk/glass08.bsp": {
+     "bytes": 23602,
+     "sha256": "82c1bfe3d83c87c908d6dac76a255843cbbaededeaf644eeec5b9b9a794e0bdf"
+    },
+    "maps/ad_brk/glass08.map": {
+     "bytes": 530,
+     "sha256": "65dba1b71881c49b29d288720f43c457c838b93aa9e522953bac885443944c04"
+    },
+    "maps/ad_brk/glass09.bsp": {
+     "bytes": 24436,
+     "sha256": "34e317a5652fcc4a3aaf517ebc178c8d8fad6738b536a6c06eff2800bf7fefba"
+    },
+    "maps/ad_brk/glass09.map": {
+     "bytes": 999,
+     "sha256": "ca9b91b38fa600b7dfa80e9a257dc15f2f2dda9e1d2c1d002ea90cbdcc0e0279"
+    },
+    "maps/ad_brk/glass10.bsp": {
+     "bytes": 24300,
+     "sha256": "6e06c140e0916cd35235bd7e6970ca3250c6c36a2ee6d4632d805da67215818a"
+    },
+    "maps/ad_brk/glass10.map": {
+     "bytes": 976,
+     "sha256": "2043f7646edcfa088a76b6104b136ff9ca0f90bffe6efb955f951a4bfe16643d"
+    },
+    "maps/ad_brk/glass11.bsp": {
+     "bytes": 23365,
+     "sha256": "caae0c47ae097f4cb1055a3f5eecd5d407b71c975b35d992f3048993b1ac7e97"
+    },
+    "maps/ad_brk/glass11.map": {
+     "bytes": 458,
+     "sha256": "5bea1bbcee409674f58a1fd26cf0c983e11f8ffd5f20c829f5c3df6a4c28b1c9"
+    },
+    "maps/ad_brk/glass12.bsp": {
+     "bytes": 23602,
+     "sha256": "526018b31a9b02b1c9e1b5123b2c936677d6fd7b6c014ea14dfe4905271e419f"
+    },
+    "maps/ad_brk/glass12.map": {
+     "bytes": 530,
+     "sha256": "499ed4ce1a1ebbd9347a2a4dc6413f2f79d203bbce293a79a5b2bde49ade0a3f"
+    },
+    "maps/ad_brk/glass13.bsp": {
+     "bytes": 24108,
+     "sha256": "fdb97447ffe9e4769f35a3e1e7bd9d6b0e2e6b555d60102991bf57f06e8b3d83"
+    },
+    "maps/ad_brk/glass13.map": {
+     "bytes": 979,
+     "sha256": "073661c415a2568c45a90cc9baa471cde9a02a975d4d4fd7596bb96d272d3934"
+    },
+    "maps/ad_brk/glass14.bsp": {
+     "bytes": 23296,
+     "sha256": "e3517bb79e2561150c4641ab3650e0697adcaa2f281c5209cacdc12d9c4023a7"
+    },
+    "maps/ad_brk/glass14.map": {
+     "bytes": 462,
+     "sha256": "066d5bade73c399cf10a9dcafecec9d65ac3c6045644988cbefb104fb8e7d8c3"
+    },
+    "maps/ad_brk/glass15.bsp": {
+     "bytes": 23892,
+     "sha256": "6abc82aca32e6c8312884db42891753c8d2ad8e1d4ae9218022604eadb08708b"
+    },
+    "maps/ad_brk/glass15.map": {
+     "bytes": 993,
+     "sha256": "5c24e1763bd26d34539bc7ee527842810e4ddb6ac80f683a7b3b35ee326360d3"
+    },
+    "maps/ad_brk/glass16.bsp": {
+     "bytes": 23532,
+     "sha256": "13725c14b226297090c4f1e9949c476f601a52247bc8f6abb937a57b964462c6"
+    },
+    "maps/ad_brk/glass16.map": {
+     "bytes": 528,
+     "sha256": "03dbc7feb833831d413e7f87ed0e79625da0800659ab65ea8d3deb63de09a27d"
+    },
+    "maps/ad_brk/kn_mtrim2_1.bsp": {
+     "bytes": 25264,
+     "sha256": "99b67eeed7ece0f46b1d7b4b2309331e655eb9c1b412d3ac4bc362acb4dd8606"
+    },
+    "maps/ad_brk/kn_mtrim2_1.map": {
+     "bytes": 1455,
+     "sha256": "51018fd4ff6d00c9c2c449e32a83b8521fdc3babb2937adf6800d8e67e38b976"
+    },
+    "maps/ad_brk/kn_mtrim2_2.bsp": {
+     "bytes": 24460,
+     "sha256": "a98bdee68b3a222af0f44fc978d09e092a08953539929a6a53f1bf0e97568e74"
+    },
+    "maps/ad_brk/kn_mtrim2_2.map": {
+     "bytes": 1103,
+     "sha256": "2880a3f7becf48ae79c27ef9a05faa5c774df20a53ec5d892304bf67bc06cbbe"
+    },
+    "maps/ad_brk/kn_mtrim2_3.bsp": {
+     "bytes": 24632,
+     "sha256": "967e89f57bc011cd3b38d60d45272633cc0f773c91045b7938766ac0436ae803"
+    },
+    "maps/ad_brk/kn_mtrim2_3.map": {
+     "bytes": 1171,
+     "sha256": "40ef38fd45c3e9c750d311bb8920b938fcd9f647f2dabc58509b327514f44907"
+    },
+    "maps/ad_brk/kn_mtrim2_4.bsp": {
+     "bytes": 24452,
+     "sha256": "e4559e1e5a3118f2c949daccb96f887d64821511f5850cfa72133f84a8e04901"
+    },
+    "maps/ad_brk/kn_mtrim2_4.map": {
+     "bytes": 1036,
+     "sha256": "595513bc0fe2441cb6aa88af41d9afd7de8b94421ac6c32c546113f83be6577c"
+    },
+    "maps/ad_brk/metal01.bsp": {
+     "bytes": 8122,
+     "sha256": "11e8e340455c487150951fb4dccaf7da72d0243892948d5c22b478221ffcca23"
+    },
+    "maps/ad_brk/metal01.map": {
+     "bytes": 780,
+     "sha256": "902c31c661df8bbc1b0c410b6a8745f680e85cf91bbdb14d85244b6937be5239"
+    },
+    "maps/ad_brk/metal02.bsp": {
+     "bytes": 10022,
+     "sha256": "59b56266e73b4246c54d8cd9c4769d7345c53ae5133c45d1db94f5c771350d94"
+    },
+    "maps/ad_brk/metal02.map": {
+     "bytes": 1414,
+     "sha256": "171bfe727b6c80a4c0350fb4c87090d30c3fb1a21962b8fc9c638c47027e1fea"
+    },
+    "maps/ad_brk/metal03.bsp": {
+     "bytes": 9386,
+     "sha256": "13e3ea83c5bdbf81075328cc14543d1ab6301378cc9af56b59b67b1cc22e3a53"
+    },
+    "maps/ad_brk/metal03.map": {
+     "bytes": 1179,
+     "sha256": "89ac4002203958a9f971601586f4e4e6bdcaab7cbde62ca7fb58cf705fbdae56"
+    },
+    "maps/ad_brk/metal04.bsp": {
+     "bytes": 10655,
+     "sha256": "785ab6aed41e60072083aeee571d76796f60ec5e24d249736575007d558c10ae"
+    },
+    "maps/ad_brk/metal04.map": {
+     "bytes": 1599,
+     "sha256": "aecd2de4ce9cdb49922c58f640f3df4c48b8dc45f5e611f5d0c75a6a96bf705e"
+    },
+    "maps/ad_brk/metal05.bsp": {
+     "bytes": 8337,
+     "sha256": "82da98a887a0101d1a638d266db3c9913090b3fcaca6af5869e7063529b3066e"
+    },
+    "maps/ad_brk/metal05.map": {
+     "bytes": 905,
+     "sha256": "541a5d633be51d32bbd6580cf3fb4fcc7e9b3c38107eaffdd88896a01d249b71"
+    },
+    "maps/ad_brk/metal06.bsp": {
+     "bytes": 7898,
+     "sha256": "3fe3f66ff336ede9d9a6f4fc0f7df16b62504b25a8dea1c8adce2113e927428e"
+    },
+    "maps/ad_brk/metal06.map": {
+     "bytes": 697,
+     "sha256": "30bfd29315a3c0d8654aa1842b7f2a2a7bcdc7a5a81ff96f359a86d57a289ce9"
+    },
+    "maps/ad_brk/metal07.bsp": {
+     "bytes": 8439,
+     "sha256": "8f8a722ae0d3350bf4331fbd4a492dd4c18b3c44006289fd7c6d393282f280a1"
+    },
+    "maps/ad_brk/metal07.map": {
+     "bytes": 1508,
+     "sha256": "f2c7442255c68ae30186692cdf49bca0f1e5769587d5d2392baf3ec4708679b2"
+    },
+    "maps/ad_brk/metal08.bsp": {
+     "bytes": 8150,
+     "sha256": "028675fecfd419e8852cabe821fac1941c914bdf43110291d7a07509e77f4d26"
+    },
+    "maps/ad_brk/metal08.map": {
+     "bytes": 847,
+     "sha256": "797217e143857e0b27e1654449a5dbdc0b1a3dc46c8cafdea5ee9c5ac0cbf16c"
+    },
+    "maps/ad_brk/metal09.bsp": {
+     "bytes": 7456,
+     "sha256": "4d6fb8a19ce5a331ceb68fcfa952fa61ed3ad336002eedd788921b0daa2a7877"
+    },
+    "maps/ad_brk/metal09.map": {
+     "bytes": 649,
+     "sha256": "1fde976a2f1372d9d55350caa3285776eee897d9786f9118d5a6988010efaeca"
+    },
+    "maps/ad_brk/metal10.bsp": {
+     "bytes": 7785,
+     "sha256": "c25084ae2f159ba73e6c43041a2e050d30af70a862a9c4846b2241848a33b55f"
+    },
+    "maps/ad_brk/metal10.map": {
+     "bytes": 709,
+     "sha256": "856390903976512f1b5372f374b5c7444238a173abbedbbfeccbb675cf93ed66"
+    },
+    "maps/ad_brk/metal11.bsp": {
+     "bytes": 7918,
+     "sha256": "e939c6c80e11479887b68bb39a97e0b877514c4e9dc9b2a4a9e18303caa317f1"
+    },
+    "maps/ad_brk/metal11.map": {
+     "bytes": 797,
+     "sha256": "74528d15a51708fdca65c900096411f1d56d6472a5058458577ac04d820e9895"
+    },
+    "maps/ad_brk/metal12.bsp": {
+     "bytes": 8226,
+     "sha256": "3ceccd7aa24fc353e0ac3ccb15531c2f243c0ed246c73c44bdd8897dbdd6537e"
+    },
+    "maps/ad_brk/metal12.map": {
+     "bytes": 872,
+     "sha256": "a95f34c46729c7849e6d45d9cdf57bb49289561b6551bd2e4a39659c272343fd"
+    },
+    "maps/ad_brk/metal13.bsp": {
+     "bytes": 8121,
+     "sha256": "e02aa4c824f5d8fcdfe302a0a194cee6fcf44e2fee844c492f434bf2b7763209"
+    },
+    "maps/ad_brk/metal13.map": {
+     "bytes": 760,
+     "sha256": "bae8879296237bea635d054428a536c0297420ff3ff61f681d569b30a984e7d0"
+    },
+    "maps/ad_brk/metal14.bsp": {
+     "bytes": 10022,
+     "sha256": "4b66b133fe892c6ae6ead0c6726638e98637d71a3a9afdc4ac0546be0f2d0292"
+    },
+    "maps/ad_brk/metal14.map": {
+     "bytes": 1376,
+     "sha256": "197bd6c01b5ffc4c9e0f27e319b25b882af4f20db36612f41b006dd6db0833e1"
+    },
+    "maps/ad_brk/metal15.bsp": {
+     "bytes": 9386,
+     "sha256": "8cf7545aa3464814908c3987f51e9693f154f690ec526ed228b37b1590730e0b"
+    },
+    "maps/ad_brk/metal15.map": {
+     "bytes": 1147,
+     "sha256": "73aef82251f5b4a9548135aedb926aad6b7cff94cb3656fc8216a594a8a9f6dc"
+    },
+    "maps/ad_brk/metal16.bsp": {
+     "bytes": 10719,
+     "sha256": "af64c13135b1e1eb6d8e09607c34d6cec57a3cbf624dd76b136b505f097ecf65"
+    },
+    "maps/ad_brk/metal16.map": {
+     "bytes": 1555,
+     "sha256": "d7220fbbb33a630d03ed2514b9ee33a9d3a424f819b4977e093863ca8568b645"
+    },
+    "maps/ad_brk/metal17.bsp": {
+     "bytes": 8347,
+     "sha256": "0d21cbf9b5bc65391e00bad35368530d3d4b5f59993e2ac7d45a7edc9a2edf73"
+    },
+    "maps/ad_brk/metal17.map": {
+     "bytes": 911,
+     "sha256": "7be91013d0e57e41aff314398634043cebf8f250691b3ebc583bf373df400c2c"
+    },
+    "maps/ad_brk/metal18.bsp": {
+     "bytes": 7907,
+     "sha256": "ef0dee9c63d7bbced8c04ea40523d47fd99638905aa20a61779820b5aebd5aab"
+    },
+    "maps/ad_brk/metal18.map": {
+     "bytes": 703,
+     "sha256": "b610432a51ac6b57f19fee9df89fc7b80d5cbffa972e539d9c5f3aded3359434"
+    },
+    "maps/ad_brk/metal19.bsp": {
+     "bytes": 8450,
+     "sha256": "2796007e11c0a1b2a3430edc4e0f7edb0e721a6d906e783233c0feb54b0482e5"
+    },
+    "maps/ad_brk/metal19.map": {
+     "bytes": 1514,
+     "sha256": "9ed741344b3c651f3b8fbda1d8ee8e779bd12315feea397e938522c9750dc214"
+    },
+    "maps/ad_brk/metal20.bsp": {
+     "bytes": 8160,
+     "sha256": "38013cdb360356827ab6c296791434c537183d082feed6944665a882e622ed84"
+    },
+    "maps/ad_brk/metal20.map": {
+     "bytes": 853,
+     "sha256": "a3b28328bb043206bc048e82dba12d91c56c464b5e4e1452c6740f0df44223bf"
+    },
+    "maps/ad_brk/rock01.bsp": {
+     "bytes": 24238,
+     "sha256": "5f2c0a6ce3c58eed53c86789ff1685551cff53ca1f239bf75e3a9bc59aa95a56"
+    },
+    "maps/ad_brk/rock01.map": {
+     "bytes": 680,
+     "sha256": "db0b6a72833e12a35f518b32920fccf4fbc45120e7ab8ca3afc6e255b5d51334"
+    },
+    "maps/ad_brk/rock02.bsp": {
+     "bytes": 24250,
+     "sha256": "c6196e82e7b3e22cb687e2d6c0780f163929b5ea42b868eedcaadd40f35927f9"
+    },
+    "maps/ad_brk/rock02.map": {
+     "bytes": 760,
+     "sha256": "49531f0a1a38e03e3b46af53cfc35845878fcc171c2579f0f13d2a000ca82829"
+    },
+    "maps/ad_brk/rock03.bsp": {
+     "bytes": 24669,
+     "sha256": "9f7ab133399a3681f0b97276c7cb9883b479995c3420e5643eaedd11c88f0a0d"
+    },
+    "maps/ad_brk/rock03.map": {
+     "bytes": 929,
+     "sha256": "4158321d447c3b323f44389661ba6c763b23e26fb9541a786c3b544ad56321d9"
+    },
+    "maps/ad_brk/rock04.bsp": {
+     "bytes": 24600,
+     "sha256": "3c8b114e8ff86b8abcba235230445d885d4c28553d83e153676b2755b0300292"
+    },
+    "maps/ad_brk/rock04.map": {
+     "bytes": 878,
+     "sha256": "229d94f5f5bd81a83be5463035d30c8838d1de092923c3281e7a3a9ec4c7e9aa"
+    },
+    "maps/ad_brk/rock05.bsp": {
+     "bytes": 24254,
+     "sha256": "6bdc990b90f24ddd77034a4cbdd4d7158e05df70e6db5e793ca990a40cd29709"
+    },
+    "maps/ad_brk/rock05.map": {
+     "bytes": 684,
+     "sha256": "708a6ad98116a72ddc862c6c99cbd59342446636c9579a00bd6c34efa1ac855b"
+    },
+    "maps/ad_brk/rock06.bsp": {
+     "bytes": 24462,
+     "sha256": "e2e3688c3cb66e2c9d738d211ad328d86963e1d67881354363696698a07be32b"
+    },
+    "maps/ad_brk/rock06.map": {
+     "bytes": 816,
+     "sha256": "5e1a399ac2e6a179a84004539f15172012db93477e5544309b01ed24cbc59f34"
+    },
+    "maps/ad_brk/rock07.bsp": {
+     "bytes": 24281,
+     "sha256": "ea3569e42b755fd1b9fde50e2740f6aa95d1dabb1911f8a4ab5b1c5028a4e1e3"
+    },
+    "maps/ad_brk/rock07.map": {
+     "bytes": 777,
+     "sha256": "02f61c60083f5007fa9d4d7a38adf2901e928a96adbfeaa7646711f21cc75409"
+    },
+    "maps/ad_brk/rock08.bsp": {
+     "bytes": 25096,
+     "sha256": "5468a365153fc7f160d7e1792b9bc9164b828a51851bd1e9744eb0cf3a7a842d"
+    },
+    "maps/ad_brk/rock08.map": {
+     "bytes": 1060,
+     "sha256": "b285f3a79407366944213b3d8eef311c662bf2eb0cf3df0ee3104e747a3c9150"
+    },
+    "maps/ad_brk/rock09.bsp": {
+     "bytes": 8314,
+     "sha256": "4320c73f55d67e4db7e596614b74b05b0c086cd57186ecaf183c96fca51106bf"
+    },
+    "maps/ad_brk/rock09.map": {
+     "bytes": 913,
+     "sha256": "629fab0d0f8022138ff5d5e573f0e3ab0f75397f120015b3f8a95a297c857911"
+    },
+    "maps/ad_brk/rock10.bsp": {
+     "bytes": 7930,
+     "sha256": "7657ad82fbdeaceb354e04f60fa76cfd3d8a7a819607a413afaa6fc16253a009"
+    },
+    "maps/ad_brk/rock10.map": {
+     "bytes": 780,
+     "sha256": "833bc2f2460f5f5ef444630b398a59974831031e408f986125a5241fab52ba99"
+    },
+    "maps/ad_brk/rock11.bsp": {
+     "bytes": 8565,
+     "sha256": "e19573b67e5dedba499da8f6d0d63ca0e829593417a1ce66e1aeb1fd2b2d1e76"
+    },
+    "maps/ad_brk/rock11.map": {
+     "bytes": 1016,
+     "sha256": "040c31d22159743b28e9f20946b34db390ef15bbe530882342638b9325542801"
+    },
+    "maps/ad_brk/rock12.bsp": {
+     "bytes": 8284,
+     "sha256": "f03a3a0184b2fa8809154754f85d81d30777261714976bdd64340b0549d3ca35"
+    },
+    "maps/ad_brk/rock12.map": {
+     "bytes": 898,
+     "sha256": "b7d2b1bba22ad5b621e699a8233a83d23415e5c6e88fec8e1525a9c84a494bf0"
+    },
+    "maps/ad_brk/rock13.bsp": {
+     "bytes": 7917,
+     "sha256": "6710c24df905df9ede31faf75fdf9a070efbdc471e58a295740092863dcb50fa"
+    },
+    "maps/ad_brk/rock13.map": {
+     "bytes": 680,
+     "sha256": "369735b7ebd630e6407371d3ab7195ef368c2f8d8d3469943b2c5e46b8e24fa5"
+    },
+    "maps/ad_brk/rock14.bsp": {
+     "bytes": 7929,
+     "sha256": "a17329c593e306d1aa4084cd2651983f53258b3e5759443efe3bb3b4daecc5f8"
+    },
+    "maps/ad_brk/rock14.map": {
+     "bytes": 760,
+     "sha256": "f86556e799f3a0240294537aa487526c674486afb7190bb705d72453cade7e68"
+    },
+    "maps/ad_brk/rock15.bsp": {
+     "bytes": 8349,
+     "sha256": "d64f11606da6b94024382315eead25dbfe19c8cc90844f60e755e2bd106c7fc0"
+    },
+    "maps/ad_brk/rock15.map": {
+     "bytes": 929,
+     "sha256": "23defe1bddcc8db664c819b60657fd536b1c44b118299495d42f7c54f740e7b0"
+    },
+    "maps/ad_brk/rock16.bsp": {
+     "bytes": 8280,
+     "sha256": "87e60c650a672c5ffe57b64c7ae3c5413799972a2ca5b73935cb0d1dad16f62c"
+    },
+    "maps/ad_brk/rock16.map": {
+     "bytes": 878,
+     "sha256": "d3616ad7b423be757f6f7873791f4c452a09243b53569347bd36e87f1a942947"
+    },
+    "maps/ad_brk/rock17.bsp": {
+     "bytes": 8340,
+     "sha256": "b317f3432532e6f6f327852fa0c7f546726c8b23c44cfc3e86869d64eb33235c"
+    },
+    "maps/ad_brk/rock17.map": {
+     "bytes": 913,
+     "sha256": "a534b032b611965c86cd81fda18d53186c474d55184f9c4c74cd292b4b207f27"
+    },
+    "maps/ad_brk/rock18.bsp": {
+     "bytes": 7924,
+     "sha256": "e5fc24e393828bdd2c24e3cb341e0c21e81511881e65424293206fe20ff54c4e"
+    },
+    "maps/ad_brk/rock18.map": {
+     "bytes": 701,
+     "sha256": "bf5974bf04067482dde83a2fd73e58a011de04220b32866fa7913e901a0e944c"
+    },
+    "maps/ad_brk/rock19.bsp": {
+     "bytes": 8620,
+     "sha256": "4a1d3e4e37f29438981f419f5a5f076fcf53227a4da544e919061d6c6bf8702e"
+    },
+    "maps/ad_brk/rock19.map": {
+     "bytes": 919,
+     "sha256": "c2626204acbd33e3299c29cd1f8a5279bbe8cd07a621f6b40b14b74b7808f444"
+    },
+    "maps/ad_brk/rock20.bsp": {
+     "bytes": 8785,
+     "sha256": "87bfda54a9f0711eedcefc6d8e691b6cac8123958db03735bd0364067445de69"
+    },
+    "maps/ad_brk/rock20.map": {
+     "bytes": 1118,
+     "sha256": "225800378c3183d5ba423140d7f5d510cf387df3df795fda69294fcb0e4bec4c"
+    },
+    "maps/ad_brk/rock21.bsp": {
+     "bytes": 24244,
+     "sha256": "161b5893f3f413969ced051a7e7aa3d816a1da9f74bffa5d0642830713d83031"
+    },
+    "maps/ad_brk/rock21.map": {
+     "bytes": 674,
+     "sha256": "db86b019086636ec085b3690bc4b252d8bac2443c0ff138a6f3b6c79e522a94b"
+    },
+    "maps/ad_brk/rock22.bsp": {
+     "bytes": 24256,
+     "sha256": "b41069e88c74ef3bfb7c5f2817c31d9d374cd1725b7270b9ac7d93c58dd34a11"
+    },
+    "maps/ad_brk/rock22.map": {
+     "bytes": 753,
+     "sha256": "aa059dd13499512fdda512b68e79068f390d1870726763958a81a54c91aeb254"
+    },
+    "maps/ad_brk/rock23.bsp": {
+     "bytes": 24676,
+     "sha256": "aac7fc5557dd385c52043d206d39d83b48e0b2f6db2822de2060f2a978be4a9d"
+    },
+    "maps/ad_brk/rock23.map": {
+     "bytes": 920,
+     "sha256": "744ccf1456c3b19318289586238b1d36e4968dbfe444f5a489e1d2202f1965d4"
+    },
+    "maps/ad_brk/rock24.bsp": {
+     "bytes": 24612,
+     "sha256": "90553422561893d50030520bcf796da9290933e53570e313d1a423aec01c8ac6"
+    },
+    "maps/ad_brk/rock24.map": {
+     "bytes": 939,
+     "sha256": "3f8f5c2053315577eda81360a9ed9a095e96f7d9a6288eed876400a91bc0922b"
+    },
+    "maps/ad_brk/rock25.bsp": {
+     "bytes": 89516,
+     "sha256": "ef87b49e322fd2a2251f0ee7ecedec32bae141ea7a589769c6fba6a3176da0d4"
+    },
+    "maps/ad_brk/rock25.map": {
+     "bytes": 737,
+     "sha256": "3cad88a720acc4d7db1666ab0d865e013717776a256c999e1b417690679f4f0b"
+    },
+    "maps/ad_brk/rock26.bsp": {
+     "bytes": 89532,
+     "sha256": "a6f46aa8183937dfe19eb1cfde621bac8f3f08721effcbbd195ba251b3b1467f"
+    },
+    "maps/ad_brk/rock26.map": {
+     "bytes": 823,
+     "sha256": "27c411424182d3e6d611f2eff2dd9a7c75ef2135f2019d4aca40b2dee2d134b5"
+    },
+    "maps/ad_brk/rock27.bsp": {
+     "bytes": 89952,
+     "sha256": "f55dc66117c856efee1dae5e311492f2aae2839ef4588af45ac0818307ad564c"
+    },
+    "maps/ad_brk/rock27.map": {
+     "bytes": 1004,
+     "sha256": "7368f6cbd051aa3ac71237b5c8d3da2ef73fc3017024ef42af6ac8af9ddc1139"
+    },
+    "maps/ad_brk/rock28.bsp": {
+     "bytes": 89880,
+     "sha256": "2132d7f311c90f8c43b4630a55f7fa0b15141fa0e9c26c0309c8023437377961"
+    },
+    "maps/ad_brk/rock28.map": {
+     "bytes": 947,
+     "sha256": "b1571df2e370ca2d51f19b3608726552f10a6f6da64f69929a2ea2c1884e51dc"
+    },
+    "maps/ad_brk/rock29.bsp": {
+     "bytes": 89516,
+     "sha256": "a179ac329768d445bfbc36bb9c3e47ce3c7506c31337730a93c9a58f96ea5399"
+    },
+    "maps/ad_brk/rock29.map": {
+     "bytes": 737,
+     "sha256": "260d08f376c81869c1f9a0c0cfd677bded9022f79bbe4e607d12128b7ad7c746"
+    },
+    "maps/ad_brk/rock30.bsp": {
+     "bytes": 89532,
+     "sha256": "febc6ed2ec191f8dcbae1ee9df9d13bbd8fff830e28e051236fa24fd211829ee"
+    },
+    "maps/ad_brk/rock30.map": {
+     "bytes": 823,
+     "sha256": "da6a3224e060f6413f70ac9f6f25bf96f3784f690084d602d63805dc8b43e7e8"
+    },
+    "maps/ad_brk/rock31.bsp": {
+     "bytes": 89952,
+     "sha256": "7a38ed8a7dd80c2f2dab17342bfdde51300c9225f4e93be78ca9b63d3a7f1e99"
+    },
+    "maps/ad_brk/rock31.map": {
+     "bytes": 1004,
+     "sha256": "3fb04740e6da6c00670536ccbcb92e7a9a5b5e3072e78af96d6dd5c79d39f984"
+    },
+    "maps/ad_brk/rock32.bsp": {
+     "bytes": 89880,
+     "sha256": "41789fbb095ef6d7b09ba6f50bea0503f73e612808f37bbb71f4a7e9fea00ae2"
+    },
+    "maps/ad_brk/rock32.map": {
+     "bytes": 947,
+     "sha256": "37e272ad3f235bb182666e46d3b087bee4ec23ebdc716647c5b0ffb671a9ee1d"
+    },
+    "maps/ad_brk/rock33.bsp": {
+     "bytes": 7916,
+     "sha256": "af3e313ba1c7013b7bd2234e9988a2b6bc451d123e7d6dab1692ae0727d40bec"
+    },
+    "maps/ad_brk/rock33.map": {
+     "bytes": 683,
+     "sha256": "de08059147e865be402e6dac4c6d8a0bea1de05bb65cf0455153386afdde2bdb"
+    },
+    "maps/ad_brk/rock34.bsp": {
+     "bytes": 7932,
+     "sha256": "392125c9afaf18c3084c1b13a0a55dcda7e2294da37f84fb73983826271dea27"
+    },
+    "maps/ad_brk/rock34.map": {
+     "bytes": 763,
+     "sha256": "dc402e2573ee3e94f3ed96274d5b6f8d0177d9745716ea96d0ffce8e0be5c943"
+    },
+    "maps/ad_brk/rock35.bsp": {
+     "bytes": 8352,
+     "sha256": "0352c35aa723330a3c05126d24a8e6b84403bf8b71d406f3fa5a2ff3fc0da39a"
+    },
+    "maps/ad_brk/rock35.map": {
+     "bytes": 932,
+     "sha256": "9841ed50187bbdfb3a7122d3b0890b0245d64dd4919485686fdf5ce61bdae3e6"
+    },
+    "maps/ad_brk/rock36.bsp": {
+     "bytes": 8280,
+     "sha256": "f1871698ef7597c51fed5d54b582df2ea70cf72e2fa7db643182e59f7e7f6ca7"
+    },
+    "maps/ad_brk/rock36.map": {
+     "bytes": 881,
+     "sha256": "974aaec9003dd3e1457582b1f770d67e07fc8e9d11a6b639981fbb753c6a6484"
+    },
+    "maps/ad_brk/sandstone01.bsp": {
+     "bytes": 24239,
+     "sha256": "ebb374110d88805e1b0b45cdaf33e5e570a9092da549facaf9f5ddcd995eb607"
+    },
+    "maps/ad_brk/sandstone01.map": {
+     "bytes": 702,
+     "sha256": "9ea9ab63b8c6a2d90fba029c4d4b768beb0d4342cf255bb5005185b61b1bcfd2"
+    },
+    "maps/ad_brk/sandstone02.bsp": {
+     "bytes": 24399,
+     "sha256": "2fa799b0a08ca2fdd9bef3ecb9d6ea4c16e8f66181d29913cdc5a9205bafe98f"
+    },
+    "maps/ad_brk/sandstone02.map": {
+     "bytes": 842,
+     "sha256": "5228b0a958ef571f33838366ef1f2b69a10f6e0c53a3269dba683b5326a95e5f"
+    },
+    "maps/ad_brk/sandstone03.bsp": {
+     "bytes": 24607,
+     "sha256": "671b8f740ba9deaeac681c703f87d61c2a3f8107d0f72b8fd636c53436555110"
+    },
+    "maps/ad_brk/sandstone03.map": {
+     "bytes": 914,
+     "sha256": "7523ff7908eb3e47154155d0448fa05d4d9b6081525069a131e7d44ea9b13c0c"
+    },
+    "maps/ad_brk/sandstone04.bsp": {
+     "bytes": 24379,
+     "sha256": "56bda0f4bf4958dc243fa9b4ab79e9e3bd6fad5f794af7beb024a6cbe7f9a0cb"
+    },
+    "maps/ad_brk/sandstone04.map": {
+     "bytes": 798,
+     "sha256": "d01584bd00868a0a69ae7513834f776566fce273d8919d9c78d0bdafbb07a799"
+    },
+    "maps/ad_brk/wood01.bsp": {
+     "bytes": 7553,
+     "sha256": "c1764181bae4852804097143fe16a4c230bd5886574125cb33d5349bbc63dc21"
+    },
+    "maps/ad_brk/wood01.map": {
+     "bytes": 1040,
+     "sha256": "05f1ebaa57c4b55e6c3da9c5440c180aa96c719f9cddc80c780ed11415ad6bd7"
+    },
+    "maps/ad_brk/wood02.bsp": {
+     "bytes": 7079,
+     "sha256": "26fc67e4e47eae3a13a449d876deabe35d50aa1b70e63060d27cb365eadecbe0"
+    },
+    "maps/ad_brk/wood02.map": {
+     "bytes": 521,
+     "sha256": "8dee7615c9e9696420331668edeccd9ff1dd874ad844e289f049391be5e61345"
+    },
+    "maps/ad_brk/wood03.bsp": {
+     "bytes": 7135,
+     "sha256": "ca17df0f61a11bd37749587e361ca404f2e5bec07c248491d86c07803fafb732"
+    },
+    "maps/ad_brk/wood03.map": {
+     "bytes": 522,
+     "sha256": "0fb4cdb1ffeda8c97026d40842d5fcb0beced0f84dae4b10a8284044875cf0c2"
+    },
+    "maps/ad_brk/wood04.bsp": {
+     "bytes": 7951,
+     "sha256": "e2d9f42bf3256be2dd38648dbd962458bdad3992b33e8d688e42a0acba5d7c3f"
+    },
+    "maps/ad_brk/wood04.map": {
+     "bytes": 912,
+     "sha256": "071556b1cac3bd95a176762302e6a60ddbbfb07cf6c9e4b2f8cf2e259e23402a"
+    },
+    "maps/ad_brk/wood05.bsp": {
+     "bytes": 7553,
+     "sha256": "5bdb275ae2c39b41d71a17244681cda9cc2008df088f4da73f547a8bf1966069"
+    },
+    "maps/ad_brk/wood05.map": {
+     "bytes": 1040,
+     "sha256": "ada27de98972730676a2d040fd284893fabfe71acd6fcbce1f2ba12da7d14632"
+    },
+    "maps/ad_brk/wood06.bsp": {
+     "bytes": 7079,
+     "sha256": "f27b0f1970f6065255b5f7a27abfc4e749f40321f6fdef4c3f9ac6bb64d46098"
+    },
+    "maps/ad_brk/wood06.map": {
+     "bytes": 521,
+     "sha256": "17c93b1c1c65a7507d794013078a1d12a67c3a24ae7202739fcd8a1108d52419"
+    },
+    "maps/ad_brk/wood07.bsp": {
+     "bytes": 7135,
+     "sha256": "8e07e7e5f5b641c644d28c9c4026efc95aa50345074f5c42acd39a3b94261344"
+    },
+    "maps/ad_brk/wood07.map": {
+     "bytes": 522,
+     "sha256": "55f1bb5f18ed30f28ac88349aee9ea5563b1e938bafebffb25c9ab5a1c918b33"
+    },
+    "maps/ad_brk/wood08.bsp": {
+     "bytes": 7951,
+     "sha256": "d26222458ba6e7fee06670021e64c1661d99a8c098581936af943891c9583858"
+    },
+    "maps/ad_brk/wood08.map": {
+     "bytes": 912,
+     "sha256": "2582987129d34bbee73594a236c4c09ce6ae1092eec649ef3957b892e125624c"
+    },
+    "maps/ad_brk/wood09.bsp": {
+     "bytes": 7282,
+     "sha256": "2735e78b25b0feb640f27eddae47104b0acba9f017c6d025e3a8dbdfcc755778"
+    },
+    "maps/ad_brk/wood09.map": {
+     "bytes": 541,
+     "sha256": "84d9789b4d79b41347fd082b0ab75c016553c03bfb952cf4b9c7dd18c85944ce"
+    },
+    "maps/ad_brk/wood10.bsp": {
+     "bytes": 7214,
+     "sha256": "43b59e9b0cb02fb1ac15afb5c782e71b4ce0661db295949b5188cc5accd1733a"
+    },
+    "maps/ad_brk/wood10.map": {
+     "bytes": 533,
+     "sha256": "365f949e19e2606cf2d7a354c3e4368a5e17c3eef94e2558ed9cef276e987d35"
+    },
+    "maps/ad_brk/wood11.bsp": {
+     "bytes": 7196,
+     "sha256": "cce8b312c4be49810f4cf90f0dcdeb1a82dfa623de1ba44c55ec83475f9e9e49"
+    },
+    "maps/ad_brk/wood11.map": {
+     "bytes": 542,
+     "sha256": "790cd93cb271402698ad7f005b908847fddbb30d3c8c3d11fa8c2f327ca8e48e"
+    },
+    "maps/ad_brk/wood12.bsp": {
+     "bytes": 7978,
+     "sha256": "6a227f92bf3b6f1120efd6179bfb3de977e4be2e59495c5d757cbe1c835e3f03"
+    },
+    "maps/ad_brk/wood12.map": {
+     "bytes": 986,
+     "sha256": "01ed96a5ce6545b334dfac7dc0196472dd6c06df09ed557cec7dc820d35c1132"
+    },
+    "maps/ad_brk/wood13.bsp": {
+     "bytes": 7284,
+     "sha256": "09325ca10ebcfeb88f688c9f4521259c3c3426e9befc06c99ba405c7e20595c9"
+    },
+    "maps/ad_brk/wood13.map": {
+     "bytes": 526,
+     "sha256": "b16b33b2a46b72a4ee235674780298eac0ed27631def07a28058a775aba7078e"
+    },
+    "maps/ad_brk/wood14.bsp": {
+     "bytes": 7216,
+     "sha256": "4c9dc5afd7b51119e5c22ad36eb77d07881c454ff47ed060521172cfc3950e2c"
+    },
+    "maps/ad_brk/wood14.map": {
+     "bytes": 518,
+     "sha256": "41b51f20630df3c046ed9ca0f7d97ca403ce8c1487074fc80caf603e763e6ac1"
+    },
+    "maps/ad_brk/wood15.bsp": {
+     "bytes": 7196,
+     "sha256": "373f6e5c5da44b7c8d1a01fb701f074bbcfc52d21bb080dd04e986ffe9e1088c"
+    },
+    "maps/ad_brk/wood15.map": {
+     "bytes": 527,
+     "sha256": "eb07eae6f0afdb4b03af57bcb589e3b385632912f12d4c55257b3031270f0421"
+    },
+    "maps/ad_brk/wood16.bsp": {
+     "bytes": 7612,
+     "sha256": "05959d3486eb43afc8959f6923156a1a83ead4dad544f8caf90ba0e1c7e2bc80"
+    },
+    "maps/ad_brk/wood16.map": {
+     "bytes": 953,
+     "sha256": "c7e804e781c95336cc91a50bc246baf4fda7172ecf36ccf24f02c5f919710ab3"
+    },
+    "maps/base_brk/baserub1.bsp": {
+     "bytes": 23612,
+     "sha256": "b5320b798366587d20ab541af06babd9575e89870fb003d56a17fdf2f7f22b0c"
+    },
+    "maps/base_brk/baserub1.map": {
+     "bytes": 637,
+     "sha256": "0a5357fb3b12d9286b4d9e6e54316cfd0a33f9fda4c661b8fcd1c461d06ae73f"
+    },
+    "maps/base_brk/bz8_brk.bsp": {
+     "bytes": 12808,
+     "sha256": "219e4371cd0b22d690c6e6660ca2fca3b526618d4ccd9f37799135d2dc6dea02"
+    },
+    "maps/base_brk/bz8_brk.map": {
+     "bytes": 692,
+     "sha256": "fae1ac45d74b2a9f482eb034e0838fe5914affb57204c5215d97ebaf7199e5c8"
+    },
+    "maps/base_brk/crate_r1.bsp": {
+     "bytes": 29110,
+     "sha256": "5dd3afab4a3ad5cf4466e272324e4afad5075ca2e662cc8b1932e277a2db73a2"
+    },
+    "maps/base_brk/crate_r1.map": {
+     "bytes": 664,
+     "sha256": "ee7ce39ec0650d3cbde924b99efc91ba884778db11a961037d4493bf587fa33e"
+    },
+    "maps/base_brk/explodebox_1.bsp": {
+     "bytes": 7707,
+     "sha256": "28bfab37e5cbe722348b753de3bd9f66f47f4a9f5b80bd5c5c1659e6eae7e6c4"
+    },
+    "maps/base_brk/explodebox_1.map": {
+     "bytes": 544,
+     "sha256": "96376f1185f158bf69d6bb0c5baf347bbad27f0ccd6fccd3096da6dd7f89540b"
+    },
+    "maps/base_brk/explodebox_2.bsp": {
+     "bytes": 7107,
+     "sha256": "59d5ba28bc049f691bf28d421327e4aecf5eedaec46599d58328f0074ce0934f"
+    },
+    "maps/base_brk/explodebox_2.map": {
+     "bytes": 375,
+     "sha256": "f906dbea8598f0290af9e224a70eb71f26f3c93c10e922b2fade3f1c63e4ddd5"
+    },
+    "maps/base_brk/explodebox_3.bsp": {
+     "bytes": 10449,
+     "sha256": "0daebb987f48b5dde145998e748ab2eecf63ec69318a6b752924e4cfb6639261"
+    },
+    "maps/base_brk/explodebox_3.map": {
+     "bytes": 1698,
+     "sha256": "538e12e7706df3b8f539bf2473e7517e737657380137de1655193843210dbf3f"
+    },
+    "maps/base_brk/glass01.bsp": {
+     "bytes": 7427,
+     "sha256": "bf3f3938ab3596b6095fb58f66c0a36042e5950169dbb86b1cf3cb9076fd5bdd"
+    },
+    "maps/base_brk/glass01.map": {
+     "bytes": 907,
+     "sha256": "6f47c3ffec4cb28d3447dbf96f0b3d6e4264accd31e10b68ad83b3e30e4e32a7"
+    },
+    "maps/base_brk/grate_r1.bsp": {
+     "bytes": 32796,
+     "sha256": "a8eac6a49f8c49c4f9f1b443c9ca5c6a5f8d03d30ce240daaeee8d150f9c5067"
+    },
+    "maps/base_brk/grate_r1.map": {
+     "bytes": 2106,
+     "sha256": "e5cac190d45b0d14901947e489622680d1b9436955b18e2a0e8cb2f92e9aa011"
+    },
+    "maps/base_brk/pbt04.bsp": {
+     "bytes": 18286,
+     "sha256": "0a3321e606857ebb78d047be51c92036b53175dc392c021891cdeabd28597c3c"
+    },
+    "maps/base_brk/pbt04.map": {
+     "bytes": 699,
+     "sha256": "a8b2d3feef56b8cad384a88a9646b596d21017cb9d26278c0b3585ef589b578d"
+    },
+    "maps/base_brk/phk_03brk.bsp": {
+     "bytes": 90417,
+     "sha256": "46efed3a00ce885798ca568563a04472200359c6111682e91fc701c37d8df143"
+    },
+    "maps/base_brk/phk_03brk.map": {
+     "bytes": 1509,
+     "sha256": "29549a0e23b3651110beae8f8697c85e1e3eeb8752dcc8c253a2756e11189209"
+    },
+    "maps/base_brk/rock_sw01.bsp": {
+     "bytes": 8843,
+     "sha256": "a3acc4f42ca89efb30d5f9d7ed7c694d59ab6003bd3c665cfa4db480550fd92d"
+    },
+    "maps/base_brk/rock_sw02.bsp": {
+     "bytes": 9179,
+     "sha256": "4b3d68587a69daa68093d32195a786e8040fed763855acb94f50d02875a8ec44"
+    },
+    "maps/base_brk/rock_sw03.bsp": {
+     "bytes": 9766,
+     "sha256": "59d2841166f7ecb216df970963b3e425da20566f2fb56a7e5472f4e3c9fcfb24"
+    },
+    "maps/base_brk/sfloor4_2.bsp": {
+     "bytes": 7431,
+     "sha256": "d4f7ee45638e0f338c96cf43779410a112bb10be26a200e24187749a80b01332"
+    },
+    "maps/base_brk/sfloor4_2.map": {
+     "bytes": 833,
+     "sha256": "f285b9a96b32420f24bccb267b268e65afd50dd03fb106fad90783aa5d82c1d4"
+    },
+    "maps/base_brk/tech10_2d1.bsp": {
+     "bytes": 45558,
+     "sha256": "272aa49909de27f7b4722848497e5da38aa50b7bef17ef2ee81a1b1240c1b8b2"
+    },
+    "maps/base_brk/tech10_2d1.map": {
+     "bytes": 740,
+     "sha256": "a3766904240cbe7603e967eb3ebdd0dc895b035f0db8758a6ad217749a332904"
+    },
+    "maps/base_brk/tech10_2d2.bsp": {
+     "bytes": 45552,
+     "sha256": "71e5e52660e4aa84f56aa7b51bad024384acb69699bcec431ae3fe6c8d16fc42"
+    },
+    "maps/base_brk/tech10_2d2.map": {
+     "bytes": 733,
+     "sha256": "9d6c4dae495d96bf4b2bbf5f7e01900f16274173c63eb2e4acfb8f8e757a399f"
+    },
+    "maps/medieval_brk/ad_column1.bsp": {
+     "bytes": 14800,
+     "sha256": "f94c99425b3987ebb9eea08dd8c1b3c0e0215cc8afcd1099f7283324ff566712"
+    },
+    "maps/medieval_brk/ad_column1.lit": {
+     "bytes": 578,
+     "sha256": "c30b5af83ab23db6614ad13aff712a15971a6b35ae29ddd49f0cd3da1c1f4919"
+    },
+    "maps/medieval_brk/ad_column1.map": {
+     "bytes": 1541,
+     "sha256": "d71326b819e902d9a32f4a1961565f6ebb10d90069ba2ae0dc0be381a4c1b764"
+    },
+    "maps/medieval_brk/ad_rock1.bsp": {
+     "bytes": 352852,
+     "sha256": "9333d2d2d848e3a4490634aa4f1cc1ee3281c57ac9a498c85b043e5856ce2578"
+    },
+    "maps/medieval_brk/ad_rock1.lit": {
+     "bytes": 920,
+     "sha256": "6d2b33cbd7b3ce1a35c25a6e006a0786fe0bd0ea8be34b1911e2663ac33ea910"
+    },
+    "maps/medieval_brk/ad_rock1.map": {
+     "bytes": 2163,
+     "sha256": "d00049f1c1bdf04d98e768ece39b7d7442e34b719ec991e5715df588d6493d8b"
+    },
+    "maps/medieval_brk/ad_rock2.bsp": {
+     "bytes": 14728,
+     "sha256": "52675efa81ecae4bb87524c97148d7da60916f0e0dc3c65e99b73745aea70fec"
+    },
+    "maps/medieval_brk/ad_rock2.lit": {
+     "bytes": 383,
+     "sha256": "306d2df8cbd9d7ad755fe7e4a6734e0089b38eefa2e2e4fccacfb68c96dd8d90"
+    },
+    "maps/medieval_brk/ad_rock2.map": {
+     "bytes": 1528,
+     "sha256": "891f208f7fdae3fcf1defe7a4cdcda7a6084fbde663ed4e2ab015af18911cb96"
+    },
+    "maps/medieval_brk/ad_rock3.bsp": {
+     "bytes": 352160,
+     "sha256": "bf041a139ed9be638cd1c548139fffca3ceeddefdad2334fcc2639018833110a"
+    },
+    "maps/medieval_brk/ad_rock3.lit": {
+     "bytes": 356,
+     "sha256": "19a61c05d08dd726a9d00174eb3eb1dbdd16da3e0e62ab93d691620aa71add83"
+    },
+    "maps/medieval_brk/ad_rock3.map": {
+     "bytes": 1878,
+     "sha256": "d0049b763f7fd8f25b2176984341421d704f9b50571b24168c60889fdbad5e20"
+    },
+    "maps/medieval_brk/ad_rock4.bsp": {
+     "bytes": 352704,
+     "sha256": "578e7d2dc0eff7bf5ac21b04919d1e137296824182d4809991a27a83addeba75"
+    },
+    "maps/medieval_brk/ad_rock4.lit": {
+     "bytes": 311,
+     "sha256": "3af5d5c9613dd5a1fa09a40b02891bf7153892db8505528b7d3315ce251bfff7"
+    },
+    "maps/medieval_brk/ad_rock4.map": {
+     "bytes": 1889,
+     "sha256": "472f41679eedc00096e8042935ad5287f4598940ef294b8175cccd196dcb6f86"
+    },
+    "maps/medieval_brk/az_ice05.bsp": {
+     "bytes": 98664,
+     "sha256": "b8b2aa063250f6dcc388ead43ff66133c8fa14b1c30afa17c2fce8f2b2c9fd81"
+    },
+    "maps/medieval_brk/az_ice05.lit": {
+     "bytes": 617,
+     "sha256": "e3e8aa044b60a26d643ff87937f83602cdffcebb948ea7ae22148e7952faa18b"
+    },
+    "maps/medieval_brk/az_ice05.map": {
+     "bytes": 3094,
+     "sha256": "dbca0fea0a986137f9b4a6fbb916cf3de830ba4a60738830cc6e1bd554f561f1"
+    },
+    "maps/medieval_brk/az_kbr1.bsp": {
+     "bytes": 7476,
+     "sha256": "2a2cd33b87f511d4c7fc25a812c632fb07c385b372e89fa900fd0f8ce8146076"
+    },
+    "maps/medieval_brk/az_kbr1.lit": {
+     "bytes": 92,
+     "sha256": "580ff7adf91b63bcd7f35e27059295b0a5fc404468e32e5d5f3323b5a822fb27"
+    },
+    "maps/medieval_brk/az_kbr1.map": {
+     "bytes": 863,
+     "sha256": "3b9d9842f17fb140b23337b452cfc8d49151410640384868a0003bd472dd0d5c"
+    },
+    "maps/medieval_brk/az_kbr1.pts": {
+     "bytes": 178,
+     "sha256": "22cf782552b8a3da946cfa0fa044cffd08f2b0ab50e588c9b68d89a373f026b0"
+    },
+    "maps/medieval_brk/az_kjw1.bsp": {
+     "bytes": 9424,
+     "sha256": "06f271813935ecb90a425d6c943bd53b207fb9d370ec42bb1228af92fe4413d1"
+    },
+    "maps/medieval_brk/az_kjw1.lit": {
+     "bytes": 380,
+     "sha256": "30e6270550b5a78bfaa31df0c6e477d6980eefd380abc2e2aaf7003dbe544f77"
+    },
+    "maps/medieval_brk/az_kjw1.map": {
+     "bytes": 1825,
+     "sha256": "61e8f8f45b2fb0e0766b125bae58b54b36cb45b6d856c7c06814681f52eb91aa"
+    },
+    "maps/medieval_brk/az_kjw1.pts": {
+     "bytes": 120,
+     "sha256": "f7d0f45d90befed57df8dd476bcd10293481eb932925853e3fdbc93a55991a49"
+    },
+    "maps/medieval_brk/az_rtex01.bsp": {
+     "bytes": 97932,
+     "sha256": "ce36fbfdd6f46f5aa7740598689fb2c7de50fa58adda9d4a8a3023ad31194367"
+    },
+    "maps/medieval_brk/az_rtex01.lit": {
+     "bytes": 692,
+     "sha256": "5fe28d309679e9871f14a9c3833184c9ad711fa2bd93adc330a34fd599032a6d"
+    },
+    "maps/medieval_brk/az_rtex01.map": {
+     "bytes": 2875,
+     "sha256": "6cc8f787b54565b3c9dffe9eec20c44d66a68b12fd555bad65bb25f03a2aa7e9"
+    },
+    "maps/medieval_brk/az_wood1.bsp": {
+     "bytes": 7560,
+     "sha256": "373c0b96905055b6b036272c954d7eaf3557d79d62b056ab9a472fb0cd27de83"
+    },
+    "maps/medieval_brk/az_wood1.lit": {
+     "bytes": 176,
+     "sha256": "67ce559200158ce198e5a93a94dd4a440ae607fedc5b3093c288049ce5f50151"
+    },
+    "maps/medieval_brk/az_wood1.map": {
+     "bytes": 950,
+     "sha256": "4fb7eae852ba72528b34d6a0947497eeeab1e1307aa1c4be552628432007c86e"
+    },
+    "maps/medieval_brk/azr1.bsp": {
+     "bytes": 13842,
+     "sha256": "e00518c5ad3beee852a6135184423d4ca985b17b2f1d2cfebc60e82f91582f26"
+    },
+    "maps/medieval_brk/azr1.map": {
+     "bytes": 1193,
+     "sha256": "ef3affe9788b130826f2b1632b5461eaaf15d630587c12c5a875f6042b0ae99c"
+    },
+    "maps/medieval_brk/azr2.bsp": {
+     "bytes": 13571,
+     "sha256": "687097f4773430ca297db9c1d8133b035c8ca1e5d574943a4caa34eef262f003"
+    },
+    "maps/medieval_brk/azr2.map": {
+     "bytes": 1319,
+     "sha256": "22b2084665b2882c976da1dc840a19b151cd44daa524955ddab9ec64e9c3233e"
+    },
+    "maps/medieval_brk/azr3.bsp": {
+     "bytes": 13571,
+     "sha256": "187a6607641c00aa6ee662af52f1b2899d5ca606e469408dd2c94d67dd2ab465"
+    },
+    "maps/medieval_brk/azr3.map": {
+     "bytes": 1338,
+     "sha256": "5e551a8ebefc386b1336e814a44e29ae6781e6da5bc929cb232674853c46a143"
+    },
+    "maps/medieval_brk/booksh1w_brk1.bsp": {
+     "bytes": 23869,
+     "sha256": "dbc342e95245a12598aade308195a3234829225944692c45c8fec792d03f17c3"
+    },
+    "maps/medieval_brk/booksh1w_brk1.map": {
+     "bytes": 793,
+     "sha256": "a9d2fe494267551f3d1638c7963bab47d292be250417f78286b39059af836af5"
+    },
+    "maps/medieval_brk/booksh1w_brk2.bsp": {
+     "bytes": 23663,
+     "sha256": "4b8cd15ae7812d581064800bbcf64cab62c3d5ecfb03c23ff2b498694a0cb708"
+    },
+    "maps/medieval_brk/booksh1w_brk2.map": {
+     "bytes": 661,
+     "sha256": "19c13935f0b045fadd9c739680de7155f0e4d29c86ef3e6950d07f265b1ef1a3"
+    },
+    "maps/medieval_brk/booksh1w_brk3.bsp": {
+     "bytes": 23700,
+     "sha256": "1fc3c7a685f5662779f4c6ad0fb02099396504dcf55eef09474183aff69861c1"
+    },
+    "maps/medieval_brk/booksh1w_brk3.map": {
+     "bytes": 746,
+     "sha256": "bd10960b3af925cf2a33bb0629d1a522de5f54ec05938b36378871fd7de0b9f3"
+    },
+    "maps/medieval_brk/booksh1w_brk5.bsp": {
+     "bytes": 23639,
+     "sha256": "851a02aced76ba77894ba744c5c781ff350a42b93216e095f75938fc95ee39a8"
+    },
+    "maps/medieval_brk/booksh1w_brk5.map": {
+     "bytes": 759,
+     "sha256": "c92ec0ad3d3a5c6588557b5f3c9c000cd1c141a4d9c3b35333d859e75c677568"
+    },
+    "maps/medieval_brk/brick2_4brk1.bsp": {
+     "bytes": 9004,
+     "sha256": "86fb182b011385225d5be8b2a2ba0763286a5a2a5880fdda6fc238d8e6a5212f"
+    },
+    "maps/medieval_brk/brick2_4brk1.map": {
+     "bytes": 1375,
+     "sha256": "208cf3d2a51b0aa4a45cd237786a9303b70a63a85e991a7f8675634bea6295ed"
+    },
+    "maps/medieval_brk/brick2_4brk2.bsp": {
+     "bytes": 7265,
+     "sha256": "151471ef184c02141716225e4403e97a69190bd8a3e9645cf2d52aeb5dce591d"
+    },
+    "maps/medieval_brk/brick2_4brk2.map": {
+     "bytes": 603,
+     "sha256": "cdd5762f851cec464b27e9bfc91c0eab8cb26e69a8b050ac1bd9b0eb662dbf7b"
+    },
+    "maps/medieval_brk/brick2_brk2.bsp": {
+     "bytes": 25323,
+     "sha256": "0d8c4dc3202bcc9f26dfd42ca555b99d0010c63b977cd058646a8e8ad4486eea"
+    },
+    "maps/medieval_brk/brick2_brk2.map": {
+     "bytes": 1378,
+     "sha256": "daeae48ab2f6fca712da2413b65c80c6a944e537571def2d153976b0175d8768"
+    },
+    "maps/medieval_brk/brick2_brk3.bsp": {
+     "bytes": 24310,
+     "sha256": "5f94a5e271bb5b921e4534be8690f005bc258e484cb842a6ead0af9aac29fcfb"
+    },
+    "maps/medieval_brk/brick2_brk3.map": {
+     "bytes": 905,
+     "sha256": "1639469c5fe31540811a8bb95d959844d200102cd19f60d1d5e9c3472477e2d2"
+    },
+    "maps/medieval_brk/brick2_brk4.bsp": {
+     "bytes": 23548,
+     "sha256": "e2049e826c103f2afbb5d0a4b69d45089d0bdcf6bd60646d6ae79c99e9a9a976"
+    },
+    "maps/medieval_brk/brick2_brk4.map": {
+     "bytes": 582,
+     "sha256": "b3528f92f4ecf8099a7bfbf3285f21312c501536b66e02b566a7e38474aa608c"
+    },
+    "maps/medieval_brk/city2_3d1.bsp": {
+     "bytes": 7358,
+     "sha256": "efc80ba0aab1284e2bcec652cc3a2748890c45d6905335f61483eab2851f7c81"
+    },
+    "maps/medieval_brk/city2_3d1.map": {
+     "bytes": 739,
+     "sha256": "ff9c2ebe0034d188443e3a72753d4ecad2a69706a4a06c114f9147f507d10b30"
+    },
+    "maps/medieval_brk/city2_3rd.bsp": {
+     "bytes": 7156,
+     "sha256": "6146e0e5961857308f2ef550213ec647ad810a97359d0946cc07f610e0f03006"
+    },
+    "maps/medieval_brk/city4_2_brk1.bsp": {
+     "bytes": 7435,
+     "sha256": "42a4cbd73804a8458a8369fdbd19ee6b3b4597b18583c242bf77b0122ddc9c1a"
+    },
+    "maps/medieval_brk/city4_2_brk1.map": {
+     "bytes": 648,
+     "sha256": "50b744f4af85aa3c0158ae0330808840710c7ee95c1bda8155cb81b4b247fc74"
+    },
+    "maps/medieval_brk/city4_2_brk2.bsp": {
+     "bytes": 7179,
+     "sha256": "cc2ddcb8877dc1b49ec2c408d6b869a35dd7b6590782525af567905d75a3ada0"
+    },
+    "maps/medieval_brk/city4_2_brk2.map": {
+     "bytes": 520,
+     "sha256": "e9309b8ec24126fd952443ae6bee72df46ba04fb4d0925b33d41c603af9ac5b3"
+    },
+    "maps/medieval_brk/city4_2_brk3.bsp": {
+     "bytes": 10009,
+     "sha256": "7f9a27098101f70090c3aff7fd6731effd2750e8c2b7fdbbb0a9f3146be94045"
+    },
+    "maps/medieval_brk/city4_2_brk3.map": {
+     "bytes": 1575,
+     "sha256": "c352d889a3bed731b7c54e38d7ed35e6fa860d2f6f69eb91319f4043423d7aa8"
+    },
+    "maps/medieval_brk/city6_8brk1.bsp": {
+     "bytes": 7187,
+     "sha256": "bcf4b2815c96308ffc1ab3467ac8b2dd4c25be47d618fd82536ba83bf74a05fc"
+    },
+    "maps/medieval_brk/city6_8brk1.map": {
+     "bytes": 529,
+     "sha256": "2db1be71ce1b1e8bf1e8a5c4c7f2802345aa19c281fd43f2b18d205cbd06bfca"
+    },
+    "maps/medieval_brk/city6_8brk2.bsp": {
+     "bytes": 7298,
+     "sha256": "3b7fd08defa832be1c3f3e40efc6d54d13af6714180be810f6527188f332fbff"
+    },
+    "maps/medieval_brk/city6_8brk2.map": {
+     "bytes": 611,
+     "sha256": "ed29b0773cb700d4b8212f9e28b23edac2d212f469b4a1406538df2b066fcbb2"
+    },
+    "maps/medieval_brk/floor015_brk1.bsp": {
+     "bytes": 12862,
+     "sha256": "5bfae9b09777fad7f26f80b5acc27e187e2259ac5c79ad32ab2a30d154e5889b"
+    },
+    "maps/medieval_brk/floor015_brk1.lit": {
+     "bytes": 179,
+     "sha256": "5d64872b2341768efce6c27686555200246e03d346a2e15089e002d53b1b348f"
+    },
+    "maps/medieval_brk/floor015_brk1.map": {
+     "bytes": 827,
+     "sha256": "08f5b26ee0ebb26416e6a1ed660e197b1ea113a553f5c7a1d26a6070b5cbdac8"
+    },
+    "maps/medieval_brk/floor015_brk2.bsp": {
+     "bytes": 12861,
+     "sha256": "377b50dac34c3789fe8a7bcf6a5b3cedda0f3ba91225135ffc9a2f41abe41e35"
+    },
+    "maps/medieval_brk/floor015_brk2.lit": {
+     "bytes": 188,
+     "sha256": "402bfba12b94cd1b3a40f1052830d4e4fa3b4cb103b196c089f4965e94766bd5"
+    },
+    "maps/medieval_brk/floor015_brk2.map": {
+     "bytes": 828,
+     "sha256": "a45245e0f19cc98f29bcc88c9173118b65058d25ff1c043aaca876353bc67531"
+    },
+    "maps/medieval_brk/floor015_brk3.bsp": {
+     "bytes": 13185,
+     "sha256": "52e2b8d426e479bffc8d518a4d8aa5d5a5dc437dbd761c7074992838ccfd070b"
+    },
+    "maps/medieval_brk/floor015_brk3.lit": {
+     "bytes": 218,
+     "sha256": "dabacc9c3ffdc3bae8c008bedfb683babaca23f6e5b0ca5e35b9c39f9d86f402"
+    },
+    "maps/medieval_brk/floor015_brk3.map": {
+     "bytes": 1078,
+     "sha256": "5235ba02c52ba6dc678f052e4efbad43b9f7d63f858c5f732519f6436246733d"
+    },
+    "maps/medieval_brk/plat_brk.bsp": {
+     "bytes": 59896,
+     "sha256": "367ec651b3cded1ecdf22305a3b48490d3df3078d556d4c7fadfb392ae12ad33"
+    },
+    "maps/medieval_brk/plat_brk.map": {
+     "bytes": 2052,
+     "sha256": "fe52fffba97e8df9acfe4607c9b08d9eb5f4559b44d8c0f6fdbd3af6a0cbf8d6"
+    },
+    "maps/medieval_brk/rock_sw01.bsp": {
+     "bytes": 8843,
+     "sha256": "a3acc4f42ca89efb30d5f9d7ed7c694d59ab6003bd3c665cfa4db480550fd92d"
+    },
+    "maps/medieval_brk/rock_sw01.map": {
+     "bytes": 1371,
+     "sha256": "0e4d621fba3a9806ffdf2bffda89e4d05231513b6f7986d504722d1b99c21a91"
+    },
+    "maps/medieval_brk/rock_sw02.bsp": {
+     "bytes": 9179,
+     "sha256": "4b3d68587a69daa68093d32195a786e8040fed763855acb94f50d02875a8ec44"
+    },
+    "maps/medieval_brk/rock_sw02.map": {
+     "bytes": 1631,
+     "sha256": "82bbf3c701301a80f55619bdac2680d9713432d8fe991838bfb7559830225322"
+    },
+    "maps/medieval_brk/rock_sw03.bsp": {
+     "bytes": 9766,
+     "sha256": "59d2841166f7ecb216df970963b3e425da20566f2fb56a7e5472f4e3c9fcfb24"
+    },
+    "maps/medieval_brk/rock_sw03.map": {
+     "bytes": 1526,
+     "sha256": "300f4c4f56cc9f6425cc8999484e18326555c57b8f53d9f42c36a4345b850d2c"
+    },
+    "maps/medieval_brk/rock_sw04.bsp": {
+     "bytes": 9836,
+     "sha256": "72854269a33665022dee9c30e53e6124bc2bba25ad34d2a3d86302e50ad795c1"
+    },
+    "maps/medieval_brk/rock_sw04.map": {
+     "bytes": 1605,
+     "sha256": "e2b3e6e53c11de10d0de4b7374d43a09be1622766cb3ff60c9e9cec8688747f9"
+    },
+    "maps/medieval_brk/rot_p.bsp": {
+     "bytes": 13554,
+     "sha256": "afcc7dc6512bba89ceec9e10bfa8256ecd043d34c1af57f33a199509500164ff"
+    },
+    "maps/medieval_brk/rot_p.map": {
+     "bytes": 2518,
+     "sha256": "c60e36e827e052cea6ca5c6c2d022b5da051090ee2accf8807f5703ec8acc79a"
+    },
+    "maps/medieval_brk/waa1.bsp": {
+     "bytes": 23869,
+     "sha256": "739aa8d0753e691020013539356d2c2e10b9d0b82c63bcc694080afe33bc585e"
+    },
+    "maps/medieval_brk/waa1.map": {
+     "bytes": 765,
+     "sha256": "f2e7bbba974ffde1e4178be825034e555ca491fffedbf007e62589214af82f0f"
+    },
+    "maps/medieval_brk/wbrick15_brk.bsp": {
+     "bytes": 7969,
+     "sha256": "0dcbd483c300f1be58a216b6d64ea385dd489babdc70868e483fb496c4dd4c38"
+    },
+    "maps/medieval_brk/wbrick15_brk.map": {
+     "bytes": 899,
+     "sha256": "43789ad5bb908aa7fb8e8893db766ce0e479cc547e31aa8de6fe1b4bd6093015"
+    },
+    "maps/medieval_brk/win1ah_brk.bsp": {
+     "bytes": 34981,
+     "sha256": "d549b60245213678c222499299e43654c25f838ed42898a25ec284d933f56b64"
+    },
+    "maps/medieval_brk/win1ah_brk.map": {
+     "bytes": 897,
+     "sha256": "da6859a14f291bef23c990977c0fce7e21ee2c790318cce46e36a8388e87fb39"
+    },
+    "maps/medieval_brk/win1ah_brk2.bsp": {
+     "bytes": 34873,
+     "sha256": "87416124f6e04adaaa5ed9144fa60e048dc03606bc294d89d99295a7c8cb2487"
+    },
+    "maps/medieval_brk/win1ah_brk2.map": {
+     "bytes": 901,
+     "sha256": "5d9a1aefeca5acfdbb25cad5489f5bcb41c89f3c9b92a3d305da0f462c439ec2"
+    },
+    "maps/medieval_brk/wiz14_brk1.bsp": {
+     "bytes": 8961,
+     "sha256": "cb45306588dc69d44422d475c0481f67a76638fe2502c16c28a8f87fa43f6787"
+    },
+    "maps/medieval_brk/wiz14_brk1.map": {
+     "bytes": 1262,
+     "sha256": "46200a77c401035e45d339d8106263e7210ed66e373be74f65687c5d1eb83124"
+    },
+    "maps/medieval_brk/wiz14_brk2.bsp": {
+     "bytes": 7338,
+     "sha256": "871684ecf4507da9773ca5568ccdd0a27173d2f35922b379a19f95e9252a777f"
+    },
+    "maps/medieval_brk/wiz14_brk2.map": {
+     "bytes": 652,
+     "sha256": "97a58529ea21e8127050b0f1e3305e4616b1970232e6517aa652061f49ffc9e0"
+    },
+    "maps/medieval_brk/ws14_brk1.bsp": {
+     "bytes": 7987,
+     "sha256": "ee96dcf614d940d9f887035be0781ad941fc5f76a0f0e553ec3592ae00af1794"
+    },
+    "maps/medieval_brk/ws14_brk1.map": {
+     "bytes": 948,
+     "sha256": "022d130b741c8976f529288f6030fabd2040991efd8bb0a6542dc1508c0b061c"
+    },
+    "maps/medieval_brk/ws14_brk2.bsp": {
+     "bytes": 9003,
+     "sha256": "6aa46294d8fffe55db6f2e6a9d30341fe07a9252b0066ff575c692d0b149f7af"
+    },
+    "maps/medieval_brk/ws14_brk2.map": {
+     "bytes": 1375,
+     "sha256": "8f175f2e3ac8a760fcb7d25da5a30cea149b55349fa0e0d20b2a8c0b080aa5b0"
+    },
+    "maps/medieval_brk/ws14_brk3.bsp": {
+     "bytes": 8944,
+     "sha256": "282944bfbd49b6dcc0aa0d67253432d88c63212ea564a9c6b8909a9b96f8946a"
+    },
+    "maps/medieval_brk/ws14_brk3.map": {
+     "bytes": 1282,
+     "sha256": "6ecd83ba25e15f363f271078c73f6c460babf95ea63340a855dfa182ec47e4b4"
+    },
+    "maps/rtex_brk/022a.bsp": {
+     "bytes": 17448,
+     "sha256": "3557f9518ca0982c871dd344ea5069e5128645029ea428de26ef991881170a59"
+    },
+    "maps/rtex_brk/022a.map": {
+     "bytes": 691,
+     "sha256": "50e0375bf596265b893e56996dbddfad26af2e50bb9af473dc2115e18b11dc02"
+    },
+    "maps/rtex_brk/022b.bsp": {
+     "bytes": 17608,
+     "sha256": "083fdbd34b34b47c5dd9dd58f4e3e0fa3debbedd554db4ce81791033349451fa"
+    },
+    "maps/rtex_brk/022b.map": {
+     "bytes": 825,
+     "sha256": "26d8800f4cfb0706ad363e958846d87755b4871792d1ac1f00b5b51fd7550777"
+    },
+    "maps/rtex_brk/022c.bsp": {
+     "bytes": 17820,
+     "sha256": "8c6b933d2cd323eba623727226ea6cb1f968e0401093f93d229d229a7a5b225d"
+    },
+    "maps/rtex_brk/022c.map": {
+     "bytes": 894,
+     "sha256": "835d4d09490552859dc79ad527bcd08af8afedfa7a863148c62f2f58742e9014"
+    },
+    "maps/rtex_brk/022d.bsp": {
+     "bytes": 17592,
+     "sha256": "0580ec01633972b2fff28c5d4b9a71766d3f1ed6fae387dff34ca691ff829e38"
+    },
+    "maps/rtex_brk/022d.map": {
+     "bytes": 784,
+     "sha256": "238fc24be385d3994586c34555e74ecbb7677aa7567bbf317947276c14b62107"
+    },
+    "maps/rtex_brk/330a.bsp": {
+     "bytes": 7928,
+     "sha256": "a446db4116b8c33f46745cf815ba9309e69591d919838006c81a9b0a5b00c7d4"
+    },
+    "maps/rtex_brk/330a.map": {
+     "bytes": 691,
+     "sha256": "964103ee6422dd3b815472c9f29126741e06517623dad050fba18a9867451903"
+    },
+    "maps/rtex_brk/330b.bsp": {
+     "bytes": 8088,
+     "sha256": "727d22fad028bac645a53ac5a425618e30575735958496b7a1ac86cfbc562e1a"
+    },
+    "maps/rtex_brk/330b.map": {
+     "bytes": 825,
+     "sha256": "807bdb97ab58709fd96cfa0e7b65cb5d377257b862eef2673606901d70b84108"
+    },
+    "maps/rtex_brk/330c.bsp": {
+     "bytes": 8300,
+     "sha256": "b25471a1f0e7fdd066dda47860ae956db2b2c4758a426b39b8a82e6b4c6d1b72"
+    },
+    "maps/rtex_brk/330c.map": {
+     "bytes": 894,
+     "sha256": "13241951b0d3cd61a71e0fe80071a1df65e369eba44aabdf3401f3ba5aa55a7f"
+    },
+    "maps/rtex_brk/330d.bsp": {
+     "bytes": 8072,
+     "sha256": "8f83245e973c42e9908b6215c5effc0f0581d654e5e8e67a6e77493f79de3e6d"
+    },
+    "maps/rtex_brk/330d.map": {
+     "bytes": 784,
+     "sha256": "f0e46c1efc3d5a814675f5760a33a2e6bc4163974ff64a4c1f88ab70c50fbb68"
+    },
+    "maps/rtex_brk/340a.bsp": {
+     "bytes": 13368,
+     "sha256": "e8a605fdff44ef59b4657a43a67cfb24d2d62f150b210a0761f69ed5f559215c"
+    },
+    "maps/rtex_brk/340a.map": {
+     "bytes": 691,
+     "sha256": "3678f5058497a6067c7ffb4d452e706af588e0aedfd30bfa2d43f1902333e7ec"
+    },
+    "maps/rtex_brk/340b.bsp": {
+     "bytes": 13528,
+     "sha256": "d92cc6afb7ae74965a8bb2a753909e2dc6c064b5fb2c9c463c95123531ba337d"
+    },
+    "maps/rtex_brk/340b.map": {
+     "bytes": 825,
+     "sha256": "29f243aa1c347358e34383f4ffb2d129f710829022524237585041c7840a02cb"
+    },
+    "maps/rtex_brk/340c.bsp": {
+     "bytes": 13740,
+     "sha256": "882a110b1a7e26481e5dd37858d5229c0273bc98ab8a2ab59f318e2b76080fac"
+    },
+    "maps/rtex_brk/340c.map": {
+     "bytes": 894,
+     "sha256": "069e17115ae35cf0fdaa9ceb8b3a67065360d4fc03f91036ba453b6b6745d77b"
+    },
+    "maps/rtex_brk/340d.bsp": {
+     "bytes": 13512,
+     "sha256": "96a6133331679ad8eb75d8581e8be12c6822d2048c18a1e704281a6e4cc0737c"
+    },
+    "maps/rtex_brk/340d.map": {
+     "bytes": 784,
+     "sha256": "b8197ea047f14d175e5b9234dcc9b625f04124b175bb0fd80da7ceffe056b00c"
+    },
+    "maps/rtex_brk/413ra.bsp": {
+     "bytes": 7972,
+     "sha256": "a3cc5962750f55c398dfaf53cb4d8394f1100c752ca9797f053ec2710acd995d"
+    },
+    "maps/rtex_brk/413ra.map": {
+     "bytes": 769,
+     "sha256": "b0a3052bfb352684f97fb7bca8fdc3d7b135ae5e3fca491d190d09423836da46"
+    },
+    "maps/rtex_brk/413rb.bsp": {
+     "bytes": 9204,
+     "sha256": "e36bf5d23b3dcaf96075b1b441ebf6424da62cb2d04ff14f04da4e9956711094"
+    },
+    "maps/rtex_brk/413rb.map": {
+     "bytes": 1682,
+     "sha256": "6be0d7cbae08ffccbb1ea9dedf03bc6f8c9b6be93c6c27d5e964e3b4f4538a52"
+    },
+    "maps/rtex_brk/413rc.bsp": {
+     "bytes": 10340,
+     "sha256": "4d57717cc2fb9db560e724df4937f7c496d77d1df6d70e6619ba686338152e79"
+    },
+    "maps/rtex_brk/413rc.map": {
+     "bytes": 1909,
+     "sha256": "71c9812cdf0647bb89fcd2a911a664b7a8dea382b0fe58e4e834a24354a23b38"
+    },
+    "maps/rtex_brk/413rd.bsp": {
+     "bytes": 13356,
+     "sha256": "573149ae9d1f687b0ddc0a702116357b4556e20ae8d62b7b32b3c5b41f227088"
+    },
+    "maps/rtex_brk/413rd.map": {
+     "bytes": 3217,
+     "sha256": "f40b142b102fefefdaf6594c2d1410f370fd8491a009ecfc6dada46c55f262d2"
+    },
+    "maps/rtex_brk/wood3_1a.bsp": {
+     "bytes": 7552,
+     "sha256": "8884a645d6193052aeba7043c139b3eb4cf8ace2e62ed6e9181d51f90cae4806"
+    },
+    "maps/rtex_brk/wood3_1a.map": {
+     "bytes": 1007,
+     "sha256": "5322a91b2aad8cf58095fb513e58317d738469c168b78f770307c3ece580fbf9"
+    },
+    "maps/rtex_brk/wood3_1b.bsp": {
+     "bytes": 7096,
+     "sha256": "9d7d44ba1c929fae0bf702ec834394c9da23c199cf742f9c7021bec00f33c056"
+    },
+    "maps/rtex_brk/wood3_1b.map": {
+     "bytes": 516,
+     "sha256": "158e6d102aaeb8dd7add01eecd7e05b4c711a20d7d7134d1bdce417fbe1b2072"
+    },
+    "maps/rtex_brk/wood3_1c.bsp": {
+     "bytes": 7144,
+     "sha256": "f292d3b9cabaa0332d7c3f6abd66420ad9ef80217f32223bd67315fa8967d908"
+    },
+    "maps/rtex_brk/wood3_1c.map": {
+     "bytes": 517,
+     "sha256": "f853df961fdcebd569943bad596dceb464c6317e44f3d77ce4def17295b37c00"
+    },
+    "maps/rtex_brk/wood3_1d.bsp": {
+     "bytes": 7804,
+     "sha256": "8e6ffa915db57d7cb958c7210e0abc35ff552713a5aa19a1ccb531a7d45bd504"
+    },
+    "maps/rtex_brk/wood3_1d.map": {
+     "bytes": 883,
+     "sha256": "d370c44a047023843caf08a41098bd3852526b614ae074c228cc6ad4e76d4aa9"
+    },
+    "maps/speedbz_brk/crate_r1.bsp": {
+     "bytes": 29110,
+     "sha256": "5dd3afab4a3ad5cf4466e272324e4afad5075ca2e662cc8b1932e277a2db73a2"
+    },
+    "maps/speedbz_brk/crate_r1.map": {
+     "bytes": 664,
+     "sha256": "ee7ce39ec0650d3cbde924b99efc91ba884778db11a961037d4493bf587fa33e"
+    },
+    "maps/speedbz_brk/door1.bsp": {
+     "bytes": 31200,
+     "sha256": "6df38f4db1bfd725dd7384b45e38d070fd4b514139a8e649aea3e640377a073d"
+    },
+    "maps/speedbz_brk/door1.map": {
+     "bytes": 1419,
+     "sha256": "17bf053113ed5cc14e99ef2880e5478ebace7d59de4797fc6cbfe3586d688494"
+    },
+    "maps/speedbz_brk/door2.bsp": {
+     "bytes": 29732,
+     "sha256": "8f58cd2f2e76fbb36a007ed7986671092b880d01dfcb9a087e93cd11240d2baf"
+    },
+    "maps/speedbz_brk/door2.map": {
+     "bytes": 726,
+     "sha256": "3fac703869c9ebb4eabfbe8f180fec752812eea0aa68c5f5574c5cf2496c3931"
+    },
+    "maps/speedbz_brk/door3.bsp": {
+     "bytes": 26516,
+     "sha256": "77f003456362f2b7ca424491485ad2d20b162598527765e5e78628ee7e6ad172"
+    },
+    "maps/speedbz_brk/door3.map": {
+     "bytes": 1247,
+     "sha256": "e56d45f63dcb0d86a0039ea443109d8c8d116fa18331a2328e90f74a891ab9d2"
+    },
+    "maps/speedbz_brk/door4.bsp": {
+     "bytes": 24020,
+     "sha256": "930881a45210317dd3550b04b20d2446cf92c8c613d4aa295a5c77810b77b3f2"
+    },
+    "maps/speedbz_brk/door4.map": {
+     "bytes": 611,
+     "sha256": "f4a68b8f4d081ff0febc276c51b5484c96e4b044eab6e20069ae84ac7c5a0ac2"
+    },
+    "maps/speedbz_brk/rock1.bsp": {
+     "bytes": 89984,
+     "sha256": "c87f60de56cfd5a932cf33d23d6e83b0fd16518001dd8fa7be84da9c3176b5b5"
+    },
+    "maps/speedbz_brk/rock1.map": {
+     "bytes": 980,
+     "sha256": "29e5bd54316e6f325d71a33051ee3a5b6c213f927222931bb35cdcc1820cc87a"
+    },
+    "maps/speedbz_brk/rock2.bsp": {
+     "bytes": 90012,
+     "sha256": "443e51be48da3594545d347ee056f3973b0360268eb6c03653d7b3af622c553e"
+    },
+    "maps/speedbz_brk/rock2.map": {
+     "bytes": 991,
+     "sha256": "40b6b9f23f788c08f362f2336048bbe1260f181d7e76de2591ea7aefa03f4b09"
+    },
+    "maps/speedbz_brk/spdcrate_r1.bsp": {
+     "bytes": 12844,
+     "sha256": "30fa3f373efefcf7db68a9acbb0eb282a0b2ea54d26db92eaaad444035462791"
+    },
+    "maps/speedbz_brk/spdcrate_r1.map": {
+     "bytes": 807,
+     "sha256": "c18735f305c2496a4801ed1a5bc1297f2d72e55824f7222a265ac5788552fc68"
+    },
+    "maps/speedbz_brk/speedbzvent1.bsp": {
+     "bytes": 15248,
+     "sha256": "bcfe36bf57cb82e5188b86af3e5bf568038ef5a50d0ebce43024155b7276008d"
+    },
+    "maps/speedbz_brk/speedbzvent1.map": {
+     "bytes": 2053,
+     "sha256": "7d447bc22e440e685648d8b39e051bce7c1b847e3f777ac092ab1104b79242a1"
+    },
+    "maps/speedbz_brk/speedbzvent2.bsp": {
+     "bytes": 14104,
+     "sha256": "8fb1e76688e27767ce77c5d7b3486048adfa284e011b91007730d424eb55ca61"
+    },
+    "maps/speedbz_brk/speedbzvent2.map": {
+     "bytes": 1381,
+     "sha256": "44cfc0509c9455865df334c1ca5bdfca49cf0fae4dab372cac99e6eeb76b438c"
+    }
+   },
    "sha256": "6ca3099935998e8678b388cd5bb1e1c601f1035da378141b6e800303b8737f02",
    "timestamp": "2021-10-31T23:13:20.000Z"
   },
   "pak2.pak": {
    "bytes": 13867395,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 94990,
+     "sha256": "e790b189b1df23f116097b45f5ed391fd210319ecfa000d029b367a7c3d32ab5"
+    },
+    "maps/bmodels/az_chain1.bsp": {
+     "bytes": 219668,
+     "sha256": "4d2648c6dd850b04d48e9631ad02756ecf78d85f56810ff7b9db131a6fe641a3"
+    },
+    "maps/bmodels/az_chain1.lit": {
+     "bytes": 33272,
+     "sha256": "1daab5bb58dbf2c73968dc9db26cf0b0bd78652d491788d0a6124aaa9a9b6f4a"
+    },
+    "maps/bmodels/az_chain1.map": {
+     "bytes": 96430,
+     "sha256": "2b6c77f844eaf5a371b36c13cf512a24d8cd39095cdc04eddd64cd571060d098"
+    },
+    "maps/bmodels/az_chain2.bsp": {
+     "bytes": 333820,
+     "sha256": "746e38bbb4cebb63ac3344e944f24b874b9fd3ed584017bb599e027508cc6187"
+    },
+    "maps/bmodels/az_chain2.lit": {
+     "bytes": 22130,
+     "sha256": "c6ebc72f8dcaa06422eaf71e08771f76105ddd39c3ee6784d40083df67d1cf32"
+    },
+    "maps/bmodels/az_chain2.map": {
+     "bytes": 148314,
+     "sha256": "e9cb3cddd08835aed7b1eed8867a67b06fee9db20dd7584830b8918d4af169ea"
+    },
+    "maps/bmodels/az_chain3.bsp": {
+     "bytes": 308800,
+     "sha256": "6b78b5a83f2f71a316e85086e12b7a1f66abaf28b02a53076433e3b2b3a20fee"
+    },
+    "maps/bmodels/az_chain3.lit": {
+     "bytes": 20684,
+     "sha256": "28870bf7c7f011206290fe69c7b6e2501c27fba21bea2ae6767e8d85a4ff56e7"
+    },
+    "maps/bmodels/az_chain3.map": {
+     "bytes": 110405,
+     "sha256": "64eee084713fdb7da2ec9f9dbc7c482930d9a871d86fd0912d32ddf52063b1aa"
+    },
+    "maps/bmodels/m_bchains1.bsp": {
+     "bytes": 74963,
+     "sha256": "73beb2dc0b953e096e69a4e049af380e99c98ce1872b4da00c858be36d4e973a"
+    },
+    "maps/bmodels/m_bchains1.map": {
+     "bytes": 43470,
+     "sha256": "ecd781a6601c6fca262909cb2e116a222de2e5aa5417dd36d4475d5c433459af"
+    },
+    "maps/bmodels/m_bchains2.bsp": {
+     "bytes": 83651,
+     "sha256": "e23fad6717790c08e661748398754e60944527eb6e48c0f2c0ffbdba73cf95db"
+    },
+    "maps/bmodels/m_bchains2.map": {
+     "bytes": 42484,
+     "sha256": "e92865750499de9117e5bf19719052109179ebcc37ddbd40f2d91d914b86fa63"
+    },
+    "maps/bmodels/m_bridge1.bsp": {
+     "bytes": 431144,
+     "sha256": "ac4d490408f7ad9068a09c4c89f82a65b8573bc4ba810fe5f16418b1d2684f66"
+    },
+    "maps/bmodels/m_bridge1.lit": {
+     "bytes": 47240,
+     "sha256": "30601eb0d533bbe0f72631b77630c3922a46f34b38687aa184b7776e48e63164"
+    },
+    "maps/bmodels/m_bridge1.map": {
+     "bytes": 120280,
+     "sha256": "3ddec67bb95d788b2fecb0e4c6d09781a6a27ba79d322a637f3a03e84a8f6ac7"
+    },
+    "maps/bmodels/m_bridge2.bsp": {
+     "bytes": 201392,
+     "sha256": "4fec9b73e50ba0608d2b5f2fd5c4957324c4cb609becf3be979aedf644281845"
+    },
+    "maps/bmodels/m_bridge2.lit": {
+     "bytes": 21902,
+     "sha256": "c1fa88042c3fde27bd608d3829c8c4a142e70617087970ec7535d48847ac435a"
+    },
+    "maps/bmodels/m_bridge2.map": {
+     "bytes": 52004,
+     "sha256": "58943dc439d4d4c8e65773c12e361c3336488a94f0a53a54c06366675517b850"
+    },
+    "maps/bmodels/m_bridge2b.bsp": {
+     "bytes": 201398,
+     "sha256": "096dcacf528d2784b79a4c0dd19c445102778f2a053fde3a2a43540a4a621c73"
+    },
+    "maps/bmodels/m_bridge2b.lit": {
+     "bytes": 21902,
+     "sha256": "1c7bdad93866cabb97e4565bf41d2b8a8d4c8237e11b0965fd05fc954b6c2c64"
+    },
+    "maps/bmodels/m_bridge2b.map": {
+     "bytes": 52268,
+     "sha256": "d361d0c3dcfec2ae5d109075bf437d013762328ee48b8fc25f779267d7b1bfb1"
+    },
+    "maps/bmodels/m_bridge3.bsp": {
+     "bytes": 309343,
+     "sha256": "12d2199af263464d48455c2e5cd7bf2abf2085841fbc7e027a4cc96b04eec2d8"
+    },
+    "maps/bmodels/m_bridge3.lit": {
+     "bytes": 46964,
+     "sha256": "b783061b14bb4caf3cf9df9a6b8be9ea1d2a367339fa09ffe01506022b21a4c5"
+    },
+    "maps/bmodels/m_bridge3.map": {
+     "bytes": 138104,
+     "sha256": "33c8835d256fd00e65da818c4d43b86033bb8104897712b824014a035c2628e0"
+    },
+    "maps/bmodels/m_chains1.bsp": {
+     "bytes": 249145,
+     "sha256": "1f51d881982d8602c0da29c1f105ab07a41977bdab4fbf4598922563373f4a98"
+    },
+    "maps/bmodels/m_chains1.map": {
+     "bytes": 170858,
+     "sha256": "e1855a52ab0ae70c382876eb74fcafe5a065fefeb2e49a6956184637b9edc1bd"
+    },
+    "maps/bmodels/m_chains2.bsp": {
+     "bytes": 134457,
+     "sha256": "57a765e0ec315eca93927ad64e11b9b3ec8adae0c405de55d86c30b30ef51e5a"
+    },
+    "maps/bmodels/m_chains2.lit": {
+     "bytes": 15698,
+     "sha256": "c858c4c47488df5cac3ed19736c1aee29f4c7add0dfb45deeb7416c4c7af1f21"
+    },
+    "maps/bmodels/m_chains2.map": {
+     "bytes": 60423,
+     "sha256": "575ae8d717a2352ac8726b3bc0f11f6e0a83f548dd471a544a62f519bb71f692"
+    },
+    "maps/bmodels/m_chains2l.bsp": {
+     "bytes": 156552,
+     "sha256": "ff04a994c83f27104d6ef126ef2d08ce894ebe0a812c49f0d2ae79ce8808e8b9"
+    },
+    "maps/bmodels/m_chains2l.lit": {
+     "bytes": 15698,
+     "sha256": "9ebbd1a675e167d9a3be233cd65654728f2f1e0259dee00f55e3da02802abfa2"
+    },
+    "maps/bmodels/m_chains2l.map": {
+     "bytes": 61112,
+     "sha256": "346320204a3413bd6654018e37e42c442c21d88e15da513395c73e6daee26bed"
+    },
+    "maps/bmodels/m_chains2p.bsp": {
+     "bytes": 156555,
+     "sha256": "f0778b1608dbb058f1f492848ae3b64f66be0fef54e32bddfd6fe09f7b0e7a74"
+    },
+    "maps/bmodels/m_chains2p.lit": {
+     "bytes": 15704,
+     "sha256": "d2e7187908b4d3823091a9d69cce5ac807507372132b4162e48a6b027ecad53a"
+    },
+    "maps/bmodels/m_chains2p.map": {
+     "bytes": 61117,
+     "sha256": "7d1acdf4240cd91b158bbc23dfab846388efa7d20431f5a9c8dba8ab421102ff"
+    },
+    "maps/bmodels/m_chains2r.bsp": {
+     "bytes": 222620,
+     "sha256": "0e1ad04fd73c4bc183331471a3406665660fd8f030d14404b7c43b31309118e0"
+    },
+    "maps/bmodels/m_chains2r.lit": {
+     "bytes": 17552,
+     "sha256": "605d297ff2ece6796c064e3dd47e1c48e4fdc87324f059f2c1721e369de23a97"
+    },
+    "maps/bmodels/m_chains2r.map": {
+     "bytes": 61788,
+     "sha256": "749cc23346335d05a53b3399f49adb157fe29fe24512a65d3ab976bc811b5818"
+    },
+    "maps/bmodels/m_chains2rl.bsp": {
+     "bytes": 151968,
+     "sha256": "653185afe2384bf68c0e6d35bdd3404196404243a1b8d16cb730de9f7a45b4b0"
+    },
+    "maps/bmodels/m_chains2rl.lit": {
+     "bytes": 17552,
+     "sha256": "ef313b8c77329539ca8bbe6831e7d5b372e4e3f3cc807e6b66901b53f83d82d4"
+    },
+    "maps/bmodels/m_chains2rl.map": {
+     "bytes": 62332,
+     "sha256": "f5961359ef0867c6ecd501231f63912bf4066bb4d65685021efcd0d51d637f95"
+    },
+    "maps/bmodels/m_chains3.bsp": {
+     "bytes": 121996,
+     "sha256": "535075d6549167b5bf61ae91abf2c407ee009e64aa4222be35692478151feab1"
+    },
+    "maps/bmodels/m_chains3.map": {
+     "bytes": 57540,
+     "sha256": "08f7d97d9e8cd45c353d1141905c93d3327d8f77984790d9e952bd91a5247803"
+    },
+    "maps/bmodels/m_chains4.bsp": {
+     "bytes": 203735,
+     "sha256": "2840e2b604d571081a2b13ba2d340f596123b53213aaec8cd695e7a4d668e774"
+    },
+    "maps/bmodels/m_chains4.map": {
+     "bytes": 113061,
+     "sha256": "6727d20079382f7f2a76391d72e6b6bc3136cc6396ef4661b679f5c8f82d8427"
+    },
+    "maps/bmodels/m_chains4p.bsp": {
+     "bytes": 205127,
+     "sha256": "20183038acde1a46c9fae81e86837f876dc6e0bb7cc7a556457d4162264d7358"
+    },
+    "maps/bmodels/m_chains4p.lit": {
+     "bytes": 35897,
+     "sha256": "0dfb9177bd73b903703f0f4630c4941467a452ee676d568e7f32b2099699659d"
+    },
+    "maps/bmodels/m_chains4p.map": {
+     "bytes": 112283,
+     "sha256": "09d773ef730e9b4d81cdf23f4ac3b0efcb365771569638e7f5574407c5560146"
+    },
+    "maps/bmodels/m_chains5.bsp": {
+     "bytes": 94806,
+     "sha256": "04c40fce5016a3d26092812be589344740b29be788921f8ce354461d77943817"
+    },
+    "maps/bmodels/m_chains5.map": {
+     "bytes": 44835,
+     "sha256": "1e897fc203a12a480c1d3dfc13bf7653a06edb8132f98a3fedae50614c3ebb34"
+    },
+    "maps/bmodels/m_chains5l.bsp": {
+     "bytes": 117061,
+     "sha256": "f01c9c1e6f87c0588be0df3f8768f563acea6735451efa41366aa0acb63851db"
+    },
+    "maps/bmodels/m_chains5l.map": {
+     "bytes": 45411,
+     "sha256": "64691e385435777a920358775cb18e7ac6ee5290a34488103753a338500b6db5"
+    },
+    "maps/bmodels/m_chains5p.bsp": {
+     "bytes": 117214,
+     "sha256": "555df3c945155f7b820fde49c3e37d114f3c52bb63c4edb647dbc19161cb13d5"
+    },
+    "maps/bmodels/m_chains5p.lit": {
+     "bytes": 9152,
+     "sha256": "f78aaec615854b6382b6802298f42ac42dcdfdfb9c638b417257876fa83200d9"
+    },
+    "maps/bmodels/m_chains5p.map": {
+     "bytes": 45566,
+     "sha256": "1969841b81be135b7cb383f84bf7d38694d012b35b17ef3e2c630afbf5d6e64d"
+    },
+    "maps/bmodels/m_thanshelf.bsp": {
+     "bytes": 140335,
+     "sha256": "8319f2ba87d5a8ed864941fe9c7341744476be658ce211aaafc1ba0747afeac4"
+    },
+    "maps/bmodels/m_thanshelf.lit": {
+     "bytes": 3134,
+     "sha256": "04fd93ccf6b864bd9226faa29db923bc093200ed3f4fc8a8f6cce29b324a9743"
+    },
+    "maps/bmodels/m_thanshelf.map": {
+     "bytes": 10306,
+     "sha256": "811e75bc34627545ff7513dc658e937195b98b7839bad409bf21da4975fb7e03"
+    },
+    "maps/bmodels/misc_radar.map": {
+     "bytes": 5314,
+     "sha256": "7ca088f70d4421b994f1852dd17de1427a2b6401b19d8f464ecf2024f5025418"
+    },
+    "maps/bmodels/sep_chain2.bsp": {
+     "bytes": 130276,
+     "sha256": "eff6d1868abd6355f4858f41657262ebb87fa9093579eb8abe8ac6f8c8880ee6"
+    },
+    "maps/bmodels/sep_chain2.lit": {
+     "bytes": 15716,
+     "sha256": "311947b14d5363ccc34fd6e32205100b612c8a77c66196dc616192b011375b59"
+    },
+    "maps/bmodels/sep_chain2.map": {
+     "bytes": 80569,
+     "sha256": "7d86dc46adc6a01b96b811021484c1e6cbfb61424f1037be59525d6f1ff2c420"
+    },
+    "maps/bmodels/sep_chain3.bsp": {
+     "bytes": 80956,
+     "sha256": "8a811a3fc8f85373d64fb3840bda3a3af63a138498bc051ddb2b0d1e0cfa9e88"
+    },
+    "maps/bmodels/sep_chain3.lit": {
+     "bytes": 10802,
+     "sha256": "50d0f90c43a132a5cb360cbb25521040632f07726c6ccfb482d3740ec940ad05"
+    },
+    "maps/bmodels/sep_chain3.map": {
+     "bytes": 41124,
+     "sha256": "ef40d6b17d8b9fc880e4a8180336554f37dabfbc8a30b78c485793aaa5dd753b"
+    },
+    "my_progs/ai_ammoresist.qc": {
+     "bytes": 7444,
+     "sha256": "d530fec92f23ed0c3d09560abb9a89bdc160ce1aefdfbe4f4771f9897ae3fc4d"
+    },
+    "my_progs/ai_checkattack.qc": {
+     "bytes": 106456,
+     "sha256": "7971ca5a87666c89b56ab0fcc102e6f551f3cd3b03bdfc0bfb73f5f8d5aed7fb"
+    },
+    "my_progs/ai_combat.qc": {
+     "bytes": 24324,
+     "sha256": "30c07395259db46836e544a68a37527f107e9010e4d64e937476ceafa58c82b8"
+    },
+    "my_progs/ai_enemytarget.qc": {
+     "bytes": 8409,
+     "sha256": "f4b0a35306d50e71fd9043ae949a421158ee9fcc4e311baf7b8fa2d345c4d46e"
+    },
+    "my_progs/ai_explosion.qc": {
+     "bytes": 12162,
+     "sha256": "7df941a7cf93b814ae9d90f646a5b0243a51db67872f621df73d43c6000ba3ab"
+    },
+    "my_progs/ai_gibs.qc": {
+     "bytes": 32373,
+     "sha256": "65e202300882ba8f0c980f65820b2d2e0bd06846073168f4bd7e37f2357f47d4"
+    },
+    "my_progs/ai_hazards.qc": {
+     "bytes": 26832,
+     "sha256": "81aace80121408f64369bc2bbfd5654650276ddd75217333d2a52364415acaa5"
+    },
+    "my_progs/ai_minions.qc": {
+     "bytes": 10236,
+     "sha256": "3e7bd34dfe0e73a11e6907d5ac69cb609eee19dff533689ea7c8eabe52500136"
+    },
+    "my_progs/ai_passive.qc": {
+     "bytes": 8224,
+     "sha256": "44473544d0da0dc778c2800a16172ab49b548286b604c9d6361f4bc4cfc1f076"
+    },
+    "my_progs/ai_pathcorner.qc": {
+     "bytes": 20921,
+     "sha256": "b3d6ed2434e0b995da51a71715647096e36e02d8cf920e18e024f920ed69238a"
+    },
+    "my_progs/ai_projectiles.qc": {
+     "bytes": 86253,
+     "sha256": "d0885ed945602af45d7db1d98be5938412cd750154ed06710b6b781b6c49abc3"
+    },
+    "my_progs/ai_states.qc": {
+     "bytes": 7480,
+     "sha256": "76fae861132b0e50006ef88ea94a953e718b661defad2ea58a4ecad5cab92dee"
+    },
+    "my_progs/ai_subs.qc": {
+     "bytes": 51485,
+     "sha256": "41a23217543056b1ea447fcf2e0dc2c06a87bdf70dc3f6f699454d7c3c900377"
+    },
+    "my_progs/ai_tether.qc": {
+     "bytes": 6470,
+     "sha256": "2229c0ea1b76e45f5707a3eca9e7626e33f8ea91d6b292da63c81723e1ae8521"
+    },
+    "my_progs/breakable.qc": {
+     "bytes": 79687,
+     "sha256": "754831599eec85a774501d9fd0a1ec7d5722ea6a6e01655b5ad74988145045af"
+    },
+    "my_progs/chaosmode.qc": {
+     "bytes": 81481,
+     "sha256": "01561dc4f1949716eba4d08f83efe27b71add80f923c1e2d89194c238772a646"
+    },
+    "my_progs/client.qc": {
+     "bytes": 70441,
+     "sha256": "00e2d4aff96ea28b0532ab0b03de0a8cdcf15750164ec82bdc8f43b9f2347447"
+    },
+    "my_progs/client_advinfo.qc": {
+     "bytes": 59677,
+     "sha256": "87aaca8bfd15935e1cd29a807bf77a2779d95418af631a6b456c6605710694fe"
+    },
+    "my_progs/client_camera.qc": {
+     "bytes": 13007,
+     "sha256": "ff4748b04c15d9a3b44dd8069f9347c12487ef353d5401a13542166576097889"
+    },
+    "my_progs/client_cshift.qc": {
+     "bytes": 725,
+     "sha256": "da1e321fe01bae486ffcdd987a942a4b0d5b2f603efb663d52c55e882f129685"
+    },
+    "my_progs/client_debuff.qc": {
+     "bytes": 15761,
+     "sha256": "0e0c9123697241ab3a366dbc46fcb90b8553b65c94cffe1442254a74a2753efd"
+    },
+    "my_progs/client_evilmode.qc": {
+     "bytes": 6982,
+     "sha256": "2cfa3bbeb36ab623c3bb137028ec5f549a2e5d2198fa2ab7fd8a445e14f4fc10"
+    },
+    "my_progs/client_ghook.qc": {
+     "bytes": 51884,
+     "sha256": "43d071195a70caa66b57cca1778679d772478fd1f71cbad7ee267e254e79a29a"
+    },
+    "my_progs/client_info.qc": {
+     "bytes": 13693,
+     "sha256": "55653ddc2b9f3cf2ca3cf1b0afdc4c1685baf1ab3c3830eb9f8b1b2d51b3ff31"
+    },
+    "my_progs/client_mapvar.qc": {
+     "bytes": 13177,
+     "sha256": "c692fa41644e6d21c945493dd891af945a072a4b39e687d1b59c86d14ee804a0"
+    },
+    "my_progs/client_power.qc": {
+     "bytes": 20157,
+     "sha256": "0309073577003ae832b259ede75ba53c49bd89985b08d98000d03e1a44893705"
+    },
+    "my_progs/csqc_defs.qc": {
+     "bytes": 21072,
+     "sha256": "eddc5f194845e78a1633807d32b1da4425bdbe7bcce193e3868bc3995e2dee9b"
+    },
+    "my_progs/csqc_defsclient.qc": {
+     "bytes": 35002,
+     "sha256": "b6674acae135dfbc5e3dbb147e69acdc6b3564b766792359bed3e4eb800705e9"
+    },
+    "my_progs/csqc_hudad.qc": {
+     "bytes": 104391,
+     "sha256": "1ca012e489dc5f6026bdae469f411b5bb25afa00e00d5169cbd35b578a7ad9f2"
+    },
+    "my_progs/csqc_hudvanilla.qc": {
+     "bytes": 37074,
+     "sha256": "c5caa6ba176185c05903d383f3ae41907129d859419a0c0bf909b0e8d3e8af5a"
+    },
+    "my_progs/csqc_progs.src": {
+     "bytes": 113,
+     "sha256": "e383fc0920e9676d92e0be81d69cd8017ed5baf9fc0616a05773de68208ce434"
+    },
+    "my_progs/defs.qc": {
+     "bytes": 31974,
+     "sha256": "1534874cf4d70c5614dedecb70f6d428fc32832ce3345c2cb51fd6058a514902"
+    },
+    "my_progs/defsclass.qc": {
+     "bytes": 24401,
+     "sha256": "811c390be7b31fd4b276410ef1a75406bbca8fb84dc195484835a6100e9cddb4"
+    },
+    "my_progs/defscustom.qc": {
+     "bytes": 95932,
+     "sha256": "c8e66698b225cac3821bf4b098e7c8b16d0babaf7f5c1a5a32006c0c1dd96eee"
+    },
+    "my_progs/dpextensions.qc": {
+     "bytes": 122912,
+     "sha256": "3758f58ebaa4186e9112da89f7ea53087eef5058a32ebc373a1ffda76c1d67a2"
+    },
+    "my_progs/estate.qc": {
+     "bytes": 7745,
+     "sha256": "9cceb71ae54b331c2702f5580094f9055d007b9e710dd5e61c7c632724022626"
+    },
+    "my_progs/fteextensions.qc": {
+     "bytes": 215531,
+     "sha256": "beb86ad10bb0726de10dd2557d6285f7bf40f08f9d30e06315c3772f8c256571"
+    },
+    "my_progs/func.qc": {
+     "bytes": 47039,
+     "sha256": "3102c5ce52ec7a15c329079fc7ca97fa249dca32c4124bad49c2853d38e5c741"
+    },
+    "my_progs/func_buttons.qc": {
+     "bytes": 13271,
+     "sha256": "9e1bd197b2367ab2b8f1c776c214a0c51120559e8d8f0b4888b262b7a1e746f0"
+    },
+    "my_progs/func_doors.qc": {
+     "bytes": 35874,
+     "sha256": "58dbdf05f0044aefdd13ee21d17045a681d255efaca6d129fbd1cec4ae516fc9"
+    },
+    "my_progs/func_doorsecret.qc": {
+     "bytes": 14379,
+     "sha256": "769a3142ccaf18060ff77b0eab57d901585202fbfe63a54ce25d4987b80f92d3"
+    },
+    "my_progs/func_insvolume.qc": {
+     "bytes": 10573,
+     "sha256": "1deaf4623a6fae80585d2d2b1978b1cd217b6f8a683ef3bbc3a77a2897e9a207"
+    },
+    "my_progs/func_plats.qc": {
+     "bytes": 11685,
+     "sha256": "5086c9aba8bbf83d29c3e1897c7867cb24220712007044792928f474216b7ea4"
+    },
+    "my_progs/func_pswitch.qc": {
+     "bytes": 8373,
+     "sha256": "b3a205176d80801216a930241508b3c5718f4be9e1b947932ace2851c34271d8"
+    },
+    "my_progs/func_trains.qc": {
+     "bytes": 26553,
+     "sha256": "81d8de4f3dff80b8523584fb5e37d8d4812a6f7f95a559edff320682217ad123"
+    },
+    "my_progs/globalfog.qc": {
+     "bytes": 18397,
+     "sha256": "84ec244a475ac41b9da772042123f58f4005130590f170f85f1b23ad53629f27"
+    },
+    "my_progs/hiprot.qc": {
+     "bytes": 31978,
+     "sha256": "82875db9fecd8bacd2c42232fb980e6a510a6863103273e2c9078dfe7c6759c5"
+    },
+    "my_progs/hipspawn.qc": {
+     "bytes": 2752,
+     "sha256": "6df8450b85821c1a76f5ccb3c807ac9b94e92f413f16f2ba618f922abf85148f"
+    },
+    "my_progs/items.qc": {
+     "bytes": 165150,
+     "sha256": "fbcc57975032c97ffea723870e39ebc2d2c4bbd9650fb5d20b3dfcecc6f6f93a"
+    },
+    "my_progs/items_progspn.qc": {
+     "bytes": 20628,
+     "sha256": "2f4824cb28192145a8fabc2da6575db3398e8f81522ab1e026d696ec87313650"
+    },
+    "my_progs/lights.qc": {
+     "bytes": 43912,
+     "sha256": "d0e0c373bb3cc68c7c9121a62c68085ff9cc290daa6faf0adab02323d8ef92bb"
+    },
+    "my_progs/mathlib.qc": {
+     "bytes": 22355,
+     "sha256": "b161ebb89a11f302427c4f124731ec38def8eb01347beb5d748a9ba4afb886f8"
+    },
+    "my_progs/misc.qc": {
+     "bytes": 85890,
+     "sha256": "6b3e8a0882d47f16ff7f54fb37a48e3a7853647f8895718e6428739c4207099a"
+    },
+    "my_progs/misc_camera.qc": {
+     "bytes": 43852,
+     "sha256": "61448a8f0354f39dd26371ae56dadbc903b08282293145a27088ac6c151ea547"
+    },
+    "my_progs/misc_model.qc": {
+     "bytes": 32157,
+     "sha256": "9afc9d440672288ffada6256a20aa0f969464907e942fab0c1556cdb28162237"
+    },
+    "my_progs/misc_targetdummy.qc": {
+     "bytes": 15123,
+     "sha256": "bcd0a0ae806ce20a8c8cfcc27178ce1b4ead3a546d927b6a261ce51a6086c253"
+    },
+    "my_progs/misc_textbook.qc": {
+     "bytes": 26321,
+     "sha256": "14bf42536a5cc75990d938a79d7bd21bde1c166245d94d8e662f9e6fd66e0ae8"
+    },
+    "my_progs/mon_baron.qc": {
+     "bytes": 31318,
+     "sha256": "b76a10da34dabf3411ddf650abcdbc77e3ebcdfebace6191a39e7c0b13a0fad5"
+    },
+    "my_progs/mon_boil.qc": {
+     "bytes": 19821,
+     "sha256": "050b21bda5341a3f81dcb21e6d7d82d458a415fd8f1cfa12435228246229a323"
+    },
+    "my_progs/mon_bossboglord.qc": {
+     "bytes": 24005,
+     "sha256": "e67081b7a5218b361c62bf4b201a18db16f3e75716ad2729c11a0616b137975a"
+    },
+    "my_progs/mon_bosseidolon.qc": {
+     "bytes": 40134,
+     "sha256": "c51eb9b9d67cadfa7178891a238329a60ad57edc3f6ef645060695b451833115"
+    },
+    "my_progs/mon_bossfiretop.qc": {
+     "bytes": 14734,
+     "sha256": "26672c9c2d1577f8caf9894b8eb5eecacac89f64251257bc25db48b1bf43a7bb"
+    },
+    "my_progs/mon_bossicegolem.qc": {
+     "bytes": 47205,
+     "sha256": "5b888302a6af24ce823919d1349c1c92e1ee709d72e79042425349368a4d65fb"
+    },
+    "my_progs/mon_bossidchthon.qc": {
+     "bytes": 20247,
+     "sha256": "65d955fb1434f806962fadc088aa5933e96ed8aa9f1211d0709a3f462ffa3027"
+    },
+    "my_progs/mon_bossidshub.qc": {
+     "bytes": 14639,
+     "sha256": "fdd0e8f8fa374ea0164f79ef1bf74ca942f04c63159f360c7a43011673774fe6"
+    },
+    "my_progs/mon_bossjudicator.qc": {
+     "bytes": 81432,
+     "sha256": "f5092f376eeef22f0a552c846f50175680c15a5c37d9603c6e3d2635661127b3"
+    },
+    "my_progs/mon_bossmammoth.qc": {
+     "bytes": 84963,
+     "sha256": "6cda415b846b2aeb215c0eebc7cdfa6a5560255df9aa014f77b48aa7073b8d34"
+    },
+    "my_progs/mon_bossnour.qc": {
+     "bytes": 45682,
+     "sha256": "d3aa7e0c62e9001887b1b0895607b512f6d9aeeb44bca544f6c900c86adbc03c"
+    },
+    "my_progs/mon_bossxxchthon.qc": {
+     "bytes": 22614,
+     "sha256": "2c1c0446b0f6a5b7a7921e8f8830c71c174d30c6f176d228a94afd9a05fdc25a"
+    },
+    "my_progs/mon_bossxxshub.qc": {
+     "bytes": 19006,
+     "sha256": "043ebc852ba7f0a06812cb0afd72d32a3da643df1dea45c87fb821f60fbcc332"
+    },
+    "my_progs/mon_centurion.qc": {
+     "bytes": 13734,
+     "sha256": "641e1c09c6df27b033e331140d242f25d27bf7f9bb83733a6b5b3469a5c7ffee"
+    },
+    "my_progs/mon_dcrossbow.qc": {
+     "bytes": 38069,
+     "sha256": "3296618a4b803fb6f1b44c1d32c17692a5bed13cf63102c6dcc58481223197a8"
+    },
+    "my_progs/mon_deflector.qc": {
+     "bytes": 32107,
+     "sha256": "d7a9344878a3a846a7e720ce704820d424362281a1675c40be7b670eca9fe342"
+    },
+    "my_progs/mon_demon.qc": {
+     "bytes": 14601,
+     "sha256": "d77f128e3f91737228c5a24b7ca146f6b4f8e87dbaac31b1ad4e79779884d0d7"
+    },
+    "my_progs/mon_dfury.qc": {
+     "bytes": 39867,
+     "sha256": "a016db202f2a418aee50cb7cce2155a24a6b807e8c98fc49a5f9273ce79c6da8"
+    },
+    "my_progs/mon_dguard.qc": {
+     "bytes": 28414,
+     "sha256": "0a2b964034559f4ca772f9f29be2c56684fd39290277046a6f7642ba934836eb"
+    },
+    "my_progs/mon_dguardquoth.qc": {
+     "bytes": 18932,
+     "sha256": "4caeb17520104cba42476ff7757f38ba6d72e941674b851f55a5c9780ce4de17"
+    },
+    "my_progs/mon_dknight.qc": {
+     "bytes": 36867,
+     "sha256": "68008427374e9ab670b6ad915c7a0f8eaf6a6699efa927a3748ae6cde86458e6"
+    },
+    "my_progs/mon_dlord.qc": {
+     "bytes": 22859,
+     "sha256": "09ca1edd4e65a166a66ba17e682aae9a1be09b05371a72dd1bc447389693bfa5"
+    },
+    "my_progs/mon_dog.qc": {
+     "bytes": 18431,
+     "sha256": "1b345447176aec54f18c31f5da215e80cb2de19f51d353c63a98507d881c2a9b"
+    },
+    "my_progs/mon_dprince.qc": {
+     "bytes": 33590,
+     "sha256": "5114caa7b6152e562e548096e41da68f43c910a5016ddaed408272a97a8320c1"
+    },
+    "my_progs/mon_drole.qc": {
+     "bytes": 25472,
+     "sha256": "36a510e910ce4ffa26d2d2ad336872c07537077ea920132a4cfd63d9133fb6af"
+    },
+    "my_progs/mon_dsergeant.qc": {
+     "bytes": 33493,
+     "sha256": "ada0cc4359a863c4e8d433c605a1c04ec6f7fd17ec852f5c4847443d3adaff1d"
+    },
+    "my_progs/mon_eel.qc": {
+     "bytes": 8252,
+     "sha256": "15c1f2fedba7077d352595e1be4a90f764354e4cf1875b40e1685d3ce81feb54"
+    },
+    "my_progs/mon_enforcer.qc": {
+     "bytes": 20146,
+     "sha256": "d453651d488afa789d0cea87ce99d9684329bbabdd17aa1625591f5a4b4ac90b"
+    },
+    "my_progs/mon_fish.qc": {
+     "bytes": 9705,
+     "sha256": "ff7d84db2c7917861ff5d81fe0e28f69d51143d27c4fba90dfcda11057222df0"
+    },
+    "my_progs/mon_floyd.qc": {
+     "bytes": 20332,
+     "sha256": "3ac2f0b0be94e311ff2fc4eee9cf66d5987af0e5c25fc06b8cc7b9efa6f581df"
+    },
+    "my_progs/mon_freddie.qc": {
+     "bytes": 25384,
+     "sha256": "4409a33e819f125852d0a4ada21a8fed2713012daec00922446f313031c845d1"
+    },
+    "my_progs/mon_gargoyle.qc": {
+     "bytes": 24293,
+     "sha256": "9e1f78b2364024efa6ec4142c1ecf4aff52cdf32f38031c34cf19e9cd74143d6"
+    },
+    "my_progs/mon_gaunt.qc": {
+     "bytes": 24111,
+     "sha256": "45be98ae0bdd32e0884280e18f867af037f2fcbf515914827c5f9107a87e52d7"
+    },
+    "my_progs/mon_golem.qc": {
+     "bytes": 35297,
+     "sha256": "dbaf3d1c0fec3166b0eb064a3c027dd3a0c907bed72b8e4581ffd74dad5ab5d1"
+    },
+    "my_progs/mon_hknight.qc": {
+     "bytes": 37618,
+     "sha256": "bac7d4b7832b95cea0f6890de66fbd0f7c4fcc7ce9051ef16ac042de465ddcb3"
+    },
+    "my_progs/mon_hogre.qc": {
+     "bytes": 24021,
+     "sha256": "8781ea9aaaa1d0f7ffb1fd8ec8b5981187eee6fdb8193160a1eb38770dffcfe0"
+    },
+    "my_progs/mon_hogreham.qc": {
+     "bytes": 23076,
+     "sha256": "b2ab6b830ce3aae7d6b033e8455de5011ded82e451ca171ea09940d9a3ec7740"
+    },
+    "my_progs/mon_hogremac.qc": {
+     "bytes": 23941,
+     "sha256": "9111c040ab1e5487936cce6ef1170e408c6d297d582702d202bbd27b0919d843"
+    },
+    "my_progs/mon_invsword.qc": {
+     "bytes": 9214,
+     "sha256": "f7287867cc6043eb7cd3fa3e1ecd5ae7115a84e5ef7021b2d5129afdb6ba6f46"
+    },
+    "my_progs/mon_jim.qc": {
+     "bytes": 22091,
+     "sha256": "55353984ad822dfd8c32f3b8ad9a06e8bfaab7bc5ff6f2a2326674ad4acd26be"
+    },
+    "my_progs/mon_knight.qc": {
+     "bytes": 24772,
+     "sha256": "d254abf88162436b9db48885ae8e59315c24c1e7f72a91d027a1d69fe9baf5b7"
+    },
+    "my_progs/mon_lostsoul.qc": {
+     "bytes": 23261,
+     "sha256": "2cdbf656c6b34164711fa88016542f4e3d2bd0555417ad00bab5ca7039f212ef"
+    },
+    "my_progs/mon_minotaur.qc": {
+     "bytes": 35316,
+     "sha256": "fbcef276ee3e2f1eeea8483303538190875e959b43efbf4f703be10fc72fc564"
+    },
+    "my_progs/mon_ogre.qc": {
+     "bytes": 24123,
+     "sha256": "d287d3b9024025237dbc68380f486572828a5114f9543599ba86b8bc35e9e25e"
+    },
+    "my_progs/mon_ogrextra.qc": {
+     "bytes": 9387,
+     "sha256": "41a9243c6006326195197a4dfba6ea4c1f1fbd729ec10adc48cfd7badd7a18de"
+    },
+    "my_progs/mon_pyro.qc": {
+     "bytes": 18235,
+     "sha256": "bd35f02c63af315ddf4820e388d0248cf065f1170bd7306957a1e86fa7e47306"
+    },
+    "my_progs/mon_scorpion.qc": {
+     "bytes": 22136,
+     "sha256": "0432d7c5e1b6a30a5452aba12b9fb6a3c2c7f3c582b1392d420414e66b8fb257"
+    },
+    "my_progs/mon_seeker.qc": {
+     "bytes": 29703,
+     "sha256": "d33939357840eedbfc63c56d6415d8fefd21de2c477b24b3165cdadcca2acd2c"
+    },
+    "my_progs/mon_sentinel.qc": {
+     "bytes": 10217,
+     "sha256": "946232c7169bf3fa966ce875523dd45402772f8045c51a96dced04f2f5f5788f"
+    },
+    "my_progs/mon_shalrath.qc": {
+     "bytes": 16434,
+     "sha256": "1b6fdf2447d7fa281d126118a9bc0e097de7b4dd4d10a33e60d5cf0ca785c58b"
+    },
+    "my_progs/mon_shambler.qc": {
+     "bytes": 23050,
+     "sha256": "576f71a38d75eedbdf58c291055674be8da5f0d04540e26311d65f70b58ee842"
+    },
+    "my_progs/mon_skullwiz.qc": {
+     "bytes": 36245,
+     "sha256": "6d3c2242bffe6eabe3f9cc59e881cb2296213cfbff809e1be045a80ca46aac53"
+    },
+    "my_progs/mon_soldier.qc": {
+     "bytes": 21645,
+     "sha256": "704c534062b11c4fc16416154c7706c125221660cdd4d9b02e00575b94c04103"
+    },
+    "my_progs/mon_spider.qc": {
+     "bytes": 30593,
+     "sha256": "4d0bbb7e38e51cef07912e6071e6bb9739e019a2d93129d38dbab9492bf43aee"
+    },
+    "my_progs/mon_steelclaw.qc": {
+     "bytes": 17126,
+     "sha256": "78dd4bb46dd76b2ff1f7d4a9f0b0902f25d94ebe13ace6b997a7f604c3718700"
+    },
+    "my_progs/mon_swampling.qc": {
+     "bytes": 25637,
+     "sha256": "fb5ed328cd3d5c09704bb84f39138463a7d26b8b1d45771e55e9ae952b1d2470"
+    },
+    "my_progs/mon_sweeper.qc": {
+     "bytes": 27025,
+     "sha256": "8f7a1d077779d88d542a325c1ae4ba4ff59d48bfcb334150ae3f024525bb725e"
+    },
+    "my_progs/mon_tarbaby.qc": {
+     "bytes": 11866,
+     "sha256": "88c9481ab7fe0cbe97d2b836492ff51b368aeae8d4ff3e5852734bb9f63a1b2d"
+    },
+    "my_progs/mon_turretbal.qc": {
+     "bytes": 38519,
+     "sha256": "fdcf915248dda5fb6a744d284233d46a2e6d62c8e4fd02fdd5bafe4f46167d30"
+    },
+    "my_progs/mon_voreling.qc": {
+     "bytes": 27678,
+     "sha256": "7734614fa6b2da2195bf3804415c06a2d10f35825e86abf4f85613a182cf21c2"
+    },
+    "my_progs/mon_wizard.qc": {
+     "bytes": 15155,
+     "sha256": "3101ca37b57343697b3d3c7637fdc84c842f78ec9081e401dcaa6df0a9b1df83"
+    },
+    "my_progs/mon_wraith.qc": {
+     "bytes": 35464,
+     "sha256": "6a28a205cb8ac574e98c8d34a01ea859922e38d55c66346a7aa867ebf84bdb5b"
+    },
+    "my_progs/mon_xmas_elf.qc": {
+     "bytes": 17589,
+     "sha256": "053eec412485090ee1ebeac25887382db40e2ba7ca456050ba4407be3ec8bc1a"
+    },
+    "my_progs/mon_xmas_raindeer.qc": {
+     "bytes": 12189,
+     "sha256": "abbe1dd5c96c25b631231d4db2f17e8243075ad08c082e0448b7cbff34f1ae0c"
+    },
+    "my_progs/mon_xmas_santa.qc": {
+     "bytes": 17853,
+     "sha256": "cc60c6de17bc3321f9b1cf75b3229e387592c9eb7fc4bb57c1de0a8d2c0e62e6"
+    },
+    "my_progs/mon_xmas_snowman.qc": {
+     "bytes": 11486,
+     "sha256": "65928bb70cb2e9352c2f5e036eda2a6bd97aea09d459d0af563a82aa5a2f2673"
+    },
+    "my_progs/mon_zombie.qc": {
+     "bytes": 33988,
+     "sha256": "83f56482374c3a79fcc64058989bd210af3add006b7388d89c92e90543ec56a0"
+    },
+    "my_progs/mon_zombiek.qc": {
+     "bytes": 42214,
+     "sha256": "2b9926454484e93f5c053bf4fd35b2a97cf7e835c26c3b30061f1ff391af9f5e"
+    },
+    "my_progs/monsters.qc": {
+     "bytes": 56573,
+     "sha256": "c2c75832e6d5e83e929214ba5c1aa9a4661bcaf7754c20b3e9648171bf804a58"
+    },
+    "my_progs/part_emitter.qc": {
+     "bytes": 82744,
+     "sha256": "fca7491171d58974ef6b15550b9a7f0474641e9eac7ee5de52c6980c96445518"
+    },
+    "my_progs/part_generate.qc": {
+     "bytes": 42914,
+     "sha256": "83b9718a85418143d92ea8311cc8cce69c1002eb7563710dfe7010ac52e15d50"
+    },
+    "my_progs/part_manage.qc": {
+     "bytes": 27407,
+     "sha256": "86eb791f4bba08fc0c965e9f81c90e7412ed2c910104d66a56cce1f3152808fe"
+    },
+    "my_progs/player.qc": {
+     "bytes": 27811,
+     "sha256": "1f0cc3eaf577c2af642495466c573cd6e226a4754902d9de9cbfc9c9ba28af0f"
+    },
+    "my_progs/progs.src": {
+     "bytes": 2482,
+     "sha256": "c773f107c562f731fbb30158422226bdc4576dd32aea0f02c122195e08eac96f"
+    },
+    "my_progs/pushable.qc": {
+     "bytes": 19823,
+     "sha256": "03b3bf9240db6e9532e45a3efc159129709f9ce095c3238daae32daddd5b07ec"
+    },
+    "my_progs/qc_highlight.xml": {
+     "bytes": 6348,
+     "sha256": "a7b326723cc1e4025e867ea5da00f54c944705600d740538aeb52f63cd027ab5"
+    },
+    "my_progs/settings.qc": {
+     "bytes": 62244,
+     "sha256": "78d9b19077028f9fd72f271aaae3d75b43e995ef95b7679df83a06fcdfbaf4f5"
+    },
+    "my_progs/sounds.qc": {
+     "bytes": 19389,
+     "sha256": "bb74ecc36a241db5a79b010f61200687c6db6e46297db39c8a2a8ce1d512bad5"
+    },
+    "my_progs/sprites.qc": {
+     "bytes": 476,
+     "sha256": "579f48b397914b02f8fb86dc24f23d4e63a4cd857df1f0eaefd6c83e9c49e238"
+    },
+    "my_progs/subs.qc": {
+     "bytes": 24000,
+     "sha256": "48832d667d7a932661ac914bc8e471843f2cd8a0985fc0458d7e1a2796e21d16"
+    },
+    "my_progs/subs_soc.qc": {
+     "bytes": 28453,
+     "sha256": "679112275e8b3597daac962074f69b6d9fd5614fc3dbff036815b9365e1413c5"
+    },
+    "my_progs/switchshad.qc": {
+     "bytes": 7054,
+     "sha256": "92a2fd4e5c41f21f46502781322ab87584bf0999d733db50e0e19b8bbea793b3"
+    },
+    "my_progs/targets.qc": {
+     "bytes": 58758,
+     "sha256": "e39b45bf6740be40c2899376e92d30d7d227a4762091d7b63e382c79fe6822e7"
+    },
+    "my_progs/traps.qc": {
+     "bytes": 24071,
+     "sha256": "9e4e822a36113bc73958fa45ab0b8c290a5148c95f3a4da7125676c984ebd202"
+    },
+    "my_progs/traps_pendulum.qc": {
+     "bytes": 17049,
+     "sha256": "b421f26fd80eb74715172e25f3ac992faa95397dd67d5f7ede286fd78384a468"
+    },
+    "my_progs/traps_sawblade.qc": {
+     "bytes": 9783,
+     "sha256": "9a6e82a05f09001c0a9cffdf6b9d6399691846c5b1ab1fbfb470e5772a87f44b"
+    },
+    "my_progs/triggers.qc": {
+     "bytes": 139722,
+     "sha256": "0ead1e997492dfe79a8c811a48b902217aafcd4bf3c49acea7101c99892886f3"
+    },
+    "my_progs/triggers_states.qc": {
+     "bytes": 17475,
+     "sha256": "2c4d25c11de0319cd54d81e67e651c8d29d22aca851988d21080ba5976137f14"
+    },
+    "my_progs/weapons.qc": {
+     "bytes": 44884,
+     "sha256": "d22ff6c46a101964e5e8e334a8d91ae8854e2eb6ca2c4565fcfc748acfcfd9e6"
+    },
+    "my_progs/world.qc": {
+     "bytes": 39815,
+     "sha256": "c160b7b050cc7a718fbc6ffe3dbfad85514936522bbabeb8ee4fb1a3c30b79d3"
+    },
+    "progs.dat": {
+     "bytes": 2347206,
+     "sha256": "5e69fece92fb4323609c8e1209a39eecf4f70c3161ae17beb53063fe3e06c340"
+    }
+   },
    "sha256": "49bb1a23ffda3e24edba1f4094ab4e031f570e8dccba7ca363b7096bbf0b84c1",
    "timestamp": "2021-10-31T23:13:28.000Z"
   },

--- a/json/by-sha256/33/33c5fcaf006a30d0692fd6ec72c59ee7141bacd656cd335d03944d439c6656fd.json
+++ b/json/by-sha256/33/33c5fcaf006a30d0692fd6ec72c59ee7141bacd656cd335d03944d439c6656fd.json
@@ -17,6 +17,180 @@
   },
   "pak2.pak": {
    "bytes": 8035385,
+   "files": {
+    "base.dem": {
+     "bytes": 1166121,
+     "sha256": "f861f97f1575aa21efb675f8477fe96313f2ceec270273044fc34bdb8277c098"
+    },
+    "default.cfg": {
+     "bytes": 2025,
+     "sha256": "3227f12ce7edbb4235d5b8b4d3f69206a9b8fd8715f939ca0601325e52ea15a4"
+    },
+    "gfx/env/moonbk.tga": {
+     "bytes": 440145,
+     "sha256": "215264c71fcfdcda4fd9470adb3b1e1e803cd5af1d8df035c3244646dbfeac2f"
+    },
+    "gfx/env/moondn.tga": {
+     "bytes": 603,
+     "sha256": "4a83e798c3d0637f03b1effe28df9998bf249831b3dccecef074ff5cd8b631df"
+    },
+    "gfx/env/moonft.tga": {
+     "bytes": 410588,
+     "sha256": "4fbbdf05866d78de6ab4bfc9867227007fc87073cc96678e0c08bbc6d9717ce5"
+    },
+    "gfx/env/moonlf.tga": {
+     "bytes": 421955,
+     "sha256": "ea304d8972653bd38c0aee88e6dd434d719360c423344d16b5db9c398af260d7"
+    },
+    "gfx/env/moonrt.tga": {
+     "bytes": 453367,
+     "sha256": "8ee2a2b97267326d4831d96c879c6238a63c485fc8865d91503adb6d7da878bd"
+    },
+    "gfx/env/moonup.tga": {
+     "bytes": 1335652,
+     "sha256": "91e764d1d7780818e58f1c30d7c8825df2adbf17c7da630acfa3dd70b29d27db"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "faa7c77704959d1ad9bb5280449b22e8c4b9425fc628b4f2037900c49e73fc9e"
+    },
+    "optout.cfg": {
+     "bytes": 1564,
+     "sha256": "51efd87218e766df5c8b5c643ccabcecacfa855ee60deaf8dde8420a02c157c8"
+    },
+    "progs.dat": {
+     "bytes": 737572,
+     "sha256": "988aea9295972e13bc2b7ceabf2c72e4eda5e3ff095090701beb65f697647a96"
+    },
+    "progs/bolt3.mdl": {
+     "bytes": 15772,
+     "sha256": "6fabed3901bab1b145e418300d333c30016070e57ede07476884283a5ef7e380"
+    },
+    "progs/box_l.bsp": {
+     "bytes": 21639,
+     "sha256": "9a20404c31446ffc497113892dc293b0e59c6bb2cd9ab4a1f0bee11cc1f61a5c"
+    },
+    "progs/box_s.bsp": {
+     "bytes": 21541,
+     "sha256": "47b3f0a947272241184b9f65aa46d694fdd8facb8a9a36509d6f11f844f3917f"
+    },
+    "progs/c_ham.mdl": {
+     "bytes": 76800,
+     "sha256": "6bdd3e6b4c8253e6aeb6e293093b88fe6b3a9254135d285c8574acb6be9de9e1"
+    },
+    "progs/c_lance.mdl": {
+     "bytes": 44164,
+     "sha256": "6925fa7f462edb6c863bef65dcbe7d5c69544454c6fc1435a98c2890b08cc757"
+    },
+    "progs/c_light.mdl": {
+     "bytes": 76388,
+     "sha256": "9f0cdcc8e56d0614e058a3e922f3f64b0de33ab2ba6fe390c4154a3cbeceff5b"
+    },
+    "progs/c_nail.mdl": {
+     "bytes": 45336,
+     "sha256": "afe38a23bd9d6ec01a386047c3030f95732a986211eb0c6aafa83e12eb300a53"
+    },
+    "progs/c_nail2.mdl": {
+     "bytes": 81136,
+     "sha256": "c2e9e328af078538722ba4894801b5e4c5334a4629faff83b11510aa0a987b21"
+    },
+    "progs/c_rock.mdl": {
+     "bytes": 74404,
+     "sha256": "058de704ba8b0c2a47c2b83fd1b767a8220b9af87460bf114b14528db57ce096"
+    },
+    "progs/c_rock2.mdl": {
+     "bytes": 73544,
+     "sha256": "c922fdbfcd8175d196cc16f2134c8d9852c788ca76c198337aa71bf0bfde5e56"
+    },
+    "progs/c_shot2.mdl": {
+     "bytes": 42636,
+     "sha256": "02226bf370133fb1c4479c56a9a3c544cb89a0e87ba4cabe3247f9ddc9994b9a"
+    },
+    "progs/dspike.mdl": {
+     "bytes": 25324,
+     "sha256": "c2c89f690e21e34bee37db5011493f3457240e22fcaa3cdcdf04ef4bf9f44ae1"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51272,
+     "sha256": "0244bf38ec29f251b425bc1cc4f1a0e003316b3699c869cea38ec553e1f96acc"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "d45e10e4002fb17b2a1aa4077d1d4e599babd5083c0f7da914f8e98b61cb2537"
+    },
+    "progs/polyp.mdl": {
+     "bytes": 343144,
+     "sha256": "a135ee3b29dd230d06babc0e80c691b35e33599a48eb152d2c2c4902d424d4ec"
+    },
+    "progs/s_vp_pll.spr": {
+     "bytes": 272700,
+     "sha256": "024935ca88793c432ac5d6c6f52a51cb82638c86e9c27cac8d87e926673012db"
+    },
+    "progs/slime.mdl": {
+     "bytes": 25976,
+     "sha256": "53b07ceca49f5c637dc5bbe1cf1393db74e3d057624039efb8d7fd2341b5466a"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "aa9165056656a1d0810d741c91e5e14b1aebf3020a95ebc0dc1f48a3a1243074"
+    },
+    "progs/waterfall.mdl": {
+     "bytes": 43588,
+     "sha256": "c4bf6157c6f3a580a6cc7a76c8d5ea6a9af00f9c53b0615bf47b6574dc5bd54c"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 845237,
+     "sha256": "ee9db9fb4e224227574067dffb1b9c49af5b9536f8cea0527282d851aab81e73"
+    },
+    "quake.rc": {
+     "bytes": 1248,
+     "sha256": "dac6aec78b770451be757493c744ffd4a3ef9fb64be379044d1de57936a746be"
+    },
+    "sound/ambience/grinder.wav": {
+     "bytes": 264572,
+     "sha256": "70789db5c6e505292dd6031241aff19bd7b327677033cac5f98c1dcfeed5c6db"
+    },
+    "sound/ambience/teeth.wav": {
+     "bytes": 51600,
+     "sha256": "9649cc3a15c66b851da286bfbfe085196e851a9a493c299b03d9874dc04431e4"
+    },
+    "sound/doors/er_stop.wav": {
+     "bytes": 51846,
+     "sha256": "f674272aa55db0cb05651c5edfa76422370d138c44789b179bc6e943a22f0d28"
+    },
+    "sound/doors/er_strt.wav": {
+     "bytes": 99372,
+     "sha256": "afb23446ab200aa3bd540bc1ac517713dbf2d7fc099283254f7b8a4480a90092"
+    },
+    "sound/doors/ir_stop.wav": {
+     "bytes": 81054,
+     "sha256": "c5ae31d19bb638cd61771f365beca5998d5795ff035929863a19148d39907904"
+    },
+    "sound/doors/ir_strt.wav": {
+     "bytes": 86616,
+     "sha256": "8e2767cf7d483ab898c7eb561834b0a7af90669976499dfe42c8f7e09560aeb9"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/wfend.wav": {
+     "bytes": 9060,
+     "sha256": "1d8381b51b40e54a47ee76a9115b95a49285fc59385ff20b941b0fc8b7cd16b7"
+    },
+    "sound/misc/wfstart.wav": {
+     "bytes": 77838,
+     "sha256": "c85b517926832c1a7ef3a04de2995a7bd58a161620b4341a3f57d556c50d7ea0"
+    }
+   },
    "sha256": "4a62df0587cb93ae080807614a5428f1bf26c83770c6fd4e7168e9ef7a4c3e77",
    "timestamp": "2015-03-21T19:54:04.000Z"
   },

--- a/json/by-sha256/33/33cd97c54ff7d5acc7f9a2c64e3059ba246325e13bbbf3ccf3d84b2e618b2d57.json
+++ b/json/by-sha256/33/33cd97c54ff7d5acc7f9a2c64e3059ba246325e13bbbf3ccf3d84b2e618b2d57.json
@@ -15,6 +15,1684 @@
  "files": {
   "rm1.1/Pak0.pak": {
    "bytes": 499723584,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "99c64cf1c7dd5d513a59733bd769c9ebfeea696fd96eb6d4adf0aae74ed9c920"
+    },
+    "gfx/env/mak_nebulacyan_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "0b73edc6a3fb95ec09bb8660fa5ee0370cd46f520e83e6434f7a6921a2851e40"
+    },
+    "gfx/env/mak_nebulacyan_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "0f23f07004cd21e8665a3f5ccc4c8d333d826a340e564fbda4645f61c248db40"
+    },
+    "gfx/env/mak_nebulacyan_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "2f13d175459a8011565dbbfbaec9edafe2d2c9a95a37af23655ba3662635125f"
+    },
+    "gfx/env/mak_nebulacyan_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "f69cbf49089278bb1f29f1d5cb15c9cf14b1a8ffab4ae781c6f73576cd67dd66"
+    },
+    "gfx/env/mak_nebulacyan_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "5e9a46853fc1ccfb302d2ec260df1f9113cac99018ff3555840ba2ba32d247b5"
+    },
+    "gfx/env/mak_nebulacyan_up.tga": {
+     "bytes": 3145772,
+     "sha256": "74f5dd91b6a4c5ac4224e44df0e50b8d904221df8b04cb615fb6b2bbf9302df7"
+    },
+    "gfx/env/mars_bk.tga": {
+     "bytes": 786450,
+     "sha256": "c89b8882101cea7dce890e1afb75048ce6f525de3d05e8edffee264c894b14c0"
+    },
+    "gfx/env/mars_dn.tga": {
+     "bytes": 786450,
+     "sha256": "79be864fb91098e7e162938b56608557e4767852ee1a0c7212f58714242137c0"
+    },
+    "gfx/env/mars_ft.tga": {
+     "bytes": 786450,
+     "sha256": "d328319bc92b57cb74934dc6ec29c773994603ada8c0d7663407c0539f53a516"
+    },
+    "gfx/env/mars_lf.tga": {
+     "bytes": 786450,
+     "sha256": "81e0331ef5883d70ba9588cee8f52e0984b6a403491242ba4268e207e86d74cb"
+    },
+    "gfx/env/mars_rt.tga": {
+     "bytes": 786450,
+     "sha256": "11ed1e93813b4faf407631709e257c3a551ab868e37aca9ab34ba6e4b81f32db"
+    },
+    "gfx/env/mars_up.tga": {
+     "bytes": 786450,
+     "sha256": "6c50889b41d1760827c2871952fa9944c99499c1d9a9f6ba735cea5ef5f89087"
+    },
+    "gfx/env/morning_bk.tga": {
+     "bytes": 716529,
+     "sha256": "9eed6f2193fbbfe3ea6b50c7d36c2bcdc387f6805d7e2ebefd79c849af9d73a9"
+    },
+    "gfx/env/morning_dn.tga": {
+     "bytes": 781318,
+     "sha256": "554843bb20e9af1cc7236460c8ecee0ce5cc6fef12e301871ee13e8209633c0c"
+    },
+    "gfx/env/morning_ft.tga": {
+     "bytes": 706691,
+     "sha256": "0a3b31ed93c78a8a833ef251ea9773c00a35f324699a40a859fee14d2a17b5df"
+    },
+    "gfx/env/morning_lf.tga": {
+     "bytes": 766964,
+     "sha256": "90fe9aa82c50eb44552cc44f28b371fd942c5e1e89e3e5512d060b23a3e98bbe"
+    },
+    "gfx/env/morning_rt.tga": {
+     "bytes": 732806,
+     "sha256": "c4219a950b02c7186c992ab2cb72940e21c9c4c9814c7c02f79a4d791ebaf0ca"
+    },
+    "gfx/env/morning_up.tga": {
+     "bytes": 703696,
+     "sha256": "11893da767dd1740a40f4242f747f2f4568f699b06e56bd00b533325a5a0be74"
+    },
+    "gfx/env/nightball_bk.tga": {
+     "bytes": 505093,
+     "sha256": "0176f518ad1fff1fc5326589da5ddcd30cb7598f787f7c531cf921ee5f9e369e"
+    },
+    "gfx/env/nightball_dn.tga": {
+     "bytes": 488801,
+     "sha256": "12ab5bfb82651c2a551259870f6f8afd152d6f7c9fd208fd9a932da8f61b7ec4"
+    },
+    "gfx/env/nightball_ft.tga": {
+     "bytes": 385599,
+     "sha256": "32aa17db6421fe771223aa27be3943f18e7ac5c05b13d23309e2a100b859b4c9"
+    },
+    "gfx/env/nightball_lf.tga": {
+     "bytes": 485058,
+     "sha256": "4faa4ededd3767adfc1cb545b0258dbf251662974c14fde9f91ffb30726a7e0e"
+    },
+    "gfx/env/nightball_rt.tga": {
+     "bytes": 500886,
+     "sha256": "2b3a747a23855bc6c6f389304947400e54c72f9c2cd0ec8bd4cb05209ba92a75"
+    },
+    "gfx/env/nightball_up.tga": {
+     "bytes": 448166,
+     "sha256": "c10bdca66aab106e2e5d56046bd375205eae06dca75df74cd444ec01ce39bb05"
+    },
+    "gfx/env/rm_carcosa/carcosa_bk.tga": {
+     "bytes": 394975,
+     "sha256": "f982c67b9e94605d215d9bf96ac57d52b85ec923e1ea3ba10b3f4aae273b02a8"
+    },
+    "gfx/env/rm_carcosa/carcosa_dn.tga": {
+     "bytes": 607451,
+     "sha256": "ee337207b500097b76d82e156ec61fb41f373bb85814d7c67b37c760d77c16f7"
+    },
+    "gfx/env/rm_carcosa/carcosa_ft.tga": {
+     "bytes": 555607,
+     "sha256": "3f25efb0c7691249749d6f01d82a3479ac09f66137febf9bbd07e1f2c75534b7"
+    },
+    "gfx/env/rm_carcosa/carcosa_lf.tga": {
+     "bytes": 389080,
+     "sha256": "96d1123edbfc27dc530638600aa4d7bcd8ac40c8309b149afe1246a5c6294086"
+    },
+    "gfx/env/rm_carcosa/carcosa_rt.tga": {
+     "bytes": 402360,
+     "sha256": "7a204bffd56fca37ca0d769bc8bef9826634fbedfc4a234c890c6ce8e1e01b85"
+    },
+    "gfx/env/rm_carcosa/carcosa_up.tga": {
+     "bytes": 169870,
+     "sha256": "ce8af8ec60aa93ea04ae94f6461e64868f82aa58b28c9fbe09d451e53b40ffc2"
+    },
+    "gfx/env/rm_carcosa/mak_stellarinky_bk.tga": {
+     "bytes": 4194348,
+     "sha256": "4d0947b5805bada32bb9673cf5919b81e976e97e22c76cf42fe78ce65fd98e55"
+    },
+    "gfx/env/rm_carcosa/mak_stellarinky_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "4bb32dac85e4e032bc2b5fca85dd432250302ac89102e663f1a1fc84197f30b1"
+    },
+    "gfx/env/rm_carcosa/mak_stellarinky_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "a513d9adc30487c3da2031ef856f92a3aaeef7655f88de8c3aab2a1067db12ff"
+    },
+    "gfx/env/rm_carcosa/mak_stellarinky_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "a27f7a0a84aebe5725c207171761f9d14f1574b888575fbbc58503d385cc743b"
+    },
+    "gfx/env/rm_carcosa/mak_stellarinky_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "21f2f011793e08f700fad5758a37783672edd878e18b568a3be6171088953c68"
+    },
+    "gfx/env/rm_carcosa/mak_stellarinky_up.tga": {
+     "bytes": 3145772,
+     "sha256": "43717f37c22837673b9893615aca5d96adaa2ea3a1d98ec6393775de2b1e7c75"
+    },
+    "gfx/env/rm_carcosa/mak_stellarinky_wind.cfg": {
+     "bytes": 77,
+     "sha256": "149a39823479b0bb4f6f2481dfb0cb7aa11fc90dacd4d0951543fd0cda822954"
+    },
+    "gfx/env/shol/shol_bk.tga": {
+     "bytes": 1048594,
+     "sha256": "128fe562f4209a0d12e0214b252dc758d2ceaac131c260865d32cf67fdb62e8e"
+    },
+    "gfx/env/shol/shol_dn.tga": {
+     "bytes": 1048594,
+     "sha256": "ddcee6f597e6abd4aa2a86a876557f1610d14595091e02850c6a0d8608cc8088"
+    },
+    "gfx/env/shol/shol_ft.tga": {
+     "bytes": 1048594,
+     "sha256": "0f06ed592759c064c95b9272810635d59f4896a75887feddca92310f98b850ed"
+    },
+    "gfx/env/shol/shol_lf.tga": {
+     "bytes": 1048594,
+     "sha256": "ded289b042a5fd2c0ada8fc0339c72d1313131f6d572689202adaef25bf9e9aa"
+    },
+    "gfx/env/shol/shol_rt.tga": {
+     "bytes": 1048594,
+     "sha256": "f28089efd3515d03ef7e9550c85e192d037229789efa78ddd049f597c2c0cf5b"
+    },
+    "gfx/env/shol/shol_up.tga": {
+     "bytes": 1048594,
+     "sha256": "edcc48632ab330f63c4bce3fc11abbc8c2f566984cffc3c78978a0d5f2cdaf95"
+    },
+    "gfx/env/violent180_bk.tga": {
+     "bytes": 4194348,
+     "sha256": "6c3035fb694ca65151528f713f92aa0828b19bc9d8d3c7103aa7eed48d7f07be"
+    },
+    "gfx/env/violent180_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a3b344abf47fae67c831aaa8d8b2ab7ff56ff1ed93091c6869139902060777ff"
+    },
+    "gfx/env/violent180_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "964ce0226b139a1af96de0c422e927d35917ad30f0c4027c1c386c7c32cc30db"
+    },
+    "gfx/env/violent180_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "b9cc1ef464535f9a911d56fb503a2e1aa68e6d07c7091cb62c42442a7d62ceaa"
+    },
+    "gfx/env/violent180_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "263af4a0d5b2e61303d8165d6b8a8b7e55d0c8dd79157ff133a5d50128d5f21b"
+    },
+    "gfx/env/violent180_up.tga": {
+     "bytes": 3145772,
+     "sha256": "3a9aae357ac1a8e8767e151024dab60845283422f204a354913282873f181413"
+    },
+    "gfx/env/violent180_wind.cfg": {
+     "bytes": 77,
+     "sha256": "b88d6646c7886eb2d5c521aa6fa567b8976a0ce10bc6859aeb8afb4ce285df8c"
+    },
+    "gfx/puzzle.spr": {
+     "bytes": 5624,
+     "sha256": "d1646c09f75fe07116cbc9029388b8eabe4be4cb9d2f7275e7bb911251295acf"
+    },
+    "maps/autohook.bsp": {
+     "bytes": 532040,
+     "sha256": "d5c0aa110199264ffced6acc71a7e78d5d90f288c62c7ed799920e21d9fcae60"
+    },
+    "maps/autohook.lit": {
+     "bytes": 140708,
+     "sha256": "1e25ccb11692d4609fae6756d62b53dc08782c034379cdc0487029280b465dbf"
+    },
+    "maps/examples.bsp": {
+     "bytes": 1412460,
+     "sha256": "9ac7ab997e30edc951b826b7033f73dbde75f41ed8c0dfacf7129d286985b39b"
+    },
+    "maps/examples.lit": {
+     "bytes": 976016,
+     "sha256": "ad3e4082138932ebffac3d55c01295c3fc663ad657a8d7149986334fbe7a6af7"
+    },
+    "maps/examples.map": {
+     "bytes": 485840,
+     "sha256": "648eeac27e6b41c5d22b2e927958b422558b9be063d8ccea47823d6c44df6ff7"
+    },
+    "maps/inventory.bsp": {
+     "bytes": 125724,
+     "sha256": "4b0c99e8f014476d48042fedd389fd7ea1fad45981a4f31ed6a72e28e936b30f"
+    },
+    "maps/inventory.map": {
+     "bytes": 19894,
+     "sha256": "94edbbc12c05452f889bce1340f66694fd451b49367153f370d35979e0ef1fa9"
+    },
+    "maps/rm_carcosa.bsp": {
+     "bytes": 20080924,
+     "sha256": "a2094862f5145e4e15c3da18e6e23b1a130f3a2b1a0150ebf7cb7e4f3cf503c8"
+    },
+    "maps/rm_carcosa.lit": {
+     "bytes": 7070120,
+     "sha256": "22743761d376c4b05e171fbd8c7f46b4d5e90c120fe47857a1fc43c4f9de221b"
+    },
+    "maps/rm_carcosa_bandit.bsp": {
+     "bytes": 13576,
+     "sha256": "97b4867b0c231c537b131e55cceb554579a8cc328e466e731a254f3a8bdb2a9f"
+    },
+    "maps/rm_carcosa_bandit.lit": {
+     "bytes": 236,
+     "sha256": "b8d238230b9a17c31a50823363c99262e9ff67731affd38de9bc337deb380a34"
+    },
+    "maps/rm_carcosa_turret.bsp": {
+     "bytes": 131940,
+     "sha256": "acb0a1998758e03aebab1005c17f138a2a9eb355def623d8cefd857e63a078e0"
+    },
+    "maps/rm_carcosa_turret.lit": {
+     "bytes": 4844,
+     "sha256": "9754fdd61b698724c07b5370c44703290c84415773592d5fbc7aa25cbf8a9702"
+    },
+    "maps/rm_directions.bsp": {
+     "bytes": 2920184,
+     "sha256": "531437ca634704f04e7cee9fdaf6761acb6c72b9708dfff20779cd83f28c117a"
+    },
+    "maps/rm_directions.lit": {
+     "bytes": 1612604,
+     "sha256": "733dd4739396d06413bcba07d08c7032f438372393882db2328c222330e50715"
+    },
+    "maps/rm_dynamics.bsp": {
+     "bytes": 5515204,
+     "sha256": "b75a5ca9d0e5e785fdc5a4de61f2d0e4b800a2bbfbafff82cc17e3c37a22abde"
+    },
+    "maps/rm_dynamics.lit": {
+     "bytes": 2007863,
+     "sha256": "4f629e278fa34dd40a8234aec33b15bcbb74a7295a363ab943c6ab78acf40463"
+    },
+    "maps/rm_dynamics.map": {
+     "bytes": 4613396,
+     "sha256": "119e84e63dc169dba0d44eea512b4f43c35d13c5971c334f4ddbd7c21704a4b5"
+    },
+    "maps/rm_echoes.bsp": {
+     "bytes": 11892900,
+     "sha256": "2cc1f9066cd48829dadeae6c917d933928ee8b5ac5f4be52bbd3e5abdcd2a3ed"
+    },
+    "maps/rm_echoes.lit": {
+     "bytes": 3963962,
+     "sha256": "ba9b64e6df75b688c720914df454020ad12c33b96d519b48a15981cf2bf442aa"
+    },
+    "maps/rm_heretics.bsp": {
+     "bytes": 78577876,
+     "sha256": "f1dbdf32b8b433cf5eb0ffc875fea90ae42f982c53cb94017e4948253b207edd"
+    },
+    "maps/rm_heretics.lit": {
+     "bytes": 10974020,
+     "sha256": "8929b062312ae0007c84efd82a611d14b337badf8434101cc26c6c1eef7d3db0"
+    },
+    "maps/rm_moon.bsp": {
+     "bytes": 3134012,
+     "sha256": "4cd3d9ad780bab3d3601935dc597bc7fe71c28fb489cc06ef97e423f2df123d2"
+    },
+    "maps/rm_moon.lit": {
+     "bytes": 1344467,
+     "sha256": "f220d3520c70000862838c2172a0c1efc87001cd9127e2f53d7d77f3a482e38d"
+    },
+    "maps/rm_peak.bsp": {
+     "bytes": 4874640,
+     "sha256": "d83709a25b12899a38870acb6f2cd953b20ad6dd1e0351c2ce194f9cc94e81f4"
+    },
+    "maps/rm_peak.lit": {
+     "bytes": 1122254,
+     "sha256": "a80b9e7d097f80e1b191f5f8d0a986386da4bd5b3b5457ee63af563dab21ec10"
+    },
+    "maps/rm_re1m8.bsp": {
+     "bytes": 3754816,
+     "sha256": "23fc5416fc5754f217db4292fd783a7bdfd6edc8e8ab0c94bbb44793c67c0402"
+    },
+    "maps/rm_re1m8.lit": {
+     "bytes": 1777148,
+     "sha256": "be5202b2f01b59ba585c8f90d45b05786201ba5271a715741af11efa57a006e3"
+    },
+    "maps/rm_substratum.bsp": {
+     "bytes": 6186276,
+     "sha256": "5adcefc10a9165bda18e692369735d90a1c43f13973b0c700214a2cc5f28b1c1"
+    },
+    "maps/rm_substratum.lit": {
+     "bytes": 2213408,
+     "sha256": "102f9d24b96d65a02d6b7a65bd7fcdd1ac87c11a4323c615c12895d77660bbfb"
+    },
+    "maps/rm_urn.bsp": {
+     "bytes": 20374684,
+     "sha256": "ce872fc51bbe56abbedce741c73b28c6685f926ad5bdb03b34d5783a146b04df"
+    },
+    "maps/rm_urn.lit": {
+     "bytes": 2132576,
+     "sha256": "3cf875e680289f9e5b583dfa0f8950c7a2798ad6e36214de5e5c692d29a6e2cb"
+    },
+    "maps/rm_waterfront.bsp": {
+     "bytes": 6501788,
+     "sha256": "7e6f9555582751c4f937c82c88274c68c6182848b7e1f81c7f78596381722c10"
+    },
+    "maps/rm_waterfront.lit": {
+     "bytes": 2831225,
+     "sha256": "1946c046227dc7807517ac62facc1c5c9bd8cedb51e8f1329fa92f094024bd8b"
+    },
+    "maps/rm_waterfront.map": {
+     "bytes": 4702785,
+     "sha256": "fe8393a5a24e4a3f3f2464cd3865f20af52241bb5f5cae7bd0daae8c2f10fb1a"
+    },
+    "maps/rm_yawning.bsp": {
+     "bytes": 4661268,
+     "sha256": "786fda9506c8fe4daf504d2fd57cb67c4a34a5b39cfcc6670b06c105c59ba5a7"
+    },
+    "maps/rm_yawning.lit": {
+     "bytes": 2137472,
+     "sha256": "d66b94f34b20b78cd8a99c360bafd842288980a6ce0b9bcd34674167dfa64be6"
+    },
+    "maps/settings.bsp": {
+     "bytes": 1038316,
+     "sha256": "70b5abb197ecb087623357280c054828cc0a47f3204ac96dbc6e26a3f2136664"
+    },
+    "maps/settings.lit": {
+     "bytes": 537587,
+     "sha256": "39d69a36c6a0f413ceccb12863fe99c0e2f5f521025f0b8caf28136159a81079"
+    },
+    "maps/settings.map": {
+     "bytes": 299347,
+     "sha256": "a6813e6933f882e9382fb1cb5d32c51d3d492b0db796ca396b52b5ff26d05be9"
+    },
+    "maps/start.bsp": {
+     "bytes": 43309336,
+     "sha256": "154e155b917a694dcc13af65f7fe763dedd827cabe7d02f999d60180a8873842"
+    },
+    "maps/start.lit": {
+     "bytes": 2420408,
+     "sha256": "f72e9fe84c831e4af9bb5c6d505fdf9db9ae24c1ac006eccc75e1a43882bd8e0"
+    },
+    "maps/start.map": {
+     "bytes": 6261034,
+     "sha256": "bb1ea2cc8ae1f6acd7f944436501ebf8f7cb57424c6c94d52d6463df818bde22"
+    },
+    "music/track100.ogg": {
+     "bytes": 7984478,
+     "sha256": "a2d2d88fdef08317c6b87597a002cfc0288c83fcf2fa335f69a55e1bfe79b8b0"
+    },
+    "music/track121.ogg": {
+     "bytes": 4907095,
+     "sha256": "187aeab4715f59991c05322efafd0362b8c543b1a423b1dac1a1c22525c1efe3"
+    },
+    "music/track142.ogg": {
+     "bytes": 3770540,
+     "sha256": "53949723a50e965dd8abc45d01c14cdd05ccf84c9e81c992eb3a6d0adca77d7c"
+    },
+    "music/track192.mp3": {
+     "bytes": 15677888,
+     "sha256": "519005daab249738d6bd3dfee313d5ba26b2f7e7662ef098f6b27493ce6504cf"
+    },
+    "music/track29.ogg": {
+     "bytes": 3352457,
+     "sha256": "0edf3cae4f07765263eb23e1c659e1ea77f26b77a9adc998454a9912c2271b67"
+    },
+    "music/track30.ogg": {
+     "bytes": 2583885,
+     "sha256": "ab74853273d014e151b8da90147c141ca7de1043aa7f23dedef9098bbf072fa1"
+    },
+    "music/track39.mp3": {
+     "bytes": 5078313,
+     "sha256": "1a2b75caa4cd5d5175a98e79d9aab1a15114e0c705b6355919496305ef26b2b3"
+    },
+    "music/track64.ogg": {
+     "bytes": 34677839,
+     "sha256": "d876f8c16abe34346a87091b518a3368de22e8687bbb2b4af0a472a67e13755d"
+    },
+    "music/track67.ogg": {
+     "bytes": 2071602,
+     "sha256": "42a3debdb80d7f7626850b7b1896876cf73869d7eda38dd7d935bca089af495c"
+    },
+    "music/track71.ogg": {
+     "bytes": 34222945,
+     "sha256": "4221cc6d86f4cda184e8cb75a089e99d21c998c18b84ee4f15c57e7a3c986753"
+    },
+    "music/track99.ogg": {
+     "bytes": 50630,
+     "sha256": "74a294d5c958f9284d68ce2c667f233e87c9f57ef0abe3e7471bea257823c0b7"
+    },
+    "progs/a_mdls/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "1cdfc2b54dd883efe9215499603e341bfa72e800740a2e874e9bcf3b0afc68ba"
+    },
+    "progs/a_mdls/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "8cb54159eeaa410b98478e9190bd2d33340d3a2e98a61d32ce1afaf4e99031a0"
+    },
+    "progs/a_mdls/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ac361970fb1cbbb87ad4593afecd6d8973a65ea4f14e5f7b565c8f38c181fa9d"
+    },
+    "progs/a_mdls/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "0870b633f95bda895074e8d423631ee8805c3923f36a1c7f09938710783e8f99"
+    },
+    "progs/a_mdls/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "146955794f29c02f6570eed83e1d4b0013b0b4341897bcbc91cc9ffea6957ff4"
+    },
+    "progs/a_mdls/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "59988afc3603b83ccfadf0a9af423a113bf15ed969d4a62db9073e3061bc0fdc"
+    },
+    "progs/a_mdls/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "696594c11dd6dbd2e60ac6923d82a55f8f5b16e93b93f7914abe5fd4df74299f"
+    },
+    "progs/a_mdls/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "b558ee2dfd0078c7e3075079fb40368f53e7dfb162aaefcd20e53f562e405b1b"
+    },
+    "progs/armshr.mdl": {
+     "bytes": 20012,
+     "sha256": "1873523424395b404ffafeb447383185e033826e33bf0a001efc34604ece95da"
+    },
+    "progs/beam.mdl": {
+     "bytes": 85496,
+     "sha256": "414259b1c9cb4b23c6cb4e560008287857dc438627138d4806a8fd7d0554f75a"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 85496,
+     "sha256": "74f83a584737f82af2f358b2ee37a9cd02a8acea23b7a1d8e0728af36703a404"
+    },
+    "progs/bolt1.mdl": {
+     "bytes": 85496,
+     "sha256": "ccb45187c4d9561258588d1d616dec1fb086782de173f83e38476f0ae0d7287c"
+    },
+    "progs/bolt3.mdl": {
+     "bytes": 85496,
+     "sha256": "2291b1d8da40d6acd9a0b21771417e0b8a68051b114785997ffefca7636bc61e"
+    },
+    "progs/candle.mdl": {
+     "bytes": 24135,
+     "sha256": "5027f8712c36de87b3967e4e623fbc64d4e99644f5b805f7e21ec38b1532cc74"
+    },
+    "progs/debris.mdl": {
+     "bytes": 263072,
+     "sha256": "2b60cba9cbb454e3524d174edc0e1a540f2b2e91fa0b35fc2ab20ccb7fabd8d1"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 472208,
+     "sha256": "3345599ba081d346c163f5c239815bd65b134ccf342601f42a31e60a45044f39"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/g_shotgu.mdl": {
+     "bytes": 29076,
+     "sha256": "4a8866ab410a93522a3d3221e0f3b45889a488b54c0551329f09493273e09840"
+    },
+    "progs/g_shotty.mdl": {
+     "bytes": 23380,
+     "sha256": "b919bbcba3f7f03fb8b82fa6d3b1464ca41e81cf29417cfea0de09658c698cfb"
+    },
+    "progs/h_boss.mdl": {
+     "bytes": 24028,
+     "sha256": "b41e2302e15d7cb47bf1eb4ee1df29e7e8d773a3dfc6059f5b1f8ce18685bba6"
+    },
+    "progs/h_mdls/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "2e7fac7418838a721d80e80370000f3e400b21248b22c8d3555588d4f8437a5b"
+    },
+    "progs/h_mdls/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "1f4b0791be3156763c15521fbf2e747744ce3355d90d630b01c2227770314771"
+    },
+    "progs/h_mdls/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "6f792b9a80f34e31bceb4258e1d2c8f22d405a7ae1198b31bb285f502c720cfe"
+    },
+    "progs/h_mdls/pd_vial.mdl": {
+     "bytes": 8292,
+     "sha256": "035673048c98991e790abe484c2403b56dfe5ea1f5fb185c1b7a657d918668e8"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 42048,
+     "sha256": "52760ce1f6e8f657e782846571baf9fde80859f5342d07a684fa8218f96f68db"
+    },
+    "progs/h_shambler.mdl": {
+     "bytes": 98400,
+     "sha256": "6508f7b05b65f230b7f1280d2023e9ed200663715db1709c43e7e187e3ed841c"
+    },
+    "progs/health_5.mdl": {
+     "bytes": 6164,
+     "sha256": "a8ba7ece01b3cb58b2f94ca20a9f4511871d26ec894b54c04e433f29fc7c3bef"
+    },
+    "progs/hook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/k_spike2.mdl": {
+     "bytes": 444704,
+     "sha256": "e466e7afa95868ec1a3b3bfc770573d93dc20c2d881a73d2b9b0e35f1dfa6d9b"
+    },
+    "progs/lspike.mdl": {
+     "bytes": 1684,
+     "sha256": "59264317258f19955b967177f0dbc5be1733e4ca07c4c7b3cc333bb88bc0c46e"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/misc_lantern.mdl": {
+     "bytes": 28836,
+     "sha256": "d84e36232543a053f2772b1070b221dc23da1b34cd08ea551a982b5e9f168ea5"
+    },
+    "progs/null.spr": {
+     "bytes": 57,
+     "sha256": "dc67fb2f31bd717353b8138f02bdc8ef2d70ace433c9fd91e3adc909fda513a3"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 366916,
+     "sha256": "29fa9866dd4862b99ebb9944ddb0bf24a6d0bb4bf00e26a94d3622cead9b6315"
+    },
+    "progs/pd_armor_sh.mdl": {
+     "bytes": 31508,
+     "sha256": "46b9de8235f07190e18d67e147ed00be6dc322cd112ccde33bf4fc1f9a77e074"
+    },
+    "progs/pd_b_key.mdl": {
+     "bytes": 128440,
+     "sha256": "c5aff23b766037ab550636516d7fe0235dacf566ddb966541d640092bcb62349"
+    },
+    "progs/pd_base_key.mdl": {
+     "bytes": 21219,
+     "sha256": "320ec52018f501f8fe428dd46f44693787e545289be883a49f3bd6476974cf46"
+    },
+    "progs/pd_bpack.mdl": {
+     "bytes": 216724,
+     "sha256": "1839c92899197344935eca44d7b4c70e903af84ab633259786f8c12c39905149"
+    },
+    "progs/pd_r_key.mdl": {
+     "bytes": 269528,
+     "sha256": "7ef6894b955c4ca34bf3e2ebdc6288f55cc3b1285478444a81ca769866e1a119"
+    },
+    "progs/pd_rune_key.mdl": {
+     "bytes": 46335,
+     "sha256": "c4fe9bd66394231ace3127635f057987ecbf4b13b00d84501127caacb5db03fc"
+    },
+    "progs/pd_w_key.mdl": {
+     "bytes": 170680,
+     "sha256": "73f06fc10a53c93db25d67f20bad7672bc5f4e14bf3a6b5115d68f00696b536a"
+    },
+    "progs/pd_wiz_key.mdl": {
+     "bytes": 21907,
+     "sha256": "36b50211f687813b85648a46bd32a1d543a8f2af84e9d4223f8b5843f885e1bc"
+    },
+    "progs/puzzle/cyaegha.mdl": {
+     "bytes": 20604,
+     "sha256": "e0134ba9b54fb67bf252a0cfc81af23cda71d1d5b3ce55c82e0fb69e7fc8f718"
+    },
+    "progs/puzzle/cyaegha.spr": {
+     "bytes": 1400,
+     "sha256": "5e47d02105ece3c9c15ee85778a6f07de8e100aae0cd30f7d1d9db6453162af3"
+    },
+    "progs/puzzle/pallid.mdl": {
+     "bytes": 23260,
+     "sha256": "e0a723f1c00ac85a86018419a9046058b77d09e5cad656fa949e25b98e1f3301"
+    },
+    "progs/puzzle/pallid.spr": {
+     "bytes": 1400,
+     "sha256": "edf63f7ea0774e0a5a6825dd9689c3224dc19abf158b8b347b5768748cb9f159"
+    },
+    "progs/puzzle/swampkey.mdl": {
+     "bytes": 18660,
+     "sha256": "63d435e8942c98adfc9307f6276cf8206ec063b5e32a05e09c5e388efa512c33"
+    },
+    "progs/puzzle/swampkey.spr": {
+     "bytes": 1400,
+     "sha256": "d5dec992ccba32e8d9c8bc381e96d6771b27cbb3dd6a1adf018a710ac53a1fd0"
+    },
+    "progs/rm_carcosa/bandit.bsp": {
+     "bytes": 13704,
+     "sha256": "0441c4c8b9e3f1674cd4c596fbb967b0c68db6d6f0404b752548c303df489b12"
+    },
+    "progs/rm_carcosa/boatee.mdl": {
+     "bytes": 237540,
+     "sha256": "edd64d1697011a5cbbc11ba9c241ce110aba2204483c3756a2ef026b1c30c604"
+    },
+    "progs/rm_carcosa/bookopen.mdl": {
+     "bytes": 6188,
+     "sha256": "eedde4ccb29ebb305ac02c4512afc4fe3b41a1028ef94b5cdf30ee51f1e02e70"
+    },
+    "progs/rm_carcosa/boy.mdl": {
+     "bytes": 347880,
+     "sha256": "a868caffe2f6009f072f0fa218274140523caa68e3b390a11fdaef5ac9c25a7b"
+    },
+    "progs/rm_carcosa/burner.mdl": {
+     "bytes": 50884,
+     "sha256": "768a5c4194d3bc77be2262b43b9bf4f58dd0cae284c341f16295dbb1e138a6be"
+    },
+    "progs/rm_carcosa/burnerh.mdl": {
+     "bytes": 31456,
+     "sha256": "3e49bb2b8b0207737411d0508b24077a92907b5c93edd9621f8193685570a65f"
+    },
+    "progs/rm_carcosa/candelabrum.mdl": {
+     "bytes": 23804,
+     "sha256": "7c2e11eff04bba20b22cbe5ca88a6f0ab41ec04c3a01b0d8d27cc5594dd60ed5"
+    },
+    "progs/rm_carcosa/cashier.mdl": {
+     "bytes": 168900,
+     "sha256": "d6e89f4f2c3b426fb9180cb2d0e3ce272318a2d7d4ddeb4dd2c42dff2f9ca8ed"
+    },
+    "progs/rm_carcosa/chandelier.mdl": {
+     "bytes": 28852,
+     "sha256": "629c64dee0c60a5d525f1c1ce2434db73a33315b53ca42332093e2e858693334"
+    },
+    "progs/rm_carcosa/cherub_small.mdl": {
+     "bytes": 126628,
+     "sha256": "c13a7e90d0f60f205458efe3a22fe4b86d61e62a576d7e3cdf4652b86da9f4ae"
+    },
+    "progs/rm_carcosa/cupid.mdl": {
+     "bytes": 129180,
+     "sha256": "b62ae66a3cfb2854100e995ad0ddff1eb259bf6343d4255b1aab86033b42f254"
+    },
+    "progs/rm_carcosa/debris.mdl": {
+     "bytes": 41652,
+     "sha256": "76b5d9412afa47d12657d779ddb91f987e46662fa6190c3721512fa3410316e9"
+    },
+    "progs/rm_carcosa/dragonhead.mdl": {
+     "bytes": 25892,
+     "sha256": "ad218cc7f37e236b689af0b1cebd6a721bb3f25de827754d96874748e26f6eb8"
+    },
+    "progs/rm_carcosa/ferryman.mdl": {
+     "bytes": 75284,
+     "sha256": "d76501bc93581caf0f875d14bf89ab2e2ae4e4ba2ba691e39b2c60040904176e"
+    },
+    "progs/rm_carcosa/g_shotgu.mdl": {
+     "bytes": 29076,
+     "sha256": "381fe8e0f41e3364ff667755506e88d6639f74d59033bc11f3b31c46b8aeaf46"
+    },
+    "progs/rm_carcosa/globe.mdl": {
+     "bytes": 68452,
+     "sha256": "1f0927b6f1a7cef5bbc4215e9138d352e9fa38c767627b7e5c00d1ff735b0c35"
+    },
+    "progs/rm_carcosa/globe_nospin.mdl": {
+     "bytes": 68452,
+     "sha256": "b74a00d297e9506797ff2f1cdbe8c518300684ec20f8c697bf4de437c644f3ef"
+    },
+    "progs/rm_carcosa/globebottom.mdl": {
+     "bytes": 26468,
+     "sha256": "d68c691d64a86f3e1dbd46461e97a14be1c8521c3cedc8604f76886299c47541"
+    },
+    "progs/rm_carcosa/globetop.mdl": {
+     "bytes": 78308,
+     "sha256": "cebee136d2578c987f95e6ee3b5b27f240ef82f0ff0af206a8dead7bd3cc08a6"
+    },
+    "progs/rm_carcosa/halberd.mdl": {
+     "bytes": 22324,
+     "sha256": "82ce4521247d90b3852468064b910bf0842c690f0ed55668f491a4d4fa6000ef"
+    },
+    "progs/rm_carcosa/hedge1.mdl": {
+     "bytes": 34232,
+     "sha256": "83bf757e09a98dd8658022d6232057a7a4babc9dc8dd87aed1ca41635e7f52a9"
+    },
+    "progs/rm_carcosa/hedge2.mdl": {
+     "bytes": 25356,
+     "sha256": "7113965e19ec6b2d2e8da17a9322211ed4f4d7a3b6f14d95333867a7509fdeb5"
+    },
+    "progs/rm_carcosa/hedge3.mdl": {
+     "bytes": 25708,
+     "sha256": "78ade31c936c195eab523e7f45371e510aa784f9e0d8af193307c76cafde36ea"
+    },
+    "progs/rm_carcosa/knight.mdl": {
+     "bytes": 89508,
+     "sha256": "3a779e632fdc2c54e6a48aa09a87e55a39db81da6fcd91647534f3761f53959e"
+    },
+    "progs/rm_carcosa/mathuz/flag2.mdl": {
+     "bytes": 81472,
+     "sha256": "2f91b03b9520781c6d9258261b843c015ad4f82f75aadfc03c327d3129f339e2"
+    },
+    "progs/rm_carcosa/misc_textbook.mdl": {
+     "bytes": 45512,
+     "sha256": "2a7744e787226c0ed73e7d44e8ccf742565f86ad3cd34053d9635cf0b88578dd"
+    },
+    "progs/rm_carcosa/monsters/elemshambler_f.mdl": {
+     "bytes": 163468,
+     "sha256": "c86980d098e1564495b2ecbb279c74f834e058c1ad8cee459ca5eaf2316c3e54"
+    },
+    "progs/rm_carcosa/monsters/elemshambler_i.mdl": {
+     "bytes": 269740,
+     "sha256": "25c5e9a258255b7a0ee8442f6eed00eaa6c5b5d22d3494c9ca1e48c4fc94efd1"
+    },
+    "progs/rm_carcosa/monsters/gib1_i.mdl": {
+     "bytes": 5876,
+     "sha256": "948ce4f477c9b0c44f3f90bbc3d1c4f9eca552f50bc0f30fbc42bbb6d39b4bee"
+    },
+    "progs/rm_carcosa/monsters/gib2_i.mdl": {
+     "bytes": 16564,
+     "sha256": "d8c12494605dcd53ac61ea40c926ba13b0ff93dd1c2bda941209500334ad0b49"
+    },
+    "progs/rm_carcosa/monsters/gib3_i.mdl": {
+     "bytes": 22356,
+     "sha256": "d4b0b70423637c1cf56a8458c39749f11f179a054c99558f265581b8f7c5a8da"
+    },
+    "progs/rm_carcosa/monsters/gkrokon.mdl": {
+     "bytes": 298216,
+     "sha256": "38e4ba39acfa2830aa93973ae1d89176a81609206d233f1e7720ab16e8fef230"
+    },
+    "progs/rm_carcosa/monsters/h_elemshambler_f.mdl": {
+     "bytes": 37316,
+     "sha256": "c2fb45095a9c7df922b2251cee0b7c2f356f84109d6b7ce6616f4645b18b3ad6"
+    },
+    "progs/rm_carcosa/monsters/h_elemshambler_i.mdl": {
+     "bytes": 37316,
+     "sha256": "9f29fe86868a479c2bf36723590209fcd260eb83655ae7ab0633c8ed04e17e27"
+    },
+    "progs/rm_carcosa/monsters/h_swambler.mdl": {
+     "bytes": 39940,
+     "sha256": "46ee53c5d5b6945d785de73a63f87a07bbe8ced993a0b01b9f9b122ca1ca8205"
+    },
+    "progs/rm_carcosa/monsters/lavaball_i.mdl": {
+     "bytes": 8916,
+     "sha256": "6c2dd678b047a4fabd932c42ddbc30fe2918436deba7750d6b43c784609917e4"
+    },
+    "progs/rm_carcosa/monsters/lrkbody.mdl": {
+     "bytes": 936252,
+     "sha256": "2757800618974e216462f7571ede51b2241cc02c7bdcede914a8edbf545a4ea4"
+    },
+    "progs/rm_carcosa/monsters/lrkeye.mdl": {
+     "bytes": 39016,
+     "sha256": "90e1d8b5bd4234df9c211a2fed9a54bf3bc714e3b0d913915ce5d2061f97a404"
+    },
+    "progs/rm_carcosa/monsters/lrkglobe - backup.mdl": {
+     "bytes": 19484,
+     "sha256": "b3c1879ea85c86801b0fdedc6a2171ef9b00a9036566365529a42e27c2a2e8b4"
+    },
+    "progs/rm_carcosa/monsters/lrkglobe.mdl": {
+     "bytes": 19484,
+     "sha256": "62cf7fa08b52c621f5c5310852f8719ce6f1c7a662e247b822f5b2d2175dddf7"
+    },
+    "progs/rm_carcosa/monsters/swambler.mdl": {
+     "bytes": 401092,
+     "sha256": "80d6fc685f3f92ea230e3605bad01bf282d198cbc3844ad0336d38356aabb1ab"
+    },
+    "progs/rm_carcosa/monsters/turreteer.mdl": {
+     "bytes": 331064,
+     "sha256": "f11bb1de608d43ce65fbfa5eca85e83d0b509e087c37ace74a82ed9bacf75401"
+    },
+    "progs/rm_carcosa/puzzle/cyaegha.mdl": {
+     "bytes": 20604,
+     "sha256": "e0134ba9b54fb67bf252a0cfc81af23cda71d1d5b3ce55c82e0fb69e7fc8f718"
+    },
+    "progs/rm_carcosa/puzzle/cyaegha.spr": {
+     "bytes": 2168,
+     "sha256": "a4bf943e912697f1fdd6aa72f46fa09bbb323cf2c00ddc5a9809852a99c56a5b"
+    },
+    "progs/rm_carcosa/puzzle/elderkey.mdl": {
+     "bytes": 18944,
+     "sha256": "e64a64d4f4878e74bed9e0b3a09366ea0e7bac9e9084ddb4b70dd52653280848"
+    },
+    "progs/rm_carcosa/puzzle/goldbar.mdl": {
+     "bytes": 12020,
+     "sha256": "6e1cf73947dda58c9c5f5971f87ce11ce2e3b20c5d6b927a511213ec91cc1fbc"
+    },
+    "progs/rm_carcosa/puzzle/goldbar.spr": {
+     "bytes": 1400,
+     "sha256": "3b515d5e1817de6efc095d3a380888b5a6e439da09b3bfae63c7553087089eee"
+    },
+    "progs/rm_carcosa/puzzle/goldbar2.mdl": {
+     "bytes": 22932,
+     "sha256": "59ce61ecc79f4a343337316a0cdf2655cd91d2fa8205c9065512ef2b0893d1af"
+    },
+    "progs/rm_carcosa/puzzle/gravekey.mdl": {
+     "bytes": 18620,
+     "sha256": "bc2d925560dab2c0763e462bd6057f58cd761aa48245522fd8e74ad368189acc"
+    },
+    "progs/rm_carcosa/puzzle/gravekey.spr": {
+     "bytes": 1208,
+     "sha256": "2659335d95f84091bd6ccaa8dc267cf41208317e11e3960465a40decc81ac49a"
+    },
+    "progs/rm_carcosa/puzzle/pallid.mdl": {
+     "bytes": 23260,
+     "sha256": "e0a723f1c00ac85a86018419a9046058b77d09e5cad656fa949e25b98e1f3301"
+    },
+    "progs/rm_carcosa/puzzle/pallid.spr": {
+     "bytes": 1400,
+     "sha256": "edf63f7ea0774e0a5a6825dd9689c3224dc19abf158b8b347b5768748cb9f159"
+    },
+    "progs/rm_carcosa/puzzle/swampkey.mdl": {
+     "bytes": 18660,
+     "sha256": "63d435e8942c98adfc9307f6276cf8206ec063b5e32a05e09c5e388efa512c33"
+    },
+    "progs/rm_carcosa/puzzle/swampkey.spr": {
+     "bytes": 1400,
+     "sha256": "d5dec992ccba32e8d9c8bc381e96d6771b27cbb3dd6a1adf018a710ac53a1fd0"
+    },
+    "progs/rm_carcosa/puzzle/trapezohedron.mdl": {
+     "bytes": 17576,
+     "sha256": "59e4bf74796b0ad51217729429fde1bab977b20736c735ddbc80419deec2e33a"
+    },
+    "progs/rm_carcosa/puzzle/trapezohedron.spr": {
+     "bytes": 1720,
+     "sha256": "43c6d29f8f247ff8c7c43beb31c7f8ff9506d561ab1b00ef03595fba735e0ab6"
+    },
+    "progs/rm_carcosa/redfield/animcurtain.mdl": {
+     "bytes": 79956,
+     "sha256": "d8952739dfad16215ada9db0930ceb8a68c8f656370dc24cbcca843a7c851e2d"
+    },
+    "progs/rm_carcosa/redfield/animcurtain2B.mdl": {
+     "bytes": 76476,
+     "sha256": "86992821c91d18e932d8848233b856b99960b40bf457e4df39bebcab91c504ef"
+    },
+    "progs/rm_carcosa/redfield/curtains.mdl": {
+     "bytes": 724496,
+     "sha256": "9f3d580318398509e13dabc504dde429c47fe6c5c3de3a95a870a5f017976838"
+    },
+    "progs/rm_carcosa/redfield/sail.mdl": {
+     "bytes": 137920,
+     "sha256": "4d3bf4faaa987dca91c31de091a733351691d2b4851eb825f81a23f478eb42d5"
+    },
+    "progs/rm_carcosa/shard1.mdl": {
+     "bytes": 5784,
+     "sha256": "086b98924977853e5e8fb66fe7b7964866575bc782632890329c7c34e0406a4a"
+    },
+    "progs/rm_carcosa/shard2.mdl": {
+     "bytes": 4384,
+     "sha256": "94b1bdd548128b4bb0a4eb089355c10de8e2a7799e8bb55d1efc27bd1a48e149"
+    },
+    "progs/rm_carcosa/shard3.mdl": {
+     "bytes": 3896,
+     "sha256": "3b0741e92ccedc74e33d780ef102131d67db972ef3065d14181c1dc7709fd3af"
+    },
+    "progs/rm_carcosa/shard4.mdl": {
+     "bytes": 3872,
+     "sha256": "72737a431373db7b1e5dd9d58aaca99e978f9bb6761128fb4c38ce518900d0f3"
+    },
+    "progs/rm_carcosa/shard5.mdl": {
+     "bytes": 2280,
+     "sha256": "fd88776bfe9fe26f8dc9c538824aa7ad75b75d498a13759b411002b43c7b302e"
+    },
+    "progs/rm_carcosa/sheep.mdl": {
+     "bytes": 561604,
+     "sha256": "426b4a9512a4389e1bd633f689e35eef28161984662750912729eaf9ee6af08c"
+    },
+    "progs/rm_carcosa/speech.spr": {
+     "bytes": 984,
+     "sha256": "f7a18f463b8aa332112bfd45e57c3259b785426f7dea6d3750e885d088986c8a"
+    },
+    "progs/rm_carcosa/stchain.mdl": {
+     "bytes": 8564,
+     "sha256": "20a9c47eb1a387bd2c6990548a69044a6cd40ef88f1923cdef871ef59345b749"
+    },
+    "progs/rm_carcosa/stillring.mdl": {
+     "bytes": 7364,
+     "sha256": "117f5b80140fb9c47fa34289e5b33139616bf2bae230691895e10f1c29865f35"
+    },
+    "progs/rm_carcosa/test/puzzle.spr": {
+     "bytes": 1080,
+     "sha256": "b87daf0390f9efa3fe38c32827213bd5fc1f0971d69a1dad214bdf32b3db188a"
+    },
+    "progs/rm_carcosa/test/puzzle_custom.spr": {
+     "bytes": 5624,
+     "sha256": "697398f7327323ca6c6b599b2e23cd10429758989a84261b0cc98b13927848b3"
+    },
+    "progs/rm_carcosa/test/trapezohedron.mdl": {
+     "bytes": 96768,
+     "sha256": "97f9b474a513eb4c8b7b81c33d55d2435bc4bb8ebe54604764d075052cb8e42c"
+    },
+    "progs/rm_carcosa/test/trapezohedron1.mdl": {
+     "bytes": 18088,
+     "sha256": "3231ab06db44702bf20e87fb702c260277360ab9b63e5df99ca87e33f81970b0"
+    },
+    "progs/rm_carcosa/test/trapezohedron2.mdl": {
+     "bytes": 18088,
+     "sha256": "d18b19c9c9213efb622350ca9eff51f94cb73053f99d0c08b4a91da01553c123"
+    },
+    "progs/rm_carcosa/test/trapezohedron3.mdl": {
+     "bytes": 18088,
+     "sha256": "7f87f9add57eae822f3f2619090d0320e3274d65ec3d9084877615622768b40b"
+    },
+    "progs/rm_carcosa/test/trapezohedron4.mdl": {
+     "bytes": 17576,
+     "sha256": "21126a9f0dc33fda1546b521f8f055c4fda3fbad8dd2f485894b66bd85d32c95"
+    },
+    "progs/rm_carcosa/test/trapezohedron4b.mdl": {
+     "bytes": 17576,
+     "sha256": "8bd45195bbaaf4edb79b41c59c2df6cd44330ea40f5910be00f37d6978e88ade"
+    },
+    "progs/rm_carcosa/test/trapezohedron4c.mdl": {
+     "bytes": 17576,
+     "sha256": "2d4787c6657473d86f0c3c39d1e76d1013832bbae555b3b661406023a797575f"
+    },
+    "progs/rm_carcosa/test/trapezohedron4d.mdl": {
+     "bytes": 17576,
+     "sha256": "59e4bf74796b0ad51217729429fde1bab977b20736c735ddbc80419deec2e33a"
+    },
+    "progs/rm_carcosa/test/trapezohedron5.mdl": {
+     "bytes": 17480,
+     "sha256": "25618fc255044d54aa2a918ce5fb0389f096e3039736d2e0313c6313e1552248"
+    },
+    "progs/rm_carcosa/test/trapezohedron6.mdl": {
+     "bytes": 66632,
+     "sha256": "6dd1c05f76148fa50cce889168ec0294b4a3ec5b0aacdcfe4ce0f9240335a5be"
+    },
+    "progs/rm_carcosa/test/trapezohedron6b.mdl": {
+     "bytes": 66632,
+     "sha256": "10241ba93661298ec99ed8bc6efc5d295e1d8ccecbfae47b191b0b411f6dcb5c"
+    },
+    "progs/rm_carcosa/test/trapezohedron7.mdl": {
+     "bytes": 66632,
+     "sha256": "92408bffcccdf89fab3572dc7e873c49edde2b903fb8138414ea9bf5b2b6cf87"
+    },
+    "progs/rm_carcosa/test/trapezohedron8.mdl": {
+     "bytes": 66632,
+     "sha256": "a1b06aabdc3b9837c9b2dd9fd6d18da9b267a31e87ede615861bc09db4ff57c2"
+    },
+    "progs/rm_carcosa/tombstone3.mdl": {
+     "bytes": 55860,
+     "sha256": "bb8463f04a2c4226386668c8dbd1d785155ea4726c527c07dbb4db24e15639d8"
+    },
+    "progs/rm_carcosa/tracer2.mdl": {
+     "bytes": 68624,
+     "sha256": "b65a7b707c714318c18e3488d2be58bb6ff253cd564f95b1c8d6db0371c44ad7"
+    },
+    "progs/rm_carcosa/tree.mdl": {
+     "bytes": 158404,
+     "sha256": "d79942626e12ab6c66f216610fc6700cc1fd49bb576f680590017ad6a23d5f40"
+    },
+    "progs/rm_carcosa/tree2.mdl": {
+     "bytes": 158404,
+     "sha256": "d79942626e12ab6c66f216610fc6700cc1fd49bb576f680590017ad6a23d5f40"
+    },
+    "progs/rm_carcosa/turret.bsp": {
+     "bytes": 131152,
+     "sha256": "c48072c18f02351cdeaf58956f085ec9ad2d0116a2e73f14b7c6e580056fce04"
+    },
+    "progs/rm_carcosa/wm_gl.mdl": {
+     "bytes": 49252,
+     "sha256": "b26a778fefab0a752588a2eadbc66f39bf9e44d3ff45c8ccba6c270790dcb534"
+    },
+    "progs/rm_carcosa/wm_lg.mdl": {
+     "bytes": 51716,
+     "sha256": "7c176cb43c957ba780b3aa8f1ec468b1ee4b6538ccf7a78a42dbb85956bd32df"
+    },
+    "progs/rm_carcosa/wm_ng.mdl": {
+     "bytes": 36092,
+     "sha256": "d573b19a1785c283f641bc39f299426418741c03ed2dd8f81eef32114897a7b9"
+    },
+    "progs/rm_carcosa/wm_rl.mdl": {
+     "bytes": 41748,
+     "sha256": "04af8e5cd8c05f181d5a1c8e4482a6b5f7f12ab734f8e1de53a7336999d12124"
+    },
+    "progs/rm_carcosa/wm_sg.mdl": {
+     "bytes": 29076,
+     "sha256": "381fe8e0f41e3364ff667755506e88d6639f74d59033bc11f3b31c46b8aeaf46"
+    },
+    "progs/rm_carcosa/wm_sng.mdl": {
+     "bytes": 32064,
+     "sha256": "462c0ff0583692b49e45039d3b9bd29c3d1d2c49c1d70900ed4818009490d4f3"
+    },
+    "progs/rm_carcosa/wm_ssg.mdl": {
+     "bytes": 33524,
+     "sha256": "972e65dd090e8ec2ed93660d25b64807fd02369f967e8a99df1889319a392a72"
+    },
+    "progs/rm_carcosa/yvain/anglstat.mdl": {
+     "bytes": 614880,
+     "sha256": "ff90b7a4f1b5ccb6673c57a66c6269ed6e8a0dbc351f86cfeea31c62e3833229"
+    },
+    "progs/rm_carcosa/yvain/athena.mdl": {
+     "bytes": 130568,
+     "sha256": "a9e27a4a2c505ec3a017806da3acc1517efc52bc8e4a9376dd03f58095d63943"
+    },
+    "progs/rm_carcosa/yvain/athena2.mdl": {
+     "bytes": 128792,
+     "sha256": "ac0a90fcc0f7e4e5565d764e867e43b8866c1147230903bc9f99643bb6daead3"
+    },
+    "progs/rm_carcosa/yvain/athena3.mdl": {
+     "bytes": 127800,
+     "sha256": "6f17a088aead97500eedaaca23c4980d47654c851b4fc4e098e3381b852a8eb0"
+    },
+    "progs/rm_carcosa/yvain/athena4.mdl": {
+     "bytes": 124808,
+     "sha256": "7322fe3173752bb06ed5b15e420204ac1a97aa82e6f4a6c0f98f490cb056ca18"
+    },
+    "progs/rm_carcosa/yvain/caesar.mdl": {
+     "bytes": 105848,
+     "sha256": "5ab19117ec4eabe49d74511e9bd7cd53334b4d1649f17d1866a96b9bb23d651e"
+    },
+    "progs/rm_carcosa/yvain/demon_p.mdl": {
+     "bytes": 124008,
+     "sha256": "255f3fd400dbc6b758b5e694653c03b67413bf2b6f8cd36241ef3c819c1cea30"
+    },
+    "progs/rm_carcosa/yvain/dog_p.mdl": {
+     "bytes": 203016,
+     "sha256": "e2163d6f8dd602fa35c1920c27a605db6341536eeadc4db1ca7a56c95a6cf411"
+    },
+    "progs/rm_carcosa/yvain/fangel.mdl": {
+     "bytes": 603792,
+     "sha256": "b1b2d20f0a4bbcb211f8ff39da482c5e617e1f10ee34ec27317e2a1f89bf6192"
+    },
+    "progs/rm_carcosa/yvain/hknight_p.mdl": {
+     "bytes": 321012,
+     "sha256": "6a89bd0989e7aa06d4254ebe2b4c2a61549e759383da91ce831683613016fb14"
+    },
+    "progs/rm_carcosa/yvain/knight_p.mdl": {
+     "bytes": 126204,
+     "sha256": "f7ce88c65938bd18b54620f9468db31906751a08978614e58202254017d042d0"
+    },
+    "progs/rm_carcosa/yvain/neptune.mdl": {
+     "bytes": 141528,
+     "sha256": "86d4c4fa786a33be47a00a8c482314b82abcbb2fe3bebf8028bc04644caa075e"
+    },
+    "progs/rm_carcosa/yvain/player_p.mdl": {
+     "bytes": 253172,
+     "sha256": "703252edbc50ee6971255760fd5b4bc66acce6080bf5e9a4cfc92e8206abd7a3"
+    },
+    "progs/rm_carcosa/yvain/shambler.mdl": {
+     "bytes": 174352,
+     "sha256": "e1889b4080ceabde1ea7574521bef5c7fd498f2b1b6624021deea42c77740d40"
+    },
+    "progs/rm_carcosa/yvain/shambler_p.mdl": {
+     "bytes": 130768,
+     "sha256": "aaa2d8b338f481fc42fd2584b62db522d474e2521b01b563985fd4e6760d361b"
+    },
+    "progs/rm_carcosa/yvain/stool.mdl": {
+     "bytes": 6964,
+     "sha256": "1d74738fdea7f2b33ecafbad405417177b05a35d8ae0e1c35b150f8a55473c8f"
+    },
+    "progs/rm_carcosa/yvain/sword.mdl": {
+     "bytes": 6792,
+     "sha256": "22d4985c1bdc99a598e10a7a61381255924061c9cc070bf242169d1bb4b97614"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 47856,
+     "sha256": "99fc3f91856aa6df2f25494a945e17b64b59ddc3faed424a6fcd73062a677fcc"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "e306ec0fbf0f5e4306c6683f7c7b87674bb0a168ef32a2b1118dcffb083deeff"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 320900,
+     "sha256": "e3321220ed34292da63fac94af63360c6544c055edd1eceed35d75eb26685e9b"
+    },
+    "progs/spark.mdl": {
+     "bytes": 2544,
+     "sha256": "77d081c51af9bd6c82d2d51dcb955a2fca5189cda4eb09a138bfa2e2b521fb05"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4416,
+     "sha256": "8c70353304b2d111260102565745a5504144568f932787906eaf50de742aa62c"
+    },
+    "progs/teleport.mdl": {
+     "bytes": 1058800,
+     "sha256": "98eeb63a1ded2d7a1d3788562478aff891af1be4ef1c552bcdb913cb338387b6"
+    },
+    "progs/tracer1.mdl": {
+     "bytes": 68624,
+     "sha256": "c0feddcacc94372041d9e02c744fd266ab6d1fcda8b970be3f5147e43169f38a"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 1058816,
+     "sha256": "ac4d47130af263cb6fd861d70ac09ebf758ab1a76da0b697e268382c65ae1a16"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 311493,
+     "sha256": "add013a5a6686ffd76ec0f2b2b3413757432ba4a8564ffd81aeb7eb2c5a98398"
+    },
+    "rm_peak_moon_assets/elemshambler_f.mdl": {
+     "bytes": 163468,
+     "sha256": "c86980d098e1564495b2ecbb279c74f834e058c1ad8cee459ca5eaf2316c3e54"
+    },
+    "sound/ad/rattle1.wav": {
+     "bytes": 88274,
+     "sha256": "c524d12100f1067bb30ecdf83e18e5d85124fef834929cfd2a2ade14f83ad730"
+    },
+    "sound/ad/windgust6_loop.wav": {
+     "bytes": 99390,
+     "sha256": "aa82daecffa513c9b528f30822534b5075262dc2c4287b0cf75fcd45a61ff9bf"
+    },
+    "sound/ambient/cavern.wav": {
+     "bytes": 110466,
+     "sha256": "3ccf6482b46b41b4d98f3bb863e84b47b3cec6c7549cad381746110c8dbec526"
+    },
+    "sound/ambient/creakypipe.wav": {
+     "bytes": 209500,
+     "sha256": "2bfc86c5fc78a17c7422296e78c908f97520c4ff67a4f544c7897a95bcfdcafc"
+    },
+    "sound/ambient/millwheel.wav": {
+     "bytes": 321834,
+     "sha256": "699fac8407d6d3831bcbcc6353dcc2cb78b05ddb24e8bf7d5e37742c84fcf202"
+    },
+    "sound/ambient/pistons.wav": {
+     "bytes": 44612,
+     "sha256": "cea65c6282630b302dc880bca537aa43d5551f229696617d46c25cebc6516b7c"
+    },
+    "sound/ambient/swampfall.wav": {
+     "bytes": 308752,
+     "sha256": "ef3186ae5a71ef93a4973b8b41a068139fefc3e11b444e583c72aed8d63d3e56"
+    },
+    "sound/ambient/waterpipe.wav": {
+     "bytes": 364356,
+     "sha256": "89b435d61340ceedc20fff0dcec8e6402cda30b54a75f45753b0d6055d248910"
+    },
+    "sound/break/bricks1.wav": {
+     "bytes": 49956,
+     "sha256": "302547c290609bc311098f9f63643199bee0164e907edf0e2b9289ccbce2a4e2"
+    },
+    "sound/break/metal1.wav": {
+     "bytes": 70054,
+     "sha256": "c178f8f52631b1ff353fbeb3557e04e8bd574646ed47f78a3003350b67540979"
+    },
+    "sound/break/metal2.wav": {
+     "bytes": 65948,
+     "sha256": "7438b112d81fb92c285a507ebfbde5b15dbddcd90a85f51ecaae2df3ef83480c"
+    },
+    "sound/break/pd_bricks1.wav": {
+     "bytes": 61786,
+     "sha256": "3829842a9cb395f99d07546be38263eaf0ee5bbed71841aa8c93864d55a7fb94"
+    },
+    "sound/break/pd_metal1.wav": {
+     "bytes": 44146,
+     "sha256": "c0111b94231bc3870cbb95ec03f13b2b44ac407a5d18b35668ccf231303cc8aa"
+    },
+    "sound/break/pd_metal2.wav": {
+     "bytes": 70722,
+     "sha256": "ce8250482e831c270cc3c8e9211b74a627b3e29159c2c8ee720dd11cafd365c1"
+    },
+    "sound/break/pd_stones1.wav": {
+     "bytes": 75150,
+     "sha256": "632d15db23ff70c23c199595b41a153ded67f664de46b7d0cbfa0228f071156e"
+    },
+    "sound/break/pd_wood1.wav": {
+     "bytes": 34526,
+     "sha256": "621865f52fc27fb10108027ce3eea18aaf17181751a3ba1ceee0c9c99da9f375"
+    },
+    "sound/break/pd_wood2.wav": {
+     "bytes": 33342,
+     "sha256": "77282f2c533b9aec72b232aace9078534db3f255f418efafdf769c7361a28e05"
+    },
+    "sound/break/stones1.wav": {
+     "bytes": 69380,
+     "sha256": "1b58b722e55c4e2d25f65e820e279699a7b236a02685fbc6a41a40e573df1928"
+    },
+    "sound/break/wood1.wav": {
+     "bytes": 53720,
+     "sha256": "026e35d7108347603453765f66311fec99097ff9f82e2d2703f69b7d80ae07c9"
+    },
+    "sound/break/wood2.wav": {
+     "bytes": 59252,
+     "sha256": "4488c91dc44e526beb95d33ad200e07e484a6f2fea59578784f3417a00df81f7"
+    },
+    "sound/dump/armsh1.wav": {
+     "bytes": 22610,
+     "sha256": "46801976a87d548c2cb7b1548f12dfd0b3f1d246aa9d86944574fa3216c6d6d1"
+    },
+    "sound/dump/elec22k.wav": {
+     "bytes": 178736,
+     "sha256": "d56ff98d1d41511833c35b5a8b5311f00b7e13932591eee53f9e2adf788569e1"
+    },
+    "sound/dump/magic_01.wav": {
+     "bytes": 125944,
+     "sha256": "3ea2bab80feccbe0f0b518ec613f45093aa76b0128752f454e239c75175cb4e0"
+    },
+    "sound/dump/pd_armor1_sh.wav": {
+     "bytes": 12410,
+     "sha256": "3b80fc8000fe624ffbe4f119faf41a77406b83bd350020c7782bc03fd51a1799"
+    },
+    "sound/dump/pd_magic_01.wav": {
+     "bytes": 125944,
+     "sha256": "3ea2bab80feccbe0f0b518ec613f45093aa76b0128752f454e239c75175cb4e0"
+    },
+    "sound/dump/pd_quake_end.wav": {
+     "bytes": 37248,
+     "sha256": "3ecb621fbf5a3f2ab090ebc0f3036069292181b11ab366689b3dfa0f19dd372a"
+    },
+    "sound/dump/pd_quake_full.wav": {
+     "bytes": 156278,
+     "sha256": "872e0b0847fd366c59341d672cba9da0faaf85a881f8d4d5471a664923c8440e"
+    },
+    "sound/dump/pd_quake_loop1.wav": {
+     "bytes": 159956,
+     "sha256": "52a330a12c35191347008f4c546b1c83b4e387f3f33c9b60c3a5e8e545b0517e"
+    },
+    "sound/dump/pd_water.wav": {
+     "bytes": 92708,
+     "sha256": "0402b1fb2501dafb33bd43fa9c49c0f6a3fff615a200693cb7953852305c49f4"
+    },
+    "sound/dump/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/dump/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/dump/water_59_02.wav": {
+     "bytes": 40038,
+     "sha256": "25aa667940a737e46da0a829d9cb94922972b9b19726664d1a1133a666dc1439"
+    },
+    "sound/grapple/gractive.wav": {
+     "bytes": 39606,
+     "sha256": "07326b827e9e9e8adf18c169f61f00f1d0dbe99a3089585c8b10aee1c900e672"
+    },
+    "sound/grapple/grdetach1.wav": {
+     "bytes": 22030,
+     "sha256": "509f831ddd9492bc961a59734afda72f44e1a602149c8139dfc8c4af9744d6db"
+    },
+    "sound/grapple/grhit2.wav": {
+     "bytes": 37912,
+     "sha256": "250cd88a7dbf49feebc457eaa240e7ff9a2e455ef9c0036351b80afc1a7e12c7"
+    },
+    "sound/grapple/mhookactive.wav": {
+     "bytes": 58160,
+     "sha256": "e53815235713a35b567af6c9013dd11f469342476eeba1ec2cefab082e5ae280"
+    },
+    "sound/grapple/mhookattach.wav": {
+     "bytes": 101568,
+     "sha256": "f971d49ba8821f70e83756241c6023d746ecbb10db00e5150cd739b7fe80736c"
+    },
+    "sound/grapple/mhookdetach.wav": {
+     "bytes": 148000,
+     "sha256": "4f3699109728a315f20c2bdfd32d0ba024ed52ae39c57b91ac4830b349e8982a"
+    },
+    "sound/grapple/mhookdisable.wav": {
+     "bytes": 55340,
+     "sha256": "6a0468e2f27e1717a9408cb782d8fe573e5110a52c43a5f980409a5ee679639a"
+    },
+    "sound/grapple/mhookenable.wav": {
+     "bytes": 55340,
+     "sha256": "dc98b548f41ac1fdd6507df62179c8cf289be0c1fa3c1c0a478fee10df09a7c7"
+    },
+    "sound/heresy/1shot_greg_01.wav": {
+     "bytes": 377344,
+     "sha256": "915523f2411f5e0361ad147659f46d8ef8dba3edc6b0d44a4edb9fc68c95ae23"
+    },
+    "sound/heresy/rock1.wav": {
+     "bytes": 133700,
+     "sha256": "8a66187ca7d7440f0275fd3631751bae9f6880104399f51e607456949e8e518b"
+    },
+    "sound/heresy/rock2.wav": {
+     "bytes": 73846,
+     "sha256": "b8ece1952ac45f9496765f561fe65bbeb9c2ad41839f9bae8329dac983d1fef9"
+    },
+    "sound/heresy/rock3.wav": {
+     "bytes": 105476,
+     "sha256": "8e5af5c0df108d5633c082d4a98cd7641a7ab122fff90a242ed0109084b0d263"
+    },
+    "sound/heresy/rock4.wav": {
+     "bytes": 93016,
+     "sha256": "5d9285d98f21df4a55494fe254ae129482c7fab2f0edc9bd9fd7aa4d6b7aab6e"
+    },
+    "sound/heresy/splashes.wav": {
+     "bytes": 100392,
+     "sha256": "55025288eb0275574fe12a4616edc0507e2602a81284f630c69ad876a8efc88a"
+    },
+    "sound/heresy/windcave.wav": {
+     "bytes": 253736,
+     "sha256": "0b21c2c2aabb169dcb68b69784be9cb8b28131205154c2a41dc0ff4d93621d60"
+    },
+    "sound/markiev1/waterriver1_loop.wav": {
+     "bytes": 92498,
+     "sha256": "aefd6a04e31aa3edd7e92089d64796a56b05dbf5444a0f748cc4b7bc8f0d20f2"
+    },
+    "sound/markiev1/windysign1.wav": {
+     "bytes": 171102,
+     "sha256": "82fc997830176004345f649684147c9933992d4adbbb58a28597ce64bdf655d9"
+    },
+    "sound/misc/bounce1.wav": {
+     "bytes": 131318,
+     "sha256": "e2ff508502105784b4d4c57866fd51c90e378da512453f2b4f0ec7d3b9c9e05b"
+    },
+    "sound/misc/bounce2.wav": {
+     "bytes": 65748,
+     "sha256": "7aa0dc7f440d26308324203b6b765f17def36e1ff93d848bf6bcfa5757c83575"
+    },
+    "sound/misc/bounce3.wav": {
+     "bytes": 38432,
+     "sha256": "0bc4a8a5ea66240a0626b0f6aa7b89596cc21f1f4661faa10046c14e91a44ca6"
+    },
+    "sound/misc/bounce4.wav": {
+     "bytes": 130190,
+     "sha256": "a6832f4e0bbeacdcfa004b2f58c5f373612d328f4e6cff136a5865b677e47fbe"
+    },
+    "sound/misc/bounce5.wav": {
+     "bytes": 111922,
+     "sha256": "75b43f7f3a81e36a03f30c8fcb9c74ec3ea2802d81ad8c170df0c6c5d687152e"
+    },
+    "sound/misc/bounce6.wav": {
+     "bytes": 90644,
+     "sha256": "61326cbca06fc86291e860ca3cea864ddfe88ad93faab30bcc2626e07f1ed362"
+    },
+    "sound/misc/bounce_c.wav": {
+     "bytes": 49084,
+     "sha256": "b09cbe0dc39101a49153cd2150f1ae77d1bac6449dcdfb6839413721e5492470"
+    },
+    "sound/misc/cushion1.wav": {
+     "bytes": 114818,
+     "sha256": "901643e1c58d71be1bcd30204081b2b35aaa4b48f08df6b6827757ac7ceb7daa"
+    },
+    "sound/misc/cushion2.wav": {
+     "bytes": 69444,
+     "sha256": "081ae22fd9a6447b0331df39b4d0066c3f1275113423a8ed9154b03cd0074ae5"
+    },
+    "sound/misc/cushion3.wav": {
+     "bytes": 18706,
+     "sha256": "bbd10a7fe94c4f17c601663999f7634fd9fc7b91b8ce18091b94e85f63c0a806"
+    },
+    "sound/misc/cushion4.wav": {
+     "bytes": 88320,
+     "sha256": "8e085176b61f2267359942b8408cb5729642b8e3b656f91e8a2b022c57755945"
+    },
+    "sound/misc/cushion5.wav": {
+     "bytes": 135156,
+     "sha256": "725f93e054fbd55e572ce7c69b0cc5a38a5654f74e304341e5e6b784f99b9c9d"
+    },
+    "sound/misc/cushion6.wav": {
+     "bytes": 75530,
+     "sha256": "f9736c287e7adfea7ec5af4ff264eff78d33061f40f0088f4ff4c72d5dc3e214"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/mesh1.wav": {
+     "bytes": 58482,
+     "sha256": "1cc350204f85be52b106ff012e5486c9c7be73d2ad1720028359f854a268b3f9"
+    },
+    "sound/misc/mesh2.wav": {
+     "bytes": 53260,
+     "sha256": "53b48ced37d7002af3af4a06912689ca00d5c2de09ceb12c2d183ddefd25fa0d"
+    },
+    "sound/misc/mesh3.wav": {
+     "bytes": 59688,
+     "sha256": "45e24bb4005871e7f096711eda928c6e8d5ebf52699239c3c16c1b59e060ba5f"
+    },
+    "sound/misc/mesh4.wav": {
+     "bytes": 95440,
+     "sha256": "4f53a83e668f1c2384684c4c8c567b3fbe26506957b57fc927f1eaac5cbf947d"
+    },
+    "sound/misc/mesh5.wav": {
+     "bytes": 315602,
+     "sha256": "b22c95cf3d7751f0a7437768cbff4c314f3faca60c079e3abfaba8bccfb907b1"
+    },
+    "sound/misc/mesh_c.wav": {
+     "bytes": 41282,
+     "sha256": "e507b003e86b197e286a378786fab189721626ed5cf5377d805edc9078510818"
+    },
+    "sound/misc/mesh_c2.wav": {
+     "bytes": 33172,
+     "sha256": "b1614e4039333f2f1746d1ec5453896c81783b614fa524bc28cc393f601259d7"
+    },
+    "sound/misc/mesh_c3.wav": {
+     "bytes": 42992,
+     "sha256": "23b19afcfbb04f236766940ad97d870f7f93d496bcbb4dacf3c6739046c737f5"
+    },
+    "sound/misc/puzzle.wav": {
+     "bytes": 6558,
+     "sha256": "749dc513e6fc6db082153a602bad5574325c1ff6e3d0b58f0f1169116a17c71b"
+    },
+    "sound/misc/puzzleaway.wav": {
+     "bytes": 4694,
+     "sha256": "bba82dd60ddc23bda2c0a905a1b73394bead2a172f78d46f0f192699b880192c"
+    },
+    "sound/misc/retro1.wav": {
+     "bytes": 22462,
+     "sha256": "35bf5034f26b8b5ccfcdbe6d371831a4c279f8ceed79601946219adb63276646"
+    },
+    "sound/misc/sticky1.wav": {
+     "bytes": 29910,
+     "sha256": "fbc3907ec6b9853130e24d768111b091d3123622631b431e538763b30f376520"
+    },
+    "sound/misc/sticky2.wav": {
+     "bytes": 27612,
+     "sha256": "8f6b498800a8c00b0a3254e687314f1d94a232e784c810178e60157991b67c14"
+    },
+    "sound/misc/sticky3.wav": {
+     "bytes": 75530,
+     "sha256": "9e0a442c0e9466eafef10a0a1a2246b6e7c523b323c7c8fd26d2ea084821b47c"
+    },
+    "sound/misc/sticky4.wav": {
+     "bytes": 42054,
+     "sha256": "e27ffc077693b4384c44daedbae19169991b0335aa3f6d79497b4656213e9dcb"
+    },
+    "sound/misc/vines1.wav": {
+     "bytes": 315602,
+     "sha256": "122ac96e09ff9fe5291ee2f8e79d9c1539a350c01ced4e6037ae857453f9f3e4"
+    },
+    "sound/misc/vines2.wav": {
+     "bytes": 244954,
+     "sha256": "924f9faef5ab66e9f32793c266d11d51faecec2dc9b4be369e883ec8d6c167f9"
+    },
+    "sound/misc/vines3.wav": {
+     "bytes": 329732,
+     "sha256": "4acaac46c6ea8fa76e3335e7df1a236fc3b1f97a1fcbfe779f2331889664a749"
+    },
+    "sound/misc/vines4.wav": {
+     "bytes": 202566,
+     "sha256": "576044eba6e7453afb8fcdc35db41107f4917bf61ce018d9fd94710a9f55dc85"
+    },
+    "sound/misc/wood1.wav": {
+     "bytes": 62108,
+     "sha256": "a13beef55a57c6506d1d7c9399c1962966bebd5d7597b0bb98a042ea4244ff4b"
+    },
+    "sound/misc/wood2.wav": {
+     "bytes": 54946,
+     "sha256": "4ddd034f1807ae0d133cbb86cc05cb7aeb7ebd5656b02c962c3eddda403acc8f"
+    },
+    "sound/misc/wood3.wav": {
+     "bytes": 85182,
+     "sha256": "1c91fd493b14935784229613f3024d4410f9b378199aa097ed62a696e4462b0a"
+    },
+    "sound/misc/wood4.wav": {
+     "bytes": 50172,
+     "sha256": "bf7711f7373e8a128216be8079eaac096c1105eff1b83231bcb684809737bea0"
+    },
+    "sound/nickster/creepy1a_11k.wav": {
+     "bytes": 1147040,
+     "sha256": "c5ad3a82aa4cd6ed5a13d4eaba6acf5300d15fb5f04020ca5ff117e5b8fd9d6a"
+    },
+    "sound/nickster/creepy1b_11k.wav": {
+     "bytes": 1147040,
+     "sha256": "4b1869585a910f69a224e63276048235dead64faeaa0074ae517605632bff8d1"
+    },
+    "sound/nickster/mach_hum1_11k.wav": {
+     "bytes": 573600,
+     "sha256": "99d47807ab6aff53ec1ef73039d7b9269faf986e943518930bea154ba5524373"
+    },
+    "sound/nickster/mufscr1a_11k.wav": {
+     "bytes": 102142,
+     "sha256": "b62a7d227f7190440e28397c53ad9dd30a53e29a2709fc9806b9a2f2641ec045"
+    },
+    "sound/nickster/mufscr1b_11k.wav": {
+     "bytes": 102142,
+     "sha256": "88c23e990e1c6edfe845a3a024449546505b27d828fbcaac3280dd8af3b9213e"
+    },
+    "sound/oldone2/pd_pop2.wav": {
+     "bytes": 42108,
+     "sha256": "1eec3103cd2eb70fa8ba63ce8ce721842a64a99e9c373f5a8abe5508273ce285"
+    },
+    "sound/pendulum/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/pendulum/swing.wav": {
+     "bytes": 12960,
+     "sha256": "68da54f9541808bdaa1f070218bd53ffce0cfccee46b460fd9181a366440952a"
+    },
+    "sound/riktoi/steam_leak.wav": {
+     "bytes": 13122,
+     "sha256": "e5200da86f5726b2ee73f042b59c543fcae414b83d33ac91bd9629561add4538"
+    },
+    "sound/rm_carcosa/alarmbell.wav": {
+     "bytes": 42386,
+     "sha256": "21cbe537dccb4c3aec5f4f04b7f24b931086b40c5cc9d398ebbeaa1db6e7a16b"
+    },
+    "sound/rm_carcosa/antigrav.wav": {
+     "bytes": 46748,
+     "sha256": "c0e81f58862805d0b3602e87492fab275c0f3cbe5894eb4c9b10f3856329c42c"
+    },
+    "sound/rm_carcosa/axe.wav": {
+     "bytes": 17474,
+     "sha256": "26a01b095ecfeb8d731b436c966b55947dede52b3d2d271eb213a63b562d233b"
+    },
+    "sound/rm_carcosa/baddoor.wav": {
+     "bytes": 4194,
+     "sha256": "9e4f6da93a65a2d134d96f748e2b143ad9bbec551aa6ce0c9130431b4fe3d8bb"
+    },
+    "sound/rm_carcosa/canopy.wav": {
+     "bytes": 75172,
+     "sha256": "7c771fd3c6bd735d3a7e7bfda9217ec1d09d76011a0c8c1efe42957a75df5a97"
+    },
+    "sound/rm_carcosa/chnswch8.wav": {
+     "bytes": 7452,
+     "sha256": "ad8557c3edabeae5dcbce4ac1dab74fa640efa5d1adeb7ba2e6d28422d50af32"
+    },
+    "sound/rm_carcosa/dsbdcls.wav": {
+     "bytes": 4208,
+     "sha256": "9c1553ca3ad8c8511151b5e0311fe028f06469e63181fa87c887b23418dbf167"
+    },
+    "sound/rm_carcosa/dsbdopn.wav": {
+     "bytes": 4194,
+     "sha256": "d6529bf62023070e1c60117497b613ac6b2a25f3ae9ed56e020e98a1b60a207a"
+    },
+    "sound/rm_carcosa/dsswtchn.wav": {
+     "bytes": 6268,
+     "sha256": "52ad7f46f457978e56753f74890336fb01148eb118c540819f10b67dca52191c"
+    },
+    "sound/rm_carcosa/flap.wav": {
+     "bytes": 1492,
+     "sha256": "90098aabe10cc4975733041794ab571a833e621a4525671898ce8ac95326a4f0"
+    },
+    "sound/rm_carcosa/fountain.wav": {
+     "bytes": 40472,
+     "sha256": "7364a33f42e22feeb22c428ad774f92e522f811f42fc7498ec84ad4deecffcca"
+    },
+    "sound/rm_carcosa/gear1.wav": {
+     "bytes": 220016,
+     "sha256": "f5f2a2f1b93bbb0ef52e7e26b7ab1840957fd71c1faeed7fe525ebd03605558d"
+    },
+    "sound/rm_carcosa/gear2.wav": {
+     "bytes": 200702,
+     "sha256": "c148a81c94f2008a7546805902599dc3fd6fff2871e4cce2b75f9cfa49b4a4d0"
+    },
+    "sound/rm_carcosa/gear3.wav": {
+     "bytes": 182804,
+     "sha256": "15bf9e08b4e88699dc42681a008cc82c9e7b83544649a65c74cbc574434fa7e9"
+    },
+    "sound/rm_carcosa/gkrokon/death.wav": {
+     "bytes": 22280,
+     "sha256": "b3409ce585af5f3424c4ba80e26e8ce254212831310278396435c4db3c404a47"
+    },
+    "sound/rm_carcosa/gkrokon/hit.wav": {
+     "bytes": 5636,
+     "sha256": "306b4dc4dac6f76938adc032603b5eb8c0644466c0d5087cf39da1fe07194b22"
+    },
+    "sound/rm_carcosa/gkrokon/idle.wav": {
+     "bytes": 17092,
+     "sha256": "8206ae086e797a74d6a9d3406428163d2483f7fa14e173e0722223d38e224db3"
+    },
+    "sound/rm_carcosa/gkrokon/jump.wav": {
+     "bytes": 17144,
+     "sha256": "0b9ee2f07f41643dd0e5d24707639b4f0f96f4231a7603f9ee6087f85d7a4074"
+    },
+    "sound/rm_carcosa/gkrokon/pain.wav": {
+     "bytes": 7900,
+     "sha256": "8ed1671f82bfafd5f8b56ec0960a5ce8f6bf679ee4882feb63c2f4b0187ea518"
+    },
+    "sound/rm_carcosa/gkrokon/sight.wav": {
+     "bytes": 18858,
+     "sha256": "9aa10bba819837f7d2249c07a68ff5823776643b8409e9f0568a667f573922c0"
+    },
+    "sound/rm_carcosa/glass.wav": {
+     "bytes": 31240,
+     "sha256": "d367db8cdc3a043fa615d8fd66952810060967050679628d57e7b9285b67c4ad"
+    },
+    "sound/rm_carcosa/knight.wav": {
+     "bytes": 89162,
+     "sha256": "3c2f8d67c7f47a9101fa76764a1d90de1439d804f5bad32da896ba4c24fd2e3e"
+    },
+    "sound/rm_carcosa/leafbrk.wav": {
+     "bytes": 18110,
+     "sha256": "a387703920ee5aa16aabc27a6721f28eaf5512cf1e4c276ba9e6cb6641fd4516"
+    },
+    "sound/rm_carcosa/lrkdeath1.wav": {
+     "bytes": 13776,
+     "sha256": "68f67f4865f5089fc4e82d33f16d20f2480baba0b8dff57fdf2e65f031b853a7"
+    },
+    "sound/rm_carcosa/lrkdeath2.wav": {
+     "bytes": 10350,
+     "sha256": "7829fcd2f195ca88479c03bba3985b2d5817da2807dee7d1a5b0fa3853f80eb4"
+    },
+    "sound/rm_carcosa/lrklight.wav": {
+     "bytes": 12466,
+     "sha256": "4bb9f27bde6ae6eeaf7ca138c1a5cb6ce40721dde0f7075d921f7d7f3ea19738"
+    },
+    "sound/rm_carcosa/lrkrearm.wav": {
+     "bytes": 16038,
+     "sha256": "29fd45187d36e63f47721fb1790abcf4cebcc7fcb1fe4e25858c5d333a448731"
+    },
+    "sound/rm_carcosa/lrkwoosh.wav": {
+     "bytes": 14752,
+     "sha256": "4094d3376657bbb31914b5eddb6c4d3950472772d1797ed6dd8ae1bc3856dbb8"
+    },
+    "sound/rm_carcosa/melt.wav": {
+     "bytes": 37872,
+     "sha256": "9fd07632bc872fc37df6ad5711c46bfb5b51c0cf47add0ffd77b5bc98306fdae"
+    },
+    "sound/rm_carcosa/mtlslide.wav": {
+     "bytes": 39292,
+     "sha256": "da1e3d92ae9c7ea9e1ac75553f5efa495b5c90e20093a4d4eeebddf2023c39df"
+    },
+    "sound/rm_carcosa/puzslv.wav": {
+     "bytes": 22308,
+     "sha256": "0eb28f48d1a8897803ace74968de7120c8765fa02d6c9c4d36ca001fa458c2b1"
+    },
+    "sound/rm_carcosa/rockfall.wav": {
+     "bytes": 24764,
+     "sha256": "db0910e1f2468508cd300b62cb367bcc8812edc30fc5b2435b41eb6a04a9f8b8"
+    },
+    "sound/rm_carcosa/sheep1.wav": {
+     "bytes": 19768,
+     "sha256": "8f0ffc73cc6a4c02ad409b942d329f6a581d3cee6551af2233473d4e9fa7a131"
+    },
+    "sound/rm_carcosa/sheep2.wav": {
+     "bytes": 18434,
+     "sha256": "10a2a1f8043eea5c1e6f3320dd614e6ddf7b57ab0843440d6b3a53e8136b13fa"
+    },
+    "sound/rm_carcosa/sheep3.wav": {
+     "bytes": 26744,
+     "sha256": "66c8d531d91694714c959be16e318148adecb813817ef080e2176d4630672a36"
+    },
+    "sound/rm_carcosa/sheepdth.wav": {
+     "bytes": 8136,
+     "sha256": "0f9f0cd9b58082a925a44192e97b74f99be719209da799b891f4a5e9d6d0a588"
+    },
+    "sound/rm_carcosa/squish.wav": {
+     "bytes": 22788,
+     "sha256": "2dc0726d0ba746d3b691371b2647ada0547382d73c439da01cf34b42f0ffac7d"
+    },
+    "sound/rm_carcosa/squish2.wav": {
+     "bytes": 22788,
+     "sha256": "1959b4d1c2d1e0cd39e09f49d3edbeab26297236c78a7789291b265014d9cae6"
+    },
+    "sound/rm_carcosa/stonslid.wav": {
+     "bytes": 22624,
+     "sha256": "966ab7ef302dd76e877c99985e0ebdcb1bd9c47929b435aae892590ba4ea97c7"
+    },
+    "sound/rm_carcosa/treefall.wav": {
+     "bytes": 130834,
+     "sha256": "2a48d13cde25b1617568118e1c21a903a8564f64df93e10989ec206c8e833810"
+    },
+    "sound/rm_carcosa/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/rm_carcosa/wdslid.wav": {
+     "bytes": 34202,
+     "sha256": "a87170e894ce358070b36e76aaeeacde3e7dd730465994603b6ac5c77404a026"
+    },
+    "sound/rm_carcosa/wheelstop.wav": {
+     "bytes": 6010,
+     "sha256": "e4495a0ee8d1c1eaafae1019be5ac2a77b28f58b0ea09c95bf32bc404f644797"
+    },
+    "sound/rm_carcosa/win.wav": {
+     "bytes": 55998,
+     "sha256": "cc66b90095b39f010538c0d693b6f7cc34ebe67d4f97d9406913195bcef57a90"
+    },
+    "sound/rm_carcosa/wswng.wav": {
+     "bytes": 34962,
+     "sha256": "2307633f2f9701eb962f6dabecdfe10e852a55860c962f0ef10d94bdc2057b1b"
+    },
+    "sound/rm_carcosa/wswngstop.wav": {
+     "bytes": 3518,
+     "sha256": "f3c79209f9358fc30dd08f1c286db256a158934d0b70c79c6c33ae74acda5743"
+    }
+   },
    "sha256": "cfdc64e025ef813b47d5825943abb4489b0851ed5eea79532c24a455f3da689e",
    "timestamp": "2023-07-14T23:28:12.000Z"
   },

--- a/json/by-sha256/34/349f5abb27c5497a5cc822b810b20525f28c232fc9b39a974c37ab7865b0875c.json
+++ b/json/by-sha256/34/349f5abb27c5497a5cc822b810b20525f28c232fc9b39a974c37ab7865b0875c.json
@@ -8,6 +8,284 @@
  "files": {
   "pak0.pak": {
    "bytes": 24381576,
+   "files": {
+    "demo1.dem": {
+     "bytes": 556562,
+     "sha256": "7099226bee4fe70f5e2fbaaaafa75ef6092f9cafd5aa4bc7f44e15e27f9e6429"
+    },
+    "demo2.dem": {
+     "bytes": 510621,
+     "sha256": "ea8c6ddbec3c757a1e263ce1bc0a330bec46f8d075816cd438a3046510aeb29e"
+    },
+    "demo3.dem": {
+     "bytes": 826695,
+     "sha256": "e0d4f8ff3f9a85ca0108bdf8eecad4e236a795e8b6b7f28a7110f8873584ed14"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "e50c993222f1d605c583364e761825f45de8b8f68a96af4c262340091eee54e5"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "b5dc6f4c0a0153eeff49821c04bd2074c9ff3956e06688f608437009f56ea0d3"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "5f7ee43ed2e411b59ef8399ce5b5d04df4a3051b5ed699ccdffa615d98c63ef0"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "89fef00df6f80ce1e79856e539c21a81e3f7933bc47f9f4c097e984e59e3f25e"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a6c048b0fc15280c27a76a4e2f443df70564e4947f02b921b3aed6bfd3f22fc6"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "96a41913264ac2fb1efeabeda1d0bf0ad01a06acc09bcd2a19441b235527fe8c"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "3d1aee28bd0828be7ee279a28db5eedd66df9eaf53af915388c6ec81af3dba58"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "9e703b8c44bb79bb95c0d1026971edf91773857989e08da9366c3a7f7af59754"
+    },
+    "maps/rub2m1.bsp": {
+     "bytes": 4840500,
+     "sha256": "229a4cc3a2cf621adea55fa64c15a783136856b077b1641d91a02113d330b667"
+    },
+    "maps/rub2m2.bsp": {
+     "bytes": 5796208,
+     "sha256": "471ce7f5a3a610bc2cd0d614af9638dc11cb5f0d9f0277e25affb0f438a30c3d"
+    },
+    "maps/rub2m3.bsp": {
+     "bytes": 6262700,
+     "sha256": "35aa8ad23825ab4ff973df76f5564a273a5f89bedeab8a8f9237679516a3e71a"
+    },
+    "maps/start.bsp": {
+     "bytes": 2452384,
+     "sha256": "ae82c3f103d364f70c840a7d68bb36fc2cab77c2f0b7916850babdc86dfae24b"
+    },
+    "progs.dat": {
+     "bytes": 514160,
+     "sha256": "a336c39333de50a761f29fad445d32c5a241a03ecd894426b7975a0566aada92"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 221936,
+     "sha256": "6e8e12db297f9f70cbe00fe2087be79a0011dc31344e642d8f309947e63cad8d"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/dread.mdl": {
+     "bytes": 183400,
+     "sha256": "efb1827edaced94142bb040b179cff11de98c097aab7fe13c80efadadc742314"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 35488,
+     "sha256": "4a04aaea3b65ef8be1e9ae5e2448bf5fcb530492241a739b689f7380ba509de5"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "sound/ambient/chatter.wav": {
+     "bytes": 190760,
+     "sha256": "59197f823b479c66c41163d82fed6dc13a715aef429b5e551ba80ca6f7c229fb"
+    },
+    "sound/ambient/comp.wav": {
+     "bytes": 12164,
+     "sha256": "ab8e3b13981bb432cca44ad4b7467734f52d01927018e72c99e7c4d052dc7874"
+    },
+    "sound/ambient/crickets.wav": {
+     "bytes": 12236,
+     "sha256": "d5cf6e56884a8e43469408d4788ec6e573167901586df259a938cd088c998ef9"
+    },
+    "sound/ambient/drone.wav": {
+     "bytes": 30902,
+     "sha256": "81993d96ab337f78c2778cecffe4767605fed210e0ac2303a46ac898979eea13"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/hum02.wav": {
+     "bytes": 37836,
+     "sha256": "8b2ee1b91fa663b6111de9251011142475831ece70ee091022b800b715f1bfa2"
+    },
+    "sound/ambient/intake.wav": {
+     "bytes": 25682,
+     "sha256": "e6d13169ce4680dd83903473897fd6e7ce1e51fab00c6df2127ea993321c05b0"
+    },
+    "sound/ambient/lonoise.wav": {
+     "bytes": 32876,
+     "sha256": "1e0f99ffadead8460a7a4bed1c6b2c16cddd70050e1524e9cdaf6724a9dc81b5"
+    },
+    "sound/ambient/motor1.wav": {
+     "bytes": 52340,
+     "sha256": "c48511a37143e9ed50ae7c1d1f28235b007762949d3d18549fc545cc670c0a24"
+    },
+    "sound/ambient/motor2.wav": {
+     "bytes": 52014,
+     "sha256": "7f36cda5c01aea4e6b356ae4d0b31b68ca15d7606eefd30f4739a64fc4e86e6c"
+    },
+    "sound/ambient/rain.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 4060,
+     "sha256": "3bab8fca9733e6c9f045e24f52ffbac401c757b1fe9f28fff967f21357bbadbc"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 11588,
+     "sha256": "8b9a0404fefb408219731ff264cb5490d1178a2ddd2afe02db4a5ddc6e427171"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 11966,
+     "sha256": "af1026fd9051e2c9c84f4eeffed454d7328969a29a2d11301464e383c6c809d8"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    }
+   },
    "sha256": "94e63081e259a3df453963a23f8c1cf833de92108418a1067b461e15a790df02",
    "timestamp": "2011-02-12T01:34:52.000Z"
   },

--- a/json/by-sha256/38/3817a3a4556a6484b6796d4f690c6d5f6ff0075264df43a98939b96616fae4e1.json
+++ b/json/by-sha256/38/3817a3a4556a6484b6796d4f690c6d5f6ff0075264df43a98939b96616fae4e1.json
@@ -42,6 +42,872 @@
   },
   "IMPEL/PAK0.PAK": {
    "bytes": 6925312,
+   "files": {
+    "end2.bin": {
+     "bytes": 4000,
+     "sha256": "6cd55fa44cc01e482ac5f565dc2d57f8e4ced22c3d92285af94156af27390d85"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "a176eac9afdd0102896a74342a12fc33bd55b399d3a66c57a6e1ba9e09b36dad"
+    },
+    "impel.cfg": {
+     "bytes": 784,
+     "sha256": "2516219f8a8a384321ecf0a4e1edaf0e8166c6da554c80524ecf4773e31ead78"
+    },
+    "progs/a_jugg.mdl": {
+     "bytes": 24324,
+     "sha256": "9981ee9b0d42bcddbbc157b66d4d6f8625c8ad88ce50ab176486f05c134ef1ce"
+    },
+    "progs/a_jugg2.mdl": {
+     "bytes": 9684,
+     "sha256": "87808db33bdfdf19ca8c3a7899d32e58dec361b55d53b6f47810804079dd4a5f"
+    },
+    "progs/bldfall.mdl": {
+     "bytes": 50033,
+     "sha256": "192f1ddc78149666c84e4707ef0df53c592c9ea9ab3866d9880b18b507bc9da6"
+    },
+    "progs/blpulse.mdl": {
+     "bytes": 9172,
+     "sha256": "b1246a72ad2d24161c4ec2332320e288ee907e26188a4988f753670b1c345176"
+    },
+    "progs/blud.mdl": {
+     "bytes": 195448,
+     "sha256": "009423d495ff2eee0d004493e856b1223fac7273e75110a4be212abb2d3ef155"
+    },
+    "progs/bone.mdl": {
+     "bytes": 11020,
+     "sha256": "7e7b8bbecacface06ee8df856b7c32eb69e92803b187215391e82f605d6fed41"
+    },
+    "progs/bone2.mdl": {
+     "bytes": 11020,
+     "sha256": "2ec5f7154bb525174bd76d32d81d41c3d54e00fe59963929ca601a2dcf792555"
+    },
+    "progs/claw.mdl": {
+     "bytes": 27928,
+     "sha256": "f3b3003b98a14cd95d76bd0b69385c7af62091354d5eab9cd2ebf498c8a46aa3"
+    },
+    "progs/dknight.mdl": {
+     "bytes": 296484,
+     "sha256": "e97af9ea1c422cc7396c1ec540f74b2c713e68494958e07d4c2994a78c83b493"
+    },
+    "progs/drop.spr": {
+     "bytes": 20616,
+     "sha256": "42ebc578749f1d39d3c854f69f133805bcca97178895daa02a3ffb3b289478e0"
+    },
+    "progs/fieldgen.mdl": {
+     "bytes": 31292,
+     "sha256": "287c8eb576b0451e5130a346f79ce1443b55cbaf21b0765bc22698fda87fb94a"
+    },
+    "progs/firesprk.mdl": {
+     "bytes": 5540,
+     "sha256": "7104c91881d1ad6a1c70391efa89d0a7ce3c83c1d0f4b31ec290961d21b450cd"
+    },
+    "progs/g_implr.mdl": {
+     "bytes": 46548,
+     "sha256": "10d1cb9298fbc2c477386a1588c46a595611eaeab9bd144c68464d8e03c294ec"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 35204,
+     "sha256": "7dd4636e61fd1056157a1c0a8e7a73d208307af971d0c578a6d398fcee476718"
+    },
+    "progs/g_tek.mdl": {
+     "bytes": 78328,
+     "sha256": "245724c5fd7dddf1fbe63fcd137fee0dc656f957a8babbd569efb774cb45984e"
+    },
+    "progs/glass.mdl": {
+     "bytes": 16668,
+     "sha256": "c7f5adc2d42ef6d8d2fd8f719d21a95b9f2e339b041cb3734d5ea20b089bcb04"
+    },
+    "progs/grenbone.mdl": {
+     "bytes": 11020,
+     "sha256": "8bacc01f22a1057bc150d611ec97379bf4670980c3c680859a4f1b29f39c5c85"
+    },
+    "progs/grenling.mdl": {
+     "bytes": 135248,
+     "sha256": "5085bdac53071f8086b9a577d623da03a311e8edc68f74cceef1b059eda56ec7"
+    },
+    "progs/h_dkni.mdl": {
+     "bytes": 7124,
+     "sha256": "5fcc7ae72c3655de5d04f5fbe2bc97bc0d6168568d1ca99ed029d614ef633ae8"
+    },
+    "progs/h_gren.mdl": {
+     "bytes": 7932,
+     "sha256": "159389bbe3220a95e67daeb3c306ae0ccaa4a2132c8007edc531b82cc049db89"
+    },
+    "progs/h_jugg.mdl": {
+     "bytes": 21500,
+     "sha256": "d2800f941f87f6ea9fe12333a95c02d610e057fca811e48f10af29cf4b715056"
+    },
+    "progs/h_jugg2.mdl": {
+     "bytes": 10068,
+     "sha256": "5a9b66665e8b545cf022c2de11574de22c08ad32ab384355c2b0bf373de0edee"
+    },
+    "progs/impaler.mdl": {
+     "bytes": 13908,
+     "sha256": "3e1fba2e8b9ec3dc8b7e2b639f7ece4d7d16602fbadbedc7f3a89f4b59b67d74"
+    },
+    "progs/impdef.mdl": {
+     "bytes": 8412,
+     "sha256": "eed4e07de5673ab2908df65103d9989925d17d7618bc5535c1f5b321d0106df2"
+    },
+    "progs/impstuck.mdl": {
+     "bytes": 8412,
+     "sha256": "eed4e07de5673ab2908df65103d9989925d17d7618bc5535c1f5b321d0106df2"
+    },
+    "progs/impwall.mdl": {
+     "bytes": 8412,
+     "sha256": "2be43ab4de557a047c2ce777f3fa16761ce5689b8f3f80f4a229441b95468838"
+    },
+    "progs/jugg.mdl": {
+     "bytes": 153424,
+     "sha256": "733d9aaeca490c950ae95796148a40d3185125ae0e06ab17db989210ccd6cf51"
+    },
+    "progs/jugg2.mdl": {
+     "bytes": 148580,
+     "sha256": "43147452aeddf8f61f0041f7fa2c12938075b4d210daf3109d832f4b00a40859"
+    },
+    "progs/leaf.mdl": {
+     "bytes": 4906,
+     "sha256": "c67352d651db2d7875daec7af98c09557b4cadb7cac5c34f00411a7d8306c6b2"
+    },
+    "progs/legond.mdl": {
+     "bytes": 284204,
+     "sha256": "97f3652900564db8ced331f1e658e3b5baf8dae7be6ccf7a12188a179ad5d331"
+    },
+    "progs/missile2.mdl": {
+     "bytes": 21268,
+     "sha256": "9e397f9621965798b8d60c83b20c1e376d5e4ea3ad23142cff026167b97d8b20"
+    },
+    "progs/nbomb.mdl": {
+     "bytes": 2244,
+     "sha256": "5846d9b0c34c394356babc1aca19d40c4a18a3162d509c06a82b23a77543bae2"
+    },
+    "progs/null.mdl": {
+     "bytes": 49352,
+     "sha256": "32ed314954414897780eda143225045f18f480be5fa52cef6b464f28c9df34fc"
+    },
+    "progs/onfire.mdl": {
+     "bytes": 64572,
+     "sha256": "0dfeb017d8e8c6ee99388617ade1fec822eea1b74c6ff9d7e771faa9fa575c0c"
+    },
+    "progs/onfire2.mdl": {
+     "bytes": 64572,
+     "sha256": "a8efa3ae675df00e82088bb0a8daa3dd91597c01418ecad61ed2a38a545e422a"
+    },
+    "progs/pulse.mdl": {
+     "bytes": 16384,
+     "sha256": "b3189cedf09e0a4fbce387cd7359f14e10605d0a7a3fdf811e15ba1d8385499b"
+    },
+    "progs/rain.spr": {
+     "bytes": 49248,
+     "sha256": "c6b46fed29279ef47f2e4126bdabe23cae042396a4a440f750582a53fa77fe50"
+    },
+    "progs/rawbone.mdl": {
+     "bytes": 61252,
+     "sha256": "f214f56660a091d2f212e99e7ddce6e0af8d3e4bc5343deae0e44cfb4143b3b7"
+    },
+    "progs/rawbone2.mdl": {
+     "bytes": 11020,
+     "sha256": "e3ab7247635061ea9fd72be4e5a96e5699ab74a76c47f195402f18e1fed8e99b"
+    },
+    "progs/rubble.mdl": {
+     "bytes": 404673,
+     "sha256": "3d5ca67fdf065a832559ac9f9a320268f2e179cf089104880624fdac6c51f7e5"
+    },
+    "progs/sglass.mdl": {
+     "bytes": 16668,
+     "sha256": "2ca84472fce770df62a263176a3af79fe4e9d72f90144e5982a52d5b6b82a9ec"
+    },
+    "progs/smlsnow.spr": {
+     "bytes": 65,
+     "sha256": "196075fa517123e0e1c9f61ca7781b1fa03f6ae47597b908145080db42b4f42d"
+    },
+    "progs/snow.spr": {
+     "bytes": 72,
+     "sha256": "17eb99d2ce6524da28d82c5aae7bdbfa9c645408b9ca047f7a829914b4e2cd21"
+    },
+    "progs/spawn.mdl": {
+     "bytes": 115444,
+     "sha256": "55dcca59cd544b2f1a2739344d4938ebc9344788e3070d0f6a503d5d641ec3d6"
+    },
+    "progs/spid.mdl": {
+     "bytes": 36608,
+     "sha256": "55daef0380d31d24524bc4a6faf9c402c1aeb2a448c6de94ebde377b5042c835"
+    },
+    "progs/spidgib.mdl": {
+     "bytes": 19976,
+     "sha256": "3e7201ece6fdd8ed5fc15e6b5aab7a52a671ae57e679f8ae89c1536bc42c1d66"
+    },
+    "progs/trapbar.mdl": {
+     "bytes": 19248,
+     "sha256": "787f237f54fbe2a02990d46a450a21671a69fbd95140e40240ab78f36df9a06e"
+    },
+    "progs/v_implr.mdl": {
+     "bytes": 49680,
+     "sha256": "80f84f0fd793723aeccd259551e552eadfd2ba349bc415aeb72e8d04d62fa055"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 83668,
+     "sha256": "0d6898afb61f5befa1b0ca4dd12ea809a9e877652fa33e43584480257c5d2179"
+    },
+    "progs/v_srock.mdl": {
+     "bytes": 58548,
+     "sha256": "329c7dba1195bd05c188cdc64be92f345e9f3aa237b1388ac9a7ea4605e8680f"
+    },
+    "progs/wing.mdl": {
+     "bytes": 78328,
+     "sha256": "245724c5fd7dddf1fbe63fcd137fee0dc656f957a8babbd569efb774cb45984e"
+    },
+    "progs/wlpulse.mdl": {
+     "bytes": 3604,
+     "sha256": "0fa5efc178b0636ab622368de5a006e2f956f0b06097f24e1df4d5b89d7d41bc"
+    },
+    "progs/xtragib.mdl": {
+     "bytes": 13780,
+     "sha256": "3b413fe8f4099d377af905d6be6ddd111a331f98e9bd4432a4113ec616f8f8dc"
+    },
+    "quake.rc": {
+     "bytes": 329,
+     "sha256": "a439be54db4140f9edbc3846b59dfd7aa92621cb300a0b63359fe8f9ca43d351"
+    },
+    "sound/ambience/pixels.wav": {
+     "bytes": 31912,
+     "sha256": "b9846a0b47140ff11975a3f966184b55a99d68c9d46acc1577f73b709276ec0f"
+    },
+    "sound/ambience/rain1.wav": {
+     "bytes": 734524,
+     "sha256": "cb4bd4af697c2b584323a2235a65cb048b34a121d9c47ca1da32ed648023b7d4"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 72062,
+     "sha256": "1fc3146d501953545b2f2f261cd2fc398959a79c753a291702609b4cdd2e8682"
+    },
+    "sound/enviro/physics/axecut1.wav": {
+     "bytes": 13290,
+     "sha256": "b0c2a384a203186474983cf1b3befb1749560db4a6015dd3e6c22cf1768d937b"
+    },
+    "sound/enviro/physics/axecut2.wav": {
+     "bytes": 8066,
+     "sha256": "3d31140e6627582816f01d320f0b67000acd1d8891606c35fd21e3e1c5238239"
+    },
+    "sound/enviro/physics/axemet1.wav": {
+     "bytes": 10066,
+     "sha256": "a50093dcad7a8ebbccbd37589dcf523311dbe236214c60b898875fe0180a3f0a"
+    },
+    "sound/enviro/physics/axemet2.wav": {
+     "bytes": 9306,
+     "sha256": "fc60fd4478c18afae1c8176285c50e7678bb5c82ee83c43c295a36aa2adcade1"
+    },
+    "sound/enviro/physics/axemet3.wav": {
+     "bytes": 12084,
+     "sha256": "4278a5848453b1492f55f3a304af74ca3d04535b26857a5869096767388a9ddd"
+    },
+    "sound/enviro/physics/bonexpl.wav": {
+     "bytes": 22612,
+     "sha256": "d85f33d4286e1b535cc0f6fc4fc5dd141908a75fd1c192dff945eeb4c7984dfd"
+    },
+    "sound/enviro/physics/flames1.wav": {
+     "bytes": 17468,
+     "sha256": "01b521d689b35395e40d9164e6818183718aa1fe08a33df6696fdf85a1c60af6"
+    },
+    "sound/enviro/physics/glass.wav": {
+     "bytes": 13592,
+     "sha256": "117c63e8a5aff0a268a53f1448c99e2811f94fa8942fdaaedce2a04f0075362d"
+    },
+    "sound/enviro/physics/glassbit.wav": {
+     "bytes": 6090,
+     "sha256": "46bbb74c5f975c1fcc575c47a69b60b5679a633c0f0229247d661b444d633e8b"
+    },
+    "sound/enviro/physics/piece1.wav": {
+     "bytes": 2212,
+     "sha256": "a8a5a474f7bb511b8e24c35490fab5fa51ad3321d1de0de3a6bf6bb725eadb3d"
+    },
+    "sound/enviro/physics/piece2.wav": {
+     "bytes": 1765,
+     "sha256": "52642c3f1499593adacffc132eafad548a5bd9704c5df8b2a0ff801903411dcd"
+    },
+    "sound/enviro/physics/piece3.wav": {
+     "bytes": 5657,
+     "sha256": "9dd34014a97889a000afd4b2a0c3c65f9aa3acc9f23bc0a1304af9dc03c3e1c8"
+    },
+    "sound/enviro/physics/pour.wav": {
+     "bytes": 7145,
+     "sha256": "1586f89c2018fa70a3abcd034697f9ac4b85bd0be473cf69a1196c4774ec35de"
+    },
+    "sound/enviro/physics/spill1.wav": {
+     "bytes": 2555,
+     "sha256": "6f49f02b9860baa41cc8506974526f5658cafc0639b8c11c48b7ff50876480d7"
+    },
+    "sound/enviro/physics/spill2.wav": {
+     "bytes": 8540,
+     "sha256": "5acb5fb925304f798f695bbeccfe5fdf5ffffdef00ef9b425091e416598d3d39"
+    },
+    "sound/enviro/physics/trcut.wav": {
+     "bytes": 9898,
+     "sha256": "88c0421cc54756512a4c929b96db6d5d8cb6ac998dc0df8eecc87a3bfd4fe2e7"
+    },
+    "sound/enviro/physics/trkild.wav": {
+     "bytes": 5106,
+     "sha256": "ef7a598607e18108e8805907d8b5c00bf5ad5443a1ed76bef885062cc9f2da31"
+    },
+    "sound/enviro/physics/trspin1.wav": {
+     "bytes": 11026,
+     "sha256": "8e88a4140a5ab0290fef306355e6cabf886ac2927bd35aa44b2263b203fc5b31"
+    },
+    "sound/enviro/physics/trspin2.wav": {
+     "bytes": 15414,
+     "sha256": "00964751612bd2931eca2937194ef4bb007bf3d0032392b5170b716c219f96c0"
+    },
+    "sound/enviro/physics/trstop.wav": {
+     "bytes": 23468,
+     "sha256": "714d0bcfdc127bfd21b3bd779e7ed911acf99fafb760cc2d8e3441547cdb073b"
+    },
+    "sound/enviro/physics/wallexpl.wav": {
+     "bytes": 16152,
+     "sha256": "4d82f44f89d8cd38dd54711b776c8db9975c78794e8e520468b8bd2c9f30d9ad"
+    },
+    "sound/enviro/pinhead/pinback.wav": {
+     "bytes": 2864,
+     "sha256": "db45513057257be6824c210e20dff4e3134669b0d1a9b60dcff333c262aee0c1"
+    },
+    "sound/enviro/pinhead/pindef.wav": {
+     "bytes": 1006,
+     "sha256": "7e9a82c272c09429b1633def7a94654fd9138cdb819552627c0bd1b9e8a6fba7"
+    },
+    "sound/enviro/pinhead/pinfire.wav": {
+     "bytes": 4630,
+     "sha256": "20b71f1a11267c53fa00770c0186ebfbcf3fd899075d3641b1161108a461113d"
+    },
+    "sound/enviro/pinhead/pinhit.wav": {
+     "bytes": 8752,
+     "sha256": "9c11f4b44a9811bb06bc13ac81c2a8506444ef91edc9268a82a675e322916575"
+    },
+    "sound/enviro/pinhead/pinpull.wav": {
+     "bytes": 2854,
+     "sha256": "792da21c0b6442fb3bdc54b470b34e7224977c288c6bb8119fc1b55f667076a7"
+    },
+    "sound/enviro/pinhead/pinrip.wav": {
+     "bytes": 2846,
+     "sha256": "8c8d69169437e5bd4665523839e259e900c0543ae30cdbc82da579a548a5acd0"
+    },
+    "sound/enviro/pinhead/pinsuck.wav": {
+     "bytes": 65074,
+     "sha256": "2a076267e5786fbf32126a98915c192a2a95f66f7b68193c089b982dc1c3a43a"
+    },
+    "sound/enviro/security/onalarm1.wav": {
+     "bytes": 36352,
+     "sha256": "058e0986a438aa0ad42a443f130e80a3eff59766f26a1473927eb28366108e4d"
+    },
+    "sound/enviro/security/onalarm2.wav": {
+     "bytes": 13906,
+     "sha256": "10711e5767aee48d0030a884089fb7d7f7702fa13775bf7b8d048fcba020103e"
+    },
+    "sound/enviro/security/onalarm3.wav": {
+     "bytes": 37030,
+     "sha256": "6391ee249d27a9bd65235d6667a597a7f371a8308a7710d23d74018188811d5f"
+    },
+    "sound/enviro/security/onalarm4.wav": {
+     "bytes": 72040,
+     "sha256": "9013094ddcaa6380efdb1f27cad7c6ba96be37262313634446ec5aa47fdf790d"
+    },
+    "sound/monsters/blud/blatt1.wav": {
+     "bytes": 7700,
+     "sha256": "dab9183f257868666920e92fa47a1391d8406a8f86b221a6350cfd09cae5b19a"
+    },
+    "sound/monsters/blud/blatt2.wav": {
+     "bytes": 9850,
+     "sha256": "87d1254d504e045864d567e7dad2af6f5773525122003e1d51bec70708b0424e"
+    },
+    "sound/monsters/blud/bldie.wav": {
+     "bytes": 172340,
+     "sha256": "1d2e3ad2ecdf67df2bf5106a870668ad36416b080424be8ae1f64fdc88b0fc17"
+    },
+    "sound/monsters/blud/blhurt1.wav": {
+     "bytes": 35720,
+     "sha256": "66b5f3952f129058c9710c1baea16d69f698d8de4f9ee91c80d05de9c2874bb4"
+    },
+    "sound/monsters/blud/blhurt2.wav": {
+     "bytes": 36774,
+     "sha256": "c905efedccda3e376e8cb267a6c4534a9dcffd07b44bbd5cac17f3ed306b63a6"
+    },
+    "sound/monsters/blud/blhurt3.wav": {
+     "bytes": 52042,
+     "sha256": "941f745d30607fb0bb02db2093401a6b4856dcb0de50fa1d21894027a4e5ef89"
+    },
+    "sound/monsters/blud/blidle1.wav": {
+     "bytes": 112046,
+     "sha256": "f74aab64eece6bd28d803589ce04547fdbf72d2d9c7c81304ac94cc89e748a8b"
+    },
+    "sound/monsters/blud/blidle2.wav": {
+     "bytes": 121402,
+     "sha256": "5c1443558ac033d927e05159923e7ab9db7605c4be791877b81ae7f019c589d2"
+    },
+    "sound/monsters/blud/blidle3.wav": {
+     "bytes": 34556,
+     "sha256": "af9e0c2922e73d81ed916783469356217f6e8481cdb2ab2946ba0ac5c4875b77"
+    },
+    "sound/monsters/blud/blidle4.wav": {
+     "bytes": 165498,
+     "sha256": "5f665a060ac0b4cf95fedb906ff52c72a27f22c92959e613510c8b75b9142c6f"
+    },
+    "sound/monsters/blud/blood.wav": {
+     "bytes": 7368,
+     "sha256": "274ddc2d095dcaab9f6d2ed66107222fff449d4b6f883b60d9d728bcee8fc602"
+    },
+    "sound/monsters/blud/blsight.wav": {
+     "bytes": 123232,
+     "sha256": "0ab1ae250459fd195a3599c4236d1d598c1d72f3bdd72851e376cb20bf158611"
+    },
+    "sound/monsters/dknight/dkdeath1.wav": {
+     "bytes": 18570,
+     "sha256": "6cf6030562a3ef8cc171276e9af019f21e48e99d458eb8a5e747f9ac7237e4f4"
+    },
+    "sound/monsters/dknight/dkdeath2.wav": {
+     "bytes": 22046,
+     "sha256": "0689505dd36dec8dfebcfdf0e98e77f876768af306d1813ff3411d508b60d647"
+    },
+    "sound/monsters/dknight/dkhurt1.wav": {
+     "bytes": 11384,
+     "sha256": "26d134b269770be1fbbe5d3d2f796a4143e7c72899adf4f94b4ce1528228f6a0"
+    },
+    "sound/monsters/dknight/dkhurt2.wav": {
+     "bytes": 9068,
+     "sha256": "e595e93b464de6480550536e01f96598739c03b88b4803eebacab8bec3beaf0c"
+    },
+    "sound/monsters/dknight/dkidle1.wav": {
+     "bytes": 12714,
+     "sha256": "d57942e7f48d575fa2f64430c50dc2cd23cbba60cfc70298868ac0c8f6a6d5fb"
+    },
+    "sound/monsters/dknight/dkidle2.wav": {
+     "bytes": 13994,
+     "sha256": "6fb8746ebeea7db1a5f812b3e978d3545614a4e146db0226c36c73fc5f8d8fc1"
+    },
+    "sound/monsters/dknight/dkidle3.wav": {
+     "bytes": 46708,
+     "sha256": "e4769e804725bd53b624de676ededaa679584c56b19cb83b41973982881ab7e4"
+    },
+    "sound/monsters/dknight/dklight.wav": {
+     "bytes": 5292,
+     "sha256": "c35a3f6f2fcca7ec06f00f0c556bd24c82fe709b6e3cd05f900e71815c493cef"
+    },
+    "sound/monsters/dknight/dksight1.wav": {
+     "bytes": 17584,
+     "sha256": "a973846938a0b08b493580423d6aec9d18f33131a9ce5c22812fbe2bf9bc684d"
+    },
+    "sound/monsters/dknight/dksight2.wav": {
+     "bytes": 8810,
+     "sha256": "3893441fd1b6213fec472fd3a1ab7fe5af841278ab1d1fbc54f098173ec623bf"
+    },
+    "sound/monsters/dknight/dksight3.wav": {
+     "bytes": 15196,
+     "sha256": "ce2ffc589f53144e7770cfcd33d9a54f9ed70d132d2eaa75caa94c76b792bff5"
+    },
+    "sound/monsters/dknight/dkswzap1.wav": {
+     "bytes": 6052,
+     "sha256": "d328d01b075015cefd39ca46d29212667736f1b33aa707e61c868101e5b4ea1c"
+    },
+    "sound/monsters/dknight/dkswzap2.wav": {
+     "bytes": 5552,
+     "sha256": "14f1fe73d01ed5fd4f446937ae25fbd6d54e438d91d336e73a7b8b982d274efb"
+    },
+    "sound/monsters/dknight/dkzap.wav": {
+     "bytes": 6974,
+     "sha256": "bf5f8f2f93ef167b5f0f70c7063525eb538ea434d714d807c812a8fb7712c021"
+    },
+    "sound/monsters/grenling/grcoon.wav": {
+     "bytes": 89860,
+     "sha256": "4a76bfb25743d747b4546a3d0b7efa2678a9d06b9f298d21ff140f8f05450198"
+    },
+    "sound/monsters/grenling/grcut.wav": {
+     "bytes": 5374,
+     "sha256": "48da55e5b7d36d0cc96abed51017c1a4ee9cd25a55cfb532658f3e556c8171d9"
+    },
+    "sound/monsters/grenling/grdie1.wav": {
+     "bytes": 9822,
+     "sha256": "f9be6d41c5d66c13daeec34d5af464bde349f6993417dc1839563dab01bb15f5"
+    },
+    "sound/monsters/grenling/grdie2.wav": {
+     "bytes": 8694,
+     "sha256": "a8ba47fcbe9e60521f74828aec71a88df63db2c88c2365e791478bde29c29488"
+    },
+    "sound/monsters/grenling/grhover.wav": {
+     "bytes": 69396,
+     "sha256": "4af8fef34d8506e6fc9721e835a81ca7a20d6141b9b703b1a4b471d574b412bb"
+    },
+    "sound/monsters/grenling/grpain1.wav": {
+     "bytes": 15106,
+     "sha256": "dda4267078d6b233324951eb9e6e44686d5e8536fb4303a2009d01b113051a95"
+    },
+    "sound/monsters/grenling/grpain2.wav": {
+     "bytes": 8734,
+     "sha256": "205d0d3adcc652fe35701de96eda7c9f8f2a3ec23782aef6bdaf2c08192a06ef"
+    },
+    "sound/monsters/grenling/grsight1.wav": {
+     "bytes": 20054,
+     "sha256": "861710b36a948a22d7d7f8e57b9e6b0d7e5241a1f62a6f43f01f8bcea69bb90c"
+    },
+    "sound/monsters/grenling/grsight2.wav": {
+     "bytes": 23428,
+     "sha256": "61a65a594b2add0f152d804f8f12a6c06c55f1f18d3b97dd2b8188bca27c7ba9"
+    },
+    "sound/monsters/grenling/grswipe.wav": {
+     "bytes": 2174,
+     "sha256": "a0a7a794af2f8fe4d1167531a2965873ebed67737399cd2d512a93383802b74a"
+    },
+    "sound/monsters/grenling/grtalk1.wav": {
+     "bytes": 4180,
+     "sha256": "bf2a1b0f53f76837b01239ecf03751fc38330a2905826798752e4ddea7af00ab"
+    },
+    "sound/monsters/grenling/grtalk2.wav": {
+     "bytes": 4180,
+     "sha256": "868d9681b961c7957012f8bc359685e0c05c395838ed5870784f861b83253803"
+    },
+    "sound/monsters/juggers/jbent.wav": {
+     "bytes": 7036,
+     "sha256": "18da56b750203a2a61a3fc0297b9dafb1b8fb1f4a120b5589d060005013d6275"
+    },
+    "sound/monsters/juggers/jfalls.wav": {
+     "bytes": 25754,
+     "sha256": "a399115538d013cfaf2e802dc5e85e2a9bea0afe5bd5a02e93065e89702d2900"
+    },
+    "sound/monsters/juggers/jgib.wav": {
+     "bytes": 22124,
+     "sha256": "e11d5c8785e0c792803ca1bcc2a57a75b8cd6d11407f55bace002bfcf533077a"
+    },
+    "sound/monsters/juggers/jhydro1.wav": {
+     "bytes": 7626,
+     "sha256": "dda0b1a06528bda40e43242e156c6b2e509d0c0219b8e2a2e6ae5aed89bf91cc"
+    },
+    "sound/monsters/juggers/jhydro2.wav": {
+     "bytes": 25030,
+     "sha256": "4dd294c650d8cb6367baca7bc27148c9fb6373c2b385562991ef0afd6b577319"
+    },
+    "sound/monsters/juggers/jhydro3.wav": {
+     "bytes": 16564,
+     "sha256": "3fe3d988825febff0de671aa46d620147a0f6132f6f42ec4f96027173b6e1fdf"
+    },
+    "sound/monsters/juggers/jidle.wav": {
+     "bytes": 44068,
+     "sha256": "f728abafff13693a0650fc03a6abdef6b48818b453d00f316c6917f3965939d9"
+    },
+    "sound/monsters/juggers/jlocked.wav": {
+     "bytes": 3948,
+     "sha256": "9b996407fb4d1d96b76643765a298489aea77eeede938313b9cd591722563970"
+    },
+    "sound/monsters/juggers/jshort1.wav": {
+     "bytes": 8778,
+     "sha256": "030e809d08562b4fa21c1dc7270504ef4a4b3d582d8c4598259755873096d19c"
+    },
+    "sound/monsters/juggers/jshort2.wav": {
+     "bytes": 11870,
+     "sha256": "4dd5f5cca2e729eef666e290a2ffcc6942602be60fd28b483696a206e9d7090c"
+    },
+    "sound/monsters/juggers/jshort3.wav": {
+     "bytes": 8962,
+     "sha256": "9f691551c7adaada28d27a63776bc0c11c9c4c952a48e40193e7ff4018ca85b8"
+    },
+    "sound/monsters/juggers/jshort4.wav": {
+     "bytes": 10338,
+     "sha256": "3fd4b07b2d8616e2b82c9a16f48f91dd1f46589f4cfe3d898b7bc9af38d84ca1"
+    },
+    "sound/monsters/juggers/jshot.wav": {
+     "bytes": 2004,
+     "sha256": "81a5a21ea9ddaf51cc67062a2db70a3b09093194f9fe4870f52fe49e5926ad46"
+    },
+    "sound/monsters/juggers/jstep1.wav": {
+     "bytes": 8042,
+     "sha256": "a0093642fa03a403171c04362717a164687fd1172f2c9ff02cc46fef1bd9e4b0"
+    },
+    "sound/monsters/juggers/jstep2.wav": {
+     "bytes": 8828,
+     "sha256": "6fb3d5d205d3ccb6f0d89cde0253bc491ba2df7a711ffcea613f7736aa6fed4e"
+    },
+    "sound/monsters/juggers/jstep3.wav": {
+     "bytes": 7354,
+     "sha256": "8575b89812f6b238149b054b2e755236e9f36c1d8e84b2356fd83d75454e30ef"
+    },
+    "sound/monsters/juggers/jswipe1.wav": {
+     "bytes": 2742,
+     "sha256": "d0f5082a2d40372e9c5f101699c8087daee5dd1fbe1287d025cfb6051ce20a48"
+    },
+    "sound/monsters/juggers/jswipe2.wav": {
+     "bytes": 3208,
+     "sha256": "544f22587d0b866dcc33964814bb70703c8eceb4c68302cd02d95b9a805caa98"
+    },
+    "sound/monsters/juggers/jswipe3.wav": {
+     "bytes": 2218,
+     "sha256": "8c2c0ffb45efa98780f69a2e9fd5d48a204e0b0e6caa79619fd9a888348aa246"
+    },
+    "sound/monsters/juggers/jwhap1.wav": {
+     "bytes": 15690,
+     "sha256": "f31ad559ced2013b53e7e1562995f47be4cc5c701bf3720e2a1ec9826f3b7cc3"
+    },
+    "sound/monsters/juggers/jwhap2.wav": {
+     "bytes": 14486,
+     "sha256": "e7d433c6ec0c7773f0085a55dd5fa404a8eaa31ff5345c9ac459f216af2e786c"
+    },
+    "sound/monsters/juggers/jwhap3.wav": {
+     "bytes": 18824,
+     "sha256": "4c5fda7dc457490807752cd883df0cdbfd95cf362e5549c9e7f6a0f57f504bde"
+    },
+    "sound/monsters/juggers/jwhir.wav": {
+     "bytes": 11110,
+     "sha256": "9fcccd411b11f0e08c1074de056509e60cd2bfdd67d3f325168b542478f94371"
+    },
+    "sound/monsters/legond/ldeath.wav": {
+     "bytes": 23238,
+     "sha256": "1a49cdac45f13eb550488ea4638623888566058abf927835cd3a8e0481fbc584"
+    },
+    "sound/monsters/legond/legond.wav": {
+     "bytes": 12278,
+     "sha256": "e12b382237afe48bb809dd48419c5d5c4bc85ab5ba0f7b63e78616fe6745d43f"
+    },
+    "sound/monsters/legond/legsmak.wav": {
+     "bytes": 8044,
+     "sha256": "f27b7fb95c4c8ec585b5701abf987833231652d23f7d2de1e10c112471713ef3"
+    },
+    "sound/monsters/legond/lidle.wav": {
+     "bytes": 41172,
+     "sha256": "636f97b4151277b04207eea96858a66a4fd50edfbf998bbaaf99c8c33e6e115e"
+    },
+    "sound/monsters/legond/lpain1.wav": {
+     "bytes": 13176,
+     "sha256": "9db4abf9a563c4b8a15de849ad9a24dc8493272c9134bbe3e1c4fe42aba55d79"
+    },
+    "sound/monsters/legond/lpain2.wav": {
+     "bytes": 21160,
+     "sha256": "df82e5fa6a94d695866e85610b422b74cb4277ee07340a86a38508f8ee4cc072"
+    },
+    "sound/monsters/legond/lpull.wav": {
+     "bytes": 9364,
+     "sha256": "97029a0fd3f4dcef919fb7a6f16b249689d5dd64d8fde99b3523e37524f12434"
+    },
+    "sound/monsters/legond/lshot.wav": {
+     "bytes": 9826,
+     "sha256": "c29f388f451a29f8edaa057b2934697b13eee6ca8c6aa8ef015603392765dbb6"
+    },
+    "sound/monsters/legond/lswipe.wav": {
+     "bytes": 2742,
+     "sha256": "ad883989af828760a92eeb46e7620d7037a67ca7a3ee083c7380bbd976534277"
+    },
+    "sound/monsters/lenforce/ledeath1.wav": {
+     "bytes": 9300,
+     "sha256": "494eafdf40767f0416ef19fc945c716b57aace7b758b06689644ba6313ad0a02"
+    },
+    "sound/monsters/lenforce/ledeath2.wav": {
+     "bytes": 9678,
+     "sha256": "0e20a15d7fbca887bb0aa06efc09b557a46b845ac93337fa3781287f005dfe94"
+    },
+    "sound/monsters/lenforce/leidle1.wav": {
+     "bytes": 15272,
+     "sha256": "2c2258506622c8a5686aa996c554979dea9acd06c57d7579dfbfb0b6308f8301"
+    },
+    "sound/monsters/lenforce/lepain1.wav": {
+     "bytes": 7734,
+     "sha256": "eb110fdc81e8a16c56400d40063617d7668ce4f967f6730ee4513e7984b132c8"
+    },
+    "sound/monsters/lenforce/lepain2.wav": {
+     "bytes": 6568,
+     "sha256": "14486a46963b579dcb297d2320d80aa7389133eab5755aae171a5bb4d42849f3"
+    },
+    "sound/monsters/lenforce/lepain3.wav": {
+     "bytes": 7238,
+     "sha256": "a87ba387d95f31e4607db8a197679f19e2f6a53be4a50a9a45e1118ec6fbbcbf"
+    },
+    "sound/monsters/lenforce/lepain4.wav": {
+     "bytes": 6610,
+     "sha256": "d3c50cb87cfc3ec3851e6b3102df48ee2008b305ac207cf441bcf4a28762d892"
+    },
+    "sound/monsters/lenforce/lesight1.wav": {
+     "bytes": 8828,
+     "sha256": "54e97def9f7defb6df4d874e4ac97d3514ff484d771d1fd08255fa7c593ba1d5"
+    },
+    "sound/monsters/lenforce/lesight2.wav": {
+     "bytes": 11112,
+     "sha256": "f356fa732b35b41fc41a2648b3212c248b13bcc432d36c40be2cccbe8271fe8e"
+    },
+    "sound/monsters/lenforce/lesight3.wav": {
+     "bytes": 12890,
+     "sha256": "8a2863c33fe03ee5ceca3b9ebb30616ac1fa99bb3b80e8dc3b7bec634925a664"
+    },
+    "sound/monsters/lenforce/lesight4.wav": {
+     "bytes": 11758,
+     "sha256": "15ecd70f5f40458100e58aec72b073f1597170e865fc22220bc51a77212ed73e"
+    },
+    "sound/monsters/spider/sactiv.wav": {
+     "bytes": 17066,
+     "sha256": "f21587ba9bfd159e48c5b3aa1c6e94eac7157053e4e5699459233fb28c2631c8"
+    },
+    "sound/monsters/spider/swalk.wav": {
+     "bytes": 12636,
+     "sha256": "5534fe1b11fea5406aada214681dba031ec4a01e4b660c405b679131ba07a7cc"
+    },
+    "sound/player/udeath.wav": {
+     "bytes": 8344,
+     "sha256": "2cbdbdde1bf9947ab483eea4706eebf10beb3b453a40c391739c80520c158b7a"
+    },
+    "sound/player/walk1.wav": {
+     "bytes": 5370,
+     "sha256": "d32cc1a61835811cef96e55093f6f749516a174486acdaceb7a5f632f250c637"
+    },
+    "sound/player/walk2.wav": {
+     "bytes": 5292,
+     "sha256": "36b9d7c760f594048a485e19c65f69ce879049a8cc32284a974a3f459e3eb29e"
+    },
+    "sound/player/walk3.wav": {
+     "bytes": 7172,
+     "sha256": "c5d97509db895b36f26ccde12b0beabebe4452e526652c9491703a64029f911e"
+    },
+    "sound/player/walk4.wav": {
+     "bytes": 6412,
+     "sha256": "40b7120a15bd5a4d1c0fc193f7977480c85135290472ceb5bae6707bd22627e3"
+    },
+    "sound/player/walk5.wav": {
+     "bytes": 5292,
+     "sha256": "81ca083ec581a71cfbf76d23833f416ff5306e32b9e2545d813ef1ce7f9e554c"
+    },
+    "sound/player/walk6.wav": {
+     "bytes": 5370,
+     "sha256": "62a1d6e6fee82628fcff12313e0bbc1a234c1e69aaf904b30c1fa44a582ef975"
+    },
+    "sound/player/walkh2o1.wav": {
+     "bytes": 12942,
+     "sha256": "ed69778ffced6f407f615fb9e5ffc84bdf1179f7b7079c19c713b7def8862cb8"
+    },
+    "sound/player/walkh2o2.wav": {
+     "bytes": 10456,
+     "sha256": "2c168e45eee16b1a4bb5c7752807fc399ddfd0c0bae5f6333f5426713c207d9c"
+    },
+    "sound/weapons/field/genactiv.wav": {
+     "bytes": 111908,
+     "sha256": "cc9f8d78ca458f1b5bc0d1454fc80ff84f505ea81dc5307cf41219b0d2123272"
+    },
+    "sound/weapons/field/genhit1.wav": {
+     "bytes": 55432,
+     "sha256": "a701c7366dfa6fcb12bb66e6a5769e1374cba8fe914f0ce592b99ddb71726024"
+    },
+    "sound/weapons/field/genhit2.wav": {
+     "bytes": 55394,
+     "sha256": "20cb5ffccef9b9a69e87bc55b4e3cc1d9cc7a91e94bfc0d913b243089902cfc2"
+    },
+    "sound/weapons/field/genhit3.wav": {
+     "bytes": 55394,
+     "sha256": "82a5487b8405a7d398e530ad0f542d314162977f6e50897cedba92a578252317"
+    },
+    "sound/weapons/field/genlev.wav": {
+     "bytes": 42428,
+     "sha256": "898350003a595d7f15f03b8f49368c500ccc78a862e22b29e78ad0f0185ef018"
+    },
+    "sound/weapons/field/genpulse.wav": {
+     "bytes": 22242,
+     "sha256": "f750a55838ee094bcd48997cbd4112840cb19ddbc61c6a66930c5bf21131bd11"
+    },
+    "sound/weapons/field/genstop.wav": {
+     "bytes": 45692,
+     "sha256": "6e46e650e04cf54e4fdad231fc32380d7b991828cc3da4fce32ba491ea5b9e80"
+    },
+    "sound/weapons/impaler/impale.wav": {
+     "bytes": 8356,
+     "sha256": "515240b3eeb19b134abbdc9ae2e7073199dbe8bb5bc37907055e23ca93f25a08"
+    },
+    "sound/weapons/impaler/impdef1.wav": {
+     "bytes": 5046,
+     "sha256": "b513f636bb843a52a400c4c2839dc76e658351efc442138d71de0d30677eebec"
+    },
+    "sound/weapons/impaler/impdef2.wav": {
+     "bytes": 3638,
+     "sha256": "9978beeea45f0831c470869774eeeb657a8df1aba996483a0b18189f56d0cbbf"
+    },
+    "sound/weapons/impaler/impdef3.wav": {
+     "bytes": 4666,
+     "sha256": "c5a961bef24c8b455c782846f770c2722399d4196756ebaaf37e9f31537b604b"
+    },
+    "sound/weapons/impaler/impex.wav": {
+     "bytes": 21058,
+     "sha256": "cd6c593a62fa55f612ef8c8b604d1ad86f210d62604218bf68b08e635afe1de5"
+    },
+    "sound/weapons/impaler/impfire.wav": {
+     "bytes": 11242,
+     "sha256": "5f233c667f23e9dfb0c0daed70220a51ac54d28094b26de25cbc91aa275c82fc"
+    },
+    "sound/weapons/impaler/impload.wav": {
+     "bytes": 6086,
+     "sha256": "e5647b73763060a598b09ca3a81bb3185bb731e9c02a863f93007242a4f8b095"
+    },
+    "sound/weapons/impaler/impwall.wav": {
+     "bytes": 4288,
+     "sha256": "708ad7ed4c1c7fae2be8dd5c0c63d4185c21132381b970178c5d5f250438e040"
+    },
+    "sound/weapons/impaler/mimpale.wav": {
+     "bytes": 19146,
+     "sha256": "b09115d52047d2d0e82fc6d31b79e58e739a7c670f2ed645265adaf69b9305ac"
+    },
+    "sound/weapons/impaler/pimpale.wav": {
+     "bytes": 14278,
+     "sha256": "f57630db6ed2aa61021ecd576a5c80baf50f96728a8698acbdf9f4cdc14a3e1b"
+    },
+    "sound/weapons/impaler/shaft1.wav": {
+     "bytes": 6202,
+     "sha256": "7bafc32155421b6e3189e922847ebfca2f79b06ac209b0c8e1c172810910b32d"
+    },
+    "sound/weapons/impaler/shaft2.wav": {
+     "bytes": 7086,
+     "sha256": "ae10f080450de9522638f5dcd6496eb4ee466b6eabc3dfff3c164a1ee7c10c60"
+    },
+    "sound/weapons/impaler/shaft3.wav": {
+     "bytes": 7304,
+     "sha256": "fef252e48eb84586bba69c6e6160b49c6bb0c0e65a3afbc9975adbeb79c9ca98"
+    },
+    "sound/weapons/light2/lgdis1.wav": {
+     "bytes": 10138,
+     "sha256": "63c65c3e1c0477d9231ab2a9d7f149e1de011514d5660c303c1197d05ca965bd"
+    },
+    "sound/weapons/light2/lgdis2.wav": {
+     "bytes": 10138,
+     "sha256": "443d67a4d6c59932282903564dbe765921d788a17d92626e2a73880cd0a0ca97"
+    },
+    "sound/weapons/light2/lgdis3.wav": {
+     "bytes": 10138,
+     "sha256": "730a8d976d7b68d40eda41e5c098ff9ad81bab6050f2a277a21a541436f4552d"
+    },
+    "sound/weapons/light2/lghit.wav": {
+     "bytes": 7144,
+     "sha256": "f4c2c797710b5551fb674f4003f093a33608a6d306a7559edb5eb5050988e950"
+    },
+    "sound/weapons/light2/lghit2.wav": {
+     "bytes": 10952,
+     "sha256": "a89cf8040b80c1a64fa34fa863177056d536fc27a4ac69020abcf3e50618aee8"
+    },
+    "sound/weapons/light2/lgstart1.wav": {
+     "bytes": 9320,
+     "sha256": "e2a018101f5ddad1066c0c08b9d24fc746e09db0adf5dadbbcc76d1f6209ccbe"
+    },
+    "sound/weapons/light2/lgstart2.wav": {
+     "bytes": 9204,
+     "sha256": "c97ee4a0e25f706765f303b7f15288d295c5d86a9347502a31d889e396fd6f3a"
+    },
+    "sound/weapons/light2/lgstart3.wav": {
+     "bytes": 8854,
+     "sha256": "7ef201bdad1f01548f7a2a33ea930f233c55b81ad5e729b3f6b8d6f83b118053"
+    },
+    "sound/weapons/light2/lhit2.wav": {
+     "bytes": 8246,
+     "sha256": "42ab314a82b9e5ed97bbf533facae7c88ada3d93d1eebdab2773b60a2c8d420d"
+    },
+    "sound/weapons/pulse/install.wav": {
+     "bytes": 29366,
+     "sha256": "c01770c0abe52f40a56397ac0fdefe9865b3964a0689f5caf98f2bb47317a1bd"
+    },
+    "sound/weapons/pulse/pulshot1.wav": {
+     "bytes": 7790,
+     "sha256": "1e75d4640e22a05348da3e2bdae4005d768f17e7b51b46146d4ffd00fcaa8bda"
+    },
+    "sound/weapons/pulse/pulshot2.wav": {
+     "bytes": 3664,
+     "sha256": "b357e923e1aff657c40f7fc4a0e71ac3d536c474ffd7d89decceb19bfabb8248"
+    }
+   },
    "sha256": "95452343ae69a50730630bc7189b639608cd0ff21ebff3e421deb4fa821509ed",
    "timestamp": "1998-05-08T03:48:18.000Z"
   },

--- a/json/by-sha256/38/38a2e239203f132b7031b13553a688d1c1e5ee01437aa444ed6de9d03737989b.json
+++ b/json/by-sha256/38/38a2e239203f132b7031b13553a688d1c1e5ee01437aa444ed6de9d03737989b.json
@@ -13,6 +13,112 @@
   },
   "Pak0.PAK": {
    "bytes": 5461674,
+   "files": {
+    "maps/final.bsp": {
+     "bytes": 1043660,
+     "sha256": "3156c2ddbd51d7d741c41772c007ea444a940ea6a12269c7a569c5910af267cc"
+    },
+    "maps/start.bsp": {
+     "bytes": 505592,
+     "sha256": "a53b94c8bf9a20b8a46cd99507987fb693b00b38981eb6c200783a0f2a20325e"
+    },
+    "maps/temple.bsp": {
+     "bytes": 1954836,
+     "sha256": "b2691f7c7367bd09bd2e43191fa4b6a85b88333b3f961676bad88a5781bb854f"
+    },
+    "progs.dat": {
+     "bytes": 658616,
+     "sha256": "0d43e4f0eb26855ce79fff4b5e1dae752b186ac3fe867b2d7bc5cdfafe87a975"
+    },
+    "progs/draco.mdl": {
+     "bytes": 304349,
+     "sha256": "806bdcd54dbba90f571a3f6207100f5494f6469d3ba038430233fc4d97842bc8"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 301816,
+     "sha256": "b5c3af1c5329aa0445a2aa5fe9315f07f4643ad93a860b2f3dc3ec0e958d553e"
+    },
+    "progs/dragon2.mdl": {
+     "bytes": 301816,
+     "sha256": "52b92800f35c1c99e8205b16f7e12707b9ec0ba87d0894d25950c4b113a088c9"
+    },
+    "progs/lwing.mdl": {
+     "bytes": 41603,
+     "sha256": "8febff0f7d189e0bb3d152dc6f0a1a78a0276507f3acba6b3ce71128ee42c160"
+    },
+    "progs/rwing.mdl": {
+     "bytes": 47243,
+     "sha256": "c88795a8e84e3ac2c00b73bef573177e34b0c3bd3b1b6680bb8c2db4237769fa"
+    },
+    "progs/tail.mdl": {
+     "bytes": 12811,
+     "sha256": "b50f08fdb0513f68a62251cede6184f6250f34832f9fdfea9d65bbfdbff2eccd"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambient/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 16944,
+     "sha256": "0fe255bd36c64acf75a53b97851b995517e70468b3818ff0ccecc4c7be5fc055"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/idlefly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/niteact.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/dragon/niteact2.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/dragon/niteact3.wav": {
+     "bytes": 17021,
+     "sha256": "577923d423f85a510a6700530325c4cf16861a39bf923e6747958de77c036578"
+    },
+    "sound/dragon/nitepain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 13848,
+     "sha256": "e71858c4de3e9ddcad1cba4ec0a6f5ec437b06c813b263ec73f853846d15a984"
+    },
+    "sound/dragon/sight.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/spike.wav": {
+     "bytes": 14990,
+     "sha256": "6aec96fda55dfb0120f106064cd324ea6e059bab3fdbb2d81cda297f9a82e02b"
+    },
+    "sound/dragon/spit.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/thunder.wav": {
+     "bytes": 14764,
+     "sha256": "b30e18bbc0a12db2032fa95d5d0504ea63eaa13b3bea34e3b42ec59f3ca4d815"
+    }
+   },
    "sha256": "0a506e76eb3d1296cfd7e1b48903f12e5bf4c7c25a01df8eda1c29bc1573cf57",
    "timestamp": "1998-01-28T09:24:10.000Z"
   }

--- a/json/by-sha256/38/38cad504bc80f89e06e8d9806a3a516fd2184de7bdfa48fd559876023bf79be2.json
+++ b/json/by-sha256/38/38cad504bc80f89e06e8d9806a3a516fd2184de7bdfa48fd559876023bf79be2.json
@@ -13,6 +13,712 @@
   },
   "pak0.pak": {
    "bytes": 38287270,
+   "files": {
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "b941e3ec692b990d1dbe0fd69c1e043b9d504374d791c8c981cb091324072826"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4424,
+     "sha256": "b4554a7ef6de5831198626fef9431582d3c17ed56c55853f1ce979be31df8dcd"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "e6719338f5c157030d8f4bdaa17bceff83e0598aa333755850466f234d26cf32"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6728,
+     "sha256": "badb0301e2e6b7f63940bd470dcf291d316d6eaa3d65b4349f5fef68459ce0b2"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "00690bf839f53105ef38f14df7b4c5a8acca850953e22949cf42a03eec665c13"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "d3858bbf343ba400a04d0bf74212313a8db6ad814d19d25c8120517e9183def3"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "211684f57053757de69b5e596861392a2ea34df5ea3b638175fc6639dc75bfd6"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "e7742670d4a5998dad0c52e97b37b792a55bad80fe5720aaf95bc764e75fde5f"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "aa8a478ba530a260e60962174ba220db0473aa54b114066a297a94177351df3b"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "3f2471dcde6704d1ac3b0153e44cb1125e9ea69655979d27db289f0153721c44"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3272,
+     "sha256": "6784f1aaed3a4c2e5bdf89a5b98a908c8e7ba798557084c8ad26f6b14d1acb48"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "fc226280c4948249790f00f97dd9b39e912131fc904ec75adb90308ba8763afc"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 6920,
+     "sha256": "11f74b17f9043d2462051d12832e921570f15aea644a5174cf4f88cd8d1b6d00"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 6728,
+     "sha256": "f523a7b62eb8b8db5d78576ac24619cb63f4ea727f71cc5af8e4f222211d3fa9"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 6728,
+     "sha256": "36b2430e19b1921401b4f1f091fa492721ea98cb596a1f84fb8afba79a0c6cba"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 6920,
+     "sha256": "2ab537bb894f48cd14fdca49591dfbe298929a3c478a10b917bb9a978c37d709"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3272,
+     "sha256": "3398c072e73a52077ecb764514fdd559128409f7460f4838cda9b43e359466fc"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "469fb1c1b19d030ee46f07fda907b3ccbcbf6a05460d02876899483cc53efc11"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "5128f341cc7c9395eb7dfafdd84b55d322785c3797dc209283b033b06cc8e8b7"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "436e842af0356ba95948c1b1d17ee9f597cacf96dbda1061e51f15acde237ccd"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 6920,
+     "sha256": "31280c064bacaef156cefc3c24ceb39ae609fd2536b9dbdf05c32daa759b9e47"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 6728,
+     "sha256": "f78f895a203d5b22b35bc82b4034aad71e9177a3013732646174b704850e2d34"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 6728,
+     "sha256": "5eeeea42e3f429aae7f907145b88376805346ebe3ce932259bdfc43399f960ff"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 4808,
+     "sha256": "e6b85a9f2120198e7d7e5b3a9f314da07acee469494dcdb82fbde214d5d142aa"
+    },
+    "its_demo_v1_1_readme.txt": {
+     "bytes": 13111,
+     "sha256": "4c38895a20e014b77181bfbbe6816cffd241afc1a97de8d25618d687fdc1992e"
+    },
+    "maps/s1m1.bsp": {
+     "bytes": 5705872,
+     "sha256": "717d27ad396064325997056bc27a9a08ebd6e12ec48b970a520d6869107bb34f"
+    },
+    "maps/s1m1.lit": {
+     "bytes": 1446005,
+     "sha256": "b0cf1c53485355460bb1f0ff4f27366d0ce1cb46e7363c83edbcaac4ca63a68b"
+    },
+    "maps/s1m2.bsp": {
+     "bytes": 5352816,
+     "sha256": "1acf48589b6dea9855a813593121c6918c64bb48915a3b86965b506326f658b1"
+    },
+    "maps/s1m2.lit": {
+     "bytes": 1420910,
+     "sha256": "7be19f4594db549878158180c68733e2e3e08d4a1d85e9bf135bb3914bdd8436"
+    },
+    "maps/start.bsp": {
+     "bytes": 7016832,
+     "sha256": "7b99d259a5a0b21b15174fc08e019cabaf695e44b3d53ff969e2e67e1e883690"
+    },
+    "maps/start.lit": {
+     "bytes": 2063564,
+     "sha256": "3c0fba79e742c391ff5b084978c2f92a63f288485470bf8aae76bcaafa7a50d5"
+    },
+    "progs.dat": {
+     "bytes": 763484,
+     "sha256": "d72c0f70749d9ae529b37f57afff52c820fd72fc218fe80277db427ef8832925"
+    },
+    "progs/aicorner.mdl": {
+     "bytes": 97266,
+     "sha256": "3c3a64b599fb160b0b6e900321e65bd7eb821a0a96b2b1e3905902d288f31a93"
+    },
+    "progs/aimarker.mdl": {
+     "bytes": 31346,
+     "sha256": "092a1a56f713d44d671fed07db08acf85ee6279a66ae9801b7a8cce6938fbc19"
+    },
+    "progs/amulet_shad.mdl": {
+     "bytes": 10224,
+     "sha256": "3372d843b29b2f55230fe0d795639df78e97a8d67a81a780afd2706da8f4493a"
+    },
+    "progs/bonequad.mdl": {
+     "bytes": 41384,
+     "sha256": "7bda2ae0d6e5953bfe6520ddd3f78d8f3703f9b45c476fa718e0eb05f40d786a"
+    },
+    "progs/book1.mdl": {
+     "bytes": 390773,
+     "sha256": "42c60f56dec9a926947b475a9d0833fba244c242c898fe1bfddd19a17da1f171"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21828,
+     "sha256": "efdd3e3e680b294d153f460592a67690c6e65954831ccb679321396d99b4e916"
+    },
+    "progs/darcher.mdl": {
+     "bytes": 1107700,
+     "sha256": "bac438015240dd9df5c82a1b386874ea6e6e9ee4c1fd9ed011025ef6016ccf36"
+    },
+    "progs/dead_demon1.mdl": {
+     "bytes": 61320,
+     "sha256": "6e9a4367933bd5f7ae8183213afc97b58c8aa9d66c427212e23a6d8584ca05d6"
+    },
+    "progs/dead_dguard.mdl": {
+     "bytes": 70452,
+     "sha256": "00a20081846e468c80505122ad9f293f4ead396b9d18c73d8f283f1b232836f2"
+    },
+    "progs/dead_dguard2.mdl": {
+     "bytes": 70452,
+     "sha256": "1120a8eec3e1b90828c3dc04fef5368842299d766f86c0e831d95d372ec5c210"
+    },
+    "progs/demon.mdl": {
+     "bytes": 291123,
+     "sha256": "0f0fe4a20a4713c46f6b863529d5c4ddc7f14f2c47b5547034040676012267f3"
+    },
+    "progs/dg_sword.mdl": {
+     "bytes": 8916,
+     "sha256": "72b137f131b85435256487f9ebd105a3dd8630686c57e9428fc8c60cff3aa25b"
+    },
+    "progs/dguard.mdl": {
+     "bytes": 709452,
+     "sha256": "e9fa00403ba65071a65315ebdb8c354d0e72f6b74a75c3ee3d7715b3c429c4db"
+    },
+    "progs/dk_sword.mdl": {
+     "bytes": 8916,
+     "sha256": "2042b9940771449537944e18b5acc6ae5fb8340315e8a38c0e8774d892f0b59a"
+    },
+    "progs/dknight.mdl": {
+     "bytes": 1044476,
+     "sha256": "d04cc57cb46ca60d4c1f7b71afa696b84a1edbe8af3c9a8f5a1d22ab2e05ed36"
+    },
+    "progs/dsergeant.mdl": {
+     "bytes": 1407980,
+     "sha256": "1d8873f94f882f70e564fa17c819051dd5a24e03572317a35af2a803073f4b4e"
+    },
+    "progs/g_crossbow.mdl": {
+     "bytes": 15028,
+     "sha256": "b92c45cfd471cad77ed86b6fbf5574d1f043a1e4f188e20efa91d2b69505741a"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 10836,
+     "sha256": "2c9f51f567356fa2d428f33f6d9b0e1c663d6302ea648f33773bcd18bb749c52"
+    },
+    "progs/h_dknight.mdl": {
+     "bytes": 12932,
+     "sha256": "ab90d86e244ca5c3df04330f7019e2631449d8def045f9b101af662c5747cefe"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 13444,
+     "sha256": "b14ecc00a70a8b5ef14cbd19b73be27a4cc84c042a80951bc9d3f57cb9c1e776"
+    },
+    "progs/h_pdemon.mdl": {
+     "bytes": 34884,
+     "sha256": "3b9e5467c4d31c1d0b7ea2e90e0ee66446dd8f50566abe270d6bb9bcdf8665d8"
+    },
+    "progs/item_medcells0.mdl": {
+     "bytes": 6980,
+     "sha256": "fa73e1d436bf315654ca49874a2b01e3208b739cabbd3e91bbce0267893bfc00"
+    },
+    "progs/item_medcells1.mdl": {
+     "bytes": 6964,
+     "sha256": "016a4d13ad45ae67f38b482fab3d9a4e9534b75dbdeb566ab6945be8b8fed4e7"
+    },
+    "progs/item_medheal100.mdl": {
+     "bytes": 7764,
+     "sha256": "dc530514c19c53b8f2a4bae79a7cdc421b21df72a5e6c1e6af28e88b2f7d7366"
+    },
+    "progs/item_medheal15.mdl": {
+     "bytes": 7124,
+     "sha256": "6c6d15119b6d0d21ef6872a5969a55493063d9860ae751f58d582fa5651a9814"
+    },
+    "progs/item_medheal25.mdl": {
+     "bytes": 8788,
+     "sha256": "7d1693cea108b2663e0377d9399a9870e94181ab4c1610db9fbe9761795ab063"
+    },
+    "progs/item_mednails0.mdl": {
+     "bytes": 5604,
+     "sha256": "8e6c10d3df6772d482193732ca08e4139e20ce99716b84b0d6dbe5f34db8412f"
+    },
+    "progs/item_mednails1.mdl": {
+     "bytes": 6820,
+     "sha256": "3adfee3bcd0c43d8157f296bb6f74d7c3414a81e00e1dfc7dddf51b55d008072"
+    },
+    "progs/item_medrockets0.mdl": {
+     "bytes": 7092,
+     "sha256": "19ce09bd08a967b76fe32067ea6dfdc60b8b97c43d72f4f15ec44e7a16443be1"
+    },
+    "progs/item_medrockets1.mdl": {
+     "bytes": 12693,
+     "sha256": "cb5e18fc5bf5c6de0cb7dbb5e40c9ab1921dd5cb57b1500402dfb01586d5da0a"
+    },
+    "progs/item_medshells0.mdl": {
+     "bytes": 5396,
+     "sha256": "9bc2dacf4a7a07d2d564f0b4a4458aa509ea1fc22c310889a8057543416c51fe"
+    },
+    "progs/item_medshells1.mdl": {
+     "bytes": 8436,
+     "sha256": "4665a998a5c7063db5e607d39131c3c5fc466b7c922bc1d29ca5bbbd158eb935"
+    },
+    "progs/item_poison0.mdl": {
+     "bytes": 11230,
+     "sha256": "0ed32796721be1d411296fa7791f45186f62f00486281095039b40138e67856d"
+    },
+    "progs/item_poison1.mdl": {
+     "bytes": 23837,
+     "sha256": "07a9f9fa2f2e2add5cc3153fcb3d3e5d8e73368d6ca3e4b7e0e8180dc9d80872"
+    },
+    "progs/ks_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "34936456bcf8c907a57ec86de22ca4c284f9ccd5c2400e811678240cba3f1816"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 3503202,
+     "sha256": "3465e89849aa502067dc17775f621cba990053a330bfe005424a1ef35fdfbfc4"
+    },
+    "progs/p_gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "7611ec47cd064b2766b3a926c5bb8fd7d0e77f40ad4fb6ef18f171e68edbca63"
+    },
+    "progs/p_gib2.mdl": {
+     "bytes": 16228,
+     "sha256": "1bdf1cdd0ceb5bae4c61ba2c9224515349b724df9aa384ce91a1909ffb1a66b0"
+    },
+    "progs/p_gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "270bf0388805d026c982fbda74a21cd452a427d83d0407d0c92df847c93d0299"
+    },
+    "progs/p_gib4_zom.mdl": {
+     "bytes": 10196,
+     "sha256": "1cfcd8cc86148f9984ab39d19411dfb9ae52aa5f02f804dd604362008aeadd31"
+    },
+    "progs/pdemon.mdl": {
+     "bytes": 291126,
+     "sha256": "c672c557439a98d99c6c6842953cc8bedaa8e5b6ab1dc715a9a66e34f20676ee"
+    },
+    "progs/pentfloor.mdl": {
+     "bytes": 21172,
+     "sha256": "fb10c551bc21b9f470adad2e7804cd85cac1dfa117a9b55699289297e1a41017"
+    },
+    "progs/plinth1.mdl": {
+     "bytes": 6196,
+     "sha256": "1ce0b7f49153f717e04436b27863c75f90a73b027c4cb7e36ce094fa037eded4"
+    },
+    "progs/plinth2.mdl": {
+     "bytes": 6164,
+     "sha256": "8527f7c85b9a0c5a32e2326c2aed529c87cdaea751f2529b86cee35754ff962e"
+    },
+    "progs/pzombie.mdl": {
+     "bytes": 186084,
+     "sha256": "7f5442f55e8265dbce89b43b924a4f0aed0adff0e7c4d998b0af877f5b67a013"
+    },
+    "progs/s_bookrune1.spr": {
+     "bytes": 1140,
+     "sha256": "b9fc52d2ca728fffa4c282d818b68aeec3555a0dbad3cd1507199d534db1f047"
+    },
+    "progs/s_bookrune2.spr": {
+     "bytes": 1140,
+     "sha256": "400a620928e3581891e8a71b338c8a53b6387e0acdc3fda3f10ae27596ae6bbc"
+    },
+    "progs/s_bubble_blue.spr": {
+     "bytes": 1140,
+     "sha256": "27cb0d1f52e3ecd4b7ae0d9dc96078a7554bde09839f1a2ee2d9772ac5d67981"
+    },
+    "progs/s_bubble_wht.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_yell.spr": {
+     "bytes": 1140,
+     "sha256": "9dcce864ad255b17d7d45e5c5531114f6a66c4e9cb549fc8b31aef0af5a9157f"
+    },
+    "progs/s_dotmed_blue.spr": {
+     "bytes": 1140,
+     "sha256": "0b3160c5a4ae42216ddb7aaa7ae4726f6b2507c914328abe3c69f2d12fd921f8"
+    },
+    "progs/s_dotmed_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "6e28b69544f8aa13ccbb9a66893e4ab86b83639ee3f81dbbe1b94290ca9b03ef"
+    },
+    "progs/s_dotmed_grey.spr": {
+     "bytes": 1140,
+     "sha256": "77c226763e90a54b4d6835bd877c08c501605e516e64177c915c422e7b36c207"
+    },
+    "progs/s_dotmed_grn.spr": {
+     "bytes": 1140,
+     "sha256": "d1a9800a8b5cad01fa1dc93e57162e9960c4a8478e7e427d66cdbfe6a6797266"
+    },
+    "progs/s_dotmed_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "6113140f371b08cda9addcf68282c1fc16692da7498fa2fdfe2b99662e345d67"
+    },
+    "progs/s_dotmed_red.spr": {
+     "bytes": 1140,
+     "sha256": "4ae92a280e0df01c0acd0a904214af485bb60919e5ded4573aa12f86875182d4"
+    },
+    "progs/s_dotmed_yell.spr": {
+     "bytes": 1140,
+     "sha256": "e6b72aac439291d7719ee78d9520c1a1def36212ac7f61ba333fa87d5265c63f"
+    },
+    "progs/s_dotsml_blue.spr": {
+     "bytes": 1140,
+     "sha256": "c0149109ae73a72da49bfaf9ba00cf2edadbe0f053928d09319083e6247883ad"
+    },
+    "progs/s_dotsml_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "f95fe813ecce2c69d2b72e5bf870d045037519c89f3da9a300e7453754cd1503"
+    },
+    "progs/s_dotsml_gold.spr": {
+     "bytes": 1140,
+     "sha256": "3833e80c32da39063b5069638ade52c4aee51b7db7206b4911cb48f321e25bdc"
+    },
+    "progs/s_dotsml_grey.spr": {
+     "bytes": 1140,
+     "sha256": "2e16d9ff8ceca2994a609703f405b1efbb7b49e02c8dbb9e77d0cdcaf3318b98"
+    },
+    "progs/s_dotsml_grn.spr": {
+     "bytes": 1140,
+     "sha256": "a2735123addacfa03f2666969e476af0d9f1cfefbef75a7ac9599d48f86226b1"
+    },
+    "progs/s_dotsml_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "ebf62caae17163587aaa3652300f1003c008ed21041b838a14cfff7672f87d90"
+    },
+    "progs/s_dotsml_red.spr": {
+     "bytes": 1140,
+     "sha256": "94c0403ee7f1e6f6c4d6bc9b99e73e48143845fe35d0d6b3de246842241b12cb"
+    },
+    "progs/s_dotsml_wht.spr": {
+     "bytes": 1140,
+     "sha256": "7ac2d5b9b1e14a1799b951ace16bcc1addb7fefc2470dec23ef2ca110a934bf5"
+    },
+    "progs/s_dotsml_yell.spr": {
+     "bytes": 1140,
+     "sha256": "686f220b937040b91b6ff4f05efd41525d40eb80a61ff8138809d550bfa99959"
+    },
+    "progs/s_healing.spr": {
+     "bytes": 1140,
+     "sha256": "cd7e99e555f11f888e3ad3cbc2cfadf0276fdfa2f2e2817060f96e4788ad9dd1"
+    },
+    "progs/s_pentskull1.spr": {
+     "bytes": 1140,
+     "sha256": "036ce82812d7e1fc2af6d8aae9fed78ac989a738371858770e1f8adf1f12350a"
+    },
+    "progs/s_poisoned.spr": {
+     "bytes": 1140,
+     "sha256": "62a8ae1311aafd4e5098f6e78eae49b7918d34ed09f7347a806ea41b5f4d233d"
+    },
+    "progs/s_sigil1.spr": {
+     "bytes": 1140,
+     "sha256": "8b2cfa67ac86841f59409e184b4f3a253218e5930a5e3f241caef39dc1baa8de"
+    },
+    "progs/s_sigil2.spr": {
+     "bytes": 1140,
+     "sha256": "476042db782f7f81cb53d91e9518881f28eb34d3a2a535c11d9c22f65518bce4"
+    },
+    "progs/s_torch1.spr": {
+     "bytes": 1140,
+     "sha256": "eddd46a4818dfa92a9817df82e893d6bf6513160164a74b95bdd42fb7cac2f75"
+    },
+    "progs/s_torch2.spr": {
+     "bytes": 1140,
+     "sha256": "dcb87897de0f54a6d8f78e9194a15c11261eb88455f058b334f8648a363159a9"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 336447,
+     "sha256": "64aa6dac013836e29d271b90d33bc7741793f0f5e40dd5d719ad37605f10ea6d"
+    },
+    "progs/statue_dcomm1.mdl": {
+     "bytes": 98196,
+     "sha256": "c648c9b4b40114ed3eeb7db8f604b2b9143269323325faed89554db39d11cc21"
+    },
+    "progs/stealth_circle.mdl": {
+     "bytes": 13460,
+     "sha256": "1f1478a5b4bda9e21ddcc26a3b635c234d8bbc369c4232d305918ddc0be63bf8"
+    },
+    "progs/stealth_eyeb.spr": {
+     "bytes": 77708,
+     "sha256": "8614bd1428d482db150ed7041ee77e92c8f17670a27c7939dc16219326a9fd55"
+    },
+    "progs/stealth_eyew.spr": {
+     "bytes": 77708,
+     "sha256": "75e001a962ba857bec09860ad8467646a2138ca1234b106e30f22c3951afe50e"
+    },
+    "progs/v_crossbolt1.mdl": {
+     "bytes": 5592,
+     "sha256": "9e23a0d6171f0fde4e4f3b4ea49180c81e095eafe3dc7f634118e2ffabf3bd76"
+    },
+    "progs/v_crossbolt2.mdl": {
+     "bytes": 5592,
+     "sha256": "a9c161890e4061929be96336c997acfb6dbfde68d0011e7a5309b2babe1e1178"
+    },
+    "progs/v_crossbow1.mdl": {
+     "bytes": 22924,
+     "sha256": "3f2fa269a77f10709445e91a6bf6ec591e05cf45c561b3ef0dd027223837b453"
+    },
+    "progs/v_crossbow2.mdl": {
+     "bytes": 22924,
+     "sha256": "7408569d5d5f4996a9caaa10a8c711c3d6903f887cb12af2a2696f6baf32dfc0"
+    },
+    "quake.rc": {
+     "bytes": 3645,
+     "sha256": "781666e81a0bb850a21aa51d192ee68872923586ebdd5ccdc518504be1e3659c"
+    },
+    "sound/ambience/background1.wav": {
+     "bytes": 403620,
+     "sha256": "47afe820548bcf248b7760f7a66a61ea65b5fb79f70d47e3b03cf8211bb4c5f3"
+    },
+    "sound/ambience/background2.wav": {
+     "bytes": 99104,
+     "sha256": "9c3d5418c7e5bac60c365f0e8b7ea496dd2b51c72c13b0e5a6640e2ef880433a"
+    },
+    "sound/ambience/background3.wav": {
+     "bytes": 209242,
+     "sha256": "864f373dbd75172e1c8f31373188f38c31a80af46592f6b2e92cf5f576e5e0e1"
+    },
+    "sound/ambience/moo.wav": {
+     "bytes": 265502,
+     "sha256": "35b7924115bc4cdf94e9cbb274a4d9ca251d6878817834bec08aaa176f2ddc9b"
+    },
+    "sound/ambience/sigil.wav": {
+     "bytes": 250476,
+     "sha256": "d1060cd75d8a520b748047790d33c9a4ab5fd626330ebf1242d318d308c165db"
+    },
+    "sound/ambience/slime_burn.wav": {
+     "bytes": 89464,
+     "sha256": "4ea16997389f1aa35549869a338f2093f40d14df030c381a7659cc7e3cbf8bfc"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 246432,
+     "sha256": "d5f5f8ffa7c061a6f9d5159a2e953edb6f94341e04c51670b07e0c802af941fd"
+    },
+    "sound/ambience/windgust1.wav": {
+     "bytes": 110934,
+     "sha256": "d6b4a536dd8c403d8fe9a20db1c72c42d32f44b863689ba4f952ad1e0b7c86d9"
+    },
+    "sound/ambience/windgust2.wav": {
+     "bytes": 110696,
+     "sha256": "85ffe34d5ee89659fd6466afa237a27ad3494176a733d9e017843e7651366a2d"
+    },
+    "sound/ambience/windgust3.wav": {
+     "bytes": 110030,
+     "sha256": "fdbb85f091cd9447f1500173aff70236abcdb947ba0758711816da59c5293344"
+    },
+    "sound/ambience/windgust4.wav": {
+     "bytes": 204800,
+     "sha256": "6bf9157f45ddb9ce15c5cad253b53d9ce59e7d20a81d5f1f8d0a510eb4edce5a"
+    },
+    "sound/ambience/windgust5.wav": {
+     "bytes": 204472,
+     "sha256": "e551c6602c35ad4f4871bffd53cb02a668f508f5ef007e7e5b9734c5640f17ac"
+    },
+    "sound/items/amulet1.wav": {
+     "bytes": 13728,
+     "sha256": "c3b5748724c2d8639343e30dde887d3d62644274ca85b39ea79688105c8b156a"
+    },
+    "sound/items/amulet2.wav": {
+     "bytes": 33216,
+     "sha256": "18177b48986676bb72721d0502ad80f9d483fb2ac1af5b89af24d4d2d6b94aa9"
+    },
+    "sound/items/amulet3.wav": {
+     "bytes": 33320,
+     "sha256": "91f9233087852a1471b9083787ce03f14b4140d0014289ead84c2965052156bb"
+    },
+    "sound/items/amulet_dest1.wav": {
+     "bytes": 8036,
+     "sha256": "82c5171888cc8289442a6daa155613f1309f80c2ece2509ba7cf4220293faa0a"
+    },
+    "sound/items/amulet_dest2.wav": {
+     "bytes": 17324,
+     "sha256": "bb220998dd2165f58af10e5fba604c982410e0445d9c4b39b7810b06b5ef97e8"
+    },
+    "sound/items/amulet_dest3.wav": {
+     "bytes": 18016,
+     "sha256": "a40289745dd6d81b66172c0a964cc3494bef56f3b38dcde0629912cbe1372a45"
+    },
+    "sound/items/amulet_dest4.wav": {
+     "bytes": 9068,
+     "sha256": "8a4c9f54f6d22329beadfb4c5bd6df1d4554b46fd47af74fbd2e1e4376a1cfb7"
+    },
+    "sound/items/amulet_dest5.wav": {
+     "bytes": 22042,
+     "sha256": "bd1bee52744e6ad5e8e5a155a51da6e9893d84bb0e145210e3793147acfda655"
+    },
+    "sound/items/swallfade.wav": {
+     "bytes": 9910,
+     "sha256": "6497d7755251df2179a4d097f9f96ff27a09484409272e5cf5f1acf87e16e847"
+    },
+    "sound/knight/dropmace.wav": {
+     "bytes": 37624,
+     "sha256": "8d985486f3011d2862e9d2c3e00669aba3bf91987e61d86d8091f3e53b57528a"
+    },
+    "sound/knight/dropsworda.wav": {
+     "bytes": 30010,
+     "sha256": "93094589b8810a7752892aaf1774a28b4595f62c262958d162a1428d456f93d6"
+    },
+    "sound/knight/dropswordb.wav": {
+     "bytes": 25172,
+     "sha256": "56ff6b06fc93afe9910be3c00244d7c5eaf71e78d4233ecf3a93c5384c09ddc4"
+    },
+    "sound/knight/idle_cough1.wav": {
+     "bytes": 18416,
+     "sha256": "17ce7c58e137b36f1c9eae6e95995145868a6d2dd576ab170d547ebed97f9704"
+    },
+    "sound/knight/idle_cough2.wav": {
+     "bytes": 21832,
+     "sha256": "523834f19acbdc97f7ab14ac08db6e190da741d8793b10a5edc7334de95e54d1"
+    },
+    "sound/knight/idle_sigh2.wav": {
+     "bytes": 176610,
+     "sha256": "a7eba673532dad555f879ba77091e3cb9e44558608b83c36d8639e51d71b660a"
+    },
+    "sound/misc/bookpages.wav": {
+     "bytes": 54962,
+     "sha256": "1aa89f0d13aedafe9153c3c05b0c77b9edb0b847e222873bf062a3f52b2b582d"
+    },
+    "sound/shambler/idle_growl1.wav": {
+     "bytes": 22112,
+     "sha256": "dde3a70f1740c1d801e37df14d5160b7329b54c94c814d4dfaa77458dd6dd3f6"
+    },
+    "sound/shambler/idle_growl2.wav": {
+     "bytes": 36924,
+     "sha256": "8c28d6c87ed56a6d552bd52cffa63f8a59866ccb101db53a2807f3c93ca02c4e"
+    },
+    "sound/steps/heavy1.wav": {
+     "bytes": 11066,
+     "sha256": "3086cbc405b6837ac4795010ba426471b9d6f21d283e300acde7345f2c9cf598"
+    },
+    "sound/steps/heavy2.wav": {
+     "bytes": 11070,
+     "sha256": "4cdd160ff3d039d59378cf45a21ae743fa76701d6740e96741ee180824a2c146"
+    },
+    "sound/steps/heavy3.wav": {
+     "bytes": 13290,
+     "sha256": "9258698f4d5e5406a39f112f0ba17cce10a76ea2524177b1a89b19e3bfa44e3f"
+    },
+    "sound/steps/heavy4.wav": {
+     "bytes": 11074,
+     "sha256": "8f52d3678440e3fdf62f1596a0858ec4c99303bb6e564442bf63e728f83478f5"
+    },
+    "sound/steps/heavy5.wav": {
+     "bytes": 11082,
+     "sha256": "63777fa8896eea7af32f32990a48c41244aca978bd29bbe4413bfeeb1d03ec8b"
+    },
+    "sound/steps/large1.wav": {
+     "bytes": 33118,
+     "sha256": "7fc97da8a2993670d47029dc009694cf00408fff3c64b4d9664a1566ffe305ff"
+    },
+    "sound/steps/large2.wav": {
+     "bytes": 24960,
+     "sha256": "6ccbaf3a08994e89782e78fe7b04712ad76048c77339435e639484c7fb5ee453"
+    },
+    "sound/steps/large3.wav": {
+     "bytes": 24280,
+     "sha256": "95aa22f2336436d7d073b560d8aef2ca08431f6da901cc566210d05845763785"
+    },
+    "sound/steps/large4.wav": {
+     "bytes": 22092,
+     "sha256": "79c1549ea123ec7b0884014cc05d6cc36b20b377f38892794536e200c668bff2"
+    },
+    "sound/steps/large5.wav": {
+     "bytes": 24320,
+     "sha256": "37b431206718d8d4547c1746ed01dd509433d47577d333b4f5a40db7d796de8f"
+    },
+    "sound/steps/light1.wav": {
+     "bytes": 8872,
+     "sha256": "f034fe2692c0fceb6de1c00e15facbcbd31ccd1fcf72510fd1e3cb6bdcc28795"
+    },
+    "sound/steps/light2.wav": {
+     "bytes": 6654,
+     "sha256": "998f665b4a7ccbc995096697606a91d208db024b0882df75ebaaac015f0d4ef6"
+    },
+    "sound/steps/light3.wav": {
+     "bytes": 6670,
+     "sha256": "b25e020a10ac6a7883fd584cff4895d6d785f8577daea15a30d2b745e146c1c6"
+    },
+    "sound/steps/light4.wav": {
+     "bytes": 4472,
+     "sha256": "a111052881024eef6e97393c1388e8ae538227b85c9b8cf0a73704abb2a504b1"
+    },
+    "sound/steps/light5.wav": {
+     "bytes": 3588,
+     "sha256": "55fb54e5ba2f8ec6249761ae6f07c12de6133457b51c584759e8841fb14cb46f"
+    },
+    "sound/steps/medium1.wav": {
+     "bytes": 8872,
+     "sha256": "c3e517eba232cdeb6039f44eac5b3905725aa8b34f1fad034b59831536f75fd2"
+    },
+    "sound/steps/medium2.wav": {
+     "bytes": 8852,
+     "sha256": "e8701598e07f43a20aebebd1d1a5043213018199d50472dea37672e6dce4a2b3"
+    },
+    "sound/steps/medium3.wav": {
+     "bytes": 11068,
+     "sha256": "3ed07795c2363552554e6da1da5749be08e460fc6cd4c7266b9fa514732abb2f"
+    },
+    "sound/steps/medium4.wav": {
+     "bytes": 8872,
+     "sha256": "008992cd7972e7e1e6f0b785b40e398a8efe744a3f3f57e47370936796c3d6b5"
+    },
+    "sound/steps/medium5.wav": {
+     "bytes": 8864,
+     "sha256": "6aa1f602017c6f7b8c71f4c84f9308a510dca028218c93a25290eb75ebb5e249"
+    },
+    "sound/steps/slow1.wav": {
+     "bytes": 8878,
+     "sha256": "15614044d9d277fa3359edb07e7af74b9d7875150fddde5ab1fdceb0143337bb"
+    },
+    "sound/steps/slow2.wav": {
+     "bytes": 8856,
+     "sha256": "a8b16b688d12812a61127a885bf43c360adc2b84ae7806cc107b433c6f4635ee"
+    },
+    "sound/steps/slow3.wav": {
+     "bytes": 8852,
+     "sha256": "3a2a57e1a37d378c1ee73d5732840f6d20e588d794216c33896bf25879807600"
+    },
+    "sound/steps/slow4.wav": {
+     "bytes": 8868,
+     "sha256": "78bdea66991184043001262cc6ef5f1148cf0eb11b5f88fc51ff948311156e5f"
+    },
+    "sound/steps/slow5.wav": {
+     "bytes": 11076,
+     "sha256": "f63c868bd87926f017bec092749bd61c763b0b18635456ed56b660e53bf581af"
+    },
+    "sound/steps/water1.wav": {
+     "bytes": 63814,
+     "sha256": "01ed631b0d92dab11086b1106acc278ffd92522e2e46d21a0650fd29a79780f2"
+    },
+    "sound/steps/water2.wav": {
+     "bytes": 71994,
+     "sha256": "1b53561f02f60da1e1b6c8b72f722ba12e549c318725b974745b38666efa8e56"
+    },
+    "sound/steps/water3.wav": {
+     "bytes": 71802,
+     "sha256": "bbc0778017ccb579a9d531316b8af46585e91a100a251707ac34f4dbddf6922d"
+    },
+    "sound/steps/water4.wav": {
+     "bytes": 61448,
+     "sha256": "d3604afcb7751d987a78a0ee8ee4ca3593315cc6cf2f1909a9f7748535ccea50"
+    },
+    "sound/weapons/crossbow_fire.wav": {
+     "bytes": 8364,
+     "sha256": "37194a2fe37bc29b39e96431590d49e9239454dfb058f8b8cdd1d902f382aa0d"
+    },
+    "sound/weapons/lg_explode2.wav": {
+     "bytes": 29598,
+     "sha256": "7a95a8337c7ad87faccc1cae98ad7840352b08608fba08aff87a1b33610f9190"
+    }
+   },
    "sha256": "4ddadb7da80d6ea2acbfcc39db086deb87da888330914a13f3b04d9b7c975a2a",
    "timestamp": "2012-12-30T19:05:58.000Z"
   }

--- a/json/by-sha256/38/38ee9811a6181f4b302ded52f1eade9fa131b2f7e0de801615aa9234beb39257.json
+++ b/json/by-sha256/38/38ee9811a6181f4b302ded52f1eade9fa131b2f7e0de801615aa9234beb39257.json
@@ -17,6 +17,40 @@
   },
   "pak0.pak": {
    "bytes": 14526472,
+   "files": {
+    "maps/czg07.bsp": {
+     "bytes": 2119692,
+     "sha256": "f1819f7a9c73d104e54ce81cb7e8c69802496e71591970158fe8c436398ebe49"
+    },
+    "maps/czg07a.bsp": {
+     "bytes": 3465792,
+     "sha256": "5912ee104468c2ebbdf8a7a0dd0f6bab6320c7667f92b99e59c1099f35e66d8c"
+    },
+    "maps/czg07b.bsp": {
+     "bytes": 3955100,
+     "sha256": "889f2e969b77b7294835d3cb10acb5c9d28deabd8b7b5a8c5bf5a84ed262148e"
+    },
+    "maps/czg07c.bsp": {
+     "bytes": 4021876,
+     "sha256": "c15e0990ab103fa221f3fde7da6a9cda67781abd57a0229383f79946f33f6c4f"
+    },
+    "sound/ambience/blood.wav": {
+     "bytes": 240964,
+     "sha256": "197a5b8be8ca0394264a763b13dcb9001818e3af2ea0a920769e697df19bc4ba"
+    },
+    "sound/ambience/growl1.wav": {
+     "bytes": 108260,
+     "sha256": "e6cfa2d088c806a2700eeccf0d39352a5bf0bafc49b285e66572ad96a4865a5a"
+    },
+    "sound/ambience/growl2.wav": {
+     "bytes": 329402,
+     "sha256": "9402a62b0453ad5096714f60913de471e5dce484832ce8fc53c18ec808e978b0"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 284862,
+     "sha256": "ed83d4b3474202822a64d4266a9e6273925d336aed71dd6b9e3e039253abc4f1"
+    }
+   },
    "sha256": "d0dd560035cc43c707c9d1bdb76668b8232ea893b4441d3ac3a0b2c139606267",
    "timestamp": "2001-01-01T19:10:20.000Z"
   },
@@ -27,6 +61,203 @@
   },
   "source.zip": {
    "bytes": 186522,
+   "files": {
+    "source/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2000-12-30T21:49:04.000Z"
+    },
+    "source/Cwsdpmi.exe": {
+     "bytes": 25920,
+     "sha256": "0a890815df6cbdc052915a856c16944cedec825267e7b6e453c351a0cdc695f2",
+     "timestamp": "1996-07-12T17:31:50.000Z"
+    },
+    "source/Hipmisc.qc": {
+     "bytes": 4393,
+     "sha256": "514c126a33f3cd2bdf092051ae8bb6cc459f7fc6595eb0aab74ff26002f269d6",
+     "timestamp": "1996-01-01T13:34:36.000Z"
+    },
+    "source/Proqc160.txt": {
+     "bytes": 9703,
+     "sha256": "ec9e30e83c67a7d8f1176859947137a070c11e57f8882f9434eee0d0c8c4cc10",
+     "timestamp": "1997-06-18T15:39:50.000Z"
+    },
+    "source/Proqcc.exe": {
+     "bytes": 128516,
+     "sha256": "2e06f5304f83e96b1c9aca46cbd1691e21c9a6d946fb6352957043a18448e11e",
+     "timestamp": "1997-06-18T15:32:26.000Z"
+    },
+    "source/ai.qc": {
+     "bytes": 14521,
+     "sha256": "54a6329a086391d2f1296fd30afd5db9ca676f7f15911c703b15e440b4e5778c",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "source/amtest.qc": {
+     "bytes": 1697,
+     "sha256": "8dd158020b8c0be6988b0f1fbe03990372fb769442dbaf85248ef8c0e18645ee",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "source/buttons.qc": {
+     "bytes": 3033,
+     "sha256": "84893d4f5388d1d32f911030b5af96eff897c7df3aab27b480b92edb903f51db",
+     "timestamp": "2000-10-13T22:31:48.000Z"
+    },
+    "source/client.qc": {
+     "bytes": 30937,
+     "sha256": "8b53eb9cc87f8ecc30ed20ba436486f7ef344f26467e42be1bfdbe06b927ba37",
+     "timestamp": "2000-12-30T22:36:14.000Z"
+    },
+    "source/combat.qc": {
+     "bytes": 6130,
+     "sha256": "9e55bcbbb486d6c396ba9ee797de982be4cc79a94ffe2c40fba89bf3f72a5c4c",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "source/defs.qc": {
+     "bytes": 18039,
+     "sha256": "d203303b7356ca040059e926ffb1306f6215b2b145b4d10513641dec31939f77",
+     "timestamp": "2000-12-10T13:58:28.000Z"
+    },
+    "source/demon.qc": {
+     "bytes": 9904,
+     "sha256": "b20d0e3664ff9ff9e55222ad73507016a832b15a4cb28f93b86e90fa35ea445c",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "source/dog.qc": {
+     "bytes": 9542,
+     "sha256": "7dd3980dc2f284046f0e516b39d8b7391ac4a87b758b2f89aeb682feab2cc2bc",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "source/doors.qc": {
+     "bytes": 17063,
+     "sha256": "6bfe293c3eee577112cc0941993a0a601b3fde710be8359579bcebf0c0f81082",
+     "timestamp": "2000-08-20T17:42:20.000Z"
+    },
+    "source/enforcer.qc": {
+     "bytes": 10727,
+     "sha256": "01b86eed9379c58b6028480ab180b8dd7be433c4c143ca361ca149609961c379",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "source/fight.qc": {
+     "bytes": 7208,
+     "sha256": "c68c3310e794200ef61c79ed9665490b3e893ff7d2d6243e5f6aeda7d9885925",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "source/flag.qc": {
+     "bytes": 141,
+     "sha256": "143f0b896c7515dcdaaf5b436d130fe1ffb6fa67cad2a34ad4639724201b3445",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "source/hknight.qc": {
+     "bytes": 18298,
+     "sha256": "302a397cbd1fc639b70767a01a6d8e3696699165e2c4a00d1a33231102408682",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "source/items.qc": {
+     "bytes": 29870,
+     "sha256": "2bd44d5ebaf3041424781937f53a6c2208806460ca870d3746e5617f8303a489",
+     "timestamp": "2000-12-10T16:44:38.000Z"
+    },
+    "source/jctest.qc": {
+     "bytes": 222,
+     "sha256": "0b356238bdae38139e36fb7f9ed5a72e65accee92b48f25035b79ec315a7da06",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "source/knight.qc": {
+     "bytes": 9684,
+     "sha256": "53202927092c04d472a311e5ec8732cdb2ed9224c6520fbe4d126e152b5cee87",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "source/misc.qc": {
+     "bytes": 15593,
+     "sha256": "ce43da2491342b82b30dcb7477ddf2127889d5d818c170bdf3e1642e4c8d8973",
+     "timestamp": "2000-12-16T16:09:18.000Z"
+    },
+    "source/models.qc": {
+     "bytes": 8996,
+     "sha256": "d11fd0939293244962c5a40766e1dce246bde98eb0d42c87eb530a58d6eca64d",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "source/monsters.qc": {
+     "bytes": 4798,
+     "sha256": "cd29084e3f58192819848c3030c6717487d2641d848d118da433e1348ee59c8e",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "source/ogre.qc": {
+     "bytes": 14657,
+     "sha256": "193565dc8f263640e62c476c885c432d774076dac8c99bca7105eadff0ebed85",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "source/plats.qc": {
+     "bytes": 8080,
+     "sha256": "598b1485ac329b39b8cf0c5cd9d9682adbf59d7b90d6109e24f9421372ceb6b1",
+     "timestamp": "2000-08-20T17:00:08.000Z"
+    },
+    "source/player.qc": {
+     "bytes": 17554,
+     "sha256": "659665c41b4cc226055e037fc9d2b89f9ad3836a2c9a7517e1655ad18338b380",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "source/progdefs.h": {
+     "bytes": 2598,
+     "sha256": "99e562ac15081804245e7c7018956f2241cffa00a024a954c97183248bd00ea4",
+     "timestamp": "2000-12-30T22:36:18.000Z"
+    },
+    "source/progs.src": {
+     "bytes": 339,
+     "sha256": "0ec8ab304a1e8e92d8d73cc6307d84513c78c68bd5473c9ab0882068eac7fe01",
+     "timestamp": "2000-12-21T23:28:18.000Z"
+    },
+    "source/shalrath.qc": {
+     "bytes": 7880,
+     "sha256": "4c53306f4412184ba7bc26b93acbcd5504d922d1056beaca11484665efcff1b7",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "source/shambler.qc": {
+     "bytes": 12725,
+     "sha256": "0c50557b8757d8be3a0876564cfa125e4e8389cae1c55c844871aff5f844c342",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "source/soldier.qc": {
+     "bytes": 9825,
+     "sha256": "f66da2d85ad5ac42dfe13fd434018e64ca8eddba1e7b3abb747b4577ba072d01",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "source/sprites.qc": {
+     "bytes": 450,
+     "sha256": "c00564e7ca0ab70d7891931ff333461ff90aa6052f46e8ebb02f59de6e03787d",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "source/subs.qc": {
+     "bytes": 6062,
+     "sha256": "8fa013564dcf7be1df26888fbc304159b29be25ed43c4599333c9d8de809b356",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "source/triggers.qc": {
+     "bytes": 14259,
+     "sha256": "cb9ce7900bd9b1c1fb0ce968ed6b4d0f14be4552f6a0fae6acff6954135ca4da",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "source/weapons.qc": {
+     "bytes": 25227,
+     "sha256": "7f3d2541500506fe8d6d9155f3893667d1c58ff5ac9e8cfd81aa183a6a5fd01c",
+     "timestamp": "1996-09-30T03:08:08.000Z"
+    },
+    "source/wizard.qc": {
+     "bytes": 10663,
+     "sha256": "250aa24a63df4d02949abe2cbeee24f9f959d1ecf468c6b3108d0384c7db6d32",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "source/world.qc": {
+     "bytes": 11162,
+     "sha256": "a72e7eab7d9eefe4419e1e011f421d0c56f906029048c4fe8557743655e5406b",
+     "timestamp": "2000-08-20T16:02:02.000Z"
+    },
+    "source/zombie.qc": {
+     "bytes": 20108,
+     "sha256": "027ec53b0caa6c1c46c1f6156a854c886ab6fcd9c628707ebea1d3ca1c185519",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    }
+   },
    "sha256": "2877c050afe49963739fca05bdf2310950e8e25038afb75d05df3bc64c912ace",
    "timestamp": "2001-01-01T19:08:38.000Z"
   }

--- a/json/by-sha256/3a/3a52ac681e571ec330f6b23f83222021e65fc3664396b8ae80b38ef8f4824b6a.json
+++ b/json/by-sha256/3a/3a52ac681e571ec330f6b23f83222021e65fc3664396b8ae80b38ef8f4824b6a.json
@@ -158,21 +158,3465 @@
   },
   "Tershibboleth/pak0.pak": {
    "bytes": 25051624,
+   "files": {
+    "maps/b_barrel.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/b_wbh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_wbh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "progs/acidbal1.mdl": {
+     "bytes": 8788,
+     "sha256": "8a9c956f1952fb8d9ea51119c1c8c758d3ca3b3bf3bb0e8b63131bf88325f5a9"
+    },
+    "progs/acidbal2.mdl": {
+     "bytes": 8788,
+     "sha256": "eceba377145b62b4721927e55de75423daaac83f9667852b16dd1bfff3beff01"
+    },
+    "progs/akarrow.mdl": {
+     "bytes": 23072,
+     "sha256": "4e0e1c007453dbc432533dab09dfbafa943c4f43f7897848c91a516bf0de43a0"
+    },
+    "progs/am_super.mdl": {
+     "bytes": 8976,
+     "sha256": "55d561bf2f73b2c6482dcb5649da1b31d4bbf40aef6e21cca3518dc6a0c5709b"
+    },
+    "progs/anglstat.mdl": {
+     "bytes": 164396,
+     "sha256": "ce4644a5e22e0ff39790a293754501add2a4ad8afa26cfbdd13205c3b833e923"
+    },
+    "progs/archer.mdl": {
+     "bytes": 581920,
+     "sha256": "858ad8a4d0d27e1a9989ad7d87a9a4404ff8adbde33b07868725d34fd2146f6d"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 141992,
+     "sha256": "9a3c9afb3c47ed9c683ce6b0fdaef6ee6d1cf74c60509f1a82f8599318e71d08"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 25752,
+     "sha256": "57518dd89a3dbf6e712ad204b0a6f41fd7fdc9bfc03cf4c17e222f9d31d72b93"
+    },
+    "progs/arrow2.mdl": {
+     "bytes": 68764,
+     "sha256": "0bc41c13a4332f6d13e7884248b2d1a83b487bc2f4e1d5cbbdcd1c81512a4579"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 290592,
+     "sha256": "f0d1dc967de929d0f0faaa61aa51239d1f262c63da83013be094a4ed99e3028c"
+    },
+    "progs/bandit.mdl": {
+     "bytes": 226380,
+     "sha256": "7cc68b0c9a4950b4d3b97353227a6b8845104417efebfd00348b7fb24986d557"
+    },
+    "progs/baron.mdl": {
+     "bytes": 426204,
+     "sha256": "09a4b10b43c2cb4847330ce3660eab93c16a97a7db0c9e1c1447e938689627d1"
+    },
+    "progs/bbg.mdl": {
+     "bytes": 190836,
+     "sha256": "3bac35175b2808bad33e3b7e7c2c54b3d9181c5b3743aa68d803dbe58edf0eea"
+    },
+    "progs/beam.mdl": {
+     "bytes": 1460,
+     "sha256": "9e9531de6f4e6f2f6274ea6612ef00bd0642c0cc05a7fdc866805fa1be851b73"
+    },
+    "progs/bellring.mdl": {
+     "bytes": 74016,
+     "sha256": "9a8131071ca927803140ce6478b8912c6eb52856861250d6b6bfa1d32cfb9cd9"
+    },
+    "progs/blood.mdl": {
+     "bytes": 184,
+     "sha256": "06825646d627df610b374a31c9265a88c9c1c45864c6e3b9d273a14dc4d745a5"
+    },
+    "progs/blood_gr.mdl": {
+     "bytes": 184,
+     "sha256": "84caed23ff1b8cabec8c5d9e5c6792c30a6d9cc57c36a9746369012015462208"
+    },
+    "progs/bloodcb.mdl": {
+     "bytes": 28036,
+     "sha256": "83f0de29aa0f9e9f1d383895da374a5313aa2252edb306eb7bd69bd71660321c"
+    },
+    "progs/bookclos.mdl": {
+     "bytes": 3420,
+     "sha256": "a129ba5428a5fbef209010b893b4407c99a3d3a9e936d9d41247af5a75fc922b"
+    },
+    "progs/bookopen.mdl": {
+     "bytes": 6188,
+     "sha256": "d57ab7e96181b3fe70bc9c0c002ed6671fe14adfd454b680cd39be10b2315a05"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/chest1.mdl": {
+     "bytes": 19352,
+     "sha256": "239f897e3a390ad44acc5ffd19784f8b78232c5af2be67165581c2f6073ecc9f"
+    },
+    "progs/coin.mdl": {
+     "bytes": 44036,
+     "sha256": "c3d65aac43713c9102f8924ef7ed1cf90297ff17cfe8aface7936e9579b4ec57"
+    },
+    "progs/courage.mdl": {
+     "bytes": 14940,
+     "sha256": "4141933fbb8682ee28277826bd0f882580025def71b96c02cb9b53aa412906c0"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "7829e2cbaa4816577c77ba12a91933eee5dcf9d899f3f4d9717f6f8fc0319a23"
+    },
+    "progs/demon.mdl": {
+     "bytes": 355000,
+     "sha256": "3bb7fc1b1f89de1d66f99de4065d71e35dec87940d47c98b24d3be074d8bf70a"
+    },
+    "progs/dog.mdl": {
+     "bytes": 269016,
+     "sha256": "9a60157b0504891c71fbaece5a729e9b954a5e2dffe92e1e1a1ab51c6d912b77"
+    },
+    "progs/doll03.mdl": {
+     "bytes": 52064,
+     "sha256": "b2962f3954740ad7f9b5ee329d3a189ed5c95ccbb279bb63dc77508c94e4fb28"
+    },
+    "progs/doomcube.mdl": {
+     "bytes": 8884,
+     "sha256": "c4d31e7a4f2a9c01c1c502fec3653d8e0b14fc6ec790d8edebb1737a6116a471"
+    },
+    "progs/dr1_head.mdl": {
+     "bytes": 7476,
+     "sha256": "06f28a6f55ba29f12965e7ca10d99147a9432c851a2747d1e861cd45c07d958f"
+    },
+    "progs/dr1_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "c208f5473b2954fb4af094119b5a63b3a205e7a26e94c0c122b1f06870db6f78"
+    },
+    "progs/dr1_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "258da574e4de9d144d4f6a71db72a8bd566ecc6b0672efeb5cacaf59c7dd969d"
+    },
+    "progs/dr1_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "698d06c98e8e9ab99b6ddf808bb32a4994299c9596354bf8f811cda0f4042588"
+    },
+    "progs/dr2_head.mdl": {
+     "bytes": 7476,
+     "sha256": "551d47f807e21d11aba52f66207515e0988e8a424012f204e517c8c6720514d0"
+    },
+    "progs/dr2_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "f636b0786ab159a368b9fa580f1a0a31dc7873f21edb1bc454eb9e64c2c27a14"
+    },
+    "progs/dr2_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "533c0d631c78c22f5ff7632e7dc19f5da1acee56225a5a1497bf34d10fc07344"
+    },
+    "progs/dr2_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "5f5eace00eef74eeaa9db48887636e08ab43c85ad0d05816745c04a4710f34d3"
+    },
+    "progs/draco.mdl": {
+     "bytes": 235148,
+     "sha256": "0b51fd9b782891c4b8b410db6ac1361dfa0f53d634366709434a926e0c7285b5"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 262688,
+     "sha256": "d27bb0ed21b8f0e8161f347cb5bba89c8c5223324f462596f972478efdacb366"
+    },
+    "progs/dragon1.mdl": {
+     "bytes": 258260,
+     "sha256": "4dbf09c018ea9f703d4daf48c0a5e504208547d5d172bf26187b8eeac8a94a02"
+    },
+    "progs/dragon2.mdl": {
+     "bytes": 258260,
+     "sha256": "fa2b5d9467299634cddcff9c7ca87c2006c8c9631f45cbf66f74a8abfd5df347"
+    },
+    "progs/dragonpl.mdl": {
+     "bytes": 77764,
+     "sha256": "57db3cbef92a0f96cd8ef1be17ce77586f9541bbffcea2e7747e43b35c50effa"
+    },
+    "progs/drggib01.mdl": {
+     "bytes": 63320,
+     "sha256": "0a2571dc74871a4d43c8c780a62d36ce4d17dd83b6819c773bfb22a247b8bcbb"
+    },
+    "progs/drggib02.mdl": {
+     "bytes": 83352,
+     "sha256": "c3ec2317e0f0f156237b7ed36d1ab3329a874a11f7a2fb343afac021a50f777b"
+    },
+    "progs/drggib03.mdl": {
+     "bytes": 58824,
+     "sha256": "9dfdc32e9616b40b82c410ca75f007bc11a9b18697d4edc82745bcda1b3313ed"
+    },
+    "progs/drilbomb.mdl": {
+     "bytes": 5396,
+     "sha256": "6615fa32cb3b464b665093296ff63fd0c624eea5ec595247d8c66941e1c8d071"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "718b8c2842877345426247148dd6ce1ebe7fecc13e969a0fa0ed6dbebc388099"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "0a386b6381824b01852910519490ac3f6e3309a96091820384ee6b9a5b452e7a"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bef43e6c7bc067d3b35dd05a793c08d7d700fbb2013606ac9ffeac8772d0997e"
+    },
+    "progs/drp_head.mdl": {
+     "bytes": 2340,
+     "sha256": "b87cb902d796dd76c03e9fc79576f368d23022fbd5b5155c8910cd315046e32a"
+    },
+    "progs/drp_lw.mdl": {
+     "bytes": 7116,
+     "sha256": "ad483731fddede05ebf1a9a3c20f735f6ec341f156669833ed1077460dac8e5c"
+    },
+    "progs/drp_rw.mdl": {
+     "bytes": 8056,
+     "sha256": "b57363de0be61e45b355d1cceccadd42fdd1b8f91fc4380847dacf186d7560df"
+    },
+    "progs/drp_tail.mdl": {
+     "bytes": 2604,
+     "sha256": "b8ad65168755d4f31b657a80c78e2e0f51316c48f4ebd10ddae0b6971c7c6e89"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/ember.mdl": {
+     "bytes": 8788,
+     "sha256": "91d6f4dfbeba0711d0864b94bb372b602959644c5c841fd659ddedb8f8e6980c"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "13d14261d863f5170fb8e64e57b8ef344c435183313ffb1127ab6ce51176d262"
+    },
+    "progs/end_bane.mdl": {
+     "bytes": 52980,
+     "sha256": "4a86fd7bd59c4ecea934e3adcec4b17d627cdfac5223976a52b5739143c37f27"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 241252,
+     "sha256": "9ae37ced89200daf2d44795bef4230c5b725226a820c28cda7908f43bbdaa747"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 414484,
+     "sha256": "3d146be46cd90ce477006354b3ed627541fc4ecdb52ff6de2b4f3159c61e1390"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 68804,
+     "sha256": "f3c760ecdbb530ff651c46f516228c588f37585315acdab199408911c2c8414b"
+    },
+    "progs/flame2a.mdl": {
+     "bytes": 68804,
+     "sha256": "e02210f2f6851cea4b9520476cfe36c31745dc2d84248f6a75132358d6d43035"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 56532,
+     "sha256": "36d304e1442ede2048036d832d36ef4624fe4e90ba16628c20c819e7b4477da5"
+    },
+    "progs/g_grpple.mdl": {
+     "bytes": 149440,
+     "sha256": "fc148b3a840b84b65488658ec26a27621a86a196feb90723269534929ee0352e"
+    },
+    "progs/g_gun.mdl": {
+     "bytes": 35580,
+     "sha256": "0d6cbc684d5c5f1112d0111e29405e73721993ad57854c936e676025b7bfbc1c"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 38004,
+     "sha256": "cf67c0a7ad3e853fa4af7544d0399fc0a3795a61d625f5e78104e659e2db0eed"
+    },
+    "progs/g_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "3e4a1e9dc2bff162612e218a25e2040b57d063d198df2e301eaa8fa9542af098"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/g_rocks.mdl": {
+     "bytes": 47732,
+     "sha256": "d6539141be1597673eb1f8c78286d6efdeefa91f9723926d61b9a81e2f433c71"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 158116,
+     "sha256": "127e4fefafc5015f03a6cd1288cab9da325ed5b5a93c9f6b90b6da9d8273ef9f"
+    },
+    "progs/g_wand.mdl": {
+     "bytes": 13684,
+     "sha256": "99212b7901c31b723704e7c62b1c5f70b6a2f7320c349605a3943f3091e962de"
+    },
+    "progs/g_xbow.mdl": {
+     "bytes": 22476,
+     "sha256": "bf1cd180a66f74da4e625a2167bf66527cebd0d4009fabeed48297018db8a4fe"
+    },
+    "progs/gem1.mdl": {
+     "bytes": 42612,
+     "sha256": "0b71e525b19e25f98dad53ce766751de8e0c9f18434582bb86242296bb7a402e"
+    },
+    "progs/gem2.mdl": {
+     "bytes": 62672,
+     "sha256": "721459e22aab0d2cece430053734b889918bde4db879ffc94084289a7b6d4d8c"
+    },
+    "progs/gem3.mdl": {
+     "bytes": 42072,
+     "sha256": "3bc3a1018cc432b694f9ec45de06775776ef55d21b4e117dd1b2c7c0d7b850a2"
+    },
+    "progs/gemini.mdl": {
+     "bytes": 35188,
+     "sha256": "fa05498ce8034d51377953db7c650f9367b072a9d614812f4f67ad15eace909e"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/gr_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "3f5b6d67b80e5f2e5bb7c129500c79dc345141133f8d415005f9384b0d2d9661"
+    },
+    "progs/gr_gib1.mdl": {
+     "bytes": 6501,
+     "sha256": "3f715cbfdcd77caef11b904aa12d2063cbb973d4a9d61c27492690344c14fb1b"
+    },
+    "progs/gr_gib2.mdl": {
+     "bytes": 17553,
+     "sha256": "c6166eb6132a3e87f51fcf48f4e9eebb719b3f1819d22640582b23d61bde4a16"
+    },
+    "progs/gr_gib3.mdl": {
+     "bytes": 22933,
+     "sha256": "0e40e5b960924ca642690c26b239c89aea6bae18badcb945e96d2102cad69622"
+    },
+    "progs/grem.mdl": {
+     "bytes": 202672,
+     "sha256": "3df027b9f674f1f3d3cd775c877fe225029f1b814ff3358f98f932cf8bb0a604"
+    },
+    "progs/h_archer.mdl": {
+     "bytes": 22128,
+     "sha256": "034d829e2ad34eeff8f5d60b8e2064f08caee64fb7f064900298f9405e9399d8"
+    },
+    "progs/h_axeman.mdl": {
+     "bytes": 18400,
+     "sha256": "e15391056ec618b412d1341914d2e6f05a759de92500ef249cc5d1789b3ab6d6"
+    },
+    "progs/h_bandit.mdl": {
+     "bytes": 9752,
+     "sha256": "cc79629b169c0560905eae7ea9a02e5ec546af8cfa07743922e0b1dc829b29ca"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 7444,
+     "sha256": "68bc1db4875fe84f25ff3d6c53e4e9e2c023ef52bf3c89b439493f2e5c5c0e19"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "53539bc39fc87627a46b75b0d86ade5e6116a0079b032b1df137b2425b7186cc"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 166100,
+     "sha256": "0484f334f5722736248531a726e9a91c69e708a882e6d581db3d4e2a54d6db94"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 68796,
+     "sha256": "57a646b291c29b490faa38e3b72d7f074d9d071946d9b9c6068095999a11ce77"
+    },
+    "progs/h_drake.mdl": {
+     "bytes": 28792,
+     "sha256": "be0bcf5fc725dbb09a82becc2339d91824a14a547ce3013deabeece662658dcf"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 30072,
+     "sha256": "e88bac12b670f6790f3e053e1547569e88f0befa7a07abfc6a3fd2ad33b9d9a3"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 22724,
+     "sha256": "905ed9f78c83e29a31b6283b5a377053763469ae048bdcc3aede9213bda80873"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 100172,
+     "sha256": "27311a59a95ab735d79e5198318d0507da7e377584702ba9e5bf673c0972e065"
+    },
+    "progs/h_hkolem.mdl": {
+     "bytes": 30552,
+     "sha256": "38b2082ead97b90f59a5fdcf24d4077ab067c55655598d023f8ec38818c914b1"
+    },
+    "progs/h_imp.mdl": {
+     "bytes": 73564,
+     "sha256": "24944207a9867d67fa24961516dc2810a5d1b33d341d5190ac1666d58c8252f4"
+    },
+    "progs/h_imp2.mdl": {
+     "bytes": 73284,
+     "sha256": "f01cd8331b8774495258e3ab85ba6434a0deef19b1b953b6ccf93252649e01fc"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 19644,
+     "sha256": "1accd89ba95db3627cee4f06f94ab3bc9d146ebf566da24b570c733f2f902c1a"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "72455aab2067fd8f887e8a8e9c61d2b943699ce90fbcb85937fbb358c9e5678e"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 53188,
+     "sha256": "6e1c28d5c53f24901ebd0aa199a1003ef4fe3c8306c5ab28191cccd14bf25f45"
+    },
+    "progs/h_necro.mdl": {
+     "bytes": 14296,
+     "sha256": "fc9c468465d0e8982fc2d6207ce94b2f400f0f37cbe88cff2a4aa64719b91f40"
+    },
+    "progs/h_nemes.mdl": {
+     "bytes": 78156,
+     "sha256": "6f350692b44907984c02779d0114576bbafb6a3ada673e1f55d1cf02fd062c18"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/h_rebel.mdl": {
+     "bytes": 5428,
+     "sha256": "b189ff3ae1596da7596f21d8f555603951fadf8e7884e96f89c8b2b5789028a5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 53096,
+     "sha256": "ff1d940222f28765b975828528016332b04423a4001a507e07cde6414847add5"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 108204,
+     "sha256": "dd7dc5c90255da868b96ac553d8a8f68b6723da6b25114bc087fd019966a023f"
+    },
+    "progs/h_vomit.mdl": {
+     "bytes": 16952,
+     "sha256": "9822885036229871594a21643f4acd3a9b4c27d141b9021464b5062dfaf410f9"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "7ff66f881f85884aea56396da7b756da32c04df163a1e1f739485e77e61279df"
+    },
+    "progs/h_yak.mdl": {
+     "bytes": 73116,
+     "sha256": "eb2cf314618ef6dbc44ab46807237e59b68470edf24780e4ccd4c5b513f91196"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "2f6fd7256662a5a4b4b907b0ac68bf7d787ebd55cf54e352da5f1b363a2b2397"
+    },
+    "progs/hero.mdl": {
+     "bytes": 66388,
+     "sha256": "ea4f359a328b6416588e5debe13a87fc2eccd8a65263ae23683d71a58b39a116"
+    },
+    "progs/hk_golem.mdl": {
+     "bytes": 179204,
+     "sha256": "972f27eb2bf8a6cc4433e1f904097ca5393312d47a75e396b0323723beff58fa"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 534604,
+     "sha256": "10058c95eca9a063c7990d919d353d3573d252eb39f00c5f471a7f22f0b5fefa"
+    },
+    "progs/hook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/ice.mdl": {
+     "bytes": 2580,
+     "sha256": "30c4853e26d51d0ca4d3df5a40ec6d8861f48e9420f10560b5de0c19e6c15ab0"
+    },
+    "progs/ice_cube.mdl": {
+     "bytes": 3192,
+     "sha256": "bf96c8c1533fa537582bd4cf7bddadb7f5ddeebafbce9ef29007a5acd5a909b0"
+    },
+    "progs/iceball.mdl": {
+     "bytes": 24632,
+     "sha256": "802fa6260e9af5abb74bab0a76f35ae3e2af2373e61091c725325aa41051be7a"
+    },
+    "progs/imp.mdl": {
+     "bytes": 583036,
+     "sha256": "299777bbf58641a6674c0877423efd9f0995421a1bfb946fe21d1f2bdb41714f"
+    },
+    "progs/imp_lord.mdl": {
+     "bytes": 583036,
+     "sha256": "0b26574642cc72b73d349881543752a1f7d7f34f00561c4b039bef83e7191b10"
+    },
+    "progs/imp_rock.mdl": {
+     "bytes": 2352,
+     "sha256": "dbe190f471f5738779e103b496117ec40e2adc9e5f593d2470172bcbd7ade0f6"
+    },
+    "progs/imp_wing.mdl": {
+     "bytes": 93932,
+     "sha256": "a0100af8c072112afde45cc2f69e40de4aacffbdb4515de107892c39a00f5eb5"
+    },
+    "progs/impwing.mdl": {
+     "bytes": 93932,
+     "sha256": "5b986189f2f28ffe6c3fc23d40bc194bda2ab636826a9d41ffc9199727cc2f49"
+    },
+    "progs/impwing2.mdl": {
+     "bytes": 93932,
+     "sha256": "0d08640bcd5c6e6336b9cedb635a6152ba479065a56b296557476a6f5e9b1e4c"
+    },
+    "progs/k_ball.mdl": {
+     "bytes": 31300,
+     "sha256": "f93346ffeed3fd5d9866fb80d1a08216759bb27757d49a1851e471aadf757ec1"
+    },
+    "progs/key_b.mdl": {
+     "bytes": 10616,
+     "sha256": "d1333d74b7e194f6587d0f5ed1fca28887cd0414734b4bd4cbb7e715ab897629"
+    },
+    "progs/key_m.mdl": {
+     "bytes": 23160,
+     "sha256": "ea2feb6eb54823668dcb112f42c3441e563e18e3cc1806b5ce509044e6c0b448"
+    },
+    "progs/key_w.mdl": {
+     "bytes": 11576,
+     "sha256": "72da64d2b29d69605c453e9ee0e5fa8ecef91a94cc541103cb24fbad96c7946d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 232536,
+     "sha256": "e3e618799612c6e521f68234a061d9a46036ef556677b0c1651e7647258ffb56"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 27960,
+     "sha256": "5877b37cc4f98a53467c412e7d06d1f7ec6b60f5c0f2088514aa51c9d2c51769"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "210e159ea4c9bf1f2431213fd95902f4ea75ecee6a67a22bed7e93366f1f2732"
+    },
+    "progs/levitate.mdl": {
+     "bytes": 15876,
+     "sha256": "03e77b0d4b8ee7b3b224cbe0cfba63e8bd27d0391bd5069981e5435287f66645"
+    },
+    "progs/life_up.mdl": {
+     "bytes": 34676,
+     "sha256": "502716aa1b0f6cb8f929fe7ee2a74024a5fa007898256e15ca495e126888c584"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 57796,
+     "sha256": "e8b38ca8f28a89f65ffc652e082e8a9aaf6a1a9db8302e961b9ceac1c8f60e8c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/morph_eg.mdl": {
+     "bytes": 300592,
+     "sha256": "14468fccffaa1508c03610dd58fb51cd9058ca3bab036bca18f7a41cb37c195b"
+    },
+    "progs/nec_rod1.mdl": {
+     "bytes": 16072,
+     "sha256": "2eded5df9441aca7a243bf6c2a831c62374cabf7bba1acd64a84803441d77fc2"
+    },
+    "progs/nec_rod2.mdl": {
+     "bytes": 4564,
+     "sha256": "60b0923cade4c8ab9a476cae75c7c73f71c1d13799ac7901d0be4db5d5038895"
+    },
+    "progs/nec_rod3.mdl": {
+     "bytes": 4132,
+     "sha256": "459edf5ee6ecf0c52ec83e055a2c12ad39d3d3a42a4774c442ccc686e298da47"
+    },
+    "progs/nec_rune.mdl": {
+     "bytes": 19524,
+     "sha256": "cea5c89dd0034465a54a8434bc9367554f0244c2e38ec9220cd28a5a53a444a9"
+    },
+    "progs/necro.mdl": {
+     "bytes": 577208,
+     "sha256": "a0e43517f3cb579e38baf9ee4b5058ed59036b69599c0fe3ffeff9c00ba843f8"
+    },
+    "progs/needle.mdl": {
+     "bytes": 16688,
+     "sha256": "5f714f6b43cc28ca1de1246cc0175ea2e07040f73c9d0a623dbe4b4577559c14"
+    },
+    "progs/nehjet.mdl": {
+     "bytes": 19956,
+     "sha256": "fd0346c9c37d2ca7d3e696a9ce0694652722f63326376ad3b8189fb81a68f5c3"
+    },
+    "progs/nemesant.mdl": {
+     "bytes": 202492,
+     "sha256": "099c26752c7160144a25716e0af0f30f8ff179766db4a05371a0392166f85c42"
+    },
+    "progs/null_256.spr": {
+     "bytes": 5412,
+     "sha256": "c52813b634ef1ab641fdd4c3a9739ad758f1b5c39ba5e10acbbf034ee0ff850b"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 230152,
+     "sha256": "b7c88ae295ef8fc8d17b4fd6facedbb8e464ee665039a884af8e215a3929f24a"
+    },
+    "progs/oldone.mdl": {
+     "bytes": 560224,
+     "sha256": "5690a29cb0ae1a4889bc398676db8477275b0953e2ab7bbb75b717509d93c985"
+    },
+    "progs/pl_oum.mdl": {
+     "bytes": 331236,
+     "sha256": "6939a925af5510ecece22c3cee3de418d3ba532f4eb17409ca1453d253de328c"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 55676,
+     "sha256": "c9810eaac822215e7c84f11e55bb614121d17a79a02aa162fb430b5f37664ade"
+    },
+    "progs/plasma1.mdl": {
+     "bytes": 9120,
+     "sha256": "78a81a8eaaf95f85cd0fb7bc31dfa45c30e660fc5265168178b50776afc96563"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/playham0.mdl": {
+     "bytes": 99756,
+     "sha256": "1016d24c984994843af5d086e36e548c55590018f1f6b2d78799e25a40271ec4"
+    },
+    "progs/playsaw.mdl": {
+     "bytes": 87340,
+     "sha256": "b53cffd1807a3710f03b350370d78dfdbb2b057455fcac9f00d1b0baaabbf8c9"
+    },
+    "progs/potion.mdl": {
+     "bytes": 53272,
+     "sha256": "6ee1b1294f1ff41bdf265d06d80fa22a89ff579acb70bd2544986a0235ebd6e7"
+    },
+    "progs/potion2.mdl": {
+     "bytes": 195484,
+     "sha256": "c4f0f920521bd6e1caa6072b19d11ba57f4d493ffc2d6a395190170c9bec702a"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 47008,
+     "sha256": "e7ba606cf1cc11d9ad5baef5aef9dfa9239b7550a1c12937965a562bc815e6a0"
+    },
+    "progs/pur_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "dbc2bf835db1c1789c329504f86802990a19288f67d9560f32cfe5a8d5a62885"
+    },
+    "progs/r_bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "2d776e4acdf20cd117f3f4d6be3647fb9d0e117756069cbfc52ece716fdbb251"
+    },
+    "progs/rain.mdl": {
+     "bytes": 39276,
+     "sha256": "9a13a2ff68c8d8eb27426cee38330a6237de8ceb9ba9ecb9b71071512b190a94"
+    },
+    "progs/rain20.mdl": {
+     "bytes": 42620,
+     "sha256": "192d3d8197976f98eb053e54a00536ca9ccc8769692e9c483990b64afa4e1d8d"
+    },
+    "progs/ranger.mdl": {
+     "bytes": 232148,
+     "sha256": "21e690b07a7d3b2b0fb630480a5fd52ea23b41a8571c3618d16ea1ab7508e52f"
+    },
+    "progs/rebel.mdl": {
+     "bytes": 215292,
+     "sha256": "433596df8d06be0882f00a2c1fad0ea49a8ae42ef148d32e0ae7c06c420322aa"
+    },
+    "progs/red_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/reflect.mdl": {
+     "bytes": 10224,
+     "sha256": "3e8b08d02c11ee9e5546c96c014c8e698ca9097046ff3873012033c0bcac8df9"
+    },
+    "progs/regen.mdl": {
+     "bytes": 50808,
+     "sha256": "1c2422c4124c235e29570580b0c1bfeb55613d6c8152c78dfb6d073ea316f122"
+    },
+    "progs/regen2.mdl": {
+     "bytes": 50040,
+     "sha256": "b8da16335e855c502b7ff0c5b6875050b73c01ff0eb5b5627fc890d155cbe013"
+    },
+    "progs/rocket1.mdl": {
+     "bytes": 34260,
+     "sha256": "c9412482647d681e08f74eb0c0260ffded91dfc67378996b86b720ef3cd2fd47"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 17204,
+     "sha256": "0dab5b94c60d92d55df3e44a8d8ea2dc0f949e98897a6525ee0be3f49a019b08"
+    },
+    "progs/s_expbig.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 165212,
+     "sha256": "5b78b324e252f95ef8f4a9fd4fb19f855c40f74fd1f93aae9b84ed822e9c3585"
+    },
+    "progs/s_fancy.spr": {
+     "bytes": 432120,
+     "sha256": "2dcb35ecb5312709ae4b295ebcf209e74a34e385823f54603e6fe0eb8999556b"
+    },
+    "progs/s_kinn.spr": {
+     "bytes": 45624,
+     "sha256": "c6412ac75ec56533cbf0487223c2c8a23a3d3518b0e3f7ed8af73b81cb6ecbba"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 8016,
+     "sha256": "fa366e4076268de137e0eecd88d02e3aac99f38c48c6ad0d0a74c88c95e8d4d4"
+    },
+    "progs/s_wave.spr": {
+     "bytes": 373212,
+     "sha256": "c2a3b258b2809f22247596b6e0505829853e9a5fd60fed7c471fd663cf9e9402"
+    },
+    "progs/s_wave2.spr": {
+     "bytes": 39480,
+     "sha256": "a0fbc773e66385a8bc3c16195ce14215050cbec7caa118fecae1a0c2a2c59d50"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 333284,
+     "sha256": "90757e506c9f0e49e4e9897708df4825e1b27774ff46abd9c113738380dfde62"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shade.mdl": {
+     "bytes": 83644,
+     "sha256": "080ad2839fafadfdbbe5412ac53061a917af3158f33e16f5df4b4f3dbe422ccb"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 128012,
+     "sha256": "94aca4b876e4794684f4f2b9e66f1c34f7b3935b0d35d406311b63aba17ea3c2"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 176048,
+     "sha256": "7ea0c1007179eb7a45112aaf38d8042213e8b644e6e79b9b1a8d4402c3843b47"
+    },
+    "progs/shotty.mdl": {
+     "bytes": 16984,
+     "sha256": "42f2e1a71e00db26092b7fb9c633daff43bfebdcb46ced46526bee057464cc88"
+    },
+    "progs/shubdome.mdl": {
+     "bytes": 97512,
+     "sha256": "3b92e43bc942b2cfba8c7b4e1206ad858484564d86bd7faa069db592f98c7232"
+    },
+    "progs/shubstar.mdl": {
+     "bytes": 14760,
+     "sha256": "ee5f914d7f3f930db06b1ead8d314dec0413e5182b7de24cc808076d117f3cda"
+    },
+    "progs/skulbook.mdl": {
+     "bytes": 15572,
+     "sha256": "794768c4237a3efedf0c13026213aa417dec5be7eba7971f6e1113b5167fb904"
+    },
+    "progs/skulhead.mdl": {
+     "bytes": 50688,
+     "sha256": "d0733746c8b7cfccdb8d0f30f9454c8863a470e6d56e8359828dbb450aade77a"
+    },
+    "progs/skullwiz.mdl": {
+     "bytes": 726948,
+     "sha256": "0736c202c56cde1cfeaa10b62ca3747f85f08ae3a9cb5daa924456166664e4c4"
+    },
+    "progs/skullwz2.mdl": {
+     "bytes": 726948,
+     "sha256": "ba9f6f478a92ef3f6eec11a1d9c72e4bacf01e755e7f68dae4f6cf2856ff5504"
+    },
+    "progs/skulshot.mdl": {
+     "bytes": 63400,
+     "sha256": "73d6d8e5411b9ae3cf815c3b0cf695a5633cedd5d586565880a9146a1a5db5c2"
+    },
+    "progs/smartbal.mdl": {
+     "bytes": 27924,
+     "sha256": "288e2d54afcbdc5242ab831f3ef611710317c52432e4585a938a12df80b7a07d"
+    },
+    "progs/smoke.mdl": {
+     "bytes": 184,
+     "sha256": "2086abd9950bc643446309a80d9df86b4ebe3f2086f75e799ce943a8454c77d7"
+    },
+    "progs/smoke2.mdl": {
+     "bytes": 184,
+     "sha256": "cdae24fb7cf8efc6ec5271c297f18b04e8c69554ac4c4aedbccd7d3dd39089be"
+    },
+    "progs/soe_coin.mdl": {
+     "bytes": 26364,
+     "sha256": "5769371db409969600bd51d573162c663fb75d358c507fcff9a4aaea95fed4dc"
+    },
+    "progs/soe_gem.mdl": {
+     "bytes": 165236,
+     "sha256": "788f32633f1f3a9f6dd2e0c2dccb76871e02fc6e002db82a219f077dcc493c3f"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 409548,
+     "sha256": "8127b55dec92682e7de27ce1619b5fc8a727413b3cdf2125510138be249a1281"
+    },
+    "progs/soul.mdl": {
+     "bytes": 8436,
+     "sha256": "eb4dc0dae8aed7c92d328096fd9633566b658c9cc65777211ade1e67c6e0ff64"
+    },
+    "progs/sp_gib.mdl": {
+     "bytes": 22228,
+     "sha256": "e902ce3a5e4be26cb781d29178b6e808c480f9e898bc50ecfa78ddf12d774238"
+    },
+    "progs/sp_gib2.mdl": {
+     "bytes": 22228,
+     "sha256": "be98f64e7c2cffce98e28d99b36856762cc15caf761015067fde234390e6b302"
+    },
+    "progs/spider.mdl": {
+     "bytes": 355540,
+     "sha256": "6b32cacff38987b0b4a5efe585dce71ce64ee03e12c4bb1243b1be350f1f3b03"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "078b774958c598bdf1503934d51a1393aeb9aadebcde806db2272b04b233c6a2"
+    },
+    "progs/spikes32.mdl": {
+     "bytes": 7668,
+     "sha256": "983176e5f12571f9b38c9c5d100841e480fe8ccf143889a0e48292a5bca8bf63"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/st_baron.mdl": {
+     "bytes": 185964,
+     "sha256": "7c00af263c1349b9dda2b1a6706bcce7034e9b0793697d67a1bfa83963ba127f"
+    },
+    "progs/st_gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "813d52c557a1eb519d801652b4bd63acdc4ec18d62db53d843ca3dcaa88e87e8"
+    },
+    "progs/st_gib2.mdl": {
+     "bytes": 16228,
+     "sha256": "2d40c1eb75eeb6f5e1781ee9db7a0be10e0d07297d563f9035a8965c4c8c3d01"
+    },
+    "progs/st_gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "d44a77787c5ff633593ad9741ddfbe28809431daf3d32fbe92f8512871b9018a"
+    },
+    "progs/t_coin.mdl": {
+     "bytes": 35040,
+     "sha256": "ed7a18cfce56a630c9adaa37757e270419fca318b3fa655fea18002b089441b0"
+    },
+    "progs/t_gem.mdl": {
+     "bytes": 165364,
+     "sha256": "955761ccf88ef8f6adcd635fb70ae5d8e434b19394a15124acc4370e614f2409"
+    },
+    "progs/tar_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "1ef69998430a54ba662abb46a0ef303b3bf0066f53e84b166065e79d58a72bef"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 313448,
+     "sha256": "fc63e6f62c83975ab2756f0a844d012b887491a6c73d9350dfcb04a6e0355b3c"
+    },
+    "progs/throwax2.mdl": {
+     "bytes": 34872,
+     "sha256": "11a22371cc72adf001e21d04e1b8b65e01497f56410867aa42ea21c0ff304e48"
+    },
+    "progs/throwaxe.mdl": {
+     "bytes": 56532,
+     "sha256": "0ebedab9ab397ba15dc3f0d90df703af2984d1c070eabc08ba781c308968150e"
+    },
+    "progs/throwham.mdl": {
+     "bytes": 7072,
+     "sha256": "f161fedb096a34db55fe57e84acd2bc42295ffea688549235c762b9a70430b35"
+    },
+    "progs/tome_pow.mdl": {
+     "bytes": 2612,
+     "sha256": "40a792071152640897de449d672a693229a87a11bf5e37ab05fd1656be22b6cb"
+    },
+    "progs/tree.mdl": {
+     "bytes": 237576,
+     "sha256": "f1f85524e4018552188aa58979154ce5544381d7bfd5ae05da521e55efdc25e5"
+    },
+    "progs/tree_zer.mdl": {
+     "bytes": 145444,
+     "sha256": "e87574f4e067fe99704d235ec155118736e0e69d9554f8622a1f1ee1c4f831cf"
+    },
+    "progs/treetall.mdl": {
+     "bytes": 120532,
+     "sha256": "e74e7c38099ccc833fadf3c7b7e97f746878d07102dad8cc5926546b344cb982"
+    },
+    "progs/uberpack.mdl": {
+     "bytes": 19348,
+     "sha256": "810cd3f895ef65e11f70fe00e195026308af02248b0f1442da5e816b7d6a7d9a"
+    },
+    "progs/v_grpple.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserb.mdl": {
+     "bytes": 35492,
+     "sha256": "cd2dcfa0fc848499235735fc5c7c5efdc631a779747f71441ff05403272bd9ea"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 93080,
+     "sha256": "05655920347b597feff05a74725b20cb88693ac78fdccb3730918a01cc4e6811"
+    },
+    "progs/v_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "a2d573bdf52015bce7a571a2263a3e8d938daf0bc1b5e4589f84580cab7da2d4"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 35492,
+     "sha256": "2f5a6e74998e4783d9b3d458d167aed31f32cd49b362f01b8d9ec0e94f90de63"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/v_rocks.mdl": {
+     "bytes": 58548,
+     "sha256": "87d0958027fadf417616cc48367b19ef6f9215a0685edc239c751b59e2b6368d"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 165540,
+     "sha256": "abd6787fff37c452fa01f4bbc9eb9594311eaf4a794f161caeb5a501ab9e103f"
+    },
+    "progs/v_sword.mdl": {
+     "bytes": 94416,
+     "sha256": "74b2fd6983cfb317ce136eeef6029d0cda063efe4706abc12057ba32cb0e988a"
+    },
+    "progs/v_wand.mdl": {
+     "bytes": 27388,
+     "sha256": "b46ba82a45a24fe4833dfdfd3c9457b98096a5800d6620d6eae11895653a6698"
+    },
+    "progs/v_xbow.mdl": {
+     "bytes": 95168,
+     "sha256": "e65f7cfe84cfa7c84c34147dadcc8b5ceea9416c7e378bd2110961fd76348e70"
+    },
+    "progs/vomitus.mdl": {
+     "bytes": 79724,
+     "sha256": "03dffcc3405c63f0e0c11301a74da5403d957b66171a6f34eaf8998e4ba31550"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "7758aaf42d0d1617e4fb172ce842be4316073f63250aba46dad441327cccb2e6"
+    },
+    "progs/wanted.mdl": {
+     "bytes": 27860,
+     "sha256": "03337a468db14377fcd36842037d2a27dfb97c3d5d5f45fcfe408e79050a5839"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 67956,
+     "sha256": "39c4a5daef1cfafc1bbfff1ca8eebb5c75d27f953f31d29f249205762605a56f"
+    },
+    "progs/wings2.mdl": {
+     "bytes": 28980,
+     "sha256": "5342d6191f59e69eb830a5e833473ac253b3a7750063d5519f6d2da2b82f5573"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 109380,
+     "sha256": "d78cd5ac1d667ec808fc7664071e060cea40179a0ba094e2f4c119d5ef7a79ba"
+    },
+    "progs/wr_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "1bfb049cf920973e32d78cbf7cf8b6c0c18f8dde55006ee43798ead4b99af9a7"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 238732,
+     "sha256": "5d0f3d6b32bfec300894dbf066a15bd9e34b985919423446232ad85d2ad6d6b7"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "progs/yakman.mdl": {
+     "bytes": 736212,
+     "sha256": "91595b5866d8f85fe67f349d22fb0c4735a4255894ca7368b10bc06618b98a3c"
+    },
+    "progs/yakman2.mdl": {
+     "bytes": 265228,
+     "sha256": "caba3ad0554bc09c10855592447424ac93beff1665803b2e5c605bd36b28cbdb"
+    },
+    "progs/zerkhelm.mdl": {
+     "bytes": 47604,
+     "sha256": "07fe43e56af442776c52da95902eda56c0bb197783fc5279ca350fc0dd34c4c5"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 226776,
+     "sha256": "f4d35645fa47d159cf7dee47a1652ff239cbe7a7b3df8567b865c6d44536abf4"
+    }
+   },
    "sha256": "9a229082e446dc3991778b3364ec5aeba9b6767e5905406767f753862997295a",
    "timestamp": "2011-06-12T21:18:08.000Z"
   },
   "Tershibboleth/pak1.pak": {
    "bytes": 11698993,
+   "files": {
+    "sound/ambience/amb21.wav": {
+     "bytes": 80716,
+     "sha256": "d664ea08d9df7e7dd135eb0726c1bc142878dcc53d13564dd3dcc5562180201a"
+    },
+    "sound/ambience/amb22.wav": {
+     "bytes": 92716,
+     "sha256": "f444289984b285a1497f55e566fbbf1896a04fa38e291efaa3ec1a0720204811"
+    },
+    "sound/ambience/amb23.wav": {
+     "bytes": 40180,
+     "sha256": "e451997ac7f37d08bd8434d708f45ee2967693317684b947ce511c9df84828b3"
+    },
+    "sound/ambience/amb24.wav": {
+     "bytes": 42282,
+     "sha256": "ead78c8507a7a6a7d6c61e913a2319964f6a8f70b5f7f720c162725edd9cd5aa"
+    },
+    "sound/ambience/brik_hit.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/brikhit2.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/chant3.wav": {
+     "bytes": 116346,
+     "sha256": "5d71f12940688414ab8cabc0d88e323dc961b60aac66f17887712133f1cb8b29"
+    },
+    "sound/ambience/current1.wav": {
+     "bytes": 50906,
+     "sha256": "dabe357d48586dccb8e1ed18c49828797c9f7a8c02c7a588ddc76a62c9b1d3e4"
+    },
+    "sound/ambience/drip_amb.wav": {
+     "bytes": 105444,
+     "sha256": "b282bc6082754011ee21a82aedb490a856c0f694f57991992296554c13149b02"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/heart.wav": {
+     "bytes": 8190,
+     "sha256": "a5b42c46cca24da59c324bb28ce6887b3a2a3baafcc18b0db2b2485f1189a4e0"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 177840,
+     "sha256": "9daec0732dcc821670b8910a1371153e3829e604b6957bf95931bea416af6074"
+    },
+    "sound/ambience/mov_watr.wav": {
+     "bytes": 44432,
+     "sha256": "9d6721844fd5559ab4f53902e70ad9789a90710dde082d222bd814a36c00ab67"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/spark2.wav": {
+     "bytes": 61640,
+     "sha256": "7eb18b00cd5e7913fea7a85ec5b1db159d1d001d24d4f687bfdb5685cb163c8e"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 106286,
+     "sha256": "056f37dfd1d5f4eba1d1911245dc0930bb0c46a84d72d867a286e5a9540248a0"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 87710,
+     "sha256": "2bb46f7c8f70fd28f0ca47b294824bcca7689047291b6c5259eebe76ad6aecfa"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 140630,
+     "sha256": "5a4dccd168cbd9f759ac468d7aa879dbcdbe5637e0fd0521f641ba1d60f61817"
+    },
+    "sound/ambience/th_clap.wav": {
+     "bytes": 570992,
+     "sha256": "5b93e5d878621c2a92e66d6214b0fa8acf8ad5a35f4120f456ddf5678e941d94"
+    },
+    "sound/ambience/th_clap1.wav": {
+     "bytes": 72062,
+     "sha256": "1fc3146d501953545b2f2f261cd2fc398959a79c753a291702609b4cdd2e8682"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/wall01.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 28798,
+     "sha256": "f66c76f07eef275e904fcc76d7ca9fc2011f3de8c61ce0b3ad035464beb7a86c"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 110578,
+     "sha256": "c3e1ccb091b9d8a06b83530b5e29b9f26f5ad8b9dcd082f3da976c3d44944b87"
+    },
+    "sound/ambience/wingend.wav": {
+     "bytes": 90874,
+     "sha256": "63e435d896b097d4dc413fb1afccc2078f1d101a4f7bfc18c4e593ca9e8b344f"
+    },
+    "sound/ambience/wingget.wav": {
+     "bytes": 65148,
+     "sha256": "533bdbd7beffa4c71c66239e3ac417f2177b20a60ed39c379c59a10b2222b367"
+    },
+    "sound/ambience/wings1.wav": {
+     "bytes": 6028,
+     "sha256": "c9e05f66a1d728a88289bc213c9f3551f1e54a4f3e8ef23ab03f8d5019e7b2c5"
+    },
+    "sound/ambience/z1m2mus.wav": {
+     "bytes": 103768,
+     "sha256": "d54261d4c9a4a8a9fe0c51eeae343c6a5b381727af88d0bae6f9b40605b8e5d3"
+    },
+    "sound/ambience/zend1.wav": {
+     "bytes": 123618,
+     "sha256": "2df6c267197b2e82241e47ce4985b04d14e1ce3cff46cebf3177369057302bb6"
+    },
+    "sound/ambience/zend2.wav": {
+     "bytes": 73742,
+     "sha256": "0ea00395004f11d41ab60352517bf5ff5c88a73b8ff2ddb3f32b5085967e3003"
+    },
+    "sound/ambience/zend6.wav": {
+     "bytes": 252626,
+     "sha256": "3f3c412e55bc7534c423c0d1bec2d817e3aea06338b4d6c3f78c4b80e55d509f"
+    },
+    "sound/ambience/zend8.wav": {
+     "bytes": 112122,
+     "sha256": "27cef28aa3d6c3ea86f0c54168db07055abfc7af284bc5a35bf53a0e53f8d677"
+    },
+    "sound/ambient/amb2.wav": {
+     "bytes": 38416,
+     "sha256": "21a4f41fb5efb52587e60395f23824ef330674a8d9499fe2cda1c91603093bfc"
+    },
+    "sound/ambient/amb7.wav": {
+     "bytes": 43020,
+     "sha256": "de7f4a0d15c711c9ca63f74ee38acf78e4ce41800900e0193a43c3e55e4efde6"
+    },
+    "sound/ambient/comphum1.wav": {
+     "bytes": 20456,
+     "sha256": "af10cad0f193d07be9c98f0dd889840fad0f54f40a61d12a1325b78033a68c8e"
+    },
+    "sound/ambient/comphum2.wav": {
+     "bytes": 72367,
+     "sha256": "fbf1ff8677cf36d78e381437f3b8e758a589a108a50c92f24c514eda06ede3f2"
+    },
+    "sound/ambient/comphum3.wav": {
+     "bytes": 116441,
+     "sha256": "62d9624940b93bcd1897abb809cb9d6f2cb3872cfd6af9a792260fb17f800150"
+    },
+    "sound/ambient/fan.wav": {
+     "bytes": 54275,
+     "sha256": "6cdc6a19b0c740d5607fa9076f749dc485483362445630877c6b59ec67085a2d"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/l_hum1.wav": {
+     "bytes": 20790,
+     "sha256": "f1b8bb19b32258ca1b126d52eb98b17c2753a255eba60864f8ad325f564681c7"
+    },
+    "sound/ambient/music1.wav": {
+     "bytes": 213944,
+     "sha256": "bf498e0cf6541b3559abd978ac420c5cb19d6542d89f19f59bdba8019dc46688"
+    },
+    "sound/ambient/pump3.wav": {
+     "bytes": 40435,
+     "sha256": "ae8ca71a1ce41bb3fa02d993930b4f100db3827ef5768326a91e61f7857370bf"
+    },
+    "sound/archer/arr2flsh.wav": {
+     "bytes": 5464,
+     "sha256": "e9a0c059430744c6546a6be4be3a1e4ac775ea6c5e6440d14611ecd8c8447d19"
+    },
+    "sound/archer/arr2wood.wav": {
+     "bytes": 5458,
+     "sha256": "97c5106007e703618291242bf1c6db9853a9d625189fc26ec9c4864436b560e3"
+    },
+    "sound/archer/arrow1.wav": {
+     "bytes": 2296,
+     "sha256": "4aeac8630ff6036f095a251a018eea5baad7a59bd7e46f624dbfec793e44d7b4"
+    },
+    "sound/archer/arrow2.wav": {
+     "bytes": 3196,
+     "sha256": "0a2734df5a69f6407ffc34ab05d8655da5d7dc0e487627932390fa6cec022083"
+    },
+    "sound/archer/arrow3.wav": {
+     "bytes": 2156,
+     "sha256": "1b866280829cb7ac051f90609baa8db285f3bfa3a27b5814e72b021b7cc05785"
+    },
+    "sound/archer/arrowbrk.wav": {
+     "bytes": 5002,
+     "sha256": "f72e35d5232f40e503192ff0ee26fe152eb42e5ee7141b2bea33a9f12f38aa2b"
+    },
+    "sound/archer/arrowg.wav": {
+     "bytes": 15132,
+     "sha256": "8ec5ee520f81c69ba367ae549a06d5ea1643b43f81dea7d8345561c94c8412ed"
+    },
+    "sound/archer/arrowmet1.wav": {
+     "bytes": 2638,
+     "sha256": "87e6ef50bfe4dabf48a1fba18ad0138bbd298965f1a9d06e2b059019e6f74b60"
+    },
+    "sound/archer/arrowmet2.wav": {
+     "bytes": 3118,
+     "sha256": "2797466dafd51473b8b6b5fd3d02a5baa4fe92a1bf9342fb038a299230037138"
+    },
+    "sound/archer/arrowmet3.wav": {
+     "bytes": 2804,
+     "sha256": "1e77951ec2218add2a8bc1633a925e4a96d2ca247d7b5dfaaaefd7a9a4f2363f"
+    },
+    "sound/archer/arrowr.wav": {
+     "bytes": 9458,
+     "sha256": "10e4bef745e55fddd004ea78d24edb9d3d9edc1ce3053c377be07be27a4da144"
+    },
+    "sound/archer/crash.wav": {
+     "bytes": 11069,
+     "sha256": "60e704bdfdb0a97863b00f3514130a172b95a86bebbf89642b65a6e757a74259"
+    },
+    "sound/archer/death.wav": {
+     "bytes": 9526,
+     "sha256": "e824b3d7d66e8bfc3ce30cc3116eab1b2d2dbc09c6311f91ff25d3e7eaef19f5"
+    },
+    "sound/archer/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/archer/draw.wav": {
+     "bytes": 6874,
+     "sha256": "c94e5cec38dc40102beebd067554c91e63b86e5c1ef11dc17976733bd9f08ce3"
+    },
+    "sound/archer/explode.wav": {
+     "bytes": 17788,
+     "sha256": "1f7d6debef492f0861ee24049ad637a11b85d595cdf3f6d6aac422b7a0376d14"
+    },
+    "sound/archer/growl.wav": {
+     "bytes": 9240,
+     "sha256": "7bdbbd23b3fe056cd1d904124824aa0044acf3aa19ec88f65e092fd13e4b9437"
+    },
+    "sound/archer/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/archer/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/archer/pain.wav": {
+     "bytes": 5082,
+     "sha256": "5347daf1a9263320f25b2a191895fbf6c85278f1fde6ca5962c09ed38e0b37b0"
+    },
+    "sound/archer/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/archer/sight.wav": {
+     "bytes": 16866,
+     "sha256": "bcd12d078e7bc34f0bdea7ae9a34ccd2c9bacb049617329b44f8301c34fffeb0"
+    },
+    "sound/archer/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/bane/death.wav": {
+     "bytes": 10935,
+     "sha256": "7e4775bc543acfb421a446a00efff6d9d5669fafb2387464cb1e1ae3db91efe8"
+    },
+    "sound/bane/growl.wav": {
+     "bytes": 9045,
+     "sha256": "86e7b3d2e685d7c20e503bdffe676727426b606ef069f4b70f182601e910ec4e"
+    },
+    "sound/bane/hit.wav": {
+     "bytes": 3884,
+     "sha256": "228faf88857d697f4d5fb9b9c03f000af4dbc8b254791e18e973fd48cc96db9b"
+    },
+    "sound/bane/laugh.wav": {
+     "bytes": 22108,
+     "sha256": "ae8e8d13e00f41bce729977f09a92806c8451ebe5cb4e8618a6b79df4d70296c"
+    },
+    "sound/bane/laugh2.wav": {
+     "bytes": 31560,
+     "sha256": "5cc5ff4c3be35eec90eaaa6579a55fa843843ad658e2e4bbb258a77f6e410020"
+    },
+    "sound/bane/pain.wav": {
+     "bytes": 9325,
+     "sha256": "1d4cfac1f9dfa1ec6958b18014ec7be18dc2615e64888d3c584d50bb48e51013"
+    },
+    "sound/bane/sight.wav": {
+     "bytes": 22962,
+     "sha256": "fbaabe115d9ca4b985c4481ccc71e6b6f55931394a29a6c51ec97e752ed3d5be"
+    },
+    "sound/bane/thunder.wav": {
+     "bytes": 43130,
+     "sha256": "cb355478e38df678e859557a0f983120a4d4275272d8ebedcae7c9cccf659bc4"
+    },
+    "sound/baron/bpain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/death.wav": {
+     "bytes": 8576,
+     "sha256": "3dd3a23d5a913548d0d0aa6ee1b455017648fcd4830f204539a1626c2ec8e1c9"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/fireball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/icefire.wav": {
+     "bytes": 8858,
+     "sha256": "b529a958de192b59438989c6b98eb50f858273febab53a238b651c70a3c92098"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/shard.wav": {
+     "bytes": 14324,
+     "sha256": "313428dd2cb681a38ad89983ab39b18979f64b3e398104b1ad80f3dc9726616c"
+    },
+    "sound/baron/sight.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/tornado.wav": {
+     "bytes": 11469,
+     "sha256": "9ede270665956ce33daf9d3b49447c09e198275f640ccaf77af4f44273bd3f64"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/bishop/conjure.wav": {
+     "bytes": 54627,
+     "sha256": "532d4b7d5db6a654aa73dfe18fa0f6a71623acfd804a848f106b0af699022bc4"
+    },
+    "sound/bishop/journey.wav": {
+     "bytes": 42051,
+     "sha256": "0995e55661447c53c3a36ae4552ea2e0bb7ec8b178bf52cdabe9d28b4deaa50c"
+    },
+    "sound/bishop/rip.wav": {
+     "bytes": 31906,
+     "sha256": "7070871da7ec08da6260a65f1a98ed1bf9682b1c95c51cea262a4b88a63fb6ca"
+    },
+    "sound/bishop/rot.wav": {
+     "bytes": 22463,
+     "sha256": "866b836874ba611d70675e5e3b83eac059c927bef0e0d1396f2183ea01bcc203"
+    },
+    "sound/bishop/skull.wav": {
+     "bytes": 34293,
+     "sha256": "48836a4d60ed8962ed0f11bffdcca95a200645e3b2cfa49a598d6392e10dc153"
+    },
+    "sound/boss1/explode.wav": {
+     "bytes": 27690,
+     "sha256": "b7eebbb64696612ee18d8d1e25b9c5cc334a4562cb99758a446a22490215f349"
+    },
+    "sound/boss1/explode2.wav": {
+     "bytes": 14798,
+     "sha256": "4c6b14b163905823f629644fbec088f37f712cf7f76e10e2f91ef23f2b573ae6"
+    },
+    "sound/boss1/explode3.wav": {
+     "bytes": 19028,
+     "sha256": "69ef0c65811704d8996b726d6e2cbcf70528d3ca7b2f28ec8814c20e7ab76ad7"
+    },
+    "sound/boss2/pain.wav": {
+     "bytes": 84796,
+     "sha256": "b9c255890f61771966327ad49994306a1e3de4b702163a079b5a733b4016810a"
+    },
+    "sound/cube/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/cube/bc_attck.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/cube/bc_gulp.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/cube/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/curse/x_armor.wav": {
+     "bytes": 17988,
+     "sha256": "61b518c8ad8410a17eaca28ee190d96a0c3d1dc755593872d7ec5429c8c19157"
+    },
+    "sound/curse/x_damage.wav": {
+     "bytes": 14772,
+     "sha256": "f74f64e3f47cee7c9b424b94a426f93c133d8acc1e6cb15551a72ab361fe95c4"
+    },
+    "sound/curse/x_leech.wav": {
+     "bytes": 16692,
+     "sha256": "78aacf297df09e21645c2e04ccf181266c35c8e52303ecb498c90db33e8c7b27"
+    },
+    "sound/curse/x_muddle.wav": {
+     "bytes": 18932,
+     "sha256": "b85810135fb3eca3f141047a08cd42a0e527d6da6e9fcfca3887a15f89edad6b"
+    },
+    "sound/curse/x_slow.wav": {
+     "bytes": 16728,
+     "sha256": "0477b046f163d36e9e41c8686ca7538659d0327668d938c0b2405f3a1e6dab3c"
+    },
+    "sound/curse/x_weaken.wav": {
+     "bytes": 15946,
+     "sha256": "f98441764b5f258ee875090c73e5841f4c8f97decbfbd8d9da836a7aac30f430"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15692,
+     "sha256": "72e737f04f1d34044dfd812c6b0e233cd38a91e6b089633e312678756952de87"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16625,
+     "sha256": "bd4cd7902712282ef8f2f749e6fcf805c2ac5212994fbb1c22fc0fe0ea5d08e2"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15527,
+     "sha256": "0b472a984137667f4788336a4f7c60e07a8893f47317b2a158aeea39920d729f"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4107,
+     "sha256": "8fe56b192838dafdf7ff4737cf1e5555d3295cbca49c1ab83568281ee188153c"
+    },
+    "sound/cyber/cybidle.wav": {
+     "bytes": 11894,
+     "sha256": "af7b96ed2eb5bc55900957b3e4136bd5dd93a72dcebca3bc2eb67cdc5186d32c"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8122,
+     "sha256": "3ea23b8d7a68e754211a10a5338b0c8d65df6e2138d4cfe06cc053b9a0f601ae"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13081,
+     "sha256": "a5ec6d4eaa707ad0246b7a7e7737b1007043ea5e5634f6f63661ecc20c27c459"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48508,
+     "sha256": "b7aac875623f8dca7597eff3dcab5910453d043fd1f9df20da89232ce8bf9306"
+    },
+    "sound/darklord/death.wav": {
+     "bytes": 10761,
+     "sha256": "7f32e12c649aa4fc4c2edb773c45b6b4258d048176d95e060390834ee7b52493"
+    },
+    "sound/darklord/idle1.wav": {
+     "bytes": 5632,
+     "sha256": "c151a3cf537f5c3668fc116e6ef5c70c9286e8a12097f376ecdf8a04774926a1"
+    },
+    "sound/darklord/pain.wav": {
+     "bytes": 12684,
+     "sha256": "f332a8cdf67fe414966f59d46714154c94de7ebcca3880a47ef5bbdad2c03ef0"
+    },
+    "sound/darklord/sight.wav": {
+     "bytes": 16832,
+     "sha256": "9710267844facf1c627ea0a8f0df458d847eb899dccd9c570e9d967acc64fa07"
+    },
+    "sound/darklord/sword1.wav": {
+     "bytes": 15982,
+     "sha256": "d36670980603c18a67d500707de9db5a8d54128601d6a6c67f7f29677244aebc"
+    },
+    "sound/darklord/sword2.wav": {
+     "bytes": 12434,
+     "sha256": "f7730881c690e0ee6a440756f74630a21241239fd1fd3bbdfd88000c7e57d1cc"
+    },
+    "sound/doomcube/dsbospit.wav": {
+     "bytes": 43719,
+     "sha256": "97f61cb588bb405cd235e242bfca6fe1108171625a7aa4f2573d63682ac42e32"
+    },
+    "sound/doomcube/dsbossit.wav": {
+     "bytes": 57109,
+     "sha256": "5843548ad38c8eea72548481b5833590fbb7fb990daebd0ede4aaac93475f461"
+    },
+    "sound/dragon/acid.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/active.wav": {
+     "bytes": 16118,
+     "sha256": "5c8762ad62bcb65e1a6fa3362393141a8564fca3ad28ea896a18545c5ebfe6ad"
+    },
+    "sound/dragon/attack1.wav": {
+     "bytes": 25054,
+     "sha256": "c96520801f27bc933928d7f793c2c28ff2dc7b36a86450f6372a9c8a668b4f58"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 63766,
+     "sha256": "55eb476a990e479c06b4c9a12b71c595d8ada35e813e512986709650ef0e54d1"
+    },
+    "sound/dragon/death1.wav": {
+     "bytes": 18358,
+     "sha256": "645baa1cccaf1dfbcd628d17fd8ea290f42f1bc40903e26c79a536a6d1528a2a"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/fly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/fly1.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/dragon/flywater.wav": {
+     "bytes": 11034,
+     "sha256": "68cac399467a55df3c80331696869309eea2339467df0ba94408be4fa2afeb3e"
+    },
+    "sound/dragon/ice.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/icehit.wav": {
+     "bytes": 9370,
+     "sha256": "089c07d0352678106aaa1c47f015792393d5aa01b4bd64fa35e798c4ee09108b"
+    },
+    "sound/dragon/idle1.wav": {
+     "bytes": 34068,
+     "sha256": "3a125f0bcf2908e4ba3af298b117f71c0efa43be4077e53c791b2805cce6a038"
+    },
+    "sound/dragon/idle2.wav": {
+     "bytes": 21474,
+     "sha256": "e1101ff0121687511a9c978d0a30a945421d0a2a30b7d139e4427d41dcc17628"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 28302,
+     "sha256": "60a99d79b6922a14e27ed63313e82ff17b127bda008bd614d8e9ed86f0f2cc3a"
+    },
+    "sound/dragon/pain1.wav": {
+     "bytes": 6524,
+     "sha256": "6cdce2fde3a1eb328007e0667c5dfe705e87bcd526e416ac948fa11a36448ac0"
+    },
+    "sound/dragon/pain2.wav": {
+     "bytes": 6875,
+     "sha256": "3238b77aafcc60c634cbdbd47ae1eec99bb969e2161b72ce5623398e6a451d2a"
+    },
+    "sound/dragon/see.wav": {
+     "bytes": 39640,
+     "sha256": "e8202c360287700da28f96d6a14fef6bdea04374ea911f2b3e41183cd8a136ba"
+    },
+    "sound/dragon/sight1.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/sight2.wav": {
+     "bytes": 15205,
+     "sha256": "197238a35261e6792c40a4da38ba7b3827116ac1af5f143e092768346605b470"
+    },
+    "sound/drone/drnblip.wav": {
+     "bytes": 2106,
+     "sha256": "b372ece13de5edfb22d88ff147a9eccfddfe446c9403607d89daae09fc7c8b68"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/force/force1.wav": {
+     "bytes": 30022,
+     "sha256": "b609981695694648cab0f2ed521dbf3d6f31b6c2e8c3e8502ab4740c7a105557"
+    },
+    "sound/force/force2.wav": {
+     "bytes": 10252,
+     "sha256": "32c0342dbc9e63220db18fa706ac0fc1afe9a86f4d488e509e1f52bee955e3cd"
+    },
+    "sound/force/force3.wav": {
+     "bytes": 10252,
+     "sha256": "0317e18dab002184b5ce11a2b86f3263d2606c40f2dc435c824bbd075c1b621b"
+    },
+    "sound/force/fusein.wav": {
+     "bytes": 13669,
+     "sha256": "53192c25adab70ebcf471204aa194ef9d34c4161138c728d95f84cf08310a879"
+    },
+    "sound/force/fuseout.wav": {
+     "bytes": 15379,
+     "sha256": "f515c6b48204f2ba158e99c10a9da60cc45756ea5dca716e256ffbe54a017512"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/goblin/death1.wav": {
+     "bytes": 13890,
+     "sha256": "bed0d074d9aeee8f046ec7b3a9d33e02d157374ddf6af1296bd1ca7bebf30f10"
+    },
+    "sound/goblin/death2.wav": {
+     "bytes": 10280,
+     "sha256": "9cc07020579d50185ea401835e41edbd1c8f007065e39a6306c7aab4f32e7781"
+    },
+    "sound/goblin/idle1.wav": {
+     "bytes": 9802,
+     "sha256": "6c5a8c36eedb0ac5bddacfdf68250c36fe472f9d87e8969b4f95a863a99b77ce"
+    },
+    "sound/goblin/idle2.wav": {
+     "bytes": 9242,
+     "sha256": "5850c885e59ef04ae90be0579dd6f6b7cc26c282045ccb163dab2c9e19fea704"
+    },
+    "sound/goblin/pain1.wav": {
+     "bytes": 5118,
+     "sha256": "8afd94fcaa2d20e7c6626eda0c6cd5463670a1dbed0eeea36da588b28196c8a2"
+    },
+    "sound/goblin/pain2.wav": {
+     "bytes": 7898,
+     "sha256": "ad1f3b63b4ae35e4bfe010447bbd18bb85cd2bbf966ea7e1370afb0e924e699c"
+    },
+    "sound/goblin/sight1.wav": {
+     "bytes": 12716,
+     "sha256": "1c20028239d217f31af57649da5d1a6def576569ef5fc7e7033c2acbef7f9345"
+    },
+    "sound/goblin/sight2.wav": {
+     "bytes": 19356,
+     "sha256": "c9182325cacd9734bfedd48cb5d8076d5823b7a94baa40d32b02de9504474b48"
+    },
+    "sound/goblin/sight3.wav": {
+     "bytes": 8526,
+     "sha256": "796b2f9f0a1c20d672382c6681e9a6ea200fee2cfcacb5b3d3faa72c8e2537d4"
+    },
+    "sound/goblin/sight4.wav": {
+     "bytes": 8668,
+     "sha256": "c0a60baf2b9918a6df5fc32cd8b58c9fa7cfed923a4cb21c841f04f7a544782e"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 27521,
+     "sha256": "424ceef852229e94dbbbc879f1546a8dfda90db93c6263700cf4973805e4bea7"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 16192,
+     "sha256": "98d55bc63eff48521faeed1046064569e932986e734168ba0973c184aa2f5d12"
+    },
+    "sound/golem/step.wav": {
+     "bytes": 11226,
+     "sha256": "851e243a2e6ecf4cb637f8c4368b0f25443d4f9d104733eecfa886c40ee92bcc"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 47176,
+     "sha256": "87f013eb50cb30a967a183f0cfa41b4848f9269afd13dbe1ab5053458bfc5f0e"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 10768,
+     "sha256": "c48f2415db3a5067dfbd99ad580e3f4809532743d653eafe2fdb924fb0bb832e"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 47502,
+     "sha256": "a0c0bd639af614c7714388009c9388f6db9a694e7ecd8fac38653609d6958f61"
+    },
+    "sound/gunner/death1.wav": {
+     "bytes": 67190,
+     "sha256": "14f89744b8f7225e0eefd9e291aee533fd9f759b6351b57d357d9597dba90956"
+    },
+    "sound/gunner/death2.wav": {
+     "bytes": 48066,
+     "sha256": "693d0d1142dfa12ce2dd1d7b959094c201f3bf783114064c29a572dffe2fcfe0"
+    },
+    "sound/gunner/idle.wav": {
+     "bytes": 18376,
+     "sha256": "6c5b1f1d39f1cc78e87cdbf584b8a508fadc99fc2b8b85d21d0e088d134a8b2b"
+    },
+    "sound/gunner/pain1.wav": {
+     "bytes": 17292,
+     "sha256": "afee7d4ac4f872716fe3deb5adced9a99bd3744784329bd12608d051b81ebfc7"
+    },
+    "sound/gunner/pain2.wav": {
+     "bytes": 20282,
+     "sha256": "38d472d2eaaa7638f7980a06a36043353e86d99aa7e86e0132c52639738c87b2"
+    },
+    "sound/gunner/sight.wav": {
+     "bytes": 22572,
+     "sha256": "395e28b6a4684ce2fa10f085f67d58d025421c594e65a0c2a1b67aeab2ee2569"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hkboss/iceball.wav": {
+     "bytes": 14990,
+     "sha256": "6aec96fda55dfb0120f106064cd324ea6e059bab3fdbb2d81cda297f9a82e02b"
+    },
+    "sound/imp/die.wav": {
+     "bytes": 8448,
+     "sha256": "a8b0e037b88829b978d3dbd3d5e657c7f775c73662d554f6247a387ba333d4bb"
+    },
+    "sound/imp/diebig.wav": {
+     "bytes": 14956,
+     "sha256": "d44d390ba11f8850105fd9601f026cb66525a415de7fc363d3574c86b72d22c4"
+    },
+    "sound/imp/fireball.wav": {
+     "bytes": 5492,
+     "sha256": "6362b59ded89655fa8b8877ed2639eca1a7aae1847306bbc3843fa98bedcbdaf"
+    },
+    "sound/imp/fly.wav": {
+     "bytes": 9204,
+     "sha256": "8036ccb256978c17234aa171267fb0332f1911b5f0dad7b9f74bba9378c39a37"
+    },
+    "sound/imp/flybig.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/imp/flywater.wav": {
+     "bytes": 9800,
+     "sha256": "c80045609b62ceb61bd8fb1a18a53c0f2fd5443502a802b0d6d3c61e9a1db4c0"
+    },
+    "sound/imp/shard.wav": {
+     "bytes": 10678,
+     "sha256": "f806167fe23f37826964c0cc345c438ff0e79c3ffb1fed2c85451c675448cae4"
+    },
+    "sound/imp/swoop.wav": {
+     "bytes": 10842,
+     "sha256": "100eacded51635de912cee171f093e869d24589c44f68887497fe751cf9b1e4d"
+    },
+    "sound/imp/swoopbig.wav": {
+     "bytes": 14012,
+     "sha256": "65d4de49684f2f9e2655abf8e4bf042a08bd706ec4971e6397f264f7274e2b63"
+    },
+    "sound/imp/swoophit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/imp/up.wav": {
+     "bytes": 12500,
+     "sha256": "874b533da43f713a1be27fbccadda8b6392fa8e689c8c4d17dac4b0d380f5822"
+    },
+    "sound/imp/upbig.wav": {
+     "bytes": 21472,
+     "sha256": "36c7bc087935cf7cd33482a50a75df75fc2bfbe53ca0ebcd9797a8bdbde73652"
+    },
+    "sound/items/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items/equalize.wav": {
+     "bytes": 13008,
+     "sha256": "933046049bae4d866250ad9a6e0a4b2a9385caffb4156daaca39ff7110a71126"
+    },
+    "sound/items/levitate.wav": {
+     "bytes": 44236,
+     "sha256": "8a04ce4a97dc22d095bc52d08111bcaaf5f57482f580ccbe0c61bdf8fd18913f"
+    },
+    "sound/items/life_up.wav": {
+     "bytes": 8660,
+     "sha256": "2712bd978343d4170bc1757706597d4de3940a07b6847977cbf117fa92f14c31"
+    },
+    "sound/items/money.wav": {
+     "bytes": 5100,
+     "sha256": "e4ac299499340c1be250f5d5e0824440d9e539de8a1d5b01e303056719cf822f"
+    },
+    "sound/items/optimize.wav": {
+     "bytes": 14854,
+     "sha256": "508d89890db17f828cde9511ebd97241ecfe07bbb6e5cba8c7538ab02e31b19f"
+    },
+    "sound/items/quaff.wav": {
+     "bytes": 3748,
+     "sha256": "ebaa4ecc17dc67d3fbc5fe1a7541e4e19769ce941d043922f8572cb2da8d3cdd"
+    },
+    "sound/items/reflect.wav": {
+     "bytes": 14936,
+     "sha256": "90dd50b25175c8d514a52165429e9ca6b90c45dddbb0f301e5873146b4a4a06c"
+    },
+    "sound/items/reflect2.wav": {
+     "bytes": 33119,
+     "sha256": "5fb5afe50e0f5fa24f1c4481b3060ae222f40138ca81052cea047a57aa6b03e8"
+    },
+    "sound/items/reflect3.wav": {
+     "bytes": 7804,
+     "sha256": "a079e5aef6ed9fb7d5c992b0ef8e11932a9efa192eedac2bc530098e0550984a"
+    },
+    "sound/items/regen.wav": {
+     "bytes": 7984,
+     "sha256": "1e125e8e7c19f29eaf09b7ad301fdfe5126d922dfa84ba2af267cdf3351b6498"
+    },
+    "sound/items/shambler.wav": {
+     "bytes": 20182,
+     "sha256": "f0cdf78367b770c97b3b89abedb7c4fb0a9ee10d742acc8c98b3daba46cfc215"
+    },
+    "sound/items/tomepow.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/items/tomepow2.wav": {
+     "bytes": 33119,
+     "sha256": "1e2e62a6f251722741b7f0adeb38c59a1d05917d0f84c8f48922efece97f02e2"
+    },
+    "sound/items/treasure.wav": {
+     "bytes": 5554,
+     "sha256": "c86f66148e8dc99af2c8e877d64d06dc1c35d0caa9c6dc5c8092b268960b8edd"
+    },
+    "sound/items/zerkhelm.wav": {
+     "bytes": 8298,
+     "sha256": "ef7b98bd965660df91ee34920806b48428a8b5c17c0ec4fdecb48d7fe28e3ba2"
+    },
+    "sound/laugh.wav": {
+     "bytes": 71573,
+     "sha256": "cb8e1381c70240a93233b8571d792e21950d00b1285f867cbc0ed1237dac1df7"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/b_rot2.wav": {
+     "bytes": 15436,
+     "sha256": "62c86077b7a29f48f5c872c68d262c03b73b57f876b718a05f2fc6b24b9a9ef4"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/bellring.wav": {
+     "bytes": 27600,
+     "sha256": "fe3b2972c722171144eaba160757803292a42342e737d6acdbd0b14802e686f2"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/dsslop.wav": {
+     "bytes": 11163,
+     "sha256": "b6a9f6e74b222169c87e6c56b47d2e7995b23b8b045f16be968f43290f22cf9d"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/met2wd.wav": {
+     "bytes": 3968,
+     "sha256": "a3ce3e10b609f7ae28fc6f39f1f5d55a7c99a41143fb161de7e4e47b7f40f100"
+    },
+    "sound/misc/metalbrk.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/mgboat.wav": {
+     "bytes": 26866,
+     "sha256": "666016e2aa958ea621ba03bee4339518f2ccc72aa3ee2d0838ef9032e8ffc981"
+    },
+    "sound/misc/pushmetl.wav": {
+     "bytes": 14042,
+     "sha256": "2657b0006f51ecb7077b5861b1b282e0bb8bef3bdd5ccb68b3bdd6794361099e"
+    },
+    "sound/misc/pushston.wav": {
+     "bytes": 11490,
+     "sha256": "f457b95dad6131472475ab22d9c260adf5d389e74629cd8ea36ca05ad7d4e749"
+    },
+    "sound/misc/pushwood.wav": {
+     "bytes": 13602,
+     "sha256": "7c3fa06978f8c7b632d12bbf1031a5ac316b44fdc5efd93338ab0a0a162bdf3a"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/rublexp.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/secret2.wav": {
+     "bytes": 87440,
+     "sha256": "36e9d9617a14daefd510e72308b9e85718a473e2b25a06b66026d463d6bbb519"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/misc/woodbrk.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/music/pkdream.wav": {
+     "bytes": 154898,
+     "sha256": "df8857901002ce9dde3c558743c94967db11cae4af3d9a0cdc00c8cc09e6a910"
+    },
+    "sound/necro/att_a.wav": {
+     "bytes": 8522,
+     "sha256": "a946c060cab5ee1bfff2d1af87cd71c9ccf63840a2751fd46fd32f387bee2c35"
+    },
+    "sound/necro/att_a2.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/necro/att_w.wav": {
+     "bytes": 26298,
+     "sha256": "9ae481ad41d16610b597989e82a8bbf9c35a74fe03a8e27900d72ff8b52e3c94"
+    },
+    "sound/necro/curse.wav": {
+     "bytes": 16852,
+     "sha256": "d3729c83c468d9320cf1f8914c8b52d446e818852c955d8d86a093c35c196b58"
+    },
+    "sound/necro/death1.wav": {
+     "bytes": 24010,
+     "sha256": "302e58b0f701ad07ade4a46d5cd3bd9c2186b2df3eb39e36c361918a72ccd24d"
+    },
+    "sound/necro/death2.wav": {
+     "bytes": 23594,
+     "sha256": "05f15a8430885b6688587eba5e249107c3e6df36d7937a3ddd2411d275e8842b"
+    },
+    "sound/necro/idle1.wav": {
+     "bytes": 49212,
+     "sha256": "737f382e89a40fc098214b77e9165e16f2a06323c07e910f336f2616b6ca87b4"
+    },
+    "sound/necro/idle2.wav": {
+     "bytes": 47120,
+     "sha256": "18893e7b31ff448831a7b7a5aa9a5d31b2dcd6e49ae8b58d5eea8b44683415dc"
+    },
+    "sound/necro/pain1.wav": {
+     "bytes": 19412,
+     "sha256": "f37e247a9e1436e4a86b78fe71e1ea6da43323e60943e86784ac87fc4393333b"
+    },
+    "sound/necro/pop.wav": {
+     "bytes": 18996,
+     "sha256": "22aff5a83ec82e759004d82308b2e210f824ac59bd3180d6b688c9d0134ca18e"
+    },
+    "sound/necro/pop1.wav": {
+     "bytes": 10836,
+     "sha256": "d5e9b7ce5a638a419eef07bba492ce75fb3d8002bd66b40d36b4dd89ad859e1c"
+    },
+    "sound/necro/pop2.wav": {
+     "bytes": 11228,
+     "sha256": "10947cad6cd5bcc0e0bc00fdbeccccd53b70bff1fda1a220c72ddc7e2b152b08"
+    },
+    "sound/necro/pop3.wav": {
+     "bytes": 11228,
+     "sha256": "56c4219dc0ecfb7ee8ff6d31fdf6c8c53c2b6990ce1b94ed956caee3c7cf83db"
+    },
+    "sound/necro/pop4.wav": {
+     "bytes": 10836,
+     "sha256": "451b660c65ebd2c7c89134896ed882d738c685f787810e1245587c0c28c38141"
+    },
+    "sound/necro/raise.wav": {
+     "bytes": 9688,
+     "sha256": "1c841e33f22cdcd5276bba9018aec5dae8c0f842da07eb261f48f1a6cc4c8314"
+    },
+    "sound/necro/sight1.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/necro/summon.wav": {
+     "bytes": 16308,
+     "sha256": "b7fc855d38431ac04e09389d7caf04bf0032d2b4edf86ebd795f1ab38d9feaf5"
+    },
+    "sound/nemesant/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/nemesant/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/nemesant/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/nemesant/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/nemesant/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/nemesant/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/nemesant/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/nemesant/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/nemesant/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/nemesant/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/nemesant/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    },
+    "sound/pendulum/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/plasma/explode.wav": {
+     "bytes": 29598,
+     "sha256": "7a95a8337c7ad87faccc1cae98ad7840352b08608fba08aff87a1b33610f9190"
+    },
+    "sound/plasma/fire.wav": {
+     "bytes": 22422,
+     "sha256": "7350d1e99f93a79bee84e94561e080dcb8448a3549a42742633cf604377a5097"
+    },
+    "sound/plasma/flight.wav": {
+     "bytes": 17494,
+     "sha256": "a03b46f31df3495a1b7a2b2f1a09f3e5223d4c0ab65aa0ed936e1445e893adeb"
+    },
+    "sound/player/boot1.wav": {
+     "bytes": 25624,
+     "sha256": "9b730ff4f811472514297921c78ea3080424c57b57ce7fa30c6c10f94bd8ccc3"
+    },
+    "sound/player/boot2.wav": {
+     "bytes": 25640,
+     "sha256": "23a3cd545ffa3c5c1e4a4c9549aff81dadd2f1ab451e397d5292c97024fc5026"
+    },
+    "sound/player/boot3.wav": {
+     "bytes": 25652,
+     "sha256": "004d267ae3fcce21aa66e566efa34e39e85915f202e3b55922b314cfd6efa2d7"
+    },
+    "sound/player/boot4.wav": {
+     "bytes": 25628,
+     "sha256": "9beb96d9a183cd6a13693961a216b4402350fc076c7a1ff98854d28c30a9f8be"
+    },
+    "sound/power1.wav": {
+     "bytes": 44370,
+     "sha256": "68f9d490b390a2510ff660917ac02fa1620893770a68a1188e06f94c57922523"
+    },
+    "sound/power2.wav": {
+     "bytes": 44370,
+     "sha256": "773aca5e1e60540b2abdc4b9b29c4281a04f6fad3bfc6bea1c029b42a7f0fe9e"
+    },
+    "sound/ranger/idle.wav": {
+     "bytes": 10819,
+     "sha256": "644fbbc14e20684fa31abc7f04969943ac950c33435271b0fa646aa324be4400"
+    },
+    "sound/ranger/sight1.wav": {
+     "bytes": 5379,
+     "sha256": "5023e2483fe5c1c37cd661d382e34c0b68eafe4bae0e35e8f3f7e516e78dcf51"
+    },
+    "sound/ranger/sight2.wav": {
+     "bytes": 11323,
+     "sha256": "3574f035e1a261b9a001d99a54bdb502da31da2639d95e7fc06f96b547c1ac44"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight1.wav": {
+     "bytes": 35068,
+     "sha256": "48db878a4eae15b37ee0ca333aae74d310103a9eaf2e4b35eecd43a89f626b9a"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk1.wav": {
+     "bytes": 19372,
+     "sha256": "42e41297df70202ec9965af7af5fcdabcab7fde43ba515c8ba0a1ee2e4429554"
+    },
+    "sound/shade/death.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/shade/death2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/shade/fly.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/shade/idle.wav": {
+     "bytes": 37192,
+     "sha256": "57b0a0a7a0e75a17df8c4bb68740b23325bd0bf3475d908ee92fa0522c71edf7"
+    },
+    "sound/shade/moan.wav": {
+     "bytes": 33684,
+     "sha256": "3a6644f2c0a6ead5992fa9752ec9b0d898f4c40f5a32b12fd61aa991f75fa0c7"
+    },
+    "sound/shade/pain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/shade/pain2.wav": {
+     "bytes": 8918,
+     "sha256": "c6fa3ba7c659faf38b00af9c9867c37ba730cbc662125f5307f755515243dc4c"
+    },
+    "sound/shade/screech.wav": {
+     "bytes": 28244,
+     "sha256": "55ef2615baa6ce39733892fc9538f702acc567f65250223329f15b191d9b1a47"
+    },
+    "sound/shade/sing.wav": {
+     "bytes": 35654,
+     "sha256": "9de82a1d3124c391466004aea5e8ad066bcc6ede2715e7978a92a2c8f66e3f6b"
+    },
+    "sound/shade/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/shade/taunt.wav": {
+     "bytes": 36418,
+     "sha256": "f556cad612249e63690ac28b17405eba70e3df43560c3a087062b9f330811720"
+    },
+    "sound/shade/taunt2.wav": {
+     "bytes": 28160,
+     "sha256": "a68174008206b79794d8d52fd027daf08767ce005189860c815cda021080363c"
+    },
+    "sound/shamvile/burn.wav": {
+     "bytes": 11316,
+     "sha256": "239c51d5cfb82ee7683075f6cd53d8a16fcc2da608c9db87c27fd7491160a627"
+    },
+    "sound/shamvile/dsvilatk.wav": {
+     "bytes": 16978,
+     "sha256": "f4fc290f121fafbc1d8e5e992b9454b404f9ebbf3c95bc376419ee8ca58425bd"
+    },
+    "sound/shamvile/melee1.wav": {
+     "bytes": 4700,
+     "sha256": "f418a627faa0b4630588914ecdd466c387e1d7d5ac2e09acecafa13baf33f10c"
+    },
+    "sound/shamvile/melee2.wav": {
+     "bytes": 6252,
+     "sha256": "dfeb5bcd8be8d9f1fcf52f89cf0af533ec28066eb0bf74e3ac4b588ca810f372"
+    },
+    "sound/shamvile/melee3.wav": {
+     "bytes": 13236,
+     "sha256": "7102a987921e4c291175ba252628613c2c6ecdb70e9a33e174b6bcf7addc239c"
+    },
+    "sound/shamvile/melee4.wav": {
+     "bytes": 9211,
+     "sha256": "da31a8531703998c06bc33c94639d5dd291c9ba24e6752599ec8e6113d3753b5"
+    },
+    "sound/shamvile/sdeath.wav": {
+     "bytes": 20996,
+     "sha256": "e27d5870c37ce74877a2681b5e9cef437d14b05c501fb93733c8e93d2d2b0931"
+    },
+    "sound/shamvile/shurt2.wav": {
+     "bytes": 3924,
+     "sha256": "541c66bfaf5f30c55d24c4013f4a8859159ebfdf2f054c681eb8b8200dba1c85"
+    },
+    "sound/shamvile/sidle.wav": {
+     "bytes": 5476,
+     "sha256": "ca3edcb476f3992027989a2a79ef21a7f8951965c8a0e77f89f0a0505f2d2b52"
+    },
+    "sound/shamvile/sidle2.wav": {
+     "bytes": 21511,
+     "sha256": "0e46d4e53c003136881723f59de4d706151b845d57608cd87361018acb7ef050"
+    },
+    "sound/shamvile/ssight.wav": {
+     "bytes": 15564,
+     "sha256": "5a5343f95ee503f1b481ef05499e023b681402b922600979367788f2fb91397c"
+    },
+    "sound/shamvile/ssight2.wav": {
+     "bytes": 27204,
+     "sha256": "2b22c0912485569f7ec87a32a29c88563c0cb8261b4428335540fc96f7e7cb52"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 19642,
+     "sha256": "91eba6c478e8475696f07079502af32d1817e3fb86418c32801846582f27561d"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 18166,
+     "sha256": "91301f18c459286798989dd164ae08f5e77433ac7a0b5c71522cf59e49bf1a30"
+    },
+    "sound/skullwiz/blinkspk.wav": {
+     "bytes": 31420,
+     "sha256": "48a4dbd2add9021727d4572af9ac4c6f333a9e2ace5fe7127ddd42c84a2ae1f4"
+    },
+    "sound/skullwiz/blnkspk2.wav": {
+     "bytes": 41834,
+     "sha256": "fc2602275102b7e1a577c30b7ab3ac2709881eb3a8798664577f8a65a9132754"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 23034,
+     "sha256": "0eb20419acddee8a5814ecad8888348f90a14db997af1045b02b6052dccd5fd1"
+    },
+    "sound/skullwiz/death2.wav": {
+     "bytes": 32314,
+     "sha256": "3b1d2ed146a334ba5cf77027faa47addbf45c51159ff9c7278a97dda8ed7ef82"
+    },
+    "sound/skullwiz/firemisl.wav": {
+     "bytes": 12186,
+     "sha256": "3583544b6d7105d5b029a490cb0730190ae9e8dc5ca8f9da1deae4ea0335e964"
+    },
+    "sound/skullwiz/gate.wav": {
+     "bytes": 16156,
+     "sha256": "5797c6450d14f363133be23d93c829a660f9b7692c07f905b5a723cda8075c55"
+    },
+    "sound/skullwiz/gatespk.wav": {
+     "bytes": 30092,
+     "sha256": "f9fc90ba497d650acfad76c42ed531314828093f114c69c28fd1611d326fab2e"
+    },
+    "sound/skullwiz/growl.wav": {
+     "bytes": 18944,
+     "sha256": "de58ed34dd69dc3e871d09ac6a5db81ef26d69e234f0834e72c6cd68501ead21"
+    },
+    "sound/skullwiz/growl2.wav": {
+     "bytes": 24954,
+     "sha256": "0cf747c71a6fad9a085c39456cd14ffd972d2d454b4bafc2781ce4464917cfa4"
+    },
+    "sound/skullwiz/pain.wav": {
+     "bytes": 6106,
+     "sha256": "0f85b6180cbfe8d26f8d174f25c109b9d8b78d0fa53735e0494280bc8a19803b"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 8890,
+     "sha256": "6d48429e7fc4b80be16afd80097b7096a94cb1a88922a62bdfdff64172526a0f"
+    },
+    "sound/skullwiz/push.wav": {
+     "bytes": 8812,
+     "sha256": "91398e953b648ab23c037940fb7996f3d77727003a60757ea50686328c05cd69"
+    },
+    "sound/skullwiz/scream.wav": {
+     "bytes": 31734,
+     "sha256": "6df299b2a59aa94a9640c83684b65259e4619e0ed2a2fd1ce518dffaa060fd43"
+    },
+    "sound/skullwiz/scream2.wav": {
+     "bytes": 13980,
+     "sha256": "adca10198e279db0789a1a026124387c40e36fc1914f3f3da315b49b6e290386"
+    },
+    "sound/spider/attack.wav": {
+     "bytes": 6576,
+     "sha256": "82593fdd5be8198a9774c163872f89a088d8d0ca10e91f1c8f846ecac92b2d81"
+    },
+    "sound/spider/bite.wav": {
+     "bytes": 4552,
+     "sha256": "abd0b64743c825661f4598b7d5b70b781452a6b7747f9eb8b53f7239b0f9b9cb"
+    },
+    "sound/spider/death.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/gib1.wav": {
+     "bytes": 10516,
+     "sha256": "bbe1a437bd05a71f9d7bba953a79886891bfc526399c67cfc8964308c91786d0"
+    },
+    "sound/spider/pain.wav": {
+     "bytes": 7576,
+     "sha256": "386e11cfd8063b6bb692ab4b90246be98288f72f29614f2e38765df9e6eaad79"
+    },
+    "sound/spider/step1.wav": {
+     "bytes": 2780,
+     "sha256": "06ee408dace817630645b0d390c496e692844fb42cc85adcaa021efeb60fae9b"
+    },
+    "sound/spider/step2.wav": {
+     "bytes": 2620,
+     "sha256": "66e802d6361a17e637f5e38366e4b0912dbb0f65e647041bed57cfda772c0770"
+    },
+    "sound/spider/step3.wav": {
+     "bytes": 1786,
+     "sha256": "418b2c536f19a5bcd0b1a8ff4aae13febc8c4f8fa6787372e9e869c45a17f54c"
+    },
+    "sound/trog/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/tur_arm.wav": {
+     "bytes": 23794,
+     "sha256": "24b428117ebd7e82865b41dcfc74a75a048c4d126d7505a6c23dd243bc054a05"
+    },
+    "sound/vomitus/death.wav": {
+     "bytes": 13236,
+     "sha256": "fa2cad86ac0ce1326132c5e378aed6a9ff5615d043df1d4d48e0b2691f8d3bde"
+    },
+    "sound/vomitus/flesh1.wav": {
+     "bytes": 8412,
+     "sha256": "9ac5a8ac2155e7d9b65144e7f65525c4660ff5959fe3a0277fab347e202b6f46"
+    },
+    "sound/vomitus/flesh2.wav": {
+     "bytes": 12788,
+     "sha256": "3fc22e2aa2c3c0bdc6501388ac18abb5e58c5fd5deba39d1cc2f7e8d48fcc869"
+    },
+    "sound/vomitus/groan.wav": {
+     "bytes": 13224,
+     "sha256": "3632e43615714e5fc1be8277881a913bf1bd79b276544418cbf1b159016f0d03"
+    },
+    "sound/weapons/axhit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/weapons/axhitwal.wav": {
+     "bytes": 6694,
+     "sha256": "0f14ba18076b25a7b8ee510b38adb282eb5c4f2fc94168baf1f8a658e1da684f"
+    },
+    "sound/weapons/block1.wav": {
+     "bytes": 5484,
+     "sha256": "ccb284becb454f395de702a263bfda1561b8bd38117893d33b5ebbb9eb7b6865"
+    },
+    "sound/weapons/block2.wav": {
+     "bytes": 5612,
+     "sha256": "62da8e44f3b1200b99f76a3bdb31d9d09a9e74c04a449c0afc482c6677a94bc2"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/weapons/clang.wav": {
+     "bytes": 7198,
+     "sha256": "634a88cf26b4de688bed392cf108d5468749f212ce67015c71baa942e8e88502"
+    },
+    "sound/weapons/dsshotgn.wav": {
+     "bytes": 9490,
+     "sha256": "98c228b3549d4908c313c783d5b0aec38b93efea1c6a65d7355767bdbb4b87e8"
+    },
+    "sound/weapons/freeze.wav": {
+     "bytes": 20619,
+     "sha256": "48689ba550c116dd8b10a138bc0f78eb6f169d6828a49aaafe12f807930eb934"
+    },
+    "sound/weapons/fwall.wav": {
+     "bytes": 40140,
+     "sha256": "e269c07608f322518e709925d5b13daded150460d19d3091f15152ce4c06c9bf"
+    },
+    "sound/weapons/fwallhit.wav": {
+     "bytes": 9426,
+     "sha256": "7b9f4da432e6fa44fbf721ed9ef753e6ceb41df59b8265b58f73764b2901224a"
+    },
+    "sound/weapons/fwalltap.wav": {
+     "bytes": 8316,
+     "sha256": "879b9970dfc3bc609ff384a0edea13b594ea6a82b5c56d33c8549cd36cccda0b"
+    },
+    "sound/weapons/icehit.wav": {
+     "bytes": 10710,
+     "sha256": "9ed8ed177a6cfcad97f8adcf94b9f3114a955e7b3abb397c6b17c44073c07b19"
+    },
+    "sound/weapons/icewall.wav": {
+     "bytes": 6124,
+     "sha256": "9668486027e07f525a27830dc3217cde36bcbcc956b21437d2637e00df368dd4"
+    },
+    "sound/weapons/mirv1.wav": {
+     "bytes": 89538,
+     "sha256": "7d60062f61d5929f5f927526d81920f24684520d230a5f2611c128b832d3357e"
+    },
+    "sound/weapons/mirv2.wav": {
+     "bytes": 18478,
+     "sha256": "67311180da390517f2ef71d161a0cf7b770548dcd4a7dda7e679cb9b58025b4b"
+    },
+    "sound/weapons/nova.wav": {
+     "bytes": 10020,
+     "sha256": "d41c8433fa1b964fafa1cdb2fec301fb4d398f1fce201b4d80b29fab7a59d7e7"
+    },
+    "sound/weapons/pkup2.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/weapons/plasma1.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/plasma2.wav": {
+     "bytes": 8350,
+     "sha256": "de03da8d300ddaf56b063584226f5673b0033a8258209e4c8c5f82a4d40b630a"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/weapons/r_exp3a.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/shatter.wav": {
+     "bytes": 20899,
+     "sha256": "31ddbef0dc746eabea23cd7cd2fb97a1f949a014b664630d7f04e6c237aafc03"
+    },
+    "sound/weapons/sheath.wav": {
+     "bytes": 7031,
+     "sha256": "8f28a1daa16db234ce77d91e688c7acbc9541c296d30af9e1f940b6d45eaf72d"
+    },
+    "sound/weapons/sprocket.wav": {
+     "bytes": 7126,
+     "sha256": "8b5c3bdc625b4954c6b504ee242591f0121d1ab64f2aceab54dd85fecadef8a4"
+    },
+    "sound/weapons/ssg.wav": {
+     "bytes": 17176,
+     "sha256": "c3307bb283499155691c01fe783d86992946475fd3b9a4839ba37cdca7ede6a4"
+    },
+    "sound/weapons/stunfire.wav": {
+     "bytes": 9902,
+     "sha256": "7214cc44e4c0bfb801209f025b591d838542a3110f770e5614b0f549a055286a"
+    },
+    "sound/weapons/sword1.wav": {
+     "bytes": 3532,
+     "sha256": "572074b68af2132285aa9fd2ac6852f52ffb6c5e56eed44b1af21e0e78171e17"
+    },
+    "sound/weapons/sword2.wav": {
+     "bytes": 3055,
+     "sha256": "b176a257409b659d80df90560bbac4da5539971576aaf1107bb88bc016558085"
+    },
+    "sound/weapons/sword3.wav": {
+     "bytes": 3012,
+     "sha256": "eaca19c8a10b7942d4a279974df6e1cf076c362d5408e439b26286126852bedf"
+    },
+    "sound/weapons/thump.wav": {
+     "bytes": 30904,
+     "sha256": "ef0aa85fbc7ff6915aa5382c80e6f571ddacd50116faff495e3d5638bace8a49"
+    },
+    "sound/weapons/unsheath.wav": {
+     "bytes": 8060,
+     "sha256": "45d9bc6b9dcaf8e0dc9b2ede7da69a872f50f7819462a71bc16b9d76a70be06b"
+    },
+    "sound/weapons/xbowdraw.wav": {
+     "bytes": 19114,
+     "sha256": "4bb73eb7161ba561970e8f2e7f5aad0e42b3419fe2b02a5953a7289c46d1442b"
+    },
+    "sound/weapons/zap1.wav": {
+     "bytes": 7648,
+     "sha256": "1ee462bf6169537cc96fa7f95ef30b782fa1be473bd6ddc297fb3a7a6aa21ad0"
+    },
+    "sound/weapons/zap2.wav": {
+     "bytes": 7178,
+     "sha256": "8ece0064dc470a86c00906c1c50a54afd3a64eb13582071b9960581a1b72f4ff"
+    },
+    "sound/wraith/call.wav": {
+     "bytes": 12328,
+     "sha256": "9ace8a0ff79d035d36b6bdfb8726054ceaf8f852d25f3c1b235616abf4646ef2"
+    },
+    "sound/wraith/die.wav": {
+     "bytes": 14024,
+     "sha256": "3f166e024c07124cc5b5c5469904f5a8b3e48d4cb50fd949be8d79b4df2e375c"
+    },
+    "sound/wraith/drain.wav": {
+     "bytes": 14094,
+     "sha256": "d767951e9630b6179fb05a80136acbdeeb530f350b1953bea62e8493f3fe67ce"
+    },
+    "sound/wraith/growl2.wav": {
+     "bytes": 24966,
+     "sha256": "1c757955bb103e0f589ec373d1517dbacb8fe7e274f7aa0928503c9f5b009b10"
+    },
+    "sound/wraith/idle.wav": {
+     "bytes": 23702,
+     "sha256": "760a4a215fa2adb6f531b15acc06a4b46daa84c85fc08691ff4fe13f17e09ee8"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 20442,
+     "sha256": "d55cb931cef7d9c336fb7bbc3fa0408ea23eff69f46e25ac377ebbc880fa5025"
+    },
+    "sound/wraith/return.wav": {
+     "bytes": 39162,
+     "sha256": "0439588ad2003732fe7f946a5597bf80b2b89d6395476671b0e050b91c49cca7"
+    },
+    "sound/wraith/rych1.wav": {
+     "bytes": 24482,
+     "sha256": "baec568f339f688ea475e37ef3fc51a36de78a52a553e85aaa3f8011e1240d13"
+    },
+    "sound/wraith/select.wav": {
+     "bytes": 29326,
+     "sha256": "1e86b92dd1d82f4f74cd7fe14a75484e6cddb4fe968d2bb3dbaf850414c6dacb"
+    },
+    "sound/wraith/soul.wav": {
+     "bytes": 70524,
+     "sha256": "612bf73a6ebe0526efa2ef3d22915bcd87bed0b0eb5e52fc4eb0e62c5e4a3039"
+    },
+    "sound/wraith/soul2.wav": {
+     "bytes": 20562,
+     "sha256": "d3701420c157109793576ac7af7c7b132ffd0897375ec99701f4cd54798d9579"
+    },
+    "sound/wraith/speak.wav": {
+     "bytes": 25630,
+     "sha256": "6d1e5b395938692d57de3ec8ef9a8b5e4ccdab920a1f247e5bcdc1f0906dfcb8"
+    },
+    "sound/wraith/talk1.wav": {
+     "bytes": 16654,
+     "sha256": "6a625383c12f7fb5979ca8977a51d40f183051d551bd0b1b4ccc8a3f43a0322a"
+    },
+    "sound/wraith/talk3.wav": {
+     "bytes": 9832,
+     "sha256": "28ecc66c85bc722059b147a1354d226fbaf3022b79aed937a4759958d52c0fab"
+    },
+    "sound/wraith/weird.wav": {
+     "bytes": 3028,
+     "sha256": "1cfcd24daeb0665dce9d68ec353377ef84a88c78d1fdfcb429f2d0cc2b7f4b78"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    },
+    "sound/yakman/big1.wav": {
+     "bytes": 21636,
+     "sha256": "16c1632682aeb4b4075006d5b8b13a7e3f8821b6f59f8eb61ad78308b0d68366"
+    },
+    "sound/yakman/big3.wav": {
+     "bytes": 25096,
+     "sha256": "2cbbc5dc1249a92b9a31a6f3fa7ff654dd6339511fc99e4c552ad6a34218a4c2"
+    },
+    "sound/yakman/breathe1.wav": {
+     "bytes": 45712,
+     "sha256": "53730dabf839c183028fbdf909df8ae7ef936828c51c58a957617444872224d4"
+    },
+    "sound/yakman/breathe3.wav": {
+     "bytes": 50728,
+     "sha256": "fd923c891934046d9770c089dfe16021373a392b429531ef9698fbd2f759c42a"
+    },
+    "sound/yakman/crash.wav": {
+     "bytes": 17808,
+     "sha256": "068f6ea04f13016615f9534e74e969a62eda98c7def921df76731c5afbd73cf2"
+    },
+    "sound/yakman/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/yakman/expsmall.wav": {
+     "bytes": 8732,
+     "sha256": "18825b9644c01ff0a488887185ac14d6fb4fd983254620009ba3ecc96c44d465"
+    },
+    "sound/yakman/firefblt.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/yakman/pain.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/yakman/slam.wav": {
+     "bytes": 6372,
+     "sha256": "2c6ff4782b389777c98f09fa6ac86e6c75a848ad800db6dc32f8ea9362706e96"
+    },
+    "sound/yakman/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/yakman/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    }
+   },
    "sha256": "22d57e211cdb714ba3df19083c1514b08e5c84650545bc1a4092b383fb72a3f9",
    "timestamp": "2011-06-12T20:56:02.000Z"
   },
   "Tershibboleth/pak2.pak": {
    "bytes": 4813402,
+   "files": {
+    "progs/brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/drlbomb.mdl": {
+     "bytes": 20355,
+     "sha256": "5c1db489f43cba73fce265db642267775245d044866cdd48396b1f1260a28237"
+    },
+    "progs/drole.mdl": {
+     "bytes": 241648,
+     "sha256": "5067b7ca5323754fe563d6696025525645a2cbd3aaf7f79232634608f9fb987a"
+    },
+    "progs/g_fx.mdl": {
+     "bytes": 32260,
+     "sha256": "ac99d4e641af0bb1495ed38ba9f3a7c1195bda19e5cf0d3a68f04defe6178ab8"
+    },
+    "progs/gaunt.mdl": {
+     "bytes": 222024,
+     "sha256": "d805c09223a651d6650ad75464cba53ae0fb7f8de1066307efd21d0079c14f5c"
+    },
+    "progs/gug.mdl": {
+     "bytes": 482020,
+     "sha256": "2cd097236a235aedf717a86b7312bd7d1b3caa6f0b25980c82eee2463fee2274"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 16854,
+     "sha256": "00f3263f1c3e0daadaaf03eea447080d727ea7d9ee1a88f2b42e060d748e1566"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 61251,
+     "sha256": "dec5afe666eba8db6e32d7535fffa3d0e4ed9344ba107b73418526ebebac574b"
+    },
+    "progs/longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/marsh.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/marshsm.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/snowflak.mdl": {
+     "bytes": 36372,
+     "sha256": "d7cdcca5767160408a43bd6b51313f9b68b696aa06eafdb0af4762513325d1a9"
+    },
+    "progs/spore.mdl": {
+     "bytes": 13469,
+     "sha256": "fc9fbb97f0d4f1a9f843769cd43fb7270ba2b351cdf3b4b624d27616980457c4"
+    },
+    "progs/vermis.mdl": {
+     "bytes": 656752,
+     "sha256": "d7060475e290482c61c122b3a477085b1aad002fd71d8293cc4a4f8bde1baec9"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/explode3.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/sight2.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 83982,
+     "sha256": "4b0d8db882ab1c9fc2109effeaf125ec46fb23a91ac2242201103e0d3da96944"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gug/bile.wav": {
+     "bytes": 54572,
+     "sha256": "e06787585ef0369798a938a1a9585d24b60aa7b5c65acda3a5fb6f2c7ab65aca"
+    },
+    "sound/gug/bileatk.wav": {
+     "bytes": 50040,
+     "sha256": "b4b05e2907789a78391ccfe8ced3902821f1097ecd1f894b12ba9278d31a8717"
+    },
+    "sound/gug/death.wav": {
+     "bytes": 132396,
+     "sha256": "20bf209a832381b77d37c54a84ab1819b6c71e2147c5d122ac62668c070167a5"
+    },
+    "sound/gug/gquake.wav": {
+     "bytes": 43350,
+     "sha256": "d232ae13b55cb5b10b8903db43c037a5c6c4cdfea1f84f9399133484df6e0175"
+    },
+    "sound/gug/idle.wav": {
+     "bytes": 50580,
+     "sha256": "ff33c63696dec5c582ff9a4537814299b47ce2480d6cc53c116721d793576fda"
+    },
+    "sound/gug/pain.wav": {
+     "bytes": 22064,
+     "sha256": "e559f2b372fe771207aeef4b1c3a71baca542863493776558ae3f933f3878c29"
+    },
+    "sound/gug/quakeatk.wav": {
+     "bytes": 65882,
+     "sha256": "2c07b7690356bd9233a79c1f8b5f4e146cbabc367a19c138d6719a1e0d09328e"
+    },
+    "sound/gug/sight.wav": {
+     "bytes": 76426,
+     "sha256": "210ed86a5d6f9d4e791954fc3a4e4b4b6dc5839d02f7c19d468493a2f87dca64"
+    },
+    "sound/gug/step1.wav": {
+     "bytes": 15494,
+     "sha256": "4e2ce285991bc0d4337c77fdbb029507697ecb4dbf6543ddefe976ea114c4214"
+    },
+    "sound/gug/step2.wav": {
+     "bytes": 15502,
+     "sha256": "27f6f770a52fce5ae04836706e63ef455555de086019a2f9e44d4da1fc99b03d"
+    },
+    "sound/gug/step3.wav": {
+     "bytes": 15502,
+     "sha256": "fcc7ab38a8ec28509d0aa062a3cb93aee6da6a0ae364e4fe0dfad791f54558af"
+    },
+    "sound/gug/step4.wav": {
+     "bytes": 15502,
+     "sha256": "fc52cad29cca2e1fc36f5c6ac7f955ed897d6da4fb5dcf4eefd052e0652d93e7"
+    },
+    "sound/gug/swipe.wav": {
+     "bytes": 16064,
+     "sha256": "90bb5831dfd19f65df19e97f76d858ec940d8e33e0a2ed8fad89a23947e430e5"
+    },
+    "sound/gug/throw.wav": {
+     "bytes": 23180,
+     "sha256": "5e901b94e7be364536603273f18791ab571c46c2fc74263774c0e312f873a281"
+    },
+    "sound/vermis/death.wav": {
+     "bytes": 148016,
+     "sha256": "44b26a9dca5ec8d5e8a7ef2b5e38196b74e4f606cd37b906ee2b2e5b5a85b08f"
+    },
+    "sound/vermis/grab.wav": {
+     "bytes": 88122,
+     "sha256": "09528bd0d49d5cac0c03fe7994b57e572eb89aa8bce63cd0a591130e4b2126ae"
+    },
+    "sound/vermis/grabbed.wav": {
+     "bytes": 51630,
+     "sha256": "99583c88b8ec2959a0d69448aee16ec86b3d9feee6df7841fc32759598349376"
+    },
+    "sound/vermis/grndhit.wav": {
+     "bytes": 36428,
+     "sha256": "1f0e78fa08efb4617b6967a6cc218c56af227c7fd6bf039420d8f106d74fca72"
+    },
+    "sound/vermis/pop.wav": {
+     "bytes": 131420,
+     "sha256": "6284ab02e604b44c5b07225b2a0544c8707517d5fec0024c127bdafef2704f70"
+    },
+    "sound/vermis/sight.wav": {
+     "bytes": 137772,
+     "sha256": "d892117e4602595b6dfb65563b8fa7a3ad2171851791f7c6f47ea4bfece76296"
+    },
+    "sound/vermis/sight2.wav": {
+     "bytes": 106780,
+     "sha256": "6132e2d0db5cfb7a1a064e708d97f7258e2c6ac15c6f4ea8d520641e0ad10f9d"
+    },
+    "sound/vermis/splash1.wav": {
+     "bytes": 30710,
+     "sha256": "f931a2927c13cdb2523dde4550c0af993cc08cbea6e332739f9cf6fe3bd1ff8b"
+    },
+    "sound/vermis/splash2.wav": {
+     "bytes": 25332,
+     "sha256": "b91c69ee695bd71537ed018800f7d89e5e7d95332124f69adee39261d84d7c13"
+    },
+    "sound/vermis/splash3.wav": {
+     "bytes": 25590,
+     "sha256": "99fad2f3815a30ef645a2162ea24e54b4302ba00d7551af9299fde74ecce98e8"
+    },
+    "sound/vermis/spore.wav": {
+     "bytes": 44204,
+     "sha256": "d01a27af99745725dae124d30af18458b2ef323bce93c3cad939310e0f47f6c7"
+    },
+    "sound/weapons/railgf1a.wav": {
+     "bytes": 66260,
+     "sha256": "a3a7edd9c470077682bde595f95d88546d416f300202ae96bd6c6371ec19cf09"
+    },
+    "sound/weapons/railgr1a.wav": {
+     "bytes": 51566,
+     "sha256": "40ce379a835e11561573be1dfdf1806a9bcb27192b94333a126cc721e38bbde4"
+    }
+   },
    "sha256": "8bf25c19172e0f7a63ad30fa14b1a93d335e50270bb1d3bd110d63adae53a3b5",
    "timestamp": "2012-12-11T08:04:08.000Z"
   },
   "Tershibboleth/pak3.pak": {
    "bytes": 6506790,
+   "files": {
+    "progs/bone1.mdl": {
+     "bytes": 6328,
+     "sha256": "9a00fdc313c40d06b9bb936c5ed0f97b2174cfc6494598cba42fb212d80dfcfd"
+    },
+    "progs/bone2.mdl": {
+     "bytes": 2940,
+     "sha256": "fc25694231ef3cb7567db44cbd080e416526fba73509781eb45c5e9841aa542e"
+    },
+    "progs/bone3.mdl": {
+     "bytes": 34368,
+     "sha256": "9f7a6f1d708b1efe687d675b459c4274143a7da6dd551ed8db83e01700375e17"
+    },
+    "progs/bone4.mdl": {
+     "bytes": 6676,
+     "sha256": "4587bdd40928b25698e89c437624c77cc2c77f32af929ca51a2122d069c8c8b2"
+    },
+    "progs/hive.mdl": {
+     "bytes": 9576,
+     "sha256": "24d505825f72178d41174d481b4ddc1981871a25f5a8d2a6bb12800dbfb57b81"
+    },
+    "progs/rider1.mdl": {
+     "bytes": 1595708,
+     "sha256": "207bb926fefd34b57bb14ec3d9d9a3106bfd58cce3201f1cb5b0d754140f79ff"
+    },
+    "progs/rider2.mdl": {
+     "bytes": 545600,
+     "sha256": "8414d8d62214848b26da3e56e3bb0ac0fc59792e9e473a9f9a4c62bfc0ae3699"
+    },
+    "progs/rider3.mdl": {
+     "bytes": 1110232,
+     "sha256": "6ca363430c2dd5a7484020cdc1e5c0936f544f51bee05d6a569c41efb6ca478e"
+    },
+    "progs/rider4.mdl": {
+     "bytes": 1454524,
+     "sha256": "14c64b22aaec0069b201982e3f126bde71683876ed80f737047f87a4dec6e86a"
+    },
+    "progs/swarm.mdl": {
+     "bytes": 127844,
+     "sha256": "eac005f0b9ff31650bfc81963b0cc3291732fa8366e31c56c5b0d809c880cc17"
+    },
+    "progs/waraxe.mdl": {
+     "bytes": 35856,
+     "sha256": "8b18a468baac0ff4201c63aea1bb2caf4a9f4a327f818567dcdb1c2cf395e570"
+    },
+    "sound/rider/death/clop.wav": {
+     "bytes": 4580,
+     "sha256": "6028b9d195ad93a68ceefcb8aec4370e950a897981989de0b665069c486a281a"
+    },
+    "sound/rider/death/clop1.wav": {
+     "bytes": 4580,
+     "sha256": "28696cdc4d6b356c6ffc1cac5d002bc651aab5b589394883e36d3ccf7f631ffd"
+    },
+    "sound/rider/death/clop2.wav": {
+     "bytes": 4580,
+     "sha256": "b2b9cc8663468d85eebbf71c404b708bed34924e9ca3271b827bc52cca67f20e"
+    },
+    "sound/rider/death/clop3.wav": {
+     "bytes": 4580,
+     "sha256": "b7bb0249d011f6dc154528919a16439a9ded749854b6d6c48bff3e1bc0c1f506"
+    },
+    "sound/rider/death/dthdie.wav": {
+     "bytes": 83066,
+     "sha256": "6625da36c6812b89e44fc5233f919cdb043e975ba63c28e432e6cc98d4d4093f"
+    },
+    "sound/rider/death/dthfire.wav": {
+     "bytes": 70778,
+     "sha256": "c9e9a417835472e4c27063b19f83e051d7311f0cce9321bd5c247f381db1a2cd"
+    },
+    "sound/rider/death/dthlaugh.wav": {
+     "bytes": 25658,
+     "sha256": "86f355417fc2e8bd9609847546ee20163dd0ce9fc9cfb3d153dcb96f212ad188"
+    },
+    "sound/rider/death/fout.wav": {
+     "bytes": 9820,
+     "sha256": "2cdb50e8f08ad8bcf06f49e853ab0ca1fb5cc98b5dd5f3aa008fdc62f2f047a3"
+    },
+    "sound/rider/death/shot.wav": {
+     "bytes": 30278,
+     "sha256": "e563c20fe5cbc6ac4b38775efc4f970d6e8ce3fa62cc2da94b6c2b91e8c196d5"
+    },
+    "sound/rider/death/victory.wav": {
+     "bytes": 38298,
+     "sha256": "d023b32dff8c6c6b4d95649eab7a3ffbaf4b1e05c9e3175ee4f112761e07e3ef"
+    },
+    "sound/rider/famine/_pull.wav": {
+     "bytes": 57686,
+     "sha256": "52106aee04a0248ca5276c8a8e1c82f416c591f2dac08083add05e5218b74e30"
+    },
+    "sound/rider/famine/clop1.wav": {
+     "bytes": 4580,
+     "sha256": "6028b9d195ad93a68ceefcb8aec4370e950a897981989de0b665069c486a281a"
+    },
+    "sound/rider/famine/clop2.wav": {
+     "bytes": 4580,
+     "sha256": "03b337ea1a348380e148ad03e99179fab0dbd1efc7820d45a74e863cdcf36cb1"
+    },
+    "sound/rider/famine/clop3.wav": {
+     "bytes": 4580,
+     "sha256": "afd07556f44f35222216a90235beccb149d74ac6a7cfcd7fbccd77cd76d8534c"
+    },
+    "sound/rider/famine/die.wav": {
+     "bytes": 57028,
+     "sha256": "9abd0716561549eae9b2ab444be276049c530a77e9c087dc9292fc18e0afb285"
+    },
+    "sound/rider/famine/flashdie.wav": {
+     "bytes": 248954,
+     "sha256": "2d8942ef8b88dd64239cddc8b4957d76d647543e50b95115bd76ddbec1f11a2b"
+    },
+    "sound/rider/famine/laugh.wav": {
+     "bytes": 45050,
+     "sha256": "efe0051a1e53d8328ae47901778f0cd19f1db793ef2a8d1c98c92bb71662fb7f"
+    },
+    "sound/rider/famine/pull.wav": {
+     "bytes": 58064,
+     "sha256": "998853d60e5f97150e266e97671c71328bb2dbf8659f9d3653a5684d05158132"
+    },
+    "sound/rider/famine/shot.wav": {
+     "bytes": 30278,
+     "sha256": "e563c20fe5cbc6ac4b38775efc4f970d6e8ce3fa62cc2da94b6c2b91e8c196d5"
+    },
+    "sound/rider/famine/snort.wav": {
+     "bytes": 25850,
+     "sha256": "06f92fc701f8f071c2892cdaf2a1d2ac94c5429033de326a46ef5523cc9d2b50"
+    },
+    "sound/rider/famine/whinny.wav": {
+     "bytes": 26362,
+     "sha256": "404de44803c2ec34721ae2fd6b0bc22b6baaa9d3c27ef88c896a1275846c7cae"
+    },
+    "sound/rider/moan1.wav": {
+     "bytes": 37224,
+     "sha256": "e86190319c4ed1fc539497e010874070b0920ee45abe960baaafabe74df09db1"
+    },
+    "sound/rider/moan2.wav": {
+     "bytes": 33598,
+     "sha256": "aa9dc4112e9343941f146d955227a1114f1d1911556db66e73fed4e39e981832"
+    },
+    "sound/rider/moan3.wav": {
+     "bytes": 35436,
+     "sha256": "b398a3f40b10b73cf63d041ad2de34e83a6c006ef5c50485c377e855fe373e65"
+    },
+    "sound/rider/pest/buzz.wav": {
+     "bytes": 21754,
+     "sha256": "957f1781514ab8e37909ea16813763357839c3d78e6eba2e5b630d3c92c389c4"
+    },
+    "sound/rider/pest/charge.wav": {
+     "bytes": 22844,
+     "sha256": "8c2a74463d2f5c6b32a5ad7f4c4654ca9f786556eafbf7e558b45c6b703415c0"
+    },
+    "sound/rider/pest/clop1.wav": {
+     "bytes": 4580,
+     "sha256": "6028b9d195ad93a68ceefcb8aec4370e950a897981989de0b665069c486a281a"
+    },
+    "sound/rider/pest/clop2.wav": {
+     "bytes": 4580,
+     "sha256": "03b337ea1a348380e148ad03e99179fab0dbd1efc7820d45a74e863cdcf36cb1"
+    },
+    "sound/rider/pest/clop3.wav": {
+     "bytes": 4580,
+     "sha256": "afd07556f44f35222216a90235beccb149d74ac6a7cfcd7fbccd77cd76d8534c"
+    },
+    "sound/rider/pest/die.wav": {
+     "bytes": 50746,
+     "sha256": "aa792d7d708de73ebe752c073376b40528ea2ab955d7b286cd8cdf933a4896ce"
+    },
+    "sound/rider/pest/gallop.wav": {
+     "bytes": 21114,
+     "sha256": "c8e5b5fbe216bcd1a59d5946ca3852302956fd5a6b4d1a7f97a73fc6859376a8"
+    },
+    "sound/rider/pest/hivehit.wav": {
+     "bytes": 16098,
+     "sha256": "ce85b2ec50191cd32697a24ef3afb62a70163116de8c185c2de4d219e2d3f26d"
+    },
+    "sound/rider/pest/laugh.wav": {
+     "bytes": 32980,
+     "sha256": "ba8aaa258dc7b21b52a2aa8316392f9f1edd8429b14253203ca0bbba128eac30"
+    },
+    "sound/rider/pest/sight.wav": {
+     "bytes": 22252,
+     "sha256": "6b4cb4b209546f52a749843ddb18767689159117e9e29f8eb7f1706c3811f022"
+    },
+    "sound/rider/pest/snort.wav": {
+     "bytes": 7150,
+     "sha256": "5af4c6e77675a0f27bcb62779205538e2e6ce4971a84361a494840c555c6b408"
+    },
+    "sound/rider/pest/snort2.wav": {
+     "bytes": 16376,
+     "sha256": "c8df6c3268bd3f2c8ddf0f9db33b410e61b550b2b6c1fc5ad0b4d20383dabe83"
+    },
+    "sound/rider/pest/sting1.wav": {
+     "bytes": 12218,
+     "sha256": "d37886f958b95e15096315a6b83bcf5f735ff5c7bf49c6654d4080978531687a"
+    },
+    "sound/rider/pest/sting2.wav": {
+     "bytes": 11482,
+     "sha256": "185692d83e0565bd5d6e7a15d533ea9032895c7863140275f4d2009e79ff6ad7"
+    },
+    "sound/rider/pest/sting3.wav": {
+     "bytes": 9758,
+     "sha256": "e6f4f6bb9742a7220d06b38c8068d7efbd9708ced0455473840e30a5c0bab740"
+    },
+    "sound/rider/pest/xbowfire.wav": {
+     "bytes": 15450,
+     "sha256": "548adc1347e3f72e83fe31bac1d3ad02efe912d49e96512afbc94ca377d0ac0e"
+    },
+    "sound/rider/pest/xbowhit.wav": {
+     "bytes": 10066,
+     "sha256": "03d93c412e226d7e71077be790ff62afff9fa4306b5335f4e0338b6fd3dc47dd"
+    },
+    "sound/rider/war/die.wav": {
+     "bytes": 75642,
+     "sha256": "16185e29265e20db7fc35836b2adc2ff5ca7ed203a25139f7656244aa8abe238"
+    },
+    "sound/rider/war/fire.wav": {
+     "bytes": 84474,
+     "sha256": "48bddc52358fb6ae4fd362ba0efb103638f9f8ab7776dd0461fd33546b50b3ed"
+    },
+    "sound/rider/war/fire_big.wav": {
+     "bytes": 32762,
+     "sha256": "2fb163e76fe46d966326879399155e045fc35063b2b8a2e55746e082e4bfbee7"
+    },
+    "sound/rider/war/laugh.wav": {
+     "bytes": 31012,
+     "sha256": "a80094ae1273615c5683e4a949a3adbdfce927635af5f5132cc46403a11d9596"
+    },
+    "sound/rider/war/laugh_sm.wav": {
+     "bytes": 20328,
+     "sha256": "9c515335988177e563d7fffb8f77c99790fdaed6631566e94ad0cd3dc74819fc"
+    },
+    "sound/rider/war/whinbig.wav": {
+     "bytes": 50940,
+     "sha256": "871b0b4b5bd3346747587cc435090d6afc978da07711cd819858b911358b1b6a"
+    },
+    "sound/rider/war/whinny.wav": {
+     "bytes": 20762,
+     "sha256": "a6b16598912d06b03c6e1f974c2b8ab4d8e1486f8785e25d68336d2e22ec55ca"
+    },
+    "sound/rider/wartrot1.wav": {
+     "bytes": 7478,
+     "sha256": "abac0cfb4bf02364e795b83197ca563c2e158d93eb9f6999cc258c12fc8a1ecb"
+    },
+    "sound/rider/wartrot2.wav": {
+     "bytes": 8920,
+     "sha256": "83f6abaced3124b50f760c666c5902abcb57309f951308ad30d0fbc7f8cf562e"
+    },
+    "sound/rider/wartrot3.wav": {
+     "bytes": 11324,
+     "sha256": "42af6fefd6b10d38f42d9987be5ccb71d595440a881fca4f492a5562f50e4bda"
+    }
+   },
    "sha256": "9a58d294e79806fc15293163ba9954f7d842238c3040aa753f497c5fec2e8473",
    "timestamp": "2012-12-11T08:01:28.000Z"
   },

--- a/json/by-sha256/3c/3cbae5ebc32c5cff4c201933265d4dd4dc4f50d9a0edc1710a6556212ab45bf7.json
+++ b/json/by-sha256/3c/3cbae5ebc32c5cff4c201933265d4dd4dc4f50d9a0edc1710a6556212ab45bf7.json
@@ -59,6 +59,360 @@
   },
   "modjam_adaya/pak0.pak": {
    "bytes": 3375374,
+   "files": {
+    "progs/armor.mdl": {
+     "bytes": 44076,
+     "sha256": "2c3ed470f75c2ed1fabca5a0ae3f152865e07e2aeabeb9f94b80bbc979d074fa"
+    },
+    "progs/bfgblst.spr": {
+     "bytes": 16500,
+     "sha256": "c8e0c255110c35e8b055a0a68fb4471b9dd0adf34ec5d9caeb3dce996ac5d722"
+    },
+    "progs/bfgexpl.spr": {
+     "bytes": 393372,
+     "sha256": "93db88bffe5ba26c4d8886ac11ca32bc7da12b7b5bfb31242069592be6d53dd3"
+    },
+    "progs/butcher.mdl": {
+     "bytes": 162036,
+     "sha256": "3de16efabfa80692984c0f8f742157d28991abf664d80d9250b3fdd4b0d5e9b2"
+    },
+    "progs/g_chain.mdl": {
+     "bytes": 50628,
+     "sha256": "caeb28e0a2a5cd18a83eb0681e76664b903a7aa850ce6662d4abef0678efbce8"
+    },
+    "progs/g_hot.mdl": {
+     "bytes": 57156,
+     "sha256": "908dba6ec48d48640d0b813a6cdb9c0e6d3517cff2ec892837f720b0741104e1"
+    },
+    "progs/g_shotcl.mdl": {
+     "bytes": 335236,
+     "sha256": "29b71ebd225844dfaeda7ee829e3d111b123977f2511821835578cd2e8536eeb"
+    },
+    "progs/h_but.mdl": {
+     "bytes": 14900,
+     "sha256": "b93958802085ea972acdf7e9c008774a807e99ab1dc4c0bdd70bddabbccece17"
+    },
+    "progs/h_nail.mdl": {
+     "bytes": 11828,
+     "sha256": "6b8222563698bb2a5759322fc1fd03713ce59fb4c62847abedfe5c626c985e4e"
+    },
+    "progs/h_shell.mdl": {
+     "bytes": 11828,
+     "sha256": "15c3f8c45a52d866981ba1ebd3c5ed2797e91d149acc5852dd7642a43d4d7a84"
+    },
+    "progs/hermes.mdl": {
+     "bytes": 62276,
+     "sha256": "55b702432f6c4cf4c21df1142ac45eae63cbd158dfd92442176f26e91f5ea770"
+    },
+    "progs/kronos.mdl": {
+     "bytes": 62276,
+     "sha256": "3a6be59da8623882cc6d50381f7237942cdf424e97d20953cde382697ef237aa"
+    },
+    "progs/kronos1.mdl": {
+     "bytes": 62276,
+     "sha256": "ad6b0e2e2b1299a97c59f00bbfa0e9c93ceeac4034d2a95391d61e90aed4573b"
+    },
+    "progs/lspike.mdl": {
+     "bytes": 1684,
+     "sha256": "75a3f036a04bf5843488758f90fc2416d8a96ed5493460444c4fe2e6ce9956e4"
+    },
+    "progs/nailinf.mdl": {
+     "bytes": 160688,
+     "sha256": "c67399daabb0905113dd77cc79a79592111c63c0097ba33b84eeb6d9144ace7c"
+    },
+    "progs/s_light4.spr": {
+     "bytes": 2124,
+     "sha256": "b265c5d1311d0cfb552a4f60234a5d14817ad0ed4211f24b544200e712e1c1f7"
+    },
+    "progs/shelltrp.mdl": {
+     "bytes": 399572,
+     "sha256": "332fb8a227e10c124d1b091a28352c1f875c6f1936c56d041066ea85819c5310"
+    },
+    "progs/v_chain.mdl": {
+     "bytes": 86004,
+     "sha256": "b0bef898fbced4aaa976a953836ec38018bb014582753534ec353709de5ac0e1"
+    },
+    "progs/v_hot.mdl": {
+     "bytes": 60228,
+     "sha256": "7d51ecfbd37d7bbc6f9702f8a9a4766261a9a9d537880ac6c0450ad0c4ce054f"
+    },
+    "progs/v_shotcl.mdl": {
+     "bytes": 76404,
+     "sha256": "fc1388687f000a9d09da9879dadd51e43ad929359da0eb2f77e0a305969f09bf"
+    },
+    "sound/butcher/flak.wav": {
+     "bytes": 17720,
+     "sha256": "36b1e2fae9c717e92364d5c67d4e00d25ed9f6dacf798d656bfaf7fd72e233b2"
+    },
+    "sound/butcher/ogdrag.wav": {
+     "bytes": 12396,
+     "sha256": "e7cf55df89c831567f8bf7b02e57b987e3b57eb34bfe48225167f2af6b640c11"
+    },
+    "sound/butcher/ogdth.wav": {
+     "bytes": 12052,
+     "sha256": "0587d14849b0fec40eeea6dc4d61db548a8d760e17cbee07f572e5de081c5a5b"
+    },
+    "sound/butcher/ogidle.wav": {
+     "bytes": 61810,
+     "sha256": "40ecc9597a7c2fa5d65f203dd022379bf3b85bfe4a19612181f5dd29f831d1f8"
+    },
+    "sound/butcher/ogidle2.wav": {
+     "bytes": 12292,
+     "sha256": "14d217d02c7a3898d835cda4ee00c80afe722943d0d538a0b7b95e7b3cb8230d"
+    },
+    "sound/butcher/ogpain1.wav": {
+     "bytes": 7730,
+     "sha256": "c8f157894e5651a2f599994d489520c539549dc5cb51d803e0ad60364b0c205a"
+    },
+    "sound/butcher/ogpain2.wav": {
+     "bytes": 9108,
+     "sha256": "77a09d54447b3ce0b3a304545f613da813b29365de2d0c168c07ccdc1d6b04e7"
+    },
+    "sound/butcher/ogpain3.wav": {
+     "bytes": 10930,
+     "sha256": "041d603a4c53633324dc28f937d80e51c70fb3f80fbd18f41a8b160ef7596f2a"
+    },
+    "sound/butcher/ogsawatk.wav": {
+     "bytes": 16154,
+     "sha256": "f24f86055999053273798d54f646064f3053414dfb14167d611aa1cb6dbbb51b"
+    },
+    "sound/butcher/ogwake.wav": {
+     "bytes": 8420,
+     "sha256": "fd327b2b1f56656b3573262486b2756494d6812dbf5bf6b1e5bd939da3ed4297"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 6494,
+     "sha256": "259c57ed9a96e2794933fb1e5ddabddbdc87069968590d6e3ac69895c18282d3"
+    },
+    "sound/items/armor2.wav": {
+     "bytes": 7704,
+     "sha256": "081c3f62f9a94969f75947b51c785d40a6d24b16d39f529804b5c85404f7cae6"
+    },
+    "sound/items/armor3.wav": {
+     "bytes": 9252,
+     "sha256": "c51e305d5a2b42f6b9b9dfd82fc1870e086a0b2ab8c04dbe3c00a1e04784f98f"
+    },
+    "sound/items/clock1.wav": {
+     "bytes": 38168,
+     "sha256": "ee475af2135a5c9d8b2afab199c2131d95070b9e3a56e3571adf3f00b95c50b9"
+    },
+    "sound/items/clock2.wav": {
+     "bytes": 70976,
+     "sha256": "8b40b62f88303d16cfc6fef6b7ad1be584c50764c2883075eab77bd220fb155b"
+    },
+    "sound/items/clock3.wav": {
+     "bytes": 130248,
+     "sha256": "a04c45553280fbb992308fb0aade8ac8e74ec4e4c2ab8400a69de8bad642fc25"
+    },
+    "sound/items/haste1.wav": {
+     "bytes": 13420,
+     "sha256": "267bcedfe84a50bc1f5257d5cc7cd401465bd012682b328546e5af61f8fc29cb"
+    },
+    "sound/items/haste2.wav": {
+     "bytes": 31622,
+     "sha256": "c8e298dab6c215bffc237cd6681dae38c803250e1c199db9b61f523500ce3e13"
+    },
+    "sound/misc/demwhis.wav": {
+     "bytes": 41860,
+     "sha256": "ebe61eef38623168a0601d06abbc7d59f99f222df6f4b7552640c7bd872f65ae"
+    },
+    "sound/nailinf/death.wav": {
+     "bytes": 18898,
+     "sha256": "b9bbb261c4f58c7857f368e7482a6706b1a4105b3ad4e41a700d1025d29d38c6"
+    },
+    "sound/nailinf/idle1.wav": {
+     "bytes": 14894,
+     "sha256": "3ec1439123c6f122838ea8d7a26db9ddf45f60e8b2eb851382c8f3aa191c5b17"
+    },
+    "sound/nailinf/nailshrd.wav": {
+     "bytes": 41464,
+     "sha256": "dd2e7b5cd674d61c4e26d20cf4162586bda9aec30ec9a33526d7ca089f8c468e"
+    },
+    "sound/nailinf/pain1.wav": {
+     "bytes": 5118,
+     "sha256": "81038879b6d933fe59d29059b5d0655b6e9bbd96c11f902c5d6fd5e3acb0a333"
+    },
+    "sound/nailinf/pain2.wav": {
+     "bytes": 5680,
+     "sha256": "a8eba9496de56151703e9a8b93dc9f0ab7e161ae351acd0082feda567959ebb1"
+    },
+    "sound/nailinf/prepfire.wav": {
+     "bytes": 8818,
+     "sha256": "e76bdc8040c3c467bc9f765f0d91508c4aba7aecfa92a1c954400e01d37688c5"
+    },
+    "sound/nailinf/sight1.wav": {
+     "bytes": 18618,
+     "sha256": "6f6f9f5c2d92b87abae4c2fc78c92b3e96f20a5d9e53eacf9eebb283bd4558da"
+    },
+    "sound/nailinf/sight2.wav": {
+     "bytes": 15670,
+     "sha256": "42dbf9e02a96ba2e6cd2bee0adf9dae22292c572d9c00bc499a699e6ea4da9cf"
+    },
+    "sound/nailinf/sight3.wav": {
+     "bytes": 14522,
+     "sha256": "38851d768386b7096548b082235da9921966905678ca84027567e59b6e603bc1"
+    },
+    "sound/nailinf/sight4.wav": {
+     "bytes": 19798,
+     "sha256": "0583212c3dd33bede0fd9e2963a04c8320add72c523305dafc6f3dd3b28cda59"
+    },
+    "sound/shelltrp/death1.wav": {
+     "bytes": 14392,
+     "sha256": "a75e4b75af69296ee5a273bf1ff62a60321b97e48d10ee333ca08b46be22ea0e"
+    },
+    "sound/shelltrp/idle1.wav": {
+     "bytes": 58092,
+     "sha256": "aae8911895b15e66c40f7a2d3b687ad19af0e278bdfe874798d2c8d9061b2470"
+    },
+    "sound/shelltrp/pain1.wav": {
+     "bytes": 11560,
+     "sha256": "e46f4d79a901c0398dfef501b6b5682129c0721f8bbb87822123c90a8a3fc050"
+    },
+    "sound/shelltrp/pain2.wav": {
+     "bytes": 16882,
+     "sha256": "e970b2107f4557869d9930077f3e8177db050a39a84421a00ac8921b09d5864f"
+    },
+    "sound/shelltrp/pump.wav": {
+     "bytes": 6390,
+     "sha256": "eec07407720f84a37e600f22eb0265549d350add8af972dc507ed0306c20a121"
+    },
+    "sound/shelltrp/shotgn.wav": {
+     "bytes": 22148,
+     "sha256": "2e676451c8c64d14bf8f9dde8213d3cc9ba48b3a4dfbf3b392b5ae6fd86d2c1f"
+    },
+    "sound/shelltrp/sight1.wav": {
+     "bytes": 25442,
+     "sha256": "6f44f881ba084bf2fcb613f46bf106de75d96119ee8c23f5f000d1692aad4468"
+    },
+    "sound/shelltrp/sight2.wav": {
+     "bytes": 16560,
+     "sha256": "f1cc4fb4aebde3174bfc659dc21d82eddcfbcb244ff6cc217831f368641ccdd3"
+    },
+    "sound/shelltrp/sight3.wav": {
+     "bytes": 22928,
+     "sha256": "5780dcc29d54533106acd161710445b07481d962129a219dd433cd516b571f71"
+    },
+    "sound/shelltrp/sight4.wav": {
+     "bytes": 49950,
+     "sha256": "cec85ed6a38bdc1670e9b9a98ddb4bf41327762baf9e7dc55a45782070fef482"
+    },
+    "sound/weapons/acell1.wav": {
+     "bytes": 8800,
+     "sha256": "fe0c36bc9e541ad620bd1725318311f3eab13442d3b9726d9b3108e6b39d17e9"
+    },
+    "sound/weapons/acell2.wav": {
+     "bytes": 10920,
+     "sha256": "56fbe4f9e61516931aa3048993c28c5398d2035e6372c69da8925ea60cdedd7c"
+    },
+    "sound/weapons/anail1.wav": {
+     "bytes": 4950,
+     "sha256": "ee61c5455fc13216173e44a58ce13a522ba74d354bbb5707177131daec2376c1"
+    },
+    "sound/weapons/anail2.wav": {
+     "bytes": 7300,
+     "sha256": "fdb33dade14269d4d5e7de03e30c087b057e00f9635a1411a12fca70b7bc91db"
+    },
+    "sound/weapons/arocket1.wav": {
+     "bytes": 9502,
+     "sha256": "2a0c639fb760088b883f083d951d82780bc918008192a032cdcd54fc06ff0a77"
+    },
+    "sound/weapons/arocket2.wav": {
+     "bytes": 11610,
+     "sha256": "c11a4db332a96d844461072082c42d331e7eb69b8681ae49724a3c11a209f98e"
+    },
+    "sound/weapons/ashell1.wav": {
+     "bytes": 4970,
+     "sha256": "110caa401cbad16cf3fc78b0d60c27c11640d355a425cf4a18dbcb58954c13e3"
+    },
+    "sound/weapons/ashell2.wav": {
+     "bytes": 8308,
+     "sha256": "e7f7c5545944f2c8ca518ffbf6af542be4bbb22ff0aa2d039c5f64bef6e83f57"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 9552,
+     "sha256": "655018e0b1ebd61283db23ff324574948295e3a9ca43337e49c8d49938666210"
+    },
+    "sound/weapons/chain2.wav": {
+     "bytes": 19022,
+     "sha256": "bbc5dcc50a31fb7c44d8c8f3cfa1c919e0c15875140f9ab3a9768ecfab0ebb8a"
+    },
+    "sound/weapons/chain2z.wav": {
+     "bytes": 19090,
+     "sha256": "b4be4c88effc6d0605b34cbcb772d79b7dbccf8c902f5bc76a17bf3131b32e95"
+    },
+    "sound/weapons/chain3.wav": {
+     "bytes": 2676,
+     "sha256": "61183aad8e0f3c4716f4243a74728fee29fde7db9ca08b522ddc98834c10998a"
+    },
+    "sound/weapons/hot1.wav": {
+     "bytes": 3252,
+     "sha256": "2b21217fbc4d5f4f862f69f31a58473dd29f23110d321a1a3afcaf7e504d672a"
+    },
+    "sound/weapons/hot2.wav": {
+     "bytes": 29170,
+     "sha256": "25cd7092c9b4987f923f534957a312852b920f185af63c73e84b765e7889d3bc"
+    },
+    "sound/weapons/hot3.wav": {
+     "bytes": 50978,
+     "sha256": "c6b312455b7678b0ebf0f55753cc39b9e07178ec5d5fea2605310eca6e52a915"
+    },
+    "sound/weapons/hot4.wav": {
+     "bytes": 10698,
+     "sha256": "254ba8798743618faf4d4738ff779cbd686dcda7c0da1a3d639290aa88dd02a0"
+    },
+    "sound/weapons/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/weapons/pkup2.wav": {
+     "bytes": 10118,
+     "sha256": "3be3ba31de2818cb915a4a4cf4721b1271a0983f1e9ad3df1142793809dd5570"
+    },
+    "sound/weapons/pkup3.wav": {
+     "bytes": 9276,
+     "sha256": "13098a619b250590b51cc0a609e18a396a3fa79576abb3c72742534c9083cfb5"
+    },
+    "sound/weapons/pkup4.wav": {
+     "bytes": 8090,
+     "sha256": "5f2e794af6199386e7bbfdd5961a3cb67ecac41b87e5d2336f15f95f09f1b865"
+    },
+    "sound/weapons/pkup5.wav": {
+     "bytes": 23018,
+     "sha256": "c3131e35745097fd1ab966e3334544f3af49e2a96c2ca0dd428e960de5562b28"
+    },
+    "sound/weapons/pkup6.wav": {
+     "bytes": 11140,
+     "sha256": "a23f96837b00b8ba574d6edfe7421f47e2115b6a6b5dedc9761eea0cece0f823"
+    },
+    "sound/weapons/pkup7.wav": {
+     "bytes": 9594,
+     "sha256": "a1b429e7759d70fb68fb90561ebb7a3addb0291628e225c8650bf9a52ff2882c"
+    },
+    "sound/weapons/pkup8.wav": {
+     "bytes": 15798,
+     "sha256": "2b8e586ae22b5138b7e2d46d76ed4c47dedd3bda14e0e1a64dd8a6a734fe0745"
+    },
+    "sound/weapons/pkup81.wav": {
+     "bytes": 10040,
+     "sha256": "708f7935c4b5d291703697400be66776417a19cd4a6db7871db85875d904e605"
+    },
+    "sound/weapons/pkup9.wav": {
+     "bytes": 33732,
+     "sha256": "cc2a7dcc1d16b17a598e2472b69f941c603dec77131853d8884d20a1ccea8046"
+    },
+    "sound/weapons/shotcyc1.wav": {
+     "bytes": 18242,
+     "sha256": "c069f126338f166129ce9eb8065999dc4348028f92ac5af72075843885b8ff48"
+    },
+    "sound/weapons/shotcyc2.wav": {
+     "bytes": 3372,
+     "sha256": "8446a93c88c9574d63f3d4c3c395894da50343b55b7a1a97354f93e75eb7a122"
+    },
+    "sound/weapons/shotcyc3.wav": {
+     "bytes": 6190,
+     "sha256": "8fcfb6080be436f6ffb5b1310ba100d39a184e20aac1588050a6d62001334f68"
+    }
+   },
    "sha256": "8c94fe82bdbc9b4bc9b795541436f9f4af178407afbafd84c1baae66f81b5585",
    "timestamp": "2019-02-09T00:51:34.000Z"
   },

--- a/json/by-sha256/3e/3e7b133a82737b006cd8fb99913076672f981222c7a3cb131d95a4aae2d6795e.json
+++ b/json/by-sha256/3e/3e7b133a82737b006cd8fb99913076672f981222c7a3cb131d95a4aae2d6795e.json
@@ -1021,6 +1021,412 @@
   },
   "rmxjam/pak0.pak": {
    "bytes": 5456024,
+   "files": {
+    "gfx.wad": {
+     "bytes": 157476,
+     "sha256": "95e62e37d1d0f29e7f72042793f84945b66cf14e439d9128a06fe7e3eb7f3a2c"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 378438,
+     "sha256": "b085d8882a11b1e8396758b18eea86590157e962de295feec1b8aa1993a81658"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "176355e1c56f6e3c580471a74f3fea7e75ac2a5fa6a4c90a8008ca042f938f5b"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "ed0f79285d93d0ef35644ecaf9ab36f3b2c6ffd223c577b25fff2ea17f90080d"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "e9c210ab88f6e98965cd2f8470f084e32ef15b3ad3912cb1e9eb0363c6204eb7"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b56880e2f720a89dcd055f5278abb21a21514322d4a31b77b46c8b509b9f3be3"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "89c3ac6fd91cdcf15c20b0d15b4c01c153e0a820c660f9222b5c8f63d43af5b2"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "8b83ffaf6b5309d371f0107ebb1340a8a09cd1a52c6a5581b7c9c4a7afcefa77"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/debris1.mdl": {
+     "bytes": 33768,
+     "sha256": "3498dffa0c3522b011a76ada880dfae64de3ca1583c94474e1e07adbc220d981"
+    },
+    "progs/debris2.mdl": {
+     "bytes": 33944,
+     "sha256": "d6d535173bb4a3a2d469be9c63bf36a01b1e2b80dd6a71636d20178d813e443c"
+    },
+    "progs/debris3.mdl": {
+     "bytes": 34136,
+     "sha256": "d6b0a2b6353c4462196d2af116652b47d464a7bc1f161509aa8ee5dbe859f98b"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 17812,
+     "sha256": "74cd41d8d5a67570cdaca34a08e9868f3476d8c4ac4a645cfaf9e91cf778c793"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "4f5ca2553db07d5cc93987b11e9f9ff054d51b96488e2bcc35c9f03ed3040d42"
+    },
+    "progs/h_zombnm.mdl": {
+     "bytes": 3220,
+     "sha256": "45d9dfe5683264edf6f6eb7b8e8d794f84caeb8701e65e8ebe9add2192bbb6fc"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "b00951cd72bb5fb03c19a1d60943162652fe149b9ee60fd2e630a076d52956fb"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/k_spike2.mdl": {
+     "bytes": 17716,
+     "sha256": "e456eb93934dab43a83305988db82ab1954e66491c256fad3ef1451d0ecf97c2"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 36496,
+     "sha256": "a001c379917628354adfb62b698856b33f4eea5f22e7d8e232e640faf15d8465"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133936,
+     "sha256": "e2d6b9de9b879327f72d97ef3c07e0b7e35cf844747208f6e615015be84157e5"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "f414f3fd07b0278bd59dd90954770f81a5ffad7f46af5f5d0abee124905dcc17"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "progs/v_spike2.mdl": {
+     "bytes": 13684,
+     "sha256": "eb3dfbe46c93454b63a6ac4a0d657d54058bd485d4fea41787de89b5b13b78ce"
+    },
+    "progs/w_spike2.mdl": {
+     "bytes": 5204,
+     "sha256": "b7616550054aed17eeb512d5d6114c68a71f1df77f3cf226d354bde3c9bf379c"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 74976,
+     "sha256": "545d70abb8d44be8e12da24a3d09fb56f87ff960c41963148682fbbd9d47e417"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 218680,
+     "sha256": "6782603eadacc7cb4bd09c11d3b6326e0d2e69205f724fe2f6e533ee398f5a16"
+    },
+    "progs/zombienm.mdl": {
+     "bytes": 224900,
+     "sha256": "f4d1ce9667ebb36088bfb59a12c9a8d93c1aefa36515b51f388cffec5132f5b2"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    },
+    "sound/zombie/z_res.wav": {
+     "bytes": 23266,
+     "sha256": "10b2962ce2817fa8a250811313307cf0dfa93ad5257a669452fe3fc834ced976"
+    }
+   },
    "sha256": "0d509e794fb11132ffa256f6967e898ec6d868642b6c1fe2ffdf1f1763052f1c",
    "timestamp": "2024-02-04T03:18:26.000Z"
   },

--- a/json/by-sha256/40/4019a0237688eefe2f2899bee6eff73e1f9aae4d7df5dfcadfc3f0fa79dea278.json
+++ b/json/by-sha256/40/4019a0237688eefe2f2899bee6eff73e1f9aae4d7df5dfcadfc3f0fa79dea278.json
@@ -17,6 +17,528 @@
   },
   "pak0.pak": {
    "bytes": 6739129,
+   "files": {
+    "default.cfg": {
+     "bytes": 2217,
+     "sha256": "c97c00c51b08948504ba64378fcef4c3d174ba889c05b82820061a927f6fd189"
+    },
+    "maps/asylum.bsp": {
+     "bytes": 2578016,
+     "sha256": "7c8ef7b1420aa35d77081838f1a576432944ba7cfec3f4447f065d0e339beb8c"
+    },
+    "maps/temp.tmp": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "progs.dat": {
+     "bytes": 649760,
+     "sha256": "35a2fdc3acb04bdafe8d0269f5327cd1d5b47971f1ef024429f1572d3201dc82"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/wetsuit.mdl": {
+     "bytes": 55156,
+     "sha256": "4e4dc7331c374d2345c3d755ff34b61850c289741314b10fa36c461db3844e99"
+    },
+    "quake.rc": {
+     "bytes": 370,
+     "sha256": "87f2069af16b84f13a62b913ffa0ec194ab959b0b2affceb73c6a538d2896b6b"
+    },
+    "sound/ambient/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambient/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambient/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambient/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambient/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/doors/techope.wav": {
+     "bytes": 14752,
+     "sha256": "3b82abdc7d218cd891d6e89f96756bd0a54884859e8ff1267075fb0f1c49d4e8"
+    },
+    "sound/doors/techopen.wav": {
+     "bytes": 14752,
+     "sha256": "3b82abdc7d218cd891d6e89f96756bd0a54884859e8ff1267075fb0f1c49d4e8"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/misc/2hours.wav": {
+     "bytes": 35075,
+     "sha256": "a543d5cf9fe154c8841dd870b2e144d016811edabfaeac0ca6498162f24c33e3"
+    },
+    "sound/misc/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/misc/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/blowit.wav": {
+     "bytes": 16756,
+     "sha256": "4c27eaf7298932a534e3ca8c1e871e95bad40a6cdef70bff9492968042954c75"
+    },
+    "sound/misc/bubble.wav": {
+     "bytes": 52256,
+     "sha256": "277d584d1bcd84f08b5af8c42d0cdaa696f7b31195d508f8f3a89fbdae3a84b5"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/confirme.wav": {
+     "bytes": 17624,
+     "sha256": "bc0747f27531d7d8b2550e52ccf91af653322e8cd23a6b950d78507163ac9c81"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/killme.wav": {
+     "bytes": 24420,
+     "sha256": "acba2e50b81d5413cbc5f3827db3c8a5e07ea8ba380e070834d07ab6d473d4f5"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/misc/moan1.wav": {
+     "bytes": 37224,
+     "sha256": "e86190319c4ed1fc539497e010874070b0920ee45abe960baaafabe74df09db1"
+    },
+    "sound/misc/mudie.wav": {
+     "bytes": 24926,
+     "sha256": "dcd006b12274a704d54016b2c3d471e330d328e4c60501e6dced84ac79766a88"
+    },
+    "sound/misc/nopanic.wav": {
+     "bytes": 21766,
+     "sha256": "d6a058f51a8926293fd7c7a6da39d3aeaf9d095ac78e09b7f5e6576f17c10932"
+    },
+    "sound/misc/poundin2.wav": {
+     "bytes": 33146,
+     "sha256": "5fc6bd8d8c9b18a72636bfc4ef1c0412c82ca4eb10eb5bc800d5224b053b764a"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakea.wav": {
+     "bytes": 24112,
+     "sha256": "cf56f499259167722bcde51455a2843b19fb468d8ec27f5a49480aba7c233839"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/secret.wav": {
+     "bytes": 21394,
+     "sha256": "b9fc9a026343a15d2f17c6884e1b65d6cf0156de0ffd644a44e4535f6ddfebea"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/stndby.wav": {
+     "bytes": 17668,
+     "sha256": "c4f756b394fd5edd648cea2b89ec48f3c9b13f8ecbaf18f3370589aafec538f3"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/unabltoc.wav": {
+     "bytes": 8314,
+     "sha256": "9a9bf99b4a38ffec8a78108a9d4a4e8ac3e16f9cc3dfff4fd02c0b42bae83127"
+    },
+    "sound/misc/voice1.wav": {
+     "bytes": 11908,
+     "sha256": "8c757323a2a6b7c03d42f554279858f8abfcfb59ae23c23af9aacf947a26b5d5"
+    },
+    "sound/misc/voice16.wav": {
+     "bytes": 42830,
+     "sha256": "dad2a9e0194bb4b755707587da3a5e08843a7a479d3b1e15c8892f128157f3a5"
+    },
+    "sound/misc/voice17.wav": {
+     "bytes": 52788,
+     "sha256": "7f5328bdb6fe4e3da993204e110c34099199ab2c808d6ad5d7c2c86831206ef9"
+    },
+    "sound/misc/voice18.wav": {
+     "bytes": 64558,
+     "sha256": "00d84f6d3ac72c3a9e844c22a0c27f07effe2b3830619d133e2ce2ebf82b1cea"
+    },
+    "sound/misc/voice19.wav": {
+     "bytes": 166368,
+     "sha256": "3d443be9c481ba9a7a07bc04e7fd1d643e8e7530ddc6871f362b1fca42c1d67c"
+    },
+    "sound/misc/voice20.wav": {
+     "bytes": 31150,
+     "sha256": "7254d9afb695ceca0733b2cecc1a641b98e12b67fb50de0fc6bd9c19ad7cc560"
+    },
+    "sound/misc/voice21.wav": {
+     "bytes": 14318,
+     "sha256": "a8a6c542d366bd93eb87c0a9c48efbde75b048485dfbc1881e8da600c5206b5f"
+    },
+    "sound/misc/voice23.wav": {
+     "bytes": 33838,
+     "sha256": "1bd0b7de8047587fcfb57e25482d947125cc56c58492d41993498c424622631c"
+    },
+    "sound/misc/voice24.wav": {
+     "bytes": 60846,
+     "sha256": "f4603f04173e069a99fe400debc91bf7d99d8e7a0885cf280806971b6f87d8e8"
+    },
+    "sound/misc/voice26.wav": {
+     "bytes": 81628,
+     "sha256": "b71ed2da7dc6819f7d9bb4745a4ca92a54d68f5e5ed31a8d91551ac71b00e4d9"
+    },
+    "sound/misc/voice28.wav": {
+     "bytes": 61542,
+     "sha256": "b302d995d1f43ea9e4ff5e4dcf4bcdf627610a326c81ce38abf3e5c55d9a879f"
+    },
+    "sound/misc/voice31.wav": {
+     "bytes": 10364,
+     "sha256": "5fd203f56c61903bc2949d801f9842f349814a218fd21291c7c28c1478d29d53"
+    },
+    "sound/misc/voice4.wav": {
+     "bytes": 11908,
+     "sha256": "8c757323a2a6b7c03d42f554279858f8abfcfb59ae23c23af9aacf947a26b5d5"
+    },
+    "sound/misc/voice5.wav": {
+     "bytes": 10514,
+     "sha256": "05f002f1de9212734781958446961e73bcd79a367730ef596ebb2cc49d0bdab3"
+    },
+    "sound/misc/voice9.wav": {
+     "bytes": 19742,
+     "sha256": "5b4ff9dd77e9529a319dc51205e4605ed21200d0ef61f3f74293ee0434b714a5"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/misc/wind2.wav": {
+     "bytes": 35606,
+     "sha256": "3ea692e4d550a82dc9e815836a8772a25043edb9536e8c794f4ad9032fd5a5bc"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    }
+   },
    "sha256": "713c71661968279dd720cedc7f58abc371f289f236d1df0c489458b9c097c964",
    "timestamp": "1997-11-03T14:04:18.000Z"
   }

--- a/json/by-sha256/40/409fe16f131937caef905e6d0d52f7d4f47271aea7faec49bb571db7dcbb3391.json
+++ b/json/by-sha256/40/409fe16f131937caef905e6d0d52f7d4f47271aea7faec49bb571db7dcbb3391.json
@@ -17,6 +17,36 @@
   },
   "koohoo/pak0.pak": {
    "bytes": 5243430,
+   "files": {
+    "maps/koohend.bsp": {
+     "bytes": 506240,
+     "sha256": "03502419502d30c5af41c2329b5a5366a6609dcb4ce6cdb4f8aa0a1449c5cdf0"
+    },
+    "maps/koohoo.bsp": {
+     "bytes": 3621928,
+     "sha256": "bda3ee85cca475db793bb9e759cb853de72a05b33204ca57ba3165b2bd863d23"
+    },
+    "maps/start.bsp": {
+     "bytes": 445144,
+     "sha256": "4d89c950f2d9ae5863ed2bc005ce881fdf0f31671dffb060bd686cc7d219779e"
+    },
+    "progs.dat": {
+     "bytes": 398068,
+     "sha256": "48494b85a0d06c5f3afd90514f44a1710e46d1c84dd27b03fb1490c0e27b77f4"
+    },
+    "progs/boss.mdl": {
+     "bytes": 211836,
+     "sha256": "9f55331e74fdfdb22754b2feb6f201856d364ff628074dc84a0bbbf2613d0be3"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 8788,
+     "sha256": "6abc446260a90c3c2a0182f510f42a19a6f4da2c721f70201f4dc9a576b28e1a"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 50966,
+     "sha256": "4ff7c86a0634a3ffce56f3948814d006bf3ba8e5107541b75b018bf01c06497c"
+    }
+   },
    "sha256": "71dfcda941611c42c96da8f0984de32c5a82e6f8117a30ce9a66415d7d72b121",
    "timestamp": "2001-03-24T23:50:00.000Z"
   }

--- a/json/by-sha256/41/4174ce650f4107fef4e047934aa113c28f4d6356b83dd1ef5fd9346c2cf0e978.json
+++ b/json/by-sha256/41/4174ce650f4107fef4e047934aa113c28f4d6356b83dd1ef5fd9346c2cf0e978.json
@@ -12,6 +12,256 @@
   },
   "pak0.pak": {
    "bytes": 8745383,
+   "files": {
+    "maps/hrim_sp1.bsp": {
+     "bytes": 5624208,
+     "sha256": "1cd37d9deb28bfc4dd5079e33a94e1b10a0f8b16b9984abd783016c62efd469e"
+    },
+    "progs.dat": {
+     "bytes": 657288,
+     "sha256": "ca0cc005dbc98fdd9de749373564ae6311cd96bcfcfba4ee1708bdcc683fb914"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 207552,
+     "sha256": "ba9c6ce0d14b2e42c891da0b195c7801d1a1bf3534ee599edb243c3d385c4b0b"
+    },
+    "progs/drggib01.mdl": {
+     "bytes": 36550,
+     "sha256": "2dcce0ee000aa827fb4a621ce94ca5d325ef1df7ebc16aff876eeea523b90083"
+    },
+    "progs/drggib02.mdl": {
+     "bytes": 42788,
+     "sha256": "03801327858a4df0312f5b1ec231b2396487c5a1c2e148bf1797945c0f954151"
+    },
+    "progs/drggib03.mdl": {
+     "bytes": 30740,
+     "sha256": "b3c8a344124ff5b1c95bb81b887546267e066d40914ab40a25e708ebbec2a489"
+    },
+    "progs/fireball.mdl": {
+     "bytes": 9076,
+     "sha256": "8b9cef5c7ebff01a836d056eeee45278cfbb91c92dc4bba4d4a8d664e8d99b32"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_boss.mdl": {
+     "bytes": 61060,
+     "sha256": "30bf06acfcb3b32bf8f940187e712e87355fc7d8cc5ba8f36c128774cf20846d"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 30552,
+     "sha256": "d1556063b3a932b3b26375e5789c911cae76aef39ec2550a7e1d82d0cad832a9"
+    },
+    "progs/h_imp.mdl": {
+     "bytes": 22780,
+     "sha256": "5d561fbf497c040194b6f7eb0541283a9b57658b9f243cf82e78ff6eb9dbba66"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 13400,
+     "sha256": "464825291ecfd070153877ee4a7fa83f97379b2cb9871b4609979161d926ba0c"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 275836,
+     "sha256": "ff5e8e7e0339d70fa0edca83a0d082cfc934ae6f60bbbd8f310f32c438646485"
+    },
+    "progs/imp.mdl": {
+     "bytes": 377028,
+     "sha256": "dba84c4742f403dc6335341d1743433e7632b9b435c817ae521d90bfb53f0bfc"
+    },
+    "progs/knight.mdl": {
+     "bytes": 208068,
+     "sha256": "3d78003704446856390cb38df9e7d9fa4847b53e68914b8300b06412ca6f08f0"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "2bd7b6633d2c95627cca8b216ad2c84057e800778a94e0fa97f3a14f86420732"
+    },
+    "progs/rireball.mdl": {
+     "bytes": 10140,
+     "sha256": "820612feb9912c6c03dd27210d6fbe5e3d01d631fe229f61a4ac490a62b2eb90"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 17204,
+     "sha256": "ad7c35515ed5eb99daa117499b1fa75050fec4dcfd9fceea68fc84f0751a259d"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 18500,
+     "sha256": "8d96f07382a6cf988fd01a37d2e640aa77741b73177f44642c38d4b7d2f87d51"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 17012,
+     "sha256": "21e37e54e18f642f876dd689e967b277adebd9b847e306805d357f5df1b2514f"
+    },
+    "progs/statgib1.mdl": {
+     "bytes": 6501,
+     "sha256": "6f05c4e70092f782e1948e6d7815a9b6bb9d4df5e22d65431cf00d204048765f"
+    },
+    "progs/statgib2.mdl": {
+     "bytes": 16228,
+     "sha256": "f7e96c3c511b0cac8939aa75fa8fb512dac252252710b1421a9a0624670169c5"
+    },
+    "progs/statgib3.mdl": {
+     "bytes": 22228,
+     "sha256": "eef48ccea13117f123b286276a5d250980657ca016f8dd6cce28e541b0360ed4"
+    },
+    "progs/tree2.mdl": {
+     "bytes": 112335,
+     "sha256": "82a16b3ce4e9370f0ff4231506da2cdd53d0596193862747f84a3f04ec481d2a"
+    },
+    "progs/treebush.mdl": {
+     "bytes": 52279,
+     "sha256": "00b4f4d3f8c7562f0d2d1699fe1f85a242b3d25d935c693265ea858e6e758173"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 18358,
+     "sha256": "645baa1cccaf1dfbcd628d17fd8ea290f42f1bc40903e26c79a536a6d1528a2a"
+    },
+    "sound/dragon/death2.wav": {
+     "bytes": 16944,
+     "sha256": "0fe255bd36c64acf75a53b97851b995517e70468b3818ff0ccecc4c7be5fc055"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/idle.wav": {
+     "bytes": 12252,
+     "sha256": "161fccc2acb1040d7dcad116f18eb795cc03f4d96ee8a94ba37440cde33e6f24"
+    },
+    "sound/dragon/idle2.wav": {
+     "bytes": 13848,
+     "sha256": "e71858c4de3e9ddcad1cba4ec0a6f5ec437b06c813b263ec73f853846d15a984"
+    },
+    "sound/dragon/idlefly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/niteact.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/dragon/niteact2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/dragon/nitepain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 8376,
+     "sha256": "5c41f639d3d59cb12cf8c37f2f80279ed4268ce9afadd7f36d26b4fa40664ada"
+    },
+    "sound/dragon/pain2.wav": {
+     "bytes": 6496,
+     "sha256": "0017ddb63a5dc282982c7459099c810d7c6d9bc3ecb9acef5b5228795a92cc7d"
+    },
+    "sound/dragon/sight.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/sight2.wav": {
+     "bytes": 15205,
+     "sha256": "197238a35261e6792c40a4da38ba7b3827116ac1af5f143e092768346605b470"
+    },
+    "sound/dragon/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/spit.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/thunder.wav": {
+     "bytes": 14764,
+     "sha256": "b30e18bbc0a12db2032fa95d5d0504ea63eaa13b3bea34e3b42ec59f3ca4d815"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/imp/death.wav": {
+     "bytes": 8448,
+     "sha256": "a8b0e037b88829b978d3dbd3d5e657c7f775c73662d554f6247a387ba333d4bb"
+    },
+    "sound/imp/fist.wav": {
+     "bytes": 5492,
+     "sha256": "6362b59ded89655fa8b8877ed2639eca1a7aae1847306bbc3843fa98bedcbdaf"
+    },
+    "sound/imp/pain.wav": {
+     "bytes": 10842,
+     "sha256": "100eacded51635de912cee171f093e869d24589c44f68887497fe751cf9b1e4d"
+    },
+    "sound/imp/up.wav": {
+     "bytes": 12500,
+     "sha256": "874b533da43f713a1be27fbccadda8b6392fa8e689c8c4d17dac4b0d380f5822"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/statue/death.wav": {
+     "bytes": 13472,
+     "sha256": "b030aeac3d806bc77fddaed4bb32684cfd2bbd707fe85e2500a3346c5931ec68"
+    },
+    "sound/statue/idle.wav": {
+     "bytes": 17722,
+     "sha256": "3567914304c8fcf224e31bc302039432cd17833daabc2ed9f83053b01fef4f7c"
+    },
+    "sound/statue/pain.wav": {
+     "bytes": 8012,
+     "sha256": "9193f4e976675042409db103f7e3b26f667a56e913e96a37f223f1c606323246"
+    },
+    "sound/statue/see.wav": {
+     "bytes": 6664,
+     "sha256": "58ca56c21040117cd37c99b648af0195f70a51d0d03ba5665e5f8981d8de255c"
+    },
+    "sound/wall/wall01.wav": {
+     "bytes": 32804,
+     "sha256": "c338c95767dded603a1a69100c1af0baab42959eaae856f6cab99ffbd140b727"
+    }
+   },
    "sha256": "077091c20cd11010caeece2c577ed9e1119866f273f5af63a02fdd69d10a5d04",
    "timestamp": "2003-04-11T09:58:14.000Z"
   }

--- a/json/by-sha256/41/41c1f7282a8e90077d3b9012abc5b208b08ad892e5e4d05824d34a285f7e1f54.json
+++ b/json/by-sha256/41/41c1f7282a8e90077d3b9012abc5b208b08ad892e5e4d05824d34a285f7e1f54.json
@@ -12,6 +12,100 @@
   },
   "pak0.pak": {
    "bytes": 6127401,
+   "files": {
+    "entsdefs.txt": {
+     "bytes": 47486,
+     "sha256": "2402a9d9a6879d93d8abdc2ad748c7b75e1af321597f7fd9515cf117bf897a7d"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "21d0d0dc88e89bde091896f50896d17625b092bc6834dd381a142800412ce5a2"
+    },
+    "maps/eagle.bsp": {
+     "bytes": 1248504,
+     "sha256": "e33ed5f1ed9bce135ba1716f9037b8afc19bfad243669c9d56f66c448cecd0ac"
+    },
+    "maps/rubicon.bsp": {
+     "bytes": 2005252,
+     "sha256": "58f552da2a1be7130c182926972b2a62d2332a852d8b74e8273dc0935e03f056"
+    },
+    "maps/start.bsp": {
+     "bytes": 528780,
+     "sha256": "d9f5127e64958cb83674f03b24789a309e9bf8dcd98ca5e01c71ae0b767be0d1"
+    },
+    "progs.dat": {
+     "bytes": 554104,
+     "sha256": "17f98436e60eda75974c493c2fa90e3fdba52d4eccd21a385f7c44a58c5d5edc"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "sound/ambient/bubble.wav": {
+     "bytes": 179808,
+     "sha256": "f87c010d2b6cd92a47f8b4abe9bddf040f9ee25cb36f5f9b90272a040986eb7e"
+    },
+    "sound/ambient/drone.wav": {
+     "bytes": 122710,
+     "sha256": "c90e3cb41af18961023d66e800721c0a70aa0e42fe295d813668cb21e30ef9ad"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/intake.wav": {
+     "bytes": 101826,
+     "sha256": "f2cdde6b9294caf576fb80f8dfceacac28e2fbfcc794ec66f002d34aa2c55773"
+    },
+    "sound/ambient/rumble.wav": {
+     "bytes": 43736,
+     "sha256": "5243d903215f7198b825a2454d5714686a2a9254f679be7a2fba4a89bb067fbb"
+    },
+    "sound/ambient/throb.wav": {
+     "bytes": 174186,
+     "sha256": "a59d888be9893df1f423dae4eea25cb5493e5aaf565d820ea2c98e19dfacdc4c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 4060,
+     "sha256": "3bab8fca9733e6c9f045e24f52ffbac401c757b1fe9f28fff967f21357bbadbc"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 11588,
+     "sha256": "8b9a0404fefb408219731ff264cb5490d1178a2ddd2afe02db4a5ddc6e427171"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 11966,
+     "sha256": "af1026fd9051e2c9c84f4eeffed454d7328969a29a2d11301464e383c6c809d8"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/zelda/maze.wav": {
+     "bytes": 201244,
+     "sha256": "c69a99d5583c32061d25d11fa139f041a3257d1be74af8f19dd996406111afef"
+    },
+    "sound/zelda/secret.wav": {
+     "bytes": 65992,
+     "sha256": "0673bbcfb4f6915f5f7754fe101db8f0f5bb0271eaa65d39760347eed7792d63"
+    },
+    "sound/zelda/triforce.wav": {
+     "bytes": 77232,
+     "sha256": "85b9a442367166ea3f935e6ae5a1e881e0c05124dec64795873c88b3fd93a6b5"
+    }
+   },
    "sha256": "1e2700c3798b5fd34521d7d893d57c1d691849cae29f3a631e6a0ed39754eb47",
    "timestamp": "1998-02-23T21:40:48.000Z"
   }

--- a/json/by-sha256/42/4207fef65cbf5f8197ea7ad633bd5620565caa28b8523e149a69d78a1f297902.json
+++ b/json/by-sha256/42/4207fef65cbf5f8197ea7ad633bd5620565caa28b8523e149a69d78a1f297902.json
@@ -13,6 +13,552 @@
   },
   "rapture/pak0.pak": {
    "bytes": 18510187,
+   "files": {
+    "demo1.dem": {
+     "bytes": 383544,
+     "sha256": "0ca79c29b69bdd9f6c62d20c7c96614b545796a098a397b96e2772b37a397145"
+    },
+    "demo2.dem": {
+     "bytes": 922402,
+     "sha256": "d4e9d76d7f62a6cdfa28d3f84b0d99c4a120c8633f8057f838f004f4f597e9a4"
+    },
+    "demo3.dem": {
+     "bytes": 749830,
+     "sha256": "9a94a36e9757f0baa57a7e8cf1b2f8665abe9e09d613b9a823ef1a875175ff62"
+    },
+    "maps/basend.bsp": {
+     "bytes": 633328,
+     "sha256": "b24895eda91a423fd9a25874bb13173cc0c4e48fa0d27c3c84ff30316cd5dfe5"
+    },
+    "maps/rainend.bsp": {
+     "bytes": 1115724,
+     "sha256": "32c6af3e07a7c0ef7af9362297df051d8d7b11ae9ccf797c575d3907cc6bb086"
+    },
+    "maps/rainpal.bsp": {
+     "bytes": 3451788,
+     "sha256": "3ecf85f49d6026be36de05692550487c30d56028c9bf4047ad999e2528298d70"
+    },
+    "maps/rapend.bsp": {
+     "bytes": 567772,
+     "sha256": "f06cf17561ca98f22849f42fe0d09e9be6d2a8984a6aed4b945d2eb7954bc34b"
+    },
+    "maps/rapstart.bsp": {
+     "bytes": 709604,
+     "sha256": "bf082d60b81cf868d4f61200e3fa01be8d6e9673a2f923f3938cf8b796b06454"
+    },
+    "maps/rapture.bsp": {
+     "bytes": 2418264,
+     "sha256": "0d6011a3c218d5169884f655310109e11ce66df200d57a67819f34840a052e6c"
+    },
+    "maps/start.bsp": {
+     "bytes": 566996,
+     "sha256": "2f8a5bcc7232d8213248c0daf9c7f06d0d899aa1d4ff3d23ad088b4f5784a1d0"
+    },
+    "maps/storm.bsp": {
+     "bytes": 1592244,
+     "sha256": "ed0654e8dd6bdb3f17d1dde13cdb111952595a0744f8ae16d9d4cc02abcb7e22"
+    },
+    "maps/sub.bsp": {
+     "bytes": 1141004,
+     "sha256": "1b884b1946f90e01e1ef82305933f50c89ab2991049b615be5b12178bc22aac8"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 106244,
+     "sha256": "2ca415ec913b3c05038c6db21f9235edf7eefe7cf41120edead53efb90ff0ef4"
+    },
+    "progs/b_earth1.mdl": {
+     "bytes": 16325,
+     "sha256": "f8721a42dd05178200b3de8fb73502ef46284f7e4e48076fb353980dfea997a2"
+    },
+    "progs/b_earth2.mdl": {
+     "bytes": 65436,
+     "sha256": "59933ccbe1fda467ca4de97ae80587eb85904779e9aa612a3621859bc474dfdc"
+    },
+    "progs/b_ice.mdl": {
+     "bytes": 17584,
+     "sha256": "7805429534fa39fc6be4016eccacdac51fd0b4c2183723e7cc8dbab2aeada925"
+    },
+    "progs/baron.mdl": {
+     "bytes": 405612,
+     "sha256": "68bb69841d1246882360b8e243bd34dc5534989dce1eda8974938ebf7acae652"
+    },
+    "progs/bball.mdl": {
+     "bytes": 130008,
+     "sha256": "6fc43ee5d3e26268cb4e9be521b4b514f21bfe3556f8189ccb8c96a44c71b115"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 5349,
+     "sha256": "b1c731745089418075fb565c13db5992d7dd54df6d5ffd38f93e146caa508561"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/hkboss.mdl": {
+     "bytes": 323272,
+     "sha256": "a632782756fbd24959a4db02d1604921b544d8dab0c5bbe3594f5939e3d320be"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/knight.mdl": {
+     "bytes": 153400,
+     "sha256": "26576f139d258b3c236faa6552d8ba09ef6e14480d4a2e2dc9e3e2c4df5177b6"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "fae8fac60b899d78a929ada720c591b7356e78cdea074f1b128f465d47fc4d8a"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.qc": {
+     "bytes": 7330,
+     "sha256": "60b9b2f830d359825647aa829bd0566f3fd8b6727df89926133898512cb10f1b"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "ba9f52e66ac380306d443e07ee4f1fac92793cba55394c01590c3dd088042e78"
+    },
+    "progs/wetsuit.mdl": {
+     "bytes": 55156,
+     "sha256": "4e4dc7331c374d2345c3d755ff34b61850c289741314b10fa36c461db3844e99"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "sound/ambient/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambient/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambient/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambient/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambient/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/adeath.wav": {
+     "bytes": 11714,
+     "sha256": "c6d2e6a1107eddcb49ca41776da1c7f8a3b27766b66dbf4bd9186fba2780cb2c"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/apain.wav": {
+     "bytes": 3302,
+     "sha256": "788466ee8cc368bcac8b07c4eeca5509ccddc30addf5a322b31a605d90bf0392"
+    },
+    "sound/axeman/asight.wav": {
+     "bytes": 8528,
+     "sha256": "d5d1a9125b9a015186d6d5e9fbd9f9d9db3fb220bdf9139f5aa73b9019d37126"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/baron/death1.wav": {
+     "bytes": 68188,
+     "sha256": "0785bad4b7b721f2bb989fa74f7186552ef9bbca016fb2f1a3fe9b52650fe3cb"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/e_nail.wav": {
+     "bytes": 26306,
+     "sha256": "04fc98e42709c9a5d1a8bbd52aff9114b4922da324e30d21859bcf8209e55b4f"
+    },
+    "sound/baron/e_shower.wav": {
+     "bytes": 10178,
+     "sha256": "6c50b5da79aa99295f9bc3de1445ef76c6e6306b413b9a934122393b6b3a633b"
+    },
+    "sound/baron/f_ball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/pain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/sight1.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hknight/death1.wav": {
+     "bytes": 15468,
+     "sha256": "b0e9cfdd68223d49820d03c2f8e5f59ab94e0f284d6865f492ae1a9d4fb13473"
+    },
+    "sound/hknight/sboom.wav": {
+     "bytes": 56376,
+     "sha256": "1df051b49aaec9b19e1f49348aaf6d9c19aad3e4591c12b18c4fcbf3c0a73218"
+    },
+    "sound/hknight/sboom2.wav": {
+     "bytes": 14764,
+     "sha256": "b30e18bbc0a12db2032fa95d5d0504ea63eaa13b3bea34e3b42ec59f3ca4d815"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    }
+   },
    "sha256": "59acff878e87d8e077ffea3081970e54366cf3c4536305fd384bc6d42deedb41",
    "timestamp": "2001-09-19T17:32:10.000Z"
   },

--- a/json/by-sha256/42/4286753b636e453dc36579400dd79f1557d9956c0c265b82a0648203fbcfe500.json
+++ b/json/by-sha256/42/4286753b636e453dc36579400dd79f1557d9956c0c265b82a0648203fbcfe500.json
@@ -12,6 +12,92 @@
   },
   "pak0.PAK": {
    "bytes": 5676675,
+   "files": {
+    "maps/n3sp03.bsp": {
+     "bytes": 3104792,
+     "sha256": "f3b8349eda955e800649b6f25ffab07463f2215c1f896fd7a9470336ac1578c9"
+    },
+    "maps/n3sp03_2.bsp": {
+     "bytes": 1150216,
+     "sha256": "f22fe40b889c1738482737a6f3084f028d0759cd6d009a81bf8dfe80f88bd3c7"
+    },
+    "progs.dat": {
+     "bytes": 427520,
+     "sha256": "03b08e8076c4d3370deba9886ade87bcc82c2376ab60d3286518a01b3605fe28"
+    },
+    "progs/demon.mdl": {
+     "bytes": 156640,
+     "sha256": "0efdb5af8d60867935878562b38688b63565fbd687684ec0c11a22a4229dd468"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 67688,
+     "sha256": "9dd923e25645f427190bfbc68b85c59f867598ad8ba75aea87acbc78d10e9686"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 13400,
+     "sha256": "32b151b3c7b603b0c5450260ac368fdb36486e31e85e7d59bb925f7a2054c48f"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 108204,
+     "sha256": "53f1e920c7c866d349167a8bff62eb0b614c5628de89d51774b3b8e88d17a0d9"
+    },
+    "progs/knight.mdl": {
+     "bytes": 153400,
+     "sha256": "eb942ef2b23cf368161868c4f0f98d7abc1d662cd9902a59c786ed2a715fa528"
+    },
+    "progs/s_fire.mdl": {
+     "bytes": 27596,
+     "sha256": "2e7e47c552a5f778ff45b8af520295726c64687c76d8d6e211bbb8786460eaba"
+    },
+    "progs/shamball.mdl": {
+     "bytes": 8788,
+     "sha256": "93482f8ebf6f8dfeab7161a0598afd4ebd45f5e9f9a602cea3fcbf665daea4b3"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 169404,
+     "sha256": "5492386814e9142d4d385d4e985f1b207dc7cdf5de4ef7e3526a69ca2131c83a"
+    },
+    "sound/demon/ddeath.wav": {
+     "bytes": 9140,
+     "sha256": "12f5dc4a16ad825e2363a176c303ee934f1467d19ea9db0361ff4288d7b9a3fe"
+    },
+    "sound/demon/ddeath2.wav": {
+     "bytes": 12296,
+     "sha256": "bae4d7eac6927fe01c2e83a124b645bfba911c21f957104035f1fceeb92833f8"
+    },
+    "sound/demon/sight1.wav": {
+     "bytes": 13574,
+     "sha256": "8957ffc09136ccd44bacc4c9069a9d7e5a5304682c222e97fc692b8fc595a732"
+    },
+    "sound/demon/sight2.wav": {
+     "bytes": 8804,
+     "sha256": "5059fa6539cfd92e6064b1c57385f4606c1d2ff769df42ade62ed3be4b39a0b7"
+    },
+    "sound/misc/chant.wav": {
+     "bytes": 146966,
+     "sha256": "218c6d5d4172c3b86ce9dfea1fff58bc20613b8dd3fe7b2df2fe1adbbf22272e"
+    },
+    "sound/shambler/s1die.wav": {
+     "bytes": 21663,
+     "sha256": "b96dfc4791bc8cc99be9d72fb25dbeb4715b7b8598b28fa1eecbf5648768c007"
+    },
+    "sound/shambler/s2die.wav": {
+     "bytes": 21301,
+     "sha256": "de2054b277caa8d15718f85fdd1d4ebb1e8a6759ce7a03a9040b242743db742b"
+    },
+    "sound/shambler/sfire.wav": {
+     "bytes": 14598,
+     "sha256": "6a478fffe74cca67345903c4b08ed4889864db5446f7d7bfe661415ca8298b6d"
+    },
+    "sound/shambler/ssight1.wav": {
+     "bytes": 26248,
+     "sha256": "127c34371425feceff7fb1d0ac847474015640140a4ae1675ebd677f8b8a9680"
+    },
+    "sound/shambler/ssight2.wav": {
+     "bytes": 13081,
+     "sha256": "fb45ca50d2750378793c5dfe5447d520550b5787ab12cbfe134f0f4de6c9cf19"
+    }
+   },
    "sha256": "ca5aa10998944c7f9a070de673a8dd288e84755d105101a3c28232d14b660c18",
    "timestamp": "2001-08-09T20:50:44.000Z"
   }

--- a/json/by-sha256/44/444a194b81e999f0181d46f3b298774611f5f2c026a00d942058e86a77d30d4f.json
+++ b/json/by-sha256/44/444a194b81e999f0181d46f3b298774611f5f2c026a00d942058e86a77d30d4f.json
@@ -22,6 +22,164 @@
   },
   "gadgets/pak0.pak": {
    "bytes": 3476336,
+   "files": {
+    "finale.txt": {
+     "bytes": 611,
+     "sha256": "b4a44ff483ba4c7189937553e340165d14ecaeea3e31fe0f7cc4aaf53192819b"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "3eaee6856ff965bf818fab79c07791e8dd0bb5a3da6ff226c3b00261d57b7ae9"
+    },
+    "maps/auximine.bsp": {
+     "bytes": 1377768,
+     "sha256": "f66344543bddb343ab7194bc922c8eece888c723d714b712ccbc24899c5bdd2d"
+    },
+    "progs.dat": {
+     "bytes": 580832,
+     "sha256": "09ad7a9f0f836d4eda7019ef40ffdfcc89cc9e655c0b5ee4cf2f9fdb2e0c0ba7"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 56204,
+     "sha256": "0bc003d99a05e6a17a3c17e78ec708712419860a96bd7ae003e28efa90f95b87"
+    },
+    "progs/h_boss.mdl": {
+     "bytes": 61060,
+     "sha256": "30bf06acfcb3b32bf8f940187e712e87355fc7d8cc5ba8f36c128774cf20846d"
+    },
+    "progs/kenobi.mdl": {
+     "bytes": 69731,
+     "sha256": "68b5695fd7972bccd7d2c602c5daa392eb2fc4d1025e26264d2d7107b4c6d314"
+    },
+    "progs/rogue.mdl": {
+     "bytes": 113763,
+     "sha256": "ed95cf6488b645563d50fe0c41bbff2fd54b3b2cd23130ab0288e13f34f41fca"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/s_null.spr": {
+     "bytes": 56,
+     "sha256": "29e9c18546413f0abc9c6f507c61952f33afa6507b52d1c2197b57e3be7870a9"
+    },
+    "progs/t_drag.mdl": {
+     "bytes": 12736,
+     "sha256": "daa3fb42ac8bca1ea5d46b1be4422b895715021d9efd6e53420f154e864cbf7e"
+    },
+    "progs/w_drag.mdl": {
+     "bytes": 36636,
+     "sha256": "785216ead72dc301b2e6c09b91ff3a399f58400d08523d4078cd47190ce74315"
+    },
+    "sound/dragon/attack.wav": {
+     "bytes": 4920,
+     "sha256": "6a5697e1dd9eca555bfda713101cdda800065e201f00ca333796f1bd4e7217ae"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/dragon/hit.wav": {
+     "bytes": 4566,
+     "sha256": "b36e7581fe973d854b6f59947c5fe30b7118c94e7973f93b54a0c17423ce3fdc"
+    },
+    "sound/dragon/idlefly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/dragon/sight.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/end1.wav": {
+     "bytes": 7564,
+     "sha256": "f568d3c269e101c3d1ebf5bea0fc41790140c8e4b5f1ae201059349730b5bb4a"
+    },
+    "sound/end2.wav": {
+     "bytes": 103668,
+     "sha256": "e026bcc135da7dcccc07c1173dabb8d8313b4a9790c3029201976e8f7265274e"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/john.wav": {
+     "bytes": 68366,
+     "sha256": "f34d69dcb14164f0e1d9577a180ba8ac02cb5d5736c1e10028a9530b31085ed7"
+    },
+    "sound/kenobi.wav": {
+     "bytes": 25168,
+     "sha256": "bfac7bc768ebf9af1f81a0edf52ddbc1edecdc61ccde924626b99b49f5176b8a"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/subdive.wav": {
+     "bytes": 23348,
+     "sha256": "6ab3b82c7d9f12468a84877232a4b4fa999065efff1b7076e369d9b8f012bcc8"
+    },
+    "sound/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    }
+   },
    "sha256": "f0ff4601de6c126cfc3bf3723a9c4bb40679d0bdf0d25c0ac9c6b929b32a0d80",
    "timestamp": "1997-05-03T02:48:00.000Z"
   }

--- a/json/by-sha256/45/45321165cc7b736a0a3d07caaa66d54343fb847a8a9710130504e291b06d04b1.json
+++ b/json/by-sha256/45/45321165cc7b736a0a3d07caaa66d54343fb847a8a9710130504e291b06d04b1.json
@@ -688,6 +688,396 @@
   },
   "pak0.pak": {
    "bytes": 4561448,
+   "files": {
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "8cec67fa37ad8a6723844c64e56b6e188e4f08d23f6ca280ea8f4ba5b8f769ce"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "f6bcca0638bbc18713c478910527cb65f31ddaaaab6755be6f0a4607164d0734"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "591744734a43a1563ee0e419fb2464783c70a3245c14e09ff5c3f022418f1e4c"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "1bbe11eff4ef46f43af7bbc7be43c69cf76543ce7fae26931939a541cb8cdae6"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "2ea3ee2b5ea3ecae4349cac0d6ecbbbf80425d63db0e18a578a6c0b6b69ab166"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "792b999f37e2f75a3d88e9f1f2a60f49aebfd8aa46e3ae52f1b55b2a11d641c2"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "ef455c1235cc6798cb1ff1b1cf728380863656e2cb9f11cc7b89819ff2ab7826"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "7a91038838edbddf5f8d58ffa72f20da93a2f9d82527ce34b0a7fe2f809cde79"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "89d123a948fc600561d2a4b67359e06b4f8bdc233f06bcfb686d98d668beb8a5"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "cc64ee5d4be787eec9d062ae9fbe3d395e96fc154e09364e827c8de0368b4330"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "eee6785919a2b1eb9979e92cac602bc04d409c502853fd488d6e88439694451f"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 22648,
+     "sha256": "39da2b29b0073d73fc0aec1e90475a28483ac91589b0f4d6f366c39a598153d2"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 51734,
+     "sha256": "ead14a48756cb125dab4ba817057be6522819f8ad00327f262633ff29c5d4a4f"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 143970,
+     "sha256": "64b8bbc006d7d89b56c8623478b915f27b5b4f1aa323b3b37f64a4142417bc71"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "898a7466322297c37309942a62197dd634168c343f464d8e9bd6d9bdc6524333",
    "timestamp": "2022-08-09T00:29:06.000Z"
   },

--- a/json/by-sha256/45/45ddd187e07af6b3d43a5f9f5597172e43aae7cebe73cdd2a5057ad6a36f570e.json
+++ b/json/by-sha256/45/45ddd187e07af6b3d43a5f9f5597172e43aae7cebe73cdd2a5057ad6a36f570e.json
@@ -14,6 +14,2428 @@
   },
   "enyo/pak0.pak": {
    "bytes": 277593155,
+   "files": {
+    "bots/navigation/eedm1.nav": {
+     "bytes": 9134,
+     "sha256": "c64828cdf6468fd3f971f3c9f58a1eceeeb1277c034f039665cf484efcdc5145"
+    },
+    "ee.fgd": {
+     "bytes": 122813,
+     "sha256": "cba4e55c2b2b46a52d7907f2a20a5a6eacf9d57038d0a246bdbecfe0efefbbab"
+    },
+    "eedemo1.dem": {
+     "bytes": 785151,
+     "sha256": "ae5bedee14520a163ad75cc879270ee37e510cebf5c091423e0e9cc205b5d8a9"
+    },
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "3346e2b2212b9cde0693d649169d6c447b702bf74a1d7bdd5c7b6445e2eb3778"
+    },
+    "gfx/Readme.md": {
+     "bytes": 1,
+     "sha256": "36a9e7f1c95b82ffb99743e0c5c4ce95d83c9a430aac59f84ef3cbfab6145068"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "7bc26724bca83ce1578e89e7642794e1533c6c362ffb590648962d33b59f8265"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "e1884c3e28c55ec69503bb7288894e045ccdf393fea98be29fbd5553555bb849"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "ff20c3c5a97db57a58a101c7587561b6cc4cc47b5fa5d615efac22b7027f89f5"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "63a4ad038d1cb1be9c234cbd3db6ab71f729d8dab6a2fddfe02cb6655439b1ea"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "1b3e89874b7329dbb527e213cd8483e3cf6a32436d7a43c23500846bc5943553"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "8bbf9b21f15e3eea3c29f37cdfea5b88ce3d9937f2ab90bf36772cc8035734c6"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "655a848347dd69c428cc77b7fd9082517698018adad131979da59cdefe1678ca"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "2ae40fc8be489bb2393027c43036763acf43d8ec7f5f93c322297974198b0b3d"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "b4e166ce01fb18ec5224b501a63bb8e06e8a7064465143e09fa30e90c7fa6bf1"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "b902099edf0832be34260aa30f0f26235ebe9329b7c5daf6f91ce6fd9658f118"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "8aa2cba62d74aa425389af89d008965525ca1f2390b13d1c73f369f09fae44a6"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "abf77a3b81eacac1774b8f886f6d252f928b9217f7314537383b60dde0acdc23"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 921608,
+     "sha256": "db69217ad6f677c24408522aefdab5da6533103c4b61a008be71be7b62a6ed26"
+    },
+    "gfx/dim_drct.lmp": {
+     "bytes": 3352,
+     "sha256": "63c8b794b70530037c6d6646071fefe829f017063b8c74783e56814608414436"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "5c44871b2b633827f5aff0b546c897b8f8e54066c73db820245fd8783d77926e"
+    },
+    "gfx/dim_modm.lmp": {
+     "bytes": 3352,
+     "sha256": "57c53a787f6d31c13a2e54b69137163031521c60925d5884acd8656cc78e3312"
+    },
+    "gfx/dim_mult.lmp": {
+     "bytes": 3352,
+     "sha256": "6496da2706d273f44d2186cffebd974b138defc23c52f2aae106e280491e1c67"
+    },
+    "gfx/dim_tcp.lmp": {
+     "bytes": 3352,
+     "sha256": "8d8181d92933af31d029a36b0a8f9f0ced1ebf5f494d5693f2e3d7d6c0b85bf2"
+    },
+    "gfx/disc.lmp": {
+     "bytes": 584,
+     "sha256": "c13c4d4bb0860d1cc5c8cfed667440d135ca4e4e97313637ed0cbfd685f2c058"
+    },
+    "gfx/env/ee3_bk.tga": {
+     "bytes": 2676634,
+     "sha256": "5d54cb990f0b4ff0874d998ef76084b81a1045e1acecb4bce0d9e266b172bf81"
+    },
+    "gfx/env/ee3_dn.tga": {
+     "bytes": 119094,
+     "sha256": "4a1295c08f608a3f95e4f286e0d849274f5be34a654be8ad760fbd1128e214bb"
+    },
+    "gfx/env/ee3_ft.tga": {
+     "bytes": 2676634,
+     "sha256": "5d54cb990f0b4ff0874d998ef76084b81a1045e1acecb4bce0d9e266b172bf81"
+    },
+    "gfx/env/ee3_lf.tga": {
+     "bytes": 2676106,
+     "sha256": "ac45f3479a66599e02cf0250951ec5fcaba35fdaa07e239f5f127f20db9ed20a"
+    },
+    "gfx/env/ee3_rt.tga": {
+     "bytes": 2676143,
+     "sha256": "92b1fbff46ee7a2748c360ea38037e0d20202e5daf2d73257b7f8834c441c34b"
+    },
+    "gfx/env/ee3_up.tga": {
+     "bytes": 71326,
+     "sha256": "b4552945a921334a5271f41e23b8cab71ad42e2e04a115270c3803bbdf065248"
+    },
+    "gfx/env/map1_bk.tga": {
+     "bytes": 2395548,
+     "sha256": "c007163d0cef012f829af2de9719cea6569f91a6c23208ebcd1b1aff4a6b723d"
+    },
+    "gfx/env/map1_dn.tga": {
+     "bytes": 2704195,
+     "sha256": "f5f37ecdd9f926b02c6641d303d4cb383388e169e09741ed3ab5c9f6ea52e6b4"
+    },
+    "gfx/env/map1_ft.tga": {
+     "bytes": 2450306,
+     "sha256": "508ca24f680d841166b8594e6b321a0771dc75952530b60d3a3e7abaa1292ba7"
+    },
+    "gfx/env/map1_lf.tga": {
+     "bytes": 2421815,
+     "sha256": "5ad6f2276c77d07b41a492847abf5e4f6fd3ae35c791fda7644ef553e59c6ac1"
+    },
+    "gfx/env/map1_rt.tga": {
+     "bytes": 2423286,
+     "sha256": "6c820825bb6554830fd9ef1e4bbafa84f52116e4784bd98ed51a0a331069eb1a"
+    },
+    "gfx/env/map1_up.tga": {
+     "bytes": 1147734,
+     "sha256": "08e016fd76c41867f23c23f6edae0c86311f7b66a570973802cd49f52574b54f"
+    },
+    "gfx/env/map5_bk.tga": {
+     "bytes": 1579882,
+     "sha256": "abb916791ce954f928563bada0297928af677aee0c52ac3a07d0a96b767b62ae"
+    },
+    "gfx/env/map5_dn.tga": {
+     "bytes": 32786,
+     "sha256": "cdc9e0756814564a8dceb69e2b0a5249558cc59c2fe8f22e5611235ab883bb4c"
+    },
+    "gfx/env/map5_ft.tga": {
+     "bytes": 1644394,
+     "sha256": "6631fd8ea34cac6f3b832210690edb87ca5073a4d476e66b7434fc5884a09e0a"
+    },
+    "gfx/env/map5_lf.tga": {
+     "bytes": 1547168,
+     "sha256": "2d110079739fd69e80e4fd17d2ce60fe49a340e3ec0f77021023a73612c3e58c"
+    },
+    "gfx/env/map5_rt.tga": {
+     "bytes": 1451773,
+     "sha256": "4bcda276a6274a0e85d93b43e1c31cb0bde089bfbd8a767e03a279073103b33e"
+    },
+    "gfx/env/map5_up.tga": {
+     "bytes": 2153165,
+     "sha256": "cd297b50099719ef7f17ca05c6d65ad82ad168ec9455b0ba3a5b5b2f6523a1a7"
+    },
+    "gfx/env/mbase2_bk.tga": {
+     "bytes": 2115987,
+     "sha256": "f1125aa505ede15376771e7f4e82eb35e8f3893c20d99577a303db25a4e934fa"
+    },
+    "gfx/env/mbase2_dn.tga": {
+     "bytes": 1061628,
+     "sha256": "414a67e7462ee1b47745bb14721050bb3d53c0138cd95aa5931c75b971b1a910"
+    },
+    "gfx/env/mbase2_ft.tga": {
+     "bytes": 2863391,
+     "sha256": "c55c9a15cf2e1c3c18a34d06653074800f4a518fa00d60f40daf39340887d540"
+    },
+    "gfx/env/mbase2_lf.tga": {
+     "bytes": 2054945,
+     "sha256": "87ccbe9cc2b8a0d43138e61824c9979e4cb0334a9ad68f0007e6db771661aabf"
+    },
+    "gfx/env/mbase2_rt.tga": {
+     "bytes": 1815307,
+     "sha256": "294afe2e41fcf1562d3a710d08a51d4fa61953086010b3e2587bc1a56bb8ef7c"
+    },
+    "gfx/env/mbase2_up.tga": {
+     "bytes": 2129724,
+     "sha256": "4a45db2a93dc6dd1cca763bc46736bc8aefdf7035421cab8263d8b20bcc58fc0"
+    },
+    "gfx/env/nee2_bk.tga": {
+     "bytes": 1687544,
+     "sha256": "88cdd9926547a139435ffc3077bbed02689670113724fd5d7e0182ed46d4fb30"
+    },
+    "gfx/env/nee2_dn.tga": {
+     "bytes": 1687544,
+     "sha256": "d8272c3fc3e6f05bef49407af342819cbcef0e5b215395563e60ef0c86b0140d"
+    },
+    "gfx/env/nee2_ft.tga": {
+     "bytes": 1687544,
+     "sha256": "654dab4fc83a23e4549a1c63b349416379c5fe1b21e0ddefce795c63057a4c63"
+    },
+    "gfx/env/nee2_lf.tga": {
+     "bytes": 1687544,
+     "sha256": "78c50b74d4c0489cb57516562d2409b8193e343de27e77eb95e6d0afaff6dc1c"
+    },
+    "gfx/env/nee2_rt.tga": {
+     "bytes": 1034023,
+     "sha256": "51840a07a834140b23bd34f1e99d270519a4f78c06d43e4eb909fbec0ad8c533"
+    },
+    "gfx/env/nee2_up.tga": {
+     "bytes": 1687544,
+     "sha256": "8d28d8d9d8cec1dbe0d595140de937c27cddf273f3e4e5b77cc9550cbf9713f6"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "f29cb8ebccfcd2d2d707c33d48ae159b846e9e1950c79084e478db87b64b601a"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "8d1ab3741895026a69fdaf0380a640c4c70d6db2861a1fef050e69de20967b67"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "12333a57fea61e2da7355563f78c064ac1fddefc637eb02baa47462b4fb5b1ef"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "a798acf16b10918e36d42d35e91b9ef614a5b22e76437ee2f52de20981df7532"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "93f3e1dfb95ec20ff1a089b20d319113a9e444b2e09c5363c13d5c98baf43b01"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "5a645adbc2ce6bd4730d17c1f56261063a09831298e32b83db4820d39a726700"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "e636cb3510f05c386a4f2dbc0ec7c030eb37c6a822f3acb2d842322f4eba4fa3"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "2ddb458cb926da9473eab6fe538066faa0ac3d2e174e95a1f0805eaad0de86ac"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "59f82f1fe5ebed6d4e1015985aaa8d2af0e5018538b256a274056a7f427063ff"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "f9d431eda82ffbcb89c10a537b2cb93ab694175f587f49c967b4614622b297e8"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "bd4b5037f7d36cd9611da6edb591bf0a7501bfbd29b888f00b09d8b5bdd7fec4"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "27c9e44c00df46306678f8b5df99ebee7996cab3768765601aa4608259566830"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "3fa7a52422a8fee47cd6cfa92581a80edc4924e72ecad8b1d2e5cd8aa64c773c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "5a90990ead5fdc54687154df98456a074378cae93cbe3a7744d3f2c703fdd86f"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "f94636bc31d005e7b972a71b31e56999e484ed850892b43da9fcf64df001d21b"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "f02886ad50ee0ed074525b73c76dd4fffd214ee70a6c80b6cb0924c6a9468c48"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "f63d8a28c4cdf03251523120897756e49b0a0505a841eb95259d46a37c5d0706"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "fa8937f81df88b0a304ccf69cdc86e5680c6932a72700912e3e3645e274cf439"
+    },
+    "gfx/netmen1.lmp": {
+     "bytes": 3352,
+     "sha256": "34840fee0395587113a4fcfb6a81b94f4cad65596db809d7e7884eca3145db82"
+    },
+    "gfx/netmen2.lmp": {
+     "bytes": 3352,
+     "sha256": "3c810052381e87d75e8dcd696acf6ee4218cb099a28dbd86d1833fef04b125c9"
+    },
+    "gfx/netmen3.lmp": {
+     "bytes": 3352,
+     "sha256": "5c9503d4cde00d285b399458e9a4640843f97836078cbf68196cb7ba4a26fbc9"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "a4f426de7c7c8b911eedec588d19e434a771b4e7ac48e320d1b8bbe4ce534241"
+    },
+    "gfx/netmen5.lmp": {
+     "bytes": 3352,
+     "sha256": "f09e0e5946c762f6600bddbb5fc14802698dafa3c7b1626780640d1b51b112e1"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "a4d6ae4f24423514df1af1016c80d9a4a2c9f3c9a06dc08843a9a7e40cc545f2"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "81921bdb08aba059ca4c3a2c37bb2d86dbd0e83a2a509feead428ee5d4ed9cb1"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "3e70a4b6412592a2c17a3eeca131b5cd4f0ad6cd38b7ce34bf66b31a26fb1f77"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "b2390c43e7e6f29c7c6c9396df8bee2292a290eec853b738609489266a4ca47e"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "a3c83161a58c462b15be95679632e64ecdfee3696ee893291f29315ba6965f69"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "7d87bd02566408f16129f06f068f397a0985d84695efaa5c513e7ad441eac49e"
+    },
+    "gfx/sb_armor1.lmp": {
+     "bytes": 584,
+     "sha256": "85ac21ae3bff2124c07339d8f436a914a4adb7e0b08674d1c18559458a675c26"
+    },
+    "gfx/sb_armor2.lmp": {
+     "bytes": 584,
+     "sha256": "b681a30084766bf80c66107ff314e59204fad3a9a8458f9ecba177aa26bb1396"
+    },
+    "gfx/sb_armor3.lmp": {
+     "bytes": 584,
+     "sha256": "73ec9f80935339c5d4ac7350d01fccbfffb69b7c45c39f13e199fcd099cdd320"
+    },
+    "gfx/sb_invis.lmp": {
+     "bytes": 264,
+     "sha256": "54a173887ed44d030aac284e7214a91efd0c026b530bdc4a0f836f23100f9c90"
+    },
+    "gfx/sb_invuln.lmp": {
+     "bytes": 264,
+     "sha256": "2fd913f13e7e8661421255a7b6394734815a64c8d240305390a8624a2bbd069e"
+    },
+    "gfx/sb_quad.lmp": {
+     "bytes": 264,
+     "sha256": "73b3612b4e64f9e6256f654f705486239f3156d27c91cc05dc88a39fe6004de6"
+    },
+    "gfx/sb_suit.lmp": {
+     "bytes": 264,
+     "sha256": "5cf57db190defe9eb32950f5e0ea0c3969a4fd65e8532df311e1abab3986a7d2"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "1eefb35eece543e2b572780f393545bf469e2f1a0e78e6c20f54b58f3d6c7188"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "d84dfc5a8528bc1e5cb40a2e094735c64d46aab68cba43597e34a7b63e212ced"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "e6db3d15bb5af528029e1b23970edb97dded39d5b8434598ccd7d6eb84783b51"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "7c189e31853bcc215d0e8878a194e7091618be135c8acd67b1fbc304fbf53f1f"
+    },
+    "gfx/weapons/ww_grenade_1.lmp": {
+     "bytes": 1544,
+     "sha256": "19f8884aa19530cbe6a0d36c03549236c050c77d7c8d8436e8d63034980f2a4e"
+    },
+    "gfx/weapons/ww_grenade_2.lmp": {
+     "bytes": 1544,
+     "sha256": "514cd727936f4a8000be9ac3398f999f9e8d3d7a6badab98598e638477e54d07"
+    },
+    "gfx/weapons/ww_pistol_1.lmp": {
+     "bytes": 1544,
+     "sha256": "f6ebc392ece6369f0ce553d0f30cc07991305a021ce66ce466a863148b675f0d"
+    },
+    "gfx/weapons/ww_pistol_2.lmp": {
+     "bytes": 1544,
+     "sha256": "2f93b15f9823052b8f91008bd38c152b4b068d17833c340cd918a1f118f3a0a5"
+    },
+    "gfx/weapons/ww_plasma_1.lmp": {
+     "bytes": 1544,
+     "sha256": "9a50d3bc66d07ecef8aefcece47ce9a0cf7cb275262a33587a43b3c48106e11c"
+    },
+    "gfx/weapons/ww_plasma_2.lmp": {
+     "bytes": 1544,
+     "sha256": "0ac7a63565846210cd1bb7afb80973a08f8c6c33c35fd797f1b7d019a4eecc14"
+    },
+    "gfx/weapons/ww_rail_1.lmp": {
+     "bytes": 1544,
+     "sha256": "dff2730263f4aec03adb98422f940e4b7c5945423b17ae3630e04df0cdb31d2b"
+    },
+    "gfx/weapons/ww_rail_2.lmp": {
+     "bytes": 1544,
+     "sha256": "bb10381a898dadeedf99bc0d8f3fde1339825acc4afb588ed558693b84fa1541"
+    },
+    "gfx/weapons/ww_rlauncher_1.lmp": {
+     "bytes": 1544,
+     "sha256": "792d29ada0e034e8f3a06c82994cb1cc8c9535259f2557a0a97b94bfddbecfcc"
+    },
+    "gfx/weapons/ww_rlauncher_2.lmp": {
+     "bytes": 1544,
+     "sha256": "ef17afc7df9250d2a359b58c7fc5ebd25df5236f33fa9aacac2fe1ede3784c6f"
+    },
+    "gfx/weapons/ww_sgun_1.lmp": {
+     "bytes": 1544,
+     "sha256": "7ec63f8154b16fe900842f483c65e4b86354c0913ca15aafbf961951ff44afae"
+    },
+    "gfx/weapons/ww_sgun_2.lmp": {
+     "bytes": 1544,
+     "sha256": "e17729981e5e75c63a661d5301f52b76472752af01fddb901d6e73b56f204a67"
+    },
+    "gfx/weapons/ww_smg_1.lmp": {
+     "bytes": 1544,
+     "sha256": "9ce764e052ae513f343af9bac3e1453b1e9ced74d9f905aecdbc229a0e94c085"
+    },
+    "gfx/weapons/ww_smg_2.lmp": {
+     "bytes": 1544,
+     "sha256": "69ef793d187e0b1ccad6b463d90e862e332a1f469ab0e616c9d3e741dbfe0447"
+    },
+    "gfx/weapons/ww_sword_1.lmp": {
+     "bytes": 1544,
+     "sha256": "20b8114914cdd685c3b3c67eb95030cab20ca35b684f3bf12c416c8cde677f7c"
+    },
+    "gfx/weapons/ww_sword_2.lmp": {
+     "bytes": 1544,
+     "sha256": "835f8e551ec3d972394cd782b2343b63c86a280505ab26ffa8d44ed8b83738e4"
+    },
+    "mapdb.json": {
+     "bytes": 1637,
+     "sha256": "91dff32f26ae84642212b1901e6608272d4d72f71b10877e3027487758a7f9fa"
+    },
+    "maps/bldg1.bsp": {
+     "bytes": 1195948,
+     "sha256": "847dee6b2c17fa9a08d0cd9f1e88409f79c44cd8a1828c6c1bb2a928884f25f7"
+    },
+    "maps/bldg1.lit": {
+     "bytes": 403760,
+     "sha256": "cc5d0df0cbd6356a6c64ca831f58e4569490ed9f5dba411bdc9432f9b2d94c34"
+    },
+    "maps/bldg2.bsp": {
+     "bytes": 465212,
+     "sha256": "586217108335f70faba68d26a03d2e5d7c09b72d745f8c6a1d43ef199b5304f6"
+    },
+    "maps/bldg2.lit": {
+     "bytes": 122912,
+     "sha256": "527dd591aa46c8401fc28f012578c7d75561d80349bc8c66a9afba4f06f7ec68"
+    },
+    "maps/bldg3.bsp": {
+     "bytes": 880480,
+     "sha256": "0afa7b7f165f1600e886be0ab4f7bac893ff091ebbb71cc93c8730fb45bf3b2b"
+    },
+    "maps/bldg3.lit": {
+     "bytes": 300044,
+     "sha256": "9e33306d00a8648356ca1fc73580d1e3aeee8870aae26127175a53290eb9e00e"
+    },
+    "maps/bldg4.bsp": {
+     "bytes": 991516,
+     "sha256": "b30e73565ddf7d80896d4ae6e6a71dbc5f15707bb41315ad10061b2b315a12df"
+    },
+    "maps/bldg4.lit": {
+     "bytes": 341936,
+     "sha256": "984f27faaf2491836c0514ec58204742686fc34b9bbf2f5656675ced1ba62f05"
+    },
+    "maps/bldg5.bsp": {
+     "bytes": 717756,
+     "sha256": "e1392221e6d3bb3ab034c3dac326bc0aa1cc5acb83702ddfb941a72ffdbe6ff9"
+    },
+    "maps/bldg5.lit": {
+     "bytes": 164552,
+     "sha256": "ee608aaeb8c327a3df9a4f3140c9ea81ea9428aba7390a9772cf318041e8eccd"
+    },
+    "maps/ee1.bsp": {
+     "bytes": 17546456,
+     "sha256": "822b4edf149a93abe2a5439f1b0e2eb0bd6eaff0ae6e47a301b26647ca7eb0db"
+    },
+    "maps/ee1.lit": {
+     "bytes": 5397608,
+     "sha256": "466b1688850408830734e3658feab6870830af026602650c3d9ee7a6268587a3"
+    },
+    "maps/ee2.bsp": {
+     "bytes": 18696824,
+     "sha256": "8b448a6819db1b5811d5d9c0d9aad5a3934b34c2d48327c431462b3edbf84636"
+    },
+    "maps/ee2.lit": {
+     "bytes": 6004184,
+     "sha256": "87c51b0ba2bc85d2301511823e71f4e007aba3204127975463b053c8e9d18c57"
+    },
+    "maps/ee3.bsp": {
+     "bytes": 19724284,
+     "sha256": "060087c3875d5281e71863359fb98e41fc9c3b56560f066da1e324cd23e26176"
+    },
+    "maps/ee3.lit": {
+     "bytes": 5897876,
+     "sha256": "c6c8875e1da929e975cca726b7136207ef93347db3ff352347904650863e3846"
+    },
+    "maps/ee4.bsp": {
+     "bytes": 8753984,
+     "sha256": "71bd012177e8157570f1a6872baff883c53399bd6ffbe9742d29e1ed5b7c1a37"
+    },
+    "maps/ee4.lit": {
+     "bytes": 1675112,
+     "sha256": "76f52e8d0caf95bb5d0bb10d8d5f716eafda3252eeefe7b8abb7bec1e60c45e9"
+    },
+    "maps/ee5.bsp": {
+     "bytes": 9355600,
+     "sha256": "80a6af8d49a4d954f9a1fc7d77cba40d4d2647662ed2fd244ff0759a5dfa7cac"
+    },
+    "maps/ee5.lit": {
+     "bytes": 2778917,
+     "sha256": "dfe0c124694fe248d60758a59eda3e8e83a0e1df67cf527d257b52f7e22643c3"
+    },
+    "maps/ee6.bsp": {
+     "bytes": 5323152,
+     "sha256": "adc27c4303f84a4464b078ea1fa0c72807a8c0b2dadb8cd767d48cacc3c6ac94"
+    },
+    "maps/ee6.lit": {
+     "bytes": 2937152,
+     "sha256": "49854a11c9808a5f34b6cf6a4b04c96171476e4333604b2fc731c478efae8e93"
+    },
+    "maps/eedemo.bsp": {
+     "bytes": 7381468,
+     "sha256": "a8f8f612412f840c70cfeb88da8635c5cfa51c9672243106786660fde9ca1c9d"
+    },
+    "maps/eedemo.lit": {
+     "bytes": 1408376,
+     "sha256": "a115cc083a57a920e81d087dd054529f7328818b20b565d08e0da39b4d1b0f90"
+    },
+    "maps/eedm1.bsp": {
+     "bytes": 6105660,
+     "sha256": "e591d431fddc0c4b499ed9f38829a5cd773e53c63b2ea39e034cb163c4bc3142"
+    },
+    "maps/eedm1.lit": {
+     "bytes": 792407,
+     "sha256": "0c047effcfca21d02033054816928c2d68933ce178170740e723791a770b7a53"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "maps/start.bsp": {
+     "bytes": 3418716,
+     "sha256": "88d24ab0ffa0dfa8f692281c95911e392319c42c2bf02b6ba55a3085100529d7"
+    },
+    "maps/start.lit": {
+     "bytes": 297380,
+     "sha256": "e5f8280dde9c678a7d8a9cfe1396d84832e971462d2d93c98bb86fd301c4586b"
+    },
+    "music/track03.ogg": {
+     "bytes": 1672826,
+     "sha256": "74a2d8be1d7ccce475a707bcb6a97bec3f743b70691d56fa569d226c2fa8b552"
+    },
+    "music/track20.ogg": {
+     "bytes": 1793776,
+     "sha256": "d18fd699e048fd7acb41e070893cefbfacef7fe6d1d0594aa08bb5a53872d233"
+    },
+    "music/track21.ogg": {
+     "bytes": 3378828,
+     "sha256": "8e81487bf36abc4c72553de2ca12546cac6f45d579d069afa677bfc39187b7a8"
+    },
+    "music/track22.ogg": {
+     "bytes": 3314904,
+     "sha256": "2de98a6936d1e7757dd533b5118844c1bf7811d5ff882879d0b5a2fa56d6df50"
+    },
+    "music/track23.ogg": {
+     "bytes": 3477603,
+     "sha256": "181d0e88b32d7250f7a3815844069c6954c73f769268dd6e3ff06eb28154f6c2"
+    },
+    "music/track24.ogg": {
+     "bytes": 3534484,
+     "sha256": "dce73540c2ef12f91f633df2a3a62b81c355aa7b7bcb5a4d7d487e5b91d671d6"
+    },
+    "music/track25.ogg": {
+     "bytes": 3989105,
+     "sha256": "1f435fda87a355e5fad1c403600c36b53441a177576bb717d7441e130c495961"
+    },
+    "music/track26.ogg": {
+     "bytes": 1969051,
+     "sha256": "a104cf33930cf1106637d666fdcc80773573ad9b8fefdc0ce4d7565ffa8d0c74"
+    },
+    "progs.dat": {
+     "bytes": 823470,
+     "sha256": "58726cf6a61e7d6a62316367ddde9607d4c34893dd3651d4752d5e4431435144"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/d-aircon-01.mdl": {
+     "bytes": 16964,
+     "sha256": "6cd8ae7f006daa5cc645b6897a2a496cca9c2d61c273db814ce63a195df8598d"
+    },
+    "progs/d-aircon-02.mdl": {
+     "bytes": 16964,
+     "sha256": "d4b964384171cfbcdb88d49818292c57197f6c198101647883f378b752866ebf"
+    },
+    "progs/d-auto-01.mdl": {
+     "bytes": 82020,
+     "sha256": "2e9bae83a727d30339ef3f3fdf51bb945306be355cf66b3371cab053b0d5855d"
+    },
+    "progs/d-auto-03.mdl": {
+     "bytes": 283844,
+     "sha256": "f639a4bb8dc0865d179073814e1182dff19f009c7964fa8629f86d04daa6df60"
+    },
+    "progs/d-biopill-05.mdl": {
+     "bytes": 275524,
+     "sha256": "03fe37b43a257f96735990f20a6a79b5bfd2915e1a46bf57fbbc890718f2bbac"
+    },
+    "progs/d-brrl-01.mdl": {
+     "bytes": 17620,
+     "sha256": "b77f574aee5bb4a3d14afd19812d25bc1b945ff12926419a8108efd14e47f0d8"
+    },
+    "progs/d-brrl-02.mdl": {
+     "bytes": 17620,
+     "sha256": "c0735f1750d728870eadd999b347912e256ac16b5e569e390f316b8b77eedba2"
+    },
+    "progs/d-brrl-03.mdl": {
+     "bytes": 21892,
+     "sha256": "8c50cd7232b91d737dd246b9f74b61f43149fabf62792f8aa0e3a09f32efb190"
+    },
+    "progs/d-brrl-04.mdl": {
+     "bytes": 21572,
+     "sha256": "b3211d218ace1a27b920f3b484a50e3862a838a4518ce33e9709801bda195d98"
+    },
+    "progs/d-brtp-02.mdl": {
+     "bytes": 69172,
+     "sha256": "8e7a0298532c483ea7a79bdfd4a10d93ae575e3c3862a35487b3857e5b2e03ac"
+    },
+    "progs/d-brtp-03.mdl": {
+     "bytes": 182316,
+     "sha256": "ccd313c493b771b2ccf9f4236df76aff60b5268687ada355d333036c754e5d52"
+    },
+    "progs/d-computer-03.mdl": {
+     "bytes": 87156,
+     "sha256": "d79b599bac19c6c064b374d7d9b48b0ab402a7c5a773ac1971d4349b0092e2d5"
+    },
+    "progs/d-console-02.mdl": {
+     "bytes": 100228,
+     "sha256": "7997db6590d6f3b4325718446bc87029faa73ecf285119be913b9fddfffe0cf9"
+    },
+    "progs/d-crate-01.mdl": {
+     "bytes": 17972,
+     "sha256": "e294bb8c5be345e326b6f3ff48f96d2d33bb8a4015fcd2fe7ed26c9d8524eaf8"
+    },
+    "progs/d-crate-02.mdl": {
+     "bytes": 17844,
+     "sha256": "dbe153b523952322a0c03ee2e2d702cad23bc4f04ec8bce7e720dfb364999a18"
+    },
+    "progs/d-croswalk-16.mdl": {
+     "bytes": 26164,
+     "sha256": "55710ca3f23b91ab48801e0782f07d97c91694ed4894075c81fa9af7fbb58f7c"
+    },
+    "progs/d-dumpster-01.mdl": {
+     "bytes": 34276,
+     "sha256": "ef58de0bc88ba33e6a6b0f7eee7e73f837eb0c27f9bf91eeaad50b4edfa9a66d"
+    },
+    "progs/d-face-01.mdl": {
+     "bytes": 78212,
+     "sha256": "cd42e54d9fe22094d58dc8d85311fc7f6ca4e3b491342806f8e42f62d014f3ac"
+    },
+    "progs/d-face-02.mdl": {
+     "bytes": 135156,
+     "sha256": "4190cc2606cbfc9a6b25bfafd5213c540dcca931c5f854bb023563ee851eb5d3"
+    },
+    "progs/d-face-03.mdl": {
+     "bytes": 128628,
+     "sha256": "c9d1e0bc95cd9ddccb21911a89fcd82ef55881e089060b1d3cc9c4dfc2c4fc2c"
+    },
+    "progs/d-face-04.mdl": {
+     "bytes": 239092,
+     "sha256": "a4e91139b105c2d77a361c9fc56a31763b60e522118e068fb9d32a39d21fff68"
+    },
+    "progs/d-furnitur-11.mdl": {
+     "bytes": 71028,
+     "sha256": "140a01a074535070ee175c67ab601343d77a4b3bd16467ad64a957821d8b2dd8"
+    },
+    "progs/d-furnitur-17.mdl": {
+     "bytes": 74260,
+     "sha256": "a385a144a5b789faea7fdc198359df75c0e0693b2913f90609399cd621bc998e"
+    },
+    "progs/d-goldbld-20.mdl": {
+     "bytes": 26740,
+     "sha256": "6ff0eaa55ae96aab0f2224f160c27379ffdae5264fb3fbd6e5a7fe513ee8f66e"
+    },
+    "progs/d-jeteng-03.mdl": {
+     "bytes": 236788,
+     "sha256": "8744788b46fb57548ea3ed7f2b67ce188e7f0e6ddaca7356488c86c215d122ea"
+    },
+    "progs/d-jeteng-25-480.mdl": {
+     "bytes": 232420,
+     "sha256": "7b25edb49fff39ad547d483e527eb61e3d6c5212e6856c0ae3b4600735fe6252"
+    },
+    "progs/d-jeteng-26-480.mdl": {
+     "bytes": 244340,
+     "sha256": "40fb5977389a18225ae865f8c968606f81d8b69f08cd678d4a78bd8bad043342"
+    },
+    "progs/d-jeteng-28-480.mdl": {
+     "bytes": 234612,
+     "sha256": "8d5d0a4049e2afda9024ff3ec4e62f3841ada7604e176826f164e7e3cf038d94"
+    },
+    "progs/d-jeteng-29-480.mdl": {
+     "bytes": 260868,
+     "sha256": "87d3f033f3c7a7b05127ab0d16317c1f2d29f61e5aecd6119c84b09ef2261632"
+    },
+    "progs/d-lamp-01.mdl": {
+     "bytes": 31460,
+     "sha256": "f7156c7e17f60e8c8a1e5a90f70972aada59eb0277451a51d5cf21ef1598aed8"
+    },
+    "progs/d-lamppost-05.mdl": {
+     "bytes": 21396,
+     "sha256": "41dadac95d90b8b45c0fad36bb679877ce6979ac919728b2b89fb54d9d5821a4"
+    },
+    "progs/d-lamppost-10.mdl": {
+     "bytes": 25732,
+     "sha256": "bb32c041bab5f3a876ca7fcecf022411d8a9b16b0791295b455f96b817df52dd"
+    },
+    "progs/d-pblock-06.mdl": {
+     "bytes": 304880,
+     "sha256": "2d0c6b831e0287d9e9b5a1c68977faa37bb19cfb125768ad5c8de021844daf4d"
+    },
+    "progs/d-pblock-07.mdl": {
+     "bytes": 268500,
+     "sha256": "76148537b3a5fc7df01293952fa70a70756bdc3bd67e4c63acc60d2894b367f3"
+    },
+    "progs/d-pipeband-01.mdl": {
+     "bytes": 81220,
+     "sha256": "6a8f18f7abeeee9490f7b9f562e246dd16a4029defed35c6178c7a3b18c1e362"
+    },
+    "progs/d-pipeband-03.mdl": {
+     "bytes": 68724,
+     "sha256": "be1d640163ce18bb36dd2dcd3f4e7a3a99390b045231db467847f93ebb70d606"
+    },
+    "progs/d-pipeband-05.mdl": {
+     "bytes": 76324,
+     "sha256": "a6d2f24df92ca5d89c0af26d5df2310f85177121678d9e98a6c82f97138f22e4"
+    },
+    "progs/d-pipeband-06.mdl": {
+     "bytes": 74804,
+     "sha256": "adc0cddef6faed06f1a692b21abcdaac81c35a6a8b4b8d32fb675d90a81be3f4"
+    },
+    "progs/d-pipeband-07.mdl": {
+     "bytes": 73284,
+     "sha256": "c1be1a3d1b752f46ec28be6642ccf49dc6cb8528f58e4cbb7eeab80b86aa8c18"
+    },
+    "progs/d-pipeband-08.mdl": {
+     "bytes": 77844,
+     "sha256": "a2aa4d7933adfa9afb4dd83c433add0f75e0385767ca0be9bbcd434016de1f00"
+    },
+    "progs/d-pipeband-09.mdl": {
+     "bytes": 70548,
+     "sha256": "4b465795b7eff4fbe66d06318e8a216b7714416f9d835bf0fcb7336544a2ed68"
+    },
+    "progs/d-pipeband-13.mdl": {
+     "bytes": 83652,
+     "sha256": "3fee3acaad427b051af3e1202f9a6d2a83a3f062d2fc2c08284317cddf89b615"
+    },
+    "progs/d-pipeband-14.mdl": {
+     "bytes": 70548,
+     "sha256": "d25824a6302f09ef2cd103651a018e897493e533af315c327cb69ee8c7893942"
+    },
+    "progs/d-scrnaray-07.mdl": {
+     "bytes": 708652,
+     "sha256": "773b849ca70175e69293a9b280c1cd53d93df972d3557e35655be5ad95020c39"
+    },
+    "progs/d-scrnaray-08.mdl": {
+     "bytes": 722604,
+     "sha256": "fd6b36e3f31cbc4ca91fe13481e27da227bdcd12ee2f170f671f0a6c0f410ffd"
+    },
+    "progs/d-scrnaray-16.mdl": {
+     "bytes": 753020,
+     "sha256": "5d2863b4aed8b89eedd683232a8961e043f65152ab0f1cb08a55294d4b5717e1"
+    },
+    "progs/d-svktank-01.mdl": {
+     "bytes": 291812,
+     "sha256": "8f73d4a62c03ff8f1e790f345015baae6b73feb46c941d16bcd91d7417865b0d"
+    },
+    "progs/d-teleport-01.mdl": {
+     "bytes": 314964,
+     "sha256": "d2609989cbb578cf0aa8473da6ddf7deee81e9d1b8b0ef71b36759b4a4e4fd96"
+    },
+    "progs/d-teleport-02.mdl": {
+     "bytes": 260564,
+     "sha256": "5515ecb14a49e8149b04ca3b21e9211c3c0455e95293dafcc719081c3ad6c781"
+    },
+    "progs/d-toilet-03.mdl": {
+     "bytes": 38872,
+     "sha256": "195c1da93a400a6cf96a6f8e673e81dfc5e83d4230a1dbea7cea836b90adf117"
+    },
+    "progs/d-train-01-L.mdl": {
+     "bytes": 116196,
+     "sha256": "81ee1e24c842190baa79cf40fadf185243c57ea5f50f9f14fa30f26137243a93"
+    },
+    "progs/d-train-01-R.mdl": {
+     "bytes": 114948,
+     "sha256": "d7c18d69b7fd03f5f7c2f79825cb66fb4e2dda2809816860f3dc464e1089ae28"
+    },
+    "progs/d-train-02-L.mdl": {
+     "bytes": 115540,
+     "sha256": "233569460f083598c51415a81040b69d77ef89630d4592c7ce3ced51452fd674"
+    },
+    "progs/d-train-02-R.mdl": {
+     "bytes": 114804,
+     "sha256": "2cc065178cfa00f36611cba037cdcbb6a9174c16e190ee485e1c78240f881fec"
+    },
+    "progs/d-train-04.mdl": {
+     "bytes": 131764,
+     "sha256": "9c5a76aa97822cfc861626e5303f787f52738684d5cb90d0bf327c4220b9751c"
+    },
+    "progs/d-trash-01.mdl": {
+     "bytes": 71668,
+     "sha256": "bc3637fcd52585a9b1868ee181110e136b07f450c3e838ea1210e7d1aba01c9e"
+    },
+    "progs/d-trash-02.mdl": {
+     "bytes": 71860,
+     "sha256": "5671fdfc4c32aad7c1eaee679b76e40332d09c70c81fb57622ca52bf92f6b254"
+    },
+    "progs/d-trash-04.mdl": {
+     "bytes": 66964,
+     "sha256": "676d460bc3eb3c04055e893fadceec8dd1e71db6d6b895250c72f80e918c4c1c"
+    },
+    "progs/d-trash-05.mdl": {
+     "bytes": 66612,
+     "sha256": "dece8a130eda6dacc9046d8f11434193dbf39fec38fb8b78e04cb9b8fb1dd650"
+    },
+    "progs/d-trash-06.mdl": {
+     "bytes": 66612,
+     "sha256": "9f50fcea9d45d5b20322997cb84ccef7d60e2dea48463c52fc8e06656b1b048d"
+    },
+    "progs/d-trash-08-1.mdl": {
+     "bytes": 83124,
+     "sha256": "8e08e067db23ed0f2667123b6d8dceeebadf256f08e5e1815690e1c27e2df902"
+    },
+    "progs/d-trash-09-1.mdl": {
+     "bytes": 112724,
+     "sha256": "94d6e59a59518747b4ada478eda93bb9452c427ed4554fa81f01b8e3e34c4624"
+    },
+    "progs/d-trash-10-1.mdl": {
+     "bytes": 125780,
+     "sha256": "b0ac3acec665a7aea217ede7668a1c721260014abed496f466fc0c4867a1de96"
+    },
+    "progs/d-trash-12.mdl": {
+     "bytes": 69012,
+     "sha256": "857cb1b9e6db899d823e0dd8546e03d3d7144aca1ea3bd3ca054fff4bcbc43de"
+    },
+    "progs/d-trash-13.mdl": {
+     "bytes": 76148,
+     "sha256": "4f61301fe88d4e9844fcddbf3d363b0c97435669eea2a7cf7329e9a7f6c4bcfb"
+    },
+    "progs/d-trash-14.mdl": {
+     "bytes": 78772,
+     "sha256": "c4668ff03d4f2f25d90b344687ef7dc3f556e4c524fca22ed903c8b7c8db0759"
+    },
+    "progs/d-trash-15.mdl": {
+     "bytes": 84276,
+     "sha256": "f0de9c15def766b5e2a656cd575da34b986d1229c3236abd0a18990b339dd6bc"
+    },
+    "progs/d-tuktuk-01.mdl": {
+     "bytes": 1212900,
+     "sha256": "c417123f8ee5cfa85f922a3232f95649ec497b8c58a2d3a2cc255662ebb38a81"
+    },
+    "progs/d-vendor-01.mdl": {
+     "bytes": 110852,
+     "sha256": "792ddbf396b88a244d889b890c483db08b445f6b04fce53d3c7647bc2665a638"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/drip.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/ee_boss.mdl": {
+     "bytes": 1135164,
+     "sha256": "e67f1fc17f7e29c373b9eaba26d746ee28a91a1c3a1c2b35e606d45b2ae0afa5"
+    },
+    "progs/ee_boss_base.mdl": {
+     "bytes": 305332,
+     "sha256": "38dda2f0d6fc5ad9e82c25f3f0a1b817952ba180798b419e8fb4d139ae94c806"
+    },
+    "progs/ee_boss_shield.mdl": {
+     "bytes": 1135164,
+     "sha256": "43671c5f060ad2c012638cb1ea60887d0c31442e34d809bbc494c5548cb7225d"
+    },
+    "progs/ee_dp_sc_claw1.mdl": {
+     "bytes": 5892,
+     "sha256": "7fdc02cb4ab90066a9ce0cb75f033e0bcd4aa7f3adb061a890443bd819bb2983"
+    },
+    "progs/ee_dp_sc_claw2.mdl": {
+     "bytes": 7332,
+     "sha256": "0eabdb584e5016cc22051d3f5c2c2d6405bd36f072fa9848cba9cec5b2e9287f"
+    },
+    "progs/ee_dp_sc_cuff.mdl": {
+     "bytes": 20740,
+     "sha256": "9124dd49de7b19a23d4761a69ad5abeebc5a0417422dde74c196e66691e6771a"
+    },
+    "progs/ee_dp_sc_fin.mdl": {
+     "bytes": 6036,
+     "sha256": "b881cf0afa3f35585db880458c962fe1ae4e9af8d5244cbfcb6b5ac42ad619ed"
+    },
+    "progs/ee_dp_sc_joint1.mdl": {
+     "bytes": 6132,
+     "sha256": "76bc042dc2315d411ad4b7083fc9f1c2b035d83f2d70926a4fc6e34dcfa7e26e"
+    },
+    "progs/ee_dp_sc_joint2.mdl": {
+     "bytes": 3188,
+     "sha256": "1b5f43fb21e34bceb707dd95eedd45c012daad091cb14a42f4d0cfb69b99dab8"
+    },
+    "progs/ee_dp_sc_tail.mdl": {
+     "bytes": 5988,
+     "sha256": "b43fc5a6409c69ee554bc7c703fe5d6b31186c1803f1b135055bbb746c81bccc"
+    },
+    "progs/ee_dp_w_club.mdl": {
+     "bytes": 11124,
+     "sha256": "44c56a2676536d8ef215e44bffabbddaa568f9eddd7fd6eddc365e2004614476"
+    },
+    "progs/ee_dp_w_hammer.mdl": {
+     "bytes": 26100,
+     "sha256": "5cb590fbbb75e9094359d10503841bb97527bd7f94baa7d6491590e85693e3c6"
+    },
+    "progs/ee_dp_w_knife.mdl": {
+     "bytes": 3236,
+     "sha256": "b01ac497d56ef2469deef26340e6b39cd0c7da3540f0f961fca61dc28913abfb"
+    },
+    "progs/ee_dp_w_lance.mdl": {
+     "bytes": 9652,
+     "sha256": "8da4603e50cf65724a8d66f5eb5c3f37ac6b9dedb65cc511eb1d52dfec323d19"
+    },
+    "progs/ee_dp_w_lcwng.mdl": {
+     "bytes": 9812,
+     "sha256": "74ef021a1a5d9e551d60771c82294783a7ed1eae63b91eb21602080327f850de"
+    },
+    "progs/ee_dp_w_pistol.mdl": {
+     "bytes": 6004,
+     "sha256": "14311cc55b96508afc0b5dd7c9b83d0201fbd0b6ccfe621293f647e37d1121aa"
+    },
+    "progs/ee_dp_w_revolver.mdl": {
+     "bytes": 7540,
+     "sha256": "11d9d68899f81d900857f277d471a45a0f3731a645377fc60b7b908688531dea"
+    },
+    "progs/ee_dp_w_rifle.mdl": {
+     "bytes": 11764,
+     "sha256": "faad21771092a230f847fc99403e3d7c4a9413b1da86d2da150a5d2e3005163c"
+    },
+    "progs/ee_dp_w_rlaunch.mdl": {
+     "bytes": 24804,
+     "sha256": "4ca5918370139d6430f43555d304f4b9f38e5d8e7b54fbc98208dce30962e9f4"
+    },
+    "progs/ee_dp_w_sgun.mdl": {
+     "bytes": 11796,
+     "sha256": "0fbef377f74dc726e4fd0ec2acdba6f24926a04a3522dfc9d05e5bc4efd48fb3"
+    },
+    "progs/ee_dp_w_shield.mdl": {
+     "bytes": 21860,
+     "sha256": "ed5bdd0d3833e0a79fb71e85e949961ab1e33502239ed480b8d608f79194b703"
+    },
+    "progs/ee_dp_w_smg.mdl": {
+     "bytes": 7284,
+     "sha256": "6e3aeb6029457d99d88a52e4b953ce5b761c1d523bf375cad26f98e8ce177c2e"
+    },
+    "progs/ee_dp_w_sword.mdl": {
+     "bytes": 12420,
+     "sha256": "b73c673db15d50e6aa80fa855825c9a5c66bf78338556a758fe6b0b5fdb1e7b3"
+    },
+    "progs/ee_dp_w_sythe.mdl": {
+     "bytes": 11252,
+     "sha256": "dfd86c95cc01fadc9030ec305397e96d8a0eb499babaa389f38451da7769858a"
+    },
+    "progs/ee_en_bwark.mdl": {
+     "bytes": 1207300,
+     "sha256": "6272f3e051bdb0ebadab49591dcbab48066d8ecf2ee23e1b94b84c0d00b2c202"
+    },
+    "progs/ee_en_cmd.mdl": {
+     "bytes": 837664,
+     "sha256": "cbf8cb19d29adb4a8e5ac8bc84a07177226716723e00f4793f1b94ba2d7da2b1"
+    },
+    "progs/ee_en_drone.mdl": {
+     "bytes": 411136,
+     "sha256": "ac52190408459221fa56b44fd8054c8a505dbc01613bf8bf9f565210d709c645"
+    },
+    "progs/ee_en_grunt.mdl": {
+     "bytes": 537668,
+     "sha256": "e0bd38db4d38d4b8f1da600052e7d4d336e21a9432e3d0ec90512ac251143b0d"
+    },
+    "progs/ee_en_gunner.mdl": {
+     "bytes": 739736,
+     "sha256": "214c94be2448cd5ee90512393c63c757d505b1659d0775db30cc6ae187497567"
+    },
+    "progs/ee_en_jackal.mdl": {
+     "bytes": 631076,
+     "sha256": "8e441e2769b8395174b7bf33a9f6d8e014375b4817aebd18316108ff94c00363"
+    },
+    "progs/ee_en_lancer.mdl": {
+     "bytes": 562676,
+     "sha256": "8434453771de0b1b304a3a948fca4e52918f0154726408fbb3031cef15b5f2d4"
+    },
+    "progs/ee_en_ltcol.mdl": {
+     "bytes": 1673764,
+     "sha256": "7a1ddb2b49fb43f7a435bbf032c926a55423d907f62b09181fa7a90d9a56b6ef"
+    },
+    "progs/ee_en_ltn.mdl": {
+     "bytes": 1441380,
+     "sha256": "83fb0f47421bed804ef92d6abf347f25b22b9b5a6b20cdfadcf4bd4a2858afa0"
+    },
+    "progs/ee_en_rifleman.mdl": {
+     "bytes": 768032,
+     "sha256": "bfbef4f6f0f7c68e094108d07717b861d59b308911b2e72da84a5ce0d45501d3"
+    },
+    "progs/ee_en_swark.mdl": {
+     "bytes": 1211496,
+     "sha256": "f4dc310abcb5234149ef492759a9361dd0522128c5a4f5f3b5aaf2e2d6a6e305"
+    },
+    "progs/ee_en_trooper.mdl": {
+     "bytes": 1117044,
+     "sha256": "e7f3f76145d40138a56befddd2126ee41a6beb96e3b257f67c832456c088c07d"
+    },
+    "progs/ee_g_av72.mdl": {
+     "bytes": 96132,
+     "sha256": "f4e308a8947bc5a15670697c9baec9ae078831dd21cfb11413d4da0171a4680a"
+    },
+    "progs/ee_g_glaunch.mdl": {
+     "bytes": 40756,
+     "sha256": "de2cefddbf3395788a746fb384e9ca48914c5bb9178dc4e519d9ce554e85a1fb"
+    },
+    "progs/ee_g_pistol.mdl": {
+     "bytes": 11572,
+     "sha256": "434129c8ac1ee84b1b8c3f5c06da00445003ad85f48c51696a43cf41bc580618"
+    },
+    "progs/ee_g_plasma.mdl": {
+     "bytes": 38900,
+     "sha256": "ef2dd140d48105ef2b9fd2623de4e28416111ec6628119a4761c149a734f9018"
+    },
+    "progs/ee_g_railgun.mdl": {
+     "bytes": 74100,
+     "sha256": "7494ba9ef8b22af82b71fa91af10e0cda45a1d6a9e0f52a2e79af0114d799796"
+    },
+    "progs/ee_g_rlaunch.mdl": {
+     "bytes": 40372,
+     "sha256": "92f85b26ebf7c62f6f12c0a677b6831bed370148df213a75e39ff1442bba5327"
+    },
+    "progs/ee_g_sgun.mdl": {
+     "bytes": 22548,
+     "sha256": "79a7054554a22743d194b378ae4f54134ef7168eae99e31c3af904431be5dba6"
+    },
+    "progs/ee_g_smgs.mdl": {
+     "bytes": 17908,
+     "sha256": "874a436bbbb91b65422575fee94d3fe0e55a53e93177b45112f43f99174f27db"
+    },
+    "progs/ee_g_sword.mdl": {
+     "bytes": 5908,
+     "sha256": "f22ef30f49e570db6af82b6f7e6d724de193918905314ba1f42f8da746332c87"
+    },
+    "progs/ee_gib_feather.mdl": {
+     "bytes": 5236,
+     "sha256": "805f5cc577048f00b48af519421923a6d498b65bee0d303becda94dce9ab6eab"
+    },
+    "progs/ee_gib_h_bwark.mdl": {
+     "bytes": 23268,
+     "sha256": "b22e1f87346df7038c4ff0ad91dc802f4aea152dcc9a3cbb9f32a6e38f8d8bb0"
+    },
+    "progs/ee_gib_h_cmd.mdl": {
+     "bytes": 11812,
+     "sha256": "adcecbf79aac7cf2543415e3fb6f87f42776f4c9ecf2799425d6364010cc4393"
+    },
+    "progs/ee_gib_h_drone.mdl": {
+     "bytes": 12596,
+     "sha256": "a84c16092b0e8f89c8a6522df37602d9807fa0c773a0043bed36b1fdede57c44"
+    },
+    "progs/ee_gib_h_enyo.mdl": {
+     "bytes": 23812,
+     "sha256": "71b7d668fb963755d16c0f2d17c00c0a25aae61a38e1f601a0355b0260d60178"
+    },
+    "progs/ee_gib_h_grunt.mdl": {
+     "bytes": 7924,
+     "sha256": "dd071bd813088652426ff883bcf398046638a27db3980746761190c9a666e5d1"
+    },
+    "progs/ee_gib_h_gunner.mdl": {
+     "bytes": 7412,
+     "sha256": "3715739087a7bd7e6b40f3abc7b87e3883a48784180e775c86a4d79d2337533e"
+    },
+    "progs/ee_gib_h_jackal.mdl": {
+     "bytes": 49348,
+     "sha256": "36db1e7b109ca113593581892a87530584d09193d3289a9e23ddb1d923210454"
+    },
+    "progs/ee_gib_h_lancer.mdl": {
+     "bytes": 11780,
+     "sha256": "5e5aa8fa8e97260d53780fc51d77b26e5e5c51b86d66babfc9e01f9bffb88cb6"
+    },
+    "progs/ee_gib_h_ltcol.mdl": {
+     "bytes": 12372,
+     "sha256": "175cae3eaeec5affa7e83ab22794e0f60dae427a65f9d2600f6112cef53b4dc9"
+    },
+    "progs/ee_gib_h_ltn.mdl": {
+     "bytes": 12372,
+     "sha256": "175cae3eaeec5affa7e83ab22794e0f60dae427a65f9d2600f6112cef53b4dc9"
+    },
+    "progs/ee_gib_h_rifleman.mdl": {
+     "bytes": 7412,
+     "sha256": "3715739087a7bd7e6b40f3abc7b87e3883a48784180e775c86a4d79d2337533e"
+    },
+    "progs/ee_gib_h_swark.mdl": {
+     "bytes": 23268,
+     "sha256": "9e9d2ae677d53d59850fb8a7e2fc5404a82676d591cfc29664ce44bb23bfe8af"
+    },
+    "progs/ee_gib_h_trooper.mdl": {
+     "bytes": 11812,
+     "sha256": "adcecbf79aac7cf2543415e3fb6f87f42776f4c9ecf2799425d6364010cc4393"
+    },
+    "progs/ee_gib_lg_bone.mdl": {
+     "bytes": 12692,
+     "sha256": "67628564dbc1a1e673e61ebffdf4b375a39ce88929f83e45b36a271fc4e40b20"
+    },
+    "progs/ee_gib_lg_guts.mdl": {
+     "bytes": 43476,
+     "sha256": "d142a25e75f5d8137cd9256db445d25f0d07fb321e609e61b6267be2a70ce10c"
+    },
+    "progs/ee_gib_lg_org1.mdl": {
+     "bytes": 46324,
+     "sha256": "02c6ac743e5f15e79e85dae7263a881ba7cdabd8987f5caf8a2b04210b3919d1"
+    },
+    "progs/ee_gib_lg_org2.mdl": {
+     "bytes": 24996,
+     "sha256": "d78e09102bd65e54527dd27b8245a29f11279e3328df3767ad3288e298db0f9f"
+    },
+    "progs/ee_gib_lg_org3.mdl": {
+     "bytes": 53124,
+     "sha256": "23b76d030d324fa66d6802179a272217b39fc00336fd6e07982c75dfcbf47209"
+    },
+    "progs/ee_gib_lg_ribs.mdl": {
+     "bytes": 73812,
+     "sha256": "9b876a6a38c04628ed7e8fabc2bb888f27e636bab809dee7d94b3b205682d8c1"
+    },
+    "progs/ee_gib_sm_bone.mdl": {
+     "bytes": 8596,
+     "sha256": "2f7b78be5da656d4a246e0315b2b1e4807d894b9e3c38f0aee772c30d615c138"
+    },
+    "progs/ee_gib_sm_guts.mdl": {
+     "bytes": 27092,
+     "sha256": "67941730f1b34b3d20cfbbdbc66a0dfe8875a8310ac716a2a915ac6394fa7e79"
+    },
+    "progs/ee_gib_sm_org1.mdl": {
+     "bytes": 29940,
+     "sha256": "98df96a83afc2c1923857e4287fa70253e88ea854dc7dd2bb013441e418aca74"
+    },
+    "progs/ee_gib_sm_org2.mdl": {
+     "bytes": 16804,
+     "sha256": "8c8344935e0799223e82fb8089c6bddf055f8f17dcf8fc39ee8a49239dac0efb"
+    },
+    "progs/ee_gib_sm_org3.mdl": {
+     "bytes": 36740,
+     "sha256": "80bb8f023d0b43a9060cb4edfb2b287ade4e1bc4851881467f5c40d6d155e088"
+    },
+    "progs/ee_gib_sm_ribs.mdl": {
+     "bytes": 49236,
+     "sha256": "5158bde7f29f798f4259eb36b8449d2695f3142fdcad2cd5a2a093e51dbdeb8f"
+    },
+    "progs/ee_it_am_blts1.mdl": {
+     "bytes": 39156,
+     "sha256": "9f37ba60da0b6ad41b1e9cb948a7e0f69ff18490fd26ac0f69686580813a9959"
+    },
+    "progs/ee_it_am_blts2.mdl": {
+     "bytes": 37972,
+     "sha256": "2f23d32078ea01fd2c3dfbead7b4fd7dc161a7f877ba1672cb719b5bda41923f"
+    },
+    "progs/ee_it_am_cells1.mdl": {
+     "bytes": 19956,
+     "sha256": "61aff9d92c1bf601777577a1672fea56b6bb884e9029988629101b3aecfbbc29"
+    },
+    "progs/ee_it_am_cells2.mdl": {
+     "bytes": 98388,
+     "sha256": "9a2aa1548052c293566bb337d88c6690998c1868f31affa94ac7ce4557e4e049"
+    },
+    "progs/ee_it_am_expl1.mdl": {
+     "bytes": 88116,
+     "sha256": "333523cf56a5ed6e69456486dd6636cbefa0542bc1290f48f27148ef04b30df7"
+    },
+    "progs/ee_it_am_expl2.mdl": {
+     "bytes": 107508,
+     "sha256": "93375777d55f542157fadde94cf6c2da53af3f13c908f2de9dc042e6e99a46a2"
+    },
+    "progs/ee_it_am_shells1.mdl": {
+     "bytes": 44916,
+     "sha256": "cef42328d6def69740602718f13b76d2a3b03e38549dba7d42db9dd6ada0e5ba"
+    },
+    "progs/ee_it_am_shells2.mdl": {
+     "bytes": 83956,
+     "sha256": "8fba0ad74969b5df7b3f3a46eaf65a5f14441bd21699ae13e25634592e851846"
+    },
+    "progs/ee_it_armor.mdl": {
+     "bytes": 218492,
+     "sha256": "41de03c939cfed11ce70539383694cfd8bd377a3305f37ac9389847369b69616"
+    },
+    "progs/ee_it_bp_blts.mdl": {
+     "bytes": 19828,
+     "sha256": "7d388c0b17b1d62c93a62e0fa62e895507b6057636e7944aad541a6d23deee1e"
+    },
+    "progs/ee_it_bp_cells.mdl": {
+     "bytes": 14132,
+     "sha256": "200efb7210ec13de4e208dae123aafaa50696bbd82edacafe6c59e3744e3083f"
+    },
+    "progs/ee_it_bp_expl.mdl": {
+     "bytes": 25220,
+     "sha256": "1d2d4f105429cbb9d60f4c4b161c891d417e074f45b0a328dca0ea833ae607e9"
+    },
+    "progs/ee_it_bp_expl2.mdl": {
+     "bytes": 25220,
+     "sha256": "1d2d4f105429cbb9d60f4c4b161c891d417e074f45b0a328dca0ea833ae607e9"
+    },
+    "progs/ee_it_bp_player.mdl": {
+     "bytes": 91300,
+     "sha256": "8f1a99bd63b0b1a25b919b6c4eddd3839f1442e1bdeac7dba5f368e18f8e9541"
+    },
+    "progs/ee_it_bp_shells.mdl": {
+     "bytes": 24276,
+     "sha256": "de8b2da4b0d87b134d1e6c3741dba3cce4769f531831bcaff160e822ec2bcbbf"
+    },
+    "progs/ee_it_bp_shells2.mdl": {
+     "bytes": 24276,
+     "sha256": "de8b2da4b0d87b134d1e6c3741dba3cce4769f531831bcaff160e822ec2bcbbf"
+    },
+    "progs/ee_it_inv.mdl": {
+     "bytes": 104820,
+     "sha256": "3844a3eabb668b150cde86b9bafbcd6ed49b3e877420dd70d19793fd381c518a"
+    },
+    "progs/ee_it_medkit_100.mdl": {
+     "bytes": 96660,
+     "sha256": "9ae04ef660cdb07572d886ae387ab582e516e0b00170085406c336c48f80c8cc"
+    },
+    "progs/ee_it_medkit_15.mdl": {
+     "bytes": 52244,
+     "sha256": "f0dcc5ec7676357c7d40331395e872dfe73f656e78963067261ab826b608aca2"
+    },
+    "progs/ee_it_medkit_25.mdl": {
+     "bytes": 85012,
+     "sha256": "a41c5999db3baf231cabf7f272adc4aaaf88d887db00b3679631e651bf36e85c"
+    },
+    "progs/ee_it_quad.mdl": {
+     "bytes": 62068,
+     "sha256": "86a996865cab7cd1a8a03bdda429adc592fe446d589ea55d1703989435d833d4"
+    },
+    "progs/ee_it_shard.mdl": {
+     "bytes": 11140,
+     "sha256": "fcc740fd36f2aa4620c7bf229b2f5036e3b25eda4c151820d1ccf4c964a41063"
+    },
+    "progs/ee_it_suit.mdl": {
+     "bytes": 86148,
+     "sha256": "066ce3f7f742943f93253f2d758caed8d473c60ebee0713eee84ea05ee0f61d4"
+    },
+    "progs/ee_it_wings.mdl": {
+     "bytes": 98548,
+     "sha256": "83ec980cf5e9e8225972b23accf72e70a8f6e8e530967d1d2d41d0397f2df952"
+    },
+    "progs/ee_it_wings_bl.mdl": {
+     "bytes": 95860,
+     "sha256": "6c299b430a0b3b7c2ba422af912d1f2a68bae82da863ce7cf8fa113c6578391c"
+    },
+    "progs/ee_it_wings_gold.mdl": {
+     "bytes": 95860,
+     "sha256": "04a0bc5dd89df6e32c52876cb03ee1f30fed2a94e0926c8cb10160e51c76f314"
+    },
+    "progs/ee_key_gold.mdl": {
+     "bytes": 11407,
+     "sha256": "410da393b9089a6a3290530a54e0675e4caec37c53b2e85e359e0dc70a7c978b"
+    },
+    "progs/ee_key_silver.mdl": {
+     "bytes": 11407,
+     "sha256": "a765664b6f093ab05648bd5bf6b21f1aec7ff4f001dd1d0a4d80e60fc8b9b9f8"
+    },
+    "progs/ee_p_blt_bl.mdl": {
+     "bytes": 58612,
+     "sha256": "e7eed9858fff9ed971cad938adf8c515d517f7f23b75fa46d5a87ba7ad71019f"
+    },
+    "progs/ee_p_blt_or.mdl": {
+     "bytes": 58612,
+     "sha256": "99c183ef61ba39d7479b42e9ce68e4b2a1c471d5baf9198cf126b7f34fbb38ab"
+    },
+    "progs/ee_p_blt_red.mdl": {
+     "bytes": 58612,
+     "sha256": "9245e0aca66f8af176cfeb39b21af08f10c65d4b5a5fa663057d843fccd2b0c5"
+    },
+    "progs/ee_p_blt_yl.mdl": {
+     "bytes": 58612,
+     "sha256": "ab2254385f8cdc21696090e3316e91820807c91c5ca161cf00afab981173ade1"
+    },
+    "progs/ee_p_gbomb.mdl": {
+     "bytes": 36148,
+     "sha256": "497c2d04fdce4d6d51dd2128707337eabf27188c4c2aac1e5f8695d5c0fc7f7f"
+    },
+    "progs/ee_p_grenade.mdl": {
+     "bytes": 16612,
+     "sha256": "5867d475211af101295c49ef7fbfb11ec8bda2ef256c2d7e8f81868a8c223e3d"
+    },
+    "progs/ee_p_missile.mdl": {
+     "bytes": 25668,
+     "sha256": "eefeee66ed435ce87e12377b2ded6a08f608275a12a1ccf1f2c019fedd2b036d"
+    },
+    "progs/ee_p_pm_bl.mdl": {
+     "bytes": 60916,
+     "sha256": "2e40b9062931378d8b8eec38b80099702414c25afd000ee6f24a40b8573add88"
+    },
+    "progs/ee_p_pm_or.mdl": {
+     "bytes": 60916,
+     "sha256": "0f709c06ded706e44297e4377b13c09f6ff6821a83923cdaf8b9b0e145dd2be3"
+    },
+    "progs/ee_p_pm_red.mdl": {
+     "bytes": 60916,
+     "sha256": "bcb5ee2bf2d96b0c056b7b037e69bc64859629b24eee2c175532d740d9bd5436"
+    },
+    "progs/ee_p_pm_yl.mdl": {
+     "bytes": 60916,
+     "sha256": "d7c5c92fb1487c2749c84d1972a558d6bda200629e767c9e1b860b34cf16bfd4"
+    },
+    "progs/ee_p_sphere.mdl": {
+     "bytes": 88692,
+     "sha256": "d98ee6f1a6c4f1bbd0cf8d6acea3a38e222b4f583f23c4b258679da5ccfc5ba3"
+    },
+    "progs/ee_pl.mdl": {
+     "bytes": 1514988,
+     "sha256": "0e1ff9e62eff2b2723ab3028f2dfc331e1861710ff29979a08142734476d1b71"
+    },
+    "progs/ee_pl_wings.mdl": {
+     "bytes": 1815204,
+     "sha256": "39d11f2ccb906b40fbf3eea55f27a29cef98000e24c684c3d4ffa6659cd08a4a"
+    },
+    "progs/ee_shellcase.mdl": {
+     "bytes": 5044,
+     "sha256": "c9adde7f608f9c2888d887df9f7e17ad3ca2dbb872882b24ca22a6b0f7c328e4"
+    },
+    "progs/ee_shellcase2.mdl": {
+     "bytes": 5044,
+     "sha256": "c9adde7f608f9c2888d887df9f7e17ad3ca2dbb872882b24ca22a6b0f7c328e4"
+    },
+    "progs/ee_v_ak.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/ee_v_av72.mdl": {
+     "bytes": 336116,
+     "sha256": "449cba4b643672ef1211cfc32f1a96306639bdc121a4a2de74347cdf474090ef"
+    },
+    "progs/ee_v_glaunch.mdl": {
+     "bytes": 344996,
+     "sha256": "64cd927b8576c236ef1195c3bd0563af963c34897fa628add6828f666c37b79c"
+    },
+    "progs/ee_v_legal.mdl": {
+     "bytes": 66228,
+     "sha256": "3f418186c6de3dd6c0e0c40f84a88d99ae4cd64f0d095a8f0195eaa5b134d10e"
+    },
+    "progs/ee_v_pistol.mdl": {
+     "bytes": 281348,
+     "sha256": "e4e46f6efe2d4cbc7d926515bf4ee7e91f855f46529efec87fd347668a02f373"
+    },
+    "progs/ee_v_plasma.mdl": {
+     "bytes": 326532,
+     "sha256": "5234001e18817bd05db9ac50b3b19e2cdd851bdcddbbb622bd7528e9c99a6759"
+    },
+    "progs/ee_v_railgun.mdl": {
+     "bytes": 391588,
+     "sha256": "f5c9b4b73ee4a653ee9b6f63db8836440819ab99f3adb0d4ad960871241376c9"
+    },
+    "progs/ee_v_rlaunch.mdl": {
+     "bytes": 352564,
+     "sha256": "b5688bf375deb5da0a2b75e139179d88c318d8463f37e3a49d5863e29b3610f9"
+    },
+    "progs/ee_v_sgun.mdl": {
+     "bytes": 345460,
+     "sha256": "c2d45012b6d11604309c4443b20cfa87dea8889b0361e586cb1bd9087a8f8ce2"
+    },
+    "progs/ee_v_smgs.mdl": {
+     "bytes": 322196,
+     "sha256": "2227564577bc0a27baff50cb99c0d3aecb7c8c2f147d6038c4ec0e1005f8acf9"
+    },
+    "progs/ee_v_sword.mdl": {
+     "bytes": 403284,
+     "sha256": "c193e4b60eb0cd929c2f26a1a25a99a8325e1222d622ca5eb6ebd94eb53fed81"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/s_bullet_new.spr": {
+     "bytes": 708,
+     "sha256": "a07fa61f4a838ac9ad8ec85ae525d70fb934d383effd1948c0775497be713043"
+    },
+    "progs/s_exp_small_2.spr": {
+     "bytes": 201720,
+     "sha256": "f7fdba9e2b9b5d318cdff33a06fad4e91e46ba3a241fe7ced4bfbcf0bcb0e873"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma_new.spr": {
+     "bytes": 13980,
+     "sha256": "5474060e55af3c462d0ef7aad043f331c1f5b642915d906c1785bb94595cc68c"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "7979d326b96ecdddf3a8980761114bbb3b35b95b302d478290b952259b4b3530"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/tracer.mdl": {
+     "bytes": 58148,
+     "sha256": "5b24b67ce9d9b2634d9a0f31319a977e1e3ec6352d491367941a0e5bf2ae10ff"
+    },
+    "quake.rc": {
+     "bytes": 2113,
+     "sha256": "79d62a614edfb47a62f1db1bfe9f4c51eeef191df3186325f42ef5f907067eea"
+    },
+    "sound/ambient/arpump1.wav": {
+     "bytes": 18262,
+     "sha256": "11ae2c08c7d5f7f777eade75770a1623386d0e0096a19076fff13e9ddec6318c"
+    },
+    "sound/ambient/arwind.wav": {
+     "bytes": 30408,
+     "sha256": "34248569bb7ab66f5e1d874e15c7a91d89fd2b70d27e5521456b2589581fe1e6"
+    },
+    "sound/ambient/cityfar.wav": {
+     "bytes": 761586,
+     "sha256": "e03acfe7ca720270a0d79699b0f7f3da8d22e7a8a86d0a8f9dfd5e79da32e17a"
+    },
+    "sound/ambient/citytraffic.wav": {
+     "bytes": 879312,
+     "sha256": "0aeab53cf7fcbc516351b86bebe50ba59a6658540a4796ffbf38b7d08df3d725"
+    },
+    "sound/ambient/dronedeep.wav": {
+     "bytes": 361304,
+     "sha256": "45852b61a3c9caf9e5364c7296ab8b3075c74ef66b6573045aa7f8e0b764f650"
+    },
+    "sound/ambient/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/ambient/energybuzz.wav": {
+     "bytes": 633208,
+     "sha256": "52472454b95c91e9549ba7d116e6966c29e368118f7eda5de8e3380f7ab9c2bf"
+    },
+    "sound/ambient/flies.wav": {
+     "bytes": 461332,
+     "sha256": "f8b8fe2acaaa8f9eb4ab464ecd2c80f61748cf4f16f5b95f4a27bbeeb0a2430a"
+    },
+    "sound/ambient/flurobuzz.wav": {
+     "bytes": 966482,
+     "sha256": "81e2c83028327010e2f91c3f1569dce753e3f9ce73e911f6d715f2fbc939f27f"
+    },
+    "sound/ambient/hum02.wav": {
+     "bytes": 37836,
+     "sha256": "8b2ee1b91fa663b6111de9251011142475831ece70ee091022b800b715f1bfa2"
+    },
+    "sound/ambient/machine_loop2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambient/motor1.wav": {
+     "bytes": 52340,
+     "sha256": "c48511a37143e9ed50ae7c1d1f28235b007762949d3d18549fc545cc670c0a24"
+    },
+    "sound/ambient/motor2.wav": {
+     "bytes": 52014,
+     "sha256": "7f36cda5c01aea4e6b356ae4d0b31b68ca15d7606eefd30f4739a64fc4e86e6c"
+    },
+    "sound/ambient/pipes.wav": {
+     "bytes": 1065120,
+     "sha256": "267f09406e59fd5ee08c5c6fff6ceb16306f0bc9256704c754a2fcc9cf1afc76"
+    },
+    "sound/ambient/train_bg.wav": {
+     "bytes": 635454,
+     "sha256": "dd32efa9cd84e30e0ea2889b90d6389e36b64b72a921d3170963ba8b9a8c029c"
+    },
+    "sound/ambient/vent.wav": {
+     "bytes": 1020138,
+     "sha256": "b8cc962ad5148ed0a03a1418b12f3f64105da6cdcb9bfdae3af28a5979797cfe"
+    },
+    "sound/ambient/wallfan.wav": {
+     "bytes": 834146,
+     "sha256": "c30ef0ead2fe2e8f4bad937150d10a95741520c21408fee521c4f485b91a7982"
+    },
+    "sound/ambient/waterpipe.wav": {
+     "bytes": 458538,
+     "sha256": "05659d9acf75a12383954319157377d48ce26a81b4ce452babe1fda09de1841c"
+    },
+    "sound/ambient/waterpipe2.wav": {
+     "bytes": 327106,
+     "sha256": "f0f7237c937801ed707f7a9a98b102c702b633f2132d536bf7fdb1fcec828e7f"
+    },
+    "sound/automate/security_breach_elevator_l.wav": {
+     "bytes": 406470,
+     "sha256": "fb1cd90cf8964a549b337325c5776a27b02062431c8b2344f5d73edb69cb561d"
+    },
+    "sound/automate/security_breach_elevator_r.wav": {
+     "bytes": 406470,
+     "sha256": "c020f6a2fae196a24534874775037a2a27e691eac3fd54931083b0ce93b04b67"
+    },
+    "sound/bulwarker_shockwarker/bulwarker_hit.wav": {
+     "bytes": 119114,
+     "sha256": "0f0804c27cd583fcedffbf00268c4e207daf2ecdd53c853fc58a84a64990ee73"
+    },
+    "sound/bulwarker_shockwarker/bulwarker_hit2.wav": {
+     "bytes": 89664,
+     "sha256": "7c343412a341e56b8687bd3fa1dd6b0f725d235f9155ccd3bc00bc2c56cbc0b4"
+    },
+    "sound/bulwarker_shockwarker/bulwarker_sight.wav": {
+     "bytes": 114424,
+     "sha256": "a6d00ed34366e4d299c53b55f9dc75973e76df0130dac26bc7c5a351c49d965d"
+    },
+    "sound/bulwarker_shockwarker/shockwarker_hit.wav": {
+     "bytes": 119114,
+     "sha256": "4d9069585aa4f3d14e0ca883bb755af56ca8b8d07895b78aa830044f05b500fc"
+    },
+    "sound/bulwarker_shockwarker/shockwarker_sight.wav": {
+     "bytes": 237014,
+     "sha256": "4abf6efac7bf293b180653b8a429ac191dd22c27bf016d68cb316cf5bf7746e2"
+    },
+    "sound/bulwarker_shockwarker/warker_die_1.wav": {
+     "bytes": 231942,
+     "sha256": "0b9affc6e0e7ad180a63ea01a1edcb0aa944ce97df5c50256eac26f11a2c08c4"
+    },
+    "sound/bulwarker_shockwarker/warker_die_2.wav": {
+     "bytes": 271690,
+     "sha256": "215e74ead7baa0cd7430cd6b508a009691683cc8d6b0b2732f719fa9cf1d1a1e"
+    },
+    "sound/bulwarker_shockwarker/warker_fall.wav": {
+     "bytes": 66886,
+     "sha256": "d04e6777811555d66198c43f032f9a7d41e419517aafab9c0c7d9a6231d8066a"
+    },
+    "sound/bulwarker_shockwarker/warker_idle_1.wav": {
+     "bytes": 118756,
+     "sha256": "6183a10495e3689e8c4c04ea82514ff0dd3e254ec950dc568155c30050df3b47"
+    },
+    "sound/bulwarker_shockwarker/warker_idle_2.wav": {
+     "bytes": 146216,
+     "sha256": "94eb877028efc5dbf479a025b84c1569f28c0735e826c18e27cccdef0a063b64"
+    },
+    "sound/bulwarker_shockwarker/warker_kick.wav": {
+     "bytes": 106464,
+     "sha256": "3cf306c314522da7a060f954caba50a8178097331874e8d5c7496ff45135268b"
+    },
+    "sound/bulwarker_shockwarker/warker_pain_1.wav": {
+     "bytes": 66016,
+     "sha256": "a14a6814ff2b236b4d94f1a46726114af44c29140fc34aaf1bcc122decbb8694"
+    },
+    "sound/bulwarker_shockwarker/warker_pain_2.wav": {
+     "bytes": 72952,
+     "sha256": "c64607de6e0fea4d5c39aa7c3060324a84a16ffbc2fba47c13f2431478713201"
+    },
+    "sound/bulwarker_shockwarker/warker_swing_1.wav": {
+     "bytes": 82684,
+     "sha256": "2adc92761d2865251b552fa860af385a357e7c0938766fc8ef54420aa2c23cf1"
+    },
+    "sound/bulwarker_shockwarker/warker_swing_2.wav": {
+     "bytes": 87914,
+     "sha256": "286e808cff595912ba336f0d0ffacdc49738aab3ff2757d842535a8d01692097"
+    },
+    "sound/doors/doorlocked.wav": {
+     "bytes": 88068,
+     "sha256": "66ccbf75aea70e4d7d6bb1cbc5c42084a7482e00f0d7450fded42aeac86b7b6a"
+    },
+    "sound/drone/drone_attack.wav": {
+     "bytes": 37752,
+     "sha256": "89e88881cfee618dd983f9244d48d11fdc218d9448c55e191b07f3270a0d2895"
+    },
+    "sound/drone/drone_die.wav": {
+     "bytes": 78738,
+     "sha256": "d627a1c64cedbffcd08daa99bd2113f533052f1498f0452fb40748bd67f1881d"
+    },
+    "sound/drone/drone_fall.wav": {
+     "bytes": 23396,
+     "sha256": "162fc0be1cd0eadfc93c35f1e1ba9b8dfc7e8df8ee53afb2a14db73e69f20ce8"
+    },
+    "sound/drone/drone_fire.wav": {
+     "bytes": 64556,
+     "sha256": "90772662a1b63f5a02da3de54187878bd6e3d83b2bba580957932941a3727caf"
+    },
+    "sound/drone/drone_idle.wav": {
+     "bytes": 37164,
+     "sha256": "bd7774a50ef039fcbbfc90bb8e0fffa6632b5987d7f609dfb24ca5ffd026f938"
+    },
+    "sound/drone/drone_pain_1.wav": {
+     "bytes": 53304,
+     "sha256": "c2fd92b3b1e15546e8dc1ef17e3957b838e047d660ab6d8bff0caffa4955bc8c"
+    },
+    "sound/drone/drone_pain_2.wav": {
+     "bytes": 61228,
+     "sha256": "5f74b327a33e6ab208ee0162a8faab72209e90e503d2a157e31914c95fbe0fe5"
+    },
+    "sound/drone/drone_sight.wav": {
+     "bytes": 92368,
+     "sha256": "ae53cd8449f6eb3f46187041d99fe3bed7512558d488c8b2c03ed6c960c8b9d6"
+    },
+    "sound/ee6/atmosphere1_l.wav": {
+     "bytes": 311902,
+     "sha256": "420a415b00fd240770fea4d57d6479e9ca2c3ae93e96806265ca87e305568938"
+    },
+    "sound/ee6/atmosphere1_r.wav": {
+     "bytes": 311902,
+     "sha256": "59279a43dcf7ed5dce530f9d545ecb1c067c471be301b1cebe5a101e5cddc89e"
+    },
+    "sound/ee6/atmosphere2_l.wav": {
+     "bytes": 240886,
+     "sha256": "81521a0a9e09074b8b6f4013226108d9ece508ec3411b3896fe1fff6cb8f0cc6"
+    },
+    "sound/ee6/atmosphere2_r.wav": {
+     "bytes": 242842,
+     "sha256": "261c162b82fd3e7f60757d52829afbfe2804cda64dcb54b38042a0ea2a03e5b6"
+    },
+    "sound/ee6/atmosphere3_l.wav": {
+     "bytes": 335362,
+     "sha256": "ecabc3cbc0e11c3f6d44e92fc15488c332c68bf6d6bb8f5c08c827d74d2a8361"
+    },
+    "sound/ee6/atmosphere3_r.wav": {
+     "bytes": 335362,
+     "sha256": "1bd201468255d0d082131232adc5fb9b50fbec4ac82e671efccedc5f1029b0d0"
+    },
+    "sound/ee6/bg1.wav": {
+     "bytes": 543046,
+     "sha256": "dfcf6d2ba9b1fbb65d610896b9c71e5dd20efe8a3200ee796874f06278ff3a86"
+    },
+    "sound/ee6/bg2.wav": {
+     "bytes": 515940,
+     "sha256": "c4d661de667421cc9af5a912e80981b8ed43cb12432226db5b13caef8f8a0c9e"
+    },
+    "sound/ee6/bg3.wav": {
+     "bytes": 571506,
+     "sha256": "3c0e933a373493db1a7a577e0e79aede722726a603b9ed8c697e02405a012b2d"
+    },
+    "sound/ee6/rumbleloop.wav": {
+     "bytes": 280532,
+     "sha256": "d64652e06f1bb5aa667c2dc098e1c04faa9c98374d5ae028f5d4057075a3ea75"
+    },
+    "sound/ee6/shake_2s.wav": {
+     "bytes": 109898,
+     "sha256": "a2b89c5191e07e12fba92b674642786834fbb8d74ba9daed393b1fbd1018b6f6"
+    },
+    "sound/ee6/shake_5s.wav": {
+     "bytes": 226198,
+     "sha256": "29a70583a3ad477ab7dd863936de08349a3b07efc58ce9c9ed6d92b94f5d8c1f"
+    },
+    "sound/grunt/grunt_angry_1.wav": {
+     "bytes": 88178,
+     "sha256": "b65ad5a12a0828340a0bee223b2ce307ff6a0ace75ddadbd0b9cc613334f140d"
+    },
+    "sound/grunt/grunt_angry_2.wav": {
+     "bytes": 79792,
+     "sha256": "ad4d9840cfccc0f8ab8c0e347cf0584b95b8befacd7073f7df672cec7a60488b"
+    },
+    "sound/grunt/grunt_attack_1.wav": {
+     "bytes": 53246,
+     "sha256": "3fd7cef4abcb1be4cab3c5de4245fb40bf65fa8eabf938c22f93ffb5ccb2fc86"
+    },
+    "sound/grunt/grunt_attack_2.wav": {
+     "bytes": 43352,
+     "sha256": "2bc37e82471a096c16adbd687c06ad72f06c89dff575622d4254e9ea00741d93"
+    },
+    "sound/grunt/grunt_die.wav": {
+     "bytes": 75618,
+     "sha256": "d7ec3efb038006996de18e09b6ec1e3ace385f0e26617ac8e56cbe650193da06"
+    },
+    "sound/grunt/grunt_idle_1.wav": {
+     "bytes": 112362,
+     "sha256": "806af5c7b7b1a2db14e2dbcc93cd9aa8aecb9308592156b4efd5c72ac20b652a"
+    },
+    "sound/grunt/grunt_idle_2.wav": {
+     "bytes": 96340,
+     "sha256": "21dcf9bbc07e4901ba61faa0f13e5dac5e9d7ca19683d12a44682679334b4cf0"
+    },
+    "sound/grunt/grunt_pain.wav": {
+     "bytes": 32400,
+     "sha256": "967c1e9c01f84fe22eea0b43b465533bf94ecf2865d8efede5f0adf845529509"
+    },
+    "sound/grunt/grunt_sight.wav": {
+     "bytes": 136370,
+     "sha256": "cab8676a5421ed96a9fc5a752fa90eede5e323071be02e6bbad0a660b6e93d0a"
+    },
+    "sound/gunner_rifleman/gunner_angry_1.wav": {
+     "bytes": 67410,
+     "sha256": "edb0c9871bf38005c5f9ce5db3a26468efdf67c5eca9264168a2f8a04b868e85"
+    },
+    "sound/gunner_rifleman/gunner_angry_2.wav": {
+     "bytes": 86394,
+     "sha256": "91f880e5ca04fa0c7e95438343bb4aaa09cce397fb2fe5826ec898564a1ba734"
+    },
+    "sound/gunner_rifleman/gunner_angry_3.wav": {
+     "bytes": 70234,
+     "sha256": "e9f562490c61b5625087f42f3d7ac8ea7815aa4a163aa982278d714b158f3251"
+    },
+    "sound/gunner_rifleman/gunner_angry_4.wav": {
+     "bytes": 53898,
+     "sha256": "95ac4da6438f0fd8527fcf029bef6ea0a86f1170721e0395fed3441598c7995c"
+    },
+    "sound/gunner_rifleman/gunner_angry_5.wav": {
+     "bytes": 73350,
+     "sha256": "5f1b6f569e84fcea099208553a470f176403a1868e74cef43b647c06b93179d3"
+    },
+    "sound/gunner_rifleman/gunner_die_1.wav": {
+     "bytes": 182386,
+     "sha256": "93faef198a95d4cf2420124b51b9ac35eed7ab434e44889fc4a7832e98f9ad0a"
+    },
+    "sound/gunner_rifleman/gunner_die_2.wav": {
+     "bytes": 81776,
+     "sha256": "580481f11c28a41cad3eafa2d2d81572bde8e3d11c5ff37695683b2e190b39ab"
+    },
+    "sound/gunner_rifleman/gunner_die_3.wav": {
+     "bytes": 145862,
+     "sha256": "f3ee8527d36f2838586eab08b088eefbe2829ceaefffe6d94fe47ff6f697d610"
+    },
+    "sound/gunner_rifleman/gunner_idle_1.wav": {
+     "bytes": 73522,
+     "sha256": "2ca1b7014f1f3dbf8a90a2d4a5b7a23eb06945077f18228d86ab5d49536bbdd4"
+    },
+    "sound/gunner_rifleman/gunner_idle_2.wav": {
+     "bytes": 106634,
+     "sha256": "51d8246674f8829481407344afceeb609a0eb85d634263b35a13a3ecb3e56c72"
+    },
+    "sound/gunner_rifleman/gunner_idle_3.wav": {
+     "bytes": 101776,
+     "sha256": "ca478d8439edd0fe99b412b215e8ebfd457c0cc6962a6eb3bf6980ad8f6fa95c"
+    },
+    "sound/gunner_rifleman/gunner_idle_4.wav": {
+     "bytes": 92138,
+     "sha256": "ea9001dc810f3825e243d69aed5998ba085a8d948a5847c965beaec48d79ab2d"
+    },
+    "sound/gunner_rifleman/gunner_pain_1.wav": {
+     "bytes": 48134,
+     "sha256": "ca7f1861249ada377f2b7c72739b0ed6e077db2bcc7b2cd70bd3a94a62a61fc6"
+    },
+    "sound/gunner_rifleman/gunner_pain_2.wav": {
+     "bytes": 46964,
+     "sha256": "65b6cbceba1d694831e604ddb45b52e57682db5665d775c32a36333bae90baf0"
+    },
+    "sound/gunner_rifleman/gunner_sight_1.wav": {
+     "bytes": 57682,
+     "sha256": "a3d9ac1a48ae71b34e15e246aff043b696ed2bf2a9d774c55d7b74688e69a8a2"
+    },
+    "sound/gunner_rifleman/gunner_sight_2.wav": {
+     "bytes": 66318,
+     "sha256": "35de4d1c714281c653c17cf7c3c49e123d29421101607af31d58e6943e10ef82"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 109234,
+     "sha256": "65a9c99193607202adf8a0ff0734b8e46abeaea550206b0d59b13f07a245e0e2"
+    },
+    "sound/items/armor_denied.wav": {
+     "bytes": 99782,
+     "sha256": "5998d81a86abf7dbf4b9b16a25dd57b7f0f6cfd834c54c5d469fffb751db8647"
+    },
+    "sound/items/r_item2.wav": {
+     "bytes": 231082,
+     "sha256": "e3737f73e3b312467236b3a725df720fd0ba9c48176ed388e6c1ed480f6f1024"
+    },
+    "sound/items/shard_pickup.wav": {
+     "bytes": 48566,
+     "sha256": "96a870957df39068296974658675439e8eeb2ca1481b43c85b97f420d97864d9"
+    },
+    "sound/items/smg1.wav": {
+     "bytes": 45770,
+     "sha256": "5fcbd74b94289b16000e80a3aef144ec37950f72416c1bf42acb6824a44d3960"
+    },
+    "sound/items/smg2.wav": {
+     "bytes": 45630,
+     "sha256": "26f8c90779ad655e3a9d5e92b2ae0ae8b77f3c7cb134f5c564384c6b109b35e9"
+    },
+    "sound/items/smg3.wav": {
+     "bytes": 45202,
+     "sha256": "50227a8668556017ec9f6c7da9e9702ca08e42ac1fa78fc64d391d2efd9e81b3"
+    },
+    "sound/items/wings.wav": {
+     "bytes": 103570,
+     "sha256": "36c1b41e0331e7c08c5966784cc4610d965c5e00599d67bfbe74fa11dd4ef0ad"
+    },
+    "sound/items/wings_got.wav": {
+     "bytes": 197774,
+     "sha256": "6decbb4644d70e4d2ec284921e9e30dde92d67f15a7f819c737ed7174c8b4e88"
+    },
+    "sound/jackal/jackal_die.wav": {
+     "bytes": 94384,
+     "sha256": "04e02e803ba997cdf81b1c617d436c7ddfd2ec04ac41c276f23e12bbff329865"
+    },
+    "sound/jackal/jackal_idle_1.wav": {
+     "bytes": 157178,
+     "sha256": "011e45abaa00cedebd4a4af161b3452ffcba7bcf21b8b57dd8a6200654fa3a8f"
+    },
+    "sound/jackal/jackal_idle_2.wav": {
+     "bytes": 157178,
+     "sha256": "d4863ffee34e1c24020502caf2c5392cd48adbf42f9a73cef824732a1aba2699"
+    },
+    "sound/jackal/jackal_jump.wav": {
+     "bytes": 163422,
+     "sha256": "0e9104ab4e69608c83edb01ed4c86092e7e1f742d363956025e51a4299074939"
+    },
+    "sound/jackal/jackal_pain_1.wav": {
+     "bytes": 79632,
+     "sha256": "f203e82d6ef25d2d768869cc465c6e335e5419a6cb336b487f75da9932d6e34a"
+    },
+    "sound/jackal/jackal_pain_2.wav": {
+     "bytes": 79632,
+     "sha256": "8d7e269e75bf50a376921b36b94259cc84cf215eee077241892ffd6bd59ec3f4"
+    },
+    "sound/jackal/jackal_sight.wav": {
+     "bytes": 211932,
+     "sha256": "62f544e75c350f70384099c150f4d5241bd99a159a9d0f0e4dc47ba6fbc920f0"
+    },
+    "sound/jackal/jackal_slash.wav": {
+     "bytes": 57344,
+     "sha256": "793e230a3df7da6eed776732446d0a79fa255b27da767bb867ac553c4590f97e"
+    },
+    "sound/jackal/jackal_slash_2.wav": {
+     "bytes": 68108,
+     "sha256": "2ea99ab0b37f1514fcb5422d89edb0f6b6500ee37b624db8516bfe6eec6c98be"
+    },
+    "sound/lancer/lancer_die_1.wav": {
+     "bytes": 110140,
+     "sha256": "0efe888c4e86f1112ccf7bd0429a4e76440d1d6aad50c1408c2cb5a743f26f78"
+    },
+    "sound/lancer/lancer_die_2.wav": {
+     "bytes": 102122,
+     "sha256": "bbd3b8b041a2271f1514878d029fbf8c4c2480b926f0662730c069d89f2ca9fd"
+    },
+    "sound/lancer/lancer_die_3.wav": {
+     "bytes": 102122,
+     "sha256": "ba86ff673e94b8156ec866c7d67a9798990e4fc2d287e9a56abd12ca6b1cd8bf"
+    },
+    "sound/lancer/lancer_fire.wav": {
+     "bytes": 90964,
+     "sha256": "c1b1ce79642323bb48b6421094fd0101a7821267569aa1985db95089c5d0319e"
+    },
+    "sound/lancer/lancer_idle_1.wav": {
+     "bytes": 93882,
+     "sha256": "c9e84a9c20c6ecfc92fb9e80e4e64aac35dc25b017b802a48ea744a4e5171541"
+    },
+    "sound/lancer/lancer_idle_2.wav": {
+     "bytes": 109234,
+     "sha256": "2ac8d779e40e423099be71135a654555727239393cf2b3c3c15caa390f689b20"
+    },
+    "sound/lancer/lancer_pain_1.wav": {
+     "bytes": 36572,
+     "sha256": "8f557ace47518a5308b4fc2d1b00cc4d44fb1b2a64115cbee02f6f117f7da719"
+    },
+    "sound/lancer/lancer_pain_2.wav": {
+     "bytes": 44908,
+     "sha256": "12f17a14ceb1add68533db9f0e4d36970285d91d29be973ce4cf7bb28ddbf268"
+    },
+    "sound/lancer/lancer_pain_3.wav": {
+     "bytes": 36986,
+     "sha256": "717edce61738cbad5a0017abeb09ed07a6734eb09000fa165c539c336cc94f78"
+    },
+    "sound/lancer/lancer_sight_1.wav": {
+     "bytes": 50796,
+     "sha256": "8829a037a04d67cbb68c85c75760ce05ae956d532c0adcf9fc26d34e2344bb14"
+    },
+    "sound/lancer/lancer_sight_2.wav": {
+     "bytes": 83984,
+     "sha256": "546b467d24ad5812d1ffeeafa56868967342af7fe843710fa2fa526916e784f9"
+    },
+    "sound/lieutenant/lieutanent_pain_1.wav": {
+     "bytes": 49966,
+     "sha256": "0bf780e9587fa04c4ab16b05b0759a5121d79a141e575a7fb22434e390cf51ae"
+    },
+    "sound/lieutenant/lieutanent_pain_2.wav": {
+     "bytes": 75444,
+     "sha256": "dc739e4b5e168a4cc28311d715f79ad13a50f18f7d993760ebc7b359ece88e67"
+    },
+    "sound/lieutenant/lieutanent_pain_3.wav": {
+     "bytes": 55262,
+     "sha256": "1739b43d88f1ce687c5d0f6f212eebca41ac7e96c51eff2c86f39d78b039e8cf"
+    },
+    "sound/lieutenant/lieutanent_sight_1.wav": {
+     "bytes": 78652,
+     "sha256": "d5533357338d2f610a8c478bd48858a4fc0c9cfcf046abb8fbc7fd621f535489"
+    },
+    "sound/lieutenant/lieutanent_sight_2.wav": {
+     "bytes": 106084,
+     "sha256": "308d74574d749239f5ad26ac0b91abcd541ca1470844913e1acae261e08cb093"
+    },
+    "sound/lieutenant/lieutanent_sight_3.wav": {
+     "bytes": 113568,
+     "sha256": "cfddcd3e427a97d078176131e078e26592b991a3cd077251cfd6bba1c4b5c402"
+    },
+    "sound/lieutenant/lieutenant_angry_1.wav": {
+     "bytes": 212502,
+     "sha256": "da9ab6c92e48d435fbf3214f5f06a32ce52721c977c96a9524e59746a5952d8f"
+    },
+    "sound/lieutenant/lieutenant_angry_2.wav": {
+     "bytes": 170202,
+     "sha256": "07bddf610b258a74795ee198db2e7c4a18ca53553d445c1e56b51922acd99a2e"
+    },
+    "sound/lieutenant/lieutenant_angry_3.wav": {
+     "bytes": 136882,
+     "sha256": "4785346f43e997b75453b0dd320514645dc694648ce4c866e2b944c8c46bfd37"
+    },
+    "sound/lieutenant/lieutenant_angry_4.wav": {
+     "bytes": 195834,
+     "sha256": "8c2dabef7e09d40d683dabd8aea43cc5515154b423eff6997700e308fa8d4a9e"
+    },
+    "sound/lieutenant/lieutenant_die_1.wav": {
+     "bytes": 173006,
+     "sha256": "78b199665ca0bfcce1132b8196a31420daae984e9a05611190f05c085249c0b6"
+    },
+    "sound/lieutenant/lieutenant_die_2.wav": {
+     "bytes": 184786,
+     "sha256": "e0a0f1695945c4c2b3e71721ac6b6b63703cee6c722ceade86cc1c5ab54b1506"
+    },
+    "sound/lieutenant/lieutenant_die_3.wav": {
+     "bytes": 189534,
+     "sha256": "70fda70b75ad8590e27c4b991e310c6b36a3d0e6e26cca084204a12b64c5e718"
+    },
+    "sound/lieutenant/lieutenant_idle_1.wav": {
+     "bytes": 188260,
+     "sha256": "39ae6e09bff5e4cf05c1a8cd09dbf50a3ce1cbd036131e4f07e46d3740fecbb4"
+    },
+    "sound/lieutenant/lieutenant_idle_2.wav": {
+     "bytes": 237250,
+     "sha256": "b44f808b245b258fb0703aedfc0295c9744f64146b34c4d1f96c429196127d71"
+    },
+    "sound/lieutenant/lieutenant_idle_3.wav": {
+     "bytes": 254302,
+     "sha256": "f4d5dd271fb7c870a3e46eab8b194b0106f2ea971fe36e3d1dc766dc3ca6aeec"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 125320,
+     "sha256": "6ca1f5973a5a60163a4984560cf846f51f8ff6d9197e6b4630aa43cd442a67e6"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 97580,
+     "sha256": "a7ce6c01fa5833a1f7d31ebe64070a76b44e0c95dc2e674393716ca16fb6d1c7"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 105378,
+     "sha256": "fe26eff88c701d0921748ae9dfbfdded5b73954274d1c9a0dacd6229df9c067d"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 105378,
+     "sha256": "e0261cda5057670c5c54ba2a5b96f44a0f353086c263351bbb9bb536f9e2a681"
+    },
+    "sound/misc/fall1.wav": {
+     "bytes": 23396,
+     "sha256": "162fc0be1cd0eadfc93c35f1e1ba9b8dfc7e8df8ee53afb2a14db73e69f20ce8"
+    },
+    "sound/misc/gibs_1.wav": {
+     "bytes": 127740,
+     "sha256": "7d157481ea27c885f7fff6a92ce3fd3d2f7bf258f3671a8f2b09e2b2b2e5b7aa"
+    },
+    "sound/misc/gibs_2.wav": {
+     "bytes": 124928,
+     "sha256": "fb0b9879a279548ba2b702459866cb4b114346836aabaf9f97d0957c548c0d5b"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 33216,
+     "sha256": "e0dd92dd8cff85cef09356bcb83c57a683abad9f46282005df5dc47e22b48972"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 34028,
+     "sha256": "35171a45005266075c812ec29eb42a266de19ceb2671744030d937b9d040f861"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 94180,
+     "sha256": "2d224100469c02e7095c12c090f13ad4884dfcaa00a97b0fd526927174a46c67"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 126388,
+     "sha256": "c70c84798b15b1613c6d2588f758e0893dc1f94e7c1f203caf8d6ef5eb1cd5a0"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 9702,
+     "sha256": "8b21c1906ec134d7cfdee540bdeb6a1b67d558d8d9f8f0d766ac767e5e1ec676"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 11968,
+     "sha256": "5a5a2aa2435f297cd1af911fa5ebc5d64662aeaed72b38981aa52bdb50008059"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 17216,
+     "sha256": "17afcdb5887785b5556169435709c4ceaa12b97f3b999c34a439f1cc4d9bde6e"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/singledrip1.wav": {
+     "bytes": 26546,
+     "sha256": "b9193092eaa02003c7ea409663dc1213f0a18a120471a76d298ce847448059b6"
+    },
+    "sound/misc/singledrip2.wav": {
+     "bytes": 25478,
+     "sha256": "562ac78cd1d84805723e3bb24f66c60197d03bab081d7ee8402bf2b59bc7bf0c"
+    },
+    "sound/misc/singledrip3.wav": {
+     "bytes": 44558,
+     "sha256": "55ae1b970143af2553b845503363d94aa917a1cdb8aa1e48edec7869660007c3"
+    },
+    "sound/misc/singledrip4.wav": {
+     "bytes": 45492,
+     "sha256": "db0126239cf71ce69f6c06eb5c5418889b96e52e6741f6b172a146887e6815ef"
+    },
+    "sound/misc/slash_1.wav": {
+     "bytes": 38930,
+     "sha256": "d48b3fa09f1a783d12d7d5b3506d672e2a0bdab611c74ff70b77af8fe8250e15"
+    },
+    "sound/misc/slash_2.wav": {
+     "bytes": 43494,
+     "sha256": "b0e3c201b070a0ceaa26d2e5d9452fe1c00712a3459b152fed42d6079f665b4c"
+    },
+    "sound/misc/slash_small_1.wav": {
+     "bytes": 38278,
+     "sha256": "9c456a01aa6f779d5f05d238aa184a7a5ee3c6f2893845915b8d4b01e87527a6"
+    },
+    "sound/misc/slash_small_2.wav": {
+     "bytes": 41546,
+     "sha256": "3ad19503decd2c6aab4b2d780959597a88936b51fbba3a9ba2f5376981f1d115"
+    },
+    "sound/misc/slash_small_3.wav": {
+     "bytes": 49170,
+     "sha256": "0239727972413ba0fc40152dc43548090a79dd2d5c02ba1f87d55a742cacaad3"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 241534,
+     "sha256": "1632c537dda0baa51135b8f0081faf97a51d8e8da540076af37c6d7a88aac6af"
+    },
+    "sound/player/enyodie.wav": {
+     "bytes": 128232,
+     "sha256": "cc83abcac88721a94b2847bfb370025bd704de1e40257303007f50a93fac44dc"
+    },
+    "sound/player/enyojump1.wav": {
+     "bytes": 64902,
+     "sha256": "2ea233bcdfa4bbde47464ab8b5d50106694823f667d705a443bed146690aaa6f"
+    },
+    "sound/player/enyojump2.wav": {
+     "bytes": 46556,
+     "sha256": "1de133a6b4b3809c50c0412090fedfe4011d5560c4850776fc567c3c67fd4b83"
+    },
+    "sound/player/enyojump3.wav": {
+     "bytes": 43328,
+     "sha256": "744650a950f64c3bd2a888a6910540e77468149898c3f0080cd19d77221ad21a"
+    },
+    "sound/player/enyojump4.wav": {
+     "bytes": 51348,
+     "sha256": "cad25072428129fa567d953a1e79cefad2c786545de16a6ae7eee0bd00ca052a"
+    },
+    "sound/player/foot1.wav": {
+     "bytes": 17336,
+     "sha256": "ce2e4fe162525349036e5049f107e4fd9155cdc3702c484bbba165b9ec5e7e86"
+    },
+    "sound/player/foot2.wav": {
+     "bytes": 15460,
+     "sha256": "59ed2f06669ae7264667c3d3220600ad59d8572841594cd283ffad3b7940646f"
+    },
+    "sound/player/foot3.wav": {
+     "bytes": 14764,
+     "sha256": "56b3d6834b5831019d47a982381dba239b29e2a799487c0872cb6e349225212d"
+    },
+    "sound/player/foot4.wav": {
+     "bytes": 15522,
+     "sha256": "feb59a1f76b30dfdef227a085427103aa43ba8c05c5d4f28e9ade5c6e009fe75"
+    },
+    "sound/player/foot5.wav": {
+     "bytes": 17276,
+     "sha256": "eb1ef5b1d117076767974cf338d25c380d4e007d97363a4766be3b60574a2be3"
+    },
+    "sound/player/foot6.wav": {
+     "bytes": 18958,
+     "sha256": "ca2aea32f5336eeb313812ae359dbf8e13de4aab0ad0fc6ec77d4850cdbc6699"
+    },
+    "sound/player/foot7.wav": {
+     "bytes": 15922,
+     "sha256": "e521b24b0e0db25de3298c106f4137f1ac41ca18617794063c5b52ccfb68ef47"
+    },
+    "sound/player/gasp1.wav": {
+     "bytes": 76986,
+     "sha256": "628c7194ddb91ebdc72979f36bc7a5d6e50879c9d5cd28f05cd762889c6bb65a"
+    },
+    "sound/player/gasp2.wav": {
+     "bytes": 96896,
+     "sha256": "f1abaec13d4e68dbfae9d5983a898af573b52b5bd9dcecdf60baa175c3823ff1"
+    },
+    "sound/player/land.wav": {
+     "bytes": 43424,
+     "sha256": "2f8d3837be1ba7b8edb77f50e681705463e9da73370b66d7fa4cfb3faffc8f12"
+    },
+    "sound/player/land2.wav": {
+     "bytes": 66106,
+     "sha256": "94c3d6046ff474cfda2c6c0727ef62294d479b1d7b6002049799a9183793a1be"
+    },
+    "sound/player/land_alt.wav": {
+     "bytes": 44180,
+     "sha256": "58ce779cec19734c5489b53a6933483644b96657fcd72bc81e14325b3f6ee6d2"
+    },
+    "sound/player/lburn1.wav": {
+     "bytes": 79352,
+     "sha256": "39c5b7dd67dc581591e50687233f77f55effbb67836b5656b9850195a9e0a9d9"
+    },
+    "sound/player/lburn2.wav": {
+     "bytes": 74840,
+     "sha256": "abb078f8ad80731de374b4c61de1957f800f5849103c3b030d3baf2d3b3944e2"
+    },
+    "sound/player/pain1.wav": {
+     "bytes": 66204,
+     "sha256": "7f77cee6cfe0cc675a4a4853f96ef75ded07580893e10cff6aa8e107f5a2ab89"
+    },
+    "sound/player/pain2.wav": {
+     "bytes": 58590,
+     "sha256": "1f68cc8fbe1edfff32acd9a3e18ef72c595a66ec7bb4dda0635bd13db6d64427"
+    },
+    "sound/player/pain3.wav": {
+     "bytes": 56338,
+     "sha256": "d354bbbf71750e602b973218b30630afc12c7d55d86ef33693685b34112102dd"
+    },
+    "sound/player/plyrjmp8.wav": {
+     "bytes": 67452,
+     "sha256": "b7ace160b1c27f10268fcf36c79e1660354600ed02ae81efa94bd898ac1df7df"
+    },
+    "sound/slavealpha/angry1_l.wav": {
+     "bytes": 159030,
+     "sha256": "317a84252acbff8f7d2a2bd3d716dffbd763c3ec9dff7fed077a48b3280d99b6"
+    },
+    "sound/slavealpha/angry1_r.wav": {
+     "bytes": 159030,
+     "sha256": "303ad704a383dc4ddb4e69e619fdf7dff742212b4d65b7825b76a6d4453cce19"
+    },
+    "sound/slavealpha/angry2_l.wav": {
+     "bytes": 117562,
+     "sha256": "72c00d5a27c10afe446993f63937035bfc9e7277fbd28e5cbb5f1e1f18de83bc"
+    },
+    "sound/slavealpha/angry2_r.wav": {
+     "bytes": 117562,
+     "sha256": "ae5c15cc53f8a1037bc89bbf8215bb7fb168806ad2404f42270ceaf51bb95fad"
+    },
+    "sound/slavealpha/die_l.wav": {
+     "bytes": 314360,
+     "sha256": "f1ffb96370741a5c973e70029336bb9263def80472c93e50a4d241518863b6ef"
+    },
+    "sound/slavealpha/die_r.wav": {
+     "bytes": 314360,
+     "sha256": "9ba0f36544aa3db5a482d61a7e10cc745303ca85fde071876c29410ff23c0c3f"
+    },
+    "sound/slavealpha/pain_l.wav": {
+     "bytes": 144514,
+     "sha256": "0bd5fd4d238b2dfca60ee47e5dfcc11fb34eeb023b5f4eebffea82fe95348025"
+    },
+    "sound/slavealpha/pain_r.wav": {
+     "bytes": 144514,
+     "sha256": "20a28ff2ac9a6da051c1a5b73c7ad68d483f02ed970a80ef3e187af08373b55c"
+    },
+    "sound/slavealpha/sight_l.wav": {
+     "bytes": 184104,
+     "sha256": "2cbf8306a1b40eca54a468c77e9cfd4c6a887041bb7e21f28a37aa1a750cc096"
+    },
+    "sound/slavealpha/sight_r.wav": {
+     "bytes": 184104,
+     "sha256": "17253694b36709d538d2338e8f143f27933dd0e31a5ea082d44a1e2e65fc8c7f"
+    },
+    "sound/taunts/beloved.wav": {
+     "bytes": 91998,
+     "sha256": "3841007c8c632bc0c0d177fd17ac49acb762022a954489cf2446c46cc4d66f92"
+    },
+    "sound/taunts/bleed.wav": {
+     "bytes": 66344,
+     "sha256": "7839e819a697320b33a0b733b8ea32a6ce20bf25146b0582a4ccf7a0bed6b1a4"
+    },
+    "sound/taunts/buckshot.wav": {
+     "bytes": 67800,
+     "sha256": "8847b3ca3a11d1329d0bb885315bc537358e9cbfccf5edadfcbe6d007207818b"
+    },
+    "sound/taunts/deathfromabove.wav": {
+     "bytes": 94600,
+     "sha256": "1bc655805a4cbe3b7af133d5c1ad601b1f3d3935b02ee8b6e4758bc5fdcb56de"
+    },
+    "sound/taunts/didthathurt.wav": {
+     "bytes": 74038,
+     "sha256": "4f399cb4051566ea1d818d32831dc085a82bbcdd035771a55323088198f6e984"
+    },
+    "sound/taunts/dogethis.wav": {
+     "bytes": 67162,
+     "sha256": "042961c82af7be6eec345bbd48ef6259598a5a89f8013986e0d9823429241026"
+    },
+    "sound/taunts/downboy.wav": {
+     "bytes": 72964,
+     "sha256": "c5e4a2399626c336a6957729d74f8e0bf1e76c955a275ae702ebe3693180d8fc"
+    },
+    "sound/taunts/eatit.wav": {
+     "bytes": 49264,
+     "sha256": "0d34e38d544b221f7e70d16ee4060ecabf68a497caa449e709010a121b030112"
+    },
+    "sound/taunts/flymydarlings.wav": {
+     "bytes": 121582,
+     "sha256": "188079852eec4a2dba756cc52c222b9407a77301eb28866eb3ab3c5a968c78f3"
+    },
+    "sound/taunts/gotyou.wav": {
+     "bytes": 61094,
+     "sha256": "bfeb3d28caab9cf7f8a87d6b855bd4e6045c8c4808ef803be7156cdadbce0afa"
+    },
+    "sound/taunts/handsometrophy.wav": {
+     "bytes": 153988,
+     "sha256": "26d209593302a2f3e22dff3d1ae7b3675e0b4fa2c995c75693de3979c246d382"
+    },
+    "sound/taunts/justgettingstarted.wav": {
+     "bytes": 103436,
+     "sha256": "8f45c10ad4b60b2902f0b9f7166adeff6bded303becbc37cf97aa6d05680ce60"
+    },
+    "sound/taunts/looksosmall.wav": {
+     "bytes": 154904,
+     "sha256": "1ee07e103985c78d4b6d66e131155c626d9a8f031940c004436da0dbff4d20b9"
+    },
+    "sound/taunts/maniaclaugh.wav": {
+     "bytes": 112750,
+     "sha256": "0df1eb35a460e7358855f0fdb4e5db4c99c2c651f97e01b022b75c92f2825bce"
+    },
+    "sound/taunts/mindyourhead.wav": {
+     "bytes": 81732,
+     "sha256": "93ec5c2839e0c346e57d7318887558f19514734e3fdb5f21036f3fa45cf131a6"
+    },
+    "sound/taunts/pinkmist.wav": {
+     "bytes": 171114,
+     "sha256": "102994c64c300977f5d8ef9bfab603e0aea706710a439267595f3cd27e5b6920"
+    },
+    "sound/taunts/scrapeoffthefloor.wav": {
+     "bytes": 115728,
+     "sha256": "00c681b8d643a2db8d08e47c19da9c6cc88dcc6d62677eb62b6646cbb02d2037"
+    },
+    "sound/taunts/targetlocked.wav": {
+     "bytes": 63904,
+     "sha256": "20cdd6ab9f7252058be2857fc118ac53c571bdcb17b2a690be71ad40a9f08848"
+    },
+    "sound/taunts/whoops.wav": {
+     "bytes": 52998,
+     "sha256": "d62c410c1f620719ed0dea8f4b376e9a0b539375797ac3428fcc0421d38909e9"
+    },
+    "sound/trooper_commando/commando_idle.wav": {
+     "bytes": 90360,
+     "sha256": "caf1f9a66ac0658293d26c9184ef80b46b7c54675093986f0b1e4cd833c3f275"
+    },
+    "sound/trooper_commando/commando_sight_1.wav": {
+     "bytes": 110418,
+     "sha256": "0bb98f3c0ce88ffb243fda3f98f71436dc1863946ea8c78b65e2a02cc6d669ed"
+    },
+    "sound/trooper_commando/commando_sight_2.wav": {
+     "bytes": 105916,
+     "sha256": "71f481995dc92d46c71faf19b3d8ad1bfbed4100d09c4c24e77afbefaf44d974"
+    },
+    "sound/trooper_commando/trooper_angry_1.wav": {
+     "bytes": 50442,
+     "sha256": "7fed95b0d177315c04ec9cb4eb72665d6eef9f784afdfce1624642c8df31a380"
+    },
+    "sound/trooper_commando/trooper_angry_2.wav": {
+     "bytes": 91026,
+     "sha256": "7057550990ad28b996360759c47f81590f80d07d7d5cfaa2b2099a4c9d9547fe"
+    },
+    "sound/trooper_commando/trooper_angry_3.wav": {
+     "bytes": 75566,
+     "sha256": "ce1a0f047dc068e64cd6528df16bf675c169ca0b6e60fe88d928d71f570b7d40"
+    },
+    "sound/trooper_commando/trooper_angry_4.wav": {
+     "bytes": 43676,
+     "sha256": "b8427f9515a5ea123086226b8f2452bdd518980c77c5bab1a6982106226f0a8b"
+    },
+    "sound/trooper_commando/trooper_die_1.wav": {
+     "bytes": 107548,
+     "sha256": "b96b526578f4c8636f185c8e9a936d92211a6692d8544144d0f791101f35fe92"
+    },
+    "sound/trooper_commando/trooper_die_2.wav": {
+     "bytes": 103090,
+     "sha256": "c5b567bd4b652209a2b757100fd4f8a52a98e1586c2f12e5db4fe32bff19d004"
+    },
+    "sound/trooper_commando/trooper_idle.wav": {
+     "bytes": 85042,
+     "sha256": "93d332174a07720d5e6d7beb0174e0ad828685831495b68e0cc23cfebe1f6b11"
+    },
+    "sound/trooper_commando/trooper_pain_1.wav": {
+     "bytes": 37740,
+     "sha256": "3898fb04b30a2ea30a81d7afc24c2f4074aed7c621431c77628785d0159127cf"
+    },
+    "sound/trooper_commando/trooper_pain_2.wav": {
+     "bytes": 32378,
+     "sha256": "285dda2a84221b5f85272cbd92c9cb73c53d73c4c68aadae92d29b8cfb8d71d3"
+    },
+    "sound/trooper_commando/trooper_pain_3.wav": {
+     "bytes": 43528,
+     "sha256": "fd978235f564c5cb4630201ef29a7da0ea3efe77be1b78cbe4ee27e8e37ad408"
+    },
+    "sound/trooper_commando/trooper_sight_1.wav": {
+     "bytes": 68932,
+     "sha256": "b6f7eea870784939159af38b8a86a3b6f25421c2ae50a4708dcae8a5204135ea"
+    },
+    "sound/trooper_commando/trooper_sight_2.wav": {
+     "bytes": 77194,
+     "sha256": "accb3c737b67892acc9a8e421a1f39e3d4eb4d7d5f67c1c8fde14de2ce0a87e9"
+    },
+    "sound/weapons/ak1.wav": {
+     "bytes": 36824,
+     "sha256": "f163c67b9c7bdd04fbbad43531c47863808d3eed8b25f07c2d3a6326290e79ac"
+    },
+    "sound/weapons/ak2.wav": {
+     "bytes": 36824,
+     "sha256": "089d12a77bfbf76d94fa89069d1df36a8abc4f073ba0bfb96d195c48a7f209bc"
+    },
+    "sound/weapons/ak3.wav": {
+     "bytes": 37164,
+     "sha256": "1a8c60a9afb6a127bb3f22e62ac2439c480ca5d577a52e26a5101475db6fd2e3"
+    },
+    "sound/weapons/ak4.wav": {
+     "bytes": 36960,
+     "sha256": "b4f48cbf65831f093a10d7db32533c2f856d66a5cd45f99a28662947e901f2c6"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/ee_rocket.wav": {
+     "bytes": 156646,
+     "sha256": "77d5318321728ae68c4721f1ff7081ca5de996b3c2087bfaa7417cecf2335eae"
+    },
+    "sound/weapons/hplasma.wav": {
+     "bytes": 48538,
+     "sha256": "a92d340b4b0895e1b585c09e855502b91e95ff57a1dc9cb69805bd4b68b7baea"
+    },
+    "sound/weapons/pistol_blast.wav": {
+     "bytes": 98896,
+     "sha256": "8b41826a474001c053ef9ab5c8124ed8fc9de1d1604978e080d5a75fe82782f3"
+    },
+    "sound/weapons/pistol_click.wav": {
+     "bytes": 34348,
+     "sha256": "73a9846d2a15926e1608b405be772eec5e623c9d99d507edcf8334f4ef87a79e"
+    },
+    "sound/weapons/rail2.wav": {
+     "bytes": 161614,
+     "sha256": "512c2b7fe381735175913f06e8f68630f2291c167f16f1d40d3ec3b67f6f0675"
+    },
+    "sound/weapons/railwhirl1.wav": {
+     "bytes": 50854,
+     "sha256": "0e30ac4bd2b16b30abf4f09dea064d58609baba6fef2443cccd4088f36c0aa47"
+    },
+    "sound/weapons/railwhirl2.wav": {
+     "bytes": 103784,
+     "sha256": "88e6db3ffa74b838a3f891b595cc36a66403ab31b0e09dd7df103b7cc3663069"
+    },
+    "sound/weapons/sgblast.wav": {
+     "bytes": 107764,
+     "sha256": "e57bd9eaa2b7fdfdaf12da6be7cb958ec92622486ede4b0d4eae3e1233ca6705"
+    },
+    "sound/weapons/smg1.wav": {
+     "bytes": 45770,
+     "sha256": "5fcbd74b94289b16000e80a3aef144ec37950f72416c1bf42acb6824a44d3960"
+    },
+    "sound/weapons/smg2.wav": {
+     "bytes": 45630,
+     "sha256": "26f8c90779ad655e3a9d5e92b2ae0ae8b77f3c7cb134f5c564384c6b109b35e9"
+    },
+    "sound/weapons/smg3.wav": {
+     "bytes": 45202,
+     "sha256": "50227a8668556017ec9f6c7da9e9702ca08e42ac1fa78fc64d391d2efd9e81b3"
+    },
+    "sound/weapons/sword1.wav": {
+     "bytes": 44836,
+     "sha256": "6049393e32aacb60e2393da6557ec992350631ebcf948824ede22e749d3a7eba"
+    },
+    "sound/weapons/sword2.wav": {
+     "bytes": 44836,
+     "sha256": "8ad23cfe0c9f3dc555287dd9923faf794c8ad8be82effa2f11863d76c8344e71"
+    },
+    "sound/weapons/sword3.wav": {
+     "bytes": 44836,
+     "sha256": "ae202290d52822864bc145c754913a53745aa880be021eacc25202e479bc1b05"
+    },
+    "sound/weapons/swordhit1.wav": {
+     "bytes": 49440,
+     "sha256": "b55eea3e9f4a2aa6cac0965f0f11a001047f75cb3d599f0ea4cf840314fe89c7"
+    },
+    "sound/weapons/swordhit2.wav": {
+     "bytes": 55326,
+     "sha256": "688270bc26b420053c98d94869efb39eb4950dab623584888eb4ed87fe7517cc"
+    },
+    "sound/weapons/swordhit3.wav": {
+     "bytes": 48970,
+     "sha256": "aafb92ce9b4e58cd3ccbd89ab41602d31c72ce64b7bd937ac7b547141668feeb"
+    },
+    "wwheel.txt": {
+     "bytes": 1526,
+     "sha256": "221b27a2dbb7463fea3d34268ec9869db2bc4b722dee2e3a4847089480363abe"
+    }
+   },
    "sha256": "93b1fcc32084ca85bc2878e38e7a091eee6965134a36d968c50ce9d08bd4ec9c",
    "timestamp": "2024-01-15T09:59:40.000Z"
   }

--- a/json/by-sha256/48/484334d9305c5097b8b735bd1b91d943753c5fd77d65401b519b84b93c00f82c.json
+++ b/json/by-sha256/48/484334d9305c5097b8b735bd1b91d943753c5fd77d65401b519b84b93c00f82c.json
@@ -32,6 +32,356 @@
   },
   "copper/pak0.pak": {
    "bytes": 4227276,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "591744734a43a1563ee0e419fb2464783c70a3245c14e09ff5c3f022418f1e4c"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "1bbe11eff4ef46f43af7bbc7be43c69cf76543ce7fae26931939a541cb8cdae6"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "fc226280c4948249790f00f97dd9b39e912131fc904ec75adb90308ba8763afc"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "9eee444c1db402805bcff09378344c5a048b6c23ff6054edbfff16dd60b76f0d",
    "timestamp": "2022-07-01T21:05:10.000Z"
   },

--- a/json/by-sha256/48/4898516ed8cb76236336d9b3b7c07facb157b72d7e74bc2dc1ad83f8ba707080.json
+++ b/json/by-sha256/48/4898516ed8cb76236336d9b3b7c07facb157b72d7e74bc2dc1ad83f8ba707080.json
@@ -7,6 +7,32 @@
  "files": {
   "Pak0.pak": {
    "bytes": 2501096,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "7be59b5215e4fb29572a319a3acfe323f14d1e4d785c56b1e0ff8afd8541e583"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "03bb2ac9f945bec9dd0f2f79aaef4a6738565eab0d13aa350831b09ce3b9c915"
+    },
+    "maps/med1.bsp": {
+     "bytes": 1451320,
+     "sha256": "a7aeb7c16e6c9f4d7a9e4d2a8c029ccc0da13c4537f325dae1b86c82094440e4"
+    },
+    "maps/start.bsp": {
+     "bytes": 803016,
+     "sha256": "fdbd943b89d2de34300ac091b9e8282b98f49df984f61e5d905a3f7e2bcba484"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 150466,
+     "sha256": "2cd1457acabf59d1ac395652f47399ac86997e7067b557a694bb59b2da6444d2"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 27274,
+     "sha256": "a9143a833b02b2e2927fbcce24334a4bf0d29bb872a0038e385a541884baa476"
+    }
+   },
    "sha256": "e1975c2e6077cbfadb57ce5baea8db6f6c382124b1c142c5ba37494daf40f506",
    "timestamp": "1996-05-06T17:20:50.000Z"
   },

--- a/json/by-sha256/48/48d450ab6fb188d5930846eb8d786ec49581aed366b819ad9418bd6a8deec770.json
+++ b/json/by-sha256/48/48d450ab6fb188d5930846eb8d786ec49581aed366b819ad9418bd6a8deec770.json
@@ -12,6 +12,88 @@
   },
   "pak0.pak": {
    "bytes": 12046728,
+   "files": {
+    "gfx/env/lunabk.tga": {
+     "bytes": 478224,
+     "sha256": "87b4c39754a3fd9531ef75e43312b6c72f6c26b0e40d1a7a5b7d3805c449e90f"
+    },
+    "gfx/env/lunadn.tga": {
+     "bytes": 771175,
+     "sha256": "7615107cd7f94f1de5522a638accf1e4df06b0303bbab865c95c5b74daea2e40"
+    },
+    "gfx/env/lunaft.tga": {
+     "bytes": 459013,
+     "sha256": "6b078b9f3924d921edba49f257c183f0f3a871bd0485d28a40a523994ecfb235"
+    },
+    "gfx/env/lunalf.tga": {
+     "bytes": 451487,
+     "sha256": "2ae012ee28612b2d94d8d3187010831119e8114444fa070c9da413019afb0ca6"
+    },
+    "gfx/env/lunart.tga": {
+     "bytes": 440493,
+     "sha256": "70bc049812b0b0dad4793dd37c58b8eade9897f1e203238898fb9d6014bf0019"
+    },
+    "gfx/env/lunaup.tga": {
+     "bytes": 91435,
+     "sha256": "6d06547dc10573ddaffbbafa8b723fdc30f5831be5cb71728d9595f6a72af227"
+    },
+    "maps/event.bsp": {
+     "bytes": 6698960,
+     "sha256": "cd7606394086b575c75b7bf463a036977f52d1b89d409574a34bc5894bd068b9"
+    },
+    "maps/event.lit": {
+     "bytes": 1912364,
+     "sha256": "8f34d5a7d54e4ea6fc1d2467b62e813a76a5622b581fabea382cad2dbf2715c7"
+    },
+    "progs.dat": {
+     "bytes": 432352,
+     "sha256": "05b0b0d39bd98bd3dd0047f7dbe7ce54afc11d1e5cb7ef7e037b7aad84a03e5a"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "c6461c3dcf90e4213f4eab64d89d20a27a22dd344100cded0576396a80636af9"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "5f770e264c3854f89f3f9ffc67810ba0127629a66825337b695ba16898f5d6e9"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "c85c8e627e9a3be2e9d3c15e3a571fb21117e8dc208fdf2fe23868ac0a6cacf5"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15692,
+     "sha256": "72e737f04f1d34044dfd812c6b0e233cd38a91e6b089633e312678756952de87"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16625,
+     "sha256": "bd4cd7902712282ef8f2f749e6fcf805c2ac5212994fbb1c22fc0fe0ea5d08e2"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15527,
+     "sha256": "0b472a984137667f4788336a4f7c60e07a8893f47317b2a158aeea39920d729f"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4107,
+     "sha256": "8fe56b192838dafdf7ff4737cf1e5555d3295cbca49c1ab83568281ee188153c"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8122,
+     "sha256": "3ea23b8d7a68e754211a10a5338b0c8d65df6e2138d4cfe06cc053b9a0f601ae"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13081,
+     "sha256": "a5ec6d4eaa707ad0246b7a7e7737b1007043ea5e5634f6f63661ecc20c27c459"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48508,
+     "sha256": "b7aac875623f8dca7597eff3dcab5910453d043fd1f9df20da89232ce8bf9306"
+    }
+   },
    "sha256": "a0f9b719d9e75989d38abc62abcf124c27af709b8392e1231ce65c7f9919aac0",
    "timestamp": "2006-03-28T20:00:24.000Z"
   }

--- a/json/by-sha256/4a/4a7faf05a650a34b2f48bf24cf2974602655f35a5aed78f3abc6854ce26dec56.json
+++ b/json/by-sha256/4a/4a7faf05a650a34b2f48bf24cf2974602655f35a5aed78f3abc6854ce26dec56.json
@@ -17,6 +17,38 @@
   },
   "rain.zip": {
    "bytes": 225358,
+   "files": {
+    "rain/Progs.dat": {
+     "bytes": 414924,
+     "sha256": "6235c59bea62242761e305b9ef141e503beaad903e757bd1df5e76c80d2b693b",
+     "timestamp": "1996-12-06T23:26:14.000Z"
+    },
+    "rain/maps/raintest.bsp": {
+     "bytes": 120608,
+     "sha256": "7be4423a160ada9deabf9de9ae4296377d6910464ee318fa921357824a8ad0ad",
+     "timestamp": "1996-12-09T16:44:06.000Z"
+    },
+    "rain/misc.qc": {
+     "bytes": 17447,
+     "sha256": "c69bd8dbd803108dae98fb37d7bbbf392f119f4b46d90f46338ea8a0cd83c5c3",
+     "timestamp": "1996-12-06T23:25:22.000Z"
+    },
+    "rain/progs/s_rain.spr": {
+     "bytes": 37196,
+     "sha256": "cc6facb55b73827c89b9459665a1969468119a9e4465debc741da1c892373a4b",
+     "timestamp": "1996-12-02T17:26:26.000Z"
+    },
+    "rain/readme.txt": {
+     "bytes": 2116,
+     "sha256": "2a4a797b2dbebc6a577177b4ed2983dc0b4a870f482d9a1d8524556642402be7",
+     "timestamp": "1996-12-09T17:20:10.000Z"
+    },
+    "rain/sound/ambience/rain.wav": {
+     "bytes": 91202,
+     "sha256": "a196a2fc8a052368f9e8f7efe853391d1a99dfb1f6afae4fc7038222f2eb6fda",
+     "timestamp": "1996-12-09T15:55:56.000Z"
+    }
+   },
    "sha256": "5f4f4b661dcc4faf7637c718d3b98cd129c7c4aa0f6b7192114c87ac6664a2f3",
    "timestamp": "1997-02-20T15:42:32.000Z"
   }

--- a/json/by-sha256/4b/4b283bc7ab9e16cdd9035008e0d0ec2a57df6ae14a3cb1656201a29432f6152a.json
+++ b/json/by-sha256/4b/4b283bc7ab9e16cdd9035008e0d0ec2a57df6ae14a3cb1656201a29432f6152a.json
@@ -32,6 +32,812 @@
   },
   "pak0.pak": {
    "bytes": 11231559,
+   "files": {
+    "maps/drasticl.bsp": {
+     "bytes": 1256400,
+     "sha256": "4be23b5238c1abc8800f1cbc03dd78bb7644a2051cebcc1c5c4e23dd44f4b31d"
+    },
+    "maps/drasticv.bsp": {
+     "bytes": 1254988,
+     "sha256": "a8b4860a93f53b3da885ef9f940d6bf4dde6872558e8b9e584ac121b0ef6565a"
+    },
+    "maps/drasticv.txt": {
+     "bytes": 3713,
+     "sha256": "382d01d4d1e80f23d8ab14ba6ff2162a803b837685b2bdd1e6da475c8bc73ceb"
+    },
+    "maps/tree2.bsp": {
+     "bytes": 41608,
+     "sha256": "4af5e211703d8a9cc4585fd72a687622dfb7b07e5ce315c13014194de532b2ba"
+    },
+    "progs.dat": {
+     "bytes": 661632,
+     "sha256": "20dc779a794f96c7302138b643b559339cd568348d8f6cfd8e129ca59ddfbd7a"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 30028,
+     "sha256": "340c09ed9270661d86dbb1689db237e10f872757046442494f0664e69ff29526"
+    },
+    "progs/b_gren.mdl": {
+     "bytes": 2244,
+     "sha256": "67b927e501bb22023ac33b7f94129ceea64727c5eb4bb4655e22c0ec9302e377"
+    },
+    "progs/battle.mdl": {
+     "bytes": 160688,
+     "sha256": "2aa81872e6a80c471a56d7199939108f3b312950942d72f64eeb2dec5cdf4188"
+    },
+    "progs/bfg.mdl": {
+     "bytes": 17140,
+     "sha256": "0c2d55fdf3de83b3b9f3ed2ad9e9fe0e962d8b46479b97adfc1ed0252718526e"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/blarg.mdl": {
+     "bytes": 123740,
+     "sha256": "1eabc36dc559cfe8a0c1a712d3de429787df488bbeea133fbf4ffffe547716ba"
+    },
+    "progs/blulaser.mdl": {
+     "bytes": 11348,
+     "sha256": "601c26ff0ffed9e2687196e6012baa0b9c5caa1224effa606202f9eeb2e1052d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 65762,
+     "sha256": "086c33b9fc5d32013bfe5e087aa637bcd16cfdd9ebb13d55f77e1d56cfaacbbe"
+    },
+    "progs/bolt2.mdl": {
+     "bytes": 65762,
+     "sha256": "7963058424a0dde74d1f137eaf5e0068e7c562403f962944f60b6bb661921889"
+    },
+    "progs/cellcase.mdl": {
+     "bytes": 7474,
+     "sha256": "fdd164b389fc06fc3b1dfd86fb5f49c1341efb24527a764ecc45599d03f4fc4d"
+    },
+    "progs/charge1.mdl": {
+     "bytes": 36972,
+     "sha256": "0e46b3fb250ff303cb4402d6aa9334205bdab56c8c7359d292ecf6757f49409b"
+    },
+    "progs/charge2.mdl": {
+     "bytes": 36972,
+     "sha256": "425fbdbac712c361168d5be84c5afb960cb450e103fe75ccb37272039c26e8f0"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "6e2fd875956e03ea76f16bc69a43749d87ed2e8216a8653234792b8dbb9fc1c2"
+    },
+    "progs/demon.mdl": {
+     "bytes": 331607,
+     "sha256": "700d67c4a95965453d8da6cdb45277d4af6053d0073f9dc602ca2979a3f909fd"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 60583,
+     "sha256": "c0031bff165881be1d0c26be434f4b1eeecc3e3c56c9b9fcf75b84b8da2c8ce5"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 281477,
+     "sha256": "3276aa92c8f625f61310f69f290a6051016ecb90e0355aad46a1e0c8c7568ad8"
+    },
+    "progs/ff/ffield.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/flame.mdl": {
+     "bytes": 46364,
+     "sha256": "87fab4f530851406e6eed33b50d924689f35a58e5c32f93eb340b07d6bc22b99"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 64572,
+     "sha256": "fae0d18aa39a24461202767804eea0d9aec11f8962e7c9170fd23289c7af1778"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 34700,
+     "sha256": "427b48f83493956b49e32024333d4db51b78cf1f79a45f130f98f1e99783e42a"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 30720,
+     "sha256": "708ee4afc78acc2ac37487e8714e7761de6a49b192524cbb41437c1e52e31685"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 9186,
+     "sha256": "01b02034ee594b716d7bddcb20e32fd89ad9ccc7ddb1461f78a27dc1b93d0a00"
+    },
+    "progs/gun.mdl": {
+     "bytes": 75867,
+     "sha256": "42c483ec803f83d94dac2eb95196961f756fe1d8237697ec1790a5453aacfe94"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "53539bc39fc87627a46b75b0d86ade5e6116a0079b032b1df137b2425b7186cc"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 51290,
+     "sha256": "47889ba0fd80d5b67bccea1818bd043f9c77891fc6510c7f0081d8c5e3a69a33"
+    },
+    "progs/h_player.mdl": {
+     "bytes": 7156,
+     "sha256": "769ff9dcac6f44501538ceeed5f5b0012f879b073f8c3698c66ff18de94feee2"
+    },
+    "progs/iceblock.mdl": {
+     "bytes": 10196,
+     "sha256": "85c358c4643258979d1596e6f05aaa1bbf7473f06dc962abe07e4e260dd406b9"
+    },
+    "progs/iceshot.mdl": {
+     "bytes": 2244,
+     "sha256": "1fb231e4da574971acdcbc9220fc825e638c57637e9f7e7643ff593d8c530610"
+    },
+    "progs/kikbull.mdl": {
+     "bytes": 116900,
+     "sha256": "562feae2b4cc03ea82dfe15f3b56123f1ac9886249158780f05c491d30b8cfcf"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "210e159ea4c9bf1f2431213fd95902f4ea75ecee6a67a22bed7e93366f1f2732"
+    },
+    "progs/lord.mdl": {
+     "bytes": 192683,
+     "sha256": "142cd38aaedd6bf5606887a0e5e6429993371fdd36b285ab2e61f1356bf756eb"
+    },
+    "progs/phase.mdl": {
+     "bytes": 1684,
+     "sha256": "768546d80ca7599d8e8c62aa68e2f7f305a4caf2d589fbb304cb36ccc9f2bdea"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 23067,
+     "sha256": "4ae67c0873e53142be3c96d280fda746fc46f8562c1e98d1a5b9b3228fe2bf33"
+    },
+    "progs/player.mdl": {
+     "bytes": 1183290,
+     "sha256": "732c69b185355faa0f576a416200efa0623b81ab63b09cbaeea1943d8cff0065"
+    },
+    "progs/pulse.mdl": {
+     "bytes": 15988,
+     "sha256": "83ad42783fe9a5dd2e2085bb6dcb3e551db7fd7ac683326943e6c5423f8131e4"
+    },
+    "progs/rockcase.mdl": {
+     "bytes": 7474,
+     "sha256": "1825b135c8fa1578110f3deb0674f927e948e908b370090119586e6c5f5e23d4"
+    },
+    "progs/rookie.mdl": {
+     "bytes": 192683,
+     "sha256": "c0c1408d4d86006ec173c30f0dd4db49b0f605f6129bd464a1f48a37b854c092"
+    },
+    "progs/s_ablast.spr": {
+     "bytes": 15816,
+     "sha256": "056e4c0505d634afbb799b50fdac609ef9695fbc11ac03e09f396fcc98387357"
+    },
+    "progs/s_bfg.spr": {
+     "bytes": 41480,
+     "sha256": "930b0cb29dd07a37bc2c2476be4d2b48ed97989de2067309c0d5e5654279ad05"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_rain.spr": {
+     "bytes": 37196,
+     "sha256": "b9734d22d214594a37d0aae22317c227851099e916af377b63436c133989e52d"
+    },
+    "progs/sergeant.mdl": {
+     "bytes": 192683,
+     "sha256": "caed422bfea161d27f682fadc077b54e015a1aae9445983a299966f956127a84"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 7060,
+     "sha256": "f386df0925156b91efb4a7627bd01419580b9282a334cc8a03611ca8357082f3"
+    },
+    "progs/shell.mdl": {
+     "bytes": 2644,
+     "sha256": "6bbdfb9ef33cc0b5d3a9f304b72e6125902eb177c0cd177ede9a95a01faad567"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 132028,
+     "sha256": "8824603b325f37bbba424f55c3ff900c21ccf61c77ba97e636e91ef99202364a"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 192683,
+     "sha256": "cb1c0c13c177a2add7a626ea7204f59f974b11695c840f000cffacf33c2a688a"
+    },
+    "progs/spider.mdl": {
+     "bytes": 94492,
+     "sha256": "df40e58bdf6465e68e5ef33cbcb77c42cc99e50c9dd842c8c3906c2fd04bfc8f"
+    },
+    "progs/star.mdl": {
+     "bytes": 37876,
+     "sha256": "3c0ba85927923d0e562ae663c775362f1be25bcbe0e2d62731ed8f1f021725ab"
+    },
+    "progs/swat.mdl": {
+     "bytes": 199118,
+     "sha256": "6de65a8339b2def1248c230788aef99df5371b7d7cee355e565431fcfb0fc332"
+    },
+    "progs/swats.mdl": {
+     "bytes": 199118,
+     "sha256": "69bb7fd986c969ec3db18c8259d7eda0ca122a742a961f77adb2eef11620d567"
+    },
+    "progs/t_drag.mdl": {
+     "bytes": 12736,
+     "sha256": "daa3fb42ac8bca1ea5d46b1be4422b895715021d9efd6e53420f154e864cbf7e"
+    },
+    "progs/term.mdl": {
+     "bytes": 251525,
+     "sha256": "d33b2f59fe224e0c6c971a15caabe8224f0ced8b3c81bb83b96f62cc1d94eaa5"
+    },
+    "progs/throwaxe.mdl": {
+     "bytes": 56532,
+     "sha256": "82945fb480ef3b001fa09628846c43d77c1d8aeed58e4428ffb21acd30181eed"
+    },
+    "progs/trophy.mdl": {
+     "bytes": 35711,
+     "sha256": "2ed7caec1169d27cbc7605e1481c642ad77bb1574dea649917d0c23a30c1725f"
+    },
+    "progs/trophy2.mdl": {
+     "bytes": 62222,
+     "sha256": "915974b74ba3e9371dae631bc92493f6afad8580f9a3486a67f80fc6270a9adf"
+    },
+    "progs/trophy3.mdl": {
+     "bytes": 43227,
+     "sha256": "90f98ac4c9e9f821fd7d90eac02653f89f9ffc863a17db1cc752cab9e727253b"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "744af1fafaacb751cf2e5ce4bb15a0fc1fb938ae519469de6f0dccfe9f320414"
+    },
+    "progs/v_airgun.mdl": {
+     "bytes": 71065,
+     "sha256": "07321d9bbbc3065650d33a195f6e83bd3c173ddf7f536f1d823a7d6b9b68d918"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 57908,
+     "sha256": "418e5e313bf613e426dbaf7594f786aec6b23ff721fd48be912ccfa3b055a93f"
+    },
+    "progs/v_bow.mdl": {
+     "bytes": 35012,
+     "sha256": "e58517e9a6326b409df286dddffaf1c7daffa4c9d6e4c76f2ca429f576f2ac01"
+    },
+    "progs/v_freeze.mdl": {
+     "bytes": 58548,
+     "sha256": "8a05172eee874867ef9befc894188d346edd519992e9a6a29d277ad7e96a7be1"
+    },
+    "progs/v_laser.mdl": {
+     "bytes": 68732,
+     "sha256": "8e42db3ff82923040b712e82c3ef09d28e4357609a8f1c2c71f6c1c2c1a98a7d"
+    },
+    "progs/v_motion.mdl": {
+     "bytes": 46248,
+     "sha256": "c435b0bf42fff28e4e338b55d38810bd0f25de13b222d852822102ba7ff013a3"
+    },
+    "progs/v_phase.mdl": {
+     "bytes": 56476,
+     "sha256": "284142faadea7e0558bf530e5f3535ffd73ce36f0cf4efe505785b78b66496ae"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 82520,
+     "sha256": "1919693cd363f4e793b0d04bc43a7c66b1f187aea900670b8f30bdf99bee0721"
+    },
+    "progs/v_star.mdl": {
+     "bytes": 56996,
+     "sha256": "abf29c0250b5cf95fe8237e389fe852222ff121c603fb0a3cd923696a22a7f2e"
+    },
+    "progs/w_drag.mdl": {
+     "bytes": 36636,
+     "sha256": "785216ead72dc301b2e6c09b91ff3a399f58400d08523d4078cd47190ce74315"
+    },
+    "progs/y_gren.mdl": {
+     "bytes": 2244,
+     "sha256": "bd588a234aab1c17c4d0094d56ab374a31299907610288ebbbb1066da4dfda3f"
+    },
+    "sound/ambience/eagle.wav": {
+     "bytes": 37218,
+     "sha256": "1d38ea8d0218bd6a07a1a55d476ea027cc2e53a4c8312a98cd1ffd8df94a6939"
+    },
+    "sound/ambience/fire1.wav": {
+     "bytes": 24064,
+     "sha256": "db160193d1db0e65b3f014291bba7c10ec2a11dc1844ac1a0288ab30ac3adf22"
+    },
+    "sound/ambience/rain.wav": {
+     "bytes": 91054,
+     "sha256": "c03490d412c7f773a73af83335e9d060347dda7bdc1f0b7620b2a06deee16456"
+    },
+    "sound/ambience/thunder1.wav": {
+     "bytes": 41492,
+     "sha256": "f7061fe3e19eaf1cea5216d0d3c776e79224e938bde1b6124a2f115eb421969d"
+    },
+    "sound/balorcer/death1.wav": {
+     "bytes": 8402,
+     "sha256": "2a6c51e7b94cc0777df86d738ab3bbd7a83374c3e7fd6b3e1577a5c32aeb769f"
+    },
+    "sound/balorcer/idle.wav": {
+     "bytes": 9770,
+     "sha256": "b8c7b5d80e37d17d4632bf42ec1080a816fa02b4f19e7736c47d57ac8b054184"
+    },
+    "sound/balorcer/pain1.wav": {
+     "bytes": 4968,
+     "sha256": "98d2c10d03ca3e70955e2971773170c4d072886cb9f7eb3baa453575d1b151cb"
+    },
+    "sound/balorcer/pain2.wav": {
+     "bytes": 4968,
+     "sha256": "822470dfe3443b115d640ef05bb8c8a88791f7ac8829767b9e91f4f72e33bc12"
+    },
+    "sound/balorcer/sattck1.wav": {
+     "bytes": 14208,
+     "sha256": "b0d1204a0e567bdd4f1942b9abc5efb121b784002b3f26ff0c9537b6c02a5551"
+    },
+    "sound/balorcer/sight1.wav": {
+     "bytes": 12684,
+     "sha256": "aec656417d66cc030a7c0f1027387c0a14324058c6612c804bb5fbacedd7eee9"
+    },
+    "sound/bfg.wav": {
+     "bytes": 18386,
+     "sha256": "95ed94739bcdc3188c8d47311543e2c7e79e65df17b82cdffc0dee063c102ac9"
+    },
+    "sound/blarg/bidle.wav": {
+     "bytes": 25832,
+     "sha256": "2f57c1c5ce363e090853eff5622131a1f978dbc62aa5998472ef9cedb041c4f5"
+    },
+    "sound/blarg/bidle2.wav": {
+     "bytes": 23488,
+     "sha256": "958724313246d20cad51194f35d539927556b3c7917f983d5344b8886bafb759"
+    },
+    "sound/blarg/bjump.wav": {
+     "bytes": 23646,
+     "sha256": "3b2c6d6e536a756323fd056083eb0093a3330bbf4c829e0354f401a9074f22fb"
+    },
+    "sound/blarg/bjump2.wav": {
+     "bytes": 6908,
+     "sha256": "1c6406eff6b00c029baa2b8d5a1c84a13bc21f47be0a84e80d852c4c7d10df4c"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15692,
+     "sha256": "72e737f04f1d34044dfd812c6b0e233cd38a91e6b089633e312678756952de87"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16625,
+     "sha256": "bd4cd7902712282ef8f2f749e6fcf805c2ac5212994fbb1c22fc0fe0ea5d08e2"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15527,
+     "sha256": "0b472a984137667f4788336a4f7c60e07a8893f47317b2a158aeea39920d729f"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4107,
+     "sha256": "8fe56b192838dafdf7ff4737cf1e5555d3295cbca49c1ab83568281ee188153c"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8122,
+     "sha256": "3ea23b8d7a68e754211a10a5338b0c8d65df6e2138d4cfe06cc053b9a0f601ae"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13081,
+     "sha256": "a5ec6d4eaa707ad0246b7a7e7737b1007043ea5e5634f6f63661ecc20c27c459"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48508,
+     "sha256": "b7aac875623f8dca7597eff3dcab5910453d043fd1f9df20da89232ce8bf9306"
+    },
+    "sound/demon/ddeath.wav": {
+     "bytes": 24916,
+     "sha256": "d051c976822a8a7bfb3613d5e67aeaa514ac9baa7a460047b49a7b95a5f3a006"
+    },
+    "sound/demon/djump.wav": {
+     "bytes": 22202,
+     "sha256": "e4c0d9a121f35afaf68f2607b4df2b4f8de606805e3b67e825f6d09960215ee1"
+    },
+    "sound/demon/dpain1.wav": {
+     "bytes": 7630,
+     "sha256": "3e4c4a133fd5387f75f554b36ad6a93887305157a903a70fddede0ed4b72d51c"
+    },
+    "sound/demon/idle1.wav": {
+     "bytes": 11174,
+     "sha256": "a09e00aef702e4d538da805bb39d35f11c2fcd058f89a0bb453a57daad45310c"
+    },
+    "sound/demon/sight2.wav": {
+     "bytes": 38642,
+     "sha256": "7f6fd555f897cef6cdc53dd5a60af74af5b3dba315f86903d4814773934f0b19"
+    },
+    "sound/dragon/attack.wav": {
+     "bytes": 4920,
+     "sha256": "6a5697e1dd9eca555bfda713101cdda800065e201f00ca333796f1bd4e7217ae"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 16944,
+     "sha256": "0fe255bd36c64acf75a53b97851b995517e70468b3818ff0ccecc4c7be5fc055"
+    },
+    "sound/dragon/hit.wav": {
+     "bytes": 4566,
+     "sha256": "b36e7581fe973d854b6f59947c5fe30b7118c94e7973f93b54a0c17423ce3fdc"
+    },
+    "sound/dragon/idlefly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 13848,
+     "sha256": "e71858c4de3e9ddcad1cba4ec0a6f5ec437b06c813b263ec73f853846d15a984"
+    },
+    "sound/dragon/sight.wav": {
+     "bytes": 21760,
+     "sha256": "fc36ea92a398c0c001010e5122d2574f1f42d9a2a5c77c58161c1f7134c105b2"
+    },
+    "sound/enforcer/death1.wav": {
+     "bytes": 47396,
+     "sha256": "249a003b784c9293baf753366e6dae895e705c6eda77c5e9ccebef59643e0cb0"
+    },
+    "sound/enforcer/idle1.wav": {
+     "bytes": 10382,
+     "sha256": "37f8d86cb7e355cc003bef31818a1c14a3960d6291006f482a5eb15f6f56169a"
+    },
+    "sound/enforcer/pain1.wav": {
+     "bytes": 59184,
+     "sha256": "3fe7d4cb370c38c567730963a4813313e78406428ae1f030ec8febf46aa49ffd"
+    },
+    "sound/enforcer/pain2.wav": {
+     "bytes": 88266,
+     "sha256": "db8145f240006d59d8cf5c0d6d9fee40da30d1e2af5f150c225a166d77b4aba9"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 26446,
+     "sha256": "74b23fb2341646dc4a26dfbd006eff88bb9dec010173b734441ad088eb07423f"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 23094,
+     "sha256": "beb36c4beb45fbf6dc9d44e1b31db77430a4a16117d92f3b2bec87ed5295b3b7"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 19134,
+     "sha256": "1620baf34a3178aecd7d5cbad6e05929d1525c77e3c9288047e1b96b08688948"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 2634,
+     "sha256": "a8793fba92eafc9774482777bf99f0fddd3826a0708f4ebaa044a89c0c831253"
+    },
+    "sound/ff/ff_hit.wav": {
+     "bytes": 20460,
+     "sha256": "6afcc2ac69c1131b0a869b220bf1964ccfa488c4de1e2acb8021c1b8507906d8"
+    },
+    "sound/ff/ff_off.wav": {
+     "bytes": 51680,
+     "sha256": "e6e88e106f4a9f259cb686ca5ecc8af15505aa30464029559c1b93140c844f0b"
+    },
+    "sound/ff/ff_on.wav": {
+     "bytes": 51680,
+     "sha256": "c6dda9f37337b83bc8ec668a4218e4a2d1b90fceb09c2a4cb7edd1b206ac7b7e"
+    },
+    "sound/ff/ff_water.wav": {
+     "bytes": 20108,
+     "sha256": "73baa9f0388c5135cdc5f0c96ca95c364ddba0b3b6ed575af5feb15ca30357d3"
+    },
+    "sound/flshot1.wav": {
+     "bytes": 3914,
+     "sha256": "a5b7ef9dba11d0cf67d263a8c70a9783f1a2599ac49601ccedd10a0f2e2204e9"
+    },
+    "sound/frozen.wav": {
+     "bytes": 20618,
+     "sha256": "05a489de35594542a929ce87087a2755fc630097292eedde6d50a18893223e90"
+    },
+    "sound/hknight/idle.wav": {
+     "bytes": 5056,
+     "sha256": "542c206c55627911b29371b210f5d5daad5ebd202b7aca8718743d705d0f4fda"
+    },
+    "sound/items/protect.wav": {
+     "bytes": 22536,
+     "sha256": "142158ff672856591c357a00369840510808a2765891e16ee6e2c77e8e1a7d53"
+    },
+    "sound/items/protect2.wav": {
+     "bytes": 34012,
+     "sha256": "f124456069de2b01b7f98b75a3480c2ec53bc681cf3a8083074bf9113f420b02"
+    },
+    "sound/lord/death1.wav": {
+     "bytes": 8402,
+     "sha256": "2a6c51e7b94cc0777df86d738ab3bbd7a83374c3e7fd6b3e1577a5c32aeb769f"
+    },
+    "sound/lord/idle.wav": {
+     "bytes": 9770,
+     "sha256": "b8c7b5d80e37d17d4632bf42ec1080a816fa02b4f19e7736c47d57ac8b054184"
+    },
+    "sound/lord/pain1.wav": {
+     "bytes": 4968,
+     "sha256": "98d2c10d03ca3e70955e2971773170c4d072886cb9f7eb3baa453575d1b151cb"
+    },
+    "sound/lord/pain2.wav": {
+     "bytes": 4968,
+     "sha256": "822470dfe3443b115d640ef05bb8c8a88791f7ac8829767b9e91f4f72e33bc12"
+    },
+    "sound/lord/sattck1.wav": {
+     "bytes": 14208,
+     "sha256": "b0d1204a0e567bdd4f1942b9abc5efb121b784002b3f26ff0c9537b6c02a5551"
+    },
+    "sound/lord/sight1.wav": {
+     "bytes": 12684,
+     "sha256": "aec656417d66cc030a7c0f1027387c0a14324058c6612c804bb5fbacedd7eee9"
+    },
+    "sound/phase.wav": {
+     "bytes": 50156,
+     "sha256": "196623f453764e89b60bafacdb29a1abbe5357336d5d1cd20322ccd8d6e7a885"
+    },
+    "sound/phit1.wav": {
+     "bytes": 16824,
+     "sha256": "6c7eb9e24127e6310fe119f8404ca5689cb59d0f1b17450d381c51ce95b1d808"
+    },
+    "sound/phit2.wav": {
+     "bytes": 42994,
+     "sha256": "2d73f8869cd160a61ea315c443bfd82735bf0b4463eab116863284f9690df8f6"
+    },
+    "sound/phit3.wav": {
+     "bytes": 50198,
+     "sha256": "464910e375aa64e34ba3ed8085dcbffededd15e4218aec412b2dc34ea988a3aa"
+    },
+    "sound/plasexpl.wav": {
+     "bytes": 11828,
+     "sha256": "385845032d03e610b8ca44e2d1c1f38ceae332ed8455e1c0f3b1dd7e743e7f7b"
+    },
+    "sound/plasma.wav": {
+     "bytes": 5780,
+     "sha256": "39d13b62d5f80e8949241afc0574e47ef1fe6c52742c30c41db70ee6ab6761d6"
+    },
+    "sound/player/axhit1.wav": {
+     "bytes": 4144,
+     "sha256": "f652f9d7866d88853adf412fb933e380afedd294c93d4f893273b6b2fb4e09f0"
+    },
+    "sound/player/axhit2.wav": {
+     "bytes": 4144,
+     "sha256": "f652f9d7866d88853adf412fb933e380afedd294c93d4f893273b6b2fb4e09f0"
+    },
+    "sound/player/pain4.wav": {
+     "bytes": 12034,
+     "sha256": "25b16ebcc39ff2779d4e2123858892146c157037050faae2e344771dbb849844"
+    },
+    "sound/release1.wav": {
+     "bytes": 32480,
+     "sha256": "5873b07c30a5851e6fdb7c5ad4c1dac1ff9e20d6bf322de719007485d2cd87bb"
+    },
+    "sound/release2.wav": {
+     "bytes": 16380,
+     "sha256": "6fcce60fdaefd5b1a061186ebd8b573445ed44719e46a39b157047e9489a5c13"
+    },
+    "sound/release3.wav": {
+     "bytes": 48898,
+     "sha256": "d430d36438a4796c06edfae089e134d3284a732de7f4dc9ead499a13462cde17"
+    },
+    "sound/shatter.wav": {
+     "bytes": 20898,
+     "sha256": "5d30558f24773771d980c4796f4cf28646a98cdfc3baadb3b3491c7d170dfa77"
+    },
+    "sound/skewer1.wav": {
+     "bytes": 75568,
+     "sha256": "0ee1597f393f2dbfb7955361bf2405eb083acd9dd95d51a04fc6d3a7fe4d37bd"
+    },
+    "sound/skewer2.wav": {
+     "bytes": 20498,
+     "sha256": "e32862e35ca2883c84ecbab95cd7d0ebbfaca5e9925ac0ce0f34020293c6cb77"
+    },
+    "sound/skewer3.wav": {
+     "bytes": 25692,
+     "sha256": "f1c7741ae81fac606baf34acba939ee7ae7340a79141a3964f2fdb45a3e54ea7"
+    },
+    "sound/soldier/load.wav": {
+     "bytes": 2232,
+     "sha256": "23235a4ff92511751ec36b8fe0c586f42dbb14783b6392f1a28c5a33cbb29014"
+    },
+    "sound/spider/tap.wav": {
+     "bytes": 410,
+     "sha256": "fd051710d2a10af0ccebf73a67dbbdcb7ddec3299f44ce511e59fc81cddccab5"
+    },
+    "sound/tap.wav": {
+     "bytes": 410,
+     "sha256": "fd051710d2a10af0ccebf73a67dbbdcb7ddec3299f44ce511e59fc81cddccab5"
+    },
+    "sound/taxhit.wav": {
+     "bytes": 2228,
+     "sha256": "f39ca9de55721127a150e345b6dd9120999bb2ca07492f5fd7391eee6fb126da"
+    },
+    "sound/taxhit1.wav": {
+     "bytes": 17908,
+     "sha256": "5b829a67960deef482abc122a0a7d8e904964d4dc543e6ec6bb3c1c56da897e6"
+    },
+    "sound/taxhit2.wav": {
+     "bytes": 6110,
+     "sha256": "be834cb36fd503538366c9d76b99ca04530d7990b32339b15dda107703649193"
+    },
+    "sound/taxhit3.wav": {
+     "bytes": 8950,
+     "sha256": "453ce31c9e11a263c4d2a777099f9b20a9c19718a5fb3ec039f99704e9182f16"
+    },
+    "sound/term/death1.wav": {
+     "bytes": 8402,
+     "sha256": "2a6c51e7b94cc0777df86d738ab3bbd7a83374c3e7fd6b3e1577a5c32aeb769f"
+    },
+    "sound/term/idle.wav": {
+     "bytes": 9770,
+     "sha256": "b8c7b5d80e37d17d4632bf42ec1080a816fa02b4f19e7736c47d57ac8b054184"
+    },
+    "sound/term/pain1.wav": {
+     "bytes": 4968,
+     "sha256": "98d2c10d03ca3e70955e2971773170c4d072886cb9f7eb3baa453575d1b151cb"
+    },
+    "sound/term/pain2.wav": {
+     "bytes": 4968,
+     "sha256": "822470dfe3443b115d640ef05bb8c8a88791f7ac8829767b9e91f4f72e33bc12"
+    },
+    "sound/term/sattck1.wav": {
+     "bytes": 14208,
+     "sha256": "b0d1204a0e567bdd4f1942b9abc5efb121b784002b3f26ff0c9537b6c02a5551"
+    },
+    "sound/term/sight1.wav": {
+     "bytes": 12684,
+     "sha256": "aec656417d66cc030a7c0f1027387c0a14324058c6612c804bb5fbacedd7eee9"
+    },
+    "sound/weapons/agfail.wav": {
+     "bytes": 66197,
+     "sha256": "ebeaaa43622fff993c83df58511bd7f3569e9aef9bbc478c9cc6b2e8b9e3e77f"
+    },
+    "sound/weapons/agfire.wav": {
+     "bytes": 66197,
+     "sha256": "db3466708718063963d8996e51bdc4e8bd0033d9932f387f624f274f6c7c648b"
+    },
+    "sound/weapons/agwater.wav": {
+     "bytes": 85900,
+     "sha256": "208883c1961633e728d5c1894a193acc923de928adf9cc77ae40244645951046"
+    },
+    "sound/weapons/agwfail.wav": {
+     "bytes": 31382,
+     "sha256": "626e26302f5b01b7a13b1354c13a41c45dfa0df9c2e9b5af4037454f8f215f37"
+    },
+    "sound/weapons/ax1.wav": {
+     "bytes": 3064,
+     "sha256": "168961748307a58d8574785e861646d2e3d551eb48f230bd85c8611a9b99617c"
+    },
+    "sound/weapons/guncock.wav": {
+     "bytes": 13572,
+     "sha256": "391b435d020e820d7bb027d16705b4027a4dcb920d395ce51d09776bd269ae78"
+    },
+    "sound/weapons/rocket1i.wav": {
+     "bytes": 8186,
+     "sha256": "f9a6212ab50965c39ee3ef0bcdc8f3027862cba964fd3241eb7c18133e6dc873"
+    },
+    "sound/weapons/sgun1.wav": {
+     "bytes": 13372,
+     "sha256": "2c60d4e537e61348291b1802c723c5bd9ac010f6b293a69ceffeb4c8160f5155"
+    },
+    "sound/weapons/shotgn2.wav": {
+     "bytes": 22323,
+     "sha256": "78770d152bcefe004f827cf04c624db1dc4f5eb18cec8f80ea53f8ab89bf1e43"
+    },
+    "sound/weapons/spike2.wav": {
+     "bytes": 16274,
+     "sha256": "1ff705fe0a4a6edffa104493a8a8fece9e46b38ee770ff6cd255cdf525101a4c"
+    },
+    "sound/woosh.wav": {
+     "bytes": 3509,
+     "sha256": "792d48054621be14516a1e176819457b6da97082a8166400681bfc33c25c56f7"
+    },
+    "text/advwepv7.txt": {
+     "bytes": 1307,
+     "sha256": "d763d5ee83174df0ab82bf50d38f65482e61b0456fc6925cf7fcc834ca629a9b"
+    },
+    "text/bfg11.txt": {
+     "bytes": 8415,
+     "sha256": "15e476f746bf87c9250e7ee1b9470c49517b0e33b4b1e43a3c536d6b6deab987"
+    },
+    "text/blarg.txt": {
+     "bytes": 2917,
+     "sha256": "fb551d35661d8ca597df97b73c8cd35dedf8ad01d54d52a913af2244c229e798"
+    },
+    "text/cannon.txt": {
+     "bytes": 3326,
+     "sha256": "711f8b6dbd8b5e03f7801dc87fceec7c6c209f3d7d12b81718ee300cc7d137cf"
+    },
+    "text/cyber.txt": {
+     "bytes": 1551,
+     "sha256": "5ed7e198ea6f777cd5f3b819ed1f13f0daae6020931f0f86b12b8f1570a95bad"
+    },
+    "text/decoyz.txt": {
+     "bytes": 3848,
+     "sha256": "3f01753e687b61f7eb4c328c5a40c1bc9ca3287e0ad9aaad0157949682d06a04"
+    },
+    "text/democh2.txt": {
+     "bytes": 732,
+     "sha256": "e5f983589d168eb6f4c5f41886a23f037e3ee518133237606cc3203f3cb6ace9"
+    },
+    "text/demochrg.txt": {
+     "bytes": 2210,
+     "sha256": "f7ac77a69ba1b2f209332f2a128a024b5cd95c941b6ffd45221e27ce4a5b7279"
+    },
+    "text/dragon.txt": {
+     "bytes": 4601,
+     "sha256": "24d171b8d8de0db30e22327e557964a4b3e0a0a0f859c8030e759cf6b1ca9506"
+    },
+    "text/eject.txt": {
+     "bytes": 2217,
+     "sha256": "4a41a7a1d4be1b382be287855a7456eb5a8d4f41698e0bc36c81e05bc9cad8a8"
+    },
+    "text/femenf~1.txt": {
+     "bytes": 1130,
+     "sha256": "fe16cff00741cf420217530d2c869f77ecf2bc874953485c09217fc1935ef844"
+    },
+    "text/flame.txt": {
+     "bytes": 3124,
+     "sha256": "c1c14b7263ff535bddb5bdb786e1e8a9b34496b6b10e698ffb0b42f1b1c06b16"
+    },
+    "text/flares.txt": {
+     "bytes": 2549,
+     "sha256": "0376b3bb613c13f5ddbd790c4095c26068912e57dfd769ad8e772bdd9b839241"
+    },
+    "text/grap109b.txt": {
+     "bytes": 6887,
+     "sha256": "c671249dad3e4b62835fd4b6a3d8af21a310a3071f76e0872ccc873dc4680c5f"
+    },
+    "text/grunts10.txt": {
+     "bytes": 5043,
+     "sha256": "6f64a7a439b406117f690b3946224abb802d9dc6b90b79d8ad60d57b122000b9"
+    },
+    "text/grunts8.txt": {
+     "bytes": 2543,
+     "sha256": "27d05401c67f54b547cb5e7d60a02f2777eb263888de26e1e0624c9edbac0d62"
+    },
+    "text/guide101.txt": {
+     "bytes": 3192,
+     "sha256": "b60b8d600794391656d52114f65040ecd63d16c0d63763e4342153af7c3ab8be"
+    },
+    "text/killer.txt": {
+     "bytes": 37158,
+     "sha256": "cd93fa60f31555d749d4bce638a45d9fdaaf3a0bc87f49046d45732fb854bd06"
+    },
+    "text/lasergn1.txt": {
+     "bytes": 953,
+     "sha256": "1459e6629761f0becc04e97a2395533996d0fd17df57775e792f3617daf5663c"
+    },
+    "text/masters.txt": {
+     "bytes": 4647,
+     "sha256": "916bf97724daa1cac89582612fe62ba3c97f93333e2570087fdb1d74b5078804"
+    },
+    "text/motion.txt": {
+     "bytes": 3860,
+     "sha256": "f340ea2203f9a338f12802ad4d015d245e11dbdd00eaf9262e7536783fab2e94"
+    },
+    "text/multisk.txt": {
+     "bytes": 13476,
+     "sha256": "8393a451d4dea96e49fd948ee020788bb730f0521405643910fb7f0e16ac8aa3"
+    },
+    "text/ogresaw.txt": {
+     "bytes": 2549,
+     "sha256": "0d27a6168b50572fa6040ed79a8f039959d4a5242a519622ef0a3915ff537e3a"
+    },
+    "text/plasma10.txt": {
+     "bytes": 4755,
+     "sha256": "6f3e531839452049d63ffafec72758fb8598e8dc82b5869e5b9d3275b7b7e1e5"
+    },
+    "text/raptor.txt": {
+     "bytes": 2225,
+     "sha256": "f5446bf7515326ce2fc705e904f8094e4e69fc3f19700461a681caaf31a017d7"
+    },
+    "text/snakeman.txt": {
+     "bytes": 4744,
+     "sha256": "cc988702d85165b6f9cf05830cf8ebe39a907b140c723799813fa14638c2d7f2"
+    },
+    "text/spider21.txt": {
+     "bytes": 3434,
+     "sha256": "7179678ee3affd3f4337820805d324417d995fb6ac2a839663901468adece064"
+    },
+    "text/stinger.txt": {
+     "bytes": 1117,
+     "sha256": "74c5481edf6c7d027d1d85c9f58f8212bead9864ae87da3e79c203c9c4918109"
+    },
+    "text/throwaxe.txt": {
+     "bytes": 2785,
+     "sha256": "3e80fbab5e8fb3974e0567053f3adc75f3dbc545d35fd30db5d238d0c290e60f"
+    },
+    "text/ultimate.txt": {
+     "bytes": 17737,
+     "sha256": "bfa55840cc29eabb43ee6f61208692763376186e9d6175f19a6f19b9ad5fa727"
+    },
+    "text/xtrawp19.txt": {
+     "bytes": 5134,
+     "sha256": "3539da3caa0e05159a8d4964a3203767d2d61bacfaf836a03691df7fb458d6ee"
+    }
+   },
    "sha256": "c76a9c4803b7487fa0ed1367fb558e93581ceb815edc486fb2a216b18eeb3ffe",
    "timestamp": "1997-03-09T21:08:18.000Z"
   }

--- a/json/by-sha256/4b/4b395b68083c794a4bc1fd2ca701d2392487df42b434b89fd791bb9437702be2.json
+++ b/json/by-sha256/4b/4b395b68083c794a4bc1fd2ca701d2392487df42b434b89fd791bb9437702be2.json
@@ -32,6 +32,488 @@
   },
   "jpqm9/pak0.pak": {
    "bytes": 64185983,
+   "files": {
+    "gfx/env/voidsmoke_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "d274189cd63786e9d86fbd3cafda0cbfd054ccd527e30aeec921a8d6f10866a7"
+    },
+    "gfx/env/voidsmoke_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "47392d93a23946a28533cf759d6aea245a2647d58bf153d2845ac0899ab8d400"
+    },
+    "gfx/env/voidsmoke_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "ced1991fffdc46e2bf156e1d89e06e1362e0e394808b74bc7aa40e6d90fde55d"
+    },
+    "gfx/env/voidsmoke_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "4d1b843a9fc61c4125262a9a95fc084cea61eb4b125288f7a7cd0c2f2e53f4ab"
+    },
+    "gfx/env/voidsmoke_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "389ae84f29901e349a266d707f62beab9de3eb607b901bcb4245028b8edaa3b1"
+    },
+    "gfx/env/voidsmoke_up.tga": {
+     "bytes": 3145772,
+     "sha256": "138e9386728cdd98935a0c484d5693db2e60375d8d770ad754fe6616906591a1"
+    },
+    "maps/debris/brick01.bsp": {
+     "bytes": 7912,
+     "sha256": "c11880924b195ed38908cbf50f9cd16f071918df0a94a19c7254b93dddb1e62d"
+    },
+    "maps/debris/wood1.bsp": {
+     "bytes": 7584,
+     "sha256": "c39390e3757553352941fcc255da6498be4c25a87575871e360a0166fac592bc"
+    },
+    "maps/jpqm9.bsp": {
+     "bytes": 30421612,
+     "sha256": "2cb06cb4dff216715ad16c51593b70bf8bb0ae8b75198217ca5f88cd656b4aaa"
+    },
+    "maps/jpqm9.lit": {
+     "bytes": 9857747,
+     "sha256": "89f75abb5f8dc98220e3081e3e7c40c7c04159710cf29de9e86c731ca157a731"
+    },
+    "progs.dat": {
+     "bytes": 629374,
+     "sha256": "958d1e69318d8fcc9b87cf5ec4caf7bc054fef4380d8b4c146b125deaa314294"
+    },
+    "progs/a_mdls/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "1cdfc2b54dd883efe9215499603e341bfa72e800740a2e874e9bcf3b0afc68ba"
+    },
+    "progs/a_mdls/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "8cb54159eeaa410b98478e9190bd2d33340d3a2e98a61d32ce1afaf4e99031a0"
+    },
+    "progs/a_mdls/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ac361970fb1cbbb87ad4593afecd6d8973a65ea4f14e5f7b565c8f38c181fa9d"
+    },
+    "progs/a_mdls/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "0870b633f95bda895074e8d423631ee8805c3923f36a1c7f09938710783e8f99"
+    },
+    "progs/a_mdls/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "146955794f29c02f6570eed83e1d4b0013b0b4341897bcbc91cc9ffea6957ff4"
+    },
+    "progs/a_mdls/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "59988afc3603b83ccfadf0a9af423a113bf15ed969d4a62db9073e3061bc0fdc"
+    },
+    "progs/a_mdls/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "696594c11dd6dbd2e60ac6923d82a55f8f5b16e93b93f7914abe5fd4df74299f"
+    },
+    "progs/a_mdls/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "b558ee2dfd0078c7e3075079fb40368f53e7dfb162aaefcd20e53f562e405b1b"
+    },
+    "progs/candle.mdl": {
+     "bytes": 24135,
+     "sha256": "5027f8712c36de87b3967e4e623fbc64d4e99644f5b805f7e21ec38b1532cc74"
+    },
+    "progs/debris.mdl": {
+     "bytes": 270552,
+     "sha256": "714b4fc3ce6675f0f4edc6ed7022e817f3922cde1877eb5418e4ddf60d798724"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 472208,
+     "sha256": "3345599ba081d346c163f5c239815bd65b134ccf342601f42a31e60a45044f39"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/g_shotty.mdl": {
+     "bytes": 23380,
+     "sha256": "b919bbcba3f7f03fb8b82fa6d3b1464ca41e81cf29417cfea0de09658c698cfb"
+    },
+    "progs/h_boss.mdl": {
+     "bytes": 63532,
+     "sha256": "320aff68d374f002ed468bf17ddeca4d95f59ef68c7dd3a17287fef2da1f0b46"
+    },
+    "progs/h_mdls/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "2e7fac7418838a721d80e80370000f3e400b21248b22c8d3555588d4f8437a5b"
+    },
+    "progs/h_mdls/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "1f4b0791be3156763c15521fbf2e747744ce3355d90d630b01c2227770314771"
+    },
+    "progs/h_mdls/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "6f792b9a80f34e31bceb4258e1d2c8f22d405a7ae1198b31bb285f502c720cfe"
+    },
+    "progs/h_mdls/pd_vial.mdl": {
+     "bytes": 24396,
+     "sha256": "aab843270d62a97b563b274d08c67c8d5de697e766ba1e928f190b7c7baaf108"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 42048,
+     "sha256": "52760ce1f6e8f657e782846571baf9fde80859f5342d07a684fa8218f96f68db"
+    },
+    "progs/lspike.mdl": {
+     "bytes": 1684,
+     "sha256": "59264317258f19955b967177f0dbc5be1733e4ca07c4c7b3cc333bb88bc0c46e"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 315696,
+     "sha256": "bbfc76137aa7beb3d16231499e041d51e156ef619607c660efa46438cce45891"
+    },
+    "progs/pd_armor_sh.mdl": {
+     "bytes": 31508,
+     "sha256": "46b9de8235f07190e18d67e147ed00be6dc322cd112ccde33bf4fc1f9a77e074"
+    },
+    "progs/pd_base_key.mdl": {
+     "bytes": 21219,
+     "sha256": "320ec52018f501f8fe428dd46f44693787e545289be883a49f3bd6476974cf46"
+    },
+    "progs/pd_bpack.mdl": {
+     "bytes": 216452,
+     "sha256": "cf13d3a5239b9f6028b2a848f564769d97fcec164b56f266bbcf2657af5127df"
+    },
+    "progs/pd_rune_key.mdl": {
+     "bytes": 46335,
+     "sha256": "c4fe9bd66394231ace3127635f057987ecbf4b13b00d84501127caacb5db03fc"
+    },
+    "progs/pd_wiz_key.mdl": {
+     "bytes": 21907,
+     "sha256": "36b50211f687813b85648a46bd32a1d543a8f2af84e9d4223f8b5843f885e1bc"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 29224,
+     "sha256": "a9c150fb5c19e6e0bf7ead5dcf6ae87d8e9745f4a439779266d0a258e16b6890"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 320900,
+     "sha256": "e3321220ed34292da63fac94af63360c6544c055edd1eceed35d75eb26685e9b"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4416,
+     "sha256": "8c70353304b2d111260102565745a5504144568f932787906eaf50de742aa62c"
+    },
+    "quakec src/LICENSE": {
+     "bytes": 18431,
+     "sha256": "189b1af95d661151e054cea10c91b3d754e4de4d3fecfb074c1fb29476f7167b"
+    },
+    "quakec src/README.md": {
+     "bytes": 239,
+     "sha256": "2be824d72bdef25ec9f90b9b55b63a24334282d53d83ec79ac273249821bc79c"
+    },
+    "quakec src/ai.qc": {
+     "bytes": 16106,
+     "sha256": "afe7fd0dab4c5acbb35b6dc2e25f9f019b45a714b07f3c677a2e77124cc296c6"
+    },
+    "quakec src/boss.qc": {
+     "bytes": 13622,
+     "sha256": "f3a9aa39d57adda1b897908fd26c28e0151eaaa2920ed6a082b18b46b94a33e3"
+    },
+    "quakec src/boss2.qc": {
+     "bytes": 15987,
+     "sha256": "4aa8179663b52698079673aa46f263f9e2769e3d657a725897023bfc414c331b"
+    },
+    "quakec src/buttons.qc": {
+     "bytes": 3249,
+     "sha256": "1a814605af733bb3fc6ae250d7af5cb0b2d40bd3b37f5522b6d928126dd6eac9"
+    },
+    "quakec src/changelog.txt": {
+     "bytes": 9966,
+     "sha256": "3cd20bfb967d6cdfc724b1da9caaf77365c158d73c092d5ae932fe337f183324"
+    },
+    "quakec src/client.qc": {
+     "bytes": 42633,
+     "sha256": "d0ecb904610a814c60e20194b1fc42287f36e9ad23ff04f2ad60a332a6e005b4"
+    },
+    "quakec src/combat.qc": {
+     "bytes": 7192,
+     "sha256": "c1b5774a0b11c50cf5e6508e11349aa38c6bc8b468fad60fe7c0a4a1d30c9cc0"
+    },
+    "quakec src/custom_mdls.qc": {
+     "bytes": 2167,
+     "sha256": "3798f019c4c7151be89ccbebb560120101e69357a1da645a497b90fcb9bbbba3"
+    },
+    "quakec src/customsounds.qc": {
+     "bytes": 5564,
+     "sha256": "26bce1b876f3a8a709a2b61298d1f65de5f568f24ac66db713e8585afc694f5d"
+    },
+    "quakec src/cutscene.qc": {
+     "bytes": 30669,
+     "sha256": "b9ec452e62de479c53c05ac56a943c79d89ac7d6ee3d3bb3c68fb203656ac5cd"
+    },
+    "quakec src/defs.qc": {
+     "bytes": 25275,
+     "sha256": "01844d4c5c8ab85a9e4276900c1aed7e6d5a4260aa4e646f6dc8d057d06ee4a8"
+    },
+    "quakec src/demon.qc": {
+     "bytes": 14554,
+     "sha256": "c86075c879715287caad3d5a014eef446ad77b438fd0756905f0f95dd202bd33"
+    },
+    "quakec src/doelightning.qc": {
+     "bytes": 4955,
+     "sha256": "4b6233156f3792d7529d714de7f992c066a927d5f9109d9947caa2a7a2341c57"
+    },
+    "quakec src/doeplats.qc": {
+     "bytes": 14879,
+     "sha256": "dcca85f99b803fbbafea7ecd0b12ae8cf02e9dc48422a28e6d70335f749eafe3"
+    },
+    "quakec src/dog.qc": {
+     "bytes": 14108,
+     "sha256": "ca8ce0d87fd1eda73eeeee13ace5eebd0bc183f7dc610cc1d6fce01c163bcb08"
+    },
+    "quakec src/doors.qc": {
+     "bytes": 18041,
+     "sha256": "539a978d92e7120db67fb89116f94744bd82333751a575c364955e8e0895cea1"
+    },
+    "quakec src/dtmisc.qc": {
+     "bytes": 29848,
+     "sha256": "8392b74d997a79b88866506c47215b50adc7a05bbb0c8bfc9cbbf5bbfb33881e"
+    },
+    "quakec src/dtquake.qc": {
+     "bytes": 2654,
+     "sha256": "170b5464e0092f6a2f261910108381fd93fdb7fb5dd7bc047863f7bcc462dd9a"
+    },
+    "quakec src/elevatr.qc": {
+     "bytes": 3624,
+     "sha256": "eb6a260d53ca8f7b69f20a8cc42341c597d5e06ea18bca86e6aabff71bbc892b"
+    },
+    "quakec src/enforcer.qc": {
+     "bytes": 24697,
+     "sha256": "55419fb7e3c912b0e47396304e3abe2fa219be8ba9b9da361d44c03dafc7b61d"
+    },
+    "quakec src/fight.qc": {
+     "bytes": 7568,
+     "sha256": "301de69f7dad8a34fb361ab90e2a907c62b4633c7dde410b9e4bd6b81c017500"
+    },
+    "quakec src/fish.qc": {
+     "bytes": 11627,
+     "sha256": "2a2a72686b7177527bbfa43304fcc126b8f66ff4724f1b0da57f93f2ebe693a5"
+    },
+    "quakec src/func_bob.qc": {
+     "bytes": 5676,
+     "sha256": "5fe11638fd89f509759c83748c519b98dc5fe5856b09fab1f6247518b9836143"
+    },
+    "quakec src/func_fall2.qc": {
+     "bytes": 5632,
+     "sha256": "11cb67e867005f519f2df4e382f6330aa2218f3c10a612911caa22cf6d69ae99"
+    },
+    "quakec src/hipcount.qc": {
+     "bytes": 5217,
+     "sha256": "da5c096495966fa9ef5315ba00b315987349a817c889b974d8a91f506e6aee1d"
+    },
+    "quakec src/hippart.qc": {
+     "bytes": 7983,
+     "sha256": "730ed584b4de9dd49283502419a8bcafb99e2f1a3d146e05afee0ab2547751c3"
+    },
+    "quakec src/hiptrig.qc": {
+     "bytes": 6260,
+     "sha256": "e0292ef23ab7c669257e30525897fa1ae64e3c0870002863e5fa98e8de95aca1"
+    },
+    "quakec src/hknight.qc": {
+     "bytes": 23977,
+     "sha256": "1c84fb40236ba7b067081570db4e0dcc1a669416efafc5c4dd99d1ffd488768f"
+    },
+    "quakec src/items.qc": {
+     "bytes": 67829,
+     "sha256": "a14256e3807beeeebb309c59092820445b226069f2927e373c08b4608b8afed8"
+    },
+    "quakec src/keydata.qc": {
+     "bytes": 5639,
+     "sha256": "5902993c9755a2851ef424e48572a9806d20d3aae67a8f9d01446c4aad09a91a"
+    },
+    "quakec src/keylock.qc": {
+     "bytes": 5884,
+     "sha256": "26751c63554a6e73da84138ee45871f501d3bb5250cbfa137a524087bc204e39"
+    },
+    "quakec src/knight.qc": {
+     "bytes": 14633,
+     "sha256": "8048aafb27c52ad8fb92bec060401a9702c0cf9918b34e2bdc49ae2b423705a1"
+    },
+    "quakec src/lights.qc": {
+     "bytes": 15369,
+     "sha256": "eb7bcc93ccdb36c7df4aa49bb370f4d37eb598cbc51c8a9c2ff668769194bcae"
+    },
+    "quakec src/math.qc": {
+     "bytes": 1813,
+     "sha256": "9d5303c03ed58760bedbeb3f017ddebd5bc0c27de43a1e62ea3b5ae8bab2b927"
+    },
+    "quakec src/misc.qc": {
+     "bytes": 39913,
+     "sha256": "fe61ad291552bea62f41c977ec823c96a8342bd026241a1bdae564942cfcaaa6"
+    },
+    "quakec src/misc_model.qc": {
+     "bytes": 1712,
+     "sha256": "1a070d9cc274f76c2032b2cc459a002df8ce76103aa9f318d100e577a204df21"
+    },
+    "quakec src/mobot.qc": {
+     "bytes": 13931,
+     "sha256": "b9e698b47980f8ca795cdc928b7e107a2897ad3578cc172eab45dcc38c96982b"
+    },
+    "quakec src/monsters.qc": {
+     "bytes": 10018,
+     "sha256": "335d8da10275b61aa57b939a022eb8995d3a745609ef83d321bf52731e94ef11"
+    },
+    "quakec src/newflags.qc": {
+     "bytes": 5870,
+     "sha256": "192bf31eb0f13e6e55342801a42608caf797bfdfbdf27750c78ae67b1c1c5568"
+    },
+    "quakec src/ogre.qc": {
+     "bytes": 39928,
+     "sha256": "37aaeb400bd87453aa8d3d5b9d399dcb7e9ca90b911d018167152d8058e7e860"
+    },
+    "quakec src/oldone.qc": {
+     "bytes": 10263,
+     "sha256": "71f269418437ca5dc5cdb1ebe917a1a7252fde104ca92011c0079fa7769aa740"
+    },
+    "quakec src/oldone2.qc": {
+     "bytes": 14736,
+     "sha256": "6a3cb7559241c34c69ca053780b8d2e156eef260e0e54a2d575ca3a690aaf357"
+    },
+    "quakec src/plats.qc": {
+     "bytes": 14266,
+     "sha256": "545511c895c06cc2676cfa33f953415b4ee33ad72f2292c7d0b70026fa77d3ac"
+    },
+    "quakec src/player.qc": {
+     "bytes": 20579,
+     "sha256": "5612eef978278acf038f2a24b9050f237ea966a79a02fe79e78f4687b527c541"
+    },
+    "quakec src/progs.src": {
+     "bytes": 1907,
+     "sha256": "9f39f79f6601938cb94f93831f5dbf7e14b974a25f7d86554cc417aba66f20d9"
+    },
+    "quakec src/rotate.qc": {
+     "bytes": 31330,
+     "sha256": "63103ad2bb9f6cf0479863d22188bfef46acc674d27ec00863b9c7f098d3c6af"
+    },
+    "quakec src/rubicon2.qc": {
+     "bytes": 28533,
+     "sha256": "6ef16da656ddbbe1550284da2f594be13623a1ac3ff5f0034df7c862e62d4e29"
+    },
+    "quakec src/shalrath.qc": {
+     "bytes": 13109,
+     "sha256": "a0f1b2be13a2a3cb3ba41b413669ed67419a8a3a26108771fe910065192cbb46"
+    },
+    "quakec src/shambler.qc": {
+     "bytes": 18148,
+     "sha256": "96c483b3af04299fd0368c430022082141ba10af96a1dc25771dfb4bc830b513"
+    },
+    "quakec src/soldier.qc": {
+     "bytes": 18710,
+     "sha256": "220d51eeb811a417c47eb999ca4b0d69c417444265f941913d1badbd898d9f99"
+    },
+    "quakec src/subs.qc": {
+     "bytes": 14185,
+     "sha256": "d0e5649ffd317bf70b4c85d686d7f7035ce68a7c616733039788746974a9554c"
+    },
+    "quakec src/tarbaby.qc": {
+     "bytes": 9855,
+     "sha256": "c81c6071648a0acb0d5f7dac6fc49b78661d43bc114ab3c11194bdeec9b199d2"
+    },
+    "quakec src/triggers.qc": {
+     "bytes": 39079,
+     "sha256": "1d057a55361fe573a3035524b44571a7f12cfd2b8be83f9c65948cf0932feb35"
+    },
+    "quakec src/weapons.qc": {
+     "bytes": 38077,
+     "sha256": "b1ba08d39931a7cd06adb497016be6a4cbbc585d507f1a86e8aa967ddda6b0a0"
+    },
+    "quakec src/wizard.qc": {
+     "bytes": 15610,
+     "sha256": "0ecf27e676b25de687da14413f82f535d6614719099fdd8775f6d7793c7d64b3"
+    },
+    "quakec src/world.qc": {
+     "bytes": 20871,
+     "sha256": "7be5e3b9e534fdd61250d1376b5c66531642b57d9edf996c7e8f365ea0e17b57"
+    },
+    "quakec src/zombie.qc": {
+     "bytes": 33395,
+     "sha256": "053eab38bec4d63e2c020b28bdf27a580de513c206d41b59cff7e49fa833e89c"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 220548,
+     "sha256": "2cec0b03aa7047110862de21f8f6c77e4d98901ecaf5e405a473c2ddc922528a"
+    },
+    "sound/break/pd_bricks1.wav": {
+     "bytes": 61786,
+     "sha256": "3829842a9cb395f99d07546be38263eaf0ee5bbed71841aa8c93864d55a7fb94"
+    },
+    "sound/break/pd_metal1.wav": {
+     "bytes": 44146,
+     "sha256": "c0111b94231bc3870cbb95ec03f13b2b44ac407a5d18b35668ccf231303cc8aa"
+    },
+    "sound/break/pd_metal2.wav": {
+     "bytes": 70722,
+     "sha256": "ce8250482e831c270cc3c8e9211b74a627b3e29159c2c8ee720dd11cafd365c1"
+    },
+    "sound/break/pd_stones1.wav": {
+     "bytes": 75150,
+     "sha256": "632d15db23ff70c23c199595b41a153ded67f664de46b7d0cbfa0228f071156e"
+    },
+    "sound/break/pd_wood1.wav": {
+     "bytes": 34526,
+     "sha256": "621865f52fc27fb10108027ce3eea18aaf17181751a3ba1ceee0c9c99da9f375"
+    },
+    "sound/break/pd_wood2.wav": {
+     "bytes": 33342,
+     "sha256": "77282f2c533b9aec72b232aace9078534db3f255f418efafdf769c7361a28e05"
+    },
+    "sound/break/rock_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/dump/elec22k.wav": {
+     "bytes": 82784,
+     "sha256": "dd63a8517e33bbe7a75cd0d6ccb16835b73f83af8d31c0ae0277b7304f7d502b"
+    },
+    "sound/dump/pd_armor1_sh.wav": {
+     "bytes": 12410,
+     "sha256": "3b80fc8000fe624ffbe4f119faf41a77406b83bd350020c7782bc03fd51a1799"
+    },
+    "sound/dump/pd_magic_01.wav": {
+     "bytes": 125944,
+     "sha256": "3ea2bab80feccbe0f0b518ec613f45093aa76b0128752f454e239c75175cb4e0"
+    },
+    "sound/dump/pd_quake_end.wav": {
+     "bytes": 37248,
+     "sha256": "3ecb621fbf5a3f2ab090ebc0f3036069292181b11ab366689b3dfa0f19dd372a"
+    },
+    "sound/dump/pd_quake_full.wav": {
+     "bytes": 156278,
+     "sha256": "872e0b0847fd366c59341d672cba9da0faaf85a881f8d4d5471a664923c8440e"
+    },
+    "sound/dump/pd_quake_loop1.wav": {
+     "bytes": 159956,
+     "sha256": "52a330a12c35191347008f4c546b1c83b4e387f3f33c9b60c3a5e8e545b0517e"
+    },
+    "sound/dump/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/dump/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/dump/water_59_02.wav": {
+     "bytes": 40038,
+     "sha256": "25aa667940a737e46da0a829d9cb94922972b9b19726664d1a1133a666dc1439"
+    },
+    "sound/oldone2/pd_pop2.wav": {
+     "bytes": 42108,
+     "sha256": "1eec3103cd2eb70fa8ba63ce8ce721842a64a99e9c373f5a8abe5508273ce285"
+    }
+   },
    "sha256": "accbe03c75e42a22b8b67d4e8788a002e28184eef5b18ba870a94fd7dac316bd",
    "timestamp": "2021-03-19T10:23:44.000Z"
   },

--- a/json/by-sha256/4b/4b8511d377ec3633a90d2d2c19ca98a7e0b4f4f735e7d0560ffd24de654aa7a4.json
+++ b/json/by-sha256/4b/4b8511d377ec3633a90d2d2c19ca98a7e0b4f4f735e7d0560ffd24de654aa7a4.json
@@ -19,6 +19,776 @@
   },
   "pak0.pak": {
    "bytes": 277892009,
+   "files": {
+    "demo1.dem": {
+     "bytes": 1665025,
+     "sha256": "7bb543baae0a93d663b96a570bbbd629692f42f34cebb6ffe2b587b631f096f8"
+    },
+    "demo2.dem": {
+     "bytes": 1963821,
+     "sha256": "3b7d1cc950c69eac93e64037ab712c664bab914bac7629b595c3aa29b0979e7c"
+    },
+    "demo3.dem": {
+     "bytes": 2373221,
+     "sha256": "08f18fe9a4857e35531c7dae79e66749e701adae4607998ae755bd2891098409"
+    },
+    "gfx.wad": {
+     "bytes": 176868,
+     "sha256": "3ed832828694ce5df11b16225ef3a105c6aad19f270dd06254a5fd942689eb48"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "a43f71566341e623447f95c4d0552575de4676efea0fb061292dfaecc8b9257c"
+    },
+    "gfx/env/smej2honeybk.tga": {
+     "bytes": 520167,
+     "sha256": "0bc1fe5580859d2bf728167c647b72c4bc8982eb8ca6e8dfd7b2d2830220321a"
+    },
+    "gfx/env/smej2honeydn.tga": {
+     "bytes": 437747,
+     "sha256": "59123dbc0d416bd135f304ec855598cac3293cd7ab35a6c48712f8fc4abbccce"
+    },
+    "gfx/env/smej2honeyft.tga": {
+     "bytes": 739924,
+     "sha256": "133e5703c7a338c8e06f8fd1928e70f8d06a0d152bd2dc20ff036879b2e61fab"
+    },
+    "gfx/env/smej2honeylf.tga": {
+     "bytes": 453769,
+     "sha256": "a75290a17e5df9c24131966d24957815559c733f48d3f5e877ce64b7b0979a55"
+    },
+    "gfx/env/smej2honeyrt.tga": {
+     "bytes": 298431,
+     "sha256": "7974f8ea5bbc3e018fb56d81792a8870429ba48efc41df838bbc9a9fcddb2dac"
+    },
+    "gfx/env/smej2honeyup.tga": {
+     "bytes": 579686,
+     "sha256": "b80af0ec0ffb2cc81d119af5e3d7903e76e4942b822df04c71fc4a592a9e5b35"
+    },
+    "gfx/env/smej2knavebk.tga": {
+     "bytes": 815434,
+     "sha256": "079c0f170f78f3208317e43de8926802a6736688a24f5395e93ad0fb59625c84"
+    },
+    "gfx/env/smej2knavedn.tga": {
+     "bytes": 480330,
+     "sha256": "d3d0c578a1bf5dd83e912752578552adbaf4f9b10b9a2f20c9940872ffb2dc85"
+    },
+    "gfx/env/smej2knaveft.tga": {
+     "bytes": 399816,
+     "sha256": "f40dad580f45008acce60a0811d9e58be5d509389776cd0f73e4634a13f3166e"
+    },
+    "gfx/env/smej2knavelf.tga": {
+     "bytes": 477355,
+     "sha256": "c8a16513b83f075138f564d49720a4af4a3f91d72d9d1b39575304098a2dfe73"
+    },
+    "gfx/env/smej2knavert.tga": {
+     "bytes": 981999,
+     "sha256": "6a29ac0a9b925bb4ff49b29902f0e6e2b4d33d3995907d90ecedbf31cac2ec39"
+    },
+    "gfx/env/smej2knaveup.tga": {
+     "bytes": 972878,
+     "sha256": "01c14e9a7b76c08ecab0eba02a0aa3a732fd7c80cddd19e96ee810078055c410"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "maps/smej2end.bsp": {
+     "bytes": 25186176,
+     "sha256": "93f802e13b7967b5523c30cebd37d0675aa4e0e1b34a879e5d507ff1b91a7041"
+    },
+    "maps/smej2end.lit": {
+     "bytes": 7629266,
+     "sha256": "b740c5a1f81c11333ead6c933198f7b4de85863ec6c31330db57e0468efe701d"
+    },
+    "maps/smej2m1.bsp": {
+     "bytes": 18806580,
+     "sha256": "6b9ee98dbf77d09c7892eeffea1251cde1e11e0de685950ba321399921e21f63"
+    },
+    "maps/smej2m1.lit": {
+     "bytes": 3886304,
+     "sha256": "a69263f323ae0424d75795bc7373bf598e08fdf675a3a4791ead2f7e65aac8f7"
+    },
+    "maps/smej2m2a.bsp": {
+     "bytes": 12592152,
+     "sha256": "85163e8089c008b29ba3d18d7666d9bdb54ad9a23ffb056a058af5f41a2b1e3a"
+    },
+    "maps/smej2m2a.lit": {
+     "bytes": 4293788,
+     "sha256": "17e19563a4b7081a8cf71aec96ddafcf026da02df9ea6c7d13a271cbac85f2dd"
+    },
+    "maps/smej2m2b.bsp": {
+     "bytes": 12592272,
+     "sha256": "e18ad38c670a6ff644dd93e232bf585beb8848bff51f3a33b245c5f7bad2817a"
+    },
+    "maps/smej2m2b.lit": {
+     "bytes": 4293788,
+     "sha256": "8030ea10196288d3074773eeeb267d91b8bb1ea56dbe91ae45811746972d8980"
+    },
+    "maps/smej2m3.bsp": {
+     "bytes": 8207772,
+     "sha256": "825a7e35b8d5057fb26cb71a025852b59371263533a740ad5647307afbe9b3a0"
+    },
+    "maps/smej2m3.lit": {
+     "bytes": 1826981,
+     "sha256": "926d8a403b0f47af7b70bc3206f38b7bd8190259830d4050907895372e863ccf"
+    },
+    "maps/smej2m4.bsp": {
+     "bytes": 34107488,
+     "sha256": "4049464a542f9ae9c0904ff824d82f28f690e07920e99563291dbae991517a09"
+    },
+    "maps/smej2m4.lit": {
+     "bytes": 13338308,
+     "sha256": "2beab5b3d7272ec3aea6d6ea83d3d7cfcd42e67b8c80dea53474d42a2ce1fe49"
+    },
+    "maps/smej2m5.bsp": {
+     "bytes": 23578552,
+     "sha256": "46a361240ca55bb3f0d99c448534de7966e98e0a7111e9a22c39a1cb2c4f27d0"
+    },
+    "maps/smej2m5.lit": {
+     "bytes": 9023432,
+     "sha256": "c0bccf3c03cccc1ccdd941c6930c3253e1dbb20f6b8b1fa4ed19a9d55bbe9358"
+    },
+    "maps/smej2s1.bsp": {
+     "bytes": 7066696,
+     "sha256": "c2e2d2291ee83bfd9cbb21542780bca1d160f0bc4d3a74d55cdb8f98513ac5b7"
+    },
+    "maps/smej2s1.lit": {
+     "bytes": 1638878,
+     "sha256": "1714248c1155d453482de3b6e68a3817e257802864041a135bf4f71ced0d4555"
+    },
+    "maps/start.bsp": {
+     "bytes": 5231472,
+     "sha256": "a2eec11c027f700543381d8b66a7ca16f7297887c404f257d0d245eca0c1c3db"
+    },
+    "maps/start.lit": {
+     "bytes": 580964,
+     "sha256": "0872e10ef0ac52b9643d20fdf99fe3bcc762af9435d12e0a7c28fb276897ab67"
+    },
+    "music/track02.ogg": {
+     "bytes": 3912634,
+     "sha256": "4c1ddb570ea25668a383e29a562b41bb77e91762a17e51dfac9a89a90791caae"
+    },
+    "music/track03.ogg": {
+     "bytes": 3820230,
+     "sha256": "5f8aa3c3415bcc29cd21bb916e2746a610ac531e6f91840c2402bfbf525209dd"
+    },
+    "music/track04.ogg": {
+     "bytes": 7089542,
+     "sha256": "6377fc591678095634c9971768fbf0b0cce2caf72b95d19c181203044b93fa23"
+    },
+    "music/track05.ogg": {
+     "bytes": 6809547,
+     "sha256": "acda71b98dc662e65cc6939f5544d0818893c14fcf9703fc1c137e07767de6a8"
+    },
+    "music/track06.ogg": {
+     "bytes": 3066577,
+     "sha256": "c8c81ba151fbc0e36bc087596382ba26e60d026021d5204eb89a63d5d8ad4206"
+    },
+    "music/track07.ogg": {
+     "bytes": 6720766,
+     "sha256": "0a4a80fbd257bebf1df1216c73b3e793236f9d06354fb757da4ecc6abdaae3ef"
+    },
+    "music/track08.ogg": {
+     "bytes": 3739616,
+     "sha256": "e8cd0d022ef6e8d74342b3b760f26b15588dd33bc25bc3d9d6f93a531a18da86"
+    },
+    "music/track09.ogg": {
+     "bytes": 7070151,
+     "sha256": "fb0afc42a55dd277ecf141ecfea029b01a1cb2ce881f84e26c6ddd8900e66bd6"
+    },
+    "music/track10.ogg": {
+     "bytes": 6041906,
+     "sha256": "5601dca61f6301af118c2f7953de5da8d7bc334247e30cc189f32761f4fcc620"
+    },
+    "music/track15.ogg": {
+     "bytes": 7554017,
+     "sha256": "4477653dc32fa998316c652f38bcfb168ada4cf35abc5744a5960c30a803e940"
+    },
+    "progs.dat": {
+     "bytes": 602366,
+     "sha256": "c2d7704dbab419fcc4f7c46d180b6a183c78eda9e2fbac39986ef9e682481dad"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/cent.mdl": {
+     "bytes": 221936,
+     "sha256": "6e8e12db297f9f70cbe00fe2087be79a0011dc31344e642d8f309947e63cad8d"
+    },
+    "progs/devastator.mdl": {
+     "bytes": 591291,
+     "sha256": "fff418d31e11ab7bb6abf82ca37230015b0470a2132cb3ee26ff11c0b4affe9b"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_devastator.mdl": {
+     "bytes": 12893,
+     "sha256": "8efbb0b744d15bd91a880cc5d7a51f17216663078f85146943a1ed912a84d72f"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/h_spectre.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 32052,
+     "sha256": "783c734d5dd05b550ef73231a618352903d8de203ced5a892ce868db18a121b4"
+    },
+    "progs/nuljaska.mdl": {
+     "bytes": 239093,
+     "sha256": "2c07329a32071e66137b31355d585001da41263676df635cccda62a29cb3780c"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/rottmauler.mdl": {
+     "bytes": 700584,
+     "sha256": "451c01dd2a7d3a82660cd4d836d9fcffb275e5572547bb3fcaa71cb4272bc56f"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/spectre.mdl": {
+     "bytes": 463331,
+     "sha256": "ac50be404cab5c08a4510b9523883cf43aa0f67c15bd9576ed20b6c2b4a1ba85"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "1eb52d0049424c3180df14e0535331965f5038df6db1b6a5b41370cbea1bc3c4"
+    },
+    "quake.rc": {
+     "bytes": 1249,
+     "sha256": "3f616de2b4566dc0cab413644f3e707a64c4542b1578432e185507a9ab4d3bee"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 14026,
+     "sha256": "7a059f5c95936c1e51e96c28b9f30fbe6d66c27b1271b6f077eddd6611e15882"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 8192,
+     "sha256": "780230c4697dea0189ff81f731394696893d321ce7f3600370cca5ae2e81822d"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 10442,
+     "sha256": "cc71b100be0fb44e58b396e5e7e3d602e646545d8b368e804469ff083ed687c1"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 9918,
+     "sha256": "bd959168eff294104f04b5b1b736c722518fbf0d8f13fdbd8c4b695f14838aea"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/nuljaska/death1.wav": {
+     "bytes": 25300,
+     "sha256": "a2dbcdba562f8e381f67df95a5a6a6bfd7c53841b477bc096d1024d7121a0f3d"
+    },
+    "sound/nuljaska/hit1.wav": {
+     "bytes": 9876,
+     "sha256": "fcd4c44d38ed64884f6e51d50e192aa578bbec0cb4c6fd92282ca151e9c5740a"
+    },
+    "sound/nuljaska/idle.wav": {
+     "bytes": 15602,
+     "sha256": "94aa6b5d1c233f4974b0bf18847eb937786eb41271fcaf888ec0cb1e0d1498d7"
+    },
+    "sound/nuljaska/land1.wav": {
+     "bytes": 8816,
+     "sha256": "4a798700888505ab05aa40623c57b96cb6d77ac04118c905155cec28b499ce62"
+    },
+    "sound/nuljaska/sattack1.wav": {
+     "bytes": 8498,
+     "sha256": "a90331abd8922f04a52ae158920f429c6dc1bb70e12860b852e2232f9cecb4aa"
+    },
+    "sound/nuljaska/sattck1.wav": {
+     "bytes": 8036,
+     "sha256": "efa18dec8f6d5066b8d494a232ca9c98c27a4a9130130086a9b0a27ffccb34ed"
+    },
+    "sound/nuljaska/sboom.wav": {
+     "bytes": 23976,
+     "sha256": "43dee1c69ad61f81fc8733f44df3f19d922f056c1f9dc0908e7a787bad656415"
+    },
+    "sound/nuljaska/sight1.wav": {
+     "bytes": 8392,
+     "sha256": "7953209ba057560eeae9c199349ed6705d0da6d4c27588512836415276053d5f"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/rottmauler/dattack1.wav": {
+     "bytes": 13692,
+     "sha256": "fc75f597814f1983efb2da44ccbb7e50a171dd2aeafa4eede6d952336e8984a0"
+    },
+    "sound/rottmauler/ddeath.wav": {
+     "bytes": 29828,
+     "sha256": "b6a5646c22cd905687727d7a7cde130e4b573f7d5f2751f8a56802cec015066c"
+    },
+    "sound/rottmauler/dpain1.wav": {
+     "bytes": 5994,
+     "sha256": "2d7a2a687a891711d43f23a5984683f2f565209058ca878eab1d1d8fd6434af7"
+    },
+    "sound/rottmauler/dsight.wav": {
+     "bytes": 57532,
+     "sha256": "12d9bc1ad8bae3755f3277b169b6f8f864deeca575c003a195a7487499b1a859"
+    },
+    "sound/rottmauler/idle.wav": {
+     "bytes": 9112,
+     "sha256": "bca0a2740df4f499586f70f8e82381b0fc872846fbd1e5f36db2bb1747c7f796"
+    },
+    "sound/smej2end/10_0.wav": {
+     "bytes": 334600,
+     "sha256": "97c26205d99b6842f141669d7cb793023350a6f1bb056c9acc397255bbe4243d"
+    },
+    "sound/smej2end/butn2.wav": {
+     "bytes": 24844,
+     "sha256": "70dab0f917602787a7cd2e3ae87cb5883ea901006643a57828411bcb17586de3"
+    },
+    "sound/smej2end/dr1_end.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/smej2end/dr1_strt.wav": {
+     "bytes": 26356,
+     "sha256": "a5adb4c58142af7f044adf9e7ddfa6713f1a051de7fa45575a5231cd79f9560f"
+    },
+    "sound/smej2end/forcefield.wav": {
+     "bytes": 67928,
+     "sha256": "feb389e023228507b3c8e1718a57ebabec36af1f474d051b9ee950c4c6a806f4"
+    },
+    "sound/smej2end/incoming.wav": {
+     "bytes": 45898,
+     "sha256": "057628eb21bb3a75bf1180b2bd1590f68c142a3854aa4f51116ca901262012a6"
+    },
+    "sound/smej2end/klaxon2.wav": {
+     "bytes": 97624,
+     "sha256": "aba8baa9c677e02d8d08994b33cd24210fa6767d778db779a2e572e64aa076e6"
+    },
+    "sound/smej2end/pumpexposed.wav": {
+     "bytes": 75654,
+     "sha256": "0f474e8830b5a8cb447b5cc095adc35ab944c3940c6d5ef63c20aa9d63a9c399"
+    },
+    "sound/smej2end/ranger-punch.wav": {
+     "bytes": 14164,
+     "sha256": "b0a484550c4593dd81a146daf963d8757aa65e74acbe5fa72c7bd1f59d37a298"
+    },
+    "sound/smej2end/siika1.wav": {
+     "bytes": 15442,
+     "sha256": "095d294c7729706b22d9529c60ba8bcc3c69c3c374a842d0c6be6548278aefd4"
+    },
+    "sound/smej2end/siika2.wav": {
+     "bytes": 17986,
+     "sha256": "4a87cf484834e3b46cc01f93ca3b9294e7780365bb439a128b81bfb7129059aa"
+    },
+    "sound/smej2end/siika3.wav": {
+     "bytes": 70326,
+     "sha256": "9db11f9c75322e93eb10746b5f21c9769e23c5c540121403e15b531f2a4917e6"
+    },
+    "sound/smej2end/spark5.wav": {
+     "bytes": 12220,
+     "sha256": "5d4337a200e60b108f95bb59ed9656630e6107171760a13f85e0b46b854530f2"
+    },
+    "sound/smej2end/spawn1.wav": {
+     "bytes": 32428,
+     "sha256": "f6d1dda0bda524ce84b8bbcb120bd292d8a1d6eadbbf2b0856638e827091116b"
+    },
+    "sound/smej2end/ventsys.wav": {
+     "bytes": 96762,
+     "sha256": "479b88772c9ca172effba74cb1555b9fe61ea0ca9eb6f91c9807dbc224ec4a9c"
+    },
+    "sound/smej2m1/forcefield.wav": {
+     "bytes": 67928,
+     "sha256": "feb389e023228507b3c8e1718a57ebabec36af1f474d051b9ee950c4c6a806f4"
+    },
+    "sound/smej2m1/reactor7.wav": {
+     "bytes": 103712,
+     "sha256": "fce0cf50bf82d903f871eee323469cf1b0ba7af2ccd79c9ce050f63f8e6b04fb"
+    },
+    "sound/smej2m2/cymbal.pipe.1.wav": {
+     "bytes": 8716,
+     "sha256": "56fa3a1ffa62e66308219c966dedad8c80cf46ffc183f20123f4c7cc6f1c5792"
+    },
+    "sound/smej2m2/cymbal.pipe.2.wav": {
+     "bytes": 8578,
+     "sha256": "154c84abe4225c3e6becc2c5b9fada285a6b10ddeeca39b2383a2996c81d6881"
+    },
+    "sound/smej2m2/cymbal.pipe.3.wav": {
+     "bytes": 10166,
+     "sha256": "b66eb15274ca2788edb573e9788e2f5b2d5fe2b16db0e719fa4317edaefa0eb3"
+    },
+    "sound/smej2m2/forcefield.wav": {
+     "bytes": 67928,
+     "sha256": "feb389e023228507b3c8e1718a57ebabec36af1f474d051b9ee950c4c6a806f4"
+    },
+    "sound/smej2m2/morsecode.wav": {
+     "bytes": 5288544,
+     "sha256": "e6d2f5807b7db0ad7b84e51cf36077245a445907ee66b740295d406b448cacaf"
+    },
+    "sound/smej2m2/tmnt.jingle.wav": {
+     "bytes": 24214,
+     "sha256": "45cb814aa0a6a49884d32dd63913a355c302b82bd38fd9b97607025ea0585fce"
+    },
+    "sound/smej2m4/burp.wav": {
+     "bytes": 14068,
+     "sha256": "3f2c17e4f791468f212f060193fd44982327345bafe0f61cee12a9b80105070b"
+    },
+    "sound/smej2m4/crow.wav": {
+     "bytes": 57728,
+     "sha256": "a4cb824e44efb80ecbce0f107ee224c84b8ac30b2870ea5abf427ba2ade00ed1"
+    },
+    "sound/smej2m4/drip1.wav": {
+     "bytes": 12344,
+     "sha256": "934926dc22cce182f25bf869089545b75532949a337763b5e0d955f91819f8a9"
+    },
+    "sound/smej2m4/fire4.wav": {
+     "bytes": 37594,
+     "sha256": "8b0bc407cd77f9a262796b048e71e2857c00c909239e48c2387377de8ecc0269"
+    },
+    "sound/smej2m4/fire7.wav": {
+     "bytes": 85206,
+     "sha256": "7979291f5300e271635f1d2bce52f5763bcb4d2f34489753b7e072bf78acef00"
+    },
+    "sound/smej2m4/gulp.wav": {
+     "bytes": 7532,
+     "sha256": "345d0e107723fc52c041d6da084a70be9ab7f9c03a2b2729bb5d3d86e023e7b8"
+    },
+    "sound/smej2m4/tom_floor.wav": {
+     "bytes": 43240,
+     "sha256": "35656dee185ee8e79889a7e57b5b242ec2b6d0bfe04129ebac83f72aa340b467"
+    },
+    "sound/smej2m4/tom_high.wav": {
+     "bytes": 44448,
+     "sha256": "98ae3087bd1d52a050142fed5fc71850bf4db7cc3e052226db32b897c23b8b99"
+    },
+    "sound/smej2m4/tom_mid.wav": {
+     "bytes": 41554,
+     "sha256": "cae724e0b1da3938c7c05dbdb56c5c0bdaf8e6b618f90e6a985f8d273da9164d"
+    },
+    "sound/smej2m4/waterfall1.wav": {
+     "bytes": 661394,
+     "sha256": "eb2000dfd2fc1cd8f500b5036a2232ecb5a97a296153103447df979a4176269e"
+    },
+    "sound/spectre/idle1.wav": {
+     "bytes": 51556,
+     "sha256": "e91f12463417df25badbbdfe817560362370d9e1e31712766bccb086e06d966f"
+    },
+    "sound/spectre/idle2.wav": {
+     "bytes": 82792,
+     "sha256": "b843d1124acc61be2aae27a7c8a9aca8f6bd471689703b41d59f1450e70e360c"
+    },
+    "sound/spectre/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/spectre/swrath1.wav": {
+     "bytes": 6028,
+     "sha256": "7d2290479c4b8fe3cbf14b8e1bddbd6a874b5e9d5f436233eec562f35ca8cfb3"
+    },
+    "sound/spectre/swrath2.wav": {
+     "bytes": 4052,
+     "sha256": "7f9ae2dcb54b6e59c67705c20179a963bb8218d4c96db4323d1fedfb4ad39afb"
+    },
+    "sound/spectre/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/spectre/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/spectre/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/spectre/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    },
+    "sound/start/dr_short.wav": {
+     "bytes": 165116,
+     "sha256": "a69070ab5c53be728c70579df548901e6c741e86540dd8d95f7d2540746afc5d"
+    },
+    "sound/start/forcefield.wav": {
+     "bytes": 67928,
+     "sha256": "feb389e023228507b3c8e1718a57ebabec36af1f474d051b9ee950c4c6a806f4"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "5c5397d74f9480b85911a94593559fc38a4a7be267d267164efef7113096e181",
    "timestamp": "2021-03-01T14:38:52.000Z"
   },

--- a/json/by-sha256/4b/4b97bb3058b22101f1cc72bb389ddc7296ce35b7aa22456bd0dd3bc22b59f5fc.json
+++ b/json/by-sha256/4b/4b97bb3058b22101f1cc72bb389ddc7296ce35b7aa22456bd0dd3bc22b59f5fc.json
@@ -13,6 +13,60 @@
   },
   "pak0.pak": {
    "bytes": 2603985,
+   "files": {
+    "maps/alba01.bsp": {
+     "bytes": 1519196,
+     "sha256": "c2dee0ddd16ee82bb7a4f2a01366532103e1169edffb8afa8ef7471f2b251ea0"
+    },
+    "progs.dat": {
+     "bytes": 436696,
+     "sha256": "114935c3c7e43a410015f9a5e07c3a8bbf3b2e9adc87557946cfd3110fcef163"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "51218d5499e577e3117f68736b112723f68ee8cadf826f6da938900b7fd7bfd6"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 146288,
+     "sha256": "4e50357c755967c9304dedfacfcb378bbc1cef88e3683f14b3cdbe754e89d852"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 186084,
+     "sha256": "6fb69a1f5a5a177f370c12af89a018a67c4d6afff392c26635c8d067d4e80285"
+    },
+    "sound/ambience/comp1.wav": {
+     "bytes": 159396,
+     "sha256": "9c64cac96e19351634cb8d612756970a6c9aac87062c7fcd16368e5fffa60925"
+    },
+    "sound/ambience/fl_hum1.wav": {
+     "bytes": 29760,
+     "sha256": "556fa888915da5a1c97c119d8107098388ec1a6f1dcb444d77f9b3a77388b001"
+    },
+    "sound/soldier/death1.wav": {
+     "bytes": 7887,
+     "sha256": "69704ef04e5965c2f389f74d2b2141b7f0fe62ce127c947ae57c384afd550950"
+    },
+    "sound/soldier/idle.wav": {
+     "bytes": 28289,
+     "sha256": "211095255a871bf2865d64f9b58547a32f56551cfea3a68888d5b92979c25737"
+    },
+    "sound/soldier/pain1.wav": {
+     "bytes": 19417,
+     "sha256": "dcb43299debeaeef3afcd56feaa97a3f11bb030c7c208f32568572d97c36174f"
+    },
+    "sound/soldier/pain2.wav": {
+     "bytes": 12512,
+     "sha256": "ab45be6c38e4a7b86921414d2eb6151fb279b8856581b4660437ceba99b503ae"
+    },
+    "sound/soldier/sattck1.wav": {
+     "bytes": 30413,
+     "sha256": "36d251252367ce80a8547002dd2efef84087100781d4e9947efdd6a4e0f0a342"
+    },
+    "sound/soldier/sight1.wav": {
+     "bytes": 21775,
+     "sha256": "1b5fdb89eaf30cf8b73812892480d0655074cf03e2cdd6a8883045bd0a243d56"
+    }
+   },
    "sha256": "aeb25233550642fdb8234fdaf590f582d1bfc0ba24d14cc9c25df4fb6a1cded0",
    "timestamp": "1997-06-25T00:18:30.000Z"
   }

--- a/json/by-sha256/4e/4e7a4ebe590974771d066c54bc7196e4205e3a783de7254f5b165de992a402c1.json
+++ b/json/by-sha256/4e/4e7a4ebe590974771d066c54bc7196e4205e3a783de7254f5b165de992a402c1.json
@@ -437,21 +437,13021 @@
   },
   "peril3.0/pak0.pak": {
    "bytes": 377820475,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 94990,
+     "sha256": "1fddba1dadd3adef5e0f13d716e514c131455c51b26c2291f71dea0eada7b97e"
+    },
+    "effectinfo.txt": {
+     "bytes": 157535,
+     "sha256": "8dbc7cf30b0bef166f0ce58a59c0f3ce1dcadd9a13867f8430541793fd723cf8"
+    },
+    "effectvanilla.txt": {
+     "bytes": 4612,
+     "sha256": "efd47c12bf71b377f3e750f46d5e242b3337ece446ba9a44cc0750a9bbf9c758"
+    },
+    "gfx/ad_blank.lmp": {
+     "bytes": 584,
+     "sha256": "37b5a1e7d0b3882eb7504e3626f8040a19a6d403e0e761dccd65db935401144f"
+    },
+    "gfx/ad_ibar0a.lmp": {
+     "bytes": 2568,
+     "sha256": "7a66fbbaa742e59d3fdd939ce35befa0f633492482912f4fa91f16d0788276e6"
+    },
+    "gfx/ad_ibar0b.lmp": {
+     "bytes": 5128,
+     "sha256": "5a955a32f0227e4d3e90e908e650c7dc53138b5db2d5bcb3eb4a14fe5c568760"
+    },
+    "gfx/ad_ibar1a.lmp": {
+     "bytes": 4616,
+     "sha256": "eb1c6337becc5c245b873b3d9a6ba5e9c458147f48826a4580ea0ffdf57e9759"
+    },
+    "gfx/ad_ibar1b.lmp": {
+     "bytes": 3080,
+     "sha256": "34e3eec992a3f567d4ac83c98d5fc53ca0a90c02764d45a40eea08d2f94c733b"
+    },
+    "gfx/ad_ibar2a.lmp": {
+     "bytes": 4616,
+     "sha256": "eec2d035f2857fc03083ccf0384ac6446f71b1aa45ed0e2409b8d4ba42c135f6"
+    },
+    "gfx/ad_ibar2b.lmp": {
+     "bytes": 3080,
+     "sha256": "17c35d1d02833d1fe900b1c2beaf77ffe1948a3f17ae790e9f0da1c1057b460c"
+    },
+    "gfx/ad_ibar4a.lmp": {
+     "bytes": 3080,
+     "sha256": "2507c6ce0a53ed62ce73b1bb0ee7e76e9c245757dee54415aeef78767bace887"
+    },
+    "gfx/ad_ibar4b.lmp": {
+     "bytes": 3080,
+     "sha256": "d977ecb360eff9b19827e956d32687234bed64f830adc5e506334a597daa7eaa"
+    },
+    "gfx/ad_ibar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "9d0d2c1eb7e665d0a28130bed09fb8bd698a6a1b246842fa353e3b0e1f5b445d"
+    },
+    "gfx/ad_ibar5b.lmp": {
+     "bytes": 4616,
+     "sha256": "26902c5879207315a7b732e8799f95bdcd45801a8086a902371808a594fa5515"
+    },
+    "gfx/ad_ibar6a.lmp": {
+     "bytes": 7688,
+     "sha256": "cfcce1c48cda88ccd405b1398576476bae52b3cdf7154a0b902a47655dd282cd"
+    },
+    "gfx/ad_ibar6b.lmp": {
+     "bytes": 7688,
+     "sha256": "49487400a56db767d37656f8ccb9e1660f470d8f989619a86bec5c296dcb77f9"
+    },
+    "gfx/ad_ibar7a.lmp": {
+     "bytes": 6152,
+     "sha256": "0d4ababef9a115ca7f6739a01d288d237e22a859ee16c5682d97dcabc4d7aa0b"
+    },
+    "gfx/ad_ibar7b.lmp": {
+     "bytes": 5832,
+     "sha256": "f9292e8d1fff09bde28baf932f11617e27247d4e9af191b89c30811e92110bca"
+    },
+    "gfx/ad_ibar7c.lmp": {
+     "bytes": 4104,
+     "sha256": "0e77dc6602c4945d5d4ec2a12f8003173430945bf7891d979c3c80b0c9212b40"
+    },
+    "gfx/ad_ibar_cell1.lmp": {
+     "bytes": 392,
+     "sha256": "5a4409731e4302bca5245f385a1cab9b91e0a2677d52336bbe3650fdcf070b05"
+    },
+    "gfx/ad_ibar_cell2.lmp": {
+     "bytes": 72,
+     "sha256": "6a519b1e8eed1d7a5365231162fcf1beaf31a6fd1c39b07de09bb0e66dc38303"
+    },
+    "gfx/ad_ibar_nail1.lmp": {
+     "bytes": 392,
+     "sha256": "850189c70ac92f3e8ee79ed9ff6e31ee73d33b5616964461373b37e3a29e60b6"
+    },
+    "gfx/ad_ibar_nail2.lmp": {
+     "bytes": 72,
+     "sha256": "b36d5196c807c6325816db9efad9a16fd7e38433f277b0ad9e6d3551f95c0ceb"
+    },
+    "gfx/ad_ibar_rock1.lmp": {
+     "bytes": 392,
+     "sha256": "f74ce0037116022557ec3a50d368442e73cb48492990a07e93503ad9aeeaa225"
+    },
+    "gfx/ad_ibar_rock2.lmp": {
+     "bytes": 72,
+     "sha256": "081911a352b3d75a4be7812082eee782c41127e70bc4a06585b163d385230a65"
+    },
+    "gfx/ad_ibar_shell1.lmp": {
+     "bytes": 392,
+     "sha256": "733750fbc8235b236f7a2a4246d6112c0a09ce2f75529e359382e25dab92ee10"
+    },
+    "gfx/ad_ibar_shell2.lmp": {
+     "bytes": 72,
+     "sha256": "22fc2a46e85e76836fa38db9868820322833b45e0473407d69378dc09b43e9a5"
+    },
+    "gfx/ad_sbar0.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar1.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar4a.lmp": {
+     "bytes": 4616,
+     "sha256": "5ecbd1e480e4c04e2efe956dcd49e609f0c5a2038f03759b9af848b3cf7dd613"
+    },
+    "gfx/ad_sbar4b.lmp": {
+     "bytes": 4616,
+     "sha256": "8fdfe5e6ffba2c209386580adc196acce9d5601fb529f651267e7186610cc392"
+    },
+    "gfx/ad_sbar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "40c7f9e7ba975d500d3861d0c5a7e592da1ce09fdc31583488fd4c78d823e20e"
+    },
+    "gfx/ad_sbar5b.lmp": {
+     "bytes": 2312,
+     "sha256": "86ff0d9678a52e5428089afe0bb9cdddc9f7688798cee45a396e4d13bf00b60d"
+    },
+    "gfx/ad_sbar6.lmp": {
+     "bytes": 9992,
+     "sha256": "5b47dbc1ae645c429627f563355c43b1fb9145d195d02606d0a7a49791034a28"
+    },
+    "gfx/ad_sbar7a.lmp": {
+     "bytes": 3464,
+     "sha256": "8773683e2edb20dfdea61775d6f955a766a15b7b733ae07212dec922d853f6ba"
+    },
+    "gfx/ad_sbar7b.lmp": {
+     "bytes": 3528,
+     "sha256": "1103f097b9896700ef5a722df927cbe71c76531a09eda9e55e5702d3b4d3b370"
+    },
+    "gfx/ad_scorebar0.lmp": {
+     "bytes": 7688,
+     "sha256": "7c479c4969b9f437c57d710edbdd6b2ce1936aa95adb559c9dd3048680868cdb"
+    },
+    "gfx/adf_1.lmp": {
+     "bytes": 584,
+     "sha256": "c2472fc1e2c58db3b7e6500c25f81c24ddd0a7a21469a9a73a21da8d88a850d8"
+    },
+    "gfx/adf_2.lmp": {
+     "bytes": 584,
+     "sha256": "b530610d078099c3735bd8e459ebd66989372ca0876ac79c3256fcd24a65030f"
+    },
+    "gfx/adf_3.lmp": {
+     "bytes": 584,
+     "sha256": "26eade3291e9309567eeb5e85b492a10563a80fa584fd254c6cea9d662cfeddd"
+    },
+    "gfx/adf_4.lmp": {
+     "bytes": 584,
+     "sha256": "6f62ccfc5e00a8985f722c630306ae872d4f6b411dbd59793a30a89a1dab5a67"
+    },
+    "gfx/adf_5.lmp": {
+     "bytes": 584,
+     "sha256": "cc6503937ed3cc2b2ca51b639b26074322ef5b22ebc6ca65487e770a5c7b11e1"
+    },
+    "gfx/adf_evil.lmp": {
+     "bytes": 584,
+     "sha256": "42445b083abae6e9f4ff009efd7a38d2ddd664ac5e47f97ad30c88a603c64c35"
+    },
+    "gfx/adf_evilinv.lmp": {
+     "bytes": 584,
+     "sha256": "ff0d8b9203d7cfae6d075ef5bfad60cdcf66b1e24bb6fd02be0cada1b7f1c82f"
+    },
+    "gfx/adf_evilpent.lmp": {
+     "bytes": 584,
+     "sha256": "0b0029bc964ed68f1b46ccf0b4bd5e527e33e76c0904a1d06e623c47ca589e56"
+    },
+    "gfx/adf_evilquad.lmp": {
+     "bytes": 584,
+     "sha256": "a511796cca84df8149ea6d3d280880e425fdd486315159462168d32f06a17822"
+    },
+    "gfx/adf_inv2.lmp": {
+     "bytes": 584,
+     "sha256": "71ce2f498612d00ed7d067513ef1c36066f1e3f288e1703c76a70b94075e8698"
+    },
+    "gfx/adf_invis.lmp": {
+     "bytes": 584,
+     "sha256": "71ce2f498612d00ed7d067513ef1c36066f1e3f288e1703c76a70b94075e8698"
+    },
+    "gfx/adf_invul1.lmp": {
+     "bytes": 584,
+     "sha256": "63eec7a165f09f3841bfa7c36ca4dc4ec2910dd947075c0059c22d2a635adca7"
+    },
+    "gfx/adf_invul2.lmp": {
+     "bytes": 584,
+     "sha256": "63eec7a165f09f3841bfa7c36ca4dc4ec2910dd947075c0059c22d2a635adca7"
+    },
+    "gfx/adf_p1.lmp": {
+     "bytes": 584,
+     "sha256": "943051a021a96b6890c6d23344192251f049593f1685896c038e06a42f4427a5"
+    },
+    "gfx/adf_p2.lmp": {
+     "bytes": 584,
+     "sha256": "01d3c1bc1b256a0f1678f23dfbc6ff5504c688e6199925f5f0b045b4d70c79f1"
+    },
+    "gfx/adf_p3.lmp": {
+     "bytes": 584,
+     "sha256": "46f60aec038d4caa3434215182275b86377d32a9455da0eae985b3b0831f97ff"
+    },
+    "gfx/adf_p4.lmp": {
+     "bytes": 584,
+     "sha256": "2e7ba113ca5ee23c279dd22db263c061d80bf9b4e2ee8bf8bdb938951fae21f3"
+    },
+    "gfx/adf_p5.lmp": {
+     "bytes": 584,
+     "sha256": "cc6503937ed3cc2b2ca51b639b26074322ef5b22ebc6ca65487e770a5c7b11e1"
+    },
+    "gfx/adf_quad.lmp": {
+     "bytes": 584,
+     "sha256": "8ed495fdb0378722c34cf4bd525b171524c970982eef0492d9e948c99f3fdb10"
+    },
+    "gfx/adib_atank.lmp": {
+     "bytes": 264,
+     "sha256": "8d963c818c0554d73d14b251eeed0321cf854777f29eddf5a82ee3fb3fde8035"
+    },
+    "gfx/adib_axe1.lmp": {
+     "bytes": 264,
+     "sha256": "90b6817aa64570e9bfc36a13e6dd1930e81468f931ceac9f2ae3790f99f2dca2"
+    },
+    "gfx/adib_axe2.lmp": {
+     "bytes": 264,
+     "sha256": "2b0821038185e41c711e399dcfff37fd54aa8f7473ba81754c379fae558a5a1d"
+    },
+    "gfx/adib_bbelt.lmp": {
+     "bytes": 264,
+     "sha256": "8b50ea739ca8ab52baefe65f90ea5943fcc4f05b63b214a36b3ae6fa4feb55a8"
+    },
+    "gfx/adib_ckey1.lmp": {
+     "bytes": 136,
+     "sha256": "8525e145fdc72947ac6d4599ae0304b84793475d44f0113c925905d715c2da8e"
+    },
+    "gfx/adib_ckey10.lmp": {
+     "bytes": 136,
+     "sha256": "a2e14b68c10109e48e86bd095775beb68f03640dfdb12d1c28b6d32abd1fa329"
+    },
+    "gfx/adib_ckey11.lmp": {
+     "bytes": 136,
+     "sha256": "2b9191d85075d6a6c06d8b295c48546ecc0bd1c91a860308f6f953dcf324604c"
+    },
+    "gfx/adib_ckey12.lmp": {
+     "bytes": 136,
+     "sha256": "9b04f101468d96f4c39d97da0be44f7152179e4a8d6a05762ca693c9f84db317"
+    },
+    "gfx/adib_ckey13.lmp": {
+     "bytes": 136,
+     "sha256": "35fa377dbf162d691de012a61458b5ec29c28b776cd3ee0e0f9ab0ad57b67c8f"
+    },
+    "gfx/adib_ckey14.lmp": {
+     "bytes": 136,
+     "sha256": "ea6b831467c97fb0ba18d97a549c54304b133830e1567ae300e83514bdbb2919"
+    },
+    "gfx/adib_ckey2.lmp": {
+     "bytes": 136,
+     "sha256": "5c80cec0c7808ed141fff4f6863eccfa71b06a7405e871c75912d5d065b4ff21"
+    },
+    "gfx/adib_ckey3.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adib_ckey4.lmp": {
+     "bytes": 136,
+     "sha256": "51ea09fa8db26de3ce6ea6c1a5abecf4c31c3877ab6c508811ea9b271f40f1fc"
+    },
+    "gfx/adib_ckey5.lmp": {
+     "bytes": 136,
+     "sha256": "e03ed662e981530264f6dcf6f6dda91fd8406c0941d0f7c4370a89e0c4f467bc"
+    },
+    "gfx/adib_ckey6.lmp": {
+     "bytes": 136,
+     "sha256": "6f4f61addc77e3492c08cd382291eaf3f8c28a7499137591dcd2c6706bb1ec57"
+    },
+    "gfx/adib_ckey7.lmp": {
+     "bytes": 136,
+     "sha256": "38c3473948f4769e4309bdbb390afd0663fc093f1f76c9fbf10d818c6f89c72b"
+    },
+    "gfx/adib_ckey8.lmp": {
+     "bytes": 136,
+     "sha256": "d0c43a81abfb623b7c3392a07b484b6bf9137fede67d78dc67864848ecbc1c12"
+    },
+    "gfx/adib_ckey9.lmp": {
+     "bytes": 136,
+     "sha256": "042cdb7aef3e06a5679158b4f33fc66ca2d97dd6cf9e7e2657b1e85e444ed006"
+    },
+    "gfx/adib_invis.lmp": {
+     "bytes": 264,
+     "sha256": "f4f1be9a2ef88b75fd9971d72796a35f7de1ed04fc2cfc3a4c35225976f21eca"
+    },
+    "gfx/adib_invuln.lmp": {
+     "bytes": 264,
+     "sha256": "87b8312e4d7fc20d6ae9df6d1f8cb616392f3a2adaf7208dd2372eefc19888a3"
+    },
+    "gfx/adib_jboots.lmp": {
+     "bytes": 264,
+     "sha256": "206ad9d67636b46418e6afa6b6e75a12df76bd3ad84b0178e86b8d140b9c3afc"
+    },
+    "gfx/adib_lshield.lmp": {
+     "bytes": 264,
+     "sha256": "79a78f4402a301d381bef260b895ba56757b779ae89b7ae5a49f8146f2a7a54a"
+    },
+    "gfx/adib_nailp.lmp": {
+     "bytes": 264,
+     "sha256": "fe59667c80612fd2e7f5d95dd0a208f3909d93eeaaab7e4580405fe153469fde"
+    },
+    "gfx/adib_quad.lmp": {
+     "bytes": 264,
+     "sha256": "915832c8c822daf8cfa1c5d88548f24da7d182be6746b265e7ae6e1d735082cd"
+    },
+    "gfx/adib_sharp.lmp": {
+     "bytes": 264,
+     "sha256": "18987634aa43dced4e06e1d5a9a3f9b1f51c7738f59fae64168bd94ab9cd6198"
+    },
+    "gfx/adib_sigil1.lmp": {
+     "bytes": 136,
+     "sha256": "34b11b26dcdf5b91f3e6e08bbe6edb83f62ba054e9eef28459cef09b742e1456"
+    },
+    "gfx/adib_sigil10.lmp": {
+     "bytes": 136,
+     "sha256": "af31a42ef81449aa656327dfe00fc1e1d744f90212ac228bd05a6d79f5048683"
+    },
+    "gfx/adib_sigil11.lmp": {
+     "bytes": 136,
+     "sha256": "9fb90ba79d5c34e2b0afdbcec8bc528fd7d3d8f2645191d95a67a65e242bd3c6"
+    },
+    "gfx/adib_sigil12.lmp": {
+     "bytes": 136,
+     "sha256": "d7c9c3c7c1167ea0791b2790d678d6bd25144adcba79d6f7c5d93302fc28119d"
+    },
+    "gfx/adib_sigil13.lmp": {
+     "bytes": 136,
+     "sha256": "0003389cd694c55fa36f1d18d38261d279c5c7ef23dd5d41c3852ad8c95e5a49"
+    },
+    "gfx/adib_sigil14.lmp": {
+     "bytes": 136,
+     "sha256": "8ac47a2e1d45d94fb1f222811320c5f07e39e65698b7436515afa29de6e1204e"
+    },
+    "gfx/adib_sigil15.lmp": {
+     "bytes": 136,
+     "sha256": "153627403fd3e3856aa34e8740fdebb5ddb26e201cd590dd76cbfc12c36e49c6"
+    },
+    "gfx/adib_sigil16.lmp": {
+     "bytes": 136,
+     "sha256": "fa95a1a372ce30516252fff8dbcda8f8f55e3cc558b4a1e7015b79838ff0cda1"
+    },
+    "gfx/adib_sigil2.lmp": {
+     "bytes": 136,
+     "sha256": "0a0c22f027e980014a246daa629b6f84f425ccfd828f75a93ef777d9616c9191"
+    },
+    "gfx/adib_sigil3.lmp": {
+     "bytes": 136,
+     "sha256": "9e5daafbe4cc032824f732ebdac3897d804df43efaff9901c315ae661af8cd31"
+    },
+    "gfx/adib_sigil4.lmp": {
+     "bytes": 136,
+     "sha256": "fd1d3791d53ab40881a2d86a0bc67b3b532ef10b201a166a3937b105c63e3c9b"
+    },
+    "gfx/adib_sigil5.lmp": {
+     "bytes": 136,
+     "sha256": "947d5088b18a12d06a93fe66a0500e5b6ae93e04cebc748858139d569693d42d"
+    },
+    "gfx/adib_sigil6.lmp": {
+     "bytes": 136,
+     "sha256": "5a2356a7479f887b20f10e03ee2f42478bdfa75febe2d802b3dbfcd25b39d744"
+    },
+    "gfx/adib_sigil7.lmp": {
+     "bytes": 136,
+     "sha256": "507011b2a191e096fadcd678590636e4033de2ffcf35cef31785539bf3f9fb4f"
+    },
+    "gfx/adib_sigil8.lmp": {
+     "bytes": 136,
+     "sha256": "2a49a4653b2ed11353c6aaca950420c38c8e7b2aa8cc82ecd746a4e73fb7aa00"
+    },
+    "gfx/adib_sigil9.lmp": {
+     "bytes": 136,
+     "sha256": "df168192d5c065c7247cff03b10da51eba431bdc4f76d2c913646bb23084d639"
+    },
+    "gfx/adib_suit.lmp": {
+     "bytes": 264,
+     "sha256": "030bf62f7f45667310f1a74bd88881e2aa8d6c7ba5355bda4bc7c87d64a3d082"
+    },
+    "gfx/adn_0.lmp": {
+     "bytes": 584,
+     "sha256": "0895fe0acba04a4e17ef64fe62c56765c4fef5933c4af09dfcb242e984e8d163"
+    },
+    "gfx/adn_1.lmp": {
+     "bytes": 584,
+     "sha256": "fc0391c514808f9cb54e0bb0bbd63edccb0bea66a7620b81d04497edd099f5b1"
+    },
+    "gfx/adn_2.lmp": {
+     "bytes": 584,
+     "sha256": "d70ca75a162f7203067f314eee6460dc9180383e5bd1a19c69a984d8f4c699ae"
+    },
+    "gfx/adn_3.lmp": {
+     "bytes": 584,
+     "sha256": "40fbf34b86a4e5d264fac3c875ad74a52b62f5868d01a7580107a52998cbe4ac"
+    },
+    "gfx/adn_4.lmp": {
+     "bytes": 584,
+     "sha256": "5c9f781b8fb46cff0bb69db9817936be10cc4e34d677a5a49f117baa1d414aef"
+    },
+    "gfx/adn_5.lmp": {
+     "bytes": 584,
+     "sha256": "f2b1a90d1f4e1e3c6eb04dd1d87f084b2bc932b76b6eabcc5a4ee12db939971e"
+    },
+    "gfx/adn_6.lmp": {
+     "bytes": 584,
+     "sha256": "ec90a75650252feb45f325815498caf518058d141c7660e594397e0e05e35cfc"
+    },
+    "gfx/adn_7.lmp": {
+     "bytes": 584,
+     "sha256": "c292389fee1e91c2c4178099a8c9b2ad193f74346adec126ae10a4383f96c6de"
+    },
+    "gfx/adn_8.lmp": {
+     "bytes": 584,
+     "sha256": "4df870d66977eddbb7c4f87ffe4b94a032f2f13ad8fa38a98fde607d7aa7b06d"
+    },
+    "gfx/adn_9.lmp": {
+     "bytes": 584,
+     "sha256": "fd7f393a0fea9c0bc9fec90492a8f074a75275fde2ce211379b098176729622d"
+    },
+    "gfx/adn_a0.lmp": {
+     "bytes": 584,
+     "sha256": "7221532ee9af2c3a2fa3d19e4ccae78458d7a1f3025627e6da45dcb4aefd6820"
+    },
+    "gfx/adn_a1.lmp": {
+     "bytes": 584,
+     "sha256": "8f594ea65757fdaa62105b5eb68d4519b96b93e12dba110a723c4bf99470d408"
+    },
+    "gfx/adn_a2.lmp": {
+     "bytes": 584,
+     "sha256": "738cd71a2344da4b1733b639e6cdef1fb412104c388d2edee0b4539655ed9fec"
+    },
+    "gfx/adn_a3.lmp": {
+     "bytes": 584,
+     "sha256": "00c7040d33a445656f33c373077564116a764142f4625b5df7fae6516817f893"
+    },
+    "gfx/adn_a4.lmp": {
+     "bytes": 584,
+     "sha256": "7fbde831e189692c1c5d048873e7098a7d017ff7e22fc57a724a2c2fcbcc8db4"
+    },
+    "gfx/adn_a5.lmp": {
+     "bytes": 584,
+     "sha256": "ecb1a8036b03abc3c95a145081762ebf8b04516bc438053e570b989195687615"
+    },
+    "gfx/adn_a6.lmp": {
+     "bytes": 584,
+     "sha256": "8495247be5584836815824b182f448348d3de924236e254c5ebffd8132a1b7ae"
+    },
+    "gfx/adn_a7.lmp": {
+     "bytes": 584,
+     "sha256": "76a1b4a37c14cf3c53047129e14bb3f2217142ca5405ebceb95b892bed49cb77"
+    },
+    "gfx/adn_a8.lmp": {
+     "bytes": 584,
+     "sha256": "943ae9da4710dfb8a8b7b22eb8ecc6131e7c4586f279701323997f931bdd486f"
+    },
+    "gfx/adn_a9.lmp": {
+     "bytes": 584,
+     "sha256": "4381c6e590644e7c7e3d64e89adb1d438802e1a81380de8f08b31669780f07ed"
+    },
+    "gfx/adn_aminus.lmp": {
+     "bytes": 584,
+     "sha256": "903c3e6081e934fb4a9b0ae4564265b0339d2289fea17720c7bac77d00155258"
+    },
+    "gfx/adn_colon.lmp": {
+     "bytes": 392,
+     "sha256": "a06510a33f355c24fc16d7591323523f13920ae6fa903c3155b5edef9e4059a9"
+    },
+    "gfx/adn_minus.lmp": {
+     "bytes": 584,
+     "sha256": "1e04325b97c5052e64187e0882b8c2f87473bd66f3e70b5a419d983b0a62ed81"
+    },
+    "gfx/adn_s0.lmp": {
+     "bytes": 264,
+     "sha256": "6a5cac8d7c8076aa42055c3b64f3fde4b1e7750b2bb143b12af07dec892c9ccc"
+    },
+    "gfx/adn_s1.lmp": {
+     "bytes": 264,
+     "sha256": "723ec3e0b6225419fa5fb8010896674d91d19eeafd8e2c9bbbec2d23fbb85792"
+    },
+    "gfx/adn_s2.lmp": {
+     "bytes": 264,
+     "sha256": "cff9bff09933ccbf43a1419d6f566807c2aee9a4aca448a86bf261394b3ca7b3"
+    },
+    "gfx/adn_s3.lmp": {
+     "bytes": 264,
+     "sha256": "8d7cf6b3f2db7463e962fd7b70b2ef7c36b0882b1e80d90b02fa1a609d09513f"
+    },
+    "gfx/adn_s4.lmp": {
+     "bytes": 264,
+     "sha256": "2bc5fa316cc366f4d1a4f1831ac3b8ced65caf89157e796ff5d673fa3955ac1c"
+    },
+    "gfx/adn_s5.lmp": {
+     "bytes": 264,
+     "sha256": "98cbff3f1b98977b8fc19523fc2e644e763fc52dba708fc5024dfbeaa1f00d6d"
+    },
+    "gfx/adn_s6.lmp": {
+     "bytes": 264,
+     "sha256": "1578d854415aaf5b68a25a0fb37057b019d12055b61c3d7402eae811a9359e1f"
+    },
+    "gfx/adn_s7.lmp": {
+     "bytes": 264,
+     "sha256": "609059534b0a59c9d5ab1180f25f0b2a952719a0ccade29d05559dfc6223f1d9"
+    },
+    "gfx/adn_s8.lmp": {
+     "bytes": 264,
+     "sha256": "7327dd480225a52c642320336ade17100228d2c1ade5f1b640cbff18e37fbe2d"
+    },
+    "gfx/adn_s9.lmp": {
+     "bytes": 264,
+     "sha256": "b8ad416098543b34c286565e3a0d7756eea7ab18c8b50145e7ddbc45fd28851a"
+    },
+    "gfx/adn_slash.lmp": {
+     "bytes": 392,
+     "sha256": "2500358f0d4bf9856c04b7be940ab41012faad597005837c99dfef93da1f3ca6"
+    },
+    "gfx/adsb_armor0.lmp": {
+     "bytes": 584,
+     "sha256": "01228bb8947103a70c9f536b168eefacda9dc5a08e1fa64ee963be44d4a9af9c"
+    },
+    "gfx/adsb_armor1.lmp": {
+     "bytes": 584,
+     "sha256": "85956c2a17460229a374e8a6e1cf22ad4ff663929dba06c9daa9d95d1582ba53"
+    },
+    "gfx/adsb_armor2.lmp": {
+     "bytes": 584,
+     "sha256": "e8e64ea8d90241677315bb9a9e25714856827642a0e331077dc6fa2b827036fc"
+    },
+    "gfx/adsb_armor3.lmp": {
+     "bytes": 584,
+     "sha256": "db6523d7c99bb15c14ad9fd1d665a24e4eab985dfa095d316f20fe5e96e9c320"
+    },
+    "gfx/adsb_axe1.lmp": {
+     "bytes": 584,
+     "sha256": "ebcafdd02b84a9bd21658a349205a09e5e242fa39013207fe6aab9697df2884f"
+    },
+    "gfx/adsb_axe2.lmp": {
+     "bytes": 584,
+     "sha256": "12caae98c176f1176a5222f7730709dcb9164a5db63984fe6f8982e8b17915e6"
+    },
+    "gfx/adsb_cells.lmp": {
+     "bytes": 584,
+     "sha256": "08da91ae0bca3d7bd546d92f7688061b7fbc8d86b84e309510ee3feeb3f63e92"
+    },
+    "gfx/adsb_key0.lmp": {
+     "bytes": 392,
+     "sha256": "49e4cda132ff7237a4b7244892fa1e059ff2d77698ec855cb4c02e08867899e2"
+    },
+    "gfx/adsb_key1.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adsb_key2.lmp": {
+     "bytes": 136,
+     "sha256": "46a6561c191c47e9445ef85c2bebdc881f330ca49afe562d7bb2a59c5442c73e"
+    },
+    "gfx/adsb_nails.lmp": {
+     "bytes": 584,
+     "sha256": "77fb4c0c61d824fafba54e91d6b23e702ae54565d7708ee0e404aff804555b73"
+    },
+    "gfx/adsb_pent.lmp": {
+     "bytes": 584,
+     "sha256": "8066cd0ef3d3ed9add280937fa51d6dd13a7eaf606ad0567366e86c51ddb7d62"
+    },
+    "gfx/adsb_rocks.lmp": {
+     "bytes": 584,
+     "sha256": "2e79b7c3e3fb6b4118a3ddedd7d9a1186f12c2df2efdbcf5300cacc51fe64744"
+    },
+    "gfx/adsb_shells.lmp": {
+     "bytes": 584,
+     "sha256": "f185cb1b1a48a8499d110e6371f2bb102ad89fda9875a267adcc6f3c8a5e613c"
+    },
+    "gfx/adw_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "ee32ef4cb14c02b9516f245fe9eae50021962ebdee3ef843076b9dbe20f038fb"
+    },
+    "gfx/adw_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "0f8884976f5ef05d5c3d7ab7c7b22bddeba9ee922664d23c6dfe835c5673ad9f"
+    },
+    "gfx/adw_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "2c1f7b1b0a5c27da9f01c84a38571901fb3636a04485102f44cb19d715e7f627"
+    },
+    "gfx/adw_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "a9802bea98b2fb57ab97784caeebf1ab2312fab73146503459c7c8021249ccef"
+    },
+    "gfx/adw_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "0c92aaf91afe914f4d06e5d2fa91bf926a0b43294d49021755b93c049e15a99d"
+    },
+    "gfx/adw_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "155eeca532e2f6d08b7575697020eebd4f492987392c68f09c66bb6522c0336b"
+    },
+    "gfx/adw_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "02d55707616bd6eae995c93d5eca3e788f227811001e2e8137c07cafe85409a4"
+    },
+    "gfx/adw_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "0d4cba204d9ea74665e164d46ead9167095cceb64a795861dfb21fcfd2b3e9ac"
+    },
+    "gfx/adw_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "3d354bd9336125ea758f2b5b56b1ecdf2a2afea4e8bb8d6edeb058448f9627e7"
+    },
+    "gfx/adws_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "457f6682e5a8b3d7b1075148c05093df1ec96c59e85057dfca80f66f4ad25815"
+    },
+    "gfx/adws_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "127d3759679f91a8633557a27abcb8425b3f8fd8b9888e029f761cff9fa20e47"
+    },
+    "gfx/adws_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd1e14b26cfa3915c23502e22413328d37749e0a77ac75508238fbaa375c7555"
+    },
+    "gfx/adws_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "424a425e24162a3a1a23e7308b8b46f4d25f1c9f11ac3b427117c596dafeb006"
+    },
+    "gfx/adws_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "41dc9eb1fb806500b41d832786a0bce0c6863c6caa3bcc7491892e25d04a81d4"
+    },
+    "gfx/adws_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "30a22fc8975b5a696ff31e859290fd780553f1857e424b1d5ecfa057277d155a"
+    },
+    "gfx/adws_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "50c5e9c358023dbbb65cc79346d99af6797af556faded31df95e2b7191aeb3f0"
+    },
+    "gfx/adws_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "94cef7136e718532b4d00b9ed8804da60be979206bde676a328270321286851a"
+    },
+    "gfx/adws_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "8259db2f3f7ddd075e6192d6e0581a2321c108232d67980fab85059fcbfe47df"
+    },
+    "gfx/adx1_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx1_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "e4d0714014c5a1c0d9874bf1ce2c0232352be1e0c90ffe927dc2d86d448f7e47"
+    },
+    "gfx/adx1_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx1_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "9da68076978e9bc4d35e2b40e972c578e0839c379c86d44bf15c033f164fc9e9"
+    },
+    "gfx/adx1_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx1_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx1_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx1_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx1_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "9341894f953061deffb42e12370fd05b7f8008e2a1caee149630a8bcd40fac10"
+    },
+    "gfx/adx2_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "c5f2e4352837eca0a67b1fe6eb5d437672f365efffd7c297848dcdbfca6fea7f"
+    },
+    "gfx/adx2_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "b627ea70b6a7a5debddd4710f31ca137c3baf01dd6109cc2cee7da968a020049"
+    },
+    "gfx/adx2_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd7a15d826f6565c97f638ff541d76e409b9cc69febbb78906c5ddbbad2e0f02"
+    },
+    "gfx/adx2_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "8239bfd1d494fae52f97d5f620bf6c9cace057a27975cddf7d0f557b5a797cb6"
+    },
+    "gfx/adx2_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "6adf5220508ec39cedaf8cc8208c8b7bff5f44f18401bc5ee7a39e91419376ab"
+    },
+    "gfx/adx2_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "f300febb1aad7dc16d592f1e1aef2cc5a8870ad08ebbb2bc15b43009122259ae"
+    },
+    "gfx/adx2_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "e15bf6fb56eca5640d521dfdbe0c20f9e3ce6fb6fc7a2e39922f0fc8cfc7d002"
+    },
+    "gfx/adx2_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "c781852ce141a1d5fb84451e1bef2b021c937d0658d7ca8f8b2a1d5cc3737a66"
+    },
+    "gfx/adx2_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "aaaac2a8b4dfaae3d02705c2fbffa38621187cc28f4246a591f38b2bec79f693"
+    },
+    "gfx/adx3_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "20209da4ccb0dbeffc6520aee7958b33bcfa728ed376b1f5f987c8305fb70d3e"
+    },
+    "gfx/adx3_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "eb13bcc843d95abf3c90c140c95aa95803a42a6afeb100e11a5e0d80c72caf8b"
+    },
+    "gfx/adx3_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "483f85f7e5a0e881f6511f2b16a25d1945dcc2fa5365e4417cb58ec6a87f062d"
+    },
+    "gfx/adx3_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5e1f15716b826a8a25e61415e675a6c94888ae4030462e1190653c4d93768743"
+    },
+    "gfx/adx3_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "99d58b01e578c88924699f85614b021dcc5ce32798c96680fb5120e8d58837c2"
+    },
+    "gfx/adx3_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "4eae7b9a7119e883d3b6d3b8b336398beca8b7cf4ed2b9b498e13d90b7743ccc"
+    },
+    "gfx/adx3_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "8568e0c106e3155b9cef3dc3bd55ce821ed151560abab4080fcf6534850b153c"
+    },
+    "gfx/adx3_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "b8764c3198aa863d67e4f7c3c19db89aab6aa4f4076abe83d50b88710eb85446"
+    },
+    "gfx/adx3_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "fbb92c8a0853070604e84da82a5232c93747f3571ba05e88ecb4e59649125838"
+    },
+    "gfx/adx4_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "4e8da401756d091a913d4a0a5618aee7eeddad1bcd8c78774bc229195bd96943"
+    },
+    "gfx/adx4_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "c68cec0c6064b7ceaad60028ed1e8f7834a6484d9fde249649d7b94addc6544a"
+    },
+    "gfx/adx4_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "386eadd2ee00c5a53179729c2b23cf56f0629c3e7ad8e5b3a739f1fd8d489d34"
+    },
+    "gfx/adx4_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5179dcb2b82032c81d02dfb35d130ed8196d5b726c7a8265c2823c3f2edde2a8"
+    },
+    "gfx/adx4_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1156e8a090be24e24605153b059646bd7d8b9d33c6e175bc9b05843eb626ce38"
+    },
+    "gfx/adx4_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "8881a5fe764d90c1113e1df7215c6520988c23601a969ea3e7b9abf8d7d4ef0c"
+    },
+    "gfx/adx4_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "7b55d6f2071d101db2a87c5958aadcdcf618f8f0eab53b19691125c1e8b6d8ad"
+    },
+    "gfx/adx4_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "199a6be6977bbebfe0aac0005466b10bfcdd9d26a764d18e56e28ee6f6f8f5ee"
+    },
+    "gfx/adx4_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "924cd9a6ac66660db99821b558a21e8dd0b02e85bb2a5415c2e24daace249663"
+    },
+    "gfx/adx5_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx5_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "9405034666f0f1247a58a97b86e5c451f0b2a315501389f43043da55493db8de"
+    },
+    "gfx/adx5_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx5_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "6c529185a7cc6dc8d066080c4246f80c7bf1fd0ea808fc0be5be63c8cff7c2b3"
+    },
+    "gfx/adx5_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx5_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx5_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx5_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx5_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "bb8e065bc9d9935d7fab8e9d0d0554948e2ab2622a54e86f70c1d8c3c9a0f178"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "b941e3ec692b990d1dbe0fd69c1e043b9d504374d791c8c981cb091324072826"
+    },
+    "gfx/community.lmp": {
+     "bytes": 256,
+     "sha256": "7d425f7678b30e94f816c93391c3322ed354c9657ef2563c964b2abb0d57d933"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4424,
+     "sha256": "56da4ce791ee32185fa4ec6196bd294c29e6fa555f8f2f3d3b66f77812602699"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 1310728,
+     "sha256": "922d241cc50f2fdafe3f7d9effc5aa6f2f0233c34f74b45a8340b6f30447c408"
+    },
+    "gfx/conchars.lmp": {
+     "bytes": 16392,
+     "sha256": "045ea49c02bc0e51336e84fb19f4c445ece3c0d8c6ec4aba3cac0fcbf4306c15"
+    },
+    "gfx/conchars.png": {
+     "bytes": 14283,
+     "sha256": "1b63b3d252a0d234553153910c6d5384de0bbe050f095ebe00d253ffab2db8b9"
+    },
+    "gfx/conchars.tga": {
+     "bytes": 65580,
+     "sha256": "6dbfcc084e12e7c053c49f257f0a2276014a46ee92d194008893a39416e9e486"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "8954bff0fefb816e69b588bdf1ebd5032e20c6b5d82a17114567134627cb5873"
+    },
+    "gfx/env/adgreenskybk.tga": {
+     "bytes": 1520289,
+     "sha256": "6a7fa2cdc97237658a3f2c73a8a5d879feadf4a31e84fb8585aeba96f3f8fb61"
+    },
+    "gfx/env/adgreenskydn.tga": {
+     "bytes": 1565620,
+     "sha256": "d4fabe617a431169df1bbc37e48404fc34718a1bbf5a1ee45d5b3a0ddda5cc6c"
+    },
+    "gfx/env/adgreenskyft.tga": {
+     "bytes": 1704063,
+     "sha256": "c6cfbbd8b09846eaea719a5e65744cdd4fddced0c277f4584c743f2639882d50"
+    },
+    "gfx/env/adgreenskylf.tga": {
+     "bytes": 1576943,
+     "sha256": "c83f24917ccb67af83602236d03e57096f73b36b7fc64da6206afe989944b4a4"
+    },
+    "gfx/env/adgreenskyrt.tga": {
+     "bytes": 1706213,
+     "sha256": "7b85287d2ce5e4d3a9ce63a560183086e812ceca9232d07eb61f63a24d678e10"
+    },
+    "gfx/env/adgreenskyup.tga": {
+     "bytes": 1798684,
+     "sha256": "703e4449b5b9ff967610dbc81d7e27c089788927d82fdb31267490cfb30ed0e3"
+    },
+    "gfx/env/asap_bk.tga": {
+     "bytes": 786476,
+     "sha256": "9f6daf48061bdc132ec28062c494d4a6abe2eeda2c86b575ac7df472a97b2c80"
+    },
+    "gfx/env/asap_dn.tga": {
+     "bytes": 786476,
+     "sha256": "a8aa31d47f7537150c1023713588b87cceff0072036ea64c895129fccfd9fa9a"
+    },
+    "gfx/env/asap_ft.tga": {
+     "bytes": 786476,
+     "sha256": "067cca994d96dcc95903ea1d3c023c479d66a655b2d3412116d462dff4e155d7"
+    },
+    "gfx/env/asap_lf.tga": {
+     "bytes": 786476,
+     "sha256": "761640856a2500019db4c3fae214fe2043fbc0edffa3e6c508d964a86b98ecf5"
+    },
+    "gfx/env/asap_rt.tga": {
+     "bytes": 786476,
+     "sha256": "08d03cf9826300c6d283028f60663f5bd3f6564a7deb5e15078440e18e1433cb"
+    },
+    "gfx/env/asap_up.tga": {
+     "bytes": 786476,
+     "sha256": "d98b750d0908addc2b0c9d513bc0bfc5d28935c9536f437cfcc3796fc0f5ce82"
+    },
+    "gfx/env/atsea_bk.tga": {
+     "bytes": 632859,
+     "sha256": "0170bac6e1114edec6fd9add7dd474b24dc047d4a1e05518b9bd5eb03444e827"
+    },
+    "gfx/env/atsea_dn.tga": {
+     "bytes": 574894,
+     "sha256": "0c1498451cd053afe41d6409ba14b156608623d316708d6a7e49383355b93fbd"
+    },
+    "gfx/env/atsea_ft.tga": {
+     "bytes": 578784,
+     "sha256": "9542abd9f7b51885b945f184e779caf83722f49dcbd1d623aba5424302fc07eb"
+    },
+    "gfx/env/atsea_lf.tga": {
+     "bytes": 603631,
+     "sha256": "a97250f90147c6633efdfe4a81234cf488a8e4b67f64352e8b009f3542be94e5"
+    },
+    "gfx/env/atsea_rt.tga": {
+     "bytes": 661491,
+     "sha256": "171aff8c805afccb39a373b4b41263650313082e00d8c1e9b6370b5a7b535e9f"
+    },
+    "gfx/env/atsea_up.tga": {
+     "bytes": 634513,
+     "sha256": "1bad6c1b80666490aefcedbc46821cbecec2c2c766197fb15b90954a0be21b0e"
+    },
+    "gfx/env/black_bk.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_dn.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_ft.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_lf.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_rt.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_up.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/bloodline_bk.tga": {
+     "bytes": 80581,
+     "sha256": "e7bf936b5ed5155b4abe8c3cb0038dbf1b0d1c3ee28fe97f410fbd3d0dff3b91"
+    },
+    "gfx/env/bloodline_dn.tga": {
+     "bytes": 10779,
+     "sha256": "96c30b0284fa45625bf67eebe3a4a7cbc8b43c1c7c8108da505aaa90031b956e"
+    },
+    "gfx/env/bloodline_ft.tga": {
+     "bytes": 77165,
+     "sha256": "d7ec654bb7942f9fcc56a2b836351952cd8e3284b3e0da410ea103fb122a73f5"
+    },
+    "gfx/env/bloodline_lf.tga": {
+     "bytes": 46158,
+     "sha256": "a6825a8dd688af7744d6ff65b74f7fb3609b5747410901a7e67b62a38786a928"
+    },
+    "gfx/env/bloodline_rt.tga": {
+     "bytes": 76590,
+     "sha256": "a51bf5015e85e21c1ea895c42d238c5a60c8f8218c5fb59ffa05fd5b98eb839e"
+    },
+    "gfx/env/bloodline_up.tga": {
+     "bytes": 218777,
+     "sha256": "51b1be8163259d85506568c1b60ade9a40c549bd8937bda5ecc985342dd3a0dc"
+    },
+    "gfx/env/bluemoon_bk.tga": {
+     "bytes": 786476,
+     "sha256": "e139ee039deb769a0e47544cd98bb90c32df9da8e7d585941b73ddc0d74c560a"
+    },
+    "gfx/env/bluemoon_dn.tga": {
+     "bytes": 786476,
+     "sha256": "b79f908d16761ef4b2c5de213e9550a92fd9d14ff812255d10deb2f9b273cc91"
+    },
+    "gfx/env/bluemoon_ft.tga": {
+     "bytes": 786476,
+     "sha256": "c5302cfa578f1369fd73ffaba8b26730cbc0b65a443406e1e33502e0e14deaac"
+    },
+    "gfx/env/bluemoon_lf.tga": {
+     "bytes": 786476,
+     "sha256": "6a92c9d2664fba95993a39fff066f839582d07283064b12d295c4cce9cd6869e"
+    },
+    "gfx/env/bluemoon_rt.tga": {
+     "bytes": 786476,
+     "sha256": "84e7dbfa73fa6f530ef34e5fd56150decd76b336d936c7f7cbe1bf687d2e3db1"
+    },
+    "gfx/env/bluemoon_up.tga": {
+     "bytes": 786476,
+     "sha256": "db9161f2217180e8887ad5239c19e3a48ae3520dc38a5a81320dbc8036e3e671"
+    },
+    "gfx/env/dawnbk.tga": {
+     "bytes": 791801,
+     "sha256": "3a415bd258f1d81bfddc5091dd67829e7b9c2d247c7d69ea263a6e743e3971e5"
+    },
+    "gfx/env/dawndn.tga": {
+     "bytes": 1032293,
+     "sha256": "33c9b1bc0ae74eeae43a90f44397cb3d2747ec40190f5b0bf28ce62d0943cf98"
+    },
+    "gfx/env/dawnft.tga": {
+     "bytes": 1206497,
+     "sha256": "1947bb641b84fd09cd9b0c17256f809fc13c81eca40520576d1ea3e2c57ea9b4"
+    },
+    "gfx/env/dawnlf.tga": {
+     "bytes": 1141280,
+     "sha256": "cc68776448bb864875e8e4ea181f6aa83800fa00ad15fca9f9ae3ac24b35d320"
+    },
+    "gfx/env/dawnrt.tga": {
+     "bytes": 1031739,
+     "sha256": "24be76b64c71f5a589f219ceccad23a68fc4e26f45a2a8a4183792bdbe7fc71f"
+    },
+    "gfx/env/dawnup.tga": {
+     "bytes": 1426811,
+     "sha256": "e4f5dabd8690dc8460d0032fba1d633d69222a242749803e960643d3cdd25454"
+    },
+    "gfx/env/duskbk.tga": {
+     "bytes": 786971,
+     "sha256": "c6ff35f38b5262c301fafd7857305cf80636efd9b67c72f511a2e93a2648d220"
+    },
+    "gfx/env/duskdn.tga": {
+     "bytes": 786971,
+     "sha256": "5a844ff50a7e7cb3115c94cf97c36fb55a998baf8a3e38118bc4524f03d533fb"
+    },
+    "gfx/env/duske_bk.tga": {
+     "bytes": 606420,
+     "sha256": "06796e1fc73783f1dccb748b4a05703e3454623439727168c47f370e358b0656"
+    },
+    "gfx/env/duske_dn.tga": {
+     "bytes": 787184,
+     "sha256": "9794d0b1b7bf571ff247baeebae5897be3cc0c6bf3428edbcf2782c1f34610c2"
+    },
+    "gfx/env/duske_ft.tga": {
+     "bytes": 594909,
+     "sha256": "e3967e5143dfc8ffaba3dc0fe0c83d0da8d56174de9da0ea09d450a0d62e6742"
+    },
+    "gfx/env/duske_lf.tga": {
+     "bytes": 585541,
+     "sha256": "0b7331135116c4e184df4d9e4824dbf5b435d045718db20a81b0d30ce91cb64a"
+    },
+    "gfx/env/duske_rt.tga": {
+     "bytes": 688109,
+     "sha256": "20d94245588988fb390440c531d787c25c2f4b97151bfbd1526fdc3c90e1320a"
+    },
+    "gfx/env/duske_up.tga": {
+     "bytes": 470425,
+     "sha256": "eba18d5e259e973c649bf16495a34ada1c523faa14ef6462b723476e820d8766"
+    },
+    "gfx/env/duskft.tga": {
+     "bytes": 786971,
+     "sha256": "c1142a0e3bba1d2b65f887c000b6b5e450fe08474d6a5d026532b63e73d03a01"
+    },
+    "gfx/env/dusklf.tga": {
+     "bytes": 786971,
+     "sha256": "1735e4c258ab8d18b971345b43c79991bf76c2c178344739c26d79d7658128e4"
+    },
+    "gfx/env/duskrt.tga": {
+     "bytes": 786971,
+     "sha256": "4cdc3edcc8c0c1ec938ef7e4297931cf1bc4ebd804660011725bc7f3abc61ddb"
+    },
+    "gfx/env/duskup.tga": {
+     "bytes": 786971,
+     "sha256": "320e8dd8e6adc4453d894d15d20ba3ad02f176af3dd4ab1baab695e0a4accfef"
+    },
+    "gfx/env/eaglesdare_bk.tga": {
+     "bytes": 582559,
+     "sha256": "465c118bc3269b9447f653f95f81627017a5054ffd6a380dcb950e4abf20db16"
+    },
+    "gfx/env/eaglesdare_dn.tga": {
+     "bytes": 763111,
+     "sha256": "40b814edab74c2f8474dcbcb726a283fdcda6f1e3fffcb64e6b962a723b231df"
+    },
+    "gfx/env/eaglesdare_ft.tga": {
+     "bytes": 647836,
+     "sha256": "1520026a5688a76bae55cc818b62c1d1f3edf236dccb86cc2e17a048d765ce30"
+    },
+    "gfx/env/eaglesdare_lf.tga": {
+     "bytes": 539838,
+     "sha256": "76424519bfe1c1fd0bd1e8f19329eb01e53aa8e175b7696e6afbf11de44bab8e"
+    },
+    "gfx/env/eaglesdare_rt.tga": {
+     "bytes": 614578,
+     "sha256": "58423ed24a324b1c377381501d78cec2e0527434925675fed34c53dd1bbea324"
+    },
+    "gfx/env/eaglesdare_up.tga": {
+     "bytes": 233432,
+     "sha256": "14590c4d78aced7a550a1563bf9e8288db5bf43562887b983465ca9a9e0ce419"
+    },
+    "gfx/env/floodland_bk.tga": {
+     "bytes": 103354,
+     "sha256": "0373cb3405614102f325e1fc4b373b93211321c077a4819c19e7be7f59f739c0"
+    },
+    "gfx/env/floodland_dn.tga": {
+     "bytes": 162355,
+     "sha256": "598319c5158caa6e4a715fad40778431de6b3c3950e285961944d83bfd1e044b"
+    },
+    "gfx/env/floodland_ft.tga": {
+     "bytes": 402531,
+     "sha256": "77f07cf545da75cc08548677359dc65fe17b68f78d092c2a96c0d1eb747335a9"
+    },
+    "gfx/env/floodland_lf.tga": {
+     "bytes": 132172,
+     "sha256": "4427043aa446d25853c68433641eb39ea8b3ecc07c5284285788cf4d27367537"
+    },
+    "gfx/env/floodland_rt.tga": {
+     "bytes": 105680,
+     "sha256": "0fdfd155d1dfb1d0a82630c85fd113683abeab55d93429d2719a0c41a64da66c"
+    },
+    "gfx/env/floodland_up.tga": {
+     "bytes": 182104,
+     "sha256": "ec6d2cb0d06f91532a183a81af7bd4e206c40306e5c4d3c81cc41cd8abd5d944"
+    },
+    "gfx/env/gehenna_bk.tga": {
+     "bytes": 673919,
+     "sha256": "2579ebbde03e3e6d7e052cffa869980ac43f59f2245d584a9212f3bf09d91d09"
+    },
+    "gfx/env/gehenna_dn.tga": {
+     "bytes": 785761,
+     "sha256": "80c1bb4234473c05f856c018659cc67289bfa001fc42e2b1f133d39609aadfa0"
+    },
+    "gfx/env/gehenna_ft.tga": {
+     "bytes": 710441,
+     "sha256": "b371a504c6e1cecaba1352ac254759e23f8aee34e9516f33fcbddf2bee9e14ad"
+    },
+    "gfx/env/gehenna_lf.tga": {
+     "bytes": 664379,
+     "sha256": "821a2381b1955c846a11dea45855defb6ca91bf7b93021ad4320db5523a367be"
+    },
+    "gfx/env/gehenna_rt.tga": {
+     "bytes": 697661,
+     "sha256": "6903bcdbb62381122e0df50286460e2cdbad499f1e6194bfc5f12d2e975949b7"
+    },
+    "gfx/env/gehenna_up.tga": {
+     "bytes": 509867,
+     "sha256": "21d744fe6dda2bcff73b713e8e3742522d161a139a8d410cd97b1f760f29ca6e"
+    },
+    "gfx/env/heather_bk.tga": {
+     "bytes": 694322,
+     "sha256": "14f7d88bd6c5e0f3790bdc5c520545524f7b11795f5bc87ff0ea67ea63a5ab75"
+    },
+    "gfx/env/heather_dn.tga": {
+     "bytes": 781498,
+     "sha256": "82c47aeacbc4e3b6879065d270254e72136185d192d07865dfcc59fa2feafbad"
+    },
+    "gfx/env/heather_ft.tga": {
+     "bytes": 693479,
+     "sha256": "39b7c219b0532fba1ec7587884c02813715194c11663c3a18a84dff04fd93180"
+    },
+    "gfx/env/heather_lf.tga": {
+     "bytes": 699839,
+     "sha256": "e785c45e8af30992c5c1ec0ea65d3b620c02156d452182cef3e216c8c022f797"
+    },
+    "gfx/env/heather_rt.tga": {
+     "bytes": 710593,
+     "sha256": "fd021a77a15684c4071cc62223f867c942efb9754a8e11e60e37d216d163bbc2"
+    },
+    "gfx/env/heather_up.tga": {
+     "bytes": 669991,
+     "sha256": "19cf35346190864b570a820117dc222e284425b02cf84ee5955943ffafd05a7a"
+    },
+    "gfx/env/interstellar_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "861352b7f4dc030af28b483d09ad88b4cbb7b8e23e5cd3cf512d2feae9640b22"
+    },
+    "gfx/env/interstellar_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "b16b2e272b7e74513f6a1961d68270dd82fa0667d6ea267a2d22c45a2bdc2fcc"
+    },
+    "gfx/env/interstellar_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "11730f0982cbadc7691ea38e57510b2b7e77484e108d591aece8f970cfdca08f"
+    },
+    "gfx/env/interstellar_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "5bf0a5999e7ea85e68291ab7b36d7f6be5104f8932a2fe46d257484e84dab4fc"
+    },
+    "gfx/env/interstellar_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "051204c9fb8a430c17fb337d84132e0d7058b88f070e457278be99d78a73e5c2"
+    },
+    "gfx/env/interstellar_up.tga": {
+     "bytes": 3145772,
+     "sha256": "d8b19a66cb5dad2f34c9059860ac24a8632ba5575ac06ca3076d57a70c47b5b0"
+    },
+    "gfx/env/knight_bk.tga": {
+     "bytes": 196652,
+     "sha256": "215232dfb3c6a5b981f71d5093cfc74f20ca5a6ba821082f4b5c4bcad853992b"
+    },
+    "gfx/env/knight_dn.tga": {
+     "bytes": 196652,
+     "sha256": "4eb1aaf9f9f1d198da3e887c421221a4b7546dabeb2c162e6426e23b76bb52de"
+    },
+    "gfx/env/knight_ft.tga": {
+     "bytes": 196652,
+     "sha256": "106a74015bd9cd826683eb1bb68e5b37663647b0748e44895910e604b977050b"
+    },
+    "gfx/env/knight_lf.tga": {
+     "bytes": 196652,
+     "sha256": "4c77813ef12cfb766dbf4876fbb4fb92f407890678f25c603fcb160fbfd0ae05"
+    },
+    "gfx/env/knight_rt.tga": {
+     "bytes": 196652,
+     "sha256": "f9f2409e7c1ded88a7d80c72face3525db79b6198dd8b822b9ae897b72b0a416"
+    },
+    "gfx/env/knight_up.tga": {
+     "bytes": 196652,
+     "sha256": "f2f7095864bf744d2846cc5b303269d35b4f7ed311b51a1f0056a25bb5d1c741"
+    },
+    "gfx/env/l_swampn_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b83c2aeccb2ec2b6a7e7de05e4eb1f120437c575769b93533708093be6d7acb"
+    },
+    "gfx/env/l_swampn_dn.tga": {
+     "bytes": 3146268,
+     "sha256": "64ea5b085c2758138760da154c77e3c90eb0831c68e75bac4c03cd03ae2e28c1"
+    },
+    "gfx/env/l_swampn_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "f8149a22f17e241f3cc50ddc2587b3d8d6e72bb26f7a47d5045b08ed436863af"
+    },
+    "gfx/env/l_swampn_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "fdf2a49932e8ee9c06b9a50fa6dcff3d29bdde55aa209d1658346cf236ca1dd8"
+    },
+    "gfx/env/l_swampn_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "a2c65a9eafab955cfe898aa28e3563714354a08725068df84f390eebfc6ca20d"
+    },
+    "gfx/env/l_swampn_up.tga": {
+     "bytes": 3146269,
+     "sha256": "aa5c65d4c106b17e695629023db1e6b304ec5b4f15e646a1a94b38c47ef9017e"
+    },
+    "gfx/env/moonhigh_bk.tga": {
+     "bytes": 1048620,
+     "sha256": "5f361bf5a352c1df5a6caef9cf42bd35fed8406c6949af480b0425c193c18b3a"
+    },
+    "gfx/env/moonhigh_dn.tga": {
+     "bytes": 1048620,
+     "sha256": "02e2b36863c1181a85aa675c53fc14a301f38dc6e0c6735098bb6d8723af02b3"
+    },
+    "gfx/env/moonhigh_ft.tga": {
+     "bytes": 1048620,
+     "sha256": "3158735bdd6f4f467a5b29639aa4f622d1136ea463967684b739b0002bec6526"
+    },
+    "gfx/env/moonhigh_lf.tga": {
+     "bytes": 1048620,
+     "sha256": "5cdaabd99655152689e40832643690d7b1c5f8e414f3126a7c0c9224f2250704"
+    },
+    "gfx/env/moonhigh_rt.tga": {
+     "bytes": 1048620,
+     "sha256": "e08a374ac19c8b8cffa6c939515cde9570b44bbc044c12d06b0c5d94aa7469bc"
+    },
+    "gfx/env/moonhigh_up.tga": {
+     "bytes": 1048620,
+     "sha256": "c0465fd6a0b069e5ff78f3e561084bf3e23b796cac9b5214a6cd4045310d36fe"
+    },
+    "gfx/env/moonrise_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b4e85116e3999d5cded25ca0a5d6fb9c297b3d69749a63daf5af6c37fe21959"
+    },
+    "gfx/env/moonrise_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a7be41496d25bc9e505b959b08a950c1bb61acc6c8c44ec4e1dd428faeac4ccd"
+    },
+    "gfx/env/moonrise_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "7381c46aa4f5c916f3bc8f82a442a4582834563c0bb0127580053bb274609180"
+    },
+    "gfx/env/moonrise_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "871df5eed200970b8c3246ca10a039f5915c95e8f48bf0692fc22f2f7e5450cd"
+    },
+    "gfx/env/moonrise_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "2cc00bb935ee2f4019f4d99170d38ef3f51c72ff80150cd74911b1038a0cb269"
+    },
+    "gfx/env/moonrise_up.tga": {
+     "bytes": 3145772,
+     "sha256": "0296084074d726170fdc85d2c1176ee64845b6805c174c08aaa63f514fd9cb65"
+    },
+    "gfx/env/red_bk.tga": {
+     "bytes": 619027,
+     "sha256": "3462c68f4adacd5aa2321bcc6ccf733e79f574cdb98b08f4df8317bc349ea7e1"
+    },
+    "gfx/env/red_dn.tga": {
+     "bytes": 672467,
+     "sha256": "8ddba1e1ed2e0bd3ba0a6a8658ef46f0420898c25d8295927fc282df8f24976a"
+    },
+    "gfx/env/red_ft.tga": {
+     "bytes": 664453,
+     "sha256": "764f9a16e9faa015f1815ddfe29a20a0fa38b1327ad29ef3fe2feb65319a995f"
+    },
+    "gfx/env/red_lf.tga": {
+     "bytes": 634654,
+     "sha256": "71510165184795e4bd36f51f5824516f7fc1615c452087c261ce7f2f78d7c007"
+    },
+    "gfx/env/red_rt.tga": {
+     "bytes": 630646,
+     "sha256": "333c1f18a4b8f3b1281aefba222acd9bf318505f9db4b2049cbf4e151255c18a"
+    },
+    "gfx/env/red_up.tga": {
+     "bytes": 446254,
+     "sha256": "084a9a4ae3f2823a8dd0f2ec1fb1e4ca612d6f5d46afa2d8bf938892a3cb60fe"
+    },
+    "gfx/env/snowmoon_bk.tga": {
+     "bytes": 707878,
+     "sha256": "f4c61c3a622a2dabfc2aa2748c3bba9ab52bf018c5c24b5aac6bd682b6d938de"
+    },
+    "gfx/env/snowmoon_dn.tga": {
+     "bytes": 754863,
+     "sha256": "a6f29123dc3da6df244c6878d1a355b9ba7c093b9a38b94e8f9253d317de846c"
+    },
+    "gfx/env/snowmoon_ft.tga": {
+     "bytes": 630095,
+     "sha256": "c10f65b43cff087a7044946f8105d24072bbcb33668bb485f501fc0bdcb7e293"
+    },
+    "gfx/env/snowmoon_lf.tga": {
+     "bytes": 671066,
+     "sha256": "8025d6d72582a374583dc4c80d15de546b1ebea3f378cc55b084483778d8f985"
+    },
+    "gfx/env/snowmoon_rt.tga": {
+     "bytes": 636559,
+     "sha256": "339a1a1a36ffafa6bb49ae5bffcb73c81d4304f0f6d40d5fe470654c0db56037"
+    },
+    "gfx/env/snowmoon_up.tga": {
+     "bytes": 410341,
+     "sha256": "f08c76ef2c7c2338b64615543ffa1217edab3ca41bc79cb74b20bc42d329e82c"
+    },
+    "gfx/env/starfrost_bk.tga": {
+     "bytes": 417249,
+     "sha256": "614feb299325951647b649a8e6587e54cd28484b3152793046d9036db45b8f0c"
+    },
+    "gfx/env/starfrost_dn.tga": {
+     "bytes": 653548,
+     "sha256": "36572a625c2677eca5f755d6569f2c0c4b0910a9df56092db52c350262a7326d"
+    },
+    "gfx/env/starfrost_ft.tga": {
+     "bytes": 598764,
+     "sha256": "e988b54fd1a0baf5a72a2ecb37354aeda5b002ffc82f3a5360067367684d7de6"
+    },
+    "gfx/env/starfrost_lf.tga": {
+     "bytes": 414555,
+     "sha256": "11ee567ccf8c22e953762411241b30a0cd89305a4907699fb172db62ae87a97e"
+    },
+    "gfx/env/starfrost_rt.tga": {
+     "bytes": 432734,
+     "sha256": "6989a7e4df72c4984580c87cac6cc60930df4d114b54e3cc000098602fd1efab"
+    },
+    "gfx/env/starfrost_up.tga": {
+     "bytes": 187234,
+     "sha256": "c68dd79aebf5ffe2774d14b4478eb817f61495eb39e542f2f8d06b50c1fdfed2"
+    },
+    "gfx/env/stormydays_bk.tga": {
+     "bytes": 786971,
+     "sha256": "d82eac0c4f574d74ff5fee6ececd1d5f0b1bd94c349cb7c9af30d3ce79bf6b2e"
+    },
+    "gfx/env/stormydays_dn.tga": {
+     "bytes": 786971,
+     "sha256": "915f33dcae63765c49252b65a58f9d4359c7a36ea99352a013e58e660b71f160"
+    },
+    "gfx/env/stormydays_ft.tga": {
+     "bytes": 786971,
+     "sha256": "4906e45ebc2760dad5faf2e6f8a0be7c280bf7525a96364376155f3d001fba99"
+    },
+    "gfx/env/stormydays_lf.tga": {
+     "bytes": 786971,
+     "sha256": "d7cc6cbaa37481b3902673d717aae7f31e0170e2226a4efe88811f6bac3f8ca6"
+    },
+    "gfx/env/stormydays_rt.tga": {
+     "bytes": 786971,
+     "sha256": "ab40bc26b750a421c95948e7f215d51e831163fd478841c30f685a2b006b8c3c"
+    },
+    "gfx/env/stormydays_up.tga": {
+     "bytes": 786971,
+     "sha256": "8ff85257da02eb361ab8127e4425b9177842f17016724beb5c3058ae460aa52b"
+    },
+    "gfx/env/violent180_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "cf1d0a870b38e4889ad4ce18f22bf894771a8c91477c0338e837880df061db31"
+    },
+    "gfx/env/violent180_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a3b344abf47fae67c831aaa8d8b2ab7ff56ff1ed93091c6869139902060777ff"
+    },
+    "gfx/env/violent180_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "964ce0226b139a1af96de0c422e927d35917ad30f0c4027c1c386c7c32cc30db"
+    },
+    "gfx/env/violent180_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "b9cc1ef464535f9a911d56fb503a2e1aa68e6d07c7091cb62c42442a7d62ceaa"
+    },
+    "gfx/env/violent180_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "263af4a0d5b2e61303d8165d6b8a8b7e55d0c8dd79157ff133a5d50128d5f21b"
+    },
+    "gfx/env/violent180_up.tga": {
+     "bytes": 3145772,
+     "sha256": "3a9aae357ac1a8e8767e151024dab60845283422f204a354913282873f181413"
+    },
+    "gfx/env/voidsmoke_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "d274189cd63786e9d86fbd3cafda0cbfd054ccd527e30aeec921a8d6f10866a7"
+    },
+    "gfx/env/voidsmoke_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "47392d93a23946a28533cf759d6aea245a2647d58bf153d2845ac0899ab8d400"
+    },
+    "gfx/env/voidsmoke_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "ced1991fffdc46e2bf156e1d89e06e1362e0e394808b74bc7aa40e6d90fde55d"
+    },
+    "gfx/env/voidsmoke_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "4d1b843a9fc61c4125262a9a95fc084cea61eb4b125288f7a7cd0c2f2e53f4ab"
+    },
+    "gfx/env/voidsmoke_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "389ae84f29901e349a266d707f62beab9de3eb607b901bcb4245028b8edaa3b1"
+    },
+    "gfx/env/voidsmoke_up.tga": {
+     "bytes": 3145772,
+     "sha256": "138e9386728cdd98935a0c484d5693db2e60375d8d770ad754fe6616906591a1"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "a878796ad2dbab6a64e1eba47605d124170d5b4a7ce476b9d0087c2e302c00f1"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "381ec91a75cacad94d2a4d5a3b1cd6f9b22cce507fe95f980ebaabdb21bbe440"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9e9568b56059e74e621ad564b51cb0b886fcf800fd8d35a06df1aa79ac2aa823"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "52164e93b333dfe09a33d7ad1905796d7e7578a036b2fb2ddf35c4bf3381f30f"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "240a13f778cc7ec7ebbc67b23a977a54099e1996fd868f51c18f81aa3606d179"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "fae9345c9eeb43a56a14e9e681f9e9dadc05ba6e35f44197fca5873dbd52904b"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "e97829834b58206d9d0d7e7f35869a01cff88b83cab19b9d193cdf3aed3fce89"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3272,
+     "sha256": "ba61bec9eaf837bddef9a1320c0acfe026a130bc078836abf971095157ee395f"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "06ba6dfccb91069bb68d06f6b4a99f2b692f3bc2d3951c4093de807e2f6d9939"
+    },
+    "gfx/mainmenu2.lmp": {
+     "bytes": 30728,
+     "sha256": "a3fd168c6454eeaeea9e248df568e5942a7f850bc5478f8946a0b6516a2ce6c4"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "52bf2f00157d8be1fdd9e7bf786e394fe853d1db165d6a504853fbfe81365960"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "782f9f062a53c431b6b03a17abfa1359e77fba917c404f02910323c7976fe1a8"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "3a0abecfc75022fb7ed8d7fc1ae59726ca1e93b29e814b0b414508bc6c66bde5"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "292b33fa289068f326195fc25109a53b03011f48db723128dc57e7cdb0142d65"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "9b06183508487cbc6efb88ed1b6a093740de29d67c9b69d3aa99d3925b1d9ad0"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "8e9ba33284035b109c0dfb2d74d1bf62f77554e441db186501aa66004e907ded"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "79dbcb073514eacf798487bba240e72719977ec1524c07f15998042988f500b3"
+    },
+    "gfx/netmen3.lmp": {
+     "bytes": 3352,
+     "sha256": "21616901c2e29d79dd4026b126e9eff6598cd4977b146d5d0d152e1b816817f1"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6eb8337404c78eccba07bd1e9785acbfee1d0fe37893ae2f374deaed8987dbae"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 6920,
+     "sha256": "2bbacd16c4f25924d77602c7eae4d306f512e347943e06449d0dcb702c4ede5f"
+    },
+    "gfx/p_mod.lmp": {
+     "bytes": 6920,
+     "sha256": "3080226ebf497787e7ee1d7bc2917ae220340b7da4af58ff1a0f89f02b5c03d0"
+    },
+    "gfx/p_mod_idver.lmp": {
+     "bytes": 2504,
+     "sha256": "56234ed3e4e4fe95f8a4a1f9a52d4a73890ea653aa88ec992e6777bf3e99b445"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 6728,
+     "sha256": "feb15e1b99154ef7189c83b11210a473124f7ac8433987bce2e73faca273232a"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 6728,
+     "sha256": "7a3e007029e4ff0019350a70809b338aae82fc94b218cb988f57d4c82c9e3c1b"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 6920,
+     "sha256": "4ecadf759ac8b3275e7868857506a847f4a8f1f1c0bdd1b8ce656abef638bc60"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3272,
+     "sha256": "223747b84f97b83f8c5f5078c0c16e527f0de8843b9153345f23639cd74d291a"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "69a7409aaf3a423453a8cd853fea905b47897bd9c4b9d11decb3eb8f7c5daf62"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "f8ee0991ff6faaef3b4d2230364776effe6a1d4b47588b98e39c1d0b4199fd9c"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "a6ccb48f7e1d00ec64e5154a0a47b433f017341b8e23ba4f7f7fef6fe9a27b3a"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "148e3379f827dbe3bc01bfdc967a159011cf6d2dd768decb681eb730a8374bc7"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 6920,
+     "sha256": "b4c3d9ca227c56477a1ec619ce26d1aed197e59ff47359fa810aceb0bc06bf17"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 6728,
+     "sha256": "be7ea9fb4fde6dffe956b811f0aba354f848fce477ea4cb562d36dcccc600546"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 6728,
+     "sha256": "7da6e49bddb57f63226423e20437d3e53643e7ae3bdac6a4c386333d10a95b66"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 4808,
+     "sha256": "5eef16c69386b9f6ea8d0e705bef91885ebf044cf8632c56a4fba7150b431c0f"
+    },
+    "music/track110.mp3": {
+     "bytes": 9500776,
+     "sha256": "960f9ad94068352454f1dcf5bf05437a1652df8edf2a7e53b54c65773e518c53"
+    },
+    "music/track120.mp3": {
+     "bytes": 3423043,
+     "sha256": "d4f5b235d653c96cd25a60b5d97516d0eaa82ea51b86ba1a2752f2a514d74afc"
+    },
+    "music/track130.mp3": {
+     "bytes": 9226448,
+     "sha256": "4cb1e96cb18fc24280c3f4ae5a0fc6a73076078a979a5c9a392bd1a1670f1e2e"
+    },
+    "music/track140.mp3": {
+     "bytes": 3853292,
+     "sha256": "993e055072a47a79115c5c21cd6d1d4673a0530252650b5eb2f7964df16fd93a"
+    },
+    "music/track150.mp3": {
+     "bytes": 2334259,
+     "sha256": "b1205fe4014054552b522d22742b6c2e95e0ec0d29f88dcb5d6a7ddfaef0a3fb"
+    },
+    "music/track160.mp3": {
+     "bytes": 2523994,
+     "sha256": "0551a71af5cfee6cfadca58a92a7472f48b9d8d6850555306659d67abe11003b"
+    },
+    "music/track170.mp3": {
+     "bytes": 7852156,
+     "sha256": "3f87c3760fc29b883cbd8c573317aef919dbc4f9a102e98e5e6d80eae72e7142"
+    },
+    "music/track180.mp3": {
+     "bytes": 9774601,
+     "sha256": "2e3f447c7e7f0b7a02013e8259cc72bc035f8689686cfa1c301591cc34dbe4e8"
+    },
+    "music/track180.ogg": {
+     "bytes": 5092750,
+     "sha256": "1b48947672b05ebb5755d97122f28c0598a5fefe724d8b4cc3301497aba94f81"
+    },
+    "music/track190.mp3": {
+     "bytes": 3396358,
+     "sha256": "acac0feee753050a5313a5cc6f9f46e737dc7e3ea8b1c1ff53a4af101c5f0cb8"
+    },
+    "music/track240.mp3": {
+     "bytes": 13534976,
+     "sha256": "9cf6489399351cee8926e39ae369fc9293349851fea2076cedad033a029d1d20"
+    },
+    "music/track35.wav": {
+     "bytes": 353002,
+     "sha256": "9b006ae5f5b2ae5c2ad84062d9bc288cee744e63301721838d70bec434178b95"
+    },
+    "my_progs/ai_ammoresist.qc": {
+     "bytes": 7444,
+     "sha256": "d530fec92f23ed0c3d09560abb9a89bdc160ce1aefdfbe4f4771f9897ae3fc4d"
+    },
+    "my_progs/ai_checkattack.qc": {
+     "bytes": 106456,
+     "sha256": "7971ca5a87666c89b56ab0fcc102e6f551f3cd3b03bdfc0bfb73f5f8d5aed7fb"
+    },
+    "my_progs/ai_combat.qc": {
+     "bytes": 24318,
+     "sha256": "a8cc4b28f82babe8ef8fc627a3c16efb25775ea736d3ee99709ed675196c2d66"
+    },
+    "my_progs/ai_enemytarget.qc": {
+     "bytes": 8409,
+     "sha256": "f4b0a35306d50e71fd9043ae949a421158ee9fcc4e311baf7b8fa2d345c4d46e"
+    },
+    "my_progs/ai_explosion.qc": {
+     "bytes": 12162,
+     "sha256": "7df941a7cf93b814ae9d90f646a5b0243a51db67872f621df73d43c6000ba3ab"
+    },
+    "my_progs/ai_gibs.qc": {
+     "bytes": 32373,
+     "sha256": "65e202300882ba8f0c980f65820b2d2e0bd06846073168f4bd7e37f2357f47d4"
+    },
+    "my_progs/ai_hazards.qc": {
+     "bytes": 26832,
+     "sha256": "81aace80121408f64369bc2bbfd5654650276ddd75217333d2a52364415acaa5"
+    },
+    "my_progs/ai_minions.qc": {
+     "bytes": 10236,
+     "sha256": "3e7bd34dfe0e73a11e6907d5ac69cb609eee19dff533689ea7c8eabe52500136"
+    },
+    "my_progs/ai_passive.qc": {
+     "bytes": 8224,
+     "sha256": "44473544d0da0dc778c2800a16172ab49b548286b604c9d6361f4bc4cfc1f076"
+    },
+    "my_progs/ai_pathcorner.qc": {
+     "bytes": 20921,
+     "sha256": "b3d6ed2434e0b995da51a71715647096e36e02d8cf920e18e024f920ed69238a"
+    },
+    "my_progs/ai_projectiles.qc": {
+     "bytes": 86235,
+     "sha256": "b28c04e84c97febe9e5a8e921a8e230755f9641d4bf5d74b4a59caaaa247dfc8"
+    },
+    "my_progs/ai_states.qc": {
+     "bytes": 7480,
+     "sha256": "76fae861132b0e50006ef88ea94a953e718b661defad2ea58a4ecad5cab92dee"
+    },
+    "my_progs/ai_subs.qc": {
+     "bytes": 50952,
+     "sha256": "9d2e356f0dba7842956ceb4e766fff9da25dc72a0b408baa3e19c4a146cbafdf"
+    },
+    "my_progs/ai_tether.qc": {
+     "bytes": 6470,
+     "sha256": "2229c0ea1b76e45f5707a3eca9e7626e33f8ea91d6b292da63c81723e1ae8521"
+    },
+    "my_progs/breakable.qc": {
+     "bytes": 79687,
+     "sha256": "754831599eec85a774501d9fd0a1ec7d5722ea6a6e01655b5ad74988145045af"
+    },
+    "my_progs/chaosmode.qc": {
+     "bytes": 81481,
+     "sha256": "01561dc4f1949716eba4d08f83efe27b71add80f923c1e2d89194c238772a646"
+    },
+    "my_progs/client.qc": {
+     "bytes": 70441,
+     "sha256": "00e2d4aff96ea28b0532ab0b03de0a8cdcf15750164ec82bdc8f43b9f2347447"
+    },
+    "my_progs/client_advinfo.qc": {
+     "bytes": 59677,
+     "sha256": "87aaca8bfd15935e1cd29a807bf77a2779d95418af631a6b456c6605710694fe"
+    },
+    "my_progs/client_camera.qc": {
+     "bytes": 13007,
+     "sha256": "ff4748b04c15d9a3b44dd8069f9347c12487ef353d5401a13542166576097889"
+    },
+    "my_progs/client_cshift.qc": {
+     "bytes": 725,
+     "sha256": "da1e321fe01bae486ffcdd987a942a4b0d5b2f603efb663d52c55e882f129685"
+    },
+    "my_progs/client_debuff.qc": {
+     "bytes": 15761,
+     "sha256": "0e0c9123697241ab3a366dbc46fcb90b8553b65c94cffe1442254a74a2753efd"
+    },
+    "my_progs/client_evilmode.qc": {
+     "bytes": 6982,
+     "sha256": "2cfa3bbeb36ab623c3bb137028ec5f549a2e5d2198fa2ab7fd8a445e14f4fc10"
+    },
+    "my_progs/client_ghook.qc": {
+     "bytes": 51884,
+     "sha256": "43d071195a70caa66b57cca1778679d772478fd1f71cbad7ee267e254e79a29a"
+    },
+    "my_progs/client_info.qc": {
+     "bytes": 13693,
+     "sha256": "55653ddc2b9f3cf2ca3cf1b0afdc4c1685baf1ab3c3830eb9f8b1b2d51b3ff31"
+    },
+    "my_progs/client_mapvar.qc": {
+     "bytes": 13177,
+     "sha256": "c692fa41644e6d21c945493dd891af945a072a4b39e687d1b59c86d14ee804a0"
+    },
+    "my_progs/client_power.qc": {
+     "bytes": 20026,
+     "sha256": "68457e8f99d3967babe95d4db3539388e95d294fa65a6190773e75951fed9ef9"
+    },
+    "my_progs/csqc_defs.qc": {
+     "bytes": 21072,
+     "sha256": "eddc5f194845e78a1633807d32b1da4425bdbe7bcce193e3868bc3995e2dee9b"
+    },
+    "my_progs/csqc_defsclient.qc": {
+     "bytes": 35002,
+     "sha256": "b6674acae135dfbc5e3dbb147e69acdc6b3564b766792359bed3e4eb800705e9"
+    },
+    "my_progs/csqc_hudad.qc": {
+     "bytes": 104391,
+     "sha256": "1ca012e489dc5f6026bdae469f411b5bb25afa00e00d5169cbd35b578a7ad9f2"
+    },
+    "my_progs/csqc_hudvanilla.qc": {
+     "bytes": 37074,
+     "sha256": "c5caa6ba176185c05903d383f3ae41907129d859419a0c0bf909b0e8d3e8af5a"
+    },
+    "my_progs/csqc_progs.src": {
+     "bytes": 113,
+     "sha256": "e383fc0920e9676d92e0be81d69cd8017ed5baf9fc0616a05773de68208ce434"
+    },
+    "my_progs/defs.qc": {
+     "bytes": 31974,
+     "sha256": "1534874cf4d70c5614dedecb70f6d428fc32832ce3345c2cb51fd6058a514902"
+    },
+    "my_progs/defsclass.qc": {
+     "bytes": 24401,
+     "sha256": "811c390be7b31fd4b276410ef1a75406bbca8fb84dc195484835a6100e9cddb4"
+    },
+    "my_progs/defscustom.qc": {
+     "bytes": 95914,
+     "sha256": "180ebe8c3fbbd4f78815c94d62f6ac0ad0c3cefe427664fdf4685adcf2c8a699"
+    },
+    "my_progs/dpextensions.qc": {
+     "bytes": 122912,
+     "sha256": "3758f58ebaa4186e9112da89f7ea53087eef5058a32ebc373a1ffda76c1d67a2"
+    },
+    "my_progs/estate.qc": {
+     "bytes": 7745,
+     "sha256": "9cceb71ae54b331c2702f5580094f9055d007b9e710dd5e61c7c632724022626"
+    },
+    "my_progs/fteextensions.qc": {
+     "bytes": 215531,
+     "sha256": "beb86ad10bb0726de10dd2557d6285f7bf40f08f9d30e06315c3772f8c256571"
+    },
+    "my_progs/func.qc": {
+     "bytes": 47039,
+     "sha256": "81cd56475c6c34a744d84c2b223e66dd1c83a1b525b4c42f3389d4ff4cca5601"
+    },
+    "my_progs/func_buttons.qc": {
+     "bytes": 13271,
+     "sha256": "9e1bd197b2367ab2b8f1c776c214a0c51120559e8d8f0b4888b262b7a1e746f0"
+    },
+    "my_progs/func_doors.qc": {
+     "bytes": 35874,
+     "sha256": "58dbdf05f0044aefdd13ee21d17045a681d255efaca6d129fbd1cec4ae516fc9"
+    },
+    "my_progs/func_doorsecret.qc": {
+     "bytes": 14379,
+     "sha256": "769a3142ccaf18060ff77b0eab57d901585202fbfe63a54ce25d4987b80f92d3"
+    },
+    "my_progs/func_insvolume.qc": {
+     "bytes": 10573,
+     "sha256": "1deaf4623a6fae80585d2d2b1978b1cd217b6f8a683ef3bbc3a77a2897e9a207"
+    },
+    "my_progs/func_plats.qc": {
+     "bytes": 11685,
+     "sha256": "5086c9aba8bbf83d29c3e1897c7867cb24220712007044792928f474216b7ea4"
+    },
+    "my_progs/func_pswitch.qc": {
+     "bytes": 8373,
+     "sha256": "b3a205176d80801216a930241508b3c5718f4be9e1b947932ace2851c34271d8"
+    },
+    "my_progs/func_trains.qc": {
+     "bytes": 26553,
+     "sha256": "81d8de4f3dff80b8523584fb5e37d8d4812a6f7f95a559edff320682217ad123"
+    },
+    "my_progs/globalfog.qc": {
+     "bytes": 18397,
+     "sha256": "84ec244a475ac41b9da772042123f58f4005130590f170f85f1b23ad53629f27"
+    },
+    "my_progs/hiprot.qc": {
+     "bytes": 31978,
+     "sha256": "82875db9fecd8bacd2c42232fb980e6a510a6863103273e2c9078dfe7c6759c5"
+    },
+    "my_progs/hipspawn.qc": {
+     "bytes": 2752,
+     "sha256": "6df8450b85821c1a76f5ccb3c807ac9b94e92f413f16f2ba618f922abf85148f"
+    },
+    "my_progs/items.qc": {
+     "bytes": 164855,
+     "sha256": "ffa38fa915821151c7dbfae3507bf804052db0f5c13eecac462400680cabcf3e"
+    },
+    "my_progs/items_progspn.qc": {
+     "bytes": 20628,
+     "sha256": "2f4824cb28192145a8fabc2da6575db3398e8f81522ab1e026d696ec87313650"
+    },
+    "my_progs/lights.qc": {
+     "bytes": 43912,
+     "sha256": "d0e0c373bb3cc68c7c9121a62c68085ff9cc290daa6faf0adab02323d8ef92bb"
+    },
+    "my_progs/mathlib.qc": {
+     "bytes": 22355,
+     "sha256": "b161ebb89a11f302427c4f124731ec38def8eb01347beb5d748a9ba4afb886f8"
+    },
+    "my_progs/misc.qc": {
+     "bytes": 85890,
+     "sha256": "6b3e8a0882d47f16ff7f54fb37a48e3a7853647f8895718e6428739c4207099a"
+    },
+    "my_progs/misc_camera.qc": {
+     "bytes": 43852,
+     "sha256": "61448a8f0354f39dd26371ae56dadbc903b08282293145a27088ac6c151ea547"
+    },
+    "my_progs/misc_model.qc": {
+     "bytes": 31793,
+     "sha256": "04774e0bab5cb0ccc5bd01e36ae7d6f449248484d0cb203eb435fb267cc8bdda"
+    },
+    "my_progs/misc_targetdummy.qc": {
+     "bytes": 15123,
+     "sha256": "bcd0a0ae806ce20a8c8cfcc27178ce1b4ead3a546d927b6a261ce51a6086c253"
+    },
+    "my_progs/misc_textbook.qc": {
+     "bytes": 26321,
+     "sha256": "14bf42536a5cc75990d938a79d7bd21bde1c166245d94d8e662f9e6fd66e0ae8"
+    },
+    "my_progs/mon_baron.qc": {
+     "bytes": 31318,
+     "sha256": "b76a10da34dabf3411ddf650abcdbc77e3ebcdfebace6191a39e7c0b13a0fad5"
+    },
+    "my_progs/mon_boil.qc": {
+     "bytes": 19821,
+     "sha256": "050b21bda5341a3f81dcb21e6d7d82d458a415fd8f1cfa12435228246229a323"
+    },
+    "my_progs/mon_bossboglord.qc": {
+     "bytes": 24005,
+     "sha256": "e67081b7a5218b361c62bf4b201a18db16f3e75716ad2729c11a0616b137975a"
+    },
+    "my_progs/mon_bosseidolon.qc": {
+     "bytes": 40134,
+     "sha256": "c51eb9b9d67cadfa7178891a238329a60ad57edc3f6ef645060695b451833115"
+    },
+    "my_progs/mon_bossfiretop.qc": {
+     "bytes": 14734,
+     "sha256": "26672c9c2d1577f8caf9894b8eb5eecacac89f64251257bc25db48b1bf43a7bb"
+    },
+    "my_progs/mon_bossicegolem.qc": {
+     "bytes": 47205,
+     "sha256": "5b888302a6af24ce823919d1349c1c92e1ee709d72e79042425349368a4d65fb"
+    },
+    "my_progs/mon_bossidchthon.qc": {
+     "bytes": 20247,
+     "sha256": "65d955fb1434f806962fadc088aa5933e96ed8aa9f1211d0709a3f462ffa3027"
+    },
+    "my_progs/mon_bossidshub.qc": {
+     "bytes": 14639,
+     "sha256": "fdd0e8f8fa374ea0164f79ef1bf74ca942f04c63159f360c7a43011673774fe6"
+    },
+    "my_progs/mon_bossjudicator.qc": {
+     "bytes": 81432,
+     "sha256": "f5092f376eeef22f0a552c846f50175680c15a5c37d9603c6e3d2635661127b3"
+    },
+    "my_progs/mon_bossmammoth.qc": {
+     "bytes": 84963,
+     "sha256": "6cda415b846b2aeb215c0eebc7cdfa6a5560255df9aa014f77b48aa7073b8d34"
+    },
+    "my_progs/mon_bossnour.qc": {
+     "bytes": 45558,
+     "sha256": "def8a1a46f3a266028df3d1a0b7c31a9ad98450f6601e176495f11d929041452"
+    },
+    "my_progs/mon_bossxxchthon.qc": {
+     "bytes": 22614,
+     "sha256": "2c1c0446b0f6a5b7a7921e8f8830c71c174d30c6f176d228a94afd9a05fdc25a"
+    },
+    "my_progs/mon_bossxxshub.qc": {
+     "bytes": 19006,
+     "sha256": "043ebc852ba7f0a06812cb0afd72d32a3da643df1dea45c87fb821f60fbcc332"
+    },
+    "my_progs/mon_centurion.qc": {
+     "bytes": 13734,
+     "sha256": "641e1c09c6df27b033e331140d242f25d27bf7f9bb83733a6b5b3469a5c7ffee"
+    },
+    "my_progs/mon_dcrossbow.qc": {
+     "bytes": 38069,
+     "sha256": "3296618a4b803fb6f1b44c1d32c17692a5bed13cf63102c6dcc58481223197a8"
+    },
+    "my_progs/mon_deflector.qc": {
+     "bytes": 32107,
+     "sha256": "d7a9344878a3a846a7e720ce704820d424362281a1675c40be7b670eca9fe342"
+    },
+    "my_progs/mon_demon.qc": {
+     "bytes": 14601,
+     "sha256": "d77f128e3f91737228c5a24b7ca146f6b4f8e87dbaac31b1ad4e79779884d0d7"
+    },
+    "my_progs/mon_dfury.qc": {
+     "bytes": 39867,
+     "sha256": "a016db202f2a418aee50cb7cce2155a24a6b807e8c98fc49a5f9273ce79c6da8"
+    },
+    "my_progs/mon_dguard.qc": {
+     "bytes": 28414,
+     "sha256": "0a2b964034559f4ca772f9f29be2c56684fd39290277046a6f7642ba934836eb"
+    },
+    "my_progs/mon_dguardquoth.qc": {
+     "bytes": 18932,
+     "sha256": "4caeb17520104cba42476ff7757f38ba6d72e941674b851f55a5c9780ce4de17"
+    },
+    "my_progs/mon_dknight.qc": {
+     "bytes": 36867,
+     "sha256": "68008427374e9ab670b6ad915c7a0f8eaf6a6699efa927a3748ae6cde86458e6"
+    },
+    "my_progs/mon_dlord.qc": {
+     "bytes": 22859,
+     "sha256": "09ca1edd4e65a166a66ba17e682aae9a1be09b05371a72dd1bc447389693bfa5"
+    },
+    "my_progs/mon_dog.qc": {
+     "bytes": 18431,
+     "sha256": "1b345447176aec54f18c31f5da215e80cb2de19f51d353c63a98507d881c2a9b"
+    },
+    "my_progs/mon_dprince.qc": {
+     "bytes": 33590,
+     "sha256": "5114caa7b6152e562e548096e41da68f43c910a5016ddaed408272a97a8320c1"
+    },
+    "my_progs/mon_drole.qc": {
+     "bytes": 25472,
+     "sha256": "36a510e910ce4ffa26d2d2ad336872c07537077ea920132a4cfd63d9133fb6af"
+    },
+    "my_progs/mon_dsergeant.qc": {
+     "bytes": 33493,
+     "sha256": "ada0cc4359a863c4e8d433c605a1c04ec6f7fd17ec852f5c4847443d3adaff1d"
+    },
+    "my_progs/mon_eel.qc": {
+     "bytes": 8252,
+     "sha256": "15c1f2fedba7077d352595e1be4a90f764354e4cf1875b40e1685d3ce81feb54"
+    },
+    "my_progs/mon_enforcer.qc": {
+     "bytes": 20146,
+     "sha256": "d453651d488afa789d0cea87ce99d9684329bbabdd17aa1625591f5a4b4ac90b"
+    },
+    "my_progs/mon_fish.qc": {
+     "bytes": 9705,
+     "sha256": "ff7d84db2c7917861ff5d81fe0e28f69d51143d27c4fba90dfcda11057222df0"
+    },
+    "my_progs/mon_floyd.qc": {
+     "bytes": 20332,
+     "sha256": "3ac2f0b0be94e311ff2fc4eee9cf66d5987af0e5c25fc06b8cc7b9efa6f581df"
+    },
+    "my_progs/mon_freddie.qc": {
+     "bytes": 25384,
+     "sha256": "4409a33e819f125852d0a4ada21a8fed2713012daec00922446f313031c845d1"
+    },
+    "my_progs/mon_gargoyle.qc": {
+     "bytes": 24293,
+     "sha256": "9e1f78b2364024efa6ec4142c1ecf4aff52cdf32f38031c34cf19e9cd74143d6"
+    },
+    "my_progs/mon_gaunt.qc": {
+     "bytes": 24111,
+     "sha256": "45be98ae0bdd32e0884280e18f867af037f2fcbf515914827c5f9107a87e52d7"
+    },
+    "my_progs/mon_golem.qc": {
+     "bytes": 35297,
+     "sha256": "dbaf3d1c0fec3166b0eb064a3c027dd3a0c907bed72b8e4581ffd74dad5ab5d1"
+    },
+    "my_progs/mon_hknight.qc": {
+     "bytes": 37618,
+     "sha256": "bac7d4b7832b95cea0f6890de66fbd0f7c4fcc7ce9051ef16ac042de465ddcb3"
+    },
+    "my_progs/mon_hogre.qc": {
+     "bytes": 24021,
+     "sha256": "8781ea9aaaa1d0f7ffb1fd8ec8b5981187eee6fdb8193160a1eb38770dffcfe0"
+    },
+    "my_progs/mon_hogreham.qc": {
+     "bytes": 23076,
+     "sha256": "b2ab6b830ce3aae7d6b033e8455de5011ded82e451ca171ea09940d9a3ec7740"
+    },
+    "my_progs/mon_hogremac.qc": {
+     "bytes": 23941,
+     "sha256": "9111c040ab1e5487936cce6ef1170e408c6d297d582702d202bbd27b0919d843"
+    },
+    "my_progs/mon_invsword.qc": {
+     "bytes": 9214,
+     "sha256": "f7287867cc6043eb7cd3fa3e1ecd5ae7115a84e5ef7021b2d5129afdb6ba6f46"
+    },
+    "my_progs/mon_jim.qc": {
+     "bytes": 22091,
+     "sha256": "55353984ad822dfd8c32f3b8ad9a06e8bfaab7bc5ff6f2a2326674ad4acd26be"
+    },
+    "my_progs/mon_knight.qc": {
+     "bytes": 24772,
+     "sha256": "d254abf88162436b9db48885ae8e59315c24c1e7f72a91d027a1d69fe9baf5b7"
+    },
+    "my_progs/mon_lostsoul.qc": {
+     "bytes": 23261,
+     "sha256": "2cdbf656c6b34164711fa88016542f4e3d2bd0555417ad00bab5ca7039f212ef"
+    },
+    "my_progs/mon_minotaur.qc": {
+     "bytes": 35316,
+     "sha256": "fbcef276ee3e2f1eeea8483303538190875e959b43efbf4f703be10fc72fc564"
+    },
+    "my_progs/mon_ogre.qc": {
+     "bytes": 24123,
+     "sha256": "d287d3b9024025237dbc68380f486572828a5114f9543599ba86b8bc35e9e25e"
+    },
+    "my_progs/mon_ogrextra.qc": {
+     "bytes": 9387,
+     "sha256": "41a9243c6006326195197a4dfba6ea4c1f1fbd729ec10adc48cfd7badd7a18de"
+    },
+    "my_progs/mon_pyro.qc": {
+     "bytes": 18235,
+     "sha256": "bd35f02c63af315ddf4820e388d0248cf065f1170bd7306957a1e86fa7e47306"
+    },
+    "my_progs/mon_scorpion.qc": {
+     "bytes": 22136,
+     "sha256": "0432d7c5e1b6a30a5452aba12b9fb6a3c2c7f3c582b1392d420414e66b8fb257"
+    },
+    "my_progs/mon_seeker.qc": {
+     "bytes": 29703,
+     "sha256": "d33939357840eedbfc63c56d6415d8fefd21de2c477b24b3165cdadcca2acd2c"
+    },
+    "my_progs/mon_sentinel.qc": {
+     "bytes": 10217,
+     "sha256": "946232c7169bf3fa966ce875523dd45402772f8045c51a96dced04f2f5f5788f"
+    },
+    "my_progs/mon_shalrath.qc": {
+     "bytes": 16434,
+     "sha256": "1b6fdf2447d7fa281d126118a9bc0e097de7b4dd4d10a33e60d5cf0ca785c58b"
+    },
+    "my_progs/mon_shambler.qc": {
+     "bytes": 23050,
+     "sha256": "576f71a38d75eedbdf58c291055674be8da5f0d04540e26311d65f70b58ee842"
+    },
+    "my_progs/mon_skullwiz.qc": {
+     "bytes": 36245,
+     "sha256": "6d3c2242bffe6eabe3f9cc59e881cb2296213cfbff809e1be045a80ca46aac53"
+    },
+    "my_progs/mon_soldier.qc": {
+     "bytes": 21645,
+     "sha256": "704c534062b11c4fc16416154c7706c125221660cdd4d9b02e00575b94c04103"
+    },
+    "my_progs/mon_spider.qc": {
+     "bytes": 30593,
+     "sha256": "4d0bbb7e38e51cef07912e6071e6bb9739e019a2d93129d38dbab9492bf43aee"
+    },
+    "my_progs/mon_steelclaw.qc": {
+     "bytes": 17126,
+     "sha256": "78dd4bb46dd76b2ff1f7d4a9f0b0902f25d94ebe13ace6b997a7f604c3718700"
+    },
+    "my_progs/mon_swampling.qc": {
+     "bytes": 25637,
+     "sha256": "fb5ed328cd3d5c09704bb84f39138463a7d26b8b1d45771e55e9ae952b1d2470"
+    },
+    "my_progs/mon_sweeper.qc": {
+     "bytes": 27025,
+     "sha256": "8f7a1d077779d88d542a325c1ae4ba4ff59d48bfcb334150ae3f024525bb725e"
+    },
+    "my_progs/mon_tarbaby.qc": {
+     "bytes": 11866,
+     "sha256": "88c9481ab7fe0cbe97d2b836492ff51b368aeae8d4ff3e5852734bb9f63a1b2d"
+    },
+    "my_progs/mon_turretbal.qc": {
+     "bytes": 38519,
+     "sha256": "fdcf915248dda5fb6a744d284233d46a2e6d62c8e4fd02fdd5bafe4f46167d30"
+    },
+    "my_progs/mon_voreling.qc": {
+     "bytes": 27678,
+     "sha256": "7734614fa6b2da2195bf3804415c06a2d10f35825e86abf4f85613a182cf21c2"
+    },
+    "my_progs/mon_wizard.qc": {
+     "bytes": 15155,
+     "sha256": "3101ca37b57343697b3d3c7637fdc84c842f78ec9081e401dcaa6df0a9b1df83"
+    },
+    "my_progs/mon_wraith.qc": {
+     "bytes": 35464,
+     "sha256": "6a28a205cb8ac574e98c8d34a01ea859922e38d55c66346a7aa867ebf84bdb5b"
+    },
+    "my_progs/mon_xmas_elf.qc": {
+     "bytes": 17589,
+     "sha256": "053eec412485090ee1ebeac25887382db40e2ba7ca456050ba4407be3ec8bc1a"
+    },
+    "my_progs/mon_xmas_raindeer.qc": {
+     "bytes": 12189,
+     "sha256": "abbe1dd5c96c25b631231d4db2f17e8243075ad08c082e0448b7cbff34f1ae0c"
+    },
+    "my_progs/mon_xmas_santa.qc": {
+     "bytes": 17853,
+     "sha256": "cc60c6de17bc3321f9b1cf75b3229e387592c9eb7fc4bb57c1de0a8d2c0e62e6"
+    },
+    "my_progs/mon_xmas_snowman.qc": {
+     "bytes": 11486,
+     "sha256": "65928bb70cb2e9352c2f5e036eda2a6bd97aea09d459d0af563a82aa5a2f2673"
+    },
+    "my_progs/mon_zombie.qc": {
+     "bytes": 33988,
+     "sha256": "83f56482374c3a79fcc64058989bd210af3add006b7388d89c92e90543ec56a0"
+    },
+    "my_progs/mon_zombiek.qc": {
+     "bytes": 42214,
+     "sha256": "2b9926454484e93f5c053bf4fd35b2a97cf7e835c26c3b30061f1ff391af9f5e"
+    },
+    "my_progs/monsters.qc": {
+     "bytes": 56573,
+     "sha256": "c2c75832e6d5e83e929214ba5c1aa9a4661bcaf7754c20b3e9648171bf804a58"
+    },
+    "my_progs/part_emitter.qc": {
+     "bytes": 82744,
+     "sha256": "fca7491171d58974ef6b15550b9a7f0474641e9eac7ee5de52c6980c96445518"
+    },
+    "my_progs/part_generate.qc": {
+     "bytes": 42914,
+     "sha256": "83b9718a85418143d92ea8311cc8cce69c1002eb7563710dfe7010ac52e15d50"
+    },
+    "my_progs/part_manage.qc": {
+     "bytes": 27407,
+     "sha256": "86eb791f4bba08fc0c965e9f81c90e7412ed2c910104d66a56cce1f3152808fe"
+    },
+    "my_progs/player.qc": {
+     "bytes": 27811,
+     "sha256": "1f0cc3eaf577c2af642495466c573cd6e226a4754902d9de9cbfc9c9ba28af0f"
+    },
+    "my_progs/progs.src": {
+     "bytes": 2482,
+     "sha256": "c773f107c562f731fbb30158422226bdc4576dd32aea0f02c122195e08eac96f"
+    },
+    "my_progs/pushable.qc": {
+     "bytes": 19823,
+     "sha256": "03b3bf9240db6e9532e45a3efc159129709f9ce095c3238daae32daddd5b07ec"
+    },
+    "my_progs/qc_highlight.xml": {
+     "bytes": 6348,
+     "sha256": "a7b326723cc1e4025e867ea5da00f54c944705600d740538aeb52f63cd027ab5"
+    },
+    "my_progs/settings.qc": {
+     "bytes": 61298,
+     "sha256": "7a1ae40ba7fa97ff7e7019017bc7640fd49d22943a2ca57c7a7e48702bbe7158"
+    },
+    "my_progs/sounds.qc": {
+     "bytes": 19389,
+     "sha256": "bb74ecc36a241db5a79b010f61200687c6db6e46297db39c8a2a8ce1d512bad5"
+    },
+    "my_progs/sprites.qc": {
+     "bytes": 476,
+     "sha256": "579f48b397914b02f8fb86dc24f23d4e63a4cd857df1f0eaefd6c83e9c49e238"
+    },
+    "my_progs/subs.qc": {
+     "bytes": 23545,
+     "sha256": "123ca7120e7ea4e4ca63bfd081caf46c7acd1560af4702c1bff40821d7f6ef44"
+    },
+    "my_progs/subs_soc.qc": {
+     "bytes": 28453,
+     "sha256": "679112275e8b3597daac962074f69b6d9fd5614fc3dbff036815b9365e1413c5"
+    },
+    "my_progs/switchshad.qc": {
+     "bytes": 7054,
+     "sha256": "92a2fd4e5c41f21f46502781322ab87584bf0999d733db50e0e19b8bbea793b3"
+    },
+    "my_progs/targets.qc": {
+     "bytes": 58758,
+     "sha256": "e39b45bf6740be40c2899376e92d30d7d227a4762091d7b63e382c79fe6822e7"
+    },
+    "my_progs/traps.qc": {
+     "bytes": 24071,
+     "sha256": "9e4e822a36113bc73958fa45ab0b8c290a5148c95f3a4da7125676c984ebd202"
+    },
+    "my_progs/traps_pendulum.qc": {
+     "bytes": 17049,
+     "sha256": "b421f26fd80eb74715172e25f3ac992faa95397dd67d5f7ede286fd78384a468"
+    },
+    "my_progs/traps_sawblade.qc": {
+     "bytes": 9783,
+     "sha256": "9a6e82a05f09001c0a9cffdf6b9d6399691846c5b1ab1fbfb470e5772a87f44b"
+    },
+    "my_progs/triggers.qc": {
+     "bytes": 139586,
+     "sha256": "2e5819bf11fecf01856bd7547af63b7c4927dec59237419dbf3dc79bc023f54d"
+    },
+    "my_progs/triggers_states.qc": {
+     "bytes": 17475,
+     "sha256": "2c4d25c11de0319cd54d81e67e651c8d29d22aca851988d21080ba5976137f14"
+    },
+    "my_progs/weapons.qc": {
+     "bytes": 44346,
+     "sha256": "f23d0cc07bab402da965ec3fa91d7de86ccabcb03c9019cd7b217fbca7fb4279"
+    },
+    "my_progs/world.qc": {
+     "bytes": 39815,
+     "sha256": "b933caca23d5a45e5d9368627b3d651af244af0aa345b91017d263be4bad7b77"
+    },
+    "particles/fte_weather.cfg": {
+     "bytes": 2758,
+     "sha256": "e0d383b0222f14edbd2bc04c1269206bbcdca22cdeac6840b5d831c042ff698e"
+    },
+    "particles/particlefont.tga": {
+     "bytes": 4194348,
+     "sha256": "bf90d469b3b41c2393f5ed0f58b4411cc8825f452341bbe3ba848c3cc855639e"
+    },
+    "particles/particlefont.txt": {
+     "bytes": 9872,
+     "sha256": "9e84ef35b813211196f8dfc8f89a420fd9d847ea514e43d0c3246ee666000b88"
+    },
+    "progs.dat": {
+     "bytes": 2345354,
+     "sha256": "f3c4218216ea0d3b00db35eef9e72945ee6687006b3e82c37ea2ae33a0eea922"
+    },
+    "progs/ammo_battery0.mdl": {
+     "bytes": 10552,
+     "sha256": "06d4f0235faedd3430e57d602ec29a2a91c0b23bdc30debc069212264a0faf54"
+    },
+    "progs/ammo_battery1.mdl": {
+     "bytes": 10552,
+     "sha256": "0cee39ac60c3eda7b5f1d1efde52f8be19c9e4f425972f16ba6d6362d646afb6"
+    },
+    "progs/ammo_cells0.mdl": {
+     "bytes": 27228,
+     "sha256": "b6f5a07c9fd48cf27f0873320589dda1e20afe7d64cd40b6c950e5f892a34fa2"
+    },
+    "progs/ammo_cells0_edit.mdl": {
+     "bytes": 27228,
+     "sha256": "47ffc9eb8ec352ab2fa479f35ee5b6ec0e0ac8f472a06fbe00e8298e9d683ed5"
+    },
+    "progs/ammo_cells1.mdl": {
+     "bytes": 29836,
+     "sha256": "c23b4e85e9edd68fec2d751af85cff391a11848bd4338a3c59a2c055508cfce9"
+    },
+    "progs/ammo_lidlarge.mdl": {
+     "bytes": 25252,
+     "sha256": "d941a1c520e49694d66598f3430420541b318cea3e1cf02d3957e06d010681a7"
+    },
+    "progs/ammo_lidsmall.mdl": {
+     "bytes": 25252,
+     "sha256": "221b3aaa2324bea668276d3de521c4945004a71368983fc74c50c4b53425c436"
+    },
+    "progs/ammo_nails0.mdl": {
+     "bytes": 14072,
+     "sha256": "1090a9c50a943c2bf04302914f69b835ecf79fbf3013f259a12668ebd57aad5a"
+    },
+    "progs/ammo_nails1.mdl": {
+     "bytes": 15976,
+     "sha256": "8dd339507f4e18953ceefe3922d04ca513728bf2b0745813723873427843213b"
+    },
+    "progs/ammo_rockets0.mdl": {
+     "bytes": 24836,
+     "sha256": "9f272b2f1cb52fcf38983f63052db653e8208b2ee1eedf053e99dca6e439c7d8"
+    },
+    "progs/ammo_rockets1.mdl": {
+     "bytes": 27672,
+     "sha256": "46d85f10a260cf13d6711420f11a235089536a3725363be0717c2ee3e7e8a18b"
+    },
+    "progs/ammo_shells0.mdl": {
+     "bytes": 14072,
+     "sha256": "053e466f1666314cbfc0cd6f67821850ad39505a6a0bbf37c80b127e6887e5c5"
+    },
+    "progs/ammo_shells1.mdl": {
+     "bytes": 15976,
+     "sha256": "6183880b36171b6784cecf74b50aea2e1fdbc17b1b0b304a89125e964d63fd1f"
+    },
+    "progs/amult.mdl": {
+     "bytes": 32892,
+     "sha256": "44ccf3197317a19ebcebd6261767763c3ae6f903333ad076c3a6394fc56a2681"
+    },
+    "progs/apple.mdl": {
+     "bytes": 69492,
+     "sha256": "2dcbe01aeb92f174aa03a9e7c09976270e18d73bb2a41e63c487c89c6946a033"
+    },
+    "progs/arma1.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/arma2.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armour.mdl": {
+     "bytes": 76144,
+     "sha256": "b6e297062cffd435d6ce5cc17854e25a49ff09750ee1eaec6d5004266884099a"
+    },
+    "progs/artifact_airtank.mdl": {
+     "bytes": 50184,
+     "sha256": "4702b7be1baa517669edd24f5b67377f532382bfedebd77b5d77f9a499f3f08b"
+    },
+    "progs/artifact_blastbelt.mdl": {
+     "bytes": 28436,
+     "sha256": "a935de1300f6fc4f03b6fc57bf43791ac32b74d55c5509eda84339dc33f0bf48"
+    },
+    "progs/artifact_envsuit.mdl": {
+     "bytes": 260844,
+     "sha256": "09192fca32cf5b7632cf0fe9cccd9b4b1313c0e92708e85f840b0971aca5d274"
+    },
+    "progs/artifact_invis.mdl": {
+     "bytes": 7108,
+     "sha256": "f6b0b925b584402d85a623e1924c50a4fb3f3a4994cb1d2f05a169a3af2e39dc"
+    },
+    "progs/artifact_jumpboots.mdl": {
+     "bytes": 37428,
+     "sha256": "668d649addf958be26f2bcff31baf3afa5ff176a178ef15073c87cc7cb57e2b8"
+    },
+    "progs/artifact_lavashield.mdl": {
+     "bytes": 469773,
+     "sha256": "2e3027df661ca197750df97599084442afda131fbf1b545ea38d40e93afff908"
+    },
+    "progs/artifact_pent.mdl": {
+     "bytes": 21412,
+     "sha256": "7ae90fc895f23f57952dacf4d8af125f99347e09edf6f0287c7e508faad67b46"
+    },
+    "progs/artifact_piercer.mdl": {
+     "bytes": 19012,
+     "sha256": "fd73ca18d93904647df923f2d0383958386c7deb9cf27547beda74c61a9f8831"
+    },
+    "progs/artifact_quad.mdl": {
+     "bytes": 22052,
+     "sha256": "bf6d2253210784391ee1ab9b38d2b6fd661a520434bb127d293f4d202040d1b5"
+    },
+    "progs/artifact_sharp.mdl": {
+     "bytes": 49248,
+     "sha256": "505fc06618d7cecb83c03ad7d7762011ff8cff025eecf007b200d87fcc2483cf"
+    },
+    "progs/artifact_tome.mdl": {
+     "bytes": 21412,
+     "sha256": "ee8cf94e2c87ff6c0d4aa8777da2f0ddb79605bf790fb8f9ed2f49c6c1f9b9cf"
+    },
+    "progs/bats.mdl": {
+     "bytes": 280372,
+     "sha256": "dd18b3f13ea8aca31406f8aa67dadf69a9b9056eec5f624e41bd8b7116e752f9"
+    },
+    "progs/beam.mdl": {
+     "bytes": 26020,
+     "sha256": "bd06e42c7f0d911a4ef1077c95d474b86f62bca4da02183449687c23879e8c6d"
+    },
+    "progs/beer_mug.mdl": {
+     "bytes": 9988,
+     "sha256": "bc0d83c4a357c27e2554fd92631c84db4e6edcd495d961c8f103de4a1e67ebbb"
+    },
+    "progs/birch.mdl": {
+     "bytes": 267396,
+     "sha256": "c0ba65a388b0faa5e89dafe4c26b1cde056b23cc0207ec7f41fa4f7f127c3539"
+    },
+    "progs/bottle.mdl": {
+     "bytes": 14860,
+     "sha256": "331590022a73d4aae93b5c6912f8b0b7de36c6a148073db9981203f970efc8d1"
+    },
+    "progs/bowl.mdl": {
+     "bytes": 95604,
+     "sha256": "da1c69015b9de541437cfabbb6fe68446aa74bf9fa02538cea63b97457fd6d5e"
+    },
+    "progs/bowl_empty.mdl": {
+     "bytes": 74788,
+     "sha256": "3f43c2a4028545132428bd8112a7235186f214345fca042b9796ea38e6d81c0a"
+    },
+    "progs/brk_pot1a.mdl": {
+     "bytes": 93352,
+     "sha256": "5612b9539e9663e06397f315968674b1de6ab50db7cdf673baadcd4652cedcd5"
+    },
+    "progs/brk_pot1aflr.mdl": {
+     "bytes": 93352,
+     "sha256": "02fd1feb7dc24b456e31f26f142aafb9adf491a16ea4caf2c4ec237e465260a5"
+    },
+    "progs/brk_pot1b.mdl": {
+     "bytes": 93352,
+     "sha256": "47c4053f0c0c941674a9d7c15a07e05c7ed648b2bf8ffbd1defb7264c151b47a"
+    },
+    "progs/brk_pot1c.mdl": {
+     "bytes": 83968,
+     "sha256": "a408707cc6793c337d0e76d86c5362de39a1f2109c23affe5def6e8194e0f4e8"
+    },
+    "progs/brk_pot1d.mdl": {
+     "bytes": 74024,
+     "sha256": "c31abc1e9e5af2cb86614f68a8be55f6192e05baba8b93479e2b2590b1e0ef1d"
+    },
+    "progs/brk_pot1part1.mdl": {
+     "bytes": 33768,
+     "sha256": "2dd32863b6006dda74b60f05a43df13e7df052ddcdb652309ba0ab29fa5352e5"
+    },
+    "progs/brk_pot1part2.mdl": {
+     "bytes": 34072,
+     "sha256": "550cae5c8893c63520c324610950eeb5b9fe842dc8ea1f07f6a217953f6e743e"
+    },
+    "progs/brk_pot1part3.mdl": {
+     "bytes": 33464,
+     "sha256": "819cf0e720637e7c5e187ccc67ae032eca217ee2f07076aefee1a8b7de894852"
+    },
+    "progs/brk_pot1part4.mdl": {
+     "bytes": 33496,
+     "sha256": "a3cc47c7f7410bb0ca2308e45144b29bc3b678600e0f288b15d8e64525585e43"
+    },
+    "progs/brk_pot2a.mdl": {
+     "bytes": 77348,
+     "sha256": "ffcf5e5f3d0b81143e2b2b387cde7b13b2d36b71345d63456f288eb036993a2b"
+    },
+    "progs/brk_pot2aflr.mdl": {
+     "bytes": 77348,
+     "sha256": "37420048a9f72abc5982f5f6813602dbc4b82ef8e788a0e309df7ff13066ea62"
+    },
+    "progs/brk_pot2b.mdl": {
+     "bytes": 77348,
+     "sha256": "40eb2c849cd06d9b985b0efc2b9d1090ec1648b0de53d0a07bd6fd5fe2af6733"
+    },
+    "progs/brk_pot2c.mdl": {
+     "bytes": 77348,
+     "sha256": "3774ade6790fc2b597c44c5206deeb3d5d3d20a23331e3fb622e1e90f833c7d4"
+    },
+    "progs/brk_pot2d.mdl": {
+     "bytes": 79004,
+     "sha256": "2af25d81ae0f1d8724f3047e95ff2f1d1700061a536b3f9ffda5522cf7e8dd13"
+    },
+    "progs/brk_pot2part1.mdl": {
+     "bytes": 34456,
+     "sha256": "13547d9ca8c36bbcc95354df03dfbdc14f19f74251ff1dc8c417436846b396bc"
+    },
+    "progs/brk_pot2part2.mdl": {
+     "bytes": 34680,
+     "sha256": "7f9824c52b01664c2dd1ccc5c1dc9e7ff2a5567dd2d0a8e9c3bf1a8bd00400e7"
+    },
+    "progs/brk_pot2part3.mdl": {
+     "bytes": 34008,
+     "sha256": "52fdc17879e0b6fb8697e1e9fffba092f1b5aa8d3cee5d657b405eb4119e8e87"
+    },
+    "progs/brk_pot2part4.mdl": {
+     "bytes": 33304,
+     "sha256": "b40cf2b029a4bfac52a80f5aef6587f3eb66e08be1fe5f40cd3f97e93133ad3b"
+    },
+    "progs/brk_vase1.mdl": {
+     "bytes": 27992,
+     "sha256": "28a8b9a0d367f17c2c265271d99b019f1762831a11ba794e2884fc7f7a8a2368"
+    },
+    "progs/brk_vase1part1.mdl": {
+     "bytes": 5524,
+     "sha256": "b8c0bef8f5d6a427f57282f086a75f39e91ad6ab035d4f1d437da97794e52f9e"
+    },
+    "progs/brk_vase1part2.mdl": {
+     "bytes": 5556,
+     "sha256": "8e1df7795140732953af83a1ef2158299a2cc393163041b6d3243478b6b644e1"
+    },
+    "progs/brk_vase1part3.mdl": {
+     "bytes": 5556,
+     "sha256": "c2e3da479defb1c3bd5130555e33dd47afc6a3b4ef7f74d4f0184cb02a02a46d"
+    },
+    "progs/brk_vase1part4.mdl": {
+     "bytes": 5524,
+     "sha256": "986c51c2cb3832f597f9dac89c6044d090b10933306814acc36a0c4ab5a04b93"
+    },
+    "progs/broom.mdl": {
+     "bytes": 19124,
+     "sha256": "ca56feb7ec309a34903071908e14022881496ca96310051f03c4e745f0f3e1d6"
+    },
+    "progs/bucket.mdl": {
+     "bytes": 20532,
+     "sha256": "7adec73034f4db3bf8f0381bfba5b72ab3c70d742efc393f86951c7b7f913def"
+    },
+    "progs/bulb.mdl": {
+     "bytes": 65672,
+     "sha256": "4de6490ccf0f60393200bb8fcec7c9a1ebba47e259af38d4f102ef1d7ebf8aec"
+    },
+    "progs/chalice.mdl": {
+     "bytes": 73296,
+     "sha256": "7c97446fe76c947a9d44a1c012c7115c5411af8eac7d4d38971bb04e7af02ab1"
+    },
+    "progs/chan1a.mdl": {
+     "bytes": 106740,
+     "sha256": "67983d9aa113b12fc787d349b26ecb09d36c188f303ce0e823fc2be180947f95"
+    },
+    "progs/chan1b.mdl": {
+     "bytes": 76676,
+     "sha256": "e15ac9573e534a8c67d2d2cb1cd6c479f4f51adf60f0bac707c52f99b9de52fe"
+    },
+    "progs/chan2a.mdl": {
+     "bytes": 106740,
+     "sha256": "14cfe1b1543a53e7b297532ee5ecdf3c8215e4457be1c18786152f93f10b2773"
+    },
+    "progs/chan2b.mdl": {
+     "bytes": 76676,
+     "sha256": "08954c294f0ff3e14e6cd5f2191d79d378ec77461d357d2f2ac71da82f09c96c"
+    },
+    "progs/corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "839b70bb6be7fac8c25e6069b999e076b04bdd3dbc7a9320924713cf75c2cadb"
+    },
+    "progs/corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "cb994b390584e1776ad1f0e60d95186a0dc54cd160a2cb8284d1a15b4fe1a35d"
+    },
+    "progs/corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "b19faa9afe7cf957ae7abf6439799e5001ff42817290f4b464aa3f7ae4e3377f"
+    },
+    "progs/cranea.mdl": {
+     "bytes": 92792,
+     "sha256": "1e9709d6f78619482576012f46b6c1a332d7cffed4604dcde22fbe962106f0b4"
+    },
+    "progs/craneb.mdl": {
+     "bytes": 21940,
+     "sha256": "686a867499ddd7baeb297ae41602b74feeb97107ee70bf0fa43f3e1503ca81c9"
+    },
+    "progs/dance_player.mdl": {
+     "bytes": 465924,
+     "sha256": "d07f23e6a40743aeac01084a1da9670ea9a635339d86be46149e9f0ee74661e0"
+    },
+    "progs/dancer.mdl": {
+     "bytes": 243764,
+     "sha256": "0c9755865d9959cc9c4231f6830d4cd78b123be5ffc13494fc968a3c7cd1467d"
+    },
+    "progs/darts.mdl": {
+     "bytes": 27068,
+     "sha256": "c2eb4b88dda96957ef4fc78a456ae4fe9e3de7c8ffb0f8dc3ceba92cb12bd751"
+    },
+    "progs/discob.mdl": {
+     "bytes": 47499,
+     "sha256": "ca457dc2268fde661fdafcfdb06376ddc75a2ebf419adcff0a9ae7470511aa4a"
+    },
+    "progs/explode_box1.mdl": {
+     "bytes": 49888,
+     "sha256": "c8a7e667c5e20735db9a816b7a11b5a1c67bf4e176d1553a79cc56bcaa9ff35b"
+    },
+    "progs/explode_box2.mdl": {
+     "bytes": 49888,
+     "sha256": "649dbfabde0a875a0c35b0109261515dc9eb287d0cc7f41ca3712283e62509c1"
+    },
+    "progs/fence.mdl": {
+     "bytes": 46448,
+     "sha256": "8bd1ce616f54285d20a5334e51f995d25e6c7dd14edce7642669aef6bbaf8ff8"
+    },
+    "progs/flame.mdl": {
+     "bytes": 41668,
+     "sha256": "d6cb4dc28d5101538b44ed53fe1cf84c9d5f8547a91eb74fc6c6bdd3645ffa17"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 74548,
+     "sha256": "f03dd3b7f94a86c4d91ffb002723a16f30321a0c2189b673dd4f12f547245816"
+    },
+    "progs/flameb.mdl": {
+     "bytes": 171134,
+     "sha256": "3093a804200a10673c0454df9e23b6d2dda6e0ddaaf62f13e323da5b3dd63df5"
+    },
+    "progs/flower.mdl": {
+     "bytes": 240080,
+     "sha256": "12c540632057d64f1333a6cd7c4d8f8039a3c9b43cd6f0aec94afa345add55e0"
+    },
+    "progs/fount2.mdl": {
+     "bytes": 906240,
+     "sha256": "0e129ac6180b4bfd13ea37e6d3f4fbce86b2dcc19332dd22a420e58a8d1e0375"
+    },
+    "progs/fruit.mdl": {
+     "bytes": 95604,
+     "sha256": "da1c69015b9de541437cfabbb6fe68446aa74bf9fa02538cea63b97457fd6d5e"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 71268,
+     "sha256": "b1e734caec73b941b1c033fbb49ffc0f947aa8e1d47250c2d8cec0f244870fc8"
+    },
+    "progs/g_ghook.mdl": {
+     "bytes": 64684,
+     "sha256": "9cdd8bccab5f11ea7f8ea6480a4ea05c9d749bc4746cc19a6452a2e0356edfc6"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 26260,
+     "sha256": "2eec21d45a889be6cbe3e975c1bd3138ddcb1826be3a6e9914dd84f927827b00"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 202020,
+     "sha256": "0b5441054d4221789ac5d8858645bd073b3a6b27d3a722c3f10aac95c991aaed"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 26244,
+     "sha256": "2c9c8d529cd93d478142330f804e8eb061bae7d56b71f94cb6ae1e0cbf7bd347"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 31012,
+     "sha256": "782aa6108c183c3e0a87381d97053b3282a8ed37903ee447a938e3e292cd7624"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 25316,
+     "sha256": "261a8479de0d5df9aea9931a62b1b93dbb7bfcff4f4467920cbebcc9c2c25381"
+    },
+    "progs/g_shadaxe.mdl": {
+     "bytes": 252228,
+     "sha256": "d0404d8853f63c573afbdb57945eef444f59a8d677ca667f2390517dbd3f153f"
+    },
+    "progs/g_shot1.mdl": {
+     "bytes": 24580,
+     "sha256": "72913fa948f1618347adaa91ceb98203186d2fc7bd3b9c84af00f7f637928058"
+    },
+    "progs/g_shot2.mdl": {
+     "bytes": 47420,
+     "sha256": "21db1f4c05567556d6e55a28e4e80ed406dbde75303b29c173d10ac42fb694b7"
+    },
+    "progs/g_shot3.mdl": {
+     "bytes": 43532,
+     "sha256": "477e4ce519c63f7bc4aff8adb933902ba595e39a60ece90175c38f9fef381580"
+    },
+    "progs/g_zershot.mdl": {
+     "bytes": 68020,
+     "sha256": "3439ce2faa846bd2b3ca50e33b55092454ed83caaf8fe654d8381e107aa3520a"
+    },
+    "progs/game.mdl": {
+     "bytes": 18276,
+     "sha256": "5d4b3b6daa9e8b3f47e9b64ca139f38924c1bfa3a558978bb3ea9a639b0e5bcb"
+    },
+    "progs/gib_1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib_2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib_3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/gib_4.mdl": {
+     "bytes": 7468,
+     "sha256": "29f9cfa3d86121e1e349de9c3a39e620b9d6ba2cd98640536923e581f7ae28bd"
+    },
+    "progs/gib_5.mdl": {
+     "bytes": 85308,
+     "sha256": "2023ae2fd305843640266ec6679511d134e1b84ac54de245a390e483557050bd"
+    },
+    "progs/gib_blclaw1.mdl": {
+     "bytes": 32860,
+     "sha256": "303c38aea48534d4ce34f3c2082a21c7408c1e4a4cd848bc7e4acadfaaddbdc0"
+    },
+    "progs/gib_blclaw1b.mdl": {
+     "bytes": 32860,
+     "sha256": "c22db765c594ee28a0863cf70e354c651a2b9282e1df7e3a57b35ce62932920d"
+    },
+    "progs/gib_blclaw2.mdl": {
+     "bytes": 32860,
+     "sha256": "c7d70c4c067aa297fbebc3d26a2068a62f307c7f00f8d15d0bf76ed9519967c8"
+    },
+    "progs/gib_blclaw2b.mdl": {
+     "bytes": 32860,
+     "sha256": "96a96606a74eb3093d88f1f946d66caf77bd57fde0a4ec44840c95fa12130551"
+    },
+    "progs/gib_blfoot1.mdl": {
+     "bytes": 32860,
+     "sha256": "74e05efa33fc9036399a1f1d484a3816129fe0e379aee579b923cf3316e5ab84"
+    },
+    "progs/gib_blfoot1b.mdl": {
+     "bytes": 32860,
+     "sha256": "2d23324414f3f1a25ee24afe914679d07df244c9c0e48139331f084b8c369054"
+    },
+    "progs/gib_blfoot2.mdl": {
+     "bytes": 32860,
+     "sha256": "c2ce3b46d8762b042d201608271c3441b975b93e6329790ca5cba61294f71e45"
+    },
+    "progs/gib_blfoot2b.mdl": {
+     "bytes": 32860,
+     "sha256": "de945be28e0b05dc380a0a2cfff6907f14a5e4b9756385874fddd712df095bb6"
+    },
+    "progs/gib_dmclaw1.mdl": {
+     "bytes": 49248,
+     "sha256": "be5f2bb9174ce47f6d3df06685ac728c852c3a028f6aeb1632e709eb69c20ee2"
+    },
+    "progs/gib_dmclaw2.mdl": {
+     "bytes": 49248,
+     "sha256": "ff6cc88ef9123812b9d8e09235074f4c7fcad47077e6fffee334f15e3f71eb27"
+    },
+    "progs/gib_dmleg1.mdl": {
+     "bytes": 49248,
+     "sha256": "106990e4d9e2746303d09ae6c481914702af0242d8cf0fc9d430d0fa5329813c"
+    },
+    "progs/gib_dmleg2.mdl": {
+     "bytes": 49248,
+     "sha256": "8308124b7c4dca218af9e8ef7042ddcb0ca2fcb30e7f86866b1a28a73ab94db2"
+    },
+    "progs/gib_dmtail.mdl": {
+     "bytes": 49248,
+     "sha256": "6b60c464ee0e7ace54313550ac5be2f4949cc6f8dd539b38459c4a6c395e6704"
+    },
+    "progs/gib_drolearm1.mdl": {
+     "bytes": 18324,
+     "sha256": "a6b0f55da1b1d8e519b3cb9a53afe229279c760ffab3862866d8c4e7a52f267e"
+    },
+    "progs/gib_drolearm2.mdl": {
+     "bytes": 18212,
+     "sha256": "aff67984dc3198d24d2184c35748e829d7f867c38227f1fa898a1986f12ac767"
+    },
+    "progs/gib_droleleg1.mdl": {
+     "bytes": 18436,
+     "sha256": "ab69d8c271f44998ccdfd10d70ccd06caa3c2674f46e4cf94285b380d08db501"
+    },
+    "progs/gib_floyd1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/gib_freddiejunk.mdl": {
+     "bytes": 71364,
+     "sha256": "13763a8cec3b643acb9b8165f1850ffae003131c84a2ac225777822a88462498"
+    },
+    "progs/gib_gargwing1.mdl": {
+     "bytes": 92088,
+     "sha256": "3979718d2403ca7cf75aad4004a56100c1bf358f2cb9ae68595e5d69f6774f47"
+    },
+    "progs/gib_gargwing2.mdl": {
+     "bytes": 92024,
+     "sha256": "7554ef45a88db1f2e457dd7071770e42bf864123827b9819435a628b412ecb32"
+    },
+    "progs/gib_judgeboot.mdl": {
+     "bytes": 199308,
+     "sha256": "557eadb703666c4868e1b231cb1c21fbff5e59e2ec0cb8ade85cd3839fd714cb"
+    },
+    "progs/gib_judgeshould.mdl": {
+     "bytes": 199132,
+     "sha256": "69e4958866a47d5c63a6385db4843a6a5011f149b25e67720291d2db63945ed8"
+    },
+    "progs/gib_justiceboot.mdl": {
+     "bytes": 264848,
+     "sha256": "b727239a7bf232c7c6164d0f9fc0961a6c692cb0c0919b17429ade6f62bdd71c"
+    },
+    "progs/gib_justiceshould.mdl": {
+     "bytes": 264672,
+     "sha256": "2fcafb2b2a19b8ae16009e827f13fea14cb389317ec476b7f58fb2fef1163180"
+    },
+    "progs/gib_knfoot_l.mdl": {
+     "bytes": 18288,
+     "sha256": "8ffcc7ce931662f2eefa0703642b140e18a99c02252ffa3ddeb71f6ebbbe360f"
+    },
+    "progs/gib_knfoot_r.mdl": {
+     "bytes": 18288,
+     "sha256": "4d503f422ac01a8565453ba4bd8268338c3a9802480785eebd27fc0487e46753"
+    },
+    "progs/gib_metal1.mdl": {
+     "bytes": 5172,
+     "sha256": "b0951de4d869e0b779aeb3f7a96f56b22a82a58d267a56b1247f0c3e667c25ad"
+    },
+    "progs/gib_metal2.mdl": {
+     "bytes": 6292,
+     "sha256": "3df78c49abb572095d3b70efbb99bccb63caf2ffd30bb3ee434c945084acb5a0"
+    },
+    "progs/gib_metal3.mdl": {
+     "bytes": 6036,
+     "sha256": "88f8a1f941e38f8528ec27a168559946cc0b69f2abce1cbf6858b813e09c5f51"
+    },
+    "progs/gib_metal4.mdl": {
+     "bytes": 6580,
+     "sha256": "fbde734f29a6691d51c58a40a89e45f81dece2f20218353a6137a2362acbe3a9"
+    },
+    "progs/gib_minoclaw1.mdl": {
+     "bytes": 135544,
+     "sha256": "1188f73d5a6319bef5e506ca994bfcf63074a4267a5a189cb92db94160310fca"
+    },
+    "progs/gib_minoclaw2.mdl": {
+     "bytes": 135544,
+     "sha256": "511bb72c8382f4cc3cc9fa3bea4adf2390dcca1e2dcd42ef8f8287765875fa99"
+    },
+    "progs/gib_minoleg1.mdl": {
+     "bytes": 135448,
+     "sha256": "f07ce357d83d3ab0f39109d93f2f6996ded4ff19a4372fd5ddc9d9fa1a0ce8d3"
+    },
+    "progs/gib_minoleg2.mdl": {
+     "bytes": 136392,
+     "sha256": "7ba78149bc60a05ceff9090ecc2bdf013ff2d55420dfdebc553a254ac0bd08fb"
+    },
+    "progs/gib_ogfoot1.mdl": {
+     "bytes": 5956,
+     "sha256": "144e2fdfbccceee039243ef343df02ce181b666070e2d0a1825c056634f2a632"
+    },
+    "progs/gib_ogfoot2.mdl": {
+     "bytes": 5956,
+     "sha256": "9997dff0bdb2622ef6ee2530c27835fd249aee04437e70486e76255f979bec25"
+    },
+    "progs/gib_p1.mdl": {
+     "bytes": 7712,
+     "sha256": "709c49c205b27793f589eab17e8356a108345069716f9095dc07dd6447be7894"
+    },
+    "progs/gib_p2.mdl": {
+     "bytes": 21216,
+     "sha256": "50d99c7fec3b8ef01bbb19c32c88dac40a372cb6a7d39c349e0ff4909360626f"
+    },
+    "progs/gib_p3.mdl": {
+     "bytes": 18176,
+     "sha256": "d53659aa99de418793337b7e878db7bd7836883ad43528d648475589aa30d85d"
+    },
+    "progs/gib_p4.mdl": {
+     "bytes": 7468,
+     "sha256": "71ad4dcc06038f0a175605a3906b1506d0144b56b238e7df178160d9ab876b8d"
+    },
+    "progs/gib_p5.mdl": {
+     "bytes": 19756,
+     "sha256": "adf63c881ff5703b8112f714140929375b5c10be957f01cfdfa131d89af3cacf"
+    },
+    "progs/gib_s1.mdl": {
+     "bytes": 7712,
+     "sha256": "31faee0daaf399feccc1ec942ff7fe85a1a790ebd93c3b8a1fcfde9bcc06da1d"
+    },
+    "progs/gib_s2.mdl": {
+     "bytes": 21216,
+     "sha256": "c85f7dbc8eec508951893253bba5eec169a87865c995ba1d0e5c083fed9e03ca"
+    },
+    "progs/gib_s3.mdl": {
+     "bytes": 18176,
+     "sha256": "ec23effca60ef407bf294a814003213928f21f05e6da501fbe996345b6171013"
+    },
+    "progs/gib_s4.mdl": {
+     "bytes": 7468,
+     "sha256": "5001ef206e1a36cc792d7b94054b2bab4c6dfbed60e0ee0d3afd240d1af88d13"
+    },
+    "progs/gib_s5.mdl": {
+     "bytes": 19756,
+     "sha256": "9e1a112412d38c559974c628649a7773ad445ba7d24a1804c5f3fe5f50ecef7f"
+    },
+    "progs/gib_scorpclaw.mdl": {
+     "bytes": 66816,
+     "sha256": "ecaf582e92d77a1722eded2c5564d2fb9575065510ff1bc9632538345ed18329"
+    },
+    "progs/gib_scorpleg.mdl": {
+     "bytes": 66304,
+     "sha256": "399067acf8f082301f6629d2b124b0d34a7d934db55c922205a96772a85a8a1c"
+    },
+    "progs/gib_scorptail.mdl": {
+     "bytes": 66864,
+     "sha256": "0831c04d7a73c6f58329b0be0f6d371f727ea880b49e5b6e16f7cdc56c124df2"
+    },
+    "progs/gib_seekarm.mdl": {
+     "bytes": 265688,
+     "sha256": "6ee70b2f4f39d8a1fd99113c7c8df5481c421960f160afea4e622ed5b3113014"
+    },
+    "progs/gib_seekchunk.mdl": {
+     "bytes": 265420,
+     "sha256": "a70331a8e43075b026cf21d364cf2341e79e7e60c5fca4777d10aabd57ce0323"
+    },
+    "progs/gib_shclaw1.mdl": {
+     "bytes": 22964,
+     "sha256": "20b29bf40dd02dce0204c14c34b0b5806d8eef580406851d73383a631ac8f2a7"
+    },
+    "progs/gib_shclaw2.mdl": {
+     "bytes": 23060,
+     "sha256": "8dcf777d5ffd2e83edf5b6f936881eaf9d384fe8fc980721c9f5881d3e6da0c3"
+    },
+    "progs/gib_shfoot1.mdl": {
+     "bytes": 23268,
+     "sha256": "634d7cbb9e2b718167fe74112e6dd4f53cfe1cffc32f75cd80e711a24cd2f983"
+    },
+    "progs/gib_shfoot2.mdl": {
+     "bytes": 23124,
+     "sha256": "aaa2393cb65fb33a8885bfdd9b808732c0aa17f0dd461d3b04e84eb27f0fe61d"
+    },
+    "progs/gib_soldfoot1.mdl": {
+     "bytes": 51148,
+     "sha256": "09357cfed1e6c9c25e0d133d95f2c2b36693cbed1010146a982bca685cb370ed"
+    },
+    "progs/gib_soldfoot2.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/gib_spidbodyb.mdl": {
+     "bytes": 17652,
+     "sha256": "313dc78de70f02de9a49c71a1fd5ddb5ae4247f90a1a04f0ab84f44797be1946"
+    },
+    "progs/gib_spidbodyg.mdl": {
+     "bytes": 17652,
+     "sha256": "5439ca0812bc2627f22fd995237607755708f7615782785093793c11497973e5"
+    },
+    "progs/gib_spidlegb.mdl": {
+     "bytes": 18560,
+     "sha256": "66dc12710dec1bd4827497e4ed28b6a4965e1f68b48d5f0903a96ecf632e7f4e"
+    },
+    "progs/gib_spidlegg.mdl": {
+     "bytes": 18560,
+     "sha256": "3474de5b97c2b424f8ec4b8d93a1457f13adca106bdbe15234492376708810f9"
+    },
+    "progs/gib_steelbody.mdl": {
+     "bytes": 17652,
+     "sha256": "2a833de4b00f439041d27d97b3660d4df1cc9e3b454dba5ac5533e5c855e8d90"
+    },
+    "progs/gib_steelleg.mdl": {
+     "bytes": 18560,
+     "sha256": "ae926ada1c4ef7b695764f2daa0b4704102bf5eebc103b9f6a56813337f43165"
+    },
+    "progs/gib_swampleg.mdl": {
+     "bytes": 4820,
+     "sha256": "2b549fd3a74b0fd6b94c71c9e397b466e2c7f823917ffe717ce1af43769e1961"
+    },
+    "progs/gib_swamplegp.mdl": {
+     "bytes": 4820,
+     "sha256": "b5cf22240bf6474cc8ea57c40ddb70f80e792c23cb87835bee94825cb645578a"
+    },
+    "progs/gib_voreleg.mdl": {
+     "bytes": 4820,
+     "sha256": "19ec59cb3436d66a8ac9d8f40480a9c83aef879f0f1e58ddb834710e2bbc4d9d"
+    },
+    "progs/gib_vorelegp.mdl": {
+     "bytes": 4820,
+     "sha256": "341679c553a719be40022fc4a3573ff68116fee7ae05df511b9083a410af5e7f"
+    },
+    "progs/gib_wraith1.mdl": {
+     "bytes": 5300,
+     "sha256": "a0642c84b36288a3d0cef22ac32e0c681c422a034204932671729624f19d0b2b"
+    },
+    "progs/gib_wraith2.mdl": {
+     "bytes": 6292,
+     "sha256": "d20a17e624d16e4c8552ac9a291cd735aeae670effc2c9865b37fbc7bcd22220"
+    },
+    "progs/gib_wraith3.mdl": {
+     "bytes": 2516,
+     "sha256": "63f10b068c6df0a80729362c094f72d0bcf90f74de97636bc5e4a630c13e741b"
+    },
+    "progs/gib_wzarm1.mdl": {
+     "bytes": 12384,
+     "sha256": "9b6f5469bfc6ae49d2bd51fb6d35e686c4e79e5691e2fb80fa7ee556bf547e04"
+    },
+    "progs/gib_wzarm2.mdl": {
+     "bytes": 12384,
+     "sha256": "2ff539f467ca9b0f23c40cb2547221a484afbe7e07a812558ec1595e5cbd0217"
+    },
+    "progs/gib_wztail.mdl": {
+     "bytes": 12384,
+     "sha256": "fb90123980ff4510e744ea2b21509492b7ff9c131527ffe5c7b80bbbf881bf41"
+    },
+    "progs/gug.mdl": {
+     "bytes": 482020,
+     "sha256": "2cd097236a235aedf717a86b7312bd7d1b3caa6f0b25980c82eee2463fee2274"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 166580,
+     "sha256": "f9a81c01d6ac5f493bca04a1c5d4ea316fb3fa6b68ef33fa608160266904b814"
+    },
+    "progs/h_boglord.mdl": {
+     "bytes": 98400,
+     "sha256": "119279b2ffdf928d34ef1470ae6c14f875cb59edc6d8b107a90bbea122c9acdc"
+    },
+    "progs/h_boglordb.mdl": {
+     "bytes": 98400,
+     "sha256": "25af0d0ea45857e64549686bb58e5f69a0754ff6e43c26ce735e58aaac3d534e"
+    },
+    "progs/h_centurion.mdl": {
+     "bytes": 63592,
+     "sha256": "2e64af530a4f5f36001ad922bb56a941738e7fe2c67c0ad0e3f06fa5854c4b08"
+    },
+    "progs/h_dcrossbow.mdl": {
+     "bytes": 51316,
+     "sha256": "5b53a01a0ce8541880abf5a3cf7455846214669417270ff68807492dfb2fa850"
+    },
+    "progs/h_deflector.mdl": {
+     "bytes": 22232,
+     "sha256": "56de00c315543073bfda7e8a5ad3c3996f549351fa1e660e676516f4122cdeac"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 67688,
+     "sha256": "ff73d5f8fcab46a806c47377679ec5473cdc0ea93a0fda6dda8b5dba8cfa4b97"
+    },
+    "progs/h_dfury.mdl": {
+     "bytes": 46056,
+     "sha256": "3b2c9ed10a7d0d57258773a0497347f233e648cc3ad11c846a0651e00a81a4ef"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 51316,
+     "sha256": "981de13d8f063e6891b56c8553faeefe088adaf5e30b7d45d6927772b934d66c"
+    },
+    "progs/h_dguardq.mdl": {
+     "bytes": 6972,
+     "sha256": "92ba5e36a4bb964bfecad6977962b6135889bf0f389078e95e287d396a6fd76f"
+    },
+    "progs/h_dknight.mdl": {
+     "bytes": 57760,
+     "sha256": "e99d4ac57dbf098efff6ded4dd12f4558d8af2dd72f642ed8332c1eec91a526e"
+    },
+    "progs/h_dlord.mdl": {
+     "bytes": 18699,
+     "sha256": "bc5a92be1c5f3d06dc0238ec7bafe6a3c25826cc50edc6214ed5aa19b0075987"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 49248,
+     "sha256": "1846ffa69579e767c0da29e0d30fc2b9e3189ba856f133afdd48cf8d1efac46f"
+    },
+    "progs/h_dprince.mdl": {
+     "bytes": 25740,
+     "sha256": "fef62ce4fb41cdbde4bce12eac0684ccfaead4737a84d152126d3862b065710d"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 14032,
+     "sha256": "bd5da6afddc520999d9c572a679c3bc8c43635ce2c73f8789603eb6a83c15aa1"
+    },
+    "progs/h_eel.mdl": {
+     "bytes": 156904,
+     "sha256": "a859ee09044d9afcd05ee2af3f1ea8c7b4ae3abc01273922dbebd5aa67b12d74"
+    },
+    "progs/h_enforcer.mdl": {
+     "bytes": 94612,
+     "sha256": "21046f6878f5f4173206debcb912d9fdee0b1f5c66d820a4355c7df8e2eb1860"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "f07b78928c992224db48daf65dad80e3742c3f5adef7591b9dabcaa20d92c484"
+    },
+    "progs/h_gargoyle.mdl": {
+     "bytes": 30152,
+     "sha256": "bbcf207c44814f5e665944db03800934eab9046a0d0d86f4c982a3116f855791"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 59888,
+     "sha256": "f57daa1ab6a721a9feb696aaeeb597c720b639cd0a027a1b1da8cdd68ad1d1f0"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 30552,
+     "sha256": "edf8a4ccc52bfd9545fda8da9360e536c026079f8d2fd9756191fc934bd55683"
+    },
+    "progs/h_hogre.mdl": {
+     "bytes": 23688,
+     "sha256": "6f21e95518cd085d20b1023951ddf4d738285210bc95c6e2b3d2e82566478776"
+    },
+    "progs/h_hogreham.mdl": {
+     "bytes": 22776,
+     "sha256": "3d3e43d16c4babcbca358b44dc03ad1a212e22ea3a10ee9e639b5f4c2e95f670"
+    },
+    "progs/h_judge.mdl": {
+     "bytes": 203276,
+     "sha256": "be57ef7327fbf3ea6fb55c02bcccc4ec207b3781bb9d2e383939f3840e1ef91a"
+    },
+    "progs/h_justice.mdl": {
+     "bytes": 268816,
+     "sha256": "01d3011001c297b85a139ecb2861f188d15b96cd1ae02f08cb1604565f2d2ee3"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 57812,
+     "sha256": "3cc8b821fd1751621b10712734f1e5aa6d6794b0cf735017207567699b691cef"
+    },
+    "progs/h_minotaur.mdl": {
+     "bytes": 138264,
+     "sha256": "c5e13818c813680fd29a94b408518731aa4e9007c23d004ec874f099c9ced6b1"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "4967d418f4810e9273732bbd4c690a1f9478243f7fe3807497134eb2994da0eb"
+    },
+    "progs/h_pyro.mdl": {
+     "bytes": 42912,
+     "sha256": "5359fd85e71cde1ab716d8d50a8618a347dd42b4ad4692805bf41c1903d55c18"
+    },
+    "progs/h_scorpion.mdl": {
+     "bytes": 67408,
+     "sha256": "d68d09c35c00d9bafb302fb7f3baeef90ee5d60de1ad8a7627f979c3561f5965"
+    },
+    "progs/h_seeker.mdl": {
+     "bytes": 9060,
+     "sha256": "9e9d601441532e16aee253b5e94ea9c32563f880782794d16ce496a580698bd8"
+    },
+    "progs/h_shalrath.mdl": {
+     "bytes": 78156,
+     "sha256": "f478f17ea9ee6843be2ebe3c487d0036657c94ace52a800fa44e0160d02a522d"
+    },
+    "progs/h_shambler.mdl": {
+     "bytes": 163944,
+     "sha256": "e263f7e53e2dc8038d0b5ec83e3035dd6570c6546616a04610c1328141cc0b84"
+    },
+    "progs/h_skullwiz.mdl": {
+     "bytes": 234304,
+     "sha256": "625c991e231d6836c36ae0c6651ec06f05541e9a7be605654fb43fba65bcc3d4"
+    },
+    "progs/h_soldier.mdl": {
+     "bytes": 166488,
+     "sha256": "0a4e322fbac8f98755adb9a4bf5ecff24d58aab30fcb1c9def3e97a0f686445e"
+    },
+    "progs/h_spiderb.mdl": {
+     "bytes": 18564,
+     "sha256": "d51c7764fccc4512db6d79ddcf03ffe42cf2817a66d6be02be0cba6551ee1206"
+    },
+    "progs/h_spiderg.mdl": {
+     "bytes": 18564,
+     "sha256": "70bec9669f3a7f3662320e32d29c38d535092db56617d5033e11669038472e2b"
+    },
+    "progs/h_steelclaw.mdl": {
+     "bytes": 18564,
+     "sha256": "be9adcdf9cf9407a729cfa9abcd692f46a55ffcf25c1878a7b2f5572fd591f8c"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "63b8a0b90691ae9a3c50a94f02943a1b94946f89402cc4e1da74c6806bd953ba"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 23516,
+     "sha256": "5a933ecbc067b8d6cbb57f71ae1614844b6e55170a206d278b3d15fe619c9cfd"
+    },
+    "progs/h_zombiek.mdl": {
+     "bytes": 4920,
+     "sha256": "9b8b3af67bdec6160ecd3880acc072b833886f7fc11d1e64ffcf06184f9ba80e"
+    },
+    "progs/health_100.mdl": {
+     "bytes": 6948,
+     "sha256": "6c6646f6081ab00ed1c309de3b697009c825d64360b06c741a533b718e0ab8d7"
+    },
+    "progs/health_100b.mdl": {
+     "bytes": 23248,
+     "sha256": "d82148af4482e3c0ff07389ebb5b09cdefda373e31105aeb7308b4126b353a97"
+    },
+    "progs/health_15.mdl": {
+     "bytes": 95604,
+     "sha256": "da1c69015b9de541437cfabbb6fe68446aa74bf9fa02538cea63b97457fd6d5e"
+    },
+    "progs/health_15b.mdl": {
+     "bytes": 10948,
+     "sha256": "eb1bb584805aea34a0f0ab846a758cdc359b730e144e141dcd756da23b5831e1"
+    },
+    "progs/health_25.mdl": {
+     "bytes": 7332,
+     "sha256": "ce8260929500cac3b57617345b2c6b5a75e763afdbd10120982e7d7fa55be27a"
+    },
+    "progs/health_25b.mdl": {
+     "bytes": 23248,
+     "sha256": "7aba68839958035319b2167369f3fcd08c9d49140969cff7fb523b7023362e00"
+    },
+    "progs/health_5.mdl": {
+     "bytes": 8404,
+     "sha256": "da4eaf7c04f2ffce0d7aa178cbe439578bf5c886e6a804d478caa2230590d819"
+    },
+    "progs/heart.mdl": {
+     "bytes": 2324,
+     "sha256": "6a714cd062fa0ea145cd18f1306ead94220bda34cfd5779b5f9d44ab6a2557c9"
+    },
+    "progs/holycrss.mdl": {
+     "bytes": 17624,
+     "sha256": "f6a81bbc96229fc6cef11c5aa9374d0a7b48c1c669571ce87a294f6e64023b0b"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/key_base.mdl": {
+     "bytes": 54436,
+     "sha256": "fb25488fa2fc16c7c4df260a20fd905a821607a675fd0907a6e65f9d534fd367"
+    },
+    "progs/key_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "2632cb327c1175b351d026e88a4e456c45779a0dcdae01381b24200769c8743f"
+    },
+    "progs/key_gold.mdl": {
+     "bytes": 9332,
+     "sha256": "e93ed2c4263bf7631efcbace2c36ed6f240bfcc2b49491751f6d6ce55db8c098"
+    },
+    "progs/key_medieval.mdl": {
+     "bytes": 58532,
+     "sha256": "0810c558e40c5833c19283eb849ba80ac5dd3499e0f077b724057c51730ee097"
+    },
+    "progs/key_rune1.mdl": {
+     "bytes": 18900,
+     "sha256": "90ac269965d42da0205307eeeaddfa5b282598b5218af8650d2d8854621ca950"
+    },
+    "progs/key_rune2.mdl": {
+     "bytes": 19828,
+     "sha256": "4a6644f0b583c85aa41362fb4533cda5f8f762bd4429e5007b3ab57e5e24ae57"
+    },
+    "progs/key_rune3.mdl": {
+     "bytes": 19700,
+     "sha256": "9b33cc0feed9fc27ea647f6d127941933aa5378b52a3f75b9331714fa9d2ff31"
+    },
+    "progs/key_rune4.mdl": {
+     "bytes": 19220,
+     "sha256": "515534b8fdaa0ef99621f0f7d59d268c0c244562372e23c13e9ce05a44e0a68a"
+    },
+    "progs/key_runic.mdl": {
+     "bytes": 57444,
+     "sha256": "e0e31948c1e172c3c9117a8ccd72900c6ebd7a7e73882ae525dd116230f054e2"
+    },
+    "progs/key_silver.mdl": {
+     "bytes": 9332,
+     "sha256": "dd54032e82de32cf1b78a25f862a82a73e9dc0926d89ca7a4279b45d367a8478"
+    },
+    "progs/labra.mdl": {
+     "bytes": 139292,
+     "sha256": "64695f1d5f352bde96c409643b1f6d313409569e52b54de07aae23db1880d572"
+    },
+    "progs/lantern3.mdl": {
+     "bytes": 44524,
+     "sha256": "97affc05648bb22886dd5f08aeb03fbdf5aa330a863ba01b2b871f10de2b8974"
+    },
+    "progs/lanterna.mdl": {
+     "bytes": 56048,
+     "sha256": "38da4fbfb876d35d922bdbb7bd8973a5d2953bbe862f75f7e93226e9d0909acb"
+    },
+    "progs/lanternb.mdl": {
+     "bytes": 26532,
+     "sha256": "1aaab3ec50e9377b6f6eb3ad97a6c67efa4ddfb78d13ae96df1b061f05ff1a38"
+    },
+    "progs/mini-sub.mdl": {
+     "bytes": 40500,
+     "sha256": "173fc702950d46ca4cb0ef043a6bb5a67fc3d6830f7a648fd2f3536dfe517b47"
+    },
+    "progs/misc_bmkdigit.mdl": {
+     "bytes": 3328,
+     "sha256": "1a7f2f762ef3a052a91db7c74cf8d980db47a56685fc61184a15be2152e843b8"
+    },
+    "progs/misc_bmkdigit2.mdl": {
+     "bytes": 3328,
+     "sha256": "2e690ffe1af05f5ad88fe90c180785adeeffdb2b330aa34c6f4fb9885285cd1e"
+    },
+    "progs/misc_bonepile.mdl": {
+     "bytes": 110796,
+     "sha256": "0f8061359681f3c11660e472c517599590447c7631edfe5a36debd9645acdec6"
+    },
+    "progs/misc_book1c.mdl": {
+     "bytes": 40096,
+     "sha256": "92b976437673f56cb890f0e1b90a550ea00939d01ee12b0df0f218b35b42953e"
+    },
+    "progs/misc_brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/misc_braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/misc_broken.mdl": {
+     "bytes": 744,
+     "sha256": "828998b238e1c5471461edc3b9d2d7fada2beab6229272041dff13a94c1d73ec"
+    },
+    "progs/misc_cable.mdl": {
+     "bytes": 57780,
+     "sha256": "bed2cca38ef4cbefa9e645eb5e9ffadffac6ebb4f2ac5f6da4bb8f354de22a48"
+    },
+    "progs/misc_candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/misc_candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/misc_candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/misc_chain.mdl": {
+     "bytes": 231184,
+     "sha256": "845fc3117f7d9860f2d0aa4a398103a13f327516144a96db508189ae1be5788c"
+    },
+    "progs/misc_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "3337f2cfe739c22d50edde7bff18c026d4336bceb207dacf8b0284ab0a5366cf"
+    },
+    "progs/misc_corner1.mdl": {
+     "bytes": 21668,
+     "sha256": "7abf8d5ca497d5e8c8ddcc09c710c0401edb71b11f9de77a2daa81b1267e5698"
+    },
+    "progs/misc_corner2.mdl": {
+     "bytes": 21348,
+     "sha256": "369c874a37ef1da8c9a79432ba2ab9484a5be0df120131b8cbac81e1786adf47"
+    },
+    "progs/misc_deadtree.mdl": {
+     "bytes": 195728,
+     "sha256": "d267db8cfc35b01430590cec643570b38f8df5872c9c3e43df31dc0f3a954e5b"
+    },
+    "progs/misc_digit.mdl": {
+     "bytes": 3328,
+     "sha256": "60f16b89c1e9b8fb8bea0c0aeb96d2dbcfc14a719c130aaa34a581b26e653416"
+    },
+    "progs/misc_doomhelm.mdl": {
+     "bytes": 70104,
+     "sha256": "1b801d032daa163fab361a39631a16c501b86cc9e9b1a52a3f1454e50cdb8c8d"
+    },
+    "progs/misc_dpull_s.mdl": {
+     "bytes": 12900,
+     "sha256": "77fed0a028829fc7120db625131f855faf9b35f97f6ce0591e224bfae0fa78e6"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_fixture1.mdl": {
+     "bytes": 9768,
+     "sha256": "c10980d00e0479f8e65ab633f19ee62ace4c0697c2193f7aea8d266e2be5fc2d"
+    },
+    "progs/misc_flag.mdl": {
+     "bytes": 16052,
+     "sha256": "f2670312a8d16dd16e42fd02a39dfd285e6ffea624e729597b773c86140631d1"
+    },
+    "progs/misc_flame_big.mdl": {
+     "bytes": 244895,
+     "sha256": "09adba1308cdf22d2f07e226cb13a35e51f4d54866f84f41e2074dc7a40371d5"
+    },
+    "progs/misc_flame_med.mdl": {
+     "bytes": 175400,
+     "sha256": "31c94bc48e6c6d6bc31bd14b8e257c4e74d45aaec3a4d5d5bf83587a08ac7c00"
+    },
+    "progs/misc_giantbell.mdl": {
+     "bytes": 74016,
+     "sha256": "0d1b0e150de4ac59c599deae96d6b21e4ceb2300e7d410a1d802385dad99560b"
+    },
+    "progs/misc_heart.mdl": {
+     "bytes": 3512,
+     "sha256": "827ce2bbf2037aa26259901f4152d114cdf38312652e65e53f64ebbad9ea0849"
+    },
+    "progs/misc_impact.mdl": {
+     "bytes": 880,
+     "sha256": "93029307003bd0437071e0a89d0d4c2b699f2cde6ba34242c321cba8243f36b9"
+    },
+    "progs/misc_jstatue_01.mdl": {
+     "bytes": 1057632,
+     "sha256": "c583186f8bd56fd5ac356a8ed34956090eaad6e78506884bd520307e8f5e5698"
+    },
+    "progs/misc_jstatue_02.mdl": {
+     "bytes": 100260,
+     "sha256": "e4f3e702073a7f76ffddb79921a2bbb880d25edc0bdd6a6f115dfebcf99dbae2"
+    },
+    "progs/misc_jstatue_03.mdl": {
+     "bytes": 100244,
+     "sha256": "587cbce564e4da156a0ae20a87bd551046427f894f34959590573ce96fdf5c31"
+    },
+    "progs/misc_lantern.mdl": {
+     "bytes": 28836,
+     "sha256": "d84e36232543a053f2772b1070b221dc23da1b34cd08ea551a982b5e9f168ea5"
+    },
+    "progs/misc_levels.mdl": {
+     "bytes": 35732,
+     "sha256": "7cf9a4c1e556e60dd4e593cad4a2be0b45bea8893d9b5232ecc7febca4bbf5fe"
+    },
+    "progs/misc_lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/misc_lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/misc_longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/misc_madfish.mdl": {
+     "bytes": 84104,
+     "sha256": "30c19dadb42a53c7ccd35f992c5841aee13a86796157ea5e0453a4cb1586a1be"
+    },
+    "progs/misc_mooring.mdl": {
+     "bytes": 6676,
+     "sha256": "29b20cf17c62dddb4f0c1be758add7b15d6b22fd738fd9e2cd7533ac5d5475f8"
+    },
+    "progs/misc_mushroom.mdl": {
+     "bytes": 10804,
+     "sha256": "5570faa6e7828e4e12f568656226b0756a87d633cbdc461af472e0982a88a549"
+    },
+    "progs/misc_oscill.mdl": {
+     "bytes": 50660,
+     "sha256": "cdc96265a646f9e9fb4c1717fa90edb13e42130fadc4dc774b60aeb94b89eac4"
+    },
+    "progs/misc_player.mdl": {
+     "bytes": 562960,
+     "sha256": "83bbcf4cb5858aa9ac03323b461b3e3b09a28f56e212645472219d7d0b0979d8"
+    },
+    "progs/misc_plinth1.mdl": {
+     "bytes": 6196,
+     "sha256": "1ce0b7f49153f717e04436b27863c75f90a73b027c4cb7e36ce094fa037eded4"
+    },
+    "progs/misc_plinth2.mdl": {
+     "bytes": 6164,
+     "sha256": "e06edd50af1748235b251fe6e4217551c58d45c1f73161014dc0e9fd40099249"
+    },
+    "progs/misc_qwindow.mdl": {
+     "bytes": 77168,
+     "sha256": "facf489ac59158a3013118ca196f11a25a543f26559d5b72eef44968aa05008f"
+    },
+    "progs/misc_radar128.mdl": {
+     "bytes": 19492,
+     "sha256": "ef004e28e51e3227121a92432375531fca26d1e44894696f3d2a950fa65aef28"
+    },
+    "progs/misc_radar64.mdl": {
+     "bytes": 19492,
+     "sha256": "b9468012707ad484c1292cbe984c54811cb8fa43542e68e18a52ef93cb37d52a"
+    },
+    "progs/misc_radar96.mdl": {
+     "bytes": 19492,
+     "sha256": "6239d117263f49b79a2a66e62f2dbd6a7f0cd15ce412c1939dd69b4a1d8fce78"
+    },
+    "progs/misc_rkplate.mdl": {
+     "bytes": 436168,
+     "sha256": "7aaa1be1ad8328b457387620f2c29144b70c230489eca04291946a15ec5994ad"
+    },
+    "progs/misc_rkteacup.mdl": {
+     "bytes": 24996,
+     "sha256": "96222ab4c02a088ebe0a74f7cfb3bc51ec4269feea90fb5c7b1d20961302ec34"
+    },
+    "progs/misc_rkteapot.mdl": {
+     "bytes": 479304,
+     "sha256": "9d6e02b2afc781c3b6349e54084f6912d010575492cc677ed33852cb1738c6f6"
+    },
+    "progs/misc_seaweed.mdl": {
+     "bytes": 16100,
+     "sha256": "dfbd38a439d392870c7c4c7ebea4475827b716004ca47bfa7f13b47daf07d774"
+    },
+    "progs/misc_shard.mdl": {
+     "bytes": 22388,
+     "sha256": "06c126f77ad931084d38f0e04d8f4341a5db3e3fa827e30de7d05bc60afd1c1d"
+    },
+    "progs/misc_skull.mdl": {
+     "bytes": 59892,
+     "sha256": "94600327093fe22acc113b8e89c8863a5548b170c9c9897bd2af8a4ff63beb5a"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 31792,
+     "sha256": "8d39b97460c9967ee36b33ea1ef1e92e89277fc410b44f054c5e06b8dc8a079c"
+    },
+    "progs/misc_spark.mdl": {
+     "bytes": 12672,
+     "sha256": "42afca9aeac1b05590b4821872cb79ebfbb4ee7264e914316d880e13f69c2b41"
+    },
+    "progs/misc_starfield.mdl": {
+     "bytes": 23548,
+     "sha256": "5b3563017939382680228e933a2a87d3edb030e75e65c51fe42c4a6889e42e15"
+    },
+    "progs/misc_stickskull1.mdl": {
+     "bytes": 87900,
+     "sha256": "38e63e10bc351ba5a48dfb6195ac5f78e5d61e67ae851f2ba50ba20255d7a37e"
+    },
+    "progs/misc_stickskull2.mdl": {
+     "bytes": 116364,
+     "sha256": "464fbee370b512d1c8057ea5a1dc3ecff69378474593919f0bbd8970419d69a5"
+    },
+    "progs/misc_tape.mdl": {
+     "bytes": 9240,
+     "sha256": "2b6a08ca3be4dd7a669e5b6d1585276759e1fb0edbe0691dd7ecbc7e41f0b189"
+    },
+    "progs/misc_textbook.mdl": {
+     "bytes": 74212,
+     "sha256": "e17e39efdf252a3da8c0574fdf272a800095671f42e71a17a3733673202dbfab"
+    },
+    "progs/misc_tree.mdl": {
+     "bytes": 120248,
+     "sha256": "888eca3c464ac068c7cdc5d7cf8f67fbcc70eb13c0079202a4f8d347f5f3bcd3"
+    },
+    "progs/misc_tree2.mdl": {
+     "bytes": 404432,
+     "sha256": "f14f3b046b58e5485afd11d396b4d358eb0598ea8cca1cbc6a70a8e629aee3f3"
+    },
+    "progs/misc_tutstatue.mdl": {
+     "bytes": 178480,
+     "sha256": "d178ba96d99b02113fe70d32f1672c1490d5f570aecf11d168e58f1bb7e8c17e"
+    },
+    "progs/misc_xmastree.mdl": {
+     "bytes": 479516,
+     "sha256": "59a89b398caa908ff6dd777cb42d0d7dfde930ac5569fdab4bc4f10dd8137584"
+    },
+    "progs/mon_baron.mdl": {
+     "bytes": 405612,
+     "sha256": "66ae5d87aef4815bd62917d04aa6a70d7213a9ef898dd4543163a7ce3bb944f2"
+    },
+    "progs/mon_boil.mdl": {
+     "bytes": 307068,
+     "sha256": "b8a79df258bf71f273dc29887c3782377bf890d43e32b690ebf2ef707eead6de"
+    },
+    "progs/mon_bossboglord.mdl": {
+     "bytes": 466632,
+     "sha256": "6fa01e17322bb2c3aa118534ace60930ba87a6ae4b429539f8e2725f7cfdbd60"
+    },
+    "progs/mon_bosschthon.mdl": {
+     "bytes": 328244,
+     "sha256": "7fc4005959377598747d3accec535b52c81154b17b00221e2cd5410670223538"
+    },
+    "progs/mon_bosseidolon.mdl": {
+     "bytes": 1847180,
+     "sha256": "e08c763865b25851703f71e973755d5a7b446c8004f7d97c09fab04175373c10"
+    },
+    "progs/mon_bossicegolem.mdl": {
+     "bytes": 632584,
+     "sha256": "2a03c71a0451c389dc29374fa3a465fb0d8e9366309cbaeffb68057c928562ec"
+    },
+    "progs/mon_bossnour.mdl": {
+     "bytes": 200036,
+     "sha256": "732041ff70ec350c664194f90a9545b23b6736e729dd128f4482a0cca3ab7966"
+    },
+    "progs/mon_centurion.mdl": {
+     "bytes": 824572,
+     "sha256": "e638ad3021c5c77a1ad78fd798017fbb7a0ffa49ca2fc4a60570ba00e349d532"
+    },
+    "progs/mon_dcrossbow.mdl": {
+     "bytes": 1539984,
+     "sha256": "5241f540b3e6de66a46379ed171fcdd5be565b827d67ddc38d7ca44d79f2e19c"
+    },
+    "progs/mon_deflector.mdl": {
+     "bytes": 300016,
+     "sha256": "c8aebb5bd5e32466be0ece534d4621d9f8865bf3ad746137c517234cdb664c79"
+    },
+    "progs/mon_demon.mdl": {
+     "bytes": 352720,
+     "sha256": "174ddb92eb8234cc1cb68e4648e00f987a69e6ed5048ccc8317a60c36735d9f3"
+    },
+    "progs/mon_demon1.mdl": {
+     "bytes": 156640,
+     "sha256": "9f1714fe997a78c9d3948e593a73fa3fe5704e11809ba095b8f564fca36b36c0"
+    },
+    "progs/mon_dfury.mdl": {
+     "bytes": 1751600,
+     "sha256": "b68c9177e75ba73deb9a59830c045f937aa1bcce3b63b2e59203eabeee703e79"
+    },
+    "progs/mon_dfury_glow.mdl": {
+     "bytes": 155140,
+     "sha256": "f743168f636c9e56475d73b3f8e139e5391e2abf0da4a6657174a7adc0f74238"
+    },
+    "progs/mon_dguard.mdl": {
+     "bytes": 980764,
+     "sha256": "0827e7275205edbbe535d4593b9b6ad8773d9a8f68e4b459f13fa4bc44b7ef85"
+    },
+    "progs/mon_dguardq.mdl": {
+     "bytes": 224084,
+     "sha256": "9f993da6d65345b72cd2ab52d8c658ab2b0da000ac90150e40123374a5103798"
+    },
+    "progs/mon_dknight.mdl": {
+     "bytes": 1329448,
+     "sha256": "f40e3acc90dcdc080ac1e93c7464f61676d9c53d03f0d6b701a72c488bedd4b0"
+    },
+    "progs/mon_dlord.mdl": {
+     "bytes": 1142583,
+     "sha256": "5065e945c8197264df1e3ea094d4e16eae166bbfc2fed814f5e852248a54e7b7"
+    },
+    "progs/mon_dog.mdl": {
+     "bytes": 526192,
+     "sha256": "424169e3311d209d7f3a2fb520dcac329f4bd98d9a28d2992f78f6b3ad87d077"
+    },
+    "progs/mon_dprince.mdl": {
+     "bytes": 1073428,
+     "sha256": "00f610abe52540e73dabf3e682eb0616cd095f76fbae1652aff2ee0e6d8e08f0"
+    },
+    "progs/mon_drole.mdl": {
+     "bytes": 241648,
+     "sha256": "2d5524d75cd52f12b42a5dfdd37bb33af27233394ec60bc234f79545d1cf13b4"
+    },
+    "progs/mon_dsergeant.mdl": {
+     "bytes": 1482988,
+     "sha256": "c551e74ae04355f0114d6d78a451f170ac83764c8d937b1c0a7644d52d118c7e"
+    },
+    "progs/mon_eel.mdl": {
+     "bytes": 177368,
+     "sha256": "6acb4804e51e7de33404a4519d7f12b2413c921f61e33107345cb111ff156f96"
+    },
+    "progs/mon_enforcer.mdl": {
+     "bytes": 680204,
+     "sha256": "b41a3c2e556e99142a96aa67408972374b21d970c52d07f91adb3b55af3db681"
+    },
+    "progs/mon_fish.mdl": {
+     "bytes": 311132,
+     "sha256": "f8f79c73f0aed0e4691fdd0577c4254a0165eee061f425f52c2f7edb3cd55761"
+    },
+    "progs/mon_floyd.mdl": {
+     "bytes": 524388,
+     "sha256": "a2a7ce21e66e72f92caadfb31257f90a97190ef8bdfceb11db5d3af9b611065b"
+    },
+    "progs/mon_freddie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/mon_fumigator.mdl": {
+     "bytes": 415072,
+     "sha256": "31bb90976e7489693c68fd6713ed5f1baf9645e3d7871922901dd093e8243da3"
+    },
+    "progs/mon_gargoyle.mdl": {
+     "bytes": 388132,
+     "sha256": "fe8134f2305858519445eb513b22f1f3382a1a6f334cf9549ddf1efe0b88435c"
+    },
+    "progs/mon_gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/mon_gaunt_elec.mdl": {
+     "bytes": 7164,
+     "sha256": "05129692bea7b62f2f5b7285cf133590e9356bfa0f6162ef6e3fc44508b29d8b"
+    },
+    "progs/mon_golem.mdl": {
+     "bytes": 725492,
+     "sha256": "0ac41742aaa188cd6c33b15885eeb1dc0105823affe745a2bab3400cebf3a734"
+    },
+    "progs/mon_hknight.mdl": {
+     "bytes": 275836,
+     "sha256": "e32a90ca707224a389b7b0d3ecde76220e23f7746c2bc4e6397fe0d3a601844a"
+    },
+    "progs/mon_hknight_glow.mdl": {
+     "bytes": 212112,
+     "sha256": "60c24cb1dceeda2c64efb66e03cb8337717402c8070c0a19e1d9a6b5e0363d89"
+    },
+    "progs/mon_hogre.mdl": {
+     "bytes": 897896,
+     "sha256": "f8e0d054c44cf83bde03ee51ca8eb558dad7da336be8caf1383cf51d5b813da9"
+    },
+    "progs/mon_hogreham.mdl": {
+     "bytes": 979960,
+     "sha256": "d4ffb64b6112d48696002baf1bf8df0c686f404d1523ae409a9d01d237573e90"
+    },
+    "progs/mon_hogremac.mdl": {
+     "bytes": 901388,
+     "sha256": "daeed66878bbe85c45d2415de4270a8526be175ac74734ff55cf9750bf7c4875"
+    },
+    "progs/mon_jim.mdl": {
+     "bytes": 331872,
+     "sha256": "a49a51562fc5875509e39b62de550c4cebba65569708e1f63d0a54a6b8497448"
+    },
+    "progs/mon_jimrock.mdl": {
+     "bytes": 357748,
+     "sha256": "6c7e4a4f9b1b4392cf6e465be50e0a637a2a9b9b44b41e97a62acfc7b889f662"
+    },
+    "progs/mon_judge.mdl": {
+     "bytes": 1184920,
+     "sha256": "4e281291b8b6728bc6801c775defa987698a0f402a3a5553a32cf61865857040"
+    },
+    "progs/mon_justice.mdl": {
+     "bytes": 1287408,
+     "sha256": "bdd6b6ad28da26701dcef14503d148e96251575e04f583bef1f362455ab12497"
+    },
+    "progs/mon_knight.mdl": {
+     "bytes": 596656,
+     "sha256": "e919a5cf9a35f7d3c28b1957030dadeae4aabfb86b9a28e467c6ef8899aa479f"
+    },
+    "progs/mon_lostsoul.mdl": {
+     "bytes": 172216,
+     "sha256": "51c6d042ac9c670926d11743a09b294cbc992204077eae28b7b440570a7b0b4c"
+    },
+    "progs/mon_minotaur.mdl": {
+     "bytes": 669648,
+     "sha256": "3016ee951f60eb90a659c641546bc6aee80b1e2e9500b125c9c1343d625deb54"
+    },
+    "progs/mon_ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "ca0b6aee92201fa3ebeb226e7767c7a0f29495496d86bd384c327ff897b3557b"
+    },
+    "progs/mon_ogrefish.mdl": {
+     "bytes": 560428,
+     "sha256": "25edf562fbf71533ae0102832d92b7e138d056e1f90c9c681e5387659cd3160e"
+    },
+    "progs/mon_pyro.mdl": {
+     "bytes": 415072,
+     "sha256": "11a7efe7358b1477867a1263fd6e13a8531f557d1a8d0e0bfc5a1e9e6eab273a"
+    },
+    "progs/mon_scorpion.mdl": {
+     "bytes": 338288,
+     "sha256": "5d8a1b194cfc741b8dd194694dce305c35b0dca0bdf1c8d96897a085ad0eaf85"
+    },
+    "progs/mon_seeker.mdl": {
+     "bytes": 594628,
+     "sha256": "ab23bfb0c8b22c67b8d4b7b1658b445fb546fcc4f1ddb1f5c4990eb860434f3a"
+    },
+    "progs/mon_seeker_glow.mdl": {
+     "bytes": 594628,
+     "sha256": "122441a3be654d0198ba368ff9fd24d7f3fecb71fbafad6edfe80e3f57103ca8"
+    },
+    "progs/mon_sentinel.mdl": {
+     "bytes": 290664,
+     "sha256": "573efd78767922b2bbb3e5dab2b16cd8f90c2cb1709ecf4a315a141f4df77d09"
+    },
+    "progs/mon_shalrath.mdl": {
+     "bytes": 163336,
+     "sha256": "50b11e859246abf75af63b858d00b436690c9ed02562c0a7a3f434ed350c3a79"
+    },
+    "progs/mon_shambler.mdl": {
+     "bytes": 532172,
+     "sha256": "89f2db0cb18dac42f35659cfba211012e1e41267cdf84a00648d50534cd98569"
+    },
+    "progs/mon_skullwiz.mdl": {
+     "bytes": 980064,
+     "sha256": "c7637f2310ae9f173de872ea4aaf4380332f3d8d32782a8523f1d5d0a5ee3e45"
+    },
+    "progs/mon_soldier.mdl": {
+     "bytes": 931376,
+     "sha256": "8a67babdf47ecc69739e067d18b2629814469aec923851bd6c1133feae6ac56b"
+    },
+    "progs/mon_spiderb.mdl": {
+     "bytes": 228508,
+     "sha256": "209ee4dabf0f9b5619408cedcd8eaec7f8d4e48a8e1b51ca667bf5f8fea02dd6"
+    },
+    "progs/mon_spiderg.mdl": {
+     "bytes": 228508,
+     "sha256": "ffac4cf5b2d42df5b8a9674dc87c30ec925d6013d9ff0d29cb109c30047bcbd6"
+    },
+    "progs/mon_steelclaw.mdl": {
+     "bytes": 228508,
+     "sha256": "06fae126b984b1ed7b0ffa029b64e9b3df3a6269f01e8aba4b953bbafaa2c536"
+    },
+    "progs/mon_stinger.mdl": {
+     "bytes": 203428,
+     "sha256": "9d867b8a3d69a94d9a049c6cfcf0fa808b200ea3befe3b2518f1165881b9ad23"
+    },
+    "progs/mon_swampling.mdl": {
+     "bytes": 45332,
+     "sha256": "c7b379fcc17af3fbfaff1976ea8c14e9562093495dac01cd647c50863c4dec50"
+    },
+    "progs/mon_swamplingp.mdl": {
+     "bytes": 45332,
+     "sha256": "f1bd1496b4b9c90493f469bf81c6da0a1697290cd6374db15fd459ebab649cea"
+    },
+    "progs/mon_sword.mdl": {
+     "bytes": 87960,
+     "sha256": "ccfa9b8c3282150fc97fa9a4106176036f6cd89abb4a4f0ee0d707c922708c4f"
+    },
+    "progs/mon_tarbaby.mdl": {
+     "bytes": 511008,
+     "sha256": "a9b9b6a49090bbf7d7d3a23618c3c21b2123e007488702d96b80531c563cdd4c"
+    },
+    "progs/mon_voreling.mdl": {
+     "bytes": 45332,
+     "sha256": "af233d21d6f0ea66267ba1c562ba223e1077bd07894333327ce12a6202938411"
+    },
+    "progs/mon_vorelingp.mdl": {
+     "bytes": 45332,
+     "sha256": "dadf32a61ef1ec6361606fc7173bab53f6c42e62dea9a3100a2073ffc5afaa58"
+    },
+    "progs/mon_wizard.mdl": {
+     "bytes": 106596,
+     "sha256": "aa93bbe4e7fd1686fcea4d6c49a982bb8b3defea2ca85c3177b86000ba8ba8e4"
+    },
+    "progs/mon_wraith.mdl": {
+     "bytes": 374256,
+     "sha256": "f2ec454f0e2896252204a99b18c16a5e61ae783220503a6b0ec75e149d1b25f7"
+    },
+    "progs/mon_wraith_glow.mdl": {
+     "bytes": 133676,
+     "sha256": "bc630a16b46ae0ef1fba35acaf4e41bc46dee4070305d32e9215692a18ae5705"
+    },
+    "progs/mon_youngone.mdl": {
+     "bytes": 103208,
+     "sha256": "de6f7f98d021ae2839cc81490886e6f29dfa31b5b45216d15ffb7f74edf1eb36"
+    },
+    "progs/mon_zombie.mdl": {
+     "bytes": 381660,
+     "sha256": "470a96617166e3deaed25785d85c8a9b1e4984535f76b48302d05bf37b164349"
+    },
+    "progs/mon_zombiek.mdl": {
+     "bytes": 228232,
+     "sha256": "431f57d3241b1253a1346ff1aa2bd7135f67c3e6fd5031140e07a7b4a0e861a2"
+    },
+    "progs/mushroom.mdl": {
+     "bytes": 10804,
+     "sha256": "5570faa6e7828e4e12f568656226b0756a87d633cbdc461af472e0982a88a549"
+    },
+    "progs/plans.mdl": {
+     "bytes": 26324,
+     "sha256": "6b669da5bacdfc41296f12925457efb6e499381f4c3365743dc8027e17b8059a"
+    },
+    "progs/plant.mdl": {
+     "bytes": 58832,
+     "sha256": "254a3a005a348683ce8c231eb9c2c87376e760ee745b567a666b781284816294"
+    },
+    "progs/player.mdl": {
+     "bytes": 923742,
+     "sha256": "977a85892889cc76c4147e1789717eb75e81c542fe30bed1c52c9c15bf0a492a"
+    },
+    "progs/proj_balllava.mdl": {
+     "bytes": 18356,
+     "sha256": "f2a1de49bd215b4c7a1f424f1c644fe5cdb52df3c2d664c24b75cd2f389ae559"
+    },
+    "progs/proj_ballslime.mdl": {
+     "bytes": 18356,
+     "sha256": "d17f20cd8db385b724d58beaac1c3ed6b2597d51d00f1996b8b02bdb8a5e3ba1"
+    },
+    "progs/proj_blord1b.mdl": {
+     "bytes": 11472,
+     "sha256": "6c05b0f8790b77d3362166b2b304379942f56d498ae8fc365dbee6fcd6031f67"
+    },
+    "progs/proj_blord1s.mdl": {
+     "bytes": 8284,
+     "sha256": "5527dd12f00911fb333c2424994c0a95881caa72612d5e8236c8ce75530f6ae0"
+    },
+    "progs/proj_blord2b.mdl": {
+     "bytes": 11472,
+     "sha256": "fce6943e84bac672bf110d986ce2ed1ccb511128cb28508fb6aca53c7655806b"
+    },
+    "progs/proj_blord2s.mdl": {
+     "bytes": 8284,
+     "sha256": "a0d0ac315e46f784c35a0eac902f625e0337e79275b9f02ecb56002848202734"
+    },
+    "progs/proj_blordbeam1.mdl": {
+     "bytes": 12244,
+     "sha256": "e01c569bf66e75acdcbbfdbb50062eb24dd09f0415e6cb79148eab960f6a6f0f"
+    },
+    "progs/proj_blordbeam2.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/proj_blordbolt1.mdl": {
+     "bytes": 7868,
+     "sha256": "2ea0a49a8a75d1174151c36851ae21212b4df2df3473be5e73cc4cf293332d0f"
+    },
+    "progs/proj_blordbolt2.mdl": {
+     "bytes": 7868,
+     "sha256": "919dda70fe618cd37f57ef1e0dbc00b339ed082e2661ca024febee3ed49576f2"
+    },
+    "progs/proj_bolt1.mdl": {
+     "bytes": 1556,
+     "sha256": "890f6cd6faf7c36954185c4566a2cca619e627d5b365f05e1bffc7e12ac00ace"
+    },
+    "progs/proj_bolt2.mdl": {
+     "bytes": 1748,
+     "sha256": "ba4a6ffa3785b0e41c15045df9621a5a33f094eae2161064d472ea939654e229"
+    },
+    "progs/proj_bolt3.mdl": {
+     "bytes": 1748,
+     "sha256": "cf255497525c53162b019fe3df536314c4661a2d270f6bb847fe39a158b7f4e8"
+    },
+    "progs/proj_chthon1.mdl": {
+     "bytes": 65636,
+     "sha256": "92a964527d72ef1c40bbcfe0e915b56df81a0dcc2165ca4be47db44a8d644eb1"
+    },
+    "progs/proj_dguardq.mdl": {
+     "bytes": 12660,
+     "sha256": "ba5cba46edc108572d78e66166f5ed0405a48dcf672e7a569d14a4397f85f285"
+    },
+    "progs/proj_diam1.mdl": {
+     "bytes": 3292,
+     "sha256": "e7cbd736a84791c5234caa14713b3e0f6077409509845ae0b1993f38c2f1e1b9"
+    },
+    "progs/proj_diam2.mdl": {
+     "bytes": 2748,
+     "sha256": "b23586b1d570a9f516f6b83ea0af6ec1d8fe5693f8cd1279b251b031ba142d8c"
+    },
+    "progs/proj_dk.mdl": {
+     "bytes": 5172,
+     "sha256": "e861a125a60c82b88c7b3c23184a1485c967d0e127b4536213b7f46a97a6430e"
+    },
+    "progs/proj_dkgrn.mdl": {
+     "bytes": 5172,
+     "sha256": "820d2dac7255db7220889f6d8c3a2c97a7f77f75cd9ffbec6319b0ee257b3984"
+    },
+    "progs/proj_dlord1.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_dprince1b.mdl": {
+     "bytes": 6644,
+     "sha256": "7bcea6065d9f6c4e8a3a7c8a1dcd61252ff8baee01b7c04ecce0a7cfbc6d690d"
+    },
+    "progs/proj_dprince1r.mdl": {
+     "bytes": 6644,
+     "sha256": "5e3cc794f6b980e5e22adf011eead8768c88dcd84d74be9a8d34caebf33bf2ba"
+    },
+    "progs/proj_dprince2b.mdl": {
+     "bytes": 7468,
+     "sha256": "e81b4f767d1bba042464f1d35314ef4f2d30f7c552aaada2f772aba61fc5d62a"
+    },
+    "progs/proj_dprince2r.mdl": {
+     "bytes": 7468,
+     "sha256": "b967299e12983dacd0fcca1672818281483e6f89746422de285002cb043e1e24"
+    },
+    "progs/proj_drole.mdl": {
+     "bytes": 20796,
+     "sha256": "fbe9acdd31f7be2321df29b6add3d287d4e86ea2581e56ace5d7e9d185e28127"
+    },
+    "progs/proj_drolegrn.mdl": {
+     "bytes": 20796,
+     "sha256": "efbede1f5d565c56a535bb6392b5e638133c99b1df8bf93b1a1918d01c790123"
+    },
+    "progs/proj_eidolonrock1.mdl": {
+     "bytes": 14084,
+     "sha256": "e085fa791a83489e41c19c623ae84f80c7bc5f767cbbf691baa4665d3f85b273"
+    },
+    "progs/proj_flesh.mdl": {
+     "bytes": 19768,
+     "sha256": "8ff3f0f61001ac8e67317e4e01d03d905f15ef4104c141ba07b5ddb0c972390e"
+    },
+    "progs/proj_fleshp.mdl": {
+     "bytes": 10196,
+     "sha256": "3def912801c4b1b9b4c0f8ceea0690241493a5dd5f17e098cd6c37cefd927893"
+    },
+    "progs/proj_fury1.mdl": {
+     "bytes": 6644,
+     "sha256": "ce55af61fbd87b8daeb14151b3f77ac64713c4b53fcca89b2150d7f5cdfe886d"
+    },
+    "progs/proj_fury2.mdl": {
+     "bytes": 5748,
+     "sha256": "deb557248017e92f5501698355577cebb91c0d825b77a79f828589769a41ece7"
+    },
+    "progs/proj_gaplasma.mdl": {
+     "bytes": 2328,
+     "sha256": "dd3b4559cb4e4439ae87255ab2958c6c2cd3796ebbd27aaf1c6abc768ad4f8ad"
+    },
+    "progs/proj_gaplasmagrn.mdl": {
+     "bytes": 2328,
+     "sha256": "ecd2fdf0eb904f8be43c41821b06443d32a581b768ce8f776b07670b49cdd9af"
+    },
+    "progs/proj_gargball.mdl": {
+     "bytes": 18184,
+     "sha256": "b4b6bd7646bf80aa6f481616ba2b531dbccd3568cacc54885ebf020a166dbadd"
+    },
+    "progs/proj_gargballgrn.mdl": {
+     "bytes": 18184,
+     "sha256": "467a44838d83a94d5716c9af6f8c860cd8ec583ddb5f260cb0dd16e9bd04b957"
+    },
+    "progs/proj_gargoyle.mdl": {
+     "bytes": 5748,
+     "sha256": "774f52126fe6598f6a01a032691a36de26a0669e93d47508689d08fe85f46c21"
+    },
+    "progs/proj_gargoylegrn.mdl": {
+     "bytes": 5748,
+     "sha256": "b293b5e8696098e77602eb065f68f8a8e15c82af1c9890d36de48f29afbf43fe"
+    },
+    "progs/proj_ghook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/proj_golemrock1.mdl": {
+     "bytes": 7468,
+     "sha256": "5a2f0435dbcbfea724fe6bd8f6a76296359dbf4d874d15feec82b50a9275da74"
+    },
+    "progs/proj_golemrock2.mdl": {
+     "bytes": 19756,
+     "sha256": "41cc9bc49d6ae2018b7cf5345bbfe52517db2da060fce23fe57300ebcf643f98"
+    },
+    "progs/proj_golemshard.mdl": {
+     "bytes": 8596,
+     "sha256": "4a4a59362f5c5ecc2c4ce56419088982d5ed79a02d3c5b5a49bafd4c21c85e42"
+    },
+    "progs/proj_grenade.mdl": {
+     "bytes": 3508,
+     "sha256": "a7916ab1f9872689a0cfbea62543974b37dae5b3ec7ae3165eecd81c2c0d6617"
+    },
+    "progs/proj_grenadegrn.mdl": {
+     "bytes": 3508,
+     "sha256": "896f7a740acb59351891e752e6cc92725fcc6e26ea4bd5d1eb3219c8443db743"
+    },
+    "progs/proj_judger.mdl": {
+     "bytes": 7868,
+     "sha256": "a12f1f0bf494bc027c43e5aa89e54e055a571226499fbddce0f6b9e2bdb63766"
+    },
+    "progs/proj_laz.mdl": {
+     "bytes": 4724,
+     "sha256": "94e8c7d09857559ad9e5aaf6361b596afbcf100cf0ce8abf0107318af28c7943"
+    },
+    "progs/proj_lazblue.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/proj_lazgrn.mdl": {
+     "bytes": 4724,
+     "sha256": "d07d736b788aa512a5e57f39596c187644e69491026382800994378d3e849a6f"
+    },
+    "progs/proj_lightning2.mdl": {
+     "bytes": 11860,
+     "sha256": "c9cebc8d6f4836e7c302d51d0f942fde3da0960dae38733ccc3a851776e71520"
+    },
+    "progs/proj_minoball.mdl": {
+     "bytes": 18184,
+     "sha256": "756d8e9ecd60abc23954a792833c565ee1b5c905106ad2bd98143f56b0410391"
+    },
+    "progs/proj_minoblood.mdl": {
+     "bytes": 8284,
+     "sha256": "badd72734b86dd9bc11c5469bef944b6aea6b84071b07b44703c1ca62dd4dee2"
+    },
+    "progs/proj_minoplasma.mdl": {
+     "bytes": 8284,
+     "sha256": "cd79d0dce08293ded22b08b3a7134d8e52fc4cff10e07ee691e6ab53011a9ea9"
+    },
+    "progs/proj_minopoison.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_ng.mdl": {
+     "bytes": 1364,
+     "sha256": "cff312dd07f629847dd5e37b6ab00243d51ff7e40fc795f3612e68614cfbbe24"
+    },
+    "progs/proj_ngred.mdl": {
+     "bytes": 1364,
+     "sha256": "a1ec22733cc292a470c23990b8d0929bf5ee88844190d7174d9053109443d0dd"
+    },
+    "progs/proj_nour1.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_nour2b.mdl": {
+     "bytes": 14084,
+     "sha256": "9c7650dba595e8f8b2bacf3141252a5a2917e0204d3326661d6b9608fc8df2b3"
+    },
+    "progs/proj_nour2p.mdl": {
+     "bytes": 13152,
+     "sha256": "4051fc3dec1155a9efbc6bc5aab947447cebff83bec38d8c1e43dd1bd51f4611"
+    },
+    "progs/proj_nour2s.mdl": {
+     "bytes": 7468,
+     "sha256": "285570bdd658dfed133399c16f1586e2b2389f537a9d4b54d2dd5c1f8f6f1aa9"
+    },
+    "progs/proj_pgplasma.mdl": {
+     "bytes": 13152,
+     "sha256": "3c04f32bbf6f0623fc4101a31a0ce2d40c93354430433d91c2caed263284531e"
+    },
+    "progs/proj_plasma.mdl": {
+     "bytes": 4724,
+     "sha256": "6c4399ddc7653a9aa7834162d38dce6368dc271fec46a7830b73939351d7142a"
+    },
+    "progs/proj_plasmagrn.mdl": {
+     "bytes": 4724,
+     "sha256": "b2941e69d90a5e97c98a03a98bd52c4e047aa23dd2a1abd9ab6d3938f595732f"
+    },
+    "progs/proj_ringblast.mdl": {
+     "bytes": 135704,
+     "sha256": "e6de9bfd15db4bbf16fdd41b50204c5090ce09adbe132b1453435d3c8646cb4d"
+    },
+    "progs/proj_ringshock.mdl": {
+     "bytes": 18928,
+     "sha256": "f1a0a77edc79f2466b866a5486b29f92b696368137eb7eff9b137b6b66d65952"
+    },
+    "progs/proj_rocket.mdl": {
+     "bytes": 7812,
+     "sha256": "52d549b217c6f34e1d68248899ec5f5f550ef729929910e5953e114a53b3c251"
+    },
+    "progs/proj_rocketgrn.mdl": {
+     "bytes": 7812,
+     "sha256": "313f381553df0d8468ccb981441bf415130c9c730377d877e397511b8cc864f7"
+    },
+    "progs/proj_scorpion.mdl": {
+     "bytes": 6612,
+     "sha256": "1a2fa47a30a7e8026bacefa1f52580a04e10c48571318effab3e0623ebcc919e"
+    },
+    "progs/proj_serg.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_shal.mdl": {
+     "bytes": 6644,
+     "sha256": "dc62e9641d1328b1cfd20ac4f4df7e56b2f42bd40a22eea186f2784d1f5bc4ba"
+    },
+    "progs/proj_shalball.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalegg.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalgrn.mdl": {
+     "bytes": 6644,
+     "sha256": "6dfdef0a204aded86ef24730985f13acc5076d1bbb4b9ec1140b7333a70f4d0e"
+    },
+    "progs/proj_shalhome.mdl": {
+     "bytes": 8632,
+     "sha256": "e882b1dc5d01882f429b3a88f752431d3b38dad297861209b589330e3507f37e"
+    },
+    "progs/proj_shalhomegrn.mdl": {
+     "bytes": 8632,
+     "sha256": "d84be851bd87603186bf907506eabb9ce110c5a265c1cc884d18923361fdf4d9"
+    },
+    "progs/proj_shalshell.mdl": {
+     "bytes": 7468,
+     "sha256": "8c1591cc767fadabad655bfaf3a80362b264f51e0a1be67476b9272c2401afbd"
+    },
+    "progs/proj_shamlit.mdl": {
+     "bytes": 35240,
+     "sha256": "787c23ca986d469080879953e49b193cf0b2d22dff050a1d781ba039fcc594e4"
+    },
+    "progs/proj_shellcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/proj_shub1.mdl": {
+     "bytes": 18932,
+     "sha256": "c1a04846b791a123ecb367f11b35f4c1cc1e7e62e1d0f62ff1dd75978a712495"
+    },
+    "progs/proj_shub2.mdl": {
+     "bytes": 32860,
+     "sha256": "3d22df8151caf23c1ad7f3e28f83f97ca7503164977f1994dca2cc2ee54f84b9"
+    },
+    "progs/proj_skullball.mdl": {
+     "bytes": 9984,
+     "sha256": "41b3c1225070dcfca79f1bf19a2833e3d68144945fba51c8ce44d8029379906b"
+    },
+    "progs/proj_skullwiz.mdl": {
+     "bytes": 33588,
+     "sha256": "ff00ce3fbf9d0d55f6488a3a0a6bf15d2105b6e94489eec296a5851bf9f4f890"
+    },
+    "progs/proj_skullwizp.mdl": {
+     "bytes": 33588,
+     "sha256": "45fe8396037d88852d3e6937749bade4ef7c00d3c8240eeb0ecba4b56e831df3"
+    },
+    "progs/proj_smoke.mdl": {
+     "bytes": 244,
+     "sha256": "816e888f8242af86812bd581c9e93212c28f108699b70eb10d3e025f27a2818e"
+    },
+    "progs/proj_sng.mdl": {
+     "bytes": 1396,
+     "sha256": "b2a8656aee7ff508737afe1fdbf1a93d6958b33a0c31bae247a3979c616bdfe1"
+    },
+    "progs/proj_spider.mdl": {
+     "bytes": 7468,
+     "sha256": "76be6023b50a3b57c73f08c5758a693098ce8762eb92b55540d8bff2680fde4d"
+    },
+    "progs/proj_swampling.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_voreling.mdl": {
+     "bytes": 7468,
+     "sha256": "ab16a7fc8bf36827f4944ebe6919876acb5b2eaf869ff59f89ed237565a7ca9a"
+    },
+    "progs/proj_wiz.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_wraithball.mdl": {
+     "bytes": 22284,
+     "sha256": "24d62690c6347f9ab71ef5900c70d256346c2dfdc26e5488c3b91f220224c923"
+    },
+    "progs/proj_wraithbone.mdl": {
+     "bytes": 6612,
+     "sha256": "8fa994dd2c7a5e9d7140ae394d07d368d083f4cee6808f6d9d026ec464804503"
+    },
+    "progs/proj_wraithegg.mdl": {
+     "bytes": 9984,
+     "sha256": "5b888e26f90cfe26800cd50d422b4ef75487dde61d63fd34965506591b326a8f"
+    },
+    "progs/proj_wraithpoison.mdl": {
+     "bytes": 6612,
+     "sha256": "02a06fdccb8f7ba595ea71f227e5b256995e782bcc9ce75bcb85a31ed0333256"
+    },
+    "progs/proj_wraithshell.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_wraithtrail.mdl": {
+     "bytes": 24544,
+     "sha256": "23ee065ea4a542ee7348d9bc08e052ffca4e272418b81937105d14730aab705e"
+    },
+    "progs/prybar.mdl": {
+     "bytes": 8280,
+     "sha256": "9073057322b1c817f750a1abf653c3b9cc000b67a3a36b063702b5dd5ff49ddb"
+    },
+    "progs/rakey.mdl": {
+     "bytes": 17748,
+     "sha256": "3e89068566ac0a991de99d3dfddb576ff8686aa48c3e7f19d4a149497274f5f3"
+    },
+    "progs/s_baronmagic.spr": {
+     "bytes": 12564,
+     "sha256": "6d08d5ada6bac219927edb39a93302f98b7b1a357e6648fc1abb49fd5cc3bd4c"
+    },
+    "progs/s_bookrune1.spr": {
+     "bytes": 1140,
+     "sha256": "b9fc52d2ca728fffa4c282d818b68aeec3555a0dbad3cd1507199d534db1f047"
+    },
+    "progs/s_bookrune2.spr": {
+     "bytes": 1140,
+     "sha256": "400a620928e3581891e8a71b338c8a53b6387e0acdc3fda3f10ae27596ae6bbc"
+    },
+    "progs/s_bubble_blue1.spr": {
+     "bytes": 1140,
+     "sha256": "27cb0d1f52e3ecd4b7ae0d9dc96078a7554bde09839f1a2ee2d9772ac5d67981"
+    },
+    "progs/s_bubble_blue2.spr": {
+     "bytes": 1140,
+     "sha256": "d540bb04a7835ec3bd7490904fbafde0f3aa64ba559bb6bd99ab538568ec0cae"
+    },
+    "progs/s_bubble_brnd1.spr": {
+     "bytes": 1140,
+     "sha256": "43591346d87a547454b387220b3c32693e7f1563b6ae4152ff7ee96c24936b84"
+    },
+    "progs/s_bubble_brnd2.spr": {
+     "bytes": 1140,
+     "sha256": "2f185b37bd1cd5a8d6b472885469dbdb3f1b0fdeba2a6d620de09b17646b4fc2"
+    },
+    "progs/s_bubble_brnl1.spr": {
+     "bytes": 1140,
+     "sha256": "370ed3a9f77291522c31ac1d0ce414078d9b3eb40a9157c08ad5cf87d6428897"
+    },
+    "progs/s_bubble_brnl2.spr": {
+     "bytes": 1140,
+     "sha256": "1b3d4f0ac00fa7cbce076d334f4b210b9059afbf2c4b07a0e98e88fe57356351"
+    },
+    "progs/s_bubble_grey.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_grn1.spr": {
+     "bytes": 1140,
+     "sha256": "efa8692bb74428af2753b415f8f08edbfc2b2cbe75cc59f6545985d289d6016f"
+    },
+    "progs/s_bubble_grn2.spr": {
+     "bytes": 1140,
+     "sha256": "3062ba1064da37ecf7dad074a9b0437352865fa43aecf783e4afe8a6c8c104c2"
+    },
+    "progs/s_bubble_pinkyel.spr": {
+     "bytes": 312,
+     "sha256": "5376726ffdf2132d3ab712ba23b408e8068500485f11adff85d0fd90c08248c6"
+    },
+    "progs/s_bubble_purp1.spr": {
+     "bytes": 1140,
+     "sha256": "2e4b7b23b08b6e89d2dc46f26b12b9ad1ee8f91ea868aeb9916d2adb42e00b75"
+    },
+    "progs/s_bubble_purp2.spr": {
+     "bytes": 1140,
+     "sha256": "ae21a26ad7897b9c5d201a1eb248e1358ee84eafdbfd899d679558e9aa5a1a66"
+    },
+    "progs/s_bubble_red1.spr": {
+     "bytes": 1140,
+     "sha256": "2a52f2c4dfdae381deeca608e5d007afe9dc245bbe16fea88c88f39c10ff7dc6"
+    },
+    "progs/s_bubble_red2.spr": {
+     "bytes": 1140,
+     "sha256": "fffcc0e03f9acc75e05636ab67f5f647568c81d0bcf4623e64d487c04d9cd5eb"
+    },
+    "progs/s_bubble_wht.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_yell.spr": {
+     "bytes": 1140,
+     "sha256": "9dcce864ad255b17d7d45e5c5531114f6a66c4e9cb549fc8b31aef0af5a9157f"
+    },
+    "progs/s_burst_flame.spr": {
+     "bytes": 22128,
+     "sha256": "66511ada8a299b0882e2939c09d3fb726d3ce52ecb93a884584a9ce11915a6c0"
+    },
+    "progs/s_burst_flamedp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_poison.spr": {
+     "bytes": 22128,
+     "sha256": "d8245e0460efc4e939a187912126f44422c39b1fe4b553c2c15da91833e8549d"
+    },
+    "progs/s_burst_poisondp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_burst_steam.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_dotmed_blue.spr": {
+     "bytes": 1140,
+     "sha256": "0b3160c5a4ae42216ddb7aaa7ae4726f6b2507c914328abe3c69f2d12fd921f8"
+    },
+    "progs/s_dotmed_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "6e28b69544f8aa13ccbb9a66893e4ab86b83639ee3f81dbbe1b94290ca9b03ef"
+    },
+    "progs/s_dotmed_grey.spr": {
+     "bytes": 1140,
+     "sha256": "77c226763e90a54b4d6835bd877c08c501605e516e64177c915c422e7b36c207"
+    },
+    "progs/s_dotmed_grn.spr": {
+     "bytes": 1140,
+     "sha256": "d1a9800a8b5cad01fa1dc93e57162e9960c4a8478e7e427d66cdbfe6a6797266"
+    },
+    "progs/s_dotmed_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "6113140f371b08cda9addcf68282c1fc16692da7498fa2fdfe2b99662e345d67"
+    },
+    "progs/s_dotmed_purp.spr": {
+     "bytes": 1140,
+     "sha256": "8b2cfa67ac86841f59409e184b4f3a253218e5930a5e3f241caef39dc1baa8de"
+    },
+    "progs/s_dotmed_red.spr": {
+     "bytes": 1140,
+     "sha256": "4ae92a280e0df01c0acd0a904214af485bb60919e5ded4573aa12f86875182d4"
+    },
+    "progs/s_dotmed_tor1.spr": {
+     "bytes": 1140,
+     "sha256": "eddd46a4818dfa92a9817df82e893d6bf6513160164a74b95bdd42fb7cac2f75"
+    },
+    "progs/s_dotmed_tor2.spr": {
+     "bytes": 1140,
+     "sha256": "dcb87897de0f54a6d8f78e9194a15c11261eb88455f058b334f8648a363159a9"
+    },
+    "progs/s_dotmed_yell.spr": {
+     "bytes": 1140,
+     "sha256": "e6b72aac439291d7719ee78d9520c1a1def36212ac7f61ba333fa87d5265c63f"
+    },
+    "progs/s_dotsml_black.spr": {
+     "bytes": 632,
+     "sha256": "2ae7fa13584d12f04b337fbbd774e74fbe54a6fcbd354239e97fecce931bd377"
+    },
+    "progs/s_dotsml_blue.spr": {
+     "bytes": 1140,
+     "sha256": "c0149109ae73a72da49bfaf9ba00cf2edadbe0f053928d09319083e6247883ad"
+    },
+    "progs/s_dotsml_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "f95fe813ecce2c69d2b72e5bf870d045037519c89f3da9a300e7453754cd1503"
+    },
+    "progs/s_dotsml_gold.spr": {
+     "bytes": 1140,
+     "sha256": "3833e80c32da39063b5069638ade52c4aee51b7db7206b4911cb48f321e25bdc"
+    },
+    "progs/s_dotsml_grey.spr": {
+     "bytes": 1140,
+     "sha256": "2e16d9ff8ceca2994a609703f405b1efbb7b49e02c8dbb9e77d0cdcaf3318b98"
+    },
+    "progs/s_dotsml_grn.spr": {
+     "bytes": 1140,
+     "sha256": "a2735123addacfa03f2666969e476af0d9f1cfefbef75a7ac9599d48f86226b1"
+    },
+    "progs/s_dotsml_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "ebf62caae17163587aaa3652300f1003c008ed21041b838a14cfff7672f87d90"
+    },
+    "progs/s_dotsml_purp.spr": {
+     "bytes": 1140,
+     "sha256": "476042db782f7f81cb53d91e9518881f28eb34d3a2a535c11d9c22f65518bce4"
+    },
+    "progs/s_dotsml_red.spr": {
+     "bytes": 1140,
+     "sha256": "94c0403ee7f1e6f6c4d6bc9b99e73e48143845fe35d0d6b3de246842241b12cb"
+    },
+    "progs/s_dotsml_wht.spr": {
+     "bytes": 1140,
+     "sha256": "7ac2d5b9b1e14a1799b951ace16bcc1addb7fefc2470dec23ef2ca110a934bf5"
+    },
+    "progs/s_dotsml_yell.spr": {
+     "bytes": 1140,
+     "sha256": "686f220b937040b91b6ff4f05efd41525d40eb80a61ff8138809d550bfa99959"
+    },
+    "progs/s_dripblue.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/s_dripgreen.spr": {
+     "bytes": 60,
+     "sha256": "805935ef90e14eda0f0ec89cc7e03acf52df768eb9e09140629bc1067a658774"
+    },
+    "progs/s_dripred.spr": {
+     "bytes": 60,
+     "sha256": "2dc81cd44438e124dedef0b656c31a066b7879940fcdbc39a0cfd57a6d2985e5"
+    },
+    "progs/s_dripsplblue.spr": {
+     "bytes": 828,
+     "sha256": "6b960ccc7a877bf2b4b67467400c0eaa1bb88d8c8a524458b9bf8d1aa1a6e29f"
+    },
+    "progs/s_dripsplgreen.spr": {
+     "bytes": 828,
+     "sha256": "397ac392598027c27240d71079f79eb9c90306724bc54c5d9854e14939059b6c"
+    },
+    "progs/s_dripsplred.spr": {
+     "bytes": 828,
+     "sha256": "268b48b87a0f352b671c04a1f7325af43372578a6d73269356389280eb7ef232"
+    },
+    "progs/s_exp_big.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_exp_electric.spr": {
+     "bytes": 5256,
+     "sha256": "ed01b728b6656a68acffe258d644712eba3b786434ab6b3e6d90434031e90d96"
+    },
+    "progs/s_exp_ice_big.spr": {
+     "bytes": 164076,
+     "sha256": "bf7317d811349602db7a020da3e77065ffd8158a3104e83ddca3b166566df18c"
+    },
+    "progs/s_exp_med.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_exp_plasma_big.spr": {
+     "bytes": 213288,
+     "sha256": "fe99a489e169ccf56f0412c2e83a7c5aea7b75b7cee0501402c62fcbd7ca969c"
+    },
+    "progs/s_exp_plasma_small.spr": {
+     "bytes": 53544,
+     "sha256": "555e39e88cedaf9e9dd1215ad1325b32019a6bf2654d53736b1f362506548150"
+    },
+    "progs/s_exp_poison_med.spr": {
+     "bytes": 72892,
+     "sha256": "60b7a8c194f3a6cd2241edd6223ac1da1f57811d7f5416216c70a2797d1baf20"
+    },
+    "progs/s_exp_poison_small.spr": {
+     "bytes": 53544,
+     "sha256": "2a54104dec9381afe338574d66bcc19bd2776caa0d46031c743cd24782098d3f"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "a9476d95ea10fbd2317c174272864efa4bb6e939893f3a3de520aeea3e3522d9"
+    },
+    "progs/s_flamemed.spr": {
+     "bytes": 43324,
+     "sha256": "3c645e305673693089fe48cc7a22f694eeaf7881cfc94ff7b1c4b05b718342cc"
+    },
+    "progs/s_flamesml.spr": {
+     "bytes": 21820,
+     "sha256": "5e60165461c34a3a25cbe6b0bb5e36131bb4a81fef384f1db4a7236f30e7ba95"
+    },
+    "progs/s_flametiny.spr": {
+     "bytes": 11068,
+     "sha256": "9d2c0af6139f3d194e73dbcb7880aa0a6f2a04019f94818ce9844691399b551b"
+    },
+    "progs/s_judgemagic.spr": {
+     "bytes": 12564,
+     "sha256": "6d08d5ada6bac219927edb39a93302f98b7b1a357e6648fc1abb49fd5cc3bd4c"
+    },
+    "progs/s_marsh_med.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/s_marsh_small.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/scope.mdl": {
+     "bytes": 93892,
+     "sha256": "631fb2d8720a4a80927a9697c3dbdb17ceb3c9a1a1e2e70dd43122bb303dfc05"
+    },
+    "progs/soul.mdl": {
+     "bytes": 36820,
+     "sha256": "41778d04ad62d3dda117ba6d356835545015096f1fdc020572946034026b11a1"
+    },
+    "progs/st.mdl": {
+     "bytes": 269016,
+     "sha256": "fdf874c04cecb40d3667ddbe1b3d03b8bedfda76d3c266c70413a05a10e20c9c"
+    },
+    "progs/statkng.mdl": {
+     "bytes": 117444,
+     "sha256": "4f0dc950ebfdb2cd9c3c4756f577c704b9aa5aff3b1d0ef2bf31b0db4319a362"
+    },
+    "progs/statweep.mdl": {
+     "bytes": 269016,
+     "sha256": "fdf874c04cecb40d3667ddbe1b3d03b8bedfda76d3c266c70413a05a10e20c9c"
+    },
+    "progs/stkey.mdl": {
+     "bytes": 18412,
+     "sha256": "5970c46e287a7ad6b1c821111b59ca87ac05987528ba82de5aaf934d6005fb7e"
+    },
+    "progs/takey.mdl": {
+     "bytes": 14820,
+     "sha256": "7398202dcf2d1f1b50618f85d97770e58e09a40d89d552e916a42ececd377b78"
+    },
+    "progs/targd_hull2.mdl": {
+     "bytes": 3380,
+     "sha256": "520c82906942d582c6b64da4dca32ca8ed236694607c3a19ec71b89136e0c757"
+    },
+    "progs/targd_massive.mdl": {
+     "bytes": 17076,
+     "sha256": "099ed67733ea3a461c2247d6f07d3dadcc5a6968bcd6a03398507c653d174395"
+    },
+    "progs/targd_short.mdl": {
+     "bytes": 4788,
+     "sha256": "c883300477d3978469aabc35ef3969c14645c1111997c64452634fc8b4a978e1"
+    },
+    "progs/targd_tall.mdl": {
+     "bytes": 4788,
+     "sha256": "bab77599f9cbbe1cf0856a642612ae30b08fed9ae27a209abda30f6dc8c07129"
+    },
+    "progs/targd_wide.mdl": {
+     "bytes": 17076,
+     "sha256": "d40a00625196f67fe26f3611cd91dd33484ddbf3db273766f8a5fac38db07b07"
+    },
+    "progs/trap_pendlong.mdl": {
+     "bytes": 44900,
+     "sha256": "62d3b86fea6e2336dfc5c7b93514e096eba05992a3bd3e0c6571e4c4a27be684"
+    },
+    "progs/trap_pendshort.mdl": {
+     "bytes": 44900,
+     "sha256": "efb3e395093e34d7b16c92ed73abb199a28d0bc653522c13d4e720030f547713"
+    },
+    "progs/trap_sawblade.mdl": {
+     "bytes": 28716,
+     "sha256": "759bd7e1f7629b4d87ecb9e53a9f2d66e3e81b9103bc4eab3f85bd598eba36f6"
+    },
+    "progs/tree1.mdl": {
+     "bytes": 57621,
+     "sha256": "8e450cd50b8dac1912e96ec78ff4a16e0b9065138d181fa58257973c2ee96578"
+    },
+    "progs/trkey.mdl": {
+     "bytes": 17012,
+     "sha256": "914773c1a2d6d0c09611b0427da9178eed2bf4d5b46852edbd0a734f3bd24193"
+    },
+    "progs/turret.mdl": {
+     "bytes": 120168,
+     "sha256": "56cfa9bf6c90f5b2daf99512bbe24bed3ab3ba5d0ba9698f59267dacfcad18ff"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 55820,
+     "sha256": "4445f1458e8d7a720dae73a8acb43029aa7853090d6db1395480ae25ce9c4748"
+    },
+    "progs/v_ghook.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 80004,
+     "sha256": "f5d9839dd5661fe653bdf9f236d33263692f1d1d23007967759bdb45d95d0ee6"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 84020,
+     "sha256": "5cc3df61d5c392e86b43770a4e89728ead68a3d13cc59c0a38ba8b55b31dc190"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 83476,
+     "sha256": "cd149dd7585c00d2c86121f7e63102b775cc182d28730e11a197ce12576f9d32"
+    },
+    "progs/v_nail3.mdl": {
+     "bytes": 97300,
+     "sha256": "2a87b7ae54e2bf310f8521e8edd2ee92bb0b9c33ab232742f1eee047c4d14344"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 87604,
+     "sha256": "a7759fa4b4278690be2d17d96b62642a5df13b39d41c5ac650528b40961d5dff"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 58548,
+     "sha256": "329c7dba1195bd05c188cdc64be92f345e9f3aa237b1388ac9a7ea4605e8680f"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 123396,
+     "sha256": "c55e900754a0007222cf6a83051f825ee407e8e94c30641ce5599450bb2cd9f2"
+    },
+    "progs/v_rock3.mdl": {
+     "bytes": 213467,
+     "sha256": "30048fc30f728fd9a9eafb6acc95fe5756e50fe266ac47470eaa506882345917"
+    },
+    "progs/v_shadaxe0.mdl": {
+     "bytes": 97860,
+     "sha256": "598f555a854590a749eee83870a869ebfa8dfd3c84ad447b7fe3fb796ea1da80"
+    },
+    "progs/v_shadaxe1.mdl": {
+     "bytes": 308932,
+     "sha256": "655794585474265444cada75db48a711206e2c85ae50380cdc13348995e71ea3"
+    },
+    "progs/v_shadaxe2.mdl": {
+     "bytes": 308932,
+     "sha256": "655794585474265444cada75db48a711206e2c85ae50380cdc13348995e71ea3"
+    },
+    "progs/v_shadaxe3.mdl": {
+     "bytes": 308932,
+     "sha256": "655794585474265444cada75db48a711206e2c85ae50380cdc13348995e71ea3"
+    },
+    "progs/v_shadaxe4.mdl": {
+     "bytes": 308932,
+     "sha256": "655794585474265444cada75db48a711206e2c85ae50380cdc13348995e71ea3"
+    },
+    "progs/v_shadaxe5.mdl": {
+     "bytes": 308932,
+     "sha256": "655794585474265444cada75db48a711206e2c85ae50380cdc13348995e71ea3"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 84644,
+     "sha256": "ba85c6ab5d304a7139b7bab13f47daa9fd3b6bec7677721d74174d10a67a3180"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 162086,
+     "sha256": "212bc88a549928f0955cf5ad30a7644c8fab9e7b7ff5adc1caec72cbdb3b85df"
+    },
+    "progs/v_shot3.mdl": {
+     "bytes": 211216,
+     "sha256": "75f73ec6ddda657bc149565607b807048e1b9784b3f8b52980d66badc1dbbc19"
+    },
+    "progs/v_zershot.mdl": {
+     "bytes": 62604,
+     "sha256": "4173bb2b84f9adce1957a87251cca591d968c3a54e801b170a87aae82539a2b1"
+    },
+    "progs/vase.mdl": {
+     "bytes": 27992,
+     "sha256": "28a8b9a0d367f17c2c265271d99b019f1762831a11ba794e2884fc7f7a8a2368"
+    },
+    "progs/w_backpack.mdl": {
+     "bytes": 138832,
+     "sha256": "78d86e7bc605746990a1b10644b12542f3380375693d4fb015884e42269314a0"
+    },
+    "progs/w_baronsword.mdl": {
+     "bytes": 166356,
+     "sha256": "8ba765c083e1e79f362b127ae1d70a09280e11c955ae89b5b9d99623fe25751f"
+    },
+    "progs/w_blueflail.mdl": {
+     "bytes": 17236,
+     "sha256": "3b645ebcb5d2249c9cf904e17006b85aa05963efda33f45f5b6f6fc3ea188d26"
+    },
+    "progs/w_chainsaw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/w_dcrossbow.mdl": {
+     "bytes": 14388,
+     "sha256": "52b14c48ec77acb261f18e1d7903e360eb96acb5c22a0702dfde90c66b103064"
+    },
+    "progs/w_dfurysword1.mdl": {
+     "bytes": 8916,
+     "sha256": "16521de90d0e71090ef4e6b5904252f3ae2d4a38ebe99eff9dc758ea009b0f90"
+    },
+    "progs/w_dfurysword2.mdl": {
+     "bytes": 8916,
+     "sha256": "2e42b37254cf8d85b098e58143fd77d86bed2f3568f630196326841298d07187"
+    },
+    "progs/w_dguardsword.mdl": {
+     "bytes": 8404,
+     "sha256": "74b884b8fd0a785fc2c1dcc29428b8d4c8725de6963bccf7ec80c396e002fa38"
+    },
+    "progs/w_dknightsword.mdl": {
+     "bytes": 8404,
+     "sha256": "1e6729ae15dd1520fff7f4c1c30260c35b637bd0b23b8fb3a5a476b175a39165"
+    },
+    "progs/w_dprincesword.mdl": {
+     "bytes": 19296,
+     "sha256": "89e5ef1382e980b68e812f7e8f6a9b6fba34af42bb2def457b7a2f6f8d7388b7"
+    },
+    "progs/w_enforcergun.mdl": {
+     "bytes": 42612,
+     "sha256": "fbbfd121a3d085d654aab512cfebb0b6890daf3c403f25ca372edc3c53039375"
+    },
+    "progs/w_hknightsword.mdl": {
+     "bytes": 20504,
+     "sha256": "a8dffdc9e400d45fcea617255a8731d752cfa83df40b923128d5dbae6839492c"
+    },
+    "progs/w_judgesword.mdl": {
+     "bytes": 199388,
+     "sha256": "c822984ba5a12948ca389f4b8536c3aa6644993242362b10ac7f6ff2e2332590"
+    },
+    "progs/w_justicesword.mdl": {
+     "bytes": 264928,
+     "sha256": "0fc111a637bdaf5372c02c53439497c2adfc0914845b947ecc9ad70ace1e1b3d"
+    },
+    "progs/w_knightsword.mdl": {
+     "bytes": 14328,
+     "sha256": "4740ee2b171380cd9481ba07f284fe720c5b49b0980dc19cb145b2356205fc0a"
+    },
+    "progs/w_ogregl.mdl": {
+     "bytes": 8260,
+     "sha256": "8071cb814b6158c8af563494687e3994192818ccc2aa80f4766bbf6912d559ee"
+    },
+    "progs/w_ogreham.mdl": {
+     "bytes": 29996,
+     "sha256": "11c1ec322889a971b7f930a7c653f13e69714e6de77b7afa4ded1fdec39145de"
+    },
+    "progs/w_ogremac.mdl": {
+     "bytes": 29324,
+     "sha256": "2f9086da6b43becab1d54e47bcb299421b1bdc1e1e71c41e581b367a75f52919"
+    },
+    "progs/w_skullbook.mdl": {
+     "bytes": 25580,
+     "sha256": "e99379e980169501931eb029f36d05b41ba52f8597a6022bf195b08dba88c70e"
+    },
+    "progs/w_soldiergun.mdl": {
+     "bytes": 36120,
+     "sha256": "9c89a19d7c5fa69783d8bcf59b46b18a0c80c37e280b18731564952faf1d6523"
+    },
+    "progs/w_zombiesword.mdl": {
+     "bytes": 14328,
+     "sha256": "e4ac73fc149fa581e64fb5f2016ce58c99ab1c9a76502ede78a525ab7f344b0c"
+    },
+    "progs/webs.mdl": {
+     "bytes": 516176,
+     "sha256": "c555940002fa3ed8f84ad7933dab8429fb0ecb22aaeee60ec3060b6f6e6c4692"
+    },
+    "textures/#bmk_water01a.tga": {
+     "bytes": 12332,
+     "sha256": "904f50c3a1de65dd5045f128d03ed8cdc86fcbc15cce295d94304b389ca5ed7c"
+    },
+    "textures/#bmk_water01b.tga": {
+     "bytes": 12332,
+     "sha256": "904f50c3a1de65dd5045f128d03ed8cdc86fcbc15cce295d94304b389ca5ed7c"
+    },
+    "textures/#bmk_water02a.tga": {
+     "bytes": 12332,
+     "sha256": "1123b4f4df8d75a1d8fc2a00d4d19fb279035771f7440b1506d0a95648123766"
+    },
+    "textures/+0bmk_fgopen02.tga": {
+     "bytes": 3145772,
+     "sha256": "1c7e70671a9a98473b3fb3926e1672d5a1712a011caba937097d5bc8c96099de"
+    },
+    "textures/+0bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "f2f139ae3d91bf3aa7c89181b87c1c645acb7be673eca5d56d804889e24f1e50"
+    },
+    "textures/+0bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "f2f139ae3d91bf3aa7c89181b87c1c645acb7be673eca5d56d804889e24f1e50"
+    },
+    "textures/+1bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "6941909c4574fb66f59f7a797f3dd0c696651e117c583f102d255e6bef4fe0ef"
+    },
+    "textures/+1bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "6941909c4574fb66f59f7a797f3dd0c696651e117c583f102d255e6bef4fe0ef"
+    },
+    "textures/+2bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "b78fb050de863bd84616c224de600521738a84ce172346bb783ba3a8708449da"
+    },
+    "textures/+2bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "b78fb050de863bd84616c224de600521738a84ce172346bb783ba3a8708449da"
+    },
+    "textures/+3bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "bf6815a6df5fe67c40ec3e46362a04c5ba15dc8a76de975a3d90a0caeec5e88c"
+    },
+    "textures/+3bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "bf6815a6df5fe67c40ec3e46362a04c5ba15dc8a76de975a3d90a0caeec5e88c"
+    },
+    "textures/+4bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "031bd453f18757388aa700fbae39e6c446959b8e38bee9fbbb53d8639f29deea"
+    },
+    "textures/+4bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "031bd453f18757388aa700fbae39e6c446959b8e38bee9fbbb53d8639f29deea"
+    },
+    "textures/+5bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "873c6b31fcaab54e309e663d23748cc5595b80e1432559761fd92a03f0d41d32"
+    },
+    "textures/+5bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "873c6b31fcaab54e309e663d23748cc5595b80e1432559761fd92a03f0d41d32"
+    },
+    "textures/+6bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "33492aebd47cc69737a2cd8460423103a76ff59b1d6bd39b750f19d6c72efc6d"
+    },
+    "textures/+6bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "33492aebd47cc69737a2cd8460423103a76ff59b1d6bd39b750f19d6c72efc6d"
+    },
+    "textures/+7bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "60741f2766db4f0eb6d622b132d2fc60d9e453d9f847661d3eca641fbf2b64f1"
+    },
+    "textures/+7bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "60741f2766db4f0eb6d622b132d2fc60d9e453d9f847661d3eca641fbf2b64f1"
+    },
+    "textures/window_blue1_2.tga": {
+     "bytes": 786476,
+     "sha256": "583f28b004c5de047037798524681ed2e7914bf1f54ac3d774c8da2880c80282"
+    },
+    "textures/{cop1_7.tga": {
+     "bytes": 16402,
+     "sha256": "464c149a2b2c9f624e7b1f8c2388117022425f058a946f0232c51def845b8bb5"
+    },
+    "textures/{cweb1.tga": {
+     "bytes": 262162,
+     "sha256": "bb0aa80709a1705199ed83bd0cad683a928cb29064eb32263fcb8bdb3999c2f5"
+    },
+    "textures/{cweb2.tga": {
+     "bytes": 262162,
+     "sha256": "64be3598db71729d4a4376c5f4e02bf0e586fc5ceca09196d71befde3265424e"
+    },
+    "textures/{cweb3.tga": {
+     "bytes": 131090,
+     "sha256": "d7b67dfdb1c80946f0de21128ddc3cda61906619ab8ed185611ef2a2a8f936b5"
+    },
+    "textures/{cweb5.tga": {
+     "bytes": 131090,
+     "sha256": "9cf5dd24994b1dc2f8f07ac5f76410fea9bdb7cb925962e1977e6aeb6ce23b02"
+    },
+    "textures/{dutcweb1.tga": {
+     "bytes": 131090,
+     "sha256": "8922bb11d99fc05d2ffeab2c2d99b04dba9d0fc5165fdd9a0ccd921f066f668c"
+    },
+    "textures/{dutcweb2.tga": {
+     "bytes": 131090,
+     "sha256": "a0377ffeac458bf27bbd86d2bc22ff17d973bd0328a4d048fb3136573c12723d"
+    },
+    "textures/{dutcweb3.tga": {
+     "bytes": 131090,
+     "sha256": "61710c94a64a506b75f36578904dbece6f666bc25ad2665333fe00b1c4b04f70"
+    },
+    "textures/{dutcweb5.tga": {
+     "bytes": 131090,
+     "sha256": "a0959d05f9bd1f4aa632b1642885261a2cbbef7d6d6d7ab677bb803ac1a00ef8"
+    },
+    "textures/{dweb1b.tga": {
+     "bytes": 65554,
+     "sha256": "7f2f310b5393519fbfdf70e07cab318504ad88c67dcce1e9988e376d5fc9c94a"
+    },
+    "textures/{dweb2b.tga": {
+     "bytes": 65554,
+     "sha256": "d95f6ebbcc21b2cb7164743b517aa69287101aa2640d5a8b249c409dcdc20333"
+    },
+    "textures/{dweb3b.tga": {
+     "bytes": 65554,
+     "sha256": "24cde40cf3791f0e054ccd2ad81353ec711bd95a7de1af58a1ad561d9d104ef1"
+    },
+    "textures/{dweb5b.tga": {
+     "bytes": 65554,
+     "sha256": "5b1fc4683289a850f5c16afa56660b710212bf18d4c047bf134529dac784d2c9"
+    },
+    "textures/{gen_gr8.tga": {
+     "bytes": 65554,
+     "sha256": "8dacb17cbbb6bb2f4dd95856dd46905a9c335f0a98dc3e8e700fac0a9c529163"
+    },
+    "textures/{kjwintex_ad.tga": {
+     "bytes": 262162,
+     "sha256": "3a2583e19c17e05877e489972b85593d9fca1e57ffd4fa02f1475e6fb3d59c34"
+    },
+    "textures/{ladder5th.tga": {
+     "bytes": 49170,
+     "sha256": "ed742e4b7072c1b11b1b801393bbfc641f96920ecabc5600c213b354313f89f0"
+    },
+    "textures/{lweb1.tga": {
+     "bytes": 262162,
+     "sha256": "e4edd91fdd0031064bd6157574ae5f81b44611424f7357daf8fd4e426c960399"
+    },
+    "textures/{lweb2.tga": {
+     "bytes": 262162,
+     "sha256": "4d2f26192388bf65091b0d5afb934bede4f07e89d002bbdbaeeba29d459fd5d7"
+    },
+    "textures/{rtex158_.tga": {
+     "bytes": 21522,
+     "sha256": "cd10217f3e5cd47b32bde516d4b36cf7995913e306f7415d25dcd7da6ccb4673"
+    },
+    "textures/{speedbz_grid1.tga": {
+     "bytes": 16402,
+     "sha256": "109e52491dda6d4968c99004296ccd503db6d6af9aad9aa6f21cca02fd2b299f"
+    },
+    "textures/{swvine.tga": {
+     "bytes": 65554,
+     "sha256": "c23639e3bd8aacd226695c913384e9c67d509b28fb9597d56f120cfea56a4006"
+    },
+    "textures/{utcweb1.tga": {
+     "bytes": 131090,
+     "sha256": "edae90ba1151fb6adc65def85d4dd7be01c3d2a18bd93ef0f26ff44d07f6c4b0"
+    },
+    "textures/{utcweb2.tga": {
+     "bytes": 131090,
+     "sha256": "829cfe898d9aa4c3ddd12a51f9ccc16a66b2ca5671d9bfd2339f402d49db3267"
+    },
+    "textures/{utcweb3.tga": {
+     "bytes": 262162,
+     "sha256": "026680576034c959e840aa4b39917497c38df12c1331a0c7a1486912e26a91f7"
+    },
+    "textures/{vinehang1.tga": {
+     "bytes": 65554,
+     "sha256": "c23639e3bd8aacd226695c913384e9c67d509b28fb9597d56f120cfea56a4006"
+    },
+    "textures/{vinehang2b.tga": {
+     "bytes": 262162,
+     "sha256": "4268dc2a183582d00c363a9fcd1965c026632150383d40b520fbd54f8751eaa7"
+    },
+    "textures/{vines3.tga": {
+     "bytes": 25618,
+     "sha256": "550b6ca0c768db472fbc970836516506034b30f0a5ca4b4b11df34d7dce8dc82"
+    },
+    "textures/{vinogrande2.tga": {
+     "bytes": 262162,
+     "sha256": "7c2d4aad4d34457ab1674bc1eaaa4ea38e4c4af384877af631cde258167fbb72"
+    },
+    "textures/{web1b.tga": {
+     "bytes": 65554,
+     "sha256": "41bb1244128013ff09f1965339ef505a7b0757bea91fcc0f77ed97cd38c8a145"
+    },
+    "textures/{web2b.tga": {
+     "bytes": 65554,
+     "sha256": "e2fbcb154962a9189614aecc7f6833e60d24709583a970d6cca0adf948df2331"
+    },
+    "textures/{web3b.tga": {
+     "bytes": 65554,
+     "sha256": "e4cfcd4c4e94ed647ef9af822d0df5ee573bd20d9f3bcf45ef8701a3102ae3ef"
+    },
+    "textures/{web5b.tga": {
+     "bytes": 65554,
+     "sha256": "dfdad98b5b62765b24abccd2ff77e85ec1c002060d6634d2593ac0fe10a4c718"
+    },
+    "textures/{win01_1brk1.tga": {
+     "bytes": 49170,
+     "sha256": "dae89ad198e0f4b1a63e37d9145084e947f7e88cb1c2e5d9ef32f25f3e0fb484"
+    },
+    "textures/{win01_1brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "88d9f8700eb9d14f9cfa6ac2e3df1bb25eae9a46553b6e46da7b225316862cb9"
+    },
+    "textures/{win01_1brk2.tga": {
+     "bytes": 49170,
+     "sha256": "2416e34e1ebdefa0cd01ea595b68ae86d2a35a4329b8853a489b1058dea44a90"
+    },
+    "textures/{win01_1brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "921ecb3434e9bd56d97ad57d10c67ace5a0f4bce79bf1b4c8c68aad4cf6ed10f"
+    },
+    "textures/{win01_1brk3.tga": {
+     "bytes": 49170,
+     "sha256": "59a6b2dc874758693574f15affea0be9c2e92e32328f81db78e5d72f488be7cb"
+    },
+    "textures/{win01_1brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "a3dcd6d471d8c65781a69c73a9fa449da02bc01a58a0a97c7313d30587611516"
+    },
+    "textures/{win01_2brk1.tga": {
+     "bytes": 49170,
+     "sha256": "589cf84c790b3165fa60e4441223da48c3df4275099fcc27bc5a8b9502579c15"
+    },
+    "textures/{win01_2brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "a0a80d249ff32c2e0a480801b721657244380732db3bdd9645dbece347d3190c"
+    },
+    "textures/{win01_2brk2.tga": {
+     "bytes": 49170,
+     "sha256": "0dc35f6a8b8b83596d127791f32f59b4a7445cb2529777555a93b9f329b7b537"
+    },
+    "textures/{win01_2brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "b313a11eb9017f0be604b673c0df88e94f94d552a7a132241f80883e68f4905f"
+    },
+    "textures/{win01_2brk3.tga": {
+     "bytes": 49170,
+     "sha256": "0fd4d13eb067aa17be299b48d500c245554fc3a6c1f5f11e10cbec1195a35273"
+    },
+    "textures/{win01_2brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "7ad6db65f6c0190a9ec569cce3b4780d21a90baf9baa728128f278807f1ba780"
+    },
+    "textures/{win01_3brk1.tga": {
+     "bytes": 49170,
+     "sha256": "ee6084ebe49ce367fd68039d548b1c960e55b136412bb00b8094dc1c545307bf"
+    },
+    "textures/{win01_3brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "afa5f0475b733a0ee1829b76598acd37cb1f28ed7f2faaf128593a13e702f5fa"
+    },
+    "textures/{win01_3brk2.tga": {
+     "bytes": 49170,
+     "sha256": "54c3abca2e42bbc4626823d4ad8081797e295bbdd07942484142d8a1c5395474"
+    },
+    "textures/{win01_3brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "0e0fc8daffc3ec8e07028904e3e55946270b8346f32efa341d64d6d1c0bcfcb5"
+    },
+    "textures/{win01_3brk3.tga": {
+     "bytes": 49170,
+     "sha256": "c1c7752039d97f7b92ec36408ffe456ff96c2a27c725c432e677a4f22e893d46"
+    },
+    "textures/{win01_3brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "0b627faae78e0d01eee393b58f978bf1a46b653001e1d1c56589d822245f86df"
+    },
+    "textures/{win01_4brk1.tga": {
+     "bytes": 49170,
+     "sha256": "af0f20f39e53d82cda8fca18e2918c1a2df2e6cf94e4d636e50c01686b3291b8"
+    },
+    "textures/{win01_4brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "4522e8d89c78119e9ff517ad64571c17c3ca750ac820142a700809620e894942"
+    },
+    "textures/{win01_4brk2.tga": {
+     "bytes": 49170,
+     "sha256": "4696f9c8ca59937230f40a3135b6c02e54b9b912eb62ba1401cbd5cccd1a9ae4"
+    },
+    "textures/{win01_4brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "a7a978f76a01a53dca360914519a8b1a93272aaad8a57c54e32ec74d4d9f1b96"
+    },
+    "textures/{win01_4brk3.tga": {
+     "bytes": 49170,
+     "sha256": "66dfc1bbe57f20c766653ab71cb339b6bff4e10b33cf66f5ed070bc0be75156f"
+    },
+    "textures/{win01_4brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "fb047a212d30b7fd140331df80d03dc718ba4237df73bf3cd74c918cc91daddf"
+    },
+    "textures/{win02_1brk1.tga": {
+     "bytes": 49170,
+     "sha256": "cb2711c7dc2ee9b77aded814296c1b1bb124ff5d2db2e248af7d7d0d882f422d"
+    },
+    "textures/{win02_1brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "9391e42b0fe2e55689e7104984fc1b5fd199cd8821e562fc4538fe2eb73825e9"
+    },
+    "textures/{win02_1brk2.tga": {
+     "bytes": 49170,
+     "sha256": "4fb71ced0a5388e41896b3b71b9c48d157eb72d229db04bbdcca45ce58658adc"
+    },
+    "textures/{win02_1brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "ed18da9a408653915554b0918a0f720cb76257231fc8ff9d465003e98fb371ab"
+    },
+    "textures/{win02_1brk3.tga": {
+     "bytes": 49170,
+     "sha256": "3b1f9bdbd53db1fa6d6920045cf4da45064dac48f7f66870e003860514804e99"
+    },
+    "textures/{win02_1brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "f1e10e37f7f2e71ddd6165607e59d39f95ec59c904017a8fa6b7b33a3adf40c1"
+    }
+   },
    "sha256": "29d227d8321ad2a734f4a8fcb29ed8f5bfbde26889ad07811af6c9a954aacdfe",
    "timestamp": "2023-07-28T17:35:40.000Z"
   },
   "peril3.0/pak1.pak": {
    "bytes": 277933899,
+   "files": {
+    "maps/ad_brk/all_brick.map": {
+     "bytes": 22738,
+     "sha256": "e0859c71d8a3d5d4b140757e4fcd2ab4e92674bbb71979d6b9d6d2deb5d2390a"
+    },
+    "maps/ad_brk/all_glassa.map": {
+     "bytes": 8834,
+     "sha256": "f4e1c7c1444b3b2d8a3463e8950c0a6a3aed8d39144a6b1fc2a69bdbf376f444"
+    },
+    "maps/ad_brk/all_metal.map": {
+     "bytes": 12297,
+     "sha256": "447c74022bea3ae89d3a4412afcf4bcd384ea725b344b987fb2e7bb37adfabe1"
+    },
+    "maps/ad_brk/all_rocka.map": {
+     "bytes": 10235,
+     "sha256": "52edb0d5b9f79e8b89a58353098316e81be31c3e289d6f96e450ea01c4bbeb62"
+    },
+    "maps/ad_brk/all_wood.map": {
+     "bytes": 8397,
+     "sha256": "93697129156d662c18391564e26c5d5ceec8bac244209496290b8e9a516a5bfb"
+    },
+    "maps/ad_brk/brick01.bsp": {
+     "bytes": 7912,
+     "sha256": "c11880924b195ed38908cbf50f9cd16f071918df0a94a19c7254b93dddb1e62d"
+    },
+    "maps/ad_brk/brick01.map": {
+     "bytes": 717,
+     "sha256": "3f87d06eb46f67efa678ddd5ddf274e9c595c4a5236d8f111d8a0ea999972e09"
+    },
+    "maps/ad_brk/brick02.bsp": {
+     "bytes": 8072,
+     "sha256": "9ec52c7441f570d2a793035ebc2128d7f7f91f71b44b4418fd01e6b3e6d503e2"
+    },
+    "maps/ad_brk/brick02.map": {
+     "bytes": 861,
+     "sha256": "616d1c5b6f3e476453e8b9b57dd59deb285c6c0482680ca5d6da358ee808c619"
+    },
+    "maps/ad_brk/brick03.bsp": {
+     "bytes": 8280,
+     "sha256": "aa55feca84b80282851ca55c71deb3d54f02a6668af820f5ac4f9c1a0514e5e1"
+    },
+    "maps/ad_brk/brick03.map": {
+     "bytes": 935,
+     "sha256": "4359e78daaac0b8d4ff58dc68301bba4cd423e81284bcd360ce1480862c19d91"
+    },
+    "maps/ad_brk/brick04.bsp": {
+     "bytes": 8052,
+     "sha256": "b1fa14c188a8ad31cf58c7ebd495fbe8ed153819015d4e97c82e01ee052081e3"
+    },
+    "maps/ad_brk/brick04.map": {
+     "bytes": 815,
+     "sha256": "2bda60cc50886dc430a053f509f2376dcd9bd4d09666cf7960a96484fa369903"
+    },
+    "maps/ad_brk/brick05.bsp": {
+     "bytes": 7952,
+     "sha256": "e137a3ea0f33a83b8717dcb9d6e2ab79876112121dc21fe2e625d24d5d251384"
+    },
+    "maps/ad_brk/brick05.map": {
+     "bytes": 770,
+     "sha256": "8ebf395096050f65a3a370971d65deb0926af70f6cbd75c6579a53b68f676793"
+    },
+    "maps/ad_brk/brick06.bsp": {
+     "bytes": 9184,
+     "sha256": "32cee0a2c668160e07568ae08b4de5beae87d74e94a347cd431c90005bf49e24"
+    },
+    "maps/ad_brk/brick06.map": {
+     "bytes": 1709,
+     "sha256": "289f58cad70a88e8a8d986644faf539dd38cf52a884aa7f85513db5df0cc438c"
+    },
+    "maps/ad_brk/brick07.bsp": {
+     "bytes": 10377,
+     "sha256": "df07446f9f6a118f11451de5d7817f582c11dcc81ca3f83c8fa72c9d95e8df9c"
+    },
+    "maps/ad_brk/brick07.map": {
+     "bytes": 1942,
+     "sha256": "fe440636e5354fb553708f3b6859023d0a520f315050dc11a564e31a7b72d5e4"
+    },
+    "maps/ad_brk/brick08.bsp": {
+     "bytes": 13964,
+     "sha256": "2abbbc958d752e742df9d1f7152c4cc8c0de6373f20e628a762e2a22f5d6b3f7"
+    },
+    "maps/ad_brk/brick08.map": {
+     "bytes": 3286,
+     "sha256": "72174f573416102bb4e087e2025b3dbdfc669ab7cafc8b354f7b1a4485af1f5b"
+    },
+    "maps/ad_brk/brick09.bsp": {
+     "bytes": 7952,
+     "sha256": "28d7162b4af3f4ce184a31a14e3a9777383f29b63920d9d62ff136ae96e3a2fd"
+    },
+    "maps/ad_brk/brick09.map": {
+     "bytes": 770,
+     "sha256": "62f11ef3e3033dea82eb6062e5b5301474dd014f889a980383891e689be2a352"
+    },
+    "maps/ad_brk/brick10.bsp": {
+     "bytes": 9184,
+     "sha256": "7d6f8e3fd1b65880bb767ab5d488ef11bbb01ec4ce14c7b747ee75b8a8238c4e"
+    },
+    "maps/ad_brk/brick10.map": {
+     "bytes": 1709,
+     "sha256": "276f975d99dfe982bf71104889f65a248d719778db89591e7193ecc46b13d645"
+    },
+    "maps/ad_brk/brick11.bsp": {
+     "bytes": 10377,
+     "sha256": "f65cbdb642220611e89725187f47427031c4b18c21cc04ae3f6cfb4dffd149a2"
+    },
+    "maps/ad_brk/brick11.map": {
+     "bytes": 1942,
+     "sha256": "3b9d73d400e29fba3c82d8b2ccdad26e03b128c7771427497d4740c2d34cd63d"
+    },
+    "maps/ad_brk/brick12.bsp": {
+     "bytes": 13918,
+     "sha256": "1e1e8191c5ebdd1f0fed27edaa04a82a6aabd5c41723cf590781ff00f7300a02"
+    },
+    "maps/ad_brk/brick12.map": {
+     "bytes": 3286,
+     "sha256": "d2b89c83f1ff95d6fe577cf4a166e7bec6e02ab85f48c51316908d7d80068156"
+    },
+    "maps/ad_brk/brick13.bsp": {
+     "bytes": 7912,
+     "sha256": "4b5ac4eb6ea5a9ec049c27082d800cb981902965a4b652f86e1753bfa1eb7c94"
+    },
+    "maps/ad_brk/brick13.map": {
+     "bytes": 690,
+     "sha256": "253425ec201a354cd1b4c93c78d740e2a17c7d946d911efffa63d522e95f9f0b"
+    },
+    "maps/ad_brk/brick14.bsp": {
+     "bytes": 8072,
+     "sha256": "afe8797d2172a5b4b06be3e2a69038346d62938f3d9da6ea224074cee5bb1669"
+    },
+    "maps/ad_brk/brick14.map": {
+     "bytes": 828,
+     "sha256": "a500705a328cafa28159ee107cbe80003848ee241c3544a73dea1432f67b4042"
+    },
+    "maps/ad_brk/brick15.bsp": {
+     "bytes": 8280,
+     "sha256": "58ddb31ce4108a70872444022369154529c532983dbc58698cd88f217f8947a0"
+    },
+    "maps/ad_brk/brick15.map": {
+     "bytes": 899,
+     "sha256": "589f256e02b66051ede4f2fe136e69313a7e01402f1caa43bada4d605a046b8e"
+    },
+    "maps/ad_brk/brick16.bsp": {
+     "bytes": 8052,
+     "sha256": "d5c15593d0d776d5f76919100602d893973cd59b7ca88af55e1ae3cc2fb56967"
+    },
+    "maps/ad_brk/brick16.map": {
+     "bytes": 785,
+     "sha256": "a15682c168f0a7128c83bf7bd38688ae1d2507873687e815c690b08d44f14a37"
+    },
+    "maps/ad_brk/brick17.bsp": {
+     "bytes": 7952,
+     "sha256": "738d902046d73e14b8a552529dd8306864661fd0469efb52b3c81329135e8372"
+    },
+    "maps/ad_brk/brick17.map": {
+     "bytes": 770,
+     "sha256": "699fa7055fa88f309fe4a4a2af24b5d61af91365d81074e44cbdf399d36939c9"
+    },
+    "maps/ad_brk/brick18.bsp": {
+     "bytes": 9184,
+     "sha256": "67ad693c292448f73ea0b3ab6ee22883709c7deb006cecd19c0dda5c9d4fa131"
+    },
+    "maps/ad_brk/brick18.map": {
+     "bytes": 1709,
+     "sha256": "849749000a41ecfc60aa4607c890e140bcd78ef26858512f56494efdc5873bcd"
+    },
+    "maps/ad_brk/brick19.bsp": {
+     "bytes": 10321,
+     "sha256": "721c3237db8c026a03e01e387bb95fe5ed8fbc49b3c527220f164d77a2f3a4f2"
+    },
+    "maps/ad_brk/brick19.map": {
+     "bytes": 1942,
+     "sha256": "1760c2c74d0b894814c89152062f2f55a8635a17559828c27532a7e913949af6"
+    },
+    "maps/ad_brk/brick20.bsp": {
+     "bytes": 13306,
+     "sha256": "bbecee9c1ac726743e6cc49d18246c650f762f577dc108ffed2a6807ff665052"
+    },
+    "maps/ad_brk/brick20.map": {
+     "bytes": 3286,
+     "sha256": "121d4fe62c07953f11a04a41577769a38cae8852af78bbd40fc44f598eee91d7"
+    },
+    "maps/ad_brk/brick21.bsp": {
+     "bytes": 7972,
+     "sha256": "e65c1df9d5f02efc9475a53d1127d7899f69d23d8a0ea20deab384fcd3351d29"
+    },
+    "maps/ad_brk/brick21.map": {
+     "bytes": 789,
+     "sha256": "8c12d093245c3937afcf62916fce9e6b2d181d72d433b879112b27e0f168ccc7"
+    },
+    "maps/ad_brk/brick22.bsp": {
+     "bytes": 9204,
+     "sha256": "b8efe5f130accf1e8704202dbaa44215259e1209b9b81bf79461ff5e5f725596"
+    },
+    "maps/ad_brk/brick22.map": {
+     "bytes": 1728,
+     "sha256": "403525bf264890c5d9adef370847749cbeec481337f284618810057e697cddde"
+    },
+    "maps/ad_brk/brick23.bsp": {
+     "bytes": 10340,
+     "sha256": "79bac69a44c7e83343bd69c2360176046e048257ecfb7ac27f3c989b42af92e9"
+    },
+    "maps/ad_brk/brick23.map": {
+     "bytes": 1961,
+     "sha256": "f25e7a514eb15637b7dedc41ec5c34e2d8b9e4dd3b584a41a1b1d7c166b362ef"
+    },
+    "maps/ad_brk/brick24.bsp": {
+     "bytes": 13312,
+     "sha256": "2e0728a16ebe0fa868d8bd0ffe0f54e013afac41c77ee7516f385d7a6718b07f"
+    },
+    "maps/ad_brk/brick24.map": {
+     "bytes": 3305,
+     "sha256": "481d21e7e07a312e894f71a8118035457164f17d48032bad54bdc62644e7e8a4"
+    },
+    "maps/ad_brk/brick25.bsp": {
+     "bytes": 7924,
+     "sha256": "8e33245bde92e94d9dddca1b61059fee1eb19aed0613945c1dffe3145fd51d78"
+    },
+    "maps/ad_brk/brick25.map": {
+     "bytes": 715,
+     "sha256": "cf6042585a2347f8ae4de546e2fa9aa905aa7ee4d9607a12dfd778d0084ba9d1"
+    },
+    "maps/ad_brk/brick26.bsp": {
+     "bytes": 8084,
+     "sha256": "4ddb5d2ca4adbc32f905a0340b26a174c25af7f6de5ad9408c4e0f4ca2816a55"
+    },
+    "maps/ad_brk/brick26.map": {
+     "bytes": 855,
+     "sha256": "baaf133d5c5c90b295855bb03a0a30340db324ddc82ed119a9d025e8ddb22724"
+    },
+    "maps/ad_brk/brick27.bsp": {
+     "bytes": 8296,
+     "sha256": "9084778144864d4167d270dd825e99d18d7ea7fc2dfb799f7e0eb12f1d236688"
+    },
+    "maps/ad_brk/brick27.map": {
+     "bytes": 927,
+     "sha256": "4e3b59df2a5b8efe85460f114baa795c36c8b410407e0752a69efc525d49e9b0"
+    },
+    "maps/ad_brk/brick28.bsp": {
+     "bytes": 8068,
+     "sha256": "42b4fe7f99032b3292996bcfe8b72e1c5e3b637357e376f8502a202a3816bcf0"
+    },
+    "maps/ad_brk/brick28.map": {
+     "bytes": 811,
+     "sha256": "c088828bbe9cdca1bb55ea4ceca9f46e03217f1643189a93d70a83eeb11f72bc"
+    },
+    "maps/ad_brk/brick29.bsp": {
+     "bytes": 24232,
+     "sha256": "463ff6bed92dfab082f13876187c506572dd3d18727e13fb708e24afd02aa7ef"
+    },
+    "maps/ad_brk/brick29.map": {
+     "bytes": 711,
+     "sha256": "1a4ff9d041df15cfd229666a9b32c24a96577ef6f249f33d89dc88cdfbe5540a"
+    },
+    "maps/ad_brk/brick30.bsp": {
+     "bytes": 24392,
+     "sha256": "a82a0d709c367d8ecf359142d99d0ad09d97b674ef1575beeb78dbbe93025c59"
+    },
+    "maps/ad_brk/brick30.map": {
+     "bytes": 853,
+     "sha256": "803c896037b5cc971e932219b5f06e363724a25de693ef6800d1332c6df4f8d1"
+    },
+    "maps/ad_brk/brick31.bsp": {
+     "bytes": 24604,
+     "sha256": "deb8a0278e043c6510e7f7d17ec708bdc7f37fa884f869ccbfc9ef9a95b6a8ac"
+    },
+    "maps/ad_brk/brick31.map": {
+     "bytes": 926,
+     "sha256": "9a3502125d9a995f10052ed6a9971bfe148a4e8fd7561a082e8bbecff5b39d56"
+    },
+    "maps/ad_brk/brick32.bsp": {
+     "bytes": 24376,
+     "sha256": "c8961b003f231b13a74bc247ce13ada38850707d443aa98dbad98b9f2ecf276b"
+    },
+    "maps/ad_brk/brick32.map": {
+     "bytes": 808,
+     "sha256": "aa96dda4508d2e98b5827ac42d8230f11969457f63022bf488dac06d2783910e"
+    },
+    "maps/ad_brk/glass01.bsp": {
+     "bytes": 8095,
+     "sha256": "d5d9b8df7fc4db671e180fbc60253ea809b61819bd77a9072d1cf1b1c9c11888"
+    },
+    "maps/ad_brk/glass01.map": {
+     "bytes": 961,
+     "sha256": "04b6721fc35e7a43fa921075bc2184bbbb2791570ea781ee6351b0cf01936456"
+    },
+    "maps/ad_brk/glass02.bsp": {
+     "bytes": 7035,
+     "sha256": "b2e6ba1e674f6a93e01ada15700b98624eae9c242a30eba9ea032d2e7d9fc555"
+    },
+    "maps/ad_brk/glass02.map": {
+     "bytes": 447,
+     "sha256": "6bf3cce568e830dd03830bb2e7225329490dae01e33806eec6a594313a8daa9e"
+    },
+    "maps/ad_brk/glass03.bsp": {
+     "bytes": 7922,
+     "sha256": "02661d1e724d41c02c977f8b869a23e6fc883303b66298c98ebddf752f365a1b"
+    },
+    "maps/ad_brk/glass03.map": {
+     "bytes": 963,
+     "sha256": "cb5245e54bc27d999bd643370557f8e766ae94e10358993951084e6ca87d087c"
+    },
+    "maps/ad_brk/glass04.bsp": {
+     "bytes": 7223,
+     "sha256": "a41bddb2d6a0ef53b96097a6e4d9731bf100b695a7a1c11091f054f746c7bf2a"
+    },
+    "maps/ad_brk/glass04.map": {
+     "bytes": 512,
+     "sha256": "f8e9f41266f3cd0017c19f7d3a29e0c738b497fb539cec2583c4eda6d509965c"
+    },
+    "maps/ad_brk/glass05.bsp": {
+     "bytes": 24436,
+     "sha256": "10fd2ef7f24bda233c3b4433e4ed64b8feb7273f09c0da5d93190ced61f20779"
+    },
+    "maps/ad_brk/glass05.map": {
+     "bytes": 999,
+     "sha256": "c8e2039929909b608ac0ddf36562443caf7052a15e8b0e39a73e0869c15930c1"
+    },
+    "maps/ad_brk/glass06.bsp": {
+     "bytes": 24300,
+     "sha256": "60f08ebc3d967dbe1b6062a59679a3e89e199a305f51bb9bc7dbada44c66fe5e"
+    },
+    "maps/ad_brk/glass06.map": {
+     "bytes": 976,
+     "sha256": "73346b8cc46166371a6e7f220ebe78f2cde29f29d8d705e1e4b0c60e153b52df"
+    },
+    "maps/ad_brk/glass07.bsp": {
+     "bytes": 23365,
+     "sha256": "ccebafe1a97953e91b64694783a1989c8e8ba440fd3c136b09785131b54c75cf"
+    },
+    "maps/ad_brk/glass07.map": {
+     "bytes": 458,
+     "sha256": "6d79a332d308ed3746c8f2fd13227b44a1cc66f0b2fd471eb6de1cbf695d81c9"
+    },
+    "maps/ad_brk/glass08.bsp": {
+     "bytes": 23602,
+     "sha256": "82c1bfe3d83c87c908d6dac76a255843cbbaededeaf644eeec5b9b9a794e0bdf"
+    },
+    "maps/ad_brk/glass08.map": {
+     "bytes": 530,
+     "sha256": "65dba1b71881c49b29d288720f43c457c838b93aa9e522953bac885443944c04"
+    },
+    "maps/ad_brk/glass09.bsp": {
+     "bytes": 24436,
+     "sha256": "34e317a5652fcc4a3aaf517ebc178c8d8fad6738b536a6c06eff2800bf7fefba"
+    },
+    "maps/ad_brk/glass09.map": {
+     "bytes": 999,
+     "sha256": "ca9b91b38fa600b7dfa80e9a257dc15f2f2dda9e1d2c1d002ea90cbdcc0e0279"
+    },
+    "maps/ad_brk/glass10.bsp": {
+     "bytes": 24300,
+     "sha256": "6e06c140e0916cd35235bd7e6970ca3250c6c36a2ee6d4632d805da67215818a"
+    },
+    "maps/ad_brk/glass10.map": {
+     "bytes": 976,
+     "sha256": "2043f7646edcfa088a76b6104b136ff9ca0f90bffe6efb955f951a4bfe16643d"
+    },
+    "maps/ad_brk/glass11.bsp": {
+     "bytes": 23365,
+     "sha256": "caae0c47ae097f4cb1055a3f5eecd5d407b71c975b35d992f3048993b1ac7e97"
+    },
+    "maps/ad_brk/glass11.map": {
+     "bytes": 458,
+     "sha256": "5bea1bbcee409674f58a1fd26cf0c983e11f8ffd5f20c829f5c3df6a4c28b1c9"
+    },
+    "maps/ad_brk/glass12.bsp": {
+     "bytes": 23602,
+     "sha256": "526018b31a9b02b1c9e1b5123b2c936677d6fd7b6c014ea14dfe4905271e419f"
+    },
+    "maps/ad_brk/glass12.map": {
+     "bytes": 530,
+     "sha256": "499ed4ce1a1ebbd9347a2a4dc6413f2f79d203bbce293a79a5b2bde49ade0a3f"
+    },
+    "maps/ad_brk/glass13.bsp": {
+     "bytes": 24108,
+     "sha256": "fdb97447ffe9e4769f35a3e1e7bd9d6b0e2e6b555d60102991bf57f06e8b3d83"
+    },
+    "maps/ad_brk/glass13.map": {
+     "bytes": 979,
+     "sha256": "073661c415a2568c45a90cc9baa471cde9a02a975d4d4fd7596bb96d272d3934"
+    },
+    "maps/ad_brk/glass14.bsp": {
+     "bytes": 23296,
+     "sha256": "e3517bb79e2561150c4641ab3650e0697adcaa2f281c5209cacdc12d9c4023a7"
+    },
+    "maps/ad_brk/glass14.map": {
+     "bytes": 462,
+     "sha256": "066d5bade73c399cf10a9dcafecec9d65ac3c6045644988cbefb104fb8e7d8c3"
+    },
+    "maps/ad_brk/glass15.bsp": {
+     "bytes": 23892,
+     "sha256": "6abc82aca32e6c8312884db42891753c8d2ad8e1d4ae9218022604eadb08708b"
+    },
+    "maps/ad_brk/glass15.map": {
+     "bytes": 993,
+     "sha256": "5c24e1763bd26d34539bc7ee527842810e4ddb6ac80f683a7b3b35ee326360d3"
+    },
+    "maps/ad_brk/glass16.bsp": {
+     "bytes": 23532,
+     "sha256": "13725c14b226297090c4f1e9949c476f601a52247bc8f6abb937a57b964462c6"
+    },
+    "maps/ad_brk/glass16.map": {
+     "bytes": 528,
+     "sha256": "03dbc7feb833831d413e7f87ed0e79625da0800659ab65ea8d3deb63de09a27d"
+    },
+    "maps/ad_brk/kn_mtrim2_1.bsp": {
+     "bytes": 25264,
+     "sha256": "99b67eeed7ece0f46b1d7b4b2309331e655eb9c1b412d3ac4bc362acb4dd8606"
+    },
+    "maps/ad_brk/kn_mtrim2_1.map": {
+     "bytes": 1455,
+     "sha256": "51018fd4ff6d00c9c2c449e32a83b8521fdc3babb2937adf6800d8e67e38b976"
+    },
+    "maps/ad_brk/kn_mtrim2_2.bsp": {
+     "bytes": 24460,
+     "sha256": "a98bdee68b3a222af0f44fc978d09e092a08953539929a6a53f1bf0e97568e74"
+    },
+    "maps/ad_brk/kn_mtrim2_2.map": {
+     "bytes": 1103,
+     "sha256": "2880a3f7becf48ae79c27ef9a05faa5c774df20a53ec5d892304bf67bc06cbbe"
+    },
+    "maps/ad_brk/kn_mtrim2_3.bsp": {
+     "bytes": 24632,
+     "sha256": "967e89f57bc011cd3b38d60d45272633cc0f773c91045b7938766ac0436ae803"
+    },
+    "maps/ad_brk/kn_mtrim2_3.map": {
+     "bytes": 1171,
+     "sha256": "40ef38fd45c3e9c750d311bb8920b938fcd9f647f2dabc58509b327514f44907"
+    },
+    "maps/ad_brk/kn_mtrim2_4.bsp": {
+     "bytes": 24452,
+     "sha256": "e4559e1e5a3118f2c949daccb96f887d64821511f5850cfa72133f84a8e04901"
+    },
+    "maps/ad_brk/kn_mtrim2_4.map": {
+     "bytes": 1036,
+     "sha256": "595513bc0fe2441cb6aa88af41d9afd7de8b94421ac6c32c546113f83be6577c"
+    },
+    "maps/ad_brk/metal01.bsp": {
+     "bytes": 8122,
+     "sha256": "11e8e340455c487150951fb4dccaf7da72d0243892948d5c22b478221ffcca23"
+    },
+    "maps/ad_brk/metal01.map": {
+     "bytes": 780,
+     "sha256": "902c31c661df8bbc1b0c410b6a8745f680e85cf91bbdb14d85244b6937be5239"
+    },
+    "maps/ad_brk/metal02.bsp": {
+     "bytes": 10022,
+     "sha256": "59b56266e73b4246c54d8cd9c4769d7345c53ae5133c45d1db94f5c771350d94"
+    },
+    "maps/ad_brk/metal02.map": {
+     "bytes": 1414,
+     "sha256": "171bfe727b6c80a4c0350fb4c87090d30c3fb1a21962b8fc9c638c47027e1fea"
+    },
+    "maps/ad_brk/metal03.bsp": {
+     "bytes": 9386,
+     "sha256": "13e3ea83c5bdbf81075328cc14543d1ab6301378cc9af56b59b67b1cc22e3a53"
+    },
+    "maps/ad_brk/metal03.map": {
+     "bytes": 1179,
+     "sha256": "89ac4002203958a9f971601586f4e4e6bdcaab7cbde62ca7fb58cf705fbdae56"
+    },
+    "maps/ad_brk/metal04.bsp": {
+     "bytes": 10655,
+     "sha256": "785ab6aed41e60072083aeee571d76796f60ec5e24d249736575007d558c10ae"
+    },
+    "maps/ad_brk/metal04.map": {
+     "bytes": 1599,
+     "sha256": "aecd2de4ce9cdb49922c58f640f3df4c48b8dc45f5e611f5d0c75a6a96bf705e"
+    },
+    "maps/ad_brk/metal05.bsp": {
+     "bytes": 8337,
+     "sha256": "82da98a887a0101d1a638d266db3c9913090b3fcaca6af5869e7063529b3066e"
+    },
+    "maps/ad_brk/metal05.map": {
+     "bytes": 905,
+     "sha256": "541a5d633be51d32bbd6580cf3fb4fcc7e9b3c38107eaffdd88896a01d249b71"
+    },
+    "maps/ad_brk/metal06.bsp": {
+     "bytes": 7898,
+     "sha256": "3fe3f66ff336ede9d9a6f4fc0f7df16b62504b25a8dea1c8adce2113e927428e"
+    },
+    "maps/ad_brk/metal06.map": {
+     "bytes": 697,
+     "sha256": "30bfd29315a3c0d8654aa1842b7f2a2a7bcdc7a5a81ff96f359a86d57a289ce9"
+    },
+    "maps/ad_brk/metal07.bsp": {
+     "bytes": 8439,
+     "sha256": "8f8a722ae0d3350bf4331fbd4a492dd4c18b3c44006289fd7c6d393282f280a1"
+    },
+    "maps/ad_brk/metal07.map": {
+     "bytes": 1508,
+     "sha256": "f2c7442255c68ae30186692cdf49bca0f1e5769587d5d2392baf3ec4708679b2"
+    },
+    "maps/ad_brk/metal08.bsp": {
+     "bytes": 8150,
+     "sha256": "028675fecfd419e8852cabe821fac1941c914bdf43110291d7a07509e77f4d26"
+    },
+    "maps/ad_brk/metal08.map": {
+     "bytes": 847,
+     "sha256": "797217e143857e0b27e1654449a5dbdc0b1a3dc46c8cafdea5ee9c5ac0cbf16c"
+    },
+    "maps/ad_brk/metal09.bsp": {
+     "bytes": 7456,
+     "sha256": "4d6fb8a19ce5a331ceb68fcfa952fa61ed3ad336002eedd788921b0daa2a7877"
+    },
+    "maps/ad_brk/metal09.map": {
+     "bytes": 649,
+     "sha256": "1fde976a2f1372d9d55350caa3285776eee897d9786f9118d5a6988010efaeca"
+    },
+    "maps/ad_brk/metal10.bsp": {
+     "bytes": 7785,
+     "sha256": "c25084ae2f159ba73e6c43041a2e050d30af70a862a9c4846b2241848a33b55f"
+    },
+    "maps/ad_brk/metal10.map": {
+     "bytes": 709,
+     "sha256": "856390903976512f1b5372f374b5c7444238a173abbedbbfeccbb675cf93ed66"
+    },
+    "maps/ad_brk/metal11.bsp": {
+     "bytes": 7918,
+     "sha256": "e939c6c80e11479887b68bb39a97e0b877514c4e9dc9b2a4a9e18303caa317f1"
+    },
+    "maps/ad_brk/metal11.map": {
+     "bytes": 797,
+     "sha256": "74528d15a51708fdca65c900096411f1d56d6472a5058458577ac04d820e9895"
+    },
+    "maps/ad_brk/metal12.bsp": {
+     "bytes": 8226,
+     "sha256": "3ceccd7aa24fc353e0ac3ccb15531c2f243c0ed246c73c44bdd8897dbdd6537e"
+    },
+    "maps/ad_brk/metal12.map": {
+     "bytes": 872,
+     "sha256": "a95f34c46729c7849e6d45d9cdf57bb49289561b6551bd2e4a39659c272343fd"
+    },
+    "maps/ad_brk/metal13.bsp": {
+     "bytes": 8121,
+     "sha256": "e02aa4c824f5d8fcdfe302a0a194cee6fcf44e2fee844c492f434bf2b7763209"
+    },
+    "maps/ad_brk/metal13.map": {
+     "bytes": 760,
+     "sha256": "bae8879296237bea635d054428a536c0297420ff3ff61f681d569b30a984e7d0"
+    },
+    "maps/ad_brk/metal14.bsp": {
+     "bytes": 10022,
+     "sha256": "4b66b133fe892c6ae6ead0c6726638e98637d71a3a9afdc4ac0546be0f2d0292"
+    },
+    "maps/ad_brk/metal14.map": {
+     "bytes": 1376,
+     "sha256": "197bd6c01b5ffc4c9e0f27e319b25b882af4f20db36612f41b006dd6db0833e1"
+    },
+    "maps/ad_brk/metal15.bsp": {
+     "bytes": 9386,
+     "sha256": "8cf7545aa3464814908c3987f51e9693f154f690ec526ed228b37b1590730e0b"
+    },
+    "maps/ad_brk/metal15.map": {
+     "bytes": 1147,
+     "sha256": "73aef82251f5b4a9548135aedb926aad6b7cff94cb3656fc8216a594a8a9f6dc"
+    },
+    "maps/ad_brk/metal16.bsp": {
+     "bytes": 10719,
+     "sha256": "af64c13135b1e1eb6d8e09607c34d6cec57a3cbf624dd76b136b505f097ecf65"
+    },
+    "maps/ad_brk/metal16.map": {
+     "bytes": 1555,
+     "sha256": "d7220fbbb33a630d03ed2514b9ee33a9d3a424f819b4977e093863ca8568b645"
+    },
+    "maps/ad_brk/metal17.bsp": {
+     "bytes": 8347,
+     "sha256": "0d21cbf9b5bc65391e00bad35368530d3d4b5f59993e2ac7d45a7edc9a2edf73"
+    },
+    "maps/ad_brk/metal17.map": {
+     "bytes": 911,
+     "sha256": "7be91013d0e57e41aff314398634043cebf8f250691b3ebc583bf373df400c2c"
+    },
+    "maps/ad_brk/metal18.bsp": {
+     "bytes": 7907,
+     "sha256": "ef0dee9c63d7bbced8c04ea40523d47fd99638905aa20a61779820b5aebd5aab"
+    },
+    "maps/ad_brk/metal18.map": {
+     "bytes": 703,
+     "sha256": "b610432a51ac6b57f19fee9df89fc7b80d5cbffa972e539d9c5f3aded3359434"
+    },
+    "maps/ad_brk/metal19.bsp": {
+     "bytes": 8450,
+     "sha256": "2796007e11c0a1b2a3430edc4e0f7edb0e721a6d906e783233c0feb54b0482e5"
+    },
+    "maps/ad_brk/metal19.map": {
+     "bytes": 1514,
+     "sha256": "9ed741344b3c651f3b8fbda1d8ee8e779bd12315feea397e938522c9750dc214"
+    },
+    "maps/ad_brk/metal20.bsp": {
+     "bytes": 8160,
+     "sha256": "38013cdb360356827ab6c296791434c537183d082feed6944665a882e622ed84"
+    },
+    "maps/ad_brk/metal20.map": {
+     "bytes": 853,
+     "sha256": "a3b28328bb043206bc048e82dba12d91c56c464b5e4e1452c6740f0df44223bf"
+    },
+    "maps/ad_brk/rock01.bsp": {
+     "bytes": 24238,
+     "sha256": "5f2c0a6ce3c58eed53c86789ff1685551cff53ca1f239bf75e3a9bc59aa95a56"
+    },
+    "maps/ad_brk/rock01.map": {
+     "bytes": 680,
+     "sha256": "db0b6a72833e12a35f518b32920fccf4fbc45120e7ab8ca3afc6e255b5d51334"
+    },
+    "maps/ad_brk/rock02.bsp": {
+     "bytes": 24250,
+     "sha256": "c6196e82e7b3e22cb687e2d6c0780f163929b5ea42b868eedcaadd40f35927f9"
+    },
+    "maps/ad_brk/rock02.map": {
+     "bytes": 760,
+     "sha256": "49531f0a1a38e03e3b46af53cfc35845878fcc171c2579f0f13d2a000ca82829"
+    },
+    "maps/ad_brk/rock03.bsp": {
+     "bytes": 24669,
+     "sha256": "9f7ab133399a3681f0b97276c7cb9883b479995c3420e5643eaedd11c88f0a0d"
+    },
+    "maps/ad_brk/rock03.map": {
+     "bytes": 929,
+     "sha256": "4158321d447c3b323f44389661ba6c763b23e26fb9541a786c3b544ad56321d9"
+    },
+    "maps/ad_brk/rock04.bsp": {
+     "bytes": 24600,
+     "sha256": "3c8b114e8ff86b8abcba235230445d885d4c28553d83e153676b2755b0300292"
+    },
+    "maps/ad_brk/rock04.map": {
+     "bytes": 878,
+     "sha256": "229d94f5f5bd81a83be5463035d30c8838d1de092923c3281e7a3a9ec4c7e9aa"
+    },
+    "maps/ad_brk/rock05.bsp": {
+     "bytes": 24254,
+     "sha256": "6bdc990b90f24ddd77034a4cbdd4d7158e05df70e6db5e793ca990a40cd29709"
+    },
+    "maps/ad_brk/rock05.map": {
+     "bytes": 684,
+     "sha256": "708a6ad98116a72ddc862c6c99cbd59342446636c9579a00bd6c34efa1ac855b"
+    },
+    "maps/ad_brk/rock06.bsp": {
+     "bytes": 24462,
+     "sha256": "e2e3688c3cb66e2c9d738d211ad328d86963e1d67881354363696698a07be32b"
+    },
+    "maps/ad_brk/rock06.map": {
+     "bytes": 816,
+     "sha256": "5e1a399ac2e6a179a84004539f15172012db93477e5544309b01ed24cbc59f34"
+    },
+    "maps/ad_brk/rock07.bsp": {
+     "bytes": 24281,
+     "sha256": "ea3569e42b755fd1b9fde50e2740f6aa95d1dabb1911f8a4ab5b1c5028a4e1e3"
+    },
+    "maps/ad_brk/rock07.map": {
+     "bytes": 777,
+     "sha256": "02f61c60083f5007fa9d4d7a38adf2901e928a96adbfeaa7646711f21cc75409"
+    },
+    "maps/ad_brk/rock08.bsp": {
+     "bytes": 25096,
+     "sha256": "5468a365153fc7f160d7e1792b9bc9164b828a51851bd1e9744eb0cf3a7a842d"
+    },
+    "maps/ad_brk/rock08.map": {
+     "bytes": 1060,
+     "sha256": "b285f3a79407366944213b3d8eef311c662bf2eb0cf3df0ee3104e747a3c9150"
+    },
+    "maps/ad_brk/rock09.bsp": {
+     "bytes": 8314,
+     "sha256": "4320c73f55d67e4db7e596614b74b05b0c086cd57186ecaf183c96fca51106bf"
+    },
+    "maps/ad_brk/rock09.map": {
+     "bytes": 913,
+     "sha256": "629fab0d0f8022138ff5d5e573f0e3ab0f75397f120015b3f8a95a297c857911"
+    },
+    "maps/ad_brk/rock10.bsp": {
+     "bytes": 7930,
+     "sha256": "7657ad82fbdeaceb354e04f60fa76cfd3d8a7a819607a413afaa6fc16253a009"
+    },
+    "maps/ad_brk/rock10.map": {
+     "bytes": 780,
+     "sha256": "833bc2f2460f5f5ef444630b398a59974831031e408f986125a5241fab52ba99"
+    },
+    "maps/ad_brk/rock11.bsp": {
+     "bytes": 8565,
+     "sha256": "e19573b67e5dedba499da8f6d0d63ca0e829593417a1ce66e1aeb1fd2b2d1e76"
+    },
+    "maps/ad_brk/rock11.map": {
+     "bytes": 1016,
+     "sha256": "040c31d22159743b28e9f20946b34db390ef15bbe530882342638b9325542801"
+    },
+    "maps/ad_brk/rock12.bsp": {
+     "bytes": 8284,
+     "sha256": "f03a3a0184b2fa8809154754f85d81d30777261714976bdd64340b0549d3ca35"
+    },
+    "maps/ad_brk/rock12.map": {
+     "bytes": 898,
+     "sha256": "b7d2b1bba22ad5b621e699a8233a83d23415e5c6e88fec8e1525a9c84a494bf0"
+    },
+    "maps/ad_brk/rock13.bsp": {
+     "bytes": 7917,
+     "sha256": "6710c24df905df9ede31faf75fdf9a070efbdc471e58a295740092863dcb50fa"
+    },
+    "maps/ad_brk/rock13.map": {
+     "bytes": 680,
+     "sha256": "369735b7ebd630e6407371d3ab7195ef368c2f8d8d3469943b2c5e46b8e24fa5"
+    },
+    "maps/ad_brk/rock14.bsp": {
+     "bytes": 7929,
+     "sha256": "a17329c593e306d1aa4084cd2651983f53258b3e5759443efe3bb3b4daecc5f8"
+    },
+    "maps/ad_brk/rock14.map": {
+     "bytes": 760,
+     "sha256": "f86556e799f3a0240294537aa487526c674486afb7190bb705d72453cade7e68"
+    },
+    "maps/ad_brk/rock15.bsp": {
+     "bytes": 8349,
+     "sha256": "d64f11606da6b94024382315eead25dbfe19c8cc90844f60e755e2bd106c7fc0"
+    },
+    "maps/ad_brk/rock15.map": {
+     "bytes": 929,
+     "sha256": "23defe1bddcc8db664c819b60657fd536b1c44b118299495d42f7c54f740e7b0"
+    },
+    "maps/ad_brk/rock16.bsp": {
+     "bytes": 8280,
+     "sha256": "87e60c650a672c5ffe57b64c7ae3c5413799972a2ca5b73935cb0d1dad16f62c"
+    },
+    "maps/ad_brk/rock16.map": {
+     "bytes": 878,
+     "sha256": "d3616ad7b423be757f6f7873791f4c452a09243b53569347bd36e87f1a942947"
+    },
+    "maps/ad_brk/rock17.bsp": {
+     "bytes": 8340,
+     "sha256": "b317f3432532e6f6f327852fa0c7f546726c8b23c44cfc3e86869d64eb33235c"
+    },
+    "maps/ad_brk/rock17.map": {
+     "bytes": 913,
+     "sha256": "a534b032b611965c86cd81fda18d53186c474d55184f9c4c74cd292b4b207f27"
+    },
+    "maps/ad_brk/rock18.bsp": {
+     "bytes": 7924,
+     "sha256": "e5fc24e393828bdd2c24e3cb341e0c21e81511881e65424293206fe20ff54c4e"
+    },
+    "maps/ad_brk/rock18.map": {
+     "bytes": 701,
+     "sha256": "bf5974bf04067482dde83a2fd73e58a011de04220b32866fa7913e901a0e944c"
+    },
+    "maps/ad_brk/rock19.bsp": {
+     "bytes": 8620,
+     "sha256": "4a1d3e4e37f29438981f419f5a5f076fcf53227a4da544e919061d6c6bf8702e"
+    },
+    "maps/ad_brk/rock19.map": {
+     "bytes": 919,
+     "sha256": "c2626204acbd33e3299c29cd1f8a5279bbe8cd07a621f6b40b14b74b7808f444"
+    },
+    "maps/ad_brk/rock20.bsp": {
+     "bytes": 8785,
+     "sha256": "87bfda54a9f0711eedcefc6d8e691b6cac8123958db03735bd0364067445de69"
+    },
+    "maps/ad_brk/rock20.map": {
+     "bytes": 1118,
+     "sha256": "225800378c3183d5ba423140d7f5d510cf387df3df795fda69294fcb0e4bec4c"
+    },
+    "maps/ad_brk/rock21.bsp": {
+     "bytes": 24244,
+     "sha256": "161b5893f3f413969ced051a7e7aa3d816a1da9f74bffa5d0642830713d83031"
+    },
+    "maps/ad_brk/rock21.map": {
+     "bytes": 674,
+     "sha256": "db86b019086636ec085b3690bc4b252d8bac2443c0ff138a6f3b6c79e522a94b"
+    },
+    "maps/ad_brk/rock22.bsp": {
+     "bytes": 24256,
+     "sha256": "b41069e88c74ef3bfb7c5f2817c31d9d374cd1725b7270b9ac7d93c58dd34a11"
+    },
+    "maps/ad_brk/rock22.map": {
+     "bytes": 753,
+     "sha256": "aa059dd13499512fdda512b68e79068f390d1870726763958a81a54c91aeb254"
+    },
+    "maps/ad_brk/rock23.bsp": {
+     "bytes": 24676,
+     "sha256": "aac7fc5557dd385c52043d206d39d83b48e0b2f6db2822de2060f2a978be4a9d"
+    },
+    "maps/ad_brk/rock23.map": {
+     "bytes": 920,
+     "sha256": "744ccf1456c3b19318289586238b1d36e4968dbfe444f5a489e1d2202f1965d4"
+    },
+    "maps/ad_brk/rock24.bsp": {
+     "bytes": 24612,
+     "sha256": "90553422561893d50030520bcf796da9290933e53570e313d1a423aec01c8ac6"
+    },
+    "maps/ad_brk/rock24.map": {
+     "bytes": 939,
+     "sha256": "3f8f5c2053315577eda81360a9ed9a095e96f7d9a6288eed876400a91bc0922b"
+    },
+    "maps/ad_brk/rock25.bsp": {
+     "bytes": 89516,
+     "sha256": "ef87b49e322fd2a2251f0ee7ecedec32bae141ea7a589769c6fba6a3176da0d4"
+    },
+    "maps/ad_brk/rock25.map": {
+     "bytes": 737,
+     "sha256": "3cad88a720acc4d7db1666ab0d865e013717776a256c999e1b417690679f4f0b"
+    },
+    "maps/ad_brk/rock26.bsp": {
+     "bytes": 89532,
+     "sha256": "a6f46aa8183937dfe19eb1cfde621bac8f3f08721effcbbd195ba251b3b1467f"
+    },
+    "maps/ad_brk/rock26.map": {
+     "bytes": 823,
+     "sha256": "27c411424182d3e6d611f2eff2dd9a7c75ef2135f2019d4aca40b2dee2d134b5"
+    },
+    "maps/ad_brk/rock27.bsp": {
+     "bytes": 89952,
+     "sha256": "f55dc66117c856efee1dae5e311492f2aae2839ef4588af45ac0818307ad564c"
+    },
+    "maps/ad_brk/rock27.map": {
+     "bytes": 1004,
+     "sha256": "7368f6cbd051aa3ac71237b5c8d3da2ef73fc3017024ef42af6ac8af9ddc1139"
+    },
+    "maps/ad_brk/rock28.bsp": {
+     "bytes": 89880,
+     "sha256": "2132d7f311c90f8c43b4630a55f7fa0b15141fa0e9c26c0309c8023437377961"
+    },
+    "maps/ad_brk/rock28.map": {
+     "bytes": 947,
+     "sha256": "b1571df2e370ca2d51f19b3608726552f10a6f6da64f69929a2ea2c1884e51dc"
+    },
+    "maps/ad_brk/rock29.bsp": {
+     "bytes": 89516,
+     "sha256": "a179ac329768d445bfbc36bb9c3e47ce3c7506c31337730a93c9a58f96ea5399"
+    },
+    "maps/ad_brk/rock29.map": {
+     "bytes": 737,
+     "sha256": "260d08f376c81869c1f9a0c0cfd677bded9022f79bbe4e607d12128b7ad7c746"
+    },
+    "maps/ad_brk/rock30.bsp": {
+     "bytes": 89532,
+     "sha256": "febc6ed2ec191f8dcbae1ee9df9d13bbd8fff830e28e051236fa24fd211829ee"
+    },
+    "maps/ad_brk/rock30.map": {
+     "bytes": 823,
+     "sha256": "da6a3224e060f6413f70ac9f6f25bf96f3784f690084d602d63805dc8b43e7e8"
+    },
+    "maps/ad_brk/rock31.bsp": {
+     "bytes": 89952,
+     "sha256": "7a38ed8a7dd80c2f2dab17342bfdde51300c9225f4e93be78ca9b63d3a7f1e99"
+    },
+    "maps/ad_brk/rock31.map": {
+     "bytes": 1004,
+     "sha256": "3fb04740e6da6c00670536ccbcb92e7a9a5b5e3072e78af96d6dd5c79d39f984"
+    },
+    "maps/ad_brk/rock32.bsp": {
+     "bytes": 89880,
+     "sha256": "41789fbb095ef6d7b09ba6f50bea0503f73e612808f37bbb71f4a7e9fea00ae2"
+    },
+    "maps/ad_brk/rock32.map": {
+     "bytes": 947,
+     "sha256": "37e272ad3f235bb182666e46d3b087bee4ec23ebdc716647c5b0ffb671a9ee1d"
+    },
+    "maps/ad_brk/rock33.bsp": {
+     "bytes": 7916,
+     "sha256": "af3e313ba1c7013b7bd2234e9988a2b6bc451d123e7d6dab1692ae0727d40bec"
+    },
+    "maps/ad_brk/rock33.map": {
+     "bytes": 683,
+     "sha256": "de08059147e865be402e6dac4c6d8a0bea1de05bb65cf0455153386afdde2bdb"
+    },
+    "maps/ad_brk/rock34.bsp": {
+     "bytes": 7932,
+     "sha256": "392125c9afaf18c3084c1b13a0a55dcda7e2294da37f84fb73983826271dea27"
+    },
+    "maps/ad_brk/rock34.map": {
+     "bytes": 763,
+     "sha256": "dc402e2573ee3e94f3ed96274d5b6f8d0177d9745716ea96d0ffce8e0be5c943"
+    },
+    "maps/ad_brk/rock35.bsp": {
+     "bytes": 8352,
+     "sha256": "0352c35aa723330a3c05126d24a8e6b84403bf8b71d406f3fa5a2ff3fc0da39a"
+    },
+    "maps/ad_brk/rock35.map": {
+     "bytes": 932,
+     "sha256": "9841ed50187bbdfb3a7122d3b0890b0245d64dd4919485686fdf5ce61bdae3e6"
+    },
+    "maps/ad_brk/rock36.bsp": {
+     "bytes": 8280,
+     "sha256": "f1871698ef7597c51fed5d54b582df2ea70cf72e2fa7db643182e59f7e7f6ca7"
+    },
+    "maps/ad_brk/rock36.map": {
+     "bytes": 881,
+     "sha256": "974aaec9003dd3e1457582b1f770d67e07fc8e9d11a6b639981fbb753c6a6484"
+    },
+    "maps/ad_brk/sandstone01.bsp": {
+     "bytes": 24239,
+     "sha256": "ebb374110d88805e1b0b45cdaf33e5e570a9092da549facaf9f5ddcd995eb607"
+    },
+    "maps/ad_brk/sandstone01.map": {
+     "bytes": 702,
+     "sha256": "9ea9ab63b8c6a2d90fba029c4d4b768beb0d4342cf255bb5005185b61b1bcfd2"
+    },
+    "maps/ad_brk/sandstone02.bsp": {
+     "bytes": 24399,
+     "sha256": "2fa799b0a08ca2fdd9bef3ecb9d6ea4c16e8f66181d29913cdc5a9205bafe98f"
+    },
+    "maps/ad_brk/sandstone02.map": {
+     "bytes": 842,
+     "sha256": "5228b0a958ef571f33838366ef1f2b69a10f6e0c53a3269dba683b5326a95e5f"
+    },
+    "maps/ad_brk/sandstone03.bsp": {
+     "bytes": 24607,
+     "sha256": "671b8f740ba9deaeac681c703f87d61c2a3f8107d0f72b8fd636c53436555110"
+    },
+    "maps/ad_brk/sandstone03.map": {
+     "bytes": 914,
+     "sha256": "7523ff7908eb3e47154155d0448fa05d4d9b6081525069a131e7d44ea9b13c0c"
+    },
+    "maps/ad_brk/sandstone04.bsp": {
+     "bytes": 24379,
+     "sha256": "56bda0f4bf4958dc243fa9b4ab79e9e3bd6fad5f794af7beb024a6cbe7f9a0cb"
+    },
+    "maps/ad_brk/sandstone04.map": {
+     "bytes": 798,
+     "sha256": "d01584bd00868a0a69ae7513834f776566fce273d8919d9c78d0bdafbb07a799"
+    },
+    "maps/ad_brk/wood01.bsp": {
+     "bytes": 7553,
+     "sha256": "c1764181bae4852804097143fe16a4c230bd5886574125cb33d5349bbc63dc21"
+    },
+    "maps/ad_brk/wood01.map": {
+     "bytes": 1040,
+     "sha256": "05f1ebaa57c4b55e6c3da9c5440c180aa96c719f9cddc80c780ed11415ad6bd7"
+    },
+    "maps/ad_brk/wood02.bsp": {
+     "bytes": 7079,
+     "sha256": "26fc67e4e47eae3a13a449d876deabe35d50aa1b70e63060d27cb365eadecbe0"
+    },
+    "maps/ad_brk/wood02.map": {
+     "bytes": 521,
+     "sha256": "8dee7615c9e9696420331668edeccd9ff1dd874ad844e289f049391be5e61345"
+    },
+    "maps/ad_brk/wood03.bsp": {
+     "bytes": 7135,
+     "sha256": "ca17df0f61a11bd37749587e361ca404f2e5bec07c248491d86c07803fafb732"
+    },
+    "maps/ad_brk/wood03.map": {
+     "bytes": 522,
+     "sha256": "0fb4cdb1ffeda8c97026d40842d5fcb0beced0f84dae4b10a8284044875cf0c2"
+    },
+    "maps/ad_brk/wood04.bsp": {
+     "bytes": 7951,
+     "sha256": "e2d9f42bf3256be2dd38648dbd962458bdad3992b33e8d688e42a0acba5d7c3f"
+    },
+    "maps/ad_brk/wood04.map": {
+     "bytes": 912,
+     "sha256": "071556b1cac3bd95a176762302e6a60ddbbfb07cf6c9e4b2f8cf2e259e23402a"
+    },
+    "maps/ad_brk/wood05.bsp": {
+     "bytes": 7553,
+     "sha256": "5bdb275ae2c39b41d71a17244681cda9cc2008df088f4da73f547a8bf1966069"
+    },
+    "maps/ad_brk/wood05.map": {
+     "bytes": 1040,
+     "sha256": "ada27de98972730676a2d040fd284893fabfe71acd6fcbce1f2ba12da7d14632"
+    },
+    "maps/ad_brk/wood06.bsp": {
+     "bytes": 7079,
+     "sha256": "f27b0f1970f6065255b5f7a27abfc4e749f40321f6fdef4c3f9ac6bb64d46098"
+    },
+    "maps/ad_brk/wood06.map": {
+     "bytes": 521,
+     "sha256": "17c93b1c1c65a7507d794013078a1d12a67c3a24ae7202739fcd8a1108d52419"
+    },
+    "maps/ad_brk/wood07.bsp": {
+     "bytes": 7135,
+     "sha256": "8e07e7e5f5b641c644d28c9c4026efc95aa50345074f5c42acd39a3b94261344"
+    },
+    "maps/ad_brk/wood07.map": {
+     "bytes": 522,
+     "sha256": "55f1bb5f18ed30f28ac88349aee9ea5563b1e938bafebffb25c9ab5a1c918b33"
+    },
+    "maps/ad_brk/wood08.bsp": {
+     "bytes": 7951,
+     "sha256": "d26222458ba6e7fee06670021e64c1661d99a8c098581936af943891c9583858"
+    },
+    "maps/ad_brk/wood08.map": {
+     "bytes": 912,
+     "sha256": "2582987129d34bbee73594a236c4c09ce6ae1092eec649ef3957b892e125624c"
+    },
+    "maps/ad_brk/wood09.bsp": {
+     "bytes": 7282,
+     "sha256": "2735e78b25b0feb640f27eddae47104b0acba9f017c6d025e3a8dbdfcc755778"
+    },
+    "maps/ad_brk/wood09.map": {
+     "bytes": 541,
+     "sha256": "84d9789b4d79b41347fd082b0ab75c016553c03bfb952cf4b9c7dd18c85944ce"
+    },
+    "maps/ad_brk/wood10.bsp": {
+     "bytes": 7214,
+     "sha256": "43b59e9b0cb02fb1ac15afb5c782e71b4ce0661db295949b5188cc5accd1733a"
+    },
+    "maps/ad_brk/wood10.map": {
+     "bytes": 533,
+     "sha256": "365f949e19e2606cf2d7a354c3e4368a5e17c3eef94e2558ed9cef276e987d35"
+    },
+    "maps/ad_brk/wood11.bsp": {
+     "bytes": 7196,
+     "sha256": "cce8b312c4be49810f4cf90f0dcdeb1a82dfa623de1ba44c55ec83475f9e9e49"
+    },
+    "maps/ad_brk/wood11.map": {
+     "bytes": 542,
+     "sha256": "790cd93cb271402698ad7f005b908847fddbb30d3c8c3d11fa8c2f327ca8e48e"
+    },
+    "maps/ad_brk/wood12.bsp": {
+     "bytes": 7978,
+     "sha256": "6a227f92bf3b6f1120efd6179bfb3de977e4be2e59495c5d757cbe1c835e3f03"
+    },
+    "maps/ad_brk/wood12.map": {
+     "bytes": 986,
+     "sha256": "01ed96a5ce6545b334dfac7dc0196472dd6c06df09ed557cec7dc820d35c1132"
+    },
+    "maps/ad_brk/wood13.bsp": {
+     "bytes": 7284,
+     "sha256": "09325ca10ebcfeb88f688c9f4521259c3c3426e9befc06c99ba405c7e20595c9"
+    },
+    "maps/ad_brk/wood13.map": {
+     "bytes": 526,
+     "sha256": "b16b33b2a46b72a4ee235674780298eac0ed27631def07a28058a775aba7078e"
+    },
+    "maps/ad_brk/wood14.bsp": {
+     "bytes": 7216,
+     "sha256": "4c9dc5afd7b51119e5c22ad36eb77d07881c454ff47ed060521172cfc3950e2c"
+    },
+    "maps/ad_brk/wood14.map": {
+     "bytes": 518,
+     "sha256": "41b51f20630df3c046ed9ca0f7d97ca403ce8c1487074fc80caf603e763e6ac1"
+    },
+    "maps/ad_brk/wood15.bsp": {
+     "bytes": 7196,
+     "sha256": "373f6e5c5da44b7c8d1a01fb701f074bbcfc52d21bb080dd04e986ffe9e1088c"
+    },
+    "maps/ad_brk/wood15.map": {
+     "bytes": 527,
+     "sha256": "eb07eae6f0afdb4b03af57bcb589e3b385632912f12d4c55257b3031270f0421"
+    },
+    "maps/ad_brk/wood16.bsp": {
+     "bytes": 7612,
+     "sha256": "05959d3486eb43afc8959f6923156a1a83ead4dad544f8caf90ba0e1c7e2bc80"
+    },
+    "maps/ad_brk/wood16.map": {
+     "bytes": 953,
+     "sha256": "c7e804e781c95336cc91a50bc246baf4fda7172ecf36ccf24f02c5f919710ab3"
+    },
+    "maps/base_brk/baserub1.bsp": {
+     "bytes": 23612,
+     "sha256": "b5320b798366587d20ab541af06babd9575e89870fb003d56a17fdf2f7f22b0c"
+    },
+    "maps/base_brk/baserub1.map": {
+     "bytes": 637,
+     "sha256": "0a5357fb3b12d9286b4d9e6e54316cfd0a33f9fda4c661b8fcd1c461d06ae73f"
+    },
+    "maps/base_brk/bz8_brk.bsp": {
+     "bytes": 12808,
+     "sha256": "219e4371cd0b22d690c6e6660ca2fca3b526618d4ccd9f37799135d2dc6dea02"
+    },
+    "maps/base_brk/bz8_brk.map": {
+     "bytes": 692,
+     "sha256": "fae1ac45d74b2a9f482eb034e0838fe5914affb57204c5215d97ebaf7199e5c8"
+    },
+    "maps/base_brk/crate_r1.bsp": {
+     "bytes": 29110,
+     "sha256": "5dd3afab4a3ad5cf4466e272324e4afad5075ca2e662cc8b1932e277a2db73a2"
+    },
+    "maps/base_brk/crate_r1.map": {
+     "bytes": 664,
+     "sha256": "ee7ce39ec0650d3cbde924b99efc91ba884778db11a961037d4493bf587fa33e"
+    },
+    "maps/base_brk/explodebox_1.bsp": {
+     "bytes": 7707,
+     "sha256": "28bfab37e5cbe722348b753de3bd9f66f47f4a9f5b80bd5c5c1659e6eae7e6c4"
+    },
+    "maps/base_brk/explodebox_1.map": {
+     "bytes": 544,
+     "sha256": "96376f1185f158bf69d6bb0c5baf347bbad27f0ccd6fccd3096da6dd7f89540b"
+    },
+    "maps/base_brk/explodebox_2.bsp": {
+     "bytes": 7107,
+     "sha256": "59d5ba28bc049f691bf28d421327e4aecf5eedaec46599d58328f0074ce0934f"
+    },
+    "maps/base_brk/explodebox_2.map": {
+     "bytes": 375,
+     "sha256": "f906dbea8598f0290af9e224a70eb71f26f3c93c10e922b2fade3f1c63e4ddd5"
+    },
+    "maps/base_brk/explodebox_3.bsp": {
+     "bytes": 10449,
+     "sha256": "0daebb987f48b5dde145998e748ab2eecf63ec69318a6b752924e4cfb6639261"
+    },
+    "maps/base_brk/explodebox_3.map": {
+     "bytes": 1698,
+     "sha256": "538e12e7706df3b8f539bf2473e7517e737657380137de1655193843210dbf3f"
+    },
+    "maps/base_brk/glass01.bsp": {
+     "bytes": 7427,
+     "sha256": "bf3f3938ab3596b6095fb58f66c0a36042e5950169dbb86b1cf3cb9076fd5bdd"
+    },
+    "maps/base_brk/glass01.map": {
+     "bytes": 907,
+     "sha256": "6f47c3ffec4cb28d3447dbf96f0b3d6e4264accd31e10b68ad83b3e30e4e32a7"
+    },
+    "maps/base_brk/grate_r1.bsp": {
+     "bytes": 32796,
+     "sha256": "a8eac6a49f8c49c4f9f1b443c9ca5c6a5f8d03d30ce240daaeee8d150f9c5067"
+    },
+    "maps/base_brk/grate_r1.map": {
+     "bytes": 2106,
+     "sha256": "e5cac190d45b0d14901947e489622680d1b9436955b18e2a0e8cb2f92e9aa011"
+    },
+    "maps/base_brk/pbt04.bsp": {
+     "bytes": 18286,
+     "sha256": "0a3321e606857ebb78d047be51c92036b53175dc392c021891cdeabd28597c3c"
+    },
+    "maps/base_brk/pbt04.map": {
+     "bytes": 699,
+     "sha256": "a8b2d3feef56b8cad384a88a9646b596d21017cb9d26278c0b3585ef589b578d"
+    },
+    "maps/base_brk/phk_03brk.bsp": {
+     "bytes": 90417,
+     "sha256": "46efed3a00ce885798ca568563a04472200359c6111682e91fc701c37d8df143"
+    },
+    "maps/base_brk/phk_03brk.map": {
+     "bytes": 1509,
+     "sha256": "29549a0e23b3651110beae8f8697c85e1e3eeb8752dcc8c253a2756e11189209"
+    },
+    "maps/base_brk/rock_sw01.bsp": {
+     "bytes": 8843,
+     "sha256": "a3acc4f42ca89efb30d5f9d7ed7c694d59ab6003bd3c665cfa4db480550fd92d"
+    },
+    "maps/base_brk/rock_sw02.bsp": {
+     "bytes": 9179,
+     "sha256": "4b3d68587a69daa68093d32195a786e8040fed763855acb94f50d02875a8ec44"
+    },
+    "maps/base_brk/rock_sw03.bsp": {
+     "bytes": 9766,
+     "sha256": "59d2841166f7ecb216df970963b3e425da20566f2fb56a7e5472f4e3c9fcfb24"
+    },
+    "maps/base_brk/sfloor4_2.bsp": {
+     "bytes": 7431,
+     "sha256": "d4f7ee45638e0f338c96cf43779410a112bb10be26a200e24187749a80b01332"
+    },
+    "maps/base_brk/sfloor4_2.map": {
+     "bytes": 833,
+     "sha256": "f285b9a96b32420f24bccb267b268e65afd50dd03fb106fad90783aa5d82c1d4"
+    },
+    "maps/base_brk/tech10_2d1.bsp": {
+     "bytes": 45558,
+     "sha256": "272aa49909de27f7b4722848497e5da38aa50b7bef17ef2ee81a1b1240c1b8b2"
+    },
+    "maps/base_brk/tech10_2d1.map": {
+     "bytes": 740,
+     "sha256": "a3766904240cbe7603e967eb3ebdd0dc895b035f0db8758a6ad217749a332904"
+    },
+    "maps/base_brk/tech10_2d2.bsp": {
+     "bytes": 45552,
+     "sha256": "71e5e52660e4aa84f56aa7b51bad024384acb69699bcec431ae3fe6c8d16fc42"
+    },
+    "maps/base_brk/tech10_2d2.map": {
+     "bytes": 733,
+     "sha256": "9d6c4dae495d96bf4b2bbf5f7e01900f16274173c63eb2e4acfb8f8e757a399f"
+    },
+    "maps/medieval_brk/ad_column1.bsp": {
+     "bytes": 14800,
+     "sha256": "f94c99425b3987ebb9eea08dd8c1b3c0e0215cc8afcd1099f7283324ff566712"
+    },
+    "maps/medieval_brk/ad_column1.lit": {
+     "bytes": 578,
+     "sha256": "c30b5af83ab23db6614ad13aff712a15971a6b35ae29ddd49f0cd3da1c1f4919"
+    },
+    "maps/medieval_brk/ad_column1.map": {
+     "bytes": 1541,
+     "sha256": "d71326b819e902d9a32f4a1961565f6ebb10d90069ba2ae0dc0be381a4c1b764"
+    },
+    "maps/medieval_brk/ad_rock1.bsp": {
+     "bytes": 352852,
+     "sha256": "9333d2d2d848e3a4490634aa4f1cc1ee3281c57ac9a498c85b043e5856ce2578"
+    },
+    "maps/medieval_brk/ad_rock1.lit": {
+     "bytes": 920,
+     "sha256": "6d2b33cbd7b3ce1a35c25a6e006a0786fe0bd0ea8be34b1911e2663ac33ea910"
+    },
+    "maps/medieval_brk/ad_rock1.map": {
+     "bytes": 2163,
+     "sha256": "d00049f1c1bdf04d98e768ece39b7d7442e34b719ec991e5715df588d6493d8b"
+    },
+    "maps/medieval_brk/ad_rock2.bsp": {
+     "bytes": 14728,
+     "sha256": "52675efa81ecae4bb87524c97148d7da60916f0e0dc3c65e99b73745aea70fec"
+    },
+    "maps/medieval_brk/ad_rock2.lit": {
+     "bytes": 383,
+     "sha256": "306d2df8cbd9d7ad755fe7e4a6734e0089b38eefa2e2e4fccacfb68c96dd8d90"
+    },
+    "maps/medieval_brk/ad_rock2.map": {
+     "bytes": 1528,
+     "sha256": "891f208f7fdae3fcf1defe7a4cdcda7a6084fbde663ed4e2ab015af18911cb96"
+    },
+    "maps/medieval_brk/ad_rock3.bsp": {
+     "bytes": 352160,
+     "sha256": "bf041a139ed9be638cd1c548139fffca3ceeddefdad2334fcc2639018833110a"
+    },
+    "maps/medieval_brk/ad_rock3.lit": {
+     "bytes": 356,
+     "sha256": "19a61c05d08dd726a9d00174eb3eb1dbdd16da3e0e62ab93d691620aa71add83"
+    },
+    "maps/medieval_brk/ad_rock3.map": {
+     "bytes": 1878,
+     "sha256": "d0049b763f7fd8f25b2176984341421d704f9b50571b24168c60889fdbad5e20"
+    },
+    "maps/medieval_brk/ad_rock4.bsp": {
+     "bytes": 352704,
+     "sha256": "578e7d2dc0eff7bf5ac21b04919d1e137296824182d4809991a27a83addeba75"
+    },
+    "maps/medieval_brk/ad_rock4.lit": {
+     "bytes": 311,
+     "sha256": "3af5d5c9613dd5a1fa09a40b02891bf7153892db8505528b7d3315ce251bfff7"
+    },
+    "maps/medieval_brk/ad_rock4.map": {
+     "bytes": 1889,
+     "sha256": "472f41679eedc00096e8042935ad5287f4598940ef294b8175cccd196dcb6f86"
+    },
+    "maps/medieval_brk/az_ice05.bsp": {
+     "bytes": 98664,
+     "sha256": "b8b2aa063250f6dcc388ead43ff66133c8fa14b1c30afa17c2fce8f2b2c9fd81"
+    },
+    "maps/medieval_brk/az_ice05.lit": {
+     "bytes": 617,
+     "sha256": "e3e8aa044b60a26d643ff87937f83602cdffcebb948ea7ae22148e7952faa18b"
+    },
+    "maps/medieval_brk/az_ice05.map": {
+     "bytes": 3094,
+     "sha256": "dbca0fea0a986137f9b4a6fbb916cf3de830ba4a60738830cc6e1bd554f561f1"
+    },
+    "maps/medieval_brk/az_kbr1.bsp": {
+     "bytes": 7476,
+     "sha256": "2a2cd33b87f511d4c7fc25a812c632fb07c385b372e89fa900fd0f8ce8146076"
+    },
+    "maps/medieval_brk/az_kbr1.lit": {
+     "bytes": 92,
+     "sha256": "580ff7adf91b63bcd7f35e27059295b0a5fc404468e32e5d5f3323b5a822fb27"
+    },
+    "maps/medieval_brk/az_kbr1.map": {
+     "bytes": 863,
+     "sha256": "3b9d9842f17fb140b23337b452cfc8d49151410640384868a0003bd472dd0d5c"
+    },
+    "maps/medieval_brk/az_kbr1.pts": {
+     "bytes": 178,
+     "sha256": "22cf782552b8a3da946cfa0fa044cffd08f2b0ab50e588c9b68d89a373f026b0"
+    },
+    "maps/medieval_brk/az_kjw1.bsp": {
+     "bytes": 9424,
+     "sha256": "06f271813935ecb90a425d6c943bd53b207fb9d370ec42bb1228af92fe4413d1"
+    },
+    "maps/medieval_brk/az_kjw1.lit": {
+     "bytes": 380,
+     "sha256": "30e6270550b5a78bfaa31df0c6e477d6980eefd380abc2e2aaf7003dbe544f77"
+    },
+    "maps/medieval_brk/az_kjw1.map": {
+     "bytes": 1825,
+     "sha256": "61e8f8f45b2fb0e0766b125bae58b54b36cb45b6d856c7c06814681f52eb91aa"
+    },
+    "maps/medieval_brk/az_kjw1.pts": {
+     "bytes": 120,
+     "sha256": "f7d0f45d90befed57df8dd476bcd10293481eb932925853e3fdbc93a55991a49"
+    },
+    "maps/medieval_brk/az_rtex01.bsp": {
+     "bytes": 97932,
+     "sha256": "ce36fbfdd6f46f5aa7740598689fb2c7de50fa58adda9d4a8a3023ad31194367"
+    },
+    "maps/medieval_brk/az_rtex01.lit": {
+     "bytes": 692,
+     "sha256": "5fe28d309679e9871f14a9c3833184c9ad711fa2bd93adc330a34fd599032a6d"
+    },
+    "maps/medieval_brk/az_rtex01.map": {
+     "bytes": 2875,
+     "sha256": "6cc8f787b54565b3c9dffe9eec20c44d66a68b12fd555bad65bb25f03a2aa7e9"
+    },
+    "maps/medieval_brk/az_wood1.bsp": {
+     "bytes": 7560,
+     "sha256": "373c0b96905055b6b036272c954d7eaf3557d79d62b056ab9a472fb0cd27de83"
+    },
+    "maps/medieval_brk/az_wood1.lit": {
+     "bytes": 176,
+     "sha256": "67ce559200158ce198e5a93a94dd4a440ae607fedc5b3093c288049ce5f50151"
+    },
+    "maps/medieval_brk/az_wood1.map": {
+     "bytes": 950,
+     "sha256": "4fb7eae852ba72528b34d6a0947497eeeab1e1307aa1c4be552628432007c86e"
+    },
+    "maps/medieval_brk/azr1.bsp": {
+     "bytes": 13842,
+     "sha256": "e00518c5ad3beee852a6135184423d4ca985b17b2f1d2cfebc60e82f91582f26"
+    },
+    "maps/medieval_brk/azr1.map": {
+     "bytes": 1193,
+     "sha256": "ef3affe9788b130826f2b1632b5461eaaf15d630587c12c5a875f6042b0ae99c"
+    },
+    "maps/medieval_brk/azr2.bsp": {
+     "bytes": 13571,
+     "sha256": "687097f4773430ca297db9c1d8133b035c8ca1e5d574943a4caa34eef262f003"
+    },
+    "maps/medieval_brk/azr2.map": {
+     "bytes": 1319,
+     "sha256": "22b2084665b2882c976da1dc840a19b151cd44daa524955ddab9ec64e9c3233e"
+    },
+    "maps/medieval_brk/azr3.bsp": {
+     "bytes": 13571,
+     "sha256": "187a6607641c00aa6ee662af52f1b2899d5ca606e469408dd2c94d67dd2ab465"
+    },
+    "maps/medieval_brk/azr3.map": {
+     "bytes": 1338,
+     "sha256": "5e551a8ebefc386b1336e814a44e29ae6781e6da5bc929cb232674853c46a143"
+    },
+    "maps/medieval_brk/booksh1w_brk1.bsp": {
+     "bytes": 23869,
+     "sha256": "dbc342e95245a12598aade308195a3234829225944692c45c8fec792d03f17c3"
+    },
+    "maps/medieval_brk/booksh1w_brk1.map": {
+     "bytes": 793,
+     "sha256": "a9d2fe494267551f3d1638c7963bab47d292be250417f78286b39059af836af5"
+    },
+    "maps/medieval_brk/booksh1w_brk2.bsp": {
+     "bytes": 23663,
+     "sha256": "4b8cd15ae7812d581064800bbcf64cab62c3d5ecfb03c23ff2b498694a0cb708"
+    },
+    "maps/medieval_brk/booksh1w_brk2.map": {
+     "bytes": 661,
+     "sha256": "19c13935f0b045fadd9c739680de7155f0e4d29c86ef3e6950d07f265b1ef1a3"
+    },
+    "maps/medieval_brk/booksh1w_brk3.bsp": {
+     "bytes": 23700,
+     "sha256": "1fc3c7a685f5662779f4c6ad0fb02099396504dcf55eef09474183aff69861c1"
+    },
+    "maps/medieval_brk/booksh1w_brk3.map": {
+     "bytes": 746,
+     "sha256": "bd10960b3af925cf2a33bb0629d1a522de5f54ec05938b36378871fd7de0b9f3"
+    },
+    "maps/medieval_brk/booksh1w_brk5.bsp": {
+     "bytes": 23639,
+     "sha256": "851a02aced76ba77894ba744c5c781ff350a42b93216e095f75938fc95ee39a8"
+    },
+    "maps/medieval_brk/booksh1w_brk5.map": {
+     "bytes": 759,
+     "sha256": "c92ec0ad3d3a5c6588557b5f3c9c000cd1c141a4d9c3b35333d859e75c677568"
+    },
+    "maps/medieval_brk/brick2_4brk1.bsp": {
+     "bytes": 9004,
+     "sha256": "86fb182b011385225d5be8b2a2ba0763286a5a2a5880fdda6fc238d8e6a5212f"
+    },
+    "maps/medieval_brk/brick2_4brk1.map": {
+     "bytes": 1375,
+     "sha256": "208cf3d2a51b0aa4a45cd237786a9303b70a63a85e991a7f8675634bea6295ed"
+    },
+    "maps/medieval_brk/brick2_4brk2.bsp": {
+     "bytes": 7265,
+     "sha256": "151471ef184c02141716225e4403e97a69190bd8a3e9645cf2d52aeb5dce591d"
+    },
+    "maps/medieval_brk/brick2_4brk2.map": {
+     "bytes": 603,
+     "sha256": "cdd5762f851cec464b27e9bfc91c0eab8cb26e69a8b050ac1bd9b0eb662dbf7b"
+    },
+    "maps/medieval_brk/brick2_brk2.bsp": {
+     "bytes": 25323,
+     "sha256": "0d8c4dc3202bcc9f26dfd42ca555b99d0010c63b977cd058646a8e8ad4486eea"
+    },
+    "maps/medieval_brk/brick2_brk2.map": {
+     "bytes": 1378,
+     "sha256": "daeae48ab2f6fca712da2413b65c80c6a944e537571def2d153976b0175d8768"
+    },
+    "maps/medieval_brk/brick2_brk3.bsp": {
+     "bytes": 24310,
+     "sha256": "5f94a5e271bb5b921e4534be8690f005bc258e484cb842a6ead0af9aac29fcfb"
+    },
+    "maps/medieval_brk/brick2_brk3.map": {
+     "bytes": 905,
+     "sha256": "1639469c5fe31540811a8bb95d959844d200102cd19f60d1d5e9c3472477e2d2"
+    },
+    "maps/medieval_brk/brick2_brk4.bsp": {
+     "bytes": 23548,
+     "sha256": "e2049e826c103f2afbb5d0a4b69d45089d0bdcf6bd60646d6ae79c99e9a9a976"
+    },
+    "maps/medieval_brk/brick2_brk4.map": {
+     "bytes": 582,
+     "sha256": "b3528f92f4ecf8099a7bfbf3285f21312c501536b66e02b566a7e38474aa608c"
+    },
+    "maps/medieval_brk/city2_3d1.bsp": {
+     "bytes": 7358,
+     "sha256": "efc80ba0aab1284e2bcec652cc3a2748890c45d6905335f61483eab2851f7c81"
+    },
+    "maps/medieval_brk/city2_3d1.map": {
+     "bytes": 739,
+     "sha256": "ff9c2ebe0034d188443e3a72753d4ecad2a69706a4a06c114f9147f507d10b30"
+    },
+    "maps/medieval_brk/city2_3rd.bsp": {
+     "bytes": 7156,
+     "sha256": "6146e0e5961857308f2ef550213ec647ad810a97359d0946cc07f610e0f03006"
+    },
+    "maps/medieval_brk/city4_2_brk1.bsp": {
+     "bytes": 7435,
+     "sha256": "42a4cbd73804a8458a8369fdbd19ee6b3b4597b18583c242bf77b0122ddc9c1a"
+    },
+    "maps/medieval_brk/city4_2_brk1.map": {
+     "bytes": 648,
+     "sha256": "50b744f4af85aa3c0158ae0330808840710c7ee95c1bda8155cb81b4b247fc74"
+    },
+    "maps/medieval_brk/city4_2_brk2.bsp": {
+     "bytes": 7179,
+     "sha256": "cc2ddcb8877dc1b49ec2c408d6b869a35dd7b6590782525af567905d75a3ada0"
+    },
+    "maps/medieval_brk/city4_2_brk2.map": {
+     "bytes": 520,
+     "sha256": "e9309b8ec24126fd952443ae6bee72df46ba04fb4d0925b33d41c603af9ac5b3"
+    },
+    "maps/medieval_brk/city4_2_brk3.bsp": {
+     "bytes": 10009,
+     "sha256": "7f9a27098101f70090c3aff7fd6731effd2750e8c2b7fdbbb0a9f3146be94045"
+    },
+    "maps/medieval_brk/city4_2_brk3.map": {
+     "bytes": 1575,
+     "sha256": "c352d889a3bed731b7c54e38d7ed35e6fa860d2f6f69eb91319f4043423d7aa8"
+    },
+    "maps/medieval_brk/city6_8brk1.bsp": {
+     "bytes": 7187,
+     "sha256": "bcf4b2815c96308ffc1ab3467ac8b2dd4c25be47d618fd82536ba83bf74a05fc"
+    },
+    "maps/medieval_brk/city6_8brk1.map": {
+     "bytes": 529,
+     "sha256": "2db1be71ce1b1e8bf1e8a5c4c7f2802345aa19c281fd43f2b18d205cbd06bfca"
+    },
+    "maps/medieval_brk/city6_8brk2.bsp": {
+     "bytes": 7298,
+     "sha256": "3b7fd08defa832be1c3f3e40efc6d54d13af6714180be810f6527188f332fbff"
+    },
+    "maps/medieval_brk/city6_8brk2.map": {
+     "bytes": 611,
+     "sha256": "ed29b0773cb700d4b8212f9e28b23edac2d212f469b4a1406538df2b066fcbb2"
+    },
+    "maps/medieval_brk/floor015_brk1.bsp": {
+     "bytes": 12862,
+     "sha256": "5bfae9b09777fad7f26f80b5acc27e187e2259ac5c79ad32ab2a30d154e5889b"
+    },
+    "maps/medieval_brk/floor015_brk1.lit": {
+     "bytes": 179,
+     "sha256": "5d64872b2341768efce6c27686555200246e03d346a2e15089e002d53b1b348f"
+    },
+    "maps/medieval_brk/floor015_brk1.map": {
+     "bytes": 827,
+     "sha256": "08f5b26ee0ebb26416e6a1ed660e197b1ea113a553f5c7a1d26a6070b5cbdac8"
+    },
+    "maps/medieval_brk/floor015_brk2.bsp": {
+     "bytes": 12861,
+     "sha256": "377b50dac34c3789fe8a7bcf6a5b3cedda0f3ba91225135ffc9a2f41abe41e35"
+    },
+    "maps/medieval_brk/floor015_brk2.lit": {
+     "bytes": 188,
+     "sha256": "402bfba12b94cd1b3a40f1052830d4e4fa3b4cb103b196c089f4965e94766bd5"
+    },
+    "maps/medieval_brk/floor015_brk2.map": {
+     "bytes": 828,
+     "sha256": "a45245e0f19cc98f29bcc88c9173118b65058d25ff1c043aaca876353bc67531"
+    },
+    "maps/medieval_brk/floor015_brk3.bsp": {
+     "bytes": 13185,
+     "sha256": "52e2b8d426e479bffc8d518a4d8aa5d5a5dc437dbd761c7074992838ccfd070b"
+    },
+    "maps/medieval_brk/floor015_brk3.lit": {
+     "bytes": 218,
+     "sha256": "dabacc9c3ffdc3bae8c008bedfb683babaca23f6e5b0ca5e35b9c39f9d86f402"
+    },
+    "maps/medieval_brk/floor015_brk3.map": {
+     "bytes": 1078,
+     "sha256": "5235ba02c52ba6dc678f052e4efbad43b9f7d63f858c5f732519f6436246733d"
+    },
+    "maps/medieval_brk/plat_brk.bsp": {
+     "bytes": 59896,
+     "sha256": "367ec651b3cded1ecdf22305a3b48490d3df3078d556d4c7fadfb392ae12ad33"
+    },
+    "maps/medieval_brk/plat_brk.map": {
+     "bytes": 2052,
+     "sha256": "fe52fffba97e8df9acfe4607c9b08d9eb5f4559b44d8c0f6fdbd3af6a0cbf8d6"
+    },
+    "maps/medieval_brk/rock_sw01.bsp": {
+     "bytes": 8843,
+     "sha256": "a3acc4f42ca89efb30d5f9d7ed7c694d59ab6003bd3c665cfa4db480550fd92d"
+    },
+    "maps/medieval_brk/rock_sw01.map": {
+     "bytes": 1371,
+     "sha256": "0e4d621fba3a9806ffdf2bffda89e4d05231513b6f7986d504722d1b99c21a91"
+    },
+    "maps/medieval_brk/rock_sw02.bsp": {
+     "bytes": 9179,
+     "sha256": "4b3d68587a69daa68093d32195a786e8040fed763855acb94f50d02875a8ec44"
+    },
+    "maps/medieval_brk/rock_sw02.map": {
+     "bytes": 1631,
+     "sha256": "82bbf3c701301a80f55619bdac2680d9713432d8fe991838bfb7559830225322"
+    },
+    "maps/medieval_brk/rock_sw03.bsp": {
+     "bytes": 9766,
+     "sha256": "59d2841166f7ecb216df970963b3e425da20566f2fb56a7e5472f4e3c9fcfb24"
+    },
+    "maps/medieval_brk/rock_sw03.map": {
+     "bytes": 1526,
+     "sha256": "300f4c4f56cc9f6425cc8999484e18326555c57b8f53d9f42c36a4345b850d2c"
+    },
+    "maps/medieval_brk/rock_sw04.bsp": {
+     "bytes": 9836,
+     "sha256": "72854269a33665022dee9c30e53e6124bc2bba25ad34d2a3d86302e50ad795c1"
+    },
+    "maps/medieval_brk/rock_sw04.map": {
+     "bytes": 1605,
+     "sha256": "e2b3e6e53c11de10d0de4b7374d43a09be1622766cb3ff60c9e9cec8688747f9"
+    },
+    "maps/medieval_brk/rot_p.bsp": {
+     "bytes": 13554,
+     "sha256": "afcc7dc6512bba89ceec9e10bfa8256ecd043d34c1af57f33a199509500164ff"
+    },
+    "maps/medieval_brk/rot_p.map": {
+     "bytes": 2518,
+     "sha256": "c60e36e827e052cea6ca5c6c2d022b5da051090ee2accf8807f5703ec8acc79a"
+    },
+    "maps/medieval_brk/waa1.bsp": {
+     "bytes": 23869,
+     "sha256": "739aa8d0753e691020013539356d2c2e10b9d0b82c63bcc694080afe33bc585e"
+    },
+    "maps/medieval_brk/waa1.map": {
+     "bytes": 765,
+     "sha256": "f2e7bbba974ffde1e4178be825034e555ca491fffedbf007e62589214af82f0f"
+    },
+    "maps/medieval_brk/wbrick15_brk.bsp": {
+     "bytes": 7969,
+     "sha256": "0dcbd483c300f1be58a216b6d64ea385dd489babdc70868e483fb496c4dd4c38"
+    },
+    "maps/medieval_brk/wbrick15_brk.map": {
+     "bytes": 899,
+     "sha256": "43789ad5bb908aa7fb8e8893db766ce0e479cc547e31aa8de6fe1b4bd6093015"
+    },
+    "maps/medieval_brk/win1ah_brk.bsp": {
+     "bytes": 34981,
+     "sha256": "d549b60245213678c222499299e43654c25f838ed42898a25ec284d933f56b64"
+    },
+    "maps/medieval_brk/win1ah_brk.map": {
+     "bytes": 897,
+     "sha256": "da6859a14f291bef23c990977c0fce7e21ee2c790318cce46e36a8388e87fb39"
+    },
+    "maps/medieval_brk/win1ah_brk2.bsp": {
+     "bytes": 34873,
+     "sha256": "87416124f6e04adaaa5ed9144fa60e048dc03606bc294d89d99295a7c8cb2487"
+    },
+    "maps/medieval_brk/win1ah_brk2.map": {
+     "bytes": 901,
+     "sha256": "5d9a1aefeca5acfdbb25cad5489f5bcb41c89f3c9b92a3d305da0f462c439ec2"
+    },
+    "maps/medieval_brk/wiz14_brk1.bsp": {
+     "bytes": 8961,
+     "sha256": "cb45306588dc69d44422d475c0481f67a76638fe2502c16c28a8f87fa43f6787"
+    },
+    "maps/medieval_brk/wiz14_brk1.map": {
+     "bytes": 1262,
+     "sha256": "46200a77c401035e45d339d8106263e7210ed66e373be74f65687c5d1eb83124"
+    },
+    "maps/medieval_brk/wiz14_brk2.bsp": {
+     "bytes": 7338,
+     "sha256": "871684ecf4507da9773ca5568ccdd0a27173d2f35922b379a19f95e9252a777f"
+    },
+    "maps/medieval_brk/wiz14_brk2.map": {
+     "bytes": 652,
+     "sha256": "97a58529ea21e8127050b0f1e3305e4616b1970232e6517aa652061f49ffc9e0"
+    },
+    "maps/medieval_brk/ws14_brk1.bsp": {
+     "bytes": 7987,
+     "sha256": "ee96dcf614d940d9f887035be0781ad941fc5f76a0f0e553ec3592ae00af1794"
+    },
+    "maps/medieval_brk/ws14_brk1.map": {
+     "bytes": 948,
+     "sha256": "022d130b741c8976f529288f6030fabd2040991efd8bb0a6542dc1508c0b061c"
+    },
+    "maps/medieval_brk/ws14_brk2.bsp": {
+     "bytes": 9003,
+     "sha256": "6aa46294d8fffe55db6f2e6a9d30341fe07a9252b0066ff575c692d0b149f7af"
+    },
+    "maps/medieval_brk/ws14_brk2.map": {
+     "bytes": 1375,
+     "sha256": "8f175f2e3ac8a760fcb7d25da5a30cea149b55349fa0e0d20b2a8c0b080aa5b0"
+    },
+    "maps/medieval_brk/ws14_brk3.bsp": {
+     "bytes": 8944,
+     "sha256": "282944bfbd49b6dcc0aa0d67253432d88c63212ea564a9c6b8909a9b96f8946a"
+    },
+    "maps/medieval_brk/ws14_brk3.map": {
+     "bytes": 1282,
+     "sha256": "6ecd83ba25e15f363f271078c73f6c460babf95ea63340a855dfa182ec47e4b4"
+    },
+    "maps/rtex_brk/022a.bsp": {
+     "bytes": 17448,
+     "sha256": "3557f9518ca0982c871dd344ea5069e5128645029ea428de26ef991881170a59"
+    },
+    "maps/rtex_brk/022a.map": {
+     "bytes": 691,
+     "sha256": "50e0375bf596265b893e56996dbddfad26af2e50bb9af473dc2115e18b11dc02"
+    },
+    "maps/rtex_brk/022b.bsp": {
+     "bytes": 17608,
+     "sha256": "083fdbd34b34b47c5dd9dd58f4e3e0fa3debbedd554db4ce81791033349451fa"
+    },
+    "maps/rtex_brk/022b.map": {
+     "bytes": 825,
+     "sha256": "26d8800f4cfb0706ad363e958846d87755b4871792d1ac1f00b5b51fd7550777"
+    },
+    "maps/rtex_brk/022c.bsp": {
+     "bytes": 17820,
+     "sha256": "8c6b933d2cd323eba623727226ea6cb1f968e0401093f93d229d229a7a5b225d"
+    },
+    "maps/rtex_brk/022c.map": {
+     "bytes": 894,
+     "sha256": "835d4d09490552859dc79ad527bcd08af8afedfa7a863148c62f2f58742e9014"
+    },
+    "maps/rtex_brk/022d.bsp": {
+     "bytes": 17592,
+     "sha256": "0580ec01633972b2fff28c5d4b9a71766d3f1ed6fae387dff34ca691ff829e38"
+    },
+    "maps/rtex_brk/022d.map": {
+     "bytes": 784,
+     "sha256": "238fc24be385d3994586c34555e74ecbb7677aa7567bbf317947276c14b62107"
+    },
+    "maps/rtex_brk/330a.bsp": {
+     "bytes": 7928,
+     "sha256": "a446db4116b8c33f46745cf815ba9309e69591d919838006c81a9b0a5b00c7d4"
+    },
+    "maps/rtex_brk/330a.map": {
+     "bytes": 691,
+     "sha256": "964103ee6422dd3b815472c9f29126741e06517623dad050fba18a9867451903"
+    },
+    "maps/rtex_brk/330b.bsp": {
+     "bytes": 8088,
+     "sha256": "727d22fad028bac645a53ac5a425618e30575735958496b7a1ac86cfbc562e1a"
+    },
+    "maps/rtex_brk/330b.map": {
+     "bytes": 825,
+     "sha256": "807bdb97ab58709fd96cfa0e7b65cb5d377257b862eef2673606901d70b84108"
+    },
+    "maps/rtex_brk/330c.bsp": {
+     "bytes": 8300,
+     "sha256": "b25471a1f0e7fdd066dda47860ae956db2b2c4758a426b39b8a82e6b4c6d1b72"
+    },
+    "maps/rtex_brk/330c.map": {
+     "bytes": 894,
+     "sha256": "13241951b0d3cd61a71e0fe80071a1df65e369eba44aabdf3401f3ba5aa55a7f"
+    },
+    "maps/rtex_brk/330d.bsp": {
+     "bytes": 8072,
+     "sha256": "8f83245e973c42e9908b6215c5effc0f0581d654e5e8e67a6e77493f79de3e6d"
+    },
+    "maps/rtex_brk/330d.map": {
+     "bytes": 784,
+     "sha256": "f0e46c1efc3d5a814675f5760a33a2e6bc4163974ff64a4c1f88ab70c50fbb68"
+    },
+    "maps/rtex_brk/340a.bsp": {
+     "bytes": 13368,
+     "sha256": "e8a605fdff44ef59b4657a43a67cfb24d2d62f150b210a0761f69ed5f559215c"
+    },
+    "maps/rtex_brk/340a.map": {
+     "bytes": 691,
+     "sha256": "3678f5058497a6067c7ffb4d452e706af588e0aedfd30bfa2d43f1902333e7ec"
+    },
+    "maps/rtex_brk/340b.bsp": {
+     "bytes": 13528,
+     "sha256": "d92cc6afb7ae74965a8bb2a753909e2dc6c064b5fb2c9c463c95123531ba337d"
+    },
+    "maps/rtex_brk/340b.map": {
+     "bytes": 825,
+     "sha256": "29f243aa1c347358e34383f4ffb2d129f710829022524237585041c7840a02cb"
+    },
+    "maps/rtex_brk/340c.bsp": {
+     "bytes": 13740,
+     "sha256": "882a110b1a7e26481e5dd37858d5229c0273bc98ab8a2ab59f318e2b76080fac"
+    },
+    "maps/rtex_brk/340c.map": {
+     "bytes": 894,
+     "sha256": "069e17115ae35cf0fdaa9ceb8b3a67065360d4fc03f91036ba453b6b6745d77b"
+    },
+    "maps/rtex_brk/340d.bsp": {
+     "bytes": 13512,
+     "sha256": "96a6133331679ad8eb75d8581e8be12c6822d2048c18a1e704281a6e4cc0737c"
+    },
+    "maps/rtex_brk/340d.map": {
+     "bytes": 784,
+     "sha256": "b8197ea047f14d175e5b9234dcc9b625f04124b175bb0fd80da7ceffe056b00c"
+    },
+    "maps/rtex_brk/413ra.bsp": {
+     "bytes": 7972,
+     "sha256": "a3cc5962750f55c398dfaf53cb4d8394f1100c752ca9797f053ec2710acd995d"
+    },
+    "maps/rtex_brk/413ra.map": {
+     "bytes": 769,
+     "sha256": "b0a3052bfb352684f97fb7bca8fdc3d7b135ae5e3fca491d190d09423836da46"
+    },
+    "maps/rtex_brk/413rb.bsp": {
+     "bytes": 9204,
+     "sha256": "e36bf5d23b3dcaf96075b1b441ebf6424da62cb2d04ff14f04da4e9956711094"
+    },
+    "maps/rtex_brk/413rb.map": {
+     "bytes": 1682,
+     "sha256": "6be0d7cbae08ffccbb1ea9dedf03bc6f8c9b6be93c6c27d5e964e3b4f4538a52"
+    },
+    "maps/rtex_brk/413rc.bsp": {
+     "bytes": 10340,
+     "sha256": "4d57717cc2fb9db560e724df4937f7c496d77d1df6d70e6619ba686338152e79"
+    },
+    "maps/rtex_brk/413rc.map": {
+     "bytes": 1909,
+     "sha256": "71c9812cdf0647bb89fcd2a911a664b7a8dea382b0fe58e4e834a24354a23b38"
+    },
+    "maps/rtex_brk/413rd.bsp": {
+     "bytes": 13356,
+     "sha256": "573149ae9d1f687b0ddc0a702116357b4556e20ae8d62b7b32b3c5b41f227088"
+    },
+    "maps/rtex_brk/413rd.map": {
+     "bytes": 3217,
+     "sha256": "f40b142b102fefefdaf6594c2d1410f370fd8491a009ecfc6dada46c55f262d2"
+    },
+    "maps/rtex_brk/wood3_1a.bsp": {
+     "bytes": 7552,
+     "sha256": "8884a645d6193052aeba7043c139b3eb4cf8ace2e62ed6e9181d51f90cae4806"
+    },
+    "maps/rtex_brk/wood3_1a.map": {
+     "bytes": 1007,
+     "sha256": "5322a91b2aad8cf58095fb513e58317d738469c168b78f770307c3ece580fbf9"
+    },
+    "maps/rtex_brk/wood3_1b.bsp": {
+     "bytes": 7096,
+     "sha256": "9d7d44ba1c929fae0bf702ec834394c9da23c199cf742f9c7021bec00f33c056"
+    },
+    "maps/rtex_brk/wood3_1b.map": {
+     "bytes": 516,
+     "sha256": "158e6d102aaeb8dd7add01eecd7e05b4c711a20d7d7134d1bdce417fbe1b2072"
+    },
+    "maps/rtex_brk/wood3_1c.bsp": {
+     "bytes": 7144,
+     "sha256": "f292d3b9cabaa0332d7c3f6abd66420ad9ef80217f32223bd67315fa8967d908"
+    },
+    "maps/rtex_brk/wood3_1c.map": {
+     "bytes": 517,
+     "sha256": "f853df961fdcebd569943bad596dceb464c6317e44f3d77ce4def17295b37c00"
+    },
+    "maps/rtex_brk/wood3_1d.bsp": {
+     "bytes": 7804,
+     "sha256": "8e6ffa915db57d7cb958c7210e0abc35ff552713a5aa19a1ccb531a7d45bd504"
+    },
+    "maps/rtex_brk/wood3_1d.map": {
+     "bytes": 883,
+     "sha256": "d370c44a047023843caf08a41098bd3852526b614ae074c228cc6ad4e76d4aa9"
+    },
+    "maps/speedbz_brk/crate_r1.bsp": {
+     "bytes": 29110,
+     "sha256": "5dd3afab4a3ad5cf4466e272324e4afad5075ca2e662cc8b1932e277a2db73a2"
+    },
+    "maps/speedbz_brk/crate_r1.map": {
+     "bytes": 664,
+     "sha256": "ee7ce39ec0650d3cbde924b99efc91ba884778db11a961037d4493bf587fa33e"
+    },
+    "maps/speedbz_brk/door1.bsp": {
+     "bytes": 31200,
+     "sha256": "6df38f4db1bfd725dd7384b45e38d070fd4b514139a8e649aea3e640377a073d"
+    },
+    "maps/speedbz_brk/door1.map": {
+     "bytes": 1419,
+     "sha256": "17bf053113ed5cc14e99ef2880e5478ebace7d59de4797fc6cbfe3586d688494"
+    },
+    "maps/speedbz_brk/door2.bsp": {
+     "bytes": 29732,
+     "sha256": "8f58cd2f2e76fbb36a007ed7986671092b880d01dfcb9a087e93cd11240d2baf"
+    },
+    "maps/speedbz_brk/door2.map": {
+     "bytes": 726,
+     "sha256": "3fac703869c9ebb4eabfbe8f180fec752812eea0aa68c5f5574c5cf2496c3931"
+    },
+    "maps/speedbz_brk/door3.bsp": {
+     "bytes": 26516,
+     "sha256": "77f003456362f2b7ca424491485ad2d20b162598527765e5e78628ee7e6ad172"
+    },
+    "maps/speedbz_brk/door3.map": {
+     "bytes": 1247,
+     "sha256": "e56d45f63dcb0d86a0039ea443109d8c8d116fa18331a2328e90f74a891ab9d2"
+    },
+    "maps/speedbz_brk/door4.bsp": {
+     "bytes": 24020,
+     "sha256": "930881a45210317dd3550b04b20d2446cf92c8c613d4aa295a5c77810b77b3f2"
+    },
+    "maps/speedbz_brk/door4.map": {
+     "bytes": 611,
+     "sha256": "f4a68b8f4d081ff0febc276c51b5484c96e4b044eab6e20069ae84ac7c5a0ac2"
+    },
+    "maps/speedbz_brk/rock1.bsp": {
+     "bytes": 89984,
+     "sha256": "c87f60de56cfd5a932cf33d23d6e83b0fd16518001dd8fa7be84da9c3176b5b5"
+    },
+    "maps/speedbz_brk/rock1.map": {
+     "bytes": 980,
+     "sha256": "29e5bd54316e6f325d71a33051ee3a5b6c213f927222931bb35cdcc1820cc87a"
+    },
+    "maps/speedbz_brk/rock2.bsp": {
+     "bytes": 90012,
+     "sha256": "443e51be48da3594545d347ee056f3973b0360268eb6c03653d7b3af622c553e"
+    },
+    "maps/speedbz_brk/rock2.map": {
+     "bytes": 991,
+     "sha256": "40b6b9f23f788c08f362f2336048bbe1260f181d7e76de2591ea7aefa03f4b09"
+    },
+    "maps/speedbz_brk/spdcrate_r1.bsp": {
+     "bytes": 12844,
+     "sha256": "30fa3f373efefcf7db68a9acbb0eb282a0b2ea54d26db92eaaad444035462791"
+    },
+    "maps/speedbz_brk/spdcrate_r1.map": {
+     "bytes": 807,
+     "sha256": "c18735f305c2496a4801ed1a5bc1297f2d72e55824f7222a265ac5788552fc68"
+    },
+    "maps/speedbz_brk/speedbzvent1.bsp": {
+     "bytes": 15248,
+     "sha256": "bcfe36bf57cb82e5188b86af3e5bf568038ef5a50d0ebce43024155b7276008d"
+    },
+    "maps/speedbz_brk/speedbzvent1.map": {
+     "bytes": 2053,
+     "sha256": "7d447bc22e440e685648d8b39e051bce7c1b847e3f777ac092ab1104b79242a1"
+    },
+    "maps/speedbz_brk/speedbzvent2.bsp": {
+     "bytes": 14104,
+     "sha256": "8fb1e76688e27767ce77c5d7b3486048adfa284e011b91007730d424eb55ca61"
+    },
+    "maps/speedbz_brk/speedbzvent2.map": {
+     "bytes": 1381,
+     "sha256": "44cfc0509c9455865df334c1ca5bdfca49cf0fae4dab372cac99e6eeb76b438c"
+    },
+    "sound/ambience/FlorHum.wav": {
+     "bytes": 41976,
+     "sha256": "4c790f23b471599d2ca66f42c19143d00dabf226732cef133813abb2e1460446"
+    },
+    "sound/ambience/Revolver.wav": {
+     "bytes": 107256,
+     "sha256": "9ed7eedb9565f48ec02a5a78a783fc12051d8200b948282edd423fd447f41a2d"
+    },
+    "sound/ambience/Static.wav": {
+     "bytes": 48568,
+     "sha256": "d57ccbfafa9a2054074eabfc3f7bf57ba6507aba29234613a6175ec76b251d4b"
+    },
+    "sound/ambience/Trans.wav": {
+     "bytes": 32180,
+     "sha256": "6bd79fc8cc5e0e417d4dedc701946ec806c9f148ab66df91402e46287be2365f"
+    },
+    "sound/ambience/an1.wav": {
+     "bytes": 276284,
+     "sha256": "dbf389d5c17e8fce94f6466f711c06f085ee24ef592ea96e54463c81c6383e00"
+    },
+    "sound/ambience/an2.wav": {
+     "bytes": 474918,
+     "sha256": "4c4003bcc60fc00bc14a48d0415fba32c7d59fac81696970698daec8e7f966e4"
+    },
+    "sound/ambience/an3.wav": {
+     "bytes": 315366,
+     "sha256": "112ec61c2704cd8d1a6753c60066648e06bf663cef0567b1948c9927b6e7a6c2"
+    },
+    "sound/ambience/arc2.wav": {
+     "bytes": 42920,
+     "sha256": "48195a261fca0b1d666d3838a8bbf55790fcf0e9f71717028ca4af3d5a7159b9"
+    },
+    "sound/ambience/atmos.wav": {
+     "bytes": 1938656,
+     "sha256": "6aea73e6aa3081a522e3db6b27db6b9b75d331db44534e70aea4d5085937dec7"
+    },
+    "sound/ambience/bbird.wav": {
+     "bytes": 1516406,
+     "sha256": "a8f4e0d3327bbbeb105a0734ac2067c5c967e737584b0991fd9e6c5e503cdfa3"
+    },
+    "sound/ambience/bell_ring1.wav": {
+     "bytes": 61586,
+     "sha256": "b9169a48fd032d7c2b0cadb61540ac5db42ca6384cb2c74818bd46bae3fc7db1"
+    },
+    "sound/ambience/bigcave.wav": {
+     "bytes": 2454910,
+     "sha256": "f1dddc76a5fd950122842d1fb5adc88ca65892fc1c0759a09a1eddba6b636039"
+    },
+    "sound/ambience/bigmachine_loop_02.wav": {
+     "bytes": 92760,
+     "sha256": "4d6dd03883ac4462c7f1741c022a3e8fd9e2c65cd54d5d126f58c00b3bfe7df3"
+    },
+    "sound/ambience/birds1.wav": {
+     "bytes": 135474,
+     "sha256": "cdda8f7387eccdab00823f3b76b1250d1b95cc2b7a7229adbfc5f47acea6b207"
+    },
+    "sound/ambience/birds2.wav": {
+     "bytes": 1205088,
+     "sha256": "b3d6340c9fb0ac1c79851f0f3c1ae9e3fb1104c007d206cda2dfa681d4dce61c"
+    },
+    "sound/ambience/bkgrnd1.wav": {
+     "bytes": 1087086,
+     "sha256": "24ef7f450e70abe663bcf092d325371c45c791988ff5685c1c17d97333519680"
+    },
+    "sound/ambience/blimp2.mp3": {
+     "bytes": 381335,
+     "sha256": "70e2265afacb7042836d09e3f1f6c4b1a5211f666d965057a0fc816753073e26"
+    },
+    "sound/ambience/blimp2.wav": {
+     "bytes": 5366840,
+     "sha256": "ecf0896bd5a4c91dd157654c0a2b3be2697b50028c5463a3145488fd2835fd69"
+    },
+    "sound/ambience/boom.wav": {
+     "bytes": 78630,
+     "sha256": "85e86f7986baf12bce852cfbfa24c3becc52f7bc6ca5be043071851d58d02551"
+    },
+    "sound/ambience/breathe.wav": {
+     "bytes": 106396,
+     "sha256": "2a6d5cef000c53d873b6d1f53d8049e69027e1ab209eff654b4f855a209e85fb"
+    },
+    "sound/ambience/buzz2.wav": {
+     "bytes": 292700,
+     "sha256": "0e5a0756ceebab9ff125c8beca36292eb57b8ba01a6ffc011df3110c97b1b00f"
+    },
+    "sound/ambience/buzz8.wav": {
+     "bytes": 133488,
+     "sha256": "692ed7d6dd314a41c94d627f75f933dc10acd79c21946b46e18f195e3341c326"
+    },
+    "sound/ambience/c1.wav": {
+     "bytes": 1002356,
+     "sha256": "ddbd42472cb52880e22da27fe64baa9609034a754ecbcb7a360ca8a04cb12cce"
+    },
+    "sound/ambience/c2.wav": {
+     "bytes": 1134636,
+     "sha256": "2c2d2327b51e3165d5c542496c09a80f4461e803763cbbddb6fcadd484d9f720"
+    },
+    "sound/ambience/c3.wav": {
+     "bytes": 992906,
+     "sha256": "2cb12bb60b513fecc28dd214e269a0662d4fac1b0189f714797dab3e8e5d72c0"
+    },
+    "sound/ambience/c4.wav": {
+     "bytes": 1532470,
+     "sha256": "8ce80721d65cf50cea36fcca241e52f6ed6eaecc7fa027f3f0867b7d4e73e7be"
+    },
+    "sound/ambience/calcul82.wav": {
+     "bytes": 56870,
+     "sha256": "3269610e9d3f69fea1be7721ce158c78c92a9a70311f7e4c75ce0e87be083651"
+    },
+    "sound/ambience/cargo1.wav": {
+     "bytes": 4225464,
+     "sha256": "813e741954c391c66c3bbc1f108119bdc6903ccfad85f6dea315e952fd548709"
+    },
+    "sound/ambience/cavdrip1.wav": {
+     "bytes": 821744,
+     "sha256": "5c30d7f47dd1b8ebf55a3cccf1c2fb42b48c6578934c5bb4b1bc5beadfaa8167"
+    },
+    "sound/ambience/cavdrip2.wav": {
+     "bytes": 897590,
+     "sha256": "9bb603f83af876de70fd75101067bf9104c0e9c2c672e925c8d163f8d81b7ada"
+    },
+    "sound/ambience/cavdrip3.wav": {
+     "bytes": 219582,
+     "sha256": "78158fa18ce87446c0cb8d6862602c5e969657465a0077c77c0582b7df93dc37"
+    },
+    "sound/ambience/cave1.wav": {
+     "bytes": 58474,
+     "sha256": "67ae91b6ffe7e426fb09370273fdadec599cf560ac8e417e9632920b2962c846"
+    },
+    "sound/ambience/cave2.wav": {
+     "bytes": 63658,
+     "sha256": "71899be554b574ddd27d286ff2ec864dbabdba12b16ae72abdedf22cf96781ae"
+    },
+    "sound/ambience/cavs.wav": {
+     "bytes": 3794902,
+     "sha256": "c914671c3e1062f8cd80d29c83971cf184bfd88f9304f6a080e409145fea1da0"
+    },
+    "sound/ambience/chaffin.wav": {
+     "bytes": 1174156,
+     "sha256": "1153fb18e5df528abd5c00907fddc263a5dcf2c3816a556c2d534f2fc6bd180e"
+    },
+    "sound/ambience/chant2.wav": {
+     "bytes": 407448,
+     "sha256": "b585b2c19e868fd32b21278819b92460ffb0efc048665e4d5dfe1c15240fa8d8"
+    },
+    "sound/ambience/cheap1.wav": {
+     "bytes": 136166,
+     "sha256": "7c388ee69f0d382b6fccc19c9e689877d84b620234aedb354eacf3c8215520ec"
+    },
+    "sound/ambience/chiff1.wav": {
+     "bytes": 1269290,
+     "sha256": "817ad57c5b099e4b803c10aec8cf378992bfe1af00d118af5c564b06ff37bb49"
+    },
+    "sound/ambience/chiff2.wav": {
+     "bytes": 1423894,
+     "sha256": "6a9c7177156ea111612d7b0192e908303db603c3a4695d797f0c1a6045a71fa4"
+    },
+    "sound/ambience/chime.wav": {
+     "bytes": 1592968,
+     "sha256": "475e299dca9ad097ff0f4d2642985c904a91b3cb78ac2451247e3d913957d119"
+    },
+    "sound/ambience/chimes.wav": {
+     "bytes": 250476,
+     "sha256": "d1060cd75d8a520b748047790d33c9a4ab5fd626330ebf1242d318d308c165db"
+    },
+    "sound/ambience/choir1.wav": {
+     "bytes": 240172,
+     "sha256": "ca6e15b637df65e458f17816b054943751b326a0160e5135ecb58fa0811b06e8"
+    },
+    "sound/ambience/cliff1.wav": {
+     "bytes": 1724580,
+     "sha256": "e5449d79d72a5198943e0e516863ac8bd36ef98a2b5e5d751b0ba32ad04b2b8e"
+    },
+    "sound/ambience/cliff2.wav": {
+     "bytes": 6516686,
+     "sha256": "509e777711894ef022cc3e69e5da60616a120f204efdba34a21d2368f4ced929"
+    },
+    "sound/ambience/cliff3.wav": {
+     "bytes": 1369766,
+     "sha256": "910a7f469a0736bd2c86a7f0b14c2686e254c911a2fc2b62d0258a859fe30d0b"
+    },
+    "sound/ambience/cliff4.wav": {
+     "bytes": 2790294,
+     "sha256": "f1ab77bf993d3755aad3edbda032e9fede3bb80d7d4fa48cda03fac12f74cf0d"
+    },
+    "sound/ambience/cliff5.wav": {
+     "bytes": 2329666,
+     "sha256": "098a136b3a562545da81a4b01413c1acd245ece5902bc74cb2471d0f75745a98"
+    },
+    "sound/ambience/cliff6.wav": {
+     "bytes": 2585090,
+     "sha256": "cffca34ed6528594beb67869da650ebf070e334723e93a359e4999e5cac3f985"
+    },
+    "sound/ambience/cliff7.wav": {
+     "bytes": 2722418,
+     "sha256": "495ee4c6f95ef7c5056736046e43e6be125424f0ba69249513f52067708d8403"
+    },
+    "sound/ambience/comp1.wav": {
+     "bytes": 160384,
+     "sha256": "aef43bb77ea7cc53ba28ae2e7c2a4f96e8c3b8fdd38c0718e0b3fc0f60bf7a9e"
+    },
+    "sound/ambience/compd1.wav": {
+     "bytes": 1326984,
+     "sha256": "641540771a0c1709dc4776279fb3309905f87f12ca4e12215cf697c23bc5b754"
+    },
+    "sound/ambience/compd2.wav": {
+     "bytes": 1095816,
+     "sha256": "1235e46c27bfeca7abfd28736c4306850a6cd7b7fe7182ed352c8c2766bcb114"
+    },
+    "sound/ambience/compd3.wav": {
+     "bytes": 373078,
+     "sha256": "e66b6aa6752d9e615d3e6d2b5f81641879e6546cb1064a4774d5f72108fe21f7"
+    },
+    "sound/ambience/compd4.wav": {
+     "bytes": 524950,
+     "sha256": "ac50a845cb3fd9578c4ce67609654998d84f0607e3d261fe524f79750b57b2f7"
+    },
+    "sound/ambience/compd5.wav": {
+     "bytes": 630722,
+     "sha256": "2f035fc05d545ff599ef2e8fca10d366d8e293376a9afa446bd24beee37f8652"
+    },
+    "sound/ambience/compd6.wav": {
+     "bytes": 544736,
+     "sha256": "e99e60f66171027b360cd69c849a3a0e81bc6fd5484651341beac90e564772e7"
+    },
+    "sound/ambience/compd7.wav": {
+     "bytes": 887698,
+     "sha256": "1d8875b6284549daf302e699b7bc92ca12f263159e4c7709e8ca9baf30a7b43f"
+    },
+    "sound/ambience/compfan1.wav": {
+     "bytes": 1345070,
+     "sha256": "2d7af4a3bd035220e4bac29a020d74f7835497699c52169696c66797a6b29747"
+    },
+    "sound/ambience/compw2.wav": {
+     "bytes": 45946,
+     "sha256": "714bdd7d866f42b5444d631b29ee8b62aaf7f5af908c2ffd7e5d7c51461dded2"
+    },
+    "sound/ambience/compwine.wav": {
+     "bytes": 799348,
+     "sha256": "e4d48c11864b60487dfb8854d86b37e52d74c38a5be6db58a0da6ad899f3200e"
+    },
+    "sound/ambience/coot.wav": {
+     "bytes": 820758,
+     "sha256": "ab4c60983540e519874f93f0509153b44a2fa7b1bd41118d6c84b76dce443f8c"
+    },
+    "sound/ambience/coot1.wav": {
+     "bytes": 820758,
+     "sha256": "ab4c60983540e519874f93f0509153b44a2fa7b1bd41118d6c84b76dce443f8c"
+    },
+    "sound/ambience/copier.wav": {
+     "bytes": 79264,
+     "sha256": "452b1f396d35e3fda88130e3235ad9a325781619e68942d0b2d1f28bebe4b045"
+    },
+    "sound/ambience/coptin.wav": {
+     "bytes": 2234022,
+     "sha256": "c9b9be33cf080c204f565ec6e81468f240221b12348e37e855eec0b9e07ed8eb"
+    },
+    "sound/ambience/coptout.wav": {
+     "bytes": 597042,
+     "sha256": "3247be32cecab0fd2c00e88e81cd7885119547ef1fde519cd4e0f7d8b90cec7b"
+    },
+    "sound/ambience/coptr.wav": {
+     "bytes": 379660,
+     "sha256": "a924c39b8ae432e30a10dc7b2b7198ee17f20235136682df45d40aa90bcc9d40"
+    },
+    "sound/ambience/cor1.wav": {
+     "bytes": 106732,
+     "sha256": "6f967acc914284b8c10a988ab61d68d20829e930a6e012e1123b82e3be21a41f"
+    },
+    "sound/ambience/creak1.wav": {
+     "bytes": 352954,
+     "sha256": "d4e6aa3e7f809aae86e2e1a16f5cf2ebbcb70234ec50740de2471e32f0dfe8e6"
+    },
+    "sound/ambience/creak2.wav": {
+     "bytes": 308882,
+     "sha256": "5f12aee71defc6d4f3a05d8fc0f1d2d2c2e173d7e58548cee2ae17bef7486040"
+    },
+    "sound/ambience/cricket1.wav": {
+     "bytes": 134446,
+     "sha256": "4fca5dfcf80ac770ad84396dfee3c7084f13ca136c55c1ae1daae8f5ac009370"
+    },
+    "sound/ambience/cricket4.wav": {
+     "bytes": 213254,
+     "sha256": "38a6f684891d0e6087ce6890bffa113da72b334326e7191250305b9791d276e1"
+    },
+    "sound/ambience/crickets.wav": {
+     "bytes": 70166,
+     "sha256": "ac2ddaa261c89abff2c10da44974bcf96245584e8a04c8a8f8944d669c2b8e22"
+    },
+    "sound/ambience/crows1.wav": {
+     "bytes": 120504,
+     "sha256": "5028785bb35270b8193ee0aea82f987cd8282e952ead3c7bc101a5eb98c5dbae"
+    },
+    "sound/ambience/crows2.wav": {
+     "bytes": 998884,
+     "sha256": "7914f6c48dd76588dcbe7b5082b16dcaae192a7ead4227b166d278248fac60ab"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 802112,
+     "sha256": "4a4873107135e80bb82384f6ecb910d40061e15a76e6d0050de982a32048813a"
+    },
+    "sound/ambience/disco.wav": {
+     "bytes": 472546,
+     "sha256": "820e0e7039ccbdd2be36e14a29383d0cbabdd10a78207b1e290730d80d2dbd04"
+    },
+    "sound/ambience/disco2.wav": {
+     "bytes": 679684,
+     "sha256": "25d709ea59b5269b8bec3a770c55e0b5af1ec8326e75c8e95e52c5af269977cd"
+    },
+    "sound/ambience/distant_gears.wav": {
+     "bytes": 72502,
+     "sha256": "760d34131249ff3c4bccdab0cd3df69874728a6db3e1b4545177e5ce381e5e80"
+    },
+    "sound/ambience/dm1.wav": {
+     "bytes": 1241276,
+     "sha256": "d415b094fb1e7d2a1f75707fbda692075c6011768a59545a9e2e645430a8c232"
+    },
+    "sound/ambience/dm2.wav": {
+     "bytes": 518276,
+     "sha256": "4981cb3a326a932b5d88a1824a92ea6dd894061baf7a3cc606da305a4b4043e3"
+    },
+    "sound/ambience/dm3.wav": {
+     "bytes": 1458182,
+     "sha256": "ba81cc4b58a1d3bb58ec5bfd4b1234b9b80d69e055ce325d9084fd6a6b64d7f0"
+    },
+    "sound/ambience/doom1.wav": {
+     "bytes": 767024,
+     "sha256": "c63397dc8813143863cedde0af60ffc9f48d920844c8c85a77e00a20bb21ca24"
+    },
+    "sound/ambience/drip1.wav": {
+     "bytes": 932116,
+     "sha256": "e244a014a22f4bafa1e445afc3b01b0ff65e4b00085df8230f623d8f7016518f"
+    },
+    "sound/ambience/drip11.wav": {
+     "bytes": 2475740,
+     "sha256": "d660295098d7fd6ef1675bcbc221ff8d1ab95f9c1525062c14fe43ab0447aa06"
+    },
+    "sound/ambience/drip2.wav": {
+     "bytes": 272570,
+     "sha256": "180650866c12d9858cd87656c2569a3337aa3fe360cad840c72e05c3f0878435"
+    },
+    "sound/ambience/drip3.wav": {
+     "bytes": 433908,
+     "sha256": "828234e0592ba1f81ed1fc98ca5614e19ca14903b95a487d82b8bf84bbd850b7"
+    },
+    "sound/ambience/drip9.wav": {
+     "bytes": 969238,
+     "sha256": "944bfc6bb078430dc19904741987f79659c940c0e9e1338c23cf2d58ad784237"
+    },
+    "sound/ambience/dripping.wav": {
+     "bytes": 272570,
+     "sha256": "89a69f7760779529c9e69b6de1cf7a008e679f0d8f699e989a49fce5fd72e6f2"
+    },
+    "sound/ambience/drippy.wav": {
+     "bytes": 269474,
+     "sha256": "2b020ba6df4393618ff98893b9ec10698fe39ef3bd95d105a9be7940cf55e4c6"
+    },
+    "sound/ambience/drn.wav": {
+     "bytes": 1398948,
+     "sha256": "8f5f0bd5fe940c5a66d12c965070a24e2d7170a54942e272e2938c6f7c4b9d8f"
+    },
+    "sound/ambience/drn10.wav": {
+     "bytes": 3652508,
+     "sha256": "917c72ee290c15c95e74ff642c5e5aa6cb743eb5c00dee70c067fb6192470350"
+    },
+    "sound/ambience/drn11.wav": {
+     "bytes": 2608454,
+     "sha256": "c6dac157d834f5837722ff0ce53f215b89a50802f860e3863ebd6561bca15585"
+    },
+    "sound/ambience/drn12.wav": {
+     "bytes": 630256,
+     "sha256": "aa6c97df2dd1a6a948becb56517f50ec998dcf0c032eadfa2183100f424b763a"
+    },
+    "sound/ambience/drn14.wav": {
+     "bytes": 1917320,
+     "sha256": "e051287c953ede86ad629a51601d8d36c733dc8296c4dec2da167d63ec25ffb8"
+    },
+    "sound/ambience/drn15.wav": {
+     "bytes": 2636982,
+     "sha256": "1b9333e796eca2d9e24e3778e2d25d97aef60855d0dc402eb126b64e24141cca"
+    },
+    "sound/ambience/drn16.wav": {
+     "bytes": 1903334,
+     "sha256": "46a76d8569c499f7dbe2f400cc681a2b4277a549ec3e9f94eb854e14a23db05b"
+    },
+    "sound/ambience/drn17.wav": {
+     "bytes": 2321498,
+     "sha256": "9022f38cdbeb5e1f8ea418fd5c7fa9c3e293c1d3e10ed504b2b2c33fa063d815"
+    },
+    "sound/ambience/drn2.wav": {
+     "bytes": 1876344,
+     "sha256": "89c2c086e35ee7598f848a4de95adf89f591b7cc4f049686ce016cb1657138a9"
+    },
+    "sound/ambience/drn20.wav": {
+     "bytes": 1891644,
+     "sha256": "bedbd68b14df7a30966b0f3a88a190f04310bbbec3d605006296e286d8ad34e4"
+    },
+    "sound/ambience/drn21.wav": {
+     "bytes": 891264,
+     "sha256": "b1aaf79be51978715fd4da9addce5789ea521b7d0b62af986031b170bdf30ab6"
+    },
+    "sound/ambience/drn22.wav": {
+     "bytes": 1007852,
+     "sha256": "e7ee6bb6bcc3e98dc91813ccd6dd9f2637cacc1f3d6cfeca1c31267a2914974b"
+    },
+    "sound/ambience/drn3.wav": {
+     "bytes": 1666080,
+     "sha256": "6ee89808d6f478fa766b2259a12f89a2f2d4eed15903486ec0e611b04b1f28a4"
+    },
+    "sound/ambience/drn4.wav": {
+     "bytes": 475742,
+     "sha256": "9a08949860ac24e0b6abd85f7b6af2cff5d00d19b59c621b9cd2d6cd386007fc"
+    },
+    "sound/ambience/drn5.wav": {
+     "bytes": 932182,
+     "sha256": "d617c1f107c57c496585d8f3c635629141d6884a50f682fff11dcf0e240515ac"
+    },
+    "sound/ambience/drn6.wav": {
+     "bytes": 1710934,
+     "sha256": "28a285b3fd9e65975443130913a7967504b272a3e6488ad4f672bd178a4de134"
+    },
+    "sound/ambience/drn7.wav": {
+     "bytes": 2204476,
+     "sha256": "2728ed6bce90ffc4269f3a524d43bf7da6e1f47317d3d17454a46e7f8c9332eb"
+    },
+    "sound/ambience/drn8.wav": {
+     "bytes": 2184100,
+     "sha256": "4f921a4a5d3f926586bacd127af43a5d135231ebad59d4fbc6cd7e6d9f23e604"
+    },
+    "sound/ambience/drn9a.wav": {
+     "bytes": 446848,
+     "sha256": "5ab0990c9018d6286b5a4abbc4891f2624240a5b8ff8ea7704ef5302eb35721c"
+    },
+    "sound/ambience/drnnw.wav": {
+     "bytes": 2008262,
+     "sha256": "3c6490f82f40010f31c994eab1104f56e5fa7d4214d25167625bf36fbbff54c5"
+    },
+    "sound/ambience/drnnw2.wav": {
+     "bytes": 4442200,
+     "sha256": "f53d1bfacfeb1476baf25c13f3a8e951af31814b23a7f4f3ed3d0536262f8b84"
+    },
+    "sound/ambience/drone6.wav": {
+     "bytes": 36820,
+     "sha256": "ab0cc1d617b06169d20b42bddc31078c0c7a1b8b15793fe6cfea6dbc96b4129e"
+    },
+    "sound/ambience/drone7.wav": {
+     "bytes": 220656,
+     "sha256": "0de30734f812d01aa79e58b2e6fe9f7c5c634e5be0dd5e24f25e7e6c0881e20d"
+    },
+    "sound/ambience/droon.wav": {
+     "bytes": 29872,
+     "sha256": "330fdeb19870c118f1c77bd3597dae2749de5f6c590552f6f52178ad14cba475"
+    },
+    "sound/ambience/drums.wav": {
+     "bytes": 1758516,
+     "sha256": "72a2b8b15c293604a57e4044b9e1439d9ebfdda047fa74861eb48abb47a7c2b8"
+    },
+    "sound/ambience/duke.wav": {
+     "bytes": 1474086,
+     "sha256": "f27d93d97cf0df61b70155797a57ad08da4a615b6b18cc14a2c3e2bdc0ab5cce"
+    },
+    "sound/ambience/eerie.wav": {
+     "bytes": 57606,
+     "sha256": "af4ae97062c4285166faab7b60ffcbbcf8572db0608721ceb50dbc110a6c37d4"
+    },
+    "sound/ambience/elevator.wav": {
+     "bytes": 1317818,
+     "sha256": "3fb1dac3d16bbe2308be8a3754fce1011d5acb1efd9d1a4a256d3ddd3c1f66bb"
+    },
+    "sound/ambience/evil.wav": {
+     "bytes": 146816,
+     "sha256": "ace4ec5e4bcd618167914b6597a6559b4fea55edf7eea7aea69ac3d57e2ada8c"
+    },
+    "sound/ambience/evloop.wav": {
+     "bytes": 347128,
+     "sha256": "521e65b7a80cd01bc84d5681407079e9da548b72b7549bf78dd97f4bfcc68665"
+    },
+    "sound/ambience/fact2.wav": {
+     "bytes": 2425270,
+     "sha256": "4ac5ca3d06547bc674931b316f625ef196dabce54bffe460d30a9fb2914c1dc3"
+    },
+    "sound/ambience/factory1.wav": {
+     "bytes": 1362806,
+     "sha256": "db2fd3ea506dc20762bc1c7ff5b969fa75e9e27cd1e36c66a49bf9fd6ee2328f"
+    },
+    "sound/ambience/fan_finish.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/fan_loop.wav": {
+     "bytes": 288110,
+     "sha256": "d7459b4f1087aa1e002f41fc0274e4cb2f313dff5af2eecaa9de5225bcdcd729"
+    },
+    "sound/ambience/fan_start1s.wav": {
+     "bytes": 96044,
+     "sha256": "b0bad8ae3cd81dc4bbd76591e29f9c43610cb6e0311d4822213e400a6b99dd9f"
+    },
+    "sound/ambience/fan_start2s.wav": {
+     "bytes": 192044,
+     "sha256": "6716a803f246e44416fc414ca2f51744fc1ed79178f79fe3baf7a986c820c020"
+    },
+    "sound/ambience/fan_stop.wav": {
+     "bytes": 192044,
+     "sha256": "ee8607922387eeb594c18096ef6dd4003990a5fe47414dee331921f6d03be6b7"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 10908,
+     "sha256": "c8b084202ce314db5eb2d2ce938b9f3870abad86aad537e26485cdb677b5ab24"
+    },
+    "sound/ambience/femcry1.wav": {
+     "bytes": 58620,
+     "sha256": "5954b453b30425cf209fb0a01b547be11fcc9fdf7ddeedef028d2dbeef71aeec"
+    },
+    "sound/ambience/femcry2.wav": {
+     "bytes": 55420,
+     "sha256": "ade2e2a1250ab8c9f375d9558b57939597d8e3dcfd26376870444937a21b253c"
+    },
+    "sound/ambience/fire1.wav": {
+     "bytes": 47906,
+     "sha256": "c1370a7c177aa21de219578cc64716bc800007e2ac86ae106affac01f8edc470"
+    },
+    "sound/ambience/flame1.wav": {
+     "bytes": 1187588,
+     "sha256": "9edf9776ec5dec9957f5d1aada5eb464d17e868167875c5a7def5be9ce72198f"
+    },
+    "sound/ambience/flame2.wav": {
+     "bytes": 1824388,
+     "sha256": "d69c9f0f59544b7bf7831e83cdb03ef91c9fcce98b793e9a15cbf6e7d6b1b645"
+    },
+    "sound/ambience/flame3.wav": {
+     "bytes": 1203360,
+     "sha256": "9b520982d9a421e5d5f14c5cdd59bb6b03d292d23cf8d2150ac001633e5e7da4"
+    },
+    "sound/ambience/flame4.wav": {
+     "bytes": 1076636,
+     "sha256": "562430d4345e19cea8352e967f2866a33d050c85b450c5d525205655c57e4a07"
+    },
+    "sound/ambience/flames1.wav": {
+     "bytes": 132406,
+     "sha256": "8ac99a7ace2ec9cc98a38fd5777973eb484e9193cf93dfcd6a51ea4f0f9d0f00"
+    },
+    "sound/ambience/flames2.wav": {
+     "bytes": 132406,
+     "sha256": "31e76d131cb4ad3c0602e2559c949feb7a8749c639363f1fd7df53136616fdd1"
+    },
+    "sound/ambience/flames3.wav": {
+     "bytes": 132406,
+     "sha256": "b4008d1da182bc0886f8bad53e5a700d8e04050920aa27ceb0922be938eb7c96"
+    },
+    "sound/ambience/flames4.wav": {
+     "bytes": 132406,
+     "sha256": "222222e080566c899a48df9e40006d0ee36575c03250c44845fb10a94c5cead9"
+    },
+    "sound/ambience/flicker1.wav": {
+     "bytes": 90822,
+     "sha256": "9f7004a0d008cb28c43de538747a16c565784620e624c20f01d3b0227aac651a"
+    },
+    "sound/ambience/fliesbuzz.wav": {
+     "bytes": 688582,
+     "sha256": "59c0f48d0f5bd362fb0dcdfc53fbb699c1996ad8ca11526f10421cf2f45c3236"
+    },
+    "sound/ambience/flybird.wav": {
+     "bytes": 929858,
+     "sha256": "c228c0e4489f00ade09d4de11389c2e87b2492cf6e0abb4c7090c27554a45e66"
+    },
+    "sound/ambience/flybirds.wav": {
+     "bytes": 129140,
+     "sha256": "d3efc001bcb45d9020aa3fa818dc13763e5698b01d8d02abc9b629be5fcedb5d"
+    },
+    "sound/ambience/forest2.wav": {
+     "bytes": 1495284,
+     "sha256": "bf1231af5ce531c5f27d11ca1f3d75a284de24a24557f5c7f7b1d8680db55c15"
+    },
+    "sound/ambience/gargoyles.wav": {
+     "bytes": 136816,
+     "sha256": "16f09404b6043aaacb4b6b2bb00143ab72b5e185f02e610d780ea7d311d2df6c"
+    },
+    "sound/ambience/gearopen.wav": {
+     "bytes": 49708,
+     "sha256": "39b73c8ada1b06c7ba07099447b9b0d75911f08df09ced3826bcff136af5b0ee"
+    },
+    "sound/ambience/generator_gas.wav": {
+     "bytes": 529314,
+     "sha256": "6710075453fde424951171823e87f3711d53fd434149ddecc14a14ce721de04a"
+    },
+    "sound/ambience/glacier1.wav": {
+     "bytes": 2548728,
+     "sha256": "039a275b9dad2bff92044570230587354e0cb2ef0626e0b0921378acb34ecc5b"
+    },
+    "sound/ambience/glacier2.wav": {
+     "bytes": 2680940,
+     "sha256": "623638e32aa5fc389367673442f308229c15e074cd52321da131d21413a9540e"
+    },
+    "sound/ambience/gloom1.wav": {
+     "bytes": 8572576,
+     "sha256": "4c70cc1a9bd16a4327b69cad920ca7ea376f16e17bcee928e68b7888528abdae"
+    },
+    "sound/ambience/gulls1.wav": {
+     "bytes": 143164,
+     "sha256": "ae9a419dec383ffcb2c8a4f68d3a053b61fa43dd198737098f54c6435c70b1c9"
+    },
+    "sound/ambience/gulls2.wav": {
+     "bytes": 137014,
+     "sha256": "2157801b81a9d379047879484cca5c23b9efc42dac91682a95ce1a9654838c19"
+    },
+    "sound/ambience/gulls3.wav": {
+     "bytes": 131152,
+     "sha256": "760b24536fd76cc5c8ab210de1402d3a9e7a40961c4e7c8f0c9f49b91d2d0009"
+    },
+    "sound/ambience/gust.wav": {
+     "bytes": 134730,
+     "sha256": "e10433e663efa64cf3aeca786ec8bbbac2211805905aae8cbf6b1110c625ce9f"
+    },
+    "sound/ambience/ham.wav": {
+     "bytes": 48552,
+     "sha256": "c590cbe9bcf72093272b14e952bdb3f7bbc303b635e7dd83b8cfb52a64e9253b"
+    },
+    "sound/ambience/haunting.wav": {
+     "bytes": 397058,
+     "sha256": "4404004c4a16f00ff024b8643d6a0aab1d7febbc4e22161440299486c6fd0df2"
+    },
+    "sound/ambience/hawk1.wav": {
+     "bytes": 98500,
+     "sha256": "a0482e00feb3695aec46da53a63082af7559793b2ff489e41d61a76624d9d828"
+    },
+    "sound/ambience/hdd.wav": {
+     "bytes": 431320,
+     "sha256": "f98e7e16f0738085c742243d5d915eff53d7bb677f6122455bd4e3c348a52c8f"
+    },
+    "sound/ambience/heart.wav": {
+     "bytes": 9852,
+     "sha256": "b28aa25355c3f613f6b945d4d984d5ed2e01d5ce747642a77a5c9e2104e10c18"
+    },
+    "sound/ambience/heretic.wav": {
+     "bytes": 752488,
+     "sha256": "e68a51d62000b51c2800b0f0af7701e750bb02c49e1fa9487a7519a42054bb99"
+    },
+    "sound/ambience/howl.wav": {
+     "bytes": 134864,
+     "sha256": "6cb2219e05afc558f0d3d732c2c0bfe7b463d3803fb4a57bab1579dd0a2f63e4"
+    },
+    "sound/ambience/hum1.wav": {
+     "bytes": 28434,
+     "sha256": "c37106bf90bd04abe4e41f7934201dd0a56e42d856904d8bab3c0e9568dae2ee"
+    },
+    "sound/ambience/icefall1.wav": {
+     "bytes": 1040944,
+     "sha256": "3e30151aa657458913fefdb163dd306aab237a58cdfceedfbe3c05411adeb46f"
+    },
+    "sound/ambience/icefall2.wav": {
+     "bytes": 589312,
+     "sha256": "6c876582647b5abebc2f6e969ab17c8418b094348626f7fdba71d153a80f1921"
+    },
+    "sound/ambience/ind1.wav": {
+     "bytes": 62154,
+     "sha256": "a5b96308577bcaa8447b2692c0231aef9080420c7b10e93392c3de27c9cc6ca2"
+    },
+    "sound/ambience/ind_lift1.wav": {
+     "bytes": 158906,
+     "sha256": "c722fa19c7851d2c7b4307489911b885527e31fd3e4de44d5a184bd786714049"
+    },
+    "sound/ambience/ind_lift2.wav": {
+     "bytes": 156008,
+     "sha256": "c404881a9758f839fd055dd69a82f04bf7e5d5b98538a4a87b2ee741d8b4956d"
+    },
+    "sound/ambience/kitti1.wav": {
+     "bytes": 777568,
+     "sha256": "fb142ac9996631780873555d9bb16489ebccdc0648e5a08ef48bc2856bb957f8"
+    },
+    "sound/ambience/lab1.wav": {
+     "bytes": 59358,
+     "sha256": "7f0b912d31de6af166248dadbf324fae9a1d1adcacc4058205734c09e19cba43"
+    },
+    "sound/ambience/lab2.wav": {
+     "bytes": 32880,
+     "sha256": "21816bdda14efc524fd69b719c20b15a9cbee0e72f59f27fe23e1ddea29dac0f"
+    },
+    "sound/ambience/lap.wav": {
+     "bytes": 904034,
+     "sha256": "7e9fb37337d20f8685b49d245931ea06296be96a8f2cb703abb359679e59ac29"
+    },
+    "sound/ambience/lap1.wav": {
+     "bytes": 904034,
+     "sha256": "7e9fb37337d20f8685b49d245931ea06296be96a8f2cb703abb359679e59ac29"
+    },
+    "sound/ambience/lap2.wav": {
+     "bytes": 1080718,
+     "sha256": "fd7600e6635eeb5013bd5eab3a6fe73d8429dfd483786bb0f2a5b00619760efc"
+    },
+    "sound/ambience/lark1.wav": {
+     "bytes": 136420,
+     "sha256": "789723000f2b81000c6b1344a98029396c556337ca1c088cdb29e0796dee52e0"
+    },
+    "sound/ambience/laser6.wav": {
+     "bytes": 48164,
+     "sha256": "95b50c6c034b4baec0dc0da5adc57efe0c2e790f19865a1cbb4e946d2c4106a3"
+    },
+    "sound/ambience/lav2.wav": {
+     "bytes": 733790,
+     "sha256": "f0570d20bb5f819a9dbb402d1e6969a8531351e740ca7e015b8d73d0dd5ae5d6"
+    },
+    "sound/ambience/lav3.wav": {
+     "bytes": 627832,
+     "sha256": "495d6663d413b09c267050b6349d309192dc8806291923fd8ee3917ec7383754"
+    },
+    "sound/ambience/lav4.wav": {
+     "bytes": 690934,
+     "sha256": "e4f268234c0fdbe925702d96ba37384de8777f506a451b64301a7ee7bb8f2642"
+    },
+    "sound/ambience/lav5.wav": {
+     "bytes": 690934,
+     "sha256": "11bfb06dd875b164eccc8fc1774701114261c89faa4729e5a84da44adaa941d5"
+    },
+    "sound/ambience/lav6.wav": {
+     "bytes": 999206,
+     "sha256": "94318a6e5430a35b219a4e4e9f8b4afca8c63594054f493e78d72eeaec40562e"
+    },
+    "sound/ambience/lav7.wav": {
+     "bytes": 1076440,
+     "sha256": "271f606922fe757059ee74af59b4b6303f910267a703f31affbc1a23133c54e6"
+    },
+    "sound/ambience/lav8.wav": {
+     "bytes": 148252,
+     "sha256": "5c9c1f4cf6ba7292fbc502e192bc4798299a3fbc956670993395bcd79c045ae9"
+    },
+    "sound/ambience/lava.wav": {
+     "bytes": 103616,
+     "sha256": "1ef2007dee618644beb7323c20aee1ed06debc676db6adff69ca41082be27015"
+    },
+    "sound/ambience/lava8.wav": {
+     "bytes": 324782,
+     "sha256": "34dd2374df59b7cbf8d02c042b40f201756c6ab7dd1ff7c695c8abe2c274d130"
+    },
+    "sound/ambience/lavflow.wav": {
+     "bytes": 893694,
+     "sha256": "fabfcfd07185b0831ea0e165cff7bc7aa2ee077fae50a8fc2bd3b3cb37d6a6da"
+    },
+    "sound/ambience/light_hum1.wav": {
+     "bytes": 100022,
+     "sha256": "cb2f04b81297621ffddbfb028dc5021a665e3285deb7c80757a47add8294f032"
+    },
+    "sound/ambience/liquid_bubble.wav": {
+     "bytes": 129688,
+     "sha256": "838ec1e72b2c433408a342a48518987edcb2124932eeb477d59653540b13d6ea"
+    },
+    "sound/ambience/liquid_burnlong.wav": {
+     "bytes": 710182,
+     "sha256": "9c9c77941f88416e3f20dfc4f028cc6c9719dd7f58a15dfc6124f1bb5a17f61a"
+    },
+    "sound/ambience/liquid_burnshort.wav": {
+     "bytes": 89464,
+     "sha256": "4ea16997389f1aa35549869a338f2093f40d14df030c381a7659cc7e3cbf8bfc"
+    },
+    "sound/ambience/liquid_drain.wav": {
+     "bytes": 220464,
+     "sha256": "e86a6012c8fc3a795791fc344ef636bb1854a602cd609e2df751531e89277cf9"
+    },
+    "sound/ambience/london2.wav": {
+     "bytes": 1795548,
+     "sha256": "dec002bfe13230dee6c587092a6ae43e1b9ed15473d39d2c119e020d728a0999"
+    },
+    "sound/ambience/lowboom.wav": {
+     "bytes": 666640,
+     "sha256": "ad591a6f574f48e654e32dacee6b7d862df8b47e20ef116f84415ad9aa515559"
+    },
+    "sound/ambience/machine_loop1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/ambience/machine_loop2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/mboat.wav": {
+     "bytes": 611162,
+     "sha256": "a8c91c5e85a8cad38a49da7037ea04ae962e3a115357f5d2a1c6b5c607a36aaa"
+    },
+    "sound/ambience/moan1.wav": {
+     "bytes": 137770,
+     "sha256": "0f2465c6f7cd894d3a87fdf3f5708f88415d2ede5bc8810717a6992fabf344c4"
+    },
+    "sound/ambience/moan2.wav": {
+     "bytes": 33598,
+     "sha256": "aa9dc4112e9343941f146d955227a1114f1d1911556db66e73fed4e39e981832"
+    },
+    "sound/ambience/moan3.wav": {
+     "bytes": 106538,
+     "sha256": "9b9b7332d2a12355d926c0d8499ae9ee34d94ba70a4a8e4591857239e97e2245"
+    },
+    "sound/ambience/moany1.wav": {
+     "bytes": 41890,
+     "sha256": "d338cd641b37e66a1ab7ea93e091c2d8d78f9e2dc2ec20669aff3192835fb2c0"
+    },
+    "sound/ambience/moany2.wav": {
+     "bytes": 66622,
+     "sha256": "300a007ba3ce1a961df6e4b54c9725dd553ca0416bb883536915e55d85c82f2d"
+    },
+    "sound/ambience/moo.wav": {
+     "bytes": 265502,
+     "sha256": "35b7924115bc4cdf94e9cbb274a4d9ca251d6878817834bec08aaa176f2ddc9b"
+    },
+    "sound/ambience/mtn1.wav": {
+     "bytes": 696776,
+     "sha256": "daa10f6e78c55487e771e4e3541413dacdd8787fe7610f1deccc820811c15b91"
+    },
+    "sound/ambience/mtn2.wav": {
+     "bytes": 2112686,
+     "sha256": "7ce3bddb79bb22ea7098ccdebdd4e028144db5e591bab257cb294d8e26711d7c"
+    },
+    "sound/ambience/mtn3.wav": {
+     "bytes": 2593192,
+     "sha256": "55bca2776e23fa7c78114d7123a6c8736856934bf63d7b217f82b436953c5074"
+    },
+    "sound/ambience/mystery_drone.wav": {
+     "bytes": 1350258,
+     "sha256": "eb3fbb28dda2a6204af07d08fa993ed09513f9915142dd6f4af808204b6b8c9e"
+    },
+    "sound/ambience/mywind.wav": {
+     "bytes": 471290,
+     "sha256": "ade4d87f628c4884314e7e4950c0dfcad5acd12a0ac456710f22012b822c0d75"
+    },
+    "sound/ambience/neon.wav": {
+     "bytes": 1326570,
+     "sha256": "127c59c1129350615d186d4006d48f808ed5d7095fde10ca8a0f4fe666f2a2c6"
+    },
+    "sound/ambience/nuke.wav": {
+     "bytes": 704444,
+     "sha256": "25d225739258153ab7a4054ed1cdde8ace0e8f9c33fdc1260206fecc08f2068d"
+    },
+    "sound/ambience/ocean.wav": {
+     "bytes": 629904,
+     "sha256": "f10c3593838924acec6be476cc0dd53ccea3a0cfa3cc7c59a3f47564f94d1bb9"
+    },
+    "sound/ambience/ocean1.wav": {
+     "bytes": 629904,
+     "sha256": "f10c3593838924acec6be476cc0dd53ccea3a0cfa3cc7c59a3f47564f94d1bb9"
+    },
+    "sound/ambience/oldcomp1.wav": {
+     "bytes": 928028,
+     "sha256": "d0dd5fd863bb929aef1e0df0d488078e28e25a1107781327a0966d8706a7ab52"
+    },
+    "sound/ambience/oldcomp2.wav": {
+     "bytes": 929732,
+     "sha256": "fb59166e8d7b1cf0c1734f14e46ca6d81cf1da10edc632c76e0e354011da36f5"
+    },
+    "sound/ambience/oldcomp3.wav": {
+     "bytes": 764348,
+     "sha256": "cd629ea843f2bfee27fc51b9013f85ab4a9ce33c0ad47dc3efbca2e47b36c6c6"
+    },
+    "sound/ambience/oldcomp4.wav": {
+     "bytes": 736754,
+     "sha256": "014941a6b453d362813d90d12f6b28f3bafef64eedd437fc6e9d0b0a09105095"
+    },
+    "sound/ambience/oldcomp5.wav": {
+     "bytes": 907758,
+     "sha256": "b0db184f1e13e918fd202947144f71b5eb9c7a8506e7df144f9eb0b1e98f9739"
+    },
+    "sound/ambience/pecker.wav": {
+     "bytes": 1164008,
+     "sha256": "95941da1a6f5245c632c652cc214750f0786699a5b0221d8879d3e45e17ff289"
+    },
+    "sound/ambience/pneu1.wav": {
+     "bytes": 28972,
+     "sha256": "2853445c940a5d5695ee6f4b1cd3ca65793f7edfec31d77b5e7a655460e5e1f4"
+    },
+    "sound/ambience/pneu2.wav": {
+     "bytes": 29222,
+     "sha256": "0a99c759f924d97ef980b59dfaa34b6b353a801d43a2efec1aacbc7f7a0d0c51"
+    },
+    "sound/ambience/power.wav": {
+     "bytes": 1432836,
+     "sha256": "a3423831d297e7d5f0ae9c22cca72658ba441da0bbfbe41fbedf77cd9579340d"
+    },
+    "sound/ambience/power_off.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/ambience/power_on.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/ambience/power_shutdown.wav": {
+     "bytes": 1118464,
+     "sha256": "e0ab1a0f67a2d37a525f7a73e8ee8c3a26f746e027fa1501f6648f5586ea2048"
+    },
+    "sound/ambience/power_switch.wav": {
+     "bytes": 66382,
+     "sha256": "5c006bb7315e6eb6d2367ae30a78f0abec8ae2a1e2b6a2c9af88354962b0f33f"
+    },
+    "sound/ambience/prayer.wav": {
+     "bytes": 1807724,
+     "sha256": "b16a67df12dc2b222c01c4ff815968f7484f1c4982618b4aa18ab65ac778f00e"
+    },
+    "sound/ambience/printer1.wav": {
+     "bytes": 1401376,
+     "sha256": "bd2736f233ba7313c60f312fa981ccf106cd4f60cef4322449c9137fcd824cca"
+    },
+    "sound/ambience/pulse8.wav": {
+     "bytes": 55534,
+     "sha256": "0394f1325e1b00403ee61ecd04ff3745026260e9b0e9b05d7731bbfdb13d5054"
+    },
+    "sound/ambience/puncher.wav": {
+     "bytes": 227682,
+     "sha256": "efcd2d085e89bec50db3435558e2fcaba85e47e7455b053b1be6f52ff0c1a446"
+    },
+    "sound/ambience/rain1_nl.wav": {
+     "bytes": 154394,
+     "sha256": "45d8c08ff4a9a2dd6ff8362fea7c22f9c3ea64a3a8d7b6c81c8cad88265f327a"
+    },
+    "sound/ambience/rain2_fade.wav": {
+     "bytes": 198550,
+     "sha256": "3cf300a4f785d416656838bd3a68120bf6a48d16f928ca74e2e0890ec9f8b426"
+    },
+    "sound/ambience/rain2_nl.wav": {
+     "bytes": 66250,
+     "sha256": "f2735ae8a7b1ae5ab5ce3b8ed66d8c61d00a65f2e66d8c565f4abe718d57ab67"
+    },
+    "sound/ambience/rain2_org.wav": {
+     "bytes": 132400,
+     "sha256": "4c1f820b2c8f4bea08b8357fb8409e9f30a98fd0faf1413a1953ea697b84b507"
+    },
+    "sound/ambience/rfall1.wav": {
+     "bytes": 516062,
+     "sha256": "86ef2d30076c56bff8e87cda611f6984ca1e3f99f09eac965cf611f953947578"
+    },
+    "sound/ambience/rfall2.wav": {
+     "bytes": 497016,
+     "sha256": "ce6fc56f5b9056ea33da1e7a57f8927f27befe1b96aead401bc2093eef83c98e"
+    },
+    "sound/ambience/ripple.wav": {
+     "bytes": 198486,
+     "sha256": "9babb6e34d1e557f74ecc0dddd624f7fb662ffb6f7707ff194caf75bbbb04a1f"
+    },
+    "sound/ambience/robo1.mp3": {
+     "bytes": 24445,
+     "sha256": "1b40cb82ddae9b94bb5c84611bf3e5e96af18a59bb2335d39454cceb120cb733"
+    },
+    "sound/ambience/robo1.wav": {
+     "bytes": 150322,
+     "sha256": "61b49ee5489e6e8754f5880e56bcc8dadf73d3fd3e04bc5aeeb1468455004d66"
+    },
+    "sound/ambience/robo2.mp3": {
+     "bytes": 20677,
+     "sha256": "f7103eaeca7fd77efec712c07c46a8b5575c7aec4dfb6386fb7155e2bbd3984e"
+    },
+    "sound/ambience/robo2.wav": {
+     "bytes": 137652,
+     "sha256": "1b8af86f3db2f768b70936fcf900e191fce46cddac1b85b585caef1bfa641dba"
+    },
+    "sound/ambience/rumble1.wav": {
+     "bytes": 403620,
+     "sha256": "47afe820548bcf248b7760f7a66a61ea65b5fb79f70d47e3b03cf8211bb4c5f3"
+    },
+    "sound/ambience/rumble2.wav": {
+     "bytes": 99104,
+     "sha256": "9c3d5418c7e5bac60c365f0e8b7ea496dd2b51c72c13b0e5a6640e2ef880433a"
+    },
+    "sound/ambience/rumble3.wav": {
+     "bytes": 209242,
+     "sha256": "864f373dbd75172e1c8f31373188f38c31a80af46592f6b2e92cf5f576e5e0e1"
+    },
+    "sound/ambience/ruskylp.wav": {
+     "bytes": 95480,
+     "sha256": "c33726020dac5cda38904ee00dd585f8b6ef3e96f0466219c0b53aa182e00155"
+    },
+    "sound/ambience/s1_stop.wav": {
+     "bytes": 16162,
+     "sha256": "9a35adf9361aa033b413762fea7d04b2cf7392b363f2aa187a81905f65a44b61"
+    },
+    "sound/ambience/scave1.wav": {
+     "bytes": 2185362,
+     "sha256": "eef4c0dbbb7fadf27ccb2678bd45a316185edb4651b54a64e4982a68ef123468"
+    },
+    "sound/ambience/sea.wav": {
+     "bytes": 2122012,
+     "sha256": "bd4073b44ba64db31cd67db0851ec404601bfb35270c5d34179be5943d2bc3d9"
+    },
+    "sound/ambience/sea2.wav": {
+     "bytes": 2313920,
+     "sha256": "a1e7fa11fc3e1cfe57dd37315f011c6db10e9fe453d171ec9da813d5422321f5"
+    },
+    "sound/ambience/sea3.wav": {
+     "bytes": 3258718,
+     "sha256": "9292f6bd1c928a890e1d5d75dd1a65bd13f57ea214e3533c64f0bf3373a3e239"
+    },
+    "sound/ambience/sea4.wav": {
+     "bytes": 2606960,
+     "sha256": "2b6da4fdbc145373fa34eb5776c1ce0b47962349433dffa6fdf33165bdfe9c4c"
+    },
+    "sound/ambience/ship1.wav": {
+     "bytes": 715970,
+     "sha256": "e0cf93a51d4adbf96aba14da7c5c437687fcec5e6e692ea4abeae70bb75732de"
+    },
+    "sound/ambience/shoppin.wav": {
+     "bytes": 1130028,
+     "sha256": "04caf88b623d49ab8b5fc4794b4660a6a5f1c0522f377f47e968dd6acd3280f7"
+    },
+    "sound/ambience/shower.wav": {
+     "bytes": 825730,
+     "sha256": "a19bd2f53d489681660ca49d67366ad5437c435f84ca3fa47c2b144eca515bdb"
+    },
+    "sound/ambience/siren.wav": {
+     "bytes": 15612,
+     "sha256": "59d5f0077e564778c34249d6b8b54a4df99412c6d89748cabfd0778650ff3fa1"
+    },
+    "sound/ambience/siren22.wav": {
+     "bytes": 405522,
+     "sha256": "707083b5f88e21496c85bf49e8fb01acfba6afb876788ec7b90a2a2ecba557e0"
+    },
+    "sound/ambience/snakey.wav": {
+     "bytes": 88916,
+     "sha256": "a1d2d8b2033b16fdfcac628bfe2fe432e54e465fb345cbe6f122796d7df9d726"
+    },
+    "sound/ambience/sndwind.wav": {
+     "bytes": 2586994,
+     "sha256": "d061f21385821b82ee1c585aacb5027e9dd0416d8d6032b119b159532d526a5a"
+    },
+    "sound/ambience/sndwind1.wav": {
+     "bytes": 2148892,
+     "sha256": "6fbec0b90aacfe0f86c0dc0e5150dc58fe0b7522ce863328d6f31e6254342621"
+    },
+    "sound/ambience/sndwind2.wav": {
+     "bytes": 2024390,
+     "sha256": "6cd756ecfe80e2e11bf30384f45b87439e132cb4eacd53847305ffc3ea0a17a7"
+    },
+    "sound/ambience/snwind1.wav": {
+     "bytes": 2148892,
+     "sha256": "6fbec0b90aacfe0f86c0dc0e5150dc58fe0b7522ce863328d6f31e6254342621"
+    },
+    "sound/ambience/snwind2.wav": {
+     "bytes": 2024390,
+     "sha256": "6cd756ecfe80e2e11bf30384f45b87439e132cb4eacd53847305ffc3ea0a17a7"
+    },
+    "sound/ambience/souls.wav": {
+     "bytes": 628896,
+     "sha256": "08c0fff33d7df0fa276c7b8b4458e0317656b4073824c2d6c7ecc9db6a0c7d42"
+    },
+    "sound/ambience/space2.wav": {
+     "bytes": 2963024,
+     "sha256": "cc7e952a60612d8b42834b9b82821b0fe5f11a3352495156122c7c5dc0486414"
+    },
+    "sound/ambience/space3.wav": {
+     "bytes": 2963140,
+     "sha256": "e21474fef0636c9175067d2274561bffd798c20dc664871eb05ab7bc4ac0d5b8"
+    },
+    "sound/ambience/spar2.wav": {
+     "bytes": 124398,
+     "sha256": "050591405072eeb8fe4941a69232e9b29b582cec4c0358f94e59210d542f6341"
+    },
+    "sound/ambience/spooky1.wav": {
+     "bytes": 48964,
+     "sha256": "c2f00c4f2726627657cd30048b6ac463660e23173999c6d711be2660d99cc60f"
+    },
+    "sound/ambience/sprklop1.wav": {
+     "bytes": 45480,
+     "sha256": "9a981c053ae92863e8280553f9cd956cd84a6c64753004a3bf7613b613bb6e36"
+    },
+    "sound/ambience/sprklop2.wav": {
+     "bytes": 30888,
+     "sha256": "fd8833d7f50575d1cf962fa02ea9a82bd5bd1cc19ce6f5621f196d93678f5064"
+    },
+    "sound/ambience/squeak.wav": {
+     "bytes": 26126,
+     "sha256": "d2aef3baa3bcce7691a41611beb09c91808de2074e44deb7101f8ab917a6ac12"
+    },
+    "sound/ambience/steam.wav": {
+     "bytes": 26722,
+     "sha256": "8228201f74255a960b8115f5dd3df929b0f8711f1ad481fdbe93e89d391be2b0"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 440806,
+     "sha256": "8cc7307954ec8f1b1607229e5f4187eba14d1770fa08ad3aa8b36d79b3346381"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 2314806,
+     "sha256": "69aabd775a504e944959604c81629838a75b0ed7896c698cbf71dc6581399620"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 584918,
+     "sha256": "0448ca80482fa440714b6aa1bad03f4e6b38267efe56312d0345b7b0d46cf95a"
+    },
+    "sound/ambience/swamp3.wav": {
+     "bytes": 2092836,
+     "sha256": "c77a0a6f6a23a0f8d11291f38bfad3a1d642098be1a6d955d6016e43709ed1c0"
+    },
+    "sound/ambience/swamp4.wav": {
+     "bytes": 1363048,
+     "sha256": "cbf68e1c81b9934f74e77f443d3562a6083a260e5085e123e1f76daf1d7f8b4d"
+    },
+    "sound/ambience/swamp5.wav": {
+     "bytes": 864420,
+     "sha256": "f3ae465629cdb235562cb0bf280dddc5cc4eb869ace50b14ee8daa40c55d710c"
+    },
+    "sound/ambience/swamp6.wav": {
+     "bytes": 1605748,
+     "sha256": "7dcc52426df74699c33a28693bacb5e02771e94bab0573e7b557736f38a384d6"
+    },
+    "sound/ambience/swan.wav": {
+     "bytes": 1266578,
+     "sha256": "48c3aa7189dab70d8a51a1db78ec10cde840fca48813d68f19086725e8ec4865"
+    },
+    "sound/ambience/switch_1.wav": {
+     "bytes": 35324,
+     "sha256": "9f73f07313ba4995247d82901111b5aea4200c48de6641dddb145dfadcac40c9"
+    },
+    "sound/ambience/switch_2.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/switch_3.wav": {
+     "bytes": 17576,
+     "sha256": "33b6ed57b0255840415df4db607f86b1183b564f4b1f2dcab6d45d4d75231b8c"
+    },
+    "sound/ambience/switch_4.wav": {
+     "bytes": 44348,
+     "sha256": "bfebdf2afdbab57bd5be3fe0996ce19ff46d983eea4d1511d85af2e4f7d0db00"
+    },
+    "sound/ambience/switch_5.wav": {
+     "bytes": 79992,
+     "sha256": "78bb8cb9ab7202657495a0ca14340886af901912850b9951b0da159f55c2cb20"
+    },
+    "sound/ambience/switch_6off.wav": {
+     "bytes": 141466,
+     "sha256": "999d3b02b7224586d5c487c2666981f054aa091f0569671c72455bff458c9a2a"
+    },
+    "sound/ambience/switch_6on.wav": {
+     "bytes": 176192,
+     "sha256": "7a67fa5d4ee042c6afd271868682a1a34908c2593e5ea9e868ecb6d3e154b55b"
+    },
+    "sound/ambience/t1lp.wav": {
+     "bytes": 1192490,
+     "sha256": "862df594ce9f9d371f758f5b5a487ffeecb0c1cb8d8b014d12f89807de2b2d72"
+    },
+    "sound/ambience/teeth.wav": {
+     "bytes": 132346,
+     "sha256": "431c615727815e9ea06675927738227a5885390e4985294498c9b04f5bed1fa0"
+    },
+    "sound/ambience/tern1.wav": {
+     "bytes": 640390,
+     "sha256": "6564b021c8503eca8bea695799a7384112614c5324d22a5596d5e73821ef1190"
+    },
+    "sound/ambience/tern2.wav": {
+     "bytes": 331828,
+     "sha256": "9769ead3809f087c741dab6ab55f0ee740e270b6c19855c3670ce1d11a76cda3"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 220548,
+     "sha256": "2cec0b03aa7047110862de21f8f6c77e4d98901ecaf5e405a473c2ddc922528a"
+    },
+    "sound/ambience/thunder2b.wav": {
+     "bytes": 286716,
+     "sha256": "44095eceb307b5f2f1093051597ea0e48bc7abe165accd5badf99c4ad692c6df"
+    },
+    "sound/ambience/tnlwind2.wav": {
+     "bytes": 275128,
+     "sha256": "85a237d1fc2365e76a9d82753bf3f9b535ebb29231f1eb6b0bd6c4cf24469c8e"
+    },
+    "sound/ambience/toot.wav": {
+     "bytes": 794816,
+     "sha256": "ba08763c76a7beb56226a053155b5869bdd46edda44911b839127dd04a0075ff"
+    },
+    "sound/ambience/train1.wav": {
+     "bytes": 139454,
+     "sha256": "89251a90469a1072deb909f61d37094cc9eb6ec3e68dd06e687751b8ffc34ece"
+    },
+    "sound/ambience/trainst.wav": {
+     "bytes": 38556,
+     "sha256": "ace3ade85a911087942396876c93e061f92fc4f5d7c3e7669d15b66fc6f532ea"
+    },
+    "sound/ambience/troll1.wav": {
+     "bytes": 953616,
+     "sha256": "c6ae5bef0592119f1a206a8b174bf1e8983dc94ed9187739e86f3cb6cb4c312a"
+    },
+    "sound/ambience/turb1.wav": {
+     "bytes": 1251510,
+     "sha256": "eb01d8368469ed9b273837cdc6c982a09e7509001600310f84aece65295d92c2"
+    },
+    "sound/ambience/turkey.wav": {
+     "bytes": 37964,
+     "sha256": "569d0ba4479ea817f5222cb388e57eda49ce49936ab479dd4ca86cfb5f4e54cf"
+    },
+    "sound/ambience/twind1.wav": {
+     "bytes": 362412,
+     "sha256": "ad024e46ab033db148cee8608c362baa9ae68f41daf2bda90824365c135be249"
+    },
+    "sound/ambience/twind2.wav": {
+     "bytes": 481050,
+     "sha256": "f64966709bde6f1513a2ddcd90df2f11492a762b359a72eecf6eafff32ed7a8c"
+    },
+    "sound/ambience/under.wav": {
+     "bytes": 64214,
+     "sha256": "9130c003d9e38e29023435b9c39b47b6ea0322e091851f39e4fd7fb8d77c458b"
+    },
+    "sound/ambience/under2.wav": {
+     "bytes": 218178,
+     "sha256": "1953f40f33cfdcc911b2080bd9ef8576d042c71a5593a19229313e8613a9f9f4"
+    },
+    "sound/ambience/wat1.wav": {
+     "bytes": 919448,
+     "sha256": "51db937a7e544dcaa4c96623dc868a5e3ce8ea6ce45e90b746a72dea4c00c07a"
+    },
+    "sound/ambience/wat2.wav": {
+     "bytes": 882206,
+     "sha256": "c44457d35a602bd5d3d3f28d3127e0bcb382a62d1b928dfc142f78da3f24f085"
+    },
+    "sound/ambience/wat3.wav": {
+     "bytes": 2542392,
+     "sha256": "c955fac71da6f6eba7bf5c44ca0aa16c151ba91596bd7d0c2fcb5971e1388173"
+    },
+    "sound/ambience/wat4.wav": {
+     "bytes": 922866,
+     "sha256": "5e26f2d5cab802d114e2145893979416d1d9376d41dbb444f71206a799f2282e"
+    },
+    "sound/ambience/wat5.wav": {
+     "bytes": 880020,
+     "sha256": "ad51f69c6960800aa24fa50c96733077a411e2ac52119f9544bf0f28029dd4c9"
+    },
+    "sound/ambience/wat6.wav": {
+     "bytes": 917386,
+     "sha256": "c10ac251e8d683d2383b7cb422697b47179f7dd585bfb145fdf6fcdf2f762ea4"
+    },
+    "sound/ambience/wat7.wav": {
+     "bytes": 828520,
+     "sha256": "4b334549b84ef932c3f73726e50be54d4696daf053bd4447a5cf847b4b7eafec"
+    },
+    "sound/ambience/watbrd1.wav": {
+     "bytes": 944566,
+     "sha256": "677888a1c4dc30c17dbeca0b7e4518d885b71488e09819e6949af5788367b29a"
+    },
+    "sound/ambience/werie.wav": {
+     "bytes": 72752,
+     "sha256": "623128f8e53ac95a12c6d05a1a93bf3b6639cc636ab96741bf4418b0812852a7"
+    },
+    "sound/ambience/willow.wav": {
+     "bytes": 1259836,
+     "sha256": "f2b0953480ad9b6d2732227d0da94fe87c0b5dfd75207ed47d898daba3f50768"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 66250,
+     "sha256": "25f72618ddd54fedc6a84ffc410673d990f781160bc241a5589bfb9e23d0c2cb"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 220656,
+     "sha256": "f651ecd509db73a4b0351e1b97f2321c6555fe637fbbc4f8648d83ba7bbd5d2b"
+    },
+    "sound/ambience/wind4.wav": {
+     "bytes": 2024390,
+     "sha256": "6cd756ecfe80e2e11bf30384f45b87439e132cb4eacd53847305ffc3ea0a17a7"
+    },
+    "sound/ambience/wind5.wav": {
+     "bytes": 314964,
+     "sha256": "5af7862159303cd5839cb01da3d5ce08c57ba709d5ac6ef275c77e46c791961b"
+    },
+    "sound/ambience/wind6.wav": {
+     "bytes": 355808,
+     "sha256": "1c4677aba9c8f804284a1e06def763daf78e71c3f1c085ef3c3d558a7985b843"
+    },
+    "sound/ambience/wind7.wav": {
+     "bytes": 351866,
+     "sha256": "4e5f645467ee3feba3be8d0afda9d6b3fe9a35918a012eb6f8560b2173524321"
+    },
+    "sound/ambience/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/ambience/windgust2.wav": {
+     "bytes": 110284,
+     "sha256": "b818f61172795942402ff0ca0d1295a91c36a245edc80689c35fe64a8ac1a4e2"
+    },
+    "sound/ambience/windgust3.wav": {
+     "bytes": 110030,
+     "sha256": "fdbb85f091cd9447f1500173aff70236abcdb947ba0758711816da59c5293344"
+    },
+    "sound/ambience/windgust4.wav": {
+     "bytes": 198502,
+     "sha256": "9a5c5a3da44f981c9deb8b437f57b3e3a35f2bcab318a1a3223f0a18fa4d2101"
+    },
+    "sound/ambience/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/ambience/windgust6.wav": {
+     "bytes": 396944,
+     "sha256": "27a19679e7164a6e7bb8e4d6bc42cc8c12a5cd56bba45218e2ec5f1dc528da0d"
+    },
+    "sound/ambience/windmill.wav": {
+     "bytes": 40682,
+     "sha256": "f323d5e1e9bab0ebf7a7c3ace51f3721b954bfbf7a6c86e9b9df6c3b271bf6c6"
+    },
+    "sound/ambience/wolfst1.wav": {
+     "bytes": 718048,
+     "sha256": "3da0691024b33a0db6003006269c110fe77e9bb211ed55fdfc6b0c59ffdba45a"
+    },
+    "sound/ambience/woodcreak2a.wav": {
+     "bytes": 352834,
+     "sha256": "24d3f57839910934eb61b74a91cf47ee4ab48b38f58f060ca05bde7547e8813c"
+    },
+    "sound/ambience/woodcreak2b.wav": {
+     "bytes": 352838,
+     "sha256": "574401233bff93169d452f4af748a289cfaff5d4e6319884e3cfb4dbd205d0a4"
+    },
+    "sound/ambience/woodcreak2c.wav": {
+     "bytes": 308746,
+     "sha256": "02deb62b856b7be5c3304a0bf745f79019b0b408a8cfcc4e1edede397ba09c7d"
+    },
+    "sound/ambience/woodcreak2d.wav": {
+     "bytes": 352856,
+     "sha256": "6d35975964b2fa32ece681a9d0cfa13202cde02bc315f32af0690f7437352452"
+    },
+    "sound/ambience/woodcreak2e.wav": {
+     "bytes": 308766,
+     "sha256": "54eb41e3f5c2a0103d07e70e83cf82b51014da3673fb770cf6ada3df669c328e"
+    },
+    "sound/ambience/woods3.wav": {
+     "bytes": 109198,
+     "sha256": "b42920303ec380aad7f0e4554829c147a8454a93bf30fcd1a0cbdb6f6a0ccf1c"
+    },
+    "sound/ambience/yehaaa.wav": {
+     "bytes": 1197436,
+     "sha256": "367df3edd7f477cdcbb3f3ff14c1381a781b288571a98e758c15ade76d328c65"
+    },
+    "sound/ambience/zmoan1.wav": {
+     "bytes": 251514,
+     "sha256": "61cfab08c072afbf7911a1cc624408441500579beea4c503ce91694c2afb840d"
+    }
+   },
    "sha256": "606e34335c080158107fd61e20f435aae5672b0411a5cd497687ec8407024b97",
    "timestamp": "2023-08-05T20:53:56.000Z"
   },
   "peril3.0/pak2.pak": {
    "bytes": 138384439,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 94990,
+     "sha256": "e790b189b1df23f116097b45f5ed391fd210319ecfa000d029b367a7c3d32ab5"
+    },
+    "maps/bmodels/az_chain1.bsp": {
+     "bytes": 219668,
+     "sha256": "4d2648c6dd850b04d48e9631ad02756ecf78d85f56810ff7b9db131a6fe641a3"
+    },
+    "maps/bmodels/az_chain1.lit": {
+     "bytes": 33272,
+     "sha256": "1daab5bb58dbf2c73968dc9db26cf0b0bd78652d491788d0a6124aaa9a9b6f4a"
+    },
+    "maps/bmodels/az_chain1.map": {
+     "bytes": 96430,
+     "sha256": "2b6c77f844eaf5a371b36c13cf512a24d8cd39095cdc04eddd64cd571060d098"
+    },
+    "maps/bmodels/az_chain2.bsp": {
+     "bytes": 333820,
+     "sha256": "746e38bbb4cebb63ac3344e944f24b874b9fd3ed584017bb599e027508cc6187"
+    },
+    "maps/bmodels/az_chain2.lit": {
+     "bytes": 22130,
+     "sha256": "c6ebc72f8dcaa06422eaf71e08771f76105ddd39c3ee6784d40083df67d1cf32"
+    },
+    "maps/bmodels/az_chain2.map": {
+     "bytes": 148314,
+     "sha256": "e9cb3cddd08835aed7b1eed8867a67b06fee9db20dd7584830b8918d4af169ea"
+    },
+    "maps/bmodels/az_chain3.bsp": {
+     "bytes": 308800,
+     "sha256": "6b78b5a83f2f71a316e85086e12b7a1f66abaf28b02a53076433e3b2b3a20fee"
+    },
+    "maps/bmodels/az_chain3.lit": {
+     "bytes": 20684,
+     "sha256": "28870bf7c7f011206290fe69c7b6e2501c27fba21bea2ae6767e8d85a4ff56e7"
+    },
+    "maps/bmodels/az_chain3.map": {
+     "bytes": 110405,
+     "sha256": "64eee084713fdb7da2ec9f9dbc7c482930d9a871d86fd0912d32ddf52063b1aa"
+    },
+    "maps/bmodels/m_bchains1.bsp": {
+     "bytes": 74963,
+     "sha256": "73beb2dc0b953e096e69a4e049af380e99c98ce1872b4da00c858be36d4e973a"
+    },
+    "maps/bmodels/m_bchains1.map": {
+     "bytes": 43470,
+     "sha256": "ecd781a6601c6fca262909cb2e116a222de2e5aa5417dd36d4475d5c433459af"
+    },
+    "maps/bmodels/m_bchains2.bsp": {
+     "bytes": 83651,
+     "sha256": "e23fad6717790c08e661748398754e60944527eb6e48c0f2c0ffbdba73cf95db"
+    },
+    "maps/bmodels/m_bchains2.map": {
+     "bytes": 42484,
+     "sha256": "e92865750499de9117e5bf19719052109179ebcc37ddbd40f2d91d914b86fa63"
+    },
+    "maps/bmodels/m_bridge1.bsp": {
+     "bytes": 431144,
+     "sha256": "ac4d490408f7ad9068a09c4c89f82a65b8573bc4ba810fe5f16418b1d2684f66"
+    },
+    "maps/bmodels/m_bridge1.lit": {
+     "bytes": 47240,
+     "sha256": "30601eb0d533bbe0f72631b77630c3922a46f34b38687aa184b7776e48e63164"
+    },
+    "maps/bmodels/m_bridge1.map": {
+     "bytes": 120280,
+     "sha256": "3ddec67bb95d788b2fecb0e4c6d09781a6a27ba79d322a637f3a03e84a8f6ac7"
+    },
+    "maps/bmodels/m_bridge2.bsp": {
+     "bytes": 201392,
+     "sha256": "4fec9b73e50ba0608d2b5f2fd5c4957324c4cb609becf3be979aedf644281845"
+    },
+    "maps/bmodels/m_bridge2.lit": {
+     "bytes": 21902,
+     "sha256": "c1fa88042c3fde27bd608d3829c8c4a142e70617087970ec7535d48847ac435a"
+    },
+    "maps/bmodels/m_bridge2.map": {
+     "bytes": 52004,
+     "sha256": "58943dc439d4d4c8e65773c12e361c3336488a94f0a53a54c06366675517b850"
+    },
+    "maps/bmodels/m_bridge2b.bsp": {
+     "bytes": 201398,
+     "sha256": "096dcacf528d2784b79a4c0dd19c445102778f2a053fde3a2a43540a4a621c73"
+    },
+    "maps/bmodels/m_bridge2b.lit": {
+     "bytes": 21902,
+     "sha256": "1c7bdad93866cabb97e4565bf41d2b8a8d4c8237e11b0965fd05fc954b6c2c64"
+    },
+    "maps/bmodels/m_bridge2b.map": {
+     "bytes": 52268,
+     "sha256": "d361d0c3dcfec2ae5d109075bf437d013762328ee48b8fc25f779267d7b1bfb1"
+    },
+    "maps/bmodels/m_bridge3.bsp": {
+     "bytes": 309343,
+     "sha256": "12d2199af263464d48455c2e5cd7bf2abf2085841fbc7e027a4cc96b04eec2d8"
+    },
+    "maps/bmodels/m_bridge3.lit": {
+     "bytes": 46964,
+     "sha256": "b783061b14bb4caf3cf9df9a6b8be9ea1d2a367339fa09ffe01506022b21a4c5"
+    },
+    "maps/bmodels/m_bridge3.map": {
+     "bytes": 138104,
+     "sha256": "33c8835d256fd00e65da818c4d43b86033bb8104897712b824014a035c2628e0"
+    },
+    "maps/bmodels/m_chains1.bsp": {
+     "bytes": 249145,
+     "sha256": "1f51d881982d8602c0da29c1f105ab07a41977bdab4fbf4598922563373f4a98"
+    },
+    "maps/bmodels/m_chains1.map": {
+     "bytes": 170858,
+     "sha256": "e1855a52ab0ae70c382876eb74fcafe5a065fefeb2e49a6956184637b9edc1bd"
+    },
+    "maps/bmodels/m_chains2.bsp": {
+     "bytes": 134457,
+     "sha256": "57a765e0ec315eca93927ad64e11b9b3ec8adae0c405de55d86c30b30ef51e5a"
+    },
+    "maps/bmodels/m_chains2.lit": {
+     "bytes": 15698,
+     "sha256": "c858c4c47488df5cac3ed19736c1aee29f4c7add0dfb45deeb7416c4c7af1f21"
+    },
+    "maps/bmodels/m_chains2.map": {
+     "bytes": 60423,
+     "sha256": "575ae8d717a2352ac8726b3bc0f11f6e0a83f548dd471a544a62f519bb71f692"
+    },
+    "maps/bmodels/m_chains2l.bsp": {
+     "bytes": 156552,
+     "sha256": "ff04a994c83f27104d6ef126ef2d08ce894ebe0a812c49f0d2ae79ce8808e8b9"
+    },
+    "maps/bmodels/m_chains2l.lit": {
+     "bytes": 15698,
+     "sha256": "9ebbd1a675e167d9a3be233cd65654728f2f1e0259dee00f55e3da02802abfa2"
+    },
+    "maps/bmodels/m_chains2l.map": {
+     "bytes": 61112,
+     "sha256": "346320204a3413bd6654018e37e42c442c21d88e15da513395c73e6daee26bed"
+    },
+    "maps/bmodels/m_chains2p.bsp": {
+     "bytes": 156555,
+     "sha256": "f0778b1608dbb058f1f492848ae3b64f66be0fef54e32bddfd6fe09f7b0e7a74"
+    },
+    "maps/bmodels/m_chains2p.lit": {
+     "bytes": 15704,
+     "sha256": "d2e7187908b4d3823091a9d69cce5ac807507372132b4162e48a6b027ecad53a"
+    },
+    "maps/bmodels/m_chains2p.map": {
+     "bytes": 61117,
+     "sha256": "7d1acdf4240cd91b158bbc23dfab846388efa7d20431f5a9c8dba8ab421102ff"
+    },
+    "maps/bmodels/m_chains2r.bsp": {
+     "bytes": 222620,
+     "sha256": "0e1ad04fd73c4bc183331471a3406665660fd8f030d14404b7c43b31309118e0"
+    },
+    "maps/bmodels/m_chains2r.lit": {
+     "bytes": 17552,
+     "sha256": "605d297ff2ece6796c064e3dd47e1c48e4fdc87324f059f2c1721e369de23a97"
+    },
+    "maps/bmodels/m_chains2r.map": {
+     "bytes": 61788,
+     "sha256": "749cc23346335d05a53b3399f49adb157fe29fe24512a65d3ab976bc811b5818"
+    },
+    "maps/bmodels/m_chains2rl.bsp": {
+     "bytes": 151968,
+     "sha256": "653185afe2384bf68c0e6d35bdd3404196404243a1b8d16cb730de9f7a45b4b0"
+    },
+    "maps/bmodels/m_chains2rl.lit": {
+     "bytes": 17552,
+     "sha256": "ef313b8c77329539ca8bbe6831e7d5b372e4e3f3cc807e6b66901b53f83d82d4"
+    },
+    "maps/bmodels/m_chains2rl.map": {
+     "bytes": 62332,
+     "sha256": "f5961359ef0867c6ecd501231f63912bf4066bb4d65685021efcd0d51d637f95"
+    },
+    "maps/bmodels/m_chains3.bsp": {
+     "bytes": 121996,
+     "sha256": "535075d6549167b5bf61ae91abf2c407ee009e64aa4222be35692478151feab1"
+    },
+    "maps/bmodels/m_chains3.map": {
+     "bytes": 57540,
+     "sha256": "08f7d97d9e8cd45c353d1141905c93d3327d8f77984790d9e952bd91a5247803"
+    },
+    "maps/bmodels/m_chains4.bsp": {
+     "bytes": 203735,
+     "sha256": "2840e2b604d571081a2b13ba2d340f596123b53213aaec8cd695e7a4d668e774"
+    },
+    "maps/bmodels/m_chains4.map": {
+     "bytes": 113061,
+     "sha256": "6727d20079382f7f2a76391d72e6b6bc3136cc6396ef4661b679f5c8f82d8427"
+    },
+    "maps/bmodels/m_chains4p.bsp": {
+     "bytes": 205127,
+     "sha256": "20183038acde1a46c9fae81e86837f876dc6e0bb7cc7a556457d4162264d7358"
+    },
+    "maps/bmodels/m_chains4p.lit": {
+     "bytes": 35897,
+     "sha256": "0dfb9177bd73b903703f0f4630c4941467a452ee676d568e7f32b2099699659d"
+    },
+    "maps/bmodels/m_chains4p.map": {
+     "bytes": 112283,
+     "sha256": "09d773ef730e9b4d81cdf23f4ac3b0efcb365771569638e7f5574407c5560146"
+    },
+    "maps/bmodels/m_chains5.bsp": {
+     "bytes": 94806,
+     "sha256": "04c40fce5016a3d26092812be589344740b29be788921f8ce354461d77943817"
+    },
+    "maps/bmodels/m_chains5.map": {
+     "bytes": 44835,
+     "sha256": "1e897fc203a12a480c1d3dfc13bf7653a06edb8132f98a3fedae50614c3ebb34"
+    },
+    "maps/bmodels/m_chains5l.bsp": {
+     "bytes": 117061,
+     "sha256": "f01c9c1e6f87c0588be0df3f8768f563acea6735451efa41366aa0acb63851db"
+    },
+    "maps/bmodels/m_chains5l.map": {
+     "bytes": 45411,
+     "sha256": "64691e385435777a920358775cb18e7ac6ee5290a34488103753a338500b6db5"
+    },
+    "maps/bmodels/m_chains5p.bsp": {
+     "bytes": 117214,
+     "sha256": "555df3c945155f7b820fde49c3e37d114f3c52bb63c4edb647dbc19161cb13d5"
+    },
+    "maps/bmodels/m_chains5p.lit": {
+     "bytes": 9152,
+     "sha256": "f78aaec615854b6382b6802298f42ac42dcdfdfb9c638b417257876fa83200d9"
+    },
+    "maps/bmodels/m_chains5p.map": {
+     "bytes": 45566,
+     "sha256": "1969841b81be135b7cb383f84bf7d38694d012b35b17ef3e2c630afbf5d6e64d"
+    },
+    "maps/bmodels/m_thanshelf.bsp": {
+     "bytes": 140335,
+     "sha256": "8319f2ba87d5a8ed864941fe9c7341744476be658ce211aaafc1ba0747afeac4"
+    },
+    "maps/bmodels/m_thanshelf.lit": {
+     "bytes": 3134,
+     "sha256": "04fd93ccf6b864bd9226faa29db923bc093200ed3f4fc8a8f6cce29b324a9743"
+    },
+    "maps/bmodels/m_thanshelf.map": {
+     "bytes": 10306,
+     "sha256": "811e75bc34627545ff7513dc658e937195b98b7839bad409bf21da4975fb7e03"
+    },
+    "maps/bmodels/misc_radar.map": {
+     "bytes": 5314,
+     "sha256": "7ca088f70d4421b994f1852dd17de1427a2b6401b19d8f464ecf2024f5025418"
+    },
+    "maps/bmodels/sep_chain2.bsp": {
+     "bytes": 130276,
+     "sha256": "eff6d1868abd6355f4858f41657262ebb87fa9093579eb8abe8ac6f8c8880ee6"
+    },
+    "maps/bmodels/sep_chain2.lit": {
+     "bytes": 15716,
+     "sha256": "311947b14d5363ccc34fd6e32205100b612c8a77c66196dc616192b011375b59"
+    },
+    "maps/bmodels/sep_chain2.map": {
+     "bytes": 80569,
+     "sha256": "7d86dc46adc6a01b96b811021484c1e6cbfb61424f1037be59525d6f1ff2c420"
+    },
+    "maps/bmodels/sep_chain3.bsp": {
+     "bytes": 80956,
+     "sha256": "8a811a3fc8f85373d64fb3840bda3a3af63a138498bc051ddb2b0d1e0cfa9e88"
+    },
+    "maps/bmodels/sep_chain3.lit": {
+     "bytes": 10802,
+     "sha256": "50d0f90c43a132a5cb360cbb25521040632f07726c6ccfb482d3740ec940ad05"
+    },
+    "maps/bmodels/sep_chain3.map": {
+     "bytes": 41124,
+     "sha256": "ef40d6b17d8b9fc880e4a8180336554f37dabfbc8a30b78c485793aaa5dd753b"
+    },
+    "music/track160.mp3": {
+     "bytes": 2523994,
+     "sha256": "0551a71af5cfee6cfadca58a92a7472f48b9d8d6850555306659d67abe11003b"
+    },
+    "music/track170.mp3": {
+     "bytes": 7852156,
+     "sha256": "3f87c3760fc29b883cbd8c573317aef919dbc4f9a102e98e5e6d80eae72e7142"
+    },
+    "music/track180.mp3": {
+     "bytes": 9774601,
+     "sha256": "2e3f447c7e7f0b7a02013e8259cc72bc035f8689686cfa1c301591cc34dbe4e8"
+    },
+    "music/track180.ogg": {
+     "bytes": 5092750,
+     "sha256": "1b48947672b05ebb5755d97122f28c0598a5fefe724d8b4cc3301497aba94f81"
+    },
+    "music/track190.mp3": {
+     "bytes": 3396358,
+     "sha256": "acac0feee753050a5313a5cc6f9f46e737dc7e3ea8b1c1ff53a4af101c5f0cb8"
+    },
+    "music/track200.mp3": {
+     "bytes": 14789443,
+     "sha256": "099893b65c4970fa5915833c377e2c010ba65d916b2be5478539b9710582007d"
+    },
+    "music/track210.mp3": {
+     "bytes": 6541195,
+     "sha256": "f889c86a341bf14e41855b189f735c00a1b84fa5c248342941c9b79643bbd2a2"
+    },
+    "music/track220.mp3": {
+     "bytes": 3293475,
+     "sha256": "be53bca9a627c9159a57f99058ba735e3bc8bfe125ae61989a1e6e919e0ac074"
+    },
+    "music/track35.wav": {
+     "bytes": 353002,
+     "sha256": "9b006ae5f5b2ae5c2ad84062d9bc288cee744e63301721838d70bec434178b95"
+    },
+    "my_progs/ai_ammoresist.qc": {
+     "bytes": 7444,
+     "sha256": "d530fec92f23ed0c3d09560abb9a89bdc160ce1aefdfbe4f4771f9897ae3fc4d"
+    },
+    "my_progs/ai_checkattack.qc": {
+     "bytes": 106456,
+     "sha256": "7971ca5a87666c89b56ab0fcc102e6f551f3cd3b03bdfc0bfb73f5f8d5aed7fb"
+    },
+    "my_progs/ai_combat.qc": {
+     "bytes": 24324,
+     "sha256": "30c07395259db46836e544a68a37527f107e9010e4d64e937476ceafa58c82b8"
+    },
+    "my_progs/ai_enemytarget.qc": {
+     "bytes": 8409,
+     "sha256": "f4b0a35306d50e71fd9043ae949a421158ee9fcc4e311baf7b8fa2d345c4d46e"
+    },
+    "my_progs/ai_explosion.qc": {
+     "bytes": 12162,
+     "sha256": "7df941a7cf93b814ae9d90f646a5b0243a51db67872f621df73d43c6000ba3ab"
+    },
+    "my_progs/ai_gibs.qc": {
+     "bytes": 32373,
+     "sha256": "65e202300882ba8f0c980f65820b2d2e0bd06846073168f4bd7e37f2357f47d4"
+    },
+    "my_progs/ai_hazards.qc": {
+     "bytes": 26832,
+     "sha256": "81aace80121408f64369bc2bbfd5654650276ddd75217333d2a52364415acaa5"
+    },
+    "my_progs/ai_minions.qc": {
+     "bytes": 10236,
+     "sha256": "3e7bd34dfe0e73a11e6907d5ac69cb609eee19dff533689ea7c8eabe52500136"
+    },
+    "my_progs/ai_passive.qc": {
+     "bytes": 8224,
+     "sha256": "44473544d0da0dc778c2800a16172ab49b548286b604c9d6361f4bc4cfc1f076"
+    },
+    "my_progs/ai_pathcorner.qc": {
+     "bytes": 20921,
+     "sha256": "b3d6ed2434e0b995da51a71715647096e36e02d8cf920e18e024f920ed69238a"
+    },
+    "my_progs/ai_projectiles.qc": {
+     "bytes": 86253,
+     "sha256": "d0885ed945602af45d7db1d98be5938412cd750154ed06710b6b781b6c49abc3"
+    },
+    "my_progs/ai_states.qc": {
+     "bytes": 7480,
+     "sha256": "76fae861132b0e50006ef88ea94a953e718b661defad2ea58a4ecad5cab92dee"
+    },
+    "my_progs/ai_subs.qc": {
+     "bytes": 51485,
+     "sha256": "41a23217543056b1ea447fcf2e0dc2c06a87bdf70dc3f6f699454d7c3c900377"
+    },
+    "my_progs/ai_tether.qc": {
+     "bytes": 6470,
+     "sha256": "2229c0ea1b76e45f5707a3eca9e7626e33f8ea91d6b292da63c81723e1ae8521"
+    },
+    "my_progs/breakable.qc": {
+     "bytes": 79687,
+     "sha256": "754831599eec85a774501d9fd0a1ec7d5722ea6a6e01655b5ad74988145045af"
+    },
+    "my_progs/chaosmode.qc": {
+     "bytes": 81481,
+     "sha256": "01561dc4f1949716eba4d08f83efe27b71add80f923c1e2d89194c238772a646"
+    },
+    "my_progs/client.qc": {
+     "bytes": 70441,
+     "sha256": "00e2d4aff96ea28b0532ab0b03de0a8cdcf15750164ec82bdc8f43b9f2347447"
+    },
+    "my_progs/client_advinfo.qc": {
+     "bytes": 59677,
+     "sha256": "87aaca8bfd15935e1cd29a807bf77a2779d95418af631a6b456c6605710694fe"
+    },
+    "my_progs/client_camera.qc": {
+     "bytes": 13007,
+     "sha256": "ff4748b04c15d9a3b44dd8069f9347c12487ef353d5401a13542166576097889"
+    },
+    "my_progs/client_cshift.qc": {
+     "bytes": 725,
+     "sha256": "da1e321fe01bae486ffcdd987a942a4b0d5b2f603efb663d52c55e882f129685"
+    },
+    "my_progs/client_debuff.qc": {
+     "bytes": 15761,
+     "sha256": "0e0c9123697241ab3a366dbc46fcb90b8553b65c94cffe1442254a74a2753efd"
+    },
+    "my_progs/client_evilmode.qc": {
+     "bytes": 6982,
+     "sha256": "2cfa3bbeb36ab623c3bb137028ec5f549a2e5d2198fa2ab7fd8a445e14f4fc10"
+    },
+    "my_progs/client_ghook.qc": {
+     "bytes": 51884,
+     "sha256": "43d071195a70caa66b57cca1778679d772478fd1f71cbad7ee267e254e79a29a"
+    },
+    "my_progs/client_info.qc": {
+     "bytes": 13693,
+     "sha256": "55653ddc2b9f3cf2ca3cf1b0afdc4c1685baf1ab3c3830eb9f8b1b2d51b3ff31"
+    },
+    "my_progs/client_mapvar.qc": {
+     "bytes": 13177,
+     "sha256": "c692fa41644e6d21c945493dd891af945a072a4b39e687d1b59c86d14ee804a0"
+    },
+    "my_progs/client_power.qc": {
+     "bytes": 20157,
+     "sha256": "0309073577003ae832b259ede75ba53c49bd89985b08d98000d03e1a44893705"
+    },
+    "my_progs/csqc_defs.qc": {
+     "bytes": 21072,
+     "sha256": "eddc5f194845e78a1633807d32b1da4425bdbe7bcce193e3868bc3995e2dee9b"
+    },
+    "my_progs/csqc_defsclient.qc": {
+     "bytes": 35002,
+     "sha256": "b6674acae135dfbc5e3dbb147e69acdc6b3564b766792359bed3e4eb800705e9"
+    },
+    "my_progs/csqc_hudad.qc": {
+     "bytes": 104391,
+     "sha256": "1ca012e489dc5f6026bdae469f411b5bb25afa00e00d5169cbd35b578a7ad9f2"
+    },
+    "my_progs/csqc_hudvanilla.qc": {
+     "bytes": 37074,
+     "sha256": "c5caa6ba176185c05903d383f3ae41907129d859419a0c0bf909b0e8d3e8af5a"
+    },
+    "my_progs/csqc_progs.src": {
+     "bytes": 113,
+     "sha256": "e383fc0920e9676d92e0be81d69cd8017ed5baf9fc0616a05773de68208ce434"
+    },
+    "my_progs/defs.qc": {
+     "bytes": 31974,
+     "sha256": "1534874cf4d70c5614dedecb70f6d428fc32832ce3345c2cb51fd6058a514902"
+    },
+    "my_progs/defsclass.qc": {
+     "bytes": 24401,
+     "sha256": "811c390be7b31fd4b276410ef1a75406bbca8fb84dc195484835a6100e9cddb4"
+    },
+    "my_progs/defscustom.qc": {
+     "bytes": 95932,
+     "sha256": "c8e66698b225cac3821bf4b098e7c8b16d0babaf7f5c1a5a32006c0c1dd96eee"
+    },
+    "my_progs/dpextensions.qc": {
+     "bytes": 122912,
+     "sha256": "3758f58ebaa4186e9112da89f7ea53087eef5058a32ebc373a1ffda76c1d67a2"
+    },
+    "my_progs/estate.qc": {
+     "bytes": 7745,
+     "sha256": "9cceb71ae54b331c2702f5580094f9055d007b9e710dd5e61c7c632724022626"
+    },
+    "my_progs/fteextensions.qc": {
+     "bytes": 215531,
+     "sha256": "beb86ad10bb0726de10dd2557d6285f7bf40f08f9d30e06315c3772f8c256571"
+    },
+    "my_progs/func.qc": {
+     "bytes": 47039,
+     "sha256": "3102c5ce52ec7a15c329079fc7ca97fa249dca32c4124bad49c2853d38e5c741"
+    },
+    "my_progs/func_buttons.qc": {
+     "bytes": 13271,
+     "sha256": "9e1bd197b2367ab2b8f1c776c214a0c51120559e8d8f0b4888b262b7a1e746f0"
+    },
+    "my_progs/func_doors.qc": {
+     "bytes": 35874,
+     "sha256": "58dbdf05f0044aefdd13ee21d17045a681d255efaca6d129fbd1cec4ae516fc9"
+    },
+    "my_progs/func_doorsecret.qc": {
+     "bytes": 14379,
+     "sha256": "769a3142ccaf18060ff77b0eab57d901585202fbfe63a54ce25d4987b80f92d3"
+    },
+    "my_progs/func_insvolume.qc": {
+     "bytes": 10573,
+     "sha256": "1deaf4623a6fae80585d2d2b1978b1cd217b6f8a683ef3bbc3a77a2897e9a207"
+    },
+    "my_progs/func_plats.qc": {
+     "bytes": 11685,
+     "sha256": "5086c9aba8bbf83d29c3e1897c7867cb24220712007044792928f474216b7ea4"
+    },
+    "my_progs/func_pswitch.qc": {
+     "bytes": 8373,
+     "sha256": "b3a205176d80801216a930241508b3c5718f4be9e1b947932ace2851c34271d8"
+    },
+    "my_progs/func_trains.qc": {
+     "bytes": 26553,
+     "sha256": "81d8de4f3dff80b8523584fb5e37d8d4812a6f7f95a559edff320682217ad123"
+    },
+    "my_progs/globalfog.qc": {
+     "bytes": 18397,
+     "sha256": "84ec244a475ac41b9da772042123f58f4005130590f170f85f1b23ad53629f27"
+    },
+    "my_progs/hiprot.qc": {
+     "bytes": 31978,
+     "sha256": "82875db9fecd8bacd2c42232fb980e6a510a6863103273e2c9078dfe7c6759c5"
+    },
+    "my_progs/hipspawn.qc": {
+     "bytes": 2752,
+     "sha256": "6df8450b85821c1a76f5ccb3c807ac9b94e92f413f16f2ba618f922abf85148f"
+    },
+    "my_progs/items.qc": {
+     "bytes": 165150,
+     "sha256": "fbcc57975032c97ffea723870e39ebc2d2c4bbd9650fb5d20b3dfcecc6f6f93a"
+    },
+    "my_progs/items_progspn.qc": {
+     "bytes": 20628,
+     "sha256": "2f4824cb28192145a8fabc2da6575db3398e8f81522ab1e026d696ec87313650"
+    },
+    "my_progs/lights.qc": {
+     "bytes": 43912,
+     "sha256": "d0e0c373bb3cc68c7c9121a62c68085ff9cc290daa6faf0adab02323d8ef92bb"
+    },
+    "my_progs/mathlib.qc": {
+     "bytes": 22355,
+     "sha256": "b161ebb89a11f302427c4f124731ec38def8eb01347beb5d748a9ba4afb886f8"
+    },
+    "my_progs/misc.qc": {
+     "bytes": 85890,
+     "sha256": "6b3e8a0882d47f16ff7f54fb37a48e3a7853647f8895718e6428739c4207099a"
+    },
+    "my_progs/misc_camera.qc": {
+     "bytes": 43852,
+     "sha256": "61448a8f0354f39dd26371ae56dadbc903b08282293145a27088ac6c151ea547"
+    },
+    "my_progs/misc_model.qc": {
+     "bytes": 32157,
+     "sha256": "9afc9d440672288ffada6256a20aa0f969464907e942fab0c1556cdb28162237"
+    },
+    "my_progs/misc_targetdummy.qc": {
+     "bytes": 15123,
+     "sha256": "bcd0a0ae806ce20a8c8cfcc27178ce1b4ead3a546d927b6a261ce51a6086c253"
+    },
+    "my_progs/misc_textbook.qc": {
+     "bytes": 26321,
+     "sha256": "14bf42536a5cc75990d938a79d7bd21bde1c166245d94d8e662f9e6fd66e0ae8"
+    },
+    "my_progs/mon_baron.qc": {
+     "bytes": 31318,
+     "sha256": "b76a10da34dabf3411ddf650abcdbc77e3ebcdfebace6191a39e7c0b13a0fad5"
+    },
+    "my_progs/mon_boil.qc": {
+     "bytes": 19821,
+     "sha256": "050b21bda5341a3f81dcb21e6d7d82d458a415fd8f1cfa12435228246229a323"
+    },
+    "my_progs/mon_bossboglord.qc": {
+     "bytes": 24005,
+     "sha256": "e67081b7a5218b361c62bf4b201a18db16f3e75716ad2729c11a0616b137975a"
+    },
+    "my_progs/mon_bosseidolon.qc": {
+     "bytes": 40134,
+     "sha256": "c51eb9b9d67cadfa7178891a238329a60ad57edc3f6ef645060695b451833115"
+    },
+    "my_progs/mon_bossfiretop.qc": {
+     "bytes": 14734,
+     "sha256": "26672c9c2d1577f8caf9894b8eb5eecacac89f64251257bc25db48b1bf43a7bb"
+    },
+    "my_progs/mon_bossicegolem.qc": {
+     "bytes": 47205,
+     "sha256": "5b888302a6af24ce823919d1349c1c92e1ee709d72e79042425349368a4d65fb"
+    },
+    "my_progs/mon_bossidchthon.qc": {
+     "bytes": 20247,
+     "sha256": "65d955fb1434f806962fadc088aa5933e96ed8aa9f1211d0709a3f462ffa3027"
+    },
+    "my_progs/mon_bossidshub.qc": {
+     "bytes": 14639,
+     "sha256": "fdd0e8f8fa374ea0164f79ef1bf74ca942f04c63159f360c7a43011673774fe6"
+    },
+    "my_progs/mon_bossjudicator.qc": {
+     "bytes": 81432,
+     "sha256": "f5092f376eeef22f0a552c846f50175680c15a5c37d9603c6e3d2635661127b3"
+    },
+    "my_progs/mon_bossmammoth.qc": {
+     "bytes": 84963,
+     "sha256": "6cda415b846b2aeb215c0eebc7cdfa6a5560255df9aa014f77b48aa7073b8d34"
+    },
+    "my_progs/mon_bossnour.qc": {
+     "bytes": 45682,
+     "sha256": "d3aa7e0c62e9001887b1b0895607b512f6d9aeeb44bca544f6c900c86adbc03c"
+    },
+    "my_progs/mon_bossxxchthon.qc": {
+     "bytes": 22614,
+     "sha256": "2c1c0446b0f6a5b7a7921e8f8830c71c174d30c6f176d228a94afd9a05fdc25a"
+    },
+    "my_progs/mon_bossxxshub.qc": {
+     "bytes": 19006,
+     "sha256": "043ebc852ba7f0a06812cb0afd72d32a3da643df1dea45c87fb821f60fbcc332"
+    },
+    "my_progs/mon_centurion.qc": {
+     "bytes": 13734,
+     "sha256": "641e1c09c6df27b033e331140d242f25d27bf7f9bb83733a6b5b3469a5c7ffee"
+    },
+    "my_progs/mon_dcrossbow.qc": {
+     "bytes": 38069,
+     "sha256": "3296618a4b803fb6f1b44c1d32c17692a5bed13cf63102c6dcc58481223197a8"
+    },
+    "my_progs/mon_deflector.qc": {
+     "bytes": 32107,
+     "sha256": "d7a9344878a3a846a7e720ce704820d424362281a1675c40be7b670eca9fe342"
+    },
+    "my_progs/mon_demon.qc": {
+     "bytes": 14601,
+     "sha256": "d77f128e3f91737228c5a24b7ca146f6b4f8e87dbaac31b1ad4e79779884d0d7"
+    },
+    "my_progs/mon_dfury.qc": {
+     "bytes": 39867,
+     "sha256": "a016db202f2a418aee50cb7cce2155a24a6b807e8c98fc49a5f9273ce79c6da8"
+    },
+    "my_progs/mon_dguard.qc": {
+     "bytes": 28414,
+     "sha256": "0a2b964034559f4ca772f9f29be2c56684fd39290277046a6f7642ba934836eb"
+    },
+    "my_progs/mon_dguardquoth.qc": {
+     "bytes": 18932,
+     "sha256": "4caeb17520104cba42476ff7757f38ba6d72e941674b851f55a5c9780ce4de17"
+    },
+    "my_progs/mon_dknight.qc": {
+     "bytes": 36867,
+     "sha256": "68008427374e9ab670b6ad915c7a0f8eaf6a6699efa927a3748ae6cde86458e6"
+    },
+    "my_progs/mon_dlord.qc": {
+     "bytes": 22859,
+     "sha256": "09ca1edd4e65a166a66ba17e682aae9a1be09b05371a72dd1bc447389693bfa5"
+    },
+    "my_progs/mon_dog.qc": {
+     "bytes": 18431,
+     "sha256": "1b345447176aec54f18c31f5da215e80cb2de19f51d353c63a98507d881c2a9b"
+    },
+    "my_progs/mon_dprince.qc": {
+     "bytes": 33590,
+     "sha256": "5114caa7b6152e562e548096e41da68f43c910a5016ddaed408272a97a8320c1"
+    },
+    "my_progs/mon_drole.qc": {
+     "bytes": 25472,
+     "sha256": "36a510e910ce4ffa26d2d2ad336872c07537077ea920132a4cfd63d9133fb6af"
+    },
+    "my_progs/mon_dsergeant.qc": {
+     "bytes": 33493,
+     "sha256": "ada0cc4359a863c4e8d433c605a1c04ec6f7fd17ec852f5c4847443d3adaff1d"
+    },
+    "my_progs/mon_eel.qc": {
+     "bytes": 8252,
+     "sha256": "15c1f2fedba7077d352595e1be4a90f764354e4cf1875b40e1685d3ce81feb54"
+    },
+    "my_progs/mon_enforcer.qc": {
+     "bytes": 20146,
+     "sha256": "d453651d488afa789d0cea87ce99d9684329bbabdd17aa1625591f5a4b4ac90b"
+    },
+    "my_progs/mon_fish.qc": {
+     "bytes": 9705,
+     "sha256": "ff7d84db2c7917861ff5d81fe0e28f69d51143d27c4fba90dfcda11057222df0"
+    },
+    "my_progs/mon_floyd.qc": {
+     "bytes": 20332,
+     "sha256": "3ac2f0b0be94e311ff2fc4eee9cf66d5987af0e5c25fc06b8cc7b9efa6f581df"
+    },
+    "my_progs/mon_freddie.qc": {
+     "bytes": 25384,
+     "sha256": "4409a33e819f125852d0a4ada21a8fed2713012daec00922446f313031c845d1"
+    },
+    "my_progs/mon_gargoyle.qc": {
+     "bytes": 24293,
+     "sha256": "9e1f78b2364024efa6ec4142c1ecf4aff52cdf32f38031c34cf19e9cd74143d6"
+    },
+    "my_progs/mon_gaunt.qc": {
+     "bytes": 24111,
+     "sha256": "45be98ae0bdd32e0884280e18f867af037f2fcbf515914827c5f9107a87e52d7"
+    },
+    "my_progs/mon_golem.qc": {
+     "bytes": 35297,
+     "sha256": "dbaf3d1c0fec3166b0eb064a3c027dd3a0c907bed72b8e4581ffd74dad5ab5d1"
+    },
+    "my_progs/mon_hknight.qc": {
+     "bytes": 37618,
+     "sha256": "bac7d4b7832b95cea0f6890de66fbd0f7c4fcc7ce9051ef16ac042de465ddcb3"
+    },
+    "my_progs/mon_hogre.qc": {
+     "bytes": 24021,
+     "sha256": "8781ea9aaaa1d0f7ffb1fd8ec8b5981187eee6fdb8193160a1eb38770dffcfe0"
+    },
+    "my_progs/mon_hogreham.qc": {
+     "bytes": 23076,
+     "sha256": "b2ab6b830ce3aae7d6b033e8455de5011ded82e451ca171ea09940d9a3ec7740"
+    },
+    "my_progs/mon_hogremac.qc": {
+     "bytes": 23941,
+     "sha256": "9111c040ab1e5487936cce6ef1170e408c6d297d582702d202bbd27b0919d843"
+    },
+    "my_progs/mon_invsword.qc": {
+     "bytes": 9214,
+     "sha256": "f7287867cc6043eb7cd3fa3e1ecd5ae7115a84e5ef7021b2d5129afdb6ba6f46"
+    },
+    "my_progs/mon_jim.qc": {
+     "bytes": 22091,
+     "sha256": "55353984ad822dfd8c32f3b8ad9a06e8bfaab7bc5ff6f2a2326674ad4acd26be"
+    },
+    "my_progs/mon_knight.qc": {
+     "bytes": 24772,
+     "sha256": "d254abf88162436b9db48885ae8e59315c24c1e7f72a91d027a1d69fe9baf5b7"
+    },
+    "my_progs/mon_lostsoul.qc": {
+     "bytes": 23261,
+     "sha256": "2cdbf656c6b34164711fa88016542f4e3d2bd0555417ad00bab5ca7039f212ef"
+    },
+    "my_progs/mon_minotaur.qc": {
+     "bytes": 35316,
+     "sha256": "fbcef276ee3e2f1eeea8483303538190875e959b43efbf4f703be10fc72fc564"
+    },
+    "my_progs/mon_ogre.qc": {
+     "bytes": 24123,
+     "sha256": "d287d3b9024025237dbc68380f486572828a5114f9543599ba86b8bc35e9e25e"
+    },
+    "my_progs/mon_ogrextra.qc": {
+     "bytes": 9387,
+     "sha256": "41a9243c6006326195197a4dfba6ea4c1f1fbd729ec10adc48cfd7badd7a18de"
+    },
+    "my_progs/mon_pyro.qc": {
+     "bytes": 18235,
+     "sha256": "bd35f02c63af315ddf4820e388d0248cf065f1170bd7306957a1e86fa7e47306"
+    },
+    "my_progs/mon_scorpion.qc": {
+     "bytes": 22136,
+     "sha256": "0432d7c5e1b6a30a5452aba12b9fb6a3c2c7f3c582b1392d420414e66b8fb257"
+    },
+    "my_progs/mon_seeker.qc": {
+     "bytes": 29703,
+     "sha256": "d33939357840eedbfc63c56d6415d8fefd21de2c477b24b3165cdadcca2acd2c"
+    },
+    "my_progs/mon_sentinel.qc": {
+     "bytes": 10217,
+     "sha256": "946232c7169bf3fa966ce875523dd45402772f8045c51a96dced04f2f5f5788f"
+    },
+    "my_progs/mon_shalrath.qc": {
+     "bytes": 16434,
+     "sha256": "1b6fdf2447d7fa281d126118a9bc0e097de7b4dd4d10a33e60d5cf0ca785c58b"
+    },
+    "my_progs/mon_shambler.qc": {
+     "bytes": 23050,
+     "sha256": "576f71a38d75eedbdf58c291055674be8da5f0d04540e26311d65f70b58ee842"
+    },
+    "my_progs/mon_skullwiz.qc": {
+     "bytes": 36245,
+     "sha256": "6d3c2242bffe6eabe3f9cc59e881cb2296213cfbff809e1be045a80ca46aac53"
+    },
+    "my_progs/mon_soldier.qc": {
+     "bytes": 21645,
+     "sha256": "704c534062b11c4fc16416154c7706c125221660cdd4d9b02e00575b94c04103"
+    },
+    "my_progs/mon_spider.qc": {
+     "bytes": 30593,
+     "sha256": "4d0bbb7e38e51cef07912e6071e6bb9739e019a2d93129d38dbab9492bf43aee"
+    },
+    "my_progs/mon_steelclaw.qc": {
+     "bytes": 17126,
+     "sha256": "78dd4bb46dd76b2ff1f7d4a9f0b0902f25d94ebe13ace6b997a7f604c3718700"
+    },
+    "my_progs/mon_swampling.qc": {
+     "bytes": 25637,
+     "sha256": "fb5ed328cd3d5c09704bb84f39138463a7d26b8b1d45771e55e9ae952b1d2470"
+    },
+    "my_progs/mon_sweeper.qc": {
+     "bytes": 27025,
+     "sha256": "8f7a1d077779d88d542a325c1ae4ba4ff59d48bfcb334150ae3f024525bb725e"
+    },
+    "my_progs/mon_tarbaby.qc": {
+     "bytes": 11866,
+     "sha256": "88c9481ab7fe0cbe97d2b836492ff51b368aeae8d4ff3e5852734bb9f63a1b2d"
+    },
+    "my_progs/mon_turretbal.qc": {
+     "bytes": 38519,
+     "sha256": "fdcf915248dda5fb6a744d284233d46a2e6d62c8e4fd02fdd5bafe4f46167d30"
+    },
+    "my_progs/mon_voreling.qc": {
+     "bytes": 27678,
+     "sha256": "7734614fa6b2da2195bf3804415c06a2d10f35825e86abf4f85613a182cf21c2"
+    },
+    "my_progs/mon_wizard.qc": {
+     "bytes": 15155,
+     "sha256": "3101ca37b57343697b3d3c7637fdc84c842f78ec9081e401dcaa6df0a9b1df83"
+    },
+    "my_progs/mon_wraith.qc": {
+     "bytes": 35464,
+     "sha256": "6a28a205cb8ac574e98c8d34a01ea859922e38d55c66346a7aa867ebf84bdb5b"
+    },
+    "my_progs/mon_xmas_elf.qc": {
+     "bytes": 17589,
+     "sha256": "053eec412485090ee1ebeac25887382db40e2ba7ca456050ba4407be3ec8bc1a"
+    },
+    "my_progs/mon_xmas_raindeer.qc": {
+     "bytes": 12189,
+     "sha256": "abbe1dd5c96c25b631231d4db2f17e8243075ad08c082e0448b7cbff34f1ae0c"
+    },
+    "my_progs/mon_xmas_santa.qc": {
+     "bytes": 17853,
+     "sha256": "cc60c6de17bc3321f9b1cf75b3229e387592c9eb7fc4bb57c1de0a8d2c0e62e6"
+    },
+    "my_progs/mon_xmas_snowman.qc": {
+     "bytes": 11486,
+     "sha256": "65928bb70cb2e9352c2f5e036eda2a6bd97aea09d459d0af563a82aa5a2f2673"
+    },
+    "my_progs/mon_zombie.qc": {
+     "bytes": 33988,
+     "sha256": "83f56482374c3a79fcc64058989bd210af3add006b7388d89c92e90543ec56a0"
+    },
+    "my_progs/mon_zombiek.qc": {
+     "bytes": 42214,
+     "sha256": "2b9926454484e93f5c053bf4fd35b2a97cf7e835c26c3b30061f1ff391af9f5e"
+    },
+    "my_progs/monsters.qc": {
+     "bytes": 56573,
+     "sha256": "c2c75832e6d5e83e929214ba5c1aa9a4661bcaf7754c20b3e9648171bf804a58"
+    },
+    "my_progs/part_emitter.qc": {
+     "bytes": 82744,
+     "sha256": "fca7491171d58974ef6b15550b9a7f0474641e9eac7ee5de52c6980c96445518"
+    },
+    "my_progs/part_generate.qc": {
+     "bytes": 42914,
+     "sha256": "83b9718a85418143d92ea8311cc8cce69c1002eb7563710dfe7010ac52e15d50"
+    },
+    "my_progs/part_manage.qc": {
+     "bytes": 27407,
+     "sha256": "86eb791f4bba08fc0c965e9f81c90e7412ed2c910104d66a56cce1f3152808fe"
+    },
+    "my_progs/player.qc": {
+     "bytes": 27811,
+     "sha256": "1f0cc3eaf577c2af642495466c573cd6e226a4754902d9de9cbfc9c9ba28af0f"
+    },
+    "my_progs/progs.src": {
+     "bytes": 2482,
+     "sha256": "c773f107c562f731fbb30158422226bdc4576dd32aea0f02c122195e08eac96f"
+    },
+    "my_progs/pushable.qc": {
+     "bytes": 19823,
+     "sha256": "03b3bf9240db6e9532e45a3efc159129709f9ce095c3238daae32daddd5b07ec"
+    },
+    "my_progs/qc_highlight.xml": {
+     "bytes": 6348,
+     "sha256": "a7b326723cc1e4025e867ea5da00f54c944705600d740538aeb52f63cd027ab5"
+    },
+    "my_progs/settings.qc": {
+     "bytes": 62244,
+     "sha256": "78d9b19077028f9fd72f271aaae3d75b43e995ef95b7679df83a06fcdfbaf4f5"
+    },
+    "my_progs/sounds.qc": {
+     "bytes": 19389,
+     "sha256": "bb74ecc36a241db5a79b010f61200687c6db6e46297db39c8a2a8ce1d512bad5"
+    },
+    "my_progs/sprites.qc": {
+     "bytes": 476,
+     "sha256": "579f48b397914b02f8fb86dc24f23d4e63a4cd857df1f0eaefd6c83e9c49e238"
+    },
+    "my_progs/subs.qc": {
+     "bytes": 24000,
+     "sha256": "48832d667d7a932661ac914bc8e471843f2cd8a0985fc0458d7e1a2796e21d16"
+    },
+    "my_progs/subs_soc.qc": {
+     "bytes": 28453,
+     "sha256": "679112275e8b3597daac962074f69b6d9fd5614fc3dbff036815b9365e1413c5"
+    },
+    "my_progs/switchshad.qc": {
+     "bytes": 7054,
+     "sha256": "92a2fd4e5c41f21f46502781322ab87584bf0999d733db50e0e19b8bbea793b3"
+    },
+    "my_progs/targets.qc": {
+     "bytes": 58758,
+     "sha256": "e39b45bf6740be40c2899376e92d30d7d227a4762091d7b63e382c79fe6822e7"
+    },
+    "my_progs/traps.qc": {
+     "bytes": 24071,
+     "sha256": "9e4e822a36113bc73958fa45ab0b8c290a5148c95f3a4da7125676c984ebd202"
+    },
+    "my_progs/traps_pendulum.qc": {
+     "bytes": 17049,
+     "sha256": "b421f26fd80eb74715172e25f3ac992faa95397dd67d5f7ede286fd78384a468"
+    },
+    "my_progs/traps_sawblade.qc": {
+     "bytes": 9783,
+     "sha256": "9a6e82a05f09001c0a9cffdf6b9d6399691846c5b1ab1fbfb470e5772a87f44b"
+    },
+    "my_progs/triggers.qc": {
+     "bytes": 139722,
+     "sha256": "0ead1e997492dfe79a8c811a48b902217aafcd4bf3c49acea7101c99892886f3"
+    },
+    "my_progs/triggers_states.qc": {
+     "bytes": 17475,
+     "sha256": "2c4d25c11de0319cd54d81e67e651c8d29d22aca851988d21080ba5976137f14"
+    },
+    "my_progs/weapons.qc": {
+     "bytes": 44884,
+     "sha256": "d22ff6c46a101964e5e8e334a8d91ae8854e2eb6ca2c4565fcfc748acfcfd9e6"
+    },
+    "my_progs/world.qc": {
+     "bytes": 39815,
+     "sha256": "c160b7b050cc7a718fbc6ffe3dbfad85514936522bbabeb8ee4fb1a3c30b79d3"
+    },
+    "progs.dat": {
+     "bytes": 2347206,
+     "sha256": "5e69fece92fb4323609c8e1209a39eecf4f70c3161ae17beb53063fe3e06c340"
+    },
+    "progs/banana.mdl": {
+     "bytes": 75700,
+     "sha256": "675be1dfb631202cf13aff6cd1c3730b245da632ecea62e3d030ddba4b51ec10"
+    },
+    "progs/baracuda.mdl": {
+     "bytes": 95844,
+     "sha256": "e17b8489665809e72e77d5ebd2cf48e6b2ccadf239424e0f6ecf45f32a3e6438"
+    },
+    "progs/blowfish.mdl": {
+     "bytes": 143828,
+     "sha256": "77f738010f8e7bb6671a5e64ea41d153feba1450dd753076240907e54be8d485"
+    },
+    "progs/cat.mdl": {
+     "bytes": 150136,
+     "sha256": "983b3cce942fcc9f599ebf66553dcf1212c2400b335da75fcbb317dd4b53cae8"
+    },
+    "progs/crystal_ball.mdl": {
+     "bytes": 198808,
+     "sha256": "f519645d23cf26db1f92901cb5f4281bb1aa6f9048ba119fa25ebc8fb93b1f7d"
+    },
+    "progs/dancer2.mdl": {
+     "bytes": 243764,
+     "sha256": "248c028869f6bf937cb31b48047d0c0175ad3c2a53aaa9032ba26640df412a00"
+    },
+    "progs/extngshr.mdl": {
+     "bytes": 25732,
+     "sha256": "fc8dec001f22c4666f6c5ca65e8aba18d5b22ed8aabbf0534d03913e821e3120"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/mon_gull.mdl": {
+     "bytes": 465348,
+     "sha256": "58c2b574c0f6a85073846b5a7c7a46e4ad5c602e5b17226a8f381798b2a0960d"
+    },
+    "progs/mon_parot.mdl": {
+     "bytes": 465348,
+     "sha256": "659d97222e7a7e4fc208b035e59202c6a2c1a22e8e04f5b75ee8baf5c956171a"
+    },
+    "progs/mon_raven.mdl": {
+     "bytes": 465348,
+     "sha256": "274e66071d2d90036d99971e948338e7f73eabdce1e026e09310d4b4cd2b7541"
+    },
+    "progs/moonglobe.mdl": {
+     "bytes": 264916,
+     "sha256": "aa2ab27baf574bc768eedafb078f8ad003962fbf04a13a13528f22de2cdd8b67"
+    },
+    "progs/orange.mdl": {
+     "bytes": 68740,
+     "sha256": "70f6e00500ce4c6835e76656d5778bcd284a868789ca4ad33da25a2672961c77"
+    },
+    "progs/pole.mdl": {
+     "bytes": 30568,
+     "sha256": "367408f41596326be87a5ce9004417826bc19ccd60db03cf047e64e1f0c10f7e"
+    },
+    "progs/potion.mdl": {
+     "bytes": 30624,
+     "sha256": "5915a0c8d8d6da7f5f7c5acd34e017d9a7711256370e0d1caf36df18185b0040"
+    },
+    "progs/potion2.mdl": {
+     "bytes": 52688,
+     "sha256": "7bbd9b153a61492289818bdd17f0b16c4f8572ea1c071ed8f8ce6bc2a9f05e92"
+    },
+    "progs/rat.mdl": {
+     "bytes": 172776,
+     "sha256": "92dd621543645fba1ebd1052edd5e445f95888fd5ac4c30a23101c9e829fcd3c"
+    },
+    "progs/statarm.mdl": {
+     "bytes": 117444,
+     "sha256": "4f0dc950ebfdb2cd9c3c4756f577c704b9aa5aff3b1d0ef2bf31b0db4319a362"
+    },
+    "progs/teacup.mdl": {
+     "bytes": 24996,
+     "sha256": "96222ab4c02a088ebe0a74f7cfb3bc51ec4269feea90fb5c7b1d20961302ec34"
+    },
+    "progs/teapot.mdl": {
+     "bytes": 479304,
+     "sha256": "9d6e02b2afc781c3b6349e54084f6912d010575492cc677ed33852cb1738c6f6"
+    },
+    "progs/vortex.mdl": {
+     "bytes": 40372,
+     "sha256": "231fd658a794f341e25edc40d188829403bbe4a761159908751d9f5be5fa79dc"
+    },
+    "progs/warbanner.mdl": {
+     "bytes": 437420,
+     "sha256": "8343cd01424f33906ee1b3808ceb4a4c77018cce2f441c9480c4a41d5ff4570a"
+    },
+    "sound/qstation/Dread.wav": {
+     "bytes": 1065652,
+     "sha256": "5c2f9c26266428e96dc150cd6dd1a6c957015835087fe712d37b8f32738bcae3"
+    },
+    "sound/qstation/Mech2.wav": {
+     "bytes": 530550,
+     "sha256": "29b2a1aef90cb2d5cef3c739da76482428718dfb519c2f2c1115d79d2fb081ff"
+    },
+    "sound/qstation/air.wav": {
+     "bytes": 251678,
+     "sha256": "a75c1894efad40546d0f53b61557752352ea3e308f35def92aa944e4068bd789"
+    },
+    "sound/qstation/air2.wav": {
+     "bytes": 213302,
+     "sha256": "7da7104bd62b6c02190e68e02838b65a1bb1f2090691536078437a0a38509098"
+    },
+    "sound/qstation/al1.wav": {
+     "bytes": 1308904,
+     "sha256": "063e377e90a1540f5a8fe40cb934ef4ce869dac7ce1ad10b36b91fdd4fd7bc3f"
+    },
+    "sound/qstation/al2.wav": {
+     "bytes": 145130,
+     "sha256": "e800d8a6be504fdfaa5e08dd5ae2a461d93b490976a0482666673315386503ea"
+    },
+    "sound/qstation/al3.wav": {
+     "bytes": 67214,
+     "sha256": "aaf35be17b4bc4553d27592ca51befb325e1334c51c35409a9e454f2c23bbc58"
+    },
+    "sound/qstation/al4.wav": {
+     "bytes": 103236,
+     "sha256": "953f512df600e43830d4663ed5d3a86bc707f006a87608e6f787cc1ed2ccd800"
+    },
+    "sound/qstation/al5.wav": {
+     "bytes": 1499958,
+     "sha256": "c98f5d4eb107a225dc841967ca8ede42cbd55c51896f02826764d9ed9e2815d5"
+    },
+    "sound/qstation/at1.wav": {
+     "bytes": 275614,
+     "sha256": "5c70e54d254794bede83d22a0d7ea35c67d004c6c1dcbcf6ac6a97fc8cd73f9d"
+    },
+    "sound/qstation/at2.wav": {
+     "bytes": 186014,
+     "sha256": "79838c09a1cd2158170b664c8d069ec1db061e99943d87fd2a11ca23647bfd02"
+    },
+    "sound/qstation/at3.wav": {
+     "bytes": 158786,
+     "sha256": "bd43fb9bafe07cbf7ba4fff85355a0b49bdaf58258faccc6d2406c88afa730ac"
+    },
+    "sound/qstation/at4.wav": {
+     "bytes": 199204,
+     "sha256": "1a7aef2ca95a75cb9a7836660ce5e8626e8757c9825819cc19725b5e585d9875"
+    },
+    "sound/qstation/at5.wav": {
+     "bytes": 163366,
+     "sha256": "e2c9e8ab2a33a0658d7fe81ccab374f008ab136425e60f1b51dfb2d2210eaf06"
+    },
+    "sound/qstation/at6.wav": {
+     "bytes": 169826,
+     "sha256": "737b4c722a92476aae63f28e5ed50372a3ac38f25e9df4690da8f7495d7f7610"
+    },
+    "sound/qstation/beam1.wav": {
+     "bytes": 51258,
+     "sha256": "430a24dc8ef90fe9745df11d79f546b4bd253ce1ebdb2204784b6ec1d9b89de4"
+    },
+    "sound/qstation/beam2.wav": {
+     "bytes": 46308,
+     "sha256": "fae32de6e14281ea08d5049e74839f7f29c4df1bf6b0afb51df22486559905c0"
+    },
+    "sound/qstation/beam3.wav": {
+     "bytes": 59290,
+     "sha256": "6245bac4690b279c558f8cf8a3f6268d828c5564579e72f23dc1f115d23201cc"
+    },
+    "sound/qstation/beam4.wav": {
+     "bytes": 38152,
+     "sha256": "8b90bdef1e915309bfeff33f34c5d1a4a849ead43df83c40acdc7f3f5c62b59c"
+    },
+    "sound/qstation/breathe2.wav": {
+     "bytes": 842162,
+     "sha256": "915926c839ab14a31eb375380620acdd9631451fd7b7a23b16dc7b10e90c6b69"
+    },
+    "sound/qstation/bridge.wav": {
+     "bytes": 205202,
+     "sha256": "479c6fc1d1a63e04f4778c1f5055b46eccedca8d8497c930c7adf5867fd0b840"
+    },
+    "sound/qstation/cargo1.wav": {
+     "bytes": 4225464,
+     "sha256": "813e741954c391c66c3bbc1f108119bdc6903ccfad85f6dea315e952fd548709"
+    },
+    "sound/qstation/corr.wav": {
+     "bytes": 517502,
+     "sha256": "d76bb038d2952c232beda163caa07dfb9096f86a4e01ab0596d9ea59455ddc08"
+    },
+    "sound/qstation/cp1.wav": {
+     "bytes": 151992,
+     "sha256": "78d2054997fd3b917953556297344b0adfdd1640ebce1f1536c6d827ca5334c1"
+    },
+    "sound/qstation/cp2.wav": {
+     "bytes": 292700,
+     "sha256": "0e5a0756ceebab9ff125c8beca36292eb57b8ba01a6ffc011df3110c97b1b00f"
+    },
+    "sound/qstation/dig.wav": {
+     "bytes": 172402,
+     "sha256": "923d091e52c90717eb6786888fa8ad8ec88fc03e7c19f899f7d9b85bca1073f3"
+    },
+    "sound/qstation/dist1.wav": {
+     "bytes": 2105900,
+     "sha256": "271f82cb4ea88c30af94bc210076694a7fc0f5dd20ff8dfdef6276fa4ecf3299"
+    },
+    "sound/qstation/dist2.wav": {
+     "bytes": 902836,
+     "sha256": "fbfbaccedde1d0728b0feb3c95a315b617abe06e77597dec1c7ceb9e4d979e0a"
+    },
+    "sound/qstation/fann.wav": {
+     "bytes": 106732,
+     "sha256": "6f967acc914284b8c10a988ab61d68d20829e930a6e012e1123b82e3be21a41f"
+    },
+    "sound/qstation/field.wav": {
+     "bytes": 44762,
+     "sha256": "53a0245f4598f62f94d33f8b37fda4e015c410fbb64ae58bac40571260f8d5c8"
+    },
+    "sound/qstation/grid.wav": {
+     "bytes": 88222,
+     "sha256": "61bc31d56c5c6dc75bf426b7e10f471d961bde90471666ffb611abf40ecaaad9"
+    },
+    "sound/qstation/halls.wav": {
+     "bytes": 55100,
+     "sha256": "b30e2a9bd28266fc9aa0f8490b224d81f629571f2ab9410c1e87c96d1d2bcb84"
+    },
+    "sound/qstation/halls2.wav": {
+     "bytes": 45098,
+     "sha256": "bbaeb69ce8a7ebec45a42cff00010d1867ea4333b1d831ee41fa498e7793065b"
+    },
+    "sound/qstation/halls3.wav": {
+     "bytes": 22174,
+     "sha256": "cc790eec282e72722b86e5c52f918fbaf7b46aa8ae91465acf8a59d85bd0a4c4"
+    },
+    "sound/qstation/halls4.wav": {
+     "bytes": 29238,
+     "sha256": "119f5f7ef948ba0d3167101b69ab0e12b058836ce79a0648a7ee1a56489a0134"
+    },
+    "sound/qstation/halls5.wav": {
+     "bytes": 64172,
+     "sha256": "c29e9b0eba8ef4d016b3ae6c182cf50cb7fd833b5f9c9575c8e5e120d5e9d9a8"
+    },
+    "sound/qstation/lec.wav": {
+     "bytes": 139246,
+     "sha256": "aeac6d311e4a1513bd4890e5ab8b7e418a17de8d6f3ed039adeb2a6702fa3724"
+    },
+    "sound/qstation/lec2.wav": {
+     "bytes": 225872,
+     "sha256": "d1b6d940eb49e325a35e82376429ade98c14059c285c21108af9a196954ce01e"
+    },
+    "sound/qstation/lec3.wav": {
+     "bytes": 671870,
+     "sha256": "c80cf3b44717074c677a3528a2959764b01f0efbce1911ff02e82b8bc820fe8c"
+    },
+    "sound/qstation/loop.wav": {
+     "bytes": 1097694,
+     "sha256": "4ab86bcc1a2829a7721354d1b4a10503f87f16d8749be989db050cf5977577c4"
+    },
+    "sound/qstation/loop2.wav": {
+     "bytes": 1097694,
+     "sha256": "cf5f654b1619de66779b85d592c0d003b88c0958aaf935585d0e98055180227c"
+    },
+    "sound/qstation/m1.wav": {
+     "bytes": 589456,
+     "sha256": "002026c63301963561e86e2fb6e652d5cd2080f821fe947f0bf42c715c668a03"
+    },
+    "sound/qstation/mech1.wav": {
+     "bytes": 1455912,
+     "sha256": "a1d1126c1ea918268771ac2cd8dd48f5089c77426b9bb3f68f7c59f633e07187"
+    },
+    "sound/qstation/reac1.wav": {
+     "bytes": 24526,
+     "sha256": "d59b60922ec65dc2a99a45d88d2d4f15bfd3027a3b828a2018bd14b1681bd08f"
+    },
+    "sound/qstation/room2.wav": {
+     "bytes": 2023038,
+     "sha256": "1ef6ac2e80bf545c3e6a488108b6f596cb021e89cf3e8225c67e05f0b7199c0e"
+    },
+    "sound/qstation/thundr.wav": {
+     "bytes": 16350196,
+     "sha256": "415c90c2f5c281146896cc29a30be6e0d0ced0308f53a371327b14bfc4e2dee0"
+    },
+    "sound/qstation/un1.wav": {
+     "bytes": 276792,
+     "sha256": "2a2dbd708fefa57bccba95a94f7d5ad0a8ed789858f8d2c5928be204be3957b5"
+    },
+    "sound/sam/bats2.wav": {
+     "bytes": 75972,
+     "sha256": "1ec063f00b6a427d5587c97c41b5a3c0b8c7039a2c0a4282838fc46d993dff7c"
+    },
+    "sound/sam/captured.wav": {
+     "bytes": 251688,
+     "sha256": "8e3627f0441d94dd1feff0daa8064d645d2fa1fcc89d3acf520faf6e41262935"
+    },
+    "sound/sam/cat.wav": {
+     "bytes": 18266,
+     "sha256": "488ae14d2d1da2a10fbb2437d0b3c7f9fcf459c4f429deaf65389e68dc7c3088"
+    },
+    "sound/sam/doomy.wav": {
+     "bytes": 126290,
+     "sha256": "e62af17ed604b401daab53b82d092fa3d1a9d955f6505bee26dc5ac446047397"
+    },
+    "sound/sam/from.wav": {
+     "bytes": 14212,
+     "sha256": "37b62981904eaf1ea44811915b4a4d70583823d5448a3183a18a144ee0276cbd"
+    },
+    "sound/sam/getout.wav": {
+     "bytes": 12690,
+     "sha256": "06ccf9789d0b65087b53e0693ce759bc8b54dd2afa3270d3b9eafaf5d3cd7f9b"
+    },
+    "sound/sam/rat1.wav": {
+     "bytes": 57772,
+     "sha256": "3fea4d8fdbadc48d990fbde836f3e1488c881e71579e87b188a6960e97a68ccf"
+    },
+    "sound/sam/rat2.wav": {
+     "bytes": 72450,
+     "sha256": "26220a17721327a09330973afa5eb0c64a2fb13fc4c2ddad98e60c08f774bd45"
+    },
+    "sound/sam/spooky1.wav": {
+     "bytes": 1797038,
+     "sha256": "d1ad52807c6643fbb6f615b2ca3348456f2962e914c66d18bc333dfb1768acf9"
+    },
+    "sound/sam/stuck.wav": {
+     "bytes": 23030,
+     "sha256": "5ecbe7c60cdbc42f37d345aaebb11fc9def2559a652d9123c530b753045645a1"
+    },
+    "sound/sam/uh.wav": {
+     "bytes": 3692,
+     "sha256": "a587be589024f5008224d7a1a7f35ac53075d4dd75a5ea948eb45831b69c1def"
+    },
+    "sound/sam/v1.wav": {
+     "bytes": 74690,
+     "sha256": "77470b79b6e7201cffd95aa4ea5e9c3040489688f0208593b1a8b3af353722b1"
+    },
+    "sound/sam/v10.wav": {
+     "bytes": 58894,
+     "sha256": "005beaa55270c3e2d6b9bcb76fb638d3b9379d64c7f99e90599c31a03a3ece2b"
+    },
+    "sound/sam/v11.wav": {
+     "bytes": 94956,
+     "sha256": "02972b224991beb60e7e97c1f4587b8eb97d8e65c9894f45ac68a5734b9682cc"
+    },
+    "sound/sam/v12.wav": {
+     "bytes": 102958,
+     "sha256": "3d553d41fff976d5f24a569fafa30bc6e04478f9d700a84c5af94bf8fb090eea"
+    },
+    "sound/sam/v13.wav": {
+     "bytes": 140018,
+     "sha256": "7b510ce3e34456f96302394f562780eca0991e20d04503eb80d7de4a90955df7"
+    },
+    "sound/sam/v14.wav": {
+     "bytes": 184762,
+     "sha256": "c7f08e45920b0673662a4b5630f7e929f27ecba1f9970f7d53998e2f009eff10"
+    },
+    "sound/sam/v15.wav": {
+     "bytes": 93644,
+     "sha256": "12de0905ec080c8155d81cade17fb65b68c6d8c37fb2e55dc26f987ef9d6c121"
+    },
+    "sound/sam/v16.wav": {
+     "bytes": 72766,
+     "sha256": "1b7395e09db38890fe93b3a9914ceda78b439d6c0faa5becdc775bc952e5d5fa"
+    },
+    "sound/sam/v17.wav": {
+     "bytes": 88956,
+     "sha256": "cf360edbaf78ff3510d9188fc1d7900d3b81bccfab0d899a7070aa57d800f230"
+    },
+    "sound/sam/v18.wav": {
+     "bytes": 344312,
+     "sha256": "0c6c6aac196149b9739a56ce6ae09417ddab36e82b17e70f9f6a4b5de8e4f8ab"
+    },
+    "sound/sam/v19.wav": {
+     "bytes": 110534,
+     "sha256": "c68214414068660886fafc2eb4edc0aa4e62a327ce1bda8138195a2c5a381a73"
+    },
+    "sound/sam/v2.wav": {
+     "bytes": 75628,
+     "sha256": "97ba083a945adebb936cf48f350a3799194c9894d72048645e7ed55b161fb909"
+    },
+    "sound/sam/v20.wav": {
+     "bytes": 150028,
+     "sha256": "b32c444e802331b28b7a5c7ad20495b724424efe1357798028678ad1f77a302f"
+    },
+    "sound/sam/v21.wav": {
+     "bytes": 126148,
+     "sha256": "654ea579fc4dc0853fa99f31f0ac1ee7d462b1998b9bccfabf1af64267d840ab"
+    },
+    "sound/sam/v22.wav": {
+     "bytes": 77110,
+     "sha256": "2d85dfc4ba55f74502f0d54c01689d09859fb2e70819ac9e0e919968c694314a"
+    },
+    "sound/sam/v23.wav": {
+     "bytes": 312242,
+     "sha256": "46b0dcafde9ae893f5ad4202668fdde8068e78fa6b00fa6e6534d5a7852119c7"
+    },
+    "sound/sam/v24.wav": {
+     "bytes": 108374,
+     "sha256": "2b4c1a35184c250a5766c464176725ef5c7b5fc410e0bc3e21db42aaee88cdce"
+    },
+    "sound/sam/v25.wav": {
+     "bytes": 122126,
+     "sha256": "50f5842f3cb912c7b171352badad4fe8243958fb99bbddd7347f6a1f981f682d"
+    },
+    "sound/sam/v26.wav": {
+     "bytes": 110970,
+     "sha256": "b84d50115974beae2a6fc83ed2aabce737a768c1c3eb8eec809ef40081710de8"
+    },
+    "sound/sam/v27.wav": {
+     "bytes": 243930,
+     "sha256": "c38c0c0bdeec6fd84b9e20edcf062f7dc0bb06b657275e889350008c07ccc5a7"
+    },
+    "sound/sam/v28.wav": {
+     "bytes": 82950,
+     "sha256": "45f4b149507a954b2d39a448217a8ea47ea239410fe89f5e03e61c6babe8e297"
+    },
+    "sound/sam/v29.wav": {
+     "bytes": 84944,
+     "sha256": "b92ea783b2ea6fefdb5d2db7cef9cb21c3e8f27f92e918ebff2986a2c509c783"
+    },
+    "sound/sam/v3.wav": {
+     "bytes": 117980,
+     "sha256": "df869c08b3b12e90db78c54f8afa64acf4b8919c8a37f4b1d5cf0400e7b11ead"
+    },
+    "sound/sam/v30.wav": {
+     "bytes": 92904,
+     "sha256": "8389ad10c912b32af4a9389df63c2b1bd2768940f7635d12166ab53bd2e2fbc5"
+    },
+    "sound/sam/v31.wav": {
+     "bytes": 76156,
+     "sha256": "2568a7025c1bb3becc2a1e82160f3af5ced38b25496e5e72e1791e903dc8584f"
+    },
+    "sound/sam/v32.wav": {
+     "bytes": 103694,
+     "sha256": "74e7aa8c5599ab0a4bf58391b58802729b70bd2906a12b1ddfcde8dfe0696892"
+    },
+    "sound/sam/v33.wav": {
+     "bytes": 93642,
+     "sha256": "73b9018eedc3d23a87a38d1d0781867a7ea6cc623655a82bec3f484df17cbe1f"
+    },
+    "sound/sam/v34.wav": {
+     "bytes": 117168,
+     "sha256": "1e52a6980da2e806a507ef94a1b923868d4cbe84252972169e86e0066ca9cc27"
+    },
+    "sound/sam/v35.wav": {
+     "bytes": 110974,
+     "sha256": "e232fabb8c1cdc439710041d6e0adaa9a1029eb7894da76c2bee149f07bdbd05"
+    },
+    "sound/sam/v36.wav": {
+     "bytes": 109414,
+     "sha256": "713e2ad0aa7de4e9c2e42f74eb50bbc9d33c68e0b213726e429c5416cbd36f27"
+    },
+    "sound/sam/v37.wav": {
+     "bytes": 90810,
+     "sha256": "a6604b63b969a854aec2a404ee431f9de4417fb205d818fe53970afbcf4ecbae"
+    },
+    "sound/sam/v38.wav": {
+     "bytes": 79764,
+     "sha256": "3b122ab196457f5401236c5653ac2c3520d916127e847305e35fecd0f6d43cfc"
+    },
+    "sound/sam/v39.wav": {
+     "bytes": 159840,
+     "sha256": "f056c6876cd850563c6cef228f1f8729c79638b34b24e5b15ac69a264d8934b3"
+    },
+    "sound/sam/v4.wav": {
+     "bytes": 69450,
+     "sha256": "88bcef2cfad76b3fbefdb65c944be3f19df8f7502977bd109935848283edcf55"
+    },
+    "sound/sam/v40.wav": {
+     "bytes": 237726,
+     "sha256": "4d1b57d2c17a93a503c0ff7f0126362f76d54093b4e8b99835dd0d07f7ec5b6b"
+    },
+    "sound/sam/v41.wav": {
+     "bytes": 58950,
+     "sha256": "3b8d9510062c1c45a42286de3fcd85dc2a2034ef3efcd205fd2991ff3ece985b"
+    },
+    "sound/sam/v42.wav": {
+     "bytes": 159058,
+     "sha256": "fbed045bc5b147e19a8c79958bc92c4bd46121dded7d9ea240c7f7bebb81c031"
+    },
+    "sound/sam/v43.wav": {
+     "bytes": 98720,
+     "sha256": "d075a98cc92322d868eafba14fd1fa7e19d4a7f843ddd20c57cd5c52a61b0cd9"
+    },
+    "sound/sam/v44.wav": {
+     "bytes": 114772,
+     "sha256": "37fadc22957cfb3d78b830a319a649f9b338ece17fca5fc6fd7f578388ca0698"
+    },
+    "sound/sam/v47.wav": {
+     "bytes": 341416,
+     "sha256": "7ccef9aad81dfa9474f2306fe34c4298017700b00403f402526dd3f395afa826"
+    },
+    "sound/sam/v48.wav": {
+     "bytes": 110440,
+     "sha256": "28e80131df1474e5393a4b77c99873d76751c097e9bc999bd27a1bd477faa3a5"
+    },
+    "sound/sam/v49.wav": {
+     "bytes": 95032,
+     "sha256": "2c120cd2d864cb9df1bba96d91a07bcdd0bf2d9ddcbaac203456358771659659"
+    },
+    "sound/sam/v5.wav": {
+     "bytes": 168736,
+     "sha256": "360e8007b2ca3df261c90c140507eebd65a2095c421fac68daf10698a65e330d"
+    },
+    "sound/sam/v50.wav": {
+     "bytes": 156648,
+     "sha256": "c963e074543cbd7b2e0b34edc864d48315cb0ec332973b712e92a19d9e8a7207"
+    },
+    "sound/sam/v51.wav": {
+     "bytes": 131686,
+     "sha256": "ac1c78135bf4f1b0173021719fe86768c415f1093f81b695d63a949853386a98"
+    },
+    "sound/sam/v52.wav": {
+     "bytes": 203512,
+     "sha256": "890c00eaf28d361d012964efa5749336016faa615091a0e90a10173dbaaa941b"
+    },
+    "sound/sam/v54.wav": {
+     "bytes": 143312,
+     "sha256": "36cb5fc980ee7434f984bc2323030921528960968e702d5d568c2e84d3c0400f"
+    },
+    "sound/sam/v6.wav": {
+     "bytes": 106624,
+     "sha256": "70d332808ca0b877f3f013c58425394c98b6ad37af1584bd85a0dce2f7566dfd"
+    },
+    "sound/sam/v7.wav": {
+     "bytes": 95746,
+     "sha256": "3f65bb29bcea0308f575fffc8596d3822e795fa1fb8286cbbe08d000200a6b13"
+    },
+    "sound/sam/v8.wav": {
+     "bytes": 324946,
+     "sha256": "302558762ad629260b3ae5efa046d5ccffe180fbd0dadfa504b94848dc5bf815"
+    },
+    "sound/sam/v9.wav": {
+     "bytes": 107948,
+     "sha256": "ae13374be029460026475cc1bfc8880c6bfc7121f61d049d3a2b1adf2d649412"
+    },
+    "sound/snow/blizzard.wav": {
+     "bytes": 838290,
+     "sha256": "29182815cc68b850fef2781c58cef2b5da7de1183dd4eb55230e89215133b333"
+    },
+    "sound/snow/creaky.wav": {
+     "bytes": 352838,
+     "sha256": "c82c89b5599fab15ea74e2f07b40661940bfc43c98191accea45fa09142a51b2"
+    },
+    "sound/snow/mywind.wav": {
+     "bytes": 471290,
+     "sha256": "ade4d87f628c4884314e7e4950c0dfcad5acd12a0ac456710f22012b822c0d75"
+    },
+    "sound/snow/rfall3.wav": {
+     "bytes": 185330,
+     "sha256": "fbed66b8e4ca7b5dfb1051be1949a7e18aee3e920c8477f775c80c4547fdc1b9"
+    },
+    "sound/snow/robdrn1.wav": {
+     "bytes": 403814,
+     "sha256": "1b94e78c170b668fb8bdfb433931198627a60f04241b7bddb9f5a94e24629d2d"
+    },
+    "sound/snow/robo3.wav": {
+     "bytes": 105824,
+     "sha256": "062082f174a82c9294bb69637538e5638aef8ebac28c5f08fe2e41aad17dc1b8"
+    },
+    "sound/snow/rubble7.wav": {
+     "bytes": 242218,
+     "sha256": "898f39157b0f4371b51145e27c95193322961699eeecbb4aa223dff02fc6d25b"
+    },
+    "sound/snow/rubble9.wav": {
+     "bytes": 417834,
+     "sha256": "2037709fa35e30d5a4853686d61fc90c4b35595772b20b50c31840a0b12f0dbe"
+    },
+    "sound/snow/rubble92.wav": {
+     "bytes": 178276,
+     "sha256": "70664f6c4c60c1b79552455122b5df50e4c292f4cc81c8857bb14c8db698c48c"
+    },
+    "sound/snow/zoom.wav": {
+     "bytes": 62008,
+     "sha256": "844a1a42e49ae5c22946277fc0712f0dcde48b17eeb6203298ff8d023ca738d0"
+    },
+    "sound/snow/zoom2.wav": {
+     "bytes": 280038,
+     "sha256": "7be3c5d704d0c8fef08b9d41843baacee3c14ef55cabe6ebdc98770c82525780"
+    },
+    "sound/swmp/rf1.wav": {
+     "bytes": 5720900,
+     "sha256": "1536040ff8b22172afb9790827f5bd33fbe9931509c546de5075f67740e3d918"
+    },
+    "sound/swmp/rf2.wav": {
+     "bytes": 1408334,
+     "sha256": "c3e81be7c89019e3145d35ba01bc1edced90e244ac6def5e41866c2d4544a365"
+    },
+    "sound/tunes/tn1.wav": {
+     "bytes": 6279500,
+     "sha256": "4e95961b3dbce96b7cbede7c790d1a495643d457e547d525ca22cb24881d0bef"
+    }
+   },
    "sha256": "6e23d147abe9b1dfd2b7bb9399ae69f10e362642b8731df46896694169b5b627",
    "timestamp": "2023-08-05T21:15:50.000Z"
   },
   "peril3.0/pak3.pak": {
    "bytes": 47388463,
+   "files": {
+    "sound/ambient/pulse8.wav": {
+     "bytes": 55534,
+     "sha256": "0394f1325e1b00403ee61ecd04ff3745026260e9b0e9b05d7731bbfdb13d5054"
+    },
+    "sound/bal/bc7_waterfall.wav": {
+     "bytes": 137846,
+     "sha256": "51dcfb96c94678cbb01e0c985240e853a01c6fc3c4f2376de177c0be59bfcfe6"
+    },
+    "sound/bal/chant3.wav": {
+     "bytes": 116346,
+     "sha256": "5d71f12940688414ab8cabc0d88e323dc961b60aac66f17887712133f1cb8b29"
+    },
+    "sound/bal/drippy.wav": {
+     "bytes": 269474,
+     "sha256": "2b020ba6df4393618ff98893b9ec10698fe39ef3bd95d105a9be7940cf55e4c6"
+    },
+    "sound/bal/flies1.wav": {
+     "bytes": 44168,
+     "sha256": "ca5cf0a4d661bf7440cd81dcd45ad7118c54c8ae58672755ee958ec6e50f7152"
+    },
+    "sound/bal/flies2.wav": {
+     "bytes": 44166,
+     "sha256": "09e6d74986b0f0ec9503d9e111f8d1436d7d6c5c4c0c87ec7808e3fca5b964b1"
+    },
+    "sound/bal/flies3.wav": {
+     "bytes": 44182,
+     "sha256": "2b5fb337ba88bd25e10c86bb6355723aea160b0ef6a6d43b30cbbd446444ed8e"
+    },
+    "sound/bal/water1.wav": {
+     "bytes": 40472,
+     "sha256": "7364a33f42e22feeb22c428ad774f92e522f811f42fc7498ec84ad4deecffcca"
+    },
+    "sound/bal/wind2.wav": {
+     "bytes": 35606,
+     "sha256": "3ea692e4d550a82dc9e815836a8772a25043edb9536e8c794f4ad9032fd5a5bc"
+    },
+    "sound/baron/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/baron/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/baron/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/baron/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/baron/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/baron/swipe1.wav": {
+     "bytes": 5368,
+     "sha256": "a523611bd853f4a30b0d8a52a1d068687e6ee01378f612ede614fc6ad1d41083"
+    },
+    "sound/baron/swipe2.wav": {
+     "bytes": 4454,
+     "sha256": "2f82268c58879ef8bb65a4e51a8e9977735befd4a65aa998e33566d767fc6af9"
+    },
+    "sound/boglord/attack2.wav": {
+     "bytes": 8036,
+     "sha256": "efa18dec8f6d5066b8d494a232ca9c98c27a4a9130130086a9b0a27ffccb34ed"
+    },
+    "sound/boglord/bangdoor1.wav": {
+     "bytes": 30968,
+     "sha256": "b267e602e76fe1d8e854e2873e06008af15612ed1a31ec41feeb4461d52fc478"
+    },
+    "sound/boglord/bangdoor2.wav": {
+     "bytes": 39828,
+     "sha256": "f904a5423580c118de1d732fff714565f1dd8d8d1556b3b58bf39d2c59fa4272"
+    },
+    "sound/boglord/bolt_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/boglord/death1.wav": {
+     "bytes": 39758,
+     "sha256": "a9e0e36b1a51d88a5b542dd2c1f79f1dbea402b3ceb18ee13606c03126f1a874"
+    },
+    "sound/boglord/idle1.wav": {
+     "bytes": 15532,
+     "sha256": "5339e3429b0510f7e8016e6ece9895df6f202b5809f739b317211a081401f202"
+    },
+    "sound/boglord/idle2.wav": {
+     "bytes": 18586,
+     "sha256": "52f8bddb2d5095f4077eb1f753d75bce94f906f1b3064067a54c875ae16d1a5c"
+    },
+    "sound/boglord/melee1.wav": {
+     "bytes": 9326,
+     "sha256": "e2f5808115d0a93dde1063db6f2d38f6ab7ff333f83d95741a8948f44ae4ace9"
+    },
+    "sound/boglord/melee2.wav": {
+     "bytes": 11746,
+     "sha256": "e299e39467c9f94730c21d1321455fdccf3aefbb0352d528b6d413639210e715"
+    },
+    "sound/boglord/melee3.wav": {
+     "bytes": 18776,
+     "sha256": "c066200b5ddb81aa0c0cc0462939681703549ac15dd6aa83db8a23ae54ce6317"
+    },
+    "sound/boglord/pain1.wav": {
+     "bytes": 11094,
+     "sha256": "6ca5a44043add6b389827e5aca8bc0c9e9c7b0cc0c7b4a5d3df292a78da0064f"
+    },
+    "sound/boglord/pain2.wav": {
+     "bytes": 11094,
+     "sha256": "7e11818fbae5354177add1e236b6f3e0f4665d50193154fbb15fead4bb4d7908"
+    },
+    "sound/boglord/sboom.wav": {
+     "bytes": 22172,
+     "sha256": "89899521eac11f922cdd4606a0fe08bc080a63a73ec4b4a502027e33f08b225b"
+    },
+    "sound/boglord/sight.wav": {
+     "bytes": 28734,
+     "sha256": "8b020b0f07a7461f5f520b8385e38828d66b3cb1fc46d7db08b845fa8ff62ad8"
+    },
+    "sound/boglord/slime_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/boglord/slime_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/boglord/thud.wav": {
+     "bytes": 22140,
+     "sha256": "f5d7b5f65e24d6a5edd04404b93a8c5a2db45cc6c142012638f050158bb783ba"
+    },
+    "sound/boglord/thud2.wav": {
+     "bytes": 105882,
+     "sha256": "7e8826a38df07d0d2b85d6d39b8b664bb2ef8a0686846573802b77811682e957"
+    },
+    "sound/break/ceramic_i1.wav": {
+     "bytes": 11106,
+     "sha256": "ed731319eb09044fe672f5d8681395a11a7449fe7b57b9a46040c717e714cf40"
+    },
+    "sound/break/ceramic_i2.wav": {
+     "bytes": 11126,
+     "sha256": "88c29d649471f031aa1049ee087cf866e1d9ea53183effd14cfabc81ecff9502"
+    },
+    "sound/break/ceramic_i3.wav": {
+     "bytes": 11144,
+     "sha256": "420d00d7884a22dd2baf9cdd1e059689858b47fb3adb2ad5ae29c80bd74b5dc5"
+    },
+    "sound/break/ceramic_i4.wav": {
+     "bytes": 17678,
+     "sha256": "0b7da87d046aeb3a52de305da60b2400c8cbf3480364235fb0bba3a0595f13dd"
+    },
+    "sound/break/ceramic_impact.wav": {
+     "bytes": 37584,
+     "sha256": "e6d2ada5c51a2787548468ad393e2497ef84b47ca487cd523f3ef6b283626226"
+    },
+    "sound/break/ceramic_impact2.wav": {
+     "bytes": 35380,
+     "sha256": "508725e20a999c339501dddb045a2ca6a51032905dccc68fe2a3fb9e9e1d0649"
+    },
+    "sound/break/ceramic_impact3.wav": {
+     "bytes": 26560,
+     "sha256": "ca4d7876a6e33cc285186d1432670878b54cc62c01e3dc4c650727069bfdb8ee"
+    },
+    "sound/break/ceramic_impact4.wav": {
+     "bytes": 37584,
+     "sha256": "e71b0559ac5d76dcd2016d07f8999ae1200d82ca7b658509339cf303c918f777"
+    },
+    "sound/break/ceramic_impact5.wav": {
+     "bytes": 37584,
+     "sha256": "1c6b3457c9d3aab209cd3b8977df579cdbe01158c1b4e5c07c2b5b227c96fb6d"
+    },
+    "sound/break/ceramic_impact6.wav": {
+     "bytes": 37584,
+     "sha256": "fac4857865a750a03f74e556f44186381315068ec1975c775fcd14ae4a7b3c7b"
+    },
+    "sound/break/flesh_impact.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/break/glass_i1.wav": {
+     "bytes": 13268,
+     "sha256": "63ec32f660d085c64274747b704bcbeb7261062b5fcbb570598d64e742dc7164"
+    },
+    "sound/break/glass_i2.wav": {
+     "bytes": 30950,
+     "sha256": "8b2ae028e6237cf06241739e3533ef3bf651194dfbef028fd648a6f06e8996de"
+    },
+    "sound/break/glass_i3.wav": {
+     "bytes": 8848,
+     "sha256": "ec97346c02431717927e2dd3712bd82428ea05960ffa027422fbaafab96b4170"
+    },
+    "sound/break/glass_i4.wav": {
+     "bytes": 4442,
+     "sha256": "b4144a008122e52aed45339e11ccf7cb1cd2e92f07e4169d029059a4ca01f5fa"
+    },
+    "sound/break/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/break/metal_i1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/break/metal_i2.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/break/metal_i3.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/break/metal_i4.wav": {
+     "bytes": 79928,
+     "sha256": "d2b35ba352f32ceae469acf9cfa04f7dcc0a462ff69e3649f5c0adf55ae2ea78"
+    },
+    "sound/break/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/break/rock_i1.wav": {
+     "bytes": 30534,
+     "sha256": "5cb61e93ebcf9bbcd3be1f6e282b51e9102d56b6650cffc0db93918b11b42322"
+    },
+    "sound/break/rock_i2.wav": {
+     "bytes": 29254,
+     "sha256": "9fdf4f489834452fce33b1fbe69bce9d4920a117c3d0d93b4fb530a7117bf160"
+    },
+    "sound/break/rock_i3.wav": {
+     "bytes": 25264,
+     "sha256": "59b506a84e018b11e9ba30a6ad299c2d8cf24d5907dc95cf30e578cd386e28bf"
+    },
+    "sound/break/rock_i4.wav": {
+     "bytes": 27244,
+     "sha256": "7a2c24ce52e272998ca035c967860873c92fbb14227a190ac82b761843680ffd"
+    },
+    "sound/break/rock_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/break/wood_i1.wav": {
+     "bytes": 28074,
+     "sha256": "6249449664f5ae509164ae3fd8588c905bea9daf5b1d919d9917b91aadf675bb"
+    },
+    "sound/break/wood_i2.wav": {
+     "bytes": 25158,
+     "sha256": "d51e731bdf895c84ec9927c496fc0a7fb6e7a37cbfbc2f6b55f54f716d804d08"
+    },
+    "sound/break/wood_i3.wav": {
+     "bytes": 17644,
+     "sha256": "8e1967cf42a7e31668d94e1b0cb7c6de4d36c6ec735d67ab01ac4e00dfb0853c"
+    },
+    "sound/break/wood_i4.wav": {
+     "bytes": 11516,
+     "sha256": "fb0908f1a2bdff824d27fa92f15690cb9f86805185119fbc7f7876547495bf45"
+    },
+    "sound/break/wood_impact.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/buttons/switch04.wav": {
+     "bytes": 24844,
+     "sha256": "70dab0f917602787a7cd2e3ae87cb5883ea901006643a57828411bcb17586de3"
+    },
+    "sound/chthon/attack1.wav": {
+     "bytes": 22116,
+     "sha256": "91df4f5be21c6a80d31a050192b04a760f25c7f88a4b0ceeb2802fe8b8499d21"
+    },
+    "sound/chthon/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/chthon/death1.wav": {
+     "bytes": 55120,
+     "sha256": "b6eeee788b9aa49ca9698d2d7977748f142053fd3f47e2828d1781d7db7ec986"
+    },
+    "sound/chthon/idle1.wav": {
+     "bytes": 24322,
+     "sha256": "6a0a9b5a0b2e74fce8cbfa9ede97c2059884c0db81b2c68fc0ec7bb1da2a4009"
+    },
+    "sound/chthon/lavasplash.wav": {
+     "bytes": 100546,
+     "sha256": "a533653ff77e2dfc443377a1f055b6abd7af3c639f0e5634b0a47fd1f040ed76"
+    },
+    "sound/chthon/pain1.wav": {
+     "bytes": 35320,
+     "sha256": "f964bdd08ffc66f9f229aacb3b584ffefdcfbacf7da0f0075a9af752569c641c"
+    },
+    "sound/chthon/sight1.wav": {
+     "bytes": 49454,
+     "sha256": "533adf244fa2c2dca72765560e823ceead8d5a0f3832ba18d4fa2928154b12c8"
+    },
+    "sound/deflector/death1.wav": {
+     "bytes": 47854,
+     "sha256": "321f49780b5250efd9d3b8a47aebf21f2c09d5fa04a250d3837267942132a4e2"
+    },
+    "sound/deflector/death2.wav": {
+     "bytes": 72870,
+     "sha256": "476148d2cf50ac33631c354aa813f7e5914e5de02bf7ea9121b52f4c909d21e9"
+    },
+    "sound/deflector/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/deflector/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/deflector/idle1.wav": {
+     "bytes": 45706,
+     "sha256": "4229860e76964c07c0f2329f285e5d7028d59f9e446094b4ac3b756ab4d23ed4"
+    },
+    "sound/deflector/melee_attack.wav": {
+     "bytes": 9722,
+     "sha256": "14c7ee8568818590a5e0506ad8945c2e1f28b06432e87ef59996d7159adaa564"
+    },
+    "sound/deflector/pain1.wav": {
+     "bytes": 33906,
+     "sha256": "548635f297b8724179ac79c3d42f21301555d6c2758de194710d55e179a5e020"
+    },
+    "sound/deflector/pain2.wav": {
+     "bytes": 19904,
+     "sha256": "39e01876b0d41ad36b0b3b08721993e180fb29a2b393759714eef734fa5f2f21"
+    },
+    "sound/deflector/pain3.wav": {
+     "bytes": 17626,
+     "sha256": "b84aa7c794d994f5dc6473ab6759e5855f0930018218efc189f482cf8c8d82ea"
+    },
+    "sound/deflector/rocket_fire.wav": {
+     "bytes": 83876,
+     "sha256": "4fa11087cfe8ebdef23a793424b6279838df8655c3115dbc8752e1bb2d51cb05"
+    },
+    "sound/deflector/rocket_hit.wav": {
+     "bytes": 13274,
+     "sha256": "4dbcd0bad68272848a32a997bb235c4324cd55b1df0b96b1876fb96ea8ca6a90"
+    },
+    "sound/deflector/rocket_load.wav": {
+     "bytes": 81510,
+     "sha256": "8795b6e56cea055f35427603e38b9ae1824e80f4fdf84571f60bcc43f7909a98"
+    },
+    "sound/deflector/shield_off.wav": {
+     "bytes": 10684,
+     "sha256": "5c3ea84c12abf632d777f90972966c4a50dde4ee7363d257e3c0f89e68027b5f"
+    },
+    "sound/deflector/shield_on.wav": {
+     "bytes": 10464,
+     "sha256": "340196ba32a9d3f672cbc3db86765eb1517550b00f2f97ed76cb519da1b93962"
+    },
+    "sound/deflector/sight1.wav": {
+     "bytes": 54148,
+     "sha256": "5c73554622c31a0cf343e345fee74e5f9e5a6dd0f3ae86894d33b6ec16cada0e"
+    },
+    "sound/deflector/sight2.wav": {
+     "bytes": 81832,
+     "sha256": "454c973e78b78e7b832db978a35ed6a12bdb25e7ed31cba38984d21f73114d14"
+    },
+    "sound/deflector/sight3.wav": {
+     "bytes": 87460,
+     "sha256": "45632669550fd3fef3722fcc770c2e3473190a2c0342bb64b8912fc2122ddc4d"
+    },
+    "sound/demon/ddeath.wav": {
+     "bytes": 26702,
+     "sha256": "383ef05891a21fbed4c5375ae08298b644613619da1e16509794f005ff20201c"
+    },
+    "sound/demon/dhit.wav": {
+     "bytes": 20298,
+     "sha256": "87e19a65ed4c9325d87c8c758a1edf534abb9431b1d3ef27bd0d46d1003f720e"
+    },
+    "sound/demon/djump.wav": {
+     "bytes": 35754,
+     "sha256": "597efd80f9b28845d7fedc4394e0c5c48dd8ef7964c6b50d5e906862f2819b5b"
+    },
+    "sound/demon/dpain1.wav": {
+     "bytes": 21214,
+     "sha256": "ec96e0e7a897b12f56655ffa9c12d58d383641faf36cb3f5fe24da3113a1a11e"
+    },
+    "sound/demon/idle1.wav": {
+     "bytes": 26702,
+     "sha256": "383ef05891a21fbed4c5375ae08298b644613619da1e16509794f005ff20201c"
+    },
+    "sound/demon/sight2.wav": {
+     "bytes": 50870,
+     "sha256": "7080c6bc4f41c45e207708f9f3955602056a31eb40100d41201980bb2860c00c"
+    },
+    "sound/dguard/death1.wav": {
+     "bytes": 30610,
+     "sha256": "af3809501261ec4d0afa6ea7301c11a5c7bbc1cc3e06b8c88172ee0214c30969"
+    },
+    "sound/dguard/death2.wav": {
+     "bytes": 43636,
+     "sha256": "93a70fc0d6fee819c723a435a3954b3fd3be86e358698ce85db1062990d1575e"
+    },
+    "sound/dguard/fire.wav": {
+     "bytes": 60820,
+     "sha256": "f5e5d4f6ccc0778c1396c66d327564a0b1892773f2c23d2e30590abf0c758bd2"
+    },
+    "sound/dguard/hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/dguard/idle.wav": {
+     "bytes": 20498,
+     "sha256": "45b2f208b9796d19d7aeb0cba64e4b0e5fd2ed7c980123f7c41ca10d17785021"
+    },
+    "sound/dguard/pain1.wav": {
+     "bytes": 10380,
+     "sha256": "9a367afb7cde241099c58c999e225ba939be39f21be818b16444f5a810049960"
+    },
+    "sound/dguard/pain2.wav": {
+     "bytes": 14892,
+     "sha256": "827a1e4d3c9983f61fffd61de33054274c144bddd9a68460b496fd6281cf9406"
+    },
+    "sound/dguard/sight1.wav": {
+     "bytes": 18124,
+     "sha256": "9cb3d960261d90ec16c9883f4326c905356b6ff4e99cdf48ab5913b098588016"
+    },
+    "sound/dguard/sight2.wav": {
+     "bytes": 18022,
+     "sha256": "35ee4b7ec6715c8c9fdc24f90ad0b5d90a0ae7a4986168cf40670e87c325d5db"
+    },
+    "sound/dguard/sight3.wav": {
+     "bytes": 19948,
+     "sha256": "c6818770267626dea27f4a72ce2249771f6968924022c2275a5a96abfa485044"
+    },
+    "sound/dguard/sight4.wav": {
+     "bytes": 20332,
+     "sha256": "7affcdbdc62f13e492a15b54fe642fe045641f5551f570cc3c8d5f7ee29521fd"
+    },
+    "sound/dguard/slash.wav": {
+     "bytes": 22942,
+     "sha256": "44b60d785ff03f033e183b6fbce69e526351187d28efdeb308f6f8bea930d450"
+    },
+    "sound/dguard/slhit.wav": {
+     "bytes": 31956,
+     "sha256": "0f07a131640f21337cd89a772588ecfc707d6a729f96b54c21920b809cd620e4"
+    },
+    "sound/dguard/slmiss1.wav": {
+     "bytes": 10458,
+     "sha256": "e32d5cb070a13fad979b021e84a727f71242305ade1af7bfe18c255f0f6dd548"
+    },
+    "sound/dguard/slmiss2.wav": {
+     "bytes": 13840,
+     "sha256": "f6b3aee08c25434d2fda7468cacf35a0912b182653a45991149b54a0fc4be537"
+    },
+    "sound/dknight/dcross_idle.wav": {
+     "bytes": 176610,
+     "sha256": "a7eba673532dad555f879ba77091e3cb9e44558608b83c36d8639e51d71b660a"
+    },
+    "sound/dknight/dcross_idlecom.wav": {
+     "bytes": 58910,
+     "sha256": "bba45bd9fc02e1d580a80596d6a1744bb8fb993ed73a7bfdf3b712670cccf989"
+    },
+    "sound/dknight/dfury_grunt1.wav": {
+     "bytes": 19702,
+     "sha256": "8d3709e913b8e26d8e094fddd9c60d74cc71b742e16276d4982c9636db05209e"
+    },
+    "sound/dknight/dfury_grunt2.wav": {
+     "bytes": 54294,
+     "sha256": "f7ca0d5970322629cc47f8c26489d5c916a570525ded20c73823c27f2834609c"
+    },
+    "sound/dknight/dfury_grunt3.wav": {
+     "bytes": 62054,
+     "sha256": "6eae53c32568ce90083dab528c18475ef840f9f684c43cdba7bfcc1c63435ba6"
+    },
+    "sound/dknight/dfury_grunt4.wav": {
+     "bytes": 28914,
+     "sha256": "0def63c77d0f116eabb77cc462ba6a57bc6523fad469946c6f1f11d786100819"
+    },
+    "sound/dknight/dfury_leap.wav": {
+     "bytes": 102756,
+     "sha256": "f288dc9324b2ccace32ce86cffaf0c042a59bf5b56b20657c018859f1038243a"
+    },
+    "sound/dknight/dfury_sight.wav": {
+     "bytes": 69602,
+     "sha256": "443887e91ca71dbba299b37a81bdbd3bb34b491c6c3e13fe73bb5c921019d1ea"
+    },
+    "sound/dknight/dprince_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/dknight/dserg_hbreath.wav": {
+     "bytes": 185884,
+     "sha256": "c8181d4844ac4b2bb7dc47bbc28bd2ae9fc2737120d6745292de4d594f40d406"
+    },
+    "sound/dknight/dserg_magic.wav": {
+     "bytes": 34768,
+     "sha256": "adcb0810b7e8b23d91d31f5727c480b35c7b59a90d9f7933f69c00e7eccd1f3e"
+    },
+    "sound/dknight/dserg_sight.wav": {
+     "bytes": 15210,
+     "sha256": "d4f7c5b6f64d48606d1d3e1889794a22107f3d5914b37c81c405fdfb1133a7eb"
+    },
+    "sound/dknight/ghost_idle1.wav": {
+     "bytes": 110292,
+     "sha256": "878416a0151a1a71891a84db2565d1e8a2b2e37f03f1822d7f9411a98b42b528"
+    },
+    "sound/dknight/ghost_idle2.wav": {
+     "bytes": 110290,
+     "sha256": "048f79f7fa8f9e49f97dad9f5cb468933be1713726ba95d3ab10d9811cbb5f2f"
+    },
+    "sound/dlord/death.wav": {
+     "bytes": 32022,
+     "sha256": "0188f6a3dd88686e15311f8c39c4277078e55bc0ec75497e2eb534af717abcdb"
+    },
+    "sound/dlord/idle.wav": {
+     "bytes": 9906,
+     "sha256": "c0ee37f80013dad1aaeb285a11a33c4d7c2ff2de0b2a94c2943d3fbe1c241bcd"
+    },
+    "sound/dlord/pain.wav": {
+     "bytes": 8632,
+     "sha256": "230ed5c7d024bfa90b973649aa79d9e9327eaf401b1632e4a1334fb4a9eb075c"
+    },
+    "sound/dlord/sight.wav": {
+     "bytes": 28028,
+     "sha256": "d82aa0028754e826705961040e1ab27f007c572a28c63dbcaeefeb681bc3ca85"
+    },
+    "sound/dog/dsight.wav": {
+     "bytes": 134864,
+     "sha256": "6cb2219e05afc558f0d3d732c2c0bfe7b463d3803fb4a57bab1579dd0a2f63e4"
+    },
+    "sound/doors/door2.wav": {
+     "bytes": 46856,
+     "sha256": "6c228c30952ca7832cd629d35c76b1714ed4db4533732e71d3bca62bc231c922"
+    },
+    "sound/doors/door3.wav": {
+     "bytes": 46856,
+     "sha256": "6c228c30952ca7832cd629d35c76b1714ed4db4533732e71d3bca62bc231c922"
+    },
+    "sound/doors/door4.wav": {
+     "bytes": 33650,
+     "sha256": "c1d63ab21f04edd39835dc6da35547d7853ef2dd6891537e082de3e277974787"
+    },
+    "sound/doors/door5.wav": {
+     "bytes": 48554,
+     "sha256": "d1547902e21629e4ffdf431a25a57e6bf38e47dfccb638a5e0d3855cb7c19f94"
+    },
+    "sound/doors/door6.wav": {
+     "bytes": 48554,
+     "sha256": "d1547902e21629e4ffdf431a25a57e6bf38e47dfccb638a5e0d3855cb7c19f94"
+    },
+    "sound/doors/hinge1.wav": {
+     "bytes": 25196,
+     "sha256": "a8f52986c923fc2facef8b0cbb972f35023cbf18580a92d7ae1310623a85c1e0"
+    },
+    "sound/doors/hinge2.wav": {
+     "bytes": 18210,
+     "sha256": "fd4e2d2eb862380150eff548666fafca7ecc886fbd3475721b512be245c8bdf5"
+    },
+    "sound/doors/rattle1.wav": {
+     "bytes": 88274,
+     "sha256": "c524d12100f1067bb30ecdf83e18e5d85124fef834929cfd2a2ade14f83ad730"
+    },
+    "sound/doors/rattle2.wav": {
+     "bytes": 123526,
+     "sha256": "e8decabe8df10f704814bf2f432b3fc6d5542022d465af336b0680793f6163ea"
+    },
+    "sound/doors/rattle6.wav": {
+     "bytes": 97072,
+     "sha256": "0aef6aac51a4e3528e5f2019bf113ee2f0e5096a708d31483a526c447ebdb00c"
+    },
+    "sound/doors/rattle_tech1.wav": {
+     "bytes": 61784,
+     "sha256": "18610e64612241e6936f2d0ebe746c957652c4ce8e37c668515281712f6a1e39"
+    },
+    "sound/doors/rattle_tech2.wav": {
+     "bytes": 88244,
+     "sha256": "de39aa8b59c988b02bf6c13a716e225b7ee029f2553357b8646aef92a2792c3e"
+    },
+    "sound/doors/rattle_tech3.wav": {
+     "bytes": 52844,
+     "sha256": "a29e8144cdab34467250f040feaad044aff784a2775b50bd220e967b39f39b3c"
+    },
+    "sound/doors/rattle_tech4.wav": {
+     "bytes": 76844,
+     "sha256": "ba34a641758a2e2cb9ef5358a398482c2b34526fc4b0c49db590c9679c732ef4"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/enrage.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/r_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/eel/attack1.wav": {
+     "bytes": 27740,
+     "sha256": "8c84b2a5e7fd0754dca3611a8300a8cc9656295ea73617ff0c85d167b28459df"
+    },
+    "sound/eel/death1.wav": {
+     "bytes": 26744,
+     "sha256": "485db98f099073acaf6a0ec465d979fa590845e2f73e2215e765b186bd7f7085"
+    },
+    "sound/eel/idle1.wav": {
+     "bytes": 53110,
+     "sha256": "c059a4f2bee33543b377803f2af1fc7e2ee205cd02d987859af18087246ae46c"
+    },
+    "sound/eel/impact1.wav": {
+     "bytes": 70632,
+     "sha256": "13cea2f7d66f40511add17d846ab6142345497ddd7cff5ebfc5e2e70a7eb1fbe"
+    },
+    "sound/eel/pain1.wav": {
+     "bytes": 13316,
+     "sha256": "569a6bf9383820e90e431db5c0b82cd0201e10fd2081d228f81a0c76a0e88d1b"
+    },
+    "sound/eel/sight1.wav": {
+     "bytes": 32074,
+     "sha256": "90786a043f5ec1bd0b761c5c8378dc2783e3b1d8e3ac95a9312f55a7c5b3baea"
+    },
+    "sound/eidolon/attacka.wav": {
+     "bytes": 27660,
+     "sha256": "a7bb5c16014c814d379585eb4c6752a91240a5856ad7f3af5f86af037bef91e6"
+    },
+    "sound/eidolon/attackc.wav": {
+     "bytes": 220544,
+     "sha256": "9815d26814c687618b7bbae4a5353570afe497c5d57fb77c083f695d102234c9"
+    },
+    "sound/eidolon/attacke.wav": {
+     "bytes": 46400,
+     "sha256": "39ad467257004bc6d2a17003abe4ef8df89d0668ec03fc8570aa755cbdf94c6c"
+    },
+    "sound/eidolon/death.wav": {
+     "bytes": 264696,
+     "sha256": "bc055e1315073c78e5571c99d29894bc89abfd64b6a258bdabc79849f81c50a0"
+    },
+    "sound/eidolon/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/eidolon/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/eidolon/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/eidolon/footstep1.wav": {
+     "bytes": 52384,
+     "sha256": "e228c0503d89118be55eafaf3a3bfa0a13e3bdcbe4a043f4a9bb31c9e96cf3dc"
+    },
+    "sound/eidolon/footstep2.wav": {
+     "bytes": 46128,
+     "sha256": "1a3b867c93932411f1c3dedf4a8f1553f19caabae438cb7989095307d1a6c5c5"
+    },
+    "sound/eidolon/footstep3.wav": {
+     "bytes": 43774,
+     "sha256": "4119d9c31e359bd48b52bff2842e51c441064896289194f04db44e2d7860cccc"
+    },
+    "sound/eidolon/footstep4.wav": {
+     "bytes": 41758,
+     "sha256": "6b97f80545d9587580a7b445f13e5a38300627e497ed85357f9448c7a910864b"
+    },
+    "sound/eidolon/growl.wav": {
+     "bytes": 44380,
+     "sha256": "f9f404c4590f2af8fa9a1cd0de34e1d031e66d88ccf553dba228396f0d8fb012"
+    },
+    "sound/eidolon/idle1.wav": {
+     "bytes": 28778,
+     "sha256": "61f423068b79bba82fb3ae3fca3957a8f059802068edf272f2695e6caab89271"
+    },
+    "sound/eidolon/idle2.wav": {
+     "bytes": 33172,
+     "sha256": "1bdd3d6862ed0b74aecae1917f09a65acf4db7fca49a0ccd21a7fbc2eea5f02b"
+    },
+    "sound/eidolon/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/eidolon/pain.wav": {
+     "bytes": 17744,
+     "sha256": "6a308180389e3fb98cc00c70dad1c6600988778b34628e04363e7ca54e5bf679"
+    },
+    "sound/eidolon/rock_hit1.wav": {
+     "bytes": 97066,
+     "sha256": "d31741c09309b240d294ba9b310b694aae1d71f823ac9ef28b27a8b5fff14405"
+    },
+    "sound/eidolon/rock_hit2.wav": {
+     "bytes": 123526,
+     "sha256": "a3d1247db98535829392172110a40fde19113dd493ab603c4b6a9a36dd743150"
+    },
+    "sound/eidolon/sight.wav": {
+     "bytes": 53044,
+     "sha256": "04c124f683e75e4d14374b7a044eeea288dd02a845ccab3ffd670f1c15799ebb"
+    },
+    "sound/enforcer/cent_hover.wav": {
+     "bytes": 103796,
+     "sha256": "a5616566072a5cdc9339e3722d6fee9e652796e9cc8f76e27dbd9aee13986f4e"
+    },
+    "sound/enforcer/death1.wav": {
+     "bytes": 33126,
+     "sha256": "4bd6775226b5985ae84c908f289e27717e527253b7dcb303cb753f5c7aa0deba"
+    },
+    "sound/enforcer/def_idle1.wav": {
+     "bytes": 48472,
+     "sha256": "b68aa439152314c549ab70be53c88b82be07501ddcda5c226944399b5033d567"
+    },
+    "sound/enforcer/def_idle2.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/enforcer/def_sight1.wav": {
+     "bytes": 18260,
+     "sha256": "7d57825c28cf4f93189261d76cccab676aeba097920114d5d3f48d7eddaaa1cd"
+    },
+    "sound/enforcer/def_ssg_fire.wav": {
+     "bytes": 14206,
+     "sha256": "494a6d493c3c298c1b9cc0051ce4c1f9e129293ea7ec283b62915c49d8c249c3"
+    },
+    "sound/enforcer/def_ssg_load.wav": {
+     "bytes": 5274,
+     "sha256": "db4f62f8d76a68f2e4d3e7a29a22d3ddc5d6ae9bb296e6e800e937b73b5a4dea"
+    },
+    "sound/enforcer/elim_idle1.wav": {
+     "bytes": 85540,
+     "sha256": "a35aa632f06a433e9fa1a327fbe1d19caf7e9ede6b72b19929759a8c0bc7a4d1"
+    },
+    "sound/enforcer/elim_idle2.wav": {
+     "bytes": 78138,
+     "sha256": "ff7ed92d4f06dac0c7f5a91b6a3c70c8dd834619cb80ff740ba0eb67c89d4c0c"
+    },
+    "sound/enforcer/elim_idle3.wav": {
+     "bytes": 44836,
+     "sha256": "5b022ad570ca92f067461e7d2407d04878989c8e329044865b6f4d1817109a46"
+    },
+    "sound/enforcer/elim_pg_load.wav": {
+     "bytes": 48086,
+     "sha256": "20233721e49f96be0cfaa3023b212b6842cf45c574dc4e5b3fc70739136ecccd"
+    },
+    "sound/enforcer/elim_sight1.wav": {
+     "bytes": 12588,
+     "sha256": "f795ab3453ee776d38bad6b7fe754f29b1c13e9db4906e260b08c47c96db2949"
+    },
+    "sound/enforcer/enfire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/enforcer/enfstop.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/enforcer/fum_poisonoff.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/enforcer/fum_poisonon.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/enforcer/idle1.wav": {
+     "bytes": 15810,
+     "sha256": "cec388af73dff076ea3af7c754ef0939f989f3412b0359c0fb668cd91bd4abaf"
+    },
+    "sound/enforcer/pain1.wav": {
+     "bytes": 12258,
+     "sha256": "3e2480cb8f44fc960445143594c3b1622fe26294a15e9e4a46641b6e33bc872c"
+    },
+    "sound/enforcer/pain2.wav": {
+     "bytes": 17146,
+     "sha256": "0ee1b4d4acac1b4bcfe37d2eaec82c8b9595b0ed63058056eaea8ee7885bbe07"
+    },
+    "sound/enforcer/pyro_flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/enforcer/pyro_flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 5870,
+     "sha256": "92dc64154602e29e95d40aa68d3544fe21cb21ce24192f1e8ffefc6b5d31b8cc"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 15682,
+     "sha256": "d164a04aea596169c8e8b4cc1188939b04cb2cabd70590e8ce33bb61c28c1360"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 26858,
+     "sha256": "92bba49e23c66cb2f6ac0d811c692fc834bb04cd2536e84f8c1d2e618a1ec3a2"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 5166,
+     "sha256": "815e05c3b14858209fee01316848c117ad89af9f0aab190fc0ca0239367373ac"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/freddie/death.wav": {
+     "bytes": 88244,
+     "sha256": "2e3de0875dd3245a98614829ab848cc1dfc34a95827aa4cfc174884977ecddf0"
+    },
+    "sound/freddie/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/freddie/idle1.wav": {
+     "bytes": 88280,
+     "sha256": "673ac7c26a9be2b1ea37b152ce48442ff40089cc7dc015c014eb42534db2c306"
+    },
+    "sound/freddie/mangle.wav": {
+     "bytes": 48548,
+     "sha256": "ee318d6849ca9dda4569db6009210a6909279bd2ffe9b31543d47134b51c1533"
+    },
+    "sound/freddie/pain.wav": {
+     "bytes": 38640,
+     "sha256": "ffe05b43444a209084c95c166b0776d33f9ba8af15ef998d3ed5c09aa0b03c3d"
+    },
+    "sound/freddie/painshrt.wav": {
+     "bytes": 8868,
+     "sha256": "31e08c51909022a6b0ad7f01f1f8dae196269b8b105e57e555025393cdc278d9"
+    },
+    "sound/freddie/sawstart.wav": {
+     "bytes": 41938,
+     "sha256": "90f83017a7ff5f2bd2824be1e122eab7d8171ab63a9025adf1fc03ee3e7a44aa"
+    },
+    "sound/freddie/sight.wav": {
+     "bytes": 50644,
+     "sha256": "feddfaee4d5fb359dc6e46f14aa3bf4d6b872b004ff34e80409cd480a8dbcab4"
+    },
+    "sound/freddie/step.wav": {
+     "bytes": 19898,
+     "sha256": "121818aa6200c770a70c2c02844bbc0351a62f166c31f9d85765896b426f610e"
+    },
+    "sound/freddie/step2.wav": {
+     "bytes": 19870,
+     "sha256": "7e33eb621ee356cbe4affe6218b988f477259dae705d57eea12d7fe10b5d4510"
+    },
+    "sound/freddie/step3.wav": {
+     "bytes": 19898,
+     "sha256": "a005232c4c0608092c7d697c6d24566892b74adfe7566030360c96996bd39357"
+    },
+    "sound/freddie/stfire.wav": {
+     "bytes": 27598,
+     "sha256": "597fa6e0e8c4da4fd85e9e26ecd7f95f3dc242846ec9b962cf2beb324e5a4fdc"
+    },
+    "sound/gargoyle/attack1.wav": {
+     "bytes": 28712,
+     "sha256": "cab70a44f7ec34343a1608ca8c13dd2b501065cade08e94b574f98436aabeadf"
+    },
+    "sound/gargoyle/death1.wav": {
+     "bytes": 41662,
+     "sha256": "07043eb3fcbcc9c8cf53b07c10b349a9f3beb471dc240a6d70d8f2b5a57e85b0"
+    },
+    "sound/gargoyle/death2.wav": {
+     "bytes": 28768,
+     "sha256": "c363613cd476d5099dbdced656244db0d704da5eeb54fe5b880f2202f6f465b2"
+    },
+    "sound/gargoyle/idle1.wav": {
+     "bytes": 72868,
+     "sha256": "90885fa6cae946ecfedec8a150911bcfdad8ef326254e1fb1bf44ca5c5af4eb0"
+    },
+    "sound/gargoyle/pain100.wav": {
+     "bytes": 26510,
+     "sha256": "d53f1e64f4c9f5e13e03cfee2681ef6dff370e95e9dd8668c7c06b79762e7773"
+    },
+    "sound/gargoyle/pain75.wav": {
+     "bytes": 28720,
+     "sha256": "78d5d0f1c5df4e1a565eeda076d5f8b3bb3582e551909b31fa8e36c292903826"
+    },
+    "sound/gargoyle/perch1.wav": {
+     "bytes": 26506,
+     "sha256": "5eab54a566e4c1136c40fbfbd636188a7a9c4aa6b278e51fb965e1761764cbff"
+    },
+    "sound/gargoyle/perch2.wav": {
+     "bytes": 30924,
+     "sha256": "745b5c5f1fd04a73a7581373925aa70cd3f35ab899df5f5fd2c610d07bf95bdd"
+    },
+    "sound/gargoyle/sight1.wav": {
+     "bytes": 35142,
+     "sha256": "1097300e4bca9ef61a7041e7f4ff403fe67c4fc0e687b30892a6bdf35bf45c09"
+    },
+    "sound/gargoyle/swoop1.wav": {
+     "bytes": 21056,
+     "sha256": "ef6b4b672dd984e846294e0be57d81df3abcb521b1f88f6afaf2f5cc2d4e91d4"
+    },
+    "sound/gargoyle/swoop1hit.wav": {
+     "bytes": 11078,
+     "sha256": "6a624e3f46e2c45f5e2d6f42ee18643a17268a6b0df2493fe6ffdba4be0c9057"
+    },
+    "sound/gargoyle/swoop2.wav": {
+     "bytes": 24364,
+     "sha256": "f98d41f9df7244e8f77c435ae4071a4e4595ec7005b7c72e44456fe7baca425e"
+    },
+    "sound/gargoyle/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 22094,
+     "sha256": "142b725ff5515cb438a592288a69e01331b3fd0bbb7311abf1dbaf90f95417ef"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/plasma_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/gaunt/plasma_start.wav": {
+     "bytes": 66270,
+     "sha256": "ad404715612b802a7d4f72f2d14abb47c338ac414af56c19ffc8dc2873f33452"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gaunt/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gibs/gib1.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/gibs/gib3.wav": {
+     "bytes": 33256,
+     "sha256": "10a19291ed8af8893b6cdbd80416425b27e5a197d39aa8d0557320752d78cf11"
+    },
+    "sound/gibs/gib5.wav": {
+     "bytes": 15490,
+     "sha256": "2d7603a9fc0c055ed3529bd4dfd511984c71b93f4719b605813eb5139d02c6d9"
+    },
+    "sound/gibs/gibacid.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/gibs/gibchain.wav": {
+     "bytes": 15938,
+     "sha256": "c6b2a37424a51810017bd5ee4764a014329467686f73bb2f48ad2704592176f3"
+    },
+    "sound/gibs/gibheavy.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/gibs/gibheavy1.wav": {
+     "bytes": 11110,
+     "sha256": "0a1313f08fa22e4df8a1beb15ffdb6e7b1906187f63042357e4a43631ef5e93a"
+    },
+    "sound/gibs/gibheavy2.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/gibs/gibhit1.wav": {
+     "bytes": 22150,
+     "sha256": "d2a73e2f9e31b9fefda789e49b17ec9bd18df0335c31f871514a282cf550829a"
+    },
+    "sound/gibs/gibhit2.wav": {
+     "bytes": 22150,
+     "sha256": "210477e93743dc6c0541bc158032d46251c6aeff551efcf515d6e7db87bb8a53"
+    },
+    "sound/gibs/gibhit3.wav": {
+     "bytes": 22150,
+     "sha256": "40db6dbb033d59dd458e5fb6102dba6d6ecf5bc5739d9fc35a3be68cc977da53"
+    },
+    "sound/gibs/gibhit4.wav": {
+     "bytes": 22150,
+     "sha256": "0bd1e29d68e41cbf2d753730df678918a38fc886b4690991fbd7e8fb3e13e055"
+    },
+    "sound/gibs/gibhit5.wav": {
+     "bytes": 22150,
+     "sha256": "4adf7a8249ee913aeb9e91120b1f6b9e529b1e1a3eadb75185589cf7c3ff910e"
+    },
+    "sound/gibs/gibmetal1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/gibs/gibmetal3.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/gibs/gibmetal5.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/gibs/gibmetala.wav": {
+     "bytes": 18474,
+     "sha256": "2c057e772307ef647b4313975cec75bacfd522bbc5dd27ae83a867065562635f"
+    },
+    "sound/gibs/gibmetalb.wav": {
+     "bytes": 30756,
+     "sha256": "fbcfa9e6cd5aa68c6fffd6699c8dc87ec3707a4281358f229afce57f3278c800"
+    },
+    "sound/gibs/gibstone1.wav": {
+     "bytes": 52956,
+     "sha256": "962dd735a1823905243700eb3f4e0caacc1be71a1f367ccad4f21dd82b4e99e1"
+    },
+    "sound/gibs/gibstone2.wav": {
+     "bytes": 22104,
+     "sha256": "04f070fa9873f382ded03a5139ce2c7da2013d8ef9221a8d10a64c3b5f912591"
+    },
+    "sound/gibs/gibstone3.wav": {
+     "bytes": 35344,
+     "sha256": "16262de5a0b703468f2c3f1e49ffa0c225eb81b89984b468b7bc95948ed890c0"
+    },
+    "sound/gibs/gibstone4.wav": {
+     "bytes": 8832,
+     "sha256": "75179beed6fb6f581944f5e7db153bea4d9ecc65899628468efd48710a392013"
+    },
+    "sound/gibs/gibstone5.wav": {
+     "bytes": 22130,
+     "sha256": "0aaff5c363ac29a9b50d83b4b04fcd7264c614a93d0c9bc7941c9704a6b4b499"
+    },
+    "sound/gibs/gibwood.wav": {
+     "bytes": 61708,
+     "sha256": "d9b53ab4d53f1265dd2083d341cd92f19729694946ff00ad15fa6d96965e63e8"
+    },
+    "sound/gibs/stonedeath.wav": {
+     "bytes": 76750,
+     "sha256": "26d0eb67357d292043fd494b1646f8ce005ba692d98610429bceedfc831d2325"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 374654,
+     "sha256": "de356a2581884e9008ef798775f82049c465aec242cad0f6024b510d33e11764"
+    },
+    "sound/golem/groundslam.wav": {
+     "bytes": 132412,
+     "sha256": "f557ad378642a77a2f31433db5fe9315cf33f5fc350018e2bd26d32359ec8617"
+    },
+    "sound/golem/iceshard1.wav": {
+     "bytes": 53022,
+     "sha256": "41e523122aa4168298b247748bbe4201928582e974e673a83e717ea33f8656a8"
+    },
+    "sound/golem/iceshard2.wav": {
+     "bytes": 53012,
+     "sha256": "4b4e457f75d051a7aa3525bf82338f8b6d2f9460583c09e63d82b202cb11d03f"
+    },
+    "sound/golem/iceshard3.wav": {
+     "bytes": 53038,
+     "sha256": "8134080a7c6478463f9ea8c368eb6e0563dacb35bb3941b1e08e2cf0763d83ab"
+    },
+    "sound/golem/iceshard_impact.wav": {
+     "bytes": 176470,
+     "sha256": "ac850565ac7cfaa8ec2e55f535603aaf131605b9399f08f1b17f7c08920f7bda"
+    },
+    "sound/golem/icestorm.wav": {
+     "bytes": 61802,
+     "sha256": "2e8129333bc1a677591f9c4838a5f8c8e9ff63050fe6a47f212380f2497ae706"
+    },
+    "sound/golem/idle1a.wav": {
+     "bytes": 88238,
+     "sha256": "d238c43b6e83c044ba70352ed9362e50d68caf606f500c7d79f5c03d1e6a432e"
+    },
+    "sound/golem/idle1b.wav": {
+     "bytes": 88242,
+     "sha256": "93e3ca1ec51345da6e06a53f71bcd1271c911c9a6272246de9f58bef93c904dc"
+    },
+    "sound/golem/idle2a.wav": {
+     "bytes": 44166,
+     "sha256": "d0ceeb0ee1681127f9f426ccaa0ddb75c6ef32594618c972536871544e8d5748"
+    },
+    "sound/golem/idle2b.wav": {
+     "bytes": 44178,
+     "sha256": "94fb43b50445dbe7a8fe6cc06ea745b729cf5bf61c33cc543123f751e4a9cdf7"
+    },
+    "sound/golem/melee_pound.wav": {
+     "bytes": 17672,
+     "sha256": "23ff4f485f3adb3ba5227ba59824e226e91005846d2879077ffbe04141bab78b"
+    },
+    "sound/golem/melee_punch.wav": {
+     "bytes": 17702,
+     "sha256": "21cbd6ca5b9c8d95a43c39b360b12ee8033dca1aaf11d4c1164d4bc9ce83b7d3"
+    },
+    "sound/golem/melee_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/golem/pain1.wav": {
+     "bytes": 27948,
+     "sha256": "388150975b33e271db5402f502c6a36899731ec85cb9b16cdcc4b427b206a3f2"
+    },
+    "sound/golem/pain2.wav": {
+     "bytes": 32940,
+     "sha256": "b3908c02406bcb8c379f345f80a825aa270a54ae02fe0356e02330620d9cf437"
+    },
+    "sound/golem/rockstorm.wav": {
+     "bytes": 264676,
+     "sha256": "c57be8195f675560b879c3fc4e23c49f021d0c45aa81f2a84b74303f111d7c7a"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 76762,
+     "sha256": "965d1107adbc9a068d1d2af16fc783855833569dcc3a6030fa920019c30a4083"
+    },
+    "sound/golem/wakestatue.wav": {
+     "bytes": 250454,
+     "sha256": "630505eb8c9c84511f39d2e77096cafcbab044f73569934cda127a4b6f37f138"
+    },
+    "sound/hknight/idle.wav": {
+     "bytes": 90378,
+     "sha256": "bd56c11b4a515dd1cfc4f25b777d5e755f3672ebe072c24b570b0a5575150c14"
+    },
+    "sound/hknight/sight1.wav": {
+     "bytes": 86540,
+     "sha256": "3129f551c2b8aa76e6159e8e304d72871749bd2d2f44a5338371379e9eb96007"
+    },
+    "sound/items/airtank.wav": {
+     "bytes": 22160,
+     "sha256": "9b8f5c5deb886800c91d46809ecf82fb114467eb8a395b9c980d47c6b35f6b17"
+    },
+    "sound/items/airtank2.wav": {
+     "bytes": 66286,
+     "sha256": "76156f8f89e2bedbfaee9ee3340adb6bfe8639f242051178c2655e04cdab5198"
+    },
+    "sound/items/airtank3.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/items/airtank3out.wav": {
+     "bytes": 176494,
+     "sha256": "672a866c27c64f7eda1e05775cea6b4373c289c39fd423a519d39198d10a9c89"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 15122,
+     "sha256": "54c25fca46991ea142e9fdf5309e690ce3ff977df89aa7d14a8938ff386a237e"
+    },
+    "sound/items/backpack_ammo.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/backpack_armour.wav": {
+     "bytes": 20612,
+     "sha256": "438a08f094f47fac5f0b959fdde0f941be50bac12abdaa159f6f727975021aec"
+    },
+    "sound/items/blastbelt1.wav": {
+     "bytes": 43442,
+     "sha256": "a85924de58caed8e32d2849838afa0f248ec26eb295c9fc82eff818bc292f28b"
+    },
+    "sound/items/blastbelt2.wav": {
+     "bytes": 74978,
+     "sha256": "e4747a55ed0d66b6ce3bfe4ad0a4cfa75308657a155ebd9396ada78e0fd46bac"
+    },
+    "sound/items/blastbelt3.wav": {
+     "bytes": 49028,
+     "sha256": "4a2f6e7f65cbbc19c4bd5facf821017f7e60c41b9c164575de5255a40de2ba53"
+    },
+    "sound/items/health0.wav": {
+     "bytes": 55544,
+     "sha256": "033a7a66a92809242854554a2360a9a71e0eb8b238c40ef1794f6e886eec3fbf"
+    },
+    "sound/items/health1.wav": {
+     "bytes": 42548,
+     "sha256": "2f324c4de0891932dace5fbdd957d8bbdf1ffc7feeed761b1e42e380ac502e0a"
+    },
+    "sound/items/itembk2.wav": {
+     "bytes": 18884,
+     "sha256": "2b5601380dcc36753327eea905d15d2e0fd0f016d9559a2f8924f6f34b8045d5"
+    },
+    "sound/items/jumpboots1.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jumpboots2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/jumpboots3a.wav": {
+     "bytes": 5764,
+     "sha256": "7d8bdc9f65283940defcb60cd0dc678139b6b24f368de6cd8b8dc675400612af"
+    },
+    "sound/items/jumpboots3b.wav": {
+     "bytes": 85590,
+     "sha256": "8eda0e57fdadfb61a414b4dae8c567a2bf10d9dabc44db7cf5589f00bba16250"
+    },
+    "sound/items/jumpboots3c.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/lavashield1.wav": {
+     "bytes": 30884,
+     "sha256": "e79050c462eeefcdbe6be0d79ff3042e80e5654c4060cf5377eee366cb4d6b43"
+    },
+    "sound/items/lavashield2.wav": {
+     "bytes": 49190,
+     "sha256": "17e93e45d150704bab8debd86ee8e9c600e9b08fefa70b16e1fe712dfdbd0c23"
+    },
+    "sound/items/lavashield3.wav": {
+     "bytes": 22094,
+     "sha256": "d94735d5df3c5850d2308972cb2495a9c9ec87e57c434c3ff0c160da659b051f"
+    },
+    "sound/items/nailp.wav": {
+     "bytes": 97394,
+     "sha256": "eb786846675412ba7bfb892fa0d5d356b67ec83ad3a551de8b423a874c3608d1"
+    },
+    "sound/items/nailp2.wav": {
+     "bytes": 132454,
+     "sha256": "2a01a3beb92154c7275c3c2ad39f648f8ecad7fd32ef7264d7404b917e0147dc"
+    },
+    "sound/items/nailp3.wav": {
+     "bytes": 45268,
+     "sha256": "0ea4502763119419b226d830b5b0147d6cfbe78996749e330d652d5b538dbb7b"
+    },
+    "sound/items/protect.wav": {
+     "bytes": 146816,
+     "sha256": "ed3c6c9d94c808cb0008413f6ef488456d9afa703b9a7d41390616371176e778"
+    },
+    "sound/items/protect2.wav": {
+     "bytes": 66286,
+     "sha256": "80b2a47fb1158f252e888bc692d352f224170c2d18177163dfea5c8110688e65"
+    },
+    "sound/items/protect3.wav": {
+     "bytes": 44176,
+     "sha256": "4aab23bd1683c733c5c85e7d55a93b27746860bd3c1a707e8c5a6439e35b5fd2"
+    },
+    "sound/items/r_item1.wav": {
+     "bytes": 63288,
+     "sha256": "debd2fdc6fbb6cffb6bd779f6a9c10325c9592878e2c194a1331542d5e31aa0d"
+    },
+    "sound/items/r_item2.wav": {
+     "bytes": 14462,
+     "sha256": "088bb9013c0d2201997d3c566b95cc91f0419ba0bc89173c9e532659ccb4e886"
+    },
+    "sound/items/sharp.wav": {
+     "bytes": 100592,
+     "sha256": "c86d353daa830fffcf5ded77b73d6b8871d15a47a857a977ebaf7cbddb6cb587"
+    },
+    "sound/items/sharp2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/sharp3.wav": {
+     "bytes": 46584,
+     "sha256": "6318f7079e79929ff0439a570c5f806ec9c2cce8a8447eddb666dee0c2211336"
+    },
+    "sound/items/sharpa.wav": {
+     "bytes": 97394,
+     "sha256": "cd0d8dc72f736b38ab9c4a473798f0dd32e2074c14a310892c3fdf6515ff53be"
+    },
+    "sound/items/sharpa2.wav": {
+     "bytes": 132454,
+     "sha256": "2545c58a3682c1e8459389dc728a39fe0d76e6ce14a9c816a4826e327ab9bddc"
+    },
+    "sound/items/sharpa3.wav": {
+     "bytes": 45268,
+     "sha256": "083cc822d4cd6819d2dfd6e125ea4ca8ef3230c1ac1c4a5f5e3fe22e4d3d36d9"
+    },
+    "sound/items/suit.wav": {
+     "bytes": 31568,
+     "sha256": "a9b13127acef0c8e617cf5e510d5654227db9049a2b06b7544eb9e3030146ee7"
+    },
+    "sound/items/suit2.wav": {
+     "bytes": 66368,
+     "sha256": "34f0ba1b415ab62f2eb3b7a59bda6fe6fbbf3e519c7d2fab29a42ce29eb073c3"
+    },
+    "sound/jim/death1.wav": {
+     "bytes": 14348,
+     "sha256": "7f97f27dfda78f9fe6fc5265e512b651e57ae466752d56cfe0dccd6d08478ed8"
+    },
+    "sound/jim/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/jim/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/jim/gunidle.wav": {
+     "bytes": 13260,
+     "sha256": "46441335fe896cb993368bb12cedc1ddd4886b5933298bb6a0d6b7ba430cdfe5"
+    },
+    "sound/jim/gunidle2.wav": {
+     "bytes": 48540,
+     "sha256": "08d3577b66ab4b4c65ae7b01e4590e8d985605cc51a939bae0b43967472208c6"
+    },
+    "sound/jim/idle1.wav": {
+     "bytes": 44460,
+     "sha256": "7bc2df6cdd0f9a06cc441c656664edb3c686ab5803dab70948cc27bbba968494"
+    },
+    "sound/jim/idle1r.wav": {
+     "bytes": 44460,
+     "sha256": "7549a540858b1a829ac010930b848474c2f2200b910371368c99e35641f24644"
+    },
+    "sound/jim/idle2.wav": {
+     "bytes": 44460,
+     "sha256": "90d55e9ac8db5523255ec80384abd2508f005890f4fb66a654f4d783435afb4d"
+    },
+    "sound/jim/idle3.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/jim/laser_load.wav": {
+     "bytes": 36040,
+     "sha256": "5f39b9f60c5de5c9c3ac25a5149f1fef557e66c09d7d1a760ed6770082c5a914"
+    },
+    "sound/jim/pain1.wav": {
+     "bytes": 27006,
+     "sha256": "27522940f1db4eb098388e049a63d3a608e4beb2fa248d1232ae45d38a944e85"
+    },
+    "sound/jim/pain2.wav": {
+     "bytes": 30850,
+     "sha256": "6d1988d75f430287ad3e8766e9aafa8c8c85e2f2ebf53395b0fc2eb0fb26d788"
+    },
+    "sound/jim/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/jim/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/jim/rocket_load.wav": {
+     "bytes": 23416,
+     "sha256": "e3820aad09060be13927e56fc0e21112c22161b50b7d5be9cf59b98f84c5a231"
+    },
+    "sound/jim/sight1.wav": {
+     "bytes": 14892,
+     "sha256": "1a0db2b8c8d763f9aae09913d1cd3548fa0e30eb03949e24ef511a70acfda303"
+    },
+    "sound/judge/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/judge/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/judge/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/judge/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/judge/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/judge/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/judge/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/judge/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/judge/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/judge/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/judge/smash_ground.wav": {
+     "bytes": 66250,
+     "sha256": "f29f17426d2bd961d4f166e25fb951c8e12a37314bbc49722f0ae34c2beae233"
+    },
+    "sound/judge/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/judge/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/judge/smash_roar.wav": {
+     "bytes": 61784,
+     "sha256": "24b26a6b00a8731693bafd8ef67a5f0e2a4bbad20e722ec14f6fefd13047dc78"
+    },
+    "sound/judge/summon.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/judge/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/justice/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/justice/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/justice/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/justice/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/justice/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/justice/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/justice/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/justice/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/justice/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/justice/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/justice/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/justice/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/justice/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/knight/idle.wav": {
+     "bytes": 84104,
+     "sha256": "fe603791a44d4f8f72d310971a90bba0f4c8dd8e176f5e61ab670735f22f6d57"
+    },
+    "sound/lostsoul/bite.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/lostsoul/charge.wav": {
+     "bytes": 114682,
+     "sha256": "327cf4f521c92b3af6ff7cf50d1bfa6d101d06dee52350f123473e56e72626e3"
+    },
+    "sound/lostsoul/death.wav": {
+     "bytes": 151916,
+     "sha256": "08b6f8d3a50465e7deb346bc8902605bfc8bafc134cfac38aeb1d9fa5d1d2863"
+    },
+    "sound/lostsoul/idle1.wav": {
+     "bytes": 132332,
+     "sha256": "aac9bd66ea75d4778a20ba07b248baaa4f446beb60e5b5be76d04be36df1a1db"
+    },
+    "sound/lostsoul/idle2.wav": {
+     "bytes": 132332,
+     "sha256": "963c18a04a41d49ced0c820fd6ec51c885e7828a2a09bd47c15227555b6d4ada"
+    },
+    "sound/lostsoul/pain1.wav": {
+     "bytes": 14948,
+     "sha256": "baccaed4fd7c4e504214eb7241d3e8ea3e187739a781c30de57c8b5af6dbe6d0"
+    },
+    "sound/markie/dronebell1.wav": {
+     "bytes": 410346,
+     "sha256": "c7b65065ba9279c8131a83b642523e4193b8611f7b14430af2d52c831082340a"
+    },
+    "sound/markie/dronehum1.wav": {
+     "bytes": 156754,
+     "sha256": "9542c51342398a1281476da03114adb01012367dac58d2a08b50c684a1a98093"
+    },
+    "sound/markie/dronehum2.wav": {
+     "bytes": 183654,
+     "sha256": "03545ae0f88b788e69e09c0aae2cccfa727a2609ef224c7d1d3451f0e6172709"
+    },
+    "sound/markie/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/markie/dronespace1.wav": {
+     "bytes": 151808,
+     "sha256": "2c9c7f38a2023d3452a48db3e5f98d11fa218315991d907f8e3fa95d128d4f76"
+    },
+    "sound/markie/dronewind1.wav": {
+     "bytes": 110328,
+     "sha256": "f65fd70b6c398e1a17975eff7d92bde89ac17bc8d5cf0e9c6dcb17934311e3a6"
+    },
+    "sound/markie/morte1.wav": {
+     "bytes": 529280,
+     "sha256": "c338e404901bbf094c5946e50cbd922580c077dc3f3e5369ab962cb07a70d855"
+    },
+    "sound/markie/morte2.wav": {
+     "bytes": 529280,
+     "sha256": "58e598c9da2ced85f6973eb897f578e0f29a13fa0eaefebfe14c8942a33c77ed"
+    },
+    "sound/markie/ritual1.wav": {
+     "bytes": 273266,
+     "sha256": "fe9b4b53f899a88321707330bb2454442d74e5098328e35549b9f0a8ff840cba"
+    },
+    "sound/markie/ritual2.wav": {
+     "bytes": 273246,
+     "sha256": "d38ee880af55413aa7c180b8c1935df71177502081ee1c376c37b572af3d9352"
+    },
+    "sound/markie/stingwhisper1.wav": {
+     "bytes": 132380,
+     "sha256": "fc6eebd33c0c99c0f4537a9727698181acb4d23d077f06b3da1ebbcb104c870c"
+    },
+    "sound/markie/stingwhisper2.wav": {
+     "bytes": 132380,
+     "sha256": "ae7319c28e0a4e492623b7ddb48634978da043c16d4450f86b8edf7e60fa283c"
+    },
+    "sound/markie/stingwhisper3.wav": {
+     "bytes": 151672,
+     "sha256": "e5dd9dcfd44dedf7b0cd4a0a94a519a0bbd84477e54293548a37aa16d3f1e428"
+    },
+    "sound/markie/watercreek1.wav": {
+     "bytes": 184884,
+     "sha256": "f0c3ac87d6f073cea0d1a9218c4e53327be7af07a8c8be00cd73f254f6c0ba03"
+    },
+    "sound/minotaur/attack1end.wav": {
+     "bytes": 19936,
+     "sha256": "eceb47163a0f495037bd067fcfe852dbd0cf8cc7c376c536f5e4bda8569d3f5c"
+    },
+    "sound/minotaur/attack1expl.wav": {
+     "bytes": 15554,
+     "sha256": "a8344e4036b9377a6c8e3d69c2e86c7f5fc157fb0034d6e0e190d5b9fc444ca7"
+    },
+    "sound/minotaur/attack1long.wav": {
+     "bytes": 42000,
+     "sha256": "bb901880112ff159b380b8bfaf19fc511f4b1217f08d55a05276a3500f6cd4c7"
+    },
+    "sound/minotaur/attack1start.wav": {
+     "bytes": 19944,
+     "sha256": "33dafc2b20be70d6da51321f9910a392535e6a31cbbd3c8d0d880307a18adb3a"
+    },
+    "sound/minotaur/bolt_fire.wav": {
+     "bytes": 17738,
+     "sha256": "2f8ea56413270eef58b56ae4c4f7af2506ee89fda82aab90c0426f4560baa80a"
+    },
+    "sound/minotaur/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/minotaur/idle1.wav": {
+     "bytes": 17686,
+     "sha256": "d213130ad4b58b5b55553da46d358526411916210e90caf082c5a93b499e2f81"
+    },
+    "sound/minotaur/idle1com.wav": {
+     "bytes": 15564,
+     "sha256": "0f8054eb2c16284a098f680dcdc65f5a4b8b971f8cceaca6adebe8c377d6117f"
+    },
+    "sound/minotaur/idle2.wav": {
+     "bytes": 15470,
+     "sha256": "390c82c79532878751bcddca11aa37dbd86018757860e46d0c950a09fee347d9"
+    },
+    "sound/minotaur/idle2com.wav": {
+     "bytes": 17764,
+     "sha256": "8369884de2f4f144b9e323f11e95f47723834b529b62100c908fef5e74391a93"
+    },
+    "sound/minotaur/jump1.wav": {
+     "bytes": 22160,
+     "sha256": "1aa935c4c76818dbe7faed7aee0d9acb9e98ad553a747bf00b83b811d141e886"
+    },
+    "sound/minotaur/pain1.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/minotaur/pain2.wav": {
+     "bytes": 41488,
+     "sha256": "bc9ffeb193379c6738ad2897ab582aa92e278a11d7f1fbb77563ca367987ff76"
+    },
+    "sound/minotaur/sight1.wav": {
+     "bytes": 48610,
+     "sha256": "8d0a5c1a31e525416430f8d45b8482b091d3bb9f6030ac2656bdeb231ddab5e9"
+    },
+    "sound/minotaur/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/minotaur/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    },
+    "sound/minotaur/strike1.wav": {
+     "bytes": 11142,
+     "sha256": "69b1419eed136c384deac99d31827825d3d57fc965ba80604faf9de3e85fd9b8"
+    },
+    "sound/minotaur/strike2.wav": {
+     "bytes": 11142,
+     "sha256": "ab12dc8ab3c9dc603e2ecd58a99beb9c1f551fb79eb6124bdba493efe7595a92"
+    },
+    "sound/minotaur/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/misc/blast1.wav": {
+     "bytes": 97420,
+     "sha256": "ac370e80a6efe76de322cbc1a62e1519bfe4393ee254f85c6dbcc407affb13ef"
+    },
+    "sound/misc/car1.wav": {
+     "bytes": 83660,
+     "sha256": "1f65f92995d6816239fc79a27729b4a248749de2b478db2d2b05a4f8b70b6339"
+    },
+    "sound/misc/car2.wav": {
+     "bytes": 143796,
+     "sha256": "84888935fcda7f990a5acf541de98a61f4b513a096e17201d1d4948997c06948"
+    },
+    "sound/misc/car3.wav": {
+     "bytes": 127606,
+     "sha256": "e647d42dc446a90f02ddc3f643599e9994805035ff70e11e7c29a44f1f63b06e"
+    },
+    "sound/misc/car4.wav": {
+     "bytes": 179414,
+     "sha256": "fff4f195f09f6fea9453496763d7907e1ff39a7fe4b91c74418f3a6f5cae13e6"
+    },
+    "sound/misc/car5.wav": {
+     "bytes": 144434,
+     "sha256": "7c6514241ac9c44230daafd3505ecb3f80c7611ed23ce747ff1811113b430a46"
+    },
+    "sound/misc/car6.wav": {
+     "bytes": 217750,
+     "sha256": "b20dbb5c7218750bdb0962a8a0aaeb9f4678da8092070b778ccd0aa8eb6a12c5"
+    },
+    "sound/misc/car7.wav": {
+     "bytes": 111892,
+     "sha256": "5dbbe7623e9bfb81549aa19c04f23473ebd38d4ac952ea5150be0f51e25e5bb7"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 19940,
+     "sha256": "0798d1a1122171f06fd6b92e3f91881725c05f40e1eeb3494a5a1a1aa8a86e58"
+    },
+    "sound/misc/drip1.wav": {
+     "bytes": 12172,
+     "sha256": "9499c277eab2210ba491b61263b71410e5e8f4b2a68403ec6eb81bef687da04a"
+    },
+    "sound/misc/drip2.wav": {
+     "bytes": 15596,
+     "sha256": "410c25c5c459362849c7d3d0ad736e006b65a949e77c094fe248e803b357d5e0"
+    },
+    "sound/misc/drip3.wav": {
+     "bytes": 15164,
+     "sha256": "9ddf50265efafde7736fb7d03419988caab691245b32d986549ef6d643d2768c"
+    },
+    "sound/misc/flies1.wav": {
+     "bytes": 44168,
+     "sha256": "ca5cf0a4d661bf7440cd81dcd45ad7118c54c8ae58672755ee958ec6e50f7152"
+    },
+    "sound/misc/flies2.wav": {
+     "bytes": 44166,
+     "sha256": "09e6d74986b0f0ec9503d9e111f8d1436d7d6c5c4c0c87ec7808e3fca5b964b1"
+    },
+    "sound/misc/flies3.wav": {
+     "bytes": 44182,
+     "sha256": "2b5fb337ba88bd25e10c86bb6355723aea160b0ef6a6d43b30cbbd446444ed8e"
+    },
+    "sound/misc/flyby1.wav": {
+     "bytes": 337218,
+     "sha256": "c0a69d19c734fffdde8d7d584456320fa3ba4b7f64c10ef6362c25f38bd1a5bd"
+    },
+    "sound/misc/genon.wav": {
+     "bytes": 1624096,
+     "sha256": "cadcda69fb14ffa72d3f5ddb061867af077cff3e73621e95b401df8c3a77ad0e"
+    },
+    "sound/misc/gibf_fire1.wav": {
+     "bytes": 14376,
+     "sha256": "804f8524135d058d3a635e6567e3369b8b9ef2ecc808bf6e216c4d65609b86a3"
+    },
+    "sound/misc/gibf_fire2.wav": {
+     "bytes": 25842,
+     "sha256": "354b551ac38a19370126f67e3975ab795953bd7beb2c597f0a01a0de6286b7c1"
+    },
+    "sound/misc/gold.wav": {
+     "bytes": 151420,
+     "sha256": "30540850d7cab12fc294118109f0aca98c9b961fd0f2db828fb7f5db8035e819"
+    },
+    "sound/misc/hlft1.wav": {
+     "bytes": 481450,
+     "sha256": "50daa24ae8c312273eda6c83a7be69d0d66fbb97f2eb80994c2f2cb99cc54669"
+    },
+    "sound/misc/hlft2.wav": {
+     "bytes": 72260,
+     "sha256": "7cdc7c323a1973b65fb28ed0bb64f8fa7e3d1d027893a8f7f8cf6b9e7b862e7a"
+    },
+    "sound/misc/hlft3.wav": {
+     "bytes": 308202,
+     "sha256": "b4c9d5fcb318ef04a391c7c84d4a1dafb4f27154dd9d78d65d76a6be24bcd03b"
+    },
+    "sound/misc/jumpad.wav": {
+     "bytes": 72540,
+     "sha256": "fbc7059cf74a4944b98ba209bead7f27d755a650aa9fd093dc7516264131b18a"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/laseron.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/misc/poweroff.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/misc/poweron.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/misc/rev.wav": {
+     "bytes": 702214,
+     "sha256": "29c22129af9378162859023770e0844c2dac046098dd0710d39daa4f6fc82e6a"
+    },
+    "sound/misc/rumbleloop.wav": {
+     "bytes": 106060,
+     "sha256": "fafcaa92b4a2174045e3826885d14e434a409bf559d1a1d519c4d50ec8939789"
+    },
+    "sound/misc/rumbleoff.wav": {
+     "bytes": 105990,
+     "sha256": "46728daf18b142575d50049188030a153c0e3e994dc83ea375c43ba6da171b3c"
+    },
+    "sound/misc/scrape.wav": {
+     "bytes": 184886,
+     "sha256": "63e4906f723b06d9ce71738cd98dbf9bdffa17e10730d7248ce0aa2547c571de"
+    },
+    "sound/misc/secret3.wav": {
+     "bytes": 302444,
+     "sha256": "75682a08b790af46c2b9f746e5772999ba1de333b567832f4a3a8414c6a0185a"
+    },
+    "sound/misc/space1.wav": {
+     "bytes": 544432,
+     "sha256": "d37e63f4fd54e2f8024bee81656b2bb61a8965799ae402df83495ce4d5614d56"
+    },
+    "sound/misc/space2.wav": {
+     "bytes": 2963024,
+     "sha256": "cc7e952a60612d8b42834b9b82821b0fe5f11a3352495156122c7c5dc0486414"
+    },
+    "sound/misc/spaceship_fadein.wav": {
+     "bytes": 231712,
+     "sha256": "d6c905eb002532087273eadb5a577db443068532795fd509571179a354c56a9f"
+    },
+    "sound/misc/spaceship_fadeout.wav": {
+     "bytes": 495982,
+     "sha256": "9e5286b29adeb9cf7b3af489bb2ea539c8eed7b26a28ec1f34cd5f78c33e521c"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 13270,
+     "sha256": "14d74e6c01df6db6f92b8684527b31a7544de8d4dd9d123ebae554989e76facc"
+    },
+    "sound/misc/torchoff.wav": {
+     "bytes": 27102,
+     "sha256": "7df1914c9a8b6a545a82699ba9c782667aba645ff3ba05059eb0488c839e8370"
+    },
+    "sound/misc/torchon1.wav": {
+     "bytes": 88680,
+     "sha256": "ecb211c777393fe3c7012bf0a35cc157af94ccb4742cac3ca7ab6daa5546a4ac"
+    },
+    "sound/misc/torchon2.wav": {
+     "bytes": 84764,
+     "sha256": "b7d885df1c70b226a77a3cc8842565fa9ebf51561158daec4b12e9629a515986"
+    },
+    "sound/misc/torchon3.wav": {
+     "bytes": 97484,
+     "sha256": "25058a3354df07a90b8660640682f7091fa40da6f8abf178c7de71d547a8b0c1"
+    },
+    "sound/misc/wizidl.wav": {
+     "bytes": 94738,
+     "sha256": "044480bddd282a9b971901e3b8be35a55eee6776563c93412c26e1d8741a1412"
+    },
+    "sound/misc/zap.wav": {
+     "bytes": 397348,
+     "sha256": "37682eb8d0ad705b7985297d6182cf9feb3cc1015273da7888bbbf55ca31d6a5"
+    },
+    "sound/nour/attack1.wav": {
+     "bytes": 50794,
+     "sha256": "7f22a1569d59bcd406efd7828ed605d71bfbc8cea01606eedb78d33037655f77"
+    },
+    "sound/nour/attack2.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/nour/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/nour/death.wav": {
+     "bytes": 39772,
+     "sha256": "2e2d15b95fc35738108d83a2b5aefded93772134d2a8124d1b937b6bfcfd74c5"
+    },
+    "sound/nour/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/nour/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/nour/explode2.wav": {
+     "bytes": 22168,
+     "sha256": "654a50eb01d1c6c64bb8df4b85669448cc08b580ffc44616da854bd3cb339ea1"
+    },
+    "sound/nour/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/nour/idle1.wav": {
+     "bytes": 24332,
+     "sha256": "c77ef8ce85720e3bf0ea97937992b5aa7cc6b63149c951e71b4d3ead14fc21af"
+    },
+    "sound/nour/idle2.wav": {
+     "bytes": 44176,
+     "sha256": "e87bd537a35c005b06ffd28f66adde24d52af338d3956d4fab455d682e78eec9"
+    },
+    "sound/nour/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/nour/pain.wav": {
+     "bytes": 8686,
+     "sha256": "073044c582c2de6f336130aeb9503fa6edf1da4eed216a4b407b2cd18d5f9995"
+    },
+    "sound/nour/projbomb_burn.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/nour/reveal.wav": {
+     "bytes": 39780,
+     "sha256": "6dd892d207fa31eb93c5a033ab44bba4952b3aed892aa409e6a49e2059381cdb"
+    },
+    "sound/nour/sight.wav": {
+     "bytes": 48612,
+     "sha256": "252c0bf76b928f7fe998f82bf148816e88cdc24f812bd8c8d3a591c1c4ec3d7d"
+    },
+    "sound/nour/sight2.wav": {
+     "bytes": 48612,
+     "sha256": "18b8e9450c00d6a9308adffa2046e747b8ed7bb5547f868ed146cca75b260b87"
+    },
+    "sound/ogre/ham_hit.wav": {
+     "bytes": 52014,
+     "sha256": "20f7ec214fdf8a342ac8c3be7d3ed04c7b7b3479f9c74138a8a052ba7674ee46"
+    },
+    "sound/ogre/ham_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/ogre/ham_wave.wav": {
+     "bytes": 132316,
+     "sha256": "d957285dc74a4e067f600465112ed41d69d14554f8e87ad6b0372b9ca8af4b25"
+    },
+    "sound/ogre/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/ogre/ogidle.wav": {
+     "bytes": 25706,
+     "sha256": "54915681452970c56f1ef405b182e90fa7ee3c4d4d80e32583a38abc7c1db713"
+    },
+    "sound/ogre/ogidle2.wav": {
+     "bytes": 22426,
+     "sha256": "2ed241e576a709285f7ea8a9671f6032da5a8db96e094e9007f60617cad491fa"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 28742,
+     "sha256": "738af1bbf36d5b3287c45e7815d87ea7f5c1a0487c804de7272091fdbb7faac2"
+    },
+    "sound/ogre/ogpull.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/ogre/ogrefish_flappy.wav": {
+     "bytes": 51262,
+     "sha256": "79a9eafef5edf45851a1c391e301c6f515536922c297b904e148b337e7f54a08"
+    },
+    "sound/ogre/ogrefish_idle.wav": {
+     "bytes": 27552,
+     "sha256": "5abf50694e67aa1e805a598a464d5d3b1f0625677a2873761cae139c4b21d524"
+    },
+    "sound/ogre/ogrefish_in.wav": {
+     "bytes": 6678,
+     "sha256": "dd5fc9aecb5b6933252739047aa5d3f775797ad7bf6ddb5652ffd26ea9ead3e2"
+    },
+    "sound/ogre/ogrefish_out.wav": {
+     "bytes": 15502,
+     "sha256": "2610f025057ee0a6682b574567b7400f83ba9f6665b9f7f3b9e76cff75b8be53"
+    },
+    "sound/player/axhit1.wav": {
+     "bytes": 9030,
+     "sha256": "7684ae0dd0551b71f91c64ace24ee7ed7420c941209079bcebc05f9007e76e50"
+    },
+    "sound/player/death1.wav": {
+     "bytes": 34330,
+     "sha256": "a5b4f5151ae7909574806ea02adbece65ba56b5baa2be2815095953979d12b46"
+    },
+    "sound/player/death2.wav": {
+     "bytes": 42764,
+     "sha256": "aa5cbfd65b8b0feebe8f010c997049bbea5272495abdc31b131375baf9762643"
+    },
+    "sound/player/death3.wav": {
+     "bytes": 48128,
+     "sha256": "c03705fe4a5acb9d074bfb6aa8c295a48eb94fc6cf86dddf580ac9f7f0513dbc"
+    },
+    "sound/player/death4.wav": {
+     "bytes": 52896,
+     "sha256": "5a58bf09cee6faa379001b3ae487dd81d8a6d498194d1df9a7957e339b48d325"
+    },
+    "sound/player/death5.wav": {
+     "bytes": 16638,
+     "sha256": "a81c4364a1880f5ce31e0683e7b2f3b871549eb300753583f0781ef3ba7daf27"
+    },
+    "sound/player/drown1.wav": {
+     "bytes": 23348,
+     "sha256": "38ecf64d201a128b7625801d6cdae99b1ddc77d13b1c289d9f43d53de85fdc6d"
+    },
+    "sound/player/drown2.wav": {
+     "bytes": 17062,
+     "sha256": "2a51b0db4c8887339a4a596a6d7da10092234f7241f055c11b27d8b32ff13814"
+    },
+    "sound/player/gasp1.wav": {
+     "bytes": 19514,
+     "sha256": "52ebc2198b9b71daa5b952b79e2e259cf19cbcf139fbfd3d09a47080a1cfe1d0"
+    },
+    "sound/player/gasp2.wav": {
+     "bytes": 20890,
+     "sha256": "3a8b8d00e38d631cb7273ce198fa3be626316dd46e961a4348161c09a1c2c463"
+    },
+    "sound/player/h2odeath.wav": {
+     "bytes": 66440,
+     "sha256": "273a9d481ee815e1733c15965229ab8a027cea994b922c8919c85176fbc99abd"
+    },
+    "sound/player/h2ojump.wav": {
+     "bytes": 22126,
+     "sha256": "dd2d3629970814e719be6c9650a497edd219f31fb1554927b9770a1b0dfcdc60"
+    },
+    "sound/player/heartbeat.wav": {
+     "bytes": 70640,
+     "sha256": "a68fd895a3212f967a4686e94df2749fa3f58392ab2228aa880697e25b548147"
+    },
+    "sound/player/inh2o.wav": {
+     "bytes": 22126,
+     "sha256": "4c4d55502ab63ddbc9beb64b0459ad4d7a2992fe41e76144d3bbd3333af4a570"
+    },
+    "sound/player/ladmetal1.wav": {
+     "bytes": 95952,
+     "sha256": "6cd990509a965ff251ffb33ff7c22b6eb708cec5f7b7b82e2196b1fb3d3cb1c2"
+    },
+    "sound/player/ladmetal2.wav": {
+     "bytes": 96116,
+     "sha256": "a477162fc355efc88568b9e18d668b7b0e8e99af460b88c755bd1ed57da35006"
+    },
+    "sound/player/ladmetal3.wav": {
+     "bytes": 96008,
+     "sha256": "20ea0c70bcc3c951bb067cb65b938c63267bba0a1eda3a335df525dc9432d234"
+    },
+    "sound/player/ladmetal4.wav": {
+     "bytes": 96126,
+     "sha256": "d2a6bede3a9c499d01a0b0b9620d4bd1935f9477ecb9c59a8d73f3133699ea45"
+    },
+    "sound/player/ladrope1.wav": {
+     "bytes": 70706,
+     "sha256": "6713acc390790d4723df21b0702796958132af34ce5ec0a85fca5edc36ccd728"
+    },
+    "sound/player/ladrope2.wav": {
+     "bytes": 70792,
+     "sha256": "384b8c3ad3749fa9963ff3210d7cb312858771cca85082b6a8ad13179ad92da3"
+    },
+    "sound/player/ladrope3.wav": {
+     "bytes": 70760,
+     "sha256": "ed397a0308ecacd0ba9774f082aec5e681bcffb219c8d9127b7d7606a6fbb02d"
+    },
+    "sound/player/ladrope4.wav": {
+     "bytes": 70758,
+     "sha256": "e1a4327f1c458f408abd6ff713d11e0aee8daaa9c876002b693135d8e64b68fe"
+    },
+    "sound/player/ladwood1.wav": {
+     "bytes": 48084,
+     "sha256": "bd68f3af0f6cd429d08aa44168e14435ed9e2e2ec0d6a038f83e2dd683cb7e74"
+    },
+    "sound/player/ladwood2.wav": {
+     "bytes": 48086,
+     "sha256": "bb687ec2183f460ac4240acfcd2f3da2f8bd9da043ba705f6e32c3439e4845b9"
+    },
+    "sound/player/ladwood3.wav": {
+     "bytes": 48088,
+     "sha256": "7271136b6398602c7b4bdbd610a37b5a82a66195842030a21de08a89808b4026"
+    },
+    "sound/player/ladwood4.wav": {
+     "bytes": 48086,
+     "sha256": "3b7580b31dee8a86e636c5fd17d92566d147417f98764d51097ad53ff0d19d29"
+    },
+    "sound/player/land.wav": {
+     "bytes": 17176,
+     "sha256": "1f316bfedf73c322e6251397606234d8b48ac7aedb40bb60f45563d179856665"
+    },
+    "sound/player/land2.wav": {
+     "bytes": 9121,
+     "sha256": "cf30e73392c6cf504e890b5f2a11ce1de74c2480248fe5d59f869541dfaa537b"
+    },
+    "sound/player/lburn1.wav": {
+     "bytes": 30024,
+     "sha256": "9f98ecc6c5904c4931f34a0424e0983ea9203c0e33222b1017372358e915050e"
+    },
+    "sound/player/lburn2.wav": {
+     "bytes": 32854,
+     "sha256": "f666cdc6766f7636a5c85dd63e68dd6fa573efd54869c5cc0f57dd1a8e9fc31f"
+    },
+    "sound/player/pain1.wav": {
+     "bytes": 21452,
+     "sha256": "7b76a34d9ef74c01fb8961db5fb862ff3497ac706073185c7af51f47c8839b9c"
+    },
+    "sound/player/pain2.wav": {
+     "bytes": 29306,
+     "sha256": "d651c83af105244da1e89cd307ed0473b1e881f71b8d86a07969dfcb59767c41"
+    },
+    "sound/player/pain3.wav": {
+     "bytes": 26216,
+     "sha256": "5f4f46860863c157a667b138ee26a757c56503b5a1b464bf60d7e2424913a6a7"
+    },
+    "sound/player/pain4.wav": {
+     "bytes": 16274,
+     "sha256": "9f1bd7c6b9c3048aa72c3b3f99346a1c13cfaf850a32ed113a66d341b4f7eb87"
+    },
+    "sound/player/pain5.wav": {
+     "bytes": 29568,
+     "sha256": "61fb3f0fb52374c7504cd82b0f7385ec97487fba8fc20a1b31e69937babdf2ff"
+    },
+    "sound/player/pain6.wav": {
+     "bytes": 20754,
+     "sha256": "53c7ec0de897d95874e46f6d694d9969f85f1ce1c09c91257ada0b35508340f4"
+    },
+    "sound/player/plyrjmp8.wav": {
+     "bytes": 14602,
+     "sha256": "4747526690a7e991722748c4583962ab6081f41e1de046aa783447787e37943d"
+    },
+    "sound/pushable/brick_m1.wav": {
+     "bytes": 44144,
+     "sha256": "7572ac5d03045552dfee673293722da8c663d072cc7b57e44adb2e3884ea33c9"
+    },
+    "sound/pushable/brick_m2.wav": {
+     "bytes": 44144,
+     "sha256": "209e22e4693184c7b0c022e650b156e255cfa76b18c1066fe20255e285b4e80b"
+    },
+    "sound/pushable/brick_m3.wav": {
+     "bytes": 44144,
+     "sha256": "edafb8bf0915badb97edd078aa129c10a29e8fc428f4e9143f5926f9aa336e43"
+    },
+    "sound/pushable/glass_m1.wav": {
+     "bytes": 48044,
+     "sha256": "66a5944b16e3fe59cf9f8632f92bd85f81b79dc8711337558c45078c91a13c46"
+    },
+    "sound/pushable/glass_m2.wav": {
+     "bytes": 48044,
+     "sha256": "d462bac59390f89facc7c00d8aaee6e71b529ae9f177514a5f2f0533c78d5a0e"
+    },
+    "sound/pushable/glass_m3.wav": {
+     "bytes": 48044,
+     "sha256": "1a2efd7875486d15df811135d589135c807ba0149c877085f165932eb2770320"
+    },
+    "sound/pushable/metal_m1.wav": {
+     "bytes": 44144,
+     "sha256": "91420caf0e2de995681ac09b2be26cc9d0759edc06498571527528419de407d1"
+    },
+    "sound/pushable/metal_m2.wav": {
+     "bytes": 44144,
+     "sha256": "72f018c79b343538fd90de944ed54e8e3351b3da0a6c198f28403d25fc8fb140"
+    },
+    "sound/pushable/metal_m3.wav": {
+     "bytes": 44144,
+     "sha256": "c26b3aff129d573a1175fb618186db3b7ede8976e134c563c1678f48eaf8e302"
+    },
+    "sound/pushable/rock_m1.wav": {
+     "bytes": 48044,
+     "sha256": "9fb6ebeae45b4c47b1e42af1f00441d0e0bb88fbb53f85ea875341f9db55efb4"
+    },
+    "sound/pushable/rock_m2.wav": {
+     "bytes": 48044,
+     "sha256": "b57d0f760bb318b1159293e38811e5607bae8ff244d8bbf56223b355ef7c5b39"
+    },
+    "sound/pushable/rock_m3.wav": {
+     "bytes": 48044,
+     "sha256": "5e6514c241bb11d6194d9762d5369fb2a8da287b3d4c08e67f23da84fdb26b04"
+    },
+    "sound/pushable/wood_m1.wav": {
+     "bytes": 48044,
+     "sha256": "e672209779ee47996ca93e60d30e572da3cced5381db3f34c14a709629a5f4d2"
+    },
+    "sound/pushable/wood_m2.wav": {
+     "bytes": 48044,
+     "sha256": "c76b7db5faf1cbf21c07dacec615436a95f34c0e16e68628b62ec89a89b12f83"
+    },
+    "sound/pushable/wood_m3.wav": {
+     "bytes": 48044,
+     "sha256": "d6751d9e67c49458df6c076d9b6be9619f845213a263cb76330f51700f8a632c"
+    },
+    "sound/scorpion/clawattack1.wav": {
+     "bytes": 13360,
+     "sha256": "b0daf0605690db89f34a19936f1c20ad25676a4e6cd9dfad0e5757cf81dc4f7d"
+    },
+    "sound/scorpion/clawattack2.wav": {
+     "bytes": 13360,
+     "sha256": "06da85e6d6035704932fdc1ef449de529e17853571d017c5a42b253b5ed71a94"
+    },
+    "sound/scorpion/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/scorpion/hiss.wav": {
+     "bytes": 26664,
+     "sha256": "9d9fae97f3996ff3c0616f7acda952166d5eced9227d15a8fbe9d285095e7936"
+    },
+    "sound/scorpion/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/scorpion/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/scorpion/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/scorpion/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/scorpion/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/scorpion/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/scorpion/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/scorpion/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/scorpion/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/scorpion/tailattack1.wav": {
+     "bytes": 25858,
+     "sha256": "61e6c65b4c68813925e594b96ebad8a945c87d51f2cd23f301e80e231e53033d"
+    },
+    "sound/scorpion/tailattack2.wav": {
+     "bytes": 19650,
+     "sha256": "aab86f97eed636ebfb79ae7b92e4b7f7a3436b0146ad75519edd4358716169c7"
+    },
+    "sound/scorpion/tailfire1.wav": {
+     "bytes": 8924,
+     "sha256": "1f41bd184aa58b9f2f1b2f1197f3b7827c55d523d03a354dd1fb6d469cf129c8"
+    },
+    "sound/scorpion/tailfire2.wav": {
+     "bytes": 8948,
+     "sha256": "40a126ab5cba6c291d69606eddb7e2ab63ab640b1347b2e78ab4b0f7aca90c5c"
+    },
+    "sound/scorpion/warning1.wav": {
+     "bytes": 76930,
+     "sha256": "ae19faeebc0d3ec8c9f136bba205e634a29425ec86c3036016e5f2d9cd550817"
+    },
+    "sound/scorpion/warning2.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/seeker/death1.wav": {
+     "bytes": 397272,
+     "sha256": "35d8a1091032f24ed6a65efa99a7618f32bc0def24779efb51752b75a9e31ca1"
+    },
+    "sound/seeker/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/seeker/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/seeker/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/seeker/footstep1.wav": {
+     "bytes": 96092,
+     "sha256": "e5cd4f907a1b70ec72048b2dd5a5062022e7058676c3d90d05b7426e189a5073"
+    },
+    "sound/seeker/footstep2.wav": {
+     "bytes": 96076,
+     "sha256": "f3c8ba8d65257ddfa73e3e54c737c49de5dcc5c17bb088feb3511c3d69d21ac4"
+    },
+    "sound/seeker/footstep3.wav": {
+     "bytes": 96092,
+     "sha256": "c6fa111be092592a253815826c499b9b1f18a0c536910e2a82eebec7fb7f817d"
+    },
+    "sound/seeker/idle1.wav": {
+     "bytes": 141126,
+     "sha256": "10693a1d5fc1d710e54a0d57ce10d71400de192b874d6776ffe176c2b399a6b5"
+    },
+    "sound/seeker/idle2.wav": {
+     "bytes": 97420,
+     "sha256": "c24b439701d9ec3cf055702f23a3eb23623320ae89b9d46ab98a791f08898573"
+    },
+    "sound/seeker/melee1.wav": {
+     "bytes": 106252,
+     "sha256": "addfb5fab225a77f08d5c126b13f929fa31aa1c9094fc79202121ca891933fb9"
+    },
+    "sound/seeker/pain1.wav": {
+     "bytes": 19884,
+     "sha256": "ccaca64b8c1ab87d7d70896333cbec22c3b61c443a36cd8f253ad0eafc2d7ae1"
+    },
+    "sound/seeker/pain2.wav": {
+     "bytes": 19884,
+     "sha256": "8c3be23111a5ef53a7b66c7b74e32404ff0e6989d7de835543e0a65645e3f793"
+    },
+    "sound/seeker/punch1.wav": {
+     "bytes": 19940,
+     "sha256": "e4bf6b7deb14b5d614b4d5b7d4eeee36059372c913cc906589e1048d4484259d"
+    },
+    "sound/seeker/range_laser.wav": {
+     "bytes": 88246,
+     "sha256": "ee9f13af042a2a98fb75fa33873a1e861f3418f598ddb390f15ab44fcf93fcbf"
+    },
+    "sound/seeker/range_plasma.wav": {
+     "bytes": 79782,
+     "sha256": "9b1d38a4e1937023536d5ab5de035c97e1ef69131d58822b194cab2a3aa340b3"
+    },
+    "sound/seeker/range_rocket.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/seeker/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/seeker/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/seeker/sight1.wav": {
+     "bytes": 12384,
+     "sha256": "926ebbbf074e20bcd3205ce44f2e427bcd5c0eebc3114b6ba5e48978d837ab1e"
+    },
+    "sound/sentinel/laser.wav": {
+     "bytes": 9712,
+     "sha256": "c5f90e1823a04b48f7f24ac5b8792e1b42030a8b07970db5847dc1e74be094c2"
+    },
+    "sound/sentinel/nail.wav": {
+     "bytes": 13750,
+     "sha256": "7acc3ac05b7218abc6fef2d2397771d90fce6fa39415e33824be7e771d30e288"
+    },
+    "sound/sentinel/widle1.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/widle2.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/wpain.wav": {
+     "bytes": 19596,
+     "sha256": "bc7b6536a1c67aa89295eeacea2d9b36cb0bf783b5fb7cc6aaf4fa01a0edb3fd"
+    },
+    "sound/sentinel/wsight.wav": {
+     "bytes": 27322,
+     "sha256": "83bca2103d60c68435e27f0660e3ecd5bffb058e796382e7bdb43efabdfb9889"
+    },
+    "sound/shalrath/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/shalrath/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/attack1.wav": {
+     "bytes": 44184,
+     "sha256": "91f50e3b69909213e23149b6a3e9622c4367d77f871da5f01e6e4aea3badf648"
+    },
+    "sound/shub/attack2.wav": {
+     "bytes": 33174,
+     "sha256": "d4928f711f7e8fc1d8ba050a87b4e1c2d48ffc24af6a454637629dfae8902e3f"
+    },
+    "sound/shub/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/death1.wav": {
+     "bytes": 107440,
+     "sha256": "1551554be1b7896ee39156ce258bf68ac5dace891994788020ee95083ae33e77"
+    },
+    "sound/shub/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/shub/idle1.wav": {
+     "bytes": 75072,
+     "sha256": "9d33c61470d0c4269c8d113b4476b84236fa00e6ee3be061865e242c988093af"
+    },
+    "sound/shub/idle2.wav": {
+     "bytes": 75000,
+     "sha256": "21b063438744def5f79a50709c567cc9f3e3a28c39e58456068a3d4ae362617f"
+    },
+    "sound/shub/idle3.wav": {
+     "bytes": 75096,
+     "sha256": "310c4ff969da63c77e7ebb5b319aca0f17a10802ee942b21174349d5e5a79d72"
+    },
+    "sound/shub/pain1.wav": {
+     "bytes": 83880,
+     "sha256": "1d1536a51822b67106ea72bcb537efbf5f69e4a4592904f6feedee06ef5084df"
+    },
+    "sound/shub/pain2.wav": {
+     "bytes": 83886,
+     "sha256": "71c30d3f41e0f99cffcf5037b482c1da7bf028b477051219f6e605ceef28ae38"
+    },
+    "sound/shub/sight0.wav": {
+     "bytes": 83880,
+     "sha256": "6d4d96fc663db248cf9279c0b028c11b451b133c6e2c38364c13e105f8fa377f"
+    },
+    "sound/shub/sight1.wav": {
+     "bytes": 83880,
+     "sha256": "ecaf1595f3acbfe2e771a193c69bd6de5e6e3bd957405fdf4bcf59a2288bdb05"
+    },
+    "sound/skullwiz/attack.wav": {
+     "bytes": 15484,
+     "sha256": "ca662d909cb3b96bdfb93197092ed8e8a5d1ed27772a91a4a6ae5e9d3063017a"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 33166,
+     "sha256": "5d1ccd5b97bd38eaf46d1e0798009765d46d58ba17e7e6efc36350b0adaa22f7"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 33178,
+     "sha256": "dd77e90760bd85fc872a96c2eaa808b094a461ab2871bd8ab6a5372861560512"
+    },
+    "sound/skullwiz/blinkspk1.wav": {
+     "bytes": 44200,
+     "sha256": "ade109f32810094922f77bc3c03f02d33e98d855d3dcaf79ceab4cb200efaa65"
+    },
+    "sound/skullwiz/blinkspk2.wav": {
+     "bytes": 44204,
+     "sha256": "16d3b1296e1ed9c3bdc06dd25f5d9db3569cf3486794d29858d5ad227741dd1a"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 33166,
+     "sha256": "bc83800a91fad273e7f84f3cec2fa2787c902f4cd97fd5495f73dc9fb6d2c368"
+    },
+    "sound/skullwiz/fadeaway.wav": {
+     "bytes": 43092,
+     "sha256": "dd67d3ffe5a592b4e449d6bb00eee3c525ede786b0a2d9089832981311bfd61e"
+    },
+    "sound/skullwiz/idle1.wav": {
+     "bytes": 88252,
+     "sha256": "1834b946ff68aab07ade01b68d95d822d0b2a1baa51c1ceba7e66c73b8b6211e"
+    },
+    "sound/skullwiz/idle2.wav": {
+     "bytes": 88240,
+     "sha256": "57c49c7fd4f52b870a658e2e854e16c67389e9d79f9a1db5928f12d74741a1da"
+    },
+    "sound/skullwiz/pain1.wav": {
+     "bytes": 11132,
+     "sha256": "125e06cdfacd6aa78a90034d3f94086736734dd1dd9d170fef3a512b42e34cd0"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 15540,
+     "sha256": "ac5a56dbff28fa4724bd8766d8443090e3026007f6f4051cfecd2869b3f5ecb9"
+    },
+    "sound/skullwiz/poison_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/skullwiz/sight.wav": {
+     "bytes": 36484,
+     "sha256": "3051df89bfdce6b80c49c3513cfcbd679bf1f71c5562430d7738737e44f04f26"
+    },
+    "sound/skullwiz/skull1.wav": {
+     "bytes": 22144,
+     "sha256": "3a43bc5e1079740b61199ff21518f75cc1e4db7cdc9e25b57631b38b04d651a2"
+    },
+    "sound/skullwiz/skull2.wav": {
+     "bytes": 22158,
+     "sha256": "fed613207dc7691118ea5b62626df8773bda59816b008bfd2aeaa4d2f26a4b7b"
+    },
+    "sound/skullwiz/summon.wav": {
+     "bytes": 97022,
+     "sha256": "bf74e3dfbb330f481790f7bbc2b88e74b1654f7d5b327235c3d00bee3f62a06a"
+    },
+    "sound/soldier/idle1.wav": {
+     "bytes": 6422,
+     "sha256": "bd6930b788abf2eafa128bbeef6810affe90a100baef9a03b8c42f8559af5a48"
+    },
+    "sound/soldier/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/soldier/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/soldier/rocket_load.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/soldier/sight1.wav": {
+     "bytes": 56212,
+     "sha256": "e07e22a6ec2324a51b14a20f385162bf872261d27de0fda82e2816231e88830d"
+    },
+    "sound/spider/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/spider/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/spider/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/hiss1.wav": {
+     "bytes": 17802,
+     "sha256": "c56fcae8a01af94c07807730857b4b367f2c70c35869505528504faa29a17ade"
+    },
+    "sound/spider/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/spider/hiss3.wav": {
+     "bytes": 22582,
+     "sha256": "1a3c71b1e4ac2389c98c4af9db88e81b51a602c681bd00a1812995654863e2d4"
+    },
+    "sound/spider/idle1.wav": {
+     "bytes": 20922,
+     "sha256": "8a6d25359bbbc1f5e4f6962f4ce1742160537c6bb8bf8b806a0df96adfae819d"
+    },
+    "sound/spider/jumpland.wav": {
+     "bytes": 6038,
+     "sha256": "3c46bc58c52a61480c1a8dc2034aa240545521baf5e0027372992a9458796919"
+    },
+    "sound/spider/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/spider/pain1.wav": {
+     "bytes": 6108,
+     "sha256": "728cd94a64b27dea4d845a9e27e1ba09cfb286bff80128a67d1da0431b6b0c20"
+    },
+    "sound/spider/pain2.wav": {
+     "bytes": 10460,
+     "sha256": "736f0a768c0f52b22a301fc6a15f18f2f60e5579d3b27c2b78bcb7bed8e0c577"
+    },
+    "sound/statue/comidle.wav": {
+     "bytes": 17722,
+     "sha256": "3567914304c8fcf224e31bc302039432cd17833daabc2ed9f83053b01fef4f7c"
+    },
+    "sound/statue/death.wav": {
+     "bytes": 13472,
+     "sha256": "b030aeac3d806bc77fddaed4bb32684cfd2bbd707fe85e2500a3346c5931ec68"
+    },
+    "sound/statue/hurt.wav": {
+     "bytes": 8012,
+     "sha256": "9193f4e976675042409db103f7e3b26f667a56e913e96a37f223f1c606323246"
+    },
+    "sound/statue/idle1.wav": {
+     "bytes": 13304,
+     "sha256": "0b5d3bcbd00e846d38986f8919ff4fa7bcce92e45e5ba5949edd0e81b741b69c"
+    },
+    "sound/statue/idle2.wav": {
+     "bytes": 13316,
+     "sha256": "45469f14a25fd434ba1ed987fd20835ac058496d41df5a6aa543dec454670f36"
+    },
+    "sound/statue/sight.wav": {
+     "bytes": 9584,
+     "sha256": "84ab06d320f9953eebda7c4dd25a0e0de3369957de01c64af10a8b3ca886241e"
+    },
+    "sound/steelclaw/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/steelclaw/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/steelclaw/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/steelclaw/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/steelclaw/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/steelclaw/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/steelclaw/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/steelclaw/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/steelclaw/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/steelclaw/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/steelclaw/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/steelclaw/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/steps/drag1.wav": {
+     "bytes": 13586,
+     "sha256": "db069e08b7de4c5074cc4dd56f3b1cd2b6d77fe7869e1e03f5dddddcf9aad530"
+    },
+    "sound/steps/drag2.wav": {
+     "bytes": 13572,
+     "sha256": "b2ac07fe014e7c5afd4a5974c5d290b34a880a52f33668030a97a345d5811db9"
+    },
+    "sound/steps/drag3.wav": {
+     "bytes": 14690,
+     "sha256": "a29ee6f0977b205d146f81ee5be2f9b2f12ca76f177aaab9e35e556c4f555fa9"
+    },
+    "sound/steps/drag4.wav": {
+     "bytes": 13584,
+     "sha256": "1b5628a4272837ccf9c4044371a1d45eef23439b164be445b6f2ca90952e3487"
+    },
+    "sound/steps/drag5.wav": {
+     "bytes": 13584,
+     "sha256": "6dec9033ece2a02ce65c437e1b7e58512fd04d41a327487704de71cdf39b99dd"
+    },
+    "sound/steps/giant1.wav": {
+     "bytes": 33140,
+     "sha256": "d28f78c1514f215c64b6a3de38b5ffb5b891341ed95dc0277b1b3dba498cc64a"
+    },
+    "sound/steps/giant2.wav": {
+     "bytes": 33138,
+     "sha256": "7936f32a0ae371e216a195c3110b24db372a15091ea5c80e78875951f874d3b0"
+    },
+    "sound/steps/giant3.wav": {
+     "bytes": 33126,
+     "sha256": "58f79749cbdaaa608e6aacc368b74e0ac1e2ecf2ef45967c7f1f7b7a3e99c8fd"
+    },
+    "sound/steps/giant4.wav": {
+     "bytes": 33136,
+     "sha256": "4ffa741a70225aa31078f73a5612cf7d5ad9f9007163f0a5aeda749da099f9bd"
+    },
+    "sound/steps/giant5.wav": {
+     "bytes": 33138,
+     "sha256": "a2706d4dd9856cccdc3980156a77702883e36d86df54221b31a781c8e5e767e3"
+    },
+    "sound/steps/heavy1.wav": {
+     "bytes": 13282,
+     "sha256": "603679f83cc5095d2fa81d945285b2980195ba50ee2615fed85487493f0a536d"
+    },
+    "sound/steps/heavy2.wav": {
+     "bytes": 10870,
+     "sha256": "384f160ad4816b6984ef6b3b59c4bc1e8a2a3e05f9aaa80ee8b30ada2645669f"
+    },
+    "sound/steps/heavy3.wav": {
+     "bytes": 12828,
+     "sha256": "936417bc5ec9d30db8a74a9798328436259ffd704b11e1155d3fa79dc829e462"
+    },
+    "sound/steps/heavy4.wav": {
+     "bytes": 11050,
+     "sha256": "8d4879d40eda9182ff45fb18130c7979997d326581c14edeedc9cab440531e00"
+    },
+    "sound/steps/heavy5.wav": {
+     "bytes": 10198,
+     "sha256": "4e2e9892dee74d3472a45ecda889ae8d2f836786b44a55e5d1436690c7dadd5e"
+    },
+    "sound/steps/large1.wav": {
+     "bytes": 33118,
+     "sha256": "c387d084a10b28329610d8e3ad3e377f43087013e802be42af79f254276d00dd"
+    },
+    "sound/steps/large2.wav": {
+     "bytes": 24960,
+     "sha256": "ab91b4605671dd16da59963959cda3368a065612d8ed1776847da310b1e7b5fd"
+    },
+    "sound/steps/large3.wav": {
+     "bytes": 24280,
+     "sha256": "3e6a5ef0d8cbaba2e976f199d8d1ffa073fe8e83dacee709137335d42ddd7558"
+    },
+    "sound/steps/large4.wav": {
+     "bytes": 22092,
+     "sha256": "f2bde1b715f679cf814c2cd1375442170cf9f6e56d8ea1756900f81f1d1df453"
+    },
+    "sound/steps/large5.wav": {
+     "bytes": 24320,
+     "sha256": "c15b388bbed461461bac2c22b3a88ff272c04ad070e4791b7ce35c1559d16f77"
+    },
+    "sound/steps/light1.wav": {
+     "bytes": 8872,
+     "sha256": "f034fe2692c0fceb6de1c00e15facbcbd31ccd1fcf72510fd1e3cb6bdcc28795"
+    },
+    "sound/steps/light2.wav": {
+     "bytes": 6654,
+     "sha256": "998f665b4a7ccbc995096697606a91d208db024b0882df75ebaaac015f0d4ef6"
+    },
+    "sound/steps/light3.wav": {
+     "bytes": 6670,
+     "sha256": "b25e020a10ac6a7883fd584cff4895d6d785f8577daea15a30d2b745e146c1c6"
+    },
+    "sound/steps/light4.wav": {
+     "bytes": 4472,
+     "sha256": "a111052881024eef6e97393c1388e8ae538227b85c9b8cf0a73704abb2a504b1"
+    },
+    "sound/steps/light5.wav": {
+     "bytes": 3588,
+     "sha256": "55fb54e5ba2f8ec6249761ae6f07c12de6133457b51c584759e8841fb14cb46f"
+    },
+    "sound/steps/medium1.wav": {
+     "bytes": 8872,
+     "sha256": "38e731803a49be7d8018dd7b44060b578b5418f2f7aefb04d1c74c968ced187a"
+    },
+    "sound/steps/medium2.wav": {
+     "bytes": 8852,
+     "sha256": "e8701598e07f43a20aebebd1d1a5043213018199d50472dea37672e6dce4a2b3"
+    },
+    "sound/steps/medium3.wav": {
+     "bytes": 11068,
+     "sha256": "3ed07795c2363552554e6da1da5749be08e460fc6cd4c7266b9fa514732abb2f"
+    },
+    "sound/steps/medium4.wav": {
+     "bytes": 8872,
+     "sha256": "008992cd7972e7e1e6f0b785b40e398a8efe744a3f3f57e47370936796c3d6b5"
+    },
+    "sound/steps/medium5.wav": {
+     "bytes": 8864,
+     "sha256": "ccd26430fd354c0e87750e02d92c40071ef9dccadae5bdeebc7e0d2a2ec4eba7"
+    },
+    "sound/steps/slow1.wav": {
+     "bytes": 8878,
+     "sha256": "15614044d9d277fa3359edb07e7af74b9d7875150fddde5ab1fdceb0143337bb"
+    },
+    "sound/steps/slow2.wav": {
+     "bytes": 8856,
+     "sha256": "a8b16b688d12812a61127a885bf43c360adc2b84ae7806cc107b433c6f4635ee"
+    },
+    "sound/steps/slow3.wav": {
+     "bytes": 8852,
+     "sha256": "3a2a57e1a37d378c1ee73d5732840f6d20e588d794216c33896bf25879807600"
+    },
+    "sound/steps/slow4.wav": {
+     "bytes": 8868,
+     "sha256": "78bdea66991184043001262cc6ef5f1148cf0eb11b5f88fc51ff948311156e5f"
+    },
+    "sound/steps/slow5.wav": {
+     "bytes": 11076,
+     "sha256": "f63c868bd87926f017bec092749bd61c763b0b18635456ed56b660e53bf581af"
+    },
+    "sound/steps/water1.wav": {
+     "bytes": 63814,
+     "sha256": "01ed631b0d92dab11086b1106acc278ffd92522e2e46d21a0650fd29a79780f2"
+    },
+    "sound/steps/water2.wav": {
+     "bytes": 71994,
+     "sha256": "1b53561f02f60da1e1b6c8b72f722ba12e549c318725b974745b38666efa8e56"
+    },
+    "sound/steps/water3.wav": {
+     "bytes": 71802,
+     "sha256": "bbc0778017ccb579a9d531316b8af46585e91a100a251707ac34f4dbddf6922d"
+    },
+    "sound/steps/water4.wav": {
+     "bytes": 61448,
+     "sha256": "d3604afcb7751d987a78a0ee8ee4ca3593315cc6cf2f1909a9f7748535ccea50"
+    },
+    "sound/swampling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/swampling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/swampling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/swampling/idle1.wav": {
+     "bytes": 132044,
+     "sha256": "418eae21e001c1ae065df9357ebf2ad331f761062d75f345f12e99d9aec8cfb5"
+    },
+    "sound/swampling/idle2.wav": {
+     "bytes": 70444,
+     "sha256": "4026b4b56ffa9a207e1457e03ec94a8eb9042cfebf1c042fa291ba2bbbf1c4b5"
+    },
+    "sound/swampling/idle3.wav": {
+     "bytes": 171644,
+     "sha256": "fa54eaf040baf965f994b328bfb1a55cd90d1741d57ed580c1d44c51e9c125f8"
+    },
+    "sound/swampling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/swampling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/swampling/pain3.wav": {
+     "bytes": 67244,
+     "sha256": "4b186834bbec7d2ef9873f55d5df980da3b3fd2f19f76e54fd835d1aaf40fedd"
+    },
+    "sound/swampling/sight2.wav": {
+     "bytes": 88044,
+     "sha256": "6989ba3aca0c5f5e12d30d9958c6ab169f5c6c96f36f4843a9a19bab0e5d0c4c"
+    },
+    "sound/swampling/spit4.wav": {
+     "bytes": 76848,
+     "sha256": "6855555e2a188ed9ae0a1cd307c7715e54c6f3c10ac0fee9edbba2edf1a48d16"
+    },
+    "sound/traps/flame_loop.wav": {
+     "bytes": 28560,
+     "sha256": "661d8325af92fb37235952e2668578dbf57d844b7359627b4a2c25d15127bff7"
+    },
+    "sound/traps/flame_off.wav": {
+     "bytes": 28496,
+     "sha256": "ebc40d62265aad20813acd189511be0bac063ecc00d7ae712863de3dbdb84c94"
+    },
+    "sound/traps/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/traps/laser_hit.wav": {
+     "bytes": 4358,
+     "sha256": "0840d9fa27bfd2bcb86c2f0174810ae3eb9baa6a43867d27de1e074f7cd75e2c"
+    },
+    "sound/traps/pend_hit.wav": {
+     "bytes": 11908,
+     "sha256": "6fec8fd4edb67e8905d9ad0d7dce5ee5a9b4f43b724b75cb449e88b508384e11"
+    },
+    "sound/traps/pend_swing.wav": {
+     "bytes": 22142,
+     "sha256": "d20bbaf323c5aa0ee2aa21222f2a9f5fc956c0317e65c05e9d003bb08d80a9ae"
+    },
+    "sound/traps/saw_end2.wav": {
+     "bytes": 99808,
+     "sha256": "2a129f2d5fe3c9fd60873c336e2eed799b3d2ebc91bc8bf5a0860b45a6b83ceb"
+    },
+    "sound/traps/saw_loop2.wav": {
+     "bytes": 173082,
+     "sha256": "b4ca1bfeaab62c73bfc10f7daa2750738874d721af9e637479e8242f5220294c"
+    },
+    "sound/traps/saw_loop2f.wav": {
+     "bytes": 132748,
+     "sha256": "03a3e77feb8775a7b486363ed1d46d04fb9294f5507040e458ed8a05c37f0de8"
+    },
+    "sound/traps/saw_start2.wav": {
+     "bytes": 217184,
+     "sha256": "49f1dd84a7be0c4d0b1293aa587ab786d69f4cb463ce5a03f09da816eb22d384"
+    },
+    "sound/traps/sawblade_off.wav": {
+     "bytes": 15276,
+     "sha256": "44924313561cf32ea95c50ef80366ba79a2c86ff2f218fc89404c82617ce2c84"
+    },
+    "sound/traps/sawblade_on.wav": {
+     "bytes": 37582,
+     "sha256": "097635d29859ce28ea37da2d51ec346b8d5239435bb6be0bf5f094a555c110e8"
+    },
+    "sound/traps/sawstrike1.wav": {
+     "bytes": 30836,
+     "sha256": "489d8cdea78b2c333771b316741d7960d5c0da6845ea15b94991ece94837367a"
+    },
+    "sound/traps/steam_loop.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/traps/steam_off.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/voreling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/voreling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/voreling/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28354,
+     "sha256": "8c9ef55e309a43b1df1f08b66192b4ab262ba07e9315d3a70f4a9cf9dee9d51a"
+    },
+    "sound/voreling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/voreling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "5035bd555e9a6439c87e6b661a2da86633f7234503d52551e68f61e9504af86d"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 44162,
+     "sha256": "ccca790ed18e3705c083259f48db7d46d26310cf80c16cd2bad191d333fec5ba"
+    },
+    "sound/weapons/axe_ceramic.wav": {
+     "bytes": 24620,
+     "sha256": "53b6e873318f84424129f1486f0a715c9b1f46e9521c97858d3ddbd94ef4dc10"
+    },
+    "sound/weapons/axe_flesh.wav": {
+     "bytes": 7754,
+     "sha256": "8d0046355ea843f56d5260f581c89d2f885b553c97cfc7e01a93f6da487e03de"
+    },
+    "sound/weapons/axe_glass.wav": {
+     "bytes": 13306,
+     "sha256": "7fd4f7f02edf972c17cf64fea9ecfecca2e0a2d69da9828c1a1e2ce726dd9a79"
+    },
+    "sound/weapons/axe_metal.wav": {
+     "bytes": 28844,
+     "sha256": "d77bc0204c9f406f50ddf01241ff3a3cb34bd571f8a038a483fe49fba81fb160"
+    },
+    "sound/weapons/axe_swoosh1.wav": {
+     "bytes": 26524,
+     "sha256": "1ee4079e691b1e3e8eca8e6fe3098ee053f99b2a0028e725442771c84dc07e49"
+    },
+    "sound/weapons/axe_swoosh2.wav": {
+     "bytes": 13284,
+     "sha256": "a28435309759dd35576099d23a36dc378d9703db9f0778fba63efa3558cfc19d"
+    },
+    "sound/weapons/axe_wood.wav": {
+     "bytes": 7776,
+     "sha256": "ce5bd1465d66aa4aad5249c387f7f537b45b4f8a0e4bf76f37f8efc2a22bd9d9"
+    },
+    "sound/weapons/bolt_hit1.wav": {
+     "bytes": 12698,
+     "sha256": "07d2b6078f7936781a641f88e6ed02ab84f248da8f19e73713c1a71ac56cf42c"
+    },
+    "sound/weapons/bolt_hit2.wav": {
+     "bytes": 10658,
+     "sha256": "27ef878b7dfc0878140a19e3a0227ba389e5d0dc2b86df386852e2da2ebc5c93"
+    },
+    "sound/weapons/bolt_hit3.wav": {
+     "bytes": 11600,
+     "sha256": "06298d7bc8d7bce64f9473ae9530e0b42ea3de0ca5895f3476f9b00b5ed566f9"
+    },
+    "sound/weapons/bolt_hit4.wav": {
+     "bytes": 15460,
+     "sha256": "814b1a71efc9b58c90ad7f116c47e6f3dceeb8eae6d0ecbca5f1cd02dd247cb6"
+    },
+    "sound/weapons/crossbow_fire.wav": {
+     "bytes": 26536,
+     "sha256": "2a6ba54090412a53471c59b3edf6e8559d424dab25729e67a78f9ada5e13e8ac"
+    },
+    "sound/weapons/crossbow_hit1.wav": {
+     "bytes": 60782,
+     "sha256": "be1e78c92c13749e988d26912fba6c23f3700df0d7cc48d724f0da1f2608d006"
+    },
+    "sound/weapons/crossbow_hit2.wav": {
+     "bytes": 32472,
+     "sha256": "30a4ef9f23b2239371d32385e55487b279ca4f8f91366d4251cf4d9abdce200a"
+    },
+    "sound/weapons/crossbow_rdy.wav": {
+     "bytes": 37532,
+     "sha256": "321eac310a291cd9cdcbd2dcafb27687a12057e778e12704d8b4388d4eb6e4df"
+    },
+    "sound/weapons/crossbow_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/weapons/ghook_fire.wav": {
+     "bytes": 11526,
+     "sha256": "6e29f4524c0be70d8bf3b1201e737712b271c9bc963ad46c1815972b6addc22e"
+    },
+    "sound/weapons/gl_loadlong.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/weapons/gl_loadshort.wav": {
+     "bytes": 7758,
+     "sha256": "c97236bbfd211dfcad8130974413a8666cdbcf646d364abd8801b3d6ba5bf9c4"
+    },
+    "sound/weapons/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/weapons/laser_hit.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/weapons/laser_richotet.wav": {
+     "bytes": 12888,
+     "sha256": "bcc0498060e71b059d1d6ec45628048b0f29a7a0509b736a519196338b5df20d"
+    },
+    "sound/weapons/nofire.wav": {
+     "bytes": 1400,
+     "sha256": "217c42718548de32b5df972d117ffc1a0e1dde5f03a7a173bd91d0b4551248c9"
+    },
+    "sound/weapons/plasma_expl.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/plasma_fire.wav": {
+     "bytes": 88288,
+     "sha256": "6a0ad4930da39ff590c79f9d26b434bb1001536d33d880735df76e9354f90e94"
+    },
+    "sound/weapons/plasma_hit.wav": {
+     "bytes": 54406,
+     "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b"
+    },
+    "sound/weapons/plasma_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/weapons/r_exp3b.wav": {
+     "bytes": 34830,
+     "sha256": "a1abb7cedfa6576205f043c2e5f562606b039f65f6f996f5ffbb758d7855f2a2"
+    },
+    "sound/weapons/resist_rocket.wav": {
+     "bytes": 19938,
+     "sha256": "1e5170aaf1d6f144e7ea77c251d15ee85c9a70eb1f50b12e4ba5a93971ad1955"
+    },
+    "sound/weapons/ric1.wav": {
+     "bytes": 5650,
+     "sha256": "49223498fbf29b97f712537e6417917befc4e4f5c725bbf2e3d463580c15454d"
+    },
+    "sound/weapons/ric2.wav": {
+     "bytes": 11146,
+     "sha256": "5fa462f4ab3184cf70bf33f923a2b7e4392db517d34f8531a381864d78c352a6"
+    },
+    "sound/weapons/ric3.wav": {
+     "bytes": 11138,
+     "sha256": "1761926b96108fd0b0ee55270ee711fbd2f394f1b5e93da4af96e42c69fa3946"
+    },
+    "sound/weapons/riotgun.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "sound/weapons/sg1.wav": {
+     "bytes": 99600,
+     "sha256": "60a04d80a8af82aa13a1dc381e83fe2b1a0c52aa75e78c76db7d37d070f95d23"
+    },
+    "sound/weapons/sg2.wav": {
+     "bytes": 28718,
+     "sha256": "279b1bb969837073c46c176fe62782e60658a6614a8e094b9722cbabdca81fe6"
+    },
+    "sound/weapons/sgun1.wav": {
+     "bytes": 45840,
+     "sha256": "3ac6c4b3ded00fa48810f09afc95b4a8375dc3e8d52e04cd9cba18dfeee20087"
+    },
+    "sound/weapons/shellc.wav": {
+     "bytes": 21006,
+     "sha256": "45a2f8bd652307b9ebd37115c27166d03a4d7055f3054a215036fbc342e22f6d"
+    },
+    "sound/weapons/ssg1.wav": {
+     "bytes": 99600,
+     "sha256": "60a04d80a8af82aa13a1dc381e83fe2b1a0c52aa75e78c76db7d37d070f95d23"
+    },
+    "sound/weapons/ssg2.wav": {
+     "bytes": 75024,
+     "sha256": "248a021818f578ec3d96b9fe59d8f839242f4d5f8140a66a500b523b137d1977"
+    },
+    "sound/weapons/sword1a.wav": {
+     "bytes": 11184,
+     "sha256": "22bc8b25a67f1ab0752f9fbc68c2eb0958d2807c9e95bc8ee35d1d1bc9c6552d"
+    },
+    "sound/weapons/sword1b.wav": {
+     "bytes": 13272,
+     "sha256": "dca39f0c4776994c1bbe5255893d50dd86a634a370ea6046fd4e851117dec726"
+    },
+    "sound/weapons/sword2a.wav": {
+     "bytes": 11150,
+     "sha256": "aa381f8c68f5753cecbd889bc184a784c934c78c8fefe3b1ba4026a99112da51"
+    },
+    "sound/weapons/sword2b.wav": {
+     "bytes": 13232,
+     "sha256": "9460973ef948f8712be967d412774d32aeefb8e68b11959c28909eb16d9e8afc"
+    },
+    "sound/weapons/widow1a.wav": {
+     "bytes": 64644,
+     "sha256": "b4ccd6b235784f7ff53ccf0d726ecbbc789d2ddcca057b40df769b7925e3b32d"
+    },
+    "sound/weapons/widow1b.wav": {
+     "bytes": 11676,
+     "sha256": "d68d150a0c573b40ed5631ac8a7f5e0eca754d192610dbaa9767d8b750113266"
+    },
+    "sound/weapons/widow1c.wav": {
+     "bytes": 20938,
+     "sha256": "729a7e06dd971ca473ab2e272b237687afa03e3ebceb90ea92f975633d91f473"
+    },
+    "sound/wraith/attack1.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/wraith/attack1_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/wraith/attack2.wav": {
+     "bytes": 88200,
+     "sha256": "bdf849b4e138fa587df136a327c71ceed1176cbbb4ecb873434766d53da35a3b"
+    },
+    "sound/wraith/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/wraith/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/wraith/death1.wav": {
+     "bytes": 19960,
+     "sha256": "c0e5e05b46e4cf4afebfe5d0ef1801fc16fe8308a7f859ff347a77871b0a9339"
+    },
+    "sound/wraith/idle1.wav": {
+     "bytes": 51556,
+     "sha256": "e91f12463417df25badbbdfe817560362370d9e1e31712766bccb086e06d966f"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 82792,
+     "sha256": "b843d1124acc61be2aae27a7c8a9aca8f6bd471689703b41d59f1450e70e360c"
+    },
+    "sound/wraith/idle3.wav": {
+     "bytes": 55228,
+     "sha256": "3393943b38a0760c2b048c87c6b11ef743b0c968397ae7e434434b8b21fe12f9"
+    },
+    "sound/wraith/pain1.wav": {
+     "bytes": 18184,
+     "sha256": "a448cf5aed2909700e4da1f3ea3158b55e288198eee771eddacf211f4b274dbe"
+    },
+    "sound/wraith/sight1.wav": {
+     "bytes": 34390,
+     "sha256": "91494295e94c54c8da0307df8a51ea10d166fb18a78ede909a710f72ffe81c4f"
+    },
+    "sound/xmas/elf/attack1.wav": {
+     "bytes": 176492,
+     "sha256": "80e3faa699aec6d20015c1070087964de5ba39f83a978388b9fadc184f9fb6c2"
+    },
+    "sound/xmas/elf/attack2.wav": {
+     "bytes": 88292,
+     "sha256": "a364c82cb932bddb438c957e88a7ea67142777dfffd0f553d00e2b04b3af0f9f"
+    },
+    "sound/xmas/elf/cane_hit1.wav": {
+     "bytes": 4536,
+     "sha256": "2686bea9533633cb6c1a5e3e5bcf0016e3fe228cd278b7b1d11a02868cdd5095"
+    },
+    "sound/xmas/elf/cane_hit2.wav": {
+     "bytes": 5638,
+     "sha256": "6e470e241f37fb38ea55adf4bd0d6f1f5a2d5adfee5d5ddac8cb9adc824cb954"
+    },
+    "sound/xmas/elf/cane_swipe1.wav": {
+     "bytes": 1670,
+     "sha256": "2dbf81b3813376cb8bea2fa916dc0d03f1fbaaa499d4fcdf845de8929f82dc47"
+    },
+    "sound/xmas/elf/cane_swipe2.wav": {
+     "bytes": 1890,
+     "sha256": "404864c7d5008b79daed226566a2e4e78f2de92de06c64da67b8bf6224ae3e88"
+    },
+    "sound/xmas/elf/death1.wav": {
+     "bytes": 14284,
+     "sha256": "d1a7063d4ed39cdb59864a2a6fe6109f844caa9ada54ed4456de0bcd056f0034"
+    },
+    "sound/xmas/elf/death2.wav": {
+     "bytes": 10888,
+     "sha256": "4e0344a1bd3fa3d3c4d9e9647203cac0c449d5a5d8e7b1c8319f8402a4b7571c"
+    },
+    "sound/xmas/elf/idle.wav": {
+     "bytes": 57016,
+     "sha256": "a824467247797aa1ecc58f1716b18d390629804eebc413f01067646c64cde87e"
+    },
+    "sound/xmas/elf/jump1.wav": {
+     "bytes": 17766,
+     "sha256": "8023110b27a70758166f710e52188b8d03b8bfd81d9c985eb7f7d326acdb05a2"
+    },
+    "sound/xmas/elf/jump2.wav": {
+     "bytes": 8946,
+     "sha256": "a60763886b743d06ffd0c90e70de304ec8002a500947a684646c227d0bbb3c4d"
+    },
+    "sound/xmas/elf/magic.wav": {
+     "bytes": 15560,
+     "sha256": "6a270540819dddf140b0387d92c914b4f4b1c88c5f37a05c8fa0efd95901f2ab"
+    },
+    "sound/xmas/elf/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/xmas/elf/pain.wav": {
+     "bytes": 11126,
+     "sha256": "4e27a8f38e07e9b69db186d5c609740814ab86c5fda57058b1e05c56b85c6fd4"
+    },
+    "sound/xmas/elf/sight1.wav": {
+     "bytes": 21048,
+     "sha256": "c57eb4fec86922cb8a0499d7dae72eba66b067b89f14ff079ce0caf3dc23a23b"
+    },
+    "sound/xmas/elf/sight2.wav": {
+     "bytes": 30996,
+     "sha256": "8cd5eed3b8e098dfd70cbf90081b38e198bf64d8edf1b76bcc98c42e177635f8"
+    },
+    "sound/xmas/elf/sight3.wav": {
+     "bytes": 10050,
+     "sha256": "e88ae556a28352c319bf5500b29008384a5c53c47480defa81795d8891f14ff8"
+    },
+    "sound/xmas/elf/sight4.wav": {
+     "bytes": 6742,
+     "sha256": "7c6120d242cbbbfd2e0cc77b1428e206accd1ab8073885d52177b0fd4c75c7ed"
+    },
+    "sound/xmas/raindeer/attack1.wav": {
+     "bytes": 5582,
+     "sha256": "bcf78087eab53e8ed0bdde2f29088a89b321a79c3b104da380dd85bd5bdb6ec1"
+    },
+    "sound/xmas/raindeer/attack2.wav": {
+     "bytes": 6274,
+     "sha256": "2ba043cce4a2f22e7743812c0fa40e9f0888d5089362264c768352c347af5089"
+    },
+    "sound/xmas/raindeer/death.wav": {
+     "bytes": 9672,
+     "sha256": "68266e96ec1be80a55f48b76c2bedd6503273245153d96269947c7fc12ae96b3"
+    },
+    "sound/xmas/raindeer/hit.wav": {
+     "bytes": 5218,
+     "sha256": "72127151c2b05cc22a812fe9e38909c8bdcaae6a369e8756d2be67d392b91223"
+    },
+    "sound/xmas/raindeer/idle.wav": {
+     "bytes": 7890,
+     "sha256": "d3ef885d0b6163a3046dc9d514b07886c33809fbb6332e7db0514c648787a9bb"
+    },
+    "sound/xmas/raindeer/sight.wav": {
+     "bytes": 23796,
+     "sha256": "aafabb6fc46c1c72c34af1baea1c59a8ec04803c26faa4310072096481f31a4f"
+    },
+    "sound/xmas/santa/death.wav": {
+     "bytes": 99352,
+     "sha256": "b63273a2574f7def133aa438926a6def025aa64d8c3c636fc6a5594268e391d7"
+    },
+    "sound/xmas/santa/death2.wav": {
+     "bytes": 99352,
+     "sha256": "24fcf23117ec31347f640aa27e6feb4a46a634aa5e1eb48344b1feb7c377f6f1"
+    },
+    "sound/xmas/santa/fire.wav": {
+     "bytes": 22176,
+     "sha256": "3a9bb42661b75287a698b6e16033158f20c59c481d37c0f176dc213205d22dcd"
+    },
+    "sound/xmas/santa/good_hohoho.wav": {
+     "bytes": 55250,
+     "sha256": "51f4d5d656032de08b95689fa55a2e7aa26ec99cf4312b0f6153d0fd57fc1fa3"
+    },
+    "sound/xmas/santa/good_saved.wav": {
+     "bytes": 77302,
+     "sha256": "51e62df5942e2a72fd48311c61ee73b6f51dc4aa3c0cc85af000cdc8d7627d21"
+    },
+    "sound/xmas/santa/hohoho.wav": {
+     "bytes": 50840,
+     "sha256": "091a28236362cab1ce3b7bd55de25010d105db3bf644825c47b91725d8a613a0"
+    },
+    "sound/xmas/santa/laugh1.wav": {
+     "bytes": 57374,
+     "sha256": "ac069694d6c41e5e0afab50d9928b8768a19fb647bb249201648874d4150c976"
+    },
+    "sound/xmas/santa/laugh2.wav": {
+     "bytes": 117440,
+     "sha256": "c726d7d86d2d7cad0a75a2d0b387f4f96218ef232b6c78437e1c83bb96286441"
+    },
+    "sound/xmas/santa/laugh3.wav": {
+     "bytes": 40256,
+     "sha256": "4dd710eee601ab81c4beb5413d95244dee58b886b8265ab9cec35df06b560591"
+    },
+    "sound/xmas/santa/laugh3_com.wav": {
+     "bytes": 44226,
+     "sha256": "4099895e037cfecb4dc3595b3b18db62ed2f3cf096384f3aa1fe1d96a7b43da2"
+    },
+    "sound/xmas/santa/pain1.wav": {
+     "bytes": 6825,
+     "sha256": "79eed9346e0954fd53a6fdb9aa9708b8c29e8c5c256e9fd7c06f449e9cb6c00d"
+    },
+    "sound/xmas/santa/pain2.wav": {
+     "bytes": 9259,
+     "sha256": "f750328d74f545a658b0b190399595687c3d9b8766b2652ad6c2a34add3cc420"
+    },
+    "sound/xmas/santa/sack_hit.wav": {
+     "bytes": 13356,
+     "sha256": "c23a04ed5134f76d1f44d2e61eeb446a569c2bcbccf79f16f472807aae3df53a"
+    },
+    "sound/xmas/santa/sack_swing.wav": {
+     "bytes": 8940,
+     "sha256": "96972ba473b6a7d28645cdc621eb3011729a53eb4acb40d1f097768291a70850"
+    },
+    "sound/xmas/santa/sight.wav": {
+     "bytes": 100144,
+     "sha256": "e29696370a0d40546a49ef0f39b1e0038d8e067ef2da1dcc5084d7683a25d5d7"
+    },
+    "sound/xmas/santa/smack.wav": {
+     "bytes": 22176,
+     "sha256": "606c0a4b634d82a1d9846f654db8a52e7f2438ba28a235f782a23ff2720c767c"
+    },
+    "sound/xmas/snowman/claw.wav": {
+     "bytes": 8292,
+     "sha256": "7857f3526fb39e722a09ebe569f2b76facab765d82f97c0caa7da2ff9b750e9e"
+    },
+    "sound/xmas/snowman/death1.wav": {
+     "bytes": 11267,
+     "sha256": "0a09776ed8e45bbfe403f1cdb50302361f5596d9027c476409d6acf5402e763e"
+    },
+    "sound/xmas/snowman/death2.wav": {
+     "bytes": 13613,
+     "sha256": "e5e3a9619a153f0c6259abdb0d45f4eb4a547f736e37951556d29c6b715ec8f6"
+    },
+    "sound/xmas/snowman/icehit.wav": {
+     "bytes": 3090,
+     "sha256": "e03f61550bafc53ab47acdc23bcd481c35e75e6eccdad5e61e6dd7b372ba07c0"
+    },
+    "sound/xmas/snowman/icemiss.wav": {
+     "bytes": 3074,
+     "sha256": "f8b86f83d9adaaee1c84e1ac2acbcf652204842f2bf6f351ec1443a998574058"
+    },
+    "sound/xmas/snowman/idle.wav": {
+     "bytes": 58582,
+     "sha256": "a0d7af1cd6246f08176f24c5591cfb6ec89cff55dc5c18766ef1b16c64429541"
+    },
+    "sound/xmas/snowman/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/xmas/snowman/pain1.wav": {
+     "bytes": 7685,
+     "sha256": "7f829300a30cb6cb4d17f8c8327bd62ae5b5dacc892d28a956d6ecd2acf5f1c2"
+    },
+    "sound/xmas/snowman/pain2.wav": {
+     "bytes": 7661,
+     "sha256": "3747d77583aa4edb3509e89ea651ea41a8e8a92cd96c34d4e00257e7371fb0e6"
+    },
+    "sound/xmas/snowman/shotg_fire.wav": {
+     "bytes": 6572,
+     "sha256": "3d54870c0f643b1e7ee5307641bb3fc4a94efdaffc2e4ecd196556b930167ef2"
+    },
+    "sound/xmas/snowman/sight1.wav": {
+     "bytes": 10042,
+     "sha256": "ce1cddbb6e85fad23231ac1fc4c04c19ec7276acb2aa86e023c117db4b8edd68"
+    },
+    "sound/xmas/snowman/sight2.wav": {
+     "bytes": 15418,
+     "sha256": "5d4e994c30a7c3f2e1f1a5cde9a56115bcb32c350e4a0ad8e339a1a46ed19707"
+    },
+    "sound/zombie/boil_explode.wav": {
+     "bytes": 38012,
+     "sha256": "210dac94ab0e4efb5eb3bdbfa5d7100094b1bfef917a8d5abb2ae186252c0a27"
+    },
+    "sound/zombie/boil_idle1.wav": {
+     "bytes": 33204,
+     "sha256": "e2b717040d436ba2a659ceb1e5b74dfeaad57577297a9827957733e00ce7cb34"
+    },
+    "sound/zombie/boil_idle2.wav": {
+     "bytes": 33206,
+     "sha256": "8bd584597f2c54e6f8ecca5c0a83e44b0b5a09a745026e41cc2cad8ded6f729a"
+    },
+    "sound/zombie/boil_sight.wav": {
+     "bytes": 33192,
+     "sha256": "0e285e98dc66cd49af507dae9ab5281aaec55eaf9d401810a8d230d93539123a"
+    },
+    "sound/zombie/boil_squirt.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/zombie/boil_windup.wav": {
+     "bytes": 22094,
+     "sha256": "3790791943ea03add95bc303df34470c534f9c2c76e4343831609eaee761633d"
+    },
+    "sound/zombie/z_idle.wav": {
+     "bytes": 21538,
+     "sha256": "17918b5fbefd58aefb955e1f3fb7975e33497f5df7ce5518e5a21684157ef843"
+    },
+    "sound/zombie/z_idle1.wav": {
+     "bytes": 26790,
+     "sha256": "db7cb0f1f7036043b131432128f3182b052a5a9d7c1487c9989faa92595e5cbd"
+    },
+    "sound/zombie/z_pain.wav": {
+     "bytes": 33984,
+     "sha256": "a4b8a33cb64c9d5faee80aadbe7c9d5062c48d8daa42a10606138d37afc9ee21"
+    },
+    "sound/zombie/z_pain1.wav": {
+     "bytes": 15686,
+     "sha256": "0fa8819bc7c827a0b3b86717a810b4222b55c295cc45384e29fa110ed280cbcc"
+    },
+    "sound/zombie/zk_sight.wav": {
+     "bytes": 26916,
+     "sha256": "8fe4d5fea16bd7c3661a968d26782ea8c4741157e16e22f33317619229b10637"
+    }
+   },
    "sha256": "78d6adf09a44a63c93910348183c795946058c701842b4f3cb434ea0a557f8f2",
    "timestamp": "2023-08-06T12:45:04.000Z"
   },
@@ -462,6 +13462,142 @@
   },
   "qss 0.93.2.zip": {
    "bytes": 1793719,
+   "files": {
+    "qss/LICENSE.txt": {
+     "bytes": 18092,
+     "sha256": "8177f97513213526df2cf6184d8ff986c675afb514d4e68a404010521b880643",
+     "timestamp": "2018-08-13T16:46:34.000Z"
+    },
+    "qss/Quakespasm-Music.txt": {
+     "bytes": 3302,
+     "sha256": "35ca9d0d750e021e093ccb92dcb93ea801bf6d411718d09a250dc5c012081e2b",
+     "timestamp": "2018-08-13T16:46:34.000Z"
+    },
+    "qss/Quakespasm-Spiked-Revision.txt": {
+     "bytes": 154,
+     "sha256": "9c2538a3a0f06537191034520ef6b2b9797274628aeaf35403c7bd398c419b67",
+     "timestamp": "2020-08-29T20:54:20.000Z"
+    },
+    "qss/Quakespasm-Spiked.txt": {
+     "bytes": 8870,
+     "sha256": "41fbceef19cadd1fdd495a91a3bc1734c1cc30d338d536cac1ca1f784e457c31",
+     "timestamp": "2018-08-13T16:46:34.000Z"
+    },
+    "qss/Quakespasm.html": {
+     "bytes": 35456,
+     "sha256": "0d773e91e57336eb5d4fba451ab4b9fce116100caf601d946450493cce243b52",
+     "timestamp": "2019-11-20T20:39:56.000Z"
+    },
+    "qss/Quakespasm.txt": {
+     "bytes": 30735,
+     "sha256": "5ed57a808cf95156b05be553562286d9d024909d003695015d68c07b5f7e5a6c",
+     "timestamp": "2019-11-20T20:39:56.000Z"
+    },
+    "qss/SDL2.dll": {
+     "bytes": 1067520,
+     "sha256": "105ae3cfef22bbafab5b07e142bf425cac5868557470e8d9957523ab5fc4a42a",
+     "timestamp": "2020-04-11T01:14:56.000Z"
+    },
+    "qss/libFLAC-8.dll": {
+     "bytes": 72704,
+     "sha256": "8f780fafe48d88708918de0624fbaa97cafb9288f94ecdc4abfc38b7ff6c2bcd",
+     "timestamp": "2019-11-20T20:39:56.000Z"
+    },
+    "qss/libmad-0.dll": {
+     "bytes": 91648,
+     "sha256": "cf30b8d520d8eb22e45cb4271c177758074e4c04807b85f8cf738d617f3295e2",
+     "timestamp": "2018-08-13T16:46:34.000Z"
+    },
+    "qss/libmikmod-3.dll": {
+     "bytes": 166912,
+     "sha256": "2d47d113c3ff20c6a8954c22ce867fc3855fd0070e97044ed02ab5872f6cd276",
+     "timestamp": "2020-04-11T01:14:56.000Z"
+    },
+    "qss/libmpg123-0.dll": {
+     "bytes": 172032,
+     "sha256": "b02f59fc0eec79cadbd9dc2171093d51fe651b4718f2a990a7669aab3db8806e",
+     "timestamp": "2020-04-11T01:14:56.000Z"
+    },
+    "qss/libogg-0.dll": {
+     "bytes": 25600,
+     "sha256": "4c06d33509ec1ccf71907514032433b02f9c500a3ed0b02f7470bba7455c2d98",
+     "timestamp": "2018-08-13T16:46:34.000Z"
+    },
+    "qss/libopus-0.dll": {
+     "bytes": 124928,
+     "sha256": "57f00fd04e7b62fc26a24b7d5af8ed35532ce0a92da3a6aab565714f853be131",
+     "timestamp": "2018-08-13T16:46:34.000Z"
+    },
+    "qss/libopusfile-0.dll": {
+     "bytes": 46592,
+     "sha256": "9b73e9e4901af2826615910c501600725be4b7522519f4c8a9d69e4423291140",
+     "timestamp": "2019-11-20T20:39:56.000Z"
+    },
+    "qss/libvorbis-0.dll": {
+     "bytes": 169984,
+     "sha256": "1eabd296045298c0fe49b60618de8dd2f926716633dc8a847e0183552c58edbc",
+     "timestamp": "2019-02-06T01:27:06.000Z"
+    },
+    "qss/libvorbisfile-3.dll": {
+     "bytes": 32768,
+     "sha256": "788371c1098659c8c5cc6323699190b0e0ea8f515ba8c31dc6ebfbcd2fb52c8e",
+     "timestamp": "2019-09-10T18:59:00.000Z"
+    },
+    "qss/libvorbisidec-1.dll": {
+     "bytes": 110080,
+     "sha256": "0945703c222c7e4f64b7ec4cdca9ed5779872deab982f2c5b11ed0fa09c1b3c3",
+     "timestamp": "2019-02-06T01:27:06.000Z"
+    },
+    "qss/libxmp.dll": {
+     "bytes": 118272,
+     "sha256": "6b13f7f7cb67d85c6de6b540bf08f1b9ce9a952154507ecd883a159f0052ada8",
+     "timestamp": "2019-09-10T18:59:00.000Z"
+    },
+    "qss/quakespasm-spiked-win64.exe": {
+     "bytes": 1177088,
+     "sha256": "5d77797aa778ecb83d58a42446243471c5196959dbbb2f5832549d247ff96b92",
+     "timestamp": "2020-08-29T20:54:54.000Z"
+    },
+    "qss/quakespasm.pak": {
+     "bytes": 558584,
+     "files": {
+      "default.cfg": {
+       "bytes": 2289,
+       "sha256": "abb74400bd1b46e8eee9780a777b81483a29ecd786732d91b3e57c95a20f6783"
+      },
+      "gfx/conback.lmp": {
+       "bytes": 327688,
+       "sha256": "b14c295d790e9a8c86ff29c46b0e5b4de8e6d390c60f62b9395fc956563a9938"
+      },
+      "maps/e1m1.ent": {
+       "bytes": 26334,
+       "sha256": "7cd55e44f9585160c7d0308c5af4d7e23a0db0bcaf81a9d1d590ba981380e4dc"
+      },
+      "maps/e1m2.ent": {
+       "bytes": 41287,
+       "sha256": "30409975f8f94e20667538ec225b639570789f775b0199eef1206515ce58fad7"
+      },
+      "maps/e1m4.ent": {
+       "bytes": 43735,
+       "sha256": "3766674493c625884402dabf9fd961dbc462cc43fd735ae72db0baa3e3cfb1e2"
+      },
+      "maps/e2m2.ent": {
+       "bytes": 27179,
+       "sha256": "a65a882e6a95452cd9a43254eea67a3fdc161c92ac68c7f0a3b8ef9eb0f7118d"
+      },
+      "maps/e2m3.ent": {
+       "bytes": 38973,
+       "sha256": "46477248d62e4894013b993cc60ee0b84942f6eae6f7af761f8e1cca0a1259c0"
+      },
+      "maps/e2m7.ent": {
+       "bytes": 50561,
+       "sha256": "cb63389052b75db30df5835be05e53641880965d1f743db416e8fb2eea4f7203"
+      }
+     },
+     "sha256": "8c871bc16224e1fe48ce2be7bb1ae9805800c66a0890bbb33e9360ba79170239",
+     "timestamp": "2018-08-13T16:46:34.000Z"
+    }
+   },
    "sha256": "4760ef55d35c7d64de73b5bc649dbdbccda8621e9d880b6b75b21e094cd9b787",
    "timestamp": "2023-09-28T11:49:54.000Z"
   }

--- a/json/by-sha256/50/503dc0b832ca6aea4ba31ac33b90186bada3697a3ce5feb31537e01821497fb6.json
+++ b/json/by-sha256/50/503dc0b832ca6aea4ba31ac33b90186bada3697a3ce5feb31537e01821497fb6.json
@@ -42,11 +42,1431 @@
   },
   "fq/pak0.pak": {
    "bytes": 22140287,
+   "files": {
+    "conchars.lmp": {
+     "bytes": 16392,
+     "sha256": "3620819e6a33ca4929e000c407733ccb2ca34452013342a9117e0ac98fb85268"
+    },
+    "end2.bin": {
+     "bytes": 4000,
+     "sha256": "5f887856151123dece7644383dfebc2a6346ec828bd8d0609a42f37926797c69"
+    },
+    "gfx.wad": {
+     "bytes": 112872,
+     "sha256": "9dafe5396f09f3e52f97473b49f1f22c9244717a8a3d476b19a41db41b883f47"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "c8b87b40f90a0fb772cc5a2100bb325a67b2c1b3b98908079339b5428bf58c5a"
+    },
+    "gfx/conchars.lmp": {
+     "bytes": 16392,
+     "sha256": "81fa17b3c67cc16ecc639707e2aad40a65b140a78f89ed7992be163f3c9a8301"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 12,
+     "sha256": "6c5c5824fbd771b2f5335ddbb87153e1918a023a0b5c2c96d0eb6c0493aaecd0"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "cb9224f93c62b9bbce61e771ce7bfe89516ba99e0e3f311b01c6d73b488060b1"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "f5b3ad553307b1c341c16970969afa96eeeca11003651b95703dd2a4a673f91a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "841eb8f4848b10ed9e4b95c325ca7006e797571a028ba3f2527ccc69af4eeacd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "e409cbe6eedf2f00cad4f30ab274ef399f7c0e592faa6a1785329815df8a0441"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "9c285f8467dddf69f8197e3a60caa4c076ff8ac95b8cd96a5ff7dbb3b0e9d7fd"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "bcdc2bce056d6ef74247e0d254b492454d95c95538e32c645f33488a97bd73a6"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "8d812446eff8d9730287d1caaf9351269cf4e289c9022c916116f50c2f7754aa"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "200654bae4623a231bacb3a8186c56d5acb5bc4d0b68e37e1a97a15553421380"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "ed964b800d15b03f09e8f24edb64b27ca226b4d8c5abe4bdbbde00751ae9987e"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "b69dded6cf31e79f375a9f29cb7109404fc4db25018db0d32e5d822bc8960dba"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "b69dded6cf31e79f375a9f29cb7109404fc4db25018db0d32e5d822bc8960dba"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "ed964b800d15b03f09e8f24edb64b27ca226b4d8c5abe4bdbbde00751ae9987e"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "200654bae4623a231bacb3a8186c56d5acb5bc4d0b68e37e1a97a15553421380"
+    },
+    "gfx/pop.lmp": {
+     "bytes": 256,
+     "sha256": "59a7a58a257ae6a231ca4201a8330fa9d90779ea5e230e07d530f2478521bb9a"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "3e9fa9dda32dae224e7137e28997759a60bc2fc54fb49b0aae8ea37cdff1ec0e"
+    },
+    "palette.lmp": {
+     "bytes": 768,
+     "sha256": "6b20b5bc4ea965ef1852b05670d043ca16148a0ecad4e63028121c8aebc268fe"
+    },
+    "progs/a_2miss.mdl": {
+     "bytes": 157635,
+     "sha256": "fc9d74b3e6914ddcd8729d63fe19305a65f3235657a68584cf4918561725a038"
+    },
+    "progs/a_3arrow.mdl": {
+     "bytes": 31366,
+     "sha256": "e6fb92799050c9f730e373eac874a7b3774df39f21a436bee6f65c2fef77b6d0"
+    },
+    "progs/a_5arrow.mdl": {
+     "bytes": 52110,
+     "sha256": "e4d486bd2e2e1331773244fd30c39ae3b11d13acdefb93ad13404484e50d6c3a"
+    },
+    "progs/a_miss.mdl": {
+     "bytes": 78947,
+     "sha256": "d62771fa99ad137a023715f6fd91fcbd59555520a1f476a1acc093f193043eb1"
+    },
+    "progs/air_wat.mdl": {
+     "bytes": 45502,
+     "sha256": "8f3ae9a0e80e2cfd59035a5e9bf13296929413a74430a1b5f33ee5eb582598d9"
+    },
+    "progs/archer.mdl": {
+     "bytes": 345872,
+     "sha256": "c3f1793c302f36d99f4b428a574a506ce875af47d474c00f726d467bb5bdcec3"
+    },
+    "progs/armor.mdl": {
+     "bytes": 44076,
+     "sha256": "b97cef71aa7e910bac3ea0afb94d619334eee5b2732b113f69c831c23ec80537"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 9828,
+     "sha256": "cc8972c9e8ddf3141069d390898902a0643e9a4fc344ac73ff15861b0a6acac8"
+    },
+    "progs/ashield.mdl": {
+     "bytes": 15364,
+     "sha256": "599b6629af7d8b6b21672c57a6bde21c6b9fbf5e86295453dcf0bf15510c4eb1"
+    },
+    "progs/barrow.mdl": {
+     "bytes": 10627,
+     "sha256": "bdf761d188532818e909296133b06986079e979890b9a08a53f417d6f232f579"
+    },
+    "progs/bl_arrow.mdl": {
+     "bytes": 1848,
+     "sha256": "4e97483e8371a643e06980e843951ba209bdcda8c742a88a0c681767a38d8c02"
+    },
+    "progs/bolt3.mdl": {
+     "bytes": 2340,
+     "sha256": "d1d7092847f4615cefb0cb6892cbf847cefeed601c78f920d2711a2e721cb025"
+    },
+    "progs/bolt4.mdl": {
+     "bytes": 2340,
+     "sha256": "2afc403aabbdd8cdec8667da16898a165711f6f16a43e0865355c4c586fbebd4"
+    },
+    "progs/bomb.mdl": {
+     "bytes": 25428,
+     "sha256": "4843cc8437110d644bac443af5411ea6be5bd451c5abf7a608fd88a4a8c19b5c"
+    },
+    "progs/bspike.mdl": {
+     "bytes": 1684,
+     "sha256": "b6fc234ffce10b1031ded5068db353945be28b9f829ae613bb49748f3092bd6f"
+    },
+    "progs/candlabr.mdl": {
+     "bytes": 31146,
+     "sha256": "a60bdbfb2ba591005837d0a4998739bb8e683d8b86bb7550a01a0628196a4f75"
+    },
+    "progs/candle.mdl": {
+     "bytes": 31146,
+     "sha256": "a60bdbfb2ba591005837d0a4998739bb8e683d8b86bb7550a01a0628196a4f75"
+    },
+    "progs/chain.mdl": {
+     "bytes": 4504,
+     "sha256": "dfc36535c92e2194b16bdc0d2272b5dd795e2959d90e28b8d08c88c58ae79043"
+    },
+    "progs/crbow.mdl": {
+     "bytes": 40024,
+     "sha256": "829effdd6c3fa4c5f81786c5315fe5d236965cfa91aa14e7640af250cef46387"
+    },
+    "progs/crusader.mdl": {
+     "bytes": 927696,
+     "sha256": "8224071ab17c4edb7ae82c2102faebbf34209373b771db4f25ca66f78f8ec129"
+    },
+    "progs/crusades.mdl": {
+     "bytes": 871468,
+     "sha256": "0938ced05819813dba01e88ba6a3bdfec26d594b5b3f9bf8d87dd00c81d7bdbd"
+    },
+    "progs/dagger2.mdl": {
+     "bytes": 53303,
+     "sha256": "c4d94e0bb372f90dc031bbd3bf34f7c2d01125dcdfa2b1c63119c8ca924cb549"
+    },
+    "progs/demon.mdl": {
+     "bytes": 156640,
+     "sha256": "044c1b2b691d2e9540665f74f7206ebeb071e5c297a48841d1c42c91e8659c99"
+    },
+    "progs/diviner.mdl": {
+     "bytes": 990284,
+     "sha256": "249ec996ec01e6edc4fbb417da015b9c66bd5246bb95a19b47c48e26792901f8"
+    },
+    "progs/dog.mdl": {
+     "bytes": 198788,
+     "sha256": "4d2b55af5620b85e63a32cca21a65e441897317dcaad03f6b5cf13aaaca99369"
+    },
+    "progs/drak.mdl": {
+     "bytes": 74642,
+     "sha256": "e11f194a0a8c68a44c9c15912db4c66491a3a828ed5f0204c783262e9d78bf54"
+    },
+    "progs/druid.mdl": {
+     "bytes": 724828,
+     "sha256": "4ad0c31133faf9a311618ab0ab6d4f7306585b94c4a545a95c6acbfecd597b90"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 323306,
+     "sha256": "3726245ea983d328c67d19eda3ac4e335aabbf1733c6f723c623d7e19ccfb78a"
+    },
+    "progs/fhod.mdl": {
+     "bytes": 184212,
+     "sha256": "abe3b02e478984cd054011de62dee6cd529bac7439fc19c6b98d641366db83a9"
+    },
+    "progs/fireball.mdl": {
+     "bytes": 51564,
+     "sha256": "dae7dc94048efd52161263eed151ff5db99d9bd64dda3e8b7cc98a2038b6a9ec"
+    },
+    "progs/fish.mdl": {
+     "bytes": 132344,
+     "sha256": "f606eb0cdce2e97bbf4d6e399b97f71c096a3b09e3f31bda474277120cfcf67e"
+    },
+    "progs/foxmed.mdl": {
+     "bytes": 71059,
+     "sha256": "8bde0c36c2be788b2f96325a5bc75c4082c134c02d4a788ce4c6a09bb39cef2f"
+    },
+    "progs/frune.mdl": {
+     "bytes": 7732,
+     "sha256": "6e6fa1fcd788b192578b28897ab525efc8016cc6fc0db38d8744302b9fa79e4d"
+    },
+    "progs/g_bale.mdl": {
+     "bytes": 47842,
+     "sha256": "152d0df0471cc7ec23bc2806c93a52cf9140cdf4495b777dd4d1d44f65462dcd"
+    },
+    "progs/g_bow.mdl": {
+     "bytes": 13911,
+     "sha256": "96c41c349fe086fc5256316fbb28dac82dd0f962a7752b0dfd7cec9a267251e1"
+    },
+    "progs/g_fball.mdl": {
+     "bytes": 52263,
+     "sha256": "ec54cf0d6ac654769eb0ac105c49a3dd070daeb51032c35168b48fcd63fba524"
+    },
+    "progs/g_phoen.mdl": {
+     "bytes": 49160,
+     "sha256": "f0e6dd50142b2ef4c620db8177adabfbf587dcfc83372e7df2dc8b73f04ee7b4"
+    },
+    "progs/g_ta.mdl": {
+     "bytes": 56532,
+     "sha256": "efd6ffe24631e1b05173b9e921d2437283513e6f1bf9fad7888f4abc6b81d312"
+    },
+    "progs/gate.mdl": {
+     "bytes": 252892,
+     "sha256": "c1451f6a13959eb73ec1b5923a1fa5f33f59c4a18122cfc7ffe9f7904bb1adc6"
+    },
+    "progs/goarc.mdl": {
+     "bytes": 279068,
+     "sha256": "1959aebf38f93c59d45207aff3b04633b64c42cd75e9ab90cc6c911f75a6894e"
+    },
+    "progs/h_archer.mdl": {
+     "bytes": 5984,
+     "sha256": "f977b1876cb0d52b06a72a5af541519d6d3ec0f4bac8c1d8a563987ad628f79c"
+    },
+    "progs/h_crusad.mdl": {
+     "bytes": 14642,
+     "sha256": "78ecc9818213d16dd27f1b50ca856b378005f5ea6deb7a38dbd5a07568fa60cc"
+    },
+    "progs/h_divine.mdl": {
+     "bytes": 10356,
+     "sha256": "4bcafd64dece0c3d4675faee192abc5a62a1a2445869ae8e1745f923c0edea66"
+    },
+    "progs/h_druid.mdl": {
+     "bytes": 10356,
+     "sha256": "83e835e39b4ced522076725610b9fcfd7a22fd1320b7148397bc482c8a85dd96"
+    },
+    "progs/h_elem.mdl": {
+     "bytes": 10912,
+     "sha256": "b6ac00502a4edcacb09616f89ee6f8ae95ce0c533404ada103f4a7fae6a02169"
+    },
+    "progs/h_goarc.mdl": {
+     "bytes": 41748,
+     "sha256": "34b01ecbd4b6f879fc0d1623285567b5cbb4785a0fb4ec2e605fa5a265ef5312"
+    },
+    "progs/h_necro.mdl": {
+     "bytes": 7156,
+     "sha256": "7d7eae23a1c5e48db339ab44bade7ed93b2b855b03c9a5d3b7faf7d31c05dd85"
+    },
+    "progs/h_outlan.mdl": {
+     "bytes": 5428,
+     "sha256": "6ec034487c17f60f05bd3c5f54fba518e18e635fd661b1dbf9ec3d9db6fb68e2"
+    },
+    "progs/h_rager.mdl": {
+     "bytes": 7696,
+     "sha256": "5eaebdb02fe918e02de01433b4ec442b2ad82406341a0ab8912f4d9fe5b7f3d3"
+    },
+    "progs/h_reaper.mdl": {
+     "bytes": 20692,
+     "sha256": "e2b7a5ff022786108452958789036c7e05d9bf11cb034f1551fe61458b0706df"
+    },
+    "progs/h_rogue.mdl": {
+     "bytes": 5428,
+     "sha256": "de914e6a74cb2dca28561e59a73ba54b895e6fe86577844cf4fb41ebb1d1e0db"
+    },
+    "progs/h_xbow.mdl": {
+     "bytes": 5984,
+     "sha256": "67812a5c4bbd84973a6984cb4d69ff7f75931489b7e88dbfe800dd611182bd1c"
+    },
+    "progs/hook.mdl": {
+     "bytes": 27444,
+     "sha256": "e75b496c11798136da7875529906184e9c51d3fa0abbd988ec752ffdbe05e275"
+    },
+    "progs/horror.mdl": {
+     "bytes": 86228,
+     "sha256": "05eeafd9a6b3ef61db3c574f345f91224eb9507a03230ddf39e262785974a1f4"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 69835,
+     "sha256": "f53ab3e269295e00aa91e3bdc5181febc028b61184d5707a0d03bde84ff3d66d"
+    },
+    "progs/lbow.mdl": {
+     "bytes": 6760,
+     "sha256": "76352b991b17dfda780da58efe592d90fe5769400cfde21f4ebfd9bbc06c7d34"
+    },
+    "progs/mino2.mdl": {
+     "bytes": 433281,
+     "sha256": "7aecb58ff8a91631eee23327a74daf2b35ad2516a347d72b1a93ff561750b623"
+    },
+    "progs/musket.mdl": {
+     "bytes": 35266,
+     "sha256": "08f41482fff9ab1cb86157d3491d85830dfb9cad954c36d4fcda1a6a73253da3"
+    },
+    "progs/necro.mdl": {
+     "bytes": 494004,
+     "sha256": "86d15fd6a0c6731a5ffb3c74882c30943101b268341900ec916ae311b5a393d2"
+    },
+    "progs/oil.mdl": {
+     "bytes": 69283,
+     "sha256": "df707ea81aa5f31a7ebabf34ef9c67c52657bbf9b80d058bd6e9e14a0451524d"
+    },
+    "progs/outland.mdl": {
+     "bytes": 932604,
+     "sha256": "ee95a66766d71bf4bfbc2b2842e5fa8622767f359730086de7339bc4ad0e20ed"
+    },
+    "progs/outlands.mdl": {
+     "bytes": 1120172,
+     "sha256": "55d36d94faf36badc279517ac2871f44533b487656e751753a0aea78af4b1833"
+    },
+    "progs/pedestal.mdl": {
+     "bytes": 19159,
+     "sha256": "3500bf5cb5b668a5d0f4ee2e7d99c79269800d272a40a2a86a10b374bb0d5bef"
+    },
+    "progs/potion1.mdl": {
+     "bytes": 36228,
+     "sha256": "ae04969aa19bcb3b133dc48463a3d1339494c53258625669a943d5e8fbbeb48e"
+    },
+    "progs/potion1b.mdl": {
+     "bytes": 36470,
+     "sha256": "1f946738b75db813e9e335b8a2efe225cc6e62046f42c2ba9699180f6e33a3ad"
+    },
+    "progs/potion2.mdl": {
+     "bytes": 46116,
+     "sha256": "f2d902837e8495a4fa32587c6ed1cfbdb416dd3e285a3d65646f9c39d190b126"
+    },
+    "progs/pouch.mdl": {
+     "bytes": 21684,
+     "sha256": "7142c8fe962646b634b5cbb3fcd480d634ef40c51a9abb5021ff2b0938745506"
+    },
+    "progs/powder.mdl": {
+     "bytes": 44060,
+     "sha256": "6ce38cc8da96432a9552efbad5942c5a831e949cbf912c9cfd566aae796231b3"
+    },
+    "progs/rager.mdl": {
+     "bytes": 257392,
+     "sha256": "331b89fdb93d73f31fc8a41066ef5e9cf39241fe4973fc2f9dacbc21de790e1a"
+    },
+    "progs/reaper.mdl": {
+     "bytes": 133376,
+     "sha256": "d52dbbe9927f10ccd29a166df26194afa55dfade18bd09a1267f49577ac4f8fe"
+    },
+    "progs/rogue.mdl": {
+     "bytes": 914108,
+     "sha256": "b26674c06af67969e6141cb29c48bca967e535784c518d16e37886b673321a28"
+    },
+    "progs/rogues.mdl": {
+     "bytes": 845596,
+     "sha256": "497d68cf7997ec678ac5cf1f7f68f488f27ea671a6c16ec979d8978a38481839"
+    },
+    "progs/rrune.mdl": {
+     "bytes": 7060,
+     "sha256": "2b5141c1dd4c56ce7f7735842f7c75b22d91ececc17a3b1b756f3349032de7ca"
+    },
+    "progs/rshield.mdl": {
+     "bytes": 233968,
+     "sha256": "bf037ec0624a846858cdf0739fc4710e0ee4e1211663636e9392ebead2e0480a"
+    },
+    "progs/s_axe.mdl": {
+     "bytes": 192066,
+     "sha256": "a1e694f9f36d6df5a2444eae3b3f3bc06cdcefbba95f657cc8df229236b348fe"
+    },
+    "progs/s_dagger.mdl": {
+     "bytes": 186884,
+     "sha256": "bcc90f79b46336d6fcebdbf4806c927bbdd84574421e7576767ef9b901c82cd3"
+    },
+    "progs/s_spear.mdl": {
+     "bytes": 56600,
+     "sha256": "8c5922a539bca032188412c98cf4567e8e258e5091b6bdb675ff08bb5721cc99"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "ce6c16618f236e72f00965a69a8284395b3157788ca988ba5c7b258cdaf2b929"
+    },
+    "progs/s_sword.mdl": {
+     "bytes": 120772,
+     "sha256": "4474d5a9ecc108df4bcc77bd25d6cd13960c28bc573400eacab5d4d9a72f242c"
+    },
+    "progs/s_sword2.mdl": {
+     "bytes": 135500,
+     "sha256": "d588100775edfd223e87ed35727059ebe7cc078e9339aacb16bd710de9827a60"
+    },
+    "progs/s_taxe.mdl": {
+     "bytes": 167332,
+     "sha256": "72af9fc43af928f7e38199ca2f1cf171c1e32de5bd23af3f101509baf0fe1699"
+    },
+    "progs/s_tknife.mdl": {
+     "bytes": 126052,
+     "sha256": "e1d182a4f7e3828c764ee55b944b88f0b3dffbd3ab78a51277dcc8963c697af9"
+    },
+    "progs/s_uaxe.mdl": {
+     "bytes": 167332,
+     "sha256": "37f43f2893e14213a082b6771329008980ab5959ec35b3dfce0dde6b0d321bc1"
+    },
+    "progs/s_udag.mdl": {
+     "bytes": 182228,
+     "sha256": "0d683946b87d3a6da5ac5ffc223d65a68d35e6800331f6b214212ac9ecfb8b72"
+    },
+    "progs/sbow.mdl": {
+     "bytes": 12748,
+     "sha256": "4b8975e03641c26b3685ffd3ea80faf5b9d38a491274dcb36e65bf69a5acaac9"
+    },
+    "progs/scandle.mdl": {
+     "bytes": 55990,
+     "sha256": "5fea4693cb0f00f6a279ebbab293190158e94f66bd39959d5b7d33a66e1ab9f9"
+    },
+    "progs/seal.mdl": {
+     "bytes": 29495,
+     "sha256": "2b4998eda0c04066e6b6e6b0b3c9fa998c2a0aacb439ff4559d875f54c6017d6"
+    },
+    "progs/shield.mdl": {
+     "bytes": 118781,
+     "sha256": "01aeb7a43e6ea0ea23ab5d594d2f20d6b1feb0a98e95388db1a99cf43fa02e07"
+    },
+    "progs/shopkeep.mdl": {
+     "bytes": 272480,
+     "sha256": "dc8293670a13d07498a257530d73bbd929b80cb1edf4761d898d66db1d63b43c"
+    },
+    "progs/skeleton.mdl": {
+     "bytes": 218680,
+     "sha256": "6219e720f64615fc7d08195395969e628d14feab721ed3c87cedaa9a357f1183"
+    },
+    "progs/skull.mdl": {
+     "bytes": 67064,
+     "sha256": "87917d0b1925a865039d35c1e23a963dfeeefe0ce3ee72161b5449f90f927634"
+    },
+    "progs/spear.mdl": {
+     "bytes": 6631,
+     "sha256": "6aa2cf559f6545fbd1d79af0cc17f00e86bada2352b8a20408509ce68310bcfd"
+    },
+    "progs/srune.mdl": {
+     "bytes": 4468,
+     "sha256": "32356eb612316228c824f2a0ded61a28f963fc03b1e2ce22c442316ae8bd027a"
+    },
+    "progs/star.mdl": {
+     "bytes": 50094,
+     "sha256": "8c185d196e7def034cfca21bd724af92c948ad8e28e0a08e350f27a6ca88a63f"
+    },
+    "progs/throwaxe.mdl": {
+     "bytes": 41488,
+     "sha256": "b4577ad94b9fee0e84c60ca15f6473b3aac323995504c8af80a52bbabbbdd592"
+    },
+    "progs/tknife.mdl": {
+     "bytes": 110852,
+     "sha256": "ff48c8934658b24461ad3a4a7a02429dc6d1ead0540e9ccb19b88588c49ad02c"
+    },
+    "progs/trune.mdl": {
+     "bytes": 5908,
+     "sha256": "ff97f03d59835f34081ad93f164359837a20a2c788ec728efcfdb7aed0351220"
+    },
+    "progs/upgrade.mdl": {
+     "bytes": 51924,
+     "sha256": "4b3d75c94a0c7909c827f5e1b153f7409d748283908d32d6d966a44fdd02808e"
+    },
+    "progs/v_bow.mdl": {
+     "bytes": 62157,
+     "sha256": "078eb0107e299831efb16802448d93a74f205abc7946ae08438dc64bcc6e88a0"
+    },
+    "progs/v_crbow.mdl": {
+     "bytes": 42584,
+     "sha256": "e4c6d5f47237368b9e96934a9d2b2719d6416cbc84445003d3dd0be4f64ab3a7"
+    },
+    "progs/v_dagger.mdl": {
+     "bytes": 102500,
+     "sha256": "15dbe8deddf034a2c12e70bfefae6df0489fdac9347da0e87f6344f7cdd6b6a6"
+    },
+    "progs/v_dball.mdl": {
+     "bytes": 108572,
+     "sha256": "b6961c856dfbd08d56df9992cc6f88c2849fdaf8ea1770ba69cbf9afb92ad842"
+    },
+    "progs/v_dbolt.mdl": {
+     "bytes": 56804,
+     "sha256": "dfc315266033aeff1f419511ba45fd0208c656e9ba5703bab83fefef251e6d8a"
+    },
+    "progs/v_fireb2.mdl": {
+     "bytes": 60182,
+     "sha256": "9119b262d0c7c46120b7c0b5629b86f10da33a230a2a2488c3dd6ab3fe84de6a"
+    },
+    "progs/v_fireba.mdl": {
+     "bytes": 60782,
+     "sha256": "925668abed2443a1b0bfe0dbb7ba2c0a885e2ea7a6f59ed6f622de7b96b5e054"
+    },
+    "progs/v_fsword.mdl": {
+     "bytes": 56204,
+     "sha256": "68056fec7369f3e727344ca0c0d514cc432747f615681b636dff4d966840d763"
+    },
+    "progs/v_gball.mdl": {
+     "bytes": 57932,
+     "sha256": "fc391e9acd099f7c8ea987e7172e2af13017aa51ceb5d16f9801283db408b260"
+    },
+    "progs/v_gball2.mdl": {
+     "bytes": 73707,
+     "sha256": "7f393a43f0e2e17c3d47cf57cd9734aaada988b52f0afcd45220cda06e076a86"
+    },
+    "progs/v_gloves.mdl": {
+     "bytes": 49464,
+     "sha256": "d543d9c6e445dc21566d352a314afe04e436eb0a5b7ecb9395a17b4fcc8c4773"
+    },
+    "progs/v_hands.mdl": {
+     "bytes": 49464,
+     "sha256": "43a5f32cd1cb9dcb6bb17afda59fafa68521a8dd524416c60c1ee8caafad41ed"
+    },
+    "progs/v_lbow.mdl": {
+     "bytes": 47680,
+     "sha256": "8a8e41934dfa2929ab5eb762a6584fbff2eebc91e912d6057625d1d9789700e0"
+    },
+    "progs/v_miss.mdl": {
+     "bytes": 58667,
+     "sha256": "33e83f3e103efe2d3e67eb9d82cda9bdeddc940436d88ce44311f4e43c79c80c"
+    },
+    "progs/v_miss2.mdl": {
+     "bytes": 58667,
+     "sha256": "a1876376012d0deee6ad30bb350cabcdbadfd3b1122ff92484fd4943d0eb0629"
+    },
+    "progs/v_musk.mdl": {
+     "bytes": 37534,
+     "sha256": "cac067c7fd56aadb2bf3edeea234c4ecb9bc335bdd2d0a22cb005ec7fe866421"
+    },
+    "progs/v_oil.mdl": {
+     "bytes": 49308,
+     "sha256": "2c31b8378c1e05a6ce3d2283726b7b7fc3d40405658a391e35723fed447147f6"
+    },
+    "progs/v_phoen.mdl": {
+     "bytes": 47520,
+     "sha256": "01e8fd88b8857d9ecaed40b55028ce78effc4c7305260af7fd90b649acd40faa"
+    },
+    "progs/v_raxe.mdl": {
+     "bytes": 107420,
+     "sha256": "417a723a32e1e25a6f059b93ac7763ccf392ee489a836a5a7f9c5e088107e233"
+    },
+    "progs/v_spear.mdl": {
+     "bytes": 7751,
+     "sha256": "0b34ad6206046f5e669f7d526115ee3536be682795fccb12314b915c58491846"
+    },
+    "progs/v_staff.mdl": {
+     "bytes": 54879,
+     "sha256": "260482b640ec237e0f7a963632fcb43cd48b21682adaeb5077162311f18e1956"
+    },
+    "progs/v_sword.mdl": {
+     "bytes": 59499,
+     "sha256": "28023e4a8acf23cc7d61d67e15a90ca2d06c50c77fb99e5f678e49e1aed49f84"
+    },
+    "progs/v_sword2.mdl": {
+     "bytes": 76595,
+     "sha256": "db22c72eda23cc5ed21178c3d316fc90218858799bdaece437cc8154728ab501"
+    },
+    "progs/v_taxe.mdl": {
+     "bytes": 107420,
+     "sha256": "48ed77fa1c2c30f851ba2d6bfee65fde56f84f121737524cd0ad6141e6ed5a75"
+    },
+    "progs/v_tknife.mdl": {
+     "bytes": 119192,
+     "sha256": "7de4e6308c8c4e48bd40a4d3f698e7a6250c33a2f4c690a826505551593536bd"
+    },
+    "progs/v_uaxe.mdl": {
+     "bytes": 127954,
+     "sha256": "7182f8d2ab3d289679c6fc72b0bd60cc5065eb8f4431d2a7ac809ffcc2c0b96e"
+    },
+    "progs/v_udag.mdl": {
+     "bytes": 102500,
+     "sha256": "3de61a777c2642c8eb18970388da83d3a58b997b5410c1ce7b6c77279bece51f"
+    },
+    "progs/v_ustaff.mdl": {
+     "bytes": 52604,
+     "sha256": "1b405284fa1c4fd9dd624363fee36636ea2d684cf6ab187e7edcb5284cdf282f"
+    },
+    "progs/wolfy.mdl": {
+     "bytes": 158872,
+     "sha256": "6d359ea4046d8d6f82f6a08e0f568e34f148991d520ee669f77da5c013548041"
+    },
+    "progs/wrune.mdl": {
+     "bytes": 7252,
+     "sha256": "e29e3d7ae730a4c55f17d16373096b4b7cb829889783b99ab02b0603a7307a7f"
+    },
+    "progs/xbowman.mdl": {
+     "bytes": 806608,
+     "sha256": "43b79438d8ab369f73a2cd1404b80c9a670376641d1eac26ff7b6af741e3a1c9"
+    },
+    "progs/xrune.mdl": {
+     "bytes": 5844,
+     "sha256": "0c7445787a762541efab22a294c08226930ea9d439fede0ae85aa9c6e7f86211"
+    },
+    "sound/ambience/brook.wav": {
+     "bytes": 40442,
+     "sha256": "67a14beb61b7fbe236bfeefd07e7af2f69c252776e9406def18a35779fcfb124"
+    },
+    "sound/ambience/chains.wav": {
+     "bytes": 16646,
+     "sha256": "3a29341673996a6ed50ef357f940b93455c8bfeb72a74da2b5c0d153611c55af"
+    },
+    "sound/ambience/rocks.wav": {
+     "bytes": 32438,
+     "sha256": "ffcb14e290eda3f9df6ac9b8f098b84dd11d2dd03709dd381e05e74de8ff4a56"
+    },
+    "sound/ambience/voices.wav": {
+     "bytes": 107388,
+     "sha256": "4ac928df785ea182653564c7e5f33ae382d2ba3fdd22cc8abc845aca219c0661"
+    },
+    "sound/crusader/repair.wav": {
+     "bytes": 19954,
+     "sha256": "8181c8f60f0349e446209b971e47c0b8d2d3cf471906fffcb245b96ce3344aff"
+    },
+    "sound/doors/airdoor3.wav": {
+     "bytes": 10129,
+     "sha256": "9444ac473a8045799871214bc3f26fb36522e1c74ca4ccaf92a6d26b7750e753"
+    },
+    "sound/doors/basesec3.wav": {
+     "bytes": 13285,
+     "sha256": "18f2f85a57ce1ba08ed656ec291a19be9dcffa6a2c06ea1b3ca6de80b84050a4"
+    },
+    "sound/doors/basesec4.wav": {
+     "bytes": 10174,
+     "sha256": "03690085e08259283f6960f2fecaa709ba6f75608f94d00f8c7cb316c56508ff"
+    },
+    "sound/doors/ddoor3.wav": {
+     "bytes": 10814,
+     "sha256": "4d5a597b3d88826244b85828637837148477d8f9f7d77c626d5895662b16125c"
+    },
+    "sound/doors/ddoor4.wav": {
+     "bytes": 9263,
+     "sha256": "8b84162de2f405115b2115c6a8e47b5ec91da2439ec839f0f065c53e6d276a60"
+    },
+    "sound/doors/doormv2.wav": {
+     "bytes": 10814,
+     "sha256": "4d5a597b3d88826244b85828637837148477d8f9f7d77c626d5895662b16125c"
+    },
+    "sound/doors/drclos5.wav": {
+     "bytes": 12795,
+     "sha256": "30a1dc9d7447ea9e8042bf13b48005757f39c998193ffec42218984956563366"
+    },
+    "sound/doors/hydro1.wav": {
+     "bytes": 10814,
+     "sha256": "4d5a597b3d88826244b85828637837148477d8f9f7d77c626d5895662b16125c"
+    },
+    "sound/doors/hydro2.wav": {
+     "bytes": 12795,
+     "sha256": "30a1dc9d7447ea9e8042bf13b48005757f39c998193ffec42218984956563366"
+    },
+    "sound/doors/medtry.wav": {
+     "bytes": 3199,
+     "sha256": "4cb22bb75eeef81c21cc5a4ab170af52ce10b9438d0cfdb34daa4dc3b19ec79c"
+    },
+    "sound/doors/meduse.wav": {
+     "bytes": 3296,
+     "sha256": "6507625aa1b12ff00e3d565902b1e3c809b405a4a488105778fd0598cd9a5523"
+    },
+    "sound/doors/stndr3.wav": {
+     "bytes": 22724,
+     "sha256": "acb9f96035eece24489c4b30a49981ac1be5f7011f594ed91848d6e678841271"
+    },
+    "sound/doors/stndr4.wav": {
+     "bytes": 12083,
+     "sha256": "7671f98d30cde8d5b071526ed8ef357e88b68bbe4274fbd94000ede9716a695a"
+    },
+    "sound/druid/block.wav": {
+     "bytes": 9326,
+     "sha256": "57fa054399cb714fa8b17fef8d979ae9ca11ae84c7ba9ce5f5ef59c97fa89c6a"
+    },
+    "sound/druid/blockoff.wav": {
+     "bytes": 25132,
+     "sha256": "992db16dfa6eb5b8d31c004561ba35cb5266984df31e9c501579c6e0bbca7b43"
+    },
+    "sound/druid/cure.wav": {
+     "bytes": 28598,
+     "sha256": "57f6ba9cf1c91c160a7b101277f033d9b1c009c12e1eb07534c95b0b43032738"
+    },
+    "sound/druid/heal.wav": {
+     "bytes": 20528,
+     "sha256": "28541d413939721177a27419fbf07fdb0843ec3ae11efcee99e5fa528f6e977c"
+    },
+    "sound/druid/light.wav": {
+     "bytes": 10001,
+     "sha256": "5f159f52b6247c915ecf689a875bc644a68ed69b7e75bbed33264f792ba2d533"
+    },
+    "sound/druid/protfire.wav": {
+     "bytes": 28598,
+     "sha256": "ec2a8b720922e7e02ecd5220e54a928cbaca228912e15731b7335f8381d29b4b"
+    },
+    "sound/druid/storm.wav": {
+     "bytes": 11532,
+     "sha256": "9d0c8ba5dbdac6da017d9dd6b390b3ce7fdd172aa6f4ef8fa12151f0716b9d65"
+    },
+    "sound/druid/thunder.wav": {
+     "bytes": 27138,
+     "sha256": "a20d7d2b5550fdef11881a4a1412b739c280e07a98781fc49d1b4ede34d36ab8"
+    },
+    "sound/druid/vigor.wav": {
+     "bytes": 6892,
+     "sha256": "375260be9d8c8a76a416d5d09a5e1926daa829da26c992217842d9a533d402c5"
+    },
+    "sound/female/axhit1.wav": {
+     "bytes": 6872,
+     "sha256": "0d6b705c91f8d114f602bcbb63ca1bbd6d417b48119b16d30703095c31ec5849"
+    },
+    "sound/female/death1.wav": {
+     "bytes": 66858,
+     "sha256": "4d94885ed56c22fa4803e488317302a70fa8743d8dfa86d8ae9a8133b8540d85"
+    },
+    "sound/female/death2.wav": {
+     "bytes": 51754,
+     "sha256": "f732120018e5667e570e120bf35cd3373868e4b8dc08c8135249a672d4149b0d"
+    },
+    "sound/female/death3.wav": {
+     "bytes": 44842,
+     "sha256": "41ce5890e05c5b46704ed90c25722c576ede8f7fe63ff95c358d622baa751d87"
+    },
+    "sound/female/death4.wav": {
+     "bytes": 40234,
+     "sha256": "87accc959958ca3f6ba2add95e8aeadd8c3f776198b3d9ee93d32df934760cdc"
+    },
+    "sound/female/drown1.wav": {
+     "bytes": 8908,
+     "sha256": "9154e2622a339a6e29804afefd3f0e98e3660e5e41913d15d08388df7100bb38"
+    },
+    "sound/female/drown2.wav": {
+     "bytes": 3114,
+     "sha256": "e55d3bacd1c6716d6988e57cb85b298063b56f1a8e74b282119a2c8f510c86c9"
+    },
+    "sound/female/gasp1.wav": {
+     "bytes": 8699,
+     "sha256": "403dec3dd2f678c868be008810f63b59da4b65263db0953bfc114c755e7562d3"
+    },
+    "sound/female/gasp2.wav": {
+     "bytes": 13098,
+     "sha256": "5197d20d971ab7a821aba1240993116260aa1ea8d446def250988a38ab9277b0"
+    },
+    "sound/female/land.wav": {
+     "bytes": 2401,
+     "sha256": "00c13d01f065a4c16c9fdc92cc276dad4f9c85f9c1053807590df1bd05d8e25c"
+    },
+    "sound/female/land2.wav": {
+     "bytes": 6170,
+     "sha256": "40faaf138e9f35a83c78658cbd69351d83307362933389a9d424a0bc7aae082c"
+    },
+    "sound/female/lburn1.wav": {
+     "bytes": 6648,
+     "sha256": "168aede56c743f00468b30cc1ce16a822449494bf9f3418354db709993b06c96"
+    },
+    "sound/female/lburn2.wav": {
+     "bytes": 6075,
+     "sha256": "3dd8440eb0a687dbde26eca6ed7c39683d4a57e947fd11fe96a77d67d5239748"
+    },
+    "sound/female/pain1.wav": {
+     "bytes": 3393,
+     "sha256": "904c369108ae32ee4ebdb243fc4a55c2624a600a640f6f84d8c81fae87e81155"
+    },
+    "sound/female/pain2.wav": {
+     "bytes": 2709,
+     "sha256": "41798682e0f27be06b4b9c73c107c407e85e2a1099ad19a2a32d785a50ec7357"
+    },
+    "sound/female/pain3.wav": {
+     "bytes": 4852,
+     "sha256": "d7325355cae34bd14688d5ddb26646071ab7c77d9d540d206a4c66d861a0b053"
+    },
+    "sound/female/pain5.wav": {
+     "bytes": 8018,
+     "sha256": "e234cac201f617772c98730be1dd0b8a92c5f121ab616f934a1124ef82c68105"
+    },
+    "sound/female/pain6.wav": {
+     "bytes": 5461,
+     "sha256": "f24da6e29287d7783d5265cfb3b20c45f2a2b7bbbc815f479a4ea1f2b5ff9fcf"
+    },
+    "sound/female/plyrjmp8.wav": {
+     "bytes": 3887,
+     "sha256": "73249e68c296d2b325faa47177f1999cee6c876dd09913b547febe8d8d445f95"
+    },
+    "sound/female/taxhit1.wav": {
+     "bytes": 9716,
+     "sha256": "98676b67336018c2122332b160ba8e5acdf1fee162f264973bcf6d96f8dad7f2"
+    },
+    "sound/female/taxhit2.wav": {
+     "bytes": 3846,
+     "sha256": "83b1402209c8d762474c47f76a9db65efb9d6745349cc75719b8640c391fa44f"
+    },
+    "sound/female/taxhit3.wav": {
+     "bytes": 5246,
+     "sha256": "128e293835ba641d5f1a697fea974ff9983253f32c3a2c3eb4086cfcb6770b8c"
+    },
+    "sound/female/teledth1.wav": {
+     "bytes": 14412,
+     "sha256": "e5e7030e3f71793d898f37c3751634b5902106b46da25f8b2be76e04352f38dd"
+    },
+    "sound/fhod/fblood1.wav": {
+     "bytes": 107744,
+     "sha256": "f8172b33d46e428b1e0c52391f950b10a88e88b2d7e3b9f96cd117a5ed7f11f9"
+    },
+    "sound/fhod/fblood2.wav": {
+     "bytes": 132024,
+     "sha256": "f2b83c3969f95697e880fc6d3f545301684b0e7c00915420778b069914677831"
+    },
+    "sound/fhod/fbreath1.wav": {
+     "bytes": 98266,
+     "sha256": "581d52ed61dae81116cec2fc8354662a5848f97a56bc9027aa143fcbf67be572"
+    },
+    "sound/fhod/fdeath.wav": {
+     "bytes": 219756,
+     "sha256": "00a3b1642eb88c2b66857d00f9e366dc0b0cc3be47a94f5b24c56f06b8568ae0"
+    },
+    "sound/fhod/fdeath1.wav": {
+     "bytes": 68732,
+     "sha256": "4f9e77bf643843bd13c5f7f979a9e0560c1b6e40bb18b84c4fe61715347e6e1b"
+    },
+    "sound/fhod/ffresh1.wav": {
+     "bytes": 113330,
+     "sha256": "8afb44d17c9bb9f46d6284738be56e3bc38293a4df61e0c85c765a9adada54c6"
+    },
+    "sound/fhod/fhod1.wav": {
+     "bytes": 127152,
+     "sha256": "a7702738727ab40767e8e8d3224d51e8adde60e0f5c47f74a89ab1c9896bf822"
+    },
+    "sound/fhod/fhod2.wav": {
+     "bytes": 133426,
+     "sha256": "628a590cb23ccd88d609d7c007ac5f2cf28addbd815c59289a3f0f2099e647be"
+    },
+    "sound/fhod/flaugh1.wav": {
+     "bytes": 63598,
+     "sha256": "bebbec68748ee34e94162410b28edc7d0171847db814583f5f6a026b25fb9cd1"
+    },
+    "sound/fhod/flaugh2.wav": {
+     "bytes": 55926,
+     "sha256": "6b66ec3fbdb847224858378cdd41643cb4102408d074a5613a198003633b1fe4"
+    },
+    "sound/fhod/fmine1.wav": {
+     "bytes": 68844,
+     "sha256": "6947547102a6548beb676ed4cfe86d9f39308e007604c11d1963aa8bea5a7e93"
+    },
+    "sound/fhod/fpain1.wav": {
+     "bytes": 95332,
+     "sha256": "9a9c0c06635ebea87b9ff53d97ac1c002c72eb4e376f7c88bdd7cf27d464053b"
+    },
+    "sound/fhod/fpain2.wav": {
+     "bytes": 78344,
+     "sha256": "1e442456ddbd36202a24de2292051cd63898c301d1cd65a773161356d0490013"
+    },
+    "sound/fhod/fpower.wav": {
+     "bytes": 75212,
+     "sha256": "db126ec1555efc7736eeac50f284eb5069851c1e761a14d828a52cac01d4e3b9"
+    },
+    "sound/fhod/fwhat.wav": {
+     "bytes": 74132,
+     "sha256": "74d0b80a4cbbf061c3cee653659430b92274ffafd448253f82b1b087013b90bc"
+    },
+    "sound/footstep/ice.wav": {
+     "bytes": 1383,
+     "sha256": "bec17d6d5e501a919178357bfd3c6d95893255fe4938328733095c301cde6c12"
+    },
+    "sound/footstep/step.wav": {
+     "bytes": 5582,
+     "sha256": "b1b67b46c69f16950c916d265e0f961bb21261651086cc3ce44fb2892a9b1902"
+    },
+    "sound/footstep/step2.wav": {
+     "bytes": 5582,
+     "sha256": "5aff67ec219562fcf3a43c50da796f51bf64455f6ee3e6875857d1aa8ce15424"
+    },
+    "sound/footstep/step3.wav": {
+     "bytes": 5582,
+     "sha256": "816bcc41605e4db11152adb23a0497f0e9f28bf3e29ea9ad382703ab4dc58a96"
+    },
+    "sound/footstep/step_r.wav": {
+     "bytes": 5582,
+     "sha256": "da8e1745f0840839bafaada8d7875908cce7ee3b679e6b6caa5690eb445acb28"
+    },
+    "sound/footstep/step_r2.wav": {
+     "bytes": 5582,
+     "sha256": "9081aa7026c951ba6d84ce440e1c775f7cbcbce08f5be8fbc322f07fa8f2c428"
+    },
+    "sound/footstep/step_r3.wav": {
+     "bytes": 5582,
+     "sha256": "6f1ffb2bee70baf517cd362dbdb127c62aa15b7a8e1fd135655b17c7c1e5d069"
+    },
+    "sound/footstep/step_r4.wav": {
+     "bytes": 5582,
+     "sha256": "9cf92bfdc253a28e71fddbb93ea72262ba75cbc19f1661df475c926ab16dd02c"
+    },
+    "sound/footstep/step_r5.wav": {
+     "bytes": 5582,
+     "sha256": "4aec47738597514c7c9740afc3712e26fc748dab5ad37c74e199ddeb1abb0e54"
+    },
+    "sound/hook/chain1.wav": {
+     "bytes": 3212,
+     "sha256": "ba4d534e96b44f34c6b4d448c4a6cc12818166cb6bca5e7a13a7ba773191f4d3"
+    },
+    "sound/hook/chain2.wav": {
+     "bytes": 3036,
+     "sha256": "1e0a90b485cfb07c100fb49a2443bb5a2fc5c33a2fd36b394e6b8520f525fbdb"
+    },
+    "sound/hook/retract.wav": {
+     "bytes": 7960,
+     "sha256": "d2da688ec5fc64f24b798b645eb80b8cdd60c6e7d44cb68a7e05e2264e1e69d5"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 6218,
+     "sha256": "df719ab9cb350ed41b9db0acb580fa40b5b07fb69f0ec0d1cbbdf347ea164a14"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 10406,
+     "sha256": "ceda8fcd85e646b83a5d0d02707f4d643350da440a3cb4c87a81bb6cd07c3735"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 7854,
+     "sha256": "ef638c00e8cda66c4e5cd3173d130b65bbdd94507892cc0db04c84bee8ae7130"
+    },
+    "sound/necro/dball.wav": {
+     "bytes": 22646,
+     "sha256": "f998a4d82f3bb7142f62acabba84b7d9d524f0f1f3b34a06121320512017c947"
+    },
+    "sound/necro/dbolt.wav": {
+     "bytes": 6054,
+     "sha256": "8a4b749e91d1d0567e906b1f7325de7047dbd16b0c11d5bae3909cd2fafed428"
+    },
+    "sound/necro/fblade.wav": {
+     "bytes": 18862,
+     "sha256": "7bbffe3726050f1c66aaada12b2afb2847901dffa4e303bcd96ca322936b09ae"
+    },
+    "sound/necro/fireball.wav": {
+     "bytes": 7064,
+     "sha256": "90d9824f715edb6333b37a3ae52a87cc87f1d2cf08c3b46ff2434ee15ab00f19"
+    },
+    "sound/necro/invis.wav": {
+     "bytes": 12326,
+     "sha256": "d37ea6c9cb3d23d80180a16468091060664903b0d42f0c2f0424b4d4a0636539"
+    },
+    "sound/necro/kontract.wav": {
+     "bytes": 40816,
+     "sha256": "7be3f25dbf14df968732e77821759d239a9b743f30a03cb98f3dcc7262bf359c"
+    },
+    "sound/necro/lavastrm.wav": {
+     "bytes": 17656,
+     "sha256": "4eb892f02ab10aabbd1969228947b02f965e01408eb549e1cfa675136d15908f"
+    },
+    "sound/necro/tele1.wav": {
+     "bytes": 13830,
+     "sha256": "e25c232e6b6d13998bcb77f12fe3d72fe5677dc5e41b6bd7cef55a6f2dd975aa"
+    },
+    "sound/necro/tele2.wav": {
+     "bytes": 15682,
+     "sha256": "e19bd5a9d4257b6e2ce2ec56b723b48a7d134d5041f80fe8c58ff90e9a605a87"
+    },
+    "sound/necro/teledrop.wav": {
+     "bytes": 3606,
+     "sha256": "6bfff9d591d572d0d695d06d8f45a0acc24cbb8e174db480ec62f422daf67085"
+    },
+    "sound/necro/zap.wav": {
+     "bytes": 2070,
+     "sha256": "0cce04c6418263727566b486b79718047e10cfc614fe51954528653152ac6699"
+    },
+    "sound/ogre/ogsawatk.wav": {
+     "bytes": 8916,
+     "sha256": "b1ae79e21fc4ff828fa7f7b8ed20898bbc7963e5b082e8a4052044938c3c0ef9"
+    },
+    "sound/ogre/spot.wav": {
+     "bytes": 7660,
+     "sha256": "a1aef7f56e0a03b3979bf260c52d0c6020d52b367956871b121c6b5d0ff0b12b"
+    },
+    "sound/outland/frenzy.wav": {
+     "bytes": 26122,
+     "sha256": "f1c93aec36c9373879b39c5a0584aa8cd964da12c14501316a46100774afab63"
+    },
+    "sound/outland/frenzyo.wav": {
+     "bytes": 25678,
+     "sha256": "74ef9151283bec63582ec4d1f1ee5b990cc57792c26440a1da86d22addbe5ac5"
+    },
+    "sound/outland/sound.wav": {
+     "bytes": 17004,
+     "sha256": "48b302cb613acf47132defaad8085fc2241cfa5be8b8a4b154a6861bb20b809a"
+    },
+    "sound/plats/plat1.wav": {
+     "bytes": 10814,
+     "sha256": "4d5a597b3d88826244b85828637837148477d8f9f7d77c626d5895662b16125c"
+    },
+    "sound/plats/plat2.wav": {
+     "bytes": 10174,
+     "sha256": "03690085e08259283f6960f2fecaa709ba6f75608f94d00f8c7cb316c56508ff"
+    },
+    "sound/player/bstab.wav": {
+     "bytes": 3344,
+     "sha256": "87ad10d8945cd09f1130f9a2edba360658ab844c7c90b1b6258b6dcb0e6f1004"
+    },
+    "sound/player/death1.wav": {
+     "bytes": 66860,
+     "sha256": "5f95c3559800ee5e588be4a5c500b5b5c956ace442c16462d376a17712eb1dc5"
+    },
+    "sound/player/death2.wav": {
+     "bytes": 51756,
+     "sha256": "5f60c16a656900a4596de2125a751b5c49723906bbd017f695c8bda0a2bb83e7"
+    },
+    "sound/player/death3.wav": {
+     "bytes": 44844,
+     "sha256": "0296bb8d050042a92a83eddc6ba9dd5a164b235bcfb2d47b7925654475c394e1"
+    },
+    "sound/player/death4.wav": {
+     "bytes": 40236,
+     "sha256": "544d71433f24978278775ff081376024188b1265e398248565c9b2f067b1f448"
+    },
+    "sound/player/disease.wav": {
+     "bytes": 12360,
+     "sha256": "0d25d12de95d892f0f5f893ea9f270f0b555a61cfa598aeb990d66b979e11f88"
+    },
+    "sound/player/dreg.wav": {
+     "bytes": 2324,
+     "sha256": "cdfe216baf223c8f0bf3d556beba0ded083933f588f73d403341d5581d28f5fa"
+    },
+    "sound/player/echostep.wav": {
+     "bytes": 12390,
+     "sha256": "39c155fea3765445b1bcb18a7a869b3e462fba516c4a7cf19ccfd6059149b1f7"
+    },
+    "sound/player/frenzy.wav": {
+     "bytes": 11434,
+     "sha256": "a3e1aef3699878f9a4d16c4c3374e15697cc2bbf72dac6a3dfec0dc450b85e84"
+    },
+    "sound/player/frenzyof.wav": {
+     "bytes": 25782,
+     "sha256": "901242b8ead822d2e8b43fcbf70802f0e36f029203b08fe999afce37e15709f8"
+    },
+    "sound/player/frenzyon.wav": {
+     "bytes": 25782,
+     "sha256": "4ea77efaf5f2891f4d1859080c19bae4e2cd3f7101021b5043e376e71e2288fd"
+    },
+    "sound/player/gainlvl.wav": {
+     "bytes": 34196,
+     "sha256": "cd9e50ae104aa84071e5488fdf3b70c2be205122e8870a663b6e7e58f9128302"
+    },
+    "sound/player/l_step.wav": {
+     "bytes": 5582,
+     "sha256": "ab3163dfb9c809f4f76a722f410b7f574c1441fff867f63340c2f07a4332098f"
+    },
+    "sound/player/l_step2.wav": {
+     "bytes": 5582,
+     "sha256": "de521d430907762648462155c8a38223b350c92599ebf0ddef23bbd03c2ae32a"
+    },
+    "sound/player/loselvl.wav": {
+     "bytes": 23730,
+     "sha256": "04fd0caeae25a4e2add96a5d7a20cbe0d542d8eb5821cde575bbabf04bda5e3b"
+    },
+    "sound/player/noecho.wav": {
+     "bytes": 11068,
+     "sha256": "6dcb67b1195007501e75a7af4ed8524aed8dfc81350aced304fedf1d31030f09"
+    },
+    "sound/player/p_step.wav": {
+     "bytes": 3228,
+     "sha256": "48a5aa1a55769944d8e75138e40bd6b7e311def1a767d8d0dd086c22073f51b0"
+    },
+    "sound/player/p_step2.wav": {
+     "bytes": 3228,
+     "sha256": "48a5aa1a55769944d8e75138e40bd6b7e311def1a767d8d0dd086c22073f51b0"
+    },
+    "sound/player/poison.wav": {
+     "bytes": 20874,
+     "sha256": "227e573822d210129c50ceb6deb7f58e29318bd1542cbf6f36e79cef86ac5c0f"
+    },
+    "sound/player/step.wav": {
+     "bytes": 3092,
+     "sha256": "b60831efe8ec9ac839639276b43f510ea2a984de43106e0f65bc2884a95d0f0c"
+    },
+    "sound/player/step2.wav": {
+     "bytes": 3092,
+     "sha256": "4a82a7e0949b84392ae0e2f551b5baaf0e471d611fdc736acfe3be80c195f29d"
+    },
+    "sound/player/swim1.wav": {
+     "bytes": 14521,
+     "sha256": "f5a5a1f1c9e058fb9f5ed4f41c4bff82450279b96cd63c296d62e5d8ff4c7d7f"
+    },
+    "sound/player/swim2.wav": {
+     "bytes": 15041,
+     "sha256": "98a87abe260089f5ab4c0160a45843164d1acc29a5f54b7a9d94624a1cf614de"
+    },
+    "sound/reap/reapara.wav": {
+     "bytes": 5632,
+     "sha256": "c151a3cf537f5c3668fc116e6ef5c70c9286e8a12097f376ecdf8a04774926a1"
+    },
+    "sound/reap/reapawre.wav": {
+     "bytes": 16832,
+     "sha256": "9710267844facf1c627ea0a8f0df458d847eb899dccd9c570e9d967acc64fa07"
+    },
+    "sound/reap/reapdth.wav": {
+     "bytes": 10761,
+     "sha256": "7f32e12c649aa4fc4c2edb773c45b6b4258d048176d95e060390834ee7b52493"
+    },
+    "sound/reap/reappain.wav": {
+     "bytes": 12684,
+     "sha256": "f332a8cdf67fe414966f59d46714154c94de7ebcca3880a47ef5bbdad2c03ef0"
+    },
+    "sound/reap/sword1.wav": {
+     "bytes": 15982,
+     "sha256": "d36670980603c18a67d500707de9db5a8d54128601d6a6c67f7f29677244aebc"
+    },
+    "sound/reap/sword2.wav": {
+     "bytes": 12434,
+     "sha256": "f7730881c690e0ee6a440756f74630a21241239fd1fd3bbdfd88000c7e57d1cc"
+    },
+    "sound/rogue/died.wav": {
+     "bytes": 24492,
+     "sha256": "3ce14cdac970a150f567dbd07cf1763f695245c34f5bf4e31ec07bfeb232db30"
+    },
+    "sound/rogue/ha.wav": {
+     "bytes": 2708,
+     "sha256": "ba2108ad5070860873887308293efd3a9635a6c4dcb3fb39357a9e16f89f97b5"
+    },
+    "sound/rogue/hiyaa.wav": {
+     "bytes": 36876,
+     "sha256": "1446e8afbfdf48a08ca6727604b33585efdd67a6d14b4b1c96bb05c6ccd5ac3a"
+    },
+    "sound/rogue/kungfu.wav": {
+     "bytes": 29008,
+     "sha256": "025b6eed19d193bd6be4c4f8f2bc7b9fb14e5c127257e570fd9fc98fd464f2a3"
+    },
+    "sound/rogue/ohdju.wav": {
+     "bytes": 12588,
+     "sha256": "346d38c12edad612ec4915d3361ebfbb81b06bee9cdb73eb9b9e0d2cc2ea6d10"
+    },
+    "sound/rogue/tchak.wav": {
+     "bytes": 10166,
+     "sha256": "f77d88ab76f7a092a7a5d40fb0aaf9530dc6da8e45559fcf1a1b5ea2aa88029b"
+    },
+    "sound/weapons/axe5.wav": {
+     "bytes": 7767,
+     "sha256": "1dd8f35a510a31ed905d21ad1ece4bdd9d0a115573817a7b222d78c263a9724e"
+    },
+    "sound/weapons/blund.wav": {
+     "bytes": 17592,
+     "sha256": "a142ad8e8ccc7c86ace43a15de7549b815a482dc6ee4a34e5d1b4e4d7b004b24"
+    },
+    "sound/weapons/bounce2.wav": {
+     "bytes": 7960,
+     "sha256": "d2da688ec5fc64f24b798b645eb80b8cdd60c6e7d44cb68a7e05e2264e1e69d5"
+    },
+    "sound/weapons/bow.wav": {
+     "bytes": 5276,
+     "sha256": "64e183f35ac14d5c918e35adb997443370d82fec5f687309d81221d6025ba6b8"
+    },
+    "sound/weapons/bowhit.wav": {
+     "bytes": 4452,
+     "sha256": "48038121b7b8d24aec7fb8b2f6a48e761a0cabe6c107dc3d87b45011704bb425"
+    },
+    "sound/weapons/c_cock.wav": {
+     "bytes": 19114,
+     "sha256": "4bb73eb7161ba561970e8f2e7f5aad0e42b3419fe2b02a5953a7289c46d1442b"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 3368,
+     "sha256": "2b62c292f87665f9b6dbbc716c24875e67d4206c548440b79443a14fa9ee7ba8"
+    },
+    "sound/weapons/chain2.wav": {
+     "bytes": 3192,
+     "sha256": "e0991b1a92351720cf85030db91bb1a896c5aa3f7ed01bcb73c7534ca798b32e"
+    },
+    "sound/weapons/chain3.wav": {
+     "bytes": 6172,
+     "sha256": "cc1bdca575e0dd0fe1986fe590b85f6c27dca84a3de89e20306e61c4677686fd"
+    },
+    "sound/weapons/click.wav": {
+     "bytes": 4452,
+     "sha256": "48038121b7b8d24aec7fb8b2f6a48e761a0cabe6c107dc3d87b45011704bb425"
+    },
+    "sound/weapons/click5.wav": {
+     "bytes": 7442,
+     "sha256": "d295bd35a8b0a8dccfeddddc8a98b243de885553490a870cb268e0f7898c9c61"
+    },
+    "sound/weapons/cock.wav": {
+     "bytes": 5120,
+     "sha256": "b0ef85c2fd8a34cde10fb65717c5d5eadbd0a35d7c026800994603b018ea6ff1"
+    },
+    "sound/weapons/crossbow.wav": {
+     "bytes": 9354,
+     "sha256": "da48c791fd4306762a4e0970dbc5db401881f123e73b654a04b4eee52ce5e8a2"
+    },
+    "sound/weapons/fax.wav": {
+     "bytes": 2398,
+     "sha256": "1871c91b84565d275f10dc48700ff31af1910b0be3147ae38a67d62d4938a042"
+    },
+    "sound/weapons/faxhit1.wav": {
+     "bytes": 18832,
+     "sha256": "0c1a987008316496e37bec75d9984904e981f7500946338d69cf5ecd9100f1eb"
+    },
+    "sound/weapons/faxhit2.wav": {
+     "bytes": 7288,
+     "sha256": "b7a8f08ea354030fb97ceeb83be11b134b0d7608edb246a64f008a41d5df5669"
+    },
+    "sound/weapons/faxhit3.wav": {
+     "bytes": 10072,
+     "sha256": "2219a07ee8187df766a10688854a21e4471ac49752bcf8900234d6471f62f578"
+    },
+    "sound/weapons/firehit.wav": {
+     "bytes": 4648,
+     "sha256": "6f000f6020eaa4e951e10d4bc1e1960aefc42747a5abf3121005d3678ff2a0ef"
+    },
+    "sound/weapons/fl_axelt.wav": {
+     "bytes": 18862,
+     "sha256": "7bbffe3726050f1c66aaada12b2afb2847901dffa4e303bcd96ca322936b09ae"
+    },
+    "sound/weapons/fl_axesw.wav": {
+     "bytes": 4920,
+     "sha256": "6a5697e1dd9eca555bfda713101cdda800065e201f00ca333796f1bd4e7217ae"
+    },
+    "sound/weapons/flo_axe.wav": {
+     "bytes": 19754,
+     "sha256": "917df2d397e31969872d44eec6d1921cc275ec22d254984a9e9ea40760a31ded"
+    },
+    "sound/weapons/gotcha.wav": {
+     "bytes": 7374,
+     "sha256": "e17abe393fd473c69b202286c2ae3079a32f90504a5292bc5e9e38888ed07cc1"
+    },
+    "sound/weapons/hiss.wav": {
+     "bytes": 6576,
+     "sha256": "82593fdd5be8198a9774c163872f89a088d8d0ca10e91f1c8f846ecac92b2d81"
+    },
+    "sound/weapons/lock4.wav": {
+     "bytes": 2152,
+     "sha256": "7d0e461ed9583f9d74b92fb98bebdafe9cc29be19cfcf31528c8c29c1ad6832f"
+    },
+    "sound/weapons/pkup.wav": {
+     "bytes": 6052,
+     "sha256": "50ab3907e8bec4097151ed68a70f8f921d32433e96375cedc7e67b4509f2a194"
+    },
+    "sound/weapons/record.wav": {
+     "bytes": 154380,
+     "sha256": "5a9110534efbd83e27941f5e64f639be894873cf9ce97fba448ed2faea485a03"
+    },
+    "sound/weapons/ric1.wav": {
+     "bytes": 4452,
+     "sha256": "48038121b7b8d24aec7fb8b2f6a48e761a0cabe6c107dc3d87b45011704bb425"
+    },
+    "sound/weapons/ric2.wav": {
+     "bytes": 4452,
+     "sha256": "48038121b7b8d24aec7fb8b2f6a48e761a0cabe6c107dc3d87b45011704bb425"
+    },
+    "sound/weapons/ric3.wav": {
+     "bytes": 4452,
+     "sha256": "48038121b7b8d24aec7fb8b2f6a48e761a0cabe6c107dc3d87b45011704bb425"
+    },
+    "sound/weapons/shget.wav": {
+     "bytes": 5824,
+     "sha256": "51e8b50d4919802bebd6e639f75e7a758343b7cdd22db84cbd1f84a9ae0e6a0d"
+    },
+    "sound/weapons/sword1.wav": {
+     "bytes": 3520,
+     "sha256": "fbfab1024211abf7c3d321223541ea120316ace967f003bec94a13239808581c"
+    },
+    "sound/weapons/sword2.wav": {
+     "bytes": 4360,
+     "sha256": "2e320c772af109c9db5c52934966ee8f1b74187e7124bb9455478890828a1890"
+    },
+    "sound/weapons/sword3.wav": {
+     "bytes": 4854,
+     "sha256": "eb3712d9b9cdf2a2ea78dac3444bbb818162c8d1f6f231bc6d55010f64c7ac3c"
+    },
+    "sound/weapons/taxhit1.wav": {
+     "bytes": 17908,
+     "sha256": "5b829a67960deef482abc122a0a7d8e904964d4dc543e6ec6bb3c1c56da897e6"
+    },
+    "sound/weapons/taxhit2.wav": {
+     "bytes": 6110,
+     "sha256": "be834cb36fd503538366c9d76b99ca04530d7990b32339b15dda107703649193"
+    },
+    "sound/weapons/taxhit3.wav": {
+     "bytes": 8950,
+     "sha256": "453ce31c9e11a263c4d2a777099f9b20a9c19718a5fb3ec039f99704e9182f16"
+    },
+    "sound/weapons/tink1.wav": {
+     "bytes": 4452,
+     "sha256": "48038121b7b8d24aec7fb8b2f6a48e761a0cabe6c107dc3d87b45011704bb425"
+    },
+    "sound/weapons/woosh.wav": {
+     "bytes": 3509,
+     "sha256": "792d48054621be14516a1e176819457b6da97082a8166400681bfc33c25c56f7"
+    }
+   },
    "sha256": "20026ae64fb1db833535aca19fa7a25af7aeceb840d580441e5f78b236ec47a3",
    "timestamp": "1997-12-21T18:13:20.000Z"
   },
   "fq/pak1.pak": {
    "bytes": 38214824,
+   "files": {
+    "maps/cornwall.bsp": {
+     "bytes": 1786360,
+     "sha256": "f8ec0743a4257e1b5a7a74f0fcee00c1d0a737d20ef69e0ee188e10ac807ab77"
+    },
+    "maps/file_id.txt": {
+     "bytes": 747,
+     "sha256": "65bdcfd5052a99b9690d6b577d3e9b12be265cd1a40162c079f387b7493367b6"
+    },
+    "maps/fqdm1.bsp": {
+     "bytes": 733368,
+     "sha256": "9ec2963e2033c373fa72aa4f29141f77de8e913abe11298072b9c5f346c99bc2"
+    },
+    "maps/fqdm2.bsp": {
+     "bytes": 1227177,
+     "sha256": "2f76dd1e00b02131bc86e3f2c4bb9e3a14e4f9d835919397c36f8e667d6f46d7"
+    },
+    "maps/fqdm3.bsp": {
+     "bytes": 1148788,
+     "sha256": "1a64b83831aba6818cb6641d2c3f2a4cf0577231f6ea2e2c67fdcf97ad688412"
+    },
+    "maps/fqdm4.bsp": {
+     "bytes": 1583106,
+     "sha256": "fc0b0a033173e3bdce390d76cdd4c750fe8f18cd08c53be810760d108d27b8e9"
+    },
+    "maps/fqextra1.bsp": {
+     "bytes": 1776326,
+     "sha256": "5ef41a3a756fbc76f9ee71dea2535b1e1f4f2379c3b669398ed680d5d3f9ec86"
+    },
+    "maps/fqextra2.bsp": {
+     "bytes": 1775124,
+     "sha256": "43fe4bb9b24b71a349fcde86a9386a36737fb3b5b2ec8ff40cd5bf7341605b32"
+    },
+    "maps/fqextra3.bsp": {
+     "bytes": 1530226,
+     "sha256": "bdc9ca255c6f5708b2b661edede599e5d13daaed5fdcd6f9ab8611742383b6de"
+    },
+    "maps/fqextra4.bsp": {
+     "bytes": 1774727,
+     "sha256": "61cdae7cf9b5fada3fad5c74a9a2ff30942f6fcd9f80d3f3ffb217381f18932e"
+    },
+    "maps/fqfhod.bsp": {
+     "bytes": 508824,
+     "sha256": "34db534ad1c583f291ffcc449d87cc3cc9f694ef0d67ed2f7ab0103a90ed0539"
+    },
+    "maps/fqrotp1.bsp": {
+     "bytes": 1475624,
+     "sha256": "6a27e6ac3f3796aea19718b0e65bbda3a1cc56851bdd082fce6c90a976621c24"
+    },
+    "maps/fqrotp10.bsp": {
+     "bytes": 898336,
+     "sha256": "4e1055c14da5bd17dd5c3f6c9fc3c2cd444701a2f4f2e9c4198cc40c77fb19e8"
+    },
+    "maps/fqrotp11.bsp": {
+     "bytes": 1993652,
+     "sha256": "216baee198e1a4713d0029c09a41acd59e395dddc83566c1620d79bcf0eca2cf"
+    },
+    "maps/fqrotp12.bsp": {
+     "bytes": 1302740,
+     "sha256": "4586415b1c5675ab3598810823cd52303404deb431c3dec27dd3ed77628878c4"
+    },
+    "maps/fqrotp13.bsp": {
+     "bytes": 1190632,
+     "sha256": "a03b7f948ec24c5b16aa093f624e050cf579ae4614c5dab452b8b315147c3fc3"
+    },
+    "maps/fqrotp14.bsp": {
+     "bytes": 1147876,
+     "sha256": "2734848d98af7230d269bb7b259bb7eec536c426baf76199f85b23aab30063d8"
+    },
+    "maps/fqrotp15.bsp": {
+     "bytes": 1952696,
+     "sha256": "473c92923273d0d5353609ce9c70ec5551753ece2605ccb2b8a5a2ad52c5664d"
+    },
+    "maps/fqrotp1s.bsp": {
+     "bytes": 878037,
+     "sha256": "d880f75010b373a09df58f1bc65cc8098800487e1278e3063b07b1abce1ba3b5"
+    },
+    "maps/fqrotp2.bsp": {
+     "bytes": 1500800,
+     "sha256": "2bca103b2503c3a500b35ebfa6d5134c36352971acd9417ec54f14c6d0b55547"
+    },
+    "maps/fqrotp3.bsp": {
+     "bytes": 675473,
+     "sha256": "2ec6dc0531b53ce79e7562abb42a04771b97d9c48b346fe0712f43aed41c6682"
+    },
+    "maps/fqrotp4.bsp": {
+     "bytes": 1435472,
+     "sha256": "a5ee9ca1ce5ba99fd84a8945c623ec74a631b6f1ce3e47c7ee31982356afa4c3"
+    },
+    "maps/fqrotp5.bsp": {
+     "bytes": 1427215,
+     "sha256": "a9d446b4f6f875e11dfef001cccf2d4840f7cc60a46a62df2ad85d2e3f81cc92"
+    },
+    "maps/fqrotp6.bsp": {
+     "bytes": 1473042,
+     "sha256": "2941c7f7d6848d4a85acf4a1e029d953277b7bcb93570a748e7844e8895e2e73"
+    },
+    "maps/fqrotp7.bsp": {
+     "bytes": 1625287,
+     "sha256": "40a5c8084bf7f3aa5dca828555c506da0370e381569b63fad0957f936344219c"
+    },
+    "maps/fqrotp8.bsp": {
+     "bytes": 1403801,
+     "sha256": "98b9006280bd2f8f476e261f56cb290c6a19df0a6453e7cabb5771541aa45305"
+    },
+    "maps/fqrotp8a.bsp": {
+     "bytes": 1374352,
+     "sha256": "72065adf6107ae54ecca1b46fa239266a56c5a29f5e36d1506e387906108cbe3"
+    },
+    "maps/fqrotp9.bsp": {
+     "bytes": 1074524,
+     "sha256": "07a0bd0612b4195c2767f21ab4186263043a2627a57d016a5739f9a0ae7e41b3"
+    },
+    "maps/fqrotp9s.bsp": {
+     "bytes": 540896,
+     "sha256": "41f729a759282c379709eb2ba0e473bdbb5fba58a094f2e6cde5d18255c82de4"
+    },
+    "maps/fqrotpst.bsp": {
+     "bytes": 997600,
+     "sha256": "3136fc93a6b79ab1a7cc44457e74c3a96f5a9d17946a15398e17f0271c28065a"
+    },
+    "maps/temp.tmp": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+   },
    "sha256": "0451206154d5ad7f013dc7ca72b9da3827231f3aba3163345c7855d964c10643",
    "timestamp": "1997-12-21T12:01:52.000Z"
   },

--- a/json/by-sha256/50/504984de0206082e0bd15ad5d136ca99ea9fb9bf2f8733569c2fddc909cd8ec7.json
+++ b/json/by-sha256/50/504984de0206082e0bd15ad5d136ca99ea9fb9bf2f8733569c2fddc909cd8ec7.json
@@ -514,21 +514,9765 @@
   },
   "rotj/pak0.pak": {
    "bytes": 270100152,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 94990,
+     "sha256": "1fddba1dadd3adef5e0f13d716e514c131455c51b26c2291f71dea0eada7b97e"
+    },
+    "effectinfo.txt": {
+     "bytes": 157535,
+     "sha256": "8dbc7cf30b0bef166f0ce58a59c0f3ce1dcadd9a13867f8430541793fd723cf8"
+    },
+    "effectvanilla.txt": {
+     "bytes": 4612,
+     "sha256": "efd47c12bf71b377f3e750f46d5e242b3337ece446ba9a44cc0750a9bbf9c758"
+    },
+    "gfx/ad_blank.lmp": {
+     "bytes": 584,
+     "sha256": "37b5a1e7d0b3882eb7504e3626f8040a19a6d403e0e761dccd65db935401144f"
+    },
+    "gfx/ad_ibar0a.lmp": {
+     "bytes": 2568,
+     "sha256": "7a66fbbaa742e59d3fdd939ce35befa0f633492482912f4fa91f16d0788276e6"
+    },
+    "gfx/ad_ibar0b.lmp": {
+     "bytes": 5128,
+     "sha256": "5a955a32f0227e4d3e90e908e650c7dc53138b5db2d5bcb3eb4a14fe5c568760"
+    },
+    "gfx/ad_ibar1a.lmp": {
+     "bytes": 4616,
+     "sha256": "eb1c6337becc5c245b873b3d9a6ba5e9c458147f48826a4580ea0ffdf57e9759"
+    },
+    "gfx/ad_ibar1b.lmp": {
+     "bytes": 3080,
+     "sha256": "34e3eec992a3f567d4ac83c98d5fc53ca0a90c02764d45a40eea08d2f94c733b"
+    },
+    "gfx/ad_ibar2a.lmp": {
+     "bytes": 4616,
+     "sha256": "eec2d035f2857fc03083ccf0384ac6446f71b1aa45ed0e2409b8d4ba42c135f6"
+    },
+    "gfx/ad_ibar2b.lmp": {
+     "bytes": 3080,
+     "sha256": "17c35d1d02833d1fe900b1c2beaf77ffe1948a3f17ae790e9f0da1c1057b460c"
+    },
+    "gfx/ad_ibar4a.lmp": {
+     "bytes": 3080,
+     "sha256": "2507c6ce0a53ed62ce73b1bb0ee7e76e9c245757dee54415aeef78767bace887"
+    },
+    "gfx/ad_ibar4b.lmp": {
+     "bytes": 3080,
+     "sha256": "d977ecb360eff9b19827e956d32687234bed64f830adc5e506334a597daa7eaa"
+    },
+    "gfx/ad_ibar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "9d0d2c1eb7e665d0a28130bed09fb8bd698a6a1b246842fa353e3b0e1f5b445d"
+    },
+    "gfx/ad_ibar5b.lmp": {
+     "bytes": 4616,
+     "sha256": "26902c5879207315a7b732e8799f95bdcd45801a8086a902371808a594fa5515"
+    },
+    "gfx/ad_ibar6a.lmp": {
+     "bytes": 7688,
+     "sha256": "cfcce1c48cda88ccd405b1398576476bae52b3cdf7154a0b902a47655dd282cd"
+    },
+    "gfx/ad_ibar6b.lmp": {
+     "bytes": 7688,
+     "sha256": "49487400a56db767d37656f8ccb9e1660f470d8f989619a86bec5c296dcb77f9"
+    },
+    "gfx/ad_ibar7a.lmp": {
+     "bytes": 6152,
+     "sha256": "0d4ababef9a115ca7f6739a01d288d237e22a859ee16c5682d97dcabc4d7aa0b"
+    },
+    "gfx/ad_ibar7b.lmp": {
+     "bytes": 5832,
+     "sha256": "f9292e8d1fff09bde28baf932f11617e27247d4e9af191b89c30811e92110bca"
+    },
+    "gfx/ad_ibar7c.lmp": {
+     "bytes": 4104,
+     "sha256": "0e77dc6602c4945d5d4ec2a12f8003173430945bf7891d979c3c80b0c9212b40"
+    },
+    "gfx/ad_ibar_cell1.lmp": {
+     "bytes": 392,
+     "sha256": "5a4409731e4302bca5245f385a1cab9b91e0a2677d52336bbe3650fdcf070b05"
+    },
+    "gfx/ad_ibar_cell2.lmp": {
+     "bytes": 72,
+     "sha256": "6a519b1e8eed1d7a5365231162fcf1beaf31a6fd1c39b07de09bb0e66dc38303"
+    },
+    "gfx/ad_ibar_nail1.lmp": {
+     "bytes": 392,
+     "sha256": "850189c70ac92f3e8ee79ed9ff6e31ee73d33b5616964461373b37e3a29e60b6"
+    },
+    "gfx/ad_ibar_nail2.lmp": {
+     "bytes": 72,
+     "sha256": "b36d5196c807c6325816db9efad9a16fd7e38433f277b0ad9e6d3551f95c0ceb"
+    },
+    "gfx/ad_ibar_rock1.lmp": {
+     "bytes": 392,
+     "sha256": "f74ce0037116022557ec3a50d368442e73cb48492990a07e93503ad9aeeaa225"
+    },
+    "gfx/ad_ibar_rock2.lmp": {
+     "bytes": 72,
+     "sha256": "081911a352b3d75a4be7812082eee782c41127e70bc4a06585b163d385230a65"
+    },
+    "gfx/ad_ibar_shell1.lmp": {
+     "bytes": 392,
+     "sha256": "733750fbc8235b236f7a2a4246d6112c0a09ce2f75529e359382e25dab92ee10"
+    },
+    "gfx/ad_ibar_shell2.lmp": {
+     "bytes": 72,
+     "sha256": "22fc2a46e85e76836fa38db9868820322833b45e0473407d69378dc09b43e9a5"
+    },
+    "gfx/ad_sbar0.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar1.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar4a.lmp": {
+     "bytes": 4616,
+     "sha256": "5ecbd1e480e4c04e2efe956dcd49e609f0c5a2038f03759b9af848b3cf7dd613"
+    },
+    "gfx/ad_sbar4b.lmp": {
+     "bytes": 4616,
+     "sha256": "8fdfe5e6ffba2c209386580adc196acce9d5601fb529f651267e7186610cc392"
+    },
+    "gfx/ad_sbar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "40c7f9e7ba975d500d3861d0c5a7e592da1ce09fdc31583488fd4c78d823e20e"
+    },
+    "gfx/ad_sbar5b.lmp": {
+     "bytes": 2312,
+     "sha256": "86ff0d9678a52e5428089afe0bb9cdddc9f7688798cee45a396e4d13bf00b60d"
+    },
+    "gfx/ad_sbar6.lmp": {
+     "bytes": 9992,
+     "sha256": "5b47dbc1ae645c429627f563355c43b1fb9145d195d02606d0a7a49791034a28"
+    },
+    "gfx/ad_sbar7a.lmp": {
+     "bytes": 3464,
+     "sha256": "8773683e2edb20dfdea61775d6f955a766a15b7b733ae07212dec922d853f6ba"
+    },
+    "gfx/ad_sbar7b.lmp": {
+     "bytes": 3528,
+     "sha256": "1103f097b9896700ef5a722df927cbe71c76531a09eda9e55e5702d3b4d3b370"
+    },
+    "gfx/ad_scorebar0.lmp": {
+     "bytes": 7688,
+     "sha256": "7c479c4969b9f437c57d710edbdd6b2ce1936aa95adb559c9dd3048680868cdb"
+    },
+    "gfx/adf_1.lmp": {
+     "bytes": 584,
+     "sha256": "5b1b35dc96ad9c2f62602caab6be13d8698fe6cc14865293d11c6b9eee64dd51"
+    },
+    "gfx/adf_2.lmp": {
+     "bytes": 584,
+     "sha256": "8cbc05801d49423bd5f14bd459e8ed5cff7841e7f2d5e44d0f4dfe0f0f7ee851"
+    },
+    "gfx/adf_3.lmp": {
+     "bytes": 584,
+     "sha256": "f0155a41ad9290c8df9fabe0faae6dde4d04772dd2a425653766ec36da76140f"
+    },
+    "gfx/adf_4.lmp": {
+     "bytes": 584,
+     "sha256": "d74c9370ce323ffdc9c3dd124dcbbf9c15fc94e58e20d15789975dd8701a74da"
+    },
+    "gfx/adf_5.lmp": {
+     "bytes": 584,
+     "sha256": "f97a78ede874ff45176e5bb85abdbed93e22dab28bc0965065927c7b215ea36f"
+    },
+    "gfx/adf_evil.lmp": {
+     "bytes": 584,
+     "sha256": "42445b083abae6e9f4ff009efd7a38d2ddd664ac5e47f97ad30c88a603c64c35"
+    },
+    "gfx/adf_evilinv.lmp": {
+     "bytes": 584,
+     "sha256": "ff0d8b9203d7cfae6d075ef5bfad60cdcf66b1e24bb6fd02be0cada1b7f1c82f"
+    },
+    "gfx/adf_evilpent.lmp": {
+     "bytes": 584,
+     "sha256": "0b0029bc964ed68f1b46ccf0b4bd5e527e33e76c0904a1d06e623c47ca589e56"
+    },
+    "gfx/adf_evilquad.lmp": {
+     "bytes": 584,
+     "sha256": "a511796cca84df8149ea6d3d280880e425fdd486315159462168d32f06a17822"
+    },
+    "gfx/adf_inv2.lmp": {
+     "bytes": 584,
+     "sha256": "a6caf84d4e2c125e80aefb51aaa1af707ccf689e641141dd3736f101a66c8fa0"
+    },
+    "gfx/adf_invis.lmp": {
+     "bytes": 584,
+     "sha256": "70117297f381fd1778e5d26e5b832af86c6013ca9a55632c24c057e0aaa1e48f"
+    },
+    "gfx/adf_invul1.lmp": {
+     "bytes": 584,
+     "sha256": "453b67ccc01b32101e1051a9407b84b5c93416ae30c3b3200e25b96868c3f6e5"
+    },
+    "gfx/adf_invul2.lmp": {
+     "bytes": 584,
+     "sha256": "c70f600538aa1d1cc121ea76602e564d0af5ce5ea67a2c1ba01ac5fe44439bd4"
+    },
+    "gfx/adf_p1.lmp": {
+     "bytes": 584,
+     "sha256": "f6da35fd9699239c060f034738615ecead6111294a419a82e503bdbdd9ed46b1"
+    },
+    "gfx/adf_p2.lmp": {
+     "bytes": 584,
+     "sha256": "431539dd9656e09c6d4007c86bad37c30447e596575d803619b14371329f9acb"
+    },
+    "gfx/adf_p3.lmp": {
+     "bytes": 584,
+     "sha256": "b832a2d2143805f8701eec7eec465d67fa692e2e87714e87fa3ac3a2c2682659"
+    },
+    "gfx/adf_p4.lmp": {
+     "bytes": 584,
+     "sha256": "40f6d70d3ebf248c1c38e90b95cec42516b3a61fd17bd866df964af8e657487f"
+    },
+    "gfx/adf_p5.lmp": {
+     "bytes": 584,
+     "sha256": "d7d4768f7324d1eca2b8cb95fd250d8c6065dcfc5c392c6f2bc6adc8c2a7579a"
+    },
+    "gfx/adf_quad.lmp": {
+     "bytes": 584,
+     "sha256": "da9a83f464049832cd049205a22d832a228b00cbd0d1e7e24d347d5ed34c4ffb"
+    },
+    "gfx/adib_atank.lmp": {
+     "bytes": 264,
+     "sha256": "8d963c818c0554d73d14b251eeed0321cf854777f29eddf5a82ee3fb3fde8035"
+    },
+    "gfx/adib_axe1.lmp": {
+     "bytes": 264,
+     "sha256": "90b6817aa64570e9bfc36a13e6dd1930e81468f931ceac9f2ae3790f99f2dca2"
+    },
+    "gfx/adib_axe2.lmp": {
+     "bytes": 264,
+     "sha256": "2b0821038185e41c711e399dcfff37fd54aa8f7473ba81754c379fae558a5a1d"
+    },
+    "gfx/adib_bbelt.lmp": {
+     "bytes": 264,
+     "sha256": "8b50ea739ca8ab52baefe65f90ea5943fcc4f05b63b214a36b3ae6fa4feb55a8"
+    },
+    "gfx/adib_ckey1.lmp": {
+     "bytes": 136,
+     "sha256": "8525e145fdc72947ac6d4599ae0304b84793475d44f0113c925905d715c2da8e"
+    },
+    "gfx/adib_ckey10.lmp": {
+     "bytes": 136,
+     "sha256": "a2e14b68c10109e48e86bd095775beb68f03640dfdb12d1c28b6d32abd1fa329"
+    },
+    "gfx/adib_ckey11.lmp": {
+     "bytes": 136,
+     "sha256": "2b9191d85075d6a6c06d8b295c48546ecc0bd1c91a860308f6f953dcf324604c"
+    },
+    "gfx/adib_ckey12.lmp": {
+     "bytes": 136,
+     "sha256": "9b04f101468d96f4c39d97da0be44f7152179e4a8d6a05762ca693c9f84db317"
+    },
+    "gfx/adib_ckey13.lmp": {
+     "bytes": 136,
+     "sha256": "35fa377dbf162d691de012a61458b5ec29c28b776cd3ee0e0f9ab0ad57b67c8f"
+    },
+    "gfx/adib_ckey14.lmp": {
+     "bytes": 136,
+     "sha256": "ea6b831467c97fb0ba18d97a549c54304b133830e1567ae300e83514bdbb2919"
+    },
+    "gfx/adib_ckey2.lmp": {
+     "bytes": 136,
+     "sha256": "5c80cec0c7808ed141fff4f6863eccfa71b06a7405e871c75912d5d065b4ff21"
+    },
+    "gfx/adib_ckey3.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adib_ckey4.lmp": {
+     "bytes": 136,
+     "sha256": "51ea09fa8db26de3ce6ea6c1a5abecf4c31c3877ab6c508811ea9b271f40f1fc"
+    },
+    "gfx/adib_ckey5.lmp": {
+     "bytes": 136,
+     "sha256": "e03ed662e981530264f6dcf6f6dda91fd8406c0941d0f7c4370a89e0c4f467bc"
+    },
+    "gfx/adib_ckey6.lmp": {
+     "bytes": 136,
+     "sha256": "6f4f61addc77e3492c08cd382291eaf3f8c28a7499137591dcd2c6706bb1ec57"
+    },
+    "gfx/adib_ckey7.lmp": {
+     "bytes": 136,
+     "sha256": "38c3473948f4769e4309bdbb390afd0663fc093f1f76c9fbf10d818c6f89c72b"
+    },
+    "gfx/adib_ckey8.lmp": {
+     "bytes": 136,
+     "sha256": "d0c43a81abfb623b7c3392a07b484b6bf9137fede67d78dc67864848ecbc1c12"
+    },
+    "gfx/adib_ckey9.lmp": {
+     "bytes": 136,
+     "sha256": "042cdb7aef3e06a5679158b4f33fc66ca2d97dd6cf9e7e2657b1e85e444ed006"
+    },
+    "gfx/adib_invis.lmp": {
+     "bytes": 264,
+     "sha256": "f4f1be9a2ef88b75fd9971d72796a35f7de1ed04fc2cfc3a4c35225976f21eca"
+    },
+    "gfx/adib_invuln.lmp": {
+     "bytes": 264,
+     "sha256": "87b8312e4d7fc20d6ae9df6d1f8cb616392f3a2adaf7208dd2372eefc19888a3"
+    },
+    "gfx/adib_jboots.lmp": {
+     "bytes": 264,
+     "sha256": "206ad9d67636b46418e6afa6b6e75a12df76bd3ad84b0178e86b8d140b9c3afc"
+    },
+    "gfx/adib_lshield.lmp": {
+     "bytes": 264,
+     "sha256": "79a78f4402a301d381bef260b895ba56757b779ae89b7ae5a49f8146f2a7a54a"
+    },
+    "gfx/adib_nailp.lmp": {
+     "bytes": 264,
+     "sha256": "fe59667c80612fd2e7f5d95dd0a208f3909d93eeaaab7e4580405fe153469fde"
+    },
+    "gfx/adib_quad.lmp": {
+     "bytes": 264,
+     "sha256": "915832c8c822daf8cfa1c5d88548f24da7d182be6746b265e7ae6e1d735082cd"
+    },
+    "gfx/adib_sharp.lmp": {
+     "bytes": 264,
+     "sha256": "18987634aa43dced4e06e1d5a9a3f9b1f51c7738f59fae64168bd94ab9cd6198"
+    },
+    "gfx/adib_sigil1.lmp": {
+     "bytes": 136,
+     "sha256": "34b11b26dcdf5b91f3e6e08bbe6edb83f62ba054e9eef28459cef09b742e1456"
+    },
+    "gfx/adib_sigil10.lmp": {
+     "bytes": 136,
+     "sha256": "af31a42ef81449aa656327dfe00fc1e1d744f90212ac228bd05a6d79f5048683"
+    },
+    "gfx/adib_sigil11.lmp": {
+     "bytes": 136,
+     "sha256": "9fb90ba79d5c34e2b0afdbcec8bc528fd7d3d8f2645191d95a67a65e242bd3c6"
+    },
+    "gfx/adib_sigil12.lmp": {
+     "bytes": 136,
+     "sha256": "d7c9c3c7c1167ea0791b2790d678d6bd25144adcba79d6f7c5d93302fc28119d"
+    },
+    "gfx/adib_sigil13.lmp": {
+     "bytes": 136,
+     "sha256": "0003389cd694c55fa36f1d18d38261d279c5c7ef23dd5d41c3852ad8c95e5a49"
+    },
+    "gfx/adib_sigil14.lmp": {
+     "bytes": 136,
+     "sha256": "8ac47a2e1d45d94fb1f222811320c5f07e39e65698b7436515afa29de6e1204e"
+    },
+    "gfx/adib_sigil15.lmp": {
+     "bytes": 136,
+     "sha256": "153627403fd3e3856aa34e8740fdebb5ddb26e201cd590dd76cbfc12c36e49c6"
+    },
+    "gfx/adib_sigil16.lmp": {
+     "bytes": 136,
+     "sha256": "fa95a1a372ce30516252fff8dbcda8f8f55e3cc558b4a1e7015b79838ff0cda1"
+    },
+    "gfx/adib_sigil2.lmp": {
+     "bytes": 136,
+     "sha256": "0a0c22f027e980014a246daa629b6f84f425ccfd828f75a93ef777d9616c9191"
+    },
+    "gfx/adib_sigil3.lmp": {
+     "bytes": 136,
+     "sha256": "9e5daafbe4cc032824f732ebdac3897d804df43efaff9901c315ae661af8cd31"
+    },
+    "gfx/adib_sigil4.lmp": {
+     "bytes": 136,
+     "sha256": "fd1d3791d53ab40881a2d86a0bc67b3b532ef10b201a166a3937b105c63e3c9b"
+    },
+    "gfx/adib_sigil5.lmp": {
+     "bytes": 136,
+     "sha256": "947d5088b18a12d06a93fe66a0500e5b6ae93e04cebc748858139d569693d42d"
+    },
+    "gfx/adib_sigil6.lmp": {
+     "bytes": 136,
+     "sha256": "5a2356a7479f887b20f10e03ee2f42478bdfa75febe2d802b3dbfcd25b39d744"
+    },
+    "gfx/adib_sigil7.lmp": {
+     "bytes": 136,
+     "sha256": "507011b2a191e096fadcd678590636e4033de2ffcf35cef31785539bf3f9fb4f"
+    },
+    "gfx/adib_sigil8.lmp": {
+     "bytes": 136,
+     "sha256": "2a49a4653b2ed11353c6aaca950420c38c8e7b2aa8cc82ecd746a4e73fb7aa00"
+    },
+    "gfx/adib_sigil9.lmp": {
+     "bytes": 136,
+     "sha256": "df168192d5c065c7247cff03b10da51eba431bdc4f76d2c913646bb23084d639"
+    },
+    "gfx/adib_suit.lmp": {
+     "bytes": 264,
+     "sha256": "030bf62f7f45667310f1a74bd88881e2aa8d6c7ba5355bda4bc7c87d64a3d082"
+    },
+    "gfx/adn_0.lmp": {
+     "bytes": 584,
+     "sha256": "0895fe0acba04a4e17ef64fe62c56765c4fef5933c4af09dfcb242e984e8d163"
+    },
+    "gfx/adn_1.lmp": {
+     "bytes": 584,
+     "sha256": "fc0391c514808f9cb54e0bb0bbd63edccb0bea66a7620b81d04497edd099f5b1"
+    },
+    "gfx/adn_2.lmp": {
+     "bytes": 584,
+     "sha256": "d70ca75a162f7203067f314eee6460dc9180383e5bd1a19c69a984d8f4c699ae"
+    },
+    "gfx/adn_3.lmp": {
+     "bytes": 584,
+     "sha256": "40fbf34b86a4e5d264fac3c875ad74a52b62f5868d01a7580107a52998cbe4ac"
+    },
+    "gfx/adn_4.lmp": {
+     "bytes": 584,
+     "sha256": "5c9f781b8fb46cff0bb69db9817936be10cc4e34d677a5a49f117baa1d414aef"
+    },
+    "gfx/adn_5.lmp": {
+     "bytes": 584,
+     "sha256": "f2b1a90d1f4e1e3c6eb04dd1d87f084b2bc932b76b6eabcc5a4ee12db939971e"
+    },
+    "gfx/adn_6.lmp": {
+     "bytes": 584,
+     "sha256": "ec90a75650252feb45f325815498caf518058d141c7660e594397e0e05e35cfc"
+    },
+    "gfx/adn_7.lmp": {
+     "bytes": 584,
+     "sha256": "c292389fee1e91c2c4178099a8c9b2ad193f74346adec126ae10a4383f96c6de"
+    },
+    "gfx/adn_8.lmp": {
+     "bytes": 584,
+     "sha256": "4df870d66977eddbb7c4f87ffe4b94a032f2f13ad8fa38a98fde607d7aa7b06d"
+    },
+    "gfx/adn_9.lmp": {
+     "bytes": 584,
+     "sha256": "fd7f393a0fea9c0bc9fec90492a8f074a75275fde2ce211379b098176729622d"
+    },
+    "gfx/adn_a0.lmp": {
+     "bytes": 584,
+     "sha256": "7221532ee9af2c3a2fa3d19e4ccae78458d7a1f3025627e6da45dcb4aefd6820"
+    },
+    "gfx/adn_a1.lmp": {
+     "bytes": 584,
+     "sha256": "8f594ea65757fdaa62105b5eb68d4519b96b93e12dba110a723c4bf99470d408"
+    },
+    "gfx/adn_a2.lmp": {
+     "bytes": 584,
+     "sha256": "738cd71a2344da4b1733b639e6cdef1fb412104c388d2edee0b4539655ed9fec"
+    },
+    "gfx/adn_a3.lmp": {
+     "bytes": 584,
+     "sha256": "00c7040d33a445656f33c373077564116a764142f4625b5df7fae6516817f893"
+    },
+    "gfx/adn_a4.lmp": {
+     "bytes": 584,
+     "sha256": "7fbde831e189692c1c5d048873e7098a7d017ff7e22fc57a724a2c2fcbcc8db4"
+    },
+    "gfx/adn_a5.lmp": {
+     "bytes": 584,
+     "sha256": "ecb1a8036b03abc3c95a145081762ebf8b04516bc438053e570b989195687615"
+    },
+    "gfx/adn_a6.lmp": {
+     "bytes": 584,
+     "sha256": "8495247be5584836815824b182f448348d3de924236e254c5ebffd8132a1b7ae"
+    },
+    "gfx/adn_a7.lmp": {
+     "bytes": 584,
+     "sha256": "76a1b4a37c14cf3c53047129e14bb3f2217142ca5405ebceb95b892bed49cb77"
+    },
+    "gfx/adn_a8.lmp": {
+     "bytes": 584,
+     "sha256": "943ae9da4710dfb8a8b7b22eb8ecc6131e7c4586f279701323997f931bdd486f"
+    },
+    "gfx/adn_a9.lmp": {
+     "bytes": 584,
+     "sha256": "4381c6e590644e7c7e3d64e89adb1d438802e1a81380de8f08b31669780f07ed"
+    },
+    "gfx/adn_aminus.lmp": {
+     "bytes": 584,
+     "sha256": "903c3e6081e934fb4a9b0ae4564265b0339d2289fea17720c7bac77d00155258"
+    },
+    "gfx/adn_colon.lmp": {
+     "bytes": 392,
+     "sha256": "a06510a33f355c24fc16d7591323523f13920ae6fa903c3155b5edef9e4059a9"
+    },
+    "gfx/adn_minus.lmp": {
+     "bytes": 584,
+     "sha256": "1e04325b97c5052e64187e0882b8c2f87473bd66f3e70b5a419d983b0a62ed81"
+    },
+    "gfx/adn_s0.lmp": {
+     "bytes": 264,
+     "sha256": "6a5cac8d7c8076aa42055c3b64f3fde4b1e7750b2bb143b12af07dec892c9ccc"
+    },
+    "gfx/adn_s1.lmp": {
+     "bytes": 264,
+     "sha256": "723ec3e0b6225419fa5fb8010896674d91d19eeafd8e2c9bbbec2d23fbb85792"
+    },
+    "gfx/adn_s2.lmp": {
+     "bytes": 264,
+     "sha256": "cff9bff09933ccbf43a1419d6f566807c2aee9a4aca448a86bf261394b3ca7b3"
+    },
+    "gfx/adn_s3.lmp": {
+     "bytes": 264,
+     "sha256": "8d7cf6b3f2db7463e962fd7b70b2ef7c36b0882b1e80d90b02fa1a609d09513f"
+    },
+    "gfx/adn_s4.lmp": {
+     "bytes": 264,
+     "sha256": "2bc5fa316cc366f4d1a4f1831ac3b8ced65caf89157e796ff5d673fa3955ac1c"
+    },
+    "gfx/adn_s5.lmp": {
+     "bytes": 264,
+     "sha256": "98cbff3f1b98977b8fc19523fc2e644e763fc52dba708fc5024dfbeaa1f00d6d"
+    },
+    "gfx/adn_s6.lmp": {
+     "bytes": 264,
+     "sha256": "1578d854415aaf5b68a25a0fb37057b019d12055b61c3d7402eae811a9359e1f"
+    },
+    "gfx/adn_s7.lmp": {
+     "bytes": 264,
+     "sha256": "609059534b0a59c9d5ab1180f25f0b2a952719a0ccade29d05559dfc6223f1d9"
+    },
+    "gfx/adn_s8.lmp": {
+     "bytes": 264,
+     "sha256": "7327dd480225a52c642320336ade17100228d2c1ade5f1b640cbff18e37fbe2d"
+    },
+    "gfx/adn_s9.lmp": {
+     "bytes": 264,
+     "sha256": "b8ad416098543b34c286565e3a0d7756eea7ab18c8b50145e7ddbc45fd28851a"
+    },
+    "gfx/adn_slash.lmp": {
+     "bytes": 392,
+     "sha256": "2500358f0d4bf9856c04b7be940ab41012faad597005837c99dfef93da1f3ca6"
+    },
+    "gfx/adsb_armor0.lmp": {
+     "bytes": 584,
+     "sha256": "01228bb8947103a70c9f536b168eefacda9dc5a08e1fa64ee963be44d4a9af9c"
+    },
+    "gfx/adsb_armor1.lmp": {
+     "bytes": 584,
+     "sha256": "85956c2a17460229a374e8a6e1cf22ad4ff663929dba06c9daa9d95d1582ba53"
+    },
+    "gfx/adsb_armor2.lmp": {
+     "bytes": 584,
+     "sha256": "e8e64ea8d90241677315bb9a9e25714856827642a0e331077dc6fa2b827036fc"
+    },
+    "gfx/adsb_armor3.lmp": {
+     "bytes": 584,
+     "sha256": "db6523d7c99bb15c14ad9fd1d665a24e4eab985dfa095d316f20fe5e96e9c320"
+    },
+    "gfx/adsb_axe1.lmp": {
+     "bytes": 584,
+     "sha256": "ebcafdd02b84a9bd21658a349205a09e5e242fa39013207fe6aab9697df2884f"
+    },
+    "gfx/adsb_axe2.lmp": {
+     "bytes": 584,
+     "sha256": "12caae98c176f1176a5222f7730709dcb9164a5db63984fe6f8982e8b17915e6"
+    },
+    "gfx/adsb_cells.lmp": {
+     "bytes": 584,
+     "sha256": "08da91ae0bca3d7bd546d92f7688061b7fbc8d86b84e309510ee3feeb3f63e92"
+    },
+    "gfx/adsb_key0.lmp": {
+     "bytes": 392,
+     "sha256": "49e4cda132ff7237a4b7244892fa1e059ff2d77698ec855cb4c02e08867899e2"
+    },
+    "gfx/adsb_key1.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adsb_key2.lmp": {
+     "bytes": 136,
+     "sha256": "46a6561c191c47e9445ef85c2bebdc881f330ca49afe562d7bb2a59c5442c73e"
+    },
+    "gfx/adsb_nails.lmp": {
+     "bytes": 584,
+     "sha256": "77fb4c0c61d824fafba54e91d6b23e702ae54565d7708ee0e404aff804555b73"
+    },
+    "gfx/adsb_pent.lmp": {
+     "bytes": 584,
+     "sha256": "8066cd0ef3d3ed9add280937fa51d6dd13a7eaf606ad0567366e86c51ddb7d62"
+    },
+    "gfx/adsb_rocks.lmp": {
+     "bytes": 584,
+     "sha256": "2e79b7c3e3fb6b4118a3ddedd7d9a1186f12c2df2efdbcf5300cacc51fe64744"
+    },
+    "gfx/adsb_shells.lmp": {
+     "bytes": 584,
+     "sha256": "f185cb1b1a48a8499d110e6371f2bb102ad89fda9875a267adcc6f3c8a5e613c"
+    },
+    "gfx/adw_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "ee32ef4cb14c02b9516f245fe9eae50021962ebdee3ef843076b9dbe20f038fb"
+    },
+    "gfx/adw_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "0f8884976f5ef05d5c3d7ab7c7b22bddeba9ee922664d23c6dfe835c5673ad9f"
+    },
+    "gfx/adw_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "2c1f7b1b0a5c27da9f01c84a38571901fb3636a04485102f44cb19d715e7f627"
+    },
+    "gfx/adw_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "a9802bea98b2fb57ab97784caeebf1ab2312fab73146503459c7c8021249ccef"
+    },
+    "gfx/adw_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "0c92aaf91afe914f4d06e5d2fa91bf926a0b43294d49021755b93c049e15a99d"
+    },
+    "gfx/adw_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "155eeca532e2f6d08b7575697020eebd4f492987392c68f09c66bb6522c0336b"
+    },
+    "gfx/adw_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "02d55707616bd6eae995c93d5eca3e788f227811001e2e8137c07cafe85409a4"
+    },
+    "gfx/adw_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "0d4cba204d9ea74665e164d46ead9167095cceb64a795861dfb21fcfd2b3e9ac"
+    },
+    "gfx/adw_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "3d354bd9336125ea758f2b5b56b1ecdf2a2afea4e8bb8d6edeb058448f9627e7"
+    },
+    "gfx/adws_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "457f6682e5a8b3d7b1075148c05093df1ec96c59e85057dfca80f66f4ad25815"
+    },
+    "gfx/adws_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "127d3759679f91a8633557a27abcb8425b3f8fd8b9888e029f761cff9fa20e47"
+    },
+    "gfx/adws_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd1e14b26cfa3915c23502e22413328d37749e0a77ac75508238fbaa375c7555"
+    },
+    "gfx/adws_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "424a425e24162a3a1a23e7308b8b46f4d25f1c9f11ac3b427117c596dafeb006"
+    },
+    "gfx/adws_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "41dc9eb1fb806500b41d832786a0bce0c6863c6caa3bcc7491892e25d04a81d4"
+    },
+    "gfx/adws_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "30a22fc8975b5a696ff31e859290fd780553f1857e424b1d5ecfa057277d155a"
+    },
+    "gfx/adws_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "50c5e9c358023dbbb65cc79346d99af6797af556faded31df95e2b7191aeb3f0"
+    },
+    "gfx/adws_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "94cef7136e718532b4d00b9ed8804da60be979206bde676a328270321286851a"
+    },
+    "gfx/adws_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "8259db2f3f7ddd075e6192d6e0581a2321c108232d67980fab85059fcbfe47df"
+    },
+    "gfx/adx1_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx1_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "e4d0714014c5a1c0d9874bf1ce2c0232352be1e0c90ffe927dc2d86d448f7e47"
+    },
+    "gfx/adx1_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx1_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "9da68076978e9bc4d35e2b40e972c578e0839c379c86d44bf15c033f164fc9e9"
+    },
+    "gfx/adx1_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx1_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx1_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx1_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx1_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "9341894f953061deffb42e12370fd05b7f8008e2a1caee149630a8bcd40fac10"
+    },
+    "gfx/adx2_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "c5f2e4352837eca0a67b1fe6eb5d437672f365efffd7c297848dcdbfca6fea7f"
+    },
+    "gfx/adx2_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "b627ea70b6a7a5debddd4710f31ca137c3baf01dd6109cc2cee7da968a020049"
+    },
+    "gfx/adx2_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd7a15d826f6565c97f638ff541d76e409b9cc69febbb78906c5ddbbad2e0f02"
+    },
+    "gfx/adx2_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "8239bfd1d494fae52f97d5f620bf6c9cace057a27975cddf7d0f557b5a797cb6"
+    },
+    "gfx/adx2_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "6adf5220508ec39cedaf8cc8208c8b7bff5f44f18401bc5ee7a39e91419376ab"
+    },
+    "gfx/adx2_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "f300febb1aad7dc16d592f1e1aef2cc5a8870ad08ebbb2bc15b43009122259ae"
+    },
+    "gfx/adx2_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "e15bf6fb56eca5640d521dfdbe0c20f9e3ce6fb6fc7a2e39922f0fc8cfc7d002"
+    },
+    "gfx/adx2_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "c781852ce141a1d5fb84451e1bef2b021c937d0658d7ca8f8b2a1d5cc3737a66"
+    },
+    "gfx/adx2_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "aaaac2a8b4dfaae3d02705c2fbffa38621187cc28f4246a591f38b2bec79f693"
+    },
+    "gfx/adx3_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "20209da4ccb0dbeffc6520aee7958b33bcfa728ed376b1f5f987c8305fb70d3e"
+    },
+    "gfx/adx3_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "eb13bcc843d95abf3c90c140c95aa95803a42a6afeb100e11a5e0d80c72caf8b"
+    },
+    "gfx/adx3_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "483f85f7e5a0e881f6511f2b16a25d1945dcc2fa5365e4417cb58ec6a87f062d"
+    },
+    "gfx/adx3_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5e1f15716b826a8a25e61415e675a6c94888ae4030462e1190653c4d93768743"
+    },
+    "gfx/adx3_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "99d58b01e578c88924699f85614b021dcc5ce32798c96680fb5120e8d58837c2"
+    },
+    "gfx/adx3_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "4eae7b9a7119e883d3b6d3b8b336398beca8b7cf4ed2b9b498e13d90b7743ccc"
+    },
+    "gfx/adx3_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "8568e0c106e3155b9cef3dc3bd55ce821ed151560abab4080fcf6534850b153c"
+    },
+    "gfx/adx3_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "b8764c3198aa863d67e4f7c3c19db89aab6aa4f4076abe83d50b88710eb85446"
+    },
+    "gfx/adx3_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "fbb92c8a0853070604e84da82a5232c93747f3571ba05e88ecb4e59649125838"
+    },
+    "gfx/adx4_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "4e8da401756d091a913d4a0a5618aee7eeddad1bcd8c78774bc229195bd96943"
+    },
+    "gfx/adx4_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "c68cec0c6064b7ceaad60028ed1e8f7834a6484d9fde249649d7b94addc6544a"
+    },
+    "gfx/adx4_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "386eadd2ee00c5a53179729c2b23cf56f0629c3e7ad8e5b3a739f1fd8d489d34"
+    },
+    "gfx/adx4_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5179dcb2b82032c81d02dfb35d130ed8196d5b726c7a8265c2823c3f2edde2a8"
+    },
+    "gfx/adx4_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1156e8a090be24e24605153b059646bd7d8b9d33c6e175bc9b05843eb626ce38"
+    },
+    "gfx/adx4_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "8881a5fe764d90c1113e1df7215c6520988c23601a969ea3e7b9abf8d7d4ef0c"
+    },
+    "gfx/adx4_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "7b55d6f2071d101db2a87c5958aadcdcf618f8f0eab53b19691125c1e8b6d8ad"
+    },
+    "gfx/adx4_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "199a6be6977bbebfe0aac0005466b10bfcdd9d26a764d18e56e28ee6f6f8f5ee"
+    },
+    "gfx/adx4_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "924cd9a6ac66660db99821b558a21e8dd0b02e85bb2a5415c2e24daace249663"
+    },
+    "gfx/adx5_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx5_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "9405034666f0f1247a58a97b86e5c451f0b2a315501389f43043da55493db8de"
+    },
+    "gfx/adx5_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx5_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "6c529185a7cc6dc8d066080c4246f80c7bf1fd0ea808fc0be5be63c8cff7c2b3"
+    },
+    "gfx/adx5_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx5_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx5_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx5_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx5_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "bb8e065bc9d9935d7fab8e9d0d0554948e2ab2622a54e86f70c1d8c3c9a0f178"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "b941e3ec692b990d1dbe0fd69c1e043b9d504374d791c8c981cb091324072826"
+    },
+    "gfx/community.lmp": {
+     "bytes": 256,
+     "sha256": "7d425f7678b30e94f816c93391c3322ed354c9657ef2563c964b2abb0d57d933"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4424,
+     "sha256": "b4554a7ef6de5831198626fef9431582d3c17ed56c55853f1ce979be31df8dcd"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "a0e7d5ec57b819a0c6ad269e777ea123f767c6d53d47cec3cecd8f25dd27b04a"
+    },
+    "gfx/conchars.lmp": {
+     "bytes": 16392,
+     "sha256": "045ea49c02bc0e51336e84fb19f4c445ece3c0d8c6ec4aba3cac0fcbf4306c15"
+    },
+    "gfx/conchars.png": {
+     "bytes": 14283,
+     "sha256": "1b63b3d252a0d234553153910c6d5384de0bbe050f095ebe00d253ffab2db8b9"
+    },
+    "gfx/conchars.tga": {
+     "bytes": 65580,
+     "sha256": "6dbfcc084e12e7c053c49f257f0a2276014a46ee92d194008893a39416e9e486"
+    },
+    "gfx/env/adgreenskybk.tga": {
+     "bytes": 1520289,
+     "sha256": "6a7fa2cdc97237658a3f2c73a8a5d879feadf4a31e84fb8585aeba96f3f8fb61"
+    },
+    "gfx/env/adgreenskydn.tga": {
+     "bytes": 1565620,
+     "sha256": "d4fabe617a431169df1bbc37e48404fc34718a1bbf5a1ee45d5b3a0ddda5cc6c"
+    },
+    "gfx/env/adgreenskyft.tga": {
+     "bytes": 1704063,
+     "sha256": "c6cfbbd8b09846eaea719a5e65744cdd4fddced0c277f4584c743f2639882d50"
+    },
+    "gfx/env/adgreenskylf.tga": {
+     "bytes": 1576943,
+     "sha256": "c83f24917ccb67af83602236d03e57096f73b36b7fc64da6206afe989944b4a4"
+    },
+    "gfx/env/adgreenskyrt.tga": {
+     "bytes": 1706213,
+     "sha256": "7b85287d2ce5e4d3a9ce63a560183086e812ceca9232d07eb61f63a24d678e10"
+    },
+    "gfx/env/adgreenskyup.tga": {
+     "bytes": 1798684,
+     "sha256": "703e4449b5b9ff967610dbc81d7e27c089788927d82fdb31267490cfb30ed0e3"
+    },
+    "gfx/env/asap_bk.tga": {
+     "bytes": 786476,
+     "sha256": "9f6daf48061bdc132ec28062c494d4a6abe2eeda2c86b575ac7df472a97b2c80"
+    },
+    "gfx/env/asap_dn.tga": {
+     "bytes": 786476,
+     "sha256": "a8aa31d47f7537150c1023713588b87cceff0072036ea64c895129fccfd9fa9a"
+    },
+    "gfx/env/asap_ft.tga": {
+     "bytes": 786476,
+     "sha256": "067cca994d96dcc95903ea1d3c023c479d66a655b2d3412116d462dff4e155d7"
+    },
+    "gfx/env/asap_lf.tga": {
+     "bytes": 786476,
+     "sha256": "761640856a2500019db4c3fae214fe2043fbc0edffa3e6c508d964a86b98ecf5"
+    },
+    "gfx/env/asap_rt.tga": {
+     "bytes": 786476,
+     "sha256": "08d03cf9826300c6d283028f60663f5bd3f6564a7deb5e15078440e18e1433cb"
+    },
+    "gfx/env/asap_up.tga": {
+     "bytes": 786476,
+     "sha256": "d98b750d0908addc2b0c9d513bc0bfc5d28935c9536f437cfcc3796fc0f5ce82"
+    },
+    "gfx/env/black_bk.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_dn.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_ft.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_lf.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_rt.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_up.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/interstellar_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "861352b7f4dc030af28b483d09ad88b4cbb7b8e23e5cd3cf512d2feae9640b22"
+    },
+    "gfx/env/interstellar_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "b16b2e272b7e74513f6a1961d68270dd82fa0667d6ea267a2d22c45a2bdc2fcc"
+    },
+    "gfx/env/interstellar_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "11730f0982cbadc7691ea38e57510b2b7e77484e108d591aece8f970cfdca08f"
+    },
+    "gfx/env/interstellar_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "5bf0a5999e7ea85e68291ab7b36d7f6be5104f8932a2fe46d257484e84dab4fc"
+    },
+    "gfx/env/interstellar_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "051204c9fb8a430c17fb337d84132e0d7058b88f070e457278be99d78a73e5c2"
+    },
+    "gfx/env/interstellar_up.tga": {
+     "bytes": 3145772,
+     "sha256": "d8b19a66cb5dad2f34c9059860ac24a8632ba5575ac06ca3076d57a70c47b5b0"
+    },
+    "gfx/env/l_swampn_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b83c2aeccb2ec2b6a7e7de05e4eb1f120437c575769b93533708093be6d7acb"
+    },
+    "gfx/env/l_swampn_dn.tga": {
+     "bytes": 3146268,
+     "sha256": "64ea5b085c2758138760da154c77e3c90eb0831c68e75bac4c03cd03ae2e28c1"
+    },
+    "gfx/env/l_swampn_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "f8149a22f17e241f3cc50ddc2587b3d8d6e72bb26f7a47d5045b08ed436863af"
+    },
+    "gfx/env/l_swampn_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "fdf2a49932e8ee9c06b9a50fa6dcff3d29bdde55aa209d1658346cf236ca1dd8"
+    },
+    "gfx/env/l_swampn_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "a2c65a9eafab955cfe898aa28e3563714354a08725068df84f390eebfc6ca20d"
+    },
+    "gfx/env/l_swampn_up.tga": {
+     "bytes": 3146269,
+     "sha256": "aa5c65d4c106b17e695629023db1e6b304ec5b4f15e646a1a94b38c47ef9017e"
+    },
+    "gfx/env/moonhigh_bk.tga": {
+     "bytes": 1048620,
+     "sha256": "5f361bf5a352c1df5a6caef9cf42bd35fed8406c6949af480b0425c193c18b3a"
+    },
+    "gfx/env/moonhigh_dn.tga": {
+     "bytes": 1048620,
+     "sha256": "02e2b36863c1181a85aa675c53fc14a301f38dc6e0c6735098bb6d8723af02b3"
+    },
+    "gfx/env/moonhigh_ft.tga": {
+     "bytes": 1048620,
+     "sha256": "3158735bdd6f4f467a5b29639aa4f622d1136ea463967684b739b0002bec6526"
+    },
+    "gfx/env/moonhigh_lf.tga": {
+     "bytes": 1048620,
+     "sha256": "5cdaabd99655152689e40832643690d7b1c5f8e414f3126a7c0c9224f2250704"
+    },
+    "gfx/env/moonhigh_rt.tga": {
+     "bytes": 1048620,
+     "sha256": "e08a374ac19c8b8cffa6c939515cde9570b44bbc044c12d06b0c5d94aa7469bc"
+    },
+    "gfx/env/moonhigh_up.tga": {
+     "bytes": 1048620,
+     "sha256": "c0465fd6a0b069e5ff78f3e561084bf3e23b796cac9b5214a6cd4045310d36fe"
+    },
+    "gfx/env/moonrise_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b4e85116e3999d5cded25ca0a5d6fb9c297b3d69749a63daf5af6c37fe21959"
+    },
+    "gfx/env/moonrise_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a7be41496d25bc9e505b959b08a950c1bb61acc6c8c44ec4e1dd428faeac4ccd"
+    },
+    "gfx/env/moonrise_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "7381c46aa4f5c916f3bc8f82a442a4582834563c0bb0127580053bb274609180"
+    },
+    "gfx/env/moonrise_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "871df5eed200970b8c3246ca10a039f5915c95e8f48bf0692fc22f2f7e5450cd"
+    },
+    "gfx/env/moonrise_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "2cc00bb935ee2f4019f4d99170d38ef3f51c72ff80150cd74911b1038a0cb269"
+    },
+    "gfx/env/moonrise_up.tga": {
+     "bytes": 3145772,
+     "sha256": "0296084074d726170fdc85d2c1176ee64845b6805c174c08aaa63f514fd9cb65"
+    },
+    "gfx/env/snowmoon_bk.tga": {
+     "bytes": 707878,
+     "sha256": "f4c61c3a622a2dabfc2aa2748c3bba9ab52bf018c5c24b5aac6bd682b6d938de"
+    },
+    "gfx/env/snowmoon_dn.tga": {
+     "bytes": 754863,
+     "sha256": "a6f29123dc3da6df244c6878d1a355b9ba7c093b9a38b94e8f9253d317de846c"
+    },
+    "gfx/env/snowmoon_ft.tga": {
+     "bytes": 630095,
+     "sha256": "c10f65b43cff087a7044946f8105d24072bbcb33668bb485f501fc0bdcb7e293"
+    },
+    "gfx/env/snowmoon_lf.tga": {
+     "bytes": 671066,
+     "sha256": "8025d6d72582a374583dc4c80d15de546b1ebea3f378cc55b084483778d8f985"
+    },
+    "gfx/env/snowmoon_rt.tga": {
+     "bytes": 636559,
+     "sha256": "339a1a1a36ffafa6bb49ae5bffcb73c81d4304f0f6d40d5fe470654c0db56037"
+    },
+    "gfx/env/snowmoon_up.tga": {
+     "bytes": 410341,
+     "sha256": "f08c76ef2c7c2338b64615543ffa1217edab3ca41bc79cb74b20bc42d329e82c"
+    },
+    "gfx/env/stormydays_bk.tga": {
+     "bytes": 786971,
+     "sha256": "d82eac0c4f574d74ff5fee6ececd1d5f0b1bd94c349cb7c9af30d3ce79bf6b2e"
+    },
+    "gfx/env/stormydays_dn.tga": {
+     "bytes": 786971,
+     "sha256": "915f33dcae63765c49252b65a58f9d4359c7a36ea99352a013e58e660b71f160"
+    },
+    "gfx/env/stormydays_ft.tga": {
+     "bytes": 786971,
+     "sha256": "4906e45ebc2760dad5faf2e6f8a0be7c280bf7525a96364376155f3d001fba99"
+    },
+    "gfx/env/stormydays_lf.tga": {
+     "bytes": 786971,
+     "sha256": "d7cc6cbaa37481b3902673d717aae7f31e0170e2226a4efe88811f6bac3f8ca6"
+    },
+    "gfx/env/stormydays_rt.tga": {
+     "bytes": 786971,
+     "sha256": "ab40bc26b750a421c95948e7f215d51e831163fd478841c30f685a2b006b8c3c"
+    },
+    "gfx/env/stormydays_up.tga": {
+     "bytes": 786971,
+     "sha256": "8ff85257da02eb361ab8127e4425b9177842f17016724beb5c3058ae460aa52b"
+    },
+    "gfx/env/violent180_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "cf1d0a870b38e4889ad4ce18f22bf894771a8c91477c0338e837880df061db31"
+    },
+    "gfx/env/violent180_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a3b344abf47fae67c831aaa8d8b2ab7ff56ff1ed93091c6869139902060777ff"
+    },
+    "gfx/env/violent180_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "964ce0226b139a1af96de0c422e927d35917ad30f0c4027c1c386c7c32cc30db"
+    },
+    "gfx/env/violent180_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "b9cc1ef464535f9a911d56fb503a2e1aa68e6d07c7091cb62c42442a7d62ceaa"
+    },
+    "gfx/env/violent180_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "263af4a0d5b2e61303d8165d6b8a8b7e55d0c8dd79157ff133a5d50128d5f21b"
+    },
+    "gfx/env/violent180_up.tga": {
+     "bytes": 3145772,
+     "sha256": "3a9aae357ac1a8e8767e151024dab60845283422f204a354913282873f181413"
+    },
+    "gfx/env/voidsmoke_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "d274189cd63786e9d86fbd3cafda0cbfd054ccd527e30aeec921a8d6f10866a7"
+    },
+    "gfx/env/voidsmoke_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "47392d93a23946a28533cf759d6aea245a2647d58bf153d2845ac0899ab8d400"
+    },
+    "gfx/env/voidsmoke_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "ced1991fffdc46e2bf156e1d89e06e1362e0e394808b74bc7aa40e6d90fde55d"
+    },
+    "gfx/env/voidsmoke_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "4d1b843a9fc61c4125262a9a95fc084cea61eb4b125288f7a7cd0c2f2e53f4ab"
+    },
+    "gfx/env/voidsmoke_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "389ae84f29901e349a266d707f62beab9de3eb607b901bcb4245028b8edaa3b1"
+    },
+    "gfx/env/voidsmoke_up.tga": {
+     "bytes": 3145772,
+     "sha256": "138e9386728cdd98935a0c484d5693db2e60375d8d770ad754fe6616906591a1"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "a878796ad2dbab6a64e1eba47605d124170d5b4a7ce476b9d0087c2e302c00f1"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "381ec91a75cacad94d2a4d5a3b1cd6f9b22cce507fe95f980ebaabdb21bbe440"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9e9568b56059e74e621ad564b51cb0b886fcf800fd8d35a06df1aa79ac2aa823"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "52164e93b333dfe09a33d7ad1905796d7e7578a036b2fb2ddf35c4bf3381f30f"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "240a13f778cc7ec7ebbc67b23a977a54099e1996fd868f51c18f81aa3606d179"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "fae9345c9eeb43a56a14e9e681f9e9dadc05ba6e35f44197fca5873dbd52904b"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3272,
+     "sha256": "ba61bec9eaf837bddef9a1320c0acfe026a130bc078836abf971095157ee395f"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "fc226280c4948249790f00f97dd9b39e912131fc904ec75adb90308ba8763afc"
+    },
+    "gfx/mainmenu2.lmp": {
+     "bytes": 30728,
+     "sha256": "a3fd168c6454eeaeea9e248df568e5942a7f850bc5478f8946a0b6516a2ce6c4"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 6920,
+     "sha256": "5a84111e70bf277960853bca69a0dff9093d00d817ffab6fed96f33751435ae6"
+    },
+    "gfx/p_mod.lmp": {
+     "bytes": 6920,
+     "sha256": "3080226ebf497787e7ee1d7bc2917ae220340b7da4af58ff1a0f89f02b5c03d0"
+    },
+    "gfx/p_mod_idver.lmp": {
+     "bytes": 2504,
+     "sha256": "56234ed3e4e4fe95f8a4a1f9a52d4a73890ea653aa88ec992e6777bf3e99b445"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 6728,
+     "sha256": "493a3ae8e9553de87c49d356e916adab7c87e3b25a44c1d1ac46e37de4df800b"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 6728,
+     "sha256": "d79623e26bed9db65257e3c0bf43b085d2419fc6e5277ff357350556882456d9"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 6920,
+     "sha256": "f51c8bd49d699f08322b734f281d7e626c24844aec09099877fbceb1884cb705"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3272,
+     "sha256": "788da2d0f96ed9f0822fff406f364a912179e33f6f4d068aa7b772f2747cbc85"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "e433f3f5b535d3157ec0feeb91804959ff671b88a04c9785a02ec3acf5539af7"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "f8ee0991ff6faaef3b4d2230364776effe6a1d4b47588b98e39c1d0b4199fd9c"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "a6ccb48f7e1d00ec64e5154a0a47b433f017341b8e23ba4f7f7fef6fe9a27b3a"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 6920,
+     "sha256": "bce2792bc38f1f097336ebdedff2029b21f4cebc523684738f7e10e086d33661"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 6728,
+     "sha256": "904d617b5b97aa6b1631e7b5dfab9b4092c488fefd94ec093c98595b38789b7d"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 6728,
+     "sha256": "5eeeea42e3f429aae7f907145b88376805346ebe3ce932259bdfc43399f960ff"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 4808,
+     "sha256": "5ae8a3fd789e7ddf6d7791ee89cb79ef989cb000c086e9269349aa623f1f6438"
+    },
+    "music/track180.mp3": {
+     "bytes": 9774601,
+     "sha256": "2e3f447c7e7f0b7a02013e8259cc72bc035f8689686cfa1c301591cc34dbe4e8"
+    },
+    "music/track180.ogg": {
+     "bytes": 5092750,
+     "sha256": "1b48947672b05ebb5755d97122f28c0598a5fefe724d8b4cc3301497aba94f81"
+    },
+    "music/track35.wav": {
+     "bytes": 353002,
+     "sha256": "9b006ae5f5b2ae5c2ad84062d9bc288cee744e63301721838d70bec434178b95"
+    },
+    "my_progs/ai_ammoresist.qc": {
+     "bytes": 7444,
+     "sha256": "d530fec92f23ed0c3d09560abb9a89bdc160ce1aefdfbe4f4771f9897ae3fc4d"
+    },
+    "my_progs/ai_checkattack.qc": {
+     "bytes": 106456,
+     "sha256": "7971ca5a87666c89b56ab0fcc102e6f551f3cd3b03bdfc0bfb73f5f8d5aed7fb"
+    },
+    "my_progs/ai_combat.qc": {
+     "bytes": 24318,
+     "sha256": "a8cc4b28f82babe8ef8fc627a3c16efb25775ea736d3ee99709ed675196c2d66"
+    },
+    "my_progs/ai_enemytarget.qc": {
+     "bytes": 8409,
+     "sha256": "f4b0a35306d50e71fd9043ae949a421158ee9fcc4e311baf7b8fa2d345c4d46e"
+    },
+    "my_progs/ai_explosion.qc": {
+     "bytes": 12162,
+     "sha256": "7df941a7cf93b814ae9d90f646a5b0243a51db67872f621df73d43c6000ba3ab"
+    },
+    "my_progs/ai_gibs.qc": {
+     "bytes": 32373,
+     "sha256": "65e202300882ba8f0c980f65820b2d2e0bd06846073168f4bd7e37f2357f47d4"
+    },
+    "my_progs/ai_hazards.qc": {
+     "bytes": 26832,
+     "sha256": "81aace80121408f64369bc2bbfd5654650276ddd75217333d2a52364415acaa5"
+    },
+    "my_progs/ai_minions.qc": {
+     "bytes": 10236,
+     "sha256": "3e7bd34dfe0e73a11e6907d5ac69cb609eee19dff533689ea7c8eabe52500136"
+    },
+    "my_progs/ai_passive.qc": {
+     "bytes": 8224,
+     "sha256": "44473544d0da0dc778c2800a16172ab49b548286b604c9d6361f4bc4cfc1f076"
+    },
+    "my_progs/ai_pathcorner.qc": {
+     "bytes": 20921,
+     "sha256": "b3d6ed2434e0b995da51a71715647096e36e02d8cf920e18e024f920ed69238a"
+    },
+    "my_progs/ai_projectiles.qc": {
+     "bytes": 86235,
+     "sha256": "b28c04e84c97febe9e5a8e921a8e230755f9641d4bf5d74b4a59caaaa247dfc8"
+    },
+    "my_progs/ai_states.qc": {
+     "bytes": 7480,
+     "sha256": "76fae861132b0e50006ef88ea94a953e718b661defad2ea58a4ecad5cab92dee"
+    },
+    "my_progs/ai_subs.qc": {
+     "bytes": 50952,
+     "sha256": "9d2e356f0dba7842956ceb4e766fff9da25dc72a0b408baa3e19c4a146cbafdf"
+    },
+    "my_progs/ai_tether.qc": {
+     "bytes": 6470,
+     "sha256": "2229c0ea1b76e45f5707a3eca9e7626e33f8ea91d6b292da63c81723e1ae8521"
+    },
+    "my_progs/breakable.qc": {
+     "bytes": 79687,
+     "sha256": "754831599eec85a774501d9fd0a1ec7d5722ea6a6e01655b5ad74988145045af"
+    },
+    "my_progs/chaosmode.qc": {
+     "bytes": 81481,
+     "sha256": "01561dc4f1949716eba4d08f83efe27b71add80f923c1e2d89194c238772a646"
+    },
+    "my_progs/client.qc": {
+     "bytes": 70441,
+     "sha256": "00e2d4aff96ea28b0532ab0b03de0a8cdcf15750164ec82bdc8f43b9f2347447"
+    },
+    "my_progs/client_advinfo.qc": {
+     "bytes": 59677,
+     "sha256": "87aaca8bfd15935e1cd29a807bf77a2779d95418af631a6b456c6605710694fe"
+    },
+    "my_progs/client_camera.qc": {
+     "bytes": 13007,
+     "sha256": "ff4748b04c15d9a3b44dd8069f9347c12487ef353d5401a13542166576097889"
+    },
+    "my_progs/client_cshift.qc": {
+     "bytes": 725,
+     "sha256": "da1e321fe01bae486ffcdd987a942a4b0d5b2f603efb663d52c55e882f129685"
+    },
+    "my_progs/client_debuff.qc": {
+     "bytes": 15761,
+     "sha256": "0e0c9123697241ab3a366dbc46fcb90b8553b65c94cffe1442254a74a2753efd"
+    },
+    "my_progs/client_evilmode.qc": {
+     "bytes": 6982,
+     "sha256": "2cfa3bbeb36ab623c3bb137028ec5f549a2e5d2198fa2ab7fd8a445e14f4fc10"
+    },
+    "my_progs/client_ghook.qc": {
+     "bytes": 51884,
+     "sha256": "43d071195a70caa66b57cca1778679d772478fd1f71cbad7ee267e254e79a29a"
+    },
+    "my_progs/client_info.qc": {
+     "bytes": 13693,
+     "sha256": "55653ddc2b9f3cf2ca3cf1b0afdc4c1685baf1ab3c3830eb9f8b1b2d51b3ff31"
+    },
+    "my_progs/client_mapvar.qc": {
+     "bytes": 13177,
+     "sha256": "c692fa41644e6d21c945493dd891af945a072a4b39e687d1b59c86d14ee804a0"
+    },
+    "my_progs/client_power.qc": {
+     "bytes": 20026,
+     "sha256": "68457e8f99d3967babe95d4db3539388e95d294fa65a6190773e75951fed9ef9"
+    },
+    "my_progs/csqc_defs.qc": {
+     "bytes": 21072,
+     "sha256": "eddc5f194845e78a1633807d32b1da4425bdbe7bcce193e3868bc3995e2dee9b"
+    },
+    "my_progs/csqc_defsclient.qc": {
+     "bytes": 35002,
+     "sha256": "b6674acae135dfbc5e3dbb147e69acdc6b3564b766792359bed3e4eb800705e9"
+    },
+    "my_progs/csqc_hudad.qc": {
+     "bytes": 104391,
+     "sha256": "1ca012e489dc5f6026bdae469f411b5bb25afa00e00d5169cbd35b578a7ad9f2"
+    },
+    "my_progs/csqc_hudvanilla.qc": {
+     "bytes": 37074,
+     "sha256": "c5caa6ba176185c05903d383f3ae41907129d859419a0c0bf909b0e8d3e8af5a"
+    },
+    "my_progs/csqc_progs.src": {
+     "bytes": 113,
+     "sha256": "e383fc0920e9676d92e0be81d69cd8017ed5baf9fc0616a05773de68208ce434"
+    },
+    "my_progs/defs.qc": {
+     "bytes": 31974,
+     "sha256": "1534874cf4d70c5614dedecb70f6d428fc32832ce3345c2cb51fd6058a514902"
+    },
+    "my_progs/defsclass.qc": {
+     "bytes": 24401,
+     "sha256": "811c390be7b31fd4b276410ef1a75406bbca8fb84dc195484835a6100e9cddb4"
+    },
+    "my_progs/defscustom.qc": {
+     "bytes": 95914,
+     "sha256": "180ebe8c3fbbd4f78815c94d62f6ac0ad0c3cefe427664fdf4685adcf2c8a699"
+    },
+    "my_progs/dpextensions.qc": {
+     "bytes": 122912,
+     "sha256": "3758f58ebaa4186e9112da89f7ea53087eef5058a32ebc373a1ffda76c1d67a2"
+    },
+    "my_progs/estate.qc": {
+     "bytes": 7745,
+     "sha256": "9cceb71ae54b331c2702f5580094f9055d007b9e710dd5e61c7c632724022626"
+    },
+    "my_progs/fteextensions.qc": {
+     "bytes": 215531,
+     "sha256": "beb86ad10bb0726de10dd2557d6285f7bf40f08f9d30e06315c3772f8c256571"
+    },
+    "my_progs/func.qc": {
+     "bytes": 47039,
+     "sha256": "81cd56475c6c34a744d84c2b223e66dd1c83a1b525b4c42f3389d4ff4cca5601"
+    },
+    "my_progs/func_buttons.qc": {
+     "bytes": 13271,
+     "sha256": "9e1bd197b2367ab2b8f1c776c214a0c51120559e8d8f0b4888b262b7a1e746f0"
+    },
+    "my_progs/func_doors.qc": {
+     "bytes": 35874,
+     "sha256": "58dbdf05f0044aefdd13ee21d17045a681d255efaca6d129fbd1cec4ae516fc9"
+    },
+    "my_progs/func_doorsecret.qc": {
+     "bytes": 14379,
+     "sha256": "769a3142ccaf18060ff77b0eab57d901585202fbfe63a54ce25d4987b80f92d3"
+    },
+    "my_progs/func_insvolume.qc": {
+     "bytes": 10573,
+     "sha256": "1deaf4623a6fae80585d2d2b1978b1cd217b6f8a683ef3bbc3a77a2897e9a207"
+    },
+    "my_progs/func_plats.qc": {
+     "bytes": 11685,
+     "sha256": "5086c9aba8bbf83d29c3e1897c7867cb24220712007044792928f474216b7ea4"
+    },
+    "my_progs/func_pswitch.qc": {
+     "bytes": 8373,
+     "sha256": "b3a205176d80801216a930241508b3c5718f4be9e1b947932ace2851c34271d8"
+    },
+    "my_progs/func_trains.qc": {
+     "bytes": 26553,
+     "sha256": "81d8de4f3dff80b8523584fb5e37d8d4812a6f7f95a559edff320682217ad123"
+    },
+    "my_progs/globalfog.qc": {
+     "bytes": 18397,
+     "sha256": "84ec244a475ac41b9da772042123f58f4005130590f170f85f1b23ad53629f27"
+    },
+    "my_progs/hiprot.qc": {
+     "bytes": 31978,
+     "sha256": "82875db9fecd8bacd2c42232fb980e6a510a6863103273e2c9078dfe7c6759c5"
+    },
+    "my_progs/hipspawn.qc": {
+     "bytes": 2752,
+     "sha256": "6df8450b85821c1a76f5ccb3c807ac9b94e92f413f16f2ba618f922abf85148f"
+    },
+    "my_progs/items.qc": {
+     "bytes": 164855,
+     "sha256": "ffa38fa915821151c7dbfae3507bf804052db0f5c13eecac462400680cabcf3e"
+    },
+    "my_progs/items_progspn.qc": {
+     "bytes": 20628,
+     "sha256": "2f4824cb28192145a8fabc2da6575db3398e8f81522ab1e026d696ec87313650"
+    },
+    "my_progs/lights.qc": {
+     "bytes": 43912,
+     "sha256": "d0e0c373bb3cc68c7c9121a62c68085ff9cc290daa6faf0adab02323d8ef92bb"
+    },
+    "my_progs/mathlib.qc": {
+     "bytes": 22355,
+     "sha256": "b161ebb89a11f302427c4f124731ec38def8eb01347beb5d748a9ba4afb886f8"
+    },
+    "my_progs/misc.qc": {
+     "bytes": 85890,
+     "sha256": "6b3e8a0882d47f16ff7f54fb37a48e3a7853647f8895718e6428739c4207099a"
+    },
+    "my_progs/misc_camera.qc": {
+     "bytes": 43852,
+     "sha256": "61448a8f0354f39dd26371ae56dadbc903b08282293145a27088ac6c151ea547"
+    },
+    "my_progs/misc_model.qc": {
+     "bytes": 31793,
+     "sha256": "04774e0bab5cb0ccc5bd01e36ae7d6f449248484d0cb203eb435fb267cc8bdda"
+    },
+    "my_progs/misc_targetdummy.qc": {
+     "bytes": 15123,
+     "sha256": "bcd0a0ae806ce20a8c8cfcc27178ce1b4ead3a546d927b6a261ce51a6086c253"
+    },
+    "my_progs/misc_textbook.qc": {
+     "bytes": 26321,
+     "sha256": "14bf42536a5cc75990d938a79d7bd21bde1c166245d94d8e662f9e6fd66e0ae8"
+    },
+    "my_progs/mon_baron.qc": {
+     "bytes": 31318,
+     "sha256": "b76a10da34dabf3411ddf650abcdbc77e3ebcdfebace6191a39e7c0b13a0fad5"
+    },
+    "my_progs/mon_boil.qc": {
+     "bytes": 19821,
+     "sha256": "050b21bda5341a3f81dcb21e6d7d82d458a415fd8f1cfa12435228246229a323"
+    },
+    "my_progs/mon_bossboglord.qc": {
+     "bytes": 24005,
+     "sha256": "e67081b7a5218b361c62bf4b201a18db16f3e75716ad2729c11a0616b137975a"
+    },
+    "my_progs/mon_bosseidolon.qc": {
+     "bytes": 40134,
+     "sha256": "c51eb9b9d67cadfa7178891a238329a60ad57edc3f6ef645060695b451833115"
+    },
+    "my_progs/mon_bossfiretop.qc": {
+     "bytes": 14734,
+     "sha256": "26672c9c2d1577f8caf9894b8eb5eecacac89f64251257bc25db48b1bf43a7bb"
+    },
+    "my_progs/mon_bossicegolem.qc": {
+     "bytes": 47205,
+     "sha256": "5b888302a6af24ce823919d1349c1c92e1ee709d72e79042425349368a4d65fb"
+    },
+    "my_progs/mon_bossidchthon.qc": {
+     "bytes": 20247,
+     "sha256": "65d955fb1434f806962fadc088aa5933e96ed8aa9f1211d0709a3f462ffa3027"
+    },
+    "my_progs/mon_bossidshub.qc": {
+     "bytes": 14639,
+     "sha256": "fdd0e8f8fa374ea0164f79ef1bf74ca942f04c63159f360c7a43011673774fe6"
+    },
+    "my_progs/mon_bossjudicator.qc": {
+     "bytes": 81432,
+     "sha256": "f5092f376eeef22f0a552c846f50175680c15a5c37d9603c6e3d2635661127b3"
+    },
+    "my_progs/mon_bossmammoth.qc": {
+     "bytes": 84963,
+     "sha256": "6cda415b846b2aeb215c0eebc7cdfa6a5560255df9aa014f77b48aa7073b8d34"
+    },
+    "my_progs/mon_bossnour.qc": {
+     "bytes": 45558,
+     "sha256": "def8a1a46f3a266028df3d1a0b7c31a9ad98450f6601e176495f11d929041452"
+    },
+    "my_progs/mon_bossxxchthon.qc": {
+     "bytes": 22614,
+     "sha256": "2c1c0446b0f6a5b7a7921e8f8830c71c174d30c6f176d228a94afd9a05fdc25a"
+    },
+    "my_progs/mon_bossxxshub.qc": {
+     "bytes": 19006,
+     "sha256": "043ebc852ba7f0a06812cb0afd72d32a3da643df1dea45c87fb821f60fbcc332"
+    },
+    "my_progs/mon_centurion.qc": {
+     "bytes": 13734,
+     "sha256": "641e1c09c6df27b033e331140d242f25d27bf7f9bb83733a6b5b3469a5c7ffee"
+    },
+    "my_progs/mon_dcrossbow.qc": {
+     "bytes": 38069,
+     "sha256": "3296618a4b803fb6f1b44c1d32c17692a5bed13cf63102c6dcc58481223197a8"
+    },
+    "my_progs/mon_deflector.qc": {
+     "bytes": 32107,
+     "sha256": "d7a9344878a3a846a7e720ce704820d424362281a1675c40be7b670eca9fe342"
+    },
+    "my_progs/mon_demon.qc": {
+     "bytes": 14601,
+     "sha256": "d77f128e3f91737228c5a24b7ca146f6b4f8e87dbaac31b1ad4e79779884d0d7"
+    },
+    "my_progs/mon_dfury.qc": {
+     "bytes": 39867,
+     "sha256": "a016db202f2a418aee50cb7cce2155a24a6b807e8c98fc49a5f9273ce79c6da8"
+    },
+    "my_progs/mon_dguard.qc": {
+     "bytes": 28414,
+     "sha256": "0a2b964034559f4ca772f9f29be2c56684fd39290277046a6f7642ba934836eb"
+    },
+    "my_progs/mon_dguardquoth.qc": {
+     "bytes": 18932,
+     "sha256": "4caeb17520104cba42476ff7757f38ba6d72e941674b851f55a5c9780ce4de17"
+    },
+    "my_progs/mon_dknight.qc": {
+     "bytes": 36867,
+     "sha256": "68008427374e9ab670b6ad915c7a0f8eaf6a6699efa927a3748ae6cde86458e6"
+    },
+    "my_progs/mon_dlord.qc": {
+     "bytes": 22859,
+     "sha256": "09ca1edd4e65a166a66ba17e682aae9a1be09b05371a72dd1bc447389693bfa5"
+    },
+    "my_progs/mon_dog.qc": {
+     "bytes": 18431,
+     "sha256": "1b345447176aec54f18c31f5da215e80cb2de19f51d353c63a98507d881c2a9b"
+    },
+    "my_progs/mon_dprince.qc": {
+     "bytes": 33590,
+     "sha256": "5114caa7b6152e562e548096e41da68f43c910a5016ddaed408272a97a8320c1"
+    },
+    "my_progs/mon_drole.qc": {
+     "bytes": 25472,
+     "sha256": "36a510e910ce4ffa26d2d2ad336872c07537077ea920132a4cfd63d9133fb6af"
+    },
+    "my_progs/mon_dsergeant.qc": {
+     "bytes": 33493,
+     "sha256": "ada0cc4359a863c4e8d433c605a1c04ec6f7fd17ec852f5c4847443d3adaff1d"
+    },
+    "my_progs/mon_eel.qc": {
+     "bytes": 8252,
+     "sha256": "15c1f2fedba7077d352595e1be4a90f764354e4cf1875b40e1685d3ce81feb54"
+    },
+    "my_progs/mon_enforcer.qc": {
+     "bytes": 20146,
+     "sha256": "d453651d488afa789d0cea87ce99d9684329bbabdd17aa1625591f5a4b4ac90b"
+    },
+    "my_progs/mon_fish.qc": {
+     "bytes": 9705,
+     "sha256": "ff7d84db2c7917861ff5d81fe0e28f69d51143d27c4fba90dfcda11057222df0"
+    },
+    "my_progs/mon_floyd.qc": {
+     "bytes": 20332,
+     "sha256": "3ac2f0b0be94e311ff2fc4eee9cf66d5987af0e5c25fc06b8cc7b9efa6f581df"
+    },
+    "my_progs/mon_freddie.qc": {
+     "bytes": 25384,
+     "sha256": "4409a33e819f125852d0a4ada21a8fed2713012daec00922446f313031c845d1"
+    },
+    "my_progs/mon_gargoyle.qc": {
+     "bytes": 24293,
+     "sha256": "9e1f78b2364024efa6ec4142c1ecf4aff52cdf32f38031c34cf19e9cd74143d6"
+    },
+    "my_progs/mon_gaunt.qc": {
+     "bytes": 24111,
+     "sha256": "45be98ae0bdd32e0884280e18f867af037f2fcbf515914827c5f9107a87e52d7"
+    },
+    "my_progs/mon_golem.qc": {
+     "bytes": 35297,
+     "sha256": "dbaf3d1c0fec3166b0eb064a3c027dd3a0c907bed72b8e4581ffd74dad5ab5d1"
+    },
+    "my_progs/mon_hknight.qc": {
+     "bytes": 37618,
+     "sha256": "bac7d4b7832b95cea0f6890de66fbd0f7c4fcc7ce9051ef16ac042de465ddcb3"
+    },
+    "my_progs/mon_hogre.qc": {
+     "bytes": 24021,
+     "sha256": "8781ea9aaaa1d0f7ffb1fd8ec8b5981187eee6fdb8193160a1eb38770dffcfe0"
+    },
+    "my_progs/mon_hogreham.qc": {
+     "bytes": 23076,
+     "sha256": "b2ab6b830ce3aae7d6b033e8455de5011ded82e451ca171ea09940d9a3ec7740"
+    },
+    "my_progs/mon_hogremac.qc": {
+     "bytes": 23941,
+     "sha256": "9111c040ab1e5487936cce6ef1170e408c6d297d582702d202bbd27b0919d843"
+    },
+    "my_progs/mon_invsword.qc": {
+     "bytes": 9214,
+     "sha256": "f7287867cc6043eb7cd3fa3e1ecd5ae7115a84e5ef7021b2d5129afdb6ba6f46"
+    },
+    "my_progs/mon_jim.qc": {
+     "bytes": 22091,
+     "sha256": "55353984ad822dfd8c32f3b8ad9a06e8bfaab7bc5ff6f2a2326674ad4acd26be"
+    },
+    "my_progs/mon_knight.qc": {
+     "bytes": 24772,
+     "sha256": "d254abf88162436b9db48885ae8e59315c24c1e7f72a91d027a1d69fe9baf5b7"
+    },
+    "my_progs/mon_lostsoul.qc": {
+     "bytes": 23261,
+     "sha256": "2cdbf656c6b34164711fa88016542f4e3d2bd0555417ad00bab5ca7039f212ef"
+    },
+    "my_progs/mon_minotaur.qc": {
+     "bytes": 35316,
+     "sha256": "fbcef276ee3e2f1eeea8483303538190875e959b43efbf4f703be10fc72fc564"
+    },
+    "my_progs/mon_ogre.qc": {
+     "bytes": 24123,
+     "sha256": "d287d3b9024025237dbc68380f486572828a5114f9543599ba86b8bc35e9e25e"
+    },
+    "my_progs/mon_ogrextra.qc": {
+     "bytes": 9387,
+     "sha256": "41a9243c6006326195197a4dfba6ea4c1f1fbd729ec10adc48cfd7badd7a18de"
+    },
+    "my_progs/mon_pyro.qc": {
+     "bytes": 18235,
+     "sha256": "bd35f02c63af315ddf4820e388d0248cf065f1170bd7306957a1e86fa7e47306"
+    },
+    "my_progs/mon_scorpion.qc": {
+     "bytes": 22136,
+     "sha256": "0432d7c5e1b6a30a5452aba12b9fb6a3c2c7f3c582b1392d420414e66b8fb257"
+    },
+    "my_progs/mon_seeker.qc": {
+     "bytes": 29703,
+     "sha256": "d33939357840eedbfc63c56d6415d8fefd21de2c477b24b3165cdadcca2acd2c"
+    },
+    "my_progs/mon_sentinel.qc": {
+     "bytes": 10217,
+     "sha256": "946232c7169bf3fa966ce875523dd45402772f8045c51a96dced04f2f5f5788f"
+    },
+    "my_progs/mon_shalrath.qc": {
+     "bytes": 16434,
+     "sha256": "1b6fdf2447d7fa281d126118a9bc0e097de7b4dd4d10a33e60d5cf0ca785c58b"
+    },
+    "my_progs/mon_shambler.qc": {
+     "bytes": 23050,
+     "sha256": "576f71a38d75eedbdf58c291055674be8da5f0d04540e26311d65f70b58ee842"
+    },
+    "my_progs/mon_skullwiz.qc": {
+     "bytes": 36245,
+     "sha256": "6d3c2242bffe6eabe3f9cc59e881cb2296213cfbff809e1be045a80ca46aac53"
+    },
+    "my_progs/mon_soldier.qc": {
+     "bytes": 21645,
+     "sha256": "704c534062b11c4fc16416154c7706c125221660cdd4d9b02e00575b94c04103"
+    },
+    "my_progs/mon_spider.qc": {
+     "bytes": 30593,
+     "sha256": "4d0bbb7e38e51cef07912e6071e6bb9739e019a2d93129d38dbab9492bf43aee"
+    },
+    "my_progs/mon_steelclaw.qc": {
+     "bytes": 17126,
+     "sha256": "78dd4bb46dd76b2ff1f7d4a9f0b0902f25d94ebe13ace6b997a7f604c3718700"
+    },
+    "my_progs/mon_swampling.qc": {
+     "bytes": 25637,
+     "sha256": "fb5ed328cd3d5c09704bb84f39138463a7d26b8b1d45771e55e9ae952b1d2470"
+    },
+    "my_progs/mon_sweeper.qc": {
+     "bytes": 27025,
+     "sha256": "8f7a1d077779d88d542a325c1ae4ba4ff59d48bfcb334150ae3f024525bb725e"
+    },
+    "my_progs/mon_tarbaby.qc": {
+     "bytes": 11866,
+     "sha256": "88c9481ab7fe0cbe97d2b836492ff51b368aeae8d4ff3e5852734bb9f63a1b2d"
+    },
+    "my_progs/mon_turretbal.qc": {
+     "bytes": 38519,
+     "sha256": "fdcf915248dda5fb6a744d284233d46a2e6d62c8e4fd02fdd5bafe4f46167d30"
+    },
+    "my_progs/mon_voreling.qc": {
+     "bytes": 27678,
+     "sha256": "7734614fa6b2da2195bf3804415c06a2d10f35825e86abf4f85613a182cf21c2"
+    },
+    "my_progs/mon_wizard.qc": {
+     "bytes": 15155,
+     "sha256": "3101ca37b57343697b3d3c7637fdc84c842f78ec9081e401dcaa6df0a9b1df83"
+    },
+    "my_progs/mon_wraith.qc": {
+     "bytes": 35464,
+     "sha256": "6a28a205cb8ac574e98c8d34a01ea859922e38d55c66346a7aa867ebf84bdb5b"
+    },
+    "my_progs/mon_xmas_elf.qc": {
+     "bytes": 17589,
+     "sha256": "053eec412485090ee1ebeac25887382db40e2ba7ca456050ba4407be3ec8bc1a"
+    },
+    "my_progs/mon_xmas_raindeer.qc": {
+     "bytes": 12189,
+     "sha256": "abbe1dd5c96c25b631231d4db2f17e8243075ad08c082e0448b7cbff34f1ae0c"
+    },
+    "my_progs/mon_xmas_santa.qc": {
+     "bytes": 17853,
+     "sha256": "cc60c6de17bc3321f9b1cf75b3229e387592c9eb7fc4bb57c1de0a8d2c0e62e6"
+    },
+    "my_progs/mon_xmas_snowman.qc": {
+     "bytes": 11486,
+     "sha256": "65928bb70cb2e9352c2f5e036eda2a6bd97aea09d459d0af563a82aa5a2f2673"
+    },
+    "my_progs/mon_zombie.qc": {
+     "bytes": 33988,
+     "sha256": "83f56482374c3a79fcc64058989bd210af3add006b7388d89c92e90543ec56a0"
+    },
+    "my_progs/mon_zombiek.qc": {
+     "bytes": 42214,
+     "sha256": "2b9926454484e93f5c053bf4fd35b2a97cf7e835c26c3b30061f1ff391af9f5e"
+    },
+    "my_progs/monsters.qc": {
+     "bytes": 56573,
+     "sha256": "c2c75832e6d5e83e929214ba5c1aa9a4661bcaf7754c20b3e9648171bf804a58"
+    },
+    "my_progs/part_emitter.qc": {
+     "bytes": 82744,
+     "sha256": "fca7491171d58974ef6b15550b9a7f0474641e9eac7ee5de52c6980c96445518"
+    },
+    "my_progs/part_generate.qc": {
+     "bytes": 42914,
+     "sha256": "83b9718a85418143d92ea8311cc8cce69c1002eb7563710dfe7010ac52e15d50"
+    },
+    "my_progs/part_manage.qc": {
+     "bytes": 27407,
+     "sha256": "86eb791f4bba08fc0c965e9f81c90e7412ed2c910104d66a56cce1f3152808fe"
+    },
+    "my_progs/player.qc": {
+     "bytes": 27811,
+     "sha256": "1f0cc3eaf577c2af642495466c573cd6e226a4754902d9de9cbfc9c9ba28af0f"
+    },
+    "my_progs/progs.src": {
+     "bytes": 2482,
+     "sha256": "c773f107c562f731fbb30158422226bdc4576dd32aea0f02c122195e08eac96f"
+    },
+    "my_progs/pushable.qc": {
+     "bytes": 19823,
+     "sha256": "03b3bf9240db6e9532e45a3efc159129709f9ce095c3238daae32daddd5b07ec"
+    },
+    "my_progs/qc_highlight.xml": {
+     "bytes": 6348,
+     "sha256": "a7b326723cc1e4025e867ea5da00f54c944705600d740538aeb52f63cd027ab5"
+    },
+    "my_progs/settings.qc": {
+     "bytes": 61298,
+     "sha256": "7a1ae40ba7fa97ff7e7019017bc7640fd49d22943a2ca57c7a7e48702bbe7158"
+    },
+    "my_progs/sounds.qc": {
+     "bytes": 19389,
+     "sha256": "bb74ecc36a241db5a79b010f61200687c6db6e46297db39c8a2a8ce1d512bad5"
+    },
+    "my_progs/sprites.qc": {
+     "bytes": 476,
+     "sha256": "579f48b397914b02f8fb86dc24f23d4e63a4cd857df1f0eaefd6c83e9c49e238"
+    },
+    "my_progs/subs.qc": {
+     "bytes": 23545,
+     "sha256": "123ca7120e7ea4e4ca63bfd081caf46c7acd1560af4702c1bff40821d7f6ef44"
+    },
+    "my_progs/subs_soc.qc": {
+     "bytes": 28453,
+     "sha256": "679112275e8b3597daac962074f69b6d9fd5614fc3dbff036815b9365e1413c5"
+    },
+    "my_progs/switchshad.qc": {
+     "bytes": 7054,
+     "sha256": "92a2fd4e5c41f21f46502781322ab87584bf0999d733db50e0e19b8bbea793b3"
+    },
+    "my_progs/targets.qc": {
+     "bytes": 58758,
+     "sha256": "e39b45bf6740be40c2899376e92d30d7d227a4762091d7b63e382c79fe6822e7"
+    },
+    "my_progs/traps.qc": {
+     "bytes": 24071,
+     "sha256": "9e4e822a36113bc73958fa45ab0b8c290a5148c95f3a4da7125676c984ebd202"
+    },
+    "my_progs/traps_pendulum.qc": {
+     "bytes": 17049,
+     "sha256": "b421f26fd80eb74715172e25f3ac992faa95397dd67d5f7ede286fd78384a468"
+    },
+    "my_progs/traps_sawblade.qc": {
+     "bytes": 9783,
+     "sha256": "9a6e82a05f09001c0a9cffdf6b9d6399691846c5b1ab1fbfb470e5772a87f44b"
+    },
+    "my_progs/triggers.qc": {
+     "bytes": 139586,
+     "sha256": "2e5819bf11fecf01856bd7547af63b7c4927dec59237419dbf3dc79bc023f54d"
+    },
+    "my_progs/triggers_states.qc": {
+     "bytes": 17475,
+     "sha256": "2c4d25c11de0319cd54d81e67e651c8d29d22aca851988d21080ba5976137f14"
+    },
+    "my_progs/weapons.qc": {
+     "bytes": 44346,
+     "sha256": "f23d0cc07bab402da965ec3fa91d7de86ccabcb03c9019cd7b217fbca7fb4279"
+    },
+    "my_progs/world.qc": {
+     "bytes": 39815,
+     "sha256": "b933caca23d5a45e5d9368627b3d651af244af0aa345b91017d263be4bad7b77"
+    },
+    "particles/fte_weather.cfg": {
+     "bytes": 2758,
+     "sha256": "e0d383b0222f14edbd2bc04c1269206bbcdca22cdeac6840b5d831c042ff698e"
+    },
+    "particles/particlefont.tga": {
+     "bytes": 4194348,
+     "sha256": "bf90d469b3b41c2393f5ed0f58b4411cc8825f452341bbe3ba848c3cc855639e"
+    },
+    "particles/particlefont.txt": {
+     "bytes": 9872,
+     "sha256": "9e84ef35b813211196f8dfc8f89a420fd9d847ea514e43d0c3246ee666000b88"
+    },
+    "progs.dat": {
+     "bytes": 2345354,
+     "sha256": "f3c4218216ea0d3b00db35eef9e72945ee6687006b3e82c37ea2ae33a0eea922"
+    },
+    "progs/ammo_battery0.mdl": {
+     "bytes": 10552,
+     "sha256": "06d4f0235faedd3430e57d602ec29a2a91c0b23bdc30debc069212264a0faf54"
+    },
+    "progs/ammo_battery1.mdl": {
+     "bytes": 10552,
+     "sha256": "0cee39ac60c3eda7b5f1d1efde52f8be19c9e4f425972f16ba6d6362d646afb6"
+    },
+    "progs/ammo_cells0.mdl": {
+     "bytes": 27228,
+     "sha256": "b6f5a07c9fd48cf27f0873320589dda1e20afe7d64cd40b6c950e5f892a34fa2"
+    },
+    "progs/ammo_cells0_edit.mdl": {
+     "bytes": 27228,
+     "sha256": "47ffc9eb8ec352ab2fa479f35ee5b6ec0e0ac8f472a06fbe00e8298e9d683ed5"
+    },
+    "progs/ammo_cells1.mdl": {
+     "bytes": 29836,
+     "sha256": "c23b4e85e9edd68fec2d751af85cff391a11848bd4338a3c59a2c055508cfce9"
+    },
+    "progs/ammo_lidlarge.mdl": {
+     "bytes": 25252,
+     "sha256": "d941a1c520e49694d66598f3430420541b318cea3e1cf02d3957e06d010681a7"
+    },
+    "progs/ammo_lidsmall.mdl": {
+     "bytes": 25252,
+     "sha256": "221b3aaa2324bea668276d3de521c4945004a71368983fc74c50c4b53425c436"
+    },
+    "progs/ammo_nails0.mdl": {
+     "bytes": 14072,
+     "sha256": "1090a9c50a943c2bf04302914f69b835ecf79fbf3013f259a12668ebd57aad5a"
+    },
+    "progs/ammo_nails1.mdl": {
+     "bytes": 15976,
+     "sha256": "8dd339507f4e18953ceefe3922d04ca513728bf2b0745813723873427843213b"
+    },
+    "progs/ammo_rockets0.mdl": {
+     "bytes": 24836,
+     "sha256": "9f272b2f1cb52fcf38983f63052db653e8208b2ee1eedf053e99dca6e439c7d8"
+    },
+    "progs/ammo_rockets1.mdl": {
+     "bytes": 27672,
+     "sha256": "46d85f10a260cf13d6711420f11a235089536a3725363be0717c2ee3e7e8a18b"
+    },
+    "progs/ammo_shells0.mdl": {
+     "bytes": 14072,
+     "sha256": "053e466f1666314cbfc0cd6f67821850ad39505a6a0bbf37c80b127e6887e5c5"
+    },
+    "progs/ammo_shells1.mdl": {
+     "bytes": 15976,
+     "sha256": "6183880b36171b6784cecf74b50aea2e1fdbc17b1b0b304a89125e964d63fd1f"
+    },
+    "progs/armour.mdl": {
+     "bytes": 76144,
+     "sha256": "b6e297062cffd435d6ce5cc17854e25a49ff09750ee1eaec6d5004266884099a"
+    },
+    "progs/artifact_airtank.mdl": {
+     "bytes": 50184,
+     "sha256": "4702b7be1baa517669edd24f5b67377f532382bfedebd77b5d77f9a499f3f08b"
+    },
+    "progs/artifact_blastbelt.mdl": {
+     "bytes": 28436,
+     "sha256": "a935de1300f6fc4f03b6fc57bf43791ac32b74d55c5509eda84339dc33f0bf48"
+    },
+    "progs/artifact_envsuit.mdl": {
+     "bytes": 260844,
+     "sha256": "09192fca32cf5b7632cf0fe9cccd9b4b1313c0e92708e85f840b0971aca5d274"
+    },
+    "progs/artifact_invis.mdl": {
+     "bytes": 7108,
+     "sha256": "f6b0b925b584402d85a623e1924c50a4fb3f3a4994cb1d2f05a169a3af2e39dc"
+    },
+    "progs/artifact_jumpboots.mdl": {
+     "bytes": 37428,
+     "sha256": "668d649addf958be26f2bcff31baf3afa5ff176a178ef15073c87cc7cb57e2b8"
+    },
+    "progs/artifact_lavashield.mdl": {
+     "bytes": 469773,
+     "sha256": "2e3027df661ca197750df97599084442afda131fbf1b545ea38d40e93afff908"
+    },
+    "progs/artifact_pent.mdl": {
+     "bytes": 21412,
+     "sha256": "7ae90fc895f23f57952dacf4d8af125f99347e09edf6f0287c7e508faad67b46"
+    },
+    "progs/artifact_piercer.mdl": {
+     "bytes": 19012,
+     "sha256": "fd73ca18d93904647df923f2d0383958386c7deb9cf27547beda74c61a9f8831"
+    },
+    "progs/artifact_quad.mdl": {
+     "bytes": 22052,
+     "sha256": "bf6d2253210784391ee1ab9b38d2b6fd661a520434bb127d293f4d202040d1b5"
+    },
+    "progs/artifact_sharp.mdl": {
+     "bytes": 49248,
+     "sha256": "505fc06618d7cecb83c03ad7d7762011ff8cff025eecf007b200d87fcc2483cf"
+    },
+    "progs/artifact_tome.mdl": {
+     "bytes": 21412,
+     "sha256": "ee8cf94e2c87ff6c0d4aa8777da2f0ddb79605bf790fb8f9ed2f49c6c1f9b9cf"
+    },
+    "progs/beam.mdl": {
+     "bytes": 26020,
+     "sha256": "bd06e42c7f0d911a4ef1077c95d474b86f62bca4da02183449687c23879e8c6d"
+    },
+    "progs/brk_pot1a.mdl": {
+     "bytes": 93352,
+     "sha256": "5612b9539e9663e06397f315968674b1de6ab50db7cdf673baadcd4652cedcd5"
+    },
+    "progs/brk_pot1aflr.mdl": {
+     "bytes": 93352,
+     "sha256": "02fd1feb7dc24b456e31f26f142aafb9adf491a16ea4caf2c4ec237e465260a5"
+    },
+    "progs/brk_pot1b.mdl": {
+     "bytes": 93352,
+     "sha256": "47c4053f0c0c941674a9d7c15a07e05c7ed648b2bf8ffbd1defb7264c151b47a"
+    },
+    "progs/brk_pot1c.mdl": {
+     "bytes": 83968,
+     "sha256": "a408707cc6793c337d0e76d86c5362de39a1f2109c23affe5def6e8194e0f4e8"
+    },
+    "progs/brk_pot1d.mdl": {
+     "bytes": 74024,
+     "sha256": "c31abc1e9e5af2cb86614f68a8be55f6192e05baba8b93479e2b2590b1e0ef1d"
+    },
+    "progs/brk_pot1part1.mdl": {
+     "bytes": 33768,
+     "sha256": "2dd32863b6006dda74b60f05a43df13e7df052ddcdb652309ba0ab29fa5352e5"
+    },
+    "progs/brk_pot1part2.mdl": {
+     "bytes": 34072,
+     "sha256": "550cae5c8893c63520c324610950eeb5b9fe842dc8ea1f07f6a217953f6e743e"
+    },
+    "progs/brk_pot1part3.mdl": {
+     "bytes": 33464,
+     "sha256": "819cf0e720637e7c5e187ccc67ae032eca217ee2f07076aefee1a8b7de894852"
+    },
+    "progs/brk_pot1part4.mdl": {
+     "bytes": 33496,
+     "sha256": "a3cc47c7f7410bb0ca2308e45144b29bc3b678600e0f288b15d8e64525585e43"
+    },
+    "progs/brk_pot2a.mdl": {
+     "bytes": 77348,
+     "sha256": "ffcf5e5f3d0b81143e2b2b387cde7b13b2d36b71345d63456f288eb036993a2b"
+    },
+    "progs/brk_pot2aflr.mdl": {
+     "bytes": 77348,
+     "sha256": "37420048a9f72abc5982f5f6813602dbc4b82ef8e788a0e309df7ff13066ea62"
+    },
+    "progs/brk_pot2b.mdl": {
+     "bytes": 77348,
+     "sha256": "40eb2c849cd06d9b985b0efc2b9d1090ec1648b0de53d0a07bd6fd5fe2af6733"
+    },
+    "progs/brk_pot2c.mdl": {
+     "bytes": 77348,
+     "sha256": "3774ade6790fc2b597c44c5206deeb3d5d3d20a23331e3fb622e1e90f833c7d4"
+    },
+    "progs/brk_pot2d.mdl": {
+     "bytes": 79004,
+     "sha256": "2af25d81ae0f1d8724f3047e95ff2f1d1700061a536b3f9ffda5522cf7e8dd13"
+    },
+    "progs/brk_pot2part1.mdl": {
+     "bytes": 34456,
+     "sha256": "13547d9ca8c36bbcc95354df03dfbdc14f19f74251ff1dc8c417436846b396bc"
+    },
+    "progs/brk_pot2part2.mdl": {
+     "bytes": 34680,
+     "sha256": "7f9824c52b01664c2dd1ccc5c1dc9e7ff2a5567dd2d0a8e9c3bf1a8bd00400e7"
+    },
+    "progs/brk_pot2part3.mdl": {
+     "bytes": 34008,
+     "sha256": "52fdc17879e0b6fb8697e1e9fffba092f1b5aa8d3cee5d657b405eb4119e8e87"
+    },
+    "progs/brk_pot2part4.mdl": {
+     "bytes": 33304,
+     "sha256": "b40cf2b029a4bfac52a80f5aef6587f3eb66e08be1fe5f40cd3f97e93133ad3b"
+    },
+    "progs/brk_vase1.mdl": {
+     "bytes": 27992,
+     "sha256": "28a8b9a0d367f17c2c265271d99b019f1762831a11ba794e2884fc7f7a8a2368"
+    },
+    "progs/brk_vase1part1.mdl": {
+     "bytes": 5524,
+     "sha256": "b8c0bef8f5d6a427f57282f086a75f39e91ad6ab035d4f1d437da97794e52f9e"
+    },
+    "progs/brk_vase1part2.mdl": {
+     "bytes": 5556,
+     "sha256": "8e1df7795140732953af83a1ef2158299a2cc393163041b6d3243478b6b644e1"
+    },
+    "progs/brk_vase1part3.mdl": {
+     "bytes": 5556,
+     "sha256": "c2e3da479defb1c3bd5130555e33dd47afc6a3b4ef7f74d4f0184cb02a02a46d"
+    },
+    "progs/brk_vase1part4.mdl": {
+     "bytes": 5524,
+     "sha256": "986c51c2cb3832f597f9dac89c6044d090b10933306814acc36a0c4ab5a04b93"
+    },
+    "progs/corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "839b70bb6be7fac8c25e6069b999e076b04bdd3dbc7a9320924713cf75c2cadb"
+    },
+    "progs/corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "cb994b390584e1776ad1f0e60d95186a0dc54cd160a2cb8284d1a15b4fe1a35d"
+    },
+    "progs/corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "b19faa9afe7cf957ae7abf6439799e5001ff42817290f4b464aa3f7ae4e3377f"
+    },
+    "progs/dance_player.mdl": {
+     "bytes": 465924,
+     "sha256": "d07f23e6a40743aeac01084a1da9670ea9a635339d86be46149e9f0ee74661e0"
+    },
+    "progs/explode_box1.mdl": {
+     "bytes": 49888,
+     "sha256": "c8a7e667c5e20735db9a816b7a11b5a1c67bf4e176d1553a79cc56bcaa9ff35b"
+    },
+    "progs/explode_box2.mdl": {
+     "bytes": 49888,
+     "sha256": "649dbfabde0a875a0c35b0109261515dc9eb287d0cc7f41ca3712283e62509c1"
+    },
+    "progs/flame.mdl": {
+     "bytes": 41668,
+     "sha256": "d6cb4dc28d5101538b44ed53fe1cf84c9d5f8547a91eb74fc6c6bdd3645ffa17"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 74548,
+     "sha256": "f03dd3b7f94a86c4d91ffb002723a16f30321a0c2189b673dd4f12f547245816"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 71268,
+     "sha256": "b1e734caec73b941b1c033fbb49ffc0f947aa8e1d47250c2d8cec0f244870fc8"
+    },
+    "progs/g_ghook.mdl": {
+     "bytes": 64684,
+     "sha256": "9cdd8bccab5f11ea7f8ea6480a4ea05c9d749bc4746cc19a6452a2e0356edfc6"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 32404,
+     "sha256": "b195b37f7e96274ea7db8e70dcf5971275bafdd0c9c10c29f2dc540c38641953"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 35876,
+     "sha256": "8ee090222c89209eec97120d5542d69a9f75b8a8aa896cd4df256d438ce83495"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 25316,
+     "sha256": "261a8479de0d5df9aea9931a62b1b93dbb7bfcff4f4467920cbebcc9c2c25381"
+    },
+    "progs/g_shadaxe.mdl": {
+     "bytes": 398968,
+     "sha256": "19d6f210a771748da589282e63a222c6c9c41a21085ed3f57f70d7f5aa20bd66"
+    },
+    "progs/g_shot1.mdl": {
+     "bytes": 24580,
+     "sha256": "72913fa948f1618347adaa91ceb98203186d2fc7bd3b9c84af00f7f637928058"
+    },
+    "progs/g_shot2.mdl": {
+     "bytes": 15876,
+     "sha256": "8ae318a3e697e4c85f60a4e5997b673e8e48f17e295551c2b0b5d0c643b3ac24"
+    },
+    "progs/g_shot3.mdl": {
+     "bytes": 156216,
+     "sha256": "8a602686e322d7357a102e0c8e91907c8b3975a8b6d36ba19f3c645e450285da"
+    },
+    "progs/g_zershot.mdl": {
+     "bytes": 68020,
+     "sha256": "3439ce2faa846bd2b3ca50e33b55092454ed83caaf8fe654d8381e107aa3520a"
+    },
+    "progs/gib_1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib_2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib_3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/gib_4.mdl": {
+     "bytes": 7468,
+     "sha256": "29f9cfa3d86121e1e349de9c3a39e620b9d6ba2cd98640536923e581f7ae28bd"
+    },
+    "progs/gib_5.mdl": {
+     "bytes": 85308,
+     "sha256": "2023ae2fd305843640266ec6679511d134e1b84ac54de245a390e483557050bd"
+    },
+    "progs/gib_blclaw1.mdl": {
+     "bytes": 32860,
+     "sha256": "303c38aea48534d4ce34f3c2082a21c7408c1e4a4cd848bc7e4acadfaaddbdc0"
+    },
+    "progs/gib_blclaw1b.mdl": {
+     "bytes": 32860,
+     "sha256": "c22db765c594ee28a0863cf70e354c651a2b9282e1df7e3a57b35ce62932920d"
+    },
+    "progs/gib_blclaw2.mdl": {
+     "bytes": 32860,
+     "sha256": "c7d70c4c067aa297fbebc3d26a2068a62f307c7f00f8d15d0bf76ed9519967c8"
+    },
+    "progs/gib_blclaw2b.mdl": {
+     "bytes": 32860,
+     "sha256": "96a96606a74eb3093d88f1f946d66caf77bd57fde0a4ec44840c95fa12130551"
+    },
+    "progs/gib_blfoot1.mdl": {
+     "bytes": 32860,
+     "sha256": "74e05efa33fc9036399a1f1d484a3816129fe0e379aee579b923cf3316e5ab84"
+    },
+    "progs/gib_blfoot1b.mdl": {
+     "bytes": 32860,
+     "sha256": "2d23324414f3f1a25ee24afe914679d07df244c9c0e48139331f084b8c369054"
+    },
+    "progs/gib_blfoot2.mdl": {
+     "bytes": 32860,
+     "sha256": "c2ce3b46d8762b042d201608271c3441b975b93e6329790ca5cba61294f71e45"
+    },
+    "progs/gib_blfoot2b.mdl": {
+     "bytes": 32860,
+     "sha256": "de945be28e0b05dc380a0a2cfff6907f14a5e4b9756385874fddd712df095bb6"
+    },
+    "progs/gib_dmclaw1.mdl": {
+     "bytes": 49248,
+     "sha256": "be5f2bb9174ce47f6d3df06685ac728c852c3a028f6aeb1632e709eb69c20ee2"
+    },
+    "progs/gib_dmclaw2.mdl": {
+     "bytes": 49248,
+     "sha256": "ff6cc88ef9123812b9d8e09235074f4c7fcad47077e6fffee334f15e3f71eb27"
+    },
+    "progs/gib_dmleg1.mdl": {
+     "bytes": 49248,
+     "sha256": "106990e4d9e2746303d09ae6c481914702af0242d8cf0fc9d430d0fa5329813c"
+    },
+    "progs/gib_dmleg2.mdl": {
+     "bytes": 49248,
+     "sha256": "8308124b7c4dca218af9e8ef7042ddcb0ca2fcb30e7f86866b1a28a73ab94db2"
+    },
+    "progs/gib_dmtail.mdl": {
+     "bytes": 49248,
+     "sha256": "6b60c464ee0e7ace54313550ac5be2f4949cc6f8dd539b38459c4a6c395e6704"
+    },
+    "progs/gib_drolearm1.mdl": {
+     "bytes": 18324,
+     "sha256": "a6b0f55da1b1d8e519b3cb9a53afe229279c760ffab3862866d8c4e7a52f267e"
+    },
+    "progs/gib_drolearm2.mdl": {
+     "bytes": 18212,
+     "sha256": "aff67984dc3198d24d2184c35748e829d7f867c38227f1fa898a1986f12ac767"
+    },
+    "progs/gib_droleleg1.mdl": {
+     "bytes": 18436,
+     "sha256": "ab69d8c271f44998ccdfd10d70ccd06caa3c2674f46e4cf94285b380d08db501"
+    },
+    "progs/gib_floyd1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/gib_freddiejunk.mdl": {
+     "bytes": 71364,
+     "sha256": "13763a8cec3b643acb9b8165f1850ffae003131c84a2ac225777822a88462498"
+    },
+    "progs/gib_gargwing1.mdl": {
+     "bytes": 92088,
+     "sha256": "3979718d2403ca7cf75aad4004a56100c1bf358f2cb9ae68595e5d69f6774f47"
+    },
+    "progs/gib_gargwing2.mdl": {
+     "bytes": 92024,
+     "sha256": "7554ef45a88db1f2e457dd7071770e42bf864123827b9819435a628b412ecb32"
+    },
+    "progs/gib_judgeboot.mdl": {
+     "bytes": 199308,
+     "sha256": "557eadb703666c4868e1b231cb1c21fbff5e59e2ec0cb8ade85cd3839fd714cb"
+    },
+    "progs/gib_judgeshould.mdl": {
+     "bytes": 199132,
+     "sha256": "69e4958866a47d5c63a6385db4843a6a5011f149b25e67720291d2db63945ed8"
+    },
+    "progs/gib_justiceboot.mdl": {
+     "bytes": 264848,
+     "sha256": "b727239a7bf232c7c6164d0f9fc0961a6c692cb0c0919b17429ade6f62bdd71c"
+    },
+    "progs/gib_justiceshould.mdl": {
+     "bytes": 264672,
+     "sha256": "2fcafb2b2a19b8ae16009e827f13fea14cb389317ec476b7f58fb2fef1163180"
+    },
+    "progs/gib_knfoot_l.mdl": {
+     "bytes": 18288,
+     "sha256": "8ffcc7ce931662f2eefa0703642b140e18a99c02252ffa3ddeb71f6ebbbe360f"
+    },
+    "progs/gib_knfoot_r.mdl": {
+     "bytes": 18288,
+     "sha256": "4d503f422ac01a8565453ba4bd8268338c3a9802480785eebd27fc0487e46753"
+    },
+    "progs/gib_metal1.mdl": {
+     "bytes": 5172,
+     "sha256": "b0951de4d869e0b779aeb3f7a96f56b22a82a58d267a56b1247f0c3e667c25ad"
+    },
+    "progs/gib_metal2.mdl": {
+     "bytes": 6292,
+     "sha256": "3df78c49abb572095d3b70efbb99bccb63caf2ffd30bb3ee434c945084acb5a0"
+    },
+    "progs/gib_metal3.mdl": {
+     "bytes": 6036,
+     "sha256": "88f8a1f941e38f8528ec27a168559946cc0b69f2abce1cbf6858b813e09c5f51"
+    },
+    "progs/gib_metal4.mdl": {
+     "bytes": 6580,
+     "sha256": "fbde734f29a6691d51c58a40a89e45f81dece2f20218353a6137a2362acbe3a9"
+    },
+    "progs/gib_minoclaw1.mdl": {
+     "bytes": 135544,
+     "sha256": "1188f73d5a6319bef5e506ca994bfcf63074a4267a5a189cb92db94160310fca"
+    },
+    "progs/gib_minoclaw2.mdl": {
+     "bytes": 135544,
+     "sha256": "511bb72c8382f4cc3cc9fa3bea4adf2390dcca1e2dcd42ef8f8287765875fa99"
+    },
+    "progs/gib_minoleg1.mdl": {
+     "bytes": 135448,
+     "sha256": "f07ce357d83d3ab0f39109d93f2f6996ded4ff19a4372fd5ddc9d9fa1a0ce8d3"
+    },
+    "progs/gib_minoleg2.mdl": {
+     "bytes": 136392,
+     "sha256": "7ba78149bc60a05ceff9090ecc2bdf013ff2d55420dfdebc553a254ac0bd08fb"
+    },
+    "progs/gib_ogfoot1.mdl": {
+     "bytes": 5956,
+     "sha256": "144e2fdfbccceee039243ef343df02ce181b666070e2d0a1825c056634f2a632"
+    },
+    "progs/gib_ogfoot2.mdl": {
+     "bytes": 5956,
+     "sha256": "9997dff0bdb2622ef6ee2530c27835fd249aee04437e70486e76255f979bec25"
+    },
+    "progs/gib_p1.mdl": {
+     "bytes": 7712,
+     "sha256": "709c49c205b27793f589eab17e8356a108345069716f9095dc07dd6447be7894"
+    },
+    "progs/gib_p2.mdl": {
+     "bytes": 21216,
+     "sha256": "50d99c7fec3b8ef01bbb19c32c88dac40a372cb6a7d39c349e0ff4909360626f"
+    },
+    "progs/gib_p3.mdl": {
+     "bytes": 18176,
+     "sha256": "d53659aa99de418793337b7e878db7bd7836883ad43528d648475589aa30d85d"
+    },
+    "progs/gib_p4.mdl": {
+     "bytes": 7468,
+     "sha256": "71ad4dcc06038f0a175605a3906b1506d0144b56b238e7df178160d9ab876b8d"
+    },
+    "progs/gib_p5.mdl": {
+     "bytes": 19756,
+     "sha256": "adf63c881ff5703b8112f714140929375b5c10be957f01cfdfa131d89af3cacf"
+    },
+    "progs/gib_s1.mdl": {
+     "bytes": 7712,
+     "sha256": "31faee0daaf399feccc1ec942ff7fe85a1a790ebd93c3b8a1fcfde9bcc06da1d"
+    },
+    "progs/gib_s2.mdl": {
+     "bytes": 21216,
+     "sha256": "c85f7dbc8eec508951893253bba5eec169a87865c995ba1d0e5c083fed9e03ca"
+    },
+    "progs/gib_s3.mdl": {
+     "bytes": 18176,
+     "sha256": "ec23effca60ef407bf294a814003213928f21f05e6da501fbe996345b6171013"
+    },
+    "progs/gib_s4.mdl": {
+     "bytes": 7468,
+     "sha256": "5001ef206e1a36cc792d7b94054b2bab4c6dfbed60e0ee0d3afd240d1af88d13"
+    },
+    "progs/gib_s5.mdl": {
+     "bytes": 19756,
+     "sha256": "9e1a112412d38c559974c628649a7773ad445ba7d24a1804c5f3fe5f50ecef7f"
+    },
+    "progs/gib_scorpclaw.mdl": {
+     "bytes": 66816,
+     "sha256": "ecaf582e92d77a1722eded2c5564d2fb9575065510ff1bc9632538345ed18329"
+    },
+    "progs/gib_scorpleg.mdl": {
+     "bytes": 66304,
+     "sha256": "399067acf8f082301f6629d2b124b0d34a7d934db55c922205a96772a85a8a1c"
+    },
+    "progs/gib_scorptail.mdl": {
+     "bytes": 66864,
+     "sha256": "0831c04d7a73c6f58329b0be0f6d371f727ea880b49e5b6e16f7cdc56c124df2"
+    },
+    "progs/gib_seekarm.mdl": {
+     "bytes": 265688,
+     "sha256": "6ee70b2f4f39d8a1fd99113c7c8df5481c421960f160afea4e622ed5b3113014"
+    },
+    "progs/gib_seekchunk.mdl": {
+     "bytes": 265420,
+     "sha256": "a70331a8e43075b026cf21d364cf2341e79e7e60c5fca4777d10aabd57ce0323"
+    },
+    "progs/gib_shclaw1.mdl": {
+     "bytes": 22964,
+     "sha256": "20b29bf40dd02dce0204c14c34b0b5806d8eef580406851d73383a631ac8f2a7"
+    },
+    "progs/gib_shclaw2.mdl": {
+     "bytes": 23060,
+     "sha256": "8dcf777d5ffd2e83edf5b6f936881eaf9d384fe8fc980721c9f5881d3e6da0c3"
+    },
+    "progs/gib_shfoot1.mdl": {
+     "bytes": 23268,
+     "sha256": "634d7cbb9e2b718167fe74112e6dd4f53cfe1cffc32f75cd80e711a24cd2f983"
+    },
+    "progs/gib_shfoot2.mdl": {
+     "bytes": 23124,
+     "sha256": "aaa2393cb65fb33a8885bfdd9b808732c0aa17f0dd461d3b04e84eb27f0fe61d"
+    },
+    "progs/gib_soldfoot1.mdl": {
+     "bytes": 51148,
+     "sha256": "09357cfed1e6c9c25e0d133d95f2c2b36693cbed1010146a982bca685cb370ed"
+    },
+    "progs/gib_soldfoot2.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/gib_spidbodyb.mdl": {
+     "bytes": 17652,
+     "sha256": "313dc78de70f02de9a49c71a1fd5ddb5ae4247f90a1a04f0ab84f44797be1946"
+    },
+    "progs/gib_spidbodyg.mdl": {
+     "bytes": 17652,
+     "sha256": "5439ca0812bc2627f22fd995237607755708f7615782785093793c11497973e5"
+    },
+    "progs/gib_spidlegb.mdl": {
+     "bytes": 18560,
+     "sha256": "66dc12710dec1bd4827497e4ed28b6a4965e1f68b48d5f0903a96ecf632e7f4e"
+    },
+    "progs/gib_spidlegg.mdl": {
+     "bytes": 18560,
+     "sha256": "3474de5b97c2b424f8ec4b8d93a1457f13adca106bdbe15234492376708810f9"
+    },
+    "progs/gib_steelbody.mdl": {
+     "bytes": 17652,
+     "sha256": "2a833de4b00f439041d27d97b3660d4df1cc9e3b454dba5ac5533e5c855e8d90"
+    },
+    "progs/gib_steelleg.mdl": {
+     "bytes": 18560,
+     "sha256": "ae926ada1c4ef7b695764f2daa0b4704102bf5eebc103b9f6a56813337f43165"
+    },
+    "progs/gib_swampleg.mdl": {
+     "bytes": 4820,
+     "sha256": "2b549fd3a74b0fd6b94c71c9e397b466e2c7f823917ffe717ce1af43769e1961"
+    },
+    "progs/gib_swamplegp.mdl": {
+     "bytes": 4820,
+     "sha256": "b5cf22240bf6474cc8ea57c40ddb70f80e792c23cb87835bee94825cb645578a"
+    },
+    "progs/gib_voreleg.mdl": {
+     "bytes": 4820,
+     "sha256": "19ec59cb3436d66a8ac9d8f40480a9c83aef879f0f1e58ddb834710e2bbc4d9d"
+    },
+    "progs/gib_vorelegp.mdl": {
+     "bytes": 4820,
+     "sha256": "341679c553a719be40022fc4a3573ff68116fee7ae05df511b9083a410af5e7f"
+    },
+    "progs/gib_wraith1.mdl": {
+     "bytes": 5300,
+     "sha256": "a0642c84b36288a3d0cef22ac32e0c681c422a034204932671729624f19d0b2b"
+    },
+    "progs/gib_wraith2.mdl": {
+     "bytes": 6292,
+     "sha256": "d20a17e624d16e4c8552ac9a291cd735aeae670effc2c9865b37fbc7bcd22220"
+    },
+    "progs/gib_wraith3.mdl": {
+     "bytes": 2516,
+     "sha256": "63f10b068c6df0a80729362c094f72d0bcf90f74de97636bc5e4a630c13e741b"
+    },
+    "progs/gib_wzarm1.mdl": {
+     "bytes": 12384,
+     "sha256": "9b6f5469bfc6ae49d2bd51fb6d35e686c4e79e5691e2fb80fa7ee556bf547e04"
+    },
+    "progs/gib_wzarm2.mdl": {
+     "bytes": 12384,
+     "sha256": "2ff539f467ca9b0f23c40cb2547221a484afbe7e07a812558ec1595e5cbd0217"
+    },
+    "progs/gib_wztail.mdl": {
+     "bytes": 12384,
+     "sha256": "fb90123980ff4510e744ea2b21509492b7ff9c131527ffe5c7b80bbbf881bf41"
+    },
+    "progs/h_boglord.mdl": {
+     "bytes": 98400,
+     "sha256": "119279b2ffdf928d34ef1470ae6c14f875cb59edc6d8b107a90bbea122c9acdc"
+    },
+    "progs/h_boglordb.mdl": {
+     "bytes": 98400,
+     "sha256": "25af0d0ea45857e64549686bb58e5f69a0754ff6e43c26ce735e58aaac3d534e"
+    },
+    "progs/h_centurion.mdl": {
+     "bytes": 63592,
+     "sha256": "2e64af530a4f5f36001ad922bb56a941738e7fe2c67c0ad0e3f06fa5854c4b08"
+    },
+    "progs/h_dcrossbow.mdl": {
+     "bytes": 25700,
+     "sha256": "0354fdb96bd5490bc18527d68813a43a41f943a05f7edca26c1aea7b943185be"
+    },
+    "progs/h_deflector.mdl": {
+     "bytes": 22232,
+     "sha256": "56de00c315543073bfda7e8a5ad3c3996f549351fa1e660e676516f4122cdeac"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 67688,
+     "sha256": "ff73d5f8fcab46a806c47377679ec5473cdc0ea93a0fda6dda8b5dba8cfa4b97"
+    },
+    "progs/h_dfury.mdl": {
+     "bytes": 14036,
+     "sha256": "3753a68126ff7caee3219c31533a1731ae9a80623c6af69315c7526f5c92669d"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 19296,
+     "sha256": "6b0867e61635543a7bb3b02647855f1384961095cd06dfc786a537b11eb926ae"
+    },
+    "progs/h_dguardq.mdl": {
+     "bytes": 4920,
+     "sha256": "337f2723daab9d1375b78cb017512ce8281087ff8df9c33b04a6c613cea3590c"
+    },
+    "progs/h_dknight.mdl": {
+     "bytes": 32144,
+     "sha256": "30af2418019b946f3582f70d2356357a97dff0391f86a9fb0abd5218cc799020"
+    },
+    "progs/h_dlord.mdl": {
+     "bytes": 18699,
+     "sha256": "bc5a92be1c5f3d06dc0238ec7bafe6a3c25826cc50edc6214ed5aa19b0075987"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 27652,
+     "sha256": "49f28b9a13867ed4a88fcac541b8a9cbabddcc594557b3490951179b3d479509"
+    },
+    "progs/h_dprince.mdl": {
+     "bytes": 19336,
+     "sha256": "77855cfc2667ed68c61d389a44ed312abc3ad1e029ea003d03e78e7131fb803c"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 14032,
+     "sha256": "bd5da6afddc520999d9c572a679c3bc8c43635ce2c73f8789603eb6a83c15aa1"
+    },
+    "progs/h_eel.mdl": {
+     "bytes": 156904,
+     "sha256": "a859ee09044d9afcd05ee2af3f1ea8c7b4ae3abc01273922dbebd5aa67b12d74"
+    },
+    "progs/h_enforcer.mdl": {
+     "bytes": 94612,
+     "sha256": "21046f6878f5f4173206debcb912d9fdee0b1f5c66d820a4355c7df8e2eb1860"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_gargoyle.mdl": {
+     "bytes": 30152,
+     "sha256": "bbcf207c44814f5e665944db03800934eab9046a0d0d86f4c982a3116f855791"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 59888,
+     "sha256": "f57daa1ab6a721a9feb696aaeeb597c720b639cd0a027a1b1da8cdd68ad1d1f0"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 30552,
+     "sha256": "edf8a4ccc52bfd9545fda8da9360e536c026079f8d2fd9756191fc934bd55683"
+    },
+    "progs/h_hogre.mdl": {
+     "bytes": 23688,
+     "sha256": "6f21e95518cd085d20b1023951ddf4d738285210bc95c6e2b3d2e82566478776"
+    },
+    "progs/h_hogreham.mdl": {
+     "bytes": 22776,
+     "sha256": "3d3e43d16c4babcbca358b44dc03ad1a212e22ea3a10ee9e639b5f4c2e95f670"
+    },
+    "progs/h_judge.mdl": {
+     "bytes": 203276,
+     "sha256": "be57ef7327fbf3ea6fb55c02bcccc4ec207b3781bb9d2e383939f3840e1ef91a"
+    },
+    "progs/h_justice.mdl": {
+     "bytes": 268816,
+     "sha256": "01d3011001c297b85a139ecb2861f188d15b96cd1ae02f08cb1604565f2d2ee3"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 42068,
+     "sha256": "aa979e22745c960cd100e814bce62018f2b992481e57838548f0ddf4816c27a8"
+    },
+    "progs/h_minotaur.mdl": {
+     "bytes": 138264,
+     "sha256": "c5e13818c813680fd29a94b408518731aa4e9007c23d004ec874f099c9ced6b1"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "4967d418f4810e9273732bbd4c690a1f9478243f7fe3807497134eb2994da0eb"
+    },
+    "progs/h_pyro.mdl": {
+     "bytes": 42912,
+     "sha256": "5359fd85e71cde1ab716d8d50a8618a347dd42b4ad4692805bf41c1903d55c18"
+    },
+    "progs/h_scorpion.mdl": {
+     "bytes": 67408,
+     "sha256": "d68d09c35c00d9bafb302fb7f3baeef90ee5d60de1ad8a7627f979c3561f5965"
+    },
+    "progs/h_seeker.mdl": {
+     "bytes": 9060,
+     "sha256": "9e9d601441532e16aee253b5e94ea9c32563f880782794d16ce496a580698bd8"
+    },
+    "progs/h_shalrath.mdl": {
+     "bytes": 78156,
+     "sha256": "f478f17ea9ee6843be2ebe3c487d0036657c94ace52a800fa44e0160d02a522d"
+    },
+    "progs/h_shambler.mdl": {
+     "bytes": 98400,
+     "sha256": "6508f7b05b65f230b7f1280d2023e9ed200663715db1709c43e7e187e3ed841c"
+    },
+    "progs/h_skullwiz.mdl": {
+     "bytes": 234304,
+     "sha256": "625c991e231d6836c36ae0c6651ec06f05541e9a7be605654fb43fba65bcc3d4"
+    },
+    "progs/h_soldier.mdl": {
+     "bytes": 166488,
+     "sha256": "0a4e322fbac8f98755adb9a4bf5ecff24d58aab30fcb1c9def3e97a0f686445e"
+    },
+    "progs/h_spiderb.mdl": {
+     "bytes": 18564,
+     "sha256": "d51c7764fccc4512db6d79ddcf03ffe42cf2817a66d6be02be0cba6551ee1206"
+    },
+    "progs/h_spiderg.mdl": {
+     "bytes": 18564,
+     "sha256": "70bec9669f3a7f3662320e32d29c38d535092db56617d5033e11669038472e2b"
+    },
+    "progs/h_steelclaw.mdl": {
+     "bytes": 18564,
+     "sha256": "be9adcdf9cf9407a729cfa9abcd692f46a55ffcf25c1878a7b2f5572fd591f8c"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "63b8a0b90691ae9a3c50a94f02943a1b94946f89402cc4e1da74c6806bd953ba"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 23516,
+     "sha256": "5a933ecbc067b8d6cbb57f71ae1614844b6e55170a206d278b3d15fe619c9cfd"
+    },
+    "progs/h_zombiek.mdl": {
+     "bytes": 4920,
+     "sha256": "9b8b3af67bdec6160ecd3880acc072b833886f7fc11d1e64ffcf06184f9ba80e"
+    },
+    "progs/health_100.mdl": {
+     "bytes": 6948,
+     "sha256": "6c6646f6081ab00ed1c309de3b697009c825d64360b06c741a533b718e0ab8d7"
+    },
+    "progs/health_100b.mdl": {
+     "bytes": 23248,
+     "sha256": "d82148af4482e3c0ff07389ebb5b09cdefda373e31105aeb7308b4126b353a97"
+    },
+    "progs/health_15.mdl": {
+     "bytes": 6788,
+     "sha256": "838b0cb6fd11ff7fdf268b1607a1999e5dce0dea11386afe5ff207e6ff734aeb"
+    },
+    "progs/health_15b.mdl": {
+     "bytes": 10948,
+     "sha256": "eb1bb584805aea34a0f0ab846a758cdc359b730e144e141dcd756da23b5831e1"
+    },
+    "progs/health_25.mdl": {
+     "bytes": 7332,
+     "sha256": "ce8260929500cac3b57617345b2c6b5a75e763afdbd10120982e7d7fa55be27a"
+    },
+    "progs/health_25b.mdl": {
+     "bytes": 23248,
+     "sha256": "7aba68839958035319b2167369f3fcd08c9d49140969cff7fb523b7023362e00"
+    },
+    "progs/health_5.mdl": {
+     "bytes": 6164,
+     "sha256": "a8ba7ece01b3cb58b2f94ca20a9f4511871d26ec894b54c04e433f29fc7c3bef"
+    },
+    "progs/key_base.mdl": {
+     "bytes": 54436,
+     "sha256": "fb25488fa2fc16c7c4df260a20fd905a821607a675fd0907a6e65f9d534fd367"
+    },
+    "progs/key_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "2632cb327c1175b351d026e88a4e456c45779a0dcdae01381b24200769c8743f"
+    },
+    "progs/key_gold.mdl": {
+     "bytes": 9332,
+     "sha256": "e93ed2c4263bf7631efcbace2c36ed6f240bfcc2b49491751f6d6ce55db8c098"
+    },
+    "progs/key_medieval.mdl": {
+     "bytes": 58532,
+     "sha256": "0810c558e40c5833c19283eb849ba80ac5dd3499e0f077b724057c51730ee097"
+    },
+    "progs/key_rune1.mdl": {
+     "bytes": 18900,
+     "sha256": "90ac269965d42da0205307eeeaddfa5b282598b5218af8650d2d8854621ca950"
+    },
+    "progs/key_rune2.mdl": {
+     "bytes": 19828,
+     "sha256": "4a6644f0b583c85aa41362fb4533cda5f8f762bd4429e5007b3ab57e5e24ae57"
+    },
+    "progs/key_rune3.mdl": {
+     "bytes": 19700,
+     "sha256": "9b33cc0feed9fc27ea647f6d127941933aa5378b52a3f75b9331714fa9d2ff31"
+    },
+    "progs/key_rune4.mdl": {
+     "bytes": 19220,
+     "sha256": "515534b8fdaa0ef99621f0f7d59d268c0c244562372e23c13e9ce05a44e0a68a"
+    },
+    "progs/key_runic.mdl": {
+     "bytes": 57444,
+     "sha256": "e0e31948c1e172c3c9117a8ccd72900c6ebd7a7e73882ae525dd116230f054e2"
+    },
+    "progs/key_silver.mdl": {
+     "bytes": 9332,
+     "sha256": "dd54032e82de32cf1b78a25f862a82a73e9dc0926d89ca7a4279b45d367a8478"
+    },
+    "progs/misc_bmkdigit.mdl": {
+     "bytes": 3328,
+     "sha256": "1a7f2f762ef3a052a91db7c74cf8d980db47a56685fc61184a15be2152e843b8"
+    },
+    "progs/misc_bmkdigit2.mdl": {
+     "bytes": 3328,
+     "sha256": "2e690ffe1af05f5ad88fe90c180785adeeffdb2b330aa34c6f4fb9885285cd1e"
+    },
+    "progs/misc_bonepile.mdl": {
+     "bytes": 110796,
+     "sha256": "0f8061359681f3c11660e472c517599590447c7631edfe5a36debd9645acdec6"
+    },
+    "progs/misc_book1c.mdl": {
+     "bytes": 40096,
+     "sha256": "92b976437673f56cb890f0e1b90a550ea00939d01ee12b0df0f218b35b42953e"
+    },
+    "progs/misc_brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/misc_braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/misc_broken.mdl": {
+     "bytes": 744,
+     "sha256": "828998b238e1c5471461edc3b9d2d7fada2beab6229272041dff13a94c1d73ec"
+    },
+    "progs/misc_cable.mdl": {
+     "bytes": 57780,
+     "sha256": "bed2cca38ef4cbefa9e645eb5e9ffadffac6ebb4f2ac5f6da4bb8f354de22a48"
+    },
+    "progs/misc_candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/misc_candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/misc_candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/misc_chain.mdl": {
+     "bytes": 231184,
+     "sha256": "845fc3117f7d9860f2d0aa4a398103a13f327516144a96db508189ae1be5788c"
+    },
+    "progs/misc_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "3337f2cfe739c22d50edde7bff18c026d4336bceb207dacf8b0284ab0a5366cf"
+    },
+    "progs/misc_corner1.mdl": {
+     "bytes": 21668,
+     "sha256": "7abf8d5ca497d5e8c8ddcc09c710c0401edb71b11f9de77a2daa81b1267e5698"
+    },
+    "progs/misc_corner2.mdl": {
+     "bytes": 21348,
+     "sha256": "369c874a37ef1da8c9a79432ba2ab9484a5be0df120131b8cbac81e1786adf47"
+    },
+    "progs/misc_deadtree.mdl": {
+     "bytes": 195728,
+     "sha256": "d267db8cfc35b01430590cec643570b38f8df5872c9c3e43df31dc0f3a954e5b"
+    },
+    "progs/misc_digit.mdl": {
+     "bytes": 3328,
+     "sha256": "60f16b89c1e9b8fb8bea0c0aeb96d2dbcfc14a719c130aaa34a581b26e653416"
+    },
+    "progs/misc_doomhelm.mdl": {
+     "bytes": 70104,
+     "sha256": "1b801d032daa163fab361a39631a16c501b86cc9e9b1a52a3f1454e50cdb8c8d"
+    },
+    "progs/misc_dpull_s.mdl": {
+     "bytes": 12900,
+     "sha256": "77fed0a028829fc7120db625131f855faf9b35f97f6ce0591e224bfae0fa78e6"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_fixture1.mdl": {
+     "bytes": 9768,
+     "sha256": "c10980d00e0479f8e65ab633f19ee62ace4c0697c2193f7aea8d266e2be5fc2d"
+    },
+    "progs/misc_flag.mdl": {
+     "bytes": 16052,
+     "sha256": "f2670312a8d16dd16e42fd02a39dfd285e6ffea624e729597b773c86140631d1"
+    },
+    "progs/misc_flame_big.mdl": {
+     "bytes": 244895,
+     "sha256": "09adba1308cdf22d2f07e226cb13a35e51f4d54866f84f41e2074dc7a40371d5"
+    },
+    "progs/misc_flame_med.mdl": {
+     "bytes": 175400,
+     "sha256": "31c94bc48e6c6d6bc31bd14b8e257c4e74d45aaec3a4d5d5bf83587a08ac7c00"
+    },
+    "progs/misc_giantbell.mdl": {
+     "bytes": 74016,
+     "sha256": "0d1b0e150de4ac59c599deae96d6b21e4ceb2300e7d410a1d802385dad99560b"
+    },
+    "progs/misc_heart.mdl": {
+     "bytes": 3512,
+     "sha256": "827ce2bbf2037aa26259901f4152d114cdf38312652e65e53f64ebbad9ea0849"
+    },
+    "progs/misc_impact.mdl": {
+     "bytes": 880,
+     "sha256": "93029307003bd0437071e0a89d0d4c2b699f2cde6ba34242c321cba8243f36b9"
+    },
+    "progs/misc_jstatue_01.mdl": {
+     "bytes": 1057632,
+     "sha256": "c583186f8bd56fd5ac356a8ed34956090eaad6e78506884bd520307e8f5e5698"
+    },
+    "progs/misc_jstatue_02.mdl": {
+     "bytes": 100260,
+     "sha256": "e4f3e702073a7f76ffddb79921a2bbb880d25edc0bdd6a6f115dfebcf99dbae2"
+    },
+    "progs/misc_jstatue_03.mdl": {
+     "bytes": 100244,
+     "sha256": "587cbce564e4da156a0ae20a87bd551046427f894f34959590573ce96fdf5c31"
+    },
+    "progs/misc_lantern.mdl": {
+     "bytes": 28836,
+     "sha256": "d84e36232543a053f2772b1070b221dc23da1b34cd08ea551a982b5e9f168ea5"
+    },
+    "progs/misc_levels.mdl": {
+     "bytes": 35732,
+     "sha256": "7cf9a4c1e556e60dd4e593cad4a2be0b45bea8893d9b5232ecc7febca4bbf5fe"
+    },
+    "progs/misc_lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/misc_lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/misc_longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/misc_madfish.mdl": {
+     "bytes": 84104,
+     "sha256": "30c19dadb42a53c7ccd35f992c5841aee13a86796157ea5e0453a4cb1586a1be"
+    },
+    "progs/misc_mooring.mdl": {
+     "bytes": 6676,
+     "sha256": "29b20cf17c62dddb4f0c1be758add7b15d6b22fd738fd9e2cd7533ac5d5475f8"
+    },
+    "progs/misc_mushroom.mdl": {
+     "bytes": 10804,
+     "sha256": "5570faa6e7828e4e12f568656226b0756a87d633cbdc461af472e0982a88a549"
+    },
+    "progs/misc_oscill.mdl": {
+     "bytes": 50660,
+     "sha256": "cdc96265a646f9e9fb4c1717fa90edb13e42130fadc4dc774b60aeb94b89eac4"
+    },
+    "progs/misc_player.mdl": {
+     "bytes": 562960,
+     "sha256": "83bbcf4cb5858aa9ac03323b461b3e3b09a28f56e212645472219d7d0b0979d8"
+    },
+    "progs/misc_plinth1.mdl": {
+     "bytes": 6196,
+     "sha256": "1ce0b7f49153f717e04436b27863c75f90a73b027c4cb7e36ce094fa037eded4"
+    },
+    "progs/misc_plinth2.mdl": {
+     "bytes": 6164,
+     "sha256": "e06edd50af1748235b251fe6e4217551c58d45c1f73161014dc0e9fd40099249"
+    },
+    "progs/misc_qwindow.mdl": {
+     "bytes": 77168,
+     "sha256": "facf489ac59158a3013118ca196f11a25a543f26559d5b72eef44968aa05008f"
+    },
+    "progs/misc_radar128.mdl": {
+     "bytes": 19492,
+     "sha256": "ef004e28e51e3227121a92432375531fca26d1e44894696f3d2a950fa65aef28"
+    },
+    "progs/misc_radar64.mdl": {
+     "bytes": 19492,
+     "sha256": "b9468012707ad484c1292cbe984c54811cb8fa43542e68e18a52ef93cb37d52a"
+    },
+    "progs/misc_radar96.mdl": {
+     "bytes": 19492,
+     "sha256": "6239d117263f49b79a2a66e62f2dbd6a7f0cd15ce412c1939dd69b4a1d8fce78"
+    },
+    "progs/misc_seaweed.mdl": {
+     "bytes": 16100,
+     "sha256": "dfbd38a439d392870c7c4c7ebea4475827b716004ca47bfa7f13b47daf07d774"
+    },
+    "progs/misc_shard.mdl": {
+     "bytes": 22388,
+     "sha256": "06c126f77ad931084d38f0e04d8f4341a5db3e3fa827e30de7d05bc60afd1c1d"
+    },
+    "progs/misc_skull.mdl": {
+     "bytes": 59892,
+     "sha256": "94600327093fe22acc113b8e89c8863a5548b170c9c9897bd2af8a4ff63beb5a"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 31792,
+     "sha256": "8d39b97460c9967ee36b33ea1ef1e92e89277fc410b44f054c5e06b8dc8a079c"
+    },
+    "progs/misc_spark.mdl": {
+     "bytes": 12672,
+     "sha256": "42afca9aeac1b05590b4821872cb79ebfbb4ee7264e914316d880e13f69c2b41"
+    },
+    "progs/misc_starfield.mdl": {
+     "bytes": 23548,
+     "sha256": "5b3563017939382680228e933a2a87d3edb030e75e65c51fe42c4a6889e42e15"
+    },
+    "progs/misc_stickskull1.mdl": {
+     "bytes": 87900,
+     "sha256": "38e63e10bc351ba5a48dfb6195ac5f78e5d61e67ae851f2ba50ba20255d7a37e"
+    },
+    "progs/misc_stickskull2.mdl": {
+     "bytes": 116364,
+     "sha256": "464fbee370b512d1c8057ea5a1dc3ecff69378474593919f0bbd8970419d69a5"
+    },
+    "progs/misc_tape.mdl": {
+     "bytes": 9240,
+     "sha256": "2b6a08ca3be4dd7a669e5b6d1585276759e1fb0edbe0691dd7ecbc7e41f0b189"
+    },
+    "progs/misc_textbook.mdl": {
+     "bytes": 74212,
+     "sha256": "e17e39efdf252a3da8c0574fdf272a800095671f42e71a17a3733673202dbfab"
+    },
+    "progs/misc_tree.mdl": {
+     "bytes": 120248,
+     "sha256": "888eca3c464ac068c7cdc5d7cf8f67fbcc70eb13c0079202a4f8d347f5f3bcd3"
+    },
+    "progs/misc_tree2.mdl": {
+     "bytes": 404432,
+     "sha256": "f14f3b046b58e5485afd11d396b4d358eb0598ea8cca1cbc6a70a8e629aee3f3"
+    },
+    "progs/misc_tutstatue.mdl": {
+     "bytes": 178480,
+     "sha256": "d178ba96d99b02113fe70d32f1672c1490d5f570aecf11d168e58f1bb7e8c17e"
+    },
+    "progs/misc_xmastree.mdl": {
+     "bytes": 479516,
+     "sha256": "59a89b398caa908ff6dd777cb42d0d7dfde930ac5569fdab4bc4f10dd8137584"
+    },
+    "progs/mon_boil.mdl": {
+     "bytes": 307068,
+     "sha256": "b8a79df258bf71f273dc29887c3782377bf890d43e32b690ebf2ef707eead6de"
+    },
+    "progs/mon_bossboglord.mdl": {
+     "bytes": 401092,
+     "sha256": "6fb5e0aa99fc9269b21e3a7c86e7ed70bf1f7e0150b629a39a4cf6647d0c9a1f"
+    },
+    "progs/mon_bosschthon.mdl": {
+     "bytes": 328244,
+     "sha256": "7fc4005959377598747d3accec535b52c81154b17b00221e2cd5410670223538"
+    },
+    "progs/mon_bosseidolon.mdl": {
+     "bytes": 1847180,
+     "sha256": "e08c763865b25851703f71e973755d5a7b446c8004f7d97c09fab04175373c10"
+    },
+    "progs/mon_bossicegolem.mdl": {
+     "bytes": 632584,
+     "sha256": "2a03c71a0451c389dc29374fa3a465fb0d8e9366309cbaeffb68057c928562ec"
+    },
+    "progs/mon_bossnour.mdl": {
+     "bytes": 200036,
+     "sha256": "732041ff70ec350c664194f90a9545b23b6736e729dd128f4482a0cca3ab7966"
+    },
+    "progs/mon_centurion.mdl": {
+     "bytes": 824572,
+     "sha256": "e638ad3021c5c77a1ad78fd798017fbb7a0ffa49ca2fc4a60570ba00e349d532"
+    },
+    "progs/mon_dcrossbow.mdl": {
+     "bytes": 1335168,
+     "sha256": "b38a7967cf800fdb45f9df9aa717ebc1c069fc8686a8e3e414f1c81d51f81d14"
+    },
+    "progs/mon_deflector.mdl": {
+     "bytes": 300016,
+     "sha256": "2bba37156abcde4ad2e7fc532a92b8139d4fc8041b565cd1e487829dc581341f"
+    },
+    "progs/mon_demon.mdl": {
+     "bytes": 156640,
+     "sha256": "9f1714fe997a78c9d3948e593a73fa3fe5704e11809ba095b8f564fca36b36c0"
+    },
+    "progs/mon_dfury.mdl": {
+     "bytes": 1495580,
+     "sha256": "0cb312b27bc1c9a7f9ac3d8c14e1e0d422d9968d4a9db0853d73185a19d6839d"
+    },
+    "progs/mon_dfury_glow.mdl": {
+     "bytes": 155140,
+     "sha256": "f743168f636c9e56475d73b3f8e139e5391e2abf0da4a6657174a7adc0f74238"
+    },
+    "progs/mon_dguard.mdl": {
+     "bytes": 724744,
+     "sha256": "1babb2976f1f86c2e499d3b8e83f4e4c04e434151bcb96a932a99a89b2bf3699"
+    },
+    "progs/mon_dguardq.mdl": {
+     "bytes": 176648,
+     "sha256": "f2f92ef84411d83c7e8c158f62b1415d8fc6aa56d77f21760dcd3080424cf6c8"
+    },
+    "progs/mon_dknight.mdl": {
+     "bytes": 1124632,
+     "sha256": "437c54ecfed53e34891b981a565c9b4f772c19702e1c099bba5ac40aabbed917"
+    },
+    "progs/mon_dknight_glow.mdl": {
+     "bytes": 971020,
+     "sha256": "22888d6171fc8df336fe686f4ffdfb0683bdb744e59cf81af9484b700666f6cf"
+    },
+    "progs/mon_dlord.mdl": {
+     "bytes": 1142583,
+     "sha256": "fb2ce7f5fbe369307f3eaefe0a74fffb2004657bec058dae50db651bc2fbc70f"
+    },
+    "progs/mon_dog.mdl": {
+     "bytes": 460652,
+     "sha256": "52cf8cb501f4b1ed457961b798eccd86974720af29f559723be82a0886824fd9"
+    },
+    "progs/mon_dprince.mdl": {
+     "bytes": 1022224,
+     "sha256": "aadd9ea12f307f0ef2b600a4a78d73082b8ea2eadd408f1fbe298082f4d03374"
+    },
+    "progs/mon_drole.mdl": {
+     "bytes": 241648,
+     "sha256": "2d5524d75cd52f12b42a5dfdd37bb33af27233394ec60bc234f79545d1cf13b4"
+    },
+    "progs/mon_dsergeant.mdl": {
+     "bytes": 1431784,
+     "sha256": "1affce6e3cbae9b5df1986672030fd869aa020972872767518f18ccc495c7432"
+    },
+    "progs/mon_eel.mdl": {
+     "bytes": 177368,
+     "sha256": "6acb4804e51e7de33404a4519d7f12b2413c921f61e33107345cb111ff156f96"
+    },
+    "progs/mon_enforcer.mdl": {
+     "bytes": 622480,
+     "sha256": "0e32f70f205a74995936d56e22259d1ccde591ed8a533577cd276419c5f60013"
+    },
+    "progs/mon_fish.mdl": {
+     "bytes": 311132,
+     "sha256": "40351e57dec8fad0aa34e5e5da233274e007a3beb80a291c9a2aa40ed43f8f00"
+    },
+    "progs/mon_floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/mon_freddie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/mon_fumigator.mdl": {
+     "bytes": 415072,
+     "sha256": "31bb90976e7489693c68fd6713ed5f1baf9645e3d7871922901dd093e8243da3"
+    },
+    "progs/mon_gargoyle.mdl": {
+     "bytes": 388132,
+     "sha256": "fe8134f2305858519445eb513b22f1f3382a1a6f334cf9549ddf1efe0b88435c"
+    },
+    "progs/mon_gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/mon_gaunt_elec.mdl": {
+     "bytes": 7164,
+     "sha256": "05129692bea7b62f2f5b7285cf133590e9356bfa0f6162ef6e3fc44508b29d8b"
+    },
+    "progs/mon_golem.mdl": {
+     "bytes": 632584,
+     "sha256": "c345c57eca380796f5dbcbdf7df80975c24e856d6d70ed1e9c11678f5d162c44"
+    },
+    "progs/mon_hknight.mdl": {
+     "bytes": 275836,
+     "sha256": "e32a90ca707224a389b7b0d3ecde76220e23f7746c2bc4e6397fe0d3a601844a"
+    },
+    "progs/mon_hknight_glow.mdl": {
+     "bytes": 212112,
+     "sha256": "60c24cb1dceeda2c64efb66e03cb8337717402c8070c0a19e1d9a6b5e0363d89"
+    },
+    "progs/mon_hogre.mdl": {
+     "bytes": 897896,
+     "sha256": "f8e0d054c44cf83bde03ee51ca8eb558dad7da336be8caf1383cf51d5b813da9"
+    },
+    "progs/mon_hogreham.mdl": {
+     "bytes": 979960,
+     "sha256": "d4ffb64b6112d48696002baf1bf8df0c686f404d1523ae409a9d01d237573e90"
+    },
+    "progs/mon_hogremac.mdl": {
+     "bytes": 901388,
+     "sha256": "daeed66878bbe85c45d2415de4270a8526be175ac74734ff55cf9750bf7c4875"
+    },
+    "progs/mon_jim.mdl": {
+     "bytes": 331872,
+     "sha256": "a49a51562fc5875509e39b62de550c4cebba65569708e1f63d0a54a6b8497448"
+    },
+    "progs/mon_jimrock.mdl": {
+     "bytes": 357748,
+     "sha256": "6c7e4a4f9b1b4392cf6e465be50e0a637a2a9b9b44b41e97a62acfc7b889f662"
+    },
+    "progs/mon_judge.mdl": {
+     "bytes": 1184920,
+     "sha256": "4e281291b8b6728bc6801c775defa987698a0f402a3a5553a32cf61865857040"
+    },
+    "progs/mon_justice.mdl": {
+     "bytes": 1287408,
+     "sha256": "bdd6b6ad28da26701dcef14503d148e96251575e04f583bef1f362455ab12497"
+    },
+    "progs/mon_knight.mdl": {
+     "bytes": 474244,
+     "sha256": "b279d87d180d237a71beddad02ecfaa87be42c990b91ee823f15f905fbb19b55"
+    },
+    "progs/mon_lostsoul.mdl": {
+     "bytes": 172216,
+     "sha256": "51c6d042ac9c670926d11743a09b294cbc992204077eae28b7b440570a7b0b4c"
+    },
+    "progs/mon_minotaur.mdl": {
+     "bytes": 669648,
+     "sha256": "3016ee951f60eb90a659c641546bc6aee80b1e2e9500b125c9c1343d625deb54"
+    },
+    "progs/mon_ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "ca0b6aee92201fa3ebeb226e7767c7a0f29495496d86bd384c327ff897b3557b"
+    },
+    "progs/mon_ogrefish.mdl": {
+     "bytes": 560428,
+     "sha256": "25edf562fbf71533ae0102832d92b7e138d056e1f90c9c681e5387659cd3160e"
+    },
+    "progs/mon_pyro.mdl": {
+     "bytes": 415072,
+     "sha256": "11a7efe7358b1477867a1263fd6e13a8531f557d1a8d0e0bfc5a1e9e6eab273a"
+    },
+    "progs/mon_scorpion.mdl": {
+     "bytes": 338288,
+     "sha256": "5d8a1b194cfc741b8dd194694dce305c35b0dca0bdf1c8d96897a085ad0eaf85"
+    },
+    "progs/mon_seeker.mdl": {
+     "bytes": 594628,
+     "sha256": "ab23bfb0c8b22c67b8d4b7b1658b445fb546fcc4f1ddb1f5c4990eb860434f3a"
+    },
+    "progs/mon_seeker_glow.mdl": {
+     "bytes": 594628,
+     "sha256": "122441a3be654d0198ba368ff9fd24d7f3fecb71fbafad6edfe80e3f57103ca8"
+    },
+    "progs/mon_sentinel.mdl": {
+     "bytes": 290664,
+     "sha256": "573efd78767922b2bbb3e5dab2b16cd8f90c2cb1709ecf4a315a141f4df77d09"
+    },
+    "progs/mon_shalrath.mdl": {
+     "bytes": 163336,
+     "sha256": "50b11e859246abf75af63b858d00b436690c9ed02562c0a7a3f434ed350c3a79"
+    },
+    "progs/mon_shambler.mdl": {
+     "bytes": 401092,
+     "sha256": "8f29b2ceddebcb9e69adbf12eb36c3924468cfaa1ff54cea31e6f289ab30e54a"
+    },
+    "progs/mon_skullwiz.mdl": {
+     "bytes": 980064,
+     "sha256": "c7637f2310ae9f173de872ea4aaf4380332f3d8d32782a8523f1d5d0a5ee3e45"
+    },
+    "progs/mon_soldier.mdl": {
+     "bytes": 931376,
+     "sha256": "8a67babdf47ecc69739e067d18b2629814469aec923851bd6c1133feae6ac56b"
+    },
+    "progs/mon_spiderb.mdl": {
+     "bytes": 228508,
+     "sha256": "209ee4dabf0f9b5619408cedcd8eaec7f8d4e48a8e1b51ca667bf5f8fea02dd6"
+    },
+    "progs/mon_spiderg.mdl": {
+     "bytes": 228508,
+     "sha256": "ffac4cf5b2d42df5b8a9674dc87c30ec925d6013d9ff0d29cb109c30047bcbd6"
+    },
+    "progs/mon_steelclaw.mdl": {
+     "bytes": 228508,
+     "sha256": "06fae126b984b1ed7b0ffa029b64e9b3df3a6269f01e8aba4b953bbafaa2c536"
+    },
+    "progs/mon_stinger.mdl": {
+     "bytes": 203428,
+     "sha256": "9d867b8a3d69a94d9a049c6cfcf0fa808b200ea3befe3b2518f1165881b9ad23"
+    },
+    "progs/mon_swampling.mdl": {
+     "bytes": 45332,
+     "sha256": "c7b379fcc17af3fbfaff1976ea8c14e9562093495dac01cd647c50863c4dec50"
+    },
+    "progs/mon_swamplingp.mdl": {
+     "bytes": 45332,
+     "sha256": "f1bd1496b4b9c90493f469bf81c6da0a1697290cd6374db15fd459ebab649cea"
+    },
+    "progs/mon_tarbaby.mdl": {
+     "bytes": 511008,
+     "sha256": "a9b9b6a49090bbf7d7d3a23618c3c21b2123e007488702d96b80531c563cdd4c"
+    },
+    "progs/mon_voreling.mdl": {
+     "bytes": 45332,
+     "sha256": "af233d21d6f0ea66267ba1c562ba223e1077bd07894333327ce12a6202938411"
+    },
+    "progs/mon_vorelingp.mdl": {
+     "bytes": 45332,
+     "sha256": "dadf32a61ef1ec6361606fc7173bab53f6c42e62dea9a3100a2073ffc5afaa58"
+    },
+    "progs/mon_wizard.mdl": {
+     "bytes": 106596,
+     "sha256": "aa93bbe4e7fd1686fcea4d6c49a982bb8b3defea2ca85c3177b86000ba8ba8e4"
+    },
+    "progs/mon_wraith.mdl": {
+     "bytes": 374256,
+     "sha256": "f2ec454f0e2896252204a99b18c16a5e61ae783220503a6b0ec75e149d1b25f7"
+    },
+    "progs/mon_wraith_glow.mdl": {
+     "bytes": 133676,
+     "sha256": "bc630a16b46ae0ef1fba35acaf4e41bc46dee4070305d32e9215692a18ae5705"
+    },
+    "progs/mon_youngone.mdl": {
+     "bytes": 103208,
+     "sha256": "de6f7f98d021ae2839cc81490886e6f29dfa31b5b45216d15ffb7f74edf1eb36"
+    },
+    "progs/mon_zombie.mdl": {
+     "bytes": 381660,
+     "sha256": "2dfc9832316861cff07f1c86da0f8809de95395a9dac718155bdbd06f739acaf"
+    },
+    "progs/mon_zombiek.mdl": {
+     "bytes": 228232,
+     "sha256": "431f57d3241b1253a1346ff1aa2bd7135f67c3e6fd5031140e07a7b4a0e861a2"
+    },
+    "progs/player.mdl": {
+     "bytes": 976432,
+     "sha256": "137eab1a3853f9a6f7f84c05442f7066268cac430bf73053cc7f806555a98925"
+    },
+    "progs/proj_balllava.mdl": {
+     "bytes": 18356,
+     "sha256": "f2a1de49bd215b4c7a1f424f1c644fe5cdb52df3c2d664c24b75cd2f389ae559"
+    },
+    "progs/proj_ballslime.mdl": {
+     "bytes": 18356,
+     "sha256": "d17f20cd8db385b724d58beaac1c3ed6b2597d51d00f1996b8b02bdb8a5e3ba1"
+    },
+    "progs/proj_blord1b.mdl": {
+     "bytes": 11472,
+     "sha256": "6c05b0f8790b77d3362166b2b304379942f56d498ae8fc365dbee6fcd6031f67"
+    },
+    "progs/proj_blord1s.mdl": {
+     "bytes": 8284,
+     "sha256": "5527dd12f00911fb333c2424994c0a95881caa72612d5e8236c8ce75530f6ae0"
+    },
+    "progs/proj_blord2b.mdl": {
+     "bytes": 11472,
+     "sha256": "fce6943e84bac672bf110d986ce2ed1ccb511128cb28508fb6aca53c7655806b"
+    },
+    "progs/proj_blord2s.mdl": {
+     "bytes": 8284,
+     "sha256": "a0d0ac315e46f784c35a0eac902f625e0337e79275b9f02ecb56002848202734"
+    },
+    "progs/proj_blordbeam1.mdl": {
+     "bytes": 12244,
+     "sha256": "e01c569bf66e75acdcbbfdbb50062eb24dd09f0415e6cb79148eab960f6a6f0f"
+    },
+    "progs/proj_blordbeam2.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/proj_blordbolt1.mdl": {
+     "bytes": 7868,
+     "sha256": "2ea0a49a8a75d1174151c36851ae21212b4df2df3473be5e73cc4cf293332d0f"
+    },
+    "progs/proj_blordbolt2.mdl": {
+     "bytes": 7868,
+     "sha256": "919dda70fe618cd37f57ef1e0dbc00b339ed082e2661ca024febee3ed49576f2"
+    },
+    "progs/proj_bolt1.mdl": {
+     "bytes": 1556,
+     "sha256": "890f6cd6faf7c36954185c4566a2cca619e627d5b365f05e1bffc7e12ac00ace"
+    },
+    "progs/proj_bolt2.mdl": {
+     "bytes": 1748,
+     "sha256": "ba4a6ffa3785b0e41c15045df9621a5a33f094eae2161064d472ea939654e229"
+    },
+    "progs/proj_bolt3.mdl": {
+     "bytes": 1748,
+     "sha256": "cf255497525c53162b019fe3df536314c4661a2d270f6bb847fe39a158b7f4e8"
+    },
+    "progs/proj_chthon1.mdl": {
+     "bytes": 65636,
+     "sha256": "92a964527d72ef1c40bbcfe0e915b56df81a0dcc2165ca4be47db44a8d644eb1"
+    },
+    "progs/proj_dguardq.mdl": {
+     "bytes": 12660,
+     "sha256": "ba5cba46edc108572d78e66166f5ed0405a48dcf672e7a569d14a4397f85f285"
+    },
+    "progs/proj_diam1.mdl": {
+     "bytes": 3292,
+     "sha256": "e7cbd736a84791c5234caa14713b3e0f6077409509845ae0b1993f38c2f1e1b9"
+    },
+    "progs/proj_diam2.mdl": {
+     "bytes": 2748,
+     "sha256": "b23586b1d570a9f516f6b83ea0af6ec1d8fe5693f8cd1279b251b031ba142d8c"
+    },
+    "progs/proj_dk.mdl": {
+     "bytes": 5172,
+     "sha256": "e861a125a60c82b88c7b3c23184a1485c967d0e127b4536213b7f46a97a6430e"
+    },
+    "progs/proj_dkgrn.mdl": {
+     "bytes": 5172,
+     "sha256": "820d2dac7255db7220889f6d8c3a2c97a7f77f75cd9ffbec6319b0ee257b3984"
+    },
+    "progs/proj_dlord1.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_dprince1b.mdl": {
+     "bytes": 6644,
+     "sha256": "7bcea6065d9f6c4e8a3a7c8a1dcd61252ff8baee01b7c04ecce0a7cfbc6d690d"
+    },
+    "progs/proj_dprince1r.mdl": {
+     "bytes": 6644,
+     "sha256": "5e3cc794f6b980e5e22adf011eead8768c88dcd84d74be9a8d34caebf33bf2ba"
+    },
+    "progs/proj_dprince2b.mdl": {
+     "bytes": 7468,
+     "sha256": "e81b4f767d1bba042464f1d35314ef4f2d30f7c552aaada2f772aba61fc5d62a"
+    },
+    "progs/proj_dprince2r.mdl": {
+     "bytes": 7468,
+     "sha256": "b967299e12983dacd0fcca1672818281483e6f89746422de285002cb043e1e24"
+    },
+    "progs/proj_drole.mdl": {
+     "bytes": 20796,
+     "sha256": "fbe9acdd31f7be2321df29b6add3d287d4e86ea2581e56ace5d7e9d185e28127"
+    },
+    "progs/proj_drolegrn.mdl": {
+     "bytes": 20796,
+     "sha256": "efbede1f5d565c56a535bb6392b5e638133c99b1df8bf93b1a1918d01c790123"
+    },
+    "progs/proj_eidolonrock1.mdl": {
+     "bytes": 14084,
+     "sha256": "e085fa791a83489e41c19c623ae84f80c7bc5f767cbbf691baa4665d3f85b273"
+    },
+    "progs/proj_flesh.mdl": {
+     "bytes": 19768,
+     "sha256": "8ff3f0f61001ac8e67317e4e01d03d905f15ef4104c141ba07b5ddb0c972390e"
+    },
+    "progs/proj_fleshp.mdl": {
+     "bytes": 10196,
+     "sha256": "3def912801c4b1b9b4c0f8ceea0690241493a5dd5f17e098cd6c37cefd927893"
+    },
+    "progs/proj_fury1.mdl": {
+     "bytes": 6644,
+     "sha256": "ce55af61fbd87b8daeb14151b3f77ac64713c4b53fcca89b2150d7f5cdfe886d"
+    },
+    "progs/proj_fury2.mdl": {
+     "bytes": 5748,
+     "sha256": "deb557248017e92f5501698355577cebb91c0d825b77a79f828589769a41ece7"
+    },
+    "progs/proj_gaplasma.mdl": {
+     "bytes": 2328,
+     "sha256": "dd3b4559cb4e4439ae87255ab2958c6c2cd3796ebbd27aaf1c6abc768ad4f8ad"
+    },
+    "progs/proj_gaplasmagrn.mdl": {
+     "bytes": 2328,
+     "sha256": "ecd2fdf0eb904f8be43c41821b06443d32a581b768ce8f776b07670b49cdd9af"
+    },
+    "progs/proj_gargball.mdl": {
+     "bytes": 18184,
+     "sha256": "b4b6bd7646bf80aa6f481616ba2b531dbccd3568cacc54885ebf020a166dbadd"
+    },
+    "progs/proj_gargballgrn.mdl": {
+     "bytes": 18184,
+     "sha256": "467a44838d83a94d5716c9af6f8c860cd8ec583ddb5f260cb0dd16e9bd04b957"
+    },
+    "progs/proj_gargoyle.mdl": {
+     "bytes": 5748,
+     "sha256": "774f52126fe6598f6a01a032691a36de26a0669e93d47508689d08fe85f46c21"
+    },
+    "progs/proj_gargoylegrn.mdl": {
+     "bytes": 5748,
+     "sha256": "b293b5e8696098e77602eb065f68f8a8e15c82af1c9890d36de48f29afbf43fe"
+    },
+    "progs/proj_ghook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/proj_golemrock1.mdl": {
+     "bytes": 7468,
+     "sha256": "5a2f0435dbcbfea724fe6bd8f6a76296359dbf4d874d15feec82b50a9275da74"
+    },
+    "progs/proj_golemrock2.mdl": {
+     "bytes": 19756,
+     "sha256": "41cc9bc49d6ae2018b7cf5345bbfe52517db2da060fce23fe57300ebcf643f98"
+    },
+    "progs/proj_golemshard.mdl": {
+     "bytes": 8596,
+     "sha256": "4a4a59362f5c5ecc2c4ce56419088982d5ed79a02d3c5b5a49bafd4c21c85e42"
+    },
+    "progs/proj_grenade.mdl": {
+     "bytes": 3508,
+     "sha256": "a7916ab1f9872689a0cfbea62543974b37dae5b3ec7ae3165eecd81c2c0d6617"
+    },
+    "progs/proj_grenadegrn.mdl": {
+     "bytes": 3508,
+     "sha256": "896f7a740acb59351891e752e6cc92725fcc6e26ea4bd5d1eb3219c8443db743"
+    },
+    "progs/proj_judger.mdl": {
+     "bytes": 7868,
+     "sha256": "a12f1f0bf494bc027c43e5aa89e54e055a571226499fbddce0f6b9e2bdb63766"
+    },
+    "progs/proj_laz.mdl": {
+     "bytes": 4724,
+     "sha256": "94e8c7d09857559ad9e5aaf6361b596afbcf100cf0ce8abf0107318af28c7943"
+    },
+    "progs/proj_lazblue.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/proj_lazgrn.mdl": {
+     "bytes": 4724,
+     "sha256": "d07d736b788aa512a5e57f39596c187644e69491026382800994378d3e849a6f"
+    },
+    "progs/proj_lightning2.mdl": {
+     "bytes": 11860,
+     "sha256": "c9cebc8d6f4836e7c302d51d0f942fde3da0960dae38733ccc3a851776e71520"
+    },
+    "progs/proj_minoball.mdl": {
+     "bytes": 18184,
+     "sha256": "756d8e9ecd60abc23954a792833c565ee1b5c905106ad2bd98143f56b0410391"
+    },
+    "progs/proj_minoblood.mdl": {
+     "bytes": 8284,
+     "sha256": "badd72734b86dd9bc11c5469bef944b6aea6b84071b07b44703c1ca62dd4dee2"
+    },
+    "progs/proj_minoplasma.mdl": {
+     "bytes": 8284,
+     "sha256": "cd79d0dce08293ded22b08b3a7134d8e52fc4cff10e07ee691e6ab53011a9ea9"
+    },
+    "progs/proj_minopoison.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_ng.mdl": {
+     "bytes": 1364,
+     "sha256": "cff312dd07f629847dd5e37b6ab00243d51ff7e40fc795f3612e68614cfbbe24"
+    },
+    "progs/proj_ngred.mdl": {
+     "bytes": 1364,
+     "sha256": "a1ec22733cc292a470c23990b8d0929bf5ee88844190d7174d9053109443d0dd"
+    },
+    "progs/proj_nour1.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_nour2b.mdl": {
+     "bytes": 14084,
+     "sha256": "9c7650dba595e8f8b2bacf3141252a5a2917e0204d3326661d6b9608fc8df2b3"
+    },
+    "progs/proj_nour2p.mdl": {
+     "bytes": 13152,
+     "sha256": "4051fc3dec1155a9efbc6bc5aab947447cebff83bec38d8c1e43dd1bd51f4611"
+    },
+    "progs/proj_nour2s.mdl": {
+     "bytes": 7468,
+     "sha256": "285570bdd658dfed133399c16f1586e2b2389f537a9d4b54d2dd5c1f8f6f1aa9"
+    },
+    "progs/proj_pgplasma.mdl": {
+     "bytes": 13152,
+     "sha256": "3c04f32bbf6f0623fc4101a31a0ce2d40c93354430433d91c2caed263284531e"
+    },
+    "progs/proj_plasma.mdl": {
+     "bytes": 4724,
+     "sha256": "6c4399ddc7653a9aa7834162d38dce6368dc271fec46a7830b73939351d7142a"
+    },
+    "progs/proj_plasmagrn.mdl": {
+     "bytes": 4724,
+     "sha256": "b2941e69d90a5e97c98a03a98bd52c4e047aa23dd2a1abd9ab6d3938f595732f"
+    },
+    "progs/proj_ringblast.mdl": {
+     "bytes": 135704,
+     "sha256": "e6de9bfd15db4bbf16fdd41b50204c5090ce09adbe132b1453435d3c8646cb4d"
+    },
+    "progs/proj_ringshock.mdl": {
+     "bytes": 18928,
+     "sha256": "f1a0a77edc79f2466b866a5486b29f92b696368137eb7eff9b137b6b66d65952"
+    },
+    "progs/proj_rocket.mdl": {
+     "bytes": 7812,
+     "sha256": "52d549b217c6f34e1d68248899ec5f5f550ef729929910e5953e114a53b3c251"
+    },
+    "progs/proj_rocketgrn.mdl": {
+     "bytes": 7812,
+     "sha256": "313f381553df0d8468ccb981441bf415130c9c730377d877e397511b8cc864f7"
+    },
+    "progs/proj_scorpion.mdl": {
+     "bytes": 6612,
+     "sha256": "1a2fa47a30a7e8026bacefa1f52580a04e10c48571318effab3e0623ebcc919e"
+    },
+    "progs/proj_serg.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_shal.mdl": {
+     "bytes": 6644,
+     "sha256": "dc62e9641d1328b1cfd20ac4f4df7e56b2f42bd40a22eea186f2784d1f5bc4ba"
+    },
+    "progs/proj_shalball.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalegg.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalgrn.mdl": {
+     "bytes": 6644,
+     "sha256": "6dfdef0a204aded86ef24730985f13acc5076d1bbb4b9ec1140b7333a70f4d0e"
+    },
+    "progs/proj_shalhome.mdl": {
+     "bytes": 8632,
+     "sha256": "e882b1dc5d01882f429b3a88f752431d3b38dad297861209b589330e3507f37e"
+    },
+    "progs/proj_shalhomegrn.mdl": {
+     "bytes": 8632,
+     "sha256": "d84be851bd87603186bf907506eabb9ce110c5a265c1cc884d18923361fdf4d9"
+    },
+    "progs/proj_shalshell.mdl": {
+     "bytes": 7468,
+     "sha256": "8c1591cc767fadabad655bfaf3a80362b264f51e0a1be67476b9272c2401afbd"
+    },
+    "progs/proj_shamlit.mdl": {
+     "bytes": 35240,
+     "sha256": "787c23ca986d469080879953e49b193cf0b2d22dff050a1d781ba039fcc594e4"
+    },
+    "progs/proj_shellcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/proj_shub1.mdl": {
+     "bytes": 18932,
+     "sha256": "c1a04846b791a123ecb367f11b35f4c1cc1e7e62e1d0f62ff1dd75978a712495"
+    },
+    "progs/proj_shub2.mdl": {
+     "bytes": 32860,
+     "sha256": "3d22df8151caf23c1ad7f3e28f83f97ca7503164977f1994dca2cc2ee54f84b9"
+    },
+    "progs/proj_skullball.mdl": {
+     "bytes": 9984,
+     "sha256": "41b3c1225070dcfca79f1bf19a2833e3d68144945fba51c8ce44d8029379906b"
+    },
+    "progs/proj_skullwiz.mdl": {
+     "bytes": 33588,
+     "sha256": "ff00ce3fbf9d0d55f6488a3a0a6bf15d2105b6e94489eec296a5851bf9f4f890"
+    },
+    "progs/proj_skullwizp.mdl": {
+     "bytes": 33588,
+     "sha256": "45fe8396037d88852d3e6937749bade4ef7c00d3c8240eeb0ecba4b56e831df3"
+    },
+    "progs/proj_smoke.mdl": {
+     "bytes": 244,
+     "sha256": "816e888f8242af86812bd581c9e93212c28f108699b70eb10d3e025f27a2818e"
+    },
+    "progs/proj_sng.mdl": {
+     "bytes": 1396,
+     "sha256": "b2a8656aee7ff508737afe1fdbf1a93d6958b33a0c31bae247a3979c616bdfe1"
+    },
+    "progs/proj_spider.mdl": {
+     "bytes": 7468,
+     "sha256": "76be6023b50a3b57c73f08c5758a693098ce8762eb92b55540d8bff2680fde4d"
+    },
+    "progs/proj_swampling.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_voreling.mdl": {
+     "bytes": 7468,
+     "sha256": "ab16a7fc8bf36827f4944ebe6919876acb5b2eaf869ff59f89ed237565a7ca9a"
+    },
+    "progs/proj_wiz.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_wraithball.mdl": {
+     "bytes": 22284,
+     "sha256": "24d62690c6347f9ab71ef5900c70d256346c2dfdc26e5488c3b91f220224c923"
+    },
+    "progs/proj_wraithbone.mdl": {
+     "bytes": 6612,
+     "sha256": "8fa994dd2c7a5e9d7140ae394d07d368d083f4cee6808f6d9d026ec464804503"
+    },
+    "progs/proj_wraithegg.mdl": {
+     "bytes": 9984,
+     "sha256": "5b888e26f90cfe26800cd50d422b4ef75487dde61d63fd34965506591b326a8f"
+    },
+    "progs/proj_wraithpoison.mdl": {
+     "bytes": 6612,
+     "sha256": "02a06fdccb8f7ba595ea71f227e5b256995e782bcc9ce75bcb85a31ed0333256"
+    },
+    "progs/proj_wraithshell.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_wraithtrail.mdl": {
+     "bytes": 24544,
+     "sha256": "23ee065ea4a542ee7348d9bc08e052ffca4e272418b81937105d14730aab705e"
+    },
+    "progs/s_bookrune1.spr": {
+     "bytes": 1140,
+     "sha256": "b9fc52d2ca728fffa4c282d818b68aeec3555a0dbad3cd1507199d534db1f047"
+    },
+    "progs/s_bookrune2.spr": {
+     "bytes": 1140,
+     "sha256": "400a620928e3581891e8a71b338c8a53b6387e0acdc3fda3f10ae27596ae6bbc"
+    },
+    "progs/s_bubble_blue1.spr": {
+     "bytes": 1140,
+     "sha256": "27cb0d1f52e3ecd4b7ae0d9dc96078a7554bde09839f1a2ee2d9772ac5d67981"
+    },
+    "progs/s_bubble_blue2.spr": {
+     "bytes": 1140,
+     "sha256": "d540bb04a7835ec3bd7490904fbafde0f3aa64ba559bb6bd99ab538568ec0cae"
+    },
+    "progs/s_bubble_brnd1.spr": {
+     "bytes": 1140,
+     "sha256": "43591346d87a547454b387220b3c32693e7f1563b6ae4152ff7ee96c24936b84"
+    },
+    "progs/s_bubble_brnd2.spr": {
+     "bytes": 1140,
+     "sha256": "2f185b37bd1cd5a8d6b472885469dbdb3f1b0fdeba2a6d620de09b17646b4fc2"
+    },
+    "progs/s_bubble_brnl1.spr": {
+     "bytes": 1140,
+     "sha256": "370ed3a9f77291522c31ac1d0ce414078d9b3eb40a9157c08ad5cf87d6428897"
+    },
+    "progs/s_bubble_brnl2.spr": {
+     "bytes": 1140,
+     "sha256": "1b3d4f0ac00fa7cbce076d334f4b210b9059afbf2c4b07a0e98e88fe57356351"
+    },
+    "progs/s_bubble_grey.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_grn1.spr": {
+     "bytes": 1140,
+     "sha256": "efa8692bb74428af2753b415f8f08edbfc2b2cbe75cc59f6545985d289d6016f"
+    },
+    "progs/s_bubble_grn2.spr": {
+     "bytes": 1140,
+     "sha256": "3062ba1064da37ecf7dad074a9b0437352865fa43aecf783e4afe8a6c8c104c2"
+    },
+    "progs/s_bubble_pinkyel.spr": {
+     "bytes": 312,
+     "sha256": "5376726ffdf2132d3ab712ba23b408e8068500485f11adff85d0fd90c08248c6"
+    },
+    "progs/s_bubble_purp1.spr": {
+     "bytes": 1140,
+     "sha256": "2e4b7b23b08b6e89d2dc46f26b12b9ad1ee8f91ea868aeb9916d2adb42e00b75"
+    },
+    "progs/s_bubble_purp2.spr": {
+     "bytes": 1140,
+     "sha256": "ae21a26ad7897b9c5d201a1eb248e1358ee84eafdbfd899d679558e9aa5a1a66"
+    },
+    "progs/s_bubble_red1.spr": {
+     "bytes": 1140,
+     "sha256": "2a52f2c4dfdae381deeca608e5d007afe9dc245bbe16fea88c88f39c10ff7dc6"
+    },
+    "progs/s_bubble_red2.spr": {
+     "bytes": 1140,
+     "sha256": "fffcc0e03f9acc75e05636ab67f5f647568c81d0bcf4623e64d487c04d9cd5eb"
+    },
+    "progs/s_bubble_wht.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_yell.spr": {
+     "bytes": 1140,
+     "sha256": "9dcce864ad255b17d7d45e5c5531114f6a66c4e9cb549fc8b31aef0af5a9157f"
+    },
+    "progs/s_burst_flame.spr": {
+     "bytes": 22128,
+     "sha256": "66511ada8a299b0882e2939c09d3fb726d3ce52ecb93a884584a9ce11915a6c0"
+    },
+    "progs/s_burst_flamedp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_poison.spr": {
+     "bytes": 22128,
+     "sha256": "d8245e0460efc4e939a187912126f44422c39b1fe4b553c2c15da91833e8549d"
+    },
+    "progs/s_burst_poisondp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_burst_steam.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_dotmed_blue.spr": {
+     "bytes": 1140,
+     "sha256": "0b3160c5a4ae42216ddb7aaa7ae4726f6b2507c914328abe3c69f2d12fd921f8"
+    },
+    "progs/s_dotmed_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "6e28b69544f8aa13ccbb9a66893e4ab86b83639ee3f81dbbe1b94290ca9b03ef"
+    },
+    "progs/s_dotmed_grey.spr": {
+     "bytes": 1140,
+     "sha256": "77c226763e90a54b4d6835bd877c08c501605e516e64177c915c422e7b36c207"
+    },
+    "progs/s_dotmed_grn.spr": {
+     "bytes": 1140,
+     "sha256": "d1a9800a8b5cad01fa1dc93e57162e9960c4a8478e7e427d66cdbfe6a6797266"
+    },
+    "progs/s_dotmed_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "6113140f371b08cda9addcf68282c1fc16692da7498fa2fdfe2b99662e345d67"
+    },
+    "progs/s_dotmed_purp.spr": {
+     "bytes": 1140,
+     "sha256": "8b2cfa67ac86841f59409e184b4f3a253218e5930a5e3f241caef39dc1baa8de"
+    },
+    "progs/s_dotmed_red.spr": {
+     "bytes": 1140,
+     "sha256": "4ae92a280e0df01c0acd0a904214af485bb60919e5ded4573aa12f86875182d4"
+    },
+    "progs/s_dotmed_tor1.spr": {
+     "bytes": 1140,
+     "sha256": "eddd46a4818dfa92a9817df82e893d6bf6513160164a74b95bdd42fb7cac2f75"
+    },
+    "progs/s_dotmed_tor2.spr": {
+     "bytes": 1140,
+     "sha256": "dcb87897de0f54a6d8f78e9194a15c11261eb88455f058b334f8648a363159a9"
+    },
+    "progs/s_dotmed_yell.spr": {
+     "bytes": 1140,
+     "sha256": "e6b72aac439291d7719ee78d9520c1a1def36212ac7f61ba333fa87d5265c63f"
+    },
+    "progs/s_dotsml_black.spr": {
+     "bytes": 632,
+     "sha256": "2ae7fa13584d12f04b337fbbd774e74fbe54a6fcbd354239e97fecce931bd377"
+    },
+    "progs/s_dotsml_blue.spr": {
+     "bytes": 1140,
+     "sha256": "c0149109ae73a72da49bfaf9ba00cf2edadbe0f053928d09319083e6247883ad"
+    },
+    "progs/s_dotsml_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "f95fe813ecce2c69d2b72e5bf870d045037519c89f3da9a300e7453754cd1503"
+    },
+    "progs/s_dotsml_gold.spr": {
+     "bytes": 1140,
+     "sha256": "3833e80c32da39063b5069638ade52c4aee51b7db7206b4911cb48f321e25bdc"
+    },
+    "progs/s_dotsml_grey.spr": {
+     "bytes": 1140,
+     "sha256": "2e16d9ff8ceca2994a609703f405b1efbb7b49e02c8dbb9e77d0cdcaf3318b98"
+    },
+    "progs/s_dotsml_grn.spr": {
+     "bytes": 1140,
+     "sha256": "a2735123addacfa03f2666969e476af0d9f1cfefbef75a7ac9599d48f86226b1"
+    },
+    "progs/s_dotsml_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "ebf62caae17163587aaa3652300f1003c008ed21041b838a14cfff7672f87d90"
+    },
+    "progs/s_dotsml_purp.spr": {
+     "bytes": 1140,
+     "sha256": "476042db782f7f81cb53d91e9518881f28eb34d3a2a535c11d9c22f65518bce4"
+    },
+    "progs/s_dotsml_red.spr": {
+     "bytes": 1140,
+     "sha256": "94c0403ee7f1e6f6c4d6bc9b99e73e48143845fe35d0d6b3de246842241b12cb"
+    },
+    "progs/s_dotsml_wht.spr": {
+     "bytes": 1140,
+     "sha256": "7ac2d5b9b1e14a1799b951ace16bcc1addb7fefc2470dec23ef2ca110a934bf5"
+    },
+    "progs/s_dotsml_yell.spr": {
+     "bytes": 1140,
+     "sha256": "686f220b937040b91b6ff4f05efd41525d40eb80a61ff8138809d550bfa99959"
+    },
+    "progs/s_dripblue.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/s_dripgreen.spr": {
+     "bytes": 60,
+     "sha256": "805935ef90e14eda0f0ec89cc7e03acf52df768eb9e09140629bc1067a658774"
+    },
+    "progs/s_dripred.spr": {
+     "bytes": 60,
+     "sha256": "2dc81cd44438e124dedef0b656c31a066b7879940fcdbc39a0cfd57a6d2985e5"
+    },
+    "progs/s_dripsplblue.spr": {
+     "bytes": 828,
+     "sha256": "6b960ccc7a877bf2b4b67467400c0eaa1bb88d8c8a524458b9bf8d1aa1a6e29f"
+    },
+    "progs/s_dripsplgreen.spr": {
+     "bytes": 828,
+     "sha256": "397ac392598027c27240d71079f79eb9c90306724bc54c5d9854e14939059b6c"
+    },
+    "progs/s_dripsplred.spr": {
+     "bytes": 828,
+     "sha256": "268b48b87a0f352b671c04a1f7325af43372578a6d73269356389280eb7ef232"
+    },
+    "progs/s_exp_big.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_exp_electric.spr": {
+     "bytes": 5256,
+     "sha256": "ed01b728b6656a68acffe258d644712eba3b786434ab6b3e6d90434031e90d96"
+    },
+    "progs/s_exp_ice_big.spr": {
+     "bytes": 164076,
+     "sha256": "bf7317d811349602db7a020da3e77065ffd8158a3104e83ddca3b166566df18c"
+    },
+    "progs/s_exp_med.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_exp_plasma_big.spr": {
+     "bytes": 213288,
+     "sha256": "fe99a489e169ccf56f0412c2e83a7c5aea7b75b7cee0501402c62fcbd7ca969c"
+    },
+    "progs/s_exp_plasma_small.spr": {
+     "bytes": 53544,
+     "sha256": "555e39e88cedaf9e9dd1215ad1325b32019a6bf2654d53736b1f362506548150"
+    },
+    "progs/s_exp_poison_med.spr": {
+     "bytes": 72892,
+     "sha256": "60b7a8c194f3a6cd2241edd6223ac1da1f57811d7f5416216c70a2797d1baf20"
+    },
+    "progs/s_exp_poison_small.spr": {
+     "bytes": 53544,
+     "sha256": "2a54104dec9381afe338574d66bcc19bd2776caa0d46031c743cd24782098d3f"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "a9476d95ea10fbd2317c174272864efa4bb6e939893f3a3de520aeea3e3522d9"
+    },
+    "progs/s_flamemed.spr": {
+     "bytes": 43324,
+     "sha256": "3c645e305673693089fe48cc7a22f694eeaf7881cfc94ff7b1c4b05b718342cc"
+    },
+    "progs/s_flamesml.spr": {
+     "bytes": 21820,
+     "sha256": "5e60165461c34a3a25cbe6b0bb5e36131bb4a81fef384f1db4a7236f30e7ba95"
+    },
+    "progs/s_flametiny.spr": {
+     "bytes": 11068,
+     "sha256": "9d2c0af6139f3d194e73dbcb7880aa0a6f2a04019f94818ce9844691399b551b"
+    },
+    "progs/s_judgemagic.spr": {
+     "bytes": 12564,
+     "sha256": "6d08d5ada6bac219927edb39a93302f98b7b1a357e6648fc1abb49fd5cc3bd4c"
+    },
+    "progs/s_marsh_med.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/s_marsh_small.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/targd_hull2.mdl": {
+     "bytes": 3380,
+     "sha256": "520c82906942d582c6b64da4dca32ca8ed236694607c3a19ec71b89136e0c757"
+    },
+    "progs/targd_massive.mdl": {
+     "bytes": 17076,
+     "sha256": "099ed67733ea3a461c2247d6f07d3dadcc5a6968bcd6a03398507c653d174395"
+    },
+    "progs/targd_short.mdl": {
+     "bytes": 4788,
+     "sha256": "c883300477d3978469aabc35ef3969c14645c1111997c64452634fc8b4a978e1"
+    },
+    "progs/targd_tall.mdl": {
+     "bytes": 4788,
+     "sha256": "bab77599f9cbbe1cf0856a642612ae30b08fed9ae27a209abda30f6dc8c07129"
+    },
+    "progs/targd_wide.mdl": {
+     "bytes": 17076,
+     "sha256": "d40a00625196f67fe26f3611cd91dd33484ddbf3db273766f8a5fac38db07b07"
+    },
+    "progs/trap_pendlong.mdl": {
+     "bytes": 44900,
+     "sha256": "62d3b86fea6e2336dfc5c7b93514e096eba05992a3bd3e0c6571e4c4a27be684"
+    },
+    "progs/trap_pendshort.mdl": {
+     "bytes": 44900,
+     "sha256": "efb3e395093e34d7b16c92ed73abb199a28d0bc653522c13d4e720030f547713"
+    },
+    "progs/trap_sawblade.mdl": {
+     "bytes": 28716,
+     "sha256": "759bd7e1f7629b4d87ecb9e53a9f2d66e3e81b9103bc4eab3f85bd598eba36f6"
+    },
+    "progs/v_ghook.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "5b6b84edc6e6c58128a6e830ec35424cc83e69fab7b1337c4c681d8d0ed81e74"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 48964,
+     "sha256": "d073c7fad7dee2c4664aa401d744024b623abcd65e60a4c7066721b988838aff"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 54940,
+     "sha256": "c0a6b7d9664b0ab5a0c77732b22592dedfefbf65c624c05bec7aa8d60835f74d"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 39668,
+     "sha256": "78fc36ddbd33fb77192ef100547f1a1a0f70a38fdaac7094df67f2df33ca9237"
+    },
+    "progs/v_shadaxe0.mdl": {
+     "bytes": 97860,
+     "sha256": "598f555a854590a749eee83870a869ebfa8dfd3c84ad447b7fe3fb796ea1da80"
+    },
+    "progs/v_shadaxe1.mdl": {
+     "bytes": 97860,
+     "sha256": "2ffbb3026a21d70a73a091222cc4f2ea2ba6abd706fbffc276f027b9475abfaa"
+    },
+    "progs/v_shadaxe2.mdl": {
+     "bytes": 97860,
+     "sha256": "cd2a7a188f73c5b841183885663470c53c3af5646491f44811a4a0f192381ed7"
+    },
+    "progs/v_shadaxe3.mdl": {
+     "bytes": 97860,
+     "sha256": "b1c0dd11ce314003de5051f8a3b9581ee3eda5ea347d3d3371eea43051820197"
+    },
+    "progs/v_shadaxe4.mdl": {
+     "bytes": 97860,
+     "sha256": "81108f8b2484d24e54e9ab3ee5b707be5ea28adb142159412aa773ae01e593c1"
+    },
+    "progs/v_shadaxe5.mdl": {
+     "bytes": 97860,
+     "sha256": "0d3ca1664ee82ab2aed6261c262fdc455db981ecd2d62371595e520756d7bb22"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 22260,
+     "sha256": "bf79b703708665b9e65556bf68c0fe9d177097b2b96b11563d7b8bf84485a81b"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 22764,
+     "sha256": "5a51ba87bcdf37463bb8f34dd7259ea2be54d540fbc59798bb62dc24b2d3e777"
+    },
+    "progs/v_shot3.mdl": {
+     "bytes": 77868,
+     "sha256": "5b08bebaeb2fa054e6bb37d51c716cfac0e4da843b0db158a4a9769fa04ad13f"
+    },
+    "progs/v_zershot.mdl": {
+     "bytes": 62604,
+     "sha256": "4173bb2b84f9adce1957a87251cca591d968c3a54e801b170a87aae82539a2b1"
+    },
+    "progs/w_backpack.mdl": {
+     "bytes": 138832,
+     "sha256": "78d86e7bc605746990a1b10644b12542f3380375693d4fb015884e42269314a0"
+    },
+    "progs/w_blueflail.mdl": {
+     "bytes": 17236,
+     "sha256": "3b645ebcb5d2249c9cf904e17006b85aa05963efda33f45f5b6f6fc3ea188d26"
+    },
+    "progs/w_chainsaw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/w_dcrossbow.mdl": {
+     "bytes": 14388,
+     "sha256": "52b14c48ec77acb261f18e1d7903e360eb96acb5c22a0702dfde90c66b103064"
+    },
+    "progs/w_dfurysword1.mdl": {
+     "bytes": 8916,
+     "sha256": "16521de90d0e71090ef4e6b5904252f3ae2d4a38ebe99eff9dc758ea009b0f90"
+    },
+    "progs/w_dfurysword2.mdl": {
+     "bytes": 8916,
+     "sha256": "2e42b37254cf8d85b098e58143fd77d86bed2f3568f630196326841298d07187"
+    },
+    "progs/w_dguardsword.mdl": {
+     "bytes": 8404,
+     "sha256": "74b884b8fd0a785fc2c1dcc29428b8d4c8725de6963bccf7ec80c396e002fa38"
+    },
+    "progs/w_dknightsword.mdl": {
+     "bytes": 8404,
+     "sha256": "1e6729ae15dd1520fff7f4c1c30260c35b637bd0b23b8fb3a5a476b175a39165"
+    },
+    "progs/w_dprincesword.mdl": {
+     "bytes": 19296,
+     "sha256": "89e5ef1382e980b68e812f7e8f6a9b6fba34af42bb2def457b7a2f6f8d7388b7"
+    },
+    "progs/w_enforcergun.mdl": {
+     "bytes": 42612,
+     "sha256": "fbbfd121a3d085d654aab512cfebb0b6890daf3c403f25ca372edc3c53039375"
+    },
+    "progs/w_hknightsword.mdl": {
+     "bytes": 20504,
+     "sha256": "a8dffdc9e400d45fcea617255a8731d752cfa83df40b923128d5dbae6839492c"
+    },
+    "progs/w_judgesword.mdl": {
+     "bytes": 199388,
+     "sha256": "c822984ba5a12948ca389f4b8536c3aa6644993242362b10ac7f6ff2e2332590"
+    },
+    "progs/w_justicesword.mdl": {
+     "bytes": 264928,
+     "sha256": "0fc111a637bdaf5372c02c53439497c2adfc0914845b947ecc9ad70ace1e1b3d"
+    },
+    "progs/w_knightsword.mdl": {
+     "bytes": 14328,
+     "sha256": "4740ee2b171380cd9481ba07f284fe720c5b49b0980dc19cb145b2356205fc0a"
+    },
+    "progs/w_ogregl.mdl": {
+     "bytes": 8260,
+     "sha256": "8071cb814b6158c8af563494687e3994192818ccc2aa80f4766bbf6912d559ee"
+    },
+    "progs/w_ogreham.mdl": {
+     "bytes": 29996,
+     "sha256": "11c1ec322889a971b7f930a7c653f13e69714e6de77b7afa4ded1fdec39145de"
+    },
+    "progs/w_ogremac.mdl": {
+     "bytes": 29324,
+     "sha256": "2f9086da6b43becab1d54e47bcb299421b1bdc1e1e71c41e581b367a75f52919"
+    },
+    "progs/w_skullbook.mdl": {
+     "bytes": 25580,
+     "sha256": "e99379e980169501931eb029f36d05b41ba52f8597a6022bf195b08dba88c70e"
+    },
+    "progs/w_soldiergun.mdl": {
+     "bytes": 36120,
+     "sha256": "9c89a19d7c5fa69783d8bcf59b46b18a0c80c37e280b18731564952faf1d6523"
+    },
+    "progs/w_zombiesword.mdl": {
+     "bytes": 14328,
+     "sha256": "e4ac73fc149fa581e64fb5f2016ce58c99ab1c9a76502ede78a525ab7f344b0c"
+    },
+    "sound/ambience/bell_ring1.wav": {
+     "bytes": 61586,
+     "sha256": "b9169a48fd032d7c2b0cadb61540ac5db42ca6384cb2c74818bd46bae3fc7db1"
+    },
+    "sound/ambience/bigmachine_loop_02.wav": {
+     "bytes": 92760,
+     "sha256": "4d6dd03883ac4462c7f1741c022a3e8fd9e2c65cd54d5d126f58c00b3bfe7df3"
+    },
+    "sound/ambience/chimes.wav": {
+     "bytes": 250476,
+     "sha256": "d1060cd75d8a520b748047790d33c9a4ab5fd626330ebf1242d318d308c165db"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/distant_gears.wav": {
+     "bytes": 72502,
+     "sha256": "760d34131249ff3c4bccdab0cd3df69874728a6db3e1b4545177e5ce381e5e80"
+    },
+    "sound/ambience/drone6.wav": {
+     "bytes": 36820,
+     "sha256": "ab0cc1d617b06169d20b42bddc31078c0c7a1b8b15793fe6cfea6dbc96b4129e"
+    },
+    "sound/ambience/fan_finish.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/fan_loop.wav": {
+     "bytes": 288110,
+     "sha256": "d7459b4f1087aa1e002f41fc0274e4cb2f313dff5af2eecaa9de5225bcdcd729"
+    },
+    "sound/ambience/fan_start1s.wav": {
+     "bytes": 96044,
+     "sha256": "b0bad8ae3cd81dc4bbd76591e29f9c43610cb6e0311d4822213e400a6b99dd9f"
+    },
+    "sound/ambience/fan_start2s.wav": {
+     "bytes": 192044,
+     "sha256": "6716a803f246e44416fc414ca2f51744fc1ed79178f79fe3baf7a986c820c020"
+    },
+    "sound/ambience/fan_stop.wav": {
+     "bytes": 192044,
+     "sha256": "ee8607922387eeb594c18096ef6dd4003990a5fe47414dee331921f6d03be6b7"
+    },
+    "sound/ambience/fire1.wav": {
+     "bytes": 47906,
+     "sha256": "c1370a7c177aa21de219578cc64716bc800007e2ac86ae106affac01f8edc470"
+    },
+    "sound/ambience/flames1.wav": {
+     "bytes": 132406,
+     "sha256": "8ac99a7ace2ec9cc98a38fd5777973eb484e9193cf93dfcd6a51ea4f0f9d0f00"
+    },
+    "sound/ambience/flames2.wav": {
+     "bytes": 132406,
+     "sha256": "31e76d131cb4ad3c0602e2559c949feb7a8749c639363f1fd7df53136616fdd1"
+    },
+    "sound/ambience/flames3.wav": {
+     "bytes": 132406,
+     "sha256": "b4008d1da182bc0886f8bad53e5a700d8e04050920aa27ceb0922be938eb7c96"
+    },
+    "sound/ambience/flames4.wav": {
+     "bytes": 132406,
+     "sha256": "222222e080566c899a48df9e40006d0ee36575c03250c44845fb10a94c5cead9"
+    },
+    "sound/ambience/gargoyles.wav": {
+     "bytes": 136816,
+     "sha256": "16f09404b6043aaacb4b6b2bb00143ab72b5e185f02e610d780ea7d311d2df6c"
+    },
+    "sound/ambience/gearopen.wav": {
+     "bytes": 49708,
+     "sha256": "39b73c8ada1b06c7ba07099447b9b0d75911f08df09ced3826bcff136af5b0ee"
+    },
+    "sound/ambience/generator_gas.wav": {
+     "bytes": 529314,
+     "sha256": "6710075453fde424951171823e87f3711d53fd434149ddecc14a14ce721de04a"
+    },
+    "sound/ambience/ind_lift1.wav": {
+     "bytes": 158906,
+     "sha256": "c722fa19c7851d2c7b4307489911b885527e31fd3e4de44d5a184bd786714049"
+    },
+    "sound/ambience/ind_lift2.wav": {
+     "bytes": 156008,
+     "sha256": "c404881a9758f839fd055dd69a82f04bf7e5d5b98538a4a87b2ee741d8b4956d"
+    },
+    "sound/ambience/light_hum1.wav": {
+     "bytes": 100022,
+     "sha256": "cb2f04b81297621ffddbfb028dc5021a665e3285deb7c80757a47add8294f032"
+    },
+    "sound/ambience/liquid_bubble.wav": {
+     "bytes": 129688,
+     "sha256": "838ec1e72b2c433408a342a48518987edcb2124932eeb477d59653540b13d6ea"
+    },
+    "sound/ambience/liquid_burnlong.wav": {
+     "bytes": 710182,
+     "sha256": "9c9c77941f88416e3f20dfc4f028cc6c9719dd7f58a15dfc6124f1bb5a17f61a"
+    },
+    "sound/ambience/liquid_burnshort.wav": {
+     "bytes": 89464,
+     "sha256": "4ea16997389f1aa35549869a338f2093f40d14df030c381a7659cc7e3cbf8bfc"
+    },
+    "sound/ambience/liquid_drain.wav": {
+     "bytes": 220464,
+     "sha256": "e86a6012c8fc3a795791fc344ef636bb1854a602cd609e2df751531e89277cf9"
+    },
+    "sound/ambience/lowboom.wav": {
+     "bytes": 666640,
+     "sha256": "ad591a6f574f48e654e32dacee6b7d862df8b47e20ef116f84415ad9aa515559"
+    },
+    "sound/ambience/machine_loop1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/ambience/machine_loop2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/moo.wav": {
+     "bytes": 265502,
+     "sha256": "35b7924115bc4cdf94e9cbb274a4d9ca251d6878817834bec08aaa176f2ddc9b"
+    },
+    "sound/ambience/mystery_drone.wav": {
+     "bytes": 1350258,
+     "sha256": "eb3fbb28dda2a6204af07d08fa993ed09513f9915142dd6f4af808204b6b8c9e"
+    },
+    "sound/ambience/power_drone.wav": {
+     "bytes": 36700,
+     "sha256": "4307c01076cb5e076d27546b17bd6b11e2369a67b59dbbd64f2607d8b262a8c2"
+    },
+    "sound/ambience/power_off.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/ambience/power_on.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/ambience/power_shutdown.wav": {
+     "bytes": 1118464,
+     "sha256": "e0ab1a0f67a2d37a525f7a73e8ee8c3a26f746e027fa1501f6648f5586ea2048"
+    },
+    "sound/ambience/power_switch.wav": {
+     "bytes": 66382,
+     "sha256": "5c006bb7315e6eb6d2367ae30a78f0abec8ae2a1e2b6a2c9af88354962b0f33f"
+    },
+    "sound/ambience/rain1_nl.wav": {
+     "bytes": 154394,
+     "sha256": "45d8c08ff4a9a2dd6ff8362fea7c22f9c3ea64a3a8d7b6c81c8cad88265f327a"
+    },
+    "sound/ambience/rain2_fade.wav": {
+     "bytes": 198550,
+     "sha256": "3cf300a4f785d416656838bd3a68120bf6a48d16f928ca74e2e0890ec9f8b426"
+    },
+    "sound/ambience/rain2_nl.wav": {
+     "bytes": 66250,
+     "sha256": "f2735ae8a7b1ae5ab5ce3b8ed66d8c61d00a65f2e66d8c565f4abe718d57ab67"
+    },
+    "sound/ambience/rain2_org.wav": {
+     "bytes": 132400,
+     "sha256": "4c1f820b2c8f4bea08b8357fb8409e9f30a98fd0faf1413a1953ea697b84b507"
+    },
+    "sound/ambience/rumble1.wav": {
+     "bytes": 403620,
+     "sha256": "47afe820548bcf248b7760f7a66a61ea65b5fb79f70d47e3b03cf8211bb4c5f3"
+    },
+    "sound/ambience/rumble2.wav": {
+     "bytes": 99104,
+     "sha256": "9c3d5418c7e5bac60c365f0e8b7ea496dd2b51c72c13b0e5a6640e2ef880433a"
+    },
+    "sound/ambience/rumble3.wav": {
+     "bytes": 209242,
+     "sha256": "864f373dbd75172e1c8f31373188f38c31a80af46592f6b2e92cf5f576e5e0e1"
+    },
+    "sound/ambience/s1_stop.wav": {
+     "bytes": 16162,
+     "sha256": "9a35adf9361aa033b413762fea7d04b2cf7392b363f2aa187a81905f65a44b61"
+    },
+    "sound/ambience/switch_1.wav": {
+     "bytes": 35324,
+     "sha256": "9f73f07313ba4995247d82901111b5aea4200c48de6641dddb145dfadcac40c9"
+    },
+    "sound/ambience/switch_2.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/switch_3.wav": {
+     "bytes": 17576,
+     "sha256": "33b6ed57b0255840415df4db607f86b1183b564f4b1f2dcab6d45d4d75231b8c"
+    },
+    "sound/ambience/switch_4.wav": {
+     "bytes": 44348,
+     "sha256": "bfebdf2afdbab57bd5be3fe0996ce19ff46d983eea4d1511d85af2e4f7d0db00"
+    },
+    "sound/ambience/switch_5.wav": {
+     "bytes": 79992,
+     "sha256": "78bb8cb9ab7202657495a0ca14340886af901912850b9951b0da159f55c2cb20"
+    },
+    "sound/ambience/switch_6off.wav": {
+     "bytes": 141466,
+     "sha256": "999d3b02b7224586d5c487c2666981f054aa091f0569671c72455bff458c9a2a"
+    },
+    "sound/ambience/switch_6on.wav": {
+     "bytes": 176192,
+     "sha256": "7a67fa5d4ee042c6afd271868682a1a34908c2593e5ea9e868ecb6d3e154b55b"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 220548,
+     "sha256": "2cec0b03aa7047110862de21f8f6c77e4d98901ecaf5e405a473c2ddc922528a"
+    },
+    "sound/ambience/thunder2b.wav": {
+     "bytes": 286716,
+     "sha256": "44095eceb307b5f2f1093051597ea0e48bc7abe165accd5badf99c4ad692c6df"
+    },
+    "sound/ambience/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/ambience/windgust2.wav": {
+     "bytes": 110284,
+     "sha256": "b818f61172795942402ff0ca0d1295a91c36a245edc80689c35fe64a8ac1a4e2"
+    },
+    "sound/ambience/windgust3.wav": {
+     "bytes": 110030,
+     "sha256": "fdbb85f091cd9447f1500173aff70236abcdb947ba0758711816da59c5293344"
+    },
+    "sound/ambience/windgust4.wav": {
+     "bytes": 198502,
+     "sha256": "9a5c5a3da44f981c9deb8b437f57b3e3a35f2bcab318a1a3223f0a18fa4d2101"
+    },
+    "sound/ambience/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/ambience/windgust6.wav": {
+     "bytes": 396944,
+     "sha256": "27a19679e7164a6e7bb8e4d6bc42cc8c12a5cd56bba45218e2ec5f1dc528da0d"
+    },
+    "sound/ambience/woodcreak2a.wav": {
+     "bytes": 352834,
+     "sha256": "24d3f57839910934eb61b74a91cf47ee4ab48b38f58f060ca05bde7547e8813c"
+    },
+    "sound/ambience/woodcreak2b.wav": {
+     "bytes": 352838,
+     "sha256": "574401233bff93169d452f4af748a289cfaff5d4e6319884e3cfb4dbd205d0a4"
+    },
+    "sound/ambience/woodcreak2c.wav": {
+     "bytes": 308746,
+     "sha256": "02deb62b856b7be5c3304a0bf745f79019b0b408a8cfcc4e1edede397ba09c7d"
+    },
+    "sound/ambience/woodcreak2d.wav": {
+     "bytes": 352856,
+     "sha256": "6d35975964b2fa32ece681a9d0cfa13202cde02bc315f32af0690f7437352452"
+    },
+    "sound/ambience/woodcreak2e.wav": {
+     "bytes": 308766,
+     "sha256": "54eb41e3f5c2a0103d07e70e83cf82b51014da3673fb770cf6ada3df669c328e"
+    },
+    "sound/bal/bc7_waterfall.wav": {
+     "bytes": 137846,
+     "sha256": "51dcfb96c94678cbb01e0c985240e853a01c6fc3c4f2376de177c0be59bfcfe6"
+    },
+    "sound/boglord/attack2.wav": {
+     "bytes": 8036,
+     "sha256": "efa18dec8f6d5066b8d494a232ca9c98c27a4a9130130086a9b0a27ffccb34ed"
+    },
+    "sound/boglord/bangdoor1.wav": {
+     "bytes": 30968,
+     "sha256": "b267e602e76fe1d8e854e2873e06008af15612ed1a31ec41feeb4461d52fc478"
+    },
+    "sound/boglord/bangdoor2.wav": {
+     "bytes": 39828,
+     "sha256": "f904a5423580c118de1d732fff714565f1dd8d8d1556b3b58bf39d2c59fa4272"
+    },
+    "sound/boglord/bolt_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/boglord/death1.wav": {
+     "bytes": 39758,
+     "sha256": "a9e0e36b1a51d88a5b542dd2c1f79f1dbea402b3ceb18ee13606c03126f1a874"
+    },
+    "sound/boglord/idle1.wav": {
+     "bytes": 15532,
+     "sha256": "5339e3429b0510f7e8016e6ece9895df6f202b5809f739b317211a081401f202"
+    },
+    "sound/boglord/idle2.wav": {
+     "bytes": 18586,
+     "sha256": "52f8bddb2d5095f4077eb1f753d75bce94f906f1b3064067a54c875ae16d1a5c"
+    },
+    "sound/boglord/melee1.wav": {
+     "bytes": 9326,
+     "sha256": "e2f5808115d0a93dde1063db6f2d38f6ab7ff333f83d95741a8948f44ae4ace9"
+    },
+    "sound/boglord/melee2.wav": {
+     "bytes": 11746,
+     "sha256": "e299e39467c9f94730c21d1321455fdccf3aefbb0352d528b6d413639210e715"
+    },
+    "sound/boglord/melee3.wav": {
+     "bytes": 18776,
+     "sha256": "c066200b5ddb81aa0c0cc0462939681703549ac15dd6aa83db8a23ae54ce6317"
+    },
+    "sound/boglord/pain1.wav": {
+     "bytes": 11094,
+     "sha256": "6ca5a44043add6b389827e5aca8bc0c9e9c7b0cc0c7b4a5d3df292a78da0064f"
+    },
+    "sound/boglord/pain2.wav": {
+     "bytes": 11094,
+     "sha256": "7e11818fbae5354177add1e236b6f3e0f4665d50193154fbb15fead4bb4d7908"
+    },
+    "sound/boglord/sboom.wav": {
+     "bytes": 22172,
+     "sha256": "89899521eac11f922cdd4606a0fe08bc080a63a73ec4b4a502027e33f08b225b"
+    },
+    "sound/boglord/sight.wav": {
+     "bytes": 28734,
+     "sha256": "8b020b0f07a7461f5f520b8385e38828d66b3cb1fc46d7db08b845fa8ff62ad8"
+    },
+    "sound/boglord/slime_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/boglord/slime_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/boglord/thud.wav": {
+     "bytes": 22140,
+     "sha256": "f5d7b5f65e24d6a5edd04404b93a8c5a2db45cc6c142012638f050158bb783ba"
+    },
+    "sound/boglord/thud2.wav": {
+     "bytes": 105882,
+     "sha256": "7e8826a38df07d0d2b85d6d39b8b664bb2ef8a0686846573802b77811682e957"
+    },
+    "sound/break/ceramic_i1.wav": {
+     "bytes": 11106,
+     "sha256": "ed731319eb09044fe672f5d8681395a11a7449fe7b57b9a46040c717e714cf40"
+    },
+    "sound/break/ceramic_i2.wav": {
+     "bytes": 11126,
+     "sha256": "88c29d649471f031aa1049ee087cf866e1d9ea53183effd14cfabc81ecff9502"
+    },
+    "sound/break/ceramic_i3.wav": {
+     "bytes": 11144,
+     "sha256": "420d00d7884a22dd2baf9cdd1e059689858b47fb3adb2ad5ae29c80bd74b5dc5"
+    },
+    "sound/break/ceramic_i4.wav": {
+     "bytes": 17678,
+     "sha256": "0b7da87d046aeb3a52de305da60b2400c8cbf3480364235fb0bba3a0595f13dd"
+    },
+    "sound/break/ceramic_impact.wav": {
+     "bytes": 37584,
+     "sha256": "e6d2ada5c51a2787548468ad393e2497ef84b47ca487cd523f3ef6b283626226"
+    },
+    "sound/break/ceramic_impact2.wav": {
+     "bytes": 35380,
+     "sha256": "508725e20a999c339501dddb045a2ca6a51032905dccc68fe2a3fb9e9e1d0649"
+    },
+    "sound/break/ceramic_impact3.wav": {
+     "bytes": 26560,
+     "sha256": "ca4d7876a6e33cc285186d1432670878b54cc62c01e3dc4c650727069bfdb8ee"
+    },
+    "sound/break/ceramic_impact4.wav": {
+     "bytes": 37584,
+     "sha256": "e71b0559ac5d76dcd2016d07f8999ae1200d82ca7b658509339cf303c918f777"
+    },
+    "sound/break/ceramic_impact5.wav": {
+     "bytes": 37584,
+     "sha256": "1c6b3457c9d3aab209cd3b8977df579cdbe01158c1b4e5c07c2b5b227c96fb6d"
+    },
+    "sound/break/ceramic_impact6.wav": {
+     "bytes": 37584,
+     "sha256": "fac4857865a750a03f74e556f44186381315068ec1975c775fcd14ae4a7b3c7b"
+    },
+    "sound/break/flesh_impact.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/break/glass_i1.wav": {
+     "bytes": 13268,
+     "sha256": "63ec32f660d085c64274747b704bcbeb7261062b5fcbb570598d64e742dc7164"
+    },
+    "sound/break/glass_i2.wav": {
+     "bytes": 30950,
+     "sha256": "8b2ae028e6237cf06241739e3533ef3bf651194dfbef028fd648a6f06e8996de"
+    },
+    "sound/break/glass_i3.wav": {
+     "bytes": 8848,
+     "sha256": "ec97346c02431717927e2dd3712bd82428ea05960ffa027422fbaafab96b4170"
+    },
+    "sound/break/glass_i4.wav": {
+     "bytes": 4442,
+     "sha256": "b4144a008122e52aed45339e11ccf7cb1cd2e92f07e4169d029059a4ca01f5fa"
+    },
+    "sound/break/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/break/metal_i1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/break/metal_i2.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/break/metal_i3.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/break/metal_i4.wav": {
+     "bytes": 79928,
+     "sha256": "d2b35ba352f32ceae469acf9cfa04f7dcc0a462ff69e3649f5c0adf55ae2ea78"
+    },
+    "sound/break/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/break/rock_i1.wav": {
+     "bytes": 30534,
+     "sha256": "5cb61e93ebcf9bbcd3be1f6e282b51e9102d56b6650cffc0db93918b11b42322"
+    },
+    "sound/break/rock_i2.wav": {
+     "bytes": 29254,
+     "sha256": "9fdf4f489834452fce33b1fbe69bce9d4920a117c3d0d93b4fb530a7117bf160"
+    },
+    "sound/break/rock_i3.wav": {
+     "bytes": 25264,
+     "sha256": "59b506a84e018b11e9ba30a6ad299c2d8cf24d5907dc95cf30e578cd386e28bf"
+    },
+    "sound/break/rock_i4.wav": {
+     "bytes": 27244,
+     "sha256": "7a2c24ce52e272998ca035c967860873c92fbb14227a190ac82b761843680ffd"
+    },
+    "sound/break/rock_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/break/wood_i1.wav": {
+     "bytes": 28074,
+     "sha256": "6249449664f5ae509164ae3fd8588c905bea9daf5b1d919d9917b91aadf675bb"
+    },
+    "sound/break/wood_i2.wav": {
+     "bytes": 25158,
+     "sha256": "d51e731bdf895c84ec9927c496fc0a7fb6e7a37cbfbc2f6b55f54f716d804d08"
+    },
+    "sound/break/wood_i3.wav": {
+     "bytes": 17644,
+     "sha256": "8e1967cf42a7e31668d94e1b0cb7c6de4d36c6ec735d67ab01ac4e00dfb0853c"
+    },
+    "sound/break/wood_i4.wav": {
+     "bytes": 11516,
+     "sha256": "fb0908f1a2bdff824d27fa92f15690cb9f86805185119fbc7f7876547495bf45"
+    },
+    "sound/break/wood_impact.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/chthon/attack1.wav": {
+     "bytes": 22116,
+     "sha256": "91df4f5be21c6a80d31a050192b04a760f25c7f88a4b0ceeb2802fe8b8499d21"
+    },
+    "sound/chthon/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/chthon/death1.wav": {
+     "bytes": 55120,
+     "sha256": "b6eeee788b9aa49ca9698d2d7977748f142053fd3f47e2828d1781d7db7ec986"
+    },
+    "sound/chthon/idle1.wav": {
+     "bytes": 24322,
+     "sha256": "6a0a9b5a0b2e74fce8cbfa9ede97c2059884c0db81b2c68fc0ec7bb1da2a4009"
+    },
+    "sound/chthon/lavasplash.wav": {
+     "bytes": 100546,
+     "sha256": "a533653ff77e2dfc443377a1f055b6abd7af3c639f0e5634b0a47fd1f040ed76"
+    },
+    "sound/chthon/pain1.wav": {
+     "bytes": 35320,
+     "sha256": "f964bdd08ffc66f9f229aacb3b584ffefdcfbacf7da0f0075a9af752569c641c"
+    },
+    "sound/chthon/sight1.wav": {
+     "bytes": 49454,
+     "sha256": "533adf244fa2c2dca72765560e823ceead8d5a0f3832ba18d4fa2928154b12c8"
+    },
+    "sound/deflector/death1.wav": {
+     "bytes": 22150,
+     "sha256": "593140594353d4d25fe6b5e455afc0f3c2cdd6874bc1d545ea03f779454cd799"
+    },
+    "sound/deflector/death2.wav": {
+     "bytes": 41334,
+     "sha256": "4295a9a79fec3bf611c25f97553420d0e42b987ad8091930db9137b93a3e8f06"
+    },
+    "sound/deflector/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/deflector/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/deflector/idle1.wav": {
+     "bytes": 7668,
+     "sha256": "76455fc9d5fc53cf5a70900a9d875ba3ac839e1c3179eccc5287619a70523e6e"
+    },
+    "sound/deflector/melee_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/deflector/pain1.wav": {
+     "bytes": 6452,
+     "sha256": "e0905dc6c945663a97119f2c1522d5a8ebd1596ed26f33650fcb63b185959517"
+    },
+    "sound/deflector/pain2.wav": {
+     "bytes": 9598,
+     "sha256": "011d69ef5153dca029bcb1c3d60b3c3f0e1263bd9ca34a02d4d14e6ab508a0d4"
+    },
+    "sound/deflector/pain3.wav": {
+     "bytes": 12014,
+     "sha256": "08f5ac27626e862b7193f101a6d0b77dc6568c4e93ef3000199934769666b1ec"
+    },
+    "sound/deflector/rocket_fire.wav": {
+     "bytes": 15482,
+     "sha256": "a08e5f83d20b5d1eb585cf782f08a4a692b0f8c95e461b9a321814d099a89d79"
+    },
+    "sound/deflector/rocket_hit.wav": {
+     "bytes": 13274,
+     "sha256": "4dbcd0bad68272848a32a997bb235c4324cd55b1df0b96b1876fb96ea8ca6a90"
+    },
+    "sound/deflector/rocket_load.wav": {
+     "bytes": 6882,
+     "sha256": "1dbddae67f93c586ea3290ed65e1234cf8ccfd076847b1b418693e97fb5768d1"
+    },
+    "sound/deflector/shield_off.wav": {
+     "bytes": 10684,
+     "sha256": "5c3ea84c12abf632d777f90972966c4a50dde4ee7363d257e3c0f89e68027b5f"
+    },
+    "sound/deflector/shield_on.wav": {
+     "bytes": 10464,
+     "sha256": "340196ba32a9d3f672cbc3db86765eb1517550b00f2f97ed76cb519da1b93962"
+    },
+    "sound/deflector/sight1.wav": {
+     "bytes": 16106,
+     "sha256": "3ec7f00e859c52846b244e69cc3ed7321175746a44eb373fe4bd3cb07612dcf3"
+    },
+    "sound/deflector/sight2.wav": {
+     "bytes": 14432,
+     "sha256": "e8c0c1367969b0346bf5fdc94665a10480636629a71a6a35e47da3d7fb7cb463"
+    },
+    "sound/deflector/sight3.wav": {
+     "bytes": 17184,
+     "sha256": "11748c58e67305ad4e1cd7a2e2c084f9c41184cd2b4f756adfd18adcc22dbc2d"
+    },
+    "sound/dguard/death1.wav": {
+     "bytes": 30610,
+     "sha256": "af3809501261ec4d0afa6ea7301c11a5c7bbc1cc3e06b8c88172ee0214c30969"
+    },
+    "sound/dguard/death2.wav": {
+     "bytes": 43636,
+     "sha256": "93a70fc0d6fee819c723a435a3954b3fd3be86e358698ce85db1062990d1575e"
+    },
+    "sound/dguard/fire.wav": {
+     "bytes": 60820,
+     "sha256": "f5e5d4f6ccc0778c1396c66d327564a0b1892773f2c23d2e30590abf0c758bd2"
+    },
+    "sound/dguard/hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/dguard/idle.wav": {
+     "bytes": 20498,
+     "sha256": "45b2f208b9796d19d7aeb0cba64e4b0e5fd2ed7c980123f7c41ca10d17785021"
+    },
+    "sound/dguard/pain1.wav": {
+     "bytes": 10380,
+     "sha256": "9a367afb7cde241099c58c999e225ba939be39f21be818b16444f5a810049960"
+    },
+    "sound/dguard/pain2.wav": {
+     "bytes": 14892,
+     "sha256": "827a1e4d3c9983f61fffd61de33054274c144bddd9a68460b496fd6281cf9406"
+    },
+    "sound/dguard/sight1.wav": {
+     "bytes": 18124,
+     "sha256": "9cb3d960261d90ec16c9883f4326c905356b6ff4e99cdf48ab5913b098588016"
+    },
+    "sound/dguard/sight2.wav": {
+     "bytes": 18022,
+     "sha256": "35ee4b7ec6715c8c9fdc24f90ad0b5d90a0ae7a4986168cf40670e87c325d5db"
+    },
+    "sound/dguard/sight3.wav": {
+     "bytes": 19948,
+     "sha256": "c6818770267626dea27f4a72ce2249771f6968924022c2275a5a96abfa485044"
+    },
+    "sound/dguard/sight4.wav": {
+     "bytes": 20332,
+     "sha256": "7affcdbdc62f13e492a15b54fe642fe045641f5551f570cc3c8d5f7ee29521fd"
+    },
+    "sound/dguard/slash.wav": {
+     "bytes": 22942,
+     "sha256": "44b60d785ff03f033e183b6fbce69e526351187d28efdeb308f6f8bea930d450"
+    },
+    "sound/dguard/slhit.wav": {
+     "bytes": 31956,
+     "sha256": "0f07a131640f21337cd89a772588ecfc707d6a729f96b54c21920b809cd620e4"
+    },
+    "sound/dguard/slmiss1.wav": {
+     "bytes": 10458,
+     "sha256": "e32d5cb070a13fad979b021e84a727f71242305ade1af7bfe18c255f0f6dd548"
+    },
+    "sound/dguard/slmiss2.wav": {
+     "bytes": 13840,
+     "sha256": "f6b3aee08c25434d2fda7468cacf35a0912b182653a45991149b54a0fc4be537"
+    },
+    "sound/dknight/dcross_idle.wav": {
+     "bytes": 176610,
+     "sha256": "a7eba673532dad555f879ba77091e3cb9e44558608b83c36d8639e51d71b660a"
+    },
+    "sound/dknight/dcross_idlecom.wav": {
+     "bytes": 58910,
+     "sha256": "bba45bd9fc02e1d580a80596d6a1744bb8fb993ed73a7bfdf3b712670cccf989"
+    },
+    "sound/dknight/dfury_grunt1.wav": {
+     "bytes": 19702,
+     "sha256": "8d3709e913b8e26d8e094fddd9c60d74cc71b742e16276d4982c9636db05209e"
+    },
+    "sound/dknight/dfury_grunt2.wav": {
+     "bytes": 54294,
+     "sha256": "f7ca0d5970322629cc47f8c26489d5c916a570525ded20c73823c27f2834609c"
+    },
+    "sound/dknight/dfury_grunt3.wav": {
+     "bytes": 62054,
+     "sha256": "6eae53c32568ce90083dab528c18475ef840f9f684c43cdba7bfcc1c63435ba6"
+    },
+    "sound/dknight/dfury_grunt4.wav": {
+     "bytes": 28914,
+     "sha256": "0def63c77d0f116eabb77cc462ba6a57bc6523fad469946c6f1f11d786100819"
+    },
+    "sound/dknight/dfury_leap.wav": {
+     "bytes": 102756,
+     "sha256": "f288dc9324b2ccace32ce86cffaf0c042a59bf5b56b20657c018859f1038243a"
+    },
+    "sound/dknight/dfury_sight.wav": {
+     "bytes": 69602,
+     "sha256": "443887e91ca71dbba299b37a81bdbd3bb34b491c6c3e13fe73bb5c921019d1ea"
+    },
+    "sound/dknight/dprince_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/dknight/dserg_hbreath.wav": {
+     "bytes": 185884,
+     "sha256": "c8181d4844ac4b2bb7dc47bbc28bd2ae9fc2737120d6745292de4d594f40d406"
+    },
+    "sound/dknight/dserg_magic.wav": {
+     "bytes": 34768,
+     "sha256": "adcb0810b7e8b23d91d31f5727c480b35c7b59a90d9f7933f69c00e7eccd1f3e"
+    },
+    "sound/dknight/dserg_sight.wav": {
+     "bytes": 15210,
+     "sha256": "d4f7c5b6f64d48606d1d3e1889794a22107f3d5914b37c81c405fdfb1133a7eb"
+    },
+    "sound/dknight/ghost_idle1.wav": {
+     "bytes": 110292,
+     "sha256": "878416a0151a1a71891a84db2565d1e8a2b2e37f03f1822d7f9411a98b42b528"
+    },
+    "sound/dknight/ghost_idle2.wav": {
+     "bytes": 110290,
+     "sha256": "048f79f7fa8f9e49f97dad9f5cb468933be1713726ba95d3ab10d9811cbb5f2f"
+    },
+    "sound/dlord/death.wav": {
+     "bytes": 32022,
+     "sha256": "0188f6a3dd88686e15311f8c39c4277078e55bc0ec75497e2eb534af717abcdb"
+    },
+    "sound/dlord/idle.wav": {
+     "bytes": 9906,
+     "sha256": "c0ee37f80013dad1aaeb285a11a33c4d7c2ff2de0b2a94c2943d3fbe1c241bcd"
+    },
+    "sound/dlord/pain.wav": {
+     "bytes": 8632,
+     "sha256": "230ed5c7d024bfa90b973649aa79d9e9327eaf401b1632e4a1334fb4a9eb075c"
+    },
+    "sound/dlord/sight.wav": {
+     "bytes": 28028,
+     "sha256": "d82aa0028754e826705961040e1ab27f007c572a28c63dbcaeefeb681bc3ca85"
+    },
+    "sound/doors/rattle1.wav": {
+     "bytes": 88274,
+     "sha256": "c524d12100f1067bb30ecdf83e18e5d85124fef834929cfd2a2ade14f83ad730"
+    },
+    "sound/doors/rattle2.wav": {
+     "bytes": 123526,
+     "sha256": "e8decabe8df10f704814bf2f432b3fc6d5542022d465af336b0680793f6163ea"
+    },
+    "sound/doors/rattle6.wav": {
+     "bytes": 97072,
+     "sha256": "0aef6aac51a4e3528e5f2019bf113ee2f0e5096a708d31483a526c447ebdb00c"
+    },
+    "sound/doors/rattle_tech1.wav": {
+     "bytes": 61784,
+     "sha256": "18610e64612241e6936f2d0ebe746c957652c4ce8e37c668515281712f6a1e39"
+    },
+    "sound/doors/rattle_tech2.wav": {
+     "bytes": 88244,
+     "sha256": "de39aa8b59c988b02bf6c13a716e225b7ee029f2553357b8646aef92a2792c3e"
+    },
+    "sound/doors/rattle_tech3.wav": {
+     "bytes": 52844,
+     "sha256": "a29e8144cdab34467250f040feaad044aff784a2775b50bd220e967b39f39b3c"
+    },
+    "sound/doors/rattle_tech4.wav": {
+     "bytes": 76844,
+     "sha256": "ba34a641758a2e2cb9ef5358a398482c2b34526fc4b0c49db590c9679c732ef4"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/enrage.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/r_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/eel/attack1.wav": {
+     "bytes": 27740,
+     "sha256": "8c84b2a5e7fd0754dca3611a8300a8cc9656295ea73617ff0c85d167b28459df"
+    },
+    "sound/eel/death1.wav": {
+     "bytes": 34264,
+     "sha256": "a0f8eab92db10e8fa9342f725743297fd8384e2aca1decc1189109196f3b960e"
+    },
+    "sound/eel/idle1.wav": {
+     "bytes": 53110,
+     "sha256": "c059a4f2bee33543b377803f2af1fc7e2ee205cd02d987859af18087246ae46c"
+    },
+    "sound/eel/impact1.wav": {
+     "bytes": 70632,
+     "sha256": "13cea2f7d66f40511add17d846ab6142345497ddd7cff5ebfc5e2e70a7eb1fbe"
+    },
+    "sound/eel/pain1.wav": {
+     "bytes": 13316,
+     "sha256": "569a6bf9383820e90e431db5c0b82cd0201e10fd2081d228f81a0c76a0e88d1b"
+    },
+    "sound/eel/sight1.wav": {
+     "bytes": 32074,
+     "sha256": "90786a043f5ec1bd0b761c5c8378dc2783e3b1d8e3ac95a9312f55a7c5b3baea"
+    },
+    "sound/eidolon/attacka.wav": {
+     "bytes": 27660,
+     "sha256": "a7bb5c16014c814d379585eb4c6752a91240a5856ad7f3af5f86af037bef91e6"
+    },
+    "sound/eidolon/attackc.wav": {
+     "bytes": 220544,
+     "sha256": "9815d26814c687618b7bbae4a5353570afe497c5d57fb77c083f695d102234c9"
+    },
+    "sound/eidolon/attacke.wav": {
+     "bytes": 46400,
+     "sha256": "39ad467257004bc6d2a17003abe4ef8df89d0668ec03fc8570aa755cbdf94c6c"
+    },
+    "sound/eidolon/death.wav": {
+     "bytes": 264696,
+     "sha256": "bc055e1315073c78e5571c99d29894bc89abfd64b6a258bdabc79849f81c50a0"
+    },
+    "sound/eidolon/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/eidolon/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/eidolon/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/eidolon/footstep1.wav": {
+     "bytes": 52384,
+     "sha256": "e228c0503d89118be55eafaf3a3bfa0a13e3bdcbe4a043f4a9bb31c9e96cf3dc"
+    },
+    "sound/eidolon/footstep2.wav": {
+     "bytes": 46128,
+     "sha256": "1a3b867c93932411f1c3dedf4a8f1553f19caabae438cb7989095307d1a6c5c5"
+    },
+    "sound/eidolon/footstep3.wav": {
+     "bytes": 43774,
+     "sha256": "4119d9c31e359bd48b52bff2842e51c441064896289194f04db44e2d7860cccc"
+    },
+    "sound/eidolon/footstep4.wav": {
+     "bytes": 41758,
+     "sha256": "6b97f80545d9587580a7b445f13e5a38300627e497ed85357f9448c7a910864b"
+    },
+    "sound/eidolon/growl.wav": {
+     "bytes": 44380,
+     "sha256": "f9f404c4590f2af8fa9a1cd0de34e1d031e66d88ccf553dba228396f0d8fb012"
+    },
+    "sound/eidolon/idle1.wav": {
+     "bytes": 28778,
+     "sha256": "61f423068b79bba82fb3ae3fca3957a8f059802068edf272f2695e6caab89271"
+    },
+    "sound/eidolon/idle2.wav": {
+     "bytes": 33172,
+     "sha256": "1bdd3d6862ed0b74aecae1917f09a65acf4db7fca49a0ccd21a7fbc2eea5f02b"
+    },
+    "sound/eidolon/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/eidolon/pain.wav": {
+     "bytes": 17744,
+     "sha256": "6a308180389e3fb98cc00c70dad1c6600988778b34628e04363e7ca54e5bf679"
+    },
+    "sound/eidolon/rock_hit1.wav": {
+     "bytes": 97066,
+     "sha256": "d31741c09309b240d294ba9b310b694aae1d71f823ac9ef28b27a8b5fff14405"
+    },
+    "sound/eidolon/rock_hit2.wav": {
+     "bytes": 123526,
+     "sha256": "a3d1247db98535829392172110a40fde19113dd493ab603c4b6a9a36dd743150"
+    },
+    "sound/eidolon/sight.wav": {
+     "bytes": 53044,
+     "sha256": "04c124f683e75e4d14374b7a044eeea288dd02a845ccab3ffd670f1c15799ebb"
+    },
+    "sound/enforcer/cent_hover.wav": {
+     "bytes": 103796,
+     "sha256": "a5616566072a5cdc9339e3722d6fee9e652796e9cc8f76e27dbd9aee13986f4e"
+    },
+    "sound/enforcer/death1.wav": {
+     "bytes": 9290,
+     "sha256": "f62aad2ae903808a0caecfc6bdfe13e5fdebb1df14d330c6ac4eda9b577b25bf"
+    },
+    "sound/enforcer/def_idle1.wav": {
+     "bytes": 32676,
+     "sha256": "7b673b07828790504caca013c18bf697fd53b758a3638b949b433cf2d72f03f3"
+    },
+    "sound/enforcer/def_idle2.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/enforcer/def_sight1.wav": {
+     "bytes": 18260,
+     "sha256": "7d57825c28cf4f93189261d76cccab676aeba097920114d5d3f48d7eddaaa1cd"
+    },
+    "sound/enforcer/def_ssg_fire.wav": {
+     "bytes": 14206,
+     "sha256": "494a6d493c3c298c1b9cc0051ce4c1f9e129293ea7ec283b62915c49d8c249c3"
+    },
+    "sound/enforcer/def_ssg_load.wav": {
+     "bytes": 5274,
+     "sha256": "db4f62f8d76a68f2e4d3e7a29a22d3ddc5d6ae9bb296e6e800e937b73b5a4dea"
+    },
+    "sound/enforcer/elim_idle1.wav": {
+     "bytes": 39084,
+     "sha256": "2ccaa3ba4f987d031a22b8048ca23e97900fca9def362ff92943b73a99ed7844"
+    },
+    "sound/enforcer/elim_idle2.wav": {
+     "bytes": 36204,
+     "sha256": "9232028e1a93c409c7000348bfadc269c49a333e8d65d904973efb547c7af805"
+    },
+    "sound/enforcer/elim_idle3.wav": {
+     "bytes": 38222,
+     "sha256": "93034d568db5c304a165c3d89cb03ffe5d97e8157755e944a863697007eb27fc"
+    },
+    "sound/enforcer/elim_pg_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/enforcer/elim_sight1.wav": {
+     "bytes": 31468,
+     "sha256": "2268ee0ad0c77a081b289a550a1dae24b274b2e3f06d156a67beca80df8ee919"
+    },
+    "sound/enforcer/enfire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/enforcer/enfstop.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/enforcer/fum_poisonoff.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/enforcer/fum_poisonon.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/enforcer/idle1.wav": {
+     "bytes": 15810,
+     "sha256": "cec388af73dff076ea3af7c754ef0939f989f3412b0359c0fb668cd91bd4abaf"
+    },
+    "sound/enforcer/pain1.wav": {
+     "bytes": 5478,
+     "sha256": "d8692021777495825974f8406e23c74ed249f9a80a9bc944c79b1722c35f64e0"
+    },
+    "sound/enforcer/pain2.wav": {
+     "bytes": 4580,
+     "sha256": "e48a524482ce67ff94ce00fe4d8a1190aed38e9c7c24cfee3607f0f2827049e6"
+    },
+    "sound/enforcer/pyro_flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/enforcer/pyro_flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 5870,
+     "sha256": "92dc64154602e29e95d40aa68d3544fe21cb21ce24192f1e8ffefc6b5d31b8cc"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 6574,
+     "sha256": "52b1991141ed9452fe6c7ebe219cc544fba443058f179b8eec5a5cbfb9aacf3d"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 6158,
+     "sha256": "d3b9e689b2b43ae74ae14fdb26680d3646d658107664965db97420ae032d74b0"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 5166,
+     "sha256": "815e05c3b14858209fee01316848c117ad89af9f0aab190fc0ca0239367373ac"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/freddie/death.wav": {
+     "bytes": 88244,
+     "sha256": "2e3de0875dd3245a98614829ab848cc1dfc34a95827aa4cfc174884977ecddf0"
+    },
+    "sound/freddie/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/freddie/idle1.wav": {
+     "bytes": 88280,
+     "sha256": "673ac7c26a9be2b1ea37b152ce48442ff40089cc7dc015c014eb42534db2c306"
+    },
+    "sound/freddie/mangle.wav": {
+     "bytes": 48548,
+     "sha256": "ee318d6849ca9dda4569db6009210a6909279bd2ffe9b31543d47134b51c1533"
+    },
+    "sound/freddie/pain.wav": {
+     "bytes": 38640,
+     "sha256": "ffe05b43444a209084c95c166b0776d33f9ba8af15ef998d3ed5c09aa0b03c3d"
+    },
+    "sound/freddie/painshrt.wav": {
+     "bytes": 8868,
+     "sha256": "31e08c51909022a6b0ad7f01f1f8dae196269b8b105e57e555025393cdc278d9"
+    },
+    "sound/freddie/sawstart.wav": {
+     "bytes": 41938,
+     "sha256": "90f83017a7ff5f2bd2824be1e122eab7d8171ab63a9025adf1fc03ee3e7a44aa"
+    },
+    "sound/freddie/sight.wav": {
+     "bytes": 55170,
+     "sha256": "3f73e5b30cef3038102ffa9ab0faf89e71af43ed2ee5a0758319c072c151c123"
+    },
+    "sound/freddie/step.wav": {
+     "bytes": 19898,
+     "sha256": "121818aa6200c770a70c2c02844bbc0351a62f166c31f9d85765896b426f610e"
+    },
+    "sound/freddie/step2.wav": {
+     "bytes": 19870,
+     "sha256": "7e33eb621ee356cbe4affe6218b988f477259dae705d57eea12d7fe10b5d4510"
+    },
+    "sound/freddie/step3.wav": {
+     "bytes": 19898,
+     "sha256": "a005232c4c0608092c7d697c6d24566892b74adfe7566030360c96996bd39357"
+    },
+    "sound/freddie/stfire.wav": {
+     "bytes": 27598,
+     "sha256": "597fa6e0e8c4da4fd85e9e26ecd7f95f3dc242846ec9b962cf2beb324e5a4fdc"
+    },
+    "sound/gargoyle/attack1.wav": {
+     "bytes": 28712,
+     "sha256": "cab70a44f7ec34343a1608ca8c13dd2b501065cade08e94b574f98436aabeadf"
+    },
+    "sound/gargoyle/death1.wav": {
+     "bytes": 41662,
+     "sha256": "07043eb3fcbcc9c8cf53b07c10b349a9f3beb471dc240a6d70d8f2b5a57e85b0"
+    },
+    "sound/gargoyle/death2.wav": {
+     "bytes": 28768,
+     "sha256": "c363613cd476d5099dbdced656244db0d704da5eeb54fe5b880f2202f6f465b2"
+    },
+    "sound/gargoyle/idle1.wav": {
+     "bytes": 72868,
+     "sha256": "90885fa6cae946ecfedec8a150911bcfdad8ef326254e1fb1bf44ca5c5af4eb0"
+    },
+    "sound/gargoyle/pain100.wav": {
+     "bytes": 26510,
+     "sha256": "d53f1e64f4c9f5e13e03cfee2681ef6dff370e95e9dd8668c7c06b79762e7773"
+    },
+    "sound/gargoyle/pain75.wav": {
+     "bytes": 28720,
+     "sha256": "78d5d0f1c5df4e1a565eeda076d5f8b3bb3582e551909b31fa8e36c292903826"
+    },
+    "sound/gargoyle/perch1.wav": {
+     "bytes": 26506,
+     "sha256": "5eab54a566e4c1136c40fbfbd636188a7a9c4aa6b278e51fb965e1761764cbff"
+    },
+    "sound/gargoyle/perch2.wav": {
+     "bytes": 30924,
+     "sha256": "745b5c5f1fd04a73a7581373925aa70cd3f35ab899df5f5fd2c610d07bf95bdd"
+    },
+    "sound/gargoyle/sight1.wav": {
+     "bytes": 35142,
+     "sha256": "1097300e4bca9ef61a7041e7f4ff403fe67c4fc0e687b30892a6bdf35bf45c09"
+    },
+    "sound/gargoyle/swoop1.wav": {
+     "bytes": 21056,
+     "sha256": "ef6b4b672dd984e846294e0be57d81df3abcb521b1f88f6afaf2f5cc2d4e91d4"
+    },
+    "sound/gargoyle/swoop1hit.wav": {
+     "bytes": 11078,
+     "sha256": "6a624e3f46e2c45f5e2d6f42ee18643a17268a6b0df2493fe6ffdba4be0c9057"
+    },
+    "sound/gargoyle/swoop2.wav": {
+     "bytes": 24364,
+     "sha256": "f98d41f9df7244e8f77c435ae4071a4e4595ec7005b7c72e44456fe7baca425e"
+    },
+    "sound/gargoyle/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 22094,
+     "sha256": "142b725ff5515cb438a592288a69e01331b3fd0bbb7311abf1dbaf90f95417ef"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/plasma_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/gaunt/plasma_start.wav": {
+     "bytes": 66270,
+     "sha256": "ad404715612b802a7d4f72f2d14abb47c338ac414af56c19ffc8dc2873f33452"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gaunt/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gibs/gib1.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/gibs/gib3.wav": {
+     "bytes": 33256,
+     "sha256": "10a19291ed8af8893b6cdbd80416425b27e5a197d39aa8d0557320752d78cf11"
+    },
+    "sound/gibs/gib5.wav": {
+     "bytes": 15490,
+     "sha256": "2d7603a9fc0c055ed3529bd4dfd511984c71b93f4719b605813eb5139d02c6d9"
+    },
+    "sound/gibs/gibacid.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/gibs/gibchain.wav": {
+     "bytes": 15938,
+     "sha256": "c6b2a37424a51810017bd5ee4764a014329467686f73bb2f48ad2704592176f3"
+    },
+    "sound/gibs/gibheavy.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/gibs/gibheavy1.wav": {
+     "bytes": 11110,
+     "sha256": "0a1313f08fa22e4df8a1beb15ffdb6e7b1906187f63042357e4a43631ef5e93a"
+    },
+    "sound/gibs/gibheavy2.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/gibs/gibhit1.wav": {
+     "bytes": 22150,
+     "sha256": "d2a73e2f9e31b9fefda789e49b17ec9bd18df0335c31f871514a282cf550829a"
+    },
+    "sound/gibs/gibhit2.wav": {
+     "bytes": 22150,
+     "sha256": "210477e93743dc6c0541bc158032d46251c6aeff551efcf515d6e7db87bb8a53"
+    },
+    "sound/gibs/gibhit3.wav": {
+     "bytes": 22150,
+     "sha256": "40db6dbb033d59dd458e5fb6102dba6d6ecf5bc5739d9fc35a3be68cc977da53"
+    },
+    "sound/gibs/gibhit4.wav": {
+     "bytes": 22150,
+     "sha256": "0bd1e29d68e41cbf2d753730df678918a38fc886b4690991fbd7e8fb3e13e055"
+    },
+    "sound/gibs/gibhit5.wav": {
+     "bytes": 22150,
+     "sha256": "4adf7a8249ee913aeb9e91120b1f6b9e529b1e1a3eadb75185589cf7c3ff910e"
+    },
+    "sound/gibs/gibmetal1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/gibs/gibmetal3.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/gibs/gibmetal5.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/gibs/gibmetala.wav": {
+     "bytes": 18474,
+     "sha256": "2c057e772307ef647b4313975cec75bacfd522bbc5dd27ae83a867065562635f"
+    },
+    "sound/gibs/gibmetalb.wav": {
+     "bytes": 30756,
+     "sha256": "fbcfa9e6cd5aa68c6fffd6699c8dc87ec3707a4281358f229afce57f3278c800"
+    },
+    "sound/gibs/gibstone1.wav": {
+     "bytes": 52956,
+     "sha256": "962dd735a1823905243700eb3f4e0caacc1be71a1f367ccad4f21dd82b4e99e1"
+    },
+    "sound/gibs/gibstone2.wav": {
+     "bytes": 22104,
+     "sha256": "04f070fa9873f382ded03a5139ce2c7da2013d8ef9221a8d10a64c3b5f912591"
+    },
+    "sound/gibs/gibstone3.wav": {
+     "bytes": 35344,
+     "sha256": "16262de5a0b703468f2c3f1e49ffa0c225eb81b89984b468b7bc95948ed890c0"
+    },
+    "sound/gibs/gibstone4.wav": {
+     "bytes": 8832,
+     "sha256": "75179beed6fb6f581944f5e7db153bea4d9ecc65899628468efd48710a392013"
+    },
+    "sound/gibs/gibstone5.wav": {
+     "bytes": 22130,
+     "sha256": "0aaff5c363ac29a9b50d83b4b04fcd7264c614a93d0c9bc7941c9704a6b4b499"
+    },
+    "sound/gibs/gibwood.wav": {
+     "bytes": 61708,
+     "sha256": "d9b53ab4d53f1265dd2083d341cd92f19729694946ff00ad15fa6d96965e63e8"
+    },
+    "sound/gibs/stonedeath.wav": {
+     "bytes": 76750,
+     "sha256": "26d0eb67357d292043fd494b1646f8ce005ba692d98610429bceedfc831d2325"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 374654,
+     "sha256": "de356a2581884e9008ef798775f82049c465aec242cad0f6024b510d33e11764"
+    },
+    "sound/golem/groundslam.wav": {
+     "bytes": 132412,
+     "sha256": "f557ad378642a77a2f31433db5fe9315cf33f5fc350018e2bd26d32359ec8617"
+    },
+    "sound/golem/iceshard1.wav": {
+     "bytes": 53022,
+     "sha256": "41e523122aa4168298b247748bbe4201928582e974e673a83e717ea33f8656a8"
+    },
+    "sound/golem/iceshard2.wav": {
+     "bytes": 53012,
+     "sha256": "4b4e457f75d051a7aa3525bf82338f8b6d2f9460583c09e63d82b202cb11d03f"
+    },
+    "sound/golem/iceshard3.wav": {
+     "bytes": 53038,
+     "sha256": "8134080a7c6478463f9ea8c368eb6e0563dacb35bb3941b1e08e2cf0763d83ab"
+    },
+    "sound/golem/iceshard_impact.wav": {
+     "bytes": 176470,
+     "sha256": "ac850565ac7cfaa8ec2e55f535603aaf131605b9399f08f1b17f7c08920f7bda"
+    },
+    "sound/golem/icestorm.wav": {
+     "bytes": 61802,
+     "sha256": "2e8129333bc1a677591f9c4838a5f8c8e9ff63050fe6a47f212380f2497ae706"
+    },
+    "sound/golem/idle1a.wav": {
+     "bytes": 88238,
+     "sha256": "d238c43b6e83c044ba70352ed9362e50d68caf606f500c7d79f5c03d1e6a432e"
+    },
+    "sound/golem/idle1b.wav": {
+     "bytes": 88242,
+     "sha256": "93e3ca1ec51345da6e06a53f71bcd1271c911c9a6272246de9f58bef93c904dc"
+    },
+    "sound/golem/idle2a.wav": {
+     "bytes": 44166,
+     "sha256": "d0ceeb0ee1681127f9f426ccaa0ddb75c6ef32594618c972536871544e8d5748"
+    },
+    "sound/golem/idle2b.wav": {
+     "bytes": 44178,
+     "sha256": "94fb43b50445dbe7a8fe6cc06ea745b729cf5bf61c33cc543123f751e4a9cdf7"
+    },
+    "sound/golem/melee_pound.wav": {
+     "bytes": 17672,
+     "sha256": "23ff4f485f3adb3ba5227ba59824e226e91005846d2879077ffbe04141bab78b"
+    },
+    "sound/golem/melee_punch.wav": {
+     "bytes": 17702,
+     "sha256": "21cbd6ca5b9c8d95a43c39b360b12ee8033dca1aaf11d4c1164d4bc9ce83b7d3"
+    },
+    "sound/golem/melee_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/golem/pain1.wav": {
+     "bytes": 27948,
+     "sha256": "388150975b33e271db5402f502c6a36899731ec85cb9b16cdcc4b427b206a3f2"
+    },
+    "sound/golem/pain2.wav": {
+     "bytes": 32940,
+     "sha256": "b3908c02406bcb8c379f345f80a825aa270a54ae02fe0356e02330620d9cf437"
+    },
+    "sound/golem/rockstorm.wav": {
+     "bytes": 264676,
+     "sha256": "c57be8195f675560b879c3fc4e23c49f021d0c45aa81f2a84b74303f111d7c7a"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 76762,
+     "sha256": "965d1107adbc9a068d1d2af16fc783855833569dcc3a6030fa920019c30a4083"
+    },
+    "sound/golem/wakestatue.wav": {
+     "bytes": 250454,
+     "sha256": "630505eb8c9c84511f39d2e77096cafcbab044f73569934cda127a4b6f37f138"
+    },
+    "sound/items/airtank.wav": {
+     "bytes": 22160,
+     "sha256": "9b8f5c5deb886800c91d46809ecf82fb114467eb8a395b9c980d47c6b35f6b17"
+    },
+    "sound/items/airtank2.wav": {
+     "bytes": 66286,
+     "sha256": "76156f8f89e2bedbfaee9ee3340adb6bfe8639f242051178c2655e04cdab5198"
+    },
+    "sound/items/airtank3.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/items/airtank3out.wav": {
+     "bytes": 176494,
+     "sha256": "672a866c27c64f7eda1e05775cea6b4373c289c39fd423a519d39198d10a9c89"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 15122,
+     "sha256": "54c25fca46991ea142e9fdf5309e690ce3ff977df89aa7d14a8938ff386a237e"
+    },
+    "sound/items/backpack_ammo.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/backpack_armour.wav": {
+     "bytes": 20612,
+     "sha256": "438a08f094f47fac5f0b959fdde0f941be50bac12abdaa159f6f727975021aec"
+    },
+    "sound/items/blastbelt1.wav": {
+     "bytes": 43442,
+     "sha256": "a85924de58caed8e32d2849838afa0f248ec26eb295c9fc82eff818bc292f28b"
+    },
+    "sound/items/blastbelt2.wav": {
+     "bytes": 74978,
+     "sha256": "e4747a55ed0d66b6ce3bfe4ad0a4cfa75308657a155ebd9396ada78e0fd46bac"
+    },
+    "sound/items/blastbelt3.wav": {
+     "bytes": 49028,
+     "sha256": "4a2f6e7f65cbbc19c4bd5facf821017f7e60c41b9c164575de5255a40de2ba53"
+    },
+    "sound/items/health0.wav": {
+     "bytes": 8718,
+     "sha256": "cd277cc4fc98dbf9d5b0ba3ab784e468ba77a5aec78fe6086bd125512b6d1dbc"
+    },
+    "sound/items/health1.wav": {
+     "bytes": 13316,
+     "sha256": "ed9a43a3506afd8073e0d5225f3fa43116bb922b84d2216c2053d58f597544e6"
+    },
+    "sound/items/itembk2.wav": {
+     "bytes": 18884,
+     "sha256": "2b5601380dcc36753327eea905d15d2e0fd0f016d9559a2f8924f6f34b8045d5"
+    },
+    "sound/items/jumpboots1.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jumpboots2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/jumpboots3a.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jumpboots3b.wav": {
+     "bytes": 85590,
+     "sha256": "8eda0e57fdadfb61a414b4dae8c567a2bf10d9dabc44db7cf5589f00bba16250"
+    },
+    "sound/items/jumpboots3c.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/lavashield1.wav": {
+     "bytes": 30884,
+     "sha256": "e79050c462eeefcdbe6be0d79ff3042e80e5654c4060cf5377eee366cb4d6b43"
+    },
+    "sound/items/lavashield2.wav": {
+     "bytes": 49190,
+     "sha256": "17e93e45d150704bab8debd86ee8e9c600e9b08fefa70b16e1fe712dfdbd0c23"
+    },
+    "sound/items/lavashield3.wav": {
+     "bytes": 22094,
+     "sha256": "d94735d5df3c5850d2308972cb2495a9c9ec87e57c434c3ff0c160da659b051f"
+    },
+    "sound/items/nailp.wav": {
+     "bytes": 97394,
+     "sha256": "eb786846675412ba7bfb892fa0d5d356b67ec83ad3a551de8b423a874c3608d1"
+    },
+    "sound/items/nailp2.wav": {
+     "bytes": 132454,
+     "sha256": "2a01a3beb92154c7275c3c2ad39f648f8ecad7fd32ef7264d7404b917e0147dc"
+    },
+    "sound/items/nailp3.wav": {
+     "bytes": 45268,
+     "sha256": "0ea4502763119419b226d830b5b0147d6cfbe78996749e330d652d5b538dbb7b"
+    },
+    "sound/items/protect.wav": {
+     "bytes": 44176,
+     "sha256": "1bc5895a71225e8a385ebc900952d3b41f3d9541eefb8affcf15804ca96e5ab4"
+    },
+    "sound/items/protect2.wav": {
+     "bytes": 66286,
+     "sha256": "80b2a47fb1158f252e888bc692d352f224170c2d18177163dfea5c8110688e65"
+    },
+    "sound/items/protect3.wav": {
+     "bytes": 44176,
+     "sha256": "4aab23bd1683c733c5c85e7d55a93b27746860bd3c1a707e8c5a6439e35b5fd2"
+    },
+    "sound/items/r_item1.wav": {
+     "bytes": 12272,
+     "sha256": "3b569e1a8210563a64045dc1629a243b382c49cf24722cbddbdae348d5fa75d7"
+    },
+    "sound/items/r_item2.wav": {
+     "bytes": 14462,
+     "sha256": "088bb9013c0d2201997d3c566b95cc91f0419ba0bc89173c9e532659ccb4e886"
+    },
+    "sound/items/sharp.wav": {
+     "bytes": 100592,
+     "sha256": "c86d353daa830fffcf5ded77b73d6b8871d15a47a857a977ebaf7cbddb6cb587"
+    },
+    "sound/items/sharp2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/sharp3.wav": {
+     "bytes": 46584,
+     "sha256": "6318f7079e79929ff0439a570c5f806ec9c2cce8a8447eddb666dee0c2211336"
+    },
+    "sound/items/sharpa.wav": {
+     "bytes": 97394,
+     "sha256": "cd0d8dc72f736b38ab9c4a473798f0dd32e2074c14a310892c3fdf6515ff53be"
+    },
+    "sound/items/sharpa2.wav": {
+     "bytes": 132454,
+     "sha256": "2545c58a3682c1e8459389dc728a39fe0d76e6ce14a9c816a4826e327ab9bddc"
+    },
+    "sound/items/sharpa3.wav": {
+     "bytes": 45268,
+     "sha256": "083cc822d4cd6819d2dfd6e125ea4ca8ef3230c1ac1c4a5f5e3fe22e4d3d36d9"
+    },
+    "sound/items/suit.wav": {
+     "bytes": 31568,
+     "sha256": "a9b13127acef0c8e617cf5e510d5654227db9049a2b06b7544eb9e3030146ee7"
+    },
+    "sound/items/suit2.wav": {
+     "bytes": 66368,
+     "sha256": "34f0ba1b415ab62f2eb3b7a59bda6fe6fbbf3e519c7d2fab29a42ce29eb073c3"
+    },
+    "sound/jim/death1.wav": {
+     "bytes": 14348,
+     "sha256": "7f97f27dfda78f9fe6fc5265e512b651e57ae466752d56cfe0dccd6d08478ed8"
+    },
+    "sound/jim/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/jim/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/jim/gunidle.wav": {
+     "bytes": 13260,
+     "sha256": "46441335fe896cb993368bb12cedc1ddd4886b5933298bb6a0d6b7ba430cdfe5"
+    },
+    "sound/jim/gunidle2.wav": {
+     "bytes": 48540,
+     "sha256": "08d3577b66ab4b4c65ae7b01e4590e8d985605cc51a939bae0b43967472208c6"
+    },
+    "sound/jim/idle1.wav": {
+     "bytes": 44460,
+     "sha256": "7bc2df6cdd0f9a06cc441c656664edb3c686ab5803dab70948cc27bbba968494"
+    },
+    "sound/jim/idle1r.wav": {
+     "bytes": 44460,
+     "sha256": "7549a540858b1a829ac010930b848474c2f2200b910371368c99e35641f24644"
+    },
+    "sound/jim/idle2.wav": {
+     "bytes": 44460,
+     "sha256": "90d55e9ac8db5523255ec80384abd2508f005890f4fb66a654f4d783435afb4d"
+    },
+    "sound/jim/idle3.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/jim/laser_load.wav": {
+     "bytes": 36040,
+     "sha256": "5f39b9f60c5de5c9c3ac25a5149f1fef557e66c09d7d1a760ed6770082c5a914"
+    },
+    "sound/jim/pain1.wav": {
+     "bytes": 27006,
+     "sha256": "27522940f1db4eb098388e049a63d3a608e4beb2fa248d1232ae45d38a944e85"
+    },
+    "sound/jim/pain2.wav": {
+     "bytes": 30850,
+     "sha256": "6d1988d75f430287ad3e8766e9aafa8c8c85e2f2ebf53395b0fc2eb0fb26d788"
+    },
+    "sound/jim/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/jim/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/jim/rocket_load.wav": {
+     "bytes": 23416,
+     "sha256": "e3820aad09060be13927e56fc0e21112c22161b50b7d5be9cf59b98f84c5a231"
+    },
+    "sound/jim/sight1.wav": {
+     "bytes": 14892,
+     "sha256": "1a0db2b8c8d763f9aae09913d1cd3548fa0e30eb03949e24ef511a70acfda303"
+    },
+    "sound/judge/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/judge/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/judge/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/judge/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/judge/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/judge/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/judge/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/judge/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/judge/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/judge/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/judge/smash_ground.wav": {
+     "bytes": 66250,
+     "sha256": "f29f17426d2bd961d4f166e25fb951c8e12a37314bbc49722f0ae34c2beae233"
+    },
+    "sound/judge/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/judge/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/judge/smash_roar.wav": {
+     "bytes": 61784,
+     "sha256": "24b26a6b00a8731693bafd8ef67a5f0e2a4bbad20e722ec14f6fefd13047dc78"
+    },
+    "sound/judge/summon.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/judge/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/justice/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/justice/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/justice/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/justice/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/justice/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/justice/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/justice/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/justice/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/justice/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/justice/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/justice/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/justice/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/justice/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/lostsoul/bite.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/lostsoul/charge.wav": {
+     "bytes": 114682,
+     "sha256": "327cf4f521c92b3af6ff7cf50d1bfa6d101d06dee52350f123473e56e72626e3"
+    },
+    "sound/lostsoul/death.wav": {
+     "bytes": 151916,
+     "sha256": "08b6f8d3a50465e7deb346bc8902605bfc8bafc134cfac38aeb1d9fa5d1d2863"
+    },
+    "sound/lostsoul/idle1.wav": {
+     "bytes": 132332,
+     "sha256": "aac9bd66ea75d4778a20ba07b248baaa4f446beb60e5b5be76d04be36df1a1db"
+    },
+    "sound/lostsoul/idle2.wav": {
+     "bytes": 132332,
+     "sha256": "963c18a04a41d49ced0c820fd6ec51c885e7828a2a09bd47c15227555b6d4ada"
+    },
+    "sound/lostsoul/pain1.wav": {
+     "bytes": 14948,
+     "sha256": "baccaed4fd7c4e504214eb7241d3e8ea3e187739a781c30de57c8b5af6dbe6d0"
+    },
+    "sound/markie/dronebell1.wav": {
+     "bytes": 410346,
+     "sha256": "c7b65065ba9279c8131a83b642523e4193b8611f7b14430af2d52c831082340a"
+    },
+    "sound/markie/dronehum1.wav": {
+     "bytes": 156754,
+     "sha256": "9542c51342398a1281476da03114adb01012367dac58d2a08b50c684a1a98093"
+    },
+    "sound/markie/dronehum2.wav": {
+     "bytes": 183654,
+     "sha256": "03545ae0f88b788e69e09c0aae2cccfa727a2609ef224c7d1d3451f0e6172709"
+    },
+    "sound/markie/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/markie/dronespace1.wav": {
+     "bytes": 151808,
+     "sha256": "2c9c7f38a2023d3452a48db3e5f98d11fa218315991d907f8e3fa95d128d4f76"
+    },
+    "sound/markie/dronewind1.wav": {
+     "bytes": 110328,
+     "sha256": "f65fd70b6c398e1a17975eff7d92bde89ac17bc8d5cf0e9c6dcb17934311e3a6"
+    },
+    "sound/markie/morte1.wav": {
+     "bytes": 529280,
+     "sha256": "c338e404901bbf094c5946e50cbd922580c077dc3f3e5369ab962cb07a70d855"
+    },
+    "sound/markie/morte2.wav": {
+     "bytes": 529280,
+     "sha256": "58e598c9da2ced85f6973eb897f578e0f29a13fa0eaefebfe14c8942a33c77ed"
+    },
+    "sound/markie/ritual1.wav": {
+     "bytes": 273266,
+     "sha256": "fe9b4b53f899a88321707330bb2454442d74e5098328e35549b9f0a8ff840cba"
+    },
+    "sound/markie/ritual2.wav": {
+     "bytes": 273246,
+     "sha256": "d38ee880af55413aa7c180b8c1935df71177502081ee1c376c37b572af3d9352"
+    },
+    "sound/markie/stingwhisper1.wav": {
+     "bytes": 132380,
+     "sha256": "fc6eebd33c0c99c0f4537a9727698181acb4d23d077f06b3da1ebbcb104c870c"
+    },
+    "sound/markie/stingwhisper2.wav": {
+     "bytes": 132380,
+     "sha256": "ae7319c28e0a4e492623b7ddb48634978da043c16d4450f86b8edf7e60fa283c"
+    },
+    "sound/markie/stingwhisper3.wav": {
+     "bytes": 151672,
+     "sha256": "e5dd9dcfd44dedf7b0cd4a0a94a519a0bbd84477e54293548a37aa16d3f1e428"
+    },
+    "sound/markie/watercreek1.wav": {
+     "bytes": 184884,
+     "sha256": "f0c3ac87d6f073cea0d1a9218c4e53327be7af07a8c8be00cd73f254f6c0ba03"
+    },
+    "sound/minotaur/attack1end.wav": {
+     "bytes": 19936,
+     "sha256": "eceb47163a0f495037bd067fcfe852dbd0cf8cc7c376c536f5e4bda8569d3f5c"
+    },
+    "sound/minotaur/attack1expl.wav": {
+     "bytes": 15554,
+     "sha256": "a8344e4036b9377a6c8e3d69c2e86c7f5fc157fb0034d6e0e190d5b9fc444ca7"
+    },
+    "sound/minotaur/attack1long.wav": {
+     "bytes": 42000,
+     "sha256": "bb901880112ff159b380b8bfaf19fc511f4b1217f08d55a05276a3500f6cd4c7"
+    },
+    "sound/minotaur/attack1start.wav": {
+     "bytes": 19944,
+     "sha256": "33dafc2b20be70d6da51321f9910a392535e6a31cbbd3c8d0d880307a18adb3a"
+    },
+    "sound/minotaur/bolt_fire.wav": {
+     "bytes": 17738,
+     "sha256": "2f8ea56413270eef58b56ae4c4f7af2506ee89fda82aab90c0426f4560baa80a"
+    },
+    "sound/minotaur/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/minotaur/idle1.wav": {
+     "bytes": 17686,
+     "sha256": "d213130ad4b58b5b55553da46d358526411916210e90caf082c5a93b499e2f81"
+    },
+    "sound/minotaur/idle1com.wav": {
+     "bytes": 15564,
+     "sha256": "0f8054eb2c16284a098f680dcdc65f5a4b8b971f8cceaca6adebe8c377d6117f"
+    },
+    "sound/minotaur/idle2.wav": {
+     "bytes": 15470,
+     "sha256": "390c82c79532878751bcddca11aa37dbd86018757860e46d0c950a09fee347d9"
+    },
+    "sound/minotaur/idle2com.wav": {
+     "bytes": 17764,
+     "sha256": "8369884de2f4f144b9e323f11e95f47723834b529b62100c908fef5e74391a93"
+    },
+    "sound/minotaur/jump1.wav": {
+     "bytes": 22160,
+     "sha256": "1aa935c4c76818dbe7faed7aee0d9acb9e98ad553a747bf00b83b811d141e886"
+    },
+    "sound/minotaur/pain1.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/minotaur/pain2.wav": {
+     "bytes": 41488,
+     "sha256": "bc9ffeb193379c6738ad2897ab582aa92e278a11d7f1fbb77563ca367987ff76"
+    },
+    "sound/minotaur/sight1.wav": {
+     "bytes": 48610,
+     "sha256": "8d0a5c1a31e525416430f8d45b8482b091d3bb9f6030ac2656bdeb231ddab5e9"
+    },
+    "sound/minotaur/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/minotaur/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    },
+    "sound/minotaur/strike1.wav": {
+     "bytes": 11142,
+     "sha256": "69b1419eed136c384deac99d31827825d3d57fc965ba80604faf9de3e85fd9b8"
+    },
+    "sound/minotaur/strike2.wav": {
+     "bytes": 11142,
+     "sha256": "ab12dc8ab3c9dc603e2ecd58a99beb9c1f551fb79eb6124bdba493efe7595a92"
+    },
+    "sound/minotaur/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 19940,
+     "sha256": "0798d1a1122171f06fd6b92e3f91881725c05f40e1eeb3494a5a1a1aa8a86e58"
+    },
+    "sound/misc/drip1.wav": {
+     "bytes": 12172,
+     "sha256": "9499c277eab2210ba491b61263b71410e5e8f4b2a68403ec6eb81bef687da04a"
+    },
+    "sound/misc/drip2.wav": {
+     "bytes": 15596,
+     "sha256": "410c25c5c459362849c7d3d0ad736e006b65a949e77c094fe248e803b357d5e0"
+    },
+    "sound/misc/drip3.wav": {
+     "bytes": 15164,
+     "sha256": "9ddf50265efafde7736fb7d03419988caab691245b32d986549ef6d643d2768c"
+    },
+    "sound/misc/flies1.wav": {
+     "bytes": 44168,
+     "sha256": "ca5cf0a4d661bf7440cd81dcd45ad7118c54c8ae58672755ee958ec6e50f7152"
+    },
+    "sound/misc/flies2.wav": {
+     "bytes": 44166,
+     "sha256": "09e6d74986b0f0ec9503d9e111f8d1436d7d6c5c4c0c87ec7808e3fca5b964b1"
+    },
+    "sound/misc/flies3.wav": {
+     "bytes": 44182,
+     "sha256": "2b5fb337ba88bd25e10c86bb6355723aea160b0ef6a6d43b30cbbd446444ed8e"
+    },
+    "sound/misc/gibf_fire1.wav": {
+     "bytes": 14376,
+     "sha256": "804f8524135d058d3a635e6567e3369b8b9ef2ecc808bf6e216c4d65609b86a3"
+    },
+    "sound/misc/gibf_fire2.wav": {
+     "bytes": 25842,
+     "sha256": "354b551ac38a19370126f67e3975ab795953bd7beb2c597f0a01a0de6286b7c1"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/laseron.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/misc/poweroff.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/misc/poweron.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/misc/rumbleloop.wav": {
+     "bytes": 106060,
+     "sha256": "fafcaa92b4a2174045e3826885d14e434a409bf559d1a1d519c4d50ec8939789"
+    },
+    "sound/misc/rumbleoff.wav": {
+     "bytes": 105990,
+     "sha256": "46728daf18b142575d50049188030a153c0e3e994dc83ea375c43ba6da171b3c"
+    },
+    "sound/misc/secret3.wav": {
+     "bytes": 302444,
+     "sha256": "75682a08b790af46c2b9f746e5772999ba1de333b567832f4a3a8414c6a0185a"
+    },
+    "sound/misc/spaceship_fadein.wav": {
+     "bytes": 231712,
+     "sha256": "d6c905eb002532087273eadb5a577db443068532795fd509571179a354c56a9f"
+    },
+    "sound/misc/spaceship_fadeout.wav": {
+     "bytes": 495982,
+     "sha256": "9e5286b29adeb9cf7b3af489bb2ea539c8eed7b26a28ec1f34cd5f78c33e521c"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 13270,
+     "sha256": "14d74e6c01df6db6f92b8684527b31a7544de8d4dd9d123ebae554989e76facc"
+    },
+    "sound/misc/torchoff.wav": {
+     "bytes": 54160,
+     "sha256": "d49cf5f2100d9b5afbf76a662019a9e3a66fcd5fb40c2b2600ceab107227cbf3"
+    },
+    "sound/misc/torchon1.wav": {
+     "bytes": 88680,
+     "sha256": "ecb211c777393fe3c7012bf0a35cc157af94ccb4742cac3ca7ab6daa5546a4ac"
+    },
+    "sound/misc/torchon2.wav": {
+     "bytes": 84764,
+     "sha256": "b7d885df1c70b226a77a3cc8842565fa9ebf51561158daec4b12e9629a515986"
+    },
+    "sound/misc/torchon3.wav": {
+     "bytes": 97484,
+     "sha256": "25058a3354df07a90b8660640682f7091fa40da6f8abf178c7de71d547a8b0c1"
+    },
+    "sound/nour/attack1.wav": {
+     "bytes": 50794,
+     "sha256": "7f22a1569d59bcd406efd7828ed605d71bfbc8cea01606eedb78d33037655f77"
+    },
+    "sound/nour/attack2.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/nour/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/nour/death.wav": {
+     "bytes": 39772,
+     "sha256": "2e2d15b95fc35738108d83a2b5aefded93772134d2a8124d1b937b6bfcfd74c5"
+    },
+    "sound/nour/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/nour/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/nour/explode2.wav": {
+     "bytes": 22168,
+     "sha256": "654a50eb01d1c6c64bb8df4b85669448cc08b580ffc44616da854bd3cb339ea1"
+    },
+    "sound/nour/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/nour/idle1.wav": {
+     "bytes": 24332,
+     "sha256": "c77ef8ce85720e3bf0ea97937992b5aa7cc6b63149c951e71b4d3ead14fc21af"
+    },
+    "sound/nour/idle2.wav": {
+     "bytes": 44176,
+     "sha256": "e87bd537a35c005b06ffd28f66adde24d52af338d3956d4fab455d682e78eec9"
+    },
+    "sound/nour/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/nour/pain.wav": {
+     "bytes": 8686,
+     "sha256": "073044c582c2de6f336130aeb9503fa6edf1da4eed216a4b407b2cd18d5f9995"
+    },
+    "sound/nour/projbomb_burn.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/nour/reveal.wav": {
+     "bytes": 39780,
+     "sha256": "6dd892d207fa31eb93c5a033ab44bba4952b3aed892aa409e6a49e2059381cdb"
+    },
+    "sound/nour/sight.wav": {
+     "bytes": 48612,
+     "sha256": "252c0bf76b928f7fe998f82bf148816e88cdc24f812bd8c8d3a591c1c4ec3d7d"
+    },
+    "sound/nour/sight2.wav": {
+     "bytes": 48612,
+     "sha256": "18b8e9450c00d6a9308adffa2046e747b8ed7bb5547f868ed146cca75b260b87"
+    },
+    "sound/ogre/ham_hit.wav": {
+     "bytes": 52014,
+     "sha256": "20f7ec214fdf8a342ac8c3be7d3ed04c7b7b3479f9c74138a8a052ba7674ee46"
+    },
+    "sound/ogre/ham_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/ogre/ham_wave.wav": {
+     "bytes": 132316,
+     "sha256": "d957285dc74a4e067f600465112ed41d69d14554f8e87ad6b0372b9ca8af4b25"
+    },
+    "sound/ogre/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/ogre/ogidle.wav": {
+     "bytes": 25706,
+     "sha256": "54915681452970c56f1ef405b182e90fa7ee3c4d4d80e32583a38abc7c1db713"
+    },
+    "sound/ogre/ogidle2.wav": {
+     "bytes": 22426,
+     "sha256": "2ed241e576a709285f7ea8a9671f6032da5a8db96e094e9007f60617cad491fa"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 28742,
+     "sha256": "738af1bbf36d5b3287c45e7815d87ea7f5c1a0487c804de7272091fdbb7faac2"
+    },
+    "sound/ogre/ogpull.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/ogre/ogrefish_flappy.wav": {
+     "bytes": 51262,
+     "sha256": "79a9eafef5edf45851a1c391e301c6f515536922c297b904e148b337e7f54a08"
+    },
+    "sound/ogre/ogrefish_idle.wav": {
+     "bytes": 27552,
+     "sha256": "5abf50694e67aa1e805a598a464d5d3b1f0625677a2873761cae139c4b21d524"
+    },
+    "sound/ogre/ogrefish_in.wav": {
+     "bytes": 6678,
+     "sha256": "dd5fc9aecb5b6933252739047aa5d3f775797ad7bf6ddb5652ffd26ea9ead3e2"
+    },
+    "sound/ogre/ogrefish_out.wav": {
+     "bytes": 15502,
+     "sha256": "2610f025057ee0a6682b574567b7400f83ba9f6665b9f7f3b9e76cff75b8be53"
+    },
+    "sound/player/h2ojump.wav": {
+     "bytes": 22126,
+     "sha256": "dd2d3629970814e719be6c9650a497edd219f31fb1554927b9770a1b0dfcdc60"
+    },
+    "sound/player/heartbeat.wav": {
+     "bytes": 70640,
+     "sha256": "a68fd895a3212f967a4686e94df2749fa3f58392ab2228aa880697e25b548147"
+    },
+    "sound/player/inh2o.wav": {
+     "bytes": 22126,
+     "sha256": "4c4d55502ab63ddbc9beb64b0459ad4d7a2992fe41e76144d3bbd3333af4a570"
+    },
+    "sound/player/ladmetal1.wav": {
+     "bytes": 95952,
+     "sha256": "6cd990509a965ff251ffb33ff7c22b6eb708cec5f7b7b82e2196b1fb3d3cb1c2"
+    },
+    "sound/player/ladmetal2.wav": {
+     "bytes": 96116,
+     "sha256": "a477162fc355efc88568b9e18d668b7b0e8e99af460b88c755bd1ed57da35006"
+    },
+    "sound/player/ladmetal3.wav": {
+     "bytes": 96008,
+     "sha256": "20ea0c70bcc3c951bb067cb65b938c63267bba0a1eda3a335df525dc9432d234"
+    },
+    "sound/player/ladmetal4.wav": {
+     "bytes": 96126,
+     "sha256": "d2a6bede3a9c499d01a0b0b9620d4bd1935f9477ecb9c59a8d73f3133699ea45"
+    },
+    "sound/player/ladrope1.wav": {
+     "bytes": 70706,
+     "sha256": "6713acc390790d4723df21b0702796958132af34ce5ec0a85fca5edc36ccd728"
+    },
+    "sound/player/ladrope2.wav": {
+     "bytes": 70792,
+     "sha256": "384b8c3ad3749fa9963ff3210d7cb312858771cca85082b6a8ad13179ad92da3"
+    },
+    "sound/player/ladrope3.wav": {
+     "bytes": 70760,
+     "sha256": "ed397a0308ecacd0ba9774f082aec5e681bcffb219c8d9127b7d7606a6fbb02d"
+    },
+    "sound/player/ladrope4.wav": {
+     "bytes": 70758,
+     "sha256": "e1a4327f1c458f408abd6ff713d11e0aee8daaa9c876002b693135d8e64b68fe"
+    },
+    "sound/player/ladwood1.wav": {
+     "bytes": 48084,
+     "sha256": "bd68f3af0f6cd429d08aa44168e14435ed9e2e2ec0d6a038f83e2dd683cb7e74"
+    },
+    "sound/player/ladwood2.wav": {
+     "bytes": 48086,
+     "sha256": "bb687ec2183f460ac4240acfcd2f3da2f8bd9da043ba705f6e32c3439e4845b9"
+    },
+    "sound/player/ladwood3.wav": {
+     "bytes": 48088,
+     "sha256": "7271136b6398602c7b4bdbd610a37b5a82a66195842030a21de08a89808b4026"
+    },
+    "sound/player/ladwood4.wav": {
+     "bytes": 48086,
+     "sha256": "3b7580b31dee8a86e636c5fd17d92566d147417f98764d51097ad53ff0d19d29"
+    },
+    "sound/pushable/brick_m1.wav": {
+     "bytes": 44144,
+     "sha256": "7572ac5d03045552dfee673293722da8c663d072cc7b57e44adb2e3884ea33c9"
+    },
+    "sound/pushable/brick_m2.wav": {
+     "bytes": 44144,
+     "sha256": "209e22e4693184c7b0c022e650b156e255cfa76b18c1066fe20255e285b4e80b"
+    },
+    "sound/pushable/brick_m3.wav": {
+     "bytes": 44144,
+     "sha256": "edafb8bf0915badb97edd078aa129c10a29e8fc428f4e9143f5926f9aa336e43"
+    },
+    "sound/pushable/glass_m1.wav": {
+     "bytes": 48044,
+     "sha256": "66a5944b16e3fe59cf9f8632f92bd85f81b79dc8711337558c45078c91a13c46"
+    },
+    "sound/pushable/glass_m2.wav": {
+     "bytes": 48044,
+     "sha256": "d462bac59390f89facc7c00d8aaee6e71b529ae9f177514a5f2f0533c78d5a0e"
+    },
+    "sound/pushable/glass_m3.wav": {
+     "bytes": 48044,
+     "sha256": "1a2efd7875486d15df811135d589135c807ba0149c877085f165932eb2770320"
+    },
+    "sound/pushable/metal_m1.wav": {
+     "bytes": 44144,
+     "sha256": "91420caf0e2de995681ac09b2be26cc9d0759edc06498571527528419de407d1"
+    },
+    "sound/pushable/metal_m2.wav": {
+     "bytes": 44144,
+     "sha256": "72f018c79b343538fd90de944ed54e8e3351b3da0a6c198f28403d25fc8fb140"
+    },
+    "sound/pushable/metal_m3.wav": {
+     "bytes": 44144,
+     "sha256": "c26b3aff129d573a1175fb618186db3b7ede8976e134c563c1678f48eaf8e302"
+    },
+    "sound/pushable/rock_m1.wav": {
+     "bytes": 48044,
+     "sha256": "9fb6ebeae45b4c47b1e42af1f00441d0e0bb88fbb53f85ea875341f9db55efb4"
+    },
+    "sound/pushable/rock_m2.wav": {
+     "bytes": 48044,
+     "sha256": "b57d0f760bb318b1159293e38811e5607bae8ff244d8bbf56223b355ef7c5b39"
+    },
+    "sound/pushable/rock_m3.wav": {
+     "bytes": 48044,
+     "sha256": "5e6514c241bb11d6194d9762d5369fb2a8da287b3d4c08e67f23da84fdb26b04"
+    },
+    "sound/pushable/wood_m1.wav": {
+     "bytes": 48044,
+     "sha256": "e672209779ee47996ca93e60d30e572da3cced5381db3f34c14a709629a5f4d2"
+    },
+    "sound/pushable/wood_m2.wav": {
+     "bytes": 48044,
+     "sha256": "c76b7db5faf1cbf21c07dacec615436a95f34c0e16e68628b62ec89a89b12f83"
+    },
+    "sound/pushable/wood_m3.wav": {
+     "bytes": 48044,
+     "sha256": "d6751d9e67c49458df6c076d9b6be9619f845213a263cb76330f51700f8a632c"
+    },
+    "sound/scorpion/clawattack1.wav": {
+     "bytes": 13360,
+     "sha256": "b0daf0605690db89f34a19936f1c20ad25676a4e6cd9dfad0e5757cf81dc4f7d"
+    },
+    "sound/scorpion/clawattack2.wav": {
+     "bytes": 13360,
+     "sha256": "06da85e6d6035704932fdc1ef449de529e17853571d017c5a42b253b5ed71a94"
+    },
+    "sound/scorpion/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/scorpion/hiss.wav": {
+     "bytes": 26664,
+     "sha256": "9d9fae97f3996ff3c0616f7acda952166d5eced9227d15a8fbe9d285095e7936"
+    },
+    "sound/scorpion/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/scorpion/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/scorpion/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/scorpion/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/scorpion/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/scorpion/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/scorpion/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/scorpion/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/scorpion/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/scorpion/tailattack1.wav": {
+     "bytes": 25858,
+     "sha256": "61e6c65b4c68813925e594b96ebad8a945c87d51f2cd23f301e80e231e53033d"
+    },
+    "sound/scorpion/tailattack2.wav": {
+     "bytes": 19650,
+     "sha256": "aab86f97eed636ebfb79ae7b92e4b7f7a3436b0146ad75519edd4358716169c7"
+    },
+    "sound/scorpion/tailfire1.wav": {
+     "bytes": 8924,
+     "sha256": "1f41bd184aa58b9f2f1b2f1197f3b7827c55d523d03a354dd1fb6d469cf129c8"
+    },
+    "sound/scorpion/tailfire2.wav": {
+     "bytes": 8948,
+     "sha256": "40a126ab5cba6c291d69606eddb7e2ab63ab640b1347b2e78ab4b0f7aca90c5c"
+    },
+    "sound/scorpion/warning1.wav": {
+     "bytes": 76930,
+     "sha256": "ae19faeebc0d3ec8c9f136bba205e634a29425ec86c3036016e5f2d9cd550817"
+    },
+    "sound/scorpion/warning2.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/seeker/death1.wav": {
+     "bytes": 397272,
+     "sha256": "35d8a1091032f24ed6a65efa99a7618f32bc0def24779efb51752b75a9e31ca1"
+    },
+    "sound/seeker/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/seeker/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/seeker/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/seeker/footstep1.wav": {
+     "bytes": 96092,
+     "sha256": "e5cd4f907a1b70ec72048b2dd5a5062022e7058676c3d90d05b7426e189a5073"
+    },
+    "sound/seeker/footstep2.wav": {
+     "bytes": 96076,
+     "sha256": "f3c8ba8d65257ddfa73e3e54c737c49de5dcc5c17bb088feb3511c3d69d21ac4"
+    },
+    "sound/seeker/footstep3.wav": {
+     "bytes": 96092,
+     "sha256": "c6fa111be092592a253815826c499b9b1f18a0c536910e2a82eebec7fb7f817d"
+    },
+    "sound/seeker/idle1.wav": {
+     "bytes": 141126,
+     "sha256": "10693a1d5fc1d710e54a0d57ce10d71400de192b874d6776ffe176c2b399a6b5"
+    },
+    "sound/seeker/idle2.wav": {
+     "bytes": 97420,
+     "sha256": "c24b439701d9ec3cf055702f23a3eb23623320ae89b9d46ab98a791f08898573"
+    },
+    "sound/seeker/melee1.wav": {
+     "bytes": 106252,
+     "sha256": "addfb5fab225a77f08d5c126b13f929fa31aa1c9094fc79202121ca891933fb9"
+    },
+    "sound/seeker/pain1.wav": {
+     "bytes": 19884,
+     "sha256": "ccaca64b8c1ab87d7d70896333cbec22c3b61c443a36cd8f253ad0eafc2d7ae1"
+    },
+    "sound/seeker/pain2.wav": {
+     "bytes": 19884,
+     "sha256": "8c3be23111a5ef53a7b66c7b74e32404ff0e6989d7de835543e0a65645e3f793"
+    },
+    "sound/seeker/punch1.wav": {
+     "bytes": 19940,
+     "sha256": "e4bf6b7deb14b5d614b4d5b7d4eeee36059372c913cc906589e1048d4484259d"
+    },
+    "sound/seeker/range_laser.wav": {
+     "bytes": 88246,
+     "sha256": "ee9f13af042a2a98fb75fa33873a1e861f3418f598ddb390f15ab44fcf93fcbf"
+    },
+    "sound/seeker/range_plasma.wav": {
+     "bytes": 79782,
+     "sha256": "9b1d38a4e1937023536d5ab5de035c97e1ef69131d58822b194cab2a3aa340b3"
+    },
+    "sound/seeker/range_rocket.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/seeker/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/seeker/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/seeker/sight1.wav": {
+     "bytes": 163526,
+     "sha256": "ca06541f54bcc297ab19ee133de5c782e978cf7afc2fab34b3789c4c56044d30"
+    },
+    "sound/sentinel/laser.wav": {
+     "bytes": 9712,
+     "sha256": "c5f90e1823a04b48f7f24ac5b8792e1b42030a8b07970db5847dc1e74be094c2"
+    },
+    "sound/sentinel/nail.wav": {
+     "bytes": 13750,
+     "sha256": "7acc3ac05b7218abc6fef2d2397771d90fce6fa39415e33824be7e771d30e288"
+    },
+    "sound/sentinel/widle1.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/widle2.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/wpain.wav": {
+     "bytes": 19596,
+     "sha256": "bc7b6536a1c67aa89295eeacea2d9b36cb0bf783b5fb7cc6aaf4fa01a0edb3fd"
+    },
+    "sound/sentinel/wsight.wav": {
+     "bytes": 27322,
+     "sha256": "83bca2103d60c68435e27f0660e3ecd5bffb058e796382e7bdb43efabdfb9889"
+    },
+    "sound/shalrath/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/shalrath/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/attack1.wav": {
+     "bytes": 44184,
+     "sha256": "91f50e3b69909213e23149b6a3e9622c4367d77f871da5f01e6e4aea3badf648"
+    },
+    "sound/shub/attack2.wav": {
+     "bytes": 33174,
+     "sha256": "d4928f711f7e8fc1d8ba050a87b4e1c2d48ffc24af6a454637629dfae8902e3f"
+    },
+    "sound/shub/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/death1.wav": {
+     "bytes": 107440,
+     "sha256": "1551554be1b7896ee39156ce258bf68ac5dace891994788020ee95083ae33e77"
+    },
+    "sound/shub/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/shub/idle1.wav": {
+     "bytes": 75072,
+     "sha256": "9d33c61470d0c4269c8d113b4476b84236fa00e6ee3be061865e242c988093af"
+    },
+    "sound/shub/idle2.wav": {
+     "bytes": 75000,
+     "sha256": "21b063438744def5f79a50709c567cc9f3e3a28c39e58456068a3d4ae362617f"
+    },
+    "sound/shub/idle3.wav": {
+     "bytes": 75096,
+     "sha256": "310c4ff969da63c77e7ebb5b319aca0f17a10802ee942b21174349d5e5a79d72"
+    },
+    "sound/shub/pain1.wav": {
+     "bytes": 83880,
+     "sha256": "1d1536a51822b67106ea72bcb537efbf5f69e4a4592904f6feedee06ef5084df"
+    },
+    "sound/shub/pain2.wav": {
+     "bytes": 83886,
+     "sha256": "71c30d3f41e0f99cffcf5037b482c1da7bf028b477051219f6e605ceef28ae38"
+    },
+    "sound/shub/sight0.wav": {
+     "bytes": 83880,
+     "sha256": "6d4d96fc663db248cf9279c0b028c11b451b133c6e2c38364c13e105f8fa377f"
+    },
+    "sound/shub/sight1.wav": {
+     "bytes": 83880,
+     "sha256": "ecaf1595f3acbfe2e771a193c69bd6de5e6e3bd957405fdf4bcf59a2288bdb05"
+    },
+    "sound/skullwiz/attack.wav": {
+     "bytes": 15484,
+     "sha256": "ca662d909cb3b96bdfb93197092ed8e8a5d1ed27772a91a4a6ae5e9d3063017a"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 33166,
+     "sha256": "5d1ccd5b97bd38eaf46d1e0798009765d46d58ba17e7e6efc36350b0adaa22f7"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 33178,
+     "sha256": "dd77e90760bd85fc872a96c2eaa808b094a461ab2871bd8ab6a5372861560512"
+    },
+    "sound/skullwiz/blinkspk1.wav": {
+     "bytes": 44200,
+     "sha256": "ade109f32810094922f77bc3c03f02d33e98d855d3dcaf79ceab4cb200efaa65"
+    },
+    "sound/skullwiz/blinkspk2.wav": {
+     "bytes": 44204,
+     "sha256": "16d3b1296e1ed9c3bdc06dd25f5d9db3569cf3486794d29858d5ad227741dd1a"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 33166,
+     "sha256": "bc83800a91fad273e7f84f3cec2fa2787c902f4cd97fd5495f73dc9fb6d2c368"
+    },
+    "sound/skullwiz/fadeaway.wav": {
+     "bytes": 43092,
+     "sha256": "dd67d3ffe5a592b4e449d6bb00eee3c525ede786b0a2d9089832981311bfd61e"
+    },
+    "sound/skullwiz/idle1.wav": {
+     "bytes": 88252,
+     "sha256": "1834b946ff68aab07ade01b68d95d822d0b2a1baa51c1ceba7e66c73b8b6211e"
+    },
+    "sound/skullwiz/idle2.wav": {
+     "bytes": 88240,
+     "sha256": "57c49c7fd4f52b870a658e2e854e16c67389e9d79f9a1db5928f12d74741a1da"
+    },
+    "sound/skullwiz/pain1.wav": {
+     "bytes": 11132,
+     "sha256": "125e06cdfacd6aa78a90034d3f94086736734dd1dd9d170fef3a512b42e34cd0"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 15540,
+     "sha256": "ac5a56dbff28fa4724bd8766d8443090e3026007f6f4051cfecd2869b3f5ecb9"
+    },
+    "sound/skullwiz/poison_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/skullwiz/sight.wav": {
+     "bytes": 36484,
+     "sha256": "3051df89bfdce6b80c49c3513cfcbd679bf1f71c5562430d7738737e44f04f26"
+    },
+    "sound/skullwiz/skull1.wav": {
+     "bytes": 22144,
+     "sha256": "3a43bc5e1079740b61199ff21518f75cc1e4db7cdc9e25b57631b38b04d651a2"
+    },
+    "sound/skullwiz/skull2.wav": {
+     "bytes": 22158,
+     "sha256": "fed613207dc7691118ea5b62626df8773bda59816b008bfd2aeaa4d2f26a4b7b"
+    },
+    "sound/skullwiz/summon.wav": {
+     "bytes": 97022,
+     "sha256": "bf74e3dfbb330f481790f7bbc2b88e74b1654f7d5b327235c3d00bee3f62a06a"
+    },
+    "sound/soldier/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/soldier/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/soldier/rocket_load.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/spider/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/spider/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/spider/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/hiss1.wav": {
+     "bytes": 17802,
+     "sha256": "c56fcae8a01af94c07807730857b4b367f2c70c35869505528504faa29a17ade"
+    },
+    "sound/spider/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/spider/hiss3.wav": {
+     "bytes": 22582,
+     "sha256": "1a3c71b1e4ac2389c98c4af9db88e81b51a602c681bd00a1812995654863e2d4"
+    },
+    "sound/spider/idle1.wav": {
+     "bytes": 20922,
+     "sha256": "8a6d25359bbbc1f5e4f6962f4ce1742160537c6bb8bf8b806a0df96adfae819d"
+    },
+    "sound/spider/jumpland.wav": {
+     "bytes": 6038,
+     "sha256": "3c46bc58c52a61480c1a8dc2034aa240545521baf5e0027372992a9458796919"
+    },
+    "sound/spider/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/spider/pain1.wav": {
+     "bytes": 6108,
+     "sha256": "728cd94a64b27dea4d845a9e27e1ba09cfb286bff80128a67d1da0431b6b0c20"
+    },
+    "sound/spider/pain2.wav": {
+     "bytes": 10460,
+     "sha256": "736f0a768c0f52b22a301fc6a15f18f2f60e5579d3b27c2b78bcb7bed8e0c577"
+    },
+    "sound/statue/comidle.wav": {
+     "bytes": 17722,
+     "sha256": "3567914304c8fcf224e31bc302039432cd17833daabc2ed9f83053b01fef4f7c"
+    },
+    "sound/statue/death.wav": {
+     "bytes": 13472,
+     "sha256": "b030aeac3d806bc77fddaed4bb32684cfd2bbd707fe85e2500a3346c5931ec68"
+    },
+    "sound/statue/hurt.wav": {
+     "bytes": 8012,
+     "sha256": "9193f4e976675042409db103f7e3b26f667a56e913e96a37f223f1c606323246"
+    },
+    "sound/statue/idle1.wav": {
+     "bytes": 13304,
+     "sha256": "0b5d3bcbd00e846d38986f8919ff4fa7bcce92e45e5ba5949edd0e81b741b69c"
+    },
+    "sound/statue/idle2.wav": {
+     "bytes": 13316,
+     "sha256": "45469f14a25fd434ba1ed987fd20835ac058496d41df5a6aa543dec454670f36"
+    },
+    "sound/statue/sight.wav": {
+     "bytes": 9584,
+     "sha256": "84ab06d320f9953eebda7c4dd25a0e0de3369957de01c64af10a8b3ca886241e"
+    },
+    "sound/steelclaw/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/steelclaw/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/steelclaw/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/steelclaw/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/steelclaw/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/steelclaw/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/steelclaw/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/steelclaw/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/steelclaw/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/steelclaw/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/steelclaw/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/steelclaw/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/steps/drag1.wav": {
+     "bytes": 13586,
+     "sha256": "db069e08b7de4c5074cc4dd56f3b1cd2b6d77fe7869e1e03f5dddddcf9aad530"
+    },
+    "sound/steps/drag2.wav": {
+     "bytes": 13572,
+     "sha256": "b2ac07fe014e7c5afd4a5974c5d290b34a880a52f33668030a97a345d5811db9"
+    },
+    "sound/steps/drag3.wav": {
+     "bytes": 14690,
+     "sha256": "a29ee6f0977b205d146f81ee5be2f9b2f12ca76f177aaab9e35e556c4f555fa9"
+    },
+    "sound/steps/drag4.wav": {
+     "bytes": 13584,
+     "sha256": "1b5628a4272837ccf9c4044371a1d45eef23439b164be445b6f2ca90952e3487"
+    },
+    "sound/steps/drag5.wav": {
+     "bytes": 13584,
+     "sha256": "6dec9033ece2a02ce65c437e1b7e58512fd04d41a327487704de71cdf39b99dd"
+    },
+    "sound/steps/giant1.wav": {
+     "bytes": 33140,
+     "sha256": "d28f78c1514f215c64b6a3de38b5ffb5b891341ed95dc0277b1b3dba498cc64a"
+    },
+    "sound/steps/giant2.wav": {
+     "bytes": 33138,
+     "sha256": "7936f32a0ae371e216a195c3110b24db372a15091ea5c80e78875951f874d3b0"
+    },
+    "sound/steps/giant3.wav": {
+     "bytes": 33126,
+     "sha256": "58f79749cbdaaa608e6aacc368b74e0ac1e2ecf2ef45967c7f1f7b7a3e99c8fd"
+    },
+    "sound/steps/giant4.wav": {
+     "bytes": 33136,
+     "sha256": "4ffa741a70225aa31078f73a5612cf7d5ad9f9007163f0a5aeda749da099f9bd"
+    },
+    "sound/steps/giant5.wav": {
+     "bytes": 33138,
+     "sha256": "a2706d4dd9856cccdc3980156a77702883e36d86df54221b31a781c8e5e767e3"
+    },
+    "sound/steps/heavy1.wav": {
+     "bytes": 13282,
+     "sha256": "603679f83cc5095d2fa81d945285b2980195ba50ee2615fed85487493f0a536d"
+    },
+    "sound/steps/heavy2.wav": {
+     "bytes": 10870,
+     "sha256": "384f160ad4816b6984ef6b3b59c4bc1e8a2a3e05f9aaa80ee8b30ada2645669f"
+    },
+    "sound/steps/heavy3.wav": {
+     "bytes": 12828,
+     "sha256": "936417bc5ec9d30db8a74a9798328436259ffd704b11e1155d3fa79dc829e462"
+    },
+    "sound/steps/heavy4.wav": {
+     "bytes": 11050,
+     "sha256": "8d4879d40eda9182ff45fb18130c7979997d326581c14edeedc9cab440531e00"
+    },
+    "sound/steps/heavy5.wav": {
+     "bytes": 10198,
+     "sha256": "4e2e9892dee74d3472a45ecda889ae8d2f836786b44a55e5d1436690c7dadd5e"
+    },
+    "sound/steps/large1.wav": {
+     "bytes": 33118,
+     "sha256": "c387d084a10b28329610d8e3ad3e377f43087013e802be42af79f254276d00dd"
+    },
+    "sound/steps/large2.wav": {
+     "bytes": 24960,
+     "sha256": "ab91b4605671dd16da59963959cda3368a065612d8ed1776847da310b1e7b5fd"
+    },
+    "sound/steps/large3.wav": {
+     "bytes": 24280,
+     "sha256": "3e6a5ef0d8cbaba2e976f199d8d1ffa073fe8e83dacee709137335d42ddd7558"
+    },
+    "sound/steps/large4.wav": {
+     "bytes": 22092,
+     "sha256": "f2bde1b715f679cf814c2cd1375442170cf9f6e56d8ea1756900f81f1d1df453"
+    },
+    "sound/steps/large5.wav": {
+     "bytes": 24320,
+     "sha256": "c15b388bbed461461bac2c22b3a88ff272c04ad070e4791b7ce35c1559d16f77"
+    },
+    "sound/steps/light1.wav": {
+     "bytes": 8872,
+     "sha256": "f034fe2692c0fceb6de1c00e15facbcbd31ccd1fcf72510fd1e3cb6bdcc28795"
+    },
+    "sound/steps/light2.wav": {
+     "bytes": 6654,
+     "sha256": "998f665b4a7ccbc995096697606a91d208db024b0882df75ebaaac015f0d4ef6"
+    },
+    "sound/steps/light3.wav": {
+     "bytes": 6670,
+     "sha256": "b25e020a10ac6a7883fd584cff4895d6d785f8577daea15a30d2b745e146c1c6"
+    },
+    "sound/steps/light4.wav": {
+     "bytes": 4472,
+     "sha256": "a111052881024eef6e97393c1388e8ae538227b85c9b8cf0a73704abb2a504b1"
+    },
+    "sound/steps/light5.wav": {
+     "bytes": 3588,
+     "sha256": "55fb54e5ba2f8ec6249761ae6f07c12de6133457b51c584759e8841fb14cb46f"
+    },
+    "sound/steps/medium1.wav": {
+     "bytes": 8872,
+     "sha256": "38e731803a49be7d8018dd7b44060b578b5418f2f7aefb04d1c74c968ced187a"
+    },
+    "sound/steps/medium2.wav": {
+     "bytes": 8852,
+     "sha256": "e8701598e07f43a20aebebd1d1a5043213018199d50472dea37672e6dce4a2b3"
+    },
+    "sound/steps/medium3.wav": {
+     "bytes": 11068,
+     "sha256": "3ed07795c2363552554e6da1da5749be08e460fc6cd4c7266b9fa514732abb2f"
+    },
+    "sound/steps/medium4.wav": {
+     "bytes": 8872,
+     "sha256": "008992cd7972e7e1e6f0b785b40e398a8efe744a3f3f57e47370936796c3d6b5"
+    },
+    "sound/steps/medium5.wav": {
+     "bytes": 8864,
+     "sha256": "ccd26430fd354c0e87750e02d92c40071ef9dccadae5bdeebc7e0d2a2ec4eba7"
+    },
+    "sound/steps/slow1.wav": {
+     "bytes": 8878,
+     "sha256": "15614044d9d277fa3359edb07e7af74b9d7875150fddde5ab1fdceb0143337bb"
+    },
+    "sound/steps/slow2.wav": {
+     "bytes": 8856,
+     "sha256": "a8b16b688d12812a61127a885bf43c360adc2b84ae7806cc107b433c6f4635ee"
+    },
+    "sound/steps/slow3.wav": {
+     "bytes": 8852,
+     "sha256": "3a2a57e1a37d378c1ee73d5732840f6d20e588d794216c33896bf25879807600"
+    },
+    "sound/steps/slow4.wav": {
+     "bytes": 8868,
+     "sha256": "78bdea66991184043001262cc6ef5f1148cf0eb11b5f88fc51ff948311156e5f"
+    },
+    "sound/steps/slow5.wav": {
+     "bytes": 11076,
+     "sha256": "f63c868bd87926f017bec092749bd61c763b0b18635456ed56b660e53bf581af"
+    },
+    "sound/steps/water1.wav": {
+     "bytes": 63814,
+     "sha256": "01ed631b0d92dab11086b1106acc278ffd92522e2e46d21a0650fd29a79780f2"
+    },
+    "sound/steps/water2.wav": {
+     "bytes": 71994,
+     "sha256": "1b53561f02f60da1e1b6c8b72f722ba12e549c318725b974745b38666efa8e56"
+    },
+    "sound/steps/water3.wav": {
+     "bytes": 71802,
+     "sha256": "bbc0778017ccb579a9d531316b8af46585e91a100a251707ac34f4dbddf6922d"
+    },
+    "sound/steps/water4.wav": {
+     "bytes": 61448,
+     "sha256": "d3604afcb7751d987a78a0ee8ee4ca3593315cc6cf2f1909a9f7748535ccea50"
+    },
+    "sound/swampling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/swampling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/swampling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/swampling/idle1.wav": {
+     "bytes": 132044,
+     "sha256": "418eae21e001c1ae065df9357ebf2ad331f761062d75f345f12e99d9aec8cfb5"
+    },
+    "sound/swampling/idle2.wav": {
+     "bytes": 70444,
+     "sha256": "4026b4b56ffa9a207e1457e03ec94a8eb9042cfebf1c042fa291ba2bbbf1c4b5"
+    },
+    "sound/swampling/idle3.wav": {
+     "bytes": 171644,
+     "sha256": "fa54eaf040baf965f994b328bfb1a55cd90d1741d57ed580c1d44c51e9c125f8"
+    },
+    "sound/swampling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/swampling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/swampling/pain3.wav": {
+     "bytes": 67244,
+     "sha256": "4b186834bbec7d2ef9873f55d5df980da3b3fd2f19f76e54fd835d1aaf40fedd"
+    },
+    "sound/swampling/sight2.wav": {
+     "bytes": 88044,
+     "sha256": "6989ba3aca0c5f5e12d30d9958c6ab169f5c6c96f36f4843a9a19bab0e5d0c4c"
+    },
+    "sound/swampling/spit4.wav": {
+     "bytes": 76848,
+     "sha256": "6855555e2a188ed9ae0a1cd307c7715e54c6f3c10ac0fee9edbba2edf1a48d16"
+    },
+    "sound/traps/flame_loop.wav": {
+     "bytes": 28560,
+     "sha256": "661d8325af92fb37235952e2668578dbf57d844b7359627b4a2c25d15127bff7"
+    },
+    "sound/traps/flame_off.wav": {
+     "bytes": 28496,
+     "sha256": "ebc40d62265aad20813acd189511be0bac063ecc00d7ae712863de3dbdb84c94"
+    },
+    "sound/traps/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/traps/laser_hit.wav": {
+     "bytes": 4358,
+     "sha256": "0840d9fa27bfd2bcb86c2f0174810ae3eb9baa6a43867d27de1e074f7cd75e2c"
+    },
+    "sound/traps/pend_hit.wav": {
+     "bytes": 11908,
+     "sha256": "6fec8fd4edb67e8905d9ad0d7dce5ee5a9b4f43b724b75cb449e88b508384e11"
+    },
+    "sound/traps/pend_swing.wav": {
+     "bytes": 22142,
+     "sha256": "d20bbaf323c5aa0ee2aa21222f2a9f5fc956c0317e65c05e9d003bb08d80a9ae"
+    },
+    "sound/traps/saw_end2.wav": {
+     "bytes": 99808,
+     "sha256": "2a129f2d5fe3c9fd60873c336e2eed799b3d2ebc91bc8bf5a0860b45a6b83ceb"
+    },
+    "sound/traps/saw_loop2.wav": {
+     "bytes": 173082,
+     "sha256": "b4ca1bfeaab62c73bfc10f7daa2750738874d721af9e637479e8242f5220294c"
+    },
+    "sound/traps/saw_loop2f.wav": {
+     "bytes": 132748,
+     "sha256": "03a3e77feb8775a7b486363ed1d46d04fb9294f5507040e458ed8a05c37f0de8"
+    },
+    "sound/traps/saw_start2.wav": {
+     "bytes": 217184,
+     "sha256": "49f1dd84a7be0c4d0b1293aa587ab786d69f4cb463ce5a03f09da816eb22d384"
+    },
+    "sound/traps/sawblade_off.wav": {
+     "bytes": 15276,
+     "sha256": "44924313561cf32ea95c50ef80366ba79a2c86ff2f218fc89404c82617ce2c84"
+    },
+    "sound/traps/sawblade_on.wav": {
+     "bytes": 37582,
+     "sha256": "097635d29859ce28ea37da2d51ec346b8d5239435bb6be0bf5f094a555c110e8"
+    },
+    "sound/traps/sawstrike1.wav": {
+     "bytes": 30836,
+     "sha256": "489d8cdea78b2c333771b316741d7960d5c0da6845ea15b94991ece94837367a"
+    },
+    "sound/traps/steam_loop.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/traps/steam_off.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/voreling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/voreling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/voreling/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28354,
+     "sha256": "8c9ef55e309a43b1df1f08b66192b4ab262ba07e9315d3a70f4a9cf9dee9d51a"
+    },
+    "sound/voreling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/voreling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "5035bd555e9a6439c87e6b661a2da86633f7234503d52551e68f61e9504af86d"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 44162,
+     "sha256": "ccca790ed18e3705c083259f48db7d46d26310cf80c16cd2bad191d333fec5ba"
+    },
+    "sound/weapons/axe_ceramic.wav": {
+     "bytes": 24620,
+     "sha256": "53b6e873318f84424129f1486f0a715c9b1f46e9521c97858d3ddbd94ef4dc10"
+    },
+    "sound/weapons/axe_flesh.wav": {
+     "bytes": 7754,
+     "sha256": "8d0046355ea843f56d5260f581c89d2f885b553c97cfc7e01a93f6da487e03de"
+    },
+    "sound/weapons/axe_glass.wav": {
+     "bytes": 13306,
+     "sha256": "7fd4f7f02edf972c17cf64fea9ecfecca2e0a2d69da9828c1a1e2ce726dd9a79"
+    },
+    "sound/weapons/axe_metal.wav": {
+     "bytes": 28844,
+     "sha256": "d77bc0204c9f406f50ddf01241ff3a3cb34bd571f8a038a483fe49fba81fb160"
+    },
+    "sound/weapons/axe_swoosh1.wav": {
+     "bytes": 26524,
+     "sha256": "1ee4079e691b1e3e8eca8e6fe3098ee053f99b2a0028e725442771c84dc07e49"
+    },
+    "sound/weapons/axe_swoosh2.wav": {
+     "bytes": 13284,
+     "sha256": "a28435309759dd35576099d23a36dc378d9703db9f0778fba63efa3558cfc19d"
+    },
+    "sound/weapons/axe_wood.wav": {
+     "bytes": 7776,
+     "sha256": "ce5bd1465d66aa4aad5249c387f7f537b45b4f8a0e4bf76f37f8efc2a22bd9d9"
+    },
+    "sound/weapons/bolt_hit1.wav": {
+     "bytes": 12698,
+     "sha256": "07d2b6078f7936781a641f88e6ed02ab84f248da8f19e73713c1a71ac56cf42c"
+    },
+    "sound/weapons/bolt_hit2.wav": {
+     "bytes": 10658,
+     "sha256": "27ef878b7dfc0878140a19e3a0227ba389e5d0dc2b86df386852e2da2ebc5c93"
+    },
+    "sound/weapons/bolt_hit3.wav": {
+     "bytes": 11600,
+     "sha256": "06298d7bc8d7bce64f9473ae9530e0b42ea3de0ca5895f3476f9b00b5ed566f9"
+    },
+    "sound/weapons/bolt_hit4.wav": {
+     "bytes": 15460,
+     "sha256": "814b1a71efc9b58c90ad7f116c47e6f3dceeb8eae6d0ecbca5f1cd02dd247cb6"
+    },
+    "sound/weapons/crossbow_fire.wav": {
+     "bytes": 26536,
+     "sha256": "2a6ba54090412a53471c59b3edf6e8559d424dab25729e67a78f9ada5e13e8ac"
+    },
+    "sound/weapons/crossbow_hit1.wav": {
+     "bytes": 60782,
+     "sha256": "be1e78c92c13749e988d26912fba6c23f3700df0d7cc48d724f0da1f2608d006"
+    },
+    "sound/weapons/crossbow_hit2.wav": {
+     "bytes": 32472,
+     "sha256": "30a4ef9f23b2239371d32385e55487b279ca4f8f91366d4251cf4d9abdce200a"
+    },
+    "sound/weapons/crossbow_rdy.wav": {
+     "bytes": 37532,
+     "sha256": "321eac310a291cd9cdcbd2dcafb27687a12057e778e12704d8b4388d4eb6e4df"
+    },
+    "sound/weapons/crossbow_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/weapons/ghook_fire.wav": {
+     "bytes": 11526,
+     "sha256": "6e29f4524c0be70d8bf3b1201e737712b271c9bc963ad46c1815972b6addc22e"
+    },
+    "sound/weapons/gl_loadlong.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/weapons/gl_loadshort.wav": {
+     "bytes": 7758,
+     "sha256": "c97236bbfd211dfcad8130974413a8666cdbcf646d364abd8801b3d6ba5bf9c4"
+    },
+    "sound/weapons/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/weapons/laser_hit.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/weapons/laser_richotet.wav": {
+     "bytes": 12888,
+     "sha256": "bcc0498060e71b059d1d6ec45628048b0f29a7a0509b736a519196338b5df20d"
+    },
+    "sound/weapons/nofire.wav": {
+     "bytes": 1400,
+     "sha256": "217c42718548de32b5df972d117ffc1a0e1dde5f03a7a173bd91d0b4551248c9"
+    },
+    "sound/weapons/plasma_expl.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/plasma_fire.wav": {
+     "bytes": 88288,
+     "sha256": "6a0ad4930da39ff590c79f9d26b434bb1001536d33d880735df76e9354f90e94"
+    },
+    "sound/weapons/plasma_hit.wav": {
+     "bytes": 54406,
+     "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b"
+    },
+    "sound/weapons/plasma_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/weapons/r_exp3b.wav": {
+     "bytes": 34830,
+     "sha256": "a1abb7cedfa6576205f043c2e5f562606b039f65f6f996f5ffbb758d7855f2a2"
+    },
+    "sound/weapons/resist_rocket.wav": {
+     "bytes": 19938,
+     "sha256": "1e5170aaf1d6f144e7ea77c251d15ee85c9a70eb1f50b12e4ba5a93971ad1955"
+    },
+    "sound/weapons/ric1.wav": {
+     "bytes": 5650,
+     "sha256": "49223498fbf29b97f712537e6417917befc4e4f5c725bbf2e3d463580c15454d"
+    },
+    "sound/weapons/ric2.wav": {
+     "bytes": 11146,
+     "sha256": "5fa462f4ab3184cf70bf33f923a2b7e4392db517d34f8531a381864d78c352a6"
+    },
+    "sound/weapons/ric3.wav": {
+     "bytes": 11138,
+     "sha256": "1761926b96108fd0b0ee55270ee711fbd2f394f1b5e93da4af96e42c69fa3946"
+    },
+    "sound/weapons/riotgun.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "sound/weapons/sg1.wav": {
+     "bytes": 28718,
+     "sha256": "49074c95da2a619d82dee9d45e28dc910f9a8e16141270a76c81b396a41a6a3e"
+    },
+    "sound/weapons/sg2.wav": {
+     "bytes": 28718,
+     "sha256": "279b1bb969837073c46c176fe62782e60658a6614a8e094b9722cbabdca81fe6"
+    },
+    "sound/weapons/sgun1.wav": {
+     "bytes": 45840,
+     "sha256": "3ac6c4b3ded00fa48810f09afc95b4a8375dc3e8d52e04cd9cba18dfeee20087"
+    },
+    "sound/weapons/shellc.wav": {
+     "bytes": 21006,
+     "sha256": "45a2f8bd652307b9ebd37115c27166d03a4d7055f3054a215036fbc342e22f6d"
+    },
+    "sound/weapons/ssg1.wav": {
+     "bytes": 17244,
+     "sha256": "3e5b9cc1cd0cb86602391e4ddedbc98bb020e44b937eec4d3c5b053ff98c98f2"
+    },
+    "sound/weapons/ssg2.wav": {
+     "bytes": 75024,
+     "sha256": "248a021818f578ec3d96b9fe59d8f839242f4d5f8140a66a500b523b137d1977"
+    },
+    "sound/weapons/sword1a.wav": {
+     "bytes": 11184,
+     "sha256": "22bc8b25a67f1ab0752f9fbc68c2eb0958d2807c9e95bc8ee35d1d1bc9c6552d"
+    },
+    "sound/weapons/sword1b.wav": {
+     "bytes": 13272,
+     "sha256": "dca39f0c4776994c1bbe5255893d50dd86a634a370ea6046fd4e851117dec726"
+    },
+    "sound/weapons/sword2a.wav": {
+     "bytes": 11150,
+     "sha256": "aa381f8c68f5753cecbd889bc184a784c934c78c8fefe3b1ba4026a99112da51"
+    },
+    "sound/weapons/sword2b.wav": {
+     "bytes": 13232,
+     "sha256": "9460973ef948f8712be967d412774d32aeefb8e68b11959c28909eb16d9e8afc"
+    },
+    "sound/weapons/widow1a.wav": {
+     "bytes": 64644,
+     "sha256": "b4ccd6b235784f7ff53ccf0d726ecbbc789d2ddcca057b40df769b7925e3b32d"
+    },
+    "sound/weapons/widow1b.wav": {
+     "bytes": 66186,
+     "sha256": "0da0346e80cdcb405ffb8f9dbe048197cd9d303130f35b2546b4f7652bd06ca6"
+    },
+    "sound/weapons/widow1c.wav": {
+     "bytes": 66186,
+     "sha256": "eb054b4b1b2784bb098e24574ced6b8c2114e3344fc73e9beb23285adfa086a8"
+    },
+    "sound/wraith/attack1.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/wraith/attack1_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/wraith/attack2.wav": {
+     "bytes": 88200,
+     "sha256": "bdf849b4e138fa587df136a327c71ceed1176cbbb4ecb873434766d53da35a3b"
+    },
+    "sound/wraith/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/wraith/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/wraith/death1.wav": {
+     "bytes": 19960,
+     "sha256": "c0e5e05b46e4cf4afebfe5d0ef1801fc16fe8308a7f859ff347a77871b0a9339"
+    },
+    "sound/wraith/idle1.wav": {
+     "bytes": 51556,
+     "sha256": "e91f12463417df25badbbdfe817560362370d9e1e31712766bccb086e06d966f"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 82792,
+     "sha256": "b843d1124acc61be2aae27a7c8a9aca8f6bd471689703b41d59f1450e70e360c"
+    },
+    "sound/wraith/idle3.wav": {
+     "bytes": 55228,
+     "sha256": "3393943b38a0760c2b048c87c6b11ef743b0c968397ae7e434434b8b21fe12f9"
+    },
+    "sound/wraith/pain1.wav": {
+     "bytes": 18184,
+     "sha256": "a448cf5aed2909700e4da1f3ea3158b55e288198eee771eddacf211f4b274dbe"
+    },
+    "sound/wraith/sight1.wav": {
+     "bytes": 34390,
+     "sha256": "91494295e94c54c8da0307df8a51ea10d166fb18a78ede909a710f72ffe81c4f"
+    },
+    "sound/xmas/elf/attack1.wav": {
+     "bytes": 176492,
+     "sha256": "80e3faa699aec6d20015c1070087964de5ba39f83a978388b9fadc184f9fb6c2"
+    },
+    "sound/xmas/elf/attack2.wav": {
+     "bytes": 88292,
+     "sha256": "a364c82cb932bddb438c957e88a7ea67142777dfffd0f553d00e2b04b3af0f9f"
+    },
+    "sound/xmas/elf/cane_hit1.wav": {
+     "bytes": 4536,
+     "sha256": "2686bea9533633cb6c1a5e3e5bcf0016e3fe228cd278b7b1d11a02868cdd5095"
+    },
+    "sound/xmas/elf/cane_hit2.wav": {
+     "bytes": 5638,
+     "sha256": "6e470e241f37fb38ea55adf4bd0d6f1f5a2d5adfee5d5ddac8cb9adc824cb954"
+    },
+    "sound/xmas/elf/cane_swipe1.wav": {
+     "bytes": 1670,
+     "sha256": "2dbf81b3813376cb8bea2fa916dc0d03f1fbaaa499d4fcdf845de8929f82dc47"
+    },
+    "sound/xmas/elf/cane_swipe2.wav": {
+     "bytes": 1890,
+     "sha256": "404864c7d5008b79daed226566a2e4e78f2de92de06c64da67b8bf6224ae3e88"
+    },
+    "sound/xmas/elf/death1.wav": {
+     "bytes": 14284,
+     "sha256": "d1a7063d4ed39cdb59864a2a6fe6109f844caa9ada54ed4456de0bcd056f0034"
+    },
+    "sound/xmas/elf/death2.wav": {
+     "bytes": 10888,
+     "sha256": "4e0344a1bd3fa3d3c4d9e9647203cac0c449d5a5d8e7b1c8319f8402a4b7571c"
+    },
+    "sound/xmas/elf/idle.wav": {
+     "bytes": 57016,
+     "sha256": "a824467247797aa1ecc58f1716b18d390629804eebc413f01067646c64cde87e"
+    },
+    "sound/xmas/elf/jump1.wav": {
+     "bytes": 17766,
+     "sha256": "8023110b27a70758166f710e52188b8d03b8bfd81d9c985eb7f7d326acdb05a2"
+    },
+    "sound/xmas/elf/jump2.wav": {
+     "bytes": 8946,
+     "sha256": "a60763886b743d06ffd0c90e70de304ec8002a500947a684646c227d0bbb3c4d"
+    },
+    "sound/xmas/elf/magic.wav": {
+     "bytes": 15560,
+     "sha256": "6a270540819dddf140b0387d92c914b4f4b1c88c5f37a05c8fa0efd95901f2ab"
+    },
+    "sound/xmas/elf/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/xmas/elf/pain.wav": {
+     "bytes": 11126,
+     "sha256": "4e27a8f38e07e9b69db186d5c609740814ab86c5fda57058b1e05c56b85c6fd4"
+    },
+    "sound/xmas/elf/sight1.wav": {
+     "bytes": 21048,
+     "sha256": "c57eb4fec86922cb8a0499d7dae72eba66b067b89f14ff079ce0caf3dc23a23b"
+    },
+    "sound/xmas/elf/sight2.wav": {
+     "bytes": 30996,
+     "sha256": "8cd5eed3b8e098dfd70cbf90081b38e198bf64d8edf1b76bcc98c42e177635f8"
+    },
+    "sound/xmas/elf/sight3.wav": {
+     "bytes": 10050,
+     "sha256": "e88ae556a28352c319bf5500b29008384a5c53c47480defa81795d8891f14ff8"
+    },
+    "sound/xmas/elf/sight4.wav": {
+     "bytes": 6742,
+     "sha256": "7c6120d242cbbbfd2e0cc77b1428e206accd1ab8073885d52177b0fd4c75c7ed"
+    },
+    "sound/xmas/raindeer/attack1.wav": {
+     "bytes": 5582,
+     "sha256": "bcf78087eab53e8ed0bdde2f29088a89b321a79c3b104da380dd85bd5bdb6ec1"
+    },
+    "sound/xmas/raindeer/attack2.wav": {
+     "bytes": 6274,
+     "sha256": "2ba043cce4a2f22e7743812c0fa40e9f0888d5089362264c768352c347af5089"
+    },
+    "sound/xmas/raindeer/death.wav": {
+     "bytes": 9672,
+     "sha256": "68266e96ec1be80a55f48b76c2bedd6503273245153d96269947c7fc12ae96b3"
+    },
+    "sound/xmas/raindeer/hit.wav": {
+     "bytes": 5218,
+     "sha256": "72127151c2b05cc22a812fe9e38909c8bdcaae6a369e8756d2be67d392b91223"
+    },
+    "sound/xmas/raindeer/idle.wav": {
+     "bytes": 7890,
+     "sha256": "d3ef885d0b6163a3046dc9d514b07886c33809fbb6332e7db0514c648787a9bb"
+    },
+    "sound/xmas/raindeer/sight.wav": {
+     "bytes": 23796,
+     "sha256": "aafabb6fc46c1c72c34af1baea1c59a8ec04803c26faa4310072096481f31a4f"
+    },
+    "sound/xmas/santa/death.wav": {
+     "bytes": 99352,
+     "sha256": "b63273a2574f7def133aa438926a6def025aa64d8c3c636fc6a5594268e391d7"
+    },
+    "sound/xmas/santa/death2.wav": {
+     "bytes": 99352,
+     "sha256": "24fcf23117ec31347f640aa27e6feb4a46a634aa5e1eb48344b1feb7c377f6f1"
+    },
+    "sound/xmas/santa/fire.wav": {
+     "bytes": 22176,
+     "sha256": "3a9bb42661b75287a698b6e16033158f20c59c481d37c0f176dc213205d22dcd"
+    },
+    "sound/xmas/santa/good_hohoho.wav": {
+     "bytes": 55250,
+     "sha256": "51f4d5d656032de08b95689fa55a2e7aa26ec99cf4312b0f6153d0fd57fc1fa3"
+    },
+    "sound/xmas/santa/good_saved.wav": {
+     "bytes": 77302,
+     "sha256": "51e62df5942e2a72fd48311c61ee73b6f51dc4aa3c0cc85af000cdc8d7627d21"
+    },
+    "sound/xmas/santa/hohoho.wav": {
+     "bytes": 50840,
+     "sha256": "091a28236362cab1ce3b7bd55de25010d105db3bf644825c47b91725d8a613a0"
+    },
+    "sound/xmas/santa/laugh1.wav": {
+     "bytes": 57374,
+     "sha256": "ac069694d6c41e5e0afab50d9928b8768a19fb647bb249201648874d4150c976"
+    },
+    "sound/xmas/santa/laugh2.wav": {
+     "bytes": 117440,
+     "sha256": "c726d7d86d2d7cad0a75a2d0b387f4f96218ef232b6c78437e1c83bb96286441"
+    },
+    "sound/xmas/santa/laugh3.wav": {
+     "bytes": 40256,
+     "sha256": "4dd710eee601ab81c4beb5413d95244dee58b886b8265ab9cec35df06b560591"
+    },
+    "sound/xmas/santa/laugh3_com.wav": {
+     "bytes": 44226,
+     "sha256": "4099895e037cfecb4dc3595b3b18db62ed2f3cf096384f3aa1fe1d96a7b43da2"
+    },
+    "sound/xmas/santa/pain1.wav": {
+     "bytes": 6825,
+     "sha256": "79eed9346e0954fd53a6fdb9aa9708b8c29e8c5c256e9fd7c06f449e9cb6c00d"
+    },
+    "sound/xmas/santa/pain2.wav": {
+     "bytes": 9259,
+     "sha256": "f750328d74f545a658b0b190399595687c3d9b8766b2652ad6c2a34add3cc420"
+    },
+    "sound/xmas/santa/sack_hit.wav": {
+     "bytes": 13356,
+     "sha256": "c23a04ed5134f76d1f44d2e61eeb446a569c2bcbccf79f16f472807aae3df53a"
+    },
+    "sound/xmas/santa/sack_swing.wav": {
+     "bytes": 8940,
+     "sha256": "96972ba473b6a7d28645cdc621eb3011729a53eb4acb40d1f097768291a70850"
+    },
+    "sound/xmas/santa/sight.wav": {
+     "bytes": 100144,
+     "sha256": "e29696370a0d40546a49ef0f39b1e0038d8e067ef2da1dcc5084d7683a25d5d7"
+    },
+    "sound/xmas/santa/smack.wav": {
+     "bytes": 22176,
+     "sha256": "606c0a4b634d82a1d9846f654db8a52e7f2438ba28a235f782a23ff2720c767c"
+    },
+    "sound/xmas/snowman/claw.wav": {
+     "bytes": 8292,
+     "sha256": "7857f3526fb39e722a09ebe569f2b76facab765d82f97c0caa7da2ff9b750e9e"
+    },
+    "sound/xmas/snowman/death1.wav": {
+     "bytes": 11267,
+     "sha256": "0a09776ed8e45bbfe403f1cdb50302361f5596d9027c476409d6acf5402e763e"
+    },
+    "sound/xmas/snowman/death2.wav": {
+     "bytes": 13613,
+     "sha256": "e5e3a9619a153f0c6259abdb0d45f4eb4a547f736e37951556d29c6b715ec8f6"
+    },
+    "sound/xmas/snowman/icehit.wav": {
+     "bytes": 3090,
+     "sha256": "e03f61550bafc53ab47acdc23bcd481c35e75e6eccdad5e61e6dd7b372ba07c0"
+    },
+    "sound/xmas/snowman/icemiss.wav": {
+     "bytes": 3074,
+     "sha256": "f8b86f83d9adaaee1c84e1ac2acbcf652204842f2bf6f351ec1443a998574058"
+    },
+    "sound/xmas/snowman/idle.wav": {
+     "bytes": 58582,
+     "sha256": "a0d7af1cd6246f08176f24c5591cfb6ec89cff55dc5c18766ef1b16c64429541"
+    },
+    "sound/xmas/snowman/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/xmas/snowman/pain1.wav": {
+     "bytes": 7685,
+     "sha256": "7f829300a30cb6cb4d17f8c8327bd62ae5b5dacc892d28a956d6ecd2acf5f1c2"
+    },
+    "sound/xmas/snowman/pain2.wav": {
+     "bytes": 7661,
+     "sha256": "3747d77583aa4edb3509e89ea651ea41a8e8a92cd96c34d4e00257e7371fb0e6"
+    },
+    "sound/xmas/snowman/shotg_fire.wav": {
+     "bytes": 6572,
+     "sha256": "3d54870c0f643b1e7ee5307641bb3fc4a94efdaffc2e4ecd196556b930167ef2"
+    },
+    "sound/xmas/snowman/sight1.wav": {
+     "bytes": 10042,
+     "sha256": "ce1cddbb6e85fad23231ac1fc4c04c19ec7276acb2aa86e023c117db4b8edd68"
+    },
+    "sound/xmas/snowman/sight2.wav": {
+     "bytes": 15418,
+     "sha256": "5d4e994c30a7c3f2e1f1a5cde9a56115bcb32c350e4a0ad8e339a1a46ed19707"
+    },
+    "sound/zombie/boil_explode.wav": {
+     "bytes": 38012,
+     "sha256": "210dac94ab0e4efb5eb3bdbfa5d7100094b1bfef917a8d5abb2ae186252c0a27"
+    },
+    "sound/zombie/boil_idle1.wav": {
+     "bytes": 33204,
+     "sha256": "e2b717040d436ba2a659ceb1e5b74dfeaad57577297a9827957733e00ce7cb34"
+    },
+    "sound/zombie/boil_idle2.wav": {
+     "bytes": 33206,
+     "sha256": "8bd584597f2c54e6f8ecca5c0a83e44b0b5a09a745026e41cc2cad8ded6f729a"
+    },
+    "sound/zombie/boil_sight.wav": {
+     "bytes": 33192,
+     "sha256": "0e285e98dc66cd49af507dae9ab5281aaec55eaf9d401810a8d230d93539123a"
+    },
+    "sound/zombie/boil_squirt.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/zombie/boil_windup.wav": {
+     "bytes": 22094,
+     "sha256": "3790791943ea03add95bc303df34470c534f9c2c76e4343831609eaee761633d"
+    },
+    "sound/zombie/zk_sight.wav": {
+     "bytes": 26916,
+     "sha256": "8fe4d5fea16bd7c3661a968d26782ea8c4741157e16e22f33317619229b10637"
+    },
+    "textures/#bmk_water01a.tga": {
+     "bytes": 12332,
+     "sha256": "904f50c3a1de65dd5045f128d03ed8cdc86fcbc15cce295d94304b389ca5ed7c"
+    },
+    "textures/#bmk_water01b.tga": {
+     "bytes": 12332,
+     "sha256": "904f50c3a1de65dd5045f128d03ed8cdc86fcbc15cce295d94304b389ca5ed7c"
+    },
+    "textures/#bmk_water02a.tga": {
+     "bytes": 12332,
+     "sha256": "1123b4f4df8d75a1d8fc2a00d4d19fb279035771f7440b1506d0a95648123766"
+    },
+    "textures/+0bmk_fgopen02.tga": {
+     "bytes": 3145772,
+     "sha256": "1c7e70671a9a98473b3fb3926e1672d5a1712a011caba937097d5bc8c96099de"
+    },
+    "textures/+0bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "f2f139ae3d91bf3aa7c89181b87c1c645acb7be673eca5d56d804889e24f1e50"
+    },
+    "textures/+0bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "f2f139ae3d91bf3aa7c89181b87c1c645acb7be673eca5d56d804889e24f1e50"
+    },
+    "textures/+1bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "6941909c4574fb66f59f7a797f3dd0c696651e117c583f102d255e6bef4fe0ef"
+    },
+    "textures/+1bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "6941909c4574fb66f59f7a797f3dd0c696651e117c583f102d255e6bef4fe0ef"
+    },
+    "textures/+2bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "b78fb050de863bd84616c224de600521738a84ce172346bb783ba3a8708449da"
+    },
+    "textures/+2bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "b78fb050de863bd84616c224de600521738a84ce172346bb783ba3a8708449da"
+    },
+    "textures/+3bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "bf6815a6df5fe67c40ec3e46362a04c5ba15dc8a76de975a3d90a0caeec5e88c"
+    },
+    "textures/+3bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "bf6815a6df5fe67c40ec3e46362a04c5ba15dc8a76de975a3d90a0caeec5e88c"
+    },
+    "textures/+4bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "031bd453f18757388aa700fbae39e6c446959b8e38bee9fbbb53d8639f29deea"
+    },
+    "textures/+4bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "031bd453f18757388aa700fbae39e6c446959b8e38bee9fbbb53d8639f29deea"
+    },
+    "textures/+5bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "873c6b31fcaab54e309e663d23748cc5595b80e1432559761fd92a03f0d41d32"
+    },
+    "textures/+5bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "873c6b31fcaab54e309e663d23748cc5595b80e1432559761fd92a03f0d41d32"
+    },
+    "textures/+6bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "33492aebd47cc69737a2cd8460423103a76ff59b1d6bd39b750f19d6c72efc6d"
+    },
+    "textures/+6bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "33492aebd47cc69737a2cd8460423103a76ff59b1d6bd39b750f19d6c72efc6d"
+    },
+    "textures/+7bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "60741f2766db4f0eb6d622b132d2fc60d9e453d9f847661d3eca641fbf2b64f1"
+    },
+    "textures/+7bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "60741f2766db4f0eb6d622b132d2fc60d9e453d9f847661d3eca641fbf2b64f1"
+    },
+    "textures/window_blue1_2.tga": {
+     "bytes": 786476,
+     "sha256": "583f28b004c5de047037798524681ed2e7914bf1f54ac3d774c8da2880c80282"
+    },
+    "textures/{cop1_7.tga": {
+     "bytes": 16402,
+     "sha256": "464c149a2b2c9f624e7b1f8c2388117022425f058a946f0232c51def845b8bb5"
+    },
+    "textures/{cweb1.tga": {
+     "bytes": 262162,
+     "sha256": "bb0aa80709a1705199ed83bd0cad683a928cb29064eb32263fcb8bdb3999c2f5"
+    },
+    "textures/{cweb2.tga": {
+     "bytes": 262162,
+     "sha256": "64be3598db71729d4a4376c5f4e02bf0e586fc5ceca09196d71befde3265424e"
+    },
+    "textures/{cweb3.tga": {
+     "bytes": 131090,
+     "sha256": "d7b67dfdb1c80946f0de21128ddc3cda61906619ab8ed185611ef2a2a8f936b5"
+    },
+    "textures/{cweb5.tga": {
+     "bytes": 131090,
+     "sha256": "9cf5dd24994b1dc2f8f07ac5f76410fea9bdb7cb925962e1977e6aeb6ce23b02"
+    },
+    "textures/{dutcweb1.tga": {
+     "bytes": 131090,
+     "sha256": "8922bb11d99fc05d2ffeab2c2d99b04dba9d0fc5165fdd9a0ccd921f066f668c"
+    },
+    "textures/{dutcweb2.tga": {
+     "bytes": 131090,
+     "sha256": "a0377ffeac458bf27bbd86d2bc22ff17d973bd0328a4d048fb3136573c12723d"
+    },
+    "textures/{dutcweb3.tga": {
+     "bytes": 131090,
+     "sha256": "61710c94a64a506b75f36578904dbece6f666bc25ad2665333fe00b1c4b04f70"
+    },
+    "textures/{dutcweb5.tga": {
+     "bytes": 131090,
+     "sha256": "a0959d05f9bd1f4aa632b1642885261a2cbbef7d6d6d7ab677bb803ac1a00ef8"
+    },
+    "textures/{dweb1b.tga": {
+     "bytes": 65554,
+     "sha256": "7f2f310b5393519fbfdf70e07cab318504ad88c67dcce1e9988e376d5fc9c94a"
+    },
+    "textures/{dweb2b.tga": {
+     "bytes": 65554,
+     "sha256": "d95f6ebbcc21b2cb7164743b517aa69287101aa2640d5a8b249c409dcdc20333"
+    },
+    "textures/{dweb3b.tga": {
+     "bytes": 65554,
+     "sha256": "24cde40cf3791f0e054ccd2ad81353ec711bd95a7de1af58a1ad561d9d104ef1"
+    },
+    "textures/{dweb5b.tga": {
+     "bytes": 65554,
+     "sha256": "5b1fc4683289a850f5c16afa56660b710212bf18d4c047bf134529dac784d2c9"
+    },
+    "textures/{gen_gr8.tga": {
+     "bytes": 65554,
+     "sha256": "8dacb17cbbb6bb2f4dd95856dd46905a9c335f0a98dc3e8e700fac0a9c529163"
+    },
+    "textures/{kjwintex_ad.tga": {
+     "bytes": 262162,
+     "sha256": "3a2583e19c17e05877e489972b85593d9fca1e57ffd4fa02f1475e6fb3d59c34"
+    },
+    "textures/{ladder5th.tga": {
+     "bytes": 49170,
+     "sha256": "ed742e4b7072c1b11b1b801393bbfc641f96920ecabc5600c213b354313f89f0"
+    },
+    "textures/{lweb1.tga": {
+     "bytes": 262162,
+     "sha256": "e4edd91fdd0031064bd6157574ae5f81b44611424f7357daf8fd4e426c960399"
+    },
+    "textures/{lweb2.tga": {
+     "bytes": 262162,
+     "sha256": "4d2f26192388bf65091b0d5afb934bede4f07e89d002bbdbaeeba29d459fd5d7"
+    },
+    "textures/{rtex158_.tga": {
+     "bytes": 21522,
+     "sha256": "cd10217f3e5cd47b32bde516d4b36cf7995913e306f7415d25dcd7da6ccb4673"
+    },
+    "textures/{speedbz_grid1.tga": {
+     "bytes": 16402,
+     "sha256": "109e52491dda6d4968c99004296ccd503db6d6af9aad9aa6f21cca02fd2b299f"
+    },
+    "textures/{swvine.tga": {
+     "bytes": 65554,
+     "sha256": "c23639e3bd8aacd226695c913384e9c67d509b28fb9597d56f120cfea56a4006"
+    },
+    "textures/{utcweb1.tga": {
+     "bytes": 131090,
+     "sha256": "edae90ba1151fb6adc65def85d4dd7be01c3d2a18bd93ef0f26ff44d07f6c4b0"
+    },
+    "textures/{utcweb2.tga": {
+     "bytes": 131090,
+     "sha256": "829cfe898d9aa4c3ddd12a51f9ccc16a66b2ca5671d9bfd2339f402d49db3267"
+    },
+    "textures/{utcweb3.tga": {
+     "bytes": 262162,
+     "sha256": "026680576034c959e840aa4b39917497c38df12c1331a0c7a1486912e26a91f7"
+    },
+    "textures/{vinehang1.tga": {
+     "bytes": 65554,
+     "sha256": "c23639e3bd8aacd226695c913384e9c67d509b28fb9597d56f120cfea56a4006"
+    },
+    "textures/{vinehang2b.tga": {
+     "bytes": 262162,
+     "sha256": "4268dc2a183582d00c363a9fcd1965c026632150383d40b520fbd54f8751eaa7"
+    },
+    "textures/{vines3.tga": {
+     "bytes": 25618,
+     "sha256": "550b6ca0c768db472fbc970836516506034b30f0a5ca4b4b11df34d7dce8dc82"
+    },
+    "textures/{vinogrande2.tga": {
+     "bytes": 262162,
+     "sha256": "7c2d4aad4d34457ab1674bc1eaaa4ea38e4c4af384877af631cde258167fbb72"
+    },
+    "textures/{web1b.tga": {
+     "bytes": 65554,
+     "sha256": "41bb1244128013ff09f1965339ef505a7b0757bea91fcc0f77ed97cd38c8a145"
+    },
+    "textures/{web2b.tga": {
+     "bytes": 65554,
+     "sha256": "e2fbcb154962a9189614aecc7f6833e60d24709583a970d6cca0adf948df2331"
+    },
+    "textures/{web3b.tga": {
+     "bytes": 65554,
+     "sha256": "e4cfcd4c4e94ed647ef9af822d0df5ee573bd20d9f3bcf45ef8701a3102ae3ef"
+    },
+    "textures/{web5b.tga": {
+     "bytes": 65554,
+     "sha256": "dfdad98b5b62765b24abccd2ff77e85ec1c002060d6634d2593ac0fe10a4c718"
+    },
+    "textures/{win01_1brk1.tga": {
+     "bytes": 49170,
+     "sha256": "dae89ad198e0f4b1a63e37d9145084e947f7e88cb1c2e5d9ef32f25f3e0fb484"
+    },
+    "textures/{win01_1brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "88d9f8700eb9d14f9cfa6ac2e3df1bb25eae9a46553b6e46da7b225316862cb9"
+    },
+    "textures/{win01_1brk2.tga": {
+     "bytes": 49170,
+     "sha256": "2416e34e1ebdefa0cd01ea595b68ae86d2a35a4329b8853a489b1058dea44a90"
+    },
+    "textures/{win01_1brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "921ecb3434e9bd56d97ad57d10c67ace5a0f4bce79bf1b4c8c68aad4cf6ed10f"
+    },
+    "textures/{win01_1brk3.tga": {
+     "bytes": 49170,
+     "sha256": "59a6b2dc874758693574f15affea0be9c2e92e32328f81db78e5d72f488be7cb"
+    },
+    "textures/{win01_1brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "a3dcd6d471d8c65781a69c73a9fa449da02bc01a58a0a97c7313d30587611516"
+    },
+    "textures/{win01_2brk1.tga": {
+     "bytes": 49170,
+     "sha256": "589cf84c790b3165fa60e4441223da48c3df4275099fcc27bc5a8b9502579c15"
+    },
+    "textures/{win01_2brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "a0a80d249ff32c2e0a480801b721657244380732db3bdd9645dbece347d3190c"
+    },
+    "textures/{win01_2brk2.tga": {
+     "bytes": 49170,
+     "sha256": "0dc35f6a8b8b83596d127791f32f59b4a7445cb2529777555a93b9f329b7b537"
+    },
+    "textures/{win01_2brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "b313a11eb9017f0be604b673c0df88e94f94d552a7a132241f80883e68f4905f"
+    },
+    "textures/{win01_2brk3.tga": {
+     "bytes": 49170,
+     "sha256": "0fd4d13eb067aa17be299b48d500c245554fc3a6c1f5f11e10cbec1195a35273"
+    },
+    "textures/{win01_2brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "7ad6db65f6c0190a9ec569cce3b4780d21a90baf9baa728128f278807f1ba780"
+    },
+    "textures/{win01_3brk1.tga": {
+     "bytes": 49170,
+     "sha256": "ee6084ebe49ce367fd68039d548b1c960e55b136412bb00b8094dc1c545307bf"
+    },
+    "textures/{win01_3brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "afa5f0475b733a0ee1829b76598acd37cb1f28ed7f2faaf128593a13e702f5fa"
+    },
+    "textures/{win01_3brk2.tga": {
+     "bytes": 49170,
+     "sha256": "54c3abca2e42bbc4626823d4ad8081797e295bbdd07942484142d8a1c5395474"
+    },
+    "textures/{win01_3brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "0e0fc8daffc3ec8e07028904e3e55946270b8346f32efa341d64d6d1c0bcfcb5"
+    },
+    "textures/{win01_3brk3.tga": {
+     "bytes": 49170,
+     "sha256": "c1c7752039d97f7b92ec36408ffe456ff96c2a27c725c432e677a4f22e893d46"
+    },
+    "textures/{win01_3brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "0b627faae78e0d01eee393b58f978bf1a46b653001e1d1c56589d822245f86df"
+    },
+    "textures/{win01_4brk1.tga": {
+     "bytes": 49170,
+     "sha256": "af0f20f39e53d82cda8fca18e2918c1a2df2e6cf94e4d636e50c01686b3291b8"
+    },
+    "textures/{win01_4brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "4522e8d89c78119e9ff517ad64571c17c3ca750ac820142a700809620e894942"
+    },
+    "textures/{win01_4brk2.tga": {
+     "bytes": 49170,
+     "sha256": "4696f9c8ca59937230f40a3135b6c02e54b9b912eb62ba1401cbd5cccd1a9ae4"
+    },
+    "textures/{win01_4brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "a7a978f76a01a53dca360914519a8b1a93272aaad8a57c54e32ec74d4d9f1b96"
+    },
+    "textures/{win01_4brk3.tga": {
+     "bytes": 49170,
+     "sha256": "66dfc1bbe57f20c766653ab71cb339b6bff4e10b33cf66f5ed070bc0be75156f"
+    },
+    "textures/{win01_4brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "fb047a212d30b7fd140331df80d03dc718ba4237df73bf3cd74c918cc91daddf"
+    },
+    "textures/{win02_1brk1.tga": {
+     "bytes": 49170,
+     "sha256": "cb2711c7dc2ee9b77aded814296c1b1bb124ff5d2db2e248af7d7d0d882f422d"
+    },
+    "textures/{win02_1brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "9391e42b0fe2e55689e7104984fc1b5fd199cd8821e562fc4538fe2eb73825e9"
+    },
+    "textures/{win02_1brk2.tga": {
+     "bytes": 49170,
+     "sha256": "4fb71ced0a5388e41896b3b71b9c48d157eb72d229db04bbdcca45ce58658adc"
+    },
+    "textures/{win02_1brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "ed18da9a408653915554b0918a0f720cb76257231fc8ff9d465003e98fb371ab"
+    },
+    "textures/{win02_1brk3.tga": {
+     "bytes": 49170,
+     "sha256": "3b1f9bdbd53db1fa6d6920045cf4da45064dac48f7f66870e003860514804e99"
+    },
+    "textures/{win02_1brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "f1e10e37f7f2e71ddd6165607e59d39f95ec59c904017a8fa6b7b33a3adf40c1"
+    }
+   },
    "sha256": "117caa759bf9f161599ff693f561c68954519eda9cefb719a97cd5c1cd863ef3",
    "timestamp": "2020-10-12T17:05:06.000Z"
   },
   "rotj/pak1.pak": {
    "bytes": 5469052,
+   "files": {
+    "maps/ad_brk/all_brick.map": {
+     "bytes": 22738,
+     "sha256": "e0859c71d8a3d5d4b140757e4fcd2ab4e92674bbb71979d6b9d6d2deb5d2390a"
+    },
+    "maps/ad_brk/all_glassa.map": {
+     "bytes": 8834,
+     "sha256": "f4e1c7c1444b3b2d8a3463e8950c0a6a3aed8d39144a6b1fc2a69bdbf376f444"
+    },
+    "maps/ad_brk/all_metal.map": {
+     "bytes": 12297,
+     "sha256": "447c74022bea3ae89d3a4412afcf4bcd384ea725b344b987fb2e7bb37adfabe1"
+    },
+    "maps/ad_brk/all_rocka.map": {
+     "bytes": 10235,
+     "sha256": "52edb0d5b9f79e8b89a58353098316e81be31c3e289d6f96e450ea01c4bbeb62"
+    },
+    "maps/ad_brk/all_wood.map": {
+     "bytes": 8397,
+     "sha256": "93697129156d662c18391564e26c5d5ceec8bac244209496290b8e9a516a5bfb"
+    },
+    "maps/ad_brk/brick01.bsp": {
+     "bytes": 7912,
+     "sha256": "c11880924b195ed38908cbf50f9cd16f071918df0a94a19c7254b93dddb1e62d"
+    },
+    "maps/ad_brk/brick01.map": {
+     "bytes": 717,
+     "sha256": "3f87d06eb46f67efa678ddd5ddf274e9c595c4a5236d8f111d8a0ea999972e09"
+    },
+    "maps/ad_brk/brick02.bsp": {
+     "bytes": 8072,
+     "sha256": "9ec52c7441f570d2a793035ebc2128d7f7f91f71b44b4418fd01e6b3e6d503e2"
+    },
+    "maps/ad_brk/brick02.map": {
+     "bytes": 861,
+     "sha256": "616d1c5b6f3e476453e8b9b57dd59deb285c6c0482680ca5d6da358ee808c619"
+    },
+    "maps/ad_brk/brick03.bsp": {
+     "bytes": 8280,
+     "sha256": "aa55feca84b80282851ca55c71deb3d54f02a6668af820f5ac4f9c1a0514e5e1"
+    },
+    "maps/ad_brk/brick03.map": {
+     "bytes": 935,
+     "sha256": "4359e78daaac0b8d4ff58dc68301bba4cd423e81284bcd360ce1480862c19d91"
+    },
+    "maps/ad_brk/brick04.bsp": {
+     "bytes": 8052,
+     "sha256": "b1fa14c188a8ad31cf58c7ebd495fbe8ed153819015d4e97c82e01ee052081e3"
+    },
+    "maps/ad_brk/brick04.map": {
+     "bytes": 815,
+     "sha256": "2bda60cc50886dc430a053f509f2376dcd9bd4d09666cf7960a96484fa369903"
+    },
+    "maps/ad_brk/brick05.bsp": {
+     "bytes": 7952,
+     "sha256": "e137a3ea0f33a83b8717dcb9d6e2ab79876112121dc21fe2e625d24d5d251384"
+    },
+    "maps/ad_brk/brick05.map": {
+     "bytes": 770,
+     "sha256": "8ebf395096050f65a3a370971d65deb0926af70f6cbd75c6579a53b68f676793"
+    },
+    "maps/ad_brk/brick06.bsp": {
+     "bytes": 9184,
+     "sha256": "32cee0a2c668160e07568ae08b4de5beae87d74e94a347cd431c90005bf49e24"
+    },
+    "maps/ad_brk/brick06.map": {
+     "bytes": 1709,
+     "sha256": "289f58cad70a88e8a8d986644faf539dd38cf52a884aa7f85513db5df0cc438c"
+    },
+    "maps/ad_brk/brick07.bsp": {
+     "bytes": 10377,
+     "sha256": "df07446f9f6a118f11451de5d7817f582c11dcc81ca3f83c8fa72c9d95e8df9c"
+    },
+    "maps/ad_brk/brick07.map": {
+     "bytes": 1942,
+     "sha256": "fe440636e5354fb553708f3b6859023d0a520f315050dc11a564e31a7b72d5e4"
+    },
+    "maps/ad_brk/brick08.bsp": {
+     "bytes": 13964,
+     "sha256": "2abbbc958d752e742df9d1f7152c4cc8c0de6373f20e628a762e2a22f5d6b3f7"
+    },
+    "maps/ad_brk/brick08.map": {
+     "bytes": 3286,
+     "sha256": "72174f573416102bb4e087e2025b3dbdfc669ab7cafc8b354f7b1a4485af1f5b"
+    },
+    "maps/ad_brk/brick09.bsp": {
+     "bytes": 7952,
+     "sha256": "28d7162b4af3f4ce184a31a14e3a9777383f29b63920d9d62ff136ae96e3a2fd"
+    },
+    "maps/ad_brk/brick09.map": {
+     "bytes": 770,
+     "sha256": "62f11ef3e3033dea82eb6062e5b5301474dd014f889a980383891e689be2a352"
+    },
+    "maps/ad_brk/brick10.bsp": {
+     "bytes": 9184,
+     "sha256": "7d6f8e3fd1b65880bb767ab5d488ef11bbb01ec4ce14c7b747ee75b8a8238c4e"
+    },
+    "maps/ad_brk/brick10.map": {
+     "bytes": 1709,
+     "sha256": "276f975d99dfe982bf71104889f65a248d719778db89591e7193ecc46b13d645"
+    },
+    "maps/ad_brk/brick11.bsp": {
+     "bytes": 10377,
+     "sha256": "f65cbdb642220611e89725187f47427031c4b18c21cc04ae3f6cfb4dffd149a2"
+    },
+    "maps/ad_brk/brick11.map": {
+     "bytes": 1942,
+     "sha256": "3b9d73d400e29fba3c82d8b2ccdad26e03b128c7771427497d4740c2d34cd63d"
+    },
+    "maps/ad_brk/brick12.bsp": {
+     "bytes": 13918,
+     "sha256": "1e1e8191c5ebdd1f0fed27edaa04a82a6aabd5c41723cf590781ff00f7300a02"
+    },
+    "maps/ad_brk/brick12.map": {
+     "bytes": 3286,
+     "sha256": "d2b89c83f1ff95d6fe577cf4a166e7bec6e02ab85f48c51316908d7d80068156"
+    },
+    "maps/ad_brk/brick13.bsp": {
+     "bytes": 7912,
+     "sha256": "4b5ac4eb6ea5a9ec049c27082d800cb981902965a4b652f86e1753bfa1eb7c94"
+    },
+    "maps/ad_brk/brick13.map": {
+     "bytes": 690,
+     "sha256": "253425ec201a354cd1b4c93c78d740e2a17c7d946d911efffa63d522e95f9f0b"
+    },
+    "maps/ad_brk/brick14.bsp": {
+     "bytes": 8072,
+     "sha256": "afe8797d2172a5b4b06be3e2a69038346d62938f3d9da6ea224074cee5bb1669"
+    },
+    "maps/ad_brk/brick14.map": {
+     "bytes": 828,
+     "sha256": "a500705a328cafa28159ee107cbe80003848ee241c3544a73dea1432f67b4042"
+    },
+    "maps/ad_brk/brick15.bsp": {
+     "bytes": 8280,
+     "sha256": "58ddb31ce4108a70872444022369154529c532983dbc58698cd88f217f8947a0"
+    },
+    "maps/ad_brk/brick15.map": {
+     "bytes": 899,
+     "sha256": "589f256e02b66051ede4f2fe136e69313a7e01402f1caa43bada4d605a046b8e"
+    },
+    "maps/ad_brk/brick16.bsp": {
+     "bytes": 8052,
+     "sha256": "d5c15593d0d776d5f76919100602d893973cd59b7ca88af55e1ae3cc2fb56967"
+    },
+    "maps/ad_brk/brick16.map": {
+     "bytes": 785,
+     "sha256": "a15682c168f0a7128c83bf7bd38688ae1d2507873687e815c690b08d44f14a37"
+    },
+    "maps/ad_brk/brick17.bsp": {
+     "bytes": 7952,
+     "sha256": "738d902046d73e14b8a552529dd8306864661fd0469efb52b3c81329135e8372"
+    },
+    "maps/ad_brk/brick17.map": {
+     "bytes": 770,
+     "sha256": "699fa7055fa88f309fe4a4a2af24b5d61af91365d81074e44cbdf399d36939c9"
+    },
+    "maps/ad_brk/brick18.bsp": {
+     "bytes": 9184,
+     "sha256": "67ad693c292448f73ea0b3ab6ee22883709c7deb006cecd19c0dda5c9d4fa131"
+    },
+    "maps/ad_brk/brick18.map": {
+     "bytes": 1709,
+     "sha256": "849749000a41ecfc60aa4607c890e140bcd78ef26858512f56494efdc5873bcd"
+    },
+    "maps/ad_brk/brick19.bsp": {
+     "bytes": 10321,
+     "sha256": "721c3237db8c026a03e01e387bb95fe5ed8fbc49b3c527220f164d77a2f3a4f2"
+    },
+    "maps/ad_brk/brick19.map": {
+     "bytes": 1942,
+     "sha256": "1760c2c74d0b894814c89152062f2f55a8635a17559828c27532a7e913949af6"
+    },
+    "maps/ad_brk/brick20.bsp": {
+     "bytes": 13306,
+     "sha256": "bbecee9c1ac726743e6cc49d18246c650f762f577dc108ffed2a6807ff665052"
+    },
+    "maps/ad_brk/brick20.map": {
+     "bytes": 3286,
+     "sha256": "121d4fe62c07953f11a04a41577769a38cae8852af78bbd40fc44f598eee91d7"
+    },
+    "maps/ad_brk/brick21.bsp": {
+     "bytes": 7972,
+     "sha256": "e65c1df9d5f02efc9475a53d1127d7899f69d23d8a0ea20deab384fcd3351d29"
+    },
+    "maps/ad_brk/brick21.map": {
+     "bytes": 789,
+     "sha256": "8c12d093245c3937afcf62916fce9e6b2d181d72d433b879112b27e0f168ccc7"
+    },
+    "maps/ad_brk/brick22.bsp": {
+     "bytes": 9204,
+     "sha256": "b8efe5f130accf1e8704202dbaa44215259e1209b9b81bf79461ff5e5f725596"
+    },
+    "maps/ad_brk/brick22.map": {
+     "bytes": 1728,
+     "sha256": "403525bf264890c5d9adef370847749cbeec481337f284618810057e697cddde"
+    },
+    "maps/ad_brk/brick23.bsp": {
+     "bytes": 10340,
+     "sha256": "79bac69a44c7e83343bd69c2360176046e048257ecfb7ac27f3c989b42af92e9"
+    },
+    "maps/ad_brk/brick23.map": {
+     "bytes": 1961,
+     "sha256": "f25e7a514eb15637b7dedc41ec5c34e2d8b9e4dd3b584a41a1b1d7c166b362ef"
+    },
+    "maps/ad_brk/brick24.bsp": {
+     "bytes": 13312,
+     "sha256": "2e0728a16ebe0fa868d8bd0ffe0f54e013afac41c77ee7516f385d7a6718b07f"
+    },
+    "maps/ad_brk/brick24.map": {
+     "bytes": 3305,
+     "sha256": "481d21e7e07a312e894f71a8118035457164f17d48032bad54bdc62644e7e8a4"
+    },
+    "maps/ad_brk/brick25.bsp": {
+     "bytes": 7924,
+     "sha256": "8e33245bde92e94d9dddca1b61059fee1eb19aed0613945c1dffe3145fd51d78"
+    },
+    "maps/ad_brk/brick25.map": {
+     "bytes": 715,
+     "sha256": "cf6042585a2347f8ae4de546e2fa9aa905aa7ee4d9607a12dfd778d0084ba9d1"
+    },
+    "maps/ad_brk/brick26.bsp": {
+     "bytes": 8084,
+     "sha256": "4ddb5d2ca4adbc32f905a0340b26a174c25af7f6de5ad9408c4e0f4ca2816a55"
+    },
+    "maps/ad_brk/brick26.map": {
+     "bytes": 855,
+     "sha256": "baaf133d5c5c90b295855bb03a0a30340db324ddc82ed119a9d025e8ddb22724"
+    },
+    "maps/ad_brk/brick27.bsp": {
+     "bytes": 8296,
+     "sha256": "9084778144864d4167d270dd825e99d18d7ea7fc2dfb799f7e0eb12f1d236688"
+    },
+    "maps/ad_brk/brick27.map": {
+     "bytes": 927,
+     "sha256": "4e3b59df2a5b8efe85460f114baa795c36c8b410407e0752a69efc525d49e9b0"
+    },
+    "maps/ad_brk/brick28.bsp": {
+     "bytes": 8068,
+     "sha256": "42b4fe7f99032b3292996bcfe8b72e1c5e3b637357e376f8502a202a3816bcf0"
+    },
+    "maps/ad_brk/brick28.map": {
+     "bytes": 811,
+     "sha256": "c088828bbe9cdca1bb55ea4ceca9f46e03217f1643189a93d70a83eeb11f72bc"
+    },
+    "maps/ad_brk/brick29.bsp": {
+     "bytes": 24232,
+     "sha256": "463ff6bed92dfab082f13876187c506572dd3d18727e13fb708e24afd02aa7ef"
+    },
+    "maps/ad_brk/brick29.map": {
+     "bytes": 711,
+     "sha256": "1a4ff9d041df15cfd229666a9b32c24a96577ef6f249f33d89dc88cdfbe5540a"
+    },
+    "maps/ad_brk/brick30.bsp": {
+     "bytes": 24392,
+     "sha256": "a82a0d709c367d8ecf359142d99d0ad09d97b674ef1575beeb78dbbe93025c59"
+    },
+    "maps/ad_brk/brick30.map": {
+     "bytes": 853,
+     "sha256": "803c896037b5cc971e932219b5f06e363724a25de693ef6800d1332c6df4f8d1"
+    },
+    "maps/ad_brk/brick31.bsp": {
+     "bytes": 24604,
+     "sha256": "deb8a0278e043c6510e7f7d17ec708bdc7f37fa884f869ccbfc9ef9a95b6a8ac"
+    },
+    "maps/ad_brk/brick31.map": {
+     "bytes": 926,
+     "sha256": "9a3502125d9a995f10052ed6a9971bfe148a4e8fd7561a082e8bbecff5b39d56"
+    },
+    "maps/ad_brk/brick32.bsp": {
+     "bytes": 24376,
+     "sha256": "c8961b003f231b13a74bc247ce13ada38850707d443aa98dbad98b9f2ecf276b"
+    },
+    "maps/ad_brk/brick32.map": {
+     "bytes": 808,
+     "sha256": "aa96dda4508d2e98b5827ac42d8230f11969457f63022bf488dac06d2783910e"
+    },
+    "maps/ad_brk/glass01.bsp": {
+     "bytes": 8095,
+     "sha256": "d5d9b8df7fc4db671e180fbc60253ea809b61819bd77a9072d1cf1b1c9c11888"
+    },
+    "maps/ad_brk/glass01.map": {
+     "bytes": 961,
+     "sha256": "04b6721fc35e7a43fa921075bc2184bbbb2791570ea781ee6351b0cf01936456"
+    },
+    "maps/ad_brk/glass02.bsp": {
+     "bytes": 7035,
+     "sha256": "b2e6ba1e674f6a93e01ada15700b98624eae9c242a30eba9ea032d2e7d9fc555"
+    },
+    "maps/ad_brk/glass02.map": {
+     "bytes": 447,
+     "sha256": "6bf3cce568e830dd03830bb2e7225329490dae01e33806eec6a594313a8daa9e"
+    },
+    "maps/ad_brk/glass03.bsp": {
+     "bytes": 7922,
+     "sha256": "02661d1e724d41c02c977f8b869a23e6fc883303b66298c98ebddf752f365a1b"
+    },
+    "maps/ad_brk/glass03.map": {
+     "bytes": 963,
+     "sha256": "cb5245e54bc27d999bd643370557f8e766ae94e10358993951084e6ca87d087c"
+    },
+    "maps/ad_brk/glass04.bsp": {
+     "bytes": 7223,
+     "sha256": "a41bddb2d6a0ef53b96097a6e4d9731bf100b695a7a1c11091f054f746c7bf2a"
+    },
+    "maps/ad_brk/glass04.map": {
+     "bytes": 512,
+     "sha256": "f8e9f41266f3cd0017c19f7d3a29e0c738b497fb539cec2583c4eda6d509965c"
+    },
+    "maps/ad_brk/glass05.bsp": {
+     "bytes": 24436,
+     "sha256": "10fd2ef7f24bda233c3b4433e4ed64b8feb7273f09c0da5d93190ced61f20779"
+    },
+    "maps/ad_brk/glass05.map": {
+     "bytes": 999,
+     "sha256": "c8e2039929909b608ac0ddf36562443caf7052a15e8b0e39a73e0869c15930c1"
+    },
+    "maps/ad_brk/glass06.bsp": {
+     "bytes": 24300,
+     "sha256": "60f08ebc3d967dbe1b6062a59679a3e89e199a305f51bb9bc7dbada44c66fe5e"
+    },
+    "maps/ad_brk/glass06.map": {
+     "bytes": 976,
+     "sha256": "73346b8cc46166371a6e7f220ebe78f2cde29f29d8d705e1e4b0c60e153b52df"
+    },
+    "maps/ad_brk/glass07.bsp": {
+     "bytes": 23365,
+     "sha256": "ccebafe1a97953e91b64694783a1989c8e8ba440fd3c136b09785131b54c75cf"
+    },
+    "maps/ad_brk/glass07.map": {
+     "bytes": 458,
+     "sha256": "6d79a332d308ed3746c8f2fd13227b44a1cc66f0b2fd471eb6de1cbf695d81c9"
+    },
+    "maps/ad_brk/glass08.bsp": {
+     "bytes": 23602,
+     "sha256": "82c1bfe3d83c87c908d6dac76a255843cbbaededeaf644eeec5b9b9a794e0bdf"
+    },
+    "maps/ad_brk/glass08.map": {
+     "bytes": 530,
+     "sha256": "65dba1b71881c49b29d288720f43c457c838b93aa9e522953bac885443944c04"
+    },
+    "maps/ad_brk/glass09.bsp": {
+     "bytes": 24436,
+     "sha256": "34e317a5652fcc4a3aaf517ebc178c8d8fad6738b536a6c06eff2800bf7fefba"
+    },
+    "maps/ad_brk/glass09.map": {
+     "bytes": 999,
+     "sha256": "ca9b91b38fa600b7dfa80e9a257dc15f2f2dda9e1d2c1d002ea90cbdcc0e0279"
+    },
+    "maps/ad_brk/glass10.bsp": {
+     "bytes": 24300,
+     "sha256": "6e06c140e0916cd35235bd7e6970ca3250c6c36a2ee6d4632d805da67215818a"
+    },
+    "maps/ad_brk/glass10.map": {
+     "bytes": 976,
+     "sha256": "2043f7646edcfa088a76b6104b136ff9ca0f90bffe6efb955f951a4bfe16643d"
+    },
+    "maps/ad_brk/glass11.bsp": {
+     "bytes": 23365,
+     "sha256": "caae0c47ae097f4cb1055a3f5eecd5d407b71c975b35d992f3048993b1ac7e97"
+    },
+    "maps/ad_brk/glass11.map": {
+     "bytes": 458,
+     "sha256": "5bea1bbcee409674f58a1fd26cf0c983e11f8ffd5f20c829f5c3df6a4c28b1c9"
+    },
+    "maps/ad_brk/glass12.bsp": {
+     "bytes": 23602,
+     "sha256": "526018b31a9b02b1c9e1b5123b2c936677d6fd7b6c014ea14dfe4905271e419f"
+    },
+    "maps/ad_brk/glass12.map": {
+     "bytes": 530,
+     "sha256": "499ed4ce1a1ebbd9347a2a4dc6413f2f79d203bbce293a79a5b2bde49ade0a3f"
+    },
+    "maps/ad_brk/glass13.bsp": {
+     "bytes": 24108,
+     "sha256": "fdb97447ffe9e4769f35a3e1e7bd9d6b0e2e6b555d60102991bf57f06e8b3d83"
+    },
+    "maps/ad_brk/glass13.map": {
+     "bytes": 979,
+     "sha256": "073661c415a2568c45a90cc9baa471cde9a02a975d4d4fd7596bb96d272d3934"
+    },
+    "maps/ad_brk/glass14.bsp": {
+     "bytes": 23296,
+     "sha256": "e3517bb79e2561150c4641ab3650e0697adcaa2f281c5209cacdc12d9c4023a7"
+    },
+    "maps/ad_brk/glass14.map": {
+     "bytes": 462,
+     "sha256": "066d5bade73c399cf10a9dcafecec9d65ac3c6045644988cbefb104fb8e7d8c3"
+    },
+    "maps/ad_brk/glass15.bsp": {
+     "bytes": 23892,
+     "sha256": "6abc82aca32e6c8312884db42891753c8d2ad8e1d4ae9218022604eadb08708b"
+    },
+    "maps/ad_brk/glass15.map": {
+     "bytes": 993,
+     "sha256": "5c24e1763bd26d34539bc7ee527842810e4ddb6ac80f683a7b3b35ee326360d3"
+    },
+    "maps/ad_brk/glass16.bsp": {
+     "bytes": 23532,
+     "sha256": "13725c14b226297090c4f1e9949c476f601a52247bc8f6abb937a57b964462c6"
+    },
+    "maps/ad_brk/glass16.map": {
+     "bytes": 528,
+     "sha256": "03dbc7feb833831d413e7f87ed0e79625da0800659ab65ea8d3deb63de09a27d"
+    },
+    "maps/ad_brk/kn_mtrim2_1.bsp": {
+     "bytes": 25264,
+     "sha256": "99b67eeed7ece0f46b1d7b4b2309331e655eb9c1b412d3ac4bc362acb4dd8606"
+    },
+    "maps/ad_brk/kn_mtrim2_1.map": {
+     "bytes": 1455,
+     "sha256": "51018fd4ff6d00c9c2c449e32a83b8521fdc3babb2937adf6800d8e67e38b976"
+    },
+    "maps/ad_brk/kn_mtrim2_2.bsp": {
+     "bytes": 24460,
+     "sha256": "a98bdee68b3a222af0f44fc978d09e092a08953539929a6a53f1bf0e97568e74"
+    },
+    "maps/ad_brk/kn_mtrim2_2.map": {
+     "bytes": 1103,
+     "sha256": "2880a3f7becf48ae79c27ef9a05faa5c774df20a53ec5d892304bf67bc06cbbe"
+    },
+    "maps/ad_brk/kn_mtrim2_3.bsp": {
+     "bytes": 24632,
+     "sha256": "967e89f57bc011cd3b38d60d45272633cc0f773c91045b7938766ac0436ae803"
+    },
+    "maps/ad_brk/kn_mtrim2_3.map": {
+     "bytes": 1171,
+     "sha256": "40ef38fd45c3e9c750d311bb8920b938fcd9f647f2dabc58509b327514f44907"
+    },
+    "maps/ad_brk/kn_mtrim2_4.bsp": {
+     "bytes": 24452,
+     "sha256": "e4559e1e5a3118f2c949daccb96f887d64821511f5850cfa72133f84a8e04901"
+    },
+    "maps/ad_brk/kn_mtrim2_4.map": {
+     "bytes": 1036,
+     "sha256": "595513bc0fe2441cb6aa88af41d9afd7de8b94421ac6c32c546113f83be6577c"
+    },
+    "maps/ad_brk/metal01.bsp": {
+     "bytes": 8122,
+     "sha256": "11e8e340455c487150951fb4dccaf7da72d0243892948d5c22b478221ffcca23"
+    },
+    "maps/ad_brk/metal01.map": {
+     "bytes": 780,
+     "sha256": "902c31c661df8bbc1b0c410b6a8745f680e85cf91bbdb14d85244b6937be5239"
+    },
+    "maps/ad_brk/metal02.bsp": {
+     "bytes": 10022,
+     "sha256": "59b56266e73b4246c54d8cd9c4769d7345c53ae5133c45d1db94f5c771350d94"
+    },
+    "maps/ad_brk/metal02.map": {
+     "bytes": 1414,
+     "sha256": "171bfe727b6c80a4c0350fb4c87090d30c3fb1a21962b8fc9c638c47027e1fea"
+    },
+    "maps/ad_brk/metal03.bsp": {
+     "bytes": 9386,
+     "sha256": "13e3ea83c5bdbf81075328cc14543d1ab6301378cc9af56b59b67b1cc22e3a53"
+    },
+    "maps/ad_brk/metal03.map": {
+     "bytes": 1179,
+     "sha256": "89ac4002203958a9f971601586f4e4e6bdcaab7cbde62ca7fb58cf705fbdae56"
+    },
+    "maps/ad_brk/metal04.bsp": {
+     "bytes": 10655,
+     "sha256": "785ab6aed41e60072083aeee571d76796f60ec5e24d249736575007d558c10ae"
+    },
+    "maps/ad_brk/metal04.map": {
+     "bytes": 1599,
+     "sha256": "aecd2de4ce9cdb49922c58f640f3df4c48b8dc45f5e611f5d0c75a6a96bf705e"
+    },
+    "maps/ad_brk/metal05.bsp": {
+     "bytes": 8337,
+     "sha256": "82da98a887a0101d1a638d266db3c9913090b3fcaca6af5869e7063529b3066e"
+    },
+    "maps/ad_brk/metal05.map": {
+     "bytes": 905,
+     "sha256": "541a5d633be51d32bbd6580cf3fb4fcc7e9b3c38107eaffdd88896a01d249b71"
+    },
+    "maps/ad_brk/metal06.bsp": {
+     "bytes": 7898,
+     "sha256": "3fe3f66ff336ede9d9a6f4fc0f7df16b62504b25a8dea1c8adce2113e927428e"
+    },
+    "maps/ad_brk/metal06.map": {
+     "bytes": 697,
+     "sha256": "30bfd29315a3c0d8654aa1842b7f2a2a7bcdc7a5a81ff96f359a86d57a289ce9"
+    },
+    "maps/ad_brk/metal07.bsp": {
+     "bytes": 8439,
+     "sha256": "8f8a722ae0d3350bf4331fbd4a492dd4c18b3c44006289fd7c6d393282f280a1"
+    },
+    "maps/ad_brk/metal07.map": {
+     "bytes": 1508,
+     "sha256": "f2c7442255c68ae30186692cdf49bca0f1e5769587d5d2392baf3ec4708679b2"
+    },
+    "maps/ad_brk/metal08.bsp": {
+     "bytes": 8150,
+     "sha256": "028675fecfd419e8852cabe821fac1941c914bdf43110291d7a07509e77f4d26"
+    },
+    "maps/ad_brk/metal08.map": {
+     "bytes": 847,
+     "sha256": "797217e143857e0b27e1654449a5dbdc0b1a3dc46c8cafdea5ee9c5ac0cbf16c"
+    },
+    "maps/ad_brk/metal09.bsp": {
+     "bytes": 7456,
+     "sha256": "4d6fb8a19ce5a331ceb68fcfa952fa61ed3ad336002eedd788921b0daa2a7877"
+    },
+    "maps/ad_brk/metal09.map": {
+     "bytes": 649,
+     "sha256": "1fde976a2f1372d9d55350caa3285776eee897d9786f9118d5a6988010efaeca"
+    },
+    "maps/ad_brk/metal10.bsp": {
+     "bytes": 7785,
+     "sha256": "c25084ae2f159ba73e6c43041a2e050d30af70a862a9c4846b2241848a33b55f"
+    },
+    "maps/ad_brk/metal10.map": {
+     "bytes": 709,
+     "sha256": "856390903976512f1b5372f374b5c7444238a173abbedbbfeccbb675cf93ed66"
+    },
+    "maps/ad_brk/metal11.bsp": {
+     "bytes": 7918,
+     "sha256": "e939c6c80e11479887b68bb39a97e0b877514c4e9dc9b2a4a9e18303caa317f1"
+    },
+    "maps/ad_brk/metal11.map": {
+     "bytes": 797,
+     "sha256": "74528d15a51708fdca65c900096411f1d56d6472a5058458577ac04d820e9895"
+    },
+    "maps/ad_brk/metal12.bsp": {
+     "bytes": 8226,
+     "sha256": "3ceccd7aa24fc353e0ac3ccb15531c2f243c0ed246c73c44bdd8897dbdd6537e"
+    },
+    "maps/ad_brk/metal12.map": {
+     "bytes": 872,
+     "sha256": "a95f34c46729c7849e6d45d9cdf57bb49289561b6551bd2e4a39659c272343fd"
+    },
+    "maps/ad_brk/metal13.bsp": {
+     "bytes": 8121,
+     "sha256": "e02aa4c824f5d8fcdfe302a0a194cee6fcf44e2fee844c492f434bf2b7763209"
+    },
+    "maps/ad_brk/metal13.map": {
+     "bytes": 760,
+     "sha256": "bae8879296237bea635d054428a536c0297420ff3ff61f681d569b30a984e7d0"
+    },
+    "maps/ad_brk/metal14.bsp": {
+     "bytes": 10022,
+     "sha256": "4b66b133fe892c6ae6ead0c6726638e98637d71a3a9afdc4ac0546be0f2d0292"
+    },
+    "maps/ad_brk/metal14.map": {
+     "bytes": 1376,
+     "sha256": "197bd6c01b5ffc4c9e0f27e319b25b882af4f20db36612f41b006dd6db0833e1"
+    },
+    "maps/ad_brk/metal15.bsp": {
+     "bytes": 9386,
+     "sha256": "8cf7545aa3464814908c3987f51e9693f154f690ec526ed228b37b1590730e0b"
+    },
+    "maps/ad_brk/metal15.map": {
+     "bytes": 1147,
+     "sha256": "73aef82251f5b4a9548135aedb926aad6b7cff94cb3656fc8216a594a8a9f6dc"
+    },
+    "maps/ad_brk/metal16.bsp": {
+     "bytes": 10719,
+     "sha256": "af64c13135b1e1eb6d8e09607c34d6cec57a3cbf624dd76b136b505f097ecf65"
+    },
+    "maps/ad_brk/metal16.map": {
+     "bytes": 1555,
+     "sha256": "d7220fbbb33a630d03ed2514b9ee33a9d3a424f819b4977e093863ca8568b645"
+    },
+    "maps/ad_brk/metal17.bsp": {
+     "bytes": 8347,
+     "sha256": "0d21cbf9b5bc65391e00bad35368530d3d4b5f59993e2ac7d45a7edc9a2edf73"
+    },
+    "maps/ad_brk/metal17.map": {
+     "bytes": 911,
+     "sha256": "7be91013d0e57e41aff314398634043cebf8f250691b3ebc583bf373df400c2c"
+    },
+    "maps/ad_brk/metal18.bsp": {
+     "bytes": 7907,
+     "sha256": "ef0dee9c63d7bbced8c04ea40523d47fd99638905aa20a61779820b5aebd5aab"
+    },
+    "maps/ad_brk/metal18.map": {
+     "bytes": 703,
+     "sha256": "b610432a51ac6b57f19fee9df89fc7b80d5cbffa972e539d9c5f3aded3359434"
+    },
+    "maps/ad_brk/metal19.bsp": {
+     "bytes": 8450,
+     "sha256": "2796007e11c0a1b2a3430edc4e0f7edb0e721a6d906e783233c0feb54b0482e5"
+    },
+    "maps/ad_brk/metal19.map": {
+     "bytes": 1514,
+     "sha256": "9ed741344b3c651f3b8fbda1d8ee8e779bd12315feea397e938522c9750dc214"
+    },
+    "maps/ad_brk/metal20.bsp": {
+     "bytes": 8160,
+     "sha256": "38013cdb360356827ab6c296791434c537183d082feed6944665a882e622ed84"
+    },
+    "maps/ad_brk/metal20.map": {
+     "bytes": 853,
+     "sha256": "a3b28328bb043206bc048e82dba12d91c56c464b5e4e1452c6740f0df44223bf"
+    },
+    "maps/ad_brk/rock01.bsp": {
+     "bytes": 24238,
+     "sha256": "5f2c0a6ce3c58eed53c86789ff1685551cff53ca1f239bf75e3a9bc59aa95a56"
+    },
+    "maps/ad_brk/rock01.map": {
+     "bytes": 680,
+     "sha256": "db0b6a72833e12a35f518b32920fccf4fbc45120e7ab8ca3afc6e255b5d51334"
+    },
+    "maps/ad_brk/rock02.bsp": {
+     "bytes": 24250,
+     "sha256": "c6196e82e7b3e22cb687e2d6c0780f163929b5ea42b868eedcaadd40f35927f9"
+    },
+    "maps/ad_brk/rock02.map": {
+     "bytes": 760,
+     "sha256": "49531f0a1a38e03e3b46af53cfc35845878fcc171c2579f0f13d2a000ca82829"
+    },
+    "maps/ad_brk/rock03.bsp": {
+     "bytes": 24669,
+     "sha256": "9f7ab133399a3681f0b97276c7cb9883b479995c3420e5643eaedd11c88f0a0d"
+    },
+    "maps/ad_brk/rock03.map": {
+     "bytes": 929,
+     "sha256": "4158321d447c3b323f44389661ba6c763b23e26fb9541a786c3b544ad56321d9"
+    },
+    "maps/ad_brk/rock04.bsp": {
+     "bytes": 24600,
+     "sha256": "3c8b114e8ff86b8abcba235230445d885d4c28553d83e153676b2755b0300292"
+    },
+    "maps/ad_brk/rock04.map": {
+     "bytes": 878,
+     "sha256": "229d94f5f5bd81a83be5463035d30c8838d1de092923c3281e7a3a9ec4c7e9aa"
+    },
+    "maps/ad_brk/rock05.bsp": {
+     "bytes": 24254,
+     "sha256": "6bdc990b90f24ddd77034a4cbdd4d7158e05df70e6db5e793ca990a40cd29709"
+    },
+    "maps/ad_brk/rock05.map": {
+     "bytes": 684,
+     "sha256": "708a6ad98116a72ddc862c6c99cbd59342446636c9579a00bd6c34efa1ac855b"
+    },
+    "maps/ad_brk/rock06.bsp": {
+     "bytes": 24462,
+     "sha256": "e2e3688c3cb66e2c9d738d211ad328d86963e1d67881354363696698a07be32b"
+    },
+    "maps/ad_brk/rock06.map": {
+     "bytes": 816,
+     "sha256": "5e1a399ac2e6a179a84004539f15172012db93477e5544309b01ed24cbc59f34"
+    },
+    "maps/ad_brk/rock07.bsp": {
+     "bytes": 24281,
+     "sha256": "ea3569e42b755fd1b9fde50e2740f6aa95d1dabb1911f8a4ab5b1c5028a4e1e3"
+    },
+    "maps/ad_brk/rock07.map": {
+     "bytes": 777,
+     "sha256": "02f61c60083f5007fa9d4d7a38adf2901e928a96adbfeaa7646711f21cc75409"
+    },
+    "maps/ad_brk/rock08.bsp": {
+     "bytes": 25096,
+     "sha256": "5468a365153fc7f160d7e1792b9bc9164b828a51851bd1e9744eb0cf3a7a842d"
+    },
+    "maps/ad_brk/rock08.map": {
+     "bytes": 1060,
+     "sha256": "b285f3a79407366944213b3d8eef311c662bf2eb0cf3df0ee3104e747a3c9150"
+    },
+    "maps/ad_brk/rock09.bsp": {
+     "bytes": 8314,
+     "sha256": "4320c73f55d67e4db7e596614b74b05b0c086cd57186ecaf183c96fca51106bf"
+    },
+    "maps/ad_brk/rock09.map": {
+     "bytes": 913,
+     "sha256": "629fab0d0f8022138ff5d5e573f0e3ab0f75397f120015b3f8a95a297c857911"
+    },
+    "maps/ad_brk/rock10.bsp": {
+     "bytes": 7930,
+     "sha256": "7657ad82fbdeaceb354e04f60fa76cfd3d8a7a819607a413afaa6fc16253a009"
+    },
+    "maps/ad_brk/rock10.map": {
+     "bytes": 780,
+     "sha256": "833bc2f2460f5f5ef444630b398a59974831031e408f986125a5241fab52ba99"
+    },
+    "maps/ad_brk/rock11.bsp": {
+     "bytes": 8565,
+     "sha256": "e19573b67e5dedba499da8f6d0d63ca0e829593417a1ce66e1aeb1fd2b2d1e76"
+    },
+    "maps/ad_brk/rock11.map": {
+     "bytes": 1016,
+     "sha256": "040c31d22159743b28e9f20946b34db390ef15bbe530882342638b9325542801"
+    },
+    "maps/ad_brk/rock12.bsp": {
+     "bytes": 8284,
+     "sha256": "f03a3a0184b2fa8809154754f85d81d30777261714976bdd64340b0549d3ca35"
+    },
+    "maps/ad_brk/rock12.map": {
+     "bytes": 898,
+     "sha256": "b7d2b1bba22ad5b621e699a8233a83d23415e5c6e88fec8e1525a9c84a494bf0"
+    },
+    "maps/ad_brk/rock13.bsp": {
+     "bytes": 7917,
+     "sha256": "6710c24df905df9ede31faf75fdf9a070efbdc471e58a295740092863dcb50fa"
+    },
+    "maps/ad_brk/rock13.map": {
+     "bytes": 680,
+     "sha256": "369735b7ebd630e6407371d3ab7195ef368c2f8d8d3469943b2c5e46b8e24fa5"
+    },
+    "maps/ad_brk/rock14.bsp": {
+     "bytes": 7929,
+     "sha256": "a17329c593e306d1aa4084cd2651983f53258b3e5759443efe3bb3b4daecc5f8"
+    },
+    "maps/ad_brk/rock14.map": {
+     "bytes": 760,
+     "sha256": "f86556e799f3a0240294537aa487526c674486afb7190bb705d72453cade7e68"
+    },
+    "maps/ad_brk/rock15.bsp": {
+     "bytes": 8349,
+     "sha256": "d64f11606da6b94024382315eead25dbfe19c8cc90844f60e755e2bd106c7fc0"
+    },
+    "maps/ad_brk/rock15.map": {
+     "bytes": 929,
+     "sha256": "23defe1bddcc8db664c819b60657fd536b1c44b118299495d42f7c54f740e7b0"
+    },
+    "maps/ad_brk/rock16.bsp": {
+     "bytes": 8280,
+     "sha256": "87e60c650a672c5ffe57b64c7ae3c5413799972a2ca5b73935cb0d1dad16f62c"
+    },
+    "maps/ad_brk/rock16.map": {
+     "bytes": 878,
+     "sha256": "d3616ad7b423be757f6f7873791f4c452a09243b53569347bd36e87f1a942947"
+    },
+    "maps/ad_brk/rock17.bsp": {
+     "bytes": 8340,
+     "sha256": "b317f3432532e6f6f327852fa0c7f546726c8b23c44cfc3e86869d64eb33235c"
+    },
+    "maps/ad_brk/rock17.map": {
+     "bytes": 913,
+     "sha256": "a534b032b611965c86cd81fda18d53186c474d55184f9c4c74cd292b4b207f27"
+    },
+    "maps/ad_brk/rock18.bsp": {
+     "bytes": 7924,
+     "sha256": "e5fc24e393828bdd2c24e3cb341e0c21e81511881e65424293206fe20ff54c4e"
+    },
+    "maps/ad_brk/rock18.map": {
+     "bytes": 701,
+     "sha256": "bf5974bf04067482dde83a2fd73e58a011de04220b32866fa7913e901a0e944c"
+    },
+    "maps/ad_brk/rock19.bsp": {
+     "bytes": 8620,
+     "sha256": "4a1d3e4e37f29438981f419f5a5f076fcf53227a4da544e919061d6c6bf8702e"
+    },
+    "maps/ad_brk/rock19.map": {
+     "bytes": 919,
+     "sha256": "c2626204acbd33e3299c29cd1f8a5279bbe8cd07a621f6b40b14b74b7808f444"
+    },
+    "maps/ad_brk/rock20.bsp": {
+     "bytes": 8785,
+     "sha256": "87bfda54a9f0711eedcefc6d8e691b6cac8123958db03735bd0364067445de69"
+    },
+    "maps/ad_brk/rock20.map": {
+     "bytes": 1118,
+     "sha256": "225800378c3183d5ba423140d7f5d510cf387df3df795fda69294fcb0e4bec4c"
+    },
+    "maps/ad_brk/rock21.bsp": {
+     "bytes": 24244,
+     "sha256": "161b5893f3f413969ced051a7e7aa3d816a1da9f74bffa5d0642830713d83031"
+    },
+    "maps/ad_brk/rock21.map": {
+     "bytes": 674,
+     "sha256": "db86b019086636ec085b3690bc4b252d8bac2443c0ff138a6f3b6c79e522a94b"
+    },
+    "maps/ad_brk/rock22.bsp": {
+     "bytes": 24256,
+     "sha256": "b41069e88c74ef3bfb7c5f2817c31d9d374cd1725b7270b9ac7d93c58dd34a11"
+    },
+    "maps/ad_brk/rock22.map": {
+     "bytes": 753,
+     "sha256": "aa059dd13499512fdda512b68e79068f390d1870726763958a81a54c91aeb254"
+    },
+    "maps/ad_brk/rock23.bsp": {
+     "bytes": 24676,
+     "sha256": "aac7fc5557dd385c52043d206d39d83b48e0b2f6db2822de2060f2a978be4a9d"
+    },
+    "maps/ad_brk/rock23.map": {
+     "bytes": 920,
+     "sha256": "744ccf1456c3b19318289586238b1d36e4968dbfe444f5a489e1d2202f1965d4"
+    },
+    "maps/ad_brk/rock24.bsp": {
+     "bytes": 24612,
+     "sha256": "90553422561893d50030520bcf796da9290933e53570e313d1a423aec01c8ac6"
+    },
+    "maps/ad_brk/rock24.map": {
+     "bytes": 939,
+     "sha256": "3f8f5c2053315577eda81360a9ed9a095e96f7d9a6288eed876400a91bc0922b"
+    },
+    "maps/ad_brk/rock25.bsp": {
+     "bytes": 89516,
+     "sha256": "ef87b49e322fd2a2251f0ee7ecedec32bae141ea7a589769c6fba6a3176da0d4"
+    },
+    "maps/ad_brk/rock25.map": {
+     "bytes": 737,
+     "sha256": "3cad88a720acc4d7db1666ab0d865e013717776a256c999e1b417690679f4f0b"
+    },
+    "maps/ad_brk/rock26.bsp": {
+     "bytes": 89532,
+     "sha256": "a6f46aa8183937dfe19eb1cfde621bac8f3f08721effcbbd195ba251b3b1467f"
+    },
+    "maps/ad_brk/rock26.map": {
+     "bytes": 823,
+     "sha256": "27c411424182d3e6d611f2eff2dd9a7c75ef2135f2019d4aca40b2dee2d134b5"
+    },
+    "maps/ad_brk/rock27.bsp": {
+     "bytes": 89952,
+     "sha256": "f55dc66117c856efee1dae5e311492f2aae2839ef4588af45ac0818307ad564c"
+    },
+    "maps/ad_brk/rock27.map": {
+     "bytes": 1004,
+     "sha256": "7368f6cbd051aa3ac71237b5c8d3da2ef73fc3017024ef42af6ac8af9ddc1139"
+    },
+    "maps/ad_brk/rock28.bsp": {
+     "bytes": 89880,
+     "sha256": "2132d7f311c90f8c43b4630a55f7fa0b15141fa0e9c26c0309c8023437377961"
+    },
+    "maps/ad_brk/rock28.map": {
+     "bytes": 947,
+     "sha256": "b1571df2e370ca2d51f19b3608726552f10a6f6da64f69929a2ea2c1884e51dc"
+    },
+    "maps/ad_brk/rock29.bsp": {
+     "bytes": 89516,
+     "sha256": "a179ac329768d445bfbc36bb9c3e47ce3c7506c31337730a93c9a58f96ea5399"
+    },
+    "maps/ad_brk/rock29.map": {
+     "bytes": 737,
+     "sha256": "260d08f376c81869c1f9a0c0cfd677bded9022f79bbe4e607d12128b7ad7c746"
+    },
+    "maps/ad_brk/rock30.bsp": {
+     "bytes": 89532,
+     "sha256": "febc6ed2ec191f8dcbae1ee9df9d13bbd8fff830e28e051236fa24fd211829ee"
+    },
+    "maps/ad_brk/rock30.map": {
+     "bytes": 823,
+     "sha256": "da6a3224e060f6413f70ac9f6f25bf96f3784f690084d602d63805dc8b43e7e8"
+    },
+    "maps/ad_brk/rock31.bsp": {
+     "bytes": 89952,
+     "sha256": "7a38ed8a7dd80c2f2dab17342bfdde51300c9225f4e93be78ca9b63d3a7f1e99"
+    },
+    "maps/ad_brk/rock31.map": {
+     "bytes": 1004,
+     "sha256": "3fb04740e6da6c00670536ccbcb92e7a9a5b5e3072e78af96d6dd5c79d39f984"
+    },
+    "maps/ad_brk/rock32.bsp": {
+     "bytes": 89880,
+     "sha256": "41789fbb095ef6d7b09ba6f50bea0503f73e612808f37bbb71f4a7e9fea00ae2"
+    },
+    "maps/ad_brk/rock32.map": {
+     "bytes": 947,
+     "sha256": "37e272ad3f235bb182666e46d3b087bee4ec23ebdc716647c5b0ffb671a9ee1d"
+    },
+    "maps/ad_brk/rock33.bsp": {
+     "bytes": 7916,
+     "sha256": "af3e313ba1c7013b7bd2234e9988a2b6bc451d123e7d6dab1692ae0727d40bec"
+    },
+    "maps/ad_brk/rock33.map": {
+     "bytes": 683,
+     "sha256": "de08059147e865be402e6dac4c6d8a0bea1de05bb65cf0455153386afdde2bdb"
+    },
+    "maps/ad_brk/rock34.bsp": {
+     "bytes": 7932,
+     "sha256": "392125c9afaf18c3084c1b13a0a55dcda7e2294da37f84fb73983826271dea27"
+    },
+    "maps/ad_brk/rock34.map": {
+     "bytes": 763,
+     "sha256": "dc402e2573ee3e94f3ed96274d5b6f8d0177d9745716ea96d0ffce8e0be5c943"
+    },
+    "maps/ad_brk/rock35.bsp": {
+     "bytes": 8352,
+     "sha256": "0352c35aa723330a3c05126d24a8e6b84403bf8b71d406f3fa5a2ff3fc0da39a"
+    },
+    "maps/ad_brk/rock35.map": {
+     "bytes": 932,
+     "sha256": "9841ed50187bbdfb3a7122d3b0890b0245d64dd4919485686fdf5ce61bdae3e6"
+    },
+    "maps/ad_brk/rock36.bsp": {
+     "bytes": 8280,
+     "sha256": "f1871698ef7597c51fed5d54b582df2ea70cf72e2fa7db643182e59f7e7f6ca7"
+    },
+    "maps/ad_brk/rock36.map": {
+     "bytes": 881,
+     "sha256": "974aaec9003dd3e1457582b1f770d67e07fc8e9d11a6b639981fbb753c6a6484"
+    },
+    "maps/ad_brk/sandstone01.bsp": {
+     "bytes": 24239,
+     "sha256": "ebb374110d88805e1b0b45cdaf33e5e570a9092da549facaf9f5ddcd995eb607"
+    },
+    "maps/ad_brk/sandstone01.map": {
+     "bytes": 702,
+     "sha256": "9ea9ab63b8c6a2d90fba029c4d4b768beb0d4342cf255bb5005185b61b1bcfd2"
+    },
+    "maps/ad_brk/sandstone02.bsp": {
+     "bytes": 24399,
+     "sha256": "2fa799b0a08ca2fdd9bef3ecb9d6ea4c16e8f66181d29913cdc5a9205bafe98f"
+    },
+    "maps/ad_brk/sandstone02.map": {
+     "bytes": 842,
+     "sha256": "5228b0a958ef571f33838366ef1f2b69a10f6e0c53a3269dba683b5326a95e5f"
+    },
+    "maps/ad_brk/sandstone03.bsp": {
+     "bytes": 24607,
+     "sha256": "671b8f740ba9deaeac681c703f87d61c2a3f8107d0f72b8fd636c53436555110"
+    },
+    "maps/ad_brk/sandstone03.map": {
+     "bytes": 914,
+     "sha256": "7523ff7908eb3e47154155d0448fa05d4d9b6081525069a131e7d44ea9b13c0c"
+    },
+    "maps/ad_brk/sandstone04.bsp": {
+     "bytes": 24379,
+     "sha256": "56bda0f4bf4958dc243fa9b4ab79e9e3bd6fad5f794af7beb024a6cbe7f9a0cb"
+    },
+    "maps/ad_brk/sandstone04.map": {
+     "bytes": 798,
+     "sha256": "d01584bd00868a0a69ae7513834f776566fce273d8919d9c78d0bdafbb07a799"
+    },
+    "maps/ad_brk/wood01.bsp": {
+     "bytes": 7553,
+     "sha256": "c1764181bae4852804097143fe16a4c230bd5886574125cb33d5349bbc63dc21"
+    },
+    "maps/ad_brk/wood01.map": {
+     "bytes": 1040,
+     "sha256": "05f1ebaa57c4b55e6c3da9c5440c180aa96c719f9cddc80c780ed11415ad6bd7"
+    },
+    "maps/ad_brk/wood02.bsp": {
+     "bytes": 7079,
+     "sha256": "26fc67e4e47eae3a13a449d876deabe35d50aa1b70e63060d27cb365eadecbe0"
+    },
+    "maps/ad_brk/wood02.map": {
+     "bytes": 521,
+     "sha256": "8dee7615c9e9696420331668edeccd9ff1dd874ad844e289f049391be5e61345"
+    },
+    "maps/ad_brk/wood03.bsp": {
+     "bytes": 7135,
+     "sha256": "ca17df0f61a11bd37749587e361ca404f2e5bec07c248491d86c07803fafb732"
+    },
+    "maps/ad_brk/wood03.map": {
+     "bytes": 522,
+     "sha256": "0fb4cdb1ffeda8c97026d40842d5fcb0beced0f84dae4b10a8284044875cf0c2"
+    },
+    "maps/ad_brk/wood04.bsp": {
+     "bytes": 7951,
+     "sha256": "e2d9f42bf3256be2dd38648dbd962458bdad3992b33e8d688e42a0acba5d7c3f"
+    },
+    "maps/ad_brk/wood04.map": {
+     "bytes": 912,
+     "sha256": "071556b1cac3bd95a176762302e6a60ddbbfb07cf6c9e4b2f8cf2e259e23402a"
+    },
+    "maps/ad_brk/wood05.bsp": {
+     "bytes": 7553,
+     "sha256": "5bdb275ae2c39b41d71a17244681cda9cc2008df088f4da73f547a8bf1966069"
+    },
+    "maps/ad_brk/wood05.map": {
+     "bytes": 1040,
+     "sha256": "ada27de98972730676a2d040fd284893fabfe71acd6fcbce1f2ba12da7d14632"
+    },
+    "maps/ad_brk/wood06.bsp": {
+     "bytes": 7079,
+     "sha256": "f27b0f1970f6065255b5f7a27abfc4e749f40321f6fdef4c3f9ac6bb64d46098"
+    },
+    "maps/ad_brk/wood06.map": {
+     "bytes": 521,
+     "sha256": "17c93b1c1c65a7507d794013078a1d12a67c3a24ae7202739fcd8a1108d52419"
+    },
+    "maps/ad_brk/wood07.bsp": {
+     "bytes": 7135,
+     "sha256": "8e07e7e5f5b641c644d28c9c4026efc95aa50345074f5c42acd39a3b94261344"
+    },
+    "maps/ad_brk/wood07.map": {
+     "bytes": 522,
+     "sha256": "55f1bb5f18ed30f28ac88349aee9ea5563b1e938bafebffb25c9ab5a1c918b33"
+    },
+    "maps/ad_brk/wood08.bsp": {
+     "bytes": 7951,
+     "sha256": "d26222458ba6e7fee06670021e64c1661d99a8c098581936af943891c9583858"
+    },
+    "maps/ad_brk/wood08.map": {
+     "bytes": 912,
+     "sha256": "2582987129d34bbee73594a236c4c09ce6ae1092eec649ef3957b892e125624c"
+    },
+    "maps/ad_brk/wood09.bsp": {
+     "bytes": 7282,
+     "sha256": "2735e78b25b0feb640f27eddae47104b0acba9f017c6d025e3a8dbdfcc755778"
+    },
+    "maps/ad_brk/wood09.map": {
+     "bytes": 541,
+     "sha256": "84d9789b4d79b41347fd082b0ab75c016553c03bfb952cf4b9c7dd18c85944ce"
+    },
+    "maps/ad_brk/wood10.bsp": {
+     "bytes": 7214,
+     "sha256": "43b59e9b0cb02fb1ac15afb5c782e71b4ce0661db295949b5188cc5accd1733a"
+    },
+    "maps/ad_brk/wood10.map": {
+     "bytes": 533,
+     "sha256": "365f949e19e2606cf2d7a354c3e4368a5e17c3eef94e2558ed9cef276e987d35"
+    },
+    "maps/ad_brk/wood11.bsp": {
+     "bytes": 7196,
+     "sha256": "cce8b312c4be49810f4cf90f0dcdeb1a82dfa623de1ba44c55ec83475f9e9e49"
+    },
+    "maps/ad_brk/wood11.map": {
+     "bytes": 542,
+     "sha256": "790cd93cb271402698ad7f005b908847fddbb30d3c8c3d11fa8c2f327ca8e48e"
+    },
+    "maps/ad_brk/wood12.bsp": {
+     "bytes": 7978,
+     "sha256": "6a227f92bf3b6f1120efd6179bfb3de977e4be2e59495c5d757cbe1c835e3f03"
+    },
+    "maps/ad_brk/wood12.map": {
+     "bytes": 986,
+     "sha256": "01ed96a5ce6545b334dfac7dc0196472dd6c06df09ed557cec7dc820d35c1132"
+    },
+    "maps/ad_brk/wood13.bsp": {
+     "bytes": 7284,
+     "sha256": "09325ca10ebcfeb88f688c9f4521259c3c3426e9befc06c99ba405c7e20595c9"
+    },
+    "maps/ad_brk/wood13.map": {
+     "bytes": 526,
+     "sha256": "b16b33b2a46b72a4ee235674780298eac0ed27631def07a28058a775aba7078e"
+    },
+    "maps/ad_brk/wood14.bsp": {
+     "bytes": 7216,
+     "sha256": "4c9dc5afd7b51119e5c22ad36eb77d07881c454ff47ed060521172cfc3950e2c"
+    },
+    "maps/ad_brk/wood14.map": {
+     "bytes": 518,
+     "sha256": "41b51f20630df3c046ed9ca0f7d97ca403ce8c1487074fc80caf603e763e6ac1"
+    },
+    "maps/ad_brk/wood15.bsp": {
+     "bytes": 7196,
+     "sha256": "373f6e5c5da44b7c8d1a01fb701f074bbcfc52d21bb080dd04e986ffe9e1088c"
+    },
+    "maps/ad_brk/wood15.map": {
+     "bytes": 527,
+     "sha256": "eb07eae6f0afdb4b03af57bcb589e3b385632912f12d4c55257b3031270f0421"
+    },
+    "maps/ad_brk/wood16.bsp": {
+     "bytes": 7612,
+     "sha256": "05959d3486eb43afc8959f6923156a1a83ead4dad544f8caf90ba0e1c7e2bc80"
+    },
+    "maps/ad_brk/wood16.map": {
+     "bytes": 953,
+     "sha256": "c7e804e781c95336cc91a50bc246baf4fda7172ecf36ccf24f02c5f919710ab3"
+    },
+    "maps/base_brk/baserub1.bsp": {
+     "bytes": 23612,
+     "sha256": "b5320b798366587d20ab541af06babd9575e89870fb003d56a17fdf2f7f22b0c"
+    },
+    "maps/base_brk/baserub1.map": {
+     "bytes": 637,
+     "sha256": "0a5357fb3b12d9286b4d9e6e54316cfd0a33f9fda4c661b8fcd1c461d06ae73f"
+    },
+    "maps/base_brk/bz8_brk.bsp": {
+     "bytes": 12808,
+     "sha256": "219e4371cd0b22d690c6e6660ca2fca3b526618d4ccd9f37799135d2dc6dea02"
+    },
+    "maps/base_brk/bz8_brk.map": {
+     "bytes": 692,
+     "sha256": "fae1ac45d74b2a9f482eb034e0838fe5914affb57204c5215d97ebaf7199e5c8"
+    },
+    "maps/base_brk/crate_r1.bsp": {
+     "bytes": 29110,
+     "sha256": "5dd3afab4a3ad5cf4466e272324e4afad5075ca2e662cc8b1932e277a2db73a2"
+    },
+    "maps/base_brk/crate_r1.map": {
+     "bytes": 664,
+     "sha256": "ee7ce39ec0650d3cbde924b99efc91ba884778db11a961037d4493bf587fa33e"
+    },
+    "maps/base_brk/explodebox_1.bsp": {
+     "bytes": 7707,
+     "sha256": "28bfab37e5cbe722348b753de3bd9f66f47f4a9f5b80bd5c5c1659e6eae7e6c4"
+    },
+    "maps/base_brk/explodebox_1.map": {
+     "bytes": 544,
+     "sha256": "96376f1185f158bf69d6bb0c5baf347bbad27f0ccd6fccd3096da6dd7f89540b"
+    },
+    "maps/base_brk/explodebox_2.bsp": {
+     "bytes": 7107,
+     "sha256": "59d5ba28bc049f691bf28d421327e4aecf5eedaec46599d58328f0074ce0934f"
+    },
+    "maps/base_brk/explodebox_2.map": {
+     "bytes": 375,
+     "sha256": "f906dbea8598f0290af9e224a70eb71f26f3c93c10e922b2fade3f1c63e4ddd5"
+    },
+    "maps/base_brk/explodebox_3.bsp": {
+     "bytes": 10449,
+     "sha256": "0daebb987f48b5dde145998e748ab2eecf63ec69318a6b752924e4cfb6639261"
+    },
+    "maps/base_brk/explodebox_3.map": {
+     "bytes": 1698,
+     "sha256": "538e12e7706df3b8f539bf2473e7517e737657380137de1655193843210dbf3f"
+    },
+    "maps/base_brk/glass01.bsp": {
+     "bytes": 7427,
+     "sha256": "bf3f3938ab3596b6095fb58f66c0a36042e5950169dbb86b1cf3cb9076fd5bdd"
+    },
+    "maps/base_brk/glass01.map": {
+     "bytes": 907,
+     "sha256": "6f47c3ffec4cb28d3447dbf96f0b3d6e4264accd31e10b68ad83b3e30e4e32a7"
+    },
+    "maps/base_brk/grate_r1.bsp": {
+     "bytes": 32796,
+     "sha256": "a8eac6a49f8c49c4f9f1b443c9ca5c6a5f8d03d30ce240daaeee8d150f9c5067"
+    },
+    "maps/base_brk/grate_r1.map": {
+     "bytes": 2106,
+     "sha256": "e5cac190d45b0d14901947e489622680d1b9436955b18e2a0e8cb2f92e9aa011"
+    },
+    "maps/base_brk/pbt04.bsp": {
+     "bytes": 18286,
+     "sha256": "0a3321e606857ebb78d047be51c92036b53175dc392c021891cdeabd28597c3c"
+    },
+    "maps/base_brk/pbt04.map": {
+     "bytes": 699,
+     "sha256": "a8b2d3feef56b8cad384a88a9646b596d21017cb9d26278c0b3585ef589b578d"
+    },
+    "maps/base_brk/phk_03brk.bsp": {
+     "bytes": 90417,
+     "sha256": "46efed3a00ce885798ca568563a04472200359c6111682e91fc701c37d8df143"
+    },
+    "maps/base_brk/phk_03brk.map": {
+     "bytes": 1509,
+     "sha256": "29549a0e23b3651110beae8f8697c85e1e3eeb8752dcc8c253a2756e11189209"
+    },
+    "maps/base_brk/rock_sw01.bsp": {
+     "bytes": 8843,
+     "sha256": "a3acc4f42ca89efb30d5f9d7ed7c694d59ab6003bd3c665cfa4db480550fd92d"
+    },
+    "maps/base_brk/rock_sw02.bsp": {
+     "bytes": 9179,
+     "sha256": "4b3d68587a69daa68093d32195a786e8040fed763855acb94f50d02875a8ec44"
+    },
+    "maps/base_brk/rock_sw03.bsp": {
+     "bytes": 9766,
+     "sha256": "59d2841166f7ecb216df970963b3e425da20566f2fb56a7e5472f4e3c9fcfb24"
+    },
+    "maps/base_brk/sfloor4_2.bsp": {
+     "bytes": 7431,
+     "sha256": "d4f7ee45638e0f338c96cf43779410a112bb10be26a200e24187749a80b01332"
+    },
+    "maps/base_brk/sfloor4_2.map": {
+     "bytes": 833,
+     "sha256": "f285b9a96b32420f24bccb267b268e65afd50dd03fb106fad90783aa5d82c1d4"
+    },
+    "maps/base_brk/tech10_2d1.bsp": {
+     "bytes": 45558,
+     "sha256": "272aa49909de27f7b4722848497e5da38aa50b7bef17ef2ee81a1b1240c1b8b2"
+    },
+    "maps/base_brk/tech10_2d1.map": {
+     "bytes": 740,
+     "sha256": "a3766904240cbe7603e967eb3ebdd0dc895b035f0db8758a6ad217749a332904"
+    },
+    "maps/base_brk/tech10_2d2.bsp": {
+     "bytes": 45552,
+     "sha256": "71e5e52660e4aa84f56aa7b51bad024384acb69699bcec431ae3fe6c8d16fc42"
+    },
+    "maps/base_brk/tech10_2d2.map": {
+     "bytes": 733,
+     "sha256": "9d6c4dae495d96bf4b2bbf5f7e01900f16274173c63eb2e4acfb8f8e757a399f"
+    },
+    "maps/medieval_brk/ad_column1.bsp": {
+     "bytes": 14800,
+     "sha256": "f94c99425b3987ebb9eea08dd8c1b3c0e0215cc8afcd1099f7283324ff566712"
+    },
+    "maps/medieval_brk/ad_column1.lit": {
+     "bytes": 578,
+     "sha256": "c30b5af83ab23db6614ad13aff712a15971a6b35ae29ddd49f0cd3da1c1f4919"
+    },
+    "maps/medieval_brk/ad_column1.map": {
+     "bytes": 1541,
+     "sha256": "d71326b819e902d9a32f4a1961565f6ebb10d90069ba2ae0dc0be381a4c1b764"
+    },
+    "maps/medieval_brk/ad_rock1.bsp": {
+     "bytes": 352852,
+     "sha256": "9333d2d2d848e3a4490634aa4f1cc1ee3281c57ac9a498c85b043e5856ce2578"
+    },
+    "maps/medieval_brk/ad_rock1.lit": {
+     "bytes": 920,
+     "sha256": "6d2b33cbd7b3ce1a35c25a6e006a0786fe0bd0ea8be34b1911e2663ac33ea910"
+    },
+    "maps/medieval_brk/ad_rock1.map": {
+     "bytes": 2163,
+     "sha256": "d00049f1c1bdf04d98e768ece39b7d7442e34b719ec991e5715df588d6493d8b"
+    },
+    "maps/medieval_brk/ad_rock2.bsp": {
+     "bytes": 14728,
+     "sha256": "52675efa81ecae4bb87524c97148d7da60916f0e0dc3c65e99b73745aea70fec"
+    },
+    "maps/medieval_brk/ad_rock2.lit": {
+     "bytes": 383,
+     "sha256": "306d2df8cbd9d7ad755fe7e4a6734e0089b38eefa2e2e4fccacfb68c96dd8d90"
+    },
+    "maps/medieval_brk/ad_rock2.map": {
+     "bytes": 1528,
+     "sha256": "891f208f7fdae3fcf1defe7a4cdcda7a6084fbde663ed4e2ab015af18911cb96"
+    },
+    "maps/medieval_brk/ad_rock3.bsp": {
+     "bytes": 352160,
+     "sha256": "bf041a139ed9be638cd1c548139fffca3ceeddefdad2334fcc2639018833110a"
+    },
+    "maps/medieval_brk/ad_rock3.lit": {
+     "bytes": 356,
+     "sha256": "19a61c05d08dd726a9d00174eb3eb1dbdd16da3e0e62ab93d691620aa71add83"
+    },
+    "maps/medieval_brk/ad_rock3.map": {
+     "bytes": 1878,
+     "sha256": "d0049b763f7fd8f25b2176984341421d704f9b50571b24168c60889fdbad5e20"
+    },
+    "maps/medieval_brk/ad_rock4.bsp": {
+     "bytes": 352704,
+     "sha256": "578e7d2dc0eff7bf5ac21b04919d1e137296824182d4809991a27a83addeba75"
+    },
+    "maps/medieval_brk/ad_rock4.lit": {
+     "bytes": 311,
+     "sha256": "3af5d5c9613dd5a1fa09a40b02891bf7153892db8505528b7d3315ce251bfff7"
+    },
+    "maps/medieval_brk/ad_rock4.map": {
+     "bytes": 1889,
+     "sha256": "472f41679eedc00096e8042935ad5287f4598940ef294b8175cccd196dcb6f86"
+    },
+    "maps/medieval_brk/az_ice05.bsp": {
+     "bytes": 98664,
+     "sha256": "b8b2aa063250f6dcc388ead43ff66133c8fa14b1c30afa17c2fce8f2b2c9fd81"
+    },
+    "maps/medieval_brk/az_ice05.lit": {
+     "bytes": 617,
+     "sha256": "e3e8aa044b60a26d643ff87937f83602cdffcebb948ea7ae22148e7952faa18b"
+    },
+    "maps/medieval_brk/az_ice05.map": {
+     "bytes": 3094,
+     "sha256": "dbca0fea0a986137f9b4a6fbb916cf3de830ba4a60738830cc6e1bd554f561f1"
+    },
+    "maps/medieval_brk/az_kbr1.bsp": {
+     "bytes": 7476,
+     "sha256": "2a2cd33b87f511d4c7fc25a812c632fb07c385b372e89fa900fd0f8ce8146076"
+    },
+    "maps/medieval_brk/az_kbr1.lit": {
+     "bytes": 92,
+     "sha256": "580ff7adf91b63bcd7f35e27059295b0a5fc404468e32e5d5f3323b5a822fb27"
+    },
+    "maps/medieval_brk/az_kbr1.map": {
+     "bytes": 863,
+     "sha256": "3b9d9842f17fb140b23337b452cfc8d49151410640384868a0003bd472dd0d5c"
+    },
+    "maps/medieval_brk/az_kbr1.pts": {
+     "bytes": 178,
+     "sha256": "22cf782552b8a3da946cfa0fa044cffd08f2b0ab50e588c9b68d89a373f026b0"
+    },
+    "maps/medieval_brk/az_kjw1.bsp": {
+     "bytes": 9424,
+     "sha256": "06f271813935ecb90a425d6c943bd53b207fb9d370ec42bb1228af92fe4413d1"
+    },
+    "maps/medieval_brk/az_kjw1.lit": {
+     "bytes": 380,
+     "sha256": "30e6270550b5a78bfaa31df0c6e477d6980eefd380abc2e2aaf7003dbe544f77"
+    },
+    "maps/medieval_brk/az_kjw1.map": {
+     "bytes": 1825,
+     "sha256": "61e8f8f45b2fb0e0766b125bae58b54b36cb45b6d856c7c06814681f52eb91aa"
+    },
+    "maps/medieval_brk/az_kjw1.pts": {
+     "bytes": 120,
+     "sha256": "f7d0f45d90befed57df8dd476bcd10293481eb932925853e3fdbc93a55991a49"
+    },
+    "maps/medieval_brk/az_rtex01.bsp": {
+     "bytes": 97932,
+     "sha256": "ce36fbfdd6f46f5aa7740598689fb2c7de50fa58adda9d4a8a3023ad31194367"
+    },
+    "maps/medieval_brk/az_rtex01.lit": {
+     "bytes": 692,
+     "sha256": "5fe28d309679e9871f14a9c3833184c9ad711fa2bd93adc330a34fd599032a6d"
+    },
+    "maps/medieval_brk/az_rtex01.map": {
+     "bytes": 2875,
+     "sha256": "6cc8f787b54565b3c9dffe9eec20c44d66a68b12fd555bad65bb25f03a2aa7e9"
+    },
+    "maps/medieval_brk/az_wood1.bsp": {
+     "bytes": 7560,
+     "sha256": "373c0b96905055b6b036272c954d7eaf3557d79d62b056ab9a472fb0cd27de83"
+    },
+    "maps/medieval_brk/az_wood1.lit": {
+     "bytes": 176,
+     "sha256": "67ce559200158ce198e5a93a94dd4a440ae607fedc5b3093c288049ce5f50151"
+    },
+    "maps/medieval_brk/az_wood1.map": {
+     "bytes": 950,
+     "sha256": "4fb7eae852ba72528b34d6a0947497eeeab1e1307aa1c4be552628432007c86e"
+    },
+    "maps/medieval_brk/azr1.bsp": {
+     "bytes": 13842,
+     "sha256": "e00518c5ad3beee852a6135184423d4ca985b17b2f1d2cfebc60e82f91582f26"
+    },
+    "maps/medieval_brk/azr1.map": {
+     "bytes": 1193,
+     "sha256": "ef3affe9788b130826f2b1632b5461eaaf15d630587c12c5a875f6042b0ae99c"
+    },
+    "maps/medieval_brk/azr2.bsp": {
+     "bytes": 13571,
+     "sha256": "687097f4773430ca297db9c1d8133b035c8ca1e5d574943a4caa34eef262f003"
+    },
+    "maps/medieval_brk/azr2.map": {
+     "bytes": 1319,
+     "sha256": "22b2084665b2882c976da1dc840a19b151cd44daa524955ddab9ec64e9c3233e"
+    },
+    "maps/medieval_brk/azr3.bsp": {
+     "bytes": 13571,
+     "sha256": "187a6607641c00aa6ee662af52f1b2899d5ca606e469408dd2c94d67dd2ab465"
+    },
+    "maps/medieval_brk/azr3.map": {
+     "bytes": 1338,
+     "sha256": "5e551a8ebefc386b1336e814a44e29ae6781e6da5bc929cb232674853c46a143"
+    },
+    "maps/medieval_brk/booksh1w_brk1.bsp": {
+     "bytes": 23869,
+     "sha256": "dbc342e95245a12598aade308195a3234829225944692c45c8fec792d03f17c3"
+    },
+    "maps/medieval_brk/booksh1w_brk1.map": {
+     "bytes": 793,
+     "sha256": "a9d2fe494267551f3d1638c7963bab47d292be250417f78286b39059af836af5"
+    },
+    "maps/medieval_brk/booksh1w_brk2.bsp": {
+     "bytes": 23663,
+     "sha256": "4b8cd15ae7812d581064800bbcf64cab62c3d5ecfb03c23ff2b498694a0cb708"
+    },
+    "maps/medieval_brk/booksh1w_brk2.map": {
+     "bytes": 661,
+     "sha256": "19c13935f0b045fadd9c739680de7155f0e4d29c86ef3e6950d07f265b1ef1a3"
+    },
+    "maps/medieval_brk/booksh1w_brk3.bsp": {
+     "bytes": 23700,
+     "sha256": "1fc3c7a685f5662779f4c6ad0fb02099396504dcf55eef09474183aff69861c1"
+    },
+    "maps/medieval_brk/booksh1w_brk3.map": {
+     "bytes": 746,
+     "sha256": "bd10960b3af925cf2a33bb0629d1a522de5f54ec05938b36378871fd7de0b9f3"
+    },
+    "maps/medieval_brk/booksh1w_brk5.bsp": {
+     "bytes": 23639,
+     "sha256": "851a02aced76ba77894ba744c5c781ff350a42b93216e095f75938fc95ee39a8"
+    },
+    "maps/medieval_brk/booksh1w_brk5.map": {
+     "bytes": 759,
+     "sha256": "c92ec0ad3d3a5c6588557b5f3c9c000cd1c141a4d9c3b35333d859e75c677568"
+    },
+    "maps/medieval_brk/brick2_4brk1.bsp": {
+     "bytes": 9004,
+     "sha256": "86fb182b011385225d5be8b2a2ba0763286a5a2a5880fdda6fc238d8e6a5212f"
+    },
+    "maps/medieval_brk/brick2_4brk1.map": {
+     "bytes": 1375,
+     "sha256": "208cf3d2a51b0aa4a45cd237786a9303b70a63a85e991a7f8675634bea6295ed"
+    },
+    "maps/medieval_brk/brick2_4brk2.bsp": {
+     "bytes": 7265,
+     "sha256": "151471ef184c02141716225e4403e97a69190bd8a3e9645cf2d52aeb5dce591d"
+    },
+    "maps/medieval_brk/brick2_4brk2.map": {
+     "bytes": 603,
+     "sha256": "cdd5762f851cec464b27e9bfc91c0eab8cb26e69a8b050ac1bd9b0eb662dbf7b"
+    },
+    "maps/medieval_brk/brick2_brk2.bsp": {
+     "bytes": 25323,
+     "sha256": "0d8c4dc3202bcc9f26dfd42ca555b99d0010c63b977cd058646a8e8ad4486eea"
+    },
+    "maps/medieval_brk/brick2_brk2.map": {
+     "bytes": 1378,
+     "sha256": "daeae48ab2f6fca712da2413b65c80c6a944e537571def2d153976b0175d8768"
+    },
+    "maps/medieval_brk/brick2_brk3.bsp": {
+     "bytes": 24310,
+     "sha256": "5f94a5e271bb5b921e4534be8690f005bc258e484cb842a6ead0af9aac29fcfb"
+    },
+    "maps/medieval_brk/brick2_brk3.map": {
+     "bytes": 905,
+     "sha256": "1639469c5fe31540811a8bb95d959844d200102cd19f60d1d5e9c3472477e2d2"
+    },
+    "maps/medieval_brk/brick2_brk4.bsp": {
+     "bytes": 23548,
+     "sha256": "e2049e826c103f2afbb5d0a4b69d45089d0bdcf6bd60646d6ae79c99e9a9a976"
+    },
+    "maps/medieval_brk/brick2_brk4.map": {
+     "bytes": 582,
+     "sha256": "b3528f92f4ecf8099a7bfbf3285f21312c501536b66e02b566a7e38474aa608c"
+    },
+    "maps/medieval_brk/city2_3d1.bsp": {
+     "bytes": 7358,
+     "sha256": "efc80ba0aab1284e2bcec652cc3a2748890c45d6905335f61483eab2851f7c81"
+    },
+    "maps/medieval_brk/city2_3d1.map": {
+     "bytes": 739,
+     "sha256": "ff9c2ebe0034d188443e3a72753d4ecad2a69706a4a06c114f9147f507d10b30"
+    },
+    "maps/medieval_brk/city2_3rd.bsp": {
+     "bytes": 7156,
+     "sha256": "6146e0e5961857308f2ef550213ec647ad810a97359d0946cc07f610e0f03006"
+    },
+    "maps/medieval_brk/city4_2_brk1.bsp": {
+     "bytes": 7435,
+     "sha256": "42a4cbd73804a8458a8369fdbd19ee6b3b4597b18583c242bf77b0122ddc9c1a"
+    },
+    "maps/medieval_brk/city4_2_brk1.map": {
+     "bytes": 648,
+     "sha256": "50b744f4af85aa3c0158ae0330808840710c7ee95c1bda8155cb81b4b247fc74"
+    },
+    "maps/medieval_brk/city4_2_brk2.bsp": {
+     "bytes": 7179,
+     "sha256": "cc2ddcb8877dc1b49ec2c408d6b869a35dd7b6590782525af567905d75a3ada0"
+    },
+    "maps/medieval_brk/city4_2_brk2.map": {
+     "bytes": 520,
+     "sha256": "e9309b8ec24126fd952443ae6bee72df46ba04fb4d0925b33d41c603af9ac5b3"
+    },
+    "maps/medieval_brk/city4_2_brk3.bsp": {
+     "bytes": 10009,
+     "sha256": "7f9a27098101f70090c3aff7fd6731effd2750e8c2b7fdbbb0a9f3146be94045"
+    },
+    "maps/medieval_brk/city4_2_brk3.map": {
+     "bytes": 1575,
+     "sha256": "c352d889a3bed731b7c54e38d7ed35e6fa860d2f6f69eb91319f4043423d7aa8"
+    },
+    "maps/medieval_brk/city6_8brk1.bsp": {
+     "bytes": 7187,
+     "sha256": "bcf4b2815c96308ffc1ab3467ac8b2dd4c25be47d618fd82536ba83bf74a05fc"
+    },
+    "maps/medieval_brk/city6_8brk1.map": {
+     "bytes": 529,
+     "sha256": "2db1be71ce1b1e8bf1e8a5c4c7f2802345aa19c281fd43f2b18d205cbd06bfca"
+    },
+    "maps/medieval_brk/city6_8brk2.bsp": {
+     "bytes": 7298,
+     "sha256": "3b7fd08defa832be1c3f3e40efc6d54d13af6714180be810f6527188f332fbff"
+    },
+    "maps/medieval_brk/city6_8brk2.map": {
+     "bytes": 611,
+     "sha256": "ed29b0773cb700d4b8212f9e28b23edac2d212f469b4a1406538df2b066fcbb2"
+    },
+    "maps/medieval_brk/floor015_brk1.bsp": {
+     "bytes": 12862,
+     "sha256": "5bfae9b09777fad7f26f80b5acc27e187e2259ac5c79ad32ab2a30d154e5889b"
+    },
+    "maps/medieval_brk/floor015_brk1.lit": {
+     "bytes": 179,
+     "sha256": "5d64872b2341768efce6c27686555200246e03d346a2e15089e002d53b1b348f"
+    },
+    "maps/medieval_brk/floor015_brk1.map": {
+     "bytes": 827,
+     "sha256": "08f5b26ee0ebb26416e6a1ed660e197b1ea113a553f5c7a1d26a6070b5cbdac8"
+    },
+    "maps/medieval_brk/floor015_brk2.bsp": {
+     "bytes": 12861,
+     "sha256": "377b50dac34c3789fe8a7bcf6a5b3cedda0f3ba91225135ffc9a2f41abe41e35"
+    },
+    "maps/medieval_brk/floor015_brk2.lit": {
+     "bytes": 188,
+     "sha256": "402bfba12b94cd1b3a40f1052830d4e4fa3b4cb103b196c089f4965e94766bd5"
+    },
+    "maps/medieval_brk/floor015_brk2.map": {
+     "bytes": 828,
+     "sha256": "a45245e0f19cc98f29bcc88c9173118b65058d25ff1c043aaca876353bc67531"
+    },
+    "maps/medieval_brk/floor015_brk3.bsp": {
+     "bytes": 13185,
+     "sha256": "52e2b8d426e479bffc8d518a4d8aa5d5a5dc437dbd761c7074992838ccfd070b"
+    },
+    "maps/medieval_brk/floor015_brk3.lit": {
+     "bytes": 218,
+     "sha256": "dabacc9c3ffdc3bae8c008bedfb683babaca23f6e5b0ca5e35b9c39f9d86f402"
+    },
+    "maps/medieval_brk/floor015_brk3.map": {
+     "bytes": 1078,
+     "sha256": "5235ba02c52ba6dc678f052e4efbad43b9f7d63f858c5f732519f6436246733d"
+    },
+    "maps/medieval_brk/plat_brk.bsp": {
+     "bytes": 59896,
+     "sha256": "367ec651b3cded1ecdf22305a3b48490d3df3078d556d4c7fadfb392ae12ad33"
+    },
+    "maps/medieval_brk/plat_brk.map": {
+     "bytes": 2052,
+     "sha256": "fe52fffba97e8df9acfe4607c9b08d9eb5f4559b44d8c0f6fdbd3af6a0cbf8d6"
+    },
+    "maps/medieval_brk/rock_sw01.bsp": {
+     "bytes": 8843,
+     "sha256": "a3acc4f42ca89efb30d5f9d7ed7c694d59ab6003bd3c665cfa4db480550fd92d"
+    },
+    "maps/medieval_brk/rock_sw01.map": {
+     "bytes": 1371,
+     "sha256": "0e4d621fba3a9806ffdf2bffda89e4d05231513b6f7986d504722d1b99c21a91"
+    },
+    "maps/medieval_brk/rock_sw02.bsp": {
+     "bytes": 9179,
+     "sha256": "4b3d68587a69daa68093d32195a786e8040fed763855acb94f50d02875a8ec44"
+    },
+    "maps/medieval_brk/rock_sw02.map": {
+     "bytes": 1631,
+     "sha256": "82bbf3c701301a80f55619bdac2680d9713432d8fe991838bfb7559830225322"
+    },
+    "maps/medieval_brk/rock_sw03.bsp": {
+     "bytes": 9766,
+     "sha256": "59d2841166f7ecb216df970963b3e425da20566f2fb56a7e5472f4e3c9fcfb24"
+    },
+    "maps/medieval_brk/rock_sw03.map": {
+     "bytes": 1526,
+     "sha256": "300f4c4f56cc9f6425cc8999484e18326555c57b8f53d9f42c36a4345b850d2c"
+    },
+    "maps/medieval_brk/rock_sw04.bsp": {
+     "bytes": 9836,
+     "sha256": "72854269a33665022dee9c30e53e6124bc2bba25ad34d2a3d86302e50ad795c1"
+    },
+    "maps/medieval_brk/rock_sw04.map": {
+     "bytes": 1605,
+     "sha256": "e2b3e6e53c11de10d0de4b7374d43a09be1622766cb3ff60c9e9cec8688747f9"
+    },
+    "maps/medieval_brk/rot_p.bsp": {
+     "bytes": 13554,
+     "sha256": "afcc7dc6512bba89ceec9e10bfa8256ecd043d34c1af57f33a199509500164ff"
+    },
+    "maps/medieval_brk/rot_p.map": {
+     "bytes": 2518,
+     "sha256": "c60e36e827e052cea6ca5c6c2d022b5da051090ee2accf8807f5703ec8acc79a"
+    },
+    "maps/medieval_brk/waa1.bsp": {
+     "bytes": 23869,
+     "sha256": "739aa8d0753e691020013539356d2c2e10b9d0b82c63bcc694080afe33bc585e"
+    },
+    "maps/medieval_brk/waa1.map": {
+     "bytes": 765,
+     "sha256": "f2e7bbba974ffde1e4178be825034e555ca491fffedbf007e62589214af82f0f"
+    },
+    "maps/medieval_brk/wbrick15_brk.bsp": {
+     "bytes": 7969,
+     "sha256": "0dcbd483c300f1be58a216b6d64ea385dd489babdc70868e483fb496c4dd4c38"
+    },
+    "maps/medieval_brk/wbrick15_brk.map": {
+     "bytes": 899,
+     "sha256": "43789ad5bb908aa7fb8e8893db766ce0e479cc547e31aa8de6fe1b4bd6093015"
+    },
+    "maps/medieval_brk/win1ah_brk.bsp": {
+     "bytes": 34981,
+     "sha256": "d549b60245213678c222499299e43654c25f838ed42898a25ec284d933f56b64"
+    },
+    "maps/medieval_brk/win1ah_brk.map": {
+     "bytes": 897,
+     "sha256": "da6859a14f291bef23c990977c0fce7e21ee2c790318cce46e36a8388e87fb39"
+    },
+    "maps/medieval_brk/win1ah_brk2.bsp": {
+     "bytes": 34873,
+     "sha256": "87416124f6e04adaaa5ed9144fa60e048dc03606bc294d89d99295a7c8cb2487"
+    },
+    "maps/medieval_brk/win1ah_brk2.map": {
+     "bytes": 901,
+     "sha256": "5d9a1aefeca5acfdbb25cad5489f5bcb41c89f3c9b92a3d305da0f462c439ec2"
+    },
+    "maps/medieval_brk/wiz14_brk1.bsp": {
+     "bytes": 8961,
+     "sha256": "cb45306588dc69d44422d475c0481f67a76638fe2502c16c28a8f87fa43f6787"
+    },
+    "maps/medieval_brk/wiz14_brk1.map": {
+     "bytes": 1262,
+     "sha256": "46200a77c401035e45d339d8106263e7210ed66e373be74f65687c5d1eb83124"
+    },
+    "maps/medieval_brk/wiz14_brk2.bsp": {
+     "bytes": 7338,
+     "sha256": "871684ecf4507da9773ca5568ccdd0a27173d2f35922b379a19f95e9252a777f"
+    },
+    "maps/medieval_brk/wiz14_brk2.map": {
+     "bytes": 652,
+     "sha256": "97a58529ea21e8127050b0f1e3305e4616b1970232e6517aa652061f49ffc9e0"
+    },
+    "maps/medieval_brk/ws14_brk1.bsp": {
+     "bytes": 7987,
+     "sha256": "ee96dcf614d940d9f887035be0781ad941fc5f76a0f0e553ec3592ae00af1794"
+    },
+    "maps/medieval_brk/ws14_brk1.map": {
+     "bytes": 948,
+     "sha256": "022d130b741c8976f529288f6030fabd2040991efd8bb0a6542dc1508c0b061c"
+    },
+    "maps/medieval_brk/ws14_brk2.bsp": {
+     "bytes": 9003,
+     "sha256": "6aa46294d8fffe55db6f2e6a9d30341fe07a9252b0066ff575c692d0b149f7af"
+    },
+    "maps/medieval_brk/ws14_brk2.map": {
+     "bytes": 1375,
+     "sha256": "8f175f2e3ac8a760fcb7d25da5a30cea149b55349fa0e0d20b2a8c0b080aa5b0"
+    },
+    "maps/medieval_brk/ws14_brk3.bsp": {
+     "bytes": 8944,
+     "sha256": "282944bfbd49b6dcc0aa0d67253432d88c63212ea564a9c6b8909a9b96f8946a"
+    },
+    "maps/medieval_brk/ws14_brk3.map": {
+     "bytes": 1282,
+     "sha256": "6ecd83ba25e15f363f271078c73f6c460babf95ea63340a855dfa182ec47e4b4"
+    },
+    "maps/rtex_brk/022a.bsp": {
+     "bytes": 17448,
+     "sha256": "3557f9518ca0982c871dd344ea5069e5128645029ea428de26ef991881170a59"
+    },
+    "maps/rtex_brk/022a.map": {
+     "bytes": 691,
+     "sha256": "50e0375bf596265b893e56996dbddfad26af2e50bb9af473dc2115e18b11dc02"
+    },
+    "maps/rtex_brk/022b.bsp": {
+     "bytes": 17608,
+     "sha256": "083fdbd34b34b47c5dd9dd58f4e3e0fa3debbedd554db4ce81791033349451fa"
+    },
+    "maps/rtex_brk/022b.map": {
+     "bytes": 825,
+     "sha256": "26d8800f4cfb0706ad363e958846d87755b4871792d1ac1f00b5b51fd7550777"
+    },
+    "maps/rtex_brk/022c.bsp": {
+     "bytes": 17820,
+     "sha256": "8c6b933d2cd323eba623727226ea6cb1f968e0401093f93d229d229a7a5b225d"
+    },
+    "maps/rtex_brk/022c.map": {
+     "bytes": 894,
+     "sha256": "835d4d09490552859dc79ad527bcd08af8afedfa7a863148c62f2f58742e9014"
+    },
+    "maps/rtex_brk/022d.bsp": {
+     "bytes": 17592,
+     "sha256": "0580ec01633972b2fff28c5d4b9a71766d3f1ed6fae387dff34ca691ff829e38"
+    },
+    "maps/rtex_brk/022d.map": {
+     "bytes": 784,
+     "sha256": "238fc24be385d3994586c34555e74ecbb7677aa7567bbf317947276c14b62107"
+    },
+    "maps/rtex_brk/330a.bsp": {
+     "bytes": 7928,
+     "sha256": "a446db4116b8c33f46745cf815ba9309e69591d919838006c81a9b0a5b00c7d4"
+    },
+    "maps/rtex_brk/330a.map": {
+     "bytes": 691,
+     "sha256": "964103ee6422dd3b815472c9f29126741e06517623dad050fba18a9867451903"
+    },
+    "maps/rtex_brk/330b.bsp": {
+     "bytes": 8088,
+     "sha256": "727d22fad028bac645a53ac5a425618e30575735958496b7a1ac86cfbc562e1a"
+    },
+    "maps/rtex_brk/330b.map": {
+     "bytes": 825,
+     "sha256": "807bdb97ab58709fd96cfa0e7b65cb5d377257b862eef2673606901d70b84108"
+    },
+    "maps/rtex_brk/330c.bsp": {
+     "bytes": 8300,
+     "sha256": "b25471a1f0e7fdd066dda47860ae956db2b2c4758a426b39b8a82e6b4c6d1b72"
+    },
+    "maps/rtex_brk/330c.map": {
+     "bytes": 894,
+     "sha256": "13241951b0d3cd61a71e0fe80071a1df65e369eba44aabdf3401f3ba5aa55a7f"
+    },
+    "maps/rtex_brk/330d.bsp": {
+     "bytes": 8072,
+     "sha256": "8f83245e973c42e9908b6215c5effc0f0581d654e5e8e67a6e77493f79de3e6d"
+    },
+    "maps/rtex_brk/330d.map": {
+     "bytes": 784,
+     "sha256": "f0e46c1efc3d5a814675f5760a33a2e6bc4163974ff64a4c1f88ab70c50fbb68"
+    },
+    "maps/rtex_brk/340a.bsp": {
+     "bytes": 13368,
+     "sha256": "e8a605fdff44ef59b4657a43a67cfb24d2d62f150b210a0761f69ed5f559215c"
+    },
+    "maps/rtex_brk/340a.map": {
+     "bytes": 691,
+     "sha256": "3678f5058497a6067c7ffb4d452e706af588e0aedfd30bfa2d43f1902333e7ec"
+    },
+    "maps/rtex_brk/340b.bsp": {
+     "bytes": 13528,
+     "sha256": "d92cc6afb7ae74965a8bb2a753909e2dc6c064b5fb2c9c463c95123531ba337d"
+    },
+    "maps/rtex_brk/340b.map": {
+     "bytes": 825,
+     "sha256": "29f243aa1c347358e34383f4ffb2d129f710829022524237585041c7840a02cb"
+    },
+    "maps/rtex_brk/340c.bsp": {
+     "bytes": 13740,
+     "sha256": "882a110b1a7e26481e5dd37858d5229c0273bc98ab8a2ab59f318e2b76080fac"
+    },
+    "maps/rtex_brk/340c.map": {
+     "bytes": 894,
+     "sha256": "069e17115ae35cf0fdaa9ceb8b3a67065360d4fc03f91036ba453b6b6745d77b"
+    },
+    "maps/rtex_brk/340d.bsp": {
+     "bytes": 13512,
+     "sha256": "96a6133331679ad8eb75d8581e8be12c6822d2048c18a1e704281a6e4cc0737c"
+    },
+    "maps/rtex_brk/340d.map": {
+     "bytes": 784,
+     "sha256": "b8197ea047f14d175e5b9234dcc9b625f04124b175bb0fd80da7ceffe056b00c"
+    },
+    "maps/rtex_brk/413ra.bsp": {
+     "bytes": 7972,
+     "sha256": "a3cc5962750f55c398dfaf53cb4d8394f1100c752ca9797f053ec2710acd995d"
+    },
+    "maps/rtex_brk/413ra.map": {
+     "bytes": 769,
+     "sha256": "b0a3052bfb352684f97fb7bca8fdc3d7b135ae5e3fca491d190d09423836da46"
+    },
+    "maps/rtex_brk/413rb.bsp": {
+     "bytes": 9204,
+     "sha256": "e36bf5d23b3dcaf96075b1b441ebf6424da62cb2d04ff14f04da4e9956711094"
+    },
+    "maps/rtex_brk/413rb.map": {
+     "bytes": 1682,
+     "sha256": "6be0d7cbae08ffccbb1ea9dedf03bc6f8c9b6be93c6c27d5e964e3b4f4538a52"
+    },
+    "maps/rtex_brk/413rc.bsp": {
+     "bytes": 10340,
+     "sha256": "4d57717cc2fb9db560e724df4937f7c496d77d1df6d70e6619ba686338152e79"
+    },
+    "maps/rtex_brk/413rc.map": {
+     "bytes": 1909,
+     "sha256": "71c9812cdf0647bb89fcd2a911a664b7a8dea382b0fe58e4e834a24354a23b38"
+    },
+    "maps/rtex_brk/413rd.bsp": {
+     "bytes": 13356,
+     "sha256": "573149ae9d1f687b0ddc0a702116357b4556e20ae8d62b7b32b3c5b41f227088"
+    },
+    "maps/rtex_brk/413rd.map": {
+     "bytes": 3217,
+     "sha256": "f40b142b102fefefdaf6594c2d1410f370fd8491a009ecfc6dada46c55f262d2"
+    },
+    "maps/rtex_brk/wood3_1a.bsp": {
+     "bytes": 7552,
+     "sha256": "8884a645d6193052aeba7043c139b3eb4cf8ace2e62ed6e9181d51f90cae4806"
+    },
+    "maps/rtex_brk/wood3_1a.map": {
+     "bytes": 1007,
+     "sha256": "5322a91b2aad8cf58095fb513e58317d738469c168b78f770307c3ece580fbf9"
+    },
+    "maps/rtex_brk/wood3_1b.bsp": {
+     "bytes": 7096,
+     "sha256": "9d7d44ba1c929fae0bf702ec834394c9da23c199cf742f9c7021bec00f33c056"
+    },
+    "maps/rtex_brk/wood3_1b.map": {
+     "bytes": 516,
+     "sha256": "158e6d102aaeb8dd7add01eecd7e05b4c711a20d7d7134d1bdce417fbe1b2072"
+    },
+    "maps/rtex_brk/wood3_1c.bsp": {
+     "bytes": 7144,
+     "sha256": "f292d3b9cabaa0332d7c3f6abd66420ad9ef80217f32223bd67315fa8967d908"
+    },
+    "maps/rtex_brk/wood3_1c.map": {
+     "bytes": 517,
+     "sha256": "f853df961fdcebd569943bad596dceb464c6317e44f3d77ce4def17295b37c00"
+    },
+    "maps/rtex_brk/wood3_1d.bsp": {
+     "bytes": 7804,
+     "sha256": "8e6ffa915db57d7cb958c7210e0abc35ff552713a5aa19a1ccb531a7d45bd504"
+    },
+    "maps/rtex_brk/wood3_1d.map": {
+     "bytes": 883,
+     "sha256": "d370c44a047023843caf08a41098bd3852526b614ae074c228cc6ad4e76d4aa9"
+    },
+    "maps/speedbz_brk/crate_r1.bsp": {
+     "bytes": 29110,
+     "sha256": "5dd3afab4a3ad5cf4466e272324e4afad5075ca2e662cc8b1932e277a2db73a2"
+    },
+    "maps/speedbz_brk/crate_r1.map": {
+     "bytes": 664,
+     "sha256": "ee7ce39ec0650d3cbde924b99efc91ba884778db11a961037d4493bf587fa33e"
+    },
+    "maps/speedbz_brk/door1.bsp": {
+     "bytes": 31200,
+     "sha256": "6df38f4db1bfd725dd7384b45e38d070fd4b514139a8e649aea3e640377a073d"
+    },
+    "maps/speedbz_brk/door1.map": {
+     "bytes": 1419,
+     "sha256": "17bf053113ed5cc14e99ef2880e5478ebace7d59de4797fc6cbfe3586d688494"
+    },
+    "maps/speedbz_brk/door2.bsp": {
+     "bytes": 29732,
+     "sha256": "8f58cd2f2e76fbb36a007ed7986671092b880d01dfcb9a087e93cd11240d2baf"
+    },
+    "maps/speedbz_brk/door2.map": {
+     "bytes": 726,
+     "sha256": "3fac703869c9ebb4eabfbe8f180fec752812eea0aa68c5f5574c5cf2496c3931"
+    },
+    "maps/speedbz_brk/door3.bsp": {
+     "bytes": 26516,
+     "sha256": "77f003456362f2b7ca424491485ad2d20b162598527765e5e78628ee7e6ad172"
+    },
+    "maps/speedbz_brk/door3.map": {
+     "bytes": 1247,
+     "sha256": "e56d45f63dcb0d86a0039ea443109d8c8d116fa18331a2328e90f74a891ab9d2"
+    },
+    "maps/speedbz_brk/door4.bsp": {
+     "bytes": 24020,
+     "sha256": "930881a45210317dd3550b04b20d2446cf92c8c613d4aa295a5c77810b77b3f2"
+    },
+    "maps/speedbz_brk/door4.map": {
+     "bytes": 611,
+     "sha256": "f4a68b8f4d081ff0febc276c51b5484c96e4b044eab6e20069ae84ac7c5a0ac2"
+    },
+    "maps/speedbz_brk/rock1.bsp": {
+     "bytes": 89984,
+     "sha256": "c87f60de56cfd5a932cf33d23d6e83b0fd16518001dd8fa7be84da9c3176b5b5"
+    },
+    "maps/speedbz_brk/rock1.map": {
+     "bytes": 980,
+     "sha256": "29e5bd54316e6f325d71a33051ee3a5b6c213f927222931bb35cdcc1820cc87a"
+    },
+    "maps/speedbz_brk/rock2.bsp": {
+     "bytes": 90012,
+     "sha256": "443e51be48da3594545d347ee056f3973b0360268eb6c03653d7b3af622c553e"
+    },
+    "maps/speedbz_brk/rock2.map": {
+     "bytes": 991,
+     "sha256": "40b6b9f23f788c08f362f2336048bbe1260f181d7e76de2591ea7aefa03f4b09"
+    },
+    "maps/speedbz_brk/spdcrate_r1.bsp": {
+     "bytes": 12844,
+     "sha256": "30fa3f373efefcf7db68a9acbb0eb282a0b2ea54d26db92eaaad444035462791"
+    },
+    "maps/speedbz_brk/spdcrate_r1.map": {
+     "bytes": 807,
+     "sha256": "c18735f305c2496a4801ed1a5bc1297f2d72e55824f7222a265ac5788552fc68"
+    },
+    "maps/speedbz_brk/speedbzvent1.bsp": {
+     "bytes": 15248,
+     "sha256": "bcfe36bf57cb82e5188b86af3e5bf568038ef5a50d0ebce43024155b7276008d"
+    },
+    "maps/speedbz_brk/speedbzvent1.map": {
+     "bytes": 2053,
+     "sha256": "7d447bc22e440e685648d8b39e051bce7c1b847e3f777ac092ab1104b79242a1"
+    },
+    "maps/speedbz_brk/speedbzvent2.bsp": {
+     "bytes": 14104,
+     "sha256": "8fb1e76688e27767ce77c5d7b3486048adfa284e011b91007730d424eb55ca61"
+    },
+    "maps/speedbz_brk/speedbzvent2.map": {
+     "bytes": 1381,
+     "sha256": "44cfc0509c9455865df334c1ca5bdfca49cf0fae4dab372cac99e6eeb76b438c"
+    }
+   },
    "sha256": "e77927ce2b3aaf7d708de67a7116fbe9319d7d3dfdf1b207945cef66582a17db",
    "timestamp": "2023-07-26T23:02:16.000Z"
   },
   "rotj/pak2.pak": {
    "bytes": 9102012,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 94990,
+     "sha256": "e790b189b1df23f116097b45f5ed391fd210319ecfa000d029b367a7c3d32ab5"
+    },
+    "maps/bmodels/az_chain1.bsp": {
+     "bytes": 219668,
+     "sha256": "4d2648c6dd850b04d48e9631ad02756ecf78d85f56810ff7b9db131a6fe641a3"
+    },
+    "maps/bmodels/az_chain1.lit": {
+     "bytes": 33272,
+     "sha256": "1daab5bb58dbf2c73968dc9db26cf0b0bd78652d491788d0a6124aaa9a9b6f4a"
+    },
+    "maps/bmodels/az_chain1.map": {
+     "bytes": 96430,
+     "sha256": "2b6c77f844eaf5a371b36c13cf512a24d8cd39095cdc04eddd64cd571060d098"
+    },
+    "maps/bmodels/az_chain2.bsp": {
+     "bytes": 333820,
+     "sha256": "746e38bbb4cebb63ac3344e944f24b874b9fd3ed584017bb599e027508cc6187"
+    },
+    "maps/bmodels/az_chain2.lit": {
+     "bytes": 22130,
+     "sha256": "c6ebc72f8dcaa06422eaf71e08771f76105ddd39c3ee6784d40083df67d1cf32"
+    },
+    "maps/bmodels/az_chain2.map": {
+     "bytes": 148314,
+     "sha256": "e9cb3cddd08835aed7b1eed8867a67b06fee9db20dd7584830b8918d4af169ea"
+    },
+    "maps/bmodels/az_chain3.bsp": {
+     "bytes": 308800,
+     "sha256": "6b78b5a83f2f71a316e85086e12b7a1f66abaf28b02a53076433e3b2b3a20fee"
+    },
+    "maps/bmodels/az_chain3.lit": {
+     "bytes": 20684,
+     "sha256": "28870bf7c7f011206290fe69c7b6e2501c27fba21bea2ae6767e8d85a4ff56e7"
+    },
+    "maps/bmodels/az_chain3.map": {
+     "bytes": 110405,
+     "sha256": "64eee084713fdb7da2ec9f9dbc7c482930d9a871d86fd0912d32ddf52063b1aa"
+    },
+    "maps/bmodels/m_bchains1.bsp": {
+     "bytes": 74963,
+     "sha256": "73beb2dc0b953e096e69a4e049af380e99c98ce1872b4da00c858be36d4e973a"
+    },
+    "maps/bmodels/m_bchains1.map": {
+     "bytes": 43470,
+     "sha256": "ecd781a6601c6fca262909cb2e116a222de2e5aa5417dd36d4475d5c433459af"
+    },
+    "maps/bmodels/m_bchains2.bsp": {
+     "bytes": 83651,
+     "sha256": "e23fad6717790c08e661748398754e60944527eb6e48c0f2c0ffbdba73cf95db"
+    },
+    "maps/bmodels/m_bchains2.map": {
+     "bytes": 42484,
+     "sha256": "e92865750499de9117e5bf19719052109179ebcc37ddbd40f2d91d914b86fa63"
+    },
+    "maps/bmodels/m_bridge1.bsp": {
+     "bytes": 431144,
+     "sha256": "ac4d490408f7ad9068a09c4c89f82a65b8573bc4ba810fe5f16418b1d2684f66"
+    },
+    "maps/bmodels/m_bridge1.lit": {
+     "bytes": 47240,
+     "sha256": "30601eb0d533bbe0f72631b77630c3922a46f34b38687aa184b7776e48e63164"
+    },
+    "maps/bmodels/m_bridge1.map": {
+     "bytes": 120280,
+     "sha256": "3ddec67bb95d788b2fecb0e4c6d09781a6a27ba79d322a637f3a03e84a8f6ac7"
+    },
+    "maps/bmodels/m_bridge2.bsp": {
+     "bytes": 201392,
+     "sha256": "4fec9b73e50ba0608d2b5f2fd5c4957324c4cb609becf3be979aedf644281845"
+    },
+    "maps/bmodels/m_bridge2.lit": {
+     "bytes": 21902,
+     "sha256": "c1fa88042c3fde27bd608d3829c8c4a142e70617087970ec7535d48847ac435a"
+    },
+    "maps/bmodels/m_bridge2.map": {
+     "bytes": 52004,
+     "sha256": "58943dc439d4d4c8e65773c12e361c3336488a94f0a53a54c06366675517b850"
+    },
+    "maps/bmodels/m_bridge2b.bsp": {
+     "bytes": 201398,
+     "sha256": "096dcacf528d2784b79a4c0dd19c445102778f2a053fde3a2a43540a4a621c73"
+    },
+    "maps/bmodels/m_bridge2b.lit": {
+     "bytes": 21902,
+     "sha256": "1c7bdad93866cabb97e4565bf41d2b8a8d4c8237e11b0965fd05fc954b6c2c64"
+    },
+    "maps/bmodels/m_bridge2b.map": {
+     "bytes": 52268,
+     "sha256": "d361d0c3dcfec2ae5d109075bf437d013762328ee48b8fc25f779267d7b1bfb1"
+    },
+    "maps/bmodels/m_bridge3.bsp": {
+     "bytes": 309343,
+     "sha256": "12d2199af263464d48455c2e5cd7bf2abf2085841fbc7e027a4cc96b04eec2d8"
+    },
+    "maps/bmodels/m_bridge3.lit": {
+     "bytes": 46964,
+     "sha256": "b783061b14bb4caf3cf9df9a6b8be9ea1d2a367339fa09ffe01506022b21a4c5"
+    },
+    "maps/bmodels/m_bridge3.map": {
+     "bytes": 138104,
+     "sha256": "33c8835d256fd00e65da818c4d43b86033bb8104897712b824014a035c2628e0"
+    },
+    "maps/bmodels/m_chains1.bsp": {
+     "bytes": 249145,
+     "sha256": "1f51d881982d8602c0da29c1f105ab07a41977bdab4fbf4598922563373f4a98"
+    },
+    "maps/bmodels/m_chains1.map": {
+     "bytes": 170858,
+     "sha256": "e1855a52ab0ae70c382876eb74fcafe5a065fefeb2e49a6956184637b9edc1bd"
+    },
+    "maps/bmodels/m_chains2.bsp": {
+     "bytes": 134457,
+     "sha256": "57a765e0ec315eca93927ad64e11b9b3ec8adae0c405de55d86c30b30ef51e5a"
+    },
+    "maps/bmodels/m_chains2.lit": {
+     "bytes": 15698,
+     "sha256": "c858c4c47488df5cac3ed19736c1aee29f4c7add0dfb45deeb7416c4c7af1f21"
+    },
+    "maps/bmodels/m_chains2.map": {
+     "bytes": 60423,
+     "sha256": "575ae8d717a2352ac8726b3bc0f11f6e0a83f548dd471a544a62f519bb71f692"
+    },
+    "maps/bmodels/m_chains2l.bsp": {
+     "bytes": 156552,
+     "sha256": "ff04a994c83f27104d6ef126ef2d08ce894ebe0a812c49f0d2ae79ce8808e8b9"
+    },
+    "maps/bmodels/m_chains2l.lit": {
+     "bytes": 15698,
+     "sha256": "9ebbd1a675e167d9a3be233cd65654728f2f1e0259dee00f55e3da02802abfa2"
+    },
+    "maps/bmodels/m_chains2l.map": {
+     "bytes": 61112,
+     "sha256": "346320204a3413bd6654018e37e42c442c21d88e15da513395c73e6daee26bed"
+    },
+    "maps/bmodels/m_chains2p.bsp": {
+     "bytes": 156555,
+     "sha256": "f0778b1608dbb058f1f492848ae3b64f66be0fef54e32bddfd6fe09f7b0e7a74"
+    },
+    "maps/bmodels/m_chains2p.lit": {
+     "bytes": 15704,
+     "sha256": "d2e7187908b4d3823091a9d69cce5ac807507372132b4162e48a6b027ecad53a"
+    },
+    "maps/bmodels/m_chains2p.map": {
+     "bytes": 61117,
+     "sha256": "7d1acdf4240cd91b158bbc23dfab846388efa7d20431f5a9c8dba8ab421102ff"
+    },
+    "maps/bmodels/m_chains2r.bsp": {
+     "bytes": 222620,
+     "sha256": "0e1ad04fd73c4bc183331471a3406665660fd8f030d14404b7c43b31309118e0"
+    },
+    "maps/bmodels/m_chains2r.lit": {
+     "bytes": 17552,
+     "sha256": "605d297ff2ece6796c064e3dd47e1c48e4fdc87324f059f2c1721e369de23a97"
+    },
+    "maps/bmodels/m_chains2r.map": {
+     "bytes": 61788,
+     "sha256": "749cc23346335d05a53b3399f49adb157fe29fe24512a65d3ab976bc811b5818"
+    },
+    "maps/bmodels/m_chains2rl.bsp": {
+     "bytes": 151968,
+     "sha256": "653185afe2384bf68c0e6d35bdd3404196404243a1b8d16cb730de9f7a45b4b0"
+    },
+    "maps/bmodels/m_chains2rl.lit": {
+     "bytes": 17552,
+     "sha256": "ef313b8c77329539ca8bbe6831e7d5b372e4e3f3cc807e6b66901b53f83d82d4"
+    },
+    "maps/bmodels/m_chains2rl.map": {
+     "bytes": 62332,
+     "sha256": "f5961359ef0867c6ecd501231f63912bf4066bb4d65685021efcd0d51d637f95"
+    },
+    "maps/bmodels/m_chains3.bsp": {
+     "bytes": 121996,
+     "sha256": "535075d6549167b5bf61ae91abf2c407ee009e64aa4222be35692478151feab1"
+    },
+    "maps/bmodels/m_chains3.map": {
+     "bytes": 57540,
+     "sha256": "08f7d97d9e8cd45c353d1141905c93d3327d8f77984790d9e952bd91a5247803"
+    },
+    "maps/bmodels/m_chains4.bsp": {
+     "bytes": 203735,
+     "sha256": "2840e2b604d571081a2b13ba2d340f596123b53213aaec8cd695e7a4d668e774"
+    },
+    "maps/bmodels/m_chains4.map": {
+     "bytes": 113061,
+     "sha256": "6727d20079382f7f2a76391d72e6b6bc3136cc6396ef4661b679f5c8f82d8427"
+    },
+    "maps/bmodels/m_chains4p.bsp": {
+     "bytes": 205127,
+     "sha256": "20183038acde1a46c9fae81e86837f876dc6e0bb7cc7a556457d4162264d7358"
+    },
+    "maps/bmodels/m_chains4p.lit": {
+     "bytes": 35897,
+     "sha256": "0dfb9177bd73b903703f0f4630c4941467a452ee676d568e7f32b2099699659d"
+    },
+    "maps/bmodels/m_chains4p.map": {
+     "bytes": 112283,
+     "sha256": "09d773ef730e9b4d81cdf23f4ac3b0efcb365771569638e7f5574407c5560146"
+    },
+    "maps/bmodels/m_chains5.bsp": {
+     "bytes": 94806,
+     "sha256": "04c40fce5016a3d26092812be589344740b29be788921f8ce354461d77943817"
+    },
+    "maps/bmodels/m_chains5.map": {
+     "bytes": 44835,
+     "sha256": "1e897fc203a12a480c1d3dfc13bf7653a06edb8132f98a3fedae50614c3ebb34"
+    },
+    "maps/bmodels/m_chains5l.bsp": {
+     "bytes": 117061,
+     "sha256": "f01c9c1e6f87c0588be0df3f8768f563acea6735451efa41366aa0acb63851db"
+    },
+    "maps/bmodels/m_chains5l.map": {
+     "bytes": 45411,
+     "sha256": "64691e385435777a920358775cb18e7ac6ee5290a34488103753a338500b6db5"
+    },
+    "maps/bmodels/m_chains5p.bsp": {
+     "bytes": 117214,
+     "sha256": "555df3c945155f7b820fde49c3e37d114f3c52bb63c4edb647dbc19161cb13d5"
+    },
+    "maps/bmodels/m_chains5p.lit": {
+     "bytes": 9152,
+     "sha256": "f78aaec615854b6382b6802298f42ac42dcdfdfb9c638b417257876fa83200d9"
+    },
+    "maps/bmodels/m_chains5p.map": {
+     "bytes": 45566,
+     "sha256": "1969841b81be135b7cb383f84bf7d38694d012b35b17ef3e2c630afbf5d6e64d"
+    },
+    "maps/bmodels/m_thanshelf.bsp": {
+     "bytes": 140335,
+     "sha256": "8319f2ba87d5a8ed864941fe9c7341744476be658ce211aaafc1ba0747afeac4"
+    },
+    "maps/bmodels/m_thanshelf.lit": {
+     "bytes": 3134,
+     "sha256": "04fd93ccf6b864bd9226faa29db923bc093200ed3f4fc8a8f6cce29b324a9743"
+    },
+    "maps/bmodels/m_thanshelf.map": {
+     "bytes": 10306,
+     "sha256": "811e75bc34627545ff7513dc658e937195b98b7839bad409bf21da4975fb7e03"
+    },
+    "maps/bmodels/misc_radar.map": {
+     "bytes": 5314,
+     "sha256": "7ca088f70d4421b994f1852dd17de1427a2b6401b19d8f464ecf2024f5025418"
+    },
+    "maps/bmodels/sep_chain2.bsp": {
+     "bytes": 130276,
+     "sha256": "eff6d1868abd6355f4858f41657262ebb87fa9093579eb8abe8ac6f8c8880ee6"
+    },
+    "maps/bmodels/sep_chain2.lit": {
+     "bytes": 15716,
+     "sha256": "311947b14d5363ccc34fd6e32205100b612c8a77c66196dc616192b011375b59"
+    },
+    "maps/bmodels/sep_chain2.map": {
+     "bytes": 80569,
+     "sha256": "7d86dc46adc6a01b96b811021484c1e6cbfb61424f1037be59525d6f1ff2c420"
+    },
+    "maps/bmodels/sep_chain3.bsp": {
+     "bytes": 80956,
+     "sha256": "8a811a3fc8f85373d64fb3840bda3a3af63a138498bc051ddb2b0d1e0cfa9e88"
+    },
+    "maps/bmodels/sep_chain3.lit": {
+     "bytes": 10802,
+     "sha256": "50d0f90c43a132a5cb360cbb25521040632f07726c6ccfb482d3740ec940ad05"
+    },
+    "maps/bmodels/sep_chain3.map": {
+     "bytes": 41124,
+     "sha256": "ef40d6b17d8b9fc880e4a8180336554f37dabfbc8a30b78c485793aaa5dd753b"
+    },
+    "progs.dat": {
+     "bytes": 2347206,
+     "sha256": "5e69fece92fb4323609c8e1209a39eecf4f70c3161ae17beb53063fe3e06c340"
+    }
+   },
    "sha256": "fbf21239f4d372e316383753c8bd6535f738972bae7787f365d10b1cf264d952",
    "timestamp": "2023-08-07T04:40:08.000Z"
   },
   "rotj/pak3.pak": {
    "bytes": 256084,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "260af3b0098c4f6bf7d55d770cedcac45153fd1156860bf88cd13b443c657c4d"
+    }
+   },
    "sha256": "64230797bf8899f747e028451090c5b74a4cea44f2ae07bf8f12311d5ab35557",
    "timestamp": "2023-08-06T20:47:02.000Z"
   },

--- a/json/by-sha256/50/50713ed56bd6df1a125e3c1ce66f8c8ead21c2b14c32d846ff5306161e55c94c.json
+++ b/json/by-sha256/50/50713ed56bd6df1a125e3c1ce66f8c8ead21c2b14c32d846ff5306161e55c94c.json
@@ -7,6 +7,68 @@
  "files": {
   "PAK0.PAK": {
    "bytes": 2888018,
+   "files": {
+    "autoexec.cfg": {
+     "bytes": 9,
+     "sha256": "c8f4e445ad48c34b6244f392a8d050e0d01c9c0a2d09c1abb86e3aca7cc7dd63"
+    },
+    "maps/vigil.bsp": {
+     "bytes": 1781332,
+     "sha256": "ec93f54a0a2bcf2f194779dc6eb6728d2ec374ed20acef4989846a02501cb482"
+    },
+    "progs.dat": {
+     "bytes": 446900,
+     "sha256": "aa097e7519001dbbfe8374f50c0cb2c8200c996a2dff6b9c790cbff9e2170868"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "sound/misc/h2ohit1.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/r_tele1.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/misc/r_tele2.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/misc/r_tele3.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/misc/r_tele4.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/misc/r_tele5.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/misc/talk.wav": {
+     "bytes": 34076,
+     "sha256": "0469ef43391ab7908ec2102579c4893be9f3e1620530c2eb377fbc396aabfe36"
+    },
+    "sound/misc/trigger1.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    }
+   },
    "sha256": "114e06d61c7ed58d1758ae8667fa6a344752cfef5f9c2640aec235d335927e9e",
    "timestamp": "1997-05-16T22:25:18.000Z"
   },

--- a/json/by-sha256/51/51c39a4723c82c53a8386fde62781526a8b94ab1d4aee0bcdf757dcc9cc5fc51.json
+++ b/json/by-sha256/51/51c39a4723c82c53a8386fde62781526a8b94ab1d4aee0bcdf757dcc9cc5fc51.json
@@ -14,6 +14,72 @@
   },
   "nightjourney/PAK0.PAK": {
    "bytes": 16429600,
+   "files": {
+    "maps/nj1.bsp": {
+     "bytes": 3341672,
+     "sha256": "9f809d798282a462326a2a95593e71bd42756d25886b5a4c102891574339aaae"
+    },
+    "maps/nj1b.bsp": {
+     "bytes": 2379788,
+     "sha256": "d43206aaeb4a629aed09e29c9ad16c09bc248f341172dabdd0919fc07d667523"
+    },
+    "maps/nj2.bsp": {
+     "bytes": 2740900,
+     "sha256": "e2fdab92da62138069f39edba5e3ca515226ec4e949407d680dbfd0c7ef9f500"
+    },
+    "maps/nj2b.bsp": {
+     "bytes": 1286608,
+     "sha256": "d0ec0413988607656c09214450479412c94b87d92d5e451db1bd1ec284201c63"
+    },
+    "maps/nj3.bsp": {
+     "bytes": 2214032,
+     "sha256": "3ace6c47fb5b76b85f4c58e86634471e5a29e63ee070a8b5b026596334d8442c"
+    },
+    "maps/nj3b.bsp": {
+     "bytes": 1894976,
+     "sha256": "e85039f220c1b9fb0bf8401e8c437f21e80dee559b865af3f77de142af0abc2c"
+    },
+    "maps/njstart.bsp": {
+     "bytes": 1846716,
+     "sha256": "2a8350a3dc03b3f34fce0a09f4a2aa71ada2ffa9ca4bed89ee85c18a3e7fabdf"
+    },
+    "progs/demon.mdl": {
+     "bytes": 178528,
+     "sha256": "47f1abf21e3ebb7359e3a92048187fad43a2de5f9f683684ecf424fd1174d696"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 68088,
+     "sha256": "f9bf2a5f976ae4862716be2b09cb0e06107f533bbc710ecb040fef9ca2d3a818"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 53640,
+     "sha256": "b701623c795388b378b40f7f57ad3c44cd9b8b4c7134ba88b61e1af31f1ce93a"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 37060,
+     "sha256": "a5fe96718d348b02299fcf04d1e02e0bb973df1519a493b8ee50eda297bf536b"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28936,
+     "sha256": "98f907d2f498a501e2451b0cc04ac36c23d9c1e590e04d719332708b33f6247a"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "d53ae9fa2b43f4150756734011e85639a5d428a2539f7a3e39f01c6353445f7d"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 137952,
+     "sha256": "2f50f314e9839d074e052bff06c28a329bd8147818d16067fba1105d9ab480ca"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 98556,
+     "sha256": "2a7ba1a647d15522eccfbc7586ad20128d250eb63055854bbfbf817496c0d25a"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 116628,
+     "sha256": "d4df2e4328f1f88b3f6e9416fb981cd4c4eb434c881f382d75fc51993bb79c14"
+    }
+   },
    "sha256": "9ecb1649077d9595bd9b27e5010ba4e50c454877604a65e7db8c838b3f2e0e3f",
    "timestamp": "2005-09-29T17:29:28.000Z"
   },

--- a/json/by-sha256/51/51cd8bd4cc5e636bd5b423339a68f7c13a71a3dee8a42addc7b1eb60b8459539.json
+++ b/json/by-sha256/51/51cd8bd4cc5e636bd5b423339a68f7c13a71a3dee8a42addc7b1eb60b8459539.json
@@ -77,6 +77,2308 @@
   },
   "rd1m1rmx/pak0.pak": {
    "bytes": 33287670,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 42302,
+     "sha256": "6c76f934d1132be338362ee9c465b64a12f79ca40ad475f2c65a8c958b9f4eb9"
+    },
+    "gfx.wad": {
+     "bytes": 204788,
+     "sha256": "8b97daeae64f4feb693905206ff585590e7e6e10d93c2ba5b6503cad3fc3ef4d"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "6072bd63a691625de201f3f3da060b5df433753d7ac2878c48b87e9d0dd08b94"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "ac11a967228e1c7d1a936859b82807cea239d80380fb6204d67af7a86c5c82e3"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "4cb99cf1b515b6547f012b6e44174c245261b058168a8bc4303d08b98e1805b6"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2c37b7697aebedb5bbf6637d4b8e158f70da6b7245195ff0e91a6ba7aa24e828"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "219002fe962a017600a37dcdcaaa0f777aad42044619f945cb70c68007763a97"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "e251893ed49aeb677096d380d4246907a039e0e21a4849f97f343b0b13faead2"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "64ec646cbab7ebca11f6af4f0b75d9706f438baa7b23059de87f8685f4686640"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "03c7cdc618e4404e2b9364c690b0a447b4be99dc5af112c66e6e2079902c76cd"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "9cf2683f2a6d22693a8c0cf35898bc5900a96afc771878df9f8a8a88f3d581c9"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "f232da5cf35acc557f3f312911e6a856cffaaf9f8078ca2ac5ef7e6f6e5e3515"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "b57ad9ad9d6240a0e035ca7a64e706e3031b8293c27355c9a95495a84972af4a"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "873af58b7244d6e82feb1af26ac044c9beb43c2865bc51d0485054a562ce861e"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "ba75badfe057b499d33168032dd5dc5a4fd0dcbaef9cbbd27efdb3f056cbfc00"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "55ac1377921460aeb691f86e7a5051e3a5481f24b93cc8578cffdab2854ba0c3"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "9600a66391996cff88d48890adfa516660fce6a32397ba4f54973159785cff4b"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9f03351fa7f31a23b63e6c13d2a643ed1ae3fd3df0cf2b0db336424eb17016dd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b7617428e8d1d74be7b770ef24c744d16c2503efce9c17facf1107cce08f5ed9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3036afb422cd299cb09532a20847ef35aaf87bb36e34ce9ce75b5e7aaf9a1ec3"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "7aa61257bd3083c00959776eb36aac86a7ca8da2bacbb4c8a41d9a5fb0b1ab97"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "cfe83953875acfe9afda11b75407ed9883eeb284b0a67b9ff6e07df85d50d9fe"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "d3b4091b83837da5a45445cd00b90267c62050e010e2a045461034ac9c48be33"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "de004dcecdff1973597a977ab63c671ad7d3f52387bdcff4be560924e3d4d17e"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "078c56d685ff1fb84b322f7a76e485c2637fb09efc61f4e44d5d067b3ef9a42d"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "9df9672c8da61ae769409e9ea741a1b8f9a4f108b5f0fa6637ff65601c535843"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "fef6b9be45d5b384d061a47f133075d1cfe0b60d93cf7e3da9ee5529f661964c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "1b1254c1f5764affca85448c4a3c2fefdb938f35bc50f44142a8e9b692ba7d64"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "39a06ff92831e1e2fd20c1bdd20e0f234cd0b3aed94e6c9909d059a20479ce3e"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "def061c922fb91a7e58850e89bb6baa9e09dcf93de7a94288a90511ecd9a114d"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "f897535531fe4b821d41d859a4085fd7d25c679493645a2ef7448f62073523c4"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d070636562a967d1abff330dcd1ea504ac7b9b29099a98994add1d9ae47e44e9"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6d92547a27d839f3c9d7a1da786fb33547cd93b7f19560b6c4bcdc12064545bd"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "e932416c58fc5de16e6d05aa737e56d3811e540bfd9e6acd1bf114ccd8bf34ac"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "bda55d4b2d7bc3f180dafd62424ee5830896563f5a5ac576dfa08894f5e17e44"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "513955ecc96eb1f0d44b340b47f79c02bb7bfa7f3b0a884a65fe111429ddb2b4"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "2faa4c1f61d175ad28b7f54540af3f87abc6e56dc20f2da5fc8a7737a0302c97"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "dcfe5287432b3a1124d032250ccc4bf25c73540521c77601ab746287ef3a0179"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "00654b7bec9981508cd9ae8eac167637926c023e7bca011a3cf37585b7e168a8"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "74c50b895f1e71ec6a569fba0e991fde8cf136ea734d6914435aaf9b2735d7fe"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "aecab7a199a4db72242659e6d1ced192d39b2619f67c7e5eaafa72a5efef3aef"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "d075eb0c8c00d30b01eae539720c20b73bb57066c6ea5e8180a4d851d9167add"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "d03aa05e24552d961ea9ca278d743860e34a97e2ffcee52fded05ad4b4740bd9"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 20040,
+     "sha256": "61c46ac5672c1e671c0c38a6498158176feaa62b074621c2a3d74e5dfc68e2f3"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "progs.dat": {
+     "bytes": 1101670,
+     "sha256": "2d72239dd484e94e7680d1fefbfe73838a8aa77023b030f3f8ed269fa3d6a00d"
+    },
+    "progs/alkturret_base_v2.mdl": {
+     "bytes": 87768,
+     "sha256": "4b1969201052a4506509bb606eb7c395daf9332cf4605036ab50190495dcfbf3"
+    },
+    "progs/alkturret_main_v2.mdl": {
+     "bytes": 116620,
+     "sha256": "11a2564f7daa19625e4514c284650242c8b3831df947f183243adafb958a1333"
+    },
+    "progs/arachnofloyd.mdl": {
+     "bytes": 741212,
+     "sha256": "554bd2ad34a830fa01a61dd4972f432812fb61f7815ec81d8a8d7e87bfad6b02"
+    },
+    "progs/arm_foot.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 164224,
+     "sha256": "35314143b9c7a9a0e26e52a865072a6e73862466e640c6bbd58be3075c4d93ff"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 497408,
+     "sha256": "40cc63b599cedb54f04c937ce407e7119c1cf4d5d35fd04bc18f247584e9899f"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bambler.mdl": {
+     "bytes": 128044,
+     "sha256": "c8ac9dbcf99f0e6efd30496ac414383c26b8d241fbaff56cfa81dfb545dfb0c8"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "698bf740683ad182feae2246526361948be6da2e144f1bd0202eafa748213ec2"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "b662513bc3a8e0e967344c55b536bd33012340dbeb79a8db1281d2c84e36d338"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b2cf62d8e989789bd76e27193b2f5205a93d4172a4e25c89aa1b30f75bebe60e"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigcranea1.mdl": {
+     "bytes": 92792,
+     "sha256": "81f6a5b55d3a585d5e9c73b088d1d20e0fb328707c1539ef41e52c460555f651"
+    },
+    "progs/bigcraneb1.mdl": {
+     "bytes": 21940,
+     "sha256": "e02faff0bb6c84c781f6b534a5a06ac1f977a028fbdcca176be2932f91e9e8ec"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/brz_saw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 575288,
+     "sha256": "f571bdf504537ce01ca2b6a78b57575a36c391f9c786625d880d956fb17390a7"
+    },
+    "progs/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/chain2.mdl": {
+     "bytes": 141764,
+     "sha256": "9334a3ec04716ce0068154bf7abb4c1e3ee6de14fb159982dd547314935d7854"
+    },
+    "progs/cyberscrag.mdl": {
+     "bytes": 311084,
+     "sha256": "307e8133ce4f48d4c3dad5ef1b9d32900a3457e91aade778b7fbbc6d8a4741e1"
+    },
+    "progs/cyberscrag_gib1.mdl": {
+     "bytes": 60500,
+     "sha256": "3db8b13bfa5a5eda07acea695cae6ffb92354053da9bed199ef29cd445317faf"
+    },
+    "progs/cyberscrag_gib2.mdl": {
+     "bytes": 58932,
+     "sha256": "ef20c0de15fe2fc2514c10b0023d14009a4871ed40311077ba107350c313f7ce"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon_alk.mdl": {
+     "bytes": 191716,
+     "sha256": "11f33f19ae0a46d3dcc6c1fee46235fb6ad201456120502b603fe4fb7cee14ac"
+    },
+    "progs/demon_old.mdl": {
+     "bytes": 272684,
+     "sha256": "538d5d01833d6910d4400f8795be582c3427748eb2a162fcec2c17d6707c57e5"
+    },
+    "progs/dog_alk.mdl": {
+     "bytes": 199324,
+     "sha256": "a16e350fcd247908c75ecd0c93e94d3b700b67bb0f66dd45d665d171a55d42b6"
+    },
+    "progs/dread.mdl": {
+     "bytes": 415072,
+     "sha256": "dcea570331c5cf4348c40451c6242bf35ecaaea2a348f12254a13c1b76b13d7c"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17284,
+     "sha256": "444692074359310be0520b1caa057ae2e084df826f7ecc9bcb0d258ea1d80373"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35988,
+     "sha256": "91aa79805577466147bd4811614b0387b3635aba8383fc2e16b178d7b63ebdf1"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42436,
+     "sha256": "93839bd6f50323f7ac5ae46037de0c6a10a533374f714229dd511ee62b88ca3c"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bcc6396dc638003480dba8c36cafaf32df2cfcf49bd460b001d0d74a164f9011"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/enf_gun.mdl": {
+     "bytes": 58684,
+     "sha256": "39ef1788b39a15f86c8d54b81c43f4126e8361ff80d386c44358f17ddc93769f"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 450424,
+     "sha256": "ecf603c4ebc56438e96d1706a451af8bbe9b090db9c48e38e758ec630a393570"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "ddcf759804fffd97e62c55f67f962e24e8cd646fd982215ac8aefd3e49f67660"
+    },
+    "progs/enforcer_alk.mdl": {
+     "bytes": 333860,
+     "sha256": "85fb5cb9eb1435da65ce0aa6940241b7b4b5fa13e7444713a75c6ec301cc8b97"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish_small.mdl": {
+     "bytes": 221279,
+     "sha256": "34b883e3bf73a520f301cced68629e0d95e88f96c03a23230f12d02aa49c247c"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flag2.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flagbig.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 451032,
+     "sha256": "1a311e7e74f9a67c9f7468252aedc8c19804f65375d229e90afbec2f93849823"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/fromitz_still.mdl": {
+     "bytes": 6964,
+     "sha256": "63204597e828e001c957e9316878995e161da0502764276b90285accadf6a222"
+    },
+    "progs/g_axe_alk.mdl": {
+     "bytes": 50460,
+     "sha256": "92988e970870f2b977f7490d2ea4ee040d338fa4bdc470e8d68f2e5a856a7a28"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_mine.mdl": {
+     "bytes": 37780,
+     "sha256": "5057c7736e8c722270c781e47584972f42e7ebdd5860596403a9ce7688d0b5cc"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "15f390e39e02c8524e575ca8fadf63187b641c58210ee9587b13a0ca94c29cc2"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 199076,
+     "sha256": "7ddca6fb95082d0cc7ffe5aa3ba896ea987a80b1bd5867db97b2a84b9d8da9f6"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "8b05b8ca87ea867c2a2397d238311fda2441f5c0e1cde130ba487b0dbd17a8e5"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_arach.mdl": {
+     "bytes": 60292,
+     "sha256": "daca6412383bec28809cee42c4ebf01085cf83ed6ff289114ba0f842b4005251"
+    },
+    "progs/h_bams.mdl": {
+     "bytes": 37316,
+     "sha256": "58c4644a2ed3e5f10741dff2ad1a8bb161f7eb205ba3fd8c5fc9b7e4ffc571dc"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_cyberscrag.mdl": {
+     "bytes": 62036,
+     "sha256": "df7d6bccc97bd5c184d9d6160005b370175aacc16a34bd06ab14c7d69ff60419"
+    },
+    "progs/h_demon_alk.mdl": {
+     "bytes": 72644,
+     "sha256": "22a9e01cdccb2e274c63c277e6dcd61986fa7556426ee3562fe11af2babea289"
+    },
+    "progs/h_dog_alk.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_mutant.mdl": {
+     "bytes": 110240,
+     "sha256": "f1f9c665b659a8c145550605ef9abddf27779d0917c897baa344d65673770875"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/h_sabrkn.mdl": {
+     "bytes": 11828,
+     "sha256": "050fcc93189211aba943674a326ddd898dc980b83fb551ee11fec3dd39973483"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shams_alk.mdl": {
+     "bytes": 37268,
+     "sha256": "9fcace6cfb38473763a5cf96007ccc5e0ec4786352d4d1063410d63157298b45"
+    },
+    "progs/h_torm.mdl": {
+     "bytes": 62056,
+     "sha256": "db0ddda0c4d2283cd3c58eb45397cfb57095acba1eb6dd38571ca23ebffe9946"
+    },
+    "progs/h_wizard_alk.mdl": {
+     "bytes": 14948,
+     "sha256": "5f6c27ba255b87718d993b29cff526bd025c0e7a4991722a96fe3c0f98d83408"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hknight_old.mdl": {
+     "bytes": 418144,
+     "sha256": "40bd5757499a2bf7e6f60a78b0039665107c9603c2557f6bc73208e080111464"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 37012,
+     "sha256": "e3c6cbabfe6c6723101f2e59f50fc99ee0e360571c95885d2d56c85eefade15d"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/jumpblue.mdl": {
+     "bytes": 37428,
+     "sha256": "be4e85e5fc643e91377d69794b997ad4dc927ae3866dfef5288d704dbc0f16d7"
+    },
+    "progs/jumpgold.mdl": {
+     "bytes": 37428,
+     "sha256": "4c543d82c88009cab7fcf6230feea0a21518a98f430636194fdbf5c1e526cc13"
+    },
+    "progs/k_laserspike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/knight_old.mdl": {
+     "bytes": 208068,
+     "sha256": "5cca43e29392051c9ba95838a58cc1038560411e6c0d2aff61867a428b119e2a"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "63220c0ebb6e266576cb3107a44be16bda10d69fa524d0462514edff9d80328c"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "29bc55efafbea3e15a385598750ba4d9242d0a87803a6bc3430ed772ec1785c3"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "f1e799e7feac3c340676bb60f6cc7a2a7d1e121b196d1f6d0e23edea3a614ed6"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "92370f5b196dc00460d73697975d14279ef659c87c7fc1613b9cbfb68e6c299c"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "4c5db792da6876f935f8a98a74f51708d52ca03f04975f28518051494660bf65"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "781837a3557c1a8b89c15fa8f477989cb4b77d8cff09c8c13d071090a4df9c1b"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "2feb7ce08070b314d163cbc7f2e2eae0986400c482f752d305ddba268639b3d8"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "04f7fc8b0c2be7ea93021819770145eaf828b2313c4fc591a5f2aa783ca97e61"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 8372,
+     "sha256": "9b6a8f7a49fb7a1f5d4d409b708663c579d433e978d898b9bdf00291a59b4e6c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "fa5d7a5e2410ac7faa5dd0a8e17873c972c6e5cfeacc94118f22db1b4b17477c"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/mutant.mdl": {
+     "bytes": 352720,
+     "sha256": "262ffca22e0c7308950076c2789436a891399862ea25afbd06040158ec9f7984"
+    },
+    "progs/nsoldier_alk.mdl": {
+     "bytes": 563108,
+     "sha256": "6071d7cecf231f0a83f2e1c7df533b4a32beb6e75969d17703446a67d011695a"
+    },
+    "progs/ogr_gun.mdl": {
+     "bytes": 52452,
+     "sha256": "eaa6e0fe01255450d578f151c06c5aeb6a9cd5ed90edbbe4f52d305069ed6825"
+    },
+    "progs/ogre_alk.mdl": {
+     "bytes": 315696,
+     "sha256": "31e9986373dc1a8cba00e09ba9b0278cf766bbd074524a891ed22329f697d643"
+    },
+    "progs/ogre_old.mdl": {
+     "bytes": 315696,
+     "sha256": "53317e9b684701e7722bea342af1a6dba5dd31e72cdbcfa5b097382516d1c6a3"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 487968,
+     "sha256": "ae0abff3ea3fc7ca8c7f80c5d8825553795a1c1ebb80127d46fa52b20905abc4"
+    },
+    "progs/ogrem.mdl": {
+     "bytes": 378296,
+     "sha256": "2bb999bf580d16fb9ee4246dea7897236d6d118232c78a6168f641dc32778fb5"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/pellet_tracer_short.mdl": {
+     "bytes": 58148,
+     "sha256": "5b24b67ce9d9b2634d9a0f31319a977e1e3ec6352d491367941a0e5bf2ae10ff"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/probegren_body.mdl": {
+     "bytes": 139044,
+     "sha256": "da0ddf337c3e2515688f2b143adf55d4ecbbfa32955a78aea01ed16e067b0065"
+    },
+    "progs/probegren_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "4f292b6f157d226e763ff28dad682ce95cfb8a3a21b4badf0ca48db4900cdd70"
+    },
+    "progs/probegren_gib1.mdl": {
+     "bytes": 63788,
+     "sha256": "0efb081efa87c9db990d984f9974f10078890a51894a3e0a6fbe76cc3c4cb5a7"
+    },
+    "progs/probegren_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "7843ddefa22b7d5beb37f889c606c6361792508c2bea202f3dadf9f3ffce73de"
+    },
+    "progs/probegren_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "7baac250aa8c27ef3158de59b536ebf59509e39b1f7bf6be1c24fd5b1e29cae0"
+    },
+    "progs/probelasr_body.mdl": {
+     "bytes": 84296,
+     "sha256": "ac545d0f545488628c864df6e464d10fbd51cb41a2cb76c46dd91233ecd11a6f"
+    },
+    "progs/probelasr_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "cec7b847c9b05f2653113454348799b9bf09c2a74c8e1760cca0ff52c1dfc18c"
+    },
+    "progs/probelasr_gib1.mdl": {
+     "bytes": 58700,
+     "sha256": "ae9f298abc0bb1d09cea3c04bf02216b0a1c3749f8c8a822d973b4c2091cd649"
+    },
+    "progs/probelasr_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "07d6defee5ce4e747daf8b397a5d207a1a42e3c3acffbdfc18d6720c88ec635c"
+    },
+    "progs/probelasr_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "8b8f376afa56e7a9f311e58a076f1fa3a52c88064887a8e0960fdb6daaf5265e"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12653,
+     "sha256": "162632bc16838f66f29e0b788845a6421b7fce708003e9fa6f4eb8ae7aa8e5be"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/rail.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 200152,
+     "sha256": "a564fba381d24e3084bc9aa0a026381c83e6b889632c8bebdf69c08c8a6bb9f2"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "f65ba83d82e90808af589ded17378f1baf37f105fa14f2b157227ee22583d25d"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 288,
+     "sha256": "6ff2797f9dc4e66f2113475a5f3e0e96f23dacbddd18fe47c8b5e12e712f0e75"
+    },
+    "progs/s_bullet_new.spr": {
+     "bytes": 708,
+     "sha256": "a07fa61f4a838ac9ad8ec85ae525d70fb934d383effd1948c0775497be713043"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "b3f1971bd28f96c623c5712e2a47f54f16c99a50d460a944cdcdf29e6eb03963"
+    },
+    "progs/s_exp_small_2.spr": {
+     "bytes": 201720,
+     "sha256": "f7fdba9e2b9b5d318cdff33a06fad4e91e46ba3a241fe7ced4bfbcf0bcb0e873"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_plasma_new.spr": {
+     "bytes": 13980,
+     "sha256": "5474060e55af3c462d0ef7aad043f331c1f5b642915d906c1785bb94595cc68c"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 2820,
+     "sha256": "ea66402d248232b0b6a77bffe024d4a62881be47becf37acb42328661b7f23ef"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shalrath_old.mdl": {
+     "bytes": 211576,
+     "sha256": "409cda15df7b271bd95a895f058a521d43eca63f37c7ac9df175e5b478229bb9"
+    },
+    "progs/shambler_alk.mdl": {
+     "bytes": 502148,
+     "sha256": "bcf685fcd1f4062dc382924d39eae073fc4d44cd2dcb5bc4ca3797fe0b342b71"
+    },
+    "progs/shard.mdl": {
+     "bytes": 10132,
+     "sha256": "0f756f280c09f44ef1e9f36fdd678566b4a5782b349a3e9fe1309c3fcd9ab19b"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "662d6a7cd68bca7a9c5e88838d190de6a501252a14b6994a191d0bc91f1f331c"
+    },
+    "progs/sknight.mdl": {
+     "bytes": 460932,
+     "sha256": "9213f6898a60cdc20a7a144c61c13f8d64f1432382dca44b636524edf737dac8"
+    },
+    "progs/soldier_alk.mdl": {
+     "bytes": 359276,
+     "sha256": "623374e5a553c3d886738c9cc0b22c0b3f3435b3dc1b3f473079a1dd1661fc8a"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spiderbot.mdl": {
+     "bytes": 82476,
+     "sha256": "e85556a194664a5f69e70b42aa863d9e67689a418a3afa51e50816174a6fe8ac"
+    },
+    "progs/spiderbot_gib.mdl": {
+     "bytes": 19444,
+     "sha256": "96ee732ac1199a89c675880700c24e1f09521c35ad478f73aaf4278a398454f6"
+    },
+    "progs/spike.mdl": {
+     "bytes": 2820,
+     "sha256": "783d711b408498dbb34581c9a0ae74ed325dc5c68fa67873745b02c8a926a201"
+    },
+    "progs/supbkpack.mdl": {
+     "bytes": 44408,
+     "sha256": "781c6b5f424fb58e06b2a84b1fb7e980778decde6b3ed257e224db0b1f250173"
+    },
+    "progs/torm_largeshot.mdl": {
+     "bytes": 37852,
+     "sha256": "ce3a87be213e39b48bc71a6fbf5e1fe9e3f5209901ca45801f27d8f297e04a01"
+    },
+    "progs/tormentor.mdl": {
+     "bytes": 461080,
+     "sha256": "df302dea113f54df908f97c26de844d1235004c08aefcf5c349f3af4b0957d41"
+    },
+    "progs/trifecta.mdl": {
+     "bytes": 25460,
+     "sha256": "2c9196af0806c48354f5522a8b7f6fa57e6390f8dfb51718fb71b8a2d4d7447a"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/v_alkaxe20fps.mdl": {
+     "bytes": 96428,
+     "sha256": "4405242db772d86c66f1012b140ba409bee86682fa5f4a6ca12c3e6f94eb9fcc"
+    },
+    "progs/v_axe_alk.mdl": {
+     "bytes": 55820,
+     "sha256": "80ad34cf2612f8fa9121f2be0ada92c1e05613ae2b35b2a1be25a4c694dd2147"
+    },
+    "progs/v_laserg40fps.mdl": {
+     "bytes": 142580,
+     "sha256": "b897ecb5868e3125597d51f970075af04782cba47ed8a42d7b17775dff01f536"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_mine_40fps.mdl": {
+     "bytes": 332920,
+     "sha256": "0039956e96a804229359aaf082b9cf66515d52360867b86c3dca884d19caf8b4"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail3.mdl": {
+     "bytes": 124944,
+     "sha256": "19045e9a5154299b68377744ad946fc3e7f2bd290497c8291a2247ed8cc572ad"
+    },
+    "progs/v_nail_alk40fps.mdl": {
+     "bytes": 44692,
+     "sha256": "402b3dc06f1e5e756cfd50cab17cca49e17e261994c5007cfd46c466a08d3dad"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 260692,
+     "sha256": "0982368440a5d20d65ec511207590c2bfb63e9a60376a5d753b209f2b047c58b"
+    },
+    "progs/v_rock2_40fps.mdl": {
+     "bytes": 139668,
+     "sha256": "89257b7580ac3f48fc775f121eef3508c326eba1369e6aacae83144f8fdfca15"
+    },
+    "progs/v_rock_20fps.mdl": {
+     "bytes": 39556,
+     "sha256": "ebdd6245e1ff65bd95eaed7fa189ac87b51818408f091a32de3f4a477b90f2f8"
+    },
+    "progs/v_rock_40fps.mdl": {
+     "bytes": 43828,
+     "sha256": "f3c32a1c37d4fc3115a8da00ba9507cdd508a98f65e2ddccbcbdc8a0ba0bf2ea"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 326464,
+     "sha256": "dd389cc337d8b7675d9a7b983fd9f53f0c59d597a9759367bd1e1beba375eaaa"
+    },
+    "progs/v_shot2_40fps.mdl": {
+     "bytes": 29076,
+     "sha256": "37ae91c018183faef847aad217da537c97b5a2430ab27a860388bffc1f4514f6"
+    },
+    "progs/v_shot40fps.mdl": {
+     "bytes": 29252,
+     "sha256": "87a47e2debbc27fd6c18a8a38a9a373e7b73ba707458e6346f069c1572df47b4"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/wizard_alk.mdl": {
+     "bytes": 158508,
+     "sha256": "aab430eb2dc0f5c50ca7b4492a7ccc427f2a12011f54ece1b81d4beb66acb4a9"
+    },
+    "progs/zombie2.mdl": {
+     "bytes": 130148,
+     "sha256": "185336c7bffe32e496e93f6828278287f89b672c71f2439918ac5e220ae8b868"
+    },
+    "quake.rc": {
+     "bytes": 1273,
+     "sha256": "b43f856e56c166cca4dd6d89da538218610b740d0b2a6113ebdcfd89352824a0"
+    },
+    "sound/arachnofloyd/death1.wav": {
+     "bytes": 119460,
+     "sha256": "d16c7ff30e9df62fbcda102befbd61fe234532f6aef30d0b34c25330679682bc"
+    },
+    "sound/arachnofloyd/death2.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/arachnofloyd/idle1.wav": {
+     "bytes": 34254,
+     "sha256": "35d6991a10637251ec0d6b830f7f57f394e4eed06e7a9dced86f0128ba5bc49e"
+    },
+    "sound/arachnofloyd/idle2.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/arachnofloyd/leap.wav": {
+     "bytes": 70884,
+     "sha256": "f47323f618db14755c57e9e25213267dcffc501fbaa9a201176ab99db6cda928"
+    },
+    "sound/arachnofloyd/pain1.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/arachnofloyd/pain2.wav": {
+     "bytes": 15906,
+     "sha256": "9c4bdc81c73787cb67677e0021b71d9e24734ef3ce272d9020dc6611a1d87842"
+    },
+    "sound/arachnofloyd/sight.wav": {
+     "bytes": 48620,
+     "sha256": "97a055dbb8e5935190348b2c2d50c6d99ab35c29f3ebcd0f66d6263bdb5485e4"
+    },
+    "sound/arachnofloyd/step1.wav": {
+     "bytes": 74932,
+     "sha256": "a8744a3e50dccf9ee391da2f381c2ecf6701a76441406929ee4581c7717b880f"
+    },
+    "sound/arachnofloyd/step2.wav": {
+     "bytes": 34478,
+     "sha256": "22ce43aa18537f7b04e31263a46dd02e181d538fdf5918d55f8ce0acbb930676"
+    },
+    "sound/arachnofloyd/whirr1.wav": {
+     "bytes": 19762,
+     "sha256": "9e2029071248e6d45f1b0d518983bad5bc5f841cda6bcfba09486e111add10de"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axegrunt/axgdeath.wav": {
+     "bytes": 20214,
+     "sha256": "e5ed762afcc516058acc1b3884b4d08e67fd36e3a5bacf711d3504363bf8136e"
+    },
+    "sound/axegrunt/axgpain.wav": {
+     "bytes": 12636,
+     "sha256": "4699951fa58fdf15ab819b13d70904fc9a1a86a4db02193d621dfad3878d17bf"
+    },
+    "sound/axegrunt/axgsight.wav": {
+     "bytes": 17712,
+     "sha256": "e7b23208831c1d83793ba06f3b8855430c92017600cd8315341afbcb6ec6c8f0"
+    },
+    "sound/bambler/melee1.wav": {
+     "bytes": 4175,
+     "sha256": "4e0e2567b9d64b3ff86b33d95fa0158bf72372aeb4968a0c2489df942f9f7c4d"
+    },
+    "sound/bambler/melee2.wav": {
+     "bytes": 5283,
+     "sha256": "4bb91991bccfc33576eff19037e12666e9825348272d3dca40199e208bc00700"
+    },
+    "sound/bambler/sdeath.wav": {
+     "bytes": 14048,
+     "sha256": "c5253af82d203e75d132a00bbb555de055d2e356106d460f34cb8c9a2ee5e643"
+    },
+    "sound/bambler/shurt2.wav": {
+     "bytes": 3736,
+     "sha256": "0f1a51e0ff72f23a4de7684d4408344b7b7bd2cb805609168d2f2459e1b8660d"
+    },
+    "sound/bambler/sidle.wav": {
+     "bytes": 4907,
+     "sha256": "ea2232ba791e306cc86f58303413d8f3fbc7dd38091281698f4d846b6cafa483"
+    },
+    "sound/bambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/bambler/ssight.wav": {
+     "bytes": 11376,
+     "sha256": "de766aa056ca5f7dc6d179e6a220ef906ceacc0341b5cb3d91a4d0e75ff55338"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/cyberscrag/fall1.wav": {
+     "bytes": 23396,
+     "sha256": "162fc0be1cd0eadfc93c35f1e1ba9b8dfc7e8df8ee53afb2a14db73e69f20ce8"
+    },
+    "sound/cyberscrag/hit.wav": {
+     "bytes": 22334,
+     "sha256": "a16ef33d94d56fb6984b2a3d06104a3cc292bdb38ec6ee22c8b10457b2cb415f"
+    },
+    "sound/cyberscrag/wattack.wav": {
+     "bytes": 25912,
+     "sha256": "6bed724b7ef9bdd480448396ed4498c75f848bf2a1e6d2879cb2b2484cdd1a7b"
+    },
+    "sound/cyberscrag/wdeath.wav": {
+     "bytes": 20684,
+     "sha256": "24602233cca209122250ba7c284933992aa2393795ea5c528a57b9986e2fc319"
+    },
+    "sound/cyberscrag/widle1.wav": {
+     "bytes": 13465,
+     "sha256": "8902628d2201eda9396c0dc134ebda8b8d5c37dabddcd286f8387aadc6532750"
+    },
+    "sound/cyberscrag/widle2.wav": {
+     "bytes": 23094,
+     "sha256": "76af020e5c25f40ab3020bbd065a9b83b9b0a51120d47d137a7abff4eb43e193"
+    },
+    "sound/cyberscrag/wpain.wav": {
+     "bytes": 8687,
+     "sha256": "af2e8589d381e634f607048ce71200df832c9e3a32147891b5bdd2efe2ff5bf0"
+    },
+    "sound/cyberscrag/wsight.wav": {
+     "bytes": 13079,
+     "sha256": "2f9178f6515eb4cd518b418441c40d1376aeaf6f42f7791533f5f4b6da87fd68"
+    },
+    "sound/doors/alka_doorlocked.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/q2door1.wav": {
+     "bytes": 30572,
+     "sha256": "3f05bddf76379933970c532656b6350bc53820319ce1cb9d4ea9288210427eee"
+    },
+    "sound/doors/q2door2.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/dread/dread_death.wav": {
+     "bytes": 49692,
+     "sha256": "22000ff613ff52eab0605418681affaf7aeef4acc420d3dddd50a9031ac1ca38"
+    },
+    "sound/dread/dread_pain1.wav": {
+     "bytes": 29220,
+     "sha256": "67e443f78043cb9fc4213bbfbc3cd847785a66849fb7b36dd6467494487e0aec"
+    },
+    "sound/dread/dread_pain2.wav": {
+     "bytes": 23380,
+     "sha256": "914fffe3ad6c02fb78be873ee96405a40df22cd321beee2d673d0b6ebbafcde4"
+    },
+    "sound/dread/dread_sight.wav": {
+     "bytes": 70792,
+     "sha256": "50449a772b2ac778b810a69de58cb63c8bbdea529091720a41a1052b7196632e"
+    },
+    "sound/dread/dread_sight2.wav": {
+     "bytes": 58420,
+     "sha256": "f7952137b648f6376a1ba4e968679abb17fc648ede87bb0dd32f633271ad80ee"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 110256,
+     "sha256": "895cfb57c0d27369530fd5e9b29abd491a989ad0a63ddb00f05dd9e4777a5cdb"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/frogman/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 32638,
+     "sha256": "3cf3933f34c7baef52df54d5b03db40424e9f7ee72e5aa5a4dba489d71be2af7"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 27662,
+     "sha256": "ec38e73fd1ffc33cd25aa065e5f5897c21a494e380763ff80b6be482689b5e33"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 44186,
+     "sha256": "7600cd32fe980646fddcf5a9077d8d43df1bca1f2ed05bd92ce8cca273ad6636"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/armor_denied.wav": {
+     "bytes": 15854,
+     "sha256": "2ec14677f483d1a1b869af64cc30fb0dbd90a640fc071fdf2ae493d27cd746e1"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/items/shard_pickup.wav": {
+     "bytes": 18260,
+     "sha256": "388923a63b48720647b9e0f2862c35bb1d5cad2e162ace343845b3fe36b48af4"
+    },
+    "sound/items/trifecta.wav": {
+     "bytes": 16412,
+     "sha256": "00baad51adaa3f5d6664e85ae5442221db6818bfd85124c164324d22f6723ab2"
+    },
+    "sound/items/trifecta2.wav": {
+     "bytes": 32778,
+     "sha256": "f742a9cee4a53ef52fce55d5e9ddaae9c6b20d2127e16c0def6cd11b3d2d6380"
+    },
+    "sound/items/trifecta3.wav": {
+     "bytes": 10728,
+     "sha256": "a78bfc9fa4fbf0c3c1e85bee273ee053598989a09146bd29e97dda811c49a473"
+    },
+    "sound/lieut/alert.wav": {
+     "bytes": 8700,
+     "sha256": "7ebbe83ae1b5d159c9f0a0ae5f3dea126650ed5d6f98a22d1512dcfcb19a23ca"
+    },
+    "sound/lieut/objective.wav": {
+     "bytes": 10052,
+     "sha256": "aa7d6726a458eaa48bf2e20446c57360b82ac23bfbd06bad7b6e01ae95ca8b0d"
+    },
+    "sound/lieut/target.wav": {
+     "bytes": 6754,
+     "sha256": "eebd50c75585894c7d5305f6c066aaef1efaca9a59e27b80d03e8ae4d69caa69"
+    },
+    "sound/lieut/you.wav": {
+     "bytes": 7126,
+     "sha256": "6bfb031b0d69b8ae4ef2e9b201da43c523ae88de344907648d4064e07477ee1c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/conc_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/misc/door_closed.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/misc/ebell.wav": {
+     "bytes": 15220,
+     "sha256": "1693337ed8873f1159e56c2925afaa210f5c28bee4e2c42d27e29bee8e06cb5f"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 4054,
+     "sha256": "b9c44f73c8bdbc900af4f06600e0d6456a040b296612b7d0fe53391285976a44"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 4098,
+     "sha256": "4fad66341514c9aa2b31b4c2fde7563369090da9b0b3a51e08bca3100f2ec282"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5054,
+     "sha256": "d158ddc35360bc43934b7a8a9b7cc830f7510e6bb3a640813157822b27b5217a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 9726,
+     "sha256": "73b74099c8cb43ab2fb09b28b72ddd9f73f2d2a4f8a00a8e835490f366680c92"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 3226,
+     "sha256": "48551cc717e5011df78a38c6a71bb001e4f62a1858a3952311499653ff423a07"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 5802,
+     "sha256": "751050f97456a0c07e88a249d40dde96c2d14640e21670ccdde983502998dbba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/mutant/mutatck1.wav": {
+     "bytes": 6116,
+     "sha256": "410f926534f21705e78a804ce048b0c15e62fe0c68a45aae1b3741fb227551f7"
+    },
+    "sound/mutant/mutatck2.wav": {
+     "bytes": 18260,
+     "sha256": "66009d09adf71f10117c74f5004c995fd48362b2f4fcfaaa3bc2da01e66d115f"
+    },
+    "sound/mutant/mutatck3.wav": {
+     "bytes": 28840,
+     "sha256": "2dd8a615ca2be248c8370d7480f5a8ca9375d31e6af41bba603df660d31883a1"
+    },
+    "sound/mutant/mutdeth1.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/mutant/mutidle1.wav": {
+     "bytes": 81004,
+     "sha256": "8c7e8ad544d7e2470bd61d88c5cd8be1a0eb66f57aaf113f82d990ee00450073"
+    },
+    "sound/mutant/mutpain1.wav": {
+     "bytes": 56716,
+     "sha256": "49ff5f97fedc87c1ac06dc43d4ff0a0fd09fb481354b6373d607bfabc9a57a6a"
+    },
+    "sound/mutant/mutpain2.wav": {
+     "bytes": 58740,
+     "sha256": "b79f1cce60226daa3e3ca8c134da968d54ad51abd9c37ffebdf3d46c5d9f91c6"
+    },
+    "sound/mutant/mutsght1.wav": {
+     "bytes": 107316,
+     "sha256": "7e15e392edc3f2d5ae9e3bde3dfe65595a85728022245f74b81f072d75dce798"
+    },
+    "sound/mutant/mutsrch1.wav": {
+     "bytes": 101244,
+     "sha256": "44484ef4c189511fb0a8d0f2bea83e443e1f1bd51cef04f518f3820e58e88a69"
+    },
+    "sound/mutant/step1.wav": {
+     "bytes": 8140,
+     "sha256": "0d9af35156c84213ac7ffbde54d0f2518fe9d39bba4edc48c94e71bed4f7ec4d"
+    },
+    "sound/mutant/step2.wav": {
+     "bytes": 14212,
+     "sha256": "f7c81df1bff56c8aeb49891fa822c37ddcb019e97a654738a9fb8ee351d19eac"
+    },
+    "sound/mutant/step3.wav": {
+     "bytes": 4092,
+     "sha256": "89856afec31f800219c45253514d0fdf5b5bd800c32f87ba74dd0c21df181550"
+    },
+    "sound/mutant/thud1.wav": {
+     "bytes": 32428,
+     "sha256": "20ed5f20729a068801d06904365e46c9d692dec835710a9b8090d0a1956d6919"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    },
+    "sound/ogre/rogre_alert.wav": {
+     "bytes": 71728,
+     "sha256": "4f3e921b6ee236289660f7ca2ee8a4689e719423266d26a3f8b91ae29d02c6a5"
+    },
+    "sound/ogre/rogre_idle1.wav": {
+     "bytes": 110330,
+     "sha256": "a07df4a53c9e8de310b9d963bfb9c841c51e502565f39dc543bf1c025edd41d6"
+    },
+    "sound/ogre/rogre_idle2.wav": {
+     "bytes": 79416,
+     "sha256": "862258641dc3c90d2a9e5f9e2a4418eb0037eedf22cde798682a169a84f13a44"
+    },
+    "sound/player/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/player/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/player/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/player/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/player/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/player/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/player/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/rail.wav": {
+     "bytes": 97196,
+     "sha256": "396a85e1e2083f2b1eaae89a3f33a21145a643f3f50419523497719ef8e7598a"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/rider/sight.wav": {
+     "bytes": 26356,
+     "sha256": "40ace6f3beeb920ba1bbdb197f8ece18d312762a71e494726289e16703d75d91"
+    },
+    "sound/rider/step.wav": {
+     "bytes": 40524,
+     "sha256": "a43e24ecbc62d44bce466b1e682ebf64c230e03f4d79449406ce021dc8276a9a"
+    },
+    "sound/rider/thump.wav": {
+     "bytes": 15444,
+     "sha256": "af29f4e8f6debb1223aeb5d840add4ae01cb5e9f6bd9a26efeadff518f34380d"
+    },
+    "sound/scientist/allnominal.wav": {
+     "bytes": 23778,
+     "sha256": "e26f9bb3c24d9a9e0da38395048f6dacffe82d800da49d56378027250393d69a"
+    },
+    "sound/scientist/alright.wav": {
+     "bytes": 9666,
+     "sha256": "372c1aa91e6841bec2441215c894b7d149bdeaef33f907d23bb7eaf637520ce3"
+    },
+    "sound/scientist/asexpected.wav": {
+     "bytes": 15982,
+     "sha256": "306933848b673bd14d7074d59e45a8c97bc00a2897601509e52e5835e2ffc997"
+    },
+    "sound/scientist/c1a0_sci_crit2a.wav": {
+     "bytes": 28364,
+     "sha256": "f972684c74eeb51872873cc2b7053448c6cdd716b8c3535929fdbcc508d62ef5"
+    },
+    "sound/scientist/c1a0_sci_stall.wav": {
+     "bytes": 13704,
+     "sha256": "541c192ad5e8a68c76706ec17b3deceafbdc607bfc372ddfd300532f8aa1eaef"
+    },
+    "sound/scientist/cantbeserious.wav": {
+     "bytes": 13236,
+     "sha256": "fc4a8a379f70e33db79a49c667dcd9f1622de29d7b32ef3973c4ffdb5d80ee44"
+    },
+    "sound/scientist/cough.wav": {
+     "bytes": 14878,
+     "sha256": "b4e620259623347a5be3f7eaf3c531e6ea9ef2e97ac42997dd78cfee9327f7bf"
+    },
+    "sound/scientist/sci_die1.wav": {
+     "bytes": 15558,
+     "sha256": "c2306d7f9fa58f99961c347b06ef26305b99ac43ec27b2b222962e1f3a9ccce9"
+    },
+    "sound/scientist/sci_die2.wav": {
+     "bytes": 5402,
+     "sha256": "14deecb570d1e315b772713d54b7250043bb0dd5f3d5538cd0636e39a523c54f"
+    },
+    "sound/scientist/sci_die3.wav": {
+     "bytes": 3104,
+     "sha256": "075cdbc5837d91b61ad7599cdb3abf9323872816f8966c83deab9c0a6e04d7d2"
+    },
+    "sound/scientist/sci_die4.wav": {
+     "bytes": 4024,
+     "sha256": "e6ca0d4f18ac6c1246926646568618057cb70b5cee995c1c2dd69f0179b892ad"
+    },
+    "sound/scientist/sci_dragoff.wav": {
+     "bytes": 8986,
+     "sha256": "0c6a21cd5edf01e495e1258e9a76c05d62c0e3cd697e787fd43fd4bd9126483b"
+    },
+    "sound/scientist/sci_fear13.wav": {
+     "bytes": 4534,
+     "sha256": "dabce7a6c12980f947f7504da264fabb67a804d2e478b7f252ab527fb21a92d0"
+    },
+    "sound/scientist/sci_fear15.wav": {
+     "bytes": 4764,
+     "sha256": "f0d23c680ad138c3cc12da78a3e45cbf3daa47e5da9bc62a1dbb3b27389565a5"
+    },
+    "sound/scientist/sci_fear6.wav": {
+     "bytes": 5588,
+     "sha256": "ff2702b2b9e517b90ea0c2853775a4a95160edfae5af0a7f9208f07624d84281"
+    },
+    "sound/scientist/sci_fear7.wav": {
+     "bytes": 8458,
+     "sha256": "f2a39185c2d39a03b39afd7fe6f942b2f35fd17135ade8ceb4c31968c768aafa"
+    },
+    "sound/scientist/sci_fear8.wav": {
+     "bytes": 5804,
+     "sha256": "4455a29590d5f42ebbf06e600d8ba3f45acfd5000a6b8045891cbecf1d937970"
+    },
+    "sound/scientist/scream01.wav": {
+     "bytes": 14666,
+     "sha256": "b738de99aefbe3a45724914dd6eb79c0f8c219aaf733554a8a5eb94836c22320"
+    },
+    "sound/scientist/scream06.wav": {
+     "bytes": 13938,
+     "sha256": "dee8ac2058635d00458e2e74402d1cfcb5362c64259fc2c4f3b6bba31bdf6337"
+    },
+    "sound/scientist/scream08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/scientist/scream09.wav": {
+     "bytes": 6130,
+     "sha256": "85947649f5fb1491732365849a3025bf5c76c791b395cfdf421fbbd6ec58d351"
+    },
+    "sound/scientist/scream10.wav": {
+     "bytes": 5392,
+     "sha256": "fff4c0735f9c312be7cda848fc2867590437ffe9758fe685e3b4c94678ca1f48"
+    },
+    "sound/scientist/scream14.wav": {
+     "bytes": 4824,
+     "sha256": "dcb7dfb0e307b813476b2e55dceb59d8ae2b9514b1ef02034ea255fa5f086b05"
+    },
+    "sound/scientist/scream15.wav": {
+     "bytes": 3048,
+     "sha256": "37d26fe2d2b8a39d0fec0eceec0ca974ec3dd7fed33bae0d3230a934954105f0"
+    },
+    "sound/scientist/scream16.wav": {
+     "bytes": 2328,
+     "sha256": "4ff04ce8ff07af708c84dacc8df114b68620d47e8e4e4c78dfc4fd33a8a9b98d"
+    },
+    "sound/scientist/scream17.wav": {
+     "bytes": 3836,
+     "sha256": "82fb51224e06db5022adfa58f0b02353c333229ed3312f86dd9ec4f04813c37c"
+    },
+    "sound/scientist/scream18.wav": {
+     "bytes": 3066,
+     "sha256": "bfefcf745ab8d30db11f9113ecf9ba1c5bc6d9b2351c53f3f46d66e03cbea3fe"
+    },
+    "sound/scientist/scream19.wav": {
+     "bytes": 2504,
+     "sha256": "47cc414d201aadb7ba2fe0ce0567ff5360e90fd9de4a167520988513f358ed41"
+    },
+    "sound/scientist/scream20.wav": {
+     "bytes": 21310,
+     "sha256": "124cb45d3d5533572e3cfe4b42bddad2a03dc0d8de1c89a42ea57433432e3a6e"
+    },
+    "sound/scientist/scream22.wav": {
+     "bytes": 15206,
+     "sha256": "6e0a509eb2468466591622e74724c31103b8b60f5d8f29514fb57e9d9d12c9d4"
+    },
+    "sound/scientist/scream23.wav": {
+     "bytes": 21988,
+     "sha256": "8521907e8cecc22e6924d23295a5e8d31333d265ca27a9533b083b68e9da6d12"
+    },
+    "sound/scientist/scream24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/scientist/scream25.wav": {
+     "bytes": 8122,
+     "sha256": "38281749deffb4e567896f71e7bcb75d7b2e253e404a953a5eea6eeb989f156a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/spiderbot/sactiv.wav": {
+     "bytes": 17066,
+     "sha256": "f21587ba9bfd159e48c5b3aa1c6e94eac7157053e4e5699459233fb28c2631c8"
+    },
+    "sound/spiderbot/scharge.wav": {
+     "bytes": 7300,
+     "sha256": "b58064dac4e12bd6685edbfe61417a530cde1e5175336193b2fa7a292aca8ef7"
+    },
+    "sound/spiderbot/swalk.wav": {
+     "bytes": 12636,
+     "sha256": "5534fe1b11fea5406aada214681dba031ec4a01e4b660c405b679131ba07a7cc"
+    },
+    "sound/tormentor/angry1.wav": {
+     "bytes": 88890,
+     "sha256": "60f757f523a9cbb3a57c335bbeda8cedbf990b9d20a5b359e610b712a1344b4b"
+    },
+    "sound/tormentor/angry2.wav": {
+     "bytes": 90912,
+     "sha256": "2f38dddb69cf0df2c1e5b028ca06ea22d979e637afa927919e9a93876dc955d6"
+    },
+    "sound/tormentor/death.wav": {
+     "bytes": 176628,
+     "sha256": "7060ecdadac0b1c9eb3574284444932573e4af13082f01374ed8a4633387bb66"
+    },
+    "sound/tormentor/fire2.wav": {
+     "bytes": 52092,
+     "sha256": "4133a00c7ef157d291d800524a148c188a314eb5ca14246958b8ddfeb0d4fe41"
+    },
+    "sound/tormentor/idle1.wav": {
+     "bytes": 115740,
+     "sha256": "78feebc847dccab66478718b66971870f11246c416e2f2c1e9830c459e4c0347"
+    },
+    "sound/tormentor/idle2.wav": {
+     "bytes": 122218,
+     "sha256": "0270712fe40851bb21d959932b4f8f75bbe8b985e2ff383319059c656ac0ce56"
+    },
+    "sound/tormentor/pain1.wav": {
+     "bytes": 67334,
+     "sha256": "03f255d6ee0d6fb83f2a643491f4cd24d9c5ff86444a51b3cf8b5a0de3d86bbc"
+    },
+    "sound/tormentor/punch_hit.wav": {
+     "bytes": 76614,
+     "sha256": "e524d16b000237615bae3b8fed7b74726823cd4258561196f4641728047aaa26"
+    },
+    "sound/tormentor/punch_swoosh.wav": {
+     "bytes": 33044,
+     "sha256": "d0ef38ef4bf33d0c2f92b22c2a767c4efd66eefaa724df50b394958a7be5a705"
+    },
+    "sound/tormentor/sight.wav": {
+     "bytes": 94334,
+     "sha256": "34a13e6469c5e0ce2f6d18721b0cdd634731b9a9f8910a8bb8b685f63dadfaac"
+    },
+    "sound/tormentor/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/tormentor/sting2.wav": {
+     "bytes": 21674,
+     "sha256": "dd2d40459c7aa9d374efe2f219c34773f390df9f5177a83dbfa5fd638a13c542"
+    },
+    "sound/turret/alarm.wav": {
+     "bytes": 22126,
+     "sha256": "20a8a83d73a55dcc3d8a6fcb79b4ff8ecba0b5887cf3bdcdc96303f069b062ce"
+    },
+    "sound/turret/beep.wav": {
+     "bytes": 22126,
+     "sha256": "89f0e2ba68562cfc3e20272f995777c174c2681cfcf29d2ef337974009b42460"
+    },
+    "sound/turret/deploy.wav": {
+     "bytes": 105260,
+     "sha256": "5bb8c1fa8ffdf22e58ac5fb7a337916a457b9d021661742fcdbbdd7ce188c6dd"
+    },
+    "sound/turret/deploy2.wav": {
+     "bytes": 54208,
+     "sha256": "ec26b9451b67dae2929488687b7b9344a96f7538ab5c4f69e8a85602804dffc2"
+    },
+    "sound/turret/disable.wav": {
+     "bytes": 57180,
+     "sha256": "d8767dcce34c1c7f660f5868c23938da4cc379cb4001b88a10ec1aebbf9e557c"
+    },
+    "sound/turret/idle.wav": {
+     "bytes": 35784,
+     "sha256": "fba6bc2ff517ef95a999e3910c74e3594e054ede298c7b3a5659a2c31565d37c"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 43820,
+     "sha256": "32082cd1d44903409e97de782e5d9295272840e13280665a0ef3ff862b187f0f"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 47570,
+     "sha256": "0dd8defb8ecfb1ea72e6ac70ab182573775812e2d7990dd2897d02d3c38464f5"
+    },
+    "sound/weapons/spindn_click.wav": {
+     "bytes": 9986,
+     "sha256": "b84866cddb7e61eea9ca49208d427c2289d63e6e3e2f59d4d51e302573079bc7"
+    },
+    "sound/zombie2/attack1.wav": {
+     "bytes": 22914,
+     "sha256": "da5345280208ea48855526989299927268566cef77ee187035bbe969076d6605"
+    },
+    "sound/zombie2/attack2.wav": {
+     "bytes": 24072,
+     "sha256": "59245700b47794e239563cc94e3ff045fcd7dad795bcfe343d8574ec3ac525b6"
+    },
+    "sound/zombie2/attack3.wav": {
+     "bytes": 15400,
+     "sha256": "0113aad711264c05a9e43bf8dba915bc89661444d7d802efabe8d61ebb3ba13f"
+    },
+    "sound/zombie2/attack4.wav": {
+     "bytes": 20922,
+     "sha256": "0aac55ae62b62cefece56103cd7079beeb433c3764f590641876e149c4328ecc"
+    },
+    "sound/zombie2/attack5.wav": {
+     "bytes": 26086,
+     "sha256": "b58c97928b535e79973e0390512b09d3d0adea79b1b1b5a8de59bc2cde40c412"
+    },
+    "sound/zombie2/attack6.wav": {
+     "bytes": 22272,
+     "sha256": "58c429256e2f5abb9d97c99ceedb78088d8ac977eca94e994b6d1eee8bb3eb8f"
+    },
+    "sound/zombie2/attack7.wav": {
+     "bytes": 34384,
+     "sha256": "d68e81783b6583738227eac608ab7af1a4b1e1b085c1e46bd9c0d029eab4fdde"
+    },
+    "sound/zombie2/death1.wav": {
+     "bytes": 46548,
+     "sha256": "a1b9e2bcebf9c56fb56405d1ec7fe4166ac10d2b6e1acc6f01e58aec9fd63e87"
+    },
+    "sound/zombie2/death2.wav": {
+     "bytes": 47048,
+     "sha256": "5964a3c1a665c70de8302052b2b6d72ea46b0a5e07ba22cc9919e1a0ffefcca3"
+    },
+    "sound/zombie2/death3.wav": {
+     "bytes": 52636,
+     "sha256": "5c76f8bc55ecea263df880e6b683b07066b37c9f62ff589b0e999534d3c256b0"
+    },
+    "sound/zombie2/footstep1.wav": {
+     "bytes": 12966,
+     "sha256": "2a85309bea05b7c7c90a82df071822828e413cce17646a9686fa4f1264d75e48"
+    },
+    "sound/zombie2/footstep2.wav": {
+     "bytes": 16880,
+     "sha256": "d1d9e9c3811b39b67c9a6966851873ff7edf8d1407c5d9b90782b233196a4872"
+    },
+    "sound/zombie2/footstep3.wav": {
+     "bytes": 20904,
+     "sha256": "b12e9ea9b9478428b886fcaab504856393a57abd8cfdfc5ba5357ad745ee3455"
+    },
+    "sound/zombie2/footstep4.wav": {
+     "bytes": 15796,
+     "sha256": "6f82ac60991e64c8c48a3208a161b46f5b916587cb41863992dc1acb08268889"
+    },
+    "sound/zombie2/footstep5.wav": {
+     "bytes": 17800,
+     "sha256": "ca12f6ade73e5d5ba4ec1bdf680ce25afe3270bb88d702e1493b75619ec088d9"
+    },
+    "sound/zombie2/idle1.wav": {
+     "bytes": 143832,
+     "sha256": "aa203b0beb2db12beb6929fbc3646f7f119d4d31ede66b13af0412d396f7dd6d"
+    },
+    "sound/zombie2/idle2.wav": {
+     "bytes": 277026,
+     "sha256": "9496f3179e875bbb4d7442c252eac0eb2b9ef6d2269d43c141e01242ed2de7ee"
+    },
+    "sound/zombie2/idle3.wav": {
+     "bytes": 234026,
+     "sha256": "4820b03de8cebdee6fe787b5bf60724c17a0e133fdd5451176a202043f730f8e"
+    },
+    "sound/zombie2/idle4.wav": {
+     "bytes": 166352,
+     "sha256": "a515e5dc0e4fe1412a7936df5fab0f57a48c385db4fa357c1a4120671ac99617"
+    },
+    "sound/zombie2/idle5.wav": {
+     "bytes": 62782,
+     "sha256": "c6e4e2f26769400b7ca3b08339af089ba28bc063447d642e10cffffc6e03a485"
+    },
+    "sound/zombie2/idle6.wav": {
+     "bytes": 47274,
+     "sha256": "9ad1ced551cb42764fd88baf26ee09dc72d1852fa2da7405fde370d3e4d69a01"
+    },
+    "sound/zombie2/idle7.wav": {
+     "bytes": 45614,
+     "sha256": "41783a7682d5f8bb91aff8308b8657504cc8f0460b5ca436a5d0fb1c93357c85"
+    },
+    "sound/zombie2/idle8.wav": {
+     "bytes": 73070,
+     "sha256": "8f390d861feda3fb3950b0f33ce3efbfa8eda214533324674ac40b6e227b6975"
+    },
+    "sound/zombie2/punch1.wav": {
+     "bytes": 9218,
+     "sha256": "db6787efe0a0b8df5da690b91afe46a2199911b661fc9de1cfffc00b6bb8c46c"
+    },
+    "sound/zombie2/punch2.wav": {
+     "bytes": 8032,
+     "sha256": "747aabd6237176ae1bc62669cb08c7ec65fb26aa2147f6a3e1ab43f02ace7322"
+    },
+    "sound/zombie2/punch3.wav": {
+     "bytes": 13076,
+     "sha256": "05bb75533252d15983a944263789de5ee51187e518f4544fd1915b57ba726c7e"
+    },
+    "sound/zombie2/punch4.wav": {
+     "bytes": 13198,
+     "sha256": "d07556e7fc774958a6105564a990c51a0dab64fcf9508475617921a0ac5b961c"
+    },
+    "sound/zombie2/sight1.wav": {
+     "bytes": 73234,
+     "sha256": "387534044f10592ca6bc7a96b8e782c7b51de87b907e79a8f410d535e17d37ee"
+    },
+    "sound/zombie2/sight2.wav": {
+     "bytes": 52224,
+     "sha256": "cbc95608d4553d0bae66411d69875210e6fc6d728bd30deb6bbce7aabbacb773"
+    },
+    "sound/zombie2/sight3.wav": {
+     "bytes": 63072,
+     "sha256": "cbbcdb6da59d830a3be66095053259b17a90cc6501728ed1aa50d9524818f99b"
+    }
+   },
    "sha256": "e5de412650faace357cc258869903e068d95711cf7d57a425e0ec5643b11e188",
    "timestamp": "2022-11-18T17:02:06.000Z"
   },

--- a/json/by-sha256/52/527753cf4e92a5272c15784782f81e699fd0c77f1e76437d38226ca413ed9cfc.json
+++ b/json/by-sha256/52/527753cf4e92a5272c15784782f81e699fd0c77f1e76437d38226ca413ed9cfc.json
@@ -7,6 +7,40 @@
  "files": {
   "Pak0.pak": {
    "bytes": 2050950,
+   "files": {
+    "glquake/h_hellkn.ms2": {
+     "bytes": 1216,
+     "sha256": "d2a87681bee47c3c723ca45dea7f71d03928273cd861ef07eaec2d2d26ff02bd"
+    },
+    "glquake/hknight.ms2": {
+     "bytes": 7568,
+     "sha256": "bb167eff8f147d338dc9c8f1d864e3f5083accc5e3a69e161c6d0778c408477a"
+    },
+    "glquake/k_spike.ms2": {
+     "bytes": 564,
+     "sha256": "f6d2d3d02c0b268204e7ae83b4507086d0c432caea07d99c4d31f87f4ed2d3b1"
+    },
+    "maps/lthsp1.bsp": {
+     "bytes": 1102060,
+     "sha256": "b536dc137e2bf95481205c45529be6ea9bb20c5fc687065c62aa38888f893740"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 11828,
+     "sha256": "2472f8139353f10017eb9a5cfa1edcdf0d8a42b419213a14deefd3f34556a1ac"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 909361,
+     "sha256": "f8ad2dc18653e36630eae567633d84b2e03a52a6cd8c125edafce1c87ff18c8c"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "quake.rc": {
+     "bytes": 245,
+     "sha256": "a6a89db5210aab5ff5f06913bbdc720392177e53765b36b99b2cc729f29908e6"
+    }
+   },
    "sha256": "1e406fdb4a578a0a70dc05830b491ae6d5ea383adf3d59f8e9a5ed4f22f72b11",
    "timestamp": "2000-12-06T17:05:06.000Z"
   },

--- a/json/by-sha256/52/528f833feeeb15d559ffd8662e7f541bfc3ca27fd328d8ae5852f87474a5a393.json
+++ b/json/by-sha256/52/528f833feeeb15d559ffd8662e7f541bfc3ca27fd328d8ae5852f87474a5a393.json
@@ -12,6 +12,96 @@
   },
   "pak0.pak": {
    "bytes": 7962250,
+   "files": {
+    "maps/b_batt0.bsp": {
+     "bytes": 6980,
+     "sha256": "0d481a2e2cd7a23e4ef19c19622195007bd6c9a67135ef739b0944a02d46fcd7"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6964,
+     "sha256": "34709c1c06ca34305a8ba1d4799d1cdc07e44ff33f3c7fa11c3d5933cb942579"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 7124,
+     "sha256": "d3371655bed274070fa98fb32b408bab4a22fe754f5158c8c94a072749a5d24d"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 7764,
+     "sha256": "abdfe383c13da6d5dd7a9409fa5d3db2c4bac78482eb75c2c2b42da7811ec3ca"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 8788,
+     "sha256": "2343448faac29720e3a690650b70623852710dcae002917ae5772fa597117e17"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 5604,
+     "sha256": "66ea23f1cdd6225afdd1b7cf1247b93d174562193e0807561b96b659429f2bf0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6820,
+     "sha256": "366ece777ae71ecfebaa9f4bebafe2074b5336e7939900f46bd9521886f9f42d"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 7092,
+     "sha256": "56a66aa3d1364a0436ff8ce880268b2a9c2c396ab02f0c6277535d5b99eae31a"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 7636,
+     "sha256": "ddd60cec57d8e3954c1ffce616ae862edb784417a6b6622cc001d408383a6cb9"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 5396,
+     "sha256": "fe60bd7880da73571e29fa4075968cccb06e913bd2b9475868ce31c69b1a8c19"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 8436,
+     "sha256": "6a2c2c3fa6f88d425ae5b9568e5d8224ee901a1d8faa8363b88fff569b7d0e5f"
+    },
+    "maps/e3m6.wad": {
+     "bytes": 333020,
+     "sha256": "c99077504b0f52296507116361714f2101587f6330610cfd4708326b4be55e89"
+    },
+    "maps/mstalk.bsp": {
+     "bytes": 3051732,
+     "sha256": "047c46f848494c62816a245e8b22b37d50e22540285e2ceacb135a36a91c71f3"
+    },
+    "maps/mstalk.lit": {
+     "bytes": 1310531,
+     "sha256": "367e128898e41921474de426d20d23da2e4e7d9444673397aa60ce022c566789"
+    },
+    "maps/mstalk.map": {
+     "bytes": 3096075,
+     "sha256": "41acebdfc4a33b576802f8ba1197ef291d2d0a278ecf6aa8f4c4a8d0b41bf9fb"
+    },
+    "mstalk1c_readme.txt": {
+     "bytes": 6031,
+     "sha256": "56908f2f43df5bdecbcbe5a08dbbe7ce6672ede078902561318ef7e43602c6db"
+    },
+    "progs/end3.mdl": {
+     "bytes": 19700,
+     "sha256": "445af16e28fff506ad65fac16b09dad1672e218ffe0183880aff565578b315b8"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 21412,
+     "sha256": "1274fcabffa89a786b29c9238cf84e95a8557369239b4a9eb813e3dbe37d35ac"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 22052,
+     "sha256": "c5657b558522e46f0833b7827520c1a5c1f1674dffd52c12609779d5bcd75462"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "quake.rc": {
+     "bytes": 1345,
+     "sha256": "4108b2a74980b78c44a1a7c1cb41366b4be72a242a404c9ed03eeb13b7e4a252"
+    }
+   },
    "sha256": "5f980aa5bec8e07f8edc4a94b3d48ee020bb1fc9d67818842a692cea9a1bdc11",
    "timestamp": "2013-05-10T13:53:14.000Z"
   }

--- a/json/by-sha256/52/52915bea35f25dc3756f6fca68ef90c144a3870549b2ae6bd969afd0a230d144.json
+++ b/json/by-sha256/52/52915bea35f25dc3756f6fca68ef90c144a3870549b2ae6bd969afd0a230d144.json
@@ -215,11 +215,431 @@
   },
   "ttj/pak0.pak": {
    "bytes": 11231782,
+   "files": {
+    "demo_c1.dem": {
+     "bytes": 1854820,
+     "sha256": "8b93e0384ac1505dde19d24a2e337686c065a43da8c8a476bfdadbfdc621928a"
+    },
+    "demo_c2.dem": {
+     "bytes": 2445116,
+     "sha256": "4e4ab2f099e5746565cd19e5695a35cc1252c24d8817b5c8670c1792c187097f"
+    },
+    "demo_c3.dem": {
+     "bytes": 1808204,
+     "sha256": "71476830e6d475ff8bb66fc8f07da76c89f407160ac26ad1ccfced0d6e7e80e2"
+    },
+    "gfx.wad": {
+     "bytes": 152468,
+     "sha256": "50d94651f3e0b0b6a29e0110ce9ff260c9f3114060b08b6d1ae19054b8024335"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "31c4858fe496187dc1bac21c02aff8cf83cbc51e0b4ee5738d6118c328b299d2"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "ed0f79285d93d0ef35644ecaf9ab36f3b2c6ffd223c577b25fff2ea17f90080d"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "e9c210ab88f6e98965cd2f8470f084e32ef15b3ad3912cb1e9eb0363c6204eb7"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b56880e2f720a89dcd055f5278abb21a21514322d4a31b77b46c8b509b9f3be3"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "89c3ac6fd91cdcf15c20b0d15b4c01c153e0a820c660f9222b5c8f63d43af5b2"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "8b83ffaf6b5309d371f0107ebb1340a8a09cd1a52c6a5581b7c9c4a7afcefa77"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/debris1.mdl": {
+     "bytes": 33768,
+     "sha256": "3498dffa0c3522b011a76ada880dfae64de3ca1583c94474e1e07adbc220d981"
+    },
+    "progs/debris2.mdl": {
+     "bytes": 33944,
+     "sha256": "d6d535173bb4a3a2d469be9c63bf36a01b1e2b80dd6a71636d20178d813e443c"
+    },
+    "progs/debris3.mdl": {
+     "bytes": 34136,
+     "sha256": "d6b0a2b6353c4462196d2af116652b47d464a7bc1f161509aa8ee5dbe859f98b"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 17812,
+     "sha256": "74cd41d8d5a67570cdaca34a08e9868f3476d8c4ac4a645cfaf9e91cf778c793"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "4f5ca2553db07d5cc93987b11e9f9ff054d51b96488e2bcc35c9f03ed3040d42"
+    },
+    "progs/h_zombnm.mdl": {
+     "bytes": 3220,
+     "sha256": "45d9dfe5683264edf6f6eb7b8e8d794f84caeb8701e65e8ebe9add2192bbb6fc"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "b00951cd72bb5fb03c19a1d60943162652fe149b9ee60fd2e630a076d52956fb"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/k_spike2.mdl": {
+     "bytes": 17716,
+     "sha256": "e456eb93934dab43a83305988db82ab1954e66491c256fad3ef1451d0ecf97c2"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 36496,
+     "sha256": "a001c379917628354adfb62b698856b33f4eea5f22e7d8e232e640faf15d8465"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133936,
+     "sha256": "e2d6b9de9b879327f72d97ef3c07e0b7e35cf844747208f6e615015be84157e5"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "f414f3fd07b0278bd59dd90954770f81a5ffad7f46af5f5d0abee124905dcc17"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "progs/w_spike2.mdl": {
+     "bytes": 5816,
+     "sha256": "b07808c532059133c31be2ed2bc4e9bb9b01b75d5d23401768058cacc3192068"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 74976,
+     "sha256": "545d70abb8d44be8e12da24a3d09fb56f87ff960c41963148682fbbd9d47e417"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 218680,
+     "sha256": "6782603eadacc7cb4bd09c11d3b6326e0d2e69205f724fe2f6e533ee398f5a16"
+    },
+    "progs/zombienm.mdl": {
+     "bytes": 224900,
+     "sha256": "f4d1ce9667ebb36088bfb59a12c9a8d93c1aefa36515b51f388cffec5132f5b2"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    },
+    "sound/zombie/z_res.wav": {
+     "bytes": 23266,
+     "sha256": "10b2962ce2817fa8a250811313307cf0dfa93ad5257a669452fe3fc834ced976"
+    }
+   },
    "sha256": "14a746abb95d03032dcf07202d9470cbc450c69a2a713d3a80bcdaeabe4262af",
    "timestamp": "2023-10-31T11:50:00.000Z"
   },
   "ttj/pak1.pak": {
    "bytes": 256084,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "5e49c426d2a2db91c72525d68acf9c7c195bb8eb637237726c9cbd8cb9f5d13a"
+    }
+   },
    "sha256": "34f8c10619a369592e0034a460256133be10d6d9cde4e5572a1d258099ae6c50",
    "timestamp": "2024-06-17T14:59:00.000Z"
   },

--- a/json/by-sha256/53/53c8d9513a801ff5fd07b35f88a3af46aa6eac5b356df321c17580952cf2ceb1.json
+++ b/json/by-sha256/53/53c8d9513a801ff5fd07b35f88a3af46aa6eac5b356df321c17580952cf2ceb1.json
@@ -127,6 +127,2468 @@
   },
   "z374/pak0.pak": {
    "bytes": 36837240,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 52058,
+     "sha256": "367e453b2ea9b4282990f595c446c70f16b4ca36717b1fd0c3220ec34e90326b"
+    },
+    "gfx.wad": {
+     "bytes": 210484,
+     "sha256": "9072806ee7e43f2ce712cbe7bd68355dd659447258c7e35e1005d71df7ad5baf"
+    },
+    "gfx/bg_ammo.lmp": {
+     "bytes": 1928,
+     "sha256": "754dc8ea867ba7dcd60407764b51a1eccac068456c38787744387a4c59cbce62"
+    },
+    "gfx/bg_runes.lmp": {
+     "bytes": 520,
+     "sha256": "6b69fad1c89ac2085dcc7b8153d1f19ae353bbd0572b05aace1afc02e8e984df"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "6072bd63a691625de201f3f3da060b5df433753d7ac2878c48b87e9d0dd08b94"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "ac11a967228e1c7d1a936859b82807cea239d80380fb6204d67af7a86c5c82e3"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "4cb99cf1b515b6547f012b6e44174c245261b058168a8bc4303d08b98e1805b6"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2c37b7697aebedb5bbf6637d4b8e158f70da6b7245195ff0e91a6ba7aa24e828"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "219002fe962a017600a37dcdcaaa0f777aad42044619f945cb70c68007763a97"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "e251893ed49aeb677096d380d4246907a039e0e21a4849f97f343b0b13faead2"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "64ec646cbab7ebca11f6af4f0b75d9706f438baa7b23059de87f8685f4686640"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "03c7cdc618e4404e2b9364c690b0a447b4be99dc5af112c66e6e2079902c76cd"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "9cf2683f2a6d22693a8c0cf35898bc5900a96afc771878df9f8a8a88f3d581c9"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "f232da5cf35acc557f3f312911e6a856cffaaf9f8078ca2ac5ef7e6f6e5e3515"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "b57ad9ad9d6240a0e035ca7a64e706e3031b8293c27355c9a95495a84972af4a"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "873af58b7244d6e82feb1af26ac044c9beb43c2865bc51d0485054a562ce861e"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "ba75badfe057b499d33168032dd5dc5a4fd0dcbaef9cbbd27efdb3f056cbfc00"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "55ac1377921460aeb691f86e7a5051e3a5481f24b93cc8578cffdab2854ba0c3"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "9600a66391996cff88d48890adfa516660fce6a32397ba4f54973159785cff4b"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9f03351fa7f31a23b63e6c13d2a643ed1ae3fd3df0cf2b0db336424eb17016dd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b7617428e8d1d74be7b770ef24c744d16c2503efce9c17facf1107cce08f5ed9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3036afb422cd299cb09532a20847ef35aaf87bb36e34ce9ce75b5e7aaf9a1ec3"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "7aa61257bd3083c00959776eb36aac86a7ca8da2bacbb4c8a41d9a5fb0b1ab97"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "cfe83953875acfe9afda11b75407ed9883eeb284b0a67b9ff6e07df85d50d9fe"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "d3b4091b83837da5a45445cd00b90267c62050e010e2a045461034ac9c48be33"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "de004dcecdff1973597a977ab63c671ad7d3f52387bdcff4be560924e3d4d17e"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "078c56d685ff1fb84b322f7a76e485c2637fb09efc61f4e44d5d067b3ef9a42d"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "9df9672c8da61ae769409e9ea741a1b8f9a4f108b5f0fa6637ff65601c535843"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "fef6b9be45d5b384d061a47f133075d1cfe0b60d93cf7e3da9ee5529f661964c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "1b1254c1f5764affca85448c4a3c2fefdb938f35bc50f44142a8e9b692ba7d64"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "39a06ff92831e1e2fd20c1bdd20e0f234cd0b3aed94e6c9909d059a20479ce3e"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "def061c922fb91a7e58850e89bb6baa9e09dcf93de7a94288a90511ecd9a114d"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "3220d953bab793165178f2666e67032398a6bd0e0510f6b92eef4fcab377ee1e"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "f897535531fe4b821d41d859a4085fd7d25c679493645a2ef7448f62073523c4"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d070636562a967d1abff330dcd1ea504ac7b9b29099a98994add1d9ae47e44e9"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6d92547a27d839f3c9d7a1da786fb33547cd93b7f19560b6c4bcdc12064545bd"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "e932416c58fc5de16e6d05aa737e56d3811e540bfd9e6acd1bf114ccd8bf34ac"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "bda55d4b2d7bc3f180dafd62424ee5830896563f5a5ac576dfa08894f5e17e44"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "513955ecc96eb1f0d44b340b47f79c02bb7bfa7f3b0a884a65fe111429ddb2b4"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "2faa4c1f61d175ad28b7f54540af3f87abc6e56dc20f2da5fc8a7737a0302c97"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "dcfe5287432b3a1124d032250ccc4bf25c73540521c77601ab746287ef3a0179"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/skillmenu.lmp": {
+     "bytes": 14408,
+     "sha256": "dbf40f0e5faedb181e84d4a822ecc9316711ae89530a30bd50cf4fba45aa8251"
+    },
+    "gfx/sp_maps.lmp": {
+     "bytes": 2248,
+     "sha256": "024bfb2d05f1c52bab1a856cbc532d06fdf4e8d96fb486f74bf451472311ebcf"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "00654b7bec9981508cd9ae8eac167637926c023e7bca011a3cf37585b7e168a8"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "74c50b895f1e71ec6a569fba0e991fde8cf136ea734d6914435aaf9b2735d7fe"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "aecab7a199a4db72242659e6d1ced192d39b2619f67c7e5eaafa72a5efef3aef"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "d075eb0c8c00d30b01eae539720c20b73bb57066c6ea5e8180a4d851d9167add"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "d03aa05e24552d961ea9ca278d743860e34a97e2ffcee52fded05ad4b4740bd9"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "maps/wood07.bsp": {
+     "bytes": 7135,
+     "sha256": "8e07e7e5f5b641c644d28c9c4026efc95aa50345074f5c42acd39a3b94261344"
+    },
+    "progs.dat": {
+     "bytes": 1195538,
+     "sha256": "e28dba3261e561246ff12c5678ebcea1dc6720798c3400277fcc6e40666b9eeb"
+    },
+    "progs/alkturret_base_v2.mdl": {
+     "bytes": 87768,
+     "sha256": "4b1969201052a4506509bb606eb7c395daf9332cf4605036ab50190495dcfbf3"
+    },
+    "progs/alkturret_main_v2.mdl": {
+     "bytes": 116620,
+     "sha256": "11a2564f7daa19625e4514c284650242c8b3831df947f183243adafb958a1333"
+    },
+    "progs/arachnofloyd.mdl": {
+     "bytes": 741212,
+     "sha256": "554bd2ad34a830fa01a61dd4972f432812fb61f7815ec81d8a8d7e87bfad6b02"
+    },
+    "progs/arm_foot.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 164224,
+     "sha256": "35314143b9c7a9a0e26e52a865072a6e73862466e640c6bbd58be3075c4d93ff"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 497408,
+     "sha256": "40cc63b599cedb54f04c937ce407e7119c1cf4d5d35fd04bc18f247584e9899f"
+    },
+    "progs/b_p_key.mdl": {
+     "bytes": 5940,
+     "sha256": "051b2e8fa67cae7aa24490a18444400f773d4a9d353542ebf979b0a22a1771ef"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bambler.mdl": {
+     "bytes": 128044,
+     "sha256": "c8ac9dbcf99f0e6efd30496ac414383c26b8d241fbaff56cfa81dfb545dfb0c8"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "698bf740683ad182feae2246526361948be6da2e144f1bd0202eafa748213ec2"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "b662513bc3a8e0e967344c55b536bd33012340dbeb79a8db1281d2c84e36d338"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b2cf62d8e989789bd76e27193b2f5205a93d4172a4e25c89aa1b30f75bebe60e"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigcranea1.mdl": {
+     "bytes": 92792,
+     "sha256": "81f6a5b55d3a585d5e9c73b088d1d20e0fb328707c1539ef41e52c460555f651"
+    },
+    "progs/bigcraneb1.mdl": {
+     "bytes": 21940,
+     "sha256": "e02faff0bb6c84c781f6b534a5a06ac1f977a028fbdcca176be2932f91e9e8ec"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/brz_saw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 575288,
+     "sha256": "f571bdf504537ce01ca2b6a78b57575a36c391f9c786625d880d956fb17390a7"
+    },
+    "progs/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/chain2.mdl": {
+     "bytes": 141764,
+     "sha256": "9334a3ec04716ce0068154bf7abb4c1e3ee6de14fb159982dd547314935d7854"
+    },
+    "progs/cyberscrag.mdl": {
+     "bytes": 306936,
+     "sha256": "868d1394e186b1e7f4fc58134c338a413814723f406fa609e2d7cb87dc2496cb"
+    },
+    "progs/cyberscrag_gib1.mdl": {
+     "bytes": 60500,
+     "sha256": "3db8b13bfa5a5eda07acea695cae6ffb92354053da9bed199ef29cd445317faf"
+    },
+    "progs/cyberscrag_gib2.mdl": {
+     "bytes": 58932,
+     "sha256": "ef20c0de15fe2fc2514c10b0023d14009a4871ed40311077ba107350c313f7ce"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon_alk.mdl": {
+     "bytes": 191716,
+     "sha256": "11f33f19ae0a46d3dcc6c1fee46235fb6ad201456120502b603fe4fb7cee14ac"
+    },
+    "progs/demon_old.mdl": {
+     "bytes": 272684,
+     "sha256": "538d5d01833d6910d4400f8795be582c3427748eb2a162fcec2c17d6707c57e5"
+    },
+    "progs/dog_alk.mdl": {
+     "bytes": 199324,
+     "sha256": "a16e350fcd247908c75ecd0c93e94d3b700b67bb0f66dd45d665d171a55d42b6"
+    },
+    "progs/dread.mdl": {
+     "bytes": 415072,
+     "sha256": "dcea570331c5cf4348c40451c6242bf35ecaaea2a348f12254a13c1b76b13d7c"
+    },
+    "progs/drip.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17284,
+     "sha256": "444692074359310be0520b1caa057ae2e084df826f7ecc9bcb0d258ea1d80373"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35988,
+     "sha256": "91aa79805577466147bd4811614b0387b3635aba8383fc2e16b178d7b63ebdf1"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42436,
+     "sha256": "93839bd6f50323f7ac5ae46037de0c6a10a533374f714229dd511ee62b88ca3c"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bcc6396dc638003480dba8c36cafaf32df2cfcf49bd460b001d0d74a164f9011"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/enf_gun.mdl": {
+     "bytes": 58684,
+     "sha256": "39ef1788b39a15f86c8d54b81c43f4126e8361ff80d386c44358f17ddc93769f"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 450424,
+     "sha256": "ecf603c4ebc56438e96d1706a451af8bbe9b090db9c48e38e758ec630a393570"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "ddcf759804fffd97e62c55f67f962e24e8cd646fd982215ac8aefd3e49f67660"
+    },
+    "progs/enforcer_alk.mdl": {
+     "bytes": 333860,
+     "sha256": "85fb5cb9eb1435da65ce0aa6940241b7b4b5fa13e7444713a75c6ec301cc8b97"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish_small.mdl": {
+     "bytes": 221279,
+     "sha256": "34b883e3bf73a520f301cced68629e0d95e88f96c03a23230f12d02aa49c247c"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flag2.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flagbig.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 451032,
+     "sha256": "1a311e7e74f9a67c9f7468252aedc8c19804f65375d229e90afbec2f93849823"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/fromitz_still.mdl": {
+     "bytes": 6964,
+     "sha256": "63204597e828e001c957e9316878995e161da0502764276b90285accadf6a222"
+    },
+    "progs/g_axe_alk.mdl": {
+     "bytes": 50460,
+     "sha256": "92988e970870f2b977f7490d2ea4ee040d338fa4bdc470e8d68f2e5a856a7a28"
+    },
+    "progs/g_axe_alk2.mdl": {
+     "bytes": 50460,
+     "sha256": "e448b2a7540ba959453592b2472d0ae498142a77242c91fd5991ca23a7973f4a"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_mine.mdl": {
+     "bytes": 37780,
+     "sha256": "5057c7736e8c722270c781e47584972f42e7ebdd5860596403a9ce7688d0b5cc"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "15f390e39e02c8524e575ca8fadf63187b641c58210ee9587b13a0ca94c29cc2"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 199076,
+     "sha256": "7ddca6fb95082d0cc7ffe5aa3ba896ea987a80b1bd5867db97b2a84b9d8da9f6"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "8b05b8ca87ea867c2a2397d238311fda2441f5c0e1cde130ba487b0dbd17a8e5"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_arach.mdl": {
+     "bytes": 60292,
+     "sha256": "daca6412383bec28809cee42c4ebf01085cf83ed6ff289114ba0f842b4005251"
+    },
+    "progs/h_bams.mdl": {
+     "bytes": 37316,
+     "sha256": "58c4644a2ed3e5f10741dff2ad1a8bb161f7eb205ba3fd8c5fc9b7e4ffc571dc"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_cyberscrag.mdl": {
+     "bytes": 62036,
+     "sha256": "df7d6bccc97bd5c184d9d6160005b370175aacc16a34bd06ab14c7d69ff60419"
+    },
+    "progs/h_demon_alk.mdl": {
+     "bytes": 72644,
+     "sha256": "22a9e01cdccb2e274c63c277e6dcd61986fa7556426ee3562fe11af2babea289"
+    },
+    "progs/h_dog_alk.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_mutant.mdl": {
+     "bytes": 110240,
+     "sha256": "f1f9c665b659a8c145550605ef9abddf27779d0917c897baa344d65673770875"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/h_sabrkn.mdl": {
+     "bytes": 11828,
+     "sha256": "050fcc93189211aba943674a326ddd898dc980b83fb551ee11fec3dd39973483"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shams_alk.mdl": {
+     "bytes": 37268,
+     "sha256": "9fcace6cfb38473763a5cf96007ccc5e0ec4786352d4d1063410d63157298b45"
+    },
+    "progs/h_torm.mdl": {
+     "bytes": 62056,
+     "sha256": "db0ddda0c4d2283cd3c58eb45397cfb57095acba1eb6dd38571ca23ebffe9946"
+    },
+    "progs/h_wizard_alk.mdl": {
+     "bytes": 14948,
+     "sha256": "5f6c27ba255b87718d993b29cff526bd025c0e7a4991722a96fe3c0f98d83408"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hknight_old.mdl": {
+     "bytes": 418144,
+     "sha256": "40bd5757499a2bf7e6f60a78b0039665107c9603c2557f6bc73208e080111464"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 37012,
+     "sha256": "e3c6cbabfe6c6723101f2e59f50fc99ee0e360571c95885d2d56c85eefade15d"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/jumpblue.mdl": {
+     "bytes": 37428,
+     "sha256": "be4e85e5fc643e91377d69794b997ad4dc927ae3866dfef5288d704dbc0f16d7"
+    },
+    "progs/jumpgold.mdl": {
+     "bytes": 37428,
+     "sha256": "4c543d82c88009cab7fcf6230feea0a21518a98f430636194fdbf5c1e526cc13"
+    },
+    "progs/k_laserspike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/kamikaze_grunt_small.mdl": {
+     "bytes": 203376,
+     "sha256": "550aaee63a82db7de25eb3329c368a8bf98ad0aee8af169ee41a857d9087c0f1"
+    },
+    "progs/knight_old.mdl": {
+     "bytes": 208068,
+     "sha256": "5cca43e29392051c9ba95838a58cc1038560411e6c0d2aff61867a428b119e2a"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "63220c0ebb6e266576cb3107a44be16bda10d69fa524d0462514edff9d80328c"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "29bc55efafbea3e15a385598750ba4d9242d0a87803a6bc3430ed772ec1785c3"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "f1e799e7feac3c340676bb60f6cc7a2a7d1e121b196d1f6d0e23edea3a614ed6"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "92370f5b196dc00460d73697975d14279ef659c87c7fc1613b9cbfb68e6c299c"
+    },
+    "progs/m_p_key.mdl": {
+     "bytes": 13428,
+     "sha256": "581a23ac3e2bf0960a7a8b1c4693efd1913d9d17a1f4fa405a1b8c6d89105f91"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "4c5db792da6876f935f8a98a74f51708d52ca03f04975f28518051494660bf65"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "781837a3557c1a8b89c15fa8f477989cb4b77d8cff09c8c13d071090a4df9c1b"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "2feb7ce08070b314d163cbc7f2e2eae0986400c482f752d305ddba268639b3d8"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "04f7fc8b0c2be7ea93021819770145eaf828b2313c4fc591a5f2aa783ca97e61"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 8372,
+     "sha256": "9b6a8f7a49fb7a1f5d4d409b708663c579d433e978d898b9bdf00291a59b4e6c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "fa5d7a5e2410ac7faa5dd0a8e17873c972c6e5cfeacc94118f22db1b4b17477c"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/mutant.mdl": {
+     "bytes": 352720,
+     "sha256": "262ffca22e0c7308950076c2789436a891399862ea25afbd06040158ec9f7984"
+    },
+    "progs/mvore_bomb.mdl": {
+     "bytes": 12653,
+     "sha256": "dd54f975b770db899ef71174d8b05cd98af99739e9506fc4eb354ee8d7e820b8"
+    },
+    "progs/nephrenka.mdl": {
+     "bytes": 807192,
+     "sha256": "e1efdf4467614012164148e6af70c5a3076438e990fc1f48bc4fafb49f681340"
+    },
+    "progs/nephrenka_shield.mdl": {
+     "bytes": 807192,
+     "sha256": "5c7a3957118c7c7370ba1b7ef8fe00b97813bff193dda6ed2c7029e72d8c1c70"
+    },
+    "progs/nsoldier_alk.mdl": {
+     "bytes": 563108,
+     "sha256": "6071d7cecf231f0a83f2e1c7df533b4a32beb6e75969d17703446a67d011695a"
+    },
+    "progs/ogr_gun.mdl": {
+     "bytes": 52452,
+     "sha256": "eaa6e0fe01255450d578f151c06c5aeb6a9cd5ed90edbbe4f52d305069ed6825"
+    },
+    "progs/ogre_alk.mdl": {
+     "bytes": 315696,
+     "sha256": "31e9986373dc1a8cba00e09ba9b0278cf766bbd074524a891ed22329f697d643"
+    },
+    "progs/ogre_old.mdl": {
+     "bytes": 315696,
+     "sha256": "53317e9b684701e7722bea342af1a6dba5dd31e72cdbcfa5b097382516d1c6a3"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 487968,
+     "sha256": "ae0abff3ea3fc7ca8c7f80c5d8825553795a1c1ebb80127d46fa52b20905abc4"
+    },
+    "progs/ogrem.mdl": {
+     "bytes": 378296,
+     "sha256": "2bb999bf580d16fb9ee4246dea7897236d6d118232c78a6168f641dc32778fb5"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/pellet_tracer_short.mdl": {
+     "bytes": 58148,
+     "sha256": "5b24b67ce9d9b2634d9a0f31319a977e1e3ec6352d491367941a0e5bf2ae10ff"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/probegren_body.mdl": {
+     "bytes": 139044,
+     "sha256": "da0ddf337c3e2515688f2b143adf55d4ecbbfa32955a78aea01ed16e067b0065"
+    },
+    "progs/probegren_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "4f292b6f157d226e763ff28dad682ce95cfb8a3a21b4badf0ca48db4900cdd70"
+    },
+    "progs/probegren_gib1.mdl": {
+     "bytes": 63788,
+     "sha256": "0efb081efa87c9db990d984f9974f10078890a51894a3e0a6fbe76cc3c4cb5a7"
+    },
+    "progs/probegren_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "7843ddefa22b7d5beb37f889c606c6361792508c2bea202f3dadf9f3ffce73de"
+    },
+    "progs/probegren_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "7baac250aa8c27ef3158de59b536ebf59509e39b1f7bf6be1c24fd5b1e29cae0"
+    },
+    "progs/probelasr_body.mdl": {
+     "bytes": 84296,
+     "sha256": "ac545d0f545488628c864df6e464d10fbd51cb41a2cb76c46dd91233ecd11a6f"
+    },
+    "progs/probelasr_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "cec7b847c9b05f2653113454348799b9bf09c2a74c8e1760cca0ff52c1dfc18c"
+    },
+    "progs/probelasr_gib1.mdl": {
+     "bytes": 58700,
+     "sha256": "ae9f298abc0bb1d09cea3c04bf02216b0a1c3749f8c8a822d973b4c2091cd649"
+    },
+    "progs/probelasr_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "07d6defee5ce4e747daf8b397a5d207a1a42e3c3acffbdfc18d6720c88ec635c"
+    },
+    "progs/probelasr_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "8b8f376afa56e7a9f311e58a076f1fa3a52c88064887a8e0960fdb6daaf5265e"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12653,
+     "sha256": "162632bc16838f66f29e0b788845a6421b7fce708003e9fa6f4eb8ae7aa8e5be"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/rail.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 200152,
+     "sha256": "a564fba381d24e3084bc9aa0a026381c83e6b889632c8bebdf69c08c8a6bb9f2"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "f65ba83d82e90808af589ded17378f1baf37f105fa14f2b157227ee22583d25d"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 288,
+     "sha256": "6ff2797f9dc4e66f2113475a5f3e0e96f23dacbddd18fe47c8b5e12e712f0e75"
+    },
+    "progs/s_bullet_new.spr": {
+     "bytes": 708,
+     "sha256": "a07fa61f4a838ac9ad8ec85ae525d70fb934d383effd1948c0775497be713043"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "b3f1971bd28f96c623c5712e2a47f54f16c99a50d460a944cdcdf29e6eb03963"
+    },
+    "progs/s_exp_small_2.spr": {
+     "bytes": 201720,
+     "sha256": "f7fdba9e2b9b5d318cdff33a06fad4e91e46ba3a241fe7ced4bfbcf0bcb0e873"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_plasma_new.spr": {
+     "bytes": 13980,
+     "sha256": "5474060e55af3c462d0ef7aad043f331c1f5b642915d906c1785bb94595cc68c"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 2820,
+     "sha256": "ea66402d248232b0b6a77bffe024d4a62881be47becf37acb42328661b7f23ef"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shalrath_newer.mdl": {
+     "bytes": 228496,
+     "sha256": "93601de7ff47f552ac9d441ddf1faf312417ca914de99529b17bdf7522e7478c"
+    },
+    "progs/shalrath_old.mdl": {
+     "bytes": 211576,
+     "sha256": "409cda15df7b271bd95a895f058a521d43eca63f37c7ac9df175e5b478229bb9"
+    },
+    "progs/shambler_alk.mdl": {
+     "bytes": 502148,
+     "sha256": "bcf685fcd1f4062dc382924d39eae073fc4d44cd2dcb5bc4ca3797fe0b342b71"
+    },
+    "progs/shard.mdl": {
+     "bytes": 10132,
+     "sha256": "0219a0f08bdc1f604ebe1ea2243cd1b27a2b1ab85bedba3a11298f2d22e9b38c"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "662d6a7cd68bca7a9c5e88838d190de6a501252a14b6994a191d0bc91f1f331c"
+    },
+    "progs/sknight.mdl": {
+     "bytes": 460932,
+     "sha256": "9213f6898a60cdc20a7a144c61c13f8d64f1432382dca44b636524edf737dac8"
+    },
+    "progs/soldier_alk.mdl": {
+     "bytes": 359276,
+     "sha256": "623374e5a553c3d886738c9cc0b22c0b3f3435b3dc1b3f473079a1dd1661fc8a"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spiderbot.mdl": {
+     "bytes": 82476,
+     "sha256": "e85556a194664a5f69e70b42aa863d9e67689a418a3afa51e50816174a6fe8ac"
+    },
+    "progs/spiderbot_gib.mdl": {
+     "bytes": 19444,
+     "sha256": "96ee732ac1199a89c675880700c24e1f09521c35ad478f73aaf4278a398454f6"
+    },
+    "progs/spike.mdl": {
+     "bytes": 2820,
+     "sha256": "783d711b408498dbb34581c9a0ae74ed325dc5c68fa67873745b02c8a926a201"
+    },
+    "progs/spike_old.mdl": {
+     "bytes": 1684,
+     "sha256": "5e3be5dff13ec94951aacbd4a453dcbd9c2aebe7e4e6bded2dd70d49d1ddd695"
+    },
+    "progs/supbkpack.mdl": {
+     "bytes": 44408,
+     "sha256": "781c6b5f424fb58e06b2a84b1fb7e980778decde6b3ed257e224db0b1f250173"
+    },
+    "progs/torm_largeshot.mdl": {
+     "bytes": 37852,
+     "sha256": "ce3a87be213e39b48bc71a6fbf5e1fe9e3f5209901ca45801f27d8f297e04a01"
+    },
+    "progs/tormentor.mdl": {
+     "bytes": 461080,
+     "sha256": "df302dea113f54df908f97c26de844d1235004c08aefcf5c349f3af4b0957d41"
+    },
+    "progs/trifecta.mdl": {
+     "bytes": 25460,
+     "sha256": "2c9196af0806c48354f5522a8b7f6fa57e6390f8dfb51718fb71b8a2d4d7447a"
+    },
+    "progs/trifecta_big.mdl": {
+     "bytes": 25460,
+     "sha256": "9633a10c7c20f77b9202befad3cb363aefe710b166e581f80967ad94b5c6b6eb"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/v_alkaxe20fps.mdl": {
+     "bytes": 96428,
+     "sha256": "4405242db772d86c66f1012b140ba409bee86682fa5f4a6ca12c3e6f94eb9fcc"
+    },
+    "progs/v_axe_alk.mdl": {
+     "bytes": 55820,
+     "sha256": "80ad34cf2612f8fa9121f2be0ada92c1e05613ae2b35b2a1be25a4c694dd2147"
+    },
+    "progs/v_laserg40fps.mdl": {
+     "bytes": 142580,
+     "sha256": "b897ecb5868e3125597d51f970075af04782cba47ed8a42d7b17775dff01f536"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_mine_40fps.mdl": {
+     "bytes": 332920,
+     "sha256": "0039956e96a804229359aaf082b9cf66515d52360867b86c3dca884d19caf8b4"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail3.mdl": {
+     "bytes": 124944,
+     "sha256": "19045e9a5154299b68377744ad946fc3e7f2bd290497c8291a2247ed8cc572ad"
+    },
+    "progs/v_nail_alk40fps.mdl": {
+     "bytes": 44692,
+     "sha256": "402b3dc06f1e5e756cfd50cab17cca49e17e261994c5007cfd46c466a08d3dad"
+    },
+    "progs/v_nephrenka.mdl": {
+     "bytes": 13684,
+     "sha256": "a6b22faa92528d6341547677c04b058c3374e2a1b3499ae73861418746c2b1ba"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 260692,
+     "sha256": "0982368440a5d20d65ec511207590c2bfb63e9a60376a5d753b209f2b047c58b"
+    },
+    "progs/v_rock2_40fps.mdl": {
+     "bytes": 139668,
+     "sha256": "89257b7580ac3f48fc775f121eef3508c326eba1369e6aacae83144f8fdfca15"
+    },
+    "progs/v_rock_20fps.mdl": {
+     "bytes": 39556,
+     "sha256": "ebdd6245e1ff65bd95eaed7fa189ac87b51818408f091a32de3f4a477b90f2f8"
+    },
+    "progs/v_rock_40fps.mdl": {
+     "bytes": 43828,
+     "sha256": "f3c32a1c37d4fc3115a8da00ba9507cdd508a98f65e2ddccbcbdc8a0ba0bf2ea"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 326464,
+     "sha256": "dd389cc337d8b7675d9a7b983fd9f53f0c59d597a9759367bd1e1beba375eaaa"
+    },
+    "progs/v_shot2_40fps.mdl": {
+     "bytes": 29076,
+     "sha256": "37ae91c018183faef847aad217da537c97b5a2430ab27a860388bffc1f4514f6"
+    },
+    "progs/v_shot40fps.mdl": {
+     "bytes": 29252,
+     "sha256": "87a47e2debbc27fd6c18a8a38a9a373e7b73ba707458e6346f069c1572df47b4"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_p_key.mdl": {
+     "bytes": 10580,
+     "sha256": "fb3db38e23feda2ca9a8ee1400bdd0b452332f07bf9455db3eac0e52af1e3c22"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/wizard_alk.mdl": {
+     "bytes": 158508,
+     "sha256": "aab430eb2dc0f5c50ca7b4492a7ccc427f2a12011f54ece1b81d4beb66acb4a9"
+    },
+    "progs/zombie2.mdl": {
+     "bytes": 130148,
+     "sha256": "a06c8cff768f0e5491e2a5a0d22671b525d841df7081036ab2d63507eb17881c"
+    },
+    "quake.rc": {
+     "bytes": 2052,
+     "sha256": "b791b9736f5ee57b06dc0bcdc156b13dda9144bb0a972ee5b5069de73c10e55d"
+    },
+    "sound/arachnofloyd/death1.wav": {
+     "bytes": 119460,
+     "sha256": "d16c7ff30e9df62fbcda102befbd61fe234532f6aef30d0b34c25330679682bc"
+    },
+    "sound/arachnofloyd/death2.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/arachnofloyd/idle1.wav": {
+     "bytes": 34254,
+     "sha256": "35d6991a10637251ec0d6b830f7f57f394e4eed06e7a9dced86f0128ba5bc49e"
+    },
+    "sound/arachnofloyd/idle2.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/arachnofloyd/leap.wav": {
+     "bytes": 70884,
+     "sha256": "f47323f618db14755c57e9e25213267dcffc501fbaa9a201176ab99db6cda928"
+    },
+    "sound/arachnofloyd/pain1.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/arachnofloyd/pain2.wav": {
+     "bytes": 15906,
+     "sha256": "9c4bdc81c73787cb67677e0021b71d9e24734ef3ce272d9020dc6611a1d87842"
+    },
+    "sound/arachnofloyd/sight.wav": {
+     "bytes": 48620,
+     "sha256": "97a055dbb8e5935190348b2c2d50c6d99ab35c29f3ebcd0f66d6263bdb5485e4"
+    },
+    "sound/arachnofloyd/step1.wav": {
+     "bytes": 74932,
+     "sha256": "a8744a3e50dccf9ee391da2f381c2ecf6701a76441406929ee4581c7717b880f"
+    },
+    "sound/arachnofloyd/step2.wav": {
+     "bytes": 34478,
+     "sha256": "22ce43aa18537f7b04e31263a46dd02e181d538fdf5918d55f8ce0acbb930676"
+    },
+    "sound/arachnofloyd/whirr1.wav": {
+     "bytes": 19762,
+     "sha256": "9e2029071248e6d45f1b0d518983bad5bc5f841cda6bcfba09486e111add10de"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axegrunt/axgdeath.wav": {
+     "bytes": 20214,
+     "sha256": "e5ed762afcc516058acc1b3884b4d08e67fd36e3a5bacf711d3504363bf8136e"
+    },
+    "sound/axegrunt/axgpain.wav": {
+     "bytes": 12636,
+     "sha256": "4699951fa58fdf15ab819b13d70904fc9a1a86a4db02193d621dfad3878d17bf"
+    },
+    "sound/axegrunt/axgsight.wav": {
+     "bytes": 17712,
+     "sha256": "e7b23208831c1d83793ba06f3b8855430c92017600cd8315341afbcb6ec6c8f0"
+    },
+    "sound/bambler/melee1.wav": {
+     "bytes": 4175,
+     "sha256": "4e0e2567b9d64b3ff86b33d95fa0158bf72372aeb4968a0c2489df942f9f7c4d"
+    },
+    "sound/bambler/melee2.wav": {
+     "bytes": 5283,
+     "sha256": "4bb91991bccfc33576eff19037e12666e9825348272d3dca40199e208bc00700"
+    },
+    "sound/bambler/sdeath.wav": {
+     "bytes": 14048,
+     "sha256": "c5253af82d203e75d132a00bbb555de055d2e356106d460f34cb8c9a2ee5e643"
+    },
+    "sound/bambler/shurt2.wav": {
+     "bytes": 3736,
+     "sha256": "0f1a51e0ff72f23a4de7684d4408344b7b7bd2cb805609168d2f2459e1b8660d"
+    },
+    "sound/bambler/sidle.wav": {
+     "bytes": 4907,
+     "sha256": "ea2232ba791e306cc86f58303413d8f3fbc7dd38091281698f4d846b6cafa483"
+    },
+    "sound/bambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/bambler/ssight.wav": {
+     "bytes": 11376,
+     "sha256": "de766aa056ca5f7dc6d179e6a220ef906ceacc0341b5cb3d91a4d0e75ff55338"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/cyberscrag/fall1.wav": {
+     "bytes": 23396,
+     "sha256": "162fc0be1cd0eadfc93c35f1e1ba9b8dfc7e8df8ee53afb2a14db73e69f20ce8"
+    },
+    "sound/cyberscrag/hit.wav": {
+     "bytes": 22334,
+     "sha256": "a16ef33d94d56fb6984b2a3d06104a3cc292bdb38ec6ee22c8b10457b2cb415f"
+    },
+    "sound/cyberscrag/wattack.wav": {
+     "bytes": 25912,
+     "sha256": "6bed724b7ef9bdd480448396ed4498c75f848bf2a1e6d2879cb2b2484cdd1a7b"
+    },
+    "sound/cyberscrag/wdeath.wav": {
+     "bytes": 20684,
+     "sha256": "24602233cca209122250ba7c284933992aa2393795ea5c528a57b9986e2fc319"
+    },
+    "sound/cyberscrag/widle1.wav": {
+     "bytes": 13465,
+     "sha256": "8902628d2201eda9396c0dc134ebda8b8d5c37dabddcd286f8387aadc6532750"
+    },
+    "sound/cyberscrag/widle2.wav": {
+     "bytes": 23094,
+     "sha256": "76af020e5c25f40ab3020bbd065a9b83b9b0a51120d47d137a7abff4eb43e193"
+    },
+    "sound/cyberscrag/wpain.wav": {
+     "bytes": 8687,
+     "sha256": "af2e8589d381e634f607048ce71200df832c9e3a32147891b5bdd2efe2ff5bf0"
+    },
+    "sound/cyberscrag/wsight.wav": {
+     "bytes": 13079,
+     "sha256": "2f9178f6515eb4cd518b418441c40d1376aeaf6f42f7791533f5f4b6da87fd68"
+    },
+    "sound/doors/alka_doorlocked.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/q2door1.wav": {
+     "bytes": 30572,
+     "sha256": "3f05bddf76379933970c532656b6350bc53820319ce1cb9d4ea9288210427eee"
+    },
+    "sound/doors/q2door2.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/dread/dread_death.wav": {
+     "bytes": 49692,
+     "sha256": "22000ff613ff52eab0605418681affaf7aeef4acc420d3dddd50a9031ac1ca38"
+    },
+    "sound/dread/dread_pain1.wav": {
+     "bytes": 29220,
+     "sha256": "67e443f78043cb9fc4213bbfbc3cd847785a66849fb7b36dd6467494487e0aec"
+    },
+    "sound/dread/dread_pain2.wav": {
+     "bytes": 23380,
+     "sha256": "914fffe3ad6c02fb78be873ee96405a40df22cd321beee2d673d0b6ebbafcde4"
+    },
+    "sound/dread/dread_sight.wav": {
+     "bytes": 70792,
+     "sha256": "50449a772b2ac778b810a69de58cb63c8bbdea529091720a41a1052b7196632e"
+    },
+    "sound/dread/dread_sight2.wav": {
+     "bytes": 58420,
+     "sha256": "f7952137b648f6376a1ba4e968679abb17fc648ede87bb0dd32f633271ad80ee"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 110256,
+     "sha256": "895cfb57c0d27369530fd5e9b29abd491a989ad0a63ddb00f05dd9e4777a5cdb"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/frogman/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 32638,
+     "sha256": "3cf3933f34c7baef52df54d5b03db40424e9f7ee72e5aa5a4dba489d71be2af7"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 27662,
+     "sha256": "ec38e73fd1ffc33cd25aa065e5f5897c21a494e380763ff80b6be482689b5e33"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 44186,
+     "sha256": "7600cd32fe980646fddcf5a9077d8d43df1bca1f2ed05bd92ce8cca273ad6636"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 132344,
+     "sha256": "9247347179344c541a627bc8ff74e5ce43744e47f5f3a02181402791257b675a"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 33120,
+     "sha256": "9fbfa3f46a27f850615fb4ea4cd760f6ee5817ddad856b44ec51a84138ec91dc"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 54336,
+     "sha256": "1e6a0c92fa9902238e01b4e8a1ff5b9fbe1a37d71cdff7e31f97c0f630d76a20"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/armor_denied.wav": {
+     "bytes": 15854,
+     "sha256": "2ec14677f483d1a1b869af64cc30fb0dbd90a640fc071fdf2ae493d27cd746e1"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/items/shard_pickup.wav": {
+     "bytes": 18260,
+     "sha256": "388923a63b48720647b9e0f2862c35bb1d5cad2e162ace343845b3fe36b48af4"
+    },
+    "sound/items/trifecta.wav": {
+     "bytes": 16412,
+     "sha256": "00baad51adaa3f5d6664e85ae5442221db6818bfd85124c164324d22f6723ab2"
+    },
+    "sound/items/trifecta2.wav": {
+     "bytes": 32778,
+     "sha256": "f742a9cee4a53ef52fce55d5e9ddaae9c6b20d2127e16c0def6cd11b3d2d6380"
+    },
+    "sound/items/trifecta3.wav": {
+     "bytes": 10728,
+     "sha256": "a78bfc9fa4fbf0c3c1e85bee273ee053598989a09146bd29e97dda811c49a473"
+    },
+    "sound/lieut/alert.wav": {
+     "bytes": 8700,
+     "sha256": "7ebbe83ae1b5d159c9f0a0ae5f3dea126650ed5d6f98a22d1512dcfcb19a23ca"
+    },
+    "sound/lieut/objective.wav": {
+     "bytes": 10052,
+     "sha256": "aa7d6726a458eaa48bf2e20446c57360b82ac23bfbd06bad7b6e01ae95ca8b0d"
+    },
+    "sound/lieut/target.wav": {
+     "bytes": 6754,
+     "sha256": "eebd50c75585894c7d5305f6c066aaef1efaca9a59e27b80d03e8ae4d69caa69"
+    },
+    "sound/lieut/you.wav": {
+     "bytes": 7126,
+     "sha256": "6bfb031b0d69b8ae4ef2e9b201da43c523ae88de344907648d4064e07477ee1c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/mechavore/attack.wav": {
+     "bytes": 66460,
+     "sha256": "fc2a8b0e2a72aebe2858b8337d5ef0638e3e04d5b60e9a62d46ac124072705f9"
+    },
+    "sound/mechavore/death.wav": {
+     "bytes": 37504,
+     "sha256": "bbdf8369941f8c2ab302fe3a55de3bf04e1d28e32a575ffd3c24009d76bebc8f"
+    },
+    "sound/mechavore/idle.wav": {
+     "bytes": 64972,
+     "sha256": "5cd8253f1abe5baf08f1852d12393ca820c34fc0f2febf6c1c8f9d4c3326b2c5"
+    },
+    "sound/mechavore/mv_attack.wav": {
+     "bytes": 67046,
+     "sha256": "af133ede9ab5627f3ea75b12716653b11dd813982cab4a6aad0792371ba58006"
+    },
+    "sound/mechavore/mv_death_a.wav": {
+     "bytes": 125364,
+     "sha256": "7a51ba5587b4c8ccd4bd0e93b105f277f4f093a1cd90f684afb33cf0bbfc812e"
+    },
+    "sound/mechavore/mv_idle_a.wav": {
+     "bytes": 61484,
+     "sha256": "463f1bd23c4bf5d2953ce2f7ee980c9fb28725a0bdc92bc1f03dab8e139a2f14"
+    },
+    "sound/mechavore/mv_pain2_a.wav": {
+     "bytes": 41004,
+     "sha256": "18e27023c1ea7ce306f49559a8f303f62fcc206f05f94878bd1898e204972ebd"
+    },
+    "sound/mechavore/mv_pain_a.wav": {
+     "bytes": 49196,
+     "sha256": "7e2a98060c2ebe14313c831e8d3d410aacd70d7bffa9ef45b0f98845cebdfab1"
+    },
+    "sound/mechavore/mv_sight_b.wav": {
+     "bytes": 57388,
+     "sha256": "2212706950e66000184352238f479d659ea37062186b595e6834bb4d1d910c7f"
+    },
+    "sound/mechavore/pain.wav": {
+     "bytes": 36444,
+     "sha256": "9f9368fdd53aec80fd43a6d3b6680e04aae72685d1cfbdf49d55dc1070e8c546"
+    },
+    "sound/mechavore/sight.wav": {
+     "bytes": 116312,
+     "sha256": "112613b44d88046653b29f21aa5fced5d4b5bfcaff037dfa5f246729e45a6968"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/conc_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/misc/door_closed.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/misc/ebell.wav": {
+     "bytes": 15220,
+     "sha256": "1693337ed8873f1159e56c2925afaa210f5c28bee4e2c42d27e29bee8e06cb5f"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/jumppad.wav": {
+     "bytes": 31485,
+     "sha256": "cfc06af995406d853cae30df8db02c340bf7c775f955f5a02de60dc20c66fc0f"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 4054,
+     "sha256": "b9c44f73c8bdbc900af4f06600e0d6456a040b296612b7d0fe53391285976a44"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 4098,
+     "sha256": "4fad66341514c9aa2b31b4c2fde7563369090da9b0b3a51e08bca3100f2ec282"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5054,
+     "sha256": "d158ddc35360bc43934b7a8a9b7cc830f7510e6bb3a640813157822b27b5217a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 9726,
+     "sha256": "73b74099c8cb43ab2fb09b28b72ddd9f73f2d2a4f8a00a8e835490f366680c92"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 3226,
+     "sha256": "48551cc717e5011df78a38c6a71bb001e4f62a1858a3952311499653ff423a07"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 5802,
+     "sha256": "751050f97456a0c07e88a249d40dde96c2d14640e21670ccdde983502998dbba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/singledrip1.wav": {
+     "bytes": 26546,
+     "sha256": "b9193092eaa02003c7ea409663dc1213f0a18a120471a76d298ce847448059b6"
+    },
+    "sound/misc/singledrip2.wav": {
+     "bytes": 25478,
+     "sha256": "562ac78cd1d84805723e3bb24f66c60197d03bab081d7ee8402bf2b59bc7bf0c"
+    },
+    "sound/misc/singledrip3.wav": {
+     "bytes": 44558,
+     "sha256": "55ae1b970143af2553b845503363d94aa917a1cdb8aa1e48edec7869660007c3"
+    },
+    "sound/misc/singledrip4.wav": {
+     "bytes": 45492,
+     "sha256": "db0126239cf71ce69f6c06eb5c5418889b96e52e6741f6b172a146887e6815ef"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/misc/wood_impact.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/mutant/mutatck1.wav": {
+     "bytes": 6116,
+     "sha256": "410f926534f21705e78a804ce048b0c15e62fe0c68a45aae1b3741fb227551f7"
+    },
+    "sound/mutant/mutatck2.wav": {
+     "bytes": 18260,
+     "sha256": "66009d09adf71f10117c74f5004c995fd48362b2f4fcfaaa3bc2da01e66d115f"
+    },
+    "sound/mutant/mutatck3.wav": {
+     "bytes": 28840,
+     "sha256": "2dd8a615ca2be248c8370d7480f5a8ca9375d31e6af41bba603df660d31883a1"
+    },
+    "sound/mutant/mutdeth1.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/mutant/mutidle1.wav": {
+     "bytes": 81004,
+     "sha256": "8c7e8ad544d7e2470bd61d88c5cd8be1a0eb66f57aaf113f82d990ee00450073"
+    },
+    "sound/mutant/mutpain1.wav": {
+     "bytes": 56716,
+     "sha256": "49ff5f97fedc87c1ac06dc43d4ff0a0fd09fb481354b6373d607bfabc9a57a6a"
+    },
+    "sound/mutant/mutpain2.wav": {
+     "bytes": 58740,
+     "sha256": "b79f1cce60226daa3e3ca8c134da968d54ad51abd9c37ffebdf3d46c5d9f91c6"
+    },
+    "sound/mutant/mutsght1.wav": {
+     "bytes": 107316,
+     "sha256": "7e15e392edc3f2d5ae9e3bde3dfe65595a85728022245f74b81f072d75dce798"
+    },
+    "sound/mutant/mutsrch1.wav": {
+     "bytes": 101244,
+     "sha256": "44484ef4c189511fb0a8d0f2bea83e443e1f1bd51cef04f518f3820e58e88a69"
+    },
+    "sound/mutant/step1.wav": {
+     "bytes": 8140,
+     "sha256": "0d9af35156c84213ac7ffbde54d0f2518fe9d39bba4edc48c94e71bed4f7ec4d"
+    },
+    "sound/mutant/step2.wav": {
+     "bytes": 14212,
+     "sha256": "f7c81df1bff56c8aeb49891fa822c37ddcb019e97a654738a9fb8ee351d19eac"
+    },
+    "sound/mutant/step3.wav": {
+     "bytes": 4092,
+     "sha256": "89856afec31f800219c45253514d0fdf5b5bd800c32f87ba74dd0c21df181550"
+    },
+    "sound/mutant/thud1.wav": {
+     "bytes": 32428,
+     "sha256": "20ed5f20729a068801d06904365e46c9d692dec835710a9b8090d0a1956d6919"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    },
+    "sound/ogre/rogre_alert.wav": {
+     "bytes": 71728,
+     "sha256": "4f3e921b6ee236289660f7ca2ee8a4689e719423266d26a3f8b91ae29d02c6a5"
+    },
+    "sound/ogre/rogre_idle1.wav": {
+     "bytes": 110330,
+     "sha256": "a07df4a53c9e8de310b9d963bfb9c841c51e502565f39dc543bf1c025edd41d6"
+    },
+    "sound/ogre/rogre_idle2.wav": {
+     "bytes": 79416,
+     "sha256": "862258641dc3c90d2a9e5f9e2a4418eb0037eedf22cde798682a169a84f13a44"
+    },
+    "sound/player/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/player/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/player/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/player/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/player/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/player/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/player/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/rail.wav": {
+     "bytes": 97196,
+     "sha256": "396a85e1e2083f2b1eaae89a3f33a21145a643f3f50419523497719ef8e7598a"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/rider/sight.wav": {
+     "bytes": 26356,
+     "sha256": "40ace6f3beeb920ba1bbdb197f8ece18d312762a71e494726289e16703d75d91"
+    },
+    "sound/rider/step.wav": {
+     "bytes": 40524,
+     "sha256": "a43e24ecbc62d44bce466b1e682ebf64c230e03f4d79449406ce021dc8276a9a"
+    },
+    "sound/rider/thump.wav": {
+     "bytes": 15444,
+     "sha256": "af29f4e8f6debb1223aeb5d840add4ae01cb5e9f6bd9a26efeadff518f34380d"
+    },
+    "sound/scientist/allnominal.wav": {
+     "bytes": 23778,
+     "sha256": "e26f9bb3c24d9a9e0da38395048f6dacffe82d800da49d56378027250393d69a"
+    },
+    "sound/scientist/alright.wav": {
+     "bytes": 9666,
+     "sha256": "372c1aa91e6841bec2441215c894b7d149bdeaef33f907d23bb7eaf637520ce3"
+    },
+    "sound/scientist/asexpected.wav": {
+     "bytes": 15982,
+     "sha256": "306933848b673bd14d7074d59e45a8c97bc00a2897601509e52e5835e2ffc997"
+    },
+    "sound/scientist/c1a0_sci_crit2a.wav": {
+     "bytes": 28364,
+     "sha256": "f972684c74eeb51872873cc2b7053448c6cdd716b8c3535929fdbcc508d62ef5"
+    },
+    "sound/scientist/c1a0_sci_stall.wav": {
+     "bytes": 13704,
+     "sha256": "541c192ad5e8a68c76706ec17b3deceafbdc607bfc372ddfd300532f8aa1eaef"
+    },
+    "sound/scientist/cantbeserious.wav": {
+     "bytes": 13236,
+     "sha256": "fc4a8a379f70e33db79a49c667dcd9f1622de29d7b32ef3973c4ffdb5d80ee44"
+    },
+    "sound/scientist/cough.wav": {
+     "bytes": 14878,
+     "sha256": "b4e620259623347a5be3f7eaf3c531e6ea9ef2e97ac42997dd78cfee9327f7bf"
+    },
+    "sound/scientist/sci_die1.wav": {
+     "bytes": 15558,
+     "sha256": "c2306d7f9fa58f99961c347b06ef26305b99ac43ec27b2b222962e1f3a9ccce9"
+    },
+    "sound/scientist/sci_die2.wav": {
+     "bytes": 5402,
+     "sha256": "14deecb570d1e315b772713d54b7250043bb0dd5f3d5538cd0636e39a523c54f"
+    },
+    "sound/scientist/sci_die3.wav": {
+     "bytes": 3104,
+     "sha256": "075cdbc5837d91b61ad7599cdb3abf9323872816f8966c83deab9c0a6e04d7d2"
+    },
+    "sound/scientist/sci_die4.wav": {
+     "bytes": 4024,
+     "sha256": "e6ca0d4f18ac6c1246926646568618057cb70b5cee995c1c2dd69f0179b892ad"
+    },
+    "sound/scientist/sci_dragoff.wav": {
+     "bytes": 8986,
+     "sha256": "0c6a21cd5edf01e495e1258e9a76c05d62c0e3cd697e787fd43fd4bd9126483b"
+    },
+    "sound/scientist/sci_fear13.wav": {
+     "bytes": 4534,
+     "sha256": "dabce7a6c12980f947f7504da264fabb67a804d2e478b7f252ab527fb21a92d0"
+    },
+    "sound/scientist/sci_fear15.wav": {
+     "bytes": 4764,
+     "sha256": "f0d23c680ad138c3cc12da78a3e45cbf3daa47e5da9bc62a1dbb3b27389565a5"
+    },
+    "sound/scientist/sci_fear6.wav": {
+     "bytes": 5588,
+     "sha256": "ff2702b2b9e517b90ea0c2853775a4a95160edfae5af0a7f9208f07624d84281"
+    },
+    "sound/scientist/sci_fear7.wav": {
+     "bytes": 8458,
+     "sha256": "f2a39185c2d39a03b39afd7fe6f942b2f35fd17135ade8ceb4c31968c768aafa"
+    },
+    "sound/scientist/sci_fear8.wav": {
+     "bytes": 5804,
+     "sha256": "4455a29590d5f42ebbf06e600d8ba3f45acfd5000a6b8045891cbecf1d937970"
+    },
+    "sound/scientist/scream01.wav": {
+     "bytes": 14666,
+     "sha256": "b738de99aefbe3a45724914dd6eb79c0f8c219aaf733554a8a5eb94836c22320"
+    },
+    "sound/scientist/scream06.wav": {
+     "bytes": 13938,
+     "sha256": "dee8ac2058635d00458e2e74402d1cfcb5362c64259fc2c4f3b6bba31bdf6337"
+    },
+    "sound/scientist/scream08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/scientist/scream09.wav": {
+     "bytes": 6130,
+     "sha256": "85947649f5fb1491732365849a3025bf5c76c791b395cfdf421fbbd6ec58d351"
+    },
+    "sound/scientist/scream10.wav": {
+     "bytes": 5392,
+     "sha256": "fff4c0735f9c312be7cda848fc2867590437ffe9758fe685e3b4c94678ca1f48"
+    },
+    "sound/scientist/scream14.wav": {
+     "bytes": 4824,
+     "sha256": "dcb7dfb0e307b813476b2e55dceb59d8ae2b9514b1ef02034ea255fa5f086b05"
+    },
+    "sound/scientist/scream15.wav": {
+     "bytes": 3048,
+     "sha256": "37d26fe2d2b8a39d0fec0eceec0ca974ec3dd7fed33bae0d3230a934954105f0"
+    },
+    "sound/scientist/scream16.wav": {
+     "bytes": 2328,
+     "sha256": "4ff04ce8ff07af708c84dacc8df114b68620d47e8e4e4c78dfc4fd33a8a9b98d"
+    },
+    "sound/scientist/scream17.wav": {
+     "bytes": 3836,
+     "sha256": "82fb51224e06db5022adfa58f0b02353c333229ed3312f86dd9ec4f04813c37c"
+    },
+    "sound/scientist/scream18.wav": {
+     "bytes": 3066,
+     "sha256": "bfefcf745ab8d30db11f9113ecf9ba1c5bc6d9b2351c53f3f46d66e03cbea3fe"
+    },
+    "sound/scientist/scream19.wav": {
+     "bytes": 2504,
+     "sha256": "47cc414d201aadb7ba2fe0ce0567ff5360e90fd9de4a167520988513f358ed41"
+    },
+    "sound/scientist/scream20.wav": {
+     "bytes": 21310,
+     "sha256": "124cb45d3d5533572e3cfe4b42bddad2a03dc0d8de1c89a42ea57433432e3a6e"
+    },
+    "sound/scientist/scream22.wav": {
+     "bytes": 15206,
+     "sha256": "6e0a509eb2468466591622e74724c31103b8b60f5d8f29514fb57e9d9d12c9d4"
+    },
+    "sound/scientist/scream23.wav": {
+     "bytes": 21988,
+     "sha256": "8521907e8cecc22e6924d23295a5e8d31333d265ca27a9533b083b68e9da6d12"
+    },
+    "sound/scientist/scream24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/scientist/scream25.wav": {
+     "bytes": 8122,
+     "sha256": "38281749deffb4e567896f71e7bcb75d7b2e253e404a953a5eea6eeb989f156a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/spiderbot/sactiv.wav": {
+     "bytes": 17066,
+     "sha256": "f21587ba9bfd159e48c5b3aa1c6e94eac7157053e4e5699459233fb28c2631c8"
+    },
+    "sound/spiderbot/scharge.wav": {
+     "bytes": 7300,
+     "sha256": "b58064dac4e12bd6685edbfe61417a530cde1e5175336193b2fa7a292aca8ef7"
+    },
+    "sound/spiderbot/swalk.wav": {
+     "bytes": 12636,
+     "sha256": "5534fe1b11fea5406aada214681dba031ec4a01e4b660c405b679131ba07a7cc"
+    },
+    "sound/tormentor/angry1.wav": {
+     "bytes": 88890,
+     "sha256": "60f757f523a9cbb3a57c335bbeda8cedbf990b9d20a5b359e610b712a1344b4b"
+    },
+    "sound/tormentor/angry2.wav": {
+     "bytes": 90912,
+     "sha256": "2f38dddb69cf0df2c1e5b028ca06ea22d979e637afa927919e9a93876dc955d6"
+    },
+    "sound/tormentor/death.wav": {
+     "bytes": 176628,
+     "sha256": "7060ecdadac0b1c9eb3574284444932573e4af13082f01374ed8a4633387bb66"
+    },
+    "sound/tormentor/fire2.wav": {
+     "bytes": 52092,
+     "sha256": "4133a00c7ef157d291d800524a148c188a314eb5ca14246958b8ddfeb0d4fe41"
+    },
+    "sound/tormentor/idle1.wav": {
+     "bytes": 115740,
+     "sha256": "78feebc847dccab66478718b66971870f11246c416e2f2c1e9830c459e4c0347"
+    },
+    "sound/tormentor/idle2.wav": {
+     "bytes": 122218,
+     "sha256": "0270712fe40851bb21d959932b4f8f75bbe8b985e2ff383319059c656ac0ce56"
+    },
+    "sound/tormentor/pain1.wav": {
+     "bytes": 67334,
+     "sha256": "03f255d6ee0d6fb83f2a643491f4cd24d9c5ff86444a51b3cf8b5a0de3d86bbc"
+    },
+    "sound/tormentor/punch_hit.wav": {
+     "bytes": 76614,
+     "sha256": "e524d16b000237615bae3b8fed7b74726823cd4258561196f4641728047aaa26"
+    },
+    "sound/tormentor/punch_swoosh.wav": {
+     "bytes": 33044,
+     "sha256": "d0ef38ef4bf33d0c2f92b22c2a767c4efd66eefaa724df50b394958a7be5a705"
+    },
+    "sound/tormentor/sight.wav": {
+     "bytes": 94334,
+     "sha256": "34a13e6469c5e0ce2f6d18721b0cdd634731b9a9f8910a8bb8b685f63dadfaac"
+    },
+    "sound/tormentor/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/tormentor/sting2.wav": {
+     "bytes": 21674,
+     "sha256": "dd2d40459c7aa9d374efe2f219c34773f390df9f5177a83dbfa5fd638a13c542"
+    },
+    "sound/turret/alarm.wav": {
+     "bytes": 22126,
+     "sha256": "20a8a83d73a55dcc3d8a6fcb79b4ff8ecba0b5887cf3bdcdc96303f069b062ce"
+    },
+    "sound/turret/beep.wav": {
+     "bytes": 22126,
+     "sha256": "89f0e2ba68562cfc3e20272f995777c174c2681cfcf29d2ef337974009b42460"
+    },
+    "sound/turret/deploy.wav": {
+     "bytes": 105260,
+     "sha256": "5bb8c1fa8ffdf22e58ac5fb7a337916a457b9d021661742fcdbbdd7ce188c6dd"
+    },
+    "sound/turret/deploy2.wav": {
+     "bytes": 54208,
+     "sha256": "ec26b9451b67dae2929488687b7b9344a96f7538ab5c4f69e8a85602804dffc2"
+    },
+    "sound/turret/disable.wav": {
+     "bytes": 57180,
+     "sha256": "d8767dcce34c1c7f660f5868c23938da4cc379cb4001b88a10ec1aebbf9e557c"
+    },
+    "sound/turret/idle.wav": {
+     "bytes": 35784,
+     "sha256": "fba6bc2ff517ef95a999e3910c74e3594e054ede298c7b3a5659a2c31565d37c"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/weapons/dsplasma2.wav": {
+     "bytes": 45596,
+     "sha256": "87a1b465c16610b012abe83da7851993f9dd756cc764abca0221d31a09aba156"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 43820,
+     "sha256": "32082cd1d44903409e97de782e5d9295272840e13280665a0ef3ff862b187f0f"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 47570,
+     "sha256": "0dd8defb8ecfb1ea72e6ac70ab182573775812e2d7990dd2897d02d3c38464f5"
+    },
+    "sound/weapons/spindn_click.wav": {
+     "bytes": 9986,
+     "sha256": "b84866cddb7e61eea9ca49208d427c2289d63e6e3e2f59d4d51e302573079bc7"
+    },
+    "sound/zombie2/attack1.wav": {
+     "bytes": 22914,
+     "sha256": "da5345280208ea48855526989299927268566cef77ee187035bbe969076d6605"
+    },
+    "sound/zombie2/attack2.wav": {
+     "bytes": 24072,
+     "sha256": "59245700b47794e239563cc94e3ff045fcd7dad795bcfe343d8574ec3ac525b6"
+    },
+    "sound/zombie2/attack3.wav": {
+     "bytes": 15400,
+     "sha256": "0113aad711264c05a9e43bf8dba915bc89661444d7d802efabe8d61ebb3ba13f"
+    },
+    "sound/zombie2/attack4.wav": {
+     "bytes": 20922,
+     "sha256": "0aac55ae62b62cefece56103cd7079beeb433c3764f590641876e149c4328ecc"
+    },
+    "sound/zombie2/attack5.wav": {
+     "bytes": 26086,
+     "sha256": "b58c97928b535e79973e0390512b09d3d0adea79b1b1b5a8de59bc2cde40c412"
+    },
+    "sound/zombie2/attack6.wav": {
+     "bytes": 22272,
+     "sha256": "58c429256e2f5abb9d97c99ceedb78088d8ac977eca94e994b6d1eee8bb3eb8f"
+    },
+    "sound/zombie2/attack7.wav": {
+     "bytes": 34384,
+     "sha256": "d68e81783b6583738227eac608ab7af1a4b1e1b085c1e46bd9c0d029eab4fdde"
+    },
+    "sound/zombie2/death1.wav": {
+     "bytes": 46548,
+     "sha256": "a1b9e2bcebf9c56fb56405d1ec7fe4166ac10d2b6e1acc6f01e58aec9fd63e87"
+    },
+    "sound/zombie2/death2.wav": {
+     "bytes": 47048,
+     "sha256": "5964a3c1a665c70de8302052b2b6d72ea46b0a5e07ba22cc9919e1a0ffefcca3"
+    },
+    "sound/zombie2/death3.wav": {
+     "bytes": 52636,
+     "sha256": "5c76f8bc55ecea263df880e6b683b07066b37c9f62ff589b0e999534d3c256b0"
+    },
+    "sound/zombie2/footstep1.wav": {
+     "bytes": 12966,
+     "sha256": "2a85309bea05b7c7c90a82df071822828e413cce17646a9686fa4f1264d75e48"
+    },
+    "sound/zombie2/footstep2.wav": {
+     "bytes": 16880,
+     "sha256": "d1d9e9c3811b39b67c9a6966851873ff7edf8d1407c5d9b90782b233196a4872"
+    },
+    "sound/zombie2/footstep3.wav": {
+     "bytes": 20904,
+     "sha256": "b12e9ea9b9478428b886fcaab504856393a57abd8cfdfc5ba5357ad745ee3455"
+    },
+    "sound/zombie2/footstep4.wav": {
+     "bytes": 15796,
+     "sha256": "6f82ac60991e64c8c48a3208a161b46f5b916587cb41863992dc1acb08268889"
+    },
+    "sound/zombie2/footstep5.wav": {
+     "bytes": 17800,
+     "sha256": "ca12f6ade73e5d5ba4ec1bdf680ce25afe3270bb88d702e1493b75619ec088d9"
+    },
+    "sound/zombie2/idle1.wav": {
+     "bytes": 143832,
+     "sha256": "aa203b0beb2db12beb6929fbc3646f7f119d4d31ede66b13af0412d396f7dd6d"
+    },
+    "sound/zombie2/idle2.wav": {
+     "bytes": 277026,
+     "sha256": "9496f3179e875bbb4d7442c252eac0eb2b9ef6d2269d43c141e01242ed2de7ee"
+    },
+    "sound/zombie2/idle3.wav": {
+     "bytes": 234026,
+     "sha256": "4820b03de8cebdee6fe787b5bf60724c17a0e133fdd5451176a202043f730f8e"
+    },
+    "sound/zombie2/idle4.wav": {
+     "bytes": 166352,
+     "sha256": "a515e5dc0e4fe1412a7936df5fab0f57a48c385db4fa357c1a4120671ac99617"
+    },
+    "sound/zombie2/idle5.wav": {
+     "bytes": 62782,
+     "sha256": "c6e4e2f26769400b7ca3b08339af089ba28bc063447d642e10cffffc6e03a485"
+    },
+    "sound/zombie2/idle6.wav": {
+     "bytes": 47274,
+     "sha256": "9ad1ced551cb42764fd88baf26ee09dc72d1852fa2da7405fde370d3e4d69a01"
+    },
+    "sound/zombie2/idle7.wav": {
+     "bytes": 45614,
+     "sha256": "41783a7682d5f8bb91aff8308b8657504cc8f0460b5ca436a5d0fb1c93357c85"
+    },
+    "sound/zombie2/idle8.wav": {
+     "bytes": 73070,
+     "sha256": "8f390d861feda3fb3950b0f33ce3efbfa8eda214533324674ac40b6e227b6975"
+    },
+    "sound/zombie2/punch1.wav": {
+     "bytes": 9218,
+     "sha256": "db6787efe0a0b8df5da690b91afe46a2199911b661fc9de1cfffc00b6bb8c46c"
+    },
+    "sound/zombie2/punch2.wav": {
+     "bytes": 8032,
+     "sha256": "747aabd6237176ae1bc62669cb08c7ec65fb26aa2147f6a3e1ab43f02ace7322"
+    },
+    "sound/zombie2/punch3.wav": {
+     "bytes": 13076,
+     "sha256": "05bb75533252d15983a944263789de5ee51187e518f4544fd1915b57ba726c7e"
+    },
+    "sound/zombie2/punch4.wav": {
+     "bytes": 13198,
+     "sha256": "d07556e7fc774958a6105564a990c51a0dab64fcf9508475617921a0ac5b961c"
+    },
+    "sound/zombie2/sight1.wav": {
+     "bytes": 73234,
+     "sha256": "387534044f10592ca6bc7a96b8e782c7b51de87b907e79a8f410d535e17d37ee"
+    },
+    "sound/zombie2/sight2.wav": {
+     "bytes": 52224,
+     "sha256": "cbc95608d4553d0bae66411d69875210e6fc6d728bd30deb6bbce7aabbacb773"
+    },
+    "sound/zombie2/sight3.wav": {
+     "bytes": 63072,
+     "sha256": "cbbcdb6da59d830a3be66095053259b17a90cc6501728ed1aa50d9524818f99b"
+    }
+   },
    "sha256": "9afa4369917a8deab694ec93888ab19a36032b6502308d87d8493f14de218041",
    "timestamp": "2024-05-30T21:39:34.000Z"
   },

--- a/json/by-sha256/54/549668ad72f070d8616913320623ec1d7fc5d7fb7fcf91fce88ea694ad22545b.json
+++ b/json/by-sha256/54/549668ad72f070d8616913320623ec1d7fc5d7fb7fcf91fce88ea694ad22545b.json
@@ -12,6 +12,40 @@
   },
   "Pak0.pak": {
    "bytes": 10527680,
+   "files": {
+    "maps/p_se_1.bsp": {
+     "bytes": 1998408,
+     "sha256": "a83761cfd4cc87db8ec48b40089d15aa4c2be0273441627b5722e4a13961b912"
+    },
+    "maps/p_se_2.bsp": {
+     "bytes": 1934084,
+     "sha256": "fe158d898af7fc026f81418c78415639d610f02334c1700b2fd2d214d986500e"
+    },
+    "maps/p_se_3.bsp": {
+     "bytes": 1956084,
+     "sha256": "85898d26c4ca239341189ff6d2196f0f5c1fc0f75ce8141af3a17ecbe5676793"
+    },
+    "maps/p_se_3b.bsp": {
+     "bytes": 1257556,
+     "sha256": "6f149e4fe2001ad4025a2a150f178ba94b0d2fe4f08521d5777fb4426d8aa770"
+    },
+    "maps/p_se_4.bsp": {
+     "bytes": 1478364,
+     "sha256": "1de18aebd5b9e9852f8283d9f8e8d48a5d5c751b790a8645837683a206d0b24d"
+    },
+    "maps/p_se_xxx.bsp": {
+     "bytes": 206968,
+     "sha256": "73d75e8d1f8a90825d6578fd447652606d96df92bde0dcdfc9369a1278a84971"
+    },
+    "maps/start.bsp": {
+     "bytes": 1644808,
+     "sha256": "b4227e515dd9fb95cc2237eb58c1ad025334180debea265ada01ab5fd2e961fe"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 50884,
+     "sha256": "ad899b103352627329fb57a400a36be5b161cc75a326c85d7facd49ee0d6836f"
+    }
+   },
    "sha256": "722a51e16e4f7001917df1f5bc170ece8e3f0a41646a34e9f317e390cd0078c8",
    "timestamp": "1997-05-05T20:34:24.000Z"
   }

--- a/json/by-sha256/55/55549e114699c8d40d864e86689045104e176ee8457768fc6fbe0bdfeaa4ced7.json
+++ b/json/by-sha256/55/55549e114699c8d40d864e86689045104e176ee8457768fc6fbe0bdfeaa4ced7.json
@@ -12,6 +12,64 @@
   },
   "PAK0.PAK": {
    "bytes": 2678541,
+   "files": {
+    "maps/start.bsp": {
+     "bytes": 1865156,
+     "sha256": "3609cbec6c6acf71f2ac5922f6a4f66ff9c8c14964851bf2c4e6aec67dd16abf"
+    },
+    "progs.dat": {
+     "bytes": 425632,
+     "sha256": "7f1d8008cc8843ebe9f5ead1f9c746f0216881a6805641a9205d9531afa4c73a"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "c6461c3dcf90e4213f4eab64d89d20a27a22dd344100cded0576396a80636af9"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "5f770e264c3854f89f3f9ffc67810ba0127629a66825337b695ba16898f5d6e9"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "c85c8e627e9a3be2e9d3c15e3a571fb21117e8dc208fdf2fe23868ac0a6cacf5"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 76811,
+     "sha256": "f3dbf9f83ccb349ff40a71d6ac398961a8afe2144009b16edf815b0dfe6f0e55"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15704,
+     "sha256": "ed21469ce018f341fda77a87f2334d0ff0071283c6488eb7b46dda271c0b84e7"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16638,
+     "sha256": "293562ac4b64afea8b75a3f2b9596a3d91472df999087b0473b776fbea686cee"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15540,
+     "sha256": "cedf5b3b1a05992ebe42034ea3f4a0478b574aa51ca870659380fbd4750f3d25"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4120,
+     "sha256": "f81112d6c7f8c7b5572490bec2f6da694ac574aab84dc068289eb5d072e4c73b"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8134,
+     "sha256": "c598d983afb987948698202918c92f9fd67ab3472767dfa58ac71bce0ab9e4ca"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9568,
+     "sha256": "438c2d6025df95b8c8d5c31dfdc0dfb0916dffbd4e0cfdeb88c1114bce5073d4"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13094,
+     "sha256": "94fec00ac665adb041f000213dc525fb6e38e4047294607d312e145f6a8a6fca"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48520,
+     "sha256": "3e33542ea8c6edbac8ee092a38182be88acfede2ae2cb0730b7eb9af463c5f45"
+    }
+   },
    "sha256": "8e4eef909fe81b5f9b47e2a1dca389ed5d82652f35652bbd8764ddcef50369e5",
    "timestamp": "1996-06-13T14:06:28.000Z"
   }

--- a/json/by-sha256/56/56d5b2bdbcf40b5cf13a74c117d34a5f563ad608287db8a52f0612832a42917d.json
+++ b/json/by-sha256/56/56d5b2bdbcf40b5cf13a74c117d34a5f563ad608287db8a52f0612832a42917d.json
@@ -7,6 +7,18 @@
  "files": {
   "pdq1sp1-scraps.zip": {
    "bytes": 150901,
+   "files": {
+    "oldstart01.bsp": {
+     "bytes": 247524,
+     "sha256": "197f188f0e8bb954c2abeb3d242691ec35a4506f5a854e3f2aca29cde592c807",
+     "timestamp": "2003-08-01T04:03:50.000Z"
+    },
+    "roomblah.bsp": {
+     "bytes": 148056,
+     "sha256": "56b830daab5e94f45fcdc71bedecaaa87d8facaec8bb4c8e1323ecaa516ca494",
+     "timestamp": "2003-08-01T04:04:32.000Z"
+    }
+   },
    "sha256": "1672509a31aba48072c3844b25bd4116dbbcd741bf2740469898e52cc96db9ba",
    "timestamp": "2003-08-01T04:05:58.000Z"
   },

--- a/json/by-sha256/58/582bfaa3049c18416a276ee40597c22e91a3362be12d585b9491d1c1d90257de.json
+++ b/json/by-sha256/58/582bfaa3049c18416a276ee40597c22e91a3362be12d585b9491d1c1d90257de.json
@@ -12,6 +12,1524 @@
   },
   "pak0.pak": {
    "bytes": 93769389,
+   "files": {
+    "gfx.disabled": {
+     "bytes": 126244,
+     "sha256": "5518a0fc91f3978553dbef7b193868b765dcdb135a931ddbf12ac60ccdcc9ac9"
+    },
+    "gfx/env/miramar_bk.tga": {
+     "bytes": 2203626,
+     "sha256": "912c37b43eb04438914f66806d617e2764f493276dfc72952b416b3f5a41d4ff"
+    },
+    "gfx/env/miramar_dn.tga": {
+     "bytes": 32816,
+     "sha256": "bdfe9f6cd8eb5f950b98233d57adae23c8d30c6b3cb0d91fe3bf761b497aa49c"
+    },
+    "gfx/env/miramar_ft.tga": {
+     "bytes": 2072253,
+     "sha256": "0a39002c9aa7398df764c3e6d868c8c9cb676629453c611f83a832bdb55805d0"
+    },
+    "gfx/env/miramar_lf.tga": {
+     "bytes": 1948166,
+     "sha256": "b4dd955b50d5178d8d11251103c10bdfe8d6a282c0c08ad15babad03dcc6461f"
+    },
+    "gfx/env/miramar_rt.tga": {
+     "bytes": 2036889,
+     "sha256": "40b30c69aeb27c4931df5b3599d80a2adc54c3a354e5cde32aef37ef414fb8fb"
+    },
+    "gfx/env/miramar_up.tga": {
+     "bytes": 1008346,
+     "sha256": "4e524a111bd985a1c55f912a58c5716bcd61d3da2bd69f46d71197faef89dad6"
+    },
+    "maps/ne_obj_wwheel.bsp": {
+     "bytes": 191288,
+     "sha256": "5120d3025ba177cfdacffb9cc9c39d22f9b1adc4c2dc4e4ce00590c5801fd1d0"
+    },
+    "maps/ne_obj_wwheel.lit": {
+     "bytes": 45152,
+     "sha256": "fd0df8f9f8413776e4842f41c067da106572481e85c97face02f12fbaac6beea"
+    },
+    "maps/ne_ruins.bsp": {
+     "bytes": 10349936,
+     "sha256": "1825333a9a6f2f47bbe6091de355c0b89b49788c4ac1d2da990b1c1a5125bd1f"
+    },
+    "maps/ne_ruins.lit": {
+     "bytes": 5022836,
+     "sha256": "da4c773ed34ff78e00c2698c5ba9ffe3a1ad030ab8916fdf3078fffa06f237b7"
+    },
+    "maps/ne_ruins_hall2.bsp": {
+     "bytes": 74364,
+     "sha256": "bda030d1d065b60d5a023fd3d7a0fe0c6d1b1ccada6ee1590a757bf8d020d22c"
+    },
+    "maps/ne_ruins_hall2.lit": {
+     "bytes": 5141,
+     "sha256": "23235205f12b5e515a25990088a484b9f6eaf8feb04c207641f467864d391dbb"
+    },
+    "maps/ne_ruins_hall3.bsp": {
+     "bytes": 102824,
+     "sha256": "4aa644371dc3d535124ba9d8efcaa45af4809c17f3c106b67b3619d88b6f6df1"
+    },
+    "maps/ne_ruins_hall3.lit": {
+     "bytes": 14585,
+     "sha256": "75fd0cb3d094e94dad03bc43be25585f9715e97307ba64a3068293b8bf99169c"
+    },
+    "maps/ne_ruins_part1.bsp": {
+     "bytes": 45604,
+     "sha256": "5f3ea1ac8dc0aec85a32afcd564aa59ea264edc125b8dabae6f22c8976427b10"
+    },
+    "maps/ne_ruins_part1.lit": {
+     "bytes": 8945,
+     "sha256": "34f4e4a9ff3411423f2018f52ab06278ac88da8d885c920b401c3ffa243778f3"
+    },
+    "maps/ne_ruins_part2.bsp": {
+     "bytes": 83976,
+     "sha256": "ffd73ed9a7d00002b87f190592f3e9ca78307a8aceb96ae4364210554108ddd7"
+    },
+    "maps/ne_ruins_part2.lit": {
+     "bytes": 12134,
+     "sha256": "be16fd077781b975794f2e53bfaa4a8c8456beea306680af9fa7c9bdb832c30d"
+    },
+    "maps/start.bsp": {
+     "bytes": 10608612,
+     "sha256": "a4a160dcbd4081d7d6c9ac921c1fb70c3a21c97b533099cf78c77b38e962536e"
+    },
+    "maps/start.lit": {
+     "bytes": 4599062,
+     "sha256": "65135e26e3c9a70b256c88521d892cc1eebfddd37c1f837a6531f64e0fd9c87f"
+    },
+    "ne_binds.cfg": {
+     "bytes": 166,
+     "sha256": "de733245b99edb5881274c738d1b60c0f3468e8611b2b41d378bf7a1828af3e6"
+    },
+    "ne_setup.cfg": {
+     "bytes": 411,
+     "sha256": "ea2822c5ac53d1912c1390c1b43bdfbe7dd107c942b9106bacc30e1bf8491620"
+    },
+    "progs.dat": {
+     "bytes": 1750344,
+     "sha256": "1f20a34aae2da3dbb55a577b4c67864a016c2a91de195883138c05c5c6902998"
+    },
+    "progs/athenalg.mdl": {
+     "bytes": 130088,
+     "sha256": "62876a8d93be10e82162ba6a121943b29f1345d3369bbb7c85295593ba66d420"
+    },
+    "progs/athenamd.mdl": {
+     "bytes": 130088,
+     "sha256": "a508b39057a3ef7359b915a216b0c1ea722a7d90696634a337e9a52d9785d178"
+    },
+    "progs/blastwave.spr": {
+     "bytes": 239958,
+     "sha256": "d4720ea8ce7aa523119295bb392adf5d2cdf2243865b1ca3978378c73e64d702"
+    },
+    "progs/blood.mdl": {
+     "bytes": 5076,
+     "sha256": "cfaa668e3ad706db851b2a7ea40a2eb9f72390b04265e0e8d620af843230b5eb"
+    },
+    "progs/bolthead.mdl": {
+     "bytes": 13240,
+     "sha256": "2e5d8d76a502dc86bf21957c308c35f2670e82b928e557ee9c4bd232ce7b3c2d"
+    },
+    "progs/bolttrail.mdl": {
+     "bytes": 9072,
+     "sha256": "5fa64f022c595d47ff1cf101f82e154c0766618230c904c25bc4d272c5b2812a"
+    },
+    "progs/boom.mdl": {
+     "bytes": 204060,
+     "sha256": "aad35debf79335ca4850a8aaf77def7656a593522c3637a8806405b6cf47bc93"
+    },
+    "progs/brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/coin.mdl": {
+     "bytes": 42756,
+     "sha256": "85099b2b3e4b7f6bded906b6ca707b05b395e1674efdfad34b61fe351ddae78b"
+    },
+    "progs/crystal2.mdl": {
+     "bytes": 12324,
+     "sha256": "c9560cddcb2611453ce689a4a9e4e9552bcfb56172170c9e194ab602832f8c91"
+    },
+    "progs/demon.mdl": {
+     "bytes": 156640,
+     "sha256": "875b197781ea3090298b3b3dbf3b8c4679e136d3f6f5e8e77d262ff458ad287f"
+    },
+    "progs/demstat.mdl": {
+     "bytes": 81396,
+     "sha256": "e7555905fe6c189efdeea623bd251ea67f30b5f6052dba50d1c916208ac8472d"
+    },
+    "progs/dog.mdl": {
+     "bytes": 198788,
+     "sha256": "271b0df20b2630a6e95e53b48b070fb6ed6c7b7f6224ed6eb4863dc375803255"
+    },
+    "progs/draflam2.spr": {
+     "bytes": 3081168,
+     "sha256": "2b515517043be915bfcf70a8671041da253af28366fcb15aa8a212e98cf5e6e1"
+    },
+    "progs/draflame.spr": {
+     "bytes": 738216,
+     "sha256": "574f28c63af5b54f15ce3b8fc81a293de1b5539ec43883c3d21d9abd6e1f4a4b"
+    },
+    "progs/dukeExp2.spr": {
+     "bytes": 45374,
+     "sha256": "bdacf663ee260c017e105472211bedc283df954a25e435314323b18eed1173da"
+    },
+    "progs/dukeExpl.spr": {
+     "bytes": 182478,
+     "sha256": "d97a24edf74720458d2154ef77d722125b1faca4d4b5419577467824fffc9af8"
+    },
+    "progs/eido.mdl": {
+     "bytes": 1847180,
+     "sha256": "911ef70cb82963bad6650ff5d7f93a0d0f0906fe94856c496b2c245e9d7df47b"
+    },
+    "progs/emitter_gren.mdl": {
+     "bytes": 5076,
+     "sha256": "e682240d2d4ade535e65e5c6c4378bcddbf096acb17b20296c5b194cdb30ed6c"
+    },
+    "progs/emitter_hk.mdl": {
+     "bytes": 5076,
+     "sha256": "a9e0252d7b628a130ccaa1eb6fbe3710333ccb23f942cec394adafd2a4ab6d57"
+    },
+    "progs/emitter_mis.mdl": {
+     "bytes": 5076,
+     "sha256": "ddf54d3e3bee45bedca1ff3e53180bcfeb9c6c59d6c145c17483bce02f2acd24"
+    },
+    "progs/fangel.mdl": {
+     "bytes": 1080144,
+     "sha256": "0af844f3e76979d8ff689505f9c340c7194b8cfb3dc2c9f878e4c43410f8c543"
+    },
+    "progs/fcastlg.spr": {
+     "bytes": 10940,
+     "sha256": "22f6c7dc98a4c679687dbf3a7915c875ef17698018eaac2df91634b7413654e7"
+    },
+    "progs/firelanc.mdl": {
+     "bytes": 4660,
+     "sha256": "57607ca5f6227a23f7681639bd59e9a3c8db931dc00831403fc540b19f000bfa"
+    },
+    "progs/flamlg.spr": {
+     "bytes": 92741,
+     "sha256": "e4dcfb11562549d82095ccea3fc08f533f28c5a4c2f153d93b560a86113981ba"
+    },
+    "progs/flammd.spr": {
+     "bytes": 110908,
+     "sha256": "118e6c581972b7f9ceb6de82eee84ce5d1742f772bde8987f09718ad6db4ded4"
+    },
+    "progs/flammd_or.spr": {
+     "bytes": 110908,
+     "sha256": "7bd7168e1e44dfacc4870843df6cfb87561de7e2379c50ab5bc94840a0b48cb4"
+    },
+    "progs/flamsm.spr": {
+     "bytes": 29224,
+     "sha256": "a9c150fb5c19e6e0bf7ead5dcf6ae87d8e9745f4a439779266d0a258e16b6890"
+    },
+    "progs/g_shot4.mdl": {
+     "bytes": 111548,
+     "sha256": "b34b650f9b092f061a05fc38f44283f52a8f1cdca09c3e511fe765694a7baa44"
+    },
+    "progs/gemlight.mdl": {
+     "bytes": 15212,
+     "sha256": "8d9a7649df5fda062256253ab90a67677b0a3c4f46998cf90a09a2578b3ab816"
+    },
+    "progs/gibfroze.mdl": {
+     "bytes": 5716,
+     "sha256": "0bcb6db8dab7bafb98c7350f6d4635beb311f02a7999d75468bf4968442a5c51"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 7544,
+     "sha256": "cffef65c21e75f7188cee71fc672d962515e2fbe153e07bd202cdf75e422bc8d"
+    },
+    "progs/gui.spr": {
+     "bytes": 2124,
+     "sha256": "97cdff61e714638f39196ff64f08a1434070e6bb88ede823dfbe04a4f12e95fb"
+    },
+    "progs/h2golem.mdl": {
+     "bytes": 513260,
+     "sha256": "654ff4d8dc044a8b3328233b72c385c407c7505aee3db01e9350e9ae107d30ab"
+    },
+    "progs/h2golemlg.mdl": {
+     "bytes": 1999788,
+     "sha256": "e8352d2cd46418d7418be2b31d7e84b68084ad2285f634b6eb85784a8cdb34af"
+    },
+    "progs/hbar.spr": {
+     "bytes": 6820,
+     "sha256": "0c79cfbc8532dbf7b960ab2b90e90df98e1596a9e065cb551fc84f55ae71f2e8"
+    },
+    "progs/hlblood.spr": {
+     "bytes": 2520,
+     "sha256": "8c03f9a6207386508fd803f852bbbc24b90fda608b1b4ff53dd2e3b2d21af433"
+    },
+    "progs/ice_expl1.spr": {
+     "bytes": 164076,
+     "sha256": "bf7317d811349602db7a020da3e77065ffd8158a3104e83ddca3b166566df18c"
+    },
+    "progs/iceblock1.mdl": {
+     "bytes": 33732,
+     "sha256": "6c6ac927c1d92a2b34fc6878ca557d712e5ed637571e526badaa9047d8905360"
+    },
+    "progs/iceshard1.mdl": {
+     "bytes": 8596,
+     "sha256": "4a4a59362f5c5ecc2c4ce56419088982d5ed79a02d3c5b5a49bafd4c21c85e42"
+    },
+    "progs/lantern2.mdl": {
+     "bytes": 29508,
+     "sha256": "5a392503ee1ffede3d8fc209c3ecd27c5af59aeb359ab0fa141a882c37bcb96b"
+    },
+    "progs/lavabal2.mdl": {
+     "bytes": 8788,
+     "sha256": "c9c0460568f050a81d53bf25fad44dda20930bf0aacb13032d0d0e7e1a06aa02"
+    },
+    "progs/lcastsm.spr": {
+     "bytes": 19200,
+     "sha256": "a56e3b9495c0c589ad22ac4b455deae48bc0ba269276b85b19342e7cd04d1cb2"
+    },
+    "progs/mistcast.spr": {
+     "bytes": 6300,
+     "sha256": "f1f774aad9c4eae8d802fd02ef4dc378aa51d34363d2470460f5c1b9bb9f2764"
+    },
+    "progs/mobj_m_key.mdl": {
+     "bytes": 23160,
+     "sha256": "ed02215838b1837ae9e771a38476b0e4d0ee16e948ca48052d0ffad094d0b1e3"
+    },
+    "progs/ne_wormgr1.mdl": {
+     "bytes": 18620,
+     "sha256": "a4213f13540591e2325ab7108d172fdb0b96dfe44fa707c6422bf889733e1255"
+    },
+    "progs/part1.mdl": {
+     "bytes": 17204,
+     "sha256": "e81f16c8ad3eed3e5af34009a78ebd8171bf7ca6da1058fa5a143e43eca64909"
+    },
+    "progs/part2.mdl": {
+     "bytes": 9004,
+     "sha256": "459a3ff4a78978ce8f58f4c8e2f928fcf87d90b9a14193c19fb35dae917630fa"
+    },
+    "progs/pot1.mdl": {
+     "bytes": 10904,
+     "sha256": "d426c3facd2d6040947ba18703eb2d2c621216692aebf4829645d59c58d96603"
+    },
+    "progs/pot2.mdl": {
+     "bytes": 6700,
+     "sha256": "662fb32377ae0aab80bcc1bb770ef383a93947dda834c79d1fd5615c39382780"
+    },
+    "progs/pot3.mdl": {
+     "bytes": 5916,
+     "sha256": "1710ec3e9933e9967fb230fa364b664ae0545d0e8d8a40db6908b8e724930d57"
+    },
+    "progs/potshard1.mdl": {
+     "bytes": 1372,
+     "sha256": "b37908a61a1133a082b2f9d821734d3a016cdbf6ca80216623d721bf4d09c9ac"
+    },
+    "progs/potshard2.mdl": {
+     "bytes": 2640,
+     "sha256": "6c8802723e5f27ecce28f1cca2784593af521b28e868038d044b98df674a17cd"
+    },
+    "progs/potshard3.mdl": {
+     "bytes": 3348,
+     "sha256": "287f6c231b202fb92171e5f9c39acc0ecf509273d3cbc0498d76f74f18e45040"
+    },
+    "progs/potshard4.mdl": {
+     "bytes": 1400,
+     "sha256": "2ca5e7a00db9094c921d98bfc12ddacd0bf339a5969501fe280b28965fc854b0"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 58444,
+     "sha256": "735f1263c4fc76fcb1d61c38ebf6b81f72133444169eea0a8de6c193a3bde5b2"
+    },
+    "progs/ring1.mdl": {
+     "bytes": 37388,
+     "sha256": "40388c5f74a75b06f4a3f2488ebd26bcf4f717aa16cdde7073841f9deff59384"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 389196,
+     "sha256": "f92635e7a4972220843cae7561b9df1da259a119ed76f815a41da8bae5c23b56"
+    },
+    "progs/shbolt.spr": {
+     "bytes": 24732,
+     "sha256": "efd794d417a2960107bb6bfb5c267ab4db3695aba89f8a3121548a36a41da29e"
+    },
+    "progs/splat.spr": {
+     "bytes": 1892,
+     "sha256": "d090f9dc34b9dc1832de827ed1b4e1f44afa81e34da5ddfdbcf8226e9b1f9404"
+    },
+    "progs/statwave2.mdl": {
+     "bytes": 15712,
+     "sha256": "c67cf27e15870fdf2be2197049aa07afe0de45b9d23134e5305496256de6d76c"
+    },
+    "progs/succubus.mdl": {
+     "bytes": 420700,
+     "sha256": "9a976f054d5bf0061e86368a2809d8c96dd0a8db47911540c6174ac9135cb7da"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 1242880,
+     "sha256": "8a3ff7c52eff9a859e5d6d8c97081d6f349bc2826221e580b6b76c0e810396b3"
+    },
+    "progs/telefx.spr": {
+     "bytes": 3277836,
+     "sha256": "91f8dd69f5990421945e114669701f61b19b8064b19765e739cfe0ac9347eff2"
+    },
+    "progs/v_book.mdl": {
+     "bytes": 379396,
+     "sha256": "926bf95ee5fea35182ff3d6718faf03efeaaafb44294a4205726771d73a99241"
+    },
+    "progs/v_lsword.mdl": {
+     "bytes": 234540,
+     "sha256": "849d4cf1803321c1b89dcc32fe44e6f6ebab29c7e9dd2057573966e1dcc65494"
+    },
+    "progs/v_shot4.mdl": {
+     "bytes": 161948,
+     "sha256": "96a0bb0f4a377113030a937628e6809cafa6bd5f1c2ffed5f098a1d5d235e17d"
+    },
+    "progs/vial.mdl": {
+     "bytes": 6164,
+     "sha256": "f6c4e6595437bc4a43e86aa801bd1c1e0c0e1435d8cf3179c3ec38308af58183"
+    },
+    "progs/zap.spr": {
+     "bytes": 5532,
+     "sha256": "17a64ccbd647bb70a3649af496f9bfc3bc203bfaecc4c0cdcaf63d785dec7901"
+    },
+    "progs/zombie2.mdl": {
+     "bytes": 130148,
+     "sha256": "185336c7bffe32e496e93f6828278287f89b672c71f2439918ac5e220ae8b868"
+    },
+    "quake.rc": {
+     "bytes": 402,
+     "sha256": "de739dd1dfa5f31b03fa75edcc6ba109171cde230e48cfbb9a7999605d5ca92c"
+    },
+    "sound/ambience/blueflame.wav": {
+     "bytes": 177244,
+     "sha256": "c738f8328f71490a88b8e6ba7cadf8a1de3daeea33d6d449a2dfaf6562953f95"
+    },
+    "sound/ambience/crystal.wav": {
+     "bytes": 371018,
+     "sha256": "4381f3a3ea36bdf9d163dd4ffcd27dafa27c11b52d4b442403633222b98d1ddc"
+    },
+    "sound/ambience/icecave.wav": {
+     "bytes": 368762,
+     "sha256": "69690048c98eb29966e7c429a70a3d8e78aa9e811cb552a61311bfca1dc14fa4"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 135116,
+     "sha256": "0b0b777d49d4f805361ba4404346228f63815a6cc4c3db8fd49686ff24f094ab"
+    },
+    "sound/ambience/region_dungeon.wav": {
+     "bytes": 306430,
+     "sha256": "f99f6bd249c4c00ef5e4bda1aa80d6306fd8eab84ee98a1dee91808d8e8b81bf"
+    },
+    "sound/ambience/region_dungeon_.wav": {
+     "bytes": 16606,
+     "sha256": "3468dbfe046d5925646ecb17dba5120c29832b821eeee1aa312e09e6612c80c0"
+    },
+    "sound/ambience/region_windmnt.wav": {
+     "bytes": 662708,
+     "sha256": "a9dfd57db116d78aea54eff7054fb00ff661aaf8469fac49f5c50bfd159d9b4a"
+    },
+    "sound/ambience/region_windmnt_.wav": {
+     "bytes": 46188,
+     "sha256": "6c35d1820edbd6b157de9c689a3ae387de29d01e7e1d1125f4291b040b6cd1f0"
+    },
+    "sound/ambience/uair1.wav": {
+     "bytes": 53792,
+     "sha256": "11deedf50203f54626fda507224cdedc164911a6352141fc9cdc3bb836160cc1"
+    },
+    "sound/ambience/uair2.wav": {
+     "bytes": 79440,
+     "sha256": "4eda33ed91b42c700e370108f5a21f4473f45d492be5a9ac09f5332f3a7093c6"
+    },
+    "sound/ambience/uair3.wav": {
+     "bytes": 93554,
+     "sha256": "ae5b41ac742a241f968e84f43e432b6c5038146793c21ab0625fde2106604166"
+    },
+    "sound/ambience/under.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/ambience/wat_fall.wav": {
+     "bytes": 39459,
+     "sha256": "d29cc6965723c86d9fbe73be1827d5a1ef755fbbbbc7878e2da8e4af8c22a49e"
+    },
+    "sound/ambience/wat_fall2.wav": {
+     "bytes": 33559,
+     "sha256": "f09234b6f769fff0b0e3fa39e2e2a8ac783f2d4d74f421204bfd79404f839085"
+    },
+    "sound/ambience/wat_fall3.wav": {
+     "bytes": 45867,
+     "sha256": "bb20c45cea2e47433b62d0cfe379445f27d9d9ca9e4a2a7ebce8ed96e5b4336d"
+    },
+    "sound/ambience/wat_fall4.wav": {
+     "bytes": 43305,
+     "sha256": "058490831436caae57010dc345745675f949fa30112f886da5dc2cbb6b9d8930"
+    },
+    "sound/ambience/wat_falla.wav": {
+     "bytes": 39442,
+     "sha256": "a509217c3b49b1c020f10447b8c8b3e41185a7793de766f4f328eb2d1c9540f2"
+    },
+    "sound/ambience/wat_stil1.wav": {
+     "bytes": 197358,
+     "sha256": "4cacc881aae3905495cd4e1b11e627ffe1dc277a07d8e8cbdc40d5e474433813"
+    },
+    "sound/ambience/waterwood.wav": {
+     "bytes": 645768,
+     "sha256": "f0563eb7e872419a71f606dfc7bc38e4ac21012bdf903e3cb74f02eb6ac8bebb"
+    },
+    "sound/boss1/expl.wav": {
+     "bytes": 38668,
+     "sha256": "4badb57891f6620f55bd465ab8924173408967effc0c5eca5ac7c6916acb9841"
+    },
+    "sound/boss1/gslam.wav": {
+     "bytes": 189304,
+     "sha256": "919592a00399c79a6a404808bfca9cafdd23f614a68b694ed9fb0b2db9685641"
+    },
+    "sound/buttons/button01.wav": {
+     "bytes": 102398,
+     "sha256": "3f21c25451f15e2548c3afcafc5e6bd80db1c0699bc8ba9e9dbafcbf1fe56307"
+    },
+    "sound/dmbaron/pain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/dog/chomp1.wav": {
+     "bytes": 78766,
+     "sha256": "834a77917a994df35f3f6180165e9ef2fc174a80266b6f8cadd3bad85b124d00"
+    },
+    "sound/dog/chomp2.wav": {
+     "bytes": 78766,
+     "sha256": "7698bd3264b872e6029089a09236d8a2218abfdec883a699c9624d14e27d1e94"
+    },
+    "sound/dog/leap1.wav": {
+     "bytes": 35122,
+     "sha256": "89cd4cb193f34c7b7f29333d19c8e27f2e46c38b3a29229d335bbe1fcb434e61"
+    },
+    "sound/dog/leap2.wav": {
+     "bytes": 53004,
+     "sha256": "795d68bcd672cb274d05ce4587f6fd2b49368b953f5fa11dd316063da8987381"
+    },
+    "sound/doors/1mopen1.wav": {
+     "bytes": 55084,
+     "sha256": "133d32eade4470ce40efed27d8afdf963126b3f919dda7d5a14e2da8e6c7e4d1"
+    },
+    "sound/doors/1mopen2.wav": {
+     "bytes": 29697,
+     "sha256": "be3a9e091128e84002a26262ff11ebaea53d334ecea3102309f97e56dbd3fd6e"
+    },
+    "sound/doors/1mopen3.wav": {
+     "bytes": 27768,
+     "sha256": "59d302d7263b245dbad0acab56888094e879ac4cd3a8125c776b4c78d2706f6f"
+    },
+    "sound/doors/1mopen4.wav": {
+     "bytes": 30520,
+     "sha256": "3d6d96a868838fdb0f7bfdf03ba2708644e49f9974dfea5917b637931aed0880"
+    },
+    "sound/doors/1mopen5.wav": {
+     "bytes": 23980,
+     "sha256": "23d7dc80c2113ee47bdd0951e6e246b8cf45d304422aae388cd45f55556e4fdc"
+    },
+    "sound/doors/cdoorlck.wav": {
+     "bytes": 146860,
+     "sha256": "f485638b372dea1e2055ebd151e70eb7dcd8c5129943f0bdb1e7b6625eb3e801"
+    },
+    "sound/doors/doorstop_metal.wav": {
+     "bytes": 197344,
+     "sha256": "7efc1130a024791f855da55704d15463d92a8895d20668490b2d900ada442d0f"
+    },
+    "sound/doors/ir_stop.wav": {
+     "bytes": 81054,
+     "sha256": "c5ae31d19bb638cd61771f365beca5998d5795ff035929863a19148d39907904"
+    },
+    "sound/dragon/lfirelp1.wav": {
+     "bytes": 242890,
+     "sha256": "18ff1dab77413a9bcca9be5fc79ccdb48a9167f6bfdc9816ed453262b970c099"
+    },
+    "sound/dragon/lfirelp2.wav": {
+     "bytes": 226826,
+     "sha256": "8059532de45ee128f29edf5016604edeebabd31b495ac1f4d8a59be2dbad1f97"
+    },
+    "sound/dragon/lfirelp3.wav": {
+     "bytes": 298762,
+     "sha256": "574d082f06818b91f01ce3b948494bbd002db3f99304ed3c0aeeadf8e2aca2bf"
+    },
+    "sound/dragon/lfirelp4.wav": {
+     "bytes": 193098,
+     "sha256": "26e8ab6ead586bf67ec01125c48e64a807433348ab85eb64c97a7e1bb122b7b1"
+    },
+    "sound/dragon3/lemit.wav": {
+     "bytes": 456826,
+     "sha256": "14d9e7fec3acc89129a9c19f47d913bbb385473946a6bff7cb936a118205a651"
+    },
+    "sound/dragon3/lhit1.wav": {
+     "bytes": 149216,
+     "sha256": "29779fb5d4e391b8370a8bd6966f495f8857fab1e04866cc65071c38d7b04477"
+    },
+    "sound/dragon3/lhit2.wav": {
+     "bytes": 149216,
+     "sha256": "29779fb5d4e391b8370a8bd6966f495f8857fab1e04866cc65071c38d7b04477"
+    },
+    "sound/dragon3/lhit3.wav": {
+     "bytes": 148442,
+     "sha256": "c08b50a74aa131e06298c1f3a6da74111cf9cc7cfe9fda33e7ecc1920edcafe7"
+    },
+    "sound/dragon3/lhit4.wav": {
+     "bytes": 153256,
+     "sha256": "afc87f82791ff3a4c66c5eef30d87fdc91d1fcda907b7390f8705ab7556da97b"
+    },
+    "sound/dragon3/lhit5.wav": {
+     "bytes": 150308,
+     "sha256": "ec517bb951de68c7aac887e4b35bd32e2835be55c1bc2d96eccd992521de32e2"
+    },
+    "sound/dragon3/lhit6.wav": {
+     "bytes": 150384,
+     "sha256": "f89a042e659bbe24f5e78d2454704d5022c825364eb051dc7cbc14cb0ca07684"
+    },
+    "sound/dragon3/lhit7.wav": {
+     "bytes": 148928,
+     "sha256": "abc070cb28a686d6f91d670957e503c376f46bc8df346d1a8351447b4b253b66"
+    },
+    "sound/dragon3/voidend.wav": {
+     "bytes": 145490,
+     "sha256": "dd49ff8e16484807eea2ee2269c10f56416a56f45d157e31330ef3dee50b7591"
+    },
+    "sound/dragon3/voidlp1.wav": {
+     "bytes": 44642,
+     "sha256": "b1f87669b911dea4c3932aa15d27a81aa10e49a51be7ee0a766a3601c1ce14b5"
+    },
+    "sound/dragon3/voidlp2.wav": {
+     "bytes": 44274,
+     "sha256": "e33fb6f7bba5a26b8f474086f3ce29e2a99b0b8aaa044d83aba033f3530d71c7"
+    },
+    "sound/dragon3/voidlp3.wav": {
+     "bytes": 44860,
+     "sha256": "c403f21f8888dfccfa7568626f4c851effffac0860c7ed8ec0045acf9442a6a0"
+    },
+    "sound/dragon3/voidlp4.wav": {
+     "bytes": 44638,
+     "sha256": "1d45ef34352ea4fb34ce5d59f46a59a8fa95905954584185d9bfeddcbb045348"
+    },
+    "sound/dragon3/voidstart.wav": {
+     "bytes": 194398,
+     "sha256": "2f31f63f8930cc72259e77e650625d72c9394dc1c6f002df4502de453219752c"
+    },
+    "sound/eidolon/death.wav": {
+     "bytes": 141178,
+     "sha256": "40d1e0def7b2fdc32ea97da0966e71f9bb278e91095886f3c0b8fb87bba90a4a"
+    },
+    "sound/eidolon/fburst.wav": {
+     "bytes": 255020,
+     "sha256": "50caa0dac8f845ab445af8bd7e5190f17e9abe323fbe37567de787d36d847cfd"
+    },
+    "sound/eidolon/firecast.wav": {
+     "bytes": 71680,
+     "sha256": "3b00270a03d879987fbc088b1def788bcc56476b410f89a557f0e4fc89ee24a0"
+    },
+    "sound/eidolon/flamebr.wav": {
+     "bytes": 428762,
+     "sha256": "dfef2320228ce44ea1d441c348460f6ba3d079f5769bf7697dbd4073a081f124"
+    },
+    "sound/eidolon/flamebr_v.wav": {
+     "bytes": 55478,
+     "sha256": "e7879988fc533f29a5b5ca89075a0317ea2b9a10f651f2846980859c1e261e75"
+    },
+    "sound/eidolon/fshieldamb1.wav": {
+     "bytes": 87752,
+     "sha256": "ff42b4429d06033f5587405bcbc4f614080b6c109593905a0f8048dbce4a439c"
+    },
+    "sound/eidolon/fshieldamb2.wav": {
+     "bytes": 88594,
+     "sha256": "ed99491db40d15d3ddcb5cea45bd472aad0c4873d5a87afec8b442ac89d0491a"
+    },
+    "sound/eidolon/fshieldamb3.wav": {
+     "bytes": 88902,
+     "sha256": "dc7eed33b1c84230d25a9a22ed4fcb9ec2fc4f2d1a2ae86a3e3d4ebab59c5419"
+    },
+    "sound/eidolon/fshieldamb4.wav": {
+     "bytes": 88880,
+     "sha256": "f156af9e5c7cb2dc22e9fa4aa5502977328842aba3d8deec3745844fed28a6dd"
+    },
+    "sound/eidolon/fshieldoff.wav": {
+     "bytes": 44812,
+     "sha256": "425fb76044ef2156c893b00cb8df40ee6e9ac0dad31e06f0ac34bd8b9eef62ac"
+    },
+    "sound/eidolon/fshieldon.wav": {
+     "bytes": 66954,
+     "sha256": "0c34dd99285cde3ce2983de89a0ed396bef5ebd81da0aa21a4b7004eb4a2df83"
+    },
+    "sound/eidolon/fshieldt.wav": {
+     "bytes": 55120,
+     "sha256": "8c7f5d203f86c767679284397d27958019efa6f8fee7f9a1fd88902c6df7ceb4"
+    },
+    "sound/eidolon/growl.wav": {
+     "bytes": 44380,
+     "sha256": "f9f404c4590f2af8fa9a1cd0de34e1d031e66d88ccf553dba228396f0d8fb012"
+    },
+    "sound/eidolon/idle1.wav": {
+     "bytes": 32612,
+     "sha256": "f14b7ebe508b18fefe8bb36e175396b4c3b6d078a5f957b5e2fb985d47412de5"
+    },
+    "sound/eidolon/idle2.wav": {
+     "bytes": 38740,
+     "sha256": "529408f0166eff030e91268f6cebc50a42894523584e337ab27059ef112633c8"
+    },
+    "sound/eidolon/incmeteor1.wav": {
+     "bytes": 132344,
+     "sha256": "5d32cf0b3cfcfbca686a383852241bdc67c286494f31cf09133b57ac74eec5de"
+    },
+    "sound/eidolon/incmeteor2.wav": {
+     "bytes": 132344,
+     "sha256": "e829474ed9d9cb38bdae66c29d0fa5d2c0e248b7891e2949fceb7ac24e369e13"
+    },
+    "sound/eidolon/incmeteor3.wav": {
+     "bytes": 132344,
+     "sha256": "5e8ce6eecf27de61b7c7d0f94bc5730b8df322ad9b9928028dd005f4fec9c4bd"
+    },
+    "sound/eidolon/meteorlg1.wav": {
+     "bytes": 408010,
+     "sha256": "b975ca2df13dc6f87098b8df7530b8b7125ccd5658aaf1f2d0b9e570785c58ae"
+    },
+    "sound/eidolon/meteorlg2.wav": {
+     "bytes": 375558,
+     "sha256": "cb60e8760480ba9e7ba158eb02dd02490b730580274372fc93d522e36d2a64da"
+    },
+    "sound/eidolon/meteorlg3.wav": {
+     "bytes": 495452,
+     "sha256": "01830642b66abf7c17f6598d2832247651552109882256fd9c07d17a708c9de5"
+    },
+    "sound/eidolon/meteorsm1.wav": {
+     "bytes": 154066,
+     "sha256": "8161a9771a6ab8c3cddf7140104baece2100136d046094532d24a1bf64f57371"
+    },
+    "sound/eidolon/meteorsm2.wav": {
+     "bytes": 197926,
+     "sha256": "d08d8f48a38b6e993abf9df6b5c92b745356ed046889211344fea0664b5c8353"
+    },
+    "sound/eidolon/meteorsm3.wav": {
+     "bytes": 188822,
+     "sha256": "a41fa0b3093b660e03eea7e7ad7c37ab8dd3069dcb75cb3c7d20eeb8f841d701"
+    },
+    "sound/eidolon/meteorsm4.wav": {
+     "bytes": 172654,
+     "sha256": "e976f9822e9696c9b1058c1c6a62f04a23d02cdd23748cd5f884f707d8760e38"
+    },
+    "sound/eidolon/meteorsm5.wav": {
+     "bytes": 181820,
+     "sha256": "1e0aa55c7abf460b261076467104af7452249a6eeb7de0fceb7a518f888ffd0b"
+    },
+    "sound/eidolon/meteorsm6.wav": {
+     "bytes": 128262,
+     "sha256": "4537ce04b421da8f981b08b61f1c42a7a6147d870e9e7789dce8443028ac3af7"
+    },
+    "sound/eidolon/mstorm.wav": {
+     "bytes": 412456,
+     "sha256": "4b26f121d3c3daba92938b6958f49f6a8549a2a88ad673cb086a2b4fc8cd1205"
+    },
+    "sound/eidolon/mstorm_v.wav": {
+     "bytes": 63198,
+     "sha256": "34abc8c03a6820e2fca29fdc678e2c81f124d2d3e881a041b5cd41e39af60865"
+    },
+    "sound/eidolon/mstormstart.wav": {
+     "bytes": 524102,
+     "sha256": "b19218cf5ec583e55409f1cb62e3581c73459f4f38170c92db038291c338ea3d"
+    },
+    "sound/eidolon/powerloop.wav": {
+     "bytes": 223966,
+     "sha256": "55c02be55c06ea86c687e4fc4207f93e7a88c1f77fd6b09fd70c0b240b909e57"
+    },
+    "sound/eidolon/powerstop.wav": {
+     "bytes": 88214,
+     "sha256": "4ecc897cbbeacb3be38b5b83e240a216fd48f5fb45a73e94b6738d7cae18be97"
+    },
+    "sound/eidolon/powerstrt.wav": {
+     "bytes": 88706,
+     "sha256": "0d79f00d7fa928cfdc1da05654292959ab0e9eb5e07c0198572c93bd6b026991"
+    },
+    "sound/eidolon/sight.wav": {
+     "bytes": 27404,
+     "sha256": "c8bc6a8a66a3eb2b6c7e7d074bf0cc9936f50d32d1f0b31d337e2da3751a993f"
+    },
+    "sound/eidolon/step1.wav": {
+     "bytes": 52384,
+     "sha256": "e228c0503d89118be55eafaf3a3bfa0a13e3bdcbe4a043f4a9bb31c9e96cf3dc"
+    },
+    "sound/eidolon/step2.wav": {
+     "bytes": 46128,
+     "sha256": "1a3b867c93932411f1c3dedf4a8f1553f19caabae438cb7989095307d1a6c5c5"
+    },
+    "sound/eidolon/step3.wav": {
+     "bytes": 43774,
+     "sha256": "4119d9c31e359bd48b52bff2842e51c441064896289194f04db44e2d7860cccc"
+    },
+    "sound/eidolon/step4.wav": {
+     "bytes": 41758,
+     "sha256": "6b97f80545d9587580a7b445f13e5a38300627e497ed85357f9448c7a910864b"
+    },
+    "sound/energy/beamloop.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/energy/powerloop.wav": {
+     "bytes": 657274,
+     "sha256": "b0c5ee3a953e926fcf7a981a1b52f4faf29afb5554a521a19fc50f78855e94b5"
+    },
+    "sound/energy/powerstrt.wav": {
+     "bytes": 88706,
+     "sha256": "0d79f00d7fa928cfdc1da05654292959ab0e9eb5e07c0198572c93bd6b026991"
+    },
+    "sound/fangel/blastwave.wav": {
+     "bytes": 66404,
+     "sha256": "eb5683f1837e2b608bd05ec5d300d27a475564f87cc7cc0a9cb1ddd460fd87b2"
+    },
+    "sound/fangel/boltpass1.wav": {
+     "bytes": 22260,
+     "sha256": "43be47a0b86f4b3efadcff2f3a7ec47f16950286010fb6f05f36ef186ce67377"
+    },
+    "sound/fangel/boltpass2.wav": {
+     "bytes": 22372,
+     "sha256": "2503c7d9c82c8bcf495fc190977c4bcd7b3948d400725be566ae4af1647af553"
+    },
+    "sound/fangel/boltpass3.wav": {
+     "bytes": 22150,
+     "sha256": "334d80939a9e94623eabfcbfb80e4717a915aa155ac18be735cc2570f36e63ef"
+    },
+    "sound/fangel/firearea.wav": {
+     "bytes": 48218,
+     "sha256": "b8b76c97da69c7a9d9ebef346b81f551ba98e4cbaeedbdc7343fa0048a7a4c4a"
+    },
+    "sound/fangel/firecast.wav": {
+     "bytes": 61766,
+     "sha256": "0e9f58a07f4f04357051309cac7cfe8e762e01900f87d55d2e8cec1046faebbd"
+    },
+    "sound/fangel/firehit.wav": {
+     "bytes": 131934,
+     "sha256": "3e9bf8fe915cec5218db4d2479e59f8a66f991f6b27cfd61f80dfe534706ebec"
+    },
+    "sound/fangel/rez.wav": {
+     "bytes": 356294,
+     "sha256": "9605a405ce3728160d9e7314949d58cfe690bc5b2fbdf1295abd387d38fd0ffb"
+    },
+    "sound/fangel/vocalize_death1.wav": {
+     "bytes": 19180,
+     "sha256": "126b3c524ea887a769b37e76dc409f81f9f8079c68ae1c9a7029eb6c385bf4a6"
+    },
+    "sound/fangel/vocalize_death2.wav": {
+     "bytes": 28972,
+     "sha256": "539f385d3fff0b661bc10a70562f5a08fd82f436617545748c11f0603ceb8096"
+    },
+    "sound/fangel/vocalize_idle.wav": {
+     "bytes": 22668,
+     "sha256": "ff05535cce970c2991662a0879501eae5e2c085780873b33b30343d4e2aa2fe7"
+    },
+    "sound/fangel/vocalize_pain1.wav": {
+     "bytes": 8516,
+     "sha256": "7351e89917da1b07dc0ed8c665e2cb409d7b99f1c91fd660ccc597d2a08dca6f"
+    },
+    "sound/fangel/vocalize_pain2.wav": {
+     "bytes": 14000,
+     "sha256": "08cc30ba4ff401994eb244a383409a4ca2bdfe8de5bed1ad0f0adf0078a91985"
+    },
+    "sound/fangel/vocalize_pain3.wav": {
+     "bytes": 21020,
+     "sha256": "075291d52a8cab8fef90a132bf6ba9b15808deb8d73f74909c07f4e9eadf05ed"
+    },
+    "sound/fangel/vocalize_rez.wav": {
+     "bytes": 31300,
+     "sha256": "829caeea56d832ede75219ff1140653c42bd90c56558f23b745b2fa85df33107"
+    },
+    "sound/firegug/flames1.wav": {
+     "bytes": 142568,
+     "sha256": "e72b3126deb4788d6c25fce2b27892c7b3012c2af8a1e3d5e0c6a9c628adf3d0"
+    },
+    "sound/firegug/flames2.wav": {
+     "bytes": 157882,
+     "sha256": "8c717b23c3a0aa292f95b97d50fb3d0ad5c60ad7676ec1abb1c8ad6f1f42b87d"
+    },
+    "sound/firegug/flames3.wav": {
+     "bytes": 142708,
+     "sha256": "07d9f83c75cd6893e0d61456b69193bb7dcba2b879e758b5be1b959e4ffd0f38"
+    },
+    "sound/firegug/flames4.wav": {
+     "bytes": 141984,
+     "sha256": "649614ca3452b5d480f43b9aaa09fa46e4be68a919a37186d94ee03dfd17cccb"
+    },
+    "sound/gui/guiEnter.wav": {
+     "bytes": 25188,
+     "sha256": "698d33b7d508ee861b655f50ac4d02c8d7b02f66e9c7ea00ff88b5fe8f8be41d"
+    },
+    "sound/gui/guiLeave.wav": {
+     "bytes": 47460,
+     "sha256": "1e7546e437f13048d217d2116ed05e3c0848e0b1b0bcf395499e551b883c7932"
+    },
+    "sound/h2golem/brkfree.wav": {
+     "bytes": 250454,
+     "sha256": "630505eb8c9c84511f39d2e77096cafcbab044f73569934cda127a4b6f37f138"
+    },
+    "sound/h2golem/death.wav": {
+     "bytes": 374654,
+     "sha256": "de356a2581884e9008ef798775f82049c465aec242cad0f6024b510d33e11764"
+    },
+    "sound/h2golem/fireslam.wav": {
+     "bytes": 103416,
+     "sha256": "544fd0ae6e4328cd63946f1df9301a156c57ef04b577bad4149b7c6a2e6f1e4b"
+    },
+    "sound/h2golem/foley1.wav": {
+     "bytes": 63172,
+     "sha256": "df70437e05de1db42f93966b56a000ea3d35e7474b7f7f3d1b3eb0b449385bea"
+    },
+    "sound/h2golem/foley2.wav": {
+     "bytes": 58308,
+     "sha256": "bf7e089d8e236862c411fdaf92ee87d7add64a9ee42da9e29844e754f2caa634"
+    },
+    "sound/h2golem/foley3.wav": {
+     "bytes": 107470,
+     "sha256": "45c9de6215d9c373048131fcc93bb3494c1e6e5497f8a5a8a490ba5f7ca384e0"
+    },
+    "sound/h2golem/foley4.wav": {
+     "bytes": 103606,
+     "sha256": "bd56749d78738beed63678936e27a56dbf691913b570507145ba36e912b8d23c"
+    },
+    "sound/h2golem/foley5.wav": {
+     "bytes": 122950,
+     "sha256": "8ceb0ec96a14c7c63724461960cc5d5ba58fb631ddc2857397532b2c28066914"
+    },
+    "sound/h2golem/fr_sight.wav": {
+     "bytes": 121884,
+     "sha256": "4dba771c79c26a395911ea0aa6a94ba018d57f017c19b1b301465cd94aecb2c4"
+    },
+    "sound/h2golem/frosthit.wav": {
+     "bytes": 179652,
+     "sha256": "a38f9c4ecea6b5c90e37a4b7745167faf6230107bf228796993528cb6c445faa"
+    },
+    "sound/h2golem/hit1.wav": {
+     "bytes": 28562,
+     "sha256": "fdb6ca2802c4fbbdf8b1090650b33e9dd07fd50c95e89c24617e67a0efd735cd"
+    },
+    "sound/h2golem/hit2.wav": {
+     "bytes": 21488,
+     "sha256": "a4524fa4ea7306b9ce252c879fcb74a836bbd53c285542f9282e09df7b9006ca"
+    },
+    "sound/h2golem/hit3.wav": {
+     "bytes": 42084,
+     "sha256": "5f6e467f27bd091c06f6659216d74b1d6bc7d97c0bf0915ca82e798dcde54227"
+    },
+    "sound/h2golem/iceblock1.wav": {
+     "bytes": 232230,
+     "sha256": "1145a731977927ef306b5de92b72f2da630bfa78eab15e20fc5b7e929ca45cfc"
+    },
+    "sound/h2golem/iceblock2.wav": {
+     "bytes": 233324,
+     "sha256": "c9832e74918d2b6c9cf48c3ae2b8dcf4c34c90445b6ba23d33a5564b05f53ddf"
+    },
+    "sound/h2golem/iceblock3.wav": {
+     "bytes": 193242,
+     "sha256": "c0dc93c8d1a4b634f1dcb1231210ef01cedc0a2e1bbedf6d16db3d6352f09a08"
+    },
+    "sound/h2golem/iceblock4.wav": {
+     "bytes": 233514,
+     "sha256": "811600d495706137d9bfe9b30699ce99c538210480a49f8d9aaab7469978adfe"
+    },
+    "sound/h2golem/iceblock5.wav": {
+     "bytes": 139192,
+     "sha256": "d28c1599b1b68c17f0fe9867a1e2cf5e9804f13822dd0cd0bf72716ea1e891fe"
+    },
+    "sound/h2golem/iceblock6.wav": {
+     "bytes": 139536,
+     "sha256": "4b03fd4a614d7caaa8efa9d393e3d2a446b3d5ea944754aab9c71ace86647216"
+    },
+    "sound/h2golem/icebreak.wav": {
+     "bytes": 325290,
+     "sha256": "24852c42755885021ade5dbb62f0cb17ba07ea46b31dfc724c0f7ba0ec3d0b1e"
+    },
+    "sound/h2golem/iceerupt.wav": {
+     "bytes": 165372,
+     "sha256": "ed87e88b2f8771ae6babb3c0d9ebe50b3c4ff3c3d463cc0b47f7141d5bc4e032"
+    },
+    "sound/h2golem/iceimpact.wav": {
+     "bytes": 91578,
+     "sha256": "9197dd4b72c944193bfc84999908c090d771f0cb9b2cf6199df675dac4ebb656"
+    },
+    "sound/h2golem/iceshard1.wav": {
+     "bytes": 60672,
+     "sha256": "ff77079507ccdfe9b8e46adceeb997514fc42941dec8c666658189213b9bc618"
+    },
+    "sound/h2golem/iceshard2.wav": {
+     "bytes": 56672,
+     "sha256": "9d051b83ccd0c2137f3929d42b422ea6f2d6af9c449376f2e21865fdb0a393d8"
+    },
+    "sound/h2golem/iceshard3.wav": {
+     "bytes": 65712,
+     "sha256": "9a8794f30efead4e5c5f4a1dcbcc21c4f3fa7383de39992f46bb076bc48f6375"
+    },
+    "sound/h2golem/mo_sight.wav": {
+     "bytes": 84320,
+     "sha256": "8e6d90e2bf02c5c7dc3711114fd5e1ba7e1f6812923289bd56ecbdf2672858ee"
+    },
+    "sound/h2golem/pain1.wav": {
+     "bytes": 27948,
+     "sha256": "388150975b33e271db5402f502c6a36899731ec85cb9b16cdcc4b427b206a3f2"
+    },
+    "sound/h2golem/pain2.wav": {
+     "bytes": 32940,
+     "sha256": "b3908c02406bcb8c379f345f80a825aa270a54ae02fe0356e02330620d9cf437"
+    },
+    "sound/h2golem/sight.wav": {
+     "bytes": 76762,
+     "sha256": "8cb83deb57c55e9b03b22fe5d9fdbb8f34032770020d643d4847908561df8ec3"
+    },
+    "sound/h2golem/step1.wav": {
+     "bytes": 47332,
+     "sha256": "3bdfbc4b72526e51511a067b528935bd283757fd67b65d1688cd7de87cbe73d0"
+    },
+    "sound/h2golem/step2.wav": {
+     "bytes": 48724,
+     "sha256": "39c294aba178be55b4b5352e5e01e65816c5d3e953cd11d721fa47c499f81aca"
+    },
+    "sound/h2golem/step3.wav": {
+     "bytes": 39982,
+     "sha256": "7c44d3e92f0cf2514262e5c1def5da2bcee808abe24601cab18bf716f8c6ab78"
+    },
+    "sound/h2golem/step4.wav": {
+     "bytes": 37596,
+     "sha256": "a801e51c6fc1a3a96556e6888cb936f5616019b14a5e311363736d903374aec4"
+    },
+    "sound/h2golem/step5.wav": {
+     "bytes": 39386,
+     "sha256": "37dd158e521c5c8116a1fd540ae0755bf02fa26265664d8c12d6f2db506996a7"
+    },
+    "sound/hknight/ritual.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/hpool/heal.wav": {
+     "bytes": 349232,
+     "sha256": "be2a5fb6649a35a669559df87e3b0890b0db4fdc72c1e43a06c11928e6dfc77b"
+    },
+    "sound/items/amulet.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/items/coin1.wav": {
+     "bytes": 37746,
+     "sha256": "69f0ba853e9bccd0f08e5c61ffabd3a05aac80c648b6e8748032d2d540a476d5"
+    },
+    "sound/items/coin2.wav": {
+     "bytes": 36788,
+     "sha256": "40c150da3f3b03409c75da2a0f21bab55b507591d087323bc459a3c28a1076d8"
+    },
+    "sound/items/s_health.wav": {
+     "bytes": 26356,
+     "sha256": "2c7890cbd0321be2de10eb14c8637bfb14cae66a6c0fe9ff9ad212cff2bef602"
+    },
+    "sound/mistress/cast.wav": {
+     "bytes": 71680,
+     "sha256": "3b00270a03d879987fbc088b1def788bcc56476b410f89a557f0e4fc89ee24a0"
+    },
+    "sound/mistress/death.wav": {
+     "bytes": 75422,
+     "sha256": "b2224b7d9fe815d7092b52ab0a0c19551eac250873af86f10d83f88360820ee3"
+    },
+    "sound/mistress/flanchit.wav": {
+     "bytes": 69802,
+     "sha256": "1f46295e93c69b4a289eefc871ec5495c7ae473cc95c291e37bee45ae4b380da"
+    },
+    "sound/mistress/precast.wav": {
+     "bytes": 132198,
+     "sha256": "ee68e873841c8aa684b04a3f825db617e1fd630777dfaf7d284c97604fba034c"
+    },
+    "sound/mistress/shield.wav": {
+     "bytes": 64094,
+     "sha256": "69d1a4687e1355c83a4b371ef7ca41506316430fd9f4b5d590966e7c94f80d3c"
+    },
+    "sound/mistress/shieldhit.wav": {
+     "bytes": 476252,
+     "sha256": "f3eab66f017070018fb5940b6c1e33e9bde44ba370d8fbf3361956a5348a2186"
+    },
+    "sound/mistress/shieldhit1.wav": {
+     "bytes": 49634,
+     "sha256": "c9bf9b6723a4fc4b7e180343a69162e51b83be4463fe184dc7d897f4f76a0392"
+    },
+    "sound/mistress/shieldhit2.wav": {
+     "bytes": 48990,
+     "sha256": "05f5de1a914a29b0bab3f847d8f897eedc3ed9c8e113c3e64ae4cde6a3f6498d"
+    },
+    "sound/mistress/shieldhit3.wav": {
+     "bytes": 48532,
+     "sha256": "4368b9cbca81fd27ddbc1df878895c0d98d231f523df141291802f6f0f7f9ab0"
+    },
+    "sound/mistress/vocalize_pain1.wav": {
+     "bytes": 16190,
+     "sha256": "2b5f9f0c09acba8e69cc7ab170c1b4ab0f8c9a7dd2c1b0f33cbcc7bff6ee713f"
+    },
+    "sound/mistress/vocalize_pain2.wav": {
+     "bytes": 18402,
+     "sha256": "e55fee7dc666c047787a698ba8e470027cdeca7a27fa5f6263f0233d5fb4843a"
+    },
+    "sound/mistress/vocalize_shield.wav": {
+     "bytes": 21894,
+     "sha256": "0c879722a5d7008e8ee20ac7c691200c5601d36cc442ff2c4bfeb78cb66bd0c1"
+    },
+    "sound/mistress/vocalize_sight.wav": {
+     "bytes": 13476,
+     "sha256": "b68a82bfda726beaba045d00e4fd489603bcb0d76f1ac14ac179bc38d44ae4dd"
+    },
+    "sound/movers/1smgear2.wav": {
+     "bytes": 186924,
+     "sha256": "435217886dbc7db0a0b11a85d1d0a9e2270cbacaeb554c50006ee115f6e75d46"
+    },
+    "sound/movers/1tinyclick.wav": {
+     "bytes": 35668,
+     "sha256": "d04c84efb03f7fa72cee9f18fa64f52331113d249fbd1fef4972f34b84a34479"
+    },
+    "sound/movers/boltretract1.wav": {
+     "bytes": 41898,
+     "sha256": "3e7488d31a213bb9b8e3efde72ce01d8c34c110d0c900c2852a2b6cffe63e7d0"
+    },
+    "sound/movers/boltretract2.wav": {
+     "bytes": 48914,
+     "sha256": "845a479efec16701d36c2a6af96d7c4e65d35844ffb47811e2d925328d9ae7b1"
+    },
+    "sound/movers/boltretract3.wav": {
+     "bytes": 72852,
+     "sha256": "0eeb1fe899b82d097be74ffd0109e0924ae049b5f4cb3bfac9499e4057af610a"
+    },
+    "sound/movers/boltretract4.wav": {
+     "bytes": 44226,
+     "sha256": "37de85a769caa8d093d47c4da60c2b0691f3bba0b9aba97ecb338d73592afac0"
+    },
+    "sound/movers/boltretract5.wav": {
+     "bytes": 59522,
+     "sha256": "a0f85631f6ba82f489f15aeace7730b2d0a8b9f0492c1df9e9e6cc9722cc6d5c"
+    },
+    "sound/movers/boregear1.wav": {
+     "bytes": 149372,
+     "sha256": "3e678989cc7e977979a5a8435b2182cb42ab8ef87cca308e05580cca7700e734"
+    },
+    "sound/movers/boregear2.wav": {
+     "bytes": 108638,
+     "sha256": "771abc11c24b01c84b5c9bff89e20244357f851e391b8ee462b2ec2467b028c9"
+    },
+    "sound/movers/complexstop.wav": {
+     "bytes": 222038,
+     "sha256": "d199e03a5f726cfc1bbf88289dc208d47b3397b9d4aafc6df88e83e21f437142"
+    },
+    "sound/movers/liftmove.wav": {
+     "bytes": 262112,
+     "sha256": "f7eb2df6bb5348743cfeb0b79473ad708e43405f4d63f3729cbf7b243ee14fd9"
+    },
+    "sound/movers/liftstall.wav": {
+     "bytes": 176812,
+     "sha256": "faa717485f814370dc897e565d849af5e75cb007fc2dacd7cfb800c24fd3a524"
+    },
+    "sound/movers/liftstop.wav": {
+     "bytes": 97614,
+     "sha256": "b0d456acf9e779fcd44a03b3664b5407b67099d991a2a70eb7de4dad7bf239ae"
+    },
+    "sound/movers/machgear_loop.wav": {
+     "bytes": 477376,
+     "sha256": "256b3617b753c9db5d746f6ef09bc2ec77682f1e3f3816ff6016dc3418dca898"
+    },
+    "sound/movers/millloop.wav": {
+     "bytes": 1036436,
+     "sha256": "283d3358c7645b145b0225adedf3336672dbdc3225313e505e692f5995d8f830"
+    },
+    "sound/movers/slift_wormloop.wav": {
+     "bytes": 527650,
+     "sha256": "3874b87c7438e56247dc69776a29176022ab7e6b91d6acff18c2b744902d8884"
+    },
+    "sound/movers/smworm_stop.wav": {
+     "bytes": 472520,
+     "sha256": "8f4036f2e4d8980df0e4edaa6181a7e567457462642f9385408ffba8a826b6c7"
+    },
+    "sound/movers/smworm_strt.wav": {
+     "bytes": 235034,
+     "sha256": "0d83d106b8ce12dec7d7000b79f760b7d53eae6aebb715c2c333f179f78ebf8f"
+    },
+    "sound/movers/stone_loop.wav": {
+     "bytes": 452558,
+     "sha256": "f22ac73601fb0fd8efe19f2226322aa587b28223d82fe1dfcca6c99c25303d0d"
+    },
+    "sound/movers/stone_loop2.wav": {
+     "bytes": 452558,
+     "sha256": "ced04af363a36dbfd72f8857ebfcca733afda242e39638a7204c43d5d7e4968d"
+    },
+    "sound/movers/wormstop.wav": {
+     "bytes": 111660,
+     "sha256": "a7b40ef3ce82ccc3cc9584a7c784ddc737eb4a499c938a4e8a69fdb1aab2e049"
+    },
+    "sound/ne_ruins/floorhit.wav": {
+     "bytes": 208428,
+     "sha256": "6a386de4365efb823b06969a6d50acc552f0eb7a859256c6f6bc77a068bfa0ca"
+    },
+    "sound/ne_ruins/floorrel.wav": {
+     "bytes": 33224,
+     "sha256": "a82761c4db759ab03847f761468379bcf62b0e830cf0e12b19e844739b19d8c9"
+    },
+    "sound/ne_urban/mindfade.wav": {
+     "bytes": 398176,
+     "sha256": "4a558656321ec2dfe324bb3e74c1390c5ab351d4b1e513ab935231a3d358f9e4"
+    },
+    "sound/physics/potbrk1.wav": {
+     "bytes": 49940,
+     "sha256": "8b1ec1702e4e5715baa7b2c4b9d44dca649e7c19036b1fc9f059d3b30c64f7e0"
+    },
+    "sound/physics/potbrk2.wav": {
+     "bytes": 62962,
+     "sha256": "a61141b0b70609db3aae1088f098a8ab3bc00cb8c766fdc0de4dddbb010609e9"
+    },
+    "sound/physics/potbrk3.wav": {
+     "bytes": 40988,
+     "sha256": "69eb47cd837baddce645169075332aa25e844426535edc08eee529a0954a1b1e"
+    },
+    "sound/physics/potbrk4.wav": {
+     "bytes": 70416,
+     "sha256": "53b41b10cb2fe35e0b45d887ffc50cf7f526ece1ca876ad050b1dde7378b9c4e"
+    },
+    "sound/physics/potbrk5.wav": {
+     "bytes": 73768,
+     "sha256": "51f2372644b41a619fbf6e6ea301412c2d7e594b69fe9f1b626c4107f76fd758"
+    },
+    "sound/physics/potbrk6.wav": {
+     "bytes": 40692,
+     "sha256": "280b9d0ee9949aa8db616ca11f7d4fbcb2ee6b7ef395ca8d70dc75b73cac3480"
+    },
+    "sound/physics/pothit1.wav": {
+     "bytes": 18388,
+     "sha256": "a4523bfc839ea9737a9d78108f493551837970997f93795b9156eb4d06a9f7ab"
+    },
+    "sound/physics/pothit2.wav": {
+     "bytes": 30914,
+     "sha256": "b0d54d6b604fac465f29767abd8159f4680e11bdf241de8498be4e6eb5caa17f"
+    },
+    "sound/physics/pothit3.wav": {
+     "bytes": 32072,
+     "sha256": "38cfe49a3fcf1336f589eda6c876eaa8f1ba526610500c60214ea1b09847b53c"
+    },
+    "sound/physics/pothit4.wav": {
+     "bytes": 33120,
+     "sha256": "00c305035a3f18b84954936397e0007ff100c526b7f40c5419a5d66a597191d1"
+    },
+    "sound/physics/pothit5.wav": {
+     "bytes": 28210,
+     "sha256": "ea82173d177a5111d00d9b4f273da6d76df609ad60ba59052d525b7cd356e60e"
+    },
+    "sound/physics/pothit6.wav": {
+     "bytes": 17290,
+     "sha256": "dfb4296dbf00366c29e6f2faf59d9505f38f9907ea200c5369c3025963df4826"
+    },
+    "sound/physics/sgrenhit1.wav": {
+     "bytes": 21600,
+     "sha256": "6ca13d8918552a64a986dc9a5097e542ec494dd949f1dd7c3b608e891d88a3f3"
+    },
+    "sound/physics/sgrenhit2.wav": {
+     "bytes": 24620,
+     "sha256": "53b6e873318f84424129f1486f0a715c9b1f46e9521c97858d3ddbd94ef4dc10"
+    },
+    "sound/physics/sgrenhit3.wav": {
+     "bytes": 14510,
+     "sha256": "3af06be78c1d2c78fa86026eff41c915036853f1ec525cd47029008c30adbf9d"
+    },
+    "sound/scripted/lavamv1.wav": {
+     "bytes": 89048,
+     "sha256": "54076b7e7fcf8e8884cd1bba5f805d377cb0df91882a922bb1badefb16e54d06"
+    },
+    "sound/scripted/lavamv2.wav": {
+     "bytes": 89596,
+     "sha256": "315ec8a43a08395aa2bca07be1a48721e4192dbd2b0fd5bb1c9e84b0dbefc1a6"
+    },
+    "sound/scripted/lavamv3.wav": {
+     "bytes": 88522,
+     "sha256": "a450bf6995bd257b1c9bff86d3ff91e54bd0082046365e9d967a20e1952a6e49"
+    },
+    "sound/scripted/lavamv4.wav": {
+     "bytes": 88732,
+     "sha256": "bf581441b80a79298ffe0c7168d04a1c9e3e8b35f871e034424ef34932df0c64"
+    },
+    "sound/spells/firelance_cast.wav": {
+     "bytes": 63774,
+     "sha256": "761310a2ef4b39357785be8b7fbbba24decc5a8dbe4fc5a4fc0211c73eb2a269"
+    },
+    "sound/spells/firelance_hit.wav": {
+     "bytes": 20844,
+     "sha256": "10cc3fe1040236af879f531fb88c6ca6afa5cd12243dcc49083e4494925327b2"
+    },
+    "sound/tarbaby/bite1.wav": {
+     "bytes": 47112,
+     "sha256": "f4855924939de68154e4c6e93b9687ca9cb569b0c119596e429386a88d7e6a05"
+    },
+    "sound/tarbaby/bite2.wav": {
+     "bytes": 49814,
+     "sha256": "115bf80acd5abdbc15b02489615591493c120df6f2ce984e307fc3cf7399f99c"
+    },
+    "sound/tarbaby/bite3.wav": {
+     "bytes": 47576,
+     "sha256": "fa2f66d9b5d85286b83fbcd32cca44ccd2e5efda14eceb28c871356af4dd654b"
+    },
+    "sound/tarbaby/chomp1.wav": {
+     "bytes": 78766,
+     "sha256": "834a77917a994df35f3f6180165e9ef2fc174a80266b6f8cadd3bad85b124d00"
+    },
+    "sound/tarbaby/chomp2.wav": {
+     "bytes": 78766,
+     "sha256": "7698bd3264b872e6029089a09236d8a2218abfdec883a699c9624d14e27d1e94"
+    },
+    "sound/tarbaby/fend.wav": {
+     "bytes": 61480,
+     "sha256": "fab02018c9a560a699d93324c38d98fe26200e7d7abaeb2d791c19200e82e46f"
+    },
+    "sound/tarbaby/fignite.wav": {
+     "bytes": 48542,
+     "sha256": "bc542095a0c8b6093de0f0533d825f56ff65b7f7dbf163cd754580b800739c51"
+    },
+    "sound/tarbaby/flexpl.wav": {
+     "bytes": 38668,
+     "sha256": "4badb57891f6620f55bd465ab8924173408967effc0c5eca5ac7c6916acb9841"
+    },
+    "sound/tarbaby/floop.wav": {
+     "bytes": 95992,
+     "sha256": "3a823998806d8b198cbe56f3cba82e70efa1de61e25304065ce5e276cc25565c"
+    },
+    "sound/tarbaby/frozenbrk.wav": {
+     "bytes": 70272,
+     "sha256": "4d5e2a2ee5aadf3ea948e16486bc5d277240a58fe8d5386e2541afe99ffbb594"
+    },
+    "sound/tarbaby/fstart.wav": {
+     "bytes": 33418,
+     "sha256": "53b4be75a4d626d5c0b75e4fcdb5913b6120e70b148a3d7e987b9dc4213c75ee"
+    },
+    "sound/tarbaby/jump.wav": {
+     "bytes": 56892,
+     "sha256": "6c6b482a1b1dc37de0a1dbf2045a14b00873826f1bf0dd8c6017680b5e0f7cec"
+    },
+    "sound/vermis/portal.wav": {
+     "bytes": 1005906,
+     "sha256": "840123a722df28d7688090c6cc8e61fe4221d4099e6b4e005ee2f42f43c8bd15"
+    },
+    "sound/vermis/portalclose.wav": {
+     "bytes": 77612,
+     "sha256": "02b7e46830fba390b004b276b4cd9fd8012f5fb412944efec6271ee47bd5e014"
+    },
+    "sound/vermis/portalopen.wav": {
+     "bytes": 164598,
+     "sha256": "3006b1f8862df93d4989c15893c595a3c5dfc8bc181511052f11abf30bbe76e8"
+    },
+    "sound/vermis/slow.wav": {
+     "bytes": 132344,
+     "sha256": "85b191ca16bd4d561f290fa4bf875ced48858de0664be62b61b73652d76850fa"
+    },
+    "sound/weapons/axeflesh1.wav": {
+     "bytes": 18656,
+     "sha256": "779067c0f65ecb7eeb9d1c20bb7e1d67a33985dea696ea185153bb00daaaed74"
+    },
+    "sound/weapons/axeflesh2.wav": {
+     "bytes": 18396,
+     "sha256": "2938ab8ec96233c1cf9b75675e9366d71c6509ecf962abb4011273bdd768e0c7"
+    },
+    "sound/weapons/axeflesh3.wav": {
+     "bytes": 20524,
+     "sha256": "17d5ef6ad18cd86b91b7acc7039388762c94dcd9825695215c1630a04a939e1b"
+    },
+    "sound/weapons/expl1.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/gtimer.wav": {
+     "bytes": 45820,
+     "sha256": "7a8f163ff07883e0779f09e009a0d1af87f1f1e4782a10dbf72492a074f26566"
+    },
+    "sound/weapons/gtimeron.wav": {
+     "bytes": 123284,
+     "sha256": "d5fa4b7d595c83b1343fb58c4a3d69df08141e5888e97cfa068ea61d1ebbe314"
+    },
+    "sound/weapons/lgfry1.wav": {
+     "bytes": 22130,
+     "sha256": "b00b2734b1da71e7e71f3bc6b8ac3a648ce263248f6591050d3fbf4ed5b7a956"
+    },
+    "sound/weapons/lgfry2.wav": {
+     "bytes": 22112,
+     "sha256": "74b5e8e005478d6ad21363bf8aa945823301256011f981afaa85cb69f91d3f12"
+    },
+    "sound/weapons/lgfry3.wav": {
+     "bytes": 22196,
+     "sha256": "135f912e9b39246a75b01ac2e2f8ba0d472838c3ecc7fa3aeb2b5ff6497680ab"
+    },
+    "sound/weapons/lgfry4.wav": {
+     "bytes": 22188,
+     "sha256": "a6ea24069ace6a0368fce794e32b6adafe487e446fd40fc20b64705a828fa2b4"
+    },
+    "sound/weapons/lgfry5.wav": {
+     "bytes": 22190,
+     "sha256": "941b5d839e8a8fb0cf7aecc261c370590f9c1df0f233313a7648d7b78e9c5025"
+    },
+    "sound/weapons/lgfry6.wav": {
+     "bytes": 22072,
+     "sha256": "2cb2754a8b3609dd4d08ec1fd35b2a378137ea0cc7c01923b99d34a88fe4627e"
+    },
+    "sound/weapons/lghitloop.wav": {
+     "bytes": 242854,
+     "sha256": "b7b65c0ca7361c5bb1cbb1cccfc8b0652a24064fa7311f181706e3eedd8a7352"
+    },
+    "sound/weapons/lgspark1.wav": {
+     "bytes": 5192,
+     "sha256": "72ee6649772dcfc498a88aefa7cc841311c6dbf4e8e15bad5ce7fc24491a0d74"
+    },
+    "sound/weapons/lgspark2.wav": {
+     "bytes": 13292,
+     "sha256": "cd91941af313ca1f5ae176a08e99ff8e88fa8815f49284193753d6633168d954"
+    },
+    "sound/weapons/lgspark3.wav": {
+     "bytes": 20656,
+     "sha256": "789c643684d8e3a1713ef4625ac99c7a6b045954dc785764841b3c69061974d9"
+    },
+    "sound/weapons/lgstart.wav": {
+     "bytes": 100206,
+     "sha256": "0553e4d1f8ca086b33ccd7383336c462638866b25e124125943b70b23f94ea75"
+    },
+    "sound/weapons/lgstop.wav": {
+     "bytes": 25736,
+     "sha256": "f2863ed0ef1d94d218caee219512cfe5c9ebd227090a157f28f6a5a9ec59cfbc"
+    },
+    "sound/weapons/misl1.wav": {
+     "bytes": 22156,
+     "sha256": "503c2dda322280d8a08dadd2958fe20ed748b36a5cfeff886d6b7f1549c304cb"
+    },
+    "sound/weapons/misl2.wav": {
+     "bytes": 22318,
+     "sha256": "da4a237f00b6f31a99a1fa1ff5c8cfff330b3d930277b3f1d3b3a0261339de14"
+    },
+    "sound/weapons/misl3.wav": {
+     "bytes": 22330,
+     "sha256": "6756209dddc1189bfa5c7813d004acefc1cc5a5c434e3ed83d0e7718f43ef4ba"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 164,
+     "sha256": "ba0d9dbe33691183ef2549fdd006a02e21ac209f1d51271018e9bf565793c1cf"
+    },
+    "sound/weapons/shotgn3.wav": {
+     "bytes": 95970,
+     "sha256": "0c8d02023154bed0c9b6bd0ba76faab8687a29b119d537ac69cccebe3658cb3d"
+    },
+    "sound/zombie2/attack1.wav": {
+     "bytes": 22914,
+     "sha256": "da5345280208ea48855526989299927268566cef77ee187035bbe969076d6605"
+    },
+    "sound/zombie2/attack2.wav": {
+     "bytes": 24072,
+     "sha256": "59245700b47794e239563cc94e3ff045fcd7dad795bcfe343d8574ec3ac525b6"
+    },
+    "sound/zombie2/attack3.wav": {
+     "bytes": 15400,
+     "sha256": "0113aad711264c05a9e43bf8dba915bc89661444d7d802efabe8d61ebb3ba13f"
+    },
+    "sound/zombie2/attack4.wav": {
+     "bytes": 20922,
+     "sha256": "0aac55ae62b62cefece56103cd7079beeb433c3764f590641876e149c4328ecc"
+    },
+    "sound/zombie2/attack5.wav": {
+     "bytes": 26086,
+     "sha256": "b58c97928b535e79973e0390512b09d3d0adea79b1b1b5a8de59bc2cde40c412"
+    },
+    "sound/zombie2/attack6.wav": {
+     "bytes": 22272,
+     "sha256": "58c429256e2f5abb9d97c99ceedb78088d8ac977eca94e994b6d1eee8bb3eb8f"
+    },
+    "sound/zombie2/attack7.wav": {
+     "bytes": 34384,
+     "sha256": "d68e81783b6583738227eac608ab7af1a4b1e1b085c1e46bd9c0d029eab4fdde"
+    },
+    "sound/zombie2/death1.wav": {
+     "bytes": 46548,
+     "sha256": "a1b9e2bcebf9c56fb56405d1ec7fe4166ac10d2b6e1acc6f01e58aec9fd63e87"
+    },
+    "sound/zombie2/death2.wav": {
+     "bytes": 47048,
+     "sha256": "5964a3c1a665c70de8302052b2b6d72ea46b0a5e07ba22cc9919e1a0ffefcca3"
+    },
+    "sound/zombie2/death3.wav": {
+     "bytes": 52636,
+     "sha256": "5c76f8bc55ecea263df880e6b683b07066b37c9f62ff589b0e999534d3c256b0"
+    },
+    "sound/zombie2/footstep1.wav": {
+     "bytes": 12966,
+     "sha256": "2a85309bea05b7c7c90a82df071822828e413cce17646a9686fa4f1264d75e48"
+    },
+    "sound/zombie2/footstep2.wav": {
+     "bytes": 16880,
+     "sha256": "d1d9e9c3811b39b67c9a6966851873ff7edf8d1407c5d9b90782b233196a4872"
+    },
+    "sound/zombie2/footstep3.wav": {
+     "bytes": 20904,
+     "sha256": "b12e9ea9b9478428b886fcaab504856393a57abd8cfdfc5ba5357ad745ee3455"
+    },
+    "sound/zombie2/footstep4.wav": {
+     "bytes": 15796,
+     "sha256": "6f82ac60991e64c8c48a3208a161b46f5b916587cb41863992dc1acb08268889"
+    },
+    "sound/zombie2/footstep5.wav": {
+     "bytes": 17800,
+     "sha256": "ca12f6ade73e5d5ba4ec1bdf680ce25afe3270bb88d702e1493b75619ec088d9"
+    },
+    "sound/zombie2/idle1.wav": {
+     "bytes": 143832,
+     "sha256": "aa203b0beb2db12beb6929fbc3646f7f119d4d31ede66b13af0412d396f7dd6d"
+    },
+    "sound/zombie2/idle2.wav": {
+     "bytes": 277026,
+     "sha256": "9496f3179e875bbb4d7442c252eac0eb2b9ef6d2269d43c141e01242ed2de7ee"
+    },
+    "sound/zombie2/idle3.wav": {
+     "bytes": 234026,
+     "sha256": "4820b03de8cebdee6fe787b5bf60724c17a0e133fdd5451176a202043f730f8e"
+    },
+    "sound/zombie2/idle4.wav": {
+     "bytes": 166352,
+     "sha256": "a515e5dc0e4fe1412a7936df5fab0f57a48c385db4fa357c1a4120671ac99617"
+    },
+    "sound/zombie2/idle5.wav": {
+     "bytes": 62782,
+     "sha256": "c6e4e2f26769400b7ca3b08339af089ba28bc063447d642e10cffffc6e03a485"
+    },
+    "sound/zombie2/idle6.wav": {
+     "bytes": 47274,
+     "sha256": "9ad1ced551cb42764fd88baf26ee09dc72d1852fa2da7405fde370d3e4d69a01"
+    },
+    "sound/zombie2/idle7.wav": {
+     "bytes": 45614,
+     "sha256": "41783a7682d5f8bb91aff8308b8657504cc8f0460b5ca436a5d0fb1c93357c85"
+    },
+    "sound/zombie2/idle8.wav": {
+     "bytes": 73070,
+     "sha256": "8f390d861feda3fb3950b0f33ce3efbfa8eda214533324674ac40b6e227b6975"
+    },
+    "sound/zombie2/punch1.wav": {
+     "bytes": 9218,
+     "sha256": "db6787efe0a0b8df5da690b91afe46a2199911b661fc9de1cfffc00b6bb8c46c"
+    },
+    "sound/zombie2/punch2.wav": {
+     "bytes": 8032,
+     "sha256": "747aabd6237176ae1bc62669cb08c7ec65fb26aa2147f6a3e1ab43f02ace7322"
+    },
+    "sound/zombie2/punch3.wav": {
+     "bytes": 13076,
+     "sha256": "05bb75533252d15983a944263789de5ee51187e518f4544fd1915b57ba726c7e"
+    },
+    "sound/zombie2/punch4.wav": {
+     "bytes": 13198,
+     "sha256": "d07556e7fc774958a6105564a990c51a0dab64fcf9508475617921a0ac5b961c"
+    },
+    "sound/zombie2/sight1.wav": {
+     "bytes": 73234,
+     "sha256": "387534044f10592ca6bc7a96b8e782c7b51de87b907e79a8f410d535e17d37ee"
+    },
+    "sound/zombie2/sight2.wav": {
+     "bytes": 52224,
+     "sha256": "cbc95608d4553d0bae66411d69875210e6fc6d728bd30deb6bbce7aabbacb773"
+    },
+    "sound/zombie2/sight3.wav": {
+     "bytes": 63072,
+     "sha256": "cbbcdb6da59d830a3be66095053259b17a90cc6501728ed1aa50d9524818f99b"
+    }
+   },
    "sha256": "f53a82d77374775430fd4ad1e589bf979644b9bf7f8035bc8c00749f6560b264",
    "timestamp": "2011-06-22T15:42:46.000Z"
   }

--- a/json/by-sha256/58/584a6bbe8f3d7b6bda118aa7b18a1135a1e0c59bf8e8d34d158a2544538b74ee.json
+++ b/json/by-sha256/58/584a6bbe8f3d7b6bda118aa7b18a1135a1e0c59bf8e8d34d158a2544538b74ee.json
@@ -12,6 +12,164 @@
   },
   "kaiser/pak0.pak": {
    "bytes": 26667123,
+   "files": {
+    "glquake/h_hlhnd.ms2": {
+     "bytes": 1824,
+     "sha256": "7423196516a04d789e99328d7e2d1ac7dda9d432d98f8e7fd5ce2f2b16a5d511"
+    },
+    "glquake/hellhnd.ms2": {
+     "bytes": 8848,
+     "sha256": "5948350fc3a40e8686b31e2edb207bb93ca2631504e49dc8fd1ad1c4427e17f5"
+    },
+    "glquake/tarbaby.ms2": {
+     "bytes": 5100,
+     "sha256": "c7c9601f91c31ac301350684a0ce52a9b17874b2a7bf4f965203a1adee243498"
+    },
+    "glquake/tardaddy.ms2": {
+     "bytes": 5100,
+     "sha256": "c7c9601f91c31ac301350684a0ce52a9b17874b2a7bf4f965203a1adee243498"
+    },
+    "maps/kq01.bsp": {
+     "bytes": 2103560,
+     "sha256": "0deacee4e9e6c98507803da116dbf6caa54ace17e8f1673ace3d755f4a3050b5"
+    },
+    "maps/kq01.lit": {
+     "bytes": 743153,
+     "sha256": "cb2f4b7c1b010f3fad223d63381ce6c3dc5dadb87af788a6114c37bca3a7eafa"
+    },
+    "maps/kq02.bsp": {
+     "bytes": 2244968,
+     "sha256": "3383c83d3aa8e643a0973fc94bc581c9c7557846d9e27847b51fc22a8393ca7f"
+    },
+    "maps/kq02.lit": {
+     "bytes": 853313,
+     "sha256": "f0dab93e485db590e32229e16570bb6fdd148fbffe37c136cb3b9bc354495624"
+    },
+    "maps/kq03.bsp": {
+     "bytes": 3059256,
+     "sha256": "4763de069b36e2bd8b3111e7a71b96da0702a87d816a629608655d98f71cd435"
+    },
+    "maps/kq03.lit": {
+     "bytes": 1120589,
+     "sha256": "199ff541bce4132264670f73479da2220d3798de332ce49924e9e00c3ca25cde"
+    },
+    "maps/props/p_bexp.bsp": {
+     "bytes": 21960,
+     "sha256": "6954914fa8e37b914b14b6ba900e86743342399c736c3764c4ca2113ff4d3f5b"
+    },
+    "maps/props/p_olpost.bsp": {
+     "bytes": 28924,
+     "sha256": "53a71171e85f5be05b9805ba96e6c89da0c4cf4e1371846d5fff1a9927c0c2d1"
+    },
+    "maps/start.bsp": {
+     "bytes": 1310620,
+     "sha256": "96343d4ed9206bf66c08030641e1c920e39113cd15ebcd83bdbdde78bf1d4f16"
+    },
+    "maps/start.lit": {
+     "bytes": 421946,
+     "sha256": "2670678a12f816b344286b93c28c5b80fc6c31afbd042102a34b6a57b07694c3"
+    },
+    "maps/t_daddy.bsp": {
+     "bytes": 71524,
+     "sha256": "78a69385a863e0922ed558648f885a0a5b10cdf34fb1727aa3c92144ecbe0db1"
+    },
+    "maps/t_daddy.lit": {
+     "bytes": 36839,
+     "sha256": "5baf66a4d28b30d99d4fb832131368b7486fb18da89748e34bd1fcae156c11e7"
+    },
+    "maps/t_hide.bsp": {
+     "bytes": 115700,
+     "sha256": "e9d75ee278ce714b559a34bbbfbc58ae298a75e64f3ca52a14949bcdac9c6af5"
+    },
+    "maps/t_hound.bsp": {
+     "bytes": 139260,
+     "sha256": "4f154eaa6516b805c66ed920c5a8a549f6fedc890309a2de512c2d117e7bc6de"
+    },
+    "maps/t_hound.lit": {
+     "bytes": 84590,
+     "sha256": "18b58215e4c581972d5d3fb82d426d40e177424f3ca3147995483caacbe79a0f"
+    },
+    "maps/t_mjump.bsp": {
+     "bytes": 119036,
+     "sha256": "4d98cec30315afa02b00fc7468bb4e225ab246b55a974ee7d8d85c6cf5b4379b"
+    },
+    "maps/t_orgo.bsp": {
+     "bytes": 409596,
+     "sha256": "68db903d9cac1b0ff00c82bbc7e3d874ba639a468e23b66c1ce3593dbc81b401"
+    },
+    "maps/t_quake.bsp": {
+     "bytes": 77232,
+     "sha256": "321937b5e75dc9f9795a3aff72f89d431892729c58c2db108c94f07f33ffd193"
+    },
+    "maps/t_quake.lit": {
+     "bytes": 5210,
+     "sha256": "5345f3090172d9489bd4758d61022080f5c76265f138dd8739519dad06fc90dc"
+    },
+    "maps/t_rotate.bsp": {
+     "bytes": 140100,
+     "sha256": "054f950caec03446d9e7d624f9571a6d4046c207c4b090e86cc05c549760916b"
+    },
+    "maps/t_rotate.lit": {
+     "bytes": 19868,
+     "sha256": "e43d3010d0e0335f9c21dd6c8553929315b41d1484494ac2e549e7f817b48bc8"
+    },
+    "progs.dat": {
+     "bytes": 485128,
+     "sha256": "3abb172cd8465b8fdb6fd5e95263fca6e412c734b9c3b1e79b5dfc433f84e1e7"
+    },
+    "progs/drip.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/h_hlhnd.mdl": {
+     "bytes": 25824,
+     "sha256": "30e197c9ac83f00abfa6a70354e75b823ad128ede95a829ef08a5112cacb545d"
+    },
+    "progs/hellhnd.mdl": {
+     "bytes": 595105,
+     "sha256": "164ce9d4c8408e0056f9afd26497a468ddaca0d386a172a5368764c661d40b7f"
+    },
+    "progs/splash.spr": {
+     "bytes": 870,
+     "sha256": "860ad378d89ca0a9748cdc14b3a57f26efe4c0368b2fbbe4020a9d21239a405d"
+    },
+    "progs/tardaddy.mdl": {
+     "bytes": 154388,
+     "sha256": "c8eaa62bf88ec7ace431c69c62b5780b82bb0d0277cdb3048ecbbf8ca20800ed"
+    },
+    "sound/env/quake.wav": {
+     "bytes": 17710,
+     "sha256": "de937920afb3dd3e1d13de3c6efd6211485a4cc2eebe25d93b723dd4bd474c7b"
+    },
+    "sound/env/rain.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/env/thunder1.wav": {
+     "bytes": 34152,
+     "sha256": "5d2eb6c0cb51587bfe1457d8fb63237256d9f511ccaba067cb5fef2887b0d1b3"
+    },
+    "sound/env/thunder2.wav": {
+     "bytes": 30378,
+     "sha256": "965fc66decd42dabb7b1bda96b4599dca16626aa303fbd55354a9350bfcda03c"
+    },
+    "sound/hellhnd/hhbite.wav": {
+     "bytes": 10094,
+     "sha256": "c63f035d7fdac82fa3355e5ee0f4b01faa0d2f897471fca448dc17cb7c7bfc11"
+    },
+    "sound/hellhnd/hhdeath.wav": {
+     "bytes": 14736,
+     "sha256": "531c122adcd01186de0d26b92b35fd1357aeb846aa8b30ba54acd57121580393"
+    },
+    "sound/hellhnd/hhidle.wav": {
+     "bytes": 19800,
+     "sha256": "26f3c157fc0e280dc8f0891be27bb6577576519f93a4f72f4a354db5f6c2eed2"
+    },
+    "sound/hellhnd/hhpain.wav": {
+     "bytes": 7778,
+     "sha256": "d765796fd6fa72a63e51f3606f98a38db9209303519dea11631fbc32a7283ce6"
+    }
+   },
    "sha256": "2dafe2eb74304290ba7ef6491da1f3bc3ae2a878daf00d252033eee25bb84b7f",
    "timestamp": "2010-01-10T21:39:14.000Z"
   },

--- a/json/by-sha256/58/584dd3194acb9a6eab0e969da9646af92c06b48958a687bef629551002e6aa42.json
+++ b/json/by-sha256/58/584dd3194acb9a6eab0e969da9646af92c06b48958a687bef629551002e6aa42.json
@@ -12,6 +12,40 @@
   },
   "pak0.pak": {
    "bytes": 1784012,
+   "files": {
+    "maps/anac.bsp": {
+     "bytes": 133584,
+     "sha256": "54692e78dd2e364a75cc116c2d31ac9a03b84ac356cb5be90896b040628736c8"
+    },
+    "maps/start.bsp": {
+     "bytes": 713688,
+     "sha256": "7295046c78584e63eddbaa8bf3fe4ccd50b093d22609e43307489e3cca06c7e7"
+    },
+    "progs.dat": {
+     "bytes": 448636,
+     "sha256": "e21d5fafb4a54f3924ec4a93b7a183d4b62818582658c0d17c241c547b747701"
+    },
+    "progs/anaconda.mdl": {
+     "bytes": 225724,
+     "sha256": "0f39b08eeec0f4cadd512939795faac5633e8a3da56401e3a3b66ccd232506c9"
+    },
+    "progs/coils.mdl": {
+     "bytes": 75324,
+     "sha256": "d617ece500e6fcc47029b2e1d807a446be5720d82ca1dbc719df5895039892b7"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 132028,
+     "sha256": "04114bd1180592f23a42d4d79efff874820f837283297e2aabf509170a527edc"
+    },
+    "progs/spike2.mdl": {
+     "bytes": 1684,
+     "sha256": "0f343afdf373071fc4a3b95bce03558dade429e26fa16eca35481757661cc620"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "744af1fafaacb751cf2e5ce4bb15a0fc1fb938ae519469de6f0dccfe9f320414"
+    }
+   },
    "sha256": "36dca6c9209ae247b1c9b427f92b1cedd2e9f55eae43fec2c711134e21fce707",
    "timestamp": "1997-04-02T17:24:38.000Z"
   }

--- a/json/by-sha256/59/59971ea485de52bfde1377acec02a7040f4737351f35b8b7010686f5c342730b.json
+++ b/json/by-sha256/59/59971ea485de52bfde1377acec02a7040f4737351f35b8b7010686f5c342730b.json
@@ -15,6 +15,96 @@
   },
   "pak0.pak": {
    "bytes": 30386924,
+   "files": {
+    "gfx/env/moonrise_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b4e85116e3999d5cded25ca0a5d6fb9c297b3d69749a63daf5af6c37fe21959"
+    },
+    "gfx/env/moonrise_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a7be41496d25bc9e505b959b08a950c1bb61acc6c8c44ec4e1dd428faeac4ccd"
+    },
+    "gfx/env/moonrise_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "7381c46aa4f5c916f3bc8f82a442a4582834563c0bb0127580053bb274609180"
+    },
+    "gfx/env/moonrise_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "871df5eed200970b8c3246ca10a039f5915c95e8f48bf0692fc22f2f7e5450cd"
+    },
+    "gfx/env/moonrise_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "2cc00bb935ee2f4019f4d99170d38ef3f51c72ff80150cd74911b1038a0cb269"
+    },
+    "gfx/env/moonrise_up.tga": {
+     "bytes": 3145772,
+     "sha256": "0296084074d726170fdc85d2c1176ee64845b6805c174c08aaa63f514fd9cb65"
+    },
+    "maps/metmon.bsp": {
+     "bytes": 4617120,
+     "sha256": "5bcacb81aab029dda90edf79ac3adff8fc5d1292112e591f25037bfb31f2f347"
+    },
+    "maps/metmon.lit": {
+     "bytes": 1320542,
+     "sha256": "acad863f1828d240858cc26ff452ac21158e45f5509e530c59f97148f7197089"
+    },
+    "maps/metmon.rtlights": {
+     "bytes": 17269,
+     "sha256": "fd55f2021fca20ae5720c0c958bec577a7cfd830316e832614cc27274d2e87f9"
+    },
+    "metmon1d_readme.txt": {
+     "bytes": 12032,
+     "sha256": "0632470262cc27f3a21d1cdea80ecaa5cbe2f28f7909b13afbc94d08e5a305a9"
+    },
+    "sound/metmon/finalswitch.wav": {
+     "bytes": 66382,
+     "sha256": "5c006bb7315e6eb6d2367ae30a78f0abec8ae2a1e2b6a2c9af88354962b0f33f"
+    },
+    "sound/metmon/powercube.wav": {
+     "bytes": 36700,
+     "sha256": "4307c01076cb5e076d27546b17bd6b11e2369a67b59dbbd64f2607d8b262a8c2"
+    },
+    "sound/metmon/powerdown.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/metmon/powerup.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/metmon/spheredown.wav": {
+     "bytes": 1118464,
+     "sha256": "e0ab1a0f67a2d37a525f7a73e8ee8c3a26f746e027fa1501f6648f5586ea2048"
+    },
+    "sound/metmon/windgust1.wav": {
+     "bytes": 110934,
+     "sha256": "d6b4a536dd8c403d8fe9a20db1c72c42d32f44b863689ba4f952ad1e0b7c86d9"
+    },
+    "sound/metmon/windgust2.wav": {
+     "bytes": 110696,
+     "sha256": "85ffe34d5ee89659fd6466afa237a27ad3494176a733d9e017843e7651366a2d"
+    },
+    "sound/metmon/windgust3.wav": {
+     "bytes": 110030,
+     "sha256": "fdbb85f091cd9447f1500173aff70236abcdb947ba0758711816da59c5293344"
+    },
+    "sound/metmon/windgust4.wav": {
+     "bytes": 204800,
+     "sha256": "6bf9157f45ddb9ce15c5cad253b53d9ce59e7d20a81d5f1f8d0a510eb4edce5a"
+    },
+    "sound/metmon/windgust5.wav": {
+     "bytes": 204472,
+     "sha256": "e551c6602c35ad4f4871bffd53cb02a668f508f5ef007e7e5b9734c5640f17ac"
+    },
+    "source/metmon.map": {
+     "bytes": 2612327,
+     "sha256": "08e7f2e06db1053f37888c8e6d0e0d052cd64f5f78d2d3af46a3b171dfeca4d2"
+    },
+    "source/metmon.wad": {
+     "bytes": 803072,
+     "sha256": "d670dfb958dcc45f90c12bf2f006d1211f9f17fc7ddef758dcc12edb0a904583"
+    }
+   },
    "sha256": "70dca4d58a12a3fc3c3bb522c2484490e96f3307862e8e8460552d6e8d21d1a8",
    "timestamp": "2014-05-25T22:27:48.000Z"
   }

--- a/json/by-sha256/5a/5a39fa6a827e18bea812b8da53e993b22c1bb538c284525da2d69c888d6a256f.json
+++ b/json/by-sha256/5a/5a39fa6a827e18bea812b8da53e993b22c1bb538c284525da2d69c888d6a256f.json
@@ -17,6 +17,20 @@
   },
   "PAK0.PAK": {
    "bytes": 2752896,
+   "files": {
+    "maps/corporal.bsp": {
+     "bytes": 1454380,
+     "sha256": "7394b8c5940906e76fca8797efc7b76a5272f12dbc86f57406bb68350ffac3c2"
+    },
+    "maps/gstart.bsp": {
+     "bytes": 833240,
+     "sha256": "f868254dce7e643f400d30ead446095761b4b9218d5e206a1fd72972352e0d8a"
+    },
+    "progs.dat": {
+     "bytes": 465072,
+     "sha256": "8d11566a4b870c9b95b943c039fce7c26b2f001861af25e3adce2e760f5d1951"
+    }
+   },
    "sha256": "f3289edbbe2d2d85d234c25a5aabb73842e0901db4b36abc0ff933015625c431",
    "timestamp": "1997-04-06T18:18:12.000Z"
   }

--- a/json/by-sha256/5a/5a9f66732d758a7f10bb066f7ec085af9d4d91e703f4ccde07aa8efcbbaf0d3c.json
+++ b/json/by-sha256/5a/5a9f66732d758a7f10bb066f7ec085af9d4d91e703f4ccde07aa8efcbbaf0d3c.json
@@ -152,26 +152,3000 @@
   },
   "nehahra/pak0.pak": {
    "bytes": 116,
+   "files": {
+    "readme.txt": {
+     "bytes": 38,
+     "sha256": "dcf733b0fb44f3a16c69563498c3e76aa476f80c78607e0975421a413d880511"
+    }
+   },
    "sha256": "ecc8da26327e25950161cb8ba21a76512d6ebc2fcdb59b4b67142288584fc8c1",
    "timestamp": "2000-08-17T21:27:10.000Z"
   },
   "nehahra/pak1.pak": {
    "bytes": 28584360,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "a3456dc7a75cd06f4b1f382839533343ef955757de7beda474fb6db6bb0e2ebc"
+    },
+    "gfx/demomenu.lmp": {
+     "bytes": 26888,
+     "sha256": "10cf6420d95c23d9bc6ad2a74cf2898601f06a8da2d6ec426fe87f4468d67c38"
+    },
+    "gfx/env/cliffedgebk.tga": {
+     "bytes": 196652,
+     "sha256": "35252b3d044c989e234fb606d864b08f291b4134eb00ed6e4d1de430f5415e30"
+    },
+    "gfx/env/cliffedgedn.tga": {
+     "bytes": 196652,
+     "sha256": "329834e185c3a2e34a74988c0654fe77352be39abf35ce4ddd7da49c44aa175c"
+    },
+    "gfx/env/cliffedgeft.tga": {
+     "bytes": 196652,
+     "sha256": "e53804fcbe5d400478908d8064d9e7a56c70187d9aa5c4b9f8aaaa605c559dc1"
+    },
+    "gfx/env/cliffedgelf.tga": {
+     "bytes": 196652,
+     "sha256": "a79faf4c09a97b8eb329194c1c5bd00eb5374dceb1441022f43cdb9e071fbb16"
+    },
+    "gfx/env/cliffedgert.tga": {
+     "bytes": 196652,
+     "sha256": "981f6bbeac65712d637bc24191bb2ae28ed6395d89b897a7d910d50b95fc1531"
+    },
+    "gfx/env/cliffedgeup.tga": {
+     "bytes": 196652,
+     "sha256": "056666267b5656c214f92923290d61f4fd2e22b823b25188931f0727a071c0fb"
+    },
+    "gfx/env/czg_voidbk.tga": {
+     "bytes": 196652,
+     "sha256": "8d3a1a63cbbff455de4a086c7473ade3aff5943ee81f9fe3f155d2051849110d"
+    },
+    "gfx/env/czg_voiddn.tga": {
+     "bytes": 196652,
+     "sha256": "736cddb47d35423e590a13f6a24fe55a02e411f21177dac0bce24961df9b189a"
+    },
+    "gfx/env/czg_voidft.tga": {
+     "bytes": 196652,
+     "sha256": "021df642382d0e14b5c5357d4708a94ad02612516dd3277e56e70b81ad82b299"
+    },
+    "gfx/env/czg_voidlf.tga": {
+     "bytes": 196652,
+     "sha256": "8e9af5307d1bb2a050c45ab35bac1a4b37433d7a24c6ead2dcb9a72d56ac4560"
+    },
+    "gfx/env/czg_voidrt.tga": {
+     "bytes": 196652,
+     "sha256": "7acf281501b791a74477c8c43e2229cd1a6a220a8f0f1ce7def653385628b558"
+    },
+    "gfx/env/czg_voidup.tga": {
+     "bytes": 196652,
+     "sha256": "1dd34df58096a0e3d50dc56bd6c0fc552f991872a390a2003030dcfccea48e1d"
+    },
+    "gfx/env/iceworld4bk.tga": {
+     "bytes": 196626,
+     "sha256": "99b9f7c306d4dfc0aaa5fbc8fb837a0d030d30bdaca20274d435cf578e6def66"
+    },
+    "gfx/env/iceworld4dn.tga": {
+     "bytes": 196626,
+     "sha256": "c5aa22171f2bdf1c4af0a723be9fde1cad244c24141c7da825fb93613cd4866b"
+    },
+    "gfx/env/iceworld4ft.tga": {
+     "bytes": 196626,
+     "sha256": "ff3a5fab22fd5d0db6bb5955c61b375e66fb984d5e0841710c104fc17c0f0471"
+    },
+    "gfx/env/iceworld4lf.tga": {
+     "bytes": 196626,
+     "sha256": "bb83ee22374baddf45a278231b099da4264f2c80f50dc2f43c8e0bd01ccdc0c5"
+    },
+    "gfx/env/iceworld4rt.tga": {
+     "bytes": 196626,
+     "sha256": "42dfd3b0f015fcf41659458eafa931d280feaf90339092c478289252ea3bf4cf"
+    },
+    "gfx/env/iceworld4up.tga": {
+     "bytes": 196626,
+     "sha256": "9db063d42bc57807f531ff5dcecc9b6064f3efa74b26ea6bcb40cfc0c2b8f9e3"
+    },
+    "gfx/env/lear_bk.tga": {
+     "bytes": 196626,
+     "sha256": "54cc0b54e4b9a2ff77469664356516a1da884361f78e2d9cfe284eb91b908c26"
+    },
+    "gfx/env/lear_dn.tga": {
+     "bytes": 196626,
+     "sha256": "f527a17cc98ac537e40aed80d619a4eb32d8bf992d89d98a8d157169791324de"
+    },
+    "gfx/env/lear_ft.tga": {
+     "bytes": 196626,
+     "sha256": "306cc9b33103deecff7f7c6d653625c064bbe0dbdcc52a1ef0113fe2e414632f"
+    },
+    "gfx/env/lear_lf.tga": {
+     "bytes": 196626,
+     "sha256": "1f5bef88eeecd674af8ee53a1aeb28cfd4a456517f235cae41a3fce826517815"
+    },
+    "gfx/env/lear_rt.tga": {
+     "bytes": 196626,
+     "sha256": "2f5fb2062e9537bc85cf1cb5c817a43b9c5abd76f26bf077386d0ba828371745"
+    },
+    "gfx/env/lear_up.tga": {
+     "bytes": 196626,
+     "sha256": "532f228b2a466bbb146bc8ea004ba303899aa901c7fa39e8f0f277fbf1bb209c"
+    },
+    "gfx/env/mtnsun_bk.tga": {
+     "bytes": 197147,
+     "sha256": "d8c4f6ba0a7cc1a867dfdc6aa2f2fd8c1c3990546040a9c10336245991ebd8c9"
+    },
+    "gfx/env/mtnsun_dn.tga": {
+     "bytes": 197147,
+     "sha256": "3c203f1e22b64973b8e9563f882321e7bf1c6b6e3b6eb931a6a10ed91ba8439f"
+    },
+    "gfx/env/mtnsun_ft.tga": {
+     "bytes": 197147,
+     "sha256": "6b9378d0a393275c1170943bbb43d8661657136ac33fa8ec14f6983008a88c40"
+    },
+    "gfx/env/mtnsun_lf.tga": {
+     "bytes": 197147,
+     "sha256": "ca035ec656c2ce59f43522592824ae5554fb6caf7fba28b740b3e3ad895c81f9"
+    },
+    "gfx/env/mtnsun_rt.tga": {
+     "bytes": 197147,
+     "sha256": "2bd71d9d5f3a9c5f220625e91a193d198d783a4baad25af47d88b89e53b0ab5e"
+    },
+    "gfx/env/mtnsun_up.tga": {
+     "bytes": 197147,
+     "sha256": "6262dee018c6e3e52edc9a28ca514231e11e1a835ad6238194f951cb847166e6"
+    },
+    "gfx/env/oberon_bk.tga": {
+     "bytes": 196626,
+     "sha256": "e4ac561ee4d6ef4ea9cfb9d474bd39a8e2f7757dc38b9947e90c26a39c2c2443"
+    },
+    "gfx/env/oberon_dn.tga": {
+     "bytes": 196626,
+     "sha256": "a59e06b3a4e2843ac65f140f18139c24a765a5d35e9580c88cde43b5a462c0a1"
+    },
+    "gfx/env/oberon_ft.tga": {
+     "bytes": 196626,
+     "sha256": "b2449d8260210a1390b373d61253cf2e300a6c94824f9c8c4e8bdda37a2ee585"
+    },
+    "gfx/env/oberon_lf.tga": {
+     "bytes": 196626,
+     "sha256": "52fbf14d13a52ba05c92b5e0910a4d2ba1133c0764934c5f0ce1c62aa32dd87e"
+    },
+    "gfx/env/oberon_rt.tga": {
+     "bytes": 196626,
+     "sha256": "ec3b0e0e35663826831897405841592d21a5114807f54db23392ae748bee0d87"
+    },
+    "gfx/env/oberon_up.tga": {
+     "bytes": 196626,
+     "sha256": "a08658e4599eea8a9d11faec2433a2184cdf053c3b7fe1fba9b2d8a0b3e82f4e"
+    },
+    "gfx/env/snow2bk.tga": {
+     "bytes": 196944,
+     "sha256": "b1989e218c27590c7b4293e080cc1a67f8d7fe4b7a04b48a9931579c79ecdf59"
+    },
+    "gfx/env/snow2dn.tga": {
+     "bytes": 196944,
+     "sha256": "904bdebc637c33c85dc8c0441d0e04650f41f38a2aa0f0b1641feeb0fe83dc34"
+    },
+    "gfx/env/snow2ft.tga": {
+     "bytes": 196944,
+     "sha256": "41cdc6506fa459d3e49ef0c216de02230c940036e272e710defa1dbc2836e112"
+    },
+    "gfx/env/snow2lf.tga": {
+     "bytes": 196944,
+     "sha256": "edae128777db88318aba2ec530364e2af607a91ebdac544cdf246ebc7c192d92"
+    },
+    "gfx/env/snow2rt.tga": {
+     "bytes": 196944,
+     "sha256": "ac56929ea7e0bac7001b0fa948a49ecc72fe9f7f208e58b74d1b53a3f7e1f3f7"
+    },
+    "gfx/env/snow2up.tga": {
+     "bytes": 196944,
+     "sha256": "35d89f993aff9e4efd80430021c0a1d43dd107618f6e053f8ff060a94f3a0488"
+    },
+    "gfx/env/vlcnobk.tga": {
+     "bytes": 196944,
+     "sha256": "efa460f343f847869c07ce9dd10b88a726ee4bcd6cafdde61ed28e8ff0a6405d"
+    },
+    "gfx/env/vlcnodn.tga": {
+     "bytes": 196944,
+     "sha256": "ef3bba677bb986a5526a1a0556abae062f7766e4229a2aa007e41eb7abf21528"
+    },
+    "gfx/env/vlcnoft.tga": {
+     "bytes": 196944,
+     "sha256": "3d53e28d59b18c502d1de1143b3200c00959c087646f7b9c4a6890ff24e361c0"
+    },
+    "gfx/env/vlcnolf.tga": {
+     "bytes": 196944,
+     "sha256": "033623f23ac60dab52a100338614bea458ea29d2488df5db2d26872a55852c73"
+    },
+    "gfx/env/vlcnort.tga": {
+     "bytes": 196944,
+     "sha256": "a6bfe982312cf804647f53b6acf906f1a2718e734404d72b2b3b561addacca2a"
+    },
+    "gfx/env/vlcnoup.tga": {
+     "bytes": 196944,
+     "sha256": "d4591ab405602891f3286a2d97f5641ac6933331990bd554fe3ec26eb6fa6cc1"
+    },
+    "gfx/gamemenu.lmp": {
+     "bytes": 26888,
+     "sha256": "a19fbced36687642220b9eb9f53fa911fd25e459be554cde30ef4b64b620f706"
+    },
+    "gfx/it/res1.lmp": {
+     "bytes": 9368,
+     "sha256": "32280fd92b54caaa50283c1ef19deaaaf0e7016800af65c05e72d123db81b4fc"
+    },
+    "gfx/it/res2.lmp": {
+     "bytes": 9368,
+     "sha256": "be037897f318bab5686c5d95527d35c10a8db8e3bc5e8c224043298d4eb496cc"
+    },
+    "gfx/it/res3.lmp": {
+     "bytes": 9368,
+     "sha256": "66c7ef65d6412965447f1029af912c2f0d794829114098bd7b5a645b55ebdf92"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 32648,
+     "sha256": "1c19b7a7469dc74c40a2c57a5d619499899fcf32be54bbe50c7296c0960b55e8"
+    },
+    "progs/actor1.mdl": {
+     "bytes": 707844,
+     "sha256": "eb6f6007526fe8a9a1838b6b81fbab6aca6e6e460a3d9894533b224c13d6ba12"
+    },
+    "progs/agun.mdl": {
+     "bytes": 14336,
+     "sha256": "4d678dd740869c6c6c9254f4b6aa5ffc15b41bf9080dc72f03a92b7d550b021d"
+    },
+    "progs/airkey.mdl": {
+     "bytes": 26516,
+     "sha256": "5705904a927397d6605ed05326f961f71983b790db989f421767f6e36e2ec6e8"
+    },
+    "progs/archg.mdl": {
+     "bytes": 815508,
+     "sha256": "22d1df23ca10ede7375c779ed632573e2e21c98a700d4311db4900f75dfc4c57"
+    },
+    "progs/baron.mdl": {
+     "bytes": 405612,
+     "sha256": "68bb69841d1246882360b8e243bd34dc5534989dce1eda8974938ebf7acae652"
+    },
+    "progs/barplay.mdl": {
+     "bytes": 86436,
+     "sha256": "e44b9ec516e09790b0660afe1ed6e7ea53d48d17c5b5fc3a05a8b9fecb59bfb0"
+    },
+    "progs/barrel.mdl": {
+     "bytes": 130972,
+     "sha256": "cc8ebfd0da975358077a6933cdcb4f7ab627ad02c7bd8612f05eb1c873926c23"
+    },
+    "progs/bartop.mdl": {
+     "bytes": 49108,
+     "sha256": "eea4755c7c80763073707db5c493740bafb9574cad4612429c02eff030709aaa"
+    },
+    "progs/beam.mdl": {
+     "bytes": 11948,
+     "sha256": "21e9ad0bbb51ebdc4a30a6ce661a10fcc879ad5c3dda4b5ba10cf9f24dc4206d"
+    },
+    "progs/beard.mdl": {
+     "bytes": 320136,
+     "sha256": "54d70af98f7c930f7c4b8582ba547de6fe1b48ca920666b45ecf28df835fa984"
+    },
+    "progs/bloodkey.mdl": {
+     "bytes": 43924,
+     "sha256": "88a4e2e19c1e6a6eb2799917218c1c3d66f5a883e4a45f6b4f808cb604f50124"
+    },
+    "progs/bolt4.mdl": {
+     "bytes": 11948,
+     "sha256": "21e9ad0bbb51ebdc4a30a6ce661a10fcc879ad5c3dda4b5ba10cf9f24dc4206d"
+    },
+    "progs/boltkey.mdl": {
+     "bytes": 54304,
+     "sha256": "ff3a89a796988978339d0cbfbd692a7b4bc443f3f79a81e938549ca6bb6e0179"
+    },
+    "progs/book.mdl": {
+     "bytes": 22788,
+     "sha256": "fec2e0e496b34989a6261013b1365076c1f5d4e4a32b8c85c87560c018a01b83"
+    },
+    "progs/candle_t.mdl": {
+     "bytes": 37296,
+     "sha256": "94de25aef5163a93e5c87a8597863acff00d99eab42d73565e62253b0bac4233"
+    },
+    "progs/candle_w.mdl": {
+     "bytes": 21340,
+     "sha256": "be428480941d3406e46c8ab9eba7ed7fe3ecf662cb4a5c19a3ba14d451293b7c"
+    },
+    "progs/candleth.mdl": {
+     "bytes": 40568,
+     "sha256": "537214419a23ed1c8299b7b27cbd4fdfc384818cb6b436762ba3536ae6c5cd80"
+    },
+    "progs/candlews.mdl": {
+     "bytes": 107984,
+     "sha256": "b9193bd59f96e07c08918848327e451e48272911350e36a13607103e900ac2f1"
+    },
+    "progs/catkey.mdl": {
+     "bytes": 35820,
+     "sha256": "d6012aba573628c24eb314e4e445ae164cd894a5d34159e543d8bb1d9ddad75e"
+    },
+    "progs/cook.mdl": {
+     "bytes": 349888,
+     "sha256": "ebb75d65c2bd819260fb109ecd3c69729a516fa70f8e8e894396575debacd017"
+    },
+    "progs/demon.mdl": {
+     "bytes": 146520,
+     "sha256": "40e264cbbe8ec9e60993ea9024e011659aa288f066e77ad1dcadb3ee539964cc"
+    },
+    "progs/earthkey.mdl": {
+     "bytes": 38964,
+     "sha256": "3ce3786eaa09226cc53cf9f8088d6dba26f1c7d6af3b7de044f747b67044e5cf"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 192748,
+     "sha256": "8fa22e978517623d5c1c958322aa5ac53bc091a9695a2e88f7d8816f83afdf47"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 5716,
+     "sha256": "996401916fff16257f96844ef3fb97a1d2665dd60ebc107050c05d417d538658"
+    },
+    "progs/fgib2.mdl": {
+     "bytes": 16228,
+     "sha256": "b2d23c5d73f972e44bf5953dfd7af4622a6f40b63f80332bc39ae400eb791fe0"
+    },
+    "progs/fgib3.mdl": {
+     "bytes": 22228,
+     "sha256": "9f9c8891e568da2d66d5c82cad4a48614273a3c119e5620445ac11d8f92fb49b"
+    },
+    "progs/firekey.mdl": {
+     "bytes": 29460,
+     "sha256": "1d0a7cb45d3e253f2d14b4a96cace7e3153e34e692cfd8c78213d2fba0c69597"
+    },
+    "progs/flying.mdl": {
+     "bytes": 227060,
+     "sha256": "daba230d95a03fbd37a1c97c77de8425aef2ddce8fb142c465a6cf602e92e8c2"
+    },
+    "progs/forqguy.mdl": {
+     "bytes": 195966,
+     "sha256": "0b9740a8389ac893c67591fbc550c6b646aaf03e26e4ea2fc2de665430d9c431"
+    },
+    "progs/frubble1.mdl": {
+     "bytes": 79548,
+     "sha256": "7cd3e16f342b28969b2fe94a4eaac8451c37a4b6f5802d69eb5250e70bf86743"
+    },
+    "progs/frubble2.mdl": {
+     "bytes": 118908,
+     "sha256": "e7dc484538a0cd36781f6701ddfa1449dc00dea03994155feefa2376ee147aca"
+    },
+    "progs/frubble3.mdl": {
+     "bytes": 10140,
+     "sha256": "608b3f6146844564308089f45a2b8f6607d2bd6b513098cfc9669c12fac819a5"
+    },
+    "progs/fscreen.mdl": {
+     "bytes": 340396,
+     "sha256": "defc43313e124cfa012f014849e450ea335b8474e22eb5060876fcee3f5d8a94"
+    },
+    "progs/gaunt.mdl": {
+     "bytes": 259340,
+     "sha256": "112341f990f5c244c3c476546a28cc2e319ac6a8e17350952ce2d3f567e7bd0c"
+    },
+    "progs/gntspke.mdl": {
+     "bytes": 12736,
+     "sha256": "571fc16892c35882cf24a6cd79a0018a956fe2872a322e9a2cd96b1b6b7d5e7c"
+    },
+    "progs/gring.mdl": {
+     "bytes": 15472,
+     "sha256": "f2ecff00596c61a5009bc6a47802a02563a3b0f7cc5754be7bce7b4088fced45"
+    },
+    "progs/gstorm.mdl": {
+     "bytes": 255493,
+     "sha256": "f5f569741e7ea6487a6cabfa050fde9e82e43c21e28c904eaeef7170b6de2c33"
+    },
+    "progs/h_archg.mdl": {
+     "bytes": 40079,
+     "sha256": "4208cd2c14b99284830bcfa949aa1e2da10c5dc3690d64376af708691b2bb724"
+    },
+    "progs/h_enf2.mdl": {
+     "bytes": 11828,
+     "sha256": "bbeceb3ef57100dc2cd6e7e42aa33137e565c1c0365dcb7368c6c6338c7fd285"
+    },
+    "progs/h_enf3.mdl": {
+     "bytes": 11828,
+     "sha256": "160454e8f4131a973785c75f3ef3364cfe15b13d50ae3e364a134ab1ca35a296"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 8389,
+     "sha256": "e616e6ee0422a5f849bb2f2e383e95ceb98878610c67874fcf8fc326b0290f6d"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 5428,
+     "sha256": "92efdcd528f1f81622cecd98b8d09fd537f3a5e9421f7e72a9684299a44d1bfb"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 232512,
+     "sha256": "a8a6b26bada4680e996e86aa67286d1bfe10791db670f162e843939174c538e8"
+    },
+    "progs/hummer.mdl": {
+     "bytes": 180541,
+     "sha256": "57029fb5ed1ab94b0c8cd09184aca9cc4353642849c1af9bd7aa6265f22303bb"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 149764,
+     "sha256": "b6a36cd33941114508963f209182094f337b77c031b9f65529533d6febd58197"
+    },
+    "progs/jack1.mdl": {
+     "bytes": 472688,
+     "sha256": "e8130d5aa20f128a197b1ac5ef9b950a7ee18f8314da4174afb2ec2b579a584a"
+    },
+    "progs/jackbike.mdl": {
+     "bytes": 291944,
+     "sha256": "651e3d0695c17a4ab311aae728a3c6ddb61e0aad3514964dd6cd6488f4268572"
+    },
+    "progs/jagger.mdl": {
+     "bytes": 372752,
+     "sha256": "f541d3ed2d7e56638f690a485eff8b0ffd1260a878a778ee2362d79a512bb77b"
+    },
+    "progs/key2.mdl": {
+     "bytes": 183996,
+     "sha256": "48d378ee6907a00615763f6fc8b2e07dda8c593e2e0ccf383a594c40b0780c74"
+    },
+    "progs/knight.mdl": {
+     "bytes": 103704,
+     "sha256": "f7e472996cd43d778b0e9b724420bdd742c62864b93b030a4063fe2cd6951982"
+    },
+    "progs/lab1.mdl": {
+     "bytes": 361276,
+     "sha256": "4b8c7cd42b2928e70213c2a4f829d87ce8e679ba1c733d559bb1a6d59693a9af"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 88040,
+     "sha256": "49197da97a7c660660ad3b292ef9da4f8bbb64f897d0c85953c41d4ff9fbea8b"
+    },
+    "progs/lantern0.mdl": {
+     "bytes": 75816,
+     "sha256": "743cfe888265af813d4d75b961d9ab907fc94e0e20dbe4288e7f14635e61517a"
+    },
+    "progs/libcart.mdl": {
+     "bytes": 42804,
+     "sha256": "1e0b50ec7ed4ea4ff8ceb8fd19a34361c9ed9865572bd82d5820a6ecc4dfc76b"
+    },
+    "progs/libogre.mdl": {
+     "bytes": 254068,
+     "sha256": "9b6b9fb07a2a2f53699cc13ab8594ac8a7cfb0eeccc49ad730355afdde3c5df3"
+    },
+    "progs/library.mdl": {
+     "bytes": 229316,
+     "sha256": "eeb144c3ba422419b9818967afb19511186efa5f2a382b96612cf6b799d39e79"
+    },
+    "progs/mark3.mdl": {
+     "bytes": 456220,
+     "sha256": "fd7e09b6c7a829657c99163bf70c66eb160a19ad607966e38920f8fdf341a809"
+    },
+    "progs/mark4.mdl": {
+     "bytes": 419952,
+     "sha256": "5573df5c7c67988f3de6115b8edf3acaf45b744a48222c3384f7bb97b79452b6"
+    },
+    "progs/maxwell.mdl": {
+     "bytes": 406452,
+     "sha256": "4290e95e194a6ff76af5fed10127be3069984510c72df31cf61aac7f1ccba364"
+    },
+    "progs/mg_nail.mdl": {
+     "bytes": 30720,
+     "sha256": "708ee4afc78acc2ac37487e8714e7761de6a49b192524cbb41437c1e52e31685"
+    },
+    "progs/mg_rock2.mdl": {
+     "bytes": 39455,
+     "sha256": "a57f05249a7813b7985a38387709b2830eb80e01b8dccb272dc06a0a84cd3d51"
+    },
+    "progs/mg_sh.mdl": {
+     "bytes": 35313,
+     "sha256": "10abbd466cc7b38c3c01087da2e1aa269ae3aa73c6ccc5e599dd31013c2481bb"
+    },
+    "progs/mg_sh2.mdl": {
+     "bytes": 52788,
+     "sha256": "02b529fe12090596209c1d6187e0cdf6a8c3b42b13dda283c094aef01516e341"
+    },
+    "progs/mgsh.mdl": {
+     "bytes": 60476,
+     "sha256": "08f998720be98b1e80555bf04a412c6dc9c15593ceeffdb6ddc7d7b1716ffbbf"
+    },
+    "progs/mhelth.mdl": {
+     "bytes": 21724,
+     "sha256": "39d5895bd074db555e990c580e3cd29307ed9c32f74423ad868f632447a5fa2f"
+    },
+    "progs/motel.mdl": {
+     "bytes": 37776,
+     "sha256": "5b6ad3c8f7e16a15a2dd17a4ec187b3235fbc9100494342cae4da377244a8f88"
+    },
+    "progs/mshelth.mdl": {
+     "bytes": 21655,
+     "sha256": "c74ab8bf5e31e8d8bcde671e5cc8ed016ac930f8ff8dbfdf1b5613e30c7f8298"
+    },
+    "progs/mv_nad.mdl": {
+     "bytes": 46776,
+     "sha256": "ecb9c6c40af63cf6c83b8075ca32b5e6de5c56b82817b25d3745bf6f3ce9f548"
+    },
+    "progs/mv_nail.mdl": {
+     "bytes": 68732,
+     "sha256": "7c137ed79f6f31b3248996c8cb765065a8c026368daa6a213123bdfd02ff91c3"
+    },
+    "progs/mv_rock2.mdl": {
+     "bytes": 28108,
+     "sha256": "90249d974747bfc35431e4278c43f240df2dc731598c06270892d67e0ca63d6b"
+    },
+    "progs/mv_sh.mdl": {
+     "bytes": 50816,
+     "sha256": "a268fcdd759290a3f804aa3dd247d0bfaf9482a4a653bac6eced814fc9b32e4e"
+    },
+    "progs/mv_sh2.mdl": {
+     "bytes": 111091,
+     "sha256": "ad4c498c4e98dd99069d1bcf0f30dcb05ec0f837ed0830f9c9344d22d3ba0e26"
+    },
+    "progs/nehah.mdl": {
+     "bytes": 816160,
+     "sha256": "44d4781e1e465ff986b10bf2ed2430f5cd2bc1fb2abb5213e60486a2669505db"
+    },
+    "progs/nehjet.mdl": {
+     "bytes": 19956,
+     "sha256": "eb67d558dcb312bcb667b1041860543d6a269114e8595ac63b83c9d5e1c4b23a"
+    },
+    "progs/null.mdl": {
+     "bytes": 3620,
+     "sha256": "196c874a365658aef12a99dabec9bbf9b28cae83a0a4345daab1a90272ea2098"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 167668,
+     "sha256": "519860fb84e12b7acbefb393741c682ece8f477d540d675c587a7fe70ebc072b"
+    },
+    "progs/player1.mdl": {
+     "bytes": 899336,
+     "sha256": "7fc7bba6a377fea86f4a8d70558c4408474cf72b0a83efdee333840d843786e3"
+    },
+    "progs/player2.mdl": {
+     "bytes": 565184,
+     "sha256": "b5abe6c3354bfd9319dc9c595d14fc2665a658765d2362136c1c6fad58e43a6c"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 39992,
+     "sha256": "4ff6776653d084facc5052c340f68385f5fff6180dc4f92c3f1daf2f59f1988b"
+    },
+    "progs/rain.mdl": {
+     "bytes": 635304,
+     "sha256": "70a375857f9bc5b52cfce74eece7af84c93a98c37676847ba54c9cd0f3d743e5"
+    },
+    "progs/regen.mdl": {
+     "bytes": 39048,
+     "sha256": "943b4e8c143a0051bf4221303d29beeae2e67de29dcad18adbf51261cb2c0ba5"
+    },
+    "progs/res.mdl": {
+     "bytes": 119976,
+     "sha256": "7187cd434156ea04ba1c91ba6fd2648df80cf44a51eca42c10a00a4b1709936e"
+    },
+    "progs/route.mdl": {
+     "bytes": 393740,
+     "sha256": "c2eff4babcbde84964bdb5a3b6f331a82f2dc948f1be9bb35e91a27c15b5f41c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 10616,
+     "sha256": "0553ae15b5938fc0f4b49ab692668b0e0176f6b8560a0d9f2a3278b6d33dfa8e"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 30344,
+     "sha256": "3471ac646119630aea14f25fc527c1b7189dcc21fd27fc5bf52e9f5ff0987b17"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 43832,
+     "sha256": "ba0f53c8f354bedaaba9c940304647789cc7b0e0255865bcdeea4af1bf6e702f"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 10616,
+     "sha256": "bf9082b92bc73e4f9d7d83b75728841fe6d586714cb31bba73d5f8caf002d367"
+    },
+    "progs/rubble5.mdl": {
+     "bytes": 30344,
+     "sha256": "64576536a7950afd4cfa0961ca949599c090f8a74ad4db452f67d066a847b813"
+    },
+    "progs/rubble6.mdl": {
+     "bytes": 43832,
+     "sha256": "d9d8f3529b9ffb085d9f94cb552205798609619ed4db4bc01db02a430fa62647"
+    },
+    "progs/rubstorm.mdl": {
+     "bytes": 242724,
+     "sha256": "4792b666b355d4a3115f95c45e4fe0add19c8a35bc3b4788a60be05caddaf0d3"
+    },
+    "progs/runekey.mdl": {
+     "bytes": 60844,
+     "sha256": "4243f82351bd7db91b4ed7af231aeb4bea0628464cb396cc2cd7a83a4fe277e3"
+    },
+    "progs/s_null.spr": {
+     "bytes": 56,
+     "sha256": "29e9c18546413f0abc9c6f507c61952f33afa6507b52d1c2197b57e3be7870a9"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 148588,
+     "sha256": "0dcc2474e14532d8f0650c493d0c3bda2a35c2d7cf1f8bdc1eb1c5c7fa84fbfd"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 104596,
+     "sha256": "ac29c95757a29ac940808592ab0757360bdb64720f3694e2157b8effc6542729"
+    },
+    "progs/shthng.mdl": {
+     "bytes": 100228,
+     "sha256": "825329cb15c6f8d3c04e7c8dcb9eed081170c0ab3ba5ea94890da6f3b4b61591"
+    },
+    "progs/slime.mdl": {
+     "bytes": 16952,
+     "sha256": "e4b1cc7d8fa1644d3eb98ddd6e18316c0a9104fa510a879b1a1691cdf4f6e7bd"
+    },
+    "progs/slimeball.mdl": {
+     "bytes": 8788,
+     "sha256": "aa53c9bbf7c57c40cdbf92e321a52625a3b1a7b24c1b81eb3428122e0bc9478c"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 251976,
+     "sha256": "ac408fc54871534eb06bcce4bbb365c5ed2dce6fd20d8d1e9f33a01bdfe3b93c"
+    },
+    "progs/soul.mdl": {
+     "bytes": 8436,
+     "sha256": "eb4dc0dae8aed7c92d328096fd9633566b658c9cc65777211ade1e67c6e0ff64"
+    },
+    "progs/spikekey.mdl": {
+     "bytes": 41444,
+     "sha256": "177ca9b01066f7b20752893405b146359ed7f37ce8d75f7c2c3cfd1d30ee0d25"
+    },
+    "progs/sprocket.mdl": {
+     "bytes": 55136,
+     "sha256": "10b929d2c889fe52dcc6b39c1ca56619dcc5f0cf3b6e7e69f8347f9948e1f62d"
+    },
+    "progs/tree1.mdl": {
+     "bytes": 232924,
+     "sha256": "7cb8b341835b99c393aa56e69a804ceeddd38a2ee5b95738aca894205875640b"
+    },
+    "progs/tree2.mdl": {
+     "bytes": 210540,
+     "sha256": "b72a4b46b655aee9b290ea43faa3845cabf9ef566e07f458bbb8220c47eaba21"
+    },
+    "progs/tree3.mdl": {
+     "bytes": 186004,
+     "sha256": "5fe6a11b3f502457ae3d60f9a0695382bf6850feddc548f6208b4b8b21ece53d"
+    },
+    "progs/tree4.mdl": {
+     "bytes": 267676,
+     "sha256": "7f64dbad8d7bbd932690b34ed8479d69f5bbd5ab77bc1061b7fe9ab6dd7d1636"
+    },
+    "progs/valve.mdl": {
+     "bytes": 17384,
+     "sha256": "23ce1b418654aea912372ba03bc11fc1fc99fe74b6d0137636ab44767ed6f1d4"
+    },
+    "progs/vending.mdl": {
+     "bytes": 320768,
+     "sha256": "8bb30b43d7c118beb631e12b95848b6270aa0cf0dc0e957ea2bca069cfab1413"
+    },
+    "progs/vomitus.mdl": {
+     "bytes": 79724,
+     "sha256": "5dab44270edd2b79518b006d4822fc732eae168ffe78b18467da138644bfe5d7"
+    },
+    "progs/wr_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "1bfb049cf920973e32d78cbf7cf8b6c0c18f8dde55006ee43798ead4b99af9a7"
+    },
+    "progs/wraith.mdl": {
+     "bytes": 393644,
+     "sha256": "5b77b2194d43932326962bcf9351b1e5c722ee74373b4f64e2e34e21e758a36d"
+    },
+    "sprites/explode1.spr32": {
+     "bytes": 393372,
+     "sha256": "95199ab85e197d10e7fb7dd8ce0551c38befeca8ab97fe18bd57c73e7e3c2dd0"
+    },
+    "sprites/explode2.spr32": {
+     "bytes": 983376,
+     "sha256": "20f721a811d0431bd2e70607f8d56a6177eb6e3909caf8a780910ab3c25a941a"
+    },
+    "sprites/explode3.spr32": {
+     "bytes": 327816,
+     "sha256": "cedd091b244e2af2473d007cbc45b6dc16d00b7081a6552895ff087fc76f6dc3"
+    },
+    "sprites/explode4.spr32": {
+     "bytes": 327816,
+     "sha256": "34f6b19f7a5519b8f3599dabcd9db4c76e325e5c75523ce3f6015ace53755c22"
+    },
+    "sprites/smoke2.tga": {
+     "bytes": 16402,
+     "sha256": "b0ad419ce2ea88f23e784587f35fb77f1232a5750f443608430e41d5ddbf4fd3"
+    }
+   },
    "sha256": "fc709e6a650ea279619257fc37e0f4a2df252adb27f059362268a6bf42e92290",
    "timestamp": "2000-08-26T22:10:42.000Z"
   },
   "nehahra/pak2.pak": {
    "bytes": 57681524,
+   "files": {
+    "maps/crate.bsp": {
+     "bytes": 18592,
+     "sha256": "68aee10a1300c78d149ce18eecfe32bf52a1d6dc012d529851d1e37fe2cd95fc"
+    },
+    "maps/neh1m1.bsp": {
+     "bytes": 2193324,
+     "sha256": "71524736f900f6a59d321d4b42f3f3e14eb33f98da0e96714688401090b9ea1a"
+    },
+    "maps/neh1m2.bsp": {
+     "bytes": 2777980,
+     "sha256": "54210164c83d9de77e93f720d1fa43b2ed3df7d201d6310638d304f35eada719"
+    },
+    "maps/neh1m3.bsp": {
+     "bytes": 3070964,
+     "sha256": "7f1612719a94e392c721a3c25594037f9faa902f09be7765f60a24e13df76e01"
+    },
+    "maps/neh1m4.bsp": {
+     "bytes": 2457748,
+     "sha256": "6b5db6837f8b3b2fbead087fdb25fad9093f1f81f3ac7505b0c1e80eca45e588"
+    },
+    "maps/neh1m5.bsp": {
+     "bytes": 3113956,
+     "sha256": "4043cef7741260baa6a2e41eef8515ebd81d73c7f941535a05e6c62ef993566e"
+    },
+    "maps/neh1m6.bsp": {
+     "bytes": 3754348,
+     "sha256": "d06c8d4aa2cb21f5be3dd3e7f433d65ae62e5ddd50c2f8f5f986e72fbf42f366"
+    },
+    "maps/neh1m7.bsp": {
+     "bytes": 1862988,
+     "sha256": "f6e86714de58e4d826c65b1e0d4b1f34a5f6ecef1c07af030fd496f8d72f4eb6"
+    },
+    "maps/neh1m8.bsp": {
+     "bytes": 2081608,
+     "sha256": "3e9638525174310801b7f656b0cbe782ac48a2bdb8de3ff0ec43a770f0852357"
+    },
+    "maps/neh1m9.bsp": {
+     "bytes": 2384596,
+     "sha256": "9301bfabfbb49e37ec01dc3ed136fe4ec286c6005cda02f39a442d50f2e4bd1e"
+    },
+    "maps/neh2m1.bsp": {
+     "bytes": 1894880,
+     "sha256": "4d23a0ddc44720ddd472c6e0008a37a2fd299dc6afa2f7068c5173feca91a316"
+    },
+    "maps/neh2m2.bsp": {
+     "bytes": 3154674,
+     "sha256": "15f1b437e589b4825b4688f10f86df283f078323600e9c2426a590b1b2b5d32c"
+    },
+    "maps/neh2m3.bsp": {
+     "bytes": 1344992,
+     "sha256": "50888b4f2c1a32b4cce0b7a89ae0b6cc9d86bb9d37968c620d07c23b9510388b"
+    },
+    "maps/neh2m4.bsp": {
+     "bytes": 2106944,
+     "sha256": "5acc896436c2e1059559a1de2d0bc6766cbbb45a3c94c62fe2c0f5d0d5a457d7"
+    },
+    "maps/neh2m5.bsp": {
+     "bytes": 1838236,
+     "sha256": "25dbed839fe399a99c97d89efb35522af1513bf571da8dd5546ba57121370b3a"
+    },
+    "maps/neh2m6.bsp": {
+     "bytes": 2325292,
+     "sha256": "674336df380edaeca9cb48ee2b16bb8b8f0e7c78e6662377cc8d90169511b0a7"
+    },
+    "maps/nehahra.bsp": {
+     "bytes": 1963892,
+     "sha256": "f2cf5e6fcf0fbcfa5a7e72f5ec5fe52bc061f8ab411bd84d8da556e44e9c79b7"
+    },
+    "maps/nehend.bsp": {
+     "bytes": 1612604,
+     "sha256": "611a94208cd8dd507e71d4d220378a9828024281907939fdea13d009034ee391"
+    },
+    "maps/nehsec.bsp": {
+     "bytes": 966672,
+     "sha256": "521055aa7ab9792b9cd8d963b6b209e598ea244b19c366f6c304a163dbf65c0e"
+    },
+    "maps/nehstart.bsp": {
+     "bytes": 1095992,
+     "sha256": "08c07f7e49d77ee618bae0aabfb3f0a02ec907204c27a2d3f2b440fd7889dced"
+    },
+    "maps/timcut_1.bsp": {
+     "bytes": 1494404,
+     "sha256": "241a4a8cf1000fe4e4fed0d4634873bf3b86cc9328816945440bb2e72934131c"
+    },
+    "sound/ambience/amsizl.wav": {
+     "bytes": 110504,
+     "sha256": "da373ab7e450ed4c8903739ce2775f72e2def1ba39008cd8f04f18808691c323"
+    },
+    "sound/ambience/begths.wav": {
+     "bytes": 198656,
+     "sha256": "55d1a287439c5259b992ab58b96041fb72e574632b1664629af7d26eb28bc3d5"
+    },
+    "sound/ambience/bugs.wav": {
+     "bytes": 167156,
+     "sha256": "1fab9dcde2b44f2a0582d70f422a8b6c36b996dea18766423a25d2d1f22efc4c"
+    },
+    "sound/ambience/bush.wav": {
+     "bytes": 184876,
+     "sha256": "887d1ded6a625396a4c98bbb63a3ac392912ae725f8c501bcac169698e1ee769"
+    },
+    "sound/ambience/class1.wav": {
+     "bytes": 176648,
+     "sha256": "1a6e90d1a8ee44c4667aeb447f198e93ad44753fda2eb60ca73a88b83f30cdd9"
+    },
+    "sound/ambience/class2.wav": {
+     "bytes": 187672,
+     "sha256": "a97cf59e359ba446c6961b94d6ec54a57759403926a09fd4718c91fd13bc629e"
+    },
+    "sound/ambience/class3.wav": {
+     "bytes": 171136,
+     "sha256": "3e580cfbd35d5293e38e203f0ba4796974fc9deb005bb42945130cb88ef4db46"
+    },
+    "sound/ambience/ctscexp2.wav": {
+     "bytes": 404366,
+     "sha256": "fb69c6be6d30c4f9d0060a83fc98fabec0cb36714d2e49a7c17dba7a966bc3ee"
+    },
+    "sound/ambience/ctsclock.wav": {
+     "bytes": 401424,
+     "sha256": "f96ffffc37c49c62b0108088ee888e790fe3a948ff24bb7c67b7863b6bc10e8b"
+    },
+    "sound/ambience/ctscseal.wav": {
+     "bytes": 229366,
+     "sha256": "b4bcb9aecb9262cecc6ff0a70b2a21632a07bfb90bddb9d5c3ec5db7bb4b8626"
+    },
+    "sound/ambience/drain.wav": {
+     "bytes": 193504,
+     "sha256": "70e6d00acfd6333d82ced5033ea26f85172df946e6d8923c47e8b999ebb5cdb5"
+    },
+    "sound/ambience/factory.wav": {
+     "bytes": 105260,
+     "sha256": "768de063af0c211b5a05573b49fd3290a9cd0dec82da5105e27a1a5d9673bf39"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/filt.wav": {
+     "bytes": 148402,
+     "sha256": "4a403c3dd0e288884d31c05c7c279bd869788cf4903372eadb677ae91b2ad657"
+    },
+    "sound/ambience/flash.wav": {
+     "bytes": 183844,
+     "sha256": "b6aa619edacf8f8059ad998dee12e092c88a2f5b0d2197a221cff890ae6298a1"
+    },
+    "sound/ambience/heart.wav": {
+     "bytes": 38176,
+     "sha256": "4a3bf21ed13e0804a51ca4f97660f6832cf5d7361a03c60f0b41201aa7acdecd"
+    },
+    "sound/ambience/hum09.wav": {
+     "bytes": 106430,
+     "sha256": "8591f59cf8e1efa3b2a574507a649b2395c902763958ca432645abe35d6150bb"
+    },
+    "sound/ambience/mayd2.wav": {
+     "bytes": 170550,
+     "sha256": "e893d11a40fe8f2996faff4d4113762390926b1afa6f49a5f8357e39122340a0"
+    },
+    "sound/ambience/maydn.wav": {
+     "bytes": 170550,
+     "sha256": "1d87c92f779de27209a78c2a5316034b82abcd49553b635f61ccdef52777a25b"
+    },
+    "sound/ambience/maydn2.wav": {
+     "bytes": 371838,
+     "sha256": "7a5d06977b57f701f0d0205d2d4d1e6dbf31c63e427ab149b614e66834517434"
+    },
+    "sound/ambience/rain.wav": {
+     "bytes": 91202,
+     "sha256": "a196a2fc8a052368f9e8f7efe853391d1a99dfb1f6afae4fc7038222f2eb6fda"
+    },
+    "sound/ambience/rych1.wav": {
+     "bytes": 192668,
+     "sha256": "fd7d93d5f42cea3e78f0ea8a5eb2ae9d454ab73d8a0a5b950bbac85385f66dd2"
+    },
+    "sound/ambience/secj.wav": {
+     "bytes": 276944,
+     "sha256": "092d29628044d42cc121747d2f786f6107cedb7331033552e0c004522e81836e"
+    },
+    "sound/ambience/sphum.wav": {
+     "bytes": 106442,
+     "sha256": "b4d03275fe769bfba687d17e2f276ca7c96b03237baf9bf52af80e7065acfe11"
+    },
+    "sound/ambience/swamp3.wav": {
+     "bytes": 178120,
+     "sha256": "f2a87ea69026479e97c6d62bb8ad838365f8545ba26668d95404eac6ef6a862c"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/thunder3.wav": {
+     "bytes": 108462,
+     "sha256": "795690ae1f37a04204b279f3fa5932a723201acfc8a0d2ad9e01e5a79a5a519d"
+    },
+    "sound/ambience/whn.wav": {
+     "bytes": 206924,
+     "sha256": "b815d643cbd05d4c10a0c76d76a68514d0a1b8ca44e6767dbc2b5cf9dba044f8"
+    },
+    "sound/archg/fire2.wav": {
+     "bytes": 17126,
+     "sha256": "e0cdeb0f1295e44e07c3848d0eb7591fd149fbf45aed05af69bf72663331a8fc"
+    },
+    "sound/archg/lift.wav": {
+     "bytes": 19746,
+     "sha256": "cefb1dd1bc70c77e5a15f8c84e51d3b40dc9dfbc298c609b335ff94fc8319edd"
+    },
+    "sound/archg/lift3.wav": {
+     "bytes": 27624,
+     "sha256": "14a6c4706344375e4ca5fdcb1aed807e6082874cfc7db007dc9e37888e0337f1"
+    },
+    "sound/archg/melt.wav": {
+     "bytes": 20110,
+     "sha256": "813f262f9244bfb8c944f0776cefef7a1c4ca7d265a1f88473b7490f345024b4"
+    },
+    "sound/archg/mykey.wav": {
+     "bytes": 33136,
+     "sha256": "5b2bca318235b401b39036e3ea71e99971249343b98d3a8c35eabbc88d001add"
+    },
+    "sound/archg/pain.wav": {
+     "bytes": 9824,
+     "sha256": "449168d6aab67ac7fd08fb5cfe913fbfeca12441839dbeef57c1b9ed03704264"
+    },
+    "sound/archg/petrify.wav": {
+     "bytes": 38162,
+     "sha256": "5e81875f013b9c0bff156de8b03dc5e2a94a4fc638e98ceb465c7ca316c874ea"
+    },
+    "sound/archg/shsh.wav": {
+     "bytes": 33136,
+     "sha256": "da081e322290528311509e0382d24c4b9d1fee7715be0ae39336222445d2b820"
+    },
+    "sound/baron/bpain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/death.wav": {
+     "bytes": 68188,
+     "sha256": "0785bad4b7b721f2bb989fa74f7186552ef9bbca016fb2f1a3fe9b52650fe3cb"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/sight.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/boss3/hit.wav": {
+     "bytes": 4566,
+     "sha256": "b36e7581fe973d854b6f59947c5fe30b7118c94e7973f93b54a0c17423ce3fdc"
+    },
+    "sound/boss3/neh1.wav": {
+     "bytes": 21924,
+     "sha256": "1aa5cfa5731d44a199fb57de869a7387b8fb4bedff962b77f85d4d3598a60e5c"
+    },
+    "sound/boss3/neh2.wav": {
+     "bytes": 19860,
+     "sha256": "e2db57f488f0cc28f737f8b18ccc0baf55c2ae5f86f96de42f07b442bb9f4e37"
+    },
+    "sound/boss3/neh3.wav": {
+     "bytes": 29528,
+     "sha256": "a114f46bf6eba665047d51b44b9dfbc0e83f644fff79f622b1354f2f9996b357"
+    },
+    "sound/boss3/nehdie1.wav": {
+     "bytes": 112516,
+     "sha256": "1c5dd743b00505b7cb6440accbff83d4043555c03d54b06206c0e8ce3a3aedf4"
+    },
+    "sound/boss3/nehdie2.wav": {
+     "bytes": 27230,
+     "sha256": "6a593203e161ffc441e7e3dd7ab4163057e8d57628d6f95825dc46c750d60885"
+    },
+    "sound/boss3/nehdie3.wav": {
+     "bytes": 17494,
+     "sha256": "efb2cf06c2c286df26b81f9a35c8dfd9a2180943eac6753761599ac4d344bd71"
+    },
+    "sound/boss3/nehdie4.wav": {
+     "bytes": 17826,
+     "sha256": "bb4ea1f3f5fd5749cb6bba3dda779795d4c04a7f39992e0ed6fa993d64c22113"
+    },
+    "sound/boss3/row.wav": {
+     "bytes": 63426,
+     "sha256": "8fd61062872b1d4935606bf9bb84659ff0a11ef4cfab918081f3f2c51064ad69"
+    },
+    "sound/boss3/step1.wav": {
+     "bytes": 39038,
+     "sha256": "b242aedf81828c37f0f16d379723e73c284587ada63e4f1c8f1cf8c985e37dfa"
+    },
+    "sound/boss3/step2.wav": {
+     "bytes": 10826,
+     "sha256": "da4be9fd2623a697e85a3f6b203a25c825307ed34dac4b53c75868d74f6eaa58"
+    },
+    "sound/boss3/swing.wav": {
+     "bytes": 5306,
+     "sha256": "318ba3459adf03374bdf9a1ddd4d0b01d69eb7df4fe8dbb7a3703bec04649b59"
+    },
+    "sound/buttons/rch_sw1.wav": {
+     "bytes": 23498,
+     "sha256": "ef5267518b0e31c7aadd9e3012d4cd7679b4b74be59acbcbd6fe9a44f2bfd8ec"
+    },
+    "sound/buttons/rch_sw2.wav": {
+     "bytes": 23748,
+     "sha256": "f5517787f927f0c5ca571b7fb088cd1a93a5f07409db96caf9e7c138e034fd4f"
+    },
+    "sound/cook/cannot.wav": {
+     "bytes": 53034,
+     "sha256": "f0c1bd7686ec831b37ffa0ab136dedf76667f58a5b14c37e5a897b3d8521e9d1"
+    },
+    "sound/cook/comm0.wav": {
+     "bytes": 68378,
+     "sha256": "205aa8a23623c7269a51d82f32af6e8e78977d08311b05a7d2f6a9cfc00faf18"
+    },
+    "sound/cook/comm1.wav": {
+     "bytes": 61984,
+     "sha256": "7670645f072fa5e8aeee8cbdb99de41432f47278614bd02ff873f0439393c4db"
+    },
+    "sound/cook/comm2.wav": {
+     "bytes": 49314,
+     "sha256": "31a7e120682b114692794af352a3c1910017f1dbcca4236a65c76965d86d7572"
+    },
+    "sound/cook/comm3.wav": {
+     "bytes": 38710,
+     "sha256": "e81d1a90c2f4b0884f43aa0a79b988c4cb42107b9c44276ee84a140524329180"
+    },
+    "sound/cook/comm4.wav": {
+     "bytes": 44920,
+     "sha256": "726218022f1550c2e85703e2f8422d07cbc3684b40547083cdd63be88e3222cc"
+    },
+    "sound/cook/comm5.wav": {
+     "bytes": 49076,
+     "sha256": "398f39ffbef199c6e2c48495988257a6ca83a9672feb2c7fa1c1c4d107079ed1"
+    },
+    "sound/cook/daddy.wav": {
+     "bytes": 21568,
+     "sha256": "815c3862b5972409614c50b3f5eee5d2eafb4db697f86a56dd50af762789f0b9"
+    },
+    "sound/cook/dpong.wav": {
+     "bytes": 61378,
+     "sha256": "d48f412c65ec87980c57aba6d94773633557a6be04c77d3dc42429043798dd91"
+    },
+    "sound/cook/gethim.wav": {
+     "bytes": 33196,
+     "sha256": "b2da7960865926eada1a79a5fe5a92d7d413f6dcd96cc0e6b654ee639281dda8"
+    },
+    "sound/cook/goway.wav": {
+     "bytes": 11728,
+     "sha256": "ba448fbf5de3a111ae9c734e8a402f14005eaf1aece2cc4c4fa306ac868a3137"
+    },
+    "sound/cook/idiot.wav": {
+     "bytes": 11580,
+     "sha256": "ccb15ea7ab54d88e325447fa8136283bf7543eb4d568e3db747a6c60ee7b78a5"
+    },
+    "sound/cook/listen.wav": {
+     "bytes": 18486,
+     "sha256": "852392fb75f2cfa1d790df941ac77a02e33aa6724332d9cf638dcca79858f8d4"
+    },
+    "sound/cook/mademe.wav": {
+     "bytes": 33334,
+     "sha256": "a9c3d1b51f4ce2ce5a044c31228777aabcaa0aa4d43918986031333bc19656f5"
+    },
+    "sound/cook/makemad.wav": {
+     "bytes": 52430,
+     "sha256": "545755bce49ee16f5b417e60dbbce7b53400d48b81bc69658955ff2be9eaed6d"
+    },
+    "sound/cook/moron.wav": {
+     "bytes": 25756,
+     "sha256": "e310703319478552bb5f33472d9aca23fa959177d31f5693eacd9af469795c85"
+    },
+    "sound/cook/pansiz1.wav": {
+     "bytes": 105546,
+     "sha256": "934181b1dd7b494c5dc77b8805060e825c9c40a0d0b69be300ac375451ac2a81"
+    },
+    "sound/cook/pansiz2.wav": {
+     "bytes": 26246,
+     "sha256": "433fb70e47cdb41ac1b9e9d78bc7524d4772469e3339ac019934aff36a654be9"
+    },
+    "sound/cook/panup.wav": {
+     "bytes": 5572,
+     "sha256": "bd7fc1f8e50f4ab1760b6e713e51897e971dd76b8fc56f85c6358e6c9b9bd13b"
+    },
+    "sound/cook/ping1.wav": {
+     "bytes": 23298,
+     "sha256": "244c90f5196a63c124ae6f56b0a833baf9a0fba79a1a82f3284527ca37e6d07d"
+    },
+    "sound/cook/ping2.wav": {
+     "bytes": 16598,
+     "sha256": "3cc73ec13a1871eb7088e1b1bd51dcd8220ebacc23fc1760d031e1798599333e"
+    },
+    "sound/cook/pity01.wav": {
+     "bytes": 46978,
+     "sha256": "5c294ce0073607f4639eb9e1047f0948b9b3785da15bfa25dd49a2bc64962bbd"
+    },
+    "sound/cook/pong1.wav": {
+     "bytes": 19906,
+     "sha256": "562d4465eeaea19d1dd6faa910f5aa2baa281bccd5bee8775e21317d550a6a1d"
+    },
+    "sound/cook/skull.wav": {
+     "bytes": 33190,
+     "sha256": "a27c47ba97dfa4d365438a3ff9850695b33910b2cadab3d01f8c4a8b1826d83a"
+    },
+    "sound/cook/skull2.wav": {
+     "bytes": 22040,
+     "sha256": "30d5e91a09f8282b4253b7ebb23a74fcc3da57809393bc5f76458011601d2b57"
+    },
+    "sound/cook/whatu.wav": {
+     "bytes": 15272,
+     "sha256": "0aa5d1dfb69d33bab7bf29281577961557de419da76bd117a51053849f7aef3c"
+    },
+    "sound/cook/you.wav": {
+     "bytes": 16654,
+     "sha256": "8c0b381a1a0fd0170f4f84b8fffc7844b59da99d8a2e21ad161e82d4d17969b6"
+    },
+    "sound/cuts1/flf1.wav": {
+     "bytes": 274014,
+     "sha256": "7ddb5fb8e2d39b4d947ded1f6ae3860c9e11958debf78d4a251d27b6212e2c4a"
+    },
+    "sound/cuts1/flf2.wav": {
+     "bytes": 220578,
+     "sha256": "06cec24763e0ed033a0e87f499dd13801562a5b3d15bbf53ec0400914416726b"
+    },
+    "sound/cuts1/flf3.wav": {
+     "bytes": 231356,
+     "sha256": "46b0f604f8b9b98b72e2e119455bbeae39b0aed4435a922b39908ef60b6c5ad8"
+    },
+    "sound/cuts1/theme18.wav": {
+     "bytes": 110496,
+     "sha256": "3b3c6bbdb29b529995d0ea111ab3be5dcc141f482f8746555edb43f30c5905eb"
+    },
+    "sound/cuts1/theme2.wav": {
+     "bytes": 177088,
+     "sha256": "35a8aa7508b3bf7e2941a29c7a8e2b9b5329b3180160738da91320637b163d7d"
+    },
+    "sound/cuts1/type.wav": {
+     "bytes": 1902,
+     "sha256": "a3b128f1585f5764d1c044a5695625635d1934ea54e76b27f0a63f93f0e5711d"
+    },
+    "sound/cuts2/char_quirk14.wav": {
+     "bytes": 23278,
+     "sha256": "2a1915463dd1042b6fa9233214fb091965efe6ca4f70c60486063ca4501a12d0"
+    },
+    "sound/cuts5/b_sold16.wav": {
+     "bytes": 71066,
+     "sha256": "39c1052306c12dc008820b6402de6a5f9b48ae27ac5503eab48f1e6c166219f9"
+    },
+    "sound/cuts5/bikego.wav": {
+     "bytes": 24942,
+     "sha256": "1aa5684265e7d9a3792749cdf383419a0b8272d9964b0baf771263277dbeb907"
+    },
+    "sound/cuts5/bikestart.wav": {
+     "bytes": 24858,
+     "sha256": "e3004795f6fc186ef29433b06dc87e913c848bbcd3b5c7c109ce2150ead1917d"
+    },
+    "sound/cuts5/gj_mexican1.wav": {
+     "bytes": 118602,
+     "sha256": "1ce20664fd29c0779b418ac1d6051d4daa6a33942c2d73a5f6d97ccab1f93985"
+    },
+    "sound/cuts5/gj_quirk12.wav": {
+     "bytes": 23394,
+     "sha256": "d0b8922ad9488eea5caff62c2db18cdb8dbd5b7aa6e969f139ee96bc8473f501"
+    },
+    "sound/cuts5/gj_quirk13.wav": {
+     "bytes": 22178,
+     "sha256": "7fa5c3b4636c533443e375b604d4b4d73109122a972fd34661e8b4566218f3e9"
+    },
+    "sound/cuts5/gj_quirk18.wav": {
+     "bytes": 148292,
+     "sha256": "bcc0930a011ffbd6bf922f88f9fa9fd2696710c0ed4764f9ca1998be61f92a54"
+    },
+    "sound/cuts5/gj_quirk5.wav": {
+     "bytes": 54586,
+     "sha256": "11988886441170f4ac530da8cb435330bdb9d81c9391df53362be7e281b966ed"
+    },
+    "sound/cuts5/gj_quirk9.wav": {
+     "bytes": 57664,
+     "sha256": "1bae9148ac7b86e67ffc23b6f802d9cfd9d1d0d9b060a14674f48936538a46c3"
+    },
+    "sound/cuts5/pre_hum1.wav": {
+     "bytes": 231066,
+     "sha256": "a1475bb674b56b444c72716828d79bd8bdddd371e8765288867799fb68ea912e"
+    },
+    "sound/demon/dland2.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/enf2/choke.wav": {
+     "bytes": 8398,
+     "sha256": "d832e83f74a7f8bc64b0db0f8a5a332fbe4b8619be21667f6fec2218147eb3dc"
+    },
+    "sound/enf2/comeon.wav": {
+     "bytes": 30650,
+     "sha256": "bdde9ae110fed59ecfcd31c04db60da1155edeb810a9cec6a68bc163e4c30227"
+    },
+    "sound/enf2/death1.wav": {
+     "bytes": 13502,
+     "sha256": "5ce981fa95de666d063a54c51be3c6e3b191386876cb9c9b4e74fc07418770d6"
+    },
+    "sound/enf2/death2.wav": {
+     "bytes": 12254,
+     "sha256": "c1dd7b7be777bd953ea008ef42501c49551bb7ab45574d8da38978468dcdadb8"
+    },
+    "sound/enf2/death3.wav": {
+     "bytes": 9812,
+     "sha256": "17d12b7c3b2d14e890322e71611bd6d307c42d6454e8ebc4be4d1bc9c04264a7"
+    },
+    "sound/enf2/die1.wav": {
+     "bytes": 18918,
+     "sha256": "f6789310ebf23d959d069697d2b780936551b9e99f04d57f4b86e6da26a9be7f"
+    },
+    "sound/enf2/fall2.wav": {
+     "bytes": 28690,
+     "sha256": "4f15bdada45a8b26490f2ce8916e0653534f7e451edf65df5e8c1e8b7dbae6b0"
+    },
+    "sound/enf2/idle1.wav": {
+     "bytes": 13762,
+     "sha256": "4813cf6095d60413ea070de81bf6d1fd6ad8fa10ae04639d479ae3557bf92d13"
+    },
+    "sound/enf2/idle2.wav": {
+     "bytes": 8674,
+     "sha256": "b4f25e2f2ec15a48f6ad67caf53682434890a29a1d5dd805d8fdf710ae994e93"
+    },
+    "sound/enf2/idle3.wav": {
+     "bytes": 16640,
+     "sha256": "c761f65f03e92c362f605213af2def9f11176ec53baa53ec6a6afe4fa1ef195f"
+    },
+    "sound/enf2/jump1.wav": {
+     "bytes": 18834,
+     "sha256": "a53c3b856f3151f3cba737334dc7e1166eb79ae1ee5d1d54806f066b4f397096"
+    },
+    "sound/enf2/pain1.wav": {
+     "bytes": 7064,
+     "sha256": "862db975479d2369910f5fdc80375dd0aa4397786e4413df13197ae35d3dab33"
+    },
+    "sound/enf2/pain2.wav": {
+     "bytes": 7572,
+     "sha256": "7d8d4ed02ecb4651205ec84dddb122e86651dec1c35eb9dbfb2654258bc1e24d"
+    },
+    "sound/enf2/sight1.wav": {
+     "bytes": 18714,
+     "sha256": "11e67340b2a3898919f18786f329d0f512b15736c775bd1cb040e9bcdb8f0560"
+    },
+    "sound/enf2/sight2.wav": {
+     "bytes": 12262,
+     "sha256": "dc7dd7d32e7d1953ee033b6d4affba14b3c2f6a0774e1bb1a1b268d690798ef2"
+    },
+    "sound/enf2/sight3.wav": {
+     "bytes": 9698,
+     "sha256": "dddc358af05df48e088e0fac8a1f9eeaa1873c8546b5d1a6858478c8bd30df7f"
+    },
+    "sound/enf2/sight4.wav": {
+     "bytes": 13980,
+     "sha256": "9c20fab4ac5f7fc4eec8252bc67babd1c36d7ae8209a934cc841d875aa6bc0d0"
+    },
+    "sound/enf2/sight5.wav": {
+     "bytes": 13802,
+     "sha256": "716b7066f0807a18fadf9f83ed1e33ddf5bacd55eceb238caa778e6b1d2891ae"
+    },
+    "sound/enf3/blgo.wav": {
+     "bytes": 28604,
+     "sha256": "709c7c21d0f50da7780cbad6add025d0f860403071a8f0047899fc33ff3a23b6"
+    },
+    "sound/enf3/blhit.wav": {
+     "bytes": 16598,
+     "sha256": "3e92178a35bed11ef2a37423dd73e5fbf711aded09c9e941c55a189a274f497b"
+    },
+    "sound/enf3/blout.wav": {
+     "bytes": 31870,
+     "sha256": "7f384429974ce03728344113ba75bb7d6bd907f9821b5d2e71eea310f85dd7d9"
+    },
+    "sound/enf3/bspin.wav": {
+     "bytes": 77300,
+     "sha256": "79851b5f887b81354840385eaf6b47185f93ec8d641a764509792a7fdfc942e1"
+    },
+    "sound/enf3/com.wav": {
+     "bytes": 15706,
+     "sha256": "51c1adf6abc77cd633f61692f74a051bb85c6e041d78beb2d8b719e8c8701462"
+    },
+    "sound/enf3/death1.wav": {
+     "bytes": 13804,
+     "sha256": "3d2411def4aa3ca326c8ffc02e5c9b0c8a8cc40c2b562bf3c9b37c7738975e60"
+    },
+    "sound/enf3/death2.wav": {
+     "bytes": 11960,
+     "sha256": "d34908076e55a4e995018d9d258a27b87289cffb0e8847bb02b5d2833916c23c"
+    },
+    "sound/enf3/death3.wav": {
+     "bytes": 19422,
+     "sha256": "6035b9fd7dc01dccd67c5b4d36ab72640780c3a82a26eb81ca5d393d55b7015b"
+    },
+    "sound/enf3/dim.wav": {
+     "bytes": 15270,
+     "sha256": "91fed3d698c127e8cc201ab4364bf5c8b294c6711aa4e32b016e3a09d8dfef96"
+    },
+    "sound/enf3/enf3p1.wav": {
+     "bytes": 9486,
+     "sha256": "efac0fd5d140ecddbb3a2bfbde7c7e0b7192a45c4cfa7eb267edac0febf2d386"
+    },
+    "sound/enf3/enf3p2.wav": {
+     "bytes": 7828,
+     "sha256": "25823024f7b37d32ed280dadef73e7517aeeb847e81400e2daa4e53c3ffd9ed6"
+    },
+    "sound/enf3/enf3p3.wav": {
+     "bytes": 6704,
+     "sha256": "7d4fdc3efd087c5af3f80cafb1e28b3fa1d10b422e90ec562131a0c725c65f0b"
+    },
+    "sound/enf3/got.wav": {
+     "bytes": 14800,
+     "sha256": "76a041951d4d3958ba063694cefa891e00d9fc1c116dd0a2e4b7ac903a2c711d"
+    },
+    "sound/enf3/hey.wav": {
+     "bytes": 8842,
+     "sha256": "02c15c047a767c5a2ced26d12b47ac646133ebc860b396035d68f75a8fc1abbe"
+    },
+    "sound/enf3/idle1.wav": {
+     "bytes": 9256,
+     "sha256": "dbe358e8cf0a2377ecb0c9d026a85c2b118fca91f74dcb02553f10e09740b7b6"
+    },
+    "sound/enf3/idle2.wav": {
+     "bytes": 8964,
+     "sha256": "1a53013613e4f16901111cfeb5f1aef3b3622c85269254c542bd3c6ababbba36"
+    },
+    "sound/enf3/idle3.wav": {
+     "bytes": 8514,
+     "sha256": "b273dde1ba704a760ad4d71cde5e022eb293005782beca904fda537e1c2bafd2"
+    },
+    "sound/enf3/jump1.wav": {
+     "bytes": 22982,
+     "sha256": "e150fff1a28d7539091cf238e660e203a135300335239c642458455abff14f49"
+    },
+    "sound/enf3/rig.wav": {
+     "bytes": 20156,
+     "sha256": "384d3ecab9d8153c18cc0ef8ff20eb9114d48c18b0530d0e9582602858e4b4f2"
+    },
+    "sound/enf3/shit.wav": {
+     "bytes": 12524,
+     "sha256": "9215678acea03754622bb07f8c4da15db2e7904830fd9117d811379a0aed3a1f"
+    },
+    "sound/enf3/sight1.wav": {
+     "bytes": 6456,
+     "sha256": "5bf25b7bdd145cd0adf1ebed768970dd1f6a99b12107f1fa3ecb08493cf2a2be"
+    },
+    "sound/enf3/sight2.wav": {
+     "bytes": 15652,
+     "sha256": "c131119af197d531cd541ecf7085d866aa3ac4509c801ac6ead2b4664ad9620c"
+    },
+    "sound/enf3/sight3.wav": {
+     "bytes": 11538,
+     "sha256": "e38d389be28f7cecca63c60e5e15cc233b4febebe43f6839ed5334ae3707f9cb"
+    },
+    "sound/forge/alarm.wav": {
+     "bytes": 11452,
+     "sha256": "7e41e3be1f494c4a45c4ba9eb6ac35d1062ee058ea7a55c08909d01b5d3602fc"
+    },
+    "sound/forge/fline1.wav": {
+     "bytes": 11106,
+     "sha256": "e07644f56eebb5eeda16c52c0a2241fddeed614c69dc1b6ceddc5f76ade64079"
+    },
+    "sound/forge/fline2.wav": {
+     "bytes": 82810,
+     "sha256": "12475f25b05833aab75bfaa7d38093445375a9e18ee426163a25e6bb1e64c8e6"
+    },
+    "sound/forge/fline3.wav": {
+     "bytes": 52494,
+     "sha256": "a361dbd08e99808a6940720bb292c7c35810912e049b770a068f43cda0aab35a"
+    },
+    "sound/forge/fline4.wav": {
+     "bytes": 24222,
+     "sha256": "aefbf174afc1266df0249c0794a56eff8383b6dfc46f8ae6074b62b9acf21811"
+    },
+    "sound/forge/fline5.wav": {
+     "bytes": 22260,
+     "sha256": "61d019376becd616178a89acde9efd289dae5d2c25dc0494bfe7aead575782db"
+    },
+    "sound/forge/fline6.wav": {
+     "bytes": 14188,
+     "sha256": "0720d4fa44846ab2a02919508db4fc3377fca53efb98fa77e888e5aebe9e568c"
+    },
+    "sound/forge/turnme.wav": {
+     "bytes": 8516,
+     "sha256": "03de637c84f07e4568839a4afa1355b9b723f8f2b3cd5393c49688efd8d5b2bb"
+    },
+    "sound/gaunt/boom.wav": {
+     "bytes": 13154,
+     "sha256": "7054bb4cfc91f4a09b461e376549d6abc05c95d202b885eba65701828feab2b4"
+    },
+    "sound/gaunt/clap.wav": {
+     "bytes": 12648,
+     "sha256": "37911eb173e646df9128c0e5e2991599425fe9128cd4c9a28ea904d2ee291fe8"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 35436,
+     "sha256": "4883884380f2b57a629e156f6253f4b1450ba5cc9bd0f91eb385f2c1e02afff3"
+    },
+    "sound/gaunt/elekt.wav": {
+     "bytes": 26028,
+     "sha256": "c1bbf3359831e067f7beb1af6522caa243ee61addf4311eacd5ce867885b4bdf"
+    },
+    "sound/gaunt/g1.wav": {
+     "bytes": 3490,
+     "sha256": "7828162e1ef938488c5dcdb1bb73af97d4779238280571de957fd0c894142a19"
+    },
+    "sound/gaunt/g10.wav": {
+     "bytes": 4296,
+     "sha256": "196eb071e24fd44bd52aa8743d1a8ca7f588e211972778dbf4a4086f5f76884a"
+    },
+    "sound/gaunt/g11.wav": {
+     "bytes": 2778,
+     "sha256": "a9006173cba9467064d1a1c3247355ce66d0745412b78fba9a0e84d3109e927e"
+    },
+    "sound/gaunt/g12.wav": {
+     "bytes": 4070,
+     "sha256": "a83ac5acd7fa9528be44d6886688a986674e9dd6cf2f71fe26cc017543a72208"
+    },
+    "sound/gaunt/g13.wav": {
+     "bytes": 4798,
+     "sha256": "ff0f5102516410a787416adfc3de3dd2efc43ca1fe49f42ae5e2bf720719e067"
+    },
+    "sound/gaunt/g14.wav": {
+     "bytes": 3120,
+     "sha256": "8dc0579247af742fae08f97ddb513c6ba68e3c2a891ddc6e6d76e6340bee5cc0"
+    },
+    "sound/gaunt/g2.wav": {
+     "bytes": 3748,
+     "sha256": "819fe35a06f09b6c063db358bf52f5093f3256cb959bdaac64e2aa61a139d20d"
+    },
+    "sound/gaunt/g3.wav": {
+     "bytes": 2868,
+     "sha256": "3c5cfccb71fc192226ea27c981a6c4bc24a35b70da62909b66d151ddd00b389c"
+    },
+    "sound/gaunt/g4.wav": {
+     "bytes": 3974,
+     "sha256": "22ac437e62806ce499da947ed7219246425bcb8462a6ef97c0a4faf302684a03"
+    },
+    "sound/gaunt/g5.wav": {
+     "bytes": 2724,
+     "sha256": "28cc33742a43eea2d1c0731f3197ee45177b74d684478dbd9f1893a9efcdb9b8"
+    },
+    "sound/gaunt/g6.wav": {
+     "bytes": 3576,
+     "sha256": "3bfb61f9e10e0c86de1fcbb962144fa6d33e9d91e3be9b093bedc5a05bb15008"
+    },
+    "sound/gaunt/g7.wav": {
+     "bytes": 2636,
+     "sha256": "4cc260e82e0a95f60a45233e206aa4084e50ae151bebc9f10f3ed7566347d249"
+    },
+    "sound/gaunt/g8.wav": {
+     "bytes": 2424,
+     "sha256": "ab7adfa1e374e47daa4e8f1d2233ee3ce2fbadd9eb033629c9b2e22b5bac264a"
+    },
+    "sound/gaunt/g9.wav": {
+     "bytes": 3316,
+     "sha256": "de9075498f82b9c4a4a6bbc7a5fa1ff82b3f67407eb26ae250f230e4cf8b2f03"
+    },
+    "sound/gaunt/ga1.wav": {
+     "bytes": 5028,
+     "sha256": "0205250863803c1d427ddf52b21a0abc171fcda1608d2aa0519db15af36bec1a"
+    },
+    "sound/gaunt/ga2.wav": {
+     "bytes": 4858,
+     "sha256": "5414bf4fff99b4fcdec353ad948f04aec17a77fb4d34b78197c1e7dfdc2cd040"
+    },
+    "sound/gaunt/ga3.wav": {
+     "bytes": 3374,
+     "sha256": "838fd596cf09e05510a652d04df7cc1a30b036ab201100e522aa69121aee4e3c"
+    },
+    "sound/gaunt/ga4.wav": {
+     "bytes": 4942,
+     "sha256": "a6ac652da26a4c86f2cb6939ba6d75b6c1bbbc60c61c91ff9dd356a541ad0d71"
+    },
+    "sound/gaunt/ga5.wav": {
+     "bytes": 1952,
+     "sha256": "aaf2ba97c5c5c7461e01226b1b507d72fb9a0940f1d2e3e0dcede8e5587c63bc"
+    },
+    "sound/gaunt/ga6.wav": {
+     "bytes": 4022,
+     "sha256": "a2808c002a29288919bc13006473a9ad81a01f4cdfa643e670e0cb23fd3e6939"
+    },
+    "sound/gaunt/ga7.wav": {
+     "bytes": 3332,
+     "sha256": "3704146e9f8428893154ae7470c610ea1b815416b7b0791a0860aaee5518c90f"
+    },
+    "sound/gaunt/ga8.wav": {
+     "bytes": 6708,
+     "sha256": "35a44c8f699d5a2add56ec4b71ffb80b1c47f99d55f08ffa8fae039f52f3927e"
+    },
+    "sound/gaunt/gspike.wav": {
+     "bytes": 11400,
+     "sha256": "af266962ddd23515e53704a518ea3abe3ea12cffd96f35e6f7b54fc3deb21906"
+    },
+    "sound/gaunt/pain1.wav": {
+     "bytes": 3814,
+     "sha256": "d1ddebcf3672b731bb6e62b9a14e40891c4ab7217457bdaddef2e674eaac7a40"
+    },
+    "sound/gaunt/spkhit.wav": {
+     "bytes": 4738,
+     "sha256": "a811546beb9efe3ea35ee26a3d5d79f8919a49076973648d235a336457e275e2"
+    },
+    "sound/ghoro/balls.wav": {
+     "bytes": 21752,
+     "sha256": "a75dfa785f014f1cb27a7015a151bb17887b8714ede9b27b86d42b70b4ce9f8f"
+    },
+    "sound/ghoro/laugh.wav": {
+     "bytes": 21442,
+     "sha256": "8e2c0fc19342db8de1d4cff896d1935b2c5f5dfac120a8296b782f8f74ef7b96"
+    },
+    "sound/ghoro/spawnb.wav": {
+     "bytes": 5778,
+     "sha256": "459cb8107e5f3416edd7352260d63580c3d0fb12371b3665a33f464090ce4449"
+    },
+    "sound/ghoro/talk1.wav": {
+     "bytes": 36058,
+     "sha256": "9a4659ff675919a494a3e223c0370797e9943e31150b0115dd6996fc29aa9d14"
+    },
+    "sound/ghoro/talk2.wav": {
+     "bytes": 30434,
+     "sha256": "0c7a9d8249e359c096fe1fad012ebaf6ac96c4a3b07dd75818bf8cacbb5183f7"
+    },
+    "sound/ghoro/talk3.wav": {
+     "bytes": 19308,
+     "sha256": "d956d30ae3b978882759838787de222529012b16a3e288c87f56813b3ce21e67"
+    },
+    "sound/hunter/die1.wav": {
+     "bytes": 11154,
+     "sha256": "873cc7cd4d1b4ad9301b06b2b29279b6dae4fe3046875a3bd6f338c95d0175d9"
+    },
+    "sound/hunter/die2.wav": {
+     "bytes": 13910,
+     "sha256": "6eb7caa7eb814656d5e34813dacc673b9379b42337526532cbb909a7923ce2f1"
+    },
+    "sound/hunter/die3.wav": {
+     "bytes": 11154,
+     "sha256": "fc38d5d590489fcf3bc55150c0790fad072616b4dc9f07fdbf060889a5397752"
+    },
+    "sound/hunter/idle1.wav": {
+     "bytes": 24934,
+     "sha256": "040b7dfebe76e534a13695abbccf25f1d95b6bab7f1d7b2d3e7bca592d105f55"
+    },
+    "sound/hunter/idle2.wav": {
+     "bytes": 14760,
+     "sha256": "6535e00acce76e2a73299866617998f0b7ffd97bc8119e02855ed55f5cf96bee"
+    },
+    "sound/hunter/idle3.wav": {
+     "bytes": 22178,
+     "sha256": "fd35bface4dd148067cb33dda9f74f59f0fd9c0787d3392ad63b3535aadf94cd"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 6820,
+     "sha256": "812bcb725d595cb924ce7d19d5dba8e327d119f6aa9b6f732376a9ca5bb564f5"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 8398,
+     "sha256": "54111bee4696d933ebd91f63aa76751beeeb2f558891fa5c74da1cc90da9a2e6"
+    },
+    "sound/hunter/talk1.wav": {
+     "bytes": 9564,
+     "sha256": "de0af83820ed934ecd2b93ee0fd904cbf45f7cfac2fecd90bc0b59b509ad038a"
+    },
+    "sound/hunter/talk2.wav": {
+     "bytes": 13656,
+     "sha256": "0c492d4896bf3db99157731ce7265bd1262d63d5f8954b9b201e34b5bf0d4f07"
+    },
+    "sound/hunter/yell1.wav": {
+     "bytes": 8060,
+     "sha256": "298b8b4f30a5d57f48fb01ad452faccafb3bbb6f31d5108f2360275e923c2957"
+    },
+    "sound/hunter/yell2.wav": {
+     "bytes": 11286,
+     "sha256": "9cb195a6ee76fb5d40745bba8e7d4564886533230e313885f17ac3261d3d2ec4"
+    },
+    "sound/jagger/bidle.wav": {
+     "bytes": 25832,
+     "sha256": "2f57c1c5ce363e090853eff5622131a1f978dbc62aa5998472ef9cedb041c4f5"
+    },
+    "sound/jagger/bidle2.wav": {
+     "bytes": 23488,
+     "sha256": "958724313246d20cad51194f35d539927556b3c7917f983d5344b8886bafb759"
+    },
+    "sound/jagger/bjump.wav": {
+     "bytes": 5370,
+     "sha256": "aab7bbaf2946b9753109af84115fee9de79c2804f3aa0769bd85fca0244fc0bb"
+    },
+    "sound/jagger/bjump2.wav": {
+     "bytes": 7968,
+     "sha256": "f711988f6ca9500562e5117572304b78f97cb813a3fd3dfaef8bee684f675b39"
+    },
+    "sound/jagger/ddeath.wav": {
+     "bytes": 17366,
+     "sha256": "cc1dbbfc5aa7b5b88be56e7b0d4bc7cf59cf660485bf3c2b47c38107aa098308"
+    },
+    "sound/jagger/dpain1.wav": {
+     "bytes": 7958,
+     "sha256": "d32156b38e7a1b24b0bbd8705369231970be1e12b1d734ad9402ddb3a49dbcab"
+    },
+    "sound/machine/m1_go.wav": {
+     "bytes": 55186,
+     "sha256": "53bfd98c99da3db3231e1d39913ddda0d4c6c61dcd85f373f8cec3ae0ae6de0b"
+    },
+    "sound/machine/m1_st.wav": {
+     "bytes": 124468,
+     "sha256": "dc35597250c29dc9a682db8825c7e11996601ddcae1ab65d3140dcd171be5540"
+    },
+    "sound/machine/m1_xx.wav": {
+     "bytes": 35082,
+     "sha256": "115f318f4acfc4f04d283075a80da5a7fbb2b1f35856718c3bb614337e1543d3"
+    },
+    "sound/machine/m2_go.wav": {
+     "bytes": 50784,
+     "sha256": "880d2f4a663a01e61059aab04f594faac068c523c06ba1ad66653062bb1f0c66"
+    },
+    "sound/machine/m2_st.wav": {
+     "bytes": 76022,
+     "sha256": "d45d9f4c8c8c56c3f3cbfaf2fd52937d7a25a61c5fa5285304939f5874370c99"
+    },
+    "sound/machine/m2_xx.wav": {
+     "bytes": 30596,
+     "sha256": "530591c47f4595fd17dde4c42328254292217cb769befb98486f0734544fcdf3"
+    },
+    "sound/machine/m3_go.wav": {
+     "bytes": 51232,
+     "sha256": "a974aabc666949308f752351faf829c496d3e88ad1c8e7a5bd539a43dff3b88a"
+    },
+    "sound/machine/m3_st.wav": {
+     "bytes": 91744,
+     "sha256": "63e80dfda80b7e2eac398783bf44f628853897bb19d0fb74d6c42c44820ba42d"
+    },
+    "sound/machine/m3_xx.wav": {
+     "bytes": 118274,
+     "sha256": "d9a6569d54640deeb8c07a6f39dae7a671bed4d7797db7385cb0fc1bd3bda2e2"
+    },
+    "sound/mods/nehend.s3m": {
+     "bytes": 389680,
+     "sha256": "1dcde863f58377fbc050dd0a52767fbb7577f0a5f3def5dbf02be7a2680ddee8"
+    },
+    "sound/ogre/cart1.wav": {
+     "bytes": 9700,
+     "sha256": "3a655f5cd1eb022d94239e649ff7804d31b04202bcd9ddf12ba60d02bec4a203"
+    },
+    "sound/ogre/cart2.wav": {
+     "bytes": 11368,
+     "sha256": "1fe2349809a4eeced57befa02e34851718bd9b38d25d5042e7fa997314b00471"
+    },
+    "sound/ogre/cart3.wav": {
+     "bytes": 20562,
+     "sha256": "71e8e9c3340ae362efae6f8608c33157b11f7803df88a49fe01f4f68d5812dfd"
+    },
+    "sound/player/dedrise.wav": {
+     "bytes": 44458,
+     "sha256": "c6d6e871cdec51b4564fa5ec7652866bfb34f4ad6228fb0b7909829298c5c6f4"
+    },
+    "sound/player/flight.wav": {
+     "bytes": 44236,
+     "sha256": "8a04ce4a97dc22d095bc52d08111bcaaf5f57482f580ccbe0c61bdf8fd18913f"
+    },
+    "sound/player/razd1.wav": {
+     "bytes": 48664,
+     "sha256": "7812cb0b27abb76c17f4283737746923f1172ec9a39d189de3e4d0f1827183c3"
+    },
+    "sound/player/razd2.wav": {
+     "bytes": 24864,
+     "sha256": "b5997c3b5e1ede5b094153742368e63a362489fd50ab32d3049290131803667d"
+    },
+    "sound/player/razh20.wav": {
+     "bytes": 20748,
+     "sha256": "8f7e3330e6179eacdf266c3c4cca5bec76b943157fbfcd29b3dae9430cca1024"
+    },
+    "sound/quake/inv2.wav": {
+     "bytes": 66212,
+     "sha256": "3f866647a2cd9ddf23b271a49b4c7d5ff6a820af136a6fb9d0fff559f1a6f9e1"
+    },
+    "sound/quake/inv3.wav": {
+     "bytes": 42124,
+     "sha256": "375f4c1c0a043bd590977da498e199a6fe3d85aa98ce1a89c708b4e67b996242"
+    },
+    "sound/sets/dml1_1.wav": {
+     "bytes": 11410,
+     "sha256": "d6728474e7a0ac75ff825c544477258bd0a75c72126107ae4a83397e54cdb645"
+    },
+    "sound/sets/dml1_2.wav": {
+     "bytes": 19050,
+     "sha256": "10466087a8b086cdf534733042116da5956be563b75ded2bf115073ef3d00cc9"
+    },
+    "sound/sets/dml1_3.wav": {
+     "bytes": 18892,
+     "sha256": "3e6c520786076aea3ed00f7fac48954cccecbd67a99291e7d2ee139f4bb9ae57"
+    },
+    "sound/sets/dml1_4.wav": {
+     "bytes": 13228,
+     "sha256": "b1a64a55add1d14c1a928f107168d340132cf8027fc6d491e09f0c254a7f0847"
+    },
+    "sound/sets/dml1_5.wav": {
+     "bytes": 16745,
+     "sha256": "453779767ff2b95e835e853820e747945d186071c11231e8dd267ee677e8d22f"
+    },
+    "sound/sets/dmlbeat2.wav": {
+     "bytes": 73363,
+     "sha256": "e4b427922729ff1e497305b7e006c36ca7082666e74e2dbff54bd9fb8b5deca9"
+    },
+    "sound/sets/set1_1.wav": {
+     "bytes": 110304,
+     "sha256": "442ef915fd85033288e543bcab470d1613c41901b686947f1ff02ea523c5e119"
+    },
+    "sound/sets/set1_2.wav": {
+     "bytes": 69450,
+     "sha256": "1fffe8ba2b4d415cee963ff61d093150223bda3087c37b25a336ad743a6164e2"
+    },
+    "sound/sets/set2_1.wav": {
+     "bytes": 45752,
+     "sha256": "db9790fd5f4be1d22725d18a8504450e7ece5ced141f370ab5b817b44df2f81d"
+    },
+    "sound/sets/set2_2.wav": {
+     "bytes": 54214,
+     "sha256": "24ee1a948315a2fd0d50ab75d05ff1df57fff6783891e968ff3412fc2f18d2be"
+    },
+    "sound/sets/set2_3.wav": {
+     "bytes": 112160,
+     "sha256": "cc08b54081dcee40d978b38b65dec73cc62d935c2b97338e7a19379e5101949b"
+    },
+    "sound/sets/set2_4.wav": {
+     "bytes": 14434,
+     "sha256": "f4c99293318480d576688057b6b068b775889fcbab363e0be261b54f13d00507"
+    },
+    "sound/sets/set2_5.wav": {
+     "bytes": 83252,
+     "sha256": "def7fa8641dfcea003e2d51b26fcbb7db6c8dd6d8b4b6daaaaf641e1465d59cc"
+    },
+    "sound/sets/set2_6.wav": {
+     "bytes": 102128,
+     "sha256": "ac26a4b54e993db67c6d2206f337c573c5a814e942173b100c56490e09cc5519"
+    },
+    "sound/sets/set2_7.wav": {
+     "bytes": 232002,
+     "sha256": "f187a037ec58b06b38b6cb996556057773297ef04f55737ffd9bd603e9c6526a"
+    },
+    "sound/sets/set3_1.wav": {
+     "bytes": 38014,
+     "sha256": "c3575266eafca13a0d131aea5a6766acf692f0bf801745e108ad1e61f1300b57"
+    },
+    "sound/sets/set3_2.wav": {
+     "bytes": 59156,
+     "sha256": "0431dc0b0e0dcd6acc6ad967e5cf1b1cdb4ad19b87ce5b89007879621848ce6a"
+    },
+    "sound/sets/set3_3.wav": {
+     "bytes": 119624,
+     "sha256": "0936fefa6dbe4afc54c0e827a740d0266e912c4ca8b44f27df6ffafcac8f8850"
+    },
+    "sound/sets/set4_1.wav": {
+     "bytes": 109706,
+     "sha256": "d2634515e1c467f427117e3e6c8c5d6f6ab891e3ccca7324f8f7ed4a28c721eb"
+    },
+    "sound/sets/set4_2.wav": {
+     "bytes": 45726,
+     "sha256": "545050cd8f5e57c3e9840d97259cade11c9104067f481b0188e2b8cc9dbd65c1"
+    },
+    "sound/shambler/sham1.wav": {
+     "bytes": 42054,
+     "sha256": "f5b2fffaf93cbc97d0cc9539c0b1f1a583ce6993b4bf42c58d9009192e373a0e"
+    },
+    "sound/shambler/sham2.wav": {
+     "bytes": 46176,
+     "sha256": "c790bf5a129f161c2bd12a81bf231c61c297662eb87c3db5c8ad1fad3d16bf06"
+    },
+    "sound/shambler/sham3.wav": {
+     "bytes": 28808,
+     "sha256": "c877e5629e4e5050862efa20576a132a18a44b0570f11a71145a398163d542eb"
+    },
+    "sound/vigil/combat1.wav": {
+     "bytes": 63922,
+     "sha256": "38aa7e0be48391b4a4a35851c25db931bb06ad7008be04964e3e87c649ec4dac"
+    },
+    "sound/vomit/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/vomit/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/vomit/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/vomit/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/vomit/groan.wav": {
+     "bytes": 13224,
+     "sha256": "3632e43615714e5fc1be8277881a913bf1bd79b276544418cbf1b159016f0d03"
+    },
+    "sound/vondur/fan1.wav": {
+     "bytes": 54036,
+     "sha256": "4938b007febf37cd96c3c5e03a9161eb575f1ab613972f8c0f5b87cd1d7eb823"
+    },
+    "sound/vondur/lava1.wav": {
+     "bytes": 355160,
+     "sha256": "67fb9471579ba5558d0c142f57b48e78df9b63b21aa143ab5044837e52b91275"
+    },
+    "sound/vondur/von.wav": {
+     "bytes": 89774,
+     "sha256": "f59992160cccd4da8964181f390c977566849a11f5e0ed7882e99bb0947028db"
+    },
+    "sound/wall/barslide.wav": {
+     "bytes": 12756,
+     "sha256": "66144c104dacf0337f4d75ae3a7ab944ca0a50ac552c3f0f757909f4db133e1d"
+    },
+    "sound/wall/claybrk.wav": {
+     "bytes": 15004,
+     "sha256": "86b0bedfe0519abb29c07ee9b83668b9f720a907640a333767b06c3f8c4e287f"
+    },
+    "sound/wall/glassbrk.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/wall/metalbrk.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/wall/push.wav": {
+     "bytes": 7330,
+     "sha256": "3df8ff61f659353f49354a9ff9eb808bf6de5aae9846827a07c0cad7d1dad74f"
+    },
+    "sound/wall/push2.wav": {
+     "bytes": 1782,
+     "sha256": "9cacebac4c8741b9a94ab1753d986ed90def89c85945f12fe28232ed6cb9775b"
+    },
+    "sound/wall/rubble.wav": {
+     "bytes": 37376,
+     "sha256": "155570b0c3e32ec1cbe38549d5344602072361524d09cfb08f9608c40d1fa281"
+    },
+    "sound/wall/statslid.wav": {
+     "bytes": 5568,
+     "sha256": "bcebc448aa10e739facdbae791681ce78c0f7b8a3acdb9682d1e2e66c0365bcd"
+    },
+    "sound/wall/thngland.wav": {
+     "bytes": 16564,
+     "sha256": "850ee64a65f3a05f6aa0f6f99ea95d4ae8a3547d7cc973b4000a12c476a64808"
+    },
+    "sound/wall/wall01.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/wall/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/wall/woodbrk.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/weapons/autos.wav": {
+     "bytes": 21780,
+     "sha256": "5034200a6f74a8be8a5c299e4b6fedaf2fc07c56a5e0e58d5811c5c76f92f388"
+    },
+    "sound/weapons/nailgun.wav": {
+     "bytes": 9672,
+     "sha256": "9c418aefe6a2844e34f8591476f1cc2343afcba2024b9f29e02fc11a622df94c"
+    },
+    "sound/weapons/shotdud.wav": {
+     "bytes": 2020,
+     "sha256": "de6e306e5e44bb5dbf5c06790447a6dcb22655c9dc4276373f36d92fa99d7b35"
+    },
+    "sound/weapons/shotgn3.wav": {
+     "bytes": 4428,
+     "sha256": "ce1545f538378e491be33d73522e93c9c60451f7e6bd1946f764c47cd4522811"
+    },
+    "sound/weapons/sprfall1.wav": {
+     "bytes": 3908,
+     "sha256": "577a0fc6af094516068e34ce8861a53f599b9ec4cccc07ce81c18946a70915fa"
+    },
+    "sound/weapons/sprfall2.wav": {
+     "bytes": 5032,
+     "sha256": "f4b0591d1916d55eb8153f822c62d23e30733dd3e70b3120abbefa9aa2893776"
+    },
+    "sound/weapons/sprocket.wav": {
+     "bytes": 7126,
+     "sha256": "8b5c3bdc625b4954c6b504ee242591f0121d1ab64f2aceab54dd85fecadef8a4"
+    },
+    "sound/weapons/sprwall.wav": {
+     "bytes": 13126,
+     "sha256": "850c046e8c47a90fcc46df7d7d405a17e49f2d4e116ffbaeaf274c87becffc50"
+    },
+    "sound/weapons/thump.wav": {
+     "bytes": 30904,
+     "sha256": "ef0aa85fbc7ff6915aa5382c80e6f571ddacd50116faff495e3d5638bace8a49"
+    },
+    "sound/wraith/call.wav": {
+     "bytes": 12328,
+     "sha256": "9ace8a0ff79d035d36b6bdfb8726054ceaf8f852d25f3c1b235616abf4646ef2"
+    },
+    "sound/wraith/die.wav": {
+     "bytes": 14024,
+     "sha256": "3f166e024c07124cc5b5c5469904f5a8b3e48d4cb50fd949be8d79b4df2e375c"
+    },
+    "sound/wraith/growl2.wav": {
+     "bytes": 24966,
+     "sha256": "1c757955bb103e0f589ec373d1517dbacb8fe7e274f7aa0928503c9f5b009b10"
+    },
+    "sound/wraith/idle.wav": {
+     "bytes": 23702,
+     "sha256": "760a4a215fa2adb6f531b15acc06a4b46daa84c85fc08691ff4fe13f17e09ee8"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 20442,
+     "sha256": "d55cb931cef7d9c336fb7bbc3fa0408ea23eff69f46e25ac377ebbc880fa5025"
+    },
+    "sound/wraith/return.wav": {
+     "bytes": 39162,
+     "sha256": "0439588ad2003732fe7f946a5597bf80b2b89d6395476671b0e050b91c49cca7"
+    },
+    "sound/wraith/rych1.wav": {
+     "bytes": 24482,
+     "sha256": "baec568f339f688ea475e37ef3fc51a36de78a52a553e85aaa3f8011e1240d13"
+    },
+    "sound/wraith/select.wav": {
+     "bytes": 29326,
+     "sha256": "1e86b92dd1d82f4f74cd7fe14a75484e6cddb4fe968d2bb3dbaf850414c6dacb"
+    },
+    "sound/wraith/soul.wav": {
+     "bytes": 70524,
+     "sha256": "612bf73a6ebe0526efa2ef3d22915bcd87bed0b0eb5e52fc4eb0e62c5e4a3039"
+    },
+    "sound/wraith/speak.wav": {
+     "bytes": 25630,
+     "sha256": "6d1e5b395938692d57de3ec8ef9a8b5e4ccdab920a1f247e5bcdc1f0906dfcb8"
+    },
+    "sound/wraith/talk1.wav": {
+     "bytes": 16654,
+     "sha256": "6a625383c12f7fb5979ca8977a51d40f183051d551bd0b1b4ccc8a3f43a0322a"
+    },
+    "sound/wraith/talk3.wav": {
+     "bytes": 9832,
+     "sha256": "28ecc66c85bc722059b147a1354d226fbaf3022b79aed937a4759958d52c0fab"
+    },
+    "sound/wraith/weird.wav": {
+     "bytes": 3028,
+     "sha256": "1cfcd24daeb0665dce9d68ec353377ef84a88c78d1fdfcb429f2d0cc2b7f4b78"
+    }
+   },
    "sha256": "cbccb374636dfb20825e64f4fb5cb591d7ef6939cca384dff4d1257e2065b42f",
    "timestamp": "2000-08-22T20:04:22.000Z"
   },
   "nehahra/pak3.pak": {
    "bytes": 63677372,
+   "files": {
+    "gamedem1.dem": {
+     "bytes": 11618105,
+     "sha256": "2ee81be332056d424742ca80b1d513a19cfd7ea2f3347e12f77f40516bee291b"
+    },
+    "gamedem2.dem": {
+     "bytes": 9139074,
+     "sha256": "bed76c1fa565aeade597b809b41b306dbfb6fcebf2234efc0396ad86c8ab176c"
+    },
+    "gamedem3.dem": {
+     "bytes": 8699544,
+     "sha256": "c4bccddf3550eef3a3cf1088491159fcd5ad184dfaf78343a3d4bf654c4e50ff"
+    },
+    "gamedem4.dem": {
+     "bytes": 2019641,
+     "sha256": "ed406b05eddb3b9a55346c8c4df2df596b771f83d10bf3c805795c49b4b55e8a"
+    },
+    "gamedem5.dem": {
+     "bytes": 1785900,
+     "sha256": "c03b8de12dfb12b072124973882224749a9914a38d36e4feb5fc5c718d528099"
+    },
+    "gamedem6.dem": {
+     "bytes": 1387320,
+     "sha256": "6c65c2e4b102c6532c225cb66207185a365bf4d4a94c5c4157ba7c17de0a0635"
+    },
+    "gamedem7.dem": {
+     "bytes": 918189,
+     "sha256": "0b000a634627b87c993b64324f76a62ad2dfa554e58a8661a745423d7fdc4e6d"
+    },
+    "gameend.dem": {
+     "bytes": 12228296,
+     "sha256": "040e45377d2d8fb1488cf87ff6efd64462c90e133a27ad9169d18b5c6950043b"
+    },
+    "sound/gcuts/d2_enf1.wav": {
+     "bytes": 16886,
+     "sha256": "b3c2039e9eab4ebe419cc45561299cc25491f399c85e59ec5b1e36821856146e"
+    },
+    "sound/gcuts/d2_enf2.wav": {
+     "bytes": 26888,
+     "sha256": "f57d441ce8d667096abd8f9215c867967092e6406630c159959d64ff3cb05980"
+    },
+    "sound/gcuts/d2_enf3.wav": {
+     "bytes": 96590,
+     "sha256": "ea1fe9c610bdaf397ddd2b7429989051e73f70e0aa13924a6fc8de330999e9b9"
+    },
+    "sound/gcuts/d2_enf4.wav": {
+     "bytes": 25840,
+     "sha256": "58e3af8a75aa7fb572ac2099e468700d3eed54652d3e88df77610125582c0803"
+    },
+    "sound/gcuts/d2_enf5.wav": {
+     "bytes": 26888,
+     "sha256": "fb41afcd5a11aa666c7ce5476c33af8c29c7f09067de058d0c52b8facc11a8e0"
+    },
+    "sound/gcuts/d2_ghoro1.wav": {
+     "bytes": 24376,
+     "sha256": "1edeb706bfd011f9cca413773c822b1a7cb8221916051504e7c68dea41f6756a"
+    },
+    "sound/gcuts/d2_ghoro10.wav": {
+     "bytes": 18798,
+     "sha256": "2f32cc8fad04f9e0fb5c59b7d1b36bce7ee328cb8874e2348d66228f390a75e8"
+    },
+    "sound/gcuts/d2_ghoro2.wav": {
+     "bytes": 11522,
+     "sha256": "6ee5e8d2f2ff0756bc01d3965a80909ddf5d5ded8b30f422c41a925e25931be7"
+    },
+    "sound/gcuts/d2_ghoro3.wav": {
+     "bytes": 48460,
+     "sha256": "bbbf0bf2b934acbd92050351ffca68cee219e5e42df2ee791024cb5f65798936"
+    },
+    "sound/gcuts/d2_ghoro4.wav": {
+     "bytes": 80054,
+     "sha256": "5ed3f5ad2a4fe98c9fb02817a418070df2f5d6b73315fd79a09db0ccc66272ee"
+    },
+    "sound/gcuts/d2_ghoro5.wav": {
+     "bytes": 136934,
+     "sha256": "f91465ac0ea88bce7e6280472f33cc2dc071ae1cae91a8c95c34d83f329606ab"
+    },
+    "sound/gcuts/d2_ghoro6.wav": {
+     "bytes": 29226,
+     "sha256": "1ed83ea57951a30575d278325d71f683877ac9bd159846984a3e43d01812c55d"
+    },
+    "sound/gcuts/d2_ghoro7.wav": {
+     "bytes": 13420,
+     "sha256": "d9d562ddd23da136f7f44a80deb8c084226dd625635c40a6768f8830e76ff59f"
+    },
+    "sound/gcuts/d2_ghoro8.wav": {
+     "bytes": 76616,
+     "sha256": "8e6b5fb6f56faf8440bdada14c11b854c7ba3021ee9e39dd9800230c8c8d2425"
+    },
+    "sound/gcuts/d2_ghoro9.wav": {
+     "bytes": 76196,
+     "sha256": "5aa24fa80d3d90ca7193034035b63824304670e190141f6ff8d4c264f8fe6110"
+    },
+    "sound/gcuts/d2_max1.wav": {
+     "bytes": 38714,
+     "sha256": "be8f7797256b75d9e08e26e3da962bfcf174cf23f575e8fe347e3eebca9cd29d"
+    },
+    "sound/gcuts/d2_max10.wav": {
+     "bytes": 130694,
+     "sha256": "3f0e5afdda03ba5ea4c45469bc4b655a7ce0280e831d590f0fefdfce54142571"
+    },
+    "sound/gcuts/d2_max11.wav": {
+     "bytes": 73660,
+     "sha256": "e02c1c04a7ac26662f6ff2c7717473b56c2e1e80975c3c341298eb1773107685"
+    },
+    "sound/gcuts/d2_max12.wav": {
+     "bytes": 102102,
+     "sha256": "7cf1d3823edc0f66dc091bc2b9399f997f9163e49cf01e385570d4e0d5547899"
+    },
+    "sound/gcuts/d2_max13.wav": {
+     "bytes": 248170,
+     "sha256": "055fa963c28b840d0692b26bbc5ad749f5c16e88b902f13077fcef83d976ace0"
+    },
+    "sound/gcuts/d2_max14.wav": {
+     "bytes": 27656,
+     "sha256": "cc049b7f05f5d8842a63030d337491d6151fc412bf7d973a6d8d10dba11555a9"
+    },
+    "sound/gcuts/d2_max15.wav": {
+     "bytes": 131008,
+     "sha256": "d7637c7e5e3ba4e454e909c75b3fc2a0520e5a0ced3b145933c55ecf69cad789"
+    },
+    "sound/gcuts/d2_max16.wav": {
+     "bytes": 287066,
+     "sha256": "7f75f9ddc85076a96881686dbb828c8f07dc9746993f38eca94450837dd1e1a1"
+    },
+    "sound/gcuts/d2_max17.wav": {
+     "bytes": 171002,
+     "sha256": "86149d5d39d681cd610e5a2696741f9f23405e1b592010ba273fa626bc6965d0"
+    },
+    "sound/gcuts/d2_max18.wav": {
+     "bytes": 235116,
+     "sha256": "f288dfec2c8130a8e4a713dac56d775e1c73ebea06fe315ef27e42db4cef415c"
+    },
+    "sound/gcuts/d2_max2.wav": {
+     "bytes": 143642,
+     "sha256": "26a335836b776c718cf7b93d610235dcabf703ae3cbad7b3d88b9a42971790ec"
+    },
+    "sound/gcuts/d2_max3.wav": {
+     "bytes": 296456,
+     "sha256": "ed2cea694c540d14017727a70cc7abc94233dda5f8921221ecaf0d363b1f3930"
+    },
+    "sound/gcuts/d2_max4.wav": {
+     "bytes": 95072,
+     "sha256": "ecd8bf99cf030f7ef7271a19ab1f55b52ce3cc9377269089ca932d79e5ac8113"
+    },
+    "sound/gcuts/d2_max5.wav": {
+     "bytes": 132176,
+     "sha256": "5be13011820d162da4484e355e71917e58cfcdec90f16f64ca3736f794dd5ad1"
+    },
+    "sound/gcuts/d2_max6.wav": {
+     "bytes": 72692,
+     "sha256": "46fd8dcdc66b253576aaa1f633ebb42e3c74de9b97d8bd97f77736d95d132e39"
+    },
+    "sound/gcuts/d2_max7.wav": {
+     "bytes": 27324,
+     "sha256": "f9548c4a16ab028b5d29296a1e77eb6aae436d1c17d1be6475decc1901932af5"
+    },
+    "sound/gcuts/d2_max8.wav": {
+     "bytes": 43202,
+     "sha256": "6f94f4a9976570358870032143f4ca1076633675943ab8a6251ed9c302cf2e6e"
+    },
+    "sound/gcuts/d2_max9.wav": {
+     "bytes": 74568,
+     "sha256": "53955b01e3c322bf49b506e6d476796535108d813ba5083ad9f965b7cacbe269"
+    },
+    "sound/gcuts/d3_jack1.wav": {
+     "bytes": 45000,
+     "sha256": "15e240398cd76b8b5a749087d61770c8ef47b04d5583874b28ce57104246e077"
+    },
+    "sound/gcuts/d3_jack10.wav": {
+     "bytes": 24934,
+     "sha256": "0c609f7ca2392254a028cebedf00a576e7c3c0b935b6614ac09b310e019babca"
+    },
+    "sound/gcuts/d3_jack11.wav": {
+     "bytes": 167704,
+     "sha256": "e072a579451e3a2564d745ca8d77e3021d8fd47954879b5ff50dedd7e02d7392"
+    },
+    "sound/gcuts/d3_jack12.wav": {
+     "bytes": 52494,
+     "sha256": "023adb12ffd8d7ed07357afaddc0c69b8863dc5ebb6ab33ef6529999e26922f2"
+    },
+    "sound/gcuts/d3_jack13.wav": {
+     "bytes": 82170,
+     "sha256": "2f552b7f6e79fe5b405569f2b401d74e046ef75095f7910beb17adc876c203fc"
+    },
+    "sound/gcuts/d3_jack14.wav": {
+     "bytes": 12882,
+     "sha256": "53a17de094019dc181617ac4b3307842a30bd272b2a5785b822b2441c700c7cf"
+    },
+    "sound/gcuts/d3_jack145.wav": {
+     "bytes": 6548,
+     "sha256": "4fbd0a5db96c4d2b944ed26c98a046dc5a685aea876ac36e2985f691e7e526a6"
+    },
+    "sound/gcuts/d3_jack15.wav": {
+     "bytes": 48194,
+     "sha256": "b1f758c902a2d677bb31eb0973fe698c2b6b31a3f112ca8721eff701db9ecb40"
+    },
+    "sound/gcuts/d3_jack16.wav": {
+     "bytes": 24998,
+     "sha256": "5247f1afa66c60e729118658af333fb945895a99b2cb7e7ed9872bf7417c503d"
+    },
+    "sound/gcuts/d3_jack17.wav": {
+     "bytes": 37162,
+     "sha256": "499f91821d0350883f3eb92d9ded347b9c92e6d448a5c75455b9dee38e5687b9"
+    },
+    "sound/gcuts/d3_jack2.wav": {
+     "bytes": 63518,
+     "sha256": "9d583513d093ec131bfcb97382d6bf4f9564eac306917c54d2b1f81f8b648eca"
+    },
+    "sound/gcuts/d3_jack3.wav": {
+     "bytes": 115882,
+     "sha256": "8d67eaf34585b0dd555fe02cc57bd850642fb7497920aed815c0d2811715f2bb"
+    },
+    "sound/gcuts/d3_jack4.wav": {
+     "bytes": 38714,
+     "sha256": "012fea77cd6cf5657ed4e598a25586a1670de3a721193da2188cd797de9047c7"
+    },
+    "sound/gcuts/d3_jack5.wav": {
+     "bytes": 50630,
+     "sha256": "ddff390e3a70c551e324c51d3b12592a9768ba24c0274f699f9fd2aee8987e7d"
+    },
+    "sound/gcuts/d3_jack6.wav": {
+     "bytes": 49738,
+     "sha256": "c9149960d221655d86603cb6d9307403557eddd8403284cdae2bda2c9d0c6e90"
+    },
+    "sound/gcuts/d3_jack7.wav": {
+     "bytes": 63518,
+     "sha256": "4c4292cd9b6ea9f2db3b2965d3071852c39bc1ff856e9188eaf2fb9bc9061fcd"
+    },
+    "sound/gcuts/d3_jack8.wav": {
+     "bytes": 88588,
+     "sha256": "efc455918459ac3e97edc627e63333376c51542455ca7db47d110985d52ad0ce"
+    },
+    "sound/gcuts/d3_jack9.wav": {
+     "bytes": 24566,
+     "sha256": "24b7a244b46a3a9d73b47d4693e5f0561be3a90493047597ece450bf3b8d23b0"
+    },
+    "sound/gcuts/d3_qguy1.wav": {
+     "bytes": 77736,
+     "sha256": "04f613470e87593a8988bef62ea33cef183a1d980cbe347c03b8d1ed54c5d5ad"
+    },
+    "sound/gcuts/d3_qguy10.wav": {
+     "bytes": 73218,
+     "sha256": "3ad23ec3a294b3d4dd24bd3cf326058f5cd19161a0a5474fbce921824499526c"
+    },
+    "sound/gcuts/d3_qguy11.wav": {
+     "bytes": 122758,
+     "sha256": "56b5ce3cafae42ac3a3d6fd810cd983211349d4bfd2244534b6b508db266fade"
+    },
+    "sound/gcuts/d3_qguy12.wav": {
+     "bytes": 117078,
+     "sha256": "2ff32ea421d2c4e43b2d19c796101e49e345e17eb410251d6c362b549c514851"
+    },
+    "sound/gcuts/d3_qguy13.wav": {
+     "bytes": 16398,
+     "sha256": "a0de11ffba8234a88ea6c5c93ba3558c2d3f9f5ceadb6cd64d5cbb88fbc08c0a"
+    },
+    "sound/gcuts/d3_qguy14.wav": {
+     "bytes": 45328,
+     "sha256": "65f7e2cec60ead543b28bf3b9399bd98fa9b103f2c68115e3b4385efba78c23a"
+    },
+    "sound/gcuts/d3_qguy15.wav": {
+     "bytes": 24934,
+     "sha256": "02d9d46d59ed6713dee0eec36bdd091aca68a4caf25e20860f2352e455bc2bdc"
+    },
+    "sound/gcuts/d3_qguy16.wav": {
+     "bytes": 32700,
+     "sha256": "ff1d3dc3efab792c060025f3a2843adc0424875e59efb6144d7d92bee7b3da28"
+    },
+    "sound/gcuts/d3_qguy17.wav": {
+     "bytes": 77298,
+     "sha256": "b9d3d013c58199f341323f13f4363dba03290caa17932ce8b8051f15da8a4422"
+    },
+    "sound/gcuts/d3_qguy18.wav": {
+     "bytes": 131274,
+     "sha256": "f3f6130894077909349360ea35bc5b278c64b92b3952a20ca85a0e4fd21e5fb7"
+    },
+    "sound/gcuts/d3_qguy19.wav": {
+     "bytes": 89762,
+     "sha256": "fb811ab0a2e6bb8c4e0085da4380734dedcc35221050c384648d8ca453b8f308"
+    },
+    "sound/gcuts/d3_qguy2.wav": {
+     "bytes": 37796,
+     "sha256": "3f3a08b554d8b020532737d8d5ad74976a43b85614f401935cf38ce2f6e74a95"
+    },
+    "sound/gcuts/d3_qguy20.wav": {
+     "bytes": 110652,
+     "sha256": "b6827adeeb3ffb4eb6e497ca481db6a9a5cb1b57cf182bc01b6b6f26b099d29a"
+    },
+    "sound/gcuts/d3_qguy21.wav": {
+     "bytes": 30682,
+     "sha256": "ce45cc84309b7f95bf046f43fe54ff709008890cea45b5afaafc543449a7ab59"
+    },
+    "sound/gcuts/d3_qguy22.wav": {
+     "bytes": 60984,
+     "sha256": "ceb95bdc837e19f08aecc69521ac37cd9f3d065948c4a08295f9cac518291df0"
+    },
+    "sound/gcuts/d3_qguy23.wav": {
+     "bytes": 129662,
+     "sha256": "34555261a8a6275c66378f622ac91a26680081645662065f5a026de4de776d1a"
+    },
+    "sound/gcuts/d3_qguy24.wav": {
+     "bytes": 63518,
+     "sha256": "97b391f146cecce00caea18f0b6fb815ccff7d9f37e83658fe5554cade10dddd"
+    },
+    "sound/gcuts/d3_qguy25.wav": {
+     "bytes": 142306,
+     "sha256": "9cbccdb18f8d6730eb2901720d314d4f39ce9b28b57d88d29cbbe33f5c78c3f0"
+    },
+    "sound/gcuts/d3_qguy26.wav": {
+     "bytes": 54384,
+     "sha256": "b4ae8cc4251b278c31af3b6aa923e576117efbb7735c1bf2263427df1bc60a7f"
+    },
+    "sound/gcuts/d3_qguy27.wav": {
+     "bytes": 36652,
+     "sha256": "7941d5ff39deb5377f95476c3eae0b482071bbef9c8c4bd376113313aa3427d3"
+    },
+    "sound/gcuts/d3_qguy28.wav": {
+     "bytes": 29110,
+     "sha256": "70f8f83ef76ed167cc90e9b6f1934b2c176d767f6a251a9f9d5e388f831eb553"
+    },
+    "sound/gcuts/d3_qguy29.wav": {
+     "bytes": 27010,
+     "sha256": "d0633c934f428b888406b10b0f87bf700f71d122e763fb1b93b9a4cba30359a7"
+    },
+    "sound/gcuts/d3_qguy3.wav": {
+     "bytes": 46982,
+     "sha256": "78006ba8f58e1ab1ac3924d9ab319443dd577167041e56b9a6cb3b9714c73c12"
+    },
+    "sound/gcuts/d3_qguy30.wav": {
+     "bytes": 44558,
+     "sha256": "dcb0554f2599856669748ce4207c7c6de13760e2098db07add77cb5504d82aef"
+    },
+    "sound/gcuts/d3_qguy31.wav": {
+     "bytes": 14618,
+     "sha256": "eb224fec5e0ac8491357cab6086c87f7b822c168a8257b9dfdba2de8c1c5c005"
+    },
+    "sound/gcuts/d3_qguy32.wav": {
+     "bytes": 55250,
+     "sha256": "1c07427ffa130e8350709502f278cad0075f962bf095b2720858bccb80665941"
+    },
+    "sound/gcuts/d3_qguy33.wav": {
+     "bytes": 21258,
+     "sha256": "a4fb565911eb8daca412df53e0688d552ffb83d9c93399e3e2b863313801bc22"
+    },
+    "sound/gcuts/d3_qguy34.wav": {
+     "bytes": 11980,
+     "sha256": "e00375fc126ac358d3d568872a54795ea6df0790e7ff161e24959af79994faec"
+    },
+    "sound/gcuts/d3_qguy35.wav": {
+     "bytes": 105592,
+     "sha256": "affb7826af9b31d793d5142954761ff2f76e22b247566aee27cc8a824ff536a4"
+    },
+    "sound/gcuts/d3_qguy36.wav": {
+     "bytes": 119238,
+     "sha256": "192893c6b36285daa955f7ae37b194c3aadcb049443ab57a1ae365bae38f1057"
+    },
+    "sound/gcuts/d3_qguy37.wav": {
+     "bytes": 18974,
+     "sha256": "9e6e196ab69e6c65b7106a7f6c36f54fccff09a382f25854ed9fd2203d5a8795"
+    },
+    "sound/gcuts/d3_qguy4.wav": {
+     "bytes": 80054,
+     "sha256": "b05a1c23adf90b773d8a43f49d2d0c64057832b2a80feae894847a28debd7374"
+    },
+    "sound/gcuts/d3_qguy5.wav": {
+     "bytes": 109680,
+     "sha256": "1dbeb59dfd11071e51198c455efa04bd48fcc136d995a127c5337896d422fc96"
+    },
+    "sound/gcuts/d3_qguy6.wav": {
+     "bytes": 38274,
+     "sha256": "d54e9a8811fe9656dcb7c8f7a161f1dcc7afc6e2e1d34229f51f5d0be2af3fd8"
+    },
+    "sound/gcuts/d3_qguy7.wav": {
+     "bytes": 30446,
+     "sha256": "1616a8d126f0641da7ce9fabc2921b53b8cff18ad6991f2a8b5170e4e434ec5f"
+    },
+    "sound/gcuts/d3_qguy8.wav": {
+     "bytes": 140252,
+     "sha256": "904c93dcbb456797d78ed8f9444bfd9f3dd47ef5522b66d4c9daf75537959555"
+    },
+    "sound/gcuts/d3_qguy9.wav": {
+     "bytes": 55004,
+     "sha256": "860060b6e3fde9fee84e610b3d5c243e689b88a9cbf3586249ce5325bda36145"
+    },
+    "sound/gcuts/d_jack1.wav": {
+     "bytes": 41470,
+     "sha256": "b0349f58c3a7760a31886a71525e32861155642651092a1dd34404c2458a79a4"
+    },
+    "sound/gcuts/d_jack10.wav": {
+     "bytes": 19422,
+     "sha256": "90b2c938ce6e1799b4de11efc98f0dd91a5663dea56d23a169df18c1d7329c6e"
+    },
+    "sound/gcuts/d_jack11.wav": {
+     "bytes": 49084,
+     "sha256": "9dbd96f1e93e2b07757acd43229363086b465f1d8477e82327c66a8b7da9d49c"
+    },
+    "sound/gcuts/d_jack12.wav": {
+     "bytes": 23722,
+     "sha256": "f165bdb317edf74fd7b7227b5aaa573a536d982ecda42ef78c55e71254c5a668"
+    },
+    "sound/gcuts/d_jack2.wav": {
+     "bytes": 61470,
+     "sha256": "f5d3fb173d4aa95b828d917f8bbe849b2973073e4ba6edf08f5b0a1998a385e5"
+    },
+    "sound/gcuts/d_jack3.wav": {
+     "bytes": 17970,
+     "sha256": "a1f07a03be1fbbf6fae626fe782cb16d23f1891a77184490321e8eb58f0b3401"
+    },
+    "sound/gcuts/d_jack4.wav": {
+     "bytes": 19926,
+     "sha256": "5c6a4949c36cf108841648f82f8a5caaf219a03ac368d631a3069f960a83f111"
+    },
+    "sound/gcuts/d_jack5.wav": {
+     "bytes": 30446,
+     "sha256": "2849490a0f0b7181cc2aa74ea4c902100afe8681626f10ff6919d7bc036b4c8a"
+    },
+    "sound/gcuts/d_jack6.wav": {
+     "bytes": 30446,
+     "sha256": "ab9998624087c665c4adf4ebdf55e82bbc74cd45d56c43c868f1723584150c21"
+    },
+    "sound/gcuts/d_jack7.wav": {
+     "bytes": 33202,
+     "sha256": "3b97e8fd7bf44a5e330bedba0fc4b94bb5da2fa34c9ee62c119d20245cbc90b1"
+    },
+    "sound/gcuts/d_jack8.wav": {
+     "bytes": 8312,
+     "sha256": "e57d4216fa5400000a421bd13b342567233725868b37dc57f926d76b3f1c9ee4"
+    },
+    "sound/gcuts/d_jack9.wav": {
+     "bytes": 83732,
+     "sha256": "cbe5061c26829995e37316ec9dd6aad74fba4853b2b44c209fc1105f8f89e0eb"
+    },
+    "sound/gcuts/d_qguy1.wav": {
+     "bytes": 35202,
+     "sha256": "dd74719c04b81f7bb81711ab85682bd2fa9465851bab74eaf01c2e838ae2c647"
+    },
+    "sound/gcuts/d_qguy10.wav": {
+     "bytes": 58006,
+     "sha256": "dfe85b82d9104b53b940dbdb583fbd56c97737a3e21671afb3463927f174261f"
+    },
+    "sound/gcuts/d_qguy11.wav": {
+     "bytes": 32074,
+     "sha256": "f327e1975541795915b28e69971b4b12a44a8289d28c2a236020e18a408bedb4"
+    },
+    "sound/gcuts/d_qguy12.wav": {
+     "bytes": 91914,
+     "sha256": "96f646f664ed9d853680e0a465a7163dc7b3362520738d31409faee903b50d9c"
+    },
+    "sound/gcuts/d_qguy125.wav": {
+     "bytes": 26442,
+     "sha256": "a952612cca25c51288d6010df0eadd9ceab3cda168e0068957890e7307c7137d"
+    },
+    "sound/gcuts/d_qguy13.wav": {
+     "bytes": 25318,
+     "sha256": "d43a24a8a522768200cbb807abc8cd169c0e86b2da8ae0a8c2dcdc53a8bb1a53"
+    },
+    "sound/gcuts/d_qguy14.wav": {
+     "bytes": 40516,
+     "sha256": "12af05e887289fdc4c86dd33e7d7ab13ba48c769a37165be62a42189cc51e298"
+    },
+    "sound/gcuts/d_qguy15.wav": {
+     "bytes": 50032,
+     "sha256": "d81e2b6e4025caa084ba6d11b7811462f68a5bbbbeb5031cc85e6cd41ab42f1f"
+    },
+    "sound/gcuts/d_qguy16.wav": {
+     "bytes": 76196,
+     "sha256": "d2ee124abb5f238159983b67bc4d7d7019ec1c6e5ee34ece53d56aff772dcf20"
+    },
+    "sound/gcuts/d_qguy17.wav": {
+     "bytes": 25474,
+     "sha256": "0b91cff65f4170eaa5730896b6cb8d5e4fde8a728c13b3833b45cf419cb121eb"
+    },
+    "sound/gcuts/d_qguy18.wav": {
+     "bytes": 79438,
+     "sha256": "5766e33bbc055170458e24a48173e8188954407e63cd587acbb192c34eab105f"
+    },
+    "sound/gcuts/d_qguy19.wav": {
+     "bytes": 38714,
+     "sha256": "251131400aec1c35d17a9a3174efc4d386e07fcf24bb1c9e5bedc69012ff688e"
+    },
+    "sound/gcuts/d_qguy2.wav": {
+     "bytes": 60100,
+     "sha256": "19bd254f26164947651102fb886feafeb3b23f3181290644371492b2f738f544"
+    },
+    "sound/gcuts/d_qguy20.wav": {
+     "bytes": 15668,
+     "sha256": "110d4d95d2e84a0927bd6789983b3a74d99af57f1e43eb69c62323a937b9c0b9"
+    },
+    "sound/gcuts/d_qguy21.wav": {
+     "bytes": 11154,
+     "sha256": "987200c0c27c16474afb91b2024a872e2f2bfa8bf31c9eb59d3fddab4a6f5689"
+    },
+    "sound/gcuts/d_qguy22.wav": {
+     "bytes": 26136,
+     "sha256": "f76bfdfaba231b36c6ffef069a8bc5290fe966db7d0e370e86e4662d5c91c923"
+    },
+    "sound/gcuts/d_qguy23.wav": {
+     "bytes": 22208,
+     "sha256": "9b1b1e64dd88cdec592268bc736a9db7e7a1e70146367cfa0c34e056b5c7b973"
+    },
+    "sound/gcuts/d_qguy24.wav": {
+     "bytes": 25336,
+     "sha256": "dc0b61454958f188ebfd25a76f1a473c8a17881276133e63d2d9afc0511ba63f"
+    },
+    "sound/gcuts/d_qguy25.wav": {
+     "bytes": 49962,
+     "sha256": "9484fb41e7e2d02042b35ca5391fc7221907e0eb6c2fb31d1057de408ebc21f4"
+    },
+    "sound/gcuts/d_qguy26.wav": {
+     "bytes": 23254,
+     "sha256": "728032ebda0d3947c9711ee28e069af43b95d7579f49ce49174b6d9d4ac3893e"
+    },
+    "sound/gcuts/d_qguy27.wav": {
+     "bytes": 38714,
+     "sha256": "3a703715e0cb2095c53d2782671cfb72ffb0bc52205b0effe9c47a43e3aaa562"
+    },
+    "sound/gcuts/d_qguy28.wav": {
+     "bytes": 13910,
+     "sha256": "41faf0523de2996f4e749255bcc6e76f6ef9e872418771b62f63cbd320c10a79"
+    },
+    "sound/gcuts/d_qguy3.wav": {
+     "bytes": 121382,
+     "sha256": "a809d0209089c98a001e5bf17b921d44dce52e713e5258d882131758deb122fe"
+    },
+    "sound/gcuts/d_qguy4.wav": {
+     "bytes": 205418,
+     "sha256": "55f13365e237edbfabdc46d38959662eaa074c88496bf5c46b3f6f24c5aaf692"
+    },
+    "sound/gcuts/d_qguy5.wav": {
+     "bytes": 49726,
+     "sha256": "0bdd989558a873da094bdf11512d9dc6cb22f899cae2d1f8ac0a74a0a9126e40"
+    },
+    "sound/gcuts/d_qguy6.wav": {
+     "bytes": 143454,
+     "sha256": "e3da91b6ccbb2940ebbccd33139cf2449753b4c71f8b5b8e78ac822c4f210fe2"
+    },
+    "sound/gcuts/d_qguy7.wav": {
+     "bytes": 11984,
+     "sha256": "d3cf2aaea4c18364d700fafecba39ce664fc9598eda47a13d9c7a6ced9f0948a"
+    },
+    "sound/gcuts/d_qguy8.wav": {
+     "bytes": 27740,
+     "sha256": "a2d526961f30be3c3dfb06752d57b4f997e224f5069653ce91da3d9030055759"
+    },
+    "sound/gcuts/d_qguy9.wav": {
+     "bytes": 35946,
+     "sha256": "f68117c3f96f7551920b56b4bc1791e63525bcac1b5fa6b72064b2c863abdad7"
+    },
+    "sound/gcuts/d_quirk1.wav": {
+     "bytes": 60762,
+     "sha256": "34603dfbf97e31d6a80142f9a73b6e6fc0f39f258a8349c8d45000a7a9852048"
+    },
+    "sound/gcuts/d_quirk10.wav": {
+     "bytes": 26290,
+     "sha256": "6c2ce308a6dbfca0deaf59fc26d712b01e995a6eeb7ccbd195242f53984a55c0"
+    },
+    "sound/gcuts/d_quirk11.wav": {
+     "bytes": 13876,
+     "sha256": "57938b9beb1bfbd79a5ec78832bd044333959ff99e4b8d540e5ad45455a28ac4"
+    },
+    "sound/gcuts/d_quirk12.wav": {
+     "bytes": 101358,
+     "sha256": "ec2df81bfba876ec0a63e33c5eb3727fcf5aaa7f07f5cf79b3a1103167fa9390"
+    },
+    "sound/gcuts/d_quirk13.wav": {
+     "bytes": 15972,
+     "sha256": "a0da59962a083a5fdf04fa0d6ff2e63c108ed2306948b3a87d115feae9367ca8"
+    },
+    "sound/gcuts/d_quirk14.wav": {
+     "bytes": 69652,
+     "sha256": "1212f82d6914ce933765e6229a80c85496c0e0bdf6353a42ae268529e21b5417"
+    },
+    "sound/gcuts/d_quirk15.wav": {
+     "bytes": 77298,
+     "sha256": "3963f371477588e098bd6db9fab7c12eeac63482eb860104a22619292f37c065"
+    },
+    "sound/gcuts/d_quirk16.wav": {
+     "bytes": 99346,
+     "sha256": "74c324c5645c4618ee5d22df847ed96d38fb733eb2301e663562b49e5ba238f0"
+    },
+    "sound/gcuts/d_quirk17.wav": {
+     "bytes": 32232,
+     "sha256": "7837309842779e56a379371fa3153b7ef7ed03de8243cb69c2f792f3fed665b2"
+    },
+    "sound/gcuts/d_quirk18.wav": {
+     "bytes": 90518,
+     "sha256": "81c8360c2fb287e747c068f8a32e46f053c79b2bc355e32d468629b1847c07e0"
+    },
+    "sound/gcuts/d_quirk19.wav": {
+     "bytes": 233716,
+     "sha256": "1562bbb958e0331d06f87c92bec57e79a9a716bb584033babe66e4fbf0a9202e"
+    },
+    "sound/gcuts/d_quirk2.wav": {
+     "bytes": 50698,
+     "sha256": "4adec7a7a3407366e44b9939b9573353af8904c78e8e2a282b6dec16d9476b0e"
+    },
+    "sound/gcuts/d_quirk20.wav": {
+     "bytes": 48940,
+     "sha256": "b8d150baa19694ae61ffb8101a1515046cfcb7341ac665c8b2a3f3e022490178"
+    },
+    "sound/gcuts/d_quirk21.wav": {
+     "bytes": 56244,
+     "sha256": "f7166fffda4e7cb2a9b5db788961354885ab285e7eba9820bd978ed72561b567"
+    },
+    "sound/gcuts/d_quirk22.wav": {
+     "bytes": 49468,
+     "sha256": "7f330aa611ac651d1e7dcc2481481b4d27b35e1a83a162eb729c866b0ee381c2"
+    },
+    "sound/gcuts/d_quirk23.wav": {
+     "bytes": 205728,
+     "sha256": "cf8fd182937842bf3782f2c58ea9d7dd05bfaf609978a32e2fa7d7eddb906a5a"
+    },
+    "sound/gcuts/d_quirk24.wav": {
+     "bytes": 70338,
+     "sha256": "c7836b4f2378ac9cd6c6b63eaa5a3492ca49a1767c3798dfd58599748136651a"
+    },
+    "sound/gcuts/d_quirk25.wav": {
+     "bytes": 54808,
+     "sha256": "6c62b4b89a4d6b3c3f214b983ec9332b77a9b6eff630d7659f8989ef4d59c445"
+    },
+    "sound/gcuts/d_quirk26.wav": {
+     "bytes": 94454,
+     "sha256": "9388f8906347cabd5b43f88bfc72202fe783b0cc4e1bd24d10281c07f8508bb9"
+    },
+    "sound/gcuts/d_quirk27.wav": {
+     "bytes": 205812,
+     "sha256": "3141990f2c2be28e9cd2d628a54046875bcaaf821bcd54270227deccd5d8e73e"
+    },
+    "sound/gcuts/d_quirk28.wav": {
+     "bytes": 81128,
+     "sha256": "5053c17ce211bedf755b8a10ca0c6dc73794b2ae214a63a570b42bbc21432117"
+    },
+    "sound/gcuts/d_quirk29.wav": {
+     "bytes": 99346,
+     "sha256": "f9258b18c9daaecf35db74024353006c4720c7382da84ec9b5b634c6d81e4451"
+    },
+    "sound/gcuts/d_quirk3.wav": {
+     "bytes": 114704,
+     "sha256": "560b244071d93df3d7d346479c2ca23bd7d39ad7c5620c6ba7c87f6d1ad2670f"
+    },
+    "sound/gcuts/d_quirk30.wav": {
+     "bytes": 146976,
+     "sha256": "f60be4f66c9a516e5f7de866239bf379799e8471221d411944bd36bfec3cbdd2"
+    },
+    "sound/gcuts/d_quirk31.wav": {
+     "bytes": 116414,
+     "sha256": "7e9a600d5ee840e6402916e43801d0dd5b9c0c2383e45291360d791417e59ced"
+    },
+    "sound/gcuts/d_quirk4.wav": {
+     "bytes": 128494,
+     "sha256": "edd6ada84319108e780a17d78c6c0163ded4a37f24b2668986deaf5728a4f20f"
+    },
+    "sound/gcuts/d_quirk5.wav": {
+     "bytes": 19526,
+     "sha256": "fa7d23d1602f8ba2b0b58b49cf6573a2edfa70c90f1671bc1be1b5cdc36da908"
+    },
+    "sound/gcuts/d_quirk6.wav": {
+     "bytes": 19422,
+     "sha256": "7339d2b7907f1047266276ce6a9e94649ebb76a1536ffbc863704e3c059d532d"
+    },
+    "sound/gcuts/d_quirk7.wav": {
+     "bytes": 195360,
+     "sha256": "c270caaf8d2589df2a08350e146b9868e997e36d90785c15e3060cecc7f1d0dd"
+    },
+    "sound/gcuts/d_quirk8.wav": {
+     "bytes": 126894,
+     "sha256": "9164b888358a01d6337d8606a12d592ec9613ce91df3abafa8dbb1dc73e04267"
+    },
+    "sound/gcuts/d_quirk9.wav": {
+     "bytes": 103926,
+     "sha256": "37b30d21afd07ed935267b017e3ead3e3116abf24ea38a59308988fdb6ea5a1f"
+    },
+    "sound/gcuts/d_radio.wav": {
+     "bytes": 99352,
+     "sha256": "88c21bd959a2e029682783d4b27603de29330727be019a7484cf4de61ac2759c"
+    },
+    "sound/gcuts/g4_ghoro1.wav": {
+     "bytes": 93038,
+     "sha256": "e99a6b1e129b61b4007a255523dc43b281371a9439c05a0da1682110450c7e27"
+    },
+    "sound/gcuts/g4_ghoro2.wav": {
+     "bytes": 82074,
+     "sha256": "83a238b20442008e598af9689fe62c9ab9be403b7c49a750b25add92fa76dca8"
+    },
+    "sound/gcuts/g4_ghoro3.wav": {
+     "bytes": 52230,
+     "sha256": "2163f2d24ddda32db594925f408ae3edffc9791eadd0d827922b746c6eede567"
+    },
+    "sound/gcuts/g4_max1.wav": {
+     "bytes": 25266,
+     "sha256": "99c47c69fd29bd91f638a1e2e0bf7aefdda9d8d7f2402d1c813ecc974930a354"
+    },
+    "sound/gcuts/g4_max2.wav": {
+     "bytes": 124150,
+     "sha256": "00bceb955546ed6f58dce83cf7fce1f6cc5b9a74ef38f03663bc881a742364de"
+    },
+    "sound/gcuts/g4_max3.wav": {
+     "bytes": 66556,
+     "sha256": "52e791088209ca181477bf96847a23e230c9eb4d18db6facb3413efb44e73bf1"
+    },
+    "sound/gcuts/g5_ghoro1.wav": {
+     "bytes": 49738,
+     "sha256": "2ff0f7ceb4e710c1a72368c4c3c62d49456158249d346c95843ee1757a1570fc"
+    },
+    "sound/gcuts/g5_ghoro2.wav": {
+     "bytes": 30446,
+     "sha256": "34d9bb769afcf77c93d07ec0f8345fbe664b7afbb6cd93cea875b10dc7e78098"
+    },
+    "sound/gcuts/g5_ghoro3.wav": {
+     "bytes": 82194,
+     "sha256": "e26e1cf11ee8321a24cfb9c888109dfba082aca98a23342dfb7b79bfe4b4a954"
+    },
+    "sound/gcuts/g5_ghoro4.wav": {
+     "bytes": 75650,
+     "sha256": "347b29967fb5abca12ee11563d7166f835ccb16d964452197ea9849dd3a4b746"
+    },
+    "sound/gcuts/g5_max1.wav": {
+     "bytes": 24934,
+     "sha256": "c9c85e63baf40da3e5a1edc1a9656ce7e048f268a6c3d4b72cc98d636eaabd0b"
+    },
+    "sound/gcuts/g5_max2.wav": {
+     "bytes": 148300,
+     "sha256": "c71ca1404ccb603be841f0187d90fb2117a86e07342a9ce8baede3652c9e6f07"
+    },
+    "sound/gcuts/g5_max3.wav": {
+     "bytes": 22842,
+     "sha256": "132942b446c9caa8d1576c06f86dd58651eca6a5364c668da9b51b8662236060"
+    },
+    "sound/gcuts/g5_max4.wav": {
+     "bytes": 146198,
+     "sha256": "1697ad8ea470f42279728e4c1bfb7f5e1012233ad01500c01635beb811701184"
+    },
+    "sound/gcuts/g6_hknight1.wav": {
+     "bytes": 30332,
+     "sha256": "fbaa6b140ad0b0a91a288653c79a91e95490459326012d0f64867ae6d918e1cc"
+    },
+    "sound/gcuts/g6_hknight2.wav": {
+     "bytes": 47424,
+     "sha256": "6021afacfc2dfac4bef390097002129e2dc2f34ad5b815a5edb024a7b2cf4c04"
+    },
+    "sound/gcuts/g6_hknight3.wav": {
+     "bytes": 25436,
+     "sha256": "51a3e7b6fab82ba3e438d03b3ef32166c4d91f04e1eb92f0dd7a2b4d62fca534"
+    },
+    "sound/gcuts/g6_hknight4.wav": {
+     "bytes": 55250,
+     "sha256": "faef0d08a723906969277ad3257b5858a8ca38a3affb452f4ad29691d710eca1"
+    },
+    "sound/gcuts/g6_hknight5.wav": {
+     "bytes": 22598,
+     "sha256": "94b8d12f66e9edb9df02398670301c6eba7b930d66dbeffec1fcd558c4ab46e5"
+    },
+    "sound/gcuts/g6_max1.wav": {
+     "bytes": 22790,
+     "sha256": "3a1392c4057490d889b07a1d34c4c34156dd845566d2e50c1553497ed72965bb"
+    },
+    "sound/gcuts/g6_max2.wav": {
+     "bytes": 135174,
+     "sha256": "42f8dffa59e928d93688248ca309833e35dd36ceb1706e7e1a77057ce08e732e"
+    },
+    "sound/gcuts/g6_max3.wav": {
+     "bytes": 57468,
+     "sha256": "613be1e688e8c17bed17ac11221241f57b047cb1c79438f551627f58f1cd8086"
+    },
+    "sound/gcuts/g6_max4.wav": {
+     "bytes": 124894,
+     "sha256": "3020f4dedf86f488e83e50f604a7025167ee971960364b7301e9ce03b7f9aaa7"
+    },
+    "sound/gcuts/g6_max5.wav": {
+     "bytes": 101066,
+     "sha256": "53aa65c12bc63f6f2557b0cd1b7dcefe20a3af7998950f2078ff08a895c7888b"
+    },
+    "sound/gcuts/g7_hknight1.wav": {
+     "bytes": 66938,
+     "sha256": "c756942d5bde044c0d23e68671fb23bc1b1c5013504ec751afdc3537aca9133e"
+    },
+    "sound/gcuts/g7_hknight2.wav": {
+     "bytes": 49352,
+     "sha256": "776ad8812524eb61f4b452b4f6c52c13bce509ae55335845d39591f083fb0345"
+    },
+    "sound/gcuts/g7_hknight3.wav": {
+     "bytes": 22546,
+     "sha256": "713e6f8582e58246003ce226c06644961c076b763183780b8d3d0ebe145d19d6"
+    },
+    "sound/gcuts/g7_hknight4.wav": {
+     "bytes": 77298,
+     "sha256": "5a5ba169ca7b4237d3d69d8ef304d2b87cea4e8db7e4ed91e942e26e3a1ea778"
+    },
+    "sound/gcuts/g7_hknight5.wav": {
+     "bytes": 107614,
+     "sha256": "7fac8e12b6bfd68269dd024a62e8cfb745d9a3f78e79123e0288db1d9a5b71dd"
+    },
+    "sound/gcuts/g7_hknight6.wav": {
+     "bytes": 17800,
+     "sha256": "bbb8b6a159c8063b0e946dd7c56636752b78fe45ca83836666e552aae8386d25"
+    },
+    "sound/gcuts/g7_hknight7.wav": {
+     "bytes": 44882,
+     "sha256": "4083e85ae01345c890f5d9acfa92ba70be22ab1f4f28f0d3c2faeb634e2fc2ed"
+    },
+    "sound/gcuts/g7_max1.wav": {
+     "bytes": 19422,
+     "sha256": "ae67d232668f5f3d41bc925ad9d8f0a74ecee1d02daa38efb982c0b28f69031e"
+    },
+    "sound/gcuts/g7_max2.wav": {
+     "bytes": 101428,
+     "sha256": "059469697023f97c037c09697c02a252d6dbca37a0d7ca65e20fa7799caa64e0"
+    },
+    "sound/gcuts/g7_max3.wav": {
+     "bytes": 47412,
+     "sha256": "4ddd51831b718a02a6e71765e8a34ba3a40509925908f6d2aaa9dfe39e9ef6c6"
+    },
+    "sound/gcuts/g7_max4.wav": {
+     "bytes": 67194,
+     "sha256": "0608804f2dfadd76fae5d1c0eed8ba463977f650ecf1ce177e241e5e00c687a4"
+    },
+    "sound/gcuts/g7_max5.wav": {
+     "bytes": 61764,
+     "sha256": "048c13811fe2f19ea86e995fa7069ff95200644cdd7b6cb228997059585c52d9"
+    },
+    "sound/gcuts/g7_max6.wav": {
+     "bytes": 154636,
+     "sha256": "36facc4f25152a0d10fac0bf37443232588bdaf071b76aa270a5131a2d0e8fea"
+    },
+    "sound/gcuts/g7_max7.wav": {
+     "bytes": 137756,
+     "sha256": "d792d6072094412b73a1410a815de7c905e768f154325857c2ed8e2b5770169d"
+    },
+    "sound/gcuts/maxlast.wav": {
+     "bytes": 37560,
+     "sha256": "21127cb86b9084216da6352def7c471eb50dbfb04e7a91a6d3c8638b4047b74d"
+    },
+    "sound/max/allday.wav": {
+     "bytes": 88326,
+     "sha256": "352c9c0394c7e684405f04473d6d4589052879ed59e5c9d3ce8986d813eaca4a"
+    },
+    "sound/max/betray.wav": {
+     "bytes": 31370,
+     "sha256": "3499d9b96f720bd21fd23e1893dc2eb4c7da30bb81effa4d4fb8b4e43855ef35"
+    },
+    "sound/max/bird.wav": {
+     "bytes": 41450,
+     "sha256": "1379bcaa37e22d3a58b0e450a17167d292a01ff9610f7e67945301fa5e6f73b6"
+    },
+    "sound/max/cantkill.wav": {
+     "bytes": 39432,
+     "sha256": "30eba395d4d86e2f6b549ac5384bd1916a88c01897e2f64e0e566eafab095904"
+    },
+    "sound/max/comeback.wav": {
+     "bytes": 49220,
+     "sha256": "72ca2f53ca9a8fd7943fd459e0261b223b0ec60e08b997b4198f21012ec3521a"
+    },
+    "sound/max/death.wav": {
+     "bytes": 54480,
+     "sha256": "7dd86373decc383ed82039e00757fff670ad30a1b03fa1639ea0f41cd6524be2"
+    },
+    "sound/max/dedrise.wav": {
+     "bytes": 38702,
+     "sha256": "46fb413b7a66642917d7f56070eb6001e1888c9b7f5ebad24d009867d5416e01"
+    },
+    "sound/max/dull.wav": {
+     "bytes": 28528,
+     "sha256": "b2e51cbaef57fc4cda5197fd8b61c7c1eae9f3d916f603e1d97c0e996adcf3b4"
+    },
+    "sound/max/eager.wav": {
+     "bytes": 53200,
+     "sha256": "d28eb658c22ce89ff95038afbabfd5297ef95b699332f24fe5f62ea133e675c6"
+    },
+    "sound/max/enjoy.wav": {
+     "bytes": 66932,
+     "sha256": "a9700f54e0513d5504b4fcd6965d4584cccbb2a7da7ae98e9230ab6487b316b3"
+    },
+    "sound/max/fofum.wav": {
+     "bytes": 38716,
+     "sha256": "123459d7759ade70b58794d51a7a1cde281e23fdf2c040d81cb7a96b4a61d791"
+    },
+    "sound/max/fun.wav": {
+     "bytes": 21400,
+     "sha256": "a550fafd56cba4a7eeb29b9914c7c881445f940770915dafea5db8ebe4bbce33"
+    },
+    "sound/max/gravity.wav": {
+     "bytes": 51170,
+     "sha256": "f38435d3f618abf1c0aea7bb41db428e4386855cb3e3ecaceea0e7b778512fe3"
+    },
+    "sound/max/grenade.wav": {
+     "bytes": 39750,
+     "sha256": "142fe516614a6bf7317ba5666155376f6bbb9e5417f204e4d48d028b2ebf4370"
+    },
+    "sound/max/handful.wav": {
+     "bytes": 33530,
+     "sha256": "5aebfd6903ce5c2480c81117a2ad62eeb1dc7f971c52da1c57167edba76a1f76"
+    },
+    "sound/max/hiding.wav": {
+     "bytes": 19410,
+     "sha256": "d45b61bbe35f3d3172e52bfc1ea9e819a33d2d70ee76f3898a040b21d68ec93b"
+    },
+    "sound/max/humanity.wav": {
+     "bytes": 30624,
+     "sha256": "a4136ccd8f3596610d76bf439f98335ffb67f7693e045edb101903eda8ee8d96"
+    },
+    "sound/max/hurt.wav": {
+     "bytes": 34212,
+     "sha256": "80ae4022066bf43d7f5c3c83cb912e18146c24b79d1873d69649c603ab65e69b"
+    },
+    "sound/max/iamgod.wav": {
+     "bytes": 19376,
+     "sha256": "9d0794d100e95df31d76b98c378e31b9d9524a9c5f12eb91df64ff2d26d683af"
+    },
+    "sound/max/inconsid.wav": {
+     "bytes": 182014,
+     "sha256": "7dc3bbc04d54948ee4fcfc49c53b2da531f70b44be089cfb9043f4d3741c9d0d"
+    },
+    "sound/max/laugh.wav": {
+     "bytes": 20524,
+     "sha256": "6e462419c61667e734a941c9d3f9bef9e9d6ee40789230576225f4554d95a85c"
+    },
+    "sound/max/laugh2.wav": {
+     "bytes": 18308,
+     "sha256": "828ecc578c44db6c0b039ea8f3f1407d287ea5a5216dadebc8715cc315f0d4cb"
+    },
+    "sound/max/lava1.wav": {
+     "bytes": 56952,
+     "sha256": "2f4cbb3df07c9d8964fc4d9919a2b03c6a2566ce473fea2fd1f3bb87d778c904"
+    },
+    "sound/max/lava2.wav": {
+     "bytes": 23528,
+     "sha256": "0b5d2970b355c0a1e39ae3c798c598f4cb4f13f9c06d5eb67fdccfb7c80735f5"
+    },
+    "sound/max/mpain1.wav": {
+     "bytes": 11662,
+     "sha256": "62afbb2a390c49da47ea6612a93d929142d932032b6befbe002a456067768c0a"
+    },
+    "sound/max/mpain2.wav": {
+     "bytes": 5002,
+     "sha256": "d816d25e3a69fe83f707348dc7c2993313ca72c0f726760d987427c76a04d5be"
+    },
+    "sound/max/mpain3.wav": {
+     "bytes": 9422,
+     "sha256": "10d462cc438a2cf7261890ff161f69c2096a5026d562ac6ca05356af4b210c13"
+    },
+    "sound/max/nehah.wav": {
+     "bytes": 71782,
+     "sha256": "4d820818284ea2ff0c524e072f9e64454c971acfcfac2969bcb7d060fdb28fe5"
+    },
+    "sound/max/nerves.wav": {
+     "bytes": 22846,
+     "sha256": "f103395f50befe5c025a3248bda49ec2d6f4084c4910365451d593b2e41a42e3"
+    },
+    "sound/max/onelife.wav": {
+     "bytes": 47346,
+     "sha256": "62b4039591dbeac3341e40a74073e91e71d957f2b36f2924011e03d1d7b8aef4"
+    },
+    "sound/max/pain1.wav": {
+     "bytes": 8670,
+     "sha256": "92a391980c7c18537a234cefafd0b35d79af259bbae325bb697bd4fa80f56a40"
+    },
+    "sound/max/pain2.wav": {
+     "bytes": 7024,
+     "sha256": "9b0a04f8347f7c709ce73f5b69201689bba2c32f3b0d2c6cee0a607fae303b3b"
+    },
+    "sound/max/pain3.wav": {
+     "bytes": 11104,
+     "sha256": "1295e5ae1d6246300966d53ad2252f7353f857a4e10741e69438aec1838dbcf8"
+    },
+    "sound/max/pathetic.wav": {
+     "bytes": 19028,
+     "sha256": "8e048fc58b14e78925f8362e1274207bef17dc29f9d7b640118b46f0670c9448"
+    },
+    "sound/max/pathop.wav": {
+     "bytes": 38710,
+     "sha256": "07c92d7d2e8529ed3ea885887ff7c50a5a9d17af3e6a49ffc76315ad5c198575"
+    },
+    "sound/max/step2.wav": {
+     "bytes": 3980,
+     "sha256": "2f104244bbf8afc151a1bb069a582c5a888a072989bcc4361282af991942f691"
+    },
+    "sound/max/step3.wav": {
+     "bytes": 7242,
+     "sha256": "e5eb1506649d5bc4ddabd4fe2d506f31a92f4d614ad2b85f86026cf54c4e2597"
+    },
+    "sound/max/suspense.wav": {
+     "bytes": 44926,
+     "sha256": "2639cbfa0e5f8a2e151982872f323d189d476a47ab7ee029457e450b8630803a"
+    },
+    "sound/max/tainted.wav": {
+     "bytes": 65470,
+     "sha256": "6d4e6b823572a5ea299b049b13eb29c29c5c6e0ee4a1bf36dab6831b59f5cb3e"
+    },
+    "sound/max/taketime.wav": {
+     "bytes": 54658,
+     "sha256": "1596bf956ff0dcd124ecf7111586834d0f667a972c07bc2e0c721e8659ba55ff"
+    },
+    "sound/max/tempor.wav": {
+     "bytes": 59692,
+     "sha256": "93c2464041f9773ad62d72e4d69560ec778a571d5da50218887cace819ce8ea5"
+    },
+    "sound/max/towin.wav": {
+     "bytes": 155984,
+     "sha256": "ceb7b95723edc31fadb58f85da7bfce27c286d6979b4e58c9e7f0827b4c159a9"
+    },
+    "sound/max/twisted.wav": {
+     "bytes": 87898,
+     "sha256": "82b2e763dab07e370b71ebc7195fde1296c3a6c97dcf80073b41a85430168d80"
+    },
+    "sound/max/witty.wav": {
+     "bytes": 65328,
+     "sha256": "326650fe95ad269846ba067a9f16c9e2c64fc9db7daf3c207a5a0378ebe218fa"
+    },
+    "sound/max/worthop.wav": {
+     "bytes": 29436,
+     "sha256": "4ce718698a443da9dca7579cb92df9ae1483e181b7a3016882a2871fac66bd69"
+    },
+    "sound/max/yorick.wav": {
+     "bytes": 47396,
+     "sha256": "73dc9c5666d97b3b27858fea6c19ad330836c58df525ac968ed48dbdf805598f"
+    }
+   },
    "sha256": "3e5e26989fe6c623d8a92051c8940a7c4d4aacd3a7a035e56120022a89e2b92a",
    "timestamp": "2000-08-27T01:49:42.000Z"
   },
   "nehahra/pak4.pak": {
    "bytes": 1841304,
+   "files": {
+    "maps/crate.bsp": {
+     "bytes": 18592,
+     "sha256": "68aee10a1300c78d149ce18eecfe32bf52a1d6dc012d529851d1e37fe2cd95fc"
+    },
+    "maps/finale1.bsp": {
+     "bytes": 87048,
+     "sha256": "80dcd70647bf81d3ff0bf15cbc7e9205a98e7a3f6b89327da87c46e2d9909269"
+    },
+    "sound/cuts1/opening.wav": {
+     "bytes": 1638804,
+     "sha256": "60f6f39b9477a5e9a9d1563dfe32e7d661544f78b4242a96f0a7544ec8fcff37"
+    },
+    "sound/cuts1/themeop2.wav": {
+     "bytes": 96590,
+     "sha256": "cfe1988742d5203519568445a7014de68d6e5f96e08258c466359b5a65eb72c1"
+    }
+   },
    "sha256": "ed8824a1a7d655a4999c9c0d7dee578cd725b50eff2661a121bc39008cd55585",
    "timestamp": "2000-08-27T01:48:12.000Z"
   },

--- a/json/by-sha256/5c/5c8b2b96e19fe9457725c7563fae40734599884592b06bf0480ce800a355137f.json
+++ b/json/by-sha256/5c/5c8b2b96e19fe9457725c7563fae40734599884592b06bf0480ce800a355137f.json
@@ -30,6 +30,40 @@
   },
   "alk10/pak0.pak": {
    "bytes": 7092014,
+   "files": {
+    "maps/alk10a.bsp": {
+     "bytes": 1650932,
+     "sha256": "418c1d69f939609d40d71bb3ec66336b4c478f374bbb117d81a1a2a5c74ec791"
+    },
+    "maps/alk10b.bsp": {
+     "bytes": 1055804,
+     "sha256": "ada9b1b0e3e91e524c3d0356b0468fc5b0f2989a3901bc18fcd65a39c7462fff"
+    },
+    "maps/alk10c.bsp": {
+     "bytes": 1366852,
+     "sha256": "4a94bcc4420db17b7b91535e41ae5f86856802939cd82559d3f8bfa9630e2c34"
+    },
+    "maps/alk10d.bsp": {
+     "bytes": 584840,
+     "sha256": "f66a3fbe6b6a57200a6aff5e8d473b7276373eefc682aeb8d522bd08634b5be2"
+    },
+    "mods/alk10a.xm": {
+     "bytes": 383080,
+     "sha256": "183b9d9a472b927a6e1be021b10f8502ed95cc6fed8d83f63978ee78844df33a"
+    },
+    "mods/alk10b.s3m": {
+     "bytes": 389680,
+     "sha256": "1dcde863f58377fbc050dd0a52767fbb7577f0a5f3def5dbf02be7a2680ddee8"
+    },
+    "mods/alk10c.xm": {
+     "bytes": 638666,
+     "sha256": "dc281be0a4ba848fb77e5e094d15925f912702cf161d04e46b446c9eb763e64e"
+    },
+    "progs.dat": {
+     "bytes": 1021636,
+     "sha256": "822e6337e3ad97646db4998e15ddf5923bf3a4bfb7bb467b7cfdc0bd53ce144e"
+    }
+   },
    "sha256": "935cb7852ae1253c70cb6902bb70c0124bcfcc6da3713a4b0c3e5e82a7358d94",
    "timestamp": "2001-08-05T00:10:54.000Z"
   }

--- a/json/by-sha256/5c/5c91b8d30d76a3eab7ecbf955d44a387bcae41ca97be09c70c23819de1636780.json
+++ b/json/by-sha256/5c/5c91b8d30d76a3eab7ecbf955d44a387bcae41ca97be09c70c23819de1636780.json
@@ -60,11 +60,3615 @@
   },
   "alk1.2/pak0.pak": {
    "bytes": 33939471,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 42302,
+     "sha256": "f3ccccf80a1046fe6de87573cb7e0633ca1d3fbea59e1cdf476d349961d4ce9f"
+    },
+    "gfx.wad": {
+     "bytes": 206620,
+     "sha256": "62e411df7989569dce7490fe61a0f60fb1a5703f886624d1916a097a4e6ba049"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "6072bd63a691625de201f3f3da060b5df433753d7ac2878c48b87e9d0dd08b94"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "ac11a967228e1c7d1a936859b82807cea239d80380fb6204d67af7a86c5c82e3"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "4cb99cf1b515b6547f012b6e44174c245261b058168a8bc4303d08b98e1805b6"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2c37b7697aebedb5bbf6637d4b8e158f70da6b7245195ff0e91a6ba7aa24e828"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "219002fe962a017600a37dcdcaaa0f777aad42044619f945cb70c68007763a97"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "e251893ed49aeb677096d380d4246907a039e0e21a4849f97f343b0b13faead2"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "64ec646cbab7ebca11f6af4f0b75d9706f438baa7b23059de87f8685f4686640"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "03c7cdc618e4404e2b9364c690b0a447b4be99dc5af112c66e6e2079902c76cd"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "9cf2683f2a6d22693a8c0cf35898bc5900a96afc771878df9f8a8a88f3d581c9"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "f232da5cf35acc557f3f312911e6a856cffaaf9f8078ca2ac5ef7e6f6e5e3515"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "b57ad9ad9d6240a0e035ca7a64e706e3031b8293c27355c9a95495a84972af4a"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "873af58b7244d6e82feb1af26ac044c9beb43c2865bc51d0485054a562ce861e"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "ba75badfe057b499d33168032dd5dc5a4fd0dcbaef9cbbd27efdb3f056cbfc00"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "55ac1377921460aeb691f86e7a5051e3a5481f24b93cc8578cffdab2854ba0c3"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "9600a66391996cff88d48890adfa516660fce6a32397ba4f54973159785cff4b"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9f03351fa7f31a23b63e6c13d2a643ed1ae3fd3df0cf2b0db336424eb17016dd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b7617428e8d1d74be7b770ef24c744d16c2503efce9c17facf1107cce08f5ed9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3036afb422cd299cb09532a20847ef35aaf87bb36e34ce9ce75b5e7aaf9a1ec3"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "7aa61257bd3083c00959776eb36aac86a7ca8da2bacbb4c8a41d9a5fb0b1ab97"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "cfe83953875acfe9afda11b75407ed9883eeb284b0a67b9ff6e07df85d50d9fe"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "d3b4091b83837da5a45445cd00b90267c62050e010e2a045461034ac9c48be33"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "de004dcecdff1973597a977ab63c671ad7d3f52387bdcff4be560924e3d4d17e"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "078c56d685ff1fb84b322f7a76e485c2637fb09efc61f4e44d5d067b3ef9a42d"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "9df9672c8da61ae769409e9ea741a1b8f9a4f108b5f0fa6637ff65601c535843"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "fef6b9be45d5b384d061a47f133075d1cfe0b60d93cf7e3da9ee5529f661964c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "1b1254c1f5764affca85448c4a3c2fefdb938f35bc50f44142a8e9b692ba7d64"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "39a06ff92831e1e2fd20c1bdd20e0f234cd0b3aed94e6c9909d059a20479ce3e"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "def061c922fb91a7e58850e89bb6baa9e09dcf93de7a94288a90511ecd9a114d"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "3220d953bab793165178f2666e67032398a6bd0e0510f6b92eef4fcab377ee1e"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "f897535531fe4b821d41d859a4085fd7d25c679493645a2ef7448f62073523c4"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d070636562a967d1abff330dcd1ea504ac7b9b29099a98994add1d9ae47e44e9"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6d92547a27d839f3c9d7a1da786fb33547cd93b7f19560b6c4bcdc12064545bd"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "e932416c58fc5de16e6d05aa737e56d3811e540bfd9e6acd1bf114ccd8bf34ac"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "bda55d4b2d7bc3f180dafd62424ee5830896563f5a5ac576dfa08894f5e17e44"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "513955ecc96eb1f0d44b340b47f79c02bb7bfa7f3b0a884a65fe111429ddb2b4"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "2faa4c1f61d175ad28b7f54540af3f87abc6e56dc20f2da5fc8a7737a0302c97"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "dcfe5287432b3a1124d032250ccc4bf25c73540521c77601ab746287ef3a0179"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/skillmenu.lmp": {
+     "bytes": 14408,
+     "sha256": "dbf40f0e5faedb181e84d4a822ecc9316711ae89530a30bd50cf4fba45aa8251"
+    },
+    "gfx/sp_maps.lmp": {
+     "bytes": 2248,
+     "sha256": "024bfb2d05f1c52bab1a856cbc532d06fdf4e8d96fb486f74bf451472311ebcf"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "00654b7bec9981508cd9ae8eac167637926c023e7bca011a3cf37585b7e168a8"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "74c50b895f1e71ec6a569fba0e991fde8cf136ea734d6914435aaf9b2735d7fe"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "aecab7a199a4db72242659e6d1ced192d39b2619f67c7e5eaafa72a5efef3aef"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "d075eb0c8c00d30b01eae539720c20b73bb57066c6ea5e8180a4d851d9167add"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "d03aa05e24552d961ea9ca278d743860e34a97e2ffcee52fded05ad4b4740bd9"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "progs.dat": {
+     "bytes": 1111198,
+     "sha256": "8c7425de5ac44b26f83c3dbe30929f0847c07d284e92f7ae726500904cbd2537"
+    },
+    "progs/alkturret_base_v2.mdl": {
+     "bytes": 87768,
+     "sha256": "4b1969201052a4506509bb606eb7c395daf9332cf4605036ab50190495dcfbf3"
+    },
+    "progs/alkturret_main_v2.mdl": {
+     "bytes": 116620,
+     "sha256": "11a2564f7daa19625e4514c284650242c8b3831df947f183243adafb958a1333"
+    },
+    "progs/arachnofloyd.mdl": {
+     "bytes": 741212,
+     "sha256": "554bd2ad34a830fa01a61dd4972f432812fb61f7815ec81d8a8d7e87bfad6b02"
+    },
+    "progs/arm_foot.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 164224,
+     "sha256": "35314143b9c7a9a0e26e52a865072a6e73862466e640c6bbd58be3075c4d93ff"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 497408,
+     "sha256": "40cc63b599cedb54f04c937ce407e7119c1cf4d5d35fd04bc18f247584e9899f"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bambler.mdl": {
+     "bytes": 128044,
+     "sha256": "c8ac9dbcf99f0e6efd30496ac414383c26b8d241fbaff56cfa81dfb545dfb0c8"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "698bf740683ad182feae2246526361948be6da2e144f1bd0202eafa748213ec2"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "b662513bc3a8e0e967344c55b536bd33012340dbeb79a8db1281d2c84e36d338"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b2cf62d8e989789bd76e27193b2f5205a93d4172a4e25c89aa1b30f75bebe60e"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigcranea1.mdl": {
+     "bytes": 92792,
+     "sha256": "81f6a5b55d3a585d5e9c73b088d1d20e0fb328707c1539ef41e52c460555f651"
+    },
+    "progs/bigcraneb1.mdl": {
+     "bytes": 21940,
+     "sha256": "e02faff0bb6c84c781f6b534a5a06ac1f977a028fbdcca176be2932f91e9e8ec"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/brz_saw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 575288,
+     "sha256": "f571bdf504537ce01ca2b6a78b57575a36c391f9c786625d880d956fb17390a7"
+    },
+    "progs/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/chain2.mdl": {
+     "bytes": 141764,
+     "sha256": "9334a3ec04716ce0068154bf7abb4c1e3ee6de14fb159982dd547314935d7854"
+    },
+    "progs/cyberscrag.mdl": {
+     "bytes": 306936,
+     "sha256": "868d1394e186b1e7f4fc58134c338a413814723f406fa609e2d7cb87dc2496cb"
+    },
+    "progs/cyberscrag_gib1.mdl": {
+     "bytes": 60500,
+     "sha256": "3db8b13bfa5a5eda07acea695cae6ffb92354053da9bed199ef29cd445317faf"
+    },
+    "progs/cyberscrag_gib2.mdl": {
+     "bytes": 58932,
+     "sha256": "ef20c0de15fe2fc2514c10b0023d14009a4871ed40311077ba107350c313f7ce"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon_alk.mdl": {
+     "bytes": 191716,
+     "sha256": "11f33f19ae0a46d3dcc6c1fee46235fb6ad201456120502b603fe4fb7cee14ac"
+    },
+    "progs/demon_old.mdl": {
+     "bytes": 272684,
+     "sha256": "538d5d01833d6910d4400f8795be582c3427748eb2a162fcec2c17d6707c57e5"
+    },
+    "progs/dog_alk.mdl": {
+     "bytes": 199324,
+     "sha256": "a16e350fcd247908c75ecd0c93e94d3b700b67bb0f66dd45d665d171a55d42b6"
+    },
+    "progs/dread.mdl": {
+     "bytes": 415072,
+     "sha256": "dcea570331c5cf4348c40451c6242bf35ecaaea2a348f12254a13c1b76b13d7c"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17284,
+     "sha256": "444692074359310be0520b1caa057ae2e084df826f7ecc9bcb0d258ea1d80373"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35988,
+     "sha256": "91aa79805577466147bd4811614b0387b3635aba8383fc2e16b178d7b63ebdf1"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42436,
+     "sha256": "93839bd6f50323f7ac5ae46037de0c6a10a533374f714229dd511ee62b88ca3c"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bcc6396dc638003480dba8c36cafaf32df2cfcf49bd460b001d0d74a164f9011"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/enf_gun.mdl": {
+     "bytes": 58684,
+     "sha256": "39ef1788b39a15f86c8d54b81c43f4126e8361ff80d386c44358f17ddc93769f"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 450424,
+     "sha256": "ecf603c4ebc56438e96d1706a451af8bbe9b090db9c48e38e758ec630a393570"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "ddcf759804fffd97e62c55f67f962e24e8cd646fd982215ac8aefd3e49f67660"
+    },
+    "progs/enforcer_alk.mdl": {
+     "bytes": 333860,
+     "sha256": "85fb5cb9eb1435da65ce0aa6940241b7b4b5fa13e7444713a75c6ec301cc8b97"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish_small.mdl": {
+     "bytes": 221279,
+     "sha256": "34b883e3bf73a520f301cced68629e0d95e88f96c03a23230f12d02aa49c247c"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flag2.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flagbig.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 451032,
+     "sha256": "1a311e7e74f9a67c9f7468252aedc8c19804f65375d229e90afbec2f93849823"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/fromitz_still.mdl": {
+     "bytes": 6964,
+     "sha256": "63204597e828e001c957e9316878995e161da0502764276b90285accadf6a222"
+    },
+    "progs/g_axe_alk.mdl": {
+     "bytes": 50460,
+     "sha256": "92988e970870f2b977f7490d2ea4ee040d338fa4bdc470e8d68f2e5a856a7a28"
+    },
+    "progs/g_axe_alk2.mdl": {
+     "bytes": 50460,
+     "sha256": "e448b2a7540ba959453592b2472d0ae498142a77242c91fd5991ca23a7973f4a"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_mine.mdl": {
+     "bytes": 37780,
+     "sha256": "5057c7736e8c722270c781e47584972f42e7ebdd5860596403a9ce7688d0b5cc"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "15f390e39e02c8524e575ca8fadf63187b641c58210ee9587b13a0ca94c29cc2"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 199076,
+     "sha256": "7ddca6fb95082d0cc7ffe5aa3ba896ea987a80b1bd5867db97b2a84b9d8da9f6"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "8b05b8ca87ea867c2a2397d238311fda2441f5c0e1cde130ba487b0dbd17a8e5"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_arach.mdl": {
+     "bytes": 60292,
+     "sha256": "daca6412383bec28809cee42c4ebf01085cf83ed6ff289114ba0f842b4005251"
+    },
+    "progs/h_bams.mdl": {
+     "bytes": 37316,
+     "sha256": "58c4644a2ed3e5f10741dff2ad1a8bb161f7eb205ba3fd8c5fc9b7e4ffc571dc"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_cyberscrag.mdl": {
+     "bytes": 62036,
+     "sha256": "df7d6bccc97bd5c184d9d6160005b370175aacc16a34bd06ab14c7d69ff60419"
+    },
+    "progs/h_demon_alk.mdl": {
+     "bytes": 72644,
+     "sha256": "22a9e01cdccb2e274c63c277e6dcd61986fa7556426ee3562fe11af2babea289"
+    },
+    "progs/h_dog_alk.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_mutant.mdl": {
+     "bytes": 110240,
+     "sha256": "f1f9c665b659a8c145550605ef9abddf27779d0917c897baa344d65673770875"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/h_sabrkn.mdl": {
+     "bytes": 11828,
+     "sha256": "050fcc93189211aba943674a326ddd898dc980b83fb551ee11fec3dd39973483"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shams_alk.mdl": {
+     "bytes": 37268,
+     "sha256": "9fcace6cfb38473763a5cf96007ccc5e0ec4786352d4d1063410d63157298b45"
+    },
+    "progs/h_torm.mdl": {
+     "bytes": 62056,
+     "sha256": "db0ddda0c4d2283cd3c58eb45397cfb57095acba1eb6dd38571ca23ebffe9946"
+    },
+    "progs/h_wizard_alk.mdl": {
+     "bytes": 14948,
+     "sha256": "5f6c27ba255b87718d993b29cff526bd025c0e7a4991722a96fe3c0f98d83408"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hknight_old.mdl": {
+     "bytes": 418144,
+     "sha256": "40bd5757499a2bf7e6f60a78b0039665107c9603c2557f6bc73208e080111464"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 37012,
+     "sha256": "e3c6cbabfe6c6723101f2e59f50fc99ee0e360571c95885d2d56c85eefade15d"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/jumpblue.mdl": {
+     "bytes": 37428,
+     "sha256": "be4e85e5fc643e91377d69794b997ad4dc927ae3866dfef5288d704dbc0f16d7"
+    },
+    "progs/jumpgold.mdl": {
+     "bytes": 37428,
+     "sha256": "4c543d82c88009cab7fcf6230feea0a21518a98f430636194fdbf5c1e526cc13"
+    },
+    "progs/k_laserspike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/knight_old.mdl": {
+     "bytes": 208068,
+     "sha256": "5cca43e29392051c9ba95838a58cc1038560411e6c0d2aff61867a428b119e2a"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "63220c0ebb6e266576cb3107a44be16bda10d69fa524d0462514edff9d80328c"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "29bc55efafbea3e15a385598750ba4d9242d0a87803a6bc3430ed772ec1785c3"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "f1e799e7feac3c340676bb60f6cc7a2a7d1e121b196d1f6d0e23edea3a614ed6"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "92370f5b196dc00460d73697975d14279ef659c87c7fc1613b9cbfb68e6c299c"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "4c5db792da6876f935f8a98a74f51708d52ca03f04975f28518051494660bf65"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "781837a3557c1a8b89c15fa8f477989cb4b77d8cff09c8c13d071090a4df9c1b"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "2feb7ce08070b314d163cbc7f2e2eae0986400c482f752d305ddba268639b3d8"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "04f7fc8b0c2be7ea93021819770145eaf828b2313c4fc591a5f2aa783ca97e61"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 8372,
+     "sha256": "9b6a8f7a49fb7a1f5d4d409b708663c579d433e978d898b9bdf00291a59b4e6c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "fa5d7a5e2410ac7faa5dd0a8e17873c972c6e5cfeacc94118f22db1b4b17477c"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/mutant.mdl": {
+     "bytes": 352720,
+     "sha256": "262ffca22e0c7308950076c2789436a891399862ea25afbd06040158ec9f7984"
+    },
+    "progs/mvore_bomb.mdl": {
+     "bytes": 12653,
+     "sha256": "dd54f975b770db899ef71174d8b05cd98af99739e9506fc4eb354ee8d7e820b8"
+    },
+    "progs/nsoldier_alk.mdl": {
+     "bytes": 563108,
+     "sha256": "6071d7cecf231f0a83f2e1c7df533b4a32beb6e75969d17703446a67d011695a"
+    },
+    "progs/ogr_gun.mdl": {
+     "bytes": 52452,
+     "sha256": "eaa6e0fe01255450d578f151c06c5aeb6a9cd5ed90edbbe4f52d305069ed6825"
+    },
+    "progs/ogre_alk.mdl": {
+     "bytes": 315696,
+     "sha256": "31e9986373dc1a8cba00e09ba9b0278cf766bbd074524a891ed22329f697d643"
+    },
+    "progs/ogre_old.mdl": {
+     "bytes": 315696,
+     "sha256": "53317e9b684701e7722bea342af1a6dba5dd31e72cdbcfa5b097382516d1c6a3"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 487968,
+     "sha256": "ae0abff3ea3fc7ca8c7f80c5d8825553795a1c1ebb80127d46fa52b20905abc4"
+    },
+    "progs/ogrem.mdl": {
+     "bytes": 378296,
+     "sha256": "2bb999bf580d16fb9ee4246dea7897236d6d118232c78a6168f641dc32778fb5"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/pellet_tracer_short.mdl": {
+     "bytes": 58148,
+     "sha256": "5b24b67ce9d9b2634d9a0f31319a977e1e3ec6352d491367941a0e5bf2ae10ff"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/probegren_body.mdl": {
+     "bytes": 139044,
+     "sha256": "da0ddf337c3e2515688f2b143adf55d4ecbbfa32955a78aea01ed16e067b0065"
+    },
+    "progs/probegren_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "4f292b6f157d226e763ff28dad682ce95cfb8a3a21b4badf0ca48db4900cdd70"
+    },
+    "progs/probegren_gib1.mdl": {
+     "bytes": 63788,
+     "sha256": "0efb081efa87c9db990d984f9974f10078890a51894a3e0a6fbe76cc3c4cb5a7"
+    },
+    "progs/probegren_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "7843ddefa22b7d5beb37f889c606c6361792508c2bea202f3dadf9f3ffce73de"
+    },
+    "progs/probegren_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "7baac250aa8c27ef3158de59b536ebf59509e39b1f7bf6be1c24fd5b1e29cae0"
+    },
+    "progs/probelasr_body.mdl": {
+     "bytes": 84296,
+     "sha256": "ac545d0f545488628c864df6e464d10fbd51cb41a2cb76c46dd91233ecd11a6f"
+    },
+    "progs/probelasr_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "cec7b847c9b05f2653113454348799b9bf09c2a74c8e1760cca0ff52c1dfc18c"
+    },
+    "progs/probelasr_gib1.mdl": {
+     "bytes": 58700,
+     "sha256": "ae9f298abc0bb1d09cea3c04bf02216b0a1c3749f8c8a822d973b4c2091cd649"
+    },
+    "progs/probelasr_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "07d6defee5ce4e747daf8b397a5d207a1a42e3c3acffbdfc18d6720c88ec635c"
+    },
+    "progs/probelasr_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "8b8f376afa56e7a9f311e58a076f1fa3a52c88064887a8e0960fdb6daaf5265e"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12653,
+     "sha256": "162632bc16838f66f29e0b788845a6421b7fce708003e9fa6f4eb8ae7aa8e5be"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/rail.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 200152,
+     "sha256": "a564fba381d24e3084bc9aa0a026381c83e6b889632c8bebdf69c08c8a6bb9f2"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "f65ba83d82e90808af589ded17378f1baf37f105fa14f2b157227ee22583d25d"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 288,
+     "sha256": "6ff2797f9dc4e66f2113475a5f3e0e96f23dacbddd18fe47c8b5e12e712f0e75"
+    },
+    "progs/s_bullet_new.spr": {
+     "bytes": 708,
+     "sha256": "a07fa61f4a838ac9ad8ec85ae525d70fb934d383effd1948c0775497be713043"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "b3f1971bd28f96c623c5712e2a47f54f16c99a50d460a944cdcdf29e6eb03963"
+    },
+    "progs/s_exp_small_2.spr": {
+     "bytes": 201720,
+     "sha256": "f7fdba9e2b9b5d318cdff33a06fad4e91e46ba3a241fe7ced4bfbcf0bcb0e873"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_plasma_new.spr": {
+     "bytes": 13980,
+     "sha256": "5474060e55af3c462d0ef7aad043f331c1f5b642915d906c1785bb94595cc68c"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 2820,
+     "sha256": "ea66402d248232b0b6a77bffe024d4a62881be47becf37acb42328661b7f23ef"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shalrath_newer.mdl": {
+     "bytes": 228496,
+     "sha256": "93601de7ff47f552ac9d441ddf1faf312417ca914de99529b17bdf7522e7478c"
+    },
+    "progs/shalrath_old.mdl": {
+     "bytes": 211576,
+     "sha256": "409cda15df7b271bd95a895f058a521d43eca63f37c7ac9df175e5b478229bb9"
+    },
+    "progs/shambler_alk.mdl": {
+     "bytes": 502148,
+     "sha256": "bcf685fcd1f4062dc382924d39eae073fc4d44cd2dcb5bc4ca3797fe0b342b71"
+    },
+    "progs/shard.mdl": {
+     "bytes": 10132,
+     "sha256": "0219a0f08bdc1f604ebe1ea2243cd1b27a2b1ab85bedba3a11298f2d22e9b38c"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "662d6a7cd68bca7a9c5e88838d190de6a501252a14b6994a191d0bc91f1f331c"
+    },
+    "progs/sknight.mdl": {
+     "bytes": 460932,
+     "sha256": "9213f6898a60cdc20a7a144c61c13f8d64f1432382dca44b636524edf737dac8"
+    },
+    "progs/soldier_alk.mdl": {
+     "bytes": 359276,
+     "sha256": "623374e5a553c3d886738c9cc0b22c0b3f3435b3dc1b3f473079a1dd1661fc8a"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spiderbot.mdl": {
+     "bytes": 82476,
+     "sha256": "e85556a194664a5f69e70b42aa863d9e67689a418a3afa51e50816174a6fe8ac"
+    },
+    "progs/spiderbot_gib.mdl": {
+     "bytes": 19444,
+     "sha256": "96ee732ac1199a89c675880700c24e1f09521c35ad478f73aaf4278a398454f6"
+    },
+    "progs/spike.mdl": {
+     "bytes": 2820,
+     "sha256": "783d711b408498dbb34581c9a0ae74ed325dc5c68fa67873745b02c8a926a201"
+    },
+    "progs/supbkpack.mdl": {
+     "bytes": 44408,
+     "sha256": "781c6b5f424fb58e06b2a84b1fb7e980778decde6b3ed257e224db0b1f250173"
+    },
+    "progs/torm_largeshot.mdl": {
+     "bytes": 37852,
+     "sha256": "ce3a87be213e39b48bc71a6fbf5e1fe9e3f5209901ca45801f27d8f297e04a01"
+    },
+    "progs/tormentor.mdl": {
+     "bytes": 461080,
+     "sha256": "df302dea113f54df908f97c26de844d1235004c08aefcf5c349f3af4b0957d41"
+    },
+    "progs/trifecta.mdl": {
+     "bytes": 25460,
+     "sha256": "2c9196af0806c48354f5522a8b7f6fa57e6390f8dfb51718fb71b8a2d4d7447a"
+    },
+    "progs/trifecta_big.mdl": {
+     "bytes": 25460,
+     "sha256": "9633a10c7c20f77b9202befad3cb363aefe710b166e581f80967ad94b5c6b6eb"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/v_alkaxe20fps.mdl": {
+     "bytes": 96428,
+     "sha256": "4405242db772d86c66f1012b140ba409bee86682fa5f4a6ca12c3e6f94eb9fcc"
+    },
+    "progs/v_axe_alk.mdl": {
+     "bytes": 55820,
+     "sha256": "80ad34cf2612f8fa9121f2be0ada92c1e05613ae2b35b2a1be25a4c694dd2147"
+    },
+    "progs/v_laserg40fps.mdl": {
+     "bytes": 142580,
+     "sha256": "b897ecb5868e3125597d51f970075af04782cba47ed8a42d7b17775dff01f536"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_mine_40fps.mdl": {
+     "bytes": 332920,
+     "sha256": "0039956e96a804229359aaf082b9cf66515d52360867b86c3dca884d19caf8b4"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail3.mdl": {
+     "bytes": 124944,
+     "sha256": "19045e9a5154299b68377744ad946fc3e7f2bd290497c8291a2247ed8cc572ad"
+    },
+    "progs/v_nail_alk40fps.mdl": {
+     "bytes": 44692,
+     "sha256": "402b3dc06f1e5e756cfd50cab17cca49e17e261994c5007cfd46c466a08d3dad"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 260692,
+     "sha256": "0982368440a5d20d65ec511207590c2bfb63e9a60376a5d753b209f2b047c58b"
+    },
+    "progs/v_rock2_40fps.mdl": {
+     "bytes": 139668,
+     "sha256": "89257b7580ac3f48fc775f121eef3508c326eba1369e6aacae83144f8fdfca15"
+    },
+    "progs/v_rock_20fps.mdl": {
+     "bytes": 39556,
+     "sha256": "ebdd6245e1ff65bd95eaed7fa189ac87b51818408f091a32de3f4a477b90f2f8"
+    },
+    "progs/v_rock_40fps.mdl": {
+     "bytes": 43828,
+     "sha256": "f3c32a1c37d4fc3115a8da00ba9507cdd508a98f65e2ddccbcbdc8a0ba0bf2ea"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 326464,
+     "sha256": "dd389cc337d8b7675d9a7b983fd9f53f0c59d597a9759367bd1e1beba375eaaa"
+    },
+    "progs/v_shot2_40fps.mdl": {
+     "bytes": 29076,
+     "sha256": "37ae91c018183faef847aad217da537c97b5a2430ab27a860388bffc1f4514f6"
+    },
+    "progs/v_shot40fps.mdl": {
+     "bytes": 29252,
+     "sha256": "87a47e2debbc27fd6c18a8a38a9a373e7b73ba707458e6346f069c1572df47b4"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/wizard_alk.mdl": {
+     "bytes": 158508,
+     "sha256": "aab430eb2dc0f5c50ca7b4492a7ccc427f2a12011f54ece1b81d4beb66acb4a9"
+    },
+    "progs/zombie2.mdl": {
+     "bytes": 130148,
+     "sha256": "185336c7bffe32e496e93f6828278287f89b672c71f2439918ac5e220ae8b868"
+    },
+    "quake.rc": {
+     "bytes": 1933,
+     "sha256": "f257658d2a0d019a231cd3fd52625d9220667c0fd1bca2a135bae57911523316"
+    },
+    "sound/arachnofloyd/death1.wav": {
+     "bytes": 119460,
+     "sha256": "d16c7ff30e9df62fbcda102befbd61fe234532f6aef30d0b34c25330679682bc"
+    },
+    "sound/arachnofloyd/death2.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/arachnofloyd/idle1.wav": {
+     "bytes": 34254,
+     "sha256": "35d6991a10637251ec0d6b830f7f57f394e4eed06e7a9dced86f0128ba5bc49e"
+    },
+    "sound/arachnofloyd/idle2.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/arachnofloyd/leap.wav": {
+     "bytes": 70884,
+     "sha256": "f47323f618db14755c57e9e25213267dcffc501fbaa9a201176ab99db6cda928"
+    },
+    "sound/arachnofloyd/pain1.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/arachnofloyd/pain2.wav": {
+     "bytes": 15906,
+     "sha256": "9c4bdc81c73787cb67677e0021b71d9e24734ef3ce272d9020dc6611a1d87842"
+    },
+    "sound/arachnofloyd/sight.wav": {
+     "bytes": 48620,
+     "sha256": "97a055dbb8e5935190348b2c2d50c6d99ab35c29f3ebcd0f66d6263bdb5485e4"
+    },
+    "sound/arachnofloyd/step1.wav": {
+     "bytes": 74932,
+     "sha256": "a8744a3e50dccf9ee391da2f381c2ecf6701a76441406929ee4581c7717b880f"
+    },
+    "sound/arachnofloyd/step2.wav": {
+     "bytes": 34478,
+     "sha256": "22ce43aa18537f7b04e31263a46dd02e181d538fdf5918d55f8ce0acbb930676"
+    },
+    "sound/arachnofloyd/whirr1.wav": {
+     "bytes": 19762,
+     "sha256": "9e2029071248e6d45f1b0d518983bad5bc5f841cda6bcfba09486e111add10de"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axegrunt/axgdeath.wav": {
+     "bytes": 20214,
+     "sha256": "e5ed762afcc516058acc1b3884b4d08e67fd36e3a5bacf711d3504363bf8136e"
+    },
+    "sound/axegrunt/axgpain.wav": {
+     "bytes": 12636,
+     "sha256": "4699951fa58fdf15ab819b13d70904fc9a1a86a4db02193d621dfad3878d17bf"
+    },
+    "sound/axegrunt/axgsight.wav": {
+     "bytes": 17712,
+     "sha256": "e7b23208831c1d83793ba06f3b8855430c92017600cd8315341afbcb6ec6c8f0"
+    },
+    "sound/bambler/melee1.wav": {
+     "bytes": 4175,
+     "sha256": "4e0e2567b9d64b3ff86b33d95fa0158bf72372aeb4968a0c2489df942f9f7c4d"
+    },
+    "sound/bambler/melee2.wav": {
+     "bytes": 5283,
+     "sha256": "4bb91991bccfc33576eff19037e12666e9825348272d3dca40199e208bc00700"
+    },
+    "sound/bambler/sdeath.wav": {
+     "bytes": 14048,
+     "sha256": "c5253af82d203e75d132a00bbb555de055d2e356106d460f34cb8c9a2ee5e643"
+    },
+    "sound/bambler/shurt2.wav": {
+     "bytes": 3736,
+     "sha256": "0f1a51e0ff72f23a4de7684d4408344b7b7bd2cb805609168d2f2459e1b8660d"
+    },
+    "sound/bambler/sidle.wav": {
+     "bytes": 4907,
+     "sha256": "ea2232ba791e306cc86f58303413d8f3fbc7dd38091281698f4d846b6cafa483"
+    },
+    "sound/bambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/bambler/ssight.wav": {
+     "bytes": 11376,
+     "sha256": "de766aa056ca5f7dc6d179e6a220ef906ceacc0341b5cb3d91a4d0e75ff55338"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/cyberscrag/fall1.wav": {
+     "bytes": 23396,
+     "sha256": "162fc0be1cd0eadfc93c35f1e1ba9b8dfc7e8df8ee53afb2a14db73e69f20ce8"
+    },
+    "sound/cyberscrag/hit.wav": {
+     "bytes": 22334,
+     "sha256": "a16ef33d94d56fb6984b2a3d06104a3cc292bdb38ec6ee22c8b10457b2cb415f"
+    },
+    "sound/cyberscrag/wattack.wav": {
+     "bytes": 25912,
+     "sha256": "6bed724b7ef9bdd480448396ed4498c75f848bf2a1e6d2879cb2b2484cdd1a7b"
+    },
+    "sound/cyberscrag/wdeath.wav": {
+     "bytes": 20684,
+     "sha256": "24602233cca209122250ba7c284933992aa2393795ea5c528a57b9986e2fc319"
+    },
+    "sound/cyberscrag/widle1.wav": {
+     "bytes": 13465,
+     "sha256": "8902628d2201eda9396c0dc134ebda8b8d5c37dabddcd286f8387aadc6532750"
+    },
+    "sound/cyberscrag/widle2.wav": {
+     "bytes": 23094,
+     "sha256": "76af020e5c25f40ab3020bbd065a9b83b9b0a51120d47d137a7abff4eb43e193"
+    },
+    "sound/cyberscrag/wpain.wav": {
+     "bytes": 8687,
+     "sha256": "af2e8589d381e634f607048ce71200df832c9e3a32147891b5bdd2efe2ff5bf0"
+    },
+    "sound/cyberscrag/wsight.wav": {
+     "bytes": 13079,
+     "sha256": "2f9178f6515eb4cd518b418441c40d1376aeaf6f42f7791533f5f4b6da87fd68"
+    },
+    "sound/doors/alka_doorlocked.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/q2door1.wav": {
+     "bytes": 30572,
+     "sha256": "3f05bddf76379933970c532656b6350bc53820319ce1cb9d4ea9288210427eee"
+    },
+    "sound/doors/q2door2.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/dread/dread_death.wav": {
+     "bytes": 49692,
+     "sha256": "22000ff613ff52eab0605418681affaf7aeef4acc420d3dddd50a9031ac1ca38"
+    },
+    "sound/dread/dread_pain1.wav": {
+     "bytes": 29220,
+     "sha256": "67e443f78043cb9fc4213bbfbc3cd847785a66849fb7b36dd6467494487e0aec"
+    },
+    "sound/dread/dread_pain2.wav": {
+     "bytes": 23380,
+     "sha256": "914fffe3ad6c02fb78be873ee96405a40df22cd321beee2d673d0b6ebbafcde4"
+    },
+    "sound/dread/dread_sight.wav": {
+     "bytes": 70792,
+     "sha256": "50449a772b2ac778b810a69de58cb63c8bbdea529091720a41a1052b7196632e"
+    },
+    "sound/dread/dread_sight2.wav": {
+     "bytes": 58420,
+     "sha256": "f7952137b648f6376a1ba4e968679abb17fc648ede87bb0dd32f633271ad80ee"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 110256,
+     "sha256": "895cfb57c0d27369530fd5e9b29abd491a989ad0a63ddb00f05dd9e4777a5cdb"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/frogman/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 32638,
+     "sha256": "3cf3933f34c7baef52df54d5b03db40424e9f7ee72e5aa5a4dba489d71be2af7"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 27662,
+     "sha256": "ec38e73fd1ffc33cd25aa065e5f5897c21a494e380763ff80b6be482689b5e33"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 44186,
+     "sha256": "7600cd32fe980646fddcf5a9077d8d43df1bca1f2ed05bd92ce8cca273ad6636"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/armor_denied.wav": {
+     "bytes": 15854,
+     "sha256": "2ec14677f483d1a1b869af64cc30fb0dbd90a640fc071fdf2ae493d27cd746e1"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/items/shard_pickup.wav": {
+     "bytes": 18260,
+     "sha256": "388923a63b48720647b9e0f2862c35bb1d5cad2e162ace343845b3fe36b48af4"
+    },
+    "sound/items/trifecta.wav": {
+     "bytes": 16412,
+     "sha256": "00baad51adaa3f5d6664e85ae5442221db6818bfd85124c164324d22f6723ab2"
+    },
+    "sound/items/trifecta2.wav": {
+     "bytes": 32778,
+     "sha256": "f742a9cee4a53ef52fce55d5e9ddaae9c6b20d2127e16c0def6cd11b3d2d6380"
+    },
+    "sound/items/trifecta3.wav": {
+     "bytes": 10728,
+     "sha256": "a78bfc9fa4fbf0c3c1e85bee273ee053598989a09146bd29e97dda811c49a473"
+    },
+    "sound/lieut/alert.wav": {
+     "bytes": 8700,
+     "sha256": "7ebbe83ae1b5d159c9f0a0ae5f3dea126650ed5d6f98a22d1512dcfcb19a23ca"
+    },
+    "sound/lieut/objective.wav": {
+     "bytes": 10052,
+     "sha256": "aa7d6726a458eaa48bf2e20446c57360b82ac23bfbd06bad7b6e01ae95ca8b0d"
+    },
+    "sound/lieut/target.wav": {
+     "bytes": 6754,
+     "sha256": "eebd50c75585894c7d5305f6c066aaef1efaca9a59e27b80d03e8ae4d69caa69"
+    },
+    "sound/lieut/you.wav": {
+     "bytes": 7126,
+     "sha256": "6bfb031b0d69b8ae4ef2e9b201da43c523ae88de344907648d4064e07477ee1c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/mechavore/attack.wav": {
+     "bytes": 66460,
+     "sha256": "fc2a8b0e2a72aebe2858b8337d5ef0638e3e04d5b60e9a62d46ac124072705f9"
+    },
+    "sound/mechavore/death.wav": {
+     "bytes": 37504,
+     "sha256": "bbdf8369941f8c2ab302fe3a55de3bf04e1d28e32a575ffd3c24009d76bebc8f"
+    },
+    "sound/mechavore/idle.wav": {
+     "bytes": 64972,
+     "sha256": "5cd8253f1abe5baf08f1852d12393ca820c34fc0f2febf6c1c8f9d4c3326b2c5"
+    },
+    "sound/mechavore/pain.wav": {
+     "bytes": 36444,
+     "sha256": "9f9368fdd53aec80fd43a6d3b6680e04aae72685d1cfbdf49d55dc1070e8c546"
+    },
+    "sound/mechavore/sight.wav": {
+     "bytes": 116312,
+     "sha256": "112613b44d88046653b29f21aa5fced5d4b5bfcaff037dfa5f246729e45a6968"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/conc_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/misc/door_closed.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/misc/ebell.wav": {
+     "bytes": 15220,
+     "sha256": "1693337ed8873f1159e56c2925afaa210f5c28bee4e2c42d27e29bee8e06cb5f"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 4054,
+     "sha256": "b9c44f73c8bdbc900af4f06600e0d6456a040b296612b7d0fe53391285976a44"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 4098,
+     "sha256": "4fad66341514c9aa2b31b4c2fde7563369090da9b0b3a51e08bca3100f2ec282"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5054,
+     "sha256": "d158ddc35360bc43934b7a8a9b7cc830f7510e6bb3a640813157822b27b5217a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 9726,
+     "sha256": "73b74099c8cb43ab2fb09b28b72ddd9f73f2d2a4f8a00a8e835490f366680c92"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 3226,
+     "sha256": "48551cc717e5011df78a38c6a71bb001e4f62a1858a3952311499653ff423a07"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 5802,
+     "sha256": "751050f97456a0c07e88a249d40dde96c2d14640e21670ccdde983502998dbba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/mutant/mutatck1.wav": {
+     "bytes": 6116,
+     "sha256": "410f926534f21705e78a804ce048b0c15e62fe0c68a45aae1b3741fb227551f7"
+    },
+    "sound/mutant/mutatck2.wav": {
+     "bytes": 18260,
+     "sha256": "66009d09adf71f10117c74f5004c995fd48362b2f4fcfaaa3bc2da01e66d115f"
+    },
+    "sound/mutant/mutatck3.wav": {
+     "bytes": 28840,
+     "sha256": "2dd8a615ca2be248c8370d7480f5a8ca9375d31e6af41bba603df660d31883a1"
+    },
+    "sound/mutant/mutdeth1.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/mutant/mutidle1.wav": {
+     "bytes": 81004,
+     "sha256": "8c7e8ad544d7e2470bd61d88c5cd8be1a0eb66f57aaf113f82d990ee00450073"
+    },
+    "sound/mutant/mutpain1.wav": {
+     "bytes": 56716,
+     "sha256": "49ff5f97fedc87c1ac06dc43d4ff0a0fd09fb481354b6373d607bfabc9a57a6a"
+    },
+    "sound/mutant/mutpain2.wav": {
+     "bytes": 58740,
+     "sha256": "b79f1cce60226daa3e3ca8c134da968d54ad51abd9c37ffebdf3d46c5d9f91c6"
+    },
+    "sound/mutant/mutsght1.wav": {
+     "bytes": 107316,
+     "sha256": "7e15e392edc3f2d5ae9e3bde3dfe65595a85728022245f74b81f072d75dce798"
+    },
+    "sound/mutant/mutsrch1.wav": {
+     "bytes": 101244,
+     "sha256": "44484ef4c189511fb0a8d0f2bea83e443e1f1bd51cef04f518f3820e58e88a69"
+    },
+    "sound/mutant/step1.wav": {
+     "bytes": 8140,
+     "sha256": "0d9af35156c84213ac7ffbde54d0f2518fe9d39bba4edc48c94e71bed4f7ec4d"
+    },
+    "sound/mutant/step2.wav": {
+     "bytes": 14212,
+     "sha256": "f7c81df1bff56c8aeb49891fa822c37ddcb019e97a654738a9fb8ee351d19eac"
+    },
+    "sound/mutant/step3.wav": {
+     "bytes": 4092,
+     "sha256": "89856afec31f800219c45253514d0fdf5b5bd800c32f87ba74dd0c21df181550"
+    },
+    "sound/mutant/thud1.wav": {
+     "bytes": 32428,
+     "sha256": "20ed5f20729a068801d06904365e46c9d692dec835710a9b8090d0a1956d6919"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    },
+    "sound/ogre/rogre_alert.wav": {
+     "bytes": 71728,
+     "sha256": "4f3e921b6ee236289660f7ca2ee8a4689e719423266d26a3f8b91ae29d02c6a5"
+    },
+    "sound/ogre/rogre_idle1.wav": {
+     "bytes": 110330,
+     "sha256": "a07df4a53c9e8de310b9d963bfb9c841c51e502565f39dc543bf1c025edd41d6"
+    },
+    "sound/ogre/rogre_idle2.wav": {
+     "bytes": 79416,
+     "sha256": "862258641dc3c90d2a9e5f9e2a4418eb0037eedf22cde798682a169a84f13a44"
+    },
+    "sound/player/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/player/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/player/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/player/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/player/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/player/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/player/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/rail.wav": {
+     "bytes": 97196,
+     "sha256": "396a85e1e2083f2b1eaae89a3f33a21145a643f3f50419523497719ef8e7598a"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/rider/sight.wav": {
+     "bytes": 26356,
+     "sha256": "40ace6f3beeb920ba1bbdb197f8ece18d312762a71e494726289e16703d75d91"
+    },
+    "sound/rider/step.wav": {
+     "bytes": 40524,
+     "sha256": "a43e24ecbc62d44bce466b1e682ebf64c230e03f4d79449406ce021dc8276a9a"
+    },
+    "sound/rider/thump.wav": {
+     "bytes": 15444,
+     "sha256": "af29f4e8f6debb1223aeb5d840add4ae01cb5e9f6bd9a26efeadff518f34380d"
+    },
+    "sound/scientist/allnominal.wav": {
+     "bytes": 23778,
+     "sha256": "e26f9bb3c24d9a9e0da38395048f6dacffe82d800da49d56378027250393d69a"
+    },
+    "sound/scientist/alright.wav": {
+     "bytes": 9666,
+     "sha256": "372c1aa91e6841bec2441215c894b7d149bdeaef33f907d23bb7eaf637520ce3"
+    },
+    "sound/scientist/asexpected.wav": {
+     "bytes": 15982,
+     "sha256": "306933848b673bd14d7074d59e45a8c97bc00a2897601509e52e5835e2ffc997"
+    },
+    "sound/scientist/c1a0_sci_crit2a.wav": {
+     "bytes": 28364,
+     "sha256": "f972684c74eeb51872873cc2b7053448c6cdd716b8c3535929fdbcc508d62ef5"
+    },
+    "sound/scientist/c1a0_sci_stall.wav": {
+     "bytes": 13704,
+     "sha256": "541c192ad5e8a68c76706ec17b3deceafbdc607bfc372ddfd300532f8aa1eaef"
+    },
+    "sound/scientist/cantbeserious.wav": {
+     "bytes": 13236,
+     "sha256": "fc4a8a379f70e33db79a49c667dcd9f1622de29d7b32ef3973c4ffdb5d80ee44"
+    },
+    "sound/scientist/cough.wav": {
+     "bytes": 14878,
+     "sha256": "b4e620259623347a5be3f7eaf3c531e6ea9ef2e97ac42997dd78cfee9327f7bf"
+    },
+    "sound/scientist/sci_die1.wav": {
+     "bytes": 15558,
+     "sha256": "c2306d7f9fa58f99961c347b06ef26305b99ac43ec27b2b222962e1f3a9ccce9"
+    },
+    "sound/scientist/sci_die2.wav": {
+     "bytes": 5402,
+     "sha256": "14deecb570d1e315b772713d54b7250043bb0dd5f3d5538cd0636e39a523c54f"
+    },
+    "sound/scientist/sci_die3.wav": {
+     "bytes": 3104,
+     "sha256": "075cdbc5837d91b61ad7599cdb3abf9323872816f8966c83deab9c0a6e04d7d2"
+    },
+    "sound/scientist/sci_die4.wav": {
+     "bytes": 4024,
+     "sha256": "e6ca0d4f18ac6c1246926646568618057cb70b5cee995c1c2dd69f0179b892ad"
+    },
+    "sound/scientist/sci_dragoff.wav": {
+     "bytes": 8986,
+     "sha256": "0c6a21cd5edf01e495e1258e9a76c05d62c0e3cd697e787fd43fd4bd9126483b"
+    },
+    "sound/scientist/sci_fear13.wav": {
+     "bytes": 4534,
+     "sha256": "dabce7a6c12980f947f7504da264fabb67a804d2e478b7f252ab527fb21a92d0"
+    },
+    "sound/scientist/sci_fear15.wav": {
+     "bytes": 4764,
+     "sha256": "f0d23c680ad138c3cc12da78a3e45cbf3daa47e5da9bc62a1dbb3b27389565a5"
+    },
+    "sound/scientist/sci_fear6.wav": {
+     "bytes": 5588,
+     "sha256": "ff2702b2b9e517b90ea0c2853775a4a95160edfae5af0a7f9208f07624d84281"
+    },
+    "sound/scientist/sci_fear7.wav": {
+     "bytes": 8458,
+     "sha256": "f2a39185c2d39a03b39afd7fe6f942b2f35fd17135ade8ceb4c31968c768aafa"
+    },
+    "sound/scientist/sci_fear8.wav": {
+     "bytes": 5804,
+     "sha256": "4455a29590d5f42ebbf06e600d8ba3f45acfd5000a6b8045891cbecf1d937970"
+    },
+    "sound/scientist/scream01.wav": {
+     "bytes": 14666,
+     "sha256": "b738de99aefbe3a45724914dd6eb79c0f8c219aaf733554a8a5eb94836c22320"
+    },
+    "sound/scientist/scream06.wav": {
+     "bytes": 13938,
+     "sha256": "dee8ac2058635d00458e2e74402d1cfcb5362c64259fc2c4f3b6bba31bdf6337"
+    },
+    "sound/scientist/scream08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/scientist/scream09.wav": {
+     "bytes": 6130,
+     "sha256": "85947649f5fb1491732365849a3025bf5c76c791b395cfdf421fbbd6ec58d351"
+    },
+    "sound/scientist/scream10.wav": {
+     "bytes": 5392,
+     "sha256": "fff4c0735f9c312be7cda848fc2867590437ffe9758fe685e3b4c94678ca1f48"
+    },
+    "sound/scientist/scream14.wav": {
+     "bytes": 4824,
+     "sha256": "dcb7dfb0e307b813476b2e55dceb59d8ae2b9514b1ef02034ea255fa5f086b05"
+    },
+    "sound/scientist/scream15.wav": {
+     "bytes": 3048,
+     "sha256": "37d26fe2d2b8a39d0fec0eceec0ca974ec3dd7fed33bae0d3230a934954105f0"
+    },
+    "sound/scientist/scream16.wav": {
+     "bytes": 2328,
+     "sha256": "4ff04ce8ff07af708c84dacc8df114b68620d47e8e4e4c78dfc4fd33a8a9b98d"
+    },
+    "sound/scientist/scream17.wav": {
+     "bytes": 3836,
+     "sha256": "82fb51224e06db5022adfa58f0b02353c333229ed3312f86dd9ec4f04813c37c"
+    },
+    "sound/scientist/scream18.wav": {
+     "bytes": 3066,
+     "sha256": "bfefcf745ab8d30db11f9113ecf9ba1c5bc6d9b2351c53f3f46d66e03cbea3fe"
+    },
+    "sound/scientist/scream19.wav": {
+     "bytes": 2504,
+     "sha256": "47cc414d201aadb7ba2fe0ce0567ff5360e90fd9de4a167520988513f358ed41"
+    },
+    "sound/scientist/scream20.wav": {
+     "bytes": 21310,
+     "sha256": "124cb45d3d5533572e3cfe4b42bddad2a03dc0d8de1c89a42ea57433432e3a6e"
+    },
+    "sound/scientist/scream22.wav": {
+     "bytes": 15206,
+     "sha256": "6e0a509eb2468466591622e74724c31103b8b60f5d8f29514fb57e9d9d12c9d4"
+    },
+    "sound/scientist/scream23.wav": {
+     "bytes": 21988,
+     "sha256": "8521907e8cecc22e6924d23295a5e8d31333d265ca27a9533b083b68e9da6d12"
+    },
+    "sound/scientist/scream24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/scientist/scream25.wav": {
+     "bytes": 8122,
+     "sha256": "38281749deffb4e567896f71e7bcb75d7b2e253e404a953a5eea6eeb989f156a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/spiderbot/sactiv.wav": {
+     "bytes": 17066,
+     "sha256": "f21587ba9bfd159e48c5b3aa1c6e94eac7157053e4e5699459233fb28c2631c8"
+    },
+    "sound/spiderbot/scharge.wav": {
+     "bytes": 7300,
+     "sha256": "b58064dac4e12bd6685edbfe61417a530cde1e5175336193b2fa7a292aca8ef7"
+    },
+    "sound/spiderbot/swalk.wav": {
+     "bytes": 12636,
+     "sha256": "5534fe1b11fea5406aada214681dba031ec4a01e4b660c405b679131ba07a7cc"
+    },
+    "sound/tormentor/angry1.wav": {
+     "bytes": 88890,
+     "sha256": "60f757f523a9cbb3a57c335bbeda8cedbf990b9d20a5b359e610b712a1344b4b"
+    },
+    "sound/tormentor/angry2.wav": {
+     "bytes": 90912,
+     "sha256": "2f38dddb69cf0df2c1e5b028ca06ea22d979e637afa927919e9a93876dc955d6"
+    },
+    "sound/tormentor/death.wav": {
+     "bytes": 176628,
+     "sha256": "7060ecdadac0b1c9eb3574284444932573e4af13082f01374ed8a4633387bb66"
+    },
+    "sound/tormentor/fire2.wav": {
+     "bytes": 52092,
+     "sha256": "4133a00c7ef157d291d800524a148c188a314eb5ca14246958b8ddfeb0d4fe41"
+    },
+    "sound/tormentor/idle1.wav": {
+     "bytes": 115740,
+     "sha256": "78feebc847dccab66478718b66971870f11246c416e2f2c1e9830c459e4c0347"
+    },
+    "sound/tormentor/idle2.wav": {
+     "bytes": 122218,
+     "sha256": "0270712fe40851bb21d959932b4f8f75bbe8b985e2ff383319059c656ac0ce56"
+    },
+    "sound/tormentor/pain1.wav": {
+     "bytes": 67334,
+     "sha256": "03f255d6ee0d6fb83f2a643491f4cd24d9c5ff86444a51b3cf8b5a0de3d86bbc"
+    },
+    "sound/tormentor/punch_hit.wav": {
+     "bytes": 76614,
+     "sha256": "e524d16b000237615bae3b8fed7b74726823cd4258561196f4641728047aaa26"
+    },
+    "sound/tormentor/punch_swoosh.wav": {
+     "bytes": 33044,
+     "sha256": "d0ef38ef4bf33d0c2f92b22c2a767c4efd66eefaa724df50b394958a7be5a705"
+    },
+    "sound/tormentor/sight.wav": {
+     "bytes": 94334,
+     "sha256": "34a13e6469c5e0ce2f6d18721b0cdd634731b9a9f8910a8bb8b685f63dadfaac"
+    },
+    "sound/tormentor/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/tormentor/sting2.wav": {
+     "bytes": 21674,
+     "sha256": "dd2d40459c7aa9d374efe2f219c34773f390df9f5177a83dbfa5fd638a13c542"
+    },
+    "sound/turret/alarm.wav": {
+     "bytes": 22126,
+     "sha256": "20a8a83d73a55dcc3d8a6fcb79b4ff8ecba0b5887cf3bdcdc96303f069b062ce"
+    },
+    "sound/turret/beep.wav": {
+     "bytes": 22126,
+     "sha256": "89f0e2ba68562cfc3e20272f995777c174c2681cfcf29d2ef337974009b42460"
+    },
+    "sound/turret/deploy.wav": {
+     "bytes": 105260,
+     "sha256": "5bb8c1fa8ffdf22e58ac5fb7a337916a457b9d021661742fcdbbdd7ce188c6dd"
+    },
+    "sound/turret/deploy2.wav": {
+     "bytes": 54208,
+     "sha256": "ec26b9451b67dae2929488687b7b9344a96f7538ab5c4f69e8a85602804dffc2"
+    },
+    "sound/turret/disable.wav": {
+     "bytes": 57180,
+     "sha256": "d8767dcce34c1c7f660f5868c23938da4cc379cb4001b88a10ec1aebbf9e557c"
+    },
+    "sound/turret/idle.wav": {
+     "bytes": 35784,
+     "sha256": "fba6bc2ff517ef95a999e3910c74e3594e054ede298c7b3a5659a2c31565d37c"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 43820,
+     "sha256": "32082cd1d44903409e97de782e5d9295272840e13280665a0ef3ff862b187f0f"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 47570,
+     "sha256": "0dd8defb8ecfb1ea72e6ac70ab182573775812e2d7990dd2897d02d3c38464f5"
+    },
+    "sound/weapons/spindn_click.wav": {
+     "bytes": 9986,
+     "sha256": "b84866cddb7e61eea9ca49208d427c2289d63e6e3e2f59d4d51e302573079bc7"
+    },
+    "sound/zombie2/attack1.wav": {
+     "bytes": 22914,
+     "sha256": "da5345280208ea48855526989299927268566cef77ee187035bbe969076d6605"
+    },
+    "sound/zombie2/attack2.wav": {
+     "bytes": 24072,
+     "sha256": "59245700b47794e239563cc94e3ff045fcd7dad795bcfe343d8574ec3ac525b6"
+    },
+    "sound/zombie2/attack3.wav": {
+     "bytes": 15400,
+     "sha256": "0113aad711264c05a9e43bf8dba915bc89661444d7d802efabe8d61ebb3ba13f"
+    },
+    "sound/zombie2/attack4.wav": {
+     "bytes": 20922,
+     "sha256": "0aac55ae62b62cefece56103cd7079beeb433c3764f590641876e149c4328ecc"
+    },
+    "sound/zombie2/attack5.wav": {
+     "bytes": 26086,
+     "sha256": "b58c97928b535e79973e0390512b09d3d0adea79b1b1b5a8de59bc2cde40c412"
+    },
+    "sound/zombie2/attack6.wav": {
+     "bytes": 22272,
+     "sha256": "58c429256e2f5abb9d97c99ceedb78088d8ac977eca94e994b6d1eee8bb3eb8f"
+    },
+    "sound/zombie2/attack7.wav": {
+     "bytes": 34384,
+     "sha256": "d68e81783b6583738227eac608ab7af1a4b1e1b085c1e46bd9c0d029eab4fdde"
+    },
+    "sound/zombie2/death1.wav": {
+     "bytes": 46548,
+     "sha256": "a1b9e2bcebf9c56fb56405d1ec7fe4166ac10d2b6e1acc6f01e58aec9fd63e87"
+    },
+    "sound/zombie2/death2.wav": {
+     "bytes": 47048,
+     "sha256": "5964a3c1a665c70de8302052b2b6d72ea46b0a5e07ba22cc9919e1a0ffefcca3"
+    },
+    "sound/zombie2/death3.wav": {
+     "bytes": 52636,
+     "sha256": "5c76f8bc55ecea263df880e6b683b07066b37c9f62ff589b0e999534d3c256b0"
+    },
+    "sound/zombie2/footstep1.wav": {
+     "bytes": 12966,
+     "sha256": "2a85309bea05b7c7c90a82df071822828e413cce17646a9686fa4f1264d75e48"
+    },
+    "sound/zombie2/footstep2.wav": {
+     "bytes": 16880,
+     "sha256": "d1d9e9c3811b39b67c9a6966851873ff7edf8d1407c5d9b90782b233196a4872"
+    },
+    "sound/zombie2/footstep3.wav": {
+     "bytes": 20904,
+     "sha256": "b12e9ea9b9478428b886fcaab504856393a57abd8cfdfc5ba5357ad745ee3455"
+    },
+    "sound/zombie2/footstep4.wav": {
+     "bytes": 15796,
+     "sha256": "6f82ac60991e64c8c48a3208a161b46f5b916587cb41863992dc1acb08268889"
+    },
+    "sound/zombie2/footstep5.wav": {
+     "bytes": 17800,
+     "sha256": "ca12f6ade73e5d5ba4ec1bdf680ce25afe3270bb88d702e1493b75619ec088d9"
+    },
+    "sound/zombie2/idle1.wav": {
+     "bytes": 143832,
+     "sha256": "aa203b0beb2db12beb6929fbc3646f7f119d4d31ede66b13af0412d396f7dd6d"
+    },
+    "sound/zombie2/idle2.wav": {
+     "bytes": 277026,
+     "sha256": "9496f3179e875bbb4d7442c252eac0eb2b9ef6d2269d43c141e01242ed2de7ee"
+    },
+    "sound/zombie2/idle3.wav": {
+     "bytes": 234026,
+     "sha256": "4820b03de8cebdee6fe787b5bf60724c17a0e133fdd5451176a202043f730f8e"
+    },
+    "sound/zombie2/idle4.wav": {
+     "bytes": 166352,
+     "sha256": "a515e5dc0e4fe1412a7936df5fab0f57a48c385db4fa357c1a4120671ac99617"
+    },
+    "sound/zombie2/idle5.wav": {
+     "bytes": 62782,
+     "sha256": "c6e4e2f26769400b7ca3b08339af089ba28bc063447d642e10cffffc6e03a485"
+    },
+    "sound/zombie2/idle6.wav": {
+     "bytes": 47274,
+     "sha256": "9ad1ced551cb42764fd88baf26ee09dc72d1852fa2da7405fde370d3e4d69a01"
+    },
+    "sound/zombie2/idle7.wav": {
+     "bytes": 45614,
+     "sha256": "41783a7682d5f8bb91aff8308b8657504cc8f0460b5ca436a5d0fb1c93357c85"
+    },
+    "sound/zombie2/idle8.wav": {
+     "bytes": 73070,
+     "sha256": "8f390d861feda3fb3950b0f33ce3efbfa8eda214533324674ac40b6e227b6975"
+    },
+    "sound/zombie2/punch1.wav": {
+     "bytes": 9218,
+     "sha256": "db6787efe0a0b8df5da690b91afe46a2199911b661fc9de1cfffc00b6bb8c46c"
+    },
+    "sound/zombie2/punch2.wav": {
+     "bytes": 8032,
+     "sha256": "747aabd6237176ae1bc62669cb08c7ec65fb26aa2147f6a3e1ab43f02ace7322"
+    },
+    "sound/zombie2/punch3.wav": {
+     "bytes": 13076,
+     "sha256": "05bb75533252d15983a944263789de5ee51187e518f4544fd1915b57ba726c7e"
+    },
+    "sound/zombie2/punch4.wav": {
+     "bytes": 13198,
+     "sha256": "d07556e7fc774958a6105564a990c51a0dab64fcf9508475617921a0ac5b961c"
+    },
+    "sound/zombie2/sight1.wav": {
+     "bytes": 73234,
+     "sha256": "387534044f10592ca6bc7a96b8e782c7b51de87b907e79a8f410d535e17d37ee"
+    },
+    "sound/zombie2/sight2.wav": {
+     "bytes": 52224,
+     "sha256": "cbc95608d4553d0bae66411d69875210e6fc6d728bd30deb6bbce7aabbacb773"
+    },
+    "sound/zombie2/sight3.wav": {
+     "bytes": 63072,
+     "sha256": "cbbcdb6da59d830a3be66095053259b17a90cc6501728ed1aa50d9524818f99b"
+    }
+   },
    "sha256": "48c9b9b2d663caf40bf3e402096271fa4000698b4a362b8ea156033edf023513",
    "timestamp": "2023-03-04T18:51:18.000Z"
   },
   "alk1.2/pak1.pak": {
    "bytes": 758585407,
+   "files": {
+    "gfx/env/abrut1_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "ffc96027930f197262bf224619f4f793b3f9792ca5ed0ad4a810de0469146bb4"
+    },
+    "gfx/env/abrut1_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "12aba296663e41f26d229f62baf24161fca2d06874944fdd738d452cfed12e22"
+    },
+    "gfx/env/abrut1_ft.tga": {
+     "bytes": 2216388,
+     "sha256": "1ffb28d2baf5809ff3ddd4dac1123e39568af6060f33671cbaa5b9366eb093f1"
+    },
+    "gfx/env/abrut1_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "40610c9f33267572a0979b37d1d01fe214254045adb80cda9303d1c4fd09d77d"
+    },
+    "gfx/env/abrut1_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "26df0c46008298c0570712f5a62fd8208dc3e319bca4bcc849a4fcdd61d9e52c"
+    },
+    "gfx/env/abrut1_up.tga": {
+     "bytes": 3145746,
+     "sha256": "8155aa7bb051a2887d74ff4a94cea6007ecd20fd5dfc33856d43dae7547ee77e"
+    },
+    "gfx/env/adgreenskybk.tga": {
+     "bytes": 1520289,
+     "sha256": "6a7fa2cdc97237658a3f2c73a8a5d879feadf4a31e84fb8585aeba96f3f8fb61"
+    },
+    "gfx/env/adgreenskydn.tga": {
+     "bytes": 1565620,
+     "sha256": "d4fabe617a431169df1bbc37e48404fc34718a1bbf5a1ee45d5b3a0ddda5cc6c"
+    },
+    "gfx/env/adgreenskyft.tga": {
+     "bytes": 1704063,
+     "sha256": "c6cfbbd8b09846eaea719a5e65744cdd4fddced0c277f4584c743f2639882d50"
+    },
+    "gfx/env/adgreenskylf.tga": {
+     "bytes": 1576943,
+     "sha256": "c83f24917ccb67af83602236d03e57096f73b36b7fc64da6206afe989944b4a4"
+    },
+    "gfx/env/adgreenskyrt.tga": {
+     "bytes": 1706213,
+     "sha256": "7b85287d2ce5e4d3a9ce63a560183086e812ceca9232d07eb61f63a24d678e10"
+    },
+    "gfx/env/adgreenskyup.tga": {
+     "bytes": 1798684,
+     "sha256": "703e4449b5b9ff967610dbc81d7e27c089788927d82fdb31267490cfb30ed0e3"
+    },
+    "gfx/env/ares_bk.tga": {
+     "bytes": 481498,
+     "sha256": "907a96e8feaada0ea37d72d99070961883ccdfba8a6b3914dcbb9afc472d18a8"
+    },
+    "gfx/env/ares_dn.tga": {
+     "bytes": 763001,
+     "sha256": "fcc51de57b71899ef969b8380ebd22269aa1e9957bba845413cb4f5394cbe49a"
+    },
+    "gfx/env/ares_ft.tga": {
+     "bytes": 490443,
+     "sha256": "8c109f48b7240f7138353a19017921660ccef0260945ae4a4792ba12c7bf3730"
+    },
+    "gfx/env/ares_lf.tga": {
+     "bytes": 503381,
+     "sha256": "ce0a40f558e72dba7653fe7f693d7e0406afa50aed1fcaac6cda2e857ac55a46"
+    },
+    "gfx/env/ares_rt.tga": {
+     "bytes": 497671,
+     "sha256": "a8033bcdb9db86386582caa29e8aa53946821266da730e17b775869a5458cbbf"
+    },
+    "gfx/env/ares_up.tga": {
+     "bytes": 106191,
+     "sha256": "d0489c8c9606a31fa3d929c1f2c561a162116333edda74f9236203eeadb1a74b"
+    },
+    "gfx/env/bal_goldensun01_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "8dd0cf560f2de9833865050d4fa50c486273ecf2db7168cac9cd2f1166cdb806"
+    },
+    "gfx/env/bal_goldensun01_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "611e10e6e603f6ea3734cd9316b8d3698e25cac289beb48b3e76c13cb4f79066"
+    },
+    "gfx/env/bal_goldensun01_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "612c6bfe6d6a3d395b46e3e2626e1b23a4b3ae92ed167fd0191236671a0bf3cb"
+    },
+    "gfx/env/bal_goldensun01_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "09583bed6543dfa818632ae73c9afd3dea4b0bc9547db6feef0d421dc7f8f243"
+    },
+    "gfx/env/bal_goldensun01_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "95792a9157b001f70c55bd3904ae370db3a9b96201616b4e57dc8cc67c5bc1f3"
+    },
+    "gfx/env/bal_goldensun01_up.tga": {
+     "bytes": 3145772,
+     "sha256": "54697cce6de2daf89657816d2f8f6ceffe2008c329b1e8fc726b82e28d726955"
+    },
+    "gfx/env/boneyardice_bk.tga": {
+     "bytes": 786476,
+     "sha256": "b8a186188b46e6932fa24bbf012b1bd53267aff1f58d2ef0d297e9e1c3631e1a"
+    },
+    "gfx/env/boneyardice_dn.tga": {
+     "bytes": 786476,
+     "sha256": "332fc0e2269b5784bd41b143e574c74b39d45c3a8ebc0d13252a3954b75d49fa"
+    },
+    "gfx/env/boneyardice_ft.tga": {
+     "bytes": 786476,
+     "sha256": "1bc33dc6cdcecff03894561f75aed65b83245b33d00970bdd50bb247a562a076"
+    },
+    "gfx/env/boneyardice_lf.tga": {
+     "bytes": 786476,
+     "sha256": "db1ed21e01bfe16c5c7874e9d51b885ad457ac6272fd99c4ce9df5ce9746bbf0"
+    },
+    "gfx/env/boneyardice_rt.tga": {
+     "bytes": 786476,
+     "sha256": "184b5b29b91c9d615d6ebc9a858295c0a6f42016736e8cf94c8f61e541687a19"
+    },
+    "gfx/env/boneyardice_up.tga": {
+     "bytes": 786476,
+     "sha256": "9ded4acb817419cb76968bfe1a20935c27da1f8b60cc5b7a50229d9e8fd624a3"
+    },
+    "gfx/env/cloudedsunglow_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "bad4922c68c66ceadfbe265a9f1963cd665273884c1c9e8937afbfc06f638c08"
+    },
+    "gfx/env/cloudedsunglow_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "4b4734557cc066c27d4a1ce2ce0cfe4bf77046f6d0faaa33b2ee80f3c97da4cc"
+    },
+    "gfx/env/cloudedsunglow_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "7a7712db51baecce806e5685611bf870adfe4ab52077a91b955f17f052d6edb0"
+    },
+    "gfx/env/cloudedsunglow_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "ee6c2afb805bda6280fbfacbe512487032e5056b54c4a1032f5cd24e281edbbd"
+    },
+    "gfx/env/cloudedsunglow_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "1122c6e10b539b2bba2f906a10e54a116e34e10959714d5e6266a574eaa74ade"
+    },
+    "gfx/env/cloudedsunglow_up.tga": {
+     "bytes": 3145772,
+     "sha256": "38d210fc9dafc0cb375831c139b618020a26603bc6170cea88aa51e35fda738e"
+    },
+    "gfx/env/dragonfire_bk.tga": {
+     "bytes": 584018,
+     "sha256": "e32d3b5a7303c63de491c62bfae48e19f084b1ef57c7b028391284c5c01b0b12"
+    },
+    "gfx/env/dragonfire_dn.tga": {
+     "bytes": 786742,
+     "sha256": "0e642386fbad4dd5b8815f136b360ff103546b4184bc4f225958386f73801cc8"
+    },
+    "gfx/env/dragonfire_ft.tga": {
+     "bytes": 653462,
+     "sha256": "9f358f99ae79a7c92503a5898170d499f0018d9c5502be1c1a28bfbd1542c2a0"
+    },
+    "gfx/env/dragonfire_lf.tga": {
+     "bytes": 577608,
+     "sha256": "fac9bde4880b569bb3adafef41d31a49814c00ab0942b305c4529469c84a730d"
+    },
+    "gfx/env/dragonfire_rt.tga": {
+     "bytes": 741280,
+     "sha256": "20c22dcae9c246bcff175b643b7b319e2ca16ce8c6c532949d4622eee4c1beee"
+    },
+    "gfx/env/dragonfire_up.tga": {
+     "bytes": 255111,
+     "sha256": "d298754cb7034a21e30c6be5d39a92745868300e25ff13deb21d88ce70af7e72"
+    },
+    "gfx/env/jjj2_juzley_bk.tga": {
+     "bytes": 1088614,
+     "sha256": "726ef9578bc96971e47ccf98086a34a12a36749c06397226aa421a4447a92367"
+    },
+    "gfx/env/jjj2_juzley_dn.tga": {
+     "bytes": 1483083,
+     "sha256": "0b6fe84280a0e15953b899c7cb021a16c4930183ac39c318ae637041c95068ff"
+    },
+    "gfx/env/jjj2_juzley_ft.tga": {
+     "bytes": 1495387,
+     "sha256": "92687855846f38d4bc37fadc6b560cf6a993afac9e3889b00bf3f7e9e7dbde95"
+    },
+    "gfx/env/jjj2_juzley_lf.tga": {
+     "bytes": 1484792,
+     "sha256": "dd9ba9305807b6d58f4cc1daa8e45568f6f98aae173e10b2c23b6fa1f48b6d60"
+    },
+    "gfx/env/jjj2_juzley_rt.tga": {
+     "bytes": 1128628,
+     "sha256": "00b47461d896a9a7f10ccd88f55430d9f3fc7cb687a586a3b2207611e9f0ed78"
+    },
+    "gfx/env/jjj2_juzley_up.tga": {
+     "bytes": 1236843,
+     "sha256": "77a44fcee3b460759344a908704f4aff93b0215b0cd40f400fe48c56e57b899e"
+    },
+    "gfx/env/maskonaive2rot_bk.tga": {
+     "bytes": 2900149,
+     "sha256": "6c68487899a78bce552cfce80ed819cfbf44af28a42262becb4c0e2388f88cc7"
+    },
+    "gfx/env/maskonaive2rot_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "d959e3320ad8845422dd62533be215e27e884bc4ee94183e05808790cb1f7059"
+    },
+    "gfx/env/maskonaive2rot_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "9dce6d9479c36acc8450241953a5c108906b27075cb5dec56b78d680ed21a79a"
+    },
+    "gfx/env/maskonaive2rot_lf.tga": {
+     "bytes": 3039291,
+     "sha256": "87c9561cbc02da60b110b5ba5c42b93d0976e7e55c25d4baba819e7c883a4458"
+    },
+    "gfx/env/maskonaive2rot_rt.tga": {
+     "bytes": 3075841,
+     "sha256": "2a5aa6298ee21851e9bb4a7399aa44196203b4aa51b64a9697af00c5e3ead5af"
+    },
+    "gfx/env/maskonaive2rot_up.tga": {
+     "bytes": 3145772,
+     "sha256": "976777e5ca286bba39429c6f1ec6079f476897fc0cecbc49b0805ade1cde3def"
+    },
+    "gfx/env/nebulabk.tga": {
+     "bytes": 786476,
+     "sha256": "9f39d79a62c92fa382872342bab06b300b7db15e337acd2c97ae8f2f629173e6"
+    },
+    "gfx/env/nebuladn.tga": {
+     "bytes": 786476,
+     "sha256": "283ccd8776d60b0f5241033ef905914c58888270bd9cbd4c49115fc6055bffc4"
+    },
+    "gfx/env/nebulaft.tga": {
+     "bytes": 786476,
+     "sha256": "abb8ed2d7664344f053231f1be6311eba3f4319d801ae4218a235c8e6cd4b67d"
+    },
+    "gfx/env/nebulalf.tga": {
+     "bytes": 786476,
+     "sha256": "c5be0fd1bb66ae32f2063811a2fd0dac080aa61838d7588e1ef5552f6c348674"
+    },
+    "gfx/env/nebulart.tga": {
+     "bytes": 786476,
+     "sha256": "f5acb0f7e12b10242ef98d9ffe07bb3bf68016ab68d6f80208f528e689ab5cbc"
+    },
+    "gfx/env/nebulaup.tga": {
+     "bytes": 786476,
+     "sha256": "7a7c9424022598d8d74f68aad4f0b73f0858ae57a5725fd53a860a9f6aae050f"
+    },
+    "gfx/env/oz/ozymandias_bk.tga": {
+     "bytes": 786476,
+     "sha256": "98b447eb25cd2cc53362f7900c4452ce9ceb4901ec263df56a4520a4e39bddae"
+    },
+    "gfx/env/oz/ozymandias_dn.tga": {
+     "bytes": 786971,
+     "sha256": "2354852349f537cc4eb1567f1e7c71b8b5891bbfa03d4350708296cab505abc2"
+    },
+    "gfx/env/oz/ozymandias_ft.tga": {
+     "bytes": 786476,
+     "sha256": "cda9321e88d17c9e8d8ed9295d9047e8b3dabb290e2fe90af05321bf6b05c973"
+    },
+    "gfx/env/oz/ozymandias_lf.tga": {
+     "bytes": 786476,
+     "sha256": "4a8ae725bdea8a0355cdcc09b690d0d556c31240344232bc90fcae71ab605599"
+    },
+    "gfx/env/oz/ozymandias_rt.tga": {
+     "bytes": 786476,
+     "sha256": "16fe8a636eafd70c8d5833ca54b9c4da7f6d4a196f1126c781d79805b87e268d"
+    },
+    "gfx/env/oz/ozymandias_up.tga": {
+     "bytes": 786971,
+     "sha256": "88a59bff68e1ba4cd29e66ff25c88d3cfbbcf2f5089fb82e9addae1edf2c5566"
+    },
+    "gfx/env/sea_sunsetbk.tga": {
+     "bytes": 2707576,
+     "sha256": "7dd0c5d580edd0a13d341d456185fed783464e86a8f15fda51e39ca7801936bc"
+    },
+    "gfx/env/sea_sunsetdn.tga": {
+     "bytes": 1346917,
+     "sha256": "e1e33eb9d7a5c055a4c8adaca55064090cf004b0c8bb85c8c3ca66edeec4432c"
+    },
+    "gfx/env/sea_sunsetft.tga": {
+     "bytes": 2533695,
+     "sha256": "5f3bbf9a6c30962dc0a8c8244627dbbff360bbe88f83e0aabff7b12aef283b11"
+    },
+    "gfx/env/sea_sunsetlf.tga": {
+     "bytes": 2576526,
+     "sha256": "690181ea266310eb0b71b88e351c544880195fc0b84de140998a0f53c978106f"
+    },
+    "gfx/env/sea_sunsetrt.tga": {
+     "bytes": 2642272,
+     "sha256": "4c5ad28b7eda5017dbff54f7568289024382b75e57c3074577b143531fdc2a1b"
+    },
+    "gfx/env/sea_sunsetup.tga": {
+     "bytes": 2931081,
+     "sha256": "71b9456aa141de7883423ad26ff6e6093a44b3b3dbfb943e24806a8332d8ad34"
+    },
+    "gfx/env/yellowozymandias_bk.tga": {
+     "bytes": 786971,
+     "sha256": "8a35fde493dc59cf93bbffe5be0009f4ad55f5d308b89fdcf1bc5eb576e437be"
+    },
+    "gfx/env/yellowozymandias_dn.tga": {
+     "bytes": 786971,
+     "sha256": "74a6578af6cabf5ca00ded9140507df3e2381d2ffa6a3c4248b6c9251d931108"
+    },
+    "gfx/env/yellowozymandias_ft.tga": {
+     "bytes": 786971,
+     "sha256": "c3a5318ec7d8a342fe8d740926d83a1b6c8e13fb138cba854addbe8fdb36ec82"
+    },
+    "gfx/env/yellowozymandias_lf.tga": {
+     "bytes": 786971,
+     "sha256": "b316cf00da8bd01752d04b53c093467490a31d964cf33c1b50eae11e942a3003"
+    },
+    "gfx/env/yellowozymandias_rt.tga": {
+     "bytes": 786971,
+     "sha256": "0eb644c5c01e47da3b70aed3dad8873cb9e39ac4b4893adfa564f7a7a8ad1e5f"
+    },
+    "gfx/env/yellowozymandias_up.tga": {
+     "bytes": 786971,
+     "sha256": "9806eb94899fede2fabaa6474e98ee43c73d83e3df8ace7046e0041a537d0ece"
+    },
+    "maps/alk_bdown.bsp": {
+     "bytes": 12125772,
+     "sha256": "d59113139a7db22dec88de00ba97421d4f172b194c2b6138673219d480d0c2ff"
+    },
+    "maps/alk_bdown.lit": {
+     "bytes": 4607144,
+     "sha256": "37122ae76405cd58cdc5ebb993340f30b3d72745c0e8863c6cae1f93cbaadee2"
+    },
+    "maps/alk_caustic.bsp": {
+     "bytes": 8330748,
+     "sha256": "dd43cb7054c2c498484defdf40b6f11e1c5e78591f2cc9e7d595f8e34bec7e09"
+    },
+    "maps/alk_caustic.lit": {
+     "bytes": 3308936,
+     "sha256": "eeb16fa506825f8c55ca9859f86172d0d0f4a0160e26024a206d1cb2e6074fbb"
+    },
+    "maps/alk_central.bsp": {
+     "bytes": 7778356,
+     "sha256": "06512082a8204f5f2d0dd3842261e4df92d7299111ea64a6eaeca8ef7b8b9187"
+    },
+    "maps/alk_central.lit": {
+     "bytes": 2567540,
+     "sha256": "2032e89bc7fdc4e4129ebbb5a227b8122cd5483de3e0784ae3416c9f3aea2370"
+    },
+    "maps/alk_chaos.bsp": {
+     "bytes": 6837580,
+     "sha256": "05ba9a786ae10aeb2ea874e1a0655a2b74606e77c4356acb769367b1c5b78d4f"
+    },
+    "maps/alk_chaos.lit": {
+     "bytes": 3208025,
+     "sha256": "26fbac410532f43ee5d8ed35af2e190ecb574ce8def90952cc3ab04556531312"
+    },
+    "maps/alk_core.bsp": {
+     "bytes": 10686068,
+     "sha256": "0d8c582c52e4a58736b634fc4c96b150d2582eafc94308e0d5273d9d4cffc987"
+    },
+    "maps/alk_core.lit": {
+     "bytes": 4119020,
+     "sha256": "3de22997cdd13dc1c4e9c709a0d52430f41d4e018d51a33582959efafc8c4122"
+    },
+    "maps/alk_corrupt.bsp": {
+     "bytes": 17491232,
+     "sha256": "b40827ce3fd926ca9a2124c3926b045739012246310277d64dfe3a65ac24aa31"
+    },
+    "maps/alk_corrupt.lit": {
+     "bytes": 10774796,
+     "sha256": "6725e52f0417e8d960ecbb0615d2395bd376a91756f385eddcc944e46921e626"
+    },
+    "maps/alk_dancing.bsp": {
+     "bytes": 22789352,
+     "sha256": "ca71723a8c5771e99053527cb92da6e46388679083d2b9393bed33ce18e45c32"
+    },
+    "maps/alk_dancing.lit": {
+     "bytes": 6922232,
+     "sha256": "22922ba1cd8149c96527b898c5de155817e1273809f08f04bd50f0ccdac5ad6a"
+    },
+    "maps/alk_derelict.bsp": {
+     "bytes": 26280388,
+     "sha256": "7f486b1fa93af6bca71e7bba1587b12f2f73388f529a461ef386cbdc3288c54c"
+    },
+    "maps/alk_derelict.lit": {
+     "bytes": 6077090,
+     "sha256": "4cdd4d29db2c4eb90fa2047f6e901374686cb7bc9908c4d6e627e17079e7f46c"
+    },
+    "maps/alk_dismal.bsp": {
+     "bytes": 73293528,
+     "sha256": "13c8b73ac36aebf2c1c32928e4f9b68593a44e46d88ebecffc1142b990d69421"
+    },
+    "maps/alk_dismal.lit": {
+     "bytes": 17054468,
+     "sha256": "7364069a9409c3c6ac3dd167f5c0776d1e589d8c1c9f996049c3a6a906225095"
+    },
+    "maps/alk_early.bsp": {
+     "bytes": 8672784,
+     "sha256": "fe96cbbc0abbd849553bd5c774fbcc73eaf0f529a27341a92fad226e034a59ab"
+    },
+    "maps/alk_early.lit": {
+     "bytes": 3632024,
+     "sha256": "2cc5d4b513cab33ea46801defec3e179d3e4eba91214d2c4103ee9f4ac547f9c"
+    },
+    "maps/alk_eclipse.bsp": {
+     "bytes": 9689996,
+     "sha256": "da3c681ec4d501d5e8798239cfe73c270e967b3c630ec2c8a121db272275cdbb"
+    },
+    "maps/alk_eclipse.lit": {
+     "bytes": 3096308,
+     "sha256": "a881bc8759c9d75d83754cce814c92298bc55e73867491415ee974c9e919228a"
+    },
+    "maps/alk_geo.bsp": {
+     "bytes": 14348068,
+     "sha256": "5d6c3e0948d21effb27f45c0ac17958cd5da4ba530874ce244a9977fc57a42b5"
+    },
+    "maps/alk_geo.lit": {
+     "bytes": 5907128,
+     "sha256": "e5a462dcc185e193d7df340ad0da2ee53067a84eb891076d634e89f41b67fb76"
+    },
+    "maps/alk_head.bsp": {
+     "bytes": 20184652,
+     "sha256": "864232fffcb4ce8d8eb93af28549105e1aecc4cb56871d8b40b797be436588fb"
+    },
+    "maps/alk_head.lit": {
+     "bytes": 1451084,
+     "sha256": "6fea50c1edca0a2306d9a93c0fb41afc4b5dc6475b1fc2c1e9cce3b590855ee1"
+    },
+    "maps/alk_insanity.bsp": {
+     "bytes": 10038388,
+     "sha256": "c9180929b287336bb5f2dd4bcb62b39680158f6c446fe04a93f242c54346bfbf"
+    },
+    "maps/alk_insanity.lit": {
+     "bytes": 3482768,
+     "sha256": "e48a52802b0ee029ecbeb481a093f9b605ab87c99df3c4bb59a460849494e305"
+    },
+    "maps/alk_mania.bsp": {
+     "bytes": 7788592,
+     "sha256": "da0ead24bbae33a453c63d011e10b321df951ce3fc68d9876c12a0c1305d2884"
+    },
+    "maps/alk_mania.lit": {
+     "bytes": 3258992,
+     "sha256": "90fd1ccc166232ff5adc13f9e7fc2ac6b0ac2027f38a2724ff8e679c28dcebe3"
+    },
+    "maps/alk_pillars.bsp": {
+     "bytes": 28713428,
+     "sha256": "8d27cd8623b8a7c7521df8cb198953c097ef32123f8566f5562d40386542e07e"
+    },
+    "maps/alk_pillars.lit": {
+     "bytes": 10581152,
+     "sha256": "e8026b0fd6d1f28e67e4d2047c0e655a6e263f1752ca42bae8629a9523368176"
+    },
+    "maps/alk_pipes.bsp": {
+     "bytes": 7634876,
+     "sha256": "ce2add954b83c33c6ae640acc9d553498b1e487f753b75c68c611ceaf0a96b4b"
+    },
+    "maps/alk_pipes.lit": {
+     "bytes": 2466314,
+     "sha256": "d56f5b5c38a8a85317afadc6f6039da5afc2e82baaac30644bd85266706e3785"
+    },
+    "maps/alk_sickness.bsp": {
+     "bytes": 2585400,
+     "sha256": "5b2e5bd611b1094a520f043381417f15cbcab4e6b5a5d4c497b9fb694d374aa7"
+    },
+    "maps/alk_sickness.lit": {
+     "bytes": 613136,
+     "sha256": "d4844ca00f4a8e68cc41cef5a6acdf9d8d416986f6a0fb7544aaacddf7942f23"
+    },
+    "maps/alk_tellus.bsp": {
+     "bytes": 21393660,
+     "sha256": "5117d25512385b420dcd5ddad5ff91aaf2753e1ddd5ec8c239a697c8a0ca7755"
+    },
+    "maps/alk_tellus.lit": {
+     "bytes": 7785695,
+     "sha256": "b2f6b2a4210ea9ce1f570a2eaa512ecbc581871167011171593518b9e556216d"
+    },
+    "maps/alk_undead.bsp": {
+     "bytes": 5186480,
+     "sha256": "a7f15c7efd98a9aa1430bb6c69b5b4e6374f4f3d8faf0b023b11657557b28245"
+    },
+    "maps/alk_undead.lit": {
+     "bytes": 1637264,
+     "sha256": "9e451e0b64b5fb313dbb6930262bd8c5847a5d2958397ee9af768b4898b7630f"
+    },
+    "maps/enemytest.bsp": {
+     "bytes": 847236,
+     "sha256": "73b2944ea88aa45e20633008f62ee359262cffe505570ef5936cab0667c09eee"
+    },
+    "maps/start.bsp": {
+     "bytes": 31890060,
+     "sha256": "97a2537d7bdf432f596c587a07499654d2346594afb09f96d2ed4584efcc41b0"
+    },
+    "maps/start.lit": {
+     "bytes": 5468504,
+     "sha256": "ca44b75ffe6669985afb47eac19aa47eb5940742f878f88ff81cbd386012d9a5"
+    },
+    "music/track00.mp3": {
+     "bytes": 10141908,
+     "sha256": "612b384d5efaea97fce9a2684550966177ca42d45ed87c0eebaa0aeb13e2de0f"
+    },
+    "music/track03.mp3": {
+     "bytes": 3334309,
+     "sha256": "ab0d724636cdc8b8eb6ef170fac78b5c55d5b76315b84a4d9d4e14ba134be64c"
+    },
+    "music/track103.ogg": {
+     "bytes": 3010473,
+     "sha256": "19b85ca1f33c5055607d57fb1205200675ed865950f136a10225082ed6299207"
+    },
+    "music/track111.mp3": {
+     "bytes": 6863642,
+     "sha256": "34d6193f5839e3b21c7253b9814b92a2f498429c2591f4415eb9beda17694422"
+    },
+    "music/track113.ogg": {
+     "bytes": 2290360,
+     "sha256": "11a45a41a65a0dcb60a123e351c3116a1034554cfa10546f1b4d94fa54f28f51"
+    },
+    "music/track12.mp3": {
+     "bytes": 6494707,
+     "sha256": "68d8364897fef4f8217beb381412297cd0213d22a30bd93d38fcd8efaf474db3"
+    },
+    "music/track17.mp3": {
+     "bytes": 7796883,
+     "sha256": "a1b2b6a3eec21719400cdfc3e716fc774939a9a0f14b7f4986aa48601b1eeb3d"
+    },
+    "music/track19.mp3": {
+     "bytes": 7178071,
+     "sha256": "2f1824299d0673dc8e50461eaca509408421b90ead4a7e9a24cae26ef9bde365"
+    },
+    "music/track23.mp3": {
+     "bytes": 3058894,
+     "sha256": "e30dfdf84a34aa24506c6019f429bf6187fb6a85b17e5bb16d3589362877a6dd"
+    },
+    "music/track24.mp3": {
+     "bytes": 2108767,
+     "sha256": "f7d7188e767865ec29ee42cf7189781e62f2ac369d530552786f4ba36e7ae382"
+    },
+    "music/track37.mp3": {
+     "bytes": 6798774,
+     "sha256": "95b55a27a06e3841157a78167627ae9a74d68505b784a9955530c9c1f6e0f557"
+    },
+    "music/track38.mp3": {
+     "bytes": 6953831,
+     "sha256": "7edad95cfb1657a6acfc4db2f901704e19dfc337038675eb844bfb0fd905cd13"
+    },
+    "music/track39.mp3": {
+     "bytes": 7103878,
+     "sha256": "84d4213e4e0ab447e47594a62271ce207ffd21123123496059567802fa97850d"
+    },
+    "music/track40.mp3": {
+     "bytes": 2387008,
+     "sha256": "9976a22f3429d45e2ed018d1c7dcc6eda968b95631ebc602524503ce3da048b2"
+    },
+    "music/track44.mp3": {
+     "bytes": 4594207,
+     "sha256": "3046432076ac4fbe4e695a2a0d5f0b153aa787554e289e89370e053e867b9aa3"
+    },
+    "music/track51.mp3": {
+     "bytes": 6497925,
+     "sha256": "dcbaa3243af62109b162e775b6f8877650c50abc933843712ee833030bc1fa13"
+    },
+    "music/track66.ogg": {
+     "bytes": 4373164,
+     "sha256": "aace44d6f7f578d6477a5bc57dcbf8c3fbf42ac3a758e09ed99931a6fee05de8"
+    },
+    "music/track67.ogg": {
+     "bytes": 5395475,
+     "sha256": "40c8c4f3dae65b7e2477d65fc49b607cc85375b951c07365480c7f0f2c2695aa"
+    },
+    "music/track68.mp3": {
+     "bytes": 7361764,
+     "sha256": "0c138ae9931860ee5dcfb18cb5975520abf6c67546240cb545b67f714b2d0592"
+    },
+    "music/track69.mp3": {
+     "bytes": 3237010,
+     "sha256": "ee32915337042fff0ed82d4e5e4236885562e8942c7c3378a7a365387b32e268"
+    },
+    "music/track77.mp3": {
+     "bytes": 7280262,
+     "sha256": "386667e944a74e20a822dc565b4da93858c447ed94c2c7bb15a336295d8ffa3a"
+    },
+    "music/track87.mp3": {
+     "bytes": 7425712,
+     "sha256": "1677b2b1c065d123b4bdfc331a0c82818b60a02190e814742725b72a37726c81"
+    },
+    "music/track90.mp3": {
+     "bytes": 6568059,
+     "sha256": "d9cfed0338fa83b10cf4ad269a18a2433d6a476968ae48d7c201319fe3a5c3e9"
+    },
+    "music/track94.ogg": {
+     "bytes": 2524483,
+     "sha256": "de3a021356714e7e5e37c70b19291740ec30826ec41ed151e5ca1d2449df8d31"
+    },
+    "progs/bloodshot/energy_beam.mdl": {
+     "bytes": 11244,
+     "sha256": "f318ce49a12ef1cabf5ce0eedf1cd3319e11a15fd1aeca1e1ddbde5d591a8e22"
+    },
+    "progs/bloodshot/turbine.mdl": {
+     "bytes": 48692,
+     "sha256": "68a5c5860542617cd93541509e0d7fe17d18eb3e9453e217566909daea5ddfe1"
+    },
+    "progs/dude3.mdl": {
+     "bytes": 443076,
+     "sha256": "ec94e7db505d0678c8a56a3bad0566af8bcd33c144dc391c4325bba1efc75e05"
+    },
+    "progs/g_axe_alk2.mdl": {
+     "bytes": 50460,
+     "sha256": "e448b2a7540ba959453592b2472d0ae498142a77242c91fd5991ca23a7973f4a"
+    },
+    "progs/jjj2_juzley/17mfromitz.mdl": {
+     "bytes": 7124,
+     "sha256": "2e4258661f1fe3271169bf8def66e9fe206ce52fc46e5e8f310214522c9985f9"
+    },
+    "progs/key_base.mdl": {
+     "bytes": 54436,
+     "sha256": "fb25488fa2fc16c7c4df260a20fd905a821607a675fd0907a6e65f9d534fd367"
+    },
+    "progs/misc_barrel.mdl": {
+     "bytes": 43684,
+     "sha256": "8382db232b9a8a6cf6f11009bd8d1806b52ee840c520cea72cfbf5b57c240f26"
+    },
+    "progs/misc_barrel2.mdl": {
+     "bytes": 130972,
+     "sha256": "cc8ebfd0da975358077a6933cdcb4f7ab627ad02c7bd8612f05eb1c873926c23"
+    },
+    "progs/misc_barrelq2.mdl": {
+     "bytes": 60380,
+     "sha256": "04c87c0210d772c53ffc134a5a2a065394dc32f5b36b30c5f24d927bacc24633"
+    },
+    "progs/misc_bigflag.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/misc_cable.mdl": {
+     "bytes": 57780,
+     "sha256": "bed2cca38ef4cbefa9e645eb5e9ffadffac6ebb4f2ac5f6da4bb8f354de22a48"
+    },
+    "progs/misc_cables.mdl": {
+     "bytes": 433607,
+     "sha256": "03c41af692903bb854cc5c05c0a8a665f312a04955737ecbac1a65a4113f6d50"
+    },
+    "progs/misc_chain.mdl": {
+     "bytes": 231184,
+     "sha256": "845fc3117f7d9860f2d0aa4a398103a13f327516144a96db508189ae1be5788c"
+    },
+    "progs/misc_charger.mdl": {
+     "bytes": 117672,
+     "sha256": "a64a62cd67894222e1b2ed25332db70961c18d0cbdffe32b17f0dbac93bb2ceb"
+    },
+    "progs/misc_corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "0287c3e7886bd2d6d1cbb504529d9e11038d0f8232ee624528eb0ccb78733c53"
+    },
+    "progs/misc_corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "22f82f29d0a88af204f7b97eef887b963bd940e7277b6f5cef5e6f3610f2ea51"
+    },
+    "progs/misc_corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "41e90f1a84e9779eb12541d923ab0a66e69deef3a9dbc82259ab84cb71b68dcc"
+    },
+    "progs/misc_deadplayer.mdl": {
+     "bytes": 562960,
+     "sha256": "83bbcf4cb5858aa9ac03323b461b3e3b09a28f56e212645472219d7d0b0979d8"
+    },
+    "progs/misc_extngshr.mdl": {
+     "bytes": 25732,
+     "sha256": "fc8dec001f22c4666f6c5ca65e8aba18d5b22ed8aabbf0534d03913e821e3120"
+    },
+    "progs/misc_flame_big.mdl": {
+     "bytes": 244895,
+     "sha256": "09adba1308cdf22d2f07e226cb13a35e51f4d54866f84f41e2074dc7a40371d5"
+    },
+    "progs/misc_flame_med.mdl": {
+     "bytes": 175400,
+     "sha256": "31c94bc48e6c6d6bc31bd14b8e257c4e74d45aaec3a4d5d5bf83587a08ac7c00"
+    },
+    "progs/misc_gen1.mdl": {
+     "bytes": 256884,
+     "sha256": "7a9124bf7628dfcfc1c43ab6624bd8cef4ac5ecbdd8a00a00e8f957f0d177ec5"
+    },
+    "progs/misc_gen2.mdl": {
+     "bytes": 74708,
+     "sha256": "c93a3f7fbda97841c0c9c7c9b2603d9e388390ab30861c4b1553285985f761a2"
+    },
+    "progs/misc_gen3.mdl": {
+     "bytes": 472728,
+     "sha256": "29032f4dcf60216906ef601d5a6bf20dba71ed5b7ff8260e7f61159b6b8ea1e0"
+    },
+    "progs/misc_hangman.mdl": {
+     "bytes": 96500,
+     "sha256": "feb2473a29e56ee278e4cdc9676306fdf3aa609b527ea4aff23bb86e3900a2d3"
+    },
+    "progs/misc_heating.mdl": {
+     "bytes": 243876,
+     "sha256": "a6ab88ce55f16b670b9ba8e42e96c9ea49acc71f124ce20c0de5fc2c0232e2f0"
+    },
+    "progs/misc_helijet.mdl": {
+     "bytes": 102656,
+     "sha256": "9dc737185928f080758e5a662ea8fd189fcad1aed4fe4547f76d73983bec9c72"
+    },
+    "progs/misc_helijet_pilot.mdl": {
+     "bytes": 105556,
+     "sha256": "8ee41a7ac244289b007921b70fd34f322b4451172f35b0c5b33400064d1c3a2f"
+    },
+    "progs/misc_hummer.mdl": {
+     "bytes": 180541,
+     "sha256": "c41208ecff2f7ea0b037f378aad5fa309af5d946eae009ace2478a294aea9b45"
+    },
+    "progs/misc_levels.mdl": {
+     "bytes": 35732,
+     "sha256": "7cf9a4c1e556e60dd4e593cad4a2be0b45bea8893d9b5232ecc7febca4bbf5fe"
+    },
+    "progs/misc_lightpod.mdl": {
+     "bytes": 81780,
+     "sha256": "e16ac3a669ace065c4cd1806ea0a21a59510d936a3a4c9d74c3ef2ef56e9d4f3"
+    },
+    "progs/misc_lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/misc_lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/misc_metal.mdl": {
+     "bytes": 246933,
+     "sha256": "07c0bb9ff1aa1639a62e5a84fca28d48c0fc738f4d22f8e3d8a5a029790d870e"
+    },
+    "progs/misc_oscill.mdl": {
+     "bytes": 50660,
+     "sha256": "cdc96265a646f9e9fb4c1717fa90edb13e42130fadc4dc774b60aeb94b89eac4"
+    },
+    "progs/misc_pallet.mdl": {
+     "bytes": 509927,
+     "sha256": "1b9c50111cedb48559424870b46a3d19cb1ac5b43ef3f165fbe928a3f7e90883"
+    },
+    "progs/misc_player_legs.mdl": {
+     "bytes": 76918,
+     "sha256": "8e54ec3002d5b0f70408f17941087e595cb20933a08c40eb934cb25e8804d5a0"
+    },
+    "progs/misc_puddle.mdl": {
+     "bytes": 38164,
+     "sha256": "ddb936aa0192e06767d1c1d1407c6ca0145011ebf985c7cc77a49796416cf119"
+    },
+    "progs/misc_radar128.mdl": {
+     "bytes": 19492,
+     "sha256": "ef004e28e51e3227121a92432375531fca26d1e44894696f3d2a950fa65aef28"
+    },
+    "progs/misc_radar64.mdl": {
+     "bytes": 19492,
+     "sha256": "b9468012707ad484c1292cbe984c54811cb8fa43542e68e18a52ef93cb37d52a"
+    },
+    "progs/misc_radar96.mdl": {
+     "bytes": 19492,
+     "sha256": "6239d117263f49b79a2a66e62f2dbd6a7f0cd15ce412c1939dd69b4a1d8fce78"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "0bbaa667b0e785aab38a90f131985e74fa04cca4c7ae869e612e4f765aa1350c"
+    },
+    "progs/misc_seaweed.mdl": {
+     "bytes": 16100,
+     "sha256": "dfbd38a439d392870c7c4c7ebea4475827b716004ca47bfa7f13b47daf07d774"
+    },
+    "progs/misc_seaweed2.mdl": {
+     "bytes": 95281,
+     "sha256": "65773f37e26d41dd72ec1cf9849c663c1475923cb77d0f4c599bc3301368373f"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 31792,
+     "sha256": "8d39b97460c9967ee36b33ea1ef1e92e89277fc410b44f054c5e06b8dc8a079c"
+    },
+    "progs/misc_starfield.mdl": {
+     "bytes": 23548,
+     "sha256": "5b3563017939382680228e933a2a87d3edb030e75e65c51fe42c4a6889e42e15"
+    },
+    "progs/misc_stool.mdl": {
+     "bytes": 85612,
+     "sha256": "12914ff8acc41ef1656aef291edef6d3b0975e994808b8e4e921edcc4927e517"
+    },
+    "progs/misc_tape.mdl": {
+     "bytes": 9240,
+     "sha256": "2b6a08ca3be4dd7a669e5b6d1585276759e1fb0edbe0691dd7ecbc7e41f0b189"
+    },
+    "progs/misc_turbine.mdl": {
+     "bytes": 53615,
+     "sha256": "57cf73dbf14b5b22795033f5b597b30b978aeb6ee037e09648d0cebd029f987e"
+    },
+    "progs/misc_victim.mdl": {
+     "bytes": 1432944,
+     "sha256": "c5d2a99ba39e82bef21cdff5f682b6b80d601f9b54fe0d58d94aae3544b5303b"
+    },
+    "progs/misc_workbench.mdl": {
+     "bytes": 87092,
+     "sha256": "89cb978aaabc4372bacc88ce577c9aefa2a5a4597aada45aa499861150bfe07e"
+    },
+    "progs/nsoldier.mdl": {
+     "bytes": 146288,
+     "sha256": "ce36f7893cd00de08f200717a333ddc3963e3ad126ec16e442def19c79717ce2"
+    },
+    "progs/nsoldier_nogun.mdl": {
+     "bytes": 563108,
+     "sha256": "cfc3c7ba56010c720607f7d81aae51f0429bfa229f20ac8fdc8ee011eea8c498"
+    },
+    "sound/alk_emt/ac1.wav": {
+     "bytes": 342374,
+     "sha256": "73752cd2b6407cb48ac651ba06b1b44b3bce2dc2187439f56fa12b947f4414b5"
+    },
+    "sound/alk_emt/bossrumble.wav": {
+     "bytes": 1095644,
+     "sha256": "592d71188f710d27bf5e4f84b987aed8be2aba11541536890996242f04724bb7"
+    },
+    "sound/alk_emt/bubblinglava.wav": {
+     "bytes": 596204,
+     "sha256": "ef18c72355b574f305e48e92566bd33719c766123d719e65b09ac89c258cf856"
+    },
+    "sound/alk_emt/hangar1.wav": {
+     "bytes": 714082,
+     "sha256": "15f0c87013e445065066cd68cec281331fbcd6501b7bd3f825ef908d85518f97"
+    },
+    "sound/alk_emt/klaxon1.wav": {
+     "bytes": 131116,
+     "sha256": "82a4ac7e620cc51bd63d20dfc256212fa9cabf384cd7431684402525ae5d3b43"
+    },
+    "sound/alk_emt/luggagescanner.wav": {
+     "bytes": 221032,
+     "sha256": "44c66ccc872a675cebe9b84ae16e2005005e3fbee36f0eacf3639a88e4168048"
+    },
+    "sound/alk_emt/movingplat.wav": {
+     "bytes": 81326,
+     "sha256": "2caad748f987b13e2ae9c2fefa62ad34a350ce11d77add0b4ee85e0a44b4d8c0"
+    },
+    "sound/alk_emt/smasher.wav": {
+     "bytes": 124588,
+     "sha256": "0609c379a0aa35df478e90942a000b8a8fbe170a26ce695e83acc421b7da4865"
+    },
+    "sound/alk_grome/alarm_et.wav": {
+     "bytes": 438392,
+     "sha256": "0d33440f3daf79f42f888a18e2eeaaeba4862b7968d734b58754e237020a9bf3"
+    },
+    "sound/alk_grome/alarm_et2.wav": {
+     "bytes": 876644,
+     "sha256": "35f1ff6583478db5d0173a51b5274285815b841249384e5fde277b3b20e1eb5c"
+    },
+    "sound/alk_grome/aramb_windup.wav": {
+     "bytes": 118068,
+     "sha256": "00184ed2487eb79fce6a41833b0c3deb0c12db4bf75cd30680eda900ad42e1c3"
+    },
+    "sound/alk_grome/arpump1.wav": {
+     "bytes": 18262,
+     "sha256": "11ae2c08c7d5f7f777eade75770a1623386d0e0096a19076fff13e9ddec6318c"
+    },
+    "sound/alk_grome/base_ambientloop1.wav": {
+     "bytes": 3480328,
+     "sha256": "e4970d2e679e7ddfdb6da696ceabb9d2ab0d6005d17ef2e56dd61eb6370f58d2"
+    },
+    "sound/alk_grome/basetry.wav": {
+     "bytes": 10518,
+     "sha256": "9f180f7bb823b1e7138fbe6f2d6acc9e9055a736223535c8dcb0f3e2e32a3c0f"
+    },
+    "sound/alk_grome/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/alk_grome/default_stop_hl2.wav": {
+     "bytes": 98836,
+     "sha256": "3dfe2f3c4e1c450ce6bbbd401a0d22f9829ffc39da7883f69019484d07298f8c"
+    },
+    "sound/alk_grome/demonwind.wav": {
+     "bytes": 357574,
+     "sha256": "8bca3e8f399d9b6e2b8a7c4e0a21c462e8a5bb1ff5044fc4e0255d6081cecbec"
+    },
+    "sound/alk_grome/drone.wav": {
+     "bytes": 30902,
+     "sha256": "81993d96ab337f78c2778cecffe4767605fed210e0ac2303a46ac898979eea13"
+    },
+    "sound/alk_grome/drone6.wav": {
+     "bytes": 18522,
+     "sha256": "dccccac054680ac00f16dd87a2f303bd9653578736ba18a56311fe55256c1176"
+    },
+    "sound/alk_grome/keyboard.wav": {
+     "bytes": 66850,
+     "sha256": "2dddfabc3ca827a9f908a00cdc6b35784b18ca1912c86337dbdd39900bbf686a"
+    },
+    "sound/alk_grome/ma1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/alk_grome/power_on.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/alk_grome/power_shutdown.wav": {
+     "bytes": 1118464,
+     "sha256": "e0ab1a0f67a2d37a525f7a73e8ee8c3a26f746e027fa1501f6648f5586ea2048"
+    },
+    "sound/alk_grome/rumble2loop.wav": {
+     "bytes": 99166,
+     "sha256": "d2247f41caa1b7540e883c7f6bd8abb59c05ef9269d5aa963469e903940a5915"
+    },
+    "sound/alk_grome/suck1.wav": {
+     "bytes": 110392,
+     "sha256": "99fec7fb4632a06fe033df49b65eefc1426dce1e4d23adc7d8788d4e9065280c"
+    },
+    "sound/alk_grome/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/alk_grome/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/alk_gw/choppa.wav": {
+     "bytes": 82726,
+     "sha256": "caf182035ddb397a69755780032ff46e39b34111e13015dad38b0f3015ca96c1"
+    },
+    "sound/alk_gw/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/alk_gw/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/alk_juz/dronehum2.wav": {
+     "bytes": 183654,
+     "sha256": "03545ae0f88b788e69e09c0aae2cccfa727a2609ef224c7d1d3451f0e6172709"
+    },
+    "sound/alk_juz/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/alk_juz/flyby1.wav": {
+     "bytes": 260406,
+     "sha256": "3fb54dce36de4164173ff68f2eed3a5b24a81c784b7d0758c29ba27620c11378"
+    },
+    "sound/alk_juz/radiostatic1.wav": {
+     "bytes": 102196,
+     "sha256": "3f1a71599802c66c63e53f5bafc8b660734fd8b623b41eb1870f26adf96a1146"
+    },
+    "sound/alk_mh/alarm.wav": {
+     "bytes": 4198,
+     "sha256": "79094546244d3b2672134d40970512cbc9c260ba6501939f90623dcfa7836042"
+    },
+    "sound/alk_mh/cranemove.wav": {
+     "bytes": 7710,
+     "sha256": "64cac7908811572bda114bcfa66d8b1470b894df1a5c6074f246ce5477666bc3"
+    },
+    "sound/alk_mh/cranestop.wav": {
+     "bytes": 10278,
+     "sha256": "92ecc69bba538b1f624cdce0c0e45c663c6e070320546123519bc3622b0a0196"
+    },
+    "sound/alk_mh/drone.wav": {
+     "bytes": 34230,
+     "sha256": "042fd60360482b1aed17df4ae5a5bfe096282ddc173b4f47e82384c4c5ed1782"
+    },
+    "sound/alk_mh/emove.wav": {
+     "bytes": 33182,
+     "sha256": "0f9de23e794e7fcff8dcfd0397c92404d51dd0e299d0b909ef16afcc4615b00e"
+    },
+    "sound/alk_mh/industrial.wav": {
+     "bytes": 32030,
+     "sha256": "c994aced4e1a944e04653e6d3a3f284d11f9974528dda2f0918a3b62791d1f64"
+    },
+    "sound/alk_mh/rotor.wav": {
+     "bytes": 84212,
+     "sha256": "6cd09e076bca0871c75e13a9c73f9d3b172c3d36e8ed979bf680b035c3b724fd"
+    },
+    "sound/alk_zigi/amb16test.wav": {
+     "bytes": 184128,
+     "sha256": "5c029ad6bc9c66c2f6d4c45a43b1bc15cf11d1b12a68276711e60865e4fea814"
+    },
+    "sound/alk_zigi/forcefield.wav": {
+     "bytes": 67928,
+     "sha256": "feb389e023228507b3c8e1718a57ebabec36af1f474d051b9ee950c4c6a806f4"
+    },
+    "sound/alk_zigi/huuto08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/alk_zigi/huuto24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/alk_zigi/kone.wav": {
+     "bytes": 190760,
+     "sha256": "59197f823b479c66c41163d82fed6dc13a715aef429b5e551ba80ca6f7c229fb"
+    },
+    "sound/alk_zigi/laf1.wav": {
+     "bytes": 126074,
+     "sha256": "a320badd6eb1189349ca484ae7f0dd005fb3f86be89618f22fcaca61f46e9b55"
+    },
+    "sound/alk_zigi/rumble2.wav": {
+     "bytes": 66200,
+     "sha256": "b2ca38e13253361aa1780c05269652c4aed4094f274948e865be6849d4a3b908"
+    },
+    "sound/alk_zigi/rumble7.wav": {
+     "bytes": 639494,
+     "sha256": "e19851eeca4d295a1e42cfece3fcced40779f14f73a4e923e3768f2cb0553a76"
+    },
+    "sound/alk_zigi/tuuletin.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/alk_zigi/valo.wav": {
+     "bytes": 26356,
+     "sha256": "c8203b1d67aa1e2458a5ac8e3edb9e7b79498b04251abd01c33356e65ad1681f"
+    },
+    "sound/alk_zigi/vent1.wav": {
+     "bytes": 153876,
+     "sha256": "0ac26f5ec7c080562c73ca3dae0fe0a705136912b641919f91f3f701875a76bb"
+    },
+    "sound/alk_zigi/ventsu.wav": {
+     "bytes": 32876,
+     "sha256": "1e0f99ffadead8460a7a4bed1c6b2c16cddd70050e1524e9cdaf6724a9dc81b5"
+    },
+    "sound/ambient/aramb1.wav": {
+     "bytes": 44476,
+     "sha256": "4c6440672b87575dd8ac5a267621881b9c70e48722cf9a4aa75a4a9b384fea5b"
+    },
+    "sound/ambient/arcohum1.wav": {
+     "bytes": 20418,
+     "sha256": "3b42cb1b62f62acabdc8ef8612ab4343b71b165c3525552701ef769f90020960"
+    },
+    "sound/ambient/arhum1.wav": {
+     "bytes": 20740,
+     "sha256": "e374f3d90564808e019abe09f4464b704512cf85ff0f3b4bb3c955b4153184e3"
+    },
+    "sound/ambient/arpump1.wav": {
+     "bytes": 18262,
+     "sha256": "11ae2c08c7d5f7f777eade75770a1623386d0e0096a19076fff13e9ddec6318c"
+    },
+    "sound/ambient/arwind.wav": {
+     "bytes": 30408,
+     "sha256": "34248569bb7ab66f5e1d874e15c7a91d89fd2b70d27e5521456b2589581fe1e6"
+    },
+    "sound/ambient/chatter.wav": {
+     "bytes": 190760,
+     "sha256": "59197f823b479c66c41163d82fed6dc13a715aef429b5e551ba80ca6f7c229fb"
+    },
+    "sound/ambient/comp.wav": {
+     "bytes": 12164,
+     "sha256": "ab8e3b13981bb432cca44ad4b7467734f52d01927018e72c99e7c4d052dc7874"
+    },
+    "sound/ambient/conveyor1.wav": {
+     "bytes": 348058,
+     "sha256": "ca68f9d44a06155fec7a886675c825b247d2b21996e92daeb76d9f47db2cf2a7"
+    },
+    "sound/ambient/crickets.wav": {
+     "bytes": 12236,
+     "sha256": "d5cf6e56884a8e43469408d4788ec6e573167901586df259a938cd088c998ef9"
+    },
+    "sound/ambient/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambient/drone.wav": {
+     "bytes": 30902,
+     "sha256": "81993d96ab337f78c2778cecffe4767605fed210e0ac2303a46ac898979eea13"
+    },
+    "sound/ambient/dronehum2.wav": {
+     "bytes": 183654,
+     "sha256": "03545ae0f88b788e69e09c0aae2cccfa727a2609ef224c7d1d3451f0e6172709"
+    },
+    "sound/ambient/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/ambient/dronesewer1.wav": {
+     "bytes": 345280,
+     "sha256": "ee8cd803398a007f2f3b412dd2401098586e1d38f558daa748ea4e86f10267ad"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/farambient_l.wav": {
+     "bytes": 330958,
+     "sha256": "4c65d4dd9c8111a0b13d625a86a30f1a6ff97b0acfb03423009fc57100981547"
+    },
+    "sound/ambient/farambient_r.wav": {
+     "bytes": 330890,
+     "sha256": "a843e4b6958b198fa7de5f54fc8902040c7257f151df89f23dadae77920da960"
+    },
+    "sound/ambient/hum02.wav": {
+     "bytes": 37836,
+     "sha256": "8b2ee1b91fa663b6111de9251011142475831ece70ee091022b800b715f1bfa2"
+    },
+    "sound/ambient/industrialbuzz.wav": {
+     "bytes": 57112,
+     "sha256": "ac872a81a917704e4e418d7f83f2b7cdb35d3f35671e11261634727dfb7cfca9"
+    },
+    "sound/ambient/intake.wav": {
+     "bytes": 25682,
+     "sha256": "e6d13169ce4680dd83903473897fd6e7ce1e51fab00c6df2127ea993321c05b0"
+    },
+    "sound/ambient/lava1.wav": {
+     "bytes": 926316,
+     "sha256": "41964be60ef167936d0ef74f47fdfa3c2b147f7ec1f5f26fbb312ee71be3a6bd"
+    },
+    "sound/ambient/lonoise.wav": {
+     "bytes": 32876,
+     "sha256": "1e0f99ffadead8460a7a4bed1c6b2c16cddd70050e1524e9cdaf6724a9dc81b5"
+    },
+    "sound/ambient/machine_loop1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/ambient/machine_loop2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambient/motor1.wav": {
+     "bytes": 52340,
+     "sha256": "c48511a37143e9ed50ae7c1d1f28235b007762949d3d18549fc545cc670c0a24"
+    },
+    "sound/ambient/motor2.wav": {
+     "bytes": 52014,
+     "sha256": "7f36cda5c01aea4e6b356ae4d0b31b68ca15d7606eefd30f4739a64fc4e86e6c"
+    },
+    "sound/ambient/rain.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/bal/markiejumppad.wav": {
+     "bytes": 20045,
+     "sha256": "6b2743edcbc6325a93aec78c15d209829d92d75fc9535f88fafc437380bc6b57"
+    },
+    "sound/bloodshot/bomb.wav": {
+     "bytes": 141228,
+     "sha256": "6fa171d6bbb3dc07f9c0fb422ceb2e3e20934e9a0465589717dfdc14c92b016c"
+    },
+    "sound/bloodshot/doormv1.wav": {
+     "bytes": 43818,
+     "sha256": "729ad30245f7b9036d197f742c067c741ab4513992322f1e844a8bc5411d54d6"
+    },
+    "sound/bloodshot/drclos4.wav": {
+     "bytes": 5582,
+     "sha256": "99c4e2100335a5c217d370277dd218602a2419e12afc6f2fd9974ae81b7cc9ca"
+    },
+    "sound/bloodshot/error.wav": {
+     "bytes": 6516,
+     "sha256": "316c201dd7a44b79f6bf07db8d03003bc07d61b754a8d940c733e3dca58fcbf3"
+    },
+    "sound/bloodshot/fan4.wav": {
+     "bytes": 19502,
+     "sha256": "5bde811e4ffba54790ec5f4d4fbc922c0d2bd5f7b0b229d21233f83c39b80e5c"
+    },
+    "sound/bloodshot/hydro2.wav": {
+     "bytes": 18420,
+     "sha256": "1d3a8e3151c52582d9f1032a6756dbd8d62f0974f3b95386265bdbc426a36eef"
+    },
+    "sound/bloodshot/liquid_bubble.wav": {
+     "bytes": 129688,
+     "sha256": "838ec1e72b2c433408a342a48518987edcb2124932eeb477d59653540b13d6ea"
+    },
+    "sound/bloodshot/liquid_burnshort.wav": {
+     "bytes": 89464,
+     "sha256": "4ea16997389f1aa35549869a338f2093f40d14df030c381a7659cc7e3cbf8bfc"
+    },
+    "sound/bloodshot/plat1y.wav": {
+     "bytes": 38690,
+     "sha256": "2c691a78650dec47a2ea0e3ef697a1af06ed86019e0756b7df3b9ca9d4135dbc"
+    },
+    "sound/bloodshot/plat2y.wav": {
+     "bytes": 11602,
+     "sha256": "0e8585808da24f28484f56a28c89a0e5938fe4044d5a8d796ed6fc3cfa7f79ff"
+    },
+    "sound/bloodshot/power_switch.wav": {
+     "bytes": 66382,
+     "sha256": "5c006bb7315e6eb6d2367ae30a78f0abec8ae2a1e2b6a2c9af88354962b0f33f"
+    },
+    "sound/bloodshot/reactor.wav": {
+     "bytes": 204254,
+     "sha256": "2fb09312579dbb219eea83d2320a0ab8bf8b8aaa93a449a05a9d60c6e393ecbd"
+    },
+    "sound/bloodshot/slimepump.wav": {
+     "bytes": 92716,
+     "sha256": "248e6507a0ef5aa3dd166df7aa2e6254cb4fbfff6f4f1eca7fca4738e9f05e10"
+    },
+    "sound/bloodshot/truck1.wav": {
+     "bytes": 6908,
+     "sha256": "2daf8d56e43cccae533efc5b8c1dfaa14eb3327cb8e5d4ab542fdbc7683aa1d1"
+    },
+    "sound/bloodshot/truck_drive.wav": {
+     "bytes": 1245432,
+     "sha256": "9516a14cd76e18dfe12d8766015344bb810961e0e12747674efde43c9f607c37"
+    },
+    "sound/bmfbr/alarm.wav": {
+     "bytes": 21058,
+     "sha256": "539cb807f9fdd4c93c24ad09f57249d600c109dfdd78a7f90f294ffb4c7e8b6b"
+    },
+    "sound/bmfbr/barmusic.wav": {
+     "bytes": 77898,
+     "sha256": "af57a7b9b00323f6395f9f81af4fb5971657ad764665552036b057442c7c18e7"
+    },
+    "sound/bmfbr/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/bmfbr/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/bmfbr/dronesewer1.wav": {
+     "bytes": 345280,
+     "sha256": "ee8cd803398a007f2f3b412dd2401098586e1d38f558daa748ea4e86f10267ad"
+    },
+    "sound/bmfbr/farambient_l.wav": {
+     "bytes": 330958,
+     "sha256": "4c65d4dd9c8111a0b13d625a86a30f1a6ff97b0acfb03423009fc57100981547"
+    },
+    "sound/bmfbr/farambient_r.wav": {
+     "bytes": 330890,
+     "sha256": "a843e4b6958b198fa7de5f54fc8902040c7257f151df89f23dadae77920da960"
+    },
+    "sound/bmfbr/industrialbuzz.wav": {
+     "bytes": 57112,
+     "sha256": "ac872a81a917704e4e418d7f83f2b7cdb35d3f35671e11261634727dfb7cfca9"
+    },
+    "sound/bmfbr/machine_loop1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/bmfbr/machine_loop2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/bmfbr/rain1_nl.wav": {
+     "bytes": 154490,
+     "sha256": "ab83161b01f9299cad8af7142f688c4f2f36e16e973eb42fa6faa13a7a6cc51d"
+    },
+    "sound/bmfbr/reactor1.wav": {
+     "bytes": 207486,
+     "sha256": "71b3bb44e623638db55b899c9847ca8c05d5c9c16c0897c28044b64c8060dc25"
+    },
+    "sound/bmfbr/rumblelong.wav": {
+     "bytes": 105990,
+     "sha256": "46728daf18b142575d50049188030a153c0e3e994dc83ea375c43ba6da171b3c"
+    },
+    "sound/bmfbr/rumbleshort.wav": {
+     "bytes": 33500,
+     "sha256": "6b389aa1afcebdd8838bb0e900c2bbd32e409a7cfcc19553e1d007d89404310c"
+    },
+    "sound/jjj2_juzley/fromitz.wav": {
+     "bytes": 154430,
+     "sha256": "58e76ad48ab3de2cfb69ba21c31d993603b83d896d6de187a2d215587091f347"
+    },
+    "sound/jjj2_juzley/rumbleoff.wav": {
+     "bytes": 105990,
+     "sha256": "46728daf18b142575d50049188030a153c0e3e994dc83ea375c43ba6da171b3c"
+    },
+    "sound/sj2_sze/watertunnel2_l.wav": {
+     "bytes": 290116,
+     "sha256": "fd2859dc8fe2fbf6a9bbef3cb213312b95fb8bdc8c383d91cc15ece6cf16776d"
+    },
+    "sound/sj2_sze/watertunnel2_r.wav": {
+     "bytes": 290116,
+     "sha256": "44922a8c38fa663fae52cd3bf0f8c496a91b3e8fd46f6b63286cdf7816968ea4"
+    }
+   },
    "sha256": "a00fce9109795ecc74b65a56b120bd6ca80a61031f89c5b985792cd8825775d5",
    "timestamp": "2023-03-04T19:49:46.000Z"
   }

--- a/json/by-sha256/5d/5d3c46d81f79d079ec6bde27aeb2b0f0dc5412dd64735e831c530c57eaa65b66.json
+++ b/json/by-sha256/5d/5d3c46d81f79d079ec6bde27aeb2b0f0dc5412dd64735e831c530c57eaa65b66.json
@@ -12,6 +12,508 @@
  "files": {
   "PAK0.PAK": {
    "bytes": 25138967,
+   "files": {
+    "gfx.wad": {
+     "bytes": 116836,
+     "sha256": "ebe8807ee56f282afabd53ac885d71b66a5d07ee2d511f1f08b173208d2bcf68"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "c913f97706b3425e4e3df50c9105a9f1cfdc450de81b2763298b183a5c0fa3bb"
+    },
+    "maps/start.bsp": {
+     "bytes": 760484,
+     "sha256": "b0c08384fcc8813e89f041f0aa46c8bd09b1a3eabf0e035cad2f9c418e461a0d"
+    },
+    "maps/zer1m1.bsp": {
+     "bytes": 1166340,
+     "sha256": "801d31585b3786966c29059c6a8d24001cf73735704ad8804f27094eea2138e9"
+    },
+    "maps/zer1m2.bsp": {
+     "bytes": 423856,
+     "sha256": "20b5749cc420fa59694795fdaf6f42e34811966a6c9264ca4ddc6bd49332ef0c"
+    },
+    "maps/zer1m3.bsp": {
+     "bytes": 2579106,
+     "sha256": "4b9809257ee3aa6757a6847932b316cafb4b823db369ba47bfa4deee39651e40"
+    },
+    "maps/zer1m4.bsp": {
+     "bytes": 1985644,
+     "sha256": "e056bcbe4afc74e8e74826e5d1fd1d844aae550ac6e4554cf97c7f58a0279e70"
+    },
+    "maps/zer1m5.bsp": {
+     "bytes": 1404988,
+     "sha256": "1a61d62e0a0d375ba54bb1f88736ecece61b3cb37b6516604692df0cc5fa3120"
+    },
+    "maps/zer1m6.bsp": {
+     "bytes": 2051484,
+     "sha256": "eb737d4f61af98e0841ca91cb8ca37bf4eaeee5771569ede3631514d68fad15a"
+    },
+    "maps/zer1m7.bsp": {
+     "bytes": 2776660,
+     "sha256": "53ea9228a88031d56a9aae28c4265df3edcacde3dd46e59787a0f41e3f01bc30"
+    },
+    "maps/zerdm1.bsp": {
+     "bytes": 1096836,
+     "sha256": "6c995b3603ff0c548226f1188059eb1468fc366410263edea87a5b2d83343109"
+    },
+    "maps/zerdm2.bsp": {
+     "bytes": 1787388,
+     "sha256": "dd9becf466c8bd8e6f4058124653ff9e700a789426937c11ccd9fc4637b877c6"
+    },
+    "maps/zerdm3.bsp": {
+     "bytes": 1416170,
+     "sha256": "89c9df2019e0e9d40797ace92b6580a70b3bd4f804e6614e542db2c5bb2b01e9"
+    },
+    "maps/zerdm4.bsp": {
+     "bytes": 394170,
+     "sha256": "9f77b8f1edd202e8996cbcad95620a5f7bbf3faac971e720b3718036501b08f7"
+    },
+    "maps/zerdm5.bsp": {
+     "bytes": 256970,
+     "sha256": "3d5c2e19c38ba7a6aed8947b37a0dad1eac6a0f7fb3320df5177fa4793703d08"
+    },
+    "maps/zerend.bsp": {
+     "bytes": 586764,
+     "sha256": "f049e9afe473b2cd93603b8818861714d8e63f272889a14867271423fcedb6da"
+    },
+    "progs/bbg.mdl": {
+     "bytes": 190836,
+     "sha256": "3bac35175b2808bad33e3b7e7c2c54b3d9181c5b3743aa68d803dbe58edf0eea"
+    },
+    "progs/bloodcb.mdl": {
+     "bytes": 28036,
+     "sha256": "83f0de29aa0f9e9f1d383895da374a5313aa2252edb306eb7bd69bd71660321c"
+    },
+    "progs/buzzsaw.mdl": {
+     "bytes": 10498,
+     "sha256": "8173fd2a525fbe11f95f5e98a17bb532c94eb74dfef3a513eed4d2273747576d"
+    },
+    "progs/courage.mdl": {
+     "bytes": 27964,
+     "sha256": "7044d59eec04c623bad8b04f1cd7066558920fb44c4f029ff15c3cebdd5512b7"
+    },
+    "progs/demon.mdl": {
+     "bytes": 184933,
+     "sha256": "57b29f15b1e1c506ab509b9ed02e2a06c08d09fc62e9a676c13c1fd8da36fed7"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 224812,
+     "sha256": "af9095cffbc74edc9d98d4e4e341736e304404df52983be33616da84d6463c87"
+    },
+    "progs/g_cgun.mdl": {
+     "bytes": 73603,
+     "sha256": "e17c3e884c66fae33057d3682f6f5f71f94f971fa3c56a695dc8687be3aad80d"
+    },
+    "progs/g_dshot.mdl": {
+     "bytes": 71894,
+     "sha256": "9f5973b2db81e67569d498ae880c4ebdf1f886fac695df50ebd93cfe5b79da0c"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 165257,
+     "sha256": "a303ab4e92b2290f99b1ed0db2fd7ac81100537de147afacee54b268ad3d1608"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 161064,
+     "sha256": "b182cf8e7915d1860f37634a610905359c7a325f4ac13f1ef5b6fc2393efe182"
+    },
+    "progs/g_stun.mdl": {
+     "bytes": 80285,
+     "sha256": "78742513c85f6104386c1ede3e0b9d40decb04044c50a3ce5f6ea97941d30820"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 59539,
+     "sha256": "c66cc4f2c8aee10b9b9dfde86a12819eea6df55880763bf6e0e0fc312cde016b"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 12416,
+     "sha256": "2fff2f36173080827a298870a956fb11ad30f34aa0342ba5ca2c8bd6509edf57"
+    },
+    "progs/h_player.mdl": {
+     "bytes": 16985,
+     "sha256": "225852fddce81fed5e7590c269a14a91166f5ea00f3cac6a74ff496b4c0fb8f4"
+    },
+    "progs/h_trog.mdl": {
+     "bytes": 28778,
+     "sha256": "13302ec9240863651316e87733455f5fb5753f35278d8600bc9f6961e11b0238"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 492976,
+     "sha256": "1cd65b15a2c368df6ea231eb17f05ba5e40e046c1ac59b6e891fa690c244ac07"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 59078,
+     "sha256": "6a7022fa8210771be206034a2b0ebeb59f6fc79719d499ac01811a4ff32eb08a"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "b4116dd10673155069d7d326fe16439596cbfbb2f6c8c5b31001fcf7e70355e1"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 16228,
+     "sha256": "16a1b41734ec932fe749051b31bd8b577af097e28bcaa930783fb84f5d51610d"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 22228,
+     "sha256": "71ceb28d923fa713eb1537c898e84e1b2bb94c17955fc39946255ea5673dfa0c"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 6047,
+     "sha256": "582f7203c44ef28a0f8a51a13b7191ea2909e121e16d51819b5b5f607b672a2a"
+    },
+    "progs/s_cg_1.spr": {
+     "bytes": 864,
+     "sha256": "f39783767087d9f02e8b09797b4ccece6ae19aaee7136291dd33e522da0149f5"
+    },
+    "progs/s_cg_2.spr": {
+     "bytes": 864,
+     "sha256": "c7191728de66e5d167df59d0b204ce96b8ba9b032b44c1befd2c854277cde7e0"
+    },
+    "progs/s_cg_3.spr": {
+     "bytes": 864,
+     "sha256": "5c4a2ceaa07fd633cbe5497e8604e553de6890245c9ff631f0520f438aa15aab"
+    },
+    "progs/s_rain.spr": {
+     "bytes": 33100,
+     "sha256": "4c0bf4b61b6cd263d3f0453f7f050c94a30708f3d9604a44d50cfca1c232444b"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 153429,
+     "sha256": "f9d50e7819ba91cf29454d6ff4905d5e6f9c0454b351252db7e3db427ce79588"
+    },
+    "progs/stunner.mdl": {
+     "bytes": 13472,
+     "sha256": "e6648c7cc191a58f9fda4309a4e08162d3513cdc31fba68b8623db1721b1be36"
+    },
+    "progs/tgib1.mdl": {
+     "bytes": 19760,
+     "sha256": "1939b9cfed1c4d82cfb7034d3d9fc4b3dfa1233126ff2e4962533bdcf9ea3ba1"
+    },
+    "progs/tgib2.mdl": {
+     "bytes": 53712,
+     "sha256": "f6e2e84f7bdb837f3b9f4bd0a3dff363985293a141d23ecbf33fb5997b3835df"
+    },
+    "progs/tgib3.mdl": {
+     "bytes": 64372,
+     "sha256": "a26e8802c5c0662ad0562ad49f487282ef43751ba0a70a3fe4ff794982bed19a"
+    },
+    "progs/tgib4.mdl": {
+     "bytes": 20484,
+     "sha256": "f7ec6242209753a3655557f8459de2516f6205e666cf7a6cc09a465eeac15230"
+    },
+    "progs/tgib5.mdl": {
+     "bytes": 2545,
+     "sha256": "b7756a235ce35f96d1ba0681207441ed0ffa60628b8663dc52d880cc3ba4726f"
+    },
+    "progs/tracer.mdl": {
+     "bytes": 11973,
+     "sha256": "928bc71a3bf560377bf08d0b38e7e0060e02d0f3f12ce49fe3fa8686021f8295"
+    },
+    "progs/tree.mdl": {
+     "bytes": 101704,
+     "sha256": "f5dad886e64ef946b0ad0aba3a06da419579911c5248ee856d2d503e40c4beab"
+    },
+    "progs/trogball.mdl": {
+     "bytes": 136671,
+     "sha256": "e0f0ac46b0173ddf761210d34334dc1b07196f0b8941d6027a5831355f7bd0e8"
+    },
+    "progs/troglod.mdl": {
+     "bytes": 155623,
+     "sha256": "93d01da2c0aa7d0ff26d685a5230cffa9a4f2d732f4a84192e2199949a224281"
+    },
+    "progs/turlaser.mdl": {
+     "bytes": 22264,
+     "sha256": "d47b2690710787999c2c565610de70a9a262176a0652f230530041cd293943f2"
+    },
+    "progs/turret.mdl": {
+     "bytes": 218092,
+     "sha256": "d68136641c97b0680939bf154dd98d79528f02ecfa27e11a723ee413565c4081"
+    },
+    "progs/v_cgun.mdl": {
+     "bytes": 62283,
+     "sha256": "c0803b83613ae3c91061f45b71b9a183269ed3afc02baab895957cfc57494562"
+    },
+    "progs/v_dshot.mdl": {
+     "bytes": 77102,
+     "sha256": "8b54bab3a0fc20bbe27ed1ef204fc4dc21c8c6ab0d9a6efa82038d570de5aacf"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 178333,
+     "sha256": "37d41f62604af8f7cedd55d84e02988b5d06e2604cb636f81d505835e493844f"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 184952,
+     "sha256": "d113effd0d5b436c468269c245647e369f26b569f3fb9031f874a7f6a5dde574"
+    },
+    "progs/v_stun.mdl": {
+     "bytes": 62074,
+     "sha256": "2e293a149a9afbb9e6e61a1aeae8af25891d2909264ce5b6e687648f61f5db7c"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 76043,
+     "sha256": "ed80eddf26e304083cd1a08349a900b9e0b4c9c91ea4e9d49d75a838b916916d"
+    },
+    "progs/wings.mdl": {
+     "bytes": 116760,
+     "sha256": "d462a4c2ec13e85ba68cac60e8ed10cc863e7862a41744e4bc396163ae000dca"
+    },
+    "progs/zerlogo.mdl": {
+     "bytes": 33380,
+     "sha256": "b305250e2c537f616557219eb81ac571f76588ff6f57525a36fc3d38114ee11a"
+    },
+    "sound/ambience/brik_hit.wav": {
+     "bytes": 6820,
+     "sha256": "499804fd15edb24a5fa931163e19c5569a45ce93ad74d313c58b2382cbf35d7f"
+    },
+    "sound/ambience/brikhit2.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/chant3.wav": {
+     "bytes": 116346,
+     "sha256": "5d71f12940688414ab8cabc0d88e323dc961b60aac66f17887712133f1cb8b29"
+    },
+    "sound/ambience/equake.wav": {
+     "bytes": 47148,
+     "sha256": "dcc45d2ef0703ecaa022c83cd66ae4992021ac379c11fc9da4401e184a191c93"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/monster1.wav": {
+     "bytes": 86142,
+     "sha256": "b93677c4793930e26e12444064cf9b74fc3e49da9ddd7df7d569ba02a3cb10fd"
+    },
+    "sound/ambience/monster2.wav": {
+     "bytes": 85116,
+     "sha256": "6fe159639935a8986685fbe2cdf02f80d4e226dea8365da516713c333ed5d0a4"
+    },
+    "sound/ambience/monster3.wav": {
+     "bytes": 99962,
+     "sha256": "310a864ee470264ac6f6c0829f1dd508632e03fd594d30c3820e26a161d1dff0"
+    },
+    "sound/ambience/rain.wav": {
+     "bytes": 91202,
+     "sha256": "a196a2fc8a052368f9e8f7efe853391d1a99dfb1f6afae4fc7038222f2eb6fda"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/torchign.wav": {
+     "bytes": 12268,
+     "sha256": "7d5e4e5a897c456b4b43173b1b796b4a3af6df66447cf7d0c8ebcd2dfad00e86"
+    },
+    "sound/ambience/wall01.wav": {
+     "bytes": 67890,
+     "sha256": "b5035fafa3e000b2e51cccf2e39404905cda1f55e42a64799ae677decb03ab19"
+    },
+    "sound/ambience/wingend.wav": {
+     "bytes": 90874,
+     "sha256": "63e435d896b097d4dc413fb1afccc2078f1d101a4f7bfc18c4e593ca9e8b344f"
+    },
+    "sound/ambience/wingget.wav": {
+     "bytes": 65148,
+     "sha256": "533bdbd7beffa4c71c66239e3ac417f2177b20a60ed39c379c59a10b2222b367"
+    },
+    "sound/ambience/wings1.wav": {
+     "bytes": 6028,
+     "sha256": "c9e05f66a1d728a88289bc213c9f3551f1e54a4f3e8ef23ab03f8d5019e7b2c5"
+    },
+    "sound/ambience/z1m2mus.wav": {
+     "bytes": 103768,
+     "sha256": "d54261d4c9a4a8a9fe0c51eeae343c6a5b381727af88d0bae6f9b40605b8e5d3"
+    },
+    "sound/ambience/zend1.wav": {
+     "bytes": 123618,
+     "sha256": "2df6c267197b2e82241e47ce4985b04d14e1ce3cff46cebf3177369057302bb6"
+    },
+    "sound/ambience/zend2.wav": {
+     "bytes": 73742,
+     "sha256": "0ea00395004f11d41ab60352517bf5ff5c88a73b8ff2ddb3f32b5085967e3003"
+    },
+    "sound/ambience/zend6.wav": {
+     "bytes": 252626,
+     "sha256": "3f3c412e55bc7534c423c0d1bec2d817e3aea06338b4d6c3f78c4b80e55d509f"
+    },
+    "sound/ambience/zend8.wav": {
+     "bytes": 112122,
+     "sha256": "27cef28aa3d6c3ea86f0c54168db07055abfc7af284bc5a35bf53a0e53f8d677"
+    },
+    "sound/cube/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/cube/bc_attck.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/cube/bc_gulp.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/cube/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/trog/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/trog/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/trog/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/trog/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/trog/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/trog/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/trog/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/trog/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/trog/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/trog/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/trog/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    },
+    "sound/turret/tur_gib.wav": {
+     "bytes": 14686,
+     "sha256": "41e04d4b8199e0e484f6fba8b9bd410d475bfc3908a5b58ea3cfdcbf223ab1cc"
+    },
+    "sound/turret/tur_move.wav": {
+     "bytes": 20602,
+     "sha256": "b31f1cafb7309cfcf302c662f7e0c41f4ed1d203f60bc3348da9483af80d85fd"
+    },
+    "sound/weapons/pc_exp.wav": {
+     "bytes": 35314,
+     "sha256": "ba81a9534ba1da310ec277a807aa31de8bdcfa36a061e80d8eff9b4581bb85ea"
+    },
+    "sound/weapons/rocket1i.wav": {
+     "bytes": 26306,
+     "sha256": "04fc98e42709c9a5d1a8bbd52aff9114b4922da324e30d21859bcf8209e55b4f"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/shotgn2.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "sound/weapons/stunfire.wav": {
+     "bytes": 9902,
+     "sha256": "7214cc44e4c0bfb801209f025b591d838542a3110f770e5614b0f549a055286a"
+    }
+   },
    "sha256": "d74418360a9b214965e6c0811334a1a618ab69d81338d3835455d55e20fd15eb",
    "timestamp": "2012-04-07T18:50:18.000Z"
   },

--- a/json/by-sha256/5d/5db34752666516d306b0c78504bef2b4d2af054b0ddc3167c974d8e08da2556f.json
+++ b/json/by-sha256/5d/5db34752666516d306b0c78504bef2b4d2af054b0ddc3167c974d8e08da2556f.json
@@ -25,6 +25,896 @@
   },
   "rmj1/pak0.pak": {
    "bytes": 324011544,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "b365e2dc368ed055fab352ee938e4be420dabe27486107a6cffaae52f473b543"
+    },
+    "gfx/env/balebs4_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "286b4d71078131f41bbeed2d954f30d10c9f9eace766d65b6ebae437e509f65e"
+    },
+    "gfx/env/balebs4_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "e3375333742e6ec9d74be35cd53b7524840df3701dd1456df66a00fbdeb75b03"
+    },
+    "gfx/env/balebs4_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "4810d53912eea1504b961dfc256d160bbd0e0c31406a8a37a4bca9b23b891344"
+    },
+    "gfx/env/balebs4_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "f14e66a1bea217d05b31446612ffd7e91cc736f268668a59e607e97df7ecf89d"
+    },
+    "gfx/env/balebs4_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "2a8c407d732681308e72ea0216cff0d89ae735a3dda93a2dee7b31336a224c8a"
+    },
+    "gfx/env/balebs4_up.tga": {
+     "bytes": 3145772,
+     "sha256": "ec8ab3fa13db2193ed087441470d91fefeeca2db61d5ff47c1d5c97d79e33cc9"
+    },
+    "gfx/env/desert_bk.tga": {
+     "bytes": 701188,
+     "sha256": "f1f711036366b486e074d0ef142c0719f5c3d42dd0eb76e1c98a7d35a8a39457"
+    },
+    "gfx/env/desert_dn.tga": {
+     "bytes": 779658,
+     "sha256": "2793a401717ce1206f91a8fb299df4e3c333e135511c1f5ed4d60a37f6e9f766"
+    },
+    "gfx/env/desert_ft.tga": {
+     "bytes": 631806,
+     "sha256": "49f9b6cef91ece307739a3b4413ba3104f5502b995117512f1f83d1bbc4d6334"
+    },
+    "gfx/env/desert_lf.tga": {
+     "bytes": 655314,
+     "sha256": "4d7226db424e55d993c7b30bed74106f3091a3b56345ca73bfa4ba7ecf04a41d"
+    },
+    "gfx/env/desert_rt.tga": {
+     "bytes": 649417,
+     "sha256": "6978740a2bc4b7bb4cf87d0a3ace4b302a28bbdbf2a4dae009f19b860ffaa93d"
+    },
+    "gfx/env/desert_up.tga": {
+     "bytes": 341983,
+     "sha256": "88f8980804bfbe03147a79b2186697af75631057ceb172d36c294f0eb16941b2"
+    },
+    "gfx/env/ep1_toxic_bk.png": {
+     "bytes": 2336206,
+     "sha256": "8f2c9230c98b4150c305d792e70874bbaeff7202e3dee0ee4138a1a8aa1718d6"
+    },
+    "gfx/env/ep1_toxic_dn.png": {
+     "bytes": 3569379,
+     "sha256": "92c2a1570a763a93f06dde5720fe1769f518c11abbfde60c932de0fade982919"
+    },
+    "gfx/env/ep1_toxic_ft.png": {
+     "bytes": 2712171,
+     "sha256": "49ebf277e67bf8b03234e1e15c22c492531523d199d7738992c69a734b8ef1f4"
+    },
+    "gfx/env/ep1_toxic_lf.png": {
+     "bytes": 2861509,
+     "sha256": "113448e784d37e477a1fd36e35893f63778f3405a3749d343aa1a719b493191b"
+    },
+    "gfx/env/ep1_toxic_rt.png": {
+     "bytes": 2525793,
+     "sha256": "b6b91435503ab93361a9c8cce15ed33a1d04f3f5e8e8bc6c553be240c99229d2"
+    },
+    "gfx/env/ep1_toxic_up.png": {
+     "bytes": 2601572,
+     "sha256": "68c7b7fbdbd4ed5f9f5b609b29f02e2e1adfac02e6b397d62fb2bf545e793ea2"
+    },
+    "gfx/env/mak_beksinskisky1_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3da19e6822edcc3870072409d0aeb3b4b470a6c59c74a5f9b8bfeefe655f3405"
+    },
+    "gfx/env/mak_beksinskisky1_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "cbf8de3af603a9fc91d7533619ed72ade3cbfde856c8f4f273c1f8b12af72a13"
+    },
+    "gfx/env/mak_beksinskisky1_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "aff0502b2d2260de6c7dc4b10bb8765b11e85062fdb2fa3224d41e5d21d1513c"
+    },
+    "gfx/env/mak_beksinskisky1_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "b7efde04b48e6bde158c4a760e6c7a6ccc9563011fc8d9cb8b5502971871952b"
+    },
+    "gfx/env/mak_beksinskisky1_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "578aa512cad9015b90d5288147d36464b6deaad31341b206d0296b7f0e8751b8"
+    },
+    "gfx/env/mak_beksinskisky1_up.tga": {
+     "bytes": 3145772,
+     "sha256": "4d23ac2745f30032a2904e0143e2d7900698fbb60b9a42fc72e7b3106a10848f"
+    },
+    "gfx/puzzle.spr": {
+     "bytes": 5624,
+     "sha256": "d1646c09f75fe07116cbc9029388b8eabe4be4cb9d2f7275e7bb911251295acf"
+    },
+    "maps/rmj1_alexunder.bsp": {
+     "bytes": 23517164,
+     "sha256": "8a404d9c3110d18bd6427f5c9f6d98fbedeac719fcfabced27959b7172c910d5"
+    },
+    "maps/rmj1_alexunder.lit": {
+     "bytes": 3736736,
+     "sha256": "35166fb8b05e5774d7dae2427c0a871e9ba1bd772c4728dd37aebc95ab4bf424"
+    },
+    "maps/rmj1_alexunder.map": {
+     "bytes": 15272700,
+     "sha256": "4ca279b75a520833b8492af0e3ee1eb4c8968ce783dd032df5b3bfdb14d77180"
+    },
+    "maps/rmj1_chuma.MAP": {
+     "bytes": 2285246,
+     "sha256": "39915185355bc9b4d33f84cfa045e2fb0cbb5e7f89f903491b47ccbf576d854a"
+    },
+    "maps/rmj1_chuma.bsp": {
+     "bytes": 9030944,
+     "sha256": "559f14b5935f65e0f0ae77a1097cc5ca848461a7fc530b34e62beb74bda52b3b"
+    },
+    "maps/rmj1_chuma.lit": {
+     "bytes": 2893169,
+     "sha256": "32b624e3314b53b4c0e8f7c8a5223ef017cc28fcf9916a78e57cf7a266b4e1dd"
+    },
+    "maps/rmj1_emeraldtiger.bsp": {
+     "bytes": 7353508,
+     "sha256": "30227879c6092dd95351a6957d22fe34cbe190a7cc13a7b19032530481d14cb2"
+    },
+    "maps/rmj1_emeraldtiger.lit": {
+     "bytes": 2787464,
+     "sha256": "7d5ba7ca3a04bc8b436070eb4f04229058d289f659cc86639bc03c4ffa221af6"
+    },
+    "maps/rmj1_emeraldtiger.map": {
+     "bytes": 5155912,
+     "sha256": "e42ebffda4736fc7f57fa7d143771f7d52f0d77fa7298e8b787aafdd657b6b24"
+    },
+    "maps/rmj1_shadesmaster.bsp": {
+     "bytes": 43636520,
+     "sha256": "a60d6e62b2fecd1155ac56c144a7dd731debb185703131e25c9bf7da172cecbf"
+    },
+    "maps/rmj1_shadesmaster.lit": {
+     "bytes": 1783181,
+     "sha256": "209025fce6d3c1feaa27d854ce7f27c93618d6b89197091aab1d34cde76f5b67"
+    },
+    "maps/rmj1_shadesmaster.map": {
+     "bytes": 1797423,
+     "sha256": "5eed8ed576fb9f5db6431b09d44d959432685186627c247de5c4e935d3c484b5"
+    },
+    "maps/rmj1_shadesmaster.wad": {
+     "bytes": 41135728,
+     "sha256": "a988f134458e8678f8f752cbba81ed64171df6a22a62c246c02b2514584c49bb"
+    },
+    "maps/start.bsp": {
+     "bytes": 11551720,
+     "sha256": "fed050e0afee53b94b76420937e8dc6e9abb40aa66e36c2c20a2efdb7601f885"
+    },
+    "maps/start.lit": {
+     "bytes": 820556,
+     "sha256": "8c4f1902f83d5c83be36612efff82310e62cc962a927705cf42cb84a80c68ca5"
+    },
+    "maps/start.map": {
+     "bytes": 2749600,
+     "sha256": "bf764a45f4947fb76cc697f53e083393138de1dc9544a5dfe63bc040cd4c30dd"
+    },
+    "models/break/stainYelGrnFB.mdl": {
+     "bytes": 50004,
+     "sha256": "7833f6e2abdb1805611f2e8f9e957d2df53f588d2a92168bfea54aba53bf7fad"
+    },
+    "models/monsters/arma_body.mdl": {
+     "bytes": 106512,
+     "sha256": "f50d36f2a3a38f4ee47f00922054fb2cb7afbf7719c3b5b2ad77c4caab9f40b9"
+    },
+    "models/monsters/arma_legs.mdl": {
+     "bytes": 51580,
+     "sha256": "c1d2c701521ec30e8d3d311f807e33bd63c21fc76eababf40dfb2e231d41008a"
+    },
+    "models/monsters/big_spike.mdl": {
+     "bytes": 1058816,
+     "sha256": "451458023db62875117f633b232d59b3b71a310ee2a7fd494e95db026b929bc7"
+    },
+    "models/monsters/enforce3.mdl": {
+     "bytes": 278028,
+     "sha256": "e867fd04bf2063e71f300fde2393ccad3d7c330dcf08c1bf61b231f53ab45f89"
+    },
+    "models/monsters/h_scourge.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "models/monsters/mon_lavamini.mdl": {
+     "bytes": 486920,
+     "sha256": "9d4cde267ac7995ce1330d09f28dcab59a7a25c0d5ddfffdcb2d9da005d7857c"
+    },
+    "models/monsters/scourge_arms.mdl": {
+     "bytes": 244804,
+     "sha256": "1473f5b3196c9ed4e7b709e8c744dc166ed2224a6073b771ce56c8a1db6d6fae"
+    },
+    "models/monsters/scourge_tail.mdl": {
+     "bytes": 244804,
+     "sha256": "67d4dd1b8376698b41efb4c3ba10085b5d49ddddb54243bb36859081390facbe"
+    },
+    "models/monsters/spectre_fiend.mdl": {
+     "bytes": 265688,
+     "sha256": "70f14b71b28e646f777bc24a79ad8ea4ffafb7a785360a0401a10e978308a5a7"
+    },
+    "models/monsters/techogrea.mdl": {
+     "bytes": 162036,
+     "sha256": "5792430724562eaf1df08f8d18db34a6e62b27b1836931f2269febe17caa9e52"
+    },
+    "models/monsters/techogreb.mdl": {
+     "bytes": 192180,
+     "sha256": "ed04d7428d2947bad6f32d0e2c482161866d58ef5c09ba0447aa02f4be83d4cb"
+    },
+    "models/monsters/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "models/monsters/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "models/monsters/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "music/track120.mp3": {
+     "bytes": 6146507,
+     "sha256": "0ba436852b82bdf85f0ef00242269b5727d45004d6ece09b52cd7554288d4ddd"
+    },
+    "music/track124.mp3": {
+     "bytes": 4335072,
+     "sha256": "29cb994b64e2ca60c31e6d8cc9badc1a0407fc0410d8a8791b4e18f00a8e0953"
+    },
+    "music/track14.ogg": {
+     "bytes": 3518561,
+     "sha256": "10c7d37ac58683ee72ef067028f7ef0a50c2feeeb68e02d6dcc15f916d607b8b"
+    },
+    "music/track195.mp3": {
+     "bytes": 5822847,
+     "sha256": "9214e53319e7b319374f1364bc3f29cc62cf1941570e902359557672f8533b00"
+    },
+    "music/track196.mp3": {
+     "bytes": 7234860,
+     "sha256": "805c3ded8f561fcccd96ba90a321660461899515c3d538f8d260a40db39ef1f5"
+    },
+    "music/track199.flac": {
+     "bytes": 8080764,
+     "sha256": "e200f2b3cd742c8bf2c956d23a8b8f2e9c5e4f0034a93db93478cfb3f23cbbab"
+    },
+    "music/track27.mp3": {
+     "bytes": 8219833,
+     "sha256": "839773153deb159a99bdcb3d95d28ef5c6bf34329edcfbb8004d5f90c7aefc41"
+    },
+    "music/track28.mp3": {
+     "bytes": 5637710,
+     "sha256": "a7e85c6b728a0ae18f086ae47b89626459b73de554262cef459b345b30719ccb"
+    },
+    "music/track69.ogg": {
+     "bytes": 4063017,
+     "sha256": "913b4745085a93540172ba7ab44a6bc8f018372fb55e2ba699c764fd97c99bfe"
+    },
+    "progs/a_mdls/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "1cdfc2b54dd883efe9215499603e341bfa72e800740a2e874e9bcf3b0afc68ba"
+    },
+    "progs/a_mdls/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "8cb54159eeaa410b98478e9190bd2d33340d3a2e98a61d32ce1afaf4e99031a0"
+    },
+    "progs/a_mdls/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ac361970fb1cbbb87ad4593afecd6d8973a65ea4f14e5f7b565c8f38c181fa9d"
+    },
+    "progs/a_mdls/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "0870b633f95bda895074e8d423631ee8805c3923f36a1c7f09938710783e8f99"
+    },
+    "progs/a_mdls/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "146955794f29c02f6570eed83e1d4b0013b0b4341897bcbc91cc9ffea6957ff4"
+    },
+    "progs/a_mdls/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "59988afc3603b83ccfadf0a9af423a113bf15ed969d4a62db9073e3061bc0fdc"
+    },
+    "progs/a_mdls/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "696594c11dd6dbd2e60ac6923d82a55f8f5b16e93b93f7914abe5fd4df74299f"
+    },
+    "progs/a_mdls/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "b558ee2dfd0078c7e3075079fb40368f53e7dfb162aaefcd20e53f562e405b1b"
+    },
+    "progs/alexunder/enforcer_y.mdl": {
+     "bytes": 472208,
+     "sha256": "95c01940921e1539dd13ca26e96ab1f0f416790cc8e92c4a0bf30261b95ca421"
+    },
+    "progs/alexunder/soldier_y.mdl": {
+     "bytes": 320900,
+     "sha256": "fe03c2266fde22596cb3e4f8ad3f836cd392b0260ec1363c401e9acce3bbabd9"
+    },
+    "progs/armshr.mdl": {
+     "bytes": 20012,
+     "sha256": "1873523424395b404ffafeb447383185e033826e33bf0a001efc34604ece95da"
+    },
+    "progs/beam.mdl": {
+     "bytes": 85496,
+     "sha256": "414259b1c9cb4b23c6cb4e560008287857dc438627138d4806a8fd7d0554f75a"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 85496,
+     "sha256": "74f83a584737f82af2f358b2ee37a9cd02a8acea23b7a1d8e0728af36703a404"
+    },
+    "progs/bolt1.mdl": {
+     "bytes": 85496,
+     "sha256": "ccb45187c4d9561258588d1d616dec1fb086782de173f83e38476f0ae0d7287c"
+    },
+    "progs/bolt3.mdl": {
+     "bytes": 85496,
+     "sha256": "2291b1d8da40d6acd9a0b21771417e0b8a68051b114785997ffefca7636bc61e"
+    },
+    "progs/candle.mdl": {
+     "bytes": 24135,
+     "sha256": "5027f8712c36de87b3967e4e623fbc64d4e99644f5b805f7e21ec38b1532cc74"
+    },
+    "progs/debris.mdl": {
+     "bytes": 263072,
+     "sha256": "2b60cba9cbb454e3524d174edc0e1a540f2b2e91fa0b35fc2ab20ccb7fabd8d1"
+    },
+    "progs/elemshambler_f.mdl": {
+     "bytes": 163468,
+     "sha256": "c86980d098e1564495b2ecbb279c74f834e058c1ad8cee459ca5eaf2316c3e54"
+    },
+    "progs/elemshambler_i.mdl": {
+     "bytes": 269740,
+     "sha256": "25c5e9a258255b7a0ee8442f6eed00eaa6c5b5d22d3494c9ca1e48c4fc94efd1"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 472208,
+     "sha256": "3345599ba081d346c163f5c239815bd65b134ccf342601f42a31e60a45044f39"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/g_shotgu.mdl": {
+     "bytes": 29076,
+     "sha256": "4a8866ab410a93522a3d3221e0f3b45889a488b54c0551329f09493273e09840"
+    },
+    "progs/g_shotty.mdl": {
+     "bytes": 23380,
+     "sha256": "b919bbcba3f7f03fb8b82fa6d3b1464ca41e81cf29417cfea0de09658c698cfb"
+    },
+    "progs/h_boss.mdl": {
+     "bytes": 24028,
+     "sha256": "b41e2302e15d7cb47bf1eb4ee1df29e7e8d773a3dfc6059f5b1f8ce18685bba6"
+    },
+    "progs/h_mdls/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "2e7fac7418838a721d80e80370000f3e400b21248b22c8d3555588d4f8437a5b"
+    },
+    "progs/h_mdls/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "1f4b0791be3156763c15521fbf2e747744ce3355d90d630b01c2227770314771"
+    },
+    "progs/h_mdls/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "6f792b9a80f34e31bceb4258e1d2c8f22d405a7ae1198b31bb285f502c720cfe"
+    },
+    "progs/h_mdls/pd_vial.mdl": {
+     "bytes": 8292,
+     "sha256": "035673048c98991e790abe484c2403b56dfe5ea1f5fb185c1b7a657d918668e8"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 42048,
+     "sha256": "52760ce1f6e8f657e782846571baf9fde80859f5342d07a684fa8218f96f68db"
+    },
+    "progs/h_shambler.mdl": {
+     "bytes": 98400,
+     "sha256": "6508f7b05b65f230b7f1280d2023e9ed200663715db1709c43e7e187e3ed841c"
+    },
+    "progs/health_5.mdl": {
+     "bytes": 6164,
+     "sha256": "a8ba7ece01b3cb58b2f94ca20a9f4511871d26ec894b54c04e433f29fc7c3bef"
+    },
+    "progs/hook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/k_spike2.mdl": {
+     "bytes": 444704,
+     "sha256": "e466e7afa95868ec1a3b3bfc770573d93dc20c2d881a73d2b9b0e35f1dfa6d9b"
+    },
+    "progs/lspike.mdl": {
+     "bytes": 1684,
+     "sha256": "59264317258f19955b967177f0dbc5be1733e4ca07c4c7b3cc333bb88bc0c46e"
+    },
+    "progs/maahes/misc_maahesstatue8.mdl": {
+     "bytes": 53188,
+     "sha256": "252c422e6f25d46a494f46ec8182c649f782df95b886d783f60075e53769b88d"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/misc_lantern.mdl": {
+     "bytes": 28836,
+     "sha256": "d84e36232543a053f2772b1070b221dc23da1b34cd08ea551a982b5e9f168ea5"
+    },
+    "progs/null.spr": {
+     "bytes": 57,
+     "sha256": "dc67fb2f31bd717353b8138f02bdc8ef2d70ace433c9fd91e3adc909fda513a3"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 366916,
+     "sha256": "29fa9866dd4862b99ebb9944ddb0bf24a6d0bb4bf00e26a94d3622cead9b6315"
+    },
+    "progs/pd_armor_sh.mdl": {
+     "bytes": 31508,
+     "sha256": "46b9de8235f07190e18d67e147ed00be6dc322cd112ccde33bf4fc1f9a77e074"
+    },
+    "progs/pd_b_key.mdl": {
+     "bytes": 128440,
+     "sha256": "c5aff23b766037ab550636516d7fe0235dacf566ddb966541d640092bcb62349"
+    },
+    "progs/pd_base_key.mdl": {
+     "bytes": 21219,
+     "sha256": "320ec52018f501f8fe428dd46f44693787e545289be883a49f3bd6476974cf46"
+    },
+    "progs/pd_bpack.mdl": {
+     "bytes": 216724,
+     "sha256": "1839c92899197344935eca44d7b4c70e903af84ab633259786f8c12c39905149"
+    },
+    "progs/pd_r_key.mdl": {
+     "bytes": 269528,
+     "sha256": "7ef6894b955c4ca34bf3e2ebdc6288f55cc3b1285478444a81ca769866e1a119"
+    },
+    "progs/pd_rune_key.mdl": {
+     "bytes": 46335,
+     "sha256": "c4fe9bd66394231ace3127635f057987ecbf4b13b00d84501127caacb5db03fc"
+    },
+    "progs/pd_w_key.mdl": {
+     "bytes": 170680,
+     "sha256": "73f06fc10a53c93db25d67f20bad7672bc5f4e14bf3a6b5115d68f00696b536a"
+    },
+    "progs/pd_wiz_key.mdl": {
+     "bytes": 21907,
+     "sha256": "36b50211f687813b85648a46bd32a1d543a8f2af84e9d4223f8b5843f885e1bc"
+    },
+    "progs/puzzle/cyaegha.mdl": {
+     "bytes": 20604,
+     "sha256": "e0134ba9b54fb67bf252a0cfc81af23cda71d1d5b3ce55c82e0fb69e7fc8f718"
+    },
+    "progs/puzzle/cyaegha.spr": {
+     "bytes": 1400,
+     "sha256": "5e47d02105ece3c9c15ee85778a6f07de8e100aae0cd30f7d1d9db6453162af3"
+    },
+    "progs/puzzle/pallid.mdl": {
+     "bytes": 23260,
+     "sha256": "e0a723f1c00ac85a86018419a9046058b77d09e5cad656fa949e25b98e1f3301"
+    },
+    "progs/puzzle/pallid.spr": {
+     "bytes": 1400,
+     "sha256": "edf63f7ea0774e0a5a6825dd9689c3224dc19abf158b8b347b5768748cb9f159"
+    },
+    "progs/puzzle/swampkey.mdl": {
+     "bytes": 18660,
+     "sha256": "63d435e8942c98adfc9307f6276cf8206ec063b5e32a05e09c5e388efa512c33"
+    },
+    "progs/puzzle/swampkey.spr": {
+     "bytes": 1400,
+     "sha256": "d5dec992ccba32e8d9c8bc381e96d6771b27cbb3dd6a1adf018a710ac53a1fd0"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 47856,
+     "sha256": "99fc3f91856aa6df2f25494a945e17b64b59ddc3faed424a6fcd73062a677fcc"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "e306ec0fbf0f5e4306c6683f7c7b87674bb0a168ef32a2b1118dcffb083deeff"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 320900,
+     "sha256": "e3321220ed34292da63fac94af63360c6544c055edd1eceed35d75eb26685e9b"
+    },
+    "progs/spark.mdl": {
+     "bytes": 2544,
+     "sha256": "77d081c51af9bd6c82d2d51dcb955a2fca5189cda4eb09a138bfa2e2b521fb05"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4416,
+     "sha256": "8c70353304b2d111260102565745a5504144568f932787906eaf50de742aa62c"
+    },
+    "progs/teleport.mdl": {
+     "bytes": 1058800,
+     "sha256": "98eeb63a1ded2d7a1d3788562478aff891af1be4ef1c552bcdb913cb338387b6"
+    },
+    "progs/tracer1.mdl": {
+     "bytes": 68624,
+     "sha256": "c0feddcacc94372041d9e02c744fd266ab6d1fcda8b970be3f5147e43169f38a"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 1058816,
+     "sha256": "ac4d47130af263cb6fd861d70ac09ebf758ab1a76da0b697e268382c65ae1a16"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 311493,
+     "sha256": "add013a5a6686ffd76ec0f2b2b3413757432ba4a8564ffd81aeb7eb2c5a98398"
+    },
+    "sound/alexunder/creaking_fan.wav": {
+     "bytes": 509348,
+     "sha256": "98011803a655711f4aeb27dc09eea1ca96a586997bd068631fe18f20317ec142"
+    },
+    "sound/alexunder/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/alexunder/reactor1end.wav": {
+     "bytes": 48590,
+     "sha256": "0a134d4c8b032b18cb4b90963a8d705f1bd76c27586dc0c11d33b4567e099fde"
+    },
+    "sound/break/bricks1.wav": {
+     "bytes": 49956,
+     "sha256": "302547c290609bc311098f9f63643199bee0164e907edf0e2b9289ccbce2a4e2"
+    },
+    "sound/break/glass_impact.wav": {
+     "bytes": 98832,
+     "sha256": "32f51f7e8cb89c6b9a83c12603c4903a77370d9d16f8d3496e7ef22fb7b04a13"
+    },
+    "sound/break/glass_impactSoft.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/break/metal1.wav": {
+     "bytes": 70054,
+     "sha256": "c178f8f52631b1ff353fbeb3557e04e8bd574646ed47f78a3003350b67540979"
+    },
+    "sound/break/metal2.wav": {
+     "bytes": 65948,
+     "sha256": "7438b112d81fb92c285a507ebfbde5b15dbddcd90a85f51ecaae2df3ef83480c"
+    },
+    "sound/break/pd_bricks1.wav": {
+     "bytes": 61786,
+     "sha256": "3829842a9cb395f99d07546be38263eaf0ee5bbed71841aa8c93864d55a7fb94"
+    },
+    "sound/break/pd_metal1.wav": {
+     "bytes": 44146,
+     "sha256": "c0111b94231bc3870cbb95ec03f13b2b44ac407a5d18b35668ccf231303cc8aa"
+    },
+    "sound/break/pd_metal2.wav": {
+     "bytes": 70722,
+     "sha256": "ce8250482e831c270cc3c8e9211b74a627b3e29159c2c8ee720dd11cafd365c1"
+    },
+    "sound/break/pd_stones1.wav": {
+     "bytes": 75150,
+     "sha256": "632d15db23ff70c23c199595b41a153ded67f664de46b7d0cbfa0228f071156e"
+    },
+    "sound/break/pd_wood1.wav": {
+     "bytes": 34526,
+     "sha256": "621865f52fc27fb10108027ce3eea18aaf17181751a3ba1ceee0c9c99da9f375"
+    },
+    "sound/break/pd_wood2.wav": {
+     "bytes": 33342,
+     "sha256": "77282f2c533b9aec72b232aace9078534db3f255f418efafdf769c7361a28e05"
+    },
+    "sound/break/stones1.wav": {
+     "bytes": 69380,
+     "sha256": "1b58b722e55c4e2d25f65e820e279699a7b236a02685fbc6a41a40e573df1928"
+    },
+    "sound/break/wood1.wav": {
+     "bytes": 53720,
+     "sha256": "026e35d7108347603453765f66311fec99097ff9f82e2d2703f69b7d80ae07c9"
+    },
+    "sound/break/wood2.wav": {
+     "bytes": 59252,
+     "sha256": "4488c91dc44e526beb95d33ad200e07e484a6f2fea59578784f3417a00df81f7"
+    },
+    "sound/dump/armsh1.wav": {
+     "bytes": 22610,
+     "sha256": "46801976a87d548c2cb7b1548f12dfd0b3f1d246aa9d86944574fa3216c6d6d1"
+    },
+    "sound/dump/elec22k.wav": {
+     "bytes": 178736,
+     "sha256": "d56ff98d1d41511833c35b5a8b5311f00b7e13932591eee53f9e2adf788569e1"
+    },
+    "sound/dump/magic_01.wav": {
+     "bytes": 125944,
+     "sha256": "3ea2bab80feccbe0f0b518ec613f45093aa76b0128752f454e239c75175cb4e0"
+    },
+    "sound/dump/pd_armor1_sh.wav": {
+     "bytes": 12410,
+     "sha256": "3b80fc8000fe624ffbe4f119faf41a77406b83bd350020c7782bc03fd51a1799"
+    },
+    "sound/dump/pd_magic_01.wav": {
+     "bytes": 125944,
+     "sha256": "3ea2bab80feccbe0f0b518ec613f45093aa76b0128752f454e239c75175cb4e0"
+    },
+    "sound/dump/pd_quake_end.wav": {
+     "bytes": 37248,
+     "sha256": "3ecb621fbf5a3f2ab090ebc0f3036069292181b11ab366689b3dfa0f19dd372a"
+    },
+    "sound/dump/pd_quake_full.wav": {
+     "bytes": 156278,
+     "sha256": "872e0b0847fd366c59341d672cba9da0faaf85a881f8d4d5471a664923c8440e"
+    },
+    "sound/dump/pd_quake_loop1.wav": {
+     "bytes": 159956,
+     "sha256": "52a330a12c35191347008f4c546b1c83b4e387f3f33c9b60c3a5e8e545b0517e"
+    },
+    "sound/dump/pd_water.wav": {
+     "bytes": 92708,
+     "sha256": "0402b1fb2501dafb33bd43fa9c49c0f6a3fff615a200693cb7953852305c49f4"
+    },
+    "sound/dump/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/dump/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/dump/water_59_02.wav": {
+     "bytes": 40038,
+     "sha256": "25aa667940a737e46da0a829d9cb94922972b9b19726664d1a1133a666dc1439"
+    },
+    "sound/grapple/gractive.wav": {
+     "bytes": 39606,
+     "sha256": "07326b827e9e9e8adf18c169f61f00f1d0dbe99a3089585c8b10aee1c900e672"
+    },
+    "sound/grapple/grdetach1.wav": {
+     "bytes": 22030,
+     "sha256": "509f831ddd9492bc961a59734afda72f44e1a602149c8139dfc8c4af9744d6db"
+    },
+    "sound/grapple/grhit2.wav": {
+     "bytes": 37912,
+     "sha256": "250cd88a7dbf49feebc457eaa240e7ff9a2e455ef9c0036351b80afc1a7e12c7"
+    },
+    "sound/grapple/mhookactive.wav": {
+     "bytes": 58160,
+     "sha256": "e53815235713a35b567af6c9013dd11f469342476eeba1ec2cefab082e5ae280"
+    },
+    "sound/grapple/mhookattach.wav": {
+     "bytes": 101568,
+     "sha256": "f971d49ba8821f70e83756241c6023d746ecbb10db00e5150cd739b7fe80736c"
+    },
+    "sound/grapple/mhookdetach.wav": {
+     "bytes": 148000,
+     "sha256": "4f3699109728a315f20c2bdfd32d0ba024ed52ae39c57b91ac4830b349e8982a"
+    },
+    "sound/grapple/mhookdisable.wav": {
+     "bytes": 55340,
+     "sha256": "6a0468e2f27e1717a9408cb782d8fe573e5110a52c43a5f980409a5ee679639a"
+    },
+    "sound/grapple/mhookenable.wav": {
+     "bytes": 55340,
+     "sha256": "dc98b548f41ac1fdd6507df62179c8cf289be0c1fa3c1c0a478fee10df09a7c7"
+    },
+    "sound/maahes/arrow_back.wav": {
+     "bytes": 53382,
+     "sha256": "95f4397c3a6123d96ff929b76bc46ef86378368167ed8a7fa2099cf6b64c945a"
+    },
+    "sound/maahes/arrow_out.wav": {
+     "bytes": 105516,
+     "sha256": "808d2a46679a2f2280ba486fc189bf048d873c44ab1109bb2ae1d45b9e8c090f"
+    },
+    "sound/maahes/flute.wav": {
+     "bytes": 569838,
+     "sha256": "4f590c39a9c39b282a13b143ea7d56f6fc4c5fba56116a048edca169a6101977"
+    },
+    "sound/maahes/smasher.wav": {
+     "bytes": 124588,
+     "sha256": "0609c379a0aa35df478e90942a000b8a8fbe170a26ce695e83acc421b7da4865"
+    },
+    "sound/maahes/stonemove.wav": {
+     "bytes": 167646,
+     "sha256": "40d4b21a67402bf537656845051205f6068d58b2b6683eae61871ed1d7f8cd4e"
+    },
+    "sound/maahes/tr_secret.wav": {
+     "bytes": 277548,
+     "sha256": "dbfa52c80ab816b5ccb8011b2f4bb6d5a087ca115bf8442fd741fcbe0e9997c6"
+    },
+    "sound/misc/bounce1.wav": {
+     "bytes": 131318,
+     "sha256": "e2ff508502105784b4d4c57866fd51c90e378da512453f2b4f0ec7d3b9c9e05b"
+    },
+    "sound/misc/bounce2.wav": {
+     "bytes": 65748,
+     "sha256": "7aa0dc7f440d26308324203b6b765f17def36e1ff93d848bf6bcfa5757c83575"
+    },
+    "sound/misc/bounce3.wav": {
+     "bytes": 38432,
+     "sha256": "0bc4a8a5ea66240a0626b0f6aa7b89596cc21f1f4661faa10046c14e91a44ca6"
+    },
+    "sound/misc/bounce4.wav": {
+     "bytes": 130190,
+     "sha256": "a6832f4e0bbeacdcfa004b2f58c5f373612d328f4e6cff136a5865b677e47fbe"
+    },
+    "sound/misc/bounce5.wav": {
+     "bytes": 111922,
+     "sha256": "75b43f7f3a81e36a03f30c8fcb9c74ec3ea2802d81ad8c170df0c6c5d687152e"
+    },
+    "sound/misc/bounce6.wav": {
+     "bytes": 90644,
+     "sha256": "61326cbca06fc86291e860ca3cea864ddfe88ad93faab30bcc2626e07f1ed362"
+    },
+    "sound/misc/bounce_c.wav": {
+     "bytes": 49084,
+     "sha256": "b09cbe0dc39101a49153cd2150f1ae77d1bac6449dcdfb6839413721e5492470"
+    },
+    "sound/misc/cushion1.wav": {
+     "bytes": 114818,
+     "sha256": "901643e1c58d71be1bcd30204081b2b35aaa4b48f08df6b6827757ac7ceb7daa"
+    },
+    "sound/misc/cushion2.wav": {
+     "bytes": 69444,
+     "sha256": "081ae22fd9a6447b0331df39b4d0066c3f1275113423a8ed9154b03cd0074ae5"
+    },
+    "sound/misc/cushion3.wav": {
+     "bytes": 18706,
+     "sha256": "bbd10a7fe94c4f17c601663999f7634fd9fc7b91b8ce18091b94e85f63c0a806"
+    },
+    "sound/misc/cushion4.wav": {
+     "bytes": 88320,
+     "sha256": "8e085176b61f2267359942b8408cb5729642b8e3b656f91e8a2b022c57755945"
+    },
+    "sound/misc/cushion5.wav": {
+     "bytes": 135156,
+     "sha256": "725f93e054fbd55e572ce7c69b0cc5a38a5654f74e304341e5e6b784f99b9c9d"
+    },
+    "sound/misc/cushion6.wav": {
+     "bytes": 75530,
+     "sha256": "f9736c287e7adfea7ec5af4ff264eff78d33061f40f0088f4ff4c72d5dc3e214"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/mesh1.wav": {
+     "bytes": 58482,
+     "sha256": "1cc350204f85be52b106ff012e5486c9c7be73d2ad1720028359f854a268b3f9"
+    },
+    "sound/misc/mesh2.wav": {
+     "bytes": 53260,
+     "sha256": "53b48ced37d7002af3af4a06912689ca00d5c2de09ceb12c2d183ddefd25fa0d"
+    },
+    "sound/misc/mesh3.wav": {
+     "bytes": 59688,
+     "sha256": "45e24bb4005871e7f096711eda928c6e8d5ebf52699239c3c16c1b59e060ba5f"
+    },
+    "sound/misc/mesh4.wav": {
+     "bytes": 95440,
+     "sha256": "4f53a83e668f1c2384684c4c8c567b3fbe26506957b57fc927f1eaac5cbf947d"
+    },
+    "sound/misc/mesh5.wav": {
+     "bytes": 315602,
+     "sha256": "b22c95cf3d7751f0a7437768cbff4c314f3faca60c079e3abfaba8bccfb907b1"
+    },
+    "sound/misc/mesh_c.wav": {
+     "bytes": 41282,
+     "sha256": "e507b003e86b197e286a378786fab189721626ed5cf5377d805edc9078510818"
+    },
+    "sound/misc/mesh_c2.wav": {
+     "bytes": 33172,
+     "sha256": "b1614e4039333f2f1746d1ec5453896c81783b614fa524bc28cc393f601259d7"
+    },
+    "sound/misc/mesh_c3.wav": {
+     "bytes": 42992,
+     "sha256": "23b19afcfbb04f236766940ad97d870f7f93d496bcbb4dacf3c6739046c737f5"
+    },
+    "sound/misc/puzzle.wav": {
+     "bytes": 6558,
+     "sha256": "749dc513e6fc6db082153a602bad5574325c1ff6e3d0b58f0f1169116a17c71b"
+    },
+    "sound/misc/puzzleaway.wav": {
+     "bytes": 4694,
+     "sha256": "bba82dd60ddc23bda2c0a905a1b73394bead2a172f78d46f0f192699b880192c"
+    },
+    "sound/misc/retro1.wav": {
+     "bytes": 22462,
+     "sha256": "35bf5034f26b8b5ccfcdbe6d371831a4c279f8ceed79601946219adb63276646"
+    },
+    "sound/misc/sticky1.wav": {
+     "bytes": 29910,
+     "sha256": "fbc3907ec6b9853130e24d768111b091d3123622631b431e538763b30f376520"
+    },
+    "sound/misc/sticky2.wav": {
+     "bytes": 27612,
+     "sha256": "8f6b498800a8c00b0a3254e687314f1d94a232e784c810178e60157991b67c14"
+    },
+    "sound/misc/sticky3.wav": {
+     "bytes": 75530,
+     "sha256": "9e0a442c0e9466eafef10a0a1a2246b6e7c523b323c7c8fd26d2ea084821b47c"
+    },
+    "sound/misc/sticky4.wav": {
+     "bytes": 42054,
+     "sha256": "e27ffc077693b4384c44daedbae19169991b0335aa3f6d79497b4656213e9dcb"
+    },
+    "sound/misc/vines1.wav": {
+     "bytes": 315602,
+     "sha256": "122ac96e09ff9fe5291ee2f8e79d9c1539a350c01ced4e6037ae857453f9f3e4"
+    },
+    "sound/misc/vines2.wav": {
+     "bytes": 244954,
+     "sha256": "924f9faef5ab66e9f32793c266d11d51faecec2dc9b4be369e883ec8d6c167f9"
+    },
+    "sound/misc/vines3.wav": {
+     "bytes": 329732,
+     "sha256": "4acaac46c6ea8fa76e3335e7df1a236fc3b1f97a1fcbfe779f2331889664a749"
+    },
+    "sound/misc/vines4.wav": {
+     "bytes": 202566,
+     "sha256": "576044eba6e7453afb8fcdc35db41107f4917bf61ce018d9fd94710a9f55dc85"
+    },
+    "sound/misc/wood1.wav": {
+     "bytes": 62108,
+     "sha256": "a13beef55a57c6506d1d7c9399c1962966bebd5d7597b0bb98a042ea4244ff4b"
+    },
+    "sound/misc/wood2.wav": {
+     "bytes": 54946,
+     "sha256": "4ddd034f1807ae0d133cbb86cc05cb7aeb7ebd5656b02c962c3eddda403acc8f"
+    },
+    "sound/misc/wood3.wav": {
+     "bytes": 85182,
+     "sha256": "1c91fd493b14935784229613f3024d4410f9b378199aa097ed62a696e4462b0a"
+    },
+    "sound/misc/wood4.wav": {
+     "bytes": 50172,
+     "sha256": "bf7711f7373e8a128216be8079eaac096c1105eff1b83231bcb684809737bea0"
+    },
+    "sound/oldone2/pd_pop2.wav": {
+     "bytes": 42108,
+     "sha256": "1eec3103cd2eb70fa8ba63ce8ce721842a64a99e9c373f5a8abe5508273ce285"
+    },
+    "sound/pendulum/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/pendulum/swing.wav": {
+     "bytes": 12960,
+     "sha256": "68da54f9541808bdaa1f070218bd53ffce0cfccee46b460fd9181a366440952a"
+    },
+    "sound/rm_carcosa/glass.wav": {
+     "bytes": 31240,
+     "sha256": "d367db8cdc3a043fa615d8fd66952810060967050679628d57e7b9285b67c4ad"
+    },
+    "sound/scourge/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "textures/mapcovers.tga": {
+     "bytes": 10416079,
+     "sha256": "885784f3266f7b5a855427ee438aa5609cb4e3e20052dd237949910cd39e1de1"
+    },
+    "textures/modecovers.tga": {
+     "bytes": 7958603,
+     "sha256": "205f790854ce56bc42afad951abfb13be775277809b4142ec0a8e4391a56dd1e"
+    }
+   },
    "sha256": "e8062423e06ffb0fa0e6478c1c004be984393cee1e56025f2393b163a7ad3b7a",
    "timestamp": "2023-10-07T23:25:30.000Z"
   },

--- a/json/by-sha256/5e/5e28e1bf5bbeffe5cfaf6429f163dded2f5c2780d9561c696033139eb1afa816.json
+++ b/json/by-sha256/5e/5e28e1bf5bbeffe5cfaf6429f163dded2f5c2780d9561c696033139eb1afa816.json
@@ -32,6 +32,584 @@
   },
   "jpqm12/pak0.pak": {
    "bytes": 38800184,
+   "files": {
+    "maps/debris/brick01.bsp": {
+     "bytes": 7912,
+     "sha256": "c11880924b195ed38908cbf50f9cd16f071918df0a94a19c7254b93dddb1e62d"
+    },
+    "maps/debris/wood1.bsp": {
+     "bytes": 7584,
+     "sha256": "c39390e3757553352941fcc255da6498be4c25a87575871e360a0166fac592bc"
+    },
+    "maps/jpqm12.bsp": {
+     "bytes": 20850760,
+     "sha256": "b24beabbe8352bdbbb68619d43b90f8e70c4fc08ee1868b836636c3e9380487d"
+    },
+    "maps/jpqm12.lit": {
+     "bytes": 7100414,
+     "sha256": "1cb18e3ae83d54ca8c12d0f79decb4f905caaf816fa34b488bb49a5981ed7cca"
+    },
+    "progs.dat": {
+     "bytes": 749842,
+     "sha256": "cf5045e62b6668ef38eece435e868c67dcc3051212d1fab442c2413a71e57f41"
+    },
+    "progs/a_mdls/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "1cdfc2b54dd883efe9215499603e341bfa72e800740a2e874e9bcf3b0afc68ba"
+    },
+    "progs/a_mdls/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "8cb54159eeaa410b98478e9190bd2d33340d3a2e98a61d32ce1afaf4e99031a0"
+    },
+    "progs/a_mdls/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ac361970fb1cbbb87ad4593afecd6d8973a65ea4f14e5f7b565c8f38c181fa9d"
+    },
+    "progs/a_mdls/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "0870b633f95bda895074e8d423631ee8805c3923f36a1c7f09938710783e8f99"
+    },
+    "progs/a_mdls/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "146955794f29c02f6570eed83e1d4b0013b0b4341897bcbc91cc9ffea6957ff4"
+    },
+    "progs/a_mdls/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "59988afc3603b83ccfadf0a9af423a113bf15ed969d4a62db9073e3061bc0fdc"
+    },
+    "progs/a_mdls/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "696594c11dd6dbd2e60ac6923d82a55f8f5b16e93b93f7914abe5fd4df74299f"
+    },
+    "progs/a_mdls/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "b558ee2dfd0078c7e3075079fb40368f53e7dfb162aaefcd20e53f562e405b1b"
+    },
+    "progs/armshr.mdl": {
+     "bytes": 20012,
+     "sha256": "1873523424395b404ffafeb447383185e033826e33bf0a001efc34604ece95da"
+    },
+    "progs/candle.mdl": {
+     "bytes": 24135,
+     "sha256": "5027f8712c36de87b3967e4e623fbc64d4e99644f5b805f7e21ec38b1532cc74"
+    },
+    "progs/debris.mdl": {
+     "bytes": 263072,
+     "sha256": "2b60cba9cbb454e3524d174edc0e1a540f2b2e91fa0b35fc2ab20ccb7fabd8d1"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 472208,
+     "sha256": "3345599ba081d346c163f5c239815bd65b134ccf342601f42a31e60a45044f39"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/g_shotgu.mdl": {
+     "bytes": 29076,
+     "sha256": "4a8866ab410a93522a3d3221e0f3b45889a488b54c0551329f09493273e09840"
+    },
+    "progs/g_shotty.mdl": {
+     "bytes": 23380,
+     "sha256": "b919bbcba3f7f03fb8b82fa6d3b1464ca41e81cf29417cfea0de09658c698cfb"
+    },
+    "progs/h_boss.mdl": {
+     "bytes": 24028,
+     "sha256": "b41e2302e15d7cb47bf1eb4ee1df29e7e8d773a3dfc6059f5b1f8ce18685bba6"
+    },
+    "progs/h_mdls/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "2e7fac7418838a721d80e80370000f3e400b21248b22c8d3555588d4f8437a5b"
+    },
+    "progs/h_mdls/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "1f4b0791be3156763c15521fbf2e747744ce3355d90d630b01c2227770314771"
+    },
+    "progs/h_mdls/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "6f792b9a80f34e31bceb4258e1d2c8f22d405a7ae1198b31bb285f502c720cfe"
+    },
+    "progs/h_mdls/pd_vial.mdl": {
+     "bytes": 8292,
+     "sha256": "035673048c98991e790abe484c2403b56dfe5ea1f5fb185c1b7a657d918668e8"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 42048,
+     "sha256": "52760ce1f6e8f657e782846571baf9fde80859f5342d07a684fa8218f96f68db"
+    },
+    "progs/k_spike2.mdl": {
+     "bytes": 444704,
+     "sha256": "e466e7afa95868ec1a3b3bfc770573d93dc20c2d881a73d2b9b0e35f1dfa6d9b"
+    },
+    "progs/lspike.mdl": {
+     "bytes": 1684,
+     "sha256": "59264317258f19955b967177f0dbc5be1733e4ca07c4c7b3cc333bb88bc0c46e"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 366916,
+     "sha256": "29fa9866dd4862b99ebb9944ddb0bf24a6d0bb4bf00e26a94d3622cead9b6315"
+    },
+    "progs/pd_armor_sh.mdl": {
+     "bytes": 31508,
+     "sha256": "46b9de8235f07190e18d67e147ed00be6dc322cd112ccde33bf4fc1f9a77e074"
+    },
+    "progs/pd_b_key.mdl": {
+     "bytes": 128440,
+     "sha256": "c5aff23b766037ab550636516d7fe0235dacf566ddb966541d640092bcb62349"
+    },
+    "progs/pd_base_key.mdl": {
+     "bytes": 21219,
+     "sha256": "320ec52018f501f8fe428dd46f44693787e545289be883a49f3bd6476974cf46"
+    },
+    "progs/pd_bpack.mdl": {
+     "bytes": 216724,
+     "sha256": "1839c92899197344935eca44d7b4c70e903af84ab633259786f8c12c39905149"
+    },
+    "progs/pd_r_key.mdl": {
+     "bytes": 269528,
+     "sha256": "7ef6894b955c4ca34bf3e2ebdc6288f55cc3b1285478444a81ca769866e1a119"
+    },
+    "progs/pd_rune_key.mdl": {
+     "bytes": 46335,
+     "sha256": "c4fe9bd66394231ace3127635f057987ecbf4b13b00d84501127caacb5db03fc"
+    },
+    "progs/pd_w_key.mdl": {
+     "bytes": 170680,
+     "sha256": "73f06fc10a53c93db25d67f20bad7672bc5f4e14bf3a6b5115d68f00696b536a"
+    },
+    "progs/pd_wiz_key.mdl": {
+     "bytes": 21907,
+     "sha256": "36b50211f687813b85648a46bd32a1d543a8f2af84e9d4223f8b5843f885e1bc"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 47856,
+     "sha256": "99fc3f91856aa6df2f25494a945e17b64b59ddc3faed424a6fcd73062a677fcc"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "e306ec0fbf0f5e4306c6683f7c7b87674bb0a168ef32a2b1118dcffb083deeff"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 320900,
+     "sha256": "e3321220ed34292da63fac94af63360c6544c055edd1eceed35d75eb26685e9b"
+    },
+    "progs/spark.mdl": {
+     "bytes": 2544,
+     "sha256": "77d081c51af9bd6c82d2d51dcb955a2fca5189cda4eb09a138bfa2e2b521fb05"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4416,
+     "sha256": "8c70353304b2d111260102565745a5504144568f932787906eaf50de742aa62c"
+    },
+    "progs/teleport.mdl": {
+     "bytes": 1058800,
+     "sha256": "98eeb63a1ded2d7a1d3788562478aff891af1be4ef1c552bcdb913cb338387b6"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 1058816,
+     "sha256": "ac4d47130af263cb6fd861d70ac09ebf758ab1a76da0b697e268382c65ae1a16"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 311493,
+     "sha256": "add013a5a6686ffd76ec0f2b2b3413757432ba4a8564ffd81aeb7eb2c5a98398"
+    },
+    "quake.rc": {
+     "bytes": 469,
+     "sha256": "490877c3d81446c26fd36f25b358a0e0e109e6b3566f23a6a2d41c8319849750"
+    },
+    "quakec src/LICENSE": {
+     "bytes": 18431,
+     "sha256": "189b1af95d661151e054cea10c91b3d754e4de4d3fecfb074c1fb29476f7167b"
+    },
+    "quakec src/ai.qc": {
+     "bytes": 18597,
+     "sha256": "bcd2d7de7ce600d39bbc9b189a2d9a6bde75cdcd0800e46bb14994424b287b26"
+    },
+    "quakec src/boss.qc": {
+     "bytes": 13803,
+     "sha256": "41ca279d62544cdb718df7bc2905e7bb5df06706c54ef348d2d478470a4d5515"
+    },
+    "quakec src/boss2.qc": {
+     "bytes": 16431,
+     "sha256": "d495677614d54635fe5f12d0f0d3fd88b88486d42ff2cc1cb467111390e79a84"
+    },
+    "quakec src/buttons.qc": {
+     "bytes": 4446,
+     "sha256": "58ff5453eac2d012d5514d6c10babe85187744e1bd293720b2c1bda1109ebe04"
+    },
+    "quakec src/changelog.txt": {
+     "bytes": 14317,
+     "sha256": "392ca6557e6c056f260904e815143403d98ecb8b6dde96d34cd98fc5504995fb"
+    },
+    "quakec src/client.qc": {
+     "bytes": 35005,
+     "sha256": "84ad056d736b796c3ca4000c41c5dc9cd487489bc4fd35eb2914c3c65f19c63b"
+    },
+    "quakec src/combat.qc": {
+     "bytes": 9118,
+     "sha256": "287c8d9d90a5dae838f6e2ced580bd306e545f255484a94308331a20d1c01d9b"
+    },
+    "quakec src/cshift.qc": {
+     "bytes": 1747,
+     "sha256": "b3442a5eb8b04cfdcd2020dcc0099883e22f04153560308f793d0fcad8b3efbb"
+    },
+    "quakec src/custom_mdls.qc": {
+     "bytes": 2275,
+     "sha256": "74f7e0e8bb25b8a70d54f1168ee90c773ee1bd909b15e045128f61e018716cc4"
+    },
+    "quakec src/customsounds.qc": {
+     "bytes": 5564,
+     "sha256": "26bce1b876f3a8a709a2b61298d1f65de5f568f24ac66db713e8585afc694f5d"
+    },
+    "quakec src/cutscene.qc": {
+     "bytes": 30738,
+     "sha256": "7b4d2fd6a7ffd2c2da115447e9f348a552d20c59728a072c7ced6308d31c0130"
+    },
+    "quakec src/defs.qc": {
+     "bytes": 28880,
+     "sha256": "7cabf435fd377fcdce5895ee1d0a27e91c46a002a4b1689df712dc8b06546a57"
+    },
+    "quakec src/demon.qc": {
+     "bytes": 15607,
+     "sha256": "14a99a3a771dfb5c0ddc4393a3cb520994a98fd16573f8ac6d6056a5b336f4f6"
+    },
+    "quakec src/doelightning.qc": {
+     "bytes": 4955,
+     "sha256": "4b6233156f3792d7529d714de7f992c066a927d5f9109d9947caa2a7a2341c57"
+    },
+    "quakec src/doeplats.qc": {
+     "bytes": 15495,
+     "sha256": "754e13c54f3d8ffc76ba80a1a7fbb3825ad5b300d9ff7f48195a7c6773036e80"
+    },
+    "quakec src/dog.qc": {
+     "bytes": 15129,
+     "sha256": "3434cfe57a78759e0295ba717cafee2514ac01ae737732be046b7708e23da988"
+    },
+    "quakec src/doors.qc": {
+     "bytes": 21714,
+     "sha256": "123edcc73083fd893140f1f4e5c337ca5925b923aa8f46862d1029ea1142afbe"
+    },
+    "quakec src/dtmisc.qc": {
+     "bytes": 30024,
+     "sha256": "f383fb5017b305923ddbe5a71868e20567128c1fd4b66d5a9a761d7e3ee1e510"
+    },
+    "quakec src/dtquake.qc": {
+     "bytes": 2654,
+     "sha256": "170b5464e0092f6a2f261910108381fd93fdb7fb5dd7bc047863f7bcc462dd9a"
+    },
+    "quakec src/elevatr.qc": {
+     "bytes": 3624,
+     "sha256": "eb6a260d53ca8f7b69f20a8cc42341c597d5e06ea18bca86e6aabff71bbc892b"
+    },
+    "quakec src/enforcer.qc": {
+     "bytes": 32786,
+     "sha256": "42de3a45a987bf7cf1921cc27d1d2a94129a43a4f8bb8b1de361e68968983ed7"
+    },
+    "quakec src/fight.qc": {
+     "bytes": 9867,
+     "sha256": "0c2b4e3afe48260206e086c9742bf99c34f4c83993a368c0cfca764a84813add"
+    },
+    "quakec src/fish.qc": {
+     "bytes": 11993,
+     "sha256": "d360b27d2e57192c2ebbaacd8532cdf7cd0330d63592032671c3b2efe5e41276"
+    },
+    "quakec src/fog.qc": {
+     "bytes": 15746,
+     "sha256": "8e89fb2fa6a035620617bf155a531cff3261c60711a5c8237283970383ab2727"
+    },
+    "quakec src/func_bob.qc": {
+     "bytes": 5676,
+     "sha256": "5fe11638fd89f509759c83748c519b98dc5fe5856b09fab1f6247518b9836143"
+    },
+    "quakec src/func_brush.qc": {
+     "bytes": 1471,
+     "sha256": "cec99401fbecf0b4b07c81d79f13f3ea05a0f13296e75ddc3fcab4fff0dbd1f8"
+    },
+    "quakec src/func_fall2.qc": {
+     "bytes": 8668,
+     "sha256": "eed5a376c5bc5a9262d2a6d08d46c67b3cae39a89830912a37d015e02e52d692"
+    },
+    "quakec src/hipcount.qc": {
+     "bytes": 5217,
+     "sha256": "da5c096495966fa9ef5315ba00b315987349a817c889b974d8a91f506e6aee1d"
+    },
+    "quakec src/hippart.qc": {
+     "bytes": 7983,
+     "sha256": "730ed584b4de9dd49283502419a8bcafb99e2f1a3d146e05afee0ab2547751c3"
+    },
+    "quakec src/hiptrig.qc": {
+     "bytes": 6589,
+     "sha256": "4a5b1c58309c0a2c2d44d6d1a455263decba46bd965d71dd4e600aebb07c47e9"
+    },
+    "quakec src/hknight.qc": {
+     "bytes": 30265,
+     "sha256": "1588171c8243cb9b71676cc35bb26cbfebe05e6577ea7a38c4cab8b7107ff3d0"
+    },
+    "quakec src/intermission.qc": {
+     "bytes": 11029,
+     "sha256": "a3f031f373dffa837a1988445fffd7d9b979af9a675d2cba7f4e2bccc8f0a486"
+    },
+    "quakec src/items.qc": {
+     "bytes": 66714,
+     "sha256": "85e2b7e7afcf5b0dab8db0f88187c5858c5790bffd98c44abd4269799e813c3d"
+    },
+    "quakec src/keydata.qc": {
+     "bytes": 5639,
+     "sha256": "5902993c9755a2851ef424e48572a9806d20d3aae67a8f9d01446c4aad09a91a"
+    },
+    "quakec src/keylock.qc": {
+     "bytes": 5884,
+     "sha256": "26751c63554a6e73da84138ee45871f501d3bb5250cbfa137a524087bc204e39"
+    },
+    "quakec src/knight.qc": {
+     "bytes": 14999,
+     "sha256": "b03ffc882929eece408722163dd9c5d25f34d8096417c3288c276c5e6778dde9"
+    },
+    "quakec src/lights.qc": {
+     "bytes": 16031,
+     "sha256": "5dc78d48aaafe3abdc220c3db75be4828bfba85fc25bbd62e799a29f4532a173"
+    },
+    "quakec src/math.qc": {
+     "bytes": 4317,
+     "sha256": "961dd24bcc4b1941fc249a6d148e2a562e24fda4efc9e47e1040b516f8d86c2f"
+    },
+    "quakec src/misc.qc": {
+     "bytes": 55326,
+     "sha256": "68871a011e43233445b6753cbceff302be8e570b8fb9049eeab2c032f1204681"
+    },
+    "quakec src/misc_model.qc": {
+     "bytes": 5082,
+     "sha256": "9b7e616256997b563c1e5ab44918cd4b936606e2d26d2cb79f7e3b270623546c"
+    },
+    "quakec src/mobot.qc": {
+     "bytes": 14723,
+     "sha256": "4d60beb5060a27a82d33ad6bcb5977e116bb9b93d9311aa7a30f925283b29be8"
+    },
+    "quakec src/monsters.qc": {
+     "bytes": 12877,
+     "sha256": "4f5e2c7356a11bbd1465e1148b554fd732c249360c68f32efd6baa3bec0a1114"
+    },
+    "quakec src/newflags.qc": {
+     "bytes": 5870,
+     "sha256": "192bf31eb0f13e6e55342801a42608caf797bfdfbdf27750c78ae67b1c1c5568"
+    },
+    "quakec src/ogre.qc": {
+     "bytes": 48366,
+     "sha256": "ac649ea8a41b1d4b4246f2e9c14bbc1cb7439381eba1b588c57545980f161930"
+    },
+    "quakec src/oldone.qc": {
+     "bytes": 10467,
+     "sha256": "33ce6342a7c06ab06af995f235ab8170917db359a956d6fd96d00709c54a08c6"
+    },
+    "quakec src/oldone2.qc": {
+     "bytes": 15136,
+     "sha256": "bad10c7974544972a4cdf8821eb745ea32a61de8bfa26c31b445ff1f619557c1"
+    },
+    "quakec src/plats.qc": {
+     "bytes": 22678,
+     "sha256": "6ce695f58b859c09c7d79ae741b31246ca49a322515bbad54898dc19e0a5e448"
+    },
+    "quakec src/player.qc": {
+     "bytes": 21779,
+     "sha256": "4c3935e710456c022c681ccf312109337616157bdebb7a72152f2ba37ec4cdce"
+    },
+    "quakec src/progs.src": {
+     "bytes": 2033,
+     "sha256": "539b2dd5c36d69491e26a508c772d2f751529753f44465f48c52ce73cd8402d0"
+    },
+    "quakec src/rotate.qc": {
+     "bytes": 31520,
+     "sha256": "ad5eee063eafd078f60ed3d247c19be9fc88887fd4c5aa307953c72089b53c6a"
+    },
+    "quakec src/rubicon2.qc": {
+     "bytes": 29182,
+     "sha256": "aef0904a68af683fb3002effa918306ddfbe4230a18fd3470af107bd34105357"
+    },
+    "quakec src/shalrath.qc": {
+     "bytes": 15839,
+     "sha256": "032b2f1eae78332de56603af833af57d78fa47ac29bf6eaf0a72c588b9e5c5df"
+    },
+    "quakec src/shambler.qc": {
+     "bytes": 26084,
+     "sha256": "782cdf07726bb5c9b63fe93d880b39b9a6657463d4b145b53d26fb21290e8453"
+    },
+    "quakec src/soldier.qc": {
+     "bytes": 21847,
+     "sha256": "28e94fd02188befb535bd16512cd6e7f4af3bdb5ef4a4cd6431965d8caf82474"
+    },
+    "quakec src/spawn.qc": {
+     "bytes": 10642,
+     "sha256": "51571dd7851c2daf9d657b19350e05f5d10f85a212afcdd06757e1a27df7ef83"
+    },
+    "quakec src/subs.qc": {
+     "bytes": 18016,
+     "sha256": "a7636b244cf1b7b8646feff48300c0ba8dd2d4e4169e18f14971de6904169880"
+    },
+    "quakec src/triggers.qc": {
+     "bytes": 51080,
+     "sha256": "0fa737b126deb2e312b3f42bbd7f82281fbcf1f35df6faf4f19d6a0259f07bf5"
+    },
+    "quakec src/utility.qc": {
+     "bytes": 4842,
+     "sha256": "a29fb47736072ad009a77ac4e063f9f7f4f854327b6c829a8e0403f4756c9994"
+    },
+    "quakec src/weapons.qc": {
+     "bytes": 41766,
+     "sha256": "faceddfc37e7b414656a4660b9f951d2eb90424a01599ec02c9f7e912cc693a8"
+    },
+    "quakec src/wizard.qc": {
+     "bytes": 16699,
+     "sha256": "02e4dfd2e264fd5901aaa3bb0a0ceb6381fc67027ddbba795c3702056a83cda2"
+    },
+    "quakec src/world.qc": {
+     "bytes": 21577,
+     "sha256": "37578572550ac480bf0ace9d44b0082768115490950dee14731782dfc41cde16"
+    },
+    "quakec src/zombie.qc": {
+     "bytes": 39679,
+     "sha256": "f2f4e0d2328c396087f9c4a06823861e5095f1c1ed7ec7a4163c8de350126fa4"
+    },
+    "sound/ambience/chimes.wav": {
+     "bytes": 250476,
+     "sha256": "d1060cd75d8a520b748047790d33c9a4ab5fd626330ebf1242d318d308c165db"
+    },
+    "sound/ambience/deepthud.wav": {
+     "bytes": 19940,
+     "sha256": "0798d1a1122171f06fd6b92e3f91881725c05f40e1eeb3494a5a1a1aa8a86e58"
+    },
+    "sound/ambience/distant_gears.wav": {
+     "bytes": 72502,
+     "sha256": "760d34131249ff3c4bccdab0cd3df69874728a6db3e1b4545177e5ce381e5e80"
+    },
+    "sound/ambience/lowboom.wav": {
+     "bytes": 666640,
+     "sha256": "ad591a6f574f48e654e32dacee6b7d862df8b47e20ef116f84415ad9aa515559"
+    },
+    "sound/ambience/moo.wav": {
+     "bytes": 265502,
+     "sha256": "35b7924115bc4cdf94e9cbb274a4d9ca251d6878817834bec08aaa176f2ddc9b"
+    },
+    "sound/ambience/rumble2.wav": {
+     "bytes": 99104,
+     "sha256": "9c3d5418c7e5bac60c365f0e8b7ea496dd2b51c72c13b0e5a6640e2ef880433a"
+    },
+    "sound/ambience/s1_stop.wav": {
+     "bytes": 16162,
+     "sha256": "9a35adf9361aa033b413762fea7d04b2cf7392b363f2aa187a81905f65a44b61"
+    },
+    "sound/ambience/switch_4.wav": {
+     "bytes": 44348,
+     "sha256": "bfebdf2afdbab57bd5be3fe0996ce19ff46d983eea4d1511d85af2e4f7d0db00"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 220548,
+     "sha256": "2cec0b03aa7047110862de21f8f6c77e4d98901ecaf5e405a473c2ddc922528a"
+    },
+    "sound/break/bricks1.wav": {
+     "bytes": 49956,
+     "sha256": "302547c290609bc311098f9f63643199bee0164e907edf0e2b9289ccbce2a4e2"
+    },
+    "sound/break/metal1.wav": {
+     "bytes": 70054,
+     "sha256": "c178f8f52631b1ff353fbeb3557e04e8bd574646ed47f78a3003350b67540979"
+    },
+    "sound/break/metal2.wav": {
+     "bytes": 65948,
+     "sha256": "7438b112d81fb92c285a507ebfbde5b15dbddcd90a85f51ecaae2df3ef83480c"
+    },
+    "sound/break/pd_bricks1.wav": {
+     "bytes": 61786,
+     "sha256": "3829842a9cb395f99d07546be38263eaf0ee5bbed71841aa8c93864d55a7fb94"
+    },
+    "sound/break/pd_metal1.wav": {
+     "bytes": 44146,
+     "sha256": "c0111b94231bc3870cbb95ec03f13b2b44ac407a5d18b35668ccf231303cc8aa"
+    },
+    "sound/break/pd_metal2.wav": {
+     "bytes": 70722,
+     "sha256": "ce8250482e831c270cc3c8e9211b74a627b3e29159c2c8ee720dd11cafd365c1"
+    },
+    "sound/break/pd_stones1.wav": {
+     "bytes": 75150,
+     "sha256": "632d15db23ff70c23c199595b41a153ded67f664de46b7d0cbfa0228f071156e"
+    },
+    "sound/break/pd_wood1.wav": {
+     "bytes": 34526,
+     "sha256": "621865f52fc27fb10108027ce3eea18aaf17181751a3ba1ceee0c9c99da9f375"
+    },
+    "sound/break/pd_wood2.wav": {
+     "bytes": 33342,
+     "sha256": "77282f2c533b9aec72b232aace9078534db3f255f418efafdf769c7361a28e05"
+    },
+    "sound/break/stones1.wav": {
+     "bytes": 69380,
+     "sha256": "1b58b722e55c4e2d25f65e820e279699a7b236a02685fbc6a41a40e573df1928"
+    },
+    "sound/break/wood1.wav": {
+     "bytes": 53720,
+     "sha256": "026e35d7108347603453765f66311fec99097ff9f82e2d2703f69b7d80ae07c9"
+    },
+    "sound/break/wood2.wav": {
+     "bytes": 59252,
+     "sha256": "4488c91dc44e526beb95d33ad200e07e484a6f2fea59578784f3417a00df81f7"
+    },
+    "sound/dump/armsh1.wav": {
+     "bytes": 22610,
+     "sha256": "46801976a87d548c2cb7b1548f12dfd0b3f1d246aa9d86944574fa3216c6d6d1"
+    },
+    "sound/dump/elec22k.wav": {
+     "bytes": 178736,
+     "sha256": "d56ff98d1d41511833c35b5a8b5311f00b7e13932591eee53f9e2adf788569e1"
+    },
+    "sound/dump/magic_01.wav": {
+     "bytes": 125944,
+     "sha256": "3ea2bab80feccbe0f0b518ec613f45093aa76b0128752f454e239c75175cb4e0"
+    },
+    "sound/dump/pd_armor1_sh.wav": {
+     "bytes": 12410,
+     "sha256": "3b80fc8000fe624ffbe4f119faf41a77406b83bd350020c7782bc03fd51a1799"
+    },
+    "sound/dump/pd_magic_01.wav": {
+     "bytes": 125944,
+     "sha256": "3ea2bab80feccbe0f0b518ec613f45093aa76b0128752f454e239c75175cb4e0"
+    },
+    "sound/dump/pd_quake_end.wav": {
+     "bytes": 37248,
+     "sha256": "3ecb621fbf5a3f2ab090ebc0f3036069292181b11ab366689b3dfa0f19dd372a"
+    },
+    "sound/dump/pd_quake_full.wav": {
+     "bytes": 156278,
+     "sha256": "872e0b0847fd366c59341d672cba9da0faaf85a881f8d4d5471a664923c8440e"
+    },
+    "sound/dump/pd_quake_loop1.wav": {
+     "bytes": 159956,
+     "sha256": "52a330a12c35191347008f4c546b1c83b4e387f3f33c9b60c3a5e8e545b0517e"
+    },
+    "sound/dump/pd_water.wav": {
+     "bytes": 92708,
+     "sha256": "0402b1fb2501dafb33bd43fa9c49c0f6a3fff615a200693cb7953852305c49f4"
+    },
+    "sound/dump/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/dump/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/dump/water_59_02.wav": {
+     "bytes": 40038,
+     "sha256": "25aa667940a737e46da0a829d9cb94922972b9b19726664d1a1133a666dc1439"
+    },
+    "sound/oldone2/pd_pop2.wav": {
+     "bytes": 42108,
+     "sha256": "1eec3103cd2eb70fa8ba63ce8ce721842a64a99e9c373f5a8abe5508273ce285"
+    }
+   },
    "sha256": "88f2e072675019da6b9554fc5879cfe0a900fab5d5b7dab00b52dd8928472aa0",
    "timestamp": "2022-10-02T00:01:28.000Z"
   },

--- a/json/by-sha256/5f/5f96f0649ccd114708566f3710357cb56e0ae0b060b2f19aade60cd8f26052a4.json
+++ b/json/by-sha256/5f/5f96f0649ccd114708566f3710357cb56e0ae0b060b2f19aade60cd8f26052a4.json
@@ -7,16 +7,2982 @@
  "files": {
   "pak0.pak": {
    "bytes": 23815404,
+   "files": {
+    "progs/acidbal1.mdl": {
+     "bytes": 8788,
+     "sha256": "8a9c956f1952fb8d9ea51119c1c8c758d3ca3b3bf3bb0e8b63131bf88325f5a9"
+    },
+    "progs/acidbal2.mdl": {
+     "bytes": 8788,
+     "sha256": "eceba377145b62b4721927e55de75423daaac83f9667852b16dd1bfff3beff01"
+    },
+    "progs/akarrow.mdl": {
+     "bytes": 23072,
+     "sha256": "4e0e1c007453dbc432533dab09dfbafa943c4f43f7897848c91a516bf0de43a0"
+    },
+    "progs/am_super.mdl": {
+     "bytes": 8976,
+     "sha256": "55d561bf2f73b2c6482dcb5649da1b31d4bbf40aef6e21cca3518dc6a0c5709b"
+    },
+    "progs/anglstat.mdl": {
+     "bytes": 164396,
+     "sha256": "ce4644a5e22e0ff39790a293754501add2a4ad8afa26cfbdd13205c3b833e923"
+    },
+    "progs/archer.mdl": {
+     "bytes": 581920,
+     "sha256": "858ad8a4d0d27e1a9989ad7d87a9a4404ff8adbde33b07868725d34fd2146f6d"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 114016,
+     "sha256": "3931d251b26709cabf212cd9cc9723ac2ff4a397ddc0f8e78dfc8424d337db6e"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 25752,
+     "sha256": "57518dd89a3dbf6e712ad204b0a6f41fd7fdc9bfc03cf4c17e222f9d31d72b93"
+    },
+    "progs/arrow2.mdl": {
+     "bytes": 68764,
+     "sha256": "0bc41c13a4332f6d13e7884248b2d1a83b487bc2f4e1d5cbbdcd1c81512a4579"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 293732,
+     "sha256": "19dcb60f0fe1927f344e82a68e2ba38e180824a37d07c7bb8a3fe2e2b5b18128"
+    },
+    "progs/bandit.mdl": {
+     "bytes": 226380,
+     "sha256": "7cc68b0c9a4950b4d3b97353227a6b8845104417efebfd00348b7fb24986d557"
+    },
+    "progs/baron.mdl": {
+     "bytes": 426204,
+     "sha256": "09a4b10b43c2cb4847330ce3660eab93c16a97a7db0c9e1c1447e938689627d1"
+    },
+    "progs/bbg.mdl": {
+     "bytes": 190836,
+     "sha256": "3bac35175b2808bad33e3b7e7c2c54b3d9181c5b3743aa68d803dbe58edf0eea"
+    },
+    "progs/beam.mdl": {
+     "bytes": 1460,
+     "sha256": "9e9531de6f4e6f2f6274ea6612ef00bd0642c0cc05a7fdc866805fa1be851b73"
+    },
+    "progs/bellring.mdl": {
+     "bytes": 74016,
+     "sha256": "9a8131071ca927803140ce6478b8912c6eb52856861250d6b6bfa1d32cfb9cd9"
+    },
+    "progs/blood.mdl": {
+     "bytes": 184,
+     "sha256": "06825646d627df610b374a31c9265a88c9c1c45864c6e3b9d273a14dc4d745a5"
+    },
+    "progs/blood_gr.mdl": {
+     "bytes": 184,
+     "sha256": "84caed23ff1b8cabec8c5d9e5c6792c30a6d9cc57c36a9746369012015462208"
+    },
+    "progs/bloodcb.mdl": {
+     "bytes": 28036,
+     "sha256": "83f0de29aa0f9e9f1d383895da374a5313aa2252edb306eb7bd69bd71660321c"
+    },
+    "progs/bookclos.mdl": {
+     "bytes": 3420,
+     "sha256": "a129ba5428a5fbef209010b893b4407c99a3d3a9e936d9d41247af5a75fc922b"
+    },
+    "progs/bookopen.mdl": {
+     "bytes": 6188,
+     "sha256": "d57ab7e96181b3fe70bc9c0c002ed6671fe14adfd454b680cd39be10b2315a05"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/chest1.mdl": {
+     "bytes": 19352,
+     "sha256": "239f897e3a390ad44acc5ffd19784f8b78232c5af2be67165581c2f6073ecc9f"
+    },
+    "progs/coin.mdl": {
+     "bytes": 44036,
+     "sha256": "c3d65aac43713c9102f8924ef7ed1cf90297ff17cfe8aface7936e9579b4ec57"
+    },
+    "progs/courage.mdl": {
+     "bytes": 14940,
+     "sha256": "4141933fbb8682ee28277826bd0f882580025def71b96c02cb9b53aa412906c0"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "7829e2cbaa4816577c77ba12a91933eee5dcf9d899f3f4d9717f6f8fc0319a23"
+    },
+    "progs/demon.mdl": {
+     "bytes": 245960,
+     "sha256": "b24014d5f453a854793b2753c11bda3130dd63c26edf12324bc376ecc9feb71a"
+    },
+    "progs/dog.mdl": {
+     "bytes": 269016,
+     "sha256": "9a60157b0504891c71fbaece5a729e9b954a5e2dffe92e1e1a1ab51c6d912b77"
+    },
+    "progs/doll03.mdl": {
+     "bytes": 52064,
+     "sha256": "b2962f3954740ad7f9b5ee329d3a189ed5c95ccbb279bb63dc77508c94e4fb28"
+    },
+    "progs/doomcube.mdl": {
+     "bytes": 8884,
+     "sha256": "c4d31e7a4f2a9c01c1c502fec3653d8e0b14fc6ec790d8edebb1737a6116a471"
+    },
+    "progs/dr1_head.mdl": {
+     "bytes": 7476,
+     "sha256": "06f28a6f55ba29f12965e7ca10d99147a9432c851a2747d1e861cd45c07d958f"
+    },
+    "progs/dr1_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "c208f5473b2954fb4af094119b5a63b3a205e7a26e94c0c122b1f06870db6f78"
+    },
+    "progs/dr1_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "258da574e4de9d144d4f6a71db72a8bd566ecc6b0672efeb5cacaf59c7dd969d"
+    },
+    "progs/dr1_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "698d06c98e8e9ab99b6ddf808bb32a4994299c9596354bf8f811cda0f4042588"
+    },
+    "progs/dr2_head.mdl": {
+     "bytes": 7476,
+     "sha256": "551d47f807e21d11aba52f66207515e0988e8a424012f204e517c8c6720514d0"
+    },
+    "progs/dr2_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "f636b0786ab159a368b9fa580f1a0a31dc7873f21edb1bc454eb9e64c2c27a14"
+    },
+    "progs/dr2_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "533c0d631c78c22f5ff7632e7dc19f5da1acee56225a5a1497bf34d10fc07344"
+    },
+    "progs/dr2_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "5f5eace00eef74eeaa9db48887636e08ab43c85ad0d05816745c04a4710f34d3"
+    },
+    "progs/draco.mdl": {
+     "bytes": 235148,
+     "sha256": "0b51fd9b782891c4b8b410db6ac1361dfa0f53d634366709434a926e0c7285b5"
+    },
+    "progs/dragon1.mdl": {
+     "bytes": 258260,
+     "sha256": "4dbf09c018ea9f703d4daf48c0a5e504208547d5d172bf26187b8eeac8a94a02"
+    },
+    "progs/dragon2.mdl": {
+     "bytes": 258260,
+     "sha256": "fa2b5d9467299634cddcff9c7ca87c2006c8c9631f45cbf66f74a8abfd5df347"
+    },
+    "progs/dragonpl.mdl": {
+     "bytes": 77764,
+     "sha256": "57db3cbef92a0f96cd8ef1be17ce77586f9541bbffcea2e7747e43b35c50effa"
+    },
+    "progs/drilbomb.mdl": {
+     "bytes": 5396,
+     "sha256": "6615fa32cb3b464b665093296ff63fd0c624eea5ec595247d8c66941e1c8d071"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "718b8c2842877345426247148dd6ce1ebe7fecc13e969a0fa0ed6dbebc388099"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "0a386b6381824b01852910519490ac3f6e3309a96091820384ee6b9a5b452e7a"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bef43e6c7bc067d3b35dd05a793c08d7d700fbb2013606ac9ffeac8772d0997e"
+    },
+    "progs/drp_head.mdl": {
+     "bytes": 2340,
+     "sha256": "b87cb902d796dd76c03e9fc79576f368d23022fbd5b5155c8910cd315046e32a"
+    },
+    "progs/drp_lw.mdl": {
+     "bytes": 7116,
+     "sha256": "ad483731fddede05ebf1a9a3c20f735f6ec341f156669833ed1077460dac8e5c"
+    },
+    "progs/drp_rw.mdl": {
+     "bytes": 8056,
+     "sha256": "b57363de0be61e45b355d1cceccadd42fdd1b8f91fc4380847dacf186d7560df"
+    },
+    "progs/drp_tail.mdl": {
+     "bytes": 2604,
+     "sha256": "b8ad65168755d4f31b657a80c78e2e0f51316c48f4ebd10ddae0b6971c7c6e89"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/ember.mdl": {
+     "bytes": 8788,
+     "sha256": "91d6f4dfbeba0711d0864b94bb372b602959644c5c841fd659ddedb8f8e6980c"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "13d14261d863f5170fb8e64e57b8ef344c435183313ffb1127ab6ce51176d262"
+    },
+    "progs/end_bane.mdl": {
+     "bytes": 52980,
+     "sha256": "4a86fd7bd59c4ecea934e3adcec4b17d627cdfac5223976a52b5739143c37f27"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 241252,
+     "sha256": "9ae37ced89200daf2d44795bef4230c5b725226a820c28cda7908f43bbdaa747"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 356760,
+     "sha256": "6ed7909a7a193f7e25bc623f1919d5c4cd45d5bd0fb5de1c13e9636a68cd9dcc"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 68804,
+     "sha256": "f3c760ecdbb530ff651c46f516228c588f37585315acdab199408911c2c8414b"
+    },
+    "progs/flame2a.mdl": {
+     "bytes": 68804,
+     "sha256": "e02210f2f6851cea4b9520476cfe36c31745dc2d84248f6a75132358d6d43035"
+    },
+    "progs/g_autos.mdl": {
+     "bytes": 52788,
+     "sha256": "02b529fe12090596209c1d6187e0cdf6a8c3b42b13dda283c094aef01516e341"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 56532,
+     "sha256": "36d304e1442ede2048036d832d36ef4624fe4e90ba16628c20c819e7b4477da5"
+    },
+    "progs/g_grpple.mdl": {
+     "bytes": 149440,
+     "sha256": "fc148b3a840b84b65488658ec26a27621a86a196feb90723269534929ee0352e"
+    },
+    "progs/g_gun.mdl": {
+     "bytes": 24344,
+     "sha256": "f6aa476d8352bf5b7010c68387fe53121f886b26e331d8dc32b9cfabf52067b9"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 38004,
+     "sha256": "cf67c0a7ad3e853fa4af7544d0399fc0a3795a61d625f5e78104e659e2db0eed"
+    },
+    "progs/g_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "3e4a1e9dc2bff162612e218a25e2040b57d063d198df2e301eaa8fa9542af098"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 158116,
+     "sha256": "127e4fefafc5015f03a6cd1288cab9da325ed5b5a93c9f6b90b6da9d8273ef9f"
+    },
+    "progs/g_wand.mdl": {
+     "bytes": 13684,
+     "sha256": "99212b7901c31b723704e7c62b1c5f70b6a2f7320c349605a3943f3091e962de"
+    },
+    "progs/g_xbow.mdl": {
+     "bytes": 22476,
+     "sha256": "bf1cd180a66f74da4e625a2167bf66527cebd0d4009fabeed48297018db8a4fe"
+    },
+    "progs/gem1.mdl": {
+     "bytes": 42612,
+     "sha256": "0b71e525b19e25f98dad53ce766751de8e0c9f18434582bb86242296bb7a402e"
+    },
+    "progs/gem2.mdl": {
+     "bytes": 62672,
+     "sha256": "721459e22aab0d2cece430053734b889918bde4db879ffc94084289a7b6d4d8c"
+    },
+    "progs/gem3.mdl": {
+     "bytes": 42072,
+     "sha256": "3bc3a1018cc432b694f9ec45de06775776ef55d21b4e117dd1b2c7c0d7b850a2"
+    },
+    "progs/gemini.mdl": {
+     "bytes": 35188,
+     "sha256": "fa05498ce8034d51377953db7c650f9367b072a9d614812f4f67ad15eace909e"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/gr_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "3f5b6d67b80e5f2e5bb7c129500c79dc345141133f8d415005f9384b0d2d9661"
+    },
+    "progs/gr_gib1.mdl": {
+     "bytes": 6501,
+     "sha256": "3f715cbfdcd77caef11b904aa12d2063cbb973d4a9d61c27492690344c14fb1b"
+    },
+    "progs/gr_gib2.mdl": {
+     "bytes": 17553,
+     "sha256": "c6166eb6132a3e87f51fcf48f4e9eebb719b3f1819d22640582b23d61bde4a16"
+    },
+    "progs/gr_gib3.mdl": {
+     "bytes": 22933,
+     "sha256": "0e40e5b960924ca642690c26b239c89aea6bae18badcb945e96d2102cad69622"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_archer.mdl": {
+     "bytes": 22128,
+     "sha256": "034d829e2ad34eeff8f5d60b8e2064f08caee64fb7f064900298f9405e9399d8"
+    },
+    "progs/h_axeman.mdl": {
+     "bytes": 18400,
+     "sha256": "e15391056ec618b412d1341914d2e6f05a759de92500ef249cc5d1789b3ab6d6"
+    },
+    "progs/h_bandit.mdl": {
+     "bytes": 9752,
+     "sha256": "cc79629b169c0560905eae7ea9a02e5ec546af8cfa07743922e0b1dc829b29ca"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 7444,
+     "sha256": "68bc1db4875fe84f25ff3d6c53e4e9e2c023ef52bf3c89b439493f2e5c5c0e19"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "53539bc39fc87627a46b75b0d86ade5e6116a0079b032b1df137b2425b7186cc"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 100492,
+     "sha256": "863b321eb07bf0de1e7ec85b948542ace35199ac55a19ced113a6d56412244a9"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 68796,
+     "sha256": "57a646b291c29b490faa38e3b72d7f074d9d071946d9b9c6068095999a11ce77"
+    },
+    "progs/h_drake.mdl": {
+     "bytes": 28792,
+     "sha256": "be0bcf5fc725dbb09a82becc2339d91824a14a547ce3013deabeece662658dcf"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 9752,
+     "sha256": "8974b166a431397d09b393ddc08dbd30a9e5bd1fb3421145d5b819984967d6ea"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 100172,
+     "sha256": "27311a59a95ab735d79e5198318d0507da7e377584702ba9e5bf673c0972e065"
+    },
+    "progs/h_hkolem.mdl": {
+     "bytes": 30552,
+     "sha256": "38b2082ead97b90f59a5fdcf24d4077ab067c55655598d023f8ec38818c914b1"
+    },
+    "progs/h_imp.mdl": {
+     "bytes": 73284,
+     "sha256": "d8146383fe6d31374c67718ff235e83d3891ebee5a0e44539b536ce049c9ce70"
+    },
+    "progs/h_imp2.mdl": {
+     "bytes": 73284,
+     "sha256": "8d41d426350d60fe2779154a4ff240c54b56e408fae7701a1e2904a210baebb3"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 19644,
+     "sha256": "1accd89ba95db3627cee4f06f94ab3bc9d146ebf566da24b570c733f2f902c1a"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "72455aab2067fd8f887e8a8e9c61d2b943699ce90fbcb85937fbb358c9e5678e"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 42848,
+     "sha256": "8f8c58d63873025f157eb37951d2a02c9d2d0cfeabaace76db7bdba303e35d18"
+    },
+    "progs/h_necro.mdl": {
+     "bytes": 14296,
+     "sha256": "fc9c468465d0e8982fc2d6207ce94b2f400f0f37cbe88cff2a4aa64719b91f40"
+    },
+    "progs/h_nemes.mdl": {
+     "bytes": 78156,
+     "sha256": "6f350692b44907984c02779d0114576bbafb6a3ada673e1f55d1cf02fd062c18"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/h_rebel.mdl": {
+     "bytes": 5428,
+     "sha256": "b189ff3ae1596da7596f21d8f555603951fadf8e7884e96f89c8b2b5789028a5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 53096,
+     "sha256": "ff1d940222f28765b975828528016332b04423a4001a507e07cde6414847add5"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 108204,
+     "sha256": "dd7dc5c90255da868b96ac553d8a8f68b6723da6b25114bc087fd019966a023f"
+    },
+    "progs/h_vomit.mdl": {
+     "bytes": 16952,
+     "sha256": "9822885036229871594a21643f4acd3a9b4c27d141b9021464b5062dfaf410f9"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "7ff66f881f85884aea56396da7b756da32c04df163a1e1f739485e77e61279df"
+    },
+    "progs/h_yak.mdl": {
+     "bytes": 73116,
+     "sha256": "eb2cf314618ef6dbc44ab46807237e59b68470edf24780e4ccd4c5b513f91196"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "2f6fd7256662a5a4b4b907b0ac68bf7d787ebd55cf54e352da5f1b363a2b2397"
+    },
+    "progs/hero.mdl": {
+     "bytes": 66388,
+     "sha256": "ea4f359a328b6416588e5debe13a87fc2eccd8a65263ae23683d71a58b39a116"
+    },
+    "progs/hk_golem.mdl": {
+     "bytes": 179204,
+     "sha256": "972f27eb2bf8a6cc4433e1f904097ca5393312d47a75e396b0323723beff58fa"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 534604,
+     "sha256": "10058c95eca9a063c7990d919d353d3573d252eb39f00c5f471a7f22f0b5fefa"
+    },
+    "progs/hook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/ice.mdl": {
+     "bytes": 2580,
+     "sha256": "30c4853e26d51d0ca4d3df5a40ec6d8861f48e9420f10560b5de0c19e6c15ab0"
+    },
+    "progs/ice_cube.mdl": {
+     "bytes": 3192,
+     "sha256": "bf96c8c1533fa537582bd4cf7bddadb7f5ddeebafbce9ef29007a5acd5a909b0"
+    },
+    "progs/iceball.mdl": {
+     "bytes": 24632,
+     "sha256": "802fa6260e9af5abb74bab0a76f35ae3e2af2373e61091c725325aa41051be7a"
+    },
+    "progs/imp.mdl": {
+     "bytes": 583036,
+     "sha256": "ca8746396a834b96eb3b6a5a2f7fe7d3930d1341a32aa528e58fc81053713a18"
+    },
+    "progs/imp_lord.mdl": {
+     "bytes": 583036,
+     "sha256": "6186f04775a695540a60543f48aad03b1d280c575399b8b68a9f69d799df74e7"
+    },
+    "progs/imp_rock.mdl": {
+     "bytes": 2352,
+     "sha256": "dbe190f471f5738779e103b496117ec40e2adc9e5f593d2470172bcbd7ade0f6"
+    },
+    "progs/imp_wing.mdl": {
+     "bytes": 93932,
+     "sha256": "d727c88da33bdcd3875509f8bf96af0cbcb31b25aa5f5b03ce1584aa0cec2047"
+    },
+    "progs/impwing2.mdl": {
+     "bytes": 93932,
+     "sha256": "6efe1dfb3290a80bc02bd47c1726a8aefc7956fa22d2e1867fbbd0557cc8ffd2"
+    },
+    "progs/k_ball.mdl": {
+     "bytes": 31300,
+     "sha256": "f93346ffeed3fd5d9866fb80d1a08216759bb27757d49a1851e471aadf757ec1"
+    },
+    "progs/key_b.mdl": {
+     "bytes": 10616,
+     "sha256": "d1333d74b7e194f6587d0f5ed1fca28887cd0414734b4bd4cbb7e715ab897629"
+    },
+    "progs/key_m.mdl": {
+     "bytes": 23160,
+     "sha256": "ea2feb6eb54823668dcb112f42c3441e563e18e3cc1806b5ce509044e6c0b448"
+    },
+    "progs/key_w.mdl": {
+     "bytes": 11576,
+     "sha256": "72da64d2b29d69605c453e9ee0e5fa8ecef91a94cc541103cb24fbad96c7946d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 232536,
+     "sha256": "e3e618799612c6e521f68234a061d9a46036ef556677b0c1651e7647258ffb56"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 27960,
+     "sha256": "5877b37cc4f98a53467c412e7d06d1f7ec6b60f5c0f2088514aa51c9d2c51769"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "210e159ea4c9bf1f2431213fd95902f4ea75ecee6a67a22bed7e93366f1f2732"
+    },
+    "progs/levitate.mdl": {
+     "bytes": 15876,
+     "sha256": "03e77b0d4b8ee7b3b224cbe0cfba63e8bd27d0391bd5069981e5435287f66645"
+    },
+    "progs/life_up.mdl": {
+     "bytes": 34676,
+     "sha256": "502716aa1b0f6cb8f929fe7ee2a74024a5fa007898256e15ca495e126888c584"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 57796,
+     "sha256": "e8b38ca8f28a89f65ffc652e082e8a9aaf6a1a9db8302e961b9ceac1c8f60e8c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/morph_eg.mdl": {
+     "bytes": 300592,
+     "sha256": "14468fccffaa1508c03610dd58fb51cd9058ca3bab036bca18f7a41cb37c195b"
+    },
+    "progs/nec_rod1.mdl": {
+     "bytes": 16072,
+     "sha256": "2eded5df9441aca7a243bf6c2a831c62374cabf7bba1acd64a84803441d77fc2"
+    },
+    "progs/nec_rod2.mdl": {
+     "bytes": 4564,
+     "sha256": "60b0923cade4c8ab9a476cae75c7c73f71c1d13799ac7901d0be4db5d5038895"
+    },
+    "progs/nec_rod3.mdl": {
+     "bytes": 4132,
+     "sha256": "459edf5ee6ecf0c52ec83e055a2c12ad39d3d3a42a4774c442ccc686e298da47"
+    },
+    "progs/nec_rune.mdl": {
+     "bytes": 19524,
+     "sha256": "cea5c89dd0034465a54a8434bc9367554f0244c2e38ec9220cd28a5a53a444a9"
+    },
+    "progs/necro.mdl": {
+     "bytes": 577208,
+     "sha256": "a0e43517f3cb579e38baf9ee4b5058ed59036b69599c0fe3ffeff9c00ba843f8"
+    },
+    "progs/needle.mdl": {
+     "bytes": 16688,
+     "sha256": "5f714f6b43cc28ca1de1246cc0175ea2e07040f73c9d0a623dbe4b4577559c14"
+    },
+    "progs/nehjet.mdl": {
+     "bytes": 19956,
+     "sha256": "fd0346c9c37d2ca7d3e696a9ce0694652722f63326376ad3b8189fb81a68f5c3"
+    },
+    "progs/nemesant.mdl": {
+     "bytes": 202492,
+     "sha256": "099c26752c7160144a25716e0af0f30f8ff179766db4a05371a0392166f85c42"
+    },
+    "progs/null_256.spr": {
+     "bytes": 5412,
+     "sha256": "c52813b634ef1ab641fdd4c3a9739ad758f1b5c39ba5e10acbbf034ee0ff850b"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 230152,
+     "sha256": "b7c88ae295ef8fc8d17b4fd6facedbb8e464ee665039a884af8e215a3929f24a"
+    },
+    "progs/oldone.mdl": {
+     "bytes": 560224,
+     "sha256": "5690a29cb0ae1a4889bc398676db8477275b0953e2ab7bbb75b717509d93c985"
+    },
+    "progs/pl_oum.mdl": {
+     "bytes": 331236,
+     "sha256": "6939a925af5510ecece22c3cee3de418d3ba532f4eb17409ca1453d253de328c"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 55676,
+     "sha256": "c9810eaac822215e7c84f11e55bb614121d17a79a02aa162fb430b5f37664ade"
+    },
+    "progs/plasma1.mdl": {
+     "bytes": 9120,
+     "sha256": "78a81a8eaaf95f85cd0fb7bc31dfa45c30e660fc5265168178b50776afc96563"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/playham0.mdl": {
+     "bytes": 99756,
+     "sha256": "1016d24c984994843af5d086e36e548c55590018f1f6b2d78799e25a40271ec4"
+    },
+    "progs/playsaw.mdl": {
+     "bytes": 87340,
+     "sha256": "b53cffd1807a3710f03b350370d78dfdbb2b057455fcac9f00d1b0baaabbf8c9"
+    },
+    "progs/potion.mdl": {
+     "bytes": 53272,
+     "sha256": "6ee1b1294f1ff41bdf265d06d80fa22a89ff579acb70bd2544986a0235ebd6e7"
+    },
+    "progs/potion2.mdl": {
+     "bytes": 195484,
+     "sha256": "c4f0f920521bd6e1caa6072b19d11ba57f4d493ffc2d6a395190170c9bec702a"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 47008,
+     "sha256": "e7ba606cf1cc11d9ad5baef5aef9dfa9239b7550a1c12937965a562bc815e6a0"
+    },
+    "progs/pur_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "dbc2bf835db1c1789c329504f86802990a19288f67d9560f32cfe5a8d5a62885"
+    },
+    "progs/r_bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "2d776e4acdf20cd117f3f4d6be3647fb9d0e117756069cbfc52ece716fdbb251"
+    },
+    "progs/rain.mdl": {
+     "bytes": 39276,
+     "sha256": "9a13a2ff68c8d8eb27426cee38330a6237de8ceb9ba9ecb9b71071512b190a94"
+    },
+    "progs/rain20.mdl": {
+     "bytes": 42620,
+     "sha256": "192d3d8197976f98eb053e54a00536ca9ccc8769692e9c483990b64afa4e1d8d"
+    },
+    "progs/ranger.mdl": {
+     "bytes": 232148,
+     "sha256": "21e690b07a7d3b2b0fb630480a5fd52ea23b41a8571c3618d16ea1ab7508e52f"
+    },
+    "progs/rebel.mdl": {
+     "bytes": 215292,
+     "sha256": "433596df8d06be0882f00a2c1fad0ea49a8ae42ef148d32e0ae7c06c420322aa"
+    },
+    "progs/red_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/reflect.mdl": {
+     "bytes": 10224,
+     "sha256": "3e8b08d02c11ee9e5546c96c014c8e698ca9097046ff3873012033c0bcac8df9"
+    },
+    "progs/regen.mdl": {
+     "bytes": 50040,
+     "sha256": "9f887be71c06ab25ada96cf8c1c2a6abb68ac9610378d9e3a2abaf2fab16af86"
+    },
+    "progs/rocket1.mdl": {
+     "bytes": 34260,
+     "sha256": "c9412482647d681e08f74eb0c0260ffded91dfc67378996b86b720ef3cd2fd47"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 17204,
+     "sha256": "0dab5b94c60d92d55df3e44a8d8ea2dc0f949e98897a6525ee0be3f49a019b08"
+    },
+    "progs/s_expbig.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 165212,
+     "sha256": "5b78b324e252f95ef8f4a9fd4fb19f855c40f74fd1f93aae9b84ed822e9c3585"
+    },
+    "progs/s_fancy.spr": {
+     "bytes": 432120,
+     "sha256": "2dcb35ecb5312709ae4b295ebcf209e74a34e385823f54603e6fe0eb8999556b"
+    },
+    "progs/s_kinn.spr": {
+     "bytes": 45624,
+     "sha256": "c6412ac75ec56533cbf0487223c2c8a23a3d3518b0e3f7ed8af73b81cb6ecbba"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 8016,
+     "sha256": "fa366e4076268de137e0eecd88d02e3aac99f38c48c6ad0d0a74c88c95e8d4d4"
+    },
+    "progs/s_wave.spr": {
+     "bytes": 373212,
+     "sha256": "c2a3b258b2809f22247596b6e0505829853e9a5fd60fed7c471fd663cf9e9402"
+    },
+    "progs/s_wave2.spr": {
+     "bytes": 39480,
+     "sha256": "a0fbc773e66385a8bc3c16195ce14215050cbec7caa118fecae1a0c2a2c59d50"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 333284,
+     "sha256": "90757e506c9f0e49e4e9897708df4825e1b27774ff46abd9c113738380dfde62"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shade.mdl": {
+     "bytes": 83644,
+     "sha256": "080ad2839fafadfdbbe5412ac53061a917af3158f33e16f5df4b4f3dbe422ccb"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 128012,
+     "sha256": "94aca4b876e4794684f4f2b9e66f1c34f7b3935b0d35d406311b63aba17ea3c2"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 176048,
+     "sha256": "7ea0c1007179eb7a45112aaf38d8042213e8b644e6e79b9b1a8d4402c3843b47"
+    },
+    "progs/shubdome.mdl": {
+     "bytes": 97512,
+     "sha256": "3b92e43bc942b2cfba8c7b4e1206ad858484564d86bd7faa069db592f98c7232"
+    },
+    "progs/shubstar.mdl": {
+     "bytes": 14760,
+     "sha256": "ee5f914d7f3f930db06b1ead8d314dec0413e5182b7de24cc808076d117f3cda"
+    },
+    "progs/skulbook.mdl": {
+     "bytes": 15572,
+     "sha256": "794768c4237a3efedf0c13026213aa417dec5be7eba7971f6e1113b5167fb904"
+    },
+    "progs/skulhead.mdl": {
+     "bytes": 50688,
+     "sha256": "d0733746c8b7cfccdb8d0f30f9454c8863a470e6d56e8359828dbb450aade77a"
+    },
+    "progs/skullwiz.mdl": {
+     "bytes": 726948,
+     "sha256": "e6c5d266321455b7bb09834646d3dd6b6e212406aca999eddb666da9ccc7212b"
+    },
+    "progs/skullwz2.mdl": {
+     "bytes": 726948,
+     "sha256": "3df14137a65ec782657de1820320b8e5377fd89859ffd44d5f566cd9845c311f"
+    },
+    "progs/skulshot.mdl": {
+     "bytes": 63400,
+     "sha256": "73d6d8e5411b9ae3cf815c3b0cf695a5633cedd5d586565880a9146a1a5db5c2"
+    },
+    "progs/smartbal.mdl": {
+     "bytes": 27924,
+     "sha256": "288e2d54afcbdc5242ab831f3ef611710317c52432e4585a938a12df80b7a07d"
+    },
+    "progs/smoke.mdl": {
+     "bytes": 184,
+     "sha256": "2086abd9950bc643446309a80d9df86b4ebe3f2086f75e799ce943a8454c77d7"
+    },
+    "progs/smoke2.mdl": {
+     "bytes": 184,
+     "sha256": "cdae24fb7cf8efc6ec5271c297f18b04e8c69554ac4c4aedbccd7d3dd39089be"
+    },
+    "progs/soe_coin.mdl": {
+     "bytes": 26364,
+     "sha256": "5769371db409969600bd51d573162c663fb75d358c507fcff9a4aaea95fed4dc"
+    },
+    "progs/soe_gem.mdl": {
+     "bytes": 165236,
+     "sha256": "788f32633f1f3a9f6dd2e0c2dccb76871e02fc6e002db82a219f077dcc493c3f"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 234936,
+     "sha256": "c5900e7784535c5eda950cfdfe2cbf3d2d304b8902c2f8bd4987df87d7039cc3"
+    },
+    "progs/soul.mdl": {
+     "bytes": 8436,
+     "sha256": "eb4dc0dae8aed7c92d328096fd9633566b658c9cc65777211ade1e67c6e0ff64"
+    },
+    "progs/sp_gib.mdl": {
+     "bytes": 22228,
+     "sha256": "e902ce3a5e4be26cb781d29178b6e808c480f9e898bc50ecfa78ddf12d774238"
+    },
+    "progs/sp_gib2.mdl": {
+     "bytes": 22228,
+     "sha256": "be98f64e7c2cffce98e28d99b36856762cc15caf761015067fde234390e6b302"
+    },
+    "progs/spider.mdl": {
+     "bytes": 355540,
+     "sha256": "b7ba038ebfab94718a5aa328f0cdeda14040ecc7de70c080caba58ee1ad84a07"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "078b774958c598bdf1503934d51a1393aeb9aadebcde806db2272b04b233c6a2"
+    },
+    "progs/spikes32.mdl": {
+     "bytes": 7668,
+     "sha256": "983176e5f12571f9b38c9c5d100841e480fe8ccf143889a0e48292a5bca8bf63"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/st_baron.mdl": {
+     "bytes": 185964,
+     "sha256": "7c00af263c1349b9dda2b1a6706bcce7034e9b0793697d67a1bfa83963ba127f"
+    },
+    "progs/st_gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "813d52c557a1eb519d801652b4bd63acdc4ec18d62db53d843ca3dcaa88e87e8"
+    },
+    "progs/st_gib2.mdl": {
+     "bytes": 16228,
+     "sha256": "2d40c1eb75eeb6f5e1781ee9db7a0be10e0d07297d563f9035a8965c4c8c3d01"
+    },
+    "progs/st_gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "d44a77787c5ff633593ad9741ddfbe28809431daf3d32fbe92f8512871b9018a"
+    },
+    "progs/t_coin.mdl": {
+     "bytes": 35040,
+     "sha256": "ed7a18cfce56a630c9adaa37757e270419fca318b3fa655fea18002b089441b0"
+    },
+    "progs/t_gem.mdl": {
+     "bytes": 165364,
+     "sha256": "955761ccf88ef8f6adcd635fb70ae5d8e434b19394a15124acc4370e614f2409"
+    },
+    "progs/tar_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "1ef69998430a54ba662abb46a0ef303b3bf0066f53e84b166065e79d58a72bef"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 313448,
+     "sha256": "fc63e6f62c83975ab2756f0a844d012b887491a6c73d9350dfcb04a6e0355b3c"
+    },
+    "progs/throwax2.mdl": {
+     "bytes": 34872,
+     "sha256": "11a22371cc72adf001e21d04e1b8b65e01497f56410867aa42ea21c0ff304e48"
+    },
+    "progs/throwaxe.mdl": {
+     "bytes": 56532,
+     "sha256": "0ebedab9ab397ba15dc3f0d90df703af2984d1c070eabc08ba781c308968150e"
+    },
+    "progs/throwham.mdl": {
+     "bytes": 7072,
+     "sha256": "f161fedb096a34db55fe57e84acd2bc42295ffea688549235c762b9a70430b35"
+    },
+    "progs/tome_pow.mdl": {
+     "bytes": 2612,
+     "sha256": "40a792071152640897de449d672a693229a87a11bf5e37ab05fd1656be22b6cb"
+    },
+    "progs/tree.mdl": {
+     "bytes": 126509,
+     "sha256": "7705f8b4e337bd370dbd0392d33da437f08768723e6d43725ddbb07ac3662b9b"
+    },
+    "progs/tree_zer.mdl": {
+     "bytes": 101704,
+     "sha256": "f5dad886e64ef946b0ad0aba3a06da419579911c5248ee856d2d503e40c4beab"
+    },
+    "progs/treetall.mdl": {
+     "bytes": 120532,
+     "sha256": "e74e7c38099ccc833fadf3c7b7e97f746878d07102dad8cc5926546b344cb982"
+    },
+    "progs/uberpack.mdl": {
+     "bytes": 19348,
+     "sha256": "97285e9eab277d5266f54184b517f9f969873f44e2a85a67abc91646e6f185c1"
+    },
+    "progs/v_autos.mdl": {
+     "bytes": 111091,
+     "sha256": "ad4c498c4e98dd99069d1bcf0f30dcb05ec0f837ed0830f9c9344d22d3ba0e26"
+    },
+    "progs/v_grpple.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_grpplr.mdl": {
+     "bytes": 66772,
+     "sha256": "498a802274ca3ae7c77eba72840cce88e4f72ed2fb4bcc1614a2ead5f89238a4"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserb.mdl": {
+     "bytes": 43852,
+     "sha256": "67e854c43efe348faffcc1aed8415a8e68fe2069ec94447a3610b580b72f3f88"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 93080,
+     "sha256": "05655920347b597feff05a74725b20cb88693ac78fdccb3730918a01cc4e6811"
+    },
+    "progs/v_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "a2d573bdf52015bce7a571a2263a3e8d938daf0bc1b5e4589f84580cab7da2d4"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/v_rocks.mdl": {
+     "bytes": 58188,
+     "sha256": "be83265c847c9d1ca475c5928605587c6ff86689b58053a1c037ad3387bbf4da"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 165540,
+     "sha256": "abd6787fff37c452fa01f4bbc9eb9594311eaf4a794f161caeb5a501ab9e103f"
+    },
+    "progs/v_sword.mdl": {
+     "bytes": 94416,
+     "sha256": "74b2fd6983cfb317ce136eeef6029d0cda063efe4706abc12057ba32cb0e988a"
+    },
+    "progs/v_wand.mdl": {
+     "bytes": 27388,
+     "sha256": "b46ba82a45a24fe4833dfdfd3c9457b98096a5800d6620d6eae11895653a6698"
+    },
+    "progs/v_xbow.mdl": {
+     "bytes": 95168,
+     "sha256": "e65f7cfe84cfa7c84c34147dadcc8b5ceea9416c7e378bd2110961fd76348e70"
+    },
+    "progs/vomitus.mdl": {
+     "bytes": 79724,
+     "sha256": "03dffcc3405c63f0e0c11301a74da5403d957b66171a6f34eaf8998e4ba31550"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "7758aaf42d0d1617e4fb172ce842be4316073f63250aba46dad441327cccb2e6"
+    },
+    "progs/wanted.mdl": {
+     "bytes": 27860,
+     "sha256": "03337a468db14377fcd36842037d2a27dfb97c3d5d5f45fcfe408e79050a5839"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 67956,
+     "sha256": "39c4a5daef1cfafc1bbfff1ca8eebb5c75d27f953f31d29f249205762605a56f"
+    },
+    "progs/wings2.mdl": {
+     "bytes": 28980,
+     "sha256": "5342d6191f59e69eb830a5e833473ac253b3a7750063d5519f6d2da2b82f5573"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 109380,
+     "sha256": "d78cd5ac1d667ec808fc7664071e060cea40179a0ba094e2f4c119d5ef7a79ba"
+    },
+    "progs/wr_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "1bfb049cf920973e32d78cbf7cf8b6c0c18f8dde55006ee43798ead4b99af9a7"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 238732,
+     "sha256": "5d0f3d6b32bfec300894dbf066a15bd9e34b985919423446232ad85d2ad6d6b7"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "progs/yakman.mdl": {
+     "bytes": 736212,
+     "sha256": "91595b5866d8f85fe67f349d22fb0c4735a4255894ca7368b10bc06618b98a3c"
+    },
+    "progs/yakman2.mdl": {
+     "bytes": 265228,
+     "sha256": "caba3ad0554bc09c10855592447424ac93beff1665803b2e5c605bd36b28cbdb"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 226776,
+     "sha256": "f4d35645fa47d159cf7dee47a1652ff239cbe7a7b3df8567b865c6d44536abf4"
+    }
+   },
    "sha256": "94341046b38e03ab52a6e19e5847a9e9476db5c9f17a8c70b8c0ed219462797f",
    "timestamp": "2010-10-29T21:01:14.000Z"
   },
   "pak1.pak": {
    "bytes": 12054535,
+   "files": {
+    "sound/ambience/amb21.wav": {
+     "bytes": 80716,
+     "sha256": "d664ea08d9df7e7dd135eb0726c1bc142878dcc53d13564dd3dcc5562180201a"
+    },
+    "sound/ambience/amb22.wav": {
+     "bytes": 92716,
+     "sha256": "f444289984b285a1497f55e566fbbf1896a04fa38e291efaa3ec1a0720204811"
+    },
+    "sound/ambience/amb23.wav": {
+     "bytes": 40180,
+     "sha256": "e451997ac7f37d08bd8434d708f45ee2967693317684b947ce511c9df84828b3"
+    },
+    "sound/ambience/amb24.wav": {
+     "bytes": 42282,
+     "sha256": "ead78c8507a7a6a7d6c61e913a2319964f6a8f70b5f7f720c162725edd9cd5aa"
+    },
+    "sound/ambience/brik_hit.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/brikhit2.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/chant3.wav": {
+     "bytes": 116346,
+     "sha256": "5d71f12940688414ab8cabc0d88e323dc961b60aac66f17887712133f1cb8b29"
+    },
+    "sound/ambience/current1.wav": {
+     "bytes": 50906,
+     "sha256": "dabe357d48586dccb8e1ed18c49828797c9f7a8c02c7a588ddc76a62c9b1d3e4"
+    },
+    "sound/ambience/drip_amb.wav": {
+     "bytes": 105444,
+     "sha256": "b282bc6082754011ee21a82aedb490a856c0f694f57991992296554c13149b02"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/heart.wav": {
+     "bytes": 8190,
+     "sha256": "a5b42c46cca24da59c324bb28ce6887b3a2a3baafcc18b0db2b2485f1189a4e0"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 177840,
+     "sha256": "9daec0732dcc821670b8910a1371153e3829e604b6957bf95931bea416af6074"
+    },
+    "sound/ambience/mov_watr.wav": {
+     "bytes": 44432,
+     "sha256": "9d6721844fd5559ab4f53902e70ad9789a90710dde082d222bd814a36c00ab67"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/spark2.wav": {
+     "bytes": 61640,
+     "sha256": "7eb18b00cd5e7913fea7a85ec5b1db159d1d001d24d4f687bfdb5685cb163c8e"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 106286,
+     "sha256": "056f37dfd1d5f4eba1d1911245dc0930bb0c46a84d72d867a286e5a9540248a0"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 87710,
+     "sha256": "2bb46f7c8f70fd28f0ca47b294824bcca7689047291b6c5259eebe76ad6aecfa"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 140630,
+     "sha256": "5a4dccd168cbd9f759ac468d7aa879dbcdbe5637e0fd0521f641ba1d60f61817"
+    },
+    "sound/ambience/th_clap.wav": {
+     "bytes": 570992,
+     "sha256": "5b93e5d878621c2a92e66d6214b0fa8acf8ad5a35f4120f456ddf5678e941d94"
+    },
+    "sound/ambience/th_clap1.wav": {
+     "bytes": 72062,
+     "sha256": "1fc3146d501953545b2f2f261cd2fc398959a79c753a291702609b4cdd2e8682"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/wall01.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 28798,
+     "sha256": "f66c76f07eef275e904fcc76d7ca9fc2011f3de8c61ce0b3ad035464beb7a86c"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 110578,
+     "sha256": "c3e1ccb091b9d8a06b83530b5e29b9f26f5ad8b9dcd082f3da976c3d44944b87"
+    },
+    "sound/ambience/wingend.wav": {
+     "bytes": 90874,
+     "sha256": "63e435d896b097d4dc413fb1afccc2078f1d101a4f7bfc18c4e593ca9e8b344f"
+    },
+    "sound/ambience/wingget.wav": {
+     "bytes": 65148,
+     "sha256": "533bdbd7beffa4c71c66239e3ac417f2177b20a60ed39c379c59a10b2222b367"
+    },
+    "sound/ambience/wings1.wav": {
+     "bytes": 6028,
+     "sha256": "c9e05f66a1d728a88289bc213c9f3551f1e54a4f3e8ef23ab03f8d5019e7b2c5"
+    },
+    "sound/ambience/z1m2mus.wav": {
+     "bytes": 103768,
+     "sha256": "d54261d4c9a4a8a9fe0c51eeae343c6a5b381727af88d0bae6f9b40605b8e5d3"
+    },
+    "sound/ambience/zend1.wav": {
+     "bytes": 123618,
+     "sha256": "2df6c267197b2e82241e47ce4985b04d14e1ce3cff46cebf3177369057302bb6"
+    },
+    "sound/ambience/zend2.wav": {
+     "bytes": 73742,
+     "sha256": "0ea00395004f11d41ab60352517bf5ff5c88a73b8ff2ddb3f32b5085967e3003"
+    },
+    "sound/ambience/zend6.wav": {
+     "bytes": 252626,
+     "sha256": "3f3c412e55bc7534c423c0d1bec2d817e3aea06338b4d6c3f78c4b80e55d509f"
+    },
+    "sound/ambience/zend8.wav": {
+     "bytes": 112122,
+     "sha256": "27cef28aa3d6c3ea86f0c54168db07055abfc7af284bc5a35bf53a0e53f8d677"
+    },
+    "sound/ambient/amb2.wav": {
+     "bytes": 38416,
+     "sha256": "21a4f41fb5efb52587e60395f23824ef330674a8d9499fe2cda1c91603093bfc"
+    },
+    "sound/ambient/amb7.wav": {
+     "bytes": 43020,
+     "sha256": "de7f4a0d15c711c9ca63f74ee38acf78e4ce41800900e0193a43c3e55e4efde6"
+    },
+    "sound/ambient/comphum1.wav": {
+     "bytes": 20456,
+     "sha256": "af10cad0f193d07be9c98f0dd889840fad0f54f40a61d12a1325b78033a68c8e"
+    },
+    "sound/ambient/comphum2.wav": {
+     "bytes": 72367,
+     "sha256": "fbf1ff8677cf36d78e381437f3b8e758a589a108a50c92f24c514eda06ede3f2"
+    },
+    "sound/ambient/comphum3.wav": {
+     "bytes": 116441,
+     "sha256": "62d9624940b93bcd1897abb809cb9d6f2cb3872cfd6af9a792260fb17f800150"
+    },
+    "sound/ambient/fan.wav": {
+     "bytes": 54275,
+     "sha256": "6cdc6a19b0c740d5607fa9076f749dc485483362445630877c6b59ec67085a2d"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/l_hum1.wav": {
+     "bytes": 20790,
+     "sha256": "f1b8bb19b32258ca1b126d52eb98b17c2753a255eba60864f8ad325f564681c7"
+    },
+    "sound/ambient/music1.wav": {
+     "bytes": 213944,
+     "sha256": "bf498e0cf6541b3559abd978ac420c5cb19d6542d89f19f59bdba8019dc46688"
+    },
+    "sound/ambient/pump3.wav": {
+     "bytes": 40435,
+     "sha256": "ae8ca71a1ce41bb3fa02d993930b4f100db3827ef5768326a91e61f7857370bf"
+    },
+    "sound/archer/arr2flsh.wav": {
+     "bytes": 5464,
+     "sha256": "e9a0c059430744c6546a6be4be3a1e4ac775ea6c5e6440d14611ecd8c8447d19"
+    },
+    "sound/archer/arr2wood.wav": {
+     "bytes": 5458,
+     "sha256": "97c5106007e703618291242bf1c6db9853a9d625189fc26ec9c4864436b560e3"
+    },
+    "sound/archer/arrow1.wav": {
+     "bytes": 2296,
+     "sha256": "4aeac8630ff6036f095a251a018eea5baad7a59bd7e46f624dbfec793e44d7b4"
+    },
+    "sound/archer/arrow2.wav": {
+     "bytes": 3196,
+     "sha256": "0a2734df5a69f6407ffc34ab05d8655da5d7dc0e487627932390fa6cec022083"
+    },
+    "sound/archer/arrow3.wav": {
+     "bytes": 2156,
+     "sha256": "1b866280829cb7ac051f90609baa8db285f3bfa3a27b5814e72b021b7cc05785"
+    },
+    "sound/archer/arrowbrk.wav": {
+     "bytes": 5002,
+     "sha256": "f72e35d5232f40e503192ff0ee26fe152eb42e5ee7141b2bea33a9f12f38aa2b"
+    },
+    "sound/archer/arrowg.wav": {
+     "bytes": 15132,
+     "sha256": "8ec5ee520f81c69ba367ae549a06d5ea1643b43f81dea7d8345561c94c8412ed"
+    },
+    "sound/archer/arrowmet1.wav": {
+     "bytes": 2638,
+     "sha256": "87e6ef50bfe4dabf48a1fba18ad0138bbd298965f1a9d06e2b059019e6f74b60"
+    },
+    "sound/archer/arrowmet2.wav": {
+     "bytes": 3118,
+     "sha256": "2797466dafd51473b8b6b5fd3d02a5baa4fe92a1bf9342fb038a299230037138"
+    },
+    "sound/archer/arrowmet3.wav": {
+     "bytes": 2804,
+     "sha256": "1e77951ec2218add2a8bc1633a925e4a96d2ca247d7b5dfaaaefd7a9a4f2363f"
+    },
+    "sound/archer/arrowr.wav": {
+     "bytes": 9458,
+     "sha256": "10e4bef745e55fddd004ea78d24edb9d3d9edc1ce3053c377be07be27a4da144"
+    },
+    "sound/archer/crash.wav": {
+     "bytes": 11069,
+     "sha256": "60e704bdfdb0a97863b00f3514130a172b95a86bebbf89642b65a6e757a74259"
+    },
+    "sound/archer/death.wav": {
+     "bytes": 9526,
+     "sha256": "e824b3d7d66e8bfc3ce30cc3116eab1b2d2dbc09c6311f91ff25d3e7eaef19f5"
+    },
+    "sound/archer/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/archer/draw.wav": {
+     "bytes": 6874,
+     "sha256": "c94e5cec38dc40102beebd067554c91e63b86e5c1ef11dc17976733bd9f08ce3"
+    },
+    "sound/archer/explode.wav": {
+     "bytes": 17788,
+     "sha256": "1f7d6debef492f0861ee24049ad637a11b85d595cdf3f6d6aac422b7a0376d14"
+    },
+    "sound/archer/growl.wav": {
+     "bytes": 9240,
+     "sha256": "7bdbbd23b3fe056cd1d904124824aa0044acf3aa19ec88f65e092fd13e4b9437"
+    },
+    "sound/archer/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/archer/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/archer/pain.wav": {
+     "bytes": 5082,
+     "sha256": "5347daf1a9263320f25b2a191895fbf6c85278f1fde6ca5962c09ed38e0b37b0"
+    },
+    "sound/archer/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/archer/sight.wav": {
+     "bytes": 16866,
+     "sha256": "bcd12d078e7bc34f0bdea7ae9a34ccd2c9bacb049617329b44f8301c34fffeb0"
+    },
+    "sound/archer/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/bane/death.wav": {
+     "bytes": 10935,
+     "sha256": "7e4775bc543acfb421a446a00efff6d9d5669fafb2387464cb1e1ae3db91efe8"
+    },
+    "sound/bane/growl.wav": {
+     "bytes": 9045,
+     "sha256": "86e7b3d2e685d7c20e503bdffe676727426b606ef069f4b70f182601e910ec4e"
+    },
+    "sound/bane/hit.wav": {
+     "bytes": 3884,
+     "sha256": "228faf88857d697f4d5fb9b9c03f000af4dbc8b254791e18e973fd48cc96db9b"
+    },
+    "sound/bane/laugh.wav": {
+     "bytes": 22108,
+     "sha256": "ae8e8d13e00f41bce729977f09a92806c8451ebe5cb4e8618a6b79df4d70296c"
+    },
+    "sound/bane/laugh2.wav": {
+     "bytes": 31560,
+     "sha256": "5cc5ff4c3be35eec90eaaa6579a55fa843843ad658e2e4bbb258a77f6e410020"
+    },
+    "sound/bane/pain.wav": {
+     "bytes": 9325,
+     "sha256": "1d4cfac1f9dfa1ec6958b18014ec7be18dc2615e64888d3c584d50bb48e51013"
+    },
+    "sound/bane/sight.wav": {
+     "bytes": 22962,
+     "sha256": "fbaabe115d9ca4b985c4481ccc71e6b6f55931394a29a6c51ec97e752ed3d5be"
+    },
+    "sound/bane/thunder.wav": {
+     "bytes": 43130,
+     "sha256": "cb355478e38df678e859557a0f983120a4d4275272d8ebedcae7c9cccf659bc4"
+    },
+    "sound/baron/bpain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/death.wav": {
+     "bytes": 8576,
+     "sha256": "3dd3a23d5a913548d0d0aa6ee1b455017648fcd4830f204539a1626c2ec8e1c9"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/fireball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/icefire.wav": {
+     "bytes": 8858,
+     "sha256": "b529a958de192b59438989c6b98eb50f858273febab53a238b651c70a3c92098"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/shard.wav": {
+     "bytes": 14324,
+     "sha256": "313428dd2cb681a38ad89983ab39b18979f64b3e398104b1ad80f3dc9726616c"
+    },
+    "sound/baron/sight.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/tornado.wav": {
+     "bytes": 11469,
+     "sha256": "9ede270665956ce33daf9d3b49447c09e198275f640ccaf77af4f44273bd3f64"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/bishop/conjure.wav": {
+     "bytes": 54627,
+     "sha256": "532d4b7d5db6a654aa73dfe18fa0f6a71623acfd804a848f106b0af699022bc4"
+    },
+    "sound/bishop/journey.wav": {
+     "bytes": 42051,
+     "sha256": "0995e55661447c53c3a36ae4552ea2e0bb7ec8b178bf52cdabe9d28b4deaa50c"
+    },
+    "sound/bishop/rip.wav": {
+     "bytes": 31906,
+     "sha256": "7070871da7ec08da6260a65f1a98ed1bf9682b1c95c51cea262a4b88a63fb6ca"
+    },
+    "sound/bishop/rot.wav": {
+     "bytes": 22463,
+     "sha256": "866b836874ba611d70675e5e3b83eac059c927bef0e0d1396f2183ea01bcc203"
+    },
+    "sound/bishop/skull.wav": {
+     "bytes": 34293,
+     "sha256": "48836a4d60ed8962ed0f11bffdcca95a200645e3b2cfa49a598d6392e10dc153"
+    },
+    "sound/boss1/explode.wav": {
+     "bytes": 27690,
+     "sha256": "b7eebbb64696612ee18d8d1e25b9c5cc334a4562cb99758a446a22490215f349"
+    },
+    "sound/boss1/explode2.wav": {
+     "bytes": 14798,
+     "sha256": "4c6b14b163905823f629644fbec088f37f712cf7f76e10e2f91ef23f2b573ae6"
+    },
+    "sound/boss1/explode3.wav": {
+     "bytes": 19028,
+     "sha256": "69ef0c65811704d8996b726d6e2cbcf70528d3ca7b2f28ec8814c20e7ab76ad7"
+    },
+    "sound/boss2/pain.wav": {
+     "bytes": 84796,
+     "sha256": "b9c255890f61771966327ad49994306a1e3de4b702163a079b5a733b4016810a"
+    },
+    "sound/cube/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/cube/bc_attck.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/cube/bc_gulp.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/cube/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/curse/x_armor.wav": {
+     "bytes": 17988,
+     "sha256": "61b518c8ad8410a17eaca28ee190d96a0c3d1dc755593872d7ec5429c8c19157"
+    },
+    "sound/curse/x_damage.wav": {
+     "bytes": 14772,
+     "sha256": "f74f64e3f47cee7c9b424b94a426f93c133d8acc1e6cb15551a72ab361fe95c4"
+    },
+    "sound/curse/x_leech.wav": {
+     "bytes": 16692,
+     "sha256": "78aacf297df09e21645c2e04ccf181266c35c8e52303ecb498c90db33e8c7b27"
+    },
+    "sound/curse/x_muddle.wav": {
+     "bytes": 18932,
+     "sha256": "b85810135fb3eca3f141047a08cd42a0e527d6da6e9fcfca3887a15f89edad6b"
+    },
+    "sound/curse/x_weaken.wav": {
+     "bytes": 15946,
+     "sha256": "f98441764b5f258ee875090c73e5841f4c8f97decbfbd8d9da836a7aac30f430"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15692,
+     "sha256": "72e737f04f1d34044dfd812c6b0e233cd38a91e6b089633e312678756952de87"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16625,
+     "sha256": "bd4cd7902712282ef8f2f749e6fcf805c2ac5212994fbb1c22fc0fe0ea5d08e2"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15527,
+     "sha256": "0b472a984137667f4788336a4f7c60e07a8893f47317b2a158aeea39920d729f"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4107,
+     "sha256": "8fe56b192838dafdf7ff4737cf1e5555d3295cbca49c1ab83568281ee188153c"
+    },
+    "sound/cyber/cybidle.wav": {
+     "bytes": 11894,
+     "sha256": "af7b96ed2eb5bc55900957b3e4136bd5dd93a72dcebca3bc2eb67cdc5186d32c"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8122,
+     "sha256": "3ea23b8d7a68e754211a10a5338b0c8d65df6e2138d4cfe06cc053b9a0f601ae"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13081,
+     "sha256": "a5ec6d4eaa707ad0246b7a7e7737b1007043ea5e5634f6f63661ecc20c27c459"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48508,
+     "sha256": "b7aac875623f8dca7597eff3dcab5910453d043fd1f9df20da89232ce8bf9306"
+    },
+    "sound/darklord/death.wav": {
+     "bytes": 10761,
+     "sha256": "7f32e12c649aa4fc4c2edb773c45b6b4258d048176d95e060390834ee7b52493"
+    },
+    "sound/darklord/idle1.wav": {
+     "bytes": 5632,
+     "sha256": "c151a3cf537f5c3668fc116e6ef5c70c9286e8a12097f376ecdf8a04774926a1"
+    },
+    "sound/darklord/pain.wav": {
+     "bytes": 12684,
+     "sha256": "f332a8cdf67fe414966f59d46714154c94de7ebcca3880a47ef5bbdad2c03ef0"
+    },
+    "sound/darklord/sight.wav": {
+     "bytes": 16832,
+     "sha256": "9710267844facf1c627ea0a8f0df458d847eb899dccd9c570e9d967acc64fa07"
+    },
+    "sound/darklord/sword1.wav": {
+     "bytes": 15982,
+     "sha256": "d36670980603c18a67d500707de9db5a8d54128601d6a6c67f7f29677244aebc"
+    },
+    "sound/darklord/sword2.wav": {
+     "bytes": 12434,
+     "sha256": "f7730881c690e0ee6a440756f74630a21241239fd1fd3bbdfd88000c7e57d1cc"
+    },
+    "sound/doomcube/dsbospit.wav": {
+     "bytes": 43719,
+     "sha256": "97f61cb588bb405cd235e242bfca6fe1108171625a7aa4f2573d63682ac42e32"
+    },
+    "sound/doomcube/dsbossit.wav": {
+     "bytes": 57109,
+     "sha256": "5843548ad38c8eea72548481b5833590fbb7fb990daebd0ede4aaac93475f461"
+    },
+    "sound/dragon/acid.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/death1.wav": {
+     "bytes": 18358,
+     "sha256": "645baa1cccaf1dfbcd628d17fd8ea290f42f1bc40903e26c79a536a6d1528a2a"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/fly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/flywater.wav": {
+     "bytes": 11034,
+     "sha256": "68cac399467a55df3c80331696869309eea2339467df0ba94408be4fa2afeb3e"
+    },
+    "sound/dragon/ice.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/icehit.wav": {
+     "bytes": 9370,
+     "sha256": "089c07d0352678106aaa1c47f015792393d5aa01b4bd64fa35e798c4ee09108b"
+    },
+    "sound/dragon/idle1.wav": {
+     "bytes": 34068,
+     "sha256": "3a125f0bcf2908e4ba3af298b117f71c0efa43be4077e53c791b2805cce6a038"
+    },
+    "sound/dragon/idle2.wav": {
+     "bytes": 21474,
+     "sha256": "e1101ff0121687511a9c978d0a30a945421d0a2a30b7d139e4427d41dcc17628"
+    },
+    "sound/dragon/pain1.wav": {
+     "bytes": 6524,
+     "sha256": "6cdce2fde3a1eb328007e0667c5dfe705e87bcd526e416ac948fa11a36448ac0"
+    },
+    "sound/dragon/pain2.wav": {
+     "bytes": 6875,
+     "sha256": "3238b77aafcc60c634cbdbd47ae1eec99bb969e2161b72ce5623398e6a451d2a"
+    },
+    "sound/dragon/sight1.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/sight2.wav": {
+     "bytes": 15205,
+     "sha256": "197238a35261e6792c40a4da38ba7b3827116ac1af5f143e092768346605b470"
+    },
+    "sound/dragon1/active.wav": {
+     "bytes": 16118,
+     "sha256": "5c8762ad62bcb65e1a6fa3362393141a8564fca3ad28ea896a18545c5ebfe6ad"
+    },
+    "sound/dragon1/attack.wav": {
+     "bytes": 24688,
+     "sha256": "3b3d3eb1e9e67c7641ead96926959e8ccd86bd4ec6e63e77ef5944616ee3dbc9"
+    },
+    "sound/dragon1/death.wav": {
+     "bytes": 63766,
+     "sha256": "55eb476a990e479c06b4c9a12b71c595d8ada35e813e512986709650ef0e54d1"
+    },
+    "sound/dragon1/pain.wav": {
+     "bytes": 28302,
+     "sha256": "60a99d79b6922a14e27ed63313e82ff17b127bda008bd614d8e9ed86f0f2cc3a"
+    },
+    "sound/dragon1/see.wav": {
+     "bytes": 39640,
+     "sha256": "e8202c360287700da28f96d6a14fef6bdea04374ea911f2b3e41183cd8a136ba"
+    },
+    "sound/drone/drnblip.wav": {
+     "bytes": 2106,
+     "sha256": "b372ece13de5edfb22d88ff147a9eccfddfe446c9403607d89daae09fc7c8b68"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/force/force1.wav": {
+     "bytes": 30022,
+     "sha256": "b609981695694648cab0f2ed521dbf3d6f31b6c2e8c3e8502ab4740c7a105557"
+    },
+    "sound/force/force2.wav": {
+     "bytes": 10252,
+     "sha256": "32c0342dbc9e63220db18fa706ac0fc1afe9a86f4d488e509e1f52bee955e3cd"
+    },
+    "sound/force/force3.wav": {
+     "bytes": 10252,
+     "sha256": "0317e18dab002184b5ce11a2b86f3263d2606c40f2dc435c824bbd075c1b621b"
+    },
+    "sound/force/fusein.wav": {
+     "bytes": 13669,
+     "sha256": "53192c25adab70ebcf471204aa194ef9d34c4161138c728d95f84cf08310a879"
+    },
+    "sound/force/fuseout.wav": {
+     "bytes": 15379,
+     "sha256": "f515c6b48204f2ba158e99c10a9da60cc45756ea5dca716e256ffbe54a017512"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/goblin/death1.wav": {
+     "bytes": 13890,
+     "sha256": "bed0d074d9aeee8f046ec7b3a9d33e02d157374ddf6af1296bd1ca7bebf30f10"
+    },
+    "sound/goblin/death2.wav": {
+     "bytes": 10280,
+     "sha256": "9cc07020579d50185ea401835e41edbd1c8f007065e39a6306c7aab4f32e7781"
+    },
+    "sound/goblin/idle1.wav": {
+     "bytes": 9802,
+     "sha256": "6c5a8c36eedb0ac5bddacfdf68250c36fe472f9d87e8969b4f95a863a99b77ce"
+    },
+    "sound/goblin/idle2.wav": {
+     "bytes": 9242,
+     "sha256": "5850c885e59ef04ae90be0579dd6f6b7cc26c282045ccb163dab2c9e19fea704"
+    },
+    "sound/goblin/pain1.wav": {
+     "bytes": 5118,
+     "sha256": "8afd94fcaa2d20e7c6626eda0c6cd5463670a1dbed0eeea36da588b28196c8a2"
+    },
+    "sound/goblin/pain2.wav": {
+     "bytes": 7898,
+     "sha256": "ad1f3b63b4ae35e4bfe010447bbd18bb85cd2bbf966ea7e1370afb0e924e699c"
+    },
+    "sound/goblin/sight1.wav": {
+     "bytes": 12716,
+     "sha256": "1c20028239d217f31af57649da5d1a6def576569ef5fc7e7033c2acbef7f9345"
+    },
+    "sound/goblin/sight2.wav": {
+     "bytes": 19356,
+     "sha256": "c9182325cacd9734bfedd48cb5d8076d5823b7a94baa40d32b02de9504474b48"
+    },
+    "sound/goblin/sight3.wav": {
+     "bytes": 8526,
+     "sha256": "796b2f9f0a1c20d672382c6681e9a6ea200fee2cfcacb5b3d3faa72c8e2537d4"
+    },
+    "sound/goblin/sight4.wav": {
+     "bytes": 8668,
+     "sha256": "c0a60baf2b9918a6df5fc32cd8b58c9fa7cfed923a4cb21c841f04f7a544782e"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 27521,
+     "sha256": "424ceef852229e94dbbbc879f1546a8dfda90db93c6263700cf4973805e4bea7"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 16192,
+     "sha256": "98d55bc63eff48521faeed1046064569e932986e734168ba0973c184aa2f5d12"
+    },
+    "sound/golem/step.wav": {
+     "bytes": 11226,
+     "sha256": "851e243a2e6ecf4cb637f8c4368b0f25443d4f9d104733eecfa886c40ee92bcc"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 47176,
+     "sha256": "87f013eb50cb30a967a183f0cfa41b4848f9269afd13dbe1ab5053458bfc5f0e"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 10768,
+     "sha256": "c48f2415db3a5067dfbd99ad580e3f4809532743d653eafe2fdb924fb0bb832e"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 47502,
+     "sha256": "a0c0bd639af614c7714388009c9388f6db9a694e7ecd8fac38653609d6958f61"
+    },
+    "sound/gunner/death1.wav": {
+     "bytes": 67190,
+     "sha256": "14f89744b8f7225e0eefd9e291aee533fd9f759b6351b57d357d9597dba90956"
+    },
+    "sound/gunner/death2.wav": {
+     "bytes": 48066,
+     "sha256": "693d0d1142dfa12ce2dd1d7b959094c201f3bf783114064c29a572dffe2fcfe0"
+    },
+    "sound/gunner/idle.wav": {
+     "bytes": 18376,
+     "sha256": "6c5b1f1d39f1cc78e87cdbf584b8a508fadc99fc2b8b85d21d0e088d134a8b2b"
+    },
+    "sound/gunner/pain1.wav": {
+     "bytes": 17292,
+     "sha256": "afee7d4ac4f872716fe3deb5adced9a99bd3744784329bd12608d051b81ebfc7"
+    },
+    "sound/gunner/pain2.wav": {
+     "bytes": 20282,
+     "sha256": "38d472d2eaaa7638f7980a06a36043353e86d99aa7e86e0132c52639738c87b2"
+    },
+    "sound/gunner/sight.wav": {
+     "bytes": 22572,
+     "sha256": "395e28b6a4684ce2fa10f085f67d58d025421c594e65a0c2a1b67aeab2ee2569"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hkboss/iceball.wav": {
+     "bytes": 14990,
+     "sha256": "6aec96fda55dfb0120f106064cd324ea6e059bab3fdbb2d81cda297f9a82e02b"
+    },
+    "sound/imp/die.wav": {
+     "bytes": 8448,
+     "sha256": "a8b0e037b88829b978d3dbd3d5e657c7f775c73662d554f6247a387ba333d4bb"
+    },
+    "sound/imp/diebig.wav": {
+     "bytes": 14956,
+     "sha256": "d44d390ba11f8850105fd9601f026cb66525a415de7fc363d3574c86b72d22c4"
+    },
+    "sound/imp/fireball.wav": {
+     "bytes": 5492,
+     "sha256": "6362b59ded89655fa8b8877ed2639eca1a7aae1847306bbc3843fa98bedcbdaf"
+    },
+    "sound/imp/fly.wav": {
+     "bytes": 9204,
+     "sha256": "8036ccb256978c17234aa171267fb0332f1911b5f0dad7b9f74bba9378c39a37"
+    },
+    "sound/imp/flybig.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/imp/flywater.wav": {
+     "bytes": 9800,
+     "sha256": "c80045609b62ceb61bd8fb1a18a53c0f2fd5443502a802b0d6d3c61e9a1db4c0"
+    },
+    "sound/imp/shard.wav": {
+     "bytes": 10678,
+     "sha256": "f806167fe23f37826964c0cc345c438ff0e79c3ffb1fed2c85451c675448cae4"
+    },
+    "sound/imp/swoop.wav": {
+     "bytes": 10842,
+     "sha256": "100eacded51635de912cee171f093e869d24589c44f68887497fe751cf9b1e4d"
+    },
+    "sound/imp/swoopbig.wav": {
+     "bytes": 14012,
+     "sha256": "65d4de49684f2f9e2655abf8e4bf042a08bd706ec4971e6397f264f7274e2b63"
+    },
+    "sound/imp/swoophit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/imp/up.wav": {
+     "bytes": 12500,
+     "sha256": "874b533da43f713a1be27fbccadda8b6392fa8e689c8c4d17dac4b0d380f5822"
+    },
+    "sound/imp/upbig.wav": {
+     "bytes": 21472,
+     "sha256": "36c7bc087935cf7cd33482a50a75df75fc2bfbe53ca0ebcd9797a8bdbde73652"
+    },
+    "sound/items/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items/equalize.wav": {
+     "bytes": 13008,
+     "sha256": "933046049bae4d866250ad9a6e0a4b2a9385caffb4156daaca39ff7110a71126"
+    },
+    "sound/items/levitate.wav": {
+     "bytes": 44236,
+     "sha256": "8a04ce4a97dc22d095bc52d08111bcaaf5f57482f580ccbe0c61bdf8fd18913f"
+    },
+    "sound/items/life_up.wav": {
+     "bytes": 8660,
+     "sha256": "2712bd978343d4170bc1757706597d4de3940a07b6847977cbf117fa92f14c31"
+    },
+    "sound/items/money.wav": {
+     "bytes": 5100,
+     "sha256": "e4ac299499340c1be250f5d5e0824440d9e539de8a1d5b01e303056719cf822f"
+    },
+    "sound/items/quaff.wav": {
+     "bytes": 3748,
+     "sha256": "ebaa4ecc17dc67d3fbc5fe1a7541e4e19769ce941d043922f8572cb2da8d3cdd"
+    },
+    "sound/items/reflect.wav": {
+     "bytes": 14936,
+     "sha256": "90dd50b25175c8d514a52165429e9ca6b90c45dddbb0f301e5873146b4a4a06c"
+    },
+    "sound/items/reflect2.wav": {
+     "bytes": 33119,
+     "sha256": "5fb5afe50e0f5fa24f1c4481b3060ae222f40138ca81052cea047a57aa6b03e8"
+    },
+    "sound/items/reflect3.wav": {
+     "bytes": 7804,
+     "sha256": "a079e5aef6ed9fb7d5c992b0ef8e11932a9efa192eedac2bc530098e0550984a"
+    },
+    "sound/items/regen.wav": {
+     "bytes": 7984,
+     "sha256": "1e125e8e7c19f29eaf09b7ad301fdfe5126d922dfa84ba2af267cdf3351b6498"
+    },
+    "sound/items/shambler.wav": {
+     "bytes": 20182,
+     "sha256": "f0cdf78367b770c97b3b89abedb7c4fb0a9ee10d742acc8c98b3daba46cfc215"
+    },
+    "sound/items/tomepow.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/items/tomepow2.wav": {
+     "bytes": 33119,
+     "sha256": "1e2e62a6f251722741b7f0adeb38c59a1d05917d0f84c8f48922efece97f02e2"
+    },
+    "sound/items/treasure.wav": {
+     "bytes": 5554,
+     "sha256": "c86f66148e8dc99af2c8e877d64d06dc1c35d0caa9c6dc5c8092b268960b8edd"
+    },
+    "sound/laugh.wav": {
+     "bytes": 71573,
+     "sha256": "cb8e1381c70240a93233b8571d792e21950d00b1285f867cbc0ed1237dac1df7"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/b_rot2.wav": {
+     "bytes": 15436,
+     "sha256": "62c86077b7a29f48f5c872c68d262c03b73b57f876b718a05f2fc6b24b9a9ef4"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/bellring.wav": {
+     "bytes": 27600,
+     "sha256": "fe3b2972c722171144eaba160757803292a42342e737d6acdbd0b14802e686f2"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/dsslop.wav": {
+     "bytes": 11163,
+     "sha256": "b6a9f6e74b222169c87e6c56b47d2e7995b23b8b045f16be968f43290f22cf9d"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/met2wd.wav": {
+     "bytes": 3968,
+     "sha256": "a3ce3e10b609f7ae28fc6f39f1f5d55a7c99a41143fb161de7e4e47b7f40f100"
+    },
+    "sound/misc/metalbrk.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/mgboat.wav": {
+     "bytes": 26866,
+     "sha256": "666016e2aa958ea621ba03bee4339518f2ccc72aa3ee2d0838ef9032e8ffc981"
+    },
+    "sound/misc/pushmetl.wav": {
+     "bytes": 14042,
+     "sha256": "2657b0006f51ecb7077b5861b1b282e0bb8bef3bdd5ccb68b3bdd6794361099e"
+    },
+    "sound/misc/pushston.wav": {
+     "bytes": 11490,
+     "sha256": "f457b95dad6131472475ab22d9c260adf5d389e74629cd8ea36ca05ad7d4e749"
+    },
+    "sound/misc/pushwood.wav": {
+     "bytes": 13602,
+     "sha256": "7c3fa06978f8c7b632d12bbf1031a5ac316b44fdc5efd93338ab0a0a162bdf3a"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/rublexp.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/secret2.wav": {
+     "bytes": 87440,
+     "sha256": "36e9d9617a14daefd510e72308b9e85718a473e2b25a06b66026d463d6bbb519"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/misc/woodbrk.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/music/pkdream.wav": {
+     "bytes": 154898,
+     "sha256": "df8857901002ce9dde3c558743c94967db11cae4af3d9a0cdc00c8cc09e6a910"
+    },
+    "sound/necro/att_a.wav": {
+     "bytes": 8522,
+     "sha256": "a946c060cab5ee1bfff2d1af87cd71c9ccf63840a2751fd46fd32f387bee2c35"
+    },
+    "sound/necro/att_a2.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/necro/att_w.wav": {
+     "bytes": 26298,
+     "sha256": "9ae481ad41d16610b597989e82a8bbf9c35a74fe03a8e27900d72ff8b52e3c94"
+    },
+    "sound/necro/curse.wav": {
+     "bytes": 16852,
+     "sha256": "d3729c83c468d9320cf1f8914c8b52d446e818852c955d8d86a093c35c196b58"
+    },
+    "sound/necro/death1.wav": {
+     "bytes": 24010,
+     "sha256": "302e58b0f701ad07ade4a46d5cd3bd9c2186b2df3eb39e36c361918a72ccd24d"
+    },
+    "sound/necro/death2.wav": {
+     "bytes": 23594,
+     "sha256": "05f15a8430885b6688587eba5e249107c3e6df36d7937a3ddd2411d275e8842b"
+    },
+    "sound/necro/idle1.wav": {
+     "bytes": 49212,
+     "sha256": "737f382e89a40fc098214b77e9165e16f2a06323c07e910f336f2616b6ca87b4"
+    },
+    "sound/necro/idle2.wav": {
+     "bytes": 47120,
+     "sha256": "18893e7b31ff448831a7b7a5aa9a5d31b2dcd6e49ae8b58d5eea8b44683415dc"
+    },
+    "sound/necro/pain1.wav": {
+     "bytes": 19412,
+     "sha256": "f37e247a9e1436e4a86b78fe71e1ea6da43323e60943e86784ac87fc4393333b"
+    },
+    "sound/necro/pop.wav": {
+     "bytes": 18996,
+     "sha256": "22aff5a83ec82e759004d82308b2e210f824ac59bd3180d6b688c9d0134ca18e"
+    },
+    "sound/necro/pop1.wav": {
+     "bytes": 10836,
+     "sha256": "d5e9b7ce5a638a419eef07bba492ce75fb3d8002bd66b40d36b4dd89ad859e1c"
+    },
+    "sound/necro/pop2.wav": {
+     "bytes": 11228,
+     "sha256": "10947cad6cd5bcc0e0bc00fdbeccccd53b70bff1fda1a220c72ddc7e2b152b08"
+    },
+    "sound/necro/pop3.wav": {
+     "bytes": 11228,
+     "sha256": "56c4219dc0ecfb7ee8ff6d31fdf6c8c53c2b6990ce1b94ed956caee3c7cf83db"
+    },
+    "sound/necro/pop4.wav": {
+     "bytes": 10836,
+     "sha256": "451b660c65ebd2c7c89134896ed882d738c685f787810e1245587c0c28c38141"
+    },
+    "sound/necro/raise.wav": {
+     "bytes": 9688,
+     "sha256": "1c841e33f22cdcd5276bba9018aec5dae8c0f842da07eb261f48f1a6cc4c8314"
+    },
+    "sound/necro/sight1.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/necro/summon.wav": {
+     "bytes": 16308,
+     "sha256": "b7fc855d38431ac04e09389d7caf04bf0032d2b4edf86ebd795f1ab38d9feaf5"
+    },
+    "sound/nemesant/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/nemesant/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/nemesant/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/nemesant/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/nemesant/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/nemesant/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/nemesant/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/nemesant/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/nemesant/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/nemesant/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/nemesant/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    },
+    "sound/pendulum/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/plasma/explode.wav": {
+     "bytes": 29598,
+     "sha256": "7a95a8337c7ad87faccc1cae98ad7840352b08608fba08aff87a1b33610f9190"
+    },
+    "sound/plasma/fire.wav": {
+     "bytes": 22422,
+     "sha256": "7350d1e99f93a79bee84e94561e080dcb8448a3549a42742633cf604377a5097"
+    },
+    "sound/plasma/flight.wav": {
+     "bytes": 17494,
+     "sha256": "a03b46f31df3495a1b7a2b2f1a09f3e5223d4c0ab65aa0ed936e1445e893adeb"
+    },
+    "sound/player/boot1.wav": {
+     "bytes": 25624,
+     "sha256": "9b730ff4f811472514297921c78ea3080424c57b57ce7fa30c6c10f94bd8ccc3"
+    },
+    "sound/player/boot2.wav": {
+     "bytes": 25640,
+     "sha256": "23a3cd545ffa3c5c1e4a4c9549aff81dadd2f1ab451e397d5292c97024fc5026"
+    },
+    "sound/player/boot3.wav": {
+     "bytes": 25652,
+     "sha256": "004d267ae3fcce21aa66e566efa34e39e85915f202e3b55922b314cfd6efa2d7"
+    },
+    "sound/player/boot4.wav": {
+     "bytes": 25628,
+     "sha256": "9beb96d9a183cd6a13693961a216b4402350fc076c7a1ff98854d28c30a9f8be"
+    },
+    "sound/power1.wav": {
+     "bytes": 44370,
+     "sha256": "68f9d490b390a2510ff660917ac02fa1620893770a68a1188e06f94c57922523"
+    },
+    "sound/power2.wav": {
+     "bytes": 44370,
+     "sha256": "773aca5e1e60540b2abdc4b9b29c4281a04f6fad3bfc6bea1c029b42a7f0fe9e"
+    },
+    "sound/ranger/idle.wav": {
+     "bytes": 10819,
+     "sha256": "644fbbc14e20684fa31abc7f04969943ac950c33435271b0fa646aa324be4400"
+    },
+    "sound/ranger/sight1.wav": {
+     "bytes": 5379,
+     "sha256": "5023e2483fe5c1c37cd661d382e34c0b68eafe4bae0e35e8f3f7e516e78dcf51"
+    },
+    "sound/ranger/sight2.wav": {
+     "bytes": 11323,
+     "sha256": "3574f035e1a261b9a001d99a54bdb502da31da2639d95e7fc06f96b547c1ac44"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight1.wav": {
+     "bytes": 35068,
+     "sha256": "48db878a4eae15b37ee0ca333aae74d310103a9eaf2e4b35eecd43a89f626b9a"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk1.wav": {
+     "bytes": 19372,
+     "sha256": "42e41297df70202ec9965af7af5fcdabcab7fde43ba515c8ba0a1ee2e4429554"
+    },
+    "sound/shade/death.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/shade/death2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/shade/fly.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/shade/idle.wav": {
+     "bytes": 37192,
+     "sha256": "57b0a0a7a0e75a17df8c4bb68740b23325bd0bf3475d908ee92fa0522c71edf7"
+    },
+    "sound/shade/moan.wav": {
+     "bytes": 33684,
+     "sha256": "3a6644f2c0a6ead5992fa9752ec9b0d898f4c40f5a32b12fd61aa991f75fa0c7"
+    },
+    "sound/shade/pain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/shade/pain2.wav": {
+     "bytes": 8918,
+     "sha256": "c6fa3ba7c659faf38b00af9c9867c37ba730cbc662125f5307f755515243dc4c"
+    },
+    "sound/shade/screech.wav": {
+     "bytes": 28244,
+     "sha256": "55ef2615baa6ce39733892fc9538f702acc567f65250223329f15b191d9b1a47"
+    },
+    "sound/shade/sing.wav": {
+     "bytes": 35654,
+     "sha256": "9de82a1d3124c391466004aea5e8ad066bcc6ede2715e7978a92a2c8f66e3f6b"
+    },
+    "sound/shade/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/shade/taunt.wav": {
+     "bytes": 36418,
+     "sha256": "f556cad612249e63690ac28b17405eba70e3df43560c3a087062b9f330811720"
+    },
+    "sound/shade/taunt2.wav": {
+     "bytes": 28160,
+     "sha256": "a68174008206b79794d8d52fd027daf08767ce005189860c815cda021080363c"
+    },
+    "sound/shamvile/burn.wav": {
+     "bytes": 11316,
+     "sha256": "239c51d5cfb82ee7683075f6cd53d8a16fcc2da608c9db87c27fd7491160a627"
+    },
+    "sound/shamvile/melee1.wav": {
+     "bytes": 4700,
+     "sha256": "f418a627faa0b4630588914ecdd466c387e1d7d5ac2e09acecafa13baf33f10c"
+    },
+    "sound/shamvile/melee2.wav": {
+     "bytes": 6252,
+     "sha256": "dfeb5bcd8be8d9f1fcf52f89cf0af533ec28066eb0bf74e3ac4b588ca810f372"
+    },
+    "sound/shamvile/melee3.wav": {
+     "bytes": 13236,
+     "sha256": "7102a987921e4c291175ba252628613c2c6ecdb70e9a33e174b6bcf7addc239c"
+    },
+    "sound/shamvile/melee4.wav": {
+     "bytes": 9211,
+     "sha256": "da31a8531703998c06bc33c94639d5dd291c9ba24e6752599ec8e6113d3753b5"
+    },
+    "sound/shamvile/sdeath.wav": {
+     "bytes": 20996,
+     "sha256": "e27d5870c37ce74877a2681b5e9cef437d14b05c501fb93733c8e93d2d2b0931"
+    },
+    "sound/shamvile/shurt2.wav": {
+     "bytes": 3924,
+     "sha256": "541c66bfaf5f30c55d24c4013f4a8859159ebfdf2f054c681eb8b8200dba1c85"
+    },
+    "sound/shamvile/sidle.wav": {
+     "bytes": 5476,
+     "sha256": "ca3edcb476f3992027989a2a79ef21a7f8951965c8a0e77f89f0a0505f2d2b52"
+    },
+    "sound/shamvile/sidle2.wav": {
+     "bytes": 21511,
+     "sha256": "0e46d4e53c003136881723f59de4d706151b845d57608cd87361018acb7ef050"
+    },
+    "sound/shamvile/ssight.wav": {
+     "bytes": 15564,
+     "sha256": "5a5343f95ee503f1b481ef05499e023b681402b922600979367788f2fb91397c"
+    },
+    "sound/shamvile/ssight2.wav": {
+     "bytes": 27204,
+     "sha256": "2b22c0912485569f7ec87a32a29c88563c0cb8261b4428335540fc96f7e7cb52"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 19642,
+     "sha256": "91eba6c478e8475696f07079502af32d1817e3fb86418c32801846582f27561d"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 18166,
+     "sha256": "91301f18c459286798989dd164ae08f5e77433ac7a0b5c71522cf59e49bf1a30"
+    },
+    "sound/skullwiz/blinkspk.wav": {
+     "bytes": 31420,
+     "sha256": "48a4dbd2add9021727d4572af9ac4c6f333a9e2ace5fe7127ddd42c84a2ae1f4"
+    },
+    "sound/skullwiz/blnkspk2.wav": {
+     "bytes": 41834,
+     "sha256": "fc2602275102b7e1a577c30b7ab3ac2709881eb3a8798664577f8a65a9132754"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 23034,
+     "sha256": "0eb20419acddee8a5814ecad8888348f90a14db997af1045b02b6052dccd5fd1"
+    },
+    "sound/skullwiz/death2.wav": {
+     "bytes": 32314,
+     "sha256": "3b1d2ed146a334ba5cf77027faa47addbf45c51159ff9c7278a97dda8ed7ef82"
+    },
+    "sound/skullwiz/firemisl.wav": {
+     "bytes": 12186,
+     "sha256": "3583544b6d7105d5b029a490cb0730190ae9e8dc5ca8f9da1deae4ea0335e964"
+    },
+    "sound/skullwiz/gate.wav": {
+     "bytes": 16156,
+     "sha256": "5797c6450d14f363133be23d93c829a660f9b7692c07f905b5a723cda8075c55"
+    },
+    "sound/skullwiz/gatespk.wav": {
+     "bytes": 30092,
+     "sha256": "f9fc90ba497d650acfad76c42ed531314828093f114c69c28fd1611d326fab2e"
+    },
+    "sound/skullwiz/growl.wav": {
+     "bytes": 18944,
+     "sha256": "de58ed34dd69dc3e871d09ac6a5db81ef26d69e234f0834e72c6cd68501ead21"
+    },
+    "sound/skullwiz/growl2.wav": {
+     "bytes": 24954,
+     "sha256": "0cf747c71a6fad9a085c39456cd14ffd972d2d454b4bafc2781ce4464917cfa4"
+    },
+    "sound/skullwiz/pain.wav": {
+     "bytes": 6106,
+     "sha256": "0f85b6180cbfe8d26f8d174f25c109b9d8b78d0fa53735e0494280bc8a19803b"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 8890,
+     "sha256": "6d48429e7fc4b80be16afd80097b7096a94cb1a88922a62bdfdff64172526a0f"
+    },
+    "sound/skullwiz/push.wav": {
+     "bytes": 8812,
+     "sha256": "91398e953b648ab23c037940fb7996f3d77727003a60757ea50686328c05cd69"
+    },
+    "sound/skullwiz/scream.wav": {
+     "bytes": 31734,
+     "sha256": "6df299b2a59aa94a9640c83684b65259e4619e0ed2a2fd1ce518dffaa060fd43"
+    },
+    "sound/skullwiz/scream2.wav": {
+     "bytes": 13980,
+     "sha256": "adca10198e279db0789a1a026124387c40e36fc1914f3f3da315b49b6e290386"
+    },
+    "sound/snake/death.wav": {
+     "bytes": 17578,
+     "sha256": "7d8e2f12369ad5fe3eb025d6ce4fefdfa10fbcff2b5b87974a1c8ddde4f851bc"
+    },
+    "sound/snake/idle.wav": {
+     "bytes": 27111,
+     "sha256": "6a69f3635136303676e168088af4a55442cb77f914e2e82f77e06e07339f0f4e"
+    },
+    "sound/snake/pain.wav": {
+     "bytes": 13882,
+     "sha256": "3737842df2079f4a2af87787bc8c4d34642249fb891a2bf3ee4d4ac95f97a182"
+    },
+    "sound/snake/sight.wav": {
+     "bytes": 13808,
+     "sha256": "296c74493be791f96b3676551df7ec4ad4c13cbb1eb484509c46fb44ee6f76b1"
+    },
+    "sound/spider/attack.wav": {
+     "bytes": 6576,
+     "sha256": "82593fdd5be8198a9774c163872f89a088d8d0ca10e91f1c8f846ecac92b2d81"
+    },
+    "sound/spider/bite.wav": {
+     "bytes": 4552,
+     "sha256": "abd0b64743c825661f4598b7d5b70b781452a6b7747f9eb8b53f7239b0f9b9cb"
+    },
+    "sound/spider/death.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/gib1.wav": {
+     "bytes": 10516,
+     "sha256": "bbe1a437bd05a71f9d7bba953a79886891bfc526399c67cfc8964308c91786d0"
+    },
+    "sound/spider/pain.wav": {
+     "bytes": 7576,
+     "sha256": "386e11cfd8063b6bb692ab4b90246be98288f72f29614f2e38765df9e6eaad79"
+    },
+    "sound/spider/step1.wav": {
+     "bytes": 2780,
+     "sha256": "06ee408dace817630645b0d390c496e692844fb42cc85adcaa021efeb60fae9b"
+    },
+    "sound/spider/step2.wav": {
+     "bytes": 2620,
+     "sha256": "66e802d6361a17e637f5e38366e4b0912dbb0f65e647041bed57cfda772c0770"
+    },
+    "sound/spider/step3.wav": {
+     "bytes": 1786,
+     "sha256": "418b2c536f19a5bcd0b1a8ff4aae13febc8c4f8fa6787372e9e869c45a17f54c"
+    },
+    "sound/trog/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/tur_arm.wav": {
+     "bytes": 23794,
+     "sha256": "24b428117ebd7e82865b41dcfc74a75a048c4d126d7505a6c23dd243bc054a05"
+    },
+    "sound/vomitus/death.wav": {
+     "bytes": 13236,
+     "sha256": "fa2cad86ac0ce1326132c5e378aed6a9ff5615d043df1d4d48e0b2691f8d3bde"
+    },
+    "sound/vomitus/flesh1.wav": {
+     "bytes": 8412,
+     "sha256": "9ac5a8ac2155e7d9b65144e7f65525c4660ff5959fe3a0277fab347e202b6f46"
+    },
+    "sound/vomitus/flesh2.wav": {
+     "bytes": 12788,
+     "sha256": "3fc22e2aa2c3c0bdc6501388ac18abb5e58c5fd5deba39d1cc2f7e8d48fcc869"
+    },
+    "sound/vomitus/groan.wav": {
+     "bytes": 13224,
+     "sha256": "3632e43615714e5fc1be8277881a913bf1bd79b276544418cbf1b159016f0d03"
+    },
+    "sound/weapons/autos.wav": {
+     "bytes": 21780,
+     "sha256": "5034200a6f74a8be8a5c299e4b6fedaf2fc07c56a5e0e58d5811c5c76f92f388"
+    },
+    "sound/weapons/axhit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/weapons/axhitwal.wav": {
+     "bytes": 6694,
+     "sha256": "0f14ba18076b25a7b8ee510b38adb282eb5c4f2fc94168baf1f8a658e1da684f"
+    },
+    "sound/weapons/block1.wav": {
+     "bytes": 5484,
+     "sha256": "ccb284becb454f395de702a263bfda1561b8bd38117893d33b5ebbb9eb7b6865"
+    },
+    "sound/weapons/block2.wav": {
+     "bytes": 5612,
+     "sha256": "62da8e44f3b1200b99f76a3bdb31d9d09a9e74c04a449c0afc482c6677a94bc2"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/weapons/clang.wav": {
+     "bytes": 7198,
+     "sha256": "634a88cf26b4de688bed392cf108d5468749f212ce67015c71baa942e8e88502"
+    },
+    "sound/weapons/dsshotgn.wav": {
+     "bytes": 9490,
+     "sha256": "98c228b3549d4908c313c783d5b0aec38b93efea1c6a65d7355767bdbb4b87e8"
+    },
+    "sound/weapons/dsshotgn1.wav": {
+     "bytes": 6418,
+     "sha256": "452efbbaafcb29edde6f5d089fb2389e046635b1f715201ae750b3b7e849f378"
+    },
+    "sound/weapons/freeze.wav": {
+     "bytes": 20619,
+     "sha256": "48689ba550c116dd8b10a138bc0f78eb6f169d6828a49aaafe12f807930eb934"
+    },
+    "sound/weapons/fwall.wav": {
+     "bytes": 40140,
+     "sha256": "e269c07608f322518e709925d5b13daded150460d19d3091f15152ce4c06c9bf"
+    },
+    "sound/weapons/fwallhit.wav": {
+     "bytes": 9426,
+     "sha256": "7b9f4da432e6fa44fbf721ed9ef753e6ceb41df59b8265b58f73764b2901224a"
+    },
+    "sound/weapons/fwalltap.wav": {
+     "bytes": 8316,
+     "sha256": "879b9970dfc3bc609ff384a0edea13b594ea6a82b5c56d33c8549cd36cccda0b"
+    },
+    "sound/weapons/gldhit.wav": {
+     "bytes": 5842,
+     "sha256": "e19a73febbcafb1f3fc8774ea07fa51e8716c1ad29285a4d3cb5c6aeb4c1d5f7"
+    },
+    "sound/weapons/icehit.wav": {
+     "bytes": 10710,
+     "sha256": "9ed8ed177a6cfcad97f8adcf94b9f3114a955e7b3abb397c6b17c44073c07b19"
+    },
+    "sound/weapons/icewall.wav": {
+     "bytes": 6124,
+     "sha256": "9668486027e07f525a27830dc3217cde36bcbcc956b21437d2637e00df368dd4"
+    },
+    "sound/weapons/lancfire.wav": {
+     "bytes": 6520,
+     "sha256": "be8d154ba1404462776ec3f5fbbda0e974970dd5d61d97cf296c3711ede5bb84"
+    },
+    "sound/weapons/lashit.wav": {
+     "bytes": 12326,
+     "sha256": "4bc5e49e2ce9943a7cb5250fe451b94359757b5390c300a1d01354754c31c86d"
+    },
+    "sound/weapons/lobhit.wav": {
+     "bytes": 11413,
+     "sha256": "d565e0898917c710020e72f4561f1e0616d5259d6c43256f195a5e152103d953"
+    },
+    "sound/weapons/mirv1.wav": {
+     "bytes": 89538,
+     "sha256": "7d60062f61d5929f5f927526d81920f24684520d230a5f2611c128b832d3357e"
+    },
+    "sound/weapons/mirv2.wav": {
+     "bytes": 18478,
+     "sha256": "67311180da390517f2ef71d161a0cf7b770548dcd4a7dda7e679cb9b58025b4b"
+    },
+    "sound/weapons/nova.wav": {
+     "bytes": 10020,
+     "sha256": "d41c8433fa1b964fafa1cdb2fec301fb4d398f1fce201b4d80b29fab7a59d7e7"
+    },
+    "sound/weapons/pkup2.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/weapons/plasexpl.wav": {
+     "bytes": 54406,
+     "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/weapons/r_exp3a.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/rg_fire.wav": {
+     "bytes": 66260,
+     "sha256": "a3a7edd9c470077682bde595f95d88546d416f300202ae96bd6c6371ec19cf09"
+    },
+    "sound/weapons/rg_hum.wav": {
+     "bytes": 51244,
+     "sha256": "84b348b10921b5f7c6539a20ead4de132e0f7988ab8f1464669fbe6ce0a20c2e"
+    },
+    "sound/weapons/rg_power.wav": {
+     "bytes": 51566,
+     "sha256": "40ce379a835e11561573be1dfdf1806a9bcb27192b94333a126cc721e38bbde4"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/shatter.wav": {
+     "bytes": 20899,
+     "sha256": "31ddbef0dc746eabea23cd7cd2fb97a1f949a014b664630d7f04e6c237aafc03"
+    },
+    "sound/weapons/sheath.wav": {
+     "bytes": 7031,
+     "sha256": "8f28a1daa16db234ce77d91e688c7acbc9541c296d30af9e1f940b6d45eaf72d"
+    },
+    "sound/weapons/sprocket.wav": {
+     "bytes": 7126,
+     "sha256": "8b5c3bdc625b4954c6b504ee242591f0121d1ab64f2aceab54dd85fecadef8a4"
+    },
+    "sound/weapons/sprwall.wav": {
+     "bytes": 13126,
+     "sha256": "850c046e8c47a90fcc46df7d7d405a17e49f2d4e116ffbaeaf274c87becffc50"
+    },
+    "sound/weapons/ssg.wav": {
+     "bytes": 87616,
+     "sha256": "e7410f9cb2660ca799d85aa4167a5e1fb14f54d17aae46ac3a009f6a45fd7cbf"
+    },
+    "sound/weapons/stunfire.wav": {
+     "bytes": 9902,
+     "sha256": "7214cc44e4c0bfb801209f025b591d838542a3110f770e5614b0f549a055286a"
+    },
+    "sound/weapons/sword1.wav": {
+     "bytes": 3532,
+     "sha256": "572074b68af2132285aa9fd2ac6852f52ffb6c5e56eed44b1af21e0e78171e17"
+    },
+    "sound/weapons/sword2.wav": {
+     "bytes": 3055,
+     "sha256": "b176a257409b659d80df90560bbac4da5539971576aaf1107bb88bc016558085"
+    },
+    "sound/weapons/sword3.wav": {
+     "bytes": 3012,
+     "sha256": "eaca19c8a10b7942d4a279974df6e1cf076c362d5408e439b26286126852bedf"
+    },
+    "sound/weapons/thump.wav": {
+     "bytes": 30904,
+     "sha256": "ef0aa85fbc7ff6915aa5382c80e6f571ddacd50116faff495e3d5638bace8a49"
+    },
+    "sound/weapons/unsheath.wav": {
+     "bytes": 8060,
+     "sha256": "45d9bc6b9dcaf8e0dc9b2ede7da69a872f50f7819462a71bc16b9d76a70be06b"
+    },
+    "sound/weapons/xbowdraw.wav": {
+     "bytes": 19114,
+     "sha256": "4bb73eb7161ba561970e8f2e7f5aad0e42b3419fe2b02a5953a7289c46d1442b"
+    },
+    "sound/weapons/zap1.wav": {
+     "bytes": 7648,
+     "sha256": "1ee462bf6169537cc96fa7f95ef30b782fa1be473bd6ddc297fb3a7a6aa21ad0"
+    },
+    "sound/weapons/zap2.wav": {
+     "bytes": 7178,
+     "sha256": "8ece0064dc470a86c00906c1c50a54afd3a64eb13582071b9960581a1b72f4ff"
+    },
+    "sound/wraith/call.wav": {
+     "bytes": 12328,
+     "sha256": "9ace8a0ff79d035d36b6bdfb8726054ceaf8f852d25f3c1b235616abf4646ef2"
+    },
+    "sound/wraith/die.wav": {
+     "bytes": 14024,
+     "sha256": "3f166e024c07124cc5b5c5469904f5a8b3e48d4cb50fd949be8d79b4df2e375c"
+    },
+    "sound/wraith/drain.wav": {
+     "bytes": 14094,
+     "sha256": "d767951e9630b6179fb05a80136acbdeeb530f350b1953bea62e8493f3fe67ce"
+    },
+    "sound/wraith/growl2.wav": {
+     "bytes": 24966,
+     "sha256": "1c757955bb103e0f589ec373d1517dbacb8fe7e274f7aa0928503c9f5b009b10"
+    },
+    "sound/wraith/idle.wav": {
+     "bytes": 23702,
+     "sha256": "760a4a215fa2adb6f531b15acc06a4b46daa84c85fc08691ff4fe13f17e09ee8"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 20442,
+     "sha256": "d55cb931cef7d9c336fb7bbc3fa0408ea23eff69f46e25ac377ebbc880fa5025"
+    },
+    "sound/wraith/return.wav": {
+     "bytes": 39162,
+     "sha256": "0439588ad2003732fe7f946a5597bf80b2b89d6395476671b0e050b91c49cca7"
+    },
+    "sound/wraith/rych1.wav": {
+     "bytes": 24482,
+     "sha256": "baec568f339f688ea475e37ef3fc51a36de78a52a553e85aaa3f8011e1240d13"
+    },
+    "sound/wraith/select.wav": {
+     "bytes": 29326,
+     "sha256": "1e86b92dd1d82f4f74cd7fe14a75484e6cddb4fe968d2bb3dbaf850414c6dacb"
+    },
+    "sound/wraith/soul.wav": {
+     "bytes": 70524,
+     "sha256": "612bf73a6ebe0526efa2ef3d22915bcd87bed0b0eb5e52fc4eb0e62c5e4a3039"
+    },
+    "sound/wraith/soul2.wav": {
+     "bytes": 20562,
+     "sha256": "d3701420c157109793576ac7af7c7b132ffd0897375ec99701f4cd54798d9579"
+    },
+    "sound/wraith/speak.wav": {
+     "bytes": 25630,
+     "sha256": "6d1e5b395938692d57de3ec8ef9a8b5e4ccdab920a1f247e5bcdc1f0906dfcb8"
+    },
+    "sound/wraith/talk1.wav": {
+     "bytes": 16654,
+     "sha256": "6a625383c12f7fb5979ca8977a51d40f183051d551bd0b1b4ccc8a3f43a0322a"
+    },
+    "sound/wraith/talk3.wav": {
+     "bytes": 9832,
+     "sha256": "28ecc66c85bc722059b147a1354d226fbaf3022b79aed937a4759958d52c0fab"
+    },
+    "sound/wraith/weird.wav": {
+     "bytes": 3028,
+     "sha256": "1cfcd24daeb0665dce9d68ec353377ef84a88c78d1fdfcb429f2d0cc2b7f4b78"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    },
+    "sound/yakman/big1.wav": {
+     "bytes": 21636,
+     "sha256": "16c1632682aeb4b4075006d5b8b13a7e3f8821b6f59f8eb61ad78308b0d68366"
+    },
+    "sound/yakman/big3.wav": {
+     "bytes": 25096,
+     "sha256": "2cbbc5dc1249a92b9a31a6f3fa7ff654dd6339511fc99e4c552ad6a34218a4c2"
+    },
+    "sound/yakman/breathe1.wav": {
+     "bytes": 45712,
+     "sha256": "53730dabf839c183028fbdf909df8ae7ef936828c51c58a957617444872224d4"
+    },
+    "sound/yakman/breathe3.wav": {
+     "bytes": 50728,
+     "sha256": "fd923c891934046d9770c089dfe16021373a392b429531ef9698fbd2f759c42a"
+    },
+    "sound/yakman/crash.wav": {
+     "bytes": 17808,
+     "sha256": "068f6ea04f13016615f9534e74e969a62eda98c7def921df76731c5afbd73cf2"
+    },
+    "sound/yakman/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/yakman/expsmall.wav": {
+     "bytes": 8732,
+     "sha256": "18825b9644c01ff0a488887185ac14d6fb4fd983254620009ba3ecc96c44d465"
+    },
+    "sound/yakman/firefblt.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/yakman/pain.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/yakman/slam.wav": {
+     "bytes": 6372,
+     "sha256": "2c6ff4782b389777c98f09fa6ac86e6c75a848ad800db6dc32f8ea9362706e96"
+    },
+    "sound/yakman/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/yakman/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    }
+   },
    "sha256": "98e70207af3e80aec3aa18738ff191bb06d80b5fc27ec69a73840357076c1a12",
    "timestamp": "2010-10-29T21:06:10.000Z"
   },
   "pak2.pak": {
    "bytes": 25496,
+   "files": {
+    "maps/b_barrel.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/b_wbh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_wbh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    }
+   },
    "sha256": "dab1123e3fd0a0e38eb916f85d6a2609bb0acf3ecf0666fd742c4fa46c0a576a",
    "timestamp": "2010-10-29T21:27:46.000Z"
   },

--- a/json/by-sha256/5f/5fb88470e8e3e625d7861ba10066938b387efe3a4d0c4b8e6a3333677422abc5.json
+++ b/json/by-sha256/5f/5fb88470e8e3e625d7861ba10066938b387efe3a4d0c4b8e6a3333677422abc5.json
@@ -17,6 +17,84 @@
   },
   "pak0.pak": {
    "bytes": 3306020,
+   "files": {
+    "apsp1.txt": {
+     "bytes": 5749,
+     "sha256": "6fc8e0d500640327e18643ad9655706f6cfd0622d55e28133a10ae7eeb23f091"
+    },
+    "maps/apsp1.bsp": {
+     "bytes": 2901492,
+     "sha256": "64b016ef9de9004bfb570425010b95b3faf7f164d2f1309e0fae846d7d6e5b38"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 224812,
+     "sha256": "af9095cffbc74edc9d98d4e4e341736e304404df52983be33616da84d6463c87"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 12416,
+     "sha256": "2fff2f36173080827a298870a956fb11ad30f34aa0342ba5ca2c8bd6509edf57"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 59078,
+     "sha256": "6a7022fa8210771be206034a2b0ebeb59f6fc79719d499ac01811a4ff32eb08a"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "than.cfg": {
+     "bytes": 3743,
+     "sha256": "1fb57476fc72b045b3a366983aafeecf3b74ccfd9dc2da74b6e2934beca96b08"
+    }
+   },
    "sha256": "2362da596813dc4abb8480dc385f288f91fd499bb9b6e563209a511dfce6f8b2",
    "timestamp": "2000-08-30T10:55:20.000Z"
   },

--- a/json/by-sha256/5f/5fbb5cae02a3616932c61f17351f886d345039822ff75e0f4a14d506ba48eb16.json
+++ b/json/by-sha256/5f/5fbb5cae02a3616932c61f17351f886d345039822ff75e0f4a14d506ba48eb16.json
@@ -27,26 +27,1036 @@
   },
   "aopfm_v2/pak0.pak": {
    "bytes": 6880135,
+   "files": {
+    "end1.bin": {
+     "bytes": 4000,
+     "sha256": "22b0e6221b8749c702ecb88595cd7df6ed243af02a1fa3f646e5031fd5464c02"
+    },
+    "end2.bin": {
+     "bytes": 4000,
+     "sha256": "c74bbe6e9a96a1bd12880406e440f3907c16e5805ad36410964bcbd32b2d23ce"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "a176eac9afdd0102896a74342a12fc33bd55b399d3a66c57a6e1ba9e09b36dad"
+    },
+    "impel.cfg": {
+     "bytes": 957,
+     "sha256": "3256b7181260185a4b16b81ac760f612520fd440b44a8d051516a5b875c71d30"
+    },
+    "progs/a_jugg.mdl": {
+     "bytes": 24324,
+     "sha256": "9981ee9b0d42bcddbbc157b66d4d6f8625c8ad88ce50ab176486f05c134ef1ce"
+    },
+    "progs/a_jugg2.mdl": {
+     "bytes": 9684,
+     "sha256": "87808db33bdfdf19ca8c3a7899d32e58dec361b55d53b6f47810804079dd4a5f"
+    },
+    "progs/bldfall.mdl": {
+     "bytes": 50033,
+     "sha256": "192f1ddc78149666c84e4707ef0df53c592c9ea9ab3866d9880b18b507bc9da6"
+    },
+    "progs/blpulse.mdl": {
+     "bytes": 9172,
+     "sha256": "b1246a72ad2d24161c4ec2332320e288ee907e26188a4988f753670b1c345176"
+    },
+    "progs/blud.mdl": {
+     "bytes": 195448,
+     "sha256": "009423d495ff2eee0d004493e856b1223fac7273e75110a4be212abb2d3ef155"
+    },
+    "progs/bone.mdl": {
+     "bytes": 11020,
+     "sha256": "7e7b8bbecacface06ee8df856b7c32eb69e92803b187215391e82f605d6fed41"
+    },
+    "progs/bone2.mdl": {
+     "bytes": 11020,
+     "sha256": "2ec5f7154bb525174bd76d32d81d41c3d54e00fe59963929ca601a2dcf792555"
+    },
+    "progs/claw.mdl": {
+     "bytes": 27928,
+     "sha256": "f3b3003b98a14cd95d76bd0b69385c7af62091354d5eab9cd2ebf498c8a46aa3"
+    },
+    "progs/dknight.mdl": {
+     "bytes": 296484,
+     "sha256": "e97af9ea1c422cc7396c1ec540f74b2c713e68494958e07d4c2994a78c83b493"
+    },
+    "progs/drop.spr": {
+     "bytes": 20616,
+     "sha256": "42ebc578749f1d39d3c854f69f133805bcca97178895daa02a3ffb3b289478e0"
+    },
+    "progs/fieldgen.mdl": {
+     "bytes": 31292,
+     "sha256": "287c8eb576b0451e5130a346f79ce1443b55cbaf21b0765bc22698fda87fb94a"
+    },
+    "progs/firesprk.mdl": {
+     "bytes": 5540,
+     "sha256": "7104c91881d1ad6a1c70391efa89d0a7ce3c83c1d0f4b31ec290961d21b450cd"
+    },
+    "progs/g_implr.mdl": {
+     "bytes": 46548,
+     "sha256": "10d1cb9298fbc2c477386a1588c46a595611eaeab9bd144c68464d8e03c294ec"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 35204,
+     "sha256": "7dd4636e61fd1056157a1c0a8e7a73d208307af971d0c578a6d398fcee476718"
+    },
+    "progs/g_tek.mdl": {
+     "bytes": 78328,
+     "sha256": "245724c5fd7dddf1fbe63fcd137fee0dc656f957a8babbd569efb774cb45984e"
+    },
+    "progs/glass.mdl": {
+     "bytes": 16668,
+     "sha256": "c7f5adc2d42ef6d8d2fd8f719d21a95b9f2e339b041cb3734d5ea20b089bcb04"
+    },
+    "progs/grenbone.mdl": {
+     "bytes": 11020,
+     "sha256": "8bacc01f22a1057bc150d611ec97379bf4670980c3c680859a4f1b29f39c5c85"
+    },
+    "progs/grenling.mdl": {
+     "bytes": 135248,
+     "sha256": "5085bdac53071f8086b9a577d623da03a311e8edc68f74cceef1b059eda56ec7"
+    },
+    "progs/h_dkni.mdl": {
+     "bytes": 7124,
+     "sha256": "5fcc7ae72c3655de5d04f5fbe2bc97bc0d6168568d1ca99ed029d614ef633ae8"
+    },
+    "progs/h_gren.mdl": {
+     "bytes": 7932,
+     "sha256": "159389bbe3220a95e67daeb3c306ae0ccaa4a2132c8007edc531b82cc049db89"
+    },
+    "progs/h_jugg.mdl": {
+     "bytes": 21500,
+     "sha256": "d2800f941f87f6ea9fe12333a95c02d610e057fca811e48f10af29cf4b715056"
+    },
+    "progs/h_jugg2.mdl": {
+     "bytes": 10068,
+     "sha256": "5a9b66665e8b545cf022c2de11574de22c08ad32ab384355c2b0bf373de0edee"
+    },
+    "progs/impaler.mdl": {
+     "bytes": 13908,
+     "sha256": "3e1fba2e8b9ec3dc8b7e2b639f7ece4d7d16602fbadbedc7f3a89f4b59b67d74"
+    },
+    "progs/impdef.mdl": {
+     "bytes": 8412,
+     "sha256": "eed4e07de5673ab2908df65103d9989925d17d7618bc5535c1f5b321d0106df2"
+    },
+    "progs/impstuck.mdl": {
+     "bytes": 8412,
+     "sha256": "eed4e07de5673ab2908df65103d9989925d17d7618bc5535c1f5b321d0106df2"
+    },
+    "progs/impwall.mdl": {
+     "bytes": 8412,
+     "sha256": "2be43ab4de557a047c2ce777f3fa16761ce5689b8f3f80f4a229441b95468838"
+    },
+    "progs/jugg.mdl": {
+     "bytes": 153424,
+     "sha256": "733d9aaeca490c950ae95796148a40d3185125ae0e06ab17db989210ccd6cf51"
+    },
+    "progs/jugg2.mdl": {
+     "bytes": 148580,
+     "sha256": "43147452aeddf8f61f0041f7fa2c12938075b4d210daf3109d832f4b00a40859"
+    },
+    "progs/leaf.mdl": {
+     "bytes": 4906,
+     "sha256": "c67352d651db2d7875daec7af98c09557b4cadb7cac5c34f00411a7d8306c6b2"
+    },
+    "progs/legond.mdl": {
+     "bytes": 284204,
+     "sha256": "97f3652900564db8ced331f1e658e3b5baf8dae7be6ccf7a12188a179ad5d331"
+    },
+    "progs/missile2.mdl": {
+     "bytes": 21268,
+     "sha256": "9e397f9621965798b8d60c83b20c1e376d5e4ea3ad23142cff026167b97d8b20"
+    },
+    "progs/nbomb.mdl": {
+     "bytes": 2244,
+     "sha256": "5846d9b0c34c394356babc1aca19d40c4a18a3162d509c06a82b23a77543bae2"
+    },
+    "progs/onfire.mdl": {
+     "bytes": 64572,
+     "sha256": "0dfeb017d8e8c6ee99388617ade1fec822eea1b74c6ff9d7e771faa9fa575c0c"
+    },
+    "progs/onfire2.mdl": {
+     "bytes": 64572,
+     "sha256": "a8efa3ae675df00e82088bb0a8daa3dd91597c01418ecad61ed2a38a545e422a"
+    },
+    "progs/pulse.mdl": {
+     "bytes": 16384,
+     "sha256": "b3189cedf09e0a4fbce387cd7359f14e10605d0a7a3fdf811e15ba1d8385499b"
+    },
+    "progs/rain.spr": {
+     "bytes": 49248,
+     "sha256": "c6b46fed29279ef47f2e4126bdabe23cae042396a4a440f750582a53fa77fe50"
+    },
+    "progs/rawbone.mdl": {
+     "bytes": 61252,
+     "sha256": "f214f56660a091d2f212e99e7ddce6e0af8d3e4bc5343deae0e44cfb4143b3b7"
+    },
+    "progs/rawbone2.mdl": {
+     "bytes": 11020,
+     "sha256": "e3ab7247635061ea9fd72be4e5a96e5699ab74a76c47f195402f18e1fed8e99b"
+    },
+    "progs/rubble.mdl": {
+     "bytes": 404673,
+     "sha256": "3d5ca67fdf065a832559ac9f9a320268f2e179cf089104880624fdac6c51f7e5"
+    },
+    "progs/sglass.mdl": {
+     "bytes": 16668,
+     "sha256": "2ca84472fce770df62a263176a3af79fe4e9d72f90144e5982a52d5b6b82a9ec"
+    },
+    "progs/smlsnow.spr": {
+     "bytes": 65,
+     "sha256": "196075fa517123e0e1c9f61ca7781b1fa03f6ae47597b908145080db42b4f42d"
+    },
+    "progs/snow.spr": {
+     "bytes": 72,
+     "sha256": "17eb99d2ce6524da28d82c5aae7bdbfa9c645408b9ca047f7a829914b4e2cd21"
+    },
+    "progs/spawn.mdl": {
+     "bytes": 115444,
+     "sha256": "55dcca59cd544b2f1a2739344d4938ebc9344788e3070d0f6a503d5d641ec3d6"
+    },
+    "progs/spid.mdl": {
+     "bytes": 36608,
+     "sha256": "55daef0380d31d24524bc4a6faf9c402c1aeb2a448c6de94ebde377b5042c835"
+    },
+    "progs/spidgib.mdl": {
+     "bytes": 19976,
+     "sha256": "3e7201ece6fdd8ed5fc15e6b5aab7a52a671ae57e679f8ae89c1536bc42c1d66"
+    },
+    "progs/trapbar.mdl": {
+     "bytes": 19248,
+     "sha256": "787f237f54fbe2a02990d46a450a21671a69fbd95140e40240ab78f36df9a06e"
+    },
+    "progs/v_implr.mdl": {
+     "bytes": 49680,
+     "sha256": "80f84f0fd793723aeccd259551e552eadfd2ba349bc415aeb72e8d04d62fa055"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 83668,
+     "sha256": "0d6898afb61f5befa1b0ca4dd12ea809a9e877652fa33e43584480257c5d2179"
+    },
+    "progs/v_srock.mdl": {
+     "bytes": 58548,
+     "sha256": "329c7dba1195bd05c188cdc64be92f345e9f3aa237b1388ac9a7ea4605e8680f"
+    },
+    "progs/wing.mdl": {
+     "bytes": 78328,
+     "sha256": "245724c5fd7dddf1fbe63fcd137fee0dc656f957a8babbd569efb774cb45984e"
+    },
+    "progs/wlpulse.mdl": {
+     "bytes": 3604,
+     "sha256": "0fa5efc178b0636ab622368de5a006e2f956f0b06097f24e1df4d5b89d7d41bc"
+    },
+    "progs/xtragib.mdl": {
+     "bytes": 13780,
+     "sha256": "3b413fe8f4099d377af905d6be6ddd111a331f98e9bd4432a4113ec616f8f8dc"
+    },
+    "quake.rc": {
+     "bytes": 331,
+     "sha256": "3cd7e089c390e80a174bbb1c3518aa0192a10887ae3822f6847f3cb899442821"
+    },
+    "sound/ambience/pixels.wav": {
+     "bytes": 31912,
+     "sha256": "b9846a0b47140ff11975a3f966184b55a99d68c9d46acc1577f73b709276ec0f"
+    },
+    "sound/ambience/rain1.wav": {
+     "bytes": 734524,
+     "sha256": "cb4bd4af697c2b584323a2235a65cb048b34a121d9c47ca1da32ed648023b7d4"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 72062,
+     "sha256": "1fc3146d501953545b2f2f261cd2fc398959a79c753a291702609b4cdd2e8682"
+    },
+    "sound/enviro/physics/axecut1.wav": {
+     "bytes": 13290,
+     "sha256": "b0c2a384a203186474983cf1b3befb1749560db4a6015dd3e6c22cf1768d937b"
+    },
+    "sound/enviro/physics/axecut2.wav": {
+     "bytes": 8066,
+     "sha256": "3d31140e6627582816f01d320f0b67000acd1d8891606c35fd21e3e1c5238239"
+    },
+    "sound/enviro/physics/axemet1.wav": {
+     "bytes": 10066,
+     "sha256": "a50093dcad7a8ebbccbd37589dcf523311dbe236214c60b898875fe0180a3f0a"
+    },
+    "sound/enviro/physics/axemet2.wav": {
+     "bytes": 9306,
+     "sha256": "fc60fd4478c18afae1c8176285c50e7678bb5c82ee83c43c295a36aa2adcade1"
+    },
+    "sound/enviro/physics/axemet3.wav": {
+     "bytes": 12084,
+     "sha256": "4278a5848453b1492f55f3a304af74ca3d04535b26857a5869096767388a9ddd"
+    },
+    "sound/enviro/physics/bonexpl.wav": {
+     "bytes": 22612,
+     "sha256": "d85f33d4286e1b535cc0f6fc4fc5dd141908a75fd1c192dff945eeb4c7984dfd"
+    },
+    "sound/enviro/physics/flames1.wav": {
+     "bytes": 17468,
+     "sha256": "01b521d689b35395e40d9164e6818183718aa1fe08a33df6696fdf85a1c60af6"
+    },
+    "sound/enviro/physics/glass.wav": {
+     "bytes": 13592,
+     "sha256": "117c63e8a5aff0a268a53f1448c99e2811f94fa8942fdaaedce2a04f0075362d"
+    },
+    "sound/enviro/physics/glassbit.wav": {
+     "bytes": 6090,
+     "sha256": "46bbb74c5f975c1fcc575c47a69b60b5679a633c0f0229247d661b444d633e8b"
+    },
+    "sound/enviro/physics/piece1.wav": {
+     "bytes": 2212,
+     "sha256": "a8a5a474f7bb511b8e24c35490fab5fa51ad3321d1de0de3a6bf6bb725eadb3d"
+    },
+    "sound/enviro/physics/piece2.wav": {
+     "bytes": 1765,
+     "sha256": "52642c3f1499593adacffc132eafad548a5bd9704c5df8b2a0ff801903411dcd"
+    },
+    "sound/enviro/physics/piece3.wav": {
+     "bytes": 5657,
+     "sha256": "9dd34014a97889a000afd4b2a0c3c65f9aa3acc9f23bc0a1304af9dc03c3e1c8"
+    },
+    "sound/enviro/physics/pour.wav": {
+     "bytes": 7145,
+     "sha256": "1586f89c2018fa70a3abcd034697f9ac4b85bd0be473cf69a1196c4774ec35de"
+    },
+    "sound/enviro/physics/spill1.wav": {
+     "bytes": 2555,
+     "sha256": "6f49f02b9860baa41cc8506974526f5658cafc0639b8c11c48b7ff50876480d7"
+    },
+    "sound/enviro/physics/spill2.wav": {
+     "bytes": 8540,
+     "sha256": "5acb5fb925304f798f695bbeccfe5fdf5ffffdef00ef9b425091e416598d3d39"
+    },
+    "sound/enviro/physics/trcut.wav": {
+     "bytes": 9898,
+     "sha256": "88c0421cc54756512a4c929b96db6d5d8cb6ac998dc0df8eecc87a3bfd4fe2e7"
+    },
+    "sound/enviro/physics/trkild.wav": {
+     "bytes": 5106,
+     "sha256": "ef7a598607e18108e8805907d8b5c00bf5ad5443a1ed76bef885062cc9f2da31"
+    },
+    "sound/enviro/physics/trspin1.wav": {
+     "bytes": 11026,
+     "sha256": "8e88a4140a5ab0290fef306355e6cabf886ac2927bd35aa44b2263b203fc5b31"
+    },
+    "sound/enviro/physics/trspin2.wav": {
+     "bytes": 15414,
+     "sha256": "00964751612bd2931eca2937194ef4bb007bf3d0032392b5170b716c219f96c0"
+    },
+    "sound/enviro/physics/trstop.wav": {
+     "bytes": 23468,
+     "sha256": "714d0bcfdc127bfd21b3bd779e7ed911acf99fafb760cc2d8e3441547cdb073b"
+    },
+    "sound/enviro/physics/wallexpl.wav": {
+     "bytes": 16152,
+     "sha256": "4d82f44f89d8cd38dd54711b776c8db9975c78794e8e520468b8bd2c9f30d9ad"
+    },
+    "sound/enviro/pinhead/pinback.wav": {
+     "bytes": 2864,
+     "sha256": "db45513057257be6824c210e20dff4e3134669b0d1a9b60dcff333c262aee0c1"
+    },
+    "sound/enviro/pinhead/pindef.wav": {
+     "bytes": 1006,
+     "sha256": "7e9a82c272c09429b1633def7a94654fd9138cdb819552627c0bd1b9e8a6fba7"
+    },
+    "sound/enviro/pinhead/pinfire.wav": {
+     "bytes": 4630,
+     "sha256": "20b71f1a11267c53fa00770c0186ebfbcf3fd899075d3641b1161108a461113d"
+    },
+    "sound/enviro/pinhead/pinhit.wav": {
+     "bytes": 8752,
+     "sha256": "9c11f4b44a9811bb06bc13ac81c2a8506444ef91edc9268a82a675e322916575"
+    },
+    "sound/enviro/pinhead/pinpull.wav": {
+     "bytes": 2854,
+     "sha256": "792da21c0b6442fb3bdc54b470b34e7224977c288c6bb8119fc1b55f667076a7"
+    },
+    "sound/enviro/pinhead/pinrip.wav": {
+     "bytes": 2846,
+     "sha256": "8c8d69169437e5bd4665523839e259e900c0543ae30cdbc82da579a548a5acd0"
+    },
+    "sound/enviro/pinhead/pinsuck.wav": {
+     "bytes": 65074,
+     "sha256": "2a076267e5786fbf32126a98915c192a2a95f66f7b68193c089b982dc1c3a43a"
+    },
+    "sound/enviro/security/onalarm1.wav": {
+     "bytes": 36352,
+     "sha256": "058e0986a438aa0ad42a443f130e80a3eff59766f26a1473927eb28366108e4d"
+    },
+    "sound/enviro/security/onalarm2.wav": {
+     "bytes": 13906,
+     "sha256": "10711e5767aee48d0030a884089fb7d7f7702fa13775bf7b8d048fcba020103e"
+    },
+    "sound/enviro/security/onalarm3.wav": {
+     "bytes": 37030,
+     "sha256": "6391ee249d27a9bd65235d6667a597a7f371a8308a7710d23d74018188811d5f"
+    },
+    "sound/enviro/security/onalarm4.wav": {
+     "bytes": 72040,
+     "sha256": "9013094ddcaa6380efdb1f27cad7c6ba96be37262313634446ec5aa47fdf790d"
+    },
+    "sound/monsters/blud/blatt1.wav": {
+     "bytes": 7700,
+     "sha256": "dab9183f257868666920e92fa47a1391d8406a8f86b221a6350cfd09cae5b19a"
+    },
+    "sound/monsters/blud/blatt2.wav": {
+     "bytes": 9850,
+     "sha256": "87d1254d504e045864d567e7dad2af6f5773525122003e1d51bec70708b0424e"
+    },
+    "sound/monsters/blud/bldie.wav": {
+     "bytes": 172340,
+     "sha256": "1d2e3ad2ecdf67df2bf5106a870668ad36416b080424be8ae1f64fdc88b0fc17"
+    },
+    "sound/monsters/blud/blhurt1.wav": {
+     "bytes": 35720,
+     "sha256": "66b5f3952f129058c9710c1baea16d69f698d8de4f9ee91c80d05de9c2874bb4"
+    },
+    "sound/monsters/blud/blhurt2.wav": {
+     "bytes": 36774,
+     "sha256": "c905efedccda3e376e8cb267a6c4534a9dcffd07b44bbd5cac17f3ed306b63a6"
+    },
+    "sound/monsters/blud/blhurt3.wav": {
+     "bytes": 52042,
+     "sha256": "941f745d30607fb0bb02db2093401a6b4856dcb0de50fa1d21894027a4e5ef89"
+    },
+    "sound/monsters/blud/blidle1.wav": {
+     "bytes": 112046,
+     "sha256": "f74aab64eece6bd28d803589ce04547fdbf72d2d9c7c81304ac94cc89e748a8b"
+    },
+    "sound/monsters/blud/blidle2.wav": {
+     "bytes": 121402,
+     "sha256": "5c1443558ac033d927e05159923e7ab9db7605c4be791877b81ae7f019c589d2"
+    },
+    "sound/monsters/blud/blidle3.wav": {
+     "bytes": 34556,
+     "sha256": "af9e0c2922e73d81ed916783469356217f6e8481cdb2ab2946ba0ac5c4875b77"
+    },
+    "sound/monsters/blud/blidle4.wav": {
+     "bytes": 165498,
+     "sha256": "5f665a060ac0b4cf95fedb906ff52c72a27f22c92959e613510c8b75b9142c6f"
+    },
+    "sound/monsters/blud/blood.wav": {
+     "bytes": 7368,
+     "sha256": "274ddc2d095dcaab9f6d2ed66107222fff449d4b6f883b60d9d728bcee8fc602"
+    },
+    "sound/monsters/blud/blsight.wav": {
+     "bytes": 123232,
+     "sha256": "0ab1ae250459fd195a3599c4236d1d598c1d72f3bdd72851e376cb20bf158611"
+    },
+    "sound/monsters/dknight/dkdeath1.wav": {
+     "bytes": 18570,
+     "sha256": "6cf6030562a3ef8cc171276e9af019f21e48e99d458eb8a5e747f9ac7237e4f4"
+    },
+    "sound/monsters/dknight/dkdeath2.wav": {
+     "bytes": 22046,
+     "sha256": "0689505dd36dec8dfebcfdf0e98e77f876768af306d1813ff3411d508b60d647"
+    },
+    "sound/monsters/dknight/dkhurt1.wav": {
+     "bytes": 11384,
+     "sha256": "26d134b269770be1fbbe5d3d2f796a4143e7c72899adf4f94b4ce1528228f6a0"
+    },
+    "sound/monsters/dknight/dkhurt2.wav": {
+     "bytes": 9068,
+     "sha256": "e595e93b464de6480550536e01f96598739c03b88b4803eebacab8bec3beaf0c"
+    },
+    "sound/monsters/dknight/dkidle1.wav": {
+     "bytes": 12714,
+     "sha256": "d57942e7f48d575fa2f64430c50dc2cd23cbba60cfc70298868ac0c8f6a6d5fb"
+    },
+    "sound/monsters/dknight/dkidle2.wav": {
+     "bytes": 13994,
+     "sha256": "6fb8746ebeea7db1a5f812b3e978d3545614a4e146db0226c36c73fc5f8d8fc1"
+    },
+    "sound/monsters/dknight/dkidle3.wav": {
+     "bytes": 46708,
+     "sha256": "e4769e804725bd53b624de676ededaa679584c56b19cb83b41973982881ab7e4"
+    },
+    "sound/monsters/dknight/dklight.wav": {
+     "bytes": 5292,
+     "sha256": "c35a3f6f2fcca7ec06f00f0c556bd24c82fe709b6e3cd05f900e71815c493cef"
+    },
+    "sound/monsters/dknight/dksight1.wav": {
+     "bytes": 17584,
+     "sha256": "a973846938a0b08b493580423d6aec9d18f33131a9ce5c22812fbe2bf9bc684d"
+    },
+    "sound/monsters/dknight/dksight2.wav": {
+     "bytes": 8810,
+     "sha256": "3893441fd1b6213fec472fd3a1ab7fe5af841278ab1d1fbc54f098173ec623bf"
+    },
+    "sound/monsters/dknight/dksight3.wav": {
+     "bytes": 15196,
+     "sha256": "ce2ffc589f53144e7770cfcd33d9a54f9ed70d132d2eaa75caa94c76b792bff5"
+    },
+    "sound/monsters/dknight/dkswzap1.wav": {
+     "bytes": 6052,
+     "sha256": "d328d01b075015cefd39ca46d29212667736f1b33aa707e61c868101e5b4ea1c"
+    },
+    "sound/monsters/dknight/dkswzap2.wav": {
+     "bytes": 5552,
+     "sha256": "14f1fe73d01ed5fd4f446937ae25fbd6d54e438d91d336e73a7b8b982d274efb"
+    },
+    "sound/monsters/dknight/dkzap.wav": {
+     "bytes": 6974,
+     "sha256": "bf5f8f2f93ef167b5f0f70c7063525eb538ea434d714d807c812a8fb7712c021"
+    },
+    "sound/monsters/grenling/grcoon.wav": {
+     "bytes": 89860,
+     "sha256": "4a76bfb25743d747b4546a3d0b7efa2678a9d06b9f298d21ff140f8f05450198"
+    },
+    "sound/monsters/grenling/grcut.wav": {
+     "bytes": 5374,
+     "sha256": "48da55e5b7d36d0cc96abed51017c1a4ee9cd25a55cfb532658f3e556c8171d9"
+    },
+    "sound/monsters/grenling/grdie1.wav": {
+     "bytes": 9822,
+     "sha256": "f9be6d41c5d66c13daeec34d5af464bde349f6993417dc1839563dab01bb15f5"
+    },
+    "sound/monsters/grenling/grdie2.wav": {
+     "bytes": 8694,
+     "sha256": "a8ba47fcbe9e60521f74828aec71a88df63db2c88c2365e791478bde29c29488"
+    },
+    "sound/monsters/grenling/grhover.wav": {
+     "bytes": 69396,
+     "sha256": "4af8fef34d8506e6fc9721e835a81ca7a20d6141b9b703b1a4b471d574b412bb"
+    },
+    "sound/monsters/grenling/grpain1.wav": {
+     "bytes": 15106,
+     "sha256": "dda4267078d6b233324951eb9e6e44686d5e8536fb4303a2009d01b113051a95"
+    },
+    "sound/monsters/grenling/grpain2.wav": {
+     "bytes": 8734,
+     "sha256": "205d0d3adcc652fe35701de96eda7c9f8f2a3ec23782aef6bdaf2c08192a06ef"
+    },
+    "sound/monsters/grenling/grsight1.wav": {
+     "bytes": 20054,
+     "sha256": "861710b36a948a22d7d7f8e57b9e6b0d7e5241a1f62a6f43f01f8bcea69bb90c"
+    },
+    "sound/monsters/grenling/grsight2.wav": {
+     "bytes": 23428,
+     "sha256": "61a65a594b2add0f152d804f8f12a6c06c55f1f18d3b97dd2b8188bca27c7ba9"
+    },
+    "sound/monsters/grenling/grswipe.wav": {
+     "bytes": 2174,
+     "sha256": "a0a7a794af2f8fe4d1167531a2965873ebed67737399cd2d512a93383802b74a"
+    },
+    "sound/monsters/grenling/grtalk1.wav": {
+     "bytes": 4180,
+     "sha256": "bf2a1b0f53f76837b01239ecf03751fc38330a2905826798752e4ddea7af00ab"
+    },
+    "sound/monsters/grenling/grtalk2.wav": {
+     "bytes": 4180,
+     "sha256": "868d9681b961c7957012f8bc359685e0c05c395838ed5870784f861b83253803"
+    },
+    "sound/monsters/juggers/jbent.wav": {
+     "bytes": 7036,
+     "sha256": "18da56b750203a2a61a3fc0297b9dafb1b8fb1f4a120b5589d060005013d6275"
+    },
+    "sound/monsters/juggers/jfalls.wav": {
+     "bytes": 25754,
+     "sha256": "a399115538d013cfaf2e802dc5e85e2a9bea0afe5bd5a02e93065e89702d2900"
+    },
+    "sound/monsters/juggers/jgib.wav": {
+     "bytes": 22124,
+     "sha256": "e11d5c8785e0c792803ca1bcc2a57a75b8cd6d11407f55bace002bfcf533077a"
+    },
+    "sound/monsters/juggers/jhydro1.wav": {
+     "bytes": 7626,
+     "sha256": "dda0b1a06528bda40e43242e156c6b2e509d0c0219b8e2a2e6ae5aed89bf91cc"
+    },
+    "sound/monsters/juggers/jhydro2.wav": {
+     "bytes": 25030,
+     "sha256": "4dd294c650d8cb6367baca7bc27148c9fb6373c2b385562991ef0afd6b577319"
+    },
+    "sound/monsters/juggers/jhydro3.wav": {
+     "bytes": 16564,
+     "sha256": "3fe3d988825febff0de671aa46d620147a0f6132f6f42ec4f96027173b6e1fdf"
+    },
+    "sound/monsters/juggers/jidle.wav": {
+     "bytes": 44068,
+     "sha256": "f728abafff13693a0650fc03a6abdef6b48818b453d00f316c6917f3965939d9"
+    },
+    "sound/monsters/juggers/jlocked.wav": {
+     "bytes": 3948,
+     "sha256": "9b996407fb4d1d96b76643765a298489aea77eeede938313b9cd591722563970"
+    },
+    "sound/monsters/juggers/jshort1.wav": {
+     "bytes": 8778,
+     "sha256": "030e809d08562b4fa21c1dc7270504ef4a4b3d582d8c4598259755873096d19c"
+    },
+    "sound/monsters/juggers/jshort2.wav": {
+     "bytes": 11870,
+     "sha256": "4dd5f5cca2e729eef666e290a2ffcc6942602be60fd28b483696a206e9d7090c"
+    },
+    "sound/monsters/juggers/jshort3.wav": {
+     "bytes": 8962,
+     "sha256": "9f691551c7adaada28d27a63776bc0c11c9c4c952a48e40193e7ff4018ca85b8"
+    },
+    "sound/monsters/juggers/jshort4.wav": {
+     "bytes": 10338,
+     "sha256": "3fd4b07b2d8616e2b82c9a16f48f91dd1f46589f4cfe3d898b7bc9af38d84ca1"
+    },
+    "sound/monsters/juggers/jshot.wav": {
+     "bytes": 2004,
+     "sha256": "81a5a21ea9ddaf51cc67062a2db70a3b09093194f9fe4870f52fe49e5926ad46"
+    },
+    "sound/monsters/juggers/jstep1.wav": {
+     "bytes": 8042,
+     "sha256": "a0093642fa03a403171c04362717a164687fd1172f2c9ff02cc46fef1bd9e4b0"
+    },
+    "sound/monsters/juggers/jstep2.wav": {
+     "bytes": 8828,
+     "sha256": "6fb3d5d205d3ccb6f0d89cde0253bc491ba2df7a711ffcea613f7736aa6fed4e"
+    },
+    "sound/monsters/juggers/jstep3.wav": {
+     "bytes": 7354,
+     "sha256": "8575b89812f6b238149b054b2e755236e9f36c1d8e84b2356fd83d75454e30ef"
+    },
+    "sound/monsters/juggers/jswipe1.wav": {
+     "bytes": 2742,
+     "sha256": "d0f5082a2d40372e9c5f101699c8087daee5dd1fbe1287d025cfb6051ce20a48"
+    },
+    "sound/monsters/juggers/jswipe2.wav": {
+     "bytes": 3208,
+     "sha256": "544f22587d0b866dcc33964814bb70703c8eceb4c68302cd02d95b9a805caa98"
+    },
+    "sound/monsters/juggers/jswipe3.wav": {
+     "bytes": 2218,
+     "sha256": "8c2c0ffb45efa98780f69a2e9fd5d48a204e0b0e6caa79619fd9a888348aa246"
+    },
+    "sound/monsters/juggers/jwhap1.wav": {
+     "bytes": 15690,
+     "sha256": "f31ad559ced2013b53e7e1562995f47be4cc5c701bf3720e2a1ec9826f3b7cc3"
+    },
+    "sound/monsters/juggers/jwhap2.wav": {
+     "bytes": 14486,
+     "sha256": "e7d433c6ec0c7773f0085a55dd5fa404a8eaa31ff5345c9ac459f216af2e786c"
+    },
+    "sound/monsters/juggers/jwhap3.wav": {
+     "bytes": 18824,
+     "sha256": "4c5fda7dc457490807752cd883df0cdbfd95cf362e5549c9e7f6a0f57f504bde"
+    },
+    "sound/monsters/juggers/jwhir.wav": {
+     "bytes": 11110,
+     "sha256": "9fcccd411b11f0e08c1074de056509e60cd2bfdd67d3f325168b542478f94371"
+    },
+    "sound/monsters/legond/ldeath.wav": {
+     "bytes": 23238,
+     "sha256": "1a49cdac45f13eb550488ea4638623888566058abf927835cd3a8e0481fbc584"
+    },
+    "sound/monsters/legond/legond.wav": {
+     "bytes": 12278,
+     "sha256": "e12b382237afe48bb809dd48419c5d5c4bc85ab5ba0f7b63e78616fe6745d43f"
+    },
+    "sound/monsters/legond/legsmak.wav": {
+     "bytes": 8044,
+     "sha256": "f27b7fb95c4c8ec585b5701abf987833231652d23f7d2de1e10c112471713ef3"
+    },
+    "sound/monsters/legond/lidle.wav": {
+     "bytes": 41172,
+     "sha256": "636f97b4151277b04207eea96858a66a4fd50edfbf998bbaaf99c8c33e6e115e"
+    },
+    "sound/monsters/legond/lpain1.wav": {
+     "bytes": 13176,
+     "sha256": "9db4abf9a563c4b8a15de849ad9a24dc8493272c9134bbe3e1c4fe42aba55d79"
+    },
+    "sound/monsters/legond/lpain2.wav": {
+     "bytes": 21160,
+     "sha256": "df82e5fa6a94d695866e85610b422b74cb4277ee07340a86a38508f8ee4cc072"
+    },
+    "sound/monsters/legond/lpull.wav": {
+     "bytes": 9364,
+     "sha256": "97029a0fd3f4dcef919fb7a6f16b249689d5dd64d8fde99b3523e37524f12434"
+    },
+    "sound/monsters/legond/lshot.wav": {
+     "bytes": 9826,
+     "sha256": "c29f388f451a29f8edaa057b2934697b13eee6ca8c6aa8ef015603392765dbb6"
+    },
+    "sound/monsters/legond/lswipe.wav": {
+     "bytes": 2742,
+     "sha256": "ad883989af828760a92eeb46e7620d7037a67ca7a3ee083c7380bbd976534277"
+    },
+    "sound/monsters/lenforce/ledeath1.wav": {
+     "bytes": 9300,
+     "sha256": "494eafdf40767f0416ef19fc945c716b57aace7b758b06689644ba6313ad0a02"
+    },
+    "sound/monsters/lenforce/ledeath2.wav": {
+     "bytes": 9678,
+     "sha256": "0e20a15d7fbca887bb0aa06efc09b557a46b845ac93337fa3781287f005dfe94"
+    },
+    "sound/monsters/lenforce/leidle1.wav": {
+     "bytes": 15272,
+     "sha256": "2c2258506622c8a5686aa996c554979dea9acd06c57d7579dfbfb0b6308f8301"
+    },
+    "sound/monsters/lenforce/lepain1.wav": {
+     "bytes": 7734,
+     "sha256": "eb110fdc81e8a16c56400d40063617d7668ce4f967f6730ee4513e7984b132c8"
+    },
+    "sound/monsters/lenforce/lepain2.wav": {
+     "bytes": 6568,
+     "sha256": "14486a46963b579dcb297d2320d80aa7389133eab5755aae171a5bb4d42849f3"
+    },
+    "sound/monsters/lenforce/lepain3.wav": {
+     "bytes": 7238,
+     "sha256": "a87ba387d95f31e4607db8a197679f19e2f6a53be4a50a9a45e1118ec6fbbcbf"
+    },
+    "sound/monsters/lenforce/lepain4.wav": {
+     "bytes": 6610,
+     "sha256": "d3c50cb87cfc3ec3851e6b3102df48ee2008b305ac207cf441bcf4a28762d892"
+    },
+    "sound/monsters/lenforce/lesight1.wav": {
+     "bytes": 8828,
+     "sha256": "54e97def9f7defb6df4d874e4ac97d3514ff484d771d1fd08255fa7c593ba1d5"
+    },
+    "sound/monsters/lenforce/lesight2.wav": {
+     "bytes": 11112,
+     "sha256": "f356fa732b35b41fc41a2648b3212c248b13bcc432d36c40be2cccbe8271fe8e"
+    },
+    "sound/monsters/lenforce/lesight3.wav": {
+     "bytes": 12890,
+     "sha256": "8a2863c33fe03ee5ceca3b9ebb30616ac1fa99bb3b80e8dc3b7bec634925a664"
+    },
+    "sound/monsters/lenforce/lesight4.wav": {
+     "bytes": 11758,
+     "sha256": "15ecd70f5f40458100e58aec72b073f1597170e865fc22220bc51a77212ed73e"
+    },
+    "sound/monsters/spider/sactiv.wav": {
+     "bytes": 17066,
+     "sha256": "f21587ba9bfd159e48c5b3aa1c6e94eac7157053e4e5699459233fb28c2631c8"
+    },
+    "sound/monsters/spider/swalk.wav": {
+     "bytes": 12636,
+     "sha256": "5534fe1b11fea5406aada214681dba031ec4a01e4b660c405b679131ba07a7cc"
+    },
+    "sound/player/udeath.wav": {
+     "bytes": 8344,
+     "sha256": "2cbdbdde1bf9947ab483eea4706eebf10beb3b453a40c391739c80520c158b7a"
+    },
+    "sound/player/walk1.wav": {
+     "bytes": 5370,
+     "sha256": "d32cc1a61835811cef96e55093f6f749516a174486acdaceb7a5f632f250c637"
+    },
+    "sound/player/walk2.wav": {
+     "bytes": 5292,
+     "sha256": "36b9d7c760f594048a485e19c65f69ce879049a8cc32284a974a3f459e3eb29e"
+    },
+    "sound/player/walk3.wav": {
+     "bytes": 7172,
+     "sha256": "c5d97509db895b36f26ccde12b0beabebe4452e526652c9491703a64029f911e"
+    },
+    "sound/player/walk4.wav": {
+     "bytes": 6412,
+     "sha256": "40b7120a15bd5a4d1c0fc193f7977480c85135290472ceb5bae6707bd22627e3"
+    },
+    "sound/player/walk5.wav": {
+     "bytes": 5292,
+     "sha256": "81ca083ec581a71cfbf76d23833f416ff5306e32b9e2545d813ef1ce7f9e554c"
+    },
+    "sound/player/walk6.wav": {
+     "bytes": 5370,
+     "sha256": "62a1d6e6fee82628fcff12313e0bbc1a234c1e69aaf904b30c1fa44a582ef975"
+    },
+    "sound/player/walkh2o1.wav": {
+     "bytes": 12942,
+     "sha256": "ed69778ffced6f407f615fb9e5ffc84bdf1179f7b7079c19c713b7def8862cb8"
+    },
+    "sound/player/walkh2o2.wav": {
+     "bytes": 10456,
+     "sha256": "2c168e45eee16b1a4bb5c7752807fc399ddfd0c0bae5f6333f5426713c207d9c"
+    },
+    "sound/weapons/field/genactiv.wav": {
+     "bytes": 111908,
+     "sha256": "cc9f8d78ca458f1b5bc0d1454fc80ff84f505ea81dc5307cf41219b0d2123272"
+    },
+    "sound/weapons/field/genhit1.wav": {
+     "bytes": 55432,
+     "sha256": "a701c7366dfa6fcb12bb66e6a5769e1374cba8fe914f0ce592b99ddb71726024"
+    },
+    "sound/weapons/field/genhit2.wav": {
+     "bytes": 55394,
+     "sha256": "20cb5ffccef9b9a69e87bc55b4e3cc1d9cc7a91e94bfc0d913b243089902cfc2"
+    },
+    "sound/weapons/field/genhit3.wav": {
+     "bytes": 55394,
+     "sha256": "82a5487b8405a7d398e530ad0f542d314162977f6e50897cedba92a578252317"
+    },
+    "sound/weapons/field/genlev.wav": {
+     "bytes": 42428,
+     "sha256": "898350003a595d7f15f03b8f49368c500ccc78a862e22b29e78ad0f0185ef018"
+    },
+    "sound/weapons/field/genpulse.wav": {
+     "bytes": 22242,
+     "sha256": "f750a55838ee094bcd48997cbd4112840cb19ddbc61c6a66930c5bf21131bd11"
+    },
+    "sound/weapons/field/genstop.wav": {
+     "bytes": 45692,
+     "sha256": "6e46e650e04cf54e4fdad231fc32380d7b991828cc3da4fce32ba491ea5b9e80"
+    },
+    "sound/weapons/impaler/impale.wav": {
+     "bytes": 8356,
+     "sha256": "515240b3eeb19b134abbdc9ae2e7073199dbe8bb5bc37907055e23ca93f25a08"
+    },
+    "sound/weapons/impaler/impdef1.wav": {
+     "bytes": 5046,
+     "sha256": "b513f636bb843a52a400c4c2839dc76e658351efc442138d71de0d30677eebec"
+    },
+    "sound/weapons/impaler/impdef2.wav": {
+     "bytes": 3638,
+     "sha256": "9978beeea45f0831c470869774eeeb657a8df1aba996483a0b18189f56d0cbbf"
+    },
+    "sound/weapons/impaler/impdef3.wav": {
+     "bytes": 4666,
+     "sha256": "c5a961bef24c8b455c782846f770c2722399d4196756ebaaf37e9f31537b604b"
+    },
+    "sound/weapons/impaler/impex.wav": {
+     "bytes": 21058,
+     "sha256": "cd6c593a62fa55f612ef8c8b604d1ad86f210d62604218bf68b08e635afe1de5"
+    },
+    "sound/weapons/impaler/impfire.wav": {
+     "bytes": 11242,
+     "sha256": "5f233c667f23e9dfb0c0daed70220a51ac54d28094b26de25cbc91aa275c82fc"
+    },
+    "sound/weapons/impaler/impload.wav": {
+     "bytes": 6086,
+     "sha256": "e5647b73763060a598b09ca3a81bb3185bb731e9c02a863f93007242a4f8b095"
+    },
+    "sound/weapons/impaler/impwall.wav": {
+     "bytes": 4288,
+     "sha256": "708ad7ed4c1c7fae2be8dd5c0c63d4185c21132381b970178c5d5f250438e040"
+    },
+    "sound/weapons/impaler/mimpale.wav": {
+     "bytes": 19146,
+     "sha256": "b09115d52047d2d0e82fc6d31b79e58e739a7c670f2ed645265adaf69b9305ac"
+    },
+    "sound/weapons/impaler/pimpale.wav": {
+     "bytes": 14278,
+     "sha256": "f57630db6ed2aa61021ecd576a5c80baf50f96728a8698acbdf9f4cdc14a3e1b"
+    },
+    "sound/weapons/impaler/shaft1.wav": {
+     "bytes": 6202,
+     "sha256": "7bafc32155421b6e3189e922847ebfca2f79b06ac209b0c8e1c172810910b32d"
+    },
+    "sound/weapons/impaler/shaft2.wav": {
+     "bytes": 7086,
+     "sha256": "ae10f080450de9522638f5dcd6496eb4ee466b6eabc3dfff3c164a1ee7c10c60"
+    },
+    "sound/weapons/impaler/shaft3.wav": {
+     "bytes": 7304,
+     "sha256": "fef252e48eb84586bba69c6e6160b49c6bb0c0e65a3afbc9975adbeb79c9ca98"
+    },
+    "sound/weapons/light2/lgdis1.wav": {
+     "bytes": 10138,
+     "sha256": "63c65c3e1c0477d9231ab2a9d7f149e1de011514d5660c303c1197d05ca965bd"
+    },
+    "sound/weapons/light2/lgdis2.wav": {
+     "bytes": 10138,
+     "sha256": "443d67a4d6c59932282903564dbe765921d788a17d92626e2a73880cd0a0ca97"
+    },
+    "sound/weapons/light2/lgdis3.wav": {
+     "bytes": 10138,
+     "sha256": "730a8d976d7b68d40eda41e5c098ff9ad81bab6050f2a277a21a541436f4552d"
+    },
+    "sound/weapons/light2/lghit.wav": {
+     "bytes": 7144,
+     "sha256": "f4c2c797710b5551fb674f4003f093a33608a6d306a7559edb5eb5050988e950"
+    },
+    "sound/weapons/light2/lghit2.wav": {
+     "bytes": 10952,
+     "sha256": "a89cf8040b80c1a64fa34fa863177056d536fc27a4ac69020abcf3e50618aee8"
+    },
+    "sound/weapons/light2/lgstart1.wav": {
+     "bytes": 9320,
+     "sha256": "e2a018101f5ddad1066c0c08b9d24fc746e09db0adf5dadbbcc76d1f6209ccbe"
+    },
+    "sound/weapons/light2/lgstart2.wav": {
+     "bytes": 9204,
+     "sha256": "c97ee4a0e25f706765f303b7f15288d295c5d86a9347502a31d889e396fd6f3a"
+    },
+    "sound/weapons/light2/lgstart3.wav": {
+     "bytes": 8854,
+     "sha256": "7ef201bdad1f01548f7a2a33ea930f233c55b81ad5e729b3f6b8d6f83b118053"
+    },
+    "sound/weapons/light2/lhit2.wav": {
+     "bytes": 8246,
+     "sha256": "42ab314a82b9e5ed97bbf533facae7c88ada3d93d1eebdab2773b60a2c8d420d"
+    },
+    "sound/weapons/pulse/install.wav": {
+     "bytes": 29366,
+     "sha256": "c01770c0abe52f40a56397ac0fdefe9865b3964a0689f5caf98f2bb47317a1bd"
+    },
+    "sound/weapons/pulse/pulshot1.wav": {
+     "bytes": 7790,
+     "sha256": "1e75d4640e22a05348da3e2bdae4005d768f17e7b51b46146d4ffd00fcaa8bda"
+    },
+    "sound/weapons/pulse/pulshot2.wav": {
+     "bytes": 3664,
+     "sha256": "b357e923e1aff657c40f7fc4a0e71ac3d536c474ffd7d89decceb19bfabb8248"
+    }
+   },
    "sha256": "8dafb37efb862e5a0fd3badd29562cd8f60aa00c7a36c83a448e9a613788e290",
    "timestamp": "2007-11-01T20:59:36.000Z"
   },
   "aopfm_v2/pak1.pak": {
    "bytes": 18734972,
+   "files": {
+    "maps/aop1m1.bsp": {
+     "bytes": 802900,
+     "sha256": "dfa4cd3d09bf7956c02d9d27cfb4bed2a6761a58e70fdce98c88a059910e2c80"
+    },
+    "maps/aop1m2.bsp": {
+     "bytes": 1916800,
+     "sha256": "bb47ce927abbaba212fa0ff42028cf3ae865a06633e32097d83806e7ec5b0250"
+    },
+    "maps/aop1m3.bsp": {
+     "bytes": 2517936,
+     "sha256": "dc6230ef028be49edbc47dd3e1b39232efb57298279bef8ecb70fd10b543f299"
+    },
+    "maps/aop1m4.bsp": {
+     "bytes": 2290820,
+     "sha256": "65019a89a5369b216ce16098c56d93c095266205cf90b95bf31f5de062a8cdaa"
+    },
+    "maps/aop1m5.bsp": {
+     "bytes": 2510632,
+     "sha256": "d521c9e4e3ec7baaf94d2ee45a0842841708da6416a151b2e0d6e14311e311cc"
+    },
+    "maps/aop1m6.bsp": {
+     "bytes": 1167244,
+     "sha256": "34cb076555a1bf0c6cd2213d9aca60dd7ff4e4868f2c7b97a5ceecbc5170a7d8"
+    },
+    "maps/aop2m1.bsp": {
+     "bytes": 1796500,
+     "sha256": "7a411e69853245ef82902d5f7739b0be59902da8ed571a806887f06c76fdff84"
+    },
+    "maps/aop2m2.bsp": {
+     "bytes": 1690488,
+     "sha256": "76bc745c6bc6827f87fc48c6561d43d874055d6e748f0f80c7b425af4453b7d7"
+    },
+    "maps/aop2m3.bsp": {
+     "bytes": 1276772,
+     "sha256": "2147a2bc1d46387b13445aa271c1b3543e837af1c6e993f4d215f23b622731ae"
+    },
+    "maps/aopend.bsp": {
+     "bytes": 1635036,
+     "sha256": "87fda207f170251d694180a1c5e5f716b3f9cd27b34f0a92567d4e39767089a0"
+    },
+    "maps/start.bsp": {
+     "bytes": 1129128,
+     "sha256": "bcfb0cb52c2b731226b21804b3d46957b852ad7b37329e846515acaabc4118f9"
+    }
+   },
    "sha256": "b5a61a1bccf392fac25778baa3d9df192bd196eb66c1e70aa993307887b6d210",
    "timestamp": "2007-10-30T18:12:26.000Z"
   },
   "aopfm_v2/pak2.pak": {
    "bytes": 3826080,
+   "files": {
+    "maps/aopdm1.bsp": {
+     "bytes": 501272,
+     "sha256": "bd793d8289096fee893843f26fd93977989a988cd7320bc6fa41af3e681fd857"
+    },
+    "maps/aopdm2.bsp": {
+     "bytes": 553304,
+     "sha256": "7ed16564da401921e41220610ad8e848dc7690296c0914ae0486fd1593651eee"
+    },
+    "maps/aopdm3.bsp": {
+     "bytes": 296356,
+     "sha256": "256b181760c5062820bbf1601c673f75e74364ab50ff027b97cd58285d3cdf28"
+    },
+    "maps/aopdm4.bsp": {
+     "bytes": 464836,
+     "sha256": "8a7bd1867aa1e1b28c3a2003239fcbe902de311d087af2c9291d70f134fab563"
+    },
+    "maps/aopdm5.bsp": {
+     "bytes": 1118860,
+     "sha256": "cf9e4315764bf5bc857054a224c4ae597025170df1279f22379147c885376b7b"
+    },
+    "maps/aopdm6.bsp": {
+     "bytes": 891056,
+     "sha256": "0199f268a0c241eefd4ec906b3e2b7be4b3edb44bc244b2a4ac1d2cc178ba58d"
+    }
+   },
    "sha256": "b1012014e98def52c98364577f5ffe813717fee7ce32e806b9accb41fbed9660",
    "timestamp": "2007-11-01T19:01:08.000Z"
   },
   "aopfm_v2/pak3.pak": {
    "bytes": 8756414,
+   "files": {
+    "aopend.dem": {
+     "bytes": 5164312,
+     "sha256": "a49386d6d0499de24095850af341153adca47e3acbaa201628d12540cb81bdf0"
+    },
+    "demo1.dem": {
+     "bytes": 1468793,
+     "sha256": "1d3add7455b579c8922da4f6fead87576f32b4981356b717c74fb7692d98eb1a"
+    },
+    "demo2.dem": {
+     "bytes": 1297536,
+     "sha256": "2200ba8de7d0e97bb017d99b55bc7a59e63b67fce510ad21e300cddaddc5d969"
+    },
+    "progs.dat": {
+     "bytes": 675632,
+     "sha256": "6d49a29329cf106a895295be42f5e005ff0acb1b9287848be040c49b04a860ef"
+    },
+    "progs/flameo.mdl": {
+     "bytes": 81036,
+     "sha256": "cc1f276845c4d551898c3453f736877f77490a949c2d1b19900c25598f51a052"
+    },
+    "progs/flameo2.mdl": {
+     "bytes": 64572,
+     "sha256": "a8efa3ae675df00e82088bb0a8daa3dd91597c01418ecad61ed2a38a545e422a"
+    },
+    "progs/null.mdl": {
+     "bytes": 3636,
+     "sha256": "c34f908eb55175c66e0649d6ada308b610116cd2ee0abde228a0b08839a1d867"
+    },
+    "quake.rc": {
+     "bytes": 373,
+     "sha256": "a7e77e1e6531aa2ca72186b9759cad973ae458ef4581f9d263392aad1920c114"
+    }
+   },
    "sha256": "a61f61eb687d6abfa1d8137d96144bb999e053dcbf84157cb1c84616391e74ee",
    "timestamp": "2008-08-10T22:40:38.000Z"
   },
   "aopfm_v2/pak4.pak": {
    "bytes": 10027992,
+   "files": {
+    "textures/models/blud_0.tga": {
+     "bytes": 1572908,
+     "sha256": "96d8ac92ae2ed9b2de7636260b119d5edf662371f1d7dc3137a474daaeb532f1"
+    },
+    "textures/models/blud_1.tga": {
+     "bytes": 1572908,
+     "sha256": "9b80e0c5520773c8dd41cc453b80871d998bce9be68dba02290a622a64be635e"
+    },
+    "textures/models/dknight_0.tga": {
+     "bytes": 786476,
+     "sha256": "36c9a4750c3a29b80d33358e4d85de313db4b6e1e8ac16945e6881f60c8186dc"
+    },
+    "textures/models/grenling_0.tga": {
+     "bytes": 393260,
+     "sha256": "b993f6dbd77f69bd55e875f005c9d4d57bc40b887744627b9c298236f9d5d182"
+    },
+    "textures/models/jugg2_0.tga": {
+     "bytes": 1572908,
+     "sha256": "cf06e40925bb06a65ae76ea318a4fccbfa31042f33375015784a1ca1eef145ea"
+    },
+    "textures/models/jugg_0.tga": {
+     "bytes": 1572908,
+     "sha256": "1099251ca0fc24945f25e28ef19203ec14a70e4d10cbc17dc2bfd33fc0547f6e"
+    },
+    "textures/models/legond_0.tga": {
+     "bytes": 786476,
+     "sha256": "0952d536add649514fc011bf725fc02760f67a3b5e066442017d323a7d845fb4"
+    },
+    "textures/models/spawn_0.tga": {
+     "bytes": 1572908,
+     "sha256": "96d8ac92ae2ed9b2de7636260b119d5edf662371f1d7dc3137a474daaeb532f1"
+    },
+    "textures/models/spid_0.tga": {
+     "bytes": 196652,
+     "sha256": "9b25cdb67b45e473537e20c1c0bd669911fdfb110bd8e0b642eb765010abad2d"
+    }
+   },
    "sha256": "c0fdbfeadc8e9b3c2385be82728d0dfe980c0466b1b782fa5edee9faff0676b1",
    "timestamp": "2008-08-11T13:25:08.000Z"
   }

--- a/json/by-sha256/60/6054ce0e5fdf114b0c37743874e07b0b85c5f4e205d2f6be352211f8eb0679be.json
+++ b/json/by-sha256/60/6054ce0e5fdf114b0c37743874e07b0b85c5f4e205d2f6be352211f8eb0679be.json
@@ -12,6 +12,216 @@
   },
   "Pak0.pak": {
    "bytes": 6654431,
+   "files": {
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "90cffe39abfbcb9fc12bbc8701496c0c8a613542eb45ea4b3c9ea0e3069c8b16"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "4366d477e5d2333750a0f334c1813ad2a3718cd7b7cc092d551e7aebd7c20507"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "88c004ec602b14590c9337a77e0e7a084b6c791bf09fb51a051fc5b84bb75961"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "085a10c65c95ab593dae27d1cc54ecaca42f11bb76b31398125c336378b9fc72"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "2136f7cac69bd364eceb670cc42efcd1df226dfab06b0ef99b5c62c5707bcdec"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "60c5ca60b7f59e7fc5995fa93ab78ab471154909cc2778a274d79b6a149944dc"
+    },
+    "maps/casspq1.bsp": {
+     "bytes": 2645072,
+     "sha256": "7a916e41ad6e185063c911f27073e1d874f7a0b2b0e7ed6ab133748d50b66452"
+    },
+    "maps/start.bsp": {
+     "bytes": 662356,
+     "sha256": "7247efd688d5dff844a5a91f7b28da6f5c9138d4f096564a0ed8523b442abf71"
+    },
+    "progs.dat": {
+     "bytes": 748392,
+     "sha256": "bdac5749f1536dd206066d775ab5bdd071f99d68a9ea79f6e8f8309478339273"
+    },
+    "progs/beam.mdl": {
+     "bytes": 10608,
+     "sha256": "2165a66ba1d40fa378df735835b014791e769cb8bc56e06977aefdf134bb61d5"
+    },
+    "progs/beamhit.spr": {
+     "bytes": 5320,
+     "sha256": "bdfe3464c0bea904c3d35135b6d242f486298447ea45c3f96cce7ac6b71a3e54"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 1364,
+     "sha256": "eb7ed9439d34fcdc6c8a04a0bf57d344a75d208d65b8e3ab455ddda5965bf0b9"
+    },
+    "progs/bs_light.mdl": {
+     "bytes": 28707,
+     "sha256": "6c646ab4291d12aecdad5d9af4c44f4d68fc207c730dbf3ac04e07103cdd2c12"
+    },
+    "progs/camera.mdl": {
+     "bytes": 33528,
+     "sha256": "afbb9ddbbb0d9a7509a555289d2517bb94991f6a0c4d8f2b5cf508794485c82c"
+    },
+    "progs/csm_cpit.mdl": {
+     "bytes": 4424,
+     "sha256": "17c3aefc3c13035e45aec9befe0bf6722d163637aa56f18c3bec23c838dd5978"
+    },
+    "progs/dring.spr": {
+     "bytes": 387832,
+     "sha256": "94adc8ada163983eae9ccb924bd4ef4d8ebb2613bd23705d2e8a7bb73e7657d1"
+    },
+    "progs/expl.spr": {
+     "bytes": 127672,
+     "sha256": "553b80901ee3d765c147ecce187a53989ded3991532e02f53c5b0cbb42aad5d4"
+    },
+    "progs/frame.mdl": {
+     "bytes": 24293,
+     "sha256": "c033f1d4dabaa36e34b58884d4b45d3a74c587893debaa362c83b286ff7d2c62"
+    },
+    "progs/g_beam.mdl": {
+     "bytes": 68996,
+     "sha256": "db2566d26863472c6176c91b2256c12b5fdd28b5e1ba0a3ff2aa9e122ed0cacb"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/v_beam.mdl": {
+     "bytes": 75588,
+     "sha256": "c00fe7872cb2c88626e63d99c3cc00b83f9968803344cd2021e8fc26bd25ccba"
+    },
+    "progs/v_beam2.mdl": {
+     "bytes": 75588,
+     "sha256": "95b3a260450ca784bda0885da994a5a857cf9948581ed1e68c4b202c51dae670"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 1241,
+     "sha256": "de4c458fd48a1d3c8e9516b11024cfc8dc330f3d072dd4cb682d00554800daab"
+    },
+    "sound/comp/10_snd.wav": {
+     "bytes": 119046,
+     "sha256": "dda8d99243ab70f26a275a61275cbb3a8468bf1a98b420f6d29dd93a57ef5f4e"
+    },
+    "sound/comp/20_snd.wav": {
+     "bytes": 47964,
+     "sha256": "45dc0bc82110be5b522176f30ebfd1e03b31276eba6095b1c35e404e50141091"
+    },
+    "sound/comp/30_snd.wav": {
+     "bytes": 44432,
+     "sha256": "705413d486df860333668b4e1c5cbdd1a1edbfabf938c91c5a9d697931cc9f20"
+    },
+    "sound/comp/ens1.wav": {
+     "bytes": 38264,
+     "sha256": "f818d6d848785ca0c4471630ddb2e9dfaef58662a71272f47830fb586e9c728b"
+    },
+    "sound/comp/ens2.wav": {
+     "bytes": 73068,
+     "sha256": "bd78258755860af316e4fa919fd4f02cc990f19fbbbf58042f174f6141c67138"
+    },
+    "sound/comp/hgrav.wav": {
+     "bytes": 38986,
+     "sha256": "c0f58afc02b16a11e9a5a5a203ca2ea405fa1bfb46b0de4569cb63c3dffb3378"
+    },
+    "sound/comp/tol2.wav": {
+     "bytes": 30372,
+     "sha256": "31781816e9ee2cc56ba64177107635d319b5841c1ffa4da96bb12ecfb778e6cd"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/misc/alarm.wav": {
+     "bytes": 52904,
+     "sha256": "0ec6c6403123a3168f6564add8bc21686b7475a59faa5939a1f96cb92b4cb2c3"
+    },
+    "sound/misc/elev.wav": {
+     "bytes": 41876,
+     "sha256": "6edef89d58a29e7c69d8c2fab14ab15ce33c0412c7e3a79a68168576ef98664a"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 1147,
+     "sha256": "886f149bdaa8a6e1b6d81cb4d4cd6a339012239a0aaaa85a5ad48a269c4ca69a"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/r_tele1.wav": {
+     "bytes": 1147,
+     "sha256": "886f149bdaa8a6e1b6d81cb4d4cd6a339012239a0aaaa85a5ad48a269c4ca69a"
+    },
+    "sound/misc/r_tele2.wav": {
+     "bytes": 1147,
+     "sha256": "886f149bdaa8a6e1b6d81cb4d4cd6a339012239a0aaaa85a5ad48a269c4ca69a"
+    },
+    "sound/misc/r_tele3.wav": {
+     "bytes": 1147,
+     "sha256": "886f149bdaa8a6e1b6d81cb4d4cd6a339012239a0aaaa85a5ad48a269c4ca69a"
+    },
+    "sound/misc/r_tele4.wav": {
+     "bytes": 1147,
+     "sha256": "886f149bdaa8a6e1b6d81cb4d4cd6a339012239a0aaaa85a5ad48a269c4ca69a"
+    },
+    "sound/misc/r_tele5.wav": {
+     "bytes": 1147,
+     "sha256": "886f149bdaa8a6e1b6d81cb4d4cd6a339012239a0aaaa85a5ad48a269c4ca69a"
+    },
+    "sound/misc/ship.wav": {
+     "bytes": 53148,
+     "sha256": "e157fcd6d5ab91b242ace54dd87580217ad0c2055e02a55380dcbf0630e064d7"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/shuttle.wav": {
+     "bytes": 61818,
+     "sha256": "19b8fed04a8565aa9e6e551a9162b13fdc746f7d3d364558de689e52514009e3"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/steps/lowecho.wav": {
+     "bytes": 1147,
+     "sha256": "886f149bdaa8a6e1b6d81cb4d4cd6a339012239a0aaaa85a5ad48a269c4ca69a"
+    },
+    "sound/turret/beamchrg.wav": {
+     "bytes": 3962,
+     "sha256": "d02bd7d2c4754fe3159fac83b4f0898f8b2e1f8996ce7e6cfdaa4a9d75a24fb1"
+    },
+    "sound/turret/beamhit.wav": {
+     "bytes": 8644,
+     "sha256": "35e5e5f28a3695ed27c2b0887a1bf118643d769c457d3642016e887248fa8ca9"
+    }
+   },
    "sha256": "d49db62ae198a11140c672210a44bf1ae9b578e51a02c248d8b7c91b00b71ce0",
    "timestamp": "1998-06-23T00:59:10.000Z"
   },

--- a/json/by-sha256/61/61a29f2506e4193b08999fcbac39c05e7c80d81d8496a74be9cbcb0330ae6db7.json
+++ b/json/by-sha256/61/61a29f2506e4193b08999fcbac39c05e7c80d81d8496a74be9cbcb0330ae6db7.json
@@ -17,6 +17,43 @@
   },
   "sky_morose.zip": {
    "bytes": 1588990,
+   "files": {
+    "morose_bk.tga": {
+     "bytes": 786450,
+     "sha256": "6f351dd4e0ecfa141465b362319a86d7b4f4cbc949ffa01d0b2336314da75b4c",
+     "timestamp": "2006-01-23T14:58:16.000Z"
+    },
+    "morose_dn.tga": {
+     "bytes": 786450,
+     "sha256": "8c0dda2929adb1c3c30b14aeed94446c5e4d43ddb431b690e513f92c6bc31370",
+     "timestamp": "2006-01-23T14:58:16.000Z"
+    },
+    "morose_ft.tga": {
+     "bytes": 786450,
+     "sha256": "9a7fe3f384bf5b68f9770a60fd79e373b8423919b1ca61197095d931e14cfc3c",
+     "timestamp": "2006-01-23T14:58:16.000Z"
+    },
+    "morose_lf.tga": {
+     "bytes": 786450,
+     "sha256": "951cf64de1dfc68e8cda000dde4167de48fbe704f9de1eb996cd7b4c63edce66",
+     "timestamp": "2006-01-23T14:58:16.000Z"
+    },
+    "morose_rt.tga": {
+     "bytes": 786450,
+     "sha256": "25cc4aeac0a4058def918884cfe2e37413152111cc82962b3e404d41d9218258",
+     "timestamp": "2006-01-23T14:58:18.000Z"
+    },
+    "morose_up.tga": {
+     "bytes": 786450,
+     "sha256": "c3c06d78ce1672227fc7cf1070b2545e6842af15691f705100286031c57d92c3",
+     "timestamp": "2006-01-23T14:58:18.000Z"
+    },
+    "sky_morose.txt": {
+     "bytes": 2146,
+     "sha256": "a2dfee7bf3122f93dc1ccef1fcff68db6ea95f67efdbd0ffd96e488451b7e5e5",
+     "timestamp": "2006-03-24T12:16:00.000Z"
+    }
+   },
    "sha256": "641122cff45de6778d068862879c143db707d6b483d673f41a5a2433e33d4477",
    "timestamp": "2006-03-24T12:16:12.000Z"
   }

--- a/json/by-sha256/62/62714001117bf1af7ada868c335ec9648a634b57eba5de98999b84b3b44c5aff.json
+++ b/json/by-sha256/62/62714001117bf1af7ada868c335ec9648a634b57eba5de98999b84b3b44c5aff.json
@@ -65,6 +65,33 @@
   },
   "src.zip": {
    "bytes": 1289311,
+   "files": {
+    "rt_alk0.map": {
+     "bytes": 2334017,
+     "sha256": "7b2fb597b855a7aea3e11d45658f048449892e32ada7ded5f119f0e45e620aa3",
+     "timestamp": "2023-06-22T01:06:10.000Z"
+    },
+    "rt_alk1.map": {
+     "bytes": 2215870,
+     "sha256": "9ea921f96b0baeeb0b6a3dd04ee709a11944e77e7416182553cb403cf2af9af8",
+     "timestamp": "2023-06-26T01:33:34.000Z"
+    },
+    "rt_alk2.map": {
+     "bytes": 4497397,
+     "sha256": "3685d5755470fba0f6f650137241ebd29ff1f9e47e26d41af4be1301c42e6da4",
+     "timestamp": "2023-06-22T02:48:20.000Z"
+    },
+    "rt_alk3.map": {
+     "bytes": 2740788,
+     "sha256": "f19d6d90e27b8018ed22431a7bfcf7b873b2577e8d3599883daa0a510099dcce",
+     "timestamp": "2023-06-26T01:32:36.000Z"
+    },
+    "rt_alk4.map": {
+     "bytes": 290157,
+     "sha256": "96ef6168d6f8d9f6e4eb444a4f0595ab2c7dc8ad73c88c9dfebe6edd9309b43c",
+     "timestamp": "2023-06-22T02:14:34.000Z"
+    }
+   },
    "sha256": "3e2bebf3be260703425709a1494c8fa70b6867595c5494f38bb1f5c14c9c5422",
    "timestamp": "2023-06-26T01:47:34.000Z"
   }

--- a/json/by-sha256/63/636423328ef557ddb8f3b2c5e63f95a7f2f0860a62d548e228d291db3798368f.json
+++ b/json/by-sha256/63/636423328ef557ddb8f3b2c5e63f95a7f2f0860a62d548e228d291db3798368f.json
@@ -7,6 +7,636 @@
  "files": {
   "pak0.pak": {
    "bytes": 11298992,
+   "files": {
+    "demo1.dem": {
+     "bytes": 284476,
+     "sha256": "654155f81720fae233cbe22c9d68eba7c5e3935153499f4892ee5247821984de"
+    },
+    "demo2.dem": {
+     "bytes": 244822,
+     "sha256": "b86242809a14f77400abd0ac9d0fe4f69244fe5bd1d2d8c3676f147290db9fc2"
+    },
+    "demo3.dem": {
+     "bytes": 585687,
+     "sha256": "4f09a01c33f7fcf8857d4023657cc62187354f611dfc471c5e2eebc08b43de01"
+    },
+    "maps/trsp3.bsp": {
+     "bytes": 3011532,
+     "sha256": "e0a3448138e9877daad95f17e1372607d3d642fcb6686dff9d7703dbcb94fc74"
+    },
+    "maps/trsp3end.bsp": {
+     "bytes": 884656,
+     "sha256": "ed9f8521f1b0210b79ee4edf62914017f13625268365044c14519e2da19453cb"
+    },
+    "maps/trsp3st.bsp": {
+     "bytes": 317908,
+     "sha256": "8d4ea39181a2c389eb55fde3f848a8a99ca636ad5c198260db1f5aa59b7c0e3c"
+    },
+    "progs.dat": {
+     "bytes": 718696,
+     "sha256": "eb9292c3f6250991d6a6a6ef6727ecb7647725c18dbd31cb4ce27f08fd8f424d"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/boss2.mdl": {
+     "bytes": 629301,
+     "sha256": "1facc0982b8b8e8dc7bc6fec04f0cce0546b50b08cc2bbcc3108c335a77fc0e1"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 224812,
+     "sha256": "af9095cffbc74edc9d98d4e4e341736e304404df52983be33616da84d6463c87"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 649023,
+     "sha256": "c320c3d37993dedb88e9e4c6e824cae03f9df223b795524cf1070e36e00aec7a"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 12416,
+     "sha256": "2fff2f36173080827a298870a956fb11ad30f34aa0342ba5ca2c8bd6509edf57"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/hknight2.mdl": {
+     "bytes": 909361,
+     "sha256": "f8ad2dc18653e36630eae567633d84b2e03a52a6cd8c125edafce1c87ff18c8c"
+    },
+    "progs/k2_spk.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 59078,
+     "sha256": "6a7022fa8210771be206034a2b0ebeb59f6fc79719d499ac01811a4ff32eb08a"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shamrock.mdl": {
+     "bytes": 45732,
+     "sha256": "0a8f6b6d751a8bcaf25a44f48f0dd88bb6c06efc0cadb7ae12d844e496522cb9"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/tarsbody.mdl": {
+     "bytes": 133520,
+     "sha256": "084d668e60990a1268059ca9d4d5a2979963ccf9c6dad06adb036787246a5943"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "qc/ai.qc": {
+     "bytes": 25496,
+     "sha256": "c54e9f2232c65724a1b7fc44782a02bb5c5f793d7d64e4b694e7898f6421f584"
+    },
+    "qc/amtest.qc": {
+     "bytes": 1697,
+     "sha256": "8dd158020b8c0be6988b0f1fbe03990372fb769442dbaf85248ef8c0e18645ee"
+    },
+    "qc/boss.qc": {
+     "bytes": 12411,
+     "sha256": "674893303bff9280f134066f168b06dd2dd1d58591c42acc2c70c6e2a4b9ba82"
+    },
+    "qc/boss2.qc": {
+     "bytes": 6553,
+     "sha256": "80e67fb24421e8048b215dc1cb005b72158c57d5e7a3552b8e5f9661e204fe99"
+    },
+    "qc/boss2f.qc": {
+     "bytes": 1345,
+     "sha256": "2520d3fcb91c37760a75109bcb4ff41b60ac9cfe4dbce6caca02b4174c614bf6"
+    },
+    "qc/builtin.c": {
+     "bytes": 31202,
+     "sha256": "b8aba0fc0a369b7acc93a623cf622db5da8bed857ced54cc8fce56f53b85144f"
+    },
+    "qc/buttons.qc": {
+     "bytes": 2910,
+     "sha256": "4a3075cd783cdb788948dd1dc79abb63cfb30a016cb3f1a5979814f457dd9f6c"
+    },
+    "qc/client.qc": {
+     "bytes": 47757,
+     "sha256": "5de3f8c18465e511414cc4d54a8287d71b1c98ddaa0755cbe6690fa9e9fcfc99"
+    },
+    "qc/cmdlib.c": {
+     "bytes": 8876,
+     "sha256": "b1c580151d9f1daea00b3dd0a72ea613568c9414b9ca1caaae8d9c4334eaaa0d"
+    },
+    "qc/combat.qc": {
+     "bytes": 7329,
+     "sha256": "f6d0b37c212f313777c4dce0909a19a58c015e34050ee03c57176e317366df6c"
+    },
+    "qc/defs.qc": {
+     "bytes": 17485,
+     "sha256": "cc62dd29caf5ed75332104641fc606a60fc54369b60d935aa01375ec9e68e11c"
+    },
+    "qc/demon.qc": {
+     "bytes": 9904,
+     "sha256": "b20d0e3664ff9ff9e55222ad73507016a832b15a4cb28f93b86e90fa35ea445c"
+    },
+    "qc/dog.qc": {
+     "bytes": 9542,
+     "sha256": "7dd3980dc2f284046f0e516b39d8b7391ac4a87b758b2f89aeb682feab2cc2bc"
+    },
+    "qc/doors.qc": {
+     "bytes": 17028,
+     "sha256": "125ecc6795edfa031b44082217a4f004a630e44e438b9dcb3e374f9d56b6ed9c"
+    },
+    "qc/enforce2.qc": {
+     "bytes": 15889,
+     "sha256": "3f75f7d0a85fe060e208eb31f8b959b205d9102e6e43c01f3e69a2d0f4967e9f"
+    },
+    "qc/enforcer.qc": {
+     "bytes": 12260,
+     "sha256": "9dcfc7cf540b0457fdfa3c0798367ea2de8f5df65c4eb674395d1a64d446e275"
+    },
+    "qc/fight.qc": {
+     "bytes": 7217,
+     "sha256": "d108ca75d6dbe2a4e578df00588a280cc23c1ab4dba3d5e46d64767b1b3089b0"
+    },
+    "qc/fish.qc": {
+     "bytes": 8377,
+     "sha256": "89a6e79d6e7d5b816db511c3a333bfb35694286673a6f665f27a2e2fcb13f2b3"
+    },
+    "qc/flag.qc": {
+     "bytes": 141,
+     "sha256": "143f0b896c7515dcdaaf5b436d130fe1ffb6fa67cad2a34ad4639724201b3445"
+    },
+    "qc/hip_brk.qc": {
+     "bytes": 2037,
+     "sha256": "dc2ec447731f17ff7282c4980b49da8b71589eec4e8b7885fa5650ecf8961eec"
+    },
+    "qc/hip_expl.qc": {
+     "bytes": 4984,
+     "sha256": "060d5467af23b6f5282b5307dc9d465219512ee8dae1f3854753af6543cb5b14"
+    },
+    "qc/hip_part.qc": {
+     "bytes": 7131,
+     "sha256": "e8ea6fd0753e810b7e8ce2094cf3d49608e55f545919c8a5d135c3871f909048"
+    },
+    "qc/hip_push.qc": {
+     "bytes": 2265,
+     "sha256": "d040d311a043b24c6140c8fee9ba0b3bcb2b136dbf2b6b54268324ffe383c6b1"
+    },
+    "qc/hiparma.qc": {
+     "bytes": 35979,
+     "sha256": "d1b52493f14271cf9d7c3fc48e7b2e9083fc199b9bf4634dc8e957d50993911f"
+    },
+    "qc/hipclock.qc": {
+     "bytes": 1881,
+     "sha256": "e9e7b43b1825a6e2f82d27abfe2c8ee7b17fe01c162d9a91f5d38b814f381be6"
+    },
+    "qc/hipcount.qc": {
+     "bytes": 3898,
+     "sha256": "c6aa9486528fa6e00b746d12a4578fb2d871e610a06f79edc11fdd691abf1854"
+    },
+    "qc/hipdecoy.qc": {
+     "bytes": 3939,
+     "sha256": "eaf81dc44c4b02a041f6c5ecf42f85e5aba63213bedddbdb30cbf151301b9793"
+    },
+    "qc/hipdefs.qc": {
+     "bytes": 2933,
+     "sha256": "aea5afeb0f5c3af17c70f77482cea5ee3de60378b06ac371388bbf81d30953c9"
+    },
+    "qc/hipgrem.qc": {
+     "bytes": 56092,
+     "sha256": "c5fa723a4cf8d71ba307d69a244821c2d4c9775de267edf0f8dd627a9b84ee0b"
+    },
+    "qc/hipholes.qc": {
+     "bytes": 2654,
+     "sha256": "aa15d16b7e2080025f58899b3e024cf131000ae337a9a432c34fac7f6045f700"
+    },
+    "qc/hipitems.qc": {
+     "bytes": 23377,
+     "sha256": "fd10dd4ef525c84cf64524b02280e4bbc293fae16738bebf002d44c9bf802269"
+    },
+    "qc/hipmisc.qc": {
+     "bytes": 13394,
+     "sha256": "5582e64668172b14a2c07fabb30fd7ccff503a7ab5a3a41233564269bd8572c1"
+    },
+    "qc/hipmodel.qc": {
+     "bytes": 3537,
+     "sha256": "47dd32c53f6b92393887325e6cae23b61cbf2dee766fd6aa40e0236e3d501008"
+    },
+    "qc/hipquake.qc": {
+     "bytes": 1681,
+     "sha256": "526b8f617fca97f9da5213542c74892ff29ca5700f4305636ab9bfc682ee86e8"
+    },
+    "qc/hiprot.qc": {
+     "bytes": 26953,
+     "sha256": "4cfbd54e7514db7095c64a905232bed478fdd11e320ca9e1f2c54ddd62a5d0ab"
+    },
+    "qc/hiprubbl.qc": {
+     "bytes": 2965,
+     "sha256": "575da38e3c434962657d0b5f265968b8590261e0ebcc7e7b935ac3fa2e28a6ff"
+    },
+    "qc/hipscrge.qc": {
+     "bytes": 16207,
+     "sha256": "3aced2bb3041e025d3880a82530e8c5f1a026994adea75812ee88922372a1585"
+    },
+    "qc/hipspawn.qc": {
+     "bytes": 10398,
+     "sha256": "cb149bf637d2efc207cd61464ee1f1a7212f5428eb1d52ae8febc6e76dd92c4e"
+    },
+    "qc/hipspike.qc": {
+     "bytes": 1717,
+     "sha256": "70c5795112ad4d25c460b99e45f4ddce3a6d4528522e6eee3fb81f9ba9aef8ff"
+    },
+    "qc/hipspr.qc": {
+     "bytes": 382,
+     "sha256": "f19e5be74eb6f49ce7d995818569d0c712c8ab792100fc6682417c8383390d15"
+    },
+    "qc/hipsubs.qc": {
+     "bytes": 6648,
+     "sha256": "8c165a40c63b9ffe0f5d7222dbae458c5a52e1955347718244d2c3bf7b0c7645"
+    },
+    "qc/hiptrain.qc": {
+     "bytes": 4785,
+     "sha256": "8d7cdd9b333a27e9b5ec18a7b5dade6a635d43027a8f44280d38ac39a6fdb865"
+    },
+    "qc/hiptrig.qc": {
+     "bytes": 6461,
+     "sha256": "5ab153ae3001c30dce8abf6056cdb0abb79cb5bf96b5a0852bc30d4b4b5eb159"
+    },
+    "qc/hipwater.qc": {
+     "bytes": 1238,
+     "sha256": "47fbac4f143a2ace2e033fd7bb2c29cc39e1b3a1bb6b16ee7786938d070e0ca3"
+    },
+    "qc/hknight.qc": {
+     "bytes": 19395,
+     "sha256": "055d95c5d2b7d202b31a2408ca9f154fee3fa9661f7c43dcb6376c92378d6c62"
+    },
+    "qc/items.qc": {
+     "bytes": 29764,
+     "sha256": "3b6a3a9cdd8008840ee857463e74098fe88e0c1f66ab4c2a19bcb68ec1539d0f"
+    },
+    "qc/jctest.qc": {
+     "bytes": 222,
+     "sha256": "0b356238bdae38139e36fb7f9ed5a72e65accee92b48f25035b79ec315a7da06"
+    },
+    "qc/knight.qc": {
+     "bytes": 9684,
+     "sha256": "53202927092c04d472a311e5ec8732cdb2ed9224c6520fbe4d126e152b5cee87"
+    },
+    "qc/misc.qc": {
+     "bytes": 17578,
+     "sha256": "2b56f2449d7f4cfcbc0437aa9f9a3ec8a98eeddc06d1f11a17278ac406bdf05b"
+    },
+    "qc/models.qc": {
+     "bytes": 8996,
+     "sha256": "d11fd0939293244962c5a40766e1dce246bde98eb0d42c87eb530a58d6eca64d"
+    },
+    "qc/monsters.qc": {
+     "bytes": 4932,
+     "sha256": "38e181b3a6dfedae2fed2781b588a96e92e1b59c7f4504de45c57a3189060340"
+    },
+    "qc/ogre.qc": {
+     "bytes": 14687,
+     "sha256": "26fe1334e7e502f5b2834d2a19741941ec748d808e104162bb382623d1558ef0"
+    },
+    "qc/oldone.qc": {
+     "bytes": 9537,
+     "sha256": "3ebf15cec4adf547d8859cb54772e9c1c331fd30cb3c82bccb328bb945e5f834"
+    },
+    "qc/plats.qc": {
+     "bytes": 7693,
+     "sha256": "a5338b5e69814d193d06685e9c24a417fe1b94d46e996f87c7788218791901b1"
+    },
+    "qc/player.qc": {
+     "bytes": 23619,
+     "sha256": "3e11eacb62c44a59bb08297dd6bccabd046e569953069bbd5d721c55102b591f"
+    },
+    "qc/progdefs.h": {
+     "bytes": 2598,
+     "sha256": "99e562ac15081804245e7c7018956f2241cffa00a024a954c97183248bd00ea4"
+    },
+    "qc/progs.src": {
+     "bytes": 837,
+     "sha256": "70981811022300d7289b7dd716348d460aa1779fe70168a295028f04b780a747"
+    },
+    "qc/shalrath.qc": {
+     "bytes": 7899,
+     "sha256": "849e0d7efbd62a04ee216f0b451fcc63dc7ea6f2ab877e400670ba0568eae7af"
+    },
+    "qc/shambler.qc": {
+     "bytes": 12725,
+     "sha256": "0c50557b8757d8be3a0876564cfa125e4e8389cae1c55c844871aff5f844c342"
+    },
+    "qc/sknight.qc": {
+     "bytes": 8515,
+     "sha256": "bfc3d406fbe0d707de02c042805d1635c2bce9150899c2689385a72761f9bfdd"
+    },
+    "qc/soldier.qc": {
+     "bytes": 9825,
+     "sha256": "f66da2d85ad5ac42dfe13fd434018e64ca8eddba1e7b3abb747b4577ba072d01"
+    },
+    "qc/sprites.qc": {
+     "bytes": 450,
+     "sha256": "c00564e7ca0ab70d7891931ff333461ff90aa6052f46e8ebb02f59de6e03787d"
+    },
+    "qc/subs.qc": {
+     "bytes": 6378,
+     "sha256": "3dcc59fd6e3eb1390c0e9ebe0878be96063f493d8fec326a8fa7a7666302f5f5"
+    },
+    "qc/sweapons.qc": {
+     "bytes": 49450,
+     "sha256": "31b2cb0cd905b397799b78fff249d8386d4189bd26e749d9566d3602c5539124"
+    },
+    "qc/tarbaby.qc": {
+     "bytes": 7116,
+     "sha256": "4968e4ee45f401c5a703a9c687cddbdb2acd80f3ca2bf95c71f4260a977aae71"
+    },
+    "qc/tarsagon.qc": {
+     "bytes": 36585,
+     "sha256": "6859f3659534a8685207f3c60c9e5a30fb300623b362f6b33b23bdd7a5d6f872"
+    },
+    "qc/temp.qc": {
+     "bytes": 2340,
+     "sha256": "5d9dfc2228d7d81e6f8c9a059c6a8347796ce96cebbf420f3126e24307553a2a"
+    },
+    "qc/triggers.qc": {
+     "bytes": 15741,
+     "sha256": "72db1388edb841295313348a20680f1547cc4f9f9d3c14fc7ec72efa0bd476c8"
+    },
+    "qc/weapons.qc": {
+     "bytes": 49494,
+     "sha256": "79e6bf632cb682c7594c19b347eb3818fbbbd3d5d06447e5342efc0f65e77f9a"
+    },
+    "qc/wizard.qc": {
+     "bytes": 10663,
+     "sha256": "250aa24a63df4d02949abe2cbeee24f9f959d1ecf468c6b3108d0384c7db6d32"
+    },
+    "qc/world.qc": {
+     "bytes": 12867,
+     "sha256": "a829901dd81a624f7f64868e3cccc49833108ebf332e201feabbb94dedb7812b"
+    },
+    "qc/xitems.qc": {
+     "bytes": 20355,
+     "sha256": "de06aade824a441f32958e47eebbbe953871ec79c9c222e0eb7fd60f1ed1bbc3"
+    },
+    "qc/xprogs.src": {
+     "bytes": 841,
+     "sha256": "fa57956cffe64b4d25798450cd21871191bab2711be050d4ab82d548b7b5f9f2"
+    },
+    "qc/xweapons.qc": {
+     "bytes": 31075,
+     "sha256": "795a7050d9f2e98d1cef34a99634277e317b87fcae988cc75570581118153136"
+    },
+    "qc/zombie.qc": {
+     "bytes": 20738,
+     "sha256": "88912bf74ae3b8bdaef9207876f38046866cadb5741e79c636b77b1c2ce527ec"
+    },
+    "quake.rc": {
+     "bytes": 293,
+     "sha256": "ba663420fe80019bb267b5817de2cc96fc1c42c2c723fd61b97a0ae8553d0d18"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 7714,
+     "sha256": "0b0fbd696b78b696bb945f1d388370c2e08d9b14615112b1858e93189a71e61f"
+    },
+    "sound/items/damage.wav": {
+     "bytes": 23374,
+     "sha256": "4cad42570a9234520c5a2d7a3c0e99f62ad468403d8a36f0e11749bdf64a4c01"
+    },
+    "sound/items/damage2.wav": {
+     "bytes": 33012,
+     "sha256": "3b1d7392be723bb60b6f4e270fed3b371386479b0d44e368fd6464645f8c2812"
+    },
+    "sound/items/damage3.wav": {
+     "bytes": 12894,
+     "sha256": "c04f4787be048d70b6f12be2723a62c212cecc08cfb59d2a21c9077ea478b142"
+    },
+    "sound/items/health1.wav": {
+     "bytes": 7958,
+     "sha256": "600ed4428179dadadaae348e3f5063b4c6430ab1bc563cfc30b641911052fda1"
+    },
+    "sound/items/r_item1.wav": {
+     "bytes": 6822,
+     "sha256": "ef880b20d435e0e89d7c5ebacbbcc4a74b90a870a3c1d10326c5636a92c2a061"
+    },
+    "sound/items/r_item2.wav": {
+     "bytes": 7448,
+     "sha256": "9a66a57e78b8904440dfca8837859bca5840517c941e2d7d2930e7356b0cc17e"
+    },
+    "sound/items/suit.wav": {
+     "bytes": 15854,
+     "sha256": "d5a53795fd14d29585194df23675b7c7911c6ae4d8b49fedfc37bded95aef219"
+    },
+    "sound/items/suit2.wav": {
+     "bytes": 33254,
+     "sha256": "ac7d57aed4be13d18f3568da8d234715169e76be3eafc1a882bcab490838f81f"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/tarsagon/death.wav": {
+     "bytes": 108702,
+     "sha256": "1afd95da6ab703a9a1b72e84380b4a3e70d7878e8fd83ce90f45c686e8192dc6"
+    },
+    "sound/tarsagon/death2.wav": {
+     "bytes": 113888,
+     "sha256": "1a842953bcaa08280e933267e3241ce6117a5cd34385089958a613020cb8b883"
+    },
+    "sound/tarsagon/footfall.wav": {
+     "bytes": 15484,
+     "sha256": "a15b15661d25849a7d69727841983d1de527ca6c24db073ffff16cd3a09810ad"
+    },
+    "sound/tarsagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/tarsagon/idle1.wav": {
+     "bytes": 32746,
+     "sha256": "700d31512ec38be95b02988cc3ae474272d3b6e00f09327540cfae353213fd8f"
+    },
+    "sound/tarsagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/tarsagon/idle3.wav": {
+     "bytes": 20938,
+     "sha256": "0188519818205f0765815a667ee9a0dae6185f5bb418922fcf23883b05d4cbb5"
+    },
+    "sound/tarsagon/idle4.wav": {
+     "bytes": 25866,
+     "sha256": "e04e6ebc16812c175978838cc2875b72b1cfed32ccef2f94d7c1bac32faf0d34"
+    },
+    "sound/tarsagon/pain.wav": {
+     "bytes": 22474,
+     "sha256": "cec04a92f40bfb4cebef67c0e40e24c78e8bd4ef16d4527156201f2071b90a65"
+    },
+    "sound/tarsagon/repel.wav": {
+     "bytes": 33442,
+     "sha256": "8156b4946524ca9359cef61161712c6a3b4d9ab389b36f428700f85667c9000b"
+    },
+    "sound/tarsagon/servo.wav": {
+     "bytes": 37684,
+     "sha256": "0aed95f20217a15503a09bc450d70a5a89a613ecbfd85e19aed9b7cc794d3f4c"
+    },
+    "sound/tarsagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/tarsagon/sight1.wav": {
+     "bytes": 31092,
+     "sha256": "bb07315ab271b9e0d72317d11b956516eedae8a5e963210b198d1fa7dc87ab6d"
+    },
+    "sound/tarsagon/sight2.wav": {
+     "bytes": 31092,
+     "sha256": "6f938579c27686229e4e8808152331a3e0aef30f82c7369e68801dec7fe400e2"
+    }
+   },
    "sha256": "c97c05d64d0951cd8ac2369a149d48ff5e46883200cf20a2b6d2773c52ace904",
    "timestamp": "2006-07-15T12:13:20.000Z"
   },

--- a/json/by-sha256/63/63ad5a20323f68cab9526efe3b8a265d05227d367b2758183bc6ac5ae3ed3a35.json
+++ b/json/by-sha256/63/63ad5a20323f68cab9526efe3b8a265d05227d367b2758183bc6ac5ae3ed3a35.json
@@ -12,6 +12,120 @@
   },
   "pak0.pak": {
    "bytes": 8214581,
+   "files": {
+    "maps/gmsp1.bsp": {
+     "bytes": 4747848,
+     "sha256": "991a89b0f530a2e78022fd7781fd190f5eabec2e959fd46feaa3a6c104cfb7c4"
+    },
+    "progs.dat": {
+     "bytes": 747988,
+     "sha256": "603cb91c7f717a72cb2ff81d584aacc29e8498cbda8729a781d9964048aa4cab"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 1364,
+     "sha256": "eb7ed9439d34fcdc6c8a04a0bf57d344a75d208d65b8e3ab455ddda5965bf0b9"
+    },
+    "progs/csm_cpit.mdl": {
+     "bytes": 4424,
+     "sha256": "17c3aefc3c13035e45aec9befe0bf6722d163637aa56f18c3bec23c838dd5978"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 218412,
+     "sha256": "f83402d6602ce9f39a85033e010f9b66edde2633155c51d671acd7bb76c90faa"
+    },
+    "progs/expl.spr": {
+     "bytes": 127672,
+     "sha256": "553b80901ee3d765c147ecce187a53989ded3991532e02f53c5b0cbb42aad5d4"
+    },
+    "progs/frame.mdl": {
+     "bytes": 24293,
+     "sha256": "c033f1d4dabaa36e34b58884d4b45d3a74c587893debaa362c83b286ff7d2c62"
+    },
+    "progs/h_servo.mdl": {
+     "bytes": 159656,
+     "sha256": "f6e00f1d618c3586d96984737a6175688b1b8943f0e5c6a0be4cfb59ccbdca3c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/servobod.mdl": {
+     "bytes": 219324,
+     "sha256": "e791ca46d9ea19e870a530e808f6c9d7e472882a4f0fe8103277316de9f09bad"
+    },
+    "progs/servodie.mdl": {
+     "bytes": 444399,
+     "sha256": "4f1c146002f4efaa3cd064167be022286066344a6106ea7d11c7320267211676"
+    },
+    "progs/servoleg.mdl": {
+     "bytes": 178044,
+     "sha256": "27b588b8c7ca9e56fb3d71c62d3886d7aaa0f3e9d9e757f855d2d762dd192efc"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 320900,
+     "sha256": "29d578cf1a503aa933f50d03ceaa4143a7b6a8319cc422a9b59f5be39a51e8fa"
+    },
+    "sound/hjs/air.wav": {
+     "bytes": 35308,
+     "sha256": "7dc55cd06f4d9adf4e9a51d31c3d279eb86b0b082a738e246d463147fc330560"
+    },
+    "sound/hjs/airlock.wav": {
+     "bytes": 37368,
+     "sha256": "b6588065141e6e1eb7880f32566ecea5995f8117e9728fb55444ec7306fdabb1"
+    },
+    "sound/hjs/klaxon1.wav": {
+     "bytes": 97718,
+     "sha256": "1d8b5135adccf4a0eca755ec1849f643415d4260a055a7c05e3d812609ac11e8"
+    },
+    "sound/hjs/stardron.sfk": {
+     "bytes": 924,
+     "sha256": "3843d62bf8369886c02869895ea9baf101208fdc06d3f2870501271112af3254"
+    },
+    "sound/hjs/stardron.wav": {
+     "bytes": 110130,
+     "sha256": "9b5c371ae14595ff7ff6dfc5739d8d4001c5e22da47591d7b8f9af4163a7e5a2"
+    },
+    "sound/mech/mechstep.wav": {
+     "bytes": 11310,
+     "sha256": "253862ad17886c0c0467f2600f185e11fdb49156500919258c7bdf1f51f5bb98"
+    },
+    "sound/mech/metal.wav": {
+     "bytes": 5442,
+     "sha256": "12f478674e401a0e8b3fa696dc87239bd25c75d543eab4cdc7dcb846cd62731f"
+    },
+    "sound/mech/pow_dn.wav": {
+     "bytes": 42904,
+     "sha256": "bcbbdf2a6c196dd3d21cb552e00cd903bde38b94d79860804b5d00f88dc05c3b"
+    },
+    "sound/mech/pow_up.wav": {
+     "bytes": 32670,
+     "sha256": "e0b232135f7db271c3f6e5f6f49eae7d948cfa3afc20d372d5cccb4fa7481663"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    }
+   },
    "sha256": "ea367d5f8285ae6d135f5b99176a767c71130a275cedd24f0733675d191b2362",
    "timestamp": "2001-03-26T00:55:50.000Z"
   }

--- a/json/by-sha256/63/63b889e609f2ed6b8e2eeb58459aea078b61d0b56d66c4f66e117b243506b44c.json
+++ b/json/by-sha256/63/63b889e609f2ed6b8e2eeb58459aea078b61d0b56d66c4f66e117b243506b44c.json
@@ -443,6 +443,356 @@
   },
   "pak0.pak": {
    "bytes": 4227276,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "591744734a43a1563ee0e419fb2464783c70a3245c14e09ff5c3f022418f1e4c"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "1bbe11eff4ef46f43af7bbc7be43c69cf76543ce7fae26931939a541cb8cdae6"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "fc226280c4948249790f00f97dd9b39e912131fc904ec75adb90308ba8763afc"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "9eee444c1db402805bcff09378344c5a048b6c23ff6054edbfff16dd60b76f0d",
    "timestamp": "2022-09-05T06:12:18.000Z"
   },

--- a/json/by-sha256/64/6421a96be778c36418fabe065f49d11adbd8661f8d7b82e2bf5a7bed09f95137.json
+++ b/json/by-sha256/64/6421a96be778c36418fabe065f49d11adbd8661f8d7b82e2bf5a7bed09f95137.json
@@ -57,6 +57,44 @@
   },
   "pak0.pak": {
    "bytes": 14810811,
+   "files": {
+    "maps/chain3.bsp": {
+     "bytes": 1457548,
+     "sha256": "ba0bb65389df4adf27e3774440e2a0e763e024317784be6f5d05aaac2825bab1"
+    },
+    "maps/discoag2.bsp": {
+     "bytes": 1420316,
+     "sha256": "483e84de4d3feb53a0d34b7f4e8c1ccda2cafa22c9d113f918625fcec02d2485"
+    },
+    "maps/jesus.bsp": {
+     "bytes": 1565972,
+     "sha256": "144c5cd3bcfcf8063d54fb7a379ef9fedd9d00cd19a0f37b001fad87935cd892"
+    },
+    "maps/nesp10.bsp": {
+     "bytes": 3655284,
+     "sha256": "346ad412c87b9e6e14d76fdb0f255d228a2b03700182a8eab3b145751066123c"
+    },
+    "maps/pushcoag.bsp": {
+     "bytes": 3181120,
+     "sha256": "ea4707d9d16fcf39bc34f9d71e082545870d57a24c60010ab1aa2f4b741db092"
+    },
+    "maps/start.bsp": {
+     "bytes": 664136,
+     "sha256": "c0b5f4b2ef57aaea40bcf38b70aa4389573c6d36dd145618c06e4bd857d1bee2"
+    },
+    "maps/tyrcoag.bsp": {
+     "bytes": 2451440,
+     "sha256": "7b4250e681719780ce2129b782af03e76e56ccf1d5a0b73aae5ffa9ccf23b638"
+    },
+    "progs.dat": {
+     "bytes": 413988,
+     "sha256": "7aeca5154f79a0ab06ed590b4d19da12c4e412e52cb4713cfd8db6efcb260f74"
+    },
+    "quake.rc": {
+     "bytes": 419,
+     "sha256": "1d59909eee20eec3aa3aee3ad177d00a27df2e5ff30642606f2075a0d3d43aca"
+    }
+   },
    "sha256": "88ae94c48d538741c67f88bdad56f3a9a5a78b4ee2d9ca057d16e218bbcf89fd",
    "timestamp": "2003-08-09T23:17:38.000Z"
   }

--- a/json/by-sha256/65/657a821187708ab5252fdee681f330f6bcfe5fe540f21608976f8a8f87a1e678.json
+++ b/json/by-sha256/65/657a821187708ab5252fdee681f330f6bcfe5fe540f21608976f8a8f87a1e678.json
@@ -12,6 +12,1372 @@
   },
   "PAK0.PAK": {
    "bytes": 49049358,
+   "files": {
+    "demo1.dem": {
+     "bytes": 1519475,
+     "sha256": "c57a0502114183c5dcff794329d1e283741caa2efd0c6e0167591a4654152c08"
+    },
+    "demo2.dem": {
+     "bytes": 1846519,
+     "sha256": "046bbc98ee7c0c257235516f392317cc801c8ae9fcbb578b908b34eed2cd5cba"
+    },
+    "demo3.dem": {
+     "bytes": 1949747,
+     "sha256": "9e5f9be6f8a1689f8a6781e60f693e87e140fdd3d96addf66505dc3c12f27e4c"
+    },
+    "gfx.wad": {
+     "bytes": 112764,
+     "sha256": "ae5824733238e44b8caf61ee63c7d486e096bfb008f10287056d4fa2b036bc74"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "de3f5506c2f38372c714ffb9bf5a006fa44e1c2c81c9ba9f691e5abb5df076be"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "67e0a13ea28f7c469bc1c98b277da0ff776805da9aec2ecb9ba41fc5cb78673c"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "7935805d040fbca4012ecdf26d26d99b9b6f173026c34c91dfea8cc905d0d205"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "3c14f8794a65dc79eba6cc6b8d047c013b992b6bf015ee1e1dfbcddc6bb8d07b"
+    },
+    "gfx/config.cfg": {
+     "bytes": 5643,
+     "sha256": "6e82e581a2f4ac4c07eb50417352fa210d422a10cce0b2e466e9dd1e3d2da9a4"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "e54d66d4a81c6cb193a6f56ed6c1a2d23204aeb8f6dbbb55827784b70b1c0c0d"
+    },
+    "gfx/gfx.wad": {
+     "bytes": 112764,
+     "sha256": "ae5824733238e44b8caf61ee63c7d486e096bfb008f10287056d4fa2b036bc74"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "9e917e54d01092f2ef522a8e003482021d594f3e31a641ea76bd1f1194ab2cd1"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "307ffc0b534ac9d1c6c4829b0b0168b1fe2248f73a4b43cedad364295d0ab03f"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "2d732a067061504d25fdcb23b13ec60ebfd2486e2846bb2484723799320ccf74"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "3cd095c5c2a0a9e63ab6149abf3d5c2489f60f798012b6e5443d588c19748d54"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "5432fa7cfb67dc494f80a1b4fcb188c32b5afd80c97bca0d034ddba232e8fee1"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "da1e888cbfe6121942164516cee07b99b6e4c8cb73b285af0804a1c11f1cae22"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "ca99963778c12356d5613f3fbbf03199121bc4ab68be28b2fa7e292adf439643"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "95dbf77c0e0afed551a598948e7a46dcf50b74e901114deda6ca314fe2edde68"
+    },
+    "gfx/menudot.wad": {
+     "bytes": 2556,
+     "sha256": "9a2ce1c901da83854385ec3a85f904749745cffa47856a7a03075fe033256e3b"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "b3f38537ef829996bc79e84f0d0f76ff436899f6c663053731fb05d37e2dd328"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "ce3aa61f57a1f292c5afd827b850f3d3bfbf94a43122ecf4223410f89339387d"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "0610306e83449612e0cfc7c037b7cd41f326072f6c1869b4e57fa729db52e26d"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "65e68dcea7e88688aec00ba87760c4cd5dc33adb35d6343a88b41d978f880486"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "e36768808d5eaa26bc54b08327924dcdedccbed13eb7efd20bf3de3ba023e4eb"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "e3fde3f35ac41a506a6dd47745cfd5ba84c144bdf07497744aa425a46c3065c4"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "38aafc0e2ebc205cb3ebcfc8f410779d837a17c395e718c62594482d2bf9fa33"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "9e9c0e239d80f3c97dfabf0726054a6aac5439c2eff2d2f3305c4443dd3b179d"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "f935090abdfb36c010a169bdcd0568345e788e811b2cc88acbebb6b19a1bbc33"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "981c6ea1efcefe2693f5470e186a135d535c4920cb42d7083125905c4a13130a"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "b93ff9ebd8b81860cf22a03f34631bd9199e2317a645a20a1a606cd6b0604d22"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "be3d24667e87f9116ca3266d5c4248cab0221eeb1b27e46324418ebabe6e741c"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "34d9d8f051e693c1b37e4b704b542fab16fdd978c32be93b1d9cada767abcafa"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "d3ae6dfee8494fda49f9cdc4ad46eb48dfe52a79ca3de45875b82cb042913168"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "092a13940490d8dfbdbd2abeef8e67461052d3382d79cda0e0a6bab24cd77e20"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "2c55a0d199bf33a6c76e1fe8107d3f107e6be6b977d08bfbea6ba32f9c7a51d6"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "15ca98af3198a25d3b8b07a62ed2593d9297d7f9ef15c9be30088f603fcda177"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "e36a9346be88707db11c56400ababe1c7ec5b85347df1cd8cf787258f9c73eba"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "c57cf9e2140ec99ab758fdfec97d8bc74f4786afc1fb8be9f902be63da77f626"
+    },
+    "maps/atfdm1.bsp": {
+     "bytes": 1142004,
+     "sha256": "000e16b0700a424ed2055b0ab17706a3f842c0382a1933f245c66502b6dc7f35"
+    },
+    "maps/atfdm2.bsp": {
+     "bytes": 939368,
+     "sha256": "9c4f371547bea95c878f48001eb74b2af0be4a2164cb56348aa6b78040d349e9"
+    },
+    "maps/atfe1m1.bsp": {
+     "bytes": 3372072,
+     "sha256": "75e481153165962c6680ae57331a4b47ab5cf9d02062cc2677c51b0800b08ac6"
+    },
+    "maps/atfe1m2.bsp": {
+     "bytes": 2951692,
+     "sha256": "0045fc6c69fb5e55c74df9e3c2b3e1c9fe1c0c6533ce0633221b14ff7283a2b5"
+    },
+    "maps/atfe1m3.bsp": {
+     "bytes": 2423212,
+     "sha256": "38f2eb4197872c10f423f43e2bbf7bffa803d82f7f093da05bc3913b01c35b10"
+    },
+    "maps/atfe2m1.bsp": {
+     "bytes": 1924552,
+     "sha256": "c61deca6ac7860e5e60bc7b3e727b363c30b1d3ad02f2b09f1cb40bc99ebf393"
+    },
+    "maps/atfe2m2.bsp": {
+     "bytes": 1941792,
+     "sha256": "1c63aa59a3b736f9c15d56b38900102ac30c910fcd01e4dabfd9f2ff378f03d4"
+    },
+    "maps/atfe2m3.bsp": {
+     "bytes": 1417824,
+     "sha256": "ee78a43ef5c423cfbf2e6c94200c24003d8af4e944795dea4dde3ef3cee651b8"
+    },
+    "maps/atfe3m1.bsp": {
+     "bytes": 1266940,
+     "sha256": "b0c6d54ff1d5791a2557ba714b24f19cceea1ebb46766e79b4abcb35dcf163ce"
+    },
+    "maps/atfe4m1.bsp": {
+     "bytes": 2216552,
+     "sha256": "9dbc04c68f27f6f981873c5e0b9eab216a0e81be0be21d3930ae2928bd71a3f1"
+    },
+    "maps/atfe4m2.bsp": {
+     "bytes": 2626904,
+     "sha256": "f6d6ff441677f1ea121b8f1c8ee0f4422b6bdaf8675c866c48fc3e48864c2d41"
+    },
+    "maps/atfe4m3.bsp": {
+     "bytes": 2044096,
+     "sha256": "7a5230637a5fb0b7919d678966628fe14f46afbd39355c4dd3e9548601638fcf"
+    },
+    "maps/atfe4m4.bsp": {
+     "bytes": 1843100,
+     "sha256": "073b2e24089ed833eba71592ae38c170cd83c55595982ceb7f0a2a9a46a2bb4e"
+    },
+    "maps/atfe5m1.bsp": {
+     "bytes": 1288720,
+     "sha256": "e90bc15fed5140b47647b9c91d559c32d8e3024328096026b4f90c3bab6c41d6"
+    },
+    "maps/atfe5m2.bsp": {
+     "bytes": 1775496,
+     "sha256": "ba4ce646f9600a7b83212e506f32e6f211a4a38186da17a509c371d9b3b22ae8"
+    },
+    "maps/start.bsp": {
+     "bytes": 823788,
+     "sha256": "0c95e4a4995e670e43c4f048f998870c8a7a98c32e8dab67d3aa1fd1ca89b854"
+    },
+    "progs/ammobox.bsp": {
+     "bytes": 4772,
+     "sha256": "3d3246949e816504c7b36e98b732dc12d2c392ccbdecc49da08e8a869eefcf79"
+    },
+    "progs/ammobox.mdl": {
+     "bytes": 29080,
+     "sha256": "44ea23808e46bfcdeac6ff9b4a3cafa83ae2a0aa233df3dadf147991461588ca"
+    },
+    "progs/amr1.mdl": {
+     "bytes": 57852,
+     "sha256": "2e53926f10287a076994c3182abc30559ba96e63709fd5145ee0e474e9edb2c7"
+    },
+    "progs/amr1old.mdl": {
+     "bytes": 136947,
+     "sha256": "ba1058d1b60362279f8e506cbc2ad7d72396c02dead12d9aaf6b9b7fbef2fbe3"
+    },
+    "progs/armor1.mdl": {
+     "bytes": 20980,
+     "sha256": "86984b772b5a4a11f44bd45d665997833528c765175cc2a8d18b29931dd6ed34"
+    },
+    "progs/asymbol.mdl": {
+     "bytes": 56872,
+     "sha256": "97c176938138325dcc9bb34244308d537867aed5978517b1e3ace7d0a600f286"
+    },
+    "progs/ball.mdl": {
+     "bytes": 96168,
+     "sha256": "e9a3299d241556595957716c7da20ac2074aa88e459ff70f13d249489a3e96b1"
+    },
+    "progs/barrel.mdl": {
+     "bytes": 129776,
+     "sha256": "80d2ba22ea7873590b514749d51da5ca26312dabe53dcdbc2c839819bc3f3a19"
+    },
+    "progs/bike.mdl": {
+     "bytes": 202786,
+     "sha256": "208d7e85e89f7ea8439c56a2eb694bc91a4ff62828674cb7af724e1bd28a8196"
+    },
+    "progs/bike2.mdl": {
+     "bytes": 30372,
+     "sha256": "e172d5089645eee1fe9037d941e5aa91cbb278384cf5c82bea22dcbd242afa1f"
+    },
+    "progs/bikebich.mdl": {
+     "bytes": 86320,
+     "sha256": "5b0134135f617b45eee34d656d5b304ad4b400f9ef08d9a2e0f7edc3f9814464"
+    },
+    "progs/bikegib.mdl": {
+     "bytes": 30332,
+     "sha256": "38a27a6762e1f16d5d762f3c1c30fa707227fd0d08764dd06e36ff8835ff9534"
+    },
+    "progs/bikeguy.mdl": {
+     "bytes": 91404,
+     "sha256": "caac6e6e1f87d75f3abc306bbfa24e49377b0640bfd2c6826ec81bb20cd08e59"
+    },
+    "progs/bikemute.mdl": {
+     "bytes": 90312,
+     "sha256": "5b94392f93dffca08a4a7667f11c84277a69515270532b84b5c524e73252dce8"
+    },
+    "progs/bikeng.mdl": {
+     "bytes": 49223,
+     "sha256": "6520ff951f2cc4df391015983c9cf34d7aef1a29eb3d7626054ba07654d61f7f"
+    },
+    "progs/bitch.mdl": {
+     "bytes": 75204,
+     "sha256": "4aeb689493f527754055839a847c942fbd2c21fef6ded02f70c84467696296ae"
+    },
+    "progs/blob.mdl": {
+     "bytes": 58664,
+     "sha256": "754a7e4ca86427ee657a214d1c35f69c044206b0afb82618c59e407116ff9ae7"
+    },
+    "progs/bullet.mdl": {
+     "bytes": 2196,
+     "sha256": "a77be782a6415ea1b2155d72c68d617e19a6626a069aa263ec20f22887eabc52"
+    },
+    "progs/bwheel.mdl": {
+     "bytes": 50949,
+     "sha256": "868eafe75f9bd5c0f7a64b9cd5353b34094e43a2b052714117875b13433a2155"
+    },
+    "progs/camera.mdl": {
+     "bytes": 54320,
+     "sha256": "cff76457d0635078eb78284d930bc4fdd65f52861e1069d0178783be8f46575b"
+    },
+    "progs/car.mdl": {
+     "bytes": 171864,
+     "sha256": "2efdbb45d8bcdb2f4871a1325d1b9502d97cf7fb6c84e0e5fe3cbbe8308ee876"
+    },
+    "progs/card_g.mdl": {
+     "bytes": 55580,
+     "sha256": "195de788ca2ea210b6e493c8a6ff292c9eb638071d66f0bc60f85e99c4af4ad7"
+    },
+    "progs/card_r.mdl": {
+     "bytes": 55580,
+     "sha256": "e89ff621b1d674e56ac1ef70fd4449c0c6c6ac773ba9ba5ab5ccb8068800803c"
+    },
+    "progs/cellbig.bsp": {
+     "bytes": 14500,
+     "sha256": "5a38059a88ad3a64848d18190ac7f088d11ec6d3853c66c343ae9ed514a6cde8"
+    },
+    "progs/cellsmal.bsp": {
+     "bytes": 7484,
+     "sha256": "408d77dc0fc552c29fad61955883ffef1c690ad433008006862030c47ed2bb75"
+    },
+    "progs/chair.mdl": {
+     "bytes": 53184,
+     "sha256": "490de45792de55210d11e1fe31f2480e2a9d2136655e759f7a419580a39059b2"
+    },
+    "progs/chicken.mdl": {
+     "bytes": 64828,
+     "sha256": "39687a3199d730ae9bc9de7f3b581176c557bb861a695ed607bf9ea747956417"
+    },
+    "progs/civfem.bak": {
+     "bytes": 98948,
+     "sha256": "19ed34d63dae686524ead30ef9135d53adb1456c39e3a50a7bb34791c1b09034"
+    },
+    "progs/civfem.mdl": {
+     "bytes": 98948,
+     "sha256": "600f6db3883745ec03479d420c9e29ce6af7cdec401af42a05754a6b85c1d8e0"
+    },
+    "progs/civguy.mdl": {
+     "bytes": 120768,
+     "sha256": "88792b5fae8f580e769133be4372858428be51a74c63088dc4efc937dd0113d0"
+    },
+    "progs/clip.mdl": {
+     "bytes": 5620,
+     "sha256": "6a129e3239b62dcd602830ec6adc99154c4fc0068e8ac22cf7b8f490ccfde7d8"
+    },
+    "progs/cycgib1.mdl": {
+     "bytes": 7480,
+     "sha256": "e5af0f7e28c5635ee9e4cd935910a47b11bf633d60f150db4b012da21bf85525"
+    },
+    "progs/cycgib2.mdl": {
+     "bytes": 15137,
+     "sha256": "cd8c8d60bc2efc9b10f074c95a23be5e8c9ead579340409f6f16fb1f0c21eabb"
+    },
+    "progs/cyclops.mdl": {
+     "bytes": 177984,
+     "sha256": "e1887ee257fcb0ae69f6cd7da7d90207ac827eb379aef59bbb5e669a211838ca"
+    },
+    "progs/drdgib1.mdl": {
+     "bytes": 7880,
+     "sha256": "9d3623a9ca4717afff097a8ce9b1ff80092c1dc17cb1715a5df728f6f114c832"
+    },
+    "progs/drdgib2.mdl": {
+     "bytes": 32644,
+     "sha256": "e78cb6fb45340fad1c1fca9517590bfb50d61eb9d18022a18a2d66ecabc0d9fc"
+    },
+    "progs/droid.mdl": {
+     "bytes": 170064,
+     "sha256": "a05d3cadbd6c00c9d12d0f4a2b3879d04277f1a2e608229756f633325b44d665"
+    },
+    "progs/drop.mdl": {
+     "bytes": 13429,
+     "sha256": "a1009d3fb5a8fa566afb98c8c9a5a9b924c0f0d77014c19ab213e91668dfe98e"
+    },
+    "progs/fat.mdl": {
+     "bytes": 78452,
+     "sha256": "639e0a2406f3ce296e0a54509cb1132aa0f85a8d91472d04e1956fdf0b06bc09"
+    },
+    "progs/fireball.mdl": {
+     "bytes": 16013,
+     "sha256": "37bdec2e0190ba29700eb0be2392b06d36d15ccc82f2d33a58b8a6c045b8ff41"
+    },
+    "progs/flask.bsp": {
+     "bytes": 7116,
+     "sha256": "4633e97720443f78e19dae5d1887c9ce12d3f2b065fff50be9ea07d00859dda4"
+    },
+    "progs/flask.mdl": {
+     "bytes": 30964,
+     "sha256": "8fe376f7cb97156bbb8a65ae2996798946edaa5a15c4c4ebcf417b660b81eb8e"
+    },
+    "progs/g_ats.mdl": {
+     "bytes": 50188,
+     "sha256": "7be684667c2f6a24aae6549772ddd376ecd37e4c9cf6eeddda2a92a754df94e5"
+    },
+    "progs/g_bolo.mdl": {
+     "bytes": 49084,
+     "sha256": "4cb731019fed00307a640a9b5083577126ac7d9a7a6adcb499510374552a90f1"
+    },
+    "progs/g_chain.mdl": {
+     "bytes": 35480,
+     "sha256": "d56286fd91eafff84a372631e75ba6c8bac39c4b3db00fd9b31242a47e2ccab3"
+    },
+    "progs/g_gren.mdl": {
+     "bytes": 36292,
+     "sha256": "5d3541b6277d881a4ea09e529de6e4e447ddf0f8f7aadf698305f8051092abfb"
+    },
+    "progs/g_laser.mdl": {
+     "bytes": 124485,
+     "sha256": "ab21552b5d6f8cb715ab21fd12595136db5bf922170c2825e494f2d7b0fae974"
+    },
+    "progs/g_rpg.mdl": {
+     "bytes": 78420,
+     "sha256": "d8d2323b3c9da38fb6a7da35b0dd76a2aade4cf9390ba1ea26afc4c927568ca2"
+    },
+    "progs/g_sshot.mdl": {
+     "bytes": 34412,
+     "sha256": "7783fb7c5aa6f7655901b00ca1d1979a9c9142df05a2ecaf19b859ca8b09d655"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 40728,
+     "sha256": "156adb8af22f7a4af759cd13eeef5184b2cf872b398d46167136870835af758a"
+    },
+    "progs/globe.mdl": {
+     "bytes": 93591,
+     "sha256": "d1a7f7a9cc0aca9158d9dbd528131707c8dabb5dc06f80acf753bc61a5a8d5a5"
+    },
+    "progs/god.mdl": {
+     "bytes": 714416,
+     "sha256": "d8b1b05ad4b9e7118c15f43dfaa884cc3021c80d2b792b8b0cf08cd8113104cd"
+    },
+    "progs/gorp.mdl": {
+     "bytes": 157816,
+     "sha256": "a5e1702fdd1a4fa06f668b61bd3e40119a7c50ed189399dd48e5bd0aaaf6dd71"
+    },
+    "progs/gren.mdl": {
+     "bytes": 28028,
+     "sha256": "94473616ed00ef9e412c8735eae682cd2fe7c23c20b0ee0603e11036935d0d34"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 54967,
+     "sha256": "73465672a803703065216c09bfe5652b32f5c75f3c201e81f2232edc4ddd1fd3"
+    },
+    "progs/gropos.mdl": {
+     "bytes": 94068,
+     "sha256": "3e2740827246c057a2ecf380c10377abf3d7359474cfe498f46dbafc7a2ae759"
+    },
+    "progs/gun.bsp": {
+     "bytes": 24672,
+     "sha256": "1d49068bb298453a98655625cccbe9f4602fb98c68183025d093878fd1dbae6e"
+    },
+    "progs/gunner.mdl": {
+     "bytes": 211988,
+     "sha256": "247bc1ffc1b7ff43989afd4f4046e87133b6691a0b3366613c2e0e392f4b119c"
+    },
+    "progs/guy.mdl": {
+     "bytes": 97632,
+     "sha256": "05f3615f9879cd53bb071c21fa53ff68d03f20f84910c5e9c2c1fde4c400d710"
+    },
+    "progs/h_bitch.mdl": {
+     "bytes": 6948,
+     "sha256": "d04142c97a1f4e821bd57da658cd958f3ffe4381054ddf89f3537facafcf4bf0"
+    },
+    "progs/h_civfem.mdl": {
+     "bytes": 2196,
+     "sha256": "2386433d441ca1c590e79aabeee9511fa85c0831a1c30c7678701b7dc790c4c2"
+    },
+    "progs/h_civguy.mdl": {
+     "bytes": 2764,
+     "sha256": "bcb0f12cba459e6af032197bb052c566bbdbb558a5176ffd5ee3ab86c36ea754"
+    },
+    "progs/h_cyc.mdl": {
+     "bytes": 14708,
+     "sha256": "a2563df09987f6db1a8f19cbfe234214310ff3b471048fd340cad03f585fc060"
+    },
+    "progs/h_gropos.mdl": {
+     "bytes": 5444,
+     "sha256": "334f46bac567a1adc0a57566af8a1b0f73961179939974eb0e7e4f50e9aa8bf9"
+    },
+    "progs/h_guy.mdl": {
+     "bytes": 2764,
+     "sha256": "38014a49ec934016bda55f5ed150ead0a8c663be5e9f3ba2a4dbe28f88aafb2e"
+    },
+    "progs/h_mute.mdl": {
+     "bytes": 6180,
+     "sha256": "02bffca1b0ed86e2ca7a704266e64bb34bb296574649926ec6b770fd1f24cba3"
+    },
+    "progs/h_player.mdl": {
+     "bytes": 2980,
+     "sha256": "7df44316b8b74ba87b7018846e4ecd63fb83773a4e301bd4ee44ed0f56d27d04"
+    },
+    "progs/h_troop.mdl": {
+     "bytes": 5124,
+     "sha256": "baaadff5321fe1c2427264d334e7b3d5bc292692d610d359c9396218cf2c4aee"
+    },
+    "progs/health.bsp": {
+     "bytes": 7496,
+     "sha256": "262625efe7d75bab6403f2ce5613ff07bcf8d5749b0c5c915740dc9af757e3f5"
+    },
+    "progs/invul.mdl": {
+     "bytes": 52044,
+     "sha256": "bd3b2c1acc154ad3c222d32f4d2e321ac67844b26ed212107f7bc2b92c2f2e84"
+    },
+    "progs/lamp1.mdl": {
+     "bytes": 45024,
+     "sha256": "04eb9d1e9ea520a0346c8169ff30da63de673e5a84bce8fcdf1943dcb1cd2013"
+    },
+    "progs/lamp2.mdl": {
+     "bytes": 8692,
+     "sha256": "a9bdfb988fa7455701ec6e7fdc59075085cbbaafd99f6b23018f1ff0cf2b226d"
+    },
+    "progs/lamp3.mdl": {
+     "bytes": 8692,
+     "sha256": "fdb3a6baa89687e8e0e46f11ec6dae58143a03b1303de281d885ec4de7de5575"
+    },
+    "progs/lamp4.mdl": {
+     "bytes": 43648,
+     "sha256": "4da87dd26b36268feb8712b956c4a0df027acd295269cc6731b1f0ff36caed5b"
+    },
+    "progs/lamp5.mdl": {
+     "bytes": 7460,
+     "sha256": "6c4f1e026b124a62363f920b345b4808491e951878b1e7f1323f3393dac3a174"
+    },
+    "progs/laser.mdl": {
+     "bytes": 3872,
+     "sha256": "b952d9bfe0ed1b6e78c0c409cc5022a6b836a473019b6ef01b24ce797e0e7f84"
+    },
+    "progs/lord.mdl": {
+     "bytes": 150132,
+     "sha256": "636120c1f3ae7c7f48b6da38e21480a246c9c8f483d007c1283620688d204309"
+    },
+    "progs/medpack1.mdl": {
+     "bytes": 38817,
+     "sha256": "6343f0907f5bdef6eff232f1c0d3e6698d8d1cb4ec35d2d12072d652945f5568"
+    },
+    "progs/medpack2.mdl": {
+     "bytes": 37585,
+     "sha256": "3b6f6af85813e01cfd1dd76f3a5bfe2fd9e6749aa4c5a11c3991aedc4bdd41e5"
+    },
+    "progs/megaheal.bsp": {
+     "bytes": 6064,
+     "sha256": "0cf930e94efdd2059f0e96e38559598adcc154202f7d7eef516b78693a5f0eac"
+    },
+    "progs/mhead.mdl": {
+     "bytes": 6180,
+     "sha256": "46c5b5b18cf3c3d291baa26e2e80305f9870cbe00db07afec9f41913368a2ef9"
+    },
+    "progs/mheart.mdl": {
+     "bytes": 6627,
+     "sha256": "0e5979d5df587f04e744866b721acd96b70ab30542f6919b3ff295383394cad2"
+    },
+    "progs/minion.mdl": {
+     "bytes": 495040,
+     "sha256": "8cd975fc8b2ffc8927a1c41bd46fdccda109e1e138994846136703f6cb2aa0ce"
+    },
+    "progs/missile.mdl": {
+     "bytes": 53122,
+     "sha256": "2196842b2a3d9c665a512b0db5da67c739075243c4de3b381d97890737e1fb43"
+    },
+    "progs/mkidney.mdl": {
+     "bytes": 5908,
+     "sha256": "14795c909451042a06d153e61a8440b1c1337485fbd827c04cd9f4c266826053"
+    },
+    "progs/mute.mdl": {
+     "bytes": 118596,
+     "sha256": "5f23aa1a1444ef4bf44ac9fe3af74bba28e6fd6a6c44165002d8e6f350fa069f"
+    },
+    "progs/mutearm.mdl": {
+     "bytes": 44785,
+     "sha256": "836af601c8cc8d94d2bd0a627608e2b1266ab53ce77faad569cac559311109c4"
+    },
+    "progs/muteleg.mdl": {
+     "bytes": 23508,
+     "sha256": "9760ae06647cc472e18f351f8a18477b16e8f118fc7e3125ec5616ebc6fb5bd8"
+    },
+    "progs/mystic.mdl": {
+     "bytes": 91476,
+     "sha256": "54ebefbc80edd368441ef9cebc4c4d5f362c67ddafc348743b931a149db3de47"
+    },
+    "progs/newats.mdl": {
+     "bytes": 58404,
+     "sha256": "fd9b4d886f8891928cba32866d9efece3208296ee1b5218f436ab53cf332dd18"
+    },
+    "progs/null.mdl": {
+     "bytes": 49352,
+     "sha256": "7ea563d78d72e43dea6bdda4d7b0042d2d5a9e938abc040d0245eb39d40fe13b"
+    },
+    "progs/player.mdl": {
+     "bytes": 192748,
+     "sha256": "d0f3e669b7af79496198169ef9fe8d7acbe41e51e4ccd3ed84959a57b72c5eef"
+    },
+    "progs/playgib1.mdl": {
+     "bytes": 9308,
+     "sha256": "ac841d569ce67a50bd71e130c3f9906201a565f573ab6d6f8427912ffddc5b37"
+    },
+    "progs/playgib2.mdl": {
+     "bytes": 6589,
+     "sha256": "61dadb86ff8c4235725f82d707819f3bed678c2fb8eee16574f60cde104e05ed"
+    },
+    "progs/pline.mdl": {
+     "bytes": 29363,
+     "sha256": "3a55374bae2bbb271f47db049a58e909027d49f1e56f0d4172971a2c23e93bbc"
+    },
+    "progs/pulse.mdl": {
+     "bytes": 12888,
+     "sha256": "0bf59c98b55f46232cb0f2acf8ac73215cf4b88d4d007ad992bd63a110cbdf0b"
+    },
+    "progs/rock1.mdl": {
+     "bytes": 5940,
+     "sha256": "d9d6bde1e3d52d5713235d8e58d7aafb97cd6b67d0d7257a63d0cc8e048b92b4"
+    },
+    "progs/rock2.mdl": {
+     "bytes": 7604,
+     "sha256": "499910e2eceb72b886162f8164faaaa50a857dcd5e2f00d5f9d793383f9b999b"
+    },
+    "progs/rockbig.bsp": {
+     "bytes": 2988,
+     "sha256": "2b2c09d7bcfdb1228a097e5e44a67f0d47c5dc108593a7587d10602efdb790fb"
+    },
+    "progs/rockbig.mdl": {
+     "bytes": 29080,
+     "sha256": "037798b495f2a83a6a8d61ca944ec647800a0fda60bf0647194f383f4b969462"
+    },
+    "progs/rocksmal.bsp": {
+     "bytes": 2972,
+     "sha256": "9863baaf228462a8885ec8c8001445e5decf98a649bc92603527c073176140cc"
+    },
+    "progs/rocksmal.mdl": {
+     "bytes": 29080,
+     "sha256": "4eb822381479ad12761998938a81954479b6e33ccfb47228aed92ca5b00336d2"
+    },
+    "progs/rod.mdl": {
+     "bytes": 16832,
+     "sha256": "6777f257078b9791ffdf91b58a5508d7cae22c2ce551e999ef5e31b4560b7522"
+    },
+    "progs/serp.mdl": {
+     "bytes": 90185,
+     "sha256": "4244eb5115fe62a3e6326267c1d0e549e1530f8421696858bf1a1e6c460b860f"
+    },
+    "progs/shellbox.mdl": {
+     "bytes": 29080,
+     "sha256": "88a7fc42ca75e8c37f6d8f90bde95c0f7aeac260f9e87d3460ce1fb7cc5b7c70"
+    },
+    "progs/shells.mdl": {
+     "bytes": 33156,
+     "sha256": "1531e5fc61da07af2ee6e7856d476bd94f8868033f1feba0edd0e36c2ea43cd2"
+    },
+    "progs/suit.mdl": {
+     "bytes": 54040,
+     "sha256": "db0defaaf2133404690657f67f3197230297fff7059df1da01b0c27bba688783"
+    },
+    "progs/table.mdl": {
+     "bytes": 41764,
+     "sha256": "e65ac1fc3252422006f2f779dd6bc9894153d8321855f40a9f2694d8fdc105dd"
+    },
+    "progs/trooper.mdl": {
+     "bytes": 144304,
+     "sha256": "b43ab8afb0bcf9c2b6a9c14c5498d5b7666c6de7781aa9809cfa8ef484096b36"
+    },
+    "progs/truck.mdl": {
+     "bytes": 70358,
+     "sha256": "4a6e1efc0950c3ad8832c8cff1a2223c7f47492a53b3aa051a9a842a9a4a6dbe"
+    },
+    "progs/turetgun.mdl": {
+     "bytes": 19588,
+     "sha256": "8ac1ab5d810d804ba92987595fc0ab0b541ada4f7c3b9744549d418b6275c0b3"
+    },
+    "progs/turtbase.mdl": {
+     "bytes": 58060,
+     "sha256": "f51722a14a3d1b43111b757d2704011487528d06a8a0218719b17fd2b6996050"
+    },
+    "progs/v_ats.bak": {
+     "bytes": 214304,
+     "sha256": "64167d2445f5b4df6a2fa9329effcabeff0685d3b6ee01e13ea9a4da5ebb700d"
+    },
+    "progs/v_ats.mdl": {
+     "bytes": 223976,
+     "sha256": "b58dfb625aab8c1a33c447287051179c1bc6f8701a26e88fe6a2edb0d84c3e15"
+    },
+    "progs/v_bolo.mdl": {
+     "bytes": 155668,
+     "sha256": "f63e919e62d946e767e6c43432dd1552c7780da1e61b8c008d3348b09fd1e00d"
+    },
+    "progs/v_camera.mdl": {
+     "bytes": 38868,
+     "sha256": "781dcdc96bff17502d327e95db2af753dc0bf595191291014b17a0d4e49fd180"
+    },
+    "progs/v_chain.mdl": {
+     "bytes": 257292,
+     "sha256": "ca7027f1f4c4fec45c2fddc6e56c6f320e9c1ff899f146b2a523538c667af726"
+    },
+    "progs/v_gren.mdl": {
+     "bytes": 94504,
+     "sha256": "3e5243002aea873fac0862bbe2dae8c3a4d084256a55ed0680d3f62839a3e58f"
+    },
+    "progs/v_hand.mdl": {
+     "bytes": 97216,
+     "sha256": "d05d8bd1576eeceb0a76afa8d1d5e935b0a177be1074f7493e89cb70a54c2e62"
+    },
+    "progs/v_laser.mdl": {
+     "bytes": 116764,
+     "sha256": "e12e73bae752100567013f69d0b66ea90719011cadd214f3ed5b23bf73f770cb"
+    },
+    "progs/v_rpg.mdl": {
+     "bytes": 82640,
+     "sha256": "65cf1c743409c02cf0cc6c452c38b20985f87dae6010730a091c0a0328e45eb0"
+    },
+    "progs/v_sshot.mdl": {
+     "bytes": 362112,
+     "sha256": "90f19fe0417a12c46e8f4f3c2073d62c78c8d0b30d155b191c6d30f03cf07d8e"
+    },
+    "progs/wall1.mdl": {
+     "bytes": 237612,
+     "sha256": "f0cb7dab7fa322ae368c38a2a7fda2c1d68d9b92da081aae15667f9c01a6a11f"
+    },
+    "progs/wall2.mdl": {
+     "bytes": 222404,
+     "sha256": "40789dc7f8cf8e837c7cf12fe4070954d3715f1fcb7fc5defec9ebc170fa792d"
+    },
+    "progs/wall3.mdl": {
+     "bytes": 125384,
+     "sha256": "b0f6f77ac64a71b8fa349562f423b77458d6aabd5491fa18268833e972509f35"
+    },
+    "progs/wallgib1.mdl": {
+     "bytes": 27396,
+     "sha256": "0d93047364504f8e6dce494429de599d9516ee3d7bc24708a8c6df80b57ebff2"
+    },
+    "progs/wallgib2.mdl": {
+     "bytes": 27492,
+     "sha256": "1dd4a12c413f875793502dd829aaf9d26b061c9f26ffcb960e9e4bd635dd5d56"
+    },
+    "progs/wookie.mdl": {
+     "bytes": 65252,
+     "sha256": "0c4ca1176eb801ffad34b7700173fa3f7ac42d205acbc16fda1c5d017c2286d2"
+    },
+    "sound/ambience/comp1.wav": {
+     "bytes": 43546,
+     "sha256": "c78a9261a2cf45175e461ce8032c1dec3633bb75f208e8595ccab7bfe9f284a0"
+    },
+    "sound/ambience/dripping.wav": {
+     "bytes": 18740,
+     "sha256": "3a7ee877f86003c24e41fac632d304f71ffc675d082473f4ae05ad7f7c046c95"
+    },
+    "sound/ambience/el.wav": {
+     "bytes": 13714,
+     "sha256": "72b11084f0c9620b952a4c073a57c22b0339f7563b29b518eda041f644ffd1fa"
+    },
+    "sound/ambience/flicker.wav": {
+     "bytes": 4200,
+     "sha256": "27f3c7b5b5ad0197c1e4d50ae54dcf2608d61287a36d829a55b8e50c546e7f99"
+    },
+    "sound/ambience/hum1.wav": {
+     "bytes": 15782,
+     "sha256": "1ffacacd2b1ca2fb7f5638f40a036ac97763c94b9e7a05d6b80e391ef682ff91"
+    },
+    "sound/ambience/hum2.wav": {
+     "bytes": 43690,
+     "sha256": "68239f628ab01cc8b4a740d3484546a9512be28ed9027521658aa89a7a63c72a"
+    },
+    "sound/ambience/hum3.wav": {
+     "bytes": 63902,
+     "sha256": "b3e3edaf5a5ad155c3d879d817281f3d28b4bb63392a280c4c790ee394146bab"
+    },
+    "sound/ambience/intermis.wav": {
+     "bytes": 83260,
+     "sha256": "fd965611be23f7a5564107dbb9262ef7b0df0a75748f3436f965f863bd106a51"
+    },
+    "sound/ambience/rumble1.wav": {
+     "bytes": 33222,
+     "sha256": "d417334359ac8a77e750962790760a7512ee733972a345622f662f62fdd29003"
+    },
+    "sound/ambience/siren1.wav": {
+     "bytes": 9610,
+     "sha256": "8236581e5557caeb48bcd8259575333af3129a8979b9d05ebe24471f2ec6ab37"
+    },
+    "sound/ambience/siren2.wav": {
+     "bytes": 19324,
+     "sha256": "b0ed7adb29d6778105f2c8b6a43b7f3e5bbfbe0a5e4306f6337590d1bfe44e41"
+    },
+    "sound/ambience/siren3.wav": {
+     "bytes": 21334,
+     "sha256": "0b295b5ea9c36f01d30579d37456b9e2300d4b6a2168f2d95a6d30edffb876fd"
+    },
+    "sound/ambience/thump1.wav": {
+     "bytes": 14470,
+     "sha256": "9b885309f65b50c81ef877596696daa2bef0d3463c6c12abc31193278d293987"
+    },
+    "sound/ambience/truck1.wav": {
+     "bytes": 6338,
+     "sha256": "c4b5baf4528b99db48ea6c94e9c4da22a041d536140e9299ce1bf01ddf89a7a3"
+    },
+    "sound/ambience/water1.wav": {
+     "bytes": 49516,
+     "sha256": "88d9a7b5df2f6bb894b4154f394691e6547f6e328d396400267a053e979cb49c"
+    },
+    "sound/ambience/wind.wav": {
+     "bytes": 31916,
+     "sha256": "9f2104aca7da87279a23159f146d767d87b04f72a1d058fb07055b5d825be346"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 31916,
+     "sha256": "549439f59551d8b819602d95c20acca66e2f0194549436e2dd7f9f2c51ce385b"
+    },
+    "sound/bike/screech1.wav": {
+     "bytes": 10354,
+     "sha256": "7951b7021b6265b12c0f2db15f64ad05d00bf83b7ba35c20411e0aeb0af117bc"
+    },
+    "sound/bike/start1.wav": {
+     "bytes": 27808,
+     "sha256": "eced7a745ec046a0af4bb785e5215f1b071156f42e7ec2435cbf04dd528528ba"
+    },
+    "sound/bitch/bitchdie.wav": {
+     "bytes": 26156,
+     "sha256": "bbb4862daf8595365a3c1e312468f90671e3c913de9278a29b606ad97d3b17fa"
+    },
+    "sound/bitch/idle1.wav": {
+     "bytes": 6344,
+     "sha256": "0eec91c24b7498be0e1890d34fc1f87f955c433b13562d092ccd55d73ba192a8"
+    },
+    "sound/bitch/pain1.wav": {
+     "bytes": 17660,
+     "sha256": "4bdf272b1bd5ab3ba1e0090953396e9a68b772821d044514465d45aab8fca54a"
+    },
+    "sound/bitch/pain2.wav": {
+     "bytes": 12820,
+     "sha256": "17e1a4d7468cc4e37eee062f0e47e8dfafb14b139bc742bd9f235849d296ce31"
+    },
+    "sound/bitch/sight1.wav": {
+     "bytes": 154088,
+     "sha256": "9a7628fc71b593b0e3c26a54b934cef13b48e4d3086f5ac7e1c5b765cc94346b"
+    },
+    "sound/civilian/female1.wav": {
+     "bytes": 101868,
+     "sha256": "51e8e7433d8ab657efed430c73afe8c96397494c7df5c047dde30c6bb9376582"
+    },
+    "sound/civilian/female2.wav": {
+     "bytes": 21370,
+     "sha256": "5c8d3314c845cfc596126c30d775e0a694b995b37e51d80bc53931e2007ebbf1"
+    },
+    "sound/civilian/femalea1.wav": {
+     "bytes": 18026,
+     "sha256": "cf882967cd4b14dff8ebe4af254ab64414a13b905501fb21b45d851b2de50772"
+    },
+    "sound/civilian/femalea2.wav": {
+     "bytes": 66444,
+     "sha256": "f9872702c6364bb0edd7b4a4edeb1150b5dc1b81576a44f39f5369ec82c9c994"
+    },
+    "sound/civilian/femalep1.wav": {
+     "bytes": 24812,
+     "sha256": "6971aa92b91366512fcbae1d83756bcf9c1cc8cf0a6325cbac3a28920527006f"
+    },
+    "sound/civilian/femalep2.wav": {
+     "bytes": 7172,
+     "sha256": "9337fde2ad550826955466fa2e6a78e4071a7e2e28dca937e2fa11fdcff70af7"
+    },
+    "sound/civilian/male1.wav": {
+     "bytes": 61272,
+     "sha256": "d31e45b6cb849cbe75da16c456139015406bcd34d69a6a72300b7917aad6e2ba"
+    },
+    "sound/civilian/male2.wav": {
+     "bytes": 29836,
+     "sha256": "1478408f654c23eb84ea2f310f2c380e13b43b0978770e6579b772693d0f41ae"
+    },
+    "sound/civilian/malea1.wav": {
+     "bytes": 29004,
+     "sha256": "08e603b2353633307adf7a2d17d2cbb253bd1a432a3fcaf58b843fc7d9a4a3ab"
+    },
+    "sound/civilian/malea2.wav": {
+     "bytes": 22060,
+     "sha256": "f2f8ac544266db47a177da3a80de7d47d2a3abc994131194845bf29c2ac40eff"
+    },
+    "sound/civilian/malep1.wav": {
+     "bytes": 7562,
+     "sha256": "832e8f12054ee54734eab91acb2ed1e941e47b635ae74f492f7d711fe003c546"
+    },
+    "sound/civilian/malep2.wav": {
+     "bytes": 20752,
+     "sha256": "23bf818f6c4eb4609aba6def4b79bdce00cd98a7992677931af9cdaae6b03cd5"
+    },
+    "sound/cyclops/step1.wav": {
+     "bytes": 5446,
+     "sha256": "2d09537275538a05fe9c5b7adfda0576eb97554f3ba60a745fa724ea119dcede"
+    },
+    "sound/doors/airdclo1.wav": {
+     "bytes": 7658,
+     "sha256": "368b25b78fa3b132acf3616f6999b42def78b0e5aad7785dfe87131c7dc1c259"
+    },
+    "sound/doors/airdmov1.wav": {
+     "bytes": 15160,
+     "sha256": "d65dac1686cf71dfeed452c57d2bed9f4e5572a9bd1a297ac84524aa472d9280"
+    },
+    "sound/doors/rustclo1.wav": {
+     "bytes": 4018,
+     "sha256": "bbeb96e14f5c5c1999771cfa9c62614d3bb1e338d15c795565289a973a760678"
+    },
+    "sound/doors/rustmov1.wav": {
+     "bytes": 67494,
+     "sha256": "1aa8e283470bb80eb0c2cc4b798a521c0c578fb74b2214feb8ba6aee9cf72dc6"
+    },
+    "sound/doors/techclo1.wav": {
+     "bytes": 4002,
+     "sha256": "a9b958abe5f51f706787a6f2fec32cfb90b282712389bb81f1998cb0a542e230"
+    },
+    "sound/doors/techkey1.sfk": {
+     "bytes": 332,
+     "sha256": "da7b6ded94557f1e149c0812b1674766a65e5ae44d8b6fb81da42f6b41bec06c"
+    },
+    "sound/doors/techkey1.wav": {
+     "bytes": 12660,
+     "sha256": "275c94be2caead41c0b904cf720895062ef3c00002f6d6f6e3d7c2206715998d"
+    },
+    "sound/doors/techlok1.wav": {
+     "bytes": 18462,
+     "sha256": "b60f56023f21173c38d7469f16d082f68c3cb9b69bd3b3d423bfc8f6d193f093"
+    },
+    "sound/doors/techmov1.wav": {
+     "bytes": 34670,
+     "sha256": "f7ba66cff561879a236bae5d76f96980b879352691311e4db813537cab4a6968"
+    },
+    "sound/droid/death.wav": {
+     "bytes": 22956,
+     "sha256": "301a31f09649e6837aa1c8f49bc1766552920dc92ee006c25a47c162fa87462d"
+    },
+    "sound/droid/move.wav": {
+     "bytes": 23442,
+     "sha256": "7a7149aaeb866f6b1941bfb19c778d9049ce3d15fee6b53ca5052dcc15dca480"
+    },
+    "sound/droid/pain1.wav": {
+     "bytes": 7124,
+     "sha256": "931cfa97ead7a066c4638a7f2b20e62857e08805a9056a69521aa06a17a09309"
+    },
+    "sound/droid/sight1.wav": {
+     "bytes": 8362,
+     "sha256": "f1d5083a714b8ad7408d6b611bdab57a1e1e7785e4e906ee3c9da177ba8a8085"
+    },
+    "sound/gorp/attack1.wav": {
+     "bytes": 7912,
+     "sha256": "18d00f7973977aa91393fefd870cef52c09e1ca612c9da04ca86097bf0c92da5"
+    },
+    "sound/gorp/attack2.wav": {
+     "bytes": 9460,
+     "sha256": "c277262b2b5b4575a7a93d5f26c2ddf8e283fc99caa0493ad339b50b6a2187cb"
+    },
+    "sound/gorp/death1.wav": {
+     "bytes": 9893,
+     "sha256": "5df358e78521eb36bc54177a91b59fd8166fe30ee59aca586026e97b16706912"
+    },
+    "sound/gorp/idle1.wav": {
+     "bytes": 16259,
+     "sha256": "12850caf6d0e57cb3a3abc33eef8de4dc462f13a0e147298ece8a7dc623872cd"
+    },
+    "sound/gorp/pain1.wav": {
+     "bytes": 7202,
+     "sha256": "6b34e509f73a44581bef9342f17877805c97df219571cd359872e3b0c81ea9e8"
+    },
+    "sound/gorp/pain2.wav": {
+     "bytes": 8698,
+     "sha256": "74a2bca88600553ad3b2da530fe1dcdd763d845af2df37e4db3d19135c831314"
+    },
+    "sound/gorp/sight1.wav": {
+     "bytes": 21224,
+     "sha256": "0cf2ae85ef47a1f4600563a6f22c68f2fa362c0a8ee5b6ac747a1eeb6cbcbff4"
+    },
+    "sound/gropos/blast.wav": {
+     "bytes": 15840,
+     "sha256": "ea99835f31acb4afedffdc9496f9b4f9f6d93467be14e6521b5ef4fc251e8e28"
+    },
+    "sound/gropos/death.wav": {
+     "bytes": 46032,
+     "sha256": "1864600e8a2f4c87b05d54e3e4cee2cf434d67a1c52d0807f231bdf532fe04bd"
+    },
+    "sound/gropos/idle.wav": {
+     "bytes": 36848,
+     "sha256": "c755fd44b15e15f288f7b748a021fee9e6f7ec8f95c38f7445b1b2f16bf38ca5"
+    },
+    "sound/gropos/pain.wav": {
+     "bytes": 15726,
+     "sha256": "c6a0a0b62927953fcfca0142300c04777308a69d7ba7ceda3a3cf0317909b70c"
+    },
+    "sound/gropos/sight1.wav": {
+     "bytes": 12054,
+     "sha256": "ad099d7e3dc46a009b6124808760c7677886ff4c91ccb33e25e6e5a1b17cc6d5"
+    },
+    "sound/guy/die1.wav": {
+     "bytes": 16570,
+     "sha256": "a62ba7c7c9a05362189b6e1abd266c097d295d289cc95051c32e1cff5b4a1cac"
+    },
+    "sound/guy/idle1.wav": {
+     "bytes": 56270,
+     "sha256": "d35c8575915c13ec65d350d89d133ccc062077d196cdd547c722c2b7c5a22c8a"
+    },
+    "sound/guy/idle2.wav": {
+     "bytes": 31704,
+     "sha256": "fa27823d70cd3168141d8ce1cfd101695198731b75deb1907735f362b9e12fa7"
+    },
+    "sound/guy/pain1.wav": {
+     "bytes": 16570,
+     "sha256": "3cac73ecec9d7a460aaf3a4b2cc6049059a4fdc76f93660dcc15c0544850a7ac"
+    },
+    "sound/guy/pain2.wav": {
+     "bytes": 16614,
+     "sha256": "77b932f67036db9565d0846de3de2dd8e7e7f53856d988f9536a245d7426ab0d"
+    },
+    "sound/guy/sight1.wav": {
+     "bytes": 17946,
+     "sha256": "6445011ae0e0351998853f04911df8b6d32f932a286e70cb3aab23efe9cdb393"
+    },
+    "sound/guy/thump1.wav": {
+     "bytes": 22762,
+     "sha256": "f94ab4e3a87f2f5f07f65df02ecc55369a88e743a69d3eac4988485f3b311ac6"
+    },
+    "sound/items/itback.wav": {
+     "bytes": 63290,
+     "sha256": "8c02d23b3c790b440c3607cb2a6381fc05a4d253bf95a965170c5c684c5db1b3"
+    },
+    "sound/misc/drip1.wav": {
+     "bytes": 11820,
+     "sha256": "1c60d53cc1321b29e311ce2593a1f1cc3e803e93f3847120db034e26cd69b823"
+    },
+    "sound/misc/drip2.wav": {
+     "bytes": 8300,
+     "sha256": "121d16eb03bc6e37ceac37d1d7ce8283225beaf2fc3474cf651168c4fefc34bf"
+    },
+    "sound/misc/dwoosh.wav": {
+     "bytes": 9320,
+     "sha256": "7d6b327263c81c3bf04c69b95ffaa8a06c08cea69fff51628df67f81750e52f8"
+    },
+    "sound/misc/intermis.wav": {
+     "bytes": 166908,
+     "sha256": "b713498c4c2b15c7b910a314bf14220c7b007a39b1b32f723705ee55fedad45b"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 6518,
+     "sha256": "57b792d4da9c18c95a127e33ce0674a3e2da81cc916578c59807040485009294"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 13288,
+     "sha256": "2f91625745903adcdcf2d1175827c8cb6e43acb70706cd8bc4e9de7a65aad1fa"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 5298,
+     "sha256": "298acf2571dee562de2b3068cb64bef95462fc55dde74a29aca5797d8b56d784"
+    },
+    "sound/misc/r_tele1.wav": {
+     "bytes": 28142,
+     "sha256": "ab9190af74b248333618f670b5e390282d3e885b3b460fbd3f891c5aca7fc00a"
+    },
+    "sound/misc/rockhit1.wav": {
+     "bytes": 7022,
+     "sha256": "345f6a899f73f9391c53d469ff8d1d0203c73e775ded7ffdce4d84bf8a30d93e"
+    },
+    "sound/misc/talk.wav": {
+     "bytes": 4100,
+     "sha256": "8b7de0e1bac03ff3dfac41d37bd4ac456814471166568a13417569486d545fd9"
+    },
+    "sound/mute/idle1.wav": {
+     "bytes": 39684,
+     "sha256": "bd2354267d73dff7266c3b648a33c325eeadd0e6223d9deccc0461df16bbbcb3"
+    },
+    "sound/mute/idle2.wav": {
+     "bytes": 66126,
+     "sha256": "451f010b2b66f15de9236bb3cb34eeb9e735d450273eb0e62ed1241ad90c84f7"
+    },
+    "sound/mute/mutedie.wav": {
+     "bytes": 55138,
+     "sha256": "fd14b2fbf28aa0d20854d7784126a72f4398fffaac6f207e13cd721d48c5b70f"
+    },
+    "sound/mute/mutespot.wav": {
+     "bytes": 60604,
+     "sha256": "6ea806e9cea9925ecc1438be195b8104424af580b18c3ceef88e4e8491f7ea59"
+    },
+    "sound/mute/pain1.wav": {
+     "bytes": 47630,
+     "sha256": "f6795527f6ece561616277a13e8db717e406299436d87d3102828d44beb1fcfd"
+    },
+    "sound/mute/pain2.wav": {
+     "bytes": 32128,
+     "sha256": "8aa6ad827cbdbd654b10b2f9e61719f9f239fd9ce9c4fda9965750b9e0769475"
+    },
+    "sound/mute/thump1.wav": {
+     "bytes": 16652,
+     "sha256": "46149fc1ab6543879bba58ab9d08dd5c9a9ac82bacef8b0e260ad815bbad9a70"
+    },
+    "sound/mystic/blast.wav": {
+     "bytes": 34228,
+     "sha256": "13b78b595d59b172ed2aeae1c4280ff1f1347aef0f40a1f7a3904f392e6509e8"
+    },
+    "sound/mystic/death.wav": {
+     "bytes": 73748,
+     "sha256": "e6d3c02e3f3738c46b5a6e5217db6a4dbba589ac4dfa82b0e33c75d26e03307a"
+    },
+    "sound/mystic/heal.wav": {
+     "bytes": 8282,
+     "sha256": "623ae34042c4235b1aedee15389b7b9e413cbd74a36af4e93c508e40b8369d40"
+    },
+    "sound/mystic/idle.wav": {
+     "bytes": 54798,
+     "sha256": "eeceddf5017e2e77160007acba478823b325ecc311b06caf827cde4ac4b5a1fb"
+    },
+    "sound/mystic/pain.wav": {
+     "bytes": 78692,
+     "sha256": "37556a2daae81494d19332d7fb09bc9ecf7dd4251fc0b1939cf69dac3e589912"
+    },
+    "sound/mystic/sight1.wav": {
+     "bytes": 37266,
+     "sha256": "5abeb6e834ccfcdf61aa51ccd27706a18ab4d22026b012f72ac87a2c8e34b82d"
+    },
+    "sound/player/drown1.wav": {
+     "bytes": 13356,
+     "sha256": "254b09e6b0eca0615ff3e2dfefcc2556489460a0a0358f4047e5721336c25510"
+    },
+    "sound/player/drown2.wav": {
+     "bytes": 9868,
+     "sha256": "2e954fd915cbd53ea668ecef86929c773af036448ca089e0106eefeceddcb0a8"
+    },
+    "sound/player/gasp1.wav": {
+     "bytes": 51030,
+     "sha256": "887e9f19cfff1ff1cc39957cb30d8babf0ef61eab6ee2cdf998d280a50a874c5"
+    },
+    "sound/player/gasp2.wav": {
+     "bytes": 32556,
+     "sha256": "66cc82091b3d908ccf511ac49131c2ae1172dc318ad85c5f26b94a2a374b243b"
+    },
+    "sound/player/h2odeath.wav": {
+     "bytes": 33836,
+     "sha256": "7ba4cdfec41e4ca3e64489fddb03cef31e29909b3b5c3ea278f1885effca8a63"
+    },
+    "sound/player/h2ojump.wav": {
+     "bytes": 16394,
+     "sha256": "3d96768e2a48339a8c205ce6212c956f4dc9ab5c8a1292d4935511c988e8d994"
+    },
+    "sound/player/hartbeat.wav": {
+     "bytes": 8178,
+     "sha256": "aaaaba089d5238fb9ab28a73f253306d1d07e185bbe673a306beadceb2146b94"
+    },
+    "sound/player/inh2o.wav": {
+     "bytes": 10766,
+     "sha256": "835c835c52159787d5bc97b15cb2c037d5a8928317128f64dd9639f03d071d2e"
+    },
+    "sound/player/inlava.wav": {
+     "bytes": 12716,
+     "sha256": "f7933b4bed0a32cf10c51d1d4f9019035d5ac5d9b72c69e91c08c95705984628"
+    },
+    "sound/player/land.wav": {
+     "bytes": 10386,
+     "sha256": "7d87d870ea00855268dd07b2f6c8710bbe2dd9e7628ffdd8e92d1e76d4137323"
+    },
+    "sound/player/land2.wav": {
+     "bytes": 9458,
+     "sha256": "d10f47d8a4ceaab73b6ab6ca7922a497050c249ab159323f154fade32cc22fb0"
+    },
+    "sound/player/pain1.wav": {
+     "bytes": 8722,
+     "sha256": "d4b0a9a55a36abd8edab934d66ede67bdea44a69904caeda644d4c4f71976092"
+    },
+    "sound/player/pain2.wav": {
+     "bytes": 8338,
+     "sha256": "78507c8f8bee8abf71edc039799d73d9a7c998497388273c8eddcc107c315c22"
+    },
+    "sound/player/pain3.wav": {
+     "bytes": 16178,
+     "sha256": "86ff275d266860b70e246d34e5740f8b5396de3c8129a8532eef1899348e718d"
+    },
+    "sound/player/pain4.wav": {
+     "bytes": 8242,
+     "sha256": "c0430147e979942b7e6cd262fe6cd0accb7a7ff9577504cc389e78d1a93501d1"
+    },
+    "sound/player/pain5.wav": {
+     "bytes": 8514,
+     "sha256": "69265b769b501145381268cb3a46ecb4af2a7009eabf710716bacdec9bde4a2f"
+    },
+    "sound/player/punch1.wav": {
+     "bytes": 3756,
+     "sha256": "86a197b0cc4984700c126803efb6f97e490761fad5fd211cea4017c2a287ad41"
+    },
+    "sound/player/r_exp3.wav": {
+     "bytes": 39026,
+     "sha256": "896727dadcdb08968690fc6016b2fe7a9c4125f03e65c2e3018920aa11148937"
+    },
+    "sound/player/scratch.wav": {
+     "bytes": 6262,
+     "sha256": "87cc853968ace968013a329eeddb99959e3325c569c84ecba1dbc20cb5c12937"
+    },
+    "sound/player/step1.wav": {
+     "bytes": 7822,
+     "sha256": "9aff3a8ac9fa791c82cc0ae34e510c1787b62e9a80df4dc236747041d4985b87"
+    },
+    "sound/player/step2.wav": {
+     "bytes": 7788,
+     "sha256": "4c332f4a28f94b6ba99e095a5098c672a99a77c58eed52ff3e6fbf50fe2b22f7"
+    },
+    "sound/weapons/bolocock.wav": {
+     "bytes": 17002,
+     "sha256": "97bb5d7efcdb58135ad0552629789216e6495593a97d30203d83d584635b4c3f"
+    },
+    "sound/weapons/bolohit.wav": {
+     "bytes": 15522,
+     "sha256": "2442e684ffc1fae02fc2b430ce5e39a152b524fd2cb5335ec6e9f2feb51cc6e4"
+    },
+    "sound/weapons/bounce.wav": {
+     "bytes": 4666,
+     "sha256": "0621df925f9d5f4b6273b7d75dacaa4b9fb73850e221e45137d2e05e4b86ef12"
+    },
+    "sound/weapons/bshotg~1.wav": {
+     "bytes": 52544,
+     "sha256": "45e89272710848469b648ab955f2127dd394e50db4eeb22b012589fbffb1ca92"
+    },
+    "sound/weapons/chain1.ba2": {
+     "bytes": 27690,
+     "sha256": "7fa56e7060fb2a65ff8ec5e4c3b00d5ffcf5e44e7305090ef16e7c2042fa012a"
+    },
+    "sound/weapons/chain1.bak": {
+     "bytes": 6678,
+     "sha256": "87b4a9d7c2df382169500e0ff7152a665d6b32afe909ed3c66b7abb77126ffb6"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 8498,
+     "sha256": "2e4703d68cedcd2699a31fab89851ef44710ab80207218201f801a8d7392f4e9"
+    },
+    "sound/weapons/chain2.wav": {
+     "bytes": 8306,
+     "sha256": "f40c079dcd4b57374f781f8dadc4b13a04bd576e38a65c127cc95368ce6c4fbe"
+    },
+    "sound/weapons/chain3.wav": {
+     "bytes": 34162,
+     "sha256": "6ac28289a43fa87075959e123c6c46c8480df39882e225032df47369cd37d0e1"
+    },
+    "sound/weapons/charge1.wav": {
+     "bytes": 5630,
+     "sha256": "046f10c30a89c0a19d5771f5b89ef9a8c7c9bd454e6016e53f4c30da9c4ea2ec"
+    },
+    "sound/weapons/charge2.sfk": {
+     "bytes": 108,
+     "sha256": "b1d592d11d16ca617f09ede912cfdf70686e27d1a95f376c17cc7140f5f2158d"
+    },
+    "sound/weapons/charge2.wav": {
+     "bytes": 5630,
+     "sha256": "cae1658064ac0af80b7dc549ad9f40fccf9293881eac6005141c257a3300f8b1"
+    },
+    "sound/weapons/charge3.sfk": {
+     "bytes": 108,
+     "sha256": "1aee6cec34f0089a26173bd02cb12e1bf24dc1c8b85f07388641f6771be5d933"
+    },
+    "sound/weapons/charge3.wav": {
+     "bytes": 5630,
+     "sha256": "b8b4228883f1cc048d7fcdf67bba2eb039030c21fdbd225619310d471bf1f5cd"
+    },
+    "sound/weapons/charge4.sfk": {
+     "bytes": 108,
+     "sha256": "45b4cd84150325a75d972493c29b2e08065b1be1e5bd2b3088c3b2c5c83c8309"
+    },
+    "sound/weapons/charge4.wav": {
+     "bytes": 5630,
+     "sha256": "7589020e2dd4ab6bd27d1f5a908a8c233c94bf43ab485bf2dab31d7f3e347056"
+    },
+    "sound/weapons/charge5.sfk": {
+     "bytes": 108,
+     "sha256": "62d7b8a7e44bb0e68a8d8aa166ccfc0dba9a0e1f35af5dc09b5b42c2a9a8b1dd"
+    },
+    "sound/weapons/charge5.wav": {
+     "bytes": 5630,
+     "sha256": "2ccc220978ad85785238ae636ae5ff63ae16cf7f8c371067b656b0051323af6d"
+    },
+    "sound/weapons/charge6.sfk": {
+     "bytes": 108,
+     "sha256": "ad1d2940f37dacb0c701780f8a858c48f117191729ea08695e4391dda7e94afa"
+    },
+    "sound/weapons/charge6.wav": {
+     "bytes": 5630,
+     "sha256": "b2ae21f974115d9f43cf8f135cc04984d9d93e4c5ad53b1856d793a56d5f01a3"
+    },
+    "sound/weapons/concuss.wav": {
+     "bytes": 11174,
+     "sha256": "041194238bfa0a707ff8e859486011e4fa8a761e2830d5fd4f0f40b8e144542c"
+    },
+    "sound/weapons/flung.wav": {
+     "bytes": 13206,
+     "sha256": "92e3e645e936078ddcd62a2d80db509c47b86dd004c5ee30c4a2bcb62b73efa3"
+    },
+    "sound/weapons/grenade.wav": {
+     "bytes": 9262,
+     "sha256": "1a0404d5f2f3337bc6a601bd7e5f057a595ffacb35e6810b77ec1d53764ca548"
+    },
+    "sound/weapons/l_hit1.wav": {
+     "bytes": 8940,
+     "sha256": "7b818fba135a1c5535c21584134125bf44a071715711abf277b2fc9a067637ef"
+    },
+    "sound/weapons/laser1.wav": {
+     "bytes": 3664,
+     "sha256": "3da698790871be5a1e7829a51a29ce345f69b7f98f30a8d9ee14ef40243cd8af"
+    },
+    "sound/weapons/lshotg~1.wav": {
+     "bytes": 9808,
+     "sha256": "5ff2d09c3f6d0bc91e9b7d6fcebd8b33b80a495c736d136ce3f202409be952ab"
+    },
+    "sound/weapons/needler.sfk": {
+     "bytes": 140,
+     "sha256": "aca9de5c8f3a010fa3be6c2974adcb31ff237f849203f4fb13af4a3589653a9b"
+    },
+    "sound/weapons/needler.wav": {
+     "bytes": 9578,
+     "sha256": "0bd55cb487b52652d54db97966c03490685763b9bb65587428ce4d8af9c15c9e"
+    },
+    "sound/weapons/needopen.wav": {
+     "bytes": 8300,
+     "sha256": "02e5bbfe53fd25943f1a4d682c41029c1b1d17aff656aab8c7cf2d005c254490"
+    },
+    "sound/weapons/pickup.wav": {
+     "bytes": 6024,
+     "sha256": "e357b969d178e924f301fbb66231e29a4315c7f22cb71cda5e72b67a99cfc1e9"
+    },
+    "sound/weapons/pulser2.wav": {
+     "bytes": 7212,
+     "sha256": "ce9fd448e72d79bbe195fe91f83ca4d940d220aefdec19cd376cc430a4da5220"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 63346,
+     "sha256": "c2b3974a7b6ab58fd96740d89e40846be565b54c9430122b54277db1b2f8e255"
+    },
+    "sound/weapons/ric1.wav": {
+     "bytes": 6262,
+     "sha256": "fbcb2d2cf71da95f10681ef4335d2c51448ed6d565d11c1313d2523681525689"
+    },
+    "sound/weapons/ric2.wav": {
+     "bytes": 3702,
+     "sha256": "89009863a9ca85d98ee5943464f008fa06e44aea2f19572cfc30594c8dd3cf26"
+    },
+    "sound/weapons/rpg1.wav": {
+     "bytes": 20374,
+     "sha256": "8eb181dafe5046c219985d0e9d47706d90f67c4225e61627161f8d857f447011"
+    },
+    "sound/weapons/rpghit1.wav": {
+     "bytes": 13814,
+     "sha256": "3e9bdfee8121cee36a2888af4ffc1d8e8490dd4e2e0f9d868b60f5df6a604694"
+    },
+    "sound/weapons/shot.wav": {
+     "bytes": 31680,
+     "sha256": "dbac6d3d8e8e3f5e688105759bba19353a299c1c0d6d7b3458b77a91a384f769"
+    },
+    "sound/weapons/shot2.wav": {
+     "bytes": 10124,
+     "sha256": "c14e2a32e881468535c117e5158ec3a371a2408f2f8fe5e8e84594890c4201d2"
+    },
+    "sound/weapons/shot3.wav": {
+     "bytes": 2330,
+     "sha256": "09744b4c93077e7adf5d25f4c1d40db6e64b1a0270c0ded4fdaf0202e14de709"
+    },
+    "sound/weapons/shotgun1.wav": {
+     "bytes": 60560,
+     "sha256": "139d914a17baba3b0ad73058a28cae9769eeefe968ab213a35988b521d114300"
+    },
+    "sound/weapons/shots1.wav": {
+     "bytes": 8440,
+     "sha256": "0258cd5d1bfdfc369a68a802be4a8d24337a3f4e4d8df1ff715c4103628a7ebd"
+    },
+    "sound/weapons/someth~1.wav": {
+     "bytes": 61684,
+     "sha256": "a1de63ada7f09aea44a0762240907f312c33d601bc416d3d230f6712b0a4976d"
+    },
+    "sound/weapons/test.wav": {
+     "bytes": 55522,
+     "sha256": "ffac6d654597bcdfb16b7fec73ec40538c399cf0b556ca6384af19b573f6b820"
+    },
+    "sound/weapons/turtshot.wav": {
+     "bytes": 7294,
+     "sha256": "ae49abe0edbf8b2615b280df78bbd1987c225a12fe8a361e8107b4ff7210d49e"
+    }
+   },
    "sha256": "ae12563e4d636ca16ceb5bc7c1b0790024fc0b6bdaebf22b7783291a29b47df0",
    "timestamp": "1997-12-10T10:04:14.000Z"
   },

--- a/json/by-sha256/66/66edf428edd505a6b13e38dd40e8da3c333c154869c7de587311da8209b9bffd.json
+++ b/json/by-sha256/66/66edf428edd505a6b13e38dd40e8da3c333c154869c7de587311da8209b9bffd.json
@@ -17,6 +17,212 @@
   },
   "pak0.pak": {
    "bytes": 10994565,
+   "files": {
+    "maps/ne_sp06.bsp": {
+     "bytes": 5186888,
+     "sha256": "d9af3127a315869e60707455594d34fe4bc5460fc4750eb7e2caf782567d49c2"
+    },
+    "progs.dat": {
+     "bytes": 507628,
+     "sha256": "8ab68053b2a6e70d4b0e8c1786b1fe06a3616df8920dfbb3c9fad0a811f1ec75"
+    },
+    "progs/b_key.mdl": {
+     "bytes": 12820,
+     "sha256": "937fcd77d89f3184e656a26feac68e8e512e94442ef58bbfdabe2b03c093ec1e"
+    },
+    "progs/ballexpl.spr": {
+     "bytes": 4152,
+     "sha256": "c5b4e3d57663340b7ecebbab694efbcfeac4714f1d443ee5da145ec4730bd641"
+    },
+    "progs/demon.mdl": {
+     "bytes": 156640,
+     "sha256": "28d61c4827ccd1a2e1ad1e9bbe275be1263caec3c9fab7df9ad3aa88482493ca"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 207552,
+     "sha256": "1ba01029d4113cc832aa5ab551c7bf060b5f7a4eb1afde35607564413bfee2ec"
+    },
+    "progs/explode.spr": {
+     "bytes": 278904,
+     "sha256": "f9362544773e228355cc48adc9cd638b95fd6eb83c60e3cf715c63821b26a2a3"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 67688,
+     "sha256": "9dd923e25645f427190bfbc68b85c59f867598ad8ba75aea87acbc78d10e9686"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 108204,
+     "sha256": "53f1e920c7c866d349167a8bff62eb0b614c5628de89d51774b3b8e88d17a0d9"
+    },
+    "progs/hkball.mdl": {
+     "bytes": 45876,
+     "sha256": "9ccbfd59b35936fb771a7ccc1ae12cf54fead8e36f315382a7cffc56a7fde3d7"
+    },
+    "progs/hkball.spr": {
+     "bytes": 105148,
+     "sha256": "ce4938c9e813e648404b25b82245cad4400682d885d044b9d353a8039cfdceb7"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 275836,
+     "sha256": "9c7bd69563863bde3fc29eb3d139ee3e4c15ca023ef50c938ca6835ed986885b"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 12820,
+     "sha256": "7ece7b32827a8193a22f357cd49e44d044319f1f300bda43b1a3067a5203bfb4"
+    },
+    "progs/s_fire.mdl": {
+     "bytes": 27596,
+     "sha256": "a75b33454397b9cdcdd55ab1ae4a6bce0552abaa75c639426ec79966555b76fe"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/shamball.mdl": {
+     "bytes": 8788,
+     "sha256": "80b41d7a040956668c8436fa3ad7e43e5b3c0cede923975b5bcee1b4dd629787"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 169404,
+     "sha256": "5492386814e9142d4d385d4e985f1b207dc7cdf5de4ef7e3526a69ca2131c83a"
+    },
+    "progs/t_drag.mdl": {
+     "bytes": 12736,
+     "sha256": "108d7c3eb1b2f4893d6d4147d1c66c8d93d6094c2f629fee90442155844ec407"
+    },
+    "progs/w_drag.mdl": {
+     "bytes": 36636,
+     "sha256": "82facf32c6a8c3fbda1d4e4e6fcf01112f9a1e65eef7be7d46ea66b497a8aaae"
+    },
+    "sound/amb/wat_amb.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/amb/wat_drip.wav": {
+     "bytes": 172196,
+     "sha256": "67981b8c9bf711f49ab7ec276872613bd5e1f8e68301d0d7998c190e0d49cde6"
+    },
+    "sound/amb/wat_fall.wav": {
+     "bytes": 118946,
+     "sha256": "f294768ec6843365659f3dee5a33a1c9f2c19b35d1d6d12db3a8701da5aeb2cb"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 308910,
+     "sha256": "aa1c42b3a8ca30b9e9a459e96db5200137eba5df44dada9362425fa7c1d1fc16"
+    },
+    "sound/demon/ddeath.wav": {
+     "bytes": 9140,
+     "sha256": "12f5dc4a16ad825e2363a176c303ee934f1467d19ea9db0361ff4288d7b9a3fe"
+    },
+    "sound/demon/ddeath2.wav": {
+     "bytes": 12296,
+     "sha256": "7297dc22813ce3211dc685e41e6bf6cd8d2a8aa441183f71115e030cd62fe553"
+    },
+    "sound/demon/sight1.wav": {
+     "bytes": 11052,
+     "sha256": "afc4e2ce38d97fcc5014739156f367d5b4f13fcbb60e8c4ede5c7e7922a6cdfb"
+    },
+    "sound/demon/sight2.wav": {
+     "bytes": 8804,
+     "sha256": "5059fa6539cfd92e6064b1c57385f4606c1d2ff769df42ade62ed3be4b39a0b7"
+    },
+    "sound/hknight/attack2.wav": {
+     "bytes": 43612,
+     "sha256": "a0a7f18bb08548b093efca29f9816da5d84056615783083637c50b7cad46a625"
+    },
+    "sound/hknight/ballexpl.wav": {
+     "bytes": 33316,
+     "sha256": "be9d88aa8905d9501625da7d2b9c02f9e1fa462dd07bce987b7e761cdc3f904a"
+    },
+    "sound/hknight/omega.wav": {
+     "bytes": 8960,
+     "sha256": "d9de409b60d06566bbb5ecc548a5afe029c2e723176d3666b7ae735fcd856b34"
+    },
+    "sound/hknight/sight2.wav": {
+     "bytes": 12712,
+     "sha256": "07ba881ba9f65ae2ad1c918e50581c2709527fc0d121b46cfa3a25eec30947a0"
+    },
+    "sound/misc/cof_end.wav": {
+     "bytes": 2092204,
+     "sha256": "1700e10264c47096a108df948d0811b9aad2d45fa9ecdbccd4dc4279c350099f"
+    },
+    "sound/misc/glass1.wav": {
+     "bytes": 41338,
+     "sha256": "cb41257d497ecd2e22ed572f0017a66bafa2804180dcdf0394c559d31d1d5043"
+    },
+    "sound/saffron/attack.wav": {
+     "bytes": 24454,
+     "sha256": "afbf01e61a1b637f7debf4add10e7512365950395e0b5ae3f4e1f64ad4153b9f"
+    },
+    "sound/saffron/death.wav": {
+     "bytes": 60334,
+     "sha256": "1fc081630434219ae15454ad0db29d0aefdc88c5674c90bab9ace9c13e256226"
+    },
+    "sound/saffron/death2.wav": {
+     "bytes": 42030,
+     "sha256": "7abab0ffd315f2286f66c27d53bbd8acb64deeba4a2a5fca830367ff066daaa5"
+    },
+    "sound/saffron/death3.wav": {
+     "bytes": 37422,
+     "sha256": "ebeb2e44a857e8fcf464592cfb17499cc80ea9b6667e0c80bd1a1c49be49c7bc"
+    },
+    "sound/saffron/explode.wav": {
+     "bytes": 27712,
+     "sha256": "2106e42f2c5debdf9c738c64b11ef36ca1d401f0a445e88bb090ff84a812d061"
+    },
+    "sound/saffron/explode2.wav": {
+     "bytes": 29550,
+     "sha256": "db864dbab2c1652ea5be6aeecbf376ffa4ee42e142829054b70102840da0bd33"
+    },
+    "sound/saffron/explode3.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/saffron/fire.wav": {
+     "bytes": 39534,
+     "sha256": "6e5492eeeeebf8e6980502f2ad995153ce1d178276bd1ebca910f6ab8b7c0f09"
+    },
+    "sound/saffron/idle1.wav": {
+     "bytes": 60334,
+     "sha256": "e74b7e1bcd4a1d505f40d5dca262e3b2b8bafffbd40c1e25389b776448ff2d5f"
+    },
+    "sound/saffron/idle2.wav": {
+     "bytes": 67608,
+     "sha256": "a0b67d61d2c1535f9e50b58209c5190973fa4176274c7f6fc58d1ae9f222c54e"
+    },
+    "sound/saffron/pain.wav": {
+     "bytes": 11936,
+     "sha256": "e7b476f5d719dc1906d70ab0c368b20f981700b3a0e5ee3736eb92cccfde484f"
+    },
+    "sound/saffron/sight.wav": {
+     "bytes": 42030,
+     "sha256": "bbd5fe233d53c799973ef6d4b5ce1f433c90b625711d399c1df9843d2f48c2c5"
+    },
+    "sound/shambler/s1die.wav": {
+     "bytes": 21663,
+     "sha256": "b96dfc4791bc8cc99be9d72fb25dbeb4715b7b8598b28fa1eecbf5648768c007"
+    },
+    "sound/shambler/s2die.wav": {
+     "bytes": 21301,
+     "sha256": "de2054b277caa8d15718f85fdd1d4ebb1e8a6759ce7a03a9040b242743db742b"
+    },
+    "sound/shambler/sfire.wav": {
+     "bytes": 14598,
+     "sha256": "6a478fffe74cca67345903c4b08ed4889864db5446f7d7bfe661415ca8298b6d"
+    },
+    "sound/shambler/ssight1.wav": {
+     "bytes": 13081,
+     "sha256": "fb45ca50d2750378793c5dfe5447d520550b5787ab12cbfe134f0f4de6c9cf19"
+    },
+    "sound/shambler/ssight2.wav": {
+     "bytes": 26248,
+     "sha256": "127c34371425feceff7fb1d0ac847474015640140a4ae1675ebd677f8b8a9680"
+    },
+    "sound/weapons/lzap.wav": {
+     "bytes": 12326,
+     "sha256": "4bc5e49e2ce9943a7cb5250fe451b94359757b5390c300a1d01354754c31c86d"
+    }
+   },
    "sha256": "ff09acca4819c2bdb26392ec9290c41655f887b1d2ff16188c6f2a18948ac8e8",
    "timestamp": "2002-02-16T20:16:02.000Z"
   }

--- a/json/by-sha256/67/67400fc494de61d662508a55f97e8e932b849a47a8c5adf8c4cf51aae56d97f7.json
+++ b/json/by-sha256/67/67400fc494de61d662508a55f97e8e932b849a47a8c5adf8c4cf51aae56d97f7.json
@@ -156,6 +156,360 @@
   },
   "sm225/pak0.pak": {
    "bytes": 4393664,
+   "files": {
+    "gfx.wad": {
+     "bytes": 121132,
+     "sha256": "fdcc42f0dad313b297845f4a4daa79dffb541dc7fdfd13c6e8610df9fd614f72"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "898d694265db0f933feecfd2a843557a6954a5f2aea05ecf9a852314119dab61"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "03e0973ee5d434c037699f9568228ab80be0df882ca77c88a9835b2d2edf0649"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "2a28a9f4861c149ebff65a36456836b694e7b4437664518d1ca5e27da0e82a16",
    "timestamp": "2022-11-24T07:55:48.000Z"
   },

--- a/json/by-sha256/67/6755b682db4d2fcd3e92dee61b7975468a2807abc2a93f29051835e7e33aec69.json
+++ b/json/by-sha256/67/6755b682db4d2fcd3e92dee61b7975468a2807abc2a93f29051835e7e33aec69.json
@@ -1007,16 +1007,10334 @@
   },
   "pak0.pak": {
    "bytes": 270031400,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 94990,
+     "sha256": "1fddba1dadd3adef5e0f13d716e514c131455c51b26c2291f71dea0eada7b97e"
+    },
+    "effectinfo.txt": {
+     "bytes": 157535,
+     "sha256": "8dbc7cf30b0bef166f0ce58a59c0f3ce1dcadd9a13867f8430541793fd723cf8"
+    },
+    "effectvanilla.txt": {
+     "bytes": 4612,
+     "sha256": "efd47c12bf71b377f3e750f46d5e242b3337ece446ba9a44cc0750a9bbf9c758"
+    },
+    "gfx/ad_blank.lmp": {
+     "bytes": 584,
+     "sha256": "37b5a1e7d0b3882eb7504e3626f8040a19a6d403e0e761dccd65db935401144f"
+    },
+    "gfx/ad_ibar0a.lmp": {
+     "bytes": 2568,
+     "sha256": "7a66fbbaa742e59d3fdd939ce35befa0f633492482912f4fa91f16d0788276e6"
+    },
+    "gfx/ad_ibar0b.lmp": {
+     "bytes": 5128,
+     "sha256": "5a955a32f0227e4d3e90e908e650c7dc53138b5db2d5bcb3eb4a14fe5c568760"
+    },
+    "gfx/ad_ibar1a.lmp": {
+     "bytes": 4616,
+     "sha256": "eb1c6337becc5c245b873b3d9a6ba5e9c458147f48826a4580ea0ffdf57e9759"
+    },
+    "gfx/ad_ibar1b.lmp": {
+     "bytes": 3080,
+     "sha256": "34e3eec992a3f567d4ac83c98d5fc53ca0a90c02764d45a40eea08d2f94c733b"
+    },
+    "gfx/ad_ibar2a.lmp": {
+     "bytes": 4616,
+     "sha256": "eec2d035f2857fc03083ccf0384ac6446f71b1aa45ed0e2409b8d4ba42c135f6"
+    },
+    "gfx/ad_ibar2b.lmp": {
+     "bytes": 3080,
+     "sha256": "17c35d1d02833d1fe900b1c2beaf77ffe1948a3f17ae790e9f0da1c1057b460c"
+    },
+    "gfx/ad_ibar4a.lmp": {
+     "bytes": 3080,
+     "sha256": "2507c6ce0a53ed62ce73b1bb0ee7e76e9c245757dee54415aeef78767bace887"
+    },
+    "gfx/ad_ibar4b.lmp": {
+     "bytes": 3080,
+     "sha256": "d977ecb360eff9b19827e956d32687234bed64f830adc5e506334a597daa7eaa"
+    },
+    "gfx/ad_ibar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "9d0d2c1eb7e665d0a28130bed09fb8bd698a6a1b246842fa353e3b0e1f5b445d"
+    },
+    "gfx/ad_ibar5b.lmp": {
+     "bytes": 4616,
+     "sha256": "26902c5879207315a7b732e8799f95bdcd45801a8086a902371808a594fa5515"
+    },
+    "gfx/ad_ibar6a.lmp": {
+     "bytes": 7688,
+     "sha256": "cfcce1c48cda88ccd405b1398576476bae52b3cdf7154a0b902a47655dd282cd"
+    },
+    "gfx/ad_ibar6b.lmp": {
+     "bytes": 7688,
+     "sha256": "49487400a56db767d37656f8ccb9e1660f470d8f989619a86bec5c296dcb77f9"
+    },
+    "gfx/ad_ibar7a.lmp": {
+     "bytes": 6152,
+     "sha256": "0d4ababef9a115ca7f6739a01d288d237e22a859ee16c5682d97dcabc4d7aa0b"
+    },
+    "gfx/ad_ibar7b.lmp": {
+     "bytes": 5832,
+     "sha256": "f9292e8d1fff09bde28baf932f11617e27247d4e9af191b89c30811e92110bca"
+    },
+    "gfx/ad_ibar7c.lmp": {
+     "bytes": 4104,
+     "sha256": "0e77dc6602c4945d5d4ec2a12f8003173430945bf7891d979c3c80b0c9212b40"
+    },
+    "gfx/ad_ibar_cell1.lmp": {
+     "bytes": 392,
+     "sha256": "5a4409731e4302bca5245f385a1cab9b91e0a2677d52336bbe3650fdcf070b05"
+    },
+    "gfx/ad_ibar_cell2.lmp": {
+     "bytes": 72,
+     "sha256": "6a519b1e8eed1d7a5365231162fcf1beaf31a6fd1c39b07de09bb0e66dc38303"
+    },
+    "gfx/ad_ibar_nail1.lmp": {
+     "bytes": 392,
+     "sha256": "850189c70ac92f3e8ee79ed9ff6e31ee73d33b5616964461373b37e3a29e60b6"
+    },
+    "gfx/ad_ibar_nail2.lmp": {
+     "bytes": 72,
+     "sha256": "b36d5196c807c6325816db9efad9a16fd7e38433f277b0ad9e6d3551f95c0ceb"
+    },
+    "gfx/ad_ibar_rock1.lmp": {
+     "bytes": 392,
+     "sha256": "f74ce0037116022557ec3a50d368442e73cb48492990a07e93503ad9aeeaa225"
+    },
+    "gfx/ad_ibar_rock2.lmp": {
+     "bytes": 72,
+     "sha256": "081911a352b3d75a4be7812082eee782c41127e70bc4a06585b163d385230a65"
+    },
+    "gfx/ad_ibar_shell1.lmp": {
+     "bytes": 392,
+     "sha256": "733750fbc8235b236f7a2a4246d6112c0a09ce2f75529e359382e25dab92ee10"
+    },
+    "gfx/ad_ibar_shell2.lmp": {
+     "bytes": 72,
+     "sha256": "22fc2a46e85e76836fa38db9868820322833b45e0473407d69378dc09b43e9a5"
+    },
+    "gfx/ad_sbar0.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar1.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar4a.lmp": {
+     "bytes": 4616,
+     "sha256": "5ecbd1e480e4c04e2efe956dcd49e609f0c5a2038f03759b9af848b3cf7dd613"
+    },
+    "gfx/ad_sbar4b.lmp": {
+     "bytes": 4616,
+     "sha256": "8fdfe5e6ffba2c209386580adc196acce9d5601fb529f651267e7186610cc392"
+    },
+    "gfx/ad_sbar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "40c7f9e7ba975d500d3861d0c5a7e592da1ce09fdc31583488fd4c78d823e20e"
+    },
+    "gfx/ad_sbar5b.lmp": {
+     "bytes": 2312,
+     "sha256": "86ff0d9678a52e5428089afe0bb9cdddc9f7688798cee45a396e4d13bf00b60d"
+    },
+    "gfx/ad_sbar6.lmp": {
+     "bytes": 9992,
+     "sha256": "5b47dbc1ae645c429627f563355c43b1fb9145d195d02606d0a7a49791034a28"
+    },
+    "gfx/ad_sbar7a.lmp": {
+     "bytes": 3464,
+     "sha256": "8773683e2edb20dfdea61775d6f955a766a15b7b733ae07212dec922d853f6ba"
+    },
+    "gfx/ad_sbar7b.lmp": {
+     "bytes": 3528,
+     "sha256": "1103f097b9896700ef5a722df927cbe71c76531a09eda9e55e5702d3b4d3b370"
+    },
+    "gfx/ad_scorebar0.lmp": {
+     "bytes": 7688,
+     "sha256": "7c479c4969b9f437c57d710edbdd6b2ce1936aa95adb559c9dd3048680868cdb"
+    },
+    "gfx/adf_1.lmp": {
+     "bytes": 584,
+     "sha256": "5b1b35dc96ad9c2f62602caab6be13d8698fe6cc14865293d11c6b9eee64dd51"
+    },
+    "gfx/adf_2.lmp": {
+     "bytes": 584,
+     "sha256": "8cbc05801d49423bd5f14bd459e8ed5cff7841e7f2d5e44d0f4dfe0f0f7ee851"
+    },
+    "gfx/adf_3.lmp": {
+     "bytes": 584,
+     "sha256": "f0155a41ad9290c8df9fabe0faae6dde4d04772dd2a425653766ec36da76140f"
+    },
+    "gfx/adf_4.lmp": {
+     "bytes": 584,
+     "sha256": "d74c9370ce323ffdc9c3dd124dcbbf9c15fc94e58e20d15789975dd8701a74da"
+    },
+    "gfx/adf_5.lmp": {
+     "bytes": 584,
+     "sha256": "f97a78ede874ff45176e5bb85abdbed93e22dab28bc0965065927c7b215ea36f"
+    },
+    "gfx/adf_evil.lmp": {
+     "bytes": 584,
+     "sha256": "42445b083abae6e9f4ff009efd7a38d2ddd664ac5e47f97ad30c88a603c64c35"
+    },
+    "gfx/adf_evilinv.lmp": {
+     "bytes": 584,
+     "sha256": "ff0d8b9203d7cfae6d075ef5bfad60cdcf66b1e24bb6fd02be0cada1b7f1c82f"
+    },
+    "gfx/adf_evilpent.lmp": {
+     "bytes": 584,
+     "sha256": "0b0029bc964ed68f1b46ccf0b4bd5e527e33e76c0904a1d06e623c47ca589e56"
+    },
+    "gfx/adf_evilquad.lmp": {
+     "bytes": 584,
+     "sha256": "a511796cca84df8149ea6d3d280880e425fdd486315159462168d32f06a17822"
+    },
+    "gfx/adf_inv2.lmp": {
+     "bytes": 584,
+     "sha256": "a6caf84d4e2c125e80aefb51aaa1af707ccf689e641141dd3736f101a66c8fa0"
+    },
+    "gfx/adf_invis.lmp": {
+     "bytes": 584,
+     "sha256": "70117297f381fd1778e5d26e5b832af86c6013ca9a55632c24c057e0aaa1e48f"
+    },
+    "gfx/adf_invul1.lmp": {
+     "bytes": 584,
+     "sha256": "453b67ccc01b32101e1051a9407b84b5c93416ae30c3b3200e25b96868c3f6e5"
+    },
+    "gfx/adf_invul2.lmp": {
+     "bytes": 584,
+     "sha256": "c70f600538aa1d1cc121ea76602e564d0af5ce5ea67a2c1ba01ac5fe44439bd4"
+    },
+    "gfx/adf_p1.lmp": {
+     "bytes": 584,
+     "sha256": "f6da35fd9699239c060f034738615ecead6111294a419a82e503bdbdd9ed46b1"
+    },
+    "gfx/adf_p2.lmp": {
+     "bytes": 584,
+     "sha256": "431539dd9656e09c6d4007c86bad37c30447e596575d803619b14371329f9acb"
+    },
+    "gfx/adf_p3.lmp": {
+     "bytes": 584,
+     "sha256": "b832a2d2143805f8701eec7eec465d67fa692e2e87714e87fa3ac3a2c2682659"
+    },
+    "gfx/adf_p4.lmp": {
+     "bytes": 584,
+     "sha256": "40f6d70d3ebf248c1c38e90b95cec42516b3a61fd17bd866df964af8e657487f"
+    },
+    "gfx/adf_p5.lmp": {
+     "bytes": 584,
+     "sha256": "d7d4768f7324d1eca2b8cb95fd250d8c6065dcfc5c392c6f2bc6adc8c2a7579a"
+    },
+    "gfx/adf_quad.lmp": {
+     "bytes": 584,
+     "sha256": "da9a83f464049832cd049205a22d832a228b00cbd0d1e7e24d347d5ed34c4ffb"
+    },
+    "gfx/adib_atank.lmp": {
+     "bytes": 264,
+     "sha256": "8d963c818c0554d73d14b251eeed0321cf854777f29eddf5a82ee3fb3fde8035"
+    },
+    "gfx/adib_axe1.lmp": {
+     "bytes": 264,
+     "sha256": "90b6817aa64570e9bfc36a13e6dd1930e81468f931ceac9f2ae3790f99f2dca2"
+    },
+    "gfx/adib_axe2.lmp": {
+     "bytes": 264,
+     "sha256": "2b0821038185e41c711e399dcfff37fd54aa8f7473ba81754c379fae558a5a1d"
+    },
+    "gfx/adib_bbelt.lmp": {
+     "bytes": 264,
+     "sha256": "8b50ea739ca8ab52baefe65f90ea5943fcc4f05b63b214a36b3ae6fa4feb55a8"
+    },
+    "gfx/adib_ckey1.lmp": {
+     "bytes": 136,
+     "sha256": "8525e145fdc72947ac6d4599ae0304b84793475d44f0113c925905d715c2da8e"
+    },
+    "gfx/adib_ckey10.lmp": {
+     "bytes": 136,
+     "sha256": "a2e14b68c10109e48e86bd095775beb68f03640dfdb12d1c28b6d32abd1fa329"
+    },
+    "gfx/adib_ckey11.lmp": {
+     "bytes": 136,
+     "sha256": "2b9191d85075d6a6c06d8b295c48546ecc0bd1c91a860308f6f953dcf324604c"
+    },
+    "gfx/adib_ckey12.lmp": {
+     "bytes": 136,
+     "sha256": "9b04f101468d96f4c39d97da0be44f7152179e4a8d6a05762ca693c9f84db317"
+    },
+    "gfx/adib_ckey13.lmp": {
+     "bytes": 136,
+     "sha256": "35fa377dbf162d691de012a61458b5ec29c28b776cd3ee0e0f9ab0ad57b67c8f"
+    },
+    "gfx/adib_ckey14.lmp": {
+     "bytes": 136,
+     "sha256": "ea6b831467c97fb0ba18d97a549c54304b133830e1567ae300e83514bdbb2919"
+    },
+    "gfx/adib_ckey2.lmp": {
+     "bytes": 136,
+     "sha256": "5c80cec0c7808ed141fff4f6863eccfa71b06a7405e871c75912d5d065b4ff21"
+    },
+    "gfx/adib_ckey3.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adib_ckey4.lmp": {
+     "bytes": 136,
+     "sha256": "51ea09fa8db26de3ce6ea6c1a5abecf4c31c3877ab6c508811ea9b271f40f1fc"
+    },
+    "gfx/adib_ckey5.lmp": {
+     "bytes": 136,
+     "sha256": "e03ed662e981530264f6dcf6f6dda91fd8406c0941d0f7c4370a89e0c4f467bc"
+    },
+    "gfx/adib_ckey6.lmp": {
+     "bytes": 136,
+     "sha256": "6f4f61addc77e3492c08cd382291eaf3f8c28a7499137591dcd2c6706bb1ec57"
+    },
+    "gfx/adib_ckey7.lmp": {
+     "bytes": 136,
+     "sha256": "38c3473948f4769e4309bdbb390afd0663fc093f1f76c9fbf10d818c6f89c72b"
+    },
+    "gfx/adib_ckey8.lmp": {
+     "bytes": 136,
+     "sha256": "d0c43a81abfb623b7c3392a07b484b6bf9137fede67d78dc67864848ecbc1c12"
+    },
+    "gfx/adib_ckey9.lmp": {
+     "bytes": 136,
+     "sha256": "042cdb7aef3e06a5679158b4f33fc66ca2d97dd6cf9e7e2657b1e85e444ed006"
+    },
+    "gfx/adib_invis.lmp": {
+     "bytes": 264,
+     "sha256": "f4f1be9a2ef88b75fd9971d72796a35f7de1ed04fc2cfc3a4c35225976f21eca"
+    },
+    "gfx/adib_invuln.lmp": {
+     "bytes": 264,
+     "sha256": "87b8312e4d7fc20d6ae9df6d1f8cb616392f3a2adaf7208dd2372eefc19888a3"
+    },
+    "gfx/adib_jboots.lmp": {
+     "bytes": 264,
+     "sha256": "206ad9d67636b46418e6afa6b6e75a12df76bd3ad84b0178e86b8d140b9c3afc"
+    },
+    "gfx/adib_lshield.lmp": {
+     "bytes": 264,
+     "sha256": "79a78f4402a301d381bef260b895ba56757b779ae89b7ae5a49f8146f2a7a54a"
+    },
+    "gfx/adib_nailp.lmp": {
+     "bytes": 264,
+     "sha256": "fe59667c80612fd2e7f5d95dd0a208f3909d93eeaaab7e4580405fe153469fde"
+    },
+    "gfx/adib_quad.lmp": {
+     "bytes": 264,
+     "sha256": "915832c8c822daf8cfa1c5d88548f24da7d182be6746b265e7ae6e1d735082cd"
+    },
+    "gfx/adib_sharp.lmp": {
+     "bytes": 264,
+     "sha256": "18987634aa43dced4e06e1d5a9a3f9b1f51c7738f59fae64168bd94ab9cd6198"
+    },
+    "gfx/adib_sigil1.lmp": {
+     "bytes": 136,
+     "sha256": "34b11b26dcdf5b91f3e6e08bbe6edb83f62ba054e9eef28459cef09b742e1456"
+    },
+    "gfx/adib_sigil10.lmp": {
+     "bytes": 136,
+     "sha256": "af31a42ef81449aa656327dfe00fc1e1d744f90212ac228bd05a6d79f5048683"
+    },
+    "gfx/adib_sigil11.lmp": {
+     "bytes": 136,
+     "sha256": "9fb90ba79d5c34e2b0afdbcec8bc528fd7d3d8f2645191d95a67a65e242bd3c6"
+    },
+    "gfx/adib_sigil12.lmp": {
+     "bytes": 136,
+     "sha256": "d7c9c3c7c1167ea0791b2790d678d6bd25144adcba79d6f7c5d93302fc28119d"
+    },
+    "gfx/adib_sigil13.lmp": {
+     "bytes": 136,
+     "sha256": "0003389cd694c55fa36f1d18d38261d279c5c7ef23dd5d41c3852ad8c95e5a49"
+    },
+    "gfx/adib_sigil14.lmp": {
+     "bytes": 136,
+     "sha256": "8ac47a2e1d45d94fb1f222811320c5f07e39e65698b7436515afa29de6e1204e"
+    },
+    "gfx/adib_sigil15.lmp": {
+     "bytes": 136,
+     "sha256": "153627403fd3e3856aa34e8740fdebb5ddb26e201cd590dd76cbfc12c36e49c6"
+    },
+    "gfx/adib_sigil16.lmp": {
+     "bytes": 136,
+     "sha256": "fa95a1a372ce30516252fff8dbcda8f8f55e3cc558b4a1e7015b79838ff0cda1"
+    },
+    "gfx/adib_sigil2.lmp": {
+     "bytes": 136,
+     "sha256": "0a0c22f027e980014a246daa629b6f84f425ccfd828f75a93ef777d9616c9191"
+    },
+    "gfx/adib_sigil3.lmp": {
+     "bytes": 136,
+     "sha256": "9e5daafbe4cc032824f732ebdac3897d804df43efaff9901c315ae661af8cd31"
+    },
+    "gfx/adib_sigil4.lmp": {
+     "bytes": 136,
+     "sha256": "fd1d3791d53ab40881a2d86a0bc67b3b532ef10b201a166a3937b105c63e3c9b"
+    },
+    "gfx/adib_sigil5.lmp": {
+     "bytes": 136,
+     "sha256": "947d5088b18a12d06a93fe66a0500e5b6ae93e04cebc748858139d569693d42d"
+    },
+    "gfx/adib_sigil6.lmp": {
+     "bytes": 136,
+     "sha256": "5a2356a7479f887b20f10e03ee2f42478bdfa75febe2d802b3dbfcd25b39d744"
+    },
+    "gfx/adib_sigil7.lmp": {
+     "bytes": 136,
+     "sha256": "507011b2a191e096fadcd678590636e4033de2ffcf35cef31785539bf3f9fb4f"
+    },
+    "gfx/adib_sigil8.lmp": {
+     "bytes": 136,
+     "sha256": "2a49a4653b2ed11353c6aaca950420c38c8e7b2aa8cc82ecd746a4e73fb7aa00"
+    },
+    "gfx/adib_sigil9.lmp": {
+     "bytes": 136,
+     "sha256": "df168192d5c065c7247cff03b10da51eba431bdc4f76d2c913646bb23084d639"
+    },
+    "gfx/adib_suit.lmp": {
+     "bytes": 264,
+     "sha256": "030bf62f7f45667310f1a74bd88881e2aa8d6c7ba5355bda4bc7c87d64a3d082"
+    },
+    "gfx/adn_0.lmp": {
+     "bytes": 584,
+     "sha256": "0895fe0acba04a4e17ef64fe62c56765c4fef5933c4af09dfcb242e984e8d163"
+    },
+    "gfx/adn_1.lmp": {
+     "bytes": 584,
+     "sha256": "fc0391c514808f9cb54e0bb0bbd63edccb0bea66a7620b81d04497edd099f5b1"
+    },
+    "gfx/adn_2.lmp": {
+     "bytes": 584,
+     "sha256": "d70ca75a162f7203067f314eee6460dc9180383e5bd1a19c69a984d8f4c699ae"
+    },
+    "gfx/adn_3.lmp": {
+     "bytes": 584,
+     "sha256": "40fbf34b86a4e5d264fac3c875ad74a52b62f5868d01a7580107a52998cbe4ac"
+    },
+    "gfx/adn_4.lmp": {
+     "bytes": 584,
+     "sha256": "5c9f781b8fb46cff0bb69db9817936be10cc4e34d677a5a49f117baa1d414aef"
+    },
+    "gfx/adn_5.lmp": {
+     "bytes": 584,
+     "sha256": "f2b1a90d1f4e1e3c6eb04dd1d87f084b2bc932b76b6eabcc5a4ee12db939971e"
+    },
+    "gfx/adn_6.lmp": {
+     "bytes": 584,
+     "sha256": "ec90a75650252feb45f325815498caf518058d141c7660e594397e0e05e35cfc"
+    },
+    "gfx/adn_7.lmp": {
+     "bytes": 584,
+     "sha256": "c292389fee1e91c2c4178099a8c9b2ad193f74346adec126ae10a4383f96c6de"
+    },
+    "gfx/adn_8.lmp": {
+     "bytes": 584,
+     "sha256": "4df870d66977eddbb7c4f87ffe4b94a032f2f13ad8fa38a98fde607d7aa7b06d"
+    },
+    "gfx/adn_9.lmp": {
+     "bytes": 584,
+     "sha256": "fd7f393a0fea9c0bc9fec90492a8f074a75275fde2ce211379b098176729622d"
+    },
+    "gfx/adn_a0.lmp": {
+     "bytes": 584,
+     "sha256": "7221532ee9af2c3a2fa3d19e4ccae78458d7a1f3025627e6da45dcb4aefd6820"
+    },
+    "gfx/adn_a1.lmp": {
+     "bytes": 584,
+     "sha256": "8f594ea65757fdaa62105b5eb68d4519b96b93e12dba110a723c4bf99470d408"
+    },
+    "gfx/adn_a2.lmp": {
+     "bytes": 584,
+     "sha256": "738cd71a2344da4b1733b639e6cdef1fb412104c388d2edee0b4539655ed9fec"
+    },
+    "gfx/adn_a3.lmp": {
+     "bytes": 584,
+     "sha256": "00c7040d33a445656f33c373077564116a764142f4625b5df7fae6516817f893"
+    },
+    "gfx/adn_a4.lmp": {
+     "bytes": 584,
+     "sha256": "7fbde831e189692c1c5d048873e7098a7d017ff7e22fc57a724a2c2fcbcc8db4"
+    },
+    "gfx/adn_a5.lmp": {
+     "bytes": 584,
+     "sha256": "ecb1a8036b03abc3c95a145081762ebf8b04516bc438053e570b989195687615"
+    },
+    "gfx/adn_a6.lmp": {
+     "bytes": 584,
+     "sha256": "8495247be5584836815824b182f448348d3de924236e254c5ebffd8132a1b7ae"
+    },
+    "gfx/adn_a7.lmp": {
+     "bytes": 584,
+     "sha256": "76a1b4a37c14cf3c53047129e14bb3f2217142ca5405ebceb95b892bed49cb77"
+    },
+    "gfx/adn_a8.lmp": {
+     "bytes": 584,
+     "sha256": "943ae9da4710dfb8a8b7b22eb8ecc6131e7c4586f279701323997f931bdd486f"
+    },
+    "gfx/adn_a9.lmp": {
+     "bytes": 584,
+     "sha256": "4381c6e590644e7c7e3d64e89adb1d438802e1a81380de8f08b31669780f07ed"
+    },
+    "gfx/adn_aminus.lmp": {
+     "bytes": 584,
+     "sha256": "903c3e6081e934fb4a9b0ae4564265b0339d2289fea17720c7bac77d00155258"
+    },
+    "gfx/adn_colon.lmp": {
+     "bytes": 392,
+     "sha256": "a06510a33f355c24fc16d7591323523f13920ae6fa903c3155b5edef9e4059a9"
+    },
+    "gfx/adn_minus.lmp": {
+     "bytes": 584,
+     "sha256": "1e04325b97c5052e64187e0882b8c2f87473bd66f3e70b5a419d983b0a62ed81"
+    },
+    "gfx/adn_s0.lmp": {
+     "bytes": 264,
+     "sha256": "6a5cac8d7c8076aa42055c3b64f3fde4b1e7750b2bb143b12af07dec892c9ccc"
+    },
+    "gfx/adn_s1.lmp": {
+     "bytes": 264,
+     "sha256": "723ec3e0b6225419fa5fb8010896674d91d19eeafd8e2c9bbbec2d23fbb85792"
+    },
+    "gfx/adn_s2.lmp": {
+     "bytes": 264,
+     "sha256": "cff9bff09933ccbf43a1419d6f566807c2aee9a4aca448a86bf261394b3ca7b3"
+    },
+    "gfx/adn_s3.lmp": {
+     "bytes": 264,
+     "sha256": "8d7cf6b3f2db7463e962fd7b70b2ef7c36b0882b1e80d90b02fa1a609d09513f"
+    },
+    "gfx/adn_s4.lmp": {
+     "bytes": 264,
+     "sha256": "2bc5fa316cc366f4d1a4f1831ac3b8ced65caf89157e796ff5d673fa3955ac1c"
+    },
+    "gfx/adn_s5.lmp": {
+     "bytes": 264,
+     "sha256": "98cbff3f1b98977b8fc19523fc2e644e763fc52dba708fc5024dfbeaa1f00d6d"
+    },
+    "gfx/adn_s6.lmp": {
+     "bytes": 264,
+     "sha256": "1578d854415aaf5b68a25a0fb37057b019d12055b61c3d7402eae811a9359e1f"
+    },
+    "gfx/adn_s7.lmp": {
+     "bytes": 264,
+     "sha256": "609059534b0a59c9d5ab1180f25f0b2a952719a0ccade29d05559dfc6223f1d9"
+    },
+    "gfx/adn_s8.lmp": {
+     "bytes": 264,
+     "sha256": "7327dd480225a52c642320336ade17100228d2c1ade5f1b640cbff18e37fbe2d"
+    },
+    "gfx/adn_s9.lmp": {
+     "bytes": 264,
+     "sha256": "b8ad416098543b34c286565e3a0d7756eea7ab18c8b50145e7ddbc45fd28851a"
+    },
+    "gfx/adn_slash.lmp": {
+     "bytes": 392,
+     "sha256": "2500358f0d4bf9856c04b7be940ab41012faad597005837c99dfef93da1f3ca6"
+    },
+    "gfx/adsb_armor0.lmp": {
+     "bytes": 584,
+     "sha256": "01228bb8947103a70c9f536b168eefacda9dc5a08e1fa64ee963be44d4a9af9c"
+    },
+    "gfx/adsb_armor1.lmp": {
+     "bytes": 584,
+     "sha256": "85956c2a17460229a374e8a6e1cf22ad4ff663929dba06c9daa9d95d1582ba53"
+    },
+    "gfx/adsb_armor2.lmp": {
+     "bytes": 584,
+     "sha256": "e8e64ea8d90241677315bb9a9e25714856827642a0e331077dc6fa2b827036fc"
+    },
+    "gfx/adsb_armor3.lmp": {
+     "bytes": 584,
+     "sha256": "db6523d7c99bb15c14ad9fd1d665a24e4eab985dfa095d316f20fe5e96e9c320"
+    },
+    "gfx/adsb_axe1.lmp": {
+     "bytes": 584,
+     "sha256": "ebcafdd02b84a9bd21658a349205a09e5e242fa39013207fe6aab9697df2884f"
+    },
+    "gfx/adsb_axe2.lmp": {
+     "bytes": 584,
+     "sha256": "12caae98c176f1176a5222f7730709dcb9164a5db63984fe6f8982e8b17915e6"
+    },
+    "gfx/adsb_cells.lmp": {
+     "bytes": 584,
+     "sha256": "08da91ae0bca3d7bd546d92f7688061b7fbc8d86b84e309510ee3feeb3f63e92"
+    },
+    "gfx/adsb_key0.lmp": {
+     "bytes": 392,
+     "sha256": "49e4cda132ff7237a4b7244892fa1e059ff2d77698ec855cb4c02e08867899e2"
+    },
+    "gfx/adsb_key1.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adsb_key2.lmp": {
+     "bytes": 136,
+     "sha256": "46a6561c191c47e9445ef85c2bebdc881f330ca49afe562d7bb2a59c5442c73e"
+    },
+    "gfx/adsb_nails.lmp": {
+     "bytes": 584,
+     "sha256": "77fb4c0c61d824fafba54e91d6b23e702ae54565d7708ee0e404aff804555b73"
+    },
+    "gfx/adsb_pent.lmp": {
+     "bytes": 584,
+     "sha256": "8066cd0ef3d3ed9add280937fa51d6dd13a7eaf606ad0567366e86c51ddb7d62"
+    },
+    "gfx/adsb_rocks.lmp": {
+     "bytes": 584,
+     "sha256": "2e79b7c3e3fb6b4118a3ddedd7d9a1186f12c2df2efdbcf5300cacc51fe64744"
+    },
+    "gfx/adsb_shells.lmp": {
+     "bytes": 584,
+     "sha256": "f185cb1b1a48a8499d110e6371f2bb102ad89fda9875a267adcc6f3c8a5e613c"
+    },
+    "gfx/adw_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "ee32ef4cb14c02b9516f245fe9eae50021962ebdee3ef843076b9dbe20f038fb"
+    },
+    "gfx/adw_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "0f8884976f5ef05d5c3d7ab7c7b22bddeba9ee922664d23c6dfe835c5673ad9f"
+    },
+    "gfx/adw_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "2c1f7b1b0a5c27da9f01c84a38571901fb3636a04485102f44cb19d715e7f627"
+    },
+    "gfx/adw_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "a9802bea98b2fb57ab97784caeebf1ab2312fab73146503459c7c8021249ccef"
+    },
+    "gfx/adw_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "0c92aaf91afe914f4d06e5d2fa91bf926a0b43294d49021755b93c049e15a99d"
+    },
+    "gfx/adw_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "155eeca532e2f6d08b7575697020eebd4f492987392c68f09c66bb6522c0336b"
+    },
+    "gfx/adw_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "02d55707616bd6eae995c93d5eca3e788f227811001e2e8137c07cafe85409a4"
+    },
+    "gfx/adw_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "0d4cba204d9ea74665e164d46ead9167095cceb64a795861dfb21fcfd2b3e9ac"
+    },
+    "gfx/adw_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "3d354bd9336125ea758f2b5b56b1ecdf2a2afea4e8bb8d6edeb058448f9627e7"
+    },
+    "gfx/adws_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "457f6682e5a8b3d7b1075148c05093df1ec96c59e85057dfca80f66f4ad25815"
+    },
+    "gfx/adws_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "127d3759679f91a8633557a27abcb8425b3f8fd8b9888e029f761cff9fa20e47"
+    },
+    "gfx/adws_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd1e14b26cfa3915c23502e22413328d37749e0a77ac75508238fbaa375c7555"
+    },
+    "gfx/adws_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "424a425e24162a3a1a23e7308b8b46f4d25f1c9f11ac3b427117c596dafeb006"
+    },
+    "gfx/adws_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "41dc9eb1fb806500b41d832786a0bce0c6863c6caa3bcc7491892e25d04a81d4"
+    },
+    "gfx/adws_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "30a22fc8975b5a696ff31e859290fd780553f1857e424b1d5ecfa057277d155a"
+    },
+    "gfx/adws_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "50c5e9c358023dbbb65cc79346d99af6797af556faded31df95e2b7191aeb3f0"
+    },
+    "gfx/adws_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "94cef7136e718532b4d00b9ed8804da60be979206bde676a328270321286851a"
+    },
+    "gfx/adws_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "8259db2f3f7ddd075e6192d6e0581a2321c108232d67980fab85059fcbfe47df"
+    },
+    "gfx/adx1_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx1_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "e4d0714014c5a1c0d9874bf1ce2c0232352be1e0c90ffe927dc2d86d448f7e47"
+    },
+    "gfx/adx1_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx1_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "9da68076978e9bc4d35e2b40e972c578e0839c379c86d44bf15c033f164fc9e9"
+    },
+    "gfx/adx1_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx1_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx1_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx1_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx1_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "9341894f953061deffb42e12370fd05b7f8008e2a1caee149630a8bcd40fac10"
+    },
+    "gfx/adx2_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "c5f2e4352837eca0a67b1fe6eb5d437672f365efffd7c297848dcdbfca6fea7f"
+    },
+    "gfx/adx2_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "b627ea70b6a7a5debddd4710f31ca137c3baf01dd6109cc2cee7da968a020049"
+    },
+    "gfx/adx2_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd7a15d826f6565c97f638ff541d76e409b9cc69febbb78906c5ddbbad2e0f02"
+    },
+    "gfx/adx2_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "8239bfd1d494fae52f97d5f620bf6c9cace057a27975cddf7d0f557b5a797cb6"
+    },
+    "gfx/adx2_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "6adf5220508ec39cedaf8cc8208c8b7bff5f44f18401bc5ee7a39e91419376ab"
+    },
+    "gfx/adx2_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "f300febb1aad7dc16d592f1e1aef2cc5a8870ad08ebbb2bc15b43009122259ae"
+    },
+    "gfx/adx2_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "e15bf6fb56eca5640d521dfdbe0c20f9e3ce6fb6fc7a2e39922f0fc8cfc7d002"
+    },
+    "gfx/adx2_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "c781852ce141a1d5fb84451e1bef2b021c937d0658d7ca8f8b2a1d5cc3737a66"
+    },
+    "gfx/adx2_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "aaaac2a8b4dfaae3d02705c2fbffa38621187cc28f4246a591f38b2bec79f693"
+    },
+    "gfx/adx3_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "20209da4ccb0dbeffc6520aee7958b33bcfa728ed376b1f5f987c8305fb70d3e"
+    },
+    "gfx/adx3_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "eb13bcc843d95abf3c90c140c95aa95803a42a6afeb100e11a5e0d80c72caf8b"
+    },
+    "gfx/adx3_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "483f85f7e5a0e881f6511f2b16a25d1945dcc2fa5365e4417cb58ec6a87f062d"
+    },
+    "gfx/adx3_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5e1f15716b826a8a25e61415e675a6c94888ae4030462e1190653c4d93768743"
+    },
+    "gfx/adx3_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "99d58b01e578c88924699f85614b021dcc5ce32798c96680fb5120e8d58837c2"
+    },
+    "gfx/adx3_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "4eae7b9a7119e883d3b6d3b8b336398beca8b7cf4ed2b9b498e13d90b7743ccc"
+    },
+    "gfx/adx3_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "8568e0c106e3155b9cef3dc3bd55ce821ed151560abab4080fcf6534850b153c"
+    },
+    "gfx/adx3_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "b8764c3198aa863d67e4f7c3c19db89aab6aa4f4076abe83d50b88710eb85446"
+    },
+    "gfx/adx3_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "fbb92c8a0853070604e84da82a5232c93747f3571ba05e88ecb4e59649125838"
+    },
+    "gfx/adx4_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "4e8da401756d091a913d4a0a5618aee7eeddad1bcd8c78774bc229195bd96943"
+    },
+    "gfx/adx4_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "c68cec0c6064b7ceaad60028ed1e8f7834a6484d9fde249649d7b94addc6544a"
+    },
+    "gfx/adx4_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "386eadd2ee00c5a53179729c2b23cf56f0629c3e7ad8e5b3a739f1fd8d489d34"
+    },
+    "gfx/adx4_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5179dcb2b82032c81d02dfb35d130ed8196d5b726c7a8265c2823c3f2edde2a8"
+    },
+    "gfx/adx4_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1156e8a090be24e24605153b059646bd7d8b9d33c6e175bc9b05843eb626ce38"
+    },
+    "gfx/adx4_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "8881a5fe764d90c1113e1df7215c6520988c23601a969ea3e7b9abf8d7d4ef0c"
+    },
+    "gfx/adx4_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "7b55d6f2071d101db2a87c5958aadcdcf618f8f0eab53b19691125c1e8b6d8ad"
+    },
+    "gfx/adx4_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "199a6be6977bbebfe0aac0005466b10bfcdd9d26a764d18e56e28ee6f6f8f5ee"
+    },
+    "gfx/adx4_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "924cd9a6ac66660db99821b558a21e8dd0b02e85bb2a5415c2e24daace249663"
+    },
+    "gfx/adx5_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx5_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "9405034666f0f1247a58a97b86e5c451f0b2a315501389f43043da55493db8de"
+    },
+    "gfx/adx5_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx5_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "6c529185a7cc6dc8d066080c4246f80c7bf1fd0ea808fc0be5be63c8cff7c2b3"
+    },
+    "gfx/adx5_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx5_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx5_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx5_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx5_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "bb8e065bc9d9935d7fab8e9d0d0554948e2ab2622a54e86f70c1d8c3c9a0f178"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "b941e3ec692b990d1dbe0fd69c1e043b9d504374d791c8c981cb091324072826"
+    },
+    "gfx/community.lmp": {
+     "bytes": 256,
+     "sha256": "7d425f7678b30e94f816c93391c3322ed354c9657ef2563c964b2abb0d57d933"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4424,
+     "sha256": "b4554a7ef6de5831198626fef9431582d3c17ed56c55853f1ce979be31df8dcd"
+    },
+    "gfx/conchars.lmp": {
+     "bytes": 16392,
+     "sha256": "045ea49c02bc0e51336e84fb19f4c445ece3c0d8c6ec4aba3cac0fcbf4306c15"
+    },
+    "gfx/conchars.png": {
+     "bytes": 14283,
+     "sha256": "1b63b3d252a0d234553153910c6d5384de0bbe050f095ebe00d253ffab2db8b9"
+    },
+    "gfx/conchars.tga": {
+     "bytes": 65580,
+     "sha256": "6dbfcc084e12e7c053c49f257f0a2276014a46ee92d194008893a39416e9e486"
+    },
+    "gfx/env/adgreenskybk.tga": {
+     "bytes": 1520289,
+     "sha256": "6a7fa2cdc97237658a3f2c73a8a5d879feadf4a31e84fb8585aeba96f3f8fb61"
+    },
+    "gfx/env/adgreenskydn.tga": {
+     "bytes": 1565620,
+     "sha256": "d4fabe617a431169df1bbc37e48404fc34718a1bbf5a1ee45d5b3a0ddda5cc6c"
+    },
+    "gfx/env/adgreenskyft.tga": {
+     "bytes": 1704063,
+     "sha256": "c6cfbbd8b09846eaea719a5e65744cdd4fddced0c277f4584c743f2639882d50"
+    },
+    "gfx/env/adgreenskylf.tga": {
+     "bytes": 1576943,
+     "sha256": "c83f24917ccb67af83602236d03e57096f73b36b7fc64da6206afe989944b4a4"
+    },
+    "gfx/env/adgreenskyrt.tga": {
+     "bytes": 1706213,
+     "sha256": "7b85287d2ce5e4d3a9ce63a560183086e812ceca9232d07eb61f63a24d678e10"
+    },
+    "gfx/env/adgreenskyup.tga": {
+     "bytes": 1798684,
+     "sha256": "703e4449b5b9ff967610dbc81d7e27c089788927d82fdb31267490cfb30ed0e3"
+    },
+    "gfx/env/asap_bk.tga": {
+     "bytes": 786476,
+     "sha256": "9f6daf48061bdc132ec28062c494d4a6abe2eeda2c86b575ac7df472a97b2c80"
+    },
+    "gfx/env/asap_dn.tga": {
+     "bytes": 786476,
+     "sha256": "a8aa31d47f7537150c1023713588b87cceff0072036ea64c895129fccfd9fa9a"
+    },
+    "gfx/env/asap_ft.tga": {
+     "bytes": 786476,
+     "sha256": "067cca994d96dcc95903ea1d3c023c479d66a655b2d3412116d462dff4e155d7"
+    },
+    "gfx/env/asap_lf.tga": {
+     "bytes": 786476,
+     "sha256": "761640856a2500019db4c3fae214fe2043fbc0edffa3e6c508d964a86b98ecf5"
+    },
+    "gfx/env/asap_rt.tga": {
+     "bytes": 786476,
+     "sha256": "08d03cf9826300c6d283028f60663f5bd3f6564a7deb5e15078440e18e1433cb"
+    },
+    "gfx/env/asap_up.tga": {
+     "bytes": 786476,
+     "sha256": "d98b750d0908addc2b0c9d513bc0bfc5d28935c9536f437cfcc3796fc0f5ce82"
+    },
+    "gfx/env/black_bk.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_dn.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_ft.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_lf.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_rt.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_up.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/interstellar_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "861352b7f4dc030af28b483d09ad88b4cbb7b8e23e5cd3cf512d2feae9640b22"
+    },
+    "gfx/env/interstellar_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "b16b2e272b7e74513f6a1961d68270dd82fa0667d6ea267a2d22c45a2bdc2fcc"
+    },
+    "gfx/env/interstellar_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "11730f0982cbadc7691ea38e57510b2b7e77484e108d591aece8f970cfdca08f"
+    },
+    "gfx/env/interstellar_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "5bf0a5999e7ea85e68291ab7b36d7f6be5104f8932a2fe46d257484e84dab4fc"
+    },
+    "gfx/env/interstellar_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "051204c9fb8a430c17fb337d84132e0d7058b88f070e457278be99d78a73e5c2"
+    },
+    "gfx/env/interstellar_up.tga": {
+     "bytes": 3145772,
+     "sha256": "d8b19a66cb5dad2f34c9059860ac24a8632ba5575ac06ca3076d57a70c47b5b0"
+    },
+    "gfx/env/l_swampn_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b83c2aeccb2ec2b6a7e7de05e4eb1f120437c575769b93533708093be6d7acb"
+    },
+    "gfx/env/l_swampn_dn.tga": {
+     "bytes": 3146268,
+     "sha256": "64ea5b085c2758138760da154c77e3c90eb0831c68e75bac4c03cd03ae2e28c1"
+    },
+    "gfx/env/l_swampn_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "f8149a22f17e241f3cc50ddc2587b3d8d6e72bb26f7a47d5045b08ed436863af"
+    },
+    "gfx/env/l_swampn_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "fdf2a49932e8ee9c06b9a50fa6dcff3d29bdde55aa209d1658346cf236ca1dd8"
+    },
+    "gfx/env/l_swampn_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "a2c65a9eafab955cfe898aa28e3563714354a08725068df84f390eebfc6ca20d"
+    },
+    "gfx/env/l_swampn_up.tga": {
+     "bytes": 3146269,
+     "sha256": "aa5c65d4c106b17e695629023db1e6b304ec5b4f15e646a1a94b38c47ef9017e"
+    },
+    "gfx/env/moonhigh_bk.tga": {
+     "bytes": 1048620,
+     "sha256": "5f361bf5a352c1df5a6caef9cf42bd35fed8406c6949af480b0425c193c18b3a"
+    },
+    "gfx/env/moonhigh_dn.tga": {
+     "bytes": 1048620,
+     "sha256": "02e2b36863c1181a85aa675c53fc14a301f38dc6e0c6735098bb6d8723af02b3"
+    },
+    "gfx/env/moonhigh_ft.tga": {
+     "bytes": 1048620,
+     "sha256": "3158735bdd6f4f467a5b29639aa4f622d1136ea463967684b739b0002bec6526"
+    },
+    "gfx/env/moonhigh_lf.tga": {
+     "bytes": 1048620,
+     "sha256": "5cdaabd99655152689e40832643690d7b1c5f8e414f3126a7c0c9224f2250704"
+    },
+    "gfx/env/moonhigh_rt.tga": {
+     "bytes": 1048620,
+     "sha256": "e08a374ac19c8b8cffa6c939515cde9570b44bbc044c12d06b0c5d94aa7469bc"
+    },
+    "gfx/env/moonhigh_up.tga": {
+     "bytes": 1048620,
+     "sha256": "c0465fd6a0b069e5ff78f3e561084bf3e23b796cac9b5214a6cd4045310d36fe"
+    },
+    "gfx/env/moonrise_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b4e85116e3999d5cded25ca0a5d6fb9c297b3d69749a63daf5af6c37fe21959"
+    },
+    "gfx/env/moonrise_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a7be41496d25bc9e505b959b08a950c1bb61acc6c8c44ec4e1dd428faeac4ccd"
+    },
+    "gfx/env/moonrise_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "7381c46aa4f5c916f3bc8f82a442a4582834563c0bb0127580053bb274609180"
+    },
+    "gfx/env/moonrise_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "871df5eed200970b8c3246ca10a039f5915c95e8f48bf0692fc22f2f7e5450cd"
+    },
+    "gfx/env/moonrise_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "2cc00bb935ee2f4019f4d99170d38ef3f51c72ff80150cd74911b1038a0cb269"
+    },
+    "gfx/env/moonrise_up.tga": {
+     "bytes": 3145772,
+     "sha256": "0296084074d726170fdc85d2c1176ee64845b6805c174c08aaa63f514fd9cb65"
+    },
+    "gfx/env/snowmoon_bk.tga": {
+     "bytes": 707878,
+     "sha256": "f4c61c3a622a2dabfc2aa2748c3bba9ab52bf018c5c24b5aac6bd682b6d938de"
+    },
+    "gfx/env/snowmoon_dn.tga": {
+     "bytes": 754863,
+     "sha256": "a6f29123dc3da6df244c6878d1a355b9ba7c093b9a38b94e8f9253d317de846c"
+    },
+    "gfx/env/snowmoon_ft.tga": {
+     "bytes": 630095,
+     "sha256": "c10f65b43cff087a7044946f8105d24072bbcb33668bb485f501fc0bdcb7e293"
+    },
+    "gfx/env/snowmoon_lf.tga": {
+     "bytes": 671066,
+     "sha256": "8025d6d72582a374583dc4c80d15de546b1ebea3f378cc55b084483778d8f985"
+    },
+    "gfx/env/snowmoon_rt.tga": {
+     "bytes": 636559,
+     "sha256": "339a1a1a36ffafa6bb49ae5bffcb73c81d4304f0f6d40d5fe470654c0db56037"
+    },
+    "gfx/env/snowmoon_up.tga": {
+     "bytes": 410341,
+     "sha256": "f08c76ef2c7c2338b64615543ffa1217edab3ca41bc79cb74b20bc42d329e82c"
+    },
+    "gfx/env/stormydays_bk.tga": {
+     "bytes": 786971,
+     "sha256": "d82eac0c4f574d74ff5fee6ececd1d5f0b1bd94c349cb7c9af30d3ce79bf6b2e"
+    },
+    "gfx/env/stormydays_dn.tga": {
+     "bytes": 786971,
+     "sha256": "915f33dcae63765c49252b65a58f9d4359c7a36ea99352a013e58e660b71f160"
+    },
+    "gfx/env/stormydays_ft.tga": {
+     "bytes": 786971,
+     "sha256": "4906e45ebc2760dad5faf2e6f8a0be7c280bf7525a96364376155f3d001fba99"
+    },
+    "gfx/env/stormydays_lf.tga": {
+     "bytes": 786971,
+     "sha256": "d7cc6cbaa37481b3902673d717aae7f31e0170e2226a4efe88811f6bac3f8ca6"
+    },
+    "gfx/env/stormydays_rt.tga": {
+     "bytes": 786971,
+     "sha256": "ab40bc26b750a421c95948e7f215d51e831163fd478841c30f685a2b006b8c3c"
+    },
+    "gfx/env/stormydays_up.tga": {
+     "bytes": 786971,
+     "sha256": "8ff85257da02eb361ab8127e4425b9177842f17016724beb5c3058ae460aa52b"
+    },
+    "gfx/env/violent180_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "cf1d0a870b38e4889ad4ce18f22bf894771a8c91477c0338e837880df061db31"
+    },
+    "gfx/env/violent180_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a3b344abf47fae67c831aaa8d8b2ab7ff56ff1ed93091c6869139902060777ff"
+    },
+    "gfx/env/violent180_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "964ce0226b139a1af96de0c422e927d35917ad30f0c4027c1c386c7c32cc30db"
+    },
+    "gfx/env/violent180_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "b9cc1ef464535f9a911d56fb503a2e1aa68e6d07c7091cb62c42442a7d62ceaa"
+    },
+    "gfx/env/violent180_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "263af4a0d5b2e61303d8165d6b8a8b7e55d0c8dd79157ff133a5d50128d5f21b"
+    },
+    "gfx/env/violent180_up.tga": {
+     "bytes": 3145772,
+     "sha256": "3a9aae357ac1a8e8767e151024dab60845283422f204a354913282873f181413"
+    },
+    "gfx/env/voidsmoke_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "d274189cd63786e9d86fbd3cafda0cbfd054ccd527e30aeec921a8d6f10866a7"
+    },
+    "gfx/env/voidsmoke_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "47392d93a23946a28533cf759d6aea245a2647d58bf153d2845ac0899ab8d400"
+    },
+    "gfx/env/voidsmoke_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "ced1991fffdc46e2bf156e1d89e06e1362e0e394808b74bc7aa40e6d90fde55d"
+    },
+    "gfx/env/voidsmoke_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "4d1b843a9fc61c4125262a9a95fc084cea61eb4b125288f7a7cd0c2f2e53f4ab"
+    },
+    "gfx/env/voidsmoke_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "389ae84f29901e349a266d707f62beab9de3eb607b901bcb4245028b8edaa3b1"
+    },
+    "gfx/env/voidsmoke_up.tga": {
+     "bytes": 3145772,
+     "sha256": "138e9386728cdd98935a0c484d5693db2e60375d8d770ad754fe6616906591a1"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "a878796ad2dbab6a64e1eba47605d124170d5b4a7ce476b9d0087c2e302c00f1"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "381ec91a75cacad94d2a4d5a3b1cd6f9b22cce507fe95f980ebaabdb21bbe440"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9e9568b56059e74e621ad564b51cb0b886fcf800fd8d35a06df1aa79ac2aa823"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "52164e93b333dfe09a33d7ad1905796d7e7578a036b2fb2ddf35c4bf3381f30f"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "240a13f778cc7ec7ebbc67b23a977a54099e1996fd868f51c18f81aa3606d179"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "fae9345c9eeb43a56a14e9e681f9e9dadc05ba6e35f44197fca5873dbd52904b"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3272,
+     "sha256": "ba61bec9eaf837bddef9a1320c0acfe026a130bc078836abf971095157ee395f"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "fc226280c4948249790f00f97dd9b39e912131fc904ec75adb90308ba8763afc"
+    },
+    "gfx/mainmenu2.lmp": {
+     "bytes": 30728,
+     "sha256": "a3fd168c6454eeaeea9e248df568e5942a7f850bc5478f8946a0b6516a2ce6c4"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 6920,
+     "sha256": "5a84111e70bf277960853bca69a0dff9093d00d817ffab6fed96f33751435ae6"
+    },
+    "gfx/p_mod.lmp": {
+     "bytes": 6920,
+     "sha256": "3080226ebf497787e7ee1d7bc2917ae220340b7da4af58ff1a0f89f02b5c03d0"
+    },
+    "gfx/p_mod_idver.lmp": {
+     "bytes": 2504,
+     "sha256": "56234ed3e4e4fe95f8a4a1f9a52d4a73890ea653aa88ec992e6777bf3e99b445"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 6728,
+     "sha256": "493a3ae8e9553de87c49d356e916adab7c87e3b25a44c1d1ac46e37de4df800b"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 6728,
+     "sha256": "d79623e26bed9db65257e3c0bf43b085d2419fc6e5277ff357350556882456d9"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 6920,
+     "sha256": "f51c8bd49d699f08322b734f281d7e626c24844aec09099877fbceb1884cb705"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3272,
+     "sha256": "788da2d0f96ed9f0822fff406f364a912179e33f6f4d068aa7b772f2747cbc85"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "f8ee0991ff6faaef3b4d2230364776effe6a1d4b47588b98e39c1d0b4199fd9c"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "a6ccb48f7e1d00ec64e5154a0a47b433f017341b8e23ba4f7f7fef6fe9a27b3a"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 6920,
+     "sha256": "bce2792bc38f1f097336ebdedff2029b21f4cebc523684738f7e10e086d33661"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 6728,
+     "sha256": "904d617b5b97aa6b1631e7b5dfab9b4092c488fefd94ec093c98595b38789b7d"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 6728,
+     "sha256": "5eeeea42e3f429aae7f907145b88376805346ebe3ce932259bdfc43399f960ff"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 4808,
+     "sha256": "5ae8a3fd789e7ddf6d7791ee89cb79ef989cb000c086e9269349aa623f1f6438"
+    },
+    "music/track180.mp3": {
+     "bytes": 9774601,
+     "sha256": "2e3f447c7e7f0b7a02013e8259cc72bc035f8689686cfa1c301591cc34dbe4e8"
+    },
+    "music/track180.ogg": {
+     "bytes": 5092750,
+     "sha256": "1b48947672b05ebb5755d97122f28c0598a5fefe724d8b4cc3301497aba94f81"
+    },
+    "music/track35.wav": {
+     "bytes": 353002,
+     "sha256": "9b006ae5f5b2ae5c2ad84062d9bc288cee744e63301721838d70bec434178b95"
+    },
+    "my_progs/ai_ammoresist.qc": {
+     "bytes": 7444,
+     "sha256": "d530fec92f23ed0c3d09560abb9a89bdc160ce1aefdfbe4f4771f9897ae3fc4d"
+    },
+    "my_progs/ai_checkattack.qc": {
+     "bytes": 106456,
+     "sha256": "7971ca5a87666c89b56ab0fcc102e6f551f3cd3b03bdfc0bfb73f5f8d5aed7fb"
+    },
+    "my_progs/ai_combat.qc": {
+     "bytes": 24318,
+     "sha256": "a8cc4b28f82babe8ef8fc627a3c16efb25775ea736d3ee99709ed675196c2d66"
+    },
+    "my_progs/ai_enemytarget.qc": {
+     "bytes": 8409,
+     "sha256": "f4b0a35306d50e71fd9043ae949a421158ee9fcc4e311baf7b8fa2d345c4d46e"
+    },
+    "my_progs/ai_explosion.qc": {
+     "bytes": 12162,
+     "sha256": "7df941a7cf93b814ae9d90f646a5b0243a51db67872f621df73d43c6000ba3ab"
+    },
+    "my_progs/ai_gibs.qc": {
+     "bytes": 32373,
+     "sha256": "65e202300882ba8f0c980f65820b2d2e0bd06846073168f4bd7e37f2357f47d4"
+    },
+    "my_progs/ai_hazards.qc": {
+     "bytes": 26832,
+     "sha256": "81aace80121408f64369bc2bbfd5654650276ddd75217333d2a52364415acaa5"
+    },
+    "my_progs/ai_minions.qc": {
+     "bytes": 10236,
+     "sha256": "3e7bd34dfe0e73a11e6907d5ac69cb609eee19dff533689ea7c8eabe52500136"
+    },
+    "my_progs/ai_passive.qc": {
+     "bytes": 8224,
+     "sha256": "44473544d0da0dc778c2800a16172ab49b548286b604c9d6361f4bc4cfc1f076"
+    },
+    "my_progs/ai_pathcorner.qc": {
+     "bytes": 20921,
+     "sha256": "b3d6ed2434e0b995da51a71715647096e36e02d8cf920e18e024f920ed69238a"
+    },
+    "my_progs/ai_projectiles.qc": {
+     "bytes": 86235,
+     "sha256": "b28c04e84c97febe9e5a8e921a8e230755f9641d4bf5d74b4a59caaaa247dfc8"
+    },
+    "my_progs/ai_states.qc": {
+     "bytes": 7480,
+     "sha256": "76fae861132b0e50006ef88ea94a953e718b661defad2ea58a4ecad5cab92dee"
+    },
+    "my_progs/ai_subs.qc": {
+     "bytes": 50952,
+     "sha256": "9d2e356f0dba7842956ceb4e766fff9da25dc72a0b408baa3e19c4a146cbafdf"
+    },
+    "my_progs/ai_tether.qc": {
+     "bytes": 6470,
+     "sha256": "2229c0ea1b76e45f5707a3eca9e7626e33f8ea91d6b292da63c81723e1ae8521"
+    },
+    "my_progs/breakable.qc": {
+     "bytes": 79687,
+     "sha256": "754831599eec85a774501d9fd0a1ec7d5722ea6a6e01655b5ad74988145045af"
+    },
+    "my_progs/chaosmode.qc": {
+     "bytes": 81481,
+     "sha256": "01561dc4f1949716eba4d08f83efe27b71add80f923c1e2d89194c238772a646"
+    },
+    "my_progs/client.qc": {
+     "bytes": 70441,
+     "sha256": "00e2d4aff96ea28b0532ab0b03de0a8cdcf15750164ec82bdc8f43b9f2347447"
+    },
+    "my_progs/client_advinfo.qc": {
+     "bytes": 59677,
+     "sha256": "87aaca8bfd15935e1cd29a807bf77a2779d95418af631a6b456c6605710694fe"
+    },
+    "my_progs/client_camera.qc": {
+     "bytes": 13007,
+     "sha256": "ff4748b04c15d9a3b44dd8069f9347c12487ef353d5401a13542166576097889"
+    },
+    "my_progs/client_cshift.qc": {
+     "bytes": 725,
+     "sha256": "da1e321fe01bae486ffcdd987a942a4b0d5b2f603efb663d52c55e882f129685"
+    },
+    "my_progs/client_debuff.qc": {
+     "bytes": 15761,
+     "sha256": "0e0c9123697241ab3a366dbc46fcb90b8553b65c94cffe1442254a74a2753efd"
+    },
+    "my_progs/client_evilmode.qc": {
+     "bytes": 6982,
+     "sha256": "2cfa3bbeb36ab623c3bb137028ec5f549a2e5d2198fa2ab7fd8a445e14f4fc10"
+    },
+    "my_progs/client_ghook.qc": {
+     "bytes": 51884,
+     "sha256": "43d071195a70caa66b57cca1778679d772478fd1f71cbad7ee267e254e79a29a"
+    },
+    "my_progs/client_info.qc": {
+     "bytes": 13693,
+     "sha256": "55653ddc2b9f3cf2ca3cf1b0afdc4c1685baf1ab3c3830eb9f8b1b2d51b3ff31"
+    },
+    "my_progs/client_mapvar.qc": {
+     "bytes": 13177,
+     "sha256": "c692fa41644e6d21c945493dd891af945a072a4b39e687d1b59c86d14ee804a0"
+    },
+    "my_progs/client_power.qc": {
+     "bytes": 20026,
+     "sha256": "68457e8f99d3967babe95d4db3539388e95d294fa65a6190773e75951fed9ef9"
+    },
+    "my_progs/csqc_defs.qc": {
+     "bytes": 21072,
+     "sha256": "eddc5f194845e78a1633807d32b1da4425bdbe7bcce193e3868bc3995e2dee9b"
+    },
+    "my_progs/csqc_defsclient.qc": {
+     "bytes": 35002,
+     "sha256": "b6674acae135dfbc5e3dbb147e69acdc6b3564b766792359bed3e4eb800705e9"
+    },
+    "my_progs/csqc_hudad.qc": {
+     "bytes": 104391,
+     "sha256": "1ca012e489dc5f6026bdae469f411b5bb25afa00e00d5169cbd35b578a7ad9f2"
+    },
+    "my_progs/csqc_hudvanilla.qc": {
+     "bytes": 37074,
+     "sha256": "c5caa6ba176185c05903d383f3ae41907129d859419a0c0bf909b0e8d3e8af5a"
+    },
+    "my_progs/csqc_progs.src": {
+     "bytes": 113,
+     "sha256": "e383fc0920e9676d92e0be81d69cd8017ed5baf9fc0616a05773de68208ce434"
+    },
+    "my_progs/defs.qc": {
+     "bytes": 31974,
+     "sha256": "1534874cf4d70c5614dedecb70f6d428fc32832ce3345c2cb51fd6058a514902"
+    },
+    "my_progs/defsclass.qc": {
+     "bytes": 24401,
+     "sha256": "811c390be7b31fd4b276410ef1a75406bbca8fb84dc195484835a6100e9cddb4"
+    },
+    "my_progs/defscustom.qc": {
+     "bytes": 95914,
+     "sha256": "180ebe8c3fbbd4f78815c94d62f6ac0ad0c3cefe427664fdf4685adcf2c8a699"
+    },
+    "my_progs/dpextensions.qc": {
+     "bytes": 122912,
+     "sha256": "3758f58ebaa4186e9112da89f7ea53087eef5058a32ebc373a1ffda76c1d67a2"
+    },
+    "my_progs/estate.qc": {
+     "bytes": 7745,
+     "sha256": "9cceb71ae54b331c2702f5580094f9055d007b9e710dd5e61c7c632724022626"
+    },
+    "my_progs/fteextensions.qc": {
+     "bytes": 215531,
+     "sha256": "beb86ad10bb0726de10dd2557d6285f7bf40f08f9d30e06315c3772f8c256571"
+    },
+    "my_progs/func.qc": {
+     "bytes": 47039,
+     "sha256": "81cd56475c6c34a744d84c2b223e66dd1c83a1b525b4c42f3389d4ff4cca5601"
+    },
+    "my_progs/func_buttons.qc": {
+     "bytes": 13271,
+     "sha256": "9e1bd197b2367ab2b8f1c776c214a0c51120559e8d8f0b4888b262b7a1e746f0"
+    },
+    "my_progs/func_doors.qc": {
+     "bytes": 35874,
+     "sha256": "58dbdf05f0044aefdd13ee21d17045a681d255efaca6d129fbd1cec4ae516fc9"
+    },
+    "my_progs/func_doorsecret.qc": {
+     "bytes": 14379,
+     "sha256": "769a3142ccaf18060ff77b0eab57d901585202fbfe63a54ce25d4987b80f92d3"
+    },
+    "my_progs/func_insvolume.qc": {
+     "bytes": 10573,
+     "sha256": "1deaf4623a6fae80585d2d2b1978b1cd217b6f8a683ef3bbc3a77a2897e9a207"
+    },
+    "my_progs/func_plats.qc": {
+     "bytes": 11685,
+     "sha256": "5086c9aba8bbf83d29c3e1897c7867cb24220712007044792928f474216b7ea4"
+    },
+    "my_progs/func_pswitch.qc": {
+     "bytes": 8373,
+     "sha256": "b3a205176d80801216a930241508b3c5718f4be9e1b947932ace2851c34271d8"
+    },
+    "my_progs/func_trains.qc": {
+     "bytes": 26553,
+     "sha256": "81d8de4f3dff80b8523584fb5e37d8d4812a6f7f95a559edff320682217ad123"
+    },
+    "my_progs/globalfog.qc": {
+     "bytes": 18397,
+     "sha256": "84ec244a475ac41b9da772042123f58f4005130590f170f85f1b23ad53629f27"
+    },
+    "my_progs/hiprot.qc": {
+     "bytes": 31978,
+     "sha256": "82875db9fecd8bacd2c42232fb980e6a510a6863103273e2c9078dfe7c6759c5"
+    },
+    "my_progs/hipspawn.qc": {
+     "bytes": 2752,
+     "sha256": "6df8450b85821c1a76f5ccb3c807ac9b94e92f413f16f2ba618f922abf85148f"
+    },
+    "my_progs/items.qc": {
+     "bytes": 164855,
+     "sha256": "ffa38fa915821151c7dbfae3507bf804052db0f5c13eecac462400680cabcf3e"
+    },
+    "my_progs/items_progspn.qc": {
+     "bytes": 20628,
+     "sha256": "2f4824cb28192145a8fabc2da6575db3398e8f81522ab1e026d696ec87313650"
+    },
+    "my_progs/lights.qc": {
+     "bytes": 43912,
+     "sha256": "d0e0c373bb3cc68c7c9121a62c68085ff9cc290daa6faf0adab02323d8ef92bb"
+    },
+    "my_progs/mathlib.qc": {
+     "bytes": 22355,
+     "sha256": "b161ebb89a11f302427c4f124731ec38def8eb01347beb5d748a9ba4afb886f8"
+    },
+    "my_progs/misc.qc": {
+     "bytes": 85890,
+     "sha256": "6b3e8a0882d47f16ff7f54fb37a48e3a7853647f8895718e6428739c4207099a"
+    },
+    "my_progs/misc_camera.qc": {
+     "bytes": 43852,
+     "sha256": "61448a8f0354f39dd26371ae56dadbc903b08282293145a27088ac6c151ea547"
+    },
+    "my_progs/misc_model.qc": {
+     "bytes": 31793,
+     "sha256": "04774e0bab5cb0ccc5bd01e36ae7d6f449248484d0cb203eb435fb267cc8bdda"
+    },
+    "my_progs/misc_targetdummy.qc": {
+     "bytes": 15123,
+     "sha256": "bcd0a0ae806ce20a8c8cfcc27178ce1b4ead3a546d927b6a261ce51a6086c253"
+    },
+    "my_progs/misc_textbook.qc": {
+     "bytes": 26321,
+     "sha256": "14bf42536a5cc75990d938a79d7bd21bde1c166245d94d8e662f9e6fd66e0ae8"
+    },
+    "my_progs/mon_baron.qc": {
+     "bytes": 31318,
+     "sha256": "b76a10da34dabf3411ddf650abcdbc77e3ebcdfebace6191a39e7c0b13a0fad5"
+    },
+    "my_progs/mon_boil.qc": {
+     "bytes": 19821,
+     "sha256": "050b21bda5341a3f81dcb21e6d7d82d458a415fd8f1cfa12435228246229a323"
+    },
+    "my_progs/mon_bossboglord.qc": {
+     "bytes": 24005,
+     "sha256": "e67081b7a5218b361c62bf4b201a18db16f3e75716ad2729c11a0616b137975a"
+    },
+    "my_progs/mon_bosseidolon.qc": {
+     "bytes": 40134,
+     "sha256": "c51eb9b9d67cadfa7178891a238329a60ad57edc3f6ef645060695b451833115"
+    },
+    "my_progs/mon_bossfiretop.qc": {
+     "bytes": 14734,
+     "sha256": "26672c9c2d1577f8caf9894b8eb5eecacac89f64251257bc25db48b1bf43a7bb"
+    },
+    "my_progs/mon_bossicegolem.qc": {
+     "bytes": 47205,
+     "sha256": "5b888302a6af24ce823919d1349c1c92e1ee709d72e79042425349368a4d65fb"
+    },
+    "my_progs/mon_bossidchthon.qc": {
+     "bytes": 20247,
+     "sha256": "65d955fb1434f806962fadc088aa5933e96ed8aa9f1211d0709a3f462ffa3027"
+    },
+    "my_progs/mon_bossidshub.qc": {
+     "bytes": 14639,
+     "sha256": "fdd0e8f8fa374ea0164f79ef1bf74ca942f04c63159f360c7a43011673774fe6"
+    },
+    "my_progs/mon_bossjudicator.qc": {
+     "bytes": 81432,
+     "sha256": "f5092f376eeef22f0a552c846f50175680c15a5c37d9603c6e3d2635661127b3"
+    },
+    "my_progs/mon_bossmammoth.qc": {
+     "bytes": 84963,
+     "sha256": "6cda415b846b2aeb215c0eebc7cdfa6a5560255df9aa014f77b48aa7073b8d34"
+    },
+    "my_progs/mon_bossnour.qc": {
+     "bytes": 45558,
+     "sha256": "def8a1a46f3a266028df3d1a0b7c31a9ad98450f6601e176495f11d929041452"
+    },
+    "my_progs/mon_bossxxchthon.qc": {
+     "bytes": 22614,
+     "sha256": "2c1c0446b0f6a5b7a7921e8f8830c71c174d30c6f176d228a94afd9a05fdc25a"
+    },
+    "my_progs/mon_bossxxshub.qc": {
+     "bytes": 19006,
+     "sha256": "043ebc852ba7f0a06812cb0afd72d32a3da643df1dea45c87fb821f60fbcc332"
+    },
+    "my_progs/mon_centurion.qc": {
+     "bytes": 13734,
+     "sha256": "641e1c09c6df27b033e331140d242f25d27bf7f9bb83733a6b5b3469a5c7ffee"
+    },
+    "my_progs/mon_dcrossbow.qc": {
+     "bytes": 38069,
+     "sha256": "3296618a4b803fb6f1b44c1d32c17692a5bed13cf63102c6dcc58481223197a8"
+    },
+    "my_progs/mon_deflector.qc": {
+     "bytes": 32107,
+     "sha256": "d7a9344878a3a846a7e720ce704820d424362281a1675c40be7b670eca9fe342"
+    },
+    "my_progs/mon_demon.qc": {
+     "bytes": 14601,
+     "sha256": "d77f128e3f91737228c5a24b7ca146f6b4f8e87dbaac31b1ad4e79779884d0d7"
+    },
+    "my_progs/mon_dfury.qc": {
+     "bytes": 39867,
+     "sha256": "a016db202f2a418aee50cb7cce2155a24a6b807e8c98fc49a5f9273ce79c6da8"
+    },
+    "my_progs/mon_dguard.qc": {
+     "bytes": 28414,
+     "sha256": "0a2b964034559f4ca772f9f29be2c56684fd39290277046a6f7642ba934836eb"
+    },
+    "my_progs/mon_dguardquoth.qc": {
+     "bytes": 18932,
+     "sha256": "4caeb17520104cba42476ff7757f38ba6d72e941674b851f55a5c9780ce4de17"
+    },
+    "my_progs/mon_dknight.qc": {
+     "bytes": 36867,
+     "sha256": "68008427374e9ab670b6ad915c7a0f8eaf6a6699efa927a3748ae6cde86458e6"
+    },
+    "my_progs/mon_dlord.qc": {
+     "bytes": 22859,
+     "sha256": "09ca1edd4e65a166a66ba17e682aae9a1be09b05371a72dd1bc447389693bfa5"
+    },
+    "my_progs/mon_dog.qc": {
+     "bytes": 18431,
+     "sha256": "1b345447176aec54f18c31f5da215e80cb2de19f51d353c63a98507d881c2a9b"
+    },
+    "my_progs/mon_dprince.qc": {
+     "bytes": 33590,
+     "sha256": "5114caa7b6152e562e548096e41da68f43c910a5016ddaed408272a97a8320c1"
+    },
+    "my_progs/mon_drole.qc": {
+     "bytes": 25472,
+     "sha256": "36a510e910ce4ffa26d2d2ad336872c07537077ea920132a4cfd63d9133fb6af"
+    },
+    "my_progs/mon_dsergeant.qc": {
+     "bytes": 33493,
+     "sha256": "ada0cc4359a863c4e8d433c605a1c04ec6f7fd17ec852f5c4847443d3adaff1d"
+    },
+    "my_progs/mon_eel.qc": {
+     "bytes": 8252,
+     "sha256": "15c1f2fedba7077d352595e1be4a90f764354e4cf1875b40e1685d3ce81feb54"
+    },
+    "my_progs/mon_enforcer.qc": {
+     "bytes": 20146,
+     "sha256": "d453651d488afa789d0cea87ce99d9684329bbabdd17aa1625591f5a4b4ac90b"
+    },
+    "my_progs/mon_fish.qc": {
+     "bytes": 9705,
+     "sha256": "ff7d84db2c7917861ff5d81fe0e28f69d51143d27c4fba90dfcda11057222df0"
+    },
+    "my_progs/mon_floyd.qc": {
+     "bytes": 20332,
+     "sha256": "3ac2f0b0be94e311ff2fc4eee9cf66d5987af0e5c25fc06b8cc7b9efa6f581df"
+    },
+    "my_progs/mon_freddie.qc": {
+     "bytes": 25384,
+     "sha256": "4409a33e819f125852d0a4ada21a8fed2713012daec00922446f313031c845d1"
+    },
+    "my_progs/mon_gargoyle.qc": {
+     "bytes": 24293,
+     "sha256": "9e1f78b2364024efa6ec4142c1ecf4aff52cdf32f38031c34cf19e9cd74143d6"
+    },
+    "my_progs/mon_gaunt.qc": {
+     "bytes": 24111,
+     "sha256": "45be98ae0bdd32e0884280e18f867af037f2fcbf515914827c5f9107a87e52d7"
+    },
+    "my_progs/mon_golem.qc": {
+     "bytes": 35297,
+     "sha256": "dbaf3d1c0fec3166b0eb064a3c027dd3a0c907bed72b8e4581ffd74dad5ab5d1"
+    },
+    "my_progs/mon_hknight.qc": {
+     "bytes": 37618,
+     "sha256": "bac7d4b7832b95cea0f6890de66fbd0f7c4fcc7ce9051ef16ac042de465ddcb3"
+    },
+    "my_progs/mon_hogre.qc": {
+     "bytes": 24021,
+     "sha256": "8781ea9aaaa1d0f7ffb1fd8ec8b5981187eee6fdb8193160a1eb38770dffcfe0"
+    },
+    "my_progs/mon_hogreham.qc": {
+     "bytes": 23076,
+     "sha256": "b2ab6b830ce3aae7d6b033e8455de5011ded82e451ca171ea09940d9a3ec7740"
+    },
+    "my_progs/mon_hogremac.qc": {
+     "bytes": 23941,
+     "sha256": "9111c040ab1e5487936cce6ef1170e408c6d297d582702d202bbd27b0919d843"
+    },
+    "my_progs/mon_invsword.qc": {
+     "bytes": 9214,
+     "sha256": "f7287867cc6043eb7cd3fa3e1ecd5ae7115a84e5ef7021b2d5129afdb6ba6f46"
+    },
+    "my_progs/mon_jim.qc": {
+     "bytes": 22091,
+     "sha256": "55353984ad822dfd8c32f3b8ad9a06e8bfaab7bc5ff6f2a2326674ad4acd26be"
+    },
+    "my_progs/mon_knight.qc": {
+     "bytes": 24772,
+     "sha256": "d254abf88162436b9db48885ae8e59315c24c1e7f72a91d027a1d69fe9baf5b7"
+    },
+    "my_progs/mon_lostsoul.qc": {
+     "bytes": 23261,
+     "sha256": "2cdbf656c6b34164711fa88016542f4e3d2bd0555417ad00bab5ca7039f212ef"
+    },
+    "my_progs/mon_minotaur.qc": {
+     "bytes": 35316,
+     "sha256": "fbcef276ee3e2f1eeea8483303538190875e959b43efbf4f703be10fc72fc564"
+    },
+    "my_progs/mon_ogre.qc": {
+     "bytes": 24123,
+     "sha256": "d287d3b9024025237dbc68380f486572828a5114f9543599ba86b8bc35e9e25e"
+    },
+    "my_progs/mon_ogrextra.qc": {
+     "bytes": 9387,
+     "sha256": "41a9243c6006326195197a4dfba6ea4c1f1fbd729ec10adc48cfd7badd7a18de"
+    },
+    "my_progs/mon_pyro.qc": {
+     "bytes": 18235,
+     "sha256": "bd35f02c63af315ddf4820e388d0248cf065f1170bd7306957a1e86fa7e47306"
+    },
+    "my_progs/mon_scorpion.qc": {
+     "bytes": 22136,
+     "sha256": "0432d7c5e1b6a30a5452aba12b9fb6a3c2c7f3c582b1392d420414e66b8fb257"
+    },
+    "my_progs/mon_seeker.qc": {
+     "bytes": 29703,
+     "sha256": "d33939357840eedbfc63c56d6415d8fefd21de2c477b24b3165cdadcca2acd2c"
+    },
+    "my_progs/mon_sentinel.qc": {
+     "bytes": 10217,
+     "sha256": "946232c7169bf3fa966ce875523dd45402772f8045c51a96dced04f2f5f5788f"
+    },
+    "my_progs/mon_shalrath.qc": {
+     "bytes": 16434,
+     "sha256": "1b6fdf2447d7fa281d126118a9bc0e097de7b4dd4d10a33e60d5cf0ca785c58b"
+    },
+    "my_progs/mon_shambler.qc": {
+     "bytes": 23050,
+     "sha256": "576f71a38d75eedbdf58c291055674be8da5f0d04540e26311d65f70b58ee842"
+    },
+    "my_progs/mon_skullwiz.qc": {
+     "bytes": 36245,
+     "sha256": "6d3c2242bffe6eabe3f9cc59e881cb2296213cfbff809e1be045a80ca46aac53"
+    },
+    "my_progs/mon_soldier.qc": {
+     "bytes": 21645,
+     "sha256": "704c534062b11c4fc16416154c7706c125221660cdd4d9b02e00575b94c04103"
+    },
+    "my_progs/mon_spider.qc": {
+     "bytes": 30593,
+     "sha256": "4d0bbb7e38e51cef07912e6071e6bb9739e019a2d93129d38dbab9492bf43aee"
+    },
+    "my_progs/mon_steelclaw.qc": {
+     "bytes": 17126,
+     "sha256": "78dd4bb46dd76b2ff1f7d4a9f0b0902f25d94ebe13ace6b997a7f604c3718700"
+    },
+    "my_progs/mon_swampling.qc": {
+     "bytes": 25637,
+     "sha256": "fb5ed328cd3d5c09704bb84f39138463a7d26b8b1d45771e55e9ae952b1d2470"
+    },
+    "my_progs/mon_sweeper.qc": {
+     "bytes": 27025,
+     "sha256": "8f7a1d077779d88d542a325c1ae4ba4ff59d48bfcb334150ae3f024525bb725e"
+    },
+    "my_progs/mon_tarbaby.qc": {
+     "bytes": 11866,
+     "sha256": "88c9481ab7fe0cbe97d2b836492ff51b368aeae8d4ff3e5852734bb9f63a1b2d"
+    },
+    "my_progs/mon_turretbal.qc": {
+     "bytes": 38519,
+     "sha256": "fdcf915248dda5fb6a744d284233d46a2e6d62c8e4fd02fdd5bafe4f46167d30"
+    },
+    "my_progs/mon_voreling.qc": {
+     "bytes": 27678,
+     "sha256": "7734614fa6b2da2195bf3804415c06a2d10f35825e86abf4f85613a182cf21c2"
+    },
+    "my_progs/mon_wizard.qc": {
+     "bytes": 15155,
+     "sha256": "3101ca37b57343697b3d3c7637fdc84c842f78ec9081e401dcaa6df0a9b1df83"
+    },
+    "my_progs/mon_wraith.qc": {
+     "bytes": 35464,
+     "sha256": "6a28a205cb8ac574e98c8d34a01ea859922e38d55c66346a7aa867ebf84bdb5b"
+    },
+    "my_progs/mon_xmas_elf.qc": {
+     "bytes": 17589,
+     "sha256": "053eec412485090ee1ebeac25887382db40e2ba7ca456050ba4407be3ec8bc1a"
+    },
+    "my_progs/mon_xmas_raindeer.qc": {
+     "bytes": 12189,
+     "sha256": "abbe1dd5c96c25b631231d4db2f17e8243075ad08c082e0448b7cbff34f1ae0c"
+    },
+    "my_progs/mon_xmas_santa.qc": {
+     "bytes": 17853,
+     "sha256": "cc60c6de17bc3321f9b1cf75b3229e387592c9eb7fc4bb57c1de0a8d2c0e62e6"
+    },
+    "my_progs/mon_xmas_snowman.qc": {
+     "bytes": 11486,
+     "sha256": "65928bb70cb2e9352c2f5e036eda2a6bd97aea09d459d0af563a82aa5a2f2673"
+    },
+    "my_progs/mon_zombie.qc": {
+     "bytes": 33988,
+     "sha256": "83f56482374c3a79fcc64058989bd210af3add006b7388d89c92e90543ec56a0"
+    },
+    "my_progs/mon_zombiek.qc": {
+     "bytes": 42214,
+     "sha256": "2b9926454484e93f5c053bf4fd35b2a97cf7e835c26c3b30061f1ff391af9f5e"
+    },
+    "my_progs/monsters.qc": {
+     "bytes": 56573,
+     "sha256": "c2c75832e6d5e83e929214ba5c1aa9a4661bcaf7754c20b3e9648171bf804a58"
+    },
+    "my_progs/part_emitter.qc": {
+     "bytes": 82744,
+     "sha256": "fca7491171d58974ef6b15550b9a7f0474641e9eac7ee5de52c6980c96445518"
+    },
+    "my_progs/part_generate.qc": {
+     "bytes": 42914,
+     "sha256": "83b9718a85418143d92ea8311cc8cce69c1002eb7563710dfe7010ac52e15d50"
+    },
+    "my_progs/part_manage.qc": {
+     "bytes": 27407,
+     "sha256": "86eb791f4bba08fc0c965e9f81c90e7412ed2c910104d66a56cce1f3152808fe"
+    },
+    "my_progs/player.qc": {
+     "bytes": 27811,
+     "sha256": "1f0cc3eaf577c2af642495466c573cd6e226a4754902d9de9cbfc9c9ba28af0f"
+    },
+    "my_progs/progs.src": {
+     "bytes": 2482,
+     "sha256": "c773f107c562f731fbb30158422226bdc4576dd32aea0f02c122195e08eac96f"
+    },
+    "my_progs/pushable.qc": {
+     "bytes": 19823,
+     "sha256": "03b3bf9240db6e9532e45a3efc159129709f9ce095c3238daae32daddd5b07ec"
+    },
+    "my_progs/qc_highlight.xml": {
+     "bytes": 6348,
+     "sha256": "a7b326723cc1e4025e867ea5da00f54c944705600d740538aeb52f63cd027ab5"
+    },
+    "my_progs/settings.qc": {
+     "bytes": 61298,
+     "sha256": "7a1ae40ba7fa97ff7e7019017bc7640fd49d22943a2ca57c7a7e48702bbe7158"
+    },
+    "my_progs/sounds.qc": {
+     "bytes": 19389,
+     "sha256": "bb74ecc36a241db5a79b010f61200687c6db6e46297db39c8a2a8ce1d512bad5"
+    },
+    "my_progs/sprites.qc": {
+     "bytes": 476,
+     "sha256": "579f48b397914b02f8fb86dc24f23d4e63a4cd857df1f0eaefd6c83e9c49e238"
+    },
+    "my_progs/subs.qc": {
+     "bytes": 23545,
+     "sha256": "123ca7120e7ea4e4ca63bfd081caf46c7acd1560af4702c1bff40821d7f6ef44"
+    },
+    "my_progs/subs_soc.qc": {
+     "bytes": 28453,
+     "sha256": "679112275e8b3597daac962074f69b6d9fd5614fc3dbff036815b9365e1413c5"
+    },
+    "my_progs/switchshad.qc": {
+     "bytes": 7054,
+     "sha256": "92a2fd4e5c41f21f46502781322ab87584bf0999d733db50e0e19b8bbea793b3"
+    },
+    "my_progs/targets.qc": {
+     "bytes": 58758,
+     "sha256": "e39b45bf6740be40c2899376e92d30d7d227a4762091d7b63e382c79fe6822e7"
+    },
+    "my_progs/traps.qc": {
+     "bytes": 24071,
+     "sha256": "9e4e822a36113bc73958fa45ab0b8c290a5148c95f3a4da7125676c984ebd202"
+    },
+    "my_progs/traps_pendulum.qc": {
+     "bytes": 17049,
+     "sha256": "b421f26fd80eb74715172e25f3ac992faa95397dd67d5f7ede286fd78384a468"
+    },
+    "my_progs/traps_sawblade.qc": {
+     "bytes": 9783,
+     "sha256": "9a6e82a05f09001c0a9cffdf6b9d6399691846c5b1ab1fbfb470e5772a87f44b"
+    },
+    "my_progs/triggers.qc": {
+     "bytes": 139586,
+     "sha256": "2e5819bf11fecf01856bd7547af63b7c4927dec59237419dbf3dc79bc023f54d"
+    },
+    "my_progs/triggers_states.qc": {
+     "bytes": 17475,
+     "sha256": "2c4d25c11de0319cd54d81e67e651c8d29d22aca851988d21080ba5976137f14"
+    },
+    "my_progs/weapons.qc": {
+     "bytes": 44346,
+     "sha256": "f23d0cc07bab402da965ec3fa91d7de86ccabcb03c9019cd7b217fbca7fb4279"
+    },
+    "my_progs/world.qc": {
+     "bytes": 39815,
+     "sha256": "b933caca23d5a45e5d9368627b3d651af244af0aa345b91017d263be4bad7b77"
+    },
+    "particles/fte_weather.cfg": {
+     "bytes": 2758,
+     "sha256": "e0d383b0222f14edbd2bc04c1269206bbcdca22cdeac6840b5d831c042ff698e"
+    },
+    "particles/particlefont.tga": {
+     "bytes": 4194348,
+     "sha256": "bf90d469b3b41c2393f5ed0f58b4411cc8825f452341bbe3ba848c3cc855639e"
+    },
+    "particles/particlefont.txt": {
+     "bytes": 9872,
+     "sha256": "9e84ef35b813211196f8dfc8f89a420fd9d847ea514e43d0c3246ee666000b88"
+    },
+    "progs.dat": {
+     "bytes": 2345354,
+     "sha256": "f3c4218216ea0d3b00db35eef9e72945ee6687006b3e82c37ea2ae33a0eea922"
+    },
+    "progs/ammo_battery0.mdl": {
+     "bytes": 10552,
+     "sha256": "06d4f0235faedd3430e57d602ec29a2a91c0b23bdc30debc069212264a0faf54"
+    },
+    "progs/ammo_battery1.mdl": {
+     "bytes": 10552,
+     "sha256": "0cee39ac60c3eda7b5f1d1efde52f8be19c9e4f425972f16ba6d6362d646afb6"
+    },
+    "progs/ammo_cells0.mdl": {
+     "bytes": 27228,
+     "sha256": "b6f5a07c9fd48cf27f0873320589dda1e20afe7d64cd40b6c950e5f892a34fa2"
+    },
+    "progs/ammo_cells0_edit.mdl": {
+     "bytes": 27228,
+     "sha256": "47ffc9eb8ec352ab2fa479f35ee5b6ec0e0ac8f472a06fbe00e8298e9d683ed5"
+    },
+    "progs/ammo_cells1.mdl": {
+     "bytes": 29836,
+     "sha256": "c23b4e85e9edd68fec2d751af85cff391a11848bd4338a3c59a2c055508cfce9"
+    },
+    "progs/ammo_lidlarge.mdl": {
+     "bytes": 25252,
+     "sha256": "d941a1c520e49694d66598f3430420541b318cea3e1cf02d3957e06d010681a7"
+    },
+    "progs/ammo_lidsmall.mdl": {
+     "bytes": 25252,
+     "sha256": "221b3aaa2324bea668276d3de521c4945004a71368983fc74c50c4b53425c436"
+    },
+    "progs/ammo_nails0.mdl": {
+     "bytes": 14072,
+     "sha256": "1090a9c50a943c2bf04302914f69b835ecf79fbf3013f259a12668ebd57aad5a"
+    },
+    "progs/ammo_nails1.mdl": {
+     "bytes": 15976,
+     "sha256": "8dd339507f4e18953ceefe3922d04ca513728bf2b0745813723873427843213b"
+    },
+    "progs/ammo_rockets0.mdl": {
+     "bytes": 24836,
+     "sha256": "9f272b2f1cb52fcf38983f63052db653e8208b2ee1eedf053e99dca6e439c7d8"
+    },
+    "progs/ammo_rockets1.mdl": {
+     "bytes": 27672,
+     "sha256": "46d85f10a260cf13d6711420f11a235089536a3725363be0717c2ee3e7e8a18b"
+    },
+    "progs/ammo_shells0.mdl": {
+     "bytes": 14072,
+     "sha256": "053e466f1666314cbfc0cd6f67821850ad39505a6a0bbf37c80b127e6887e5c5"
+    },
+    "progs/ammo_shells1.mdl": {
+     "bytes": 15976,
+     "sha256": "6183880b36171b6784cecf74b50aea2e1fdbc17b1b0b304a89125e964d63fd1f"
+    },
+    "progs/armour.mdl": {
+     "bytes": 76144,
+     "sha256": "b6e297062cffd435d6ce5cc17854e25a49ff09750ee1eaec6d5004266884099a"
+    },
+    "progs/artifact_airtank.mdl": {
+     "bytes": 50184,
+     "sha256": "4702b7be1baa517669edd24f5b67377f532382bfedebd77b5d77f9a499f3f08b"
+    },
+    "progs/artifact_blastbelt.mdl": {
+     "bytes": 28436,
+     "sha256": "a935de1300f6fc4f03b6fc57bf43791ac32b74d55c5509eda84339dc33f0bf48"
+    },
+    "progs/artifact_envsuit.mdl": {
+     "bytes": 260844,
+     "sha256": "09192fca32cf5b7632cf0fe9cccd9b4b1313c0e92708e85f840b0971aca5d274"
+    },
+    "progs/artifact_invis.mdl": {
+     "bytes": 7108,
+     "sha256": "f6b0b925b584402d85a623e1924c50a4fb3f3a4994cb1d2f05a169a3af2e39dc"
+    },
+    "progs/artifact_jumpboots.mdl": {
+     "bytes": 37428,
+     "sha256": "668d649addf958be26f2bcff31baf3afa5ff176a178ef15073c87cc7cb57e2b8"
+    },
+    "progs/artifact_lavashield.mdl": {
+     "bytes": 469773,
+     "sha256": "2e3027df661ca197750df97599084442afda131fbf1b545ea38d40e93afff908"
+    },
+    "progs/artifact_pent.mdl": {
+     "bytes": 21412,
+     "sha256": "7ae90fc895f23f57952dacf4d8af125f99347e09edf6f0287c7e508faad67b46"
+    },
+    "progs/artifact_piercer.mdl": {
+     "bytes": 19012,
+     "sha256": "fd73ca18d93904647df923f2d0383958386c7deb9cf27547beda74c61a9f8831"
+    },
+    "progs/artifact_quad.mdl": {
+     "bytes": 22052,
+     "sha256": "bf6d2253210784391ee1ab9b38d2b6fd661a520434bb127d293f4d202040d1b5"
+    },
+    "progs/artifact_sharp.mdl": {
+     "bytes": 49248,
+     "sha256": "505fc06618d7cecb83c03ad7d7762011ff8cff025eecf007b200d87fcc2483cf"
+    },
+    "progs/artifact_tome.mdl": {
+     "bytes": 21412,
+     "sha256": "ee8cf94e2c87ff6c0d4aa8777da2f0ddb79605bf790fb8f9ed2f49c6c1f9b9cf"
+    },
+    "progs/beam.mdl": {
+     "bytes": 26020,
+     "sha256": "bd06e42c7f0d911a4ef1077c95d474b86f62bca4da02183449687c23879e8c6d"
+    },
+    "progs/brk_pot1a.mdl": {
+     "bytes": 93352,
+     "sha256": "5612b9539e9663e06397f315968674b1de6ab50db7cdf673baadcd4652cedcd5"
+    },
+    "progs/brk_pot1aflr.mdl": {
+     "bytes": 93352,
+     "sha256": "02fd1feb7dc24b456e31f26f142aafb9adf491a16ea4caf2c4ec237e465260a5"
+    },
+    "progs/brk_pot1b.mdl": {
+     "bytes": 93352,
+     "sha256": "47c4053f0c0c941674a9d7c15a07e05c7ed648b2bf8ffbd1defb7264c151b47a"
+    },
+    "progs/brk_pot1c.mdl": {
+     "bytes": 83968,
+     "sha256": "a408707cc6793c337d0e76d86c5362de39a1f2109c23affe5def6e8194e0f4e8"
+    },
+    "progs/brk_pot1d.mdl": {
+     "bytes": 74024,
+     "sha256": "c31abc1e9e5af2cb86614f68a8be55f6192e05baba8b93479e2b2590b1e0ef1d"
+    },
+    "progs/brk_pot1part1.mdl": {
+     "bytes": 33768,
+     "sha256": "2dd32863b6006dda74b60f05a43df13e7df052ddcdb652309ba0ab29fa5352e5"
+    },
+    "progs/brk_pot1part2.mdl": {
+     "bytes": 34072,
+     "sha256": "550cae5c8893c63520c324610950eeb5b9fe842dc8ea1f07f6a217953f6e743e"
+    },
+    "progs/brk_pot1part3.mdl": {
+     "bytes": 33464,
+     "sha256": "819cf0e720637e7c5e187ccc67ae032eca217ee2f07076aefee1a8b7de894852"
+    },
+    "progs/brk_pot1part4.mdl": {
+     "bytes": 33496,
+     "sha256": "a3cc47c7f7410bb0ca2308e45144b29bc3b678600e0f288b15d8e64525585e43"
+    },
+    "progs/brk_pot2a.mdl": {
+     "bytes": 77348,
+     "sha256": "ffcf5e5f3d0b81143e2b2b387cde7b13b2d36b71345d63456f288eb036993a2b"
+    },
+    "progs/brk_pot2aflr.mdl": {
+     "bytes": 77348,
+     "sha256": "37420048a9f72abc5982f5f6813602dbc4b82ef8e788a0e309df7ff13066ea62"
+    },
+    "progs/brk_pot2b.mdl": {
+     "bytes": 77348,
+     "sha256": "40eb2c849cd06d9b985b0efc2b9d1090ec1648b0de53d0a07bd6fd5fe2af6733"
+    },
+    "progs/brk_pot2c.mdl": {
+     "bytes": 77348,
+     "sha256": "3774ade6790fc2b597c44c5206deeb3d5d3d20a23331e3fb622e1e90f833c7d4"
+    },
+    "progs/brk_pot2d.mdl": {
+     "bytes": 79004,
+     "sha256": "2af25d81ae0f1d8724f3047e95ff2f1d1700061a536b3f9ffda5522cf7e8dd13"
+    },
+    "progs/brk_pot2part1.mdl": {
+     "bytes": 34456,
+     "sha256": "13547d9ca8c36bbcc95354df03dfbdc14f19f74251ff1dc8c417436846b396bc"
+    },
+    "progs/brk_pot2part2.mdl": {
+     "bytes": 34680,
+     "sha256": "7f9824c52b01664c2dd1ccc5c1dc9e7ff2a5567dd2d0a8e9c3bf1a8bd00400e7"
+    },
+    "progs/brk_pot2part3.mdl": {
+     "bytes": 34008,
+     "sha256": "52fdc17879e0b6fb8697e1e9fffba092f1b5aa8d3cee5d657b405eb4119e8e87"
+    },
+    "progs/brk_pot2part4.mdl": {
+     "bytes": 33304,
+     "sha256": "b40cf2b029a4bfac52a80f5aef6587f3eb66e08be1fe5f40cd3f97e93133ad3b"
+    },
+    "progs/brk_vase1.mdl": {
+     "bytes": 27992,
+     "sha256": "28a8b9a0d367f17c2c265271d99b019f1762831a11ba794e2884fc7f7a8a2368"
+    },
+    "progs/brk_vase1part1.mdl": {
+     "bytes": 5524,
+     "sha256": "b8c0bef8f5d6a427f57282f086a75f39e91ad6ab035d4f1d437da97794e52f9e"
+    },
+    "progs/brk_vase1part2.mdl": {
+     "bytes": 5556,
+     "sha256": "8e1df7795140732953af83a1ef2158299a2cc393163041b6d3243478b6b644e1"
+    },
+    "progs/brk_vase1part3.mdl": {
+     "bytes": 5556,
+     "sha256": "c2e3da479defb1c3bd5130555e33dd47afc6a3b4ef7f74d4f0184cb02a02a46d"
+    },
+    "progs/brk_vase1part4.mdl": {
+     "bytes": 5524,
+     "sha256": "986c51c2cb3832f597f9dac89c6044d090b10933306814acc36a0c4ab5a04b93"
+    },
+    "progs/corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "839b70bb6be7fac8c25e6069b999e076b04bdd3dbc7a9320924713cf75c2cadb"
+    },
+    "progs/corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "cb994b390584e1776ad1f0e60d95186a0dc54cd160a2cb8284d1a15b4fe1a35d"
+    },
+    "progs/corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "b19faa9afe7cf957ae7abf6439799e5001ff42817290f4b464aa3f7ae4e3377f"
+    },
+    "progs/dance_player.mdl": {
+     "bytes": 465924,
+     "sha256": "d07f23e6a40743aeac01084a1da9670ea9a635339d86be46149e9f0ee74661e0"
+    },
+    "progs/explode_box1.mdl": {
+     "bytes": 49888,
+     "sha256": "c8a7e667c5e20735db9a816b7a11b5a1c67bf4e176d1553a79cc56bcaa9ff35b"
+    },
+    "progs/explode_box2.mdl": {
+     "bytes": 49888,
+     "sha256": "649dbfabde0a875a0c35b0109261515dc9eb287d0cc7f41ca3712283e62509c1"
+    },
+    "progs/flame.mdl": {
+     "bytes": 41668,
+     "sha256": "d6cb4dc28d5101538b44ed53fe1cf84c9d5f8547a91eb74fc6c6bdd3645ffa17"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 74548,
+     "sha256": "f03dd3b7f94a86c4d91ffb002723a16f30321a0c2189b673dd4f12f547245816"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 71268,
+     "sha256": "b1e734caec73b941b1c033fbb49ffc0f947aa8e1d47250c2d8cec0f244870fc8"
+    },
+    "progs/g_ghook.mdl": {
+     "bytes": 64684,
+     "sha256": "9cdd8bccab5f11ea7f8ea6480a4ea05c9d749bc4746cc19a6452a2e0356edfc6"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 32404,
+     "sha256": "b195b37f7e96274ea7db8e70dcf5971275bafdd0c9c10c29f2dc540c38641953"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 35876,
+     "sha256": "8ee090222c89209eec97120d5542d69a9f75b8a8aa896cd4df256d438ce83495"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 25316,
+     "sha256": "261a8479de0d5df9aea9931a62b1b93dbb7bfcff4f4467920cbebcc9c2c25381"
+    },
+    "progs/g_shadaxe.mdl": {
+     "bytes": 398968,
+     "sha256": "19d6f210a771748da589282e63a222c6c9c41a21085ed3f57f70d7f5aa20bd66"
+    },
+    "progs/g_shot1.mdl": {
+     "bytes": 24580,
+     "sha256": "72913fa948f1618347adaa91ceb98203186d2fc7bd3b9c84af00f7f637928058"
+    },
+    "progs/g_shot2.mdl": {
+     "bytes": 15876,
+     "sha256": "8ae318a3e697e4c85f60a4e5997b673e8e48f17e295551c2b0b5d0c643b3ac24"
+    },
+    "progs/g_shot3.mdl": {
+     "bytes": 156216,
+     "sha256": "8a602686e322d7357a102e0c8e91907c8b3975a8b6d36ba19f3c645e450285da"
+    },
+    "progs/g_zershot.mdl": {
+     "bytes": 68020,
+     "sha256": "3439ce2faa846bd2b3ca50e33b55092454ed83caaf8fe654d8381e107aa3520a"
+    },
+    "progs/gib_1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib_2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib_3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/gib_4.mdl": {
+     "bytes": 7468,
+     "sha256": "29f9cfa3d86121e1e349de9c3a39e620b9d6ba2cd98640536923e581f7ae28bd"
+    },
+    "progs/gib_5.mdl": {
+     "bytes": 85308,
+     "sha256": "2023ae2fd305843640266ec6679511d134e1b84ac54de245a390e483557050bd"
+    },
+    "progs/gib_blclaw1.mdl": {
+     "bytes": 32860,
+     "sha256": "303c38aea48534d4ce34f3c2082a21c7408c1e4a4cd848bc7e4acadfaaddbdc0"
+    },
+    "progs/gib_blclaw1b.mdl": {
+     "bytes": 32860,
+     "sha256": "c22db765c594ee28a0863cf70e354c651a2b9282e1df7e3a57b35ce62932920d"
+    },
+    "progs/gib_blclaw2.mdl": {
+     "bytes": 32860,
+     "sha256": "c7d70c4c067aa297fbebc3d26a2068a62f307c7f00f8d15d0bf76ed9519967c8"
+    },
+    "progs/gib_blclaw2b.mdl": {
+     "bytes": 32860,
+     "sha256": "96a96606a74eb3093d88f1f946d66caf77bd57fde0a4ec44840c95fa12130551"
+    },
+    "progs/gib_blfoot1.mdl": {
+     "bytes": 32860,
+     "sha256": "74e05efa33fc9036399a1f1d484a3816129fe0e379aee579b923cf3316e5ab84"
+    },
+    "progs/gib_blfoot1b.mdl": {
+     "bytes": 32860,
+     "sha256": "2d23324414f3f1a25ee24afe914679d07df244c9c0e48139331f084b8c369054"
+    },
+    "progs/gib_blfoot2.mdl": {
+     "bytes": 32860,
+     "sha256": "c2ce3b46d8762b042d201608271c3441b975b93e6329790ca5cba61294f71e45"
+    },
+    "progs/gib_blfoot2b.mdl": {
+     "bytes": 32860,
+     "sha256": "de945be28e0b05dc380a0a2cfff6907f14a5e4b9756385874fddd712df095bb6"
+    },
+    "progs/gib_dmclaw1.mdl": {
+     "bytes": 49248,
+     "sha256": "be5f2bb9174ce47f6d3df06685ac728c852c3a028f6aeb1632e709eb69c20ee2"
+    },
+    "progs/gib_dmclaw2.mdl": {
+     "bytes": 49248,
+     "sha256": "ff6cc88ef9123812b9d8e09235074f4c7fcad47077e6fffee334f15e3f71eb27"
+    },
+    "progs/gib_dmleg1.mdl": {
+     "bytes": 49248,
+     "sha256": "106990e4d9e2746303d09ae6c481914702af0242d8cf0fc9d430d0fa5329813c"
+    },
+    "progs/gib_dmleg2.mdl": {
+     "bytes": 49248,
+     "sha256": "8308124b7c4dca218af9e8ef7042ddcb0ca2fcb30e7f86866b1a28a73ab94db2"
+    },
+    "progs/gib_dmtail.mdl": {
+     "bytes": 49248,
+     "sha256": "6b60c464ee0e7ace54313550ac5be2f4949cc6f8dd539b38459c4a6c395e6704"
+    },
+    "progs/gib_drolearm1.mdl": {
+     "bytes": 18324,
+     "sha256": "a6b0f55da1b1d8e519b3cb9a53afe229279c760ffab3862866d8c4e7a52f267e"
+    },
+    "progs/gib_drolearm2.mdl": {
+     "bytes": 18212,
+     "sha256": "aff67984dc3198d24d2184c35748e829d7f867c38227f1fa898a1986f12ac767"
+    },
+    "progs/gib_droleleg1.mdl": {
+     "bytes": 18436,
+     "sha256": "ab69d8c271f44998ccdfd10d70ccd06caa3c2674f46e4cf94285b380d08db501"
+    },
+    "progs/gib_floyd1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/gib_freddiejunk.mdl": {
+     "bytes": 71364,
+     "sha256": "13763a8cec3b643acb9b8165f1850ffae003131c84a2ac225777822a88462498"
+    },
+    "progs/gib_gargwing1.mdl": {
+     "bytes": 92088,
+     "sha256": "3979718d2403ca7cf75aad4004a56100c1bf358f2cb9ae68595e5d69f6774f47"
+    },
+    "progs/gib_gargwing2.mdl": {
+     "bytes": 92024,
+     "sha256": "7554ef45a88db1f2e457dd7071770e42bf864123827b9819435a628b412ecb32"
+    },
+    "progs/gib_judgeboot.mdl": {
+     "bytes": 199308,
+     "sha256": "557eadb703666c4868e1b231cb1c21fbff5e59e2ec0cb8ade85cd3839fd714cb"
+    },
+    "progs/gib_judgeshould.mdl": {
+     "bytes": 199132,
+     "sha256": "69e4958866a47d5c63a6385db4843a6a5011f149b25e67720291d2db63945ed8"
+    },
+    "progs/gib_justiceboot.mdl": {
+     "bytes": 264848,
+     "sha256": "b727239a7bf232c7c6164d0f9fc0961a6c692cb0c0919b17429ade6f62bdd71c"
+    },
+    "progs/gib_justiceshould.mdl": {
+     "bytes": 264672,
+     "sha256": "2fcafb2b2a19b8ae16009e827f13fea14cb389317ec476b7f58fb2fef1163180"
+    },
+    "progs/gib_knfoot_l.mdl": {
+     "bytes": 18288,
+     "sha256": "8ffcc7ce931662f2eefa0703642b140e18a99c02252ffa3ddeb71f6ebbbe360f"
+    },
+    "progs/gib_knfoot_r.mdl": {
+     "bytes": 18288,
+     "sha256": "4d503f422ac01a8565453ba4bd8268338c3a9802480785eebd27fc0487e46753"
+    },
+    "progs/gib_metal1.mdl": {
+     "bytes": 5172,
+     "sha256": "b0951de4d869e0b779aeb3f7a96f56b22a82a58d267a56b1247f0c3e667c25ad"
+    },
+    "progs/gib_metal2.mdl": {
+     "bytes": 6292,
+     "sha256": "3df78c49abb572095d3b70efbb99bccb63caf2ffd30bb3ee434c945084acb5a0"
+    },
+    "progs/gib_metal3.mdl": {
+     "bytes": 6036,
+     "sha256": "88f8a1f941e38f8528ec27a168559946cc0b69f2abce1cbf6858b813e09c5f51"
+    },
+    "progs/gib_metal4.mdl": {
+     "bytes": 6580,
+     "sha256": "fbde734f29a6691d51c58a40a89e45f81dece2f20218353a6137a2362acbe3a9"
+    },
+    "progs/gib_minoclaw1.mdl": {
+     "bytes": 135544,
+     "sha256": "1188f73d5a6319bef5e506ca994bfcf63074a4267a5a189cb92db94160310fca"
+    },
+    "progs/gib_minoclaw2.mdl": {
+     "bytes": 135544,
+     "sha256": "511bb72c8382f4cc3cc9fa3bea4adf2390dcca1e2dcd42ef8f8287765875fa99"
+    },
+    "progs/gib_minoleg1.mdl": {
+     "bytes": 135448,
+     "sha256": "f07ce357d83d3ab0f39109d93f2f6996ded4ff19a4372fd5ddc9d9fa1a0ce8d3"
+    },
+    "progs/gib_minoleg2.mdl": {
+     "bytes": 136392,
+     "sha256": "7ba78149bc60a05ceff9090ecc2bdf013ff2d55420dfdebc553a254ac0bd08fb"
+    },
+    "progs/gib_ogfoot1.mdl": {
+     "bytes": 5956,
+     "sha256": "144e2fdfbccceee039243ef343df02ce181b666070e2d0a1825c056634f2a632"
+    },
+    "progs/gib_ogfoot2.mdl": {
+     "bytes": 5956,
+     "sha256": "9997dff0bdb2622ef6ee2530c27835fd249aee04437e70486e76255f979bec25"
+    },
+    "progs/gib_p1.mdl": {
+     "bytes": 7712,
+     "sha256": "709c49c205b27793f589eab17e8356a108345069716f9095dc07dd6447be7894"
+    },
+    "progs/gib_p2.mdl": {
+     "bytes": 21216,
+     "sha256": "50d99c7fec3b8ef01bbb19c32c88dac40a372cb6a7d39c349e0ff4909360626f"
+    },
+    "progs/gib_p3.mdl": {
+     "bytes": 18176,
+     "sha256": "d53659aa99de418793337b7e878db7bd7836883ad43528d648475589aa30d85d"
+    },
+    "progs/gib_p4.mdl": {
+     "bytes": 7468,
+     "sha256": "71ad4dcc06038f0a175605a3906b1506d0144b56b238e7df178160d9ab876b8d"
+    },
+    "progs/gib_p5.mdl": {
+     "bytes": 19756,
+     "sha256": "adf63c881ff5703b8112f714140929375b5c10be957f01cfdfa131d89af3cacf"
+    },
+    "progs/gib_s1.mdl": {
+     "bytes": 7712,
+     "sha256": "31faee0daaf399feccc1ec942ff7fe85a1a790ebd93c3b8a1fcfde9bcc06da1d"
+    },
+    "progs/gib_s2.mdl": {
+     "bytes": 21216,
+     "sha256": "c85f7dbc8eec508951893253bba5eec169a87865c995ba1d0e5c083fed9e03ca"
+    },
+    "progs/gib_s3.mdl": {
+     "bytes": 18176,
+     "sha256": "ec23effca60ef407bf294a814003213928f21f05e6da501fbe996345b6171013"
+    },
+    "progs/gib_s4.mdl": {
+     "bytes": 7468,
+     "sha256": "5001ef206e1a36cc792d7b94054b2bab4c6dfbed60e0ee0d3afd240d1af88d13"
+    },
+    "progs/gib_s5.mdl": {
+     "bytes": 19756,
+     "sha256": "9e1a112412d38c559974c628649a7773ad445ba7d24a1804c5f3fe5f50ecef7f"
+    },
+    "progs/gib_scorpclaw.mdl": {
+     "bytes": 66816,
+     "sha256": "ecaf582e92d77a1722eded2c5564d2fb9575065510ff1bc9632538345ed18329"
+    },
+    "progs/gib_scorpleg.mdl": {
+     "bytes": 66304,
+     "sha256": "399067acf8f082301f6629d2b124b0d34a7d934db55c922205a96772a85a8a1c"
+    },
+    "progs/gib_scorptail.mdl": {
+     "bytes": 66864,
+     "sha256": "0831c04d7a73c6f58329b0be0f6d371f727ea880b49e5b6e16f7cdc56c124df2"
+    },
+    "progs/gib_seekarm.mdl": {
+     "bytes": 265688,
+     "sha256": "6ee70b2f4f39d8a1fd99113c7c8df5481c421960f160afea4e622ed5b3113014"
+    },
+    "progs/gib_seekchunk.mdl": {
+     "bytes": 265420,
+     "sha256": "a70331a8e43075b026cf21d364cf2341e79e7e60c5fca4777d10aabd57ce0323"
+    },
+    "progs/gib_shclaw1.mdl": {
+     "bytes": 22964,
+     "sha256": "20b29bf40dd02dce0204c14c34b0b5806d8eef580406851d73383a631ac8f2a7"
+    },
+    "progs/gib_shclaw2.mdl": {
+     "bytes": 23060,
+     "sha256": "8dcf777d5ffd2e83edf5b6f936881eaf9d384fe8fc980721c9f5881d3e6da0c3"
+    },
+    "progs/gib_shfoot1.mdl": {
+     "bytes": 23268,
+     "sha256": "634d7cbb9e2b718167fe74112e6dd4f53cfe1cffc32f75cd80e711a24cd2f983"
+    },
+    "progs/gib_shfoot2.mdl": {
+     "bytes": 23124,
+     "sha256": "aaa2393cb65fb33a8885bfdd9b808732c0aa17f0dd461d3b04e84eb27f0fe61d"
+    },
+    "progs/gib_soldfoot1.mdl": {
+     "bytes": 51148,
+     "sha256": "09357cfed1e6c9c25e0d133d95f2c2b36693cbed1010146a982bca685cb370ed"
+    },
+    "progs/gib_soldfoot2.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/gib_spidbodyb.mdl": {
+     "bytes": 17652,
+     "sha256": "313dc78de70f02de9a49c71a1fd5ddb5ae4247f90a1a04f0ab84f44797be1946"
+    },
+    "progs/gib_spidbodyg.mdl": {
+     "bytes": 17652,
+     "sha256": "5439ca0812bc2627f22fd995237607755708f7615782785093793c11497973e5"
+    },
+    "progs/gib_spidlegb.mdl": {
+     "bytes": 18560,
+     "sha256": "66dc12710dec1bd4827497e4ed28b6a4965e1f68b48d5f0903a96ecf632e7f4e"
+    },
+    "progs/gib_spidlegg.mdl": {
+     "bytes": 18560,
+     "sha256": "3474de5b97c2b424f8ec4b8d93a1457f13adca106bdbe15234492376708810f9"
+    },
+    "progs/gib_steelbody.mdl": {
+     "bytes": 17652,
+     "sha256": "2a833de4b00f439041d27d97b3660d4df1cc9e3b454dba5ac5533e5c855e8d90"
+    },
+    "progs/gib_steelleg.mdl": {
+     "bytes": 18560,
+     "sha256": "ae926ada1c4ef7b695764f2daa0b4704102bf5eebc103b9f6a56813337f43165"
+    },
+    "progs/gib_swampleg.mdl": {
+     "bytes": 4820,
+     "sha256": "2b549fd3a74b0fd6b94c71c9e397b466e2c7f823917ffe717ce1af43769e1961"
+    },
+    "progs/gib_swamplegp.mdl": {
+     "bytes": 4820,
+     "sha256": "b5cf22240bf6474cc8ea57c40ddb70f80e792c23cb87835bee94825cb645578a"
+    },
+    "progs/gib_voreleg.mdl": {
+     "bytes": 4820,
+     "sha256": "19ec59cb3436d66a8ac9d8f40480a9c83aef879f0f1e58ddb834710e2bbc4d9d"
+    },
+    "progs/gib_vorelegp.mdl": {
+     "bytes": 4820,
+     "sha256": "341679c553a719be40022fc4a3573ff68116fee7ae05df511b9083a410af5e7f"
+    },
+    "progs/gib_wraith1.mdl": {
+     "bytes": 5300,
+     "sha256": "a0642c84b36288a3d0cef22ac32e0c681c422a034204932671729624f19d0b2b"
+    },
+    "progs/gib_wraith2.mdl": {
+     "bytes": 6292,
+     "sha256": "d20a17e624d16e4c8552ac9a291cd735aeae670effc2c9865b37fbc7bcd22220"
+    },
+    "progs/gib_wraith3.mdl": {
+     "bytes": 2516,
+     "sha256": "63f10b068c6df0a80729362c094f72d0bcf90f74de97636bc5e4a630c13e741b"
+    },
+    "progs/gib_wzarm1.mdl": {
+     "bytes": 12384,
+     "sha256": "9b6f5469bfc6ae49d2bd51fb6d35e686c4e79e5691e2fb80fa7ee556bf547e04"
+    },
+    "progs/gib_wzarm2.mdl": {
+     "bytes": 12384,
+     "sha256": "2ff539f467ca9b0f23c40cb2547221a484afbe7e07a812558ec1595e5cbd0217"
+    },
+    "progs/gib_wztail.mdl": {
+     "bytes": 12384,
+     "sha256": "fb90123980ff4510e744ea2b21509492b7ff9c131527ffe5c7b80bbbf881bf41"
+    },
+    "progs/h_boglord.mdl": {
+     "bytes": 98400,
+     "sha256": "119279b2ffdf928d34ef1470ae6c14f875cb59edc6d8b107a90bbea122c9acdc"
+    },
+    "progs/h_boglordb.mdl": {
+     "bytes": 98400,
+     "sha256": "25af0d0ea45857e64549686bb58e5f69a0754ff6e43c26ce735e58aaac3d534e"
+    },
+    "progs/h_centurion.mdl": {
+     "bytes": 63592,
+     "sha256": "2e64af530a4f5f36001ad922bb56a941738e7fe2c67c0ad0e3f06fa5854c4b08"
+    },
+    "progs/h_dcrossbow.mdl": {
+     "bytes": 25700,
+     "sha256": "0354fdb96bd5490bc18527d68813a43a41f943a05f7edca26c1aea7b943185be"
+    },
+    "progs/h_deflector.mdl": {
+     "bytes": 22232,
+     "sha256": "56de00c315543073bfda7e8a5ad3c3996f549351fa1e660e676516f4122cdeac"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 67688,
+     "sha256": "ff73d5f8fcab46a806c47377679ec5473cdc0ea93a0fda6dda8b5dba8cfa4b97"
+    },
+    "progs/h_dfury.mdl": {
+     "bytes": 14036,
+     "sha256": "3753a68126ff7caee3219c31533a1731ae9a80623c6af69315c7526f5c92669d"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 19296,
+     "sha256": "6b0867e61635543a7bb3b02647855f1384961095cd06dfc786a537b11eb926ae"
+    },
+    "progs/h_dguardq.mdl": {
+     "bytes": 4920,
+     "sha256": "337f2723daab9d1375b78cb017512ce8281087ff8df9c33b04a6c613cea3590c"
+    },
+    "progs/h_dknight.mdl": {
+     "bytes": 32144,
+     "sha256": "30af2418019b946f3582f70d2356357a97dff0391f86a9fb0abd5218cc799020"
+    },
+    "progs/h_dlord.mdl": {
+     "bytes": 18699,
+     "sha256": "bc5a92be1c5f3d06dc0238ec7bafe6a3c25826cc50edc6214ed5aa19b0075987"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 27652,
+     "sha256": "49f28b9a13867ed4a88fcac541b8a9cbabddcc594557b3490951179b3d479509"
+    },
+    "progs/h_dprince.mdl": {
+     "bytes": 19336,
+     "sha256": "77855cfc2667ed68c61d389a44ed312abc3ad1e029ea003d03e78e7131fb803c"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 14032,
+     "sha256": "bd5da6afddc520999d9c572a679c3bc8c43635ce2c73f8789603eb6a83c15aa1"
+    },
+    "progs/h_eel.mdl": {
+     "bytes": 156904,
+     "sha256": "a859ee09044d9afcd05ee2af3f1ea8c7b4ae3abc01273922dbebd5aa67b12d74"
+    },
+    "progs/h_enforcer.mdl": {
+     "bytes": 94612,
+     "sha256": "21046f6878f5f4173206debcb912d9fdee0b1f5c66d820a4355c7df8e2eb1860"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_gargoyle.mdl": {
+     "bytes": 30152,
+     "sha256": "bbcf207c44814f5e665944db03800934eab9046a0d0d86f4c982a3116f855791"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 59888,
+     "sha256": "f57daa1ab6a721a9feb696aaeeb597c720b639cd0a027a1b1da8cdd68ad1d1f0"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 30552,
+     "sha256": "edf8a4ccc52bfd9545fda8da9360e536c026079f8d2fd9756191fc934bd55683"
+    },
+    "progs/h_hogre.mdl": {
+     "bytes": 23688,
+     "sha256": "6f21e95518cd085d20b1023951ddf4d738285210bc95c6e2b3d2e82566478776"
+    },
+    "progs/h_hogreham.mdl": {
+     "bytes": 22776,
+     "sha256": "3d3e43d16c4babcbca358b44dc03ad1a212e22ea3a10ee9e639b5f4c2e95f670"
+    },
+    "progs/h_judge.mdl": {
+     "bytes": 203276,
+     "sha256": "be57ef7327fbf3ea6fb55c02bcccc4ec207b3781bb9d2e383939f3840e1ef91a"
+    },
+    "progs/h_justice.mdl": {
+     "bytes": 268816,
+     "sha256": "01d3011001c297b85a139ecb2861f188d15b96cd1ae02f08cb1604565f2d2ee3"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 42068,
+     "sha256": "aa979e22745c960cd100e814bce62018f2b992481e57838548f0ddf4816c27a8"
+    },
+    "progs/h_minotaur.mdl": {
+     "bytes": 138264,
+     "sha256": "c5e13818c813680fd29a94b408518731aa4e9007c23d004ec874f099c9ced6b1"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "4967d418f4810e9273732bbd4c690a1f9478243f7fe3807497134eb2994da0eb"
+    },
+    "progs/h_pyro.mdl": {
+     "bytes": 42912,
+     "sha256": "5359fd85e71cde1ab716d8d50a8618a347dd42b4ad4692805bf41c1903d55c18"
+    },
+    "progs/h_scorpion.mdl": {
+     "bytes": 67408,
+     "sha256": "d68d09c35c00d9bafb302fb7f3baeef90ee5d60de1ad8a7627f979c3561f5965"
+    },
+    "progs/h_seeker.mdl": {
+     "bytes": 9060,
+     "sha256": "9e9d601441532e16aee253b5e94ea9c32563f880782794d16ce496a580698bd8"
+    },
+    "progs/h_shalrath.mdl": {
+     "bytes": 78156,
+     "sha256": "f478f17ea9ee6843be2ebe3c487d0036657c94ace52a800fa44e0160d02a522d"
+    },
+    "progs/h_shambler.mdl": {
+     "bytes": 98400,
+     "sha256": "6508f7b05b65f230b7f1280d2023e9ed200663715db1709c43e7e187e3ed841c"
+    },
+    "progs/h_skullwiz.mdl": {
+     "bytes": 234304,
+     "sha256": "625c991e231d6836c36ae0c6651ec06f05541e9a7be605654fb43fba65bcc3d4"
+    },
+    "progs/h_soldier.mdl": {
+     "bytes": 166488,
+     "sha256": "0a4e322fbac8f98755adb9a4bf5ecff24d58aab30fcb1c9def3e97a0f686445e"
+    },
+    "progs/h_spiderb.mdl": {
+     "bytes": 18564,
+     "sha256": "d51c7764fccc4512db6d79ddcf03ffe42cf2817a66d6be02be0cba6551ee1206"
+    },
+    "progs/h_spiderg.mdl": {
+     "bytes": 18564,
+     "sha256": "70bec9669f3a7f3662320e32d29c38d535092db56617d5033e11669038472e2b"
+    },
+    "progs/h_steelclaw.mdl": {
+     "bytes": 18564,
+     "sha256": "be9adcdf9cf9407a729cfa9abcd692f46a55ffcf25c1878a7b2f5572fd591f8c"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "63b8a0b90691ae9a3c50a94f02943a1b94946f89402cc4e1da74c6806bd953ba"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 23516,
+     "sha256": "5a933ecbc067b8d6cbb57f71ae1614844b6e55170a206d278b3d15fe619c9cfd"
+    },
+    "progs/h_zombiek.mdl": {
+     "bytes": 4920,
+     "sha256": "9b8b3af67bdec6160ecd3880acc072b833886f7fc11d1e64ffcf06184f9ba80e"
+    },
+    "progs/health_100.mdl": {
+     "bytes": 6948,
+     "sha256": "6c6646f6081ab00ed1c309de3b697009c825d64360b06c741a533b718e0ab8d7"
+    },
+    "progs/health_100b.mdl": {
+     "bytes": 23248,
+     "sha256": "d82148af4482e3c0ff07389ebb5b09cdefda373e31105aeb7308b4126b353a97"
+    },
+    "progs/health_15.mdl": {
+     "bytes": 6788,
+     "sha256": "838b0cb6fd11ff7fdf268b1607a1999e5dce0dea11386afe5ff207e6ff734aeb"
+    },
+    "progs/health_15b.mdl": {
+     "bytes": 10948,
+     "sha256": "eb1bb584805aea34a0f0ab846a758cdc359b730e144e141dcd756da23b5831e1"
+    },
+    "progs/health_25.mdl": {
+     "bytes": 7332,
+     "sha256": "ce8260929500cac3b57617345b2c6b5a75e763afdbd10120982e7d7fa55be27a"
+    },
+    "progs/health_25b.mdl": {
+     "bytes": 23248,
+     "sha256": "7aba68839958035319b2167369f3fcd08c9d49140969cff7fb523b7023362e00"
+    },
+    "progs/health_5.mdl": {
+     "bytes": 6164,
+     "sha256": "a8ba7ece01b3cb58b2f94ca20a9f4511871d26ec894b54c04e433f29fc7c3bef"
+    },
+    "progs/key_base.mdl": {
+     "bytes": 54436,
+     "sha256": "fb25488fa2fc16c7c4df260a20fd905a821607a675fd0907a6e65f9d534fd367"
+    },
+    "progs/key_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "2632cb327c1175b351d026e88a4e456c45779a0dcdae01381b24200769c8743f"
+    },
+    "progs/key_gold.mdl": {
+     "bytes": 9332,
+     "sha256": "e93ed2c4263bf7631efcbace2c36ed6f240bfcc2b49491751f6d6ce55db8c098"
+    },
+    "progs/key_medieval.mdl": {
+     "bytes": 58532,
+     "sha256": "0810c558e40c5833c19283eb849ba80ac5dd3499e0f077b724057c51730ee097"
+    },
+    "progs/key_rune1.mdl": {
+     "bytes": 18900,
+     "sha256": "90ac269965d42da0205307eeeaddfa5b282598b5218af8650d2d8854621ca950"
+    },
+    "progs/key_rune2.mdl": {
+     "bytes": 19828,
+     "sha256": "4a6644f0b583c85aa41362fb4533cda5f8f762bd4429e5007b3ab57e5e24ae57"
+    },
+    "progs/key_rune3.mdl": {
+     "bytes": 19700,
+     "sha256": "9b33cc0feed9fc27ea647f6d127941933aa5378b52a3f75b9331714fa9d2ff31"
+    },
+    "progs/key_rune4.mdl": {
+     "bytes": 19220,
+     "sha256": "515534b8fdaa0ef99621f0f7d59d268c0c244562372e23c13e9ce05a44e0a68a"
+    },
+    "progs/key_runic.mdl": {
+     "bytes": 57444,
+     "sha256": "e0e31948c1e172c3c9117a8ccd72900c6ebd7a7e73882ae525dd116230f054e2"
+    },
+    "progs/key_silver.mdl": {
+     "bytes": 9332,
+     "sha256": "dd54032e82de32cf1b78a25f862a82a73e9dc0926d89ca7a4279b45d367a8478"
+    },
+    "progs/misc_bmkdigit.mdl": {
+     "bytes": 3328,
+     "sha256": "1a7f2f762ef3a052a91db7c74cf8d980db47a56685fc61184a15be2152e843b8"
+    },
+    "progs/misc_bmkdigit2.mdl": {
+     "bytes": 3328,
+     "sha256": "2e690ffe1af05f5ad88fe90c180785adeeffdb2b330aa34c6f4fb9885285cd1e"
+    },
+    "progs/misc_bonepile.mdl": {
+     "bytes": 110796,
+     "sha256": "0f8061359681f3c11660e472c517599590447c7631edfe5a36debd9645acdec6"
+    },
+    "progs/misc_book1c.mdl": {
+     "bytes": 40096,
+     "sha256": "92b976437673f56cb890f0e1b90a550ea00939d01ee12b0df0f218b35b42953e"
+    },
+    "progs/misc_brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/misc_braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/misc_broken.mdl": {
+     "bytes": 744,
+     "sha256": "828998b238e1c5471461edc3b9d2d7fada2beab6229272041dff13a94c1d73ec"
+    },
+    "progs/misc_cable.mdl": {
+     "bytes": 57780,
+     "sha256": "bed2cca38ef4cbefa9e645eb5e9ffadffac6ebb4f2ac5f6da4bb8f354de22a48"
+    },
+    "progs/misc_candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/misc_candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/misc_candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/misc_chain.mdl": {
+     "bytes": 231184,
+     "sha256": "845fc3117f7d9860f2d0aa4a398103a13f327516144a96db508189ae1be5788c"
+    },
+    "progs/misc_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "3337f2cfe739c22d50edde7bff18c026d4336bceb207dacf8b0284ab0a5366cf"
+    },
+    "progs/misc_corner1.mdl": {
+     "bytes": 21668,
+     "sha256": "7abf8d5ca497d5e8c8ddcc09c710c0401edb71b11f9de77a2daa81b1267e5698"
+    },
+    "progs/misc_corner2.mdl": {
+     "bytes": 21348,
+     "sha256": "369c874a37ef1da8c9a79432ba2ab9484a5be0df120131b8cbac81e1786adf47"
+    },
+    "progs/misc_deadtree.mdl": {
+     "bytes": 195728,
+     "sha256": "d267db8cfc35b01430590cec643570b38f8df5872c9c3e43df31dc0f3a954e5b"
+    },
+    "progs/misc_digit.mdl": {
+     "bytes": 3328,
+     "sha256": "60f16b89c1e9b8fb8bea0c0aeb96d2dbcfc14a719c130aaa34a581b26e653416"
+    },
+    "progs/misc_doomhelm.mdl": {
+     "bytes": 70104,
+     "sha256": "1b801d032daa163fab361a39631a16c501b86cc9e9b1a52a3f1454e50cdb8c8d"
+    },
+    "progs/misc_dpull_s.mdl": {
+     "bytes": 12900,
+     "sha256": "77fed0a028829fc7120db625131f855faf9b35f97f6ce0591e224bfae0fa78e6"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_fixture1.mdl": {
+     "bytes": 9768,
+     "sha256": "c10980d00e0479f8e65ab633f19ee62ace4c0697c2193f7aea8d266e2be5fc2d"
+    },
+    "progs/misc_flag.mdl": {
+     "bytes": 16052,
+     "sha256": "f2670312a8d16dd16e42fd02a39dfd285e6ffea624e729597b773c86140631d1"
+    },
+    "progs/misc_flame_big.mdl": {
+     "bytes": 244895,
+     "sha256": "09adba1308cdf22d2f07e226cb13a35e51f4d54866f84f41e2074dc7a40371d5"
+    },
+    "progs/misc_flame_med.mdl": {
+     "bytes": 175400,
+     "sha256": "31c94bc48e6c6d6bc31bd14b8e257c4e74d45aaec3a4d5d5bf83587a08ac7c00"
+    },
+    "progs/misc_giantbell.mdl": {
+     "bytes": 74016,
+     "sha256": "0d1b0e150de4ac59c599deae96d6b21e4ceb2300e7d410a1d802385dad99560b"
+    },
+    "progs/misc_heart.mdl": {
+     "bytes": 3512,
+     "sha256": "827ce2bbf2037aa26259901f4152d114cdf38312652e65e53f64ebbad9ea0849"
+    },
+    "progs/misc_impact.mdl": {
+     "bytes": 880,
+     "sha256": "93029307003bd0437071e0a89d0d4c2b699f2cde6ba34242c321cba8243f36b9"
+    },
+    "progs/misc_jstatue_01.mdl": {
+     "bytes": 1057632,
+     "sha256": "c583186f8bd56fd5ac356a8ed34956090eaad6e78506884bd520307e8f5e5698"
+    },
+    "progs/misc_jstatue_02.mdl": {
+     "bytes": 100260,
+     "sha256": "e4f3e702073a7f76ffddb79921a2bbb880d25edc0bdd6a6f115dfebcf99dbae2"
+    },
+    "progs/misc_jstatue_03.mdl": {
+     "bytes": 100244,
+     "sha256": "587cbce564e4da156a0ae20a87bd551046427f894f34959590573ce96fdf5c31"
+    },
+    "progs/misc_lantern.mdl": {
+     "bytes": 28836,
+     "sha256": "d84e36232543a053f2772b1070b221dc23da1b34cd08ea551a982b5e9f168ea5"
+    },
+    "progs/misc_levels.mdl": {
+     "bytes": 35732,
+     "sha256": "7cf9a4c1e556e60dd4e593cad4a2be0b45bea8893d9b5232ecc7febca4bbf5fe"
+    },
+    "progs/misc_lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/misc_lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/misc_longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/misc_madfish.mdl": {
+     "bytes": 84104,
+     "sha256": "30c19dadb42a53c7ccd35f992c5841aee13a86796157ea5e0453a4cb1586a1be"
+    },
+    "progs/misc_mooring.mdl": {
+     "bytes": 6676,
+     "sha256": "29b20cf17c62dddb4f0c1be758add7b15d6b22fd738fd9e2cd7533ac5d5475f8"
+    },
+    "progs/misc_mushroom.mdl": {
+     "bytes": 10804,
+     "sha256": "5570faa6e7828e4e12f568656226b0756a87d633cbdc461af472e0982a88a549"
+    },
+    "progs/misc_oscill.mdl": {
+     "bytes": 50660,
+     "sha256": "cdc96265a646f9e9fb4c1717fa90edb13e42130fadc4dc774b60aeb94b89eac4"
+    },
+    "progs/misc_player.mdl": {
+     "bytes": 562960,
+     "sha256": "83bbcf4cb5858aa9ac03323b461b3e3b09a28f56e212645472219d7d0b0979d8"
+    },
+    "progs/misc_plinth1.mdl": {
+     "bytes": 6196,
+     "sha256": "1ce0b7f49153f717e04436b27863c75f90a73b027c4cb7e36ce094fa037eded4"
+    },
+    "progs/misc_plinth2.mdl": {
+     "bytes": 6164,
+     "sha256": "e06edd50af1748235b251fe6e4217551c58d45c1f73161014dc0e9fd40099249"
+    },
+    "progs/misc_qwindow.mdl": {
+     "bytes": 77168,
+     "sha256": "facf489ac59158a3013118ca196f11a25a543f26559d5b72eef44968aa05008f"
+    },
+    "progs/misc_radar128.mdl": {
+     "bytes": 19492,
+     "sha256": "ef004e28e51e3227121a92432375531fca26d1e44894696f3d2a950fa65aef28"
+    },
+    "progs/misc_radar64.mdl": {
+     "bytes": 19492,
+     "sha256": "b9468012707ad484c1292cbe984c54811cb8fa43542e68e18a52ef93cb37d52a"
+    },
+    "progs/misc_radar96.mdl": {
+     "bytes": 19492,
+     "sha256": "6239d117263f49b79a2a66e62f2dbd6a7f0cd15ce412c1939dd69b4a1d8fce78"
+    },
+    "progs/misc_seaweed.mdl": {
+     "bytes": 16100,
+     "sha256": "dfbd38a439d392870c7c4c7ebea4475827b716004ca47bfa7f13b47daf07d774"
+    },
+    "progs/misc_shard.mdl": {
+     "bytes": 22388,
+     "sha256": "06c126f77ad931084d38f0e04d8f4341a5db3e3fa827e30de7d05bc60afd1c1d"
+    },
+    "progs/misc_skull.mdl": {
+     "bytes": 59892,
+     "sha256": "94600327093fe22acc113b8e89c8863a5548b170c9c9897bd2af8a4ff63beb5a"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 31792,
+     "sha256": "8d39b97460c9967ee36b33ea1ef1e92e89277fc410b44f054c5e06b8dc8a079c"
+    },
+    "progs/misc_spark.mdl": {
+     "bytes": 12672,
+     "sha256": "42afca9aeac1b05590b4821872cb79ebfbb4ee7264e914316d880e13f69c2b41"
+    },
+    "progs/misc_starfield.mdl": {
+     "bytes": 23548,
+     "sha256": "5b3563017939382680228e933a2a87d3edb030e75e65c51fe42c4a6889e42e15"
+    },
+    "progs/misc_stickskull1.mdl": {
+     "bytes": 87900,
+     "sha256": "38e63e10bc351ba5a48dfb6195ac5f78e5d61e67ae851f2ba50ba20255d7a37e"
+    },
+    "progs/misc_stickskull2.mdl": {
+     "bytes": 116364,
+     "sha256": "464fbee370b512d1c8057ea5a1dc3ecff69378474593919f0bbd8970419d69a5"
+    },
+    "progs/misc_tape.mdl": {
+     "bytes": 9240,
+     "sha256": "2b6a08ca3be4dd7a669e5b6d1585276759e1fb0edbe0691dd7ecbc7e41f0b189"
+    },
+    "progs/misc_textbook.mdl": {
+     "bytes": 74212,
+     "sha256": "e17e39efdf252a3da8c0574fdf272a800095671f42e71a17a3733673202dbfab"
+    },
+    "progs/misc_tree.mdl": {
+     "bytes": 120248,
+     "sha256": "888eca3c464ac068c7cdc5d7cf8f67fbcc70eb13c0079202a4f8d347f5f3bcd3"
+    },
+    "progs/misc_tree2.mdl": {
+     "bytes": 404432,
+     "sha256": "f14f3b046b58e5485afd11d396b4d358eb0598ea8cca1cbc6a70a8e629aee3f3"
+    },
+    "progs/misc_tutstatue.mdl": {
+     "bytes": 178480,
+     "sha256": "d178ba96d99b02113fe70d32f1672c1490d5f570aecf11d168e58f1bb7e8c17e"
+    },
+    "progs/misc_xmastree.mdl": {
+     "bytes": 479516,
+     "sha256": "59a89b398caa908ff6dd777cb42d0d7dfde930ac5569fdab4bc4f10dd8137584"
+    },
+    "progs/mon_boil.mdl": {
+     "bytes": 307068,
+     "sha256": "b8a79df258bf71f273dc29887c3782377bf890d43e32b690ebf2ef707eead6de"
+    },
+    "progs/mon_bossboglord.mdl": {
+     "bytes": 401092,
+     "sha256": "6fb5e0aa99fc9269b21e3a7c86e7ed70bf1f7e0150b629a39a4cf6647d0c9a1f"
+    },
+    "progs/mon_bosschthon.mdl": {
+     "bytes": 328244,
+     "sha256": "7fc4005959377598747d3accec535b52c81154b17b00221e2cd5410670223538"
+    },
+    "progs/mon_bosseidolon.mdl": {
+     "bytes": 1847180,
+     "sha256": "e08c763865b25851703f71e973755d5a7b446c8004f7d97c09fab04175373c10"
+    },
+    "progs/mon_bossicegolem.mdl": {
+     "bytes": 632584,
+     "sha256": "2a03c71a0451c389dc29374fa3a465fb0d8e9366309cbaeffb68057c928562ec"
+    },
+    "progs/mon_bossnour.mdl": {
+     "bytes": 200036,
+     "sha256": "732041ff70ec350c664194f90a9545b23b6736e729dd128f4482a0cca3ab7966"
+    },
+    "progs/mon_centurion.mdl": {
+     "bytes": 824572,
+     "sha256": "e638ad3021c5c77a1ad78fd798017fbb7a0ffa49ca2fc4a60570ba00e349d532"
+    },
+    "progs/mon_dcrossbow.mdl": {
+     "bytes": 1335168,
+     "sha256": "b38a7967cf800fdb45f9df9aa717ebc1c069fc8686a8e3e414f1c81d51f81d14"
+    },
+    "progs/mon_deflector.mdl": {
+     "bytes": 300016,
+     "sha256": "2bba37156abcde4ad2e7fc532a92b8139d4fc8041b565cd1e487829dc581341f"
+    },
+    "progs/mon_demon.mdl": {
+     "bytes": 156640,
+     "sha256": "9f1714fe997a78c9d3948e593a73fa3fe5704e11809ba095b8f564fca36b36c0"
+    },
+    "progs/mon_dfury.mdl": {
+     "bytes": 1495580,
+     "sha256": "0cb312b27bc1c9a7f9ac3d8c14e1e0d422d9968d4a9db0853d73185a19d6839d"
+    },
+    "progs/mon_dfury_glow.mdl": {
+     "bytes": 155140,
+     "sha256": "f743168f636c9e56475d73b3f8e139e5391e2abf0da4a6657174a7adc0f74238"
+    },
+    "progs/mon_dguard.mdl": {
+     "bytes": 724744,
+     "sha256": "1babb2976f1f86c2e499d3b8e83f4e4c04e434151bcb96a932a99a89b2bf3699"
+    },
+    "progs/mon_dguardq.mdl": {
+     "bytes": 176648,
+     "sha256": "f2f92ef84411d83c7e8c158f62b1415d8fc6aa56d77f21760dcd3080424cf6c8"
+    },
+    "progs/mon_dknight.mdl": {
+     "bytes": 1124632,
+     "sha256": "437c54ecfed53e34891b981a565c9b4f772c19702e1c099bba5ac40aabbed917"
+    },
+    "progs/mon_dknight_glow.mdl": {
+     "bytes": 971020,
+     "sha256": "22888d6171fc8df336fe686f4ffdfb0683bdb744e59cf81af9484b700666f6cf"
+    },
+    "progs/mon_dlord.mdl": {
+     "bytes": 1142583,
+     "sha256": "fb2ce7f5fbe369307f3eaefe0a74fffb2004657bec058dae50db651bc2fbc70f"
+    },
+    "progs/mon_dog.mdl": {
+     "bytes": 460652,
+     "sha256": "52cf8cb501f4b1ed457961b798eccd86974720af29f559723be82a0886824fd9"
+    },
+    "progs/mon_dprince.mdl": {
+     "bytes": 1022224,
+     "sha256": "aadd9ea12f307f0ef2b600a4a78d73082b8ea2eadd408f1fbe298082f4d03374"
+    },
+    "progs/mon_drole.mdl": {
+     "bytes": 241648,
+     "sha256": "2d5524d75cd52f12b42a5dfdd37bb33af27233394ec60bc234f79545d1cf13b4"
+    },
+    "progs/mon_dsergeant.mdl": {
+     "bytes": 1431784,
+     "sha256": "1affce6e3cbae9b5df1986672030fd869aa020972872767518f18ccc495c7432"
+    },
+    "progs/mon_eel.mdl": {
+     "bytes": 177368,
+     "sha256": "6acb4804e51e7de33404a4519d7f12b2413c921f61e33107345cb111ff156f96"
+    },
+    "progs/mon_enforcer.mdl": {
+     "bytes": 622480,
+     "sha256": "0e32f70f205a74995936d56e22259d1ccde591ed8a533577cd276419c5f60013"
+    },
+    "progs/mon_fish.mdl": {
+     "bytes": 311132,
+     "sha256": "40351e57dec8fad0aa34e5e5da233274e007a3beb80a291c9a2aa40ed43f8f00"
+    },
+    "progs/mon_floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/mon_freddie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/mon_fumigator.mdl": {
+     "bytes": 415072,
+     "sha256": "31bb90976e7489693c68fd6713ed5f1baf9645e3d7871922901dd093e8243da3"
+    },
+    "progs/mon_gargoyle.mdl": {
+     "bytes": 388132,
+     "sha256": "fe8134f2305858519445eb513b22f1f3382a1a6f334cf9549ddf1efe0b88435c"
+    },
+    "progs/mon_gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/mon_gaunt_elec.mdl": {
+     "bytes": 7164,
+     "sha256": "05129692bea7b62f2f5b7285cf133590e9356bfa0f6162ef6e3fc44508b29d8b"
+    },
+    "progs/mon_golem.mdl": {
+     "bytes": 632584,
+     "sha256": "c345c57eca380796f5dbcbdf7df80975c24e856d6d70ed1e9c11678f5d162c44"
+    },
+    "progs/mon_hknight.mdl": {
+     "bytes": 275836,
+     "sha256": "e32a90ca707224a389b7b0d3ecde76220e23f7746c2bc4e6397fe0d3a601844a"
+    },
+    "progs/mon_hknight_glow.mdl": {
+     "bytes": 212112,
+     "sha256": "60c24cb1dceeda2c64efb66e03cb8337717402c8070c0a19e1d9a6b5e0363d89"
+    },
+    "progs/mon_hogre.mdl": {
+     "bytes": 897896,
+     "sha256": "f8e0d054c44cf83bde03ee51ca8eb558dad7da336be8caf1383cf51d5b813da9"
+    },
+    "progs/mon_hogreham.mdl": {
+     "bytes": 979960,
+     "sha256": "d4ffb64b6112d48696002baf1bf8df0c686f404d1523ae409a9d01d237573e90"
+    },
+    "progs/mon_hogremac.mdl": {
+     "bytes": 901388,
+     "sha256": "daeed66878bbe85c45d2415de4270a8526be175ac74734ff55cf9750bf7c4875"
+    },
+    "progs/mon_jim.mdl": {
+     "bytes": 331872,
+     "sha256": "a49a51562fc5875509e39b62de550c4cebba65569708e1f63d0a54a6b8497448"
+    },
+    "progs/mon_jimrock.mdl": {
+     "bytes": 357748,
+     "sha256": "6c7e4a4f9b1b4392cf6e465be50e0a637a2a9b9b44b41e97a62acfc7b889f662"
+    },
+    "progs/mon_judge.mdl": {
+     "bytes": 1184920,
+     "sha256": "4e281291b8b6728bc6801c775defa987698a0f402a3a5553a32cf61865857040"
+    },
+    "progs/mon_justice.mdl": {
+     "bytes": 1287408,
+     "sha256": "bdd6b6ad28da26701dcef14503d148e96251575e04f583bef1f362455ab12497"
+    },
+    "progs/mon_knight.mdl": {
+     "bytes": 474244,
+     "sha256": "b279d87d180d237a71beddad02ecfaa87be42c990b91ee823f15f905fbb19b55"
+    },
+    "progs/mon_lostsoul.mdl": {
+     "bytes": 172216,
+     "sha256": "51c6d042ac9c670926d11743a09b294cbc992204077eae28b7b440570a7b0b4c"
+    },
+    "progs/mon_minotaur.mdl": {
+     "bytes": 669648,
+     "sha256": "3016ee951f60eb90a659c641546bc6aee80b1e2e9500b125c9c1343d625deb54"
+    },
+    "progs/mon_ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "ca0b6aee92201fa3ebeb226e7767c7a0f29495496d86bd384c327ff897b3557b"
+    },
+    "progs/mon_ogrefish.mdl": {
+     "bytes": 560428,
+     "sha256": "25edf562fbf71533ae0102832d92b7e138d056e1f90c9c681e5387659cd3160e"
+    },
+    "progs/mon_pyro.mdl": {
+     "bytes": 415072,
+     "sha256": "11a7efe7358b1477867a1263fd6e13a8531f557d1a8d0e0bfc5a1e9e6eab273a"
+    },
+    "progs/mon_scorpion.mdl": {
+     "bytes": 338288,
+     "sha256": "5d8a1b194cfc741b8dd194694dce305c35b0dca0bdf1c8d96897a085ad0eaf85"
+    },
+    "progs/mon_seeker.mdl": {
+     "bytes": 594628,
+     "sha256": "ab23bfb0c8b22c67b8d4b7b1658b445fb546fcc4f1ddb1f5c4990eb860434f3a"
+    },
+    "progs/mon_seeker_glow.mdl": {
+     "bytes": 594628,
+     "sha256": "122441a3be654d0198ba368ff9fd24d7f3fecb71fbafad6edfe80e3f57103ca8"
+    },
+    "progs/mon_sentinel.mdl": {
+     "bytes": 290664,
+     "sha256": "573efd78767922b2bbb3e5dab2b16cd8f90c2cb1709ecf4a315a141f4df77d09"
+    },
+    "progs/mon_shalrath.mdl": {
+     "bytes": 163336,
+     "sha256": "50b11e859246abf75af63b858d00b436690c9ed02562c0a7a3f434ed350c3a79"
+    },
+    "progs/mon_shambler.mdl": {
+     "bytes": 401092,
+     "sha256": "8f29b2ceddebcb9e69adbf12eb36c3924468cfaa1ff54cea31e6f289ab30e54a"
+    },
+    "progs/mon_skullwiz.mdl": {
+     "bytes": 980064,
+     "sha256": "c7637f2310ae9f173de872ea4aaf4380332f3d8d32782a8523f1d5d0a5ee3e45"
+    },
+    "progs/mon_soldier.mdl": {
+     "bytes": 931376,
+     "sha256": "8a67babdf47ecc69739e067d18b2629814469aec923851bd6c1133feae6ac56b"
+    },
+    "progs/mon_spiderb.mdl": {
+     "bytes": 228508,
+     "sha256": "209ee4dabf0f9b5619408cedcd8eaec7f8d4e48a8e1b51ca667bf5f8fea02dd6"
+    },
+    "progs/mon_spiderg.mdl": {
+     "bytes": 228508,
+     "sha256": "ffac4cf5b2d42df5b8a9674dc87c30ec925d6013d9ff0d29cb109c30047bcbd6"
+    },
+    "progs/mon_steelclaw.mdl": {
+     "bytes": 228508,
+     "sha256": "06fae126b984b1ed7b0ffa029b64e9b3df3a6269f01e8aba4b953bbafaa2c536"
+    },
+    "progs/mon_stinger.mdl": {
+     "bytes": 203428,
+     "sha256": "9d867b8a3d69a94d9a049c6cfcf0fa808b200ea3befe3b2518f1165881b9ad23"
+    },
+    "progs/mon_swampling.mdl": {
+     "bytes": 45332,
+     "sha256": "c7b379fcc17af3fbfaff1976ea8c14e9562093495dac01cd647c50863c4dec50"
+    },
+    "progs/mon_swamplingp.mdl": {
+     "bytes": 45332,
+     "sha256": "f1bd1496b4b9c90493f469bf81c6da0a1697290cd6374db15fd459ebab649cea"
+    },
+    "progs/mon_tarbaby.mdl": {
+     "bytes": 511008,
+     "sha256": "a9b9b6a49090bbf7d7d3a23618c3c21b2123e007488702d96b80531c563cdd4c"
+    },
+    "progs/mon_voreling.mdl": {
+     "bytes": 45332,
+     "sha256": "af233d21d6f0ea66267ba1c562ba223e1077bd07894333327ce12a6202938411"
+    },
+    "progs/mon_vorelingp.mdl": {
+     "bytes": 45332,
+     "sha256": "dadf32a61ef1ec6361606fc7173bab53f6c42e62dea9a3100a2073ffc5afaa58"
+    },
+    "progs/mon_wizard.mdl": {
+     "bytes": 106596,
+     "sha256": "aa93bbe4e7fd1686fcea4d6c49a982bb8b3defea2ca85c3177b86000ba8ba8e4"
+    },
+    "progs/mon_wraith.mdl": {
+     "bytes": 374256,
+     "sha256": "f2ec454f0e2896252204a99b18c16a5e61ae783220503a6b0ec75e149d1b25f7"
+    },
+    "progs/mon_wraith_glow.mdl": {
+     "bytes": 133676,
+     "sha256": "bc630a16b46ae0ef1fba35acaf4e41bc46dee4070305d32e9215692a18ae5705"
+    },
+    "progs/mon_youngone.mdl": {
+     "bytes": 103208,
+     "sha256": "de6f7f98d021ae2839cc81490886e6f29dfa31b5b45216d15ffb7f74edf1eb36"
+    },
+    "progs/mon_zombie.mdl": {
+     "bytes": 381660,
+     "sha256": "2dfc9832316861cff07f1c86da0f8809de95395a9dac718155bdbd06f739acaf"
+    },
+    "progs/mon_zombiek.mdl": {
+     "bytes": 228232,
+     "sha256": "431f57d3241b1253a1346ff1aa2bd7135f67c3e6fd5031140e07a7b4a0e861a2"
+    },
+    "progs/player.mdl": {
+     "bytes": 976432,
+     "sha256": "137eab1a3853f9a6f7f84c05442f7066268cac430bf73053cc7f806555a98925"
+    },
+    "progs/proj_balllava.mdl": {
+     "bytes": 18356,
+     "sha256": "f2a1de49bd215b4c7a1f424f1c644fe5cdb52df3c2d664c24b75cd2f389ae559"
+    },
+    "progs/proj_ballslime.mdl": {
+     "bytes": 18356,
+     "sha256": "d17f20cd8db385b724d58beaac1c3ed6b2597d51d00f1996b8b02bdb8a5e3ba1"
+    },
+    "progs/proj_blord1b.mdl": {
+     "bytes": 11472,
+     "sha256": "6c05b0f8790b77d3362166b2b304379942f56d498ae8fc365dbee6fcd6031f67"
+    },
+    "progs/proj_blord1s.mdl": {
+     "bytes": 8284,
+     "sha256": "5527dd12f00911fb333c2424994c0a95881caa72612d5e8236c8ce75530f6ae0"
+    },
+    "progs/proj_blord2b.mdl": {
+     "bytes": 11472,
+     "sha256": "fce6943e84bac672bf110d986ce2ed1ccb511128cb28508fb6aca53c7655806b"
+    },
+    "progs/proj_blord2s.mdl": {
+     "bytes": 8284,
+     "sha256": "a0d0ac315e46f784c35a0eac902f625e0337e79275b9f02ecb56002848202734"
+    },
+    "progs/proj_blordbeam1.mdl": {
+     "bytes": 12244,
+     "sha256": "e01c569bf66e75acdcbbfdbb50062eb24dd09f0415e6cb79148eab960f6a6f0f"
+    },
+    "progs/proj_blordbeam2.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/proj_blordbolt1.mdl": {
+     "bytes": 7868,
+     "sha256": "2ea0a49a8a75d1174151c36851ae21212b4df2df3473be5e73cc4cf293332d0f"
+    },
+    "progs/proj_blordbolt2.mdl": {
+     "bytes": 7868,
+     "sha256": "919dda70fe618cd37f57ef1e0dbc00b339ed082e2661ca024febee3ed49576f2"
+    },
+    "progs/proj_bolt1.mdl": {
+     "bytes": 1556,
+     "sha256": "890f6cd6faf7c36954185c4566a2cca619e627d5b365f05e1bffc7e12ac00ace"
+    },
+    "progs/proj_bolt2.mdl": {
+     "bytes": 1748,
+     "sha256": "ba4a6ffa3785b0e41c15045df9621a5a33f094eae2161064d472ea939654e229"
+    },
+    "progs/proj_bolt3.mdl": {
+     "bytes": 1748,
+     "sha256": "cf255497525c53162b019fe3df536314c4661a2d270f6bb847fe39a158b7f4e8"
+    },
+    "progs/proj_chthon1.mdl": {
+     "bytes": 65636,
+     "sha256": "92a964527d72ef1c40bbcfe0e915b56df81a0dcc2165ca4be47db44a8d644eb1"
+    },
+    "progs/proj_dguardq.mdl": {
+     "bytes": 12660,
+     "sha256": "ba5cba46edc108572d78e66166f5ed0405a48dcf672e7a569d14a4397f85f285"
+    },
+    "progs/proj_diam1.mdl": {
+     "bytes": 3292,
+     "sha256": "e7cbd736a84791c5234caa14713b3e0f6077409509845ae0b1993f38c2f1e1b9"
+    },
+    "progs/proj_diam2.mdl": {
+     "bytes": 2748,
+     "sha256": "b23586b1d570a9f516f6b83ea0af6ec1d8fe5693f8cd1279b251b031ba142d8c"
+    },
+    "progs/proj_dk.mdl": {
+     "bytes": 5172,
+     "sha256": "e861a125a60c82b88c7b3c23184a1485c967d0e127b4536213b7f46a97a6430e"
+    },
+    "progs/proj_dkgrn.mdl": {
+     "bytes": 5172,
+     "sha256": "820d2dac7255db7220889f6d8c3a2c97a7f77f75cd9ffbec6319b0ee257b3984"
+    },
+    "progs/proj_dlord1.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_dprince1b.mdl": {
+     "bytes": 6644,
+     "sha256": "7bcea6065d9f6c4e8a3a7c8a1dcd61252ff8baee01b7c04ecce0a7cfbc6d690d"
+    },
+    "progs/proj_dprince1r.mdl": {
+     "bytes": 6644,
+     "sha256": "5e3cc794f6b980e5e22adf011eead8768c88dcd84d74be9a8d34caebf33bf2ba"
+    },
+    "progs/proj_dprince2b.mdl": {
+     "bytes": 7468,
+     "sha256": "e81b4f767d1bba042464f1d35314ef4f2d30f7c552aaada2f772aba61fc5d62a"
+    },
+    "progs/proj_dprince2r.mdl": {
+     "bytes": 7468,
+     "sha256": "b967299e12983dacd0fcca1672818281483e6f89746422de285002cb043e1e24"
+    },
+    "progs/proj_drole.mdl": {
+     "bytes": 20796,
+     "sha256": "fbe9acdd31f7be2321df29b6add3d287d4e86ea2581e56ace5d7e9d185e28127"
+    },
+    "progs/proj_drolegrn.mdl": {
+     "bytes": 20796,
+     "sha256": "efbede1f5d565c56a535bb6392b5e638133c99b1df8bf93b1a1918d01c790123"
+    },
+    "progs/proj_eidolonrock1.mdl": {
+     "bytes": 14084,
+     "sha256": "e085fa791a83489e41c19c623ae84f80c7bc5f767cbbf691baa4665d3f85b273"
+    },
+    "progs/proj_flesh.mdl": {
+     "bytes": 19768,
+     "sha256": "8ff3f0f61001ac8e67317e4e01d03d905f15ef4104c141ba07b5ddb0c972390e"
+    },
+    "progs/proj_fleshp.mdl": {
+     "bytes": 10196,
+     "sha256": "3def912801c4b1b9b4c0f8ceea0690241493a5dd5f17e098cd6c37cefd927893"
+    },
+    "progs/proj_fury1.mdl": {
+     "bytes": 6644,
+     "sha256": "ce55af61fbd87b8daeb14151b3f77ac64713c4b53fcca89b2150d7f5cdfe886d"
+    },
+    "progs/proj_fury2.mdl": {
+     "bytes": 5748,
+     "sha256": "deb557248017e92f5501698355577cebb91c0d825b77a79f828589769a41ece7"
+    },
+    "progs/proj_gaplasma.mdl": {
+     "bytes": 2328,
+     "sha256": "dd3b4559cb4e4439ae87255ab2958c6c2cd3796ebbd27aaf1c6abc768ad4f8ad"
+    },
+    "progs/proj_gaplasmagrn.mdl": {
+     "bytes": 2328,
+     "sha256": "ecd2fdf0eb904f8be43c41821b06443d32a581b768ce8f776b07670b49cdd9af"
+    },
+    "progs/proj_gargball.mdl": {
+     "bytes": 18184,
+     "sha256": "b4b6bd7646bf80aa6f481616ba2b531dbccd3568cacc54885ebf020a166dbadd"
+    },
+    "progs/proj_gargballgrn.mdl": {
+     "bytes": 18184,
+     "sha256": "467a44838d83a94d5716c9af6f8c860cd8ec583ddb5f260cb0dd16e9bd04b957"
+    },
+    "progs/proj_gargoyle.mdl": {
+     "bytes": 5748,
+     "sha256": "774f52126fe6598f6a01a032691a36de26a0669e93d47508689d08fe85f46c21"
+    },
+    "progs/proj_gargoylegrn.mdl": {
+     "bytes": 5748,
+     "sha256": "b293b5e8696098e77602eb065f68f8a8e15c82af1c9890d36de48f29afbf43fe"
+    },
+    "progs/proj_ghook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/proj_golemrock1.mdl": {
+     "bytes": 7468,
+     "sha256": "5a2f0435dbcbfea724fe6bd8f6a76296359dbf4d874d15feec82b50a9275da74"
+    },
+    "progs/proj_golemrock2.mdl": {
+     "bytes": 19756,
+     "sha256": "41cc9bc49d6ae2018b7cf5345bbfe52517db2da060fce23fe57300ebcf643f98"
+    },
+    "progs/proj_golemshard.mdl": {
+     "bytes": 8596,
+     "sha256": "4a4a59362f5c5ecc2c4ce56419088982d5ed79a02d3c5b5a49bafd4c21c85e42"
+    },
+    "progs/proj_grenade.mdl": {
+     "bytes": 3508,
+     "sha256": "a7916ab1f9872689a0cfbea62543974b37dae5b3ec7ae3165eecd81c2c0d6617"
+    },
+    "progs/proj_grenadegrn.mdl": {
+     "bytes": 3508,
+     "sha256": "896f7a740acb59351891e752e6cc92725fcc6e26ea4bd5d1eb3219c8443db743"
+    },
+    "progs/proj_judger.mdl": {
+     "bytes": 7868,
+     "sha256": "a12f1f0bf494bc027c43e5aa89e54e055a571226499fbddce0f6b9e2bdb63766"
+    },
+    "progs/proj_laz.mdl": {
+     "bytes": 4724,
+     "sha256": "94e8c7d09857559ad9e5aaf6361b596afbcf100cf0ce8abf0107318af28c7943"
+    },
+    "progs/proj_lazblue.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/proj_lazgrn.mdl": {
+     "bytes": 4724,
+     "sha256": "d07d736b788aa512a5e57f39596c187644e69491026382800994378d3e849a6f"
+    },
+    "progs/proj_lightning2.mdl": {
+     "bytes": 11860,
+     "sha256": "c9cebc8d6f4836e7c302d51d0f942fde3da0960dae38733ccc3a851776e71520"
+    },
+    "progs/proj_minoball.mdl": {
+     "bytes": 18184,
+     "sha256": "756d8e9ecd60abc23954a792833c565ee1b5c905106ad2bd98143f56b0410391"
+    },
+    "progs/proj_minoblood.mdl": {
+     "bytes": 8284,
+     "sha256": "badd72734b86dd9bc11c5469bef944b6aea6b84071b07b44703c1ca62dd4dee2"
+    },
+    "progs/proj_minoplasma.mdl": {
+     "bytes": 8284,
+     "sha256": "cd79d0dce08293ded22b08b3a7134d8e52fc4cff10e07ee691e6ab53011a9ea9"
+    },
+    "progs/proj_minopoison.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_ng.mdl": {
+     "bytes": 1364,
+     "sha256": "cff312dd07f629847dd5e37b6ab00243d51ff7e40fc795f3612e68614cfbbe24"
+    },
+    "progs/proj_ngred.mdl": {
+     "bytes": 1364,
+     "sha256": "a1ec22733cc292a470c23990b8d0929bf5ee88844190d7174d9053109443d0dd"
+    },
+    "progs/proj_nour1.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_nour2b.mdl": {
+     "bytes": 14084,
+     "sha256": "9c7650dba595e8f8b2bacf3141252a5a2917e0204d3326661d6b9608fc8df2b3"
+    },
+    "progs/proj_nour2p.mdl": {
+     "bytes": 13152,
+     "sha256": "4051fc3dec1155a9efbc6bc5aab947447cebff83bec38d8c1e43dd1bd51f4611"
+    },
+    "progs/proj_nour2s.mdl": {
+     "bytes": 7468,
+     "sha256": "285570bdd658dfed133399c16f1586e2b2389f537a9d4b54d2dd5c1f8f6f1aa9"
+    },
+    "progs/proj_pgplasma.mdl": {
+     "bytes": 13152,
+     "sha256": "3c04f32bbf6f0623fc4101a31a0ce2d40c93354430433d91c2caed263284531e"
+    },
+    "progs/proj_plasma.mdl": {
+     "bytes": 4724,
+     "sha256": "6c4399ddc7653a9aa7834162d38dce6368dc271fec46a7830b73939351d7142a"
+    },
+    "progs/proj_plasmagrn.mdl": {
+     "bytes": 4724,
+     "sha256": "b2941e69d90a5e97c98a03a98bd52c4e047aa23dd2a1abd9ab6d3938f595732f"
+    },
+    "progs/proj_ringblast.mdl": {
+     "bytes": 135704,
+     "sha256": "e6de9bfd15db4bbf16fdd41b50204c5090ce09adbe132b1453435d3c8646cb4d"
+    },
+    "progs/proj_ringshock.mdl": {
+     "bytes": 18928,
+     "sha256": "f1a0a77edc79f2466b866a5486b29f92b696368137eb7eff9b137b6b66d65952"
+    },
+    "progs/proj_rocket.mdl": {
+     "bytes": 7812,
+     "sha256": "52d549b217c6f34e1d68248899ec5f5f550ef729929910e5953e114a53b3c251"
+    },
+    "progs/proj_rocketgrn.mdl": {
+     "bytes": 7812,
+     "sha256": "313f381553df0d8468ccb981441bf415130c9c730377d877e397511b8cc864f7"
+    },
+    "progs/proj_scorpion.mdl": {
+     "bytes": 6612,
+     "sha256": "1a2fa47a30a7e8026bacefa1f52580a04e10c48571318effab3e0623ebcc919e"
+    },
+    "progs/proj_serg.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_shal.mdl": {
+     "bytes": 6644,
+     "sha256": "dc62e9641d1328b1cfd20ac4f4df7e56b2f42bd40a22eea186f2784d1f5bc4ba"
+    },
+    "progs/proj_shalball.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalegg.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalgrn.mdl": {
+     "bytes": 6644,
+     "sha256": "6dfdef0a204aded86ef24730985f13acc5076d1bbb4b9ec1140b7333a70f4d0e"
+    },
+    "progs/proj_shalhome.mdl": {
+     "bytes": 8632,
+     "sha256": "e882b1dc5d01882f429b3a88f752431d3b38dad297861209b589330e3507f37e"
+    },
+    "progs/proj_shalhomegrn.mdl": {
+     "bytes": 8632,
+     "sha256": "d84be851bd87603186bf907506eabb9ce110c5a265c1cc884d18923361fdf4d9"
+    },
+    "progs/proj_shalshell.mdl": {
+     "bytes": 7468,
+     "sha256": "8c1591cc767fadabad655bfaf3a80362b264f51e0a1be67476b9272c2401afbd"
+    },
+    "progs/proj_shamlit.mdl": {
+     "bytes": 35240,
+     "sha256": "787c23ca986d469080879953e49b193cf0b2d22dff050a1d781ba039fcc594e4"
+    },
+    "progs/proj_shellcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/proj_shub1.mdl": {
+     "bytes": 18932,
+     "sha256": "c1a04846b791a123ecb367f11b35f4c1cc1e7e62e1d0f62ff1dd75978a712495"
+    },
+    "progs/proj_shub2.mdl": {
+     "bytes": 32860,
+     "sha256": "3d22df8151caf23c1ad7f3e28f83f97ca7503164977f1994dca2cc2ee54f84b9"
+    },
+    "progs/proj_skullball.mdl": {
+     "bytes": 9984,
+     "sha256": "41b3c1225070dcfca79f1bf19a2833e3d68144945fba51c8ce44d8029379906b"
+    },
+    "progs/proj_skullwiz.mdl": {
+     "bytes": 33588,
+     "sha256": "ff00ce3fbf9d0d55f6488a3a0a6bf15d2105b6e94489eec296a5851bf9f4f890"
+    },
+    "progs/proj_skullwizp.mdl": {
+     "bytes": 33588,
+     "sha256": "45fe8396037d88852d3e6937749bade4ef7c00d3c8240eeb0ecba4b56e831df3"
+    },
+    "progs/proj_smoke.mdl": {
+     "bytes": 244,
+     "sha256": "816e888f8242af86812bd581c9e93212c28f108699b70eb10d3e025f27a2818e"
+    },
+    "progs/proj_sng.mdl": {
+     "bytes": 1396,
+     "sha256": "b2a8656aee7ff508737afe1fdbf1a93d6958b33a0c31bae247a3979c616bdfe1"
+    },
+    "progs/proj_spider.mdl": {
+     "bytes": 7468,
+     "sha256": "76be6023b50a3b57c73f08c5758a693098ce8762eb92b55540d8bff2680fde4d"
+    },
+    "progs/proj_swampling.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_voreling.mdl": {
+     "bytes": 7468,
+     "sha256": "ab16a7fc8bf36827f4944ebe6919876acb5b2eaf869ff59f89ed237565a7ca9a"
+    },
+    "progs/proj_wiz.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_wraithball.mdl": {
+     "bytes": 22284,
+     "sha256": "24d62690c6347f9ab71ef5900c70d256346c2dfdc26e5488c3b91f220224c923"
+    },
+    "progs/proj_wraithbone.mdl": {
+     "bytes": 6612,
+     "sha256": "8fa994dd2c7a5e9d7140ae394d07d368d083f4cee6808f6d9d026ec464804503"
+    },
+    "progs/proj_wraithegg.mdl": {
+     "bytes": 9984,
+     "sha256": "5b888e26f90cfe26800cd50d422b4ef75487dde61d63fd34965506591b326a8f"
+    },
+    "progs/proj_wraithpoison.mdl": {
+     "bytes": 6612,
+     "sha256": "02a06fdccb8f7ba595ea71f227e5b256995e782bcc9ce75bcb85a31ed0333256"
+    },
+    "progs/proj_wraithshell.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_wraithtrail.mdl": {
+     "bytes": 24544,
+     "sha256": "23ee065ea4a542ee7348d9bc08e052ffca4e272418b81937105d14730aab705e"
+    },
+    "progs/s_bookrune1.spr": {
+     "bytes": 1140,
+     "sha256": "b9fc52d2ca728fffa4c282d818b68aeec3555a0dbad3cd1507199d534db1f047"
+    },
+    "progs/s_bookrune2.spr": {
+     "bytes": 1140,
+     "sha256": "400a620928e3581891e8a71b338c8a53b6387e0acdc3fda3f10ae27596ae6bbc"
+    },
+    "progs/s_bubble_blue1.spr": {
+     "bytes": 1140,
+     "sha256": "27cb0d1f52e3ecd4b7ae0d9dc96078a7554bde09839f1a2ee2d9772ac5d67981"
+    },
+    "progs/s_bubble_blue2.spr": {
+     "bytes": 1140,
+     "sha256": "d540bb04a7835ec3bd7490904fbafde0f3aa64ba559bb6bd99ab538568ec0cae"
+    },
+    "progs/s_bubble_brnd1.spr": {
+     "bytes": 1140,
+     "sha256": "43591346d87a547454b387220b3c32693e7f1563b6ae4152ff7ee96c24936b84"
+    },
+    "progs/s_bubble_brnd2.spr": {
+     "bytes": 1140,
+     "sha256": "2f185b37bd1cd5a8d6b472885469dbdb3f1b0fdeba2a6d620de09b17646b4fc2"
+    },
+    "progs/s_bubble_brnl1.spr": {
+     "bytes": 1140,
+     "sha256": "370ed3a9f77291522c31ac1d0ce414078d9b3eb40a9157c08ad5cf87d6428897"
+    },
+    "progs/s_bubble_brnl2.spr": {
+     "bytes": 1140,
+     "sha256": "1b3d4f0ac00fa7cbce076d334f4b210b9059afbf2c4b07a0e98e88fe57356351"
+    },
+    "progs/s_bubble_grey.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_grn1.spr": {
+     "bytes": 1140,
+     "sha256": "efa8692bb74428af2753b415f8f08edbfc2b2cbe75cc59f6545985d289d6016f"
+    },
+    "progs/s_bubble_grn2.spr": {
+     "bytes": 1140,
+     "sha256": "3062ba1064da37ecf7dad074a9b0437352865fa43aecf783e4afe8a6c8c104c2"
+    },
+    "progs/s_bubble_pinkyel.spr": {
+     "bytes": 312,
+     "sha256": "5376726ffdf2132d3ab712ba23b408e8068500485f11adff85d0fd90c08248c6"
+    },
+    "progs/s_bubble_purp1.spr": {
+     "bytes": 1140,
+     "sha256": "2e4b7b23b08b6e89d2dc46f26b12b9ad1ee8f91ea868aeb9916d2adb42e00b75"
+    },
+    "progs/s_bubble_purp2.spr": {
+     "bytes": 1140,
+     "sha256": "ae21a26ad7897b9c5d201a1eb248e1358ee84eafdbfd899d679558e9aa5a1a66"
+    },
+    "progs/s_bubble_red1.spr": {
+     "bytes": 1140,
+     "sha256": "2a52f2c4dfdae381deeca608e5d007afe9dc245bbe16fea88c88f39c10ff7dc6"
+    },
+    "progs/s_bubble_red2.spr": {
+     "bytes": 1140,
+     "sha256": "fffcc0e03f9acc75e05636ab67f5f647568c81d0bcf4623e64d487c04d9cd5eb"
+    },
+    "progs/s_bubble_wht.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_yell.spr": {
+     "bytes": 1140,
+     "sha256": "9dcce864ad255b17d7d45e5c5531114f6a66c4e9cb549fc8b31aef0af5a9157f"
+    },
+    "progs/s_burst_flame.spr": {
+     "bytes": 22128,
+     "sha256": "66511ada8a299b0882e2939c09d3fb726d3ce52ecb93a884584a9ce11915a6c0"
+    },
+    "progs/s_burst_flamedp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_poison.spr": {
+     "bytes": 22128,
+     "sha256": "d8245e0460efc4e939a187912126f44422c39b1fe4b553c2c15da91833e8549d"
+    },
+    "progs/s_burst_poisondp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_burst_steam.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_dotmed_blue.spr": {
+     "bytes": 1140,
+     "sha256": "0b3160c5a4ae42216ddb7aaa7ae4726f6b2507c914328abe3c69f2d12fd921f8"
+    },
+    "progs/s_dotmed_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "6e28b69544f8aa13ccbb9a66893e4ab86b83639ee3f81dbbe1b94290ca9b03ef"
+    },
+    "progs/s_dotmed_grey.spr": {
+     "bytes": 1140,
+     "sha256": "77c226763e90a54b4d6835bd877c08c501605e516e64177c915c422e7b36c207"
+    },
+    "progs/s_dotmed_grn.spr": {
+     "bytes": 1140,
+     "sha256": "d1a9800a8b5cad01fa1dc93e57162e9960c4a8478e7e427d66cdbfe6a6797266"
+    },
+    "progs/s_dotmed_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "6113140f371b08cda9addcf68282c1fc16692da7498fa2fdfe2b99662e345d67"
+    },
+    "progs/s_dotmed_purp.spr": {
+     "bytes": 1140,
+     "sha256": "8b2cfa67ac86841f59409e184b4f3a253218e5930a5e3f241caef39dc1baa8de"
+    },
+    "progs/s_dotmed_red.spr": {
+     "bytes": 1140,
+     "sha256": "4ae92a280e0df01c0acd0a904214af485bb60919e5ded4573aa12f86875182d4"
+    },
+    "progs/s_dotmed_tor1.spr": {
+     "bytes": 1140,
+     "sha256": "eddd46a4818dfa92a9817df82e893d6bf6513160164a74b95bdd42fb7cac2f75"
+    },
+    "progs/s_dotmed_tor2.spr": {
+     "bytes": 1140,
+     "sha256": "dcb87897de0f54a6d8f78e9194a15c11261eb88455f058b334f8648a363159a9"
+    },
+    "progs/s_dotmed_yell.spr": {
+     "bytes": 1140,
+     "sha256": "e6b72aac439291d7719ee78d9520c1a1def36212ac7f61ba333fa87d5265c63f"
+    },
+    "progs/s_dotsml_black.spr": {
+     "bytes": 632,
+     "sha256": "2ae7fa13584d12f04b337fbbd774e74fbe54a6fcbd354239e97fecce931bd377"
+    },
+    "progs/s_dotsml_blue.spr": {
+     "bytes": 1140,
+     "sha256": "c0149109ae73a72da49bfaf9ba00cf2edadbe0f053928d09319083e6247883ad"
+    },
+    "progs/s_dotsml_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "f95fe813ecce2c69d2b72e5bf870d045037519c89f3da9a300e7453754cd1503"
+    },
+    "progs/s_dotsml_gold.spr": {
+     "bytes": 1140,
+     "sha256": "3833e80c32da39063b5069638ade52c4aee51b7db7206b4911cb48f321e25bdc"
+    },
+    "progs/s_dotsml_grey.spr": {
+     "bytes": 1140,
+     "sha256": "2e16d9ff8ceca2994a609703f405b1efbb7b49e02c8dbb9e77d0cdcaf3318b98"
+    },
+    "progs/s_dotsml_grn.spr": {
+     "bytes": 1140,
+     "sha256": "a2735123addacfa03f2666969e476af0d9f1cfefbef75a7ac9599d48f86226b1"
+    },
+    "progs/s_dotsml_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "ebf62caae17163587aaa3652300f1003c008ed21041b838a14cfff7672f87d90"
+    },
+    "progs/s_dotsml_purp.spr": {
+     "bytes": 1140,
+     "sha256": "476042db782f7f81cb53d91e9518881f28eb34d3a2a535c11d9c22f65518bce4"
+    },
+    "progs/s_dotsml_red.spr": {
+     "bytes": 1140,
+     "sha256": "94c0403ee7f1e6f6c4d6bc9b99e73e48143845fe35d0d6b3de246842241b12cb"
+    },
+    "progs/s_dotsml_wht.spr": {
+     "bytes": 1140,
+     "sha256": "7ac2d5b9b1e14a1799b951ace16bcc1addb7fefc2470dec23ef2ca110a934bf5"
+    },
+    "progs/s_dotsml_yell.spr": {
+     "bytes": 1140,
+     "sha256": "686f220b937040b91b6ff4f05efd41525d40eb80a61ff8138809d550bfa99959"
+    },
+    "progs/s_dripblue.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/s_dripgreen.spr": {
+     "bytes": 60,
+     "sha256": "805935ef90e14eda0f0ec89cc7e03acf52df768eb9e09140629bc1067a658774"
+    },
+    "progs/s_dripred.spr": {
+     "bytes": 60,
+     "sha256": "2dc81cd44438e124dedef0b656c31a066b7879940fcdbc39a0cfd57a6d2985e5"
+    },
+    "progs/s_dripsplblue.spr": {
+     "bytes": 828,
+     "sha256": "6b960ccc7a877bf2b4b67467400c0eaa1bb88d8c8a524458b9bf8d1aa1a6e29f"
+    },
+    "progs/s_dripsplgreen.spr": {
+     "bytes": 828,
+     "sha256": "397ac392598027c27240d71079f79eb9c90306724bc54c5d9854e14939059b6c"
+    },
+    "progs/s_dripsplred.spr": {
+     "bytes": 828,
+     "sha256": "268b48b87a0f352b671c04a1f7325af43372578a6d73269356389280eb7ef232"
+    },
+    "progs/s_exp_big.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_exp_electric.spr": {
+     "bytes": 5256,
+     "sha256": "ed01b728b6656a68acffe258d644712eba3b786434ab6b3e6d90434031e90d96"
+    },
+    "progs/s_exp_ice_big.spr": {
+     "bytes": 164076,
+     "sha256": "bf7317d811349602db7a020da3e77065ffd8158a3104e83ddca3b166566df18c"
+    },
+    "progs/s_exp_med.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_exp_plasma_big.spr": {
+     "bytes": 213288,
+     "sha256": "fe99a489e169ccf56f0412c2e83a7c5aea7b75b7cee0501402c62fcbd7ca969c"
+    },
+    "progs/s_exp_plasma_small.spr": {
+     "bytes": 53544,
+     "sha256": "555e39e88cedaf9e9dd1215ad1325b32019a6bf2654d53736b1f362506548150"
+    },
+    "progs/s_exp_poison_med.spr": {
+     "bytes": 72892,
+     "sha256": "60b7a8c194f3a6cd2241edd6223ac1da1f57811d7f5416216c70a2797d1baf20"
+    },
+    "progs/s_exp_poison_small.spr": {
+     "bytes": 53544,
+     "sha256": "2a54104dec9381afe338574d66bcc19bd2776caa0d46031c743cd24782098d3f"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "a9476d95ea10fbd2317c174272864efa4bb6e939893f3a3de520aeea3e3522d9"
+    },
+    "progs/s_flamemed.spr": {
+     "bytes": 43324,
+     "sha256": "3c645e305673693089fe48cc7a22f694eeaf7881cfc94ff7b1c4b05b718342cc"
+    },
+    "progs/s_flamesml.spr": {
+     "bytes": 21820,
+     "sha256": "5e60165461c34a3a25cbe6b0bb5e36131bb4a81fef384f1db4a7236f30e7ba95"
+    },
+    "progs/s_flametiny.spr": {
+     "bytes": 11068,
+     "sha256": "9d2c0af6139f3d194e73dbcb7880aa0a6f2a04019f94818ce9844691399b551b"
+    },
+    "progs/s_judgemagic.spr": {
+     "bytes": 12564,
+     "sha256": "6d08d5ada6bac219927edb39a93302f98b7b1a357e6648fc1abb49fd5cc3bd4c"
+    },
+    "progs/s_marsh_med.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/s_marsh_small.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/targd_hull2.mdl": {
+     "bytes": 3380,
+     "sha256": "520c82906942d582c6b64da4dca32ca8ed236694607c3a19ec71b89136e0c757"
+    },
+    "progs/targd_massive.mdl": {
+     "bytes": 17076,
+     "sha256": "099ed67733ea3a461c2247d6f07d3dadcc5a6968bcd6a03398507c653d174395"
+    },
+    "progs/targd_short.mdl": {
+     "bytes": 4788,
+     "sha256": "c883300477d3978469aabc35ef3969c14645c1111997c64452634fc8b4a978e1"
+    },
+    "progs/targd_tall.mdl": {
+     "bytes": 4788,
+     "sha256": "bab77599f9cbbe1cf0856a642612ae30b08fed9ae27a209abda30f6dc8c07129"
+    },
+    "progs/targd_wide.mdl": {
+     "bytes": 17076,
+     "sha256": "d40a00625196f67fe26f3611cd91dd33484ddbf3db273766f8a5fac38db07b07"
+    },
+    "progs/trap_pendlong.mdl": {
+     "bytes": 44900,
+     "sha256": "62d3b86fea6e2336dfc5c7b93514e096eba05992a3bd3e0c6571e4c4a27be684"
+    },
+    "progs/trap_pendshort.mdl": {
+     "bytes": 44900,
+     "sha256": "efb3e395093e34d7b16c92ed73abb199a28d0bc653522c13d4e720030f547713"
+    },
+    "progs/trap_sawblade.mdl": {
+     "bytes": 28716,
+     "sha256": "759bd7e1f7629b4d87ecb9e53a9f2d66e3e81b9103bc4eab3f85bd598eba36f6"
+    },
+    "progs/v_ghook.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "5b6b84edc6e6c58128a6e830ec35424cc83e69fab7b1337c4c681d8d0ed81e74"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 48964,
+     "sha256": "d073c7fad7dee2c4664aa401d744024b623abcd65e60a4c7066721b988838aff"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 54940,
+     "sha256": "c0a6b7d9664b0ab5a0c77732b22592dedfefbf65c624c05bec7aa8d60835f74d"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 39668,
+     "sha256": "78fc36ddbd33fb77192ef100547f1a1a0f70a38fdaac7094df67f2df33ca9237"
+    },
+    "progs/v_shadaxe0.mdl": {
+     "bytes": 97860,
+     "sha256": "598f555a854590a749eee83870a869ebfa8dfd3c84ad447b7fe3fb796ea1da80"
+    },
+    "progs/v_shadaxe1.mdl": {
+     "bytes": 97860,
+     "sha256": "2ffbb3026a21d70a73a091222cc4f2ea2ba6abd706fbffc276f027b9475abfaa"
+    },
+    "progs/v_shadaxe2.mdl": {
+     "bytes": 97860,
+     "sha256": "cd2a7a188f73c5b841183885663470c53c3af5646491f44811a4a0f192381ed7"
+    },
+    "progs/v_shadaxe3.mdl": {
+     "bytes": 97860,
+     "sha256": "b1c0dd11ce314003de5051f8a3b9581ee3eda5ea347d3d3371eea43051820197"
+    },
+    "progs/v_shadaxe4.mdl": {
+     "bytes": 97860,
+     "sha256": "81108f8b2484d24e54e9ab3ee5b707be5ea28adb142159412aa773ae01e593c1"
+    },
+    "progs/v_shadaxe5.mdl": {
+     "bytes": 97860,
+     "sha256": "0d3ca1664ee82ab2aed6261c262fdc455db981ecd2d62371595e520756d7bb22"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 22260,
+     "sha256": "bf79b703708665b9e65556bf68c0fe9d177097b2b96b11563d7b8bf84485a81b"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 22764,
+     "sha256": "5a51ba87bcdf37463bb8f34dd7259ea2be54d540fbc59798bb62dc24b2d3e777"
+    },
+    "progs/v_shot3.mdl": {
+     "bytes": 77868,
+     "sha256": "5b08bebaeb2fa054e6bb37d51c716cfac0e4da843b0db158a4a9769fa04ad13f"
+    },
+    "progs/v_zershot.mdl": {
+     "bytes": 62604,
+     "sha256": "4173bb2b84f9adce1957a87251cca591d968c3a54e801b170a87aae82539a2b1"
+    },
+    "progs/w_backpack.mdl": {
+     "bytes": 138832,
+     "sha256": "78d86e7bc605746990a1b10644b12542f3380375693d4fb015884e42269314a0"
+    },
+    "progs/w_blueflail.mdl": {
+     "bytes": 17236,
+     "sha256": "3b645ebcb5d2249c9cf904e17006b85aa05963efda33f45f5b6f6fc3ea188d26"
+    },
+    "progs/w_chainsaw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/w_dcrossbow.mdl": {
+     "bytes": 14388,
+     "sha256": "52b14c48ec77acb261f18e1d7903e360eb96acb5c22a0702dfde90c66b103064"
+    },
+    "progs/w_dfurysword1.mdl": {
+     "bytes": 8916,
+     "sha256": "16521de90d0e71090ef4e6b5904252f3ae2d4a38ebe99eff9dc758ea009b0f90"
+    },
+    "progs/w_dfurysword2.mdl": {
+     "bytes": 8916,
+     "sha256": "2e42b37254cf8d85b098e58143fd77d86bed2f3568f630196326841298d07187"
+    },
+    "progs/w_dguardsword.mdl": {
+     "bytes": 8404,
+     "sha256": "74b884b8fd0a785fc2c1dcc29428b8d4c8725de6963bccf7ec80c396e002fa38"
+    },
+    "progs/w_dknightsword.mdl": {
+     "bytes": 8404,
+     "sha256": "1e6729ae15dd1520fff7f4c1c30260c35b637bd0b23b8fb3a5a476b175a39165"
+    },
+    "progs/w_dprincesword.mdl": {
+     "bytes": 19296,
+     "sha256": "89e5ef1382e980b68e812f7e8f6a9b6fba34af42bb2def457b7a2f6f8d7388b7"
+    },
+    "progs/w_enforcergun.mdl": {
+     "bytes": 42612,
+     "sha256": "fbbfd121a3d085d654aab512cfebb0b6890daf3c403f25ca372edc3c53039375"
+    },
+    "progs/w_hknightsword.mdl": {
+     "bytes": 20504,
+     "sha256": "a8dffdc9e400d45fcea617255a8731d752cfa83df40b923128d5dbae6839492c"
+    },
+    "progs/w_judgesword.mdl": {
+     "bytes": 199388,
+     "sha256": "c822984ba5a12948ca389f4b8536c3aa6644993242362b10ac7f6ff2e2332590"
+    },
+    "progs/w_justicesword.mdl": {
+     "bytes": 264928,
+     "sha256": "0fc111a637bdaf5372c02c53439497c2adfc0914845b947ecc9ad70ace1e1b3d"
+    },
+    "progs/w_knightsword.mdl": {
+     "bytes": 14328,
+     "sha256": "4740ee2b171380cd9481ba07f284fe720c5b49b0980dc19cb145b2356205fc0a"
+    },
+    "progs/w_ogregl.mdl": {
+     "bytes": 8260,
+     "sha256": "8071cb814b6158c8af563494687e3994192818ccc2aa80f4766bbf6912d559ee"
+    },
+    "progs/w_ogreham.mdl": {
+     "bytes": 29996,
+     "sha256": "11c1ec322889a971b7f930a7c653f13e69714e6de77b7afa4ded1fdec39145de"
+    },
+    "progs/w_ogremac.mdl": {
+     "bytes": 29324,
+     "sha256": "2f9086da6b43becab1d54e47bcb299421b1bdc1e1e71c41e581b367a75f52919"
+    },
+    "progs/w_skullbook.mdl": {
+     "bytes": 25580,
+     "sha256": "e99379e980169501931eb029f36d05b41ba52f8597a6022bf195b08dba88c70e"
+    },
+    "progs/w_soldiergun.mdl": {
+     "bytes": 36120,
+     "sha256": "9c89a19d7c5fa69783d8bcf59b46b18a0c80c37e280b18731564952faf1d6523"
+    },
+    "progs/w_zombiesword.mdl": {
+     "bytes": 14328,
+     "sha256": "e4ac73fc149fa581e64fb5f2016ce58c99ab1c9a76502ede78a525ab7f344b0c"
+    },
+    "sound/ambience/bell_ring1.wav": {
+     "bytes": 61586,
+     "sha256": "b9169a48fd032d7c2b0cadb61540ac5db42ca6384cb2c74818bd46bae3fc7db1"
+    },
+    "sound/ambience/bigmachine_loop_02.wav": {
+     "bytes": 92760,
+     "sha256": "4d6dd03883ac4462c7f1741c022a3e8fd9e2c65cd54d5d126f58c00b3bfe7df3"
+    },
+    "sound/ambience/chimes.wav": {
+     "bytes": 250476,
+     "sha256": "d1060cd75d8a520b748047790d33c9a4ab5fd626330ebf1242d318d308c165db"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/distant_gears.wav": {
+     "bytes": 72502,
+     "sha256": "760d34131249ff3c4bccdab0cd3df69874728a6db3e1b4545177e5ce381e5e80"
+    },
+    "sound/ambience/drone6.wav": {
+     "bytes": 36820,
+     "sha256": "ab0cc1d617b06169d20b42bddc31078c0c7a1b8b15793fe6cfea6dbc96b4129e"
+    },
+    "sound/ambience/fan_finish.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/fan_loop.wav": {
+     "bytes": 288110,
+     "sha256": "d7459b4f1087aa1e002f41fc0274e4cb2f313dff5af2eecaa9de5225bcdcd729"
+    },
+    "sound/ambience/fan_start1s.wav": {
+     "bytes": 96044,
+     "sha256": "b0bad8ae3cd81dc4bbd76591e29f9c43610cb6e0311d4822213e400a6b99dd9f"
+    },
+    "sound/ambience/fan_start2s.wav": {
+     "bytes": 192044,
+     "sha256": "6716a803f246e44416fc414ca2f51744fc1ed79178f79fe3baf7a986c820c020"
+    },
+    "sound/ambience/fan_stop.wav": {
+     "bytes": 192044,
+     "sha256": "ee8607922387eeb594c18096ef6dd4003990a5fe47414dee331921f6d03be6b7"
+    },
+    "sound/ambience/fire1.wav": {
+     "bytes": 47906,
+     "sha256": "c1370a7c177aa21de219578cc64716bc800007e2ac86ae106affac01f8edc470"
+    },
+    "sound/ambience/flames1.wav": {
+     "bytes": 132406,
+     "sha256": "8ac99a7ace2ec9cc98a38fd5777973eb484e9193cf93dfcd6a51ea4f0f9d0f00"
+    },
+    "sound/ambience/flames2.wav": {
+     "bytes": 132406,
+     "sha256": "31e76d131cb4ad3c0602e2559c949feb7a8749c639363f1fd7df53136616fdd1"
+    },
+    "sound/ambience/flames3.wav": {
+     "bytes": 132406,
+     "sha256": "b4008d1da182bc0886f8bad53e5a700d8e04050920aa27ceb0922be938eb7c96"
+    },
+    "sound/ambience/flames4.wav": {
+     "bytes": 132406,
+     "sha256": "222222e080566c899a48df9e40006d0ee36575c03250c44845fb10a94c5cead9"
+    },
+    "sound/ambience/gargoyles.wav": {
+     "bytes": 136816,
+     "sha256": "16f09404b6043aaacb4b6b2bb00143ab72b5e185f02e610d780ea7d311d2df6c"
+    },
+    "sound/ambience/gearopen.wav": {
+     "bytes": 49708,
+     "sha256": "39b73c8ada1b06c7ba07099447b9b0d75911f08df09ced3826bcff136af5b0ee"
+    },
+    "sound/ambience/generator_gas.wav": {
+     "bytes": 529314,
+     "sha256": "6710075453fde424951171823e87f3711d53fd434149ddecc14a14ce721de04a"
+    },
+    "sound/ambience/ind_lift1.wav": {
+     "bytes": 158906,
+     "sha256": "c722fa19c7851d2c7b4307489911b885527e31fd3e4de44d5a184bd786714049"
+    },
+    "sound/ambience/ind_lift2.wav": {
+     "bytes": 156008,
+     "sha256": "c404881a9758f839fd055dd69a82f04bf7e5d5b98538a4a87b2ee741d8b4956d"
+    },
+    "sound/ambience/light_hum1.wav": {
+     "bytes": 100022,
+     "sha256": "cb2f04b81297621ffddbfb028dc5021a665e3285deb7c80757a47add8294f032"
+    },
+    "sound/ambience/liquid_bubble.wav": {
+     "bytes": 129688,
+     "sha256": "838ec1e72b2c433408a342a48518987edcb2124932eeb477d59653540b13d6ea"
+    },
+    "sound/ambience/liquid_burnlong.wav": {
+     "bytes": 710182,
+     "sha256": "9c9c77941f88416e3f20dfc4f028cc6c9719dd7f58a15dfc6124f1bb5a17f61a"
+    },
+    "sound/ambience/liquid_burnshort.wav": {
+     "bytes": 89464,
+     "sha256": "4ea16997389f1aa35549869a338f2093f40d14df030c381a7659cc7e3cbf8bfc"
+    },
+    "sound/ambience/liquid_drain.wav": {
+     "bytes": 220464,
+     "sha256": "e86a6012c8fc3a795791fc344ef636bb1854a602cd609e2df751531e89277cf9"
+    },
+    "sound/ambience/lowboom.wav": {
+     "bytes": 666640,
+     "sha256": "ad591a6f574f48e654e32dacee6b7d862df8b47e20ef116f84415ad9aa515559"
+    },
+    "sound/ambience/machine_loop1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/ambience/machine_loop2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/moo.wav": {
+     "bytes": 265502,
+     "sha256": "35b7924115bc4cdf94e9cbb274a4d9ca251d6878817834bec08aaa176f2ddc9b"
+    },
+    "sound/ambience/mystery_drone.wav": {
+     "bytes": 1350258,
+     "sha256": "eb3fbb28dda2a6204af07d08fa993ed09513f9915142dd6f4af808204b6b8c9e"
+    },
+    "sound/ambience/power_drone.wav": {
+     "bytes": 36700,
+     "sha256": "4307c01076cb5e076d27546b17bd6b11e2369a67b59dbbd64f2607d8b262a8c2"
+    },
+    "sound/ambience/power_off.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/ambience/power_on.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/ambience/power_shutdown.wav": {
+     "bytes": 1118464,
+     "sha256": "e0ab1a0f67a2d37a525f7a73e8ee8c3a26f746e027fa1501f6648f5586ea2048"
+    },
+    "sound/ambience/power_switch.wav": {
+     "bytes": 66382,
+     "sha256": "5c006bb7315e6eb6d2367ae30a78f0abec8ae2a1e2b6a2c9af88354962b0f33f"
+    },
+    "sound/ambience/rain1_nl.wav": {
+     "bytes": 154394,
+     "sha256": "45d8c08ff4a9a2dd6ff8362fea7c22f9c3ea64a3a8d7b6c81c8cad88265f327a"
+    },
+    "sound/ambience/rain2_fade.wav": {
+     "bytes": 198550,
+     "sha256": "3cf300a4f785d416656838bd3a68120bf6a48d16f928ca74e2e0890ec9f8b426"
+    },
+    "sound/ambience/rain2_nl.wav": {
+     "bytes": 66250,
+     "sha256": "f2735ae8a7b1ae5ab5ce3b8ed66d8c61d00a65f2e66d8c565f4abe718d57ab67"
+    },
+    "sound/ambience/rain2_org.wav": {
+     "bytes": 132400,
+     "sha256": "4c1f820b2c8f4bea08b8357fb8409e9f30a98fd0faf1413a1953ea697b84b507"
+    },
+    "sound/ambience/rumble1.wav": {
+     "bytes": 403620,
+     "sha256": "47afe820548bcf248b7760f7a66a61ea65b5fb79f70d47e3b03cf8211bb4c5f3"
+    },
+    "sound/ambience/rumble2.wav": {
+     "bytes": 99104,
+     "sha256": "9c3d5418c7e5bac60c365f0e8b7ea496dd2b51c72c13b0e5a6640e2ef880433a"
+    },
+    "sound/ambience/rumble3.wav": {
+     "bytes": 209242,
+     "sha256": "864f373dbd75172e1c8f31373188f38c31a80af46592f6b2e92cf5f576e5e0e1"
+    },
+    "sound/ambience/s1_stop.wav": {
+     "bytes": 16162,
+     "sha256": "9a35adf9361aa033b413762fea7d04b2cf7392b363f2aa187a81905f65a44b61"
+    },
+    "sound/ambience/switch_1.wav": {
+     "bytes": 35324,
+     "sha256": "9f73f07313ba4995247d82901111b5aea4200c48de6641dddb145dfadcac40c9"
+    },
+    "sound/ambience/switch_2.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/switch_3.wav": {
+     "bytes": 17576,
+     "sha256": "33b6ed57b0255840415df4db607f86b1183b564f4b1f2dcab6d45d4d75231b8c"
+    },
+    "sound/ambience/switch_4.wav": {
+     "bytes": 44348,
+     "sha256": "bfebdf2afdbab57bd5be3fe0996ce19ff46d983eea4d1511d85af2e4f7d0db00"
+    },
+    "sound/ambience/switch_5.wav": {
+     "bytes": 79992,
+     "sha256": "78bb8cb9ab7202657495a0ca14340886af901912850b9951b0da159f55c2cb20"
+    },
+    "sound/ambience/switch_6off.wav": {
+     "bytes": 141466,
+     "sha256": "999d3b02b7224586d5c487c2666981f054aa091f0569671c72455bff458c9a2a"
+    },
+    "sound/ambience/switch_6on.wav": {
+     "bytes": 176192,
+     "sha256": "7a67fa5d4ee042c6afd271868682a1a34908c2593e5ea9e868ecb6d3e154b55b"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 220548,
+     "sha256": "2cec0b03aa7047110862de21f8f6c77e4d98901ecaf5e405a473c2ddc922528a"
+    },
+    "sound/ambience/thunder2b.wav": {
+     "bytes": 286716,
+     "sha256": "44095eceb307b5f2f1093051597ea0e48bc7abe165accd5badf99c4ad692c6df"
+    },
+    "sound/ambience/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/ambience/windgust2.wav": {
+     "bytes": 110284,
+     "sha256": "b818f61172795942402ff0ca0d1295a91c36a245edc80689c35fe64a8ac1a4e2"
+    },
+    "sound/ambience/windgust3.wav": {
+     "bytes": 110030,
+     "sha256": "fdbb85f091cd9447f1500173aff70236abcdb947ba0758711816da59c5293344"
+    },
+    "sound/ambience/windgust4.wav": {
+     "bytes": 198502,
+     "sha256": "9a5c5a3da44f981c9deb8b437f57b3e3a35f2bcab318a1a3223f0a18fa4d2101"
+    },
+    "sound/ambience/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/ambience/windgust6.wav": {
+     "bytes": 396944,
+     "sha256": "27a19679e7164a6e7bb8e4d6bc42cc8c12a5cd56bba45218e2ec5f1dc528da0d"
+    },
+    "sound/ambience/woodcreak2a.wav": {
+     "bytes": 352834,
+     "sha256": "24d3f57839910934eb61b74a91cf47ee4ab48b38f58f060ca05bde7547e8813c"
+    },
+    "sound/ambience/woodcreak2b.wav": {
+     "bytes": 352838,
+     "sha256": "574401233bff93169d452f4af748a289cfaff5d4e6319884e3cfb4dbd205d0a4"
+    },
+    "sound/ambience/woodcreak2c.wav": {
+     "bytes": 308746,
+     "sha256": "02deb62b856b7be5c3304a0bf745f79019b0b408a8cfcc4e1edede397ba09c7d"
+    },
+    "sound/ambience/woodcreak2d.wav": {
+     "bytes": 352856,
+     "sha256": "6d35975964b2fa32ece681a9d0cfa13202cde02bc315f32af0690f7437352452"
+    },
+    "sound/ambience/woodcreak2e.wav": {
+     "bytes": 308766,
+     "sha256": "54eb41e3f5c2a0103d07e70e83cf82b51014da3673fb770cf6ada3df669c328e"
+    },
+    "sound/bal/bc7_waterfall.wav": {
+     "bytes": 137846,
+     "sha256": "51dcfb96c94678cbb01e0c985240e853a01c6fc3c4f2376de177c0be59bfcfe6"
+    },
+    "sound/boglord/attack2.wav": {
+     "bytes": 8036,
+     "sha256": "efa18dec8f6d5066b8d494a232ca9c98c27a4a9130130086a9b0a27ffccb34ed"
+    },
+    "sound/boglord/bangdoor1.wav": {
+     "bytes": 30968,
+     "sha256": "b267e602e76fe1d8e854e2873e06008af15612ed1a31ec41feeb4461d52fc478"
+    },
+    "sound/boglord/bangdoor2.wav": {
+     "bytes": 39828,
+     "sha256": "f904a5423580c118de1d732fff714565f1dd8d8d1556b3b58bf39d2c59fa4272"
+    },
+    "sound/boglord/bolt_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/boglord/death1.wav": {
+     "bytes": 39758,
+     "sha256": "a9e0e36b1a51d88a5b542dd2c1f79f1dbea402b3ceb18ee13606c03126f1a874"
+    },
+    "sound/boglord/idle1.wav": {
+     "bytes": 15532,
+     "sha256": "5339e3429b0510f7e8016e6ece9895df6f202b5809f739b317211a081401f202"
+    },
+    "sound/boglord/idle2.wav": {
+     "bytes": 18586,
+     "sha256": "52f8bddb2d5095f4077eb1f753d75bce94f906f1b3064067a54c875ae16d1a5c"
+    },
+    "sound/boglord/melee1.wav": {
+     "bytes": 9326,
+     "sha256": "e2f5808115d0a93dde1063db6f2d38f6ab7ff333f83d95741a8948f44ae4ace9"
+    },
+    "sound/boglord/melee2.wav": {
+     "bytes": 11746,
+     "sha256": "e299e39467c9f94730c21d1321455fdccf3aefbb0352d528b6d413639210e715"
+    },
+    "sound/boglord/melee3.wav": {
+     "bytes": 18776,
+     "sha256": "c066200b5ddb81aa0c0cc0462939681703549ac15dd6aa83db8a23ae54ce6317"
+    },
+    "sound/boglord/pain1.wav": {
+     "bytes": 11094,
+     "sha256": "6ca5a44043add6b389827e5aca8bc0c9e9c7b0cc0c7b4a5d3df292a78da0064f"
+    },
+    "sound/boglord/pain2.wav": {
+     "bytes": 11094,
+     "sha256": "7e11818fbae5354177add1e236b6f3e0f4665d50193154fbb15fead4bb4d7908"
+    },
+    "sound/boglord/sboom.wav": {
+     "bytes": 22172,
+     "sha256": "89899521eac11f922cdd4606a0fe08bc080a63a73ec4b4a502027e33f08b225b"
+    },
+    "sound/boglord/sight.wav": {
+     "bytes": 28734,
+     "sha256": "8b020b0f07a7461f5f520b8385e38828d66b3cb1fc46d7db08b845fa8ff62ad8"
+    },
+    "sound/boglord/slime_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/boglord/slime_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/boglord/thud.wav": {
+     "bytes": 22140,
+     "sha256": "f5d7b5f65e24d6a5edd04404b93a8c5a2db45cc6c142012638f050158bb783ba"
+    },
+    "sound/boglord/thud2.wav": {
+     "bytes": 105882,
+     "sha256": "7e8826a38df07d0d2b85d6d39b8b664bb2ef8a0686846573802b77811682e957"
+    },
+    "sound/break/ceramic_i1.wav": {
+     "bytes": 11106,
+     "sha256": "ed731319eb09044fe672f5d8681395a11a7449fe7b57b9a46040c717e714cf40"
+    },
+    "sound/break/ceramic_i2.wav": {
+     "bytes": 11126,
+     "sha256": "88c29d649471f031aa1049ee087cf866e1d9ea53183effd14cfabc81ecff9502"
+    },
+    "sound/break/ceramic_i3.wav": {
+     "bytes": 11144,
+     "sha256": "420d00d7884a22dd2baf9cdd1e059689858b47fb3adb2ad5ae29c80bd74b5dc5"
+    },
+    "sound/break/ceramic_i4.wav": {
+     "bytes": 17678,
+     "sha256": "0b7da87d046aeb3a52de305da60b2400c8cbf3480364235fb0bba3a0595f13dd"
+    },
+    "sound/break/ceramic_impact.wav": {
+     "bytes": 37584,
+     "sha256": "e6d2ada5c51a2787548468ad393e2497ef84b47ca487cd523f3ef6b283626226"
+    },
+    "sound/break/ceramic_impact2.wav": {
+     "bytes": 35380,
+     "sha256": "508725e20a999c339501dddb045a2ca6a51032905dccc68fe2a3fb9e9e1d0649"
+    },
+    "sound/break/ceramic_impact3.wav": {
+     "bytes": 26560,
+     "sha256": "ca4d7876a6e33cc285186d1432670878b54cc62c01e3dc4c650727069bfdb8ee"
+    },
+    "sound/break/ceramic_impact4.wav": {
+     "bytes": 37584,
+     "sha256": "e71b0559ac5d76dcd2016d07f8999ae1200d82ca7b658509339cf303c918f777"
+    },
+    "sound/break/ceramic_impact5.wav": {
+     "bytes": 37584,
+     "sha256": "1c6b3457c9d3aab209cd3b8977df579cdbe01158c1b4e5c07c2b5b227c96fb6d"
+    },
+    "sound/break/ceramic_impact6.wav": {
+     "bytes": 37584,
+     "sha256": "fac4857865a750a03f74e556f44186381315068ec1975c775fcd14ae4a7b3c7b"
+    },
+    "sound/break/flesh_impact.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/break/glass_i1.wav": {
+     "bytes": 13268,
+     "sha256": "63ec32f660d085c64274747b704bcbeb7261062b5fcbb570598d64e742dc7164"
+    },
+    "sound/break/glass_i2.wav": {
+     "bytes": 30950,
+     "sha256": "8b2ae028e6237cf06241739e3533ef3bf651194dfbef028fd648a6f06e8996de"
+    },
+    "sound/break/glass_i3.wav": {
+     "bytes": 8848,
+     "sha256": "ec97346c02431717927e2dd3712bd82428ea05960ffa027422fbaafab96b4170"
+    },
+    "sound/break/glass_i4.wav": {
+     "bytes": 4442,
+     "sha256": "b4144a008122e52aed45339e11ccf7cb1cd2e92f07e4169d029059a4ca01f5fa"
+    },
+    "sound/break/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/break/metal_i1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/break/metal_i2.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/break/metal_i3.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/break/metal_i4.wav": {
+     "bytes": 79928,
+     "sha256": "d2b35ba352f32ceae469acf9cfa04f7dcc0a462ff69e3649f5c0adf55ae2ea78"
+    },
+    "sound/break/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/break/rock_i1.wav": {
+     "bytes": 30534,
+     "sha256": "5cb61e93ebcf9bbcd3be1f6e282b51e9102d56b6650cffc0db93918b11b42322"
+    },
+    "sound/break/rock_i2.wav": {
+     "bytes": 29254,
+     "sha256": "9fdf4f489834452fce33b1fbe69bce9d4920a117c3d0d93b4fb530a7117bf160"
+    },
+    "sound/break/rock_i3.wav": {
+     "bytes": 25264,
+     "sha256": "59b506a84e018b11e9ba30a6ad299c2d8cf24d5907dc95cf30e578cd386e28bf"
+    },
+    "sound/break/rock_i4.wav": {
+     "bytes": 27244,
+     "sha256": "7a2c24ce52e272998ca035c967860873c92fbb14227a190ac82b761843680ffd"
+    },
+    "sound/break/rock_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/break/wood_i1.wav": {
+     "bytes": 28074,
+     "sha256": "6249449664f5ae509164ae3fd8588c905bea9daf5b1d919d9917b91aadf675bb"
+    },
+    "sound/break/wood_i2.wav": {
+     "bytes": 25158,
+     "sha256": "d51e731bdf895c84ec9927c496fc0a7fb6e7a37cbfbc2f6b55f54f716d804d08"
+    },
+    "sound/break/wood_i3.wav": {
+     "bytes": 17644,
+     "sha256": "8e1967cf42a7e31668d94e1b0cb7c6de4d36c6ec735d67ab01ac4e00dfb0853c"
+    },
+    "sound/break/wood_i4.wav": {
+     "bytes": 11516,
+     "sha256": "fb0908f1a2bdff824d27fa92f15690cb9f86805185119fbc7f7876547495bf45"
+    },
+    "sound/break/wood_impact.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/chthon/attack1.wav": {
+     "bytes": 22116,
+     "sha256": "91df4f5be21c6a80d31a050192b04a760f25c7f88a4b0ceeb2802fe8b8499d21"
+    },
+    "sound/chthon/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/chthon/death1.wav": {
+     "bytes": 55120,
+     "sha256": "b6eeee788b9aa49ca9698d2d7977748f142053fd3f47e2828d1781d7db7ec986"
+    },
+    "sound/chthon/idle1.wav": {
+     "bytes": 24322,
+     "sha256": "6a0a9b5a0b2e74fce8cbfa9ede97c2059884c0db81b2c68fc0ec7bb1da2a4009"
+    },
+    "sound/chthon/lavasplash.wav": {
+     "bytes": 100546,
+     "sha256": "a533653ff77e2dfc443377a1f055b6abd7af3c639f0e5634b0a47fd1f040ed76"
+    },
+    "sound/chthon/pain1.wav": {
+     "bytes": 35320,
+     "sha256": "f964bdd08ffc66f9f229aacb3b584ffefdcfbacf7da0f0075a9af752569c641c"
+    },
+    "sound/chthon/sight1.wav": {
+     "bytes": 49454,
+     "sha256": "533adf244fa2c2dca72765560e823ceead8d5a0f3832ba18d4fa2928154b12c8"
+    },
+    "sound/deflector/death1.wav": {
+     "bytes": 22150,
+     "sha256": "593140594353d4d25fe6b5e455afc0f3c2cdd6874bc1d545ea03f779454cd799"
+    },
+    "sound/deflector/death2.wav": {
+     "bytes": 41334,
+     "sha256": "4295a9a79fec3bf611c25f97553420d0e42b987ad8091930db9137b93a3e8f06"
+    },
+    "sound/deflector/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/deflector/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/deflector/idle1.wav": {
+     "bytes": 7668,
+     "sha256": "76455fc9d5fc53cf5a70900a9d875ba3ac839e1c3179eccc5287619a70523e6e"
+    },
+    "sound/deflector/melee_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/deflector/pain1.wav": {
+     "bytes": 6452,
+     "sha256": "e0905dc6c945663a97119f2c1522d5a8ebd1596ed26f33650fcb63b185959517"
+    },
+    "sound/deflector/pain2.wav": {
+     "bytes": 9598,
+     "sha256": "011d69ef5153dca029bcb1c3d60b3c3f0e1263bd9ca34a02d4d14e6ab508a0d4"
+    },
+    "sound/deflector/pain3.wav": {
+     "bytes": 12014,
+     "sha256": "08f5ac27626e862b7193f101a6d0b77dc6568c4e93ef3000199934769666b1ec"
+    },
+    "sound/deflector/rocket_fire.wav": {
+     "bytes": 15482,
+     "sha256": "a08e5f83d20b5d1eb585cf782f08a4a692b0f8c95e461b9a321814d099a89d79"
+    },
+    "sound/deflector/rocket_hit.wav": {
+     "bytes": 13274,
+     "sha256": "4dbcd0bad68272848a32a997bb235c4324cd55b1df0b96b1876fb96ea8ca6a90"
+    },
+    "sound/deflector/rocket_load.wav": {
+     "bytes": 6882,
+     "sha256": "1dbddae67f93c586ea3290ed65e1234cf8ccfd076847b1b418693e97fb5768d1"
+    },
+    "sound/deflector/shield_off.wav": {
+     "bytes": 10684,
+     "sha256": "5c3ea84c12abf632d777f90972966c4a50dde4ee7363d257e3c0f89e68027b5f"
+    },
+    "sound/deflector/shield_on.wav": {
+     "bytes": 10464,
+     "sha256": "340196ba32a9d3f672cbc3db86765eb1517550b00f2f97ed76cb519da1b93962"
+    },
+    "sound/deflector/sight1.wav": {
+     "bytes": 16106,
+     "sha256": "3ec7f00e859c52846b244e69cc3ed7321175746a44eb373fe4bd3cb07612dcf3"
+    },
+    "sound/deflector/sight2.wav": {
+     "bytes": 14432,
+     "sha256": "e8c0c1367969b0346bf5fdc94665a10480636629a71a6a35e47da3d7fb7cb463"
+    },
+    "sound/deflector/sight3.wav": {
+     "bytes": 17184,
+     "sha256": "11748c58e67305ad4e1cd7a2e2c084f9c41184cd2b4f756adfd18adcc22dbc2d"
+    },
+    "sound/dguard/death1.wav": {
+     "bytes": 30610,
+     "sha256": "af3809501261ec4d0afa6ea7301c11a5c7bbc1cc3e06b8c88172ee0214c30969"
+    },
+    "sound/dguard/death2.wav": {
+     "bytes": 43636,
+     "sha256": "93a70fc0d6fee819c723a435a3954b3fd3be86e358698ce85db1062990d1575e"
+    },
+    "sound/dguard/fire.wav": {
+     "bytes": 60820,
+     "sha256": "f5e5d4f6ccc0778c1396c66d327564a0b1892773f2c23d2e30590abf0c758bd2"
+    },
+    "sound/dguard/hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/dguard/idle.wav": {
+     "bytes": 20498,
+     "sha256": "45b2f208b9796d19d7aeb0cba64e4b0e5fd2ed7c980123f7c41ca10d17785021"
+    },
+    "sound/dguard/pain1.wav": {
+     "bytes": 10380,
+     "sha256": "9a367afb7cde241099c58c999e225ba939be39f21be818b16444f5a810049960"
+    },
+    "sound/dguard/pain2.wav": {
+     "bytes": 14892,
+     "sha256": "827a1e4d3c9983f61fffd61de33054274c144bddd9a68460b496fd6281cf9406"
+    },
+    "sound/dguard/sight1.wav": {
+     "bytes": 18124,
+     "sha256": "9cb3d960261d90ec16c9883f4326c905356b6ff4e99cdf48ab5913b098588016"
+    },
+    "sound/dguard/sight2.wav": {
+     "bytes": 18022,
+     "sha256": "35ee4b7ec6715c8c9fdc24f90ad0b5d90a0ae7a4986168cf40670e87c325d5db"
+    },
+    "sound/dguard/sight3.wav": {
+     "bytes": 19948,
+     "sha256": "c6818770267626dea27f4a72ce2249771f6968924022c2275a5a96abfa485044"
+    },
+    "sound/dguard/sight4.wav": {
+     "bytes": 20332,
+     "sha256": "7affcdbdc62f13e492a15b54fe642fe045641f5551f570cc3c8d5f7ee29521fd"
+    },
+    "sound/dguard/slash.wav": {
+     "bytes": 22942,
+     "sha256": "44b60d785ff03f033e183b6fbce69e526351187d28efdeb308f6f8bea930d450"
+    },
+    "sound/dguard/slhit.wav": {
+     "bytes": 31956,
+     "sha256": "0f07a131640f21337cd89a772588ecfc707d6a729f96b54c21920b809cd620e4"
+    },
+    "sound/dguard/slmiss1.wav": {
+     "bytes": 10458,
+     "sha256": "e32d5cb070a13fad979b021e84a727f71242305ade1af7bfe18c255f0f6dd548"
+    },
+    "sound/dguard/slmiss2.wav": {
+     "bytes": 13840,
+     "sha256": "f6b3aee08c25434d2fda7468cacf35a0912b182653a45991149b54a0fc4be537"
+    },
+    "sound/dknight/dcross_idle.wav": {
+     "bytes": 176610,
+     "sha256": "a7eba673532dad555f879ba77091e3cb9e44558608b83c36d8639e51d71b660a"
+    },
+    "sound/dknight/dcross_idlecom.wav": {
+     "bytes": 58910,
+     "sha256": "bba45bd9fc02e1d580a80596d6a1744bb8fb993ed73a7bfdf3b712670cccf989"
+    },
+    "sound/dknight/dfury_grunt1.wav": {
+     "bytes": 19702,
+     "sha256": "8d3709e913b8e26d8e094fddd9c60d74cc71b742e16276d4982c9636db05209e"
+    },
+    "sound/dknight/dfury_grunt2.wav": {
+     "bytes": 54294,
+     "sha256": "f7ca0d5970322629cc47f8c26489d5c916a570525ded20c73823c27f2834609c"
+    },
+    "sound/dknight/dfury_grunt3.wav": {
+     "bytes": 62054,
+     "sha256": "6eae53c32568ce90083dab528c18475ef840f9f684c43cdba7bfcc1c63435ba6"
+    },
+    "sound/dknight/dfury_grunt4.wav": {
+     "bytes": 28914,
+     "sha256": "0def63c77d0f116eabb77cc462ba6a57bc6523fad469946c6f1f11d786100819"
+    },
+    "sound/dknight/dfury_leap.wav": {
+     "bytes": 102756,
+     "sha256": "f288dc9324b2ccace32ce86cffaf0c042a59bf5b56b20657c018859f1038243a"
+    },
+    "sound/dknight/dfury_sight.wav": {
+     "bytes": 69602,
+     "sha256": "443887e91ca71dbba299b37a81bdbd3bb34b491c6c3e13fe73bb5c921019d1ea"
+    },
+    "sound/dknight/dprince_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/dknight/dserg_hbreath.wav": {
+     "bytes": 185884,
+     "sha256": "c8181d4844ac4b2bb7dc47bbc28bd2ae9fc2737120d6745292de4d594f40d406"
+    },
+    "sound/dknight/dserg_magic.wav": {
+     "bytes": 34768,
+     "sha256": "adcb0810b7e8b23d91d31f5727c480b35c7b59a90d9f7933f69c00e7eccd1f3e"
+    },
+    "sound/dknight/dserg_sight.wav": {
+     "bytes": 15210,
+     "sha256": "d4f7c5b6f64d48606d1d3e1889794a22107f3d5914b37c81c405fdfb1133a7eb"
+    },
+    "sound/dknight/ghost_idle1.wav": {
+     "bytes": 110292,
+     "sha256": "878416a0151a1a71891a84db2565d1e8a2b2e37f03f1822d7f9411a98b42b528"
+    },
+    "sound/dknight/ghost_idle2.wav": {
+     "bytes": 110290,
+     "sha256": "048f79f7fa8f9e49f97dad9f5cb468933be1713726ba95d3ab10d9811cbb5f2f"
+    },
+    "sound/dlord/death.wav": {
+     "bytes": 32022,
+     "sha256": "0188f6a3dd88686e15311f8c39c4277078e55bc0ec75497e2eb534af717abcdb"
+    },
+    "sound/dlord/idle.wav": {
+     "bytes": 9906,
+     "sha256": "c0ee37f80013dad1aaeb285a11a33c4d7c2ff2de0b2a94c2943d3fbe1c241bcd"
+    },
+    "sound/dlord/pain.wav": {
+     "bytes": 8632,
+     "sha256": "230ed5c7d024bfa90b973649aa79d9e9327eaf401b1632e4a1334fb4a9eb075c"
+    },
+    "sound/dlord/sight.wav": {
+     "bytes": 28028,
+     "sha256": "d82aa0028754e826705961040e1ab27f007c572a28c63dbcaeefeb681bc3ca85"
+    },
+    "sound/doors/rattle1.wav": {
+     "bytes": 88274,
+     "sha256": "c524d12100f1067bb30ecdf83e18e5d85124fef834929cfd2a2ade14f83ad730"
+    },
+    "sound/doors/rattle2.wav": {
+     "bytes": 123526,
+     "sha256": "e8decabe8df10f704814bf2f432b3fc6d5542022d465af336b0680793f6163ea"
+    },
+    "sound/doors/rattle6.wav": {
+     "bytes": 97072,
+     "sha256": "0aef6aac51a4e3528e5f2019bf113ee2f0e5096a708d31483a526c447ebdb00c"
+    },
+    "sound/doors/rattle_tech1.wav": {
+     "bytes": 61784,
+     "sha256": "18610e64612241e6936f2d0ebe746c957652c4ce8e37c668515281712f6a1e39"
+    },
+    "sound/doors/rattle_tech2.wav": {
+     "bytes": 88244,
+     "sha256": "de39aa8b59c988b02bf6c13a716e225b7ee029f2553357b8646aef92a2792c3e"
+    },
+    "sound/doors/rattle_tech3.wav": {
+     "bytes": 52844,
+     "sha256": "a29e8144cdab34467250f040feaad044aff784a2775b50bd220e967b39f39b3c"
+    },
+    "sound/doors/rattle_tech4.wav": {
+     "bytes": 76844,
+     "sha256": "ba34a641758a2e2cb9ef5358a398482c2b34526fc4b0c49db590c9679c732ef4"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/enrage.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/r_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/eel/attack1.wav": {
+     "bytes": 27740,
+     "sha256": "8c84b2a5e7fd0754dca3611a8300a8cc9656295ea73617ff0c85d167b28459df"
+    },
+    "sound/eel/death1.wav": {
+     "bytes": 34264,
+     "sha256": "a0f8eab92db10e8fa9342f725743297fd8384e2aca1decc1189109196f3b960e"
+    },
+    "sound/eel/idle1.wav": {
+     "bytes": 53110,
+     "sha256": "c059a4f2bee33543b377803f2af1fc7e2ee205cd02d987859af18087246ae46c"
+    },
+    "sound/eel/impact1.wav": {
+     "bytes": 70632,
+     "sha256": "13cea2f7d66f40511add17d846ab6142345497ddd7cff5ebfc5e2e70a7eb1fbe"
+    },
+    "sound/eel/pain1.wav": {
+     "bytes": 13316,
+     "sha256": "569a6bf9383820e90e431db5c0b82cd0201e10fd2081d228f81a0c76a0e88d1b"
+    },
+    "sound/eel/sight1.wav": {
+     "bytes": 32074,
+     "sha256": "90786a043f5ec1bd0b761c5c8378dc2783e3b1d8e3ac95a9312f55a7c5b3baea"
+    },
+    "sound/eidolon/attacka.wav": {
+     "bytes": 27660,
+     "sha256": "a7bb5c16014c814d379585eb4c6752a91240a5856ad7f3af5f86af037bef91e6"
+    },
+    "sound/eidolon/attackc.wav": {
+     "bytes": 220544,
+     "sha256": "9815d26814c687618b7bbae4a5353570afe497c5d57fb77c083f695d102234c9"
+    },
+    "sound/eidolon/attacke.wav": {
+     "bytes": 46400,
+     "sha256": "39ad467257004bc6d2a17003abe4ef8df89d0668ec03fc8570aa755cbdf94c6c"
+    },
+    "sound/eidolon/death.wav": {
+     "bytes": 264696,
+     "sha256": "bc055e1315073c78e5571c99d29894bc89abfd64b6a258bdabc79849f81c50a0"
+    },
+    "sound/eidolon/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/eidolon/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/eidolon/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/eidolon/footstep1.wav": {
+     "bytes": 52384,
+     "sha256": "e228c0503d89118be55eafaf3a3bfa0a13e3bdcbe4a043f4a9bb31c9e96cf3dc"
+    },
+    "sound/eidolon/footstep2.wav": {
+     "bytes": 46128,
+     "sha256": "1a3b867c93932411f1c3dedf4a8f1553f19caabae438cb7989095307d1a6c5c5"
+    },
+    "sound/eidolon/footstep3.wav": {
+     "bytes": 43774,
+     "sha256": "4119d9c31e359bd48b52bff2842e51c441064896289194f04db44e2d7860cccc"
+    },
+    "sound/eidolon/footstep4.wav": {
+     "bytes": 41758,
+     "sha256": "6b97f80545d9587580a7b445f13e5a38300627e497ed85357f9448c7a910864b"
+    },
+    "sound/eidolon/growl.wav": {
+     "bytes": 44380,
+     "sha256": "f9f404c4590f2af8fa9a1cd0de34e1d031e66d88ccf553dba228396f0d8fb012"
+    },
+    "sound/eidolon/idle1.wav": {
+     "bytes": 28778,
+     "sha256": "61f423068b79bba82fb3ae3fca3957a8f059802068edf272f2695e6caab89271"
+    },
+    "sound/eidolon/idle2.wav": {
+     "bytes": 33172,
+     "sha256": "1bdd3d6862ed0b74aecae1917f09a65acf4db7fca49a0ccd21a7fbc2eea5f02b"
+    },
+    "sound/eidolon/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/eidolon/pain.wav": {
+     "bytes": 17744,
+     "sha256": "6a308180389e3fb98cc00c70dad1c6600988778b34628e04363e7ca54e5bf679"
+    },
+    "sound/eidolon/rock_hit1.wav": {
+     "bytes": 97066,
+     "sha256": "d31741c09309b240d294ba9b310b694aae1d71f823ac9ef28b27a8b5fff14405"
+    },
+    "sound/eidolon/rock_hit2.wav": {
+     "bytes": 123526,
+     "sha256": "a3d1247db98535829392172110a40fde19113dd493ab603c4b6a9a36dd743150"
+    },
+    "sound/eidolon/sight.wav": {
+     "bytes": 53044,
+     "sha256": "04c124f683e75e4d14374b7a044eeea288dd02a845ccab3ffd670f1c15799ebb"
+    },
+    "sound/enforcer/cent_hover.wav": {
+     "bytes": 103796,
+     "sha256": "a5616566072a5cdc9339e3722d6fee9e652796e9cc8f76e27dbd9aee13986f4e"
+    },
+    "sound/enforcer/death1.wav": {
+     "bytes": 9290,
+     "sha256": "f62aad2ae903808a0caecfc6bdfe13e5fdebb1df14d330c6ac4eda9b577b25bf"
+    },
+    "sound/enforcer/def_idle1.wav": {
+     "bytes": 32676,
+     "sha256": "7b673b07828790504caca013c18bf697fd53b758a3638b949b433cf2d72f03f3"
+    },
+    "sound/enforcer/def_idle2.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/enforcer/def_sight1.wav": {
+     "bytes": 18260,
+     "sha256": "7d57825c28cf4f93189261d76cccab676aeba097920114d5d3f48d7eddaaa1cd"
+    },
+    "sound/enforcer/def_ssg_fire.wav": {
+     "bytes": 14206,
+     "sha256": "494a6d493c3c298c1b9cc0051ce4c1f9e129293ea7ec283b62915c49d8c249c3"
+    },
+    "sound/enforcer/def_ssg_load.wav": {
+     "bytes": 5274,
+     "sha256": "db4f62f8d76a68f2e4d3e7a29a22d3ddc5d6ae9bb296e6e800e937b73b5a4dea"
+    },
+    "sound/enforcer/elim_idle1.wav": {
+     "bytes": 39084,
+     "sha256": "2ccaa3ba4f987d031a22b8048ca23e97900fca9def362ff92943b73a99ed7844"
+    },
+    "sound/enforcer/elim_idle2.wav": {
+     "bytes": 36204,
+     "sha256": "9232028e1a93c409c7000348bfadc269c49a333e8d65d904973efb547c7af805"
+    },
+    "sound/enforcer/elim_idle3.wav": {
+     "bytes": 38222,
+     "sha256": "93034d568db5c304a165c3d89cb03ffe5d97e8157755e944a863697007eb27fc"
+    },
+    "sound/enforcer/elim_pg_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/enforcer/elim_sight1.wav": {
+     "bytes": 31468,
+     "sha256": "2268ee0ad0c77a081b289a550a1dae24b274b2e3f06d156a67beca80df8ee919"
+    },
+    "sound/enforcer/enfire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/enforcer/enfstop.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/enforcer/fum_poisonoff.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/enforcer/fum_poisonon.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/enforcer/idle1.wav": {
+     "bytes": 15810,
+     "sha256": "cec388af73dff076ea3af7c754ef0939f989f3412b0359c0fb668cd91bd4abaf"
+    },
+    "sound/enforcer/pain1.wav": {
+     "bytes": 5478,
+     "sha256": "d8692021777495825974f8406e23c74ed249f9a80a9bc944c79b1722c35f64e0"
+    },
+    "sound/enforcer/pain2.wav": {
+     "bytes": 4580,
+     "sha256": "e48a524482ce67ff94ce00fe4d8a1190aed38e9c7c24cfee3607f0f2827049e6"
+    },
+    "sound/enforcer/pyro_flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/enforcer/pyro_flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 5870,
+     "sha256": "92dc64154602e29e95d40aa68d3544fe21cb21ce24192f1e8ffefc6b5d31b8cc"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 6574,
+     "sha256": "52b1991141ed9452fe6c7ebe219cc544fba443058f179b8eec5a5cbfb9aacf3d"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 6158,
+     "sha256": "d3b9e689b2b43ae74ae14fdb26680d3646d658107664965db97420ae032d74b0"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 5166,
+     "sha256": "815e05c3b14858209fee01316848c117ad89af9f0aab190fc0ca0239367373ac"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/freddie/death.wav": {
+     "bytes": 88244,
+     "sha256": "2e3de0875dd3245a98614829ab848cc1dfc34a95827aa4cfc174884977ecddf0"
+    },
+    "sound/freddie/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/freddie/idle1.wav": {
+     "bytes": 88280,
+     "sha256": "673ac7c26a9be2b1ea37b152ce48442ff40089cc7dc015c014eb42534db2c306"
+    },
+    "sound/freddie/mangle.wav": {
+     "bytes": 48548,
+     "sha256": "ee318d6849ca9dda4569db6009210a6909279bd2ffe9b31543d47134b51c1533"
+    },
+    "sound/freddie/pain.wav": {
+     "bytes": 38640,
+     "sha256": "ffe05b43444a209084c95c166b0776d33f9ba8af15ef998d3ed5c09aa0b03c3d"
+    },
+    "sound/freddie/painshrt.wav": {
+     "bytes": 8868,
+     "sha256": "31e08c51909022a6b0ad7f01f1f8dae196269b8b105e57e555025393cdc278d9"
+    },
+    "sound/freddie/sawstart.wav": {
+     "bytes": 41938,
+     "sha256": "90f83017a7ff5f2bd2824be1e122eab7d8171ab63a9025adf1fc03ee3e7a44aa"
+    },
+    "sound/freddie/sight.wav": {
+     "bytes": 55170,
+     "sha256": "3f73e5b30cef3038102ffa9ab0faf89e71af43ed2ee5a0758319c072c151c123"
+    },
+    "sound/freddie/step.wav": {
+     "bytes": 19898,
+     "sha256": "121818aa6200c770a70c2c02844bbc0351a62f166c31f9d85765896b426f610e"
+    },
+    "sound/freddie/step2.wav": {
+     "bytes": 19870,
+     "sha256": "7e33eb621ee356cbe4affe6218b988f477259dae705d57eea12d7fe10b5d4510"
+    },
+    "sound/freddie/step3.wav": {
+     "bytes": 19898,
+     "sha256": "a005232c4c0608092c7d697c6d24566892b74adfe7566030360c96996bd39357"
+    },
+    "sound/freddie/stfire.wav": {
+     "bytes": 27598,
+     "sha256": "597fa6e0e8c4da4fd85e9e26ecd7f95f3dc242846ec9b962cf2beb324e5a4fdc"
+    },
+    "sound/gargoyle/attack1.wav": {
+     "bytes": 28712,
+     "sha256": "cab70a44f7ec34343a1608ca8c13dd2b501065cade08e94b574f98436aabeadf"
+    },
+    "sound/gargoyle/death1.wav": {
+     "bytes": 41662,
+     "sha256": "07043eb3fcbcc9c8cf53b07c10b349a9f3beb471dc240a6d70d8f2b5a57e85b0"
+    },
+    "sound/gargoyle/death2.wav": {
+     "bytes": 28768,
+     "sha256": "c363613cd476d5099dbdced656244db0d704da5eeb54fe5b880f2202f6f465b2"
+    },
+    "sound/gargoyle/idle1.wav": {
+     "bytes": 72868,
+     "sha256": "90885fa6cae946ecfedec8a150911bcfdad8ef326254e1fb1bf44ca5c5af4eb0"
+    },
+    "sound/gargoyle/pain100.wav": {
+     "bytes": 26510,
+     "sha256": "d53f1e64f4c9f5e13e03cfee2681ef6dff370e95e9dd8668c7c06b79762e7773"
+    },
+    "sound/gargoyle/pain75.wav": {
+     "bytes": 28720,
+     "sha256": "78d5d0f1c5df4e1a565eeda076d5f8b3bb3582e551909b31fa8e36c292903826"
+    },
+    "sound/gargoyle/perch1.wav": {
+     "bytes": 26506,
+     "sha256": "5eab54a566e4c1136c40fbfbd636188a7a9c4aa6b278e51fb965e1761764cbff"
+    },
+    "sound/gargoyle/perch2.wav": {
+     "bytes": 30924,
+     "sha256": "745b5c5f1fd04a73a7581373925aa70cd3f35ab899df5f5fd2c610d07bf95bdd"
+    },
+    "sound/gargoyle/sight1.wav": {
+     "bytes": 35142,
+     "sha256": "1097300e4bca9ef61a7041e7f4ff403fe67c4fc0e687b30892a6bdf35bf45c09"
+    },
+    "sound/gargoyle/swoop1.wav": {
+     "bytes": 21056,
+     "sha256": "ef6b4b672dd984e846294e0be57d81df3abcb521b1f88f6afaf2f5cc2d4e91d4"
+    },
+    "sound/gargoyle/swoop1hit.wav": {
+     "bytes": 11078,
+     "sha256": "6a624e3f46e2c45f5e2d6f42ee18643a17268a6b0df2493fe6ffdba4be0c9057"
+    },
+    "sound/gargoyle/swoop2.wav": {
+     "bytes": 24364,
+     "sha256": "f98d41f9df7244e8f77c435ae4071a4e4595ec7005b7c72e44456fe7baca425e"
+    },
+    "sound/gargoyle/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 22094,
+     "sha256": "142b725ff5515cb438a592288a69e01331b3fd0bbb7311abf1dbaf90f95417ef"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/plasma_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/gaunt/plasma_start.wav": {
+     "bytes": 66270,
+     "sha256": "ad404715612b802a7d4f72f2d14abb47c338ac414af56c19ffc8dc2873f33452"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gaunt/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gibs/gib1.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/gibs/gib3.wav": {
+     "bytes": 33256,
+     "sha256": "10a19291ed8af8893b6cdbd80416425b27e5a197d39aa8d0557320752d78cf11"
+    },
+    "sound/gibs/gib5.wav": {
+     "bytes": 15490,
+     "sha256": "2d7603a9fc0c055ed3529bd4dfd511984c71b93f4719b605813eb5139d02c6d9"
+    },
+    "sound/gibs/gibacid.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/gibs/gibchain.wav": {
+     "bytes": 15938,
+     "sha256": "c6b2a37424a51810017bd5ee4764a014329467686f73bb2f48ad2704592176f3"
+    },
+    "sound/gibs/gibheavy.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/gibs/gibheavy1.wav": {
+     "bytes": 11110,
+     "sha256": "0a1313f08fa22e4df8a1beb15ffdb6e7b1906187f63042357e4a43631ef5e93a"
+    },
+    "sound/gibs/gibheavy2.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/gibs/gibhit1.wav": {
+     "bytes": 22150,
+     "sha256": "d2a73e2f9e31b9fefda789e49b17ec9bd18df0335c31f871514a282cf550829a"
+    },
+    "sound/gibs/gibhit2.wav": {
+     "bytes": 22150,
+     "sha256": "210477e93743dc6c0541bc158032d46251c6aeff551efcf515d6e7db87bb8a53"
+    },
+    "sound/gibs/gibhit3.wav": {
+     "bytes": 22150,
+     "sha256": "40db6dbb033d59dd458e5fb6102dba6d6ecf5bc5739d9fc35a3be68cc977da53"
+    },
+    "sound/gibs/gibhit4.wav": {
+     "bytes": 22150,
+     "sha256": "0bd1e29d68e41cbf2d753730df678918a38fc886b4690991fbd7e8fb3e13e055"
+    },
+    "sound/gibs/gibhit5.wav": {
+     "bytes": 22150,
+     "sha256": "4adf7a8249ee913aeb9e91120b1f6b9e529b1e1a3eadb75185589cf7c3ff910e"
+    },
+    "sound/gibs/gibmetal1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/gibs/gibmetal3.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/gibs/gibmetal5.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/gibs/gibmetala.wav": {
+     "bytes": 18474,
+     "sha256": "2c057e772307ef647b4313975cec75bacfd522bbc5dd27ae83a867065562635f"
+    },
+    "sound/gibs/gibmetalb.wav": {
+     "bytes": 30756,
+     "sha256": "fbcfa9e6cd5aa68c6fffd6699c8dc87ec3707a4281358f229afce57f3278c800"
+    },
+    "sound/gibs/gibstone1.wav": {
+     "bytes": 52956,
+     "sha256": "962dd735a1823905243700eb3f4e0caacc1be71a1f367ccad4f21dd82b4e99e1"
+    },
+    "sound/gibs/gibstone2.wav": {
+     "bytes": 22104,
+     "sha256": "04f070fa9873f382ded03a5139ce2c7da2013d8ef9221a8d10a64c3b5f912591"
+    },
+    "sound/gibs/gibstone3.wav": {
+     "bytes": 35344,
+     "sha256": "16262de5a0b703468f2c3f1e49ffa0c225eb81b89984b468b7bc95948ed890c0"
+    },
+    "sound/gibs/gibstone4.wav": {
+     "bytes": 8832,
+     "sha256": "75179beed6fb6f581944f5e7db153bea4d9ecc65899628468efd48710a392013"
+    },
+    "sound/gibs/gibstone5.wav": {
+     "bytes": 22130,
+     "sha256": "0aaff5c363ac29a9b50d83b4b04fcd7264c614a93d0c9bc7941c9704a6b4b499"
+    },
+    "sound/gibs/gibwood.wav": {
+     "bytes": 61708,
+     "sha256": "d9b53ab4d53f1265dd2083d341cd92f19729694946ff00ad15fa6d96965e63e8"
+    },
+    "sound/gibs/stonedeath.wav": {
+     "bytes": 76750,
+     "sha256": "26d0eb67357d292043fd494b1646f8ce005ba692d98610429bceedfc831d2325"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 374654,
+     "sha256": "de356a2581884e9008ef798775f82049c465aec242cad0f6024b510d33e11764"
+    },
+    "sound/golem/groundslam.wav": {
+     "bytes": 132412,
+     "sha256": "f557ad378642a77a2f31433db5fe9315cf33f5fc350018e2bd26d32359ec8617"
+    },
+    "sound/golem/iceshard1.wav": {
+     "bytes": 53022,
+     "sha256": "41e523122aa4168298b247748bbe4201928582e974e673a83e717ea33f8656a8"
+    },
+    "sound/golem/iceshard2.wav": {
+     "bytes": 53012,
+     "sha256": "4b4e457f75d051a7aa3525bf82338f8b6d2f9460583c09e63d82b202cb11d03f"
+    },
+    "sound/golem/iceshard3.wav": {
+     "bytes": 53038,
+     "sha256": "8134080a7c6478463f9ea8c368eb6e0563dacb35bb3941b1e08e2cf0763d83ab"
+    },
+    "sound/golem/iceshard_impact.wav": {
+     "bytes": 176470,
+     "sha256": "ac850565ac7cfaa8ec2e55f535603aaf131605b9399f08f1b17f7c08920f7bda"
+    },
+    "sound/golem/icestorm.wav": {
+     "bytes": 61802,
+     "sha256": "2e8129333bc1a677591f9c4838a5f8c8e9ff63050fe6a47f212380f2497ae706"
+    },
+    "sound/golem/idle1a.wav": {
+     "bytes": 88238,
+     "sha256": "d238c43b6e83c044ba70352ed9362e50d68caf606f500c7d79f5c03d1e6a432e"
+    },
+    "sound/golem/idle1b.wav": {
+     "bytes": 88242,
+     "sha256": "93e3ca1ec51345da6e06a53f71bcd1271c911c9a6272246de9f58bef93c904dc"
+    },
+    "sound/golem/idle2a.wav": {
+     "bytes": 44166,
+     "sha256": "d0ceeb0ee1681127f9f426ccaa0ddb75c6ef32594618c972536871544e8d5748"
+    },
+    "sound/golem/idle2b.wav": {
+     "bytes": 44178,
+     "sha256": "94fb43b50445dbe7a8fe6cc06ea745b729cf5bf61c33cc543123f751e4a9cdf7"
+    },
+    "sound/golem/melee_pound.wav": {
+     "bytes": 17672,
+     "sha256": "23ff4f485f3adb3ba5227ba59824e226e91005846d2879077ffbe04141bab78b"
+    },
+    "sound/golem/melee_punch.wav": {
+     "bytes": 17702,
+     "sha256": "21cbd6ca5b9c8d95a43c39b360b12ee8033dca1aaf11d4c1164d4bc9ce83b7d3"
+    },
+    "sound/golem/melee_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/golem/pain1.wav": {
+     "bytes": 27948,
+     "sha256": "388150975b33e271db5402f502c6a36899731ec85cb9b16cdcc4b427b206a3f2"
+    },
+    "sound/golem/pain2.wav": {
+     "bytes": 32940,
+     "sha256": "b3908c02406bcb8c379f345f80a825aa270a54ae02fe0356e02330620d9cf437"
+    },
+    "sound/golem/rockstorm.wav": {
+     "bytes": 264676,
+     "sha256": "c57be8195f675560b879c3fc4e23c49f021d0c45aa81f2a84b74303f111d7c7a"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 76762,
+     "sha256": "965d1107adbc9a068d1d2af16fc783855833569dcc3a6030fa920019c30a4083"
+    },
+    "sound/golem/wakestatue.wav": {
+     "bytes": 250454,
+     "sha256": "630505eb8c9c84511f39d2e77096cafcbab044f73569934cda127a4b6f37f138"
+    },
+    "sound/items/airtank.wav": {
+     "bytes": 22160,
+     "sha256": "9b8f5c5deb886800c91d46809ecf82fb114467eb8a395b9c980d47c6b35f6b17"
+    },
+    "sound/items/airtank2.wav": {
+     "bytes": 66286,
+     "sha256": "76156f8f89e2bedbfaee9ee3340adb6bfe8639f242051178c2655e04cdab5198"
+    },
+    "sound/items/airtank3.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/items/airtank3out.wav": {
+     "bytes": 176494,
+     "sha256": "672a866c27c64f7eda1e05775cea6b4373c289c39fd423a519d39198d10a9c89"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 15122,
+     "sha256": "54c25fca46991ea142e9fdf5309e690ce3ff977df89aa7d14a8938ff386a237e"
+    },
+    "sound/items/backpack_ammo.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/backpack_armour.wav": {
+     "bytes": 20612,
+     "sha256": "438a08f094f47fac5f0b959fdde0f941be50bac12abdaa159f6f727975021aec"
+    },
+    "sound/items/blastbelt1.wav": {
+     "bytes": 43442,
+     "sha256": "a85924de58caed8e32d2849838afa0f248ec26eb295c9fc82eff818bc292f28b"
+    },
+    "sound/items/blastbelt2.wav": {
+     "bytes": 74978,
+     "sha256": "e4747a55ed0d66b6ce3bfe4ad0a4cfa75308657a155ebd9396ada78e0fd46bac"
+    },
+    "sound/items/blastbelt3.wav": {
+     "bytes": 49028,
+     "sha256": "4a2f6e7f65cbbc19c4bd5facf821017f7e60c41b9c164575de5255a40de2ba53"
+    },
+    "sound/items/health0.wav": {
+     "bytes": 8718,
+     "sha256": "cd277cc4fc98dbf9d5b0ba3ab784e468ba77a5aec78fe6086bd125512b6d1dbc"
+    },
+    "sound/items/health1.wav": {
+     "bytes": 13316,
+     "sha256": "ed9a43a3506afd8073e0d5225f3fa43116bb922b84d2216c2053d58f597544e6"
+    },
+    "sound/items/itembk2.wav": {
+     "bytes": 18884,
+     "sha256": "2b5601380dcc36753327eea905d15d2e0fd0f016d9559a2f8924f6f34b8045d5"
+    },
+    "sound/items/jumpboots1.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jumpboots2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/jumpboots3a.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jumpboots3b.wav": {
+     "bytes": 85590,
+     "sha256": "8eda0e57fdadfb61a414b4dae8c567a2bf10d9dabc44db7cf5589f00bba16250"
+    },
+    "sound/items/jumpboots3c.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/lavashield1.wav": {
+     "bytes": 30884,
+     "sha256": "e79050c462eeefcdbe6be0d79ff3042e80e5654c4060cf5377eee366cb4d6b43"
+    },
+    "sound/items/lavashield2.wav": {
+     "bytes": 49190,
+     "sha256": "17e93e45d150704bab8debd86ee8e9c600e9b08fefa70b16e1fe712dfdbd0c23"
+    },
+    "sound/items/lavashield3.wav": {
+     "bytes": 22094,
+     "sha256": "d94735d5df3c5850d2308972cb2495a9c9ec87e57c434c3ff0c160da659b051f"
+    },
+    "sound/items/nailp.wav": {
+     "bytes": 97394,
+     "sha256": "eb786846675412ba7bfb892fa0d5d356b67ec83ad3a551de8b423a874c3608d1"
+    },
+    "sound/items/nailp2.wav": {
+     "bytes": 132454,
+     "sha256": "2a01a3beb92154c7275c3c2ad39f648f8ecad7fd32ef7264d7404b917e0147dc"
+    },
+    "sound/items/nailp3.wav": {
+     "bytes": 45268,
+     "sha256": "0ea4502763119419b226d830b5b0147d6cfbe78996749e330d652d5b538dbb7b"
+    },
+    "sound/items/protect.wav": {
+     "bytes": 44176,
+     "sha256": "1bc5895a71225e8a385ebc900952d3b41f3d9541eefb8affcf15804ca96e5ab4"
+    },
+    "sound/items/protect2.wav": {
+     "bytes": 66286,
+     "sha256": "80b2a47fb1158f252e888bc692d352f224170c2d18177163dfea5c8110688e65"
+    },
+    "sound/items/protect3.wav": {
+     "bytes": 44176,
+     "sha256": "4aab23bd1683c733c5c85e7d55a93b27746860bd3c1a707e8c5a6439e35b5fd2"
+    },
+    "sound/items/r_item1.wav": {
+     "bytes": 12272,
+     "sha256": "3b569e1a8210563a64045dc1629a243b382c49cf24722cbddbdae348d5fa75d7"
+    },
+    "sound/items/r_item2.wav": {
+     "bytes": 14462,
+     "sha256": "088bb9013c0d2201997d3c566b95cc91f0419ba0bc89173c9e532659ccb4e886"
+    },
+    "sound/items/sharp.wav": {
+     "bytes": 100592,
+     "sha256": "c86d353daa830fffcf5ded77b73d6b8871d15a47a857a977ebaf7cbddb6cb587"
+    },
+    "sound/items/sharp2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/sharp3.wav": {
+     "bytes": 46584,
+     "sha256": "6318f7079e79929ff0439a570c5f806ec9c2cce8a8447eddb666dee0c2211336"
+    },
+    "sound/items/sharpa.wav": {
+     "bytes": 97394,
+     "sha256": "cd0d8dc72f736b38ab9c4a473798f0dd32e2074c14a310892c3fdf6515ff53be"
+    },
+    "sound/items/sharpa2.wav": {
+     "bytes": 132454,
+     "sha256": "2545c58a3682c1e8459389dc728a39fe0d76e6ce14a9c816a4826e327ab9bddc"
+    },
+    "sound/items/sharpa3.wav": {
+     "bytes": 45268,
+     "sha256": "083cc822d4cd6819d2dfd6e125ea4ca8ef3230c1ac1c4a5f5e3fe22e4d3d36d9"
+    },
+    "sound/items/suit.wav": {
+     "bytes": 31568,
+     "sha256": "a9b13127acef0c8e617cf5e510d5654227db9049a2b06b7544eb9e3030146ee7"
+    },
+    "sound/items/suit2.wav": {
+     "bytes": 66368,
+     "sha256": "34f0ba1b415ab62f2eb3b7a59bda6fe6fbbf3e519c7d2fab29a42ce29eb073c3"
+    },
+    "sound/jim/death1.wav": {
+     "bytes": 14348,
+     "sha256": "7f97f27dfda78f9fe6fc5265e512b651e57ae466752d56cfe0dccd6d08478ed8"
+    },
+    "sound/jim/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/jim/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/jim/gunidle.wav": {
+     "bytes": 13260,
+     "sha256": "46441335fe896cb993368bb12cedc1ddd4886b5933298bb6a0d6b7ba430cdfe5"
+    },
+    "sound/jim/gunidle2.wav": {
+     "bytes": 48540,
+     "sha256": "08d3577b66ab4b4c65ae7b01e4590e8d985605cc51a939bae0b43967472208c6"
+    },
+    "sound/jim/idle1.wav": {
+     "bytes": 44460,
+     "sha256": "7bc2df6cdd0f9a06cc441c656664edb3c686ab5803dab70948cc27bbba968494"
+    },
+    "sound/jim/idle1r.wav": {
+     "bytes": 44460,
+     "sha256": "7549a540858b1a829ac010930b848474c2f2200b910371368c99e35641f24644"
+    },
+    "sound/jim/idle2.wav": {
+     "bytes": 44460,
+     "sha256": "90d55e9ac8db5523255ec80384abd2508f005890f4fb66a654f4d783435afb4d"
+    },
+    "sound/jim/idle3.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/jim/laser_load.wav": {
+     "bytes": 36040,
+     "sha256": "5f39b9f60c5de5c9c3ac25a5149f1fef557e66c09d7d1a760ed6770082c5a914"
+    },
+    "sound/jim/pain1.wav": {
+     "bytes": 27006,
+     "sha256": "27522940f1db4eb098388e049a63d3a608e4beb2fa248d1232ae45d38a944e85"
+    },
+    "sound/jim/pain2.wav": {
+     "bytes": 30850,
+     "sha256": "6d1988d75f430287ad3e8766e9aafa8c8c85e2f2ebf53395b0fc2eb0fb26d788"
+    },
+    "sound/jim/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/jim/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/jim/rocket_load.wav": {
+     "bytes": 23416,
+     "sha256": "e3820aad09060be13927e56fc0e21112c22161b50b7d5be9cf59b98f84c5a231"
+    },
+    "sound/jim/sight1.wav": {
+     "bytes": 14892,
+     "sha256": "1a0db2b8c8d763f9aae09913d1cd3548fa0e30eb03949e24ef511a70acfda303"
+    },
+    "sound/judge/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/judge/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/judge/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/judge/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/judge/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/judge/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/judge/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/judge/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/judge/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/judge/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/judge/smash_ground.wav": {
+     "bytes": 66250,
+     "sha256": "f29f17426d2bd961d4f166e25fb951c8e12a37314bbc49722f0ae34c2beae233"
+    },
+    "sound/judge/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/judge/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/judge/smash_roar.wav": {
+     "bytes": 61784,
+     "sha256": "24b26a6b00a8731693bafd8ef67a5f0e2a4bbad20e722ec14f6fefd13047dc78"
+    },
+    "sound/judge/summon.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/judge/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/justice/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/justice/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/justice/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/justice/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/justice/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/justice/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/justice/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/justice/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/justice/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/justice/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/justice/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/justice/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/justice/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/lostsoul/bite.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/lostsoul/charge.wav": {
+     "bytes": 114682,
+     "sha256": "327cf4f521c92b3af6ff7cf50d1bfa6d101d06dee52350f123473e56e72626e3"
+    },
+    "sound/lostsoul/death.wav": {
+     "bytes": 151916,
+     "sha256": "08b6f8d3a50465e7deb346bc8902605bfc8bafc134cfac38aeb1d9fa5d1d2863"
+    },
+    "sound/lostsoul/idle1.wav": {
+     "bytes": 132332,
+     "sha256": "aac9bd66ea75d4778a20ba07b248baaa4f446beb60e5b5be76d04be36df1a1db"
+    },
+    "sound/lostsoul/idle2.wav": {
+     "bytes": 132332,
+     "sha256": "963c18a04a41d49ced0c820fd6ec51c885e7828a2a09bd47c15227555b6d4ada"
+    },
+    "sound/lostsoul/pain1.wav": {
+     "bytes": 14948,
+     "sha256": "baccaed4fd7c4e504214eb7241d3e8ea3e187739a781c30de57c8b5af6dbe6d0"
+    },
+    "sound/markie/dronebell1.wav": {
+     "bytes": 410346,
+     "sha256": "c7b65065ba9279c8131a83b642523e4193b8611f7b14430af2d52c831082340a"
+    },
+    "sound/markie/dronehum1.wav": {
+     "bytes": 156754,
+     "sha256": "9542c51342398a1281476da03114adb01012367dac58d2a08b50c684a1a98093"
+    },
+    "sound/markie/dronehum2.wav": {
+     "bytes": 183654,
+     "sha256": "03545ae0f88b788e69e09c0aae2cccfa727a2609ef224c7d1d3451f0e6172709"
+    },
+    "sound/markie/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/markie/dronespace1.wav": {
+     "bytes": 151808,
+     "sha256": "2c9c7f38a2023d3452a48db3e5f98d11fa218315991d907f8e3fa95d128d4f76"
+    },
+    "sound/markie/dronewind1.wav": {
+     "bytes": 110328,
+     "sha256": "f65fd70b6c398e1a17975eff7d92bde89ac17bc8d5cf0e9c6dcb17934311e3a6"
+    },
+    "sound/markie/morte1.wav": {
+     "bytes": 529280,
+     "sha256": "c338e404901bbf094c5946e50cbd922580c077dc3f3e5369ab962cb07a70d855"
+    },
+    "sound/markie/morte2.wav": {
+     "bytes": 529280,
+     "sha256": "58e598c9da2ced85f6973eb897f578e0f29a13fa0eaefebfe14c8942a33c77ed"
+    },
+    "sound/markie/ritual1.wav": {
+     "bytes": 273266,
+     "sha256": "fe9b4b53f899a88321707330bb2454442d74e5098328e35549b9f0a8ff840cba"
+    },
+    "sound/markie/ritual2.wav": {
+     "bytes": 273246,
+     "sha256": "d38ee880af55413aa7c180b8c1935df71177502081ee1c376c37b572af3d9352"
+    },
+    "sound/markie/stingwhisper1.wav": {
+     "bytes": 132380,
+     "sha256": "fc6eebd33c0c99c0f4537a9727698181acb4d23d077f06b3da1ebbcb104c870c"
+    },
+    "sound/markie/stingwhisper2.wav": {
+     "bytes": 132380,
+     "sha256": "ae7319c28e0a4e492623b7ddb48634978da043c16d4450f86b8edf7e60fa283c"
+    },
+    "sound/markie/stingwhisper3.wav": {
+     "bytes": 151672,
+     "sha256": "e5dd9dcfd44dedf7b0cd4a0a94a519a0bbd84477e54293548a37aa16d3f1e428"
+    },
+    "sound/markie/watercreek1.wav": {
+     "bytes": 184884,
+     "sha256": "f0c3ac87d6f073cea0d1a9218c4e53327be7af07a8c8be00cd73f254f6c0ba03"
+    },
+    "sound/minotaur/attack1end.wav": {
+     "bytes": 19936,
+     "sha256": "eceb47163a0f495037bd067fcfe852dbd0cf8cc7c376c536f5e4bda8569d3f5c"
+    },
+    "sound/minotaur/attack1expl.wav": {
+     "bytes": 15554,
+     "sha256": "a8344e4036b9377a6c8e3d69c2e86c7f5fc157fb0034d6e0e190d5b9fc444ca7"
+    },
+    "sound/minotaur/attack1long.wav": {
+     "bytes": 42000,
+     "sha256": "bb901880112ff159b380b8bfaf19fc511f4b1217f08d55a05276a3500f6cd4c7"
+    },
+    "sound/minotaur/attack1start.wav": {
+     "bytes": 19944,
+     "sha256": "33dafc2b20be70d6da51321f9910a392535e6a31cbbd3c8d0d880307a18adb3a"
+    },
+    "sound/minotaur/bolt_fire.wav": {
+     "bytes": 17738,
+     "sha256": "2f8ea56413270eef58b56ae4c4f7af2506ee89fda82aab90c0426f4560baa80a"
+    },
+    "sound/minotaur/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/minotaur/idle1.wav": {
+     "bytes": 17686,
+     "sha256": "d213130ad4b58b5b55553da46d358526411916210e90caf082c5a93b499e2f81"
+    },
+    "sound/minotaur/idle1com.wav": {
+     "bytes": 15564,
+     "sha256": "0f8054eb2c16284a098f680dcdc65f5a4b8b971f8cceaca6adebe8c377d6117f"
+    },
+    "sound/minotaur/idle2.wav": {
+     "bytes": 15470,
+     "sha256": "390c82c79532878751bcddca11aa37dbd86018757860e46d0c950a09fee347d9"
+    },
+    "sound/minotaur/idle2com.wav": {
+     "bytes": 17764,
+     "sha256": "8369884de2f4f144b9e323f11e95f47723834b529b62100c908fef5e74391a93"
+    },
+    "sound/minotaur/jump1.wav": {
+     "bytes": 22160,
+     "sha256": "1aa935c4c76818dbe7faed7aee0d9acb9e98ad553a747bf00b83b811d141e886"
+    },
+    "sound/minotaur/pain1.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/minotaur/pain2.wav": {
+     "bytes": 41488,
+     "sha256": "bc9ffeb193379c6738ad2897ab582aa92e278a11d7f1fbb77563ca367987ff76"
+    },
+    "sound/minotaur/sight1.wav": {
+     "bytes": 48610,
+     "sha256": "8d0a5c1a31e525416430f8d45b8482b091d3bb9f6030ac2656bdeb231ddab5e9"
+    },
+    "sound/minotaur/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/minotaur/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    },
+    "sound/minotaur/strike1.wav": {
+     "bytes": 11142,
+     "sha256": "69b1419eed136c384deac99d31827825d3d57fc965ba80604faf9de3e85fd9b8"
+    },
+    "sound/minotaur/strike2.wav": {
+     "bytes": 11142,
+     "sha256": "ab12dc8ab3c9dc603e2ecd58a99beb9c1f551fb79eb6124bdba493efe7595a92"
+    },
+    "sound/minotaur/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 19940,
+     "sha256": "0798d1a1122171f06fd6b92e3f91881725c05f40e1eeb3494a5a1a1aa8a86e58"
+    },
+    "sound/misc/drip1.wav": {
+     "bytes": 12172,
+     "sha256": "9499c277eab2210ba491b61263b71410e5e8f4b2a68403ec6eb81bef687da04a"
+    },
+    "sound/misc/drip2.wav": {
+     "bytes": 15596,
+     "sha256": "410c25c5c459362849c7d3d0ad736e006b65a949e77c094fe248e803b357d5e0"
+    },
+    "sound/misc/drip3.wav": {
+     "bytes": 15164,
+     "sha256": "9ddf50265efafde7736fb7d03419988caab691245b32d986549ef6d643d2768c"
+    },
+    "sound/misc/flies1.wav": {
+     "bytes": 44168,
+     "sha256": "ca5cf0a4d661bf7440cd81dcd45ad7118c54c8ae58672755ee958ec6e50f7152"
+    },
+    "sound/misc/flies2.wav": {
+     "bytes": 44166,
+     "sha256": "09e6d74986b0f0ec9503d9e111f8d1436d7d6c5c4c0c87ec7808e3fca5b964b1"
+    },
+    "sound/misc/flies3.wav": {
+     "bytes": 44182,
+     "sha256": "2b5fb337ba88bd25e10c86bb6355723aea160b0ef6a6d43b30cbbd446444ed8e"
+    },
+    "sound/misc/gibf_fire1.wav": {
+     "bytes": 14376,
+     "sha256": "804f8524135d058d3a635e6567e3369b8b9ef2ecc808bf6e216c4d65609b86a3"
+    },
+    "sound/misc/gibf_fire2.wav": {
+     "bytes": 25842,
+     "sha256": "354b551ac38a19370126f67e3975ab795953bd7beb2c597f0a01a0de6286b7c1"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/laseron.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/misc/poweroff.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/misc/poweron.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/misc/rumbleloop.wav": {
+     "bytes": 106060,
+     "sha256": "fafcaa92b4a2174045e3826885d14e434a409bf559d1a1d519c4d50ec8939789"
+    },
+    "sound/misc/rumbleoff.wav": {
+     "bytes": 105990,
+     "sha256": "46728daf18b142575d50049188030a153c0e3e994dc83ea375c43ba6da171b3c"
+    },
+    "sound/misc/secret3.wav": {
+     "bytes": 302444,
+     "sha256": "75682a08b790af46c2b9f746e5772999ba1de333b567832f4a3a8414c6a0185a"
+    },
+    "sound/misc/spaceship_fadein.wav": {
+     "bytes": 231712,
+     "sha256": "d6c905eb002532087273eadb5a577db443068532795fd509571179a354c56a9f"
+    },
+    "sound/misc/spaceship_fadeout.wav": {
+     "bytes": 495982,
+     "sha256": "9e5286b29adeb9cf7b3af489bb2ea539c8eed7b26a28ec1f34cd5f78c33e521c"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 13270,
+     "sha256": "14d74e6c01df6db6f92b8684527b31a7544de8d4dd9d123ebae554989e76facc"
+    },
+    "sound/misc/torchoff.wav": {
+     "bytes": 54160,
+     "sha256": "d49cf5f2100d9b5afbf76a662019a9e3a66fcd5fb40c2b2600ceab107227cbf3"
+    },
+    "sound/misc/torchon1.wav": {
+     "bytes": 88680,
+     "sha256": "ecb211c777393fe3c7012bf0a35cc157af94ccb4742cac3ca7ab6daa5546a4ac"
+    },
+    "sound/misc/torchon2.wav": {
+     "bytes": 84764,
+     "sha256": "b7d885df1c70b226a77a3cc8842565fa9ebf51561158daec4b12e9629a515986"
+    },
+    "sound/misc/torchon3.wav": {
+     "bytes": 97484,
+     "sha256": "25058a3354df07a90b8660640682f7091fa40da6f8abf178c7de71d547a8b0c1"
+    },
+    "sound/nour/attack1.wav": {
+     "bytes": 50794,
+     "sha256": "7f22a1569d59bcd406efd7828ed605d71bfbc8cea01606eedb78d33037655f77"
+    },
+    "sound/nour/attack2.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/nour/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/nour/death.wav": {
+     "bytes": 39772,
+     "sha256": "2e2d15b95fc35738108d83a2b5aefded93772134d2a8124d1b937b6bfcfd74c5"
+    },
+    "sound/nour/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/nour/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/nour/explode2.wav": {
+     "bytes": 22168,
+     "sha256": "654a50eb01d1c6c64bb8df4b85669448cc08b580ffc44616da854bd3cb339ea1"
+    },
+    "sound/nour/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/nour/idle1.wav": {
+     "bytes": 24332,
+     "sha256": "c77ef8ce85720e3bf0ea97937992b5aa7cc6b63149c951e71b4d3ead14fc21af"
+    },
+    "sound/nour/idle2.wav": {
+     "bytes": 44176,
+     "sha256": "e87bd537a35c005b06ffd28f66adde24d52af338d3956d4fab455d682e78eec9"
+    },
+    "sound/nour/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/nour/pain.wav": {
+     "bytes": 8686,
+     "sha256": "073044c582c2de6f336130aeb9503fa6edf1da4eed216a4b407b2cd18d5f9995"
+    },
+    "sound/nour/projbomb_burn.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/nour/reveal.wav": {
+     "bytes": 39780,
+     "sha256": "6dd892d207fa31eb93c5a033ab44bba4952b3aed892aa409e6a49e2059381cdb"
+    },
+    "sound/nour/sight.wav": {
+     "bytes": 48612,
+     "sha256": "252c0bf76b928f7fe998f82bf148816e88cdc24f812bd8c8d3a591c1c4ec3d7d"
+    },
+    "sound/nour/sight2.wav": {
+     "bytes": 48612,
+     "sha256": "18b8e9450c00d6a9308adffa2046e747b8ed7bb5547f868ed146cca75b260b87"
+    },
+    "sound/ogre/ham_hit.wav": {
+     "bytes": 52014,
+     "sha256": "20f7ec214fdf8a342ac8c3be7d3ed04c7b7b3479f9c74138a8a052ba7674ee46"
+    },
+    "sound/ogre/ham_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/ogre/ham_wave.wav": {
+     "bytes": 132316,
+     "sha256": "d957285dc74a4e067f600465112ed41d69d14554f8e87ad6b0372b9ca8af4b25"
+    },
+    "sound/ogre/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/ogre/ogidle.wav": {
+     "bytes": 25706,
+     "sha256": "54915681452970c56f1ef405b182e90fa7ee3c4d4d80e32583a38abc7c1db713"
+    },
+    "sound/ogre/ogidle2.wav": {
+     "bytes": 22426,
+     "sha256": "2ed241e576a709285f7ea8a9671f6032da5a8db96e094e9007f60617cad491fa"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 28742,
+     "sha256": "738af1bbf36d5b3287c45e7815d87ea7f5c1a0487c804de7272091fdbb7faac2"
+    },
+    "sound/ogre/ogpull.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/ogre/ogrefish_flappy.wav": {
+     "bytes": 51262,
+     "sha256": "79a9eafef5edf45851a1c391e301c6f515536922c297b904e148b337e7f54a08"
+    },
+    "sound/ogre/ogrefish_idle.wav": {
+     "bytes": 27552,
+     "sha256": "5abf50694e67aa1e805a598a464d5d3b1f0625677a2873761cae139c4b21d524"
+    },
+    "sound/ogre/ogrefish_in.wav": {
+     "bytes": 6678,
+     "sha256": "dd5fc9aecb5b6933252739047aa5d3f775797ad7bf6ddb5652ffd26ea9ead3e2"
+    },
+    "sound/ogre/ogrefish_out.wav": {
+     "bytes": 15502,
+     "sha256": "2610f025057ee0a6682b574567b7400f83ba9f6665b9f7f3b9e76cff75b8be53"
+    },
+    "sound/player/h2ojump.wav": {
+     "bytes": 22126,
+     "sha256": "dd2d3629970814e719be6c9650a497edd219f31fb1554927b9770a1b0dfcdc60"
+    },
+    "sound/player/heartbeat.wav": {
+     "bytes": 70640,
+     "sha256": "a68fd895a3212f967a4686e94df2749fa3f58392ab2228aa880697e25b548147"
+    },
+    "sound/player/inh2o.wav": {
+     "bytes": 22126,
+     "sha256": "4c4d55502ab63ddbc9beb64b0459ad4d7a2992fe41e76144d3bbd3333af4a570"
+    },
+    "sound/player/ladmetal1.wav": {
+     "bytes": 95952,
+     "sha256": "6cd990509a965ff251ffb33ff7c22b6eb708cec5f7b7b82e2196b1fb3d3cb1c2"
+    },
+    "sound/player/ladmetal2.wav": {
+     "bytes": 96116,
+     "sha256": "a477162fc355efc88568b9e18d668b7b0e8e99af460b88c755bd1ed57da35006"
+    },
+    "sound/player/ladmetal3.wav": {
+     "bytes": 96008,
+     "sha256": "20ea0c70bcc3c951bb067cb65b938c63267bba0a1eda3a335df525dc9432d234"
+    },
+    "sound/player/ladmetal4.wav": {
+     "bytes": 96126,
+     "sha256": "d2a6bede3a9c499d01a0b0b9620d4bd1935f9477ecb9c59a8d73f3133699ea45"
+    },
+    "sound/player/ladrope1.wav": {
+     "bytes": 70706,
+     "sha256": "6713acc390790d4723df21b0702796958132af34ce5ec0a85fca5edc36ccd728"
+    },
+    "sound/player/ladrope2.wav": {
+     "bytes": 70792,
+     "sha256": "384b8c3ad3749fa9963ff3210d7cb312858771cca85082b6a8ad13179ad92da3"
+    },
+    "sound/player/ladrope3.wav": {
+     "bytes": 70760,
+     "sha256": "ed397a0308ecacd0ba9774f082aec5e681bcffb219c8d9127b7d7606a6fbb02d"
+    },
+    "sound/player/ladrope4.wav": {
+     "bytes": 70758,
+     "sha256": "e1a4327f1c458f408abd6ff713d11e0aee8daaa9c876002b693135d8e64b68fe"
+    },
+    "sound/player/ladwood1.wav": {
+     "bytes": 48084,
+     "sha256": "bd68f3af0f6cd429d08aa44168e14435ed9e2e2ec0d6a038f83e2dd683cb7e74"
+    },
+    "sound/player/ladwood2.wav": {
+     "bytes": 48086,
+     "sha256": "bb687ec2183f460ac4240acfcd2f3da2f8bd9da043ba705f6e32c3439e4845b9"
+    },
+    "sound/player/ladwood3.wav": {
+     "bytes": 48088,
+     "sha256": "7271136b6398602c7b4bdbd610a37b5a82a66195842030a21de08a89808b4026"
+    },
+    "sound/player/ladwood4.wav": {
+     "bytes": 48086,
+     "sha256": "3b7580b31dee8a86e636c5fd17d92566d147417f98764d51097ad53ff0d19d29"
+    },
+    "sound/pushable/brick_m1.wav": {
+     "bytes": 44144,
+     "sha256": "7572ac5d03045552dfee673293722da8c663d072cc7b57e44adb2e3884ea33c9"
+    },
+    "sound/pushable/brick_m2.wav": {
+     "bytes": 44144,
+     "sha256": "209e22e4693184c7b0c022e650b156e255cfa76b18c1066fe20255e285b4e80b"
+    },
+    "sound/pushable/brick_m3.wav": {
+     "bytes": 44144,
+     "sha256": "edafb8bf0915badb97edd078aa129c10a29e8fc428f4e9143f5926f9aa336e43"
+    },
+    "sound/pushable/glass_m1.wav": {
+     "bytes": 48044,
+     "sha256": "66a5944b16e3fe59cf9f8632f92bd85f81b79dc8711337558c45078c91a13c46"
+    },
+    "sound/pushable/glass_m2.wav": {
+     "bytes": 48044,
+     "sha256": "d462bac59390f89facc7c00d8aaee6e71b529ae9f177514a5f2f0533c78d5a0e"
+    },
+    "sound/pushable/glass_m3.wav": {
+     "bytes": 48044,
+     "sha256": "1a2efd7875486d15df811135d589135c807ba0149c877085f165932eb2770320"
+    },
+    "sound/pushable/metal_m1.wav": {
+     "bytes": 44144,
+     "sha256": "91420caf0e2de995681ac09b2be26cc9d0759edc06498571527528419de407d1"
+    },
+    "sound/pushable/metal_m2.wav": {
+     "bytes": 44144,
+     "sha256": "72f018c79b343538fd90de944ed54e8e3351b3da0a6c198f28403d25fc8fb140"
+    },
+    "sound/pushable/metal_m3.wav": {
+     "bytes": 44144,
+     "sha256": "c26b3aff129d573a1175fb618186db3b7ede8976e134c563c1678f48eaf8e302"
+    },
+    "sound/pushable/rock_m1.wav": {
+     "bytes": 48044,
+     "sha256": "9fb6ebeae45b4c47b1e42af1f00441d0e0bb88fbb53f85ea875341f9db55efb4"
+    },
+    "sound/pushable/rock_m2.wav": {
+     "bytes": 48044,
+     "sha256": "b57d0f760bb318b1159293e38811e5607bae8ff244d8bbf56223b355ef7c5b39"
+    },
+    "sound/pushable/rock_m3.wav": {
+     "bytes": 48044,
+     "sha256": "5e6514c241bb11d6194d9762d5369fb2a8da287b3d4c08e67f23da84fdb26b04"
+    },
+    "sound/pushable/wood_m1.wav": {
+     "bytes": 48044,
+     "sha256": "e672209779ee47996ca93e60d30e572da3cced5381db3f34c14a709629a5f4d2"
+    },
+    "sound/pushable/wood_m2.wav": {
+     "bytes": 48044,
+     "sha256": "c76b7db5faf1cbf21c07dacec615436a95f34c0e16e68628b62ec89a89b12f83"
+    },
+    "sound/pushable/wood_m3.wav": {
+     "bytes": 48044,
+     "sha256": "d6751d9e67c49458df6c076d9b6be9619f845213a263cb76330f51700f8a632c"
+    },
+    "sound/scorpion/clawattack1.wav": {
+     "bytes": 13360,
+     "sha256": "b0daf0605690db89f34a19936f1c20ad25676a4e6cd9dfad0e5757cf81dc4f7d"
+    },
+    "sound/scorpion/clawattack2.wav": {
+     "bytes": 13360,
+     "sha256": "06da85e6d6035704932fdc1ef449de529e17853571d017c5a42b253b5ed71a94"
+    },
+    "sound/scorpion/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/scorpion/hiss.wav": {
+     "bytes": 26664,
+     "sha256": "9d9fae97f3996ff3c0616f7acda952166d5eced9227d15a8fbe9d285095e7936"
+    },
+    "sound/scorpion/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/scorpion/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/scorpion/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/scorpion/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/scorpion/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/scorpion/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/scorpion/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/scorpion/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/scorpion/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/scorpion/tailattack1.wav": {
+     "bytes": 25858,
+     "sha256": "61e6c65b4c68813925e594b96ebad8a945c87d51f2cd23f301e80e231e53033d"
+    },
+    "sound/scorpion/tailattack2.wav": {
+     "bytes": 19650,
+     "sha256": "aab86f97eed636ebfb79ae7b92e4b7f7a3436b0146ad75519edd4358716169c7"
+    },
+    "sound/scorpion/tailfire1.wav": {
+     "bytes": 8924,
+     "sha256": "1f41bd184aa58b9f2f1b2f1197f3b7827c55d523d03a354dd1fb6d469cf129c8"
+    },
+    "sound/scorpion/tailfire2.wav": {
+     "bytes": 8948,
+     "sha256": "40a126ab5cba6c291d69606eddb7e2ab63ab640b1347b2e78ab4b0f7aca90c5c"
+    },
+    "sound/scorpion/warning1.wav": {
+     "bytes": 76930,
+     "sha256": "ae19faeebc0d3ec8c9f136bba205e634a29425ec86c3036016e5f2d9cd550817"
+    },
+    "sound/scorpion/warning2.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/seeker/death1.wav": {
+     "bytes": 397272,
+     "sha256": "35d8a1091032f24ed6a65efa99a7618f32bc0def24779efb51752b75a9e31ca1"
+    },
+    "sound/seeker/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/seeker/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/seeker/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/seeker/footstep1.wav": {
+     "bytes": 96092,
+     "sha256": "e5cd4f907a1b70ec72048b2dd5a5062022e7058676c3d90d05b7426e189a5073"
+    },
+    "sound/seeker/footstep2.wav": {
+     "bytes": 96076,
+     "sha256": "f3c8ba8d65257ddfa73e3e54c737c49de5dcc5c17bb088feb3511c3d69d21ac4"
+    },
+    "sound/seeker/footstep3.wav": {
+     "bytes": 96092,
+     "sha256": "c6fa111be092592a253815826c499b9b1f18a0c536910e2a82eebec7fb7f817d"
+    },
+    "sound/seeker/idle1.wav": {
+     "bytes": 141126,
+     "sha256": "10693a1d5fc1d710e54a0d57ce10d71400de192b874d6776ffe176c2b399a6b5"
+    },
+    "sound/seeker/idle2.wav": {
+     "bytes": 97420,
+     "sha256": "c24b439701d9ec3cf055702f23a3eb23623320ae89b9d46ab98a791f08898573"
+    },
+    "sound/seeker/melee1.wav": {
+     "bytes": 106252,
+     "sha256": "addfb5fab225a77f08d5c126b13f929fa31aa1c9094fc79202121ca891933fb9"
+    },
+    "sound/seeker/pain1.wav": {
+     "bytes": 19884,
+     "sha256": "ccaca64b8c1ab87d7d70896333cbec22c3b61c443a36cd8f253ad0eafc2d7ae1"
+    },
+    "sound/seeker/pain2.wav": {
+     "bytes": 19884,
+     "sha256": "8c3be23111a5ef53a7b66c7b74e32404ff0e6989d7de835543e0a65645e3f793"
+    },
+    "sound/seeker/punch1.wav": {
+     "bytes": 19940,
+     "sha256": "e4bf6b7deb14b5d614b4d5b7d4eeee36059372c913cc906589e1048d4484259d"
+    },
+    "sound/seeker/range_laser.wav": {
+     "bytes": 88246,
+     "sha256": "ee9f13af042a2a98fb75fa33873a1e861f3418f598ddb390f15ab44fcf93fcbf"
+    },
+    "sound/seeker/range_plasma.wav": {
+     "bytes": 79782,
+     "sha256": "9b1d38a4e1937023536d5ab5de035c97e1ef69131d58822b194cab2a3aa340b3"
+    },
+    "sound/seeker/range_rocket.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/seeker/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/seeker/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/seeker/sight1.wav": {
+     "bytes": 163526,
+     "sha256": "ca06541f54bcc297ab19ee133de5c782e978cf7afc2fab34b3789c4c56044d30"
+    },
+    "sound/sentinel/laser.wav": {
+     "bytes": 9712,
+     "sha256": "c5f90e1823a04b48f7f24ac5b8792e1b42030a8b07970db5847dc1e74be094c2"
+    },
+    "sound/sentinel/nail.wav": {
+     "bytes": 13750,
+     "sha256": "7acc3ac05b7218abc6fef2d2397771d90fce6fa39415e33824be7e771d30e288"
+    },
+    "sound/sentinel/widle1.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/widle2.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/wpain.wav": {
+     "bytes": 19596,
+     "sha256": "bc7b6536a1c67aa89295eeacea2d9b36cb0bf783b5fb7cc6aaf4fa01a0edb3fd"
+    },
+    "sound/sentinel/wsight.wav": {
+     "bytes": 27322,
+     "sha256": "83bca2103d60c68435e27f0660e3ecd5bffb058e796382e7bdb43efabdfb9889"
+    },
+    "sound/shalrath/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/shalrath/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/attack1.wav": {
+     "bytes": 44184,
+     "sha256": "91f50e3b69909213e23149b6a3e9622c4367d77f871da5f01e6e4aea3badf648"
+    },
+    "sound/shub/attack2.wav": {
+     "bytes": 33174,
+     "sha256": "d4928f711f7e8fc1d8ba050a87b4e1c2d48ffc24af6a454637629dfae8902e3f"
+    },
+    "sound/shub/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/death1.wav": {
+     "bytes": 107440,
+     "sha256": "1551554be1b7896ee39156ce258bf68ac5dace891994788020ee95083ae33e77"
+    },
+    "sound/shub/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/shub/idle1.wav": {
+     "bytes": 75072,
+     "sha256": "9d33c61470d0c4269c8d113b4476b84236fa00e6ee3be061865e242c988093af"
+    },
+    "sound/shub/idle2.wav": {
+     "bytes": 75000,
+     "sha256": "21b063438744def5f79a50709c567cc9f3e3a28c39e58456068a3d4ae362617f"
+    },
+    "sound/shub/idle3.wav": {
+     "bytes": 75096,
+     "sha256": "310c4ff969da63c77e7ebb5b319aca0f17a10802ee942b21174349d5e5a79d72"
+    },
+    "sound/shub/pain1.wav": {
+     "bytes": 83880,
+     "sha256": "1d1536a51822b67106ea72bcb537efbf5f69e4a4592904f6feedee06ef5084df"
+    },
+    "sound/shub/pain2.wav": {
+     "bytes": 83886,
+     "sha256": "71c30d3f41e0f99cffcf5037b482c1da7bf028b477051219f6e605ceef28ae38"
+    },
+    "sound/shub/sight0.wav": {
+     "bytes": 83880,
+     "sha256": "6d4d96fc663db248cf9279c0b028c11b451b133c6e2c38364c13e105f8fa377f"
+    },
+    "sound/shub/sight1.wav": {
+     "bytes": 83880,
+     "sha256": "ecaf1595f3acbfe2e771a193c69bd6de5e6e3bd957405fdf4bcf59a2288bdb05"
+    },
+    "sound/skullwiz/attack.wav": {
+     "bytes": 15484,
+     "sha256": "ca662d909cb3b96bdfb93197092ed8e8a5d1ed27772a91a4a6ae5e9d3063017a"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 33166,
+     "sha256": "5d1ccd5b97bd38eaf46d1e0798009765d46d58ba17e7e6efc36350b0adaa22f7"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 33178,
+     "sha256": "dd77e90760bd85fc872a96c2eaa808b094a461ab2871bd8ab6a5372861560512"
+    },
+    "sound/skullwiz/blinkspk1.wav": {
+     "bytes": 44200,
+     "sha256": "ade109f32810094922f77bc3c03f02d33e98d855d3dcaf79ceab4cb200efaa65"
+    },
+    "sound/skullwiz/blinkspk2.wav": {
+     "bytes": 44204,
+     "sha256": "16d3b1296e1ed9c3bdc06dd25f5d9db3569cf3486794d29858d5ad227741dd1a"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 33166,
+     "sha256": "bc83800a91fad273e7f84f3cec2fa2787c902f4cd97fd5495f73dc9fb6d2c368"
+    },
+    "sound/skullwiz/fadeaway.wav": {
+     "bytes": 43092,
+     "sha256": "dd67d3ffe5a592b4e449d6bb00eee3c525ede786b0a2d9089832981311bfd61e"
+    },
+    "sound/skullwiz/idle1.wav": {
+     "bytes": 88252,
+     "sha256": "1834b946ff68aab07ade01b68d95d822d0b2a1baa51c1ceba7e66c73b8b6211e"
+    },
+    "sound/skullwiz/idle2.wav": {
+     "bytes": 88240,
+     "sha256": "57c49c7fd4f52b870a658e2e854e16c67389e9d79f9a1db5928f12d74741a1da"
+    },
+    "sound/skullwiz/pain1.wav": {
+     "bytes": 11132,
+     "sha256": "125e06cdfacd6aa78a90034d3f94086736734dd1dd9d170fef3a512b42e34cd0"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 15540,
+     "sha256": "ac5a56dbff28fa4724bd8766d8443090e3026007f6f4051cfecd2869b3f5ecb9"
+    },
+    "sound/skullwiz/poison_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/skullwiz/sight.wav": {
+     "bytes": 36484,
+     "sha256": "3051df89bfdce6b80c49c3513cfcbd679bf1f71c5562430d7738737e44f04f26"
+    },
+    "sound/skullwiz/skull1.wav": {
+     "bytes": 22144,
+     "sha256": "3a43bc5e1079740b61199ff21518f75cc1e4db7cdc9e25b57631b38b04d651a2"
+    },
+    "sound/skullwiz/skull2.wav": {
+     "bytes": 22158,
+     "sha256": "fed613207dc7691118ea5b62626df8773bda59816b008bfd2aeaa4d2f26a4b7b"
+    },
+    "sound/skullwiz/summon.wav": {
+     "bytes": 97022,
+     "sha256": "bf74e3dfbb330f481790f7bbc2b88e74b1654f7d5b327235c3d00bee3f62a06a"
+    },
+    "sound/soldier/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/soldier/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/soldier/rocket_load.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/spider/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/spider/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/spider/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/hiss1.wav": {
+     "bytes": 17802,
+     "sha256": "c56fcae8a01af94c07807730857b4b367f2c70c35869505528504faa29a17ade"
+    },
+    "sound/spider/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/spider/hiss3.wav": {
+     "bytes": 22582,
+     "sha256": "1a3c71b1e4ac2389c98c4af9db88e81b51a602c681bd00a1812995654863e2d4"
+    },
+    "sound/spider/idle1.wav": {
+     "bytes": 20922,
+     "sha256": "8a6d25359bbbc1f5e4f6962f4ce1742160537c6bb8bf8b806a0df96adfae819d"
+    },
+    "sound/spider/jumpland.wav": {
+     "bytes": 6038,
+     "sha256": "3c46bc58c52a61480c1a8dc2034aa240545521baf5e0027372992a9458796919"
+    },
+    "sound/spider/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/spider/pain1.wav": {
+     "bytes": 6108,
+     "sha256": "728cd94a64b27dea4d845a9e27e1ba09cfb286bff80128a67d1da0431b6b0c20"
+    },
+    "sound/spider/pain2.wav": {
+     "bytes": 10460,
+     "sha256": "736f0a768c0f52b22a301fc6a15f18f2f60e5579d3b27c2b78bcb7bed8e0c577"
+    },
+    "sound/statue/comidle.wav": {
+     "bytes": 17722,
+     "sha256": "3567914304c8fcf224e31bc302039432cd17833daabc2ed9f83053b01fef4f7c"
+    },
+    "sound/statue/death.wav": {
+     "bytes": 13472,
+     "sha256": "b030aeac3d806bc77fddaed4bb32684cfd2bbd707fe85e2500a3346c5931ec68"
+    },
+    "sound/statue/hurt.wav": {
+     "bytes": 8012,
+     "sha256": "9193f4e976675042409db103f7e3b26f667a56e913e96a37f223f1c606323246"
+    },
+    "sound/statue/idle1.wav": {
+     "bytes": 13304,
+     "sha256": "0b5d3bcbd00e846d38986f8919ff4fa7bcce92e45e5ba5949edd0e81b741b69c"
+    },
+    "sound/statue/idle2.wav": {
+     "bytes": 13316,
+     "sha256": "45469f14a25fd434ba1ed987fd20835ac058496d41df5a6aa543dec454670f36"
+    },
+    "sound/statue/sight.wav": {
+     "bytes": 9584,
+     "sha256": "84ab06d320f9953eebda7c4dd25a0e0de3369957de01c64af10a8b3ca886241e"
+    },
+    "sound/steelclaw/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/steelclaw/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/steelclaw/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/steelclaw/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/steelclaw/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/steelclaw/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/steelclaw/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/steelclaw/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/steelclaw/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/steelclaw/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/steelclaw/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/steelclaw/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/steps/drag1.wav": {
+     "bytes": 13586,
+     "sha256": "db069e08b7de4c5074cc4dd56f3b1cd2b6d77fe7869e1e03f5dddddcf9aad530"
+    },
+    "sound/steps/drag2.wav": {
+     "bytes": 13572,
+     "sha256": "b2ac07fe014e7c5afd4a5974c5d290b34a880a52f33668030a97a345d5811db9"
+    },
+    "sound/steps/drag3.wav": {
+     "bytes": 14690,
+     "sha256": "a29ee6f0977b205d146f81ee5be2f9b2f12ca76f177aaab9e35e556c4f555fa9"
+    },
+    "sound/steps/drag4.wav": {
+     "bytes": 13584,
+     "sha256": "1b5628a4272837ccf9c4044371a1d45eef23439b164be445b6f2ca90952e3487"
+    },
+    "sound/steps/drag5.wav": {
+     "bytes": 13584,
+     "sha256": "6dec9033ece2a02ce65c437e1b7e58512fd04d41a327487704de71cdf39b99dd"
+    },
+    "sound/steps/giant1.wav": {
+     "bytes": 33140,
+     "sha256": "d28f78c1514f215c64b6a3de38b5ffb5b891341ed95dc0277b1b3dba498cc64a"
+    },
+    "sound/steps/giant2.wav": {
+     "bytes": 33138,
+     "sha256": "7936f32a0ae371e216a195c3110b24db372a15091ea5c80e78875951f874d3b0"
+    },
+    "sound/steps/giant3.wav": {
+     "bytes": 33126,
+     "sha256": "58f79749cbdaaa608e6aacc368b74e0ac1e2ecf2ef45967c7f1f7b7a3e99c8fd"
+    },
+    "sound/steps/giant4.wav": {
+     "bytes": 33136,
+     "sha256": "4ffa741a70225aa31078f73a5612cf7d5ad9f9007163f0a5aeda749da099f9bd"
+    },
+    "sound/steps/giant5.wav": {
+     "bytes": 33138,
+     "sha256": "a2706d4dd9856cccdc3980156a77702883e36d86df54221b31a781c8e5e767e3"
+    },
+    "sound/steps/heavy1.wav": {
+     "bytes": 13282,
+     "sha256": "603679f83cc5095d2fa81d945285b2980195ba50ee2615fed85487493f0a536d"
+    },
+    "sound/steps/heavy2.wav": {
+     "bytes": 10870,
+     "sha256": "384f160ad4816b6984ef6b3b59c4bc1e8a2a3e05f9aaa80ee8b30ada2645669f"
+    },
+    "sound/steps/heavy3.wav": {
+     "bytes": 12828,
+     "sha256": "936417bc5ec9d30db8a74a9798328436259ffd704b11e1155d3fa79dc829e462"
+    },
+    "sound/steps/heavy4.wav": {
+     "bytes": 11050,
+     "sha256": "8d4879d40eda9182ff45fb18130c7979997d326581c14edeedc9cab440531e00"
+    },
+    "sound/steps/heavy5.wav": {
+     "bytes": 10198,
+     "sha256": "4e2e9892dee74d3472a45ecda889ae8d2f836786b44a55e5d1436690c7dadd5e"
+    },
+    "sound/steps/large1.wav": {
+     "bytes": 33118,
+     "sha256": "c387d084a10b28329610d8e3ad3e377f43087013e802be42af79f254276d00dd"
+    },
+    "sound/steps/large2.wav": {
+     "bytes": 24960,
+     "sha256": "ab91b4605671dd16da59963959cda3368a065612d8ed1776847da310b1e7b5fd"
+    },
+    "sound/steps/large3.wav": {
+     "bytes": 24280,
+     "sha256": "3e6a5ef0d8cbaba2e976f199d8d1ffa073fe8e83dacee709137335d42ddd7558"
+    },
+    "sound/steps/large4.wav": {
+     "bytes": 22092,
+     "sha256": "f2bde1b715f679cf814c2cd1375442170cf9f6e56d8ea1756900f81f1d1df453"
+    },
+    "sound/steps/large5.wav": {
+     "bytes": 24320,
+     "sha256": "c15b388bbed461461bac2c22b3a88ff272c04ad070e4791b7ce35c1559d16f77"
+    },
+    "sound/steps/light1.wav": {
+     "bytes": 8872,
+     "sha256": "f034fe2692c0fceb6de1c00e15facbcbd31ccd1fcf72510fd1e3cb6bdcc28795"
+    },
+    "sound/steps/light2.wav": {
+     "bytes": 6654,
+     "sha256": "998f665b4a7ccbc995096697606a91d208db024b0882df75ebaaac015f0d4ef6"
+    },
+    "sound/steps/light3.wav": {
+     "bytes": 6670,
+     "sha256": "b25e020a10ac6a7883fd584cff4895d6d785f8577daea15a30d2b745e146c1c6"
+    },
+    "sound/steps/light4.wav": {
+     "bytes": 4472,
+     "sha256": "a111052881024eef6e97393c1388e8ae538227b85c9b8cf0a73704abb2a504b1"
+    },
+    "sound/steps/light5.wav": {
+     "bytes": 3588,
+     "sha256": "55fb54e5ba2f8ec6249761ae6f07c12de6133457b51c584759e8841fb14cb46f"
+    },
+    "sound/steps/medium1.wav": {
+     "bytes": 8872,
+     "sha256": "38e731803a49be7d8018dd7b44060b578b5418f2f7aefb04d1c74c968ced187a"
+    },
+    "sound/steps/medium2.wav": {
+     "bytes": 8852,
+     "sha256": "e8701598e07f43a20aebebd1d1a5043213018199d50472dea37672e6dce4a2b3"
+    },
+    "sound/steps/medium3.wav": {
+     "bytes": 11068,
+     "sha256": "3ed07795c2363552554e6da1da5749be08e460fc6cd4c7266b9fa514732abb2f"
+    },
+    "sound/steps/medium4.wav": {
+     "bytes": 8872,
+     "sha256": "008992cd7972e7e1e6f0b785b40e398a8efe744a3f3f57e47370936796c3d6b5"
+    },
+    "sound/steps/medium5.wav": {
+     "bytes": 8864,
+     "sha256": "ccd26430fd354c0e87750e02d92c40071ef9dccadae5bdeebc7e0d2a2ec4eba7"
+    },
+    "sound/steps/slow1.wav": {
+     "bytes": 8878,
+     "sha256": "15614044d9d277fa3359edb07e7af74b9d7875150fddde5ab1fdceb0143337bb"
+    },
+    "sound/steps/slow2.wav": {
+     "bytes": 8856,
+     "sha256": "a8b16b688d12812a61127a885bf43c360adc2b84ae7806cc107b433c6f4635ee"
+    },
+    "sound/steps/slow3.wav": {
+     "bytes": 8852,
+     "sha256": "3a2a57e1a37d378c1ee73d5732840f6d20e588d794216c33896bf25879807600"
+    },
+    "sound/steps/slow4.wav": {
+     "bytes": 8868,
+     "sha256": "78bdea66991184043001262cc6ef5f1148cf0eb11b5f88fc51ff948311156e5f"
+    },
+    "sound/steps/slow5.wav": {
+     "bytes": 11076,
+     "sha256": "f63c868bd87926f017bec092749bd61c763b0b18635456ed56b660e53bf581af"
+    },
+    "sound/steps/water1.wav": {
+     "bytes": 63814,
+     "sha256": "01ed631b0d92dab11086b1106acc278ffd92522e2e46d21a0650fd29a79780f2"
+    },
+    "sound/steps/water2.wav": {
+     "bytes": 71994,
+     "sha256": "1b53561f02f60da1e1b6c8b72f722ba12e549c318725b974745b38666efa8e56"
+    },
+    "sound/steps/water3.wav": {
+     "bytes": 71802,
+     "sha256": "bbc0778017ccb579a9d531316b8af46585e91a100a251707ac34f4dbddf6922d"
+    },
+    "sound/steps/water4.wav": {
+     "bytes": 61448,
+     "sha256": "d3604afcb7751d987a78a0ee8ee4ca3593315cc6cf2f1909a9f7748535ccea50"
+    },
+    "sound/swampling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/swampling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/swampling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/swampling/idle1.wav": {
+     "bytes": 132044,
+     "sha256": "418eae21e001c1ae065df9357ebf2ad331f761062d75f345f12e99d9aec8cfb5"
+    },
+    "sound/swampling/idle2.wav": {
+     "bytes": 70444,
+     "sha256": "4026b4b56ffa9a207e1457e03ec94a8eb9042cfebf1c042fa291ba2bbbf1c4b5"
+    },
+    "sound/swampling/idle3.wav": {
+     "bytes": 171644,
+     "sha256": "fa54eaf040baf965f994b328bfb1a55cd90d1741d57ed580c1d44c51e9c125f8"
+    },
+    "sound/swampling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/swampling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/swampling/pain3.wav": {
+     "bytes": 67244,
+     "sha256": "4b186834bbec7d2ef9873f55d5df980da3b3fd2f19f76e54fd835d1aaf40fedd"
+    },
+    "sound/swampling/sight2.wav": {
+     "bytes": 88044,
+     "sha256": "6989ba3aca0c5f5e12d30d9958c6ab169f5c6c96f36f4843a9a19bab0e5d0c4c"
+    },
+    "sound/swampling/spit4.wav": {
+     "bytes": 76848,
+     "sha256": "6855555e2a188ed9ae0a1cd307c7715e54c6f3c10ac0fee9edbba2edf1a48d16"
+    },
+    "sound/traps/flame_loop.wav": {
+     "bytes": 28560,
+     "sha256": "661d8325af92fb37235952e2668578dbf57d844b7359627b4a2c25d15127bff7"
+    },
+    "sound/traps/flame_off.wav": {
+     "bytes": 28496,
+     "sha256": "ebc40d62265aad20813acd189511be0bac063ecc00d7ae712863de3dbdb84c94"
+    },
+    "sound/traps/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/traps/laser_hit.wav": {
+     "bytes": 4358,
+     "sha256": "0840d9fa27bfd2bcb86c2f0174810ae3eb9baa6a43867d27de1e074f7cd75e2c"
+    },
+    "sound/traps/pend_hit.wav": {
+     "bytes": 11908,
+     "sha256": "6fec8fd4edb67e8905d9ad0d7dce5ee5a9b4f43b724b75cb449e88b508384e11"
+    },
+    "sound/traps/pend_swing.wav": {
+     "bytes": 22142,
+     "sha256": "d20bbaf323c5aa0ee2aa21222f2a9f5fc956c0317e65c05e9d003bb08d80a9ae"
+    },
+    "sound/traps/saw_end2.wav": {
+     "bytes": 99808,
+     "sha256": "2a129f2d5fe3c9fd60873c336e2eed799b3d2ebc91bc8bf5a0860b45a6b83ceb"
+    },
+    "sound/traps/saw_loop2.wav": {
+     "bytes": 173082,
+     "sha256": "b4ca1bfeaab62c73bfc10f7daa2750738874d721af9e637479e8242f5220294c"
+    },
+    "sound/traps/saw_loop2f.wav": {
+     "bytes": 132748,
+     "sha256": "03a3e77feb8775a7b486363ed1d46d04fb9294f5507040e458ed8a05c37f0de8"
+    },
+    "sound/traps/saw_start2.wav": {
+     "bytes": 217184,
+     "sha256": "49f1dd84a7be0c4d0b1293aa587ab786d69f4cb463ce5a03f09da816eb22d384"
+    },
+    "sound/traps/sawblade_off.wav": {
+     "bytes": 15276,
+     "sha256": "44924313561cf32ea95c50ef80366ba79a2c86ff2f218fc89404c82617ce2c84"
+    },
+    "sound/traps/sawblade_on.wav": {
+     "bytes": 37582,
+     "sha256": "097635d29859ce28ea37da2d51ec346b8d5239435bb6be0bf5f094a555c110e8"
+    },
+    "sound/traps/sawstrike1.wav": {
+     "bytes": 30836,
+     "sha256": "489d8cdea78b2c333771b316741d7960d5c0da6845ea15b94991ece94837367a"
+    },
+    "sound/traps/steam_loop.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/traps/steam_off.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/voreling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/voreling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/voreling/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28354,
+     "sha256": "8c9ef55e309a43b1df1f08b66192b4ab262ba07e9315d3a70f4a9cf9dee9d51a"
+    },
+    "sound/voreling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/voreling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "5035bd555e9a6439c87e6b661a2da86633f7234503d52551e68f61e9504af86d"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 44162,
+     "sha256": "ccca790ed18e3705c083259f48db7d46d26310cf80c16cd2bad191d333fec5ba"
+    },
+    "sound/weapons/axe_ceramic.wav": {
+     "bytes": 24620,
+     "sha256": "53b6e873318f84424129f1486f0a715c9b1f46e9521c97858d3ddbd94ef4dc10"
+    },
+    "sound/weapons/axe_flesh.wav": {
+     "bytes": 7754,
+     "sha256": "8d0046355ea843f56d5260f581c89d2f885b553c97cfc7e01a93f6da487e03de"
+    },
+    "sound/weapons/axe_glass.wav": {
+     "bytes": 13306,
+     "sha256": "7fd4f7f02edf972c17cf64fea9ecfecca2e0a2d69da9828c1a1e2ce726dd9a79"
+    },
+    "sound/weapons/axe_metal.wav": {
+     "bytes": 28844,
+     "sha256": "d77bc0204c9f406f50ddf01241ff3a3cb34bd571f8a038a483fe49fba81fb160"
+    },
+    "sound/weapons/axe_swoosh1.wav": {
+     "bytes": 26524,
+     "sha256": "1ee4079e691b1e3e8eca8e6fe3098ee053f99b2a0028e725442771c84dc07e49"
+    },
+    "sound/weapons/axe_swoosh2.wav": {
+     "bytes": 13284,
+     "sha256": "a28435309759dd35576099d23a36dc378d9703db9f0778fba63efa3558cfc19d"
+    },
+    "sound/weapons/axe_wood.wav": {
+     "bytes": 7776,
+     "sha256": "ce5bd1465d66aa4aad5249c387f7f537b45b4f8a0e4bf76f37f8efc2a22bd9d9"
+    },
+    "sound/weapons/bolt_hit1.wav": {
+     "bytes": 12698,
+     "sha256": "07d2b6078f7936781a641f88e6ed02ab84f248da8f19e73713c1a71ac56cf42c"
+    },
+    "sound/weapons/bolt_hit2.wav": {
+     "bytes": 10658,
+     "sha256": "27ef878b7dfc0878140a19e3a0227ba389e5d0dc2b86df386852e2da2ebc5c93"
+    },
+    "sound/weapons/bolt_hit3.wav": {
+     "bytes": 11600,
+     "sha256": "06298d7bc8d7bce64f9473ae9530e0b42ea3de0ca5895f3476f9b00b5ed566f9"
+    },
+    "sound/weapons/bolt_hit4.wav": {
+     "bytes": 15460,
+     "sha256": "814b1a71efc9b58c90ad7f116c47e6f3dceeb8eae6d0ecbca5f1cd02dd247cb6"
+    },
+    "sound/weapons/crossbow_fire.wav": {
+     "bytes": 26536,
+     "sha256": "2a6ba54090412a53471c59b3edf6e8559d424dab25729e67a78f9ada5e13e8ac"
+    },
+    "sound/weapons/crossbow_hit1.wav": {
+     "bytes": 60782,
+     "sha256": "be1e78c92c13749e988d26912fba6c23f3700df0d7cc48d724f0da1f2608d006"
+    },
+    "sound/weapons/crossbow_hit2.wav": {
+     "bytes": 32472,
+     "sha256": "30a4ef9f23b2239371d32385e55487b279ca4f8f91366d4251cf4d9abdce200a"
+    },
+    "sound/weapons/crossbow_rdy.wav": {
+     "bytes": 37532,
+     "sha256": "321eac310a291cd9cdcbd2dcafb27687a12057e778e12704d8b4388d4eb6e4df"
+    },
+    "sound/weapons/crossbow_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/weapons/ghook_fire.wav": {
+     "bytes": 11526,
+     "sha256": "6e29f4524c0be70d8bf3b1201e737712b271c9bc963ad46c1815972b6addc22e"
+    },
+    "sound/weapons/gl_loadlong.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/weapons/gl_loadshort.wav": {
+     "bytes": 7758,
+     "sha256": "c97236bbfd211dfcad8130974413a8666cdbcf646d364abd8801b3d6ba5bf9c4"
+    },
+    "sound/weapons/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/weapons/laser_hit.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/weapons/laser_richotet.wav": {
+     "bytes": 12888,
+     "sha256": "bcc0498060e71b059d1d6ec45628048b0f29a7a0509b736a519196338b5df20d"
+    },
+    "sound/weapons/nofire.wav": {
+     "bytes": 1400,
+     "sha256": "217c42718548de32b5df972d117ffc1a0e1dde5f03a7a173bd91d0b4551248c9"
+    },
+    "sound/weapons/plasma_expl.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/plasma_fire.wav": {
+     "bytes": 88288,
+     "sha256": "6a0ad4930da39ff590c79f9d26b434bb1001536d33d880735df76e9354f90e94"
+    },
+    "sound/weapons/plasma_hit.wav": {
+     "bytes": 54406,
+     "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b"
+    },
+    "sound/weapons/plasma_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/weapons/r_exp3b.wav": {
+     "bytes": 34830,
+     "sha256": "a1abb7cedfa6576205f043c2e5f562606b039f65f6f996f5ffbb758d7855f2a2"
+    },
+    "sound/weapons/resist_rocket.wav": {
+     "bytes": 19938,
+     "sha256": "1e5170aaf1d6f144e7ea77c251d15ee85c9a70eb1f50b12e4ba5a93971ad1955"
+    },
+    "sound/weapons/ric1.wav": {
+     "bytes": 5650,
+     "sha256": "49223498fbf29b97f712537e6417917befc4e4f5c725bbf2e3d463580c15454d"
+    },
+    "sound/weapons/ric2.wav": {
+     "bytes": 11146,
+     "sha256": "5fa462f4ab3184cf70bf33f923a2b7e4392db517d34f8531a381864d78c352a6"
+    },
+    "sound/weapons/ric3.wav": {
+     "bytes": 11138,
+     "sha256": "1761926b96108fd0b0ee55270ee711fbd2f394f1b5e93da4af96e42c69fa3946"
+    },
+    "sound/weapons/riotgun.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "sound/weapons/sg1.wav": {
+     "bytes": 28718,
+     "sha256": "49074c95da2a619d82dee9d45e28dc910f9a8e16141270a76c81b396a41a6a3e"
+    },
+    "sound/weapons/sg2.wav": {
+     "bytes": 28718,
+     "sha256": "279b1bb969837073c46c176fe62782e60658a6614a8e094b9722cbabdca81fe6"
+    },
+    "sound/weapons/sgun1.wav": {
+     "bytes": 45840,
+     "sha256": "3ac6c4b3ded00fa48810f09afc95b4a8375dc3e8d52e04cd9cba18dfeee20087"
+    },
+    "sound/weapons/shellc.wav": {
+     "bytes": 21006,
+     "sha256": "45a2f8bd652307b9ebd37115c27166d03a4d7055f3054a215036fbc342e22f6d"
+    },
+    "sound/weapons/ssg1.wav": {
+     "bytes": 17244,
+     "sha256": "3e5b9cc1cd0cb86602391e4ddedbc98bb020e44b937eec4d3c5b053ff98c98f2"
+    },
+    "sound/weapons/ssg2.wav": {
+     "bytes": 75024,
+     "sha256": "248a021818f578ec3d96b9fe59d8f839242f4d5f8140a66a500b523b137d1977"
+    },
+    "sound/weapons/sword1a.wav": {
+     "bytes": 11184,
+     "sha256": "22bc8b25a67f1ab0752f9fbc68c2eb0958d2807c9e95bc8ee35d1d1bc9c6552d"
+    },
+    "sound/weapons/sword1b.wav": {
+     "bytes": 13272,
+     "sha256": "dca39f0c4776994c1bbe5255893d50dd86a634a370ea6046fd4e851117dec726"
+    },
+    "sound/weapons/sword2a.wav": {
+     "bytes": 11150,
+     "sha256": "aa381f8c68f5753cecbd889bc184a784c934c78c8fefe3b1ba4026a99112da51"
+    },
+    "sound/weapons/sword2b.wav": {
+     "bytes": 13232,
+     "sha256": "9460973ef948f8712be967d412774d32aeefb8e68b11959c28909eb16d9e8afc"
+    },
+    "sound/weapons/widow1a.wav": {
+     "bytes": 64644,
+     "sha256": "b4ccd6b235784f7ff53ccf0d726ecbbc789d2ddcca057b40df769b7925e3b32d"
+    },
+    "sound/weapons/widow1b.wav": {
+     "bytes": 66186,
+     "sha256": "0da0346e80cdcb405ffb8f9dbe048197cd9d303130f35b2546b4f7652bd06ca6"
+    },
+    "sound/weapons/widow1c.wav": {
+     "bytes": 66186,
+     "sha256": "eb054b4b1b2784bb098e24574ced6b8c2114e3344fc73e9beb23285adfa086a8"
+    },
+    "sound/wraith/attack1.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/wraith/attack1_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/wraith/attack2.wav": {
+     "bytes": 88200,
+     "sha256": "bdf849b4e138fa587df136a327c71ceed1176cbbb4ecb873434766d53da35a3b"
+    },
+    "sound/wraith/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/wraith/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/wraith/death1.wav": {
+     "bytes": 19960,
+     "sha256": "c0e5e05b46e4cf4afebfe5d0ef1801fc16fe8308a7f859ff347a77871b0a9339"
+    },
+    "sound/wraith/idle1.wav": {
+     "bytes": 51556,
+     "sha256": "e91f12463417df25badbbdfe817560362370d9e1e31712766bccb086e06d966f"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 82792,
+     "sha256": "b843d1124acc61be2aae27a7c8a9aca8f6bd471689703b41d59f1450e70e360c"
+    },
+    "sound/wraith/idle3.wav": {
+     "bytes": 55228,
+     "sha256": "3393943b38a0760c2b048c87c6b11ef743b0c968397ae7e434434b8b21fe12f9"
+    },
+    "sound/wraith/pain1.wav": {
+     "bytes": 18184,
+     "sha256": "a448cf5aed2909700e4da1f3ea3158b55e288198eee771eddacf211f4b274dbe"
+    },
+    "sound/wraith/sight1.wav": {
+     "bytes": 34390,
+     "sha256": "91494295e94c54c8da0307df8a51ea10d166fb18a78ede909a710f72ffe81c4f"
+    },
+    "sound/xmas/elf/attack1.wav": {
+     "bytes": 176492,
+     "sha256": "80e3faa699aec6d20015c1070087964de5ba39f83a978388b9fadc184f9fb6c2"
+    },
+    "sound/xmas/elf/attack2.wav": {
+     "bytes": 88292,
+     "sha256": "a364c82cb932bddb438c957e88a7ea67142777dfffd0f553d00e2b04b3af0f9f"
+    },
+    "sound/xmas/elf/cane_hit1.wav": {
+     "bytes": 4536,
+     "sha256": "2686bea9533633cb6c1a5e3e5bcf0016e3fe228cd278b7b1d11a02868cdd5095"
+    },
+    "sound/xmas/elf/cane_hit2.wav": {
+     "bytes": 5638,
+     "sha256": "6e470e241f37fb38ea55adf4bd0d6f1f5a2d5adfee5d5ddac8cb9adc824cb954"
+    },
+    "sound/xmas/elf/cane_swipe1.wav": {
+     "bytes": 1670,
+     "sha256": "2dbf81b3813376cb8bea2fa916dc0d03f1fbaaa499d4fcdf845de8929f82dc47"
+    },
+    "sound/xmas/elf/cane_swipe2.wav": {
+     "bytes": 1890,
+     "sha256": "404864c7d5008b79daed226566a2e4e78f2de92de06c64da67b8bf6224ae3e88"
+    },
+    "sound/xmas/elf/death1.wav": {
+     "bytes": 14284,
+     "sha256": "d1a7063d4ed39cdb59864a2a6fe6109f844caa9ada54ed4456de0bcd056f0034"
+    },
+    "sound/xmas/elf/death2.wav": {
+     "bytes": 10888,
+     "sha256": "4e0344a1bd3fa3d3c4d9e9647203cac0c449d5a5d8e7b1c8319f8402a4b7571c"
+    },
+    "sound/xmas/elf/idle.wav": {
+     "bytes": 57016,
+     "sha256": "a824467247797aa1ecc58f1716b18d390629804eebc413f01067646c64cde87e"
+    },
+    "sound/xmas/elf/jump1.wav": {
+     "bytes": 17766,
+     "sha256": "8023110b27a70758166f710e52188b8d03b8bfd81d9c985eb7f7d326acdb05a2"
+    },
+    "sound/xmas/elf/jump2.wav": {
+     "bytes": 8946,
+     "sha256": "a60763886b743d06ffd0c90e70de304ec8002a500947a684646c227d0bbb3c4d"
+    },
+    "sound/xmas/elf/magic.wav": {
+     "bytes": 15560,
+     "sha256": "6a270540819dddf140b0387d92c914b4f4b1c88c5f37a05c8fa0efd95901f2ab"
+    },
+    "sound/xmas/elf/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/xmas/elf/pain.wav": {
+     "bytes": 11126,
+     "sha256": "4e27a8f38e07e9b69db186d5c609740814ab86c5fda57058b1e05c56b85c6fd4"
+    },
+    "sound/xmas/elf/sight1.wav": {
+     "bytes": 21048,
+     "sha256": "c57eb4fec86922cb8a0499d7dae72eba66b067b89f14ff079ce0caf3dc23a23b"
+    },
+    "sound/xmas/elf/sight2.wav": {
+     "bytes": 30996,
+     "sha256": "8cd5eed3b8e098dfd70cbf90081b38e198bf64d8edf1b76bcc98c42e177635f8"
+    },
+    "sound/xmas/elf/sight3.wav": {
+     "bytes": 10050,
+     "sha256": "e88ae556a28352c319bf5500b29008384a5c53c47480defa81795d8891f14ff8"
+    },
+    "sound/xmas/elf/sight4.wav": {
+     "bytes": 6742,
+     "sha256": "7c6120d242cbbbfd2e0cc77b1428e206accd1ab8073885d52177b0fd4c75c7ed"
+    },
+    "sound/xmas/raindeer/attack1.wav": {
+     "bytes": 5582,
+     "sha256": "bcf78087eab53e8ed0bdde2f29088a89b321a79c3b104da380dd85bd5bdb6ec1"
+    },
+    "sound/xmas/raindeer/attack2.wav": {
+     "bytes": 6274,
+     "sha256": "2ba043cce4a2f22e7743812c0fa40e9f0888d5089362264c768352c347af5089"
+    },
+    "sound/xmas/raindeer/death.wav": {
+     "bytes": 9672,
+     "sha256": "68266e96ec1be80a55f48b76c2bedd6503273245153d96269947c7fc12ae96b3"
+    },
+    "sound/xmas/raindeer/hit.wav": {
+     "bytes": 5218,
+     "sha256": "72127151c2b05cc22a812fe9e38909c8bdcaae6a369e8756d2be67d392b91223"
+    },
+    "sound/xmas/raindeer/idle.wav": {
+     "bytes": 7890,
+     "sha256": "d3ef885d0b6163a3046dc9d514b07886c33809fbb6332e7db0514c648787a9bb"
+    },
+    "sound/xmas/raindeer/sight.wav": {
+     "bytes": 23796,
+     "sha256": "aafabb6fc46c1c72c34af1baea1c59a8ec04803c26faa4310072096481f31a4f"
+    },
+    "sound/xmas/santa/death.wav": {
+     "bytes": 99352,
+     "sha256": "b63273a2574f7def133aa438926a6def025aa64d8c3c636fc6a5594268e391d7"
+    },
+    "sound/xmas/santa/death2.wav": {
+     "bytes": 99352,
+     "sha256": "24fcf23117ec31347f640aa27e6feb4a46a634aa5e1eb48344b1feb7c377f6f1"
+    },
+    "sound/xmas/santa/fire.wav": {
+     "bytes": 22176,
+     "sha256": "3a9bb42661b75287a698b6e16033158f20c59c481d37c0f176dc213205d22dcd"
+    },
+    "sound/xmas/santa/good_hohoho.wav": {
+     "bytes": 55250,
+     "sha256": "51f4d5d656032de08b95689fa55a2e7aa26ec99cf4312b0f6153d0fd57fc1fa3"
+    },
+    "sound/xmas/santa/good_saved.wav": {
+     "bytes": 77302,
+     "sha256": "51e62df5942e2a72fd48311c61ee73b6f51dc4aa3c0cc85af000cdc8d7627d21"
+    },
+    "sound/xmas/santa/hohoho.wav": {
+     "bytes": 50840,
+     "sha256": "091a28236362cab1ce3b7bd55de25010d105db3bf644825c47b91725d8a613a0"
+    },
+    "sound/xmas/santa/laugh1.wav": {
+     "bytes": 57374,
+     "sha256": "ac069694d6c41e5e0afab50d9928b8768a19fb647bb249201648874d4150c976"
+    },
+    "sound/xmas/santa/laugh2.wav": {
+     "bytes": 117440,
+     "sha256": "c726d7d86d2d7cad0a75a2d0b387f4f96218ef232b6c78437e1c83bb96286441"
+    },
+    "sound/xmas/santa/laugh3.wav": {
+     "bytes": 40256,
+     "sha256": "4dd710eee601ab81c4beb5413d95244dee58b886b8265ab9cec35df06b560591"
+    },
+    "sound/xmas/santa/laugh3_com.wav": {
+     "bytes": 44226,
+     "sha256": "4099895e037cfecb4dc3595b3b18db62ed2f3cf096384f3aa1fe1d96a7b43da2"
+    },
+    "sound/xmas/santa/pain1.wav": {
+     "bytes": 6825,
+     "sha256": "79eed9346e0954fd53a6fdb9aa9708b8c29e8c5c256e9fd7c06f449e9cb6c00d"
+    },
+    "sound/xmas/santa/pain2.wav": {
+     "bytes": 9259,
+     "sha256": "f750328d74f545a658b0b190399595687c3d9b8766b2652ad6c2a34add3cc420"
+    },
+    "sound/xmas/santa/sack_hit.wav": {
+     "bytes": 13356,
+     "sha256": "c23a04ed5134f76d1f44d2e61eeb446a569c2bcbccf79f16f472807aae3df53a"
+    },
+    "sound/xmas/santa/sack_swing.wav": {
+     "bytes": 8940,
+     "sha256": "96972ba473b6a7d28645cdc621eb3011729a53eb4acb40d1f097768291a70850"
+    },
+    "sound/xmas/santa/sight.wav": {
+     "bytes": 100144,
+     "sha256": "e29696370a0d40546a49ef0f39b1e0038d8e067ef2da1dcc5084d7683a25d5d7"
+    },
+    "sound/xmas/santa/smack.wav": {
+     "bytes": 22176,
+     "sha256": "606c0a4b634d82a1d9846f654db8a52e7f2438ba28a235f782a23ff2720c767c"
+    },
+    "sound/xmas/snowman/claw.wav": {
+     "bytes": 8292,
+     "sha256": "7857f3526fb39e722a09ebe569f2b76facab765d82f97c0caa7da2ff9b750e9e"
+    },
+    "sound/xmas/snowman/death1.wav": {
+     "bytes": 11267,
+     "sha256": "0a09776ed8e45bbfe403f1cdb50302361f5596d9027c476409d6acf5402e763e"
+    },
+    "sound/xmas/snowman/death2.wav": {
+     "bytes": 13613,
+     "sha256": "e5e3a9619a153f0c6259abdb0d45f4eb4a547f736e37951556d29c6b715ec8f6"
+    },
+    "sound/xmas/snowman/icehit.wav": {
+     "bytes": 3090,
+     "sha256": "e03f61550bafc53ab47acdc23bcd481c35e75e6eccdad5e61e6dd7b372ba07c0"
+    },
+    "sound/xmas/snowman/icemiss.wav": {
+     "bytes": 3074,
+     "sha256": "f8b86f83d9adaaee1c84e1ac2acbcf652204842f2bf6f351ec1443a998574058"
+    },
+    "sound/xmas/snowman/idle.wav": {
+     "bytes": 58582,
+     "sha256": "a0d7af1cd6246f08176f24c5591cfb6ec89cff55dc5c18766ef1b16c64429541"
+    },
+    "sound/xmas/snowman/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/xmas/snowman/pain1.wav": {
+     "bytes": 7685,
+     "sha256": "7f829300a30cb6cb4d17f8c8327bd62ae5b5dacc892d28a956d6ecd2acf5f1c2"
+    },
+    "sound/xmas/snowman/pain2.wav": {
+     "bytes": 7661,
+     "sha256": "3747d77583aa4edb3509e89ea651ea41a8e8a92cd96c34d4e00257e7371fb0e6"
+    },
+    "sound/xmas/snowman/shotg_fire.wav": {
+     "bytes": 6572,
+     "sha256": "3d54870c0f643b1e7ee5307641bb3fc4a94efdaffc2e4ecd196556b930167ef2"
+    },
+    "sound/xmas/snowman/sight1.wav": {
+     "bytes": 10042,
+     "sha256": "ce1cddbb6e85fad23231ac1fc4c04c19ec7276acb2aa86e023c117db4b8edd68"
+    },
+    "sound/xmas/snowman/sight2.wav": {
+     "bytes": 15418,
+     "sha256": "5d4e994c30a7c3f2e1f1a5cde9a56115bcb32c350e4a0ad8e339a1a46ed19707"
+    },
+    "sound/zombie/boil_explode.wav": {
+     "bytes": 38012,
+     "sha256": "210dac94ab0e4efb5eb3bdbfa5d7100094b1bfef917a8d5abb2ae186252c0a27"
+    },
+    "sound/zombie/boil_idle1.wav": {
+     "bytes": 33204,
+     "sha256": "e2b717040d436ba2a659ceb1e5b74dfeaad57577297a9827957733e00ce7cb34"
+    },
+    "sound/zombie/boil_idle2.wav": {
+     "bytes": 33206,
+     "sha256": "8bd584597f2c54e6f8ecca5c0a83e44b0b5a09a745026e41cc2cad8ded6f729a"
+    },
+    "sound/zombie/boil_sight.wav": {
+     "bytes": 33192,
+     "sha256": "0e285e98dc66cd49af507dae9ab5281aaec55eaf9d401810a8d230d93539123a"
+    },
+    "sound/zombie/boil_squirt.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/zombie/boil_windup.wav": {
+     "bytes": 22094,
+     "sha256": "3790791943ea03add95bc303df34470c534f9c2c76e4343831609eaee761633d"
+    },
+    "sound/zombie/zk_sight.wav": {
+     "bytes": 26916,
+     "sha256": "8fe4d5fea16bd7c3661a968d26782ea8c4741157e16e22f33317619229b10637"
+    },
+    "textures/#bmk_water01a.tga": {
+     "bytes": 12332,
+     "sha256": "904f50c3a1de65dd5045f128d03ed8cdc86fcbc15cce295d94304b389ca5ed7c"
+    },
+    "textures/#bmk_water01b.tga": {
+     "bytes": 12332,
+     "sha256": "904f50c3a1de65dd5045f128d03ed8cdc86fcbc15cce295d94304b389ca5ed7c"
+    },
+    "textures/#bmk_water02a.tga": {
+     "bytes": 12332,
+     "sha256": "1123b4f4df8d75a1d8fc2a00d4d19fb279035771f7440b1506d0a95648123766"
+    },
+    "textures/+0bmk_fgopen02.tga": {
+     "bytes": 3145772,
+     "sha256": "1c7e70671a9a98473b3fb3926e1672d5a1712a011caba937097d5bc8c96099de"
+    },
+    "textures/+0bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "f2f139ae3d91bf3aa7c89181b87c1c645acb7be673eca5d56d804889e24f1e50"
+    },
+    "textures/+0bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "f2f139ae3d91bf3aa7c89181b87c1c645acb7be673eca5d56d804889e24f1e50"
+    },
+    "textures/+1bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "6941909c4574fb66f59f7a797f3dd0c696651e117c583f102d255e6bef4fe0ef"
+    },
+    "textures/+1bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "6941909c4574fb66f59f7a797f3dd0c696651e117c583f102d255e6bef4fe0ef"
+    },
+    "textures/+2bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "b78fb050de863bd84616c224de600521738a84ce172346bb783ba3a8708449da"
+    },
+    "textures/+2bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "b78fb050de863bd84616c224de600521738a84ce172346bb783ba3a8708449da"
+    },
+    "textures/+3bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "bf6815a6df5fe67c40ec3e46362a04c5ba15dc8a76de975a3d90a0caeec5e88c"
+    },
+    "textures/+3bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "bf6815a6df5fe67c40ec3e46362a04c5ba15dc8a76de975a3d90a0caeec5e88c"
+    },
+    "textures/+4bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "031bd453f18757388aa700fbae39e6c446959b8e38bee9fbbb53d8639f29deea"
+    },
+    "textures/+4bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "031bd453f18757388aa700fbae39e6c446959b8e38bee9fbbb53d8639f29deea"
+    },
+    "textures/+5bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "873c6b31fcaab54e309e663d23748cc5595b80e1432559761fd92a03f0d41d32"
+    },
+    "textures/+5bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "873c6b31fcaab54e309e663d23748cc5595b80e1432559761fd92a03f0d41d32"
+    },
+    "textures/+6bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "33492aebd47cc69737a2cd8460423103a76ff59b1d6bd39b750f19d6c72efc6d"
+    },
+    "textures/+6bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "33492aebd47cc69737a2cd8460423103a76ff59b1d6bd39b750f19d6c72efc6d"
+    },
+    "textures/+7bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "60741f2766db4f0eb6d622b132d2fc60d9e453d9f847661d3eca641fbf2b64f1"
+    },
+    "textures/+7bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "60741f2766db4f0eb6d622b132d2fc60d9e453d9f847661d3eca641fbf2b64f1"
+    },
+    "textures/window_blue1_2.tga": {
+     "bytes": 786476,
+     "sha256": "583f28b004c5de047037798524681ed2e7914bf1f54ac3d774c8da2880c80282"
+    },
+    "textures/{cop1_7.tga": {
+     "bytes": 16402,
+     "sha256": "464c149a2b2c9f624e7b1f8c2388117022425f058a946f0232c51def845b8bb5"
+    },
+    "textures/{cweb1.tga": {
+     "bytes": 262162,
+     "sha256": "bb0aa80709a1705199ed83bd0cad683a928cb29064eb32263fcb8bdb3999c2f5"
+    },
+    "textures/{cweb2.tga": {
+     "bytes": 262162,
+     "sha256": "64be3598db71729d4a4376c5f4e02bf0e586fc5ceca09196d71befde3265424e"
+    },
+    "textures/{cweb3.tga": {
+     "bytes": 131090,
+     "sha256": "d7b67dfdb1c80946f0de21128ddc3cda61906619ab8ed185611ef2a2a8f936b5"
+    },
+    "textures/{cweb5.tga": {
+     "bytes": 131090,
+     "sha256": "9cf5dd24994b1dc2f8f07ac5f76410fea9bdb7cb925962e1977e6aeb6ce23b02"
+    },
+    "textures/{dutcweb1.tga": {
+     "bytes": 131090,
+     "sha256": "8922bb11d99fc05d2ffeab2c2d99b04dba9d0fc5165fdd9a0ccd921f066f668c"
+    },
+    "textures/{dutcweb2.tga": {
+     "bytes": 131090,
+     "sha256": "a0377ffeac458bf27bbd86d2bc22ff17d973bd0328a4d048fb3136573c12723d"
+    },
+    "textures/{dutcweb3.tga": {
+     "bytes": 131090,
+     "sha256": "61710c94a64a506b75f36578904dbece6f666bc25ad2665333fe00b1c4b04f70"
+    },
+    "textures/{dutcweb5.tga": {
+     "bytes": 131090,
+     "sha256": "a0959d05f9bd1f4aa632b1642885261a2cbbef7d6d6d7ab677bb803ac1a00ef8"
+    },
+    "textures/{dweb1b.tga": {
+     "bytes": 65554,
+     "sha256": "7f2f310b5393519fbfdf70e07cab318504ad88c67dcce1e9988e376d5fc9c94a"
+    },
+    "textures/{dweb2b.tga": {
+     "bytes": 65554,
+     "sha256": "d95f6ebbcc21b2cb7164743b517aa69287101aa2640d5a8b249c409dcdc20333"
+    },
+    "textures/{dweb3b.tga": {
+     "bytes": 65554,
+     "sha256": "24cde40cf3791f0e054ccd2ad81353ec711bd95a7de1af58a1ad561d9d104ef1"
+    },
+    "textures/{dweb5b.tga": {
+     "bytes": 65554,
+     "sha256": "5b1fc4683289a850f5c16afa56660b710212bf18d4c047bf134529dac784d2c9"
+    },
+    "textures/{gen_gr8.tga": {
+     "bytes": 65554,
+     "sha256": "8dacb17cbbb6bb2f4dd95856dd46905a9c335f0a98dc3e8e700fac0a9c529163"
+    },
+    "textures/{kjwintex_ad.tga": {
+     "bytes": 262162,
+     "sha256": "3a2583e19c17e05877e489972b85593d9fca1e57ffd4fa02f1475e6fb3d59c34"
+    },
+    "textures/{ladder5th.tga": {
+     "bytes": 49170,
+     "sha256": "ed742e4b7072c1b11b1b801393bbfc641f96920ecabc5600c213b354313f89f0"
+    },
+    "textures/{lweb1.tga": {
+     "bytes": 262162,
+     "sha256": "e4edd91fdd0031064bd6157574ae5f81b44611424f7357daf8fd4e426c960399"
+    },
+    "textures/{lweb2.tga": {
+     "bytes": 262162,
+     "sha256": "4d2f26192388bf65091b0d5afb934bede4f07e89d002bbdbaeeba29d459fd5d7"
+    },
+    "textures/{rtex158_.tga": {
+     "bytes": 21522,
+     "sha256": "cd10217f3e5cd47b32bde516d4b36cf7995913e306f7415d25dcd7da6ccb4673"
+    },
+    "textures/{speedbz_grid1.tga": {
+     "bytes": 16402,
+     "sha256": "109e52491dda6d4968c99004296ccd503db6d6af9aad9aa6f21cca02fd2b299f"
+    },
+    "textures/{swvine.tga": {
+     "bytes": 65554,
+     "sha256": "c23639e3bd8aacd226695c913384e9c67d509b28fb9597d56f120cfea56a4006"
+    },
+    "textures/{utcweb1.tga": {
+     "bytes": 131090,
+     "sha256": "edae90ba1151fb6adc65def85d4dd7be01c3d2a18bd93ef0f26ff44d07f6c4b0"
+    },
+    "textures/{utcweb2.tga": {
+     "bytes": 131090,
+     "sha256": "829cfe898d9aa4c3ddd12a51f9ccc16a66b2ca5671d9bfd2339f402d49db3267"
+    },
+    "textures/{utcweb3.tga": {
+     "bytes": 262162,
+     "sha256": "026680576034c959e840aa4b39917497c38df12c1331a0c7a1486912e26a91f7"
+    },
+    "textures/{vinehang1.tga": {
+     "bytes": 65554,
+     "sha256": "c23639e3bd8aacd226695c913384e9c67d509b28fb9597d56f120cfea56a4006"
+    },
+    "textures/{vinehang2b.tga": {
+     "bytes": 262162,
+     "sha256": "4268dc2a183582d00c363a9fcd1965c026632150383d40b520fbd54f8751eaa7"
+    },
+    "textures/{vines3.tga": {
+     "bytes": 25618,
+     "sha256": "550b6ca0c768db472fbc970836516506034b30f0a5ca4b4b11df34d7dce8dc82"
+    },
+    "textures/{vinogrande2.tga": {
+     "bytes": 262162,
+     "sha256": "7c2d4aad4d34457ab1674bc1eaaa4ea38e4c4af384877af631cde258167fbb72"
+    },
+    "textures/{web1b.tga": {
+     "bytes": 65554,
+     "sha256": "41bb1244128013ff09f1965339ef505a7b0757bea91fcc0f77ed97cd38c8a145"
+    },
+    "textures/{web2b.tga": {
+     "bytes": 65554,
+     "sha256": "e2fbcb154962a9189614aecc7f6833e60d24709583a970d6cca0adf948df2331"
+    },
+    "textures/{web3b.tga": {
+     "bytes": 65554,
+     "sha256": "e4cfcd4c4e94ed647ef9af822d0df5ee573bd20d9f3bcf45ef8701a3102ae3ef"
+    },
+    "textures/{web5b.tga": {
+     "bytes": 65554,
+     "sha256": "dfdad98b5b62765b24abccd2ff77e85ec1c002060d6634d2593ac0fe10a4c718"
+    },
+    "textures/{win01_1brk1.tga": {
+     "bytes": 49170,
+     "sha256": "dae89ad198e0f4b1a63e37d9145084e947f7e88cb1c2e5d9ef32f25f3e0fb484"
+    },
+    "textures/{win01_1brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "88d9f8700eb9d14f9cfa6ac2e3df1bb25eae9a46553b6e46da7b225316862cb9"
+    },
+    "textures/{win01_1brk2.tga": {
+     "bytes": 49170,
+     "sha256": "2416e34e1ebdefa0cd01ea595b68ae86d2a35a4329b8853a489b1058dea44a90"
+    },
+    "textures/{win01_1brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "921ecb3434e9bd56d97ad57d10c67ace5a0f4bce79bf1b4c8c68aad4cf6ed10f"
+    },
+    "textures/{win01_1brk3.tga": {
+     "bytes": 49170,
+     "sha256": "59a6b2dc874758693574f15affea0be9c2e92e32328f81db78e5d72f488be7cb"
+    },
+    "textures/{win01_1brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "a3dcd6d471d8c65781a69c73a9fa449da02bc01a58a0a97c7313d30587611516"
+    },
+    "textures/{win01_2brk1.tga": {
+     "bytes": 49170,
+     "sha256": "589cf84c790b3165fa60e4441223da48c3df4275099fcc27bc5a8b9502579c15"
+    },
+    "textures/{win01_2brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "a0a80d249ff32c2e0a480801b721657244380732db3bdd9645dbece347d3190c"
+    },
+    "textures/{win01_2brk2.tga": {
+     "bytes": 49170,
+     "sha256": "0dc35f6a8b8b83596d127791f32f59b4a7445cb2529777555a93b9f329b7b537"
+    },
+    "textures/{win01_2brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "b313a11eb9017f0be604b673c0df88e94f94d552a7a132241f80883e68f4905f"
+    },
+    "textures/{win01_2brk3.tga": {
+     "bytes": 49170,
+     "sha256": "0fd4d13eb067aa17be299b48d500c245554fc3a6c1f5f11e10cbec1195a35273"
+    },
+    "textures/{win01_2brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "7ad6db65f6c0190a9ec569cce3b4780d21a90baf9baa728128f278807f1ba780"
+    },
+    "textures/{win01_3brk1.tga": {
+     "bytes": 49170,
+     "sha256": "ee6084ebe49ce367fd68039d548b1c960e55b136412bb00b8094dc1c545307bf"
+    },
+    "textures/{win01_3brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "afa5f0475b733a0ee1829b76598acd37cb1f28ed7f2faaf128593a13e702f5fa"
+    },
+    "textures/{win01_3brk2.tga": {
+     "bytes": 49170,
+     "sha256": "54c3abca2e42bbc4626823d4ad8081797e295bbdd07942484142d8a1c5395474"
+    },
+    "textures/{win01_3brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "0e0fc8daffc3ec8e07028904e3e55946270b8346f32efa341d64d6d1c0bcfcb5"
+    },
+    "textures/{win01_3brk3.tga": {
+     "bytes": 49170,
+     "sha256": "c1c7752039d97f7b92ec36408ffe456ff96c2a27c725c432e677a4f22e893d46"
+    },
+    "textures/{win01_3brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "0b627faae78e0d01eee393b58f978bf1a46b653001e1d1c56589d822245f86df"
+    },
+    "textures/{win01_4brk1.tga": {
+     "bytes": 49170,
+     "sha256": "af0f20f39e53d82cda8fca18e2918c1a2df2e6cf94e4d636e50c01686b3291b8"
+    },
+    "textures/{win01_4brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "4522e8d89c78119e9ff517ad64571c17c3ca750ac820142a700809620e894942"
+    },
+    "textures/{win01_4brk2.tga": {
+     "bytes": 49170,
+     "sha256": "4696f9c8ca59937230f40a3135b6c02e54b9b912eb62ba1401cbd5cccd1a9ae4"
+    },
+    "textures/{win01_4brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "a7a978f76a01a53dca360914519a8b1a93272aaad8a57c54e32ec74d4d9f1b96"
+    },
+    "textures/{win01_4brk3.tga": {
+     "bytes": 49170,
+     "sha256": "66dfc1bbe57f20c766653ab71cb339b6bff4e10b33cf66f5ed070bc0be75156f"
+    },
+    "textures/{win01_4brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "fb047a212d30b7fd140331df80d03dc718ba4237df73bf3cd74c918cc91daddf"
+    },
+    "textures/{win02_1brk1.tga": {
+     "bytes": 49170,
+     "sha256": "cb2711c7dc2ee9b77aded814296c1b1bb124ff5d2db2e248af7d7d0d882f422d"
+    },
+    "textures/{win02_1brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "9391e42b0fe2e55689e7104984fc1b5fd199cd8821e562fc4538fe2eb73825e9"
+    },
+    "textures/{win02_1brk2.tga": {
+     "bytes": 49170,
+     "sha256": "4fb71ced0a5388e41896b3b71b9c48d157eb72d229db04bbdcca45ce58658adc"
+    },
+    "textures/{win02_1brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "ed18da9a408653915554b0918a0f720cb76257231fc8ff9d465003e98fb371ab"
+    },
+    "textures/{win02_1brk3.tga": {
+     "bytes": 49170,
+     "sha256": "3b1f9bdbd53db1fa6d6920045cf4da45064dac48f7f66870e003860514804e99"
+    },
+    "textures/{win02_1brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "f1e10e37f7f2e71ddd6165607e59d39f95ec59c904017a8fa6b7b33a3adf40c1"
+    }
+   },
    "sha256": "facc0b4bd5c0f9b030c1949239001b573a77ce7daad9d63c4a92c2a6e73af98b",
    "timestamp": "2020-12-18T14:33:02.000Z"
   },
   "pak1.pak": {
    "bytes": 5468494,
+   "files": {
+    "maps/ad_brk/all_brick.map": {
+     "bytes": 22738,
+     "sha256": "e0859c71d8a3d5d4b140757e4fcd2ab4e92674bbb71979d6b9d6d2deb5d2390a"
+    },
+    "maps/ad_brk/all_glassa.map": {
+     "bytes": 8834,
+     "sha256": "f4e1c7c1444b3b2d8a3463e8950c0a6a3aed8d39144a6b1fc2a69bdbf376f444"
+    },
+    "maps/ad_brk/all_metal.map": {
+     "bytes": 12297,
+     "sha256": "447c74022bea3ae89d3a4412afcf4bcd384ea725b344b987fb2e7bb37adfabe1"
+    },
+    "maps/ad_brk/all_rocka.map": {
+     "bytes": 10235,
+     "sha256": "52edb0d5b9f79e8b89a58353098316e81be31c3e289d6f96e450ea01c4bbeb62"
+    },
+    "maps/ad_brk/all_wood.map": {
+     "bytes": 8397,
+     "sha256": "93697129156d662c18391564e26c5d5ceec8bac244209496290b8e9a516a5bfb"
+    },
+    "maps/ad_brk/brick01.bsp": {
+     "bytes": 7912,
+     "sha256": "c11880924b195ed38908cbf50f9cd16f071918df0a94a19c7254b93dddb1e62d"
+    },
+    "maps/ad_brk/brick01.map": {
+     "bytes": 717,
+     "sha256": "3f87d06eb46f67efa678ddd5ddf274e9c595c4a5236d8f111d8a0ea999972e09"
+    },
+    "maps/ad_brk/brick02.bsp": {
+     "bytes": 8072,
+     "sha256": "9ec52c7441f570d2a793035ebc2128d7f7f91f71b44b4418fd01e6b3e6d503e2"
+    },
+    "maps/ad_brk/brick02.map": {
+     "bytes": 861,
+     "sha256": "616d1c5b6f3e476453e8b9b57dd59deb285c6c0482680ca5d6da358ee808c619"
+    },
+    "maps/ad_brk/brick03.bsp": {
+     "bytes": 8280,
+     "sha256": "aa55feca84b80282851ca55c71deb3d54f02a6668af820f5ac4f9c1a0514e5e1"
+    },
+    "maps/ad_brk/brick03.map": {
+     "bytes": 935,
+     "sha256": "4359e78daaac0b8d4ff58dc68301bba4cd423e81284bcd360ce1480862c19d91"
+    },
+    "maps/ad_brk/brick04.bsp": {
+     "bytes": 8052,
+     "sha256": "b1fa14c188a8ad31cf58c7ebd495fbe8ed153819015d4e97c82e01ee052081e3"
+    },
+    "maps/ad_brk/brick04.map": {
+     "bytes": 815,
+     "sha256": "2bda60cc50886dc430a053f509f2376dcd9bd4d09666cf7960a96484fa369903"
+    },
+    "maps/ad_brk/brick05.bsp": {
+     "bytes": 7952,
+     "sha256": "e137a3ea0f33a83b8717dcb9d6e2ab79876112121dc21fe2e625d24d5d251384"
+    },
+    "maps/ad_brk/brick05.map": {
+     "bytes": 770,
+     "sha256": "8ebf395096050f65a3a370971d65deb0926af70f6cbd75c6579a53b68f676793"
+    },
+    "maps/ad_brk/brick06.bsp": {
+     "bytes": 9184,
+     "sha256": "32cee0a2c668160e07568ae08b4de5beae87d74e94a347cd431c90005bf49e24"
+    },
+    "maps/ad_brk/brick06.map": {
+     "bytes": 1709,
+     "sha256": "289f58cad70a88e8a8d986644faf539dd38cf52a884aa7f85513db5df0cc438c"
+    },
+    "maps/ad_brk/brick07.bsp": {
+     "bytes": 10377,
+     "sha256": "df07446f9f6a118f11451de5d7817f582c11dcc81ca3f83c8fa72c9d95e8df9c"
+    },
+    "maps/ad_brk/brick07.map": {
+     "bytes": 1942,
+     "sha256": "fe440636e5354fb553708f3b6859023d0a520f315050dc11a564e31a7b72d5e4"
+    },
+    "maps/ad_brk/brick08.bsp": {
+     "bytes": 13964,
+     "sha256": "2abbbc958d752e742df9d1f7152c4cc8c0de6373f20e628a762e2a22f5d6b3f7"
+    },
+    "maps/ad_brk/brick08.map": {
+     "bytes": 3286,
+     "sha256": "72174f573416102bb4e087e2025b3dbdfc669ab7cafc8b354f7b1a4485af1f5b"
+    },
+    "maps/ad_brk/brick09.bsp": {
+     "bytes": 7952,
+     "sha256": "28d7162b4af3f4ce184a31a14e3a9777383f29b63920d9d62ff136ae96e3a2fd"
+    },
+    "maps/ad_brk/brick09.map": {
+     "bytes": 770,
+     "sha256": "62f11ef3e3033dea82eb6062e5b5301474dd014f889a980383891e689be2a352"
+    },
+    "maps/ad_brk/brick10.bsp": {
+     "bytes": 9184,
+     "sha256": "7d6f8e3fd1b65880bb767ab5d488ef11bbb01ec4ce14c7b747ee75b8a8238c4e"
+    },
+    "maps/ad_brk/brick10.map": {
+     "bytes": 1709,
+     "sha256": "276f975d99dfe982bf71104889f65a248d719778db89591e7193ecc46b13d645"
+    },
+    "maps/ad_brk/brick11.bsp": {
+     "bytes": 10377,
+     "sha256": "f65cbdb642220611e89725187f47427031c4b18c21cc04ae3f6cfb4dffd149a2"
+    },
+    "maps/ad_brk/brick11.map": {
+     "bytes": 1942,
+     "sha256": "3b9d73d400e29fba3c82d8b2ccdad26e03b128c7771427497d4740c2d34cd63d"
+    },
+    "maps/ad_brk/brick12.bsp": {
+     "bytes": 13918,
+     "sha256": "1e1e8191c5ebdd1f0fed27edaa04a82a6aabd5c41723cf590781ff00f7300a02"
+    },
+    "maps/ad_brk/brick12.map": {
+     "bytes": 3286,
+     "sha256": "d2b89c83f1ff95d6fe577cf4a166e7bec6e02ab85f48c51316908d7d80068156"
+    },
+    "maps/ad_brk/brick13.bsp": {
+     "bytes": 7912,
+     "sha256": "4b5ac4eb6ea5a9ec049c27082d800cb981902965a4b652f86e1753bfa1eb7c94"
+    },
+    "maps/ad_brk/brick13.map": {
+     "bytes": 690,
+     "sha256": "253425ec201a354cd1b4c93c78d740e2a17c7d946d911efffa63d522e95f9f0b"
+    },
+    "maps/ad_brk/brick14.bsp": {
+     "bytes": 8072,
+     "sha256": "afe8797d2172a5b4b06be3e2a69038346d62938f3d9da6ea224074cee5bb1669"
+    },
+    "maps/ad_brk/brick14.map": {
+     "bytes": 828,
+     "sha256": "a500705a328cafa28159ee107cbe80003848ee241c3544a73dea1432f67b4042"
+    },
+    "maps/ad_brk/brick15.bsp": {
+     "bytes": 8280,
+     "sha256": "58ddb31ce4108a70872444022369154529c532983dbc58698cd88f217f8947a0"
+    },
+    "maps/ad_brk/brick15.map": {
+     "bytes": 899,
+     "sha256": "589f256e02b66051ede4f2fe136e69313a7e01402f1caa43bada4d605a046b8e"
+    },
+    "maps/ad_brk/brick16.bsp": {
+     "bytes": 8052,
+     "sha256": "d5c15593d0d776d5f76919100602d893973cd59b7ca88af55e1ae3cc2fb56967"
+    },
+    "maps/ad_brk/brick16.map": {
+     "bytes": 785,
+     "sha256": "a15682c168f0a7128c83bf7bd38688ae1d2507873687e815c690b08d44f14a37"
+    },
+    "maps/ad_brk/brick17.bsp": {
+     "bytes": 7952,
+     "sha256": "738d902046d73e14b8a552529dd8306864661fd0469efb52b3c81329135e8372"
+    },
+    "maps/ad_brk/brick17.map": {
+     "bytes": 770,
+     "sha256": "699fa7055fa88f309fe4a4a2af24b5d61af91365d81074e44cbdf399d36939c9"
+    },
+    "maps/ad_brk/brick18.bsp": {
+     "bytes": 9184,
+     "sha256": "67ad693c292448f73ea0b3ab6ee22883709c7deb006cecd19c0dda5c9d4fa131"
+    },
+    "maps/ad_brk/brick18.map": {
+     "bytes": 1709,
+     "sha256": "849749000a41ecfc60aa4607c890e140bcd78ef26858512f56494efdc5873bcd"
+    },
+    "maps/ad_brk/brick19.bsp": {
+     "bytes": 10321,
+     "sha256": "721c3237db8c026a03e01e387bb95fe5ed8fbc49b3c527220f164d77a2f3a4f2"
+    },
+    "maps/ad_brk/brick19.map": {
+     "bytes": 1942,
+     "sha256": "1760c2c74d0b894814c89152062f2f55a8635a17559828c27532a7e913949af6"
+    },
+    "maps/ad_brk/brick20.bsp": {
+     "bytes": 13306,
+     "sha256": "bbecee9c1ac726743e6cc49d18246c650f762f577dc108ffed2a6807ff665052"
+    },
+    "maps/ad_brk/brick20.map": {
+     "bytes": 3286,
+     "sha256": "121d4fe62c07953f11a04a41577769a38cae8852af78bbd40fc44f598eee91d7"
+    },
+    "maps/ad_brk/brick21.bsp": {
+     "bytes": 7972,
+     "sha256": "e65c1df9d5f02efc9475a53d1127d7899f69d23d8a0ea20deab384fcd3351d29"
+    },
+    "maps/ad_brk/brick21.map": {
+     "bytes": 789,
+     "sha256": "8c12d093245c3937afcf62916fce9e6b2d181d72d433b879112b27e0f168ccc7"
+    },
+    "maps/ad_brk/brick22.bsp": {
+     "bytes": 9204,
+     "sha256": "b8efe5f130accf1e8704202dbaa44215259e1209b9b81bf79461ff5e5f725596"
+    },
+    "maps/ad_brk/brick22.map": {
+     "bytes": 1728,
+     "sha256": "403525bf264890c5d9adef370847749cbeec481337f284618810057e697cddde"
+    },
+    "maps/ad_brk/brick23.bsp": {
+     "bytes": 10340,
+     "sha256": "79bac69a44c7e83343bd69c2360176046e048257ecfb7ac27f3c989b42af92e9"
+    },
+    "maps/ad_brk/brick23.map": {
+     "bytes": 1961,
+     "sha256": "f25e7a514eb15637b7dedc41ec5c34e2d8b9e4dd3b584a41a1b1d7c166b362ef"
+    },
+    "maps/ad_brk/brick24.bsp": {
+     "bytes": 13312,
+     "sha256": "2e0728a16ebe0fa868d8bd0ffe0f54e013afac41c77ee7516f385d7a6718b07f"
+    },
+    "maps/ad_brk/brick24.map": {
+     "bytes": 3305,
+     "sha256": "481d21e7e07a312e894f71a8118035457164f17d48032bad54bdc62644e7e8a4"
+    },
+    "maps/ad_brk/brick25.bsp": {
+     "bytes": 7924,
+     "sha256": "8e33245bde92e94d9dddca1b61059fee1eb19aed0613945c1dffe3145fd51d78"
+    },
+    "maps/ad_brk/brick25.map": {
+     "bytes": 715,
+     "sha256": "cf6042585a2347f8ae4de546e2fa9aa905aa7ee4d9607a12dfd778d0084ba9d1"
+    },
+    "maps/ad_brk/brick26.bsp": {
+     "bytes": 8084,
+     "sha256": "4ddb5d2ca4adbc32f905a0340b26a174c25af7f6de5ad9408c4e0f4ca2816a55"
+    },
+    "maps/ad_brk/brick26.map": {
+     "bytes": 855,
+     "sha256": "baaf133d5c5c90b295855bb03a0a30340db324ddc82ed119a9d025e8ddb22724"
+    },
+    "maps/ad_brk/brick27.bsp": {
+     "bytes": 8296,
+     "sha256": "9084778144864d4167d270dd825e99d18d7ea7fc2dfb799f7e0eb12f1d236688"
+    },
+    "maps/ad_brk/brick27.map": {
+     "bytes": 927,
+     "sha256": "4e3b59df2a5b8efe85460f114baa795c36c8b410407e0752a69efc525d49e9b0"
+    },
+    "maps/ad_brk/brick28.bsp": {
+     "bytes": 8068,
+     "sha256": "42b4fe7f99032b3292996bcfe8b72e1c5e3b637357e376f8502a202a3816bcf0"
+    },
+    "maps/ad_brk/brick28.map": {
+     "bytes": 811,
+     "sha256": "c088828bbe9cdca1bb55ea4ceca9f46e03217f1643189a93d70a83eeb11f72bc"
+    },
+    "maps/ad_brk/brick29.bsp": {
+     "bytes": 24232,
+     "sha256": "463ff6bed92dfab082f13876187c506572dd3d18727e13fb708e24afd02aa7ef"
+    },
+    "maps/ad_brk/brick29.map": {
+     "bytes": 711,
+     "sha256": "1a4ff9d041df15cfd229666a9b32c24a96577ef6f249f33d89dc88cdfbe5540a"
+    },
+    "maps/ad_brk/brick30.bsp": {
+     "bytes": 24392,
+     "sha256": "a82a0d709c367d8ecf359142d99d0ad09d97b674ef1575beeb78dbbe93025c59"
+    },
+    "maps/ad_brk/brick30.map": {
+     "bytes": 853,
+     "sha256": "803c896037b5cc971e932219b5f06e363724a25de693ef6800d1332c6df4f8d1"
+    },
+    "maps/ad_brk/brick31.bsp": {
+     "bytes": 24604,
+     "sha256": "deb8a0278e043c6510e7f7d17ec708bdc7f37fa884f869ccbfc9ef9a95b6a8ac"
+    },
+    "maps/ad_brk/brick31.map": {
+     "bytes": 926,
+     "sha256": "9a3502125d9a995f10052ed6a9971bfe148a4e8fd7561a082e8bbecff5b39d56"
+    },
+    "maps/ad_brk/brick32.bsp": {
+     "bytes": 24376,
+     "sha256": "c8961b003f231b13a74bc247ce13ada38850707d443aa98dbad98b9f2ecf276b"
+    },
+    "maps/ad_brk/brick32.map": {
+     "bytes": 808,
+     "sha256": "aa96dda4508d2e98b5827ac42d8230f11969457f63022bf488dac06d2783910e"
+    },
+    "maps/ad_brk/glass01.bsp": {
+     "bytes": 8095,
+     "sha256": "d5d9b8df7fc4db671e180fbc60253ea809b61819bd77a9072d1cf1b1c9c11888"
+    },
+    "maps/ad_brk/glass01.map": {
+     "bytes": 961,
+     "sha256": "04b6721fc35e7a43fa921075bc2184bbbb2791570ea781ee6351b0cf01936456"
+    },
+    "maps/ad_brk/glass02.bsp": {
+     "bytes": 7035,
+     "sha256": "b2e6ba1e674f6a93e01ada15700b98624eae9c242a30eba9ea032d2e7d9fc555"
+    },
+    "maps/ad_brk/glass02.map": {
+     "bytes": 447,
+     "sha256": "6bf3cce568e830dd03830bb2e7225329490dae01e33806eec6a594313a8daa9e"
+    },
+    "maps/ad_brk/glass03.bsp": {
+     "bytes": 7922,
+     "sha256": "02661d1e724d41c02c977f8b869a23e6fc883303b66298c98ebddf752f365a1b"
+    },
+    "maps/ad_brk/glass03.map": {
+     "bytes": 963,
+     "sha256": "cb5245e54bc27d999bd643370557f8e766ae94e10358993951084e6ca87d087c"
+    },
+    "maps/ad_brk/glass04.bsp": {
+     "bytes": 7223,
+     "sha256": "a41bddb2d6a0ef53b96097a6e4d9731bf100b695a7a1c11091f054f746c7bf2a"
+    },
+    "maps/ad_brk/glass04.map": {
+     "bytes": 512,
+     "sha256": "f8e9f41266f3cd0017c19f7d3a29e0c738b497fb539cec2583c4eda6d509965c"
+    },
+    "maps/ad_brk/glass05.bsp": {
+     "bytes": 24436,
+     "sha256": "10fd2ef7f24bda233c3b4433e4ed64b8feb7273f09c0da5d93190ced61f20779"
+    },
+    "maps/ad_brk/glass05.map": {
+     "bytes": 999,
+     "sha256": "c8e2039929909b608ac0ddf36562443caf7052a15e8b0e39a73e0869c15930c1"
+    },
+    "maps/ad_brk/glass06.bsp": {
+     "bytes": 24300,
+     "sha256": "60f08ebc3d967dbe1b6062a59679a3e89e199a305f51bb9bc7dbada44c66fe5e"
+    },
+    "maps/ad_brk/glass06.map": {
+     "bytes": 976,
+     "sha256": "73346b8cc46166371a6e7f220ebe78f2cde29f29d8d705e1e4b0c60e153b52df"
+    },
+    "maps/ad_brk/glass07.bsp": {
+     "bytes": 23365,
+     "sha256": "ccebafe1a97953e91b64694783a1989c8e8ba440fd3c136b09785131b54c75cf"
+    },
+    "maps/ad_brk/glass07.map": {
+     "bytes": 458,
+     "sha256": "6d79a332d308ed3746c8f2fd13227b44a1cc66f0b2fd471eb6de1cbf695d81c9"
+    },
+    "maps/ad_brk/glass08.bsp": {
+     "bytes": 23602,
+     "sha256": "82c1bfe3d83c87c908d6dac76a255843cbbaededeaf644eeec5b9b9a794e0bdf"
+    },
+    "maps/ad_brk/glass08.map": {
+     "bytes": 530,
+     "sha256": "65dba1b71881c49b29d288720f43c457c838b93aa9e522953bac885443944c04"
+    },
+    "maps/ad_brk/glass09.bsp": {
+     "bytes": 24436,
+     "sha256": "34e317a5652fcc4a3aaf517ebc178c8d8fad6738b536a6c06eff2800bf7fefba"
+    },
+    "maps/ad_brk/glass09.map": {
+     "bytes": 999,
+     "sha256": "ca9b91b38fa600b7dfa80e9a257dc15f2f2dda9e1d2c1d002ea90cbdcc0e0279"
+    },
+    "maps/ad_brk/glass10.bsp": {
+     "bytes": 24300,
+     "sha256": "6e06c140e0916cd35235bd7e6970ca3250c6c36a2ee6d4632d805da67215818a"
+    },
+    "maps/ad_brk/glass10.map": {
+     "bytes": 976,
+     "sha256": "2043f7646edcfa088a76b6104b136ff9ca0f90bffe6efb955f951a4bfe16643d"
+    },
+    "maps/ad_brk/glass11.bsp": {
+     "bytes": 23365,
+     "sha256": "caae0c47ae097f4cb1055a3f5eecd5d407b71c975b35d992f3048993b1ac7e97"
+    },
+    "maps/ad_brk/glass11.map": {
+     "bytes": 458,
+     "sha256": "5bea1bbcee409674f58a1fd26cf0c983e11f8ffd5f20c829f5c3df6a4c28b1c9"
+    },
+    "maps/ad_brk/glass12.bsp": {
+     "bytes": 23602,
+     "sha256": "526018b31a9b02b1c9e1b5123b2c936677d6fd7b6c014ea14dfe4905271e419f"
+    },
+    "maps/ad_brk/glass12.map": {
+     "bytes": 530,
+     "sha256": "499ed4ce1a1ebbd9347a2a4dc6413f2f79d203bbce293a79a5b2bde49ade0a3f"
+    },
+    "maps/ad_brk/glass13.bsp": {
+     "bytes": 24108,
+     "sha256": "fdb97447ffe9e4769f35a3e1e7bd9d6b0e2e6b555d60102991bf57f06e8b3d83"
+    },
+    "maps/ad_brk/glass13.map": {
+     "bytes": 979,
+     "sha256": "073661c415a2568c45a90cc9baa471cde9a02a975d4d4fd7596bb96d272d3934"
+    },
+    "maps/ad_brk/glass14.bsp": {
+     "bytes": 23296,
+     "sha256": "e3517bb79e2561150c4641ab3650e0697adcaa2f281c5209cacdc12d9c4023a7"
+    },
+    "maps/ad_brk/glass14.map": {
+     "bytes": 462,
+     "sha256": "066d5bade73c399cf10a9dcafecec9d65ac3c6045644988cbefb104fb8e7d8c3"
+    },
+    "maps/ad_brk/glass15.bsp": {
+     "bytes": 23892,
+     "sha256": "6abc82aca32e6c8312884db42891753c8d2ad8e1d4ae9218022604eadb08708b"
+    },
+    "maps/ad_brk/glass15.map": {
+     "bytes": 993,
+     "sha256": "5c24e1763bd26d34539bc7ee527842810e4ddb6ac80f683a7b3b35ee326360d3"
+    },
+    "maps/ad_brk/glass16.bsp": {
+     "bytes": 23532,
+     "sha256": "13725c14b226297090c4f1e9949c476f601a52247bc8f6abb937a57b964462c6"
+    },
+    "maps/ad_brk/glass16.map": {
+     "bytes": 528,
+     "sha256": "03dbc7feb833831d413e7f87ed0e79625da0800659ab65ea8d3deb63de09a27d"
+    },
+    "maps/ad_brk/kn_mtrim2_1.bsp": {
+     "bytes": 25264,
+     "sha256": "99b67eeed7ece0f46b1d7b4b2309331e655eb9c1b412d3ac4bc362acb4dd8606"
+    },
+    "maps/ad_brk/kn_mtrim2_1.map": {
+     "bytes": 1455,
+     "sha256": "51018fd4ff6d00c9c2c449e32a83b8521fdc3babb2937adf6800d8e67e38b976"
+    },
+    "maps/ad_brk/kn_mtrim2_2.bsp": {
+     "bytes": 24460,
+     "sha256": "a98bdee68b3a222af0f44fc978d09e092a08953539929a6a53f1bf0e97568e74"
+    },
+    "maps/ad_brk/kn_mtrim2_2.map": {
+     "bytes": 1103,
+     "sha256": "2880a3f7becf48ae79c27ef9a05faa5c774df20a53ec5d892304bf67bc06cbbe"
+    },
+    "maps/ad_brk/kn_mtrim2_3.bsp": {
+     "bytes": 24632,
+     "sha256": "967e89f57bc011cd3b38d60d45272633cc0f773c91045b7938766ac0436ae803"
+    },
+    "maps/ad_brk/kn_mtrim2_3.map": {
+     "bytes": 1171,
+     "sha256": "40ef38fd45c3e9c750d311bb8920b938fcd9f647f2dabc58509b327514f44907"
+    },
+    "maps/ad_brk/kn_mtrim2_4.bsp": {
+     "bytes": 24452,
+     "sha256": "e4559e1e5a3118f2c949daccb96f887d64821511f5850cfa72133f84a8e04901"
+    },
+    "maps/ad_brk/kn_mtrim2_4.map": {
+     "bytes": 1036,
+     "sha256": "595513bc0fe2441cb6aa88af41d9afd7de8b94421ac6c32c546113f83be6577c"
+    },
+    "maps/ad_brk/metal01.bsp": {
+     "bytes": 8122,
+     "sha256": "11e8e340455c487150951fb4dccaf7da72d0243892948d5c22b478221ffcca23"
+    },
+    "maps/ad_brk/metal01.map": {
+     "bytes": 780,
+     "sha256": "902c31c661df8bbc1b0c410b6a8745f680e85cf91bbdb14d85244b6937be5239"
+    },
+    "maps/ad_brk/metal02.bsp": {
+     "bytes": 10022,
+     "sha256": "59b56266e73b4246c54d8cd9c4769d7345c53ae5133c45d1db94f5c771350d94"
+    },
+    "maps/ad_brk/metal02.map": {
+     "bytes": 1414,
+     "sha256": "171bfe727b6c80a4c0350fb4c87090d30c3fb1a21962b8fc9c638c47027e1fea"
+    },
+    "maps/ad_brk/metal03.bsp": {
+     "bytes": 9386,
+     "sha256": "13e3ea83c5bdbf81075328cc14543d1ab6301378cc9af56b59b67b1cc22e3a53"
+    },
+    "maps/ad_brk/metal03.map": {
+     "bytes": 1179,
+     "sha256": "89ac4002203958a9f971601586f4e4e6bdcaab7cbde62ca7fb58cf705fbdae56"
+    },
+    "maps/ad_brk/metal04.bsp": {
+     "bytes": 10655,
+     "sha256": "785ab6aed41e60072083aeee571d76796f60ec5e24d249736575007d558c10ae"
+    },
+    "maps/ad_brk/metal04.map": {
+     "bytes": 1599,
+     "sha256": "aecd2de4ce9cdb49922c58f640f3df4c48b8dc45f5e611f5d0c75a6a96bf705e"
+    },
+    "maps/ad_brk/metal05.bsp": {
+     "bytes": 8337,
+     "sha256": "82da98a887a0101d1a638d266db3c9913090b3fcaca6af5869e7063529b3066e"
+    },
+    "maps/ad_brk/metal05.map": {
+     "bytes": 905,
+     "sha256": "541a5d633be51d32bbd6580cf3fb4fcc7e9b3c38107eaffdd88896a01d249b71"
+    },
+    "maps/ad_brk/metal06.bsp": {
+     "bytes": 7898,
+     "sha256": "3fe3f66ff336ede9d9a6f4fc0f7df16b62504b25a8dea1c8adce2113e927428e"
+    },
+    "maps/ad_brk/metal06.map": {
+     "bytes": 697,
+     "sha256": "30bfd29315a3c0d8654aa1842b7f2a2a7bcdc7a5a81ff96f359a86d57a289ce9"
+    },
+    "maps/ad_brk/metal07.bsp": {
+     "bytes": 8439,
+     "sha256": "8f8a722ae0d3350bf4331fbd4a492dd4c18b3c44006289fd7c6d393282f280a1"
+    },
+    "maps/ad_brk/metal07.map": {
+     "bytes": 1508,
+     "sha256": "f2c7442255c68ae30186692cdf49bca0f1e5769587d5d2392baf3ec4708679b2"
+    },
+    "maps/ad_brk/metal08.bsp": {
+     "bytes": 8150,
+     "sha256": "028675fecfd419e8852cabe821fac1941c914bdf43110291d7a07509e77f4d26"
+    },
+    "maps/ad_brk/metal08.map": {
+     "bytes": 847,
+     "sha256": "797217e143857e0b27e1654449a5dbdc0b1a3dc46c8cafdea5ee9c5ac0cbf16c"
+    },
+    "maps/ad_brk/metal09.bsp": {
+     "bytes": 7456,
+     "sha256": "4d6fb8a19ce5a331ceb68fcfa952fa61ed3ad336002eedd788921b0daa2a7877"
+    },
+    "maps/ad_brk/metal09.map": {
+     "bytes": 649,
+     "sha256": "1fde976a2f1372d9d55350caa3285776eee897d9786f9118d5a6988010efaeca"
+    },
+    "maps/ad_brk/metal10.bsp": {
+     "bytes": 7785,
+     "sha256": "c25084ae2f159ba73e6c43041a2e050d30af70a862a9c4846b2241848a33b55f"
+    },
+    "maps/ad_brk/metal10.map": {
+     "bytes": 709,
+     "sha256": "856390903976512f1b5372f374b5c7444238a173abbedbbfeccbb675cf93ed66"
+    },
+    "maps/ad_brk/metal11.bsp": {
+     "bytes": 7918,
+     "sha256": "e939c6c80e11479887b68bb39a97e0b877514c4e9dc9b2a4a9e18303caa317f1"
+    },
+    "maps/ad_brk/metal11.map": {
+     "bytes": 797,
+     "sha256": "74528d15a51708fdca65c900096411f1d56d6472a5058458577ac04d820e9895"
+    },
+    "maps/ad_brk/metal12.bsp": {
+     "bytes": 8226,
+     "sha256": "3ceccd7aa24fc353e0ac3ccb15531c2f243c0ed246c73c44bdd8897dbdd6537e"
+    },
+    "maps/ad_brk/metal12.map": {
+     "bytes": 872,
+     "sha256": "a95f34c46729c7849e6d45d9cdf57bb49289561b6551bd2e4a39659c272343fd"
+    },
+    "maps/ad_brk/metal13.bsp": {
+     "bytes": 8121,
+     "sha256": "e02aa4c824f5d8fcdfe302a0a194cee6fcf44e2fee844c492f434bf2b7763209"
+    },
+    "maps/ad_brk/metal13.map": {
+     "bytes": 760,
+     "sha256": "bae8879296237bea635d054428a536c0297420ff3ff61f681d569b30a984e7d0"
+    },
+    "maps/ad_brk/metal14.bsp": {
+     "bytes": 10022,
+     "sha256": "4b66b133fe892c6ae6ead0c6726638e98637d71a3a9afdc4ac0546be0f2d0292"
+    },
+    "maps/ad_brk/metal14.map": {
+     "bytes": 1376,
+     "sha256": "197bd6c01b5ffc4c9e0f27e319b25b882af4f20db36612f41b006dd6db0833e1"
+    },
+    "maps/ad_brk/metal15.bsp": {
+     "bytes": 9386,
+     "sha256": "8cf7545aa3464814908c3987f51e9693f154f690ec526ed228b37b1590730e0b"
+    },
+    "maps/ad_brk/metal15.map": {
+     "bytes": 1147,
+     "sha256": "73aef82251f5b4a9548135aedb926aad6b7cff94cb3656fc8216a594a8a9f6dc"
+    },
+    "maps/ad_brk/metal16.bsp": {
+     "bytes": 10719,
+     "sha256": "af64c13135b1e1eb6d8e09607c34d6cec57a3cbf624dd76b136b505f097ecf65"
+    },
+    "maps/ad_brk/metal16.map": {
+     "bytes": 1555,
+     "sha256": "d7220fbbb33a630d03ed2514b9ee33a9d3a424f819b4977e093863ca8568b645"
+    },
+    "maps/ad_brk/metal17.bsp": {
+     "bytes": 8347,
+     "sha256": "0d21cbf9b5bc65391e00bad35368530d3d4b5f59993e2ac7d45a7edc9a2edf73"
+    },
+    "maps/ad_brk/metal17.map": {
+     "bytes": 911,
+     "sha256": "7be91013d0e57e41aff314398634043cebf8f250691b3ebc583bf373df400c2c"
+    },
+    "maps/ad_brk/metal18.bsp": {
+     "bytes": 7907,
+     "sha256": "ef0dee9c63d7bbced8c04ea40523d47fd99638905aa20a61779820b5aebd5aab"
+    },
+    "maps/ad_brk/metal18.map": {
+     "bytes": 703,
+     "sha256": "b610432a51ac6b57f19fee9df89fc7b80d5cbffa972e539d9c5f3aded3359434"
+    },
+    "maps/ad_brk/metal19.bsp": {
+     "bytes": 8450,
+     "sha256": "2796007e11c0a1b2a3430edc4e0f7edb0e721a6d906e783233c0feb54b0482e5"
+    },
+    "maps/ad_brk/metal19.map": {
+     "bytes": 1514,
+     "sha256": "9ed741344b3c651f3b8fbda1d8ee8e779bd12315feea397e938522c9750dc214"
+    },
+    "maps/ad_brk/metal20.bsp": {
+     "bytes": 8160,
+     "sha256": "38013cdb360356827ab6c296791434c537183d082feed6944665a882e622ed84"
+    },
+    "maps/ad_brk/metal20.map": {
+     "bytes": 853,
+     "sha256": "a3b28328bb043206bc048e82dba12d91c56c464b5e4e1452c6740f0df44223bf"
+    },
+    "maps/ad_brk/rock01.bsp": {
+     "bytes": 24238,
+     "sha256": "5f2c0a6ce3c58eed53c86789ff1685551cff53ca1f239bf75e3a9bc59aa95a56"
+    },
+    "maps/ad_brk/rock01.map": {
+     "bytes": 680,
+     "sha256": "db0b6a72833e12a35f518b32920fccf4fbc45120e7ab8ca3afc6e255b5d51334"
+    },
+    "maps/ad_brk/rock02.bsp": {
+     "bytes": 24250,
+     "sha256": "c6196e82e7b3e22cb687e2d6c0780f163929b5ea42b868eedcaadd40f35927f9"
+    },
+    "maps/ad_brk/rock02.map": {
+     "bytes": 760,
+     "sha256": "49531f0a1a38e03e3b46af53cfc35845878fcc171c2579f0f13d2a000ca82829"
+    },
+    "maps/ad_brk/rock03.bsp": {
+     "bytes": 24669,
+     "sha256": "9f7ab133399a3681f0b97276c7cb9883b479995c3420e5643eaedd11c88f0a0d"
+    },
+    "maps/ad_brk/rock03.map": {
+     "bytes": 929,
+     "sha256": "4158321d447c3b323f44389661ba6c763b23e26fb9541a786c3b544ad56321d9"
+    },
+    "maps/ad_brk/rock04.bsp": {
+     "bytes": 24600,
+     "sha256": "3c8b114e8ff86b8abcba235230445d885d4c28553d83e153676b2755b0300292"
+    },
+    "maps/ad_brk/rock04.map": {
+     "bytes": 878,
+     "sha256": "229d94f5f5bd81a83be5463035d30c8838d1de092923c3281e7a3a9ec4c7e9aa"
+    },
+    "maps/ad_brk/rock05.bsp": {
+     "bytes": 24254,
+     "sha256": "6bdc990b90f24ddd77034a4cbdd4d7158e05df70e6db5e793ca990a40cd29709"
+    },
+    "maps/ad_brk/rock05.map": {
+     "bytes": 684,
+     "sha256": "708a6ad98116a72ddc862c6c99cbd59342446636c9579a00bd6c34efa1ac855b"
+    },
+    "maps/ad_brk/rock06.bsp": {
+     "bytes": 24462,
+     "sha256": "e2e3688c3cb66e2c9d738d211ad328d86963e1d67881354363696698a07be32b"
+    },
+    "maps/ad_brk/rock06.map": {
+     "bytes": 816,
+     "sha256": "5e1a399ac2e6a179a84004539f15172012db93477e5544309b01ed24cbc59f34"
+    },
+    "maps/ad_brk/rock07.bsp": {
+     "bytes": 24281,
+     "sha256": "ea3569e42b755fd1b9fde50e2740f6aa95d1dabb1911f8a4ab5b1c5028a4e1e3"
+    },
+    "maps/ad_brk/rock07.map": {
+     "bytes": 777,
+     "sha256": "02f61c60083f5007fa9d4d7a38adf2901e928a96adbfeaa7646711f21cc75409"
+    },
+    "maps/ad_brk/rock08.bsp": {
+     "bytes": 25096,
+     "sha256": "5468a365153fc7f160d7e1792b9bc9164b828a51851bd1e9744eb0cf3a7a842d"
+    },
+    "maps/ad_brk/rock08.map": {
+     "bytes": 1060,
+     "sha256": "b285f3a79407366944213b3d8eef311c662bf2eb0cf3df0ee3104e747a3c9150"
+    },
+    "maps/ad_brk/rock09.bsp": {
+     "bytes": 8314,
+     "sha256": "4320c73f55d67e4db7e596614b74b05b0c086cd57186ecaf183c96fca51106bf"
+    },
+    "maps/ad_brk/rock09.map": {
+     "bytes": 913,
+     "sha256": "629fab0d0f8022138ff5d5e573f0e3ab0f75397f120015b3f8a95a297c857911"
+    },
+    "maps/ad_brk/rock10.bsp": {
+     "bytes": 7930,
+     "sha256": "7657ad82fbdeaceb354e04f60fa76cfd3d8a7a819607a413afaa6fc16253a009"
+    },
+    "maps/ad_brk/rock10.map": {
+     "bytes": 780,
+     "sha256": "833bc2f2460f5f5ef444630b398a59974831031e408f986125a5241fab52ba99"
+    },
+    "maps/ad_brk/rock11.bsp": {
+     "bytes": 8565,
+     "sha256": "e19573b67e5dedba499da8f6d0d63ca0e829593417a1ce66e1aeb1fd2b2d1e76"
+    },
+    "maps/ad_brk/rock11.map": {
+     "bytes": 1016,
+     "sha256": "040c31d22159743b28e9f20946b34db390ef15bbe530882342638b9325542801"
+    },
+    "maps/ad_brk/rock12.bsp": {
+     "bytes": 8284,
+     "sha256": "f03a3a0184b2fa8809154754f85d81d30777261714976bdd64340b0549d3ca35"
+    },
+    "maps/ad_brk/rock12.map": {
+     "bytes": 898,
+     "sha256": "b7d2b1bba22ad5b621e699a8233a83d23415e5c6e88fec8e1525a9c84a494bf0"
+    },
+    "maps/ad_brk/rock13.bsp": {
+     "bytes": 7917,
+     "sha256": "6710c24df905df9ede31faf75fdf9a070efbdc471e58a295740092863dcb50fa"
+    },
+    "maps/ad_brk/rock13.map": {
+     "bytes": 680,
+     "sha256": "369735b7ebd630e6407371d3ab7195ef368c2f8d8d3469943b2c5e46b8e24fa5"
+    },
+    "maps/ad_brk/rock14.bsp": {
+     "bytes": 7929,
+     "sha256": "a17329c593e306d1aa4084cd2651983f53258b3e5759443efe3bb3b4daecc5f8"
+    },
+    "maps/ad_brk/rock14.map": {
+     "bytes": 760,
+     "sha256": "f86556e799f3a0240294537aa487526c674486afb7190bb705d72453cade7e68"
+    },
+    "maps/ad_brk/rock15.bsp": {
+     "bytes": 8349,
+     "sha256": "d64f11606da6b94024382315eead25dbfe19c8cc90844f60e755e2bd106c7fc0"
+    },
+    "maps/ad_brk/rock15.map": {
+     "bytes": 929,
+     "sha256": "23defe1bddcc8db664c819b60657fd536b1c44b118299495d42f7c54f740e7b0"
+    },
+    "maps/ad_brk/rock16.bsp": {
+     "bytes": 8280,
+     "sha256": "87e60c650a672c5ffe57b64c7ae3c5413799972a2ca5b73935cb0d1dad16f62c"
+    },
+    "maps/ad_brk/rock16.map": {
+     "bytes": 878,
+     "sha256": "d3616ad7b423be757f6f7873791f4c452a09243b53569347bd36e87f1a942947"
+    },
+    "maps/ad_brk/rock17.bsp": {
+     "bytes": 8340,
+     "sha256": "b317f3432532e6f6f327852fa0c7f546726c8b23c44cfc3e86869d64eb33235c"
+    },
+    "maps/ad_brk/rock17.map": {
+     "bytes": 913,
+     "sha256": "a534b032b611965c86cd81fda18d53186c474d55184f9c4c74cd292b4b207f27"
+    },
+    "maps/ad_brk/rock18.bsp": {
+     "bytes": 7924,
+     "sha256": "e5fc24e393828bdd2c24e3cb341e0c21e81511881e65424293206fe20ff54c4e"
+    },
+    "maps/ad_brk/rock18.map": {
+     "bytes": 701,
+     "sha256": "bf5974bf04067482dde83a2fd73e58a011de04220b32866fa7913e901a0e944c"
+    },
+    "maps/ad_brk/rock19.bsp": {
+     "bytes": 8620,
+     "sha256": "4a1d3e4e37f29438981f419f5a5f076fcf53227a4da544e919061d6c6bf8702e"
+    },
+    "maps/ad_brk/rock19.map": {
+     "bytes": 919,
+     "sha256": "c2626204acbd33e3299c29cd1f8a5279bbe8cd07a621f6b40b14b74b7808f444"
+    },
+    "maps/ad_brk/rock20.bsp": {
+     "bytes": 8785,
+     "sha256": "87bfda54a9f0711eedcefc6d8e691b6cac8123958db03735bd0364067445de69"
+    },
+    "maps/ad_brk/rock20.map": {
+     "bytes": 1118,
+     "sha256": "225800378c3183d5ba423140d7f5d510cf387df3df795fda69294fcb0e4bec4c"
+    },
+    "maps/ad_brk/rock21.bsp": {
+     "bytes": 24244,
+     "sha256": "161b5893f3f413969ced051a7e7aa3d816a1da9f74bffa5d0642830713d83031"
+    },
+    "maps/ad_brk/rock21.map": {
+     "bytes": 674,
+     "sha256": "db86b019086636ec085b3690bc4b252d8bac2443c0ff138a6f3b6c79e522a94b"
+    },
+    "maps/ad_brk/rock22.bsp": {
+     "bytes": 24256,
+     "sha256": "b41069e88c74ef3bfb7c5f2817c31d9d374cd1725b7270b9ac7d93c58dd34a11"
+    },
+    "maps/ad_brk/rock22.map": {
+     "bytes": 753,
+     "sha256": "aa059dd13499512fdda512b68e79068f390d1870726763958a81a54c91aeb254"
+    },
+    "maps/ad_brk/rock23.bsp": {
+     "bytes": 24676,
+     "sha256": "aac7fc5557dd385c52043d206d39d83b48e0b2f6db2822de2060f2a978be4a9d"
+    },
+    "maps/ad_brk/rock23.map": {
+     "bytes": 920,
+     "sha256": "744ccf1456c3b19318289586238b1d36e4968dbfe444f5a489e1d2202f1965d4"
+    },
+    "maps/ad_brk/rock24.bsp": {
+     "bytes": 24612,
+     "sha256": "90553422561893d50030520bcf796da9290933e53570e313d1a423aec01c8ac6"
+    },
+    "maps/ad_brk/rock24.map": {
+     "bytes": 939,
+     "sha256": "3f8f5c2053315577eda81360a9ed9a095e96f7d9a6288eed876400a91bc0922b"
+    },
+    "maps/ad_brk/rock25.bsp": {
+     "bytes": 89516,
+     "sha256": "ef87b49e322fd2a2251f0ee7ecedec32bae141ea7a589769c6fba6a3176da0d4"
+    },
+    "maps/ad_brk/rock25.map": {
+     "bytes": 737,
+     "sha256": "3cad88a720acc4d7db1666ab0d865e013717776a256c999e1b417690679f4f0b"
+    },
+    "maps/ad_brk/rock26.bsp": {
+     "bytes": 89532,
+     "sha256": "a6f46aa8183937dfe19eb1cfde621bac8f3f08721effcbbd195ba251b3b1467f"
+    },
+    "maps/ad_brk/rock26.map": {
+     "bytes": 823,
+     "sha256": "27c411424182d3e6d611f2eff2dd9a7c75ef2135f2019d4aca40b2dee2d134b5"
+    },
+    "maps/ad_brk/rock27.bsp": {
+     "bytes": 89952,
+     "sha256": "f55dc66117c856efee1dae5e311492f2aae2839ef4588af45ac0818307ad564c"
+    },
+    "maps/ad_brk/rock27.map": {
+     "bytes": 1004,
+     "sha256": "7368f6cbd051aa3ac71237b5c8d3da2ef73fc3017024ef42af6ac8af9ddc1139"
+    },
+    "maps/ad_brk/rock28.bsp": {
+     "bytes": 89880,
+     "sha256": "2132d7f311c90f8c43b4630a55f7fa0b15141fa0e9c26c0309c8023437377961"
+    },
+    "maps/ad_brk/rock28.map": {
+     "bytes": 947,
+     "sha256": "b1571df2e370ca2d51f19b3608726552f10a6f6da64f69929a2ea2c1884e51dc"
+    },
+    "maps/ad_brk/rock29.bsp": {
+     "bytes": 89516,
+     "sha256": "a179ac329768d445bfbc36bb9c3e47ce3c7506c31337730a93c9a58f96ea5399"
+    },
+    "maps/ad_brk/rock29.map": {
+     "bytes": 737,
+     "sha256": "260d08f376c81869c1f9a0c0cfd677bded9022f79bbe4e607d12128b7ad7c746"
+    },
+    "maps/ad_brk/rock30.bsp": {
+     "bytes": 89532,
+     "sha256": "febc6ed2ec191f8dcbae1ee9df9d13bbd8fff830e28e051236fa24fd211829ee"
+    },
+    "maps/ad_brk/rock30.map": {
+     "bytes": 823,
+     "sha256": "da6a3224e060f6413f70ac9f6f25bf96f3784f690084d602d63805dc8b43e7e8"
+    },
+    "maps/ad_brk/rock31.bsp": {
+     "bytes": 89952,
+     "sha256": "7a38ed8a7dd80c2f2dab17342bfdde51300c9225f4e93be78ca9b63d3a7f1e99"
+    },
+    "maps/ad_brk/rock31.map": {
+     "bytes": 1004,
+     "sha256": "3fb04740e6da6c00670536ccbcb92e7a9a5b5e3072e78af96d6dd5c79d39f984"
+    },
+    "maps/ad_brk/rock32.bsp": {
+     "bytes": 89880,
+     "sha256": "41789fbb095ef6d7b09ba6f50bea0503f73e612808f37bbb71f4a7e9fea00ae2"
+    },
+    "maps/ad_brk/rock32.map": {
+     "bytes": 947,
+     "sha256": "37e272ad3f235bb182666e46d3b087bee4ec23ebdc716647c5b0ffb671a9ee1d"
+    },
+    "maps/ad_brk/rock33.bsp": {
+     "bytes": 7916,
+     "sha256": "af3e313ba1c7013b7bd2234e9988a2b6bc451d123e7d6dab1692ae0727d40bec"
+    },
+    "maps/ad_brk/rock33.map": {
+     "bytes": 683,
+     "sha256": "de08059147e865be402e6dac4c6d8a0bea1de05bb65cf0455153386afdde2bdb"
+    },
+    "maps/ad_brk/rock34.bsp": {
+     "bytes": 7932,
+     "sha256": "392125c9afaf18c3084c1b13a0a55dcda7e2294da37f84fb73983826271dea27"
+    },
+    "maps/ad_brk/rock34.map": {
+     "bytes": 763,
+     "sha256": "dc402e2573ee3e94f3ed96274d5b6f8d0177d9745716ea96d0ffce8e0be5c943"
+    },
+    "maps/ad_brk/rock35.bsp": {
+     "bytes": 8352,
+     "sha256": "0352c35aa723330a3c05126d24a8e6b84403bf8b71d406f3fa5a2ff3fc0da39a"
+    },
+    "maps/ad_brk/rock35.map": {
+     "bytes": 932,
+     "sha256": "9841ed50187bbdfb3a7122d3b0890b0245d64dd4919485686fdf5ce61bdae3e6"
+    },
+    "maps/ad_brk/rock36.bsp": {
+     "bytes": 8280,
+     "sha256": "f1871698ef7597c51fed5d54b582df2ea70cf72e2fa7db643182e59f7e7f6ca7"
+    },
+    "maps/ad_brk/rock36.map": {
+     "bytes": 881,
+     "sha256": "974aaec9003dd3e1457582b1f770d67e07fc8e9d11a6b639981fbb753c6a6484"
+    },
+    "maps/ad_brk/sandstone01.bsp": {
+     "bytes": 24239,
+     "sha256": "ebb374110d88805e1b0b45cdaf33e5e570a9092da549facaf9f5ddcd995eb607"
+    },
+    "maps/ad_brk/sandstone01.map": {
+     "bytes": 702,
+     "sha256": "9ea9ab63b8c6a2d90fba029c4d4b768beb0d4342cf255bb5005185b61b1bcfd2"
+    },
+    "maps/ad_brk/sandstone02.bsp": {
+     "bytes": 24399,
+     "sha256": "2fa799b0a08ca2fdd9bef3ecb9d6ea4c16e8f66181d29913cdc5a9205bafe98f"
+    },
+    "maps/ad_brk/sandstone02.map": {
+     "bytes": 842,
+     "sha256": "5228b0a958ef571f33838366ef1f2b69a10f6e0c53a3269dba683b5326a95e5f"
+    },
+    "maps/ad_brk/sandstone03.bsp": {
+     "bytes": 24607,
+     "sha256": "671b8f740ba9deaeac681c703f87d61c2a3f8107d0f72b8fd636c53436555110"
+    },
+    "maps/ad_brk/sandstone03.map": {
+     "bytes": 914,
+     "sha256": "7523ff7908eb3e47154155d0448fa05d4d9b6081525069a131e7d44ea9b13c0c"
+    },
+    "maps/ad_brk/sandstone04.bsp": {
+     "bytes": 24379,
+     "sha256": "56bda0f4bf4958dc243fa9b4ab79e9e3bd6fad5f794af7beb024a6cbe7f9a0cb"
+    },
+    "maps/ad_brk/sandstone04.map": {
+     "bytes": 798,
+     "sha256": "d01584bd00868a0a69ae7513834f776566fce273d8919d9c78d0bdafbb07a799"
+    },
+    "maps/ad_brk/wood01.bsp": {
+     "bytes": 7553,
+     "sha256": "c1764181bae4852804097143fe16a4c230bd5886574125cb33d5349bbc63dc21"
+    },
+    "maps/ad_brk/wood01.map": {
+     "bytes": 1040,
+     "sha256": "05f1ebaa57c4b55e6c3da9c5440c180aa96c719f9cddc80c780ed11415ad6bd7"
+    },
+    "maps/ad_brk/wood02.bsp": {
+     "bytes": 7079,
+     "sha256": "26fc67e4e47eae3a13a449d876deabe35d50aa1b70e63060d27cb365eadecbe0"
+    },
+    "maps/ad_brk/wood02.map": {
+     "bytes": 521,
+     "sha256": "8dee7615c9e9696420331668edeccd9ff1dd874ad844e289f049391be5e61345"
+    },
+    "maps/ad_brk/wood03.bsp": {
+     "bytes": 7135,
+     "sha256": "ca17df0f61a11bd37749587e361ca404f2e5bec07c248491d86c07803fafb732"
+    },
+    "maps/ad_brk/wood03.map": {
+     "bytes": 522,
+     "sha256": "0fb4cdb1ffeda8c97026d40842d5fcb0beced0f84dae4b10a8284044875cf0c2"
+    },
+    "maps/ad_brk/wood04.bsp": {
+     "bytes": 7951,
+     "sha256": "e2d9f42bf3256be2dd38648dbd962458bdad3992b33e8d688e42a0acba5d7c3f"
+    },
+    "maps/ad_brk/wood04.map": {
+     "bytes": 912,
+     "sha256": "071556b1cac3bd95a176762302e6a60ddbbfb07cf6c9e4b2f8cf2e259e23402a"
+    },
+    "maps/ad_brk/wood05.bsp": {
+     "bytes": 7553,
+     "sha256": "5bdb275ae2c39b41d71a17244681cda9cc2008df088f4da73f547a8bf1966069"
+    },
+    "maps/ad_brk/wood05.map": {
+     "bytes": 1040,
+     "sha256": "ada27de98972730676a2d040fd284893fabfe71acd6fcbce1f2ba12da7d14632"
+    },
+    "maps/ad_brk/wood06.bsp": {
+     "bytes": 7079,
+     "sha256": "f27b0f1970f6065255b5f7a27abfc4e749f40321f6fdef4c3f9ac6bb64d46098"
+    },
+    "maps/ad_brk/wood06.map": {
+     "bytes": 521,
+     "sha256": "17c93b1c1c65a7507d794013078a1d12a67c3a24ae7202739fcd8a1108d52419"
+    },
+    "maps/ad_brk/wood07.bsp": {
+     "bytes": 7135,
+     "sha256": "8e07e7e5f5b641c644d28c9c4026efc95aa50345074f5c42acd39a3b94261344"
+    },
+    "maps/ad_brk/wood07.map": {
+     "bytes": 522,
+     "sha256": "55f1bb5f18ed30f28ac88349aee9ea5563b1e938bafebffb25c9ab5a1c918b33"
+    },
+    "maps/ad_brk/wood08.bsp": {
+     "bytes": 7951,
+     "sha256": "d26222458ba6e7fee06670021e64c1661d99a8c098581936af943891c9583858"
+    },
+    "maps/ad_brk/wood08.map": {
+     "bytes": 912,
+     "sha256": "2582987129d34bbee73594a236c4c09ce6ae1092eec649ef3957b892e125624c"
+    },
+    "maps/ad_brk/wood09.bsp": {
+     "bytes": 7282,
+     "sha256": "2735e78b25b0feb640f27eddae47104b0acba9f017c6d025e3a8dbdfcc755778"
+    },
+    "maps/ad_brk/wood09.map": {
+     "bytes": 541,
+     "sha256": "84d9789b4d79b41347fd082b0ab75c016553c03bfb952cf4b9c7dd18c85944ce"
+    },
+    "maps/ad_brk/wood10.bsp": {
+     "bytes": 7214,
+     "sha256": "43b59e9b0cb02fb1ac15afb5c782e71b4ce0661db295949b5188cc5accd1733a"
+    },
+    "maps/ad_brk/wood10.map": {
+     "bytes": 533,
+     "sha256": "365f949e19e2606cf2d7a354c3e4368a5e17c3eef94e2558ed9cef276e987d35"
+    },
+    "maps/ad_brk/wood11.bsp": {
+     "bytes": 7196,
+     "sha256": "cce8b312c4be49810f4cf90f0dcdeb1a82dfa623de1ba44c55ec83475f9e9e49"
+    },
+    "maps/ad_brk/wood11.map": {
+     "bytes": 542,
+     "sha256": "790cd93cb271402698ad7f005b908847fddbb30d3c8c3d11fa8c2f327ca8e48e"
+    },
+    "maps/ad_brk/wood12.bsp": {
+     "bytes": 7978,
+     "sha256": "6a227f92bf3b6f1120efd6179bfb3de977e4be2e59495c5d757cbe1c835e3f03"
+    },
+    "maps/ad_brk/wood12.map": {
+     "bytes": 986,
+     "sha256": "01ed96a5ce6545b334dfac7dc0196472dd6c06df09ed557cec7dc820d35c1132"
+    },
+    "maps/ad_brk/wood13.bsp": {
+     "bytes": 7284,
+     "sha256": "09325ca10ebcfeb88f688c9f4521259c3c3426e9befc06c99ba405c7e20595c9"
+    },
+    "maps/ad_brk/wood13.map": {
+     "bytes": 526,
+     "sha256": "b16b33b2a46b72a4ee235674780298eac0ed27631def07a28058a775aba7078e"
+    },
+    "maps/ad_brk/wood14.bsp": {
+     "bytes": 7216,
+     "sha256": "4c9dc5afd7b51119e5c22ad36eb77d07881c454ff47ed060521172cfc3950e2c"
+    },
+    "maps/ad_brk/wood14.map": {
+     "bytes": 518,
+     "sha256": "41b51f20630df3c046ed9ca0f7d97ca403ce8c1487074fc80caf603e763e6ac1"
+    },
+    "maps/ad_brk/wood15.bsp": {
+     "bytes": 7196,
+     "sha256": "373f6e5c5da44b7c8d1a01fb701f074bbcfc52d21bb080dd04e986ffe9e1088c"
+    },
+    "maps/ad_brk/wood15.map": {
+     "bytes": 527,
+     "sha256": "eb07eae6f0afdb4b03af57bcb589e3b385632912f12d4c55257b3031270f0421"
+    },
+    "maps/ad_brk/wood16.bsp": {
+     "bytes": 7612,
+     "sha256": "05959d3486eb43afc8959f6923156a1a83ead4dad544f8caf90ba0e1c7e2bc80"
+    },
+    "maps/ad_brk/wood16.map": {
+     "bytes": 953,
+     "sha256": "c7e804e781c95336cc91a50bc246baf4fda7172ecf36ccf24f02c5f919710ab3"
+    },
+    "maps/base_brk/baserub1.bsp": {
+     "bytes": 23612,
+     "sha256": "b5320b798366587d20ab541af06babd9575e89870fb003d56a17fdf2f7f22b0c"
+    },
+    "maps/base_brk/baserub1.map": {
+     "bytes": 637,
+     "sha256": "0a5357fb3b12d9286b4d9e6e54316cfd0a33f9fda4c661b8fcd1c461d06ae73f"
+    },
+    "maps/base_brk/bz8_brk.bsp": {
+     "bytes": 12808,
+     "sha256": "219e4371cd0b22d690c6e6660ca2fca3b526618d4ccd9f37799135d2dc6dea02"
+    },
+    "maps/base_brk/bz8_brk.map": {
+     "bytes": 692,
+     "sha256": "fae1ac45d74b2a9f482eb034e0838fe5914affb57204c5215d97ebaf7199e5c8"
+    },
+    "maps/base_brk/crate_r1.bsp": {
+     "bytes": 29110,
+     "sha256": "5dd3afab4a3ad5cf4466e272324e4afad5075ca2e662cc8b1932e277a2db73a2"
+    },
+    "maps/base_brk/crate_r1.map": {
+     "bytes": 664,
+     "sha256": "ee7ce39ec0650d3cbde924b99efc91ba884778db11a961037d4493bf587fa33e"
+    },
+    "maps/base_brk/explodebox_1.bsp": {
+     "bytes": 7707,
+     "sha256": "28bfab37e5cbe722348b753de3bd9f66f47f4a9f5b80bd5c5c1659e6eae7e6c4"
+    },
+    "maps/base_brk/explodebox_1.map": {
+     "bytes": 544,
+     "sha256": "96376f1185f158bf69d6bb0c5baf347bbad27f0ccd6fccd3096da6dd7f89540b"
+    },
+    "maps/base_brk/explodebox_2.bsp": {
+     "bytes": 7107,
+     "sha256": "59d5ba28bc049f691bf28d421327e4aecf5eedaec46599d58328f0074ce0934f"
+    },
+    "maps/base_brk/explodebox_2.map": {
+     "bytes": 375,
+     "sha256": "f906dbea8598f0290af9e224a70eb71f26f3c93c10e922b2fade3f1c63e4ddd5"
+    },
+    "maps/base_brk/explodebox_3.bsp": {
+     "bytes": 10449,
+     "sha256": "0daebb987f48b5dde145998e748ab2eecf63ec69318a6b752924e4cfb6639261"
+    },
+    "maps/base_brk/explodebox_3.map": {
+     "bytes": 1698,
+     "sha256": "538e12e7706df3b8f539bf2473e7517e737657380137de1655193843210dbf3f"
+    },
+    "maps/base_brk/glass01.bsp": {
+     "bytes": 7427,
+     "sha256": "bf3f3938ab3596b6095fb58f66c0a36042e5950169dbb86b1cf3cb9076fd5bdd"
+    },
+    "maps/base_brk/glass01.map": {
+     "bytes": 907,
+     "sha256": "6f47c3ffec4cb28d3447dbf96f0b3d6e4264accd31e10b68ad83b3e30e4e32a7"
+    },
+    "maps/base_brk/grate_r1.bsp": {
+     "bytes": 32796,
+     "sha256": "a8eac6a49f8c49c4f9f1b443c9ca5c6a5f8d03d30ce240daaeee8d150f9c5067"
+    },
+    "maps/base_brk/grate_r1.map": {
+     "bytes": 2106,
+     "sha256": "e5cac190d45b0d14901947e489622680d1b9436955b18e2a0e8cb2f92e9aa011"
+    },
+    "maps/base_brk/pbt04.bsp": {
+     "bytes": 18286,
+     "sha256": "0a3321e606857ebb78d047be51c92036b53175dc392c021891cdeabd28597c3c"
+    },
+    "maps/base_brk/pbt04.map": {
+     "bytes": 699,
+     "sha256": "a8b2d3feef56b8cad384a88a9646b596d21017cb9d26278c0b3585ef589b578d"
+    },
+    "maps/base_brk/phk_03brk.bsp": {
+     "bytes": 90417,
+     "sha256": "46efed3a00ce885798ca568563a04472200359c6111682e91fc701c37d8df143"
+    },
+    "maps/base_brk/phk_03brk.map": {
+     "bytes": 1509,
+     "sha256": "29549a0e23b3651110beae8f8697c85e1e3eeb8752dcc8c253a2756e11189209"
+    },
+    "maps/base_brk/rock_sw01.bsp": {
+     "bytes": 8843,
+     "sha256": "a3acc4f42ca89efb30d5f9d7ed7c694d59ab6003bd3c665cfa4db480550fd92d"
+    },
+    "maps/base_brk/rock_sw02.bsp": {
+     "bytes": 9179,
+     "sha256": "4b3d68587a69daa68093d32195a786e8040fed763855acb94f50d02875a8ec44"
+    },
+    "maps/base_brk/rock_sw03.bsp": {
+     "bytes": 9766,
+     "sha256": "59d2841166f7ecb216df970963b3e425da20566f2fb56a7e5472f4e3c9fcfb24"
+    },
+    "maps/base_brk/sfloor4_2.bsp": {
+     "bytes": 7431,
+     "sha256": "d4f7ee45638e0f338c96cf43779410a112bb10be26a200e24187749a80b01332"
+    },
+    "maps/base_brk/sfloor4_2.map": {
+     "bytes": 833,
+     "sha256": "f285b9a96b32420f24bccb267b268e65afd50dd03fb106fad90783aa5d82c1d4"
+    },
+    "maps/base_brk/tech10_2d1.bsp": {
+     "bytes": 45558,
+     "sha256": "272aa49909de27f7b4722848497e5da38aa50b7bef17ef2ee81a1b1240c1b8b2"
+    },
+    "maps/base_brk/tech10_2d1.map": {
+     "bytes": 740,
+     "sha256": "a3766904240cbe7603e967eb3ebdd0dc895b035f0db8758a6ad217749a332904"
+    },
+    "maps/base_brk/tech10_2d2.bsp": {
+     "bytes": 45552,
+     "sha256": "71e5e52660e4aa84f56aa7b51bad024384acb69699bcec431ae3fe6c8d16fc42"
+    },
+    "maps/base_brk/tech10_2d2.map": {
+     "bytes": 733,
+     "sha256": "9d6c4dae495d96bf4b2bbf5f7e01900f16274173c63eb2e4acfb8f8e757a399f"
+    },
+    "maps/medieval_brk/ad_column1.bsp": {
+     "bytes": 14800,
+     "sha256": "f94c99425b3987ebb9eea08dd8c1b3c0e0215cc8afcd1099f7283324ff566712"
+    },
+    "maps/medieval_brk/ad_column1.lit": {
+     "bytes": 578,
+     "sha256": "c30b5af83ab23db6614ad13aff712a15971a6b35ae29ddd49f0cd3da1c1f4919"
+    },
+    "maps/medieval_brk/ad_column1.map": {
+     "bytes": 1541,
+     "sha256": "d71326b819e902d9a32f4a1961565f6ebb10d90069ba2ae0dc0be381a4c1b764"
+    },
+    "maps/medieval_brk/ad_rock1.bsp": {
+     "bytes": 352852,
+     "sha256": "9333d2d2d848e3a4490634aa4f1cc1ee3281c57ac9a498c85b043e5856ce2578"
+    },
+    "maps/medieval_brk/ad_rock1.lit": {
+     "bytes": 920,
+     "sha256": "6d2b33cbd7b3ce1a35c25a6e006a0786fe0bd0ea8be34b1911e2663ac33ea910"
+    },
+    "maps/medieval_brk/ad_rock1.map": {
+     "bytes": 2163,
+     "sha256": "d00049f1c1bdf04d98e768ece39b7d7442e34b719ec991e5715df588d6493d8b"
+    },
+    "maps/medieval_brk/ad_rock2.bsp": {
+     "bytes": 14728,
+     "sha256": "52675efa81ecae4bb87524c97148d7da60916f0e0dc3c65e99b73745aea70fec"
+    },
+    "maps/medieval_brk/ad_rock2.lit": {
+     "bytes": 383,
+     "sha256": "306d2df8cbd9d7ad755fe7e4a6734e0089b38eefa2e2e4fccacfb68c96dd8d90"
+    },
+    "maps/medieval_brk/ad_rock2.map": {
+     "bytes": 1528,
+     "sha256": "891f208f7fdae3fcf1defe7a4cdcda7a6084fbde663ed4e2ab015af18911cb96"
+    },
+    "maps/medieval_brk/ad_rock3.bsp": {
+     "bytes": 352160,
+     "sha256": "bf041a139ed9be638cd1c548139fffca3ceeddefdad2334fcc2639018833110a"
+    },
+    "maps/medieval_brk/ad_rock3.lit": {
+     "bytes": 356,
+     "sha256": "19a61c05d08dd726a9d00174eb3eb1dbdd16da3e0e62ab93d691620aa71add83"
+    },
+    "maps/medieval_brk/ad_rock3.map": {
+     "bytes": 1878,
+     "sha256": "d0049b763f7fd8f25b2176984341421d704f9b50571b24168c60889fdbad5e20"
+    },
+    "maps/medieval_brk/ad_rock4.bsp": {
+     "bytes": 352704,
+     "sha256": "578e7d2dc0eff7bf5ac21b04919d1e137296824182d4809991a27a83addeba75"
+    },
+    "maps/medieval_brk/ad_rock4.lit": {
+     "bytes": 311,
+     "sha256": "3af5d5c9613dd5a1fa09a40b02891bf7153892db8505528b7d3315ce251bfff7"
+    },
+    "maps/medieval_brk/ad_rock4.map": {
+     "bytes": 1889,
+     "sha256": "472f41679eedc00096e8042935ad5287f4598940ef294b8175cccd196dcb6f86"
+    },
+    "maps/medieval_brk/az_ice05.bsp": {
+     "bytes": 98664,
+     "sha256": "b8b2aa063250f6dcc388ead43ff66133c8fa14b1c30afa17c2fce8f2b2c9fd81"
+    },
+    "maps/medieval_brk/az_ice05.lit": {
+     "bytes": 617,
+     "sha256": "e3e8aa044b60a26d643ff87937f83602cdffcebb948ea7ae22148e7952faa18b"
+    },
+    "maps/medieval_brk/az_ice05.map": {
+     "bytes": 3094,
+     "sha256": "dbca0fea0a986137f9b4a6fbb916cf3de830ba4a60738830cc6e1bd554f561f1"
+    },
+    "maps/medieval_brk/az_kbr1.bsp": {
+     "bytes": 7476,
+     "sha256": "2a2cd33b87f511d4c7fc25a812c632fb07c385b372e89fa900fd0f8ce8146076"
+    },
+    "maps/medieval_brk/az_kbr1.lit": {
+     "bytes": 92,
+     "sha256": "580ff7adf91b63bcd7f35e27059295b0a5fc404468e32e5d5f3323b5a822fb27"
+    },
+    "maps/medieval_brk/az_kbr1.map": {
+     "bytes": 863,
+     "sha256": "3b9d9842f17fb140b23337b452cfc8d49151410640384868a0003bd472dd0d5c"
+    },
+    "maps/medieval_brk/az_kbr1.pts": {
+     "bytes": 178,
+     "sha256": "22cf782552b8a3da946cfa0fa044cffd08f2b0ab50e588c9b68d89a373f026b0"
+    },
+    "maps/medieval_brk/az_kjw1.bsp": {
+     "bytes": 9424,
+     "sha256": "06f271813935ecb90a425d6c943bd53b207fb9d370ec42bb1228af92fe4413d1"
+    },
+    "maps/medieval_brk/az_kjw1.lit": {
+     "bytes": 380,
+     "sha256": "30e6270550b5a78bfaa31df0c6e477d6980eefd380abc2e2aaf7003dbe544f77"
+    },
+    "maps/medieval_brk/az_kjw1.map": {
+     "bytes": 1825,
+     "sha256": "61e8f8f45b2fb0e0766b125bae58b54b36cb45b6d856c7c06814681f52eb91aa"
+    },
+    "maps/medieval_brk/az_kjw1.pts": {
+     "bytes": 120,
+     "sha256": "f7d0f45d90befed57df8dd476bcd10293481eb932925853e3fdbc93a55991a49"
+    },
+    "maps/medieval_brk/az_rtex01.bsp": {
+     "bytes": 97932,
+     "sha256": "ce36fbfdd6f46f5aa7740598689fb2c7de50fa58adda9d4a8a3023ad31194367"
+    },
+    "maps/medieval_brk/az_rtex01.lit": {
+     "bytes": 692,
+     "sha256": "5fe28d309679e9871f14a9c3833184c9ad711fa2bd93adc330a34fd599032a6d"
+    },
+    "maps/medieval_brk/az_rtex01.map": {
+     "bytes": 2875,
+     "sha256": "6cc8f787b54565b3c9dffe9eec20c44d66a68b12fd555bad65bb25f03a2aa7e9"
+    },
+    "maps/medieval_brk/az_wood1.bsp": {
+     "bytes": 7560,
+     "sha256": "373c0b96905055b6b036272c954d7eaf3557d79d62b056ab9a472fb0cd27de83"
+    },
+    "maps/medieval_brk/az_wood1.lit": {
+     "bytes": 176,
+     "sha256": "67ce559200158ce198e5a93a94dd4a440ae607fedc5b3093c288049ce5f50151"
+    },
+    "maps/medieval_brk/az_wood1.map": {
+     "bytes": 950,
+     "sha256": "4fb7eae852ba72528b34d6a0947497eeeab1e1307aa1c4be552628432007c86e"
+    },
+    "maps/medieval_brk/azr1.bsp": {
+     "bytes": 13842,
+     "sha256": "e00518c5ad3beee852a6135184423d4ca985b17b2f1d2cfebc60e82f91582f26"
+    },
+    "maps/medieval_brk/azr1.map": {
+     "bytes": 1193,
+     "sha256": "ef3affe9788b130826f2b1632b5461eaaf15d630587c12c5a875f6042b0ae99c"
+    },
+    "maps/medieval_brk/azr2.bsp": {
+     "bytes": 13571,
+     "sha256": "687097f4773430ca297db9c1d8133b035c8ca1e5d574943a4caa34eef262f003"
+    },
+    "maps/medieval_brk/azr2.map": {
+     "bytes": 1319,
+     "sha256": "22b2084665b2882c976da1dc840a19b151cd44daa524955ddab9ec64e9c3233e"
+    },
+    "maps/medieval_brk/azr3.bsp": {
+     "bytes": 13571,
+     "sha256": "187a6607641c00aa6ee662af52f1b2899d5ca606e469408dd2c94d67dd2ab465"
+    },
+    "maps/medieval_brk/azr3.map": {
+     "bytes": 1338,
+     "sha256": "5e551a8ebefc386b1336e814a44e29ae6781e6da5bc929cb232674853c46a143"
+    },
+    "maps/medieval_brk/booksh1w_brk1.bsp": {
+     "bytes": 23869,
+     "sha256": "dbc342e95245a12598aade308195a3234829225944692c45c8fec792d03f17c3"
+    },
+    "maps/medieval_brk/booksh1w_brk1.map": {
+     "bytes": 793,
+     "sha256": "a9d2fe494267551f3d1638c7963bab47d292be250417f78286b39059af836af5"
+    },
+    "maps/medieval_brk/booksh1w_brk2.bsp": {
+     "bytes": 23663,
+     "sha256": "4b8cd15ae7812d581064800bbcf64cab62c3d5ecfb03c23ff2b498694a0cb708"
+    },
+    "maps/medieval_brk/booksh1w_brk2.map": {
+     "bytes": 661,
+     "sha256": "19c13935f0b045fadd9c739680de7155f0e4d29c86ef3e6950d07f265b1ef1a3"
+    },
+    "maps/medieval_brk/booksh1w_brk3.bsp": {
+     "bytes": 23700,
+     "sha256": "1fc3c7a685f5662779f4c6ad0fb02099396504dcf55eef09474183aff69861c1"
+    },
+    "maps/medieval_brk/booksh1w_brk3.map": {
+     "bytes": 746,
+     "sha256": "bd10960b3af925cf2a33bb0629d1a522de5f54ec05938b36378871fd7de0b9f3"
+    },
+    "maps/medieval_brk/booksh1w_brk5.bsp": {
+     "bytes": 23639,
+     "sha256": "851a02aced76ba77894ba744c5c781ff350a42b93216e095f75938fc95ee39a8"
+    },
+    "maps/medieval_brk/booksh1w_brk5.map": {
+     "bytes": 759,
+     "sha256": "c92ec0ad3d3a5c6588557b5f3c9c000cd1c141a4d9c3b35333d859e75c677568"
+    },
+    "maps/medieval_brk/brick2_4brk1.bsp": {
+     "bytes": 9004,
+     "sha256": "86fb182b011385225d5be8b2a2ba0763286a5a2a5880fdda6fc238d8e6a5212f"
+    },
+    "maps/medieval_brk/brick2_4brk1.map": {
+     "bytes": 1375,
+     "sha256": "208cf3d2a51b0aa4a45cd237786a9303b70a63a85e991a7f8675634bea6295ed"
+    },
+    "maps/medieval_brk/brick2_4brk2.bsp": {
+     "bytes": 7265,
+     "sha256": "151471ef184c02141716225e4403e97a69190bd8a3e9645cf2d52aeb5dce591d"
+    },
+    "maps/medieval_brk/brick2_4brk2.map": {
+     "bytes": 603,
+     "sha256": "cdd5762f851cec464b27e9bfc91c0eab8cb26e69a8b050ac1bd9b0eb662dbf7b"
+    },
+    "maps/medieval_brk/brick2_brk2.bsp": {
+     "bytes": 25323,
+     "sha256": "0d8c4dc3202bcc9f26dfd42ca555b99d0010c63b977cd058646a8e8ad4486eea"
+    },
+    "maps/medieval_brk/brick2_brk2.map": {
+     "bytes": 1378,
+     "sha256": "daeae48ab2f6fca712da2413b65c80c6a944e537571def2d153976b0175d8768"
+    },
+    "maps/medieval_brk/brick2_brk3.bsp": {
+     "bytes": 24310,
+     "sha256": "5f94a5e271bb5b921e4534be8690f005bc258e484cb842a6ead0af9aac29fcfb"
+    },
+    "maps/medieval_brk/brick2_brk3.map": {
+     "bytes": 905,
+     "sha256": "1639469c5fe31540811a8bb95d959844d200102cd19f60d1d5e9c3472477e2d2"
+    },
+    "maps/medieval_brk/brick2_brk4.bsp": {
+     "bytes": 23548,
+     "sha256": "e2049e826c103f2afbb5d0a4b69d45089d0bdcf6bd60646d6ae79c99e9a9a976"
+    },
+    "maps/medieval_brk/brick2_brk4.map": {
+     "bytes": 582,
+     "sha256": "b3528f92f4ecf8099a7bfbf3285f21312c501536b66e02b566a7e38474aa608c"
+    },
+    "maps/medieval_brk/city2_3d1.bsp": {
+     "bytes": 7358,
+     "sha256": "efc80ba0aab1284e2bcec652cc3a2748890c45d6905335f61483eab2851f7c81"
+    },
+    "maps/medieval_brk/city2_3d1.map": {
+     "bytes": 739,
+     "sha256": "ff9c2ebe0034d188443e3a72753d4ecad2a69706a4a06c114f9147f507d10b30"
+    },
+    "maps/medieval_brk/city2_3rd.bsp": {
+     "bytes": 7156,
+     "sha256": "6146e0e5961857308f2ef550213ec647ad810a97359d0946cc07f610e0f03006"
+    },
+    "maps/medieval_brk/city4_2_brk1.bsp": {
+     "bytes": 7435,
+     "sha256": "42a4cbd73804a8458a8369fdbd19ee6b3b4597b18583c242bf77b0122ddc9c1a"
+    },
+    "maps/medieval_brk/city4_2_brk1.map": {
+     "bytes": 648,
+     "sha256": "50b744f4af85aa3c0158ae0330808840710c7ee95c1bda8155cb81b4b247fc74"
+    },
+    "maps/medieval_brk/city4_2_brk2.bsp": {
+     "bytes": 7179,
+     "sha256": "cc2ddcb8877dc1b49ec2c408d6b869a35dd7b6590782525af567905d75a3ada0"
+    },
+    "maps/medieval_brk/city4_2_brk2.map": {
+     "bytes": 520,
+     "sha256": "e9309b8ec24126fd952443ae6bee72df46ba04fb4d0925b33d41c603af9ac5b3"
+    },
+    "maps/medieval_brk/city4_2_brk3.bsp": {
+     "bytes": 10009,
+     "sha256": "7f9a27098101f70090c3aff7fd6731effd2750e8c2b7fdbbb0a9f3146be94045"
+    },
+    "maps/medieval_brk/city4_2_brk3.map": {
+     "bytes": 1575,
+     "sha256": "c352d889a3bed731b7c54e38d7ed35e6fa860d2f6f69eb91319f4043423d7aa8"
+    },
+    "maps/medieval_brk/city6_8brk1.bsp": {
+     "bytes": 7187,
+     "sha256": "bcf4b2815c96308ffc1ab3467ac8b2dd4c25be47d618fd82536ba83bf74a05fc"
+    },
+    "maps/medieval_brk/city6_8brk1.map": {
+     "bytes": 529,
+     "sha256": "2db1be71ce1b1e8bf1e8a5c4c7f2802345aa19c281fd43f2b18d205cbd06bfca"
+    },
+    "maps/medieval_brk/city6_8brk2.bsp": {
+     "bytes": 7298,
+     "sha256": "3b7fd08defa832be1c3f3e40efc6d54d13af6714180be810f6527188f332fbff"
+    },
+    "maps/medieval_brk/city6_8brk2.map": {
+     "bytes": 611,
+     "sha256": "ed29b0773cb700d4b8212f9e28b23edac2d212f469b4a1406538df2b066fcbb2"
+    },
+    "maps/medieval_brk/floor015_brk1.bsp": {
+     "bytes": 12862,
+     "sha256": "5bfae9b09777fad7f26f80b5acc27e187e2259ac5c79ad32ab2a30d154e5889b"
+    },
+    "maps/medieval_brk/floor015_brk1.lit": {
+     "bytes": 179,
+     "sha256": "5d64872b2341768efce6c27686555200246e03d346a2e15089e002d53b1b348f"
+    },
+    "maps/medieval_brk/floor015_brk1.map": {
+     "bytes": 827,
+     "sha256": "08f5b26ee0ebb26416e6a1ed660e197b1ea113a553f5c7a1d26a6070b5cbdac8"
+    },
+    "maps/medieval_brk/floor015_brk2.bsp": {
+     "bytes": 12861,
+     "sha256": "377b50dac34c3789fe8a7bcf6a5b3cedda0f3ba91225135ffc9a2f41abe41e35"
+    },
+    "maps/medieval_brk/floor015_brk2.lit": {
+     "bytes": 188,
+     "sha256": "402bfba12b94cd1b3a40f1052830d4e4fa3b4cb103b196c089f4965e94766bd5"
+    },
+    "maps/medieval_brk/floor015_brk2.map": {
+     "bytes": 828,
+     "sha256": "a45245e0f19cc98f29bcc88c9173118b65058d25ff1c043aaca876353bc67531"
+    },
+    "maps/medieval_brk/floor015_brk3.bsp": {
+     "bytes": 13185,
+     "sha256": "52e2b8d426e479bffc8d518a4d8aa5d5a5dc437dbd761c7074992838ccfd070b"
+    },
+    "maps/medieval_brk/floor015_brk3.lit": {
+     "bytes": 218,
+     "sha256": "dabacc9c3ffdc3bae8c008bedfb683babaca23f6e5b0ca5e35b9c39f9d86f402"
+    },
+    "maps/medieval_brk/floor015_brk3.map": {
+     "bytes": 1078,
+     "sha256": "5235ba02c52ba6dc678f052e4efbad43b9f7d63f858c5f732519f6436246733d"
+    },
+    "maps/medieval_brk/plat_brk.bsp": {
+     "bytes": 59896,
+     "sha256": "367ec651b3cded1ecdf22305a3b48490d3df3078d556d4c7fadfb392ae12ad33"
+    },
+    "maps/medieval_brk/plat_brk.map": {
+     "bytes": 2052,
+     "sha256": "fe52fffba97e8df9acfe4607c9b08d9eb5f4559b44d8c0f6fdbd3af6a0cbf8d6"
+    },
+    "maps/medieval_brk/rock_sw01.bsp": {
+     "bytes": 8843,
+     "sha256": "a3acc4f42ca89efb30d5f9d7ed7c694d59ab6003bd3c665cfa4db480550fd92d"
+    },
+    "maps/medieval_brk/rock_sw01.map": {
+     "bytes": 1371,
+     "sha256": "0e4d621fba3a9806ffdf2bffda89e4d05231513b6f7986d504722d1b99c21a91"
+    },
+    "maps/medieval_brk/rock_sw02.bsp": {
+     "bytes": 9179,
+     "sha256": "4b3d68587a69daa68093d32195a786e8040fed763855acb94f50d02875a8ec44"
+    },
+    "maps/medieval_brk/rock_sw02.map": {
+     "bytes": 1631,
+     "sha256": "82bbf3c701301a80f55619bdac2680d9713432d8fe991838bfb7559830225322"
+    },
+    "maps/medieval_brk/rock_sw03.bsp": {
+     "bytes": 9766,
+     "sha256": "59d2841166f7ecb216df970963b3e425da20566f2fb56a7e5472f4e3c9fcfb24"
+    },
+    "maps/medieval_brk/rock_sw03.map": {
+     "bytes": 1526,
+     "sha256": "300f4c4f56cc9f6425cc8999484e18326555c57b8f53d9f42c36a4345b850d2c"
+    },
+    "maps/medieval_brk/rock_sw04.bsp": {
+     "bytes": 9836,
+     "sha256": "72854269a33665022dee9c30e53e6124bc2bba25ad34d2a3d86302e50ad795c1"
+    },
+    "maps/medieval_brk/rock_sw04.map": {
+     "bytes": 1605,
+     "sha256": "e2b3e6e53c11de10d0de4b7374d43a09be1622766cb3ff60c9e9cec8688747f9"
+    },
+    "maps/medieval_brk/rot_p.bsp": {
+     "bytes": 13554,
+     "sha256": "afcc7dc6512bba89ceec9e10bfa8256ecd043d34c1af57f33a199509500164ff"
+    },
+    "maps/medieval_brk/rot_p.map": {
+     "bytes": 2518,
+     "sha256": "c60e36e827e052cea6ca5c6c2d022b5da051090ee2accf8807f5703ec8acc79a"
+    },
+    "maps/medieval_brk/waa1.bsp": {
+     "bytes": 23869,
+     "sha256": "739aa8d0753e691020013539356d2c2e10b9d0b82c63bcc694080afe33bc585e"
+    },
+    "maps/medieval_brk/waa1.map": {
+     "bytes": 765,
+     "sha256": "f2e7bbba974ffde1e4178be825034e555ca491fffedbf007e62589214af82f0f"
+    },
+    "maps/medieval_brk/wbrick15_brk.bsp": {
+     "bytes": 7969,
+     "sha256": "0dcbd483c300f1be58a216b6d64ea385dd489babdc70868e483fb496c4dd4c38"
+    },
+    "maps/medieval_brk/wbrick15_brk.map": {
+     "bytes": 899,
+     "sha256": "43789ad5bb908aa7fb8e8893db766ce0e479cc547e31aa8de6fe1b4bd6093015"
+    },
+    "maps/medieval_brk/win1ah_brk.bsp": {
+     "bytes": 34981,
+     "sha256": "d549b60245213678c222499299e43654c25f838ed42898a25ec284d933f56b64"
+    },
+    "maps/medieval_brk/win1ah_brk.map": {
+     "bytes": 897,
+     "sha256": "da6859a14f291bef23c990977c0fce7e21ee2c790318cce46e36a8388e87fb39"
+    },
+    "maps/medieval_brk/win1ah_brk2.bsp": {
+     "bytes": 34873,
+     "sha256": "87416124f6e04adaaa5ed9144fa60e048dc03606bc294d89d99295a7c8cb2487"
+    },
+    "maps/medieval_brk/win1ah_brk2.map": {
+     "bytes": 901,
+     "sha256": "5d9a1aefeca5acfdbb25cad5489f5bcb41c89f3c9b92a3d305da0f462c439ec2"
+    },
+    "maps/medieval_brk/wiz14_brk1.bsp": {
+     "bytes": 8961,
+     "sha256": "cb45306588dc69d44422d475c0481f67a76638fe2502c16c28a8f87fa43f6787"
+    },
+    "maps/medieval_brk/wiz14_brk1.map": {
+     "bytes": 1262,
+     "sha256": "46200a77c401035e45d339d8106263e7210ed66e373be74f65687c5d1eb83124"
+    },
+    "maps/medieval_brk/wiz14_brk2.bsp": {
+     "bytes": 7338,
+     "sha256": "871684ecf4507da9773ca5568ccdd0a27173d2f35922b379a19f95e9252a777f"
+    },
+    "maps/medieval_brk/wiz14_brk2.map": {
+     "bytes": 652,
+     "sha256": "97a58529ea21e8127050b0f1e3305e4616b1970232e6517aa652061f49ffc9e0"
+    },
+    "maps/medieval_brk/ws14_brk1.bsp": {
+     "bytes": 7987,
+     "sha256": "ee96dcf614d940d9f887035be0781ad941fc5f76a0f0e553ec3592ae00af1794"
+    },
+    "maps/medieval_brk/ws14_brk1.map": {
+     "bytes": 948,
+     "sha256": "022d130b741c8976f529288f6030fabd2040991efd8bb0a6542dc1508c0b061c"
+    },
+    "maps/medieval_brk/ws14_brk2.bsp": {
+     "bytes": 9003,
+     "sha256": "6aa46294d8fffe55db6f2e6a9d30341fe07a9252b0066ff575c692d0b149f7af"
+    },
+    "maps/medieval_brk/ws14_brk2.map": {
+     "bytes": 1375,
+     "sha256": "8f175f2e3ac8a760fcb7d25da5a30cea149b55349fa0e0d20b2a8c0b080aa5b0"
+    },
+    "maps/medieval_brk/ws14_brk3.bsp": {
+     "bytes": 8944,
+     "sha256": "282944bfbd49b6dcc0aa0d67253432d88c63212ea564a9c6b8909a9b96f8946a"
+    },
+    "maps/medieval_brk/ws14_brk3.map": {
+     "bytes": 1282,
+     "sha256": "6ecd83ba25e15f363f271078c73f6c460babf95ea63340a855dfa182ec47e4b4"
+    },
+    "maps/rtex_brk/022a.bsp": {
+     "bytes": 17448,
+     "sha256": "3557f9518ca0982c871dd344ea5069e5128645029ea428de26ef991881170a59"
+    },
+    "maps/rtex_brk/022a.map": {
+     "bytes": 691,
+     "sha256": "50e0375bf596265b893e56996dbddfad26af2e50bb9af473dc2115e18b11dc02"
+    },
+    "maps/rtex_brk/022b.bsp": {
+     "bytes": 17608,
+     "sha256": "083fdbd34b34b47c5dd9dd58f4e3e0fa3debbedd554db4ce81791033349451fa"
+    },
+    "maps/rtex_brk/022b.map": {
+     "bytes": 825,
+     "sha256": "26d8800f4cfb0706ad363e958846d87755b4871792d1ac1f00b5b51fd7550777"
+    },
+    "maps/rtex_brk/022c.bsp": {
+     "bytes": 17820,
+     "sha256": "8c6b933d2cd323eba623727226ea6cb1f968e0401093f93d229d229a7a5b225d"
+    },
+    "maps/rtex_brk/022c.map": {
+     "bytes": 894,
+     "sha256": "835d4d09490552859dc79ad527bcd08af8afedfa7a863148c62f2f58742e9014"
+    },
+    "maps/rtex_brk/022d.bsp": {
+     "bytes": 17592,
+     "sha256": "0580ec01633972b2fff28c5d4b9a71766d3f1ed6fae387dff34ca691ff829e38"
+    },
+    "maps/rtex_brk/022d.map": {
+     "bytes": 784,
+     "sha256": "238fc24be385d3994586c34555e74ecbb7677aa7567bbf317947276c14b62107"
+    },
+    "maps/rtex_brk/330a.bsp": {
+     "bytes": 7928,
+     "sha256": "a446db4116b8c33f46745cf815ba9309e69591d919838006c81a9b0a5b00c7d4"
+    },
+    "maps/rtex_brk/330a.map": {
+     "bytes": 691,
+     "sha256": "964103ee6422dd3b815472c9f29126741e06517623dad050fba18a9867451903"
+    },
+    "maps/rtex_brk/330b.bsp": {
+     "bytes": 8088,
+     "sha256": "727d22fad028bac645a53ac5a425618e30575735958496b7a1ac86cfbc562e1a"
+    },
+    "maps/rtex_brk/330b.map": {
+     "bytes": 825,
+     "sha256": "807bdb97ab58709fd96cfa0e7b65cb5d377257b862eef2673606901d70b84108"
+    },
+    "maps/rtex_brk/330c.bsp": {
+     "bytes": 8300,
+     "sha256": "b25471a1f0e7fdd066dda47860ae956db2b2c4758a426b39b8a82e6b4c6d1b72"
+    },
+    "maps/rtex_brk/330c.map": {
+     "bytes": 894,
+     "sha256": "13241951b0d3cd61a71e0fe80071a1df65e369eba44aabdf3401f3ba5aa55a7f"
+    },
+    "maps/rtex_brk/330d.bsp": {
+     "bytes": 8072,
+     "sha256": "8f83245e973c42e9908b6215c5effc0f0581d654e5e8e67a6e77493f79de3e6d"
+    },
+    "maps/rtex_brk/330d.map": {
+     "bytes": 784,
+     "sha256": "f0e46c1efc3d5a814675f5760a33a2e6bc4163974ff64a4c1f88ab70c50fbb68"
+    },
+    "maps/rtex_brk/340a.bsp": {
+     "bytes": 13368,
+     "sha256": "e8a605fdff44ef59b4657a43a67cfb24d2d62f150b210a0761f69ed5f559215c"
+    },
+    "maps/rtex_brk/340a.map": {
+     "bytes": 691,
+     "sha256": "3678f5058497a6067c7ffb4d452e706af588e0aedfd30bfa2d43f1902333e7ec"
+    },
+    "maps/rtex_brk/340b.bsp": {
+     "bytes": 13528,
+     "sha256": "d92cc6afb7ae74965a8bb2a753909e2dc6c064b5fb2c9c463c95123531ba337d"
+    },
+    "maps/rtex_brk/340b.map": {
+     "bytes": 825,
+     "sha256": "29f243aa1c347358e34383f4ffb2d129f710829022524237585041c7840a02cb"
+    },
+    "maps/rtex_brk/340c.bsp": {
+     "bytes": 13740,
+     "sha256": "882a110b1a7e26481e5dd37858d5229c0273bc98ab8a2ab59f318e2b76080fac"
+    },
+    "maps/rtex_brk/340c.map": {
+     "bytes": 894,
+     "sha256": "069e17115ae35cf0fdaa9ceb8b3a67065360d4fc03f91036ba453b6b6745d77b"
+    },
+    "maps/rtex_brk/340d.bsp": {
+     "bytes": 13512,
+     "sha256": "96a6133331679ad8eb75d8581e8be12c6822d2048c18a1e704281a6e4cc0737c"
+    },
+    "maps/rtex_brk/340d.map": {
+     "bytes": 784,
+     "sha256": "b8197ea047f14d175e5b9234dcc9b625f04124b175bb0fd80da7ceffe056b00c"
+    },
+    "maps/rtex_brk/413ra.bsp": {
+     "bytes": 7972,
+     "sha256": "a3cc5962750f55c398dfaf53cb4d8394f1100c752ca9797f053ec2710acd995d"
+    },
+    "maps/rtex_brk/413ra.map": {
+     "bytes": 769,
+     "sha256": "b0a3052bfb352684f97fb7bca8fdc3d7b135ae5e3fca491d190d09423836da46"
+    },
+    "maps/rtex_brk/413rb.bsp": {
+     "bytes": 9204,
+     "sha256": "e36bf5d23b3dcaf96075b1b441ebf6424da62cb2d04ff14f04da4e9956711094"
+    },
+    "maps/rtex_brk/413rb.map": {
+     "bytes": 1682,
+     "sha256": "6be0d7cbae08ffccbb1ea9dedf03bc6f8c9b6be93c6c27d5e964e3b4f4538a52"
+    },
+    "maps/rtex_brk/413rc.bsp": {
+     "bytes": 10340,
+     "sha256": "4d57717cc2fb9db560e724df4937f7c496d77d1df6d70e6619ba686338152e79"
+    },
+    "maps/rtex_brk/413rc.map": {
+     "bytes": 1909,
+     "sha256": "71c9812cdf0647bb89fcd2a911a664b7a8dea382b0fe58e4e834a24354a23b38"
+    },
+    "maps/rtex_brk/413rd.bsp": {
+     "bytes": 13356,
+     "sha256": "573149ae9d1f687b0ddc0a702116357b4556e20ae8d62b7b32b3c5b41f227088"
+    },
+    "maps/rtex_brk/413rd.map": {
+     "bytes": 3217,
+     "sha256": "f40b142b102fefefdaf6594c2d1410f370fd8491a009ecfc6dada46c55f262d2"
+    },
+    "maps/rtex_brk/wood3_1a.bsp": {
+     "bytes": 7552,
+     "sha256": "8884a645d6193052aeba7043c139b3eb4cf8ace2e62ed6e9181d51f90cae4806"
+    },
+    "maps/rtex_brk/wood3_1a.map": {
+     "bytes": 1007,
+     "sha256": "5322a91b2aad8cf58095fb513e58317d738469c168b78f770307c3ece580fbf9"
+    },
+    "maps/rtex_brk/wood3_1b.bsp": {
+     "bytes": 7096,
+     "sha256": "9d7d44ba1c929fae0bf702ec834394c9da23c199cf742f9c7021bec00f33c056"
+    },
+    "maps/rtex_brk/wood3_1b.map": {
+     "bytes": 516,
+     "sha256": "158e6d102aaeb8dd7add01eecd7e05b4c711a20d7d7134d1bdce417fbe1b2072"
+    },
+    "maps/rtex_brk/wood3_1c.bsp": {
+     "bytes": 7144,
+     "sha256": "f292d3b9cabaa0332d7c3f6abd66420ad9ef80217f32223bd67315fa8967d908"
+    },
+    "maps/rtex_brk/wood3_1c.map": {
+     "bytes": 517,
+     "sha256": "f853df961fdcebd569943bad596dceb464c6317e44f3d77ce4def17295b37c00"
+    },
+    "maps/rtex_brk/wood3_1d.bsp": {
+     "bytes": 7804,
+     "sha256": "8e6ffa915db57d7cb958c7210e0abc35ff552713a5aa19a1ccb531a7d45bd504"
+    },
+    "maps/rtex_brk/wood3_1d.map": {
+     "bytes": 883,
+     "sha256": "d370c44a047023843caf08a41098bd3852526b614ae074c228cc6ad4e76d4aa9"
+    },
+    "maps/speedbz_brk/crate_r1.bsp": {
+     "bytes": 29110,
+     "sha256": "5dd3afab4a3ad5cf4466e272324e4afad5075ca2e662cc8b1932e277a2db73a2"
+    },
+    "maps/speedbz_brk/crate_r1.map": {
+     "bytes": 664,
+     "sha256": "ee7ce39ec0650d3cbde924b99efc91ba884778db11a961037d4493bf587fa33e"
+    },
+    "maps/speedbz_brk/door1.bsp": {
+     "bytes": 31200,
+     "sha256": "6df38f4db1bfd725dd7384b45e38d070fd4b514139a8e649aea3e640377a073d"
+    },
+    "maps/speedbz_brk/door1.map": {
+     "bytes": 1419,
+     "sha256": "17bf053113ed5cc14e99ef2880e5478ebace7d59de4797fc6cbfe3586d688494"
+    },
+    "maps/speedbz_brk/door2.bsp": {
+     "bytes": 29732,
+     "sha256": "8f58cd2f2e76fbb36a007ed7986671092b880d01dfcb9a087e93cd11240d2baf"
+    },
+    "maps/speedbz_brk/door2.map": {
+     "bytes": 726,
+     "sha256": "3fac703869c9ebb4eabfbe8f180fec752812eea0aa68c5f5574c5cf2496c3931"
+    },
+    "maps/speedbz_brk/door3.bsp": {
+     "bytes": 26516,
+     "sha256": "77f003456362f2b7ca424491485ad2d20b162598527765e5e78628ee7e6ad172"
+    },
+    "maps/speedbz_brk/door3.map": {
+     "bytes": 1247,
+     "sha256": "e56d45f63dcb0d86a0039ea443109d8c8d116fa18331a2328e90f74a891ab9d2"
+    },
+    "maps/speedbz_brk/door4.bsp": {
+     "bytes": 24020,
+     "sha256": "930881a45210317dd3550b04b20d2446cf92c8c613d4aa295a5c77810b77b3f2"
+    },
+    "maps/speedbz_brk/door4.map": {
+     "bytes": 611,
+     "sha256": "f4a68b8f4d081ff0febc276c51b5484c96e4b044eab6e20069ae84ac7c5a0ac2"
+    },
+    "maps/speedbz_brk/rock1.bsp": {
+     "bytes": 89984,
+     "sha256": "c87f60de56cfd5a932cf33d23d6e83b0fd16518001dd8fa7be84da9c3176b5b5"
+    },
+    "maps/speedbz_brk/rock1.map": {
+     "bytes": 980,
+     "sha256": "29e5bd54316e6f325d71a33051ee3a5b6c213f927222931bb35cdcc1820cc87a"
+    },
+    "maps/speedbz_brk/rock2.bsp": {
+     "bytes": 90012,
+     "sha256": "443e51be48da3594545d347ee056f3973b0360268eb6c03653d7b3af622c553e"
+    },
+    "maps/speedbz_brk/rock2.map": {
+     "bytes": 991,
+     "sha256": "40b6b9f23f788c08f362f2336048bbe1260f181d7e76de2591ea7aefa03f4b09"
+    },
+    "maps/speedbz_brk/spdcrate_r1.bsp": {
+     "bytes": 12844,
+     "sha256": "30fa3f373efefcf7db68a9acbb0eb282a0b2ea54d26db92eaaad444035462791"
+    },
+    "maps/speedbz_brk/spdcrate_r1.map": {
+     "bytes": 807,
+     "sha256": "c18735f305c2496a4801ed1a5bc1297f2d72e55824f7222a265ac5788552fc68"
+    },
+    "maps/speedbz_brk/speedbzvent1.bsp": {
+     "bytes": 15248,
+     "sha256": "bcfe36bf57cb82e5188b86af3e5bf568038ef5a50d0ebce43024155b7276008d"
+    },
+    "maps/speedbz_brk/speedbzvent1.map": {
+     "bytes": 2053,
+     "sha256": "7d447bc22e440e685648d8b39e051bce7c1b847e3f777ac092ab1104b79242a1"
+    },
+    "maps/speedbz_brk/speedbzvent2.bsp": {
+     "bytes": 14104,
+     "sha256": "8fb1e76688e27767ce77c5d7b3486048adfa284e011b91007730d424eb55ca61"
+    },
+    "maps/speedbz_brk/speedbzvent2.map": {
+     "bytes": 1381,
+     "sha256": "44cfc0509c9455865df334c1ca5bdfca49cf0fae4dab372cac99e6eeb76b438c"
+    }
+   },
    "sha256": "6ca3099935998e8678b388cd5bb1e1c601f1035da378141b6e800303b8737f02",
    "timestamp": "2020-11-22T11:34:38.000Z"
   },
   "pak2.pak": {
    "bytes": 13867395,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 94990,
+     "sha256": "e790b189b1df23f116097b45f5ed391fd210319ecfa000d029b367a7c3d32ab5"
+    },
+    "maps/bmodels/az_chain1.bsp": {
+     "bytes": 219668,
+     "sha256": "4d2648c6dd850b04d48e9631ad02756ecf78d85f56810ff7b9db131a6fe641a3"
+    },
+    "maps/bmodels/az_chain1.lit": {
+     "bytes": 33272,
+     "sha256": "1daab5bb58dbf2c73968dc9db26cf0b0bd78652d491788d0a6124aaa9a9b6f4a"
+    },
+    "maps/bmodels/az_chain1.map": {
+     "bytes": 96430,
+     "sha256": "2b6c77f844eaf5a371b36c13cf512a24d8cd39095cdc04eddd64cd571060d098"
+    },
+    "maps/bmodels/az_chain2.bsp": {
+     "bytes": 333820,
+     "sha256": "746e38bbb4cebb63ac3344e944f24b874b9fd3ed584017bb599e027508cc6187"
+    },
+    "maps/bmodels/az_chain2.lit": {
+     "bytes": 22130,
+     "sha256": "c6ebc72f8dcaa06422eaf71e08771f76105ddd39c3ee6784d40083df67d1cf32"
+    },
+    "maps/bmodels/az_chain2.map": {
+     "bytes": 148314,
+     "sha256": "e9cb3cddd08835aed7b1eed8867a67b06fee9db20dd7584830b8918d4af169ea"
+    },
+    "maps/bmodels/az_chain3.bsp": {
+     "bytes": 308800,
+     "sha256": "6b78b5a83f2f71a316e85086e12b7a1f66abaf28b02a53076433e3b2b3a20fee"
+    },
+    "maps/bmodels/az_chain3.lit": {
+     "bytes": 20684,
+     "sha256": "28870bf7c7f011206290fe69c7b6e2501c27fba21bea2ae6767e8d85a4ff56e7"
+    },
+    "maps/bmodels/az_chain3.map": {
+     "bytes": 110405,
+     "sha256": "64eee084713fdb7da2ec9f9dbc7c482930d9a871d86fd0912d32ddf52063b1aa"
+    },
+    "maps/bmodels/m_bchains1.bsp": {
+     "bytes": 74963,
+     "sha256": "73beb2dc0b953e096e69a4e049af380e99c98ce1872b4da00c858be36d4e973a"
+    },
+    "maps/bmodels/m_bchains1.map": {
+     "bytes": 43470,
+     "sha256": "ecd781a6601c6fca262909cb2e116a222de2e5aa5417dd36d4475d5c433459af"
+    },
+    "maps/bmodels/m_bchains2.bsp": {
+     "bytes": 83651,
+     "sha256": "e23fad6717790c08e661748398754e60944527eb6e48c0f2c0ffbdba73cf95db"
+    },
+    "maps/bmodels/m_bchains2.map": {
+     "bytes": 42484,
+     "sha256": "e92865750499de9117e5bf19719052109179ebcc37ddbd40f2d91d914b86fa63"
+    },
+    "maps/bmodels/m_bridge1.bsp": {
+     "bytes": 431144,
+     "sha256": "ac4d490408f7ad9068a09c4c89f82a65b8573bc4ba810fe5f16418b1d2684f66"
+    },
+    "maps/bmodels/m_bridge1.lit": {
+     "bytes": 47240,
+     "sha256": "30601eb0d533bbe0f72631b77630c3922a46f34b38687aa184b7776e48e63164"
+    },
+    "maps/bmodels/m_bridge1.map": {
+     "bytes": 120280,
+     "sha256": "3ddec67bb95d788b2fecb0e4c6d09781a6a27ba79d322a637f3a03e84a8f6ac7"
+    },
+    "maps/bmodels/m_bridge2.bsp": {
+     "bytes": 201392,
+     "sha256": "4fec9b73e50ba0608d2b5f2fd5c4957324c4cb609becf3be979aedf644281845"
+    },
+    "maps/bmodels/m_bridge2.lit": {
+     "bytes": 21902,
+     "sha256": "c1fa88042c3fde27bd608d3829c8c4a142e70617087970ec7535d48847ac435a"
+    },
+    "maps/bmodels/m_bridge2.map": {
+     "bytes": 52004,
+     "sha256": "58943dc439d4d4c8e65773c12e361c3336488a94f0a53a54c06366675517b850"
+    },
+    "maps/bmodels/m_bridge2b.bsp": {
+     "bytes": 201398,
+     "sha256": "096dcacf528d2784b79a4c0dd19c445102778f2a053fde3a2a43540a4a621c73"
+    },
+    "maps/bmodels/m_bridge2b.lit": {
+     "bytes": 21902,
+     "sha256": "1c7bdad93866cabb97e4565bf41d2b8a8d4c8237e11b0965fd05fc954b6c2c64"
+    },
+    "maps/bmodels/m_bridge2b.map": {
+     "bytes": 52268,
+     "sha256": "d361d0c3dcfec2ae5d109075bf437d013762328ee48b8fc25f779267d7b1bfb1"
+    },
+    "maps/bmodels/m_bridge3.bsp": {
+     "bytes": 309343,
+     "sha256": "12d2199af263464d48455c2e5cd7bf2abf2085841fbc7e027a4cc96b04eec2d8"
+    },
+    "maps/bmodels/m_bridge3.lit": {
+     "bytes": 46964,
+     "sha256": "b783061b14bb4caf3cf9df9a6b8be9ea1d2a367339fa09ffe01506022b21a4c5"
+    },
+    "maps/bmodels/m_bridge3.map": {
+     "bytes": 138104,
+     "sha256": "33c8835d256fd00e65da818c4d43b86033bb8104897712b824014a035c2628e0"
+    },
+    "maps/bmodels/m_chains1.bsp": {
+     "bytes": 249145,
+     "sha256": "1f51d881982d8602c0da29c1f105ab07a41977bdab4fbf4598922563373f4a98"
+    },
+    "maps/bmodels/m_chains1.map": {
+     "bytes": 170858,
+     "sha256": "e1855a52ab0ae70c382876eb74fcafe5a065fefeb2e49a6956184637b9edc1bd"
+    },
+    "maps/bmodels/m_chains2.bsp": {
+     "bytes": 134457,
+     "sha256": "57a765e0ec315eca93927ad64e11b9b3ec8adae0c405de55d86c30b30ef51e5a"
+    },
+    "maps/bmodels/m_chains2.lit": {
+     "bytes": 15698,
+     "sha256": "c858c4c47488df5cac3ed19736c1aee29f4c7add0dfb45deeb7416c4c7af1f21"
+    },
+    "maps/bmodels/m_chains2.map": {
+     "bytes": 60423,
+     "sha256": "575ae8d717a2352ac8726b3bc0f11f6e0a83f548dd471a544a62f519bb71f692"
+    },
+    "maps/bmodels/m_chains2l.bsp": {
+     "bytes": 156552,
+     "sha256": "ff04a994c83f27104d6ef126ef2d08ce894ebe0a812c49f0d2ae79ce8808e8b9"
+    },
+    "maps/bmodels/m_chains2l.lit": {
+     "bytes": 15698,
+     "sha256": "9ebbd1a675e167d9a3be233cd65654728f2f1e0259dee00f55e3da02802abfa2"
+    },
+    "maps/bmodels/m_chains2l.map": {
+     "bytes": 61112,
+     "sha256": "346320204a3413bd6654018e37e42c442c21d88e15da513395c73e6daee26bed"
+    },
+    "maps/bmodels/m_chains2p.bsp": {
+     "bytes": 156555,
+     "sha256": "f0778b1608dbb058f1f492848ae3b64f66be0fef54e32bddfd6fe09f7b0e7a74"
+    },
+    "maps/bmodels/m_chains2p.lit": {
+     "bytes": 15704,
+     "sha256": "d2e7187908b4d3823091a9d69cce5ac807507372132b4162e48a6b027ecad53a"
+    },
+    "maps/bmodels/m_chains2p.map": {
+     "bytes": 61117,
+     "sha256": "7d1acdf4240cd91b158bbc23dfab846388efa7d20431f5a9c8dba8ab421102ff"
+    },
+    "maps/bmodels/m_chains2r.bsp": {
+     "bytes": 222620,
+     "sha256": "0e1ad04fd73c4bc183331471a3406665660fd8f030d14404b7c43b31309118e0"
+    },
+    "maps/bmodels/m_chains2r.lit": {
+     "bytes": 17552,
+     "sha256": "605d297ff2ece6796c064e3dd47e1c48e4fdc87324f059f2c1721e369de23a97"
+    },
+    "maps/bmodels/m_chains2r.map": {
+     "bytes": 61788,
+     "sha256": "749cc23346335d05a53b3399f49adb157fe29fe24512a65d3ab976bc811b5818"
+    },
+    "maps/bmodels/m_chains2rl.bsp": {
+     "bytes": 151968,
+     "sha256": "653185afe2384bf68c0e6d35bdd3404196404243a1b8d16cb730de9f7a45b4b0"
+    },
+    "maps/bmodels/m_chains2rl.lit": {
+     "bytes": 17552,
+     "sha256": "ef313b8c77329539ca8bbe6831e7d5b372e4e3f3cc807e6b66901b53f83d82d4"
+    },
+    "maps/bmodels/m_chains2rl.map": {
+     "bytes": 62332,
+     "sha256": "f5961359ef0867c6ecd501231f63912bf4066bb4d65685021efcd0d51d637f95"
+    },
+    "maps/bmodels/m_chains3.bsp": {
+     "bytes": 121996,
+     "sha256": "535075d6549167b5bf61ae91abf2c407ee009e64aa4222be35692478151feab1"
+    },
+    "maps/bmodels/m_chains3.map": {
+     "bytes": 57540,
+     "sha256": "08f7d97d9e8cd45c353d1141905c93d3327d8f77984790d9e952bd91a5247803"
+    },
+    "maps/bmodels/m_chains4.bsp": {
+     "bytes": 203735,
+     "sha256": "2840e2b604d571081a2b13ba2d340f596123b53213aaec8cd695e7a4d668e774"
+    },
+    "maps/bmodels/m_chains4.map": {
+     "bytes": 113061,
+     "sha256": "6727d20079382f7f2a76391d72e6b6bc3136cc6396ef4661b679f5c8f82d8427"
+    },
+    "maps/bmodels/m_chains4p.bsp": {
+     "bytes": 205127,
+     "sha256": "20183038acde1a46c9fae81e86837f876dc6e0bb7cc7a556457d4162264d7358"
+    },
+    "maps/bmodels/m_chains4p.lit": {
+     "bytes": 35897,
+     "sha256": "0dfb9177bd73b903703f0f4630c4941467a452ee676d568e7f32b2099699659d"
+    },
+    "maps/bmodels/m_chains4p.map": {
+     "bytes": 112283,
+     "sha256": "09d773ef730e9b4d81cdf23f4ac3b0efcb365771569638e7f5574407c5560146"
+    },
+    "maps/bmodels/m_chains5.bsp": {
+     "bytes": 94806,
+     "sha256": "04c40fce5016a3d26092812be589344740b29be788921f8ce354461d77943817"
+    },
+    "maps/bmodels/m_chains5.map": {
+     "bytes": 44835,
+     "sha256": "1e897fc203a12a480c1d3dfc13bf7653a06edb8132f98a3fedae50614c3ebb34"
+    },
+    "maps/bmodels/m_chains5l.bsp": {
+     "bytes": 117061,
+     "sha256": "f01c9c1e6f87c0588be0df3f8768f563acea6735451efa41366aa0acb63851db"
+    },
+    "maps/bmodels/m_chains5l.map": {
+     "bytes": 45411,
+     "sha256": "64691e385435777a920358775cb18e7ac6ee5290a34488103753a338500b6db5"
+    },
+    "maps/bmodels/m_chains5p.bsp": {
+     "bytes": 117214,
+     "sha256": "555df3c945155f7b820fde49c3e37d114f3c52bb63c4edb647dbc19161cb13d5"
+    },
+    "maps/bmodels/m_chains5p.lit": {
+     "bytes": 9152,
+     "sha256": "f78aaec615854b6382b6802298f42ac42dcdfdfb9c638b417257876fa83200d9"
+    },
+    "maps/bmodels/m_chains5p.map": {
+     "bytes": 45566,
+     "sha256": "1969841b81be135b7cb383f84bf7d38694d012b35b17ef3e2c630afbf5d6e64d"
+    },
+    "maps/bmodels/m_thanshelf.bsp": {
+     "bytes": 140335,
+     "sha256": "8319f2ba87d5a8ed864941fe9c7341744476be658ce211aaafc1ba0747afeac4"
+    },
+    "maps/bmodels/m_thanshelf.lit": {
+     "bytes": 3134,
+     "sha256": "04fd93ccf6b864bd9226faa29db923bc093200ed3f4fc8a8f6cce29b324a9743"
+    },
+    "maps/bmodels/m_thanshelf.map": {
+     "bytes": 10306,
+     "sha256": "811e75bc34627545ff7513dc658e937195b98b7839bad409bf21da4975fb7e03"
+    },
+    "maps/bmodels/misc_radar.map": {
+     "bytes": 5314,
+     "sha256": "7ca088f70d4421b994f1852dd17de1427a2b6401b19d8f464ecf2024f5025418"
+    },
+    "maps/bmodels/sep_chain2.bsp": {
+     "bytes": 130276,
+     "sha256": "eff6d1868abd6355f4858f41657262ebb87fa9093579eb8abe8ac6f8c8880ee6"
+    },
+    "maps/bmodels/sep_chain2.lit": {
+     "bytes": 15716,
+     "sha256": "311947b14d5363ccc34fd6e32205100b612c8a77c66196dc616192b011375b59"
+    },
+    "maps/bmodels/sep_chain2.map": {
+     "bytes": 80569,
+     "sha256": "7d86dc46adc6a01b96b811021484c1e6cbfb61424f1037be59525d6f1ff2c420"
+    },
+    "maps/bmodels/sep_chain3.bsp": {
+     "bytes": 80956,
+     "sha256": "8a811a3fc8f85373d64fb3840bda3a3af63a138498bc051ddb2b0d1e0cfa9e88"
+    },
+    "maps/bmodels/sep_chain3.lit": {
+     "bytes": 10802,
+     "sha256": "50d0f90c43a132a5cb360cbb25521040632f07726c6ccfb482d3740ec940ad05"
+    },
+    "maps/bmodels/sep_chain3.map": {
+     "bytes": 41124,
+     "sha256": "ef40d6b17d8b9fc880e4a8180336554f37dabfbc8a30b78c485793aaa5dd753b"
+    },
+    "my_progs/ai_ammoresist.qc": {
+     "bytes": 7444,
+     "sha256": "d530fec92f23ed0c3d09560abb9a89bdc160ce1aefdfbe4f4771f9897ae3fc4d"
+    },
+    "my_progs/ai_checkattack.qc": {
+     "bytes": 106456,
+     "sha256": "7971ca5a87666c89b56ab0fcc102e6f551f3cd3b03bdfc0bfb73f5f8d5aed7fb"
+    },
+    "my_progs/ai_combat.qc": {
+     "bytes": 24324,
+     "sha256": "30c07395259db46836e544a68a37527f107e9010e4d64e937476ceafa58c82b8"
+    },
+    "my_progs/ai_enemytarget.qc": {
+     "bytes": 8409,
+     "sha256": "f4b0a35306d50e71fd9043ae949a421158ee9fcc4e311baf7b8fa2d345c4d46e"
+    },
+    "my_progs/ai_explosion.qc": {
+     "bytes": 12162,
+     "sha256": "7df941a7cf93b814ae9d90f646a5b0243a51db67872f621df73d43c6000ba3ab"
+    },
+    "my_progs/ai_gibs.qc": {
+     "bytes": 32373,
+     "sha256": "65e202300882ba8f0c980f65820b2d2e0bd06846073168f4bd7e37f2357f47d4"
+    },
+    "my_progs/ai_hazards.qc": {
+     "bytes": 26832,
+     "sha256": "81aace80121408f64369bc2bbfd5654650276ddd75217333d2a52364415acaa5"
+    },
+    "my_progs/ai_minions.qc": {
+     "bytes": 10236,
+     "sha256": "3e7bd34dfe0e73a11e6907d5ac69cb609eee19dff533689ea7c8eabe52500136"
+    },
+    "my_progs/ai_passive.qc": {
+     "bytes": 8224,
+     "sha256": "44473544d0da0dc778c2800a16172ab49b548286b604c9d6361f4bc4cfc1f076"
+    },
+    "my_progs/ai_pathcorner.qc": {
+     "bytes": 20921,
+     "sha256": "b3d6ed2434e0b995da51a71715647096e36e02d8cf920e18e024f920ed69238a"
+    },
+    "my_progs/ai_projectiles.qc": {
+     "bytes": 86253,
+     "sha256": "d0885ed945602af45d7db1d98be5938412cd750154ed06710b6b781b6c49abc3"
+    },
+    "my_progs/ai_states.qc": {
+     "bytes": 7480,
+     "sha256": "76fae861132b0e50006ef88ea94a953e718b661defad2ea58a4ecad5cab92dee"
+    },
+    "my_progs/ai_subs.qc": {
+     "bytes": 51485,
+     "sha256": "41a23217543056b1ea447fcf2e0dc2c06a87bdf70dc3f6f699454d7c3c900377"
+    },
+    "my_progs/ai_tether.qc": {
+     "bytes": 6470,
+     "sha256": "2229c0ea1b76e45f5707a3eca9e7626e33f8ea91d6b292da63c81723e1ae8521"
+    },
+    "my_progs/breakable.qc": {
+     "bytes": 79687,
+     "sha256": "754831599eec85a774501d9fd0a1ec7d5722ea6a6e01655b5ad74988145045af"
+    },
+    "my_progs/chaosmode.qc": {
+     "bytes": 81481,
+     "sha256": "01561dc4f1949716eba4d08f83efe27b71add80f923c1e2d89194c238772a646"
+    },
+    "my_progs/client.qc": {
+     "bytes": 70441,
+     "sha256": "00e2d4aff96ea28b0532ab0b03de0a8cdcf15750164ec82bdc8f43b9f2347447"
+    },
+    "my_progs/client_advinfo.qc": {
+     "bytes": 59677,
+     "sha256": "87aaca8bfd15935e1cd29a807bf77a2779d95418af631a6b456c6605710694fe"
+    },
+    "my_progs/client_camera.qc": {
+     "bytes": 13007,
+     "sha256": "ff4748b04c15d9a3b44dd8069f9347c12487ef353d5401a13542166576097889"
+    },
+    "my_progs/client_cshift.qc": {
+     "bytes": 725,
+     "sha256": "da1e321fe01bae486ffcdd987a942a4b0d5b2f603efb663d52c55e882f129685"
+    },
+    "my_progs/client_debuff.qc": {
+     "bytes": 15761,
+     "sha256": "0e0c9123697241ab3a366dbc46fcb90b8553b65c94cffe1442254a74a2753efd"
+    },
+    "my_progs/client_evilmode.qc": {
+     "bytes": 6982,
+     "sha256": "2cfa3bbeb36ab623c3bb137028ec5f549a2e5d2198fa2ab7fd8a445e14f4fc10"
+    },
+    "my_progs/client_ghook.qc": {
+     "bytes": 51884,
+     "sha256": "43d071195a70caa66b57cca1778679d772478fd1f71cbad7ee267e254e79a29a"
+    },
+    "my_progs/client_info.qc": {
+     "bytes": 13693,
+     "sha256": "55653ddc2b9f3cf2ca3cf1b0afdc4c1685baf1ab3c3830eb9f8b1b2d51b3ff31"
+    },
+    "my_progs/client_mapvar.qc": {
+     "bytes": 13177,
+     "sha256": "c692fa41644e6d21c945493dd891af945a072a4b39e687d1b59c86d14ee804a0"
+    },
+    "my_progs/client_power.qc": {
+     "bytes": 20157,
+     "sha256": "0309073577003ae832b259ede75ba53c49bd89985b08d98000d03e1a44893705"
+    },
+    "my_progs/csqc_defs.qc": {
+     "bytes": 21072,
+     "sha256": "eddc5f194845e78a1633807d32b1da4425bdbe7bcce193e3868bc3995e2dee9b"
+    },
+    "my_progs/csqc_defsclient.qc": {
+     "bytes": 35002,
+     "sha256": "b6674acae135dfbc5e3dbb147e69acdc6b3564b766792359bed3e4eb800705e9"
+    },
+    "my_progs/csqc_hudad.qc": {
+     "bytes": 104391,
+     "sha256": "1ca012e489dc5f6026bdae469f411b5bb25afa00e00d5169cbd35b578a7ad9f2"
+    },
+    "my_progs/csqc_hudvanilla.qc": {
+     "bytes": 37074,
+     "sha256": "c5caa6ba176185c05903d383f3ae41907129d859419a0c0bf909b0e8d3e8af5a"
+    },
+    "my_progs/csqc_progs.src": {
+     "bytes": 113,
+     "sha256": "e383fc0920e9676d92e0be81d69cd8017ed5baf9fc0616a05773de68208ce434"
+    },
+    "my_progs/defs.qc": {
+     "bytes": 31974,
+     "sha256": "1534874cf4d70c5614dedecb70f6d428fc32832ce3345c2cb51fd6058a514902"
+    },
+    "my_progs/defsclass.qc": {
+     "bytes": 24401,
+     "sha256": "811c390be7b31fd4b276410ef1a75406bbca8fb84dc195484835a6100e9cddb4"
+    },
+    "my_progs/defscustom.qc": {
+     "bytes": 95932,
+     "sha256": "c8e66698b225cac3821bf4b098e7c8b16d0babaf7f5c1a5a32006c0c1dd96eee"
+    },
+    "my_progs/dpextensions.qc": {
+     "bytes": 122912,
+     "sha256": "3758f58ebaa4186e9112da89f7ea53087eef5058a32ebc373a1ffda76c1d67a2"
+    },
+    "my_progs/estate.qc": {
+     "bytes": 7745,
+     "sha256": "9cceb71ae54b331c2702f5580094f9055d007b9e710dd5e61c7c632724022626"
+    },
+    "my_progs/fteextensions.qc": {
+     "bytes": 215531,
+     "sha256": "beb86ad10bb0726de10dd2557d6285f7bf40f08f9d30e06315c3772f8c256571"
+    },
+    "my_progs/func.qc": {
+     "bytes": 47039,
+     "sha256": "3102c5ce52ec7a15c329079fc7ca97fa249dca32c4124bad49c2853d38e5c741"
+    },
+    "my_progs/func_buttons.qc": {
+     "bytes": 13271,
+     "sha256": "9e1bd197b2367ab2b8f1c776c214a0c51120559e8d8f0b4888b262b7a1e746f0"
+    },
+    "my_progs/func_doors.qc": {
+     "bytes": 35874,
+     "sha256": "58dbdf05f0044aefdd13ee21d17045a681d255efaca6d129fbd1cec4ae516fc9"
+    },
+    "my_progs/func_doorsecret.qc": {
+     "bytes": 14379,
+     "sha256": "769a3142ccaf18060ff77b0eab57d901585202fbfe63a54ce25d4987b80f92d3"
+    },
+    "my_progs/func_insvolume.qc": {
+     "bytes": 10573,
+     "sha256": "1deaf4623a6fae80585d2d2b1978b1cd217b6f8a683ef3bbc3a77a2897e9a207"
+    },
+    "my_progs/func_plats.qc": {
+     "bytes": 11685,
+     "sha256": "5086c9aba8bbf83d29c3e1897c7867cb24220712007044792928f474216b7ea4"
+    },
+    "my_progs/func_pswitch.qc": {
+     "bytes": 8373,
+     "sha256": "b3a205176d80801216a930241508b3c5718f4be9e1b947932ace2851c34271d8"
+    },
+    "my_progs/func_trains.qc": {
+     "bytes": 26553,
+     "sha256": "81d8de4f3dff80b8523584fb5e37d8d4812a6f7f95a559edff320682217ad123"
+    },
+    "my_progs/globalfog.qc": {
+     "bytes": 18397,
+     "sha256": "84ec244a475ac41b9da772042123f58f4005130590f170f85f1b23ad53629f27"
+    },
+    "my_progs/hiprot.qc": {
+     "bytes": 31978,
+     "sha256": "82875db9fecd8bacd2c42232fb980e6a510a6863103273e2c9078dfe7c6759c5"
+    },
+    "my_progs/hipspawn.qc": {
+     "bytes": 2752,
+     "sha256": "6df8450b85821c1a76f5ccb3c807ac9b94e92f413f16f2ba618f922abf85148f"
+    },
+    "my_progs/items.qc": {
+     "bytes": 165150,
+     "sha256": "fbcc57975032c97ffea723870e39ebc2d2c4bbd9650fb5d20b3dfcecc6f6f93a"
+    },
+    "my_progs/items_progspn.qc": {
+     "bytes": 20628,
+     "sha256": "2f4824cb28192145a8fabc2da6575db3398e8f81522ab1e026d696ec87313650"
+    },
+    "my_progs/lights.qc": {
+     "bytes": 43912,
+     "sha256": "d0e0c373bb3cc68c7c9121a62c68085ff9cc290daa6faf0adab02323d8ef92bb"
+    },
+    "my_progs/mathlib.qc": {
+     "bytes": 22355,
+     "sha256": "b161ebb89a11f302427c4f124731ec38def8eb01347beb5d748a9ba4afb886f8"
+    },
+    "my_progs/misc.qc": {
+     "bytes": 85890,
+     "sha256": "6b3e8a0882d47f16ff7f54fb37a48e3a7853647f8895718e6428739c4207099a"
+    },
+    "my_progs/misc_camera.qc": {
+     "bytes": 43852,
+     "sha256": "61448a8f0354f39dd26371ae56dadbc903b08282293145a27088ac6c151ea547"
+    },
+    "my_progs/misc_model.qc": {
+     "bytes": 32157,
+     "sha256": "9afc9d440672288ffada6256a20aa0f969464907e942fab0c1556cdb28162237"
+    },
+    "my_progs/misc_targetdummy.qc": {
+     "bytes": 15123,
+     "sha256": "bcd0a0ae806ce20a8c8cfcc27178ce1b4ead3a546d927b6a261ce51a6086c253"
+    },
+    "my_progs/misc_textbook.qc": {
+     "bytes": 26321,
+     "sha256": "14bf42536a5cc75990d938a79d7bd21bde1c166245d94d8e662f9e6fd66e0ae8"
+    },
+    "my_progs/mon_baron.qc": {
+     "bytes": 31318,
+     "sha256": "b76a10da34dabf3411ddf650abcdbc77e3ebcdfebace6191a39e7c0b13a0fad5"
+    },
+    "my_progs/mon_boil.qc": {
+     "bytes": 19821,
+     "sha256": "050b21bda5341a3f81dcb21e6d7d82d458a415fd8f1cfa12435228246229a323"
+    },
+    "my_progs/mon_bossboglord.qc": {
+     "bytes": 24005,
+     "sha256": "e67081b7a5218b361c62bf4b201a18db16f3e75716ad2729c11a0616b137975a"
+    },
+    "my_progs/mon_bosseidolon.qc": {
+     "bytes": 40134,
+     "sha256": "c51eb9b9d67cadfa7178891a238329a60ad57edc3f6ef645060695b451833115"
+    },
+    "my_progs/mon_bossfiretop.qc": {
+     "bytes": 14734,
+     "sha256": "26672c9c2d1577f8caf9894b8eb5eecacac89f64251257bc25db48b1bf43a7bb"
+    },
+    "my_progs/mon_bossicegolem.qc": {
+     "bytes": 47205,
+     "sha256": "5b888302a6af24ce823919d1349c1c92e1ee709d72e79042425349368a4d65fb"
+    },
+    "my_progs/mon_bossidchthon.qc": {
+     "bytes": 20247,
+     "sha256": "65d955fb1434f806962fadc088aa5933e96ed8aa9f1211d0709a3f462ffa3027"
+    },
+    "my_progs/mon_bossidshub.qc": {
+     "bytes": 14639,
+     "sha256": "fdd0e8f8fa374ea0164f79ef1bf74ca942f04c63159f360c7a43011673774fe6"
+    },
+    "my_progs/mon_bossjudicator.qc": {
+     "bytes": 81432,
+     "sha256": "f5092f376eeef22f0a552c846f50175680c15a5c37d9603c6e3d2635661127b3"
+    },
+    "my_progs/mon_bossmammoth.qc": {
+     "bytes": 84963,
+     "sha256": "6cda415b846b2aeb215c0eebc7cdfa6a5560255df9aa014f77b48aa7073b8d34"
+    },
+    "my_progs/mon_bossnour.qc": {
+     "bytes": 45682,
+     "sha256": "d3aa7e0c62e9001887b1b0895607b512f6d9aeeb44bca544f6c900c86adbc03c"
+    },
+    "my_progs/mon_bossxxchthon.qc": {
+     "bytes": 22614,
+     "sha256": "2c1c0446b0f6a5b7a7921e8f8830c71c174d30c6f176d228a94afd9a05fdc25a"
+    },
+    "my_progs/mon_bossxxshub.qc": {
+     "bytes": 19006,
+     "sha256": "043ebc852ba7f0a06812cb0afd72d32a3da643df1dea45c87fb821f60fbcc332"
+    },
+    "my_progs/mon_centurion.qc": {
+     "bytes": 13734,
+     "sha256": "641e1c09c6df27b033e331140d242f25d27bf7f9bb83733a6b5b3469a5c7ffee"
+    },
+    "my_progs/mon_dcrossbow.qc": {
+     "bytes": 38069,
+     "sha256": "3296618a4b803fb6f1b44c1d32c17692a5bed13cf63102c6dcc58481223197a8"
+    },
+    "my_progs/mon_deflector.qc": {
+     "bytes": 32107,
+     "sha256": "d7a9344878a3a846a7e720ce704820d424362281a1675c40be7b670eca9fe342"
+    },
+    "my_progs/mon_demon.qc": {
+     "bytes": 14601,
+     "sha256": "d77f128e3f91737228c5a24b7ca146f6b4f8e87dbaac31b1ad4e79779884d0d7"
+    },
+    "my_progs/mon_dfury.qc": {
+     "bytes": 39867,
+     "sha256": "a016db202f2a418aee50cb7cce2155a24a6b807e8c98fc49a5f9273ce79c6da8"
+    },
+    "my_progs/mon_dguard.qc": {
+     "bytes": 28414,
+     "sha256": "0a2b964034559f4ca772f9f29be2c56684fd39290277046a6f7642ba934836eb"
+    },
+    "my_progs/mon_dguardquoth.qc": {
+     "bytes": 18932,
+     "sha256": "4caeb17520104cba42476ff7757f38ba6d72e941674b851f55a5c9780ce4de17"
+    },
+    "my_progs/mon_dknight.qc": {
+     "bytes": 36867,
+     "sha256": "68008427374e9ab670b6ad915c7a0f8eaf6a6699efa927a3748ae6cde86458e6"
+    },
+    "my_progs/mon_dlord.qc": {
+     "bytes": 22859,
+     "sha256": "09ca1edd4e65a166a66ba17e682aae9a1be09b05371a72dd1bc447389693bfa5"
+    },
+    "my_progs/mon_dog.qc": {
+     "bytes": 18431,
+     "sha256": "1b345447176aec54f18c31f5da215e80cb2de19f51d353c63a98507d881c2a9b"
+    },
+    "my_progs/mon_dprince.qc": {
+     "bytes": 33590,
+     "sha256": "5114caa7b6152e562e548096e41da68f43c910a5016ddaed408272a97a8320c1"
+    },
+    "my_progs/mon_drole.qc": {
+     "bytes": 25472,
+     "sha256": "36a510e910ce4ffa26d2d2ad336872c07537077ea920132a4cfd63d9133fb6af"
+    },
+    "my_progs/mon_dsergeant.qc": {
+     "bytes": 33493,
+     "sha256": "ada0cc4359a863c4e8d433c605a1c04ec6f7fd17ec852f5c4847443d3adaff1d"
+    },
+    "my_progs/mon_eel.qc": {
+     "bytes": 8252,
+     "sha256": "15c1f2fedba7077d352595e1be4a90f764354e4cf1875b40e1685d3ce81feb54"
+    },
+    "my_progs/mon_enforcer.qc": {
+     "bytes": 20146,
+     "sha256": "d453651d488afa789d0cea87ce99d9684329bbabdd17aa1625591f5a4b4ac90b"
+    },
+    "my_progs/mon_fish.qc": {
+     "bytes": 9705,
+     "sha256": "ff7d84db2c7917861ff5d81fe0e28f69d51143d27c4fba90dfcda11057222df0"
+    },
+    "my_progs/mon_floyd.qc": {
+     "bytes": 20332,
+     "sha256": "3ac2f0b0be94e311ff2fc4eee9cf66d5987af0e5c25fc06b8cc7b9efa6f581df"
+    },
+    "my_progs/mon_freddie.qc": {
+     "bytes": 25384,
+     "sha256": "4409a33e819f125852d0a4ada21a8fed2713012daec00922446f313031c845d1"
+    },
+    "my_progs/mon_gargoyle.qc": {
+     "bytes": 24293,
+     "sha256": "9e1f78b2364024efa6ec4142c1ecf4aff52cdf32f38031c34cf19e9cd74143d6"
+    },
+    "my_progs/mon_gaunt.qc": {
+     "bytes": 24111,
+     "sha256": "45be98ae0bdd32e0884280e18f867af037f2fcbf515914827c5f9107a87e52d7"
+    },
+    "my_progs/mon_golem.qc": {
+     "bytes": 35297,
+     "sha256": "dbaf3d1c0fec3166b0eb064a3c027dd3a0c907bed72b8e4581ffd74dad5ab5d1"
+    },
+    "my_progs/mon_hknight.qc": {
+     "bytes": 37618,
+     "sha256": "bac7d4b7832b95cea0f6890de66fbd0f7c4fcc7ce9051ef16ac042de465ddcb3"
+    },
+    "my_progs/mon_hogre.qc": {
+     "bytes": 24021,
+     "sha256": "8781ea9aaaa1d0f7ffb1fd8ec8b5981187eee6fdb8193160a1eb38770dffcfe0"
+    },
+    "my_progs/mon_hogreham.qc": {
+     "bytes": 23076,
+     "sha256": "b2ab6b830ce3aae7d6b033e8455de5011ded82e451ca171ea09940d9a3ec7740"
+    },
+    "my_progs/mon_hogremac.qc": {
+     "bytes": 23941,
+     "sha256": "9111c040ab1e5487936cce6ef1170e408c6d297d582702d202bbd27b0919d843"
+    },
+    "my_progs/mon_invsword.qc": {
+     "bytes": 9214,
+     "sha256": "f7287867cc6043eb7cd3fa3e1ecd5ae7115a84e5ef7021b2d5129afdb6ba6f46"
+    },
+    "my_progs/mon_jim.qc": {
+     "bytes": 22091,
+     "sha256": "55353984ad822dfd8c32f3b8ad9a06e8bfaab7bc5ff6f2a2326674ad4acd26be"
+    },
+    "my_progs/mon_knight.qc": {
+     "bytes": 24772,
+     "sha256": "d254abf88162436b9db48885ae8e59315c24c1e7f72a91d027a1d69fe9baf5b7"
+    },
+    "my_progs/mon_lostsoul.qc": {
+     "bytes": 23261,
+     "sha256": "2cdbf656c6b34164711fa88016542f4e3d2bd0555417ad00bab5ca7039f212ef"
+    },
+    "my_progs/mon_minotaur.qc": {
+     "bytes": 35316,
+     "sha256": "fbcef276ee3e2f1eeea8483303538190875e959b43efbf4f703be10fc72fc564"
+    },
+    "my_progs/mon_ogre.qc": {
+     "bytes": 24123,
+     "sha256": "d287d3b9024025237dbc68380f486572828a5114f9543599ba86b8bc35e9e25e"
+    },
+    "my_progs/mon_ogrextra.qc": {
+     "bytes": 9387,
+     "sha256": "41a9243c6006326195197a4dfba6ea4c1f1fbd729ec10adc48cfd7badd7a18de"
+    },
+    "my_progs/mon_pyro.qc": {
+     "bytes": 18235,
+     "sha256": "bd35f02c63af315ddf4820e388d0248cf065f1170bd7306957a1e86fa7e47306"
+    },
+    "my_progs/mon_scorpion.qc": {
+     "bytes": 22136,
+     "sha256": "0432d7c5e1b6a30a5452aba12b9fb6a3c2c7f3c582b1392d420414e66b8fb257"
+    },
+    "my_progs/mon_seeker.qc": {
+     "bytes": 29703,
+     "sha256": "d33939357840eedbfc63c56d6415d8fefd21de2c477b24b3165cdadcca2acd2c"
+    },
+    "my_progs/mon_sentinel.qc": {
+     "bytes": 10217,
+     "sha256": "946232c7169bf3fa966ce875523dd45402772f8045c51a96dced04f2f5f5788f"
+    },
+    "my_progs/mon_shalrath.qc": {
+     "bytes": 16434,
+     "sha256": "1b6fdf2447d7fa281d126118a9bc0e097de7b4dd4d10a33e60d5cf0ca785c58b"
+    },
+    "my_progs/mon_shambler.qc": {
+     "bytes": 23050,
+     "sha256": "576f71a38d75eedbdf58c291055674be8da5f0d04540e26311d65f70b58ee842"
+    },
+    "my_progs/mon_skullwiz.qc": {
+     "bytes": 36245,
+     "sha256": "6d3c2242bffe6eabe3f9cc59e881cb2296213cfbff809e1be045a80ca46aac53"
+    },
+    "my_progs/mon_soldier.qc": {
+     "bytes": 21645,
+     "sha256": "704c534062b11c4fc16416154c7706c125221660cdd4d9b02e00575b94c04103"
+    },
+    "my_progs/mon_spider.qc": {
+     "bytes": 30593,
+     "sha256": "4d0bbb7e38e51cef07912e6071e6bb9739e019a2d93129d38dbab9492bf43aee"
+    },
+    "my_progs/mon_steelclaw.qc": {
+     "bytes": 17126,
+     "sha256": "78dd4bb46dd76b2ff1f7d4a9f0b0902f25d94ebe13ace6b997a7f604c3718700"
+    },
+    "my_progs/mon_swampling.qc": {
+     "bytes": 25637,
+     "sha256": "fb5ed328cd3d5c09704bb84f39138463a7d26b8b1d45771e55e9ae952b1d2470"
+    },
+    "my_progs/mon_sweeper.qc": {
+     "bytes": 27025,
+     "sha256": "8f7a1d077779d88d542a325c1ae4ba4ff59d48bfcb334150ae3f024525bb725e"
+    },
+    "my_progs/mon_tarbaby.qc": {
+     "bytes": 11866,
+     "sha256": "88c9481ab7fe0cbe97d2b836492ff51b368aeae8d4ff3e5852734bb9f63a1b2d"
+    },
+    "my_progs/mon_turretbal.qc": {
+     "bytes": 38519,
+     "sha256": "fdcf915248dda5fb6a744d284233d46a2e6d62c8e4fd02fdd5bafe4f46167d30"
+    },
+    "my_progs/mon_voreling.qc": {
+     "bytes": 27678,
+     "sha256": "7734614fa6b2da2195bf3804415c06a2d10f35825e86abf4f85613a182cf21c2"
+    },
+    "my_progs/mon_wizard.qc": {
+     "bytes": 15155,
+     "sha256": "3101ca37b57343697b3d3c7637fdc84c842f78ec9081e401dcaa6df0a9b1df83"
+    },
+    "my_progs/mon_wraith.qc": {
+     "bytes": 35464,
+     "sha256": "6a28a205cb8ac574e98c8d34a01ea859922e38d55c66346a7aa867ebf84bdb5b"
+    },
+    "my_progs/mon_xmas_elf.qc": {
+     "bytes": 17589,
+     "sha256": "053eec412485090ee1ebeac25887382db40e2ba7ca456050ba4407be3ec8bc1a"
+    },
+    "my_progs/mon_xmas_raindeer.qc": {
+     "bytes": 12189,
+     "sha256": "abbe1dd5c96c25b631231d4db2f17e8243075ad08c082e0448b7cbff34f1ae0c"
+    },
+    "my_progs/mon_xmas_santa.qc": {
+     "bytes": 17853,
+     "sha256": "cc60c6de17bc3321f9b1cf75b3229e387592c9eb7fc4bb57c1de0a8d2c0e62e6"
+    },
+    "my_progs/mon_xmas_snowman.qc": {
+     "bytes": 11486,
+     "sha256": "65928bb70cb2e9352c2f5e036eda2a6bd97aea09d459d0af563a82aa5a2f2673"
+    },
+    "my_progs/mon_zombie.qc": {
+     "bytes": 33988,
+     "sha256": "83f56482374c3a79fcc64058989bd210af3add006b7388d89c92e90543ec56a0"
+    },
+    "my_progs/mon_zombiek.qc": {
+     "bytes": 42214,
+     "sha256": "2b9926454484e93f5c053bf4fd35b2a97cf7e835c26c3b30061f1ff391af9f5e"
+    },
+    "my_progs/monsters.qc": {
+     "bytes": 56573,
+     "sha256": "c2c75832e6d5e83e929214ba5c1aa9a4661bcaf7754c20b3e9648171bf804a58"
+    },
+    "my_progs/part_emitter.qc": {
+     "bytes": 82744,
+     "sha256": "fca7491171d58974ef6b15550b9a7f0474641e9eac7ee5de52c6980c96445518"
+    },
+    "my_progs/part_generate.qc": {
+     "bytes": 42914,
+     "sha256": "83b9718a85418143d92ea8311cc8cce69c1002eb7563710dfe7010ac52e15d50"
+    },
+    "my_progs/part_manage.qc": {
+     "bytes": 27407,
+     "sha256": "86eb791f4bba08fc0c965e9f81c90e7412ed2c910104d66a56cce1f3152808fe"
+    },
+    "my_progs/player.qc": {
+     "bytes": 27811,
+     "sha256": "1f0cc3eaf577c2af642495466c573cd6e226a4754902d9de9cbfc9c9ba28af0f"
+    },
+    "my_progs/progs.src": {
+     "bytes": 2482,
+     "sha256": "c773f107c562f731fbb30158422226bdc4576dd32aea0f02c122195e08eac96f"
+    },
+    "my_progs/pushable.qc": {
+     "bytes": 19823,
+     "sha256": "03b3bf9240db6e9532e45a3efc159129709f9ce095c3238daae32daddd5b07ec"
+    },
+    "my_progs/qc_highlight.xml": {
+     "bytes": 6348,
+     "sha256": "a7b326723cc1e4025e867ea5da00f54c944705600d740538aeb52f63cd027ab5"
+    },
+    "my_progs/settings.qc": {
+     "bytes": 62244,
+     "sha256": "78d9b19077028f9fd72f271aaae3d75b43e995ef95b7679df83a06fcdfbaf4f5"
+    },
+    "my_progs/sounds.qc": {
+     "bytes": 19389,
+     "sha256": "bb74ecc36a241db5a79b010f61200687c6db6e46297db39c8a2a8ce1d512bad5"
+    },
+    "my_progs/sprites.qc": {
+     "bytes": 476,
+     "sha256": "579f48b397914b02f8fb86dc24f23d4e63a4cd857df1f0eaefd6c83e9c49e238"
+    },
+    "my_progs/subs.qc": {
+     "bytes": 24000,
+     "sha256": "48832d667d7a932661ac914bc8e471843f2cd8a0985fc0458d7e1a2796e21d16"
+    },
+    "my_progs/subs_soc.qc": {
+     "bytes": 28453,
+     "sha256": "679112275e8b3597daac962074f69b6d9fd5614fc3dbff036815b9365e1413c5"
+    },
+    "my_progs/switchshad.qc": {
+     "bytes": 7054,
+     "sha256": "92a2fd4e5c41f21f46502781322ab87584bf0999d733db50e0e19b8bbea793b3"
+    },
+    "my_progs/targets.qc": {
+     "bytes": 58758,
+     "sha256": "e39b45bf6740be40c2899376e92d30d7d227a4762091d7b63e382c79fe6822e7"
+    },
+    "my_progs/traps.qc": {
+     "bytes": 24071,
+     "sha256": "9e4e822a36113bc73958fa45ab0b8c290a5148c95f3a4da7125676c984ebd202"
+    },
+    "my_progs/traps_pendulum.qc": {
+     "bytes": 17049,
+     "sha256": "b421f26fd80eb74715172e25f3ac992faa95397dd67d5f7ede286fd78384a468"
+    },
+    "my_progs/traps_sawblade.qc": {
+     "bytes": 9783,
+     "sha256": "9a6e82a05f09001c0a9cffdf6b9d6399691846c5b1ab1fbfb470e5772a87f44b"
+    },
+    "my_progs/triggers.qc": {
+     "bytes": 139722,
+     "sha256": "0ead1e997492dfe79a8c811a48b902217aafcd4bf3c49acea7101c99892886f3"
+    },
+    "my_progs/triggers_states.qc": {
+     "bytes": 17475,
+     "sha256": "2c4d25c11de0319cd54d81e67e651c8d29d22aca851988d21080ba5976137f14"
+    },
+    "my_progs/weapons.qc": {
+     "bytes": 44884,
+     "sha256": "d22ff6c46a101964e5e8e334a8d91ae8854e2eb6ca2c4565fcfc748acfcfd9e6"
+    },
+    "my_progs/world.qc": {
+     "bytes": 39815,
+     "sha256": "c160b7b050cc7a718fbc6ffe3dbfad85514936522bbabeb8ee4fb1a3c30b79d3"
+    },
+    "progs.dat": {
+     "bytes": 2347206,
+     "sha256": "5e69fece92fb4323609c8e1209a39eecf4f70c3161ae17beb53063fe3e06c340"
+    }
+   },
    "sha256": "49bb1a23ffda3e24edba1f4094ab4e031f570e8dccba7ca363b7096bbf0b84c1",
    "timestamp": "2020-11-22T11:35:34.000Z"
   },

--- a/json/by-sha256/68/681d67a59ff42a6114ef48e5c717ddceb1713371a8736075b0f8847649295747.json
+++ b/json/by-sha256/68/681d67a59ff42a6114ef48e5c717ddceb1713371a8736075b0f8847649295747.json
@@ -365,6 +365,432 @@
   },
   "sm227/pak0.pak": {
    "bytes": 12042158,
+   "files": {
+    "demo_c1.dem": {
+     "bytes": 1854820,
+     "sha256": "8b93e0384ac1505dde19d24a2e337686c065a43da8c8a476bfdadbfdc621928a"
+    },
+    "demo_c2.dem": {
+     "bytes": 2445116,
+     "sha256": "4e4ab2f099e5746565cd19e5695a35cc1252c24d8817b5c8670c1792c187097f"
+    },
+    "demo_c3.dem": {
+     "bytes": 1808204,
+     "sha256": "71476830e6d475ff8bb66fc8f07da76c89f407160ac26ad1ccfced0d6e7e80e2"
+    },
+    "gfx.wad": {
+     "bytes": 152468,
+     "sha256": "50d94651f3e0b0b6a29e0110ce9ff260c9f3114060b08b6d1ae19054b8024335"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "31c4858fe496187dc1bac21c02aff8cf83cbc51e0b4ee5738d6118c328b299d2"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "ed0f79285d93d0ef35644ecaf9ab36f3b2c6ffd223c577b25fff2ea17f90080d"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "e9c210ab88f6e98965cd2f8470f084e32ef15b3ad3912cb1e9eb0363c6204eb7"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b56880e2f720a89dcd055f5278abb21a21514322d4a31b77b46c8b509b9f3be3"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "89c3ac6fd91cdcf15c20b0d15b4c01c153e0a820c660f9222b5c8f63d43af5b2"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "8b83ffaf6b5309d371f0107ebb1340a8a09cd1a52c6a5581b7c9c4a7afcefa77"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/debris1.mdl": {
+     "bytes": 33768,
+     "sha256": "3498dffa0c3522b011a76ada880dfae64de3ca1583c94474e1e07adbc220d981"
+    },
+    "progs/debris2.mdl": {
+     "bytes": 33944,
+     "sha256": "d6d535173bb4a3a2d469be9c63bf36a01b1e2b80dd6a71636d20178d813e443c"
+    },
+    "progs/debris3.mdl": {
+     "bytes": 34136,
+     "sha256": "d6b0a2b6353c4462196d2af116652b47d464a7bc1f161509aa8ee5dbe859f98b"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 17812,
+     "sha256": "74cd41d8d5a67570cdaca34a08e9868f3476d8c4ac4a645cfaf9e91cf778c793"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "4f5ca2553db07d5cc93987b11e9f9ff054d51b96488e2bcc35c9f03ed3040d42"
+    },
+    "progs/h_zombnm.mdl": {
+     "bytes": 3220,
+     "sha256": "45d9dfe5683264edf6f6eb7b8e8d794f84caeb8701e65e8ebe9add2192bbb6fc"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "b00951cd72bb5fb03c19a1d60943162652fe149b9ee60fd2e630a076d52956fb"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/k_spike2.mdl": {
+     "bytes": 17716,
+     "sha256": "e456eb93934dab43a83305988db82ab1954e66491c256fad3ef1451d0ecf97c2"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 36496,
+     "sha256": "a001c379917628354adfb62b698856b33f4eea5f22e7d8e232e640faf15d8465"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/mini_pent.mdl": {
+     "bytes": 268148,
+     "sha256": "578e8013d4ad85289af822dea270c74c56b97db82071d4f12df9b308d3a3c20d"
+    },
+    "progs/mini_quad.mdl": {
+     "bytes": 268388,
+     "sha256": "7e6a3f8260a5b8e23711d68ed0438b7238838eead2b838b46289a3b34d4bef15"
+    },
+    "progs/mini_suit.mdl": {
+     "bytes": 273648,
+     "sha256": "c29ec50a7abfcbee0d8c672fcc0dbeb87b9a257e4c2803ed0d25d208a8f8b742"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133936,
+     "sha256": "e2d6b9de9b879327f72d97ef3c07e0b7e35cf844747208f6e615015be84157e5"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "f414f3fd07b0278bd59dd90954770f81a5ffad7f46af5f5d0abee124905dcc17"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "progs/w_spike2.mdl": {
+     "bytes": 5816,
+     "sha256": "b07808c532059133c31be2ed2bc4e9bb9b01b75d5d23401768058cacc3192068"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 74976,
+     "sha256": "545d70abb8d44be8e12da24a3d09fb56f87ff960c41963148682fbbd9d47e417"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 218680,
+     "sha256": "6782603eadacc7cb4bd09c11d3b6326e0d2e69205f724fe2f6e533ee398f5a16"
+    },
+    "progs/zombienm.mdl": {
+     "bytes": 224900,
+     "sha256": "f4d1ce9667ebb36088bfb59a12c9a8d93c1aefa36515b51f388cffec5132f5b2"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    },
+    "sound/zombie/z_res.wav": {
+     "bytes": 23266,
+     "sha256": "10b2962ce2817fa8a250811313307cf0dfa93ad5257a669452fe3fc834ced976"
+    }
+   },
    "sha256": "68bbf797f696821a6f19557aa6ef2575e7ef0092da75286440b7b58846c2b51f",
    "timestamp": "2023-11-16T23:16:12.000Z"
   },

--- a/json/by-sha256/68/687689c7b7b433b60de0ab9cf326f82ea022abf4f86a144abfd01169f7ceea46.json
+++ b/json/by-sha256/68/687689c7b7b433b60de0ab9cf326f82ea022abf4f86a144abfd01169f7ceea46.json
@@ -7,6 +7,180 @@
  "files": {
   "gibfact/Pak0.pak": {
    "bytes": 3739361,
+   "files": {
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "66c2f011d0ae47550f57a8d7b39000f534c49653442ab0d392480683f6851184"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "2d7cf7444909c92b475991b069a665145dc15302137dce41745ca7f0e2e01312"
+    },
+    "maps/gibfact.bsp": {
+     "bytes": 1540496,
+     "sha256": "b89977d36f763e2dc9feea621adf888e3966346a24869ebb2cd50b56fe07e767"
+    },
+    "progs.dat": {
+     "bytes": 478200,
+     "sha256": "5783b0c20a1948e61bda81ef7ad792e23761c78f143aef5379c75b1f2844be63"
+    },
+    "progs/blarg.mdl": {
+     "bytes": 123740,
+     "sha256": "1eabc36dc559cfe8a0c1a712d3de429787df488bbeea133fbf4ffffe547716ba"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "6e2fd875956e03ea76f16bc69a43749d87ed2e8216a8653234792b8dbb9fc1c2"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "718b8c2842877345426247148dd6ce1ebe7fecc13e969a0fa0ed6dbebc388099"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "0a386b6381824b01852910519490ac3f6e3309a96091820384ee6b9a5b452e7a"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "ebd3e614ca2afdead497209fcf79f304218f4cff2bd3bca7d3e3a6c542f63362"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 50636,
+     "sha256": "c5af6bb197f51c0236c1a85cbd6907f33107247858a922def7d2382c488fdf0c"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "53539bc39fc87627a46b75b0d86ade5e6116a0079b032b1df137b2425b7186cc"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "210e159ea4c9bf1f2431213fd95902f4ea75ecee6a67a22bed7e93366f1f2732"
+    },
+    "progs/manga3.mdl": {
+     "bytes": 96256,
+     "sha256": "81bb691947f88dda5672ab1e1af689098d08a9b5bea9d31c38197db909fe3b76"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/s_ablast.spr": {
+     "bytes": 15816,
+     "sha256": "056e4c0505d634afbb799b50fdac609ef9695fbc11ac03e09f396fcc98387357"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 146288,
+     "sha256": "1b2de1dca9c15240ef20c5e48cf473691b00304a8cf0dcc7cf4892e643e5e49a"
+    },
+    "progs/v_airgun.mdl": {
+     "bytes": 71065,
+     "sha256": "07321d9bbbc3065650d33a195f6e83bd3c173ddf7f536f1d823a7d6b9b68d918"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 54564,
+     "sha256": "4f2a06e5b9df3dddd29962562e8a8959cdf643fb9bee5b922ceda4303d2161fd"
+    },
+    "sound/blarg/bidle.wav": {
+     "bytes": 25832,
+     "sha256": "2f57c1c5ce363e090853eff5622131a1f978dbc62aa5998472ef9cedb041c4f5"
+    },
+    "sound/blarg/bidle2.wav": {
+     "bytes": 23488,
+     "sha256": "958724313246d20cad51194f35d539927556b3c7917f983d5344b8886bafb759"
+    },
+    "sound/blarg/bjump.wav": {
+     "bytes": 23646,
+     "sha256": "3b2c6d6e536a756323fd056083eb0093a3330bbf4c829e0354f401a9074f22fb"
+    },
+    "sound/blarg/bjump2.wav": {
+     "bytes": 6908,
+     "sha256": "1c6406eff6b00c029baa2b8d5a1c84a13bc21f47be0a84e80d852c4c7d10df4c"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15692,
+     "sha256": "72e737f04f1d34044dfd812c6b0e233cd38a91e6b089633e312678756952de87"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16625,
+     "sha256": "bd4cd7902712282ef8f2f749e6fcf805c2ac5212994fbb1c22fc0fe0ea5d08e2"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15527,
+     "sha256": "0b472a984137667f4788336a4f7c60e07a8893f47317b2a158aeea39920d729f"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4107,
+     "sha256": "8fe56b192838dafdf7ff4737cf1e5555d3295cbca49c1ab83568281ee188153c"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8122,
+     "sha256": "3ea23b8d7a68e754211a10a5338b0c8d65df6e2138d4cfe06cc053b9a0f601ae"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13081,
+     "sha256": "a5ec6d4eaa707ad0246b7a7e7737b1007043ea5e5634f6f63661ecc20c27c459"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48508,
+     "sha256": "b7aac875623f8dca7597eff3dcab5910453d043fd1f9df20da89232ce8bf9306"
+    },
+    "sound/died.wav": {
+     "bytes": 24492,
+     "sha256": "3ce14cdac970a150f567dbd07cf1763f695245c34f5bf4e31ec07bfeb232db30"
+    },
+    "sound/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/ha.wav": {
+     "bytes": 2708,
+     "sha256": "ba2108ad5070860873887308293efd3a9635a6c4dcb3fb39357a9e16f89f97b5"
+    },
+    "sound/hiyaa.wav": {
+     "bytes": 36876,
+     "sha256": "1446e8afbfdf48a08ca6727604b33585efdd67a6d14b4b1c96bb05c6ccd5ac3a"
+    },
+    "sound/kungfu.wav": {
+     "bytes": 29008,
+     "sha256": "025b6eed19d193bd6be4c4f8f2bc7b9fb14e5c127257e570fd9fc98fd464f2a3"
+    },
+    "sound/ohdju.wav": {
+     "bytes": 12588,
+     "sha256": "346d38c12edad612ec4915d3361ebfbb81b06bee9cdb73eb9b9e0d2cc2ea6d10"
+    },
+    "sound/tchak.wav": {
+     "bytes": 10166,
+     "sha256": "f77d88ab76f7a092a7a5d40fb0aaf9530dc6da8e45559fcf1a1b5ea2aa88029b"
+    },
+    "sound/weapons/agfail.wav": {
+     "bytes": 66197,
+     "sha256": "ebeaaa43622fff993c83df58511bd7f3569e9aef9bbc478c9cc6b2e8b9e3e77f"
+    },
+    "sound/weapons/agfire.wav": {
+     "bytes": 66197,
+     "sha256": "db3466708718063963d8996e51bdc4e8bd0033d9932f387f624f274f6c7c648b"
+    },
+    "sound/weapons/agwater.wav": {
+     "bytes": 85900,
+     "sha256": "208883c1961633e728d5c1894a193acc923de928adf9cc77ae40244645951046"
+    },
+    "sound/weapons/agwfail.wav": {
+     "bytes": 31382,
+     "sha256": "626e26302f5b01b7a13b1354c13a41c45dfa0df9c2e9b5af4037454f8f215f37"
+    }
+   },
    "sha256": "aab95875c19bd106d16af5bb84ab597671b3727c779458ce1e880eac12b6db68",
    "timestamp": "1997-02-01T22:32:04.000Z"
   },

--- a/json/by-sha256/6a/6a494eaf1d1d2d153bb79a94cd4069a5011ce4c601fa31929f1a6aedbd85c734.json
+++ b/json/by-sha256/6a/6a494eaf1d1d2d153bb79a94cd4069a5011ce4c601fa31929f1a6aedbd85c734.json
@@ -17,6 +17,160 @@
   },
   "simmer/Pak0.pak": {
    "bytes": 1500888,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "03210a3ac0a8fa16688ccdfe72cc20e59e698e0d970d6b4934e2e8e8021569ab"
+    },
+    "progs/beam.mdl": {
+     "bytes": 10608,
+     "sha256": "2165a66ba1d40fa378df735835b014791e769cb8bc56e06977aefdf134bb61d5"
+    },
+    "progs/beamhit.spr": {
+     "bytes": 5320,
+     "sha256": "bdfe3464c0bea904c3d35135b6d242f486298447ea45c3f96cce7ac6b71a3e54"
+    },
+    "progs/bs_light.mdl": {
+     "bytes": 28707,
+     "sha256": "6c646ab4291d12aecdad5d9af4c44f4d68fc207c730dbf3ac04e07103cdd2c12"
+    },
+    "progs/buzzsaw.mdl": {
+     "bytes": 28716,
+     "sha256": "9b85232f930a7e34ef4cd1abfa266bcfa09b8da9e3f96f875d89e56ff702b403"
+    },
+    "progs/camera.mdl": {
+     "bytes": 33528,
+     "sha256": "afbb9ddbbb0d9a7509a555289d2517bb94991f6a0c4d8f2b5cf508794485c82c"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/csm_cpit.mdl": {
+     "bytes": 4424,
+     "sha256": "17c3aefc3c13035e45aec9befe0bf6722d163637aa56f18c3bec23c838dd5978"
+    },
+    "progs/dedturet.mdl": {
+     "bytes": 53268,
+     "sha256": "8a0f9e57646d4f443b0b28a5d054b5f78d98dc52e3797ef42fb9dec1c6d87b96"
+    },
+    "progs/dring.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/frame.mdl": {
+     "bytes": 24293,
+     "sha256": "c033f1d4dabaa36e34b58884d4b45d3a74c587893debaa362c83b286ff7d2c62"
+    },
+    "progs/g_beam.mdl": {
+     "bytes": 68996,
+     "sha256": "db2566d26863472c6176c91b2256c12b5fdd28b5e1ba0a3ff2aa9e122ed0cacb"
+    },
+    "progs/h_turret.mdl": {
+     "bytes": 21812,
+     "sha256": "cd09fc309437b5930d500d4832d1eae7ab7ffa521b0b3eba953e63341326c276"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 15092,
+     "sha256": "362ff3c50031d80b46a11c3d1902fe1cc3d442cd13b7db59f6d46c5655fc9351"
+    },
+    "progs/pendulum.mdl": {
+     "bytes": 44128,
+     "sha256": "0970c838e4246a47d0b39395af03754a06dcb5878830233413e6fc893cf80599"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 146288,
+     "sha256": "563057a41f47a8462482bfded02558efe662d427970afd9b877879dd46389bd5"
+    },
+    "progs/turetgib.mdl": {
+     "bytes": 9172,
+     "sha256": "01caa25c4d2ebcfd4bde7d8db73331001f9d3c4d61504529f9f405c70800c906"
+    },
+    "progs/turret.mdl": {
+     "bytes": 67692,
+     "sha256": "e50bc0e32b38751eb8cd618c0996c52e9f7d1033f8d484e18fe1fa6f6b365cdf"
+    },
+    "progs/v_beam.mdl": {
+     "bytes": 75588,
+     "sha256": "c00fe7872cb2c88626e63d99c3cc00b83f9968803344cd2021e8fc26bd25ccba"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 92444,
+     "sha256": "502bf52da66ce8a3ad7826685b6cb759a31004db0ddb213cd48fc9c0a3e2705e"
+    },
+    "sound/ambient/cpu1.wav": {
+     "bytes": 72606,
+     "sha256": "8f0b65a9d7c9495999632d51b6c9b918b3f922a6031404318b76f7c88aa12aa5"
+    },
+    "sound/ambient/gener3.wav": {
+     "bytes": 18260,
+     "sha256": "a6d9025cea55fc1c2b4bf993aa71a836e7d8ae04185b34f879826718fcc07d94"
+    },
+    "sound/ambient/under.wav": {
+     "bytes": 15722,
+     "sha256": "e5ccf747813d6bb9cf40d90dc54dcd9851ff6ecdaf49dc87e0254b36dc2c0c4a"
+    },
+    "sound/buzz/buzz.wav": {
+     "bytes": 26568,
+     "sha256": "9f6bbc6cd33beb735c81ed86da32356f65fa90aeb2792489aaed97e41b201227"
+    },
+    "sound/buzz/buzz1.wav": {
+     "bytes": 18828,
+     "sha256": "f9aa4cbaef41e71e9711e4d54c3714dd784068ab60993c382e07c684fe456e37"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rublexp.wav": {
+     "bytes": 42422,
+     "sha256": "85063f2a4baed6f0944ed41e346959da06472368702e5e458867fc8a755928ba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/turret/beamchrg.wav": {
+     "bytes": 3962,
+     "sha256": "d02bd7d2c4754fe3159fac83b4f0898f8b2e1f8996ce7e6cfdaa4a9d75a24fb1"
+    },
+    "sound/turret/beamhit.wav": {
+     "bytes": 8644,
+     "sha256": "35e5e5f28a3695ed27c2b0887a1bf118643d769c457d3642016e887248fa8ca9"
+    },
+    "sound/turret/beammode.wav": {
+     "bytes": 3664,
+     "sha256": "1589cc75daf6c3838ed7e926c205e50ceb4c21338fc1ddacae98d53a37acfbf2"
+    },
+    "sound/turret/plasbult.wav": {
+     "bytes": 18038,
+     "sha256": "dfb145c600c2d447fee8ab89a3afe8e44cf7ae46d770c8eb42903d83a687b122"
+    }
+   },
    "sha256": "25b0142c53b736b16b187c2bc6f4baa296ebd7f6c4914d1e80c61639a98c4a6b",
    "timestamp": "2002-08-11T07:46:28.000Z"
   },

--- a/json/by-sha256/6c/6c2b951eaaa5f26334f240332b8a63037cf590fa4523d86552df7c05555acae7.json
+++ b/json/by-sha256/6c/6c2b951eaaa5f26334f240332b8a63037cf590fa4523d86552df7c05555acae7.json
@@ -7,6 +7,23 @@
  "files": {
   "logs.zip": {
    "bytes": 1501,
+   "files": {
+    "rvis+.txt": {
+     "bytes": 217,
+     "sha256": "eaf511361054a6bc1a1a485d5f712f5a424ecb572bf98f0708041c23f666b743",
+     "timestamp": "2002-08-17T11:29:30.000Z"
+    },
+    "tyrlite.txt": {
+     "bytes": 252,
+     "sha256": "3910bb4ca9656a75bab0bcdabac9453dbc66c2fa4765fdbe01d0e5629d3f0c63",
+     "timestamp": "2002-08-17T11:28:40.000Z"
+    },
+    "wqbsp.txt": {
+     "bytes": 2313,
+     "sha256": "0a535c81efe88eaa7ca28a505f9773884f6b48930dfedaa111929588e79cf27e",
+     "timestamp": "2002-08-17T11:28:12.000Z"
+    }
+   },
    "sha256": "15eb33ae1cd7de79711ba124392443304148a7e527f56e9be9a5a0eebac1e557",
    "timestamp": "2002-08-17T11:55:08.000Z"
   },

--- a/json/by-sha256/6e/6e42a183c0e1992069f53e235285eb3863d4d7fc33f0eb584f262223e174a381.json
+++ b/json/by-sha256/6e/6e42a183c0e1992069f53e235285eb3863d4d7fc33f0eb584f262223e174a381.json
@@ -17,6 +17,64 @@
   },
   "pak0.pak": {
    "bytes": 18557329,
+   "files": {
+    "demo1.dem": {
+     "bytes": 621186,
+     "sha256": "fe8c4e8bdcb7feddec368bcaf810525191e2f5d9bdb53ba85b0e16e176f77637"
+    },
+    "demo2.dem": {
+     "bytes": 772251,
+     "sha256": "d2bc8f22977c7b51daeb02a4acf642e6d22038538df8950fa280cb81cf2b3a37"
+    },
+    "demo3.dem": {
+     "bytes": 467188,
+     "sha256": "867a1cec5737d8079fb2ee44612bc646012e16cc1f2f95040727776bba05528b"
+    },
+    "maps/e5dm.bsp": {
+     "bytes": 532608,
+     "sha256": "f3c8f59a36921636d105c32cc22ce04af70f7a1e9e35856e87518265c043da1b"
+    },
+    "maps/e5end.bsp": {
+     "bytes": 1022056,
+     "sha256": "e46b9b1fcfc9d07c2153f6682660727f98eb53630697f0876db7378bf61455c5"
+    },
+    "maps/e5m1.bsp": {
+     "bytes": 1746668,
+     "sha256": "7027f52d84b3bfdaff4cb895a15f5038ea3547eee9173d24fe68a3561631900c"
+    },
+    "maps/e5m2.bsp": {
+     "bytes": 2119616,
+     "sha256": "69b47a1fca1d3f39e1fc327a88a92bd82f2399f34bc7905d1af98bcee68219d8"
+    },
+    "maps/e5m3.bsp": {
+     "bytes": 1321428,
+     "sha256": "ec7adf4ebce2be8391c9d86a9176b9d02ee721682961496632f52a371681054f"
+    },
+    "maps/e5m4.bsp": {
+     "bytes": 2328924,
+     "sha256": "39da31d0f529697870a63b8d10793a5d6b4d6d15d18cc2c956c92c03e135bfe9"
+    },
+    "maps/e5m5.bsp": {
+     "bytes": 2043048,
+     "sha256": "456f8b79af803ec9297cf5459d5e540d29fcc5879d8ec0edcb6a9d092b2c4936"
+    },
+    "maps/e5m6.bsp": {
+     "bytes": 1668812,
+     "sha256": "9d6b87189cb5f9bed262acd9c891e6915919cad930ce3625d0d6db2fd74a6de0"
+    },
+    "maps/e5m7.bsp": {
+     "bytes": 1606116,
+     "sha256": "42f1a5f0b97336b00d4ceee36d715b2af259aa53b288970adfa0a27b57e9b91c"
+    },
+    "maps/e5m8.bsp": {
+     "bytes": 1129392,
+     "sha256": "fdf2fdc832b9fa45f4b2ae26870b3b2a1cbe9f3c77e113149fc88a0225360fe3"
+    },
+    "maps/start.bsp": {
+     "bytes": 1177128,
+     "sha256": "d633459bf1bc4cb3a9e4adf13e361752cddef915c78c4e0f5dee4546bde7f367"
+    }
+   },
    "sha256": "282d916c396595eaf6c4e6b698bc9c73fe24d2a4ccb72758edd37a253df34057",
    "timestamp": "2016-06-21T20:18:06.000Z"
   },

--- a/json/by-sha256/6e/6efe30edd79dd2516ffdb3a569144f0e4e1e0b8e06524f5f3bde5195e9443398.json
+++ b/json/by-sha256/6e/6efe30edd79dd2516ffdb3a569144f0e4e1e0b8e06524f5f3bde5195e9443398.json
@@ -213,6 +213,340 @@
   },
   "sm211/pak0.pak": {
    "bytes": 4085208,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "b1deebb2268d373683100cc9df4c9dcbf817f9bdb0e3f2cd13edde0037609b53"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "11454a7ec41855cc66adc9b80e60b1c76b0af873656d46cc20543ea4d2a7ef8c"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "d2a59d07042577c9c5a5ceace5ad0e3893ba3ac2d206f039f11cf282ead3945e"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "63f869e1e553ccae238279e4b78c902463505a3d1dd7c5d21d4f4acbb56857ee"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "6e3d8ed0cf22d78c0e05bf75837214a12f647fda33da1fa1ad1195cff3cb9681"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "35db83f82066ac1db85f4094dc9710e313b638e019d8e4d6fb5abf0457d506af"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "7b3838322dc860c3ea5dec5e246e9ecac4b0f75182edeff7b719e16f4f33d874",
    "timestamp": "2021-01-25T23:17:46.000Z"
   },

--- a/json/by-sha256/6f/6f720dde5e6156b36631955ec369845d0eef25e5a96732ba5026f7a1204d7aff.json
+++ b/json/by-sha256/6f/6f720dde5e6156b36631955ec369845d0eef25e5a96732ba5026f7a1204d7aff.json
@@ -12,6 +12,20 @@
   },
   "Pak0.PAK": {
    "bytes": 7744945,
+   "files": {
+    "maps/masque.bsp": {
+     "bytes": 6188816,
+     "sha256": "813e0b81a4d865ed5ef285d7371defe3faba0ca851a0290c582c5dda4420444d"
+    },
+    "maps/masquestart.bsp": {
+     "bytes": 1484352,
+     "sha256": "70b9b10c53fb8613bfc90d630ad97175dc162e50468bbad22dbcb6e3aa8a8877"
+    },
+    "sound/laugh.wav": {
+     "bytes": 71573,
+     "sha256": "cb8e1381c70240a93233b8571d792e21950d00b1285f867cbc0ed1237dac1df7"
+    }
+   },
    "sha256": "f7835700639386cc5fefe7f15d00b815cab7b1a5462f4864d078e2a8217d8194",
    "timestamp": "2005-10-11T21:10:58.000Z"
   }

--- a/json/by-sha256/72/72b3c9b987f1a43b52789373cf1511ac06133dbbd014145707fcd57b5ec569a9.json
+++ b/json/by-sha256/72/72b3c9b987f1a43b52789373cf1511ac06133dbbd014145707fcd57b5ec569a9.json
@@ -9,6 +9,1072 @@
  "files": {
   "pak0.pak": {
    "bytes": 223662393,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "9224bc4c8a9cd008bbfdf386ac3d6e40cb4ab5453b268aaf667acb1c14e65991"
+    },
+    "gfx/env/browncloudbk.tga": {
+     "bytes": 3145746,
+     "sha256": "08073f21f6328141c058e7faef8ccc3db5a2da9530bf78471ecc058353e1aeed"
+    },
+    "gfx/env/brownclouddn.tga": {
+     "bytes": 3145746,
+     "sha256": "d260403b2945cd68dcff741ebdf33eaebd65adef3b7f389eac4f48fea3077ecb"
+    },
+    "gfx/env/browncloudft.tga": {
+     "bytes": 3145746,
+     "sha256": "469c841735437788452d8d34850728cdc1eab1fd8070edff05da4fffab32c8ca"
+    },
+    "gfx/env/browncloudlf.tga": {
+     "bytes": 3145746,
+     "sha256": "1ee9129a66f805f5d3d17bac335c74bd7a2ab258e95ad83414daf66e31e00edc"
+    },
+    "gfx/env/browncloudrt.tga": {
+     "bytes": 3145746,
+     "sha256": "75603b5c6773c24bce224259f15421d6792e28cf165fe22b85b20ffe54712b67"
+    },
+    "gfx/env/browncloudup.tga": {
+     "bytes": 3145746,
+     "sha256": "c60b7e240dd391d85c19270355a47ff6594ff54fd814c0905d737bac8fa67155"
+    },
+    "gfx/env/dawnbk.tga": {
+     "bytes": 791801,
+     "sha256": "3a415bd258f1d81bfddc5091dd67829e7b9c2d247c7d69ea263a6e743e3971e5"
+    },
+    "gfx/env/dawndn.tga": {
+     "bytes": 1032293,
+     "sha256": "33c9b1bc0ae74eeae43a90f44397cb3d2747ec40190f5b0bf28ce62d0943cf98"
+    },
+    "gfx/env/dawnft.tga": {
+     "bytes": 1206497,
+     "sha256": "1947bb641b84fd09cd9b0c17256f809fc13c81eca40520576d1ea3e2c57ea9b4"
+    },
+    "gfx/env/dawnlf.tga": {
+     "bytes": 1141280,
+     "sha256": "cc68776448bb864875e8e4ea181f6aa83800fa00ad15fca9f9ae3ac24b35d320"
+    },
+    "gfx/env/dawnrt.tga": {
+     "bytes": 1031739,
+     "sha256": "24be76b64c71f5a589f219ceccad23a68fc4e26f45a2a8a4183792bdbe7fc71f"
+    },
+    "gfx/env/dawnup.tga": {
+     "bytes": 1426811,
+     "sha256": "e4f5dabd8690dc8460d0032fba1d633d69222a242749803e960643d3cdd25454"
+    },
+    "gfx/env/entropic_bk.tga": {
+     "bytes": 510156,
+     "sha256": "6700c738144aafdf4d6d7eb7ed35d458465a1093b6234c5203cddedea0567b48"
+    },
+    "gfx/env/entropic_dn.tga": {
+     "bytes": 770663,
+     "sha256": "baaea08eff631fabaa789d533fb7c6b9f0ab0b50a4b6955b5d29ff9bed8ce167"
+    },
+    "gfx/env/entropic_ft.tga": {
+     "bytes": 467276,
+     "sha256": "cddf02a881c34e25dd8e57234677530c0edc1356b34285523b4d3b005766b233"
+    },
+    "gfx/env/entropic_lf.tga": {
+     "bytes": 489064,
+     "sha256": "fea224567923765da64eec9889146b23ecd165d391e122fa73e17899afa06c45"
+    },
+    "gfx/env/entropic_rt.tga": {
+     "bytes": 524252,
+     "sha256": "0abe2f217f212ee461beac49613213083f4f6195defae49e1249a9dcd03fca19"
+    },
+    "gfx/env/entropic_up.tga": {
+     "bytes": 167596,
+     "sha256": "a3bb5d574c5c1ad6953629dae8355008b181ebac22ef3ded69ad21f94af638ca"
+    },
+    "gfx/env/graynightbk.tga": {
+     "bytes": 786971,
+     "sha256": "3cd8f98206a4267c0cbd7a8028dd55a2869e4a0840a45c89e4a03d1300d970bf"
+    },
+    "gfx/env/graynightdn.tga": {
+     "bytes": 786971,
+     "sha256": "2d2e929246612062e871629464e8508a0dc9fe35680015e90a441c6c20e1a936"
+    },
+    "gfx/env/graynightft.tga": {
+     "bytes": 786971,
+     "sha256": "387759c32fdce1b459b7fad63f47ca35c5755794aa960c8486b2e4de24c59949"
+    },
+    "gfx/env/graynightlf.tga": {
+     "bytes": 786971,
+     "sha256": "16654901eabc2f4da7ac602c240932acd73cc5831e29afc4dafc51cd2daaa9b4"
+    },
+    "gfx/env/graynightrt.tga": {
+     "bytes": 786971,
+     "sha256": "4f13113e77b85644febb7baff162c19cc353f4257322826389974e516ffd77a6"
+    },
+    "gfx/env/graynightup.tga": {
+     "bytes": 786971,
+     "sha256": "178c815e62bb236b75d967e502ed4a93eba64cd12818081f6f41591860b3d4da"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "e52b65af7e48a66d1b3a9f103c6bf4618b0ad492c103239aec264e21859354c9"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "03f1cedc8786488428d279e382fde8db675ac7ec5d873ac5115a01cfbbc6de40"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "db1a596f26135f81f3fff7e80c75a1cb07c05544be5def0e54d4d8d67ae02be7"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "0bf8a99c4cbf251810de55b8ea308a2b0fc2106ececbfab2d8746a0fabe89cb5"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "d7588a4ce85176b358b8c5c8e22ab946d8aa18634931bdb745afa574eedabd74"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "20ecf7c1229b190a2cabddf016d54125992ae63a6fb469f7f019da92191278b0"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "3f1338998e0e99048fb8cbc242b425a5e91e8124ee32448a1a2725fd169cc437"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8319,
+     "sha256": "9b2eb99c5eba0f4d725c36c30c0934069a8f85442288f66d7609decc06d6f7ad"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 9132,
+     "sha256": "707efb92510d94b65a918e94fd3ae9902b8d78d79934e94be48d8162b3042580"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 20700,
+     "sha256": "3140507b821dc25063ed656e3b6c7ec98a14fc129b690fce67df295c02b48ede"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 24274,
+     "sha256": "677ddf7b9ae6b6a54224981756365ae2cdc325c5c0863df29bd8f1853e1e322c"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 25556,
+     "sha256": "a5e266fefa97fd20c9e73a235e2e8d3d2a40cbcfcb84efc1d05bc67da18ef15a"
+    },
+    "maps/b_exbox2.bsp": {
+     "bytes": 35994,
+     "sha256": "5ef90a59ccab2b70cc9235ad9c3e0a521cd2ff152d64423231102b4f1a1d0843"
+    },
+    "maps/b_explob.bsp": {
+     "bytes": 37148,
+     "sha256": "5895d11eb07913e0f55cecda5d54c333f65e1a7a1bc5795040a4527437ca6f97"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9239,
+     "sha256": "0fa9a0e46a3eadb6bb7ea6fe527f582b67a5c92119e31e5c30d742bd282eda95"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 13950,
+     "sha256": "255c8e560727451e90187f52ebc6fc81dddd6b392e9648c9f0811a02a56a788f"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6946,
+     "sha256": "a422fee149ad2738d035d3a748cbbe89926ff15b5f7f7000d86d82b68c03e6a9"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8792,
+     "sha256": "c521cda7fd9b9c00888728167a6fc23381e5dde881968dd6f784c0ccf21bc520"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10603,
+     "sha256": "1f12bf8c1535a767dfb0efbaf6667ecb9da82c10830abb78b542be7b18a987a4"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 14032,
+     "sha256": "9045aa9140bfa6081eae57f91fc693e9d909496433e06eb9a4f0e927b5cbeb38"
+    },
+    "maps/b_tarbox.bsp": {
+     "bytes": 47042,
+     "sha256": "eb984008bb6401f8ce89c5e1d9571a3ab55c5a81bc6fc2d04f4ab54f2692596c"
+    },
+    "maps/locust.bsp": {
+     "bytes": 41377396,
+     "sha256": "de09dd12089addede5589e2698d26c89beb5849696c23decdb21c5377ce7162e"
+    },
+    "maps/mfxsp19.bsp": {
+     "bytes": 25089863,
+     "sha256": "8533626d47ced92b8398d0b60b34bdec75247b117e39bbf65c42ede02ca47d44"
+    },
+    "maps/mfxsp19.lit": {
+     "bytes": 7383131,
+     "sha256": "91a1f2559be04c021db180ba4bf012439241bff6baab8bec1a5cd49e01f7ca42"
+    },
+    "maps/mfxsp20.bsp": {
+     "bytes": 4251914,
+     "sha256": "0b618c67529b12565afe1e5752357fba4e042cbed4a3522cd6fbcf8bcec80473"
+    },
+    "maps/mfxsp20.lit": {
+     "bytes": 1760972,
+     "sha256": "6ff1feeaa85694a90ad356304aa7841ef745306a16a91e5497533634de860bf9"
+    },
+    "maps/start.bsp": {
+     "bytes": 6785902,
+     "sha256": "c02cfaf0ccbb7f13b3bfc78ea9be7b89706dc4e0733512347b71c95c575fe325"
+    },
+    "maps/start.lit": {
+     "bytes": 2364248,
+     "sha256": "94f6fd6f2be06a3f02782b8f55e2ac1a1701d68ff72d1dc7673a39d22f05979b"
+    },
+    "maps/telefragged.bsp": {
+     "bytes": 48158388,
+     "sha256": "7e77cfd215e40c172b0fb04010bd3a28a9fb813e7986d46617ec3d7548ab09c4"
+    },
+    "maps/telefragged.lit": {
+     "bytes": 9839744,
+     "sha256": "9f6d83f65f86c4a6492922c62fec2845f7c39e77a774f3ee6d018115be364179"
+    },
+    "progs.dat": {
+     "bytes": 626536,
+     "sha256": "676313c8050bd39157a9c2a40546bd92907d6425cea1339d6dfdc1aaa10567ae"
+    },
+    "progs/bank2.mdl": {
+     "bytes": 87092,
+     "sha256": "89cb978aaabc4372bacc88ce577c9aefa2a5a4597aada45aa499861150bfe07e"
+    },
+    "progs/barr.mdl": {
+     "bytes": 43684,
+     "sha256": "8382db232b9a8a6cf6f11009bd8d1806b52ee840c520cea72cfbf5b57c240f26"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigflag.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/blast.mdl": {
+     "bytes": 38268,
+     "sha256": "588c21708e333cc6734849b0067089bd29c6cc15ccaebe5282eef5499ce52334"
+    },
+    "progs/boom.mdl": {
+     "bytes": 77388,
+     "sha256": "c0b2d8695564dbb1ef37aef9a9e226160ff8f5ab40de7a6d7129a66675096179"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cable.mdl": {
+     "bytes": 57780,
+     "sha256": "bed2cca38ef4cbefa9e645eb5e9ffadffac6ebb4f2ac5f6da4bb8f354de22a48"
+    },
+    "progs/cent.mdl": {
+     "bytes": 339720,
+     "sha256": "39762ebe387c080227a35ccec0e8c139b0c9401882c5094d11020e1025f34749"
+    },
+    "progs/chain.mdl": {
+     "bytes": 231184,
+     "sha256": "28974c5f07f119bc5b25b142daae7ac49a29b15ea2ccf0751c213dc1695dbdd2"
+    },
+    "progs/crow.mdl": {
+     "bytes": 12820,
+     "sha256": "b93da84618993c49fea2e4c1550d7c059a01a6f1f1afffa1ecf8c32cf0dd37fb"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/debris_rock.mdl": {
+     "bytes": 17092,
+     "sha256": "6bc5237527f424485344f1689e9906229316a86b10de050d659f44aece3de64b"
+    },
+    "progs/dog.mdl": {
+     "bytes": 317660,
+     "sha256": "d5615d6d0c3b7fe4f284d0fd153a6ea831f5b723ad3df815e10b942533ef6d0e"
+    },
+    "progs/dopefish07.mdl": {
+     "bytes": 224756,
+     "sha256": "0ba9389e5ef7e7a34e319540b70112e3cd788a1888385ffb7f36df176fc356e7"
+    },
+    "progs/dread.mdl": {
+     "bytes": 183400,
+     "sha256": "efb1827edaced94142bb040b179cff11de98c097aab7fe13c80efadadc742314"
+    },
+    "progs/drip.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 770561,
+     "sha256": "bd36712d965c7c2abca65b54d5fe44bdfffdfb8eff69063ff3daac86f3ca0dca"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish.mdl": {
+     "bytes": 221279,
+     "sha256": "34b883e3bf73a520f301cced68629e0d95e88f96c03a23230f12d02aa49c247c"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flamebig.mdl": {
+     "bytes": 176773,
+     "sha256": "ed25b1ae68b7067fc0d112ce9d0161ab055b707ce5b390ea2e0a18a3202e07a0"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "5e59f3019c3a2326fc339f676185e718da6ce116790d544b65a045dae5674ac7"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 349192,
+     "sha256": "697b045e73360642d2108e2936d81a7ebeb3b00966172db8fd677ab4987df34e"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 35488,
+     "sha256": "4a04aaea3b65ef8be1e9ae5e2448bf5fcb530492241a739b689f7380ba509de5"
+    },
+    "progs/g_shotty.mdl": {
+     "bytes": 23380,
+     "sha256": "b919bbcba3f7f03fb8b82fa6d3b1464ca41e81cf29417cfea0de09658c698cfb"
+    },
+    "progs/gen1.mdl": {
+     "bytes": 256884,
+     "sha256": "7a9124bf7628dfcfc1c43ab6624bd8cef4ac5ecbdd8a00a00e8f957f0d177ec5"
+    },
+    "progs/gen2.mdl": {
+     "bytes": 74708,
+     "sha256": "c93a3f7fbda97841c0c9c7c9b2603d9e388390ab30861c4b1553285985f761a2"
+    },
+    "progs/gen3.mdl": {
+     "bytes": 472728,
+     "sha256": "29032f4dcf60216906ef601d5a6bf20dba71ed5b7ff8260e7f61159b6b8ea1e0"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib_tarbaby.mdl": {
+     "bytes": 8788,
+     "sha256": "4b5a5d09ce93ddaf4574e01b514d23c6c12d83b149a942343403f42913cb6bad"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 27652,
+     "sha256": "6ad407e4117bdd615009d4918d32094d9a8b65c04bb1c0abda9a42d288e59153"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "439b117a870ae1d363d5afc4b031f8972be5f7be733b64a054bfca5726b33114"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/hazard.mdl": {
+     "bytes": 7820,
+     "sha256": "d8c1f4b7957bfd98ad10cc4c8cd7c812d9d66283c44f44255f42c7fa2c8aa54d"
+    },
+    "progs/heating.mdl": {
+     "bytes": 243876,
+     "sha256": "a6ab88ce55f16b670b9ba8e42e96c9ea49acc71f124ce20c0de5fc2c0232e2f0"
+    },
+    "progs/helijet.mdl": {
+     "bytes": 102656,
+     "sha256": "9dc737185928f080758e5a662ea8fd189fcad1aed4fe4547f76d73983bec9c72"
+    },
+    "progs/helijet_pilot.mdl": {
+     "bytes": 105556,
+     "sha256": "8ee41a7ac244289b007921b70fd34f322b4451172f35b0c5b33400064d1c3a2f"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/kabels.mdl": {
+     "bytes": 433607,
+     "sha256": "03c41af692903bb854cc5c05c0a8a665f312a04955737ecbac1a65a4113f6d50"
+    },
+    "progs/kruk.mdl": {
+     "bytes": 85612,
+     "sha256": "12914ff8acc41ef1656aef291edef6d3b0975e994808b8e4e921edcc4927e517"
+    },
+    "progs/levels.mdl": {
+     "bytes": 35732,
+     "sha256": "7cf9a4c1e556e60dd4e593cad4a2be0b45bea8893d9b5232ecc7febca4bbf5fe"
+    },
+    "progs/light6.mdl": {
+     "bytes": 81780,
+     "sha256": "e16ac3a669ace065c4cd1806ea0a21a59510d936a3a4c9d74c3ef2ef56e9d4f3"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 315696,
+     "sha256": "7756b837c97369d0c30202ab27b6049596410f15708fd564b2f05702c365efc8"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 192180,
+     "sha256": "ed04d7428d2947bad6f32d0e2c482161866d58ef5c09ba0447aa02f4be83d4cb"
+    },
+    "progs/oscill.mdl": {
+     "bytes": 50660,
+     "sha256": "cdc96265a646f9e9fb4c1717fa90edb13e42130fadc4dc774b60aeb94b89eac4"
+    },
+    "progs/pallet.mdl": {
+     "bytes": 509927,
+     "sha256": "1b9c50111cedb48559424870b46a3d19cb1ac5b43ef3f165fbe928a3f7e90883"
+    },
+    "progs/pilot.mdl": {
+     "bytes": 105556,
+     "sha256": "8ee41a7ac244289b007921b70fd34f322b4451172f35b0c5b33400064d1c3a2f"
+    },
+    "progs/player.mdl": {
+     "bytes": 517652,
+     "sha256": "eaead3d31f963cfe79aebf26b11377be2427701fca9d490503e0e7233e331a0d"
+    },
+    "progs/poster.mdl": {
+     "bytes": 176040,
+     "sha256": "2fa559bb41b0ee212bde75b887678aae53775190ed260f8958aeb753efd8ad8a"
+    },
+    "progs/pstrtorn.mdl": {
+     "bytes": 50428,
+     "sha256": "0f33f23b4b2453a3d433b5df187c0f983ad52be6770bf303edeba21089c54e81"
+    },
+    "progs/raddecal.mdl": {
+     "bytes": 3668,
+     "sha256": "7c149f9e4c1b21fa1972522d82aef407a74917616f35ebfff031f52d6f1888a8"
+    },
+    "progs/res.mdl": {
+     "bytes": 21220,
+     "sha256": "274d9b2d5825135a47cd54773765eac72f5d01b09c39c6a12122662692937c8f"
+    },
+    "progs/rune1.mdl": {
+     "bytes": 18900,
+     "sha256": "0d5bacc295ef6386b360dd017f0d047316e57bb056bff9242142c1ebac83565a"
+    },
+    "progs/rune2.mdl": {
+     "bytes": 19828,
+     "sha256": "ee5855b02abe8de6d1a51187c298a3628abf073ea571de6967da08ccb57bc58d"
+    },
+    "progs/rune3.mdl": {
+     "bytes": 19700,
+     "sha256": "445af16e28fff506ad65fac16b09dad1672e218ffe0183880aff565578b315b8"
+    },
+    "progs/rune4.mdl": {
+     "bytes": 19220,
+     "sha256": "cf52525422a102760bfcabd6e8dd5c5df7c2028daea5baa2a1b1717648dd143e"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/smoke.mdl": {
+     "bytes": 31808,
+     "sha256": "beea4c1bf2e1b0de51074ba3ad70ee19e72ead9929f31cf9eba64ef0d7b0594d"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 341516,
+     "sha256": "d2c12052cf527e0b67089ebb176a8ad2bdb49ada6aed485721d2dd35b6f07518"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/splash.spr": {
+     "bytes": 870,
+     "sha256": "860ad378d89ca0a9748cdc14b3a57f26efe4c0368b2fbbe4020a9d21239a405d"
+    },
+    "progs/starfield.mdl": {
+     "bytes": 23548,
+     "sha256": "5b3563017939382680228e933a2a87d3edb030e75e65c51fe42c4a6889e42e15"
+    },
+    "progs/tarancient.mdl": {
+     "bytes": 98148,
+     "sha256": "78ee304a3e54b04c19a7aff0c2860739e3d7ecd46eec721e16481b68650a6aae"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 239096,
+     "sha256": "52e7adb0272ee90985cc65dbd18391618cf9cf1906519671e34ee3044145808f"
+    },
+    "progs/tarchild.mdl": {
+     "bytes": 239096,
+     "sha256": "71c48a66b4fe6c203b4cb16a572f459b825fdd40a77656eb5073b67e36dd81eb"
+    },
+    "progs/tarparent.mdl": {
+     "bytes": 239096,
+     "sha256": "1646200584ba353e74fd4d291e3fa06f5b6e2ff91aeba04b9d42a29a090dc79c"
+    },
+    "progs/tl.mdl": {
+     "bytes": 132148,
+     "sha256": "81527d7e8917b2582fc5d620b7530b1e41cc041f892a9116b0849fdaf59a578c"
+    },
+    "progs/tree1.mdl": {
+     "bytes": 232924,
+     "sha256": "7cb8b341835b99c393aa56e69a804ceeddd38a2ee5b95738aca894205875640b"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 53615,
+     "sha256": "57cf73dbf14b5b22795033f5b597b30b978aeb6ee037e09648d0cebd029f987e"
+    },
+    "progs/victim.mdl": {
+     "bytes": 1432944,
+     "sha256": "c5d2a99ba39e82bef21cdff5f682b6b80d601f9b54fe0d58d94aae3544b5303b"
+    },
+    "progs/vine.mdl": {
+     "bytes": 20736,
+     "sha256": "5ae41ea778a9ed499e57b95e66b4340709ab64560784c346ea2755fe9cc90a72"
+    },
+    "progs/waterfall.mdl": {
+     "bytes": 43588,
+     "sha256": "402925369f4fab61b9e61da3df09138d6f52a64e4daa357a7d1fb5adad95f1fe"
+    },
+    "quake.rc": {
+     "bytes": 617,
+     "sha256": "f9984923c21275756d6468f4fa18a84e8e37af060b9df72c376fd8bf510d20e9"
+    },
+    "sound/ambient/airvent.wav": {
+     "bytes": 430618,
+     "sha256": "1e37b913f0e9dbbf9ac1b01f5ce44ae7534aa98a4e4e8cef1a9568b7837de6cd"
+    },
+    "sound/ambient/alarm.wav": {
+     "bytes": 168024,
+     "sha256": "031e1d682e02c68ed2d00a30cd66aee78d61f545df1c50ce24061a7bf71dfd81"
+    },
+    "sound/ambient/base_ambientloop1.wav": {
+     "bytes": 3480328,
+     "sha256": "e4970d2e679e7ddfdb6da696ceabb9d2ab0d6005d17ef2e56dd61eb6370f58d2"
+    },
+    "sound/ambient/base_ambientloop2.wav": {
+     "bytes": 2419576,
+     "sha256": "8f487f47f7ac1313c0d93b7ee4356fc0c574e70100a4ecd933e62b4c77eea7ac"
+    },
+    "sound/ambient/base_ambientloop3.wav": {
+     "bytes": 2419576,
+     "sha256": "f5c28d2fec4d0a87629e45a535ed2af337fce616e31bfb057fff27a4522b2844"
+    },
+    "sound/ambient/base_machinedrone1.wav": {
+     "bytes": 605176,
+     "sha256": "8d54df6f381fbd08620812992a261760c3dd50fb870530c65e91e2d31b0709fb"
+    },
+    "sound/ambient/base_machinedrone2.wav": {
+     "bytes": 605176,
+     "sha256": "0361d4670874263b41d43cc9ee1e1626ba0461f0335d3a799909218f4cc5b2b3"
+    },
+    "sound/ambient/base_machinedrone3.wav": {
+     "bytes": 605176,
+     "sha256": "dc14b44d55876fbdf4553fb395b0ced35e1919f660cc51eff1cadfdb703feb17"
+    },
+    "sound/ambient/base_noises1.wav": {
+     "bytes": 4233976,
+     "sha256": "628e1461a3d6cabc498765be56ae75f2dd47c995cdeb5e5708a87cb3852ddfcf"
+    },
+    "sound/ambient/chatter.wav": {
+     "bytes": 190760,
+     "sha256": "59197f823b479c66c41163d82fed6dc13a715aef429b5e551ba80ca6f7c229fb"
+    },
+    "sound/ambient/clicker.wav": {
+     "bytes": 1013172,
+     "sha256": "1ba16c18364fe0dd8d0d75485c7b0530b762b76a0a869d86ae3ea6bc95859236"
+    },
+    "sound/ambient/comp.wav": {
+     "bytes": 12164,
+     "sha256": "ab8e3b13981bb432cca44ad4b7467734f52d01927018e72c99e7c4d052dc7874"
+    },
+    "sound/ambient/compressor.wav": {
+     "bytes": 797264,
+     "sha256": "f9744ee5de6ad1949f0fc917ad3602f8eaa6cf1c3544747220c31ba5d4d1050c"
+    },
+    "sound/ambient/crickets.wav": {
+     "bytes": 12236,
+     "sha256": "d5cf6e56884a8e43469408d4788ec6e573167901586df259a938cd088c998ef9"
+    },
+    "sound/ambient/curnt1.wav": {
+     "bytes": 202706,
+     "sha256": "9747fd9a0a546a1bdee77e4eaf5f4ac4e4e3f4f875dd764aa61e9fcdf549cdc8"
+    },
+    "sound/ambient/curnt2.wav": {
+     "bytes": 183438,
+     "sha256": "66107487b96c250125d31f78c6e77928768fc8c3555f298a94b012addfc9b925"
+    },
+    "sound/ambient/curnt3.wav": {
+     "bytes": 159226,
+     "sha256": "b10338b7cc58c6ed4f69d21d8e65ea15568dda3b067f7ad8e4e386f27aef6b17"
+    },
+    "sound/ambient/demonwind.wav": {
+     "bytes": 357574,
+     "sha256": "8bca3e8f399d9b6e2b8a7c4e0a21c462e8a5bb1ff5044fc4e0255d6081cecbec"
+    },
+    "sound/ambient/dishwasher.wav": {
+     "bytes": 702736,
+     "sha256": "a23001fb2c9dd6cafda4cb1c1314046a80d18abd76927d63019cf38d0b30a191"
+    },
+    "sound/ambient/doomtweet.wav": {
+     "bytes": 49818,
+     "sha256": "e04298e7bb770dacce5d70e39309538b5dbd5c33b9ad613572f3be45e0283615"
+    },
+    "sound/ambient/drone.wav": {
+     "bytes": 30902,
+     "sha256": "81993d96ab337f78c2778cecffe4767605fed210e0ac2303a46ac898979eea13"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/freight_train.wav": {
+     "bytes": 518592,
+     "sha256": "1547f633989130099ee02f7f6031e5b7f200f8693adc8288d8e7cb4561b8ad57"
+    },
+    "sound/ambient/fusein.wav": {
+     "bytes": 54542,
+     "sha256": "0cc8a1c6176c7c26dfbd03631c74bf25a5cfe99c03d402188c9f0a5ff5a4fcac"
+    },
+    "sound/ambient/fuseout.wav": {
+     "bytes": 61382,
+     "sha256": "59809909620202a8d10f0495ab314e6f052c8a18479846bc4487b766f593faef"
+    },
+    "sound/ambient/generator_electric.wav": {
+     "bytes": 247384,
+     "sha256": "8f5004d6b83b1c11969544252589675fefda3b5634057e8fcb38ea9d67b8f396"
+    },
+    "sound/ambient/generator_gas.wav": {
+     "bytes": 529314,
+     "sha256": "6710075453fde424951171823e87f3711d53fd434149ddecc14a14ce721de04a"
+    },
+    "sound/ambient/ghost1.wav": {
+     "bytes": 317854,
+     "sha256": "9e42bb161511128c5f9081a3df40c7df4e37d6d268acc3ba393683e484e57fe4"
+    },
+    "sound/ambient/ghost2.wav": {
+     "bytes": 292034,
+     "sha256": "d5f5e9835df3d4afdf2c279ecdf1e4fe01332a54fe39c88a3fa81c57e1697b8c"
+    },
+    "sound/ambient/ghost3.wav": {
+     "bytes": 289946,
+     "sha256": "0c8e2669959e8d75c38cbb607063f00e81d906b77939ac1c51395152a02acd7b"
+    },
+    "sound/ambient/grinder.wav": {
+     "bytes": 264572,
+     "sha256": "70789db5c6e505292dd6031241aff19bd7b327677033cac5f98c1dcfeed5c6db"
+    },
+    "sound/ambient/hammer.wav": {
+     "bytes": 23300,
+     "sha256": "4122f7da3b462514adafcf1af2ab24d784cbc1ac8d94a143ab62dde11364c686"
+    },
+    "sound/ambient/heating_vent.wav": {
+     "bytes": 422018,
+     "sha256": "9c17e400683bd2e671b846e9c7740870303a52390803d69cbb769fbd5afd91c0"
+    },
+    "sound/ambient/hum02.wav": {
+     "bytes": 37836,
+     "sha256": "8b2ee1b91fa663b6111de9251011142475831ece70ee091022b800b715f1bfa2"
+    },
+    "sound/ambient/icemaker.wav": {
+     "bytes": 421230,
+     "sha256": "4b6869f552c38e5ccdbb809c7005270a8760ce042b34a5bb5cfafcfe2dd5f34a"
+    },
+    "sound/ambient/install.wav": {
+     "bytes": 29366,
+     "sha256": "c01770c0abe52f40a56397ac0fdefe9865b3964a0689f5caf98f2bb47317a1bd"
+    },
+    "sound/ambient/intake.wav": {
+     "bytes": 25682,
+     "sha256": "e6d13169ce4680dd83903473897fd6e7ce1e51fab00c6df2127ea993321c05b0"
+    },
+    "sound/ambient/lathe.wav": {
+     "bytes": 874760,
+     "sha256": "1d9d7c6b8b665dffb6f1682e6faa39d92bc75ac6278297e1948c6ee6c5fb09c1"
+    },
+    "sound/ambient/lite_on1.wav": {
+     "bytes": 46188,
+     "sha256": "6a8f489dcc99fed3d7d0f731c84bd1ee90711d032b6e0204e12187a4c5923748"
+    },
+    "sound/ambient/lite_on2.wav": {
+     "bytes": 35746,
+     "sha256": "d605e14c21b797772507ab5177631647243f68e08b0ae316fb85ca252dceed6b"
+    },
+    "sound/ambient/lite_on3.wav": {
+     "bytes": 92362,
+     "sha256": "ca329bad63910f68b603c3cd9eea0b8cd9d7428f96ebb27032a066808637e8bc"
+    },
+    "sound/ambient/lite_out.wav": {
+     "bytes": 80906,
+     "sha256": "d5e5747ec548eb9118c2190a59b9dcdcbe5335a2987726d7768415eb7e1fe573"
+    },
+    "sound/ambient/lonoise.wav": {
+     "bytes": 32876,
+     "sha256": "1e0f99ffadead8460a7a4bed1c6b2c16cddd70050e1524e9cdaf6724a9dc81b5"
+    },
+    "sound/ambient/lowboom.wav": {
+     "bytes": 666640,
+     "sha256": "ad591a6f574f48e654e32dacee6b7d862df8b47e20ef116f84415ad9aa515559"
+    },
+    "sound/ambient/machinea1.wav": {
+     "bytes": 314794,
+     "sha256": "af6c32af2cbac08d23e0626d83b2d55467f1d6aedf9f9c09a05fe3256e589c39"
+    },
+    "sound/ambient/machinevat_loop.wav": {
+     "bytes": 264706,
+     "sha256": "9c7217209bc2fd059622c217f403208e97699236ab79bcad867c4e990ee3b38d"
+    },
+    "sound/ambient/metal01.wav": {
+     "bytes": 439842,
+     "sha256": "c5bb0ff8f14e138244ce76279a816980e3e8b19ebede04ac9fca28e653e874a2"
+    },
+    "sound/ambient/metal02.wav": {
+     "bytes": 188002,
+     "sha256": "9eb4637999234308b3fceb5cdf30df765f721d4f1e80554690fbfa74646eebd7"
+    },
+    "sound/ambient/metal03.wav": {
+     "bytes": 238550,
+     "sha256": "5404861e66ce3394d9a352485f8dc6063b926f900f1ee84ae6512e142c1d0f44"
+    },
+    "sound/ambient/mother/alarm.wav": {
+     "bytes": 168024,
+     "sha256": "031e1d682e02c68ed2d00a30cd66aee78d61f545df1c50ce24061a7bf71dfd81"
+    },
+    "sound/ambient/mother/countdown1.wav": {
+     "bytes": 5276,
+     "sha256": "342ea3abbd6096432e639cba75caf59bae7224494eed2391133f5e1feb811e0f"
+    },
+    "sound/ambient/mother/countdown10.wav": {
+     "bytes": 10762,
+     "sha256": "e2fe24b7f85d245c0244f212311193a1c7dace66ddca97a7a99ccfefc06f0aaa"
+    },
+    "sound/ambient/mother/countdown1minute.wav": {
+     "bytes": 31064,
+     "sha256": "79aa380b1e03510afa0641acb4165963ac318524bf6b9a3ef94f737307636c5f"
+    },
+    "sound/ambient/mother/countdown2.wav": {
+     "bytes": 5024,
+     "sha256": "62cd08e528b9c6dde14de39ed93f994bd9315ee1eb9d09b680ba31f1b7d8238c"
+    },
+    "sound/ambient/mother/countdown2minutes.wav": {
+     "bytes": 31614,
+     "sha256": "4cbfc3ae6f6057fc1ba80000de49422ffb4db74eb0ba3f8e878c3aabe69d041b"
+    },
+    "sound/ambient/mother/countdown3.wav": {
+     "bytes": 5192,
+     "sha256": "238df29f8855e4e54e66a0b9f602a130ebce489aef0dbf6ceda7f09260a9c186"
+    },
+    "sound/ambient/mother/countdown30seconds.wav": {
+     "bytes": 35574,
+     "sha256": "3fa43fe929505489afdb670f7690d916439f1e8639170611f19d9c0ae329c487"
+    },
+    "sound/ambient/mother/countdown3minutes.wav": {
+     "bytes": 31394,
+     "sha256": "b82a14748057cc872deaf2cd67ed8d8c83774bd894274828f9c04fb9c11d21ba"
+    },
+    "sound/ambient/mother/countdown4.wav": {
+     "bytes": 6036,
+     "sha256": "20a795ac340d376041385a96664db61773bce5b54e4f0696ba5b4c32dc18275e"
+    },
+    "sound/ambient/mother/countdown4minutes.wav": {
+     "bytes": 32494,
+     "sha256": "e3d69e6593870044bdbdab84e1baf49df8e4874be2b3725421670aa72439be80"
+    },
+    "sound/ambient/mother/countdown5.wav": {
+     "bytes": 6626,
+     "sha256": "abbed1c6808b7886f338d687c03c93f564a5180bc32580f6735a3202c3ea6c0f"
+    },
+    "sound/ambient/mother/countdown5minutes.wav": {
+     "bytes": 33264,
+     "sha256": "9341552210cba0f5767b166d65612096b09c69f761f354d627a261cf741e57c0"
+    },
+    "sound/ambient/mother/countdown6.wav": {
+     "bytes": 6120,
+     "sha256": "9c8ed0a8fa00bfef5d6f5ad5cd89402cb9d00db35e8dd091a3d68257fc5f766f"
+    },
+    "sound/ambient/mother/countdown7.wav": {
+     "bytes": 7134,
+     "sha256": "78c63a99b21827350bd45b98b5dab1c0be2584d4e4a120f45acce5904ac33f10"
+    },
+    "sound/ambient/mother/countdown8.wav": {
+     "bytes": 5952,
+     "sha256": "29f4a3aeafab97b05a8b51223ce4c877e934f632c15869ad75326a373ddfef70"
+    },
+    "sound/ambient/mother/countdown9.wav": {
+     "bytes": 7048,
+     "sha256": "8f650347b39854001b5e22964a53490c2c7de4cc2e9248c420c01b97f2893271"
+    },
+    "sound/ambient/mother/countdownstart.wav": {
+     "bytes": 75714,
+     "sha256": "0333512b5337a80c32ea82ff187f49548e859d39463d5fb3fb4a5f0239d1d15a"
+    },
+    "sound/ambient/motor1.wav": {
+     "bytes": 52340,
+     "sha256": "c48511a37143e9ed50ae7c1d1f28235b007762949d3d18549fc545cc670c0a24"
+    },
+    "sound/ambient/motor2.wav": {
+     "bytes": 52014,
+     "sha256": "7f36cda5c01aea4e6b356ae4d0b31b68ca15d7606eefd30f4739a64fc4e86e6c"
+    },
+    "sound/ambient/ne_lava.wav": {
+     "bytes": 688210,
+     "sha256": "97b6639fcb33610af32490b93763761a6c905f6f47d599fcf16711c71e711385"
+    },
+    "sound/ambient/pipewater_loop.wav": {
+     "bytes": 264712,
+     "sha256": "c9e841cba9ddb9bbfc0adb6811096e5f30bc6d90328c2000507f85749ffb88ca"
+    },
+    "sound/ambient/powerloom.wav": {
+     "bytes": 386188,
+     "sha256": "e78bf67110d34ea105e8f674261826d81d4637ac2f1d4ee08c54940120801d2e"
+    },
+    "sound/ambient/rain.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambient/teeth.wav": {
+     "bytes": 51600,
+     "sha256": "9649cc3a15c66b851da286bfbfe085196e851a9a493c299b03d9874dc04431e4"
+    },
+    "sound/ambient/valveturn.wav": {
+     "bytes": 171604,
+     "sha256": "87a6b446aebeeecfbfe6a47307ab64221a6864039fa8234a466dc2c60864950c"
+    },
+    "sound/ambient/washing_machine.wav": {
+     "bytes": 264722,
+     "sha256": "6c9ec4fc45ff24639fedbda291dbcbfac5dac8e5da0293227aba67511d7bb1b7"
+    },
+    "sound/ambient/weirdpipe.wav": {
+     "bytes": 1003484,
+     "sha256": "2ab680927cd84a2aa3d3fba40f1c2f7629e0508605893bb913562710818364fe"
+    },
+    "sound/blob/death1.wav": {
+     "bytes": 16368,
+     "sha256": "7abfd2fc8d60450c8cb8ff8fe966f6abaa3314083eb650caf4f5de5fae2b234f"
+    },
+    "sound/blob/hit1.wav": {
+     "bytes": 10026,
+     "sha256": "6b1ea1fcef3b54a3d76561f5cf275b59b926005be7112d18459698da394c2d76"
+    },
+    "sound/blob/land1.wav": {
+     "bytes": 9232,
+     "sha256": "31d420d09405629e8b4acb3a83f14c1ff2637634d25dd462c018878892b89686"
+    },
+    "sound/blob/shoot1.wav": {
+     "bytes": 7180,
+     "sha256": "c511dae17bb6adc80a3cfc9d12d1a968063777576e0ab797a518e1f7c7ce76ba"
+    },
+    "sound/blob/sight1.wav": {
+     "bytes": 7182,
+     "sha256": "6d6778ac09c501b350bfa727f97bb1da7a0867afac8baed2f73c4e6c2378687a"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/env/ma1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/env/s10.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/res.wav": {
+     "bytes": 144258,
+     "sha256": "a85395fd0531a2958377dc91434ec02db8537d92e2fdb3b1f5bee5d6353a9e27"
+    },
+    "sound/items/res2.wav": {
+     "bytes": 144258,
+     "sha256": "63027a4ef67098aa225b846d32b355aca4707c64b402a67d2b99ae461968438d"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/drip1.wav": {
+     "bytes": 12172,
+     "sha256": "9499c277eab2210ba491b61263b71410e5e8f4b2a68403ec6eb81bef687da04a"
+    },
+    "sound/misc/drip2.wav": {
+     "bytes": 15596,
+     "sha256": "410c25c5c459362849c7d3d0ad736e006b65a949e77c094fe248e803b357d5e0"
+    },
+    "sound/misc/drip3.wav": {
+     "bytes": 15164,
+     "sha256": "9ddf50265efafde7736fb7d03419988caab691245b32d986549ef6d643d2768c"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 4060,
+     "sha256": "3bab8fca9733e6c9f045e24f52ffbac401c757b1fe9f28fff967f21357bbadbc"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 11588,
+     "sha256": "8b9a0404fefb408219731ff264cb5490d1178a2ddd2afe02db4a5ddc6e427171"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 11966,
+     "sha256": "af1026fd9051e2c9c84f4eeffed454d7328969a29a2d11301464e383c6c809d8"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    }
+   },
    "sha256": "cc993c453d1a106e21a0b2b316c739cc0a7675b3554241c5de7fb4339353e975",
    "timestamp": "2014-09-13T18:01:22.000Z"
   },

--- a/json/by-sha256/73/73d52d6c1c07ba76597cd2df90d22eb3d41fa5e0ccbe2dbf530e6bf70f86a9f5.json
+++ b/json/by-sha256/73/73d52d6c1c07ba76597cd2df90d22eb3d41fa5e0ccbe2dbf530e6bf70f86a9f5.json
@@ -12,11 +12,143 @@
   },
   "pak0.pak": {
    "bytes": 23284165,
+   "files": {
+    "gfx/env/1960moon_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "2cc00bb935ee2f4019f4d99170d38ef3f51c72ff80150cd74911b1038a0cb269"
+    },
+    "gfx/env/1960moon_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "4620858e8161b2582255a2209757e216f7e66c3630a8756cceb2433727617249"
+    },
+    "gfx/env/1960moon_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "871df5eed200970b8c3246ca10a039f5915c95e8f48bf0692fc22f2f7e5450cd"
+    },
+    "gfx/env/1960moon_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "3b4e85116e3999d5cded25ca0a5d6fb9c297b3d69749a63daf5af6c37fe21959"
+    },
+    "gfx/env/1960moon_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "7381c46aa4f5c916f3bc8f82a442a4582834563c0bb0127580053bb274609180"
+    },
+    "gfx/env/1960moon_up.tga": {
+     "bytes": 3145772,
+     "sha256": "26ea233063b0289e905bbd16f20bd3cd3789e6580be31bdb2e5c7a274b711058"
+    },
+    "kaahoo1a_readme.txt": {
+     "bytes": 2937,
+     "sha256": "868e04f53b31050df3355a5859b0d8687b071d7dad8f842b9e0c40d3c94de6d7"
+    },
+    "maps/kaahoo.bsp": {
+     "bytes": 1863116,
+     "sha256": "e245688bc1f8ff8cff09c308f6794c155f64c344ea29f1d961e9780c05bab132"
+    },
+    "maps/kaahoo.lit": {
+     "bytes": 982580,
+     "sha256": "e95ca2ade5f509fa8707a32cd3355fb4604903c5c90c15c7ffd2f8706ca65482"
+    },
+    "source/kaahoo.map": {
+     "bytes": 1062056,
+     "sha256": "91a2ebf3fdd39387d1afb1dc16d7db50273ca4d9704bf912f7debf0d4f6a8046"
+    },
+    "source/kaahoo.wad": {
+     "bytes": 498128,
+     "sha256": "3047a9494ccb044c2ff359afbc17b7d6363009f2544fcf1f97c430497d3e7a79"
+    }
+   },
    "sha256": "9799e46f1e7de9248589a9d1fb7bc471ee6400f14b96ac3c1e41cf2b3841bc81",
    "timestamp": "2014-06-10T21:59:14.000Z"
   },
   "pak1.pak": {
    "bytes": 164928,
+   "files": {
+    "maps/b_batt0.bsp": {
+     "bytes": 6980,
+     "sha256": "0d481a2e2cd7a23e4ef19c19622195007bd6c9a67135ef739b0944a02d46fcd7"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6964,
+     "sha256": "34709c1c06ca34305a8ba1d4799d1cdc07e44ff33f3c7fa11c3d5933cb942579"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 7124,
+     "sha256": "d3371655bed274070fa98fb32b408bab4a22fe754f5158c8c94a072749a5d24d"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 7764,
+     "sha256": "abdfe383c13da6d5dd7a9409fa5d3db2c4bac78482eb75c2c2b42da7811ec3ca"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 8788,
+     "sha256": "2343448faac29720e3a690650b70623852710dcae002917ae5772fa597117e17"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 5604,
+     "sha256": "66ea23f1cdd6225afdd1b7cf1247b93d174562193e0807561b96b659429f2bf0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6820,
+     "sha256": "366ece777ae71ecfebaa9f4bebafe2074b5336e7939900f46bd9521886f9f42d"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 7092,
+     "sha256": "56a66aa3d1364a0436ff8ce880268b2a9c2c396ab02f0c6277535d5b99eae31a"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 7636,
+     "sha256": "ddd60cec57d8e3954c1ffce616ae862edb784417a6b6622cc001d408383a6cb9"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 5396,
+     "sha256": "fe60bd7880da73571e29fa4075968cccb06e913bd2b9475868ce31c69b1a8c19"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 8436,
+     "sha256": "6a2c2c3fa6f88d425ae5b9568e5d8224ee901a1d8faa8363b88fff569b7d0e5f"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 25812,
+     "sha256": "1ba9d3176bb2e03a0457427fd9394d8c15eb9ebae8af9462e955e9c6c6068513"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 3860,
+     "sha256": "256412b0d88c020fb03efc5e914c5dd721c9dfe8d6a36ce4a7b01e7597d7e7d5"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 5492,
+     "sha256": "ecf293b2e8146a33de7bc8bb3cded80bb785b931012b40dca204db3dad50e776"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 22052,
+     "sha256": "c5657b558522e46f0833b7827520c1a5c1f1674dffd52c12609779d5bcd75462"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 1396,
+     "sha256": "945ad552ad86e5193ef9c007dbe23686fbe89be1060063f57ea693b89e5df229"
+    },
+    "progs/spike.mdl": {
+     "bytes": 1396,
+     "sha256": "c5e6afcfbfe35ffde5bda7eaf91e2a583c3f20cf8f3175b4f4e0ad03b358983c"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 9012,
+     "sha256": "06e8f32092cbc0b5ba4d26227df9ac2d10f3a76d9a63bc7928af147b4ade12d7"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 6356,
+     "sha256": "40d9d29c58df57ece6892d71d0464022eb5939aa45699e98eae22136b973c4c8"
+    },
+    "quake.rc": {
+     "bytes": 1220,
+     "sha256": "780422c2d8dff247ed267e21a0e4fd1df895ac95cdd65d180c1c02669550c924"
+    }
+   },
    "sha256": "eb3eede078c4529d27d9376b453fb74c8687cf0a975bc994dadb55dd68baf62e",
    "timestamp": "2014-06-10T21:59:18.000Z"
   }

--- a/json/by-sha256/74/74e8a4b31d5062510ec4793388bf4fc4c5c672663138c37f59dab7c857d98ef8.json
+++ b/json/by-sha256/74/74e8a4b31d5062510ec4793388bf4fc4c5c672663138c37f59dab7c857d98ef8.json
@@ -7,6 +7,276 @@
  "files": {
   "Pak0.pak": {
    "bytes": 4068093,
+   "files": {
+    "end2.bin": {
+     "bytes": 4000,
+     "sha256": "8e882df320279c16a2a14440ad84184e9b754af8603d3ff051bd3a606568aa0d"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "175f9747ae7feca1b718ea86e0edced0870a7980db3ab5dae5645299c7984de3"
+    },
+    "he.com": {
+     "bytes": 24878,
+     "sha256": "963315333a419e33024b98559fecede1a0975be685e8fd816865f4c826bb530a"
+    },
+    "maps/ruliano.bsp": {
+     "bytes": 1541920,
+     "sha256": "7cdede56bdf786343a0dc7ac1a135570dcd2ab54524f4d8bf7f287713e3953df"
+    },
+    "progs.dat": {
+     "bytes": 621388,
+     "sha256": "dabd5d8a8791b4b6e333fca8dbba2cd3867dfe91ce4a1d86b5fb4320d4164407"
+    },
+    "progs/bazooka.mdl": {
+     "bytes": 143952,
+     "sha256": "47772f91909c6d23ba031fb2faa2941ed427affea3c22a5d1b31b5e6b53ff98f"
+    },
+    "progs/beam.mdl": {
+     "bytes": 11348,
+     "sha256": "4e42c53fa58ed775a4f331b46fc31cfe537e28179cbefe579e9d9309e3a0afe7"
+    },
+    "progs/fem.mdl": {
+     "bytes": 252188,
+     "sha256": "ba8de6d4c3f504e33f46e6ae4d32d5034f4d49753640433b34685a94eb56fa24"
+    },
+    "progs/g_dshot.mdl": {
+     "bytes": 71894,
+     "sha256": "cbd8b63c4bd24f82e5d40bf1493c9f1ecf68aac6634ea4b01df8b8baaa174a78"
+    },
+    "progs/h_babe.mdl": {
+     "bytes": 26804,
+     "sha256": "9adecc483c26658401d441592a92f19337a13c65b59aa64c14a6ee21afed9d63"
+    },
+    "progs/h_fem.mdl": {
+     "bytes": 12311,
+     "sha256": "2cca1ecff95e6f62ac26991360919412957c89176ba89d367db3ed3fb7b67dd7"
+    },
+    "progs/h_pino.mdl": {
+     "bytes": 15613,
+     "sha256": "31c7c684cdc2444585256889b8d2eaa33ac2798c13e7f2e7957225560e8e297f"
+    },
+    "progs/hgren.mdl": {
+     "bytes": 1997,
+     "sha256": "61e33e422d011b5e838e19f9b04f4c40bb78e617c06a2ff566119535946337f1"
+    },
+    "progs/pino.mdl": {
+     "bytes": 220356,
+     "sha256": "82556b19cdaa96f52d70d0efcf56ae206e48a36f2e763a475b20cb80e999fb18"
+    },
+    "progs/pulse.mdl": {
+     "bytes": 15988,
+     "sha256": "a1d14c7171de546fba12a05de679b65f3106320c412269ebd16240fa83b0f93e"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5509,
+     "sha256": "ee355fc9721a0827b444701e9c9825d706d9911b72e64f5335fbcbef9e2b0053"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 16228,
+     "sha256": "580b6949c1858d7ef517b601817e0d2f3ac190bf753bcb5b834f874adaf61d4b"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 5509,
+     "sha256": "ee355fc9721a0827b444701e9c9825d706d9911b72e64f5335fbcbef9e2b0053"
+    },
+    "progs/s_explo.spr": {
+     "bytes": 21885,
+     "sha256": "f5039571da0e57cb6a640bfa78a42fd8d8b5909e6838f336d2018bfecf3802d2"
+    },
+    "progs/scrap.mdl": {
+     "bytes": 1332,
+     "sha256": "668b024fdb6d2c48de06462481614bcf03319fa70766d49882275e8358782a1f"
+    },
+    "progs/v_dshot.mdl": {
+     "bytes": 77102,
+     "sha256": "b68cb1442486543e3f05a5ca4af03f0d8857291819c0e84e4d7688b08f4d7a1d"
+    },
+    "progs/v_laser.mdl": {
+     "bytes": 68732,
+     "sha256": "8e42db3ff82923040b712e82c3ef09d28e4357609a8f1c2c71f6c1c2c1a98a7d"
+    },
+    "sound/ambience/back1.wav": {
+     "bytes": 29044,
+     "sha256": "4caace7efee0535a545e462902d3aab1989f9ddfc9d5b6bbdce344a113585fc5"
+    },
+    "sound/ambience/moan1.wav": {
+     "bytes": 31508,
+     "sha256": "25d2cff48eaeb909012d5a3f2823175223729fd5146ce68e369023f8cf8a41a1"
+    },
+    "sound/ambience/newhum1.wav": {
+     "bytes": 35258,
+     "sha256": "d2c07398d1a6ecada4987780bdac04460d4faa578a2e829f7bca8f5edf8100a3"
+    },
+    "sound/ambience/vd.wav": {
+     "bytes": 41584,
+     "sha256": "ba92783bfcb887e68af3bb57c1d3fb4071674a17066a3685ea2187dae61bf850"
+    },
+    "sound/bazooka/ahaia.wav": {
+     "bytes": 7748,
+     "sha256": "b9a2527347e2272a676390b3a6bce4cf623f233a11b27d932e340ed67e72823d"
+    },
+    "sound/bazooka/die.wav": {
+     "bytes": 9260,
+     "sha256": "0bae4e5baa31c64ba4fc94df64e0dca08c06a732baea03ae4167b75e00318e9b"
+    },
+    "sound/bazooka/dies1.wav": {
+     "bytes": 8856,
+     "sha256": "663fcd16df6c845fc318a6181b2eece0678f9f3980a90ea3d34f0592e61e6087"
+    },
+    "sound/bazooka/dies2.wav": {
+     "bytes": 9212,
+     "sha256": "93f2868e3bbda78b74970a8912e8bad6f50e130692c4ce066aacdb5d51811e48"
+    },
+    "sound/bazooka/dies3.wav": {
+     "bytes": 9752,
+     "sha256": "439d327515f423fe662a8930b6a1d07d693f43331996119e05d32efc5d44457c"
+    },
+    "sound/bazooka/grrr.wav": {
+     "bytes": 11356,
+     "sha256": "8c6609a6ea9d85f10cda8dd2aa2d0fb77f5e9690698cbafbc213eb5d4f2b6f5d"
+    },
+    "sound/bazooka/ooaa.wav": {
+     "bytes": 4872,
+     "sha256": "76d5ae6f0532eb1a43493330c90966be651e05ba9eed2a994a9afaf28c73de78"
+    },
+    "sound/bazooka/step1.wav": {
+     "bytes": 27042,
+     "sha256": "fc485f8365abf042f2abb94ba4a21f077f688419e252a50fe9cfba2f55fd280a"
+    },
+    "sound/bazooka/stepstop.wav": {
+     "bytes": 6102,
+     "sha256": "79ec338698b2f8bfde44e0b5e8e31ca3d34e140ca88a45eb81c7c72b7ca31134"
+    },
+    "sound/bazooka/when.wav": {
+     "bytes": 23194,
+     "sha256": "af1c2534c69cfb3f07e160cd39f66fcfbe9d64580cb9fcfc43520637c6931532"
+    },
+    "sound/bazooka/yeow.wav": {
+     "bytes": 6474,
+     "sha256": "776a81059bc7fd0f8c998f5e8e05837686d1578c8860aad77901665c31370caf"
+    },
+    "sound/female/die.wav": {
+     "bytes": 8950,
+     "sha256": "6cf8516d992c87def74648c412187398bbca5a38ebabf87b847132ab2c6a37f3"
+    },
+    "sound/female/fire1.wav": {
+     "bytes": 3042,
+     "sha256": "588e59142330a09865485646a20eacd86a64c66c4c37c9db757882d06518b775"
+    },
+    "sound/female/hurt1.wav": {
+     "bytes": 3386,
+     "sha256": "44203f7119bb5b1659c02fb687f43cd6639629ffd3b6ece9c2b31bb6d6b34e8b"
+    },
+    "sound/female/hurt2.wav": {
+     "bytes": 5650,
+     "sha256": "3750428ae5b2e114a5ef2ca9d604bf69c28c4eb976870d6ba0d02d7bc77d38e7"
+    },
+    "sound/lobo/he.wav": {
+     "bytes": 28379,
+     "sha256": "07c09a5732a220cf69c12804e51453e9d6b243614da1812bbfa75a45d066038f"
+    },
+    "sound/lobo/he2.wav": {
+     "bytes": 5964,
+     "sha256": "778e4db73aa617441cf4eb92cec398668d265e3355212211bdf159559d0ab9b0"
+    },
+    "sound/lobo/muere.wav": {
+     "bytes": 23006,
+     "sha256": "b52effb5f8205e1018744d32fac384a696fc61d78459797ce219a0294aa05545"
+    },
+    "sound/lobo/pain.wav": {
+     "bytes": 8415,
+     "sha256": "2c2610659be802d0851e5e395243b97a833cda55b19c6bb44bf4a60798c69c79"
+    },
+    "sound/lobo/pain1.wav": {
+     "bytes": 4548,
+     "sha256": "1fe1f90e5fdbba29c0f401bfa22bf62cc3d3ff9e65fd9f908dbbe97d48d7da3b"
+    },
+    "sound/lobo/pain2.wav": {
+     "bytes": 5036,
+     "sha256": "484d939485badf63bef04a2b31c3302a5a6a3763d5ae480363e15cf2040d3ce4"
+    },
+    "sound/lobo/wizact.wav": {
+     "bytes": 41332,
+     "sha256": "a53b50cacb36380905f8e1a4276cd1061352eccf2d850f690dd2789f614d06d8"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/pino/alto.wav": {
+     "bytes": 6836,
+     "sha256": "7a4cec339d65a495130adb00eaf0d1629149e3d0ec8b5b1486dea10d0d5b1aa6"
+    },
+    "sound/pino/death.wav": {
+     "bytes": 23034,
+     "sha256": "0eb20419acddee8a5814ecad8888348f90a14db997af1045b02b6052dccd5fd1"
+    },
+    "sound/pino/death2.wav": {
+     "bytes": 32314,
+     "sha256": "3b1d2ed146a334ba5cf77027faa47addbf45c51159ff9c7278a97dda8ed7ef82"
+    },
+    "sound/pino/duda.wav": {
+     "bytes": 30758,
+     "sha256": "df21aeac84b0b423be711e6e769eaac5e00f8d8d780056fdce29bbaff122279a"
+    },
+    "sound/pino/heytu.wav": {
+     "bytes": 9388,
+     "sha256": "84a0a779e3cf41908d5786eefc401898967e74c4c4b715b4e3cc82dd793f7893"
+    },
+    "sound/pino/mcruli.wav": {
+     "bytes": 8286,
+     "sha256": "27e43463bf237b8dc471cdaa2ae3e2354a1677302659ca460463f356b86e4a4d"
+    },
+    "sound/pino/oscilos.wav": {
+     "bytes": 8507,
+     "sha256": "d8678b26eb0dda2edbe26f797474035c8ff84f13e17594c30a968edd5429c7a3"
+    },
+    "sound/pino/pain1.wav": {
+     "bytes": 6106,
+     "sha256": "0f85b6180cbfe8d26f8d174f25c109b9d8b78d0fa53735e0494280bc8a19803b"
+    },
+    "sound/pino/pain2.wav": {
+     "bytes": 8890,
+     "sha256": "6d48429e7fc4b80be16afd80097b7096a94cb1a88922a62bdfdff64172526a0f"
+    },
+    "sound/pino/plaser.wav": {
+     "bytes": 8132,
+     "sha256": "f1e6a07551f17c2bec0b8b9dc2afc27207629a2bede43849ea828802a6caaaf3"
+    },
+    "sound/pino/realidad.wav": {
+     "bytes": 153477,
+     "sha256": "e0f2d611900bedcda485f9756e47f07b37584e84a30d0dbda3233979a7b82947"
+    },
+    "sound/pino/teresita.wav": {
+     "bytes": 12390,
+     "sha256": "c7d992454bd1b8edfad56fc1a5c7b57c009d3ec2824fcf8ab3cb2dcb63343cf6"
+    },
+    "sound/pino/what.wav": {
+     "bytes": 11661,
+     "sha256": "36a779e01691d335921a2ac45c5aff355c8d4d1e419c8e8c0e2dcf502cd8a2ee"
+    },
+    "sound/weapons/s2-011.wav": {
+     "bytes": 10051,
+     "sha256": "ce4cecd907ade67777da3fc07f4734f117f1743ece02ce9404aa61745d2351ab"
+    },
+    "sound/weapons/s2-019.wav": {
+     "bytes": 12708,
+     "sha256": "9e87e3cbe74a63898f4e56155e088b1638074a846f2f1fdce0d6e29b59900796"
+    },
+    "sound/weapons/s2-053.wav": {
+     "bytes": 14829,
+     "sha256": "919d6b3ce829e7aba06cab5c1be7eabcb476a54656cd47c4a2aedbf6442063d3"
+    },
+    "sound/weapons/shotgn3.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    }
+   },
    "sha256": "5e77a1959a97704150328343adeb9baa3c5e2bfe0e7bfdb84fd848fc181d7a58",
    "timestamp": "1998-03-08T13:23:10.000Z"
   },

--- a/json/by-sha256/76/76ec31782bf5c8cf9a372c59bfd20b5e38f7d76c94aa1190078cfb72ecb41cd3.json
+++ b/json/by-sha256/76/76ec31782bf5c8cf9a372c59bfd20b5e38f7d76c94aa1190078cfb72ecb41cd3.json
@@ -78,21 +78,3469 @@
   },
   "drakebeta2021/pak0.pak": {
    "bytes": 25085068,
+   "files": {
+    "maps/b_barrel.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/b_wbh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_wbh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "progs/acidbal1.mdl": {
+     "bytes": 8788,
+     "sha256": "8a9c956f1952fb8d9ea51119c1c8c758d3ca3b3bf3bb0e8b63131bf88325f5a9"
+    },
+    "progs/acidbal2.mdl": {
+     "bytes": 8788,
+     "sha256": "eceba377145b62b4721927e55de75423daaac83f9667852b16dd1bfff3beff01"
+    },
+    "progs/akarrow.mdl": {
+     "bytes": 23072,
+     "sha256": "4e0e1c007453dbc432533dab09dfbafa943c4f43f7897848c91a516bf0de43a0"
+    },
+    "progs/am_super.mdl": {
+     "bytes": 8976,
+     "sha256": "55d561bf2f73b2c6482dcb5649da1b31d4bbf40aef6e21cca3518dc6a0c5709b"
+    },
+    "progs/anglstat.mdl": {
+     "bytes": 164396,
+     "sha256": "ce4644a5e22e0ff39790a293754501add2a4ad8afa26cfbdd13205c3b833e923"
+    },
+    "progs/archer.mdl": {
+     "bytes": 581920,
+     "sha256": "858ad8a4d0d27e1a9989ad7d87a9a4404ff8adbde33b07868725d34fd2146f6d"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 141992,
+     "sha256": "9a3c9afb3c47ed9c683ce6b0fdaef6ee6d1cf74c60509f1a82f8599318e71d08"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 25752,
+     "sha256": "57518dd89a3dbf6e712ad204b0a6f41fd7fdc9bfc03cf4c17e222f9d31d72b93"
+    },
+    "progs/arrow2.mdl": {
+     "bytes": 68764,
+     "sha256": "0bc41c13a4332f6d13e7884248b2d1a83b487bc2f4e1d5cbbdcd1c81512a4579"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 290592,
+     "sha256": "f0d1dc967de929d0f0faaa61aa51239d1f262c63da83013be094a4ed99e3028c"
+    },
+    "progs/bandit.mdl": {
+     "bytes": 226380,
+     "sha256": "7cc68b0c9a4950b4d3b97353227a6b8845104417efebfd00348b7fb24986d557"
+    },
+    "progs/baron.mdl": {
+     "bytes": 426204,
+     "sha256": "09a4b10b43c2cb4847330ce3660eab93c16a97a7db0c9e1c1447e938689627d1"
+    },
+    "progs/bbg.mdl": {
+     "bytes": 190836,
+     "sha256": "3bac35175b2808bad33e3b7e7c2c54b3d9181c5b3743aa68d803dbe58edf0eea"
+    },
+    "progs/beam.mdl": {
+     "bytes": 1460,
+     "sha256": "9e9531de6f4e6f2f6274ea6612ef00bd0642c0cc05a7fdc866805fa1be851b73"
+    },
+    "progs/bellring.mdl": {
+     "bytes": 74016,
+     "sha256": "9a8131071ca927803140ce6478b8912c6eb52856861250d6b6bfa1d32cfb9cd9"
+    },
+    "progs/blood.mdl": {
+     "bytes": 184,
+     "sha256": "06825646d627df610b374a31c9265a88c9c1c45864c6e3b9d273a14dc4d745a5"
+    },
+    "progs/blood_gr.mdl": {
+     "bytes": 184,
+     "sha256": "84caed23ff1b8cabec8c5d9e5c6792c30a6d9cc57c36a9746369012015462208"
+    },
+    "progs/bloodcb.mdl": {
+     "bytes": 28036,
+     "sha256": "83f0de29aa0f9e9f1d383895da374a5313aa2252edb306eb7bd69bd71660321c"
+    },
+    "progs/bookclos.mdl": {
+     "bytes": 3420,
+     "sha256": "a129ba5428a5fbef209010b893b4407c99a3d3a9e936d9d41247af5a75fc922b"
+    },
+    "progs/bookopen.mdl": {
+     "bytes": 6188,
+     "sha256": "d57ab7e96181b3fe70bc9c0c002ed6671fe14adfd454b680cd39be10b2315a05"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/chest1.mdl": {
+     "bytes": 19352,
+     "sha256": "239f897e3a390ad44acc5ffd19784f8b78232c5af2be67165581c2f6073ecc9f"
+    },
+    "progs/coin.mdl": {
+     "bytes": 44036,
+     "sha256": "c3d65aac43713c9102f8924ef7ed1cf90297ff17cfe8aface7936e9579b4ec57"
+    },
+    "progs/courage.mdl": {
+     "bytes": 14940,
+     "sha256": "4141933fbb8682ee28277826bd0f882580025def71b96c02cb9b53aa412906c0"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "7829e2cbaa4816577c77ba12a91933eee5dcf9d899f3f4d9717f6f8fc0319a23"
+    },
+    "progs/demon.mdl": {
+     "bytes": 355000,
+     "sha256": "3bb7fc1b1f89de1d66f99de4065d71e35dec87940d47c98b24d3be074d8bf70a"
+    },
+    "progs/dog.mdl": {
+     "bytes": 269016,
+     "sha256": "9a60157b0504891c71fbaece5a729e9b954a5e2dffe92e1e1a1ab51c6d912b77"
+    },
+    "progs/doll03.mdl": {
+     "bytes": 52064,
+     "sha256": "b2962f3954740ad7f9b5ee329d3a189ed5c95ccbb279bb63dc77508c94e4fb28"
+    },
+    "progs/doomcube.mdl": {
+     "bytes": 8884,
+     "sha256": "c4d31e7a4f2a9c01c1c502fec3653d8e0b14fc6ec790d8edebb1737a6116a471"
+    },
+    "progs/dr1_head.mdl": {
+     "bytes": 7476,
+     "sha256": "06f28a6f55ba29f12965e7ca10d99147a9432c851a2747d1e861cd45c07d958f"
+    },
+    "progs/dr1_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "c208f5473b2954fb4af094119b5a63b3a205e7a26e94c0c122b1f06870db6f78"
+    },
+    "progs/dr1_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "258da574e4de9d144d4f6a71db72a8bd566ecc6b0672efeb5cacaf59c7dd969d"
+    },
+    "progs/dr1_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "698d06c98e8e9ab99b6ddf808bb32a4994299c9596354bf8f811cda0f4042588"
+    },
+    "progs/dr2_head.mdl": {
+     "bytes": 7476,
+     "sha256": "551d47f807e21d11aba52f66207515e0988e8a424012f204e517c8c6720514d0"
+    },
+    "progs/dr2_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "f636b0786ab159a368b9fa580f1a0a31dc7873f21edb1bc454eb9e64c2c27a14"
+    },
+    "progs/dr2_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "533c0d631c78c22f5ff7632e7dc19f5da1acee56225a5a1497bf34d10fc07344"
+    },
+    "progs/dr2_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "5f5eace00eef74eeaa9db48887636e08ab43c85ad0d05816745c04a4710f34d3"
+    },
+    "progs/draco.mdl": {
+     "bytes": 235148,
+     "sha256": "0b51fd9b782891c4b8b410db6ac1361dfa0f53d634366709434a926e0c7285b5"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 262688,
+     "sha256": "d27bb0ed21b8f0e8161f347cb5bba89c8c5223324f462596f972478efdacb366"
+    },
+    "progs/dragon1.mdl": {
+     "bytes": 258260,
+     "sha256": "4dbf09c018ea9f703d4daf48c0a5e504208547d5d172bf26187b8eeac8a94a02"
+    },
+    "progs/dragon2.mdl": {
+     "bytes": 258260,
+     "sha256": "fa2b5d9467299634cddcff9c7ca87c2006c8c9631f45cbf66f74a8abfd5df347"
+    },
+    "progs/dragonpl.mdl": {
+     "bytes": 77764,
+     "sha256": "57db3cbef92a0f96cd8ef1be17ce77586f9541bbffcea2e7747e43b35c50effa"
+    },
+    "progs/drggib01.mdl": {
+     "bytes": 63320,
+     "sha256": "0a2571dc74871a4d43c8c780a62d36ce4d17dd83b6819c773bfb22a247b8bcbb"
+    },
+    "progs/drggib02.mdl": {
+     "bytes": 83352,
+     "sha256": "c3ec2317e0f0f156237b7ed36d1ab3329a874a11f7a2fb343afac021a50f777b"
+    },
+    "progs/drggib03.mdl": {
+     "bytes": 58824,
+     "sha256": "9dfdc32e9616b40b82c410ca75f007bc11a9b18697d4edc82745bcda1b3313ed"
+    },
+    "progs/drilbomb.mdl": {
+     "bytes": 5396,
+     "sha256": "6615fa32cb3b464b665093296ff63fd0c624eea5ec595247d8c66941e1c8d071"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "718b8c2842877345426247148dd6ce1ebe7fecc13e969a0fa0ed6dbebc388099"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "0a386b6381824b01852910519490ac3f6e3309a96091820384ee6b9a5b452e7a"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bef43e6c7bc067d3b35dd05a793c08d7d700fbb2013606ac9ffeac8772d0997e"
+    },
+    "progs/drp_head.mdl": {
+     "bytes": 2340,
+     "sha256": "b87cb902d796dd76c03e9fc79576f368d23022fbd5b5155c8910cd315046e32a"
+    },
+    "progs/drp_lw.mdl": {
+     "bytes": 7116,
+     "sha256": "ad483731fddede05ebf1a9a3c20f735f6ec341f156669833ed1077460dac8e5c"
+    },
+    "progs/drp_rw.mdl": {
+     "bytes": 8056,
+     "sha256": "b57363de0be61e45b355d1cceccadd42fdd1b8f91fc4380847dacf186d7560df"
+    },
+    "progs/drp_tail.mdl": {
+     "bytes": 2604,
+     "sha256": "b8ad65168755d4f31b657a80c78e2e0f51316c48f4ebd10ddae0b6971c7c6e89"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/ember.mdl": {
+     "bytes": 8788,
+     "sha256": "91d6f4dfbeba0711d0864b94bb372b602959644c5c841fd659ddedb8f8e6980c"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "13d14261d863f5170fb8e64e57b8ef344c435183313ffb1127ab6ce51176d262"
+    },
+    "progs/end_bane.mdl": {
+     "bytes": 52980,
+     "sha256": "4a86fd7bd59c4ecea934e3adcec4b17d627cdfac5223976a52b5739143c37f27"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 241252,
+     "sha256": "9ae37ced89200daf2d44795bef4230c5b725226a820c28cda7908f43bbdaa747"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 414484,
+     "sha256": "3d146be46cd90ce477006354b3ed627541fc4ecdb52ff6de2b4f3159c61e1390"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 68804,
+     "sha256": "f3c760ecdbb530ff651c46f516228c588f37585315acdab199408911c2c8414b"
+    },
+    "progs/flame2a.mdl": {
+     "bytes": 68804,
+     "sha256": "e02210f2f6851cea4b9520476cfe36c31745dc2d84248f6a75132358d6d43035"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 56532,
+     "sha256": "36d304e1442ede2048036d832d36ef4624fe4e90ba16628c20c819e7b4477da5"
+    },
+    "progs/g_grpple.mdl": {
+     "bytes": 149440,
+     "sha256": "fc148b3a840b84b65488658ec26a27621a86a196feb90723269534929ee0352e"
+    },
+    "progs/g_gun.mdl": {
+     "bytes": 35580,
+     "sha256": "0d6cbc684d5c5f1112d0111e29405e73721993ad57854c936e676025b7bfbc1c"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 38004,
+     "sha256": "cf67c0a7ad3e853fa4af7544d0399fc0a3795a61d625f5e78104e659e2db0eed"
+    },
+    "progs/g_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "3e4a1e9dc2bff162612e218a25e2040b57d063d198df2e301eaa8fa9542af098"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/g_rocks.mdl": {
+     "bytes": 47732,
+     "sha256": "d6539141be1597673eb1f8c78286d6efdeefa91f9723926d61b9a81e2f433c71"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 158116,
+     "sha256": "127e4fefafc5015f03a6cd1288cab9da325ed5b5a93c9f6b90b6da9d8273ef9f"
+    },
+    "progs/g_wand.mdl": {
+     "bytes": 13684,
+     "sha256": "99212b7901c31b723704e7c62b1c5f70b6a2f7320c349605a3943f3091e962de"
+    },
+    "progs/g_xbow.mdl": {
+     "bytes": 22476,
+     "sha256": "bf1cd180a66f74da4e625a2167bf66527cebd0d4009fabeed48297018db8a4fe"
+    },
+    "progs/gem1.mdl": {
+     "bytes": 42612,
+     "sha256": "0b71e525b19e25f98dad53ce766751de8e0c9f18434582bb86242296bb7a402e"
+    },
+    "progs/gem2.mdl": {
+     "bytes": 62672,
+     "sha256": "721459e22aab0d2cece430053734b889918bde4db879ffc94084289a7b6d4d8c"
+    },
+    "progs/gem3.mdl": {
+     "bytes": 42072,
+     "sha256": "3bc3a1018cc432b694f9ec45de06775776ef55d21b4e117dd1b2c7c0d7b850a2"
+    },
+    "progs/gemini.mdl": {
+     "bytes": 35188,
+     "sha256": "fa05498ce8034d51377953db7c650f9367b072a9d614812f4f67ad15eace909e"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/gr_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "3f5b6d67b80e5f2e5bb7c129500c79dc345141133f8d415005f9384b0d2d9661"
+    },
+    "progs/gr_gib1.mdl": {
+     "bytes": 6501,
+     "sha256": "3f715cbfdcd77caef11b904aa12d2063cbb973d4a9d61c27492690344c14fb1b"
+    },
+    "progs/gr_gib2.mdl": {
+     "bytes": 17553,
+     "sha256": "c6166eb6132a3e87f51fcf48f4e9eebb719b3f1819d22640582b23d61bde4a16"
+    },
+    "progs/gr_gib3.mdl": {
+     "bytes": 22933,
+     "sha256": "0e40e5b960924ca642690c26b239c89aea6bae18badcb945e96d2102cad69622"
+    },
+    "progs/grem.mdl": {
+     "bytes": 202672,
+     "sha256": "3df027b9f674f1f3d3cd775c877fe225029f1b814ff3358f98f932cf8bb0a604"
+    },
+    "progs/h_archer.mdl": {
+     "bytes": 22128,
+     "sha256": "034d829e2ad34eeff8f5d60b8e2064f08caee64fb7f064900298f9405e9399d8"
+    },
+    "progs/h_axeman.mdl": {
+     "bytes": 18400,
+     "sha256": "e15391056ec618b412d1341914d2e6f05a759de92500ef249cc5d1789b3ab6d6"
+    },
+    "progs/h_bandit.mdl": {
+     "bytes": 9752,
+     "sha256": "cc79629b169c0560905eae7ea9a02e5ec546af8cfa07743922e0b1dc829b29ca"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 7444,
+     "sha256": "68bc1db4875fe84f25ff3d6c53e4e9e2c023ef52bf3c89b439493f2e5c5c0e19"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "53539bc39fc87627a46b75b0d86ade5e6116a0079b032b1df137b2425b7186cc"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 166100,
+     "sha256": "0484f334f5722736248531a726e9a91c69e708a882e6d581db3d4e2a54d6db94"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 68796,
+     "sha256": "57a646b291c29b490faa38e3b72d7f074d9d071946d9b9c6068095999a11ce77"
+    },
+    "progs/h_drake.mdl": {
+     "bytes": 28792,
+     "sha256": "be0bcf5fc725dbb09a82becc2339d91824a14a547ce3013deabeece662658dcf"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 30072,
+     "sha256": "e88bac12b670f6790f3e053e1547569e88f0befa7a07abfc6a3fd2ad33b9d9a3"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 22724,
+     "sha256": "905ed9f78c83e29a31b6283b5a377053763469ae048bdcc3aede9213bda80873"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 100172,
+     "sha256": "27311a59a95ab735d79e5198318d0507da7e377584702ba9e5bf673c0972e065"
+    },
+    "progs/h_hkolem.mdl": {
+     "bytes": 30552,
+     "sha256": "38b2082ead97b90f59a5fdcf24d4077ab067c55655598d023f8ec38818c914b1"
+    },
+    "progs/h_imp.mdl": {
+     "bytes": 73564,
+     "sha256": "24944207a9867d67fa24961516dc2810a5d1b33d341d5190ac1666d58c8252f4"
+    },
+    "progs/h_imp2.mdl": {
+     "bytes": 73284,
+     "sha256": "f01cd8331b8774495258e3ab85ba6434a0deef19b1b953b6ccf93252649e01fc"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 19644,
+     "sha256": "1accd89ba95db3627cee4f06f94ab3bc9d146ebf566da24b570c733f2f902c1a"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "72455aab2067fd8f887e8a8e9c61d2b943699ce90fbcb85937fbb358c9e5678e"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 53188,
+     "sha256": "6e1c28d5c53f24901ebd0aa199a1003ef4fe3c8306c5ab28191cccd14bf25f45"
+    },
+    "progs/h_necro.mdl": {
+     "bytes": 14296,
+     "sha256": "fc9c468465d0e8982fc2d6207ce94b2f400f0f37cbe88cff2a4aa64719b91f40"
+    },
+    "progs/h_nemes.mdl": {
+     "bytes": 78156,
+     "sha256": "6f350692b44907984c02779d0114576bbafb6a3ada673e1f55d1cf02fd062c18"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/h_rebel.mdl": {
+     "bytes": 5428,
+     "sha256": "b189ff3ae1596da7596f21d8f555603951fadf8e7884e96f89c8b2b5789028a5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 53096,
+     "sha256": "ff1d940222f28765b975828528016332b04423a4001a507e07cde6414847add5"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 108204,
+     "sha256": "dd7dc5c90255da868b96ac553d8a8f68b6723da6b25114bc087fd019966a023f"
+    },
+    "progs/h_vomit.mdl": {
+     "bytes": 16952,
+     "sha256": "9822885036229871594a21643f4acd3a9b4c27d141b9021464b5062dfaf410f9"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "7ff66f881f85884aea56396da7b756da32c04df163a1e1f739485e77e61279df"
+    },
+    "progs/h_yak.mdl": {
+     "bytes": 73116,
+     "sha256": "eb2cf314618ef6dbc44ab46807237e59b68470edf24780e4ccd4c5b513f91196"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "2f6fd7256662a5a4b4b907b0ac68bf7d787ebd55cf54e352da5f1b363a2b2397"
+    },
+    "progs/hero.mdl": {
+     "bytes": 66388,
+     "sha256": "ea4f359a328b6416588e5debe13a87fc2eccd8a65263ae23683d71a58b39a116"
+    },
+    "progs/hk_golem.mdl": {
+     "bytes": 179204,
+     "sha256": "972f27eb2bf8a6cc4433e1f904097ca5393312d47a75e396b0323723beff58fa"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 534604,
+     "sha256": "10058c95eca9a063c7990d919d353d3573d252eb39f00c5f471a7f22f0b5fefa"
+    },
+    "progs/hook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/ice.mdl": {
+     "bytes": 2580,
+     "sha256": "30c4853e26d51d0ca4d3df5a40ec6d8861f48e9420f10560b5de0c19e6c15ab0"
+    },
+    "progs/ice_cube.mdl": {
+     "bytes": 3192,
+     "sha256": "bf96c8c1533fa537582bd4cf7bddadb7f5ddeebafbce9ef29007a5acd5a909b0"
+    },
+    "progs/iceball.mdl": {
+     "bytes": 24632,
+     "sha256": "802fa6260e9af5abb74bab0a76f35ae3e2af2373e61091c725325aa41051be7a"
+    },
+    "progs/imp.mdl": {
+     "bytes": 583036,
+     "sha256": "299777bbf58641a6674c0877423efd9f0995421a1bfb946fe21d1f2bdb41714f"
+    },
+    "progs/imp_lord.mdl": {
+     "bytes": 583036,
+     "sha256": "0b26574642cc72b73d349881543752a1f7d7f34f00561c4b039bef83e7191b10"
+    },
+    "progs/imp_rock.mdl": {
+     "bytes": 2352,
+     "sha256": "dbe190f471f5738779e103b496117ec40e2adc9e5f593d2470172bcbd7ade0f6"
+    },
+    "progs/imp_wing.mdl": {
+     "bytes": 93932,
+     "sha256": "a0100af8c072112afde45cc2f69e40de4aacffbdb4515de107892c39a00f5eb5"
+    },
+    "progs/impwing.mdl": {
+     "bytes": 93932,
+     "sha256": "5b986189f2f28ffe6c3fc23d40bc194bda2ab636826a9d41ffc9199727cc2f49"
+    },
+    "progs/impwing2.mdl": {
+     "bytes": 93932,
+     "sha256": "0d08640bcd5c6e6336b9cedb635a6152ba479065a56b296557476a6f5e9b1e4c"
+    },
+    "progs/k_ball.mdl": {
+     "bytes": 31300,
+     "sha256": "f93346ffeed3fd5d9866fb80d1a08216759bb27757d49a1851e471aadf757ec1"
+    },
+    "progs/key_b.mdl": {
+     "bytes": 10616,
+     "sha256": "d1333d74b7e194f6587d0f5ed1fca28887cd0414734b4bd4cbb7e715ab897629"
+    },
+    "progs/key_m.mdl": {
+     "bytes": 23160,
+     "sha256": "ea2feb6eb54823668dcb112f42c3441e563e18e3cc1806b5ce509044e6c0b448"
+    },
+    "progs/key_w.mdl": {
+     "bytes": 11576,
+     "sha256": "72da64d2b29d69605c453e9ee0e5fa8ecef91a94cc541103cb24fbad96c7946d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 232536,
+     "sha256": "e3e618799612c6e521f68234a061d9a46036ef556677b0c1651e7647258ffb56"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 27960,
+     "sha256": "5877b37cc4f98a53467c412e7d06d1f7ec6b60f5c0f2088514aa51c9d2c51769"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "210e159ea4c9bf1f2431213fd95902f4ea75ecee6a67a22bed7e93366f1f2732"
+    },
+    "progs/levitate.mdl": {
+     "bytes": 15876,
+     "sha256": "03e77b0d4b8ee7b3b224cbe0cfba63e8bd27d0391bd5069981e5435287f66645"
+    },
+    "progs/life_up.mdl": {
+     "bytes": 34676,
+     "sha256": "502716aa1b0f6cb8f929fe7ee2a74024a5fa007898256e15ca495e126888c584"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 57796,
+     "sha256": "e8b38ca8f28a89f65ffc652e082e8a9aaf6a1a9db8302e961b9ceac1c8f60e8c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/morph_eg.mdl": {
+     "bytes": 300592,
+     "sha256": "14468fccffaa1508c03610dd58fb51cd9058ca3bab036bca18f7a41cb37c195b"
+    },
+    "progs/nec_rod1.mdl": {
+     "bytes": 16072,
+     "sha256": "2eded5df9441aca7a243bf6c2a831c62374cabf7bba1acd64a84803441d77fc2"
+    },
+    "progs/nec_rod2.mdl": {
+     "bytes": 4564,
+     "sha256": "60b0923cade4c8ab9a476cae75c7c73f71c1d13799ac7901d0be4db5d5038895"
+    },
+    "progs/nec_rod3.mdl": {
+     "bytes": 4132,
+     "sha256": "459edf5ee6ecf0c52ec83e055a2c12ad39d3d3a42a4774c442ccc686e298da47"
+    },
+    "progs/nec_rune.mdl": {
+     "bytes": 19524,
+     "sha256": "cea5c89dd0034465a54a8434bc9367554f0244c2e38ec9220cd28a5a53a444a9"
+    },
+    "progs/necro.mdl": {
+     "bytes": 577208,
+     "sha256": "a0e43517f3cb579e38baf9ee4b5058ed59036b69599c0fe3ffeff9c00ba843f8"
+    },
+    "progs/needle.mdl": {
+     "bytes": 16688,
+     "sha256": "5f714f6b43cc28ca1de1246cc0175ea2e07040f73c9d0a623dbe4b4577559c14"
+    },
+    "progs/nehjet.mdl": {
+     "bytes": 19956,
+     "sha256": "fd0346c9c37d2ca7d3e696a9ce0694652722f63326376ad3b8189fb81a68f5c3"
+    },
+    "progs/nemesant.mdl": {
+     "bytes": 202492,
+     "sha256": "099c26752c7160144a25716e0af0f30f8ff179766db4a05371a0392166f85c42"
+    },
+    "progs/null_256.spr": {
+     "bytes": 5412,
+     "sha256": "c52813b634ef1ab641fdd4c3a9739ad758f1b5c39ba5e10acbbf034ee0ff850b"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 230152,
+     "sha256": "b7c88ae295ef8fc8d17b4fd6facedbb8e464ee665039a884af8e215a3929f24a"
+    },
+    "progs/oldone.mdl": {
+     "bytes": 560224,
+     "sha256": "5690a29cb0ae1a4889bc398676db8477275b0953e2ab7bbb75b717509d93c985"
+    },
+    "progs/pl_oum.mdl": {
+     "bytes": 331236,
+     "sha256": "6939a925af5510ecece22c3cee3de418d3ba532f4eb17409ca1453d253de328c"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 55676,
+     "sha256": "c9810eaac822215e7c84f11e55bb614121d17a79a02aa162fb430b5f37664ade"
+    },
+    "progs/plasma1.mdl": {
+     "bytes": 9120,
+     "sha256": "78a81a8eaaf95f85cd0fb7bc31dfa45c30e660fc5265168178b50776afc96563"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/playham0.mdl": {
+     "bytes": 99756,
+     "sha256": "1016d24c984994843af5d086e36e548c55590018f1f6b2d78799e25a40271ec4"
+    },
+    "progs/playsaw.mdl": {
+     "bytes": 87340,
+     "sha256": "b53cffd1807a3710f03b350370d78dfdbb2b057455fcac9f00d1b0baaabbf8c9"
+    },
+    "progs/potion.mdl": {
+     "bytes": 53272,
+     "sha256": "6ee1b1294f1ff41bdf265d06d80fa22a89ff579acb70bd2544986a0235ebd6e7"
+    },
+    "progs/potion2.mdl": {
+     "bytes": 195484,
+     "sha256": "c4f0f920521bd6e1caa6072b19d11ba57f4d493ffc2d6a395190170c9bec702a"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 47008,
+     "sha256": "e7ba606cf1cc11d9ad5baef5aef9dfa9239b7550a1c12937965a562bc815e6a0"
+    },
+    "progs/pur_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "dbc2bf835db1c1789c329504f86802990a19288f67d9560f32cfe5a8d5a62885"
+    },
+    "progs/r_bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "2d776e4acdf20cd117f3f4d6be3647fb9d0e117756069cbfc52ece716fdbb251"
+    },
+    "progs/rain.mdl": {
+     "bytes": 39276,
+     "sha256": "9a13a2ff68c8d8eb27426cee38330a6237de8ceb9ba9ecb9b71071512b190a94"
+    },
+    "progs/rain20.mdl": {
+     "bytes": 42620,
+     "sha256": "192d3d8197976f98eb053e54a00536ca9ccc8769692e9c483990b64afa4e1d8d"
+    },
+    "progs/ranger.mdl": {
+     "bytes": 232148,
+     "sha256": "21e690b07a7d3b2b0fb630480a5fd52ea23b41a8571c3618d16ea1ab7508e52f"
+    },
+    "progs/rebel.mdl": {
+     "bytes": 215292,
+     "sha256": "433596df8d06be0882f00a2c1fad0ea49a8ae42ef148d32e0ae7c06c420322aa"
+    },
+    "progs/red_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/reflect.mdl": {
+     "bytes": 10224,
+     "sha256": "3e8b08d02c11ee9e5546c96c014c8e698ca9097046ff3873012033c0bcac8df9"
+    },
+    "progs/regen.mdl": {
+     "bytes": 50808,
+     "sha256": "1c2422c4124c235e29570580b0c1bfeb55613d6c8152c78dfb6d073ea316f122"
+    },
+    "progs/regen2.mdl": {
+     "bytes": 50040,
+     "sha256": "b8da16335e855c502b7ff0c5b6875050b73c01ff0eb5b5627fc890d155cbe013"
+    },
+    "progs/rocket1.mdl": {
+     "bytes": 34260,
+     "sha256": "c9412482647d681e08f74eb0c0260ffded91dfc67378996b86b720ef3cd2fd47"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 17204,
+     "sha256": "0dab5b94c60d92d55df3e44a8d8ea2dc0f949e98897a6525ee0be3f49a019b08"
+    },
+    "progs/s_expbig.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 165212,
+     "sha256": "5b78b324e252f95ef8f4a9fd4fb19f855c40f74fd1f93aae9b84ed822e9c3585"
+    },
+    "progs/s_fancy.spr": {
+     "bytes": 432120,
+     "sha256": "2dcb35ecb5312709ae4b295ebcf209e74a34e385823f54603e6fe0eb8999556b"
+    },
+    "progs/s_kinn.spr": {
+     "bytes": 45624,
+     "sha256": "c6412ac75ec56533cbf0487223c2c8a23a3d3518b0e3f7ed8af73b81cb6ecbba"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 8016,
+     "sha256": "fa366e4076268de137e0eecd88d02e3aac99f38c48c6ad0d0a74c88c95e8d4d4"
+    },
+    "progs/s_wave.spr": {
+     "bytes": 373212,
+     "sha256": "c2a3b258b2809f22247596b6e0505829853e9a5fd60fed7c471fd663cf9e9402"
+    },
+    "progs/s_wave2.spr": {
+     "bytes": 39480,
+     "sha256": "a0fbc773e66385a8bc3c16195ce14215050cbec7caa118fecae1a0c2a2c59d50"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 333284,
+     "sha256": "90757e506c9f0e49e4e9897708df4825e1b27774ff46abd9c113738380dfde62"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shade.mdl": {
+     "bytes": 83644,
+     "sha256": "080ad2839fafadfdbbe5412ac53061a917af3158f33e16f5df4b4f3dbe422ccb"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 128012,
+     "sha256": "94aca4b876e4794684f4f2b9e66f1c34f7b3935b0d35d406311b63aba17ea3c2"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 176048,
+     "sha256": "7ea0c1007179eb7a45112aaf38d8042213e8b644e6e79b9b1a8d4402c3843b47"
+    },
+    "progs/shotty.mdl": {
+     "bytes": 16984,
+     "sha256": "42f2e1a71e00db26092b7fb9c633daff43bfebdcb46ced46526bee057464cc88"
+    },
+    "progs/shubdome.mdl": {
+     "bytes": 97512,
+     "sha256": "3b92e43bc942b2cfba8c7b4e1206ad858484564d86bd7faa069db592f98c7232"
+    },
+    "progs/shubstar.mdl": {
+     "bytes": 14760,
+     "sha256": "ee5f914d7f3f930db06b1ead8d314dec0413e5182b7de24cc808076d117f3cda"
+    },
+    "progs/skulbook.mdl": {
+     "bytes": 15572,
+     "sha256": "794768c4237a3efedf0c13026213aa417dec5be7eba7971f6e1113b5167fb904"
+    },
+    "progs/skulhead.mdl": {
+     "bytes": 50688,
+     "sha256": "d0733746c8b7cfccdb8d0f30f9454c8863a470e6d56e8359828dbb450aade77a"
+    },
+    "progs/skullwiz.mdl": {
+     "bytes": 726948,
+     "sha256": "0736c202c56cde1cfeaa10b62ca3747f85f08ae3a9cb5daa924456166664e4c4"
+    },
+    "progs/skullwz2.mdl": {
+     "bytes": 726948,
+     "sha256": "ba9f6f478a92ef3f6eec11a1d9c72e4bacf01e755e7f68dae4f6cf2856ff5504"
+    },
+    "progs/skulshot.mdl": {
+     "bytes": 63400,
+     "sha256": "73d6d8e5411b9ae3cf815c3b0cf695a5633cedd5d586565880a9146a1a5db5c2"
+    },
+    "progs/smartbal.mdl": {
+     "bytes": 27924,
+     "sha256": "288e2d54afcbdc5242ab831f3ef611710317c52432e4585a938a12df80b7a07d"
+    },
+    "progs/smoke.mdl": {
+     "bytes": 184,
+     "sha256": "2086abd9950bc643446309a80d9df86b4ebe3f2086f75e799ce943a8454c77d7"
+    },
+    "progs/smoke2.mdl": {
+     "bytes": 184,
+     "sha256": "cdae24fb7cf8efc6ec5271c297f18b04e8c69554ac4c4aedbccd7d3dd39089be"
+    },
+    "progs/soe_coin.mdl": {
+     "bytes": 26364,
+     "sha256": "5769371db409969600bd51d573162c663fb75d358c507fcff9a4aaea95fed4dc"
+    },
+    "progs/soe_gem.mdl": {
+     "bytes": 165236,
+     "sha256": "788f32633f1f3a9f6dd2e0c2dccb76871e02fc6e002db82a219f077dcc493c3f"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 409548,
+     "sha256": "8127b55dec92682e7de27ce1619b5fc8a727413b3cdf2125510138be249a1281"
+    },
+    "progs/soul.mdl": {
+     "bytes": 8436,
+     "sha256": "eb4dc0dae8aed7c92d328096fd9633566b658c9cc65777211ade1e67c6e0ff64"
+    },
+    "progs/sp_gib.mdl": {
+     "bytes": 22228,
+     "sha256": "e902ce3a5e4be26cb781d29178b6e808c480f9e898bc50ecfa78ddf12d774238"
+    },
+    "progs/sp_gib2.mdl": {
+     "bytes": 22228,
+     "sha256": "be98f64e7c2cffce98e28d99b36856762cc15caf761015067fde234390e6b302"
+    },
+    "progs/spider.mdl": {
+     "bytes": 355540,
+     "sha256": "6b32cacff38987b0b4a5efe585dce71ce64ee03e12c4bb1243b1be350f1f3b03"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "078b774958c598bdf1503934d51a1393aeb9aadebcde806db2272b04b233c6a2"
+    },
+    "progs/spikes32.mdl": {
+     "bytes": 7668,
+     "sha256": "983176e5f12571f9b38c9c5d100841e480fe8ccf143889a0e48292a5bca8bf63"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/st_baron.mdl": {
+     "bytes": 185964,
+     "sha256": "7c00af263c1349b9dda2b1a6706bcce7034e9b0793697d67a1bfa83963ba127f"
+    },
+    "progs/st_gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "813d52c557a1eb519d801652b4bd63acdc4ec18d62db53d843ca3dcaa88e87e8"
+    },
+    "progs/st_gib2.mdl": {
+     "bytes": 16228,
+     "sha256": "2d40c1eb75eeb6f5e1781ee9db7a0be10e0d07297d563f9035a8965c4c8c3d01"
+    },
+    "progs/st_gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "d44a77787c5ff633593ad9741ddfbe28809431daf3d32fbe92f8512871b9018a"
+    },
+    "progs/t_coin.mdl": {
+     "bytes": 35040,
+     "sha256": "ed7a18cfce56a630c9adaa37757e270419fca318b3fa655fea18002b089441b0"
+    },
+    "progs/t_gem.mdl": {
+     "bytes": 165364,
+     "sha256": "955761ccf88ef8f6adcd635fb70ae5d8e434b19394a15124acc4370e614f2409"
+    },
+    "progs/tar_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "1ef69998430a54ba662abb46a0ef303b3bf0066f53e84b166065e79d58a72bef"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 313448,
+     "sha256": "fc63e6f62c83975ab2756f0a844d012b887491a6c73d9350dfcb04a6e0355b3c"
+    },
+    "progs/throwax2.mdl": {
+     "bytes": 34872,
+     "sha256": "11a22371cc72adf001e21d04e1b8b65e01497f56410867aa42ea21c0ff304e48"
+    },
+    "progs/throwaxe.mdl": {
+     "bytes": 56532,
+     "sha256": "0ebedab9ab397ba15dc3f0d90df703af2984d1c070eabc08ba781c308968150e"
+    },
+    "progs/throwham.mdl": {
+     "bytes": 7072,
+     "sha256": "f161fedb096a34db55fe57e84acd2bc42295ffea688549235c762b9a70430b35"
+    },
+    "progs/tome_pow.mdl": {
+     "bytes": 2612,
+     "sha256": "40a792071152640897de449d672a693229a87a11bf5e37ab05fd1656be22b6cb"
+    },
+    "progs/tree.mdl": {
+     "bytes": 237576,
+     "sha256": "f1f85524e4018552188aa58979154ce5544381d7bfd5ae05da521e55efdc25e5"
+    },
+    "progs/tree_zer.mdl": {
+     "bytes": 145444,
+     "sha256": "e87574f4e067fe99704d235ec155118736e0e69d9554f8622a1f1ee1c4f831cf"
+    },
+    "progs/treetall.mdl": {
+     "bytes": 120532,
+     "sha256": "e74e7c38099ccc833fadf3c7b7e97f746878d07102dad8cc5926546b344cb982"
+    },
+    "progs/uberpack.mdl": {
+     "bytes": 19348,
+     "sha256": "810cd3f895ef65e11f70fe00e195026308af02248b0f1442da5e816b7d6a7d9a"
+    },
+    "progs/v_grpple.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserb.mdl": {
+     "bytes": 35492,
+     "sha256": "cd2dcfa0fc848499235735fc5c7c5efdc631a779747f71441ff05403272bd9ea"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 93080,
+     "sha256": "05655920347b597feff05a74725b20cb88693ac78fdccb3730918a01cc4e6811"
+    },
+    "progs/v_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "a2d573bdf52015bce7a571a2263a3e8d938daf0bc1b5e4589f84580cab7da2d4"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 35492,
+     "sha256": "2f5a6e74998e4783d9b3d458d167aed31f32cd49b362f01b8d9ec0e94f90de63"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/v_rocks.mdl": {
+     "bytes": 58548,
+     "sha256": "87d0958027fadf417616cc48367b19ef6f9215a0685edc239c751b59e2b6368d"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 165540,
+     "sha256": "abd6787fff37c452fa01f4bbc9eb9594311eaf4a794f161caeb5a501ab9e103f"
+    },
+    "progs/v_sword.mdl": {
+     "bytes": 94416,
+     "sha256": "74b2fd6983cfb317ce136eeef6029d0cda063efe4706abc12057ba32cb0e988a"
+    },
+    "progs/v_wand.mdl": {
+     "bytes": 27388,
+     "sha256": "b46ba82a45a24fe4833dfdfd3c9457b98096a5800d6620d6eae11895653a6698"
+    },
+    "progs/v_xbow.mdl": {
+     "bytes": 95168,
+     "sha256": "e65f7cfe84cfa7c84c34147dadcc8b5ceea9416c7e378bd2110961fd76348e70"
+    },
+    "progs/vomitus.mdl": {
+     "bytes": 79724,
+     "sha256": "03dffcc3405c63f0e0c11301a74da5403d957b66171a6f34eaf8998e4ba31550"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "7758aaf42d0d1617e4fb172ce842be4316073f63250aba46dad441327cccb2e6"
+    },
+    "progs/wanted.mdl": {
+     "bytes": 27860,
+     "sha256": "03337a468db14377fcd36842037d2a27dfb97c3d5d5f45fcfe408e79050a5839"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 67956,
+     "sha256": "39c4a5daef1cfafc1bbfff1ca8eebb5c75d27f953f31d29f249205762605a56f"
+    },
+    "progs/wings2.mdl": {
+     "bytes": 28980,
+     "sha256": "5342d6191f59e69eb830a5e833473ac253b3a7750063d5519f6d2da2b82f5573"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 109380,
+     "sha256": "d78cd5ac1d667ec808fc7664071e060cea40179a0ba094e2f4c119d5ef7a79ba"
+    },
+    "progs/wr_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "1bfb049cf920973e32d78cbf7cf8b6c0c18f8dde55006ee43798ead4b99af9a7"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 238732,
+     "sha256": "5d0f3d6b32bfec300894dbf066a15bd9e34b985919423446232ad85d2ad6d6b7"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "progs/yakman.mdl": {
+     "bytes": 736212,
+     "sha256": "91595b5866d8f85fe67f349d22fb0c4735a4255894ca7368b10bc06618b98a3c"
+    },
+    "progs/yakman2.mdl": {
+     "bytes": 265228,
+     "sha256": "caba3ad0554bc09c10855592447424ac93beff1665803b2e5c605bd36b28cbdb"
+    },
+    "progs/zerkhelm.mdl": {
+     "bytes": 47604,
+     "sha256": "07fe43e56af442776c52da95902eda56c0bb197783fc5279ca350fc0dd34c4c5"
+    },
+    "progs/zerlogo.mdl": {
+     "bytes": 33380,
+     "sha256": "b305250e2c537f616557219eb81ac571f76588ff6f57525a36fc3d38114ee11a"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 226776,
+     "sha256": "f4d35645fa47d159cf7dee47a1652ff239cbe7a7b3df8567b865c6d44536abf4"
+    }
+   },
    "sha256": "391a6531bacfbeb4370d62964ad13ecb441d7ab4e8ebc5028bbb3c23acf76558",
    "timestamp": "2021-03-12T09:15:42.000Z"
   },
   "drakebeta2021/pak1.pak": {
    "bytes": 11698993,
+   "files": {
+    "sound/ambience/amb21.wav": {
+     "bytes": 80716,
+     "sha256": "d664ea08d9df7e7dd135eb0726c1bc142878dcc53d13564dd3dcc5562180201a"
+    },
+    "sound/ambience/amb22.wav": {
+     "bytes": 92716,
+     "sha256": "f444289984b285a1497f55e566fbbf1896a04fa38e291efaa3ec1a0720204811"
+    },
+    "sound/ambience/amb23.wav": {
+     "bytes": 40180,
+     "sha256": "e451997ac7f37d08bd8434d708f45ee2967693317684b947ce511c9df84828b3"
+    },
+    "sound/ambience/amb24.wav": {
+     "bytes": 42282,
+     "sha256": "ead78c8507a7a6a7d6c61e913a2319964f6a8f70b5f7f720c162725edd9cd5aa"
+    },
+    "sound/ambience/brik_hit.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/brikhit2.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/chant3.wav": {
+     "bytes": 116346,
+     "sha256": "5d71f12940688414ab8cabc0d88e323dc961b60aac66f17887712133f1cb8b29"
+    },
+    "sound/ambience/current1.wav": {
+     "bytes": 50906,
+     "sha256": "dabe357d48586dccb8e1ed18c49828797c9f7a8c02c7a588ddc76a62c9b1d3e4"
+    },
+    "sound/ambience/drip_amb.wav": {
+     "bytes": 105444,
+     "sha256": "b282bc6082754011ee21a82aedb490a856c0f694f57991992296554c13149b02"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/heart.wav": {
+     "bytes": 8190,
+     "sha256": "a5b42c46cca24da59c324bb28ce6887b3a2a3baafcc18b0db2b2485f1189a4e0"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 177840,
+     "sha256": "9daec0732dcc821670b8910a1371153e3829e604b6957bf95931bea416af6074"
+    },
+    "sound/ambience/mov_watr.wav": {
+     "bytes": 44432,
+     "sha256": "9d6721844fd5559ab4f53902e70ad9789a90710dde082d222bd814a36c00ab67"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/spark2.wav": {
+     "bytes": 61640,
+     "sha256": "7eb18b00cd5e7913fea7a85ec5b1db159d1d001d24d4f687bfdb5685cb163c8e"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 106286,
+     "sha256": "056f37dfd1d5f4eba1d1911245dc0930bb0c46a84d72d867a286e5a9540248a0"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 87710,
+     "sha256": "2bb46f7c8f70fd28f0ca47b294824bcca7689047291b6c5259eebe76ad6aecfa"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 140630,
+     "sha256": "5a4dccd168cbd9f759ac468d7aa879dbcdbe5637e0fd0521f641ba1d60f61817"
+    },
+    "sound/ambience/th_clap.wav": {
+     "bytes": 570992,
+     "sha256": "5b93e5d878621c2a92e66d6214b0fa8acf8ad5a35f4120f456ddf5678e941d94"
+    },
+    "sound/ambience/th_clap1.wav": {
+     "bytes": 72062,
+     "sha256": "1fc3146d501953545b2f2f261cd2fc398959a79c753a291702609b4cdd2e8682"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/wall01.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 28798,
+     "sha256": "f66c76f07eef275e904fcc76d7ca9fc2011f3de8c61ce0b3ad035464beb7a86c"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 110578,
+     "sha256": "c3e1ccb091b9d8a06b83530b5e29b9f26f5ad8b9dcd082f3da976c3d44944b87"
+    },
+    "sound/ambience/wingend.wav": {
+     "bytes": 90874,
+     "sha256": "63e435d896b097d4dc413fb1afccc2078f1d101a4f7bfc18c4e593ca9e8b344f"
+    },
+    "sound/ambience/wingget.wav": {
+     "bytes": 65148,
+     "sha256": "533bdbd7beffa4c71c66239e3ac417f2177b20a60ed39c379c59a10b2222b367"
+    },
+    "sound/ambience/wings1.wav": {
+     "bytes": 6028,
+     "sha256": "c9e05f66a1d728a88289bc213c9f3551f1e54a4f3e8ef23ab03f8d5019e7b2c5"
+    },
+    "sound/ambience/z1m2mus.wav": {
+     "bytes": 103768,
+     "sha256": "d54261d4c9a4a8a9fe0c51eeae343c6a5b381727af88d0bae6f9b40605b8e5d3"
+    },
+    "sound/ambience/zend1.wav": {
+     "bytes": 123618,
+     "sha256": "2df6c267197b2e82241e47ce4985b04d14e1ce3cff46cebf3177369057302bb6"
+    },
+    "sound/ambience/zend2.wav": {
+     "bytes": 73742,
+     "sha256": "0ea00395004f11d41ab60352517bf5ff5c88a73b8ff2ddb3f32b5085967e3003"
+    },
+    "sound/ambience/zend6.wav": {
+     "bytes": 252626,
+     "sha256": "3f3c412e55bc7534c423c0d1bec2d817e3aea06338b4d6c3f78c4b80e55d509f"
+    },
+    "sound/ambience/zend8.wav": {
+     "bytes": 112122,
+     "sha256": "27cef28aa3d6c3ea86f0c54168db07055abfc7af284bc5a35bf53a0e53f8d677"
+    },
+    "sound/ambient/amb2.wav": {
+     "bytes": 38416,
+     "sha256": "21a4f41fb5efb52587e60395f23824ef330674a8d9499fe2cda1c91603093bfc"
+    },
+    "sound/ambient/amb7.wav": {
+     "bytes": 43020,
+     "sha256": "de7f4a0d15c711c9ca63f74ee38acf78e4ce41800900e0193a43c3e55e4efde6"
+    },
+    "sound/ambient/comphum1.wav": {
+     "bytes": 20456,
+     "sha256": "af10cad0f193d07be9c98f0dd889840fad0f54f40a61d12a1325b78033a68c8e"
+    },
+    "sound/ambient/comphum2.wav": {
+     "bytes": 72367,
+     "sha256": "fbf1ff8677cf36d78e381437f3b8e758a589a108a50c92f24c514eda06ede3f2"
+    },
+    "sound/ambient/comphum3.wav": {
+     "bytes": 116441,
+     "sha256": "62d9624940b93bcd1897abb809cb9d6f2cb3872cfd6af9a792260fb17f800150"
+    },
+    "sound/ambient/fan.wav": {
+     "bytes": 54275,
+     "sha256": "6cdc6a19b0c740d5607fa9076f749dc485483362445630877c6b59ec67085a2d"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/l_hum1.wav": {
+     "bytes": 20790,
+     "sha256": "f1b8bb19b32258ca1b126d52eb98b17c2753a255eba60864f8ad325f564681c7"
+    },
+    "sound/ambient/music1.wav": {
+     "bytes": 213944,
+     "sha256": "bf498e0cf6541b3559abd978ac420c5cb19d6542d89f19f59bdba8019dc46688"
+    },
+    "sound/ambient/pump3.wav": {
+     "bytes": 40435,
+     "sha256": "ae8ca71a1ce41bb3fa02d993930b4f100db3827ef5768326a91e61f7857370bf"
+    },
+    "sound/archer/arr2flsh.wav": {
+     "bytes": 5464,
+     "sha256": "e9a0c059430744c6546a6be4be3a1e4ac775ea6c5e6440d14611ecd8c8447d19"
+    },
+    "sound/archer/arr2wood.wav": {
+     "bytes": 5458,
+     "sha256": "97c5106007e703618291242bf1c6db9853a9d625189fc26ec9c4864436b560e3"
+    },
+    "sound/archer/arrow1.wav": {
+     "bytes": 2296,
+     "sha256": "4aeac8630ff6036f095a251a018eea5baad7a59bd7e46f624dbfec793e44d7b4"
+    },
+    "sound/archer/arrow2.wav": {
+     "bytes": 3196,
+     "sha256": "0a2734df5a69f6407ffc34ab05d8655da5d7dc0e487627932390fa6cec022083"
+    },
+    "sound/archer/arrow3.wav": {
+     "bytes": 2156,
+     "sha256": "1b866280829cb7ac051f90609baa8db285f3bfa3a27b5814e72b021b7cc05785"
+    },
+    "sound/archer/arrowbrk.wav": {
+     "bytes": 5002,
+     "sha256": "f72e35d5232f40e503192ff0ee26fe152eb42e5ee7141b2bea33a9f12f38aa2b"
+    },
+    "sound/archer/arrowg.wav": {
+     "bytes": 15132,
+     "sha256": "8ec5ee520f81c69ba367ae549a06d5ea1643b43f81dea7d8345561c94c8412ed"
+    },
+    "sound/archer/arrowmet1.wav": {
+     "bytes": 2638,
+     "sha256": "87e6ef50bfe4dabf48a1fba18ad0138bbd298965f1a9d06e2b059019e6f74b60"
+    },
+    "sound/archer/arrowmet2.wav": {
+     "bytes": 3118,
+     "sha256": "2797466dafd51473b8b6b5fd3d02a5baa4fe92a1bf9342fb038a299230037138"
+    },
+    "sound/archer/arrowmet3.wav": {
+     "bytes": 2804,
+     "sha256": "1e77951ec2218add2a8bc1633a925e4a96d2ca247d7b5dfaaaefd7a9a4f2363f"
+    },
+    "sound/archer/arrowr.wav": {
+     "bytes": 9458,
+     "sha256": "10e4bef745e55fddd004ea78d24edb9d3d9edc1ce3053c377be07be27a4da144"
+    },
+    "sound/archer/crash.wav": {
+     "bytes": 11069,
+     "sha256": "60e704bdfdb0a97863b00f3514130a172b95a86bebbf89642b65a6e757a74259"
+    },
+    "sound/archer/death.wav": {
+     "bytes": 9526,
+     "sha256": "e824b3d7d66e8bfc3ce30cc3116eab1b2d2dbc09c6311f91ff25d3e7eaef19f5"
+    },
+    "sound/archer/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/archer/draw.wav": {
+     "bytes": 6874,
+     "sha256": "c94e5cec38dc40102beebd067554c91e63b86e5c1ef11dc17976733bd9f08ce3"
+    },
+    "sound/archer/explode.wav": {
+     "bytes": 17788,
+     "sha256": "1f7d6debef492f0861ee24049ad637a11b85d595cdf3f6d6aac422b7a0376d14"
+    },
+    "sound/archer/growl.wav": {
+     "bytes": 9240,
+     "sha256": "7bdbbd23b3fe056cd1d904124824aa0044acf3aa19ec88f65e092fd13e4b9437"
+    },
+    "sound/archer/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/archer/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/archer/pain.wav": {
+     "bytes": 5082,
+     "sha256": "5347daf1a9263320f25b2a191895fbf6c85278f1fde6ca5962c09ed38e0b37b0"
+    },
+    "sound/archer/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/archer/sight.wav": {
+     "bytes": 16866,
+     "sha256": "bcd12d078e7bc34f0bdea7ae9a34ccd2c9bacb049617329b44f8301c34fffeb0"
+    },
+    "sound/archer/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/bane/death.wav": {
+     "bytes": 10935,
+     "sha256": "7e4775bc543acfb421a446a00efff6d9d5669fafb2387464cb1e1ae3db91efe8"
+    },
+    "sound/bane/growl.wav": {
+     "bytes": 9045,
+     "sha256": "86e7b3d2e685d7c20e503bdffe676727426b606ef069f4b70f182601e910ec4e"
+    },
+    "sound/bane/hit.wav": {
+     "bytes": 3884,
+     "sha256": "228faf88857d697f4d5fb9b9c03f000af4dbc8b254791e18e973fd48cc96db9b"
+    },
+    "sound/bane/laugh.wav": {
+     "bytes": 22108,
+     "sha256": "ae8e8d13e00f41bce729977f09a92806c8451ebe5cb4e8618a6b79df4d70296c"
+    },
+    "sound/bane/laugh2.wav": {
+     "bytes": 31560,
+     "sha256": "5cc5ff4c3be35eec90eaaa6579a55fa843843ad658e2e4bbb258a77f6e410020"
+    },
+    "sound/bane/pain.wav": {
+     "bytes": 9325,
+     "sha256": "1d4cfac1f9dfa1ec6958b18014ec7be18dc2615e64888d3c584d50bb48e51013"
+    },
+    "sound/bane/sight.wav": {
+     "bytes": 22962,
+     "sha256": "fbaabe115d9ca4b985c4481ccc71e6b6f55931394a29a6c51ec97e752ed3d5be"
+    },
+    "sound/bane/thunder.wav": {
+     "bytes": 43130,
+     "sha256": "cb355478e38df678e859557a0f983120a4d4275272d8ebedcae7c9cccf659bc4"
+    },
+    "sound/baron/bpain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/death.wav": {
+     "bytes": 8576,
+     "sha256": "3dd3a23d5a913548d0d0aa6ee1b455017648fcd4830f204539a1626c2ec8e1c9"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/fireball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/icefire.wav": {
+     "bytes": 8858,
+     "sha256": "b529a958de192b59438989c6b98eb50f858273febab53a238b651c70a3c92098"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/shard.wav": {
+     "bytes": 14324,
+     "sha256": "313428dd2cb681a38ad89983ab39b18979f64b3e398104b1ad80f3dc9726616c"
+    },
+    "sound/baron/sight.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/tornado.wav": {
+     "bytes": 11469,
+     "sha256": "9ede270665956ce33daf9d3b49447c09e198275f640ccaf77af4f44273bd3f64"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/bishop/conjure.wav": {
+     "bytes": 54627,
+     "sha256": "532d4b7d5db6a654aa73dfe18fa0f6a71623acfd804a848f106b0af699022bc4"
+    },
+    "sound/bishop/journey.wav": {
+     "bytes": 42051,
+     "sha256": "0995e55661447c53c3a36ae4552ea2e0bb7ec8b178bf52cdabe9d28b4deaa50c"
+    },
+    "sound/bishop/rip.wav": {
+     "bytes": 31906,
+     "sha256": "7070871da7ec08da6260a65f1a98ed1bf9682b1c95c51cea262a4b88a63fb6ca"
+    },
+    "sound/bishop/rot.wav": {
+     "bytes": 22463,
+     "sha256": "866b836874ba611d70675e5e3b83eac059c927bef0e0d1396f2183ea01bcc203"
+    },
+    "sound/bishop/skull.wav": {
+     "bytes": 34293,
+     "sha256": "48836a4d60ed8962ed0f11bffdcca95a200645e3b2cfa49a598d6392e10dc153"
+    },
+    "sound/boss1/explode.wav": {
+     "bytes": 27690,
+     "sha256": "b7eebbb64696612ee18d8d1e25b9c5cc334a4562cb99758a446a22490215f349"
+    },
+    "sound/boss1/explode2.wav": {
+     "bytes": 14798,
+     "sha256": "4c6b14b163905823f629644fbec088f37f712cf7f76e10e2f91ef23f2b573ae6"
+    },
+    "sound/boss1/explode3.wav": {
+     "bytes": 19028,
+     "sha256": "69ef0c65811704d8996b726d6e2cbcf70528d3ca7b2f28ec8814c20e7ab76ad7"
+    },
+    "sound/boss2/pain.wav": {
+     "bytes": 84796,
+     "sha256": "b9c255890f61771966327ad49994306a1e3de4b702163a079b5a733b4016810a"
+    },
+    "sound/cube/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/cube/bc_attck.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/cube/bc_gulp.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/cube/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/curse/x_armor.wav": {
+     "bytes": 17988,
+     "sha256": "61b518c8ad8410a17eaca28ee190d96a0c3d1dc755593872d7ec5429c8c19157"
+    },
+    "sound/curse/x_damage.wav": {
+     "bytes": 14772,
+     "sha256": "f74f64e3f47cee7c9b424b94a426f93c133d8acc1e6cb15551a72ab361fe95c4"
+    },
+    "sound/curse/x_leech.wav": {
+     "bytes": 16692,
+     "sha256": "78aacf297df09e21645c2e04ccf181266c35c8e52303ecb498c90db33e8c7b27"
+    },
+    "sound/curse/x_muddle.wav": {
+     "bytes": 18932,
+     "sha256": "b85810135fb3eca3f141047a08cd42a0e527d6da6e9fcfca3887a15f89edad6b"
+    },
+    "sound/curse/x_slow.wav": {
+     "bytes": 16728,
+     "sha256": "0477b046f163d36e9e41c8686ca7538659d0327668d938c0b2405f3a1e6dab3c"
+    },
+    "sound/curse/x_weaken.wav": {
+     "bytes": 15946,
+     "sha256": "f98441764b5f258ee875090c73e5841f4c8f97decbfbd8d9da836a7aac30f430"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15692,
+     "sha256": "72e737f04f1d34044dfd812c6b0e233cd38a91e6b089633e312678756952de87"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16625,
+     "sha256": "bd4cd7902712282ef8f2f749e6fcf805c2ac5212994fbb1c22fc0fe0ea5d08e2"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15527,
+     "sha256": "0b472a984137667f4788336a4f7c60e07a8893f47317b2a158aeea39920d729f"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4107,
+     "sha256": "8fe56b192838dafdf7ff4737cf1e5555d3295cbca49c1ab83568281ee188153c"
+    },
+    "sound/cyber/cybidle.wav": {
+     "bytes": 11894,
+     "sha256": "af7b96ed2eb5bc55900957b3e4136bd5dd93a72dcebca3bc2eb67cdc5186d32c"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8122,
+     "sha256": "3ea23b8d7a68e754211a10a5338b0c8d65df6e2138d4cfe06cc053b9a0f601ae"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13081,
+     "sha256": "a5ec6d4eaa707ad0246b7a7e7737b1007043ea5e5634f6f63661ecc20c27c459"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48508,
+     "sha256": "b7aac875623f8dca7597eff3dcab5910453d043fd1f9df20da89232ce8bf9306"
+    },
+    "sound/darklord/death.wav": {
+     "bytes": 10761,
+     "sha256": "7f32e12c649aa4fc4c2edb773c45b6b4258d048176d95e060390834ee7b52493"
+    },
+    "sound/darklord/idle1.wav": {
+     "bytes": 5632,
+     "sha256": "c151a3cf537f5c3668fc116e6ef5c70c9286e8a12097f376ecdf8a04774926a1"
+    },
+    "sound/darklord/pain.wav": {
+     "bytes": 12684,
+     "sha256": "f332a8cdf67fe414966f59d46714154c94de7ebcca3880a47ef5bbdad2c03ef0"
+    },
+    "sound/darklord/sight.wav": {
+     "bytes": 16832,
+     "sha256": "9710267844facf1c627ea0a8f0df458d847eb899dccd9c570e9d967acc64fa07"
+    },
+    "sound/darklord/sword1.wav": {
+     "bytes": 15982,
+     "sha256": "d36670980603c18a67d500707de9db5a8d54128601d6a6c67f7f29677244aebc"
+    },
+    "sound/darklord/sword2.wav": {
+     "bytes": 12434,
+     "sha256": "f7730881c690e0ee6a440756f74630a21241239fd1fd3bbdfd88000c7e57d1cc"
+    },
+    "sound/doomcube/dsbospit.wav": {
+     "bytes": 43719,
+     "sha256": "97f61cb588bb405cd235e242bfca6fe1108171625a7aa4f2573d63682ac42e32"
+    },
+    "sound/doomcube/dsbossit.wav": {
+     "bytes": 57109,
+     "sha256": "5843548ad38c8eea72548481b5833590fbb7fb990daebd0ede4aaac93475f461"
+    },
+    "sound/dragon/acid.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/active.wav": {
+     "bytes": 16118,
+     "sha256": "5c8762ad62bcb65e1a6fa3362393141a8564fca3ad28ea896a18545c5ebfe6ad"
+    },
+    "sound/dragon/attack1.wav": {
+     "bytes": 25054,
+     "sha256": "c96520801f27bc933928d7f793c2c28ff2dc7b36a86450f6372a9c8a668b4f58"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 63766,
+     "sha256": "55eb476a990e479c06b4c9a12b71c595d8ada35e813e512986709650ef0e54d1"
+    },
+    "sound/dragon/death1.wav": {
+     "bytes": 18358,
+     "sha256": "645baa1cccaf1dfbcd628d17fd8ea290f42f1bc40903e26c79a536a6d1528a2a"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/fly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/fly1.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/dragon/flywater.wav": {
+     "bytes": 11034,
+     "sha256": "68cac399467a55df3c80331696869309eea2339467df0ba94408be4fa2afeb3e"
+    },
+    "sound/dragon/ice.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/icehit.wav": {
+     "bytes": 9370,
+     "sha256": "089c07d0352678106aaa1c47f015792393d5aa01b4bd64fa35e798c4ee09108b"
+    },
+    "sound/dragon/idle1.wav": {
+     "bytes": 34068,
+     "sha256": "3a125f0bcf2908e4ba3af298b117f71c0efa43be4077e53c791b2805cce6a038"
+    },
+    "sound/dragon/idle2.wav": {
+     "bytes": 21474,
+     "sha256": "e1101ff0121687511a9c978d0a30a945421d0a2a30b7d139e4427d41dcc17628"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 28302,
+     "sha256": "60a99d79b6922a14e27ed63313e82ff17b127bda008bd614d8e9ed86f0f2cc3a"
+    },
+    "sound/dragon/pain1.wav": {
+     "bytes": 6524,
+     "sha256": "6cdce2fde3a1eb328007e0667c5dfe705e87bcd526e416ac948fa11a36448ac0"
+    },
+    "sound/dragon/pain2.wav": {
+     "bytes": 6875,
+     "sha256": "3238b77aafcc60c634cbdbd47ae1eec99bb969e2161b72ce5623398e6a451d2a"
+    },
+    "sound/dragon/see.wav": {
+     "bytes": 39640,
+     "sha256": "e8202c360287700da28f96d6a14fef6bdea04374ea911f2b3e41183cd8a136ba"
+    },
+    "sound/dragon/sight1.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/sight2.wav": {
+     "bytes": 15205,
+     "sha256": "197238a35261e6792c40a4da38ba7b3827116ac1af5f143e092768346605b470"
+    },
+    "sound/drone/drnblip.wav": {
+     "bytes": 2106,
+     "sha256": "b372ece13de5edfb22d88ff147a9eccfddfe446c9403607d89daae09fc7c8b68"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/force/force1.wav": {
+     "bytes": 30022,
+     "sha256": "b609981695694648cab0f2ed521dbf3d6f31b6c2e8c3e8502ab4740c7a105557"
+    },
+    "sound/force/force2.wav": {
+     "bytes": 10252,
+     "sha256": "32c0342dbc9e63220db18fa706ac0fc1afe9a86f4d488e509e1f52bee955e3cd"
+    },
+    "sound/force/force3.wav": {
+     "bytes": 10252,
+     "sha256": "0317e18dab002184b5ce11a2b86f3263d2606c40f2dc435c824bbd075c1b621b"
+    },
+    "sound/force/fusein.wav": {
+     "bytes": 13669,
+     "sha256": "53192c25adab70ebcf471204aa194ef9d34c4161138c728d95f84cf08310a879"
+    },
+    "sound/force/fuseout.wav": {
+     "bytes": 15379,
+     "sha256": "f515c6b48204f2ba158e99c10a9da60cc45756ea5dca716e256ffbe54a017512"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/goblin/death1.wav": {
+     "bytes": 13890,
+     "sha256": "bed0d074d9aeee8f046ec7b3a9d33e02d157374ddf6af1296bd1ca7bebf30f10"
+    },
+    "sound/goblin/death2.wav": {
+     "bytes": 10280,
+     "sha256": "9cc07020579d50185ea401835e41edbd1c8f007065e39a6306c7aab4f32e7781"
+    },
+    "sound/goblin/idle1.wav": {
+     "bytes": 9802,
+     "sha256": "6c5a8c36eedb0ac5bddacfdf68250c36fe472f9d87e8969b4f95a863a99b77ce"
+    },
+    "sound/goblin/idle2.wav": {
+     "bytes": 9242,
+     "sha256": "5850c885e59ef04ae90be0579dd6f6b7cc26c282045ccb163dab2c9e19fea704"
+    },
+    "sound/goblin/pain1.wav": {
+     "bytes": 5118,
+     "sha256": "8afd94fcaa2d20e7c6626eda0c6cd5463670a1dbed0eeea36da588b28196c8a2"
+    },
+    "sound/goblin/pain2.wav": {
+     "bytes": 7898,
+     "sha256": "ad1f3b63b4ae35e4bfe010447bbd18bb85cd2bbf966ea7e1370afb0e924e699c"
+    },
+    "sound/goblin/sight1.wav": {
+     "bytes": 12716,
+     "sha256": "1c20028239d217f31af57649da5d1a6def576569ef5fc7e7033c2acbef7f9345"
+    },
+    "sound/goblin/sight2.wav": {
+     "bytes": 19356,
+     "sha256": "c9182325cacd9734bfedd48cb5d8076d5823b7a94baa40d32b02de9504474b48"
+    },
+    "sound/goblin/sight3.wav": {
+     "bytes": 8526,
+     "sha256": "796b2f9f0a1c20d672382c6681e9a6ea200fee2cfcacb5b3d3faa72c8e2537d4"
+    },
+    "sound/goblin/sight4.wav": {
+     "bytes": 8668,
+     "sha256": "c0a60baf2b9918a6df5fc32cd8b58c9fa7cfed923a4cb21c841f04f7a544782e"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 27521,
+     "sha256": "424ceef852229e94dbbbc879f1546a8dfda90db93c6263700cf4973805e4bea7"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 16192,
+     "sha256": "98d55bc63eff48521faeed1046064569e932986e734168ba0973c184aa2f5d12"
+    },
+    "sound/golem/step.wav": {
+     "bytes": 11226,
+     "sha256": "851e243a2e6ecf4cb637f8c4368b0f25443d4f9d104733eecfa886c40ee92bcc"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 47176,
+     "sha256": "87f013eb50cb30a967a183f0cfa41b4848f9269afd13dbe1ab5053458bfc5f0e"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 10768,
+     "sha256": "c48f2415db3a5067dfbd99ad580e3f4809532743d653eafe2fdb924fb0bb832e"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 47502,
+     "sha256": "a0c0bd639af614c7714388009c9388f6db9a694e7ecd8fac38653609d6958f61"
+    },
+    "sound/gunner/death1.wav": {
+     "bytes": 67190,
+     "sha256": "14f89744b8f7225e0eefd9e291aee533fd9f759b6351b57d357d9597dba90956"
+    },
+    "sound/gunner/death2.wav": {
+     "bytes": 48066,
+     "sha256": "693d0d1142dfa12ce2dd1d7b959094c201f3bf783114064c29a572dffe2fcfe0"
+    },
+    "sound/gunner/idle.wav": {
+     "bytes": 18376,
+     "sha256": "6c5b1f1d39f1cc78e87cdbf584b8a508fadc99fc2b8b85d21d0e088d134a8b2b"
+    },
+    "sound/gunner/pain1.wav": {
+     "bytes": 17292,
+     "sha256": "afee7d4ac4f872716fe3deb5adced9a99bd3744784329bd12608d051b81ebfc7"
+    },
+    "sound/gunner/pain2.wav": {
+     "bytes": 20282,
+     "sha256": "38d472d2eaaa7638f7980a06a36043353e86d99aa7e86e0132c52639738c87b2"
+    },
+    "sound/gunner/sight.wav": {
+     "bytes": 22572,
+     "sha256": "395e28b6a4684ce2fa10f085f67d58d025421c594e65a0c2a1b67aeab2ee2569"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hkboss/iceball.wav": {
+     "bytes": 14990,
+     "sha256": "6aec96fda55dfb0120f106064cd324ea6e059bab3fdbb2d81cda297f9a82e02b"
+    },
+    "sound/imp/die.wav": {
+     "bytes": 8448,
+     "sha256": "a8b0e037b88829b978d3dbd3d5e657c7f775c73662d554f6247a387ba333d4bb"
+    },
+    "sound/imp/diebig.wav": {
+     "bytes": 14956,
+     "sha256": "d44d390ba11f8850105fd9601f026cb66525a415de7fc363d3574c86b72d22c4"
+    },
+    "sound/imp/fireball.wav": {
+     "bytes": 5492,
+     "sha256": "6362b59ded89655fa8b8877ed2639eca1a7aae1847306bbc3843fa98bedcbdaf"
+    },
+    "sound/imp/fly.wav": {
+     "bytes": 9204,
+     "sha256": "8036ccb256978c17234aa171267fb0332f1911b5f0dad7b9f74bba9378c39a37"
+    },
+    "sound/imp/flybig.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/imp/flywater.wav": {
+     "bytes": 9800,
+     "sha256": "c80045609b62ceb61bd8fb1a18a53c0f2fd5443502a802b0d6d3c61e9a1db4c0"
+    },
+    "sound/imp/shard.wav": {
+     "bytes": 10678,
+     "sha256": "f806167fe23f37826964c0cc345c438ff0e79c3ffb1fed2c85451c675448cae4"
+    },
+    "sound/imp/swoop.wav": {
+     "bytes": 10842,
+     "sha256": "100eacded51635de912cee171f093e869d24589c44f68887497fe751cf9b1e4d"
+    },
+    "sound/imp/swoopbig.wav": {
+     "bytes": 14012,
+     "sha256": "65d4de49684f2f9e2655abf8e4bf042a08bd706ec4971e6397f264f7274e2b63"
+    },
+    "sound/imp/swoophit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/imp/up.wav": {
+     "bytes": 12500,
+     "sha256": "874b533da43f713a1be27fbccadda8b6392fa8e689c8c4d17dac4b0d380f5822"
+    },
+    "sound/imp/upbig.wav": {
+     "bytes": 21472,
+     "sha256": "36c7bc087935cf7cd33482a50a75df75fc2bfbe53ca0ebcd9797a8bdbde73652"
+    },
+    "sound/items/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items/equalize.wav": {
+     "bytes": 13008,
+     "sha256": "933046049bae4d866250ad9a6e0a4b2a9385caffb4156daaca39ff7110a71126"
+    },
+    "sound/items/levitate.wav": {
+     "bytes": 44236,
+     "sha256": "8a04ce4a97dc22d095bc52d08111bcaaf5f57482f580ccbe0c61bdf8fd18913f"
+    },
+    "sound/items/life_up.wav": {
+     "bytes": 8660,
+     "sha256": "2712bd978343d4170bc1757706597d4de3940a07b6847977cbf117fa92f14c31"
+    },
+    "sound/items/money.wav": {
+     "bytes": 5100,
+     "sha256": "e4ac299499340c1be250f5d5e0824440d9e539de8a1d5b01e303056719cf822f"
+    },
+    "sound/items/optimize.wav": {
+     "bytes": 14854,
+     "sha256": "508d89890db17f828cde9511ebd97241ecfe07bbb6e5cba8c7538ab02e31b19f"
+    },
+    "sound/items/quaff.wav": {
+     "bytes": 3748,
+     "sha256": "ebaa4ecc17dc67d3fbc5fe1a7541e4e19769ce941d043922f8572cb2da8d3cdd"
+    },
+    "sound/items/reflect.wav": {
+     "bytes": 14936,
+     "sha256": "90dd50b25175c8d514a52165429e9ca6b90c45dddbb0f301e5873146b4a4a06c"
+    },
+    "sound/items/reflect2.wav": {
+     "bytes": 33119,
+     "sha256": "5fb5afe50e0f5fa24f1c4481b3060ae222f40138ca81052cea047a57aa6b03e8"
+    },
+    "sound/items/reflect3.wav": {
+     "bytes": 7804,
+     "sha256": "a079e5aef6ed9fb7d5c992b0ef8e11932a9efa192eedac2bc530098e0550984a"
+    },
+    "sound/items/regen.wav": {
+     "bytes": 7984,
+     "sha256": "1e125e8e7c19f29eaf09b7ad301fdfe5126d922dfa84ba2af267cdf3351b6498"
+    },
+    "sound/items/shambler.wav": {
+     "bytes": 20182,
+     "sha256": "f0cdf78367b770c97b3b89abedb7c4fb0a9ee10d742acc8c98b3daba46cfc215"
+    },
+    "sound/items/tomepow.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/items/tomepow2.wav": {
+     "bytes": 33119,
+     "sha256": "1e2e62a6f251722741b7f0adeb38c59a1d05917d0f84c8f48922efece97f02e2"
+    },
+    "sound/items/treasure.wav": {
+     "bytes": 5554,
+     "sha256": "c86f66148e8dc99af2c8e877d64d06dc1c35d0caa9c6dc5c8092b268960b8edd"
+    },
+    "sound/items/zerkhelm.wav": {
+     "bytes": 8298,
+     "sha256": "ef7b98bd965660df91ee34920806b48428a8b5c17c0ec4fdecb48d7fe28e3ba2"
+    },
+    "sound/laugh.wav": {
+     "bytes": 71573,
+     "sha256": "cb8e1381c70240a93233b8571d792e21950d00b1285f867cbc0ed1237dac1df7"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/b_rot2.wav": {
+     "bytes": 15436,
+     "sha256": "62c86077b7a29f48f5c872c68d262c03b73b57f876b718a05f2fc6b24b9a9ef4"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/bellring.wav": {
+     "bytes": 27600,
+     "sha256": "fe3b2972c722171144eaba160757803292a42342e737d6acdbd0b14802e686f2"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/dsslop.wav": {
+     "bytes": 11163,
+     "sha256": "b6a9f6e74b222169c87e6c56b47d2e7995b23b8b045f16be968f43290f22cf9d"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/met2wd.wav": {
+     "bytes": 3968,
+     "sha256": "a3ce3e10b609f7ae28fc6f39f1f5d55a7c99a41143fb161de7e4e47b7f40f100"
+    },
+    "sound/misc/metalbrk.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/mgboat.wav": {
+     "bytes": 26866,
+     "sha256": "666016e2aa958ea621ba03bee4339518f2ccc72aa3ee2d0838ef9032e8ffc981"
+    },
+    "sound/misc/pushmetl.wav": {
+     "bytes": 14042,
+     "sha256": "2657b0006f51ecb7077b5861b1b282e0bb8bef3bdd5ccb68b3bdd6794361099e"
+    },
+    "sound/misc/pushston.wav": {
+     "bytes": 11490,
+     "sha256": "f457b95dad6131472475ab22d9c260adf5d389e74629cd8ea36ca05ad7d4e749"
+    },
+    "sound/misc/pushwood.wav": {
+     "bytes": 13602,
+     "sha256": "7c3fa06978f8c7b632d12bbf1031a5ac316b44fdc5efd93338ab0a0a162bdf3a"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/rublexp.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/secret2.wav": {
+     "bytes": 87440,
+     "sha256": "36e9d9617a14daefd510e72308b9e85718a473e2b25a06b66026d463d6bbb519"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/misc/woodbrk.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/music/pkdream.wav": {
+     "bytes": 154898,
+     "sha256": "df8857901002ce9dde3c558743c94967db11cae4af3d9a0cdc00c8cc09e6a910"
+    },
+    "sound/necro/att_a.wav": {
+     "bytes": 8522,
+     "sha256": "a946c060cab5ee1bfff2d1af87cd71c9ccf63840a2751fd46fd32f387bee2c35"
+    },
+    "sound/necro/att_a2.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/necro/att_w.wav": {
+     "bytes": 26298,
+     "sha256": "9ae481ad41d16610b597989e82a8bbf9c35a74fe03a8e27900d72ff8b52e3c94"
+    },
+    "sound/necro/curse.wav": {
+     "bytes": 16852,
+     "sha256": "d3729c83c468d9320cf1f8914c8b52d446e818852c955d8d86a093c35c196b58"
+    },
+    "sound/necro/death1.wav": {
+     "bytes": 24010,
+     "sha256": "302e58b0f701ad07ade4a46d5cd3bd9c2186b2df3eb39e36c361918a72ccd24d"
+    },
+    "sound/necro/death2.wav": {
+     "bytes": 23594,
+     "sha256": "05f15a8430885b6688587eba5e249107c3e6df36d7937a3ddd2411d275e8842b"
+    },
+    "sound/necro/idle1.wav": {
+     "bytes": 49212,
+     "sha256": "737f382e89a40fc098214b77e9165e16f2a06323c07e910f336f2616b6ca87b4"
+    },
+    "sound/necro/idle2.wav": {
+     "bytes": 47120,
+     "sha256": "18893e7b31ff448831a7b7a5aa9a5d31b2dcd6e49ae8b58d5eea8b44683415dc"
+    },
+    "sound/necro/pain1.wav": {
+     "bytes": 19412,
+     "sha256": "f37e247a9e1436e4a86b78fe71e1ea6da43323e60943e86784ac87fc4393333b"
+    },
+    "sound/necro/pop.wav": {
+     "bytes": 18996,
+     "sha256": "22aff5a83ec82e759004d82308b2e210f824ac59bd3180d6b688c9d0134ca18e"
+    },
+    "sound/necro/pop1.wav": {
+     "bytes": 10836,
+     "sha256": "d5e9b7ce5a638a419eef07bba492ce75fb3d8002bd66b40d36b4dd89ad859e1c"
+    },
+    "sound/necro/pop2.wav": {
+     "bytes": 11228,
+     "sha256": "10947cad6cd5bcc0e0bc00fdbeccccd53b70bff1fda1a220c72ddc7e2b152b08"
+    },
+    "sound/necro/pop3.wav": {
+     "bytes": 11228,
+     "sha256": "56c4219dc0ecfb7ee8ff6d31fdf6c8c53c2b6990ce1b94ed956caee3c7cf83db"
+    },
+    "sound/necro/pop4.wav": {
+     "bytes": 10836,
+     "sha256": "451b660c65ebd2c7c89134896ed882d738c685f787810e1245587c0c28c38141"
+    },
+    "sound/necro/raise.wav": {
+     "bytes": 9688,
+     "sha256": "1c841e33f22cdcd5276bba9018aec5dae8c0f842da07eb261f48f1a6cc4c8314"
+    },
+    "sound/necro/sight1.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/necro/summon.wav": {
+     "bytes": 16308,
+     "sha256": "b7fc855d38431ac04e09389d7caf04bf0032d2b4edf86ebd795f1ab38d9feaf5"
+    },
+    "sound/nemesant/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/nemesant/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/nemesant/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/nemesant/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/nemesant/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/nemesant/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/nemesant/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/nemesant/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/nemesant/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/nemesant/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/nemesant/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    },
+    "sound/pendulum/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/plasma/explode.wav": {
+     "bytes": 29598,
+     "sha256": "7a95a8337c7ad87faccc1cae98ad7840352b08608fba08aff87a1b33610f9190"
+    },
+    "sound/plasma/fire.wav": {
+     "bytes": 22422,
+     "sha256": "7350d1e99f93a79bee84e94561e080dcb8448a3549a42742633cf604377a5097"
+    },
+    "sound/plasma/flight.wav": {
+     "bytes": 17494,
+     "sha256": "a03b46f31df3495a1b7a2b2f1a09f3e5223d4c0ab65aa0ed936e1445e893adeb"
+    },
+    "sound/player/boot1.wav": {
+     "bytes": 25624,
+     "sha256": "9b730ff4f811472514297921c78ea3080424c57b57ce7fa30c6c10f94bd8ccc3"
+    },
+    "sound/player/boot2.wav": {
+     "bytes": 25640,
+     "sha256": "23a3cd545ffa3c5c1e4a4c9549aff81dadd2f1ab451e397d5292c97024fc5026"
+    },
+    "sound/player/boot3.wav": {
+     "bytes": 25652,
+     "sha256": "004d267ae3fcce21aa66e566efa34e39e85915f202e3b55922b314cfd6efa2d7"
+    },
+    "sound/player/boot4.wav": {
+     "bytes": 25628,
+     "sha256": "9beb96d9a183cd6a13693961a216b4402350fc076c7a1ff98854d28c30a9f8be"
+    },
+    "sound/power1.wav": {
+     "bytes": 44370,
+     "sha256": "68f9d490b390a2510ff660917ac02fa1620893770a68a1188e06f94c57922523"
+    },
+    "sound/power2.wav": {
+     "bytes": 44370,
+     "sha256": "773aca5e1e60540b2abdc4b9b29c4281a04f6fad3bfc6bea1c029b42a7f0fe9e"
+    },
+    "sound/ranger/idle.wav": {
+     "bytes": 10819,
+     "sha256": "644fbbc14e20684fa31abc7f04969943ac950c33435271b0fa646aa324be4400"
+    },
+    "sound/ranger/sight1.wav": {
+     "bytes": 5379,
+     "sha256": "5023e2483fe5c1c37cd661d382e34c0b68eafe4bae0e35e8f3f7e516e78dcf51"
+    },
+    "sound/ranger/sight2.wav": {
+     "bytes": 11323,
+     "sha256": "3574f035e1a261b9a001d99a54bdb502da31da2639d95e7fc06f96b547c1ac44"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight1.wav": {
+     "bytes": 35068,
+     "sha256": "48db878a4eae15b37ee0ca333aae74d310103a9eaf2e4b35eecd43a89f626b9a"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk1.wav": {
+     "bytes": 19372,
+     "sha256": "42e41297df70202ec9965af7af5fcdabcab7fde43ba515c8ba0a1ee2e4429554"
+    },
+    "sound/shade/death.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/shade/death2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/shade/fly.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/shade/idle.wav": {
+     "bytes": 37192,
+     "sha256": "57b0a0a7a0e75a17df8c4bb68740b23325bd0bf3475d908ee92fa0522c71edf7"
+    },
+    "sound/shade/moan.wav": {
+     "bytes": 33684,
+     "sha256": "3a6644f2c0a6ead5992fa9752ec9b0d898f4c40f5a32b12fd61aa991f75fa0c7"
+    },
+    "sound/shade/pain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/shade/pain2.wav": {
+     "bytes": 8918,
+     "sha256": "c6fa3ba7c659faf38b00af9c9867c37ba730cbc662125f5307f755515243dc4c"
+    },
+    "sound/shade/screech.wav": {
+     "bytes": 28244,
+     "sha256": "55ef2615baa6ce39733892fc9538f702acc567f65250223329f15b191d9b1a47"
+    },
+    "sound/shade/sing.wav": {
+     "bytes": 35654,
+     "sha256": "9de82a1d3124c391466004aea5e8ad066bcc6ede2715e7978a92a2c8f66e3f6b"
+    },
+    "sound/shade/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/shade/taunt.wav": {
+     "bytes": 36418,
+     "sha256": "f556cad612249e63690ac28b17405eba70e3df43560c3a087062b9f330811720"
+    },
+    "sound/shade/taunt2.wav": {
+     "bytes": 28160,
+     "sha256": "a68174008206b79794d8d52fd027daf08767ce005189860c815cda021080363c"
+    },
+    "sound/shamvile/burn.wav": {
+     "bytes": 11316,
+     "sha256": "239c51d5cfb82ee7683075f6cd53d8a16fcc2da608c9db87c27fd7491160a627"
+    },
+    "sound/shamvile/dsvilatk.wav": {
+     "bytes": 16978,
+     "sha256": "f4fc290f121fafbc1d8e5e992b9454b404f9ebbf3c95bc376419ee8ca58425bd"
+    },
+    "sound/shamvile/melee1.wav": {
+     "bytes": 4700,
+     "sha256": "f418a627faa0b4630588914ecdd466c387e1d7d5ac2e09acecafa13baf33f10c"
+    },
+    "sound/shamvile/melee2.wav": {
+     "bytes": 6252,
+     "sha256": "dfeb5bcd8be8d9f1fcf52f89cf0af533ec28066eb0bf74e3ac4b588ca810f372"
+    },
+    "sound/shamvile/melee3.wav": {
+     "bytes": 13236,
+     "sha256": "7102a987921e4c291175ba252628613c2c6ecdb70e9a33e174b6bcf7addc239c"
+    },
+    "sound/shamvile/melee4.wav": {
+     "bytes": 9211,
+     "sha256": "da31a8531703998c06bc33c94639d5dd291c9ba24e6752599ec8e6113d3753b5"
+    },
+    "sound/shamvile/sdeath.wav": {
+     "bytes": 20996,
+     "sha256": "e27d5870c37ce74877a2681b5e9cef437d14b05c501fb93733c8e93d2d2b0931"
+    },
+    "sound/shamvile/shurt2.wav": {
+     "bytes": 3924,
+     "sha256": "541c66bfaf5f30c55d24c4013f4a8859159ebfdf2f054c681eb8b8200dba1c85"
+    },
+    "sound/shamvile/sidle.wav": {
+     "bytes": 5476,
+     "sha256": "ca3edcb476f3992027989a2a79ef21a7f8951965c8a0e77f89f0a0505f2d2b52"
+    },
+    "sound/shamvile/sidle2.wav": {
+     "bytes": 21511,
+     "sha256": "0e46d4e53c003136881723f59de4d706151b845d57608cd87361018acb7ef050"
+    },
+    "sound/shamvile/ssight.wav": {
+     "bytes": 15564,
+     "sha256": "5a5343f95ee503f1b481ef05499e023b681402b922600979367788f2fb91397c"
+    },
+    "sound/shamvile/ssight2.wav": {
+     "bytes": 27204,
+     "sha256": "2b22c0912485569f7ec87a32a29c88563c0cb8261b4428335540fc96f7e7cb52"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 19642,
+     "sha256": "91eba6c478e8475696f07079502af32d1817e3fb86418c32801846582f27561d"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 18166,
+     "sha256": "91301f18c459286798989dd164ae08f5e77433ac7a0b5c71522cf59e49bf1a30"
+    },
+    "sound/skullwiz/blinkspk.wav": {
+     "bytes": 31420,
+     "sha256": "48a4dbd2add9021727d4572af9ac4c6f333a9e2ace5fe7127ddd42c84a2ae1f4"
+    },
+    "sound/skullwiz/blnkspk2.wav": {
+     "bytes": 41834,
+     "sha256": "fc2602275102b7e1a577c30b7ab3ac2709881eb3a8798664577f8a65a9132754"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 23034,
+     "sha256": "0eb20419acddee8a5814ecad8888348f90a14db997af1045b02b6052dccd5fd1"
+    },
+    "sound/skullwiz/death2.wav": {
+     "bytes": 32314,
+     "sha256": "3b1d2ed146a334ba5cf77027faa47addbf45c51159ff9c7278a97dda8ed7ef82"
+    },
+    "sound/skullwiz/firemisl.wav": {
+     "bytes": 12186,
+     "sha256": "3583544b6d7105d5b029a490cb0730190ae9e8dc5ca8f9da1deae4ea0335e964"
+    },
+    "sound/skullwiz/gate.wav": {
+     "bytes": 16156,
+     "sha256": "5797c6450d14f363133be23d93c829a660f9b7692c07f905b5a723cda8075c55"
+    },
+    "sound/skullwiz/gatespk.wav": {
+     "bytes": 30092,
+     "sha256": "f9fc90ba497d650acfad76c42ed531314828093f114c69c28fd1611d326fab2e"
+    },
+    "sound/skullwiz/growl.wav": {
+     "bytes": 18944,
+     "sha256": "de58ed34dd69dc3e871d09ac6a5db81ef26d69e234f0834e72c6cd68501ead21"
+    },
+    "sound/skullwiz/growl2.wav": {
+     "bytes": 24954,
+     "sha256": "0cf747c71a6fad9a085c39456cd14ffd972d2d454b4bafc2781ce4464917cfa4"
+    },
+    "sound/skullwiz/pain.wav": {
+     "bytes": 6106,
+     "sha256": "0f85b6180cbfe8d26f8d174f25c109b9d8b78d0fa53735e0494280bc8a19803b"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 8890,
+     "sha256": "6d48429e7fc4b80be16afd80097b7096a94cb1a88922a62bdfdff64172526a0f"
+    },
+    "sound/skullwiz/push.wav": {
+     "bytes": 8812,
+     "sha256": "91398e953b648ab23c037940fb7996f3d77727003a60757ea50686328c05cd69"
+    },
+    "sound/skullwiz/scream.wav": {
+     "bytes": 31734,
+     "sha256": "6df299b2a59aa94a9640c83684b65259e4619e0ed2a2fd1ce518dffaa060fd43"
+    },
+    "sound/skullwiz/scream2.wav": {
+     "bytes": 13980,
+     "sha256": "adca10198e279db0789a1a026124387c40e36fc1914f3f3da315b49b6e290386"
+    },
+    "sound/spider/attack.wav": {
+     "bytes": 6576,
+     "sha256": "82593fdd5be8198a9774c163872f89a088d8d0ca10e91f1c8f846ecac92b2d81"
+    },
+    "sound/spider/bite.wav": {
+     "bytes": 4552,
+     "sha256": "abd0b64743c825661f4598b7d5b70b781452a6b7747f9eb8b53f7239b0f9b9cb"
+    },
+    "sound/spider/death.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/gib1.wav": {
+     "bytes": 10516,
+     "sha256": "bbe1a437bd05a71f9d7bba953a79886891bfc526399c67cfc8964308c91786d0"
+    },
+    "sound/spider/pain.wav": {
+     "bytes": 7576,
+     "sha256": "386e11cfd8063b6bb692ab4b90246be98288f72f29614f2e38765df9e6eaad79"
+    },
+    "sound/spider/step1.wav": {
+     "bytes": 2780,
+     "sha256": "06ee408dace817630645b0d390c496e692844fb42cc85adcaa021efeb60fae9b"
+    },
+    "sound/spider/step2.wav": {
+     "bytes": 2620,
+     "sha256": "66e802d6361a17e637f5e38366e4b0912dbb0f65e647041bed57cfda772c0770"
+    },
+    "sound/spider/step3.wav": {
+     "bytes": 1786,
+     "sha256": "418b2c536f19a5bcd0b1a8ff4aae13febc8c4f8fa6787372e9e869c45a17f54c"
+    },
+    "sound/trog/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/tur_arm.wav": {
+     "bytes": 23794,
+     "sha256": "24b428117ebd7e82865b41dcfc74a75a048c4d126d7505a6c23dd243bc054a05"
+    },
+    "sound/vomitus/death.wav": {
+     "bytes": 13236,
+     "sha256": "fa2cad86ac0ce1326132c5e378aed6a9ff5615d043df1d4d48e0b2691f8d3bde"
+    },
+    "sound/vomitus/flesh1.wav": {
+     "bytes": 8412,
+     "sha256": "9ac5a8ac2155e7d9b65144e7f65525c4660ff5959fe3a0277fab347e202b6f46"
+    },
+    "sound/vomitus/flesh2.wav": {
+     "bytes": 12788,
+     "sha256": "3fc22e2aa2c3c0bdc6501388ac18abb5e58c5fd5deba39d1cc2f7e8d48fcc869"
+    },
+    "sound/vomitus/groan.wav": {
+     "bytes": 13224,
+     "sha256": "3632e43615714e5fc1be8277881a913bf1bd79b276544418cbf1b159016f0d03"
+    },
+    "sound/weapons/axhit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/weapons/axhitwal.wav": {
+     "bytes": 6694,
+     "sha256": "0f14ba18076b25a7b8ee510b38adb282eb5c4f2fc94168baf1f8a658e1da684f"
+    },
+    "sound/weapons/block1.wav": {
+     "bytes": 5484,
+     "sha256": "ccb284becb454f395de702a263bfda1561b8bd38117893d33b5ebbb9eb7b6865"
+    },
+    "sound/weapons/block2.wav": {
+     "bytes": 5612,
+     "sha256": "62da8e44f3b1200b99f76a3bdb31d9d09a9e74c04a449c0afc482c6677a94bc2"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/weapons/clang.wav": {
+     "bytes": 7198,
+     "sha256": "634a88cf26b4de688bed392cf108d5468749f212ce67015c71baa942e8e88502"
+    },
+    "sound/weapons/dsshotgn.wav": {
+     "bytes": 9490,
+     "sha256": "98c228b3549d4908c313c783d5b0aec38b93efea1c6a65d7355767bdbb4b87e8"
+    },
+    "sound/weapons/freeze.wav": {
+     "bytes": 20619,
+     "sha256": "48689ba550c116dd8b10a138bc0f78eb6f169d6828a49aaafe12f807930eb934"
+    },
+    "sound/weapons/fwall.wav": {
+     "bytes": 40140,
+     "sha256": "e269c07608f322518e709925d5b13daded150460d19d3091f15152ce4c06c9bf"
+    },
+    "sound/weapons/fwallhit.wav": {
+     "bytes": 9426,
+     "sha256": "7b9f4da432e6fa44fbf721ed9ef753e6ceb41df59b8265b58f73764b2901224a"
+    },
+    "sound/weapons/fwalltap.wav": {
+     "bytes": 8316,
+     "sha256": "879b9970dfc3bc609ff384a0edea13b594ea6a82b5c56d33c8549cd36cccda0b"
+    },
+    "sound/weapons/icehit.wav": {
+     "bytes": 10710,
+     "sha256": "9ed8ed177a6cfcad97f8adcf94b9f3114a955e7b3abb397c6b17c44073c07b19"
+    },
+    "sound/weapons/icewall.wav": {
+     "bytes": 6124,
+     "sha256": "9668486027e07f525a27830dc3217cde36bcbcc956b21437d2637e00df368dd4"
+    },
+    "sound/weapons/mirv1.wav": {
+     "bytes": 89538,
+     "sha256": "7d60062f61d5929f5f927526d81920f24684520d230a5f2611c128b832d3357e"
+    },
+    "sound/weapons/mirv2.wav": {
+     "bytes": 18478,
+     "sha256": "67311180da390517f2ef71d161a0cf7b770548dcd4a7dda7e679cb9b58025b4b"
+    },
+    "sound/weapons/nova.wav": {
+     "bytes": 10020,
+     "sha256": "d41c8433fa1b964fafa1cdb2fec301fb4d398f1fce201b4d80b29fab7a59d7e7"
+    },
+    "sound/weapons/pkup2.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/weapons/plasma1.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/plasma2.wav": {
+     "bytes": 8350,
+     "sha256": "de03da8d300ddaf56b063584226f5673b0033a8258209e4c8c5f82a4d40b630a"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/weapons/r_exp3a.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/shatter.wav": {
+     "bytes": 20899,
+     "sha256": "31ddbef0dc746eabea23cd7cd2fb97a1f949a014b664630d7f04e6c237aafc03"
+    },
+    "sound/weapons/sheath.wav": {
+     "bytes": 7031,
+     "sha256": "8f28a1daa16db234ce77d91e688c7acbc9541c296d30af9e1f940b6d45eaf72d"
+    },
+    "sound/weapons/sprocket.wav": {
+     "bytes": 7126,
+     "sha256": "8b5c3bdc625b4954c6b504ee242591f0121d1ab64f2aceab54dd85fecadef8a4"
+    },
+    "sound/weapons/ssg.wav": {
+     "bytes": 17176,
+     "sha256": "c3307bb283499155691c01fe783d86992946475fd3b9a4839ba37cdca7ede6a4"
+    },
+    "sound/weapons/stunfire.wav": {
+     "bytes": 9902,
+     "sha256": "7214cc44e4c0bfb801209f025b591d838542a3110f770e5614b0f549a055286a"
+    },
+    "sound/weapons/sword1.wav": {
+     "bytes": 3532,
+     "sha256": "572074b68af2132285aa9fd2ac6852f52ffb6c5e56eed44b1af21e0e78171e17"
+    },
+    "sound/weapons/sword2.wav": {
+     "bytes": 3055,
+     "sha256": "b176a257409b659d80df90560bbac4da5539971576aaf1107bb88bc016558085"
+    },
+    "sound/weapons/sword3.wav": {
+     "bytes": 3012,
+     "sha256": "eaca19c8a10b7942d4a279974df6e1cf076c362d5408e439b26286126852bedf"
+    },
+    "sound/weapons/thump.wav": {
+     "bytes": 30904,
+     "sha256": "ef0aa85fbc7ff6915aa5382c80e6f571ddacd50116faff495e3d5638bace8a49"
+    },
+    "sound/weapons/unsheath.wav": {
+     "bytes": 8060,
+     "sha256": "45d9bc6b9dcaf8e0dc9b2ede7da69a872f50f7819462a71bc16b9d76a70be06b"
+    },
+    "sound/weapons/xbowdraw.wav": {
+     "bytes": 19114,
+     "sha256": "4bb73eb7161ba561970e8f2e7f5aad0e42b3419fe2b02a5953a7289c46d1442b"
+    },
+    "sound/weapons/zap1.wav": {
+     "bytes": 7648,
+     "sha256": "1ee462bf6169537cc96fa7f95ef30b782fa1be473bd6ddc297fb3a7a6aa21ad0"
+    },
+    "sound/weapons/zap2.wav": {
+     "bytes": 7178,
+     "sha256": "8ece0064dc470a86c00906c1c50a54afd3a64eb13582071b9960581a1b72f4ff"
+    },
+    "sound/wraith/call.wav": {
+     "bytes": 12328,
+     "sha256": "9ace8a0ff79d035d36b6bdfb8726054ceaf8f852d25f3c1b235616abf4646ef2"
+    },
+    "sound/wraith/die.wav": {
+     "bytes": 14024,
+     "sha256": "3f166e024c07124cc5b5c5469904f5a8b3e48d4cb50fd949be8d79b4df2e375c"
+    },
+    "sound/wraith/drain.wav": {
+     "bytes": 14094,
+     "sha256": "d767951e9630b6179fb05a80136acbdeeb530f350b1953bea62e8493f3fe67ce"
+    },
+    "sound/wraith/growl2.wav": {
+     "bytes": 24966,
+     "sha256": "1c757955bb103e0f589ec373d1517dbacb8fe7e274f7aa0928503c9f5b009b10"
+    },
+    "sound/wraith/idle.wav": {
+     "bytes": 23702,
+     "sha256": "760a4a215fa2adb6f531b15acc06a4b46daa84c85fc08691ff4fe13f17e09ee8"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 20442,
+     "sha256": "d55cb931cef7d9c336fb7bbc3fa0408ea23eff69f46e25ac377ebbc880fa5025"
+    },
+    "sound/wraith/return.wav": {
+     "bytes": 39162,
+     "sha256": "0439588ad2003732fe7f946a5597bf80b2b89d6395476671b0e050b91c49cca7"
+    },
+    "sound/wraith/rych1.wav": {
+     "bytes": 24482,
+     "sha256": "baec568f339f688ea475e37ef3fc51a36de78a52a553e85aaa3f8011e1240d13"
+    },
+    "sound/wraith/select.wav": {
+     "bytes": 29326,
+     "sha256": "1e86b92dd1d82f4f74cd7fe14a75484e6cddb4fe968d2bb3dbaf850414c6dacb"
+    },
+    "sound/wraith/soul.wav": {
+     "bytes": 70524,
+     "sha256": "612bf73a6ebe0526efa2ef3d22915bcd87bed0b0eb5e52fc4eb0e62c5e4a3039"
+    },
+    "sound/wraith/soul2.wav": {
+     "bytes": 20562,
+     "sha256": "d3701420c157109793576ac7af7c7b132ffd0897375ec99701f4cd54798d9579"
+    },
+    "sound/wraith/speak.wav": {
+     "bytes": 25630,
+     "sha256": "6d1e5b395938692d57de3ec8ef9a8b5e4ccdab920a1f247e5bcdc1f0906dfcb8"
+    },
+    "sound/wraith/talk1.wav": {
+     "bytes": 16654,
+     "sha256": "6a625383c12f7fb5979ca8977a51d40f183051d551bd0b1b4ccc8a3f43a0322a"
+    },
+    "sound/wraith/talk3.wav": {
+     "bytes": 9832,
+     "sha256": "28ecc66c85bc722059b147a1354d226fbaf3022b79aed937a4759958d52c0fab"
+    },
+    "sound/wraith/weird.wav": {
+     "bytes": 3028,
+     "sha256": "1cfcd24daeb0665dce9d68ec353377ef84a88c78d1fdfcb429f2d0cc2b7f4b78"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    },
+    "sound/yakman/big1.wav": {
+     "bytes": 21636,
+     "sha256": "16c1632682aeb4b4075006d5b8b13a7e3f8821b6f59f8eb61ad78308b0d68366"
+    },
+    "sound/yakman/big3.wav": {
+     "bytes": 25096,
+     "sha256": "2cbbc5dc1249a92b9a31a6f3fa7ff654dd6339511fc99e4c552ad6a34218a4c2"
+    },
+    "sound/yakman/breathe1.wav": {
+     "bytes": 45712,
+     "sha256": "53730dabf839c183028fbdf909df8ae7ef936828c51c58a957617444872224d4"
+    },
+    "sound/yakman/breathe3.wav": {
+     "bytes": 50728,
+     "sha256": "fd923c891934046d9770c089dfe16021373a392b429531ef9698fbd2f759c42a"
+    },
+    "sound/yakman/crash.wav": {
+     "bytes": 17808,
+     "sha256": "068f6ea04f13016615f9534e74e969a62eda98c7def921df76731c5afbd73cf2"
+    },
+    "sound/yakman/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/yakman/expsmall.wav": {
+     "bytes": 8732,
+     "sha256": "18825b9644c01ff0a488887185ac14d6fb4fd983254620009ba3ecc96c44d465"
+    },
+    "sound/yakman/firefblt.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/yakman/pain.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/yakman/slam.wav": {
+     "bytes": 6372,
+     "sha256": "2c6ff4782b389777c98f09fa6ac86e6c75a848ad800db6dc32f8ea9362706e96"
+    },
+    "sound/yakman/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/yakman/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    }
+   },
    "sha256": "22d57e211cdb714ba3df19083c1514b08e5c84650545bc1a4092b383fb72a3f9",
    "timestamp": "2011-06-12T20:56:02.000Z"
   },
   "drakebeta2021/pak2.pak": {
    "bytes": 4813402,
+   "files": {
+    "progs/brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/drlbomb.mdl": {
+     "bytes": 20355,
+     "sha256": "5c1db489f43cba73fce265db642267775245d044866cdd48396b1f1260a28237"
+    },
+    "progs/drole.mdl": {
+     "bytes": 241648,
+     "sha256": "5067b7ca5323754fe563d6696025525645a2cbd3aaf7f79232634608f9fb987a"
+    },
+    "progs/g_fx.mdl": {
+     "bytes": 32260,
+     "sha256": "ac99d4e641af0bb1495ed38ba9f3a7c1195bda19e5cf0d3a68f04defe6178ab8"
+    },
+    "progs/gaunt.mdl": {
+     "bytes": 222024,
+     "sha256": "d805c09223a651d6650ad75464cba53ae0fb7f8de1066307efd21d0079c14f5c"
+    },
+    "progs/gug.mdl": {
+     "bytes": 482020,
+     "sha256": "2cd097236a235aedf717a86b7312bd7d1b3caa6f0b25980c82eee2463fee2274"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 16854,
+     "sha256": "00f3263f1c3e0daadaaf03eea447080d727ea7d9ee1a88f2b42e060d748e1566"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 61251,
+     "sha256": "dec5afe666eba8db6e32d7535fffa3d0e4ed9344ba107b73418526ebebac574b"
+    },
+    "progs/longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/marsh.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/marshsm.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/snowflak.mdl": {
+     "bytes": 36372,
+     "sha256": "d7cdcca5767160408a43bd6b51313f9b68b696aa06eafdb0af4762513325d1a9"
+    },
+    "progs/spore.mdl": {
+     "bytes": 13469,
+     "sha256": "fc9fbb97f0d4f1a9f843769cd43fb7270ba2b351cdf3b4b624d27616980457c4"
+    },
+    "progs/vermis.mdl": {
+     "bytes": 656752,
+     "sha256": "d7060475e290482c61c122b3a477085b1aad002fd71d8293cc4a4f8bde1baec9"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/explode3.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/sight2.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 83982,
+     "sha256": "4b0d8db882ab1c9fc2109effeaf125ec46fb23a91ac2242201103e0d3da96944"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gug/bile.wav": {
+     "bytes": 54572,
+     "sha256": "e06787585ef0369798a938a1a9585d24b60aa7b5c65acda3a5fb6f2c7ab65aca"
+    },
+    "sound/gug/bileatk.wav": {
+     "bytes": 50040,
+     "sha256": "b4b05e2907789a78391ccfe8ced3902821f1097ecd1f894b12ba9278d31a8717"
+    },
+    "sound/gug/death.wav": {
+     "bytes": 132396,
+     "sha256": "20bf209a832381b77d37c54a84ab1819b6c71e2147c5d122ac62668c070167a5"
+    },
+    "sound/gug/gquake.wav": {
+     "bytes": 43350,
+     "sha256": "d232ae13b55cb5b10b8903db43c037a5c6c4cdfea1f84f9399133484df6e0175"
+    },
+    "sound/gug/idle.wav": {
+     "bytes": 50580,
+     "sha256": "ff33c63696dec5c582ff9a4537814299b47ce2480d6cc53c116721d793576fda"
+    },
+    "sound/gug/pain.wav": {
+     "bytes": 22064,
+     "sha256": "e559f2b372fe771207aeef4b1c3a71baca542863493776558ae3f933f3878c29"
+    },
+    "sound/gug/quakeatk.wav": {
+     "bytes": 65882,
+     "sha256": "2c07b7690356bd9233a79c1f8b5f4e146cbabc367a19c138d6719a1e0d09328e"
+    },
+    "sound/gug/sight.wav": {
+     "bytes": 76426,
+     "sha256": "210ed86a5d6f9d4e791954fc3a4e4b4b6dc5839d02f7c19d468493a2f87dca64"
+    },
+    "sound/gug/step1.wav": {
+     "bytes": 15494,
+     "sha256": "4e2ce285991bc0d4337c77fdbb029507697ecb4dbf6543ddefe976ea114c4214"
+    },
+    "sound/gug/step2.wav": {
+     "bytes": 15502,
+     "sha256": "27f6f770a52fce5ae04836706e63ef455555de086019a2f9e44d4da1fc99b03d"
+    },
+    "sound/gug/step3.wav": {
+     "bytes": 15502,
+     "sha256": "fcc7ab38a8ec28509d0aa062a3cb93aee6da6a0ae364e4fe0dfad791f54558af"
+    },
+    "sound/gug/step4.wav": {
+     "bytes": 15502,
+     "sha256": "fc52cad29cca2e1fc36f5c6ac7f955ed897d6da4fb5dcf4eefd052e0652d93e7"
+    },
+    "sound/gug/swipe.wav": {
+     "bytes": 16064,
+     "sha256": "90bb5831dfd19f65df19e97f76d858ec940d8e33e0a2ed8fad89a23947e430e5"
+    },
+    "sound/gug/throw.wav": {
+     "bytes": 23180,
+     "sha256": "5e901b94e7be364536603273f18791ab571c46c2fc74263774c0e312f873a281"
+    },
+    "sound/vermis/death.wav": {
+     "bytes": 148016,
+     "sha256": "44b26a9dca5ec8d5e8a7ef2b5e38196b74e4f606cd37b906ee2b2e5b5a85b08f"
+    },
+    "sound/vermis/grab.wav": {
+     "bytes": 88122,
+     "sha256": "09528bd0d49d5cac0c03fe7994b57e572eb89aa8bce63cd0a591130e4b2126ae"
+    },
+    "sound/vermis/grabbed.wav": {
+     "bytes": 51630,
+     "sha256": "99583c88b8ec2959a0d69448aee16ec86b3d9feee6df7841fc32759598349376"
+    },
+    "sound/vermis/grndhit.wav": {
+     "bytes": 36428,
+     "sha256": "1f0e78fa08efb4617b6967a6cc218c56af227c7fd6bf039420d8f106d74fca72"
+    },
+    "sound/vermis/pop.wav": {
+     "bytes": 131420,
+     "sha256": "6284ab02e604b44c5b07225b2a0544c8707517d5fec0024c127bdafef2704f70"
+    },
+    "sound/vermis/sight.wav": {
+     "bytes": 137772,
+     "sha256": "d892117e4602595b6dfb65563b8fa7a3ad2171851791f7c6f47ea4bfece76296"
+    },
+    "sound/vermis/sight2.wav": {
+     "bytes": 106780,
+     "sha256": "6132e2d0db5cfb7a1a064e708d97f7258e2c6ac15c6f4ea8d520641e0ad10f9d"
+    },
+    "sound/vermis/splash1.wav": {
+     "bytes": 30710,
+     "sha256": "f931a2927c13cdb2523dde4550c0af993cc08cbea6e332739f9cf6fe3bd1ff8b"
+    },
+    "sound/vermis/splash2.wav": {
+     "bytes": 25332,
+     "sha256": "b91c69ee695bd71537ed018800f7d89e5e7d95332124f69adee39261d84d7c13"
+    },
+    "sound/vermis/splash3.wav": {
+     "bytes": 25590,
+     "sha256": "99fad2f3815a30ef645a2162ea24e54b4302ba00d7551af9299fde74ecce98e8"
+    },
+    "sound/vermis/spore.wav": {
+     "bytes": 44204,
+     "sha256": "d01a27af99745725dae124d30af18458b2ef323bce93c3cad939310e0f47f6c7"
+    },
+    "sound/weapons/railgf1a.wav": {
+     "bytes": 66260,
+     "sha256": "a3a7edd9c470077682bde595f95d88546d416f300202ae96bd6c6371ec19cf09"
+    },
+    "sound/weapons/railgr1a.wav": {
+     "bytes": 51566,
+     "sha256": "40ce379a835e11561573be1dfdf1806a9bcb27192b94333a126cc721e38bbde4"
+    }
+   },
    "sha256": "8bf25c19172e0f7a63ad30fa14b1a93d335e50270bb1d3bd110d63adae53a3b5",
    "timestamp": "2012-12-11T08:04:08.000Z"
   },
   "drakebeta2021/pak3.pak": {
    "bytes": 6506790,
+   "files": {
+    "progs/bone1.mdl": {
+     "bytes": 6328,
+     "sha256": "9a00fdc313c40d06b9bb936c5ed0f97b2174cfc6494598cba42fb212d80dfcfd"
+    },
+    "progs/bone2.mdl": {
+     "bytes": 2940,
+     "sha256": "fc25694231ef3cb7567db44cbd080e416526fba73509781eb45c5e9841aa542e"
+    },
+    "progs/bone3.mdl": {
+     "bytes": 34368,
+     "sha256": "9f7a6f1d708b1efe687d675b459c4274143a7da6dd551ed8db83e01700375e17"
+    },
+    "progs/bone4.mdl": {
+     "bytes": 6676,
+     "sha256": "4587bdd40928b25698e89c437624c77cc2c77f32af929ca51a2122d069c8c8b2"
+    },
+    "progs/hive.mdl": {
+     "bytes": 9576,
+     "sha256": "24d505825f72178d41174d481b4ddc1981871a25f5a8d2a6bb12800dbfb57b81"
+    },
+    "progs/rider1.mdl": {
+     "bytes": 1595708,
+     "sha256": "207bb926fefd34b57bb14ec3d9d9a3106bfd58cce3201f1cb5b0d754140f79ff"
+    },
+    "progs/rider2.mdl": {
+     "bytes": 545600,
+     "sha256": "8414d8d62214848b26da3e56e3bb0ac0fc59792e9e473a9f9a4c62bfc0ae3699"
+    },
+    "progs/rider3.mdl": {
+     "bytes": 1110232,
+     "sha256": "6ca363430c2dd5a7484020cdc1e5c0936f544f51bee05d6a569c41efb6ca478e"
+    },
+    "progs/rider4.mdl": {
+     "bytes": 1454524,
+     "sha256": "14c64b22aaec0069b201982e3f126bde71683876ed80f737047f87a4dec6e86a"
+    },
+    "progs/swarm.mdl": {
+     "bytes": 127844,
+     "sha256": "eac005f0b9ff31650bfc81963b0cc3291732fa8366e31c56c5b0d809c880cc17"
+    },
+    "progs/waraxe.mdl": {
+     "bytes": 35856,
+     "sha256": "8b18a468baac0ff4201c63aea1bb2caf4a9f4a327f818567dcdb1c2cf395e570"
+    },
+    "sound/rider/death/clop.wav": {
+     "bytes": 4580,
+     "sha256": "6028b9d195ad93a68ceefcb8aec4370e950a897981989de0b665069c486a281a"
+    },
+    "sound/rider/death/clop1.wav": {
+     "bytes": 4580,
+     "sha256": "28696cdc4d6b356c6ffc1cac5d002bc651aab5b589394883e36d3ccf7f631ffd"
+    },
+    "sound/rider/death/clop2.wav": {
+     "bytes": 4580,
+     "sha256": "b2b9cc8663468d85eebbf71c404b708bed34924e9ca3271b827bc52cca67f20e"
+    },
+    "sound/rider/death/clop3.wav": {
+     "bytes": 4580,
+     "sha256": "b7bb0249d011f6dc154528919a16439a9ded749854b6d6c48bff3e1bc0c1f506"
+    },
+    "sound/rider/death/dthdie.wav": {
+     "bytes": 83066,
+     "sha256": "6625da36c6812b89e44fc5233f919cdb043e975ba63c28e432e6cc98d4d4093f"
+    },
+    "sound/rider/death/dthfire.wav": {
+     "bytes": 70778,
+     "sha256": "c9e9a417835472e4c27063b19f83e051d7311f0cce9321bd5c247f381db1a2cd"
+    },
+    "sound/rider/death/dthlaugh.wav": {
+     "bytes": 25658,
+     "sha256": "86f355417fc2e8bd9609847546ee20163dd0ce9fc9cfb3d153dcb96f212ad188"
+    },
+    "sound/rider/death/fout.wav": {
+     "bytes": 9820,
+     "sha256": "2cdb50e8f08ad8bcf06f49e853ab0ca1fb5cc98b5dd5f3aa008fdc62f2f047a3"
+    },
+    "sound/rider/death/shot.wav": {
+     "bytes": 30278,
+     "sha256": "e563c20fe5cbc6ac4b38775efc4f970d6e8ce3fa62cc2da94b6c2b91e8c196d5"
+    },
+    "sound/rider/death/victory.wav": {
+     "bytes": 38298,
+     "sha256": "d023b32dff8c6c6b4d95649eab7a3ffbaf4b1e05c9e3175ee4f112761e07e3ef"
+    },
+    "sound/rider/famine/_pull.wav": {
+     "bytes": 57686,
+     "sha256": "52106aee04a0248ca5276c8a8e1c82f416c591f2dac08083add05e5218b74e30"
+    },
+    "sound/rider/famine/clop1.wav": {
+     "bytes": 4580,
+     "sha256": "6028b9d195ad93a68ceefcb8aec4370e950a897981989de0b665069c486a281a"
+    },
+    "sound/rider/famine/clop2.wav": {
+     "bytes": 4580,
+     "sha256": "03b337ea1a348380e148ad03e99179fab0dbd1efc7820d45a74e863cdcf36cb1"
+    },
+    "sound/rider/famine/clop3.wav": {
+     "bytes": 4580,
+     "sha256": "afd07556f44f35222216a90235beccb149d74ac6a7cfcd7fbccd77cd76d8534c"
+    },
+    "sound/rider/famine/die.wav": {
+     "bytes": 57028,
+     "sha256": "9abd0716561549eae9b2ab444be276049c530a77e9c087dc9292fc18e0afb285"
+    },
+    "sound/rider/famine/flashdie.wav": {
+     "bytes": 248954,
+     "sha256": "2d8942ef8b88dd64239cddc8b4957d76d647543e50b95115bd76ddbec1f11a2b"
+    },
+    "sound/rider/famine/laugh.wav": {
+     "bytes": 45050,
+     "sha256": "efe0051a1e53d8328ae47901778f0cd19f1db793ef2a8d1c98c92bb71662fb7f"
+    },
+    "sound/rider/famine/pull.wav": {
+     "bytes": 58064,
+     "sha256": "998853d60e5f97150e266e97671c71328bb2dbf8659f9d3653a5684d05158132"
+    },
+    "sound/rider/famine/shot.wav": {
+     "bytes": 30278,
+     "sha256": "e563c20fe5cbc6ac4b38775efc4f970d6e8ce3fa62cc2da94b6c2b91e8c196d5"
+    },
+    "sound/rider/famine/snort.wav": {
+     "bytes": 25850,
+     "sha256": "06f92fc701f8f071c2892cdaf2a1d2ac94c5429033de326a46ef5523cc9d2b50"
+    },
+    "sound/rider/famine/whinny.wav": {
+     "bytes": 26362,
+     "sha256": "404de44803c2ec34721ae2fd6b0bc22b6baaa9d3c27ef88c896a1275846c7cae"
+    },
+    "sound/rider/moan1.wav": {
+     "bytes": 37224,
+     "sha256": "e86190319c4ed1fc539497e010874070b0920ee45abe960baaafabe74df09db1"
+    },
+    "sound/rider/moan2.wav": {
+     "bytes": 33598,
+     "sha256": "aa9dc4112e9343941f146d955227a1114f1d1911556db66e73fed4e39e981832"
+    },
+    "sound/rider/moan3.wav": {
+     "bytes": 35436,
+     "sha256": "b398a3f40b10b73cf63d041ad2de34e83a6c006ef5c50485c377e855fe373e65"
+    },
+    "sound/rider/pest/buzz.wav": {
+     "bytes": 21754,
+     "sha256": "957f1781514ab8e37909ea16813763357839c3d78e6eba2e5b630d3c92c389c4"
+    },
+    "sound/rider/pest/charge.wav": {
+     "bytes": 22844,
+     "sha256": "8c2a74463d2f5c6b32a5ad7f4c4654ca9f786556eafbf7e558b45c6b703415c0"
+    },
+    "sound/rider/pest/clop1.wav": {
+     "bytes": 4580,
+     "sha256": "6028b9d195ad93a68ceefcb8aec4370e950a897981989de0b665069c486a281a"
+    },
+    "sound/rider/pest/clop2.wav": {
+     "bytes": 4580,
+     "sha256": "03b337ea1a348380e148ad03e99179fab0dbd1efc7820d45a74e863cdcf36cb1"
+    },
+    "sound/rider/pest/clop3.wav": {
+     "bytes": 4580,
+     "sha256": "afd07556f44f35222216a90235beccb149d74ac6a7cfcd7fbccd77cd76d8534c"
+    },
+    "sound/rider/pest/die.wav": {
+     "bytes": 50746,
+     "sha256": "aa792d7d708de73ebe752c073376b40528ea2ab955d7b286cd8cdf933a4896ce"
+    },
+    "sound/rider/pest/gallop.wav": {
+     "bytes": 21114,
+     "sha256": "c8e5b5fbe216bcd1a59d5946ca3852302956fd5a6b4d1a7f97a73fc6859376a8"
+    },
+    "sound/rider/pest/hivehit.wav": {
+     "bytes": 16098,
+     "sha256": "ce85b2ec50191cd32697a24ef3afb62a70163116de8c185c2de4d219e2d3f26d"
+    },
+    "sound/rider/pest/laugh.wav": {
+     "bytes": 32980,
+     "sha256": "ba8aaa258dc7b21b52a2aa8316392f9f1edd8429b14253203ca0bbba128eac30"
+    },
+    "sound/rider/pest/sight.wav": {
+     "bytes": 22252,
+     "sha256": "6b4cb4b209546f52a749843ddb18767689159117e9e29f8eb7f1706c3811f022"
+    },
+    "sound/rider/pest/snort.wav": {
+     "bytes": 7150,
+     "sha256": "5af4c6e77675a0f27bcb62779205538e2e6ce4971a84361a494840c555c6b408"
+    },
+    "sound/rider/pest/snort2.wav": {
+     "bytes": 16376,
+     "sha256": "c8df6c3268bd3f2c8ddf0f9db33b410e61b550b2b6c1fc5ad0b4d20383dabe83"
+    },
+    "sound/rider/pest/sting1.wav": {
+     "bytes": 12218,
+     "sha256": "d37886f958b95e15096315a6b83bcf5f735ff5c7bf49c6654d4080978531687a"
+    },
+    "sound/rider/pest/sting2.wav": {
+     "bytes": 11482,
+     "sha256": "185692d83e0565bd5d6e7a15d533ea9032895c7863140275f4d2009e79ff6ad7"
+    },
+    "sound/rider/pest/sting3.wav": {
+     "bytes": 9758,
+     "sha256": "e6f4f6bb9742a7220d06b38c8068d7efbd9708ced0455473840e30a5c0bab740"
+    },
+    "sound/rider/pest/xbowfire.wav": {
+     "bytes": 15450,
+     "sha256": "548adc1347e3f72e83fe31bac1d3ad02efe912d49e96512afbc94ca377d0ac0e"
+    },
+    "sound/rider/pest/xbowhit.wav": {
+     "bytes": 10066,
+     "sha256": "03d93c412e226d7e71077be790ff62afff9fa4306b5335f4e0338b6fd3dc47dd"
+    },
+    "sound/rider/war/die.wav": {
+     "bytes": 75642,
+     "sha256": "16185e29265e20db7fc35836b2adc2ff5ca7ed203a25139f7656244aa8abe238"
+    },
+    "sound/rider/war/fire.wav": {
+     "bytes": 84474,
+     "sha256": "48bddc52358fb6ae4fd362ba0efb103638f9f8ab7776dd0461fd33546b50b3ed"
+    },
+    "sound/rider/war/fire_big.wav": {
+     "bytes": 32762,
+     "sha256": "2fb163e76fe46d966326879399155e045fc35063b2b8a2e55746e082e4bfbee7"
+    },
+    "sound/rider/war/laugh.wav": {
+     "bytes": 31012,
+     "sha256": "a80094ae1273615c5683e4a949a3adbdfce927635af5f5132cc46403a11d9596"
+    },
+    "sound/rider/war/laugh_sm.wav": {
+     "bytes": 20328,
+     "sha256": "9c515335988177e563d7fffb8f77c99790fdaed6631566e94ad0cd3dc74819fc"
+    },
+    "sound/rider/war/whinbig.wav": {
+     "bytes": 50940,
+     "sha256": "871b0b4b5bd3346747587cc435090d6afc978da07711cd819858b911358b1b6a"
+    },
+    "sound/rider/war/whinny.wav": {
+     "bytes": 20762,
+     "sha256": "a6b16598912d06b03c6e1f974c2b8ab4d8e1486f8785e25d68336d2e22ec55ca"
+    },
+    "sound/rider/wartrot1.wav": {
+     "bytes": 7478,
+     "sha256": "abac0cfb4bf02364e795b83197ca563c2e158d93eb9f6999cc258c12fc8a1ecb"
+    },
+    "sound/rider/wartrot2.wav": {
+     "bytes": 8920,
+     "sha256": "83f6abaced3124b50f760c666c5902abcb57309f951308ad30d0fbc7f8cf562e"
+    },
+    "sound/rider/wartrot3.wav": {
+     "bytes": 11324,
+     "sha256": "42af6fefd6b10d38f42d9987be5ccb71d595440a881fca4f492a5562f50e4bda"
+    }
+   },
    "sha256": "9a58d294e79806fc15293163ba9954f7d842238c3040aa753f497c5fec2e8473",
    "timestamp": "2012-12-11T08:01:28.000Z"
   },

--- a/json/by-sha256/78/78039e2132b59dd08a8ddb19340c0e0606d4e7eeacb0d9c4e323ca98e694d57e.json
+++ b/json/by-sha256/78/78039e2132b59dd08a8ddb19340c0e0606d4e7eeacb0d9c4e323ca98e694d57e.json
@@ -26,6 +26,528 @@
   },
   "eoe/pak0.pak": {
    "bytes": 232396172,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "c3435f4a56399584544b8a704612ad42e845331f1fdd7d0797b863882ec9fcd7"
+    },
+    "gfx/env/doombk.tga": {
+     "bytes": 3145772,
+     "sha256": "f1bec0f5fca61e0aa38c0bfefc735a5f467c026b80f1c5c30afddb947156979d"
+    },
+    "gfx/env/doomdn.tga": {
+     "bytes": 3145772,
+     "sha256": "1c99590f1ddf7b57869207492c2e2b154d3b554a32dc22ab259cab05bb291ca6"
+    },
+    "gfx/env/doomft.tga": {
+     "bytes": 3145772,
+     "sha256": "978806bbb9c5c22898dc8c23f78f06f63438a89109f03caa8a81c3aa14340ed6"
+    },
+    "gfx/env/doomlf.tga": {
+     "bytes": 3145772,
+     "sha256": "94e8b8d1cdd39db025e3f24c3be11a19c641794512950cc0e52938e612fe516e"
+    },
+    "gfx/env/doomrt.tga": {
+     "bytes": 3145772,
+     "sha256": "930e85c98df23c9a4a400561b206fee3e6de2ce1947609416d3a31524ed5cd4a"
+    },
+    "gfx/env/doomup.tga": {
+     "bytes": 3145772,
+     "sha256": "8f42929d4c744fc8e07dae7b342e6dde9d3b77637dd79463d5ddb4e865743c36"
+    },
+    "gfx/env/eoe_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "b0504debde343e6a51d872af08d496cdb3e9c78564136f08ba4fbcf9cbf2d421"
+    },
+    "gfx/env/eoe_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "138e9386728cdd98935a0c484d5693db2e60375d8d770ad754fe6616906591a1"
+    },
+    "gfx/env/eoe_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "138e9386728cdd98935a0c484d5693db2e60375d8d770ad754fe6616906591a1"
+    },
+    "gfx/env/eoe_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "8552c362ecc4ec21bcaf3c86e93933e05e3d194d623e8f7da9521e0bc038fc19"
+    },
+    "gfx/env/eoe_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "304b2b14fbfecb7cb4de71d34fc3239975e390be6a6385b0391490754f1c8144"
+    },
+    "gfx/env/eoe_up.tga": {
+     "bytes": 3145772,
+     "sha256": "138e9386728cdd98935a0c484d5693db2e60375d8d770ad754fe6616906591a1"
+    },
+    "gfx/env/grimbk.tga": {
+     "bytes": 3145746,
+     "sha256": "59be3026e6030ebcb4f301dc27569da94866569bd264990d5b68c0c0470be470"
+    },
+    "gfx/env/grimdn.tga": {
+     "bytes": 3145746,
+     "sha256": "6d9b33f83ccf56f92abdf2b1197ce5fa8a3979f8b40793a73219618b8f46c33d"
+    },
+    "gfx/env/grimft.tga": {
+     "bytes": 3145772,
+     "sha256": "0e1892d4675a0630cde9a1a1453fb936b5fd4f62c97a91fde60778d94bced01f"
+    },
+    "gfx/env/grimlf.tga": {
+     "bytes": 3145746,
+     "sha256": "c69dca07d21151d7ea43527494687f3951715d692ed616af3a059f01481204cc"
+    },
+    "gfx/env/grimrt.tga": {
+     "bytes": 3145772,
+     "sha256": "bf2c9897af366d36efc11de39c051f3345ceeb6d38845be71b712c9403d726e7"
+    },
+    "gfx/env/grimup.tga": {
+     "bytes": 3145772,
+     "sha256": "e4e35e286d93770157119d60889ff0d2df08fa13ccafa32ea26884e31a1344bc"
+    },
+    "gfx/env/jajbk.tga": {
+     "bytes": 786476,
+     "sha256": "257c3f41d70179e7f371f29a35542788a580e46ef9fe96f7321d74a77fab54e8"
+    },
+    "gfx/env/jajdn.tga": {
+     "bytes": 786476,
+     "sha256": "e534b8d81df676cf80282dc3a63abc1b8d66648a833d390a475156472834480e"
+    },
+    "gfx/env/jajft.tga": {
+     "bytes": 786476,
+     "sha256": "b1a273da93ae7eebc6659f60662e5a37f4f0663bd2667c17879e4d6ff6fb86fb"
+    },
+    "gfx/env/jajlf.tga": {
+     "bytes": 786476,
+     "sha256": "ec2b579b1ec484ec3f5a4a4d09803629acfb82721290be54672fc858a640c059"
+    },
+    "gfx/env/jajrt.tga": {
+     "bytes": 786476,
+     "sha256": "14aed5df2783c0afa620be84ec8a1d77ba02995ed6ee55207d657d9f50e27ff0"
+    },
+    "gfx/env/jajup.tga": {
+     "bytes": 786476,
+     "sha256": "9cb883fb0077ac79482cb0561f7c1a82af61b5fb374fcbdc5eb63bae49e525be"
+    },
+    "gfx/env/moonbk.tga": {
+     "bytes": 1048620,
+     "sha256": "5f361bf5a352c1df5a6caef9cf42bd35fed8406c6949af480b0425c193c18b3a"
+    },
+    "gfx/env/moondn.tga": {
+     "bytes": 1048620,
+     "sha256": "02e2b36863c1181a85aa675c53fc14a301f38dc6e0c6735098bb6d8723af02b3"
+    },
+    "gfx/env/moonft.tga": {
+     "bytes": 1048620,
+     "sha256": "3158735bdd6f4f467a5b29639aa4f622d1136ea463967684b739b0002bec6526"
+    },
+    "gfx/env/moonlf.tga": {
+     "bytes": 1048620,
+     "sha256": "5cdaabd99655152689e40832643690d7b1c5f8e414f3126a7c0c9224f2250704"
+    },
+    "gfx/env/moonrt.tga": {
+     "bytes": 1048620,
+     "sha256": "e08a374ac19c8b8cffa6c939515cde9570b44bbc044c12d06b0c5d94aa7469bc"
+    },
+    "gfx/env/moonup.tga": {
+     "bytes": 1048620,
+     "sha256": "c0465fd6a0b069e5ff78f3e561084bf3e23b796cac9b5214a6cd4045310d36fe"
+    },
+    "gfx/env/valleybk.tga": {
+     "bytes": 786450,
+     "sha256": "c3c3d22fa37400d5c9e4311802591104dec021e30537e37d45e5be9016181176"
+    },
+    "gfx/env/valleydn.tga": {
+     "bytes": 786450,
+     "sha256": "330f745e8e40bcada140ed136255e74292af193dfe126d8c83cc6a35b394f5ad"
+    },
+    "gfx/env/valleyft.tga": {
+     "bytes": 786450,
+     "sha256": "8e8c544dad62735bce9cb1f470112aa8411a148dee0de39b667b0fe3e323b821"
+    },
+    "gfx/env/valleylf.tga": {
+     "bytes": 786450,
+     "sha256": "48af6971b525c6b3d943fa118b4dd4e1d8d8b89512bc93631afb419d65fa740f"
+    },
+    "gfx/env/valleyrt.tga": {
+     "bytes": 786450,
+     "sha256": "c9a9fbf31aae6217c98b571f697d6e649ba1d2956351b8d2e895372121f9868d"
+    },
+    "gfx/env/valleyup.tga": {
+     "bytes": 786450,
+     "sha256": "c02d3ebf1bf842871cce85999ca4211b8ba640951f57a8a415c68897b3b3ae57"
+    },
+    "gfx/env/voidbk.tga": {
+     "bytes": 3145772,
+     "sha256": "0c7a321f84420912c643596ee189a4173196d82b1de98a6939a5e16d0cb4f6bc"
+    },
+    "gfx/env/voiddn.tga": {
+     "bytes": 3145772,
+     "sha256": "c3a28030a757deb7d113cf25ab12f4de52fbaa7d8ac7dba1aa20a81c2ebb2b12"
+    },
+    "gfx/env/voidft.tga": {
+     "bytes": 3145772,
+     "sha256": "b0ec6524d0e783cdc102f210df9d0310008accbcdcf181f3aead29e91be1ae19"
+    },
+    "gfx/env/voidlf.tga": {
+     "bytes": 3145772,
+     "sha256": "c4f90d0a6cb09a53677ecf1c535564d9515ce31aebb53fa6bc94893ac5a4ef56"
+    },
+    "gfx/env/voidrt.tga": {
+     "bytes": 3145772,
+     "sha256": "8891063d8e69c82d19062e5f622a1b36e0e23a2c7bc5cac26df5632b664dc8b8"
+    },
+    "gfx/env/voidup.tga": {
+     "bytes": 3145772,
+     "sha256": "88134416527ede30a98df0d927c969dea556252b7f9fac8fa7c9a1cc4d763ab0"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "maps/eoeend.bsp": {
+     "bytes": 801408,
+     "sha256": "2b97b07f78b5f905079675ad80ab542699550b76801bff450011ea64c5da786a"
+    },
+    "maps/eoeend.lit": {
+     "bytes": 100499,
+     "sha256": "36db5f623516fba49a6d8749bb9aef6eda7de26a5bde40d6a6391a6a3fffda0b"
+    },
+    "maps/eoem1.bsp": {
+     "bytes": 4532116,
+     "sha256": "7b5c3fb88fc1db066dcd97c390eebc084ce9e8d9d5b8c7982381571d7faeab8b"
+    },
+    "maps/eoem1.lit": {
+     "bytes": 2578814,
+     "sha256": "45096fb80488774210f3baac7151136855f39fcb5a9715b38c6e61a3360d268a"
+    },
+    "maps/eoem13.bsp": {
+     "bytes": 5420156,
+     "sha256": "e2de5cb04f221dad9be86825f97c00e55c7aa7a9be76cb9e9328b54f9b24190f"
+    },
+    "maps/eoem13.lit": {
+     "bytes": 1108796,
+     "sha256": "17f7f093d7dab0f75c3afbd3c66c53cf9e2be0dfdd1264c10675b294f14a0dba"
+    },
+    "maps/eoem2.bsp": {
+     "bytes": 15024620,
+     "sha256": "1c362b611625e2b92492fd8dbd0dd6fa029e8fa4d9488acc6b66c4c3d3594fe2"
+    },
+    "maps/eoem2.lit": {
+     "bytes": 6029420,
+     "sha256": "13d98cd269b6ab5acea91e94ea1dce43960399ba0e19562d79de01c09557ceef"
+    },
+    "maps/eoem3.bsp": {
+     "bytes": 6072984,
+     "sha256": "62f59f9c0d69b0ce0bbf8353388a79c6b4970a4ed0c2772e4f99953bd1bed63d"
+    },
+    "maps/eoem3.lit": {
+     "bytes": 2495636,
+     "sha256": "4fbeee91ac4f66bead33f0a75f885d1fac44e4ce8644ab28dc0e828081889f12"
+    },
+    "maps/eoem4.bsp": {
+     "bytes": 3069812,
+     "sha256": "2dbad7215b28d6863b4732cc366ecc7ee56a4306ba1828c4940c3fcea5e61ddd"
+    },
+    "maps/eoem5.bsp": {
+     "bytes": 11896892,
+     "sha256": "8640c42cf7688377a294be7803626e1d7db3a5f8efb7e90ea4925b62e1f748e0"
+    },
+    "maps/eoem6.bsp": {
+     "bytes": 4094560,
+     "sha256": "c56266e01057bc52e8b373dbb120f99fe2bdbaf6045c94cd064445a5b4d1d293"
+    },
+    "maps/eoem6.lit": {
+     "bytes": 1309670,
+     "sha256": "223bcecf982c4c8faeff965ff1c0a9de0bc9b92b62bfcfd7e30c2ed191a0a25c"
+    },
+    "maps/eoem7.bsp": {
+     "bytes": 3084536,
+     "sha256": "bc785be5e2a9275fc8a0be2690a7f8a6473cdf67307512b57e8aab7a6cbd171f"
+    },
+    "maps/eoem7.lit": {
+     "bytes": 752609,
+     "sha256": "7acebc00bb1cf78cfc390270d93e4eb64fcbabd61933fdb6ec7e3503b9a1947f"
+    },
+    "maps/eoem8.bsp": {
+     "bytes": 3207392,
+     "sha256": "ac2368c8a214b2f702e16591e010c671edc61e418231d14bd36b0566f066144d"
+    },
+    "maps/eoem8.lit": {
+     "bytes": 1932071,
+     "sha256": "965f3de4f6a1709d275896f47fcf17f00f56004f3a5c286cfa28332befc0a584"
+    },
+    "maps/eoem9.bsp": {
+     "bytes": 12852668,
+     "sha256": "1d6e4d217908db62fcdb5f89b41e54e1e4182eabcbfb6a5e478ada1faf413be0"
+    },
+    "maps/eoem9.lit": {
+     "bytes": 3708011,
+     "sha256": "0739f9c18202aff5ea7f91c0ac8a6b9c94350afe5c8e8221c2fae639c1f78c92"
+    },
+    "maps/start.bsp": {
+     "bytes": 2538260,
+     "sha256": "8fcd517558a2bb84ba0954c5b6d4861b5baf7ef4cadb8a03a67c3e3aa8389771"
+    },
+    "maps/start.lit": {
+     "bytes": 644024,
+     "sha256": "7963e8fbc24dd5a47ac4e1c8f2de1a8bced169588341509127f043fb724b9102"
+    },
+    "music/track03.ogg": {
+     "bytes": 1149733,
+     "sha256": "eaf87788e9f5b39350da8c608159e1e308d16378b8eadd32abe8af26e54aab51"
+    },
+    "music/track100.ogg": {
+     "bytes": 1297659,
+     "sha256": "459ff6d8a17bf33bdbbeae170840c5fdc08a915df7fe037f4466720af30bb18f"
+    },
+    "music/track101.ogg": {
+     "bytes": 4008804,
+     "sha256": "d3139ec239ad88701491f130530a44f71e930cd9c046ee210bf06599c582587b"
+    },
+    "music/track102.ogg": {
+     "bytes": 3352457,
+     "sha256": "0edf3cae4f07765263eb23e1c659e1ea77f26b77a9adc998454a9912c2271b67"
+    },
+    "music/track103.ogg": {
+     "bytes": 3010473,
+     "sha256": "19b85ca1f33c5055607d57fb1205200675ed865950f136a10225082ed6299207"
+    },
+    "music/track104.ogg": {
+     "bytes": 4877264,
+     "sha256": "d012b82c3bb9b3a567038bca72e85ad22bdde857fc7246e4ca2a9258b8615747"
+    },
+    "music/track105.ogg": {
+     "bytes": 6374897,
+     "sha256": "7782b630a3bd2c887d483635bec3d5b7c2f0ba44f93308ec15872a92ae1a71a1"
+    },
+    "music/track106.ogg": {
+     "bytes": 2863674,
+     "sha256": "772f68eea47cf5f64e23c35adfdb0862d2e7a07771832d4d9414d80c7cd72d0d"
+    },
+    "music/track107.ogg": {
+     "bytes": 4288381,
+     "sha256": "959cc98c9b38e6abb8b75d0bd44cd8d40c8381a78da67a68ce8d0c77fbe0a5a4"
+    },
+    "music/track108.ogg": {
+     "bytes": 5395475,
+     "sha256": "40c8c4f3dae65b7e2477d65fc49b607cc85375b951c07365480c7f0f2c2695aa"
+    },
+    "music/track109.ogg": {
+     "bytes": 2816160,
+     "sha256": "e39fec14f853090fb9f274d815c3e98ebda8970919c7df6ca9c715911a0f2e26"
+    },
+    "music/track111.ogg": {
+     "bytes": 2290360,
+     "sha256": "11a45a41a65a0dcb60a123e351c3116a1034554cfa10546f1b4d94fa54f28f51"
+    },
+    "music/track113.ogg": {
+     "bytes": 3089741,
+     "sha256": "91cb1a5669fb94692a629b116705a215c5717fb1b5dbffcc5a906c1217feeb32"
+    },
+    "progs.dat": {
+     "bytes": 599738,
+     "sha256": "20d6d554ce3d3bb31393200ca6e8875ed542d42773cc994f900e5a08d55920b2"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/boss.mdl": {
+     "bytes": 211836,
+     "sha256": "392308ca6cdb63fd6ec27ae60a3d451fecc00217feed39b5b902ded9117571b8"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f6c43a5d21e1675e4ad95acbc1a47a3be07ccb74fffcb53574f00945d5b06cf9"
+    },
+    "progs/flame.mdl": {
+     "bytes": 41668,
+     "sha256": "d9719335e9d33d77101738ea89d0b852001cb23b90e63e14487c3c596bc5e811"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 74548,
+     "sha256": "23ff56c0386cda65be8ea6f0fb3fcacc70231ab14abe6530c53de912244459bd"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 48244,
+     "sha256": "da03e8ee6c7cc410bb47b3137346cc7dff151770f7f41a42bf6c445fff473c02"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "77ef7027b6c0b5a6c96c6740896bc016412e60c3098cc0d0077a284f2b3708b6"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 16308,
+     "sha256": "97f17422aefc3d80a4942be5990c9784b17731a31fb9559e5bbde5ec0fe8b6a9"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "8f9824990808ebf06e86d3bf245321cae87a0b98bca2caaacb598f9ecdee85c3"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 2836,
+     "sha256": "af7f5ea603b39efa4cfcec8eb1d5ff12e60421c40bfe914dec2ac5e98711053a"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 59604,
+     "sha256": "98f338ceef4c0e3062bf3c38ac3fc5a2187865d325f06b7fa6eb68d3ff956ed7"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 7092,
+     "sha256": "4d69cfc6343baa8bdc8660428e646abf9ad66b1460ea766cc2e231e7d3c9508e"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 5492,
+     "sha256": "ecf293b2e8146a33de7bc8bb3cded80bb785b931012b40dca204db3dad50e776"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 956200,
+     "sha256": "7add75ccdbfdc1ff2fdf3e6abab8dc24dcd6c2e8714c8a1a4c8e4d9681efffe0"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 2820,
+     "sha256": "1b0494b274aee493b2f60161f27a6d795800d55eef99996816385fde019af271"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 77332,
+     "sha256": "e2a8a92ebbe86069de925f733567738ac67624a913cb8c1fe15a6946536d58e7"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 48964,
+     "sha256": "98a239b4fcfcf78c68079de14984bb8c30b251418044f63c9097c5c16f64da09"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 39668,
+     "sha256": "68e38e54cf4aad130c6b3ad2d8ce12ba20e4ffcd4c5a866aae85b69e56ce50c3"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 22260,
+     "sha256": "bf79b703708665b9e65556bf68c0fe9d177097b2b96b11563d7b8bf84485a81b"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 21804,
+     "sha256": "06a1f7cef5d1d3f8c377addc4026523b656b8f77986495f96048a1a6ea94549c"
+    },
+    "progs/v_shot_p.mdl": {
+     "bytes": 43852,
+     "sha256": "0507a1bc8abf8503eecfef5e786930734bc20a6620f01448c72d3c08c17aad63"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 18764,
+     "sha256": "6acc27e652007519f4c0538c38815814b9d90314e6af205204494d99feb09a16"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 6356,
+     "sha256": "40d9d29c58df57ece6892d71d0464022eb5939aa45699e98eae22136b973c4c8"
+    }
+   },
    "sha256": "44a9771342e4a47e0e016a5e6d9bd2e1046396c796919bcaccd17f23a765d189",
    "timestamp": "2020-10-21T16:26:48.000Z"
   }

--- a/json/by-sha256/78/78a3ad271171a9e87784db1759e1b0f58278fce360d0adad7cec9dc1b1f19591.json
+++ b/json/by-sha256/78/78a3ad271171a9e87784db1759e1b0f58278fce360d0adad7cec9dc1b1f19591.json
@@ -12,6 +12,172 @@
   },
   "pak0.pak": {
    "bytes": 17567387,
+   "files": {
+    "default.cfg": {
+     "bytes": 1967,
+     "sha256": "6fc8ac123328ea5bdd4e1f411dbbc0e21752364decd7de211385e40458d4978e"
+    },
+    "demo1.dem": {
+     "bytes": 82002,
+     "sha256": "887afc223c334ec99312c4ccf56791f733f252a1cd2f280d256bea44de30c990"
+    },
+    "demo2.dem": {
+     "bytes": 83501,
+     "sha256": "bc7439c616d5016d3d26af16536df2ec216fee06140f6fec953d8314bdfc2569"
+    },
+    "demo3.dem": {
+     "bytes": 205255,
+     "sha256": "b80d69618f05aedec82014a971db36166d9618f035d940745fa7ecaa96e94332"
+    },
+    "demo4.dem": {
+     "bytes": 258036,
+     "sha256": "831f3d07c0bff8e4709f0dc28b6b5f2e8e82b9051b79fe964a78ef5154701bea"
+    },
+    "final.dem": {
+     "bytes": 136425,
+     "sha256": "83d9e1fff5c1801f2f08e15ab4b244534e49350a2884d421899340f0e40b47bf"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "3132851680dd39dc6be7931a4f3acacd21e2cbf2179ac633263a90d22671a0a5"
+    },
+    "intro.dem": {
+     "bytes": 279872,
+     "sha256": "63ea6c4cad753e2ecd3f50e8f7bf5de498fdf9b18496798e6c96fca7d0b10779"
+    },
+    "maps/rd1m1.bsp": {
+     "bytes": 1983724,
+     "sha256": "6796c9dc9505ddeb36984c66e02cd08d933a35fbd163e99d1171e2b1c1d2f7fa"
+    },
+    "maps/rd1m2.bsp": {
+     "bytes": 1419540,
+     "sha256": "a5f5822da1ccb035be2e721731d79581de4eebecb2c3bbfae4a920b93d32e331"
+    },
+    "maps/rd1m3.bsp": {
+     "bytes": 2757904,
+     "sha256": "2244ad9429bcbec76b7f5332c5bf1c50f6df7c8a6d7edb32f7e03b84e7432d91"
+    },
+    "maps/rd1m4.bsp": {
+     "bytes": 2148040,
+     "sha256": "ab2c51df46fd6a7816d9906a9c1caf8b1db80d3d1317e39bf4b1e49090139d96"
+    },
+    "maps/rdend.bsp": {
+     "bytes": 3506252,
+     "sha256": "a963f58c9d14797d1f126eac3ad265c9eb99f87fe4f6d2c6654c3d387333c855"
+    },
+    "maps/rdstart.bsp": {
+     "bytes": 1737256,
+     "sha256": "583cc518085f9c06d58f150e5194a04aa1d3519ede2c9479b7305e9c84d94582"
+    },
+    "maps/sphere4.bsp": {
+     "bytes": 483208,
+     "sha256": "a7a3fb02d51a703dd1ff90615372307fe502260c3cb4ce8b027368c8eda8c331"
+    },
+    "progs.dat": {
+     "bytes": 509508,
+     "sha256": "15c2bf0fd346dd00d0bfaa390efaf4c15b30cf3e3cf73a6c3964bb51f3ec198d"
+    },
+    "progs/bodygib.mdl": {
+     "bytes": 56077,
+     "sha256": "432f1f7c781fc086583992856c2e78ba8895422f4a188a9856ed1b99dd65d5fe"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 22483,
+     "sha256": "11553315aeedcb61c5196922e59c22dbcdaa997d8513042bb477001ee7f5a3af"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "91e4a4a8024d2e5316a0a41b4623a58dd401257124a0da6a6770ab79507f20ea"
+    },
+    "progs/h_raptor.mdl": {
+     "bytes": 44553,
+     "sha256": "175ee0e2e28ebb3a004d1783af2eaad4880a3572fb38c1d24b6281a9ebb4023f"
+    },
+    "progs/raptor.mdl": {
+     "bytes": 729330,
+     "sha256": "56992d1a530ab6145712ac9abb1d1ea510255d15e16411feec8331aaa96abb5c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "quake.rc": {
+     "bytes": 298,
+     "sha256": "b70707e0bf575f10303a9051054b19f0e07c4b716380c56296c96d4ac9fb1c73"
+    },
+    "sound/ambient/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/items/damage.wav": {
+     "bytes": 39566,
+     "sha256": "1d08e4bdb7a9c4fdd7539d7fef6b7168114aaddcace3a6cf3fe0d602532d7212"
+    },
+    "sound/misc/final3.wav": {
+     "bytes": 454598,
+     "sha256": "f0def3b6fd883840fab66dd3da011b6a3177d571675f1f161fa5140ec5aa909d"
+    },
+    "sound/misc/introm8.wav": {
+     "bytes": 160480,
+     "sha256": "99abe7b173689b73ab6bb7225a04c9a26bfdf72a0a475fd57ab77e947ff5c978"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/raptor/rdeath1.wav": {
+     "bytes": 24916,
+     "sha256": "d051c976822a8a7bfb3613d5e67aeaa514ac9baa7a460047b49a7b95a5f3a006"
+    },
+    "sound/raptor/rdeath2.wav": {
+     "bytes": 17064,
+     "sha256": "389400b469081b6b768ba248b0d07b6f1f9dbfc28be54885de2f7a11e784e910"
+    },
+    "sound/raptor/ridle1.wav": {
+     "bytes": 11174,
+     "sha256": "a09e00aef702e4d538da805bb39d35f11c2fcd058f89a0bb453a57daad45310c"
+    },
+    "sound/raptor/ridle2.wav": {
+     "bytes": 15026,
+     "sha256": "32cb09ad315e8805e8c6cadb622e4ea313d29b763443dfe120bd9cb2981c335d"
+    },
+    "sound/raptor/ridle3.wav": {
+     "bytes": 22150,
+     "sha256": "7dc33fb4b3590120b442a627f5215f62c37d467e2b03173f269aa85cd06a42b0"
+    },
+    "sound/raptor/ridle4.wav": {
+     "bytes": 4458,
+     "sha256": "aaa75d6aa6e8a04845c5cd88830052fde063a2245f00ba285d3345655951a3e9"
+    },
+    "sound/raptor/rjump.wav": {
+     "bytes": 22202,
+     "sha256": "e4c0d9a121f35afaf68f2607b4df2b4f8de606805e3b67e825f6d09960215ee1"
+    },
+    "sound/raptor/rpain1.wav": {
+     "bytes": 11716,
+     "sha256": "a7e30308a8ad2505cadc647301f2283d19450528f01b5b7e345db97d27050b08"
+    },
+    "sound/raptor/rpain2.wav": {
+     "bytes": 12798,
+     "sha256": "93feac5142cda6fc4596bdcbc0fa3e784a24d6ebc5d4279860d1e67e221a1739"
+    },
+    "sound/raptor/rsight.wav": {
+     "bytes": 38642,
+     "sha256": "7f6fd555f897cef6cdc53dd5a60af74af5b3dba315f86903d4814773934f0b19"
+    }
+   },
    "sha256": "bcdb3d077a069bcbc1fcdcefec0aa477f6e940d5fa8f777013ec3937101f5913",
    "timestamp": "1999-08-13T22:04:04.000Z"
   },

--- a/json/by-sha256/7a/7a154d9869c79858a43c56cf910d9764037c7099fbad47f1998b47ba6802ab38.json
+++ b/json/by-sha256/7a/7a154d9869c79858a43c56cf910d9764037c7099fbad47f1998b47ba6802ab38.json
@@ -17,6 +17,232 @@
   },
   "Pak0.pak": {
    "bytes": 4138584,
+   "files": {
+    "end2.bin": {
+     "bytes": 4000,
+     "sha256": "ff39fc77a23d54cd0100ec96ba6856a31a5ba01f7adfffb1f2bd461cab57a706"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "7414a53f6587a185f7fd1cca21caf610559c0857bffe9206d01dec7e34ed9235"
+    },
+    "maps/hrdtrgt2.bsp": {
+     "bytes": 1501420,
+     "sha256": "7a99c442b8ce4f009ba2582030e7f41fcaa26461c04ba740b182a6dc8d8cbe35"
+    },
+    "progs.dat": {
+     "bytes": 661996,
+     "sha256": "03627cf0c4602b2259a730e36a10c74f605e3e706ef0147c2df77d45bbb46066"
+    },
+    "progs/bazooka.mdl": {
+     "bytes": 143952,
+     "sha256": "fcee6fd34a295b108ac7adc3da70156b6bb6c4ee6aef4eb06e9f9394611e0376"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "718b8c2842877345426247148dd6ce1ebe7fecc13e969a0fa0ed6dbebc388099"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "0a386b6381824b01852910519490ac3f6e3309a96091820384ee6b9a5b452e7a"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "ebd3e614ca2afdead497209fcf79f304218f4cff2bd3bca7d3e3a6c542f63362"
+    },
+    "progs/h_babe.mdl": {
+     "bytes": 26804,
+     "sha256": "61b34a2d1599e86932f0e5c1db8ee0054f8e52f02716a7cf889b9b75ab7667b2"
+    },
+    "progs/manga3.mdl": {
+     "bytes": 96256,
+     "sha256": "81bb691947f88dda5672ab1e1af689098d08a9b5bea9d31c38197db909fe3b76"
+    },
+    "progs/null.spr": {
+     "bytes": 57,
+     "sha256": "dc67fb2f31bd717353b8138f02bdc8ef2d70ace433c9fd91e3adc909fda513a3"
+    },
+    "progs/nun.mdl": {
+     "bytes": 168958,
+     "sha256": "fbf65d2c751fd78b2823379728b4eabdc9102aa51ea622c81a61bc260e09f4dc"
+    },
+    "progs/nunbolt2.mdl": {
+     "bytes": 29061,
+     "sha256": "acc78654c3cb39977741c4f9d218de854383b54b2f24af7a9471dc9408326f63"
+    },
+    "progs/player.mdl": {
+     "bytes": 800296,
+     "sha256": "b2ae33d7722f1fc87efa3ad166db07a52744aa5fd925019154b20128f4503bcb"
+    },
+    "progs/pulse.mdl": {
+     "bytes": 15988,
+     "sha256": "83ad42783fe9a5dd2e2085bb6dcb3e551db7fd7ac683326943e6c5423f8131e4"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "8650870ea418a2e51ff0cba26c9e9e0ea39f383075e279378009d3ebf010f0ca"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 16228,
+     "sha256": "f50f68f3247678041ae0eb26bd24b9ea8a57cbc2c66a092f8d35d6463b05b977"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 22228,
+     "sha256": "64fe85a3f08f916df89ce670a1668d7dc28eaba000747b5e534423ea1d80dd85"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 7060,
+     "sha256": "f386df0925156b91efb4a7627bd01419580b9282a334cc8a03611ca8357082f3"
+    },
+    "sound/ambient/equake.wav": {
+     "bytes": 47148,
+     "sha256": "dcc45d2ef0703ecaa022c83cd66ae4992021ac379c11fc9da4401e184a191c93"
+    },
+    "sound/ambient/spark1.wav": {
+     "bytes": 3288,
+     "sha256": "edd25ab7bbc00e8952dedc1d671735f649134481860526bcdcb17f3bf20aa464"
+    },
+    "sound/bazooka/ahaia.wav": {
+     "bytes": 7748,
+     "sha256": "b9a2527347e2272a676390b3a6bce4cf623f233a11b27d932e340ed67e72823d"
+    },
+    "sound/bazooka/die.wav": {
+     "bytes": 9260,
+     "sha256": "0bae4e5baa31c64ba4fc94df64e0dca08c06a732baea03ae4167b75e00318e9b"
+    },
+    "sound/bazooka/dies1.wav": {
+     "bytes": 8856,
+     "sha256": "663fcd16df6c845fc318a6181b2eece0678f9f3980a90ea3d34f0592e61e6087"
+    },
+    "sound/bazooka/dies2.wav": {
+     "bytes": 9212,
+     "sha256": "93f2868e3bbda78b74970a8912e8bad6f50e130692c4ce066aacdb5d51811e48"
+    },
+    "sound/bazooka/dies3.wav": {
+     "bytes": 9752,
+     "sha256": "439d327515f423fe662a8930b6a1d07d693f43331996119e05d32efc5d44457c"
+    },
+    "sound/bazooka/grrr.wav": {
+     "bytes": 11356,
+     "sha256": "8c6609a6ea9d85f10cda8dd2aa2d0fb77f5e9690698cbafbc213eb5d4f2b6f5d"
+    },
+    "sound/bazooka/ooaa.wav": {
+     "bytes": 4872,
+     "sha256": "76d5ae6f0532eb1a43493330c90966be651e05ba9eed2a994a9afaf28c73de78"
+    },
+    "sound/bazooka/step1.wav": {
+     "bytes": 27042,
+     "sha256": "fc485f8365abf042f2abb94ba4a21f077f688419e252a50fe9cfba2f55fd280a"
+    },
+    "sound/bazooka/stepstop.wav": {
+     "bytes": 6102,
+     "sha256": "79ec338698b2f8bfde44e0b5e8e31ca3d34e140ca88a45eb81c7c72b7ca31134"
+    },
+    "sound/bazooka/when.wav": {
+     "bytes": 23194,
+     "sha256": "af1c2534c69cfb3f07e160cd39f66fcfbe9d64580cb9fcfc43520637c6931532"
+    },
+    "sound/bazooka/yeow.wav": {
+     "bytes": 6474,
+     "sha256": "776a81059bc7fd0f8c998f5e8e05837686d1578c8860aad77901665c31370caf"
+    },
+    "sound/manga/died.wav": {
+     "bytes": 24492,
+     "sha256": "3ce14cdac970a150f567dbd07cf1763f695245c34f5bf4e31ec07bfeb232db30"
+    },
+    "sound/manga/ha.wav": {
+     "bytes": 2708,
+     "sha256": "ba2108ad5070860873887308293efd3a9635a6c4dcb3fb39357a9e16f89f97b5"
+    },
+    "sound/manga/hiyaa.wav": {
+     "bytes": 36876,
+     "sha256": "1446e8afbfdf48a08ca6727604b33585efdd67a6d14b4b1c96bb05c6ccd5ac3a"
+    },
+    "sound/manga/kungfu.wav": {
+     "bytes": 29008,
+     "sha256": "025b6eed19d193bd6be4c4f8f2bc7b9fb14e5c127257e570fd9fc98fd464f2a3"
+    },
+    "sound/manga/ohdju.wav": {
+     "bytes": 12588,
+     "sha256": "346d38c12edad612ec4915d3361ebfbb81b06bee9cdb73eb9b9e0d2cc2ea6d10"
+    },
+    "sound/manga/tchak.wav": {
+     "bytes": 10166,
+     "sha256": "f77d88ab76f7a092a7a5d40fb0aaf9530dc6da8e45559fcf1a1b5ea2aa88029b"
+    },
+    "sound/nun/death1.wav": {
+     "bytes": 9289,
+     "sha256": "77a3dfddc7ffb1eb65d6ac812ec8e3a642be3cf7a2546fab2f92465086f50391"
+    },
+    "sound/nun/nunch1.wav": {
+     "bytes": 6209,
+     "sha256": "5e276c38920a084811a69e541b2ed6536b1fe1eb378fac724db891db2dfe902d"
+    },
+    "sound/nun/nunch2.wav": {
+     "bytes": 8751,
+     "sha256": "59d2cc8b02ecef0f408c79b25caeb0fce9174acb565abec7c49f9b16a0822cd2"
+    },
+    "sound/nun/nunch3.wav": {
+     "bytes": 4940,
+     "sha256": "04a0baa2ccc6abb70caff4a0acfef64d7908bc804016bdc13892334f200796fc"
+    },
+    "sound/nun/pain1.wav": {
+     "bytes": 5444,
+     "sha256": "b709e973f2e32900690826af4c94cd3cb00ce2f2177e8bf9cbae6660e9e178a2"
+    },
+    "sound/nun/pain2.wav": {
+     "bytes": 4689,
+     "sha256": "0da97d7a436c506a98010d0ea1b6b80186cda4693aa3f3e87d4d7adc3cfe5f84"
+    },
+    "sound/shellhit.wav": {
+     "bytes": 1598,
+     "sha256": "17e0784b9c2ca8b5c60ba0ee6fe85f0eb04d0450ec948b6c4652cf64e0912cca"
+    },
+    "sound/wall/wall01.wav": {
+     "bytes": 32804,
+     "sha256": "c338c95767dded603a1a69100c1af0baab42959eaae856f6cab99ffbd140b727"
+    },
+    "txt/bazooka.txt": {
+     "bytes": 4512,
+     "sha256": "ea6ec68b8465524d034f9fbb33919e75c22bbc177300f255d53cb1f87dabec9f"
+    },
+    "txt/damage.txt": {
+     "bytes": 1546,
+     "sha256": "8684d30ed60b5fb0a843f4308d9b9a7dfcd080689fa73fb28f43fcb9151df72b"
+    },
+    "txt/drone.txt": {
+     "bytes": 3282,
+     "sha256": "78cc4b700db62b830ac700afc9a12602a941c18ec4ff0e68ad78b6129fb10ad9"
+    },
+    "txt/eject.txt": {
+     "bytes": 2244,
+     "sha256": "04ff84fb7680f984d5e5cbc9f0eb568c16ec3582fcec0f55abfb079632efc506"
+    },
+    "txt/gyrobot.txt": {
+     "bytes": 15522,
+     "sha256": "b19185538e9433b690dfaa5175501790d2f4ce8c32220e822069cccd51749817"
+    },
+    "txt/hrdtrgt2.txt": {
+     "bytes": 9627,
+     "sha256": "6f3e7a8e1aaf7e56c4b9367049d1daad7bab5054e13b36dd0ece594ec1b1ad52"
+    },
+    "txt/manga.txt": {
+     "bytes": 2019,
+     "sha256": "2e3c3b3e22ddcbb1ad804b6ae33144a4daee18ced4d8d17720e2412a4498ea2a"
+    },
+    "txt/nunsgt.txt": {
+     "bytes": 1221,
+     "sha256": "3eb0e02156e4c88908b9f7e89ed60f0610dfb0374d863b6f6063f783e1af6ded"
+    },
+    "txt/walls01.txt": {
+     "bytes": 3093,
+     "sha256": "d7c7a2b26ca415635abdb06c983eae75319924b7ec91ead6e0751ae174b69c8e"
+    }
+   },
    "sha256": "f362a910847734257a5b2300f23b1acaa7a78b3148f43cc6e4aa9bb445b01fec",
    "timestamp": "1997-12-04T16:19:06.000Z"
   },

--- a/json/by-sha256/7a/7ad993da6c760c446ca31fad71e9f5b6c9eee99b6354f161aa746b572fe70a7d.json
+++ b/json/by-sha256/7a/7ad993da6c760c446ca31fad71e9f5b6c9eee99b6354f161aa746b572fe70a7d.json
@@ -55,16 +55,10670 @@
   },
   "pak0.pak": {
    "bytes": 270100152,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 94990,
+     "sha256": "1fddba1dadd3adef5e0f13d716e514c131455c51b26c2291f71dea0eada7b97e"
+    },
+    "effectinfo.txt": {
+     "bytes": 157535,
+     "sha256": "8dbc7cf30b0bef166f0ce58a59c0f3ce1dcadd9a13867f8430541793fd723cf8"
+    },
+    "effectvanilla.txt": {
+     "bytes": 4612,
+     "sha256": "efd47c12bf71b377f3e750f46d5e242b3337ece446ba9a44cc0750a9bbf9c758"
+    },
+    "gfx/ad_blank.lmp": {
+     "bytes": 584,
+     "sha256": "37b5a1e7d0b3882eb7504e3626f8040a19a6d403e0e761dccd65db935401144f"
+    },
+    "gfx/ad_ibar0a.lmp": {
+     "bytes": 2568,
+     "sha256": "7a66fbbaa742e59d3fdd939ce35befa0f633492482912f4fa91f16d0788276e6"
+    },
+    "gfx/ad_ibar0b.lmp": {
+     "bytes": 5128,
+     "sha256": "5a955a32f0227e4d3e90e908e650c7dc53138b5db2d5bcb3eb4a14fe5c568760"
+    },
+    "gfx/ad_ibar1a.lmp": {
+     "bytes": 4616,
+     "sha256": "eb1c6337becc5c245b873b3d9a6ba5e9c458147f48826a4580ea0ffdf57e9759"
+    },
+    "gfx/ad_ibar1b.lmp": {
+     "bytes": 3080,
+     "sha256": "34e3eec992a3f567d4ac83c98d5fc53ca0a90c02764d45a40eea08d2f94c733b"
+    },
+    "gfx/ad_ibar2a.lmp": {
+     "bytes": 4616,
+     "sha256": "eec2d035f2857fc03083ccf0384ac6446f71b1aa45ed0e2409b8d4ba42c135f6"
+    },
+    "gfx/ad_ibar2b.lmp": {
+     "bytes": 3080,
+     "sha256": "17c35d1d02833d1fe900b1c2beaf77ffe1948a3f17ae790e9f0da1c1057b460c"
+    },
+    "gfx/ad_ibar4a.lmp": {
+     "bytes": 3080,
+     "sha256": "2507c6ce0a53ed62ce73b1bb0ee7e76e9c245757dee54415aeef78767bace887"
+    },
+    "gfx/ad_ibar4b.lmp": {
+     "bytes": 3080,
+     "sha256": "d977ecb360eff9b19827e956d32687234bed64f830adc5e506334a597daa7eaa"
+    },
+    "gfx/ad_ibar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "9d0d2c1eb7e665d0a28130bed09fb8bd698a6a1b246842fa353e3b0e1f5b445d"
+    },
+    "gfx/ad_ibar5b.lmp": {
+     "bytes": 4616,
+     "sha256": "26902c5879207315a7b732e8799f95bdcd45801a8086a902371808a594fa5515"
+    },
+    "gfx/ad_ibar6a.lmp": {
+     "bytes": 7688,
+     "sha256": "cfcce1c48cda88ccd405b1398576476bae52b3cdf7154a0b902a47655dd282cd"
+    },
+    "gfx/ad_ibar6b.lmp": {
+     "bytes": 7688,
+     "sha256": "49487400a56db767d37656f8ccb9e1660f470d8f989619a86bec5c296dcb77f9"
+    },
+    "gfx/ad_ibar7a.lmp": {
+     "bytes": 6152,
+     "sha256": "0d4ababef9a115ca7f6739a01d288d237e22a859ee16c5682d97dcabc4d7aa0b"
+    },
+    "gfx/ad_ibar7b.lmp": {
+     "bytes": 5832,
+     "sha256": "f9292e8d1fff09bde28baf932f11617e27247d4e9af191b89c30811e92110bca"
+    },
+    "gfx/ad_ibar7c.lmp": {
+     "bytes": 4104,
+     "sha256": "0e77dc6602c4945d5d4ec2a12f8003173430945bf7891d979c3c80b0c9212b40"
+    },
+    "gfx/ad_ibar_cell1.lmp": {
+     "bytes": 392,
+     "sha256": "5a4409731e4302bca5245f385a1cab9b91e0a2677d52336bbe3650fdcf070b05"
+    },
+    "gfx/ad_ibar_cell2.lmp": {
+     "bytes": 72,
+     "sha256": "6a519b1e8eed1d7a5365231162fcf1beaf31a6fd1c39b07de09bb0e66dc38303"
+    },
+    "gfx/ad_ibar_nail1.lmp": {
+     "bytes": 392,
+     "sha256": "850189c70ac92f3e8ee79ed9ff6e31ee73d33b5616964461373b37e3a29e60b6"
+    },
+    "gfx/ad_ibar_nail2.lmp": {
+     "bytes": 72,
+     "sha256": "b36d5196c807c6325816db9efad9a16fd7e38433f277b0ad9e6d3551f95c0ceb"
+    },
+    "gfx/ad_ibar_rock1.lmp": {
+     "bytes": 392,
+     "sha256": "f74ce0037116022557ec3a50d368442e73cb48492990a07e93503ad9aeeaa225"
+    },
+    "gfx/ad_ibar_rock2.lmp": {
+     "bytes": 72,
+     "sha256": "081911a352b3d75a4be7812082eee782c41127e70bc4a06585b163d385230a65"
+    },
+    "gfx/ad_ibar_shell1.lmp": {
+     "bytes": 392,
+     "sha256": "733750fbc8235b236f7a2a4246d6112c0a09ce2f75529e359382e25dab92ee10"
+    },
+    "gfx/ad_ibar_shell2.lmp": {
+     "bytes": 72,
+     "sha256": "22fc2a46e85e76836fa38db9868820322833b45e0473407d69378dc09b43e9a5"
+    },
+    "gfx/ad_sbar0.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar1.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar4a.lmp": {
+     "bytes": 4616,
+     "sha256": "5ecbd1e480e4c04e2efe956dcd49e609f0c5a2038f03759b9af848b3cf7dd613"
+    },
+    "gfx/ad_sbar4b.lmp": {
+     "bytes": 4616,
+     "sha256": "8fdfe5e6ffba2c209386580adc196acce9d5601fb529f651267e7186610cc392"
+    },
+    "gfx/ad_sbar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "40c7f9e7ba975d500d3861d0c5a7e592da1ce09fdc31583488fd4c78d823e20e"
+    },
+    "gfx/ad_sbar5b.lmp": {
+     "bytes": 2312,
+     "sha256": "86ff0d9678a52e5428089afe0bb9cdddc9f7688798cee45a396e4d13bf00b60d"
+    },
+    "gfx/ad_sbar6.lmp": {
+     "bytes": 9992,
+     "sha256": "5b47dbc1ae645c429627f563355c43b1fb9145d195d02606d0a7a49791034a28"
+    },
+    "gfx/ad_sbar7a.lmp": {
+     "bytes": 3464,
+     "sha256": "8773683e2edb20dfdea61775d6f955a766a15b7b733ae07212dec922d853f6ba"
+    },
+    "gfx/ad_sbar7b.lmp": {
+     "bytes": 3528,
+     "sha256": "1103f097b9896700ef5a722df927cbe71c76531a09eda9e55e5702d3b4d3b370"
+    },
+    "gfx/ad_scorebar0.lmp": {
+     "bytes": 7688,
+     "sha256": "7c479c4969b9f437c57d710edbdd6b2ce1936aa95adb559c9dd3048680868cdb"
+    },
+    "gfx/adf_1.lmp": {
+     "bytes": 584,
+     "sha256": "5b1b35dc96ad9c2f62602caab6be13d8698fe6cc14865293d11c6b9eee64dd51"
+    },
+    "gfx/adf_2.lmp": {
+     "bytes": 584,
+     "sha256": "8cbc05801d49423bd5f14bd459e8ed5cff7841e7f2d5e44d0f4dfe0f0f7ee851"
+    },
+    "gfx/adf_3.lmp": {
+     "bytes": 584,
+     "sha256": "f0155a41ad9290c8df9fabe0faae6dde4d04772dd2a425653766ec36da76140f"
+    },
+    "gfx/adf_4.lmp": {
+     "bytes": 584,
+     "sha256": "d74c9370ce323ffdc9c3dd124dcbbf9c15fc94e58e20d15789975dd8701a74da"
+    },
+    "gfx/adf_5.lmp": {
+     "bytes": 584,
+     "sha256": "f97a78ede874ff45176e5bb85abdbed93e22dab28bc0965065927c7b215ea36f"
+    },
+    "gfx/adf_evil.lmp": {
+     "bytes": 584,
+     "sha256": "42445b083abae6e9f4ff009efd7a38d2ddd664ac5e47f97ad30c88a603c64c35"
+    },
+    "gfx/adf_evilinv.lmp": {
+     "bytes": 584,
+     "sha256": "ff0d8b9203d7cfae6d075ef5bfad60cdcf66b1e24bb6fd02be0cada1b7f1c82f"
+    },
+    "gfx/adf_evilpent.lmp": {
+     "bytes": 584,
+     "sha256": "0b0029bc964ed68f1b46ccf0b4bd5e527e33e76c0904a1d06e623c47ca589e56"
+    },
+    "gfx/adf_evilquad.lmp": {
+     "bytes": 584,
+     "sha256": "a511796cca84df8149ea6d3d280880e425fdd486315159462168d32f06a17822"
+    },
+    "gfx/adf_inv2.lmp": {
+     "bytes": 584,
+     "sha256": "a6caf84d4e2c125e80aefb51aaa1af707ccf689e641141dd3736f101a66c8fa0"
+    },
+    "gfx/adf_invis.lmp": {
+     "bytes": 584,
+     "sha256": "70117297f381fd1778e5d26e5b832af86c6013ca9a55632c24c057e0aaa1e48f"
+    },
+    "gfx/adf_invul1.lmp": {
+     "bytes": 584,
+     "sha256": "453b67ccc01b32101e1051a9407b84b5c93416ae30c3b3200e25b96868c3f6e5"
+    },
+    "gfx/adf_invul2.lmp": {
+     "bytes": 584,
+     "sha256": "c70f600538aa1d1cc121ea76602e564d0af5ce5ea67a2c1ba01ac5fe44439bd4"
+    },
+    "gfx/adf_p1.lmp": {
+     "bytes": 584,
+     "sha256": "f6da35fd9699239c060f034738615ecead6111294a419a82e503bdbdd9ed46b1"
+    },
+    "gfx/adf_p2.lmp": {
+     "bytes": 584,
+     "sha256": "431539dd9656e09c6d4007c86bad37c30447e596575d803619b14371329f9acb"
+    },
+    "gfx/adf_p3.lmp": {
+     "bytes": 584,
+     "sha256": "b832a2d2143805f8701eec7eec465d67fa692e2e87714e87fa3ac3a2c2682659"
+    },
+    "gfx/adf_p4.lmp": {
+     "bytes": 584,
+     "sha256": "40f6d70d3ebf248c1c38e90b95cec42516b3a61fd17bd866df964af8e657487f"
+    },
+    "gfx/adf_p5.lmp": {
+     "bytes": 584,
+     "sha256": "d7d4768f7324d1eca2b8cb95fd250d8c6065dcfc5c392c6f2bc6adc8c2a7579a"
+    },
+    "gfx/adf_quad.lmp": {
+     "bytes": 584,
+     "sha256": "da9a83f464049832cd049205a22d832a228b00cbd0d1e7e24d347d5ed34c4ffb"
+    },
+    "gfx/adib_atank.lmp": {
+     "bytes": 264,
+     "sha256": "8d963c818c0554d73d14b251eeed0321cf854777f29eddf5a82ee3fb3fde8035"
+    },
+    "gfx/adib_axe1.lmp": {
+     "bytes": 264,
+     "sha256": "90b6817aa64570e9bfc36a13e6dd1930e81468f931ceac9f2ae3790f99f2dca2"
+    },
+    "gfx/adib_axe2.lmp": {
+     "bytes": 264,
+     "sha256": "2b0821038185e41c711e399dcfff37fd54aa8f7473ba81754c379fae558a5a1d"
+    },
+    "gfx/adib_bbelt.lmp": {
+     "bytes": 264,
+     "sha256": "8b50ea739ca8ab52baefe65f90ea5943fcc4f05b63b214a36b3ae6fa4feb55a8"
+    },
+    "gfx/adib_ckey1.lmp": {
+     "bytes": 136,
+     "sha256": "8525e145fdc72947ac6d4599ae0304b84793475d44f0113c925905d715c2da8e"
+    },
+    "gfx/adib_ckey10.lmp": {
+     "bytes": 136,
+     "sha256": "a2e14b68c10109e48e86bd095775beb68f03640dfdb12d1c28b6d32abd1fa329"
+    },
+    "gfx/adib_ckey11.lmp": {
+     "bytes": 136,
+     "sha256": "2b9191d85075d6a6c06d8b295c48546ecc0bd1c91a860308f6f953dcf324604c"
+    },
+    "gfx/adib_ckey12.lmp": {
+     "bytes": 136,
+     "sha256": "9b04f101468d96f4c39d97da0be44f7152179e4a8d6a05762ca693c9f84db317"
+    },
+    "gfx/adib_ckey13.lmp": {
+     "bytes": 136,
+     "sha256": "35fa377dbf162d691de012a61458b5ec29c28b776cd3ee0e0f9ab0ad57b67c8f"
+    },
+    "gfx/adib_ckey14.lmp": {
+     "bytes": 136,
+     "sha256": "ea6b831467c97fb0ba18d97a549c54304b133830e1567ae300e83514bdbb2919"
+    },
+    "gfx/adib_ckey2.lmp": {
+     "bytes": 136,
+     "sha256": "5c80cec0c7808ed141fff4f6863eccfa71b06a7405e871c75912d5d065b4ff21"
+    },
+    "gfx/adib_ckey3.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adib_ckey4.lmp": {
+     "bytes": 136,
+     "sha256": "51ea09fa8db26de3ce6ea6c1a5abecf4c31c3877ab6c508811ea9b271f40f1fc"
+    },
+    "gfx/adib_ckey5.lmp": {
+     "bytes": 136,
+     "sha256": "e03ed662e981530264f6dcf6f6dda91fd8406c0941d0f7c4370a89e0c4f467bc"
+    },
+    "gfx/adib_ckey6.lmp": {
+     "bytes": 136,
+     "sha256": "6f4f61addc77e3492c08cd382291eaf3f8c28a7499137591dcd2c6706bb1ec57"
+    },
+    "gfx/adib_ckey7.lmp": {
+     "bytes": 136,
+     "sha256": "38c3473948f4769e4309bdbb390afd0663fc093f1f76c9fbf10d818c6f89c72b"
+    },
+    "gfx/adib_ckey8.lmp": {
+     "bytes": 136,
+     "sha256": "d0c43a81abfb623b7c3392a07b484b6bf9137fede67d78dc67864848ecbc1c12"
+    },
+    "gfx/adib_ckey9.lmp": {
+     "bytes": 136,
+     "sha256": "042cdb7aef3e06a5679158b4f33fc66ca2d97dd6cf9e7e2657b1e85e444ed006"
+    },
+    "gfx/adib_invis.lmp": {
+     "bytes": 264,
+     "sha256": "f4f1be9a2ef88b75fd9971d72796a35f7de1ed04fc2cfc3a4c35225976f21eca"
+    },
+    "gfx/adib_invuln.lmp": {
+     "bytes": 264,
+     "sha256": "87b8312e4d7fc20d6ae9df6d1f8cb616392f3a2adaf7208dd2372eefc19888a3"
+    },
+    "gfx/adib_jboots.lmp": {
+     "bytes": 264,
+     "sha256": "206ad9d67636b46418e6afa6b6e75a12df76bd3ad84b0178e86b8d140b9c3afc"
+    },
+    "gfx/adib_lshield.lmp": {
+     "bytes": 264,
+     "sha256": "79a78f4402a301d381bef260b895ba56757b779ae89b7ae5a49f8146f2a7a54a"
+    },
+    "gfx/adib_nailp.lmp": {
+     "bytes": 264,
+     "sha256": "fe59667c80612fd2e7f5d95dd0a208f3909d93eeaaab7e4580405fe153469fde"
+    },
+    "gfx/adib_quad.lmp": {
+     "bytes": 264,
+     "sha256": "915832c8c822daf8cfa1c5d88548f24da7d182be6746b265e7ae6e1d735082cd"
+    },
+    "gfx/adib_sharp.lmp": {
+     "bytes": 264,
+     "sha256": "18987634aa43dced4e06e1d5a9a3f9b1f51c7738f59fae64168bd94ab9cd6198"
+    },
+    "gfx/adib_sigil1.lmp": {
+     "bytes": 136,
+     "sha256": "34b11b26dcdf5b91f3e6e08bbe6edb83f62ba054e9eef28459cef09b742e1456"
+    },
+    "gfx/adib_sigil10.lmp": {
+     "bytes": 136,
+     "sha256": "af31a42ef81449aa656327dfe00fc1e1d744f90212ac228bd05a6d79f5048683"
+    },
+    "gfx/adib_sigil11.lmp": {
+     "bytes": 136,
+     "sha256": "9fb90ba79d5c34e2b0afdbcec8bc528fd7d3d8f2645191d95a67a65e242bd3c6"
+    },
+    "gfx/adib_sigil12.lmp": {
+     "bytes": 136,
+     "sha256": "d7c9c3c7c1167ea0791b2790d678d6bd25144adcba79d6f7c5d93302fc28119d"
+    },
+    "gfx/adib_sigil13.lmp": {
+     "bytes": 136,
+     "sha256": "0003389cd694c55fa36f1d18d38261d279c5c7ef23dd5d41c3852ad8c95e5a49"
+    },
+    "gfx/adib_sigil14.lmp": {
+     "bytes": 136,
+     "sha256": "8ac47a2e1d45d94fb1f222811320c5f07e39e65698b7436515afa29de6e1204e"
+    },
+    "gfx/adib_sigil15.lmp": {
+     "bytes": 136,
+     "sha256": "153627403fd3e3856aa34e8740fdebb5ddb26e201cd590dd76cbfc12c36e49c6"
+    },
+    "gfx/adib_sigil16.lmp": {
+     "bytes": 136,
+     "sha256": "fa95a1a372ce30516252fff8dbcda8f8f55e3cc558b4a1e7015b79838ff0cda1"
+    },
+    "gfx/adib_sigil2.lmp": {
+     "bytes": 136,
+     "sha256": "0a0c22f027e980014a246daa629b6f84f425ccfd828f75a93ef777d9616c9191"
+    },
+    "gfx/adib_sigil3.lmp": {
+     "bytes": 136,
+     "sha256": "9e5daafbe4cc032824f732ebdac3897d804df43efaff9901c315ae661af8cd31"
+    },
+    "gfx/adib_sigil4.lmp": {
+     "bytes": 136,
+     "sha256": "fd1d3791d53ab40881a2d86a0bc67b3b532ef10b201a166a3937b105c63e3c9b"
+    },
+    "gfx/adib_sigil5.lmp": {
+     "bytes": 136,
+     "sha256": "947d5088b18a12d06a93fe66a0500e5b6ae93e04cebc748858139d569693d42d"
+    },
+    "gfx/adib_sigil6.lmp": {
+     "bytes": 136,
+     "sha256": "5a2356a7479f887b20f10e03ee2f42478bdfa75febe2d802b3dbfcd25b39d744"
+    },
+    "gfx/adib_sigil7.lmp": {
+     "bytes": 136,
+     "sha256": "507011b2a191e096fadcd678590636e4033de2ffcf35cef31785539bf3f9fb4f"
+    },
+    "gfx/adib_sigil8.lmp": {
+     "bytes": 136,
+     "sha256": "2a49a4653b2ed11353c6aaca950420c38c8e7b2aa8cc82ecd746a4e73fb7aa00"
+    },
+    "gfx/adib_sigil9.lmp": {
+     "bytes": 136,
+     "sha256": "df168192d5c065c7247cff03b10da51eba431bdc4f76d2c913646bb23084d639"
+    },
+    "gfx/adib_suit.lmp": {
+     "bytes": 264,
+     "sha256": "030bf62f7f45667310f1a74bd88881e2aa8d6c7ba5355bda4bc7c87d64a3d082"
+    },
+    "gfx/adn_0.lmp": {
+     "bytes": 584,
+     "sha256": "0895fe0acba04a4e17ef64fe62c56765c4fef5933c4af09dfcb242e984e8d163"
+    },
+    "gfx/adn_1.lmp": {
+     "bytes": 584,
+     "sha256": "fc0391c514808f9cb54e0bb0bbd63edccb0bea66a7620b81d04497edd099f5b1"
+    },
+    "gfx/adn_2.lmp": {
+     "bytes": 584,
+     "sha256": "d70ca75a162f7203067f314eee6460dc9180383e5bd1a19c69a984d8f4c699ae"
+    },
+    "gfx/adn_3.lmp": {
+     "bytes": 584,
+     "sha256": "40fbf34b86a4e5d264fac3c875ad74a52b62f5868d01a7580107a52998cbe4ac"
+    },
+    "gfx/adn_4.lmp": {
+     "bytes": 584,
+     "sha256": "5c9f781b8fb46cff0bb69db9817936be10cc4e34d677a5a49f117baa1d414aef"
+    },
+    "gfx/adn_5.lmp": {
+     "bytes": 584,
+     "sha256": "f2b1a90d1f4e1e3c6eb04dd1d87f084b2bc932b76b6eabcc5a4ee12db939971e"
+    },
+    "gfx/adn_6.lmp": {
+     "bytes": 584,
+     "sha256": "ec90a75650252feb45f325815498caf518058d141c7660e594397e0e05e35cfc"
+    },
+    "gfx/adn_7.lmp": {
+     "bytes": 584,
+     "sha256": "c292389fee1e91c2c4178099a8c9b2ad193f74346adec126ae10a4383f96c6de"
+    },
+    "gfx/adn_8.lmp": {
+     "bytes": 584,
+     "sha256": "4df870d66977eddbb7c4f87ffe4b94a032f2f13ad8fa38a98fde607d7aa7b06d"
+    },
+    "gfx/adn_9.lmp": {
+     "bytes": 584,
+     "sha256": "fd7f393a0fea9c0bc9fec90492a8f074a75275fde2ce211379b098176729622d"
+    },
+    "gfx/adn_a0.lmp": {
+     "bytes": 584,
+     "sha256": "7221532ee9af2c3a2fa3d19e4ccae78458d7a1f3025627e6da45dcb4aefd6820"
+    },
+    "gfx/adn_a1.lmp": {
+     "bytes": 584,
+     "sha256": "8f594ea65757fdaa62105b5eb68d4519b96b93e12dba110a723c4bf99470d408"
+    },
+    "gfx/adn_a2.lmp": {
+     "bytes": 584,
+     "sha256": "738cd71a2344da4b1733b639e6cdef1fb412104c388d2edee0b4539655ed9fec"
+    },
+    "gfx/adn_a3.lmp": {
+     "bytes": 584,
+     "sha256": "00c7040d33a445656f33c373077564116a764142f4625b5df7fae6516817f893"
+    },
+    "gfx/adn_a4.lmp": {
+     "bytes": 584,
+     "sha256": "7fbde831e189692c1c5d048873e7098a7d017ff7e22fc57a724a2c2fcbcc8db4"
+    },
+    "gfx/adn_a5.lmp": {
+     "bytes": 584,
+     "sha256": "ecb1a8036b03abc3c95a145081762ebf8b04516bc438053e570b989195687615"
+    },
+    "gfx/adn_a6.lmp": {
+     "bytes": 584,
+     "sha256": "8495247be5584836815824b182f448348d3de924236e254c5ebffd8132a1b7ae"
+    },
+    "gfx/adn_a7.lmp": {
+     "bytes": 584,
+     "sha256": "76a1b4a37c14cf3c53047129e14bb3f2217142ca5405ebceb95b892bed49cb77"
+    },
+    "gfx/adn_a8.lmp": {
+     "bytes": 584,
+     "sha256": "943ae9da4710dfb8a8b7b22eb8ecc6131e7c4586f279701323997f931bdd486f"
+    },
+    "gfx/adn_a9.lmp": {
+     "bytes": 584,
+     "sha256": "4381c6e590644e7c7e3d64e89adb1d438802e1a81380de8f08b31669780f07ed"
+    },
+    "gfx/adn_aminus.lmp": {
+     "bytes": 584,
+     "sha256": "903c3e6081e934fb4a9b0ae4564265b0339d2289fea17720c7bac77d00155258"
+    },
+    "gfx/adn_colon.lmp": {
+     "bytes": 392,
+     "sha256": "a06510a33f355c24fc16d7591323523f13920ae6fa903c3155b5edef9e4059a9"
+    },
+    "gfx/adn_minus.lmp": {
+     "bytes": 584,
+     "sha256": "1e04325b97c5052e64187e0882b8c2f87473bd66f3e70b5a419d983b0a62ed81"
+    },
+    "gfx/adn_s0.lmp": {
+     "bytes": 264,
+     "sha256": "6a5cac8d7c8076aa42055c3b64f3fde4b1e7750b2bb143b12af07dec892c9ccc"
+    },
+    "gfx/adn_s1.lmp": {
+     "bytes": 264,
+     "sha256": "723ec3e0b6225419fa5fb8010896674d91d19eeafd8e2c9bbbec2d23fbb85792"
+    },
+    "gfx/adn_s2.lmp": {
+     "bytes": 264,
+     "sha256": "cff9bff09933ccbf43a1419d6f566807c2aee9a4aca448a86bf261394b3ca7b3"
+    },
+    "gfx/adn_s3.lmp": {
+     "bytes": 264,
+     "sha256": "8d7cf6b3f2db7463e962fd7b70b2ef7c36b0882b1e80d90b02fa1a609d09513f"
+    },
+    "gfx/adn_s4.lmp": {
+     "bytes": 264,
+     "sha256": "2bc5fa316cc366f4d1a4f1831ac3b8ced65caf89157e796ff5d673fa3955ac1c"
+    },
+    "gfx/adn_s5.lmp": {
+     "bytes": 264,
+     "sha256": "98cbff3f1b98977b8fc19523fc2e644e763fc52dba708fc5024dfbeaa1f00d6d"
+    },
+    "gfx/adn_s6.lmp": {
+     "bytes": 264,
+     "sha256": "1578d854415aaf5b68a25a0fb37057b019d12055b61c3d7402eae811a9359e1f"
+    },
+    "gfx/adn_s7.lmp": {
+     "bytes": 264,
+     "sha256": "609059534b0a59c9d5ab1180f25f0b2a952719a0ccade29d05559dfc6223f1d9"
+    },
+    "gfx/adn_s8.lmp": {
+     "bytes": 264,
+     "sha256": "7327dd480225a52c642320336ade17100228d2c1ade5f1b640cbff18e37fbe2d"
+    },
+    "gfx/adn_s9.lmp": {
+     "bytes": 264,
+     "sha256": "b8ad416098543b34c286565e3a0d7756eea7ab18c8b50145e7ddbc45fd28851a"
+    },
+    "gfx/adn_slash.lmp": {
+     "bytes": 392,
+     "sha256": "2500358f0d4bf9856c04b7be940ab41012faad597005837c99dfef93da1f3ca6"
+    },
+    "gfx/adsb_armor0.lmp": {
+     "bytes": 584,
+     "sha256": "01228bb8947103a70c9f536b168eefacda9dc5a08e1fa64ee963be44d4a9af9c"
+    },
+    "gfx/adsb_armor1.lmp": {
+     "bytes": 584,
+     "sha256": "85956c2a17460229a374e8a6e1cf22ad4ff663929dba06c9daa9d95d1582ba53"
+    },
+    "gfx/adsb_armor2.lmp": {
+     "bytes": 584,
+     "sha256": "e8e64ea8d90241677315bb9a9e25714856827642a0e331077dc6fa2b827036fc"
+    },
+    "gfx/adsb_armor3.lmp": {
+     "bytes": 584,
+     "sha256": "db6523d7c99bb15c14ad9fd1d665a24e4eab985dfa095d316f20fe5e96e9c320"
+    },
+    "gfx/adsb_axe1.lmp": {
+     "bytes": 584,
+     "sha256": "ebcafdd02b84a9bd21658a349205a09e5e242fa39013207fe6aab9697df2884f"
+    },
+    "gfx/adsb_axe2.lmp": {
+     "bytes": 584,
+     "sha256": "12caae98c176f1176a5222f7730709dcb9164a5db63984fe6f8982e8b17915e6"
+    },
+    "gfx/adsb_cells.lmp": {
+     "bytes": 584,
+     "sha256": "08da91ae0bca3d7bd546d92f7688061b7fbc8d86b84e309510ee3feeb3f63e92"
+    },
+    "gfx/adsb_key0.lmp": {
+     "bytes": 392,
+     "sha256": "49e4cda132ff7237a4b7244892fa1e059ff2d77698ec855cb4c02e08867899e2"
+    },
+    "gfx/adsb_key1.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adsb_key2.lmp": {
+     "bytes": 136,
+     "sha256": "46a6561c191c47e9445ef85c2bebdc881f330ca49afe562d7bb2a59c5442c73e"
+    },
+    "gfx/adsb_nails.lmp": {
+     "bytes": 584,
+     "sha256": "77fb4c0c61d824fafba54e91d6b23e702ae54565d7708ee0e404aff804555b73"
+    },
+    "gfx/adsb_pent.lmp": {
+     "bytes": 584,
+     "sha256": "8066cd0ef3d3ed9add280937fa51d6dd13a7eaf606ad0567366e86c51ddb7d62"
+    },
+    "gfx/adsb_rocks.lmp": {
+     "bytes": 584,
+     "sha256": "2e79b7c3e3fb6b4118a3ddedd7d9a1186f12c2df2efdbcf5300cacc51fe64744"
+    },
+    "gfx/adsb_shells.lmp": {
+     "bytes": 584,
+     "sha256": "f185cb1b1a48a8499d110e6371f2bb102ad89fda9875a267adcc6f3c8a5e613c"
+    },
+    "gfx/adw_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "ee32ef4cb14c02b9516f245fe9eae50021962ebdee3ef843076b9dbe20f038fb"
+    },
+    "gfx/adw_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "0f8884976f5ef05d5c3d7ab7c7b22bddeba9ee922664d23c6dfe835c5673ad9f"
+    },
+    "gfx/adw_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "2c1f7b1b0a5c27da9f01c84a38571901fb3636a04485102f44cb19d715e7f627"
+    },
+    "gfx/adw_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "a9802bea98b2fb57ab97784caeebf1ab2312fab73146503459c7c8021249ccef"
+    },
+    "gfx/adw_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "0c92aaf91afe914f4d06e5d2fa91bf926a0b43294d49021755b93c049e15a99d"
+    },
+    "gfx/adw_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "155eeca532e2f6d08b7575697020eebd4f492987392c68f09c66bb6522c0336b"
+    },
+    "gfx/adw_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "02d55707616bd6eae995c93d5eca3e788f227811001e2e8137c07cafe85409a4"
+    },
+    "gfx/adw_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "0d4cba204d9ea74665e164d46ead9167095cceb64a795861dfb21fcfd2b3e9ac"
+    },
+    "gfx/adw_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "3d354bd9336125ea758f2b5b56b1ecdf2a2afea4e8bb8d6edeb058448f9627e7"
+    },
+    "gfx/adws_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "457f6682e5a8b3d7b1075148c05093df1ec96c59e85057dfca80f66f4ad25815"
+    },
+    "gfx/adws_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "127d3759679f91a8633557a27abcb8425b3f8fd8b9888e029f761cff9fa20e47"
+    },
+    "gfx/adws_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd1e14b26cfa3915c23502e22413328d37749e0a77ac75508238fbaa375c7555"
+    },
+    "gfx/adws_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "424a425e24162a3a1a23e7308b8b46f4d25f1c9f11ac3b427117c596dafeb006"
+    },
+    "gfx/adws_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "41dc9eb1fb806500b41d832786a0bce0c6863c6caa3bcc7491892e25d04a81d4"
+    },
+    "gfx/adws_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "30a22fc8975b5a696ff31e859290fd780553f1857e424b1d5ecfa057277d155a"
+    },
+    "gfx/adws_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "50c5e9c358023dbbb65cc79346d99af6797af556faded31df95e2b7191aeb3f0"
+    },
+    "gfx/adws_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "94cef7136e718532b4d00b9ed8804da60be979206bde676a328270321286851a"
+    },
+    "gfx/adws_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "8259db2f3f7ddd075e6192d6e0581a2321c108232d67980fab85059fcbfe47df"
+    },
+    "gfx/adx1_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx1_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "e4d0714014c5a1c0d9874bf1ce2c0232352be1e0c90ffe927dc2d86d448f7e47"
+    },
+    "gfx/adx1_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx1_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "9da68076978e9bc4d35e2b40e972c578e0839c379c86d44bf15c033f164fc9e9"
+    },
+    "gfx/adx1_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx1_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx1_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx1_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx1_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "9341894f953061deffb42e12370fd05b7f8008e2a1caee149630a8bcd40fac10"
+    },
+    "gfx/adx2_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "c5f2e4352837eca0a67b1fe6eb5d437672f365efffd7c297848dcdbfca6fea7f"
+    },
+    "gfx/adx2_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "b627ea70b6a7a5debddd4710f31ca137c3baf01dd6109cc2cee7da968a020049"
+    },
+    "gfx/adx2_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd7a15d826f6565c97f638ff541d76e409b9cc69febbb78906c5ddbbad2e0f02"
+    },
+    "gfx/adx2_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "8239bfd1d494fae52f97d5f620bf6c9cace057a27975cddf7d0f557b5a797cb6"
+    },
+    "gfx/adx2_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "6adf5220508ec39cedaf8cc8208c8b7bff5f44f18401bc5ee7a39e91419376ab"
+    },
+    "gfx/adx2_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "f300febb1aad7dc16d592f1e1aef2cc5a8870ad08ebbb2bc15b43009122259ae"
+    },
+    "gfx/adx2_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "e15bf6fb56eca5640d521dfdbe0c20f9e3ce6fb6fc7a2e39922f0fc8cfc7d002"
+    },
+    "gfx/adx2_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "c781852ce141a1d5fb84451e1bef2b021c937d0658d7ca8f8b2a1d5cc3737a66"
+    },
+    "gfx/adx2_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "aaaac2a8b4dfaae3d02705c2fbffa38621187cc28f4246a591f38b2bec79f693"
+    },
+    "gfx/adx3_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "20209da4ccb0dbeffc6520aee7958b33bcfa728ed376b1f5f987c8305fb70d3e"
+    },
+    "gfx/adx3_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "eb13bcc843d95abf3c90c140c95aa95803a42a6afeb100e11a5e0d80c72caf8b"
+    },
+    "gfx/adx3_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "483f85f7e5a0e881f6511f2b16a25d1945dcc2fa5365e4417cb58ec6a87f062d"
+    },
+    "gfx/adx3_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5e1f15716b826a8a25e61415e675a6c94888ae4030462e1190653c4d93768743"
+    },
+    "gfx/adx3_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "99d58b01e578c88924699f85614b021dcc5ce32798c96680fb5120e8d58837c2"
+    },
+    "gfx/adx3_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "4eae7b9a7119e883d3b6d3b8b336398beca8b7cf4ed2b9b498e13d90b7743ccc"
+    },
+    "gfx/adx3_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "8568e0c106e3155b9cef3dc3bd55ce821ed151560abab4080fcf6534850b153c"
+    },
+    "gfx/adx3_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "b8764c3198aa863d67e4f7c3c19db89aab6aa4f4076abe83d50b88710eb85446"
+    },
+    "gfx/adx3_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "fbb92c8a0853070604e84da82a5232c93747f3571ba05e88ecb4e59649125838"
+    },
+    "gfx/adx4_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "4e8da401756d091a913d4a0a5618aee7eeddad1bcd8c78774bc229195bd96943"
+    },
+    "gfx/adx4_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "c68cec0c6064b7ceaad60028ed1e8f7834a6484d9fde249649d7b94addc6544a"
+    },
+    "gfx/adx4_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "386eadd2ee00c5a53179729c2b23cf56f0629c3e7ad8e5b3a739f1fd8d489d34"
+    },
+    "gfx/adx4_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5179dcb2b82032c81d02dfb35d130ed8196d5b726c7a8265c2823c3f2edde2a8"
+    },
+    "gfx/adx4_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1156e8a090be24e24605153b059646bd7d8b9d33c6e175bc9b05843eb626ce38"
+    },
+    "gfx/adx4_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "8881a5fe764d90c1113e1df7215c6520988c23601a969ea3e7b9abf8d7d4ef0c"
+    },
+    "gfx/adx4_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "7b55d6f2071d101db2a87c5958aadcdcf618f8f0eab53b19691125c1e8b6d8ad"
+    },
+    "gfx/adx4_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "199a6be6977bbebfe0aac0005466b10bfcdd9d26a764d18e56e28ee6f6f8f5ee"
+    },
+    "gfx/adx4_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "924cd9a6ac66660db99821b558a21e8dd0b02e85bb2a5415c2e24daace249663"
+    },
+    "gfx/adx5_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx5_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "9405034666f0f1247a58a97b86e5c451f0b2a315501389f43043da55493db8de"
+    },
+    "gfx/adx5_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx5_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "6c529185a7cc6dc8d066080c4246f80c7bf1fd0ea808fc0be5be63c8cff7c2b3"
+    },
+    "gfx/adx5_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx5_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx5_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx5_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx5_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "bb8e065bc9d9935d7fab8e9d0d0554948e2ab2622a54e86f70c1d8c3c9a0f178"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "b941e3ec692b990d1dbe0fd69c1e043b9d504374d791c8c981cb091324072826"
+    },
+    "gfx/community.lmp": {
+     "bytes": 256,
+     "sha256": "7d425f7678b30e94f816c93391c3322ed354c9657ef2563c964b2abb0d57d933"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4424,
+     "sha256": "b4554a7ef6de5831198626fef9431582d3c17ed56c55853f1ce979be31df8dcd"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "a0e7d5ec57b819a0c6ad269e777ea123f767c6d53d47cec3cecd8f25dd27b04a"
+    },
+    "gfx/conchars.lmp": {
+     "bytes": 16392,
+     "sha256": "045ea49c02bc0e51336e84fb19f4c445ece3c0d8c6ec4aba3cac0fcbf4306c15"
+    },
+    "gfx/conchars.png": {
+     "bytes": 14283,
+     "sha256": "1b63b3d252a0d234553153910c6d5384de0bbe050f095ebe00d253ffab2db8b9"
+    },
+    "gfx/conchars.tga": {
+     "bytes": 65580,
+     "sha256": "6dbfcc084e12e7c053c49f257f0a2276014a46ee92d194008893a39416e9e486"
+    },
+    "gfx/env/adgreenskybk.tga": {
+     "bytes": 1520289,
+     "sha256": "6a7fa2cdc97237658a3f2c73a8a5d879feadf4a31e84fb8585aeba96f3f8fb61"
+    },
+    "gfx/env/adgreenskydn.tga": {
+     "bytes": 1565620,
+     "sha256": "d4fabe617a431169df1bbc37e48404fc34718a1bbf5a1ee45d5b3a0ddda5cc6c"
+    },
+    "gfx/env/adgreenskyft.tga": {
+     "bytes": 1704063,
+     "sha256": "c6cfbbd8b09846eaea719a5e65744cdd4fddced0c277f4584c743f2639882d50"
+    },
+    "gfx/env/adgreenskylf.tga": {
+     "bytes": 1576943,
+     "sha256": "c83f24917ccb67af83602236d03e57096f73b36b7fc64da6206afe989944b4a4"
+    },
+    "gfx/env/adgreenskyrt.tga": {
+     "bytes": 1706213,
+     "sha256": "7b85287d2ce5e4d3a9ce63a560183086e812ceca9232d07eb61f63a24d678e10"
+    },
+    "gfx/env/adgreenskyup.tga": {
+     "bytes": 1798684,
+     "sha256": "703e4449b5b9ff967610dbc81d7e27c089788927d82fdb31267490cfb30ed0e3"
+    },
+    "gfx/env/asap_bk.tga": {
+     "bytes": 786476,
+     "sha256": "9f6daf48061bdc132ec28062c494d4a6abe2eeda2c86b575ac7df472a97b2c80"
+    },
+    "gfx/env/asap_dn.tga": {
+     "bytes": 786476,
+     "sha256": "a8aa31d47f7537150c1023713588b87cceff0072036ea64c895129fccfd9fa9a"
+    },
+    "gfx/env/asap_ft.tga": {
+     "bytes": 786476,
+     "sha256": "067cca994d96dcc95903ea1d3c023c479d66a655b2d3412116d462dff4e155d7"
+    },
+    "gfx/env/asap_lf.tga": {
+     "bytes": 786476,
+     "sha256": "761640856a2500019db4c3fae214fe2043fbc0edffa3e6c508d964a86b98ecf5"
+    },
+    "gfx/env/asap_rt.tga": {
+     "bytes": 786476,
+     "sha256": "08d03cf9826300c6d283028f60663f5bd3f6564a7deb5e15078440e18e1433cb"
+    },
+    "gfx/env/asap_up.tga": {
+     "bytes": 786476,
+     "sha256": "d98b750d0908addc2b0c9d513bc0bfc5d28935c9536f437cfcc3796fc0f5ce82"
+    },
+    "gfx/env/black_bk.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_dn.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_ft.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_lf.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_rt.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_up.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/interstellar_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "861352b7f4dc030af28b483d09ad88b4cbb7b8e23e5cd3cf512d2feae9640b22"
+    },
+    "gfx/env/interstellar_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "b16b2e272b7e74513f6a1961d68270dd82fa0667d6ea267a2d22c45a2bdc2fcc"
+    },
+    "gfx/env/interstellar_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "11730f0982cbadc7691ea38e57510b2b7e77484e108d591aece8f970cfdca08f"
+    },
+    "gfx/env/interstellar_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "5bf0a5999e7ea85e68291ab7b36d7f6be5104f8932a2fe46d257484e84dab4fc"
+    },
+    "gfx/env/interstellar_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "051204c9fb8a430c17fb337d84132e0d7058b88f070e457278be99d78a73e5c2"
+    },
+    "gfx/env/interstellar_up.tga": {
+     "bytes": 3145772,
+     "sha256": "d8b19a66cb5dad2f34c9059860ac24a8632ba5575ac06ca3076d57a70c47b5b0"
+    },
+    "gfx/env/l_swampn_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b83c2aeccb2ec2b6a7e7de05e4eb1f120437c575769b93533708093be6d7acb"
+    },
+    "gfx/env/l_swampn_dn.tga": {
+     "bytes": 3146268,
+     "sha256": "64ea5b085c2758138760da154c77e3c90eb0831c68e75bac4c03cd03ae2e28c1"
+    },
+    "gfx/env/l_swampn_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "f8149a22f17e241f3cc50ddc2587b3d8d6e72bb26f7a47d5045b08ed436863af"
+    },
+    "gfx/env/l_swampn_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "fdf2a49932e8ee9c06b9a50fa6dcff3d29bdde55aa209d1658346cf236ca1dd8"
+    },
+    "gfx/env/l_swampn_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "a2c65a9eafab955cfe898aa28e3563714354a08725068df84f390eebfc6ca20d"
+    },
+    "gfx/env/l_swampn_up.tga": {
+     "bytes": 3146269,
+     "sha256": "aa5c65d4c106b17e695629023db1e6b304ec5b4f15e646a1a94b38c47ef9017e"
+    },
+    "gfx/env/moonhigh_bk.tga": {
+     "bytes": 1048620,
+     "sha256": "5f361bf5a352c1df5a6caef9cf42bd35fed8406c6949af480b0425c193c18b3a"
+    },
+    "gfx/env/moonhigh_dn.tga": {
+     "bytes": 1048620,
+     "sha256": "02e2b36863c1181a85aa675c53fc14a301f38dc6e0c6735098bb6d8723af02b3"
+    },
+    "gfx/env/moonhigh_ft.tga": {
+     "bytes": 1048620,
+     "sha256": "3158735bdd6f4f467a5b29639aa4f622d1136ea463967684b739b0002bec6526"
+    },
+    "gfx/env/moonhigh_lf.tga": {
+     "bytes": 1048620,
+     "sha256": "5cdaabd99655152689e40832643690d7b1c5f8e414f3126a7c0c9224f2250704"
+    },
+    "gfx/env/moonhigh_rt.tga": {
+     "bytes": 1048620,
+     "sha256": "e08a374ac19c8b8cffa6c939515cde9570b44bbc044c12d06b0c5d94aa7469bc"
+    },
+    "gfx/env/moonhigh_up.tga": {
+     "bytes": 1048620,
+     "sha256": "c0465fd6a0b069e5ff78f3e561084bf3e23b796cac9b5214a6cd4045310d36fe"
+    },
+    "gfx/env/moonrise_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3b4e85116e3999d5cded25ca0a5d6fb9c297b3d69749a63daf5af6c37fe21959"
+    },
+    "gfx/env/moonrise_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a7be41496d25bc9e505b959b08a950c1bb61acc6c8c44ec4e1dd428faeac4ccd"
+    },
+    "gfx/env/moonrise_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "7381c46aa4f5c916f3bc8f82a442a4582834563c0bb0127580053bb274609180"
+    },
+    "gfx/env/moonrise_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "871df5eed200970b8c3246ca10a039f5915c95e8f48bf0692fc22f2f7e5450cd"
+    },
+    "gfx/env/moonrise_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "2cc00bb935ee2f4019f4d99170d38ef3f51c72ff80150cd74911b1038a0cb269"
+    },
+    "gfx/env/moonrise_up.tga": {
+     "bytes": 3145772,
+     "sha256": "0296084074d726170fdc85d2c1176ee64845b6805c174c08aaa63f514fd9cb65"
+    },
+    "gfx/env/snowmoon_bk.tga": {
+     "bytes": 707878,
+     "sha256": "f4c61c3a622a2dabfc2aa2748c3bba9ab52bf018c5c24b5aac6bd682b6d938de"
+    },
+    "gfx/env/snowmoon_dn.tga": {
+     "bytes": 754863,
+     "sha256": "a6f29123dc3da6df244c6878d1a355b9ba7c093b9a38b94e8f9253d317de846c"
+    },
+    "gfx/env/snowmoon_ft.tga": {
+     "bytes": 630095,
+     "sha256": "c10f65b43cff087a7044946f8105d24072bbcb33668bb485f501fc0bdcb7e293"
+    },
+    "gfx/env/snowmoon_lf.tga": {
+     "bytes": 671066,
+     "sha256": "8025d6d72582a374583dc4c80d15de546b1ebea3f378cc55b084483778d8f985"
+    },
+    "gfx/env/snowmoon_rt.tga": {
+     "bytes": 636559,
+     "sha256": "339a1a1a36ffafa6bb49ae5bffcb73c81d4304f0f6d40d5fe470654c0db56037"
+    },
+    "gfx/env/snowmoon_up.tga": {
+     "bytes": 410341,
+     "sha256": "f08c76ef2c7c2338b64615543ffa1217edab3ca41bc79cb74b20bc42d329e82c"
+    },
+    "gfx/env/stormydays_bk.tga": {
+     "bytes": 786971,
+     "sha256": "d82eac0c4f574d74ff5fee6ececd1d5f0b1bd94c349cb7c9af30d3ce79bf6b2e"
+    },
+    "gfx/env/stormydays_dn.tga": {
+     "bytes": 786971,
+     "sha256": "915f33dcae63765c49252b65a58f9d4359c7a36ea99352a013e58e660b71f160"
+    },
+    "gfx/env/stormydays_ft.tga": {
+     "bytes": 786971,
+     "sha256": "4906e45ebc2760dad5faf2e6f8a0be7c280bf7525a96364376155f3d001fba99"
+    },
+    "gfx/env/stormydays_lf.tga": {
+     "bytes": 786971,
+     "sha256": "d7cc6cbaa37481b3902673d717aae7f31e0170e2226a4efe88811f6bac3f8ca6"
+    },
+    "gfx/env/stormydays_rt.tga": {
+     "bytes": 786971,
+     "sha256": "ab40bc26b750a421c95948e7f215d51e831163fd478841c30f685a2b006b8c3c"
+    },
+    "gfx/env/stormydays_up.tga": {
+     "bytes": 786971,
+     "sha256": "8ff85257da02eb361ab8127e4425b9177842f17016724beb5c3058ae460aa52b"
+    },
+    "gfx/env/violent180_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "cf1d0a870b38e4889ad4ce18f22bf894771a8c91477c0338e837880df061db31"
+    },
+    "gfx/env/violent180_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a3b344abf47fae67c831aaa8d8b2ab7ff56ff1ed93091c6869139902060777ff"
+    },
+    "gfx/env/violent180_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "964ce0226b139a1af96de0c422e927d35917ad30f0c4027c1c386c7c32cc30db"
+    },
+    "gfx/env/violent180_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "b9cc1ef464535f9a911d56fb503a2e1aa68e6d07c7091cb62c42442a7d62ceaa"
+    },
+    "gfx/env/violent180_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "263af4a0d5b2e61303d8165d6b8a8b7e55d0c8dd79157ff133a5d50128d5f21b"
+    },
+    "gfx/env/violent180_up.tga": {
+     "bytes": 3145772,
+     "sha256": "3a9aae357ac1a8e8767e151024dab60845283422f204a354913282873f181413"
+    },
+    "gfx/env/voidsmoke_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "d274189cd63786e9d86fbd3cafda0cbfd054ccd527e30aeec921a8d6f10866a7"
+    },
+    "gfx/env/voidsmoke_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "47392d93a23946a28533cf759d6aea245a2647d58bf153d2845ac0899ab8d400"
+    },
+    "gfx/env/voidsmoke_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "ced1991fffdc46e2bf156e1d89e06e1362e0e394808b74bc7aa40e6d90fde55d"
+    },
+    "gfx/env/voidsmoke_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "4d1b843a9fc61c4125262a9a95fc084cea61eb4b125288f7a7cd0c2f2e53f4ab"
+    },
+    "gfx/env/voidsmoke_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "389ae84f29901e349a266d707f62beab9de3eb607b901bcb4245028b8edaa3b1"
+    },
+    "gfx/env/voidsmoke_up.tga": {
+     "bytes": 3145772,
+     "sha256": "138e9386728cdd98935a0c484d5693db2e60375d8d770ad754fe6616906591a1"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "a878796ad2dbab6a64e1eba47605d124170d5b4a7ce476b9d0087c2e302c00f1"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "381ec91a75cacad94d2a4d5a3b1cd6f9b22cce507fe95f980ebaabdb21bbe440"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9e9568b56059e74e621ad564b51cb0b886fcf800fd8d35a06df1aa79ac2aa823"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "52164e93b333dfe09a33d7ad1905796d7e7578a036b2fb2ddf35c4bf3381f30f"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "240a13f778cc7ec7ebbc67b23a977a54099e1996fd868f51c18f81aa3606d179"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "fae9345c9eeb43a56a14e9e681f9e9dadc05ba6e35f44197fca5873dbd52904b"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3272,
+     "sha256": "ba61bec9eaf837bddef9a1320c0acfe026a130bc078836abf971095157ee395f"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "fc226280c4948249790f00f97dd9b39e912131fc904ec75adb90308ba8763afc"
+    },
+    "gfx/mainmenu2.lmp": {
+     "bytes": 30728,
+     "sha256": "a3fd168c6454eeaeea9e248df568e5942a7f850bc5478f8946a0b6516a2ce6c4"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 6920,
+     "sha256": "5a84111e70bf277960853bca69a0dff9093d00d817ffab6fed96f33751435ae6"
+    },
+    "gfx/p_mod.lmp": {
+     "bytes": 6920,
+     "sha256": "3080226ebf497787e7ee1d7bc2917ae220340b7da4af58ff1a0f89f02b5c03d0"
+    },
+    "gfx/p_mod_idver.lmp": {
+     "bytes": 2504,
+     "sha256": "56234ed3e4e4fe95f8a4a1f9a52d4a73890ea653aa88ec992e6777bf3e99b445"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 6728,
+     "sha256": "493a3ae8e9553de87c49d356e916adab7c87e3b25a44c1d1ac46e37de4df800b"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 6728,
+     "sha256": "d79623e26bed9db65257e3c0bf43b085d2419fc6e5277ff357350556882456d9"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 6920,
+     "sha256": "f51c8bd49d699f08322b734f281d7e626c24844aec09099877fbceb1884cb705"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3272,
+     "sha256": "788da2d0f96ed9f0822fff406f364a912179e33f6f4d068aa7b772f2747cbc85"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "e433f3f5b535d3157ec0feeb91804959ff671b88a04c9785a02ec3acf5539af7"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "f8ee0991ff6faaef3b4d2230364776effe6a1d4b47588b98e39c1d0b4199fd9c"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "a6ccb48f7e1d00ec64e5154a0a47b433f017341b8e23ba4f7f7fef6fe9a27b3a"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 6920,
+     "sha256": "bce2792bc38f1f097336ebdedff2029b21f4cebc523684738f7e10e086d33661"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 6728,
+     "sha256": "904d617b5b97aa6b1631e7b5dfab9b4092c488fefd94ec093c98595b38789b7d"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 6728,
+     "sha256": "5eeeea42e3f429aae7f907145b88376805346ebe3ce932259bdfc43399f960ff"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 4808,
+     "sha256": "5ae8a3fd789e7ddf6d7791ee89cb79ef989cb000c086e9269349aa623f1f6438"
+    },
+    "music/track180.mp3": {
+     "bytes": 9774601,
+     "sha256": "2e3f447c7e7f0b7a02013e8259cc72bc035f8689686cfa1c301591cc34dbe4e8"
+    },
+    "music/track180.ogg": {
+     "bytes": 5092750,
+     "sha256": "1b48947672b05ebb5755d97122f28c0598a5fefe724d8b4cc3301497aba94f81"
+    },
+    "music/track35.wav": {
+     "bytes": 353002,
+     "sha256": "9b006ae5f5b2ae5c2ad84062d9bc288cee744e63301721838d70bec434178b95"
+    },
+    "my_progs/ai_ammoresist.qc": {
+     "bytes": 7444,
+     "sha256": "d530fec92f23ed0c3d09560abb9a89bdc160ce1aefdfbe4f4771f9897ae3fc4d"
+    },
+    "my_progs/ai_checkattack.qc": {
+     "bytes": 106456,
+     "sha256": "7971ca5a87666c89b56ab0fcc102e6f551f3cd3b03bdfc0bfb73f5f8d5aed7fb"
+    },
+    "my_progs/ai_combat.qc": {
+     "bytes": 24318,
+     "sha256": "a8cc4b28f82babe8ef8fc627a3c16efb25775ea736d3ee99709ed675196c2d66"
+    },
+    "my_progs/ai_enemytarget.qc": {
+     "bytes": 8409,
+     "sha256": "f4b0a35306d50e71fd9043ae949a421158ee9fcc4e311baf7b8fa2d345c4d46e"
+    },
+    "my_progs/ai_explosion.qc": {
+     "bytes": 12162,
+     "sha256": "7df941a7cf93b814ae9d90f646a5b0243a51db67872f621df73d43c6000ba3ab"
+    },
+    "my_progs/ai_gibs.qc": {
+     "bytes": 32373,
+     "sha256": "65e202300882ba8f0c980f65820b2d2e0bd06846073168f4bd7e37f2357f47d4"
+    },
+    "my_progs/ai_hazards.qc": {
+     "bytes": 26832,
+     "sha256": "81aace80121408f64369bc2bbfd5654650276ddd75217333d2a52364415acaa5"
+    },
+    "my_progs/ai_minions.qc": {
+     "bytes": 10236,
+     "sha256": "3e7bd34dfe0e73a11e6907d5ac69cb609eee19dff533689ea7c8eabe52500136"
+    },
+    "my_progs/ai_passive.qc": {
+     "bytes": 8224,
+     "sha256": "44473544d0da0dc778c2800a16172ab49b548286b604c9d6361f4bc4cfc1f076"
+    },
+    "my_progs/ai_pathcorner.qc": {
+     "bytes": 20921,
+     "sha256": "b3d6ed2434e0b995da51a71715647096e36e02d8cf920e18e024f920ed69238a"
+    },
+    "my_progs/ai_projectiles.qc": {
+     "bytes": 86235,
+     "sha256": "b28c04e84c97febe9e5a8e921a8e230755f9641d4bf5d74b4a59caaaa247dfc8"
+    },
+    "my_progs/ai_states.qc": {
+     "bytes": 7480,
+     "sha256": "76fae861132b0e50006ef88ea94a953e718b661defad2ea58a4ecad5cab92dee"
+    },
+    "my_progs/ai_subs.qc": {
+     "bytes": 50952,
+     "sha256": "9d2e356f0dba7842956ceb4e766fff9da25dc72a0b408baa3e19c4a146cbafdf"
+    },
+    "my_progs/ai_tether.qc": {
+     "bytes": 6470,
+     "sha256": "2229c0ea1b76e45f5707a3eca9e7626e33f8ea91d6b292da63c81723e1ae8521"
+    },
+    "my_progs/breakable.qc": {
+     "bytes": 79687,
+     "sha256": "754831599eec85a774501d9fd0a1ec7d5722ea6a6e01655b5ad74988145045af"
+    },
+    "my_progs/chaosmode.qc": {
+     "bytes": 81481,
+     "sha256": "01561dc4f1949716eba4d08f83efe27b71add80f923c1e2d89194c238772a646"
+    },
+    "my_progs/client.qc": {
+     "bytes": 70441,
+     "sha256": "00e2d4aff96ea28b0532ab0b03de0a8cdcf15750164ec82bdc8f43b9f2347447"
+    },
+    "my_progs/client_advinfo.qc": {
+     "bytes": 59677,
+     "sha256": "87aaca8bfd15935e1cd29a807bf77a2779d95418af631a6b456c6605710694fe"
+    },
+    "my_progs/client_camera.qc": {
+     "bytes": 13007,
+     "sha256": "ff4748b04c15d9a3b44dd8069f9347c12487ef353d5401a13542166576097889"
+    },
+    "my_progs/client_cshift.qc": {
+     "bytes": 725,
+     "sha256": "da1e321fe01bae486ffcdd987a942a4b0d5b2f603efb663d52c55e882f129685"
+    },
+    "my_progs/client_debuff.qc": {
+     "bytes": 15761,
+     "sha256": "0e0c9123697241ab3a366dbc46fcb90b8553b65c94cffe1442254a74a2753efd"
+    },
+    "my_progs/client_evilmode.qc": {
+     "bytes": 6982,
+     "sha256": "2cfa3bbeb36ab623c3bb137028ec5f549a2e5d2198fa2ab7fd8a445e14f4fc10"
+    },
+    "my_progs/client_ghook.qc": {
+     "bytes": 51884,
+     "sha256": "43d071195a70caa66b57cca1778679d772478fd1f71cbad7ee267e254e79a29a"
+    },
+    "my_progs/client_info.qc": {
+     "bytes": 13693,
+     "sha256": "55653ddc2b9f3cf2ca3cf1b0afdc4c1685baf1ab3c3830eb9f8b1b2d51b3ff31"
+    },
+    "my_progs/client_mapvar.qc": {
+     "bytes": 13177,
+     "sha256": "c692fa41644e6d21c945493dd891af945a072a4b39e687d1b59c86d14ee804a0"
+    },
+    "my_progs/client_power.qc": {
+     "bytes": 20026,
+     "sha256": "68457e8f99d3967babe95d4db3539388e95d294fa65a6190773e75951fed9ef9"
+    },
+    "my_progs/csqc_defs.qc": {
+     "bytes": 21072,
+     "sha256": "eddc5f194845e78a1633807d32b1da4425bdbe7bcce193e3868bc3995e2dee9b"
+    },
+    "my_progs/csqc_defsclient.qc": {
+     "bytes": 35002,
+     "sha256": "b6674acae135dfbc5e3dbb147e69acdc6b3564b766792359bed3e4eb800705e9"
+    },
+    "my_progs/csqc_hudad.qc": {
+     "bytes": 104391,
+     "sha256": "1ca012e489dc5f6026bdae469f411b5bb25afa00e00d5169cbd35b578a7ad9f2"
+    },
+    "my_progs/csqc_hudvanilla.qc": {
+     "bytes": 37074,
+     "sha256": "c5caa6ba176185c05903d383f3ae41907129d859419a0c0bf909b0e8d3e8af5a"
+    },
+    "my_progs/csqc_progs.src": {
+     "bytes": 113,
+     "sha256": "e383fc0920e9676d92e0be81d69cd8017ed5baf9fc0616a05773de68208ce434"
+    },
+    "my_progs/defs.qc": {
+     "bytes": 31974,
+     "sha256": "1534874cf4d70c5614dedecb70f6d428fc32832ce3345c2cb51fd6058a514902"
+    },
+    "my_progs/defsclass.qc": {
+     "bytes": 24401,
+     "sha256": "811c390be7b31fd4b276410ef1a75406bbca8fb84dc195484835a6100e9cddb4"
+    },
+    "my_progs/defscustom.qc": {
+     "bytes": 95914,
+     "sha256": "180ebe8c3fbbd4f78815c94d62f6ac0ad0c3cefe427664fdf4685adcf2c8a699"
+    },
+    "my_progs/dpextensions.qc": {
+     "bytes": 122912,
+     "sha256": "3758f58ebaa4186e9112da89f7ea53087eef5058a32ebc373a1ffda76c1d67a2"
+    },
+    "my_progs/estate.qc": {
+     "bytes": 7745,
+     "sha256": "9cceb71ae54b331c2702f5580094f9055d007b9e710dd5e61c7c632724022626"
+    },
+    "my_progs/fteextensions.qc": {
+     "bytes": 215531,
+     "sha256": "beb86ad10bb0726de10dd2557d6285f7bf40f08f9d30e06315c3772f8c256571"
+    },
+    "my_progs/func.qc": {
+     "bytes": 47039,
+     "sha256": "81cd56475c6c34a744d84c2b223e66dd1c83a1b525b4c42f3389d4ff4cca5601"
+    },
+    "my_progs/func_buttons.qc": {
+     "bytes": 13271,
+     "sha256": "9e1bd197b2367ab2b8f1c776c214a0c51120559e8d8f0b4888b262b7a1e746f0"
+    },
+    "my_progs/func_doors.qc": {
+     "bytes": 35874,
+     "sha256": "58dbdf05f0044aefdd13ee21d17045a681d255efaca6d129fbd1cec4ae516fc9"
+    },
+    "my_progs/func_doorsecret.qc": {
+     "bytes": 14379,
+     "sha256": "769a3142ccaf18060ff77b0eab57d901585202fbfe63a54ce25d4987b80f92d3"
+    },
+    "my_progs/func_insvolume.qc": {
+     "bytes": 10573,
+     "sha256": "1deaf4623a6fae80585d2d2b1978b1cd217b6f8a683ef3bbc3a77a2897e9a207"
+    },
+    "my_progs/func_plats.qc": {
+     "bytes": 11685,
+     "sha256": "5086c9aba8bbf83d29c3e1897c7867cb24220712007044792928f474216b7ea4"
+    },
+    "my_progs/func_pswitch.qc": {
+     "bytes": 8373,
+     "sha256": "b3a205176d80801216a930241508b3c5718f4be9e1b947932ace2851c34271d8"
+    },
+    "my_progs/func_trains.qc": {
+     "bytes": 26553,
+     "sha256": "81d8de4f3dff80b8523584fb5e37d8d4812a6f7f95a559edff320682217ad123"
+    },
+    "my_progs/globalfog.qc": {
+     "bytes": 18397,
+     "sha256": "84ec244a475ac41b9da772042123f58f4005130590f170f85f1b23ad53629f27"
+    },
+    "my_progs/hiprot.qc": {
+     "bytes": 31978,
+     "sha256": "82875db9fecd8bacd2c42232fb980e6a510a6863103273e2c9078dfe7c6759c5"
+    },
+    "my_progs/hipspawn.qc": {
+     "bytes": 2752,
+     "sha256": "6df8450b85821c1a76f5ccb3c807ac9b94e92f413f16f2ba618f922abf85148f"
+    },
+    "my_progs/items.qc": {
+     "bytes": 164855,
+     "sha256": "ffa38fa915821151c7dbfae3507bf804052db0f5c13eecac462400680cabcf3e"
+    },
+    "my_progs/items_progspn.qc": {
+     "bytes": 20628,
+     "sha256": "2f4824cb28192145a8fabc2da6575db3398e8f81522ab1e026d696ec87313650"
+    },
+    "my_progs/lights.qc": {
+     "bytes": 43912,
+     "sha256": "d0e0c373bb3cc68c7c9121a62c68085ff9cc290daa6faf0adab02323d8ef92bb"
+    },
+    "my_progs/mathlib.qc": {
+     "bytes": 22355,
+     "sha256": "b161ebb89a11f302427c4f124731ec38def8eb01347beb5d748a9ba4afb886f8"
+    },
+    "my_progs/misc.qc": {
+     "bytes": 85890,
+     "sha256": "6b3e8a0882d47f16ff7f54fb37a48e3a7853647f8895718e6428739c4207099a"
+    },
+    "my_progs/misc_camera.qc": {
+     "bytes": 43852,
+     "sha256": "61448a8f0354f39dd26371ae56dadbc903b08282293145a27088ac6c151ea547"
+    },
+    "my_progs/misc_model.qc": {
+     "bytes": 31793,
+     "sha256": "04774e0bab5cb0ccc5bd01e36ae7d6f449248484d0cb203eb435fb267cc8bdda"
+    },
+    "my_progs/misc_targetdummy.qc": {
+     "bytes": 15123,
+     "sha256": "bcd0a0ae806ce20a8c8cfcc27178ce1b4ead3a546d927b6a261ce51a6086c253"
+    },
+    "my_progs/misc_textbook.qc": {
+     "bytes": 26321,
+     "sha256": "14bf42536a5cc75990d938a79d7bd21bde1c166245d94d8e662f9e6fd66e0ae8"
+    },
+    "my_progs/mon_baron.qc": {
+     "bytes": 31318,
+     "sha256": "b76a10da34dabf3411ddf650abcdbc77e3ebcdfebace6191a39e7c0b13a0fad5"
+    },
+    "my_progs/mon_boil.qc": {
+     "bytes": 19821,
+     "sha256": "050b21bda5341a3f81dcb21e6d7d82d458a415fd8f1cfa12435228246229a323"
+    },
+    "my_progs/mon_bossboglord.qc": {
+     "bytes": 24005,
+     "sha256": "e67081b7a5218b361c62bf4b201a18db16f3e75716ad2729c11a0616b137975a"
+    },
+    "my_progs/mon_bosseidolon.qc": {
+     "bytes": 40134,
+     "sha256": "c51eb9b9d67cadfa7178891a238329a60ad57edc3f6ef645060695b451833115"
+    },
+    "my_progs/mon_bossfiretop.qc": {
+     "bytes": 14734,
+     "sha256": "26672c9c2d1577f8caf9894b8eb5eecacac89f64251257bc25db48b1bf43a7bb"
+    },
+    "my_progs/mon_bossicegolem.qc": {
+     "bytes": 47205,
+     "sha256": "5b888302a6af24ce823919d1349c1c92e1ee709d72e79042425349368a4d65fb"
+    },
+    "my_progs/mon_bossidchthon.qc": {
+     "bytes": 20247,
+     "sha256": "65d955fb1434f806962fadc088aa5933e96ed8aa9f1211d0709a3f462ffa3027"
+    },
+    "my_progs/mon_bossidshub.qc": {
+     "bytes": 14639,
+     "sha256": "fdd0e8f8fa374ea0164f79ef1bf74ca942f04c63159f360c7a43011673774fe6"
+    },
+    "my_progs/mon_bossjudicator.qc": {
+     "bytes": 81432,
+     "sha256": "f5092f376eeef22f0a552c846f50175680c15a5c37d9603c6e3d2635661127b3"
+    },
+    "my_progs/mon_bossmammoth.qc": {
+     "bytes": 84963,
+     "sha256": "6cda415b846b2aeb215c0eebc7cdfa6a5560255df9aa014f77b48aa7073b8d34"
+    },
+    "my_progs/mon_bossnour.qc": {
+     "bytes": 45558,
+     "sha256": "def8a1a46f3a266028df3d1a0b7c31a9ad98450f6601e176495f11d929041452"
+    },
+    "my_progs/mon_bossxxchthon.qc": {
+     "bytes": 22614,
+     "sha256": "2c1c0446b0f6a5b7a7921e8f8830c71c174d30c6f176d228a94afd9a05fdc25a"
+    },
+    "my_progs/mon_bossxxshub.qc": {
+     "bytes": 19006,
+     "sha256": "043ebc852ba7f0a06812cb0afd72d32a3da643df1dea45c87fb821f60fbcc332"
+    },
+    "my_progs/mon_centurion.qc": {
+     "bytes": 13734,
+     "sha256": "641e1c09c6df27b033e331140d242f25d27bf7f9bb83733a6b5b3469a5c7ffee"
+    },
+    "my_progs/mon_dcrossbow.qc": {
+     "bytes": 38069,
+     "sha256": "3296618a4b803fb6f1b44c1d32c17692a5bed13cf63102c6dcc58481223197a8"
+    },
+    "my_progs/mon_deflector.qc": {
+     "bytes": 32107,
+     "sha256": "d7a9344878a3a846a7e720ce704820d424362281a1675c40be7b670eca9fe342"
+    },
+    "my_progs/mon_demon.qc": {
+     "bytes": 14601,
+     "sha256": "d77f128e3f91737228c5a24b7ca146f6b4f8e87dbaac31b1ad4e79779884d0d7"
+    },
+    "my_progs/mon_dfury.qc": {
+     "bytes": 39867,
+     "sha256": "a016db202f2a418aee50cb7cce2155a24a6b807e8c98fc49a5f9273ce79c6da8"
+    },
+    "my_progs/mon_dguard.qc": {
+     "bytes": 28414,
+     "sha256": "0a2b964034559f4ca772f9f29be2c56684fd39290277046a6f7642ba934836eb"
+    },
+    "my_progs/mon_dguardquoth.qc": {
+     "bytes": 18932,
+     "sha256": "4caeb17520104cba42476ff7757f38ba6d72e941674b851f55a5c9780ce4de17"
+    },
+    "my_progs/mon_dknight.qc": {
+     "bytes": 36867,
+     "sha256": "68008427374e9ab670b6ad915c7a0f8eaf6a6699efa927a3748ae6cde86458e6"
+    },
+    "my_progs/mon_dlord.qc": {
+     "bytes": 22859,
+     "sha256": "09ca1edd4e65a166a66ba17e682aae9a1be09b05371a72dd1bc447389693bfa5"
+    },
+    "my_progs/mon_dog.qc": {
+     "bytes": 18431,
+     "sha256": "1b345447176aec54f18c31f5da215e80cb2de19f51d353c63a98507d881c2a9b"
+    },
+    "my_progs/mon_dprince.qc": {
+     "bytes": 33590,
+     "sha256": "5114caa7b6152e562e548096e41da68f43c910a5016ddaed408272a97a8320c1"
+    },
+    "my_progs/mon_drole.qc": {
+     "bytes": 25472,
+     "sha256": "36a510e910ce4ffa26d2d2ad336872c07537077ea920132a4cfd63d9133fb6af"
+    },
+    "my_progs/mon_dsergeant.qc": {
+     "bytes": 33493,
+     "sha256": "ada0cc4359a863c4e8d433c605a1c04ec6f7fd17ec852f5c4847443d3adaff1d"
+    },
+    "my_progs/mon_eel.qc": {
+     "bytes": 8252,
+     "sha256": "15c1f2fedba7077d352595e1be4a90f764354e4cf1875b40e1685d3ce81feb54"
+    },
+    "my_progs/mon_enforcer.qc": {
+     "bytes": 20146,
+     "sha256": "d453651d488afa789d0cea87ce99d9684329bbabdd17aa1625591f5a4b4ac90b"
+    },
+    "my_progs/mon_fish.qc": {
+     "bytes": 9705,
+     "sha256": "ff7d84db2c7917861ff5d81fe0e28f69d51143d27c4fba90dfcda11057222df0"
+    },
+    "my_progs/mon_floyd.qc": {
+     "bytes": 20332,
+     "sha256": "3ac2f0b0be94e311ff2fc4eee9cf66d5987af0e5c25fc06b8cc7b9efa6f581df"
+    },
+    "my_progs/mon_freddie.qc": {
+     "bytes": 25384,
+     "sha256": "4409a33e819f125852d0a4ada21a8fed2713012daec00922446f313031c845d1"
+    },
+    "my_progs/mon_gargoyle.qc": {
+     "bytes": 24293,
+     "sha256": "9e1f78b2364024efa6ec4142c1ecf4aff52cdf32f38031c34cf19e9cd74143d6"
+    },
+    "my_progs/mon_gaunt.qc": {
+     "bytes": 24111,
+     "sha256": "45be98ae0bdd32e0884280e18f867af037f2fcbf515914827c5f9107a87e52d7"
+    },
+    "my_progs/mon_golem.qc": {
+     "bytes": 35297,
+     "sha256": "dbaf3d1c0fec3166b0eb064a3c027dd3a0c907bed72b8e4581ffd74dad5ab5d1"
+    },
+    "my_progs/mon_hknight.qc": {
+     "bytes": 37618,
+     "sha256": "bac7d4b7832b95cea0f6890de66fbd0f7c4fcc7ce9051ef16ac042de465ddcb3"
+    },
+    "my_progs/mon_hogre.qc": {
+     "bytes": 24021,
+     "sha256": "8781ea9aaaa1d0f7ffb1fd8ec8b5981187eee6fdb8193160a1eb38770dffcfe0"
+    },
+    "my_progs/mon_hogreham.qc": {
+     "bytes": 23076,
+     "sha256": "b2ab6b830ce3aae7d6b033e8455de5011ded82e451ca171ea09940d9a3ec7740"
+    },
+    "my_progs/mon_hogremac.qc": {
+     "bytes": 23941,
+     "sha256": "9111c040ab1e5487936cce6ef1170e408c6d297d582702d202bbd27b0919d843"
+    },
+    "my_progs/mon_invsword.qc": {
+     "bytes": 9214,
+     "sha256": "f7287867cc6043eb7cd3fa3e1ecd5ae7115a84e5ef7021b2d5129afdb6ba6f46"
+    },
+    "my_progs/mon_jim.qc": {
+     "bytes": 22091,
+     "sha256": "55353984ad822dfd8c32f3b8ad9a06e8bfaab7bc5ff6f2a2326674ad4acd26be"
+    },
+    "my_progs/mon_knight.qc": {
+     "bytes": 24772,
+     "sha256": "d254abf88162436b9db48885ae8e59315c24c1e7f72a91d027a1d69fe9baf5b7"
+    },
+    "my_progs/mon_lostsoul.qc": {
+     "bytes": 23261,
+     "sha256": "2cdbf656c6b34164711fa88016542f4e3d2bd0555417ad00bab5ca7039f212ef"
+    },
+    "my_progs/mon_minotaur.qc": {
+     "bytes": 35316,
+     "sha256": "fbcef276ee3e2f1eeea8483303538190875e959b43efbf4f703be10fc72fc564"
+    },
+    "my_progs/mon_ogre.qc": {
+     "bytes": 24123,
+     "sha256": "d287d3b9024025237dbc68380f486572828a5114f9543599ba86b8bc35e9e25e"
+    },
+    "my_progs/mon_ogrextra.qc": {
+     "bytes": 9387,
+     "sha256": "41a9243c6006326195197a4dfba6ea4c1f1fbd729ec10adc48cfd7badd7a18de"
+    },
+    "my_progs/mon_pyro.qc": {
+     "bytes": 18235,
+     "sha256": "bd35f02c63af315ddf4820e388d0248cf065f1170bd7306957a1e86fa7e47306"
+    },
+    "my_progs/mon_scorpion.qc": {
+     "bytes": 22136,
+     "sha256": "0432d7c5e1b6a30a5452aba12b9fb6a3c2c7f3c582b1392d420414e66b8fb257"
+    },
+    "my_progs/mon_seeker.qc": {
+     "bytes": 29703,
+     "sha256": "d33939357840eedbfc63c56d6415d8fefd21de2c477b24b3165cdadcca2acd2c"
+    },
+    "my_progs/mon_sentinel.qc": {
+     "bytes": 10217,
+     "sha256": "946232c7169bf3fa966ce875523dd45402772f8045c51a96dced04f2f5f5788f"
+    },
+    "my_progs/mon_shalrath.qc": {
+     "bytes": 16434,
+     "sha256": "1b6fdf2447d7fa281d126118a9bc0e097de7b4dd4d10a33e60d5cf0ca785c58b"
+    },
+    "my_progs/mon_shambler.qc": {
+     "bytes": 23050,
+     "sha256": "576f71a38d75eedbdf58c291055674be8da5f0d04540e26311d65f70b58ee842"
+    },
+    "my_progs/mon_skullwiz.qc": {
+     "bytes": 36245,
+     "sha256": "6d3c2242bffe6eabe3f9cc59e881cb2296213cfbff809e1be045a80ca46aac53"
+    },
+    "my_progs/mon_soldier.qc": {
+     "bytes": 21645,
+     "sha256": "704c534062b11c4fc16416154c7706c125221660cdd4d9b02e00575b94c04103"
+    },
+    "my_progs/mon_spider.qc": {
+     "bytes": 30593,
+     "sha256": "4d0bbb7e38e51cef07912e6071e6bb9739e019a2d93129d38dbab9492bf43aee"
+    },
+    "my_progs/mon_steelclaw.qc": {
+     "bytes": 17126,
+     "sha256": "78dd4bb46dd76b2ff1f7d4a9f0b0902f25d94ebe13ace6b997a7f604c3718700"
+    },
+    "my_progs/mon_swampling.qc": {
+     "bytes": 25637,
+     "sha256": "fb5ed328cd3d5c09704bb84f39138463a7d26b8b1d45771e55e9ae952b1d2470"
+    },
+    "my_progs/mon_sweeper.qc": {
+     "bytes": 27025,
+     "sha256": "8f7a1d077779d88d542a325c1ae4ba4ff59d48bfcb334150ae3f024525bb725e"
+    },
+    "my_progs/mon_tarbaby.qc": {
+     "bytes": 11866,
+     "sha256": "88c9481ab7fe0cbe97d2b836492ff51b368aeae8d4ff3e5852734bb9f63a1b2d"
+    },
+    "my_progs/mon_turretbal.qc": {
+     "bytes": 38519,
+     "sha256": "fdcf915248dda5fb6a744d284233d46a2e6d62c8e4fd02fdd5bafe4f46167d30"
+    },
+    "my_progs/mon_voreling.qc": {
+     "bytes": 27678,
+     "sha256": "7734614fa6b2da2195bf3804415c06a2d10f35825e86abf4f85613a182cf21c2"
+    },
+    "my_progs/mon_wizard.qc": {
+     "bytes": 15155,
+     "sha256": "3101ca37b57343697b3d3c7637fdc84c842f78ec9081e401dcaa6df0a9b1df83"
+    },
+    "my_progs/mon_wraith.qc": {
+     "bytes": 35464,
+     "sha256": "6a28a205cb8ac574e98c8d34a01ea859922e38d55c66346a7aa867ebf84bdb5b"
+    },
+    "my_progs/mon_xmas_elf.qc": {
+     "bytes": 17589,
+     "sha256": "053eec412485090ee1ebeac25887382db40e2ba7ca456050ba4407be3ec8bc1a"
+    },
+    "my_progs/mon_xmas_raindeer.qc": {
+     "bytes": 12189,
+     "sha256": "abbe1dd5c96c25b631231d4db2f17e8243075ad08c082e0448b7cbff34f1ae0c"
+    },
+    "my_progs/mon_xmas_santa.qc": {
+     "bytes": 17853,
+     "sha256": "cc60c6de17bc3321f9b1cf75b3229e387592c9eb7fc4bb57c1de0a8d2c0e62e6"
+    },
+    "my_progs/mon_xmas_snowman.qc": {
+     "bytes": 11486,
+     "sha256": "65928bb70cb2e9352c2f5e036eda2a6bd97aea09d459d0af563a82aa5a2f2673"
+    },
+    "my_progs/mon_zombie.qc": {
+     "bytes": 33988,
+     "sha256": "83f56482374c3a79fcc64058989bd210af3add006b7388d89c92e90543ec56a0"
+    },
+    "my_progs/mon_zombiek.qc": {
+     "bytes": 42214,
+     "sha256": "2b9926454484e93f5c053bf4fd35b2a97cf7e835c26c3b30061f1ff391af9f5e"
+    },
+    "my_progs/monsters.qc": {
+     "bytes": 56573,
+     "sha256": "c2c75832e6d5e83e929214ba5c1aa9a4661bcaf7754c20b3e9648171bf804a58"
+    },
+    "my_progs/part_emitter.qc": {
+     "bytes": 82744,
+     "sha256": "fca7491171d58974ef6b15550b9a7f0474641e9eac7ee5de52c6980c96445518"
+    },
+    "my_progs/part_generate.qc": {
+     "bytes": 42914,
+     "sha256": "83b9718a85418143d92ea8311cc8cce69c1002eb7563710dfe7010ac52e15d50"
+    },
+    "my_progs/part_manage.qc": {
+     "bytes": 27407,
+     "sha256": "86eb791f4bba08fc0c965e9f81c90e7412ed2c910104d66a56cce1f3152808fe"
+    },
+    "my_progs/player.qc": {
+     "bytes": 27811,
+     "sha256": "1f0cc3eaf577c2af642495466c573cd6e226a4754902d9de9cbfc9c9ba28af0f"
+    },
+    "my_progs/progs.src": {
+     "bytes": 2482,
+     "sha256": "c773f107c562f731fbb30158422226bdc4576dd32aea0f02c122195e08eac96f"
+    },
+    "my_progs/pushable.qc": {
+     "bytes": 19823,
+     "sha256": "03b3bf9240db6e9532e45a3efc159129709f9ce095c3238daae32daddd5b07ec"
+    },
+    "my_progs/qc_highlight.xml": {
+     "bytes": 6348,
+     "sha256": "a7b326723cc1e4025e867ea5da00f54c944705600d740538aeb52f63cd027ab5"
+    },
+    "my_progs/settings.qc": {
+     "bytes": 61298,
+     "sha256": "7a1ae40ba7fa97ff7e7019017bc7640fd49d22943a2ca57c7a7e48702bbe7158"
+    },
+    "my_progs/sounds.qc": {
+     "bytes": 19389,
+     "sha256": "bb74ecc36a241db5a79b010f61200687c6db6e46297db39c8a2a8ce1d512bad5"
+    },
+    "my_progs/sprites.qc": {
+     "bytes": 476,
+     "sha256": "579f48b397914b02f8fb86dc24f23d4e63a4cd857df1f0eaefd6c83e9c49e238"
+    },
+    "my_progs/subs.qc": {
+     "bytes": 23545,
+     "sha256": "123ca7120e7ea4e4ca63bfd081caf46c7acd1560af4702c1bff40821d7f6ef44"
+    },
+    "my_progs/subs_soc.qc": {
+     "bytes": 28453,
+     "sha256": "679112275e8b3597daac962074f69b6d9fd5614fc3dbff036815b9365e1413c5"
+    },
+    "my_progs/switchshad.qc": {
+     "bytes": 7054,
+     "sha256": "92a2fd4e5c41f21f46502781322ab87584bf0999d733db50e0e19b8bbea793b3"
+    },
+    "my_progs/targets.qc": {
+     "bytes": 58758,
+     "sha256": "e39b45bf6740be40c2899376e92d30d7d227a4762091d7b63e382c79fe6822e7"
+    },
+    "my_progs/traps.qc": {
+     "bytes": 24071,
+     "sha256": "9e4e822a36113bc73958fa45ab0b8c290a5148c95f3a4da7125676c984ebd202"
+    },
+    "my_progs/traps_pendulum.qc": {
+     "bytes": 17049,
+     "sha256": "b421f26fd80eb74715172e25f3ac992faa95397dd67d5f7ede286fd78384a468"
+    },
+    "my_progs/traps_sawblade.qc": {
+     "bytes": 9783,
+     "sha256": "9a6e82a05f09001c0a9cffdf6b9d6399691846c5b1ab1fbfb470e5772a87f44b"
+    },
+    "my_progs/triggers.qc": {
+     "bytes": 139586,
+     "sha256": "2e5819bf11fecf01856bd7547af63b7c4927dec59237419dbf3dc79bc023f54d"
+    },
+    "my_progs/triggers_states.qc": {
+     "bytes": 17475,
+     "sha256": "2c4d25c11de0319cd54d81e67e651c8d29d22aca851988d21080ba5976137f14"
+    },
+    "my_progs/weapons.qc": {
+     "bytes": 44346,
+     "sha256": "f23d0cc07bab402da965ec3fa91d7de86ccabcb03c9019cd7b217fbca7fb4279"
+    },
+    "my_progs/world.qc": {
+     "bytes": 39815,
+     "sha256": "b933caca23d5a45e5d9368627b3d651af244af0aa345b91017d263be4bad7b77"
+    },
+    "particles/fte_weather.cfg": {
+     "bytes": 2758,
+     "sha256": "e0d383b0222f14edbd2bc04c1269206bbcdca22cdeac6840b5d831c042ff698e"
+    },
+    "particles/particlefont.tga": {
+     "bytes": 4194348,
+     "sha256": "bf90d469b3b41c2393f5ed0f58b4411cc8825f452341bbe3ba848c3cc855639e"
+    },
+    "particles/particlefont.txt": {
+     "bytes": 9872,
+     "sha256": "9e84ef35b813211196f8dfc8f89a420fd9d847ea514e43d0c3246ee666000b88"
+    },
+    "progs.dat": {
+     "bytes": 2345354,
+     "sha256": "f3c4218216ea0d3b00db35eef9e72945ee6687006b3e82c37ea2ae33a0eea922"
+    },
+    "progs/ammo_battery0.mdl": {
+     "bytes": 10552,
+     "sha256": "06d4f0235faedd3430e57d602ec29a2a91c0b23bdc30debc069212264a0faf54"
+    },
+    "progs/ammo_battery1.mdl": {
+     "bytes": 10552,
+     "sha256": "0cee39ac60c3eda7b5f1d1efde52f8be19c9e4f425972f16ba6d6362d646afb6"
+    },
+    "progs/ammo_cells0.mdl": {
+     "bytes": 27228,
+     "sha256": "b6f5a07c9fd48cf27f0873320589dda1e20afe7d64cd40b6c950e5f892a34fa2"
+    },
+    "progs/ammo_cells0_edit.mdl": {
+     "bytes": 27228,
+     "sha256": "47ffc9eb8ec352ab2fa479f35ee5b6ec0e0ac8f472a06fbe00e8298e9d683ed5"
+    },
+    "progs/ammo_cells1.mdl": {
+     "bytes": 29836,
+     "sha256": "c23b4e85e9edd68fec2d751af85cff391a11848bd4338a3c59a2c055508cfce9"
+    },
+    "progs/ammo_lidlarge.mdl": {
+     "bytes": 25252,
+     "sha256": "d941a1c520e49694d66598f3430420541b318cea3e1cf02d3957e06d010681a7"
+    },
+    "progs/ammo_lidsmall.mdl": {
+     "bytes": 25252,
+     "sha256": "221b3aaa2324bea668276d3de521c4945004a71368983fc74c50c4b53425c436"
+    },
+    "progs/ammo_nails0.mdl": {
+     "bytes": 14072,
+     "sha256": "1090a9c50a943c2bf04302914f69b835ecf79fbf3013f259a12668ebd57aad5a"
+    },
+    "progs/ammo_nails1.mdl": {
+     "bytes": 15976,
+     "sha256": "8dd339507f4e18953ceefe3922d04ca513728bf2b0745813723873427843213b"
+    },
+    "progs/ammo_rockets0.mdl": {
+     "bytes": 24836,
+     "sha256": "9f272b2f1cb52fcf38983f63052db653e8208b2ee1eedf053e99dca6e439c7d8"
+    },
+    "progs/ammo_rockets1.mdl": {
+     "bytes": 27672,
+     "sha256": "46d85f10a260cf13d6711420f11a235089536a3725363be0717c2ee3e7e8a18b"
+    },
+    "progs/ammo_shells0.mdl": {
+     "bytes": 14072,
+     "sha256": "053e466f1666314cbfc0cd6f67821850ad39505a6a0bbf37c80b127e6887e5c5"
+    },
+    "progs/ammo_shells1.mdl": {
+     "bytes": 15976,
+     "sha256": "6183880b36171b6784cecf74b50aea2e1fdbc17b1b0b304a89125e964d63fd1f"
+    },
+    "progs/armour.mdl": {
+     "bytes": 76144,
+     "sha256": "b6e297062cffd435d6ce5cc17854e25a49ff09750ee1eaec6d5004266884099a"
+    },
+    "progs/artifact_airtank.mdl": {
+     "bytes": 50184,
+     "sha256": "4702b7be1baa517669edd24f5b67377f532382bfedebd77b5d77f9a499f3f08b"
+    },
+    "progs/artifact_blastbelt.mdl": {
+     "bytes": 28436,
+     "sha256": "a935de1300f6fc4f03b6fc57bf43791ac32b74d55c5509eda84339dc33f0bf48"
+    },
+    "progs/artifact_envsuit.mdl": {
+     "bytes": 260844,
+     "sha256": "09192fca32cf5b7632cf0fe9cccd9b4b1313c0e92708e85f840b0971aca5d274"
+    },
+    "progs/artifact_invis.mdl": {
+     "bytes": 7108,
+     "sha256": "f6b0b925b584402d85a623e1924c50a4fb3f3a4994cb1d2f05a169a3af2e39dc"
+    },
+    "progs/artifact_jumpboots.mdl": {
+     "bytes": 37428,
+     "sha256": "668d649addf958be26f2bcff31baf3afa5ff176a178ef15073c87cc7cb57e2b8"
+    },
+    "progs/artifact_lavashield.mdl": {
+     "bytes": 469773,
+     "sha256": "2e3027df661ca197750df97599084442afda131fbf1b545ea38d40e93afff908"
+    },
+    "progs/artifact_pent.mdl": {
+     "bytes": 21412,
+     "sha256": "7ae90fc895f23f57952dacf4d8af125f99347e09edf6f0287c7e508faad67b46"
+    },
+    "progs/artifact_piercer.mdl": {
+     "bytes": 19012,
+     "sha256": "fd73ca18d93904647df923f2d0383958386c7deb9cf27547beda74c61a9f8831"
+    },
+    "progs/artifact_quad.mdl": {
+     "bytes": 22052,
+     "sha256": "bf6d2253210784391ee1ab9b38d2b6fd661a520434bb127d293f4d202040d1b5"
+    },
+    "progs/artifact_sharp.mdl": {
+     "bytes": 49248,
+     "sha256": "505fc06618d7cecb83c03ad7d7762011ff8cff025eecf007b200d87fcc2483cf"
+    },
+    "progs/artifact_tome.mdl": {
+     "bytes": 21412,
+     "sha256": "ee8cf94e2c87ff6c0d4aa8777da2f0ddb79605bf790fb8f9ed2f49c6c1f9b9cf"
+    },
+    "progs/beam.mdl": {
+     "bytes": 26020,
+     "sha256": "bd06e42c7f0d911a4ef1077c95d474b86f62bca4da02183449687c23879e8c6d"
+    },
+    "progs/brk_pot1a.mdl": {
+     "bytes": 93352,
+     "sha256": "5612b9539e9663e06397f315968674b1de6ab50db7cdf673baadcd4652cedcd5"
+    },
+    "progs/brk_pot1aflr.mdl": {
+     "bytes": 93352,
+     "sha256": "02fd1feb7dc24b456e31f26f142aafb9adf491a16ea4caf2c4ec237e465260a5"
+    },
+    "progs/brk_pot1b.mdl": {
+     "bytes": 93352,
+     "sha256": "47c4053f0c0c941674a9d7c15a07e05c7ed648b2bf8ffbd1defb7264c151b47a"
+    },
+    "progs/brk_pot1c.mdl": {
+     "bytes": 83968,
+     "sha256": "a408707cc6793c337d0e76d86c5362de39a1f2109c23affe5def6e8194e0f4e8"
+    },
+    "progs/brk_pot1d.mdl": {
+     "bytes": 74024,
+     "sha256": "c31abc1e9e5af2cb86614f68a8be55f6192e05baba8b93479e2b2590b1e0ef1d"
+    },
+    "progs/brk_pot1part1.mdl": {
+     "bytes": 33768,
+     "sha256": "2dd32863b6006dda74b60f05a43df13e7df052ddcdb652309ba0ab29fa5352e5"
+    },
+    "progs/brk_pot1part2.mdl": {
+     "bytes": 34072,
+     "sha256": "550cae5c8893c63520c324610950eeb5b9fe842dc8ea1f07f6a217953f6e743e"
+    },
+    "progs/brk_pot1part3.mdl": {
+     "bytes": 33464,
+     "sha256": "819cf0e720637e7c5e187ccc67ae032eca217ee2f07076aefee1a8b7de894852"
+    },
+    "progs/brk_pot1part4.mdl": {
+     "bytes": 33496,
+     "sha256": "a3cc47c7f7410bb0ca2308e45144b29bc3b678600e0f288b15d8e64525585e43"
+    },
+    "progs/brk_pot2a.mdl": {
+     "bytes": 77348,
+     "sha256": "ffcf5e5f3d0b81143e2b2b387cde7b13b2d36b71345d63456f288eb036993a2b"
+    },
+    "progs/brk_pot2aflr.mdl": {
+     "bytes": 77348,
+     "sha256": "37420048a9f72abc5982f5f6813602dbc4b82ef8e788a0e309df7ff13066ea62"
+    },
+    "progs/brk_pot2b.mdl": {
+     "bytes": 77348,
+     "sha256": "40eb2c849cd06d9b985b0efc2b9d1090ec1648b0de53d0a07bd6fd5fe2af6733"
+    },
+    "progs/brk_pot2c.mdl": {
+     "bytes": 77348,
+     "sha256": "3774ade6790fc2b597c44c5206deeb3d5d3d20a23331e3fb622e1e90f833c7d4"
+    },
+    "progs/brk_pot2d.mdl": {
+     "bytes": 79004,
+     "sha256": "2af25d81ae0f1d8724f3047e95ff2f1d1700061a536b3f9ffda5522cf7e8dd13"
+    },
+    "progs/brk_pot2part1.mdl": {
+     "bytes": 34456,
+     "sha256": "13547d9ca8c36bbcc95354df03dfbdc14f19f74251ff1dc8c417436846b396bc"
+    },
+    "progs/brk_pot2part2.mdl": {
+     "bytes": 34680,
+     "sha256": "7f9824c52b01664c2dd1ccc5c1dc9e7ff2a5567dd2d0a8e9c3bf1a8bd00400e7"
+    },
+    "progs/brk_pot2part3.mdl": {
+     "bytes": 34008,
+     "sha256": "52fdc17879e0b6fb8697e1e9fffba092f1b5aa8d3cee5d657b405eb4119e8e87"
+    },
+    "progs/brk_pot2part4.mdl": {
+     "bytes": 33304,
+     "sha256": "b40cf2b029a4bfac52a80f5aef6587f3eb66e08be1fe5f40cd3f97e93133ad3b"
+    },
+    "progs/brk_vase1.mdl": {
+     "bytes": 27992,
+     "sha256": "28a8b9a0d367f17c2c265271d99b019f1762831a11ba794e2884fc7f7a8a2368"
+    },
+    "progs/brk_vase1part1.mdl": {
+     "bytes": 5524,
+     "sha256": "b8c0bef8f5d6a427f57282f086a75f39e91ad6ab035d4f1d437da97794e52f9e"
+    },
+    "progs/brk_vase1part2.mdl": {
+     "bytes": 5556,
+     "sha256": "8e1df7795140732953af83a1ef2158299a2cc393163041b6d3243478b6b644e1"
+    },
+    "progs/brk_vase1part3.mdl": {
+     "bytes": 5556,
+     "sha256": "c2e3da479defb1c3bd5130555e33dd47afc6a3b4ef7f74d4f0184cb02a02a46d"
+    },
+    "progs/brk_vase1part4.mdl": {
+     "bytes": 5524,
+     "sha256": "986c51c2cb3832f597f9dac89c6044d090b10933306814acc36a0c4ab5a04b93"
+    },
+    "progs/corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "839b70bb6be7fac8c25e6069b999e076b04bdd3dbc7a9320924713cf75c2cadb"
+    },
+    "progs/corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "cb994b390584e1776ad1f0e60d95186a0dc54cd160a2cb8284d1a15b4fe1a35d"
+    },
+    "progs/corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "b19faa9afe7cf957ae7abf6439799e5001ff42817290f4b464aa3f7ae4e3377f"
+    },
+    "progs/dance_player.mdl": {
+     "bytes": 465924,
+     "sha256": "d07f23e6a40743aeac01084a1da9670ea9a635339d86be46149e9f0ee74661e0"
+    },
+    "progs/explode_box1.mdl": {
+     "bytes": 49888,
+     "sha256": "c8a7e667c5e20735db9a816b7a11b5a1c67bf4e176d1553a79cc56bcaa9ff35b"
+    },
+    "progs/explode_box2.mdl": {
+     "bytes": 49888,
+     "sha256": "649dbfabde0a875a0c35b0109261515dc9eb287d0cc7f41ca3712283e62509c1"
+    },
+    "progs/flame.mdl": {
+     "bytes": 41668,
+     "sha256": "d6cb4dc28d5101538b44ed53fe1cf84c9d5f8547a91eb74fc6c6bdd3645ffa17"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 74548,
+     "sha256": "f03dd3b7f94a86c4d91ffb002723a16f30321a0c2189b673dd4f12f547245816"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 71268,
+     "sha256": "b1e734caec73b941b1c033fbb49ffc0f947aa8e1d47250c2d8cec0f244870fc8"
+    },
+    "progs/g_ghook.mdl": {
+     "bytes": 64684,
+     "sha256": "9cdd8bccab5f11ea7f8ea6480a4ea05c9d749bc4746cc19a6452a2e0356edfc6"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 32404,
+     "sha256": "b195b37f7e96274ea7db8e70dcf5971275bafdd0c9c10c29f2dc540c38641953"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 35876,
+     "sha256": "8ee090222c89209eec97120d5542d69a9f75b8a8aa896cd4df256d438ce83495"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 25316,
+     "sha256": "261a8479de0d5df9aea9931a62b1b93dbb7bfcff4f4467920cbebcc9c2c25381"
+    },
+    "progs/g_shadaxe.mdl": {
+     "bytes": 398968,
+     "sha256": "19d6f210a771748da589282e63a222c6c9c41a21085ed3f57f70d7f5aa20bd66"
+    },
+    "progs/g_shot1.mdl": {
+     "bytes": 24580,
+     "sha256": "72913fa948f1618347adaa91ceb98203186d2fc7bd3b9c84af00f7f637928058"
+    },
+    "progs/g_shot2.mdl": {
+     "bytes": 15876,
+     "sha256": "8ae318a3e697e4c85f60a4e5997b673e8e48f17e295551c2b0b5d0c643b3ac24"
+    },
+    "progs/g_shot3.mdl": {
+     "bytes": 156216,
+     "sha256": "8a602686e322d7357a102e0c8e91907c8b3975a8b6d36ba19f3c645e450285da"
+    },
+    "progs/g_zershot.mdl": {
+     "bytes": 68020,
+     "sha256": "3439ce2faa846bd2b3ca50e33b55092454ed83caaf8fe654d8381e107aa3520a"
+    },
+    "progs/gib_1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib_2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib_3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/gib_4.mdl": {
+     "bytes": 7468,
+     "sha256": "29f9cfa3d86121e1e349de9c3a39e620b9d6ba2cd98640536923e581f7ae28bd"
+    },
+    "progs/gib_5.mdl": {
+     "bytes": 85308,
+     "sha256": "2023ae2fd305843640266ec6679511d134e1b84ac54de245a390e483557050bd"
+    },
+    "progs/gib_blclaw1.mdl": {
+     "bytes": 32860,
+     "sha256": "303c38aea48534d4ce34f3c2082a21c7408c1e4a4cd848bc7e4acadfaaddbdc0"
+    },
+    "progs/gib_blclaw1b.mdl": {
+     "bytes": 32860,
+     "sha256": "c22db765c594ee28a0863cf70e354c651a2b9282e1df7e3a57b35ce62932920d"
+    },
+    "progs/gib_blclaw2.mdl": {
+     "bytes": 32860,
+     "sha256": "c7d70c4c067aa297fbebc3d26a2068a62f307c7f00f8d15d0bf76ed9519967c8"
+    },
+    "progs/gib_blclaw2b.mdl": {
+     "bytes": 32860,
+     "sha256": "96a96606a74eb3093d88f1f946d66caf77bd57fde0a4ec44840c95fa12130551"
+    },
+    "progs/gib_blfoot1.mdl": {
+     "bytes": 32860,
+     "sha256": "74e05efa33fc9036399a1f1d484a3816129fe0e379aee579b923cf3316e5ab84"
+    },
+    "progs/gib_blfoot1b.mdl": {
+     "bytes": 32860,
+     "sha256": "2d23324414f3f1a25ee24afe914679d07df244c9c0e48139331f084b8c369054"
+    },
+    "progs/gib_blfoot2.mdl": {
+     "bytes": 32860,
+     "sha256": "c2ce3b46d8762b042d201608271c3441b975b93e6329790ca5cba61294f71e45"
+    },
+    "progs/gib_blfoot2b.mdl": {
+     "bytes": 32860,
+     "sha256": "de945be28e0b05dc380a0a2cfff6907f14a5e4b9756385874fddd712df095bb6"
+    },
+    "progs/gib_dmclaw1.mdl": {
+     "bytes": 49248,
+     "sha256": "be5f2bb9174ce47f6d3df06685ac728c852c3a028f6aeb1632e709eb69c20ee2"
+    },
+    "progs/gib_dmclaw2.mdl": {
+     "bytes": 49248,
+     "sha256": "ff6cc88ef9123812b9d8e09235074f4c7fcad47077e6fffee334f15e3f71eb27"
+    },
+    "progs/gib_dmleg1.mdl": {
+     "bytes": 49248,
+     "sha256": "106990e4d9e2746303d09ae6c481914702af0242d8cf0fc9d430d0fa5329813c"
+    },
+    "progs/gib_dmleg2.mdl": {
+     "bytes": 49248,
+     "sha256": "8308124b7c4dca218af9e8ef7042ddcb0ca2fcb30e7f86866b1a28a73ab94db2"
+    },
+    "progs/gib_dmtail.mdl": {
+     "bytes": 49248,
+     "sha256": "6b60c464ee0e7ace54313550ac5be2f4949cc6f8dd539b38459c4a6c395e6704"
+    },
+    "progs/gib_drolearm1.mdl": {
+     "bytes": 18324,
+     "sha256": "a6b0f55da1b1d8e519b3cb9a53afe229279c760ffab3862866d8c4e7a52f267e"
+    },
+    "progs/gib_drolearm2.mdl": {
+     "bytes": 18212,
+     "sha256": "aff67984dc3198d24d2184c35748e829d7f867c38227f1fa898a1986f12ac767"
+    },
+    "progs/gib_droleleg1.mdl": {
+     "bytes": 18436,
+     "sha256": "ab69d8c271f44998ccdfd10d70ccd06caa3c2674f46e4cf94285b380d08db501"
+    },
+    "progs/gib_floyd1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/gib_freddiejunk.mdl": {
+     "bytes": 71364,
+     "sha256": "13763a8cec3b643acb9b8165f1850ffae003131c84a2ac225777822a88462498"
+    },
+    "progs/gib_gargwing1.mdl": {
+     "bytes": 92088,
+     "sha256": "3979718d2403ca7cf75aad4004a56100c1bf358f2cb9ae68595e5d69f6774f47"
+    },
+    "progs/gib_gargwing2.mdl": {
+     "bytes": 92024,
+     "sha256": "7554ef45a88db1f2e457dd7071770e42bf864123827b9819435a628b412ecb32"
+    },
+    "progs/gib_judgeboot.mdl": {
+     "bytes": 199308,
+     "sha256": "557eadb703666c4868e1b231cb1c21fbff5e59e2ec0cb8ade85cd3839fd714cb"
+    },
+    "progs/gib_judgeshould.mdl": {
+     "bytes": 199132,
+     "sha256": "69e4958866a47d5c63a6385db4843a6a5011f149b25e67720291d2db63945ed8"
+    },
+    "progs/gib_justiceboot.mdl": {
+     "bytes": 264848,
+     "sha256": "b727239a7bf232c7c6164d0f9fc0961a6c692cb0c0919b17429ade6f62bdd71c"
+    },
+    "progs/gib_justiceshould.mdl": {
+     "bytes": 264672,
+     "sha256": "2fcafb2b2a19b8ae16009e827f13fea14cb389317ec476b7f58fb2fef1163180"
+    },
+    "progs/gib_knfoot_l.mdl": {
+     "bytes": 18288,
+     "sha256": "8ffcc7ce931662f2eefa0703642b140e18a99c02252ffa3ddeb71f6ebbbe360f"
+    },
+    "progs/gib_knfoot_r.mdl": {
+     "bytes": 18288,
+     "sha256": "4d503f422ac01a8565453ba4bd8268338c3a9802480785eebd27fc0487e46753"
+    },
+    "progs/gib_metal1.mdl": {
+     "bytes": 5172,
+     "sha256": "b0951de4d869e0b779aeb3f7a96f56b22a82a58d267a56b1247f0c3e667c25ad"
+    },
+    "progs/gib_metal2.mdl": {
+     "bytes": 6292,
+     "sha256": "3df78c49abb572095d3b70efbb99bccb63caf2ffd30bb3ee434c945084acb5a0"
+    },
+    "progs/gib_metal3.mdl": {
+     "bytes": 6036,
+     "sha256": "88f8a1f941e38f8528ec27a168559946cc0b69f2abce1cbf6858b813e09c5f51"
+    },
+    "progs/gib_metal4.mdl": {
+     "bytes": 6580,
+     "sha256": "fbde734f29a6691d51c58a40a89e45f81dece2f20218353a6137a2362acbe3a9"
+    },
+    "progs/gib_minoclaw1.mdl": {
+     "bytes": 135544,
+     "sha256": "1188f73d5a6319bef5e506ca994bfcf63074a4267a5a189cb92db94160310fca"
+    },
+    "progs/gib_minoclaw2.mdl": {
+     "bytes": 135544,
+     "sha256": "511bb72c8382f4cc3cc9fa3bea4adf2390dcca1e2dcd42ef8f8287765875fa99"
+    },
+    "progs/gib_minoleg1.mdl": {
+     "bytes": 135448,
+     "sha256": "f07ce357d83d3ab0f39109d93f2f6996ded4ff19a4372fd5ddc9d9fa1a0ce8d3"
+    },
+    "progs/gib_minoleg2.mdl": {
+     "bytes": 136392,
+     "sha256": "7ba78149bc60a05ceff9090ecc2bdf013ff2d55420dfdebc553a254ac0bd08fb"
+    },
+    "progs/gib_ogfoot1.mdl": {
+     "bytes": 5956,
+     "sha256": "144e2fdfbccceee039243ef343df02ce181b666070e2d0a1825c056634f2a632"
+    },
+    "progs/gib_ogfoot2.mdl": {
+     "bytes": 5956,
+     "sha256": "9997dff0bdb2622ef6ee2530c27835fd249aee04437e70486e76255f979bec25"
+    },
+    "progs/gib_p1.mdl": {
+     "bytes": 7712,
+     "sha256": "709c49c205b27793f589eab17e8356a108345069716f9095dc07dd6447be7894"
+    },
+    "progs/gib_p2.mdl": {
+     "bytes": 21216,
+     "sha256": "50d99c7fec3b8ef01bbb19c32c88dac40a372cb6a7d39c349e0ff4909360626f"
+    },
+    "progs/gib_p3.mdl": {
+     "bytes": 18176,
+     "sha256": "d53659aa99de418793337b7e878db7bd7836883ad43528d648475589aa30d85d"
+    },
+    "progs/gib_p4.mdl": {
+     "bytes": 7468,
+     "sha256": "71ad4dcc06038f0a175605a3906b1506d0144b56b238e7df178160d9ab876b8d"
+    },
+    "progs/gib_p5.mdl": {
+     "bytes": 19756,
+     "sha256": "adf63c881ff5703b8112f714140929375b5c10be957f01cfdfa131d89af3cacf"
+    },
+    "progs/gib_s1.mdl": {
+     "bytes": 7712,
+     "sha256": "31faee0daaf399feccc1ec942ff7fe85a1a790ebd93c3b8a1fcfde9bcc06da1d"
+    },
+    "progs/gib_s2.mdl": {
+     "bytes": 21216,
+     "sha256": "c85f7dbc8eec508951893253bba5eec169a87865c995ba1d0e5c083fed9e03ca"
+    },
+    "progs/gib_s3.mdl": {
+     "bytes": 18176,
+     "sha256": "ec23effca60ef407bf294a814003213928f21f05e6da501fbe996345b6171013"
+    },
+    "progs/gib_s4.mdl": {
+     "bytes": 7468,
+     "sha256": "5001ef206e1a36cc792d7b94054b2bab4c6dfbed60e0ee0d3afd240d1af88d13"
+    },
+    "progs/gib_s5.mdl": {
+     "bytes": 19756,
+     "sha256": "9e1a112412d38c559974c628649a7773ad445ba7d24a1804c5f3fe5f50ecef7f"
+    },
+    "progs/gib_scorpclaw.mdl": {
+     "bytes": 66816,
+     "sha256": "ecaf582e92d77a1722eded2c5564d2fb9575065510ff1bc9632538345ed18329"
+    },
+    "progs/gib_scorpleg.mdl": {
+     "bytes": 66304,
+     "sha256": "399067acf8f082301f6629d2b124b0d34a7d934db55c922205a96772a85a8a1c"
+    },
+    "progs/gib_scorptail.mdl": {
+     "bytes": 66864,
+     "sha256": "0831c04d7a73c6f58329b0be0f6d371f727ea880b49e5b6e16f7cdc56c124df2"
+    },
+    "progs/gib_seekarm.mdl": {
+     "bytes": 265688,
+     "sha256": "6ee70b2f4f39d8a1fd99113c7c8df5481c421960f160afea4e622ed5b3113014"
+    },
+    "progs/gib_seekchunk.mdl": {
+     "bytes": 265420,
+     "sha256": "a70331a8e43075b026cf21d364cf2341e79e7e60c5fca4777d10aabd57ce0323"
+    },
+    "progs/gib_shclaw1.mdl": {
+     "bytes": 22964,
+     "sha256": "20b29bf40dd02dce0204c14c34b0b5806d8eef580406851d73383a631ac8f2a7"
+    },
+    "progs/gib_shclaw2.mdl": {
+     "bytes": 23060,
+     "sha256": "8dcf777d5ffd2e83edf5b6f936881eaf9d384fe8fc980721c9f5881d3e6da0c3"
+    },
+    "progs/gib_shfoot1.mdl": {
+     "bytes": 23268,
+     "sha256": "634d7cbb9e2b718167fe74112e6dd4f53cfe1cffc32f75cd80e711a24cd2f983"
+    },
+    "progs/gib_shfoot2.mdl": {
+     "bytes": 23124,
+     "sha256": "aaa2393cb65fb33a8885bfdd9b808732c0aa17f0dd461d3b04e84eb27f0fe61d"
+    },
+    "progs/gib_soldfoot1.mdl": {
+     "bytes": 51148,
+     "sha256": "09357cfed1e6c9c25e0d133d95f2c2b36693cbed1010146a982bca685cb370ed"
+    },
+    "progs/gib_soldfoot2.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/gib_spidbodyb.mdl": {
+     "bytes": 17652,
+     "sha256": "313dc78de70f02de9a49c71a1fd5ddb5ae4247f90a1a04f0ab84f44797be1946"
+    },
+    "progs/gib_spidbodyg.mdl": {
+     "bytes": 17652,
+     "sha256": "5439ca0812bc2627f22fd995237607755708f7615782785093793c11497973e5"
+    },
+    "progs/gib_spidlegb.mdl": {
+     "bytes": 18560,
+     "sha256": "66dc12710dec1bd4827497e4ed28b6a4965e1f68b48d5f0903a96ecf632e7f4e"
+    },
+    "progs/gib_spidlegg.mdl": {
+     "bytes": 18560,
+     "sha256": "3474de5b97c2b424f8ec4b8d93a1457f13adca106bdbe15234492376708810f9"
+    },
+    "progs/gib_steelbody.mdl": {
+     "bytes": 17652,
+     "sha256": "2a833de4b00f439041d27d97b3660d4df1cc9e3b454dba5ac5533e5c855e8d90"
+    },
+    "progs/gib_steelleg.mdl": {
+     "bytes": 18560,
+     "sha256": "ae926ada1c4ef7b695764f2daa0b4704102bf5eebc103b9f6a56813337f43165"
+    },
+    "progs/gib_swampleg.mdl": {
+     "bytes": 4820,
+     "sha256": "2b549fd3a74b0fd6b94c71c9e397b466e2c7f823917ffe717ce1af43769e1961"
+    },
+    "progs/gib_swamplegp.mdl": {
+     "bytes": 4820,
+     "sha256": "b5cf22240bf6474cc8ea57c40ddb70f80e792c23cb87835bee94825cb645578a"
+    },
+    "progs/gib_voreleg.mdl": {
+     "bytes": 4820,
+     "sha256": "19ec59cb3436d66a8ac9d8f40480a9c83aef879f0f1e58ddb834710e2bbc4d9d"
+    },
+    "progs/gib_vorelegp.mdl": {
+     "bytes": 4820,
+     "sha256": "341679c553a719be40022fc4a3573ff68116fee7ae05df511b9083a410af5e7f"
+    },
+    "progs/gib_wraith1.mdl": {
+     "bytes": 5300,
+     "sha256": "a0642c84b36288a3d0cef22ac32e0c681c422a034204932671729624f19d0b2b"
+    },
+    "progs/gib_wraith2.mdl": {
+     "bytes": 6292,
+     "sha256": "d20a17e624d16e4c8552ac9a291cd735aeae670effc2c9865b37fbc7bcd22220"
+    },
+    "progs/gib_wraith3.mdl": {
+     "bytes": 2516,
+     "sha256": "63f10b068c6df0a80729362c094f72d0bcf90f74de97636bc5e4a630c13e741b"
+    },
+    "progs/gib_wzarm1.mdl": {
+     "bytes": 12384,
+     "sha256": "9b6f5469bfc6ae49d2bd51fb6d35e686c4e79e5691e2fb80fa7ee556bf547e04"
+    },
+    "progs/gib_wzarm2.mdl": {
+     "bytes": 12384,
+     "sha256": "2ff539f467ca9b0f23c40cb2547221a484afbe7e07a812558ec1595e5cbd0217"
+    },
+    "progs/gib_wztail.mdl": {
+     "bytes": 12384,
+     "sha256": "fb90123980ff4510e744ea2b21509492b7ff9c131527ffe5c7b80bbbf881bf41"
+    },
+    "progs/h_boglord.mdl": {
+     "bytes": 98400,
+     "sha256": "119279b2ffdf928d34ef1470ae6c14f875cb59edc6d8b107a90bbea122c9acdc"
+    },
+    "progs/h_boglordb.mdl": {
+     "bytes": 98400,
+     "sha256": "25af0d0ea45857e64549686bb58e5f69a0754ff6e43c26ce735e58aaac3d534e"
+    },
+    "progs/h_centurion.mdl": {
+     "bytes": 63592,
+     "sha256": "2e64af530a4f5f36001ad922bb56a941738e7fe2c67c0ad0e3f06fa5854c4b08"
+    },
+    "progs/h_dcrossbow.mdl": {
+     "bytes": 25700,
+     "sha256": "0354fdb96bd5490bc18527d68813a43a41f943a05f7edca26c1aea7b943185be"
+    },
+    "progs/h_deflector.mdl": {
+     "bytes": 22232,
+     "sha256": "56de00c315543073bfda7e8a5ad3c3996f549351fa1e660e676516f4122cdeac"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 67688,
+     "sha256": "ff73d5f8fcab46a806c47377679ec5473cdc0ea93a0fda6dda8b5dba8cfa4b97"
+    },
+    "progs/h_dfury.mdl": {
+     "bytes": 14036,
+     "sha256": "3753a68126ff7caee3219c31533a1731ae9a80623c6af69315c7526f5c92669d"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 19296,
+     "sha256": "6b0867e61635543a7bb3b02647855f1384961095cd06dfc786a537b11eb926ae"
+    },
+    "progs/h_dguardq.mdl": {
+     "bytes": 4920,
+     "sha256": "337f2723daab9d1375b78cb017512ce8281087ff8df9c33b04a6c613cea3590c"
+    },
+    "progs/h_dknight.mdl": {
+     "bytes": 32144,
+     "sha256": "30af2418019b946f3582f70d2356357a97dff0391f86a9fb0abd5218cc799020"
+    },
+    "progs/h_dlord.mdl": {
+     "bytes": 18699,
+     "sha256": "bc5a92be1c5f3d06dc0238ec7bafe6a3c25826cc50edc6214ed5aa19b0075987"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 27652,
+     "sha256": "49f28b9a13867ed4a88fcac541b8a9cbabddcc594557b3490951179b3d479509"
+    },
+    "progs/h_dprince.mdl": {
+     "bytes": 19336,
+     "sha256": "77855cfc2667ed68c61d389a44ed312abc3ad1e029ea003d03e78e7131fb803c"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 14032,
+     "sha256": "bd5da6afddc520999d9c572a679c3bc8c43635ce2c73f8789603eb6a83c15aa1"
+    },
+    "progs/h_eel.mdl": {
+     "bytes": 156904,
+     "sha256": "a859ee09044d9afcd05ee2af3f1ea8c7b4ae3abc01273922dbebd5aa67b12d74"
+    },
+    "progs/h_enforcer.mdl": {
+     "bytes": 94612,
+     "sha256": "21046f6878f5f4173206debcb912d9fdee0b1f5c66d820a4355c7df8e2eb1860"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_gargoyle.mdl": {
+     "bytes": 30152,
+     "sha256": "bbcf207c44814f5e665944db03800934eab9046a0d0d86f4c982a3116f855791"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 59888,
+     "sha256": "f57daa1ab6a721a9feb696aaeeb597c720b639cd0a027a1b1da8cdd68ad1d1f0"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 30552,
+     "sha256": "edf8a4ccc52bfd9545fda8da9360e536c026079f8d2fd9756191fc934bd55683"
+    },
+    "progs/h_hogre.mdl": {
+     "bytes": 23688,
+     "sha256": "6f21e95518cd085d20b1023951ddf4d738285210bc95c6e2b3d2e82566478776"
+    },
+    "progs/h_hogreham.mdl": {
+     "bytes": 22776,
+     "sha256": "3d3e43d16c4babcbca358b44dc03ad1a212e22ea3a10ee9e639b5f4c2e95f670"
+    },
+    "progs/h_judge.mdl": {
+     "bytes": 203276,
+     "sha256": "be57ef7327fbf3ea6fb55c02bcccc4ec207b3781bb9d2e383939f3840e1ef91a"
+    },
+    "progs/h_justice.mdl": {
+     "bytes": 268816,
+     "sha256": "01d3011001c297b85a139ecb2861f188d15b96cd1ae02f08cb1604565f2d2ee3"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 42068,
+     "sha256": "aa979e22745c960cd100e814bce62018f2b992481e57838548f0ddf4816c27a8"
+    },
+    "progs/h_minotaur.mdl": {
+     "bytes": 138264,
+     "sha256": "c5e13818c813680fd29a94b408518731aa4e9007c23d004ec874f099c9ced6b1"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "4967d418f4810e9273732bbd4c690a1f9478243f7fe3807497134eb2994da0eb"
+    },
+    "progs/h_pyro.mdl": {
+     "bytes": 42912,
+     "sha256": "5359fd85e71cde1ab716d8d50a8618a347dd42b4ad4692805bf41c1903d55c18"
+    },
+    "progs/h_scorpion.mdl": {
+     "bytes": 67408,
+     "sha256": "d68d09c35c00d9bafb302fb7f3baeef90ee5d60de1ad8a7627f979c3561f5965"
+    },
+    "progs/h_seeker.mdl": {
+     "bytes": 9060,
+     "sha256": "9e9d601441532e16aee253b5e94ea9c32563f880782794d16ce496a580698bd8"
+    },
+    "progs/h_shalrath.mdl": {
+     "bytes": 78156,
+     "sha256": "f478f17ea9ee6843be2ebe3c487d0036657c94ace52a800fa44e0160d02a522d"
+    },
+    "progs/h_shambler.mdl": {
+     "bytes": 98400,
+     "sha256": "6508f7b05b65f230b7f1280d2023e9ed200663715db1709c43e7e187e3ed841c"
+    },
+    "progs/h_skullwiz.mdl": {
+     "bytes": 234304,
+     "sha256": "625c991e231d6836c36ae0c6651ec06f05541e9a7be605654fb43fba65bcc3d4"
+    },
+    "progs/h_soldier.mdl": {
+     "bytes": 166488,
+     "sha256": "0a4e322fbac8f98755adb9a4bf5ecff24d58aab30fcb1c9def3e97a0f686445e"
+    },
+    "progs/h_spiderb.mdl": {
+     "bytes": 18564,
+     "sha256": "d51c7764fccc4512db6d79ddcf03ffe42cf2817a66d6be02be0cba6551ee1206"
+    },
+    "progs/h_spiderg.mdl": {
+     "bytes": 18564,
+     "sha256": "70bec9669f3a7f3662320e32d29c38d535092db56617d5033e11669038472e2b"
+    },
+    "progs/h_steelclaw.mdl": {
+     "bytes": 18564,
+     "sha256": "be9adcdf9cf9407a729cfa9abcd692f46a55ffcf25c1878a7b2f5572fd591f8c"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "63b8a0b90691ae9a3c50a94f02943a1b94946f89402cc4e1da74c6806bd953ba"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 23516,
+     "sha256": "5a933ecbc067b8d6cbb57f71ae1614844b6e55170a206d278b3d15fe619c9cfd"
+    },
+    "progs/h_zombiek.mdl": {
+     "bytes": 4920,
+     "sha256": "9b8b3af67bdec6160ecd3880acc072b833886f7fc11d1e64ffcf06184f9ba80e"
+    },
+    "progs/health_100.mdl": {
+     "bytes": 6948,
+     "sha256": "6c6646f6081ab00ed1c309de3b697009c825d64360b06c741a533b718e0ab8d7"
+    },
+    "progs/health_100b.mdl": {
+     "bytes": 23248,
+     "sha256": "d82148af4482e3c0ff07389ebb5b09cdefda373e31105aeb7308b4126b353a97"
+    },
+    "progs/health_15.mdl": {
+     "bytes": 6788,
+     "sha256": "838b0cb6fd11ff7fdf268b1607a1999e5dce0dea11386afe5ff207e6ff734aeb"
+    },
+    "progs/health_15b.mdl": {
+     "bytes": 10948,
+     "sha256": "eb1bb584805aea34a0f0ab846a758cdc359b730e144e141dcd756da23b5831e1"
+    },
+    "progs/health_25.mdl": {
+     "bytes": 7332,
+     "sha256": "ce8260929500cac3b57617345b2c6b5a75e763afdbd10120982e7d7fa55be27a"
+    },
+    "progs/health_25b.mdl": {
+     "bytes": 23248,
+     "sha256": "7aba68839958035319b2167369f3fcd08c9d49140969cff7fb523b7023362e00"
+    },
+    "progs/health_5.mdl": {
+     "bytes": 6164,
+     "sha256": "a8ba7ece01b3cb58b2f94ca20a9f4511871d26ec894b54c04e433f29fc7c3bef"
+    },
+    "progs/key_base.mdl": {
+     "bytes": 54436,
+     "sha256": "fb25488fa2fc16c7c4df260a20fd905a821607a675fd0907a6e65f9d534fd367"
+    },
+    "progs/key_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "2632cb327c1175b351d026e88a4e456c45779a0dcdae01381b24200769c8743f"
+    },
+    "progs/key_gold.mdl": {
+     "bytes": 9332,
+     "sha256": "e93ed2c4263bf7631efcbace2c36ed6f240bfcc2b49491751f6d6ce55db8c098"
+    },
+    "progs/key_medieval.mdl": {
+     "bytes": 58532,
+     "sha256": "0810c558e40c5833c19283eb849ba80ac5dd3499e0f077b724057c51730ee097"
+    },
+    "progs/key_rune1.mdl": {
+     "bytes": 18900,
+     "sha256": "90ac269965d42da0205307eeeaddfa5b282598b5218af8650d2d8854621ca950"
+    },
+    "progs/key_rune2.mdl": {
+     "bytes": 19828,
+     "sha256": "4a6644f0b583c85aa41362fb4533cda5f8f762bd4429e5007b3ab57e5e24ae57"
+    },
+    "progs/key_rune3.mdl": {
+     "bytes": 19700,
+     "sha256": "9b33cc0feed9fc27ea647f6d127941933aa5378b52a3f75b9331714fa9d2ff31"
+    },
+    "progs/key_rune4.mdl": {
+     "bytes": 19220,
+     "sha256": "515534b8fdaa0ef99621f0f7d59d268c0c244562372e23c13e9ce05a44e0a68a"
+    },
+    "progs/key_runic.mdl": {
+     "bytes": 57444,
+     "sha256": "e0e31948c1e172c3c9117a8ccd72900c6ebd7a7e73882ae525dd116230f054e2"
+    },
+    "progs/key_silver.mdl": {
+     "bytes": 9332,
+     "sha256": "dd54032e82de32cf1b78a25f862a82a73e9dc0926d89ca7a4279b45d367a8478"
+    },
+    "progs/misc_bmkdigit.mdl": {
+     "bytes": 3328,
+     "sha256": "1a7f2f762ef3a052a91db7c74cf8d980db47a56685fc61184a15be2152e843b8"
+    },
+    "progs/misc_bmkdigit2.mdl": {
+     "bytes": 3328,
+     "sha256": "2e690ffe1af05f5ad88fe90c180785adeeffdb2b330aa34c6f4fb9885285cd1e"
+    },
+    "progs/misc_bonepile.mdl": {
+     "bytes": 110796,
+     "sha256": "0f8061359681f3c11660e472c517599590447c7631edfe5a36debd9645acdec6"
+    },
+    "progs/misc_book1c.mdl": {
+     "bytes": 40096,
+     "sha256": "92b976437673f56cb890f0e1b90a550ea00939d01ee12b0df0f218b35b42953e"
+    },
+    "progs/misc_brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/misc_braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/misc_broken.mdl": {
+     "bytes": 744,
+     "sha256": "828998b238e1c5471461edc3b9d2d7fada2beab6229272041dff13a94c1d73ec"
+    },
+    "progs/misc_cable.mdl": {
+     "bytes": 57780,
+     "sha256": "bed2cca38ef4cbefa9e645eb5e9ffadffac6ebb4f2ac5f6da4bb8f354de22a48"
+    },
+    "progs/misc_candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/misc_candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/misc_candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/misc_chain.mdl": {
+     "bytes": 231184,
+     "sha256": "845fc3117f7d9860f2d0aa4a398103a13f327516144a96db508189ae1be5788c"
+    },
+    "progs/misc_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "3337f2cfe739c22d50edde7bff18c026d4336bceb207dacf8b0284ab0a5366cf"
+    },
+    "progs/misc_corner1.mdl": {
+     "bytes": 21668,
+     "sha256": "7abf8d5ca497d5e8c8ddcc09c710c0401edb71b11f9de77a2daa81b1267e5698"
+    },
+    "progs/misc_corner2.mdl": {
+     "bytes": 21348,
+     "sha256": "369c874a37ef1da8c9a79432ba2ab9484a5be0df120131b8cbac81e1786adf47"
+    },
+    "progs/misc_deadtree.mdl": {
+     "bytes": 195728,
+     "sha256": "d267db8cfc35b01430590cec643570b38f8df5872c9c3e43df31dc0f3a954e5b"
+    },
+    "progs/misc_digit.mdl": {
+     "bytes": 3328,
+     "sha256": "60f16b89c1e9b8fb8bea0c0aeb96d2dbcfc14a719c130aaa34a581b26e653416"
+    },
+    "progs/misc_doomhelm.mdl": {
+     "bytes": 70104,
+     "sha256": "1b801d032daa163fab361a39631a16c501b86cc9e9b1a52a3f1454e50cdb8c8d"
+    },
+    "progs/misc_dpull_s.mdl": {
+     "bytes": 12900,
+     "sha256": "77fed0a028829fc7120db625131f855faf9b35f97f6ce0591e224bfae0fa78e6"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_fixture1.mdl": {
+     "bytes": 9768,
+     "sha256": "c10980d00e0479f8e65ab633f19ee62ace4c0697c2193f7aea8d266e2be5fc2d"
+    },
+    "progs/misc_flag.mdl": {
+     "bytes": 16052,
+     "sha256": "f2670312a8d16dd16e42fd02a39dfd285e6ffea624e729597b773c86140631d1"
+    },
+    "progs/misc_flame_big.mdl": {
+     "bytes": 244895,
+     "sha256": "09adba1308cdf22d2f07e226cb13a35e51f4d54866f84f41e2074dc7a40371d5"
+    },
+    "progs/misc_flame_med.mdl": {
+     "bytes": 175400,
+     "sha256": "31c94bc48e6c6d6bc31bd14b8e257c4e74d45aaec3a4d5d5bf83587a08ac7c00"
+    },
+    "progs/misc_giantbell.mdl": {
+     "bytes": 74016,
+     "sha256": "0d1b0e150de4ac59c599deae96d6b21e4ceb2300e7d410a1d802385dad99560b"
+    },
+    "progs/misc_heart.mdl": {
+     "bytes": 3512,
+     "sha256": "827ce2bbf2037aa26259901f4152d114cdf38312652e65e53f64ebbad9ea0849"
+    },
+    "progs/misc_impact.mdl": {
+     "bytes": 880,
+     "sha256": "93029307003bd0437071e0a89d0d4c2b699f2cde6ba34242c321cba8243f36b9"
+    },
+    "progs/misc_jstatue_01.mdl": {
+     "bytes": 1057632,
+     "sha256": "c583186f8bd56fd5ac356a8ed34956090eaad6e78506884bd520307e8f5e5698"
+    },
+    "progs/misc_jstatue_02.mdl": {
+     "bytes": 100260,
+     "sha256": "e4f3e702073a7f76ffddb79921a2bbb880d25edc0bdd6a6f115dfebcf99dbae2"
+    },
+    "progs/misc_jstatue_03.mdl": {
+     "bytes": 100244,
+     "sha256": "587cbce564e4da156a0ae20a87bd551046427f894f34959590573ce96fdf5c31"
+    },
+    "progs/misc_lantern.mdl": {
+     "bytes": 28836,
+     "sha256": "d84e36232543a053f2772b1070b221dc23da1b34cd08ea551a982b5e9f168ea5"
+    },
+    "progs/misc_levels.mdl": {
+     "bytes": 35732,
+     "sha256": "7cf9a4c1e556e60dd4e593cad4a2be0b45bea8893d9b5232ecc7febca4bbf5fe"
+    },
+    "progs/misc_lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/misc_lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/misc_longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/misc_madfish.mdl": {
+     "bytes": 84104,
+     "sha256": "30c19dadb42a53c7ccd35f992c5841aee13a86796157ea5e0453a4cb1586a1be"
+    },
+    "progs/misc_mooring.mdl": {
+     "bytes": 6676,
+     "sha256": "29b20cf17c62dddb4f0c1be758add7b15d6b22fd738fd9e2cd7533ac5d5475f8"
+    },
+    "progs/misc_mushroom.mdl": {
+     "bytes": 10804,
+     "sha256": "5570faa6e7828e4e12f568656226b0756a87d633cbdc461af472e0982a88a549"
+    },
+    "progs/misc_oscill.mdl": {
+     "bytes": 50660,
+     "sha256": "cdc96265a646f9e9fb4c1717fa90edb13e42130fadc4dc774b60aeb94b89eac4"
+    },
+    "progs/misc_player.mdl": {
+     "bytes": 562960,
+     "sha256": "83bbcf4cb5858aa9ac03323b461b3e3b09a28f56e212645472219d7d0b0979d8"
+    },
+    "progs/misc_plinth1.mdl": {
+     "bytes": 6196,
+     "sha256": "1ce0b7f49153f717e04436b27863c75f90a73b027c4cb7e36ce094fa037eded4"
+    },
+    "progs/misc_plinth2.mdl": {
+     "bytes": 6164,
+     "sha256": "e06edd50af1748235b251fe6e4217551c58d45c1f73161014dc0e9fd40099249"
+    },
+    "progs/misc_qwindow.mdl": {
+     "bytes": 77168,
+     "sha256": "facf489ac59158a3013118ca196f11a25a543f26559d5b72eef44968aa05008f"
+    },
+    "progs/misc_radar128.mdl": {
+     "bytes": 19492,
+     "sha256": "ef004e28e51e3227121a92432375531fca26d1e44894696f3d2a950fa65aef28"
+    },
+    "progs/misc_radar64.mdl": {
+     "bytes": 19492,
+     "sha256": "b9468012707ad484c1292cbe984c54811cb8fa43542e68e18a52ef93cb37d52a"
+    },
+    "progs/misc_radar96.mdl": {
+     "bytes": 19492,
+     "sha256": "6239d117263f49b79a2a66e62f2dbd6a7f0cd15ce412c1939dd69b4a1d8fce78"
+    },
+    "progs/misc_seaweed.mdl": {
+     "bytes": 16100,
+     "sha256": "dfbd38a439d392870c7c4c7ebea4475827b716004ca47bfa7f13b47daf07d774"
+    },
+    "progs/misc_shard.mdl": {
+     "bytes": 22388,
+     "sha256": "06c126f77ad931084d38f0e04d8f4341a5db3e3fa827e30de7d05bc60afd1c1d"
+    },
+    "progs/misc_skull.mdl": {
+     "bytes": 59892,
+     "sha256": "94600327093fe22acc113b8e89c8863a5548b170c9c9897bd2af8a4ff63beb5a"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 31792,
+     "sha256": "8d39b97460c9967ee36b33ea1ef1e92e89277fc410b44f054c5e06b8dc8a079c"
+    },
+    "progs/misc_spark.mdl": {
+     "bytes": 12672,
+     "sha256": "42afca9aeac1b05590b4821872cb79ebfbb4ee7264e914316d880e13f69c2b41"
+    },
+    "progs/misc_starfield.mdl": {
+     "bytes": 23548,
+     "sha256": "5b3563017939382680228e933a2a87d3edb030e75e65c51fe42c4a6889e42e15"
+    },
+    "progs/misc_stickskull1.mdl": {
+     "bytes": 87900,
+     "sha256": "38e63e10bc351ba5a48dfb6195ac5f78e5d61e67ae851f2ba50ba20255d7a37e"
+    },
+    "progs/misc_stickskull2.mdl": {
+     "bytes": 116364,
+     "sha256": "464fbee370b512d1c8057ea5a1dc3ecff69378474593919f0bbd8970419d69a5"
+    },
+    "progs/misc_tape.mdl": {
+     "bytes": 9240,
+     "sha256": "2b6a08ca3be4dd7a669e5b6d1585276759e1fb0edbe0691dd7ecbc7e41f0b189"
+    },
+    "progs/misc_textbook.mdl": {
+     "bytes": 74212,
+     "sha256": "e17e39efdf252a3da8c0574fdf272a800095671f42e71a17a3733673202dbfab"
+    },
+    "progs/misc_tree.mdl": {
+     "bytes": 120248,
+     "sha256": "888eca3c464ac068c7cdc5d7cf8f67fbcc70eb13c0079202a4f8d347f5f3bcd3"
+    },
+    "progs/misc_tree2.mdl": {
+     "bytes": 404432,
+     "sha256": "f14f3b046b58e5485afd11d396b4d358eb0598ea8cca1cbc6a70a8e629aee3f3"
+    },
+    "progs/misc_tutstatue.mdl": {
+     "bytes": 178480,
+     "sha256": "d178ba96d99b02113fe70d32f1672c1490d5f570aecf11d168e58f1bb7e8c17e"
+    },
+    "progs/misc_xmastree.mdl": {
+     "bytes": 479516,
+     "sha256": "59a89b398caa908ff6dd777cb42d0d7dfde930ac5569fdab4bc4f10dd8137584"
+    },
+    "progs/mon_boil.mdl": {
+     "bytes": 307068,
+     "sha256": "b8a79df258bf71f273dc29887c3782377bf890d43e32b690ebf2ef707eead6de"
+    },
+    "progs/mon_bossboglord.mdl": {
+     "bytes": 401092,
+     "sha256": "6fb5e0aa99fc9269b21e3a7c86e7ed70bf1f7e0150b629a39a4cf6647d0c9a1f"
+    },
+    "progs/mon_bosschthon.mdl": {
+     "bytes": 328244,
+     "sha256": "7fc4005959377598747d3accec535b52c81154b17b00221e2cd5410670223538"
+    },
+    "progs/mon_bosseidolon.mdl": {
+     "bytes": 1847180,
+     "sha256": "e08c763865b25851703f71e973755d5a7b446c8004f7d97c09fab04175373c10"
+    },
+    "progs/mon_bossicegolem.mdl": {
+     "bytes": 632584,
+     "sha256": "2a03c71a0451c389dc29374fa3a465fb0d8e9366309cbaeffb68057c928562ec"
+    },
+    "progs/mon_bossnour.mdl": {
+     "bytes": 200036,
+     "sha256": "732041ff70ec350c664194f90a9545b23b6736e729dd128f4482a0cca3ab7966"
+    },
+    "progs/mon_centurion.mdl": {
+     "bytes": 824572,
+     "sha256": "e638ad3021c5c77a1ad78fd798017fbb7a0ffa49ca2fc4a60570ba00e349d532"
+    },
+    "progs/mon_dcrossbow.mdl": {
+     "bytes": 1335168,
+     "sha256": "b38a7967cf800fdb45f9df9aa717ebc1c069fc8686a8e3e414f1c81d51f81d14"
+    },
+    "progs/mon_deflector.mdl": {
+     "bytes": 300016,
+     "sha256": "2bba37156abcde4ad2e7fc532a92b8139d4fc8041b565cd1e487829dc581341f"
+    },
+    "progs/mon_demon.mdl": {
+     "bytes": 156640,
+     "sha256": "9f1714fe997a78c9d3948e593a73fa3fe5704e11809ba095b8f564fca36b36c0"
+    },
+    "progs/mon_dfury.mdl": {
+     "bytes": 1495580,
+     "sha256": "0cb312b27bc1c9a7f9ac3d8c14e1e0d422d9968d4a9db0853d73185a19d6839d"
+    },
+    "progs/mon_dfury_glow.mdl": {
+     "bytes": 155140,
+     "sha256": "f743168f636c9e56475d73b3f8e139e5391e2abf0da4a6657174a7adc0f74238"
+    },
+    "progs/mon_dguard.mdl": {
+     "bytes": 724744,
+     "sha256": "1babb2976f1f86c2e499d3b8e83f4e4c04e434151bcb96a932a99a89b2bf3699"
+    },
+    "progs/mon_dguardq.mdl": {
+     "bytes": 176648,
+     "sha256": "f2f92ef84411d83c7e8c158f62b1415d8fc6aa56d77f21760dcd3080424cf6c8"
+    },
+    "progs/mon_dknight.mdl": {
+     "bytes": 1124632,
+     "sha256": "437c54ecfed53e34891b981a565c9b4f772c19702e1c099bba5ac40aabbed917"
+    },
+    "progs/mon_dknight_glow.mdl": {
+     "bytes": 971020,
+     "sha256": "22888d6171fc8df336fe686f4ffdfb0683bdb744e59cf81af9484b700666f6cf"
+    },
+    "progs/mon_dlord.mdl": {
+     "bytes": 1142583,
+     "sha256": "fb2ce7f5fbe369307f3eaefe0a74fffb2004657bec058dae50db651bc2fbc70f"
+    },
+    "progs/mon_dog.mdl": {
+     "bytes": 460652,
+     "sha256": "52cf8cb501f4b1ed457961b798eccd86974720af29f559723be82a0886824fd9"
+    },
+    "progs/mon_dprince.mdl": {
+     "bytes": 1022224,
+     "sha256": "aadd9ea12f307f0ef2b600a4a78d73082b8ea2eadd408f1fbe298082f4d03374"
+    },
+    "progs/mon_drole.mdl": {
+     "bytes": 241648,
+     "sha256": "2d5524d75cd52f12b42a5dfdd37bb33af27233394ec60bc234f79545d1cf13b4"
+    },
+    "progs/mon_dsergeant.mdl": {
+     "bytes": 1431784,
+     "sha256": "1affce6e3cbae9b5df1986672030fd869aa020972872767518f18ccc495c7432"
+    },
+    "progs/mon_eel.mdl": {
+     "bytes": 177368,
+     "sha256": "6acb4804e51e7de33404a4519d7f12b2413c921f61e33107345cb111ff156f96"
+    },
+    "progs/mon_enforcer.mdl": {
+     "bytes": 622480,
+     "sha256": "0e32f70f205a74995936d56e22259d1ccde591ed8a533577cd276419c5f60013"
+    },
+    "progs/mon_fish.mdl": {
+     "bytes": 311132,
+     "sha256": "40351e57dec8fad0aa34e5e5da233274e007a3beb80a291c9a2aa40ed43f8f00"
+    },
+    "progs/mon_floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/mon_freddie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/mon_fumigator.mdl": {
+     "bytes": 415072,
+     "sha256": "31bb90976e7489693c68fd6713ed5f1baf9645e3d7871922901dd093e8243da3"
+    },
+    "progs/mon_gargoyle.mdl": {
+     "bytes": 388132,
+     "sha256": "fe8134f2305858519445eb513b22f1f3382a1a6f334cf9549ddf1efe0b88435c"
+    },
+    "progs/mon_gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/mon_gaunt_elec.mdl": {
+     "bytes": 7164,
+     "sha256": "05129692bea7b62f2f5b7285cf133590e9356bfa0f6162ef6e3fc44508b29d8b"
+    },
+    "progs/mon_golem.mdl": {
+     "bytes": 632584,
+     "sha256": "c345c57eca380796f5dbcbdf7df80975c24e856d6d70ed1e9c11678f5d162c44"
+    },
+    "progs/mon_hknight.mdl": {
+     "bytes": 275836,
+     "sha256": "e32a90ca707224a389b7b0d3ecde76220e23f7746c2bc4e6397fe0d3a601844a"
+    },
+    "progs/mon_hknight_glow.mdl": {
+     "bytes": 212112,
+     "sha256": "60c24cb1dceeda2c64efb66e03cb8337717402c8070c0a19e1d9a6b5e0363d89"
+    },
+    "progs/mon_hogre.mdl": {
+     "bytes": 897896,
+     "sha256": "f8e0d054c44cf83bde03ee51ca8eb558dad7da336be8caf1383cf51d5b813da9"
+    },
+    "progs/mon_hogreham.mdl": {
+     "bytes": 979960,
+     "sha256": "d4ffb64b6112d48696002baf1bf8df0c686f404d1523ae409a9d01d237573e90"
+    },
+    "progs/mon_hogremac.mdl": {
+     "bytes": 901388,
+     "sha256": "daeed66878bbe85c45d2415de4270a8526be175ac74734ff55cf9750bf7c4875"
+    },
+    "progs/mon_jim.mdl": {
+     "bytes": 331872,
+     "sha256": "a49a51562fc5875509e39b62de550c4cebba65569708e1f63d0a54a6b8497448"
+    },
+    "progs/mon_jimrock.mdl": {
+     "bytes": 357748,
+     "sha256": "6c7e4a4f9b1b4392cf6e465be50e0a637a2a9b9b44b41e97a62acfc7b889f662"
+    },
+    "progs/mon_judge.mdl": {
+     "bytes": 1184920,
+     "sha256": "4e281291b8b6728bc6801c775defa987698a0f402a3a5553a32cf61865857040"
+    },
+    "progs/mon_justice.mdl": {
+     "bytes": 1287408,
+     "sha256": "bdd6b6ad28da26701dcef14503d148e96251575e04f583bef1f362455ab12497"
+    },
+    "progs/mon_knight.mdl": {
+     "bytes": 474244,
+     "sha256": "b279d87d180d237a71beddad02ecfaa87be42c990b91ee823f15f905fbb19b55"
+    },
+    "progs/mon_lostsoul.mdl": {
+     "bytes": 172216,
+     "sha256": "51c6d042ac9c670926d11743a09b294cbc992204077eae28b7b440570a7b0b4c"
+    },
+    "progs/mon_minotaur.mdl": {
+     "bytes": 669648,
+     "sha256": "3016ee951f60eb90a659c641546bc6aee80b1e2e9500b125c9c1343d625deb54"
+    },
+    "progs/mon_ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "ca0b6aee92201fa3ebeb226e7767c7a0f29495496d86bd384c327ff897b3557b"
+    },
+    "progs/mon_ogrefish.mdl": {
+     "bytes": 560428,
+     "sha256": "25edf562fbf71533ae0102832d92b7e138d056e1f90c9c681e5387659cd3160e"
+    },
+    "progs/mon_pyro.mdl": {
+     "bytes": 415072,
+     "sha256": "11a7efe7358b1477867a1263fd6e13a8531f557d1a8d0e0bfc5a1e9e6eab273a"
+    },
+    "progs/mon_scorpion.mdl": {
+     "bytes": 338288,
+     "sha256": "5d8a1b194cfc741b8dd194694dce305c35b0dca0bdf1c8d96897a085ad0eaf85"
+    },
+    "progs/mon_seeker.mdl": {
+     "bytes": 594628,
+     "sha256": "ab23bfb0c8b22c67b8d4b7b1658b445fb546fcc4f1ddb1f5c4990eb860434f3a"
+    },
+    "progs/mon_seeker_glow.mdl": {
+     "bytes": 594628,
+     "sha256": "122441a3be654d0198ba368ff9fd24d7f3fecb71fbafad6edfe80e3f57103ca8"
+    },
+    "progs/mon_sentinel.mdl": {
+     "bytes": 290664,
+     "sha256": "573efd78767922b2bbb3e5dab2b16cd8f90c2cb1709ecf4a315a141f4df77d09"
+    },
+    "progs/mon_shalrath.mdl": {
+     "bytes": 163336,
+     "sha256": "50b11e859246abf75af63b858d00b436690c9ed02562c0a7a3f434ed350c3a79"
+    },
+    "progs/mon_shambler.mdl": {
+     "bytes": 401092,
+     "sha256": "8f29b2ceddebcb9e69adbf12eb36c3924468cfaa1ff54cea31e6f289ab30e54a"
+    },
+    "progs/mon_skullwiz.mdl": {
+     "bytes": 980064,
+     "sha256": "c7637f2310ae9f173de872ea4aaf4380332f3d8d32782a8523f1d5d0a5ee3e45"
+    },
+    "progs/mon_soldier.mdl": {
+     "bytes": 931376,
+     "sha256": "8a67babdf47ecc69739e067d18b2629814469aec923851bd6c1133feae6ac56b"
+    },
+    "progs/mon_spiderb.mdl": {
+     "bytes": 228508,
+     "sha256": "209ee4dabf0f9b5619408cedcd8eaec7f8d4e48a8e1b51ca667bf5f8fea02dd6"
+    },
+    "progs/mon_spiderg.mdl": {
+     "bytes": 228508,
+     "sha256": "ffac4cf5b2d42df5b8a9674dc87c30ec925d6013d9ff0d29cb109c30047bcbd6"
+    },
+    "progs/mon_steelclaw.mdl": {
+     "bytes": 228508,
+     "sha256": "06fae126b984b1ed7b0ffa029b64e9b3df3a6269f01e8aba4b953bbafaa2c536"
+    },
+    "progs/mon_stinger.mdl": {
+     "bytes": 203428,
+     "sha256": "9d867b8a3d69a94d9a049c6cfcf0fa808b200ea3befe3b2518f1165881b9ad23"
+    },
+    "progs/mon_swampling.mdl": {
+     "bytes": 45332,
+     "sha256": "c7b379fcc17af3fbfaff1976ea8c14e9562093495dac01cd647c50863c4dec50"
+    },
+    "progs/mon_swamplingp.mdl": {
+     "bytes": 45332,
+     "sha256": "f1bd1496b4b9c90493f469bf81c6da0a1697290cd6374db15fd459ebab649cea"
+    },
+    "progs/mon_tarbaby.mdl": {
+     "bytes": 511008,
+     "sha256": "a9b9b6a49090bbf7d7d3a23618c3c21b2123e007488702d96b80531c563cdd4c"
+    },
+    "progs/mon_voreling.mdl": {
+     "bytes": 45332,
+     "sha256": "af233d21d6f0ea66267ba1c562ba223e1077bd07894333327ce12a6202938411"
+    },
+    "progs/mon_vorelingp.mdl": {
+     "bytes": 45332,
+     "sha256": "dadf32a61ef1ec6361606fc7173bab53f6c42e62dea9a3100a2073ffc5afaa58"
+    },
+    "progs/mon_wizard.mdl": {
+     "bytes": 106596,
+     "sha256": "aa93bbe4e7fd1686fcea4d6c49a982bb8b3defea2ca85c3177b86000ba8ba8e4"
+    },
+    "progs/mon_wraith.mdl": {
+     "bytes": 374256,
+     "sha256": "f2ec454f0e2896252204a99b18c16a5e61ae783220503a6b0ec75e149d1b25f7"
+    },
+    "progs/mon_wraith_glow.mdl": {
+     "bytes": 133676,
+     "sha256": "bc630a16b46ae0ef1fba35acaf4e41bc46dee4070305d32e9215692a18ae5705"
+    },
+    "progs/mon_youngone.mdl": {
+     "bytes": 103208,
+     "sha256": "de6f7f98d021ae2839cc81490886e6f29dfa31b5b45216d15ffb7f74edf1eb36"
+    },
+    "progs/mon_zombie.mdl": {
+     "bytes": 381660,
+     "sha256": "2dfc9832316861cff07f1c86da0f8809de95395a9dac718155bdbd06f739acaf"
+    },
+    "progs/mon_zombiek.mdl": {
+     "bytes": 228232,
+     "sha256": "431f57d3241b1253a1346ff1aa2bd7135f67c3e6fd5031140e07a7b4a0e861a2"
+    },
+    "progs/player.mdl": {
+     "bytes": 976432,
+     "sha256": "137eab1a3853f9a6f7f84c05442f7066268cac430bf73053cc7f806555a98925"
+    },
+    "progs/proj_balllava.mdl": {
+     "bytes": 18356,
+     "sha256": "f2a1de49bd215b4c7a1f424f1c644fe5cdb52df3c2d664c24b75cd2f389ae559"
+    },
+    "progs/proj_ballslime.mdl": {
+     "bytes": 18356,
+     "sha256": "d17f20cd8db385b724d58beaac1c3ed6b2597d51d00f1996b8b02bdb8a5e3ba1"
+    },
+    "progs/proj_blord1b.mdl": {
+     "bytes": 11472,
+     "sha256": "6c05b0f8790b77d3362166b2b304379942f56d498ae8fc365dbee6fcd6031f67"
+    },
+    "progs/proj_blord1s.mdl": {
+     "bytes": 8284,
+     "sha256": "5527dd12f00911fb333c2424994c0a95881caa72612d5e8236c8ce75530f6ae0"
+    },
+    "progs/proj_blord2b.mdl": {
+     "bytes": 11472,
+     "sha256": "fce6943e84bac672bf110d986ce2ed1ccb511128cb28508fb6aca53c7655806b"
+    },
+    "progs/proj_blord2s.mdl": {
+     "bytes": 8284,
+     "sha256": "a0d0ac315e46f784c35a0eac902f625e0337e79275b9f02ecb56002848202734"
+    },
+    "progs/proj_blordbeam1.mdl": {
+     "bytes": 12244,
+     "sha256": "e01c569bf66e75acdcbbfdbb50062eb24dd09f0415e6cb79148eab960f6a6f0f"
+    },
+    "progs/proj_blordbeam2.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/proj_blordbolt1.mdl": {
+     "bytes": 7868,
+     "sha256": "2ea0a49a8a75d1174151c36851ae21212b4df2df3473be5e73cc4cf293332d0f"
+    },
+    "progs/proj_blordbolt2.mdl": {
+     "bytes": 7868,
+     "sha256": "919dda70fe618cd37f57ef1e0dbc00b339ed082e2661ca024febee3ed49576f2"
+    },
+    "progs/proj_bolt1.mdl": {
+     "bytes": 1556,
+     "sha256": "890f6cd6faf7c36954185c4566a2cca619e627d5b365f05e1bffc7e12ac00ace"
+    },
+    "progs/proj_bolt2.mdl": {
+     "bytes": 1748,
+     "sha256": "ba4a6ffa3785b0e41c15045df9621a5a33f094eae2161064d472ea939654e229"
+    },
+    "progs/proj_bolt3.mdl": {
+     "bytes": 1748,
+     "sha256": "cf255497525c53162b019fe3df536314c4661a2d270f6bb847fe39a158b7f4e8"
+    },
+    "progs/proj_chthon1.mdl": {
+     "bytes": 65636,
+     "sha256": "92a964527d72ef1c40bbcfe0e915b56df81a0dcc2165ca4be47db44a8d644eb1"
+    },
+    "progs/proj_dguardq.mdl": {
+     "bytes": 12660,
+     "sha256": "ba5cba46edc108572d78e66166f5ed0405a48dcf672e7a569d14a4397f85f285"
+    },
+    "progs/proj_diam1.mdl": {
+     "bytes": 3292,
+     "sha256": "e7cbd736a84791c5234caa14713b3e0f6077409509845ae0b1993f38c2f1e1b9"
+    },
+    "progs/proj_diam2.mdl": {
+     "bytes": 2748,
+     "sha256": "b23586b1d570a9f516f6b83ea0af6ec1d8fe5693f8cd1279b251b031ba142d8c"
+    },
+    "progs/proj_dk.mdl": {
+     "bytes": 5172,
+     "sha256": "e861a125a60c82b88c7b3c23184a1485c967d0e127b4536213b7f46a97a6430e"
+    },
+    "progs/proj_dkgrn.mdl": {
+     "bytes": 5172,
+     "sha256": "820d2dac7255db7220889f6d8c3a2c97a7f77f75cd9ffbec6319b0ee257b3984"
+    },
+    "progs/proj_dlord1.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_dprince1b.mdl": {
+     "bytes": 6644,
+     "sha256": "7bcea6065d9f6c4e8a3a7c8a1dcd61252ff8baee01b7c04ecce0a7cfbc6d690d"
+    },
+    "progs/proj_dprince1r.mdl": {
+     "bytes": 6644,
+     "sha256": "5e3cc794f6b980e5e22adf011eead8768c88dcd84d74be9a8d34caebf33bf2ba"
+    },
+    "progs/proj_dprince2b.mdl": {
+     "bytes": 7468,
+     "sha256": "e81b4f767d1bba042464f1d35314ef4f2d30f7c552aaada2f772aba61fc5d62a"
+    },
+    "progs/proj_dprince2r.mdl": {
+     "bytes": 7468,
+     "sha256": "b967299e12983dacd0fcca1672818281483e6f89746422de285002cb043e1e24"
+    },
+    "progs/proj_drole.mdl": {
+     "bytes": 20796,
+     "sha256": "fbe9acdd31f7be2321df29b6add3d287d4e86ea2581e56ace5d7e9d185e28127"
+    },
+    "progs/proj_drolegrn.mdl": {
+     "bytes": 20796,
+     "sha256": "efbede1f5d565c56a535bb6392b5e638133c99b1df8bf93b1a1918d01c790123"
+    },
+    "progs/proj_eidolonrock1.mdl": {
+     "bytes": 14084,
+     "sha256": "e085fa791a83489e41c19c623ae84f80c7bc5f767cbbf691baa4665d3f85b273"
+    },
+    "progs/proj_flesh.mdl": {
+     "bytes": 19768,
+     "sha256": "8ff3f0f61001ac8e67317e4e01d03d905f15ef4104c141ba07b5ddb0c972390e"
+    },
+    "progs/proj_fleshp.mdl": {
+     "bytes": 10196,
+     "sha256": "3def912801c4b1b9b4c0f8ceea0690241493a5dd5f17e098cd6c37cefd927893"
+    },
+    "progs/proj_fury1.mdl": {
+     "bytes": 6644,
+     "sha256": "ce55af61fbd87b8daeb14151b3f77ac64713c4b53fcca89b2150d7f5cdfe886d"
+    },
+    "progs/proj_fury2.mdl": {
+     "bytes": 5748,
+     "sha256": "deb557248017e92f5501698355577cebb91c0d825b77a79f828589769a41ece7"
+    },
+    "progs/proj_gaplasma.mdl": {
+     "bytes": 2328,
+     "sha256": "dd3b4559cb4e4439ae87255ab2958c6c2cd3796ebbd27aaf1c6abc768ad4f8ad"
+    },
+    "progs/proj_gaplasmagrn.mdl": {
+     "bytes": 2328,
+     "sha256": "ecd2fdf0eb904f8be43c41821b06443d32a581b768ce8f776b07670b49cdd9af"
+    },
+    "progs/proj_gargball.mdl": {
+     "bytes": 18184,
+     "sha256": "b4b6bd7646bf80aa6f481616ba2b531dbccd3568cacc54885ebf020a166dbadd"
+    },
+    "progs/proj_gargballgrn.mdl": {
+     "bytes": 18184,
+     "sha256": "467a44838d83a94d5716c9af6f8c860cd8ec583ddb5f260cb0dd16e9bd04b957"
+    },
+    "progs/proj_gargoyle.mdl": {
+     "bytes": 5748,
+     "sha256": "774f52126fe6598f6a01a032691a36de26a0669e93d47508689d08fe85f46c21"
+    },
+    "progs/proj_gargoylegrn.mdl": {
+     "bytes": 5748,
+     "sha256": "b293b5e8696098e77602eb065f68f8a8e15c82af1c9890d36de48f29afbf43fe"
+    },
+    "progs/proj_ghook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/proj_golemrock1.mdl": {
+     "bytes": 7468,
+     "sha256": "5a2f0435dbcbfea724fe6bd8f6a76296359dbf4d874d15feec82b50a9275da74"
+    },
+    "progs/proj_golemrock2.mdl": {
+     "bytes": 19756,
+     "sha256": "41cc9bc49d6ae2018b7cf5345bbfe52517db2da060fce23fe57300ebcf643f98"
+    },
+    "progs/proj_golemshard.mdl": {
+     "bytes": 8596,
+     "sha256": "4a4a59362f5c5ecc2c4ce56419088982d5ed79a02d3c5b5a49bafd4c21c85e42"
+    },
+    "progs/proj_grenade.mdl": {
+     "bytes": 3508,
+     "sha256": "a7916ab1f9872689a0cfbea62543974b37dae5b3ec7ae3165eecd81c2c0d6617"
+    },
+    "progs/proj_grenadegrn.mdl": {
+     "bytes": 3508,
+     "sha256": "896f7a740acb59351891e752e6cc92725fcc6e26ea4bd5d1eb3219c8443db743"
+    },
+    "progs/proj_judger.mdl": {
+     "bytes": 7868,
+     "sha256": "a12f1f0bf494bc027c43e5aa89e54e055a571226499fbddce0f6b9e2bdb63766"
+    },
+    "progs/proj_laz.mdl": {
+     "bytes": 4724,
+     "sha256": "94e8c7d09857559ad9e5aaf6361b596afbcf100cf0ce8abf0107318af28c7943"
+    },
+    "progs/proj_lazblue.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/proj_lazgrn.mdl": {
+     "bytes": 4724,
+     "sha256": "d07d736b788aa512a5e57f39596c187644e69491026382800994378d3e849a6f"
+    },
+    "progs/proj_lightning2.mdl": {
+     "bytes": 11860,
+     "sha256": "c9cebc8d6f4836e7c302d51d0f942fde3da0960dae38733ccc3a851776e71520"
+    },
+    "progs/proj_minoball.mdl": {
+     "bytes": 18184,
+     "sha256": "756d8e9ecd60abc23954a792833c565ee1b5c905106ad2bd98143f56b0410391"
+    },
+    "progs/proj_minoblood.mdl": {
+     "bytes": 8284,
+     "sha256": "badd72734b86dd9bc11c5469bef944b6aea6b84071b07b44703c1ca62dd4dee2"
+    },
+    "progs/proj_minoplasma.mdl": {
+     "bytes": 8284,
+     "sha256": "cd79d0dce08293ded22b08b3a7134d8e52fc4cff10e07ee691e6ab53011a9ea9"
+    },
+    "progs/proj_minopoison.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_ng.mdl": {
+     "bytes": 1364,
+     "sha256": "cff312dd07f629847dd5e37b6ab00243d51ff7e40fc795f3612e68614cfbbe24"
+    },
+    "progs/proj_ngred.mdl": {
+     "bytes": 1364,
+     "sha256": "a1ec22733cc292a470c23990b8d0929bf5ee88844190d7174d9053109443d0dd"
+    },
+    "progs/proj_nour1.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_nour2b.mdl": {
+     "bytes": 14084,
+     "sha256": "9c7650dba595e8f8b2bacf3141252a5a2917e0204d3326661d6b9608fc8df2b3"
+    },
+    "progs/proj_nour2p.mdl": {
+     "bytes": 13152,
+     "sha256": "4051fc3dec1155a9efbc6bc5aab947447cebff83bec38d8c1e43dd1bd51f4611"
+    },
+    "progs/proj_nour2s.mdl": {
+     "bytes": 7468,
+     "sha256": "285570bdd658dfed133399c16f1586e2b2389f537a9d4b54d2dd5c1f8f6f1aa9"
+    },
+    "progs/proj_pgplasma.mdl": {
+     "bytes": 13152,
+     "sha256": "3c04f32bbf6f0623fc4101a31a0ce2d40c93354430433d91c2caed263284531e"
+    },
+    "progs/proj_plasma.mdl": {
+     "bytes": 4724,
+     "sha256": "6c4399ddc7653a9aa7834162d38dce6368dc271fec46a7830b73939351d7142a"
+    },
+    "progs/proj_plasmagrn.mdl": {
+     "bytes": 4724,
+     "sha256": "b2941e69d90a5e97c98a03a98bd52c4e047aa23dd2a1abd9ab6d3938f595732f"
+    },
+    "progs/proj_ringblast.mdl": {
+     "bytes": 135704,
+     "sha256": "e6de9bfd15db4bbf16fdd41b50204c5090ce09adbe132b1453435d3c8646cb4d"
+    },
+    "progs/proj_ringshock.mdl": {
+     "bytes": 18928,
+     "sha256": "f1a0a77edc79f2466b866a5486b29f92b696368137eb7eff9b137b6b66d65952"
+    },
+    "progs/proj_rocket.mdl": {
+     "bytes": 7812,
+     "sha256": "52d549b217c6f34e1d68248899ec5f5f550ef729929910e5953e114a53b3c251"
+    },
+    "progs/proj_rocketgrn.mdl": {
+     "bytes": 7812,
+     "sha256": "313f381553df0d8468ccb981441bf415130c9c730377d877e397511b8cc864f7"
+    },
+    "progs/proj_scorpion.mdl": {
+     "bytes": 6612,
+     "sha256": "1a2fa47a30a7e8026bacefa1f52580a04e10c48571318effab3e0623ebcc919e"
+    },
+    "progs/proj_serg.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_shal.mdl": {
+     "bytes": 6644,
+     "sha256": "dc62e9641d1328b1cfd20ac4f4df7e56b2f42bd40a22eea186f2784d1f5bc4ba"
+    },
+    "progs/proj_shalball.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalegg.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalgrn.mdl": {
+     "bytes": 6644,
+     "sha256": "6dfdef0a204aded86ef24730985f13acc5076d1bbb4b9ec1140b7333a70f4d0e"
+    },
+    "progs/proj_shalhome.mdl": {
+     "bytes": 8632,
+     "sha256": "e882b1dc5d01882f429b3a88f752431d3b38dad297861209b589330e3507f37e"
+    },
+    "progs/proj_shalhomegrn.mdl": {
+     "bytes": 8632,
+     "sha256": "d84be851bd87603186bf907506eabb9ce110c5a265c1cc884d18923361fdf4d9"
+    },
+    "progs/proj_shalshell.mdl": {
+     "bytes": 7468,
+     "sha256": "8c1591cc767fadabad655bfaf3a80362b264f51e0a1be67476b9272c2401afbd"
+    },
+    "progs/proj_shamlit.mdl": {
+     "bytes": 35240,
+     "sha256": "787c23ca986d469080879953e49b193cf0b2d22dff050a1d781ba039fcc594e4"
+    },
+    "progs/proj_shellcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/proj_shub1.mdl": {
+     "bytes": 18932,
+     "sha256": "c1a04846b791a123ecb367f11b35f4c1cc1e7e62e1d0f62ff1dd75978a712495"
+    },
+    "progs/proj_shub2.mdl": {
+     "bytes": 32860,
+     "sha256": "3d22df8151caf23c1ad7f3e28f83f97ca7503164977f1994dca2cc2ee54f84b9"
+    },
+    "progs/proj_skullball.mdl": {
+     "bytes": 9984,
+     "sha256": "41b3c1225070dcfca79f1bf19a2833e3d68144945fba51c8ce44d8029379906b"
+    },
+    "progs/proj_skullwiz.mdl": {
+     "bytes": 33588,
+     "sha256": "ff00ce3fbf9d0d55f6488a3a0a6bf15d2105b6e94489eec296a5851bf9f4f890"
+    },
+    "progs/proj_skullwizp.mdl": {
+     "bytes": 33588,
+     "sha256": "45fe8396037d88852d3e6937749bade4ef7c00d3c8240eeb0ecba4b56e831df3"
+    },
+    "progs/proj_smoke.mdl": {
+     "bytes": 244,
+     "sha256": "816e888f8242af86812bd581c9e93212c28f108699b70eb10d3e025f27a2818e"
+    },
+    "progs/proj_sng.mdl": {
+     "bytes": 1396,
+     "sha256": "b2a8656aee7ff508737afe1fdbf1a93d6958b33a0c31bae247a3979c616bdfe1"
+    },
+    "progs/proj_spider.mdl": {
+     "bytes": 7468,
+     "sha256": "76be6023b50a3b57c73f08c5758a693098ce8762eb92b55540d8bff2680fde4d"
+    },
+    "progs/proj_swampling.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_voreling.mdl": {
+     "bytes": 7468,
+     "sha256": "ab16a7fc8bf36827f4944ebe6919876acb5b2eaf869ff59f89ed237565a7ca9a"
+    },
+    "progs/proj_wiz.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_wraithball.mdl": {
+     "bytes": 22284,
+     "sha256": "24d62690c6347f9ab71ef5900c70d256346c2dfdc26e5488c3b91f220224c923"
+    },
+    "progs/proj_wraithbone.mdl": {
+     "bytes": 6612,
+     "sha256": "8fa994dd2c7a5e9d7140ae394d07d368d083f4cee6808f6d9d026ec464804503"
+    },
+    "progs/proj_wraithegg.mdl": {
+     "bytes": 9984,
+     "sha256": "5b888e26f90cfe26800cd50d422b4ef75487dde61d63fd34965506591b326a8f"
+    },
+    "progs/proj_wraithpoison.mdl": {
+     "bytes": 6612,
+     "sha256": "02a06fdccb8f7ba595ea71f227e5b256995e782bcc9ce75bcb85a31ed0333256"
+    },
+    "progs/proj_wraithshell.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_wraithtrail.mdl": {
+     "bytes": 24544,
+     "sha256": "23ee065ea4a542ee7348d9bc08e052ffca4e272418b81937105d14730aab705e"
+    },
+    "progs/s_bookrune1.spr": {
+     "bytes": 1140,
+     "sha256": "b9fc52d2ca728fffa4c282d818b68aeec3555a0dbad3cd1507199d534db1f047"
+    },
+    "progs/s_bookrune2.spr": {
+     "bytes": 1140,
+     "sha256": "400a620928e3581891e8a71b338c8a53b6387e0acdc3fda3f10ae27596ae6bbc"
+    },
+    "progs/s_bubble_blue1.spr": {
+     "bytes": 1140,
+     "sha256": "27cb0d1f52e3ecd4b7ae0d9dc96078a7554bde09839f1a2ee2d9772ac5d67981"
+    },
+    "progs/s_bubble_blue2.spr": {
+     "bytes": 1140,
+     "sha256": "d540bb04a7835ec3bd7490904fbafde0f3aa64ba559bb6bd99ab538568ec0cae"
+    },
+    "progs/s_bubble_brnd1.spr": {
+     "bytes": 1140,
+     "sha256": "43591346d87a547454b387220b3c32693e7f1563b6ae4152ff7ee96c24936b84"
+    },
+    "progs/s_bubble_brnd2.spr": {
+     "bytes": 1140,
+     "sha256": "2f185b37bd1cd5a8d6b472885469dbdb3f1b0fdeba2a6d620de09b17646b4fc2"
+    },
+    "progs/s_bubble_brnl1.spr": {
+     "bytes": 1140,
+     "sha256": "370ed3a9f77291522c31ac1d0ce414078d9b3eb40a9157c08ad5cf87d6428897"
+    },
+    "progs/s_bubble_brnl2.spr": {
+     "bytes": 1140,
+     "sha256": "1b3d4f0ac00fa7cbce076d334f4b210b9059afbf2c4b07a0e98e88fe57356351"
+    },
+    "progs/s_bubble_grey.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_grn1.spr": {
+     "bytes": 1140,
+     "sha256": "efa8692bb74428af2753b415f8f08edbfc2b2cbe75cc59f6545985d289d6016f"
+    },
+    "progs/s_bubble_grn2.spr": {
+     "bytes": 1140,
+     "sha256": "3062ba1064da37ecf7dad074a9b0437352865fa43aecf783e4afe8a6c8c104c2"
+    },
+    "progs/s_bubble_pinkyel.spr": {
+     "bytes": 312,
+     "sha256": "5376726ffdf2132d3ab712ba23b408e8068500485f11adff85d0fd90c08248c6"
+    },
+    "progs/s_bubble_purp1.spr": {
+     "bytes": 1140,
+     "sha256": "2e4b7b23b08b6e89d2dc46f26b12b9ad1ee8f91ea868aeb9916d2adb42e00b75"
+    },
+    "progs/s_bubble_purp2.spr": {
+     "bytes": 1140,
+     "sha256": "ae21a26ad7897b9c5d201a1eb248e1358ee84eafdbfd899d679558e9aa5a1a66"
+    },
+    "progs/s_bubble_red1.spr": {
+     "bytes": 1140,
+     "sha256": "2a52f2c4dfdae381deeca608e5d007afe9dc245bbe16fea88c88f39c10ff7dc6"
+    },
+    "progs/s_bubble_red2.spr": {
+     "bytes": 1140,
+     "sha256": "fffcc0e03f9acc75e05636ab67f5f647568c81d0bcf4623e64d487c04d9cd5eb"
+    },
+    "progs/s_bubble_wht.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_yell.spr": {
+     "bytes": 1140,
+     "sha256": "9dcce864ad255b17d7d45e5c5531114f6a66c4e9cb549fc8b31aef0af5a9157f"
+    },
+    "progs/s_burst_flame.spr": {
+     "bytes": 22128,
+     "sha256": "66511ada8a299b0882e2939c09d3fb726d3ce52ecb93a884584a9ce11915a6c0"
+    },
+    "progs/s_burst_flamedp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_poison.spr": {
+     "bytes": 22128,
+     "sha256": "d8245e0460efc4e939a187912126f44422c39b1fe4b553c2c15da91833e8549d"
+    },
+    "progs/s_burst_poisondp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_burst_steam.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_dotmed_blue.spr": {
+     "bytes": 1140,
+     "sha256": "0b3160c5a4ae42216ddb7aaa7ae4726f6b2507c914328abe3c69f2d12fd921f8"
+    },
+    "progs/s_dotmed_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "6e28b69544f8aa13ccbb9a66893e4ab86b83639ee3f81dbbe1b94290ca9b03ef"
+    },
+    "progs/s_dotmed_grey.spr": {
+     "bytes": 1140,
+     "sha256": "77c226763e90a54b4d6835bd877c08c501605e516e64177c915c422e7b36c207"
+    },
+    "progs/s_dotmed_grn.spr": {
+     "bytes": 1140,
+     "sha256": "d1a9800a8b5cad01fa1dc93e57162e9960c4a8478e7e427d66cdbfe6a6797266"
+    },
+    "progs/s_dotmed_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "6113140f371b08cda9addcf68282c1fc16692da7498fa2fdfe2b99662e345d67"
+    },
+    "progs/s_dotmed_purp.spr": {
+     "bytes": 1140,
+     "sha256": "8b2cfa67ac86841f59409e184b4f3a253218e5930a5e3f241caef39dc1baa8de"
+    },
+    "progs/s_dotmed_red.spr": {
+     "bytes": 1140,
+     "sha256": "4ae92a280e0df01c0acd0a904214af485bb60919e5ded4573aa12f86875182d4"
+    },
+    "progs/s_dotmed_tor1.spr": {
+     "bytes": 1140,
+     "sha256": "eddd46a4818dfa92a9817df82e893d6bf6513160164a74b95bdd42fb7cac2f75"
+    },
+    "progs/s_dotmed_tor2.spr": {
+     "bytes": 1140,
+     "sha256": "dcb87897de0f54a6d8f78e9194a15c11261eb88455f058b334f8648a363159a9"
+    },
+    "progs/s_dotmed_yell.spr": {
+     "bytes": 1140,
+     "sha256": "e6b72aac439291d7719ee78d9520c1a1def36212ac7f61ba333fa87d5265c63f"
+    },
+    "progs/s_dotsml_black.spr": {
+     "bytes": 632,
+     "sha256": "2ae7fa13584d12f04b337fbbd774e74fbe54a6fcbd354239e97fecce931bd377"
+    },
+    "progs/s_dotsml_blue.spr": {
+     "bytes": 1140,
+     "sha256": "c0149109ae73a72da49bfaf9ba00cf2edadbe0f053928d09319083e6247883ad"
+    },
+    "progs/s_dotsml_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "f95fe813ecce2c69d2b72e5bf870d045037519c89f3da9a300e7453754cd1503"
+    },
+    "progs/s_dotsml_gold.spr": {
+     "bytes": 1140,
+     "sha256": "3833e80c32da39063b5069638ade52c4aee51b7db7206b4911cb48f321e25bdc"
+    },
+    "progs/s_dotsml_grey.spr": {
+     "bytes": 1140,
+     "sha256": "2e16d9ff8ceca2994a609703f405b1efbb7b49e02c8dbb9e77d0cdcaf3318b98"
+    },
+    "progs/s_dotsml_grn.spr": {
+     "bytes": 1140,
+     "sha256": "a2735123addacfa03f2666969e476af0d9f1cfefbef75a7ac9599d48f86226b1"
+    },
+    "progs/s_dotsml_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "ebf62caae17163587aaa3652300f1003c008ed21041b838a14cfff7672f87d90"
+    },
+    "progs/s_dotsml_purp.spr": {
+     "bytes": 1140,
+     "sha256": "476042db782f7f81cb53d91e9518881f28eb34d3a2a535c11d9c22f65518bce4"
+    },
+    "progs/s_dotsml_red.spr": {
+     "bytes": 1140,
+     "sha256": "94c0403ee7f1e6f6c4d6bc9b99e73e48143845fe35d0d6b3de246842241b12cb"
+    },
+    "progs/s_dotsml_wht.spr": {
+     "bytes": 1140,
+     "sha256": "7ac2d5b9b1e14a1799b951ace16bcc1addb7fefc2470dec23ef2ca110a934bf5"
+    },
+    "progs/s_dotsml_yell.spr": {
+     "bytes": 1140,
+     "sha256": "686f220b937040b91b6ff4f05efd41525d40eb80a61ff8138809d550bfa99959"
+    },
+    "progs/s_dripblue.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/s_dripgreen.spr": {
+     "bytes": 60,
+     "sha256": "805935ef90e14eda0f0ec89cc7e03acf52df768eb9e09140629bc1067a658774"
+    },
+    "progs/s_dripred.spr": {
+     "bytes": 60,
+     "sha256": "2dc81cd44438e124dedef0b656c31a066b7879940fcdbc39a0cfd57a6d2985e5"
+    },
+    "progs/s_dripsplblue.spr": {
+     "bytes": 828,
+     "sha256": "6b960ccc7a877bf2b4b67467400c0eaa1bb88d8c8a524458b9bf8d1aa1a6e29f"
+    },
+    "progs/s_dripsplgreen.spr": {
+     "bytes": 828,
+     "sha256": "397ac392598027c27240d71079f79eb9c90306724bc54c5d9854e14939059b6c"
+    },
+    "progs/s_dripsplred.spr": {
+     "bytes": 828,
+     "sha256": "268b48b87a0f352b671c04a1f7325af43372578a6d73269356389280eb7ef232"
+    },
+    "progs/s_exp_big.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_exp_electric.spr": {
+     "bytes": 5256,
+     "sha256": "ed01b728b6656a68acffe258d644712eba3b786434ab6b3e6d90434031e90d96"
+    },
+    "progs/s_exp_ice_big.spr": {
+     "bytes": 164076,
+     "sha256": "bf7317d811349602db7a020da3e77065ffd8158a3104e83ddca3b166566df18c"
+    },
+    "progs/s_exp_med.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_exp_plasma_big.spr": {
+     "bytes": 213288,
+     "sha256": "fe99a489e169ccf56f0412c2e83a7c5aea7b75b7cee0501402c62fcbd7ca969c"
+    },
+    "progs/s_exp_plasma_small.spr": {
+     "bytes": 53544,
+     "sha256": "555e39e88cedaf9e9dd1215ad1325b32019a6bf2654d53736b1f362506548150"
+    },
+    "progs/s_exp_poison_med.spr": {
+     "bytes": 72892,
+     "sha256": "60b7a8c194f3a6cd2241edd6223ac1da1f57811d7f5416216c70a2797d1baf20"
+    },
+    "progs/s_exp_poison_small.spr": {
+     "bytes": 53544,
+     "sha256": "2a54104dec9381afe338574d66bcc19bd2776caa0d46031c743cd24782098d3f"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "a9476d95ea10fbd2317c174272864efa4bb6e939893f3a3de520aeea3e3522d9"
+    },
+    "progs/s_flamemed.spr": {
+     "bytes": 43324,
+     "sha256": "3c645e305673693089fe48cc7a22f694eeaf7881cfc94ff7b1c4b05b718342cc"
+    },
+    "progs/s_flamesml.spr": {
+     "bytes": 21820,
+     "sha256": "5e60165461c34a3a25cbe6b0bb5e36131bb4a81fef384f1db4a7236f30e7ba95"
+    },
+    "progs/s_flametiny.spr": {
+     "bytes": 11068,
+     "sha256": "9d2c0af6139f3d194e73dbcb7880aa0a6f2a04019f94818ce9844691399b551b"
+    },
+    "progs/s_judgemagic.spr": {
+     "bytes": 12564,
+     "sha256": "6d08d5ada6bac219927edb39a93302f98b7b1a357e6648fc1abb49fd5cc3bd4c"
+    },
+    "progs/s_marsh_med.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/s_marsh_small.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/targd_hull2.mdl": {
+     "bytes": 3380,
+     "sha256": "520c82906942d582c6b64da4dca32ca8ed236694607c3a19ec71b89136e0c757"
+    },
+    "progs/targd_massive.mdl": {
+     "bytes": 17076,
+     "sha256": "099ed67733ea3a461c2247d6f07d3dadcc5a6968bcd6a03398507c653d174395"
+    },
+    "progs/targd_short.mdl": {
+     "bytes": 4788,
+     "sha256": "c883300477d3978469aabc35ef3969c14645c1111997c64452634fc8b4a978e1"
+    },
+    "progs/targd_tall.mdl": {
+     "bytes": 4788,
+     "sha256": "bab77599f9cbbe1cf0856a642612ae30b08fed9ae27a209abda30f6dc8c07129"
+    },
+    "progs/targd_wide.mdl": {
+     "bytes": 17076,
+     "sha256": "d40a00625196f67fe26f3611cd91dd33484ddbf3db273766f8a5fac38db07b07"
+    },
+    "progs/trap_pendlong.mdl": {
+     "bytes": 44900,
+     "sha256": "62d3b86fea6e2336dfc5c7b93514e096eba05992a3bd3e0c6571e4c4a27be684"
+    },
+    "progs/trap_pendshort.mdl": {
+     "bytes": 44900,
+     "sha256": "efb3e395093e34d7b16c92ed73abb199a28d0bc653522c13d4e720030f547713"
+    },
+    "progs/trap_sawblade.mdl": {
+     "bytes": 28716,
+     "sha256": "759bd7e1f7629b4d87ecb9e53a9f2d66e3e81b9103bc4eab3f85bd598eba36f6"
+    },
+    "progs/v_ghook.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "5b6b84edc6e6c58128a6e830ec35424cc83e69fab7b1337c4c681d8d0ed81e74"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 48964,
+     "sha256": "d073c7fad7dee2c4664aa401d744024b623abcd65e60a4c7066721b988838aff"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 54940,
+     "sha256": "c0a6b7d9664b0ab5a0c77732b22592dedfefbf65c624c05bec7aa8d60835f74d"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 39668,
+     "sha256": "78fc36ddbd33fb77192ef100547f1a1a0f70a38fdaac7094df67f2df33ca9237"
+    },
+    "progs/v_shadaxe0.mdl": {
+     "bytes": 97860,
+     "sha256": "598f555a854590a749eee83870a869ebfa8dfd3c84ad447b7fe3fb796ea1da80"
+    },
+    "progs/v_shadaxe1.mdl": {
+     "bytes": 97860,
+     "sha256": "2ffbb3026a21d70a73a091222cc4f2ea2ba6abd706fbffc276f027b9475abfaa"
+    },
+    "progs/v_shadaxe2.mdl": {
+     "bytes": 97860,
+     "sha256": "cd2a7a188f73c5b841183885663470c53c3af5646491f44811a4a0f192381ed7"
+    },
+    "progs/v_shadaxe3.mdl": {
+     "bytes": 97860,
+     "sha256": "b1c0dd11ce314003de5051f8a3b9581ee3eda5ea347d3d3371eea43051820197"
+    },
+    "progs/v_shadaxe4.mdl": {
+     "bytes": 97860,
+     "sha256": "81108f8b2484d24e54e9ab3ee5b707be5ea28adb142159412aa773ae01e593c1"
+    },
+    "progs/v_shadaxe5.mdl": {
+     "bytes": 97860,
+     "sha256": "0d3ca1664ee82ab2aed6261c262fdc455db981ecd2d62371595e520756d7bb22"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 22260,
+     "sha256": "bf79b703708665b9e65556bf68c0fe9d177097b2b96b11563d7b8bf84485a81b"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 22764,
+     "sha256": "5a51ba87bcdf37463bb8f34dd7259ea2be54d540fbc59798bb62dc24b2d3e777"
+    },
+    "progs/v_shot3.mdl": {
+     "bytes": 77868,
+     "sha256": "5b08bebaeb2fa054e6bb37d51c716cfac0e4da843b0db158a4a9769fa04ad13f"
+    },
+    "progs/v_zershot.mdl": {
+     "bytes": 62604,
+     "sha256": "4173bb2b84f9adce1957a87251cca591d968c3a54e801b170a87aae82539a2b1"
+    },
+    "progs/w_backpack.mdl": {
+     "bytes": 138832,
+     "sha256": "78d86e7bc605746990a1b10644b12542f3380375693d4fb015884e42269314a0"
+    },
+    "progs/w_blueflail.mdl": {
+     "bytes": 17236,
+     "sha256": "3b645ebcb5d2249c9cf904e17006b85aa05963efda33f45f5b6f6fc3ea188d26"
+    },
+    "progs/w_chainsaw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/w_dcrossbow.mdl": {
+     "bytes": 14388,
+     "sha256": "52b14c48ec77acb261f18e1d7903e360eb96acb5c22a0702dfde90c66b103064"
+    },
+    "progs/w_dfurysword1.mdl": {
+     "bytes": 8916,
+     "sha256": "16521de90d0e71090ef4e6b5904252f3ae2d4a38ebe99eff9dc758ea009b0f90"
+    },
+    "progs/w_dfurysword2.mdl": {
+     "bytes": 8916,
+     "sha256": "2e42b37254cf8d85b098e58143fd77d86bed2f3568f630196326841298d07187"
+    },
+    "progs/w_dguardsword.mdl": {
+     "bytes": 8404,
+     "sha256": "74b884b8fd0a785fc2c1dcc29428b8d4c8725de6963bccf7ec80c396e002fa38"
+    },
+    "progs/w_dknightsword.mdl": {
+     "bytes": 8404,
+     "sha256": "1e6729ae15dd1520fff7f4c1c30260c35b637bd0b23b8fb3a5a476b175a39165"
+    },
+    "progs/w_dprincesword.mdl": {
+     "bytes": 19296,
+     "sha256": "89e5ef1382e980b68e812f7e8f6a9b6fba34af42bb2def457b7a2f6f8d7388b7"
+    },
+    "progs/w_enforcergun.mdl": {
+     "bytes": 42612,
+     "sha256": "fbbfd121a3d085d654aab512cfebb0b6890daf3c403f25ca372edc3c53039375"
+    },
+    "progs/w_hknightsword.mdl": {
+     "bytes": 20504,
+     "sha256": "a8dffdc9e400d45fcea617255a8731d752cfa83df40b923128d5dbae6839492c"
+    },
+    "progs/w_judgesword.mdl": {
+     "bytes": 199388,
+     "sha256": "c822984ba5a12948ca389f4b8536c3aa6644993242362b10ac7f6ff2e2332590"
+    },
+    "progs/w_justicesword.mdl": {
+     "bytes": 264928,
+     "sha256": "0fc111a637bdaf5372c02c53439497c2adfc0914845b947ecc9ad70ace1e1b3d"
+    },
+    "progs/w_knightsword.mdl": {
+     "bytes": 14328,
+     "sha256": "4740ee2b171380cd9481ba07f284fe720c5b49b0980dc19cb145b2356205fc0a"
+    },
+    "progs/w_ogregl.mdl": {
+     "bytes": 8260,
+     "sha256": "8071cb814b6158c8af563494687e3994192818ccc2aa80f4766bbf6912d559ee"
+    },
+    "progs/w_ogreham.mdl": {
+     "bytes": 29996,
+     "sha256": "11c1ec322889a971b7f930a7c653f13e69714e6de77b7afa4ded1fdec39145de"
+    },
+    "progs/w_ogremac.mdl": {
+     "bytes": 29324,
+     "sha256": "2f9086da6b43becab1d54e47bcb299421b1bdc1e1e71c41e581b367a75f52919"
+    },
+    "progs/w_skullbook.mdl": {
+     "bytes": 25580,
+     "sha256": "e99379e980169501931eb029f36d05b41ba52f8597a6022bf195b08dba88c70e"
+    },
+    "progs/w_soldiergun.mdl": {
+     "bytes": 36120,
+     "sha256": "9c89a19d7c5fa69783d8bcf59b46b18a0c80c37e280b18731564952faf1d6523"
+    },
+    "progs/w_zombiesword.mdl": {
+     "bytes": 14328,
+     "sha256": "e4ac73fc149fa581e64fb5f2016ce58c99ab1c9a76502ede78a525ab7f344b0c"
+    },
+    "sound/ambience/bell_ring1.wav": {
+     "bytes": 61586,
+     "sha256": "b9169a48fd032d7c2b0cadb61540ac5db42ca6384cb2c74818bd46bae3fc7db1"
+    },
+    "sound/ambience/bigmachine_loop_02.wav": {
+     "bytes": 92760,
+     "sha256": "4d6dd03883ac4462c7f1741c022a3e8fd9e2c65cd54d5d126f58c00b3bfe7df3"
+    },
+    "sound/ambience/chimes.wav": {
+     "bytes": 250476,
+     "sha256": "d1060cd75d8a520b748047790d33c9a4ab5fd626330ebf1242d318d308c165db"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/distant_gears.wav": {
+     "bytes": 72502,
+     "sha256": "760d34131249ff3c4bccdab0cd3df69874728a6db3e1b4545177e5ce381e5e80"
+    },
+    "sound/ambience/drone6.wav": {
+     "bytes": 36820,
+     "sha256": "ab0cc1d617b06169d20b42bddc31078c0c7a1b8b15793fe6cfea6dbc96b4129e"
+    },
+    "sound/ambience/fan_finish.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/fan_loop.wav": {
+     "bytes": 288110,
+     "sha256": "d7459b4f1087aa1e002f41fc0274e4cb2f313dff5af2eecaa9de5225bcdcd729"
+    },
+    "sound/ambience/fan_start1s.wav": {
+     "bytes": 96044,
+     "sha256": "b0bad8ae3cd81dc4bbd76591e29f9c43610cb6e0311d4822213e400a6b99dd9f"
+    },
+    "sound/ambience/fan_start2s.wav": {
+     "bytes": 192044,
+     "sha256": "6716a803f246e44416fc414ca2f51744fc1ed79178f79fe3baf7a986c820c020"
+    },
+    "sound/ambience/fan_stop.wav": {
+     "bytes": 192044,
+     "sha256": "ee8607922387eeb594c18096ef6dd4003990a5fe47414dee331921f6d03be6b7"
+    },
+    "sound/ambience/fire1.wav": {
+     "bytes": 47906,
+     "sha256": "c1370a7c177aa21de219578cc64716bc800007e2ac86ae106affac01f8edc470"
+    },
+    "sound/ambience/flames1.wav": {
+     "bytes": 132406,
+     "sha256": "8ac99a7ace2ec9cc98a38fd5777973eb484e9193cf93dfcd6a51ea4f0f9d0f00"
+    },
+    "sound/ambience/flames2.wav": {
+     "bytes": 132406,
+     "sha256": "31e76d131cb4ad3c0602e2559c949feb7a8749c639363f1fd7df53136616fdd1"
+    },
+    "sound/ambience/flames3.wav": {
+     "bytes": 132406,
+     "sha256": "b4008d1da182bc0886f8bad53e5a700d8e04050920aa27ceb0922be938eb7c96"
+    },
+    "sound/ambience/flames4.wav": {
+     "bytes": 132406,
+     "sha256": "222222e080566c899a48df9e40006d0ee36575c03250c44845fb10a94c5cead9"
+    },
+    "sound/ambience/gargoyles.wav": {
+     "bytes": 136816,
+     "sha256": "16f09404b6043aaacb4b6b2bb00143ab72b5e185f02e610d780ea7d311d2df6c"
+    },
+    "sound/ambience/gearopen.wav": {
+     "bytes": 49708,
+     "sha256": "39b73c8ada1b06c7ba07099447b9b0d75911f08df09ced3826bcff136af5b0ee"
+    },
+    "sound/ambience/generator_gas.wav": {
+     "bytes": 529314,
+     "sha256": "6710075453fde424951171823e87f3711d53fd434149ddecc14a14ce721de04a"
+    },
+    "sound/ambience/ind_lift1.wav": {
+     "bytes": 158906,
+     "sha256": "c722fa19c7851d2c7b4307489911b885527e31fd3e4de44d5a184bd786714049"
+    },
+    "sound/ambience/ind_lift2.wav": {
+     "bytes": 156008,
+     "sha256": "c404881a9758f839fd055dd69a82f04bf7e5d5b98538a4a87b2ee741d8b4956d"
+    },
+    "sound/ambience/light_hum1.wav": {
+     "bytes": 100022,
+     "sha256": "cb2f04b81297621ffddbfb028dc5021a665e3285deb7c80757a47add8294f032"
+    },
+    "sound/ambience/liquid_bubble.wav": {
+     "bytes": 129688,
+     "sha256": "838ec1e72b2c433408a342a48518987edcb2124932eeb477d59653540b13d6ea"
+    },
+    "sound/ambience/liquid_burnlong.wav": {
+     "bytes": 710182,
+     "sha256": "9c9c77941f88416e3f20dfc4f028cc6c9719dd7f58a15dfc6124f1bb5a17f61a"
+    },
+    "sound/ambience/liquid_burnshort.wav": {
+     "bytes": 89464,
+     "sha256": "4ea16997389f1aa35549869a338f2093f40d14df030c381a7659cc7e3cbf8bfc"
+    },
+    "sound/ambience/liquid_drain.wav": {
+     "bytes": 220464,
+     "sha256": "e86a6012c8fc3a795791fc344ef636bb1854a602cd609e2df751531e89277cf9"
+    },
+    "sound/ambience/lowboom.wav": {
+     "bytes": 666640,
+     "sha256": "ad591a6f574f48e654e32dacee6b7d862df8b47e20ef116f84415ad9aa515559"
+    },
+    "sound/ambience/machine_loop1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/ambience/machine_loop2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/moo.wav": {
+     "bytes": 265502,
+     "sha256": "35b7924115bc4cdf94e9cbb274a4d9ca251d6878817834bec08aaa176f2ddc9b"
+    },
+    "sound/ambience/mystery_drone.wav": {
+     "bytes": 1350258,
+     "sha256": "eb3fbb28dda2a6204af07d08fa993ed09513f9915142dd6f4af808204b6b8c9e"
+    },
+    "sound/ambience/power_drone.wav": {
+     "bytes": 36700,
+     "sha256": "4307c01076cb5e076d27546b17bd6b11e2369a67b59dbbd64f2607d8b262a8c2"
+    },
+    "sound/ambience/power_off.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/ambience/power_on.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/ambience/power_shutdown.wav": {
+     "bytes": 1118464,
+     "sha256": "e0ab1a0f67a2d37a525f7a73e8ee8c3a26f746e027fa1501f6648f5586ea2048"
+    },
+    "sound/ambience/power_switch.wav": {
+     "bytes": 66382,
+     "sha256": "5c006bb7315e6eb6d2367ae30a78f0abec8ae2a1e2b6a2c9af88354962b0f33f"
+    },
+    "sound/ambience/rain1_nl.wav": {
+     "bytes": 154394,
+     "sha256": "45d8c08ff4a9a2dd6ff8362fea7c22f9c3ea64a3a8d7b6c81c8cad88265f327a"
+    },
+    "sound/ambience/rain2_fade.wav": {
+     "bytes": 198550,
+     "sha256": "3cf300a4f785d416656838bd3a68120bf6a48d16f928ca74e2e0890ec9f8b426"
+    },
+    "sound/ambience/rain2_nl.wav": {
+     "bytes": 66250,
+     "sha256": "f2735ae8a7b1ae5ab5ce3b8ed66d8c61d00a65f2e66d8c565f4abe718d57ab67"
+    },
+    "sound/ambience/rain2_org.wav": {
+     "bytes": 132400,
+     "sha256": "4c1f820b2c8f4bea08b8357fb8409e9f30a98fd0faf1413a1953ea697b84b507"
+    },
+    "sound/ambience/rumble1.wav": {
+     "bytes": 403620,
+     "sha256": "47afe820548bcf248b7760f7a66a61ea65b5fb79f70d47e3b03cf8211bb4c5f3"
+    },
+    "sound/ambience/rumble2.wav": {
+     "bytes": 99104,
+     "sha256": "9c3d5418c7e5bac60c365f0e8b7ea496dd2b51c72c13b0e5a6640e2ef880433a"
+    },
+    "sound/ambience/rumble3.wav": {
+     "bytes": 209242,
+     "sha256": "864f373dbd75172e1c8f31373188f38c31a80af46592f6b2e92cf5f576e5e0e1"
+    },
+    "sound/ambience/s1_stop.wav": {
+     "bytes": 16162,
+     "sha256": "9a35adf9361aa033b413762fea7d04b2cf7392b363f2aa187a81905f65a44b61"
+    },
+    "sound/ambience/switch_1.wav": {
+     "bytes": 35324,
+     "sha256": "9f73f07313ba4995247d82901111b5aea4200c48de6641dddb145dfadcac40c9"
+    },
+    "sound/ambience/switch_2.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/switch_3.wav": {
+     "bytes": 17576,
+     "sha256": "33b6ed57b0255840415df4db607f86b1183b564f4b1f2dcab6d45d4d75231b8c"
+    },
+    "sound/ambience/switch_4.wav": {
+     "bytes": 44348,
+     "sha256": "bfebdf2afdbab57bd5be3fe0996ce19ff46d983eea4d1511d85af2e4f7d0db00"
+    },
+    "sound/ambience/switch_5.wav": {
+     "bytes": 79992,
+     "sha256": "78bb8cb9ab7202657495a0ca14340886af901912850b9951b0da159f55c2cb20"
+    },
+    "sound/ambience/switch_6off.wav": {
+     "bytes": 141466,
+     "sha256": "999d3b02b7224586d5c487c2666981f054aa091f0569671c72455bff458c9a2a"
+    },
+    "sound/ambience/switch_6on.wav": {
+     "bytes": 176192,
+     "sha256": "7a67fa5d4ee042c6afd271868682a1a34908c2593e5ea9e868ecb6d3e154b55b"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 220548,
+     "sha256": "2cec0b03aa7047110862de21f8f6c77e4d98901ecaf5e405a473c2ddc922528a"
+    },
+    "sound/ambience/thunder2b.wav": {
+     "bytes": 286716,
+     "sha256": "44095eceb307b5f2f1093051597ea0e48bc7abe165accd5badf99c4ad692c6df"
+    },
+    "sound/ambience/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/ambience/windgust2.wav": {
+     "bytes": 110284,
+     "sha256": "b818f61172795942402ff0ca0d1295a91c36a245edc80689c35fe64a8ac1a4e2"
+    },
+    "sound/ambience/windgust3.wav": {
+     "bytes": 110030,
+     "sha256": "fdbb85f091cd9447f1500173aff70236abcdb947ba0758711816da59c5293344"
+    },
+    "sound/ambience/windgust4.wav": {
+     "bytes": 198502,
+     "sha256": "9a5c5a3da44f981c9deb8b437f57b3e3a35f2bcab318a1a3223f0a18fa4d2101"
+    },
+    "sound/ambience/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/ambience/windgust6.wav": {
+     "bytes": 396944,
+     "sha256": "27a19679e7164a6e7bb8e4d6bc42cc8c12a5cd56bba45218e2ec5f1dc528da0d"
+    },
+    "sound/ambience/woodcreak2a.wav": {
+     "bytes": 352834,
+     "sha256": "24d3f57839910934eb61b74a91cf47ee4ab48b38f58f060ca05bde7547e8813c"
+    },
+    "sound/ambience/woodcreak2b.wav": {
+     "bytes": 352838,
+     "sha256": "574401233bff93169d452f4af748a289cfaff5d4e6319884e3cfb4dbd205d0a4"
+    },
+    "sound/ambience/woodcreak2c.wav": {
+     "bytes": 308746,
+     "sha256": "02deb62b856b7be5c3304a0bf745f79019b0b408a8cfcc4e1edede397ba09c7d"
+    },
+    "sound/ambience/woodcreak2d.wav": {
+     "bytes": 352856,
+     "sha256": "6d35975964b2fa32ece681a9d0cfa13202cde02bc315f32af0690f7437352452"
+    },
+    "sound/ambience/woodcreak2e.wav": {
+     "bytes": 308766,
+     "sha256": "54eb41e3f5c2a0103d07e70e83cf82b51014da3673fb770cf6ada3df669c328e"
+    },
+    "sound/bal/bc7_waterfall.wav": {
+     "bytes": 137846,
+     "sha256": "51dcfb96c94678cbb01e0c985240e853a01c6fc3c4f2376de177c0be59bfcfe6"
+    },
+    "sound/boglord/attack2.wav": {
+     "bytes": 8036,
+     "sha256": "efa18dec8f6d5066b8d494a232ca9c98c27a4a9130130086a9b0a27ffccb34ed"
+    },
+    "sound/boglord/bangdoor1.wav": {
+     "bytes": 30968,
+     "sha256": "b267e602e76fe1d8e854e2873e06008af15612ed1a31ec41feeb4461d52fc478"
+    },
+    "sound/boglord/bangdoor2.wav": {
+     "bytes": 39828,
+     "sha256": "f904a5423580c118de1d732fff714565f1dd8d8d1556b3b58bf39d2c59fa4272"
+    },
+    "sound/boglord/bolt_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/boglord/death1.wav": {
+     "bytes": 39758,
+     "sha256": "a9e0e36b1a51d88a5b542dd2c1f79f1dbea402b3ceb18ee13606c03126f1a874"
+    },
+    "sound/boglord/idle1.wav": {
+     "bytes": 15532,
+     "sha256": "5339e3429b0510f7e8016e6ece9895df6f202b5809f739b317211a081401f202"
+    },
+    "sound/boglord/idle2.wav": {
+     "bytes": 18586,
+     "sha256": "52f8bddb2d5095f4077eb1f753d75bce94f906f1b3064067a54c875ae16d1a5c"
+    },
+    "sound/boglord/melee1.wav": {
+     "bytes": 9326,
+     "sha256": "e2f5808115d0a93dde1063db6f2d38f6ab7ff333f83d95741a8948f44ae4ace9"
+    },
+    "sound/boglord/melee2.wav": {
+     "bytes": 11746,
+     "sha256": "e299e39467c9f94730c21d1321455fdccf3aefbb0352d528b6d413639210e715"
+    },
+    "sound/boglord/melee3.wav": {
+     "bytes": 18776,
+     "sha256": "c066200b5ddb81aa0c0cc0462939681703549ac15dd6aa83db8a23ae54ce6317"
+    },
+    "sound/boglord/pain1.wav": {
+     "bytes": 11094,
+     "sha256": "6ca5a44043add6b389827e5aca8bc0c9e9c7b0cc0c7b4a5d3df292a78da0064f"
+    },
+    "sound/boglord/pain2.wav": {
+     "bytes": 11094,
+     "sha256": "7e11818fbae5354177add1e236b6f3e0f4665d50193154fbb15fead4bb4d7908"
+    },
+    "sound/boglord/sboom.wav": {
+     "bytes": 22172,
+     "sha256": "89899521eac11f922cdd4606a0fe08bc080a63a73ec4b4a502027e33f08b225b"
+    },
+    "sound/boglord/sight.wav": {
+     "bytes": 28734,
+     "sha256": "8b020b0f07a7461f5f520b8385e38828d66b3cb1fc46d7db08b845fa8ff62ad8"
+    },
+    "sound/boglord/slime_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/boglord/slime_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/boglord/thud.wav": {
+     "bytes": 22140,
+     "sha256": "f5d7b5f65e24d6a5edd04404b93a8c5a2db45cc6c142012638f050158bb783ba"
+    },
+    "sound/boglord/thud2.wav": {
+     "bytes": 105882,
+     "sha256": "7e8826a38df07d0d2b85d6d39b8b664bb2ef8a0686846573802b77811682e957"
+    },
+    "sound/break/ceramic_i1.wav": {
+     "bytes": 11106,
+     "sha256": "ed731319eb09044fe672f5d8681395a11a7449fe7b57b9a46040c717e714cf40"
+    },
+    "sound/break/ceramic_i2.wav": {
+     "bytes": 11126,
+     "sha256": "88c29d649471f031aa1049ee087cf866e1d9ea53183effd14cfabc81ecff9502"
+    },
+    "sound/break/ceramic_i3.wav": {
+     "bytes": 11144,
+     "sha256": "420d00d7884a22dd2baf9cdd1e059689858b47fb3adb2ad5ae29c80bd74b5dc5"
+    },
+    "sound/break/ceramic_i4.wav": {
+     "bytes": 17678,
+     "sha256": "0b7da87d046aeb3a52de305da60b2400c8cbf3480364235fb0bba3a0595f13dd"
+    },
+    "sound/break/ceramic_impact.wav": {
+     "bytes": 37584,
+     "sha256": "e6d2ada5c51a2787548468ad393e2497ef84b47ca487cd523f3ef6b283626226"
+    },
+    "sound/break/ceramic_impact2.wav": {
+     "bytes": 35380,
+     "sha256": "508725e20a999c339501dddb045a2ca6a51032905dccc68fe2a3fb9e9e1d0649"
+    },
+    "sound/break/ceramic_impact3.wav": {
+     "bytes": 26560,
+     "sha256": "ca4d7876a6e33cc285186d1432670878b54cc62c01e3dc4c650727069bfdb8ee"
+    },
+    "sound/break/ceramic_impact4.wav": {
+     "bytes": 37584,
+     "sha256": "e71b0559ac5d76dcd2016d07f8999ae1200d82ca7b658509339cf303c918f777"
+    },
+    "sound/break/ceramic_impact5.wav": {
+     "bytes": 37584,
+     "sha256": "1c6b3457c9d3aab209cd3b8977df579cdbe01158c1b4e5c07c2b5b227c96fb6d"
+    },
+    "sound/break/ceramic_impact6.wav": {
+     "bytes": 37584,
+     "sha256": "fac4857865a750a03f74e556f44186381315068ec1975c775fcd14ae4a7b3c7b"
+    },
+    "sound/break/flesh_impact.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/break/glass_i1.wav": {
+     "bytes": 13268,
+     "sha256": "63ec32f660d085c64274747b704bcbeb7261062b5fcbb570598d64e742dc7164"
+    },
+    "sound/break/glass_i2.wav": {
+     "bytes": 30950,
+     "sha256": "8b2ae028e6237cf06241739e3533ef3bf651194dfbef028fd648a6f06e8996de"
+    },
+    "sound/break/glass_i3.wav": {
+     "bytes": 8848,
+     "sha256": "ec97346c02431717927e2dd3712bd82428ea05960ffa027422fbaafab96b4170"
+    },
+    "sound/break/glass_i4.wav": {
+     "bytes": 4442,
+     "sha256": "b4144a008122e52aed45339e11ccf7cb1cd2e92f07e4169d029059a4ca01f5fa"
+    },
+    "sound/break/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/break/metal_i1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/break/metal_i2.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/break/metal_i3.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/break/metal_i4.wav": {
+     "bytes": 79928,
+     "sha256": "d2b35ba352f32ceae469acf9cfa04f7dcc0a462ff69e3649f5c0adf55ae2ea78"
+    },
+    "sound/break/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/break/rock_i1.wav": {
+     "bytes": 30534,
+     "sha256": "5cb61e93ebcf9bbcd3be1f6e282b51e9102d56b6650cffc0db93918b11b42322"
+    },
+    "sound/break/rock_i2.wav": {
+     "bytes": 29254,
+     "sha256": "9fdf4f489834452fce33b1fbe69bce9d4920a117c3d0d93b4fb530a7117bf160"
+    },
+    "sound/break/rock_i3.wav": {
+     "bytes": 25264,
+     "sha256": "59b506a84e018b11e9ba30a6ad299c2d8cf24d5907dc95cf30e578cd386e28bf"
+    },
+    "sound/break/rock_i4.wav": {
+     "bytes": 27244,
+     "sha256": "7a2c24ce52e272998ca035c967860873c92fbb14227a190ac82b761843680ffd"
+    },
+    "sound/break/rock_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/break/wood_i1.wav": {
+     "bytes": 28074,
+     "sha256": "6249449664f5ae509164ae3fd8588c905bea9daf5b1d919d9917b91aadf675bb"
+    },
+    "sound/break/wood_i2.wav": {
+     "bytes": 25158,
+     "sha256": "d51e731bdf895c84ec9927c496fc0a7fb6e7a37cbfbc2f6b55f54f716d804d08"
+    },
+    "sound/break/wood_i3.wav": {
+     "bytes": 17644,
+     "sha256": "8e1967cf42a7e31668d94e1b0cb7c6de4d36c6ec735d67ab01ac4e00dfb0853c"
+    },
+    "sound/break/wood_i4.wav": {
+     "bytes": 11516,
+     "sha256": "fb0908f1a2bdff824d27fa92f15690cb9f86805185119fbc7f7876547495bf45"
+    },
+    "sound/break/wood_impact.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/chthon/attack1.wav": {
+     "bytes": 22116,
+     "sha256": "91df4f5be21c6a80d31a050192b04a760f25c7f88a4b0ceeb2802fe8b8499d21"
+    },
+    "sound/chthon/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/chthon/death1.wav": {
+     "bytes": 55120,
+     "sha256": "b6eeee788b9aa49ca9698d2d7977748f142053fd3f47e2828d1781d7db7ec986"
+    },
+    "sound/chthon/idle1.wav": {
+     "bytes": 24322,
+     "sha256": "6a0a9b5a0b2e74fce8cbfa9ede97c2059884c0db81b2c68fc0ec7bb1da2a4009"
+    },
+    "sound/chthon/lavasplash.wav": {
+     "bytes": 100546,
+     "sha256": "a533653ff77e2dfc443377a1f055b6abd7af3c639f0e5634b0a47fd1f040ed76"
+    },
+    "sound/chthon/pain1.wav": {
+     "bytes": 35320,
+     "sha256": "f964bdd08ffc66f9f229aacb3b584ffefdcfbacf7da0f0075a9af752569c641c"
+    },
+    "sound/chthon/sight1.wav": {
+     "bytes": 49454,
+     "sha256": "533adf244fa2c2dca72765560e823ceead8d5a0f3832ba18d4fa2928154b12c8"
+    },
+    "sound/deflector/death1.wav": {
+     "bytes": 22150,
+     "sha256": "593140594353d4d25fe6b5e455afc0f3c2cdd6874bc1d545ea03f779454cd799"
+    },
+    "sound/deflector/death2.wav": {
+     "bytes": 41334,
+     "sha256": "4295a9a79fec3bf611c25f97553420d0e42b987ad8091930db9137b93a3e8f06"
+    },
+    "sound/deflector/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/deflector/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/deflector/idle1.wav": {
+     "bytes": 7668,
+     "sha256": "76455fc9d5fc53cf5a70900a9d875ba3ac839e1c3179eccc5287619a70523e6e"
+    },
+    "sound/deflector/melee_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/deflector/pain1.wav": {
+     "bytes": 6452,
+     "sha256": "e0905dc6c945663a97119f2c1522d5a8ebd1596ed26f33650fcb63b185959517"
+    },
+    "sound/deflector/pain2.wav": {
+     "bytes": 9598,
+     "sha256": "011d69ef5153dca029bcb1c3d60b3c3f0e1263bd9ca34a02d4d14e6ab508a0d4"
+    },
+    "sound/deflector/pain3.wav": {
+     "bytes": 12014,
+     "sha256": "08f5ac27626e862b7193f101a6d0b77dc6568c4e93ef3000199934769666b1ec"
+    },
+    "sound/deflector/rocket_fire.wav": {
+     "bytes": 15482,
+     "sha256": "a08e5f83d20b5d1eb585cf782f08a4a692b0f8c95e461b9a321814d099a89d79"
+    },
+    "sound/deflector/rocket_hit.wav": {
+     "bytes": 13274,
+     "sha256": "4dbcd0bad68272848a32a997bb235c4324cd55b1df0b96b1876fb96ea8ca6a90"
+    },
+    "sound/deflector/rocket_load.wav": {
+     "bytes": 6882,
+     "sha256": "1dbddae67f93c586ea3290ed65e1234cf8ccfd076847b1b418693e97fb5768d1"
+    },
+    "sound/deflector/shield_off.wav": {
+     "bytes": 10684,
+     "sha256": "5c3ea84c12abf632d777f90972966c4a50dde4ee7363d257e3c0f89e68027b5f"
+    },
+    "sound/deflector/shield_on.wav": {
+     "bytes": 10464,
+     "sha256": "340196ba32a9d3f672cbc3db86765eb1517550b00f2f97ed76cb519da1b93962"
+    },
+    "sound/deflector/sight1.wav": {
+     "bytes": 16106,
+     "sha256": "3ec7f00e859c52846b244e69cc3ed7321175746a44eb373fe4bd3cb07612dcf3"
+    },
+    "sound/deflector/sight2.wav": {
+     "bytes": 14432,
+     "sha256": "e8c0c1367969b0346bf5fdc94665a10480636629a71a6a35e47da3d7fb7cb463"
+    },
+    "sound/deflector/sight3.wav": {
+     "bytes": 17184,
+     "sha256": "11748c58e67305ad4e1cd7a2e2c084f9c41184cd2b4f756adfd18adcc22dbc2d"
+    },
+    "sound/dguard/death1.wav": {
+     "bytes": 30610,
+     "sha256": "af3809501261ec4d0afa6ea7301c11a5c7bbc1cc3e06b8c88172ee0214c30969"
+    },
+    "sound/dguard/death2.wav": {
+     "bytes": 43636,
+     "sha256": "93a70fc0d6fee819c723a435a3954b3fd3be86e358698ce85db1062990d1575e"
+    },
+    "sound/dguard/fire.wav": {
+     "bytes": 60820,
+     "sha256": "f5e5d4f6ccc0778c1396c66d327564a0b1892773f2c23d2e30590abf0c758bd2"
+    },
+    "sound/dguard/hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/dguard/idle.wav": {
+     "bytes": 20498,
+     "sha256": "45b2f208b9796d19d7aeb0cba64e4b0e5fd2ed7c980123f7c41ca10d17785021"
+    },
+    "sound/dguard/pain1.wav": {
+     "bytes": 10380,
+     "sha256": "9a367afb7cde241099c58c999e225ba939be39f21be818b16444f5a810049960"
+    },
+    "sound/dguard/pain2.wav": {
+     "bytes": 14892,
+     "sha256": "827a1e4d3c9983f61fffd61de33054274c144bddd9a68460b496fd6281cf9406"
+    },
+    "sound/dguard/sight1.wav": {
+     "bytes": 18124,
+     "sha256": "9cb3d960261d90ec16c9883f4326c905356b6ff4e99cdf48ab5913b098588016"
+    },
+    "sound/dguard/sight2.wav": {
+     "bytes": 18022,
+     "sha256": "35ee4b7ec6715c8c9fdc24f90ad0b5d90a0ae7a4986168cf40670e87c325d5db"
+    },
+    "sound/dguard/sight3.wav": {
+     "bytes": 19948,
+     "sha256": "c6818770267626dea27f4a72ce2249771f6968924022c2275a5a96abfa485044"
+    },
+    "sound/dguard/sight4.wav": {
+     "bytes": 20332,
+     "sha256": "7affcdbdc62f13e492a15b54fe642fe045641f5551f570cc3c8d5f7ee29521fd"
+    },
+    "sound/dguard/slash.wav": {
+     "bytes": 22942,
+     "sha256": "44b60d785ff03f033e183b6fbce69e526351187d28efdeb308f6f8bea930d450"
+    },
+    "sound/dguard/slhit.wav": {
+     "bytes": 31956,
+     "sha256": "0f07a131640f21337cd89a772588ecfc707d6a729f96b54c21920b809cd620e4"
+    },
+    "sound/dguard/slmiss1.wav": {
+     "bytes": 10458,
+     "sha256": "e32d5cb070a13fad979b021e84a727f71242305ade1af7bfe18c255f0f6dd548"
+    },
+    "sound/dguard/slmiss2.wav": {
+     "bytes": 13840,
+     "sha256": "f6b3aee08c25434d2fda7468cacf35a0912b182653a45991149b54a0fc4be537"
+    },
+    "sound/dknight/dcross_idle.wav": {
+     "bytes": 176610,
+     "sha256": "a7eba673532dad555f879ba77091e3cb9e44558608b83c36d8639e51d71b660a"
+    },
+    "sound/dknight/dcross_idlecom.wav": {
+     "bytes": 58910,
+     "sha256": "bba45bd9fc02e1d580a80596d6a1744bb8fb993ed73a7bfdf3b712670cccf989"
+    },
+    "sound/dknight/dfury_grunt1.wav": {
+     "bytes": 19702,
+     "sha256": "8d3709e913b8e26d8e094fddd9c60d74cc71b742e16276d4982c9636db05209e"
+    },
+    "sound/dknight/dfury_grunt2.wav": {
+     "bytes": 54294,
+     "sha256": "f7ca0d5970322629cc47f8c26489d5c916a570525ded20c73823c27f2834609c"
+    },
+    "sound/dknight/dfury_grunt3.wav": {
+     "bytes": 62054,
+     "sha256": "6eae53c32568ce90083dab528c18475ef840f9f684c43cdba7bfcc1c63435ba6"
+    },
+    "sound/dknight/dfury_grunt4.wav": {
+     "bytes": 28914,
+     "sha256": "0def63c77d0f116eabb77cc462ba6a57bc6523fad469946c6f1f11d786100819"
+    },
+    "sound/dknight/dfury_leap.wav": {
+     "bytes": 102756,
+     "sha256": "f288dc9324b2ccace32ce86cffaf0c042a59bf5b56b20657c018859f1038243a"
+    },
+    "sound/dknight/dfury_sight.wav": {
+     "bytes": 69602,
+     "sha256": "443887e91ca71dbba299b37a81bdbd3bb34b491c6c3e13fe73bb5c921019d1ea"
+    },
+    "sound/dknight/dprince_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/dknight/dserg_hbreath.wav": {
+     "bytes": 185884,
+     "sha256": "c8181d4844ac4b2bb7dc47bbc28bd2ae9fc2737120d6745292de4d594f40d406"
+    },
+    "sound/dknight/dserg_magic.wav": {
+     "bytes": 34768,
+     "sha256": "adcb0810b7e8b23d91d31f5727c480b35c7b59a90d9f7933f69c00e7eccd1f3e"
+    },
+    "sound/dknight/dserg_sight.wav": {
+     "bytes": 15210,
+     "sha256": "d4f7c5b6f64d48606d1d3e1889794a22107f3d5914b37c81c405fdfb1133a7eb"
+    },
+    "sound/dknight/ghost_idle1.wav": {
+     "bytes": 110292,
+     "sha256": "878416a0151a1a71891a84db2565d1e8a2b2e37f03f1822d7f9411a98b42b528"
+    },
+    "sound/dknight/ghost_idle2.wav": {
+     "bytes": 110290,
+     "sha256": "048f79f7fa8f9e49f97dad9f5cb468933be1713726ba95d3ab10d9811cbb5f2f"
+    },
+    "sound/dlord/death.wav": {
+     "bytes": 32022,
+     "sha256": "0188f6a3dd88686e15311f8c39c4277078e55bc0ec75497e2eb534af717abcdb"
+    },
+    "sound/dlord/idle.wav": {
+     "bytes": 9906,
+     "sha256": "c0ee37f80013dad1aaeb285a11a33c4d7c2ff2de0b2a94c2943d3fbe1c241bcd"
+    },
+    "sound/dlord/pain.wav": {
+     "bytes": 8632,
+     "sha256": "230ed5c7d024bfa90b973649aa79d9e9327eaf401b1632e4a1334fb4a9eb075c"
+    },
+    "sound/dlord/sight.wav": {
+     "bytes": 28028,
+     "sha256": "d82aa0028754e826705961040e1ab27f007c572a28c63dbcaeefeb681bc3ca85"
+    },
+    "sound/doors/rattle1.wav": {
+     "bytes": 88274,
+     "sha256": "c524d12100f1067bb30ecdf83e18e5d85124fef834929cfd2a2ade14f83ad730"
+    },
+    "sound/doors/rattle2.wav": {
+     "bytes": 123526,
+     "sha256": "e8decabe8df10f704814bf2f432b3fc6d5542022d465af336b0680793f6163ea"
+    },
+    "sound/doors/rattle6.wav": {
+     "bytes": 97072,
+     "sha256": "0aef6aac51a4e3528e5f2019bf113ee2f0e5096a708d31483a526c447ebdb00c"
+    },
+    "sound/doors/rattle_tech1.wav": {
+     "bytes": 61784,
+     "sha256": "18610e64612241e6936f2d0ebe746c957652c4ce8e37c668515281712f6a1e39"
+    },
+    "sound/doors/rattle_tech2.wav": {
+     "bytes": 88244,
+     "sha256": "de39aa8b59c988b02bf6c13a716e225b7ee029f2553357b8646aef92a2792c3e"
+    },
+    "sound/doors/rattle_tech3.wav": {
+     "bytes": 52844,
+     "sha256": "a29e8144cdab34467250f040feaad044aff784a2775b50bd220e967b39f39b3c"
+    },
+    "sound/doors/rattle_tech4.wav": {
+     "bytes": 76844,
+     "sha256": "ba34a641758a2e2cb9ef5358a398482c2b34526fc4b0c49db590c9679c732ef4"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/enrage.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/r_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/eel/attack1.wav": {
+     "bytes": 27740,
+     "sha256": "8c84b2a5e7fd0754dca3611a8300a8cc9656295ea73617ff0c85d167b28459df"
+    },
+    "sound/eel/death1.wav": {
+     "bytes": 34264,
+     "sha256": "a0f8eab92db10e8fa9342f725743297fd8384e2aca1decc1189109196f3b960e"
+    },
+    "sound/eel/idle1.wav": {
+     "bytes": 53110,
+     "sha256": "c059a4f2bee33543b377803f2af1fc7e2ee205cd02d987859af18087246ae46c"
+    },
+    "sound/eel/impact1.wav": {
+     "bytes": 70632,
+     "sha256": "13cea2f7d66f40511add17d846ab6142345497ddd7cff5ebfc5e2e70a7eb1fbe"
+    },
+    "sound/eel/pain1.wav": {
+     "bytes": 13316,
+     "sha256": "569a6bf9383820e90e431db5c0b82cd0201e10fd2081d228f81a0c76a0e88d1b"
+    },
+    "sound/eel/sight1.wav": {
+     "bytes": 32074,
+     "sha256": "90786a043f5ec1bd0b761c5c8378dc2783e3b1d8e3ac95a9312f55a7c5b3baea"
+    },
+    "sound/eidolon/attacka.wav": {
+     "bytes": 27660,
+     "sha256": "a7bb5c16014c814d379585eb4c6752a91240a5856ad7f3af5f86af037bef91e6"
+    },
+    "sound/eidolon/attackc.wav": {
+     "bytes": 220544,
+     "sha256": "9815d26814c687618b7bbae4a5353570afe497c5d57fb77c083f695d102234c9"
+    },
+    "sound/eidolon/attacke.wav": {
+     "bytes": 46400,
+     "sha256": "39ad467257004bc6d2a17003abe4ef8df89d0668ec03fc8570aa755cbdf94c6c"
+    },
+    "sound/eidolon/death.wav": {
+     "bytes": 264696,
+     "sha256": "bc055e1315073c78e5571c99d29894bc89abfd64b6a258bdabc79849f81c50a0"
+    },
+    "sound/eidolon/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/eidolon/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/eidolon/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/eidolon/footstep1.wav": {
+     "bytes": 52384,
+     "sha256": "e228c0503d89118be55eafaf3a3bfa0a13e3bdcbe4a043f4a9bb31c9e96cf3dc"
+    },
+    "sound/eidolon/footstep2.wav": {
+     "bytes": 46128,
+     "sha256": "1a3b867c93932411f1c3dedf4a8f1553f19caabae438cb7989095307d1a6c5c5"
+    },
+    "sound/eidolon/footstep3.wav": {
+     "bytes": 43774,
+     "sha256": "4119d9c31e359bd48b52bff2842e51c441064896289194f04db44e2d7860cccc"
+    },
+    "sound/eidolon/footstep4.wav": {
+     "bytes": 41758,
+     "sha256": "6b97f80545d9587580a7b445f13e5a38300627e497ed85357f9448c7a910864b"
+    },
+    "sound/eidolon/growl.wav": {
+     "bytes": 44380,
+     "sha256": "f9f404c4590f2af8fa9a1cd0de34e1d031e66d88ccf553dba228396f0d8fb012"
+    },
+    "sound/eidolon/idle1.wav": {
+     "bytes": 28778,
+     "sha256": "61f423068b79bba82fb3ae3fca3957a8f059802068edf272f2695e6caab89271"
+    },
+    "sound/eidolon/idle2.wav": {
+     "bytes": 33172,
+     "sha256": "1bdd3d6862ed0b74aecae1917f09a65acf4db7fca49a0ccd21a7fbc2eea5f02b"
+    },
+    "sound/eidolon/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/eidolon/pain.wav": {
+     "bytes": 17744,
+     "sha256": "6a308180389e3fb98cc00c70dad1c6600988778b34628e04363e7ca54e5bf679"
+    },
+    "sound/eidolon/rock_hit1.wav": {
+     "bytes": 97066,
+     "sha256": "d31741c09309b240d294ba9b310b694aae1d71f823ac9ef28b27a8b5fff14405"
+    },
+    "sound/eidolon/rock_hit2.wav": {
+     "bytes": 123526,
+     "sha256": "a3d1247db98535829392172110a40fde19113dd493ab603c4b6a9a36dd743150"
+    },
+    "sound/eidolon/sight.wav": {
+     "bytes": 53044,
+     "sha256": "04c124f683e75e4d14374b7a044eeea288dd02a845ccab3ffd670f1c15799ebb"
+    },
+    "sound/enforcer/cent_hover.wav": {
+     "bytes": 103796,
+     "sha256": "a5616566072a5cdc9339e3722d6fee9e652796e9cc8f76e27dbd9aee13986f4e"
+    },
+    "sound/enforcer/death1.wav": {
+     "bytes": 9290,
+     "sha256": "f62aad2ae903808a0caecfc6bdfe13e5fdebb1df14d330c6ac4eda9b577b25bf"
+    },
+    "sound/enforcer/def_idle1.wav": {
+     "bytes": 32676,
+     "sha256": "7b673b07828790504caca013c18bf697fd53b758a3638b949b433cf2d72f03f3"
+    },
+    "sound/enforcer/def_idle2.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/enforcer/def_sight1.wav": {
+     "bytes": 18260,
+     "sha256": "7d57825c28cf4f93189261d76cccab676aeba097920114d5d3f48d7eddaaa1cd"
+    },
+    "sound/enforcer/def_ssg_fire.wav": {
+     "bytes": 14206,
+     "sha256": "494a6d493c3c298c1b9cc0051ce4c1f9e129293ea7ec283b62915c49d8c249c3"
+    },
+    "sound/enforcer/def_ssg_load.wav": {
+     "bytes": 5274,
+     "sha256": "db4f62f8d76a68f2e4d3e7a29a22d3ddc5d6ae9bb296e6e800e937b73b5a4dea"
+    },
+    "sound/enforcer/elim_idle1.wav": {
+     "bytes": 39084,
+     "sha256": "2ccaa3ba4f987d031a22b8048ca23e97900fca9def362ff92943b73a99ed7844"
+    },
+    "sound/enforcer/elim_idle2.wav": {
+     "bytes": 36204,
+     "sha256": "9232028e1a93c409c7000348bfadc269c49a333e8d65d904973efb547c7af805"
+    },
+    "sound/enforcer/elim_idle3.wav": {
+     "bytes": 38222,
+     "sha256": "93034d568db5c304a165c3d89cb03ffe5d97e8157755e944a863697007eb27fc"
+    },
+    "sound/enforcer/elim_pg_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/enforcer/elim_sight1.wav": {
+     "bytes": 31468,
+     "sha256": "2268ee0ad0c77a081b289a550a1dae24b274b2e3f06d156a67beca80df8ee919"
+    },
+    "sound/enforcer/enfire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/enforcer/enfstop.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/enforcer/fum_poisonoff.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/enforcer/fum_poisonon.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/enforcer/idle1.wav": {
+     "bytes": 15810,
+     "sha256": "cec388af73dff076ea3af7c754ef0939f989f3412b0359c0fb668cd91bd4abaf"
+    },
+    "sound/enforcer/pain1.wav": {
+     "bytes": 5478,
+     "sha256": "d8692021777495825974f8406e23c74ed249f9a80a9bc944c79b1722c35f64e0"
+    },
+    "sound/enforcer/pain2.wav": {
+     "bytes": 4580,
+     "sha256": "e48a524482ce67ff94ce00fe4d8a1190aed38e9c7c24cfee3607f0f2827049e6"
+    },
+    "sound/enforcer/pyro_flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/enforcer/pyro_flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 5870,
+     "sha256": "92dc64154602e29e95d40aa68d3544fe21cb21ce24192f1e8ffefc6b5d31b8cc"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 6574,
+     "sha256": "52b1991141ed9452fe6c7ebe219cc544fba443058f179b8eec5a5cbfb9aacf3d"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 6158,
+     "sha256": "d3b9e689b2b43ae74ae14fdb26680d3646d658107664965db97420ae032d74b0"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 5166,
+     "sha256": "815e05c3b14858209fee01316848c117ad89af9f0aab190fc0ca0239367373ac"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/freddie/death.wav": {
+     "bytes": 88244,
+     "sha256": "2e3de0875dd3245a98614829ab848cc1dfc34a95827aa4cfc174884977ecddf0"
+    },
+    "sound/freddie/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/freddie/idle1.wav": {
+     "bytes": 88280,
+     "sha256": "673ac7c26a9be2b1ea37b152ce48442ff40089cc7dc015c014eb42534db2c306"
+    },
+    "sound/freddie/mangle.wav": {
+     "bytes": 48548,
+     "sha256": "ee318d6849ca9dda4569db6009210a6909279bd2ffe9b31543d47134b51c1533"
+    },
+    "sound/freddie/pain.wav": {
+     "bytes": 38640,
+     "sha256": "ffe05b43444a209084c95c166b0776d33f9ba8af15ef998d3ed5c09aa0b03c3d"
+    },
+    "sound/freddie/painshrt.wav": {
+     "bytes": 8868,
+     "sha256": "31e08c51909022a6b0ad7f01f1f8dae196269b8b105e57e555025393cdc278d9"
+    },
+    "sound/freddie/sawstart.wav": {
+     "bytes": 41938,
+     "sha256": "90f83017a7ff5f2bd2824be1e122eab7d8171ab63a9025adf1fc03ee3e7a44aa"
+    },
+    "sound/freddie/sight.wav": {
+     "bytes": 55170,
+     "sha256": "3f73e5b30cef3038102ffa9ab0faf89e71af43ed2ee5a0758319c072c151c123"
+    },
+    "sound/freddie/step.wav": {
+     "bytes": 19898,
+     "sha256": "121818aa6200c770a70c2c02844bbc0351a62f166c31f9d85765896b426f610e"
+    },
+    "sound/freddie/step2.wav": {
+     "bytes": 19870,
+     "sha256": "7e33eb621ee356cbe4affe6218b988f477259dae705d57eea12d7fe10b5d4510"
+    },
+    "sound/freddie/step3.wav": {
+     "bytes": 19898,
+     "sha256": "a005232c4c0608092c7d697c6d24566892b74adfe7566030360c96996bd39357"
+    },
+    "sound/freddie/stfire.wav": {
+     "bytes": 27598,
+     "sha256": "597fa6e0e8c4da4fd85e9e26ecd7f95f3dc242846ec9b962cf2beb324e5a4fdc"
+    },
+    "sound/gargoyle/attack1.wav": {
+     "bytes": 28712,
+     "sha256": "cab70a44f7ec34343a1608ca8c13dd2b501065cade08e94b574f98436aabeadf"
+    },
+    "sound/gargoyle/death1.wav": {
+     "bytes": 41662,
+     "sha256": "07043eb3fcbcc9c8cf53b07c10b349a9f3beb471dc240a6d70d8f2b5a57e85b0"
+    },
+    "sound/gargoyle/death2.wav": {
+     "bytes": 28768,
+     "sha256": "c363613cd476d5099dbdced656244db0d704da5eeb54fe5b880f2202f6f465b2"
+    },
+    "sound/gargoyle/idle1.wav": {
+     "bytes": 72868,
+     "sha256": "90885fa6cae946ecfedec8a150911bcfdad8ef326254e1fb1bf44ca5c5af4eb0"
+    },
+    "sound/gargoyle/pain100.wav": {
+     "bytes": 26510,
+     "sha256": "d53f1e64f4c9f5e13e03cfee2681ef6dff370e95e9dd8668c7c06b79762e7773"
+    },
+    "sound/gargoyle/pain75.wav": {
+     "bytes": 28720,
+     "sha256": "78d5d0f1c5df4e1a565eeda076d5f8b3bb3582e551909b31fa8e36c292903826"
+    },
+    "sound/gargoyle/perch1.wav": {
+     "bytes": 26506,
+     "sha256": "5eab54a566e4c1136c40fbfbd636188a7a9c4aa6b278e51fb965e1761764cbff"
+    },
+    "sound/gargoyle/perch2.wav": {
+     "bytes": 30924,
+     "sha256": "745b5c5f1fd04a73a7581373925aa70cd3f35ab899df5f5fd2c610d07bf95bdd"
+    },
+    "sound/gargoyle/sight1.wav": {
+     "bytes": 35142,
+     "sha256": "1097300e4bca9ef61a7041e7f4ff403fe67c4fc0e687b30892a6bdf35bf45c09"
+    },
+    "sound/gargoyle/swoop1.wav": {
+     "bytes": 21056,
+     "sha256": "ef6b4b672dd984e846294e0be57d81df3abcb521b1f88f6afaf2f5cc2d4e91d4"
+    },
+    "sound/gargoyle/swoop1hit.wav": {
+     "bytes": 11078,
+     "sha256": "6a624e3f46e2c45f5e2d6f42ee18643a17268a6b0df2493fe6ffdba4be0c9057"
+    },
+    "sound/gargoyle/swoop2.wav": {
+     "bytes": 24364,
+     "sha256": "f98d41f9df7244e8f77c435ae4071a4e4595ec7005b7c72e44456fe7baca425e"
+    },
+    "sound/gargoyle/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 22094,
+     "sha256": "142b725ff5515cb438a592288a69e01331b3fd0bbb7311abf1dbaf90f95417ef"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/plasma_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/gaunt/plasma_start.wav": {
+     "bytes": 66270,
+     "sha256": "ad404715612b802a7d4f72f2d14abb47c338ac414af56c19ffc8dc2873f33452"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gaunt/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gibs/gib1.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/gibs/gib3.wav": {
+     "bytes": 33256,
+     "sha256": "10a19291ed8af8893b6cdbd80416425b27e5a197d39aa8d0557320752d78cf11"
+    },
+    "sound/gibs/gib5.wav": {
+     "bytes": 15490,
+     "sha256": "2d7603a9fc0c055ed3529bd4dfd511984c71b93f4719b605813eb5139d02c6d9"
+    },
+    "sound/gibs/gibacid.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/gibs/gibchain.wav": {
+     "bytes": 15938,
+     "sha256": "c6b2a37424a51810017bd5ee4764a014329467686f73bb2f48ad2704592176f3"
+    },
+    "sound/gibs/gibheavy.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/gibs/gibheavy1.wav": {
+     "bytes": 11110,
+     "sha256": "0a1313f08fa22e4df8a1beb15ffdb6e7b1906187f63042357e4a43631ef5e93a"
+    },
+    "sound/gibs/gibheavy2.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/gibs/gibhit1.wav": {
+     "bytes": 22150,
+     "sha256": "d2a73e2f9e31b9fefda789e49b17ec9bd18df0335c31f871514a282cf550829a"
+    },
+    "sound/gibs/gibhit2.wav": {
+     "bytes": 22150,
+     "sha256": "210477e93743dc6c0541bc158032d46251c6aeff551efcf515d6e7db87bb8a53"
+    },
+    "sound/gibs/gibhit3.wav": {
+     "bytes": 22150,
+     "sha256": "40db6dbb033d59dd458e5fb6102dba6d6ecf5bc5739d9fc35a3be68cc977da53"
+    },
+    "sound/gibs/gibhit4.wav": {
+     "bytes": 22150,
+     "sha256": "0bd1e29d68e41cbf2d753730df678918a38fc886b4690991fbd7e8fb3e13e055"
+    },
+    "sound/gibs/gibhit5.wav": {
+     "bytes": 22150,
+     "sha256": "4adf7a8249ee913aeb9e91120b1f6b9e529b1e1a3eadb75185589cf7c3ff910e"
+    },
+    "sound/gibs/gibmetal1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/gibs/gibmetal3.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/gibs/gibmetal5.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/gibs/gibmetala.wav": {
+     "bytes": 18474,
+     "sha256": "2c057e772307ef647b4313975cec75bacfd522bbc5dd27ae83a867065562635f"
+    },
+    "sound/gibs/gibmetalb.wav": {
+     "bytes": 30756,
+     "sha256": "fbcfa9e6cd5aa68c6fffd6699c8dc87ec3707a4281358f229afce57f3278c800"
+    },
+    "sound/gibs/gibstone1.wav": {
+     "bytes": 52956,
+     "sha256": "962dd735a1823905243700eb3f4e0caacc1be71a1f367ccad4f21dd82b4e99e1"
+    },
+    "sound/gibs/gibstone2.wav": {
+     "bytes": 22104,
+     "sha256": "04f070fa9873f382ded03a5139ce2c7da2013d8ef9221a8d10a64c3b5f912591"
+    },
+    "sound/gibs/gibstone3.wav": {
+     "bytes": 35344,
+     "sha256": "16262de5a0b703468f2c3f1e49ffa0c225eb81b89984b468b7bc95948ed890c0"
+    },
+    "sound/gibs/gibstone4.wav": {
+     "bytes": 8832,
+     "sha256": "75179beed6fb6f581944f5e7db153bea4d9ecc65899628468efd48710a392013"
+    },
+    "sound/gibs/gibstone5.wav": {
+     "bytes": 22130,
+     "sha256": "0aaff5c363ac29a9b50d83b4b04fcd7264c614a93d0c9bc7941c9704a6b4b499"
+    },
+    "sound/gibs/gibwood.wav": {
+     "bytes": 61708,
+     "sha256": "d9b53ab4d53f1265dd2083d341cd92f19729694946ff00ad15fa6d96965e63e8"
+    },
+    "sound/gibs/stonedeath.wav": {
+     "bytes": 76750,
+     "sha256": "26d0eb67357d292043fd494b1646f8ce005ba692d98610429bceedfc831d2325"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 374654,
+     "sha256": "de356a2581884e9008ef798775f82049c465aec242cad0f6024b510d33e11764"
+    },
+    "sound/golem/groundslam.wav": {
+     "bytes": 132412,
+     "sha256": "f557ad378642a77a2f31433db5fe9315cf33f5fc350018e2bd26d32359ec8617"
+    },
+    "sound/golem/iceshard1.wav": {
+     "bytes": 53022,
+     "sha256": "41e523122aa4168298b247748bbe4201928582e974e673a83e717ea33f8656a8"
+    },
+    "sound/golem/iceshard2.wav": {
+     "bytes": 53012,
+     "sha256": "4b4e457f75d051a7aa3525bf82338f8b6d2f9460583c09e63d82b202cb11d03f"
+    },
+    "sound/golem/iceshard3.wav": {
+     "bytes": 53038,
+     "sha256": "8134080a7c6478463f9ea8c368eb6e0563dacb35bb3941b1e08e2cf0763d83ab"
+    },
+    "sound/golem/iceshard_impact.wav": {
+     "bytes": 176470,
+     "sha256": "ac850565ac7cfaa8ec2e55f535603aaf131605b9399f08f1b17f7c08920f7bda"
+    },
+    "sound/golem/icestorm.wav": {
+     "bytes": 61802,
+     "sha256": "2e8129333bc1a677591f9c4838a5f8c8e9ff63050fe6a47f212380f2497ae706"
+    },
+    "sound/golem/idle1a.wav": {
+     "bytes": 88238,
+     "sha256": "d238c43b6e83c044ba70352ed9362e50d68caf606f500c7d79f5c03d1e6a432e"
+    },
+    "sound/golem/idle1b.wav": {
+     "bytes": 88242,
+     "sha256": "93e3ca1ec51345da6e06a53f71bcd1271c911c9a6272246de9f58bef93c904dc"
+    },
+    "sound/golem/idle2a.wav": {
+     "bytes": 44166,
+     "sha256": "d0ceeb0ee1681127f9f426ccaa0ddb75c6ef32594618c972536871544e8d5748"
+    },
+    "sound/golem/idle2b.wav": {
+     "bytes": 44178,
+     "sha256": "94fb43b50445dbe7a8fe6cc06ea745b729cf5bf61c33cc543123f751e4a9cdf7"
+    },
+    "sound/golem/melee_pound.wav": {
+     "bytes": 17672,
+     "sha256": "23ff4f485f3adb3ba5227ba59824e226e91005846d2879077ffbe04141bab78b"
+    },
+    "sound/golem/melee_punch.wav": {
+     "bytes": 17702,
+     "sha256": "21cbd6ca5b9c8d95a43c39b360b12ee8033dca1aaf11d4c1164d4bc9ce83b7d3"
+    },
+    "sound/golem/melee_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/golem/pain1.wav": {
+     "bytes": 27948,
+     "sha256": "388150975b33e271db5402f502c6a36899731ec85cb9b16cdcc4b427b206a3f2"
+    },
+    "sound/golem/pain2.wav": {
+     "bytes": 32940,
+     "sha256": "b3908c02406bcb8c379f345f80a825aa270a54ae02fe0356e02330620d9cf437"
+    },
+    "sound/golem/rockstorm.wav": {
+     "bytes": 264676,
+     "sha256": "c57be8195f675560b879c3fc4e23c49f021d0c45aa81f2a84b74303f111d7c7a"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 76762,
+     "sha256": "965d1107adbc9a068d1d2af16fc783855833569dcc3a6030fa920019c30a4083"
+    },
+    "sound/golem/wakestatue.wav": {
+     "bytes": 250454,
+     "sha256": "630505eb8c9c84511f39d2e77096cafcbab044f73569934cda127a4b6f37f138"
+    },
+    "sound/items/airtank.wav": {
+     "bytes": 22160,
+     "sha256": "9b8f5c5deb886800c91d46809ecf82fb114467eb8a395b9c980d47c6b35f6b17"
+    },
+    "sound/items/airtank2.wav": {
+     "bytes": 66286,
+     "sha256": "76156f8f89e2bedbfaee9ee3340adb6bfe8639f242051178c2655e04cdab5198"
+    },
+    "sound/items/airtank3.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/items/airtank3out.wav": {
+     "bytes": 176494,
+     "sha256": "672a866c27c64f7eda1e05775cea6b4373c289c39fd423a519d39198d10a9c89"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 15122,
+     "sha256": "54c25fca46991ea142e9fdf5309e690ce3ff977df89aa7d14a8938ff386a237e"
+    },
+    "sound/items/backpack_ammo.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/backpack_armour.wav": {
+     "bytes": 20612,
+     "sha256": "438a08f094f47fac5f0b959fdde0f941be50bac12abdaa159f6f727975021aec"
+    },
+    "sound/items/blastbelt1.wav": {
+     "bytes": 43442,
+     "sha256": "a85924de58caed8e32d2849838afa0f248ec26eb295c9fc82eff818bc292f28b"
+    },
+    "sound/items/blastbelt2.wav": {
+     "bytes": 74978,
+     "sha256": "e4747a55ed0d66b6ce3bfe4ad0a4cfa75308657a155ebd9396ada78e0fd46bac"
+    },
+    "sound/items/blastbelt3.wav": {
+     "bytes": 49028,
+     "sha256": "4a2f6e7f65cbbc19c4bd5facf821017f7e60c41b9c164575de5255a40de2ba53"
+    },
+    "sound/items/health0.wav": {
+     "bytes": 8718,
+     "sha256": "cd277cc4fc98dbf9d5b0ba3ab784e468ba77a5aec78fe6086bd125512b6d1dbc"
+    },
+    "sound/items/health1.wav": {
+     "bytes": 13316,
+     "sha256": "ed9a43a3506afd8073e0d5225f3fa43116bb922b84d2216c2053d58f597544e6"
+    },
+    "sound/items/itembk2.wav": {
+     "bytes": 18884,
+     "sha256": "2b5601380dcc36753327eea905d15d2e0fd0f016d9559a2f8924f6f34b8045d5"
+    },
+    "sound/items/jumpboots1.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jumpboots2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/jumpboots3a.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jumpboots3b.wav": {
+     "bytes": 85590,
+     "sha256": "8eda0e57fdadfb61a414b4dae8c567a2bf10d9dabc44db7cf5589f00bba16250"
+    },
+    "sound/items/jumpboots3c.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/lavashield1.wav": {
+     "bytes": 30884,
+     "sha256": "e79050c462eeefcdbe6be0d79ff3042e80e5654c4060cf5377eee366cb4d6b43"
+    },
+    "sound/items/lavashield2.wav": {
+     "bytes": 49190,
+     "sha256": "17e93e45d150704bab8debd86ee8e9c600e9b08fefa70b16e1fe712dfdbd0c23"
+    },
+    "sound/items/lavashield3.wav": {
+     "bytes": 22094,
+     "sha256": "d94735d5df3c5850d2308972cb2495a9c9ec87e57c434c3ff0c160da659b051f"
+    },
+    "sound/items/nailp.wav": {
+     "bytes": 97394,
+     "sha256": "eb786846675412ba7bfb892fa0d5d356b67ec83ad3a551de8b423a874c3608d1"
+    },
+    "sound/items/nailp2.wav": {
+     "bytes": 132454,
+     "sha256": "2a01a3beb92154c7275c3c2ad39f648f8ecad7fd32ef7264d7404b917e0147dc"
+    },
+    "sound/items/nailp3.wav": {
+     "bytes": 45268,
+     "sha256": "0ea4502763119419b226d830b5b0147d6cfbe78996749e330d652d5b538dbb7b"
+    },
+    "sound/items/protect.wav": {
+     "bytes": 44176,
+     "sha256": "1bc5895a71225e8a385ebc900952d3b41f3d9541eefb8affcf15804ca96e5ab4"
+    },
+    "sound/items/protect2.wav": {
+     "bytes": 66286,
+     "sha256": "80b2a47fb1158f252e888bc692d352f224170c2d18177163dfea5c8110688e65"
+    },
+    "sound/items/protect3.wav": {
+     "bytes": 44176,
+     "sha256": "4aab23bd1683c733c5c85e7d55a93b27746860bd3c1a707e8c5a6439e35b5fd2"
+    },
+    "sound/items/r_item1.wav": {
+     "bytes": 12272,
+     "sha256": "3b569e1a8210563a64045dc1629a243b382c49cf24722cbddbdae348d5fa75d7"
+    },
+    "sound/items/r_item2.wav": {
+     "bytes": 14462,
+     "sha256": "088bb9013c0d2201997d3c566b95cc91f0419ba0bc89173c9e532659ccb4e886"
+    },
+    "sound/items/sharp.wav": {
+     "bytes": 100592,
+     "sha256": "c86d353daa830fffcf5ded77b73d6b8871d15a47a857a977ebaf7cbddb6cb587"
+    },
+    "sound/items/sharp2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/sharp3.wav": {
+     "bytes": 46584,
+     "sha256": "6318f7079e79929ff0439a570c5f806ec9c2cce8a8447eddb666dee0c2211336"
+    },
+    "sound/items/sharpa.wav": {
+     "bytes": 97394,
+     "sha256": "cd0d8dc72f736b38ab9c4a473798f0dd32e2074c14a310892c3fdf6515ff53be"
+    },
+    "sound/items/sharpa2.wav": {
+     "bytes": 132454,
+     "sha256": "2545c58a3682c1e8459389dc728a39fe0d76e6ce14a9c816a4826e327ab9bddc"
+    },
+    "sound/items/sharpa3.wav": {
+     "bytes": 45268,
+     "sha256": "083cc822d4cd6819d2dfd6e125ea4ca8ef3230c1ac1c4a5f5e3fe22e4d3d36d9"
+    },
+    "sound/items/suit.wav": {
+     "bytes": 31568,
+     "sha256": "a9b13127acef0c8e617cf5e510d5654227db9049a2b06b7544eb9e3030146ee7"
+    },
+    "sound/items/suit2.wav": {
+     "bytes": 66368,
+     "sha256": "34f0ba1b415ab62f2eb3b7a59bda6fe6fbbf3e519c7d2fab29a42ce29eb073c3"
+    },
+    "sound/jim/death1.wav": {
+     "bytes": 14348,
+     "sha256": "7f97f27dfda78f9fe6fc5265e512b651e57ae466752d56cfe0dccd6d08478ed8"
+    },
+    "sound/jim/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/jim/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/jim/gunidle.wav": {
+     "bytes": 13260,
+     "sha256": "46441335fe896cb993368bb12cedc1ddd4886b5933298bb6a0d6b7ba430cdfe5"
+    },
+    "sound/jim/gunidle2.wav": {
+     "bytes": 48540,
+     "sha256": "08d3577b66ab4b4c65ae7b01e4590e8d985605cc51a939bae0b43967472208c6"
+    },
+    "sound/jim/idle1.wav": {
+     "bytes": 44460,
+     "sha256": "7bc2df6cdd0f9a06cc441c656664edb3c686ab5803dab70948cc27bbba968494"
+    },
+    "sound/jim/idle1r.wav": {
+     "bytes": 44460,
+     "sha256": "7549a540858b1a829ac010930b848474c2f2200b910371368c99e35641f24644"
+    },
+    "sound/jim/idle2.wav": {
+     "bytes": 44460,
+     "sha256": "90d55e9ac8db5523255ec80384abd2508f005890f4fb66a654f4d783435afb4d"
+    },
+    "sound/jim/idle3.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/jim/laser_load.wav": {
+     "bytes": 36040,
+     "sha256": "5f39b9f60c5de5c9c3ac25a5149f1fef557e66c09d7d1a760ed6770082c5a914"
+    },
+    "sound/jim/pain1.wav": {
+     "bytes": 27006,
+     "sha256": "27522940f1db4eb098388e049a63d3a608e4beb2fa248d1232ae45d38a944e85"
+    },
+    "sound/jim/pain2.wav": {
+     "bytes": 30850,
+     "sha256": "6d1988d75f430287ad3e8766e9aafa8c8c85e2f2ebf53395b0fc2eb0fb26d788"
+    },
+    "sound/jim/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/jim/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/jim/rocket_load.wav": {
+     "bytes": 23416,
+     "sha256": "e3820aad09060be13927e56fc0e21112c22161b50b7d5be9cf59b98f84c5a231"
+    },
+    "sound/jim/sight1.wav": {
+     "bytes": 14892,
+     "sha256": "1a0db2b8c8d763f9aae09913d1cd3548fa0e30eb03949e24ef511a70acfda303"
+    },
+    "sound/judge/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/judge/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/judge/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/judge/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/judge/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/judge/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/judge/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/judge/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/judge/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/judge/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/judge/smash_ground.wav": {
+     "bytes": 66250,
+     "sha256": "f29f17426d2bd961d4f166e25fb951c8e12a37314bbc49722f0ae34c2beae233"
+    },
+    "sound/judge/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/judge/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/judge/smash_roar.wav": {
+     "bytes": 61784,
+     "sha256": "24b26a6b00a8731693bafd8ef67a5f0e2a4bbad20e722ec14f6fefd13047dc78"
+    },
+    "sound/judge/summon.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/judge/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/justice/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/justice/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/justice/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/justice/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/justice/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/justice/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/justice/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/justice/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/justice/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/justice/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/justice/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/justice/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/justice/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/lostsoul/bite.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/lostsoul/charge.wav": {
+     "bytes": 114682,
+     "sha256": "327cf4f521c92b3af6ff7cf50d1bfa6d101d06dee52350f123473e56e72626e3"
+    },
+    "sound/lostsoul/death.wav": {
+     "bytes": 151916,
+     "sha256": "08b6f8d3a50465e7deb346bc8902605bfc8bafc134cfac38aeb1d9fa5d1d2863"
+    },
+    "sound/lostsoul/idle1.wav": {
+     "bytes": 132332,
+     "sha256": "aac9bd66ea75d4778a20ba07b248baaa4f446beb60e5b5be76d04be36df1a1db"
+    },
+    "sound/lostsoul/idle2.wav": {
+     "bytes": 132332,
+     "sha256": "963c18a04a41d49ced0c820fd6ec51c885e7828a2a09bd47c15227555b6d4ada"
+    },
+    "sound/lostsoul/pain1.wav": {
+     "bytes": 14948,
+     "sha256": "baccaed4fd7c4e504214eb7241d3e8ea3e187739a781c30de57c8b5af6dbe6d0"
+    },
+    "sound/markie/dronebell1.wav": {
+     "bytes": 410346,
+     "sha256": "c7b65065ba9279c8131a83b642523e4193b8611f7b14430af2d52c831082340a"
+    },
+    "sound/markie/dronehum1.wav": {
+     "bytes": 156754,
+     "sha256": "9542c51342398a1281476da03114adb01012367dac58d2a08b50c684a1a98093"
+    },
+    "sound/markie/dronehum2.wav": {
+     "bytes": 183654,
+     "sha256": "03545ae0f88b788e69e09c0aae2cccfa727a2609ef224c7d1d3451f0e6172709"
+    },
+    "sound/markie/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/markie/dronespace1.wav": {
+     "bytes": 151808,
+     "sha256": "2c9c7f38a2023d3452a48db3e5f98d11fa218315991d907f8e3fa95d128d4f76"
+    },
+    "sound/markie/dronewind1.wav": {
+     "bytes": 110328,
+     "sha256": "f65fd70b6c398e1a17975eff7d92bde89ac17bc8d5cf0e9c6dcb17934311e3a6"
+    },
+    "sound/markie/morte1.wav": {
+     "bytes": 529280,
+     "sha256": "c338e404901bbf094c5946e50cbd922580c077dc3f3e5369ab962cb07a70d855"
+    },
+    "sound/markie/morte2.wav": {
+     "bytes": 529280,
+     "sha256": "58e598c9da2ced85f6973eb897f578e0f29a13fa0eaefebfe14c8942a33c77ed"
+    },
+    "sound/markie/ritual1.wav": {
+     "bytes": 273266,
+     "sha256": "fe9b4b53f899a88321707330bb2454442d74e5098328e35549b9f0a8ff840cba"
+    },
+    "sound/markie/ritual2.wav": {
+     "bytes": 273246,
+     "sha256": "d38ee880af55413aa7c180b8c1935df71177502081ee1c376c37b572af3d9352"
+    },
+    "sound/markie/stingwhisper1.wav": {
+     "bytes": 132380,
+     "sha256": "fc6eebd33c0c99c0f4537a9727698181acb4d23d077f06b3da1ebbcb104c870c"
+    },
+    "sound/markie/stingwhisper2.wav": {
+     "bytes": 132380,
+     "sha256": "ae7319c28e0a4e492623b7ddb48634978da043c16d4450f86b8edf7e60fa283c"
+    },
+    "sound/markie/stingwhisper3.wav": {
+     "bytes": 151672,
+     "sha256": "e5dd9dcfd44dedf7b0cd4a0a94a519a0bbd84477e54293548a37aa16d3f1e428"
+    },
+    "sound/markie/watercreek1.wav": {
+     "bytes": 184884,
+     "sha256": "f0c3ac87d6f073cea0d1a9218c4e53327be7af07a8c8be00cd73f254f6c0ba03"
+    },
+    "sound/minotaur/attack1end.wav": {
+     "bytes": 19936,
+     "sha256": "eceb47163a0f495037bd067fcfe852dbd0cf8cc7c376c536f5e4bda8569d3f5c"
+    },
+    "sound/minotaur/attack1expl.wav": {
+     "bytes": 15554,
+     "sha256": "a8344e4036b9377a6c8e3d69c2e86c7f5fc157fb0034d6e0e190d5b9fc444ca7"
+    },
+    "sound/minotaur/attack1long.wav": {
+     "bytes": 42000,
+     "sha256": "bb901880112ff159b380b8bfaf19fc511f4b1217f08d55a05276a3500f6cd4c7"
+    },
+    "sound/minotaur/attack1start.wav": {
+     "bytes": 19944,
+     "sha256": "33dafc2b20be70d6da51321f9910a392535e6a31cbbd3c8d0d880307a18adb3a"
+    },
+    "sound/minotaur/bolt_fire.wav": {
+     "bytes": 17738,
+     "sha256": "2f8ea56413270eef58b56ae4c4f7af2506ee89fda82aab90c0426f4560baa80a"
+    },
+    "sound/minotaur/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/minotaur/idle1.wav": {
+     "bytes": 17686,
+     "sha256": "d213130ad4b58b5b55553da46d358526411916210e90caf082c5a93b499e2f81"
+    },
+    "sound/minotaur/idle1com.wav": {
+     "bytes": 15564,
+     "sha256": "0f8054eb2c16284a098f680dcdc65f5a4b8b971f8cceaca6adebe8c377d6117f"
+    },
+    "sound/minotaur/idle2.wav": {
+     "bytes": 15470,
+     "sha256": "390c82c79532878751bcddca11aa37dbd86018757860e46d0c950a09fee347d9"
+    },
+    "sound/minotaur/idle2com.wav": {
+     "bytes": 17764,
+     "sha256": "8369884de2f4f144b9e323f11e95f47723834b529b62100c908fef5e74391a93"
+    },
+    "sound/minotaur/jump1.wav": {
+     "bytes": 22160,
+     "sha256": "1aa935c4c76818dbe7faed7aee0d9acb9e98ad553a747bf00b83b811d141e886"
+    },
+    "sound/minotaur/pain1.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/minotaur/pain2.wav": {
+     "bytes": 41488,
+     "sha256": "bc9ffeb193379c6738ad2897ab582aa92e278a11d7f1fbb77563ca367987ff76"
+    },
+    "sound/minotaur/sight1.wav": {
+     "bytes": 48610,
+     "sha256": "8d0a5c1a31e525416430f8d45b8482b091d3bb9f6030ac2656bdeb231ddab5e9"
+    },
+    "sound/minotaur/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/minotaur/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    },
+    "sound/minotaur/strike1.wav": {
+     "bytes": 11142,
+     "sha256": "69b1419eed136c384deac99d31827825d3d57fc965ba80604faf9de3e85fd9b8"
+    },
+    "sound/minotaur/strike2.wav": {
+     "bytes": 11142,
+     "sha256": "ab12dc8ab3c9dc603e2ecd58a99beb9c1f551fb79eb6124bdba493efe7595a92"
+    },
+    "sound/minotaur/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 19940,
+     "sha256": "0798d1a1122171f06fd6b92e3f91881725c05f40e1eeb3494a5a1a1aa8a86e58"
+    },
+    "sound/misc/drip1.wav": {
+     "bytes": 12172,
+     "sha256": "9499c277eab2210ba491b61263b71410e5e8f4b2a68403ec6eb81bef687da04a"
+    },
+    "sound/misc/drip2.wav": {
+     "bytes": 15596,
+     "sha256": "410c25c5c459362849c7d3d0ad736e006b65a949e77c094fe248e803b357d5e0"
+    },
+    "sound/misc/drip3.wav": {
+     "bytes": 15164,
+     "sha256": "9ddf50265efafde7736fb7d03419988caab691245b32d986549ef6d643d2768c"
+    },
+    "sound/misc/flies1.wav": {
+     "bytes": 44168,
+     "sha256": "ca5cf0a4d661bf7440cd81dcd45ad7118c54c8ae58672755ee958ec6e50f7152"
+    },
+    "sound/misc/flies2.wav": {
+     "bytes": 44166,
+     "sha256": "09e6d74986b0f0ec9503d9e111f8d1436d7d6c5c4c0c87ec7808e3fca5b964b1"
+    },
+    "sound/misc/flies3.wav": {
+     "bytes": 44182,
+     "sha256": "2b5fb337ba88bd25e10c86bb6355723aea160b0ef6a6d43b30cbbd446444ed8e"
+    },
+    "sound/misc/gibf_fire1.wav": {
+     "bytes": 14376,
+     "sha256": "804f8524135d058d3a635e6567e3369b8b9ef2ecc808bf6e216c4d65609b86a3"
+    },
+    "sound/misc/gibf_fire2.wav": {
+     "bytes": 25842,
+     "sha256": "354b551ac38a19370126f67e3975ab795953bd7beb2c597f0a01a0de6286b7c1"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/laseron.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/misc/poweroff.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/misc/poweron.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/misc/rumbleloop.wav": {
+     "bytes": 106060,
+     "sha256": "fafcaa92b4a2174045e3826885d14e434a409bf559d1a1d519c4d50ec8939789"
+    },
+    "sound/misc/rumbleoff.wav": {
+     "bytes": 105990,
+     "sha256": "46728daf18b142575d50049188030a153c0e3e994dc83ea375c43ba6da171b3c"
+    },
+    "sound/misc/secret3.wav": {
+     "bytes": 302444,
+     "sha256": "75682a08b790af46c2b9f746e5772999ba1de333b567832f4a3a8414c6a0185a"
+    },
+    "sound/misc/spaceship_fadein.wav": {
+     "bytes": 231712,
+     "sha256": "d6c905eb002532087273eadb5a577db443068532795fd509571179a354c56a9f"
+    },
+    "sound/misc/spaceship_fadeout.wav": {
+     "bytes": 495982,
+     "sha256": "9e5286b29adeb9cf7b3af489bb2ea539c8eed7b26a28ec1f34cd5f78c33e521c"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 13270,
+     "sha256": "14d74e6c01df6db6f92b8684527b31a7544de8d4dd9d123ebae554989e76facc"
+    },
+    "sound/misc/torchoff.wav": {
+     "bytes": 54160,
+     "sha256": "d49cf5f2100d9b5afbf76a662019a9e3a66fcd5fb40c2b2600ceab107227cbf3"
+    },
+    "sound/misc/torchon1.wav": {
+     "bytes": 88680,
+     "sha256": "ecb211c777393fe3c7012bf0a35cc157af94ccb4742cac3ca7ab6daa5546a4ac"
+    },
+    "sound/misc/torchon2.wav": {
+     "bytes": 84764,
+     "sha256": "b7d885df1c70b226a77a3cc8842565fa9ebf51561158daec4b12e9629a515986"
+    },
+    "sound/misc/torchon3.wav": {
+     "bytes": 97484,
+     "sha256": "25058a3354df07a90b8660640682f7091fa40da6f8abf178c7de71d547a8b0c1"
+    },
+    "sound/nour/attack1.wav": {
+     "bytes": 50794,
+     "sha256": "7f22a1569d59bcd406efd7828ed605d71bfbc8cea01606eedb78d33037655f77"
+    },
+    "sound/nour/attack2.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/nour/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/nour/death.wav": {
+     "bytes": 39772,
+     "sha256": "2e2d15b95fc35738108d83a2b5aefded93772134d2a8124d1b937b6bfcfd74c5"
+    },
+    "sound/nour/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/nour/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/nour/explode2.wav": {
+     "bytes": 22168,
+     "sha256": "654a50eb01d1c6c64bb8df4b85669448cc08b580ffc44616da854bd3cb339ea1"
+    },
+    "sound/nour/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/nour/idle1.wav": {
+     "bytes": 24332,
+     "sha256": "c77ef8ce85720e3bf0ea97937992b5aa7cc6b63149c951e71b4d3ead14fc21af"
+    },
+    "sound/nour/idle2.wav": {
+     "bytes": 44176,
+     "sha256": "e87bd537a35c005b06ffd28f66adde24d52af338d3956d4fab455d682e78eec9"
+    },
+    "sound/nour/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/nour/pain.wav": {
+     "bytes": 8686,
+     "sha256": "073044c582c2de6f336130aeb9503fa6edf1da4eed216a4b407b2cd18d5f9995"
+    },
+    "sound/nour/projbomb_burn.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/nour/reveal.wav": {
+     "bytes": 39780,
+     "sha256": "6dd892d207fa31eb93c5a033ab44bba4952b3aed892aa409e6a49e2059381cdb"
+    },
+    "sound/nour/sight.wav": {
+     "bytes": 48612,
+     "sha256": "252c0bf76b928f7fe998f82bf148816e88cdc24f812bd8c8d3a591c1c4ec3d7d"
+    },
+    "sound/nour/sight2.wav": {
+     "bytes": 48612,
+     "sha256": "18b8e9450c00d6a9308adffa2046e747b8ed7bb5547f868ed146cca75b260b87"
+    },
+    "sound/ogre/ham_hit.wav": {
+     "bytes": 52014,
+     "sha256": "20f7ec214fdf8a342ac8c3be7d3ed04c7b7b3479f9c74138a8a052ba7674ee46"
+    },
+    "sound/ogre/ham_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/ogre/ham_wave.wav": {
+     "bytes": 132316,
+     "sha256": "d957285dc74a4e067f600465112ed41d69d14554f8e87ad6b0372b9ca8af4b25"
+    },
+    "sound/ogre/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/ogre/ogidle.wav": {
+     "bytes": 25706,
+     "sha256": "54915681452970c56f1ef405b182e90fa7ee3c4d4d80e32583a38abc7c1db713"
+    },
+    "sound/ogre/ogidle2.wav": {
+     "bytes": 22426,
+     "sha256": "2ed241e576a709285f7ea8a9671f6032da5a8db96e094e9007f60617cad491fa"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 28742,
+     "sha256": "738af1bbf36d5b3287c45e7815d87ea7f5c1a0487c804de7272091fdbb7faac2"
+    },
+    "sound/ogre/ogpull.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/ogre/ogrefish_flappy.wav": {
+     "bytes": 51262,
+     "sha256": "79a9eafef5edf45851a1c391e301c6f515536922c297b904e148b337e7f54a08"
+    },
+    "sound/ogre/ogrefish_idle.wav": {
+     "bytes": 27552,
+     "sha256": "5abf50694e67aa1e805a598a464d5d3b1f0625677a2873761cae139c4b21d524"
+    },
+    "sound/ogre/ogrefish_in.wav": {
+     "bytes": 6678,
+     "sha256": "dd5fc9aecb5b6933252739047aa5d3f775797ad7bf6ddb5652ffd26ea9ead3e2"
+    },
+    "sound/ogre/ogrefish_out.wav": {
+     "bytes": 15502,
+     "sha256": "2610f025057ee0a6682b574567b7400f83ba9f6665b9f7f3b9e76cff75b8be53"
+    },
+    "sound/player/h2ojump.wav": {
+     "bytes": 22126,
+     "sha256": "dd2d3629970814e719be6c9650a497edd219f31fb1554927b9770a1b0dfcdc60"
+    },
+    "sound/player/heartbeat.wav": {
+     "bytes": 70640,
+     "sha256": "a68fd895a3212f967a4686e94df2749fa3f58392ab2228aa880697e25b548147"
+    },
+    "sound/player/inh2o.wav": {
+     "bytes": 22126,
+     "sha256": "4c4d55502ab63ddbc9beb64b0459ad4d7a2992fe41e76144d3bbd3333af4a570"
+    },
+    "sound/player/ladmetal1.wav": {
+     "bytes": 95952,
+     "sha256": "6cd990509a965ff251ffb33ff7c22b6eb708cec5f7b7b82e2196b1fb3d3cb1c2"
+    },
+    "sound/player/ladmetal2.wav": {
+     "bytes": 96116,
+     "sha256": "a477162fc355efc88568b9e18d668b7b0e8e99af460b88c755bd1ed57da35006"
+    },
+    "sound/player/ladmetal3.wav": {
+     "bytes": 96008,
+     "sha256": "20ea0c70bcc3c951bb067cb65b938c63267bba0a1eda3a335df525dc9432d234"
+    },
+    "sound/player/ladmetal4.wav": {
+     "bytes": 96126,
+     "sha256": "d2a6bede3a9c499d01a0b0b9620d4bd1935f9477ecb9c59a8d73f3133699ea45"
+    },
+    "sound/player/ladrope1.wav": {
+     "bytes": 70706,
+     "sha256": "6713acc390790d4723df21b0702796958132af34ce5ec0a85fca5edc36ccd728"
+    },
+    "sound/player/ladrope2.wav": {
+     "bytes": 70792,
+     "sha256": "384b8c3ad3749fa9963ff3210d7cb312858771cca85082b6a8ad13179ad92da3"
+    },
+    "sound/player/ladrope3.wav": {
+     "bytes": 70760,
+     "sha256": "ed397a0308ecacd0ba9774f082aec5e681bcffb219c8d9127b7d7606a6fbb02d"
+    },
+    "sound/player/ladrope4.wav": {
+     "bytes": 70758,
+     "sha256": "e1a4327f1c458f408abd6ff713d11e0aee8daaa9c876002b693135d8e64b68fe"
+    },
+    "sound/player/ladwood1.wav": {
+     "bytes": 48084,
+     "sha256": "bd68f3af0f6cd429d08aa44168e14435ed9e2e2ec0d6a038f83e2dd683cb7e74"
+    },
+    "sound/player/ladwood2.wav": {
+     "bytes": 48086,
+     "sha256": "bb687ec2183f460ac4240acfcd2f3da2f8bd9da043ba705f6e32c3439e4845b9"
+    },
+    "sound/player/ladwood3.wav": {
+     "bytes": 48088,
+     "sha256": "7271136b6398602c7b4bdbd610a37b5a82a66195842030a21de08a89808b4026"
+    },
+    "sound/player/ladwood4.wav": {
+     "bytes": 48086,
+     "sha256": "3b7580b31dee8a86e636c5fd17d92566d147417f98764d51097ad53ff0d19d29"
+    },
+    "sound/pushable/brick_m1.wav": {
+     "bytes": 44144,
+     "sha256": "7572ac5d03045552dfee673293722da8c663d072cc7b57e44adb2e3884ea33c9"
+    },
+    "sound/pushable/brick_m2.wav": {
+     "bytes": 44144,
+     "sha256": "209e22e4693184c7b0c022e650b156e255cfa76b18c1066fe20255e285b4e80b"
+    },
+    "sound/pushable/brick_m3.wav": {
+     "bytes": 44144,
+     "sha256": "edafb8bf0915badb97edd078aa129c10a29e8fc428f4e9143f5926f9aa336e43"
+    },
+    "sound/pushable/glass_m1.wav": {
+     "bytes": 48044,
+     "sha256": "66a5944b16e3fe59cf9f8632f92bd85f81b79dc8711337558c45078c91a13c46"
+    },
+    "sound/pushable/glass_m2.wav": {
+     "bytes": 48044,
+     "sha256": "d462bac59390f89facc7c00d8aaee6e71b529ae9f177514a5f2f0533c78d5a0e"
+    },
+    "sound/pushable/glass_m3.wav": {
+     "bytes": 48044,
+     "sha256": "1a2efd7875486d15df811135d589135c807ba0149c877085f165932eb2770320"
+    },
+    "sound/pushable/metal_m1.wav": {
+     "bytes": 44144,
+     "sha256": "91420caf0e2de995681ac09b2be26cc9d0759edc06498571527528419de407d1"
+    },
+    "sound/pushable/metal_m2.wav": {
+     "bytes": 44144,
+     "sha256": "72f018c79b343538fd90de944ed54e8e3351b3da0a6c198f28403d25fc8fb140"
+    },
+    "sound/pushable/metal_m3.wav": {
+     "bytes": 44144,
+     "sha256": "c26b3aff129d573a1175fb618186db3b7ede8976e134c563c1678f48eaf8e302"
+    },
+    "sound/pushable/rock_m1.wav": {
+     "bytes": 48044,
+     "sha256": "9fb6ebeae45b4c47b1e42af1f00441d0e0bb88fbb53f85ea875341f9db55efb4"
+    },
+    "sound/pushable/rock_m2.wav": {
+     "bytes": 48044,
+     "sha256": "b57d0f760bb318b1159293e38811e5607bae8ff244d8bbf56223b355ef7c5b39"
+    },
+    "sound/pushable/rock_m3.wav": {
+     "bytes": 48044,
+     "sha256": "5e6514c241bb11d6194d9762d5369fb2a8da287b3d4c08e67f23da84fdb26b04"
+    },
+    "sound/pushable/wood_m1.wav": {
+     "bytes": 48044,
+     "sha256": "e672209779ee47996ca93e60d30e572da3cced5381db3f34c14a709629a5f4d2"
+    },
+    "sound/pushable/wood_m2.wav": {
+     "bytes": 48044,
+     "sha256": "c76b7db5faf1cbf21c07dacec615436a95f34c0e16e68628b62ec89a89b12f83"
+    },
+    "sound/pushable/wood_m3.wav": {
+     "bytes": 48044,
+     "sha256": "d6751d9e67c49458df6c076d9b6be9619f845213a263cb76330f51700f8a632c"
+    },
+    "sound/scorpion/clawattack1.wav": {
+     "bytes": 13360,
+     "sha256": "b0daf0605690db89f34a19936f1c20ad25676a4e6cd9dfad0e5757cf81dc4f7d"
+    },
+    "sound/scorpion/clawattack2.wav": {
+     "bytes": 13360,
+     "sha256": "06da85e6d6035704932fdc1ef449de529e17853571d017c5a42b253b5ed71a94"
+    },
+    "sound/scorpion/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/scorpion/hiss.wav": {
+     "bytes": 26664,
+     "sha256": "9d9fae97f3996ff3c0616f7acda952166d5eced9227d15a8fbe9d285095e7936"
+    },
+    "sound/scorpion/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/scorpion/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/scorpion/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/scorpion/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/scorpion/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/scorpion/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/scorpion/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/scorpion/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/scorpion/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/scorpion/tailattack1.wav": {
+     "bytes": 25858,
+     "sha256": "61e6c65b4c68813925e594b96ebad8a945c87d51f2cd23f301e80e231e53033d"
+    },
+    "sound/scorpion/tailattack2.wav": {
+     "bytes": 19650,
+     "sha256": "aab86f97eed636ebfb79ae7b92e4b7f7a3436b0146ad75519edd4358716169c7"
+    },
+    "sound/scorpion/tailfire1.wav": {
+     "bytes": 8924,
+     "sha256": "1f41bd184aa58b9f2f1b2f1197f3b7827c55d523d03a354dd1fb6d469cf129c8"
+    },
+    "sound/scorpion/tailfire2.wav": {
+     "bytes": 8948,
+     "sha256": "40a126ab5cba6c291d69606eddb7e2ab63ab640b1347b2e78ab4b0f7aca90c5c"
+    },
+    "sound/scorpion/warning1.wav": {
+     "bytes": 76930,
+     "sha256": "ae19faeebc0d3ec8c9f136bba205e634a29425ec86c3036016e5f2d9cd550817"
+    },
+    "sound/scorpion/warning2.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/seeker/death1.wav": {
+     "bytes": 397272,
+     "sha256": "35d8a1091032f24ed6a65efa99a7618f32bc0def24779efb51752b75a9e31ca1"
+    },
+    "sound/seeker/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/seeker/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/seeker/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/seeker/footstep1.wav": {
+     "bytes": 96092,
+     "sha256": "e5cd4f907a1b70ec72048b2dd5a5062022e7058676c3d90d05b7426e189a5073"
+    },
+    "sound/seeker/footstep2.wav": {
+     "bytes": 96076,
+     "sha256": "f3c8ba8d65257ddfa73e3e54c737c49de5dcc5c17bb088feb3511c3d69d21ac4"
+    },
+    "sound/seeker/footstep3.wav": {
+     "bytes": 96092,
+     "sha256": "c6fa111be092592a253815826c499b9b1f18a0c536910e2a82eebec7fb7f817d"
+    },
+    "sound/seeker/idle1.wav": {
+     "bytes": 141126,
+     "sha256": "10693a1d5fc1d710e54a0d57ce10d71400de192b874d6776ffe176c2b399a6b5"
+    },
+    "sound/seeker/idle2.wav": {
+     "bytes": 97420,
+     "sha256": "c24b439701d9ec3cf055702f23a3eb23623320ae89b9d46ab98a791f08898573"
+    },
+    "sound/seeker/melee1.wav": {
+     "bytes": 106252,
+     "sha256": "addfb5fab225a77f08d5c126b13f929fa31aa1c9094fc79202121ca891933fb9"
+    },
+    "sound/seeker/pain1.wav": {
+     "bytes": 19884,
+     "sha256": "ccaca64b8c1ab87d7d70896333cbec22c3b61c443a36cd8f253ad0eafc2d7ae1"
+    },
+    "sound/seeker/pain2.wav": {
+     "bytes": 19884,
+     "sha256": "8c3be23111a5ef53a7b66c7b74e32404ff0e6989d7de835543e0a65645e3f793"
+    },
+    "sound/seeker/punch1.wav": {
+     "bytes": 19940,
+     "sha256": "e4bf6b7deb14b5d614b4d5b7d4eeee36059372c913cc906589e1048d4484259d"
+    },
+    "sound/seeker/range_laser.wav": {
+     "bytes": 88246,
+     "sha256": "ee9f13af042a2a98fb75fa33873a1e861f3418f598ddb390f15ab44fcf93fcbf"
+    },
+    "sound/seeker/range_plasma.wav": {
+     "bytes": 79782,
+     "sha256": "9b1d38a4e1937023536d5ab5de035c97e1ef69131d58822b194cab2a3aa340b3"
+    },
+    "sound/seeker/range_rocket.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/seeker/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/seeker/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/seeker/sight1.wav": {
+     "bytes": 163526,
+     "sha256": "ca06541f54bcc297ab19ee133de5c782e978cf7afc2fab34b3789c4c56044d30"
+    },
+    "sound/sentinel/laser.wav": {
+     "bytes": 9712,
+     "sha256": "c5f90e1823a04b48f7f24ac5b8792e1b42030a8b07970db5847dc1e74be094c2"
+    },
+    "sound/sentinel/nail.wav": {
+     "bytes": 13750,
+     "sha256": "7acc3ac05b7218abc6fef2d2397771d90fce6fa39415e33824be7e771d30e288"
+    },
+    "sound/sentinel/widle1.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/widle2.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/wpain.wav": {
+     "bytes": 19596,
+     "sha256": "bc7b6536a1c67aa89295eeacea2d9b36cb0bf783b5fb7cc6aaf4fa01a0edb3fd"
+    },
+    "sound/sentinel/wsight.wav": {
+     "bytes": 27322,
+     "sha256": "83bca2103d60c68435e27f0660e3ecd5bffb058e796382e7bdb43efabdfb9889"
+    },
+    "sound/shalrath/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/shalrath/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/attack1.wav": {
+     "bytes": 44184,
+     "sha256": "91f50e3b69909213e23149b6a3e9622c4367d77f871da5f01e6e4aea3badf648"
+    },
+    "sound/shub/attack2.wav": {
+     "bytes": 33174,
+     "sha256": "d4928f711f7e8fc1d8ba050a87b4e1c2d48ffc24af6a454637629dfae8902e3f"
+    },
+    "sound/shub/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/death1.wav": {
+     "bytes": 107440,
+     "sha256": "1551554be1b7896ee39156ce258bf68ac5dace891994788020ee95083ae33e77"
+    },
+    "sound/shub/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/shub/idle1.wav": {
+     "bytes": 75072,
+     "sha256": "9d33c61470d0c4269c8d113b4476b84236fa00e6ee3be061865e242c988093af"
+    },
+    "sound/shub/idle2.wav": {
+     "bytes": 75000,
+     "sha256": "21b063438744def5f79a50709c567cc9f3e3a28c39e58456068a3d4ae362617f"
+    },
+    "sound/shub/idle3.wav": {
+     "bytes": 75096,
+     "sha256": "310c4ff969da63c77e7ebb5b319aca0f17a10802ee942b21174349d5e5a79d72"
+    },
+    "sound/shub/pain1.wav": {
+     "bytes": 83880,
+     "sha256": "1d1536a51822b67106ea72bcb537efbf5f69e4a4592904f6feedee06ef5084df"
+    },
+    "sound/shub/pain2.wav": {
+     "bytes": 83886,
+     "sha256": "71c30d3f41e0f99cffcf5037b482c1da7bf028b477051219f6e605ceef28ae38"
+    },
+    "sound/shub/sight0.wav": {
+     "bytes": 83880,
+     "sha256": "6d4d96fc663db248cf9279c0b028c11b451b133c6e2c38364c13e105f8fa377f"
+    },
+    "sound/shub/sight1.wav": {
+     "bytes": 83880,
+     "sha256": "ecaf1595f3acbfe2e771a193c69bd6de5e6e3bd957405fdf4bcf59a2288bdb05"
+    },
+    "sound/skullwiz/attack.wav": {
+     "bytes": 15484,
+     "sha256": "ca662d909cb3b96bdfb93197092ed8e8a5d1ed27772a91a4a6ae5e9d3063017a"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 33166,
+     "sha256": "5d1ccd5b97bd38eaf46d1e0798009765d46d58ba17e7e6efc36350b0adaa22f7"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 33178,
+     "sha256": "dd77e90760bd85fc872a96c2eaa808b094a461ab2871bd8ab6a5372861560512"
+    },
+    "sound/skullwiz/blinkspk1.wav": {
+     "bytes": 44200,
+     "sha256": "ade109f32810094922f77bc3c03f02d33e98d855d3dcaf79ceab4cb200efaa65"
+    },
+    "sound/skullwiz/blinkspk2.wav": {
+     "bytes": 44204,
+     "sha256": "16d3b1296e1ed9c3bdc06dd25f5d9db3569cf3486794d29858d5ad227741dd1a"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 33166,
+     "sha256": "bc83800a91fad273e7f84f3cec2fa2787c902f4cd97fd5495f73dc9fb6d2c368"
+    },
+    "sound/skullwiz/fadeaway.wav": {
+     "bytes": 43092,
+     "sha256": "dd67d3ffe5a592b4e449d6bb00eee3c525ede786b0a2d9089832981311bfd61e"
+    },
+    "sound/skullwiz/idle1.wav": {
+     "bytes": 88252,
+     "sha256": "1834b946ff68aab07ade01b68d95d822d0b2a1baa51c1ceba7e66c73b8b6211e"
+    },
+    "sound/skullwiz/idle2.wav": {
+     "bytes": 88240,
+     "sha256": "57c49c7fd4f52b870a658e2e854e16c67389e9d79f9a1db5928f12d74741a1da"
+    },
+    "sound/skullwiz/pain1.wav": {
+     "bytes": 11132,
+     "sha256": "125e06cdfacd6aa78a90034d3f94086736734dd1dd9d170fef3a512b42e34cd0"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 15540,
+     "sha256": "ac5a56dbff28fa4724bd8766d8443090e3026007f6f4051cfecd2869b3f5ecb9"
+    },
+    "sound/skullwiz/poison_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/skullwiz/sight.wav": {
+     "bytes": 36484,
+     "sha256": "3051df89bfdce6b80c49c3513cfcbd679bf1f71c5562430d7738737e44f04f26"
+    },
+    "sound/skullwiz/skull1.wav": {
+     "bytes": 22144,
+     "sha256": "3a43bc5e1079740b61199ff21518f75cc1e4db7cdc9e25b57631b38b04d651a2"
+    },
+    "sound/skullwiz/skull2.wav": {
+     "bytes": 22158,
+     "sha256": "fed613207dc7691118ea5b62626df8773bda59816b008bfd2aeaa4d2f26a4b7b"
+    },
+    "sound/skullwiz/summon.wav": {
+     "bytes": 97022,
+     "sha256": "bf74e3dfbb330f481790f7bbc2b88e74b1654f7d5b327235c3d00bee3f62a06a"
+    },
+    "sound/soldier/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/soldier/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/soldier/rocket_load.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/spider/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/spider/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/spider/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/hiss1.wav": {
+     "bytes": 17802,
+     "sha256": "c56fcae8a01af94c07807730857b4b367f2c70c35869505528504faa29a17ade"
+    },
+    "sound/spider/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/spider/hiss3.wav": {
+     "bytes": 22582,
+     "sha256": "1a3c71b1e4ac2389c98c4af9db88e81b51a602c681bd00a1812995654863e2d4"
+    },
+    "sound/spider/idle1.wav": {
+     "bytes": 20922,
+     "sha256": "8a6d25359bbbc1f5e4f6962f4ce1742160537c6bb8bf8b806a0df96adfae819d"
+    },
+    "sound/spider/jumpland.wav": {
+     "bytes": 6038,
+     "sha256": "3c46bc58c52a61480c1a8dc2034aa240545521baf5e0027372992a9458796919"
+    },
+    "sound/spider/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/spider/pain1.wav": {
+     "bytes": 6108,
+     "sha256": "728cd94a64b27dea4d845a9e27e1ba09cfb286bff80128a67d1da0431b6b0c20"
+    },
+    "sound/spider/pain2.wav": {
+     "bytes": 10460,
+     "sha256": "736f0a768c0f52b22a301fc6a15f18f2f60e5579d3b27c2b78bcb7bed8e0c577"
+    },
+    "sound/statue/comidle.wav": {
+     "bytes": 17722,
+     "sha256": "3567914304c8fcf224e31bc302039432cd17833daabc2ed9f83053b01fef4f7c"
+    },
+    "sound/statue/death.wav": {
+     "bytes": 13472,
+     "sha256": "b030aeac3d806bc77fddaed4bb32684cfd2bbd707fe85e2500a3346c5931ec68"
+    },
+    "sound/statue/hurt.wav": {
+     "bytes": 8012,
+     "sha256": "9193f4e976675042409db103f7e3b26f667a56e913e96a37f223f1c606323246"
+    },
+    "sound/statue/idle1.wav": {
+     "bytes": 13304,
+     "sha256": "0b5d3bcbd00e846d38986f8919ff4fa7bcce92e45e5ba5949edd0e81b741b69c"
+    },
+    "sound/statue/idle2.wav": {
+     "bytes": 13316,
+     "sha256": "45469f14a25fd434ba1ed987fd20835ac058496d41df5a6aa543dec454670f36"
+    },
+    "sound/statue/sight.wav": {
+     "bytes": 9584,
+     "sha256": "84ab06d320f9953eebda7c4dd25a0e0de3369957de01c64af10a8b3ca886241e"
+    },
+    "sound/steelclaw/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/steelclaw/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/steelclaw/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/steelclaw/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/steelclaw/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/steelclaw/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/steelclaw/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/steelclaw/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/steelclaw/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/steelclaw/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/steelclaw/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/steelclaw/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/steps/drag1.wav": {
+     "bytes": 13586,
+     "sha256": "db069e08b7de4c5074cc4dd56f3b1cd2b6d77fe7869e1e03f5dddddcf9aad530"
+    },
+    "sound/steps/drag2.wav": {
+     "bytes": 13572,
+     "sha256": "b2ac07fe014e7c5afd4a5974c5d290b34a880a52f33668030a97a345d5811db9"
+    },
+    "sound/steps/drag3.wav": {
+     "bytes": 14690,
+     "sha256": "a29ee6f0977b205d146f81ee5be2f9b2f12ca76f177aaab9e35e556c4f555fa9"
+    },
+    "sound/steps/drag4.wav": {
+     "bytes": 13584,
+     "sha256": "1b5628a4272837ccf9c4044371a1d45eef23439b164be445b6f2ca90952e3487"
+    },
+    "sound/steps/drag5.wav": {
+     "bytes": 13584,
+     "sha256": "6dec9033ece2a02ce65c437e1b7e58512fd04d41a327487704de71cdf39b99dd"
+    },
+    "sound/steps/giant1.wav": {
+     "bytes": 33140,
+     "sha256": "d28f78c1514f215c64b6a3de38b5ffb5b891341ed95dc0277b1b3dba498cc64a"
+    },
+    "sound/steps/giant2.wav": {
+     "bytes": 33138,
+     "sha256": "7936f32a0ae371e216a195c3110b24db372a15091ea5c80e78875951f874d3b0"
+    },
+    "sound/steps/giant3.wav": {
+     "bytes": 33126,
+     "sha256": "58f79749cbdaaa608e6aacc368b74e0ac1e2ecf2ef45967c7f1f7b7a3e99c8fd"
+    },
+    "sound/steps/giant4.wav": {
+     "bytes": 33136,
+     "sha256": "4ffa741a70225aa31078f73a5612cf7d5ad9f9007163f0a5aeda749da099f9bd"
+    },
+    "sound/steps/giant5.wav": {
+     "bytes": 33138,
+     "sha256": "a2706d4dd9856cccdc3980156a77702883e36d86df54221b31a781c8e5e767e3"
+    },
+    "sound/steps/heavy1.wav": {
+     "bytes": 13282,
+     "sha256": "603679f83cc5095d2fa81d945285b2980195ba50ee2615fed85487493f0a536d"
+    },
+    "sound/steps/heavy2.wav": {
+     "bytes": 10870,
+     "sha256": "384f160ad4816b6984ef6b3b59c4bc1e8a2a3e05f9aaa80ee8b30ada2645669f"
+    },
+    "sound/steps/heavy3.wav": {
+     "bytes": 12828,
+     "sha256": "936417bc5ec9d30db8a74a9798328436259ffd704b11e1155d3fa79dc829e462"
+    },
+    "sound/steps/heavy4.wav": {
+     "bytes": 11050,
+     "sha256": "8d4879d40eda9182ff45fb18130c7979997d326581c14edeedc9cab440531e00"
+    },
+    "sound/steps/heavy5.wav": {
+     "bytes": 10198,
+     "sha256": "4e2e9892dee74d3472a45ecda889ae8d2f836786b44a55e5d1436690c7dadd5e"
+    },
+    "sound/steps/large1.wav": {
+     "bytes": 33118,
+     "sha256": "c387d084a10b28329610d8e3ad3e377f43087013e802be42af79f254276d00dd"
+    },
+    "sound/steps/large2.wav": {
+     "bytes": 24960,
+     "sha256": "ab91b4605671dd16da59963959cda3368a065612d8ed1776847da310b1e7b5fd"
+    },
+    "sound/steps/large3.wav": {
+     "bytes": 24280,
+     "sha256": "3e6a5ef0d8cbaba2e976f199d8d1ffa073fe8e83dacee709137335d42ddd7558"
+    },
+    "sound/steps/large4.wav": {
+     "bytes": 22092,
+     "sha256": "f2bde1b715f679cf814c2cd1375442170cf9f6e56d8ea1756900f81f1d1df453"
+    },
+    "sound/steps/large5.wav": {
+     "bytes": 24320,
+     "sha256": "c15b388bbed461461bac2c22b3a88ff272c04ad070e4791b7ce35c1559d16f77"
+    },
+    "sound/steps/light1.wav": {
+     "bytes": 8872,
+     "sha256": "f034fe2692c0fceb6de1c00e15facbcbd31ccd1fcf72510fd1e3cb6bdcc28795"
+    },
+    "sound/steps/light2.wav": {
+     "bytes": 6654,
+     "sha256": "998f665b4a7ccbc995096697606a91d208db024b0882df75ebaaac015f0d4ef6"
+    },
+    "sound/steps/light3.wav": {
+     "bytes": 6670,
+     "sha256": "b25e020a10ac6a7883fd584cff4895d6d785f8577daea15a30d2b745e146c1c6"
+    },
+    "sound/steps/light4.wav": {
+     "bytes": 4472,
+     "sha256": "a111052881024eef6e97393c1388e8ae538227b85c9b8cf0a73704abb2a504b1"
+    },
+    "sound/steps/light5.wav": {
+     "bytes": 3588,
+     "sha256": "55fb54e5ba2f8ec6249761ae6f07c12de6133457b51c584759e8841fb14cb46f"
+    },
+    "sound/steps/medium1.wav": {
+     "bytes": 8872,
+     "sha256": "38e731803a49be7d8018dd7b44060b578b5418f2f7aefb04d1c74c968ced187a"
+    },
+    "sound/steps/medium2.wav": {
+     "bytes": 8852,
+     "sha256": "e8701598e07f43a20aebebd1d1a5043213018199d50472dea37672e6dce4a2b3"
+    },
+    "sound/steps/medium3.wav": {
+     "bytes": 11068,
+     "sha256": "3ed07795c2363552554e6da1da5749be08e460fc6cd4c7266b9fa514732abb2f"
+    },
+    "sound/steps/medium4.wav": {
+     "bytes": 8872,
+     "sha256": "008992cd7972e7e1e6f0b785b40e398a8efe744a3f3f57e47370936796c3d6b5"
+    },
+    "sound/steps/medium5.wav": {
+     "bytes": 8864,
+     "sha256": "ccd26430fd354c0e87750e02d92c40071ef9dccadae5bdeebc7e0d2a2ec4eba7"
+    },
+    "sound/steps/slow1.wav": {
+     "bytes": 8878,
+     "sha256": "15614044d9d277fa3359edb07e7af74b9d7875150fddde5ab1fdceb0143337bb"
+    },
+    "sound/steps/slow2.wav": {
+     "bytes": 8856,
+     "sha256": "a8b16b688d12812a61127a885bf43c360adc2b84ae7806cc107b433c6f4635ee"
+    },
+    "sound/steps/slow3.wav": {
+     "bytes": 8852,
+     "sha256": "3a2a57e1a37d378c1ee73d5732840f6d20e588d794216c33896bf25879807600"
+    },
+    "sound/steps/slow4.wav": {
+     "bytes": 8868,
+     "sha256": "78bdea66991184043001262cc6ef5f1148cf0eb11b5f88fc51ff948311156e5f"
+    },
+    "sound/steps/slow5.wav": {
+     "bytes": 11076,
+     "sha256": "f63c868bd87926f017bec092749bd61c763b0b18635456ed56b660e53bf581af"
+    },
+    "sound/steps/water1.wav": {
+     "bytes": 63814,
+     "sha256": "01ed631b0d92dab11086b1106acc278ffd92522e2e46d21a0650fd29a79780f2"
+    },
+    "sound/steps/water2.wav": {
+     "bytes": 71994,
+     "sha256": "1b53561f02f60da1e1b6c8b72f722ba12e549c318725b974745b38666efa8e56"
+    },
+    "sound/steps/water3.wav": {
+     "bytes": 71802,
+     "sha256": "bbc0778017ccb579a9d531316b8af46585e91a100a251707ac34f4dbddf6922d"
+    },
+    "sound/steps/water4.wav": {
+     "bytes": 61448,
+     "sha256": "d3604afcb7751d987a78a0ee8ee4ca3593315cc6cf2f1909a9f7748535ccea50"
+    },
+    "sound/swampling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/swampling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/swampling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/swampling/idle1.wav": {
+     "bytes": 132044,
+     "sha256": "418eae21e001c1ae065df9357ebf2ad331f761062d75f345f12e99d9aec8cfb5"
+    },
+    "sound/swampling/idle2.wav": {
+     "bytes": 70444,
+     "sha256": "4026b4b56ffa9a207e1457e03ec94a8eb9042cfebf1c042fa291ba2bbbf1c4b5"
+    },
+    "sound/swampling/idle3.wav": {
+     "bytes": 171644,
+     "sha256": "fa54eaf040baf965f994b328bfb1a55cd90d1741d57ed580c1d44c51e9c125f8"
+    },
+    "sound/swampling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/swampling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/swampling/pain3.wav": {
+     "bytes": 67244,
+     "sha256": "4b186834bbec7d2ef9873f55d5df980da3b3fd2f19f76e54fd835d1aaf40fedd"
+    },
+    "sound/swampling/sight2.wav": {
+     "bytes": 88044,
+     "sha256": "6989ba3aca0c5f5e12d30d9958c6ab169f5c6c96f36f4843a9a19bab0e5d0c4c"
+    },
+    "sound/swampling/spit4.wav": {
+     "bytes": 76848,
+     "sha256": "6855555e2a188ed9ae0a1cd307c7715e54c6f3c10ac0fee9edbba2edf1a48d16"
+    },
+    "sound/traps/flame_loop.wav": {
+     "bytes": 28560,
+     "sha256": "661d8325af92fb37235952e2668578dbf57d844b7359627b4a2c25d15127bff7"
+    },
+    "sound/traps/flame_off.wav": {
+     "bytes": 28496,
+     "sha256": "ebc40d62265aad20813acd189511be0bac063ecc00d7ae712863de3dbdb84c94"
+    },
+    "sound/traps/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/traps/laser_hit.wav": {
+     "bytes": 4358,
+     "sha256": "0840d9fa27bfd2bcb86c2f0174810ae3eb9baa6a43867d27de1e074f7cd75e2c"
+    },
+    "sound/traps/pend_hit.wav": {
+     "bytes": 11908,
+     "sha256": "6fec8fd4edb67e8905d9ad0d7dce5ee5a9b4f43b724b75cb449e88b508384e11"
+    },
+    "sound/traps/pend_swing.wav": {
+     "bytes": 22142,
+     "sha256": "d20bbaf323c5aa0ee2aa21222f2a9f5fc956c0317e65c05e9d003bb08d80a9ae"
+    },
+    "sound/traps/saw_end2.wav": {
+     "bytes": 99808,
+     "sha256": "2a129f2d5fe3c9fd60873c336e2eed799b3d2ebc91bc8bf5a0860b45a6b83ceb"
+    },
+    "sound/traps/saw_loop2.wav": {
+     "bytes": 173082,
+     "sha256": "b4ca1bfeaab62c73bfc10f7daa2750738874d721af9e637479e8242f5220294c"
+    },
+    "sound/traps/saw_loop2f.wav": {
+     "bytes": 132748,
+     "sha256": "03a3e77feb8775a7b486363ed1d46d04fb9294f5507040e458ed8a05c37f0de8"
+    },
+    "sound/traps/saw_start2.wav": {
+     "bytes": 217184,
+     "sha256": "49f1dd84a7be0c4d0b1293aa587ab786d69f4cb463ce5a03f09da816eb22d384"
+    },
+    "sound/traps/sawblade_off.wav": {
+     "bytes": 15276,
+     "sha256": "44924313561cf32ea95c50ef80366ba79a2c86ff2f218fc89404c82617ce2c84"
+    },
+    "sound/traps/sawblade_on.wav": {
+     "bytes": 37582,
+     "sha256": "097635d29859ce28ea37da2d51ec346b8d5239435bb6be0bf5f094a555c110e8"
+    },
+    "sound/traps/sawstrike1.wav": {
+     "bytes": 30836,
+     "sha256": "489d8cdea78b2c333771b316741d7960d5c0da6845ea15b94991ece94837367a"
+    },
+    "sound/traps/steam_loop.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/traps/steam_off.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/voreling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/voreling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/voreling/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28354,
+     "sha256": "8c9ef55e309a43b1df1f08b66192b4ab262ba07e9315d3a70f4a9cf9dee9d51a"
+    },
+    "sound/voreling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/voreling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "5035bd555e9a6439c87e6b661a2da86633f7234503d52551e68f61e9504af86d"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 44162,
+     "sha256": "ccca790ed18e3705c083259f48db7d46d26310cf80c16cd2bad191d333fec5ba"
+    },
+    "sound/weapons/axe_ceramic.wav": {
+     "bytes": 24620,
+     "sha256": "53b6e873318f84424129f1486f0a715c9b1f46e9521c97858d3ddbd94ef4dc10"
+    },
+    "sound/weapons/axe_flesh.wav": {
+     "bytes": 7754,
+     "sha256": "8d0046355ea843f56d5260f581c89d2f885b553c97cfc7e01a93f6da487e03de"
+    },
+    "sound/weapons/axe_glass.wav": {
+     "bytes": 13306,
+     "sha256": "7fd4f7f02edf972c17cf64fea9ecfecca2e0a2d69da9828c1a1e2ce726dd9a79"
+    },
+    "sound/weapons/axe_metal.wav": {
+     "bytes": 28844,
+     "sha256": "d77bc0204c9f406f50ddf01241ff3a3cb34bd571f8a038a483fe49fba81fb160"
+    },
+    "sound/weapons/axe_swoosh1.wav": {
+     "bytes": 26524,
+     "sha256": "1ee4079e691b1e3e8eca8e6fe3098ee053f99b2a0028e725442771c84dc07e49"
+    },
+    "sound/weapons/axe_swoosh2.wav": {
+     "bytes": 13284,
+     "sha256": "a28435309759dd35576099d23a36dc378d9703db9f0778fba63efa3558cfc19d"
+    },
+    "sound/weapons/axe_wood.wav": {
+     "bytes": 7776,
+     "sha256": "ce5bd1465d66aa4aad5249c387f7f537b45b4f8a0e4bf76f37f8efc2a22bd9d9"
+    },
+    "sound/weapons/bolt_hit1.wav": {
+     "bytes": 12698,
+     "sha256": "07d2b6078f7936781a641f88e6ed02ab84f248da8f19e73713c1a71ac56cf42c"
+    },
+    "sound/weapons/bolt_hit2.wav": {
+     "bytes": 10658,
+     "sha256": "27ef878b7dfc0878140a19e3a0227ba389e5d0dc2b86df386852e2da2ebc5c93"
+    },
+    "sound/weapons/bolt_hit3.wav": {
+     "bytes": 11600,
+     "sha256": "06298d7bc8d7bce64f9473ae9530e0b42ea3de0ca5895f3476f9b00b5ed566f9"
+    },
+    "sound/weapons/bolt_hit4.wav": {
+     "bytes": 15460,
+     "sha256": "814b1a71efc9b58c90ad7f116c47e6f3dceeb8eae6d0ecbca5f1cd02dd247cb6"
+    },
+    "sound/weapons/crossbow_fire.wav": {
+     "bytes": 26536,
+     "sha256": "2a6ba54090412a53471c59b3edf6e8559d424dab25729e67a78f9ada5e13e8ac"
+    },
+    "sound/weapons/crossbow_hit1.wav": {
+     "bytes": 60782,
+     "sha256": "be1e78c92c13749e988d26912fba6c23f3700df0d7cc48d724f0da1f2608d006"
+    },
+    "sound/weapons/crossbow_hit2.wav": {
+     "bytes": 32472,
+     "sha256": "30a4ef9f23b2239371d32385e55487b279ca4f8f91366d4251cf4d9abdce200a"
+    },
+    "sound/weapons/crossbow_rdy.wav": {
+     "bytes": 37532,
+     "sha256": "321eac310a291cd9cdcbd2dcafb27687a12057e778e12704d8b4388d4eb6e4df"
+    },
+    "sound/weapons/crossbow_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/weapons/ghook_fire.wav": {
+     "bytes": 11526,
+     "sha256": "6e29f4524c0be70d8bf3b1201e737712b271c9bc963ad46c1815972b6addc22e"
+    },
+    "sound/weapons/gl_loadlong.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/weapons/gl_loadshort.wav": {
+     "bytes": 7758,
+     "sha256": "c97236bbfd211dfcad8130974413a8666cdbcf646d364abd8801b3d6ba5bf9c4"
+    },
+    "sound/weapons/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/weapons/laser_hit.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/weapons/laser_richotet.wav": {
+     "bytes": 12888,
+     "sha256": "bcc0498060e71b059d1d6ec45628048b0f29a7a0509b736a519196338b5df20d"
+    },
+    "sound/weapons/nofire.wav": {
+     "bytes": 1400,
+     "sha256": "217c42718548de32b5df972d117ffc1a0e1dde5f03a7a173bd91d0b4551248c9"
+    },
+    "sound/weapons/plasma_expl.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/plasma_fire.wav": {
+     "bytes": 88288,
+     "sha256": "6a0ad4930da39ff590c79f9d26b434bb1001536d33d880735df76e9354f90e94"
+    },
+    "sound/weapons/plasma_hit.wav": {
+     "bytes": 54406,
+     "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b"
+    },
+    "sound/weapons/plasma_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/weapons/r_exp3b.wav": {
+     "bytes": 34830,
+     "sha256": "a1abb7cedfa6576205f043c2e5f562606b039f65f6f996f5ffbb758d7855f2a2"
+    },
+    "sound/weapons/resist_rocket.wav": {
+     "bytes": 19938,
+     "sha256": "1e5170aaf1d6f144e7ea77c251d15ee85c9a70eb1f50b12e4ba5a93971ad1955"
+    },
+    "sound/weapons/ric1.wav": {
+     "bytes": 5650,
+     "sha256": "49223498fbf29b97f712537e6417917befc4e4f5c725bbf2e3d463580c15454d"
+    },
+    "sound/weapons/ric2.wav": {
+     "bytes": 11146,
+     "sha256": "5fa462f4ab3184cf70bf33f923a2b7e4392db517d34f8531a381864d78c352a6"
+    },
+    "sound/weapons/ric3.wav": {
+     "bytes": 11138,
+     "sha256": "1761926b96108fd0b0ee55270ee711fbd2f394f1b5e93da4af96e42c69fa3946"
+    },
+    "sound/weapons/riotgun.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "sound/weapons/sg1.wav": {
+     "bytes": 28718,
+     "sha256": "49074c95da2a619d82dee9d45e28dc910f9a8e16141270a76c81b396a41a6a3e"
+    },
+    "sound/weapons/sg2.wav": {
+     "bytes": 28718,
+     "sha256": "279b1bb969837073c46c176fe62782e60658a6614a8e094b9722cbabdca81fe6"
+    },
+    "sound/weapons/sgun1.wav": {
+     "bytes": 45840,
+     "sha256": "3ac6c4b3ded00fa48810f09afc95b4a8375dc3e8d52e04cd9cba18dfeee20087"
+    },
+    "sound/weapons/shellc.wav": {
+     "bytes": 21006,
+     "sha256": "45a2f8bd652307b9ebd37115c27166d03a4d7055f3054a215036fbc342e22f6d"
+    },
+    "sound/weapons/ssg1.wav": {
+     "bytes": 17244,
+     "sha256": "3e5b9cc1cd0cb86602391e4ddedbc98bb020e44b937eec4d3c5b053ff98c98f2"
+    },
+    "sound/weapons/ssg2.wav": {
+     "bytes": 75024,
+     "sha256": "248a021818f578ec3d96b9fe59d8f839242f4d5f8140a66a500b523b137d1977"
+    },
+    "sound/weapons/sword1a.wav": {
+     "bytes": 11184,
+     "sha256": "22bc8b25a67f1ab0752f9fbc68c2eb0958d2807c9e95bc8ee35d1d1bc9c6552d"
+    },
+    "sound/weapons/sword1b.wav": {
+     "bytes": 13272,
+     "sha256": "dca39f0c4776994c1bbe5255893d50dd86a634a370ea6046fd4e851117dec726"
+    },
+    "sound/weapons/sword2a.wav": {
+     "bytes": 11150,
+     "sha256": "aa381f8c68f5753cecbd889bc184a784c934c78c8fefe3b1ba4026a99112da51"
+    },
+    "sound/weapons/sword2b.wav": {
+     "bytes": 13232,
+     "sha256": "9460973ef948f8712be967d412774d32aeefb8e68b11959c28909eb16d9e8afc"
+    },
+    "sound/weapons/widow1a.wav": {
+     "bytes": 64644,
+     "sha256": "b4ccd6b235784f7ff53ccf0d726ecbbc789d2ddcca057b40df769b7925e3b32d"
+    },
+    "sound/weapons/widow1b.wav": {
+     "bytes": 66186,
+     "sha256": "0da0346e80cdcb405ffb8f9dbe048197cd9d303130f35b2546b4f7652bd06ca6"
+    },
+    "sound/weapons/widow1c.wav": {
+     "bytes": 66186,
+     "sha256": "eb054b4b1b2784bb098e24574ced6b8c2114e3344fc73e9beb23285adfa086a8"
+    },
+    "sound/wraith/attack1.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/wraith/attack1_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/wraith/attack2.wav": {
+     "bytes": 88200,
+     "sha256": "bdf849b4e138fa587df136a327c71ceed1176cbbb4ecb873434766d53da35a3b"
+    },
+    "sound/wraith/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/wraith/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/wraith/death1.wav": {
+     "bytes": 19960,
+     "sha256": "c0e5e05b46e4cf4afebfe5d0ef1801fc16fe8308a7f859ff347a77871b0a9339"
+    },
+    "sound/wraith/idle1.wav": {
+     "bytes": 51556,
+     "sha256": "e91f12463417df25badbbdfe817560362370d9e1e31712766bccb086e06d966f"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 82792,
+     "sha256": "b843d1124acc61be2aae27a7c8a9aca8f6bd471689703b41d59f1450e70e360c"
+    },
+    "sound/wraith/idle3.wav": {
+     "bytes": 55228,
+     "sha256": "3393943b38a0760c2b048c87c6b11ef743b0c968397ae7e434434b8b21fe12f9"
+    },
+    "sound/wraith/pain1.wav": {
+     "bytes": 18184,
+     "sha256": "a448cf5aed2909700e4da1f3ea3158b55e288198eee771eddacf211f4b274dbe"
+    },
+    "sound/wraith/sight1.wav": {
+     "bytes": 34390,
+     "sha256": "91494295e94c54c8da0307df8a51ea10d166fb18a78ede909a710f72ffe81c4f"
+    },
+    "sound/xmas/elf/attack1.wav": {
+     "bytes": 176492,
+     "sha256": "80e3faa699aec6d20015c1070087964de5ba39f83a978388b9fadc184f9fb6c2"
+    },
+    "sound/xmas/elf/attack2.wav": {
+     "bytes": 88292,
+     "sha256": "a364c82cb932bddb438c957e88a7ea67142777dfffd0f553d00e2b04b3af0f9f"
+    },
+    "sound/xmas/elf/cane_hit1.wav": {
+     "bytes": 4536,
+     "sha256": "2686bea9533633cb6c1a5e3e5bcf0016e3fe228cd278b7b1d11a02868cdd5095"
+    },
+    "sound/xmas/elf/cane_hit2.wav": {
+     "bytes": 5638,
+     "sha256": "6e470e241f37fb38ea55adf4bd0d6f1f5a2d5adfee5d5ddac8cb9adc824cb954"
+    },
+    "sound/xmas/elf/cane_swipe1.wav": {
+     "bytes": 1670,
+     "sha256": "2dbf81b3813376cb8bea2fa916dc0d03f1fbaaa499d4fcdf845de8929f82dc47"
+    },
+    "sound/xmas/elf/cane_swipe2.wav": {
+     "bytes": 1890,
+     "sha256": "404864c7d5008b79daed226566a2e4e78f2de92de06c64da67b8bf6224ae3e88"
+    },
+    "sound/xmas/elf/death1.wav": {
+     "bytes": 14284,
+     "sha256": "d1a7063d4ed39cdb59864a2a6fe6109f844caa9ada54ed4456de0bcd056f0034"
+    },
+    "sound/xmas/elf/death2.wav": {
+     "bytes": 10888,
+     "sha256": "4e0344a1bd3fa3d3c4d9e9647203cac0c449d5a5d8e7b1c8319f8402a4b7571c"
+    },
+    "sound/xmas/elf/idle.wav": {
+     "bytes": 57016,
+     "sha256": "a824467247797aa1ecc58f1716b18d390629804eebc413f01067646c64cde87e"
+    },
+    "sound/xmas/elf/jump1.wav": {
+     "bytes": 17766,
+     "sha256": "8023110b27a70758166f710e52188b8d03b8bfd81d9c985eb7f7d326acdb05a2"
+    },
+    "sound/xmas/elf/jump2.wav": {
+     "bytes": 8946,
+     "sha256": "a60763886b743d06ffd0c90e70de304ec8002a500947a684646c227d0bbb3c4d"
+    },
+    "sound/xmas/elf/magic.wav": {
+     "bytes": 15560,
+     "sha256": "6a270540819dddf140b0387d92c914b4f4b1c88c5f37a05c8fa0efd95901f2ab"
+    },
+    "sound/xmas/elf/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/xmas/elf/pain.wav": {
+     "bytes": 11126,
+     "sha256": "4e27a8f38e07e9b69db186d5c609740814ab86c5fda57058b1e05c56b85c6fd4"
+    },
+    "sound/xmas/elf/sight1.wav": {
+     "bytes": 21048,
+     "sha256": "c57eb4fec86922cb8a0499d7dae72eba66b067b89f14ff079ce0caf3dc23a23b"
+    },
+    "sound/xmas/elf/sight2.wav": {
+     "bytes": 30996,
+     "sha256": "8cd5eed3b8e098dfd70cbf90081b38e198bf64d8edf1b76bcc98c42e177635f8"
+    },
+    "sound/xmas/elf/sight3.wav": {
+     "bytes": 10050,
+     "sha256": "e88ae556a28352c319bf5500b29008384a5c53c47480defa81795d8891f14ff8"
+    },
+    "sound/xmas/elf/sight4.wav": {
+     "bytes": 6742,
+     "sha256": "7c6120d242cbbbfd2e0cc77b1428e206accd1ab8073885d52177b0fd4c75c7ed"
+    },
+    "sound/xmas/raindeer/attack1.wav": {
+     "bytes": 5582,
+     "sha256": "bcf78087eab53e8ed0bdde2f29088a89b321a79c3b104da380dd85bd5bdb6ec1"
+    },
+    "sound/xmas/raindeer/attack2.wav": {
+     "bytes": 6274,
+     "sha256": "2ba043cce4a2f22e7743812c0fa40e9f0888d5089362264c768352c347af5089"
+    },
+    "sound/xmas/raindeer/death.wav": {
+     "bytes": 9672,
+     "sha256": "68266e96ec1be80a55f48b76c2bedd6503273245153d96269947c7fc12ae96b3"
+    },
+    "sound/xmas/raindeer/hit.wav": {
+     "bytes": 5218,
+     "sha256": "72127151c2b05cc22a812fe9e38909c8bdcaae6a369e8756d2be67d392b91223"
+    },
+    "sound/xmas/raindeer/idle.wav": {
+     "bytes": 7890,
+     "sha256": "d3ef885d0b6163a3046dc9d514b07886c33809fbb6332e7db0514c648787a9bb"
+    },
+    "sound/xmas/raindeer/sight.wav": {
+     "bytes": 23796,
+     "sha256": "aafabb6fc46c1c72c34af1baea1c59a8ec04803c26faa4310072096481f31a4f"
+    },
+    "sound/xmas/santa/death.wav": {
+     "bytes": 99352,
+     "sha256": "b63273a2574f7def133aa438926a6def025aa64d8c3c636fc6a5594268e391d7"
+    },
+    "sound/xmas/santa/death2.wav": {
+     "bytes": 99352,
+     "sha256": "24fcf23117ec31347f640aa27e6feb4a46a634aa5e1eb48344b1feb7c377f6f1"
+    },
+    "sound/xmas/santa/fire.wav": {
+     "bytes": 22176,
+     "sha256": "3a9bb42661b75287a698b6e16033158f20c59c481d37c0f176dc213205d22dcd"
+    },
+    "sound/xmas/santa/good_hohoho.wav": {
+     "bytes": 55250,
+     "sha256": "51f4d5d656032de08b95689fa55a2e7aa26ec99cf4312b0f6153d0fd57fc1fa3"
+    },
+    "sound/xmas/santa/good_saved.wav": {
+     "bytes": 77302,
+     "sha256": "51e62df5942e2a72fd48311c61ee73b6f51dc4aa3c0cc85af000cdc8d7627d21"
+    },
+    "sound/xmas/santa/hohoho.wav": {
+     "bytes": 50840,
+     "sha256": "091a28236362cab1ce3b7bd55de25010d105db3bf644825c47b91725d8a613a0"
+    },
+    "sound/xmas/santa/laugh1.wav": {
+     "bytes": 57374,
+     "sha256": "ac069694d6c41e5e0afab50d9928b8768a19fb647bb249201648874d4150c976"
+    },
+    "sound/xmas/santa/laugh2.wav": {
+     "bytes": 117440,
+     "sha256": "c726d7d86d2d7cad0a75a2d0b387f4f96218ef232b6c78437e1c83bb96286441"
+    },
+    "sound/xmas/santa/laugh3.wav": {
+     "bytes": 40256,
+     "sha256": "4dd710eee601ab81c4beb5413d95244dee58b886b8265ab9cec35df06b560591"
+    },
+    "sound/xmas/santa/laugh3_com.wav": {
+     "bytes": 44226,
+     "sha256": "4099895e037cfecb4dc3595b3b18db62ed2f3cf096384f3aa1fe1d96a7b43da2"
+    },
+    "sound/xmas/santa/pain1.wav": {
+     "bytes": 6825,
+     "sha256": "79eed9346e0954fd53a6fdb9aa9708b8c29e8c5c256e9fd7c06f449e9cb6c00d"
+    },
+    "sound/xmas/santa/pain2.wav": {
+     "bytes": 9259,
+     "sha256": "f750328d74f545a658b0b190399595687c3d9b8766b2652ad6c2a34add3cc420"
+    },
+    "sound/xmas/santa/sack_hit.wav": {
+     "bytes": 13356,
+     "sha256": "c23a04ed5134f76d1f44d2e61eeb446a569c2bcbccf79f16f472807aae3df53a"
+    },
+    "sound/xmas/santa/sack_swing.wav": {
+     "bytes": 8940,
+     "sha256": "96972ba473b6a7d28645cdc621eb3011729a53eb4acb40d1f097768291a70850"
+    },
+    "sound/xmas/santa/sight.wav": {
+     "bytes": 100144,
+     "sha256": "e29696370a0d40546a49ef0f39b1e0038d8e067ef2da1dcc5084d7683a25d5d7"
+    },
+    "sound/xmas/santa/smack.wav": {
+     "bytes": 22176,
+     "sha256": "606c0a4b634d82a1d9846f654db8a52e7f2438ba28a235f782a23ff2720c767c"
+    },
+    "sound/xmas/snowman/claw.wav": {
+     "bytes": 8292,
+     "sha256": "7857f3526fb39e722a09ebe569f2b76facab765d82f97c0caa7da2ff9b750e9e"
+    },
+    "sound/xmas/snowman/death1.wav": {
+     "bytes": 11267,
+     "sha256": "0a09776ed8e45bbfe403f1cdb50302361f5596d9027c476409d6acf5402e763e"
+    },
+    "sound/xmas/snowman/death2.wav": {
+     "bytes": 13613,
+     "sha256": "e5e3a9619a153f0c6259abdb0d45f4eb4a547f736e37951556d29c6b715ec8f6"
+    },
+    "sound/xmas/snowman/icehit.wav": {
+     "bytes": 3090,
+     "sha256": "e03f61550bafc53ab47acdc23bcd481c35e75e6eccdad5e61e6dd7b372ba07c0"
+    },
+    "sound/xmas/snowman/icemiss.wav": {
+     "bytes": 3074,
+     "sha256": "f8b86f83d9adaaee1c84e1ac2acbcf652204842f2bf6f351ec1443a998574058"
+    },
+    "sound/xmas/snowman/idle.wav": {
+     "bytes": 58582,
+     "sha256": "a0d7af1cd6246f08176f24c5591cfb6ec89cff55dc5c18766ef1b16c64429541"
+    },
+    "sound/xmas/snowman/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/xmas/snowman/pain1.wav": {
+     "bytes": 7685,
+     "sha256": "7f829300a30cb6cb4d17f8c8327bd62ae5b5dacc892d28a956d6ecd2acf5f1c2"
+    },
+    "sound/xmas/snowman/pain2.wav": {
+     "bytes": 7661,
+     "sha256": "3747d77583aa4edb3509e89ea651ea41a8e8a92cd96c34d4e00257e7371fb0e6"
+    },
+    "sound/xmas/snowman/shotg_fire.wav": {
+     "bytes": 6572,
+     "sha256": "3d54870c0f643b1e7ee5307641bb3fc4a94efdaffc2e4ecd196556b930167ef2"
+    },
+    "sound/xmas/snowman/sight1.wav": {
+     "bytes": 10042,
+     "sha256": "ce1cddbb6e85fad23231ac1fc4c04c19ec7276acb2aa86e023c117db4b8edd68"
+    },
+    "sound/xmas/snowman/sight2.wav": {
+     "bytes": 15418,
+     "sha256": "5d4e994c30a7c3f2e1f1a5cde9a56115bcb32c350e4a0ad8e339a1a46ed19707"
+    },
+    "sound/zombie/boil_explode.wav": {
+     "bytes": 38012,
+     "sha256": "210dac94ab0e4efb5eb3bdbfa5d7100094b1bfef917a8d5abb2ae186252c0a27"
+    },
+    "sound/zombie/boil_idle1.wav": {
+     "bytes": 33204,
+     "sha256": "e2b717040d436ba2a659ceb1e5b74dfeaad57577297a9827957733e00ce7cb34"
+    },
+    "sound/zombie/boil_idle2.wav": {
+     "bytes": 33206,
+     "sha256": "8bd584597f2c54e6f8ecca5c0a83e44b0b5a09a745026e41cc2cad8ded6f729a"
+    },
+    "sound/zombie/boil_sight.wav": {
+     "bytes": 33192,
+     "sha256": "0e285e98dc66cd49af507dae9ab5281aaec55eaf9d401810a8d230d93539123a"
+    },
+    "sound/zombie/boil_squirt.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/zombie/boil_windup.wav": {
+     "bytes": 22094,
+     "sha256": "3790791943ea03add95bc303df34470c534f9c2c76e4343831609eaee761633d"
+    },
+    "sound/zombie/zk_sight.wav": {
+     "bytes": 26916,
+     "sha256": "8fe4d5fea16bd7c3661a968d26782ea8c4741157e16e22f33317619229b10637"
+    },
+    "textures/#bmk_water01a.tga": {
+     "bytes": 12332,
+     "sha256": "904f50c3a1de65dd5045f128d03ed8cdc86fcbc15cce295d94304b389ca5ed7c"
+    },
+    "textures/#bmk_water01b.tga": {
+     "bytes": 12332,
+     "sha256": "904f50c3a1de65dd5045f128d03ed8cdc86fcbc15cce295d94304b389ca5ed7c"
+    },
+    "textures/#bmk_water02a.tga": {
+     "bytes": 12332,
+     "sha256": "1123b4f4df8d75a1d8fc2a00d4d19fb279035771f7440b1506d0a95648123766"
+    },
+    "textures/+0bmk_fgopen02.tga": {
+     "bytes": 3145772,
+     "sha256": "1c7e70671a9a98473b3fb3926e1672d5a1712a011caba937097d5bc8c96099de"
+    },
+    "textures/+0bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "f2f139ae3d91bf3aa7c89181b87c1c645acb7be673eca5d56d804889e24f1e50"
+    },
+    "textures/+0bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "f2f139ae3d91bf3aa7c89181b87c1c645acb7be673eca5d56d804889e24f1e50"
+    },
+    "textures/+1bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "6941909c4574fb66f59f7a797f3dd0c696651e117c583f102d255e6bef4fe0ef"
+    },
+    "textures/+1bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "6941909c4574fb66f59f7a797f3dd0c696651e117c583f102d255e6bef4fe0ef"
+    },
+    "textures/+2bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "b78fb050de863bd84616c224de600521738a84ce172346bb783ba3a8708449da"
+    },
+    "textures/+2bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "b78fb050de863bd84616c224de600521738a84ce172346bb783ba3a8708449da"
+    },
+    "textures/+3bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "bf6815a6df5fe67c40ec3e46362a04c5ba15dc8a76de975a3d90a0caeec5e88c"
+    },
+    "textures/+3bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "bf6815a6df5fe67c40ec3e46362a04c5ba15dc8a76de975a3d90a0caeec5e88c"
+    },
+    "textures/+4bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "031bd453f18757388aa700fbae39e6c446959b8e38bee9fbbb53d8639f29deea"
+    },
+    "textures/+4bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "031bd453f18757388aa700fbae39e6c446959b8e38bee9fbbb53d8639f29deea"
+    },
+    "textures/+5bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "873c6b31fcaab54e309e663d23748cc5595b80e1432559761fd92a03f0d41d32"
+    },
+    "textures/+5bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "873c6b31fcaab54e309e663d23748cc5595b80e1432559761fd92a03f0d41d32"
+    },
+    "textures/+6bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "33492aebd47cc69737a2cd8460423103a76ff59b1d6bd39b750f19d6c72efc6d"
+    },
+    "textures/+6bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "33492aebd47cc69737a2cd8460423103a76ff59b1d6bd39b750f19d6c72efc6d"
+    },
+    "textures/+7bmk_wfall01a.tga": {
+     "bytes": 98348,
+     "sha256": "60741f2766db4f0eb6d622b132d2fc60d9e453d9f847661d3eca641fbf2b64f1"
+    },
+    "textures/+7bmk_wfall01b.tga": {
+     "bytes": 98348,
+     "sha256": "60741f2766db4f0eb6d622b132d2fc60d9e453d9f847661d3eca641fbf2b64f1"
+    },
+    "textures/window_blue1_2.tga": {
+     "bytes": 786476,
+     "sha256": "583f28b004c5de047037798524681ed2e7914bf1f54ac3d774c8da2880c80282"
+    },
+    "textures/{cop1_7.tga": {
+     "bytes": 16402,
+     "sha256": "464c149a2b2c9f624e7b1f8c2388117022425f058a946f0232c51def845b8bb5"
+    },
+    "textures/{cweb1.tga": {
+     "bytes": 262162,
+     "sha256": "bb0aa80709a1705199ed83bd0cad683a928cb29064eb32263fcb8bdb3999c2f5"
+    },
+    "textures/{cweb2.tga": {
+     "bytes": 262162,
+     "sha256": "64be3598db71729d4a4376c5f4e02bf0e586fc5ceca09196d71befde3265424e"
+    },
+    "textures/{cweb3.tga": {
+     "bytes": 131090,
+     "sha256": "d7b67dfdb1c80946f0de21128ddc3cda61906619ab8ed185611ef2a2a8f936b5"
+    },
+    "textures/{cweb5.tga": {
+     "bytes": 131090,
+     "sha256": "9cf5dd24994b1dc2f8f07ac5f76410fea9bdb7cb925962e1977e6aeb6ce23b02"
+    },
+    "textures/{dutcweb1.tga": {
+     "bytes": 131090,
+     "sha256": "8922bb11d99fc05d2ffeab2c2d99b04dba9d0fc5165fdd9a0ccd921f066f668c"
+    },
+    "textures/{dutcweb2.tga": {
+     "bytes": 131090,
+     "sha256": "a0377ffeac458bf27bbd86d2bc22ff17d973bd0328a4d048fb3136573c12723d"
+    },
+    "textures/{dutcweb3.tga": {
+     "bytes": 131090,
+     "sha256": "61710c94a64a506b75f36578904dbece6f666bc25ad2665333fe00b1c4b04f70"
+    },
+    "textures/{dutcweb5.tga": {
+     "bytes": 131090,
+     "sha256": "a0959d05f9bd1f4aa632b1642885261a2cbbef7d6d6d7ab677bb803ac1a00ef8"
+    },
+    "textures/{dweb1b.tga": {
+     "bytes": 65554,
+     "sha256": "7f2f310b5393519fbfdf70e07cab318504ad88c67dcce1e9988e376d5fc9c94a"
+    },
+    "textures/{dweb2b.tga": {
+     "bytes": 65554,
+     "sha256": "d95f6ebbcc21b2cb7164743b517aa69287101aa2640d5a8b249c409dcdc20333"
+    },
+    "textures/{dweb3b.tga": {
+     "bytes": 65554,
+     "sha256": "24cde40cf3791f0e054ccd2ad81353ec711bd95a7de1af58a1ad561d9d104ef1"
+    },
+    "textures/{dweb5b.tga": {
+     "bytes": 65554,
+     "sha256": "5b1fc4683289a850f5c16afa56660b710212bf18d4c047bf134529dac784d2c9"
+    },
+    "textures/{gen_gr8.tga": {
+     "bytes": 65554,
+     "sha256": "8dacb17cbbb6bb2f4dd95856dd46905a9c335f0a98dc3e8e700fac0a9c529163"
+    },
+    "textures/{kjwintex_ad.tga": {
+     "bytes": 262162,
+     "sha256": "3a2583e19c17e05877e489972b85593d9fca1e57ffd4fa02f1475e6fb3d59c34"
+    },
+    "textures/{ladder5th.tga": {
+     "bytes": 49170,
+     "sha256": "ed742e4b7072c1b11b1b801393bbfc641f96920ecabc5600c213b354313f89f0"
+    },
+    "textures/{lweb1.tga": {
+     "bytes": 262162,
+     "sha256": "e4edd91fdd0031064bd6157574ae5f81b44611424f7357daf8fd4e426c960399"
+    },
+    "textures/{lweb2.tga": {
+     "bytes": 262162,
+     "sha256": "4d2f26192388bf65091b0d5afb934bede4f07e89d002bbdbaeeba29d459fd5d7"
+    },
+    "textures/{rtex158_.tga": {
+     "bytes": 21522,
+     "sha256": "cd10217f3e5cd47b32bde516d4b36cf7995913e306f7415d25dcd7da6ccb4673"
+    },
+    "textures/{speedbz_grid1.tga": {
+     "bytes": 16402,
+     "sha256": "109e52491dda6d4968c99004296ccd503db6d6af9aad9aa6f21cca02fd2b299f"
+    },
+    "textures/{swvine.tga": {
+     "bytes": 65554,
+     "sha256": "c23639e3bd8aacd226695c913384e9c67d509b28fb9597d56f120cfea56a4006"
+    },
+    "textures/{utcweb1.tga": {
+     "bytes": 131090,
+     "sha256": "edae90ba1151fb6adc65def85d4dd7be01c3d2a18bd93ef0f26ff44d07f6c4b0"
+    },
+    "textures/{utcweb2.tga": {
+     "bytes": 131090,
+     "sha256": "829cfe898d9aa4c3ddd12a51f9ccc16a66b2ca5671d9bfd2339f402d49db3267"
+    },
+    "textures/{utcweb3.tga": {
+     "bytes": 262162,
+     "sha256": "026680576034c959e840aa4b39917497c38df12c1331a0c7a1486912e26a91f7"
+    },
+    "textures/{vinehang1.tga": {
+     "bytes": 65554,
+     "sha256": "c23639e3bd8aacd226695c913384e9c67d509b28fb9597d56f120cfea56a4006"
+    },
+    "textures/{vinehang2b.tga": {
+     "bytes": 262162,
+     "sha256": "4268dc2a183582d00c363a9fcd1965c026632150383d40b520fbd54f8751eaa7"
+    },
+    "textures/{vines3.tga": {
+     "bytes": 25618,
+     "sha256": "550b6ca0c768db472fbc970836516506034b30f0a5ca4b4b11df34d7dce8dc82"
+    },
+    "textures/{vinogrande2.tga": {
+     "bytes": 262162,
+     "sha256": "7c2d4aad4d34457ab1674bc1eaaa4ea38e4c4af384877af631cde258167fbb72"
+    },
+    "textures/{web1b.tga": {
+     "bytes": 65554,
+     "sha256": "41bb1244128013ff09f1965339ef505a7b0757bea91fcc0f77ed97cd38c8a145"
+    },
+    "textures/{web2b.tga": {
+     "bytes": 65554,
+     "sha256": "e2fbcb154962a9189614aecc7f6833e60d24709583a970d6cca0adf948df2331"
+    },
+    "textures/{web3b.tga": {
+     "bytes": 65554,
+     "sha256": "e4cfcd4c4e94ed647ef9af822d0df5ee573bd20d9f3bcf45ef8701a3102ae3ef"
+    },
+    "textures/{web5b.tga": {
+     "bytes": 65554,
+     "sha256": "dfdad98b5b62765b24abccd2ff77e85ec1c002060d6634d2593ac0fe10a4c718"
+    },
+    "textures/{win01_1brk1.tga": {
+     "bytes": 49170,
+     "sha256": "dae89ad198e0f4b1a63e37d9145084e947f7e88cb1c2e5d9ef32f25f3e0fb484"
+    },
+    "textures/{win01_1brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "88d9f8700eb9d14f9cfa6ac2e3df1bb25eae9a46553b6e46da7b225316862cb9"
+    },
+    "textures/{win01_1brk2.tga": {
+     "bytes": 49170,
+     "sha256": "2416e34e1ebdefa0cd01ea595b68ae86d2a35a4329b8853a489b1058dea44a90"
+    },
+    "textures/{win01_1brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "921ecb3434e9bd56d97ad57d10c67ace5a0f4bce79bf1b4c8c68aad4cf6ed10f"
+    },
+    "textures/{win01_1brk3.tga": {
+     "bytes": 49170,
+     "sha256": "59a6b2dc874758693574f15affea0be9c2e92e32328f81db78e5d72f488be7cb"
+    },
+    "textures/{win01_1brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "a3dcd6d471d8c65781a69c73a9fa449da02bc01a58a0a97c7313d30587611516"
+    },
+    "textures/{win01_2brk1.tga": {
+     "bytes": 49170,
+     "sha256": "589cf84c790b3165fa60e4441223da48c3df4275099fcc27bc5a8b9502579c15"
+    },
+    "textures/{win01_2brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "a0a80d249ff32c2e0a480801b721657244380732db3bdd9645dbece347d3190c"
+    },
+    "textures/{win01_2brk2.tga": {
+     "bytes": 49170,
+     "sha256": "0dc35f6a8b8b83596d127791f32f59b4a7445cb2529777555a93b9f329b7b537"
+    },
+    "textures/{win01_2brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "b313a11eb9017f0be604b673c0df88e94f94d552a7a132241f80883e68f4905f"
+    },
+    "textures/{win01_2brk3.tga": {
+     "bytes": 49170,
+     "sha256": "0fd4d13eb067aa17be299b48d500c245554fc3a6c1f5f11e10cbec1195a35273"
+    },
+    "textures/{win01_2brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "7ad6db65f6c0190a9ec569cce3b4780d21a90baf9baa728128f278807f1ba780"
+    },
+    "textures/{win01_3brk1.tga": {
+     "bytes": 49170,
+     "sha256": "ee6084ebe49ce367fd68039d548b1c960e55b136412bb00b8094dc1c545307bf"
+    },
+    "textures/{win01_3brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "afa5f0475b733a0ee1829b76598acd37cb1f28ed7f2faaf128593a13e702f5fa"
+    },
+    "textures/{win01_3brk2.tga": {
+     "bytes": 49170,
+     "sha256": "54c3abca2e42bbc4626823d4ad8081797e295bbdd07942484142d8a1c5395474"
+    },
+    "textures/{win01_3brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "0e0fc8daffc3ec8e07028904e3e55946270b8346f32efa341d64d6d1c0bcfcb5"
+    },
+    "textures/{win01_3brk3.tga": {
+     "bytes": 49170,
+     "sha256": "c1c7752039d97f7b92ec36408ffe456ff96c2a27c725c432e677a4f22e893d46"
+    },
+    "textures/{win01_3brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "0b627faae78e0d01eee393b58f978bf1a46b653001e1d1c56589d822245f86df"
+    },
+    "textures/{win01_4brk1.tga": {
+     "bytes": 49170,
+     "sha256": "af0f20f39e53d82cda8fca18e2918c1a2df2e6cf94e4d636e50c01686b3291b8"
+    },
+    "textures/{win01_4brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "4522e8d89c78119e9ff517ad64571c17c3ca750ac820142a700809620e894942"
+    },
+    "textures/{win01_4brk2.tga": {
+     "bytes": 49170,
+     "sha256": "4696f9c8ca59937230f40a3135b6c02e54b9b912eb62ba1401cbd5cccd1a9ae4"
+    },
+    "textures/{win01_4brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "a7a978f76a01a53dca360914519a8b1a93272aaad8a57c54e32ec74d4d9f1b96"
+    },
+    "textures/{win01_4brk3.tga": {
+     "bytes": 49170,
+     "sha256": "66dfc1bbe57f20c766653ab71cb339b6bff4e10b33cf66f5ed070bc0be75156f"
+    },
+    "textures/{win01_4brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "fb047a212d30b7fd140331df80d03dc718ba4237df73bf3cd74c918cc91daddf"
+    },
+    "textures/{win02_1brk1.tga": {
+     "bytes": 49170,
+     "sha256": "cb2711c7dc2ee9b77aded814296c1b1bb124ff5d2db2e248af7d7d0d882f422d"
+    },
+    "textures/{win02_1brk1b.tga": {
+     "bytes": 49170,
+     "sha256": "9391e42b0fe2e55689e7104984fc1b5fd199cd8821e562fc4538fe2eb73825e9"
+    },
+    "textures/{win02_1brk2.tga": {
+     "bytes": 49170,
+     "sha256": "4fb71ced0a5388e41896b3b71b9c48d157eb72d229db04bbdcca45ce58658adc"
+    },
+    "textures/{win02_1brk2b.tga": {
+     "bytes": 49170,
+     "sha256": "ed18da9a408653915554b0918a0f720cb76257231fc8ff9d465003e98fb371ab"
+    },
+    "textures/{win02_1brk3.tga": {
+     "bytes": 49170,
+     "sha256": "3b1f9bdbd53db1fa6d6920045cf4da45064dac48f7f66870e003860514804e99"
+    },
+    "textures/{win02_1brk3b.tga": {
+     "bytes": 49170,
+     "sha256": "f1e10e37f7f2e71ddd6165607e59d39f95ec59c904017a8fa6b7b33a3adf40c1"
+    }
+   },
    "sha256": "117caa759bf9f161599ff693f561c68954519eda9cefb719a97cd5c1cd863ef3",
    "timestamp": "2020-10-12T17:05:06.000Z"
   },
   "pak1.pak": {
    "bytes": 537160200,
+   "files": {
+    "maps/ad_ac.bsp": {
+     "bytes": 8666624,
+     "sha256": "81174268a4817be5e86d1862b1a31bcec33c5465a28963eab438146344a61a95"
+    },
+    "maps/ad_ac.lit": {
+     "bytes": 2948405,
+     "sha256": "1418dba74e92d03cce8a4f31e93c793045ca5a48a3656eafe2501f0e53d43f95"
+    },
+    "maps/ad_akalakha.bsp": {
+     "bytes": 7370644,
+     "sha256": "ced1f4022a18c30424cbcc9245e45a4aee390ba6fb0dc566b75dc92e0c283d4b"
+    },
+    "maps/ad_akalakha.lit": {
+     "bytes": 1091987,
+     "sha256": "dfb61f77bc1d1b02301b643c14142572e7e9fabd9fc689466919f79dcf3b435e"
+    },
+    "maps/ad_azad.bsp": {
+     "bytes": 27262044,
+     "sha256": "55776b0c128190044f1675e0d3128661221ed9452bfbeb51701b123227411b6b"
+    },
+    "maps/ad_azad.lit": {
+     "bytes": 7463279,
+     "sha256": "5afa7b9223a1d0768deffcbc4134801d8733f21d15dc9dd09dee3253d9d51184"
+    },
+    "maps/ad_azad.map": {
+     "bytes": 11271545,
+     "sha256": "12e66686f085122fa33a6d4cd48f4b93ddb6c8242e5eb47aeed6174863537e85"
+    },
+    "maps/ad_brk/all_brick.map": {
+     "bytes": 22738,
+     "sha256": "e0859c71d8a3d5d4b140757e4fcd2ab4e92674bbb71979d6b9d6d2deb5d2390a"
+    },
+    "maps/ad_brk/all_glassa.map": {
+     "bytes": 8834,
+     "sha256": "f4e1c7c1444b3b2d8a3463e8950c0a6a3aed8d39144a6b1fc2a69bdbf376f444"
+    },
+    "maps/ad_brk/all_metal.map": {
+     "bytes": 12297,
+     "sha256": "447c74022bea3ae89d3a4412afcf4bcd384ea725b344b987fb2e7bb37adfabe1"
+    },
+    "maps/ad_brk/all_rocka.map": {
+     "bytes": 10235,
+     "sha256": "52edb0d5b9f79e8b89a58353098316e81be31c3e289d6f96e450ea01c4bbeb62"
+    },
+    "maps/ad_brk/all_wood.map": {
+     "bytes": 8397,
+     "sha256": "93697129156d662c18391564e26c5d5ceec8bac244209496290b8e9a516a5bfb"
+    },
+    "maps/ad_brk/brick01.bsp": {
+     "bytes": 7912,
+     "sha256": "c11880924b195ed38908cbf50f9cd16f071918df0a94a19c7254b93dddb1e62d"
+    },
+    "maps/ad_brk/brick01.map": {
+     "bytes": 717,
+     "sha256": "3f87d06eb46f67efa678ddd5ddf274e9c595c4a5236d8f111d8a0ea999972e09"
+    },
+    "maps/ad_brk/brick02.bsp": {
+     "bytes": 8072,
+     "sha256": "9ec52c7441f570d2a793035ebc2128d7f7f91f71b44b4418fd01e6b3e6d503e2"
+    },
+    "maps/ad_brk/brick02.map": {
+     "bytes": 861,
+     "sha256": "616d1c5b6f3e476453e8b9b57dd59deb285c6c0482680ca5d6da358ee808c619"
+    },
+    "maps/ad_brk/brick03.bsp": {
+     "bytes": 8280,
+     "sha256": "aa55feca84b80282851ca55c71deb3d54f02a6668af820f5ac4f9c1a0514e5e1"
+    },
+    "maps/ad_brk/brick03.map": {
+     "bytes": 935,
+     "sha256": "4359e78daaac0b8d4ff58dc68301bba4cd423e81284bcd360ce1480862c19d91"
+    },
+    "maps/ad_brk/brick04.bsp": {
+     "bytes": 8052,
+     "sha256": "b1fa14c188a8ad31cf58c7ebd495fbe8ed153819015d4e97c82e01ee052081e3"
+    },
+    "maps/ad_brk/brick04.map": {
+     "bytes": 815,
+     "sha256": "2bda60cc50886dc430a053f509f2376dcd9bd4d09666cf7960a96484fa369903"
+    },
+    "maps/ad_brk/brick05.bsp": {
+     "bytes": 7952,
+     "sha256": "e137a3ea0f33a83b8717dcb9d6e2ab79876112121dc21fe2e625d24d5d251384"
+    },
+    "maps/ad_brk/brick05.map": {
+     "bytes": 770,
+     "sha256": "8ebf395096050f65a3a370971d65deb0926af70f6cbd75c6579a53b68f676793"
+    },
+    "maps/ad_brk/brick06.bsp": {
+     "bytes": 9184,
+     "sha256": "32cee0a2c668160e07568ae08b4de5beae87d74e94a347cd431c90005bf49e24"
+    },
+    "maps/ad_brk/brick06.map": {
+     "bytes": 1709,
+     "sha256": "289f58cad70a88e8a8d986644faf539dd38cf52a884aa7f85513db5df0cc438c"
+    },
+    "maps/ad_brk/brick07.bsp": {
+     "bytes": 10377,
+     "sha256": "df07446f9f6a118f11451de5d7817f582c11dcc81ca3f83c8fa72c9d95e8df9c"
+    },
+    "maps/ad_brk/brick07.map": {
+     "bytes": 1942,
+     "sha256": "fe440636e5354fb553708f3b6859023d0a520f315050dc11a564e31a7b72d5e4"
+    },
+    "maps/ad_brk/brick08.bsp": {
+     "bytes": 13964,
+     "sha256": "2abbbc958d752e742df9d1f7152c4cc8c0de6373f20e628a762e2a22f5d6b3f7"
+    },
+    "maps/ad_brk/brick08.map": {
+     "bytes": 3286,
+     "sha256": "72174f573416102bb4e087e2025b3dbdfc669ab7cafc8b354f7b1a4485af1f5b"
+    },
+    "maps/ad_brk/brick09.bsp": {
+     "bytes": 7952,
+     "sha256": "28d7162b4af3f4ce184a31a14e3a9777383f29b63920d9d62ff136ae96e3a2fd"
+    },
+    "maps/ad_brk/brick09.map": {
+     "bytes": 770,
+     "sha256": "62f11ef3e3033dea82eb6062e5b5301474dd014f889a980383891e689be2a352"
+    },
+    "maps/ad_brk/brick10.bsp": {
+     "bytes": 9184,
+     "sha256": "7d6f8e3fd1b65880bb767ab5d488ef11bbb01ec4ce14c7b747ee75b8a8238c4e"
+    },
+    "maps/ad_brk/brick10.map": {
+     "bytes": 1709,
+     "sha256": "276f975d99dfe982bf71104889f65a248d719778db89591e7193ecc46b13d645"
+    },
+    "maps/ad_brk/brick11.bsp": {
+     "bytes": 10377,
+     "sha256": "f65cbdb642220611e89725187f47427031c4b18c21cc04ae3f6cfb4dffd149a2"
+    },
+    "maps/ad_brk/brick11.map": {
+     "bytes": 1942,
+     "sha256": "3b9d73d400e29fba3c82d8b2ccdad26e03b128c7771427497d4740c2d34cd63d"
+    },
+    "maps/ad_brk/brick12.bsp": {
+     "bytes": 13918,
+     "sha256": "1e1e8191c5ebdd1f0fed27edaa04a82a6aabd5c41723cf590781ff00f7300a02"
+    },
+    "maps/ad_brk/brick12.map": {
+     "bytes": 3286,
+     "sha256": "d2b89c83f1ff95d6fe577cf4a166e7bec6e02ab85f48c51316908d7d80068156"
+    },
+    "maps/ad_brk/brick13.bsp": {
+     "bytes": 7912,
+     "sha256": "4b5ac4eb6ea5a9ec049c27082d800cb981902965a4b652f86e1753bfa1eb7c94"
+    },
+    "maps/ad_brk/brick13.map": {
+     "bytes": 690,
+     "sha256": "253425ec201a354cd1b4c93c78d740e2a17c7d946d911efffa63d522e95f9f0b"
+    },
+    "maps/ad_brk/brick14.bsp": {
+     "bytes": 8072,
+     "sha256": "afe8797d2172a5b4b06be3e2a69038346d62938f3d9da6ea224074cee5bb1669"
+    },
+    "maps/ad_brk/brick14.map": {
+     "bytes": 828,
+     "sha256": "a500705a328cafa28159ee107cbe80003848ee241c3544a73dea1432f67b4042"
+    },
+    "maps/ad_brk/brick15.bsp": {
+     "bytes": 8280,
+     "sha256": "58ddb31ce4108a70872444022369154529c532983dbc58698cd88f217f8947a0"
+    },
+    "maps/ad_brk/brick15.map": {
+     "bytes": 899,
+     "sha256": "589f256e02b66051ede4f2fe136e69313a7e01402f1caa43bada4d605a046b8e"
+    },
+    "maps/ad_brk/brick16.bsp": {
+     "bytes": 8052,
+     "sha256": "d5c15593d0d776d5f76919100602d893973cd59b7ca88af55e1ae3cc2fb56967"
+    },
+    "maps/ad_brk/brick16.map": {
+     "bytes": 785,
+     "sha256": "a15682c168f0a7128c83bf7bd38688ae1d2507873687e815c690b08d44f14a37"
+    },
+    "maps/ad_brk/brick17.bsp": {
+     "bytes": 7952,
+     "sha256": "738d902046d73e14b8a552529dd8306864661fd0469efb52b3c81329135e8372"
+    },
+    "maps/ad_brk/brick17.map": {
+     "bytes": 770,
+     "sha256": "699fa7055fa88f309fe4a4a2af24b5d61af91365d81074e44cbdf399d36939c9"
+    },
+    "maps/ad_brk/brick18.bsp": {
+     "bytes": 9184,
+     "sha256": "67ad693c292448f73ea0b3ab6ee22883709c7deb006cecd19c0dda5c9d4fa131"
+    },
+    "maps/ad_brk/brick18.map": {
+     "bytes": 1709,
+     "sha256": "849749000a41ecfc60aa4607c890e140bcd78ef26858512f56494efdc5873bcd"
+    },
+    "maps/ad_brk/brick19.bsp": {
+     "bytes": 10321,
+     "sha256": "721c3237db8c026a03e01e387bb95fe5ed8fbc49b3c527220f164d77a2f3a4f2"
+    },
+    "maps/ad_brk/brick19.map": {
+     "bytes": 1942,
+     "sha256": "1760c2c74d0b894814c89152062f2f55a8635a17559828c27532a7e913949af6"
+    },
+    "maps/ad_brk/brick20.bsp": {
+     "bytes": 13306,
+     "sha256": "bbecee9c1ac726743e6cc49d18246c650f762f577dc108ffed2a6807ff665052"
+    },
+    "maps/ad_brk/brick20.map": {
+     "bytes": 3286,
+     "sha256": "121d4fe62c07953f11a04a41577769a38cae8852af78bbd40fc44f598eee91d7"
+    },
+    "maps/ad_brk/brick21.bsp": {
+     "bytes": 7972,
+     "sha256": "e65c1df9d5f02efc9475a53d1127d7899f69d23d8a0ea20deab384fcd3351d29"
+    },
+    "maps/ad_brk/brick21.map": {
+     "bytes": 789,
+     "sha256": "8c12d093245c3937afcf62916fce9e6b2d181d72d433b879112b27e0f168ccc7"
+    },
+    "maps/ad_brk/brick22.bsp": {
+     "bytes": 9204,
+     "sha256": "b8efe5f130accf1e8704202dbaa44215259e1209b9b81bf79461ff5e5f725596"
+    },
+    "maps/ad_brk/brick22.map": {
+     "bytes": 1728,
+     "sha256": "403525bf264890c5d9adef370847749cbeec481337f284618810057e697cddde"
+    },
+    "maps/ad_brk/brick23.bsp": {
+     "bytes": 10340,
+     "sha256": "79bac69a44c7e83343bd69c2360176046e048257ecfb7ac27f3c989b42af92e9"
+    },
+    "maps/ad_brk/brick23.map": {
+     "bytes": 1961,
+     "sha256": "f25e7a514eb15637b7dedc41ec5c34e2d8b9e4dd3b584a41a1b1d7c166b362ef"
+    },
+    "maps/ad_brk/brick24.bsp": {
+     "bytes": 13312,
+     "sha256": "2e0728a16ebe0fa868d8bd0ffe0f54e013afac41c77ee7516f385d7a6718b07f"
+    },
+    "maps/ad_brk/brick24.map": {
+     "bytes": 3305,
+     "sha256": "481d21e7e07a312e894f71a8118035457164f17d48032bad54bdc62644e7e8a4"
+    },
+    "maps/ad_brk/brick25.bsp": {
+     "bytes": 7924,
+     "sha256": "8e33245bde92e94d9dddca1b61059fee1eb19aed0613945c1dffe3145fd51d78"
+    },
+    "maps/ad_brk/brick25.map": {
+     "bytes": 715,
+     "sha256": "cf6042585a2347f8ae4de546e2fa9aa905aa7ee4d9607a12dfd778d0084ba9d1"
+    },
+    "maps/ad_brk/brick26.bsp": {
+     "bytes": 8084,
+     "sha256": "4ddb5d2ca4adbc32f905a0340b26a174c25af7f6de5ad9408c4e0f4ca2816a55"
+    },
+    "maps/ad_brk/brick26.map": {
+     "bytes": 855,
+     "sha256": "baaf133d5c5c90b295855bb03a0a30340db324ddc82ed119a9d025e8ddb22724"
+    },
+    "maps/ad_brk/brick27.bsp": {
+     "bytes": 8296,
+     "sha256": "9084778144864d4167d270dd825e99d18d7ea7fc2dfb799f7e0eb12f1d236688"
+    },
+    "maps/ad_brk/brick27.map": {
+     "bytes": 927,
+     "sha256": "4e3b59df2a5b8efe85460f114baa795c36c8b410407e0752a69efc525d49e9b0"
+    },
+    "maps/ad_brk/brick28.bsp": {
+     "bytes": 8068,
+     "sha256": "42b4fe7f99032b3292996bcfe8b72e1c5e3b637357e376f8502a202a3816bcf0"
+    },
+    "maps/ad_brk/brick28.map": {
+     "bytes": 811,
+     "sha256": "c088828bbe9cdca1bb55ea4ceca9f46e03217f1643189a93d70a83eeb11f72bc"
+    },
+    "maps/ad_brk/brick29.bsp": {
+     "bytes": 24232,
+     "sha256": "463ff6bed92dfab082f13876187c506572dd3d18727e13fb708e24afd02aa7ef"
+    },
+    "maps/ad_brk/brick29.map": {
+     "bytes": 711,
+     "sha256": "1a4ff9d041df15cfd229666a9b32c24a96577ef6f249f33d89dc88cdfbe5540a"
+    },
+    "maps/ad_brk/brick30.bsp": {
+     "bytes": 24392,
+     "sha256": "a82a0d709c367d8ecf359142d99d0ad09d97b674ef1575beeb78dbbe93025c59"
+    },
+    "maps/ad_brk/brick30.map": {
+     "bytes": 853,
+     "sha256": "803c896037b5cc971e932219b5f06e363724a25de693ef6800d1332c6df4f8d1"
+    },
+    "maps/ad_brk/brick31.bsp": {
+     "bytes": 24604,
+     "sha256": "deb8a0278e043c6510e7f7d17ec708bdc7f37fa884f869ccbfc9ef9a95b6a8ac"
+    },
+    "maps/ad_brk/brick31.map": {
+     "bytes": 926,
+     "sha256": "9a3502125d9a995f10052ed6a9971bfe148a4e8fd7561a082e8bbecff5b39d56"
+    },
+    "maps/ad_brk/brick32.bsp": {
+     "bytes": 24376,
+     "sha256": "c8961b003f231b13a74bc247ce13ada38850707d443aa98dbad98b9f2ecf276b"
+    },
+    "maps/ad_brk/brick32.map": {
+     "bytes": 808,
+     "sha256": "aa96dda4508d2e98b5827ac42d8230f11969457f63022bf488dac06d2783910e"
+    },
+    "maps/ad_brk/glass01.bsp": {
+     "bytes": 8095,
+     "sha256": "d5d9b8df7fc4db671e180fbc60253ea809b61819bd77a9072d1cf1b1c9c11888"
+    },
+    "maps/ad_brk/glass01.map": {
+     "bytes": 961,
+     "sha256": "04b6721fc35e7a43fa921075bc2184bbbb2791570ea781ee6351b0cf01936456"
+    },
+    "maps/ad_brk/glass02.bsp": {
+     "bytes": 7035,
+     "sha256": "b2e6ba1e674f6a93e01ada15700b98624eae9c242a30eba9ea032d2e7d9fc555"
+    },
+    "maps/ad_brk/glass02.map": {
+     "bytes": 447,
+     "sha256": "6bf3cce568e830dd03830bb2e7225329490dae01e33806eec6a594313a8daa9e"
+    },
+    "maps/ad_brk/glass03.bsp": {
+     "bytes": 7922,
+     "sha256": "02661d1e724d41c02c977f8b869a23e6fc883303b66298c98ebddf752f365a1b"
+    },
+    "maps/ad_brk/glass03.map": {
+     "bytes": 963,
+     "sha256": "cb5245e54bc27d999bd643370557f8e766ae94e10358993951084e6ca87d087c"
+    },
+    "maps/ad_brk/glass04.bsp": {
+     "bytes": 7223,
+     "sha256": "a41bddb2d6a0ef53b96097a6e4d9731bf100b695a7a1c11091f054f746c7bf2a"
+    },
+    "maps/ad_brk/glass04.map": {
+     "bytes": 512,
+     "sha256": "f8e9f41266f3cd0017c19f7d3a29e0c738b497fb539cec2583c4eda6d509965c"
+    },
+    "maps/ad_brk/glass05.bsp": {
+     "bytes": 24436,
+     "sha256": "10fd2ef7f24bda233c3b4433e4ed64b8feb7273f09c0da5d93190ced61f20779"
+    },
+    "maps/ad_brk/glass05.map": {
+     "bytes": 999,
+     "sha256": "c8e2039929909b608ac0ddf36562443caf7052a15e8b0e39a73e0869c15930c1"
+    },
+    "maps/ad_brk/glass06.bsp": {
+     "bytes": 24300,
+     "sha256": "60f08ebc3d967dbe1b6062a59679a3e89e199a305f51bb9bc7dbada44c66fe5e"
+    },
+    "maps/ad_brk/glass06.map": {
+     "bytes": 976,
+     "sha256": "73346b8cc46166371a6e7f220ebe78f2cde29f29d8d705e1e4b0c60e153b52df"
+    },
+    "maps/ad_brk/glass07.bsp": {
+     "bytes": 23365,
+     "sha256": "ccebafe1a97953e91b64694783a1989c8e8ba440fd3c136b09785131b54c75cf"
+    },
+    "maps/ad_brk/glass07.map": {
+     "bytes": 458,
+     "sha256": "6d79a332d308ed3746c8f2fd13227b44a1cc66f0b2fd471eb6de1cbf695d81c9"
+    },
+    "maps/ad_brk/glass08.bsp": {
+     "bytes": 23602,
+     "sha256": "82c1bfe3d83c87c908d6dac76a255843cbbaededeaf644eeec5b9b9a794e0bdf"
+    },
+    "maps/ad_brk/glass08.map": {
+     "bytes": 530,
+     "sha256": "65dba1b71881c49b29d288720f43c457c838b93aa9e522953bac885443944c04"
+    },
+    "maps/ad_brk/glass09.bsp": {
+     "bytes": 24436,
+     "sha256": "34e317a5652fcc4a3aaf517ebc178c8d8fad6738b536a6c06eff2800bf7fefba"
+    },
+    "maps/ad_brk/glass09.map": {
+     "bytes": 999,
+     "sha256": "ca9b91b38fa600b7dfa80e9a257dc15f2f2dda9e1d2c1d002ea90cbdcc0e0279"
+    },
+    "maps/ad_brk/glass10.bsp": {
+     "bytes": 24300,
+     "sha256": "6e06c140e0916cd35235bd7e6970ca3250c6c36a2ee6d4632d805da67215818a"
+    },
+    "maps/ad_brk/glass10.map": {
+     "bytes": 976,
+     "sha256": "2043f7646edcfa088a76b6104b136ff9ca0f90bffe6efb955f951a4bfe16643d"
+    },
+    "maps/ad_brk/glass11.bsp": {
+     "bytes": 23365,
+     "sha256": "caae0c47ae097f4cb1055a3f5eecd5d407b71c975b35d992f3048993b1ac7e97"
+    },
+    "maps/ad_brk/glass11.map": {
+     "bytes": 458,
+     "sha256": "5bea1bbcee409674f58a1fd26cf0c983e11f8ffd5f20c829f5c3df6a4c28b1c9"
+    },
+    "maps/ad_brk/glass12.bsp": {
+     "bytes": 23602,
+     "sha256": "526018b31a9b02b1c9e1b5123b2c936677d6fd7b6c014ea14dfe4905271e419f"
+    },
+    "maps/ad_brk/glass12.map": {
+     "bytes": 530,
+     "sha256": "499ed4ce1a1ebbd9347a2a4dc6413f2f79d203bbce293a79a5b2bde49ade0a3f"
+    },
+    "maps/ad_brk/glass13.bsp": {
+     "bytes": 24108,
+     "sha256": "fdb97447ffe9e4769f35a3e1e7bd9d6b0e2e6b555d60102991bf57f06e8b3d83"
+    },
+    "maps/ad_brk/glass13.map": {
+     "bytes": 979,
+     "sha256": "073661c415a2568c45a90cc9baa471cde9a02a975d4d4fd7596bb96d272d3934"
+    },
+    "maps/ad_brk/glass14.bsp": {
+     "bytes": 23296,
+     "sha256": "e3517bb79e2561150c4641ab3650e0697adcaa2f281c5209cacdc12d9c4023a7"
+    },
+    "maps/ad_brk/glass14.map": {
+     "bytes": 462,
+     "sha256": "066d5bade73c399cf10a9dcafecec9d65ac3c6045644988cbefb104fb8e7d8c3"
+    },
+    "maps/ad_brk/glass15.bsp": {
+     "bytes": 23892,
+     "sha256": "6abc82aca32e6c8312884db42891753c8d2ad8e1d4ae9218022604eadb08708b"
+    },
+    "maps/ad_brk/glass15.map": {
+     "bytes": 993,
+     "sha256": "5c24e1763bd26d34539bc7ee527842810e4ddb6ac80f683a7b3b35ee326360d3"
+    },
+    "maps/ad_brk/glass16.bsp": {
+     "bytes": 23532,
+     "sha256": "13725c14b226297090c4f1e9949c476f601a52247bc8f6abb937a57b964462c6"
+    },
+    "maps/ad_brk/glass16.map": {
+     "bytes": 528,
+     "sha256": "03dbc7feb833831d413e7f87ed0e79625da0800659ab65ea8d3deb63de09a27d"
+    },
+    "maps/ad_brk/kn_mtrim2_1.bsp": {
+     "bytes": 25264,
+     "sha256": "99b67eeed7ece0f46b1d7b4b2309331e655eb9c1b412d3ac4bc362acb4dd8606"
+    },
+    "maps/ad_brk/kn_mtrim2_1.map": {
+     "bytes": 1455,
+     "sha256": "51018fd4ff6d00c9c2c449e32a83b8521fdc3babb2937adf6800d8e67e38b976"
+    },
+    "maps/ad_brk/kn_mtrim2_2.bsp": {
+     "bytes": 24460,
+     "sha256": "a98bdee68b3a222af0f44fc978d09e092a08953539929a6a53f1bf0e97568e74"
+    },
+    "maps/ad_brk/kn_mtrim2_2.map": {
+     "bytes": 1103,
+     "sha256": "2880a3f7becf48ae79c27ef9a05faa5c774df20a53ec5d892304bf67bc06cbbe"
+    },
+    "maps/ad_brk/kn_mtrim2_3.bsp": {
+     "bytes": 24632,
+     "sha256": "967e89f57bc011cd3b38d60d45272633cc0f773c91045b7938766ac0436ae803"
+    },
+    "maps/ad_brk/kn_mtrim2_3.map": {
+     "bytes": 1171,
+     "sha256": "40ef38fd45c3e9c750d311bb8920b938fcd9f647f2dabc58509b327514f44907"
+    },
+    "maps/ad_brk/kn_mtrim2_4.bsp": {
+     "bytes": 24452,
+     "sha256": "e4559e1e5a3118f2c949daccb96f887d64821511f5850cfa72133f84a8e04901"
+    },
+    "maps/ad_brk/kn_mtrim2_4.map": {
+     "bytes": 1036,
+     "sha256": "595513bc0fe2441cb6aa88af41d9afd7de8b94421ac6c32c546113f83be6577c"
+    },
+    "maps/ad_brk/metal01.bsp": {
+     "bytes": 8122,
+     "sha256": "11e8e340455c487150951fb4dccaf7da72d0243892948d5c22b478221ffcca23"
+    },
+    "maps/ad_brk/metal01.map": {
+     "bytes": 780,
+     "sha256": "902c31c661df8bbc1b0c410b6a8745f680e85cf91bbdb14d85244b6937be5239"
+    },
+    "maps/ad_brk/metal02.bsp": {
+     "bytes": 10022,
+     "sha256": "59b56266e73b4246c54d8cd9c4769d7345c53ae5133c45d1db94f5c771350d94"
+    },
+    "maps/ad_brk/metal02.map": {
+     "bytes": 1414,
+     "sha256": "171bfe727b6c80a4c0350fb4c87090d30c3fb1a21962b8fc9c638c47027e1fea"
+    },
+    "maps/ad_brk/metal03.bsp": {
+     "bytes": 9386,
+     "sha256": "13e3ea83c5bdbf81075328cc14543d1ab6301378cc9af56b59b67b1cc22e3a53"
+    },
+    "maps/ad_brk/metal03.map": {
+     "bytes": 1179,
+     "sha256": "89ac4002203958a9f971601586f4e4e6bdcaab7cbde62ca7fb58cf705fbdae56"
+    },
+    "maps/ad_brk/metal04.bsp": {
+     "bytes": 10655,
+     "sha256": "785ab6aed41e60072083aeee571d76796f60ec5e24d249736575007d558c10ae"
+    },
+    "maps/ad_brk/metal04.map": {
+     "bytes": 1599,
+     "sha256": "aecd2de4ce9cdb49922c58f640f3df4c48b8dc45f5e611f5d0c75a6a96bf705e"
+    },
+    "maps/ad_brk/metal05.bsp": {
+     "bytes": 8337,
+     "sha256": "82da98a887a0101d1a638d266db3c9913090b3fcaca6af5869e7063529b3066e"
+    },
+    "maps/ad_brk/metal05.map": {
+     "bytes": 905,
+     "sha256": "541a5d633be51d32bbd6580cf3fb4fcc7e9b3c38107eaffdd88896a01d249b71"
+    },
+    "maps/ad_brk/metal06.bsp": {
+     "bytes": 7898,
+     "sha256": "3fe3f66ff336ede9d9a6f4fc0f7df16b62504b25a8dea1c8adce2113e927428e"
+    },
+    "maps/ad_brk/metal06.map": {
+     "bytes": 697,
+     "sha256": "30bfd29315a3c0d8654aa1842b7f2a2a7bcdc7a5a81ff96f359a86d57a289ce9"
+    },
+    "maps/ad_brk/metal07.bsp": {
+     "bytes": 8439,
+     "sha256": "8f8a722ae0d3350bf4331fbd4a492dd4c18b3c44006289fd7c6d393282f280a1"
+    },
+    "maps/ad_brk/metal07.map": {
+     "bytes": 1508,
+     "sha256": "f2c7442255c68ae30186692cdf49bca0f1e5769587d5d2392baf3ec4708679b2"
+    },
+    "maps/ad_brk/metal08.bsp": {
+     "bytes": 8150,
+     "sha256": "028675fecfd419e8852cabe821fac1941c914bdf43110291d7a07509e77f4d26"
+    },
+    "maps/ad_brk/metal08.map": {
+     "bytes": 847,
+     "sha256": "797217e143857e0b27e1654449a5dbdc0b1a3dc46c8cafdea5ee9c5ac0cbf16c"
+    },
+    "maps/ad_brk/metal09.bsp": {
+     "bytes": 7456,
+     "sha256": "4d6fb8a19ce5a331ceb68fcfa952fa61ed3ad336002eedd788921b0daa2a7877"
+    },
+    "maps/ad_brk/metal09.map": {
+     "bytes": 649,
+     "sha256": "1fde976a2f1372d9d55350caa3285776eee897d9786f9118d5a6988010efaeca"
+    },
+    "maps/ad_brk/metal10.bsp": {
+     "bytes": 7785,
+     "sha256": "c25084ae2f159ba73e6c43041a2e050d30af70a862a9c4846b2241848a33b55f"
+    },
+    "maps/ad_brk/metal10.map": {
+     "bytes": 709,
+     "sha256": "856390903976512f1b5372f374b5c7444238a173abbedbbfeccbb675cf93ed66"
+    },
+    "maps/ad_brk/metal11.bsp": {
+     "bytes": 7918,
+     "sha256": "e939c6c80e11479887b68bb39a97e0b877514c4e9dc9b2a4a9e18303caa317f1"
+    },
+    "maps/ad_brk/metal11.map": {
+     "bytes": 797,
+     "sha256": "74528d15a51708fdca65c900096411f1d56d6472a5058458577ac04d820e9895"
+    },
+    "maps/ad_brk/metal12.bsp": {
+     "bytes": 8226,
+     "sha256": "3ceccd7aa24fc353e0ac3ccb15531c2f243c0ed246c73c44bdd8897dbdd6537e"
+    },
+    "maps/ad_brk/metal12.map": {
+     "bytes": 872,
+     "sha256": "a95f34c46729c7849e6d45d9cdf57bb49289561b6551bd2e4a39659c272343fd"
+    },
+    "maps/ad_brk/metal13.bsp": {
+     "bytes": 8121,
+     "sha256": "e02aa4c824f5d8fcdfe302a0a194cee6fcf44e2fee844c492f434bf2b7763209"
+    },
+    "maps/ad_brk/metal13.map": {
+     "bytes": 760,
+     "sha256": "bae8879296237bea635d054428a536c0297420ff3ff61f681d569b30a984e7d0"
+    },
+    "maps/ad_brk/metal14.bsp": {
+     "bytes": 10022,
+     "sha256": "4b66b133fe892c6ae6ead0c6726638e98637d71a3a9afdc4ac0546be0f2d0292"
+    },
+    "maps/ad_brk/metal14.map": {
+     "bytes": 1376,
+     "sha256": "197bd6c01b5ffc4c9e0f27e319b25b882af4f20db36612f41b006dd6db0833e1"
+    },
+    "maps/ad_brk/metal15.bsp": {
+     "bytes": 9386,
+     "sha256": "8cf7545aa3464814908c3987f51e9693f154f690ec526ed228b37b1590730e0b"
+    },
+    "maps/ad_brk/metal15.map": {
+     "bytes": 1147,
+     "sha256": "73aef82251f5b4a9548135aedb926aad6b7cff94cb3656fc8216a594a8a9f6dc"
+    },
+    "maps/ad_brk/metal16.bsp": {
+     "bytes": 10719,
+     "sha256": "af64c13135b1e1eb6d8e09607c34d6cec57a3cbf624dd76b136b505f097ecf65"
+    },
+    "maps/ad_brk/metal16.map": {
+     "bytes": 1555,
+     "sha256": "d7220fbbb33a630d03ed2514b9ee33a9d3a424f819b4977e093863ca8568b645"
+    },
+    "maps/ad_brk/metal17.bsp": {
+     "bytes": 8347,
+     "sha256": "0d21cbf9b5bc65391e00bad35368530d3d4b5f59993e2ac7d45a7edc9a2edf73"
+    },
+    "maps/ad_brk/metal17.map": {
+     "bytes": 911,
+     "sha256": "7be91013d0e57e41aff314398634043cebf8f250691b3ebc583bf373df400c2c"
+    },
+    "maps/ad_brk/metal18.bsp": {
+     "bytes": 7907,
+     "sha256": "ef0dee9c63d7bbced8c04ea40523d47fd99638905aa20a61779820b5aebd5aab"
+    },
+    "maps/ad_brk/metal18.map": {
+     "bytes": 703,
+     "sha256": "b610432a51ac6b57f19fee9df89fc7b80d5cbffa972e539d9c5f3aded3359434"
+    },
+    "maps/ad_brk/metal19.bsp": {
+     "bytes": 8450,
+     "sha256": "2796007e11c0a1b2a3430edc4e0f7edb0e721a6d906e783233c0feb54b0482e5"
+    },
+    "maps/ad_brk/metal19.map": {
+     "bytes": 1514,
+     "sha256": "9ed741344b3c651f3b8fbda1d8ee8e779bd12315feea397e938522c9750dc214"
+    },
+    "maps/ad_brk/metal20.bsp": {
+     "bytes": 8160,
+     "sha256": "38013cdb360356827ab6c296791434c537183d082feed6944665a882e622ed84"
+    },
+    "maps/ad_brk/metal20.map": {
+     "bytes": 853,
+     "sha256": "a3b28328bb043206bc048e82dba12d91c56c464b5e4e1452c6740f0df44223bf"
+    },
+    "maps/ad_brk/rock01.bsp": {
+     "bytes": 24238,
+     "sha256": "5f2c0a6ce3c58eed53c86789ff1685551cff53ca1f239bf75e3a9bc59aa95a56"
+    },
+    "maps/ad_brk/rock01.map": {
+     "bytes": 680,
+     "sha256": "db0b6a72833e12a35f518b32920fccf4fbc45120e7ab8ca3afc6e255b5d51334"
+    },
+    "maps/ad_brk/rock02.bsp": {
+     "bytes": 24250,
+     "sha256": "c6196e82e7b3e22cb687e2d6c0780f163929b5ea42b868eedcaadd40f35927f9"
+    },
+    "maps/ad_brk/rock02.map": {
+     "bytes": 760,
+     "sha256": "49531f0a1a38e03e3b46af53cfc35845878fcc171c2579f0f13d2a000ca82829"
+    },
+    "maps/ad_brk/rock03.bsp": {
+     "bytes": 24669,
+     "sha256": "9f7ab133399a3681f0b97276c7cb9883b479995c3420e5643eaedd11c88f0a0d"
+    },
+    "maps/ad_brk/rock03.map": {
+     "bytes": 929,
+     "sha256": "4158321d447c3b323f44389661ba6c763b23e26fb9541a786c3b544ad56321d9"
+    },
+    "maps/ad_brk/rock04.bsp": {
+     "bytes": 24600,
+     "sha256": "3c8b114e8ff86b8abcba235230445d885d4c28553d83e153676b2755b0300292"
+    },
+    "maps/ad_brk/rock04.map": {
+     "bytes": 878,
+     "sha256": "229d94f5f5bd81a83be5463035d30c8838d1de092923c3281e7a3a9ec4c7e9aa"
+    },
+    "maps/ad_brk/rock05.bsp": {
+     "bytes": 24254,
+     "sha256": "6bdc990b90f24ddd77034a4cbdd4d7158e05df70e6db5e793ca990a40cd29709"
+    },
+    "maps/ad_brk/rock05.map": {
+     "bytes": 684,
+     "sha256": "708a6ad98116a72ddc862c6c99cbd59342446636c9579a00bd6c34efa1ac855b"
+    },
+    "maps/ad_brk/rock06.bsp": {
+     "bytes": 24462,
+     "sha256": "e2e3688c3cb66e2c9d738d211ad328d86963e1d67881354363696698a07be32b"
+    },
+    "maps/ad_brk/rock06.map": {
+     "bytes": 816,
+     "sha256": "5e1a399ac2e6a179a84004539f15172012db93477e5544309b01ed24cbc59f34"
+    },
+    "maps/ad_brk/rock07.bsp": {
+     "bytes": 24281,
+     "sha256": "ea3569e42b755fd1b9fde50e2740f6aa95d1dabb1911f8a4ab5b1c5028a4e1e3"
+    },
+    "maps/ad_brk/rock07.map": {
+     "bytes": 777,
+     "sha256": "02f61c60083f5007fa9d4d7a38adf2901e928a96adbfeaa7646711f21cc75409"
+    },
+    "maps/ad_brk/rock08.bsp": {
+     "bytes": 25096,
+     "sha256": "5468a365153fc7f160d7e1792b9bc9164b828a51851bd1e9744eb0cf3a7a842d"
+    },
+    "maps/ad_brk/rock08.map": {
+     "bytes": 1060,
+     "sha256": "b285f3a79407366944213b3d8eef311c662bf2eb0cf3df0ee3104e747a3c9150"
+    },
+    "maps/ad_brk/rock09.bsp": {
+     "bytes": 8314,
+     "sha256": "4320c73f55d67e4db7e596614b74b05b0c086cd57186ecaf183c96fca51106bf"
+    },
+    "maps/ad_brk/rock09.map": {
+     "bytes": 913,
+     "sha256": "629fab0d0f8022138ff5d5e573f0e3ab0f75397f120015b3f8a95a297c857911"
+    },
+    "maps/ad_brk/rock10.bsp": {
+     "bytes": 7930,
+     "sha256": "7657ad82fbdeaceb354e04f60fa76cfd3d8a7a819607a413afaa6fc16253a009"
+    },
+    "maps/ad_brk/rock10.map": {
+     "bytes": 780,
+     "sha256": "833bc2f2460f5f5ef444630b398a59974831031e408f986125a5241fab52ba99"
+    },
+    "maps/ad_brk/rock11.bsp": {
+     "bytes": 8565,
+     "sha256": "e19573b67e5dedba499da8f6d0d63ca0e829593417a1ce66e1aeb1fd2b2d1e76"
+    },
+    "maps/ad_brk/rock11.map": {
+     "bytes": 1016,
+     "sha256": "040c31d22159743b28e9f20946b34db390ef15bbe530882342638b9325542801"
+    },
+    "maps/ad_brk/rock12.bsp": {
+     "bytes": 8284,
+     "sha256": "f03a3a0184b2fa8809154754f85d81d30777261714976bdd64340b0549d3ca35"
+    },
+    "maps/ad_brk/rock12.map": {
+     "bytes": 898,
+     "sha256": "b7d2b1bba22ad5b621e699a8233a83d23415e5c6e88fec8e1525a9c84a494bf0"
+    },
+    "maps/ad_brk/rock13.bsp": {
+     "bytes": 7917,
+     "sha256": "6710c24df905df9ede31faf75fdf9a070efbdc471e58a295740092863dcb50fa"
+    },
+    "maps/ad_brk/rock13.map": {
+     "bytes": 680,
+     "sha256": "369735b7ebd630e6407371d3ab7195ef368c2f8d8d3469943b2c5e46b8e24fa5"
+    },
+    "maps/ad_brk/rock14.bsp": {
+     "bytes": 7929,
+     "sha256": "a17329c593e306d1aa4084cd2651983f53258b3e5759443efe3bb3b4daecc5f8"
+    },
+    "maps/ad_brk/rock14.map": {
+     "bytes": 760,
+     "sha256": "f86556e799f3a0240294537aa487526c674486afb7190bb705d72453cade7e68"
+    },
+    "maps/ad_brk/rock15.bsp": {
+     "bytes": 8349,
+     "sha256": "d64f11606da6b94024382315eead25dbfe19c8cc90844f60e755e2bd106c7fc0"
+    },
+    "maps/ad_brk/rock15.map": {
+     "bytes": 929,
+     "sha256": "23defe1bddcc8db664c819b60657fd536b1c44b118299495d42f7c54f740e7b0"
+    },
+    "maps/ad_brk/rock16.bsp": {
+     "bytes": 8280,
+     "sha256": "87e60c650a672c5ffe57b64c7ae3c5413799972a2ca5b73935cb0d1dad16f62c"
+    },
+    "maps/ad_brk/rock16.map": {
+     "bytes": 878,
+     "sha256": "d3616ad7b423be757f6f7873791f4c452a09243b53569347bd36e87f1a942947"
+    },
+    "maps/ad_brk/rock17.bsp": {
+     "bytes": 8340,
+     "sha256": "b317f3432532e6f6f327852fa0c7f546726c8b23c44cfc3e86869d64eb33235c"
+    },
+    "maps/ad_brk/rock17.map": {
+     "bytes": 913,
+     "sha256": "a534b032b611965c86cd81fda18d53186c474d55184f9c4c74cd292b4b207f27"
+    },
+    "maps/ad_brk/rock18.bsp": {
+     "bytes": 7924,
+     "sha256": "e5fc24e393828bdd2c24e3cb341e0c21e81511881e65424293206fe20ff54c4e"
+    },
+    "maps/ad_brk/rock18.map": {
+     "bytes": 701,
+     "sha256": "bf5974bf04067482dde83a2fd73e58a011de04220b32866fa7913e901a0e944c"
+    },
+    "maps/ad_brk/rock19.bsp": {
+     "bytes": 8620,
+     "sha256": "4a1d3e4e37f29438981f419f5a5f076fcf53227a4da544e919061d6c6bf8702e"
+    },
+    "maps/ad_brk/rock19.map": {
+     "bytes": 919,
+     "sha256": "c2626204acbd33e3299c29cd1f8a5279bbe8cd07a621f6b40b14b74b7808f444"
+    },
+    "maps/ad_brk/rock20.bsp": {
+     "bytes": 8785,
+     "sha256": "87bfda54a9f0711eedcefc6d8e691b6cac8123958db03735bd0364067445de69"
+    },
+    "maps/ad_brk/rock20.map": {
+     "bytes": 1118,
+     "sha256": "225800378c3183d5ba423140d7f5d510cf387df3df795fda69294fcb0e4bec4c"
+    },
+    "maps/ad_brk/rock21.bsp": {
+     "bytes": 24244,
+     "sha256": "161b5893f3f413969ced051a7e7aa3d816a1da9f74bffa5d0642830713d83031"
+    },
+    "maps/ad_brk/rock21.map": {
+     "bytes": 674,
+     "sha256": "db86b019086636ec085b3690bc4b252d8bac2443c0ff138a6f3b6c79e522a94b"
+    },
+    "maps/ad_brk/rock22.bsp": {
+     "bytes": 24256,
+     "sha256": "b41069e88c74ef3bfb7c5f2817c31d9d374cd1725b7270b9ac7d93c58dd34a11"
+    },
+    "maps/ad_brk/rock22.map": {
+     "bytes": 753,
+     "sha256": "aa059dd13499512fdda512b68e79068f390d1870726763958a81a54c91aeb254"
+    },
+    "maps/ad_brk/rock23.bsp": {
+     "bytes": 24676,
+     "sha256": "aac7fc5557dd385c52043d206d39d83b48e0b2f6db2822de2060f2a978be4a9d"
+    },
+    "maps/ad_brk/rock23.map": {
+     "bytes": 920,
+     "sha256": "744ccf1456c3b19318289586238b1d36e4968dbfe444f5a489e1d2202f1965d4"
+    },
+    "maps/ad_brk/rock24.bsp": {
+     "bytes": 24612,
+     "sha256": "90553422561893d50030520bcf796da9290933e53570e313d1a423aec01c8ac6"
+    },
+    "maps/ad_brk/rock24.map": {
+     "bytes": 939,
+     "sha256": "3f8f5c2053315577eda81360a9ed9a095e96f7d9a6288eed876400a91bc0922b"
+    },
+    "maps/ad_brk/rock25.bsp": {
+     "bytes": 89516,
+     "sha256": "ef87b49e322fd2a2251f0ee7ecedec32bae141ea7a589769c6fba6a3176da0d4"
+    },
+    "maps/ad_brk/rock25.map": {
+     "bytes": 737,
+     "sha256": "3cad88a720acc4d7db1666ab0d865e013717776a256c999e1b417690679f4f0b"
+    },
+    "maps/ad_brk/rock26.bsp": {
+     "bytes": 89532,
+     "sha256": "a6f46aa8183937dfe19eb1cfde621bac8f3f08721effcbbd195ba251b3b1467f"
+    },
+    "maps/ad_brk/rock26.map": {
+     "bytes": 823,
+     "sha256": "27c411424182d3e6d611f2eff2dd9a7c75ef2135f2019d4aca40b2dee2d134b5"
+    },
+    "maps/ad_brk/rock27.bsp": {
+     "bytes": 89952,
+     "sha256": "f55dc66117c856efee1dae5e311492f2aae2839ef4588af45ac0818307ad564c"
+    },
+    "maps/ad_brk/rock27.map": {
+     "bytes": 1004,
+     "sha256": "7368f6cbd051aa3ac71237b5c8d3da2ef73fc3017024ef42af6ac8af9ddc1139"
+    },
+    "maps/ad_brk/rock28.bsp": {
+     "bytes": 89880,
+     "sha256": "2132d7f311c90f8c43b4630a55f7fa0b15141fa0e9c26c0309c8023437377961"
+    },
+    "maps/ad_brk/rock28.map": {
+     "bytes": 947,
+     "sha256": "b1571df2e370ca2d51f19b3608726552f10a6f6da64f69929a2ea2c1884e51dc"
+    },
+    "maps/ad_brk/rock29.bsp": {
+     "bytes": 89516,
+     "sha256": "a179ac329768d445bfbc36bb9c3e47ce3c7506c31337730a93c9a58f96ea5399"
+    },
+    "maps/ad_brk/rock29.map": {
+     "bytes": 737,
+     "sha256": "260d08f376c81869c1f9a0c0cfd677bded9022f79bbe4e607d12128b7ad7c746"
+    },
+    "maps/ad_brk/rock30.bsp": {
+     "bytes": 89532,
+     "sha256": "febc6ed2ec191f8dcbae1ee9df9d13bbd8fff830e28e051236fa24fd211829ee"
+    },
+    "maps/ad_brk/rock30.map": {
+     "bytes": 823,
+     "sha256": "da6a3224e060f6413f70ac9f6f25bf96f3784f690084d602d63805dc8b43e7e8"
+    },
+    "maps/ad_brk/rock31.bsp": {
+     "bytes": 89952,
+     "sha256": "7a38ed8a7dd80c2f2dab17342bfdde51300c9225f4e93be78ca9b63d3a7f1e99"
+    },
+    "maps/ad_brk/rock31.map": {
+     "bytes": 1004,
+     "sha256": "3fb04740e6da6c00670536ccbcb92e7a9a5b5e3072e78af96d6dd5c79d39f984"
+    },
+    "maps/ad_brk/rock32.bsp": {
+     "bytes": 89880,
+     "sha256": "41789fbb095ef6d7b09ba6f50bea0503f73e612808f37bbb71f4a7e9fea00ae2"
+    },
+    "maps/ad_brk/rock32.map": {
+     "bytes": 947,
+     "sha256": "37e272ad3f235bb182666e46d3b087bee4ec23ebdc716647c5b0ffb671a9ee1d"
+    },
+    "maps/ad_brk/rock33.bsp": {
+     "bytes": 7916,
+     "sha256": "af3e313ba1c7013b7bd2234e9988a2b6bc451d123e7d6dab1692ae0727d40bec"
+    },
+    "maps/ad_brk/rock33.map": {
+     "bytes": 683,
+     "sha256": "de08059147e865be402e6dac4c6d8a0bea1de05bb65cf0455153386afdde2bdb"
+    },
+    "maps/ad_brk/rock34.bsp": {
+     "bytes": 7932,
+     "sha256": "392125c9afaf18c3084c1b13a0a55dcda7e2294da37f84fb73983826271dea27"
+    },
+    "maps/ad_brk/rock34.map": {
+     "bytes": 763,
+     "sha256": "dc402e2573ee3e94f3ed96274d5b6f8d0177d9745716ea96d0ffce8e0be5c943"
+    },
+    "maps/ad_brk/rock35.bsp": {
+     "bytes": 8352,
+     "sha256": "0352c35aa723330a3c05126d24a8e6b84403bf8b71d406f3fa5a2ff3fc0da39a"
+    },
+    "maps/ad_brk/rock35.map": {
+     "bytes": 932,
+     "sha256": "9841ed50187bbdfb3a7122d3b0890b0245d64dd4919485686fdf5ce61bdae3e6"
+    },
+    "maps/ad_brk/rock36.bsp": {
+     "bytes": 8280,
+     "sha256": "f1871698ef7597c51fed5d54b582df2ea70cf72e2fa7db643182e59f7e7f6ca7"
+    },
+    "maps/ad_brk/rock36.map": {
+     "bytes": 881,
+     "sha256": "974aaec9003dd3e1457582b1f770d67e07fc8e9d11a6b639981fbb753c6a6484"
+    },
+    "maps/ad_brk/sandstone01.bsp": {
+     "bytes": 24239,
+     "sha256": "ebb374110d88805e1b0b45cdaf33e5e570a9092da549facaf9f5ddcd995eb607"
+    },
+    "maps/ad_brk/sandstone01.map": {
+     "bytes": 702,
+     "sha256": "9ea9ab63b8c6a2d90fba029c4d4b768beb0d4342cf255bb5005185b61b1bcfd2"
+    },
+    "maps/ad_brk/sandstone02.bsp": {
+     "bytes": 24399,
+     "sha256": "2fa799b0a08ca2fdd9bef3ecb9d6ea4c16e8f66181d29913cdc5a9205bafe98f"
+    },
+    "maps/ad_brk/sandstone02.map": {
+     "bytes": 842,
+     "sha256": "5228b0a958ef571f33838366ef1f2b69a10f6e0c53a3269dba683b5326a95e5f"
+    },
+    "maps/ad_brk/sandstone03.bsp": {
+     "bytes": 24607,
+     "sha256": "671b8f740ba9deaeac681c703f87d61c2a3f8107d0f72b8fd636c53436555110"
+    },
+    "maps/ad_brk/sandstone03.map": {
+     "bytes": 914,
+     "sha256": "7523ff7908eb3e47154155d0448fa05d4d9b6081525069a131e7d44ea9b13c0c"
+    },
+    "maps/ad_brk/sandstone04.bsp": {
+     "bytes": 24379,
+     "sha256": "56bda0f4bf4958dc243fa9b4ab79e9e3bd6fad5f794af7beb024a6cbe7f9a0cb"
+    },
+    "maps/ad_brk/sandstone04.map": {
+     "bytes": 798,
+     "sha256": "d01584bd00868a0a69ae7513834f776566fce273d8919d9c78d0bdafbb07a799"
+    },
+    "maps/ad_brk/wood01.bsp": {
+     "bytes": 7553,
+     "sha256": "c1764181bae4852804097143fe16a4c230bd5886574125cb33d5349bbc63dc21"
+    },
+    "maps/ad_brk/wood01.map": {
+     "bytes": 1040,
+     "sha256": "05f1ebaa57c4b55e6c3da9c5440c180aa96c719f9cddc80c780ed11415ad6bd7"
+    },
+    "maps/ad_brk/wood02.bsp": {
+     "bytes": 7079,
+     "sha256": "26fc67e4e47eae3a13a449d876deabe35d50aa1b70e63060d27cb365eadecbe0"
+    },
+    "maps/ad_brk/wood02.map": {
+     "bytes": 521,
+     "sha256": "8dee7615c9e9696420331668edeccd9ff1dd874ad844e289f049391be5e61345"
+    },
+    "maps/ad_brk/wood03.bsp": {
+     "bytes": 7135,
+     "sha256": "ca17df0f61a11bd37749587e361ca404f2e5bec07c248491d86c07803fafb732"
+    },
+    "maps/ad_brk/wood03.map": {
+     "bytes": 522,
+     "sha256": "0fb4cdb1ffeda8c97026d40842d5fcb0beced0f84dae4b10a8284044875cf0c2"
+    },
+    "maps/ad_brk/wood04.bsp": {
+     "bytes": 7951,
+     "sha256": "e2d9f42bf3256be2dd38648dbd962458bdad3992b33e8d688e42a0acba5d7c3f"
+    },
+    "maps/ad_brk/wood04.map": {
+     "bytes": 912,
+     "sha256": "071556b1cac3bd95a176762302e6a60ddbbfb07cf6c9e4b2f8cf2e259e23402a"
+    },
+    "maps/ad_brk/wood05.bsp": {
+     "bytes": 7553,
+     "sha256": "5bdb275ae2c39b41d71a17244681cda9cc2008df088f4da73f547a8bf1966069"
+    },
+    "maps/ad_brk/wood05.map": {
+     "bytes": 1040,
+     "sha256": "ada27de98972730676a2d040fd284893fabfe71acd6fcbce1f2ba12da7d14632"
+    },
+    "maps/ad_brk/wood06.bsp": {
+     "bytes": 7079,
+     "sha256": "f27b0f1970f6065255b5f7a27abfc4e749f40321f6fdef4c3f9ac6bb64d46098"
+    },
+    "maps/ad_brk/wood06.map": {
+     "bytes": 521,
+     "sha256": "17c93b1c1c65a7507d794013078a1d12a67c3a24ae7202739fcd8a1108d52419"
+    },
+    "maps/ad_brk/wood07.bsp": {
+     "bytes": 7135,
+     "sha256": "8e07e7e5f5b641c644d28c9c4026efc95aa50345074f5c42acd39a3b94261344"
+    },
+    "maps/ad_brk/wood07.map": {
+     "bytes": 522,
+     "sha256": "55f1bb5f18ed30f28ac88349aee9ea5563b1e938bafebffb25c9ab5a1c918b33"
+    },
+    "maps/ad_brk/wood08.bsp": {
+     "bytes": 7951,
+     "sha256": "d26222458ba6e7fee06670021e64c1661d99a8c098581936af943891c9583858"
+    },
+    "maps/ad_brk/wood08.map": {
+     "bytes": 912,
+     "sha256": "2582987129d34bbee73594a236c4c09ce6ae1092eec649ef3957b892e125624c"
+    },
+    "maps/ad_brk/wood09.bsp": {
+     "bytes": 7282,
+     "sha256": "2735e78b25b0feb640f27eddae47104b0acba9f017c6d025e3a8dbdfcc755778"
+    },
+    "maps/ad_brk/wood09.map": {
+     "bytes": 541,
+     "sha256": "84d9789b4d79b41347fd082b0ab75c016553c03bfb952cf4b9c7dd18c85944ce"
+    },
+    "maps/ad_brk/wood10.bsp": {
+     "bytes": 7214,
+     "sha256": "43b59e9b0cb02fb1ac15afb5c782e71b4ce0661db295949b5188cc5accd1733a"
+    },
+    "maps/ad_brk/wood10.map": {
+     "bytes": 533,
+     "sha256": "365f949e19e2606cf2d7a354c3e4368a5e17c3eef94e2558ed9cef276e987d35"
+    },
+    "maps/ad_brk/wood11.bsp": {
+     "bytes": 7196,
+     "sha256": "cce8b312c4be49810f4cf90f0dcdeb1a82dfa623de1ba44c55ec83475f9e9e49"
+    },
+    "maps/ad_brk/wood11.map": {
+     "bytes": 542,
+     "sha256": "790cd93cb271402698ad7f005b908847fddbb30d3c8c3d11fa8c2f327ca8e48e"
+    },
+    "maps/ad_brk/wood12.bsp": {
+     "bytes": 7978,
+     "sha256": "6a227f92bf3b6f1120efd6179bfb3de977e4be2e59495c5d757cbe1c835e3f03"
+    },
+    "maps/ad_brk/wood12.map": {
+     "bytes": 986,
+     "sha256": "01ed96a5ce6545b334dfac7dc0196472dd6c06df09ed557cec7dc820d35c1132"
+    },
+    "maps/ad_brk/wood13.bsp": {
+     "bytes": 7284,
+     "sha256": "09325ca10ebcfeb88f688c9f4521259c3c3426e9befc06c99ba405c7e20595c9"
+    },
+    "maps/ad_brk/wood13.map": {
+     "bytes": 526,
+     "sha256": "b16b33b2a46b72a4ee235674780298eac0ed27631def07a28058a775aba7078e"
+    },
+    "maps/ad_brk/wood14.bsp": {
+     "bytes": 7216,
+     "sha256": "4c9dc5afd7b51119e5c22ad36eb77d07881c454ff47ed060521172cfc3950e2c"
+    },
+    "maps/ad_brk/wood14.map": {
+     "bytes": 518,
+     "sha256": "41b51f20630df3c046ed9ca0f7d97ca403ce8c1487074fc80caf603e763e6ac1"
+    },
+    "maps/ad_brk/wood15.bsp": {
+     "bytes": 7196,
+     "sha256": "373f6e5c5da44b7c8d1a01fb701f074bbcfc52d21bb080dd04e986ffe9e1088c"
+    },
+    "maps/ad_brk/wood15.map": {
+     "bytes": 527,
+     "sha256": "eb07eae6f0afdb4b03af57bcb589e3b385632912f12d4c55257b3031270f0421"
+    },
+    "maps/ad_brk/wood16.bsp": {
+     "bytes": 7612,
+     "sha256": "05959d3486eb43afc8959f6923156a1a83ead4dad544f8caf90ba0e1c7e2bc80"
+    },
+    "maps/ad_brk/wood16.map": {
+     "bytes": 953,
+     "sha256": "c7e804e781c95336cc91a50bc246baf4fda7172ecf36ccf24f02c5f919710ab3"
+    },
+    "maps/ad_chapters.bsp": {
+     "bytes": 6833224,
+     "sha256": "a30fe517bc30f80d1c3afbe1a045bb77cf39fa26083accf785423710e976fdb0"
+    },
+    "maps/ad_chapters.lit": {
+     "bytes": 871928,
+     "sha256": "9944732819b6d8e0884ca01f728e717fb6791e774325e347b6f81dfae81bb6e1"
+    },
+    "maps/ad_crucial.bsp": {
+     "bytes": 14837880,
+     "sha256": "1f60ed7ebb644c1cf28fd995b8d9a27b41fba316c61b1ec555e944768d1a7084"
+    },
+    "maps/ad_crucial.lit": {
+     "bytes": 3901238,
+     "sha256": "ef8ca2db9aed9f2c5a9e146263d14a284078f01005848ca2209c2ea092109d71"
+    },
+    "maps/ad_dm1.bsp": {
+     "bytes": 3200093,
+     "sha256": "6f5bae8b8f42d85323a91544d6e3c1aaf2c23aefadd78dd7237a8112b55dbeff"
+    },
+    "maps/ad_dm1.lit": {
+     "bytes": 1088066,
+     "sha256": "d785d32a7776971adc25f4615dac0eb58aec9626145cc6b0adbe15748ab60638"
+    },
+    "maps/ad_dm5.bsp": {
+     "bytes": 6177538,
+     "sha256": "a72637f8db60f1b72111e41b2e1e8abf9022ace1561b01e4a5bfd5be9714234d"
+    },
+    "maps/ad_dm5.lit": {
+     "bytes": 1816892,
+     "sha256": "76f706cf6cbf4bf23720f17664d814361adf1e6d05b25298adcd4c50ab7bcfeb"
+    },
+    "maps/ad_e1m1.bsp": {
+     "bytes": 3804176,
+     "sha256": "57f602311ba0ae7c945d53bd9c3fea01aab676b91249cc03209f1083424639ee"
+    },
+    "maps/ad_e1m1.lit": {
+     "bytes": 1873346,
+     "sha256": "5529e4d3ed21bd8fd8698ed7ff67750e7f189fb60b4717870119bf18d1920145"
+    },
+    "maps/ad_e2m2.bsp": {
+     "bytes": 5943420,
+     "sha256": "bad7e99e9fdf6fe121065c2abca2dd08b2965f036ed588127635097bef2aae70"
+    },
+    "maps/ad_e2m2.lit": {
+     "bytes": 1541606,
+     "sha256": "891c4274c9092bd99e7261ab41633b006c54b2b6cbf780e49f3c8b7a2aedeaf7"
+    },
+    "maps/ad_e2m7.bsp": {
+     "bytes": 4522994,
+     "sha256": "e899ecb8aa41f13cb6b858d09a2a5703d74865975c77ad284eefb6fb93621370"
+    },
+    "maps/ad_e2m7.lit": {
+     "bytes": 1336838,
+     "sha256": "f7786314f77e4fe79991288b1153cc6a745e8dbd3da99e82c105347776d6e348"
+    },
+    "maps/ad_end.bsp": {
+     "bytes": 6026240,
+     "sha256": "51cebce69c9b5955c6011a612a59952fe740b1e17699100347641003cca05882"
+    },
+    "maps/ad_end.lit": {
+     "bytes": 871766,
+     "sha256": "4d3675e3b4c4314c68da8d23816de2151be87629d574cf8356c7118ecb4b1a90"
+    },
+    "maps/ad_grendel.bsp": {
+     "bytes": 11775232,
+     "sha256": "fd3ee62350709485b8364309871b7a752233f900128b8fc054e04a5c427696a5"
+    },
+    "maps/ad_grendel.lit": {
+     "bytes": 2942042,
+     "sha256": "91fdc2301dbfb2e84ea4d1d920c3d89e9f86bc31beed0bcd317bdbb666e3fea3"
+    },
+    "maps/ad_grendel.map": {
+     "bytes": 9175688,
+     "sha256": "284a5cadec75cfb679392d4049f78509a505905ced881d24df9d4230dca5d641"
+    },
+    "maps/ad_lavatomb.bsp": {
+     "bytes": 17945380,
+     "sha256": "63a16336aa83309f8e267ca6083f1d72388d3a261f0d947cc51a739f280fbe06"
+    },
+    "maps/ad_lavatomb.lit": {
+     "bytes": 5504342,
+     "sha256": "ab06118de2e9ad55ab79c520e5fc0ad3611f27ea32e74994a5f72ba8f20c972d"
+    },
+    "maps/ad_magna.bsp": {
+     "bytes": 22683776,
+     "sha256": "8d3ebdbb385d2f69d64c8f25bc0a84159e31e1967bad4b97afbc3f7e3fab7c07"
+    },
+    "maps/ad_magna.lit": {
+     "bytes": 5238992,
+     "sha256": "46e0723e083e3b707d1905efde52384e2b6784e3f7c297b0eec281f40004df66"
+    },
+    "maps/ad_metmon.bsp": {
+     "bytes": 3899632,
+     "sha256": "b7899dea35298ba4019922a215b8970e9a16a869b4d28ca8e61b23075d8d5514"
+    },
+    "maps/ad_metmon.lit": {
+     "bytes": 1142768,
+     "sha256": "21d38685d9d5bd8aa77d871c882c5ab269387f60c1a15e0b60d775b5ca458880"
+    },
+    "maps/ad_mountain.bsp": {
+     "bytes": 5499484,
+     "sha256": "594547760e2c06c864df452b56bae6b164c8f165a164222af4aefd0e5edb3d83"
+    },
+    "maps/ad_mountain.lit": {
+     "bytes": 1992431,
+     "sha256": "b0983c99864de25c84e7c88353ad9f24859a3d7ceabacf2fa1bf2db2638dd252"
+    },
+    "maps/ad_necrokeep.bsp": {
+     "bytes": 11316596,
+     "sha256": "dfbdd1858b6f141336e702a838431237175291e3605f62e174a1f69655a4432e"
+    },
+    "maps/ad_necrokeep.lit": {
+     "bytes": 5560790,
+     "sha256": "83d67d1751fa758a068102f367512ae41c2f70fb56f11ec1f0686ff4790c39ef"
+    },
+    "maps/ad_obd.bsp": {
+     "bytes": 6320540,
+     "sha256": "09953e1518fd4bfe7970228dbc8db384a5415b1dbe174efaeb4e8027b12e4984"
+    },
+    "maps/ad_obd.lit": {
+     "bytes": 2547662,
+     "sha256": "36d4e6824eac42b5d164da6b75aeecaee1939c6c7e4526917f0779f5d139f4e0"
+    },
+    "maps/ad_s1m1.bsp": {
+     "bytes": 4083808,
+     "sha256": "6c9b669b0c1a8b964ace927ec473ac05482b6b520a7d6a91f9545ad77a054005"
+    },
+    "maps/ad_s1m1.lit": {
+     "bytes": 1253408,
+     "sha256": "7c05e9c5587a7c4cd64fdccf690479f22e7e83951776f0c75a7a6fab09cad21e"
+    },
+    "maps/ad_scastle.bsp": {
+     "bytes": 3814208,
+     "sha256": "a385a4f5ca74b142100db2b2798687dab18baa32b6ee4b15ac457eb4ac2fdb31"
+    },
+    "maps/ad_scastle.lit": {
+     "bytes": 1451444,
+     "sha256": "01ebeee3dc97455bc5360903aeafea932d3e7a21e905df1e5b1bc67a5f825f50"
+    },
+    "maps/ad_sepulcher.bsp": {
+     "bytes": 42216960,
+     "sha256": "09880e7e9bebab934a3743057b9c3da2d4fa519db538d087f6db444df527b8e0"
+    },
+    "maps/ad_sepulcher.lit": {
+     "bytes": 8401922,
+     "sha256": "2eefd3f3a474d5b792c679397f26c9589e7243ad799d6092d9d7fecd99577ed7"
+    },
+    "maps/ad_swampy.bsp": {
+     "bytes": 27548820,
+     "sha256": "8eadb3215d14c5f965d35dc27425be04d7faa2736e0670f3b4a36bbe7bd28da4"
+    },
+    "maps/ad_swampy.lit": {
+     "bytes": 7383500,
+     "sha256": "a2eb0fde5e0c8de0d922a9feb3592b53a056df49a60dabb1538eb4fa6438be58"
+    },
+    "maps/ad_tears.bsp": {
+     "bytes": 84620656,
+     "sha256": "07cc604031e0b095d4bd9eca75e63806acbd0d23867490883e3284ed700e4419"
+    },
+    "maps/ad_tears.lit": {
+     "bytes": 26279840,
+     "sha256": "a5aa6478d531294386199cacc139dfb1e2d7fe040c2985d285bcd64570210b84"
+    },
+    "maps/ad_test1.bsp": {
+     "bytes": 3239600,
+     "sha256": "0b44918d9a83fffed87ff809cf909f1d0df8e9a060b1dec50b32a4a81e8a5899"
+    },
+    "maps/ad_test1.lit": {
+     "bytes": 1008785,
+     "sha256": "5f1bb51d14df10a132757f0b3f13e249b9229b7a5703952d395dae12e9431d64"
+    },
+    "maps/ad_test1.rtlights": {
+     "bytes": 17831,
+     "sha256": "6f1253c34e0dcc13a160a384cdf4b1df9157bb27a6e8efe2d16e8f0ff503b2b4"
+    },
+    "maps/ad_test10.bsp": {
+     "bytes": 1852740,
+     "sha256": "0daae2a42ed3771a72207dc8bb9ad68fa85587ef256a2f0341c4b3f593770f05"
+    },
+    "maps/ad_test10.lit": {
+     "bytes": 466253,
+     "sha256": "a46e40278d270a3f21de6e15d548b97afd9cd6b443a214ed764fbcfead9658e4"
+    },
+    "maps/ad_test11.bsp": {
+     "bytes": 367588,
+     "sha256": "d91b755fbd4b5c634601f5cfe4e9bad405fecc6f23c89afbac0853a6846d0741"
+    },
+    "maps/ad_test11.lit": {
+     "bytes": 123134,
+     "sha256": "ba0bb549e2278bb14edddb1e39809b7b1968bc470e0a2d16f6c2ff0413113282"
+    },
+    "maps/ad_test2.bsp": {
+     "bytes": 1507900,
+     "sha256": "cfd9b7cfff46217240ee06b72d37b5c34522a0d900fb1950c61850771dd6ad38"
+    },
+    "maps/ad_test2.lit": {
+     "bytes": 392834,
+     "sha256": "8e6b0bc4fbdb3a74f07d215f672769e8c1181416ca02b3e0eba23d4b9f5a8149"
+    },
+    "maps/ad_test3.bsp": {
+     "bytes": 6138676,
+     "sha256": "46f58f6bc555f134c4ef129aa23522ae24188252a9a2787d0994bd3f17ac0f34"
+    },
+    "maps/ad_test3.lit": {
+     "bytes": 1697684,
+     "sha256": "ce77153d3ac800c1d11a227467cf94a350de59ed9d1d50198d55a818555c7a56"
+    },
+    "maps/ad_test4.bsp": {
+     "bytes": 795388,
+     "sha256": "414c3fa6ab21cc1d69cc1b2152cf4fc95e8c5901d2911ddbc3f1072c08696b24"
+    },
+    "maps/ad_test4.lit": {
+     "bytes": 187538,
+     "sha256": "4f82ff0f8a717da64b1df296aa8653a1211477a1dcdd0a696d488bad48efa98c"
+    },
+    "maps/ad_test4.rtlights": {
+     "bytes": 2263,
+     "sha256": "2aa706b147e4ff850fd8c080e8d6e5814d628aba6eed58133e3b26e81d12f8a5"
+    },
+    "maps/ad_test5.bsp": {
+     "bytes": 1876092,
+     "sha256": "a1ab24fbf07ea5f07ef63ee13679a096ed74b319bd79a6db806ca2335ca81738"
+    },
+    "maps/ad_test5.lit": {
+     "bytes": 468149,
+     "sha256": "f0ad9d851a38fbd5dcc550899c80746a887c60ff2d68c821f5bb65981533d380"
+    },
+    "maps/ad_test6.bsp": {
+     "bytes": 5727160,
+     "sha256": "1d6e3fb1655efccd556ae9315c2e0a17616f8c47b1aef2241b1ad664ba34563f"
+    },
+    "maps/ad_test6.lit": {
+     "bytes": 1787270,
+     "sha256": "e6038e338e23bd532ddade6c8eb29b9c932e5b0e7eda8fbf8cf8e5c2cefb7e9d"
+    },
+    "maps/ad_test7.bsp": {
+     "bytes": 2127564,
+     "sha256": "0502940ebefa5ac0bf2511f904c427289d1c2965a2beb69c0143670a82116b32"
+    },
+    "maps/ad_test7.lit": {
+     "bytes": 640370,
+     "sha256": "395753de59267eaeb90d17e65ac2b16406295ddc2ec72c418b32f15f9159f257"
+    },
+    "maps/ad_test8.bsp": {
+     "bytes": 598288,
+     "sha256": "1871418fe4757a56db7f9e25173aa56cd44d16e7eae00ba17327faba4f43f95d"
+    },
+    "maps/ad_test8.lit": {
+     "bytes": 126086,
+     "sha256": "a6ad4c3a239e4a43e70c6954a30057f72cfdc6a818b1fed5d32af40db1dadc9d"
+    },
+    "maps/ad_test9.bsp": {
+     "bytes": 731464,
+     "sha256": "d0a561298805a725fa32acae368e09dd7ae887efb4c65ee7d930706ad1d23bcc"
+    },
+    "maps/ad_test9.lit": {
+     "bytes": 273566,
+     "sha256": "2e157bb45f7104bd87432213750e404bc301e23cee57de6bbebd41cd3adc7abf"
+    },
+    "maps/ad_tfuma.bsp": {
+     "bytes": 18040240,
+     "sha256": "94c6419744b18608484ad12c06b190ee02133ee37a096d976cb28d22ceece70f"
+    },
+    "maps/ad_tfuma.lit": {
+     "bytes": 4725947,
+     "sha256": "635886885e83202e08ff27b7fc139408209cc30a7fa7b27055cb8fa5ab62a79c"
+    },
+    "maps/ad_zendar.bsp": {
+     "bytes": 8585016,
+     "sha256": "de90eaaab45179c62465f271630313c0b401d82726e49dcb42c6d650a1900286"
+    },
+    "maps/ad_zendar.lit": {
+     "bytes": 2361236,
+     "sha256": "0151bfc59de66478edd6b7eab0131a48d0e07a5c95b908209bd52c7b47a0b6fc"
+    },
+    "maps/base_brk/baserub1.bsp": {
+     "bytes": 23612,
+     "sha256": "b5320b798366587d20ab541af06babd9575e89870fb003d56a17fdf2f7f22b0c"
+    },
+    "maps/base_brk/baserub1.map": {
+     "bytes": 637,
+     "sha256": "0a5357fb3b12d9286b4d9e6e54316cfd0a33f9fda4c661b8fcd1c461d06ae73f"
+    },
+    "maps/base_brk/bz8_brk.bsp": {
+     "bytes": 12808,
+     "sha256": "219e4371cd0b22d690c6e6660ca2fca3b526618d4ccd9f37799135d2dc6dea02"
+    },
+    "maps/base_brk/bz8_brk.map": {
+     "bytes": 692,
+     "sha256": "fae1ac45d74b2a9f482eb034e0838fe5914affb57204c5215d97ebaf7199e5c8"
+    },
+    "maps/base_brk/crate_r1.bsp": {
+     "bytes": 29110,
+     "sha256": "5dd3afab4a3ad5cf4466e272324e4afad5075ca2e662cc8b1932e277a2db73a2"
+    },
+    "maps/base_brk/crate_r1.map": {
+     "bytes": 664,
+     "sha256": "ee7ce39ec0650d3cbde924b99efc91ba884778db11a961037d4493bf587fa33e"
+    },
+    "maps/base_brk/explodebox_1.bsp": {
+     "bytes": 7707,
+     "sha256": "28bfab37e5cbe722348b753de3bd9f66f47f4a9f5b80bd5c5c1659e6eae7e6c4"
+    },
+    "maps/base_brk/explodebox_1.map": {
+     "bytes": 544,
+     "sha256": "96376f1185f158bf69d6bb0c5baf347bbad27f0ccd6fccd3096da6dd7f89540b"
+    },
+    "maps/base_brk/explodebox_2.bsp": {
+     "bytes": 7107,
+     "sha256": "59d5ba28bc049f691bf28d421327e4aecf5eedaec46599d58328f0074ce0934f"
+    },
+    "maps/base_brk/explodebox_2.map": {
+     "bytes": 375,
+     "sha256": "f906dbea8598f0290af9e224a70eb71f26f3c93c10e922b2fade3f1c63e4ddd5"
+    },
+    "maps/base_brk/explodebox_3.bsp": {
+     "bytes": 10449,
+     "sha256": "0daebb987f48b5dde145998e748ab2eecf63ec69318a6b752924e4cfb6639261"
+    },
+    "maps/base_brk/explodebox_3.map": {
+     "bytes": 1698,
+     "sha256": "538e12e7706df3b8f539bf2473e7517e737657380137de1655193843210dbf3f"
+    },
+    "maps/base_brk/glass01.bsp": {
+     "bytes": 7427,
+     "sha256": "bf3f3938ab3596b6095fb58f66c0a36042e5950169dbb86b1cf3cb9076fd5bdd"
+    },
+    "maps/base_brk/glass01.map": {
+     "bytes": 907,
+     "sha256": "6f47c3ffec4cb28d3447dbf96f0b3d6e4264accd31e10b68ad83b3e30e4e32a7"
+    },
+    "maps/base_brk/grate_r1.bsp": {
+     "bytes": 32796,
+     "sha256": "a8eac6a49f8c49c4f9f1b443c9ca5c6a5f8d03d30ce240daaeee8d150f9c5067"
+    },
+    "maps/base_brk/grate_r1.map": {
+     "bytes": 2106,
+     "sha256": "e5cac190d45b0d14901947e489622680d1b9436955b18e2a0e8cb2f92e9aa011"
+    },
+    "maps/base_brk/pbt04.bsp": {
+     "bytes": 18286,
+     "sha256": "0a3321e606857ebb78d047be51c92036b53175dc392c021891cdeabd28597c3c"
+    },
+    "maps/base_brk/pbt04.map": {
+     "bytes": 699,
+     "sha256": "a8b2d3feef56b8cad384a88a9646b596d21017cb9d26278c0b3585ef589b578d"
+    },
+    "maps/base_brk/phk_03brk.bsp": {
+     "bytes": 90417,
+     "sha256": "46efed3a00ce885798ca568563a04472200359c6111682e91fc701c37d8df143"
+    },
+    "maps/base_brk/phk_03brk.map": {
+     "bytes": 1509,
+     "sha256": "29549a0e23b3651110beae8f8697c85e1e3eeb8752dcc8c253a2756e11189209"
+    },
+    "maps/base_brk/rock_sw01.bsp": {
+     "bytes": 8843,
+     "sha256": "a3acc4f42ca89efb30d5f9d7ed7c694d59ab6003bd3c665cfa4db480550fd92d"
+    },
+    "maps/base_brk/rock_sw02.bsp": {
+     "bytes": 9179,
+     "sha256": "4b3d68587a69daa68093d32195a786e8040fed763855acb94f50d02875a8ec44"
+    },
+    "maps/base_brk/rock_sw03.bsp": {
+     "bytes": 9766,
+     "sha256": "59d2841166f7ecb216df970963b3e425da20566f2fb56a7e5472f4e3c9fcfb24"
+    },
+    "maps/base_brk/sfloor4_2.bsp": {
+     "bytes": 7431,
+     "sha256": "d4f7ee45638e0f338c96cf43779410a112bb10be26a200e24187749a80b01332"
+    },
+    "maps/base_brk/sfloor4_2.map": {
+     "bytes": 833,
+     "sha256": "f285b9a96b32420f24bccb267b268e65afd50dd03fb106fad90783aa5d82c1d4"
+    },
+    "maps/base_brk/tech10_2d1.bsp": {
+     "bytes": 45558,
+     "sha256": "272aa49909de27f7b4722848497e5da38aa50b7bef17ef2ee81a1b1240c1b8b2"
+    },
+    "maps/base_brk/tech10_2d1.map": {
+     "bytes": 740,
+     "sha256": "a3766904240cbe7603e967eb3ebdd0dc895b035f0db8758a6ad217749a332904"
+    },
+    "maps/base_brk/tech10_2d2.bsp": {
+     "bytes": 45552,
+     "sha256": "71e5e52660e4aa84f56aa7b51bad024384acb69699bcec431ae3fe6c8d16fc42"
+    },
+    "maps/base_brk/tech10_2d2.map": {
+     "bytes": 733,
+     "sha256": "9d6c4dae495d96bf4b2bbf5f7e01900f16274173c63eb2e4acfb8f8e757a399f"
+    },
+    "maps/medieval_brk/ad_column1.bsp": {
+     "bytes": 14800,
+     "sha256": "f94c99425b3987ebb9eea08dd8c1b3c0e0215cc8afcd1099f7283324ff566712"
+    },
+    "maps/medieval_brk/ad_column1.lit": {
+     "bytes": 578,
+     "sha256": "c30b5af83ab23db6614ad13aff712a15971a6b35ae29ddd49f0cd3da1c1f4919"
+    },
+    "maps/medieval_brk/ad_column1.map": {
+     "bytes": 1541,
+     "sha256": "d71326b819e902d9a32f4a1961565f6ebb10d90069ba2ae0dc0be381a4c1b764"
+    },
+    "maps/medieval_brk/ad_rock1.bsp": {
+     "bytes": 352852,
+     "sha256": "9333d2d2d848e3a4490634aa4f1cc1ee3281c57ac9a498c85b043e5856ce2578"
+    },
+    "maps/medieval_brk/ad_rock1.lit": {
+     "bytes": 920,
+     "sha256": "6d2b33cbd7b3ce1a35c25a6e006a0786fe0bd0ea8be34b1911e2663ac33ea910"
+    },
+    "maps/medieval_brk/ad_rock1.map": {
+     "bytes": 2163,
+     "sha256": "d00049f1c1bdf04d98e768ece39b7d7442e34b719ec991e5715df588d6493d8b"
+    },
+    "maps/medieval_brk/ad_rock2.bsp": {
+     "bytes": 14728,
+     "sha256": "52675efa81ecae4bb87524c97148d7da60916f0e0dc3c65e99b73745aea70fec"
+    },
+    "maps/medieval_brk/ad_rock2.lit": {
+     "bytes": 383,
+     "sha256": "306d2df8cbd9d7ad755fe7e4a6734e0089b38eefa2e2e4fccacfb68c96dd8d90"
+    },
+    "maps/medieval_brk/ad_rock2.map": {
+     "bytes": 1528,
+     "sha256": "891f208f7fdae3fcf1defe7a4cdcda7a6084fbde663ed4e2ab015af18911cb96"
+    },
+    "maps/medieval_brk/ad_rock3.bsp": {
+     "bytes": 352160,
+     "sha256": "bf041a139ed9be638cd1c548139fffca3ceeddefdad2334fcc2639018833110a"
+    },
+    "maps/medieval_brk/ad_rock3.lit": {
+     "bytes": 356,
+     "sha256": "19a61c05d08dd726a9d00174eb3eb1dbdd16da3e0e62ab93d691620aa71add83"
+    },
+    "maps/medieval_brk/ad_rock3.map": {
+     "bytes": 1878,
+     "sha256": "d0049b763f7fd8f25b2176984341421d704f9b50571b24168c60889fdbad5e20"
+    },
+    "maps/medieval_brk/ad_rock4.bsp": {
+     "bytes": 352704,
+     "sha256": "578e7d2dc0eff7bf5ac21b04919d1e137296824182d4809991a27a83addeba75"
+    },
+    "maps/medieval_brk/ad_rock4.lit": {
+     "bytes": 311,
+     "sha256": "3af5d5c9613dd5a1fa09a40b02891bf7153892db8505528b7d3315ce251bfff7"
+    },
+    "maps/medieval_brk/ad_rock4.map": {
+     "bytes": 1889,
+     "sha256": "472f41679eedc00096e8042935ad5287f4598940ef294b8175cccd196dcb6f86"
+    },
+    "maps/medieval_brk/az_ice05.bsp": {
+     "bytes": 98664,
+     "sha256": "b8b2aa063250f6dcc388ead43ff66133c8fa14b1c30afa17c2fce8f2b2c9fd81"
+    },
+    "maps/medieval_brk/az_ice05.lit": {
+     "bytes": 617,
+     "sha256": "e3e8aa044b60a26d643ff87937f83602cdffcebb948ea7ae22148e7952faa18b"
+    },
+    "maps/medieval_brk/az_ice05.map": {
+     "bytes": 3094,
+     "sha256": "dbca0fea0a986137f9b4a6fbb916cf3de830ba4a60738830cc6e1bd554f561f1"
+    },
+    "maps/medieval_brk/az_kbr1.bsp": {
+     "bytes": 7476,
+     "sha256": "2a2cd33b87f511d4c7fc25a812c632fb07c385b372e89fa900fd0f8ce8146076"
+    },
+    "maps/medieval_brk/az_kbr1.lit": {
+     "bytes": 92,
+     "sha256": "580ff7adf91b63bcd7f35e27059295b0a5fc404468e32e5d5f3323b5a822fb27"
+    },
+    "maps/medieval_brk/az_kbr1.map": {
+     "bytes": 863,
+     "sha256": "3b9d9842f17fb140b23337b452cfc8d49151410640384868a0003bd472dd0d5c"
+    },
+    "maps/medieval_brk/az_kbr1.pts": {
+     "bytes": 178,
+     "sha256": "22cf782552b8a3da946cfa0fa044cffd08f2b0ab50e588c9b68d89a373f026b0"
+    },
+    "maps/medieval_brk/az_kjw1.bsp": {
+     "bytes": 9424,
+     "sha256": "06f271813935ecb90a425d6c943bd53b207fb9d370ec42bb1228af92fe4413d1"
+    },
+    "maps/medieval_brk/az_kjw1.lit": {
+     "bytes": 380,
+     "sha256": "30e6270550b5a78bfaa31df0c6e477d6980eefd380abc2e2aaf7003dbe544f77"
+    },
+    "maps/medieval_brk/az_kjw1.map": {
+     "bytes": 1825,
+     "sha256": "61e8f8f45b2fb0e0766b125bae58b54b36cb45b6d856c7c06814681f52eb91aa"
+    },
+    "maps/medieval_brk/az_kjw1.pts": {
+     "bytes": 120,
+     "sha256": "f7d0f45d90befed57df8dd476bcd10293481eb932925853e3fdbc93a55991a49"
+    },
+    "maps/medieval_brk/az_rtex01.bsp": {
+     "bytes": 97932,
+     "sha256": "ce36fbfdd6f46f5aa7740598689fb2c7de50fa58adda9d4a8a3023ad31194367"
+    },
+    "maps/medieval_brk/az_rtex01.lit": {
+     "bytes": 692,
+     "sha256": "5fe28d309679e9871f14a9c3833184c9ad711fa2bd93adc330a34fd599032a6d"
+    },
+    "maps/medieval_brk/az_rtex01.map": {
+     "bytes": 2875,
+     "sha256": "6cc8f787b54565b3c9dffe9eec20c44d66a68b12fd555bad65bb25f03a2aa7e9"
+    },
+    "maps/medieval_brk/az_wood1.bsp": {
+     "bytes": 7560,
+     "sha256": "373c0b96905055b6b036272c954d7eaf3557d79d62b056ab9a472fb0cd27de83"
+    },
+    "maps/medieval_brk/az_wood1.lit": {
+     "bytes": 176,
+     "sha256": "67ce559200158ce198e5a93a94dd4a440ae607fedc5b3093c288049ce5f50151"
+    },
+    "maps/medieval_brk/az_wood1.map": {
+     "bytes": 950,
+     "sha256": "4fb7eae852ba72528b34d6a0947497eeeab1e1307aa1c4be552628432007c86e"
+    },
+    "maps/medieval_brk/azr1.bsp": {
+     "bytes": 13842,
+     "sha256": "e00518c5ad3beee852a6135184423d4ca985b17b2f1d2cfebc60e82f91582f26"
+    },
+    "maps/medieval_brk/azr1.map": {
+     "bytes": 1193,
+     "sha256": "ef3affe9788b130826f2b1632b5461eaaf15d630587c12c5a875f6042b0ae99c"
+    },
+    "maps/medieval_brk/azr2.bsp": {
+     "bytes": 13571,
+     "sha256": "687097f4773430ca297db9c1d8133b035c8ca1e5d574943a4caa34eef262f003"
+    },
+    "maps/medieval_brk/azr2.map": {
+     "bytes": 1319,
+     "sha256": "22b2084665b2882c976da1dc840a19b151cd44daa524955ddab9ec64e9c3233e"
+    },
+    "maps/medieval_brk/azr3.bsp": {
+     "bytes": 13571,
+     "sha256": "187a6607641c00aa6ee662af52f1b2899d5ca606e469408dd2c94d67dd2ab465"
+    },
+    "maps/medieval_brk/azr3.map": {
+     "bytes": 1338,
+     "sha256": "5e551a8ebefc386b1336e814a44e29ae6781e6da5bc929cb232674853c46a143"
+    },
+    "maps/medieval_brk/booksh1w_brk1.bsp": {
+     "bytes": 23869,
+     "sha256": "dbc342e95245a12598aade308195a3234829225944692c45c8fec792d03f17c3"
+    },
+    "maps/medieval_brk/booksh1w_brk1.map": {
+     "bytes": 793,
+     "sha256": "a9d2fe494267551f3d1638c7963bab47d292be250417f78286b39059af836af5"
+    },
+    "maps/medieval_brk/booksh1w_brk2.bsp": {
+     "bytes": 23663,
+     "sha256": "4b8cd15ae7812d581064800bbcf64cab62c3d5ecfb03c23ff2b498694a0cb708"
+    },
+    "maps/medieval_brk/booksh1w_brk2.map": {
+     "bytes": 661,
+     "sha256": "19c13935f0b045fadd9c739680de7155f0e4d29c86ef3e6950d07f265b1ef1a3"
+    },
+    "maps/medieval_brk/booksh1w_brk3.bsp": {
+     "bytes": 23700,
+     "sha256": "1fc3c7a685f5662779f4c6ad0fb02099396504dcf55eef09474183aff69861c1"
+    },
+    "maps/medieval_brk/booksh1w_brk3.map": {
+     "bytes": 746,
+     "sha256": "bd10960b3af925cf2a33bb0629d1a522de5f54ec05938b36378871fd7de0b9f3"
+    },
+    "maps/medieval_brk/booksh1w_brk5.bsp": {
+     "bytes": 23639,
+     "sha256": "851a02aced76ba77894ba744c5c781ff350a42b93216e095f75938fc95ee39a8"
+    },
+    "maps/medieval_brk/booksh1w_brk5.map": {
+     "bytes": 759,
+     "sha256": "c92ec0ad3d3a5c6588557b5f3c9c000cd1c141a4d9c3b35333d859e75c677568"
+    },
+    "maps/medieval_brk/brick2_4brk1.bsp": {
+     "bytes": 9004,
+     "sha256": "86fb182b011385225d5be8b2a2ba0763286a5a2a5880fdda6fc238d8e6a5212f"
+    },
+    "maps/medieval_brk/brick2_4brk1.map": {
+     "bytes": 1375,
+     "sha256": "208cf3d2a51b0aa4a45cd237786a9303b70a63a85e991a7f8675634bea6295ed"
+    },
+    "maps/medieval_brk/brick2_4brk2.bsp": {
+     "bytes": 7265,
+     "sha256": "151471ef184c02141716225e4403e97a69190bd8a3e9645cf2d52aeb5dce591d"
+    },
+    "maps/medieval_brk/brick2_4brk2.map": {
+     "bytes": 603,
+     "sha256": "cdd5762f851cec464b27e9bfc91c0eab8cb26e69a8b050ac1bd9b0eb662dbf7b"
+    },
+    "maps/medieval_brk/brick2_brk2.bsp": {
+     "bytes": 25323,
+     "sha256": "0d8c4dc3202bcc9f26dfd42ca555b99d0010c63b977cd058646a8e8ad4486eea"
+    },
+    "maps/medieval_brk/brick2_brk2.map": {
+     "bytes": 1378,
+     "sha256": "daeae48ab2f6fca712da2413b65c80c6a944e537571def2d153976b0175d8768"
+    },
+    "maps/medieval_brk/brick2_brk3.bsp": {
+     "bytes": 24310,
+     "sha256": "5f94a5e271bb5b921e4534be8690f005bc258e484cb842a6ead0af9aac29fcfb"
+    },
+    "maps/medieval_brk/brick2_brk3.map": {
+     "bytes": 905,
+     "sha256": "1639469c5fe31540811a8bb95d959844d200102cd19f60d1d5e9c3472477e2d2"
+    },
+    "maps/medieval_brk/brick2_brk4.bsp": {
+     "bytes": 23548,
+     "sha256": "e2049e826c103f2afbb5d0a4b69d45089d0bdcf6bd60646d6ae79c99e9a9a976"
+    },
+    "maps/medieval_brk/brick2_brk4.map": {
+     "bytes": 582,
+     "sha256": "b3528f92f4ecf8099a7bfbf3285f21312c501536b66e02b566a7e38474aa608c"
+    },
+    "maps/medieval_brk/city2_3d1.bsp": {
+     "bytes": 7358,
+     "sha256": "efc80ba0aab1284e2bcec652cc3a2748890c45d6905335f61483eab2851f7c81"
+    },
+    "maps/medieval_brk/city2_3d1.map": {
+     "bytes": 739,
+     "sha256": "ff9c2ebe0034d188443e3a72753d4ecad2a69706a4a06c114f9147f507d10b30"
+    },
+    "maps/medieval_brk/city2_3rd.bsp": {
+     "bytes": 7156,
+     "sha256": "6146e0e5961857308f2ef550213ec647ad810a97359d0946cc07f610e0f03006"
+    },
+    "maps/medieval_brk/city4_2_brk1.bsp": {
+     "bytes": 7435,
+     "sha256": "42a4cbd73804a8458a8369fdbd19ee6b3b4597b18583c242bf77b0122ddc9c1a"
+    },
+    "maps/medieval_brk/city4_2_brk1.map": {
+     "bytes": 648,
+     "sha256": "50b744f4af85aa3c0158ae0330808840710c7ee95c1bda8155cb81b4b247fc74"
+    },
+    "maps/medieval_brk/city4_2_brk2.bsp": {
+     "bytes": 7179,
+     "sha256": "cc2ddcb8877dc1b49ec2c408d6b869a35dd7b6590782525af567905d75a3ada0"
+    },
+    "maps/medieval_brk/city4_2_brk2.map": {
+     "bytes": 520,
+     "sha256": "e9309b8ec24126fd952443ae6bee72df46ba04fb4d0925b33d41c603af9ac5b3"
+    },
+    "maps/medieval_brk/city4_2_brk3.bsp": {
+     "bytes": 10009,
+     "sha256": "7f9a27098101f70090c3aff7fd6731effd2750e8c2b7fdbbb0a9f3146be94045"
+    },
+    "maps/medieval_brk/city4_2_brk3.map": {
+     "bytes": 1575,
+     "sha256": "c352d889a3bed731b7c54e38d7ed35e6fa860d2f6f69eb91319f4043423d7aa8"
+    },
+    "maps/medieval_brk/city6_8brk1.bsp": {
+     "bytes": 7187,
+     "sha256": "bcf4b2815c96308ffc1ab3467ac8b2dd4c25be47d618fd82536ba83bf74a05fc"
+    },
+    "maps/medieval_brk/city6_8brk1.map": {
+     "bytes": 529,
+     "sha256": "2db1be71ce1b1e8bf1e8a5c4c7f2802345aa19c281fd43f2b18d205cbd06bfca"
+    },
+    "maps/medieval_brk/city6_8brk2.bsp": {
+     "bytes": 7298,
+     "sha256": "3b7fd08defa832be1c3f3e40efc6d54d13af6714180be810f6527188f332fbff"
+    },
+    "maps/medieval_brk/city6_8brk2.map": {
+     "bytes": 611,
+     "sha256": "ed29b0773cb700d4b8212f9e28b23edac2d212f469b4a1406538df2b066fcbb2"
+    },
+    "maps/medieval_brk/floor015_brk1.bsp": {
+     "bytes": 12862,
+     "sha256": "5bfae9b09777fad7f26f80b5acc27e187e2259ac5c79ad32ab2a30d154e5889b"
+    },
+    "maps/medieval_brk/floor015_brk1.lit": {
+     "bytes": 179,
+     "sha256": "5d64872b2341768efce6c27686555200246e03d346a2e15089e002d53b1b348f"
+    },
+    "maps/medieval_brk/floor015_brk1.map": {
+     "bytes": 827,
+     "sha256": "08f5b26ee0ebb26416e6a1ed660e197b1ea113a553f5c7a1d26a6070b5cbdac8"
+    },
+    "maps/medieval_brk/floor015_brk2.bsp": {
+     "bytes": 12861,
+     "sha256": "377b50dac34c3789fe8a7bcf6a5b3cedda0f3ba91225135ffc9a2f41abe41e35"
+    },
+    "maps/medieval_brk/floor015_brk2.lit": {
+     "bytes": 188,
+     "sha256": "402bfba12b94cd1b3a40f1052830d4e4fa3b4cb103b196c089f4965e94766bd5"
+    },
+    "maps/medieval_brk/floor015_brk2.map": {
+     "bytes": 828,
+     "sha256": "a45245e0f19cc98f29bcc88c9173118b65058d25ff1c043aaca876353bc67531"
+    },
+    "maps/medieval_brk/floor015_brk3.bsp": {
+     "bytes": 13185,
+     "sha256": "52e2b8d426e479bffc8d518a4d8aa5d5a5dc437dbd761c7074992838ccfd070b"
+    },
+    "maps/medieval_brk/floor015_brk3.lit": {
+     "bytes": 218,
+     "sha256": "dabacc9c3ffdc3bae8c008bedfb683babaca23f6e5b0ca5e35b9c39f9d86f402"
+    },
+    "maps/medieval_brk/floor015_brk3.map": {
+     "bytes": 1078,
+     "sha256": "5235ba02c52ba6dc678f052e4efbad43b9f7d63f858c5f732519f6436246733d"
+    },
+    "maps/medieval_brk/plat_brk.bsp": {
+     "bytes": 59896,
+     "sha256": "367ec651b3cded1ecdf22305a3b48490d3df3078d556d4c7fadfb392ae12ad33"
+    },
+    "maps/medieval_brk/plat_brk.map": {
+     "bytes": 2052,
+     "sha256": "fe52fffba97e8df9acfe4607c9b08d9eb5f4559b44d8c0f6fdbd3af6a0cbf8d6"
+    },
+    "maps/medieval_brk/rock_sw01.bsp": {
+     "bytes": 8843,
+     "sha256": "a3acc4f42ca89efb30d5f9d7ed7c694d59ab6003bd3c665cfa4db480550fd92d"
+    },
+    "maps/medieval_brk/rock_sw01.map": {
+     "bytes": 1371,
+     "sha256": "0e4d621fba3a9806ffdf2bffda89e4d05231513b6f7986d504722d1b99c21a91"
+    },
+    "maps/medieval_brk/rock_sw02.bsp": {
+     "bytes": 9179,
+     "sha256": "4b3d68587a69daa68093d32195a786e8040fed763855acb94f50d02875a8ec44"
+    },
+    "maps/medieval_brk/rock_sw02.map": {
+     "bytes": 1631,
+     "sha256": "82bbf3c701301a80f55619bdac2680d9713432d8fe991838bfb7559830225322"
+    },
+    "maps/medieval_brk/rock_sw03.bsp": {
+     "bytes": 9766,
+     "sha256": "59d2841166f7ecb216df970963b3e425da20566f2fb56a7e5472f4e3c9fcfb24"
+    },
+    "maps/medieval_brk/rock_sw03.map": {
+     "bytes": 1526,
+     "sha256": "300f4c4f56cc9f6425cc8999484e18326555c57b8f53d9f42c36a4345b850d2c"
+    },
+    "maps/medieval_brk/rock_sw04.bsp": {
+     "bytes": 9836,
+     "sha256": "72854269a33665022dee9c30e53e6124bc2bba25ad34d2a3d86302e50ad795c1"
+    },
+    "maps/medieval_brk/rock_sw04.map": {
+     "bytes": 1605,
+     "sha256": "e2b3e6e53c11de10d0de4b7374d43a09be1622766cb3ff60c9e9cec8688747f9"
+    },
+    "maps/medieval_brk/rot_p.bsp": {
+     "bytes": 13554,
+     "sha256": "afcc7dc6512bba89ceec9e10bfa8256ecd043d34c1af57f33a199509500164ff"
+    },
+    "maps/medieval_brk/rot_p.map": {
+     "bytes": 2518,
+     "sha256": "c60e36e827e052cea6ca5c6c2d022b5da051090ee2accf8807f5703ec8acc79a"
+    },
+    "maps/medieval_brk/waa1.bsp": {
+     "bytes": 23869,
+     "sha256": "739aa8d0753e691020013539356d2c2e10b9d0b82c63bcc694080afe33bc585e"
+    },
+    "maps/medieval_brk/waa1.map": {
+     "bytes": 765,
+     "sha256": "f2e7bbba974ffde1e4178be825034e555ca491fffedbf007e62589214af82f0f"
+    },
+    "maps/medieval_brk/wbrick15_brk.bsp": {
+     "bytes": 7969,
+     "sha256": "0dcbd483c300f1be58a216b6d64ea385dd489babdc70868e483fb496c4dd4c38"
+    },
+    "maps/medieval_brk/wbrick15_brk.map": {
+     "bytes": 899,
+     "sha256": "43789ad5bb908aa7fb8e8893db766ce0e479cc547e31aa8de6fe1b4bd6093015"
+    },
+    "maps/medieval_brk/win1ah_brk.bsp": {
+     "bytes": 34981,
+     "sha256": "d549b60245213678c222499299e43654c25f838ed42898a25ec284d933f56b64"
+    },
+    "maps/medieval_brk/win1ah_brk.map": {
+     "bytes": 897,
+     "sha256": "da6859a14f291bef23c990977c0fce7e21ee2c790318cce46e36a8388e87fb39"
+    },
+    "maps/medieval_brk/win1ah_brk2.bsp": {
+     "bytes": 34873,
+     "sha256": "87416124f6e04adaaa5ed9144fa60e048dc03606bc294d89d99295a7c8cb2487"
+    },
+    "maps/medieval_brk/win1ah_brk2.map": {
+     "bytes": 901,
+     "sha256": "5d9a1aefeca5acfdbb25cad5489f5bcb41c89f3c9b92a3d305da0f462c439ec2"
+    },
+    "maps/medieval_brk/wiz14_brk1.bsp": {
+     "bytes": 8961,
+     "sha256": "cb45306588dc69d44422d475c0481f67a76638fe2502c16c28a8f87fa43f6787"
+    },
+    "maps/medieval_brk/wiz14_brk1.map": {
+     "bytes": 1262,
+     "sha256": "46200a77c401035e45d339d8106263e7210ed66e373be74f65687c5d1eb83124"
+    },
+    "maps/medieval_brk/wiz14_brk2.bsp": {
+     "bytes": 7338,
+     "sha256": "871684ecf4507da9773ca5568ccdd0a27173d2f35922b379a19f95e9252a777f"
+    },
+    "maps/medieval_brk/wiz14_brk2.map": {
+     "bytes": 652,
+     "sha256": "97a58529ea21e8127050b0f1e3305e4616b1970232e6517aa652061f49ffc9e0"
+    },
+    "maps/medieval_brk/ws14_brk1.bsp": {
+     "bytes": 7987,
+     "sha256": "ee96dcf614d940d9f887035be0781ad941fc5f76a0f0e553ec3592ae00af1794"
+    },
+    "maps/medieval_brk/ws14_brk1.map": {
+     "bytes": 948,
+     "sha256": "022d130b741c8976f529288f6030fabd2040991efd8bb0a6542dc1508c0b061c"
+    },
+    "maps/medieval_brk/ws14_brk2.bsp": {
+     "bytes": 9003,
+     "sha256": "6aa46294d8fffe55db6f2e6a9d30341fe07a9252b0066ff575c692d0b149f7af"
+    },
+    "maps/medieval_brk/ws14_brk2.map": {
+     "bytes": 1375,
+     "sha256": "8f175f2e3ac8a760fcb7d25da5a30cea149b55349fa0e0d20b2a8c0b080aa5b0"
+    },
+    "maps/medieval_brk/ws14_brk3.bsp": {
+     "bytes": 8944,
+     "sha256": "282944bfbd49b6dcc0aa0d67253432d88c63212ea564a9c6b8909a9b96f8946a"
+    },
+    "maps/medieval_brk/ws14_brk3.map": {
+     "bytes": 1282,
+     "sha256": "6ecd83ba25e15f363f271078c73f6c460babf95ea63340a855dfa182ec47e4b4"
+    },
+    "maps/rtex_brk/022a.bsp": {
+     "bytes": 17448,
+     "sha256": "3557f9518ca0982c871dd344ea5069e5128645029ea428de26ef991881170a59"
+    },
+    "maps/rtex_brk/022a.map": {
+     "bytes": 691,
+     "sha256": "50e0375bf596265b893e56996dbddfad26af2e50bb9af473dc2115e18b11dc02"
+    },
+    "maps/rtex_brk/022b.bsp": {
+     "bytes": 17608,
+     "sha256": "083fdbd34b34b47c5dd9dd58f4e3e0fa3debbedd554db4ce81791033349451fa"
+    },
+    "maps/rtex_brk/022b.map": {
+     "bytes": 825,
+     "sha256": "26d8800f4cfb0706ad363e958846d87755b4871792d1ac1f00b5b51fd7550777"
+    },
+    "maps/rtex_brk/022c.bsp": {
+     "bytes": 17820,
+     "sha256": "8c6b933d2cd323eba623727226ea6cb1f968e0401093f93d229d229a7a5b225d"
+    },
+    "maps/rtex_brk/022c.map": {
+     "bytes": 894,
+     "sha256": "835d4d09490552859dc79ad527bcd08af8afedfa7a863148c62f2f58742e9014"
+    },
+    "maps/rtex_brk/022d.bsp": {
+     "bytes": 17592,
+     "sha256": "0580ec01633972b2fff28c5d4b9a71766d3f1ed6fae387dff34ca691ff829e38"
+    },
+    "maps/rtex_brk/022d.map": {
+     "bytes": 784,
+     "sha256": "238fc24be385d3994586c34555e74ecbb7677aa7567bbf317947276c14b62107"
+    },
+    "maps/rtex_brk/330a.bsp": {
+     "bytes": 7928,
+     "sha256": "a446db4116b8c33f46745cf815ba9309e69591d919838006c81a9b0a5b00c7d4"
+    },
+    "maps/rtex_brk/330a.map": {
+     "bytes": 691,
+     "sha256": "964103ee6422dd3b815472c9f29126741e06517623dad050fba18a9867451903"
+    },
+    "maps/rtex_brk/330b.bsp": {
+     "bytes": 8088,
+     "sha256": "727d22fad028bac645a53ac5a425618e30575735958496b7a1ac86cfbc562e1a"
+    },
+    "maps/rtex_brk/330b.map": {
+     "bytes": 825,
+     "sha256": "807bdb97ab58709fd96cfa0e7b65cb5d377257b862eef2673606901d70b84108"
+    },
+    "maps/rtex_brk/330c.bsp": {
+     "bytes": 8300,
+     "sha256": "b25471a1f0e7fdd066dda47860ae956db2b2c4758a426b39b8a82e6b4c6d1b72"
+    },
+    "maps/rtex_brk/330c.map": {
+     "bytes": 894,
+     "sha256": "13241951b0d3cd61a71e0fe80071a1df65e369eba44aabdf3401f3ba5aa55a7f"
+    },
+    "maps/rtex_brk/330d.bsp": {
+     "bytes": 8072,
+     "sha256": "8f83245e973c42e9908b6215c5effc0f0581d654e5e8e67a6e77493f79de3e6d"
+    },
+    "maps/rtex_brk/330d.map": {
+     "bytes": 784,
+     "sha256": "f0e46c1efc3d5a814675f5760a33a2e6bc4163974ff64a4c1f88ab70c50fbb68"
+    },
+    "maps/rtex_brk/340a.bsp": {
+     "bytes": 13368,
+     "sha256": "e8a605fdff44ef59b4657a43a67cfb24d2d62f150b210a0761f69ed5f559215c"
+    },
+    "maps/rtex_brk/340a.map": {
+     "bytes": 691,
+     "sha256": "3678f5058497a6067c7ffb4d452e706af588e0aedfd30bfa2d43f1902333e7ec"
+    },
+    "maps/rtex_brk/340b.bsp": {
+     "bytes": 13528,
+     "sha256": "d92cc6afb7ae74965a8bb2a753909e2dc6c064b5fb2c9c463c95123531ba337d"
+    },
+    "maps/rtex_brk/340b.map": {
+     "bytes": 825,
+     "sha256": "29f243aa1c347358e34383f4ffb2d129f710829022524237585041c7840a02cb"
+    },
+    "maps/rtex_brk/340c.bsp": {
+     "bytes": 13740,
+     "sha256": "882a110b1a7e26481e5dd37858d5229c0273bc98ab8a2ab59f318e2b76080fac"
+    },
+    "maps/rtex_brk/340c.map": {
+     "bytes": 894,
+     "sha256": "069e17115ae35cf0fdaa9ceb8b3a67065360d4fc03f91036ba453b6b6745d77b"
+    },
+    "maps/rtex_brk/340d.bsp": {
+     "bytes": 13512,
+     "sha256": "96a6133331679ad8eb75d8581e8be12c6822d2048c18a1e704281a6e4cc0737c"
+    },
+    "maps/rtex_brk/340d.map": {
+     "bytes": 784,
+     "sha256": "b8197ea047f14d175e5b9234dcc9b625f04124b175bb0fd80da7ceffe056b00c"
+    },
+    "maps/rtex_brk/413ra.bsp": {
+     "bytes": 7972,
+     "sha256": "a3cc5962750f55c398dfaf53cb4d8394f1100c752ca9797f053ec2710acd995d"
+    },
+    "maps/rtex_brk/413ra.map": {
+     "bytes": 769,
+     "sha256": "b0a3052bfb352684f97fb7bca8fdc3d7b135ae5e3fca491d190d09423836da46"
+    },
+    "maps/rtex_brk/413rb.bsp": {
+     "bytes": 9204,
+     "sha256": "e36bf5d23b3dcaf96075b1b441ebf6424da62cb2d04ff14f04da4e9956711094"
+    },
+    "maps/rtex_brk/413rb.map": {
+     "bytes": 1682,
+     "sha256": "6be0d7cbae08ffccbb1ea9dedf03bc6f8c9b6be93c6c27d5e964e3b4f4538a52"
+    },
+    "maps/rtex_brk/413rc.bsp": {
+     "bytes": 10340,
+     "sha256": "4d57717cc2fb9db560e724df4937f7c496d77d1df6d70e6619ba686338152e79"
+    },
+    "maps/rtex_brk/413rc.map": {
+     "bytes": 1909,
+     "sha256": "71c9812cdf0647bb89fcd2a911a664b7a8dea382b0fe58e4e834a24354a23b38"
+    },
+    "maps/rtex_brk/413rd.bsp": {
+     "bytes": 13356,
+     "sha256": "573149ae9d1f687b0ddc0a702116357b4556e20ae8d62b7b32b3c5b41f227088"
+    },
+    "maps/rtex_brk/413rd.map": {
+     "bytes": 3217,
+     "sha256": "f40b142b102fefefdaf6594c2d1410f370fd8491a009ecfc6dada46c55f262d2"
+    },
+    "maps/rtex_brk/wood3_1a.bsp": {
+     "bytes": 7552,
+     "sha256": "8884a645d6193052aeba7043c139b3eb4cf8ace2e62ed6e9181d51f90cae4806"
+    },
+    "maps/rtex_brk/wood3_1a.map": {
+     "bytes": 1007,
+     "sha256": "5322a91b2aad8cf58095fb513e58317d738469c168b78f770307c3ece580fbf9"
+    },
+    "maps/rtex_brk/wood3_1b.bsp": {
+     "bytes": 7096,
+     "sha256": "9d7d44ba1c929fae0bf702ec834394c9da23c199cf742f9c7021bec00f33c056"
+    },
+    "maps/rtex_brk/wood3_1b.map": {
+     "bytes": 516,
+     "sha256": "158e6d102aaeb8dd7add01eecd7e05b4c711a20d7d7134d1bdce417fbe1b2072"
+    },
+    "maps/rtex_brk/wood3_1c.bsp": {
+     "bytes": 7144,
+     "sha256": "f292d3b9cabaa0332d7c3f6abd66420ad9ef80217f32223bd67315fa8967d908"
+    },
+    "maps/rtex_brk/wood3_1c.map": {
+     "bytes": 517,
+     "sha256": "f853df961fdcebd569943bad596dceb464c6317e44f3d77ce4def17295b37c00"
+    },
+    "maps/rtex_brk/wood3_1d.bsp": {
+     "bytes": 7804,
+     "sha256": "8e6ffa915db57d7cb958c7210e0abc35ff552713a5aa19a1ccb531a7d45bd504"
+    },
+    "maps/rtex_brk/wood3_1d.map": {
+     "bytes": 883,
+     "sha256": "d370c44a047023843caf08a41098bd3852526b614ae074c228cc6ad4e76d4aa9"
+    },
+    "maps/speedbz_brk/crate_r1.bsp": {
+     "bytes": 29110,
+     "sha256": "5dd3afab4a3ad5cf4466e272324e4afad5075ca2e662cc8b1932e277a2db73a2"
+    },
+    "maps/speedbz_brk/crate_r1.map": {
+     "bytes": 664,
+     "sha256": "ee7ce39ec0650d3cbde924b99efc91ba884778db11a961037d4493bf587fa33e"
+    },
+    "maps/speedbz_brk/door1.bsp": {
+     "bytes": 31200,
+     "sha256": "6df38f4db1bfd725dd7384b45e38d070fd4b514139a8e649aea3e640377a073d"
+    },
+    "maps/speedbz_brk/door1.map": {
+     "bytes": 1419,
+     "sha256": "17bf053113ed5cc14e99ef2880e5478ebace7d59de4797fc6cbfe3586d688494"
+    },
+    "maps/speedbz_brk/door2.bsp": {
+     "bytes": 29732,
+     "sha256": "8f58cd2f2e76fbb36a007ed7986671092b880d01dfcb9a087e93cd11240d2baf"
+    },
+    "maps/speedbz_brk/door2.map": {
+     "bytes": 726,
+     "sha256": "3fac703869c9ebb4eabfbe8f180fec752812eea0aa68c5f5574c5cf2496c3931"
+    },
+    "maps/speedbz_brk/door3.bsp": {
+     "bytes": 26516,
+     "sha256": "77f003456362f2b7ca424491485ad2d20b162598527765e5e78628ee7e6ad172"
+    },
+    "maps/speedbz_brk/door3.map": {
+     "bytes": 1247,
+     "sha256": "e56d45f63dcb0d86a0039ea443109d8c8d116fa18331a2328e90f74a891ab9d2"
+    },
+    "maps/speedbz_brk/door4.bsp": {
+     "bytes": 24020,
+     "sha256": "930881a45210317dd3550b04b20d2446cf92c8c613d4aa295a5c77810b77b3f2"
+    },
+    "maps/speedbz_brk/door4.map": {
+     "bytes": 611,
+     "sha256": "f4a68b8f4d081ff0febc276c51b5484c96e4b044eab6e20069ae84ac7c5a0ac2"
+    },
+    "maps/speedbz_brk/rock1.bsp": {
+     "bytes": 89984,
+     "sha256": "c87f60de56cfd5a932cf33d23d6e83b0fd16518001dd8fa7be84da9c3176b5b5"
+    },
+    "maps/speedbz_brk/rock1.map": {
+     "bytes": 980,
+     "sha256": "29e5bd54316e6f325d71a33051ee3a5b6c213f927222931bb35cdcc1820cc87a"
+    },
+    "maps/speedbz_brk/rock2.bsp": {
+     "bytes": 90012,
+     "sha256": "443e51be48da3594545d347ee056f3973b0360268eb6c03653d7b3af622c553e"
+    },
+    "maps/speedbz_brk/rock2.map": {
+     "bytes": 991,
+     "sha256": "40b6b9f23f788c08f362f2336048bbe1260f181d7e76de2591ea7aefa03f4b09"
+    },
+    "maps/speedbz_brk/spdcrate_r1.bsp": {
+     "bytes": 12844,
+     "sha256": "30fa3f373efefcf7db68a9acbb0eb282a0b2ea54d26db92eaaad444035462791"
+    },
+    "maps/speedbz_brk/spdcrate_r1.map": {
+     "bytes": 807,
+     "sha256": "c18735f305c2496a4801ed1a5bc1297f2d72e55824f7222a265ac5788552fc68"
+    },
+    "maps/speedbz_brk/speedbzvent1.bsp": {
+     "bytes": 15248,
+     "sha256": "bcfe36bf57cb82e5188b86af3e5bf568038ef5a50d0ebce43024155b7276008d"
+    },
+    "maps/speedbz_brk/speedbzvent1.map": {
+     "bytes": 2053,
+     "sha256": "7d447bc22e440e685648d8b39e051bce7c1b847e3f777ac092ab1104b79242a1"
+    },
+    "maps/speedbz_brk/speedbzvent2.bsp": {
+     "bytes": 14104,
+     "sha256": "8fb1e76688e27767ce77c5d7b3486048adfa284e011b91007730d424eb55ca61"
+    },
+    "maps/speedbz_brk/speedbzvent2.map": {
+     "bytes": 1381,
+     "sha256": "44cfc0509c9455865df334c1ca5bdfca49cf0fae4dab372cac99e6eeb76b438c"
+    },
+    "maps/start.bsp": {
+     "bytes": 12210776,
+     "sha256": "cb58e7e8a2b31f262795ad2bc913cae5ba1fcc66cdfd3fec99789e3587b97ee4"
+    },
+    "maps/start.lit": {
+     "bytes": 1237664,
+     "sha256": "6177fc612c64a3e7a8eb9ebb2836a450a3a38a178ff7a2bb5331738782a825d8"
+    },
+    "maps/start_test.bsp": {
+     "bytes": 825184,
+     "sha256": "8bb03bfd143d0a6f41651628805643456e555b359e2468f85734e43554eb7a66"
+    },
+    "maps/start_test.lit": {
+     "bytes": 224606,
+     "sha256": "538085016b60759fff305ed1b26b0d9b8917c3d1b3b9913831a842b4d6807651"
+    }
+   },
    "sha256": "243e360503d33e7023aec21c73fb3f62399c9b39b78b31a9d2b5715009f22961",
    "timestamp": "2020-10-12T13:27:30.000Z"
   },
   "pak2.pak": {
    "bytes": 22309198,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 94990,
+     "sha256": "e790b189b1df23f116097b45f5ed391fd210319ecfa000d029b367a7c3d32ab5"
+    },
+    "maps/ad_akalakha.bsp": {
+     "bytes": 7351464,
+     "sha256": "5184a1ae668d384f5221cd82dbf863a26658ea20adb1b101fdca2c1d49c91ec1"
+    },
+    "maps/ad_akalakha.lit": {
+     "bytes": 1090211,
+     "sha256": "625577d6850425c3e0b9a3d7dd555eee1665bcb4a364ab069260a71c6aedc490"
+    },
+    "maps/bmodels/az_chain1.bsp": {
+     "bytes": 219668,
+     "sha256": "4d2648c6dd850b04d48e9631ad02756ecf78d85f56810ff7b9db131a6fe641a3"
+    },
+    "maps/bmodels/az_chain1.lit": {
+     "bytes": 33272,
+     "sha256": "1daab5bb58dbf2c73968dc9db26cf0b0bd78652d491788d0a6124aaa9a9b6f4a"
+    },
+    "maps/bmodels/az_chain1.map": {
+     "bytes": 96430,
+     "sha256": "2b6c77f844eaf5a371b36c13cf512a24d8cd39095cdc04eddd64cd571060d098"
+    },
+    "maps/bmodels/az_chain2.bsp": {
+     "bytes": 333820,
+     "sha256": "746e38bbb4cebb63ac3344e944f24b874b9fd3ed584017bb599e027508cc6187"
+    },
+    "maps/bmodels/az_chain2.lit": {
+     "bytes": 22130,
+     "sha256": "c6ebc72f8dcaa06422eaf71e08771f76105ddd39c3ee6784d40083df67d1cf32"
+    },
+    "maps/bmodels/az_chain2.map": {
+     "bytes": 148314,
+     "sha256": "e9cb3cddd08835aed7b1eed8867a67b06fee9db20dd7584830b8918d4af169ea"
+    },
+    "maps/bmodels/az_chain3.bsp": {
+     "bytes": 308800,
+     "sha256": "6b78b5a83f2f71a316e85086e12b7a1f66abaf28b02a53076433e3b2b3a20fee"
+    },
+    "maps/bmodels/az_chain3.lit": {
+     "bytes": 20684,
+     "sha256": "28870bf7c7f011206290fe69c7b6e2501c27fba21bea2ae6767e8d85a4ff56e7"
+    },
+    "maps/bmodels/az_chain3.map": {
+     "bytes": 110405,
+     "sha256": "64eee084713fdb7da2ec9f9dbc7c482930d9a871d86fd0912d32ddf52063b1aa"
+    },
+    "maps/bmodels/m_bchains1.bsp": {
+     "bytes": 74963,
+     "sha256": "73beb2dc0b953e096e69a4e049af380e99c98ce1872b4da00c858be36d4e973a"
+    },
+    "maps/bmodels/m_bchains1.map": {
+     "bytes": 43470,
+     "sha256": "ecd781a6601c6fca262909cb2e116a222de2e5aa5417dd36d4475d5c433459af"
+    },
+    "maps/bmodels/m_bchains2.bsp": {
+     "bytes": 83651,
+     "sha256": "e23fad6717790c08e661748398754e60944527eb6e48c0f2c0ffbdba73cf95db"
+    },
+    "maps/bmodels/m_bchains2.map": {
+     "bytes": 42484,
+     "sha256": "e92865750499de9117e5bf19719052109179ebcc37ddbd40f2d91d914b86fa63"
+    },
+    "maps/bmodels/m_bridge1.bsp": {
+     "bytes": 431144,
+     "sha256": "ac4d490408f7ad9068a09c4c89f82a65b8573bc4ba810fe5f16418b1d2684f66"
+    },
+    "maps/bmodels/m_bridge1.lit": {
+     "bytes": 47240,
+     "sha256": "30601eb0d533bbe0f72631b77630c3922a46f34b38687aa184b7776e48e63164"
+    },
+    "maps/bmodels/m_bridge1.map": {
+     "bytes": 120280,
+     "sha256": "3ddec67bb95d788b2fecb0e4c6d09781a6a27ba79d322a637f3a03e84a8f6ac7"
+    },
+    "maps/bmodels/m_bridge2.bsp": {
+     "bytes": 201392,
+     "sha256": "4fec9b73e50ba0608d2b5f2fd5c4957324c4cb609becf3be979aedf644281845"
+    },
+    "maps/bmodels/m_bridge2.lit": {
+     "bytes": 21902,
+     "sha256": "c1fa88042c3fde27bd608d3829c8c4a142e70617087970ec7535d48847ac435a"
+    },
+    "maps/bmodels/m_bridge2.map": {
+     "bytes": 52004,
+     "sha256": "58943dc439d4d4c8e65773c12e361c3336488a94f0a53a54c06366675517b850"
+    },
+    "maps/bmodels/m_bridge2b.bsp": {
+     "bytes": 201398,
+     "sha256": "096dcacf528d2784b79a4c0dd19c445102778f2a053fde3a2a43540a4a621c73"
+    },
+    "maps/bmodels/m_bridge2b.lit": {
+     "bytes": 21902,
+     "sha256": "1c7bdad93866cabb97e4565bf41d2b8a8d4c8237e11b0965fd05fc954b6c2c64"
+    },
+    "maps/bmodels/m_bridge2b.map": {
+     "bytes": 52268,
+     "sha256": "d361d0c3dcfec2ae5d109075bf437d013762328ee48b8fc25f779267d7b1bfb1"
+    },
+    "maps/bmodels/m_bridge3.bsp": {
+     "bytes": 309343,
+     "sha256": "12d2199af263464d48455c2e5cd7bf2abf2085841fbc7e027a4cc96b04eec2d8"
+    },
+    "maps/bmodels/m_bridge3.lit": {
+     "bytes": 46964,
+     "sha256": "b783061b14bb4caf3cf9df9a6b8be9ea1d2a367339fa09ffe01506022b21a4c5"
+    },
+    "maps/bmodels/m_bridge3.map": {
+     "bytes": 138104,
+     "sha256": "33c8835d256fd00e65da818c4d43b86033bb8104897712b824014a035c2628e0"
+    },
+    "maps/bmodels/m_chains1.bsp": {
+     "bytes": 249145,
+     "sha256": "1f51d881982d8602c0da29c1f105ab07a41977bdab4fbf4598922563373f4a98"
+    },
+    "maps/bmodels/m_chains1.map": {
+     "bytes": 170858,
+     "sha256": "e1855a52ab0ae70c382876eb74fcafe5a065fefeb2e49a6956184637b9edc1bd"
+    },
+    "maps/bmodels/m_chains2.bsp": {
+     "bytes": 134457,
+     "sha256": "57a765e0ec315eca93927ad64e11b9b3ec8adae0c405de55d86c30b30ef51e5a"
+    },
+    "maps/bmodels/m_chains2.lit": {
+     "bytes": 15698,
+     "sha256": "c858c4c47488df5cac3ed19736c1aee29f4c7add0dfb45deeb7416c4c7af1f21"
+    },
+    "maps/bmodels/m_chains2.map": {
+     "bytes": 60423,
+     "sha256": "575ae8d717a2352ac8726b3bc0f11f6e0a83f548dd471a544a62f519bb71f692"
+    },
+    "maps/bmodels/m_chains2l.bsp": {
+     "bytes": 156552,
+     "sha256": "ff04a994c83f27104d6ef126ef2d08ce894ebe0a812c49f0d2ae79ce8808e8b9"
+    },
+    "maps/bmodels/m_chains2l.lit": {
+     "bytes": 15698,
+     "sha256": "9ebbd1a675e167d9a3be233cd65654728f2f1e0259dee00f55e3da02802abfa2"
+    },
+    "maps/bmodels/m_chains2l.map": {
+     "bytes": 61112,
+     "sha256": "346320204a3413bd6654018e37e42c442c21d88e15da513395c73e6daee26bed"
+    },
+    "maps/bmodels/m_chains2p.bsp": {
+     "bytes": 156555,
+     "sha256": "f0778b1608dbb058f1f492848ae3b64f66be0fef54e32bddfd6fe09f7b0e7a74"
+    },
+    "maps/bmodels/m_chains2p.lit": {
+     "bytes": 15704,
+     "sha256": "d2e7187908b4d3823091a9d69cce5ac807507372132b4162e48a6b027ecad53a"
+    },
+    "maps/bmodels/m_chains2p.map": {
+     "bytes": 61117,
+     "sha256": "7d1acdf4240cd91b158bbc23dfab846388efa7d20431f5a9c8dba8ab421102ff"
+    },
+    "maps/bmodels/m_chains2r.bsp": {
+     "bytes": 222620,
+     "sha256": "0e1ad04fd73c4bc183331471a3406665660fd8f030d14404b7c43b31309118e0"
+    },
+    "maps/bmodels/m_chains2r.lit": {
+     "bytes": 17552,
+     "sha256": "605d297ff2ece6796c064e3dd47e1c48e4fdc87324f059f2c1721e369de23a97"
+    },
+    "maps/bmodels/m_chains2r.map": {
+     "bytes": 61788,
+     "sha256": "749cc23346335d05a53b3399f49adb157fe29fe24512a65d3ab976bc811b5818"
+    },
+    "maps/bmodels/m_chains2rl.bsp": {
+     "bytes": 151968,
+     "sha256": "653185afe2384bf68c0e6d35bdd3404196404243a1b8d16cb730de9f7a45b4b0"
+    },
+    "maps/bmodels/m_chains2rl.lit": {
+     "bytes": 17552,
+     "sha256": "ef313b8c77329539ca8bbe6831e7d5b372e4e3f3cc807e6b66901b53f83d82d4"
+    },
+    "maps/bmodels/m_chains2rl.map": {
+     "bytes": 62332,
+     "sha256": "f5961359ef0867c6ecd501231f63912bf4066bb4d65685021efcd0d51d637f95"
+    },
+    "maps/bmodels/m_chains3.bsp": {
+     "bytes": 121996,
+     "sha256": "535075d6549167b5bf61ae91abf2c407ee009e64aa4222be35692478151feab1"
+    },
+    "maps/bmodels/m_chains3.map": {
+     "bytes": 57540,
+     "sha256": "08f7d97d9e8cd45c353d1141905c93d3327d8f77984790d9e952bd91a5247803"
+    },
+    "maps/bmodels/m_chains4.bsp": {
+     "bytes": 203735,
+     "sha256": "2840e2b604d571081a2b13ba2d340f596123b53213aaec8cd695e7a4d668e774"
+    },
+    "maps/bmodels/m_chains4.map": {
+     "bytes": 113061,
+     "sha256": "6727d20079382f7f2a76391d72e6b6bc3136cc6396ef4661b679f5c8f82d8427"
+    },
+    "maps/bmodels/m_chains4p.bsp": {
+     "bytes": 205127,
+     "sha256": "20183038acde1a46c9fae81e86837f876dc6e0bb7cc7a556457d4162264d7358"
+    },
+    "maps/bmodels/m_chains4p.lit": {
+     "bytes": 35897,
+     "sha256": "0dfb9177bd73b903703f0f4630c4941467a452ee676d568e7f32b2099699659d"
+    },
+    "maps/bmodels/m_chains4p.map": {
+     "bytes": 112283,
+     "sha256": "09d773ef730e9b4d81cdf23f4ac3b0efcb365771569638e7f5574407c5560146"
+    },
+    "maps/bmodels/m_chains5.bsp": {
+     "bytes": 94806,
+     "sha256": "04c40fce5016a3d26092812be589344740b29be788921f8ce354461d77943817"
+    },
+    "maps/bmodels/m_chains5.map": {
+     "bytes": 44835,
+     "sha256": "1e897fc203a12a480c1d3dfc13bf7653a06edb8132f98a3fedae50614c3ebb34"
+    },
+    "maps/bmodels/m_chains5l.bsp": {
+     "bytes": 117061,
+     "sha256": "f01c9c1e6f87c0588be0df3f8768f563acea6735451efa41366aa0acb63851db"
+    },
+    "maps/bmodels/m_chains5l.map": {
+     "bytes": 45411,
+     "sha256": "64691e385435777a920358775cb18e7ac6ee5290a34488103753a338500b6db5"
+    },
+    "maps/bmodels/m_chains5p.bsp": {
+     "bytes": 117214,
+     "sha256": "555df3c945155f7b820fde49c3e37d114f3c52bb63c4edb647dbc19161cb13d5"
+    },
+    "maps/bmodels/m_chains5p.lit": {
+     "bytes": 9152,
+     "sha256": "f78aaec615854b6382b6802298f42ac42dcdfdfb9c638b417257876fa83200d9"
+    },
+    "maps/bmodels/m_chains5p.map": {
+     "bytes": 45566,
+     "sha256": "1969841b81be135b7cb383f84bf7d38694d012b35b17ef3e2c630afbf5d6e64d"
+    },
+    "maps/bmodels/m_thanshelf.bsp": {
+     "bytes": 140335,
+     "sha256": "8319f2ba87d5a8ed864941fe9c7341744476be658ce211aaafc1ba0747afeac4"
+    },
+    "maps/bmodels/m_thanshelf.lit": {
+     "bytes": 3134,
+     "sha256": "04fd93ccf6b864bd9226faa29db923bc093200ed3f4fc8a8f6cce29b324a9743"
+    },
+    "maps/bmodels/m_thanshelf.map": {
+     "bytes": 10306,
+     "sha256": "811e75bc34627545ff7513dc658e937195b98b7839bad409bf21da4975fb7e03"
+    },
+    "maps/bmodels/misc_radar.map": {
+     "bytes": 5314,
+     "sha256": "7ca088f70d4421b994f1852dd17de1427a2b6401b19d8f464ecf2024f5025418"
+    },
+    "maps/bmodels/sep_chain2.bsp": {
+     "bytes": 130276,
+     "sha256": "eff6d1868abd6355f4858f41657262ebb87fa9093579eb8abe8ac6f8c8880ee6"
+    },
+    "maps/bmodels/sep_chain2.lit": {
+     "bytes": 15716,
+     "sha256": "311947b14d5363ccc34fd6e32205100b612c8a77c66196dc616192b011375b59"
+    },
+    "maps/bmodels/sep_chain2.map": {
+     "bytes": 80569,
+     "sha256": "7d86dc46adc6a01b96b811021484c1e6cbfb61424f1037be59525d6f1ff2c420"
+    },
+    "maps/bmodels/sep_chain3.bsp": {
+     "bytes": 80956,
+     "sha256": "8a811a3fc8f85373d64fb3840bda3a3af63a138498bc051ddb2b0d1e0cfa9e88"
+    },
+    "maps/bmodels/sep_chain3.lit": {
+     "bytes": 10802,
+     "sha256": "50d0f90c43a132a5cb360cbb25521040632f07726c6ccfb482d3740ec940ad05"
+    },
+    "maps/bmodels/sep_chain3.map": {
+     "bytes": 41124,
+     "sha256": "ef40d6b17d8b9fc880e4a8180336554f37dabfbc8a30b78c485793aaa5dd753b"
+    },
+    "my_progs/ai_ammoresist.qc": {
+     "bytes": 7444,
+     "sha256": "d530fec92f23ed0c3d09560abb9a89bdc160ce1aefdfbe4f4771f9897ae3fc4d"
+    },
+    "my_progs/ai_checkattack.qc": {
+     "bytes": 106456,
+     "sha256": "7971ca5a87666c89b56ab0fcc102e6f551f3cd3b03bdfc0bfb73f5f8d5aed7fb"
+    },
+    "my_progs/ai_combat.qc": {
+     "bytes": 24324,
+     "sha256": "30c07395259db46836e544a68a37527f107e9010e4d64e937476ceafa58c82b8"
+    },
+    "my_progs/ai_enemytarget.qc": {
+     "bytes": 8409,
+     "sha256": "f4b0a35306d50e71fd9043ae949a421158ee9fcc4e311baf7b8fa2d345c4d46e"
+    },
+    "my_progs/ai_explosion.qc": {
+     "bytes": 12162,
+     "sha256": "7df941a7cf93b814ae9d90f646a5b0243a51db67872f621df73d43c6000ba3ab"
+    },
+    "my_progs/ai_gibs.qc": {
+     "bytes": 32373,
+     "sha256": "65e202300882ba8f0c980f65820b2d2e0bd06846073168f4bd7e37f2357f47d4"
+    },
+    "my_progs/ai_hazards.qc": {
+     "bytes": 26832,
+     "sha256": "81aace80121408f64369bc2bbfd5654650276ddd75217333d2a52364415acaa5"
+    },
+    "my_progs/ai_minions.qc": {
+     "bytes": 10236,
+     "sha256": "3e7bd34dfe0e73a11e6907d5ac69cb609eee19dff533689ea7c8eabe52500136"
+    },
+    "my_progs/ai_passive.qc": {
+     "bytes": 8224,
+     "sha256": "44473544d0da0dc778c2800a16172ab49b548286b604c9d6361f4bc4cfc1f076"
+    },
+    "my_progs/ai_pathcorner.qc": {
+     "bytes": 20921,
+     "sha256": "b3d6ed2434e0b995da51a71715647096e36e02d8cf920e18e024f920ed69238a"
+    },
+    "my_progs/ai_projectiles.qc": {
+     "bytes": 86253,
+     "sha256": "d0885ed945602af45d7db1d98be5938412cd750154ed06710b6b781b6c49abc3"
+    },
+    "my_progs/ai_states.qc": {
+     "bytes": 7480,
+     "sha256": "76fae861132b0e50006ef88ea94a953e718b661defad2ea58a4ecad5cab92dee"
+    },
+    "my_progs/ai_subs.qc": {
+     "bytes": 51485,
+     "sha256": "41a23217543056b1ea447fcf2e0dc2c06a87bdf70dc3f6f699454d7c3c900377"
+    },
+    "my_progs/ai_tether.qc": {
+     "bytes": 6470,
+     "sha256": "2229c0ea1b76e45f5707a3eca9e7626e33f8ea91d6b292da63c81723e1ae8521"
+    },
+    "my_progs/breakable.qc": {
+     "bytes": 79687,
+     "sha256": "754831599eec85a774501d9fd0a1ec7d5722ea6a6e01655b5ad74988145045af"
+    },
+    "my_progs/chaosmode.qc": {
+     "bytes": 81481,
+     "sha256": "01561dc4f1949716eba4d08f83efe27b71add80f923c1e2d89194c238772a646"
+    },
+    "my_progs/client.qc": {
+     "bytes": 70441,
+     "sha256": "00e2d4aff96ea28b0532ab0b03de0a8cdcf15750164ec82bdc8f43b9f2347447"
+    },
+    "my_progs/client_advinfo.qc": {
+     "bytes": 59677,
+     "sha256": "87aaca8bfd15935e1cd29a807bf77a2779d95418af631a6b456c6605710694fe"
+    },
+    "my_progs/client_camera.qc": {
+     "bytes": 13007,
+     "sha256": "ff4748b04c15d9a3b44dd8069f9347c12487ef353d5401a13542166576097889"
+    },
+    "my_progs/client_cshift.qc": {
+     "bytes": 725,
+     "sha256": "da1e321fe01bae486ffcdd987a942a4b0d5b2f603efb663d52c55e882f129685"
+    },
+    "my_progs/client_debuff.qc": {
+     "bytes": 15761,
+     "sha256": "0e0c9123697241ab3a366dbc46fcb90b8553b65c94cffe1442254a74a2753efd"
+    },
+    "my_progs/client_evilmode.qc": {
+     "bytes": 6982,
+     "sha256": "2cfa3bbeb36ab623c3bb137028ec5f549a2e5d2198fa2ab7fd8a445e14f4fc10"
+    },
+    "my_progs/client_ghook.qc": {
+     "bytes": 51884,
+     "sha256": "43d071195a70caa66b57cca1778679d772478fd1f71cbad7ee267e254e79a29a"
+    },
+    "my_progs/client_info.qc": {
+     "bytes": 13693,
+     "sha256": "55653ddc2b9f3cf2ca3cf1b0afdc4c1685baf1ab3c3830eb9f8b1b2d51b3ff31"
+    },
+    "my_progs/client_mapvar.qc": {
+     "bytes": 13177,
+     "sha256": "c692fa41644e6d21c945493dd891af945a072a4b39e687d1b59c86d14ee804a0"
+    },
+    "my_progs/client_power.qc": {
+     "bytes": 20157,
+     "sha256": "0309073577003ae832b259ede75ba53c49bd89985b08d98000d03e1a44893705"
+    },
+    "my_progs/csqc_defs.qc": {
+     "bytes": 21072,
+     "sha256": "eddc5f194845e78a1633807d32b1da4425bdbe7bcce193e3868bc3995e2dee9b"
+    },
+    "my_progs/csqc_defsclient.qc": {
+     "bytes": 35002,
+     "sha256": "b6674acae135dfbc5e3dbb147e69acdc6b3564b766792359bed3e4eb800705e9"
+    },
+    "my_progs/csqc_hudad.qc": {
+     "bytes": 104391,
+     "sha256": "1ca012e489dc5f6026bdae469f411b5bb25afa00e00d5169cbd35b578a7ad9f2"
+    },
+    "my_progs/csqc_hudvanilla.qc": {
+     "bytes": 37074,
+     "sha256": "c5caa6ba176185c05903d383f3ae41907129d859419a0c0bf909b0e8d3e8af5a"
+    },
+    "my_progs/csqc_progs.src": {
+     "bytes": 113,
+     "sha256": "e383fc0920e9676d92e0be81d69cd8017ed5baf9fc0616a05773de68208ce434"
+    },
+    "my_progs/defs.qc": {
+     "bytes": 31974,
+     "sha256": "1534874cf4d70c5614dedecb70f6d428fc32832ce3345c2cb51fd6058a514902"
+    },
+    "my_progs/defsclass.qc": {
+     "bytes": 24401,
+     "sha256": "811c390be7b31fd4b276410ef1a75406bbca8fb84dc195484835a6100e9cddb4"
+    },
+    "my_progs/defscustom.qc": {
+     "bytes": 95932,
+     "sha256": "c8e66698b225cac3821bf4b098e7c8b16d0babaf7f5c1a5a32006c0c1dd96eee"
+    },
+    "my_progs/dpextensions.qc": {
+     "bytes": 122912,
+     "sha256": "3758f58ebaa4186e9112da89f7ea53087eef5058a32ebc373a1ffda76c1d67a2"
+    },
+    "my_progs/estate.qc": {
+     "bytes": 7745,
+     "sha256": "9cceb71ae54b331c2702f5580094f9055d007b9e710dd5e61c7c632724022626"
+    },
+    "my_progs/fteextensions.qc": {
+     "bytes": 215531,
+     "sha256": "beb86ad10bb0726de10dd2557d6285f7bf40f08f9d30e06315c3772f8c256571"
+    },
+    "my_progs/func.qc": {
+     "bytes": 47039,
+     "sha256": "3102c5ce52ec7a15c329079fc7ca97fa249dca32c4124bad49c2853d38e5c741"
+    },
+    "my_progs/func_buttons.qc": {
+     "bytes": 13271,
+     "sha256": "9e1bd197b2367ab2b8f1c776c214a0c51120559e8d8f0b4888b262b7a1e746f0"
+    },
+    "my_progs/func_doors.qc": {
+     "bytes": 35874,
+     "sha256": "58dbdf05f0044aefdd13ee21d17045a681d255efaca6d129fbd1cec4ae516fc9"
+    },
+    "my_progs/func_doorsecret.qc": {
+     "bytes": 14379,
+     "sha256": "769a3142ccaf18060ff77b0eab57d901585202fbfe63a54ce25d4987b80f92d3"
+    },
+    "my_progs/func_insvolume.qc": {
+     "bytes": 10573,
+     "sha256": "1deaf4623a6fae80585d2d2b1978b1cd217b6f8a683ef3bbc3a77a2897e9a207"
+    },
+    "my_progs/func_plats.qc": {
+     "bytes": 11685,
+     "sha256": "5086c9aba8bbf83d29c3e1897c7867cb24220712007044792928f474216b7ea4"
+    },
+    "my_progs/func_pswitch.qc": {
+     "bytes": 8373,
+     "sha256": "b3a205176d80801216a930241508b3c5718f4be9e1b947932ace2851c34271d8"
+    },
+    "my_progs/func_trains.qc": {
+     "bytes": 26553,
+     "sha256": "81d8de4f3dff80b8523584fb5e37d8d4812a6f7f95a559edff320682217ad123"
+    },
+    "my_progs/globalfog.qc": {
+     "bytes": 18397,
+     "sha256": "84ec244a475ac41b9da772042123f58f4005130590f170f85f1b23ad53629f27"
+    },
+    "my_progs/hiprot.qc": {
+     "bytes": 31978,
+     "sha256": "82875db9fecd8bacd2c42232fb980e6a510a6863103273e2c9078dfe7c6759c5"
+    },
+    "my_progs/hipspawn.qc": {
+     "bytes": 2752,
+     "sha256": "6df8450b85821c1a76f5ccb3c807ac9b94e92f413f16f2ba618f922abf85148f"
+    },
+    "my_progs/items.qc": {
+     "bytes": 165150,
+     "sha256": "fbcc57975032c97ffea723870e39ebc2d2c4bbd9650fb5d20b3dfcecc6f6f93a"
+    },
+    "my_progs/items_progspn.qc": {
+     "bytes": 20628,
+     "sha256": "2f4824cb28192145a8fabc2da6575db3398e8f81522ab1e026d696ec87313650"
+    },
+    "my_progs/lights.qc": {
+     "bytes": 43912,
+     "sha256": "d0e0c373bb3cc68c7c9121a62c68085ff9cc290daa6faf0adab02323d8ef92bb"
+    },
+    "my_progs/mathlib.qc": {
+     "bytes": 22355,
+     "sha256": "b161ebb89a11f302427c4f124731ec38def8eb01347beb5d748a9ba4afb886f8"
+    },
+    "my_progs/misc.qc": {
+     "bytes": 85890,
+     "sha256": "6b3e8a0882d47f16ff7f54fb37a48e3a7853647f8895718e6428739c4207099a"
+    },
+    "my_progs/misc_camera.qc": {
+     "bytes": 43852,
+     "sha256": "61448a8f0354f39dd26371ae56dadbc903b08282293145a27088ac6c151ea547"
+    },
+    "my_progs/misc_model.qc": {
+     "bytes": 32157,
+     "sha256": "9afc9d440672288ffada6256a20aa0f969464907e942fab0c1556cdb28162237"
+    },
+    "my_progs/misc_targetdummy.qc": {
+     "bytes": 15123,
+     "sha256": "bcd0a0ae806ce20a8c8cfcc27178ce1b4ead3a546d927b6a261ce51a6086c253"
+    },
+    "my_progs/misc_textbook.qc": {
+     "bytes": 26321,
+     "sha256": "14bf42536a5cc75990d938a79d7bd21bde1c166245d94d8e662f9e6fd66e0ae8"
+    },
+    "my_progs/mon_baron.qc": {
+     "bytes": 31318,
+     "sha256": "b76a10da34dabf3411ddf650abcdbc77e3ebcdfebace6191a39e7c0b13a0fad5"
+    },
+    "my_progs/mon_boil.qc": {
+     "bytes": 19821,
+     "sha256": "050b21bda5341a3f81dcb21e6d7d82d458a415fd8f1cfa12435228246229a323"
+    },
+    "my_progs/mon_bossboglord.qc": {
+     "bytes": 24005,
+     "sha256": "e67081b7a5218b361c62bf4b201a18db16f3e75716ad2729c11a0616b137975a"
+    },
+    "my_progs/mon_bosseidolon.qc": {
+     "bytes": 40134,
+     "sha256": "c51eb9b9d67cadfa7178891a238329a60ad57edc3f6ef645060695b451833115"
+    },
+    "my_progs/mon_bossfiretop.qc": {
+     "bytes": 14734,
+     "sha256": "26672c9c2d1577f8caf9894b8eb5eecacac89f64251257bc25db48b1bf43a7bb"
+    },
+    "my_progs/mon_bossicegolem.qc": {
+     "bytes": 47205,
+     "sha256": "5b888302a6af24ce823919d1349c1c92e1ee709d72e79042425349368a4d65fb"
+    },
+    "my_progs/mon_bossidchthon.qc": {
+     "bytes": 20247,
+     "sha256": "65d955fb1434f806962fadc088aa5933e96ed8aa9f1211d0709a3f462ffa3027"
+    },
+    "my_progs/mon_bossidshub.qc": {
+     "bytes": 14639,
+     "sha256": "fdd0e8f8fa374ea0164f79ef1bf74ca942f04c63159f360c7a43011673774fe6"
+    },
+    "my_progs/mon_bossjudicator.qc": {
+     "bytes": 81432,
+     "sha256": "f5092f376eeef22f0a552c846f50175680c15a5c37d9603c6e3d2635661127b3"
+    },
+    "my_progs/mon_bossmammoth.qc": {
+     "bytes": 84963,
+     "sha256": "6cda415b846b2aeb215c0eebc7cdfa6a5560255df9aa014f77b48aa7073b8d34"
+    },
+    "my_progs/mon_bossnour.qc": {
+     "bytes": 45682,
+     "sha256": "d3aa7e0c62e9001887b1b0895607b512f6d9aeeb44bca544f6c900c86adbc03c"
+    },
+    "my_progs/mon_bossxxchthon.qc": {
+     "bytes": 22614,
+     "sha256": "2c1c0446b0f6a5b7a7921e8f8830c71c174d30c6f176d228a94afd9a05fdc25a"
+    },
+    "my_progs/mon_bossxxshub.qc": {
+     "bytes": 19006,
+     "sha256": "043ebc852ba7f0a06812cb0afd72d32a3da643df1dea45c87fb821f60fbcc332"
+    },
+    "my_progs/mon_centurion.qc": {
+     "bytes": 13734,
+     "sha256": "641e1c09c6df27b033e331140d242f25d27bf7f9bb83733a6b5b3469a5c7ffee"
+    },
+    "my_progs/mon_dcrossbow.qc": {
+     "bytes": 38069,
+     "sha256": "3296618a4b803fb6f1b44c1d32c17692a5bed13cf63102c6dcc58481223197a8"
+    },
+    "my_progs/mon_deflector.qc": {
+     "bytes": 32107,
+     "sha256": "d7a9344878a3a846a7e720ce704820d424362281a1675c40be7b670eca9fe342"
+    },
+    "my_progs/mon_demon.qc": {
+     "bytes": 14601,
+     "sha256": "d77f128e3f91737228c5a24b7ca146f6b4f8e87dbaac31b1ad4e79779884d0d7"
+    },
+    "my_progs/mon_dfury.qc": {
+     "bytes": 39867,
+     "sha256": "a016db202f2a418aee50cb7cce2155a24a6b807e8c98fc49a5f9273ce79c6da8"
+    },
+    "my_progs/mon_dguard.qc": {
+     "bytes": 28414,
+     "sha256": "0a2b964034559f4ca772f9f29be2c56684fd39290277046a6f7642ba934836eb"
+    },
+    "my_progs/mon_dguardquoth.qc": {
+     "bytes": 18932,
+     "sha256": "4caeb17520104cba42476ff7757f38ba6d72e941674b851f55a5c9780ce4de17"
+    },
+    "my_progs/mon_dknight.qc": {
+     "bytes": 36867,
+     "sha256": "68008427374e9ab670b6ad915c7a0f8eaf6a6699efa927a3748ae6cde86458e6"
+    },
+    "my_progs/mon_dlord.qc": {
+     "bytes": 22859,
+     "sha256": "09ca1edd4e65a166a66ba17e682aae9a1be09b05371a72dd1bc447389693bfa5"
+    },
+    "my_progs/mon_dog.qc": {
+     "bytes": 18431,
+     "sha256": "1b345447176aec54f18c31f5da215e80cb2de19f51d353c63a98507d881c2a9b"
+    },
+    "my_progs/mon_dprince.qc": {
+     "bytes": 33590,
+     "sha256": "5114caa7b6152e562e548096e41da68f43c910a5016ddaed408272a97a8320c1"
+    },
+    "my_progs/mon_drole.qc": {
+     "bytes": 25472,
+     "sha256": "36a510e910ce4ffa26d2d2ad336872c07537077ea920132a4cfd63d9133fb6af"
+    },
+    "my_progs/mon_dsergeant.qc": {
+     "bytes": 33493,
+     "sha256": "ada0cc4359a863c4e8d433c605a1c04ec6f7fd17ec852f5c4847443d3adaff1d"
+    },
+    "my_progs/mon_eel.qc": {
+     "bytes": 8252,
+     "sha256": "15c1f2fedba7077d352595e1be4a90f764354e4cf1875b40e1685d3ce81feb54"
+    },
+    "my_progs/mon_enforcer.qc": {
+     "bytes": 20146,
+     "sha256": "d453651d488afa789d0cea87ce99d9684329bbabdd17aa1625591f5a4b4ac90b"
+    },
+    "my_progs/mon_fish.qc": {
+     "bytes": 9705,
+     "sha256": "ff7d84db2c7917861ff5d81fe0e28f69d51143d27c4fba90dfcda11057222df0"
+    },
+    "my_progs/mon_floyd.qc": {
+     "bytes": 20332,
+     "sha256": "3ac2f0b0be94e311ff2fc4eee9cf66d5987af0e5c25fc06b8cc7b9efa6f581df"
+    },
+    "my_progs/mon_freddie.qc": {
+     "bytes": 25384,
+     "sha256": "4409a33e819f125852d0a4ada21a8fed2713012daec00922446f313031c845d1"
+    },
+    "my_progs/mon_gargoyle.qc": {
+     "bytes": 24293,
+     "sha256": "9e1f78b2364024efa6ec4142c1ecf4aff52cdf32f38031c34cf19e9cd74143d6"
+    },
+    "my_progs/mon_gaunt.qc": {
+     "bytes": 24111,
+     "sha256": "45be98ae0bdd32e0884280e18f867af037f2fcbf515914827c5f9107a87e52d7"
+    },
+    "my_progs/mon_golem.qc": {
+     "bytes": 35297,
+     "sha256": "dbaf3d1c0fec3166b0eb064a3c027dd3a0c907bed72b8e4581ffd74dad5ab5d1"
+    },
+    "my_progs/mon_hknight.qc": {
+     "bytes": 37618,
+     "sha256": "bac7d4b7832b95cea0f6890de66fbd0f7c4fcc7ce9051ef16ac042de465ddcb3"
+    },
+    "my_progs/mon_hogre.qc": {
+     "bytes": 24021,
+     "sha256": "8781ea9aaaa1d0f7ffb1fd8ec8b5981187eee6fdb8193160a1eb38770dffcfe0"
+    },
+    "my_progs/mon_hogreham.qc": {
+     "bytes": 23076,
+     "sha256": "b2ab6b830ce3aae7d6b033e8455de5011ded82e451ca171ea09940d9a3ec7740"
+    },
+    "my_progs/mon_hogremac.qc": {
+     "bytes": 23941,
+     "sha256": "9111c040ab1e5487936cce6ef1170e408c6d297d582702d202bbd27b0919d843"
+    },
+    "my_progs/mon_invsword.qc": {
+     "bytes": 9214,
+     "sha256": "f7287867cc6043eb7cd3fa3e1ecd5ae7115a84e5ef7021b2d5129afdb6ba6f46"
+    },
+    "my_progs/mon_jim.qc": {
+     "bytes": 22091,
+     "sha256": "55353984ad822dfd8c32f3b8ad9a06e8bfaab7bc5ff6f2a2326674ad4acd26be"
+    },
+    "my_progs/mon_knight.qc": {
+     "bytes": 24772,
+     "sha256": "d254abf88162436b9db48885ae8e59315c24c1e7f72a91d027a1d69fe9baf5b7"
+    },
+    "my_progs/mon_lostsoul.qc": {
+     "bytes": 23261,
+     "sha256": "2cdbf656c6b34164711fa88016542f4e3d2bd0555417ad00bab5ca7039f212ef"
+    },
+    "my_progs/mon_minotaur.qc": {
+     "bytes": 35316,
+     "sha256": "fbcef276ee3e2f1eeea8483303538190875e959b43efbf4f703be10fc72fc564"
+    },
+    "my_progs/mon_ogre.qc": {
+     "bytes": 24123,
+     "sha256": "d287d3b9024025237dbc68380f486572828a5114f9543599ba86b8bc35e9e25e"
+    },
+    "my_progs/mon_ogrextra.qc": {
+     "bytes": 9387,
+     "sha256": "41a9243c6006326195197a4dfba6ea4c1f1fbd729ec10adc48cfd7badd7a18de"
+    },
+    "my_progs/mon_pyro.qc": {
+     "bytes": 18235,
+     "sha256": "bd35f02c63af315ddf4820e388d0248cf065f1170bd7306957a1e86fa7e47306"
+    },
+    "my_progs/mon_scorpion.qc": {
+     "bytes": 22136,
+     "sha256": "0432d7c5e1b6a30a5452aba12b9fb6a3c2c7f3c582b1392d420414e66b8fb257"
+    },
+    "my_progs/mon_seeker.qc": {
+     "bytes": 29703,
+     "sha256": "d33939357840eedbfc63c56d6415d8fefd21de2c477b24b3165cdadcca2acd2c"
+    },
+    "my_progs/mon_sentinel.qc": {
+     "bytes": 10217,
+     "sha256": "946232c7169bf3fa966ce875523dd45402772f8045c51a96dced04f2f5f5788f"
+    },
+    "my_progs/mon_shalrath.qc": {
+     "bytes": 16434,
+     "sha256": "1b6fdf2447d7fa281d126118a9bc0e097de7b4dd4d10a33e60d5cf0ca785c58b"
+    },
+    "my_progs/mon_shambler.qc": {
+     "bytes": 23050,
+     "sha256": "576f71a38d75eedbdf58c291055674be8da5f0d04540e26311d65f70b58ee842"
+    },
+    "my_progs/mon_skullwiz.qc": {
+     "bytes": 36245,
+     "sha256": "6d3c2242bffe6eabe3f9cc59e881cb2296213cfbff809e1be045a80ca46aac53"
+    },
+    "my_progs/mon_soldier.qc": {
+     "bytes": 21645,
+     "sha256": "704c534062b11c4fc16416154c7706c125221660cdd4d9b02e00575b94c04103"
+    },
+    "my_progs/mon_spider.qc": {
+     "bytes": 30593,
+     "sha256": "4d0bbb7e38e51cef07912e6071e6bb9739e019a2d93129d38dbab9492bf43aee"
+    },
+    "my_progs/mon_steelclaw.qc": {
+     "bytes": 17126,
+     "sha256": "78dd4bb46dd76b2ff1f7d4a9f0b0902f25d94ebe13ace6b997a7f604c3718700"
+    },
+    "my_progs/mon_swampling.qc": {
+     "bytes": 25637,
+     "sha256": "fb5ed328cd3d5c09704bb84f39138463a7d26b8b1d45771e55e9ae952b1d2470"
+    },
+    "my_progs/mon_sweeper.qc": {
+     "bytes": 27025,
+     "sha256": "8f7a1d077779d88d542a325c1ae4ba4ff59d48bfcb334150ae3f024525bb725e"
+    },
+    "my_progs/mon_tarbaby.qc": {
+     "bytes": 11866,
+     "sha256": "88c9481ab7fe0cbe97d2b836492ff51b368aeae8d4ff3e5852734bb9f63a1b2d"
+    },
+    "my_progs/mon_turretbal.qc": {
+     "bytes": 38519,
+     "sha256": "fdcf915248dda5fb6a744d284233d46a2e6d62c8e4fd02fdd5bafe4f46167d30"
+    },
+    "my_progs/mon_voreling.qc": {
+     "bytes": 27678,
+     "sha256": "7734614fa6b2da2195bf3804415c06a2d10f35825e86abf4f85613a182cf21c2"
+    },
+    "my_progs/mon_wizard.qc": {
+     "bytes": 15155,
+     "sha256": "3101ca37b57343697b3d3c7637fdc84c842f78ec9081e401dcaa6df0a9b1df83"
+    },
+    "my_progs/mon_wraith.qc": {
+     "bytes": 35464,
+     "sha256": "6a28a205cb8ac574e98c8d34a01ea859922e38d55c66346a7aa867ebf84bdb5b"
+    },
+    "my_progs/mon_xmas_elf.qc": {
+     "bytes": 17589,
+     "sha256": "053eec412485090ee1ebeac25887382db40e2ba7ca456050ba4407be3ec8bc1a"
+    },
+    "my_progs/mon_xmas_raindeer.qc": {
+     "bytes": 12189,
+     "sha256": "abbe1dd5c96c25b631231d4db2f17e8243075ad08c082e0448b7cbff34f1ae0c"
+    },
+    "my_progs/mon_xmas_santa.qc": {
+     "bytes": 17853,
+     "sha256": "cc60c6de17bc3321f9b1cf75b3229e387592c9eb7fc4bb57c1de0a8d2c0e62e6"
+    },
+    "my_progs/mon_xmas_snowman.qc": {
+     "bytes": 11486,
+     "sha256": "65928bb70cb2e9352c2f5e036eda2a6bd97aea09d459d0af563a82aa5a2f2673"
+    },
+    "my_progs/mon_zombie.qc": {
+     "bytes": 33988,
+     "sha256": "83f56482374c3a79fcc64058989bd210af3add006b7388d89c92e90543ec56a0"
+    },
+    "my_progs/mon_zombiek.qc": {
+     "bytes": 42214,
+     "sha256": "2b9926454484e93f5c053bf4fd35b2a97cf7e835c26c3b30061f1ff391af9f5e"
+    },
+    "my_progs/monsters.qc": {
+     "bytes": 56573,
+     "sha256": "c2c75832e6d5e83e929214ba5c1aa9a4661bcaf7754c20b3e9648171bf804a58"
+    },
+    "my_progs/part_emitter.qc": {
+     "bytes": 82744,
+     "sha256": "fca7491171d58974ef6b15550b9a7f0474641e9eac7ee5de52c6980c96445518"
+    },
+    "my_progs/part_generate.qc": {
+     "bytes": 42914,
+     "sha256": "83b9718a85418143d92ea8311cc8cce69c1002eb7563710dfe7010ac52e15d50"
+    },
+    "my_progs/part_manage.qc": {
+     "bytes": 27407,
+     "sha256": "86eb791f4bba08fc0c965e9f81c90e7412ed2c910104d66a56cce1f3152808fe"
+    },
+    "my_progs/player.qc": {
+     "bytes": 27811,
+     "sha256": "1f0cc3eaf577c2af642495466c573cd6e226a4754902d9de9cbfc9c9ba28af0f"
+    },
+    "my_progs/progs.src": {
+     "bytes": 2482,
+     "sha256": "c773f107c562f731fbb30158422226bdc4576dd32aea0f02c122195e08eac96f"
+    },
+    "my_progs/pushable.qc": {
+     "bytes": 19823,
+     "sha256": "03b3bf9240db6e9532e45a3efc159129709f9ce095c3238daae32daddd5b07ec"
+    },
+    "my_progs/qc_highlight.xml": {
+     "bytes": 6348,
+     "sha256": "a7b326723cc1e4025e867ea5da00f54c944705600d740538aeb52f63cd027ab5"
+    },
+    "my_progs/settings.qc": {
+     "bytes": 62244,
+     "sha256": "78d9b19077028f9fd72f271aaae3d75b43e995ef95b7679df83a06fcdfbaf4f5"
+    },
+    "my_progs/sounds.qc": {
+     "bytes": 19389,
+     "sha256": "bb74ecc36a241db5a79b010f61200687c6db6e46297db39c8a2a8ce1d512bad5"
+    },
+    "my_progs/sprites.qc": {
+     "bytes": 476,
+     "sha256": "579f48b397914b02f8fb86dc24f23d4e63a4cd857df1f0eaefd6c83e9c49e238"
+    },
+    "my_progs/subs.qc": {
+     "bytes": 24000,
+     "sha256": "48832d667d7a932661ac914bc8e471843f2cd8a0985fc0458d7e1a2796e21d16"
+    },
+    "my_progs/subs_soc.qc": {
+     "bytes": 28453,
+     "sha256": "679112275e8b3597daac962074f69b6d9fd5614fc3dbff036815b9365e1413c5"
+    },
+    "my_progs/switchshad.qc": {
+     "bytes": 7054,
+     "sha256": "92a2fd4e5c41f21f46502781322ab87584bf0999d733db50e0e19b8bbea793b3"
+    },
+    "my_progs/targets.qc": {
+     "bytes": 58758,
+     "sha256": "e39b45bf6740be40c2899376e92d30d7d227a4762091d7b63e382c79fe6822e7"
+    },
+    "my_progs/traps.qc": {
+     "bytes": 24071,
+     "sha256": "9e4e822a36113bc73958fa45ab0b8c290a5148c95f3a4da7125676c984ebd202"
+    },
+    "my_progs/traps_pendulum.qc": {
+     "bytes": 17049,
+     "sha256": "b421f26fd80eb74715172e25f3ac992faa95397dd67d5f7ede286fd78384a468"
+    },
+    "my_progs/traps_sawblade.qc": {
+     "bytes": 9783,
+     "sha256": "9a6e82a05f09001c0a9cffdf6b9d6399691846c5b1ab1fbfb470e5772a87f44b"
+    },
+    "my_progs/triggers.qc": {
+     "bytes": 139722,
+     "sha256": "0ead1e997492dfe79a8c811a48b902217aafcd4bf3c49acea7101c99892886f3"
+    },
+    "my_progs/triggers_states.qc": {
+     "bytes": 17475,
+     "sha256": "2c4d25c11de0319cd54d81e67e651c8d29d22aca851988d21080ba5976137f14"
+    },
+    "my_progs/weapons.qc": {
+     "bytes": 44884,
+     "sha256": "d22ff6c46a101964e5e8e334a8d91ae8854e2eb6ca2c4565fcfc748acfcfd9e6"
+    },
+    "my_progs/world.qc": {
+     "bytes": 39815,
+     "sha256": "c160b7b050cc7a718fbc6ffe3dbfad85514936522bbabeb8ee4fb1a3c30b79d3"
+    },
+    "progs.dat": {
+     "bytes": 2347206,
+     "sha256": "5e69fece92fb4323609c8e1209a39eecf4f70c3161ae17beb53063fe3e06c340"
+    }
+   },
    "sha256": "4c82e0347952b38b0265fd34e0c3c3a6b6b4bea17642d18bf4189a97d93dd0f1",
    "timestamp": "2020-10-13T20:59:16.000Z"
   },

--- a/json/by-sha256/7a/7ae72b3affa5970d30ec9dd0e9bb1e7dd0d08a9f9429daeb417c42c71d66c93f.json
+++ b/json/by-sha256/7a/7ae72b3affa5970d30ec9dd0e9bb1e7dd0d08a9f9429daeb417c42c71d66c93f.json
@@ -10,6 +10,508 @@
  "files": {
   "PAK0.PAK": {
    "bytes": 25844961,
+   "files": {
+    "gfx.wad": {
+     "bytes": 112836,
+     "sha256": "044fe7b94fc3920e3f1db10f883ba1e1275036cf480b5b60df4be27c00c93be9"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "f043ced9dfec649ca69836e1a67f28bc96d5a3688e88259524cef30dd54ddf62"
+    },
+    "gfx/conchars.lmp": {
+     "bytes": 16392,
+     "sha256": "76f2170f03f009241d6ff23c8bd63cbdcfa37142c67734508f4b4844cfc28022"
+    },
+    "maps/or1.bsp": {
+     "bytes": 609916,
+     "sha256": "90397a43c689eee7134d0965f1b05fc0f7b0f0e9829a54f912111e9a7f80c16b"
+    },
+    "maps/oum1.bsp": {
+     "bytes": 2112624,
+     "sha256": "0bba6e02f2b9e239e018e62b652599144dd37bfe8b23a95ce05c3d09f0599ae1"
+    },
+    "maps/oum2.bsp": {
+     "bytes": 3951152,
+     "sha256": "2eed92a6ffcaf7990b69d99cbd1946a456c4dcdec29ccde80e316a30a6132be4"
+    },
+    "maps/oum3.bsp": {
+     "bytes": 3813300,
+     "sha256": "d0b82c73427482b532dc231c58383146fed9bdec8288e081c1a1ce06de602779"
+    },
+    "maps/oum4.bsp": {
+     "bytes": 3666836,
+     "sha256": "8b0f8ed105034a55e79d9e48880a40bc99e9b81f7a4859f9dbd2a63e27294ff7"
+    },
+    "maps/start.bsp": {
+     "bytes": 373800,
+     "sha256": "90950bec8aaa72336df2d8470d71c5046c9003526fb87f33783d45ced8b29dd5"
+    },
+    "maps/toum.bsp": {
+     "bytes": 3846268,
+     "sha256": "491889081568c3d3f226de3321457447a24b5464dabc60b2c70646e93f878aa2"
+    },
+    "progs.dat": {
+     "bytes": 649504,
+     "sha256": "2e11470ce5513153cfc9a5239b499cd5438efe7d87248c6b7f1a0f6209fe204b"
+    },
+    "progs/aagba.mdl": {
+     "bytes": 47520,
+     "sha256": "3d241c4ef67ff5f72727a47f2a0dbd47e458eb1dadda598a2a51d6a7e317c254"
+    },
+    "progs/aagtb.mdl": {
+     "bytes": 65761,
+     "sha256": "dce6af4135b595aeaa53d8afddb55d5fce2d1f249a9a0511492f5905d170c769"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "718b8c2842877345426247148dd6ce1ebe7fecc13e969a0fa0ed6dbebc388099"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "0a386b6381824b01852910519490ac3f6e3309a96091820384ee6b9a5b452e7a"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "9a8d7793b5d197e8162ab7ab8db9b527acee248bbe2543845eb3b2c3f4cd89da"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 224812,
+     "sha256": "af9095cffbc74edc9d98d4e4e341736e304404df52983be33616da84d6463c87"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 276136,
+     "sha256": "ef262c0f468d0ccdd5c465d9b781962580c18f7eb3cffc3f48207f29c8ed441f"
+    },
+    "progs/g_asha.mdl": {
+     "bytes": 49400,
+     "sha256": "adb9212dcf5530275072dce0c038bc101a2ad7b68604e75ddd77c946be120ec2"
+    },
+    "progs/g_beam.mdl": {
+     "bytes": 68996,
+     "sha256": "db2566d26863472c6176c91b2256c12b5fdd28b5e1ba0a3ff2aa9e122ed0cacb"
+    },
+    "progs/g_dshot.mdl": {
+     "bytes": 71894,
+     "sha256": "9f5973b2db81e67569d498ae880c4ebdf1f886fac695df50ebd93cfe5b79da0c"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 50636,
+     "sha256": "c5af6bb197f51c0236c1a85cbd6907f33107247858a922def7d2382c488fdf0c"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 161064,
+     "sha256": "b182cf8e7915d1860f37634a610905359c7a325f4ac13f1ef5b6fc2393efe182"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 12416,
+     "sha256": "2fff2f36173080827a298870a956fb11ad30f34aa0342ba5ca2c8bd6509edf57"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 323272,
+     "sha256": "89cd6bd51fc4ea32e51edf4dff669ab23f1e1e5b0b7993ba1705b31a0ff37e94"
+    },
+    "progs/knight.mdl": {
+     "bytes": 205396,
+     "sha256": "c4a1097da4e465abf79c2f5d80fb50b05faec3605bf17f52bc068eca31bf8a88"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 59078,
+     "sha256": "6a7022fa8210771be206034a2b0ebeb59f6fc79719d499ac01811a4ff32eb08a"
+    },
+    "progs/morph_eg.mdl": {
+     "bytes": 300592,
+     "sha256": "14468fccffaa1508c03610dd58fb51cd9058ca3bab036bca18f7a41cb37c195b"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 264476,
+     "sha256": "3141e6bfe25012402393eb57e52fb2be349afdee3cd109dfe7a81ad67b2765c1"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/player.mdl": {
+     "bytes": 331236,
+     "sha256": "6939a925af5510ecece22c3cee3de418d3ba532f4eb17409ca1453d253de328c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 17204,
+     "sha256": "0dab5b94c60d92d55df3e44a8d8ea2dc0f949e98897a6525ee0be3f49a019b08"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 6300,
+     "sha256": "ae856d7d30e50cc615d1b35fb9ad9f6481e874bdce527d6abcb6ad92de93420b"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 262696,
+     "sha256": "094e8fac21ab31e29a12119ea908252ebc209eb83e8a2b2a8aff14a1b8aca9ff"
+    },
+    "progs/splint1.mdl": {
+     "bytes": 1684,
+     "sha256": "0a64f602cccf2b243b7a4ef9294ab03e25c6e61fd738e8217b3e83a0bd05f171"
+    },
+    "progs/splint2.mdl": {
+     "bytes": 1748,
+     "sha256": "79c9cb57e646d9384daec38e0b06c4b7f10d2883a4e5c8373840901240b6026d"
+    },
+    "progs/v_asha.mdl": {
+     "bytes": 54064,
+     "sha256": "5845e437bd84f6aea7201a83beb0d794d571704bb8580c998b20127972ff5504"
+    },
+    "progs/v_beam.mdl": {
+     "bytes": 75588,
+     "sha256": "c00fe7872cb2c88626e63d99c3cc00b83f9968803344cd2021e8fc26bd25ccba"
+    },
+    "progs/v_beam2.mdl": {
+     "bytes": 75588,
+     "sha256": "95b3a260450ca784bda0885da994a5a857cf9948581ed1e68c4b202c51dae670"
+    },
+    "progs/v_dshot.mdl": {
+     "bytes": 77102,
+     "sha256": "8b54bab3a0fc20bbe27ed1ef204fc4dc21c8c6ab0d9a6efa82038d570de5aacf"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 54564,
+     "sha256": "4f2a06e5b9df3dddd29962562e8a8959cdf643fb9bee5b922ceda4303d2161fd"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 184952,
+     "sha256": "d113effd0d5b436c468269c245647e369f26b569f3fb9031f874a7f6a5dde574"
+    },
+    "sound/ambience/equake.wav": {
+     "bytes": 47148,
+     "sha256": "dcc45d2ef0703ecaa022c83cd66ae4992021ac379c11fc9da4401e184a191c93"
+    },
+    "sound/ambience/hum1.wav": {
+     "bytes": 35476,
+     "sha256": "8dea1fb5b08d26c03544075ee25f2ec838365f1002c2d03b2788d88deb846e47"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 30408,
+     "sha256": "34248569bb7ab66f5e1d874e15c7a91d89fd2b70d27e5521456b2589581fe1e6"
+    },
+    "sound/ambient/amb2.wav": {
+     "bytes": 38416,
+     "sha256": "21a4f41fb5efb52587e60395f23824ef330674a8d9499fe2cda1c91603093bfc"
+    },
+    "sound/ambient/amb7.wav": {
+     "bytes": 43020,
+     "sha256": "de7f4a0d15c711c9ca63f74ee38acf78e4ce41800900e0193a43c3e55e4efde6"
+    },
+    "sound/ambient/comphum1.wav": {
+     "bytes": 20456,
+     "sha256": "af10cad0f193d07be9c98f0dd889840fad0f54f40a61d12a1325b78033a68c8e"
+    },
+    "sound/ambient/comphum2.wav": {
+     "bytes": 72367,
+     "sha256": "fbf1ff8677cf36d78e381437f3b8e758a589a108a50c92f24c514eda06ede3f2"
+    },
+    "sound/ambient/comphum3.wav": {
+     "bytes": 116441,
+     "sha256": "62d9624940b93bcd1897abb809cb9d6f2cb3872cfd6af9a792260fb17f800150"
+    },
+    "sound/ambient/fan.wav": {
+     "bytes": 54275,
+     "sha256": "6cdc6a19b0c740d5607fa9076f749dc485483362445630877c6b59ec67085a2d"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/l_hum1.wav": {
+     "bytes": 20790,
+     "sha256": "f1b8bb19b32258ca1b126d52eb98b17c2753a255eba60864f8ad325f564681c7"
+    },
+    "sound/ambient/music1.wav": {
+     "bytes": 213944,
+     "sha256": "bf498e0cf6541b3559abd978ac420c5cb19d6542d89f19f59bdba8019dc46688"
+    },
+    "sound/ambient/pump3.wav": {
+     "bytes": 40435,
+     "sha256": "ae8ca71a1ce41bb3fa02d993930b4f100db3827ef5768326a91e61f7857370bf"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/force/force1.wav": {
+     "bytes": 30022,
+     "sha256": "b609981695694648cab0f2ed521dbf3d6f31b6c2e8c3e8502ab4740c7a105557"
+    },
+    "sound/force/force2.wav": {
+     "bytes": 10252,
+     "sha256": "32c0342dbc9e63220db18fa706ac0fc1afe9a86f4d488e509e1f52bee955e3cd"
+    },
+    "sound/force/force3.wav": {
+     "bytes": 10252,
+     "sha256": "0317e18dab002184b5ce11a2b86f3263d2606c40f2dc435c824bbd075c1b621b"
+    },
+    "sound/force/fusein.wav": {
+     "bytes": 13669,
+     "sha256": "53192c25adab70ebcf471204aa194ef9d34c4161138c728d95f84cf08310a879"
+    },
+    "sound/force/fuseout.wav": {
+     "bytes": 15379,
+     "sha256": "f515c6b48204f2ba158e99c10a9da60cc45756ea5dca716e256ffbe54a017512"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 47176,
+     "sha256": "87f013eb50cb30a967a183f0cfa41b4848f9269afd13dbe1ab5053458bfc5f0e"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 10768,
+     "sha256": "c48f2415db3a5067dfbd99ad580e3f4809532743d653eafe2fdb924fb0bb832e"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 47502,
+     "sha256": "a0c0bd639af614c7714388009c9388f6db9a694e7ecd8fac38653609d6958f61"
+    },
+    "sound/knight/bhdeath1.wav": {
+     "bytes": 8302,
+     "sha256": "d3d8609d72b16dd0ebf0ff8e471a6036a5c7d4719e676c14fe31e22c5d133d36"
+    },
+    "sound/knight/bhidle.wav": {
+     "bytes": 5056,
+     "sha256": "3c7f2d507ed4b6e77e19b4eca6974c73bb2ec17319cde47d2f53408f59dbcc31"
+    },
+    "sound/knight/bhsight1.wav": {
+     "bytes": 8790,
+     "sha256": "c785d0f88ef035402e9ae6a0d8c24b0bbcaff4f4595c90718d5dcfbaed08f500"
+    },
+    "sound/knight/bkdeath.wav": {
+     "bytes": 10688,
+     "sha256": "a1a8fa8365bc5d42985c47249fe00c11c2b85b121533740c7647436379637ea7"
+    },
+    "sound/knight/bkidle.wav": {
+     "bytes": 11064,
+     "sha256": "7347501e6d44b3fd95287c58c10440808ac3e8155f67d11d071f75f585abb5b4"
+    },
+    "sound/knight/bksight.wav": {
+     "bytes": 12075,
+     "sha256": "02caa75821e39ceb404647a764abbe3955d0139165aa0ec48e956e027c22bb7c"
+    },
+    "sound/knight/bsword1.wav": {
+     "bytes": 3541,
+     "sha256": "689077f95be77350ab37a456b3b4a20d889e860db8d73b37f7b64c3fe4d04024"
+    },
+    "sound/knight/bsword2.wav": {
+     "bytes": 6862,
+     "sha256": "cd73388fdb044b6bad42713d7b74f4914a5172229df0d6dc3290f35011012949"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/b_rot2.wav": {
+     "bytes": 15436,
+     "sha256": "62c86077b7a29f48f5c872c68d262c03b73b57f876b718a05f2fc6b24b9a9ef4"
+    },
+    "sound/misc/coin.wav": {
+     "bytes": 12628,
+     "sha256": "0c7bbb698ede5fa289503b591cd0fc31d46f18503a10dcfbb7dbcc66467e3c2d"
+    },
+    "sound/misc/liftloop.wav": {
+     "bytes": 64438,
+     "sha256": "223ea82cd9ef67f8752087d6999daaa5981b81d68f9627a2fb73013acc26f02c"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/mgboat.wav": {
+     "bytes": 26866,
+     "sha256": "666016e2aa958ea621ba03bee4339518f2ccc72aa3ee2d0838ef9032e8ffc981"
+    },
+    "sound/misc/mov_watr.wav": {
+     "bytes": 44147,
+     "sha256": "f80964a01b3a335117a604822d1d470864b241adb850c5fe773df8a709559c8c"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rublexp.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/secret.wav": {
+     "bytes": 55974,
+     "sha256": "788c6e268de149cab893e7d2a4885780cc9a95b28ebc02d00a1d2770c50492e1"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/stop.wav": {
+     "bytes": 17780,
+     "sha256": "e5078f98c3c28dff9c2750008b0923c0f7cee1ad34000cbe5679ec5a5ea38110"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/tur_arm.wav": {
+     "bytes": 23794,
+     "sha256": "24b428117ebd7e82865b41dcfc74a75a048c4d126d7505a6c23dd243bc054a05"
+    },
+    "sound/tyrdie1.wav": {
+     "bytes": 34011,
+     "sha256": "079890edcbdf92b19c3e7260352d7eb9642908eec168e0ec642fb696bb0110e5"
+    },
+    "sound/tyrdie2.wav": {
+     "bytes": 98229,
+     "sha256": "d6ba1844de558b1b3552e7ad29a9282a9224fbcf76e9dc4f5423134908c645cf"
+    },
+    "sound/tyrintro.wav": {
+     "bytes": 353044,
+     "sha256": "bb184eaed7e09e275873102fbc708706863a936ce526e95902dabe87d4602dd4"
+    },
+    "sound/weapons/gunswap.wav": {
+     "bytes": 3392,
+     "sha256": "b3130db70e049f0b97f25658568b250965002a7ce55319dd21eaa7bcc8897743"
+    },
+    "sound/weapons/null.wav": {
+     "bytes": 11161,
+     "sha256": "abf66dfabf7a34006ba4b47c04bf4c1cc86dcb9008877b4d46bbfe47fc8da969"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/shotgn2.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    }
+   },
    "sha256": "cb2ca2e2fa6db4fb0fcc366802f21fc7d9b69e820c198b27131f068251518613",
    "timestamp": "2001-07-26T07:45:44.000Z"
   },

--- a/json/by-sha256/7b/7b1c71a43edbc9b0d05d50890b220caabda20685590f928d6233a808b8e92bfc.json
+++ b/json/by-sha256/7b/7b1c71a43edbc9b0d05d50890b220caabda20685590f928d6233a808b8e92bfc.json
@@ -7,6 +7,148 @@
  "files": {
   "Pak0.pak": {
    "bytes": 6188904,
+   "files": {
+    "maps/pbrsp1.bsp": {
+     "bytes": 3798148,
+     "sha256": "8144a73c7e418d4fa1f58ec11ec9be15c2fc30373b45e35d48f8ff6776077b54"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 906577,
+     "sha256": "d0859d676a10a10d29d24e6703b203369adf95ab2cfd32832f553ccfe3337585"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 731891,
+     "sha256": "e65950824bdd93ad5a2f3e0d436919eab84bf53ee24bdfa9be51670b517f4f56"
+    },
+    "progs/fireball1.spr": {
+     "bytes": 62484,
+     "sha256": "dd7cd00d28b3ced55a772b8f8bc97465641efc9c4bbba33c9267a25bd8a024ab"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/pb_rubble1.mdl": {
+     "bytes": 6501,
+     "sha256": "76060cb65c5a435bb53f1cf27dc378771e01eca37a640938560e425ebecf3401"
+    },
+    "progs/pb_rubble2.mdl": {
+     "bytes": 17553,
+     "sha256": "5a9cbb9552bc88e57c438eafd7802feaaf24736f53178d49da3e1faddbda5c8f"
+    },
+    "progs/pb_rubble3.mdl": {
+     "bytes": 22933,
+     "sha256": "ebda9d4388fffd51b534c40cabd9b15db8b631e019ce5e1263d48007ddd905a6"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "sound/ambient/back2.wav": {
+     "bytes": 22418,
+     "sha256": "993d9d47e354673b1aa3b9e04a4d786e7ca029b5561301e9933ef0e0db6287f7"
+    },
+    "sound/ambient/back3.wav": {
+     "bytes": 40484,
+     "sha256": "f3cfa81848177963b5403cd5fa80bb02c409502519836cfacc53f450c3a02bee"
+    },
+    "sound/ambient/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambient/fuzz.wav": {
+     "bytes": 37304,
+     "sha256": "38354da21c7d7c7c27dd2e6afdf74fd4a5f1ef822ce6ce4407325deee579d14c"
+    },
+    "sound/ambient/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambient/techy1.wav": {
+     "bytes": 65418,
+     "sha256": "f9445528fa3a4135b77e9c3ea21f9911fe582d09aa605cfaebc7ff53b3ea6278"
+    },
+    "sound/ambient/techy2.wav": {
+     "bytes": 27888,
+     "sha256": "f861cf97f1b7512520c253118ec8a519b7f1c697d04dd1e6bed48098d1d3afe7"
+    },
+    "sound/force/off.wav": {
+     "bytes": 25260,
+     "sha256": "52e0d8ce1a9d73459ec41386de2b47a164d2ab41dd159fcffd969eb2480a814c"
+    },
+    "sound/force/on.wav": {
+     "bytes": 4794,
+     "sha256": "caf8093abce563f55bfe2d7b5cfbbe31695333c9715cf9e2c6e8724e88af9cdb"
+    },
+    "sound/me/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/me/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/short1.wav": {
+     "bytes": 7580,
+     "sha256": "1f374c39740ddc9b691b6260d04caa8a25e7a122930e12723b0ba006f26d7ee4"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 22153,
+     "sha256": "dfeb64a2eb091cab67d7a1620b772adcddad1d4b513bf6b1d347a50d67a5b25b"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    }
+   },
    "sha256": "89bc2dc3393737869b3c05f135358afe8d1f14de50b768b37d9efa39c66544bb",
    "timestamp": "2002-09-28T14:45:44.000Z"
   },

--- a/json/by-sha256/7b/7b696ac7580923b0b23cb01108706ddf02a799034235167feaaf92123dd9d8cc.json
+++ b/json/by-sha256/7b/7b696ac7580923b0b23cb01108706ddf02a799034235167feaaf92123dd9d8cc.json
@@ -12,6 +12,20 @@
   },
   "PAK0.pak": {
    "bytes": 10131152,
+   "files": {
+    "maps/cda.bsp": {
+     "bytes": 7204696,
+     "sha256": "74b652f09953c116a8d1921f42e2d168add317483b4b2bc500faef64d653c673"
+    },
+    "maps/cda.lit": {
+     "bytes": 2506796,
+     "sha256": "9ed5fb538d3c51a52a86726fbb47924b7de83e946dc004c42d9967b0976f3aa8"
+    },
+    "progs.dat": {
+     "bytes": 419456,
+     "sha256": "d776573027f19c587f8bec0bd703b3f67117659022fb00b32880994ed2920ec5"
+    }
+   },
    "sha256": "3fc6d45349e61065724b48aec53c599d8f830ff81c7dd8a824a2ee730d0f1a6b",
    "timestamp": "2005-10-22T09:21:54.000Z"
   }

--- a/json/by-sha256/7b/7b9a1c82d77a7ebdc4f55ee758e7cc493f521df87772bb7c6eccc8037a41d8fa.json
+++ b/json/by-sha256/7b/7b9a1c82d77a7ebdc4f55ee758e7cc493f521df87772bb7c6eccc8037a41d8fa.json
@@ -373,6 +373,296 @@
   },
   "pak0.pak": {
    "bytes": 3563368,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "896bcddcd05bda4e9ad139f814079bf78410ff45719bbdfc955be8270c8a7dc2",
    "timestamp": "2020-10-01T19:45:32.000Z"
   },

--- a/json/by-sha256/7c/7c2efd235e8f9fd3716ffa98529779ee68d0677de2417e741e81c955e059e28a.json
+++ b/json/by-sha256/7c/7c2efd235e8f9fd3716ffa98529779ee68d0677de2417e741e81c955e059e28a.json
@@ -32,6 +32,344 @@
   },
   "copper/pak0.pak": {
    "bytes": 4110228,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "b1deebb2268d373683100cc9df4c9dcbf817f9bdb0e3f2cd13edde0037609b53"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "11454a7ec41855cc66adc9b80e60b1c76b0af873656d46cc20543ea4d2a7ef8c"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "d2a59d07042577c9c5a5ceace5ad0e3893ba3ac2d206f039f11cf282ead3945e"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "63f869e1e553ccae238279e4b78c902463505a3d1dd7c5d21d4f4acbb56857ee"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "6e3d8ed0cf22d78c0e05bf75837214a12f647fda33da1fa1ad1195cff3cb9681"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "35db83f82066ac1db85f4094dc9710e313b638e019d8e4d6fb5abf0457d506af"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "0191d8c540203ac186f94012d21a474c77a048c040cecfed00fc9f6f63a57dbe",
    "timestamp": "2021-08-25T13:58:22.000Z"
   },

--- a/json/by-sha256/7c/7c4ee2dbb6f3094988d21f6e2f5ef47ce482bdf2f8d84228464b273945d72503.json
+++ b/json/by-sha256/7c/7c4ee2dbb6f3094988d21f6e2f5ef47ce482bdf2f8d84228464b273945d72503.json
@@ -7,11 +7,68 @@
  "files": {
   "PAK0.PAK": {
    "bytes": 1165524,
+   "files": {
+    "maps/vision.bsp": {
+     "bytes": 736716,
+     "sha256": "6ee33260ab47ecebdccf99157eae6ccd643cfca4d68a8b7f07788ea94925572b"
+    },
+    "progs.dat": {
+     "bytes": 428668,
+     "sha256": "0488bf92428de4df29a111c8cda5f26d7b6465163df458064a3b6f45ac867e87"
+    }
+   },
    "sha256": "f448d7b9913852bf816e4b6b4f2f32e9c4b16e69999d8049289c4700c65b933a",
    "timestamp": "1997-01-15T20:23:48.000Z"
   },
   "cck.zip": {
    "bytes": 164261,
+   "files": {
+    "cck.txt": {
+     "bytes": 4760,
+     "sha256": "31396dd05430f2e0c1738c089ca3f8a762bb5e599a36f229ae05cf4dbc7b63f0",
+     "timestamp": "1997-01-15T19:42:46.000Z"
+    },
+    "client.qc": {
+     "bytes": 33189,
+     "sha256": "910145d0839b8b7b461c0d8107ad832f5e7427766ed2df9bb1005c59667c1a95",
+     "timestamp": "1997-01-11T17:37:50.000Z"
+    },
+    "cutscene.qc": {
+     "bytes": 15948,
+     "sha256": "4993d54c53f089809079ad47a1b39192a8b0bb3fe3350df7fe85d50143b02ad7",
+     "timestamp": "1997-01-13T18:57:50.000Z"
+    },
+    "defs.qc": {
+     "bytes": 17742,
+     "sha256": "ec1832906cb8c7cd20c5430bd24d294f93afffc119427c671d6f5f230a64b8ec",
+     "timestamp": "1996-12-10T22:40:54.000Z"
+    },
+    "dog.qc": {
+     "bytes": 12092,
+     "sha256": "c6bf5db366788d47f75f0480522e481c5a648ce1f540cb3f4f125bf4ff5d1baa",
+     "timestamp": "1997-01-04T11:40:18.000Z"
+    },
+    "monsters.qc": {
+     "bytes": 4857,
+     "sha256": "7c7d82125c4e416aa376b3facbc9f1da68722b74ac09bc0eaeb171d0f4624ab8",
+     "timestamp": "1997-01-15T20:17:06.000Z"
+    },
+    "progs.dat": {
+     "bytes": 428668,
+     "sha256": "0488bf92428de4df29a111c8cda5f26d7b6465163df458064a3b6f45ac867e87",
+     "timestamp": "1997-01-13T18:49:02.000Z"
+    },
+    "progs.src": {
+     "bytes": 458,
+     "sha256": "9ee451e50551bc072e6b07378e8d37146a3a5700ab8160bac89c44f9804fe7bc",
+     "timestamp": "1996-12-15T15:58:54.000Z"
+    },
+    "shambler.qc": {
+     "bytes": 13948,
+     "sha256": "c129e8525bac460bb98fef823089b97bb0f925f077bdf6417aca2e36e049cf17",
+     "timestamp": "1997-01-10T22:25:46.000Z"
+    }
+   },
    "sha256": "5f079e4acae4b2bc7f2c22f7e8a4a709aa41350177df8252368118773fb13daf",
    "timestamp": "1997-01-15T20:19:38.000Z"
   },

--- a/json/by-sha256/7c/7c9cad5df043f259f587d99e04af4006a71450c0e30b290c862e671ea957c756.json
+++ b/json/by-sha256/7c/7c9cad5df043f259f587d99e04af4006a71450c0e30b290c862e671ea957c756.json
@@ -7,6 +7,32 @@
  "files": {
   "pak0.pak": {
    "bytes": 3056185,
+   "files": {
+    "demo1.dem": {
+     "bytes": 130932,
+     "sha256": "a204b73e25a922e4fbf6dc52e465f3042ab633e5460ef489903fb14ce9d195be"
+    },
+    "demo2.dem": {
+     "bytes": 198207,
+     "sha256": "052dd2509bcb1ee6da472c3cc3a09e69c31efd2917a0553b378dfd741396ec6f"
+    },
+    "maps/level5.bsp": {
+     "bytes": 1836152,
+     "sha256": "1923d9bb2dea3e8b27bbd9f6f055eae2d50e8939deaef4f60116831445ac8423"
+    },
+    "maps/start.bsp": {
+     "bytes": 472592,
+     "sha256": "c6b90f8be173fdc117a935cd05ef483a173f3a0966dc32c357e6d5c1041f55d5"
+    },
+    "progs.dat": {
+     "bytes": 417608,
+     "sha256": "17e49a869f754d237669cfdae6aa3675e77d76886ec3ca654d40efcb1cda25ce"
+    },
+    "quake.rc": {
+     "bytes": 298,
+     "sha256": "a33d6bc621bbf8a9350e5bbed78ed3d9a9ab471c38ebbfd9f926ec4ef5b7101a"
+    }
+   },
    "sha256": "59fa7273df4000fab1e74b72ab1313173f05a3057f54f205bc7ab57c9c86c97e",
    "timestamp": "1998-05-19T08:42:46.000Z"
   },

--- a/json/by-sha256/7c/7cc783ecf6332fd1c8b0d14862f1e7e3d23e81c240bf09a0dceaa4d8d284154a.json
+++ b/json/by-sha256/7c/7cc783ecf6332fd1c8b0d14862f1e7e3d23e81c240bf09a0dceaa4d8d284154a.json
@@ -107,6 +107,2468 @@
   },
   "utotp/pak0.pak": {
    "bytes": 36840840,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 52014,
+     "sha256": "cd10b4453a4563d165fede594ae2ece6e780af19b06733838b83528dcaab299c"
+    },
+    "gfx.wad": {
+     "bytes": 210484,
+     "sha256": "9072806ee7e43f2ce712cbe7bd68355dd659447258c7e35e1005d71df7ad5baf"
+    },
+    "gfx/bg_ammo.lmp": {
+     "bytes": 1928,
+     "sha256": "754dc8ea867ba7dcd60407764b51a1eccac068456c38787744387a4c59cbce62"
+    },
+    "gfx/bg_runes.lmp": {
+     "bytes": 520,
+     "sha256": "6b69fad1c89ac2085dcc7b8153d1f19ae353bbd0572b05aace1afc02e8e984df"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "6072bd63a691625de201f3f3da060b5df433753d7ac2878c48b87e9d0dd08b94"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "ac11a967228e1c7d1a936859b82807cea239d80380fb6204d67af7a86c5c82e3"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "4cb99cf1b515b6547f012b6e44174c245261b058168a8bc4303d08b98e1805b6"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2c37b7697aebedb5bbf6637d4b8e158f70da6b7245195ff0e91a6ba7aa24e828"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "219002fe962a017600a37dcdcaaa0f777aad42044619f945cb70c68007763a97"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "e251893ed49aeb677096d380d4246907a039e0e21a4849f97f343b0b13faead2"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "64ec646cbab7ebca11f6af4f0b75d9706f438baa7b23059de87f8685f4686640"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "03c7cdc618e4404e2b9364c690b0a447b4be99dc5af112c66e6e2079902c76cd"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "9cf2683f2a6d22693a8c0cf35898bc5900a96afc771878df9f8a8a88f3d581c9"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "f232da5cf35acc557f3f312911e6a856cffaaf9f8078ca2ac5ef7e6f6e5e3515"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "b57ad9ad9d6240a0e035ca7a64e706e3031b8293c27355c9a95495a84972af4a"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "873af58b7244d6e82feb1af26ac044c9beb43c2865bc51d0485054a562ce861e"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "ba75badfe057b499d33168032dd5dc5a4fd0dcbaef9cbbd27efdb3f056cbfc00"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "55ac1377921460aeb691f86e7a5051e3a5481f24b93cc8578cffdab2854ba0c3"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "9600a66391996cff88d48890adfa516660fce6a32397ba4f54973159785cff4b"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9f03351fa7f31a23b63e6c13d2a643ed1ae3fd3df0cf2b0db336424eb17016dd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b7617428e8d1d74be7b770ef24c744d16c2503efce9c17facf1107cce08f5ed9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3036afb422cd299cb09532a20847ef35aaf87bb36e34ce9ce75b5e7aaf9a1ec3"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "7aa61257bd3083c00959776eb36aac86a7ca8da2bacbb4c8a41d9a5fb0b1ab97"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "cfe83953875acfe9afda11b75407ed9883eeb284b0a67b9ff6e07df85d50d9fe"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "d3b4091b83837da5a45445cd00b90267c62050e010e2a045461034ac9c48be33"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "de004dcecdff1973597a977ab63c671ad7d3f52387bdcff4be560924e3d4d17e"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "078c56d685ff1fb84b322f7a76e485c2637fb09efc61f4e44d5d067b3ef9a42d"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "9df9672c8da61ae769409e9ea741a1b8f9a4f108b5f0fa6637ff65601c535843"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "fef6b9be45d5b384d061a47f133075d1cfe0b60d93cf7e3da9ee5529f661964c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "1b1254c1f5764affca85448c4a3c2fefdb938f35bc50f44142a8e9b692ba7d64"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "39a06ff92831e1e2fd20c1bdd20e0f234cd0b3aed94e6c9909d059a20479ce3e"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "def061c922fb91a7e58850e89bb6baa9e09dcf93de7a94288a90511ecd9a114d"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "3220d953bab793165178f2666e67032398a6bd0e0510f6b92eef4fcab377ee1e"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "f897535531fe4b821d41d859a4085fd7d25c679493645a2ef7448f62073523c4"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d070636562a967d1abff330dcd1ea504ac7b9b29099a98994add1d9ae47e44e9"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6d92547a27d839f3c9d7a1da786fb33547cd93b7f19560b6c4bcdc12064545bd"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "e932416c58fc5de16e6d05aa737e56d3811e540bfd9e6acd1bf114ccd8bf34ac"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "bda55d4b2d7bc3f180dafd62424ee5830896563f5a5ac576dfa08894f5e17e44"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "513955ecc96eb1f0d44b340b47f79c02bb7bfa7f3b0a884a65fe111429ddb2b4"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "2faa4c1f61d175ad28b7f54540af3f87abc6e56dc20f2da5fc8a7737a0302c97"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "dcfe5287432b3a1124d032250ccc4bf25c73540521c77601ab746287ef3a0179"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/skillmenu.lmp": {
+     "bytes": 14408,
+     "sha256": "dbf40f0e5faedb181e84d4a822ecc9316711ae89530a30bd50cf4fba45aa8251"
+    },
+    "gfx/sp_maps.lmp": {
+     "bytes": 2248,
+     "sha256": "024bfb2d05f1c52bab1a856cbc532d06fdf4e8d96fb486f74bf451472311ebcf"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "00654b7bec9981508cd9ae8eac167637926c023e7bca011a3cf37585b7e168a8"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "74c50b895f1e71ec6a569fba0e991fde8cf136ea734d6914435aaf9b2735d7fe"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "aecab7a199a4db72242659e6d1ced192d39b2619f67c7e5eaafa72a5efef3aef"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "d075eb0c8c00d30b01eae539720c20b73bb57066c6ea5e8180a4d851d9167add"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "d03aa05e24552d961ea9ca278d743860e34a97e2ffcee52fded05ad4b4740bd9"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "maps/wood07.bsp": {
+     "bytes": 7135,
+     "sha256": "8e07e7e5f5b641c644d28c9c4026efc95aa50345074f5c42acd39a3b94261344"
+    },
+    "progs.dat": {
+     "bytes": 1199182,
+     "sha256": "594a6e7f927ff67e195086bfc7b03d80f1c0c4f68662c3bb5e06cb9ca0a89bff"
+    },
+    "progs/alkturret_base_v2.mdl": {
+     "bytes": 87768,
+     "sha256": "4b1969201052a4506509bb606eb7c395daf9332cf4605036ab50190495dcfbf3"
+    },
+    "progs/alkturret_main_v2.mdl": {
+     "bytes": 116620,
+     "sha256": "11a2564f7daa19625e4514c284650242c8b3831df947f183243adafb958a1333"
+    },
+    "progs/arachnofloyd.mdl": {
+     "bytes": 741212,
+     "sha256": "554bd2ad34a830fa01a61dd4972f432812fb61f7815ec81d8a8d7e87bfad6b02"
+    },
+    "progs/arm_foot.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 164224,
+     "sha256": "35314143b9c7a9a0e26e52a865072a6e73862466e640c6bbd58be3075c4d93ff"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 497408,
+     "sha256": "40cc63b599cedb54f04c937ce407e7119c1cf4d5d35fd04bc18f247584e9899f"
+    },
+    "progs/b_p_key.mdl": {
+     "bytes": 5940,
+     "sha256": "051b2e8fa67cae7aa24490a18444400f773d4a9d353542ebf979b0a22a1771ef"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bambler.mdl": {
+     "bytes": 128044,
+     "sha256": "c8ac9dbcf99f0e6efd30496ac414383c26b8d241fbaff56cfa81dfb545dfb0c8"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "698bf740683ad182feae2246526361948be6da2e144f1bd0202eafa748213ec2"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "b662513bc3a8e0e967344c55b536bd33012340dbeb79a8db1281d2c84e36d338"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b2cf62d8e989789bd76e27193b2f5205a93d4172a4e25c89aa1b30f75bebe60e"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigcranea1.mdl": {
+     "bytes": 92792,
+     "sha256": "81f6a5b55d3a585d5e9c73b088d1d20e0fb328707c1539ef41e52c460555f651"
+    },
+    "progs/bigcraneb1.mdl": {
+     "bytes": 21940,
+     "sha256": "e02faff0bb6c84c781f6b534a5a06ac1f977a028fbdcca176be2932f91e9e8ec"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/brz_saw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 575288,
+     "sha256": "f571bdf504537ce01ca2b6a78b57575a36c391f9c786625d880d956fb17390a7"
+    },
+    "progs/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/chain2.mdl": {
+     "bytes": 141764,
+     "sha256": "9334a3ec04716ce0068154bf7abb4c1e3ee6de14fb159982dd547314935d7854"
+    },
+    "progs/cyberscrag.mdl": {
+     "bytes": 306936,
+     "sha256": "868d1394e186b1e7f4fc58134c338a413814723f406fa609e2d7cb87dc2496cb"
+    },
+    "progs/cyberscrag_gib1.mdl": {
+     "bytes": 60500,
+     "sha256": "3db8b13bfa5a5eda07acea695cae6ffb92354053da9bed199ef29cd445317faf"
+    },
+    "progs/cyberscrag_gib2.mdl": {
+     "bytes": 58932,
+     "sha256": "ef20c0de15fe2fc2514c10b0023d14009a4871ed40311077ba107350c313f7ce"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon_alk.mdl": {
+     "bytes": 191716,
+     "sha256": "11f33f19ae0a46d3dcc6c1fee46235fb6ad201456120502b603fe4fb7cee14ac"
+    },
+    "progs/demon_old.mdl": {
+     "bytes": 272684,
+     "sha256": "538d5d01833d6910d4400f8795be582c3427748eb2a162fcec2c17d6707c57e5"
+    },
+    "progs/dog_alk.mdl": {
+     "bytes": 199324,
+     "sha256": "a16e350fcd247908c75ecd0c93e94d3b700b67bb0f66dd45d665d171a55d42b6"
+    },
+    "progs/dread.mdl": {
+     "bytes": 415072,
+     "sha256": "dcea570331c5cf4348c40451c6242bf35ecaaea2a348f12254a13c1b76b13d7c"
+    },
+    "progs/drip.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17284,
+     "sha256": "444692074359310be0520b1caa057ae2e084df826f7ecc9bcb0d258ea1d80373"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35988,
+     "sha256": "91aa79805577466147bd4811614b0387b3635aba8383fc2e16b178d7b63ebdf1"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42436,
+     "sha256": "93839bd6f50323f7ac5ae46037de0c6a10a533374f714229dd511ee62b88ca3c"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bcc6396dc638003480dba8c36cafaf32df2cfcf49bd460b001d0d74a164f9011"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/enf_gun.mdl": {
+     "bytes": 58684,
+     "sha256": "39ef1788b39a15f86c8d54b81c43f4126e8361ff80d386c44358f17ddc93769f"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 450424,
+     "sha256": "ecf603c4ebc56438e96d1706a451af8bbe9b090db9c48e38e758ec630a393570"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "ddcf759804fffd97e62c55f67f962e24e8cd646fd982215ac8aefd3e49f67660"
+    },
+    "progs/enforcer_alk.mdl": {
+     "bytes": 333860,
+     "sha256": "85fb5cb9eb1435da65ce0aa6940241b7b4b5fa13e7444713a75c6ec301cc8b97"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish_small.mdl": {
+     "bytes": 221279,
+     "sha256": "34b883e3bf73a520f301cced68629e0d95e88f96c03a23230f12d02aa49c247c"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flag2.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flagbig.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 451032,
+     "sha256": "1a311e7e74f9a67c9f7468252aedc8c19804f65375d229e90afbec2f93849823"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/fromitz_still.mdl": {
+     "bytes": 6964,
+     "sha256": "63204597e828e001c957e9316878995e161da0502764276b90285accadf6a222"
+    },
+    "progs/g_axe_alk.mdl": {
+     "bytes": 50460,
+     "sha256": "92988e970870f2b977f7490d2ea4ee040d338fa4bdc470e8d68f2e5a856a7a28"
+    },
+    "progs/g_axe_alk2.mdl": {
+     "bytes": 50460,
+     "sha256": "e448b2a7540ba959453592b2472d0ae498142a77242c91fd5991ca23a7973f4a"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_mine.mdl": {
+     "bytes": 37780,
+     "sha256": "5057c7736e8c722270c781e47584972f42e7ebdd5860596403a9ce7688d0b5cc"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "15f390e39e02c8524e575ca8fadf63187b641c58210ee9587b13a0ca94c29cc2"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 199076,
+     "sha256": "7ddca6fb95082d0cc7ffe5aa3ba896ea987a80b1bd5867db97b2a84b9d8da9f6"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "8b05b8ca87ea867c2a2397d238311fda2441f5c0e1cde130ba487b0dbd17a8e5"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_arach.mdl": {
+     "bytes": 60292,
+     "sha256": "daca6412383bec28809cee42c4ebf01085cf83ed6ff289114ba0f842b4005251"
+    },
+    "progs/h_bams.mdl": {
+     "bytes": 37316,
+     "sha256": "58c4644a2ed3e5f10741dff2ad1a8bb161f7eb205ba3fd8c5fc9b7e4ffc571dc"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_cyberscrag.mdl": {
+     "bytes": 62036,
+     "sha256": "df7d6bccc97bd5c184d9d6160005b370175aacc16a34bd06ab14c7d69ff60419"
+    },
+    "progs/h_demon_alk.mdl": {
+     "bytes": 72644,
+     "sha256": "22a9e01cdccb2e274c63c277e6dcd61986fa7556426ee3562fe11af2babea289"
+    },
+    "progs/h_dog_alk.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_mutant.mdl": {
+     "bytes": 110240,
+     "sha256": "f1f9c665b659a8c145550605ef9abddf27779d0917c897baa344d65673770875"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/h_sabrkn.mdl": {
+     "bytes": 11828,
+     "sha256": "050fcc93189211aba943674a326ddd898dc980b83fb551ee11fec3dd39973483"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shams_alk.mdl": {
+     "bytes": 37268,
+     "sha256": "9fcace6cfb38473763a5cf96007ccc5e0ec4786352d4d1063410d63157298b45"
+    },
+    "progs/h_torm.mdl": {
+     "bytes": 62056,
+     "sha256": "db0ddda0c4d2283cd3c58eb45397cfb57095acba1eb6dd38571ca23ebffe9946"
+    },
+    "progs/h_wizard_alk.mdl": {
+     "bytes": 14948,
+     "sha256": "5f6c27ba255b87718d993b29cff526bd025c0e7a4991722a96fe3c0f98d83408"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hknight_old.mdl": {
+     "bytes": 418144,
+     "sha256": "40bd5757499a2bf7e6f60a78b0039665107c9603c2557f6bc73208e080111464"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 37012,
+     "sha256": "e3c6cbabfe6c6723101f2e59f50fc99ee0e360571c95885d2d56c85eefade15d"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/jumpblue.mdl": {
+     "bytes": 37428,
+     "sha256": "be4e85e5fc643e91377d69794b997ad4dc927ae3866dfef5288d704dbc0f16d7"
+    },
+    "progs/jumpgold.mdl": {
+     "bytes": 37428,
+     "sha256": "4c543d82c88009cab7fcf6230feea0a21518a98f430636194fdbf5c1e526cc13"
+    },
+    "progs/k_laserspike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/kamikaze_grunt_small.mdl": {
+     "bytes": 203376,
+     "sha256": "550aaee63a82db7de25eb3329c368a8bf98ad0aee8af169ee41a857d9087c0f1"
+    },
+    "progs/knight_old.mdl": {
+     "bytes": 208068,
+     "sha256": "5cca43e29392051c9ba95838a58cc1038560411e6c0d2aff61867a428b119e2a"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "63220c0ebb6e266576cb3107a44be16bda10d69fa524d0462514edff9d80328c"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "29bc55efafbea3e15a385598750ba4d9242d0a87803a6bc3430ed772ec1785c3"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "f1e799e7feac3c340676bb60f6cc7a2a7d1e121b196d1f6d0e23edea3a614ed6"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "92370f5b196dc00460d73697975d14279ef659c87c7fc1613b9cbfb68e6c299c"
+    },
+    "progs/m_p_key.mdl": {
+     "bytes": 13428,
+     "sha256": "581a23ac3e2bf0960a7a8b1c4693efd1913d9d17a1f4fa405a1b8c6d89105f91"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "4c5db792da6876f935f8a98a74f51708d52ca03f04975f28518051494660bf65"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "781837a3557c1a8b89c15fa8f477989cb4b77d8cff09c8c13d071090a4df9c1b"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "2feb7ce08070b314d163cbc7f2e2eae0986400c482f752d305ddba268639b3d8"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "04f7fc8b0c2be7ea93021819770145eaf828b2313c4fc591a5f2aa783ca97e61"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 8372,
+     "sha256": "9b6a8f7a49fb7a1f5d4d409b708663c579d433e978d898b9bdf00291a59b4e6c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "fa5d7a5e2410ac7faa5dd0a8e17873c972c6e5cfeacc94118f22db1b4b17477c"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/mutant.mdl": {
+     "bytes": 352720,
+     "sha256": "262ffca22e0c7308950076c2789436a891399862ea25afbd06040158ec9f7984"
+    },
+    "progs/mvore_bomb.mdl": {
+     "bytes": 12653,
+     "sha256": "dd54f975b770db899ef71174d8b05cd98af99739e9506fc4eb354ee8d7e820b8"
+    },
+    "progs/nephrenka.mdl": {
+     "bytes": 807192,
+     "sha256": "e1efdf4467614012164148e6af70c5a3076438e990fc1f48bc4fafb49f681340"
+    },
+    "progs/nephrenka_shield.mdl": {
+     "bytes": 807192,
+     "sha256": "5c7a3957118c7c7370ba1b7ef8fe00b97813bff193dda6ed2c7029e72d8c1c70"
+    },
+    "progs/nsoldier_alk.mdl": {
+     "bytes": 563108,
+     "sha256": "6071d7cecf231f0a83f2e1c7df533b4a32beb6e75969d17703446a67d011695a"
+    },
+    "progs/ogr_gun.mdl": {
+     "bytes": 52452,
+     "sha256": "eaa6e0fe01255450d578f151c06c5aeb6a9cd5ed90edbbe4f52d305069ed6825"
+    },
+    "progs/ogre_alk.mdl": {
+     "bytes": 315696,
+     "sha256": "31e9986373dc1a8cba00e09ba9b0278cf766bbd074524a891ed22329f697d643"
+    },
+    "progs/ogre_old.mdl": {
+     "bytes": 315696,
+     "sha256": "53317e9b684701e7722bea342af1a6dba5dd31e72cdbcfa5b097382516d1c6a3"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 487968,
+     "sha256": "ae0abff3ea3fc7ca8c7f80c5d8825553795a1c1ebb80127d46fa52b20905abc4"
+    },
+    "progs/ogrem.mdl": {
+     "bytes": 378296,
+     "sha256": "2bb999bf580d16fb9ee4246dea7897236d6d118232c78a6168f641dc32778fb5"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/pellet_tracer_short.mdl": {
+     "bytes": 58148,
+     "sha256": "5b24b67ce9d9b2634d9a0f31319a977e1e3ec6352d491367941a0e5bf2ae10ff"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/probegren_body.mdl": {
+     "bytes": 139044,
+     "sha256": "da0ddf337c3e2515688f2b143adf55d4ecbbfa32955a78aea01ed16e067b0065"
+    },
+    "progs/probegren_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "4f292b6f157d226e763ff28dad682ce95cfb8a3a21b4badf0ca48db4900cdd70"
+    },
+    "progs/probegren_gib1.mdl": {
+     "bytes": 63788,
+     "sha256": "0efb081efa87c9db990d984f9974f10078890a51894a3e0a6fbe76cc3c4cb5a7"
+    },
+    "progs/probegren_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "7843ddefa22b7d5beb37f889c606c6361792508c2bea202f3dadf9f3ffce73de"
+    },
+    "progs/probegren_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "7baac250aa8c27ef3158de59b536ebf59509e39b1f7bf6be1c24fd5b1e29cae0"
+    },
+    "progs/probelasr_body.mdl": {
+     "bytes": 84296,
+     "sha256": "ac545d0f545488628c864df6e464d10fbd51cb41a2cb76c46dd91233ecd11a6f"
+    },
+    "progs/probelasr_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "cec7b847c9b05f2653113454348799b9bf09c2a74c8e1760cca0ff52c1dfc18c"
+    },
+    "progs/probelasr_gib1.mdl": {
+     "bytes": 58700,
+     "sha256": "ae9f298abc0bb1d09cea3c04bf02216b0a1c3749f8c8a822d973b4c2091cd649"
+    },
+    "progs/probelasr_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "07d6defee5ce4e747daf8b397a5d207a1a42e3c3acffbdfc18d6720c88ec635c"
+    },
+    "progs/probelasr_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "8b8f376afa56e7a9f311e58a076f1fa3a52c88064887a8e0960fdb6daaf5265e"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12653,
+     "sha256": "162632bc16838f66f29e0b788845a6421b7fce708003e9fa6f4eb8ae7aa8e5be"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/rail.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 200152,
+     "sha256": "a564fba381d24e3084bc9aa0a026381c83e6b889632c8bebdf69c08c8a6bb9f2"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "f65ba83d82e90808af589ded17378f1baf37f105fa14f2b157227ee22583d25d"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 288,
+     "sha256": "6ff2797f9dc4e66f2113475a5f3e0e96f23dacbddd18fe47c8b5e12e712f0e75"
+    },
+    "progs/s_bullet_new.spr": {
+     "bytes": 708,
+     "sha256": "a07fa61f4a838ac9ad8ec85ae525d70fb934d383effd1948c0775497be713043"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "b3f1971bd28f96c623c5712e2a47f54f16c99a50d460a944cdcdf29e6eb03963"
+    },
+    "progs/s_exp_small_2.spr": {
+     "bytes": 201720,
+     "sha256": "f7fdba9e2b9b5d318cdff33a06fad4e91e46ba3a241fe7ced4bfbcf0bcb0e873"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_plasma_new.spr": {
+     "bytes": 13980,
+     "sha256": "5474060e55af3c462d0ef7aad043f331c1f5b642915d906c1785bb94595cc68c"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 2820,
+     "sha256": "ea66402d248232b0b6a77bffe024d4a62881be47becf37acb42328661b7f23ef"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shalrath_newer.mdl": {
+     "bytes": 228496,
+     "sha256": "93601de7ff47f552ac9d441ddf1faf312417ca914de99529b17bdf7522e7478c"
+    },
+    "progs/shalrath_old.mdl": {
+     "bytes": 211576,
+     "sha256": "409cda15df7b271bd95a895f058a521d43eca63f37c7ac9df175e5b478229bb9"
+    },
+    "progs/shambler_alk.mdl": {
+     "bytes": 502148,
+     "sha256": "bcf685fcd1f4062dc382924d39eae073fc4d44cd2dcb5bc4ca3797fe0b342b71"
+    },
+    "progs/shard.mdl": {
+     "bytes": 10132,
+     "sha256": "0219a0f08bdc1f604ebe1ea2243cd1b27a2b1ab85bedba3a11298f2d22e9b38c"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "662d6a7cd68bca7a9c5e88838d190de6a501252a14b6994a191d0bc91f1f331c"
+    },
+    "progs/sknight.mdl": {
+     "bytes": 460932,
+     "sha256": "9213f6898a60cdc20a7a144c61c13f8d64f1432382dca44b636524edf737dac8"
+    },
+    "progs/soldier_alk.mdl": {
+     "bytes": 359276,
+     "sha256": "623374e5a553c3d886738c9cc0b22c0b3f3435b3dc1b3f473079a1dd1661fc8a"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spiderbot.mdl": {
+     "bytes": 82476,
+     "sha256": "e85556a194664a5f69e70b42aa863d9e67689a418a3afa51e50816174a6fe8ac"
+    },
+    "progs/spiderbot_gib.mdl": {
+     "bytes": 19444,
+     "sha256": "96ee732ac1199a89c675880700c24e1f09521c35ad478f73aaf4278a398454f6"
+    },
+    "progs/spike.mdl": {
+     "bytes": 2820,
+     "sha256": "783d711b408498dbb34581c9a0ae74ed325dc5c68fa67873745b02c8a926a201"
+    },
+    "progs/spike_old.mdl": {
+     "bytes": 1684,
+     "sha256": "5e3be5dff13ec94951aacbd4a453dcbd9c2aebe7e4e6bded2dd70d49d1ddd695"
+    },
+    "progs/supbkpack.mdl": {
+     "bytes": 44408,
+     "sha256": "781c6b5f424fb58e06b2a84b1fb7e980778decde6b3ed257e224db0b1f250173"
+    },
+    "progs/torm_largeshot.mdl": {
+     "bytes": 37852,
+     "sha256": "ce3a87be213e39b48bc71a6fbf5e1fe9e3f5209901ca45801f27d8f297e04a01"
+    },
+    "progs/tormentor.mdl": {
+     "bytes": 461080,
+     "sha256": "df302dea113f54df908f97c26de844d1235004c08aefcf5c349f3af4b0957d41"
+    },
+    "progs/trifecta.mdl": {
+     "bytes": 25460,
+     "sha256": "2c9196af0806c48354f5522a8b7f6fa57e6390f8dfb51718fb71b8a2d4d7447a"
+    },
+    "progs/trifecta_big.mdl": {
+     "bytes": 25460,
+     "sha256": "9633a10c7c20f77b9202befad3cb363aefe710b166e581f80967ad94b5c6b6eb"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/v_alkaxe20fps.mdl": {
+     "bytes": 96428,
+     "sha256": "4405242db772d86c66f1012b140ba409bee86682fa5f4a6ca12c3e6f94eb9fcc"
+    },
+    "progs/v_axe_alk.mdl": {
+     "bytes": 55820,
+     "sha256": "80ad34cf2612f8fa9121f2be0ada92c1e05613ae2b35b2a1be25a4c694dd2147"
+    },
+    "progs/v_laserg40fps.mdl": {
+     "bytes": 142580,
+     "sha256": "b897ecb5868e3125597d51f970075af04782cba47ed8a42d7b17775dff01f536"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_mine_40fps.mdl": {
+     "bytes": 332920,
+     "sha256": "0039956e96a804229359aaf082b9cf66515d52360867b86c3dca884d19caf8b4"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail3.mdl": {
+     "bytes": 124944,
+     "sha256": "19045e9a5154299b68377744ad946fc3e7f2bd290497c8291a2247ed8cc572ad"
+    },
+    "progs/v_nail_alk40fps.mdl": {
+     "bytes": 44692,
+     "sha256": "402b3dc06f1e5e756cfd50cab17cca49e17e261994c5007cfd46c466a08d3dad"
+    },
+    "progs/v_nephrenka.mdl": {
+     "bytes": 13684,
+     "sha256": "a6b22faa92528d6341547677c04b058c3374e2a1b3499ae73861418746c2b1ba"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 260692,
+     "sha256": "0982368440a5d20d65ec511207590c2bfb63e9a60376a5d753b209f2b047c58b"
+    },
+    "progs/v_rock2_40fps.mdl": {
+     "bytes": 139668,
+     "sha256": "89257b7580ac3f48fc775f121eef3508c326eba1369e6aacae83144f8fdfca15"
+    },
+    "progs/v_rock_20fps.mdl": {
+     "bytes": 39556,
+     "sha256": "ebdd6245e1ff65bd95eaed7fa189ac87b51818408f091a32de3f4a477b90f2f8"
+    },
+    "progs/v_rock_40fps.mdl": {
+     "bytes": 43828,
+     "sha256": "f3c32a1c37d4fc3115a8da00ba9507cdd508a98f65e2ddccbcbdc8a0ba0bf2ea"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 326464,
+     "sha256": "dd389cc337d8b7675d9a7b983fd9f53f0c59d597a9759367bd1e1beba375eaaa"
+    },
+    "progs/v_shot2_40fps.mdl": {
+     "bytes": 29076,
+     "sha256": "37ae91c018183faef847aad217da537c97b5a2430ab27a860388bffc1f4514f6"
+    },
+    "progs/v_shot40fps.mdl": {
+     "bytes": 29252,
+     "sha256": "87a47e2debbc27fd6c18a8a38a9a373e7b73ba707458e6346f069c1572df47b4"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_p_key.mdl": {
+     "bytes": 10580,
+     "sha256": "fb3db38e23feda2ca9a8ee1400bdd0b452332f07bf9455db3eac0e52af1e3c22"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/wizard_alk.mdl": {
+     "bytes": 158508,
+     "sha256": "aab430eb2dc0f5c50ca7b4492a7ccc427f2a12011f54ece1b81d4beb66acb4a9"
+    },
+    "progs/zombie2.mdl": {
+     "bytes": 130148,
+     "sha256": "a06c8cff768f0e5491e2a5a0d22671b525d841df7081036ab2d63507eb17881c"
+    },
+    "quake.rc": {
+     "bytes": 2052,
+     "sha256": "b791b9736f5ee57b06dc0bcdc156b13dda9144bb0a972ee5b5069de73c10e55d"
+    },
+    "sound/arachnofloyd/death1.wav": {
+     "bytes": 119460,
+     "sha256": "d16c7ff30e9df62fbcda102befbd61fe234532f6aef30d0b34c25330679682bc"
+    },
+    "sound/arachnofloyd/death2.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/arachnofloyd/idle1.wav": {
+     "bytes": 34254,
+     "sha256": "35d6991a10637251ec0d6b830f7f57f394e4eed06e7a9dced86f0128ba5bc49e"
+    },
+    "sound/arachnofloyd/idle2.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/arachnofloyd/leap.wav": {
+     "bytes": 70884,
+     "sha256": "f47323f618db14755c57e9e25213267dcffc501fbaa9a201176ab99db6cda928"
+    },
+    "sound/arachnofloyd/pain1.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/arachnofloyd/pain2.wav": {
+     "bytes": 15906,
+     "sha256": "9c4bdc81c73787cb67677e0021b71d9e24734ef3ce272d9020dc6611a1d87842"
+    },
+    "sound/arachnofloyd/sight.wav": {
+     "bytes": 48620,
+     "sha256": "97a055dbb8e5935190348b2c2d50c6d99ab35c29f3ebcd0f66d6263bdb5485e4"
+    },
+    "sound/arachnofloyd/step1.wav": {
+     "bytes": 74932,
+     "sha256": "a8744a3e50dccf9ee391da2f381c2ecf6701a76441406929ee4581c7717b880f"
+    },
+    "sound/arachnofloyd/step2.wav": {
+     "bytes": 34478,
+     "sha256": "22ce43aa18537f7b04e31263a46dd02e181d538fdf5918d55f8ce0acbb930676"
+    },
+    "sound/arachnofloyd/whirr1.wav": {
+     "bytes": 19762,
+     "sha256": "9e2029071248e6d45f1b0d518983bad5bc5f841cda6bcfba09486e111add10de"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axegrunt/axgdeath.wav": {
+     "bytes": 20214,
+     "sha256": "e5ed762afcc516058acc1b3884b4d08e67fd36e3a5bacf711d3504363bf8136e"
+    },
+    "sound/axegrunt/axgpain.wav": {
+     "bytes": 12636,
+     "sha256": "4699951fa58fdf15ab819b13d70904fc9a1a86a4db02193d621dfad3878d17bf"
+    },
+    "sound/axegrunt/axgsight.wav": {
+     "bytes": 17712,
+     "sha256": "e7b23208831c1d83793ba06f3b8855430c92017600cd8315341afbcb6ec6c8f0"
+    },
+    "sound/bambler/melee1.wav": {
+     "bytes": 4175,
+     "sha256": "4e0e2567b9d64b3ff86b33d95fa0158bf72372aeb4968a0c2489df942f9f7c4d"
+    },
+    "sound/bambler/melee2.wav": {
+     "bytes": 5283,
+     "sha256": "4bb91991bccfc33576eff19037e12666e9825348272d3dca40199e208bc00700"
+    },
+    "sound/bambler/sdeath.wav": {
+     "bytes": 14048,
+     "sha256": "c5253af82d203e75d132a00bbb555de055d2e356106d460f34cb8c9a2ee5e643"
+    },
+    "sound/bambler/shurt2.wav": {
+     "bytes": 3736,
+     "sha256": "0f1a51e0ff72f23a4de7684d4408344b7b7bd2cb805609168d2f2459e1b8660d"
+    },
+    "sound/bambler/sidle.wav": {
+     "bytes": 4907,
+     "sha256": "ea2232ba791e306cc86f58303413d8f3fbc7dd38091281698f4d846b6cafa483"
+    },
+    "sound/bambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/bambler/ssight.wav": {
+     "bytes": 11376,
+     "sha256": "de766aa056ca5f7dc6d179e6a220ef906ceacc0341b5cb3d91a4d0e75ff55338"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/cyberscrag/fall1.wav": {
+     "bytes": 23396,
+     "sha256": "162fc0be1cd0eadfc93c35f1e1ba9b8dfc7e8df8ee53afb2a14db73e69f20ce8"
+    },
+    "sound/cyberscrag/hit.wav": {
+     "bytes": 22334,
+     "sha256": "a16ef33d94d56fb6984b2a3d06104a3cc292bdb38ec6ee22c8b10457b2cb415f"
+    },
+    "sound/cyberscrag/wattack.wav": {
+     "bytes": 25912,
+     "sha256": "6bed724b7ef9bdd480448396ed4498c75f848bf2a1e6d2879cb2b2484cdd1a7b"
+    },
+    "sound/cyberscrag/wdeath.wav": {
+     "bytes": 20684,
+     "sha256": "24602233cca209122250ba7c284933992aa2393795ea5c528a57b9986e2fc319"
+    },
+    "sound/cyberscrag/widle1.wav": {
+     "bytes": 13465,
+     "sha256": "8902628d2201eda9396c0dc134ebda8b8d5c37dabddcd286f8387aadc6532750"
+    },
+    "sound/cyberscrag/widle2.wav": {
+     "bytes": 23094,
+     "sha256": "76af020e5c25f40ab3020bbd065a9b83b9b0a51120d47d137a7abff4eb43e193"
+    },
+    "sound/cyberscrag/wpain.wav": {
+     "bytes": 8687,
+     "sha256": "af2e8589d381e634f607048ce71200df832c9e3a32147891b5bdd2efe2ff5bf0"
+    },
+    "sound/cyberscrag/wsight.wav": {
+     "bytes": 13079,
+     "sha256": "2f9178f6515eb4cd518b418441c40d1376aeaf6f42f7791533f5f4b6da87fd68"
+    },
+    "sound/doors/alka_doorlocked.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/q2door1.wav": {
+     "bytes": 30572,
+     "sha256": "3f05bddf76379933970c532656b6350bc53820319ce1cb9d4ea9288210427eee"
+    },
+    "sound/doors/q2door2.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/dread/dread_death.wav": {
+     "bytes": 49692,
+     "sha256": "22000ff613ff52eab0605418681affaf7aeef4acc420d3dddd50a9031ac1ca38"
+    },
+    "sound/dread/dread_pain1.wav": {
+     "bytes": 29220,
+     "sha256": "67e443f78043cb9fc4213bbfbc3cd847785a66849fb7b36dd6467494487e0aec"
+    },
+    "sound/dread/dread_pain2.wav": {
+     "bytes": 23380,
+     "sha256": "914fffe3ad6c02fb78be873ee96405a40df22cd321beee2d673d0b6ebbafcde4"
+    },
+    "sound/dread/dread_sight.wav": {
+     "bytes": 70792,
+     "sha256": "50449a772b2ac778b810a69de58cb63c8bbdea529091720a41a1052b7196632e"
+    },
+    "sound/dread/dread_sight2.wav": {
+     "bytes": 58420,
+     "sha256": "f7952137b648f6376a1ba4e968679abb17fc648ede87bb0dd32f633271ad80ee"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 110256,
+     "sha256": "895cfb57c0d27369530fd5e9b29abd491a989ad0a63ddb00f05dd9e4777a5cdb"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/frogman/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 32638,
+     "sha256": "3cf3933f34c7baef52df54d5b03db40424e9f7ee72e5aa5a4dba489d71be2af7"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 27662,
+     "sha256": "ec38e73fd1ffc33cd25aa065e5f5897c21a494e380763ff80b6be482689b5e33"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 44186,
+     "sha256": "7600cd32fe980646fddcf5a9077d8d43df1bca1f2ed05bd92ce8cca273ad6636"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 132344,
+     "sha256": "9247347179344c541a627bc8ff74e5ce43744e47f5f3a02181402791257b675a"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 33120,
+     "sha256": "9fbfa3f46a27f850615fb4ea4cd760f6ee5817ddad856b44ec51a84138ec91dc"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 54336,
+     "sha256": "1e6a0c92fa9902238e01b4e8a1ff5b9fbe1a37d71cdff7e31f97c0f630d76a20"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/armor_denied.wav": {
+     "bytes": 15854,
+     "sha256": "2ec14677f483d1a1b869af64cc30fb0dbd90a640fc071fdf2ae493d27cd746e1"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/items/shard_pickup.wav": {
+     "bytes": 18260,
+     "sha256": "388923a63b48720647b9e0f2862c35bb1d5cad2e162ace343845b3fe36b48af4"
+    },
+    "sound/items/trifecta.wav": {
+     "bytes": 16412,
+     "sha256": "00baad51adaa3f5d6664e85ae5442221db6818bfd85124c164324d22f6723ab2"
+    },
+    "sound/items/trifecta2.wav": {
+     "bytes": 32778,
+     "sha256": "f742a9cee4a53ef52fce55d5e9ddaae9c6b20d2127e16c0def6cd11b3d2d6380"
+    },
+    "sound/items/trifecta3.wav": {
+     "bytes": 10728,
+     "sha256": "a78bfc9fa4fbf0c3c1e85bee273ee053598989a09146bd29e97dda811c49a473"
+    },
+    "sound/lieut/alert.wav": {
+     "bytes": 8700,
+     "sha256": "7ebbe83ae1b5d159c9f0a0ae5f3dea126650ed5d6f98a22d1512dcfcb19a23ca"
+    },
+    "sound/lieut/objective.wav": {
+     "bytes": 10052,
+     "sha256": "aa7d6726a458eaa48bf2e20446c57360b82ac23bfbd06bad7b6e01ae95ca8b0d"
+    },
+    "sound/lieut/target.wav": {
+     "bytes": 6754,
+     "sha256": "eebd50c75585894c7d5305f6c066aaef1efaca9a59e27b80d03e8ae4d69caa69"
+    },
+    "sound/lieut/you.wav": {
+     "bytes": 7126,
+     "sha256": "6bfb031b0d69b8ae4ef2e9b201da43c523ae88de344907648d4064e07477ee1c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/mechavore/attack.wav": {
+     "bytes": 66460,
+     "sha256": "fc2a8b0e2a72aebe2858b8337d5ef0638e3e04d5b60e9a62d46ac124072705f9"
+    },
+    "sound/mechavore/death.wav": {
+     "bytes": 37504,
+     "sha256": "bbdf8369941f8c2ab302fe3a55de3bf04e1d28e32a575ffd3c24009d76bebc8f"
+    },
+    "sound/mechavore/idle.wav": {
+     "bytes": 64972,
+     "sha256": "5cd8253f1abe5baf08f1852d12393ca820c34fc0f2febf6c1c8f9d4c3326b2c5"
+    },
+    "sound/mechavore/mv_attack.wav": {
+     "bytes": 67046,
+     "sha256": "af133ede9ab5627f3ea75b12716653b11dd813982cab4a6aad0792371ba58006"
+    },
+    "sound/mechavore/mv_death_a.wav": {
+     "bytes": 125364,
+     "sha256": "7a51ba5587b4c8ccd4bd0e93b105f277f4f093a1cd90f684afb33cf0bbfc812e"
+    },
+    "sound/mechavore/mv_idle_a.wav": {
+     "bytes": 61484,
+     "sha256": "463f1bd23c4bf5d2953ce2f7ee980c9fb28725a0bdc92bc1f03dab8e139a2f14"
+    },
+    "sound/mechavore/mv_pain2_a.wav": {
+     "bytes": 41004,
+     "sha256": "18e27023c1ea7ce306f49559a8f303f62fcc206f05f94878bd1898e204972ebd"
+    },
+    "sound/mechavore/mv_pain_a.wav": {
+     "bytes": 49196,
+     "sha256": "7e2a98060c2ebe14313c831e8d3d410aacd70d7bffa9ef45b0f98845cebdfab1"
+    },
+    "sound/mechavore/mv_sight_b.wav": {
+     "bytes": 57388,
+     "sha256": "2212706950e66000184352238f479d659ea37062186b595e6834bb4d1d910c7f"
+    },
+    "sound/mechavore/pain.wav": {
+     "bytes": 36444,
+     "sha256": "9f9368fdd53aec80fd43a6d3b6680e04aae72685d1cfbdf49d55dc1070e8c546"
+    },
+    "sound/mechavore/sight.wav": {
+     "bytes": 116312,
+     "sha256": "112613b44d88046653b29f21aa5fced5d4b5bfcaff037dfa5f246729e45a6968"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/conc_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/misc/door_closed.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/misc/ebell.wav": {
+     "bytes": 15220,
+     "sha256": "1693337ed8873f1159e56c2925afaa210f5c28bee4e2c42d27e29bee8e06cb5f"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/jumppad.wav": {
+     "bytes": 31485,
+     "sha256": "cfc06af995406d853cae30df8db02c340bf7c775f955f5a02de60dc20c66fc0f"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 4054,
+     "sha256": "b9c44f73c8bdbc900af4f06600e0d6456a040b296612b7d0fe53391285976a44"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 4098,
+     "sha256": "4fad66341514c9aa2b31b4c2fde7563369090da9b0b3a51e08bca3100f2ec282"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5054,
+     "sha256": "d158ddc35360bc43934b7a8a9b7cc830f7510e6bb3a640813157822b27b5217a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 9726,
+     "sha256": "73b74099c8cb43ab2fb09b28b72ddd9f73f2d2a4f8a00a8e835490f366680c92"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 3226,
+     "sha256": "48551cc717e5011df78a38c6a71bb001e4f62a1858a3952311499653ff423a07"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 5802,
+     "sha256": "751050f97456a0c07e88a249d40dde96c2d14640e21670ccdde983502998dbba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/singledrip1.wav": {
+     "bytes": 26546,
+     "sha256": "b9193092eaa02003c7ea409663dc1213f0a18a120471a76d298ce847448059b6"
+    },
+    "sound/misc/singledrip2.wav": {
+     "bytes": 25478,
+     "sha256": "562ac78cd1d84805723e3bb24f66c60197d03bab081d7ee8402bf2b59bc7bf0c"
+    },
+    "sound/misc/singledrip3.wav": {
+     "bytes": 44558,
+     "sha256": "55ae1b970143af2553b845503363d94aa917a1cdb8aa1e48edec7869660007c3"
+    },
+    "sound/misc/singledrip4.wav": {
+     "bytes": 45492,
+     "sha256": "db0126239cf71ce69f6c06eb5c5418889b96e52e6741f6b172a146887e6815ef"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/misc/wood_impact.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/mutant/mutatck1.wav": {
+     "bytes": 6116,
+     "sha256": "410f926534f21705e78a804ce048b0c15e62fe0c68a45aae1b3741fb227551f7"
+    },
+    "sound/mutant/mutatck2.wav": {
+     "bytes": 18260,
+     "sha256": "66009d09adf71f10117c74f5004c995fd48362b2f4fcfaaa3bc2da01e66d115f"
+    },
+    "sound/mutant/mutatck3.wav": {
+     "bytes": 28840,
+     "sha256": "2dd8a615ca2be248c8370d7480f5a8ca9375d31e6af41bba603df660d31883a1"
+    },
+    "sound/mutant/mutdeth1.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/mutant/mutidle1.wav": {
+     "bytes": 81004,
+     "sha256": "8c7e8ad544d7e2470bd61d88c5cd8be1a0eb66f57aaf113f82d990ee00450073"
+    },
+    "sound/mutant/mutpain1.wav": {
+     "bytes": 56716,
+     "sha256": "49ff5f97fedc87c1ac06dc43d4ff0a0fd09fb481354b6373d607bfabc9a57a6a"
+    },
+    "sound/mutant/mutpain2.wav": {
+     "bytes": 58740,
+     "sha256": "b79f1cce60226daa3e3ca8c134da968d54ad51abd9c37ffebdf3d46c5d9f91c6"
+    },
+    "sound/mutant/mutsght1.wav": {
+     "bytes": 107316,
+     "sha256": "7e15e392edc3f2d5ae9e3bde3dfe65595a85728022245f74b81f072d75dce798"
+    },
+    "sound/mutant/mutsrch1.wav": {
+     "bytes": 101244,
+     "sha256": "44484ef4c189511fb0a8d0f2bea83e443e1f1bd51cef04f518f3820e58e88a69"
+    },
+    "sound/mutant/step1.wav": {
+     "bytes": 8140,
+     "sha256": "0d9af35156c84213ac7ffbde54d0f2518fe9d39bba4edc48c94e71bed4f7ec4d"
+    },
+    "sound/mutant/step2.wav": {
+     "bytes": 14212,
+     "sha256": "f7c81df1bff56c8aeb49891fa822c37ddcb019e97a654738a9fb8ee351d19eac"
+    },
+    "sound/mutant/step3.wav": {
+     "bytes": 4092,
+     "sha256": "89856afec31f800219c45253514d0fdf5b5bd800c32f87ba74dd0c21df181550"
+    },
+    "sound/mutant/thud1.wav": {
+     "bytes": 32428,
+     "sha256": "20ed5f20729a068801d06904365e46c9d692dec835710a9b8090d0a1956d6919"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    },
+    "sound/ogre/rogre_alert.wav": {
+     "bytes": 71728,
+     "sha256": "4f3e921b6ee236289660f7ca2ee8a4689e719423266d26a3f8b91ae29d02c6a5"
+    },
+    "sound/ogre/rogre_idle1.wav": {
+     "bytes": 110330,
+     "sha256": "a07df4a53c9e8de310b9d963bfb9c841c51e502565f39dc543bf1c025edd41d6"
+    },
+    "sound/ogre/rogre_idle2.wav": {
+     "bytes": 79416,
+     "sha256": "862258641dc3c90d2a9e5f9e2a4418eb0037eedf22cde798682a169a84f13a44"
+    },
+    "sound/player/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/player/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/player/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/player/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/player/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/player/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/player/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/rail.wav": {
+     "bytes": 97196,
+     "sha256": "396a85e1e2083f2b1eaae89a3f33a21145a643f3f50419523497719ef8e7598a"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/rider/sight.wav": {
+     "bytes": 26356,
+     "sha256": "40ace6f3beeb920ba1bbdb197f8ece18d312762a71e494726289e16703d75d91"
+    },
+    "sound/rider/step.wav": {
+     "bytes": 40524,
+     "sha256": "a43e24ecbc62d44bce466b1e682ebf64c230e03f4d79449406ce021dc8276a9a"
+    },
+    "sound/rider/thump.wav": {
+     "bytes": 15444,
+     "sha256": "af29f4e8f6debb1223aeb5d840add4ae01cb5e9f6bd9a26efeadff518f34380d"
+    },
+    "sound/scientist/allnominal.wav": {
+     "bytes": 23778,
+     "sha256": "e26f9bb3c24d9a9e0da38395048f6dacffe82d800da49d56378027250393d69a"
+    },
+    "sound/scientist/alright.wav": {
+     "bytes": 9666,
+     "sha256": "372c1aa91e6841bec2441215c894b7d149bdeaef33f907d23bb7eaf637520ce3"
+    },
+    "sound/scientist/asexpected.wav": {
+     "bytes": 15982,
+     "sha256": "306933848b673bd14d7074d59e45a8c97bc00a2897601509e52e5835e2ffc997"
+    },
+    "sound/scientist/c1a0_sci_crit2a.wav": {
+     "bytes": 28364,
+     "sha256": "f972684c74eeb51872873cc2b7053448c6cdd716b8c3535929fdbcc508d62ef5"
+    },
+    "sound/scientist/c1a0_sci_stall.wav": {
+     "bytes": 13704,
+     "sha256": "541c192ad5e8a68c76706ec17b3deceafbdc607bfc372ddfd300532f8aa1eaef"
+    },
+    "sound/scientist/cantbeserious.wav": {
+     "bytes": 13236,
+     "sha256": "fc4a8a379f70e33db79a49c667dcd9f1622de29d7b32ef3973c4ffdb5d80ee44"
+    },
+    "sound/scientist/cough.wav": {
+     "bytes": 14878,
+     "sha256": "b4e620259623347a5be3f7eaf3c531e6ea9ef2e97ac42997dd78cfee9327f7bf"
+    },
+    "sound/scientist/sci_die1.wav": {
+     "bytes": 15558,
+     "sha256": "c2306d7f9fa58f99961c347b06ef26305b99ac43ec27b2b222962e1f3a9ccce9"
+    },
+    "sound/scientist/sci_die2.wav": {
+     "bytes": 5402,
+     "sha256": "14deecb570d1e315b772713d54b7250043bb0dd5f3d5538cd0636e39a523c54f"
+    },
+    "sound/scientist/sci_die3.wav": {
+     "bytes": 3104,
+     "sha256": "075cdbc5837d91b61ad7599cdb3abf9323872816f8966c83deab9c0a6e04d7d2"
+    },
+    "sound/scientist/sci_die4.wav": {
+     "bytes": 4024,
+     "sha256": "e6ca0d4f18ac6c1246926646568618057cb70b5cee995c1c2dd69f0179b892ad"
+    },
+    "sound/scientist/sci_dragoff.wav": {
+     "bytes": 8986,
+     "sha256": "0c6a21cd5edf01e495e1258e9a76c05d62c0e3cd697e787fd43fd4bd9126483b"
+    },
+    "sound/scientist/sci_fear13.wav": {
+     "bytes": 4534,
+     "sha256": "dabce7a6c12980f947f7504da264fabb67a804d2e478b7f252ab527fb21a92d0"
+    },
+    "sound/scientist/sci_fear15.wav": {
+     "bytes": 4764,
+     "sha256": "f0d23c680ad138c3cc12da78a3e45cbf3daa47e5da9bc62a1dbb3b27389565a5"
+    },
+    "sound/scientist/sci_fear6.wav": {
+     "bytes": 5588,
+     "sha256": "ff2702b2b9e517b90ea0c2853775a4a95160edfae5af0a7f9208f07624d84281"
+    },
+    "sound/scientist/sci_fear7.wav": {
+     "bytes": 8458,
+     "sha256": "f2a39185c2d39a03b39afd7fe6f942b2f35fd17135ade8ceb4c31968c768aafa"
+    },
+    "sound/scientist/sci_fear8.wav": {
+     "bytes": 5804,
+     "sha256": "4455a29590d5f42ebbf06e600d8ba3f45acfd5000a6b8045891cbecf1d937970"
+    },
+    "sound/scientist/scream01.wav": {
+     "bytes": 14666,
+     "sha256": "b738de99aefbe3a45724914dd6eb79c0f8c219aaf733554a8a5eb94836c22320"
+    },
+    "sound/scientist/scream06.wav": {
+     "bytes": 13938,
+     "sha256": "dee8ac2058635d00458e2e74402d1cfcb5362c64259fc2c4f3b6bba31bdf6337"
+    },
+    "sound/scientist/scream08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/scientist/scream09.wav": {
+     "bytes": 6130,
+     "sha256": "85947649f5fb1491732365849a3025bf5c76c791b395cfdf421fbbd6ec58d351"
+    },
+    "sound/scientist/scream10.wav": {
+     "bytes": 5392,
+     "sha256": "fff4c0735f9c312be7cda848fc2867590437ffe9758fe685e3b4c94678ca1f48"
+    },
+    "sound/scientist/scream14.wav": {
+     "bytes": 4824,
+     "sha256": "dcb7dfb0e307b813476b2e55dceb59d8ae2b9514b1ef02034ea255fa5f086b05"
+    },
+    "sound/scientist/scream15.wav": {
+     "bytes": 3048,
+     "sha256": "37d26fe2d2b8a39d0fec0eceec0ca974ec3dd7fed33bae0d3230a934954105f0"
+    },
+    "sound/scientist/scream16.wav": {
+     "bytes": 2328,
+     "sha256": "4ff04ce8ff07af708c84dacc8df114b68620d47e8e4e4c78dfc4fd33a8a9b98d"
+    },
+    "sound/scientist/scream17.wav": {
+     "bytes": 3836,
+     "sha256": "82fb51224e06db5022adfa58f0b02353c333229ed3312f86dd9ec4f04813c37c"
+    },
+    "sound/scientist/scream18.wav": {
+     "bytes": 3066,
+     "sha256": "bfefcf745ab8d30db11f9113ecf9ba1c5bc6d9b2351c53f3f46d66e03cbea3fe"
+    },
+    "sound/scientist/scream19.wav": {
+     "bytes": 2504,
+     "sha256": "47cc414d201aadb7ba2fe0ce0567ff5360e90fd9de4a167520988513f358ed41"
+    },
+    "sound/scientist/scream20.wav": {
+     "bytes": 21310,
+     "sha256": "124cb45d3d5533572e3cfe4b42bddad2a03dc0d8de1c89a42ea57433432e3a6e"
+    },
+    "sound/scientist/scream22.wav": {
+     "bytes": 15206,
+     "sha256": "6e0a509eb2468466591622e74724c31103b8b60f5d8f29514fb57e9d9d12c9d4"
+    },
+    "sound/scientist/scream23.wav": {
+     "bytes": 21988,
+     "sha256": "8521907e8cecc22e6924d23295a5e8d31333d265ca27a9533b083b68e9da6d12"
+    },
+    "sound/scientist/scream24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/scientist/scream25.wav": {
+     "bytes": 8122,
+     "sha256": "38281749deffb4e567896f71e7bcb75d7b2e253e404a953a5eea6eeb989f156a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/spiderbot/sactiv.wav": {
+     "bytes": 17066,
+     "sha256": "f21587ba9bfd159e48c5b3aa1c6e94eac7157053e4e5699459233fb28c2631c8"
+    },
+    "sound/spiderbot/scharge.wav": {
+     "bytes": 7300,
+     "sha256": "b58064dac4e12bd6685edbfe61417a530cde1e5175336193b2fa7a292aca8ef7"
+    },
+    "sound/spiderbot/swalk.wav": {
+     "bytes": 12636,
+     "sha256": "5534fe1b11fea5406aada214681dba031ec4a01e4b660c405b679131ba07a7cc"
+    },
+    "sound/tormentor/angry1.wav": {
+     "bytes": 88890,
+     "sha256": "60f757f523a9cbb3a57c335bbeda8cedbf990b9d20a5b359e610b712a1344b4b"
+    },
+    "sound/tormentor/angry2.wav": {
+     "bytes": 90912,
+     "sha256": "2f38dddb69cf0df2c1e5b028ca06ea22d979e637afa927919e9a93876dc955d6"
+    },
+    "sound/tormentor/death.wav": {
+     "bytes": 176628,
+     "sha256": "7060ecdadac0b1c9eb3574284444932573e4af13082f01374ed8a4633387bb66"
+    },
+    "sound/tormentor/fire2.wav": {
+     "bytes": 52092,
+     "sha256": "4133a00c7ef157d291d800524a148c188a314eb5ca14246958b8ddfeb0d4fe41"
+    },
+    "sound/tormentor/idle1.wav": {
+     "bytes": 115740,
+     "sha256": "78feebc847dccab66478718b66971870f11246c416e2f2c1e9830c459e4c0347"
+    },
+    "sound/tormentor/idle2.wav": {
+     "bytes": 122218,
+     "sha256": "0270712fe40851bb21d959932b4f8f75bbe8b985e2ff383319059c656ac0ce56"
+    },
+    "sound/tormentor/pain1.wav": {
+     "bytes": 67334,
+     "sha256": "03f255d6ee0d6fb83f2a643491f4cd24d9c5ff86444a51b3cf8b5a0de3d86bbc"
+    },
+    "sound/tormentor/punch_hit.wav": {
+     "bytes": 76614,
+     "sha256": "e524d16b000237615bae3b8fed7b74726823cd4258561196f4641728047aaa26"
+    },
+    "sound/tormentor/punch_swoosh.wav": {
+     "bytes": 33044,
+     "sha256": "d0ef38ef4bf33d0c2f92b22c2a767c4efd66eefaa724df50b394958a7be5a705"
+    },
+    "sound/tormentor/sight.wav": {
+     "bytes": 94334,
+     "sha256": "34a13e6469c5e0ce2f6d18721b0cdd634731b9a9f8910a8bb8b685f63dadfaac"
+    },
+    "sound/tormentor/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/tormentor/sting2.wav": {
+     "bytes": 21674,
+     "sha256": "dd2d40459c7aa9d374efe2f219c34773f390df9f5177a83dbfa5fd638a13c542"
+    },
+    "sound/turret/alarm.wav": {
+     "bytes": 22126,
+     "sha256": "20a8a83d73a55dcc3d8a6fcb79b4ff8ecba0b5887cf3bdcdc96303f069b062ce"
+    },
+    "sound/turret/beep.wav": {
+     "bytes": 22126,
+     "sha256": "89f0e2ba68562cfc3e20272f995777c174c2681cfcf29d2ef337974009b42460"
+    },
+    "sound/turret/deploy.wav": {
+     "bytes": 105260,
+     "sha256": "5bb8c1fa8ffdf22e58ac5fb7a337916a457b9d021661742fcdbbdd7ce188c6dd"
+    },
+    "sound/turret/deploy2.wav": {
+     "bytes": 54208,
+     "sha256": "ec26b9451b67dae2929488687b7b9344a96f7538ab5c4f69e8a85602804dffc2"
+    },
+    "sound/turret/disable.wav": {
+     "bytes": 57180,
+     "sha256": "d8767dcce34c1c7f660f5868c23938da4cc379cb4001b88a10ec1aebbf9e557c"
+    },
+    "sound/turret/idle.wav": {
+     "bytes": 35784,
+     "sha256": "fba6bc2ff517ef95a999e3910c74e3594e054ede298c7b3a5659a2c31565d37c"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/weapons/dsplasma2.wav": {
+     "bytes": 45596,
+     "sha256": "87a1b465c16610b012abe83da7851993f9dd756cc764abca0221d31a09aba156"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 43820,
+     "sha256": "32082cd1d44903409e97de782e5d9295272840e13280665a0ef3ff862b187f0f"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 47570,
+     "sha256": "0dd8defb8ecfb1ea72e6ac70ab182573775812e2d7990dd2897d02d3c38464f5"
+    },
+    "sound/weapons/spindn_click.wav": {
+     "bytes": 9986,
+     "sha256": "b84866cddb7e61eea9ca49208d427c2289d63e6e3e2f59d4d51e302573079bc7"
+    },
+    "sound/zombie2/attack1.wav": {
+     "bytes": 22914,
+     "sha256": "da5345280208ea48855526989299927268566cef77ee187035bbe969076d6605"
+    },
+    "sound/zombie2/attack2.wav": {
+     "bytes": 24072,
+     "sha256": "59245700b47794e239563cc94e3ff045fcd7dad795bcfe343d8574ec3ac525b6"
+    },
+    "sound/zombie2/attack3.wav": {
+     "bytes": 15400,
+     "sha256": "0113aad711264c05a9e43bf8dba915bc89661444d7d802efabe8d61ebb3ba13f"
+    },
+    "sound/zombie2/attack4.wav": {
+     "bytes": 20922,
+     "sha256": "0aac55ae62b62cefece56103cd7079beeb433c3764f590641876e149c4328ecc"
+    },
+    "sound/zombie2/attack5.wav": {
+     "bytes": 26086,
+     "sha256": "b58c97928b535e79973e0390512b09d3d0adea79b1b1b5a8de59bc2cde40c412"
+    },
+    "sound/zombie2/attack6.wav": {
+     "bytes": 22272,
+     "sha256": "58c429256e2f5abb9d97c99ceedb78088d8ac977eca94e994b6d1eee8bb3eb8f"
+    },
+    "sound/zombie2/attack7.wav": {
+     "bytes": 34384,
+     "sha256": "d68e81783b6583738227eac608ab7af1a4b1e1b085c1e46bd9c0d029eab4fdde"
+    },
+    "sound/zombie2/death1.wav": {
+     "bytes": 46548,
+     "sha256": "a1b9e2bcebf9c56fb56405d1ec7fe4166ac10d2b6e1acc6f01e58aec9fd63e87"
+    },
+    "sound/zombie2/death2.wav": {
+     "bytes": 47048,
+     "sha256": "5964a3c1a665c70de8302052b2b6d72ea46b0a5e07ba22cc9919e1a0ffefcca3"
+    },
+    "sound/zombie2/death3.wav": {
+     "bytes": 52636,
+     "sha256": "5c76f8bc55ecea263df880e6b683b07066b37c9f62ff589b0e999534d3c256b0"
+    },
+    "sound/zombie2/footstep1.wav": {
+     "bytes": 12966,
+     "sha256": "2a85309bea05b7c7c90a82df071822828e413cce17646a9686fa4f1264d75e48"
+    },
+    "sound/zombie2/footstep2.wav": {
+     "bytes": 16880,
+     "sha256": "d1d9e9c3811b39b67c9a6966851873ff7edf8d1407c5d9b90782b233196a4872"
+    },
+    "sound/zombie2/footstep3.wav": {
+     "bytes": 20904,
+     "sha256": "b12e9ea9b9478428b886fcaab504856393a57abd8cfdfc5ba5357ad745ee3455"
+    },
+    "sound/zombie2/footstep4.wav": {
+     "bytes": 15796,
+     "sha256": "6f82ac60991e64c8c48a3208a161b46f5b916587cb41863992dc1acb08268889"
+    },
+    "sound/zombie2/footstep5.wav": {
+     "bytes": 17800,
+     "sha256": "ca12f6ade73e5d5ba4ec1bdf680ce25afe3270bb88d702e1493b75619ec088d9"
+    },
+    "sound/zombie2/idle1.wav": {
+     "bytes": 143832,
+     "sha256": "aa203b0beb2db12beb6929fbc3646f7f119d4d31ede66b13af0412d396f7dd6d"
+    },
+    "sound/zombie2/idle2.wav": {
+     "bytes": 277026,
+     "sha256": "9496f3179e875bbb4d7442c252eac0eb2b9ef6d2269d43c141e01242ed2de7ee"
+    },
+    "sound/zombie2/idle3.wav": {
+     "bytes": 234026,
+     "sha256": "4820b03de8cebdee6fe787b5bf60724c17a0e133fdd5451176a202043f730f8e"
+    },
+    "sound/zombie2/idle4.wav": {
+     "bytes": 166352,
+     "sha256": "a515e5dc0e4fe1412a7936df5fab0f57a48c385db4fa357c1a4120671ac99617"
+    },
+    "sound/zombie2/idle5.wav": {
+     "bytes": 62782,
+     "sha256": "c6e4e2f26769400b7ca3b08339af089ba28bc063447d642e10cffffc6e03a485"
+    },
+    "sound/zombie2/idle6.wav": {
+     "bytes": 47274,
+     "sha256": "9ad1ced551cb42764fd88baf26ee09dc72d1852fa2da7405fde370d3e4d69a01"
+    },
+    "sound/zombie2/idle7.wav": {
+     "bytes": 45614,
+     "sha256": "41783a7682d5f8bb91aff8308b8657504cc8f0460b5ca436a5d0fb1c93357c85"
+    },
+    "sound/zombie2/idle8.wav": {
+     "bytes": 73070,
+     "sha256": "8f390d861feda3fb3950b0f33ce3efbfa8eda214533324674ac40b6e227b6975"
+    },
+    "sound/zombie2/punch1.wav": {
+     "bytes": 9218,
+     "sha256": "db6787efe0a0b8df5da690b91afe46a2199911b661fc9de1cfffc00b6bb8c46c"
+    },
+    "sound/zombie2/punch2.wav": {
+     "bytes": 8032,
+     "sha256": "747aabd6237176ae1bc62669cb08c7ec65fb26aa2147f6a3e1ab43f02ace7322"
+    },
+    "sound/zombie2/punch3.wav": {
+     "bytes": 13076,
+     "sha256": "05bb75533252d15983a944263789de5ee51187e518f4544fd1915b57ba726c7e"
+    },
+    "sound/zombie2/punch4.wav": {
+     "bytes": 13198,
+     "sha256": "d07556e7fc774958a6105564a990c51a0dab64fcf9508475617921a0ac5b961c"
+    },
+    "sound/zombie2/sight1.wav": {
+     "bytes": 73234,
+     "sha256": "387534044f10592ca6bc7a96b8e782c7b51de87b907e79a8f410d535e17d37ee"
+    },
+    "sound/zombie2/sight2.wav": {
+     "bytes": 52224,
+     "sha256": "cbc95608d4553d0bae66411d69875210e6fc6d728bd30deb6bbce7aabbacb773"
+    },
+    "sound/zombie2/sight3.wav": {
+     "bytes": 63072,
+     "sha256": "cbbcdb6da59d830a3be66095053259b17a90cc6501728ed1aa50d9524818f99b"
+    }
+   },
    "sha256": "84fe71af50a5be582f8656003f4047d7c259881e6d8a5ef2f5d2c85e0fb7ec41",
    "timestamp": "2023-12-17T10:09:14.000Z"
   },

--- a/json/by-sha256/7d/7d72ad45c6d031c04f27e26fae53c9e332bd7712b29c17d80bcbdfbf3cf1b066.json
+++ b/json/by-sha256/7d/7d72ad45c6d031c04f27e26fae53c9e332bd7712b29c17d80bcbdfbf3cf1b066.json
@@ -7,6 +7,96 @@
  "files": {
   "pak0.pak": {
    "bytes": 3387829,
+   "files": {
+    "maps/starship.bsp": {
+     "bytes": 1336868,
+     "sha256": "dda9e6f0953b313709dd40ac620be55ee8a1b09355b0885031d1915d999217f1"
+    },
+    "progs.dat": {
+     "bytes": 671688,
+     "sha256": "879cbb58056a8127f6e4c0c8a2bce2982122afee39de800e1dd2d33ec5cc8658"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 160688,
+     "sha256": "7961e469c6f39801f130138017154f7a540dde070139b171ad7c81d1bead9195"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 228400,
+     "sha256": "448a39ca9c63447ad5a859e2e3aeafc4c2d64e7f8ce3ff46bb086cafa7cb83f0"
+    },
+    "progs/knight.mdl": {
+     "bytes": 101404,
+     "sha256": "bf4a676e5b8d07a48585ee9bca07acd88974900326a904b83cf7ddc4958bcb14"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 162036,
+     "sha256": "44832fbc4f21a22f8ef7fe97e713d0f32ee290c6f4866229362181c1ef7dfd01"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 98556,
+     "sha256": "f4f95ccd8c647ef9c83aac6519ed54c3ea11151a398f358c586679d6d5e23711"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 146288,
+     "sha256": "20a99e9cb14f2f954740a72350452a08e575a022e8ba8b01c31f33e899f7b972"
+    },
+    "sound/ambience/thunder1.wav": {
+     "bytes": 213754,
+     "sha256": "6fea03b0328c6922ee9e258ec3b3e9a6442cc4dc6852c033e92ae005d40ff0aa"
+    },
+    "sound/knight/ksight.wav": {
+     "bytes": 12075,
+     "sha256": "02caa75821e39ceb404647a764abbe3955d0139165aa0ec48e956e027c22bb7c"
+    },
+    "sound/knight/sword1.wav": {
+     "bytes": 3541,
+     "sha256": "689077f95be77350ab37a456b3b4a20d889e860db8d73b37f7b64c3fe4d04024"
+    },
+    "sound/knight/sword2.wav": {
+     "bytes": 6862,
+     "sha256": "cd73388fdb044b6bad42713d7b74f4914a5172229df0d6dc3290f35011012949"
+    },
+    "sound/misc/bubbles.wav": {
+     "bytes": 18358,
+     "sha256": "963626e3a7c94501dc35f49366c5f07aaa1b452e606f97733138e6abe84338bf"
+    },
+    "sound/misc/buzzer.wav": {
+     "bytes": 12638,
+     "sha256": "b5cd04c5d98f0aa425f6444a1bb309486a55161a7a592955be28fea51179f4ab"
+    },
+    "sound/misc/coin.wav": {
+     "bytes": 12628,
+     "sha256": "0c7bbb698ede5fa289503b591cd0fc31d46f18503a10dcfbb7dbcc66467e3c2d"
+    },
+    "sound/misc/explo3.wav": {
+     "bytes": 20421,
+     "sha256": "303add67bc345b9d2d5c5ccce8cb0927377c66bb13a80f30bd5313380a801594"
+    },
+    "sound/misc/funny.wav": {
+     "bytes": 2780,
+     "sha256": "1e9b992b7e34c82faf6182d3e0dd005f4d39a5bccc6aa34d02e96479d15a7d8c"
+    },
+    "sound/misc/machine.wav": {
+     "bytes": 42955,
+     "sha256": "8b8748eb75c3de745c993bc45b319b6dd594aa14790d402e48b8dc469cc17e86"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 49438,
+     "sha256": "d91434f754543be1ef3d743b6a9c639461fae8198983fa05b1c8af2b1018c2f2"
+    },
+    "sound/misc/stop.wav": {
+     "bytes": 17780,
+     "sha256": "e5078f98c3c28dff9c2750008b0923c0f7cee1ad34000cbe5679ec5a5ea38110"
+    },
+    "sound/misc/toilet.wav": {
+     "bytes": 36838,
+     "sha256": "33fe477a427abe693cb758f8a6a7f5b59ab0110859735e0f3420b85ab7da7042"
+    },
+    "sound/soldier/sattck1.wav": {
+     "bytes": 30413,
+     "sha256": "36d251252367ce80a8547002dd2efef84087100781d4e9947efdd6a4e0f0a342"
+    }
+   },
    "sha256": "de12d74a10590e321225d18e86bc1292d052e7a813af488d0eb0922204798f5e",
    "timestamp": "1997-08-27T04:59:08.000Z"
   },

--- a/json/by-sha256/7e/7edef08c19aa8d45dfdef6ceabc155d9dc0c47c0d053e9962f8631b9d6dc917c.json
+++ b/json/by-sha256/7e/7edef08c19aa8d45dfdef6ceabc155d9dc0c47c0d053e9962f8631b9d6dc917c.json
@@ -12,11 +12,115 @@
   },
   "pak0.pak": {
    "bytes": 14594703,
+   "files": {
+    "1024.cfg": {
+     "bytes": 61,
+     "sha256": "1ca2f03f2f82ae07a5f2a4c323403913fc25e5b013d4ed4bce30706239ebc099"
+    },
+    "ivory1b_readme.txt": {
+     "bytes": 6497,
+     "sha256": "de21baa8b9eb1ffe155763e9261746c3f2af2b9b2b0f9014037975c054a0f835"
+    },
+    "maps/ivory.bsp": {
+     "bytes": 6350356,
+     "sha256": "6f284a5e02fb3bbb4b8f556e1116a13a95f1d048bb5e1addbeccbaed050ea683"
+    },
+    "maps/ivory.lit": {
+     "bytes": 1999724,
+     "sha256": "540321279da9d9863c7a72769f9d5187ece819ba301556c654240c1f7d57b84b"
+    },
+    "source/offcut.map": {
+     "bytes": 5068329,
+     "sha256": "caffcf69908d3d82265838e209e947f45b590c3fd6a7bc1bcb947a72548ca888"
+    },
+    "source/offcut.wad": {
+     "bytes": 1169340,
+     "sha256": "28cf68aa3607b99c34e9308aaa57beaf6dbcd026af233eb7274d2f820b55b09a"
+    }
+   },
    "sha256": "d617de193bc1397c03f5fdce38b0da2416db2e8d6743d325647164ff3453ac43",
    "timestamp": "2013-09-28T12:46:14.000Z"
   },
   "pak1.pak": {
    "bytes": 194557,
+   "files": {
+    "maps/b_batt0.bsp": {
+     "bytes": 6980,
+     "sha256": "0d481a2e2cd7a23e4ef19c19622195007bd6c9a67135ef739b0944a02d46fcd7"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6964,
+     "sha256": "34709c1c06ca34305a8ba1d4799d1cdc07e44ff33f3c7fa11c3d5933cb942579"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 7124,
+     "sha256": "d3371655bed274070fa98fb32b408bab4a22fe754f5158c8c94a072749a5d24d"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 7764,
+     "sha256": "abdfe383c13da6d5dd7a9409fa5d3db2c4bac78482eb75c2c2b42da7811ec3ca"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 8788,
+     "sha256": "2343448faac29720e3a690650b70623852710dcae002917ae5772fa597117e17"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 5604,
+     "sha256": "66ea23f1cdd6225afdd1b7cf1247b93d174562193e0807561b96b659429f2bf0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6820,
+     "sha256": "366ece777ae71ecfebaa9f4bebafe2074b5336e7939900f46bd9521886f9f42d"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 7092,
+     "sha256": "56a66aa3d1364a0436ff8ce880268b2a9c2c396ab02f0c6277535d5b99eae31a"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 7636,
+     "sha256": "ddd60cec57d8e3954c1ffce616ae862edb784417a6b6622cc001d408383a6cb9"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 5396,
+     "sha256": "fe60bd7880da73571e29fa4075968cccb06e913bd2b9475868ce31c69b1a8c19"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 8436,
+     "sha256": "6a2c2c3fa6f88d425ae5b9568e5d8224ee901a1d8faa8363b88fff569b7d0e5f"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 25812,
+     "sha256": "1ba9d3176bb2e03a0457427fd9394d8c15eb9ebae8af9462e955e9c6c6068513"
+    },
+    "progs/end1.mdl": {
+     "bytes": 18900,
+     "sha256": "0d5bacc295ef6386b360dd017f0d047316e57bb056bff9242142c1ebac83565a"
+    },
+    "progs/end3.mdl": {
+     "bytes": 19700,
+     "sha256": "445af16e28fff506ad65fac16b09dad1672e218ffe0183880aff565578b315b8"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 7108,
+     "sha256": "d4c5b6316aa02d600951c6a8ec1f4682568b9e877e988cf4cedd77c0e95cf663"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 22052,
+     "sha256": "c5657b558522e46f0833b7827520c1a5c1f1674dffd52c12609779d5bcd75462"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "quake.rc": {
+     "bytes": 825,
+     "sha256": "c89f1c2d59e424d1a41e07b1e7e1260ae00bcb6456d8b0e11cf2c15f6ff77308"
+    }
+   },
    "sha256": "efea04d138e948d9501f770308e65f06dede9aa6cbacfa3c90f569d61e18c4ba",
    "timestamp": "2013-09-28T12:46:18.000Z"
   }

--- a/json/by-sha256/7f/7f05c31e8c45532a1c5cc67ccec1c239082cb03a75ab61db96de746f0d338818.json
+++ b/json/by-sha256/7f/7f05c31e8c45532a1c5cc67ccec1c239082cb03a75ab61db96de746f0d338818.json
@@ -8,6 +8,64 @@
  "files": {
   "pak0.pak": {
    "bytes": 14053002,
+   "files": {
+    "docs/retrojam3_fifth.txt": {
+     "bytes": 3002,
+     "sha256": "6803d0aba0ddb5770632a578b878c60a1d872af277b41b141fa2169da638f1c6"
+    },
+    "docs/retrojam3_skacky.txt": {
+     "bytes": 1080,
+     "sha256": "0d2fc0062eb8c9d2f68a8a845e036cdc262fb712e78b164fb87291cee688e707"
+    },
+    "gfx/env/shol_bk.tga": {
+     "bytes": 286426,
+     "sha256": "afc656e21fdba58ec0df854cd4f0a8681257a993bec6b5185b24821b9b3e73be"
+    },
+    "gfx/env/shol_dn.tga": {
+     "bytes": 139320,
+     "sha256": "aa4b3cf9005975c47096fbacd3041439ab0492025c0756df7d5098192043d53e"
+    },
+    "gfx/env/shol_ft.tga": {
+     "bytes": 280100,
+     "sha256": "9334cced4dfe72e3be40a86f830c6d39444d4bd4aa1df0f26b4fbf359f369520"
+    },
+    "gfx/env/shol_lf.tga": {
+     "bytes": 305263,
+     "sha256": "84e81f9c3d29722d40b2dc3f9bc934d610a1bc7a05903265546e33d3c201383a"
+    },
+    "gfx/env/shol_rt.tga": {
+     "bytes": 303582,
+     "sha256": "b407a22b61b77bd86e1eecdfbb2a64c25acc004b25020318e67e9a179d07c533"
+    },
+    "gfx/env/shol_up.tga": {
+     "bytes": 344881,
+     "sha256": "3eff1076ea76b963355452aefddb7afcee5d75a41a65d1560a375f24f9715660"
+    },
+    "maps/retrojam3_fifth.bsp": {
+     "bytes": 1785020,
+     "sha256": "de16b9d19a41623d8347dff13b8c0bc7d4e2db1b584a46cb90964d9ef0d24e21"
+    },
+    "maps/retrojam3_fifth.lit": {
+     "bytes": 889952,
+     "sha256": "8dd709ccf46beb2187bce86448e10cc0aea417fb38b5bae97bfbaf1ddd6289c2"
+    },
+    "maps/retrojam3_skacky.bsp": {
+     "bytes": 4447738,
+     "sha256": "2706962c995eb59b6bb8611b4bec5a5ed14c989abe6cc2cd1c3ad3f293c6893c"
+    },
+    "maps/retrojam3_skacky.lit": {
+     "bytes": 1648715,
+     "sha256": "7285f2427f07d43e8caccca82e080ff4904ed83690002ff182c4c4501595cec6"
+    },
+    "source/retrojam3_fifth.map": {
+     "bytes": 766240,
+     "sha256": "7a4a6f04ad90adaa6fce32383b3e17841a804a54f173772f090b818b8c1a319e"
+    },
+    "source/retrojam3_skacky.map": {
+     "bytes": 2850775,
+     "sha256": "2d108652bf09b5815988734051d29f625f8742e47b85120c61f622804359b316"
+    }
+   },
    "sha256": "f6ee255db3df15b812f1760bbecf8cb4c23f0e260b53a60516ee13d2b6898a43",
    "timestamp": "2015-04-29T17:15:34.000Z"
   },

--- a/json/by-sha256/7f/7f4321465335b8b145cb7a1b5bc5fd7eda19ec4803927bcf49a6094180ee6563.json
+++ b/json/by-sha256/7f/7f4321465335b8b145cb7a1b5bc5fd7eda19ec4803927bcf49a6094180ee6563.json
@@ -103,16 +103,2382 @@
   },
   "map sources.zip": {
    "bytes": 19301577,
+   "files": {
+    "map sources/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2024-07-30T08:32:14.000Z"
+    },
+    "map sources/bonk_cc.map": {
+     "bytes": 1647779,
+     "sha256": "8d9de90190b05cd5112fd861805188b60313ebd41a1c38edf352abaa8ece2fa8",
+     "timestamp": "2024-07-08T08:45:12.000Z"
+    },
+    "map sources/bonk_chuma.map": {
+     "bytes": 1539733,
+     "sha256": "333d4c6e1a4172901394a7e059a812adf3148dd4b59e818485306e001d22cca4",
+     "timestamp": "2024-07-29T13:15:36.000Z"
+    },
+    "map sources/bonk_indigo.map": {
+     "bytes": 470023,
+     "sha256": "83cbaf1a8d8bd4bb68b0d50056b2169bd722cf385dd3adf197d9a928710e2ffd",
+     "timestamp": "2024-07-11T07:36:36.000Z"
+    },
+    "map sources/bonk_iyago.map": {
+     "bytes": 1510072,
+     "sha256": "5aad113c0a89e0a54fd9598b1a529adba180e35d0074e4e1540debb0f45e1114",
+     "timestamp": "2024-07-29T14:32:40.000Z"
+    },
+    "map sources/bonk_makkon.map": {
+     "bytes": 124582276,
+     "sha256": "59ae9ac0084a317593c4fa4716230dbe87a907fad6a63f2528bd5ffe44ae47a9",
+     "timestamp": "2024-07-17T22:27:36.000Z"
+    },
+    "map sources/bonk_milestone.map": {
+     "bytes": 3474081,
+     "sha256": "20edc1775c0018ecc36f54387c5a60c315fc7d0ab0e9a086227e167ef592ee04",
+     "timestamp": "2024-07-20T10:52:42.000Z"
+    },
+    "map sources/bonk_nickster.map": {
+     "bytes": 4830384,
+     "sha256": "65062a7401f3558b285849c2534ff5dd6fdd2067e434f5f8e1aa182157c60b58",
+     "timestamp": "2024-07-29T18:16:28.000Z"
+    },
+    "map sources/bonk_pinchy.map": {
+     "bytes": 37181713,
+     "sha256": "53ced1c73cd2731ef04a6aefcb8a855bbc3c740e91f36528df5707ce2292dd99",
+     "timestamp": "2024-07-14T20:43:54.000Z"
+    },
+    "map sources/bonk_rabbit.map": {
+     "bytes": 4772839,
+     "sha256": "621c4c3d76bda8ccecb45f8f3982725946d7272bedc58c21ef99e70eab1fa35f",
+     "timestamp": "2024-07-01T21:45:30.000Z"
+    },
+    "map sources/bonk_rabbit2.map": {
+     "bytes": 882739,
+     "sha256": "0e6d81ddab0feb77350211938022a29feeb5986761606e9214406bc679df0370",
+     "timestamp": "2024-07-14T00:46:18.000Z"
+    },
+    "map sources/bonk_roj.map": {
+     "bytes": 2828788,
+     "sha256": "04866c71e4a4f2647f75d8a3feabfb221d2107f4bf8fe48fe00158f7527280f6",
+     "timestamp": "2024-07-14T10:19:58.000Z"
+    },
+    "map sources/bonk_shades.map": {
+     "bytes": 591114,
+     "sha256": "524d3e986a060e0bb567ab0fe3dcb66ee2385728ef647532110cf260ca31a219",
+     "timestamp": "2024-07-14T21:00:04.000Z"
+    },
+    "map sources/bonk_simonn.map": {
+     "bytes": 2961806,
+     "sha256": "c2e389efff346734311b0d4502d2a8f4b79dfe259530093fc8a74bd1a51184ce",
+     "timestamp": "2024-07-06T19:27:22.000Z"
+    },
+    "map sources/bonk_sze.map": {
+     "bytes": 8439299,
+     "sha256": "f4fd5d7b6542001557cf1234c566750eca589b7299f21164d40451b920a075ad",
+     "timestamp": "2024-07-17T02:55:20.000Z"
+    },
+    "map sources/bonk_thatspacepirate1.map": {
+     "bytes": 1886958,
+     "sha256": "f5376ed73a64bbe8c432c9cadf8b326c1c3a2b7e3780ada500e7d43baa9779c0",
+     "timestamp": "2024-07-13T22:23:00.000Z"
+    }
+   },
    "sha256": "aa28b92a5ad8852b201e75f939fc32a8e6876f6e1099976ec8901ecd6f6ee759",
    "timestamp": "2024-07-30T01:34:10.000Z"
   },
   "pak0.pak": {
    "bytes": 5232226,
+   "files": {
+    "conback.lmp": {
+     "bytes": 64008,
+     "sha256": "394be8d82c7bc2a781fe68bef2f5df9e60e7860b2959e4e2f931b4f828a43b2a"
+    },
+    "gfx.wad": {
+     "bytes": 197172,
+     "sha256": "fe672ef01708267b8afda4df12952640e513a3f90ad24d51337f1326990dc29b"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "31c4858fe496187dc1bac21c02aff8cf83cbc51e0b4ee5738d6118c328b299d2"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "ed0f79285d93d0ef35644ecaf9ab36f3b2c6ffd223c577b25fff2ea17f90080d"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "e9c210ab88f6e98965cd2f8470f084e32ef15b3ad3912cb1e9eb0363c6204eb7"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b56880e2f720a89dcd055f5278abb21a21514322d4a31b77b46c8b509b9f3be3"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "89c3ac6fd91cdcf15c20b0d15b4c01c153e0a820c660f9222b5c8f63d43af5b2"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "8b83ffaf6b5309d371f0107ebb1340a8a09cd1a52c6a5581b7c9c4a7afcefa77"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/debris1.mdl": {
+     "bytes": 33768,
+     "sha256": "3498dffa0c3522b011a76ada880dfae64de3ca1583c94474e1e07adbc220d981"
+    },
+    "progs/debris2.mdl": {
+     "bytes": 33944,
+     "sha256": "d6d535173bb4a3a2d469be9c63bf36a01b1e2b80dd6a71636d20178d813e443c"
+    },
+    "progs/debris3.mdl": {
+     "bytes": 34136,
+     "sha256": "d6b0a2b6353c4462196d2af116652b47d464a7bc1f161509aa8ee5dbe859f98b"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 17812,
+     "sha256": "74cd41d8d5a67570cdaca34a08e9868f3476d8c4ac4a645cfaf9e91cf778c793"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "4f5ca2553db07d5cc93987b11e9f9ff054d51b96488e2bcc35c9f03ed3040d42"
+    },
+    "progs/h_zombnm.mdl": {
+     "bytes": 3220,
+     "sha256": "45d9dfe5683264edf6f6eb7b8e8d794f84caeb8701e65e8ebe9add2192bbb6fc"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "b00951cd72bb5fb03c19a1d60943162652fe149b9ee60fd2e630a076d52956fb"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/k_spike2.mdl": {
+     "bytes": 17716,
+     "sha256": "e456eb93934dab43a83305988db82ab1954e66491c256fad3ef1451d0ecf97c2"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 36496,
+     "sha256": "a001c379917628354adfb62b698856b33f4eea5f22e7d8e232e640faf15d8465"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133936,
+     "sha256": "e2d6b9de9b879327f72d97ef3c07e0b7e35cf844747208f6e615015be84157e5"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "f414f3fd07b0278bd59dd90954770f81a5ffad7f46af5f5d0abee124905dcc17"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "progs/w_spike2.mdl": {
+     "bytes": 5816,
+     "sha256": "b07808c532059133c31be2ed2bc4e9bb9b01b75d5d23401768058cacc3192068"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 74976,
+     "sha256": "545d70abb8d44be8e12da24a3d09fb56f87ff960c41963148682fbbd9d47e417"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 218680,
+     "sha256": "6782603eadacc7cb4bd09c11d3b6326e0d2e69205f724fe2f6e533ee398f5a16"
+    },
+    "progs/zombienm.mdl": {
+     "bytes": 224900,
+     "sha256": "f4d1ce9667ebb36088bfb59a12c9a8d93c1aefa36515b51f388cffec5132f5b2"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    },
+    "sound/zombie/z_res.wav": {
+     "bytes": 23266,
+     "sha256": "10b2962ce2817fa8a250811313307cf0dfa93ad5257a669452fe3fc834ced976"
+    }
+   },
    "sha256": "6958c536f6f0a278c64d7f9c4635b1f55516f6ad9c336bc8a6c2f31691892dc3",
    "timestamp": "2024-07-23T06:52:30.000Z"
   },
   "pak1.pak": {
    "bytes": 762503656,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 71918,
+     "sha256": "234bb97b5add306ddd8f7fe264cabba7061e63bd2d6bdec4f54a50402a35d183"
+    },
+    "gfx.wad": {
+     "bytes": 197172,
+     "sha256": "fe672ef01708267b8afda4df12952640e513a3f90ad24d51337f1326990dc29b"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "394be8d82c7bc2a781fe68bef2f5df9e60e7860b2959e4e2f931b4f828a43b2a"
+    },
+    "gfx/env/browncloudsmall_bk.tga": {
+     "bytes": 786476,
+     "sha256": "40ef22e28898025692b13240c1ba92bfcf742d7dcf34a45aa9ed4a85bb97d957"
+    },
+    "gfx/env/browncloudsmall_dn.tga": {
+     "bytes": 786476,
+     "sha256": "8336d53ac085cd3a1517cb21f34017134e35d8a579fc3f95e514cbea9a8bf801"
+    },
+    "gfx/env/browncloudsmall_ft.tga": {
+     "bytes": 786476,
+     "sha256": "ba3b8db26a17742027f610fc00c26d29908f50c256f32c3f9a40aaca1cc70679"
+    },
+    "gfx/env/browncloudsmall_lf.tga": {
+     "bytes": 786476,
+     "sha256": "510770e7962506b72fc1d67d42c854c4db58164dd63d0226ef6f3b7135c5036c"
+    },
+    "gfx/env/browncloudsmall_rt.tga": {
+     "bytes": 786476,
+     "sha256": "b015facacd6881b43a17f438b4a3d220341c78f6b95417067f647f8a05e0e767"
+    },
+    "gfx/env/browncloudsmall_up.tga": {
+     "bytes": 786476,
+     "sha256": "5b946ef04bac05dc0238ca05e79416ce3a89ed7a99370466e7845f6c02f8464f"
+    },
+    "gfx/env/deepblue_bk.tga": {
+     "bytes": 467895,
+     "sha256": "779c94406c20c444aeb931049bd75d3bc24a3f7dd2fdb982fa17e76c929df9d8"
+    },
+    "gfx/env/deepblue_dn.tga": {
+     "bytes": 781154,
+     "sha256": "4c58639453d239d4dbc1916817c0cbbf385491c501ab1ff54092fd3bada65892"
+    },
+    "gfx/env/deepblue_ft.tga": {
+     "bytes": 435549,
+     "sha256": "908c4b9797f7278b408b746031c81ad53a230857e280520637bd8690f9252f01"
+    },
+    "gfx/env/deepblue_lf.tga": {
+     "bytes": 499563,
+     "sha256": "d927f2cbe4dcf25a1b7c163e7a0910fdba730a9f1c95bf8b692ba74dad94add7"
+    },
+    "gfx/env/deepblue_rt.tga": {
+     "bytes": 436674,
+     "sha256": "2b8b8487108a6f43fb260fd4d090f78e3dc630fcfb3bf3ebc0d7ddc1af40e883"
+    },
+    "gfx/env/deepblue_up.tga": {
+     "bytes": 84377,
+     "sha256": "9b2b26fe2bbd08a3905032613cb7f982ad0c881ab654561c599f7c7c49d0da70"
+    },
+    "gfx/env/hw_desertnight/desert_night_bk.tga": {
+     "bytes": 728024,
+     "sha256": "8331f070c52bcd367c2a6ae78ba8543f48d80f2bd7f8b5ea19cf4ab4687f1011"
+    },
+    "gfx/env/hw_desertnight/desert_night_dn.tga": {
+     "bytes": 773033,
+     "sha256": "4c353c81eac8a132c2956de36b3c64a0457e38541277a773d6b1666f86ef78b3"
+    },
+    "gfx/env/hw_desertnight/desert_night_ft.tga": {
+     "bytes": 434091,
+     "sha256": "ae082f8c2fa11150dd10f45d7c8f6a500cf745c96ee79f41cff91f957af7a3d8"
+    },
+    "gfx/env/hw_desertnight/desert_night_lf.tga": {
+     "bytes": 598700,
+     "sha256": "260c8f74bbc74d17482cab58b82f06a8a928704e92e700f6676af7f7cbd3408a"
+    },
+    "gfx/env/hw_desertnight/desert_night_rt.tga": {
+     "bytes": 528631,
+     "sha256": "9bb37a8607388a4b10bf25e8c1e08540ba8718ad01dfb3c4d75279ba6ac2540d"
+    },
+    "gfx/env/hw_desertnight/desert_night_up.tga": {
+     "bytes": 440821,
+     "sha256": "f3fdfaba05a0e83e60763ace616d1b47e6ed0a3a24abd4200fc6029b2eba8789"
+    },
+    "gfx/env/hw_desertnight/hw_desertnight.shader": {
+     "bytes": 368,
+     "sha256": "c74762bfee27c268625d4fe80f35f2ad4e4eaa49b0a91027aef12477a3b5acb9"
+    },
+    "gfx/env/hw_desertnight/license.txt": {
+     "bytes": 283,
+     "sha256": "3c6a08e5dccedb87f67aaa50feb964c98fbde4bb4888c64c56bc35e5fd256b43"
+    },
+    "gfx/env/mak_aurora4_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "f36777df894379136a6cf38e7b8b338080fd8ba8b0dc06c4cc64442a86a21d44"
+    },
+    "gfx/env/mak_aurora4_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "9d850af9aa593c36b7e34115e5cb2e4a679c3c8c1e2befc01f8cb4bb8d7c815c"
+    },
+    "gfx/env/mak_aurora4_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "060b6ed8d82a87b0a90c00e5f8e117f329266dbf32e3f4a07604514092af0c9f"
+    },
+    "gfx/env/mak_aurora4_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "29fc09dc4a912fea87f7803258523dcce39c0e586e20a69378443f7360359628"
+    },
+    "gfx/env/mak_aurora4_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "a3574235c47108779926211e5e3bde17ed4c581c27ba98c84c601915210ce7d9"
+    },
+    "gfx/env/mak_aurora4_up.tga": {
+     "bytes": 3145772,
+     "sha256": "9fe52a73eaf6b3812cc79a3f5aebf4b51b00b5af57e02b74755118fc35b6cd17"
+    },
+    "gfx/env/mak_nightsky1_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "4078d021f89972ed7d11c41a0cdf3b053d7161cd142a8a8946101d86614beead"
+    },
+    "gfx/env/mak_nightsky1_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "41e728c4386d5461371933f51bb424a1c40b2882aa496db8f390976d21630f98"
+    },
+    "gfx/env/mak_nightsky1_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "544c88434228344c3c5087c13a0f27e06843312695565a48a73f819484db7741"
+    },
+    "gfx/env/mak_nightsky1_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "f4e5527e363c0a714300eaced314103208859bb75f74f57adb153114a9ba2051"
+    },
+    "gfx/env/mak_nightsky1_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "d3dd339652fdb82370730c5a18765c34858326d49b2cf3b82d1a429fcc9543c5"
+    },
+    "gfx/env/mak_nightsky1_up.tga": {
+     "bytes": 3145772,
+     "sha256": "17a39daadeed06e143b71808952ba84d7c608eebed78541aa4882367b4a83825"
+    },
+    "gfx/env/mak_purplesky4_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "a343ec8a7e494456fc46ce657a5a1db5a3cb5eec08e89dafd557f2349cef7896"
+    },
+    "gfx/env/mak_purplesky4_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "322e439464c9b831c05f493f1cf57f91eac4671b23cf9075902d84d35ddfa7a3"
+    },
+    "gfx/env/mak_purplesky4_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "1574f8008ef27836e4a68336805edf01e3a6b295a0ba902077fb71592308a48b"
+    },
+    "gfx/env/mak_purplesky4_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "d8d2e48267642cc32ce721d6620f84f4edad4a99ac5f37e5c914f5cb1aed3d99"
+    },
+    "gfx/env/mak_purplesky4_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "0778783241c92968c8abcbab7de4925f9133e7cc2bea0931bdf09b6bc53499dc"
+    },
+    "gfx/env/mak_purplesky4_up.tga": {
+     "bytes": 3145772,
+     "sha256": "71d04ac03de58d8410e08c6bcf5e25286e5368e228b5a85ffe51ea44cebf7f0c"
+    },
+    "gfx/env/mak_sunset3_nbonk_bk.tga": {
+     "bytes": 4194348,
+     "sha256": "39ed47345ea9631da38fb0c6c769371c613ae7d63b706167fd309747b097cae2"
+    },
+    "gfx/env/mak_sunset3_nbonk_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "097b0a2c8500edac31f3f77b476f27b56be949fd1e5f20d9a3402660ce757326"
+    },
+    "gfx/env/mak_sunset3_nbonk_ft.tga": {
+     "bytes": 4194348,
+     "sha256": "e46e61b0c29817569fbc783ba8fc31a0cdd40bf4011e8959c9c775eabe40aa9d"
+    },
+    "gfx/env/mak_sunset3_nbonk_lf.tga": {
+     "bytes": 4194348,
+     "sha256": "c0aa7fa089f3387940bb8171be4a17efbcd30f95ae04ba72530b08a1e1bd04dd"
+    },
+    "gfx/env/mak_sunset3_nbonk_rt.tga": {
+     "bytes": 4194348,
+     "sha256": "30f48768949cfeb23cb3940f12b7b5cf7916a63c4b2a48ba61a3f5c06284c468"
+    },
+    "gfx/env/mak_sunset3_nbonk_up.tga": {
+     "bytes": 4194348,
+     "sha256": "9550d051effd0abdba4286f90163d8b295923f1789160cabd6301e662b508af6"
+    },
+    "gfx/env/mak_sunset3_nbonk_wind.cfg": {
+     "bytes": 48,
+     "sha256": "cf11cf46895ca7462bc1451d80ca96ca9766797cb6a0773b5236cb34dfdb5624"
+    },
+    "gfx/env/rabbit/jungle_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "51d4224989a9d49b3866061c42eb254aeb01dbf6f6b790e79427870f50ce0c05"
+    },
+    "gfx/env/rabbit/jungle_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "2b0b80e7dfd90b2d29f01bc96eab0be41517bac6f5d321ebcab19fd5f78b5df4"
+    },
+    "gfx/env/rabbit/jungle_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "88af4c2ccd7bf97548234c7295a07df2ac8c4e19a7e144850eb075a836aec6b9"
+    },
+    "gfx/env/rabbit/jungle_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "78fb9d2798352247fca654f9484d7c3c88f073468575ed6a86bb0e1816ed3b67"
+    },
+    "gfx/env/rabbit/jungle_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "31c58f6dbb971486be9c95844f416ded1943ba9035f079eb7964e3648d156c8f"
+    },
+    "gfx/env/rabbit/jungle_up.tga": {
+     "bytes": 3145746,
+     "sha256": "fbd0ad4bd177f6955fbaaafc3d053a838c2988f0b3239b07b84dc0215c3cf0e4"
+    },
+    "gfx/env/rabbit/mak_bluesky2_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "bc242bd204b40a89bd572ebe2d4d4f4202ccbe4658d534065477414837efb970"
+    },
+    "gfx/env/rabbit/mak_bluesky2_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "35199d0182e22c02c36143f934f8f3f29747625a7609dae40e0f339318645bd5"
+    },
+    "gfx/env/rabbit/mak_bluesky2_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "c42b34347ed48bd1279b1b53fb0ec6cf834ee571d814b7742e8f3365f618dbdb"
+    },
+    "gfx/env/rabbit/mak_bluesky2_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "c3d0be6c7ba64bfc93f0785433c50c11d8c6bc8c54c9954491e36b5fe74f6f6f"
+    },
+    "gfx/env/rabbit/mak_bluesky2_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "03fa680ec85bf5d74faed72e94ebde9a1ada380acee19b37b400162af92fcf34"
+    },
+    "gfx/env/rabbit/mak_bluesky2_up.tga": {
+     "bytes": 3145772,
+     "sha256": "4525860d5a23a25d4a10f4b78d138fa1cd340685c40936fa94961be3acdd2934"
+    },
+    "gfx/env/roj/jajsundown1_bk.tga": {
+     "bytes": 786476,
+     "sha256": "257c3f41d70179e7f371f29a35542788a580e46ef9fe96f7321d74a77fab54e8"
+    },
+    "gfx/env/roj/jajsundown1_dn.tga": {
+     "bytes": 786476,
+     "sha256": "e534b8d81df676cf80282dc3a63abc1b8d66648a833d390a475156472834480e"
+    },
+    "gfx/env/roj/jajsundown1_ft.tga": {
+     "bytes": 786476,
+     "sha256": "b1a273da93ae7eebc6659f60662e5a37f4f0663bd2667c17879e4d6ff6fb86fb"
+    },
+    "gfx/env/roj/jajsundown1_lf.tga": {
+     "bytes": 786476,
+     "sha256": "ec2b579b1ec484ec3f5a4a4d09803629acfb82721290be54672fc858a640c059"
+    },
+    "gfx/env/roj/jajsundown1_rt.tga": {
+     "bytes": 786476,
+     "sha256": "14aed5df2783c0afa620be84ec8a1d77ba02995ed6ee55207d657d9f50e27ff0"
+    },
+    "gfx/env/roj/jajsundown1_up.tga": {
+     "bytes": 786476,
+     "sha256": "9cb883fb0077ac79482cb0561f7c1a82af61b5fb374fcbdc5eb63bae49e525be"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "c376bda6d071bf7b939db999c723d0b08ab50878d9ce2e1b4428fd8da85daa9f"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "dfb6683fed7f727680ba0990ce2f9cf9bf67cd44e1783f4f11574ca0f7e8a07c"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "6703415cfb25c1a30c1bc1e9b3318acb081c3dae0f3909ab497fe32df731a52a"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "2be70dca4a990b9d7446703c0bfa2551fedc19fc6fc5f10ea5e310407c9ce57b"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "364ec3f50db7caf006579158c510897bb2b88380d19e2a30857f486001aeb273"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "57c1866118fe01630859189ec0c07a0657ee28403808913e3b8fe06ea2da15e6"
+    },
+    "maps/bonk_4lt.bsp": {
+     "bytes": 6146300,
+     "sha256": "b23af4e38f30ffef45bfd8113bf46defbf82ae63ff183f6fabff45d3ed9d1ad4"
+    },
+    "maps/bonk_4lt.lit": {
+     "bytes": 7601180,
+     "sha256": "e553c60ee40ce55cd67eb2351946d16d9f2f1992c891644d9217fcfe54ea872e"
+    },
+    "maps/bonk_cc.bsp": {
+     "bytes": 24839532,
+     "sha256": "0af1e6e6921bcf645562c130714a18f1cf7f28a1975949205526048dedaa417d"
+    },
+    "maps/bonk_cc.lit": {
+     "bytes": 2874440,
+     "sha256": "e73196495065dc13c8463aaea435b91c5dde58b0059d6c1a8ef655afef9c6f81"
+    },
+    "maps/bonk_chadquad.bsp": {
+     "bytes": 9018888,
+     "sha256": "5ff0df380201fd91c52d0e9010e6f6cd329193fe7e7f3ddc7d1c0051eb06a2ee"
+    },
+    "maps/bonk_chadquad.lit": {
+     "bytes": 6402296,
+     "sha256": "5d90870babc60d620663f754c970913f4b512e8a4ca691c37ce73abe54423c1d"
+    },
+    "maps/bonk_chuma.bsp": {
+     "bytes": 4801256,
+     "sha256": "c9aca137a3803adfd470599df43d19fe2e7bcb74df006c5812ae7f011da8eee9"
+    },
+    "maps/bonk_chuma.lit": {
+     "bytes": 1393112,
+     "sha256": "b659b33a2d34076db3ba5317513d2e102c0c2e40c3f5d8613a2a2fb77c32ee59"
+    },
+    "maps/bonk_indigo.bsp": {
+     "bytes": 973828,
+     "sha256": "a62ddad51b20b93a1b0e72e3110087f78339454fbc949f03e09ba6258b6987ee"
+    },
+    "maps/bonk_iyago.bsp": {
+     "bytes": 3605424,
+     "sha256": "2b8b0808f277dd1e64d75b59ce89388f77a89126750b49d65d15b902185a2724"
+    },
+    "maps/bonk_iyago.lit": {
+     "bytes": 3027344,
+     "sha256": "6f32204b2ccb68bec14dcff4dae822cd38f85913601803e718a7392941a89b75"
+    },
+    "maps/bonk_makkon.bsp": {
+     "bytes": 63269936,
+     "sha256": "295eb72e586df5af6d093fa4bbf39c4694a5fdc64fce4b865a0d0c4f64c4d292"
+    },
+    "maps/bonk_makkon.lit": {
+     "bytes": 8063420,
+     "sha256": "d1f8d499dc03ed19f10d8af7ea4c8c7bdad2277f13eb6f49bc43b5bf48107532"
+    },
+    "maps/bonk_milestone.bsp": {
+     "bytes": 47421608,
+     "sha256": "b00b71993062b47ecf4caeaeb440469caf3f600d338642b6baf65c6a2e26bcc7"
+    },
+    "maps/bonk_milestone.lit": {
+     "bytes": 3631664,
+     "sha256": "858751fc66a846f017cd89da23890361aaae573b20fce0d44f5ee7a05e1631f2"
+    },
+    "maps/bonk_nickster.bsp": {
+     "bytes": 36441780,
+     "sha256": "e48f7ace7637f47f2818fdde8a74f7e1714afd196dbd374e1a9796958fe27ef1"
+    },
+    "maps/bonk_nickster.lit": {
+     "bytes": 3901877,
+     "sha256": "25a9c71b937e874b8138e92897565ae0b0b677e3bf532e1b795ea7029ded0515"
+    },
+    "maps/bonk_pinchy.bsp": {
+     "bytes": 20126800,
+     "sha256": "4d0ecce294d288e01013b111791b21368d3cd7a934aa948710133802880f9079"
+    },
+    "maps/bonk_pinchy.lit": {
+     "bytes": 4969472,
+     "sha256": "0970750ffdc30ddfab5831a6a83ccffcb7e995ffc657491089823711555cc960"
+    },
+    "maps/bonk_rabbit.bsp": {
+     "bytes": 18072540,
+     "sha256": "f2fb9425d1dc7a54acbd7cca02dafdb7e2155dbef0bbaa7a6a75a0b3c561e5ff"
+    },
+    "maps/bonk_rabbit.lit": {
+     "bytes": 4280504,
+     "sha256": "6ca8479f10b6e7fc8388506125bc268d8350a2f7a5205de173a35d6ad3de84b0"
+    },
+    "maps/bonk_rabbit2.bsp": {
+     "bytes": 3741124,
+     "sha256": "212cba23ea14d6adab1792972495296640d3fe2ca7f2d23006a63b10edc34eb8"
+    },
+    "maps/bonk_rabbit2.lit": {
+     "bytes": 2243456,
+     "sha256": "7f1ec23ef611a9fd62138187a05de0b1c03a10445e590b4a2e43b28d951e999d"
+    },
+    "maps/bonk_roj.bsp": {
+     "bytes": 4734444,
+     "sha256": "4dd3ab0460e241e102f2bc0f7e3f46cc12097f8645a46a689f372dd35a1bdf1e"
+    },
+    "maps/bonk_shades.bsp": {
+     "bytes": 3667912,
+     "sha256": "00b1ec212a8bbcb7bfec508a81a2e1b2e088f40372c53feb5716a0b51ea3d5c6"
+    },
+    "maps/bonk_shades.lit": {
+     "bytes": 526694,
+     "sha256": "5c02fdd4a59b46b3f19b2a3101f0335a6bd5959cd3cacaacd8f673968b89e9de"
+    },
+    "maps/bonk_simonn.bsp": {
+     "bytes": 32826912,
+     "sha256": "17813d6fc7619bb65a45bc68ae2d42d561fcc406dcbce3a07751c5db7338939e"
+    },
+    "maps/bonk_simonn.lit": {
+     "bytes": 1724756,
+     "sha256": "89cbdc2f56221e3be57cd5b900d4f03fa5c7b2d63a1011b57b4ca0c90f6e7f3d"
+    },
+    "maps/bonk_spoot.bsp": {
+     "bytes": 6672784,
+     "sha256": "55c8dd4e67f31cf600323c6b2cebc3c740111835cdb05af9988e3d3fc0e06c1a"
+    },
+    "maps/bonk_spoot.lit": {
+     "bytes": 6768680,
+     "sha256": "fab6ee9ff728c1b04f3cc794524c0cee5b96199ded0e9b0bb35c58872a9c8f6c"
+    },
+    "maps/bonk_sze.bsp": {
+     "bytes": 13966448,
+     "sha256": "b252e8301867f2fbe5fae358488c353d01e26834ac713b617502100e999cc69d"
+    },
+    "maps/bonk_sze.lit": {
+     "bytes": 7566356,
+     "sha256": "29a0e92830d98323c67262fddea32eb0f9b0234c84bca0c04c228759f2a463d0"
+    },
+    "maps/bonk_test.bsp": {
+     "bytes": 1495848,
+     "sha256": "546ebaf046d6d436eefc5db839e9a561bedd1824b10c34952fa2df7ac80192f4"
+    },
+    "maps/bonk_test.map": {
+     "bytes": 586367,
+     "sha256": "156f9bd4a0498b91ea122debe235b7c31070e88986fbc235bccd26664c3b633a"
+    },
+    "maps/bonk_thatspacepirate.bsp": {
+     "bytes": 2091404,
+     "sha256": "e9437598665ac23ab95113c9824e775545d695871cd9281081bdbb3f58b6f94d"
+    },
+    "maps/bonk_thatspacepirate.lit": {
+     "bytes": 1000493,
+     "sha256": "02f8f31e46ee277fa3967288c06dc2a494b12322ddddbe462eb1b59b2f99876b"
+    },
+    "maps/brkpinchy/makkonstonegrey1.bsp": {
+     "bytes": 698740,
+     "sha256": "2ba15df3b996c11b2b846afce1035385be2514da54750d0ea99ee55e955d69c7"
+    },
+    "maps/brkpinchy/makkonstonegrey1.map": {
+     "bytes": 763,
+     "sha256": "e0ae09cf375eb37af0bf15a991c63adcbbc9151858d79e01fe824c1b63eb26e8"
+    },
+    "maps/brkpinchy/makkonstonegrey2.bsp": {
+     "bytes": 698928,
+     "sha256": "5944678583069e18f76550736798753985a7bfdda41359e0e5e37af13897e2a4"
+    },
+    "maps/brkpinchy/makkonstonegrey2.map": {
+     "bytes": 838,
+     "sha256": "b231548603fc304dd8b238620bf85855fa0a339708e06998960deb4b091b4b66"
+    },
+    "maps/brkpinchy/makkonstonegrey3.bsp": {
+     "bytes": 698992,
+     "sha256": "183a975044aff61c3a52e15a9d3a9de782ec4fa5c6a7c4b8649728ccd49b49a8"
+    },
+    "maps/brkpinchy/makkonstonegrey3.map": {
+     "bytes": 812,
+     "sha256": "117e1611ed239ef3ea98013971f75e49e5940cebddcee2222935f9cc54709faa"
+    },
+    "maps/brkpinchy/stucco1.bsp": {
+     "bytes": 25084,
+     "sha256": "fc0cebd4edd4a97ed07f30ae7724fd5b348daad77cec9477b083322d78e0c05f"
+    },
+    "maps/brkpinchy/stucco1.map": {
+     "bytes": 990,
+     "sha256": "89a5e5111034ac1fde79f48e1db5f57e602843674544b82c4659205e9afa461b"
+    },
+    "maps/brkpinchy/stucco2.bsp": {
+     "bytes": 26396,
+     "sha256": "95daf51511ba7be0d912579ef3dc68bbf65ed5c5c860364c049ad909597d7e15"
+    },
+    "maps/brkpinchy/stucco2.map": {
+     "bytes": 1715,
+     "sha256": "32903bf5596e5ae1c89ad0b16900e7959b95003626715798c38235a8c6cae2e8"
+    },
+    "maps/brkpinchy/stucco3.bsp": {
+     "bytes": 25744,
+     "sha256": "6b393af05c337cb79eb7452c68aabd23e27ebbfdc4b95f06569039c538256581"
+    },
+    "maps/brkpinchy/stucco3.map": {
+     "bytes": 1193,
+     "sha256": "6a74c3cd63f52071eb70804c7a2cbad5eb8a607dfca3a26934530c428b026017"
+    },
+    "maps/brkpinchy/woodknave1.bsp": {
+     "bytes": 24396,
+     "sha256": "3b5a0997856a37546e9321c06985557959c658197775c315d12f51dc2d7bdd59"
+    },
+    "maps/brkpinchy/woodknave1.map": {
+     "bytes": 785,
+     "sha256": "28386ffecc4b837013a3bb29659ad07ccf2c9e1171e99d2a01f2cbc9c2a26e9d"
+    },
+    "maps/brkpinchy/woodknave2.bsp": {
+     "bytes": 24364,
+     "sha256": "f2f880b9816f45d0a578517dd1a6fd2af24db05947eb9c7d1abac343d7bfeb43"
+    },
+    "maps/brkpinchy/woodknave2.map": {
+     "bytes": 745,
+     "sha256": "c1e8f62d5bbdf1caae3166dfa10ef1ab69b3195b27dca37e676f3155cb74c2cd"
+    },
+    "maps/brkpinchy/woodknave3.bsp": {
+     "bytes": 24312,
+     "sha256": "bec8f5b44e0158aeea99e4bc4944d6d6426b87a760823294edb831a61bee0a7e"
+    },
+    "maps/brkpinchy/woodknave3.map": {
+     "bytes": 702,
+     "sha256": "6faccaf1b21eec9a9781ada8ac1f889ea7802d0fb935cc3549a02257f7114577"
+    },
+    "maps/start.bsp": {
+     "bytes": 15740044,
+     "sha256": "5658ed1c13c67be3dabcb01bba21bfe556dc2ef1612bcdc58a6dfc32dfbee514"
+    },
+    "maps/start.lit": {
+     "bytes": 27090272,
+     "sha256": "611793b472c1f15941f98334f3e98a69eda35109dc267213c17c678de81767a9"
+    },
+    "maps/start/purp/shop/tele1.bsp": {
+     "bytes": 32504,
+     "sha256": "a5001e370c39d0cfb7d7e81f89773ffabdac63f2d5e6213c9c36f4eb850b0555"
+    },
+    "maps/start/purp/shop/tele1.lit": {
+     "bytes": 9608,
+     "sha256": "b0dce5568c3b692421c351b6e05875e3dc90321f8f0d3a72b148e975908723b8"
+    },
+    "maps/start/purp/shop/tele1.map": {
+     "bytes": 1420,
+     "sha256": "3ef17fef134186554e57ee27ad34224ab61dbb3206fe410642acc9d7ab0073f8"
+    },
+    "maps/start/purp/shop/tele2.bsp": {
+     "bytes": 32184,
+     "sha256": "dd83662e299c8647c6f256f4c7ba7a19b58036da65bad33c3eaf1e3bd0385dfb"
+    },
+    "maps/start/purp/shop/tele2.lit": {
+     "bytes": 8648,
+     "sha256": "6504e8b1af7528a8351fbc6f09c6120971cc13988e88661ccd23dd6ae6606f78"
+    },
+    "maps/start/purp/shop/tele2.map": {
+     "bytes": 2423,
+     "sha256": "c1a595b830127248dfa608ea1066333f3822d41b04cc20f8345b708279404c6c"
+    },
+    "maps/start/purp/shop/tele3.bsp": {
+     "bytes": 31352,
+     "sha256": "ebd8576e798e638dcfe296afffe21172606fb80addce9e5b107f6b4d8528218c"
+    },
+    "maps/start/purp/shop/tele3.lit": {
+     "bytes": 6152,
+     "sha256": "c867955a51f27772512fc186bcaac0f8621b1e5d8f319daff1a58eccaf31540c"
+    },
+    "maps/start/purp/shop/tele3.map": {
+     "bytes": 1769,
+     "sha256": "a5ffc7e11ff2c2797ac3640dab5dbe7594f10b2cdea4bc0a04181db86685cb43"
+    },
+    "maps/start/purp/shop/tele4.bsp": {
+     "bytes": 31096,
+     "sha256": "b76c1f868e10a4aed511a43e1f4421298759c41c5d2233fb9f2f1b434a5a5a6f"
+    },
+    "maps/start/purp/shop/tele4.lit": {
+     "bytes": 5384,
+     "sha256": "93497d3104c1dcad24195b45a36a5ed00f17cafe4d988ef6b45afdde67470b5e"
+    },
+    "maps/start/purp/shop/tele4.map": {
+     "bytes": 2429,
+     "sha256": "08a67c847fb86c580ac9e3af550e7756b72381b9778528e0c5e1c0b2d5af1421"
+    },
+    "maps/start/purp/shop/tele5.bsp": {
+     "bytes": 30264,
+     "sha256": "b20b90033a05b81469c52d7b0facbc525ae5e3dbf1e5ada001c46034783d06ee"
+    },
+    "maps/start/purp/shop/tele5.lit": {
+     "bytes": 2888,
+     "sha256": "74131d178098385c7cb489de4061cc837bc51cd895369e8e8fd57175f82fb6f9"
+    },
+    "maps/start/purp/shop/tele5.map": {
+     "bytes": 2439,
+     "sha256": "d598fe5919a7ba7df17744bd55ce6acf3208b57fbd82d295186ce945075c5d7e"
+    },
+    "maps/start/purp/shop/tele6.bsp": {
+     "bytes": 30136,
+     "sha256": "1a5264ae676992ac800535559b207c3fea3379e0a6c449ae6eba66facb7963ca"
+    },
+    "maps/start/purp/shop/tele6.lit": {
+     "bytes": 2504,
+     "sha256": "ce95857f144528765fdbff874cdc66621156607f95e52a65e397a67bddd84de1"
+    },
+    "maps/start/purp/shop/tele6.map": {
+     "bytes": 2384,
+     "sha256": "ea3d00d12a0c9587dd17aa31d81fbff4fa57c1c3ab880e34d1f6149a3a943ad5"
+    },
+    "maps/start/purp/tele1.bsp": {
+     "bytes": 16140,
+     "sha256": "063a52e558efe6703f582ff2518d1a8bcc02f3257786932eb69d8bf16518d351"
+    },
+    "maps/start/purp/tele1.lit": {
+     "bytes": 9608,
+     "sha256": "cdc0603498c4a95fc34b312aa4e8c7592626b074b46a9ae7cc7987ba6f296852"
+    },
+    "maps/start/purp/tele1.map": {
+     "bytes": 1337,
+     "sha256": "14eaf5f2518419af362d10b4b80c523419b121d2b2b3926c6a5f9a5fc508a96d"
+    },
+    "maps/start/purp/tele2.bsp": {
+     "bytes": 15820,
+     "sha256": "ebdaf63fd0fb10cc6fdb7983efa4c8d2b38bd21c9a1f2e891f75b7100045986a"
+    },
+    "maps/start/purp/tele2.lit": {
+     "bytes": 8648,
+     "sha256": "035db8a070b017930d61fe09a27895e93ec02e8e8ebb482bf7bf528605e0f96b"
+    },
+    "maps/start/purp/tele2.map": {
+     "bytes": 2340,
+     "sha256": "cf7695252e077bbcdfdd0548af54b9d6621b4705955d97747a93e4628ab4a58d"
+    },
+    "maps/start/purp/tele3.bsp": {
+     "bytes": 14988,
+     "sha256": "f946bbde301d000dc8d004666a516ff53f690906e9ffc73a93699db7a4bf2a73"
+    },
+    "maps/start/purp/tele3.lit": {
+     "bytes": 6152,
+     "sha256": "b1e7c7fafdc22c35691ed8038463066089d5f4909b4dfff98e7bed6250478644"
+    },
+    "maps/start/purp/tele3.map": {
+     "bytes": 1686,
+     "sha256": "c18c94de9770ecaf3d1dc953e2749ba2f07fd1ab4ffd46a6f1918dd6b4fd1a65"
+    },
+    "maps/start/purp/tele4.bsp": {
+     "bytes": 14732,
+     "sha256": "282c824502aae0be42919cd558090376f2a51dac5e56cc560278157bd5fc98a9"
+    },
+    "maps/start/purp/tele4.lit": {
+     "bytes": 5384,
+     "sha256": "1d52d9161c4cee48cfbf5fbbc7a3fe5cb633a42a6e6543f24599204cac0035b0"
+    },
+    "maps/start/purp/tele4.map": {
+     "bytes": 2346,
+     "sha256": "28e38c45be13ae5cd6f78c53680cc4179f81cbfee02cc1b1891e33a3ee8a5560"
+    },
+    "maps/start/purp/tele5.bsp": {
+     "bytes": 13900,
+     "sha256": "ef6e2a8c86492c1d4e10ae00435939f7acd5fc1ee97acc34d1245f833d0239df"
+    },
+    "maps/start/purp/tele5.lit": {
+     "bytes": 2888,
+     "sha256": "ef1b889517c80e072efc33a9321d577d1703a9f9dd1c47b6e5b7f00f593d63e5"
+    },
+    "maps/start/purp/tele5.map": {
+     "bytes": 2356,
+     "sha256": "94fdc0bb1c0ccfa9382dc8a64338f5a33ed288266519944eb0937472e89a8e25"
+    },
+    "maps/start/purp/tele6.bsp": {
+     "bytes": 13772,
+     "sha256": "e7db4a9d7aef7dce89dcc12cc54001f51da66991f9f9decca0d1c77b4af792bb"
+    },
+    "maps/start/purp/tele6.lit": {
+     "bytes": 2504,
+     "sha256": "7e2a121d4636e60f724e208dfcc147b65b814a8cbd3cba7013e3b577b81e73eb"
+    },
+    "maps/start/purp/tele6.map": {
+     "bytes": 2301,
+     "sha256": "e6d7914cd1c72e9bbbb28befb46a9cea2706e88419afd5b98923d7bfa6875f2c"
+    },
+    "maps/start/tele1.bsp": {
+     "bytes": 16108,
+     "sha256": "e32b3e0c1257447fbdba6bea775d242b176946abb76c2e296497d428c441d334"
+    },
+    "maps/start/tele1.lit": {
+     "bytes": 9608,
+     "sha256": "90bdc6ee0e0ade4bc579e906a81c6dc40e53042509d526dcf8cbd489293a744e"
+    },
+    "maps/start/tele1.map": {
+     "bytes": 1297,
+     "sha256": "b312a32a6c1d403acf94dc7eac23839d1a6a022891ed88c90b21cddd3fa15c0f"
+    },
+    "maps/start/tele2.bsp": {
+     "bytes": 15788,
+     "sha256": "8508cb35a9266168f05f28609c693bff03ea228c848b7de608d13f9767155964"
+    },
+    "maps/start/tele2.lit": {
+     "bytes": 8648,
+     "sha256": "da5941757e99fb617e92a1a3570a35f01b91c7d16ea01316d7db548141ee77a8"
+    },
+    "maps/start/tele2.map": {
+     "bytes": 2300,
+     "sha256": "990afd8f799cd2d4b3f1b8d66cbacfccc57e554fe583da470f8a710d4fab301b"
+    },
+    "maps/start/tele3.bsp": {
+     "bytes": 14956,
+     "sha256": "eda4864080c540730b27d718ace5ae4eecf820c8947b4c3e8ce3e7355584ca32"
+    },
+    "maps/start/tele3.lit": {
+     "bytes": 6152,
+     "sha256": "3bb2bbfecec9d0306be1f76a5e404418df8eeba9b3a5d597886a393dc240fe7f"
+    },
+    "maps/start/tele3.map": {
+     "bytes": 1646,
+     "sha256": "282416b1cdbb4e1ae1699b4e39b23297694db20851d2a7cf6756ac920d80390b"
+    },
+    "maps/start/tele4.bsp": {
+     "bytes": 14700,
+     "sha256": "8ec56a61e3c3ee35e33afb000a20ace74f802475e262f69fe2a5b3c6519bbb2d"
+    },
+    "maps/start/tele4.lit": {
+     "bytes": 5384,
+     "sha256": "d127698d93f633351d53f38c7fd5deb420665175332244ea2085fa5000158c26"
+    },
+    "maps/start/tele4.map": {
+     "bytes": 2306,
+     "sha256": "8d443ce7450412ace62c97c0a2beae4d01b0893b7b918e424028384cfc35c4e9"
+    },
+    "maps/start/tele5.bsp": {
+     "bytes": 13868,
+     "sha256": "4534e3dbe06a90b8d33e0a07ce100e53717db7c10038f7ca0b7b555b7ee9a937"
+    },
+    "maps/start/tele5.lit": {
+     "bytes": 2888,
+     "sha256": "5d9c9337b4f1472b36dae1d48bf81378b6f322c55c701dade412c1d2fa821063"
+    },
+    "maps/start/tele5.map": {
+     "bytes": 2316,
+     "sha256": "2912aa9798414c317be63111b51bcbf632ac45459d8f53d9861ec5cab1655fcb"
+    },
+    "maps/start/tele6.bsp": {
+     "bytes": 13740,
+     "sha256": "79fc7740398cbb7350bbc0069c8b73cce9b4090444dcc67586c7ad13764a5a2d"
+    },
+    "maps/start/tele6.lit": {
+     "bytes": 2504,
+     "sha256": "f6c0eda3231e9c4a4acfe8279b8b32383fd53a7dea8153dfcb9e4f0d2579f3b5"
+    },
+    "maps/start/tele6.map": {
+     "bytes": 2261,
+     "sha256": "99ca171b71c8002115b0bc523e8948b15272a56a3f6967b99d45ab3de52f1dc6"
+    },
+    "music/track120.ogg": {
+     "bytes": 5697225,
+     "sha256": "4ffa311eb16781fe7cbd7b366fb2cb29ac9303fdaf3d6742a0f73b4200b832cc"
+    },
+    "music/track125.ogg": {
+     "bytes": 11758014,
+     "sha256": "45a43c47fd05eeafedd1a509a25e8059c6273969611dcee61ef81ac5311b9e46"
+    },
+    "music/track27.ogg": {
+     "bytes": 3204681,
+     "sha256": "90423f61355555717010be12da1e1aa7e331c00f3f0c6838f700a83bc7f88e3f"
+    },
+    "music/track36.ogg": {
+     "bytes": 8609705,
+     "sha256": "488b86ad7b5d7c8f3b79b49c394c29ffdc903c9820c562a26abfa82046edb5f9"
+    },
+    "music/track44.ogg": {
+     "bytes": 6170616,
+     "sha256": "3d3bb23b93b9f4a501e0ba34a2c68b80ad50dc7e4d9d6c54c576b7b3f5177ef5"
+    },
+    "music/track45.ogg": {
+     "bytes": 10125346,
+     "sha256": "bd249281d5a75cf88635e596fbbdf32dd5d91fe8c08f247b86063586da389a20"
+    },
+    "music/track66.mp3": {
+     "bytes": 13421284,
+     "sha256": "9c05f986a9c86059733e8861df0095d457610cd24e5e37b04988d529ad5b91e9"
+    },
+    "music/track66.ogg": {
+     "bytes": 7530433,
+     "sha256": "cf80d520d5475a14092c39e9e5252a4348ae4b237506088758ca694ced91005a"
+    },
+    "music/track69.mp3": {
+     "bytes": 13483005,
+     "sha256": "55f52c6d19233dba50bdc84d513abba05da0f080655c2fcc88b61b72542d5098"
+    },
+    "music/track70.ogg": {
+     "bytes": 7204634,
+     "sha256": "dcfa02f9584d0112deafd2050cc0c6b9254bca49e4752c7cecc1dee0412bedfd"
+    },
+    "music/track80.mp3": {
+     "bytes": 3206713,
+     "sha256": "b2a236079cbb8fad16a3ce7e4d67a7967b0d59fc2a6852fccd9c53179d321bc2"
+    },
+    "music/track81.mp3": {
+     "bytes": 8165169,
+     "sha256": "c14001e0ae50c8510ded5b5e66e39142fa3b4ddff6a1b3a605ddad43f383577d"
+    },
+    "music/track82.ogg": {
+     "bytes": 6111723,
+     "sha256": "9d38ad6ecf902d65405cd138861825eea0fe01365020c96a6332cae824737d91"
+    },
+    "music/track84.ogg": {
+     "bytes": 3305779,
+     "sha256": "bc243f07254ec8940f3f6023787aabb088ac777fd50599b3839cca4ed8874ebb"
+    },
+    "progs.dat": {
+     "bytes": 684974,
+     "sha256": "b54e33e50ad06d5628132a26bb6b089534d091bd2b6756799a15b61e7af49811"
+    },
+    "progs/bonk_shard.mdl": {
+     "bytes": 23572,
+     "sha256": "26aeffa72655670da33288f3d348e1242cffa973127048ce5937b8ec92ad54d0"
+    },
+    "progs/brute/h_brute.mdl": {
+     "bytes": 182968,
+     "sha256": "e28f8727d88931178521f188e748f79c286e45d1f56cc33e6f36d6543736608d"
+    },
+    "progs/brute/mon_brute.mdl": {
+     "bytes": 991068,
+     "sha256": "6d4642ad73cdf22362e17ba24002f92f9436c06491214b0af5e5777222225615"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 39028,
+     "sha256": "6a23999e3ad1d2d5d9838b322b953c2a914cc5bff8d76ddefa1a90113638a66d"
+    },
+    "progs/g_hammer_alkaline_axe.mdl": {
+     "bytes": 73412,
+     "sha256": "50163da065f3cf3954983af542f29f1cc389d3679223ba3b02b7da012ddf8262"
+    },
+    "progs/g_hammer_baseball.mdl": {
+     "bytes": 87268,
+     "sha256": "5eb97dc66970a50ff34c9a279773bdddc8254a9d7a3dfdb92b6a2e730ed90443"
+    },
+    "progs/g_hammer_baseball_bat.mdl": {
+     "bytes": 87268,
+     "sha256": "9c0a5779182319bcf16d904573334a239d22e88bc2962714be8d7aa48c5dc0f4"
+    },
+    "progs/g_hammer_baseball_bat_bloody.mdl": {
+     "bytes": 87268,
+     "sha256": "5eb97dc66970a50ff34c9a279773bdddc8254a9d7a3dfdb92b6a2e730ed90443"
+    },
+    "progs/g_hammer_blocky_axe.mdl": {
+     "bytes": 83796,
+     "sha256": "1ba8252d4d209c3fbb6a262acee9f274e09f86dc3991c6ed41fc881f9dd22fe5"
+    },
+    "progs/g_hammer_blocky_brown_brick.mdl": {
+     "bytes": 151252,
+     "sha256": "833d0d4d9e42c23cd407074dce823843c444947e8729dd0fe362895bf453134e"
+    },
+    "progs/g_hammer_brown_brick.mdl": {
+     "bytes": 151252,
+     "sha256": "833d0d4d9e42c23cd407074dce823843c444947e8729dd0fe362895bf453134e"
+    },
+    "progs/g_hammer_burger.mdl": {
+     "bytes": 151636,
+     "sha256": "3e75d266b07faa72a74eb5e1d0020a2fe4d9be91cb48ee2ab0f9b6a30456c28c"
+    },
+    "progs/g_hammer_buster_sword.mdl": {
+     "bytes": 141076,
+     "sha256": "5a5d547cf131ccff7241930fad4b368a853a0c7c4bdc1bafa4bc99ee9f65a59c"
+    },
+    "progs/g_hammer_copper_axe.mdl": {
+     "bytes": 17812,
+     "sha256": "9265f7867f2d81f5bc778ba0f14b70d10b44e11b7a242032c536fd2f98250c8b"
+    },
+    "progs/g_hammer_default.mdl": {
+     "bytes": 71796,
+     "sha256": "e161bf81eec4ab871fbe7fc6c53ffa9b014e2570d89b293614063c725fceb770"
+    },
+    "progs/g_hammer_default_bloody.mdl": {
+     "bytes": 71796,
+     "sha256": "b99306233d2d0384d0597646d75b21ca7f3f073bdb606deb81d7dc1383d16765"
+    },
+    "progs/g_hammer_default_gold.mdl": {
+     "bytes": 71796,
+     "sha256": "bc1d2cd466469f1d222e8ea10c2eb71a5958ca58f2d7e02a6c5b471d30e2bcf2"
+    },
+    "progs/g_hammer_default_gold_bloody.mdl": {
+     "bytes": 71796,
+     "sha256": "bf1f33ea9c87fbbc4260896e694d4dfdd5ffe4bd140a006bff3a0c0acb72c184"
+    },
+    "progs/g_hammer_dwarven.mdl": {
+     "bytes": 78388,
+     "sha256": "3308d9c3af6f67e81356a2e6f75b83151354ac69e67a97182e52cb7ac9e42a71"
+    },
+    "progs/g_hammer_error.mdl": {
+     "bytes": 111860,
+     "sha256": "16fbe4bdcc3498c0e2913ac96c305d97c2d1a68fabd4b7dadfe1bfdc91d13658"
+    },
+    "progs/g_hammer_floyd.mdl": {
+     "bytes": 142244,
+     "sha256": "ea58a7bce25ec9ad352e9706a63de455bd9e447ee79e1822f9f158f6e81114c7"
+    },
+    "progs/g_hammer_guitar.mdl": {
+     "bytes": 73332,
+     "sha256": "99689467c986502bf35b5ad15d577c8887be478086412564c13e393be05476bf"
+    },
+    "progs/g_hammer_heavy_rocket.mdl": {
+     "bytes": 151028,
+     "sha256": "5ff13af63586413d7af5e54ddc70cff5251f0ecf43a7d40e95cfffd4df787b5c"
+    },
+    "progs/g_hammer_jester_mallet.mdl": {
+     "bytes": 144308,
+     "sha256": "95f9fd0274b0cf16b76a06769b1c9f65fa5f0e43698570e0f1a92584124a6b79"
+    },
+    "progs/g_hammer_katana.mdl": {
+     "bytes": 71540,
+     "sha256": "915b9310500626794ba7d894188f513664dc7c1cd624a56321efdcc4847451c9"
+    },
+    "progs/g_hammer_kebby_gears.mdl": {
+     "bytes": 158708,
+     "sha256": "515215ada512b72113fe6ce7722ac6b3ed2acc36ac6fc634a4be7937e3b8cc43"
+    },
+    "progs/g_hammer_mace.mdl": {
+     "bytes": 73236,
+     "sha256": "39c2a88deadc9510a62bd116d3c148f85b39588bc766480560ba04aacbf009d0"
+    },
+    "progs/g_hammer_mailbox.mdl": {
+     "bytes": 73396,
+     "sha256": "c259d8f39672bb1dcc1221d5f856d58dc22cb9b3711c0c8ed3fbbe302cf6daeb"
+    },
+    "progs/g_hammer_moving_past_it.mdl": {
+     "bytes": 70500,
+     "sha256": "112e59069a42ba5a17cfbaa81c9b9555c92bf848cf9d8af73e98289284f4630e"
+    },
+    "progs/g_hammer_pickaxe.mdl": {
+     "bytes": 80660,
+     "sha256": "a16d7107d91f3b00ab65f5b05c61b31365effd035f1451255b410640d056db45"
+    },
+    "progs/g_hammer_pirate_skull.mdl": {
+     "bytes": 99572,
+     "sha256": "9936e7157434678d6b47666e58cd4db3438fc78dae908ecfe4c66ff9fcd419e6"
+    },
+    "progs/g_hammer_sailor_sceptre.mdl": {
+     "bytes": 84852,
+     "sha256": "f7c428a3367f46782acb6d0a57550c963762cdaaf4c1f2de547bbf8bcca6d8e7"
+    },
+    "progs/g_hammer_sblade.mdl": {
+     "bytes": 74260,
+     "sha256": "60fb7f7b36006b00694082e0c4fccc4c1ac16274eb877d89486f716f5cbe0b64"
+    },
+    "progs/g_hammer_sentinel.mdl": {
+     "bytes": 83988,
+     "sha256": "6aae635349aa5fd7e8d5d5e28debe999c527d69d360c9f7b7e54a4653d919d1b"
+    },
+    "progs/g_hammer_squeaky.mdl": {
+     "bytes": 80548,
+     "sha256": "ea6d9d0e8dd84ef4ed2ff8473af5de97951b2d594fd39078d09b6bddff75cc44"
+    },
+    "progs/g_hammer_stop_sign.mdl": {
+     "bytes": 69684,
+     "sha256": "a43b45244358cd95e0ed2eec10dd6544dc0e776e8732b43e9d447084a1666152"
+    },
+    "progs/gaunt/g_fx.mdl": {
+     "bytes": 32260,
+     "sha256": "ac99d4e641af0bb1495ed38ba9f3a7c1195bda19e5cf0d3a68f04defe6178ab8"
+    },
+    "progs/gaunt/gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/gaunt/h_gaunt.mdl": {
+     "bytes": 61251,
+     "sha256": "dec5afe666eba8db6e32d7535fffa3d0e4ed9344ba107b73418526ebebac574b"
+    },
+    "progs/jumpboots.mdl": {
+     "bytes": 96180,
+     "sha256": "74fa27f5580474bc57be595aff60ba342d3877fa3abb7901c26944c9cf228a22"
+    },
+    "progs/kanji.mdl": {
+     "bytes": 158704,
+     "sha256": "dcb6b4d3f1514f01176526d1a87115c5c13f47c702d68ffdbaef768e0079ed95"
+    },
+    "progs/megashambler.mdl": {
+     "bytes": 335552,
+     "sha256": "16f6d2502b84d8d4b33469976f32f6537bb27e239f0d9b09d374c8ab28dab8e0"
+    },
+    "progs/player.mdl": {
+     "bytes": 754644,
+     "sha256": "fdabb2114f3f1ed98af1e90503deb19d71644a67fe10addc9c8647f0924f1f8f"
+    },
+    "progs/player_mace.mdl": {
+     "bytes": 422804,
+     "sha256": "70623c63bd9df5f6e9e0e73fb7891ddd593f58f93d6dc7200c3cc792f528c711"
+    },
+    "progs/s_blood_128x.spr": {
+     "bytes": 246096,
+     "sha256": "594fba70e8c23357cad424393091cdb3ed6264aabbee5943ebeba8e2bea8a492"
+    },
+    "progs/s_blood_32x.spr": {
+     "bytes": 15696,
+     "sha256": "fd39b54c5da142ddf83892cff40fbb5e0436588aa8e7f3d669bcf5dbd8038cac"
+    },
+    "progs/s_blood_64x.spr": {
+     "bytes": 61776,
+     "sha256": "4658921f645875be2e36415658f65ce389c40500cc9f4929b1445f6bd808cba6"
+    },
+    "progs/s_blood_96x.spr": {
+     "bytes": 138576,
+     "sha256": "214d0587d2b1009151c8bba51a97b829af5ebf6c90c15ea20507e6c6ae6a7b90"
+    },
+    "progs/spark_blue.mdl": {
+     "bytes": 23460,
+     "sha256": "4781151723448f5f929f2b0d64d5cac2fbcd93e495b63b3b1c95af87d97ef0b0"
+    },
+    "progs/spark_red.mdl": {
+     "bytes": 12900,
+     "sha256": "eb2bd332b016ebd32c7bcf2b044c4f9e62122bf47bdb591b71b991b4609ae605"
+    },
+    "progs/spark_yellow.mdl": {
+     "bytes": 23460,
+     "sha256": "310882dc63b18b2a506a8bc08884eaf23d3ae621b8dcc6c679968bcb00781eb1"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 1325884,
+     "sha256": "f02aacc444c638ddc5271d69b76e6db02b5a9f7d59e2ac8f14e4999c215bebb5"
+    },
+    "progs/v_hammer_alkaline_axe.mdl": {
+     "bytes": 1542372,
+     "sha256": "6c4ab3ce7b668c2631401a279b57db1ae9392ddb76c69c61da1c52f884437f30"
+    },
+    "progs/v_hammer_baseball.mdl": {
+     "bytes": 1820532,
+     "sha256": "fb4163cda833431d47378fc59be1cfef5b1ecdfcdca374fdb5f49c00df163bec"
+    },
+    "progs/v_hammer_baseball_bat.mdl": {
+     "bytes": 1820532,
+     "sha256": "e745d8760338b2ac78166e84a7f74c3b296b8bf16e2193fd0c6c28cab6fbf96c"
+    },
+    "progs/v_hammer_baseball_bat_bloody.mdl": {
+     "bytes": 1820532,
+     "sha256": "fb4163cda833431d47378fc59be1cfef5b1ecdfcdca374fdb5f49c00df163bec"
+    },
+    "progs/v_hammer_blocky_axe.mdl": {
+     "bytes": 1941884,
+     "sha256": "0434b4a60781e72ba43fcab224a9b57f150b28a079146665fbf10428d6eea1ce"
+    },
+    "progs/v_hammer_blocky_brown_brick.mdl": {
+     "bytes": 1891484,
+     "sha256": "bfcb8cb3c061e259df9cb8841da2d870c0b8c734ee269562f73429dc65a26ea6"
+    },
+    "progs/v_hammer_brown_brick.mdl": {
+     "bytes": 1891484,
+     "sha256": "bfcb8cb3c061e259df9cb8841da2d870c0b8c734ee269562f73429dc65a26ea6"
+    },
+    "progs/v_hammer_burger.mdl": {
+     "bytes": 2090844,
+     "sha256": "caaf0c6d2837cfaef9574bbcfe43fb9ef287681ff5fa75c48c3f35e3c074c010"
+    },
+    "progs/v_hammer_buster_sword.mdl": {
+     "bytes": 1624380,
+     "sha256": "5516fd4e96bad6bdc9557bcc0657cd381af279d4c2fa480c630d31d7cb37d637"
+    },
+    "progs/v_hammer_copper_axe.mdl": {
+     "bytes": 1108748,
+     "sha256": "54a1be810924085b6e3eaed306404b3d6d9e6a2d591133f9df52e0088e350e20"
+    },
+    "progs/v_hammer_default.mdl": {
+     "bytes": 1325884,
+     "sha256": "fef8c2ec7c3c31264f86d39cb785c223a2bb2558a79b3aa3ab3b3765c502cdff"
+    },
+    "progs/v_hammer_default_bloody.mdl": {
+     "bytes": 1325884,
+     "sha256": "75bd972e8d104b36c398df0dfbb0051b00a7cd610d7e3d986e651e284ff447b0"
+    },
+    "progs/v_hammer_default_gold.mdl": {
+     "bytes": 1325884,
+     "sha256": "4bd1ae85b04b535a0ac3975b099a3d99fd0a4d2ed3ff86edd5e33520ea87e1dc"
+    },
+    "progs/v_hammer_default_gold_bloody.mdl": {
+     "bytes": 1325884,
+     "sha256": "40ae37a9fafcba8b3cdddc85b0f378d4580ad64b8b854ce7e2a9409317c9f232"
+    },
+    "progs/v_hammer_dwarven.mdl": {
+     "bytes": 1693132,
+     "sha256": "de56594658f837812b4208500d2f1ff879d9d6415a10797c9b1359e76a5b9cbd"
+    },
+    "progs/v_hammer_error.mdl": {
+     "bytes": 2235116,
+     "sha256": "97b01e96d0429c9ea9cdfe36c79cb14f81ac8d5bb0972db8989c2c48cdf68e8f"
+    },
+    "progs/v_hammer_floyd.mdl": {
+     "bytes": 1757156,
+     "sha256": "003d27180377f51d81067e0531099f0ff18537b9d4f6bdeecc80388377833117"
+    },
+    "progs/v_hammer_guitar.mdl": {
+     "bytes": 1451324,
+     "sha256": "2541cf9b7e8a547f829a98a0aff0d5cd58e2fa6b1fe312372f95998fe9bc01ef"
+    },
+    "progs/v_hammer_heavy_rocket.mdl": {
+     "bytes": 2162924,
+     "sha256": "4d40a247d750d7a76ce815614446e4a1ae6ccd7ef20ff1dbe3cbba6e72f1a175"
+    },
+    "progs/v_hammer_jester_mallet.mdl": {
+     "bytes": 1874876,
+     "sha256": "c6ef08fb2dfeb07723281577a7bd357160331a7ab467c559c099864483de5050"
+    },
+    "progs/v_hammer_katana.mdl": {
+     "bytes": 1285356,
+     "sha256": "13473bcd57d84305499dba53045fccab9ce82e41a7d3f662d1731f31d43ad916"
+    },
+    "progs/v_hammer_kebby_gears.mdl": {
+     "bytes": 2441980,
+     "sha256": "3fd311806a631b426c69c29314e553b2f3185921ea8cf33c4164fbea9a3cea6e"
+    },
+    "progs/v_hammer_mace.mdl": {
+     "bytes": 1499004,
+     "sha256": "9f36583a4fdd694449919b0c7eb26a2bed1f1ff8683b6b35563f060773e08917"
+    },
+    "progs/v_hammer_mailbox.mdl": {
+     "bytes": 1357756,
+     "sha256": "ba2c170a010df7d6190d37d8eaf2fab67e4360de78119692bc59b41aa13f4714"
+    },
+    "progs/v_hammer_moving_past_it.mdl": {
+     "bytes": 1325556,
+     "sha256": "d8bc4d88e9f36964807b45391b2674355d81b79d9bae3b32708e35ccd2c8be0a"
+    },
+    "progs/v_hammer_pickaxe.mdl": {
+     "bytes": 1645708,
+     "sha256": "0653219a86223f36b3720ed49bab8f70e8f810ec28e62553d76f48f6d18fc4fc"
+    },
+    "progs/v_hammer_pirate_skull.mdl": {
+     "bytes": 2268780,
+     "sha256": "35fb1bb182e87c9a8aa7862d28dabce13fefc7ade1a4c340b6bdce893b93b4f2"
+    },
+    "progs/v_hammer_sailor_sceptre.mdl": {
+     "bytes": 1715036,
+     "sha256": "5c7e85fa8c0252103caae690ceeaa5ac126995a5ebd45f944160c9241d3d56a1"
+    },
+    "progs/v_hammer_sblade.mdl": {
+     "bytes": 1543404,
+     "sha256": "e11218965fd17530f13c3978d98df9ecf6ba433b803f9d069c38ff501848479b"
+    },
+    "progs/v_hammer_sentinel.mdl": {
+     "bytes": 2039260,
+     "sha256": "2b881b4f45c04e901c2438eea39baab0c80617142dad8c923d2364a4a2ba0f31"
+    },
+    "progs/v_hammer_squeaky.mdl": {
+     "bytes": 1493556,
+     "sha256": "c113e6fd7f9a339b0b5d8680f01a38cd7d55cdc502d6f982bc762d2045cf8a4e"
+    },
+    "progs/v_hammer_stop_sign.mdl": {
+     "bytes": 1219548,
+     "sha256": "b83c0ec4dcd60e4057ef1467a247960b291e5c7d2c8e5be433903a6d3621532f"
+    },
+    "qcsrc/ai.qc": {
+     "bytes": 40288,
+     "sha256": "7814a98d314797a34766e731501a0fc5fadf2fb45070f886dd8820cf53c80fcb"
+    },
+    "qcsrc/buttons.qc": {
+     "bytes": 14737,
+     "sha256": "8c5d4304a882b42fd50dd3ae6ce54e23be80733ff96aafed93f6c40fa8960475"
+    },
+    "qcsrc/client.qc": {
+     "bytes": 52946,
+     "sha256": "3b37d1af8b40d889c188eb4685b6e2b870e4ee974a6b787f7e2393342aa99e9c"
+    },
+    "qcsrc/combat.qc": {
+     "bytes": 17950,
+     "sha256": "cf1d95ed7026c630ea2e2a729eabde41f01b5f161303685e772282ab0a81a0eb"
+    },
+    "qcsrc/constants.qc": {
+     "bytes": 13374,
+     "sha256": "9b2f3281d77305e2f77513e2ed0d0143d830eb9f4acae16a4ae4aebe4b06eb43"
+    },
+    "qcsrc/csdefs.qc": {
+     "bytes": 42891,
+     "sha256": "e7ae286995262dc42ec74809483894a6c82bfe4e487f4a20f1256d528ea8c0d1"
+    },
+    "qcsrc/csprogs.src": {
+     "bytes": 68,
+     "sha256": "694f993105db7187e507bf4c7a187aeece0da5fa1fa426713c2179549afeecf0"
+    },
+    "qcsrc/defs.qc": {
+     "bytes": 19087,
+     "sha256": "1f2302e92176f5d03ba75c676908f108318e8f928e846498cd9679315fa11c96"
+    },
+    "qcsrc/dev.qc": {
+     "bytes": 11605,
+     "sha256": "d6eb905e91da53316ff2673bc7fe0d636597142a0a3ac0cbf96ab09f18306ddf"
+    },
+    "qcsrc/doors.qc": {
+     "bytes": 35917,
+     "sha256": "4481b811eb32dafb44e9e9e28831dde65c166612833382060ff51452af2b0a29"
+    },
+    "qcsrc/explobox.qc": {
+     "bytes": 8309,
+     "sha256": "8a2dc22319521da9f560a5c1d6c7298ecca80a8872ee95ea68c7f8ceeb8a5d60"
+    },
+    "qcsrc/fly.qc": {
+     "bytes": 5659,
+     "sha256": "c7a48dce5fc451d0cbfab36caa88380be3b7015a55bb956745af77a99b8121ff"
+    },
+    "qcsrc/fog.qc": {
+     "bytes": 14857,
+     "sha256": "a5d851330a0429ac2495c70cde62c775236c9581d41b941a891cd9244d55ed74"
+    },
+    "qcsrc/fx.qc": {
+     "bytes": 42148,
+     "sha256": "221da3c98ed8b2f9518e41c78ad9673a2dfc076225894507db66baf80e068937"
+    },
+    "qcsrc/hud.qc": {
+     "bytes": 26728,
+     "sha256": "0e979c59c8e3bbec8c50ead813640e92e514725b6bbe5c5cc1c8196a6b31e7ec"
+    },
+    "qcsrc/impulse.qc": {
+     "bytes": 6068,
+     "sha256": "668f5ceae7c3f3ff2eecc3f693cdb4be945285931cebe8cd827b0d412dd634a4"
+    },
+    "qcsrc/item_backpack.qc": {
+     "bytes": 8866,
+     "sha256": "04786fd5a93abe2bd2e71dd0a9aacfda1a473c4379fe0cb2ca9ae20f981fea58"
+    },
+    "qcsrc/item_health_armor.qc": {
+     "bytes": 9064,
+     "sha256": "026fe3577d26ff2409d9746dbc614f5ae8dac1ce8119c248f308b9a3335d1326"
+    },
+    "qcsrc/item_keys_runes.qc": {
+     "bytes": 21995,
+     "sha256": "f08dde412d090004d91b75642d9743188f0dfd1f748ec4d33b0857bb324160a2"
+    },
+    "qcsrc/item_powerups.qc": {
+     "bytes": 10176,
+     "sha256": "aaee4f37c10b8674d4556daa81e9abc5117217102df1057d6f7091d2b1dee3a2"
+    },
+    "qcsrc/item_weap_ammo.qc": {
+     "bytes": 14460,
+     "sha256": "b4a11de1b5ffc67c63543a274738fe3c9a2d3cc2609abd2acfac4540798e5bb9"
+    },
+    "qcsrc/items.qc": {
+     "bytes": 26193,
+     "sha256": "81868dd27c5e70225f820faec7a268b74fa0a5111492425b6b87231199eeac13"
+    },
+    "qcsrc/lights.qc": {
+     "bytes": 29314,
+     "sha256": "0b803042f2a4152f1fbd553e48cc85120eb943153cf4d430d27150bd14c03e47"
+    },
+    "qcsrc/m_boss.qc": {
+     "bytes": 17863,
+     "sha256": "406245d8663bcc89e1a51876efbbe9b9f97b23ddeea8d6edeb53689d6d273f64"
+    },
+    "qcsrc/m_brute.qc": {
+     "bytes": 28745,
+     "sha256": "fcfc9da2c5fedce5a188136067590c8c1133865d78ac813e6bd02f2061e89e35"
+    },
+    "qcsrc/m_demon.qc": {
+     "bytes": 19502,
+     "sha256": "cc035c3c87afe929dea44e71ac7647b0d7cb160cdc1d113fe73a3e53fb722435"
+    },
+    "qcsrc/m_dog.qc": {
+     "bytes": 12240,
+     "sha256": "cf267b0604c67948891568eadf16a74179ce9fd68b6814e35a3609be02957a3b"
+    },
+    "qcsrc/m_enforcer.qc": {
+     "bytes": 12682,
+     "sha256": "bbbdcd5ffb801f1b160a79ad2074ddd1fc68ceccea150edd0c2a2dec36d84d97"
+    },
+    "qcsrc/m_fish.qc": {
+     "bytes": 13058,
+     "sha256": "c3cb58376fec30fe4d20e097bb5ac4e8f37e187a5c01741198e3787a5e2731e5"
+    },
+    "qcsrc/m_gaunt.qc": {
+     "bytes": 16426,
+     "sha256": "ba4101c6f45b0ebcdd3d46f83f0d5e98eac59cbc4b13e7bd96aaa65a119834e4"
+    },
+    "qcsrc/m_hknight.qc": {
+     "bytes": 23764,
+     "sha256": "bab8f82ae07631b568503379d15b5d753ab45325889ba652da6a188029d1b78c"
+    },
+    "qcsrc/m_knight.qc": {
+     "bytes": 11957,
+     "sha256": "c9b1d8b7123b0acf0dc615423b224ca6810eafd6d03f7afbd46e03374264f056"
+    },
+    "qcsrc/m_ogre.qc": {
+     "bytes": 17676,
+     "sha256": "0cf81262a8e26d494186ffc9479d9e740957edeac1258999ac2d36598b4fb329"
+    },
+    "qcsrc/m_oldone.qc": {
+     "bytes": 13905,
+     "sha256": "76536a7149f8685f55bbb45dc5ec9a063b1e5948ff70c1dbd49ef51170be1f0e"
+    },
+    "qcsrc/m_shalrath.qc": {
+     "bytes": 13331,
+     "sha256": "8e66a8e0229d58d0a480e0b25b34a0077ea73bd0b4b1d9add020ce30630d3f36"
+    },
+    "qcsrc/m_shambler.qc": {
+     "bytes": 17419,
+     "sha256": "53402e83c12f8d6a00bd7df1bd315f4a7d0f93962aca8fc154c91516c5beb316"
+    },
+    "qcsrc/m_soldier.qc": {
+     "bytes": 12742,
+     "sha256": "0de032d2d2f89fec92414d6977d82839737c75251811f17fbe8a5893d36f5b7e"
+    },
+    "qcsrc/m_tarbaby.qc": {
+     "bytes": 10963,
+     "sha256": "ebd9d97db66cabfabb49e95a70c08087d3f53bb03b384d51e35aafd17fb8266f"
+    },
+    "qcsrc/m_wizard.qc": {
+     "bytes": 13679,
+     "sha256": "23a639ee8ea2e4b3bb05bed8689473078a3975f0c513e08195c01120872c3466"
+    },
+    "qcsrc/m_zombie.qc": {
+     "bytes": 27924,
+     "sha256": "e3ef049e21782d4f0fdd5cf91229d03130eb74823e7d22e488a5a83ed73da28f"
+    },
+    "qcsrc/maths.qc": {
+     "bytes": 6538,
+     "sha256": "8df959bf2947abae7941dbbf214f4ed4f0cc313bdcbc3eed50dfe65b427a8d2e"
+    },
+    "qcsrc/meat.qc": {
+     "bytes": 8163,
+     "sha256": "f1f0e3c83beaacb4ff46457437d83dc2829bebc869f6e046b636fdfc3a1cfc99"
+    },
+    "qcsrc/misc.qc": {
+     "bytes": 24062,
+     "sha256": "67f3a1b91960fb5fda45807a51063ab017e06aa64edb5973385a0d06fcb181b8"
+    },
+    "qcsrc/monsters.qc": {
+     "bytes": 21790,
+     "sha256": "e2107decb5a996a88b7f3e2e486155701810aa1778c787fad2cd7fe3a9658102"
+    },
+    "qcsrc/plats.qc": {
+     "bytes": 43195,
+     "sha256": "7d463cfd116c4df9fdccc0752c3ecb15e8f152687bc3f2373ce37b7ea0a10bcf"
+    },
+    "qcsrc/player.qc": {
+     "bytes": 18842,
+     "sha256": "2116467ee31ea338e1b36b3b30b965a686265b765cca924e4bc9e7a2b1336e2d"
+    },
+    "qcsrc/progs.src": {
+     "bytes": 1171,
+     "sha256": "e3192163150183c02348eafbe67ef171e6b6f39e1a52b4d152327bbe222cc5a8"
+    },
+    "qcsrc/projectiles.qc": {
+     "bytes": 15014,
+     "sha256": "6931759849013fbfbcfce539a17f3a537a43b73c3dd581392f805a1a34f676d2"
+    },
+    "qcsrc/qc2def.py": {
+     "bytes": 2064,
+     "sha256": "59df45642d042a9f98a08b4103a9a26cfbbbab13ef601f1ba3a119337e7516f5"
+    },
+    "qcsrc/qc2fgd.py": {
+     "bytes": 2138,
+     "sha256": "c7380a27cf55974d0b5727a0f528f997dcbabe081b9368054d86b06ebe2441bc"
+    },
+    "qcsrc/shooters.qc": {
+     "bytes": 13663,
+     "sha256": "e95cfb87780fe0973cb284d0bb0b2f0586d8cb46bc5dbfb50565c2728cffc5b3"
+    },
+    "qcsrc/sound.qc": {
+     "bytes": 14026,
+     "sha256": "535a5b7f80a93054e603ac6aed38b0e370b849c63a9e2d776f7a18708bcb4498"
+    },
+    "qcsrc/subs.qc": {
+     "bytes": 3456,
+     "sha256": "ea2a1d96baa0f9991794472e5eea1ddb299d43104a190ce3b4ae031000437c5f"
+    },
+    "qcsrc/subs_move.qc": {
+     "bytes": 5662,
+     "sha256": "8a495c020bab7e58affe85de8bb84ccccd59cb57082d3d30b013e6760a76faac"
+    },
+    "qcsrc/subs_tgt.qc": {
+     "bytes": 13170,
+     "sha256": "cea0244f1b7aa92326c2775bfa7185f21ddc1c2c28a35d58c4534a8147a8c894"
+    },
+    "qcsrc/t_ctrl.qc": {
+     "bytes": 20252,
+     "sha256": "2d1a04c7bac2b55b2a2eaf255706dd7b06b3a4ca88a375440ca9ae2823009ba6"
+    },
+    "qcsrc/t_level.qc": {
+     "bytes": 15057,
+     "sha256": "24c8c4fce54b623f28dfa518748171574b6ef4bb56ee5e6b457cfce79f53146a"
+    },
+    "qcsrc/t_tele.qc": {
+     "bytes": 22124,
+     "sha256": "a184a2e8265bb384e2716299d80bfdbe3480d3b00999f7cfda8f29991ea87ed0"
+    },
+    "qcsrc/t_void.qc": {
+     "bytes": 19847,
+     "sha256": "cc95c4ae5cebdb1bec2cc46ba18e2c785210ac806ce28b2bf38bbd9bc02beae0"
+    },
+    "qcsrc/test.qc": {
+     "bytes": 329,
+     "sha256": "1db99110de27d9e6fe20330cbfefde0d443455a85a12ae8443d9ea295e66c3f1"
+    },
+    "qcsrc/triggers.qc": {
+     "bytes": 42325,
+     "sha256": "9d6787b3f8b3a8dbeaf43fac9fc1a8da1b81e6b81c6f2498e96d966bad348c9f"
+    },
+    "qcsrc/utility.qc": {
+     "bytes": 19105,
+     "sha256": "5c75fba033346fc3841924c3614c4efbf74fa3d7a2e90acb26d4b1d50f35b031"
+    },
+    "qcsrc/w_axe.qc": {
+     "bytes": 3346,
+     "sha256": "3ebccb0ef8093f879e4618f982a827f9af441300304c6413d2b1297401252194"
+    },
+    "qcsrc/w_hammer.qc": {
+     "bytes": 44188,
+     "sha256": "949048e99a8ca21b222ff7cb00a987f694b96604cb754bff43f2f7a5d0b705fa"
+    },
+    "qcsrc/w_lightning.qc": {
+     "bytes": 10493,
+     "sha256": "f9fe37bff29278d069e9ba64cf724d647b046d2f4b66086d3f2268d15af6f7be"
+    },
+    "qcsrc/w_nails.qc": {
+     "bytes": 4799,
+     "sha256": "7bdd6a079efa97babae3867e2e697d0ff9a0f424c58a07c5ac65c7c3a137b1e7"
+    },
+    "qcsrc/w_rockets.qc": {
+     "bytes": 3622,
+     "sha256": "ac0faf3e7ed5ae469b57bbcc753113939100856eef851cbe5f165e1ad1085f3b"
+    },
+    "qcsrc/w_shotguns.qc": {
+     "bytes": 4508,
+     "sha256": "14cccead121592a9e69d389d7b45771dd8e78e9ab046bc930dbbcb0d54e37d6d"
+    },
+    "qcsrc/walls.qc": {
+     "bytes": 14327,
+     "sha256": "711ec396adc3eff44a1cf99e26f55e9abed1d7c58a2a4ff3a6537b4d71051327"
+    },
+    "qcsrc/weapons.qc": {
+     "bytes": 21191,
+     "sha256": "e6318afda988cc91a2e08f1475588b4b4971815f7a69b848ac2918677ba388eb"
+    },
+    "qcsrc/world.qc": {
+     "bytes": 15805,
+     "sha256": "fea0dd28ab5c35d8ca8388dbd6996c3d5fbf36b933361a450a5b6c0d3cce0ddc"
+    },
+    "quake.rc": {
+     "bytes": 1169,
+     "sha256": "6e65da076ca9a3b946357faf873bd21428c48585485aca4c306e362b5806d6bf"
+    },
+    "sound/brute/death1.wav": {
+     "bytes": 22144,
+     "sha256": "45f001ffe6357e1600b5e7041ce7f29ae4c55c0e6c27a6bad566c4c284f21119"
+    },
+    "sound/brute/death2.wav": {
+     "bytes": 18028,
+     "sha256": "2263b9499a1d7f419fcb1a028db1d34cb4d0b1db257707847730b7f975051fb6"
+    },
+    "sound/brute/deaththump.wav": {
+     "bytes": 34994,
+     "sha256": "e704d883d0b4618ff721922b5bcc72c10cb5c22069823e18ee76d3a0047498e6"
+    },
+    "sound/brute/idle1.wav": {
+     "bytes": 46670,
+     "sha256": "778afa05b143e3a1035bab1718c166bcce27f863d2d45ef9b1bb817e363e836b"
+    },
+    "sound/brute/idle2.wav": {
+     "bytes": 44366,
+     "sha256": "e79e103fd3923e549569e55c2dc5348218fe9cc793e86d3d24e692db031be4f7"
+    },
+    "sound/brute/injure1.wav": {
+     "bytes": 11152,
+     "sha256": "97b3535ee21f8ebb54585a19a544d43aea45e3c56fa05b8b88a75281b347d38b"
+    },
+    "sound/brute/injure2.wav": {
+     "bytes": 7814,
+     "sha256": "b7bb89734f0dadd928522ad97209b311dcb872f47f9ed46dfed09ea548c46c06"
+    },
+    "sound/brute/meleeswing.wav": {
+     "bytes": 6400,
+     "sha256": "e8e571aadac62cb75b88099954fcb9d277cb60a6f9d160930d99ad81548e92b9"
+    },
+    "sound/brute/shoot.wav": {
+     "bytes": 48128,
+     "sha256": "9d1918ad3ff81f85f7ff4bd1f92a5163d1461785e495002f0e272f13a25383a8"
+    },
+    "sound/brute/sight1.wav": {
+     "bytes": 18378,
+     "sha256": "48e8d359ae63446b935dfa240cc8fa82ddaa152212ec939721e71266791ae3d5"
+    },
+    "sound/brute/sight2.wav": {
+     "bytes": 21830,
+     "sha256": "86ad465863325659873300ed964474b00e8b69924c0c97097804ee848718844e"
+    },
+    "sound/brute/walk1.wav": {
+     "bytes": 11984,
+     "sha256": "4a27fc4ce1c1663c124fd4b2aa440850f75a1848d096ef535095d790f1f6383b"
+    },
+    "sound/brute/walk2.wav": {
+     "bytes": 12160,
+     "sha256": "6d67b13902fe615cef6d2851a18b795dc8941456f2f6d882ec8faf8ccd12853f"
+    },
+    "sound/commoncold/ext1.wav": {
+     "bytes": 5051808,
+     "sha256": "9bbb98a5837b75202ed021acf7d4fc9732b015f36781952e932bd29e13f78f17"
+    },
+    "sound/commoncold/ext2.wav": {
+     "bytes": 5494844,
+     "sha256": "641eba344c0f208b3ca95c644fd3e2f16a77dde3f621367a491cd16ea9eb9f60"
+    },
+    "sound/commoncold/ext3.wav": {
+     "bytes": 11453828,
+     "sha256": "b79407d3f2f94fbb26c00ca3d514055677312c809a20e42714452fbe1c48d16a"
+    },
+    "sound/commoncold/ext4.wav": {
+     "bytes": 1003734,
+     "sha256": "4996491652cb9250d1c588337b2a0c74757c503887e7853806030f9c0b9cfb7a"
+    },
+    "sound/commoncold/vo1.wav": {
+     "bytes": 2395478,
+     "sha256": "fb5feb74ed86464b99e7f07936b3f64e9b58edbc8bf52c0c5a05a8eb24c6f550"
+    },
+    "sound/commoncold/vo2.wav": {
+     "bytes": 1990700,
+     "sha256": "33f5a581633de4d5812c6b34d724bbed7ca1b3b40b1255d3a5cfb7d6c21938f8"
+    },
+    "sound/commoncold/vo3.wav": {
+     "bytes": 1813646,
+     "sha256": "d10cccd9f23282b537a2c91e2cc9e08f4a72a3f0fb2f9202dee856bf7fd7add8"
+    },
+    "sound/commoncold/vo4.wav": {
+     "bytes": 1745882,
+     "sha256": "34c427cac22cca06c05b6fed90d6441938b7887ba906f733c8b6864a8887604f"
+    },
+    "sound/commoncold/vo5.wav": {
+     "bytes": 2169900,
+     "sha256": "2f75eedae6bd4471081f10ef23ad5346ccb5fc1938994cc07744d801742ed68a"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 83982,
+     "sha256": "4b0d8db882ab1c9fc2109effeaf125ec46fb23a91ac2242201103e0d3da96944"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/hammer/axhit1_error.wav": {
+     "bytes": 50996,
+     "sha256": "0eb60b4c56a1d52b5e505b8bf06eebf9b1b481d7bec64149b8fd78ecdacf3c91"
+    },
+    "sound/hammer/axhit1_ff7.wav": {
+     "bytes": 12302,
+     "sha256": "d8be990702d5b9c6e62a468c210000688332ab875fefb8f32d1f6496a52e6646"
+    },
+    "sound/hammer/axhit1_floyd.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/hammer/axhit1_guitar.wav": {
+     "bytes": 29924,
+     "sha256": "c43e2ad3775147518f13ccd73d1f4c900f500279d0b5b4f88a9ae9c5eb0b00ff"
+    },
+    "sound/hammer/axhit1_katana.wav": {
+     "bytes": 23724,
+     "sha256": "bef02f06fcb791ce28630563bcd51a142f105ffb83b5735c89784e24f0e962c3"
+    },
+    "sound/hammer/axhit1_squeaky.wav": {
+     "bytes": 17586,
+     "sha256": "1820cafe254f5ad1ec31f089c0b5d6fffc1d3a869eb6e79210023b48495eef7b"
+    },
+    "sound/hammer/axhit2_error.wav": {
+     "bytes": 39960,
+     "sha256": "029b4d9024f2115d7c5d1901f54ad57b098afc1ff898293a5663ec2af08a70d6"
+    },
+    "sound/hammer/axhit2_guitar.wav": {
+     "bytes": 43932,
+     "sha256": "d9cad9916a27785870b081d8bb56123eec8a276310099a57bf9da4deac6ef5a6"
+    },
+    "sound/hammer/axhit2_katana.wav": {
+     "bytes": 24046,
+     "sha256": "55609017b5800ccc4b067ca3a3e4dcff64c07046cdeb8ffb1bc630f19da1e8b1"
+    },
+    "sound/hammer/axhit2_squeaky.wav": {
+     "bytes": 14672,
+     "sha256": "6dcc45c3b5c4f68c50c9105a78970be3d39b487e90e76475023bb160779d9c58"
+    },
+    "sound/hammer/axhit_squeaky.wav": {
+     "bytes": 21042,
+     "sha256": "e3d5fc7ef9daef101a0c2148495db27ab00e6a215898afd0866225afbb24d0b4"
+    },
+    "sound/hammer/charge_full.wav": {
+     "bytes": 69420,
+     "sha256": "961b4d110387ef514b25d4062e2635913fe179683b32824e0944d3292a0ff320"
+    },
+    "sound/hammer/charge_full_error.wav": {
+     "bytes": 14538,
+     "sha256": "064972cfa55c2e4e40ca9a67e6c8a992bde4048be74cb131df034a666b0cadeb"
+    },
+    "sound/hammer/charge_full_ff7.wav": {
+     "bytes": 16374,
+     "sha256": "2850ba728ab9d099b82b617af007f09ab5d87c054ec36775a3f00f39a08da8f7"
+    },
+    "sound/hammer/charge_full_floyd.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/hammer/charge_full_guitar.wav": {
+     "bytes": 17202,
+     "sha256": "49b00541f3f6392d3f764c7f75073c47f9709bed0c6fdb2198d97cbcd80b4c9a"
+    },
+    "sound/hammer/charge_full_katana.wav": {
+     "bytes": 32300,
+     "sha256": "b233e11dd39522108016898ec07391742d7573995ae16db26c03eeb2fab4fa82"
+    },
+    "sound/hammer/charge_full_sceptre.wav": {
+     "bytes": 113452,
+     "sha256": "0e0b002ec2bd317b23d21d0b68287aa8fc2b9a9d63e00037d31df69c498ef50b"
+    },
+    "sound/hammer/charge_full_squeaky.wav": {
+     "bytes": 23814,
+     "sha256": "75177d11d8e477a7933ed09d9175f4bd49e997a07879d4767f509f68b1900536"
+    },
+    "sound/hammer/charge_med.wav": {
+     "bytes": 24108,
+     "sha256": "dd7de8af6c24217fa7fca1d4d0d28131e2d52a48313d5a3f43fefe3fd2aa7cfe"
+    },
+    "sound/hammer/charge_med_error.wav": {
+     "bytes": 14228,
+     "sha256": "b0d02364ea65a1a7c63d1ac8a30aec7424852895e1428258198e128e8bee6bec"
+    },
+    "sound/hammer/charge_med_ff7.wav": {
+     "bytes": 4158,
+     "sha256": "2ec220806a834485b7dd65898ee28a51c4eb3b903a6d4447a29c1a69b1653700"
+    },
+    "sound/hammer/charge_med_floyd.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/hammer/charge_med_guitar.wav": {
+     "bytes": 17632,
+     "sha256": "d01e6a4071ebb51f7cc4c00dbe0e3ac3e5d9dc2d88a0fa123c2b6daf8106e328"
+    },
+    "sound/hammer/charge_med_katana.wav": {
+     "bytes": 40972,
+     "sha256": "e5330d94a28e77666ec0aa8f7696e08a7053a08bf518173b3e9dec7a60eba4ca"
+    },
+    "sound/hammer/charge_med_sceptre.wav": {
+     "bytes": 41132,
+     "sha256": "31c89c0a5ede3f6828662b96473ff28f555673225493c54555a283bdffc5dfb1"
+    },
+    "sound/hammer/charge_med_squeaky.wav": {
+     "bytes": 25046,
+     "sha256": "5a254061e033c6193216fc04488cf2e238ec52c51ef6d1d1437992ba17f70e18"
+    },
+    "sound/hammer/error_kill.wav": {
+     "bytes": 63174,
+     "sha256": "ee7daeb475bc2e2d8f703c4d9f2a7c96a09372205bde92620b902a78cebe1641"
+    },
+    "sound/hammer/ff7_kill.wav": {
+     "bytes": 20446,
+     "sha256": "d97532f49865bc6dfda51c04597f6f6df9411ad504f9fec182b8e0e190710f8c"
+    },
+    "sound/hammer/floyd_kill.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/hammer/frying_pan.wav": {
+     "bytes": 61484,
+     "sha256": "3dad623719f285ed94455e551c5756259e088467852648b2c4e11011e33dddb6"
+    },
+    "sound/hammer/guitar_a.wav": {
+     "bytes": 213096,
+     "sha256": "ab084d63b54e22072461bda0b4095f5ecd3f16c967145b87ff846e176ed12466"
+    },
+    "sound/hammer/guitar_b.wav": {
+     "bytes": 194664,
+     "sha256": "14c3f311bec1efa9c8665f4344f87f555de1f47d72d0717d6a4bbd9952a437fb"
+    },
+    "sound/hammer/guitar_d.wav": {
+     "bytes": 173160,
+     "sha256": "9d9e6cbae33f5854cd2abb1391c89f754f56860935cb6e3a787a6220ace46f0f"
+    },
+    "sound/hammer/guitar_e.wav": {
+     "bytes": 204332,
+     "sha256": "ff9814788aee5e58bbfb4aab74db72a86351cef8d3d4724b3211b6e7dde6401c"
+    },
+    "sound/hammer/hammer_clang.wav": {
+     "bytes": 222252,
+     "sha256": "0aab43d6565a34d6f6ba9c3626fbdaf0c15a4c21e2644a1f178e17ac7a4cf834"
+    },
+    "sound/hammer/hammer_clang2.wav": {
+     "bytes": 50220,
+     "sha256": "098549f0978b16e685d3ccaf0837c5dbad045626980629a21edf464b2b49d871"
+    },
+    "sound/hammer/hammer_clang2_error.wav": {
+     "bytes": 40034,
+     "sha256": "16641cec3afdddd998b40cc5806ba8bbae7e5c44e835591b048b658e217aaa3d"
+    },
+    "sound/hammer/hammer_clang2_ff7.wav": {
+     "bytes": 20446,
+     "sha256": "2df574087a15fffe9f3b0d556dd27c4b64270bcc9b8d3af110aa59eef0ee28a7"
+    },
+    "sound/hammer/hammer_clang2_floyd.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/hammer/hammer_clang2_guitar.wav": {
+     "bytes": 34904,
+     "sha256": "02b9e9ac4c4473086970b4c89b0c25989a6a323fb5c6cd2d42a6723ffa6d3b87"
+    },
+    "sound/hammer/hammer_clang2_katana.wav": {
+     "bytes": 13996,
+     "sha256": "26056f0ed4b700cfdfc335ed303968c48d124398e62e0079fc823fbc2defd57e"
+    },
+    "sound/hammer/hammer_clang2_squeaky.wav": {
+     "bytes": 10738,
+     "sha256": "2191ac2cd7cb0b594bf77e791f0d2ab25ea115b46e3cb04805457955c3387742"
+    },
+    "sound/hammer/hammer_clang_error.wav": {
+     "bytes": 39362,
+     "sha256": "2376dd047957249cc7f934cde50b8f88cc02cc2bc00dea839b0a734ccf10ce36"
+    },
+    "sound/hammer/hammer_clang_ff7.wav": {
+     "bytes": 20446,
+     "sha256": "4b85f755e4c89f9fdbbfbab9847d0a735628a97c8651e67aec03ee031920ad0f"
+    },
+    "sound/hammer/hammer_clang_floyd.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/hammer/hammer_clang_guitar.wav": {
+     "bytes": 101020,
+     "sha256": "ba7014a0bddcdd0350478389b4ae301043862fafeca18338d84f68abcad967c5"
+    },
+    "sound/hammer/hammer_clang_katana.wav": {
+     "bytes": 42784,
+     "sha256": "811ce03a86a70494cf188a8e3108256cd2fd7fab493e0f7f64c4cbd0acdaba14"
+    },
+    "sound/hammer/hammer_clang_squeaky.wav": {
+     "bytes": 34526,
+     "sha256": "5d428919122eed39103ea954066c1d5ea24626b4f7cd189f50459580ced1f974"
+    },
+    "sound/hammer/hammer_unlock.wav": {
+     "bytes": 95756,
+     "sha256": "6f26159b9f71d36198d9b1571460f7424fed9a8fb46f1514ca774acad93e85de"
+    },
+    "sound/hammer/katana_kill1.wav": {
+     "bytes": 65486,
+     "sha256": "213cba5925ebf3ae0427179d7db5fed5841343e8b172a1cc38fc2e55be095d94"
+    },
+    "sound/hammer/katana_kill2.wav": {
+     "bytes": 63976,
+     "sha256": "7c9906df9d4fe2002a70e969009b164e5897b2955d24fb5dbf486eaec5871da6"
+    },
+    "sound/hammer/katana_secret.wav": {
+     "bytes": 120414,
+     "sha256": "5895b98c11d1a81b22731b2bd07f389d287b0ea5c4822ea78ea31721c6d2a677"
+    },
+    "sound/hammer/slice1.wav": {
+     "bytes": 44836,
+     "sha256": "6049393e32aacb60e2393da6557ec992350631ebcf948824ede22e749d3a7eba"
+    },
+    "sound/hammer/slice2.wav": {
+     "bytes": 44836,
+     "sha256": "8ad23cfe0c9f3dc555287dd9923faf794c8ad8be82effa2f11863d76c8344e71"
+    },
+    "sound/hammer/slice3.wav": {
+     "bytes": 44836,
+     "sha256": "ae202290d52822864bc145c754913a53745aa880be021eacc25202e479bc1b05"
+    },
+    "sound/hammer/slice_hit1.wav": {
+     "bytes": 49440,
+     "sha256": "b55eea3e9f4a2aa6cac0965f0f11a001047f75cb3d599f0ea4cf840314fe89c7"
+    },
+    "sound/hammer/slice_hit2.wav": {
+     "bytes": 55326,
+     "sha256": "688270bc26b420053c98d94869efb39eb4950dab623584888eb4ed87fe7517cc"
+    },
+    "sound/hammer/slice_hit3.wav": {
+     "bytes": 48970,
+     "sha256": "aafb92ce9b4e58cd3ccbd89ab41602d31c72ce64b7bd937ac7b547141668feeb"
+    },
+    "sound/hammer/squeaky_kill.wav": {
+     "bytes": 24994,
+     "sha256": "d8d69076c3e2924f5225f00b08370371233780324eb96e50b7340def94fae82c"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_g_charge.wav": {
+     "bytes": 28358,
+     "sha256": "db3b36d46abcf402002bdfa10cdc03d19e8d51c25115310b8842546fce4d8070"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/items/shard.wav": {
+     "bytes": 38934,
+     "sha256": "bb6a69c5cadfa4128886815e429812977e82de5ca2db59fe6fe1faa57be658c3"
+    },
+    "sound/megashambler/msawake.wav": {
+     "bytes": 37520,
+     "sha256": "63b71cc3adc3b57d9041f0507482f2eb64941190c41839fc504ffe8ebba7338b"
+    },
+    "sound/megashambler/msdeath.wav": {
+     "bytes": 61164,
+     "sha256": "05ed0537a8125f76036452067669562a81abb7f1de8f44a8db25e852a711b3a3"
+    },
+    "sound/megashambler/mshurt2.wav": {
+     "bytes": 4302,
+     "sha256": "64e930df679789e6d2cd9a2b4e9300ea02f17cb8926777db9c31b6c79e03ca76"
+    },
+    "sound/megashambler/msidle.wav": {
+     "bytes": 76934,
+     "sha256": "51945b4d89a8c608ccfbbb0da0795b4b68e94ef9066ac9a4ca5df9b04f103d79"
+    },
+    "sound/megashambler/msidle1.wav": {
+     "bytes": 12116,
+     "sha256": "6aa0a2cf1d80bb85f24ce5fbecbfdb67472698e79a5ba52cd344440690eec56e"
+    },
+    "sound/megashambler/msidle2.wav": {
+     "bytes": 39802,
+     "sha256": "82e505bb1ad777f701437f17931589c0167cdf5ff1edf5ebd77651e41914dcad"
+    },
+    "sound/megashambler/msidle3.wav": {
+     "bytes": 11742,
+     "sha256": "8d1c1f8196481d676f26c492ace6342e8f9e976679a9933ccf897f49cdf10b26"
+    },
+    "sound/megashambler/mslightning.wav": {
+     "bytes": 8036,
+     "sha256": "efa18dec8f6d5066b8d494a232ca9c98c27a4a9130130086a9b0a27ffccb34ed"
+    },
+    "sound/megashambler/msmack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/megashambler/mspain.wav": {
+     "bytes": 37520,
+     "sha256": "63b71cc3adc3b57d9041f0507482f2eb64941190c41839fc504ffe8ebba7338b"
+    },
+    "sound/megashambler/mssight.wav": {
+     "bytes": 15420,
+     "sha256": "9aff3b6cdac49976a4fe97b88ca14bc928ef55a14929fc796ae2b23148422f3b"
+    },
+    "sound/megashambler/mssmack.wav": {
+     "bytes": 10560,
+     "sha256": "6684ae6e141f5ced5e305682f4f9b7b1b2cad017ac02ac08371c061883cb88c4"
+    },
+    "sound/megashambler/sattck1.wav": {
+     "bytes": 8036,
+     "sha256": "efa18dec8f6d5066b8d494a232ca9c98c27a4a9130130086a9b0a27ffccb34ed"
+    },
+    "sound/megashambler/sboom.wav": {
+     "bytes": 11672,
+     "sha256": "6c64dafb52536ae35f9d50cd5f6c5c636f3403b83cac4d1e55e62e913e2ca79b"
+    },
+    "sound/megashambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/misc/baah.wav": {
+     "bytes": 66794,
+     "sha256": "5da2b4f07c308aef0d6fcaad4fcfb16c0a783238911e0a7d5343b3272d053d24"
+    },
+    "sound/misc/ms_waterdrain.wav": {
+     "bytes": 1802020,
+     "sha256": "15154f4bfc348fddd064c484cc2a4616ddcf420a1fee7449ebb5ebbd1e608bd7"
+    },
+    "sound/pinchy/bridge-break.wav": {
+     "bytes": 33446,
+     "sha256": "9d3fe8ff92dbc726bd3d8bb123ef2a09d73584a05510ea0367d09a167fc8414e"
+    },
+    "sound/pinchy/wall-break.wav": {
+     "bytes": 22656,
+     "sha256": "1b336e22926b17c1b103b0b6dbc95ba35eb1066af24bc9426b0797597ca6e830"
+    },
+    "sound/roj/waterocean1.wav": {
+     "bytes": 308916,
+     "sha256": "b1cf4f77a54d45db71b17a8daf35cf738c9dbecdcc55ebe569bbfaec60917752"
+    }
+   },
    "sha256": "6989578c0107bab790f8da46ebab94f4c884f3125410ff716c64eb012ae3caf0",
    "timestamp": "2024-07-30T01:33:06.000Z"
   }

--- a/json/by-sha256/80/8048b61c3155f2a3a7f3f740abb6497d0a53fe0a32adfe1bb4c9f211a076cbb3.json
+++ b/json/by-sha256/80/8048b61c3155f2a3a7f3f740abb6497d0a53fe0a32adfe1bb4c9f211a076cbb3.json
@@ -12,6 +12,236 @@
   },
   "PAK0.PAK": {
    "bytes": 7197455,
+   "files": {
+    "maps/mexx10.bsp": {
+     "bytes": 2374808,
+     "sha256": "5635700d39414c8d57d6111ef24d490064e4c130c6f1c47d57b93adee5306a21"
+    },
+    "maps/mexx10b.bsp": {
+     "bytes": 2119772,
+     "sha256": "b077639699377d12448e31fb58085ad390c31d6536cd697c532b2f40f7deb104"
+    },
+    "progs.dat": {
+     "bytes": 549444,
+     "sha256": "0e29976d0d20d01752c16f0565bdbc6c042f5e654c4e687693ee22e2dbc76e48"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 218412,
+     "sha256": "8878b79bb9fee049b0e75314433ad9ef90fc9a7dc3b148c9e02835d0a0ab66b9"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 31104,
+     "sha256": "4ea4b07b6e2913b91fdd8812e5328d054c75bd79715344be2ad1b798cc7568b8"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "4842cb06e22c6b1f80de8659fb0c7ece1a29a5797cff3fbeaee04bffa363e96d"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 146288,
+     "sha256": "8d38139342c6451537be026badcb9d562f7c8f593e939e40e8a06937b4df346e"
+    },
+    "sound/ambience/back1.wav": {
+     "bytes": 29044,
+     "sha256": "4caace7efee0535a545e462902d3aab1989f9ddfc9d5b6bbdce344a113585fc5"
+    },
+    "sound/ambience/back2.wav": {
+     "bytes": 22418,
+     "sha256": "993d9d47e354673b1aa3b9e04a4d786e7ca029b5561301e9933ef0e0db6287f7"
+    },
+    "sound/ambience/back3.wav": {
+     "bytes": 40484,
+     "sha256": "f3cfa81848177963b5403cd5fa80bb02c409502519836cfacc53f450c3a02bee"
+    },
+    "sound/ambience/back4.wav": {
+     "bytes": 37296,
+     "sha256": "e82efd189be0e367c648ab1526e0f700507deac329aeddd6984ed2dfc0bde916"
+    },
+    "sound/ambience/back5.wav": {
+     "bytes": 4814,
+     "sha256": "b7f4e2aa8b1ee4f7bb235777514c07a5addac7a9fb0faf7f3e0cf767e4419078"
+    },
+    "sound/ambience/equake.wav": {
+     "bytes": 35556,
+     "sha256": "18e06698f5522371b1a9ea9a49fcdfdcf52af14e1f26ad98cfde9666132bc55f"
+    },
+    "sound/ambience/fanfast.wav": {
+     "bytes": 6130,
+     "sha256": "cecfe8686dbe1ba43919fc0a58f8d0d2e36f071d5a799b086a2e56292bbafa35"
+    },
+    "sound/ambience/fanmid.wav": {
+     "bytes": 8434,
+     "sha256": "8ce4214cbf5519b66eabb2dfa72815b2cf45c7fc8eb804776a13c3449134323f"
+    },
+    "sound/ambience/fanslow.wav": {
+     "bytes": 13414,
+     "sha256": "4b6916ebfbe125b68774d3da26309ab6181a8de62c5c04acf7c65b0c85df9092"
+    },
+    "sound/force/off.wav": {
+     "bytes": 25260,
+     "sha256": "52e0d8ce1a9d73459ec41386de2b47a164d2ab41dd159fcffd969eb2480a814c"
+    },
+    "sound/force/on.wav": {
+     "bytes": 4794,
+     "sha256": "caf8093abce563f55bfe2d7b5cfbbe31695333c9715cf9e2c6e8724e88af9cdb"
+    },
+    "sound/force/short1.wav": {
+     "bytes": 7580,
+     "sha256": "1f374c39740ddc9b691b6260d04caa8a25e7a122930e12723b0ba006f26d7ee4"
+    },
+    "sound/misc/charge.wav": {
+     "bytes": 22526,
+     "sha256": "88bcd59a89853f69b74b610e2949f49c266d7298046986f01bd7fcb4263260e4"
+    },
+    "sound/misc/ffield.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/liftfail.wav": {
+     "bytes": 57096,
+     "sha256": "c17b9b94e17450ddb27df5a0103c4be293393961c9a4909a0a51fc1bfacbd8bf"
+    },
+    "sound/misc/liftloop.wav": {
+     "bytes": 64438,
+     "sha256": "223ea82cd9ef67f8752087d6999daaa5981b81d68f9627a2fb73013acc26f02c"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "93cb9a78f016cdcbd8932807a17de79bae1f161c995570bf81f3faa5b077f072"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27479,
+     "sha256": "47c049c827a991d75692c5668c542d430beee5239a1437bb0c3fd0fdb61d892c"
+    },
+    "sound/mother/ainvalid.wav": {
+     "bytes": 49458,
+     "sha256": "fec10e0db4474596470ec93dc66a5147d8c598fb6d24374b2eed42472caa93b6"
+    },
+    "sound/mother/breach.wav": {
+     "bytes": 22150,
+     "sha256": "fbc4f854bc053c12224b824cf7292cc1741cc5363499f36073436481c6a0d93b"
+    },
+    "sound/mother/cheater.wav": {
+     "bytes": 14194,
+     "sha256": "c29c10988bb4a80553da3a01beeb5ed62be3d562ea88eb6d2d5b2d61d544d5bc"
+    },
+    "sound/mother/count.wav": {
+     "bytes": 467838,
+     "sha256": "6ede6e5b0a9689c37dcc3bc2bc2fd849027948d79811dfc7030260b79f987782"
+    },
+    "sound/mother/elevator.wav": {
+     "bytes": 30130,
+     "sha256": "e3a52cc4d01e414af77fc57da4679efe0502fe318d7cb0e211fd9ac5357a8183"
+    },
+    "sound/mother/elevmal.wav": {
+     "bytes": 41840,
+     "sha256": "1da1770cde87827f3c577bfd600a8b8870f2bd4897e25424cb9d45943d431e91"
+    },
+    "sound/mother/elim.wav": {
+     "bytes": 33920,
+     "sha256": "a2647900b76ec8b28fc9f771fec82f4637b9fbe62cdaa8c5af0a47aeb068cd94"
+    },
+    "sound/mother/endboom.wav": {
+     "bytes": 102956,
+     "sha256": "f2625745cd6e090fcbd9e8c66fb22bc452708c02205b55da8365bdd600b16aea"
+    },
+    "sound/mother/forcedea.wav": {
+     "bytes": 43944,
+     "sha256": "a764a24b83c386cbf8edef53fa32079206d02cfdfa42afff87854006e40c80b3"
+    },
+    "sound/mother/intruder.wav": {
+     "bytes": 26412,
+     "sha256": "1ab011a0869605c0623c93c1d8a1a885190f67a1050dcc01c873fb0a9f87a201"
+    },
+    "sound/mother/kaccept.wav": {
+     "bytes": 22642,
+     "sha256": "2c5d4d4ea9d2e4e985e09326a79bb1f47a1275656e19471a110ecf515fdef2c0"
+    },
+    "sound/mother/kreject.wav": {
+     "bytes": 24636,
+     "sha256": "22a6c8d714332fded6da494897a8eded7d145aae94d94281a69449b709f7fdce"
+    },
+    "sound/mother/warning.wav": {
+     "bytes": 14574,
+     "sha256": "bc51a0985c9425eaa4720c883c112d8761f8481b5f0d3d2771aad9328abab909"
+    },
+    "sound/swat/death1.wav": {
+     "bytes": 12326,
+     "sha256": "c899fe19a1758e106544686ae1ce3856c1c6af966ec1c412a415406297fb6a76"
+    },
+    "sound/swat/death2.wav": {
+     "bytes": 18214,
+     "sha256": "ec4856f0bbea6f57b630d309584e952b4001930f989793229f05c4f65daec2a5"
+    },
+    "sound/swat/death3.wav": {
+     "bytes": 14790,
+     "sha256": "a829872b22e998d81f1c069d14056cb1d0c0fc01b1fd7da82e88f7bb19a887da"
+    },
+    "sound/swat/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/swat/enfstop.wav": {
+     "bytes": 4325,
+     "sha256": "d3792af1a9141119589d57ef00b95ea32d4127f9590c3d2e82d3689407610cf9"
+    },
+    "sound/swat/idle1.wav": {
+     "bytes": 30022,
+     "sha256": "c76f41b2732cafe99ee9938496ad68d590cc32e9816a7521c89670f94b8e9639"
+    },
+    "sound/swat/pain1.wav": {
+     "bytes": 4989,
+     "sha256": "459faa98a2b1a8e40b9dbe6a8bf1e232f403e8c40105723576bf4a74555b2c08"
+    },
+    "sound/swat/pain2.wav": {
+     "bytes": 9318,
+     "sha256": "db7bb2315b1852e3480af81c02bb5215b7ff730b342557fbdbc9a315db9289d3"
+    },
+    "sound/swat/sight1.wav": {
+     "bytes": 16966,
+     "sha256": "8eb25dbd33fc23878aad58c970456eecf52406bc4a10663afb9640273bd9fc34"
+    },
+    "sound/swat/sight2.wav": {
+     "bytes": 21734,
+     "sha256": "c8db3fbc2095bfbf6edf4943fe90bb575609b25310099ee3164015b2e1aaebd5"
+    },
+    "sound/swat/sight3.wav": {
+     "bytes": 12998,
+     "sha256": "b85255bf4a62cc21e0c14cec7a8909889037c176b7e251fc9e70343941d0230a"
+    },
+    "sound/swat/sight4.wav": {
+     "bytes": 18054,
+     "sha256": "b78dd977c95441a871a950eb29c34589ea7a79225e2d8587f43e4fc32dd04d7c"
+    },
+    "sound/swat/sight5.wav": {
+     "bytes": 16050,
+     "sha256": "7b6aebd08f6a193d626d55a48bbe6be3f7bdbe235e132cb23a50345fe00dbb7a"
+    },
+    "sound/swat/sight6.wav": {
+     "bytes": 10962,
+     "sha256": "07e4cfb68ea720e447e93a97ca76bba75dcd6c4ce128030c029f130f5c254e0d"
+    },
+    "sound/swat/sight7.wav": {
+     "bytes": 23070,
+     "sha256": "59bc80aba930e7c37c25d103190b200e38ac49eb2bc4e30ccf63c55881be3089"
+    }
+   },
    "sha256": "bdab2f00c5338bc20fdc63e0c4f6bdcfdcc772c91d811a1f7d0075d60ebbabe9",
    "timestamp": "1997-12-10T14:36:40.000Z"
   }

--- a/json/by-sha256/82/8216cf9d57dfe38aaf2bf13a6347e21c724faa68a4d84eb3344cd15668ac592b.json
+++ b/json/by-sha256/82/8216cf9d57dfe38aaf2bf13a6347e21c724faa68a4d84eb3344cd15668ac592b.json
@@ -7,6 +7,12 @@
  "files": {
   "Pak0.pak": {
    "bytes": 17496,
+   "files": {
+    "maps/b_explob.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    }
+   },
    "sha256": "2b093f835a5d9b516b438b6a5ae4cee0f2ceed46d4ef842c3b267f040b9f1596",
    "timestamp": "1996-12-29T16:45:24.000Z"
   },

--- a/json/by-sha256/82/8297cb7f82348b6fae2ff9cbc87aa8517f2e40c8fee59b1115892e1cb86e7b7e.json
+++ b/json/by-sha256/82/8297cb7f82348b6fae2ff9cbc87aa8517f2e40c8fee59b1115892e1cb86e7b7e.json
@@ -10,6 +10,11 @@
    "sha256": "13d1fe074f64f5a03f96e79456c2a0b4d0a9b927026c68bff80a337bb81be3e7",
    "timestamp": "2025-08-06T10:31:54.036Z"
   },
+  "maps/": {
+   "bytes": 0,
+   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "timestamp": "2025-08-06T12:32:24.000Z"
+  },
   "maps/grenedin.bsp": {
    "bytes": 7296896,
    "sha256": "20847c74c7b8132062e7dceab847b0b9a79f76952e747d930302172ab1510ec5",

--- a/json/by-sha256/83/831806d2a176f4e2d48769c5e07859ad0059cd5d15c12c12e5e84e902357983e.json
+++ b/json/by-sha256/83/831806d2a176f4e2d48769c5e07859ad0059cd5d15c12c12e5e84e902357983e.json
@@ -12,6 +12,428 @@
   },
   "pak0.pak": {
    "bytes": 30400821,
+   "files": {
+    "its_demo1e_readme.txt": {
+     "bytes": 9766,
+     "sha256": "66d92be6c59225df5578cc830d83f42680a766c7c629b4fe4d733539805a64df"
+    },
+    "maps/s1m1.bsp": {
+     "bytes": 5711656,
+     "sha256": "82db8fe2043540f8ad3247f0e6d05ce6153907a18cdf18f3ef8d0f3849464772"
+    },
+    "maps/s1m1.lit": {
+     "bytes": 1455452,
+     "sha256": "2eeec453baa1e786f0595250d1507c6e11ffebbdf915146b1949680dfd4383c0"
+    },
+    "maps/s1m2.bsp": {
+     "bytes": 5266728,
+     "sha256": "5588bf1df48583b9c01f1e3bfe1ce04f08d287f847de4237391435acac86813d"
+    },
+    "maps/s1m2.lit": {
+     "bytes": 1419440,
+     "sha256": "fd2b8bff1127b02c812b994493002e45e1251290241b6d08bf8e1b997034e4e7"
+    },
+    "maps/start.bsp": {
+     "bytes": 6937596,
+     "sha256": "931acc2f037571c46dc7c00bcec3d5d8ee723d3c6e550423ec3dba6d35d6780f"
+    },
+    "maps/start.lit": {
+     "bytes": 2052068,
+     "sha256": "6ddcab70eb427a017d39d0c6add5bcc22bc1c96f44391680a7fe49d934e691ea"
+    },
+    "progs.dat": {
+     "bytes": 764336,
+     "sha256": "e209c128ea90ae5aeb0260563aac7d57eafd47ebcc003bfccf32f911a96ed514"
+    },
+    "progs/aicorner.mdl": {
+     "bytes": 97266,
+     "sha256": "3c3a64b599fb160b0b6e900321e65bd7eb821a0a96b2b1e3905902d288f31a93"
+    },
+    "progs/aimarker.mdl": {
+     "bytes": 31346,
+     "sha256": "092a1a56f713d44d671fed07db08acf85ee6279a66ae9801b7a8cce6938fbc19"
+    },
+    "progs/amulet_shad.mdl": {
+     "bytes": 10224,
+     "sha256": "3372d843b29b2f55230fe0d795639df78e97a8d67a81a780afd2706da8f4493a"
+    },
+    "progs/bonequad.mdl": {
+     "bytes": 41384,
+     "sha256": "7bda2ae0d6e5953bfe6520ddd3f78d8f3703f9b45c476fa718e0eb05f40d786a"
+    },
+    "progs/book1.mdl": {
+     "bytes": 45512,
+     "sha256": "4e506c934a1c772457e33d2c18816aab8c51d0655b7bf27f2e0060de1cfea39c"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21828,
+     "sha256": "efdd3e3e680b294d153f460592a67690c6e65954831ccb679321396d99b4e916"
+    },
+    "progs/dead_demon1.mdl": {
+     "bytes": 61320,
+     "sha256": "6e9a4367933bd5f7ae8183213afc97b58c8aa9d66c427212e23a6d8584ca05d6"
+    },
+    "progs/dead_dguard.mdl": {
+     "bytes": 70452,
+     "sha256": "00a20081846e468c80505122ad9f293f4ead396b9d18c73d8f283f1b232836f2"
+    },
+    "progs/dead_dguard2.mdl": {
+     "bytes": 70452,
+     "sha256": "1120a8eec3e1b90828c3dc04fef5368842299d766f86c0e831d95d372ec5c210"
+    },
+    "progs/demon.mdl": {
+     "bytes": 291123,
+     "sha256": "0f0fe4a20a4713c46f6b863529d5c4ddc7f14f2c47b5547034040676012267f3"
+    },
+    "progs/dg_sword.mdl": {
+     "bytes": 8916,
+     "sha256": "72b137f131b85435256487f9ebd105a3dd8630686c57e9428fc8c60cff3aa25b"
+    },
+    "progs/dguard.mdl": {
+     "bytes": 709452,
+     "sha256": "e9fa00403ba65071a65315ebdb8c354d0e72f6b74a75c3ee3d7715b3c429c4db"
+    },
+    "progs/dk_sword.mdl": {
+     "bytes": 8916,
+     "sha256": "2042b9940771449537944e18b5acc6ae5fb8340315e8a38c0e8774d892f0b59a"
+    },
+    "progs/dknight.mdl": {
+     "bytes": 1044476,
+     "sha256": "d04cc57cb46ca60d4c1f7b71afa696b84a1edbe8af3c9a8f5a1d22ab2e05ed36"
+    },
+    "progs/g_crossbow.mdl": {
+     "bytes": 15028,
+     "sha256": "b92c45cfd471cad77ed86b6fbf5574d1f043a1e4f188e20efa91d2b69505741a"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 10836,
+     "sha256": "2c9f51f567356fa2d428f33f6d9b0e1c663d6302ea648f33773bcd18bb749c52"
+    },
+    "progs/h_dknight.mdl": {
+     "bytes": 12932,
+     "sha256": "ab90d86e244ca5c3df04330f7019e2631449d8def045f9b101af662c5747cefe"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 13444,
+     "sha256": "b14ecc00a70a8b5ef14cbd19b73be27a4cc84c042a80951bc9d3f57cb9c1e776"
+    },
+    "progs/h_pdemon.mdl": {
+     "bytes": 34884,
+     "sha256": "3b9e5467c4d31c1d0b7ea2e90e0ee66446dd8f50566abe270d6bb9bcdf8665d8"
+    },
+    "progs/item_medcells0.mdl": {
+     "bytes": 6980,
+     "sha256": "fa73e1d436bf315654ca49874a2b01e3208b739cabbd3e91bbce0267893bfc00"
+    },
+    "progs/item_medcells1.mdl": {
+     "bytes": 6964,
+     "sha256": "016a4d13ad45ae67f38b482fab3d9a4e9534b75dbdeb566ab6945be8b8fed4e7"
+    },
+    "progs/item_medheal100.mdl": {
+     "bytes": 7764,
+     "sha256": "dc530514c19c53b8f2a4bae79a7cdc421b21df72a5e6c1e6af28e88b2f7d7366"
+    },
+    "progs/item_medheal15.mdl": {
+     "bytes": 7124,
+     "sha256": "6c6d15119b6d0d21ef6872a5969a55493063d9860ae751f58d582fa5651a9814"
+    },
+    "progs/item_medheal25.mdl": {
+     "bytes": 8788,
+     "sha256": "7d1693cea108b2663e0377d9399a9870e94181ab4c1610db9fbe9761795ab063"
+    },
+    "progs/item_mednails0.mdl": {
+     "bytes": 5604,
+     "sha256": "8e6c10d3df6772d482193732ca08e4139e20ce99716b84b0d6dbe5f34db8412f"
+    },
+    "progs/item_mednails1.mdl": {
+     "bytes": 6820,
+     "sha256": "3adfee3bcd0c43d8157f296bb6f74d7c3414a81e00e1dfc7dddf51b55d008072"
+    },
+    "progs/item_medrockets0.mdl": {
+     "bytes": 7092,
+     "sha256": "19ce09bd08a967b76fe32067ea6dfdc60b8b97c43d72f4f15ec44e7a16443be1"
+    },
+    "progs/item_medrockets1.mdl": {
+     "bytes": 12693,
+     "sha256": "cb5e18fc5bf5c6de0cb7dbb5e40c9ab1921dd5cb57b1500402dfb01586d5da0a"
+    },
+    "progs/item_medshells0.mdl": {
+     "bytes": 5396,
+     "sha256": "9bc2dacf4a7a07d2d564f0b4a4458aa509ea1fc22c310889a8057543416c51fe"
+    },
+    "progs/item_medshells1.mdl": {
+     "bytes": 8436,
+     "sha256": "4665a998a5c7063db5e607d39131c3c5fc466b7c922bc1d29ca5bbbd158eb935"
+    },
+    "progs/item_poison0.mdl": {
+     "bytes": 11230,
+     "sha256": "0ed32796721be1d411296fa7791f45186f62f00486281095039b40138e67856d"
+    },
+    "progs/item_poison1.mdl": {
+     "bytes": 23837,
+     "sha256": "07a9f9fa2f2e2add5cc3153fcb3d3e5d8e73368d6ca3e4b7e0e8180dc9d80872"
+    },
+    "progs/ks_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "34936456bcf8c907a57ec86de22ca4c284f9ccd5c2400e811678240cba3f1816"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 580080,
+     "sha256": "c9df8c2624b72840da5270a99f1e2fcbc849d0c5bb110602f81acc20f147cafa"
+    },
+    "progs/p_gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "7611ec47cd064b2766b3a926c5bb8fd7d0e77f40ad4fb6ef18f171e68edbca63"
+    },
+    "progs/p_gib2.mdl": {
+     "bytes": 16228,
+     "sha256": "1bdf1cdd0ceb5bae4c61ba2c9224515349b724df9aa384ce91a1909ffb1a66b0"
+    },
+    "progs/p_gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "270bf0388805d026c982fbda74a21cd452a427d83d0407d0c92df847c93d0299"
+    },
+    "progs/p_gib4_zom.mdl": {
+     "bytes": 10196,
+     "sha256": "1cfcd8cc86148f9984ab39d19411dfb9ae52aa5f02f804dd604362008aeadd31"
+    },
+    "progs/pdemon.mdl": {
+     "bytes": 291126,
+     "sha256": "c672c557439a98d99c6c6842953cc8bedaa8e5b6ab1dc715a9a66e34f20676ee"
+    },
+    "progs/pentfloor.mdl": {
+     "bytes": 21172,
+     "sha256": "fb10c551bc21b9f470adad2e7804cd85cac1dfa117a9b55699289297e1a41017"
+    },
+    "progs/plinth1.mdl": {
+     "bytes": 6196,
+     "sha256": "1ce0b7f49153f717e04436b27863c75f90a73b027c4cb7e36ce094fa037eded4"
+    },
+    "progs/plinth2.mdl": {
+     "bytes": 6164,
+     "sha256": "8527f7c85b9a0c5a32e2326c2aed529c87cdaea751f2529b86cee35754ff962e"
+    },
+    "progs/pzombie.mdl": {
+     "bytes": 186084,
+     "sha256": "7f5442f55e8265dbce89b43b924a4f0aed0adff0e7c4d998b0af877f5b67a013"
+    },
+    "progs/s_bookrune1.spr": {
+     "bytes": 1140,
+     "sha256": "b9fc52d2ca728fffa4c282d818b68aeec3555a0dbad3cd1507199d534db1f047"
+    },
+    "progs/s_bookrune2.spr": {
+     "bytes": 1140,
+     "sha256": "400a620928e3581891e8a71b338c8a53b6387e0acdc3fda3f10ae27596ae6bbc"
+    },
+    "progs/s_bubble_blue.spr": {
+     "bytes": 1140,
+     "sha256": "27cb0d1f52e3ecd4b7ae0d9dc96078a7554bde09839f1a2ee2d9772ac5d67981"
+    },
+    "progs/s_bubble_wht.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_yell.spr": {
+     "bytes": 1140,
+     "sha256": "9dcce864ad255b17d7d45e5c5531114f6a66c4e9cb549fc8b31aef0af5a9157f"
+    },
+    "progs/s_dotmed_blue.spr": {
+     "bytes": 1140,
+     "sha256": "0b3160c5a4ae42216ddb7aaa7ae4726f6b2507c914328abe3c69f2d12fd921f8"
+    },
+    "progs/s_dotmed_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "6e28b69544f8aa13ccbb9a66893e4ab86b83639ee3f81dbbe1b94290ca9b03ef"
+    },
+    "progs/s_dotmed_grey.spr": {
+     "bytes": 1140,
+     "sha256": "77c226763e90a54b4d6835bd877c08c501605e516e64177c915c422e7b36c207"
+    },
+    "progs/s_dotmed_grn.spr": {
+     "bytes": 1140,
+     "sha256": "d1a9800a8b5cad01fa1dc93e57162e9960c4a8478e7e427d66cdbfe6a6797266"
+    },
+    "progs/s_dotmed_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "6113140f371b08cda9addcf68282c1fc16692da7498fa2fdfe2b99662e345d67"
+    },
+    "progs/s_dotmed_red.spr": {
+     "bytes": 1140,
+     "sha256": "4ae92a280e0df01c0acd0a904214af485bb60919e5ded4573aa12f86875182d4"
+    },
+    "progs/s_dotmed_yell.spr": {
+     "bytes": 1140,
+     "sha256": "e6b72aac439291d7719ee78d9520c1a1def36212ac7f61ba333fa87d5265c63f"
+    },
+    "progs/s_dotsml_blue.spr": {
+     "bytes": 1140,
+     "sha256": "c0149109ae73a72da49bfaf9ba00cf2edadbe0f053928d09319083e6247883ad"
+    },
+    "progs/s_dotsml_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "f95fe813ecce2c69d2b72e5bf870d045037519c89f3da9a300e7453754cd1503"
+    },
+    "progs/s_dotsml_gold.spr": {
+     "bytes": 1140,
+     "sha256": "3833e80c32da39063b5069638ade52c4aee51b7db7206b4911cb48f321e25bdc"
+    },
+    "progs/s_dotsml_grey.spr": {
+     "bytes": 1140,
+     "sha256": "2e16d9ff8ceca2994a609703f405b1efbb7b49e02c8dbb9e77d0cdcaf3318b98"
+    },
+    "progs/s_dotsml_grn.spr": {
+     "bytes": 1140,
+     "sha256": "a2735123addacfa03f2666969e476af0d9f1cfefbef75a7ac9599d48f86226b1"
+    },
+    "progs/s_dotsml_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "ebf62caae17163587aaa3652300f1003c008ed21041b838a14cfff7672f87d90"
+    },
+    "progs/s_dotsml_red.spr": {
+     "bytes": 1140,
+     "sha256": "94c0403ee7f1e6f6c4d6bc9b99e73e48143845fe35d0d6b3de246842241b12cb"
+    },
+    "progs/s_dotsml_wht.spr": {
+     "bytes": 1140,
+     "sha256": "7ac2d5b9b1e14a1799b951ace16bcc1addb7fefc2470dec23ef2ca110a934bf5"
+    },
+    "progs/s_dotsml_yell.spr": {
+     "bytes": 1140,
+     "sha256": "686f220b937040b91b6ff4f05efd41525d40eb80a61ff8138809d550bfa99959"
+    },
+    "progs/s_healing.spr": {
+     "bytes": 1140,
+     "sha256": "cd7e99e555f11f888e3ad3cbc2cfadf0276fdfa2f2e2817060f96e4788ad9dd1"
+    },
+    "progs/s_pentskull1.spr": {
+     "bytes": 1140,
+     "sha256": "036ce82812d7e1fc2af6d8aae9fed78ac989a738371858770e1f8adf1f12350a"
+    },
+    "progs/s_poisoned.spr": {
+     "bytes": 1140,
+     "sha256": "62a8ae1311aafd4e5098f6e78eae49b7918d34ed09f7347a806ea41b5f4d233d"
+    },
+    "progs/s_sigil1.spr": {
+     "bytes": 1140,
+     "sha256": "8b2cfa67ac86841f59409e184b4f3a253218e5930a5e3f241caef39dc1baa8de"
+    },
+    "progs/s_sigil2.spr": {
+     "bytes": 1140,
+     "sha256": "476042db782f7f81cb53d91e9518881f28eb34d3a2a535c11d9c22f65518bce4"
+    },
+    "progs/s_torch1.spr": {
+     "bytes": 1140,
+     "sha256": "eddd46a4818dfa92a9817df82e893d6bf6513160164a74b95bdd42fb7cac2f75"
+    },
+    "progs/s_torch2.spr": {
+     "bytes": 1140,
+     "sha256": "dcb87897de0f54a6d8f78e9194a15c11261eb88455f058b334f8648a363159a9"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 336447,
+     "sha256": "64aa6dac013836e29d271b90d33bc7741793f0f5e40dd5d719ad37605f10ea6d"
+    },
+    "progs/statue_dcomm1.mdl": {
+     "bytes": 98196,
+     "sha256": "c648c9b4b40114ed3eeb7db8f604b2b9143269323325faed89554db39d11cc21"
+    },
+    "progs/stealth_circle.mdl": {
+     "bytes": 13460,
+     "sha256": "1f1478a5b4bda9e21ddcc26a3b635c234d8bbc369c4232d305918ddc0be63bf8"
+    },
+    "progs/stealth_eye.spr": {
+     "bytes": 67068,
+     "sha256": "315046c41765917885de2f373905599a348ef1fab93ee5da25083d7e2ae4603c"
+    },
+    "progs/v_crossbolt1.mdl": {
+     "bytes": 5592,
+     "sha256": "9e23a0d6171f0fde4e4f3b4ea49180c81e095eafe3dc7f634118e2ffabf3bd76"
+    },
+    "progs/v_crossbolt2.mdl": {
+     "bytes": 5592,
+     "sha256": "a9c161890e4061929be96336c997acfb6dbfde68d0011e7a5309b2babe1e1178"
+    },
+    "progs/v_crossbow1.mdl": {
+     "bytes": 22924,
+     "sha256": "3f2fa269a77f10709445e91a6bf6ec591e05cf45c561b3ef0dd027223837b453"
+    },
+    "progs/v_crossbow2.mdl": {
+     "bytes": 22924,
+     "sha256": "7408569d5d5f4996a9caaa10a8c711c3d6903f887cb12af2a2696f6baf32dfc0"
+    },
+    "quake.rc": {
+     "bytes": 3391,
+     "sha256": "fc72fc874b2c09a1f8e3ab4bc16639a82c68bbacb100c9134c5c507629765d4e"
+    },
+    "sound/ambience/background1.wav": {
+     "bytes": 403620,
+     "sha256": "47afe820548bcf248b7760f7a66a61ea65b5fb79f70d47e3b03cf8211bb4c5f3"
+    },
+    "sound/ambience/background2.wav": {
+     "bytes": 99104,
+     "sha256": "9c3d5418c7e5bac60c365f0e8b7ea496dd2b51c72c13b0e5a6640e2ef880433a"
+    },
+    "sound/ambience/background3.wav": {
+     "bytes": 209242,
+     "sha256": "864f373dbd75172e1c8f31373188f38c31a80af46592f6b2e92cf5f576e5e0e1"
+    },
+    "sound/ambience/sigil.wav": {
+     "bytes": 250476,
+     "sha256": "d1060cd75d8a520b748047790d33c9a4ab5fd626330ebf1242d318d308c165db"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 246432,
+     "sha256": "d5f5f8ffa7c061a6f9d5159a2e953edb6f94341e04c51670b07e0c802af941fd"
+    },
+    "sound/ambience/windgust1.wav": {
+     "bytes": 110934,
+     "sha256": "d6b4a536dd8c403d8fe9a20db1c72c42d32f44b863689ba4f952ad1e0b7c86d9"
+    },
+    "sound/ambience/windgust2.wav": {
+     "bytes": 110696,
+     "sha256": "85ffe34d5ee89659fd6466afa237a27ad3494176a733d9e017843e7651366a2d"
+    },
+    "sound/ambience/windgust3.wav": {
+     "bytes": 110030,
+     "sha256": "fdbb85f091cd9447f1500173aff70236abcdb947ba0758711816da59c5293344"
+    },
+    "sound/ambience/windgust4.wav": {
+     "bytes": 204800,
+     "sha256": "6bf9157f45ddb9ce15c5cad253b53d9ce59e7d20a81d5f1f8d0a510eb4edce5a"
+    },
+    "sound/ambience/windgust5.wav": {
+     "bytes": 204472,
+     "sha256": "e551c6602c35ad4f4871bffd53cb02a668f508f5ef007e7e5b9734c5640f17ac"
+    },
+    "sound/knight/dropmace.wav": {
+     "bytes": 37624,
+     "sha256": "8d985486f3011d2862e9d2c3e00669aba3bf91987e61d86d8091f3e53b57528a"
+    },
+    "sound/knight/dropsworda.wav": {
+     "bytes": 30010,
+     "sha256": "93094589b8810a7752892aaf1774a28b4595f62c262958d162a1428d456f93d6"
+    },
+    "sound/knight/dropswordb.wav": {
+     "bytes": 25172,
+     "sha256": "56ff6b06fc93afe9910be3c00244d7c5eaf71e78d4233ecf3a93c5384c09ddc4"
+    },
+    "sound/knight/idle_cough1.wav": {
+     "bytes": 18416,
+     "sha256": "17ce7c58e137b36f1c9eae6e95995145868a6d2dd576ab170d547ebed97f9704"
+    },
+    "sound/knight/idle_cough2.wav": {
+     "bytes": 21832,
+     "sha256": "523834f19acbdc97f7ab14ac08db6e190da741d8793b10a5edc7334de95e54d1"
+    },
+    "sound/knight/idle_sigh2.wav": {
+     "bytes": 176610,
+     "sha256": "a7eba673532dad555f879ba77091e3cb9e44558608b83c36d8639e51d71b660a"
+    },
+    "sound/weapons/lg_explode2.wav": {
+     "bytes": 29598,
+     "sha256": "7a95a8337c7ad87faccc1cae98ad7840352b08608fba08aff87a1b33610f9190"
+    }
+   },
    "sha256": "0f70b69853a9eaa4cbdeed9f7912e0395d9fcff17fc586a4f57ce087aefb4732",
    "timestamp": "2012-12-09T16:09:58.000Z"
   }

--- a/json/by-sha256/84/8476b92aa351f6319abc6d1ddf46a8d3cccf221f5fed3206a42eb559f4386d07.json
+++ b/json/by-sha256/84/8476b92aa351f6319abc6d1ddf46a8d3cccf221f5fed3206a42eb559f4386d07.json
@@ -7,6 +7,340 @@
  "files": {
   "Pak0.pak": {
    "bytes": 5403608,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4232,
+     "sha256": "d36145db2eec7a544992dd065fe61b9a9180e30c07cb2549d09c910a276ed16d"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "ff1371a6c5d088b16eeff202908eaec917388d1c0b8f92908393db19c2458fe4"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6296,
+     "sha256": "1e7a362fe636948c1a98718bec511d9f8bacca38a7e412315541f0beec1a7b3d"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "724e74d197efaf545ba36a7d1a2f178ea5b8ce90127257dd4b583ae8f2631678"
+    },
+    "maps/arbol.bsp": {
+     "bytes": 41608,
+     "sha256": "4af5e211703d8a9cc4585fd72a687622dfb7b07e5ce315c13014194de532b2ba"
+    },
+    "maps/utem.bsp": {
+     "bytes": 2121900,
+     "sha256": "b70b8714b8226aa07b9e2b21147c04ed987813337f3370eb3bfa73d21fe05694"
+    },
+    "progs.dat": {
+     "bytes": 547720,
+     "sha256": "178fd16c05d3e7e77d4a26a0e5106526068c25ab3210d52a008c6f27b466dcd2"
+    },
+    "progs/bazooka.mdl": {
+     "bytes": 143952,
+     "sha256": "47772f91909c6d23ba031fb2faa2941ed427affea3c22a5d1b31b5e6b53ff98f"
+    },
+    "progs/bchili.mdl": {
+     "bytes": 47627,
+     "sha256": "a134f7d0eb26ffb04e051d3d68287bd7a97c0510913cd34a3c3e4ce66f1e9681"
+    },
+    "progs/beam.mdl": {
+     "bytes": 11348,
+     "sha256": "4e42c53fa58ed775a4f331b46fc31cfe537e28179cbefe579e9d9309e3a0afe7"
+    },
+    "progs/butem.mdl": {
+     "bytes": 47627,
+     "sha256": "9568a521808dbd30d9e2cc296556d46cd2d01e351817a70145a9d6426a16de7b"
+    },
+    "progs/end6.mdl": {
+     "bytes": 18648,
+     "sha256": "b94fd7c55de38a8cfa19d4f891bc1e19c9f2a088f851297947e355725a6cc4af"
+    },
+    "progs/fem.mdl": {
+     "bytes": 252188,
+     "sha256": "ba8de6d4c3f504e33f46e6ae4d32d5034f4d49753640433b34685a94eb56fa24"
+    },
+    "progs/h_babe.mdl": {
+     "bytes": 26804,
+     "sha256": "9adecc483c26658401d441592a92f19337a13c65b59aa64c14a6ee21afed9d63"
+    },
+    "progs/h_fem.mdl": {
+     "bytes": 12311,
+     "sha256": "2cca1ecff95e6f62ac26991360919412957c89176ba89d367db3ed3fb7b67dd7"
+    },
+    "progs/h_pino.mdl": {
+     "bytes": 15613,
+     "sha256": "31c7c684cdc2444585256889b8d2eaa33ac2798c13e7f2e7957225560e8e297f"
+    },
+    "progs/hgren.mdl": {
+     "bytes": 1997,
+     "sha256": "61e33e422d011b5e838e19f9b04f4c40bb78e617c06a2ff566119535946337f1"
+    },
+    "progs/pino.mdl": {
+     "bytes": 205884,
+     "sha256": "c57a7cbd02db59373eeb2638d9b03da785a1f91c9afda60e51bb409c5567d90a"
+    },
+    "progs/pulse.mdl": {
+     "bytes": 15988,
+     "sha256": "a1d14c7171de546fba12a05de679b65f3106320c412269ebd16240fa83b0f93e"
+    },
+    "progs/rifle/rspike.mdl": {
+     "bytes": 4304,
+     "sha256": "d1a58f0644e0d8b62ac8486063f94c67af6f4cf943e69dcc8128732fe2a3f400"
+    },
+    "progs/rifle/sight.mdl": {
+     "bytes": 11232,
+     "sha256": "f2ced2c64ba751ef8439f95b18c89223f0a3cf898f0dbb2b39ed73814d4fd4d0"
+    },
+    "progs/rifle/v_rifle1.mdl": {
+     "bytes": 61188,
+     "sha256": "a29e389ebb63b1df7c2f4b2429ac86e4ce86cd88624c7b4d6afd00d7c661b297"
+    },
+    "progs/rifle/v_rifle2.mdl": {
+     "bytes": 61188,
+     "sha256": "9e1443e7005dcc4be25fd7cb1603d02dfcebf3b54a774fd8d3f60d4fada9fbff"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_arbol3.spr": {
+     "bytes": 28028,
+     "sha256": "0cef3c604b3577916eb712d8f8a204d040001d7daf75d0de9d4445633824b9fe"
+    },
+    "progs/s_explo.spr": {
+     "bytes": 21885,
+     "sha256": "f5039571da0e57cb6a640bfa78a42fd8d8b5909e6838f336d2018bfecf3802d2"
+    },
+    "progs/s_humo.spr": {
+     "bytes": 113666,
+     "sha256": "849ab86bb554e4a4a8c49703bd33cc3da7b7fe331ae1605f1d1d0c10ab70d03f"
+    },
+    "progs/s_rain.spr": {
+     "bytes": 37196,
+     "sha256": "b799b259604498fc19a7f1b12e6742b0bd9c399733ea539a390394d80e88b448"
+    },
+    "progs/scrap.mdl": {
+     "bytes": 1332,
+     "sha256": "9c3ce43ddec1e72ec3612f41281599362c9292b7dab1fe4faa0e491d4ccbf2ee"
+    },
+    "progs/v_laser.mdl": {
+     "bytes": 68732,
+     "sha256": "8e42db3ff82923040b712e82c3ef09d28e4357609a8f1c2c71f6c1c2c1a98a7d"
+    },
+    "progs/v_rock3.mdl": {
+     "bytes": 71821,
+     "sha256": "b7f3a597a54091c66c56cc70806126368b76e1e561f69b85183780f5d537f111"
+    },
+    "sound/ambience/amb.wav": {
+     "bytes": 8024,
+     "sha256": "d88a5f8c5787570ca70fdb435160f0743433c25e82d55d66b1f20130d3b78b9d"
+    },
+    "sound/ambience/back1.wav": {
+     "bytes": 29044,
+     "sha256": "4caace7efee0535a545e462902d3aab1989f9ddfc9d5b6bbdce344a113585fc5"
+    },
+    "sound/ambience/back3.wav": {
+     "bytes": 40484,
+     "sha256": "f3cfa81848177963b5403cd5fa80bb02c409502519836cfacc53f450c3a02bee"
+    },
+    "sound/ambience/birds.wav": {
+     "bytes": 3338,
+     "sha256": "ecf7664e89aa92bc49735b1f4bc425feb40eae20ddd41f48782406ecec24fcd7"
+    },
+    "sound/ambience/comp1.wav": {
+     "bytes": 62734,
+     "sha256": "023903bd93bebc49b2a9c66b17f1f32e533d14fe111d93ea36b362f2e0437b22"
+    },
+    "sound/ambience/comp_3.wav": {
+     "bytes": 116227,
+     "sha256": "44713b99b38620cecbd1a9bff944ae42bae09c7b3d7cc25008a070d7de215cf6"
+    },
+    "sound/ambience/eagle.wav": {
+     "bytes": 37218,
+     "sha256": "1d38ea8d0218bd6a07a1a55d476ea027cc2e53a4c8312a98cd1ffd8df94a6939"
+    },
+    "sound/ambience/moan1.wav": {
+     "bytes": 37224,
+     "sha256": "e86190319c4ed1fc539497e010874070b0920ee45abe960baaafabe74df09db1"
+    },
+    "sound/ambience/newhum1.wav": {
+     "bytes": 35258,
+     "sha256": "d2c07398d1a6ecada4987780bdac04460d4faa578a2e829f7bca8f5edf8100a3"
+    },
+    "sound/ambience/rain_2.wav": {
+     "bytes": 91230,
+     "sha256": "570ecb8b1ae06fe70ca06a268259f3207e2e081c114bd0ad40d700a366d65017"
+    },
+    "sound/ambience/raven.wav": {
+     "bytes": 4410,
+     "sha256": "e676a2c5fb3b5e0783e4efe596d3a95a6ae253e767d866fdc5bd43da12c14bb5"
+    },
+    "sound/ambience/thunder1.wav": {
+     "bytes": 41492,
+     "sha256": "f7061fe3e19eaf1cea5216d0d3c776e79224e938bde1b6124a2f115eb421969d"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 41490,
+     "sha256": "3d28310c759e38414f8794beee6e7e7cf073cb089c7a3625acf1543bf522ca60"
+    },
+    "sound/bazooka/ahaia.wav": {
+     "bytes": 7748,
+     "sha256": "b9a2527347e2272a676390b3a6bce4cf623f233a11b27d932e340ed67e72823d"
+    },
+    "sound/bazooka/die.wav": {
+     "bytes": 9260,
+     "sha256": "0bae4e5baa31c64ba4fc94df64e0dca08c06a732baea03ae4167b75e00318e9b"
+    },
+    "sound/bazooka/dies1.wav": {
+     "bytes": 8856,
+     "sha256": "663fcd16df6c845fc318a6181b2eece0678f9f3980a90ea3d34f0592e61e6087"
+    },
+    "sound/bazooka/dies2.wav": {
+     "bytes": 9212,
+     "sha256": "93f2868e3bbda78b74970a8912e8bad6f50e130692c4ce066aacdb5d51811e48"
+    },
+    "sound/bazooka/dies3.wav": {
+     "bytes": 9752,
+     "sha256": "439d327515f423fe662a8930b6a1d07d693f43331996119e05d32efc5d44457c"
+    },
+    "sound/bazooka/grrr.wav": {
+     "bytes": 11356,
+     "sha256": "8c6609a6ea9d85f10cda8dd2aa2d0fb77f5e9690698cbafbc213eb5d4f2b6f5d"
+    },
+    "sound/bazooka/ooaa.wav": {
+     "bytes": 4872,
+     "sha256": "76d5ae6f0532eb1a43493330c90966be651e05ba9eed2a994a9afaf28c73de78"
+    },
+    "sound/bazooka/step1.wav": {
+     "bytes": 27042,
+     "sha256": "fc485f8365abf042f2abb94ba4a21f077f688419e252a50fe9cfba2f55fd280a"
+    },
+    "sound/bazooka/stepstop.wav": {
+     "bytes": 6102,
+     "sha256": "79ec338698b2f8bfde44e0b5e8e31ca3d34e140ca88a45eb81c7c72b7ca31134"
+    },
+    "sound/bazooka/when.wav": {
+     "bytes": 23194,
+     "sha256": "af1c2534c69cfb3f07e160cd39f66fcfbe9d64580cb9fcfc43520637c6931532"
+    },
+    "sound/bazooka/yeow.wav": {
+     "bytes": 6474,
+     "sha256": "776a81059bc7fd0f8c998f5e8e05837686d1578c8860aad77901665c31370caf"
+    },
+    "sound/female/die.wav": {
+     "bytes": 8950,
+     "sha256": "6cf8516d992c87def74648c412187398bbca5a38ebabf87b847132ab2c6a37f3"
+    },
+    "sound/female/fire1.wav": {
+     "bytes": 3042,
+     "sha256": "588e59142330a09865485646a20eacd86a64c66c4c37c9db757882d06518b775"
+    },
+    "sound/female/hurt1.wav": {
+     "bytes": 3386,
+     "sha256": "44203f7119bb5b1659c02fb687f43cd6639629ffd3b6ece9c2b31bb6d6b34e8b"
+    },
+    "sound/female/hurt2.wav": {
+     "bytes": 5650,
+     "sha256": "3750428ae5b2e114a5ef2ca9d604bf69c28c4eb976870d6ba0d02d7bc77d38e7"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/pino/alto.wav": {
+     "bytes": 6836,
+     "sha256": "7a4cec339d65a495130adb00eaf0d1629149e3d0ec8b5b1486dea10d0d5b1aa6"
+    },
+    "sound/pino/death.wav": {
+     "bytes": 23034,
+     "sha256": "0eb20419acddee8a5814ecad8888348f90a14db997af1045b02b6052dccd5fd1"
+    },
+    "sound/pino/death2.wav": {
+     "bytes": 32314,
+     "sha256": "3b1d2ed146a334ba5cf77027faa47addbf45c51159ff9c7278a97dda8ed7ef82"
+    },
+    "sound/pino/duda.wav": {
+     "bytes": 30758,
+     "sha256": "df21aeac84b0b423be711e6e769eaac5e00f8d8d780056fdce29bbaff122279a"
+    },
+    "sound/pino/heytu.wav": {
+     "bytes": 9388,
+     "sha256": "84a0a779e3cf41908d5786eefc401898967e74c4c4b715b4e3cc82dd793f7893"
+    },
+    "sound/pino/mcruli.wav": {
+     "bytes": 8286,
+     "sha256": "27e43463bf237b8dc471cdaa2ae3e2354a1677302659ca460463f356b86e4a4d"
+    },
+    "sound/pino/oscilos.wav": {
+     "bytes": 8507,
+     "sha256": "d8678b26eb0dda2edbe26f797474035c8ff84f13e17594c30a968edd5429c7a3"
+    },
+    "sound/pino/pain1.wav": {
+     "bytes": 6106,
+     "sha256": "0f85b6180cbfe8d26f8d174f25c109b9d8b78d0fa53735e0494280bc8a19803b"
+    },
+    "sound/pino/pain2.wav": {
+     "bytes": 8890,
+     "sha256": "6d48429e7fc4b80be16afd80097b7096a94cb1a88922a62bdfdff64172526a0f"
+    },
+    "sound/pino/plaser.wav": {
+     "bytes": 8132,
+     "sha256": "f1e6a07551f17c2bec0b8b9dc2afc27207629a2bede43849ea828802a6caaaf3"
+    },
+    "sound/pino/realidad.wav": {
+     "bytes": 153477,
+     "sha256": "e0f2d611900bedcda485f9756e47f07b37584e84a30d0dbda3233979a7b82947"
+    },
+    "sound/pino/teresita.wav": {
+     "bytes": 12390,
+     "sha256": "c7d992454bd1b8edfad56fc1a5c7b57c009d3ec2824fcf8ab3cb2dcb63343cf6"
+    },
+    "sound/pino/what.wav": {
+     "bytes": 11661,
+     "sha256": "36a779e01691d335921a2ac45c5aff355c8d4d1e419c8e8c0e2dcf502cd8a2ee"
+    },
+    "sound/ruli/he.wav": {
+     "bytes": 28379,
+     "sha256": "07c09a5732a220cf69c12804e51453e9d6b243614da1812bbfa75a45d066038f"
+    },
+    "sound/ruli/soract.wav": {
+     "bytes": 27319,
+     "sha256": "858a7af724ec99fd494492c28a90298c15b29a8572d3f2caac3016cfa2dcb1f3"
+    },
+    "sound/ruli/sorsit.wav": {
+     "bytes": 32062,
+     "sha256": "be367b7a2ed37a222c36e08b46841c69220aabd34622acc2bfd802cf4ea3f384"
+    },
+    "sound/weapons/rifle1.wav": {
+     "bytes": 12656,
+     "sha256": "a217f0765df3d8b9f99895e37b7e906cde1d7a1e0ab05a81be4839ffc6893751"
+    },
+    "sound/weapons/s2-011.wav": {
+     "bytes": 10051,
+     "sha256": "ce4cecd907ade67777da3fc07f4734f117f1743ece02ce9404aa61745d2351ab"
+    },
+    "sound/weapons/s2-019.wav": {
+     "bytes": 12708,
+     "sha256": "9e87e3cbe74a63898f4e56155e088b1638074a846f2f1fdce0d6e29b59900796"
+    },
+    "sound/weapons/s2-053.wav": {
+     "bytes": 14829,
+     "sha256": "919d6b3ce829e7aba06cab5c1be7eabcb476a54656cd47c4a2aedbf6442063d3"
+    }
+   },
    "sha256": "3a8fb124b55ed06a0ae31b9860df9f498493fa3c00936b92a8a07ff69207d856",
    "timestamp": "1997-12-25T13:35:14.000Z"
   },

--- a/json/by-sha256/84/848b3d9f71de828890839ced4c5c2799ec25a07e111b61c5787b9a401740b95c.json
+++ b/json/by-sha256/84/848b3d9f71de828890839ced4c5c2799ec25a07e111b61c5787b9a401740b95c.json
@@ -694,6 +694,396 @@
   },
   "ctsj2/pak0.pak": {
    "bytes": 4561448,
+   "files": {
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "8cec67fa37ad8a6723844c64e56b6e188e4f08d23f6ca280ea8f4ba5b8f769ce"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "f6bcca0638bbc18713c478910527cb65f31ddaaaab6755be6f0a4607164d0734"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "591744734a43a1563ee0e419fb2464783c70a3245c14e09ff5c3f022418f1e4c"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "1bbe11eff4ef46f43af7bbc7be43c69cf76543ce7fae26931939a541cb8cdae6"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "2ea3ee2b5ea3ecae4349cac0d6ecbbbf80425d63db0e18a578a6c0b6b69ab166"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "792b999f37e2f75a3d88e9f1f2a60f49aebfd8aa46e3ae52f1b55b2a11d641c2"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "ef455c1235cc6798cb1ff1b1cf728380863656e2cb9f11cc7b89819ff2ab7826"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "7a91038838edbddf5f8d58ffa72f20da93a2f9d82527ce34b0a7fe2f809cde79"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "89d123a948fc600561d2a4b67359e06b4f8bdc233f06bcfb686d98d668beb8a5"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "cc64ee5d4be787eec9d062ae9fbe3d395e96fc154e09364e827c8de0368b4330"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "eee6785919a2b1eb9979e92cac602bc04d409c502853fd488d6e88439694451f"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 22648,
+     "sha256": "39da2b29b0073d73fc0aec1e90475a28483ac91589b0f4d6f366c39a598153d2"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 51734,
+     "sha256": "ead14a48756cb125dab4ba817057be6522819f8ad00327f262633ff29c5d4a4f"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 143970,
+     "sha256": "64b8bbc006d7d89b56c8623478b915f27b5b4f1aa323b3b37f64a4142417bc71"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "898a7466322297c37309942a62197dd634168c343f464d8e9bd6d9bdc6524333",
    "timestamp": "2022-08-11T02:02:02.000Z"
   },

--- a/json/by-sha256/84/849aeb90455a10199d9475c02651f1a6757821edddb0e9bec7078e13bf16ac50.json
+++ b/json/by-sha256/84/849aeb90455a10199d9475c02651f1a6757821edddb0e9bec7078e13bf16ac50.json
@@ -8,6 +8,16 @@
  "files": {
   "pak0.pak": {
    "bytes": 1408456,
+   "files": {
+    "maps/e1m8.bsp": {
+     "bytes": 955068,
+     "sha256": "cc69a466334a98e1236e91a1533523f0b71bdededa9f4c817f03b224c45ce2c8"
+    },
+    "progs.dat": {
+     "bytes": 453248,
+     "sha256": "a6f7ec149c389e5280e1d1e659619a3baa6317dd2ebaf1496c26878629472e91"
+    }
+   },
    "sha256": "78148ca5669d28557b8dabd936f6132a60fb3194f0368e7e31de234105b27817",
    "timestamp": "2006-11-20T17:54:26.000Z"
   },
@@ -18,6 +28,23 @@
   },
   "source.zip": {
    "bytes": 55703,
+   "files": {
+    "e1m8up3d.map": {
+     "bytes": 485507,
+     "sha256": "5f6da34e9e4c7a5936ad8c06f5fe1b0da7d49bd028b748caa71cd5d7519b49df",
+     "timestamp": "2006-11-20T12:26:26.000Z"
+    },
+    "gnu.txt": {
+     "bytes": 14969,
+     "sha256": "2f4d8811d21f8a6e1ba2353644e93a973cf3ef326776a06ff755b9357f4ca248",
+     "timestamp": "1999-12-21T19:01:14.000Z"
+    },
+    "release_readme.txt": {
+     "bytes": 1198,
+     "sha256": "b801f786115abfcec9b6e910d9efcb7924e8a5cd9f2b312a484ace171d5b8c4f",
+     "timestamp": "2006-10-12T02:03:20.000Z"
+    }
+   },
    "sha256": "1a2fc70103f3b659956f4c1888ee35860b4a11021979bc8d1a961c790f3e5546",
    "timestamp": "2006-11-20T18:15:14.000Z"
   }

--- a/json/by-sha256/84/84a262cd840e957add537853551d4fdf565ebba7584cc23a94634f2616cafea9.json
+++ b/json/by-sha256/84/84a262cd840e957add537853551d4fdf565ebba7584cc23a94634f2616cafea9.json
@@ -37,16 +37,1302 @@
   },
   "tsoa/pak0.pak": {
    "bytes": 820000,
+   "files": {
+    "gfx.wad": {
+     "bytes": 111940,
+     "sha256": "a1005fae140e6ec301d421c8021fa6025eb2439c6413501cf85cfda1da27fcf8"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "e5d1b968aacd812656c7d05a9358516030040d88ce6b47936689368285f5d011"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "4f991f7139b3ae61107627935f4f2b1e489e9b4c421b0edde8388711d4d3b34d"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "e761eeca193728fa3bb634821842e112f3659c4b78171f0db5888a294b92b5eb"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "be5540a3ce75d76ac88bca5665dd7d742c9238dcc8cb8b93288c4839abf2736b"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "8153d90d6c3b44ec2acf3cd3f1cd53515b8d0c201ddf0019534e886e1d9e28dd"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "9122336c38ef6812bdf2d47a47a9ec7a46e0562a03a27af725030291782e3c81"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "f7b2b0c8777108af57f924041c347d67d86cf40f4745df303601f46318bf6b0b"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "fdb101495e77381fa772f9e18f95e3d68ab820ab9130f692487ef7806d02c580"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "2ddc497468adb8a5efade16fb55241e56fe3a8e67db76580b76ef4164401f7c6"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "dbb75c30e8e084f4139921b31648c861f66b25f25d1259795d42994fcfd9cbb5"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "4d552b7ba6ce570e3072eb7eb548af3544d4773da3f7cb42126df5514ecfa525"
+    },
+    "gfx/cdnfnt.lmp": {
+     "bytes": 16392,
+     "sha256": "72c949abe4e75936f3a471f21850d1759e974f551f16cd054f5e7da7903cb7e9"
+    },
+    "gfx/conchars.lmp": {
+     "bytes": 16384,
+     "sha256": "640a4fd8107d86802bf558a4fed9d3e9792af15e999129390dc7ea28056c7fe6"
+    },
+    "gfx/dim_drct.lmp": {
+     "bytes": 3352,
+     "sha256": "b574a46c07a5269049aa2b52340ef7c07b7c5b4a21bbaf93131880707b4d2de9"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "2de9f484fc4bc8ed6193fc62dffc4589dc5b59813309adf074e49c3a19b76afd"
+    },
+    "gfx/dim_modm.lmp": {
+     "bytes": 3352,
+     "sha256": "32a04b30d54327fca469609c5847eefa2de96afc4e92d4364b557eb1a5f78f7d"
+    },
+    "gfx/dim_mult.lmp": {
+     "bytes": 3352,
+     "sha256": "f650e81854e5583ab0df7123023c56812c681a00b8934416bb165cd651dd4934"
+    },
+    "gfx/dim_tcp.lmp": {
+     "bytes": 3352,
+     "sha256": "43f8a9e06673a329f55848f9b474a6b6728afbb66f5a226c58a751e31df0b0e0"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "66fb6ffa591d39a254218667b434c784f15ec0b42d2cec8dc041627d82de8b6d"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "65ea6296ee87050267701937708851900e030cf81798058072c61d2b80929fdc"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "23414edf0be2a12307f4c6114b49f9669b6e63fa28b6464aa984e39f7a8f8ee6"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "b7b3f5034e9e08fb6e5fb7adeaf5c786f2b97312b6b8eebd365ebc9ae282fcf6"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "c4d72d3b60f9024565b5954ee41acc6de3b7b0856b0a28e7fd29b9dba803e3ba"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "264906ec97556645849ddb4b804fbd8e6651c5e41f833423c536570d9420b9d0"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "c4d72d3b60f9024565b5954ee41acc6de3b7b0856b0a28e7fd29b9dba803e3ba"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "b7b3f5034e9e08fb6e5fb7adeaf5c786f2b97312b6b8eebd365ebc9ae282fcf6"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "a750580bd45f6c98a6be2e022985c55ea9feaad39042be9aa54fa6d01789085d"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "5c960cd6661d4f6e27d9abb45466eadedb69185b1767b48de3611530107271e8"
+    },
+    "gfx/netmen1.lmp": {
+     "bytes": 3352,
+     "sha256": "e4eed27f475d8dca1e30a473125a5c5190b8ec466072ed01b2b7dddbff3cadb4"
+    },
+    "gfx/netmen2.lmp": {
+     "bytes": 3352,
+     "sha256": "ec81bea43a585e226f12e43238c7e0dc09564823ee83a70bb33510f8b4944437"
+    },
+    "gfx/netmen3.lmp": {
+     "bytes": 3352,
+     "sha256": "37eafd151f2d4832ffc6bd030552fd20e063a5b7fdde48fb906052f65af9692d"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "94d853615829a2c6b943720c474439c65f5768def9b858eccec03c63f1b6e52c"
+    },
+    "gfx/netmen5.lmp": {
+     "bytes": 3352,
+     "sha256": "a7d84fc706732e504c5e7e732d11b9d073c1ceb3accb15c50165a7b8206a362d"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "9ab63bf8df6c7e3dc579962b39c42b212c8f864ffbf067cf1635ad4df804ec7a"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "c474a242ca22231784bb7d823b8bdbfd8298b41a5e1501c74411c70c7eced123"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "70050af1d6922232328637f943ffdb163bfe841224d4d349d3e00f96869bd538"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "4a3fea4fc727a4c7773b3fdbaaecd3669bccaa1cb41c7dfedb49d9a3dda648c8"
+    },
+    "gfx/pop.lmp": {
+     "bytes": 256,
+     "sha256": "59a7a58a257ae6a231ca4201a8330fa9d90779ea5e230e07d530f2478521bb9a"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "7f5fefbedf883ae22bacba9c5ba28acab5fd71ca014e48e1e542561a478bf782"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d5da328d425cccc063cd9e1cb6a291bcd869c50e3a2fc63502c65085e3407cfe"
+    },
+    "maps/b_exbox2.bsp": {
+     "bytes": 5964,
+     "sha256": "6edfca3b4cbefd3657cf9fbb2419a6ac6d2f42f04aaa2d1c220989854b703b28"
+    },
+    "maps/b_explob.bsp": {
+     "bytes": 11528,
+     "sha256": "e40bc77d60799477a1cc9463115a31a45afe046e77f6e7cb0a800fc2792e9dd7"
+    },
+    "maps/lectorch.bsp": {
+     "bytes": 25524,
+     "sha256": "587443212147af734451e00a23f3fa0cae73cb2f96a3d9c385f58ac49e6b54c2"
+    },
+    "progs/gibotron.mdl": {
+     "bytes": 11418,
+     "sha256": "5f27cac70e16d5c8fa036e480733e9047260554e2c2e6b953b5bd15321d9b25e"
+    },
+    "progs/globe.mdl": {
+     "bytes": 31072,
+     "sha256": "2717efdf0e883b47960e856d9cb7b27f708e667846db7f395309c8b0673501f7"
+    },
+    "progs/guard.mdl": {
+     "bytes": 172760,
+     "sha256": "bc3f2615d76f65173281ac998637e1e643a5fce2bbdaef0b625e3ec3d98191a5"
+    },
+    "progs/helmet.mdl": {
+     "bytes": 82877,
+     "sha256": "244c824bde9a466c1db591bc538c3b450f6d6f1a9cc86e26ab91a6871dac14fc"
+    },
+    "progs/lense.mdl": {
+     "bytes": 74366,
+     "sha256": "2f754fa8862132726ca821fa3dd2575280a48e42e486f76b0e9e9e92edbca217"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 11650,
+     "sha256": "4d2e7347b57ccf10a754b78e5f5b5d3881b748502c3326291b671fdf74efcf1a"
+    },
+    "progs/s_fence.spr": {
+     "bytes": 4152,
+     "sha256": "d5ce29daea93977e06f697018c50a236aceea84d12cb89d11ca5740c017f5226"
+    },
+    "progs/s_invis.spr": {
+     "bytes": 5556,
+     "sha256": "79eae2eb897a0fb181d4345b2b17c7cdd1f90105df7272a350b936b2f3edc8b1"
+    },
+    "progs/torch.mdl": {
+     "bytes": 21961,
+     "sha256": "1d986eada1756043eb07eeb83ad16347913a718012d7e5208605fc3edd54d577"
+    },
+    "sound/weapons/shank.wav": {
+     "bytes": 11060,
+     "sha256": "4034bd27b1dc32da8c5ad548767e5d72c437ff2457bd26a88015d9de1532a461"
+    }
+   },
    "sha256": "c06def148423e79d65e1efaf60dd5eebeb86cd0e02a2edcf97b68426572ef664",
    "timestamp": "1998-01-18T13:35:54.000Z"
   },
   "tsoa/pak1.pak": {
    "bytes": 12288698,
+   "files": {
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "e5d1b968aacd812656c7d05a9358516030040d88ce6b47936689368285f5d011"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "4f991f7139b3ae61107627935f4f2b1e489e9b4c421b0edde8388711d4d3b34d"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "e761eeca193728fa3bb634821842e112f3659c4b78171f0db5888a294b92b5eb"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "be5540a3ce75d76ac88bca5665dd7d742c9238dcc8cb8b93288c4839abf2736b"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "8153d90d6c3b44ec2acf3cd3f1cd53515b8d0c201ddf0019534e886e1d9e28dd"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "9122336c38ef6812bdf2d47a47a9ec7a46e0562a03a27af725030291782e3c81"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "f7b2b0c8777108af57f924041c347d67d86cf40f4745df303601f46318bf6b0b"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "fdb101495e77381fa772f9e18f95e3d68ab820ab9130f692487ef7806d02c580"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "2ddc497468adb8a5efade16fb55241e56fe3a8e67db76580b76ef4164401f7c6"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "dbb75c30e8e084f4139921b31648c861f66b25f25d1259795d42994fcfd9cbb5"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "4d552b7ba6ce570e3072eb7eb548af3544d4773da3f7cb42126df5514ecfa525"
+    },
+    "gfx/cdnfnt.lmp": {
+     "bytes": 16392,
+     "sha256": "72c949abe4e75936f3a471f21850d1759e974f551f16cd054f5e7da7903cb7e9"
+    },
+    "gfx/colormap.lmp": {
+     "bytes": 16385,
+     "sha256": "b9acd77125b314db77102f78c9d00abd14760fb77b6e9d79c8c5962f4546858a"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "558ab7a83934ac72559bcbfab8982d0c0aeeb04da07390774f03dc6475b333ab"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "f6dfbb56743a97a4b0f8c5ef3f4e3b865b1ceeda273559f6b372331abb3a15f3"
+    },
+    "gfx/conchars.lmp": {
+     "bytes": 16384,
+     "sha256": "640a4fd8107d86802bf558a4fed9d3e9792af15e999129390dc7ea28056c7fe6"
+    },
+    "gfx/dim_drct.lmp": {
+     "bytes": 3352,
+     "sha256": "b574a46c07a5269049aa2b52340ef7c07b7c5b4a21bbaf93131880707b4d2de9"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "2de9f484fc4bc8ed6193fc62dffc4589dc5b59813309adf074e49c3a19b76afd"
+    },
+    "gfx/dim_modm.lmp": {
+     "bytes": 3352,
+     "sha256": "32a04b30d54327fca469609c5847eefa2de96afc4e92d4364b557eb1a5f78f7d"
+    },
+    "gfx/dim_mult.lmp": {
+     "bytes": 3352,
+     "sha256": "f650e81854e5583ab0df7123023c56812c681a00b8934416bb165cd651dd4934"
+    },
+    "gfx/dim_tcp.lmp": {
+     "bytes": 3352,
+     "sha256": "43f8a9e06673a329f55848f9b474a6b6728afbb66f5a226c58a751e31df0b0e0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "ac00b36a8eaf4705cd402f452616016c59c2372bf262934b1f73b94b3e9ab907"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "89f5a30d0391d0b19385038fa810bf3016fe50cb2ebf1c38412833faad24b7c9"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "519a01b6a418c93a94bd85595bd8e8cd3df8436c557666d2fda47a08126e7a44"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "f2e0d9263f3a9b0b16923399cf06d38daf43b77a12ad0ad8c6d7038321bee01d"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "7544bd77d35efedabf92cedffc7b7f5f371ce2518d25602f9aae8bc30cbe8a09"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "f6dfbb56743a97a4b0f8c5ef3f4e3b865b1ceeda273559f6b372331abb3a15f3"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "3c3d3d1c313142069e4b94aa86dd6c764dd788c74fd1ff5b1cb80d013acdf3dc"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "66fb6ffa591d39a254218667b434c784f15ec0b42d2cec8dc041627d82de8b6d"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "62a42219465309fb36abd65d7f7cdec376896e31db87b37e8f54addc8edbfa55"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "65ea6296ee87050267701937708851900e030cf81798058072c61d2b80929fdc"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "23414edf0be2a12307f4c6114b49f9669b6e63fa28b6464aa984e39f7a8f8ee6"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "b7b3f5034e9e08fb6e5fb7adeaf5c786f2b97312b6b8eebd365ebc9ae282fcf6"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "c4d72d3b60f9024565b5954ee41acc6de3b7b0856b0a28e7fd29b9dba803e3ba"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "264906ec97556645849ddb4b804fbd8e6651c5e41f833423c536570d9420b9d0"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "c4d72d3b60f9024565b5954ee41acc6de3b7b0856b0a28e7fd29b9dba803e3ba"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "b7b3f5034e9e08fb6e5fb7adeaf5c786f2b97312b6b8eebd365ebc9ae282fcf6"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "a750580bd45f6c98a6be2e022985c55ea9feaad39042be9aa54fa6d01789085d"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "5c960cd6661d4f6e27d9abb45466eadedb69185b1767b48de3611530107271e8"
+    },
+    "gfx/netmen1.lmp": {
+     "bytes": 3352,
+     "sha256": "e4eed27f475d8dca1e30a473125a5c5190b8ec466072ed01b2b7dddbff3cadb4"
+    },
+    "gfx/netmen2.lmp": {
+     "bytes": 3352,
+     "sha256": "ec81bea43a585e226f12e43238c7e0dc09564823ee83a70bb33510f8b4944437"
+    },
+    "gfx/netmen3.lmp": {
+     "bytes": 3352,
+     "sha256": "37eafd151f2d4832ffc6bd030552fd20e063a5b7fdde48fb906052f65af9692d"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "94d853615829a2c6b943720c474439c65f5768def9b858eccec03c63f1b6e52c"
+    },
+    "gfx/netmen5.lmp": {
+     "bytes": 3352,
+     "sha256": "a7d84fc706732e504c5e7e732d11b9d073c1ceb3accb15c50165a7b8206a362d"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "9ab63bf8df6c7e3dc579962b39c42b212c8f864ffbf067cf1635ad4df804ec7a"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "c474a242ca22231784bb7d823b8bdbfd8298b41a5e1501c74411c70c7eced123"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "70050af1d6922232328637f943ffdb163bfe841224d4d349d3e00f96869bd538"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "4a3fea4fc727a4c7773b3fdbaaecd3669bccaa1cb41c7dfedb49d9a3dda648c8"
+    },
+    "gfx/palette.lmp": {
+     "bytes": 768,
+     "sha256": "6b20b5bc4ea965ef1852b05670d043ca16148a0ecad4e63028121c8aebc268fe"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "e0a2186fcf1a706728e7672065a2962512153539c8b6ff392b7c03408d2c7ceb"
+    },
+    "gfx/pop.lmp": {
+     "bytes": 256,
+     "sha256": "59a7a58a257ae6a231ca4201a8330fa9d90779ea5e230e07d530f2478521bb9a"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "1a346f681038abb6125aec77fb1333198ed78049b9bbc7abf66121e735fe8303"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "cc8884c8cd386fec2e0e802d2e3c4052e54fdae920aac711190b36cb736c9482"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "7f5fefbedf883ae22bacba9c5ba28acab5fd71ca014e48e1e542561a478bf782"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d5da328d425cccc063cd9e1cb6a291bcd869c50e3a2fc63502c65085e3407cfe"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "34f9e9bad46481362dc76aa52eaade174c7bdc8d0326d76b215cc6331b165801"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "be77b6f764e434c9ad6da6cc56706b37ba7baa8da6dfa5313694bc525ddeecb8"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "0df6181dd5e23ead8d0907672165846260292aa6fb5413a6e1bb7b9de3923092"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "071e8f8beee9c4c1e060541766a6f38c705a303c6fb9e1d3927fd3d4288af3b0"
+    },
+    "maps/b_exbox2.bsp": {
+     "bytes": 5964,
+     "sha256": "6edfca3b4cbefd3657cf9fbb2419a6ac6d2f42f04aaa2d1c220989854b703b28"
+    },
+    "maps/b_explob.bsp": {
+     "bytes": 11528,
+     "sha256": "e40bc77d60799477a1cc9463115a31a45afe046e77f6e7cb0a800fc2792e9dd7"
+    },
+    "maps/basement.bsp": {
+     "bytes": 669200,
+     "sha256": "c385b3b2f2a1c3afa22f0807fafc0ad0db6315e77c88e80179e2401130177980"
+    },
+    "maps/gate.bsp": {
+     "bytes": 990828,
+     "sha256": "0cb0e68ef3643a416b41c3095fbc336814cd064e327de37c24f18c30690ec40a"
+    },
+    "maps/grounds.bsp": {
+     "bytes": 977512,
+     "sha256": "3c6565c6be87582a6b856ef7d9d53ebb80813cd9b55c825f1dd111ec63cc7e01"
+    },
+    "maps/lectorch.bsp": {
+     "bytes": 25524,
+     "sha256": "587443212147af734451e00a23f3fa0cae73cb2f96a3d9c385f58ac49e6b54c2"
+    },
+    "maps/start.bsp": {
+     "bytes": 533096,
+     "sha256": "d5d1c5f3f64ad869c9e7219ef42b724018c084a3c6355d613e9aea8a07ab891b"
+    },
+    "maps/storage.bsp": {
+     "bytes": 1243372,
+     "sha256": "559bfce12bf43fec4802e31082d7b1928ada1f357adcd0bf27b87c93c798b517"
+    },
+    "maps/water.bsp": {
+     "bytes": 121812,
+     "sha256": "e291581dc80dee669a707320a3fcac3f9de6c8fcb6896e0109e06eb156b969d6"
+    },
+    "progs/acidb.mdl": {
+     "bytes": 14716,
+     "sha256": "bb3e1888d8698e6ae44c1e8a82b2d1fff6bed6f8a1e851822c09092d79b278e2"
+    },
+    "progs/armor1.mdl": {
+     "bytes": 14988,
+     "sha256": "b3accc0c223510b9e199b02d23ada944f2673125a3a6fb5b26b5cae9c3a4a728"
+    },
+    "progs/armora.mdl": {
+     "bytes": 28524,
+     "sha256": "fa019caa7e6a025e1a5e5cc82044ebcce0c0219aef407caf65ad0f2e4d4e622c"
+    },
+    "progs/armorb.mdl": {
+     "bytes": 42060,
+     "sha256": "86c7e9908c1b184a2988070ace7185330dd87a8a1fb3a8b974080d16e5396659"
+    },
+    "progs/avatarg.mdl": {
+     "bytes": 571107,
+     "sha256": "ac74d4b23913d2f402d3a190bd2039943f1774025a1813bd52fb9488b6fb666e"
+    },
+    "progs/avatars.mdl": {
+     "bytes": 452543,
+     "sha256": "b7cef690e765139c3c0e781d23b139a9d193f5311f0c7ff8fe4e3f34565ea26a"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 89236,
+     "sha256": "d4a0c2668b5270488f83c0df8b4f93b26dd693cbbf8235f5846f80bc1319f21a"
+    },
+    "progs/bioelec.mdl": {
+     "bytes": 54588,
+     "sha256": "ce11999f9d7d200afc5e3b8851d0d6f519ede03904c86df20c81d29e2beeb9f7"
+    },
+    "progs/biospike.mdl": {
+     "bytes": 22484,
+     "sha256": "fedc4bbc289db448e692f81b9a38dc29cb5aacf735f6ecb3943596108abf8d6c"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 10820,
+     "sha256": "3434bb1b32ff5308505ef9b525e2f348a9281fc7b544ef93926f0915c4624337"
+    },
+    "progs/bolt2.mdl": {
+     "bytes": 10820,
+     "sha256": "603ea9e55cec61298697622cb7f2ff613b8e60d8379b9269d8d161e84d28d106"
+    },
+    "progs/bolt3.mdl": {
+     "bytes": 21524,
+     "sha256": "621e8b5743e37e31fadfa0dd119a5d8c6bcf743e48c5b5ba45fc8e1a455c3d4d"
+    },
+    "progs/box.mdl": {
+     "bytes": 145192,
+     "sha256": "de01705c7d54a9c15d46fa48f676dfdd9b4a07b09d000bd340896f53c06e124b"
+    },
+    "progs/buggy51b.mdl": {
+     "bytes": 112312,
+     "sha256": "16941fe9fdc10cfd33ea035762b0f85f1b7334259a96041f3c3eaeecdeab4bae"
+    },
+    "progs/camera.mdl": {
+     "bytes": 41748,
+     "sha256": "c3ff03d26336228270d26e2953d13f9ddeca7d665ad80a8e40cccd0e93eb3d20"
+    },
+    "progs/cdplayer.mdl": {
+     "bytes": 549428,
+     "sha256": "31074a9a27602b2c001114748843f42ece1530f18609169e51add9992b0d9fc1"
+    },
+    "progs/chip.mdl": {
+     "bytes": 7268,
+     "sha256": "42d1190b710743f748c445217ace8f4ee40184a1c23f0809eb7f463d8cd2a86d"
+    },
+    "progs/chopper.mdl": {
+     "bytes": 168144,
+     "sha256": "724584049b17280352c47353cc990b3f2dfdd290b6e972b7c103fe9042d867fd"
+    },
+    "progs/chopper2.mdl": {
+     "bytes": 168144,
+     "sha256": "2b69709b6f9e15c244aaf3558adb024f2a530d9480c966fd7eb899a0c49c4298"
+    },
+    "progs/elec1.mdl": {
+     "bytes": 34888,
+     "sha256": "064e04a0c800edc82fa02db5502e8d391d94e718f18ec407b9d025081956736d"
+    },
+    "progs/explo2.mdl": {
+     "bytes": 69992,
+     "sha256": "52e36daf4246d3dc3760ee6bbfc4226f94f977108cd10d0daf6af6577c8f6714"
+    },
+    "progs/explode.mdl": {
+     "bytes": 201220,
+     "sha256": "95ac38a47404885c7fd9ee358f610b0ab2edc5b80cd654c2011477881223266c"
+    },
+    "progs/fly.mdl": {
+     "bytes": 42892,
+     "sha256": "6dd8f798792adc8d8d64c86916e174cdafce70fdf1d946d86389508a9eecca4c"
+    },
+    "progs/g_key.mdl": {
+     "bytes": 8436,
+     "sha256": "7aa989136532426c74bd48eb876f40bba08275fa159a34401f8604114291f527"
+    },
+    "progs/gibotron.mdl": {
+     "bytes": 10236,
+     "sha256": "8c06956de9bdd64d3c39120ccc9f53845d2f8dadd2fdf369d8d7664d86681645"
+    },
+    "progs/globe.mdl": {
+     "bytes": 22164,
+     "sha256": "8958a7a1d4d6669b3b9068935b77573d5cfec8e8868a8fb0a8784bb16e7acfad"
+    },
+    "progs/guard.mdl": {
+     "bytes": 172760,
+     "sha256": "9225ad03658c5cc8d7fc931e9caf2683a12390a73aa3fac30368e07cccc2ae16"
+    },
+    "progs/gun.mdl": {
+     "bytes": 91452,
+     "sha256": "b4781e7bdc97c99b6ee2a5f69ca0b4cf83acb2b78901f27d5864633a6e66edcf"
+    },
+    "progs/h.mdl": {
+     "bytes": 26540,
+     "sha256": "04ffbd303a0e844a79e0f47bbe2ecfda661ab5faa72bdf98de976ab4123164ac"
+    },
+    "progs/helmet.mdl": {
+     "bytes": 79780,
+     "sha256": "989aac9fbe0ebb5dde335eb9eeef1e3f4267ef9885184dc5039fae62444c3917"
+    },
+    "progs/lense.mdl": {
+     "bytes": 71892,
+     "sha256": "cbe2526c4aa778f105adec9891e7f606744926b37a7621de6b7eb052873529d9"
+    },
+    "progs/light.mdl": {
+     "bytes": 28084,
+     "sha256": "05e6aafcfc131caa8c1088f6a36a138f6ad92f118d2ca4cf12a9479914a849c5"
+    },
+    "progs/mech.mdl": {
+     "bytes": 61316,
+     "sha256": "95958319b49ea9a5b16cd99751a77a31a8e1b06ce1aa8d11ee98f723bfe98555"
+    },
+    "progs/missile.mdl": {
+     "bytes": 43292,
+     "sha256": "306cde7fbc6a666f85cf7d4a9475b6d2826cbb54feb93e8fa95c8b7352a7fe1b"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 11348,
+     "sha256": "0934899f45a68c76bfc2404d77c8cd72ad7e609575753971c30013f253db4636"
+    },
+    "progs/pod2.mdl": {
+     "bytes": 234336,
+     "sha256": "f3cfe5cb62b9d949217229fa05bd6c02984cfd45a4f132b3e4a48001f36a5eab"
+    },
+    "progs/protect.mdl": {
+     "bytes": 14988,
+     "sha256": "96f682914cfa2a64072bfe0f27272fff7737df476feaedd39a839a01c98e8436"
+    },
+    "progs/ray.mdl": {
+     "bytes": 77516,
+     "sha256": "77d5e9d86010325951d97de4862f0cb61053455f1932bad3072fdc7a22b731a4"
+    },
+    "progs/rayweap.mdl": {
+     "bytes": 68700,
+     "sha256": "8ad72aaca6e535298bfab88aa75221267e89c8caac3afde347d3c9d54668b159"
+    },
+    "progs/s_dither.spr": {
+     "bytes": 16440,
+     "sha256": "9738fc061c3175ea6cf0b0b2c80f6f5ac71c9ae0d6e50b98224d1f9d537d32d9"
+    },
+    "progs/s_fence.spr": {
+     "bytes": 4152,
+     "sha256": "d5ce29daea93977e06f697018c50a236aceea84d12cb89d11ca5740c017f5226"
+    },
+    "progs/s_invis.spr": {
+     "bytes": 5556,
+     "sha256": "79eae2eb897a0fb181d4345b2b17c7cdd1f90105df7272a350b936b2f3edc8b1"
+    },
+    "progs/s_key.mdl": {
+     "bytes": 8436,
+     "sha256": "a4e13d058f042b2970a913a2251634ced3d51a096e085c007a39af68d0333b73"
+    },
+    "progs/sentry.mdl": {
+     "bytes": 90068,
+     "sha256": "fa3a5a4ec492a85d22052f44c45a7de013002ef6daed267b9caee0312609c1ff"
+    },
+    "progs/spiky2.mdl": {
+     "bytes": 48540,
+     "sha256": "bff953a600a9aeb7749ed17bada64728ab87e7afa9f4a14042ef3edb1c1394a2"
+    },
+    "progs/spiky3.mdl": {
+     "bytes": 48540,
+     "sha256": "84991f07aa4f30911576ef46d14e37cb57cb43299eb8b440683672aaf7615f86"
+    },
+    "progs/spiky4.mdl": {
+     "bytes": 48348,
+     "sha256": "98fc629e936d1d790d23e4f4df0f0f8e577200e01d856144cb8a9b61a2cb1bf3"
+    },
+    "progs/sword.mdl": {
+     "bytes": 16456,
+     "sha256": "b2fa806d7fd8f5087829b617be714356b5a6c9bbc170166a1ca79660de5eb952"
+    },
+    "progs/torch1.mdl": {
+     "bytes": 72345,
+     "sha256": "6e96289d4db56f59aa94f40a7b00a4c093b8337a50a0e1a9e30d0ffcb0870dd3"
+    },
+    "progs/tv.mdl": {
+     "bytes": 17548,
+     "sha256": "823dc36f1fa691aa8aa111c5ef9eeba160229f8f85eb973ab45874dc880c611c"
+    },
+    "progs/v_fists.mdl": {
+     "bytes": 23716,
+     "sha256": "f6e8b0b67c76da7da75a99b05dd002338ba37bcbccf5599fcbfc4409222d50af"
+    },
+    "progs/v_torch.mdl": {
+     "bytes": 81760,
+     "sha256": "7c3ee057db192bb401c9fbb3b49bee6b79056d8beba7b431e03d7e6046fa4963"
+    },
+    "progs/woodgib1.mdl": {
+     "bytes": 16020,
+     "sha256": "1c222aba38c6e4bc1855942a03d59f490f388ac18ac76aae0978f93e92344e81"
+    },
+    "progs/woodgib2.mdl": {
+     "bytes": 10452,
+     "sha256": "c2ac32d2bbf6aee5f666d93efef82dfabf160114212a266ba6d6a91a3b9ccbe2"
+    },
+    "progs/woodgib3.mdl": {
+     "bytes": 11252,
+     "sha256": "7142b185caef15a9e194cf9eac75b1df24ce80f32d623460720d8367126eee5e"
+    },
+    "progs/xsentry.mdl": {
+     "bytes": 90068,
+     "sha256": "6084427ad1e6e80be47faed67ede53dce99f2802a6d82cc978013565eb0af846"
+    },
+    "sound/blob/death1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/blob/sight1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/chopper/attack.wav": {
+     "bytes": 7024,
+     "sha256": "e81f88b3b9d74c36658b8812a31d53926ea6875f8f2076cdf9023c5eb67c04b9"
+    },
+    "sound/chopper/attack2.wav": {
+     "bytes": 7250,
+     "sha256": "0637ac6cc112d445e4156c4b35d9697572d3257e67de925a5d10ead30019fc53"
+    },
+    "sound/chopper/death.wav": {
+     "bytes": 58884,
+     "sha256": "1857b2e38d85acc9147f55cd30ec190ccfc1c677408fcd9ece0523bb9aa1ac14"
+    },
+    "sound/chopper/idle.wav": {
+     "bytes": 93330,
+     "sha256": "7276b69d9934627bcf0eb6d9576208e0542d802f73c01d14a668d8aa45bcf6db"
+    },
+    "sound/chopper/pain.wav": {
+     "bytes": 13446,
+     "sha256": "c55cc0cd5e5bdbee5b6a9c1324b2d3cd16c7df7687f46c26edb22010f802d36f"
+    },
+    "sound/chopper/sight.wav": {
+     "bytes": 38658,
+     "sha256": "1ff5485e2eb6d0c1c8c28ca8f52b7d6ffe5a9be0c5597f121bde4da867c13f80"
+    },
+    "sound/demon/ddeath.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/demon/dhit2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/demon/djump.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/demon/dpain.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/demon/idle1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/demon/sight2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/dog/dattack1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/dog/ddeath.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/dog/dpain1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/dog/dsight.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/dog/idle.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/enforcer/death1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/enforcer/enfire.wav": {
+     "bytes": 14570,
+     "sha256": "d5b91ad9b67f43164a758870611f07763fc48098edcccf6161df32f20460cffe"
+    },
+    "sound/enforcer/pain1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/enforcer/pain2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/fish/bite.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/hknight/death1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/hknight/grunt.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/hknight/idle.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/hknight/pain1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/hknight/sight1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/knight/idle.wav": {
+     "bytes": 80126,
+     "sha256": "a680742c581c4fa84545853804095e28e4ec3c5741816f979eb692712c80df31"
+    },
+    "sound/knight/kdeath.wav": {
+     "bytes": 35336,
+     "sha256": "03eca6597ec3b5838b44730afb315dc473204be9980d617a5c22cb4330ae1fef"
+    },
+    "sound/knight/khurt.wav": {
+     "bytes": 15934,
+     "sha256": "04367c1bd2dd833ea2e56926fab451a500d4aebc1abd8f7e250b004e5181d508"
+    },
+    "sound/knight/ksight.wav": {
+     "bytes": 16604,
+     "sha256": "02fd6f5de0519f1bb247138d8216231ac559bf8b2dc7dab973e6405b2e45a25b"
+    },
+    "sound/mech/attack.wav": {
+     "bytes": 20574,
+     "sha256": "dcd8ea70e042372d9d7411c27c0a2b11e1e3ddcc9d3f7aa50b63a0e6eb92cad1"
+    },
+    "sound/mech/death.wav": {
+     "bytes": 58884,
+     "sha256": "1857b2e38d85acc9147f55cd30ec190ccfc1c677408fcd9ece0523bb9aa1ac14"
+    },
+    "sound/mech/idle.wav": {
+     "bytes": 93330,
+     "sha256": "638dd2ebd2b42bfcf0caacca19cbf55224c6fed7132e5170306c8f525203cb11"
+    },
+    "sound/mech/pain.wav": {
+     "bytes": 13446,
+     "sha256": "c55cc0cd5e5bdbee5b6a9c1324b2d3cd16c7df7687f46c26edb22010f802d36f"
+    },
+    "sound/mech/sight.wav": {
+     "bytes": 38658,
+     "sha256": "1ff5485e2eb6d0c1c8c28ca8f52b7d6ffe5a9be0c5597f121bde4da867c13f80"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/ogre/ogdth.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/ogre/ogidle2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/ogre/ogpain1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/ogre/ogwake.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/orca/attack.wav": {
+     "bytes": 20574,
+     "sha256": "dcd8ea70e042372d9d7411c27c0a2b11e1e3ddcc9d3f7aa50b63a0e6eb92cad1"
+    },
+    "sound/orca/death.wav": {
+     "bytes": 58884,
+     "sha256": "1857b2e38d85acc9147f55cd30ec190ccfc1c677408fcd9ece0523bb9aa1ac14"
+    },
+    "sound/orca/idle.wav": {
+     "bytes": 93330,
+     "sha256": "638dd2ebd2b42bfcf0caacca19cbf55224c6fed7132e5170306c8f525203cb11"
+    },
+    "sound/orca/pain.wav": {
+     "bytes": 13446,
+     "sha256": "c55cc0cd5e5bdbee5b6a9c1324b2d3cd16c7df7687f46c26edb22010f802d36f"
+    },
+    "sound/orca/sight.wav": {
+     "bytes": 38658,
+     "sha256": "1ff5485e2eb6d0c1c8c28ca8f52b7d6ffe5a9be0c5597f121bde4da867c13f80"
+    },
+    "sound/player/axhit1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/death1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/death2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/death3.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/death4.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/death5.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/gib.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/lburn1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/lburn2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/pain1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/pain2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/pain3.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/pain4.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/pain5.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/pain6.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/step1.wav": {
+     "bytes": 16322,
+     "sha256": "0e34fdc3f008f6c9779ba49926993c1b5a6d42bb49a6ba7a7579ee6b6e658a95"
+    },
+    "sound/player/step2.wav": {
+     "bytes": 14800,
+     "sha256": "96a7cbe263fea62635347b74e73d94b16092aed3bfad1a01f5856f58ab701dca"
+    },
+    "sound/player/step3.wav": {
+     "bytes": 13014,
+     "sha256": "52e9d03cb45c17702441f8e6e3dee64fef62c315874b9ea10d17bf3221778f84"
+    },
+    "sound/player/teledth1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/tornoff2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/player/udeath.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/ray/attack.wav": {
+     "bytes": 14570,
+     "sha256": "d5b91ad9b67f43164a758870611f07763fc48098edcccf6161df32f20460cffe"
+    },
+    "sound/ray/death.wav": {
+     "bytes": 58884,
+     "sha256": "1857b2e38d85acc9147f55cd30ec190ccfc1c677408fcd9ece0523bb9aa1ac14"
+    },
+    "sound/ray/idle.wav": {
+     "bytes": 93330,
+     "sha256": "638dd2ebd2b42bfcf0caacca19cbf55224c6fed7132e5170306c8f525203cb11"
+    },
+    "sound/ray/pain.wav": {
+     "bytes": 13446,
+     "sha256": "c55cc0cd5e5bdbee5b6a9c1324b2d3cd16c7df7687f46c26edb22010f802d36f"
+    },
+    "sound/ray/sight.wav": {
+     "bytes": 38658,
+     "sha256": "1ff5485e2eb6d0c1c8c28ca8f52b7d6ffe5a9be0c5597f121bde4da867c13f80"
+    },
+    "sound/sentry/attack.wav": {
+     "bytes": 20574,
+     "sha256": "dcd8ea70e042372d9d7411c27c0a2b11e1e3ddcc9d3f7aa50b63a0e6eb92cad1"
+    },
+    "sound/sentry/death.wav": {
+     "bytes": 58884,
+     "sha256": "1857b2e38d85acc9147f55cd30ec190ccfc1c677408fcd9ece0523bb9aa1ac14"
+    },
+    "sound/sentry/idle.wav": {
+     "bytes": 93330,
+     "sha256": "638dd2ebd2b42bfcf0caacca19cbf55224c6fed7132e5170306c8f525203cb11"
+    },
+    "sound/sentry/pain.wav": {
+     "bytes": 13446,
+     "sha256": "c55cc0cd5e5bdbee5b6a9c1324b2d3cd16c7df7687f46c26edb22010f802d36f"
+    },
+    "sound/sentry/sight.wav": {
+     "bytes": 38658,
+     "sha256": "1ff5485e2eb6d0c1c8c28ca8f52b7d6ffe5a9be0c5597f121bde4da867c13f80"
+    },
+    "sound/shalrath/attack.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/shalrath/attack2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/shalrath/death.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/shalrath/idle.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/shalrath/pain.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/shalrath/sight.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/shambler/melee1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/shambler/melee2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/shambler/sdeath.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/shambler/shurt2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/shambler/sidle.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/shambler/smack.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/shambler/ssight.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/soldier/death1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/soldier/idle.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/soldier/pain1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/soldier/pain2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/soldier/sight1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/weapons/2acid.wav": {
+     "bytes": 36656,
+     "sha256": "afe032fb0e0cb5052d5deda3915eee2950ee144d0aacea9a88dc148dbaa46524"
+    },
+    "sound/weapons/2laser.wav": {
+     "bytes": 3503,
+     "sha256": "af39a03858f9c7e2dfc08b27039128ef31e107b1ad626eecef85a07974b075e9"
+    },
+    "sound/weapons/2missile.wav": {
+     "bytes": 7250,
+     "sha256": "0637ac6cc112d445e4156c4b35d9697572d3257e67de925a5d10ead30019fc53"
+    },
+    "sound/weapons/2spike.wav": {
+     "bytes": 7024,
+     "sha256": "e81f88b3b9d74c36658b8812a31d53926ea6875f8f2076cdf9023c5eb67c04b9"
+    },
+    "sound/weapons/charge.wav": {
+     "bytes": 7250,
+     "sha256": "0637ac6cc112d445e4156c4b35d9697572d3257e67de925a5d10ead30019fc53"
+    },
+    "sound/weapons/shank.wav": {
+     "bytes": 11060,
+     "sha256": "4034bd27b1dc32da8c5ad548767e5d72c437ff2457bd26a88015d9de1532a461"
+    },
+    "sound/weapons/swordcut.wav": {
+     "bytes": 27324,
+     "sha256": "cf3674ef098e0074d48794a523c417e3729147ae4116f95a3932dabb4bbd34f3"
+    },
+    "sound/weapons/swordhit.wav": {
+     "bytes": 33734,
+     "sha256": "35400e850a087dad008c27763ecc82edba8b5cf7ad6bff8fd012b223d5886878"
+    },
+    "sound/weapons/swordmis.wav": {
+     "bytes": 33734,
+     "sha256": "825e8de346b4ac6a83bcbd0c02f9baf368763fcf1bcd7adfdf9f785ff1d8e9f8"
+    },
+    "sound/weapons/weap0011.wav": {
+     "bytes": 6288,
+     "sha256": "1352a8bb16a0f2df2e80443d987508f5cf8789cc7fcef75f146f32e18aca260a"
+    },
+    "sound/weapons/weap0101.wav": {
+     "bytes": 7250,
+     "sha256": "0637ac6cc112d445e4156c4b35d9697572d3257e67de925a5d10ead30019fc53"
+    },
+    "sound/weapons/weap0110.wav": {
+     "bytes": 8811,
+     "sha256": "449181cebe956ecf9901c5c9cd7f84ae7f0c0f56b812e2bda99ac1257b8f9a05"
+    },
+    "sound/weapons/weap0111.wav": {
+     "bytes": 7250,
+     "sha256": "0637ac6cc112d445e4156c4b35d9697572d3257e67de925a5d10ead30019fc53"
+    },
+    "sound/weapons/weap1001.wav": {
+     "bytes": 7017,
+     "sha256": "064415735b46cd8478a5cf7802b63676d485038d0c97cda36d265aab0930c9e2"
+    },
+    "sound/weapons/weap1010.wav": {
+     "bytes": 7250,
+     "sha256": "0637ac6cc112d445e4156c4b35d9697572d3257e67de925a5d10ead30019fc53"
+    },
+    "sound/weapons/weap1011.wav": {
+     "bytes": 6288,
+     "sha256": "1352a8bb16a0f2df2e80443d987508f5cf8789cc7fcef75f146f32e18aca260a"
+    },
+    "sound/weapons/weap1100.wav": {
+     "bytes": 6288,
+     "sha256": "1352a8bb16a0f2df2e80443d987508f5cf8789cc7fcef75f146f32e18aca260a"
+    },
+    "sound/weapons/weap1101.wav": {
+     "bytes": 8811,
+     "sha256": "449181cebe956ecf9901c5c9cd7f84ae7f0c0f56b812e2bda99ac1257b8f9a05"
+    },
+    "sound/weapons/weap1110.wav": {
+     "bytes": 6288,
+     "sha256": "1352a8bb16a0f2df2e80443d987508f5cf8789cc7fcef75f146f32e18aca260a"
+    },
+    "sound/weapons/weap1111.wav": {
+     "bytes": 6288,
+     "sha256": "1352a8bb16a0f2df2e80443d987508f5cf8789cc7fcef75f146f32e18aca260a"
+    },
+    "sound/wizard/wattack.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/wizard/wdeath.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/wizard/widle2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/wizard/wpain.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/wizard/wsight.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/zombie/idle_w2.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/zombie/z_gib.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/zombie/z_idle.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/zombie/z_idle1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/zombie/z_pain.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    },
+    "sound/zombie/z_pain1.wav": {
+     "bytes": 11586,
+     "sha256": "7cdd0b12ca41bf88fe7ba714e0f2d161a49a0508f4989268d94e11070dec1383"
+    }
+   },
    "sha256": "fbe31664e203114437c6e67c63268f8feaad6e3d5f736efa4229579101f4cb74",
    "timestamp": "1998-01-18T13:29:00.000Z"
   },
   "tsoa/pak2.pak": {
    "bytes": 12530804,
+   "files": {
+    "maps/basement.bsp": {
+     "bytes": 669204,
+     "sha256": "a60f7104c1fe235ccd57a449c762e750b7d4bdba81b1e5c584d08e5fb3b49101"
+    },
+    "maps/cascade.bsp": {
+     "bytes": 1731980,
+     "sha256": "76b2fc300385bfad7ba1add6fe5953d4c72ca5b074dca3cd96df27eff48ada40"
+    },
+    "maps/guardhou.bsp": {
+     "bytes": 771372,
+     "sha256": "d948371db135664cfe9eb2215b76af68e369b1a7e90a1cbfc4a788c8105a6582"
+    },
+    "maps/lobby.bsp": {
+     "bytes": 1904868,
+     "sha256": "af30e17c1ce9decc908ea6755a2e12a2ab363c76f2c28258e67515e8686a7872"
+    },
+    "maps/mine.bsp": {
+     "bytes": 1028228,
+     "sha256": "55a15fea809f6cea7205202950875460741320e1d11370c5984bca430dfaad50"
+    },
+    "maps/minenter.bsp": {
+     "bytes": 1055928,
+     "sha256": "af70c856275d9517835ba0d7b3a55847d336cf33f104008e502663bd26d2ed3d"
+    },
+    "maps/missile.bsp": {
+     "bytes": 465088,
+     "sha256": "4e5c03246031cf82a25ae8ae45f1433a2c30cd13915541a388a9cab6cb5139be"
+    },
+    "maps/physical.bsp": {
+     "bytes": 1386524,
+     "sha256": "b4eac55e5ae3efe03cdc97baa4932c9587a788572ff34d0ac3a36ed75b6c1a29"
+    },
+    "maps/pressure.bsp": {
+     "bytes": 930568,
+     "sha256": "29429aadc280f41fe131b53782457b422a92e3ba8f9b0f5ed6309bf5018d53f4"
+    },
+    "maps/research.bsp": {
+     "bytes": 1592732,
+     "sha256": "e4a2ba41a96fcfec1a05b3d96777c1913c3699851fe9ea37ba59d8a80ad9132d"
+    },
+    "maps/round.bsp": {
+     "bytes": 177028,
+     "sha256": "81569e0525410b99999b238c602b590a0e6ce2e8381920938a294da5642afc1b"
+    },
+    "maps/vat.bsp": {
+     "bytes": 816504,
+     "sha256": "48766422214f456b3f55c7a473020b017b2caa61e6b02ecc98896236a8a65344"
+    }
+   },
    "sha256": "847b8697aa078458e464f914c8838bb5dd9bc2dc7580d2509a1121f34ad026a8",
    "timestamp": "1998-01-18T13:31:00.000Z"
   },

--- a/json/by-sha256/86/8638cac882448315db3ebe1ec51baa7bafa4a4187033f9eab35e8eeaed4aabb1.json
+++ b/json/by-sha256/86/8638cac882448315db3ebe1ec51baa7bafa4a4187033f9eab35e8eeaed4aabb1.json
@@ -8,16 +8,1874 @@
  "files": {
   "pak0.pak": {
    "bytes": 48226771,
+   "files": {
+    "coop.dem": {
+     "bytes": 2575532,
+     "sha256": "214de04930a259e6a37101fb8a8838d7af07e6bc79efaf7525ca3b68610d5a3b"
+    },
+    "gfx.wad": {
+     "bytes": 128932,
+     "sha256": "6f7878b23deb09b151a58b8357f8a5b966cc87dce24a52407d931ceef885fbc5"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "d3608be2643c55487f8a90c2bbfb72f7aa8a0fcaa72cd4e156943a59fbeae68b"
+    },
+    "gfx/env/bseabk.tga": {
+     "bytes": 786450,
+     "sha256": "d00b39ceb291dc3a56f1b65cb40d90cabd49495785cf7754ee93920985e8946c"
+    },
+    "gfx/env/bseadn.tga": {
+     "bytes": 786450,
+     "sha256": "ac81fbab4610004d3b8f9f26fccce1aa9bf013414f714b261177eb7a23730c9f"
+    },
+    "gfx/env/bseaft.tga": {
+     "bytes": 786450,
+     "sha256": "cd36bc74f3f779b70c05e9394f74d0dd62655fbff8206e4828d9e1d669b05416"
+    },
+    "gfx/env/bsealf.tga": {
+     "bytes": 786450,
+     "sha256": "94ad30078b5516ff4baaffe003f73fdfd10a9446ab1c5239474a6fe46bcb588c"
+    },
+    "gfx/env/bseart.tga": {
+     "bytes": 786450,
+     "sha256": "ffa0b7fc5b127c82c3a73dc576bea00cd95b9b7697db377ea457fe9275a38290"
+    },
+    "gfx/env/bseaup.tga": {
+     "bytes": 786450,
+     "sha256": "5c69640f2d24cf1f39fe632a3315e4e810628725e77fa967bda7a215e76df9f7"
+    },
+    "gfx/env/duskbk.tga": {
+     "bytes": 786971,
+     "sha256": "c6ff35f38b5262c301fafd7857305cf80636efd9b67c72f511a2e93a2648d220"
+    },
+    "gfx/env/duskdn.tga": {
+     "bytes": 786971,
+     "sha256": "5a844ff50a7e7cb3115c94cf97c36fb55a998baf8a3e38118bc4524f03d533fb"
+    },
+    "gfx/env/duskft.tga": {
+     "bytes": 786971,
+     "sha256": "c1142a0e3bba1d2b65f887c000b6b5e450fe08474d6a5d026532b63e73d03a01"
+    },
+    "gfx/env/dusklf.tga": {
+     "bytes": 786971,
+     "sha256": "1735e4c258ab8d18b971345b43c79991bf76c2c178344739c26d79d7658128e4"
+    },
+    "gfx/env/duskrt.tga": {
+     "bytes": 786971,
+     "sha256": "4cdc3edcc8c0c1ec938ef7e4297931cf1bc4ebd804660011725bc7f3abc61ddb"
+    },
+    "gfx/env/duskup.tga": {
+     "bytes": 786971,
+     "sha256": "320e8dd8e6adc4453d894d15d20ba3ad02f176af3dd4ab1baab695e0a4accfef"
+    },
+    "gfx/env/fodrianbk.tga": {
+     "bytes": 438466,
+     "sha256": "023a119b49e2a3630b156cf622fdf0d9efe6a8144d1128542dad3a36852d571f"
+    },
+    "gfx/env/fodriandn.tga": {
+     "bytes": 526472,
+     "sha256": "ece0abbb9d478368c9b80fca7fe03ab2cfd349d0d087e134b2ac7d5f8c61ba89"
+    },
+    "gfx/env/fodrianft.tga": {
+     "bytes": 491268,
+     "sha256": "1914f73da39bd55a6a167508a3e0474cdf8f9047b59fbf74113c50cb1a682d0b"
+    },
+    "gfx/env/fodrianlf.tga": {
+     "bytes": 502698,
+     "sha256": "c75d67a6f12f9e96fe5af60ec6f7a6d93778371d3bf141f28e750ff6113945a7"
+    },
+    "gfx/env/fodrianrt.tga": {
+     "bytes": 468382,
+     "sha256": "aad1a02a8c636463fbee3178aaa69b90380b96d8550c581ab74fc91ec05f6e9c"
+    },
+    "gfx/env/fodrianup.tga": {
+     "bytes": 538367,
+     "sha256": "31a61f7f5f476a81a2191153794770fbcab42c61e9f32253daffe78f38585b75"
+    },
+    "gfx/env/graynightbk.tga": {
+     "bytes": 786971,
+     "sha256": "3cd8f98206a4267c0cbd7a8028dd55a2869e4a0840a45c89e4a03d1300d970bf"
+    },
+    "gfx/env/graynightdn.tga": {
+     "bytes": 786971,
+     "sha256": "2d2e929246612062e871629464e8508a0dc9fe35680015e90a441c6c20e1a936"
+    },
+    "gfx/env/graynightft.tga": {
+     "bytes": 786971,
+     "sha256": "387759c32fdce1b459b7fad63f47ca35c5755794aa960c8486b2e4de24c59949"
+    },
+    "gfx/env/graynightlf.tga": {
+     "bytes": 786971,
+     "sha256": "16654901eabc2f4da7ac602c240932acd73cc5831e29afc4dafc51cd2daaa9b4"
+    },
+    "gfx/env/graynightrt.tga": {
+     "bytes": 786971,
+     "sha256": "4f13113e77b85644febb7baff162c19cc353f4257322826389974e516ffd77a6"
+    },
+    "gfx/env/graynightup.tga": {
+     "bytes": 786971,
+     "sha256": "178c815e62bb236b75d967e502ed4a93eba64cd12818081f6f41591860b3d4da"
+    },
+    "gfx/env/starsbk.tga": {
+     "bytes": 51294,
+     "sha256": "7292194bfe9a6444173b6c4949568ec42cd6900883dcc444da0f2344fe3d4d69"
+    },
+    "gfx/env/starsdn.tga": {
+     "bytes": 51322,
+     "sha256": "59e645a79cd93b98c05de9c2f8a136394ab561ce0b9978aad4de17c6508da60b"
+    },
+    "gfx/env/starsft.tga": {
+     "bytes": 51685,
+     "sha256": "2dc8d4ab7cdd655c2a63bfe7059815bedc56692a5c1867191d12433958f633c5"
+    },
+    "gfx/env/starslf.tga": {
+     "bytes": 50756,
+     "sha256": "f74f36da6239c9b011b6ecf1f0fabf7c40f3372fe3841d2168473a31e16e646c"
+    },
+    "gfx/env/starsrt.tga": {
+     "bytes": 52319,
+     "sha256": "9ce812f2efe3dd4fb077bc751fc8209de661c04544e54c3271b956316b7c162e"
+    },
+    "gfx/env/starsup.tga": {
+     "bytes": 51416,
+     "sha256": "d31b6a617776b2ccd90662ec1196267ac4c8be85696b9702ec39c41386f2fc47"
+    },
+    "gfx/env/voidbk.tga": {
+     "bytes": 603,
+     "sha256": "6e095aecdb2ee0ebb2636b48ce7f7754ee357b217f32a83025830db3d9a87fdc"
+    },
+    "gfx/env/voiddn.tga": {
+     "bytes": 603,
+     "sha256": "0c7a0cf2c30d6d87f21567c4e4dacedccc3840fb82b37bfd8c0949315526cc46"
+    },
+    "gfx/env/voidft.tga": {
+     "bytes": 603,
+     "sha256": "bc18cbf4e5c4036b64203d6a165aa18edf24d86bcee9b6e7c183bd54f456550e"
+    },
+    "gfx/env/voidlf.tga": {
+     "bytes": 603,
+     "sha256": "a350d7da744018421f60d6b95edc609f36d059ad27fe0621599c018e6ccbf3d7"
+    },
+    "gfx/env/voidrt.tga": {
+     "bytes": 603,
+     "sha256": "6447fc6c5ddb2a696fccd2611323758ce44be8a236ec9602ed9947b800d1240a"
+    },
+    "gfx/env/voidup.tga": {
+     "bytes": 603,
+     "sha256": "76c1a1a57bfc1099bde3814a7d998b842ad6f8b619d3e4e1169ab7ab8850f133"
+    },
+    "maps/e1m1quoth.bsp": {
+     "bytes": 4120260,
+     "sha256": "7ae26353d1d578c660fc399a5e46836a35477f772fb08039a1c75e5b409610f8"
+    },
+    "maps/kelltest1.bsp": {
+     "bytes": 896456,
+     "sha256": "a913e05c0b4b5fc09257ace118d55205b3e34f2f9e44e6184828a7150c7a6618"
+    },
+    "maps/kelltest2.bsp": {
+     "bytes": 507808,
+     "sha256": "f3874478333d08938247cff6dd23a9717763b42af87ed5283b31f85515404c07"
+    },
+    "maps/kelltest3.bsp": {
+     "bytes": 405700,
+     "sha256": "3e2497ca1bf2cd3aae0a0616066ab89288fa777ffacab11e1981f74f5ed8385d"
+    },
+    "maps/kelltest4.bsp": {
+     "bytes": 306912,
+     "sha256": "36639ed4b47a30328f358c1e63067020b273d8d831bc47dec4b24cc1599159f5"
+    },
+    "maps/ne_basetest.bsp": {
+     "bytes": 1196080,
+     "sha256": "1477ebc35c85b4d81ffc4bc623a75757c28b2d3a36c934763735b5947b656c47"
+    },
+    "maps/start.bsp": {
+     "bytes": 1927828,
+     "sha256": "4c452be3b25eed55d3df7e03baab033c5963cb82e09dc4e157299bec75fc792f"
+    },
+    "progs/air.mdl": {
+     "bytes": 5076,
+     "sha256": "930e21887f0c482f353d5009efe1f5ef3f88e18d7a4f2e1232978cb2e8f73932"
+    },
+    "progs/beam.mdl": {
+     "bytes": 3307,
+     "sha256": "18295a66ab4a4da70b5dc0558d5cac7622afd65e9937ebe8d2c5321a67a418ee"
+    },
+    "progs/bigexp.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/bilebomb.mdl": {
+     "bytes": 13469,
+     "sha256": "2f77d07f24b62edc095facdee8c670711cc189a85258a631ada71cd4746e26ac"
+    },
+    "progs/bilefrag.mdl": {
+     "bytes": 9216,
+     "sha256": "34e6ed3456aef2c89d4ab9d857a173bfa98c17381be380f9665d496791f6f814"
+    },
+    "progs/bob.mdl": {
+     "bytes": 177959,
+     "sha256": "173f9aa590a0b23e0525c86b6945f3b8d565b865f2376daea00ac8f88791abc1"
+    },
+    "progs/bobblaster.mdl": {
+     "bytes": 27556,
+     "sha256": "3aa3e956183dc641fe601edaae52b7f2d5c92d90d00e8994e106dde4c0c25092"
+    },
+    "progs/boom.mdl": {
+     "bytes": 77388,
+     "sha256": "c0b2d8695564dbb1ef37aef9a9e226160ff8f5ab40de7a6d7129a66675096179"
+    },
+    "progs/brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "0287c3e7886bd2d6d1cbb504529d9e11038d0f8232ee624528eb0ccb78733c53"
+    },
+    "progs/corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "22f82f29d0a88af204f7b97eef887b963bd940e7277b6f5cef5e6f3610f2ea51"
+    },
+    "progs/corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "41e90f1a84e9779eb12541d923ab0a66e69deef3a9dbc82259ab84cb71b68dcc"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/dguard.mdl": {
+     "bytes": 176648,
+     "sha256": "f2f92ef84411d83c7e8c158f62b1415d8fc6aa56d77f21760dcd3080424cf6c8"
+    },
+    "progs/drlbomb.mdl": {
+     "bytes": 20355,
+     "sha256": "5c1db489f43cba73fce265db642267775245d044866cdd48396b1f1260a28237"
+    },
+    "progs/drole.mdl": {
+     "bytes": 241648,
+     "sha256": "5067b7ca5323754fe563d6696025525645a2cbd3aaf7f79232634608f9fb987a"
+    },
+    "progs/dspike.mdl": {
+     "bytes": 13684,
+     "sha256": "05bc998adf950efaeba0f0216e008ec8d6fa732d5eb726dbe70ff07e088275c6"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 333860,
+     "sha256": "230181ce6ea00c8e80c7d59189340424424ba5d99d71230b309907e206e07682"
+    },
+    "progs/fireball.mdl": {
+     "bytes": 12660,
+     "sha256": "ba5cba46edc108572d78e66166f5ed0405a48dcf672e7a569d14a4397f85f285"
+    },
+    "progs/fish.mdl": {
+     "bytes": 90636,
+     "sha256": "037ebaf6566f8fed7609b4e2c79eb36c4c78c49d914b225e7aa37fd4e3d6fa17"
+    },
+    "progs/g_bomb.mdl": {
+     "bytes": 50176,
+     "sha256": "33bc7cbf807cdae850d42cd11af0d332a7ca140741a3d29353e558bd8468aaa3"
+    },
+    "progs/g_fx.mdl": {
+     "bytes": 32260,
+     "sha256": "ac99d4e641af0bb1495ed38ba9f3a7c1195bda19e5cf0d3a68f04defe6178ab8"
+    },
+    "progs/g_ham.mdl": {
+     "bytes": 71639,
+     "sha256": "424bd4ecf03e0f364f57448b7c426924e1e0ccd06dad40294c00a23a645b8c0a"
+    },
+    "progs/g_lance.mdl": {
+     "bytes": 32906,
+     "sha256": "6eab37228d67437eccd9735de6e7933c79576a921c23479ad317e7c3db5b1f0d"
+    },
+    "progs/gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/greenexp.spr": {
+     "bytes": 24732,
+     "sha256": "8cd2c8f20214cc1f8de491785a27d3aafa924819c9f56078d2bdb219d4f16f5e"
+    },
+    "progs/gug.mdl": {
+     "bytes": 482020,
+     "sha256": "2cd097236a235aedf717a86b7312bd7d1b3caa6f0b25980c82eee2463fee2274"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 4920,
+     "sha256": "337f2723daab9d1375b78cb017512ce8281087ff8df9c33b04a6c613cea3590c"
+    },
+    "progs/h_dlord.mdl": {
+     "bytes": 18699,
+     "sha256": "bc5a92be1c5f3d06dc0238ec7bafe6a3c25826cc50edc6214ed5aa19b0075987"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 16854,
+     "sha256": "00f3263f1c3e0daadaaf03eea447080d727ea7d9ee1a88f2b42e060d748e1566"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 61251,
+     "sha256": "dec5afe666eba8db6e32d7535fffa3d0e4ed9344ba107b73418526ebebac574b"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 10663,
+     "sha256": "819b7cd0c4c38edb9725dffa46913ed89d75276aac3ea34b2bc683daedd5db0e"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 32629,
+     "sha256": "d69f21f26e13276272bb6b59352e66082a224534e8a0e46753037136927e0929"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 23239,
+     "sha256": "00117347d1acc46beb4972853572e14ce3e9d6dca25b883540896fcd873f3e3a"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 1142583,
+     "sha256": "2c3d4002e7c5f1682367c3f649e67333303d1763e6da0b3cfdce8c7519dfc2dc"
+    },
+    "progs/keybase.mdl": {
+     "bytes": 11407,
+     "sha256": "5fed79622ad6f6751b2c771ddff06b88dcf049719336c228520bc84f0db441cd"
+    },
+    "progs/keyeye.mdl": {
+     "bytes": 37528,
+     "sha256": "a4612e183f026ea63161377682c1001b178b9e0f94f6b9a801b983962162dbbc"
+    },
+    "progs/keymed.mdl": {
+     "bytes": 13247,
+     "sha256": "e147a4e527b9b797680732c33cc0ebe3503bcd6e2c8a5b0917701cdd41f99297"
+    },
+    "progs/keyrune.mdl": {
+     "bytes": 25643,
+     "sha256": "f06fafe1b92a172a2cebcbc68ad5e2a8aafdfc99d13ce6d5bf5b36f25ca48f73"
+    },
+    "progs/knight.mdl": {
+     "bytes": 342850,
+     "sha256": "9e23eca66dbe332f49a1a82ceef197d5ee980abb24145050ea3088e05468dd4b"
+    },
+    "progs/longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/marsh.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/marshsm.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 3542,
+     "sha256": "2f3efa19a64b60d480fbef7c10e8f2a56e90d656e8fcb8bcd656932f8686f482"
+    },
+    "progs/polyp.mdl": {
+     "bytes": 211928,
+     "sha256": "36268021903129e7e0e81600072ff3b38229cb6851cc6800945d9810510fad0b"
+    },
+    "progs/polyp_t1.mdl": {
+     "bytes": 66925,
+     "sha256": "82f5f86f210e8cfc541259a3a9efe7b0b4a046f5b5240c5d39ab08a021a4e2ee"
+    },
+    "progs/polyp_t2.mdl": {
+     "bytes": 65473,
+     "sha256": "130699464f89836047b7bf6b4ad0ac7feee810dd31da5add2892e1f61ed07a30"
+    },
+    "progs/polyp_t3.mdl": {
+     "bytes": 64069,
+     "sha256": "72a5a60e71e09a4a0e73dba0658b301540b3d871ec4ea88e24ace135db19d046"
+    },
+    "progs/polypgib.mdl": {
+     "bytes": 5716,
+     "sha256": "dc2aae40f92f8c75057a664b583f9d790d010289e858b218adfc92de6d6be878"
+    },
+    "progs/s_bubble.spr": {
+     "bytes": 396,
+     "sha256": "f7efaea9964c8ad347f170dcfd2a6dbe5bfcf8dc074cffc385cfbf28f991c13d"
+    },
+    "progs/s_light.spr": {
+     "bytes": 7344,
+     "sha256": "45ae7c364a43b76d834476f49fe6c35423330cce41d8f3dbc90780f561bb51e7"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/s_plas.spr": {
+     "bytes": 5256,
+     "sha256": "ed01b728b6656a68acffe258d644712eba3b786434ab6b3e6d90434031e90d96"
+    },
+    "progs/shockwave.mdl": {
+     "bytes": 167520,
+     "sha256": "861ee3b0ab6edd5233740a609c4367c5ebe4108ffb03124861bf85047a314f5e"
+    },
+    "progs/smlexp.spr": {
+     "bytes": 105148,
+     "sha256": "ce4938c9e813e648404b25b82245cad4400682d885d044b9d353a8039cfdceb7"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 565441,
+     "sha256": "9d3da38ea15726d8543413120414d4178efd900fd131a7fd84eff5a305df21f5"
+    },
+    "progs/spore.mdl": {
+     "bytes": 13469,
+     "sha256": "fc9fbb97f0d4f1a9f843769cd43fb7270ba2b351cdf3b4b624d27616980457c4"
+    },
+    "progs/trinity.mdl": {
+     "bytes": 13249,
+     "sha256": "3e0d4636dfd20112bd5415e92c1d8f85fdda65a9a33b09111cca2bbf4561f349"
+    },
+    "progs/v_bomb.mdl": {
+     "bytes": 80804,
+     "sha256": "48c2393efb079787f56be5ab6fd0dc3e748b5ef009ba15830fe0f9898ad94b7b"
+    },
+    "progs/v_ham.mdl": {
+     "bytes": 84563,
+     "sha256": "76f03b4e5d8222c2c3b3d2f0e1156ac90708a42f4997f6a4555c01073dab49dd"
+    },
+    "progs/v_lance.mdl": {
+     "bytes": 87209,
+     "sha256": "5c50ded5952ab06ca91ff413edf17a167b21bed88b027571e643ffc515a71560"
+    },
+    "progs/vermis.mdl": {
+     "bytes": 656752,
+     "sha256": "d7060475e290482c61c122b3a477085b1aad002fd71d8293cc4a4f8bde1baec9"
+    },
+    "progs/vleg.mdl": {
+     "bytes": 4904,
+     "sha256": "cc9ac24012d342ed54eb1a3241bcc6baf16e40fb95a904a789845ed76b8606ba"
+    },
+    "progs/voreling.mdl": {
+     "bytes": 41852,
+     "sha256": "b10f3623291b5182ab6b987cef1c40abc362aae41638b8481709660e923cc46b"
+    },
+    "sound/ambience/nightmare.wav": {
+     "bytes": 34284,
+     "sha256": "2caac27dfee5758eb293e0c76bf86baf82b0522c6f71281160e805c6ec282f96"
+    },
+    "sound/ambience/thrum.wav": {
+     "bytes": 220542,
+     "sha256": "c925d73ef744b0a8c56507ff6fb18888de7ab803ea1f743060f8f9782180dcc7"
+    },
+    "sound/bob/death.wav": {
+     "bytes": 14348,
+     "sha256": "7f97f27dfda78f9fe6fc5265e512b651e57ae466752d56cfe0dccd6d08478ed8"
+    },
+    "sound/bob/explode.wav": {
+     "bytes": 36898,
+     "sha256": "e00cd6cf71662de858fd0b8f63409217c957d6e3dea571b759fe97aec9d58724"
+    },
+    "sound/bob/fire.wav": {
+     "bytes": 36040,
+     "sha256": "5f39b9f60c5de5c9c3ac25a5149f1fef557e66c09d7d1a760ed6770082c5a914"
+    },
+    "sound/bob/hover.wav": {
+     "bytes": 13260,
+     "sha256": "46441335fe896cb993368bb12cedc1ddd4886b5933298bb6a0d6b7ba430cdfe5"
+    },
+    "sound/bob/idle1.wav": {
+     "bytes": 44460,
+     "sha256": "de548d73ab2d96ea9d550b86e264d430b8c0429cd99dd10404f52780bda6c683"
+    },
+    "sound/bob/pain.wav": {
+     "bytes": 27006,
+     "sha256": "d5d07123eb3c15917dc265cfa6df8971ab215f4408847225827359e1c175ee6b"
+    },
+    "sound/bob/s_explode.wav": {
+     "bytes": 30700,
+     "sha256": "94f9b780d25154f8c04cbe297a4aeda13fb0669c0a21e48e2b46f0102c35375e"
+    },
+    "sound/bob/sight.wav": {
+     "bytes": 14892,
+     "sha256": "1a0db2b8c8d763f9aae09913d1cd3548fa0e30eb03949e24ef511a70acfda303"
+    },
+    "sound/defender/blip.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/defender/breathe.wav": {
+     "bytes": 32676,
+     "sha256": "7b673b07828790504caca013c18bf697fd53b758a3638b949b433cf2d72f03f3"
+    },
+    "sound/defender/sight1.wav": {
+     "bytes": 18260,
+     "sha256": "7d57825c28cf4f93189261d76cccab676aeba097920114d5d3f48d7eddaaa1cd"
+    },
+    "sound/defender/sight2.wav": {
+     "bytes": 18248,
+     "sha256": "b8b54fffdc7e2bfea51172cb8147407576f799181c1e6c2402433a546d8ee1c2"
+    },
+    "sound/defender/sight3.wav": {
+     "bytes": 17064,
+     "sha256": "25b7fc4212184996a7027211c543018f1dff539d3f9355f82a8da498d52b7a33"
+    },
+    "sound/defender/sight4.wav": {
+     "bytes": 16714,
+     "sha256": "deee8172ce02140002369c9807c513421a312240221113d86244e36300866758"
+    },
+    "sound/defender/ssg.wav": {
+     "bytes": 38828,
+     "sha256": "5c4e3a9baeec3f714ed00f2585d04256ac33582db911a026fdc56dea7f0a7dfa"
+    },
+    "sound/dguard/death1.wav": {
+     "bytes": 30610,
+     "sha256": "af3809501261ec4d0afa6ea7301c11a5c7bbc1cc3e06b8c88172ee0214c30969"
+    },
+    "sound/dguard/death2.wav": {
+     "bytes": 43636,
+     "sha256": "93a70fc0d6fee819c723a435a3954b3fd3be86e358698ce85db1062990d1575e"
+    },
+    "sound/dguard/fire.wav": {
+     "bytes": 60820,
+     "sha256": "f5e5d4f6ccc0778c1396c66d327564a0b1892773f2c23d2e30590abf0c758bd2"
+    },
+    "sound/dguard/hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/dguard/idle.wav": {
+     "bytes": 20498,
+     "sha256": "45b2f208b9796d19d7aeb0cba64e4b0e5fd2ed7c980123f7c41ca10d17785021"
+    },
+    "sound/dguard/pain1.wav": {
+     "bytes": 10380,
+     "sha256": "9a367afb7cde241099c58c999e225ba939be39f21be818b16444f5a810049960"
+    },
+    "sound/dguard/pain2.wav": {
+     "bytes": 14892,
+     "sha256": "827a1e4d3c9983f61fffd61de33054274c144bddd9a68460b496fd6281cf9406"
+    },
+    "sound/dguard/sight1.wav": {
+     "bytes": 18124,
+     "sha256": "9cb3d960261d90ec16c9883f4326c905356b6ff4e99cdf48ab5913b098588016"
+    },
+    "sound/dguard/sight2.wav": {
+     "bytes": 18022,
+     "sha256": "35ee4b7ec6715c8c9fdc24f90ad0b5d90a0ae7a4986168cf40670e87c325d5db"
+    },
+    "sound/dguard/sight3.wav": {
+     "bytes": 19948,
+     "sha256": "c6818770267626dea27f4a72ce2249771f6968924022c2275a5a96abfa485044"
+    },
+    "sound/dguard/sight4.wav": {
+     "bytes": 20332,
+     "sha256": "7affcdbdc62f13e492a15b54fe642fe045641f5551f570cc3c8d5f7ee29521fd"
+    },
+    "sound/dguard/slash.wav": {
+     "bytes": 22942,
+     "sha256": "44b60d785ff03f033e183b6fbce69e526351187d28efdeb308f6f8bea930d450"
+    },
+    "sound/dguard/slhit.wav": {
+     "bytes": 31956,
+     "sha256": "0f07a131640f21337cd89a772588ecfc707d6a729f96b54c21920b809cd620e4"
+    },
+    "sound/dguard/slmiss1.wav": {
+     "bytes": 10458,
+     "sha256": "e32d5cb070a13fad979b021e84a727f71242305ade1af7bfe18c255f0f6dd548"
+    },
+    "sound/dguard/slmiss2.wav": {
+     "bytes": 13840,
+     "sha256": "f6b3aee08c25434d2fda7468cacf35a0912b182653a45991149b54a0fc4be537"
+    },
+    "sound/dlord/death.wav": {
+     "bytes": 32022,
+     "sha256": "0188f6a3dd88686e15311f8c39c4277078e55bc0ec75497e2eb534af717abcdb"
+    },
+    "sound/dlord/idle.wav": {
+     "bytes": 9906,
+     "sha256": "c0ee37f80013dad1aaeb285a11a33c4d7c2ff2de0b2a94c2943d3fbe1c241bcd"
+    },
+    "sound/dlord/pain.wav": {
+     "bytes": 8632,
+     "sha256": "230ed5c7d024bfa90b973649aa79d9e9327eaf401b1632e4a1334fb4a9eb075c"
+    },
+    "sound/dlord/sight.wav": {
+     "bytes": 28028,
+     "sha256": "d82aa0028754e826705961040e1ab27f007c572a28c63dbcaeefeb681bc3ca85"
+    },
+    "sound/doors/eldertry.wav": {
+     "bytes": 76358,
+     "sha256": "769f4e43083dfa153a2cfdfb11c09920757a407c871f82957dbc9120de140230"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/explode3.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/sight2.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 83982,
+     "sha256": "4b0d8db882ab1c9fc2109effeaf125ec46fb23a91ac2242201103e0d3da96944"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gug/bile.wav": {
+     "bytes": 54572,
+     "sha256": "e06787585ef0369798a938a1a9585d24b60aa7b5c65acda3a5fb6f2c7ab65aca"
+    },
+    "sound/gug/bileatk.wav": {
+     "bytes": 50040,
+     "sha256": "b4b05e2907789a78391ccfe8ced3902821f1097ecd1f894b12ba9278d31a8717"
+    },
+    "sound/gug/death.wav": {
+     "bytes": 132396,
+     "sha256": "20bf209a832381b77d37c54a84ab1819b6c71e2147c5d122ac62668c070167a5"
+    },
+    "sound/gug/gquake.wav": {
+     "bytes": 43350,
+     "sha256": "d232ae13b55cb5b10b8903db43c037a5c6c4cdfea1f84f9399133484df6e0175"
+    },
+    "sound/gug/idle.wav": {
+     "bytes": 50580,
+     "sha256": "ff33c63696dec5c582ff9a4537814299b47ce2480d6cc53c116721d793576fda"
+    },
+    "sound/gug/pain.wav": {
+     "bytes": 22064,
+     "sha256": "e559f2b372fe771207aeef4b1c3a71baca542863493776558ae3f933f3878c29"
+    },
+    "sound/gug/quakeatk.wav": {
+     "bytes": 65882,
+     "sha256": "2c07b7690356bd9233a79c1f8b5f4e146cbabc367a19c138d6719a1e0d09328e"
+    },
+    "sound/gug/sight.wav": {
+     "bytes": 76426,
+     "sha256": "210ed86a5d6f9d4e791954fc3a4e4b4b6dc5839d02f7c19d468493a2f87dca64"
+    },
+    "sound/gug/step1.wav": {
+     "bytes": 15494,
+     "sha256": "4e2ce285991bc0d4337c77fdbb029507697ecb4dbf6543ddefe976ea114c4214"
+    },
+    "sound/gug/step2.wav": {
+     "bytes": 15502,
+     "sha256": "27f6f770a52fce5ae04836706e63ef455555de086019a2f9e44d4da1fc99b03d"
+    },
+    "sound/gug/step3.wav": {
+     "bytes": 15502,
+     "sha256": "fcc7ab38a8ec28509d0aa062a3cb93aee6da6a0ae364e4fe0dfad791f54558af"
+    },
+    "sound/gug/step4.wav": {
+     "bytes": 15502,
+     "sha256": "fc52cad29cca2e1fc36f5c6ac7f955ed897d6da4fb5dcf4eefd052e0652d93e7"
+    },
+    "sound/gug/swipe.wav": {
+     "bytes": 16064,
+     "sha256": "90bb5831dfd19f65df19e97f76d858ec940d8e33e0a2ed8fad89a23947e430e5"
+    },
+    "sound/gug/throw.wav": {
+     "bytes": 23180,
+     "sha256": "5e901b94e7be364536603273f18791ab571c46c2fc74263774c0e312f873a281"
+    },
+    "sound/items2/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items2/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items2/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items2/trinend.wav": {
+     "bytes": 79450,
+     "sha256": "6edc4b653c671187012e5ad6a95f777a861ab18a1d27b69a10912b459dab2577"
+    },
+    "sound/items2/trintake.wav": {
+     "bytes": 73428,
+     "sha256": "b26c0f0af98016163bf1fc7c4376ca90dfa4ad447e31a04fff9d8c9d820cda86"
+    },
+    "sound/items2/trinuse.wav": {
+     "bytes": 16990,
+     "sha256": "ea0b2b20b8137da8388bab00812218a47049183a7d4eb031449b975289de4ed4"
+    },
+    "sound/misc/elderkey.wav": {
+     "bytes": 55212,
+     "sha256": "70af94f89ca397badfe01eadc36b1375f3d219ecd8c19f691a4a6cd257cf9e7b"
+    },
+    "sound/necros/dias.wav": {
+     "bytes": 412204,
+     "sha256": "2de75ccc9f971c3c56b87c145ac96cfc7d3e13a758c89081133389d13399606f"
+    },
+    "sound/necros/drivshft.wav": {
+     "bytes": 385808,
+     "sha256": "a84800586cff4027335aa94cc05e0f5a0d88ab2404cba7a5ccc40c3581ffb981"
+    },
+    "sound/necros/forebode.wav": {
+     "bytes": 97960,
+     "sha256": "5dc4a7a6c7c2444595c0a7511ec8e1d5913211591202cd9a0e478588e1939c0e"
+    },
+    "sound/necros/gen.wav": {
+     "bytes": 136482,
+     "sha256": "f0d4932c1bc41d8701dee215fe04ec5f8667ac1de980d9d6158eef7f9e3e7fe0"
+    },
+    "sound/necros/gen_fire.wav": {
+     "bytes": 182316,
+     "sha256": "da244c2acc4a6b496330f1b7202a3f3d68ff61bc0e7e1c0a66a4208fdb66e9db"
+    },
+    "sound/necros/highwind.wav": {
+     "bytes": 158882,
+     "sha256": "41decf2ffe971f07420ab67deb227a285246d92eb01f77284920f01cc3652284"
+    },
+    "sound/necros/irulan.wav": {
+     "bytes": 196396,
+     "sha256": "52fc652f8b7814d4d28252f421e7ecebad629dd4c613e73adc643d67dabab3d5"
+    },
+    "sound/necros/sgatehum.wav": {
+     "bytes": 128670,
+     "sha256": "1a06f2e664cf213248990ee27ec117a46a4ba6ea6067b114c896cc9500f4fa99"
+    },
+    "sound/necros/strongwind.wav": {
+     "bytes": 133538,
+     "sha256": "fbc3ce4f537ebaf9603c6c4de350f06b2373f420e5c47a300668942ecd1a9064"
+    },
+    "sound/necros/tld_stop.wav": {
+     "bytes": 72304,
+     "sha256": "b58180629cb28e31b5fa0e00fc74c2c75841dbdcb778674509877d40abdf51df"
+    },
+    "sound/necros/tld_strt.wav": {
+     "bytes": 101584,
+     "sha256": "66ae791b7a06a8aa233d59bafb63d7b4ecb71be8b6ffc50c6794ea71807fbefa"
+    },
+    "sound/necros/tshaft.wav": {
+     "bytes": 221356,
+     "sha256": "95690f3dca8be51dcf789f5cb8977f37c20257b9b7bc84a4c57caa3aba0316a7"
+    },
+    "sound/necros/wat_amb.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/necros/water6.wav": {
+     "bytes": 45870,
+     "sha256": "d7505b517d6573f661739d765222c33d9ac1a86da362328d5635fc8634c9d823"
+    },
+    "sound/necros/woodmve.wav": {
+     "bytes": 70716,
+     "sha256": "bc27833a4d5b60b2212311cfefa7e8e04333e7a0c1efec939048a050bef4ab15"
+    },
+    "sound/necros/woodstp.wav": {
+     "bytes": 58554,
+     "sha256": "a86696cbcc070443f939497ba76c1e2c101bea2534dcc0993523031c6f500a2e"
+    },
+    "sound/polyp/blast.wav": {
+     "bytes": 25036,
+     "sha256": "0c3942daeedfa438ba36bd31481f7b24b067cab3d167c9e5cfd1cf3c498bf367"
+    },
+    "sound/polyp/cloak.wav": {
+     "bytes": 46252,
+     "sha256": "31cb79048b0c511ad0d40989785d835584c4c808025b8eb8060a74b36c9bca39"
+    },
+    "sound/polyp/decloak.wav": {
+     "bytes": 91152,
+     "sha256": "e2ee4693b0e466c5bc229db186257254c381c6a6985e71b02b20838859bcb5ae"
+    },
+    "sound/polyp/gibsplt1.wav": {
+     "bytes": 19580,
+     "sha256": "e9b7b73242aa04fdb6aed5de1c343ced81b15d6f78dde07097826b78bb1f87a0"
+    },
+    "sound/polyp/idle.wav": {
+     "bytes": 17750,
+     "sha256": "4edd47fe2508cb818ce36916a16c6e4c7cea4f61ff0310b7195e74bccc4f5d2b"
+    },
+    "sound/polyp/idle2.wav": {
+     "bytes": 22210,
+     "sha256": "b07894dd93545ed0c54fabae04f139c371a8b36ab84fc399f870f813b535000c"
+    },
+    "sound/polyp/sight.wav": {
+     "bytes": 11664,
+     "sha256": "a9c414ba4ca74fa3e08018af695674ede79a2f63aab26be0566dda9426eaef43"
+    },
+    "sound/soldier/load.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/soldier/rocket.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/vermis/death.wav": {
+     "bytes": 148016,
+     "sha256": "44b26a9dca5ec8d5e8a7ef2b5e38196b74e4f606cd37b906ee2b2e5b5a85b08f"
+    },
+    "sound/vermis/grab.wav": {
+     "bytes": 88122,
+     "sha256": "09528bd0d49d5cac0c03fe7994b57e572eb89aa8bce63cd0a591130e4b2126ae"
+    },
+    "sound/vermis/grabbed.wav": {
+     "bytes": 51630,
+     "sha256": "99583c88b8ec2959a0d69448aee16ec86b3d9feee6df7841fc32759598349376"
+    },
+    "sound/vermis/grndhit.wav": {
+     "bytes": 36428,
+     "sha256": "1f0e78fa08efb4617b6967a6cc218c56af227c7fd6bf039420d8f106d74fca72"
+    },
+    "sound/vermis/pop.wav": {
+     "bytes": 131420,
+     "sha256": "6284ab02e604b44c5b07225b2a0544c8707517d5fec0024c127bdafef2704f70"
+    },
+    "sound/vermis/sight.wav": {
+     "bytes": 137772,
+     "sha256": "d892117e4602595b6dfb65563b8fa7a3ad2171851791f7c6f47ea4bfece76296"
+    },
+    "sound/vermis/sight2.wav": {
+     "bytes": 106780,
+     "sha256": "6132e2d0db5cfb7a1a064e708d97f7258e2c6ac15c6f4ea8d520641e0ad10f9d"
+    },
+    "sound/vermis/splash1.wav": {
+     "bytes": 30710,
+     "sha256": "f931a2927c13cdb2523dde4550c0af993cc08cbea6e332739f9cf6fe3bd1ff8b"
+    },
+    "sound/vermis/splash2.wav": {
+     "bytes": 25332,
+     "sha256": "b91c69ee695bd71537ed018800f7d89e5e7d95332124f69adee39261d84d7c13"
+    },
+    "sound/vermis/splash3.wav": {
+     "bytes": 25590,
+     "sha256": "99fad2f3815a30ef645a2162ea24e54b4302ba00d7551af9299fde74ecce98e8"
+    },
+    "sound/vermis/spore.wav": {
+     "bytes": 44204,
+     "sha256": "d01a27af99745725dae124d30af18458b2ef323bce93c3cad939310e0f47f6c7"
+    },
+    "sound/voreling/bite.wav": {
+     "bytes": 8920,
+     "sha256": "a5bbebd7178205c400115846314709fa22c4db390fafbf3abaee2e33342e1a0c"
+    },
+    "sound/voreling/bitestrt.wav": {
+     "bytes": 11132,
+     "sha256": "be72b6a15a73bda266331309046229fd6f94b0856f4dfc306204e6266ad1cb59"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 19584,
+     "sha256": "e5bc7634816b927c305679e9b0ff3e4f33a2d09cb5e80db3c5dd04373ba452e5"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28378,
+     "sha256": "b9daf80e6bc998d521cd35f6d8ef74295f39fafbb71f6d6cfe8f0e7c1fb3f0ba"
+    },
+    "sound/voreling/land.wav": {
+     "bytes": 6154,
+     "sha256": "92f08d203711dbd3bc2049ba61a62938b4eb34a9c7285c26406da3b29bbdfba2"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "0b6c021bc7301757918201ad1175387eabfc0af4f6e8b94e273ba22a2aa6c53c"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 55972,
+     "sha256": "9aaaebf47f82cd7a521800aa9d81d14bd2747735481cb15b88ce104cf1568b6f"
+    },
+    "sound/weapons/bomb.wav": {
+     "bytes": 141228,
+     "sha256": "6fa171d6bbb3dc07f9c0fb422ceb2e3e20934e9a0465589717dfdc14c92b016c"
+    },
+    "sound/weapons/bombfar.wav": {
+     "bytes": 246316,
+     "sha256": "12334d1af40522f124564f354acf44f419d1e1477cdef97d0f790ab52a38d765"
+    },
+    "sound/weapons/dryfire.wav": {
+     "bytes": 47872,
+     "sha256": "d119284b7e97ab626587b20349eb5c2a90489b37df85a1fec52c98962185da06"
+    },
+    "sound/weapons/expl1.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/hamhit.wav": {
+     "bytes": 2434,
+     "sha256": "7754c2ab32c5d34473e4fe4977f9aa1b326a622431b44b599c798c7a0fbe2b60"
+    },
+    "sound/weapons/lancfire.wav": {
+     "bytes": 6520,
+     "sha256": "be8d154ba1404462776ec3f5fbbda0e974970dd5d61d97cf296c3711ede5bb84"
+    },
+    "sound/weapons/plasexpl.wav": {
+     "bytes": 54406,
+     "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 164,
+     "sha256": "ba0d9dbe33691183ef2549fdd006a02e21ac209f1d51271018e9bf565793c1cf"
+    },
+    "textures/+0bfall.tga": {
+     "bytes": 24594,
+     "sha256": "e16452c0adf12a064b2c78dfc9c10965fde399cac99076f29486bd434865d20f"
+    },
+    "textures/+0wall58.tga": {
+     "bytes": 24594,
+     "sha256": "dc10523848dd691e477cb7dc3c8f8926bcaff43df0bc8aca5b4814ec9e416ca0"
+    },
+    "textures/+1bfall.tga": {
+     "bytes": 24594,
+     "sha256": "f0ccb330e0668af52906c3bb8ca56513e49ec4b7d3a10a1af8fa1e552c12aa9e"
+    },
+    "textures/+1wall58.tga": {
+     "bytes": 24594,
+     "sha256": "6a3071293d6c5833f71dd9dc6400a8971a42fa08d975139286412863a2afa15c"
+    },
+    "textures/+2bfall.tga": {
+     "bytes": 24594,
+     "sha256": "5a4839cf5a9bfaa3e0eaf6419502aa9b68941a76a82aaffcbb42ccc16b7251ad"
+    },
+    "textures/+2wall58.tga": {
+     "bytes": 24594,
+     "sha256": "2e21abc263631a86253f1c7c3d85b1e1706656a8ee2a4946c083d4da188e6c98"
+    },
+    "textures/+3bfall.tga": {
+     "bytes": 24594,
+     "sha256": "0cd9f7f04e1d94c5aeac21a22be9b085364b76f80255d2111f080d25b9571272"
+    },
+    "textures/dem1_5.tga": {
+     "bytes": 12306,
+     "sha256": "3c7981d83daaf54eac8c7fc3eb917f3b37206f04f7217c5f61c72ddcfa4e4e7c"
+    },
+    "textures/dem1_6.tga": {
+     "bytes": 12306,
+     "sha256": "c605259684bfcdda9c7439aeb1625b753b39ec326b199b79708aeed4e94192c6"
+    },
+    "textures/door11_1.tga": {
+     "bytes": 49170,
+     "sha256": "e41bbe8d0b3c06e3e63335e54e76a9ff46f746d97521d423d26e843e1c73339e"
+    },
+    "textures/mwall1_1.tga": {
+     "bytes": 49170,
+     "sha256": "74618ddeed744fa78d55d52332bba75e3e8e4bb10801968c4e7fa434a3145424"
+    },
+    "textures/mwall1_2.tga": {
+     "bytes": 49170,
+     "sha256": "ef9f0957aab307dfd959a2fbdfba0746590bf72543e3e9c267e82825a4153df9"
+    },
+    "textures/mwall2_1.tga": {
+     "bytes": 49170,
+     "sha256": "8aaff86f44b797ac6744f13e99935f89ae7220f47ad640a376c0f65e0c2a0ac9"
+    },
+    "textures/mwall2_1_red.tga": {
+     "bytes": 49196,
+     "sha256": "9e8e232605d1e957cc37436c1bf6fe16c733aed297e2b2f821cc98d1f03d2611"
+    },
+    "textures/mwall2_1_red_tr.tga": {
+     "bytes": 12332,
+     "sha256": "95fe8beaead00d82042e00c633772c98512448b8ede744f8dd19e6d073e8ac2f"
+    },
+    "textures/mwall3_1.tga": {
+     "bytes": 49170,
+     "sha256": "7177eaddb4df53978e97d461bdb3691bf5cfa85f37518975577702f2e1018aad"
+    },
+    "textures/mwall3_1_red.tga": {
+     "bytes": 49196,
+     "sha256": "4382c35808a81d43b349482e135f7362748a059e7f0d12c564c9907e10c634ba"
+    },
+    "textures/mwall4_1.tga": {
+     "bytes": 49170,
+     "sha256": "e9692306843a29a826fe2d680cd120f6f2503cce23c8e2dac9709459e892268f"
+    },
+    "textures/mwall4_2.tga": {
+     "bytes": 49170,
+     "sha256": "60a8569f93461c4180be984e37adfe2ca24f3d04daab19d492953dcbc16f8055"
+    },
+    "textures/mwall5_1.tga": {
+     "bytes": 49170,
+     "sha256": "fb7d723160581302ff0dd079e93d8a8dc54b2a6304a1fecdc77934b19b1e15ef"
+    },
+    "textures/rw15_1.tga": {
+     "bytes": 24594,
+     "sha256": "d1becff2637e213ef94cef4134429ae3cdeb821f3e84aab230dbacb94c6518c2"
+    },
+    "textures/rw15_2.tga": {
+     "bytes": 24594,
+     "sha256": "91ab56c9f1621de1c386fabdb6aac1814ab0154d88452fee0c4a1bab89d653bf"
+    },
+    "textures/rw15_3.tga": {
+     "bytes": 24594,
+     "sha256": "abe1fda7a20c0aea206ad57beaf736829e2024509b2e8cc8164a9b23177a623e"
+    },
+    "textures/rw15_4.tga": {
+     "bytes": 24594,
+     "sha256": "745948c0cd48e6e01068a0f1305481c1c806e3e838ae22c3d142bf0e91c0943d"
+    },
+    "textures/rw21_1.tga": {
+     "bytes": 12306,
+     "sha256": "935b7aacfa98763e85ed7d6775a742815ec6112aede7a5ff148d90b52a6dcfa9"
+    },
+    "textures/rw21_2.tga": {
+     "bytes": 6162,
+     "sha256": "42fb2832ac2eec8cd73a3444cb75c0021581e899b02e94ea333c98fb112c9829"
+    },
+    "textures/rw21_3.tga": {
+     "bytes": 24594,
+     "sha256": "4f8537864f72db12061ce70d9baab17c98031e781e058e4adf38e0ac34a21ea8"
+    },
+    "textures/rw21_4.tga": {
+     "bytes": 24594,
+     "sha256": "fc2677db2925f405ea9225d4c6d8e5c0e2f5e713f9074deaa78a8d491aa6f1bc"
+    },
+    "textures/rw21_5.tga": {
+     "bytes": 24594,
+     "sha256": "a7527f4ad249827052c1ca3415a36c5a965975cae2d6aff799236e7eb5a59cbf"
+    },
+    "textures/rw26_1.tga": {
+     "bytes": 24594,
+     "sha256": "ba91b31bb38fe81f0ef7e08f32b6d7ee27f4ef2d54909bed9c7302d823198864"
+    },
+    "textures/rw26_2.tga": {
+     "bytes": 24594,
+     "sha256": "686fd937365107bc99daaf6c8d419cee027ffa9da50eb70b5e10cb8cc5398dea"
+    },
+    "textures/rw26_3.tga": {
+     "bytes": 24594,
+     "sha256": "ca4cb9d2d9637f9f676aeb9178a2b4f8a8c084bd1678d9787a88a159e7513f93"
+    },
+    "textures/rw26_4.tga": {
+     "bytes": 24594,
+     "sha256": "735df64fc6e627139b4f76228e49831c051948cc7c0a734924680d3472087f16"
+    },
+    "textures/rw7_2.tga": {
+     "bytes": 24594,
+     "sha256": "caba2d8cf9ef2d9c90c0aae3b43b2ec2f86d1c14bc085ef5e78a63edbc437c2c"
+    },
+    "textures/rw7_3.tga": {
+     "bytes": 24594,
+     "sha256": "b0daa16c1e9a25055618e3692a5fe0fc766e3d66b0a8ab19022744112bf4a340"
+    },
+    "textures/w105_1.tga": {
+     "bytes": 49170,
+     "sha256": "2830a744ca1a7c6ce8ad63675d71ec545e87c7ed5c18a3f8a9af4defedb4dffa"
+    },
+    "textures/wall30_2.tga": {
+     "bytes": 24594,
+     "sha256": "d14e42b6469b059bf66c766ccca4a1ad11140d48ea35068f58ec0ffd46384950"
+    },
+    "textures/wall30_2_red.tga": {
+     "bytes": 24620,
+     "sha256": "49c5e077694909aceff34f9e192b7e7d3c9d3ff18e3018d4b03e60970d366d60"
+    },
+    "textures/wall30_3.tga": {
+     "bytes": 24594,
+     "sha256": "04a5bfd1dbf4254e63e3a2ca206bff20deccfe4902195a4037cc1c340a5e5ea0"
+    },
+    "textures/wall30_3_red.tga": {
+     "bytes": 24620,
+     "sha256": "146f5aa381d2649d9f7104c749642e400e5b3912ce568eb48bd966e58817bdd6"
+    },
+    "textures/wall30_4.tga": {
+     "bytes": 24594,
+     "sha256": "e6d90bebd4adb579791a718b9190a4a6603c82f0b41db1658c1fccb3ebd9dc8b"
+    },
+    "textures/wall30_4_red.tga": {
+     "bytes": 24620,
+     "sha256": "f4afc3527f258ea27cadb656314716bca6d3d16286539694572dea795be361ba"
+    },
+    "textures/wall48_1.tga": {
+     "bytes": 98322,
+     "sha256": "bcae8399e797e1c6413de7c7bde9435cee13d77f100e948444153201232083e9"
+    },
+    "textures/wall48_1_red.tga": {
+     "bytes": 98348,
+     "sha256": "73f1c4781c0c7c639d6779138060e394e525ace2e61e7fa84f5611beabef11a3"
+    },
+    "textures/wall48_vine.tga": {
+     "bytes": 98348,
+     "sha256": "d7de6acf61f49c1cfbe5d59436835b67cd5d1250e8b667b80b08d87a84e5381a"
+    },
+    "textures/wall59_1.tga": {
+     "bytes": 98322,
+     "sha256": "a3f2bf922132dd358fdbb2a6d501bff14ad38c7a762ffd9068048ceba6d1dfeb"
+    },
+    "textures/wrcka1x.tga": {
+     "bytes": 196652,
+     "sha256": "c78a5aea451c6915b26f7e3327581c270a65420bf23ce8b8c3dbd9bc9d664318"
+    },
+    "vongug.dem": {
+     "bytes": 1079956,
+     "sha256": "5228133bc5b5e3e0a11747b93eb0f5bca355e65be0b60527304a54cdc32d9e2a"
+    }
+   },
    "sha256": "ddace91ad8a3e3d436c95efea430f5dbd8a319f511a6f7d2d05ac6fffc68ffe6",
    "timestamp": "2008-02-06T19:38:38.000Z"
   },
   "pak1.pak": {
    "bytes": 84961704,
+   "files": {
+    "coop2.dem": {
+     "bytes": 1974743,
+     "sha256": "45c35c4ccf3eb06cd98d33e7aa17003b2f242c8271034036b0d4d3d41bf5cdff"
+    },
+    "gfx.wad": {
+     "bytes": 128932,
+     "sha256": "b9b298830f1c48cdc378d83b84e3b308f0ca3052c278d6b4afeb70fa4035ab7d"
+    },
+    "gfx/env/dawnbk.tga": {
+     "bytes": 791801,
+     "sha256": "3a415bd258f1d81bfddc5091dd67829e7b9c2d247c7d69ea263a6e743e3971e5"
+    },
+    "gfx/env/dawndn.tga": {
+     "bytes": 1032293,
+     "sha256": "33c9b1bc0ae74eeae43a90f44397cb3d2747ec40190f5b0bf28ce62d0943cf98"
+    },
+    "gfx/env/dawnft.tga": {
+     "bytes": 1206497,
+     "sha256": "1947bb641b84fd09cd9b0c17256f809fc13c81eca40520576d1ea3e2c57ea9b4"
+    },
+    "gfx/env/dawnlf.tga": {
+     "bytes": 1141280,
+     "sha256": "cc68776448bb864875e8e4ea181f6aa83800fa00ad15fca9f9ae3ac24b35d320"
+    },
+    "gfx/env/dawnrt.tga": {
+     "bytes": 1031739,
+     "sha256": "24be76b64c71f5a589f219ceccad23a68fc4e26f45a2a8a4183792bdbe7fc71f"
+    },
+    "gfx/env/dawnup.tga": {
+     "bytes": 1426811,
+     "sha256": "e4f5dabd8690dc8460d0032fba1d633d69222a242749803e960643d3cdd25454"
+    },
+    "gfx/env/daybk.tga": {
+     "bytes": 1885848,
+     "sha256": "81598177219150a0700e3ba1847157bbf1c7995d001989f64b6aa9a43f30559e"
+    },
+    "gfx/env/daydn.tga": {
+     "bytes": 1009895,
+     "sha256": "7bce7500395ecda3e1d82d30f7da1a5a7deeb78ccdd11cfd72a4e08114d2c0e9"
+    },
+    "gfx/env/dayft.tga": {
+     "bytes": 1997325,
+     "sha256": "40c45bca3df588c07cb5bad2783e4a4d2eddafb82d2a508993d8a0ef9374bd4d"
+    },
+    "gfx/env/daylf.tga": {
+     "bytes": 1914168,
+     "sha256": "f860f4796a517fb3280223cdbf4599bb77e681b27bd721d6fb50a98aafbaf19e"
+    },
+    "gfx/env/dayrt.tga": {
+     "bytes": 2080059,
+     "sha256": "dda11898b40d60a21e09d08bc31a785a02abe5a848da2b87d528d2b434c5a031"
+    },
+    "gfx/env/dayup.tga": {
+     "bytes": 1246252,
+     "sha256": "aedf3ba21436941882432c44cb791a4fc941409f229b256725d5c1c1b625329e"
+    },
+    "gfx/env/duskbk.tga": {
+     "bytes": 1364708,
+     "sha256": "2372a2a60805d3ef0d727edbe5b203d082b4b608c417e671b2ee39d40178bcbf"
+    },
+    "gfx/env/duskdn.tga": {
+     "bytes": 1310868,
+     "sha256": "1e96211accd4c0cc40c6ba54c22d1f1fee27433598f4cf74b7a242eed4dfcf06"
+    },
+    "gfx/env/duskft.tga": {
+     "bytes": 1367663,
+     "sha256": "9c7331e1f7ef1959776af623594fc2186b15362b300a67f8eb1e0fda4f4188a8"
+    },
+    "gfx/env/dusklf.tga": {
+     "bytes": 1426730,
+     "sha256": "65819e48a62862cdea4bce2f5dab063c8cc3b8ab2dd44d90e4f7fe329fbe55c7"
+    },
+    "gfx/env/duskrt.tga": {
+     "bytes": 1400147,
+     "sha256": "ec17749d0c623b05142fb4cadff8b29950ca8fb92a8e6ab02576a7d8a8be3077"
+    },
+    "gfx/env/duskup.tga": {
+     "bytes": 1327551,
+     "sha256": "2a40691f8439cd706cffe9b3d777dfb272a5c7306ab02912af0d19b151dda815"
+    },
+    "gfx/env/epiphanybk.tga": {
+     "bytes": 2336400,
+     "sha256": "520320d2d4bd655138753f1d036494129761ad93cfcca0b1e5a814d30c2828e7"
+    },
+    "gfx/env/epiphanydn.tga": {
+     "bytes": 2299843,
+     "sha256": "f95ab44b70525f6fc83737ab572de3a17308ac47ca28bb0bc938e7854659141c"
+    },
+    "gfx/env/epiphanyft.tga": {
+     "bytes": 2612108,
+     "sha256": "99aae0dea453bf26bd1622ef5136558833605054d38eb359dcaf451bb99d938d"
+    },
+    "gfx/env/epiphanylf.tga": {
+     "bytes": 2377534,
+     "sha256": "b44b482a9b308f8d6b7f12c2b359242ce22ec3a9d398dcd9afb446adb2f2703e"
+    },
+    "gfx/env/epiphanyrt.tga": {
+     "bytes": 2490366,
+     "sha256": "5b07aa824bb0c583c65576edef3f76a2bceb78bf4754d24e3ae349ce937eadcf"
+    },
+    "gfx/env/epiphanyup.tga": {
+     "bytes": 2350734,
+     "sha256": "08b91d998c2fe5279960c5d6c83c3bc79fa7600a10e6a8dd2a5fd678e5a34c8c"
+    },
+    "gfx/env/fodrianbk.tga": {
+     "bytes": 1218431,
+     "sha256": "3d8a751a50330bff69af3a63d772485bfc4e9ef9640076d98d4ddb5943201695"
+    },
+    "gfx/env/fodriandn.tga": {
+     "bytes": 752376,
+     "sha256": "58e65c036e28b02d9149f180919c9676343627e5f76ad87a2a27c8d3e114a34a"
+    },
+    "gfx/env/fodrianft.tga": {
+     "bytes": 996781,
+     "sha256": "699b065c4840785136c4cb969fda73e6b2ad9bc0f5f0c384f8076baf4196e5b2"
+    },
+    "gfx/env/fodrianlf.tga": {
+     "bytes": 1052142,
+     "sha256": "a5794f3e893c615505d5ddeffd48f25246a34341167670c304273bf812a35056"
+    },
+    "gfx/env/fodrianrt.tga": {
+     "bytes": 1011425,
+     "sha256": "c8cdb878f4d8ae894dd2531030132b92306a54cf7e7fab047e616cc8a0c3f063"
+    },
+    "gfx/env/fodrianup.tga": {
+     "bytes": 783041,
+     "sha256": "03e6c3eb578d533c5b46c8fd7bdb67a9e3d0cd1d6eb241b26feb353d4e1e6a23"
+    },
+    "gfx/env/graynightbk.tga": {
+     "bytes": 1771903,
+     "sha256": "d1173e9781c585cbf525374abcd1067cfd498c9dadb1d7d4febe69b890b9fa0b"
+    },
+    "gfx/env/graynightdn.tga": {
+     "bytes": 1901023,
+     "sha256": "fd464ebaa459ae2722860ad39fb613d44ac35f0afd914d52b5a9a4817fb81dce"
+    },
+    "gfx/env/graynightft.tga": {
+     "bytes": 1800892,
+     "sha256": "69b4ebc470c36ae1f0cb41824f981911503d2932bc0ee82f730254bfe59cc140"
+    },
+    "gfx/env/graynightlf.tga": {
+     "bytes": 1769279,
+     "sha256": "e988f1f6169479ce3515c046cc989e96fc5182d41faaa4c3af3ea9065a581557"
+    },
+    "gfx/env/graynightrt.tga": {
+     "bytes": 1788173,
+     "sha256": "1a969121d5e25cf04cd8bc059838ef74ba83f448d0e97aee22dba574bb802a8d"
+    },
+    "gfx/env/graynightup.tga": {
+     "bytes": 1660412,
+     "sha256": "2b282f7996ee8bc97d2140ead34ee6b5a62922c8b5ea30e147ffceb8a2b29e49"
+    },
+    "gfx/env/predatorbk.tga": {
+     "bytes": 1048179,
+     "sha256": "89021e04d172d32461f2eaff8aac30c750a9bac5bd165bb39b9b6210b374a3f0"
+    },
+    "gfx/env/predatordn.tga": {
+     "bytes": 1062175,
+     "sha256": "fb8b1483d01cb885165f3fe9468b568c278dbec2b07d2ad81c0574f5756336eb"
+    },
+    "gfx/env/predatorft.tga": {
+     "bytes": 953806,
+     "sha256": "09a5bcf66a64056b18d447a2799d090e8b4d1c5c6e54e1d6e6b6f5ea9f5f303a"
+    },
+    "gfx/env/predatorlf.tga": {
+     "bytes": 1007515,
+     "sha256": "3c5b93eabc11e727f24365ab0102b954d7a5f1eec8998776573fade8be49fa23"
+    },
+    "gfx/env/predatorrt.tga": {
+     "bytes": 1090878,
+     "sha256": "22ce280760e9330ca9c4a6c85994c0c98b7c83e7182562715032635d2956167e"
+    },
+    "gfx/env/predatorup.tga": {
+     "bytes": 1307351,
+     "sha256": "3ef7374f2b8a6ef6098f9ed07f85325b495917c1adb699df503b25a3fa5ebe0f"
+    },
+    "gfx/env/starsbk.tga": {
+     "bytes": 532751,
+     "sha256": "e74499e2d2fca2e86a1c1fa29a49a0074ee68bb02d6a4ad14a722087de83ffba"
+    },
+    "gfx/env/starsdn.tga": {
+     "bytes": 516841,
+     "sha256": "6e922014e7e2a7382c3b2c7c89af2b2a134722ab5838108efe881e9752a5a8cb"
+    },
+    "gfx/env/starsft.tga": {
+     "bytes": 545250,
+     "sha256": "b9d0a03dc6728f92db7572170a0f2bd49fe0d2e375578750ebca88f48d68262e"
+    },
+    "gfx/env/starslf.tga": {
+     "bytes": 540900,
+     "sha256": "e6aa8b634f0335fef501864ed21b24c1a7949c353eed10adca493bd7eb808ba8"
+    },
+    "gfx/env/starsrt.tga": {
+     "bytes": 528742,
+     "sha256": "e6ff0c6f8228e0890a722fb25457e7248729e407336f225bb6ff6d9f2aadd218"
+    },
+    "gfx/env/starsup.tga": {
+     "bytes": 540621,
+     "sha256": "629e2b1d4d8eb74014652b6e5e7c9fcebfe60b68d97fb6c25bb57c980e4436b9"
+    },
+    "maps/breakable.bsp": {
+     "bytes": 1924412,
+     "sha256": "1b7c46e6581380db7416e943ee4c31763de08159bc08aa1e1ccc0fb2eaf8f810"
+    },
+    "maps/e1m2quoth.bsp": {
+     "bytes": 4255536,
+     "sha256": "3d3cfa7ceceb18ca198270aa9df8da45988d1dd583759a5e41d5c3c0a691832a"
+    },
+    "maps/kellbase1.bsp": {
+     "bytes": 2346024,
+     "sha256": "8b84da3a5946a7b37dec18e5c6b3eaea4d536789ce9ec691c326ca365b95f86c"
+    },
+    "maps/kellbase1_fan.bsp": {
+     "bytes": 15508,
+     "sha256": "e018283c4f7ae64147a13f64ddced6e0f4f597492d677fa4e9758455d0ed6520"
+    },
+    "maps/kelltest5.bsp": {
+     "bytes": 539264,
+     "sha256": "4b9f25060b13bbbbe623e2b53c7cb5d0397e2362ac4dabf10486e676baafed1a"
+    },
+    "progs.dat": {
+     "bytes": 761082,
+     "sha256": "028ee957df11e12c26c6bb8bcf2f58e4b099a59797b78beebbce65a4f41d4cc6"
+    },
+    "progs/b_bio_l.bsp": {
+     "bytes": 11572,
+     "sha256": "e076780538e320d1a5ffcac210668e95edf63fce95edba192acdbbf0f634649a"
+    },
+    "progs/b_bio_s.bsp": {
+     "bytes": 6028,
+     "sha256": "1609a5f827eef414efe184ef62e8a7a7191208bef9e1593bd67724f19948b84d"
+    },
+    "progs/b_plas_l.bsp": {
+     "bytes": 11572,
+     "sha256": "5ab7b0e25b37c65ea87743bcbfdb482f5556d0595bae15eecb95ab8f1c8c2edf"
+    },
+    "progs/b_plas_s.bsp": {
+     "bytes": 6028,
+     "sha256": "58adae5e3ec3f32d65abbf74fb7fdad9bf19d6f33f2a4f2fe621b46867261322"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 331328,
+     "sha256": "046d34a681439138dca323f54e54d358e225d2d958b21b36ee564fe6d4be7b82"
+    },
+    "progs/brick.mdl": {
+     "bytes": 108308,
+     "sha256": "b566efdd77a56bc38866eb95d167b2e53b8453d4194dd641efe6a15a6d22a6ad"
+    },
+    "progs/c_ham.mdl": {
+     "bytes": 78908,
+     "sha256": "3ef97f78252e0c2aec063649102aad9765eb320fe172c24db29d8c08fac5951c"
+    },
+    "progs/c_lance.mdl": {
+     "bytes": 48404,
+     "sha256": "03d923d70944814497b47312137221bec8ed46c2e8f6681ebac07dfb5b5517c7"
+    },
+    "progs/c_light.mdl": {
+     "bytes": 63500,
+     "sha256": "d0c16e23a406b1833408e216e34759a5060b202e603889ac8c39cac92d6d9434"
+    },
+    "progs/c_nail.mdl": {
+     "bytes": 63324,
+     "sha256": "b98d0281f8958d5b7a50e795711cb9e7b04d73e417dfae13f64f17d1ffc52228"
+    },
+    "progs/c_nail2.mdl": {
+     "bytes": 79328,
+     "sha256": "088e8d8994344e46918df796a38e87d0dbe2ba0baf1ad9359e072ee538902551"
+    },
+    "progs/c_rock.mdl": {
+     "bytes": 67924,
+     "sha256": "c0d3b99d6edde1329011a6754f65caa55888421c94669cee26beda3c1525bb63"
+    },
+    "progs/c_rock2.mdl": {
+     "bytes": 65932,
+     "sha256": "6fa52810c7164815d909085f80d27e3cf60f2a9dc48547c877947ebfc045fd4e"
+    },
+    "progs/c_shot2.mdl": {
+     "bytes": 58572,
+     "sha256": "381c796447399a343a4dff310ba58942eb45168708ef3899a2043ceaefc86c14"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/flame_pyre.mdl": {
+     "bytes": 85180,
+     "sha256": "9df2ae13e72ffe5a305a6ce877b0284023520d5d34df751498a2003c3e420ebc"
+    },
+    "progs/flashlight.mdl": {
+     "bytes": 35596,
+     "sha256": "8442b889437acf210587a7d567ad71c839b978e7dcf27a580503a05983368c70"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41908,
+     "sha256": "52eeb2cb3923bccdf6960abbea3f39cee9c8e504c984c5ccaa7e218627fdb882"
+    },
+    "progs/glass.mdl": {
+     "bytes": 127788,
+     "sha256": "f1e6a01f984e742bfd4d6428878e356e736251b7d18ac65e84aae63fa807fc69"
+    },
+    "progs/greenexp.spr": {
+     "bytes": 24732,
+     "sha256": "52b354786534248048d517a16fea53ad54c39ff7c82185c45067daba31dbb522"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/grill128.spr": {
+     "bytes": 492156,
+     "sha256": "c1ffd3a6680099e228605480d83bc5929ecd5730c01d24cfbcff3f195b509b51"
+    },
+    "progs/grill64.spr": {
+     "bytes": 123516,
+     "sha256": "c8d559303231ce4a7a1c246bea0a24c322d249f3b1cea61114fc0816a73cc781"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 43931,
+     "sha256": "f87f4d5b690c6ca434e5ff904d02f33cae0ac9e44bac4350b9631f47e29f6287"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 28501,
+     "sha256": "24f0d69fa8e5aa9cf70fd2653dab9bbd59fff7985b895234f8b07d1a4546998a"
+    },
+    "progs/lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/medexp.spr": {
+     "bytes": 72892,
+     "sha256": "d9887be2c9837d713d3aef856c1fc9245a4628b76ecd9e4e50a28d0deee1a679"
+    },
+    "progs/metal.mdl": {
+     "bytes": 246933,
+     "sha256": "07c0bb9ff1aa1639a62e5a84fca28d48c0fc738f4d22f8e3d8a5a029790d870e"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "e0bd8b2d3da7f2d8bdd59c4664b9202f00fa6dbe8c6321fd3651b3e857edd6c3"
+    },
+    "progs/pickup.mdl": {
+     "bytes": 36332,
+     "sha256": "7d0e5cac5f2a9f5ce879d81499c770b246ce5fcce049e2661fb35d2b15cbd2b1"
+    },
+    "progs/plank.mdl": {
+     "bytes": 19967,
+     "sha256": "d0fd70c3bd6dc93d13b229d4e0fa804a32a6688ef9640b4cc6340d9dab5fbd3d"
+    },
+    "progs/plasmabox.spr": {
+     "bytes": 14472,
+     "sha256": "89432660fdfbbdd90c72639152666f38ea6e7016a1d13171bf2d2e63bd2f4e89"
+    },
+    "progs/reed1.mdl": {
+     "bytes": 95281,
+     "sha256": "65773f37e26d41dd72ec1cf9849c663c1475923cb77d0f4c599bc3301368373f"
+    },
+    "progs/rock.mdl": {
+     "bytes": 136476,
+     "sha256": "0f80e53002bee59dad6dfe6f73b1ba2287700bea1cdade8e1dd4c35ec9d212a8"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "0350089b0bcf3a63a5d7b1e0bd070ac993be60f652f9bf9e3cf48957d31d561b"
+    },
+    "progs/sentinel.mdl": {
+     "bytes": 290664,
+     "sha256": "573efd78767922b2bbb3e5dab2b16cd8f90c2cb1709ecf4a315a141f4df77d09"
+    },
+    "progs/smlexp.spr": {
+     "bytes": 105148,
+     "sha256": "ce4938c9e813e648404b25b82245cad4400682d885d044b9d353a8039cfdceb7"
+    },
+    "progs/tree1.mdl": {
+     "bytes": 57621,
+     "sha256": "8e450cd50b8dac1912e96ec78ff4a16e0b9065138d181fa58257973c2ee96578"
+    },
+    "progs/veg.spr": {
+     "bytes": 8340,
+     "sha256": "4248f027adca723fb0101abf5c51b604ca6aabf80d4ccd9aa305cd34e072a682"
+    },
+    "progs/wreckage.mdl": {
+     "bytes": 71364,
+     "sha256": "13763a8cec3b643acb9b8165f1850ffae003131c84a2ac225777822a88462498"
+    },
+    "quake.rc": {
+     "bytes": 1173,
+     "sha256": "882eb84a6273cd0e47677a09c4ee33109124ae253190b2400314fdafda6c1b9e"
+    },
+    "sound/defender/ssgcock.wav": {
+     "bytes": 5274,
+     "sha256": "db4f62f8d76a68f2e4d3e7a29a22d3ddc5d6ae9bb296e6e800e937b73b5a4dea"
+    },
+    "sound/defender/ssgfire.wav": {
+     "bytes": 14206,
+     "sha256": "494a6d493c3c298c1b9cc0051ce4c1f9e129293ea7ec283b62915c49d8c249c3"
+    },
+    "sound/doors/blocks2.wav": {
+     "bytes": 38638,
+     "sha256": "12df7d5a55311ad33e5d3cf1efbad53f2209b7598c59d4e4715ef18d9e4532e0"
+    },
+    "sound/doors/blockse1m2.wav": {
+     "bytes": 91858,
+     "sha256": "12e39c7592dc01f13b7be34306c6b77c13e8d0429219fa46402752e5e6f62ca8"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eliminator/acknow.wav": {
+     "bytes": 77318,
+     "sha256": "5eceea3e5c2d77b919ad0e05375f7c891e6a7192192b5c1f7bde3f999adf8649"
+    },
+    "sound/eliminator/hesdown.wav": {
+     "bytes": 188790,
+     "sha256": "43688ea2cda3a2edb9f9d575eea9e8b2bb8e962bcd989bdfa5a8962eb2c74480"
+    },
+    "sound/eliminator/hostile.wav": {
+     "bytes": 100856,
+     "sha256": "03ee39ba5581da66909d721f4f40a259ccea095501dcbaeff47ab9d2e8044bc2"
+    },
+    "sound/eliminator/idle1.wav": {
+     "bytes": 39084,
+     "sha256": "2ccaa3ba4f987d031a22b8048ca23e97900fca9def362ff92943b73a99ed7844"
+    },
+    "sound/eliminator/idle2.wav": {
+     "bytes": 36204,
+     "sha256": "9232028e1a93c409c7000348bfadc269c49a333e8d65d904973efb547c7af805"
+    },
+    "sound/eliminator/idle3.wav": {
+     "bytes": 38222,
+     "sha256": "93034d568db5c304a165c3d89cb03ffe5d97e8157755e944a863697007eb27fc"
+    },
+    "sound/eliminator/sight.wav": {
+     "bytes": 31468,
+     "sha256": "2268ee0ad0c77a081b289a550a1dae24b274b2e3f06d156a67beca80df8ee919"
+    },
+    "sound/eliminator/target.wav": {
+     "bytes": 159480,
+     "sha256": "f2c8c4e9f515d682387ec9b4ba40102917355cffc58ad95dcc935b9805742cbe"
+    },
+    "sound/impact/gib_i2.wav": {
+     "bytes": 19252,
+     "sha256": "6a5ddcd321e9543960098d000255abc76b2f502e0e2da798dba4dc6fdd076e3b"
+    },
+    "sound/impact/gib_i3.wav": {
+     "bytes": 14956,
+     "sha256": "e6a2eb024a5101846479865d49ea5ba551d3972567eee70f1a9db3bc6687ccbc"
+    },
+    "sound/impact/gib_i4.wav": {
+     "bytes": 32782,
+     "sha256": "59b447c5e03b7ebc2914704f0e3caaa6b65e393e25d6f19b0a14f2f570676caa"
+    },
+    "sound/impact/glass_bk.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/impact/glass_i1.wav": {
+     "bytes": 13526,
+     "sha256": "e57ff2304e1ed3b85bca5803ab3309f74b115669527ad7c54371bc4377aa3f60"
+    },
+    "sound/impact/glass_i2.wav": {
+     "bytes": 34624,
+     "sha256": "1e403adc1d18b90440d2b10793c0c356617b138be309ed7b9774b9de86d23a8e"
+    },
+    "sound/impact/glass_i3.wav": {
+     "bytes": 9520,
+     "sha256": "250f438c593fed13a5493edc2b4a88c6a4cb22034f81dd7571ba2db7bfee9fa5"
+    },
+    "sound/impact/glass_i4.wav": {
+     "bytes": 6192,
+     "sha256": "05b2dcf83bdcf50f0ac1b6a341d85380293bb519948da38a07a842df53e8e774"
+    },
+    "sound/impact/mach_bk.wav": {
+     "bytes": 124920,
+     "sha256": "642a3ef399d357428f0800ac39557a6e841301aa47263f2f0f3e1b719a4d3923"
+    },
+    "sound/impact/metal_bk.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/impact/metal_i1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/impact/metal_i2.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/impact/metal_i3.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/impact/metal_i4.wav": {
+     "bytes": 79928,
+     "sha256": "d2b35ba352f32ceae469acf9cfa04f7dcc0a462ff69e3649f5c0adf55ae2ea78"
+    },
+    "sound/impact/rock1.wav": {
+     "bytes": 30534,
+     "sha256": "5cb61e93ebcf9bbcd3be1f6e282b51e9102d56b6650cffc0db93918b11b42322"
+    },
+    "sound/impact/rock2.wav": {
+     "bytes": 29254,
+     "sha256": "9fdf4f489834452fce33b1fbe69bce9d4920a117c3d0d93b4fb530a7117bf160"
+    },
+    "sound/impact/rock3.wav": {
+     "bytes": 25264,
+     "sha256": "59b506a84e018b11e9ba30a6ad299c2d8cf24d5907dc95cf30e578cd386e28bf"
+    },
+    "sound/impact/rock4.wav": {
+     "bytes": 27244,
+     "sha256": "7a2c24ce52e272998ca035c967860873c92fbb14227a190ac82b761843680ffd"
+    },
+    "sound/impact/rockbrk.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/impact/wood_bk.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/impact/wood_bk_old.wav": {
+     "bytes": 61250,
+     "sha256": "f9cff6955830b4219b3cfa01e04f41f311f7fbbadbc2738c92bf21808f1e7800"
+    },
+    "sound/impact/wood_i1.wav": {
+     "bytes": 28074,
+     "sha256": "6249449664f5ae509164ae3fd8588c905bea9daf5b1d919d9917b91aadf675bb"
+    },
+    "sound/impact/wood_i2.wav": {
+     "bytes": 25158,
+     "sha256": "d51e731bdf895c84ec9927c496fc0a7fb6e7a37cbfbc2f6b55f54f716d804d08"
+    },
+    "sound/impact/wood_i3.wav": {
+     "bytes": 17644,
+     "sha256": "8e1967cf42a7e31668d94e1b0cb7c6de4d36c6ec735d67ab01ac4e00dfb0853c"
+    },
+    "sound/impact/wood_i4.wav": {
+     "bytes": 11516,
+     "sha256": "fb0908f1a2bdff824d27fa92f15690cb9f86805185119fbc7f7876547495bf45"
+    },
+    "sound/items/click.wav": {
+     "bytes": 6534,
+     "sha256": "fab804dd505a2d823b062b348f126788bb3ce6c6399e8e76b1b7e39ffc8c82e3"
+    },
+    "sound/ogre/flakfire.wav": {
+     "bytes": 25932,
+     "sha256": "d00213964c69abe9c1661aa2cd2ae9305b0bdacb46a3e0945763883fb2d991b6"
+    },
+    "sound/ogre/flakhit.wav": {
+     "bytes": 11846,
+     "sha256": "a7c4a0b04c8c39de0bfb560283ac872e6bb6b240fdeef9a1565d314eb99cbefb"
+    },
+    "sound/player/ftladmet.wav": {
+     "bytes": 67720,
+     "sha256": "7cd7028d84b16700661848a36a866a2602bcf50185b79ca94d5a2eb541fb1294"
+    },
+    "sound/player/ftladwd.wav": {
+     "bytes": 35760,
+     "sha256": "b09b57b7da9ae84b359260d7c600b70a05ed2314597af6cfd38999f664568d65"
+    },
+    "sound/pyro/death1.wav": {
+     "bytes": 18468,
+     "sha256": "f69cb5d6086c78c8e7bdb9d8fcb9365e6500ece5156810b568a2cf2d0acdc126"
+    },
+    "sound/pyro/flame.wav": {
+     "bytes": 44268,
+     "sha256": "44aa350cb7efbe578f785820ba28bf6aec29561a7d150072ebe841966adcc45d"
+    },
+    "sound/pyro/fstop.wav": {
+     "bytes": 44268,
+     "sha256": "50a724e76295283a5cca503ac1b46d5ca97a33055e0c8e85bcfdfc0c90d5169d"
+    },
+    "sound/pyro/sight.wav": {
+     "bytes": 88918,
+     "sha256": "39d9c5460096478952c203bfc358ee52c5f2147e742b937f2e8517b45843c360"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sentinel/laser.wav": {
+     "bytes": 9712,
+     "sha256": "c5f90e1823a04b48f7f24ac5b8792e1b42030a8b07970db5847dc1e74be094c2"
+    },
+    "sound/sentinel/nail.wav": {
+     "bytes": 13750,
+     "sha256": "7acc3ac05b7218abc6fef2d2397771d90fce6fa39415e33824be7e771d30e288"
+    },
+    "sound/sentinel/widle1.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/widle2.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/wpain.wav": {
+     "bytes": 19596,
+     "sha256": "bc7b6536a1c67aa89295eeacea2d9b36cb0bf783b5fb7cc6aaf4fa01a0edb3fd"
+    },
+    "sound/sentinel/wsight.wav": {
+     "bytes": 27322,
+     "sha256": "83bca2103d60c68435e27f0660e3ecd5bffb058e796382e7bdb43efabdfb9889"
+    },
+    "sound/weapons/dryfire.wav": {
+     "bytes": 11268,
+     "sha256": "43e10c707d097c577f465c89fe9444c59b5ff4cdaf7c8d6619bcf61568d39bf2"
+    },
+    "sound/weapons/plasexp2.wav": {
+     "bytes": 112340,
+     "sha256": "92ea6112b21e65d625d34fbe1ec6abc592c2cf7c28f1b55c5999a8a56daebe8b"
+    },
+    "sound/weapons/slime.wav": {
+     "bytes": 57132,
+     "sha256": "88ce5f10c8acb0e51d54a4066ef8faf1643c5baf75edeafb82d350c733131215"
+    }
+   },
    "sha256": "fdc0703ba7a16def597892eacb384bbe137c20ef6034f5038d9f748791f5c14c",
    "timestamp": "2008-03-08T17:54:20.000Z"
   },
   "pak2.pak": {
    "bytes": 4846686,
+   "files": {
+    "gfx/env/moonbk.tga": {
+     "bytes": 440145,
+     "sha256": "215264c71fcfdcda4fd9470adb3b1e1e803cd5af1d8df035c3244646dbfeac2f"
+    },
+    "gfx/env/moondn.tga": {
+     "bytes": 603,
+     "sha256": "4a83e798c3d0637f03b1effe28df9998bf249831b3dccecef074ff5cd8b631df"
+    },
+    "gfx/env/moonft.tga": {
+     "bytes": 410588,
+     "sha256": "4fbbdf05866d78de6ab4bfc9867227007fc87073cc96678e0c08bbc6d9717ce5"
+    },
+    "gfx/env/moonlf.tga": {
+     "bytes": 421955,
+     "sha256": "ea304d8972653bd38c0aee88e6dd434d719360c423344d16b5db9c398af260d7"
+    },
+    "gfx/env/moonrt.tga": {
+     "bytes": 453367,
+     "sha256": "8ee2a2b97267326d4831d96c879c6238a63c485fc8865d91503adb6d7da878bd"
+    },
+    "gfx/env/moonup.tga": {
+     "bytes": 1335652,
+     "sha256": "91e764d1d7780818e58f1c30d7c8825df2adbf17c7da630acfa3dd70b29d27db"
+    },
+    "progs.dat": {
+     "bytes": 887330,
+     "sha256": "bf790f151b40008dfc2a7701f8635b2f6dc2470239d38ff36d2d2c310eb347b0"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 8647,
+     "sha256": "08baae9eefdb3a51c78fba37ff9a1ff8771fbe741be8081f710301e972491b07"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 845237,
+     "sha256": "ee9db9fb4e224227574067dffb1b9c49af5b9536f8cea0527282d851aab81e73"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    }
+   },
    "sha256": "36efab4aeef671264d7d10d683bba1fbce6aa4b5b716e8245a79406029ab6098",
    "timestamp": "2008-07-17T16:08:36.000Z"
   },

--- a/json/by-sha256/86/868392383256f2d1e9f6910ef1c69318c064c268321af2d8dd25964db64b5a00.json
+++ b/json/by-sha256/86/868392383256f2d1e9f6910ef1c69318c064c268321af2d8dd25964db64b5a00.json
@@ -12,6 +12,76 @@
   },
   "M&M/pak0.pak": {
    "bytes": 1848510,
+   "files": {
+    "bazooka.qc": {
+     "bytes": 13090,
+     "sha256": "d7603af6666a4730ec95135d0b72a7a362b979556c0a6a510e4f6afc9391fe23"
+    },
+    "maps/m&m.bsp": {
+     "bytes": 1094072,
+     "sha256": "553b73765eab68023f69e29a7b72bc07497a3109d57f816adbae4f30efc7835b"
+    },
+    "progs.dat": {
+     "bytes": 428548,
+     "sha256": "12b706786d4a3c2190794f449d42ab8574f7c82a113246f77789fb43d2930a84"
+    },
+    "progs/bazooka.mdl": {
+     "bytes": 143952,
+     "sha256": "fcee6fd34a295b108ac7adc3da70156b6bb6c4ee6aef4eb06e9f9394611e0376"
+    },
+    "progs/h_babe.mdl": {
+     "bytes": 26804,
+     "sha256": "61b34a2d1599e86932f0e5c1db8ee0054f8e52f02716a7cf889b9b75ab7667b2"
+    },
+    "progs/pulse.mdl": {
+     "bytes": 15988,
+     "sha256": "83ad42783fe9a5dd2e2085bb6dcb3e551db7fd7ac683326943e6c5423f8131e4"
+    },
+    "sound/bazooka/ahaia.wav": {
+     "bytes": 7748,
+     "sha256": "b9a2527347e2272a676390b3a6bce4cf623f233a11b27d932e340ed67e72823d"
+    },
+    "sound/bazooka/die.wav": {
+     "bytes": 9260,
+     "sha256": "0bae4e5baa31c64ba4fc94df64e0dca08c06a732baea03ae4167b75e00318e9b"
+    },
+    "sound/bazooka/dies1.wav": {
+     "bytes": 8856,
+     "sha256": "663fcd16df6c845fc318a6181b2eece0678f9f3980a90ea3d34f0592e61e6087"
+    },
+    "sound/bazooka/dies2.wav": {
+     "bytes": 9212,
+     "sha256": "93f2868e3bbda78b74970a8912e8bad6f50e130692c4ce066aacdb5d51811e48"
+    },
+    "sound/bazooka/dies3.wav": {
+     "bytes": 9752,
+     "sha256": "439d327515f423fe662a8930b6a1d07d693f43331996119e05d32efc5d44457c"
+    },
+    "sound/bazooka/grrr.wav": {
+     "bytes": 11356,
+     "sha256": "8c6609a6ea9d85f10cda8dd2aa2d0fb77f5e9690698cbafbc213eb5d4f2b6f5d"
+    },
+    "sound/bazooka/ooaa.wav": {
+     "bytes": 4872,
+     "sha256": "76d5ae6f0532eb1a43493330c90966be651e05ba9eed2a994a9afaf28c73de78"
+    },
+    "sound/bazooka/step1.wav": {
+     "bytes": 27042,
+     "sha256": "fc485f8365abf042f2abb94ba4a21f077f688419e252a50fe9cfba2f55fd280a"
+    },
+    "sound/bazooka/stepstop.wav": {
+     "bytes": 6102,
+     "sha256": "79ec338698b2f8bfde44e0b5e8e31ca3d34e140ca88a45eb81c7c72b7ca31134"
+    },
+    "sound/bazooka/when.wav": {
+     "bytes": 23194,
+     "sha256": "af1c2534c69cfb3f07e160cd39f66fcfbe9d64580cb9fcfc43520637c6931532"
+    },
+    "sound/bazooka/yeow.wav": {
+     "bytes": 6474,
+     "sha256": "776a81059bc7fd0f8c998f5e8e05837686d1578c8860aad77901665c31370caf"
+    }
+   },
    "sha256": "14441169a726f7501f0535a7f4942cb6f0fab89839babb5b3b58c30cb09fe451",
    "timestamp": "1996-11-23T13:27:16.000Z"
   }

--- a/json/by-sha256/86/86f887964816d2231410655d07dd636331a805b94b465faf9186751a6b65cfae.json
+++ b/json/by-sha256/86/86f887964816d2231410655d07dd636331a805b94b465faf9186751a6b65cfae.json
@@ -580,6 +580,356 @@
   },
   "reload/pak0.pak": {
    "bytes": 4329592,
+   "files": {
+    "gfx.wad": {
+     "bytes": 121132,
+     "sha256": "fdcc42f0dad313b297845f4a4daa79dffb541dc7fdfd13c6e8610df9fd614f72"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "898d694265db0f933feecfd2a843557a6954a5f2aea05ecf9a852314119dab61"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "03e0973ee5d434c037699f9568228ab80be0df882ca77c88a9835b2d2edf0649"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "582e279ac4040f4ee29c15e8a5fae31ea6e5c391efe06f52a577f8688e086e8d",
    "timestamp": "2023-09-10T04:55:40.000Z"
   },

--- a/json/by-sha256/89/8906a3fb762eabd1771a1f36fa2d025c94f9c3428b6385a9ab1a58c4415096ac.json
+++ b/json/by-sha256/89/8906a3fb762eabd1771a1f36fa2d025c94f9c3428b6385a9ab1a58c4415096ac.json
@@ -10,6 +10,16 @@
  "files": {
   "PAK1.PAK": {
    "bytes": 959980,
+   "files": {
+    "progs.dat": {
+     "bytes": 484252,
+     "sha256": "95cb95fb506a700a15494d4ad84389d12562582a57762bc97a1473af33077826"
+    },
+    "progs/necro.mdl": {
+     "bytes": 475588,
+     "sha256": "c49fc9ac936de6780feaf6369a7b78314d062de65e29c67e4967e00e0897b9bf"
+    }
+   },
    "sha256": "a520abe1577bc06097eab83466f7fa79dbf66b8a8c174ed8356aaa239e63652a",
    "timestamp": "2001-01-08T15:11:22.000Z"
   },

--- a/json/by-sha256/8c/8c6d056aff2617e900845711630c5a016a9f3db11bda59925142dfe33fb8bde0.json
+++ b/json/by-sha256/8c/8c6d056aff2617e900845711630c5a016a9f3db11bda59925142dfe33fb8bde0.json
@@ -17,6 +17,596 @@
   },
   "haunting/pak0.pak": {
    "bytes": 13243793,
+   "files": {
+    "maps/haunting.bsp": {
+     "bytes": 3150296,
+     "sha256": "f11acc39c6c651bf1986b4159acb647283d6eaecaec3c7b9a4c77ea9e1dcc50d"
+    },
+    "maps/haunting2.bsp": {
+     "bytes": 1429404,
+     "sha256": "a4a582697ba9008221a6bb95995b5c748c77e002e31b3ca304c4a5c610a8aec3"
+    },
+    "progs.dat": {
+     "bytes": 876828,
+     "sha256": "1fac21bd8acefdb2efa9e7929aa607a1a943cdcaafbaed3ccf719660bf6df219"
+    },
+    "progs/armor.mdl": {
+     "bytes": 44076,
+     "sha256": "0e16c3f0ba370dbb172af676540ce2f4a58b151d8a6dd10c1c353748257c82d3"
+    },
+    "progs/b_earth1.mdl": {
+     "bytes": 16325,
+     "sha256": "f8721a42dd05178200b3de8fb73502ef46284f7e4e48076fb353980dfea997a2"
+    },
+    "progs/b_earth2.mdl": {
+     "bytes": 65436,
+     "sha256": "59933ccbe1fda467ca4de97ae80587eb85904779e9aa612a3621859bc474dfdc"
+    },
+    "progs/b_ice.mdl": {
+     "bytes": 17584,
+     "sha256": "7805429534fa39fc6be4016eccacdac51fd0b4c2183723e7cc8dbab2aeada925"
+    },
+    "progs/baron.mdl": {
+     "bytes": 405612,
+     "sha256": "68bb69841d1246882360b8e243bd34dc5534989dce1eda8974938ebf7acae652"
+    },
+    "progs/bball.mdl": {
+     "bytes": 130008,
+     "sha256": "6fc43ee5d3e26268cb4e9be521b4b514f21bfe3556f8189ccb8c96a44c71b115"
+    },
+    "progs/bolt2.mdl": {
+     "bytes": 20971,
+     "sha256": "ca530afb1e205749ca625e37c75656523ec8c1a5320fcf934585dec7eea03966"
+    },
+    "progs/demon2.mdl": {
+     "bytes": 100920,
+     "sha256": "8acae561375e9ed2e02e408518a3d835ff59f27e579476861b05a19db0214cb3"
+    },
+    "progs/demon3.mdl": {
+     "bytes": 102120,
+     "sha256": "378d0373bf55216b7e1807f715c39681a0f5de2f5e4e91adce6634a6ac4ea190"
+    },
+    "progs/f_gib1.mdl": {
+     "bytes": 5900,
+     "sha256": "7684e5b71c188455fef23f6c5296118c6e6097244e130f19a7baaa8624d01d94"
+    },
+    "progs/f_gib2.mdl": {
+     "bytes": 16628,
+     "sha256": "87c71727daa0b117fa69cbbe28e74dda48709da3f9efee09cce42d4c72120c5d"
+    },
+    "progs/f_gib3.mdl": {
+     "bytes": 23038,
+     "sha256": "8def0f3a19c2cfa2a7dc8f6367c0ef1f367d5be4dd339a6d2a13b7c199254054"
+    },
+    "progs/f_head.mdl": {
+     "bytes": 15264,
+     "sha256": "6a08ff3fe11c8adda90dd126b9f4321e1777aaac7d53612515c161c0ec2a0341"
+    },
+    "progs/fireball.mdl": {
+     "bytes": 14336,
+     "sha256": "749b11c5d8e61ca4b9ba2e8907a713c3fb683760f2e81113426f5826e817409e"
+    },
+    "progs/freezem.mdl": {
+     "bytes": 38589,
+     "sha256": "1a7b293eba8a6f0cf6481583de89c0f93bc734affbe968e8e9ebd1d66f974513"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 34700,
+     "sha256": "427b48f83493956b49e32024333d4db51b78cf1f79a45f130f98f1e99783e42a"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 30720,
+     "sha256": "708ee4afc78acc2ac37487e8714e7761de6a49b192524cbb41437c1e52e31685"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 48244,
+     "sha256": "90bb98719c5b3d509a1df75600e3f308edc7a463531889504888727b0cd6e138"
+    },
+    "progs/gib.mdl": {
+     "bytes": 22228,
+     "sha256": "43da76f68a5340755391c2ffec44b3dfa5f271754d509fd9e6292de6281111a8"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 22228,
+     "sha256": "d8f920e51e1cded370a45e9e7c7d3e928194817a9f8037830c62fcdc2ce50a82"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 5349,
+     "sha256": "b1c731745089418075fb565c13db5992d7dd54df6d5ffd38f93e146caa508561"
+    },
+    "progs/hkboss.mdl": {
+     "bytes": 228400,
+     "sha256": "2cf03ef0c70ac4999559a9e3ec2518384f636fcdda62f32cf67a6953303e3c5e"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 228400,
+     "sha256": "f96150ef6e364beb401cf9993398cd7065c9a0d7807d403a1eec098ea8acd369"
+    },
+    "progs/ice.mdl": {
+     "bytes": 10712,
+     "sha256": "b8b1e2bc3acbef197f1a824189a5545906b927410ded34ede6aee4c70260f4e4"
+    },
+    "progs/knight.mdl": {
+     "bytes": 101404,
+     "sha256": "8049534559a69e840ddfb3b6c1a8d2cdce1f526142460997c48c4c62e12bc382"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/manga3.mdl": {
+     "bytes": 96256,
+     "sha256": "99ab9beb24e1f5fefc2a99025943c225c17a0216e82b7a359483c8b19622fb10"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "fd5407cde15b79e1d5b2d5bc78366cac4ea1d436308e6740608b8e2440d9a0da"
+    },
+    "progs/oknight.mdl": {
+     "bytes": 221448,
+     "sha256": "f648d62f1c6bc202103fcb20dad7c56574a4994a3ad563b24426572a8473a0e1"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/pt_beam.mdl": {
+     "bytes": 64436,
+     "sha256": "4a5c7e27e8a05cb98e007df414dea795887eac4d441b194d676202b47ea35f07"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 200848,
+     "sha256": "4c0653e3adba99be4d581c92a928fd6e8c27b0a2159a97f7ec5e885478249b8d"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/sphere.mdl": {
+     "bytes": 95481,
+     "sha256": "c5b8f8bcbdff20c19f0237b01cd391d746dd45996890a5eae7982c621e422a45"
+    },
+    "progs/v_freeze.mdl": {
+     "bytes": 76847,
+     "sha256": "cfcc74d7b6e3dbe6cba270f97c495c04c766d9f2d1cd813a889c7c8998ed5836"
+    },
+    "progs/v_gib.mdl": {
+     "bytes": 9172,
+     "sha256": "fe66c04aceb3b8ab14bcb03ecc9fd5ffcf01e2679e3372bbef5c52e2ee52e768"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_lava.mdl": {
+     "bytes": 126644,
+     "sha256": "3eac7f583062c719975fc834ffa645586e43b1c5adca2d07ac7845262317bf81"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 128952,
+     "sha256": "b94788b9eb67a3e35e0f8f1563e1308c3ead46aa14882d5afbb2bb60b7995eff"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/v_ptron.mdl": {
+     "bytes": 103038,
+     "sha256": "e7eed8d4fc4bec47557e5fe2d017979230a306329ee12d845dd37e056888bc2a"
+    },
+    "progs/vile.mdl": {
+     "bytes": 98556,
+     "sha256": "6061e9a47f664a682696f4816611d8d22dbc145477663f341b9e498f0c170c0d"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "7758aaf42d0d1617e4fb172ce842be4316073f63250aba46dad441327cccb2e6"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 133676,
+     "sha256": "0a57ee912df3142c5e17183d5f6bd461021b141d53f7534014d59eda97e6bfa6"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "sound/alkamb/creepywind1.wav": {
+     "bytes": 149550,
+     "sha256": "de80fc2c4171bb542d9ffa5b40cb31eea2fef8311c4f9ebc15b7d9a28bf3e610"
+    },
+    "sound/alkamb/demonwind01.wav": {
+     "bytes": 89228,
+     "sha256": "1a44a8cf17be9fe6e8aaecfc9c65ec0ef761eb27ea6df77e016cebf01cf62216"
+    },
+    "sound/alkamb/drips.wav": {
+     "bytes": 80712,
+     "sha256": "96f7890d2fea2f1f6443d0e75bb6084f39931e7c5399a6e75787dec4eaba5033"
+    },
+    "sound/alkamb/moans1.wav": {
+     "bytes": 312472,
+     "sha256": "87d2dd817fbf578bb94a22aaa20c6a0daa28dbb0b78f6ccc0b7f0f6d17ffc04f"
+    },
+    "sound/alkamb/moans2.wav": {
+     "bytes": 275802,
+     "sha256": "279a5b7190aa28d598930d7cfef6f5fd611dac51fb5297058b7714e1f6fdd0e9"
+    },
+    "sound/alkamb/moans3.wav": {
+     "bytes": 162450,
+     "sha256": "6b46ddb6560b63b16a7493abeea49c7bff4afe430830a7115959e8db89a91bdb"
+    },
+    "sound/alkamb/scaryswamp1.wav": {
+     "bytes": 201212,
+     "sha256": "c6fded08f1da1020a0a13ef5f5be9c99b7cbeda8f51746e156389bd859279791"
+    },
+    "sound/alkamb/scaryswamp2.wav": {
+     "bytes": 261302,
+     "sha256": "7a1a1e01cae8293d1cafce426580cb34641ac0c6ed379c4ab64e2307fa25ab94"
+    },
+    "sound/alkamb/scaryswamp4.wav": {
+     "bytes": 252754,
+     "sha256": "e71d7791f2340b1824247c940f7b8ea9934db493ed564fbedfb68775d9799bab"
+    },
+    "sound/alkamb/underground1.wav": {
+     "bytes": 114950,
+     "sha256": "989203aa820c170f5813441d665c193977eca0562b7eee60a5dc8133fc503dfa"
+    },
+    "sound/alkamb/wind_med.wav": {
+     "bytes": 32212,
+     "sha256": "005616904ebfec049860ca33b790903e76c75615f3048dba17ce8d85cd6c65f5"
+    },
+    "sound/alkamb/wind_rumb.wav": {
+     "bytes": 63234,
+     "sha256": "24760cbf8622bb933fcd59e847067de3581f6a3d54db72bcb3f864d2cf508a36"
+    },
+    "sound/alkamb/wind_rumb2.wav": {
+     "bytes": 32872,
+     "sha256": "9c77014eb35b692af657a524f1e7eb82b1b1ebe9d95c62462e6f6925baf4153a"
+    },
+    "sound/alkamb/windeerie.wav": {
+     "bytes": 58476,
+     "sha256": "0759ad526d301c3bb14c467818bacdbe3a64237657c45a435e06cb166b570b85"
+    },
+    "sound/baron/death1.wav": {
+     "bytes": 68188,
+     "sha256": "0785bad4b7b721f2bb989fa74f7186552ef9bbca016fb2f1a3fe9b52650fe3cb"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/e_nail.wav": {
+     "bytes": 26306,
+     "sha256": "04fc98e42709c9a5d1a8bbd52aff9114b4922da324e30d21859bcf8209e55b4f"
+    },
+    "sound/baron/e_shower.wav": {
+     "bytes": 10178,
+     "sha256": "6c50b5da79aa99295f9bc3de1445ef76c6e6306b413b9a934122393b6b3a633b"
+    },
+    "sound/baron/f_ball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/pain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/sight1.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/demon2/ddeath.wav": {
+     "bytes": 119852,
+     "sha256": "2e5c590d68b6b17c224e0362b1b174812412cc3de817e57ec36bd495259e0b72"
+    },
+    "sound/demon2/dpain1.wav": {
+     "bytes": 68012,
+     "sha256": "6bce074ba79a267f90f1eaec23952a1b67fb9ccc84e0652af3998b965a8a7f78"
+    },
+    "sound/demon2/idle1.wav": {
+     "bytes": 109484,
+     "sha256": "a9c13339e4303ed281f9a653fc6718aa8da31f004e687c506838ca2f678e0b40"
+    },
+    "sound/demon2/sight2.wav": {
+     "bytes": 87596,
+     "sha256": "3bbeef3faab854f2725cbe833c4c9628592d823f25a94686a27660c25e2955c0"
+    },
+    "sound/demon3/ddeath.wav": {
+     "bytes": 16453,
+     "sha256": "4674e8017812c77fe47b75e49751373f8e541f12b1516d8cb6e258e74fc23d2d"
+    },
+    "sound/demon3/djump.wav": {
+     "bytes": 13360,
+     "sha256": "cebb2a78470818d5e8d80b7061d756337b046dbea925d9efb9dfeadb0e6c6046"
+    },
+    "sound/demon3/dland2.wav": {
+     "bytes": 4398,
+     "sha256": "0828634696cad5557833d51f2ed9745567b2f80ce55b3bfa8a21a7cf518ba56e"
+    },
+    "sound/demon3/dpain1.wav": {
+     "bytes": 15679,
+     "sha256": "0624bcdb408f3963ff01680d05d0c6d6c815e0d0e32617e1c5eb02b69311b7a8"
+    },
+    "sound/demon3/idle1.wav": {
+     "bytes": 6521,
+     "sha256": "5fa6854795867f42272ea1d7d4f212c760ab7a2e6ed369c729ff59fcd7382ee5"
+    },
+    "sound/demon3/sight2.wav": {
+     "bytes": 8770,
+     "sha256": "a9c22263c7be78f32c54417cf0ded45007d3e0d03d87e2793343493526006faf"
+    },
+    "sound/hknight/fireballsound.wav": {
+     "bytes": 33230,
+     "sha256": "98911278ad588279697aa84092c33366577e3e4e700c19668baecf154fa27fa3"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 12202,
+     "sha256": "2e0f2a66e528175f8636b4b832b1f5241c09237fc09081e46e6ec3e536e69162"
+    },
+    "sound/lhit.wav": {
+     "bytes": 9552,
+     "sha256": "f66fdec000ae50bbc32110030ab2071ebf43e659f3bef4c0d275b16267c5c4ac"
+    },
+    "sound/lstart.wav": {
+     "bytes": 9552,
+     "sha256": "f66fdec000ae50bbc32110030ab2071ebf43e659f3bef4c0d275b16267c5c4ac"
+    },
+    "sound/manga/died.wav": {
+     "bytes": 71468,
+     "sha256": "5c4b4cf74f73e053cfb042fa8e69535a2454ceae39f35bac2762d8ebe8460a25"
+    },
+    "sound/manga/ha.wav": {
+     "bytes": 17324,
+     "sha256": "15575f8f3e16f6a466edb9e6016d76c1d148be8b4f1d983958085bbcf5085bfd"
+    },
+    "sound/manga/hiyaa.wav": {
+     "bytes": 24236,
+     "sha256": "7fd511e453b5ce84ba9787f1586b0648ef122934324b5e2ece8bb4ff08ce5aaf"
+    },
+    "sound/manga/kungfu.wav": {
+     "bytes": 61100,
+     "sha256": "d170f81971005d4e687d67cf162372132a7ef07d6d73086d53803a3ad61290b2"
+    },
+    "sound/manga/ohdju.wav": {
+     "bytes": 18476,
+     "sha256": "15ac78885fc53d156381ee1fb0310c469cc597ab747b87b6295afa14dd32c3f5"
+    },
+    "sound/manga/tchak.wav": {
+     "bytes": 34604,
+     "sha256": "8a4067a528ee8895aa7dd1da922677e91973cb60ef4e5f8b0ecbb75bb1cabd24"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/oknight/ogdth.wav": {
+     "bytes": 78380,
+     "sha256": "45497ebb89998ec93f02fc2a8d66c62392475de72fe4729d85bd5bfa3d2758e7"
+    },
+    "sound/oknight/ogidle.wav": {
+     "bytes": 5056,
+     "sha256": "542c206c55627911b29371b210f5d5daad5ebd202b7aca8718743d705d0f4fda"
+    },
+    "sound/oknight/ogpain1.wav": {
+     "bytes": 29996,
+     "sha256": "90e139a7abf0197c378cea36bcfa4c8842394fc21bce4df579d29b00fadfdd4f"
+    },
+    "sound/oknight/ogwake.wav": {
+     "bytes": 85292,
+     "sha256": "c0719580bd8bdb0679b2d913fac3def68bcea5e1d848a31ebab0a0a2cd92165d"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/s_wrath/swrath1.wav": {
+     "bytes": 6028,
+     "sha256": "7d2290479c4b8fe3cbf14b8e1bddbd6a874b5e9d5f436233eec562f35ca8cfb3"
+    },
+    "sound/s_wrath/swrath2.wav": {
+     "bytes": 4052,
+     "sha256": "7f9ae2dcb54b6e59c67705c20179a963bb8218d4c96db4323d1fedfb4ad39afb"
+    },
+    "sound/weapons/blaze/flhiss1.wav": {
+     "bytes": 13484,
+     "sha256": "e44b1a5029b339a00c3682d9f79f7f813b4ddbe033710bec7ef0cd20a496983a"
+    },
+    "sound/weapons/blaze/flhit1.wav": {
+     "bytes": 10586,
+     "sha256": "26b113f15390071f4585f0859b1aae738ac8c692531e3e4e638b4eb3836aca84"
+    },
+    "sound/weapons/blaze/flshot1.wav": {
+     "bytes": 3914,
+     "sha256": "a5b7ef9dba11d0cf67d263a8c70a9783f1a2599ac49601ccedd10a0f2e2204e9"
+    },
+    "sound/weapons/frozen.wav": {
+     "bytes": 20618,
+     "sha256": "05a489de35594542a929ce87087a2755fc630097292eedde6d50a18893223e90"
+    },
+    "sound/weapons/icefire.wav": {
+     "bytes": 8940,
+     "sha256": "7b818fba135a1c5535c21584134125bf44a071715711abf277b2fc9a067637ef"
+    },
+    "sound/weapons/pt_blast.wav": {
+     "bytes": 20448,
+     "sha256": "b5bafb4758dff4ea092079935a55ef8725beebd986be806e795f49de7109244e"
+    },
+    "sound/weapons/pt_fire.wav": {
+     "bytes": 12580,
+     "sha256": "a4535e2d594995d08a8c69fb75454963070145ec01b798371b09a1b668942daf"
+    },
+    "sound/weapons/shatter.wav": {
+     "bytes": 20898,
+     "sha256": "5d30558f24773771d980c4796f4cf28646a98cdfc3baadb3b3491c7d170dfa77"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    }
+   },
    "sha256": "4fb87becc50067e8e9eb419917e169f35f854b731ca00e6686e1ce07e49c8f2c",
    "timestamp": "2003-07-09T20:17:34.000Z"
   }

--- a/json/by-sha256/8c/8c702b8a5dc79b447ec8825a0835ffc6ac0171f76f0f830d4de4c60cc762a70f.json
+++ b/json/by-sha256/8c/8c702b8a5dc79b447ec8825a0835ffc6ac0171f76f0f830d4de4c60cc762a70f.json
@@ -12,6 +12,248 @@
   },
   "copper/PAK0.PAK": {
    "bytes": 4048317,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs.dat": {
+     "bytes": 481910,
+     "sha256": "c6249c016d912bb8602abfe25683c26e021cac63259e8328d4695a8360a7df07"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/fish.mdl": {
+     "bytes": 221279,
+     "sha256": "b220c5bdbcfdcd0df834944ecbccb5ffbaa98fa7844d2a1da455183bcc2f463f"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "6585197d235de9b551f6049072ee5bb64d2ef0ac3d5a861b0750d63a14dde306",
    "timestamp": "2019-06-20T15:33:54.000Z"
   },

--- a/json/by-sha256/8d/8d7ede6e224d4e4d194cd89202a2fd648bf7a51be16411e659a4a4ec78ce2fe6.json
+++ b/json/by-sha256/8d/8d7ede6e224d4e4d194cd89202a2fd648bf7a51be16411e659a4a4ec78ce2fe6.json
@@ -7,11 +7,95 @@
  "files": {
   "PAK2.PAK": {
    "bytes": 10467766,
+   "files": {
+    "maps/inflict.bsp": {
+     "bytes": 1228120,
+     "sha256": "a97fb5ca2589a7f8657d45a29f855f0679e58b262992ece1f84a5babb0d810ed"
+    },
+    "maps/k3m1.bsp": {
+     "bytes": 2019944,
+     "sha256": "33c4ef12e7999098f36e5d2258899c5e308cc67a904b8f2ff11004573c3db5da"
+    },
+    "maps/k3m2.bsp": {
+     "bytes": 1798192,
+     "sha256": "e223fdc64018aa3ab91417e2c597f4a0a7352bcaa2201144148ac0a87f58903a"
+    },
+    "maps/k4m1.bsp": {
+     "bytes": 2862172,
+     "sha256": "470fe456e8d22bf3b4b3f7937f9128c7dd29f649221eee26b4c1d714dbee3f1a"
+    },
+    "maps/kend.bsp": {
+     "bytes": 1665416,
+     "sha256": "49119b26449112cb706f0f4e8ccc5775fd901fbed88e79ff4bac84d03d877ddb"
+    },
+    "sound/boss2/death.wav": {
+     "bytes": 253690,
+     "sha256": "587b4d386442d8af2ce1a48d29919103cf5883cbf9c512e3e5fe0360fec1ec14"
+    },
+    "sound/boss2/end.wav": {
+     "bytes": 294326,
+     "sha256": "e3810fe1d0bda2bda0ce115ced95fb31614d6c4ef57c67a75e8ae21c883421e0"
+    },
+    "sound/boss2/pop2.wav": {
+     "bytes": 53772,
+     "sha256": "400e8171ab576c39f563e8c21e39368699c838964b673dab248c830cd777806e"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 225484,
+     "sha256": "de2a73c974756bdacd966714ac9fa36a47f8a9840c6c04a8cd84c07030d8cca2"
+    },
+    "sound/player/h2ojump.wav": {
+     "bytes": 22374,
+     "sha256": "bff10747b81c46e452105fa641bbde23b8949c44c17a799db9dc8ac25ac9bc7e"
+    },
+    "sound/weapons/rocket1i.wav": {
+     "bytes": 43560,
+     "sha256": "9b23cfaee14d7a577250a5c5c2473a4d6ab3e6641c34f477b967dbcca5a29633"
+    }
+   },
    "sha256": "8f6189ffe0c288984bfce4ffe6051db5b1ad2c8f6213fc4b8dc5b4e164bef2c2",
    "timestamp": "1997-12-02T13:56:58.000Z"
   },
   "Pak1.pak": {
    "bytes": 9802343,
+   "files": {
+    "dd1.dem": {
+     "bytes": 112486,
+     "sha256": "674eef42fc28801001b8861cd2730711000ca9df3c26256e4756f4b03d111121"
+    },
+    "dd2.dem": {
+     "bytes": 153272,
+     "sha256": "898d2c789a922665f6031e165f7cf10ab673f720678d4182d2a5e865feec64e8"
+    },
+    "dd3.dem": {
+     "bytes": 346188,
+     "sha256": "47c896060323fd63aa3645ec98e35a89bee10c0b36a282079923783efdf53b4c"
+    },
+    "maps/k2m1.bsp": {
+     "bytes": 1874500,
+     "sha256": "44c4dcda48869319016525b18b7fdb303d3f6c83eb948ee19d280a54707c8b23"
+    },
+    "maps/k2m2.bsp": {
+     "bytes": 2581456,
+     "sha256": "9c2eefa0208bd72db44e64070bb90d5a05de4e9fbefc5b3c6f1364955b670ed8"
+    },
+    "maps/k2m3.bsp": {
+     "bytes": 1093672,
+     "sha256": "c1543c5c4b9c51f7a2f0cd449709fee1536bf2656cd0ba7eab6983a00fff251b"
+    },
+    "maps/korn.bsp": {
+     "bytes": 1567628,
+     "sha256": "d3a50efda282707368cac62a56fa457edcd36c588bce71657d42d6a9ced2c3c2"
+    },
+    "maps/start.bsp": {
+     "bytes": 2072396,
+     "sha256": "b92a53854ba299f90fac1af067aecbf365bf531c1f78d2e189bc7e0414f271f3"
+    },
+    "quake.rc": {
+     "bytes": 157,
+     "sha256": "60cf3373020156b2ab7a59a4efd5b69f72d9b28dc83acb64c0d4fa5db66d11e7"
+    }
+   },
    "sha256": "d71c283ed444ca942424a8003e1496d16befbec697815968148554dbd1860a7d",
    "timestamp": "1997-10-19T20:58:04.000Z"
   },

--- a/json/by-sha256/8f/8fc5b9acd9fb2e0f1ad4fe27287420b996adddb3121b2e1f341a49f19cff355c.json
+++ b/json/by-sha256/8f/8fc5b9acd9fb2e0f1ad4fe27287420b996adddb3121b2e1f341a49f19cff355c.json
@@ -257,6 +257,352 @@
   },
   "pak0.pak": {
    "bytes": 4383638,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 307208,
+     "sha256": "49840a548ce580f644d4b6b6dab85c826c9a0ab096adcf43332243923664a8f6"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "b1deebb2268d373683100cc9df4c9dcbf817f9bdb0e3f2cd13edde0037609b53"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "11454a7ec41855cc66adc9b80e60b1c76b0af873656d46cc20543ea4d2a7ef8c"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "d2a59d07042577c9c5a5ceace5ad0e3893ba3ac2d206f039f11cf282ead3945e"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "63f869e1e553ccae238279e4b78c902463505a3d1dd7c5d21d4f4acbb56857ee"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "6e3d8ed0cf22d78c0e05bf75837214a12f647fda33da1fa1ad1195cff3cb9681"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "35db83f82066ac1db85f4094dc9710e313b638e019d8e4d6fb5abf0457d506af"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 23658,
+     "sha256": "82b46faae4c0f08e8edc2fa9bcba0f1f49dadc8e0beaf78746304f3ce0e686db"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 6424,
+     "sha256": "a846a94e5db77d8b3bf36e62befe363fec54c07233398378c115745d34b7b1a3"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "1e56e9cd33fbdaa826bfd3c2ff8e77d34050df8f6dee8d08a62c6b181721a4e5",
    "timestamp": "2022-01-30T22:41:00.000Z"
   },

--- a/json/by-sha256/8f/8fc9936a33ff006b096a0df566ac49da38f383c009c19907749be84d91869214.json
+++ b/json/by-sha256/8f/8fc9936a33ff006b096a0df566ac49da38f383c009c19907749be84d91869214.json
@@ -132,6 +132,360 @@
   },
   "sm226/pak0.pak": {
    "bytes": 4393664,
+   "files": {
+    "gfx.wad": {
+     "bytes": 121132,
+     "sha256": "fdcc42f0dad313b297845f4a4daa79dffb541dc7fdfd13c6e8610df9fd614f72"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "898d694265db0f933feecfd2a843557a6954a5f2aea05ecf9a852314119dab61"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "03e0973ee5d434c037699f9568228ab80be0df882ca77c88a9835b2d2edf0649"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "2a28a9f4861c149ebff65a36456836b694e7b4437664518d1ca5e27da0e82a16",
    "timestamp": "2023-09-13T13:46:32.000Z"
   },

--- a/json/by-sha256/8f/8fe3d61a0e046478541287ed19c5704d20a5926f1ec904c154b98f28e1b01243.json
+++ b/json/by-sha256/8f/8fe3d61a0e046478541287ed19c5704d20a5926f1ec904c154b98f28e1b01243.json
@@ -17,6 +17,48 @@
   },
   "sthangar/pak0.pak": {
    "bytes": 8389617,
+   "files": {
+    "maps/sthangar.bsp": {
+     "bytes": 5982536,
+     "sha256": "be773edc96e7b6a68d7050cc4adab0e0b1ae6abad518b02be94956bcabdbad35"
+    },
+    "maps/sthangar.lit": {
+     "bytes": 1766558,
+     "sha256": "c1bbe8b7d7dc5b74a08bd2aa627258ae281c3d49a20cfbeabdf199c3be267d52"
+    },
+    "progs.dat": {
+     "bytes": 331582,
+     "sha256": "5331a32015c0e392c76ff07eee78db868192daac050008cc8aa951e2aa2ee05c"
+    },
+    "progs/bigcranea.mdl": {
+     "bytes": 92792,
+     "sha256": "3e8c70c79bd0844dd40e0538104779ffdf59510f68be90ddffb447c9b4ea5410"
+    },
+    "progs/bigcraneb.mdl": {
+     "bytes": 21940,
+     "sha256": "6a88f3586991d8ce5eabb5c9e05a4d21d3c0b9e121d95cb6606b534a40e28a88"
+    },
+    "progs/bigheli.mdl": {
+     "bytes": 44904,
+     "sha256": "0a202b1859508adf995ce87f982e21c68f38c52f622ac33ec7f9e8e07c66e92b"
+    },
+    "progs/bighelijet.mdl": {
+     "bytes": 102656,
+     "sha256": "00326ed3cc0f70a0967999322c31257d7522662b559af2de413325f99632c9f6"
+    },
+    "progs/bumpmap.pcx": {
+     "bytes": 1842,
+     "sha256": "675c8072315d0a1d49c036027c584b271df4850953c5ddf69a9c3ac229cdd3b6"
+    },
+    "progs/console.mdl": {
+     "bytes": 41912,
+     "sha256": "1ee5f0fc5f4e676a3b9169b06ea91925257c509125f3daeb115853717ed509af"
+    },
+    "progs/console.py": {
+     "bytes": 2243,
+     "sha256": "c5cc4e1881691124f6bf0e9ba065f7e347449481a3eb51dc6257b8c9964f4647"
+    }
+   },
    "sha256": "8e10e0d322ffad4f9aa492aac516c827752a1aa1406b683c83dc1b4996211eed",
    "timestamp": "2018-05-02T13:40:30.000Z"
   },
@@ -37,6 +79,203 @@
   },
   "sthangar/sthangarqc.zip": {
    "bytes": 107073,
+   "files": {
+    "sthangarqc/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2018-05-02T14:13:16.000Z"
+    },
+    "sthangarqc/ai.qc": {
+     "bytes": 14521,
+     "sha256": "54a6329a086391d2f1296fd30afd5db9ca676f7f15911c703b15e440b4e5778c",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/amtest.qc": {
+     "bytes": 1697,
+     "sha256": "8dd158020b8c0be6988b0f1fbe03990372fb769442dbaf85248ef8c0e18645ee",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/boss.qc": {
+     "bytes": 12411,
+     "sha256": "674893303bff9280f134066f168b06dd2dd1d58591c42acc2c70c6e2a4b9ba82",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/buttons.qc": {
+     "bytes": 2910,
+     "sha256": "4a3075cd783cdb788948dd1dc79abb63cfb30a016cb3f1a5979814f457dd9f6c",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/client.qc": {
+     "bytes": 33404,
+     "sha256": "dba49e1f5207b631fd7fc061580979925aa90062076180264f879eb40a83f4e7",
+     "timestamp": "2018-04-23T10:36:02.000Z"
+    },
+    "sthangarqc/combat.qc": {
+     "bytes": 6130,
+     "sha256": "9e55bcbbb486d6c396ba9ee797de982be4cc79a94ffe2c40fba89bf3f72a5c4c",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/defs.qc": {
+     "bytes": 17423,
+     "sha256": "04cb32ac80aba9f2092dea14e811603422bc5aefa830c818cbdbae8440852c10",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/demon.qc": {
+     "bytes": 9904,
+     "sha256": "b20d0e3664ff9ff9e55222ad73507016a832b15a4cb28f93b86e90fa35ea445c",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/dog.qc": {
+     "bytes": 9542,
+     "sha256": "7dd3980dc2f284046f0e516b39d8b7391ac4a87b758b2f89aeb682feab2cc2bc",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/doors.qc": {
+     "bytes": 17028,
+     "sha256": "125ecc6795edfa031b44082217a4f004a630e44e438b9dcb3e374f9d56b6ed9c",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/enforcer.qc": {
+     "bytes": 10727,
+     "sha256": "01b86eed9379c58b6028480ab180b8dd7be433c4c143ca361ca149609961c379",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/fight.qc": {
+     "bytes": 7208,
+     "sha256": "c68c3310e794200ef61c79ed9665490b3e893ff7d2d6243e5f6aeda7d9885925",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/fish.qc": {
+     "bytes": 7747,
+     "sha256": "d42dc2975ddc8a606959661ae26b95156aa90fcef0c25de7b47934b2ef509c94",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/flag.qc": {
+     "bytes": 141,
+     "sha256": "143f0b896c7515dcdaaf5b436d130fe1ffb6fa67cad2a34ad4639724201b3445",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/hknight.qc": {
+     "bytes": 18298,
+     "sha256": "302a397cbd1fc639b70767a01a6d8e3696699165e2c4a00d1a33231102408682",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/items.qc": {
+     "bytes": 30000,
+     "sha256": "d3e9e5fb26ac51f9fffcb282f2b98b3f7130f5531b157aa1812a0e578b245e19",
+     "timestamp": "2018-04-23T10:35:16.000Z"
+    },
+    "sthangarqc/jctest.qc": {
+     "bytes": 222,
+     "sha256": "0b356238bdae38139e36fb7f9ed5a72e65accee92b48f25035b79ec315a7da06",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/knight.qc": {
+     "bytes": 9684,
+     "sha256": "53202927092c04d472a311e5ec8732cdb2ed9224c6520fbe4d126e152b5cee87",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "sthangarqc/misc.qc": {
+     "bytes": 16771,
+     "sha256": "d929a42f43075702687d4caa6048ba995bf310a9847b4cca336c4139991a2f7c",
+     "timestamp": "2018-03-01T21:02:32.000Z"
+    },
+    "sthangarqc/models.qc": {
+     "bytes": 8996,
+     "sha256": "d11fd0939293244962c5a40766e1dce246bde98eb0d42c87eb530a58d6eca64d",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "sthangarqc/monsters.qc": {
+     "bytes": 4798,
+     "sha256": "cd29084e3f58192819848c3030c6717487d2641d848d118da433e1348ee59c8e",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "sthangarqc/ogre.qc": {
+     "bytes": 14657,
+     "sha256": "193565dc8f263640e62c476c885c432d774076dac8c99bca7105eadff0ebed85",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "sthangarqc/oldone.qc": {
+     "bytes": 9537,
+     "sha256": "3ebf15cec4adf547d8859cb54772e9c1c331fd30cb3c82bccb328bb945e5f834",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "sthangarqc/plats.qc": {
+     "bytes": 7693,
+     "sha256": "a5338b5e69814d193d06685e9c24a417fe1b94d46e996f87c7788218791901b1",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "sthangarqc/player.qc": {
+     "bytes": 17554,
+     "sha256": "659665c41b4cc226055e037fc9d2b89f9ad3836a2c9a7517e1655ad18338b380",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "sthangarqc/progdefs.h": {
+     "bytes": 2598,
+     "sha256": "99e562ac15081804245e7c7018956f2241cffa00a024a954c97183248bd00ea4",
+     "timestamp": "2000-11-04T16:03:40.000Z"
+    },
+    "sthangarqc/progs.src": {
+     "bytes": 1216,
+     "sha256": "2548097b705b06c1749088b3276305d08d39f49dce2826e4df23a2bb392e01f8",
+     "timestamp": "2018-03-01T21:14:20.000Z"
+    },
+    "sthangarqc/shalrath.qc": {
+     "bytes": 7880,
+     "sha256": "4c53306f4412184ba7bc26b93acbcd5504d922d1056beaca11484665efcff1b7",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "sthangarqc/shambler.qc": {
+     "bytes": 12725,
+     "sha256": "0c50557b8757d8be3a0876564cfa125e4e8389cae1c55c844871aff5f844c342",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "sthangarqc/soldier.qc": {
+     "bytes": 9825,
+     "sha256": "f66da2d85ad5ac42dfe13fd434018e64ca8eddba1e7b3abb747b4577ba072d01",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "sthangarqc/sprites.qc": {
+     "bytes": 450,
+     "sha256": "c00564e7ca0ab70d7891931ff333461ff90aa6052f46e8ebb02f59de6e03787d",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "sthangarqc/subs.qc": {
+     "bytes": 6062,
+     "sha256": "8fa013564dcf7be1df26888fbc304159b29be25ed43c4599333c9d8de809b356",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "sthangarqc/tarbaby.qc": {
+     "bytes": 7116,
+     "sha256": "4968e4ee45f401c5a703a9c687cddbdb2acd80f3ca2bf95c71f4260a977aae71",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "sthangarqc/triggers.qc": {
+     "bytes": 14121,
+     "sha256": "2d35e4bfc2d5450401d2a27580a09abd69cdc8b125b0de29086e65275bb8dd51",
+     "timestamp": "2018-04-23T09:43:14.000Z"
+    },
+    "sthangarqc/weapons.qc": {
+     "bytes": 25227,
+     "sha256": "7f3d2541500506fe8d6d9155f3893667d1c58ff5ac9e8cfd81aa183a6a5fd01c",
+     "timestamp": "1996-09-30T03:08:08.000Z"
+    },
+    "sthangarqc/wizard.qc": {
+     "bytes": 10663,
+     "sha256": "250aa24a63df4d02949abe2cbeee24f9f959d1ecf468c6b3108d0384c7db6d32",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "sthangarqc/world.qc": {
+     "bytes": 11058,
+     "sha256": "85e5fc17f9eb4cbcc702183a148d543b035604471bb83422f1bb1b40639de58f",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "sthangarqc/zombie.qc": {
+     "bytes": 20108,
+     "sha256": "027ec53b0caa6c1c46c1f6156a854c886ab6fcd9c628707ebea1d3ca1c185519",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    }
+   },
    "sha256": "f9e9ecd61b7c026f54ca85cb058d3984f7911624fe5949877e44b87a9bc0607e",
    "timestamp": "2018-05-02T14:14:16.000Z"
   }

--- a/json/by-sha256/8f/8ff07a745ab03f2be24ec6d30e91029c352470c254974dfafdf18d10d9f458b2.json
+++ b/json/by-sha256/8f/8ff07a745ab03f2be24ec6d30e91029c352470c254974dfafdf18d10d9f458b2.json
@@ -7,6 +7,168 @@
  "files": {
   "pak0.pak": {
    "bytes": 4970646,
+   "files": {
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "e70a35b82916d02765d9711cd78877b83662b5c1be2dfdbe3a3d423d7c69b12a"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "d7d310308634b735b418f2d30865833aef4dbeba9fe2e2d0e7c1eb505d6b13f9"
+    },
+    "maps/sof1.bsp": {
+     "bytes": 1385984,
+     "sha256": "349463b73077dfe09f2407c5817938f4faa18426f66aa6525bc6560dcd182399"
+    },
+    "maps/start.bsp": {
+     "bytes": 481552,
+     "sha256": "ae6b81db15f676a8e48351f8183247a0f59777cbd26ad511124a366a258382fc"
+    },
+    "progs.dat": {
+     "bytes": 673220,
+     "sha256": "01e0f7b5828474e762d40c7dff77df5fb03093ef2ba0499f72ea410d3e87791b"
+    },
+    "progs/demon.mdl": {
+     "bytes": 102120,
+     "sha256": "37dd96b970b76913d9ad82d504fb043efebcf84c5d5a3315311642b024473d69"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 34884,
+     "sha256": "17dfedcb8759356102791ade777cb017c5c57c5b81a0689bac6f74c60ce94b3e"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 14076,
+     "sha256": "4a39f6869769e46f4e6e4546c07c1337b526175b1932d8c66a145d72ffa15842"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 14900,
+     "sha256": "ae5dccffc922a576b922c247bf06a5f28ad8369c9904d40e1bccf493533117d8"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 72632,
+     "sha256": "553ccc7f74c9f882571dcf91d7e8a1e4ab65e2848163739547029f52e239f7f6"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "ec61398885df6be67cc4aed9bfde63af8c192229d8ea36dcd580450c668eb88d"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 162036,
+     "sha256": "b9b7fe83234f60f226d47311452df197c37980c786c9300a645ebed1879b24b4"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 133980,
+     "sha256": "9de75307e4d88b461aa1d3a2aa7c03b1c5e8fc5b60ea7acefe43914848873728"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 262696,
+     "sha256": "922856dff9e3388fa0b1d7af49bc76f497e6ee73a4311aaf732cd63345f26efc"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 218680,
+     "sha256": "7d06d081ed4c03f094851cbf4bc6bd0d9f154d2bacd7aabd2af3d9fbe81cb6c1"
+    },
+    "sound/ambience/thunder1.wav": {
+     "bytes": 32168,
+     "sha256": "c02be038d7bb1b269ca0eae99e6ab6d972bc6ce2079fd193150371ef1a9e97c2"
+    },
+    "sound/dog/ddeath.wav": {
+     "bytes": 21317,
+     "sha256": "2a49398424a014fcbee0e4003d49b62aed172f039f79d903f63b39836b6c80b4"
+    },
+    "sound/dog/idle.wav": {
+     "bytes": 10319,
+     "sha256": "3864c49637c10f3d4cc0c3e362c02ba1bc375f7864b8dd5e81236c0114ba7b07"
+    },
+    "sound/misc/amazon.wav": {
+     "bytes": 100068,
+     "sha256": "82ad8f823b55ba0685b3337160f9c7d74865a3cc4815df111a159046a0a64273"
+    },
+    "sound/misc/bird1.wav": {
+     "bytes": 55499,
+     "sha256": "c47cdab2f25a1638115903e7646b075cf14fb0a619bec36038cecfb63890d81b"
+    },
+    "sound/misc/bird2.wav": {
+     "bytes": 11494,
+     "sha256": "4458ed20ffeb67327e9eca82b3995245a2d643fb8e319c9ae82d714039f28280"
+    },
+    "sound/misc/bird3.wav": {
+     "bytes": 33395,
+     "sha256": "801a66898cd1ec51bca8eec82569a2c6f37ee25c436f06cd949e997294464fd9"
+    },
+    "sound/misc/bubbles.wav": {
+     "bytes": 18358,
+     "sha256": "963626e3a7c94501dc35f49366c5f07aaa1b452e606f97733138e6abe84338bf"
+    },
+    "sound/misc/buzzer.wav": {
+     "bytes": 12638,
+     "sha256": "b5cd04c5d98f0aa425f6444a1bb309486a55161a7a592955be28fea51179f4ab"
+    },
+    "sound/misc/crickets.wav": {
+     "bytes": 35470,
+     "sha256": "7f542e8b89675e4c008618111af6eda0d2da53957189c1e5564aa520209b8d0a"
+    },
+    "sound/misc/explo3.wav": {
+     "bytes": 20421,
+     "sha256": "303add67bc345b9d2d5c5ccce8cb0927377c66bb13a80f30bd5313380a801594"
+    },
+    "sound/misc/frog.wav": {
+     "bytes": 6277,
+     "sha256": "74ca28a1db2d3273001a626e14688c32a7a32a55c3df6d588babd6a64b09834f"
+    },
+    "sound/misc/heli.wav": {
+     "bytes": 103196,
+     "sha256": "056d01adca71977fe60eddc850b832e98c14e28be2526bd1bb4628a66d716708"
+    },
+    "sound/misc/helistop.wav": {
+     "bytes": 42957,
+     "sha256": "ead81df106766bc22ee9d2d8d1a6f3861aadd46c849f5428b4b84e7c12ec83bd"
+    },
+    "sound/misc/moan.wav": {
+     "bytes": 30770,
+     "sha256": "f25cea462063c27070d6ff74304b88d1d305dbfa0c9a36d201cdb18c746f0de0"
+    },
+    "sound/misc/monkey.wav": {
+     "bytes": 3270,
+     "sha256": "e5bddfc7306bcb37a262fe4a32d5c403b919efaf9eeafe938ffb13067137d60f"
+    },
+    "sound/misc/parrot.wav": {
+     "bytes": 51202,
+     "sha256": "b9e2e2a00c177051dbbbe776450eb291ba2c57b076b6c0cc5c15eee8e5c32a2a"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 49438,
+     "sha256": "d91434f754543be1ef3d743b6a9c639461fae8198983fa05b1c8af2b1018c2f2"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8077,
+     "sha256": "58a62fd7ffdc4bce9d377454fb25b4b87ded2094fe61055afa54df8623769f8c"
+    },
+    "sound/misc/setitdn.wav": {
+     "bytes": 154769,
+     "sha256": "faf8d3c9e8dd6252b291fe5ec93bfe780b444872adda27657dd64acfb9e7a1e8"
+    },
+    "sound/misc/snore.wav": {
+     "bytes": 128002,
+     "sha256": "283516e548fe03e1aee20e0d1f3a733c0bc8f1ae646319464b4fd88325fe70e8"
+    },
+    "sound/misc/stop.wav": {
+     "bytes": 17780,
+     "sha256": "e5078f98c3c28dff9c2750008b0923c0f7cee1ad34000cbe5679ec5a5ea38110"
+    },
+    "sound/misc/toilet.wav": {
+     "bytes": 36838,
+     "sha256": "33fe477a427abe693cb758f8a6a7f5b59ab0110859735e0f3420b85ab7da7042"
+    },
+    "sound/misc/watch.wav": {
+     "bytes": 212686,
+     "sha256": "165dddaba814bce3839b9ccaebbbdaa559e40f680b2f4cbc9d59bcc9389289be"
+    },
+    "sound/soldier/sattck1.wav": {
+     "bytes": 30413,
+     "sha256": "36d251252367ce80a8547002dd2efef84087100781d4e9947efdd6a4e0f0a342"
+    }
+   },
    "sha256": "ca3de2bc537add96931d6f8c4f2c50373fd1413496d06df3fce4103244a6b6ca",
    "timestamp": "1997-10-19T17:21:48.000Z"
   },

--- a/json/by-sha256/90/905fa6a34e1eb8457287a80900b3b81fb6dac89e738618d66c7ee43bf7ecefa1.json
+++ b/json/by-sha256/90/905fa6a34e1eb8457287a80900b3b81fb6dac89e738618d66c7ee43bf7ecefa1.json
@@ -315,6 +315,356 @@
   },
   "pak0.pak": {
    "bytes": 4227276,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "591744734a43a1563ee0e419fb2464783c70a3245c14e09ff5c3f022418f1e4c"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "1bbe11eff4ef46f43af7bbc7be43c69cf76543ce7fae26931939a541cb8cdae6"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "fc226280c4948249790f00f97dd9b39e912131fc904ec75adb90308ba8763afc"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "9eee444c1db402805bcff09378344c5a048b6c23ff6054edbfff16dd60b76f0d",
    "timestamp": "2021-08-25T15:58:24.000Z"
   },

--- a/json/by-sha256/91/9120e5800b3bd32355c06925e9be2829c8096344168913afe285f60f758860fc.json
+++ b/json/by-sha256/91/9120e5800b3bd32355c06925e9be2829c8096344168913afe285f60f758860fc.json
@@ -7,6 +7,24 @@
  "files": {
   "pak0.PAK": {
    "bytes": 3623932,
+   "files": {
+    "maps/ne_sp04.bsp": {
+     "bytes": 3126112,
+     "sha256": "959e5fc0ec533648cc4985296a1c52a3e05e1b4d269375bbb6f4ad959107c092"
+    },
+    "progs.dat": {
+     "bytes": 417820,
+     "sha256": "6d794f678c9d05d873df172df5c428ac57abea14dce39cf66c569e7610f23ce8"
+    },
+    "sound/trains/lock.wav": {
+     "bytes": 30522,
+     "sha256": "87b4dc7084ed54d67da50b13571567ffc5ee707ebcbd83d82f09abad5b77aeb8"
+    },
+    "sound/trains/release.wav": {
+     "bytes": 49210,
+     "sha256": "1339b779920c9c8f3393b591b339c9b90bb61499c31f4ef66541170f59b87605"
+    }
+   },
    "sha256": "d5e5a1d9136792cbd31681a9c54e6344d96b9b7801ff0f7e9053f5bfeaaf0f95",
    "timestamp": "2002-01-27T15:56:44.000Z"
   }

--- a/json/by-sha256/92/92b11d3749b3b7d0ada1cbf779417d56ccfbfaf24347c91a416c5da91f82d687.json
+++ b/json/by-sha256/92/92b11d3749b3b7d0ada1cbf779417d56ccfbfaf24347c91a416c5da91f82d687.json
@@ -243,6 +243,652 @@
   },
   "snack3/pak0.pak": {
    "bytes": 108357732,
+   "files": {
+    "gfx.wad": {
+     "bytes": 152468,
+     "sha256": "7f605effde46936654b6abe81c5097732b1b6a52c9bcde920acdec1a6b183805"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "24ee03fb65cc5a6dd4ca82c0e8a61e0bb1bee3c3fd2a094985a3377d56bbc359"
+    },
+    "gfx/env/eoe_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "7c728c5c56add4ea3f64bbdc10bbe1966567ed9815ccdf24b4877b540b592b4a"
+    },
+    "gfx/env/eoe_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "138e9386728cdd98935a0c484d5693db2e60375d8d770ad754fe6616906591a1"
+    },
+    "gfx/env/eoe_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "138e9386728cdd98935a0c484d5693db2e60375d8d770ad754fe6616906591a1"
+    },
+    "gfx/env/eoe_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "8552c362ecc4ec21bcaf3c86e93933e05e3d194d623e8f7da9521e0bc038fc19"
+    },
+    "gfx/env/eoe_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "304b2b14fbfecb7cb4de71d34fc3239975e390be6a6385b0391490754f1c8144"
+    },
+    "gfx/env/eoe_up.tga": {
+     "bytes": 3145772,
+     "sha256": "138e9386728cdd98935a0c484d5693db2e60375d8d770ad754fe6616906591a1"
+    },
+    "gfx/env/mak_cloudysky6_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "90e0d51517f66432de89842d3de48d6067011618070e3c790e3c94b454e9daf5"
+    },
+    "gfx/env/mak_cloudysky6_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "88f9a2cd938dc9cf206662f244c13c3686adacfaff8f320885dfccae70595189"
+    },
+    "gfx/env/mak_cloudysky6_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "92abd74bea6778be392427a8d55cbdd8dd026ff03d3e4831238b0d8b085bc726"
+    },
+    "gfx/env/mak_cloudysky6_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "5d11072205aa28e8868447280e2034aa999cb5868b05b371d95e13607145ca8a"
+    },
+    "gfx/env/mak_cloudysky6_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "6bdef037cb529cdfa34fac4eef7389684abf772659a360ce770c0dec674a669e"
+    },
+    "gfx/env/mak_cloudysky6_up.tga": {
+     "bytes": 3145772,
+     "sha256": "0f5e6cff7729ab24d193582d987ed97adbe5b158260ef7ceabde6c50ceac46a9"
+    },
+    "gfx/env/mak_halloween_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "ac4b145aafcdc45a3667d7417dc24b14a2ccc2e1d534fb5604e26678c6d81edc"
+    },
+    "gfx/env/mak_halloween_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "2f8812a12c9604affeb66ebc784185a27e778df068863c760d4ac58aa77f0ac1"
+    },
+    "gfx/env/mak_halloween_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "945bbbcaa7ac7f6c51e72fbfc17ee09dd405a9a317562369d408339be25b7905"
+    },
+    "gfx/env/mak_halloween_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "5bbbc721197e2cf27d9888c0f37d7150804df95d0026955042c457d707842094"
+    },
+    "gfx/env/mak_halloween_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "26bef4cacad86e1b021540d1e87ab9e5ac6a280ab11657eec290cc88acd2c601"
+    },
+    "gfx/env/mak_halloween_up.tga": {
+     "bytes": 3145746,
+     "sha256": "f1a1931e846ed195ae73e9690a4e8551e2450810a7f688bbe4843863d60aeb1e"
+    },
+    "gfx/env/mak_nightsky1_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "4078d021f89972ed7d11c41a0cdf3b053d7161cd142a8a8946101d86614beead"
+    },
+    "gfx/env/mak_nightsky1_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "41e728c4386d5461371933f51bb424a1c40b2882aa496db8f390976d21630f98"
+    },
+    "gfx/env/mak_nightsky1_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "544c88434228344c3c5087c13a0f27e06843312695565a48a73f819484db7741"
+    },
+    "gfx/env/mak_nightsky1_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "f4e5527e363c0a714300eaced314103208859bb75f74f57adb153114a9ba2051"
+    },
+    "gfx/env/mak_nightsky1_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "d3dd339652fdb82370730c5a18765c34858326d49b2cf3b82d1a429fcc9543c5"
+    },
+    "gfx/env/mak_nightsky1_up.tga": {
+     "bytes": 3145772,
+     "sha256": "17a39daadeed06e143b71808952ba84d7c608eebed78541aa4882367b4a83825"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "31c4858fe496187dc1bac21c02aff8cf83cbc51e0b4ee5738d6118c328b299d2"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "ed0f79285d93d0ef35644ecaf9ab36f3b2c6ffd223c577b25fff2ea17f90080d"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "e9c210ab88f6e98965cd2f8470f084e32ef15b3ad3912cb1e9eb0363c6204eb7"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b56880e2f720a89dcd055f5278abb21a21514322d4a31b77b46c8b509b9f3be3"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "89c3ac6fd91cdcf15c20b0d15b4c01c153e0a820c660f9222b5c8f63d43af5b2"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "8b83ffaf6b5309d371f0107ebb1340a8a09cd1a52c6a5581b7c9c4a7afcefa77"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "music/track37.mp3": {
+     "bytes": 3332956,
+     "sha256": "e75173c4c5771a20ec5cee25678780ac19a5712dafce30dbf6ec2c8622f80e7d"
+    },
+    "music/track69.ogg": {
+     "bytes": 5151443,
+     "sha256": "388301b5077748e78d2ebdeb2edcd0d92cab408234424f3220d9d15c3e43e816"
+    },
+    "music/track80.mp3": {
+     "bytes": 8445354,
+     "sha256": "f4acc8e1216aa8e2a8b4ad1d57cfccca42021990f18a3f4127537b0c476bb5e3"
+    },
+    "music/track99.ogg": {
+     "bytes": 2390326,
+     "sha256": "420ff4d7f63eb2ad944a0b40a60863e43bc8f2870cc67a7168ae4f3f109e976c"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/debris1.mdl": {
+     "bytes": 33768,
+     "sha256": "3498dffa0c3522b011a76ada880dfae64de3ca1583c94474e1e07adbc220d981"
+    },
+    "progs/debris2.mdl": {
+     "bytes": 33944,
+     "sha256": "d6d535173bb4a3a2d469be9c63bf36a01b1e2b80dd6a71636d20178d813e443c"
+    },
+    "progs/debris3.mdl": {
+     "bytes": 34136,
+     "sha256": "d6b0a2b6353c4462196d2af116652b47d464a7bc1f161509aa8ee5dbe859f98b"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 17812,
+     "sha256": "74cd41d8d5a67570cdaca34a08e9868f3476d8c4ac4a645cfaf9e91cf778c793"
+    },
+    "progs/g_fx.mdl": {
+     "bytes": 32260,
+     "sha256": "ac99d4e641af0bb1495ed38ba9f3a7c1195bda19e5cf0d3a68f04defe6178ab8"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 87508,
+     "sha256": "bab2c7825771e276474ebe4ff4acb59460c4f36ae5032b939ed68683a3d6ea69"
+    },
+    "progs/g_shot3.mdl": {
+     "bytes": 84916,
+     "sha256": "30137048433aa82f07a97a114135847dd81c5397abc5b7bcfe709be2de34aaa4"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 61251,
+     "sha256": "dec5afe666eba8db6e32d7535fffa3d0e4ed9344ba107b73418526ebebac574b"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "4f5ca2553db07d5cc93987b11e9f9ff054d51b96488e2bcc35c9f03ed3040d42"
+    },
+    "progs/h_zombnm.mdl": {
+     "bytes": 3220,
+     "sha256": "9c1620004701df1a560bff33375ab3f925fa81671b036188cde9f0687552a2c5"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "b00951cd72bb5fb03c19a1d60943162652fe149b9ee60fd2e630a076d52956fb"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/k_spike2.mdl": {
+     "bytes": 17716,
+     "sha256": "e456eb93934dab43a83305988db82ab1954e66491c256fad3ef1451d0ecf97c2"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 36496,
+     "sha256": "a001c379917628354adfb62b698856b33f4eea5f22e7d8e232e640faf15d8465"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 4318,
+     "sha256": "549ef04273b73ba0affd6e4370760e39507ee269d11aedf18f48c1f83ba76079"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 6100,
+     "sha256": "bcc312d13b1f5b93657d9bc771ce02f34ccda6ac6a20eb9dc98bcb5c9a7e3902"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/proj_impalespike.mdl": {
+     "bytes": 70324,
+     "sha256": "7b3c5540379e5efbc950e7ec08b0126f9426ee14c91abc41f8e41f0162e1cc85"
+    },
+    "progs/pumpkin_extra.mdl": {
+     "bytes": 65508,
+     "sha256": "553b1890bfa82d1853131f4fad2e90e7f0eb596c9d025c123c43b0c299a287f6"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133936,
+     "sha256": "e2d6b9de9b879327f72d97ef3c07e0b7e35cf844747208f6e615015be84157e5"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "f414f3fd07b0278bd59dd90954770f81a5ffad7f46af5f5d0abee124905dcc17"
+    },
+    "progs/spike.mdl": {
+     "bytes": 65940,
+     "sha256": "340c228c008dc9fad1fa32f632dd2448313efb6b5d98b18547cf1301c2176c5f"
+    },
+    "progs/str_fern_large.mdl": {
+     "bytes": 119312,
+     "sha256": "690274e94a48a0999a3018a9b0fa0a5b768673d8b2787ae6ea573a95f4fbec1c"
+    },
+    "progs/str_fern_small.mdl": {
+     "bytes": 91312,
+     "sha256": "ac706b08c4bd68e01694bd1b53dbd1846f0ec6cc4517901ec6d42d1b6c78e614"
+    },
+    "progs/str_lantern_blu.mdl": {
+     "bytes": 326400,
+     "sha256": "40f3aed791281e998a8462ec037195fa643b8bcbed26aa9ab34da8851966ceb6"
+    },
+    "progs/str_lantern_org.mdl": {
+     "bytes": 326400,
+     "sha256": "05cf6110ca5049f18fc50d90b85888e14356dbfe897908ba0548e2013ba6f34d"
+    },
+    "progs/str_lantern_red.mdl": {
+     "bytes": 326400,
+     "sha256": "6e76f856b143baecc35471956b9b9f83e13a22352217bacdd1018f3697eced3a"
+    },
+    "progs/str_lantern_shell.mdl": {
+     "bytes": 301856,
+     "sha256": "8946c1c3b86a14f9ae13ca646dedcadf9ef2c5045726e5b166916dd44e6acecd"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 294892,
+     "sha256": "ff1779d22bee11d56753098d4a91b47270f766aff84c61fbbecb38ef6d5389b4"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 279216,
+     "sha256": "00107a1d65222382559bec706a000c4abd771d666fca55a5be14b5c3029c2855"
+    },
+    "progs/v_shot3.mdl": {
+     "bytes": 152352,
+     "sha256": "2c405838c0c86d8818ae61d636b4a714f79fff0e51bbfe460711e89ae43ef63c"
+    },
+    "progs/w_spike2.mdl": {
+     "bytes": 5816,
+     "sha256": "b07808c532059133c31be2ed2bc4e9bb9b01b75d5d23401768058cacc3192068"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 74976,
+     "sha256": "545d70abb8d44be8e12da24a3d09fb56f87ff960c41963148682fbbd9d47e417"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 218680,
+     "sha256": "6782603eadacc7cb4bd09c11d3b6326e0d2e69205f724fe2f6e533ee398f5a16"
+    },
+    "progs/zombienm.mdl": {
+     "bytes": 224900,
+     "sha256": "f4d1ce9667ebb36088bfb59a12c9a8d93c1aefa36515b51f388cffec5132f5b2"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 83982,
+     "sha256": "4b0d8db882ab1c9fc2109effeaf125ec46fb23a91ac2242201103e0d3da96944"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/grue/waterclose_loop.wav": {
+     "bytes": 246506,
+     "sha256": "f2b7d2f4070b74600613fbcce8a2f617acfe75ffc6a553292eaead803fc4e866"
+    },
+    "sound/halloween/crickets_loop.wav": {
+     "bytes": 1920154,
+     "sha256": "e6ccf14c43b54c43af391c5719bc7c2d69f249dbac2b571ab4e5c6cc4df0ffde"
+    },
+    "sound/halloween/wind_loop.wav": {
+     "bytes": 2634272,
+     "sha256": "0630b7f1058b8ef507f07214711e0dc102262d5c126a06dfd438104118314950"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 34604,
+     "sha256": "7397e87b812f202940d90290736647ff830ca232878b6a51552bb7775ec12d1e"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 63810,
+     "sha256": "7e17fe56cb624073453a21b5689b90396df46742c1674d9068d6d9fec4bd7b0b"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    },
+    "sound/weapons/penfire.wav": {
+     "bytes": 46536,
+     "sha256": "d801c50e09f3bbf41459a6621fe245083bae4a7a552c5f4ad83fd4b704e20d78"
+    },
+    "sound/weapons/pierce1.wav": {
+     "bytes": 41882,
+     "sha256": "acc05436dd355dc2a515d8a52ebb913ce2c0d8e3b5cbff1425747fbd6a920e2f"
+    },
+    "sound/weapons/pierce2.wav": {
+     "bytes": 33250,
+     "sha256": "c735653bb696753aaea7c637449fd4ca36dad7d1d82af0ddf40eb692f91603d1"
+    },
+    "sound/weapons/pierce3.wav": {
+     "bytes": 34914,
+     "sha256": "2cc877f495467d10e86d22defc8b927f4152006231a579ebcbc70704e058f0a7"
+    },
+    "sound/weapons/shotgn3.wav": {
+     "bytes": 103668,
+     "sha256": "eab5689ac7d35c4361fe999dbba5b58c3bf1a01c2830e988f65c59fdf05d9fb8"
+    },
+    "sound/weapons/stick1.wav": {
+     "bytes": 27786,
+     "sha256": "81476d248b6beb8db6daec909de943886053a3f6e4b3b29bab192ad5957fe73a"
+    },
+    "sound/zombie/z_res.wav": {
+     "bytes": 23266,
+     "sha256": "10b2962ce2817fa8a250811313307cf0dfa93ad5257a669452fe3fc834ced976"
+    }
+   },
    "sha256": "2f6b5468f8fdd73553ada6c971dbd13a46cbde95e1995554db0507e4ce54d788",
    "timestamp": "2023-10-31T21:33:10.000Z"
   },

--- a/json/by-sha256/94/9409c0debed303683964af869690583b53c2f0376471b3eed655b65e5f29b673.json
+++ b/json/by-sha256/94/9409c0debed303683964af869690583b53c2f0376471b3eed655b65e5f29b673.json
@@ -7,21 +7,857 @@
  "files": {
   "pak0.PAK": {
    "bytes": 13969201,
+   "files": {
+    "demo1.dem": {
+     "bytes": 66479,
+     "sha256": "bf81912bf0655f78164c56a72eab980b912a93268c5bd8b65e7b33e53e4b741a"
+    },
+    "demo2.dem": {
+     "bytes": 1141822,
+     "sha256": "5b448d504a7476a7f96d8c175b78fbf4897c5d7b852d85587bd521b1710ff26b"
+    },
+    "demo3.dem": {
+     "bytes": 1224398,
+     "sha256": "0cb566081b29e13f48999fe593fe13f07e866fb281da75d60e23471b1a84f618"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "e8bafd0bcd003efb3c797025e9a8b26769e6facf7202673fcec23fe8b1350528"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 8820,
+     "sha256": "74aa7b2f080562dae303a3601872df9a684c5b52e71c8fed2460bbb47ff190c7"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "maps/b_explob.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "progs.dat": {
+     "bytes": 907352,
+     "sha256": "28fddb3fe5c787c77c0cf7231bbd5295355e8e45bf93db44850c74edf0b65026"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 229796,
+     "sha256": "8d3fa98f67545704879cfda74eef37dba73a02a1f5b32741857590e15ba3f165"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/corpse.mdl": {
+     "bytes": 122680,
+     "sha256": "a4c379506e20fb47a886720881dd73b66e87e6e34f98be8244879c46e4fe4a68"
+    },
+    "progs/demon.mdl": {
+     "bytes": 218164,
+     "sha256": "71ee3cb490cec06db7e4f4b35a123d604a7179d41457a4ddc195fd6f7506628c"
+    },
+    "progs/dog.mdl": {
+     "bytes": 198788,
+     "sha256": "e6bc7b91e52139e3769ff52e0d8c06b441defe0e7dbc70e6f06e4a6a362e3768"
+    },
+    "progs/draco.mdl": {
+     "bytes": 243029,
+     "sha256": "e1b41a2008b4d273e088330a260ca71593eba3764299d4a7d9ce5416e91e80aa"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 346940,
+     "sha256": "9332833f2c6206073b132b5b097e3ccec8f2572e3d16cd52797c46b169c5d6d8"
+    },
+    "progs/dragon2.mdl": {
+     "bytes": 417963,
+     "sha256": "c369cbb601ad4dfb33edb40b526df0d9bd7487a754aba61be9f54bcbfc75e08e"
+    },
+    "progs/dragon3.mdl": {
+     "bytes": 192313,
+     "sha256": "83e4792c9276bf6be9e359e3ff5076f3926aee9372cbf964121318116a05320b"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 160688,
+     "sha256": "df1991fc90a4176013b374b75acd262b34ee4ca2a88f19c19b99eb2cd08c6810"
+    },
+    "progs/fbolt2.mdl": {
+     "bytes": 11860,
+     "sha256": "2d776e4acdf20cd117f3f4d6be3647fb9d0e117756069cbfc52ece716fdbb251"
+    },
+    "progs/finale.mdl": {
+     "bytes": 78699,
+     "sha256": "62d4989ec7b55ef589a3cd984ecd0bda6956749cfc82f28ddac4cb96a470c9f2"
+    },
+    "progs/fragwiz.mdl": {
+     "bytes": 221076,
+     "sha256": "4301fe35d26baccb59526a6885335cd033b6c8c0271ffe36f3d25fd0de1cf57a"
+    },
+    "progs/h_trog.mdl": {
+     "bytes": 28778,
+     "sha256": "13302ec9240863651316e87733455f5fb5753f35278d8600bc9f6961e11b0238"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 14804,
+     "sha256": "a4e5899509bc262decc152a6756df8e457d7e6bcf49886cda55a7d62d5acdf23"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 370708,
+     "sha256": "da535fc9afe3ee210d3b6608539f2232eced9229390830437a3090014d739113"
+    },
+    "progs/hlord.mdl": {
+     "bytes": 323272,
+     "sha256": "01c027ad89a99fc7cc1ae3227c407ff00deb52c1d959ba32987160c0ea6fcd73"
+    },
+    "progs/horn.mdl": {
+     "bytes": 324120,
+     "sha256": "bd6a698f4fd17586831329875d09924151042714788c8424f27f04ba6cc01d14"
+    },
+    "progs/ice.mdl": {
+     "bytes": 8952,
+     "sha256": "67c2addf03913285851ca1f1c9764e11fb8a41a0b7b76744f04c55921c97dd79"
+    },
+    "progs/knight.mdl": {
+     "bytes": 153400,
+     "sha256": "26576f139d258b3c236faa6552d8ba09ef6e14480d4a2e2dc9e3e2c4df5177b6"
+    },
+    "progs/lwing.mdl": {
+     "bytes": 34587,
+     "sha256": "a94e3b5fe5dc4b940e860906f94d45a20869f0b9178ed5b0f8a5cd81691d4e65"
+    },
+    "progs/necro.mdl": {
+     "bytes": 475588,
+     "sha256": "c49fc9ac936de6780feaf6369a7b78314d062de65e29c67e4967e00e0897b9bf"
+    },
+    "progs/player.mdl": {
+     "bytes": 421564,
+     "sha256": "9467518543f05373d068530cb20fa6432a1613f42b9e40cd1c7495c8d956fcb5"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 17204,
+     "sha256": "0dab5b94c60d92d55df3e44a8d8ea2dc0f949e98897a6525ee0be3f49a019b08"
+    },
+    "progs/rwing.mdl": {
+     "bytes": 39287,
+     "sha256": "d2a579b35c29065cfdf735bee5728d14cdb076d9328d945b709f4882a422ad54"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 121992,
+     "sha256": "db0005cd649bdcdfa52abf75b81198a84e3a8e2afb93f9bad86e4776df790078"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 133980,
+     "sha256": "de7630106195265ab9818da4b554bba28fcaddc785f03a51713fd1303c7d80ba"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 146288,
+     "sha256": "9ed515e86f32cea82b790dd769f81d5e72ef48fdaf22b47e90937dfd638a699a"
+    },
+    "progs/splint1.mdl": {
+     "bytes": 1684,
+     "sha256": "0a64f602cccf2b243b7a4ef9294ab03e25c6e61fd738e8217b3e83a0bd05f171"
+    },
+    "progs/splint2.mdl": {
+     "bytes": 1748,
+     "sha256": "79c9cb57e646d9384daec38e0b06c4b7f10d2883a4e5c8373840901240b6026d"
+    },
+    "progs/tail.mdl": {
+     "bytes": 10571,
+     "sha256": "6c995018ce82218702ec196a50d36ecbdb939d56401f9c33a51e80906795e34b"
+    },
+    "progs/tree.mdl": {
+     "bytes": 126509,
+     "sha256": "7705f8b4e337bd370dbd0392d33da437f08768723e6d43725ddbb07ac3662b9b"
+    },
+    "progs/tree2.mdl": {
+     "bytes": 112335,
+     "sha256": "82a16b3ce4e9370f0ff4231506da2cdd53d0596193862747f84a3f04ec481d2a"
+    },
+    "progs/trogball.mdl": {
+     "bytes": 136671,
+     "sha256": "e0f0ac46b0173ddf761210d34334dc1b07196f0b8941d6027a5831355f7bd0e8"
+    },
+    "progs/troglod.mdl": {
+     "bytes": 98400,
+     "sha256": "48bb6420c135f3348c944fad00fb428b1403c697895e2b4cd40cbd9cf4fc7dd3"
+    },
+    "progs/v_axe(2).mdl": {
+     "bytes": 176671,
+     "sha256": "82e6c85b2f0cee3b980fe5d14ed0d3d016fb0521f55c9f18cc52bf5e9f067c2c"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 176671,
+     "sha256": "a55464b720852595bcee42bf7beb1bd4eefb37856bd58ad2e29c7e14d8aca8db"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 76043,
+     "sha256": "ed80eddf26e304083cd1a08349a900b9e0b4c9c91ea4e9d49d75a838b916916d"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 126456,
+     "sha256": "73e48f41199d096aedb5c05e6482c033b4815e5ba1cb4140a398dae6ba034464"
+    },
+    "sound/ambience/amb21.wav": {
+     "bytes": 80716,
+     "sha256": "d664ea08d9df7e7dd135eb0726c1bc142878dcc53d13564dd3dcc5562180201a"
+    },
+    "sound/ambience/amb22.wav": {
+     "bytes": 92716,
+     "sha256": "f444289984b285a1497f55e566fbbf1896a04fa38e291efaa3ec1a0720204811"
+    },
+    "sound/ambience/amb23.wav": {
+     "bytes": 40180,
+     "sha256": "e451997ac7f37d08bd8434d708f45ee2967693317684b947ce511c9df84828b3"
+    },
+    "sound/ambience/amb24.wav": {
+     "bytes": 42282,
+     "sha256": "ead78c8507a7a6a7d6c61e913a2319964f6a8f70b5f7f720c162725edd9cd5aa"
+    },
+    "sound/ambience/current1.wav": {
+     "bytes": 50906,
+     "sha256": "dabe357d48586dccb8e1ed18c49828797c9f7a8c02c7a588ddc76a62c9b1d3e4"
+    },
+    "sound/ambience/drip_amb.wav": {
+     "bytes": 105444,
+     "sha256": "b282bc6082754011ee21a82aedb490a856c0f694f57991992296554c13149b02"
+    },
+    "sound/ambience/lava1.pk": {
+     "bytes": 5624,
+     "sha256": "6436f53169f2c16fcc7055ce2e6d5cf2ca64f6f94efef2e276d10c51382517ed"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 177840,
+     "sha256": "9daec0732dcc821670b8910a1371153e3829e604b6957bf95931bea416af6074"
+    },
+    "sound/ambience/mov_watr.wav": {
+     "bytes": 44432,
+     "sha256": "9d6721844fd5559ab4f53902e70ad9789a90710dde082d222bd814a36c00ab67"
+    },
+    "sound/ambience/spark2.wav": {
+     "bytes": 61640,
+     "sha256": "7eb18b00cd5e7913fea7a85ec5b1db159d1d001d24d4f687bfdb5685cb163c8e"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 106286,
+     "sha256": "056f37dfd1d5f4eba1d1911245dc0930bb0c46a84d72d867a286e5a9540248a0"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 87710,
+     "sha256": "2bb46f7c8f70fd28f0ca47b294824bcca7689047291b6c5259eebe76ad6aecfa"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 140630,
+     "sha256": "5a4dccd168cbd9f759ac468d7aa879dbcdbe5637e0fd0521f641ba1d60f61817"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 28798,
+     "sha256": "f66c76f07eef275e904fcc76d7ca9fc2011f3de8c61ce0b3ad035464beb7a86c"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 110578,
+     "sha256": "c3e1ccb091b9d8a06b83530b5e29b9f26f5ad8b9dcd082f3da976c3d44944b87"
+    },
+    "sound/axeman/adeath.wav": {
+     "bytes": 11714,
+     "sha256": "c6d2e6a1107eddcb49ca41776da1c7f8a3b27766b66dbf4bd9186fba2780cb2c"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/apain.wav": {
+     "bytes": 3302,
+     "sha256": "788466ee8cc368bcac8b07c4eeca5509ccddc30addf5a322b31a605d90bf0392"
+    },
+    "sound/axeman/asight.wav": {
+     "bytes": 8528,
+     "sha256": "d5d1a9125b9a015186d6d5e9fbd9f9d9db3fb220bdf9139f5aa73b9019d37126"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/bishop/conjur2.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/bishop/conjure.wav": {
+     "bytes": 54627,
+     "sha256": "532d4b7d5db6a654aa73dfe18fa0f6a71623acfd804a848f106b0af699022bc4"
+    },
+    "sound/bishop/journey.wav": {
+     "bytes": 42051,
+     "sha256": "0995e55661447c53c3a36ae4552ea2e0bb7ec8b178bf52cdabe9d28b4deaa50c"
+    },
+    "sound/bishop/rip.wav": {
+     "bytes": 31906,
+     "sha256": "7070871da7ec08da6260a65f1a98ed1bf9682b1c95c51cea262a4b88a63fb6ca"
+    },
+    "sound/bishop/rot.wav": {
+     "bytes": 22463,
+     "sha256": "866b836874ba611d70675e5e3b83eac059c927bef0e0d1396f2183ea01bcc203"
+    },
+    "sound/bishop/skull.wav": {
+     "bytes": 34293,
+     "sha256": "48836a4d60ed8962ed0f11bffdcca95a200645e3b2cfa49a598d6392e10dc153"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 18358,
+     "sha256": "645baa1cccaf1dfbcd628d17fd8ea290f42f1bc40903e26c79a536a6d1528a2a"
+    },
+    "sound/dragon/death2.wav": {
+     "bytes": 16944,
+     "sha256": "0fe255bd36c64acf75a53b97851b995517e70468b3818ff0ccecc4c7be5fc055"
+    },
+    "sound/dragon/eat.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/dragon/eathead.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/fly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/freeze.wav": {
+     "bytes": 20619,
+     "sha256": "48689ba550c116dd8b10a138bc0f78eb6f169d6828a49aaafe12f807930eb934"
+    },
+    "sound/dragon/ice.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/icehit.wav": {
+     "bytes": 8000,
+     "sha256": "03f62f26b9dacbb0e23e328a106620bdc8eff916816bcc9a2045d5b983527b5f"
+    },
+    "sound/dragon/idle.wav": {
+     "bytes": 12252,
+     "sha256": "161fccc2acb1040d7dcad116f18eb795cc03f4d96ee8a94ba37440cde33e6f24"
+    },
+    "sound/dragon/idle2.wav": {
+     "bytes": 13848,
+     "sha256": "e71858c4de3e9ddcad1cba4ec0a6f5ec437b06c813b263ec73f853846d15a984"
+    },
+    "sound/dragon/idlefly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/niteact.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/dragon/niteact2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/dragon/nitepain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 8376,
+     "sha256": "5c41f639d3d59cb12cf8c37f2f80279ed4268ce9afadd7f36d26b4fa40664ada"
+    },
+    "sound/dragon/pain2.wav": {
+     "bytes": 6496,
+     "sha256": "0017ddb63a5dc282982c7459099c810d7c6d9bc3ecb9acef5b5228795a92cc7d"
+    },
+    "sound/dragon/shatter.wav": {
+     "bytes": 20899,
+     "sha256": "31ddbef0dc746eabea23cd7cd2fb97a1f949a014b664630d7f04e6c237aafc03"
+    },
+    "sound/dragon/sight.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/sight2.wav": {
+     "bytes": 15205,
+     "sha256": "197238a35261e6792c40a4da38ba7b3827116ac1af5f143e092768346605b470"
+    },
+    "sound/dragon/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/spit.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/thunder.wav": {
+     "bytes": 14764,
+     "sha256": "b30e18bbc0a12db2032fa95d5d0504ea63eaa13b3bea34e3b42ec59f3ca4d815"
+    },
+    "sound/enforcer/e_arrow.wav": {
+     "bytes": 9458,
+     "sha256": "10e4bef745e55fddd004ea78d24edb9d3d9edc1ce3053c377be07be27a4da144"
+    },
+    "sound/enforcer/e_death.wav": {
+     "bytes": 10280,
+     "sha256": "9cc07020579d50185ea401835e41edbd1c8f007065e39a6306c7aab4f32e7781"
+    },
+    "sound/enforcer/e_idle.wav": {
+     "bytes": 9242,
+     "sha256": "5850c885e59ef04ae90be0579dd6f6b7cc26c282045ccb163dab2c9e19fea704"
+    },
+    "sound/enforcer/e_pain1.wav": {
+     "bytes": 7898,
+     "sha256": "ad1f3b63b4ae35e4bfe010447bbd18bb85cd2bbf966ea7e1370afb0e924e699c"
+    },
+    "sound/enforcer/e_sight1.wav": {
+     "bytes": 19356,
+     "sha256": "c9182325cacd9734bfedd48cb5d8076d5823b7a94baa40d32b02de9504474b48"
+    },
+    "sound/enforcer/e_sight2.wav": {
+     "bytes": 8526,
+     "sha256": "796b2f9f0a1c20d672382c6681e9a6ea200fee2cfcacb5b3d3faa72c8e2537d4"
+    },
+    "sound/enforcer/e_sight3.wav": {
+     "bytes": 8668,
+     "sha256": "c0a60baf2b9918a6df5fc32cd8b58c9fa7cfed923a4cb21c841f04f7a544782e"
+    },
+    "sound/fwiz/dsbospit.wav": {
+     "bytes": 43718,
+     "sha256": "e78640cf0bf9d1c22f489a01358385555acd40e17e7641f80c69aceb48dcbc18"
+    },
+    "sound/fwiz/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/fwiz/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/fwiz/fwiz_d1.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/fwiz/fwiz_i1.wav": {
+     "bytes": 21194,
+     "sha256": "08454d31d601d329fd9ebed7d16a78bd64efdd6c36741f68602537b990099f9e"
+    },
+    "sound/fwiz/fwiz_i2.wav": {
+     "bytes": 17618,
+     "sha256": "c61c969fb71f68d2de2b9e0a895eb3147183cdc98acb2b9f1abbff0e8e6ac4b5"
+    },
+    "sound/fwiz/fwiz_i3.wav": {
+     "bytes": 12252,
+     "sha256": "a94fdd14816c001bdbc135207a9fa8486d4e36d668c68ab94b3faf087bdd9115"
+    },
+    "sound/fwiz/fwiz_p1.wav": {
+     "bytes": 19412,
+     "sha256": "f37e247a9e1436e4a86b78fe71e1ea6da43323e60943e86784ac87fc4393333b"
+    },
+    "sound/fwiz/fwiz_s1.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hknight/death1.wav": {
+     "bytes": 15468,
+     "sha256": "b0e9cfdd68223d49820d03c2f8e5f59ab94e0f284d6865f492ae1a9d4fb13473"
+    },
+    "sound/hknight/pain1.wav": {
+     "bytes": 14568,
+     "sha256": "a069f8260f241acecc313dd0d2e688763052cf65c32597c5779d4776497fd6fd"
+    },
+    "sound/hknight/sboom.wav": {
+     "bytes": 56376,
+     "sha256": "1df051b49aaec9b19e1f49348aaf6d9c19aad3e4591c12b18c4fcbf3c0a73218"
+    },
+    "sound/hknight/sboom2.wav": {
+     "bytes": 14764,
+     "sha256": "b30e18bbc0a12db2032fa95d5d0504ea63eaa13b3bea34e3b42ec59f3ca4d815"
+    },
+    "sound/knight/kdeath.wav": {
+     "bytes": 17854,
+     "sha256": "b712871a7316df7f6341719d488d67e65344f20d8561c97ae3115dde67cf0bfe"
+    },
+    "sound/knight/khurt.wav": {
+     "bytes": 7198,
+     "sha256": "634a88cf26b4de688bed392cf108d5468749f212ce67015c71baa942e8e88502"
+    },
+    "sound/lord/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/lord/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/lord/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/lord/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/lord/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/misc/decomp.wav": {
+     "bytes": 24572,
+     "sha256": "ef3bf26024ff206831ebfe727c5306ad79cdca017167978a630a8d1f07e4f733"
+    },
+    "sound/misc/kmtrain.wav": {
+     "bytes": 78728,
+     "sha256": "b6c67ea0dd00b9ab7959a6e4e3b285af248b8c55119ad5b67e58c4f7b6cfa69b"
+    },
+    "sound/misc/kmtrain2.wav": {
+     "bytes": 8416,
+     "sha256": "0ae9632910accf22527175637c73474d33731dd6b1b76f26b2d1a8b732b7f585"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/met2wd.wav": {
+     "bytes": 3968,
+     "sha256": "a3ce3e10b609f7ae28fc6f39f1f5d55a7c99a41143fb161de7e4e47b7f40f100"
+    },
+    "sound/misc/pkdream.wav": {
+     "bytes": 154898,
+     "sha256": "df8857901002ce9dde3c558743c94967db11cae4af3d9a0cdc00c8cc09e6a910"
+    },
+    "sound/misc/rublexp(2).wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/rublexp.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/secret.wav": {
+     "bytes": 87440,
+     "sha256": "36e9d9617a14daefd510e72308b9e85718a473e2b25a06b66026d463d6bbb519"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/woodbrk.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/ra/1.wav": {
+     "bytes": 7098,
+     "sha256": "6f41307a1d8a57f67917520d9c517df7b5e403f6e4f27b8c4b464ae1a57a4945"
+    },
+    "sound/ra/2.wav": {
+     "bytes": 6138,
+     "sha256": "6db176165cca16a7bd0538b77cf5dc6a68343ce13be3c5e716b61c7e5fc8840f"
+    },
+    "sound/ra/3.wav": {
+     "bytes": 8298,
+     "sha256": "bb0395f548fff802c76a113a521f0fc7a31029f7c701cd4ac4c6b954452286f3"
+    },
+    "sound/ra/fight.wav": {
+     "bytes": 10218,
+     "sha256": "69b9e0165290de5760a4ade9cba2b412d2a8f5777ece37f1f80a82e6cdf2b979"
+    },
+    "sound/random/thump/thump_1.wav": {
+     "bytes": 17013,
+     "sha256": "6aaee6ee956e9244265227e67fc4ab824b2d2612738edf8905945110cf2a755f"
+    },
+    "sound/random/thump/thump_2.wav": {
+     "bytes": 15660,
+     "sha256": "defb723191cd6d20024c9a8699d7673958512fb0437aa844347883cc8a50dd05"
+    },
+    "sound/random/thump/thump_3.wav": {
+     "bytes": 14523,
+     "sha256": "ee06b736825729a1dba77a62f3c9f7c8771ad5a8481b42f5af3b35755bfacd18"
+    },
+    "sound/random/thump/thump_4.wav": {
+     "bytes": 16877,
+     "sha256": "f0b02c1e1173f484a7b622598df6f18ffcebe0a9711c96ca0804d3e0d5ffa821"
+    },
+    "sound/random/thump/thump_5.wav": {
+     "bytes": 12775,
+     "sha256": "2373758e7bc591df02a09dc35d5f4b2a1cab2ce1e150121665e3797e1fb14d03"
+    },
+    "sound/random/thump/thump_6.wav": {
+     "bytes": 21820,
+     "sha256": "77ad075668ba72853c2615eab006042279e1a88dff8ca8fd286d291bb6b789eb"
+    },
+    "sound/random/thump/thump_7.wav": {
+     "bytes": 10836,
+     "sha256": "f7fd6a4ade0a8dba076304e1454a41da2bb770f9a34dd94b1de3ff1a361c6cf9"
+    },
+    "sound/random/thump/thump_8.wav": {
+     "bytes": 13386,
+     "sha256": "75ccfea9a0728abd0857df8630d1f12d02f43b6d9fcc5588848336420a050215"
+    },
+    "sound/random/wind_1.wav": {
+     "bytes": 36758,
+     "sha256": "219f0637ec3e1e86ae0f8c63f12567f50806e4c3786f7e8807da5313f9d63ff8"
+    },
+    "sound/random/wind_2.wav": {
+     "bytes": 108304,
+     "sha256": "c655fcd037be380d8313f13d4743ff4ab17300df79ab5801dffdafdb6a95268e"
+    },
+    "sound/random/wind_3.wav": {
+     "bytes": 121514,
+     "sha256": "e055a33413cbb5872b8df2095bdf89ef1b8dc2b3fd218782facc506d19f336f2"
+    },
+    "sound/random/wind_4.wav": {
+     "bytes": 155492,
+     "sha256": "582fe3b2019b052f563ef2c0c41045b3068b8f0ee8282be4c9db1759e93f8079"
+    },
+    "sound/random/wind_5.wav": {
+     "bytes": 22188,
+     "sha256": "27a7d6eae7ea84a7cee3baf45e4e3debaa0532610a05dae3126601870e658bad"
+    },
+    "sound/shade/echo.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/shade/echo2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/shade/pain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/shade/sight.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/shade/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/soldier/draw.wav": {
+     "bytes": 6874,
+     "sha256": "c94e5cec38dc40102beebd067554c91e63b86e5c1ef11dc17976733bd9f08ce3"
+    },
+    "sound/soldier/idle.wav": {
+     "bytes": 9802,
+     "sha256": "6c5a8c36eedb0ac5bddacfdf68250c36fe472f9d87e8969b4f95a863a99b77ce"
+    },
+    "sound/soldier/s_arrow.wav": {
+     "bytes": 15132,
+     "sha256": "8ec5ee520f81c69ba367ae549a06d5ea1643b43f81dea7d8345561c94c8412ed"
+    },
+    "sound/soldier/s_death.wav": {
+     "bytes": 13890,
+     "sha256": "bed0d074d9aeee8f046ec7b3a9d33e02d157374ddf6af1296bd1ca7bebf30f10"
+    },
+    "sound/soldier/s_pain.wav": {
+     "bytes": 5118,
+     "sha256": "8afd94fcaa2d20e7c6626eda0c6cd5463670a1dbed0eeea36da588b28196c8a2"
+    },
+    "sound/soldier/s_sight1.wav": {
+     "bytes": 12716,
+     "sha256": "1c20028239d217f31af57649da5d1a6def576569ef5fc7e7033c2acbef7f9345"
+    },
+    "sound/trog/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/trog/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/trog/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/trog/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/trog/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/trog/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/trog/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/trog/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/trog/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/trog/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/trog/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    }
+   },
    "sha256": "9eafaf425d8e4e13573de2292316b4b97db186aae4a61323374093ca0c0d217d",
    "timestamp": "2002-04-01T15:13:52.000Z"
   },
   "pak1.PAK": {
    "bytes": 17282008,
+   "files": {
+    "maps/soe1m1.bsp": {
+     "bytes": 3159552,
+     "sha256": "2b76b1b81010078a6ac94ed34ea8e9a65f5b5602245009673fd7a1eb5ab75af3"
+    },
+    "maps/soe1m2.bsp": {
+     "bytes": 3203720,
+     "sha256": "4233c281ef1fc8021e337e01dea3c63faf9c6c72c5a3b811d700f9820fa2eb78"
+    },
+    "maps/soe1m3.bsp": {
+     "bytes": 2319484,
+     "sha256": "310bae8dbee2dfc725a7482c7173a02cd31ac880082e5d483ade9f795e4ee5f1"
+    },
+    "maps/soe1m4.bsp": {
+     "bytes": 2476152,
+     "sha256": "d7b692c0466efb7cc9a0061ac0d53503969219a75b3cb6aac658c6c025b5caa2"
+    },
+    "maps/soe1m5.bsp": {
+     "bytes": 1061032,
+     "sha256": "0afc14b48f792a1dd00ac8017a879170c7765e9543ec67634824fcf74e7906b6"
+    },
+    "maps/soe1m6.bsp": {
+     "bytes": 673044,
+     "sha256": "c9ad849063b03ac85531ba4294e276c3aa00e59762c5e350d7d1a2b9aa787fa4"
+    },
+    "maps/soe2m7.bsp": {
+     "bytes": 2158660,
+     "sha256": "4ac07a237dade165ae54b7843318c74dd979c8c71aadedc239dfb537f8938aa9"
+    },
+    "maps/soeintro.bsp": {
+     "bytes": 183140,
+     "sha256": "12e0c37015a6c52100a2e36daeeb831501d77b36a3a26de134e267d9b40fc409"
+    },
+    "maps/soestart.bsp": {
+     "bytes": 1568504,
+     "sha256": "f3ab853f203c419d9937444f7ed99110b6fc0a025d8b89c3de17cb742e9a00d1"
+    },
+    "maps/start.bsp": {
+     "bytes": 478068,
+     "sha256": "7d9ea47a92e0c30e145d1a0ffd79f31aee6802751f0531a8c758a9a1c906e16b"
+    }
+   },
    "sha256": "44a19d56cead0083c7c8c7ced13272741a9d8b4e1b862bff5ac962dc88c6918f",
    "timestamp": "2002-04-01T00:23:54.000Z"
   },
   "pak2.PAK": {
    "bytes": 16164328,
+   "files": {
+    "maps/soe2m1.bsp": {
+     "bytes": 2370552,
+     "sha256": "443c5821690626480834ccac20e98d26355789a0e80918de7121eee7f18d8f41"
+    },
+    "maps/soe2m2.bsp": {
+     "bytes": 2992032,
+     "sha256": "b86813735bcd99d2a33f9ac557a6e0a6bdb1de1fe3c5121ac0d04e43d6293539"
+    },
+    "maps/soe2m3.bsp": {
+     "bytes": 1657584,
+     "sha256": "e6d4bc3d4182660f071af3c526911fc6fc117261e4b293ed863789bbc6c3a880"
+    },
+    "maps/soe2m4.bsp": {
+     "bytes": 2344332,
+     "sha256": "c934e54fdbe2c63500cd4702a36b27d7ccb272b5df6f083f9cf5bd2581624195"
+    },
+    "maps/soe2m5.bsp": {
+     "bytes": 4261888,
+     "sha256": "707c5e54499ed6745ac2885f1a1bcd4ee906d68a5f2482820da62e99fb6c09a2"
+    },
+    "maps/soe2m6.bsp": {
+     "bytes": 1818228,
+     "sha256": "8408436f3f27f20a076876404501c710ed6bb3cac6f4d5899a1622701d4f3d70"
+    },
+    "maps/soeexit.bsp": {
+     "bytes": 719252,
+     "sha256": "d4bbb0792c0dad6c614605606910c01c18ea404d7c14e53c05e2b25945cb15a9"
+    }
+   },
    "sha256": "885a40c04534e31e08dedc84ec7c8781c3c3358ad05740bdf4ddfb523e7b966a",
    "timestamp": "2002-04-01T15:37:54.000Z"
   },
   "pak3.PAK": {
    "bytes": 8314988,
+   "files": {
+    "maps/soearena.bsp": {
+     "bytes": 375596,
+     "sha256": "539378d9d5f7e3b936c6c20bb17d805e2d437c9f572f5c0754e25cf27ec47317"
+    },
+    "maps/soedm1.bsp": {
+     "bytes": 1741864,
+     "sha256": "51a2a5492ff03b6fa616705c4b168fef8b45bbfa9b17249970f5bc8c80872385"
+    },
+    "maps/soedm2.bsp": {
+     "bytes": 954392,
+     "sha256": "16e73644bba9e4804fe8664798a2007544fee097845de80ba7478e9828e828f2"
+    },
+    "maps/soedm3.bsp": {
+     "bytes": 1526044,
+     "sha256": "dd4dd67dc719ae97ced1fe575f8922e84399f416afb8f98a54d45e6d5684fe44"
+    },
+    "maps/soedm4.bsp": {
+     "bytes": 1919468,
+     "sha256": "fc9b9509fc943021442a3ea3a23b7fd2a2be13967a19cfd4a645341be462bfa9"
+    },
+    "maps/soedm5.bsp": {
+     "bytes": 1082920,
+     "sha256": "80b848dfa94b9f5a0aba5b54bd90adb9a4405df0936dcbb6881b6ddc7af9bdcd"
+    },
+    "maps/soedm6.bsp": {
+     "bytes": 714244,
+     "sha256": "325d9346fdf138fc9580adf345c0fb0f557b44e4d80df3741b178187b13155c1"
+    }
+   },
    "sha256": "f7f553e208b3e68a26a8884b4161b7aee32da76135c893e14690eb96db06d67d",
    "timestamp": "2002-03-31T22:44:36.000Z"
   },
@@ -32,6 +868,328 @@
   },
   "soe_readme.zip": {
    "bytes": 1103605,
+   "files": {
+    "Soul of Evil - Readme.htm": {
+     "bytes": 405,
+     "sha256": "0523fb8f482e778db0e42be2a1e402660213ca42f5e2c0168387b354f66afbf3",
+     "timestamp": "2002-03-27T20:47:06.000Z"
+    },
+    "html/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2002-04-01T00:07:32.000Z"
+    },
+    "html/bonus.htm": {
+     "bytes": 2897,
+     "sha256": "a33982a5401d207e48246ef3c725693c910c6a5ce95c39119bf4aca34d3bf384",
+     "timestamp": "2002-03-31T23:10:38.000Z"
+    },
+    "html/credits.htm": {
+     "bytes": 5243,
+     "sha256": "0e08c46468eeb2520da0ee96d71c577284cbcdd979bfdee4f2098743a0efe90b",
+     "timestamp": "2002-03-31T23:11:10.000Z"
+    },
+    "html/development.htm": {
+     "bytes": 4986,
+     "sha256": "f00cf280926b9cd8b937602c0bf18f6e5b41a3979812a9c86fbba59604458f04",
+     "timestamp": "2002-03-27T12:14:18.000Z"
+    },
+    "html/frikbots.txt": {
+     "bytes": 7943,
+     "sha256": "af634684cc72dc059ea2752a2e5395a81a5328644ac92182ba4e48772383328e",
+     "timestamp": "2001-12-27T01:25:26.000Z"
+    },
+    "html/hints.htm": {
+     "bytes": 5106,
+     "sha256": "1e339c39aa21c175d8350bd2f120e355b646d4a069865f7ef2db61107f5bfb10",
+     "timestamp": "2002-03-27T20:07:50.000Z"
+    },
+    "html/img/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2002-04-01T00:07:32.000Z"
+    },
+    "html/img/QUAKE26.jpg": {
+     "bytes": 21514,
+     "sha256": "5df56735c46ced8bc03a3a4a731b3dbe7c11f247a26bd92272972eca6f6dab3a",
+     "timestamp": "2002-03-27T11:58:32.000Z"
+    },
+    "html/img/TCOM1.jpg": {
+     "bytes": 14197,
+     "sha256": "47c5f393fdf3fbbd4da1f6c49f85d4c3dc13e359be6d235b32bd7b1b824f2516",
+     "timestamp": "2002-03-27T12:00:38.000Z"
+    },
+    "html/img/bane.jpg": {
+     "bytes": 139371,
+     "sha256": "7789cac315b45c1b4ef24c7e6edf13a8d0f959e31d60649be110664c9369e699",
+     "timestamp": "2000-08-30T22:02:40.000Z"
+    },
+    "html/img/citadel.jpg": {
+     "bytes": 15441,
+     "sha256": "ece9043bcd2d9821e127b5ad8788872db871c2adae83827f98ff010725f8d526",
+     "timestamp": "2002-03-26T21:50:24.000Z"
+    },
+    "html/img/dh/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2002-04-01T00:07:34.000Z"
+    },
+    "html/img/dh/bat.jpg": {
+     "bytes": 14148,
+     "sha256": "c995d5c9bef2b929d045b7aa56a5921d6c622d323e816c53fd95c3b99e3ddb9e",
+     "timestamp": "2002-03-27T16:06:14.000Z"
+    },
+    "html/img/dh/buttons.jpg": {
+     "bytes": 5173,
+     "sha256": "8e3f84a6b6a56363d4bb829de11ec4eb05e6b5c371e798991203a96a7671ec8a",
+     "timestamp": "2002-03-27T15:42:04.000Z"
+    },
+    "html/img/dh/fatty.jpg": {
+     "bytes": 13848,
+     "sha256": "b0ae45afb23b6c43cd59807019ce2bef5cee9cc81ff8a7707f36d302255fd6b2",
+     "timestamp": "2002-03-27T14:59:30.000Z"
+    },
+    "html/img/dh/rotpig.jpg": {
+     "bytes": 11524,
+     "sha256": "500d2feb44fb2095bc9123aad5f106db60d0cc583bb13680c78d4b72f2236bd1",
+     "timestamp": "2002-03-27T16:06:04.000Z"
+    },
+    "html/img/dh/skunk.jpg": {
+     "bytes": 20123,
+     "sha256": "6df52bc097df2b1df45423e00a1cd7ae4dac345313f617234795b1886abf1c5d",
+     "timestamp": "2002-03-27T16:05:28.000Z"
+    },
+    "html/img/dh/tronyn.jpg": {
+     "bytes": 9956,
+     "sha256": "3f7be3a12f0ce7a9f62d35dc5421f80f41afc0b7f95c38b14ca8c23f5bf21ddd",
+     "timestamp": "2002-03-27T16:05:42.000Z"
+    },
+    "html/img/dh/xenon.jpg": {
+     "bytes": 11826,
+     "sha256": "55463bfb44ac2426f1884bcb59c692e9ac7f7348f770ea27ae88f8169ebaf80b",
+     "timestamp": "2002-03-27T16:05:56.000Z"
+    },
+    "html/img/dungeon.jpg": {
+     "bytes": 122087,
+     "sha256": "86fa81f6b4a346c265d1886ff2f60d7f0fb3295eeea0e43fd9f17b4d75c1a877",
+     "timestamp": "2000-08-30T22:00:20.000Z"
+    },
+    "html/img/elemental.jpg": {
+     "bytes": 9037,
+     "sha256": "91799958f59412997a5618bdb9bcecff43c1154e73acb893ae32fcd20dfcd484",
+     "timestamp": "2000-05-30T20:15:36.000Z"
+    },
+    "html/img/fv4.jpg": {
+     "bytes": 11358,
+     "sha256": "09232b562f36d0e38f2bd6e6e1f253baadb362695bb1ec12bb39e81ba4941f62",
+     "timestamp": "2002-03-27T11:55:32.000Z"
+    },
+    "html/img/goblin.jpg": {
+     "bytes": 95517,
+     "sha256": "bd6de56b1bc600c6cdcc83fd49d685a8374d1d3df9f439da104022fdbc4dda4d",
+     "timestamp": "2000-08-30T22:03:08.000Z"
+    },
+    "html/img/heroes.jpg": {
+     "bytes": 193972,
+     "sha256": "d647b0004a261ab2d1ec651076055c4721e330df88e2d673d2667b296c6fd509",
+     "timestamp": "2000-08-30T22:01:26.000Z"
+    },
+    "html/img/m/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2002-04-01T00:07:34.000Z"
+    },
+    "html/img/m/axeman.jpg": {
+     "bytes": 5771,
+     "sha256": "461bba0d72a8a39bb8e413ff444b0abb1c27f34f9aac1fe20d3e20fd5545e38a",
+     "timestamp": "2002-03-27T17:16:20.000Z"
+    },
+    "html/img/m/biggoblin.jpg": {
+     "bytes": 5872,
+     "sha256": "f4db7a28deab2f81f9d8219508b32577803959137f622a3c00614b4febb79705",
+     "timestamp": "2002-03-27T17:16:26.000Z"
+    },
+    "html/img/m/bigwolf.jpg": {
+     "bytes": 5130,
+     "sha256": "12eec461db09a0673362e42fe184035e3fb353d3c4b2a76ad6f06b302da92c01",
+     "timestamp": "2002-03-27T17:16:32.000Z"
+    },
+    "html/img/m/disciple.jpg": {
+     "bytes": 5526,
+     "sha256": "d997bf0c2a5489299067e3436dd3b6291679a0ac9b5e64f22c0ddee076f8e92e",
+     "timestamp": "2002-03-27T17:16:38.000Z"
+    },
+    "html/img/m/dragon.jpg": {
+     "bytes": 4810,
+     "sha256": "97bfbd595110b87477c53085aa9a7e19e933ff6f410f5951c601cb87e81eb1c8",
+     "timestamp": "2002-03-27T17:16:42.000Z"
+    },
+    "html/img/m/drake.jpg": {
+     "bytes": 4669,
+     "sha256": "5127bcc55eb1e7ae62499bf6dfa037d0260a6f5fc3c2aa0aaa3822e5b65aee26",
+     "timestamp": "2002-03-27T17:16:48.000Z"
+    },
+    "html/img/m/forestthug.jpg": {
+     "bytes": 5773,
+     "sha256": "53ad17454e14776bf9cbd3bd08df91d709f4fd861f80e4fb0cda0dfe38c9482a",
+     "timestamp": "2002-03-27T17:16:54.000Z"
+    },
+    "html/img/m/hellknight.jpg": {
+     "bytes": 5882,
+     "sha256": "1d0cbfcf301ceca09c325c3a706473f1e793b6a1781509ace460f1affd36aa85",
+     "timestamp": "2002-03-27T17:17:00.000Z"
+    },
+    "html/img/m/helllord.jpg": {
+     "bytes": 5345,
+     "sha256": "5ab1ac06165e57ca05f73df9b1cafa36f93f985d4f0bdf1e0d33b6fb57d42f11",
+     "timestamp": "2002-03-27T17:17:06.000Z"
+    },
+    "html/img/m/knight.jpg": {
+     "bytes": 5688,
+     "sha256": "ed01e878f90d14821dece6ff1acffc873eb1db9a8307c2ddbad0179de3ab08f5",
+     "timestamp": "2002-03-27T17:17:12.000Z"
+    },
+    "html/img/m/ogre.jpg": {
+     "bytes": 5767,
+     "sha256": "5fd86e8418587d4c5fbcbe4b3afad18db81b533ec436aa2c72d6442db8ca33c9",
+     "timestamp": "2002-03-27T17:17:16.000Z"
+    },
+    "html/img/m/pawn.jpg": {
+     "bytes": 5425,
+     "sha256": "790e073eb8ad6e74b31e88d83e2d489c869c96827c2b729e8524b6e300494a6e",
+     "timestamp": "2002-03-27T17:17:22.000Z"
+    },
+    "html/img/m/scrag.jpg": {
+     "bytes": 5284,
+     "sha256": "b2c03ffde5fb5d4f30b4a1a03c6038ffe37cdbaab295b7f923d1ed0fdd0a7745",
+     "timestamp": "2002-03-27T17:17:28.000Z"
+    },
+    "html/img/m/shadows.jpg": {
+     "bytes": 5482,
+     "sha256": "47d34db9d2575512c21220bd0cdf1e64a6b084e9954cfc754b0f84c570b2c464",
+     "timestamp": "2002-03-27T17:17:34.000Z"
+    },
+    "html/img/m/shalrath.jpg": {
+     "bytes": 5131,
+     "sha256": "f8b6ba2d7c189a97171371b708bc0512f7a7d53baddef4a7c44a9002fc7ae9bc",
+     "timestamp": "2002-03-27T17:17:42.000Z"
+    },
+    "html/img/m/smallgoblin.jpg": {
+     "bytes": 5620,
+     "sha256": "ea909bcae15af05dd527cb7cba70c9180926b37a5dc1ae497492de9822bc4d72",
+     "timestamp": "2002-03-27T17:16:06.000Z"
+    },
+    "html/img/m/smallwolf.jpg": {
+     "bytes": 4814,
+     "sha256": "2473808c36728f93877db71f0eedb5e0a27ffd09174fe970201cf16bc8e6940f",
+     "timestamp": "2002-03-27T17:15:58.000Z"
+    },
+    "html/img/mage2.jpg": {
+     "bytes": 19683,
+     "sha256": "77b566848e9d99e999dbb638ef24630cef619bfe59051fcd6ecdd04b0a849ae1",
+     "timestamp": "2002-03-26T21:50:42.000Z"
+    },
+    "html/img/newtcom.jpg": {
+     "bytes": 13761,
+     "sha256": "2de854f1b2d04a3248ad0b90ef56618d689978e3108b8322649ca392faca4b37",
+     "timestamp": "2002-03-27T11:47:42.000Z"
+    },
+    "html/img/ogre.jpg": {
+     "bytes": 35713,
+     "sha256": "849b52c6095fc804a591c6cac1bd904f196b0f01daf75ec9287ba493712c9c21",
+     "timestamp": "2002-03-27T17:34:32.000Z"
+    },
+    "html/img/oldforest.jpg": {
+     "bytes": 19049,
+     "sha256": "83b4b2cedd4819a37e376e935c27e454e5b47a564c06c8d43d89ee022a8cbd80",
+     "timestamp": "2002-03-27T11:58:12.000Z"
+    },
+    "html/img/oldtcom.jpg": {
+     "bytes": 10533,
+     "sha256": "ec2fbcb7acf177dadd606180098d378b107507f9ce068b027c5d762a68b5f2ae",
+     "timestamp": "2002-03-27T11:48:10.000Z"
+    },
+    "html/img/oldtcom1.jpg": {
+     "bytes": 11878,
+     "sha256": "ccb44d292274edb813c22d5def98771c25506d8c53169538849ba14943316f77",
+     "timestamp": "2002-03-27T12:00:16.000Z"
+    },
+    "html/img/quake69.jpg": {
+     "bytes": 18546,
+     "sha256": "e169b72bb91ec338e871cb42da14e339ba1d75590be2bfd2d7c9c410a227c1c6",
+     "timestamp": "2002-03-27T20:01:34.000Z"
+    },
+    "html/img/ranger2.jpg": {
+     "bytes": 16958,
+     "sha256": "c1b227f76f429c72564e49c9c04f074fb155808bb36fbf028576941b74c2c582",
+     "timestamp": "2002-03-26T21:51:10.000Z"
+    },
+    "html/img/shot1.jpg": {
+     "bytes": 11577,
+     "sha256": "835d7d4a5420673850884c591df7c7d6c1e1be3a9a728d7ac601d08a9e1908c7",
+     "timestamp": "2002-03-26T21:59:38.000Z"
+    },
+    "html/img/shot2.jpg": {
+     "bytes": 10953,
+     "sha256": "e70d647d032266a43391d971189f05b78a503b5a12ff7b29587c2f7a974a8a9c",
+     "timestamp": "2002-03-26T21:59:56.000Z"
+    },
+    "html/img/smallpike.jpg": {
+     "bytes": 7918,
+     "sha256": "2fe938105580c74bbd665d97454e72de246c13ae3eb7efa77ed8c19278bf04a4",
+     "timestamp": "2002-03-26T22:00:30.000Z"
+    },
+    "html/img/soe.jpg": {
+     "bytes": 42159,
+     "sha256": "21b99faa83fd0c65c21b11bae062e29cdfb3e64464d76a3db6b54d9404d4c288",
+     "timestamp": "2002-03-27T20:36:56.000Z"
+    },
+    "html/img/soe1m3_1.jpg": {
+     "bytes": 14679,
+     "sha256": "a4a5e6ab8b908a63f9409b93b9a949ec785855c7d03ca8516956715146002ff6",
+     "timestamp": "2002-03-27T11:55:00.000Z"
+    },
+    "html/img/sr_logo.jpg": {
+     "bytes": 30874,
+     "sha256": "f10a0ce79675cad553fbb6d4d12fab2f594a626c1b72bf14cbf33772f9b9bceb",
+     "timestamp": "2002-03-21T23:39:26.000Z"
+    },
+    "html/img/sr_yell.jpg": {
+     "bytes": 833,
+     "sha256": "187926485a7ad54313bc9d75ba42ea39810f19bd3456a0fecdd1bb5be4a45b48",
+     "timestamp": "2002-03-23T00:12:44.000Z"
+    },
+    "html/img/tac4.jpg": {
+     "bytes": 17281,
+     "sha256": "b6d69dd796b6df0ba46e88ae7ae6a3e024f3d9309b87ed6968c649e4bf43ec37",
+     "timestamp": "2002-03-27T19:59:54.000Z"
+    },
+    "html/index.htm": {
+     "bytes": 3361,
+     "sha256": "0c45a91c43d10b697a0c6233ea776a61640dedd897dc882dc4c20461b8cac804",
+     "timestamp": "2002-03-31T23:11:32.000Z"
+    },
+    "html/multiplayer.htm": {
+     "bytes": 4853,
+     "sha256": "bb12e210a0934d36c6b3c87990b9e3fbbcbb3fa02e28696ffae45100b65fc0b1",
+     "timestamp": "2002-03-31T23:15:04.000Z"
+    },
+    "html/singleplayer.htm": {
+     "bytes": 23727,
+     "sha256": "da2f80cc772f44ca64b24010c954232baf66c4a902f9ac0512ace09639fde369",
+     "timestamp": "2002-03-27T19:44:52.000Z"
+    },
+    "html/ssh.htm": {
+     "bytes": 4534,
+     "sha256": "a74fd999c8a8349b1e801eaf51496f71630a70c7ab207ff30844af8f776b45ae",
+     "timestamp": "2002-03-27T19:55:18.000Z"
+    },
+    "html/text_only_readme.txt": {
+     "bytes": 9143,
+     "sha256": "fa9c00c184f69966f26771a63f186cf8f217231751a1145c087b92d054e5c254",
+     "timestamp": "2002-03-31T23:13:34.000Z"
+    }
+   },
    "sha256": "c7f95eb199569391441c71e33a3b04690ee74e5a3b9715eacac2e1c3fc99e1c0",
    "timestamp": "2002-04-01T00:07:50.000Z"
   }

--- a/json/by-sha256/96/964c7f1e6f20f04d32cc075ca70e6fdb28913875b8861d408e52b732643742ed.json
+++ b/json/by-sha256/96/964c7f1e6f20f04d32cc075ca70e6fdb28913875b8861d408e52b732643742ed.json
@@ -234,11 +234,263 @@
   },
   "smej/pak0.pak": {
    "bytes": 3566343,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/fish.mdl": {
+     "bytes": 221279,
+     "sha256": "b220c5bdbcfdcd0df834944ecbccb5ffbaa98fa7844d2a1da455183bcc2f463f"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "425f8984ce158653dfc9d226b4ab8190ff5a8550bb5a69e4da36b6c9ec9e804f",
    "timestamp": "2019-12-30T14:52:02.000Z"
   },
   "smej/pak1.pak": {
    "bytes": 663170,
+   "files": {
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "05c7f2543a25462c839add0af7d711cb9d604360cc562405989625d96d8500b3"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "4c8e01b1bbfd413fc3818ab213eeec7f5757ec55a3e917b8cbadf6038b40dc08"
+    },
+    "progs.dat": {
+     "bytes": 486130,
+     "sha256": "40a2bfce0c8cde89e73067989c731f7d90711be8a6fd7c018309c5f770b7c77f"
+    }
+   },
    "sha256": "e223d16fa16c94434cec5f26c51d1ae37d07ff47122f2d37e41210cb301f1712",
    "timestamp": "2019-12-30T14:51:52.000Z"
   },

--- a/json/by-sha256/96/96e97692f6aa27a642bfbb8301c4fb35c5037e1664ba1989ed5e615ccf1bda9c.json
+++ b/json/by-sha256/96/96e97692f6aa27a642bfbb8301c4fb35c5037e1664ba1989ed5e615ccf1bda9c.json
@@ -92,6 +92,288 @@
   },
   "pak0.pak": {
    "bytes": 18049945,
+   "files": {
+    "autoexec.cfg": {
+     "bytes": 991,
+     "sha256": "5f6afd1b9faa1b8ad38734f786d1bad7780f00f32e12657e1b1b08f402fd03e7"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "df060c0ebb8eab546751f153d2aa41d418b8336e407e0638d6a711142ee9a53c"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64512,
+     "sha256": "9a3757b58f26b80135b041182f64430d4ec76c1c6b4b868282173af3a57a2fd7"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64512,
+     "sha256": "bb5e88e97cb2ff8f1978495191fb060bcf98dd19074170ee17a70cfd07bfeacd"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64512,
+     "sha256": "f9e77faa48bf851842b75fe7bd39be46467deac8b3b1e729426d78da22d0e35a"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64648,
+     "sha256": "e95aa0452cf479fdb0aa8ad841ecc92c148172ce4bf5f5cedd95be5506832a50"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64512,
+     "sha256": "2d976713fc08bd79c0d60f2d66453cf66f4dd6fedfa7c94f2fb156b22c2fe329"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64512,
+     "sha256": "ca4495c64100840fa4901193817a9db49723a44f8837484f86e6077dd639d9cd"
+    },
+    "intro.dem": {
+     "bytes": 770084,
+     "sha256": "e474e95d7ced9e6418f2af11d774b863d379cf59b393eda61da634e856c3cbbe"
+    },
+    "maps/demo.bsp": {
+     "bytes": 598400,
+     "sha256": "9655b42fd080c8eacf92b22795388e92f5c4822048a9cb39162065ae0d648ead"
+    },
+    "maps/sop1.bsp": {
+     "bytes": 1526152,
+     "sha256": "717cd3155e683947c1f1debdf5c1e656c74663f869c9f540bd7b888e73343b41"
+    },
+    "maps/sop2.bsp": {
+     "bytes": 2106356,
+     "sha256": "63ad47dda8f7698b9c990389ab21b4f1a9221858bb0d6e570ec834871a7e7d8a"
+    },
+    "maps/sop3.bsp": {
+     "bytes": 2136112,
+     "sha256": "4642f88438146b798b45cbd6cae94c2033a310bd2be8d31b2aa0d4aa22e8a87b"
+    },
+    "maps/start.bsp": {
+     "bytes": 854764,
+     "sha256": "19690d383febfe9c1610ea3185e4435f3649aafa045074ae397f35f676d6be5c"
+    },
+    "progs.dat": {
+     "bytes": 748392,
+     "sha256": "0f1a6f2a0b5c7c6dc694ec68de6affa0fb8200cd01a1fb23eb5cfd72cce25e20"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 12161,
+     "sha256": "41339f3222ee6fc0cd85a58a7b2a6c4330e284ea39ecb7002d97927244c5250a"
+    },
+    "progs/babysham.mdl": {
+     "bytes": 98556,
+     "sha256": "8e86cddcb2f52107ed6d39f7b16ef8c4d9cd90184387e078af2dea8a1f9439d2"
+    },
+    "progs/beam.mdl": {
+     "bytes": 10608,
+     "sha256": "2165a66ba1d40fa378df735835b014791e769cb8bc56e06977aefdf134bb61d5"
+    },
+    "progs/beamhit.spr": {
+     "bytes": 5320,
+     "sha256": "bdfe3464c0bea904c3d35135b6d242f486298447ea45c3f96cce7ac6b71a3e54"
+    },
+    "progs/bs_light.mdl": {
+     "bytes": 28707,
+     "sha256": "6c646ab4291d12aecdad5d9af4c44f4d68fc207c730dbf3ac04e07103cdd2c12"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/dring.spr": {
+     "bytes": 387832,
+     "sha256": "94adc8ada163983eae9ccb924bd4ef4d8ebb2613bd23705d2e8a7bb73e7657d1"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 649023,
+     "sha256": "c320c3d37993dedb88e9e4c6e824cae03f9df223b795524cf1070e36e00aec7a"
+    },
+    "progs/expl.spr": {
+     "bytes": 127672,
+     "sha256": "553b80901ee3d765c147ecce187a53989ded3991532e02f53c5b0cbb42aad5d4"
+    },
+    "progs/g_beam.mdl": {
+     "bytes": 68996,
+     "sha256": "db2566d26863472c6176c91b2256c12b5fdd28b5e1ba0a3ff2aa9e122ed0cacb"
+    },
+    "progs/h_bsham.mdl": {
+     "bytes": 37447,
+     "sha256": "28f210b7a891c8a430c39932700ae116331cb673f68a9f8963c663932bf583d5"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 18592,
+     "sha256": "707314ea9504949537167c8b231311d723d697a34d45e5084c0d37a508ca9347"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 22424,
+     "sha256": "d9e962460a6b50ca4c85eea374bb1d46acf6041174968dc3179a597319fe9b3a"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 43068,
+     "sha256": "5c2c9dd9416f652e7664e393b56b779888555b80926076625336b8597725ee40"
+    },
+    "progs/h_servo.mdl": {
+     "bytes": 159944,
+     "sha256": "b2e00c8536a78ba933773d9f379d4bcd4be4242ebb690e1bccc584b8db1417e0"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 218888,
+     "sha256": "ade29444973daeae2b8dd0a271ffd78d657e2553eed14469cd87c490da324885"
+    },
+    "progs/player.mdl": {
+     "bytes": 191852,
+     "sha256": "10cecfe08d312ff17c63529e280b976c50018f683f541cb03b2048c7a681ebf9"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/s_null.spr": {
+     "bytes": 56,
+     "sha256": "29e9c18546413f0abc9c6f507c61952f33afa6507b52d1c2197b57e3be7870a9"
+    },
+    "progs/servobod.mdl": {
+     "bytes": 235580,
+     "sha256": "fa1cb5e68f4dd149e917aecd2534c93a5e87ef1989dbcb8d117471b7713dfc5c"
+    },
+    "progs/servodie.mdl": {
+     "bytes": 388596,
+     "sha256": "64c3c8cf80d3c046fb0c6295b105dca31c31bde433a1f35b556c492f1691c0cb"
+    },
+    "progs/servoleg.mdl": {
+     "bytes": 185436,
+     "sha256": "d2de0d4bbe7b09208bfae65be9183eeb2bb59c0ff9f0efb035b4916a070f4a5b"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 320900,
+     "sha256": "29d578cf1a503aa933f50d03ceaa4143a7b6a8319cc422a9b59f5be39a51e8fa"
+    },
+    "progs/v_beam.mdl": {
+     "bytes": 75588,
+     "sha256": "c00fe7872cb2c88626e63d99c3cc00b83f9968803344cd2021e8fc26bd25ccba"
+    },
+    "progs/v_beam2.mdl": {
+     "bytes": 75588,
+     "sha256": "95b3a260450ca784bda0885da994a5a857cf9948581ed1e68c4b202c51dae670"
+    },
+    "progs/weather.spr": {
+     "bytes": 66164,
+     "sha256": "6364500483ce0b25486611c3fd48c239414a094a1a5ba3fd29acdf85fe8eb419"
+    },
+    "quake.rc": {
+     "bytes": 289,
+     "sha256": "368b616e9a365c528f2e0380e86dae75fcdd109525d16268ea1c792c07e5d578"
+    },
+    "sound/1minmy~1.wav": {
+     "bytes": 667102,
+     "sha256": "d9546ef5ceb098df0733f2a7035d0abf97e70e2f294aea9dbf466b355593104a"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/dwrinto.wav": {
+     "bytes": 1324314,
+     "sha256": "767016a2da943abedacf9ae6578dd8736ebdfe8ebaa4139051d6861e648ff7f5"
+    },
+    "sound/dwrrep.wav": {
+     "bytes": 1160404,
+     "sha256": "8f52017194a4ad7caadaabbec28be43ca8bb68fd845b5005540a36e100ceddb2"
+    },
+    "sound/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/mech/mechstep.wav": {
+     "bytes": 11310,
+     "sha256": "253862ad17886c0c0467f2600f185e11fdb49156500919258c7bdf1f51f5bb98"
+    },
+    "sound/mech/metal.wav": {
+     "bytes": 5442,
+     "sha256": "12f478674e401a0e8b3fa696dc87239bd25c75d543eab4cdc7dcb846cd62731f"
+    },
+    "sound/mech/pow_dn.wav": {
+     "bytes": 42904,
+     "sha256": "bcbbdf2a6c196dd3d21cb552e00cd903bde38b94d79860804b5d00f88dc05c3b"
+    },
+    "sound/mech/pow_up.wav": {
+     "bytes": 32670,
+     "sha256": "e0b232135f7db271c3f6e5f6f49eae7d948cfa3afc20d372d5cccb4fa7481663"
+    },
+    "sound/midintro.wav": {
+     "bytes": 662214,
+     "sha256": "4ea7d01836fe4d1c6c390235ad0790d5bceceb8c05774899d9799fc8aaf14a9e"
+    },
+    "sound/midrep.wav": {
+     "bytes": 352926,
+     "sha256": "daa244911559c8526c085df8a71d53da48284e61fa148119f9bdcf14b17db896"
+    },
+    "sound/misc/heal.wav": {
+     "bytes": 17911,
+     "sha256": "a62179d3ff3072a057d1c3d94c7bc3dbf6488f6fc1ffa923388f8b743ee265d7"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/steps/lowecho.wav": {
+     "bytes": 1147,
+     "sha256": "886f149bdaa8a6e1b6d81cb4d4cd6a339012239a0aaaa85a5ad48a269c4ca69a"
+    },
+    "sound/thud.wav": {
+     "bytes": 12814,
+     "sha256": "3339425267d81adf2186e4dbca724804e918d1e3b12f462497a2f8f0aa07c9d8"
+    },
+    "sound/turret/beamchrg.wav": {
+     "bytes": 3962,
+     "sha256": "d02bd7d2c4754fe3159fac83b4f0898f8b2e1f8996ce7e6cfdaa4a9d75a24fb1"
+    },
+    "sound/turret/beamhit.wav": {
+     "bytes": 8644,
+     "sha256": "35e5e5f28a3695ed27c2b0887a1bf118643d769c457d3642016e887248fa8ca9"
+    },
+    "sound/voice1.wav": {
+     "bytes": 73110,
+     "sha256": "71a421c069e6db60393ad676d0ca29844f2ed2fc84c6d2498438f80a53d75089"
+    },
+    "sound/wall/wall.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/wave1.wav": {
+     "bytes": 183008,
+     "sha256": "0928e73f02e678a3d10f3e25e32c5f8104f64f089fe01fd3a5ad5ba34e1546c4"
+    },
+    "sound/weapons/arrowhit.wav": {
+     "bytes": 3644,
+     "sha256": "7348632798578416b240951489cf027abcaa04ac7f1190a22581349c8b06ede3"
+    },
+    "sound/weapons/lncharow.wav": {
+     "bytes": 2872,
+     "sha256": "546ef60ffa1d6f311f24093af551514ef4f4b9832d4481e4ae78fd0bf6e273b2"
+    }
+   },
    "sha256": "ada57c5fda7148c7f5d976e38e117ccdaa3c2f44c285386d052ae9a5e20f1ff5",
    "timestamp": "2003-05-25T21:42:02.000Z"
   },

--- a/json/by-sha256/97/97230cbb48a274a4f8533fb51e2c6aac6a4f14ec30253e8e98f0ed7db1472476.json
+++ b/json/by-sha256/97/97230cbb48a274a4f8533fb51e2c6aac6a4f14ec30253e8e98f0ed7db1472476.json
@@ -62,6 +62,40 @@
   },
   "dknights/pak0.pak": {
    "bytes": 30530522,
+   "files": {
+    "maps/100kknights.bsp": {
+     "bytes": 12610436,
+     "sha256": "9214f20e66d49303c0ecd6b5742121f7b13dc87a5b23f2826b75cd1aa2234dc2"
+    },
+    "maps/100kknights.map": {
+     "bytes": 14763882,
+     "sha256": "d54e839a5d6def16c0fa934b7eaaeef0587ef95a0cd1b7405c5452f1ad1d6cf1"
+    },
+    "maps/10kknights.bsp": {
+     "bytes": 1718136,
+     "sha256": "ca03daf7145cf66efca90b2ab49495bc69ef9240f64f12dd226fb9cbc0ecb914"
+    },
+    "maps/10kknights.lit": {
+     "bytes": 493544,
+     "sha256": "4565eea2bbdc0b0cc51c4bddca1b7c3b1839dee81c74d5ef95a94de1e305ca90"
+    },
+    "maps/1kknights.bsp": {
+     "bytes": 365260,
+     "sha256": "756f6ba1b30ea5adcb271e4c887bd362fe01192d9d879a5491d6f330bc373a58"
+    },
+    "maps/1kknights.lit": {
+     "bytes": 109916,
+     "sha256": "c58e6a163cdcc6fe9779925b7f3bb188916b7dc9d947cc5bf640d81a39c00e5f"
+    },
+    "maps/start.bsp": {
+     "bytes": 390876,
+     "sha256": "5115be6619a147394995de219e9e960c2be4cd26aadba3e07cb1f7ec37c8a5e1"
+    },
+    "maps/start.lit": {
+     "bytes": 77948,
+     "sha256": "ad727302c09a147c12cac6af37fd80da27c7362df575292688ba559bb50eea00"
+    }
+   },
    "sha256": "e41ec48517830c561a7a4156b0fa7d84a89e8504b08a34a7f6c55de50b9b81c6",
    "timestamp": "2022-04-01T17:11:18.000Z"
   },

--- a/json/by-sha256/97/9755bf7150f47e3ae285d3a9c188d3b3800d14c416bed99f1296cecea612e012.json
+++ b/json/by-sha256/97/9755bf7150f47e3ae285d3a9c188d3b3800d14c416bed99f1296cecea612e012.json
@@ -23,321 +23,1031 @@
   },
   "tombofthunder/LibreQuake docs.zip": {
    "bytes": 14973,
+   "files": {
+    "docs/COPYING": {
+     "bytes": 1697,
+     "sha256": "c3426ae10fd52ab1a3c3d4de4f2fae60543403e3cfd09ae5dc2ec16ae4717d28",
+     "timestamp": "2024-05-15T17:33:40.000Z"
+    },
+    "docs/CREDITS": {
+     "bytes": 3254,
+     "sha256": "60b632851de3e5d02cb96ed158ff06700ced1c9fb6425f2d5d10509392021bd0",
+     "timestamp": "2024-05-15T17:33:40.000Z"
+    },
+    "docs/freedoom-docs/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2024-05-15T17:33:40.000Z"
+    },
+    "docs/freedoom-docs/COPYING.adoc": {
+     "bytes": 1611,
+     "sha256": "07b1d04bb498dfcce23bc186bf72ae0356f67c1f90361e9d2394e54b296facc8",
+     "timestamp": "2024-05-15T17:33:40.000Z"
+    },
+    "docs/freedoom-docs/CREDITS": {
+     "bytes": 14715,
+     "sha256": "dc39ff7086cffed47aabe8dbfff160916f8043c4aa9f6156310d5d9cf2dd69ee",
+     "timestamp": "2024-05-15T17:33:40.000Z"
+    },
+    "docs/freedoom-docs/README.adoc": {
+     "bytes": 11713,
+     "sha256": "67a9250b25fb2313cbf4c76295df6f9483a7370fbc59e2db222ab59edbf2a75e",
+     "timestamp": "2024-05-15T17:33:40.000Z"
+    }
+   },
    "sha256": "1c93d84804a35349a2e09f21c3ef2fa5ef732aa10c756b882d3caf18a7f974ae",
-   "timestamp": "2024-05-18T23:14:36.000Z"
+   "timestamp": "2024-05-19T00:14:36.000Z"
   },
   "tombofthunder/Tomb of Thunder - Secrets guide.docx": {
    "bytes": 10513,
    "sha256": "b6488194509e47ffa2feba1f4e5becc818f641cd3f5ea5cfda309dafe4f31807",
-   "timestamp": "2024-07-01T11:26:24.000Z"
+   "timestamp": "2024-07-01T12:26:24.000Z"
   },
   "tombofthunder/autoconfig.cfg": {
    "bytes": 7,
    "sha256": "52808d039973d98b4c74d9b20728ae1d4d6a427a3ce72289f7c8943e80a1a0a2",
-   "timestamp": "2024-05-15T08:22:00.000Z"
+   "timestamp": "2024-05-15T09:22:00.000Z"
   },
   "tombofthunder/demo1.dem": {
    "bytes": 11026362,
    "sha256": "2046f664a8b89e6039d38954091b801930b69153935b37df9f0d8cb0612bf015",
-   "timestamp": "2024-05-16T16:57:42.000Z"
+   "timestamp": "2024-05-16T17:57:42.000Z"
   },
   "tombofthunder/demo2.dem": {
    "bytes": 9506290,
    "sha256": "c13198472600ab08cc8d90e9036defdedd2a47b9f5dd05bb3f8de19372b628fd",
-   "timestamp": "2024-05-16T16:59:38.000Z"
+   "timestamp": "2024-05-16T17:59:38.000Z"
   },
   "tombofthunder/demo3.dem": {
    "bytes": 12504719,
    "sha256": "63b76764eb1cff4f3f4cb3b624955ad25ae8caf5c7950f94c5da1d2cc237c887",
-   "timestamp": "2024-05-16T17:02:18.000Z"
+   "timestamp": "2024-05-16T18:02:18.000Z"
   },
   "tombofthunder/gfx/": {
    "bytes": 0,
    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-   "timestamp": "2022-10-19T22:00:04.000Z"
+   "timestamp": "2022-10-19T23:00:04.000Z"
   },
   "tombofthunder/gfx/conback.lmp": {
    "bytes": 307208,
    "sha256": "8d3814bcbfa7168685dd1044504d3a422b8619b2ff6d87208203b79cd8f970db",
-   "timestamp": "2021-01-27T16:33:50.000Z"
+   "timestamp": "2021-01-27T17:33:50.000Z"
   },
   "tombofthunder/gfx/conbackog.lmp": {
    "bytes": 307208,
    "sha256": "799d1ce56f3d54d13f58663325cc687e777cd8c4cb82c63f43c874a5eb793767",
-   "timestamp": "2021-01-27T16:05:48.000Z"
+   "timestamp": "2021-01-27T17:05:48.000Z"
   },
   "tombofthunder/gfx/env/": {
    "bytes": 0,
    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-   "timestamp": "2023-12-21T17:21:18.000Z"
+   "timestamp": "2023-12-21T18:21:18.000Z"
   },
   "tombofthunder/gfx/env/atsea_bk.tga": {
    "bytes": 632859,
    "sha256": "0170bac6e1114edec6fd9add7dd474b24dc047d4a1e05518b9bd5eb03444e827",
-   "timestamp": "2003-02-09T11:02:52.000Z"
+   "timestamp": "2003-02-09T12:02:52.000Z"
   },
   "tombofthunder/gfx/env/atsea_dn.tga": {
    "bytes": 574894,
    "sha256": "0c1498451cd053afe41d6409ba14b156608623d316708d6a7e49383355b93fbd",
-   "timestamp": "2003-02-09T11:02:56.000Z"
+   "timestamp": "2003-02-09T12:02:56.000Z"
   },
   "tombofthunder/gfx/env/atsea_ft.tga": {
    "bytes": 578784,
    "sha256": "9542abd9f7b51885b945f184e779caf83722f49dcbd1d623aba5424302fc07eb",
-   "timestamp": "2003-02-09T11:02:50.000Z"
+   "timestamp": "2003-02-09T12:02:50.000Z"
   },
   "tombofthunder/gfx/env/atsea_lf.tga": {
    "bytes": 603631,
    "sha256": "a97250f90147c6633efdfe4a81234cf488a8e4b67f64352e8b009f3542be94e5",
-   "timestamp": "2003-02-09T11:02:50.000Z"
+   "timestamp": "2003-02-09T12:02:50.000Z"
   },
   "tombofthunder/gfx/env/atsea_rt.tga": {
    "bytes": 661491,
    "sha256": "171aff8c805afccb39a373b4b41263650313082e00d8c1e9b6370b5a7b535e9f",
-   "timestamp": "2003-02-09T11:02:54.000Z"
+   "timestamp": "2003-02-09T12:02:54.000Z"
   },
   "tombofthunder/gfx/env/atsea_up.tga": {
    "bytes": 634513,
    "sha256": "1bad6c1b80666490aefcedbc46821cbecec2c2c766197fb15b90954a0be21b0e",
-   "timestamp": "2003-02-09T11:02:58.000Z"
+   "timestamp": "2003-02-09T12:02:58.000Z"
   },
   "tombofthunder/gfx/env/ofelas_bk.tga": {
    "bytes": 478922,
    "sha256": "3f92c428da1353c3d28ef05162cdfcc57c79cbda679196b7f2eb4d9430d4f835",
-   "timestamp": "2004-09-06T17:01:36.000Z"
+   "timestamp": "2004-09-06T18:01:36.000Z"
   },
   "tombofthunder/gfx/env/ofelas_dn.tga": {
    "bytes": 643000,
    "sha256": "bee478075b3909db7f7f2b1ef4b4ccc621a9ef587edfe790ecc92f718ca80230",
-   "timestamp": "2004-09-06T17:01:36.000Z"
+   "timestamp": "2004-09-06T18:01:36.000Z"
   },
   "tombofthunder/gfx/env/ofelas_ft.tga": {
    "bytes": 515988,
    "sha256": "ac6ee09da7578713d91d261d4667bbe580df55a487c30726f05bb75e89839b5c",
-   "timestamp": "2004-09-06T17:01:36.000Z"
+   "timestamp": "2004-09-06T18:01:36.000Z"
   },
   "tombofthunder/gfx/env/ofelas_lf.tga": {
    "bytes": 413651,
    "sha256": "0377e4985a3babcc9baa8a2b1aa4fe755bbea46ec57c50efd2e7f5628cf1a619",
-   "timestamp": "2004-09-06T17:01:36.000Z"
+   "timestamp": "2004-09-06T18:01:36.000Z"
   },
   "tombofthunder/gfx/env/ofelas_rt.tga": {
    "bytes": 587061,
    "sha256": "dc0bf02b9ee7a8463546d29eeddcad0e191a5b0d0f8086f522301956b60db51b",
-   "timestamp": "2004-09-06T17:01:36.000Z"
+   "timestamp": "2004-09-06T18:01:36.000Z"
   },
   "tombofthunder/gfx/env/ofelas_up.tga": {
    "bytes": 22362,
    "sha256": "cd74413cbf0113173ed742802a7c663d348cffe0dee40defd997377b067eb18f",
-   "timestamp": "2004-09-06T17:01:36.000Z"
+   "timestamp": "2004-09-06T18:01:36.000Z"
   },
   "tombofthunder/gfx/env/shol_bk.tga": {
    "bytes": 286426,
    "sha256": "afc656e21fdba58ec0df854cd4f0a8681257a993bec6b5185b24821b9b3e73be",
-   "timestamp": "2003-01-22T20:26:38.000Z"
+   "timestamp": "2003-01-22T21:26:38.000Z"
   },
   "tombofthunder/gfx/env/shol_dn.tga": {
    "bytes": 139320,
    "sha256": "aa4b3cf9005975c47096fbacd3041439ab0492025c0756df7d5098192043d53e",
-   "timestamp": "2003-02-20T17:28:00.000Z"
+   "timestamp": "2003-02-20T18:28:00.000Z"
   },
   "tombofthunder/gfx/env/shol_ft.tga": {
    "bytes": 280100,
    "sha256": "9334cced4dfe72e3be40a86f830c6d39444d4bd4aa1df0f26b4fbf359f369520",
-   "timestamp": "2003-01-22T20:26:28.000Z"
+   "timestamp": "2003-01-22T21:26:28.000Z"
   },
   "tombofthunder/gfx/env/shol_lf.tga": {
    "bytes": 305263,
    "sha256": "84e81f9c3d29722d40b2dc3f9bc934d610a1bc7a05903265546e33d3c201383a",
-   "timestamp": "2003-01-22T20:26:34.000Z"
+   "timestamp": "2003-01-22T21:26:34.000Z"
   },
   "tombofthunder/gfx/env/shol_rt.tga": {
    "bytes": 303582,
    "sha256": "b407a22b61b77bd86e1eecdfbb2a64c25acc004b25020318e67e9a179d07c533",
-   "timestamp": "2003-01-22T20:26:42.000Z"
+   "timestamp": "2003-01-22T21:26:42.000Z"
   },
   "tombofthunder/gfx/env/shol_up.tga": {
    "bytes": 344881,
    "sha256": "3eff1076ea76b963355452aefddb7afcee5d75a41a65d1560a375f24f9715660",
-   "timestamp": "2004-02-05T17:30:48.000Z"
+   "timestamp": "2004-02-05T18:30:48.000Z"
   },
   "tombofthunder/maps/": {
    "bytes": 0,
    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-   "timestamp": "2024-07-23T14:25:14.000Z"
+   "timestamp": "2024-07-23T15:25:14.000Z"
   },
   "tombofthunder/maps/discipletest.bsp": {
    "bytes": 165112,
    "sha256": "f36b372897c0c1df758743869c41d73a3bb9cd4e608ab2f7420dfec78e79a1e6",
-   "timestamp": "2023-09-07T12:43:48.000Z"
+   "timestamp": "2023-09-07T13:43:48.000Z"
   },
   "tombofthunder/maps/seeyou.bsp": {
    "bytes": 1354236,
    "sha256": "f34b0ea88dc175a9ca8f620b4ebead3553bfbaa8841d1f65dd4a559d4e0cc884",
-   "timestamp": "2024-06-02T10:12:38.000Z"
+   "timestamp": "2024-06-02T11:12:38.000Z"
   },
   "tombofthunder/maps/seeyou.lit": {
    "bytes": 275780,
    "sha256": "01ff24fee75ef39e0e1e9946e246808381a6ca80afbb3332716017cc5fd0b00e",
-   "timestamp": "2024-06-02T10:12:38.000Z"
+   "timestamp": "2024-06-02T11:12:38.000Z"
   },
   "tombofthunder/maps/start.bsp": {
    "bytes": 5019516,
    "sha256": "9b0037d2ef1cc7fb02b0f7e3122b2c3946ee502db43b2981faa20cbd7bef1064",
-   "timestamp": "2024-06-02T10:12:30.000Z"
+   "timestamp": "2024-06-02T11:12:30.000Z"
   },
   "tombofthunder/maps/start.lit": {
    "bytes": 1677932,
    "sha256": "928ec852f4ec279bf76232aba33699638e3b0a6c0970b13e1755507988400116",
-   "timestamp": "2024-06-02T10:12:28.000Z"
+   "timestamp": "2024-06-02T11:12:28.000Z"
   },
   "tombofthunder/maps/test1.bsp": {
    "bytes": 190776,
    "sha256": "6910d4fd79322fe1061b49e4a7aa329c35883f058516cef7f83e85b88e16f4e1",
-   "timestamp": "2020-12-09T17:20:46.000Z"
+   "timestamp": "2020-12-09T18:20:46.000Z"
   },
   "tombofthunder/maps/testsham.bsp": {
    "bytes": 105688,
    "sha256": "e0cb05b1b66a35828dd316844b192ac61a76b7def8b01da9acfa38514574aef8",
-   "timestamp": "2021-02-11T11:11:50.000Z"
+   "timestamp": "2021-02-11T12:11:50.000Z"
   },
   "tombofthunder/maps/tot1.bsp": {
    "bytes": 13496744,
    "sha256": "54c94f72293f649846351c08c79b38dc3e509f02971af5bf00b76062f160bab0",
-   "timestamp": "2024-06-01T22:12:36.000Z"
+   "timestamp": "2024-06-01T23:12:36.000Z"
   },
   "tombofthunder/maps/tot1.lit": {
    "bytes": 4423124,
    "sha256": "bc323e97de6f9cdee09897da47f2b7e971ec6ca0bb1580fe62d4d039e0aa54d7",
-   "timestamp": "2024-06-01T22:12:34.000Z"
+   "timestamp": "2024-06-01T23:12:34.000Z"
   },
   "tombofthunder/maps/tot2.bsp": {
    "bytes": 20933656,
    "sha256": "4e2c0db214706a0635f8f21575ff4ffd5187f9096acb02e03b42b37e3e4c14f0",
-   "timestamp": "2024-06-01T22:09:04.000Z"
+   "timestamp": "2024-06-01T23:09:04.000Z"
   },
   "tombofthunder/maps/tot2.lit": {
    "bytes": 12336176,
    "sha256": "8d814fa01bc7fb7df0270e0934424f8afe6ee5beb18e1d9c72abedf125f6b796",
-   "timestamp": "2024-06-01T22:08:52.000Z"
+   "timestamp": "2024-06-01T23:08:52.000Z"
   },
   "tombofthunder/maps/tot3.bsp": {
    "bytes": 18941040,
    "sha256": "7af08969d26f55335d7d5218bece6d57e31b4775bc16fce6cb2c74ff2a1b05e4",
-   "timestamp": "2024-07-01T11:27:24.000Z"
+   "timestamp": "2024-07-01T12:27:24.000Z"
   },
   "tombofthunder/maps/tot3.lit": {
    "bytes": 6759200,
    "sha256": "a3ee2e2972968bc0dff47214ec7385b453094a2c3fca798bae1c5afe3d3fdfcd",
-   "timestamp": "2024-07-01T11:27:18.000Z"
+   "timestamp": "2024-07-01T12:27:18.000Z"
   },
   "tombofthunder/maps/tot4a.bsp": {
    "bytes": 21577920,
    "sha256": "70dd194f7fb8266181e88dde2352927d3e2f250f6eb9a4857564979ff9945063",
-   "timestamp": "2024-07-24T09:26:14.000Z"
+   "timestamp": "2024-07-24T10:26:14.000Z"
   },
   "tombofthunder/maps/tot4a.lit": {
    "bytes": 12336056,
    "sha256": "1dcf6a8a92d4ee1607de8dd770f5ae9b1ed6a7a3890aa8d91c336d1865b68bf9",
-   "timestamp": "2024-07-24T09:25:54.000Z"
+   "timestamp": "2024-07-24T10:25:54.000Z"
   },
   "tombofthunder/maps/tot4b.bsp": {
    "bytes": 21577448,
    "sha256": "40533ce1fee444e69a8247c9adb55bb467b002e50ca922dff656dc2f054b58f1",
-   "timestamp": "2024-07-24T09:43:06.000Z"
+   "timestamp": "2024-07-24T10:43:06.000Z"
   },
   "tombofthunder/maps/tot4b.lit": {
    "bytes": 12336056,
    "sha256": "96985572c8c605226e47dd367f6dcb5c9b606e9e5fc87ba01a388bc7383f5afe",
-   "timestamp": "2024-07-24T09:42:46.000Z"
+   "timestamp": "2024-07-24T10:42:46.000Z"
   },
   "tombofthunder/maps/tot4c.bsp": {
    "bytes": 21581368,
    "sha256": "1964787fc503b3b30d3ab57515b69383c05f1a688aca2e2513c7f57e716f5843",
-   "timestamp": "2024-07-24T09:58:08.000Z"
+   "timestamp": "2024-07-24T10:58:08.000Z"
   },
   "tombofthunder/maps/tot4c.lit": {
    "bytes": 12337112,
    "sha256": "5a10f8bff843c1ff701ad6789070def2958c15121761de7f363c7259cbcd0a88",
-   "timestamp": "2024-07-24T09:57:48.000Z"
+   "timestamp": "2024-07-24T10:57:48.000Z"
   },
   "tombofthunder/maps/tot5.bsp": {
    "bytes": 23201000,
    "sha256": "f36b7c776c1d97a78ac5a7816a7479e660a3c04aecb08664aa7e8778331a3be5",
-   "timestamp": "2024-07-08T08:28:58.000Z"
+   "timestamp": "2024-07-08T09:28:58.000Z"
   },
   "tombofthunder/maps/tot5.lit": {
    "bytes": 9687932,
    "sha256": "53c1436cbe4e99e24ea0d585a06a591b56205bac6ddf8ecce9fb467ba5c904e8",
-   "timestamp": "2024-07-08T08:28:44.000Z"
+   "timestamp": "2024-07-08T09:28:44.000Z"
   },
   "tombofthunder/maps/tot6.bsp": {
    "bytes": 7983864,
    "sha256": "f0b974887fb341f0662a94e71ed66f694c8efa6ff4abcfea0c1c95b78c9f2607",
-   "timestamp": "2024-05-20T11:42:42.000Z"
+   "timestamp": "2024-05-20T12:42:42.000Z"
   },
   "tombofthunder/maps/tot6.lit": {
    "bytes": 3668252,
    "sha256": "2587e3a1f536535e0ce4eda92b6ed89025c26b75325091f8558410d689fed330",
-   "timestamp": "2024-05-20T11:42:42.000Z"
+   "timestamp": "2024-05-20T12:42:42.000Z"
   },
   "tombofthunder/maps/tot7.bsp": {
    "bytes": 24527588,
    "sha256": "bdfe21e70e48ad3039c6bf8eec501e749dba7694e15cc114bba3a32f00c45c04",
-   "timestamp": "2024-07-01T12:46:54.000Z"
+   "timestamp": "2024-07-01T13:46:54.000Z"
   },
   "tombofthunder/maps/tot7.lit": {
    "bytes": 14776928,
    "sha256": "979ff0ffc17d3e0e027764fa525336e9504986d7fac91cd4a79a6de3f82d6d09",
-   "timestamp": "2024-07-01T12:46:34.000Z"
+   "timestamp": "2024-07-01T13:46:34.000Z"
   },
   "tombofthunder/music/": {
    "bytes": 0,
    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-   "timestamp": "2023-12-14T22:55:00.000Z"
+   "timestamp": "2023-12-14T23:55:00.000Z"
   },
   "tombofthunder/music/track12.ogg": {
    "bytes": 1750132,
    "sha256": "c321c68fcea1a8d9247f7d2f61c6423b75cee37bf7979b14518d36a9c3fb204f",
-   "timestamp": "2021-10-07T10:42:38.000Z"
+   "timestamp": "2021-10-07T11:42:38.000Z"
   },
   "tombofthunder/music/track13.ogg": {
    "bytes": 5475071,
    "sha256": "43cb8ba8e7865ff27cd2c7b21f7cf6825395b670f7ff5015a9bc481cfb7e49f4",
-   "timestamp": "2021-10-07T10:52:02.000Z"
+   "timestamp": "2021-10-07T11:52:02.000Z"
   },
   "tombofthunder/music/track14.ogg": {
    "bytes": 3849154,
    "sha256": "6408f2a9c7ea9c43c98cee348097917cfe91803dd6648167699837d62462522c",
-   "timestamp": "2021-10-07T10:55:10.000Z"
+   "timestamp": "2021-10-07T11:55:10.000Z"
   },
   "tombofthunder/music/track15.ogg": {
    "bytes": 4628309,
    "sha256": "d61e8e5fff53154335dad555b15610e23090d711c9744f30400a3c910e0cf3b5",
-   "timestamp": "2021-10-07T10:56:10.000Z"
+   "timestamp": "2021-10-07T11:56:10.000Z"
   },
   "tombofthunder/music/track16.ogg": {
    "bytes": 4205436,
    "sha256": "49e8500cdf10331c40e2e425cd5b8a45d073bb9c3e706a9a083b7980bf28d40a",
-   "timestamp": "2021-10-07T10:57:06.000Z"
+   "timestamp": "2021-10-07T11:57:06.000Z"
   },
   "tombofthunder/music/track17.ogg": {
    "bytes": 6337428,
    "sha256": "c728ac295b5be0bba7b4bc0a4edb4585eda3d4a8c41db44bf31e964bf1a48d72",
-   "timestamp": "2021-10-07T11:00:30.000Z"
+   "timestamp": "2021-10-07T12:00:30.000Z"
   },
   "tombofthunder/music/track18.ogg": {
    "bytes": 6958538,
    "sha256": "af33e96ed2ae137ade2483228c2cabc7f153202f3a213206318c32ffae8e23c0",
-   "timestamp": "2021-10-07T11:03:32.000Z"
+   "timestamp": "2021-10-07T12:03:32.000Z"
   },
   "tombofthunder/music/track19.ogg": {
    "bytes": 4543868,
    "sha256": "852f0143536a21a19e6d81c639e6523ee07f493b4e5c0a5a319603b364b5b5c0",
-   "timestamp": "2023-12-14T22:55:02.000Z"
+   "timestamp": "2023-12-14T23:55:02.000Z"
   },
   "tombofthunder/pak0.pak": {
    "bytes": 8014300,
+   "files": {
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "9aea834c381c925104dab6aaa818f6c4bee9ea625c47cb912b9b71a602b7470c"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 307208,
+     "sha256": "8d3814bcbfa7168685dd1044504d3a422b8619b2ff6d87208203b79cd8f970db"
+    },
+    "gfx/temp.tmp": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "gfx1.wad": {
+     "bytes": 118996,
+     "sha256": "fb6c53211df13506775e876e48eee64bbedd4db68d90805c0bbf6885639aa8d2"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/alarm.wav": {
+     "bytes": 83564,
+     "sha256": "62025f4871e7433bdff0ba4385a49305a31074bd77e916b7be823ccbdb517fac"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/fusein.wav": {
+     "bytes": 54542,
+     "sha256": "0cc8a1c6176c7c26dfbd03631c74bf25a5cfe99c03d402188c9f0a5ff5a4fcac"
+    },
+    "sound/ambience/fuseout.wav": {
+     "bytes": 61382,
+     "sha256": "59809909620202a8d10f0495ab314e6f052c8a18479846bc4487b766f593faef"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/klaxon1.wav": {
+     "bytes": 97624,
+     "sha256": "aba8baa9c677e02d8d08994b33cd24210fa6767d778db779a2e572e64aa076e6"
+    },
+    "sound/ambience/klaxon2.wav": {
+     "bytes": 53056,
+     "sha256": "3ae3bf58b9a45dbf51243555b04d2d6776cd708c4dc8c13ba4e1e2b2daa8f8cf"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/lite_on.wav": {
+     "bytes": 92362,
+     "sha256": "ca329bad63910f68b603c3cd9eea0b8cd9d7428f96ebb27032a066808637e8bc"
+    },
+    "sound/ambience/lite_out.wav": {
+     "bytes": 80906,
+     "sha256": "d5e5747ec548eb9118c2190a59b9dcdcbe5335a2987726d7768415eb7e1fe573"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/radio.wav": {
+     "bytes": 235522,
+     "sha256": "fa0c9d92d9705e11d60b5964d67c23853d99904d98e202f361ef6c8d989e4b5f"
+    },
+    "sound/ambience/rain00.wav": {
+     "bytes": 54948,
+     "sha256": "60d957454e6802d90ed163b20f9729d1cb2455bb8ab9b6f8964105e876b3793b"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/vent.wav": {
+     "bytes": 75816,
+     "sha256": "f7092e792f7e9d8f57c3417bacda4f445b4f24cf5076071cb0eb23490b71fb31"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/enforcer/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/glad/flak.wav": {
+     "bytes": 19658,
+     "sha256": "de2bd26b99e767c13e6aece83ff6790b46abe27e91f4bd20b2646b0428786f76"
+    },
+    "sound/glad/ogdrag.wav": {
+     "bytes": 12396,
+     "sha256": "e7cf55df89c831567f8bf7b02e57b987e3b57eb34bfe48225167f2af6b640c11"
+    },
+    "sound/glad/ogdth.wav": {
+     "bytes": 12052,
+     "sha256": "0587d14849b0fec40eeea6dc4d61db548a8d760e17cbee07f572e5de081c5a5b"
+    },
+    "sound/glad/ogidle.wav": {
+     "bytes": 61810,
+     "sha256": "40ecc9597a7c2fa5d65f203dd022379bf3b85bfe4a19612181f5dd29f831d1f8"
+    },
+    "sound/glad/ogidle2.wav": {
+     "bytes": 12292,
+     "sha256": "14d217d02c7a3898d835cda4ee00c80afe722943d0d538a0b7b95e7b3cb8230d"
+    },
+    "sound/glad/ogpain1.wav": {
+     "bytes": 7730,
+     "sha256": "c8f157894e5651a2f599994d489520c539549dc5cb51d803e0ad60364b0c205a"
+    },
+    "sound/glad/ogpain2.wav": {
+     "bytes": 9108,
+     "sha256": "77a09d54447b3ce0b3a304545f613da813b29365de2d0c168c07ccdc1d6b04e7"
+    },
+    "sound/glad/ogpain3.wav": {
+     "bytes": 10930,
+     "sha256": "041d603a4c53633324dc28f937d80e51c70fb3f80fbd18f41a8b160ef7596f2a"
+    },
+    "sound/glad/ogsawatk.wav": {
+     "bytes": 16154,
+     "sha256": "f24f86055999053273798d54f646064f3053414dfb14167d611aa1cb6dbbb51b"
+    },
+    "sound/glad/ogwake.wav": {
+     "bytes": 8420,
+     "sha256": "fd327b2b1f56656b3573262486b2756494d6812dbf5bf6b1e5bd939da3ed4297"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 6494,
+     "sha256": "259c57ed9a96e2794933fb1e5ddabddbdc87069968590d6e3ac69895c18282d3"
+    },
+    "sound/items/armor2.wav": {
+     "bytes": 7704,
+     "sha256": "081c3f62f9a94969f75947b51c785d40a6d24b16d39f529804b5c85404f7cae6"
+    },
+    "sound/items/armor3.wav": {
+     "bytes": 9252,
+     "sha256": "c51e305d5a2b42f6b9b9dfd82fc1870e086a0b2ab8c04dbe3c00a1e04784f98f"
+    },
+    "sound/items/clock1.wav": {
+     "bytes": 38168,
+     "sha256": "ee475af2135a5c9d8b2afab199c2131d95070b9e3a56e3571adf3f00b95c50b9"
+    },
+    "sound/items/clock2.wav": {
+     "bytes": 70976,
+     "sha256": "8b40b62f88303d16cfc6fef6b7ad1be584c50764c2883075eab77bd220fb155b"
+    },
+    "sound/items/clock3.wav": {
+     "bytes": 130248,
+     "sha256": "a04c45553280fbb992308fb0aade8ac8e74ec4e4c2ab8400a69de8bad642fc25"
+    },
+    "sound/items/drop.wav": {
+     "bytes": 11888,
+     "sha256": "fc7a1d39fb54ace150dab785d0e9e642f8f710ea3d425c7799daf223542a3b58"
+    },
+    "sound/items/haste1.wav": {
+     "bytes": 13420,
+     "sha256": "267bcedfe84a50bc1f5257d5cc7cd401465bd012682b328546e5af61f8fc29cb"
+    },
+    "sound/items/haste2.wav": {
+     "bytes": 31622,
+     "sha256": "c8e298dab6c215bffc237cd6681dae38c803250e1c199db9b61f523500ce3e13"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/items/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/misc/nuke1.wav": {
+     "bytes": 203012,
+     "sha256": "d79e18f8f3dec7f83cceeb8d273bad68457690c876069f03c64d4e194dfedc04"
+    },
+    "sound/misc/nuke2.wav": {
+     "bytes": 504160,
+     "sha256": "42edcbb094427ec9adaaa6e7a853296abfa35bb5e9fd38081f71c5c72179f755"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/zeus.wav": {
+     "bytes": 68308,
+     "sha256": "59947806a8313f276a873fd0f7c1265a671f74e04e3b35217f6f8728cf8d2fc5"
+    },
+    "sound/nailinf/death.wav": {
+     "bytes": 18898,
+     "sha256": "b9bbb261c4f58c7857f368e7482a6706b1a4105b3ad4e41a700d1025d29d38c6"
+    },
+    "sound/nailinf/idle1.wav": {
+     "bytes": 28822,
+     "sha256": "c5dcd7bf900ad11e204beaf05f3db54d4c9f23f33358c0bb34e063fd41900390"
+    },
+    "sound/nailinf/nailshrd.wav": {
+     "bytes": 19178,
+     "sha256": "fd948e19c399a4b157601acbd875b1f2b4f5da8e000cd3c688d1e6ee0dc76a47"
+    },
+    "sound/nailinf/pain1.wav": {
+     "bytes": 5118,
+     "sha256": "81038879b6d933fe59d29059b5d0655b6e9bbd96c11f902c5d6fd5e3acb0a333"
+    },
+    "sound/nailinf/pain2.wav": {
+     "bytes": 5680,
+     "sha256": "a8eba9496de56151703e9a8b93dc9f0ab7e161ae351acd0082feda567959ebb1"
+    },
+    "sound/nailinf/prepfire.wav": {
+     "bytes": 6390,
+     "sha256": "eec07407720f84a37e600f22eb0265549d350add8af972dc507ed0306c20a121"
+    },
+    "sound/nailinf/sight1.wav": {
+     "bytes": 18618,
+     "sha256": "6f6f9f5c2d92b87abae4c2fc78c92b3e96f20a5d9e53eacf9eebb283bd4558da"
+    },
+    "sound/nailinf/sight2.wav": {
+     "bytes": 15670,
+     "sha256": "42dbf9e02a96ba2e6cd2bee0adf9dae22292c572d9c00bc499a699e6ea4da9cf"
+    },
+    "sound/nailinf/sight3.wav": {
+     "bytes": 14522,
+     "sha256": "38851d768386b7096548b082235da9921966905678ca84027567e59b6e603bc1"
+    },
+    "sound/nailinf/sight4.wav": {
+     "bytes": 19798,
+     "sha256": "0583212c3dd33bede0fd9e2963a04c8320add72c523305dafc6f3dd3b28cda59"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "sound/progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "sound/progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "sound/progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "sound/progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "sound/progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "sound/progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "sound/progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "sound/progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "sound/progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "sound/progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "sound/progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "sound/progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "sound/progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "sound/progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "sound/progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "sound/progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "sound/progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "sound/progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "sound/progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "sound/progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "sound/progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "sound/progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "sound/progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "sound/progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "sound/progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "sound/progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "sound/progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "sound/progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "sound/progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/weapons/acell1.wav": {
+     "bytes": 46444,
+     "sha256": "36effe01dee2f868809118ef297e9a210ccdc1ba6b1bafdce31b508b8431a5c2"
+    },
+    "sound/weapons/acell2.wav": {
+     "bytes": 49860,
+     "sha256": "12fb19410492c42e0f97ec3c33ebe75c9128b2b5bce29cae1b21c5d110c127cd"
+    },
+    "sound/weapons/anail1.wav": {
+     "bytes": 4950,
+     "sha256": "ee61c5455fc13216173e44a58ce13a522ba74d354bbb5707177131daec2376c1"
+    },
+    "sound/weapons/anail2.wav": {
+     "bytes": 7300,
+     "sha256": "fdb33dade14269d4d5e7de03e30c087b057e00f9635a1411a12fca70b7bc91db"
+    },
+    "sound/weapons/arocket1.wav": {
+     "bytes": 11626,
+     "sha256": "094f39f68641a9deea4b101c1cb88beb1ea35b81354daf84aebe9949bf48f36f"
+    },
+    "sound/weapons/arocket2.wav": {
+     "bytes": 14462,
+     "sha256": "6cb040193e0bb7042f119839205b153f2312328602a9b969fa319bc45b521a39"
+    },
+    "sound/weapons/ashell1.wav": {
+     "bytes": 4970,
+     "sha256": "110caa401cbad16cf3fc78b0d60c27c11640d355a425cf4a18dbcb58954c13e3"
+    },
+    "sound/weapons/ashell2.wav": {
+     "bytes": 8308,
+     "sha256": "e7f7c5545944f2c8ca518ffbf6af542be4bbb22ff0aa2d039c5f64bef6e83f57"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 9552,
+     "sha256": "655018e0b1ebd61283db23ff324574948295e3a9ca43337e49c8d49938666210"
+    },
+    "sound/weapons/chain2.wav": {
+     "bytes": 19022,
+     "sha256": "bbc5dcc50a31fb7c44d8c8f3cfa1c919e0c15875140f9ab3a9768ecfab0ebb8a"
+    },
+    "sound/weapons/chain2z.wav": {
+     "bytes": 19090,
+     "sha256": "b4be4c88effc6d0605b34cbcb772d79b7dbccf8c902f5bc76a17bf3131b32e95"
+    },
+    "sound/weapons/chain3.wav": {
+     "bytes": 2676,
+     "sha256": "61183aad8e0f3c4716f4243a74728fee29fde7db9ca08b522ddc98834c10998a"
+    },
+    "sound/weapons/expl.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/guncock1.wav": {
+     "bytes": 20384,
+     "sha256": "7d399ac16f8740afa3abef1ced4f2793ec280c3a9cdc7e44c4cf66c2da3e979a"
+    },
+    "sound/weapons/hot1.wav": {
+     "bytes": 3252,
+     "sha256": "2b21217fbc4d5f4f862f69f31a58473dd29f23110d321a1a3afcaf7e504d672a"
+    },
+    "sound/weapons/hot2.wav": {
+     "bytes": 29170,
+     "sha256": "25cd7092c9b4987f923f534957a312852b920f185af63c73e84b765e7889d3bc"
+    },
+    "sound/weapons/hot3.wav": {
+     "bytes": 50978,
+     "sha256": "c6b312455b7678b0ebf0f55753cc39b9e07178ec5d5fea2605310eca6e52a915"
+    },
+    "sound/weapons/hot4.wav": {
+     "bytes": 10698,
+     "sha256": "254ba8798743618faf4d4738ff779cbd686dcda7c0da1a3d639290aa88dd02a0"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    },
+    "sound/weapons/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/weapons/noammo.wav": {
+     "bytes": 5410,
+     "sha256": "30f367e95cf5193d4c6d964b642d7b10d49fdaf354afdfb686e4661256c3db56"
+    },
+    "sound/weapons/pkup2.wav": {
+     "bytes": 10118,
+     "sha256": "3be3ba31de2818cb915a4a4cf4721b1271a0983f1e9ad3df1142793809dd5570"
+    },
+    "sound/weapons/pkup3.wav": {
+     "bytes": 9276,
+     "sha256": "13098a619b250590b51cc0a609e18a396a3fa79576abb3c72742534c9083cfb5"
+    },
+    "sound/weapons/pkup4.wav": {
+     "bytes": 8090,
+     "sha256": "5f2e794af6199386e7bbfdd5961a3cb67ecac41b87e5d2336f15f95f09f1b865"
+    },
+    "sound/weapons/pkup5.wav": {
+     "bytes": 23018,
+     "sha256": "c3131e35745097fd1ab966e3334544f3af49e2a96c2ca0dd428e960de5562b28"
+    },
+    "sound/weapons/pkup6.wav": {
+     "bytes": 11140,
+     "sha256": "a23f96837b00b8ba574d6edfe7421f47e2115b6a6b5dedc9761eea0cece0f823"
+    },
+    "sound/weapons/pkup7.wav": {
+     "bytes": 9594,
+     "sha256": "a1b429e7759d70fb68fb90561ebb7a3addb0291628e225c8650bf9a52ff2882c"
+    },
+    "sound/weapons/pkup8.wav": {
+     "bytes": 15798,
+     "sha256": "2b8e586ae22b5138b7e2d46d76ed4c47dedd3bda14e0e1a64dd8a6a734fe0745"
+    },
+    "sound/weapons/pkup81.wav": {
+     "bytes": 10040,
+     "sha256": "708f7935c4b5d291703697400be66776417a19cd4a6db7871db85875d904e605"
+    },
+    "sound/weapons/pkup9.wav": {
+     "bytes": 33732,
+     "sha256": "cc2a7dcc1d16b17a598e2472b69f941c603dec77131853d8884d20a1ccea8046"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/weapons/rail1.wav": {
+     "bytes": 28566,
+     "sha256": "837b5d892f618e74178c0dbf455c3cd24c3d067d28b56d785e4c8e08302251b7"
+    },
+    "sound/weapons/rail2.wav": {
+     "bytes": 19078,
+     "sha256": "b2ad37e275ce2857b2ddc52a8d7f537eb02bbf2f7239b857d12d87fcfa5b4793"
+    },
+    "sound/weapons/shotcyc1.wav": {
+     "bytes": 18242,
+     "sha256": "c069f126338f166129ce9eb8065999dc4348028f92ac5af72075843885b8ff48"
+    },
+    "sound/weapons/shotcyc2.wav": {
+     "bytes": 3372,
+     "sha256": "8446a93c88c9574d63f3d4c3c395894da50343b55b7a1a97354f93e75eb7a122"
+    },
+    "sound/weapons/shotcyc3.wav": {
+     "bytes": 6190,
+     "sha256": "8fcfb6080be436f6ffb5b1310ba100d39a184e20aac1588050a6d62001334f68"
+    },
+    "sound/weapons/switch.wav": {
+     "bytes": 6238,
+     "sha256": "149f95b9a0a2711ff1578419efa367f384ae50311ca0b9e928f12f806501799c"
+    }
+   },
    "sha256": "9397cfeeabcc3f90c92255a84defef7b2cfb4b09841549fd8100b6932819bada",
    "timestamp": "2024-05-17T10:43:02.000Z"
   },

--- a/json/by-sha256/97/97bb61f85d3b64492bf6e3a003c41b038351ad26d5eeaf0ded602e2e25e5d809.json
+++ b/json/by-sha256/97/97bb61f85d3b64492bf6e3a003c41b038351ad26d5eeaf0ded602e2e25e5d809.json
@@ -32,6 +32,480 @@
   },
   "jpqm4/pak0.pak": {
    "bytes": 30375826,
+   "files": {
+    "maps/debris/brick01.bsp": {
+     "bytes": 7912,
+     "sha256": "c11880924b195ed38908cbf50f9cd16f071918df0a94a19c7254b93dddb1e62d"
+    },
+    "maps/debris/wood1.bsp": {
+     "bytes": 7584,
+     "sha256": "c39390e3757553352941fcc255da6498be4c25a87575871e360a0166fac592bc"
+    },
+    "maps/jpqm4.bsp": {
+     "bytes": 17784280,
+     "sha256": "b2e1b649cd782983b8e6d8997575374b4154acb9d746f60eee6ab0c3ebe7bac5"
+    },
+    "maps/jpqm4.lit": {
+     "bytes": 6733316,
+     "sha256": "3a5b579d8adc18bd418966923b7ddfe3abf911d65b0fa1d3b91a68ac85ff71d7"
+    },
+    "progs.dat": {
+     "bytes": 629374,
+     "sha256": "958d1e69318d8fcc9b87cf5ec4caf7bc054fef4380d8b4c146b125deaa314294"
+    },
+    "progs/a_mdls/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "1cdfc2b54dd883efe9215499603e341bfa72e800740a2e874e9bcf3b0afc68ba"
+    },
+    "progs/a_mdls/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "8cb54159eeaa410b98478e9190bd2d33340d3a2e98a61d32ce1afaf4e99031a0"
+    },
+    "progs/a_mdls/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ac361970fb1cbbb87ad4593afecd6d8973a65ea4f14e5f7b565c8f38c181fa9d"
+    },
+    "progs/a_mdls/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "0870b633f95bda895074e8d423631ee8805c3923f36a1c7f09938710783e8f99"
+    },
+    "progs/a_mdls/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "146955794f29c02f6570eed83e1d4b0013b0b4341897bcbc91cc9ffea6957ff4"
+    },
+    "progs/a_mdls/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "59988afc3603b83ccfadf0a9af423a113bf15ed969d4a62db9073e3061bc0fdc"
+    },
+    "progs/a_mdls/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "696594c11dd6dbd2e60ac6923d82a55f8f5b16e93b93f7914abe5fd4df74299f"
+    },
+    "progs/a_mdls/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "b558ee2dfd0078c7e3075079fb40368f53e7dfb162aaefcd20e53f562e405b1b"
+    },
+    "progs/candle.mdl": {
+     "bytes": 24135,
+     "sha256": "5027f8712c36de87b3967e4e623fbc64d4e99644f5b805f7e21ec38b1532cc74"
+    },
+    "progs/debris.mdl": {
+     "bytes": 270552,
+     "sha256": "714b4fc3ce6675f0f4edc6ed7022e817f3922cde1877eb5418e4ddf60d798724"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 472208,
+     "sha256": "3345599ba081d346c163f5c239815bd65b134ccf342601f42a31e60a45044f39"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/g_shotty.mdl": {
+     "bytes": 23380,
+     "sha256": "b919bbcba3f7f03fb8b82fa6d3b1464ca41e81cf29417cfea0de09658c698cfb"
+    },
+    "progs/h_boss.mdl": {
+     "bytes": 63532,
+     "sha256": "320aff68d374f002ed468bf17ddeca4d95f59ef68c7dd3a17287fef2da1f0b46"
+    },
+    "progs/h_mdls/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "2e7fac7418838a721d80e80370000f3e400b21248b22c8d3555588d4f8437a5b"
+    },
+    "progs/h_mdls/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "1f4b0791be3156763c15521fbf2e747744ce3355d90d630b01c2227770314771"
+    },
+    "progs/h_mdls/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "6f792b9a80f34e31bceb4258e1d2c8f22d405a7ae1198b31bb285f502c720cfe"
+    },
+    "progs/h_mdls/pd_vial.mdl": {
+     "bytes": 24396,
+     "sha256": "aab843270d62a97b563b274d08c67c8d5de697e766ba1e928f190b7c7baaf108"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 42048,
+     "sha256": "52760ce1f6e8f657e782846571baf9fde80859f5342d07a684fa8218f96f68db"
+    },
+    "progs/lspike.mdl": {
+     "bytes": 1684,
+     "sha256": "59264317258f19955b967177f0dbc5be1733e4ca07c4c7b3cc333bb88bc0c46e"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 315696,
+     "sha256": "bbfc76137aa7beb3d16231499e041d51e156ef619607c660efa46438cce45891"
+    },
+    "progs/pd_armor_sh.mdl": {
+     "bytes": 31508,
+     "sha256": "46b9de8235f07190e18d67e147ed00be6dc322cd112ccde33bf4fc1f9a77e074"
+    },
+    "progs/pd_base_key.mdl": {
+     "bytes": 21219,
+     "sha256": "320ec52018f501f8fe428dd46f44693787e545289be883a49f3bd6476974cf46"
+    },
+    "progs/pd_bpack.mdl": {
+     "bytes": 216452,
+     "sha256": "cf13d3a5239b9f6028b2a848f564769d97fcec164b56f266bbcf2657af5127df"
+    },
+    "progs/pd_rune_key.mdl": {
+     "bytes": 46335,
+     "sha256": "c4fe9bd66394231ace3127635f057987ecbf4b13b00d84501127caacb5db03fc"
+    },
+    "progs/pd_wiz_key.mdl": {
+     "bytes": 21907,
+     "sha256": "36b50211f687813b85648a46bd32a1d543a8f2af84e9d4223f8b5843f885e1bc"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 29224,
+     "sha256": "a9c150fb5c19e6e0bf7ead5dcf6ae87d8e9745f4a439779266d0a258e16b6890"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 320900,
+     "sha256": "e3321220ed34292da63fac94af63360c6544c055edd1eceed35d75eb26685e9b"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4416,
+     "sha256": "8c70353304b2d111260102565745a5504144568f932787906eaf50de742aa62c"
+    },
+    "quakec src/LICENSE": {
+     "bytes": 18431,
+     "sha256": "189b1af95d661151e054cea10c91b3d754e4de4d3fecfb074c1fb29476f7167b"
+    },
+    "quakec src/README.md": {
+     "bytes": 239,
+     "sha256": "2be824d72bdef25ec9f90b9b55b63a24334282d53d83ec79ac273249821bc79c"
+    },
+    "quakec src/ai.qc": {
+     "bytes": 16106,
+     "sha256": "afe7fd0dab4c5acbb35b6dc2e25f9f019b45a714b07f3c677a2e77124cc296c6"
+    },
+    "quakec src/boss.qc": {
+     "bytes": 13622,
+     "sha256": "f3a9aa39d57adda1b897908fd26c28e0151eaaa2920ed6a082b18b46b94a33e3"
+    },
+    "quakec src/boss2.qc": {
+     "bytes": 15987,
+     "sha256": "4aa8179663b52698079673aa46f263f9e2769e3d657a725897023bfc414c331b"
+    },
+    "quakec src/buttons.qc": {
+     "bytes": 3249,
+     "sha256": "1a814605af733bb3fc6ae250d7af5cb0b2d40bd3b37f5522b6d928126dd6eac9"
+    },
+    "quakec src/changelog.txt": {
+     "bytes": 9966,
+     "sha256": "3cd20bfb967d6cdfc724b1da9caaf77365c158d73c092d5ae932fe337f183324"
+    },
+    "quakec src/client.qc": {
+     "bytes": 42633,
+     "sha256": "d0ecb904610a814c60e20194b1fc42287f36e9ad23ff04f2ad60a332a6e005b4"
+    },
+    "quakec src/combat.qc": {
+     "bytes": 7192,
+     "sha256": "c1b5774a0b11c50cf5e6508e11349aa38c6bc8b468fad60fe7c0a4a1d30c9cc0"
+    },
+    "quakec src/custom_mdls.qc": {
+     "bytes": 2167,
+     "sha256": "3798f019c4c7151be89ccbebb560120101e69357a1da645a497b90fcb9bbbba3"
+    },
+    "quakec src/customsounds.qc": {
+     "bytes": 5564,
+     "sha256": "26bce1b876f3a8a709a2b61298d1f65de5f568f24ac66db713e8585afc694f5d"
+    },
+    "quakec src/cutscene.qc": {
+     "bytes": 30669,
+     "sha256": "b9ec452e62de479c53c05ac56a943c79d89ac7d6ee3d3bb3c68fb203656ac5cd"
+    },
+    "quakec src/defs.qc": {
+     "bytes": 25275,
+     "sha256": "01844d4c5c8ab85a9e4276900c1aed7e6d5a4260aa4e646f6dc8d057d06ee4a8"
+    },
+    "quakec src/demon.qc": {
+     "bytes": 14554,
+     "sha256": "c86075c879715287caad3d5a014eef446ad77b438fd0756905f0f95dd202bd33"
+    },
+    "quakec src/doelightning.qc": {
+     "bytes": 4955,
+     "sha256": "4b6233156f3792d7529d714de7f992c066a927d5f9109d9947caa2a7a2341c57"
+    },
+    "quakec src/doeplats.qc": {
+     "bytes": 14879,
+     "sha256": "dcca85f99b803fbbafea7ecd0b12ae8cf02e9dc48422a28e6d70335f749eafe3"
+    },
+    "quakec src/dog.qc": {
+     "bytes": 14108,
+     "sha256": "ca8ce0d87fd1eda73eeeee13ace5eebd0bc183f7dc610cc1d6fce01c163bcb08"
+    },
+    "quakec src/doors.qc": {
+     "bytes": 18041,
+     "sha256": "539a978d92e7120db67fb89116f94744bd82333751a575c364955e8e0895cea1"
+    },
+    "quakec src/dtmisc.qc": {
+     "bytes": 29848,
+     "sha256": "8392b74d997a79b88866506c47215b50adc7a05bbb0c8bfc9cbbf5bbfb33881e"
+    },
+    "quakec src/dtquake.qc": {
+     "bytes": 2654,
+     "sha256": "170b5464e0092f6a2f261910108381fd93fdb7fb5dd7bc047863f7bcc462dd9a"
+    },
+    "quakec src/elevatr.qc": {
+     "bytes": 3624,
+     "sha256": "eb6a260d53ca8f7b69f20a8cc42341c597d5e06ea18bca86e6aabff71bbc892b"
+    },
+    "quakec src/enforcer.qc": {
+     "bytes": 24697,
+     "sha256": "55419fb7e3c912b0e47396304e3abe2fa219be8ba9b9da361d44c03dafc7b61d"
+    },
+    "quakec src/fight.qc": {
+     "bytes": 7568,
+     "sha256": "301de69f7dad8a34fb361ab90e2a907c62b4633c7dde410b9e4bd6b81c017500"
+    },
+    "quakec src/fish.qc": {
+     "bytes": 11627,
+     "sha256": "2a2a72686b7177527bbfa43304fcc126b8f66ff4724f1b0da57f93f2ebe693a5"
+    },
+    "quakec src/func_bob.qc": {
+     "bytes": 5676,
+     "sha256": "5fe11638fd89f509759c83748c519b98dc5fe5856b09fab1f6247518b9836143"
+    },
+    "quakec src/func_fall2.qc": {
+     "bytes": 5632,
+     "sha256": "11cb67e867005f519f2df4e382f6330aa2218f3c10a612911caa22cf6d69ae99"
+    },
+    "quakec src/hipcount.qc": {
+     "bytes": 5217,
+     "sha256": "da5c096495966fa9ef5315ba00b315987349a817c889b974d8a91f506e6aee1d"
+    },
+    "quakec src/hippart.qc": {
+     "bytes": 7983,
+     "sha256": "730ed584b4de9dd49283502419a8bcafb99e2f1a3d146e05afee0ab2547751c3"
+    },
+    "quakec src/hiptrig.qc": {
+     "bytes": 6260,
+     "sha256": "e0292ef23ab7c669257e30525897fa1ae64e3c0870002863e5fa98e8de95aca1"
+    },
+    "quakec src/hknight.qc": {
+     "bytes": 23977,
+     "sha256": "1c84fb40236ba7b067081570db4e0dcc1a669416efafc5c4dd99d1ffd488768f"
+    },
+    "quakec src/items.qc": {
+     "bytes": 67829,
+     "sha256": "a14256e3807beeeebb309c59092820445b226069f2927e373c08b4608b8afed8"
+    },
+    "quakec src/keydata.qc": {
+     "bytes": 5639,
+     "sha256": "5902993c9755a2851ef424e48572a9806d20d3aae67a8f9d01446c4aad09a91a"
+    },
+    "quakec src/keylock.qc": {
+     "bytes": 5884,
+     "sha256": "26751c63554a6e73da84138ee45871f501d3bb5250cbfa137a524087bc204e39"
+    },
+    "quakec src/knight.qc": {
+     "bytes": 14633,
+     "sha256": "8048aafb27c52ad8fb92bec060401a9702c0cf9918b34e2bdc49ae2b423705a1"
+    },
+    "quakec src/lights.qc": {
+     "bytes": 15369,
+     "sha256": "eb7bcc93ccdb36c7df4aa49bb370f4d37eb598cbc51c8a9c2ff668769194bcae"
+    },
+    "quakec src/math.qc": {
+     "bytes": 1813,
+     "sha256": "9d5303c03ed58760bedbeb3f017ddebd5bc0c27de43a1e62ea3b5ae8bab2b927"
+    },
+    "quakec src/misc.qc": {
+     "bytes": 39913,
+     "sha256": "fe61ad291552bea62f41c977ec823c96a8342bd026241a1bdae564942cfcaaa6"
+    },
+    "quakec src/misc_model.qc": {
+     "bytes": 1712,
+     "sha256": "1a070d9cc274f76c2032b2cc459a002df8ce76103aa9f318d100e577a204df21"
+    },
+    "quakec src/mobot.qc": {
+     "bytes": 13931,
+     "sha256": "b9e698b47980f8ca795cdc928b7e107a2897ad3578cc172eab45dcc38c96982b"
+    },
+    "quakec src/monsters.qc": {
+     "bytes": 10018,
+     "sha256": "335d8da10275b61aa57b939a022eb8995d3a745609ef83d321bf52731e94ef11"
+    },
+    "quakec src/newflags.qc": {
+     "bytes": 5870,
+     "sha256": "192bf31eb0f13e6e55342801a42608caf797bfdfbdf27750c78ae67b1c1c5568"
+    },
+    "quakec src/ogre.qc": {
+     "bytes": 39928,
+     "sha256": "37aaeb400bd87453aa8d3d5b9d399dcb7e9ca90b911d018167152d8058e7e860"
+    },
+    "quakec src/oldone.qc": {
+     "bytes": 10263,
+     "sha256": "71f269418437ca5dc5cdb1ebe917a1a7252fde104ca92011c0079fa7769aa740"
+    },
+    "quakec src/oldone2.qc": {
+     "bytes": 14736,
+     "sha256": "6a3cb7559241c34c69ca053780b8d2e156eef260e0e54a2d575ca3a690aaf357"
+    },
+    "quakec src/plats.qc": {
+     "bytes": 14266,
+     "sha256": "545511c895c06cc2676cfa33f953415b4ee33ad72f2292c7d0b70026fa77d3ac"
+    },
+    "quakec src/player.qc": {
+     "bytes": 20579,
+     "sha256": "5612eef978278acf038f2a24b9050f237ea966a79a02fe79e78f4687b527c541"
+    },
+    "quakec src/progs.src": {
+     "bytes": 1907,
+     "sha256": "9f39f79f6601938cb94f93831f5dbf7e14b974a25f7d86554cc417aba66f20d9"
+    },
+    "quakec src/rotate.qc": {
+     "bytes": 31330,
+     "sha256": "63103ad2bb9f6cf0479863d22188bfef46acc674d27ec00863b9c7f098d3c6af"
+    },
+    "quakec src/rubicon2.qc": {
+     "bytes": 28533,
+     "sha256": "6ef16da656ddbbe1550284da2f594be13623a1ac3ff5f0034df7c862e62d4e29"
+    },
+    "quakec src/shalrath.qc": {
+     "bytes": 13109,
+     "sha256": "a0f1b2be13a2a3cb3ba41b413669ed67419a8a3a26108771fe910065192cbb46"
+    },
+    "quakec src/shambler.qc": {
+     "bytes": 18148,
+     "sha256": "96c483b3af04299fd0368c430022082141ba10af96a1dc25771dfb4bc830b513"
+    },
+    "quakec src/soldier.qc": {
+     "bytes": 18710,
+     "sha256": "220d51eeb811a417c47eb999ca4b0d69c417444265f941913d1badbd898d9f99"
+    },
+    "quakec src/subs.qc": {
+     "bytes": 14185,
+     "sha256": "d0e5649ffd317bf70b4c85d686d7f7035ce68a7c616733039788746974a9554c"
+    },
+    "quakec src/tarbaby.qc": {
+     "bytes": 9855,
+     "sha256": "c81c6071648a0acb0d5f7dac6fc49b78661d43bc114ab3c11194bdeec9b199d2"
+    },
+    "quakec src/triggers.qc": {
+     "bytes": 39079,
+     "sha256": "1d057a55361fe573a3035524b44571a7f12cfd2b8be83f9c65948cf0932feb35"
+    },
+    "quakec src/weapons.qc": {
+     "bytes": 38077,
+     "sha256": "b1ba08d39931a7cd06adb497016be6a4cbbc585d507f1a86e8aa967ddda6b0a0"
+    },
+    "quakec src/wizard.qc": {
+     "bytes": 15610,
+     "sha256": "0ecf27e676b25de687da14413f82f535d6614719099fdd8775f6d7793c7d64b3"
+    },
+    "quakec src/world.qc": {
+     "bytes": 20871,
+     "sha256": "7be5e3b9e534fdd61250d1376b5c66531642b57d9edf996c7e8f365ea0e17b57"
+    },
+    "quakec src/zombie.qc": {
+     "bytes": 33395,
+     "sha256": "053eab38bec4d63e2c020b28bdf27a580de513c206d41b59cff7e49fa833e89c"
+    },
+    "sound/ambience/distant_gears.wav": {
+     "bytes": 72502,
+     "sha256": "760d34131249ff3c4bccdab0cd3df69874728a6db3e1b4545177e5ce381e5e80"
+    },
+    "sound/ambience/moo.wav": {
+     "bytes": 265502,
+     "sha256": "35b7924115bc4cdf94e9cbb274a4d9ca251d6878817834bec08aaa176f2ddc9b"
+    },
+    "sound/ambience/rumble1.wav": {
+     "bytes": 403620,
+     "sha256": "47afe820548bcf248b7760f7a66a61ea65b5fb79f70d47e3b03cf8211bb4c5f3"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 220548,
+     "sha256": "2cec0b03aa7047110862de21f8f6c77e4d98901ecaf5e405a473c2ddc922528a"
+    },
+    "sound/break/pd_bricks1.wav": {
+     "bytes": 61786,
+     "sha256": "3829842a9cb395f99d07546be38263eaf0ee5bbed71841aa8c93864d55a7fb94"
+    },
+    "sound/break/pd_metal1.wav": {
+     "bytes": 44146,
+     "sha256": "c0111b94231bc3870cbb95ec03f13b2b44ac407a5d18b35668ccf231303cc8aa"
+    },
+    "sound/break/pd_metal2.wav": {
+     "bytes": 70722,
+     "sha256": "ce8250482e831c270cc3c8e9211b74a627b3e29159c2c8ee720dd11cafd365c1"
+    },
+    "sound/break/pd_stones1.wav": {
+     "bytes": 75150,
+     "sha256": "632d15db23ff70c23c199595b41a153ded67f664de46b7d0cbfa0228f071156e"
+    },
+    "sound/break/pd_wood1.wav": {
+     "bytes": 34526,
+     "sha256": "621865f52fc27fb10108027ce3eea18aaf17181751a3ba1ceee0c9c99da9f375"
+    },
+    "sound/break/pd_wood2.wav": {
+     "bytes": 33342,
+     "sha256": "77282f2c533b9aec72b232aace9078534db3f255f418efafdf769c7361a28e05"
+    },
+    "sound/break/rock_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/break/wood_impact.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/dump/elec22k.wav": {
+     "bytes": 82784,
+     "sha256": "dd63a8517e33bbe7a75cd0d6ccb16835b73f83af8d31c0ae0277b7304f7d502b"
+    },
+    "sound/dump/pd_armor1_sh.wav": {
+     "bytes": 12410,
+     "sha256": "3b80fc8000fe624ffbe4f119faf41a77406b83bd350020c7782bc03fd51a1799"
+    },
+    "sound/dump/pd_magic_01.wav": {
+     "bytes": 125944,
+     "sha256": "3ea2bab80feccbe0f0b518ec613f45093aa76b0128752f454e239c75175cb4e0"
+    },
+    "sound/dump/pd_quake_end.wav": {
+     "bytes": 37248,
+     "sha256": "3ecb621fbf5a3f2ab090ebc0f3036069292181b11ab366689b3dfa0f19dd372a"
+    },
+    "sound/dump/pd_quake_full.wav": {
+     "bytes": 156278,
+     "sha256": "872e0b0847fd366c59341d672cba9da0faaf85a881f8d4d5471a664923c8440e"
+    },
+    "sound/dump/pd_quake_loop1.wav": {
+     "bytes": 159956,
+     "sha256": "52a330a12c35191347008f4c546b1c83b4e387f3f33c9b60c3a5e8e545b0517e"
+    },
+    "sound/dump/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/dump/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/dump/water_59_02.wav": {
+     "bytes": 40038,
+     "sha256": "25aa667940a737e46da0a829d9cb94922972b9b19726664d1a1133a666dc1439"
+    },
+    "sound/oldone2/pd_pop2.wav": {
+     "bytes": 42108,
+     "sha256": "1eec3103cd2eb70fa8ba63ce8ce721842a64a99e9c373f5a8abe5508273ce285"
+    }
+   },
    "sha256": "2530b53b7134d160b3c506cb67eafbafa156e17372f119af89c7f7f66be9c463",
    "timestamp": "2021-07-04T00:42:10.000Z"
   },

--- a/json/by-sha256/99/9945d6cc68c6de416e857a4cff09df4dbd3cbe9c20c690bc4fe24c9970318512.json
+++ b/json/by-sha256/99/9945d6cc68c6de416e857a4cff09df4dbd3cbe9c20c690bc4fe24c9970318512.json
@@ -22,6 +22,36 @@
   },
   "alk05/pak0.pak": {
    "bytes": 3336236,
+   "files": {
+    "alk05.txt": {
+     "bytes": 5304,
+     "sha256": "d39764984dece7c38f3844866de1f65d66ca82ded87572f2ebd065f92f2e0d41"
+    },
+    "maps/alk05.bsp": {
+     "bytes": 2620600,
+     "sha256": "29d52e40efae3cd02e7383600db97bc1e745e49aee71ee87ca532383602d7c89"
+    },
+    "progs.dat": {
+     "bytes": 423736,
+     "sha256": "c28f5d31d2a9ea83e9ce0aea20c749d1f35e4ef066655caf52ec4f6633127774"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 132028,
+     "sha256": "8824603b325f37bbba424f55c3ff900c21ccf61c77ba97e636e91ef99202364a"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "744af1fafaacb751cf2e5ce4bb15a0fc1fb938ae519469de6f0dccfe9f320414"
+    },
+    "sound/snakeman/sdeath.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/snakeman/spain.wav": {
+     "bytes": 34452,
+     "sha256": "15b84d6adb80e4ceace4226b5185c578a752adb36f213f2488e80ad2192378aa"
+    }
+   },
    "sha256": "84c21e370d51b118b8a6d5cf7b09dd1c7b89a42d771836c71c59109de6b8d6de",
    "timestamp": "2000-02-10T15:12:06.000Z"
   }

--- a/json/by-sha256/9a/9a921184890e7e5afd49f3973339433a73d8dff7b157a007320f7cc546fd63f0.json
+++ b/json/by-sha256/9a/9a921184890e7e5afd49f3973339433a73d8dff7b157a007320f7cc546fd63f0.json
@@ -12,6 +12,140 @@
   },
   "ZOOM9/PAK0.PAK": {
    "bytes": 3659146,
+   "files": {
+    "maps/zoom9.bsp": {
+     "bytes": 2043552,
+     "sha256": "744389a04c47c93208fe236b202108017415502ea8e7ddfde5fa2c1b2f66792d"
+    },
+    "progs.dat": {
+     "bytes": 646428,
+     "sha256": "10ca8a9764090681cba226b3a8b10b194eee26cd6d231dc08face6b579fdbfbe"
+    },
+    "progs/bomb.mdl": {
+     "bytes": 12724,
+     "sha256": "6846ac5cbbcd831063c541ec6accb9706a8be42ae4a58e723d90e8b4469d93ea"
+    },
+    "progs/boss.mdl": {
+     "bytes": 211836,
+     "sha256": "8bd7bfc5ee55d6c5c0cc3670176f264eeae8d88a2f0d505bba286968ebe48ab0"
+    },
+    "progs/dead2.mdl": {
+     "bytes": 64252,
+     "sha256": "4ccffc5b8aebcbdada3798700a3241379e6910117dfa6d65ca24b0adf83e74b6"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 160688,
+     "sha256": "64b61cc500edbd713c2ae3514bc28c7236f90e701021e4e1888baab2fffb7628"
+    },
+    "progs/laser.mdl": {
+     "bytes": 11348,
+     "sha256": "e313842710824e0952bd91876d65cf206688f32199926d1af15f657a3f6165cd"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 8788,
+     "sha256": "9777909b5cca5f1f92a61b5d4523b14bc70da81e3193c8b23065bf006e20d232"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 204492,
+     "sha256": "f417b20f750bfa1ba73e044d8d4c84af2aa91bc00148a45970c98ad59742a857"
+    },
+    "quake.rc": {
+     "bytes": 388,
+     "sha256": "2516c50bb7da57d5560d097509c0ed4377bd9030d606c9883cd3d0296c921cd7"
+    },
+    "quark.cfg": {
+     "bytes": 2,
+     "sha256": "7eb70257593da06f682a3ddda54a9d260d4fc514f645237f5ca74b08f8da61a6"
+    },
+    "sound/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/count11.wav": {
+     "bytes": 12220,
+     "sha256": "fa52530f524913ab4386e37709e29d0a5d91afc021c09ccd5c8c151167ba3d95"
+    },
+    "sound/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/enforcer/death1.wav": {
+     "bytes": 12326,
+     "sha256": "c899fe19a1758e106544686ae1ce3856c1c6af966ec1c412a415406297fb6a76"
+    },
+    "sound/enforcer/death2.wav": {
+     "bytes": 18214,
+     "sha256": "ec4856f0bbea6f57b630d309584e952b4001930f989793229f05c4f65daec2a5"
+    },
+    "sound/enforcer/death3.wav": {
+     "bytes": 14790,
+     "sha256": "a829872b22e998d81f1c069d14056cb1d0c0fc01b1fd7da82e88f7bb19a887da"
+    },
+    "sound/enforcer/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/enforcer/enfstop.wav": {
+     "bytes": 4325,
+     "sha256": "d3792af1a9141119589d57ef00b95ea32d4127f9590c3d2e82d3689407610cf9"
+    },
+    "sound/enforcer/idle1.wav": {
+     "bytes": 12768,
+     "sha256": "34d27f604bfb9ccd0c17e89883b5cfac68df1c30c06e6597bf1b868c44d62263"
+    },
+    "sound/enforcer/pain1.wav": {
+     "bytes": 4989,
+     "sha256": "459faa98a2b1a8e40b9dbe6a8bf1e232f403e8c40105723576bf4a74555b2c08"
+    },
+    "sound/enforcer/pain2.wav": {
+     "bytes": 9318,
+     "sha256": "db7bb2315b1852e3480af81c02bb5215b7ff730b342557fbdbc9a315db9289d3"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 16966,
+     "sha256": "8eb25dbd33fc23878aad58c970456eecf52406bc4a10663afb9640273bd9fc34"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 21734,
+     "sha256": "c8db3fbc2095bfbf6edf4943fe90bb575609b25310099ee3164015b2e1aaebd5"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 12998,
+     "sha256": "b85255bf4a62cc21e0c14cec7a8909889037c176b7e251fc9e70343941d0230a"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 18054,
+     "sha256": "b78dd977c95441a871a950eb29c34589ea7a79225e2d8587f43e4fc32dd04d7c"
+    },
+    "sound/fnoise.wav": {
+     "bytes": 22094,
+     "sha256": "94157d9e7132b80e3c209654eaefc7eb19345e86c214296a5f29aecc2479b033"
+    },
+    "sound/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/ice.wav": {
+     "bytes": 18514,
+     "sha256": "66715334fbe3c23a7e39766dec3e446a9626e6dceb5fad0833c0c967b63fe372"
+    },
+    "sound/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/misc/talk.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/swing.wav": {
+     "bytes": 12960,
+     "sha256": "68da54f9541808bdaa1f070218bd53ffce0cfccee46b460fd9181a366440952a"
+    },
+    "sound/techopen.wav": {
+     "bytes": 11108,
+     "sha256": "799f9b74eae7872dc1051f1dfb77a5b19c5e656fa4d8d84b30db23d04f611828"
+    }
+   },
    "sha256": "487ebd04282410bff8aa6526005da50c9ae6e1829a346512a7b0cf2ccd193372",
    "timestamp": "1997-12-18T08:31:32.000Z"
   },

--- a/json/by-sha256/9c/9c27f016d12f5772e7c5bf9b2a4be50aa87720d32b98f344313baeb34d31afdb.json
+++ b/json/by-sha256/9c/9c27f016d12f5772e7c5bf9b2a4be50aa87720d32b98f344313baeb34d31afdb.json
@@ -7,6 +7,448 @@
  "files": {
   "Pak0.pak": {
    "bytes": 13543634,
+   "files": {
+    "chasecam.cfg": {
+     "bytes": 2423,
+     "sha256": "13d568eaec3e199cfc6f01aa62c8118835c89b4467c8fe74f1f5b2b00d6da119"
+    },
+    "default.cfg": {
+     "bytes": 1918,
+     "sha256": "5e2088d68fdb391aca14c5a5af4a92035b4fbcaa98a775594384880234821560"
+    },
+    "demo1.dem": {
+     "bytes": 280293,
+     "sha256": "82be93ac2294aa05faae0283ba669a09acdd034e1011209c7a18210293dc8aec"
+    },
+    "demo2.dem": {
+     "bytes": 169582,
+     "sha256": "ad886bb5f7d9b329713a18b2a9332cc7fb4515bb17aa3a851e2f4ac333882b0c"
+    },
+    "demo3.dem": {
+     "bytes": 137882,
+     "sha256": "6a9e1b7f495e135f10033a109c8a0c927a00ca4ea6235211d221df0b77d8bb49"
+    },
+    "demo4.dem": {
+     "bytes": 250189,
+     "sha256": "d6c5ea7570caa3a47201e868aef79691603f6bca3d593d72117b87004c87a520"
+    },
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "5323a7c882536e17656258fc38b9cc4427a89e4b1f2fa5493b70f66b59178bd7"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "7414a53f6587a185f7fd1cca21caf610559c0857bffe9206d01dec7e34ed9235"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "473d3d7efcbb00f78b3e5c5bb01ed4bf1dc0bbf84ae2ce5049b2a9f09fd4cf7e"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "8f034873ef76f232eca4cf54d4fb7f6edee92c5b3ea5b34a2ceda6ad3573875c"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "ced4a0b4f17c337570f01919c32ad3ff87d022700eed46dc578ebd9a88ba33a1"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "1a715f59d6519902277534a93dc17ffb2fa59455e8bba1f7c9b68931fb2cb1c0"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3e425bb14b5e2446f12eec33d7828082fdc632c695b8e8e8719c36c8f2e91779"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "e6b318a2019058709ca0d68d67b65e7eee56072c098f44878a812b189459606b"
+    },
+    "maps/smdm1.bsp": {
+     "bytes": 749452,
+     "sha256": "2d2602ef9146ae82a8f06505614a66be48c5d761f7b8216c72da02cf4b177b0b"
+    },
+    "maps/smend.bsp": {
+     "bytes": 515556,
+     "sha256": "1daf4b89b85911db7ff827935c38914575c1294400c5767c92fb0f1106bd5a8a"
+    },
+    "maps/smlevel1.bsp": {
+     "bytes": 597040,
+     "sha256": "51e1651487a2e3d99d8edd910d4ee4eebc749c94317bb531fb2e523c3d01a8bf"
+    },
+    "maps/smlevel2.bsp": {
+     "bytes": 1946736,
+     "sha256": "ac832cfdbc530291bb9a8d2765da6257544ead50b5c7808dba3e11cbaecb39c1"
+    },
+    "maps/smlevel3.bsp": {
+     "bytes": 1467472,
+     "sha256": "8b3eb92696d8d56a702f606234fe4cb7b2c3b7f0f9618166c6b1df348a43b934"
+    },
+    "maps/smlevel4.bsp": {
+     "bytes": 1329420,
+     "sha256": "1f137913ba061639708e1ce48a7716d12240cf3f2668dbe188f549a0e179a81a"
+    },
+    "maps/smsecret.bsp": {
+     "bytes": 731636,
+     "sha256": "3d5d6aa19d37229f226c4b83f5fc9a24353be4766a89bd5f3c5353f8f1c7a1b4"
+    },
+    "maps/smstart.bsp": {
+     "bytes": 1178492,
+     "sha256": "8cb6692072cfd70f078db36e7eed8359ef7ed7ac5f6021b60495cfe0f28c0d78"
+    },
+    "maps/start.bsp": {
+     "bytes": 413480,
+     "sha256": "b83fb017cc0d1d1d0e59b29f72d0673dbc2c57254ce4b81e7edab2119a9aec38"
+    },
+    "progs.dat": {
+     "bytes": 820348,
+     "sha256": "f80f83081d115ec8b85f3dbd3d6c369ee15163bc40eb8eaa6d69b6abb1d32c1c"
+    },
+    "progs/bloodcb.mdl": {
+     "bytes": 28036,
+     "sha256": "83f0de29aa0f9e9f1d383895da374a5313aa2252edb306eb7bd69bd71660321c"
+    },
+    "progs/bomb.mdl": {
+     "bytes": 2889,
+     "sha256": "349773100c1560896ebfaf9566eacda9d38a2fe7cf9d2942fb00b995a0bfd766"
+    },
+    "progs/choke.mdl": {
+     "bytes": 2889,
+     "sha256": "e33aefd92f0fcda89e547dcddf25a282b765322fce9161a56da95055ea673a5c"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 256692,
+     "sha256": "bc712c93083e01fd2a8bab15b62bfbf5920811b936f09e4744f62bb30b9a8a1d"
+    },
+    "progs/lwing.mdl": {
+     "bytes": 34181,
+     "sha256": "2dd6e48dfd79c0cd01732010e287db6ed1c81422b50b2b3a709e2f852c5b67ef"
+    },
+    "progs/null.spr": {
+     "bytes": 57,
+     "sha256": "dc67fb2f31bd717353b8138f02bdc8ef2d70ace433c9fd91e3adc909fda513a3"
+    },
+    "progs/player.mdl": {
+     "bytes": 191852,
+     "sha256": "feb2f7747f6fd17d18eba5f1f594ac4db281fe7a727a6c1acb576ffeae83810c"
+    },
+    "progs/rabbit.mdl": {
+     "bytes": 92012,
+     "sha256": "1a0786f63d9a2f0e274f05ccf8b82ca0df1794a3cc637d0e82c728f2755914df"
+    },
+    "progs/rspike.mdl": {
+     "bytes": 4304,
+     "sha256": "31c04f10de010d94745f0dc603d24c3bb5c4142880543b2ce3f022be1bb8c47f"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "8650870ea418a2e51ff0cba26c9e9e0ea39f383075e279378009d3ebf010f0ca"
+    },
+    "progs/rubble1a.mdl": {
+     "bytes": 5716,
+     "sha256": "b4116dd10673155069d7d326fe16439596cbfbb2f6c8c5b31001fcf7e70355e1"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 16228,
+     "sha256": "f50f68f3247678041ae0eb26bd24b9ea8a57cbc2c66a092f8d35d6463b05b977"
+    },
+    "progs/rubble2a.mdl": {
+     "bytes": 16228,
+     "sha256": "16a1b41734ec932fe749051b31bd8b577af097e28bcaa930783fb84f5d51610d"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 22228,
+     "sha256": "64fe85a3f08f916df89ce670a1668d7dc28eaba000747b5e534423ea1d80dd85"
+    },
+    "progs/rubble3a.mdl": {
+     "bytes": 22228,
+     "sha256": "71ceb28d923fa713eb1537c898e84e1b2bb94c17955fc39946255ea5673dfa0c"
+    },
+    "progs/rwing.mdl": {
+     "bytes": 38881,
+     "sha256": "c10ad21e0f360fe2b197ca8d7c131095a4874e5fb42e3f52ad4ac0c1c46e276d"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/s_rain.spr": {
+     "bytes": 33100,
+     "sha256": "4c0bf4b61b6cd263d3f0453f7f050c94a30708f3d9604a44d50cfca1c232444b"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 7060,
+     "sha256": "dc89626ac1857e3f73629ff8246cd012bef5db2308ff9f1ef0a4c44804821bca"
+    },
+    "progs/sight.mdl": {
+     "bytes": 11232,
+     "sha256": "403e45bd6d474734d41bedb59102fc526340b307c408ad889316684f927b4b3d"
+    },
+    "progs/snail.mdl": {
+     "bytes": 248864,
+     "sha256": "276e89f96e9146c55c642de85eb099db4eb08aa569f34ec0883dab319a1baecf"
+    },
+    "progs/snake1.mdl": {
+     "bytes": 132028,
+     "sha256": "8824603b325f37bbba424f55c3ff900c21ccf61c77ba97e636e91ef99202364a"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 132028,
+     "sha256": "9ea32284a06ca961abe1e08a4f699ddfad1331277fc740d786322b634bcada35"
+    },
+    "progs/spider.mdl": {
+     "bytes": 94492,
+     "sha256": "df40e58bdf6465e68e5ef33cbcb77c42cc99e50c9dd842c8c3906c2fd04bfc8f"
+    },
+    "progs/tail.mdl": {
+     "bytes": 9965,
+     "sha256": "f284d7c91b2426896b845343ff36ef7a435fbf28bbbfecfc4ed07013fc4618b4"
+    },
+    "progs/tomb.mdl": {
+     "bytes": 38444,
+     "sha256": "19babf8fa5256c81245468bcb8af55328ee1726c2ecfe1ef1864975676a6e7f7"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "744af1fafaacb751cf2e5ce4bb15a0fc1fb938ae519469de6f0dccfe9f320414"
+    },
+    "progs/v_rifle1.mdl": {
+     "bytes": 61188,
+     "sha256": "5f3bbdb6cf49b4f73ca00f2b7dd3986c0c8bcc84a9726e20fd58d4e112a51a4a"
+    },
+    "progs/v_rifle2.mdl": {
+     "bytes": 61188,
+     "sha256": "accceb54fe55dfae7ef9bb46e891f47027ff2461d7feb542c13fed61190adb4e"
+    },
+    "quake.rc": {
+     "bytes": 428,
+     "sha256": "4cda28144230f00e63c25d046859ac4d37ec95f55ae834f80e05cf9edbee750c"
+    },
+    "sound/ambient/aog.wav": {
+     "bytes": 21636,
+     "sha256": "e157b5a8144b8dfb34ac0ac913864dea6ecff37415f4c31eada459a8c0b63ac2"
+    },
+    "sound/ambient/equake.wav": {
+     "bytes": 47148,
+     "sha256": "dcc45d2ef0703ecaa022c83cd66ae4992021ac379c11fc9da4401e184a191c93"
+    },
+    "sound/ambient/rain.wav": {
+     "bytes": 91202,
+     "sha256": "a196a2fc8a052368f9e8f7efe853391d1a99dfb1f6afae4fc7038222f2eb6fda"
+    },
+    "sound/ambient/rtd.wav": {
+     "bytes": 12890,
+     "sha256": "18fc4122141023c2271c311c9987ac9fdbb971f93a482d06ef765e008db4b0a4"
+    },
+    "sound/ambient/spark1.wav": {
+     "bytes": 3288,
+     "sha256": "edd25ab7bbc00e8952dedc1d671735f649134481860526bcdcb17f3bf20aa464"
+    },
+    "sound/ambient/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/cube/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/cube/bc_attck.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/cube/bc_gulp.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/cube/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 16944,
+     "sha256": "0fe255bd36c64acf75a53b97851b995517e70468b3818ff0ccecc4c7be5fc055"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/idlefly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/niteact.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/dragon/nitepain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 13848,
+     "sha256": "e71858c4de3e9ddcad1cba4ec0a6f5ec437b06c813b263ec73f853846d15a984"
+    },
+    "sound/dragon/sight.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/spit.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/thunder.wav": {
+     "bytes": 14764,
+     "sha256": "b30e18bbc0a12db2032fa95d5d0504ea63eaa13b3bea34e3b42ec59f3ca4d815"
+    },
+    "sound/shellhit.wav": {
+     "bytes": 1598,
+     "sha256": "17e0784b9c2ca8b5c60ba0ee6fe85f0eb04d0450ec948b6c4652cf64e0912cca"
+    },
+    "sound/snail/ni.wav": {
+     "bytes": 2592,
+     "sha256": "4bd1f1f2fd5182fd2fd8c5c1180d187fda03efa778457676efd2862e26045dd8"
+    },
+    "sound/snail/ni1.wav": {
+     "bytes": 5248,
+     "sha256": "fe9a0d1987e6715f01bad0af6a2b79af91d320c82cc56571082b3dd1e918b6e9"
+    },
+    "sound/snail/ni2.wav": {
+     "bytes": 5846,
+     "sha256": "24328dd87d8580b958a733aa8b163cb110e58046c2956e436658225b6d780a7d"
+    },
+    "sound/snail/ni3.wav": {
+     "bytes": 7202,
+     "sha256": "0451ab80d6f02a299575a017a8729655c9e19fc851ccf77897bacfd2dc048337"
+    },
+    "sound/snail/ni4.wav": {
+     "bytes": 7596,
+     "sha256": "a374ad002201c94849b6ff525764fcf5969e32073afd5d0be5dee5c161f504ea"
+    },
+    "sound/snail/ni5.wav": {
+     "bytes": 4278,
+     "sha256": "09dd1f3b2acb0be7d145b45d9bcc4a6745c37346dbfd2e87fe9631dee4e23660"
+    },
+    "sound/snail/ni6.wav": {
+     "bytes": 4778,
+     "sha256": "baf4c6a0e289c0d59175b76fedd66d8a082af1de039a354ecb75caaf7efa59e9"
+    },
+    "sound/snail/niwong.wav": {
+     "bytes": 14670,
+     "sha256": "7be14f65f860eebe4317b5f2062dba6aac54f515be14339ac20b9dfa100267bf"
+    },
+    "sound/snail/noo.wav": {
+     "bytes": 8266,
+     "sha256": "db84a6db394bb669270c7d55af2f7dceac35653476e772b80233f783f9f24b92"
+    },
+    "sound/snail/peng.wav": {
+     "bytes": 7040,
+     "sha256": "bdd7d3b46b4c193fe12790d3a4769a0d8b1f3d4f14d3a1e616c7319a4b3dd50b"
+    },
+    "sound/wall/wall01.wav": {
+     "bytes": 32804,
+     "sha256": "c338c95767dded603a1a69100c1af0baab42959eaae856f6cab99ffbd140b727"
+    },
+    "sound/weapons/rifle1.wav": {
+     "bytes": 12656,
+     "sha256": "a217f0765df3d8b9f99895e37b7e906cde1d7a1e0ab05a81be4839ffc6893751"
+    },
+    "txt/ambient.txt": {
+     "bytes": 840,
+     "sha256": "7cf7dd0049c8dba5a3d0e03568778663ecb340eaca5370ece6f8fcb9bf9d7ece"
+    },
+    "txt/chasecam.txt": {
+     "bytes": 5940,
+     "sha256": "6181219189f19f79f2c94a18300857edf6f205192c262be388464ba841477d0c"
+    },
+    "txt/choke.txt": {
+     "bytes": 5960,
+     "sha256": "d7a59d39ac95c5fc5ab23da316f63fd1da9f056e71bbe30bc9f124fcc9cea861"
+    },
+    "txt/cranked.txt": {
+     "bytes": 4080,
+     "sha256": "80bd1f1fcb5b6464f80322f2c34faec0219536b63db9636550246f12134e358c"
+    },
+    "txt/deadstuf.txt": {
+     "bytes": 1749,
+     "sha256": "508bf7ae49da9ef1b3fbb05ba74f80c11f66abfc385ffda15d584126f9258441"
+    },
+    "txt/dragons.txt": {
+     "bytes": 7446,
+     "sha256": "338003d21a40fbf8a31f760620a07e92b6b1615fac47656f9c5aca147b727ef6"
+    },
+    "txt/eject.txt": {
+     "bytes": 2244,
+     "sha256": "04ff84fb7680f984d5e5cbc9f0eb568c16ec3582fcec0f55abfb079632efc506"
+    },
+    "txt/flares.txt": {
+     "bytes": 2649,
+     "sha256": "32d94a9b9a6022ced1c86fd98e1b3516eb7a027b6753f025f7eff9869ef1d151"
+    },
+    "txt/gibfount.txt": {
+     "bytes": 2173,
+     "sha256": "6b41bbd6f072c9b8ebfd0afb1baa776c4e5b0f3ba5c635cefbe11c1f456e90da"
+    },
+    "txt/gyrobot.txt": {
+     "bytes": 15522,
+     "sha256": "b19185538e9433b690dfaa5175501790d2f4ce8c32220e822069cccd51749817"
+    },
+    "txt/idglobe2.txt": {
+     "bytes": 1248,
+     "sha256": "b299dc471f61b6964040d3534bf47e617e0e223e83abde059fc73f1c17066554"
+    },
+    "txt/ogresaw.txt": {
+     "bytes": 2549,
+     "sha256": "0d27a6168b50572fa6040ed79a8f039959d4a5242a519622ef0a3915ff537e3a"
+    },
+    "txt/plsrfl20.txt": {
+     "bytes": 2367,
+     "sha256": "aed7841a1f02193f61a24d4da31dd9e775ba386a3ef5e77fd1084bb022873e69"
+    },
+    "txt/rabbit.txt": {
+     "bytes": 927,
+     "sha256": "e68f8bc25bcf4c83067a4680884a0beb510d29d96b85154c125ede83ad03ab9e"
+    },
+    "txt/rain.txt": {
+     "bytes": 2116,
+     "sha256": "2a4a797b2dbebc6a577177b4ed2983dc0b4a870f482d9a1d8524556642402be7"
+    },
+    "txt/skinz.txt": {
+     "bytes": 3918,
+     "sha256": "de63038a0ebfc912b8ec00348326fdb53aaadf914481cfe5ca74aa19f9361947"
+    },
+    "txt/smlevels.txt": {
+     "bytes": 15832,
+     "sha256": "c84e08e3540cfe0d60fa4bf95c52ba521e7bfbea0917d878c10f9eb7aa6bf0c6"
+    },
+    "txt/snakeman.txt": {
+     "bytes": 4744,
+     "sha256": "cc988702d85165b6f9cf05830cf8ebe39a907b140c723799813fa14638c2d7f2"
+    },
+    "txt/spider.txt": {
+     "bytes": 2604,
+     "sha256": "647a43b615b99837464f5a92f188edef7d08506f0d897cece2d1192aff65c2ba"
+    },
+    "txt/walls01.txt": {
+     "bytes": 3093,
+     "sha256": "d7c7a2b26ca415635abdb06c983eae75319924b7ec91ead6e0751ae174b69c8e"
+    },
+    "txt/zer.txt": {
+     "bytes": 11251,
+     "sha256": "f88d82cb989d8acebe31a81e4a1adf54aa60d7cfc6c7e82c7b9b3eae3f09a54a"
+    }
+   },
    "sha256": "ca243d0a39b179c5b9850fa1563bf5ea52335f4c3c193a8dce88aac055539d9b",
    "timestamp": "1997-11-08T22:15:46.000Z"
   },

--- a/json/by-sha256/9c/9cc7dbee0c4133830f8045206457dc21fd0dd67524f956e9cdc4eb6f22adf2d9.json
+++ b/json/by-sha256/9c/9cc7dbee0c4133830f8045206457dc21fd0dd67524f956e9cdc4eb6f22adf2d9.json
@@ -26,6 +26,136 @@
   },
   "q25limit/pak0.pak": {
    "bytes": 38694238,
+   "files": {
+    "maps/q25l4lt.bsp": {
+     "bytes": 1218968,
+     "sha256": "47e8ea4182df6a150ee2ec5860ce2c712d09618794dcfb502cecf673c7fa201b"
+    },
+    "maps/q25lboxf.bsp": {
+     "bytes": 1063220,
+     "sha256": "d2379763e10660ae5c48517b4e4810afc9763776184f1487967c443c1be14ca0"
+    },
+    "maps/q25ldfl.bsp": {
+     "bytes": 1446148,
+     "sha256": "e8138d125e21cb422686d3b07716aafd1d67068ab037127c2fd0676fd25d9973"
+    },
+    "maps/q25ldoom.bsp": {
+     "bytes": 1492380,
+     "sha256": "5f8157da6ad080a1808ad02093029bba2ccd1f9f4a99b3977ee0b2c97a598ec5"
+    },
+    "maps/q25lgree.bsp": {
+     "bytes": 1387788,
+     "sha256": "a2e711323a915890814d355ab4c9f85b1b32ed768e0dbcb997616a736c86dee5"
+    },
+    "maps/q25lgrue.bsp": {
+     "bytes": 1520752,
+     "sha256": "951a33ccd8666545ac452ef710eb011edf18027b594d51ed1ff8ae19c4361e73"
+    },
+    "maps/q25lil8r.bsp": {
+     "bytes": 1352228,
+     "sha256": "58d4eb3dc5c8baaab615ed0831f5c13ffbcd1f1f88c71c49e859c3c315030d6e"
+    },
+    "maps/q25ljcr.bsp": {
+     "bytes": 1368456,
+     "sha256": "f30a340303d1a10f87a1d05231c418db48f068162d54e55f8ef40eb134a85715"
+    },
+    "maps/q25ljcr2.bsp": {
+     "bytes": 1435904,
+     "sha256": "dd88e6dad254579ac014ca651e25d67d47429b6e2c7d7a7b47f01eab4403c956"
+    },
+    "maps/q25lkoni.bsp": {
+     "bytes": 1061716,
+     "sha256": "73475c5df1da8b6b82a6435d91416bb1200909c88868a4145dde906ab099ed3b"
+    },
+    "maps/q25lmark.bsp": {
+     "bytes": 1521816,
+     "sha256": "f4be08c23947eef30a03d520f8c63f89529dda1326d660d155393a81d434cfe3"
+    },
+    "maps/q25lmike.bsp": {
+     "bytes": 1390148,
+     "sha256": "7f394dcf34efdea4ba8485ea8571cda2d02b1da9ac4ab6d0b9efd3869fd61df3"
+    },
+    "maps/q25lpief.bsp": {
+     "bytes": 821768,
+     "sha256": "e6d139b954e137400ae6f7dc66dabe86f130fc43933f42aee0ef28fadeadbaf2"
+    },
+    "maps/q25lskor.bsp": {
+     "bytes": 1407288,
+     "sha256": "b0dc0ca62b742fcb1b0a866d53b67f1c0738da4d71683d757536d7f3b78d7f43"
+    },
+    "maps/q25lsoli.bsp": {
+     "bytes": 1433572,
+     "sha256": "f33db6ef97876236e2ab15243e83a60e19d521807af062ca0e2f368ef9c3b111"
+    },
+    "maps/q25lspud.bsp": {
+     "bytes": 1764468,
+     "sha256": "510b2e48994b6bbf99bb49f59974d2d826271809140a30007f0f27c1af10a1d6"
+    },
+    "maps/start.bsp": {
+     "bytes": 1832836,
+     "sha256": "88c5934c911a5d431bc9ccd73609bfcce1519d3d0082cb66fa887dde6b05a92a"
+    },
+    "progs.dat": {
+     "bytes": 336646,
+     "sha256": "79ed9d30d98ca0f9c3238ce43ad1c2573a2ff1b8251e475d63756477b81ce1e0"
+    },
+    "src/q25_limits_4lt.map": {
+     "bytes": 778169,
+     "sha256": "b6bbe84e339b9e11201963f203d01fba44a9fe1a7f2ed44575a06198fced971e"
+    },
+    "src/q25_limits_boxfigs.map": {
+     "bytes": 268055,
+     "sha256": "8237a8a74841da9e81a6004e7dbc8022eaeaf7ae0a162ccf6fe2335acb27f720"
+    },
+    "src/q25_limits_dfl.map": {
+     "bytes": 1206428,
+     "sha256": "d79d3f816cd16070c9070029c9b4855fd390bea17f7641df2cc69a2905e9d621"
+    },
+    "src/q25_limits_doompope.map": {
+     "bytes": 1771412,
+     "sha256": "c39321d0df7b4797907b9edd97f8681fc2072d560ec1244e43cb77454863f3dc"
+    },
+    "src/q25_limits_grue.map": {
+     "bytes": 1236427,
+     "sha256": "0ac069f3dcc9fcf6fd598186f110387de0ecd68ed36a24eb2d842e6ecd96721b"
+    },
+    "src/q25_limits_il8r.map": {
+     "bytes": 1193030,
+     "sha256": "ef4c66fc0f571044ff2fe0b9a05807ce0da01af288996363a268f470f52c7fd3"
+    },
+    "src/q25_limits_jcr.map": {
+     "bytes": 690306,
+     "sha256": "bd7e167fcfa5026cd0d466b4d23a57da565b95b95a7a62b4d9b3a526ba9cdc39"
+    },
+    "src/q25_limits_jcr2.map": {
+     "bytes": 1056967,
+     "sha256": "00272c4dc5da5a412dd330e13209372797a7f1ccd55a0226d4edbf70c2a250b7"
+    },
+    "src/q25_limits_konig.map": {
+     "bytes": 512132,
+     "sha256": "6a66a9f7bad66100b54b399c40ce9d9327149a60125352cc5a40cc4f8c47f09a"
+    },
+    "src/q25_limits_markie.map": {
+     "bytes": 2099601,
+     "sha256": "ca5b35df492c37988fd9451f7fb1341b3eb7853f72d5d081140d86b4bfea00cc"
+    },
+    "src/q25_limits_mikec.map": {
+     "bytes": 865667,
+     "sha256": "c581ed4ac2bd7851802c483210d0e0810b4f14eade6c1485520669b91a15c48d"
+    },
+    "src/q25_limits_pieface.map": {
+     "bytes": 564860,
+     "sha256": "66de278bf57db0db16747089996e7dc4c500ac6135da957a787b0c0ef5d7ffbe"
+    },
+    "src/q25_limits_spud.map": {
+     "bytes": 1447112,
+     "sha256": "d9d2345fa09c273ca509f2b730678a907e32867f613206cdd6b682181ebb5ed2"
+    },
+    "src/start.map": {
+     "bytes": 1145910,
+     "sha256": "6439f21c8fe093307948016c890a5ba3b151092f799189d84d71b191c770b7a8"
+    }
+   },
    "sha256": "5e0106cd81376f46b10f9c18c7973e393c26ac73f6110121bd07f92113a991d1",
    "timestamp": "2021-06-23T08:18:02.000Z"
   },

--- a/json/by-sha256/9d/9d32bc380a3c791bf8464c4fe391ecb3e5c1fd6ae97e159e44053ffc04242832.json
+++ b/json/by-sha256/9d/9d32bc380a3c791bf8464c4fe391ecb3e5c1fd6ae97e159e44053ffc04242832.json
@@ -22,16 +22,3210 @@
   },
   "pak0.pak": {
    "bytes": 25051624,
+   "files": {
+    "maps/b_barrel.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/b_wbh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_wbh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "progs/acidbal1.mdl": {
+     "bytes": 8788,
+     "sha256": "8a9c956f1952fb8d9ea51119c1c8c758d3ca3b3bf3bb0e8b63131bf88325f5a9"
+    },
+    "progs/acidbal2.mdl": {
+     "bytes": 8788,
+     "sha256": "eceba377145b62b4721927e55de75423daaac83f9667852b16dd1bfff3beff01"
+    },
+    "progs/akarrow.mdl": {
+     "bytes": 23072,
+     "sha256": "4e0e1c007453dbc432533dab09dfbafa943c4f43f7897848c91a516bf0de43a0"
+    },
+    "progs/am_super.mdl": {
+     "bytes": 8976,
+     "sha256": "55d561bf2f73b2c6482dcb5649da1b31d4bbf40aef6e21cca3518dc6a0c5709b"
+    },
+    "progs/anglstat.mdl": {
+     "bytes": 164396,
+     "sha256": "ce4644a5e22e0ff39790a293754501add2a4ad8afa26cfbdd13205c3b833e923"
+    },
+    "progs/archer.mdl": {
+     "bytes": 581920,
+     "sha256": "858ad8a4d0d27e1a9989ad7d87a9a4404ff8adbde33b07868725d34fd2146f6d"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 141992,
+     "sha256": "9a3c9afb3c47ed9c683ce6b0fdaef6ee6d1cf74c60509f1a82f8599318e71d08"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 25752,
+     "sha256": "57518dd89a3dbf6e712ad204b0a6f41fd7fdc9bfc03cf4c17e222f9d31d72b93"
+    },
+    "progs/arrow2.mdl": {
+     "bytes": 68764,
+     "sha256": "0bc41c13a4332f6d13e7884248b2d1a83b487bc2f4e1d5cbbdcd1c81512a4579"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 290592,
+     "sha256": "f0d1dc967de929d0f0faaa61aa51239d1f262c63da83013be094a4ed99e3028c"
+    },
+    "progs/bandit.mdl": {
+     "bytes": 226380,
+     "sha256": "7cc68b0c9a4950b4d3b97353227a6b8845104417efebfd00348b7fb24986d557"
+    },
+    "progs/baron.mdl": {
+     "bytes": 426204,
+     "sha256": "09a4b10b43c2cb4847330ce3660eab93c16a97a7db0c9e1c1447e938689627d1"
+    },
+    "progs/bbg.mdl": {
+     "bytes": 190836,
+     "sha256": "3bac35175b2808bad33e3b7e7c2c54b3d9181c5b3743aa68d803dbe58edf0eea"
+    },
+    "progs/beam.mdl": {
+     "bytes": 1460,
+     "sha256": "9e9531de6f4e6f2f6274ea6612ef00bd0642c0cc05a7fdc866805fa1be851b73"
+    },
+    "progs/bellring.mdl": {
+     "bytes": 74016,
+     "sha256": "9a8131071ca927803140ce6478b8912c6eb52856861250d6b6bfa1d32cfb9cd9"
+    },
+    "progs/blood.mdl": {
+     "bytes": 184,
+     "sha256": "06825646d627df610b374a31c9265a88c9c1c45864c6e3b9d273a14dc4d745a5"
+    },
+    "progs/blood_gr.mdl": {
+     "bytes": 184,
+     "sha256": "84caed23ff1b8cabec8c5d9e5c6792c30a6d9cc57c36a9746369012015462208"
+    },
+    "progs/bloodcb.mdl": {
+     "bytes": 28036,
+     "sha256": "83f0de29aa0f9e9f1d383895da374a5313aa2252edb306eb7bd69bd71660321c"
+    },
+    "progs/bookclos.mdl": {
+     "bytes": 3420,
+     "sha256": "a129ba5428a5fbef209010b893b4407c99a3d3a9e936d9d41247af5a75fc922b"
+    },
+    "progs/bookopen.mdl": {
+     "bytes": 6188,
+     "sha256": "d57ab7e96181b3fe70bc9c0c002ed6671fe14adfd454b680cd39be10b2315a05"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/chest1.mdl": {
+     "bytes": 19352,
+     "sha256": "239f897e3a390ad44acc5ffd19784f8b78232c5af2be67165581c2f6073ecc9f"
+    },
+    "progs/coin.mdl": {
+     "bytes": 44036,
+     "sha256": "c3d65aac43713c9102f8924ef7ed1cf90297ff17cfe8aface7936e9579b4ec57"
+    },
+    "progs/courage.mdl": {
+     "bytes": 14940,
+     "sha256": "4141933fbb8682ee28277826bd0f882580025def71b96c02cb9b53aa412906c0"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "7829e2cbaa4816577c77ba12a91933eee5dcf9d899f3f4d9717f6f8fc0319a23"
+    },
+    "progs/demon.mdl": {
+     "bytes": 355000,
+     "sha256": "3bb7fc1b1f89de1d66f99de4065d71e35dec87940d47c98b24d3be074d8bf70a"
+    },
+    "progs/dog.mdl": {
+     "bytes": 269016,
+     "sha256": "9a60157b0504891c71fbaece5a729e9b954a5e2dffe92e1e1a1ab51c6d912b77"
+    },
+    "progs/doll03.mdl": {
+     "bytes": 52064,
+     "sha256": "b2962f3954740ad7f9b5ee329d3a189ed5c95ccbb279bb63dc77508c94e4fb28"
+    },
+    "progs/doomcube.mdl": {
+     "bytes": 8884,
+     "sha256": "c4d31e7a4f2a9c01c1c502fec3653d8e0b14fc6ec790d8edebb1737a6116a471"
+    },
+    "progs/dr1_head.mdl": {
+     "bytes": 7476,
+     "sha256": "06f28a6f55ba29f12965e7ca10d99147a9432c851a2747d1e861cd45c07d958f"
+    },
+    "progs/dr1_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "c208f5473b2954fb4af094119b5a63b3a205e7a26e94c0c122b1f06870db6f78"
+    },
+    "progs/dr1_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "258da574e4de9d144d4f6a71db72a8bd566ecc6b0672efeb5cacaf59c7dd969d"
+    },
+    "progs/dr1_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "698d06c98e8e9ab99b6ddf808bb32a4994299c9596354bf8f811cda0f4042588"
+    },
+    "progs/dr2_head.mdl": {
+     "bytes": 7476,
+     "sha256": "551d47f807e21d11aba52f66207515e0988e8a424012f204e517c8c6720514d0"
+    },
+    "progs/dr2_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "f636b0786ab159a368b9fa580f1a0a31dc7873f21edb1bc454eb9e64c2c27a14"
+    },
+    "progs/dr2_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "533c0d631c78c22f5ff7632e7dc19f5da1acee56225a5a1497bf34d10fc07344"
+    },
+    "progs/dr2_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "5f5eace00eef74eeaa9db48887636e08ab43c85ad0d05816745c04a4710f34d3"
+    },
+    "progs/draco.mdl": {
+     "bytes": 235148,
+     "sha256": "0b51fd9b782891c4b8b410db6ac1361dfa0f53d634366709434a926e0c7285b5"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 262688,
+     "sha256": "d27bb0ed21b8f0e8161f347cb5bba89c8c5223324f462596f972478efdacb366"
+    },
+    "progs/dragon1.mdl": {
+     "bytes": 258260,
+     "sha256": "4dbf09c018ea9f703d4daf48c0a5e504208547d5d172bf26187b8eeac8a94a02"
+    },
+    "progs/dragon2.mdl": {
+     "bytes": 258260,
+     "sha256": "fa2b5d9467299634cddcff9c7ca87c2006c8c9631f45cbf66f74a8abfd5df347"
+    },
+    "progs/dragonpl.mdl": {
+     "bytes": 77764,
+     "sha256": "57db3cbef92a0f96cd8ef1be17ce77586f9541bbffcea2e7747e43b35c50effa"
+    },
+    "progs/drggib01.mdl": {
+     "bytes": 63320,
+     "sha256": "0a2571dc74871a4d43c8c780a62d36ce4d17dd83b6819c773bfb22a247b8bcbb"
+    },
+    "progs/drggib02.mdl": {
+     "bytes": 83352,
+     "sha256": "c3ec2317e0f0f156237b7ed36d1ab3329a874a11f7a2fb343afac021a50f777b"
+    },
+    "progs/drggib03.mdl": {
+     "bytes": 58824,
+     "sha256": "9dfdc32e9616b40b82c410ca75f007bc11a9b18697d4edc82745bcda1b3313ed"
+    },
+    "progs/drilbomb.mdl": {
+     "bytes": 5396,
+     "sha256": "6615fa32cb3b464b665093296ff63fd0c624eea5ec595247d8c66941e1c8d071"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "718b8c2842877345426247148dd6ce1ebe7fecc13e969a0fa0ed6dbebc388099"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "0a386b6381824b01852910519490ac3f6e3309a96091820384ee6b9a5b452e7a"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bef43e6c7bc067d3b35dd05a793c08d7d700fbb2013606ac9ffeac8772d0997e"
+    },
+    "progs/drp_head.mdl": {
+     "bytes": 2340,
+     "sha256": "b87cb902d796dd76c03e9fc79576f368d23022fbd5b5155c8910cd315046e32a"
+    },
+    "progs/drp_lw.mdl": {
+     "bytes": 7116,
+     "sha256": "ad483731fddede05ebf1a9a3c20f735f6ec341f156669833ed1077460dac8e5c"
+    },
+    "progs/drp_rw.mdl": {
+     "bytes": 8056,
+     "sha256": "b57363de0be61e45b355d1cceccadd42fdd1b8f91fc4380847dacf186d7560df"
+    },
+    "progs/drp_tail.mdl": {
+     "bytes": 2604,
+     "sha256": "b8ad65168755d4f31b657a80c78e2e0f51316c48f4ebd10ddae0b6971c7c6e89"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/ember.mdl": {
+     "bytes": 8788,
+     "sha256": "91d6f4dfbeba0711d0864b94bb372b602959644c5c841fd659ddedb8f8e6980c"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "13d14261d863f5170fb8e64e57b8ef344c435183313ffb1127ab6ce51176d262"
+    },
+    "progs/end_bane.mdl": {
+     "bytes": 52980,
+     "sha256": "4a86fd7bd59c4ecea934e3adcec4b17d627cdfac5223976a52b5739143c37f27"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 241252,
+     "sha256": "9ae37ced89200daf2d44795bef4230c5b725226a820c28cda7908f43bbdaa747"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 414484,
+     "sha256": "3d146be46cd90ce477006354b3ed627541fc4ecdb52ff6de2b4f3159c61e1390"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 68804,
+     "sha256": "f3c760ecdbb530ff651c46f516228c588f37585315acdab199408911c2c8414b"
+    },
+    "progs/flame2a.mdl": {
+     "bytes": 68804,
+     "sha256": "e02210f2f6851cea4b9520476cfe36c31745dc2d84248f6a75132358d6d43035"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 56532,
+     "sha256": "36d304e1442ede2048036d832d36ef4624fe4e90ba16628c20c819e7b4477da5"
+    },
+    "progs/g_grpple.mdl": {
+     "bytes": 149440,
+     "sha256": "fc148b3a840b84b65488658ec26a27621a86a196feb90723269534929ee0352e"
+    },
+    "progs/g_gun.mdl": {
+     "bytes": 35580,
+     "sha256": "0d6cbc684d5c5f1112d0111e29405e73721993ad57854c936e676025b7bfbc1c"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 38004,
+     "sha256": "cf67c0a7ad3e853fa4af7544d0399fc0a3795a61d625f5e78104e659e2db0eed"
+    },
+    "progs/g_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "3e4a1e9dc2bff162612e218a25e2040b57d063d198df2e301eaa8fa9542af098"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/g_rocks.mdl": {
+     "bytes": 47732,
+     "sha256": "d6539141be1597673eb1f8c78286d6efdeefa91f9723926d61b9a81e2f433c71"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 158116,
+     "sha256": "127e4fefafc5015f03a6cd1288cab9da325ed5b5a93c9f6b90b6da9d8273ef9f"
+    },
+    "progs/g_wand.mdl": {
+     "bytes": 13684,
+     "sha256": "99212b7901c31b723704e7c62b1c5f70b6a2f7320c349605a3943f3091e962de"
+    },
+    "progs/g_xbow.mdl": {
+     "bytes": 22476,
+     "sha256": "bf1cd180a66f74da4e625a2167bf66527cebd0d4009fabeed48297018db8a4fe"
+    },
+    "progs/gem1.mdl": {
+     "bytes": 42612,
+     "sha256": "0b71e525b19e25f98dad53ce766751de8e0c9f18434582bb86242296bb7a402e"
+    },
+    "progs/gem2.mdl": {
+     "bytes": 62672,
+     "sha256": "721459e22aab0d2cece430053734b889918bde4db879ffc94084289a7b6d4d8c"
+    },
+    "progs/gem3.mdl": {
+     "bytes": 42072,
+     "sha256": "3bc3a1018cc432b694f9ec45de06775776ef55d21b4e117dd1b2c7c0d7b850a2"
+    },
+    "progs/gemini.mdl": {
+     "bytes": 35188,
+     "sha256": "fa05498ce8034d51377953db7c650f9367b072a9d614812f4f67ad15eace909e"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/gr_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "3f5b6d67b80e5f2e5bb7c129500c79dc345141133f8d415005f9384b0d2d9661"
+    },
+    "progs/gr_gib1.mdl": {
+     "bytes": 6501,
+     "sha256": "3f715cbfdcd77caef11b904aa12d2063cbb973d4a9d61c27492690344c14fb1b"
+    },
+    "progs/gr_gib2.mdl": {
+     "bytes": 17553,
+     "sha256": "c6166eb6132a3e87f51fcf48f4e9eebb719b3f1819d22640582b23d61bde4a16"
+    },
+    "progs/gr_gib3.mdl": {
+     "bytes": 22933,
+     "sha256": "0e40e5b960924ca642690c26b239c89aea6bae18badcb945e96d2102cad69622"
+    },
+    "progs/grem.mdl": {
+     "bytes": 202672,
+     "sha256": "3df027b9f674f1f3d3cd775c877fe225029f1b814ff3358f98f932cf8bb0a604"
+    },
+    "progs/h_archer.mdl": {
+     "bytes": 22128,
+     "sha256": "034d829e2ad34eeff8f5d60b8e2064f08caee64fb7f064900298f9405e9399d8"
+    },
+    "progs/h_axeman.mdl": {
+     "bytes": 18400,
+     "sha256": "e15391056ec618b412d1341914d2e6f05a759de92500ef249cc5d1789b3ab6d6"
+    },
+    "progs/h_bandit.mdl": {
+     "bytes": 9752,
+     "sha256": "cc79629b169c0560905eae7ea9a02e5ec546af8cfa07743922e0b1dc829b29ca"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 7444,
+     "sha256": "68bc1db4875fe84f25ff3d6c53e4e9e2c023ef52bf3c89b439493f2e5c5c0e19"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "53539bc39fc87627a46b75b0d86ade5e6116a0079b032b1df137b2425b7186cc"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 166100,
+     "sha256": "0484f334f5722736248531a726e9a91c69e708a882e6d581db3d4e2a54d6db94"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 68796,
+     "sha256": "57a646b291c29b490faa38e3b72d7f074d9d071946d9b9c6068095999a11ce77"
+    },
+    "progs/h_drake.mdl": {
+     "bytes": 28792,
+     "sha256": "be0bcf5fc725dbb09a82becc2339d91824a14a547ce3013deabeece662658dcf"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 30072,
+     "sha256": "e88bac12b670f6790f3e053e1547569e88f0befa7a07abfc6a3fd2ad33b9d9a3"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 22724,
+     "sha256": "905ed9f78c83e29a31b6283b5a377053763469ae048bdcc3aede9213bda80873"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 100172,
+     "sha256": "27311a59a95ab735d79e5198318d0507da7e377584702ba9e5bf673c0972e065"
+    },
+    "progs/h_hkolem.mdl": {
+     "bytes": 30552,
+     "sha256": "38b2082ead97b90f59a5fdcf24d4077ab067c55655598d023f8ec38818c914b1"
+    },
+    "progs/h_imp.mdl": {
+     "bytes": 73564,
+     "sha256": "24944207a9867d67fa24961516dc2810a5d1b33d341d5190ac1666d58c8252f4"
+    },
+    "progs/h_imp2.mdl": {
+     "bytes": 73284,
+     "sha256": "f01cd8331b8774495258e3ab85ba6434a0deef19b1b953b6ccf93252649e01fc"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 19644,
+     "sha256": "1accd89ba95db3627cee4f06f94ab3bc9d146ebf566da24b570c733f2f902c1a"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "72455aab2067fd8f887e8a8e9c61d2b943699ce90fbcb85937fbb358c9e5678e"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 53188,
+     "sha256": "6e1c28d5c53f24901ebd0aa199a1003ef4fe3c8306c5ab28191cccd14bf25f45"
+    },
+    "progs/h_necro.mdl": {
+     "bytes": 14296,
+     "sha256": "fc9c468465d0e8982fc2d6207ce94b2f400f0f37cbe88cff2a4aa64719b91f40"
+    },
+    "progs/h_nemes.mdl": {
+     "bytes": 78156,
+     "sha256": "6f350692b44907984c02779d0114576bbafb6a3ada673e1f55d1cf02fd062c18"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/h_rebel.mdl": {
+     "bytes": 5428,
+     "sha256": "b189ff3ae1596da7596f21d8f555603951fadf8e7884e96f89c8b2b5789028a5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 53096,
+     "sha256": "ff1d940222f28765b975828528016332b04423a4001a507e07cde6414847add5"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 108204,
+     "sha256": "dd7dc5c90255da868b96ac553d8a8f68b6723da6b25114bc087fd019966a023f"
+    },
+    "progs/h_vomit.mdl": {
+     "bytes": 16952,
+     "sha256": "9822885036229871594a21643f4acd3a9b4c27d141b9021464b5062dfaf410f9"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "7ff66f881f85884aea56396da7b756da32c04df163a1e1f739485e77e61279df"
+    },
+    "progs/h_yak.mdl": {
+     "bytes": 73116,
+     "sha256": "eb2cf314618ef6dbc44ab46807237e59b68470edf24780e4ccd4c5b513f91196"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "2f6fd7256662a5a4b4b907b0ac68bf7d787ebd55cf54e352da5f1b363a2b2397"
+    },
+    "progs/hero.mdl": {
+     "bytes": 66388,
+     "sha256": "ea4f359a328b6416588e5debe13a87fc2eccd8a65263ae23683d71a58b39a116"
+    },
+    "progs/hk_golem.mdl": {
+     "bytes": 179204,
+     "sha256": "972f27eb2bf8a6cc4433e1f904097ca5393312d47a75e396b0323723beff58fa"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 534604,
+     "sha256": "10058c95eca9a063c7990d919d353d3573d252eb39f00c5f471a7f22f0b5fefa"
+    },
+    "progs/hook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/ice.mdl": {
+     "bytes": 2580,
+     "sha256": "30c4853e26d51d0ca4d3df5a40ec6d8861f48e9420f10560b5de0c19e6c15ab0"
+    },
+    "progs/ice_cube.mdl": {
+     "bytes": 3192,
+     "sha256": "bf96c8c1533fa537582bd4cf7bddadb7f5ddeebafbce9ef29007a5acd5a909b0"
+    },
+    "progs/iceball.mdl": {
+     "bytes": 24632,
+     "sha256": "802fa6260e9af5abb74bab0a76f35ae3e2af2373e61091c725325aa41051be7a"
+    },
+    "progs/imp.mdl": {
+     "bytes": 583036,
+     "sha256": "299777bbf58641a6674c0877423efd9f0995421a1bfb946fe21d1f2bdb41714f"
+    },
+    "progs/imp_lord.mdl": {
+     "bytes": 583036,
+     "sha256": "0b26574642cc72b73d349881543752a1f7d7f34f00561c4b039bef83e7191b10"
+    },
+    "progs/imp_rock.mdl": {
+     "bytes": 2352,
+     "sha256": "dbe190f471f5738779e103b496117ec40e2adc9e5f593d2470172bcbd7ade0f6"
+    },
+    "progs/imp_wing.mdl": {
+     "bytes": 93932,
+     "sha256": "a0100af8c072112afde45cc2f69e40de4aacffbdb4515de107892c39a00f5eb5"
+    },
+    "progs/impwing.mdl": {
+     "bytes": 93932,
+     "sha256": "5b986189f2f28ffe6c3fc23d40bc194bda2ab636826a9d41ffc9199727cc2f49"
+    },
+    "progs/impwing2.mdl": {
+     "bytes": 93932,
+     "sha256": "0d08640bcd5c6e6336b9cedb635a6152ba479065a56b296557476a6f5e9b1e4c"
+    },
+    "progs/k_ball.mdl": {
+     "bytes": 31300,
+     "sha256": "f93346ffeed3fd5d9866fb80d1a08216759bb27757d49a1851e471aadf757ec1"
+    },
+    "progs/key_b.mdl": {
+     "bytes": 10616,
+     "sha256": "d1333d74b7e194f6587d0f5ed1fca28887cd0414734b4bd4cbb7e715ab897629"
+    },
+    "progs/key_m.mdl": {
+     "bytes": 23160,
+     "sha256": "ea2feb6eb54823668dcb112f42c3441e563e18e3cc1806b5ce509044e6c0b448"
+    },
+    "progs/key_w.mdl": {
+     "bytes": 11576,
+     "sha256": "72da64d2b29d69605c453e9ee0e5fa8ecef91a94cc541103cb24fbad96c7946d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 232536,
+     "sha256": "e3e618799612c6e521f68234a061d9a46036ef556677b0c1651e7647258ffb56"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 27960,
+     "sha256": "5877b37cc4f98a53467c412e7d06d1f7ec6b60f5c0f2088514aa51c9d2c51769"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "210e159ea4c9bf1f2431213fd95902f4ea75ecee6a67a22bed7e93366f1f2732"
+    },
+    "progs/levitate.mdl": {
+     "bytes": 15876,
+     "sha256": "03e77b0d4b8ee7b3b224cbe0cfba63e8bd27d0391bd5069981e5435287f66645"
+    },
+    "progs/life_up.mdl": {
+     "bytes": 34676,
+     "sha256": "502716aa1b0f6cb8f929fe7ee2a74024a5fa007898256e15ca495e126888c584"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 57796,
+     "sha256": "e8b38ca8f28a89f65ffc652e082e8a9aaf6a1a9db8302e961b9ceac1c8f60e8c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/morph_eg.mdl": {
+     "bytes": 300592,
+     "sha256": "14468fccffaa1508c03610dd58fb51cd9058ca3bab036bca18f7a41cb37c195b"
+    },
+    "progs/nec_rod1.mdl": {
+     "bytes": 16072,
+     "sha256": "2eded5df9441aca7a243bf6c2a831c62374cabf7bba1acd64a84803441d77fc2"
+    },
+    "progs/nec_rod2.mdl": {
+     "bytes": 4564,
+     "sha256": "60b0923cade4c8ab9a476cae75c7c73f71c1d13799ac7901d0be4db5d5038895"
+    },
+    "progs/nec_rod3.mdl": {
+     "bytes": 4132,
+     "sha256": "459edf5ee6ecf0c52ec83e055a2c12ad39d3d3a42a4774c442ccc686e298da47"
+    },
+    "progs/nec_rune.mdl": {
+     "bytes": 19524,
+     "sha256": "cea5c89dd0034465a54a8434bc9367554f0244c2e38ec9220cd28a5a53a444a9"
+    },
+    "progs/necro.mdl": {
+     "bytes": 577208,
+     "sha256": "a0e43517f3cb579e38baf9ee4b5058ed59036b69599c0fe3ffeff9c00ba843f8"
+    },
+    "progs/needle.mdl": {
+     "bytes": 16688,
+     "sha256": "5f714f6b43cc28ca1de1246cc0175ea2e07040f73c9d0a623dbe4b4577559c14"
+    },
+    "progs/nehjet.mdl": {
+     "bytes": 19956,
+     "sha256": "fd0346c9c37d2ca7d3e696a9ce0694652722f63326376ad3b8189fb81a68f5c3"
+    },
+    "progs/nemesant.mdl": {
+     "bytes": 202492,
+     "sha256": "099c26752c7160144a25716e0af0f30f8ff179766db4a05371a0392166f85c42"
+    },
+    "progs/null_256.spr": {
+     "bytes": 5412,
+     "sha256": "c52813b634ef1ab641fdd4c3a9739ad758f1b5c39ba5e10acbbf034ee0ff850b"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 230152,
+     "sha256": "b7c88ae295ef8fc8d17b4fd6facedbb8e464ee665039a884af8e215a3929f24a"
+    },
+    "progs/oldone.mdl": {
+     "bytes": 560224,
+     "sha256": "5690a29cb0ae1a4889bc398676db8477275b0953e2ab7bbb75b717509d93c985"
+    },
+    "progs/pl_oum.mdl": {
+     "bytes": 331236,
+     "sha256": "6939a925af5510ecece22c3cee3de418d3ba532f4eb17409ca1453d253de328c"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 55676,
+     "sha256": "c9810eaac822215e7c84f11e55bb614121d17a79a02aa162fb430b5f37664ade"
+    },
+    "progs/plasma1.mdl": {
+     "bytes": 9120,
+     "sha256": "78a81a8eaaf95f85cd0fb7bc31dfa45c30e660fc5265168178b50776afc96563"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/playham0.mdl": {
+     "bytes": 99756,
+     "sha256": "1016d24c984994843af5d086e36e548c55590018f1f6b2d78799e25a40271ec4"
+    },
+    "progs/playsaw.mdl": {
+     "bytes": 87340,
+     "sha256": "b53cffd1807a3710f03b350370d78dfdbb2b057455fcac9f00d1b0baaabbf8c9"
+    },
+    "progs/potion.mdl": {
+     "bytes": 53272,
+     "sha256": "6ee1b1294f1ff41bdf265d06d80fa22a89ff579acb70bd2544986a0235ebd6e7"
+    },
+    "progs/potion2.mdl": {
+     "bytes": 195484,
+     "sha256": "c4f0f920521bd6e1caa6072b19d11ba57f4d493ffc2d6a395190170c9bec702a"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 47008,
+     "sha256": "e7ba606cf1cc11d9ad5baef5aef9dfa9239b7550a1c12937965a562bc815e6a0"
+    },
+    "progs/pur_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "dbc2bf835db1c1789c329504f86802990a19288f67d9560f32cfe5a8d5a62885"
+    },
+    "progs/r_bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "2d776e4acdf20cd117f3f4d6be3647fb9d0e117756069cbfc52ece716fdbb251"
+    },
+    "progs/rain.mdl": {
+     "bytes": 39276,
+     "sha256": "9a13a2ff68c8d8eb27426cee38330a6237de8ceb9ba9ecb9b71071512b190a94"
+    },
+    "progs/rain20.mdl": {
+     "bytes": 42620,
+     "sha256": "192d3d8197976f98eb053e54a00536ca9ccc8769692e9c483990b64afa4e1d8d"
+    },
+    "progs/ranger.mdl": {
+     "bytes": 232148,
+     "sha256": "21e690b07a7d3b2b0fb630480a5fd52ea23b41a8571c3618d16ea1ab7508e52f"
+    },
+    "progs/rebel.mdl": {
+     "bytes": 215292,
+     "sha256": "433596df8d06be0882f00a2c1fad0ea49a8ae42ef148d32e0ae7c06c420322aa"
+    },
+    "progs/red_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/reflect.mdl": {
+     "bytes": 10224,
+     "sha256": "3e8b08d02c11ee9e5546c96c014c8e698ca9097046ff3873012033c0bcac8df9"
+    },
+    "progs/regen.mdl": {
+     "bytes": 50808,
+     "sha256": "1c2422c4124c235e29570580b0c1bfeb55613d6c8152c78dfb6d073ea316f122"
+    },
+    "progs/regen2.mdl": {
+     "bytes": 50040,
+     "sha256": "b8da16335e855c502b7ff0c5b6875050b73c01ff0eb5b5627fc890d155cbe013"
+    },
+    "progs/rocket1.mdl": {
+     "bytes": 34260,
+     "sha256": "c9412482647d681e08f74eb0c0260ffded91dfc67378996b86b720ef3cd2fd47"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 17204,
+     "sha256": "0dab5b94c60d92d55df3e44a8d8ea2dc0f949e98897a6525ee0be3f49a019b08"
+    },
+    "progs/s_expbig.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 165212,
+     "sha256": "5b78b324e252f95ef8f4a9fd4fb19f855c40f74fd1f93aae9b84ed822e9c3585"
+    },
+    "progs/s_fancy.spr": {
+     "bytes": 432120,
+     "sha256": "2dcb35ecb5312709ae4b295ebcf209e74a34e385823f54603e6fe0eb8999556b"
+    },
+    "progs/s_kinn.spr": {
+     "bytes": 45624,
+     "sha256": "c6412ac75ec56533cbf0487223c2c8a23a3d3518b0e3f7ed8af73b81cb6ecbba"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 8016,
+     "sha256": "fa366e4076268de137e0eecd88d02e3aac99f38c48c6ad0d0a74c88c95e8d4d4"
+    },
+    "progs/s_wave.spr": {
+     "bytes": 373212,
+     "sha256": "c2a3b258b2809f22247596b6e0505829853e9a5fd60fed7c471fd663cf9e9402"
+    },
+    "progs/s_wave2.spr": {
+     "bytes": 39480,
+     "sha256": "a0fbc773e66385a8bc3c16195ce14215050cbec7caa118fecae1a0c2a2c59d50"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 333284,
+     "sha256": "90757e506c9f0e49e4e9897708df4825e1b27774ff46abd9c113738380dfde62"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shade.mdl": {
+     "bytes": 83644,
+     "sha256": "080ad2839fafadfdbbe5412ac53061a917af3158f33e16f5df4b4f3dbe422ccb"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 128012,
+     "sha256": "94aca4b876e4794684f4f2b9e66f1c34f7b3935b0d35d406311b63aba17ea3c2"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 176048,
+     "sha256": "7ea0c1007179eb7a45112aaf38d8042213e8b644e6e79b9b1a8d4402c3843b47"
+    },
+    "progs/shotty.mdl": {
+     "bytes": 16984,
+     "sha256": "42f2e1a71e00db26092b7fb9c633daff43bfebdcb46ced46526bee057464cc88"
+    },
+    "progs/shubdome.mdl": {
+     "bytes": 97512,
+     "sha256": "3b92e43bc942b2cfba8c7b4e1206ad858484564d86bd7faa069db592f98c7232"
+    },
+    "progs/shubstar.mdl": {
+     "bytes": 14760,
+     "sha256": "ee5f914d7f3f930db06b1ead8d314dec0413e5182b7de24cc808076d117f3cda"
+    },
+    "progs/skulbook.mdl": {
+     "bytes": 15572,
+     "sha256": "794768c4237a3efedf0c13026213aa417dec5be7eba7971f6e1113b5167fb904"
+    },
+    "progs/skulhead.mdl": {
+     "bytes": 50688,
+     "sha256": "d0733746c8b7cfccdb8d0f30f9454c8863a470e6d56e8359828dbb450aade77a"
+    },
+    "progs/skullwiz.mdl": {
+     "bytes": 726948,
+     "sha256": "0736c202c56cde1cfeaa10b62ca3747f85f08ae3a9cb5daa924456166664e4c4"
+    },
+    "progs/skullwz2.mdl": {
+     "bytes": 726948,
+     "sha256": "ba9f6f478a92ef3f6eec11a1d9c72e4bacf01e755e7f68dae4f6cf2856ff5504"
+    },
+    "progs/skulshot.mdl": {
+     "bytes": 63400,
+     "sha256": "73d6d8e5411b9ae3cf815c3b0cf695a5633cedd5d586565880a9146a1a5db5c2"
+    },
+    "progs/smartbal.mdl": {
+     "bytes": 27924,
+     "sha256": "288e2d54afcbdc5242ab831f3ef611710317c52432e4585a938a12df80b7a07d"
+    },
+    "progs/smoke.mdl": {
+     "bytes": 184,
+     "sha256": "2086abd9950bc643446309a80d9df86b4ebe3f2086f75e799ce943a8454c77d7"
+    },
+    "progs/smoke2.mdl": {
+     "bytes": 184,
+     "sha256": "cdae24fb7cf8efc6ec5271c297f18b04e8c69554ac4c4aedbccd7d3dd39089be"
+    },
+    "progs/soe_coin.mdl": {
+     "bytes": 26364,
+     "sha256": "5769371db409969600bd51d573162c663fb75d358c507fcff9a4aaea95fed4dc"
+    },
+    "progs/soe_gem.mdl": {
+     "bytes": 165236,
+     "sha256": "788f32633f1f3a9f6dd2e0c2dccb76871e02fc6e002db82a219f077dcc493c3f"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 409548,
+     "sha256": "8127b55dec92682e7de27ce1619b5fc8a727413b3cdf2125510138be249a1281"
+    },
+    "progs/soul.mdl": {
+     "bytes": 8436,
+     "sha256": "eb4dc0dae8aed7c92d328096fd9633566b658c9cc65777211ade1e67c6e0ff64"
+    },
+    "progs/sp_gib.mdl": {
+     "bytes": 22228,
+     "sha256": "e902ce3a5e4be26cb781d29178b6e808c480f9e898bc50ecfa78ddf12d774238"
+    },
+    "progs/sp_gib2.mdl": {
+     "bytes": 22228,
+     "sha256": "be98f64e7c2cffce98e28d99b36856762cc15caf761015067fde234390e6b302"
+    },
+    "progs/spider.mdl": {
+     "bytes": 355540,
+     "sha256": "6b32cacff38987b0b4a5efe585dce71ce64ee03e12c4bb1243b1be350f1f3b03"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "078b774958c598bdf1503934d51a1393aeb9aadebcde806db2272b04b233c6a2"
+    },
+    "progs/spikes32.mdl": {
+     "bytes": 7668,
+     "sha256": "983176e5f12571f9b38c9c5d100841e480fe8ccf143889a0e48292a5bca8bf63"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/st_baron.mdl": {
+     "bytes": 185964,
+     "sha256": "7c00af263c1349b9dda2b1a6706bcce7034e9b0793697d67a1bfa83963ba127f"
+    },
+    "progs/st_gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "813d52c557a1eb519d801652b4bd63acdc4ec18d62db53d843ca3dcaa88e87e8"
+    },
+    "progs/st_gib2.mdl": {
+     "bytes": 16228,
+     "sha256": "2d40c1eb75eeb6f5e1781ee9db7a0be10e0d07297d563f9035a8965c4c8c3d01"
+    },
+    "progs/st_gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "d44a77787c5ff633593ad9741ddfbe28809431daf3d32fbe92f8512871b9018a"
+    },
+    "progs/t_coin.mdl": {
+     "bytes": 35040,
+     "sha256": "ed7a18cfce56a630c9adaa37757e270419fca318b3fa655fea18002b089441b0"
+    },
+    "progs/t_gem.mdl": {
+     "bytes": 165364,
+     "sha256": "955761ccf88ef8f6adcd635fb70ae5d8e434b19394a15124acc4370e614f2409"
+    },
+    "progs/tar_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "1ef69998430a54ba662abb46a0ef303b3bf0066f53e84b166065e79d58a72bef"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 313448,
+     "sha256": "fc63e6f62c83975ab2756f0a844d012b887491a6c73d9350dfcb04a6e0355b3c"
+    },
+    "progs/throwax2.mdl": {
+     "bytes": 34872,
+     "sha256": "11a22371cc72adf001e21d04e1b8b65e01497f56410867aa42ea21c0ff304e48"
+    },
+    "progs/throwaxe.mdl": {
+     "bytes": 56532,
+     "sha256": "0ebedab9ab397ba15dc3f0d90df703af2984d1c070eabc08ba781c308968150e"
+    },
+    "progs/throwham.mdl": {
+     "bytes": 7072,
+     "sha256": "f161fedb096a34db55fe57e84acd2bc42295ffea688549235c762b9a70430b35"
+    },
+    "progs/tome_pow.mdl": {
+     "bytes": 2612,
+     "sha256": "40a792071152640897de449d672a693229a87a11bf5e37ab05fd1656be22b6cb"
+    },
+    "progs/tree.mdl": {
+     "bytes": 237576,
+     "sha256": "f1f85524e4018552188aa58979154ce5544381d7bfd5ae05da521e55efdc25e5"
+    },
+    "progs/tree_zer.mdl": {
+     "bytes": 145444,
+     "sha256": "e87574f4e067fe99704d235ec155118736e0e69d9554f8622a1f1ee1c4f831cf"
+    },
+    "progs/treetall.mdl": {
+     "bytes": 120532,
+     "sha256": "e74e7c38099ccc833fadf3c7b7e97f746878d07102dad8cc5926546b344cb982"
+    },
+    "progs/uberpack.mdl": {
+     "bytes": 19348,
+     "sha256": "810cd3f895ef65e11f70fe00e195026308af02248b0f1442da5e816b7d6a7d9a"
+    },
+    "progs/v_grpple.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserb.mdl": {
+     "bytes": 35492,
+     "sha256": "cd2dcfa0fc848499235735fc5c7c5efdc631a779747f71441ff05403272bd9ea"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 93080,
+     "sha256": "05655920347b597feff05a74725b20cb88693ac78fdccb3730918a01cc4e6811"
+    },
+    "progs/v_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "a2d573bdf52015bce7a571a2263a3e8d938daf0bc1b5e4589f84580cab7da2d4"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 35492,
+     "sha256": "2f5a6e74998e4783d9b3d458d167aed31f32cd49b362f01b8d9ec0e94f90de63"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/v_rocks.mdl": {
+     "bytes": 58548,
+     "sha256": "87d0958027fadf417616cc48367b19ef6f9215a0685edc239c751b59e2b6368d"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 165540,
+     "sha256": "abd6787fff37c452fa01f4bbc9eb9594311eaf4a794f161caeb5a501ab9e103f"
+    },
+    "progs/v_sword.mdl": {
+     "bytes": 94416,
+     "sha256": "74b2fd6983cfb317ce136eeef6029d0cda063efe4706abc12057ba32cb0e988a"
+    },
+    "progs/v_wand.mdl": {
+     "bytes": 27388,
+     "sha256": "b46ba82a45a24fe4833dfdfd3c9457b98096a5800d6620d6eae11895653a6698"
+    },
+    "progs/v_xbow.mdl": {
+     "bytes": 95168,
+     "sha256": "e65f7cfe84cfa7c84c34147dadcc8b5ceea9416c7e378bd2110961fd76348e70"
+    },
+    "progs/vomitus.mdl": {
+     "bytes": 79724,
+     "sha256": "03dffcc3405c63f0e0c11301a74da5403d957b66171a6f34eaf8998e4ba31550"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "7758aaf42d0d1617e4fb172ce842be4316073f63250aba46dad441327cccb2e6"
+    },
+    "progs/wanted.mdl": {
+     "bytes": 27860,
+     "sha256": "03337a468db14377fcd36842037d2a27dfb97c3d5d5f45fcfe408e79050a5839"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 67956,
+     "sha256": "39c4a5daef1cfafc1bbfff1ca8eebb5c75d27f953f31d29f249205762605a56f"
+    },
+    "progs/wings2.mdl": {
+     "bytes": 28980,
+     "sha256": "5342d6191f59e69eb830a5e833473ac253b3a7750063d5519f6d2da2b82f5573"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 109380,
+     "sha256": "d78cd5ac1d667ec808fc7664071e060cea40179a0ba094e2f4c119d5ef7a79ba"
+    },
+    "progs/wr_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "1bfb049cf920973e32d78cbf7cf8b6c0c18f8dde55006ee43798ead4b99af9a7"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 238732,
+     "sha256": "5d0f3d6b32bfec300894dbf066a15bd9e34b985919423446232ad85d2ad6d6b7"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "progs/yakman.mdl": {
+     "bytes": 736212,
+     "sha256": "91595b5866d8f85fe67f349d22fb0c4735a4255894ca7368b10bc06618b98a3c"
+    },
+    "progs/yakman2.mdl": {
+     "bytes": 265228,
+     "sha256": "caba3ad0554bc09c10855592447424ac93beff1665803b2e5c605bd36b28cbdb"
+    },
+    "progs/zerkhelm.mdl": {
+     "bytes": 47604,
+     "sha256": "07fe43e56af442776c52da95902eda56c0bb197783fc5279ca350fc0dd34c4c5"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 226776,
+     "sha256": "f4d35645fa47d159cf7dee47a1652ff239cbe7a7b3df8567b865c6d44536abf4"
+    }
+   },
    "sha256": "9a229082e446dc3991778b3364ec5aeba9b6767e5905406767f753862997295a",
    "timestamp": "2011-06-12T20:18:08.000Z"
   },
   "pak1.pak": {
    "bytes": 11698993,
+   "files": {
+    "sound/ambience/amb21.wav": {
+     "bytes": 80716,
+     "sha256": "d664ea08d9df7e7dd135eb0726c1bc142878dcc53d13564dd3dcc5562180201a"
+    },
+    "sound/ambience/amb22.wav": {
+     "bytes": 92716,
+     "sha256": "f444289984b285a1497f55e566fbbf1896a04fa38e291efaa3ec1a0720204811"
+    },
+    "sound/ambience/amb23.wav": {
+     "bytes": 40180,
+     "sha256": "e451997ac7f37d08bd8434d708f45ee2967693317684b947ce511c9df84828b3"
+    },
+    "sound/ambience/amb24.wav": {
+     "bytes": 42282,
+     "sha256": "ead78c8507a7a6a7d6c61e913a2319964f6a8f70b5f7f720c162725edd9cd5aa"
+    },
+    "sound/ambience/brik_hit.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/brikhit2.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/chant3.wav": {
+     "bytes": 116346,
+     "sha256": "5d71f12940688414ab8cabc0d88e323dc961b60aac66f17887712133f1cb8b29"
+    },
+    "sound/ambience/current1.wav": {
+     "bytes": 50906,
+     "sha256": "dabe357d48586dccb8e1ed18c49828797c9f7a8c02c7a588ddc76a62c9b1d3e4"
+    },
+    "sound/ambience/drip_amb.wav": {
+     "bytes": 105444,
+     "sha256": "b282bc6082754011ee21a82aedb490a856c0f694f57991992296554c13149b02"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/heart.wav": {
+     "bytes": 8190,
+     "sha256": "a5b42c46cca24da59c324bb28ce6887b3a2a3baafcc18b0db2b2485f1189a4e0"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 177840,
+     "sha256": "9daec0732dcc821670b8910a1371153e3829e604b6957bf95931bea416af6074"
+    },
+    "sound/ambience/mov_watr.wav": {
+     "bytes": 44432,
+     "sha256": "9d6721844fd5559ab4f53902e70ad9789a90710dde082d222bd814a36c00ab67"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/spark2.wav": {
+     "bytes": 61640,
+     "sha256": "7eb18b00cd5e7913fea7a85ec5b1db159d1d001d24d4f687bfdb5685cb163c8e"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 106286,
+     "sha256": "056f37dfd1d5f4eba1d1911245dc0930bb0c46a84d72d867a286e5a9540248a0"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 87710,
+     "sha256": "2bb46f7c8f70fd28f0ca47b294824bcca7689047291b6c5259eebe76ad6aecfa"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 140630,
+     "sha256": "5a4dccd168cbd9f759ac468d7aa879dbcdbe5637e0fd0521f641ba1d60f61817"
+    },
+    "sound/ambience/th_clap.wav": {
+     "bytes": 570992,
+     "sha256": "5b93e5d878621c2a92e66d6214b0fa8acf8ad5a35f4120f456ddf5678e941d94"
+    },
+    "sound/ambience/th_clap1.wav": {
+     "bytes": 72062,
+     "sha256": "1fc3146d501953545b2f2f261cd2fc398959a79c753a291702609b4cdd2e8682"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/wall01.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 28798,
+     "sha256": "f66c76f07eef275e904fcc76d7ca9fc2011f3de8c61ce0b3ad035464beb7a86c"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 110578,
+     "sha256": "c3e1ccb091b9d8a06b83530b5e29b9f26f5ad8b9dcd082f3da976c3d44944b87"
+    },
+    "sound/ambience/wingend.wav": {
+     "bytes": 90874,
+     "sha256": "63e435d896b097d4dc413fb1afccc2078f1d101a4f7bfc18c4e593ca9e8b344f"
+    },
+    "sound/ambience/wingget.wav": {
+     "bytes": 65148,
+     "sha256": "533bdbd7beffa4c71c66239e3ac417f2177b20a60ed39c379c59a10b2222b367"
+    },
+    "sound/ambience/wings1.wav": {
+     "bytes": 6028,
+     "sha256": "c9e05f66a1d728a88289bc213c9f3551f1e54a4f3e8ef23ab03f8d5019e7b2c5"
+    },
+    "sound/ambience/z1m2mus.wav": {
+     "bytes": 103768,
+     "sha256": "d54261d4c9a4a8a9fe0c51eeae343c6a5b381727af88d0bae6f9b40605b8e5d3"
+    },
+    "sound/ambience/zend1.wav": {
+     "bytes": 123618,
+     "sha256": "2df6c267197b2e82241e47ce4985b04d14e1ce3cff46cebf3177369057302bb6"
+    },
+    "sound/ambience/zend2.wav": {
+     "bytes": 73742,
+     "sha256": "0ea00395004f11d41ab60352517bf5ff5c88a73b8ff2ddb3f32b5085967e3003"
+    },
+    "sound/ambience/zend6.wav": {
+     "bytes": 252626,
+     "sha256": "3f3c412e55bc7534c423c0d1bec2d817e3aea06338b4d6c3f78c4b80e55d509f"
+    },
+    "sound/ambience/zend8.wav": {
+     "bytes": 112122,
+     "sha256": "27cef28aa3d6c3ea86f0c54168db07055abfc7af284bc5a35bf53a0e53f8d677"
+    },
+    "sound/ambient/amb2.wav": {
+     "bytes": 38416,
+     "sha256": "21a4f41fb5efb52587e60395f23824ef330674a8d9499fe2cda1c91603093bfc"
+    },
+    "sound/ambient/amb7.wav": {
+     "bytes": 43020,
+     "sha256": "de7f4a0d15c711c9ca63f74ee38acf78e4ce41800900e0193a43c3e55e4efde6"
+    },
+    "sound/ambient/comphum1.wav": {
+     "bytes": 20456,
+     "sha256": "af10cad0f193d07be9c98f0dd889840fad0f54f40a61d12a1325b78033a68c8e"
+    },
+    "sound/ambient/comphum2.wav": {
+     "bytes": 72367,
+     "sha256": "fbf1ff8677cf36d78e381437f3b8e758a589a108a50c92f24c514eda06ede3f2"
+    },
+    "sound/ambient/comphum3.wav": {
+     "bytes": 116441,
+     "sha256": "62d9624940b93bcd1897abb809cb9d6f2cb3872cfd6af9a792260fb17f800150"
+    },
+    "sound/ambient/fan.wav": {
+     "bytes": 54275,
+     "sha256": "6cdc6a19b0c740d5607fa9076f749dc485483362445630877c6b59ec67085a2d"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/l_hum1.wav": {
+     "bytes": 20790,
+     "sha256": "f1b8bb19b32258ca1b126d52eb98b17c2753a255eba60864f8ad325f564681c7"
+    },
+    "sound/ambient/music1.wav": {
+     "bytes": 213944,
+     "sha256": "bf498e0cf6541b3559abd978ac420c5cb19d6542d89f19f59bdba8019dc46688"
+    },
+    "sound/ambient/pump3.wav": {
+     "bytes": 40435,
+     "sha256": "ae8ca71a1ce41bb3fa02d993930b4f100db3827ef5768326a91e61f7857370bf"
+    },
+    "sound/archer/arr2flsh.wav": {
+     "bytes": 5464,
+     "sha256": "e9a0c059430744c6546a6be4be3a1e4ac775ea6c5e6440d14611ecd8c8447d19"
+    },
+    "sound/archer/arr2wood.wav": {
+     "bytes": 5458,
+     "sha256": "97c5106007e703618291242bf1c6db9853a9d625189fc26ec9c4864436b560e3"
+    },
+    "sound/archer/arrow1.wav": {
+     "bytes": 2296,
+     "sha256": "4aeac8630ff6036f095a251a018eea5baad7a59bd7e46f624dbfec793e44d7b4"
+    },
+    "sound/archer/arrow2.wav": {
+     "bytes": 3196,
+     "sha256": "0a2734df5a69f6407ffc34ab05d8655da5d7dc0e487627932390fa6cec022083"
+    },
+    "sound/archer/arrow3.wav": {
+     "bytes": 2156,
+     "sha256": "1b866280829cb7ac051f90609baa8db285f3bfa3a27b5814e72b021b7cc05785"
+    },
+    "sound/archer/arrowbrk.wav": {
+     "bytes": 5002,
+     "sha256": "f72e35d5232f40e503192ff0ee26fe152eb42e5ee7141b2bea33a9f12f38aa2b"
+    },
+    "sound/archer/arrowg.wav": {
+     "bytes": 15132,
+     "sha256": "8ec5ee520f81c69ba367ae549a06d5ea1643b43f81dea7d8345561c94c8412ed"
+    },
+    "sound/archer/arrowmet1.wav": {
+     "bytes": 2638,
+     "sha256": "87e6ef50bfe4dabf48a1fba18ad0138bbd298965f1a9d06e2b059019e6f74b60"
+    },
+    "sound/archer/arrowmet2.wav": {
+     "bytes": 3118,
+     "sha256": "2797466dafd51473b8b6b5fd3d02a5baa4fe92a1bf9342fb038a299230037138"
+    },
+    "sound/archer/arrowmet3.wav": {
+     "bytes": 2804,
+     "sha256": "1e77951ec2218add2a8bc1633a925e4a96d2ca247d7b5dfaaaefd7a9a4f2363f"
+    },
+    "sound/archer/arrowr.wav": {
+     "bytes": 9458,
+     "sha256": "10e4bef745e55fddd004ea78d24edb9d3d9edc1ce3053c377be07be27a4da144"
+    },
+    "sound/archer/crash.wav": {
+     "bytes": 11069,
+     "sha256": "60e704bdfdb0a97863b00f3514130a172b95a86bebbf89642b65a6e757a74259"
+    },
+    "sound/archer/death.wav": {
+     "bytes": 9526,
+     "sha256": "e824b3d7d66e8bfc3ce30cc3116eab1b2d2dbc09c6311f91ff25d3e7eaef19f5"
+    },
+    "sound/archer/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/archer/draw.wav": {
+     "bytes": 6874,
+     "sha256": "c94e5cec38dc40102beebd067554c91e63b86e5c1ef11dc17976733bd9f08ce3"
+    },
+    "sound/archer/explode.wav": {
+     "bytes": 17788,
+     "sha256": "1f7d6debef492f0861ee24049ad637a11b85d595cdf3f6d6aac422b7a0376d14"
+    },
+    "sound/archer/growl.wav": {
+     "bytes": 9240,
+     "sha256": "7bdbbd23b3fe056cd1d904124824aa0044acf3aa19ec88f65e092fd13e4b9437"
+    },
+    "sound/archer/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/archer/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/archer/pain.wav": {
+     "bytes": 5082,
+     "sha256": "5347daf1a9263320f25b2a191895fbf6c85278f1fde6ca5962c09ed38e0b37b0"
+    },
+    "sound/archer/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/archer/sight.wav": {
+     "bytes": 16866,
+     "sha256": "bcd12d078e7bc34f0bdea7ae9a34ccd2c9bacb049617329b44f8301c34fffeb0"
+    },
+    "sound/archer/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/bane/death.wav": {
+     "bytes": 10935,
+     "sha256": "7e4775bc543acfb421a446a00efff6d9d5669fafb2387464cb1e1ae3db91efe8"
+    },
+    "sound/bane/growl.wav": {
+     "bytes": 9045,
+     "sha256": "86e7b3d2e685d7c20e503bdffe676727426b606ef069f4b70f182601e910ec4e"
+    },
+    "sound/bane/hit.wav": {
+     "bytes": 3884,
+     "sha256": "228faf88857d697f4d5fb9b9c03f000af4dbc8b254791e18e973fd48cc96db9b"
+    },
+    "sound/bane/laugh.wav": {
+     "bytes": 22108,
+     "sha256": "ae8e8d13e00f41bce729977f09a92806c8451ebe5cb4e8618a6b79df4d70296c"
+    },
+    "sound/bane/laugh2.wav": {
+     "bytes": 31560,
+     "sha256": "5cc5ff4c3be35eec90eaaa6579a55fa843843ad658e2e4bbb258a77f6e410020"
+    },
+    "sound/bane/pain.wav": {
+     "bytes": 9325,
+     "sha256": "1d4cfac1f9dfa1ec6958b18014ec7be18dc2615e64888d3c584d50bb48e51013"
+    },
+    "sound/bane/sight.wav": {
+     "bytes": 22962,
+     "sha256": "fbaabe115d9ca4b985c4481ccc71e6b6f55931394a29a6c51ec97e752ed3d5be"
+    },
+    "sound/bane/thunder.wav": {
+     "bytes": 43130,
+     "sha256": "cb355478e38df678e859557a0f983120a4d4275272d8ebedcae7c9cccf659bc4"
+    },
+    "sound/baron/bpain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/death.wav": {
+     "bytes": 8576,
+     "sha256": "3dd3a23d5a913548d0d0aa6ee1b455017648fcd4830f204539a1626c2ec8e1c9"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/fireball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/icefire.wav": {
+     "bytes": 8858,
+     "sha256": "b529a958de192b59438989c6b98eb50f858273febab53a238b651c70a3c92098"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/shard.wav": {
+     "bytes": 14324,
+     "sha256": "313428dd2cb681a38ad89983ab39b18979f64b3e398104b1ad80f3dc9726616c"
+    },
+    "sound/baron/sight.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/tornado.wav": {
+     "bytes": 11469,
+     "sha256": "9ede270665956ce33daf9d3b49447c09e198275f640ccaf77af4f44273bd3f64"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/bishop/conjure.wav": {
+     "bytes": 54627,
+     "sha256": "532d4b7d5db6a654aa73dfe18fa0f6a71623acfd804a848f106b0af699022bc4"
+    },
+    "sound/bishop/journey.wav": {
+     "bytes": 42051,
+     "sha256": "0995e55661447c53c3a36ae4552ea2e0bb7ec8b178bf52cdabe9d28b4deaa50c"
+    },
+    "sound/bishop/rip.wav": {
+     "bytes": 31906,
+     "sha256": "7070871da7ec08da6260a65f1a98ed1bf9682b1c95c51cea262a4b88a63fb6ca"
+    },
+    "sound/bishop/rot.wav": {
+     "bytes": 22463,
+     "sha256": "866b836874ba611d70675e5e3b83eac059c927bef0e0d1396f2183ea01bcc203"
+    },
+    "sound/bishop/skull.wav": {
+     "bytes": 34293,
+     "sha256": "48836a4d60ed8962ed0f11bffdcca95a200645e3b2cfa49a598d6392e10dc153"
+    },
+    "sound/boss1/explode.wav": {
+     "bytes": 27690,
+     "sha256": "b7eebbb64696612ee18d8d1e25b9c5cc334a4562cb99758a446a22490215f349"
+    },
+    "sound/boss1/explode2.wav": {
+     "bytes": 14798,
+     "sha256": "4c6b14b163905823f629644fbec088f37f712cf7f76e10e2f91ef23f2b573ae6"
+    },
+    "sound/boss1/explode3.wav": {
+     "bytes": 19028,
+     "sha256": "69ef0c65811704d8996b726d6e2cbcf70528d3ca7b2f28ec8814c20e7ab76ad7"
+    },
+    "sound/boss2/pain.wav": {
+     "bytes": 84796,
+     "sha256": "b9c255890f61771966327ad49994306a1e3de4b702163a079b5a733b4016810a"
+    },
+    "sound/cube/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/cube/bc_attck.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/cube/bc_gulp.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/cube/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/curse/x_armor.wav": {
+     "bytes": 17988,
+     "sha256": "61b518c8ad8410a17eaca28ee190d96a0c3d1dc755593872d7ec5429c8c19157"
+    },
+    "sound/curse/x_damage.wav": {
+     "bytes": 14772,
+     "sha256": "f74f64e3f47cee7c9b424b94a426f93c133d8acc1e6cb15551a72ab361fe95c4"
+    },
+    "sound/curse/x_leech.wav": {
+     "bytes": 16692,
+     "sha256": "78aacf297df09e21645c2e04ccf181266c35c8e52303ecb498c90db33e8c7b27"
+    },
+    "sound/curse/x_muddle.wav": {
+     "bytes": 18932,
+     "sha256": "b85810135fb3eca3f141047a08cd42a0e527d6da6e9fcfca3887a15f89edad6b"
+    },
+    "sound/curse/x_slow.wav": {
+     "bytes": 16728,
+     "sha256": "0477b046f163d36e9e41c8686ca7538659d0327668d938c0b2405f3a1e6dab3c"
+    },
+    "sound/curse/x_weaken.wav": {
+     "bytes": 15946,
+     "sha256": "f98441764b5f258ee875090c73e5841f4c8f97decbfbd8d9da836a7aac30f430"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15692,
+     "sha256": "72e737f04f1d34044dfd812c6b0e233cd38a91e6b089633e312678756952de87"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16625,
+     "sha256": "bd4cd7902712282ef8f2f749e6fcf805c2ac5212994fbb1c22fc0fe0ea5d08e2"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15527,
+     "sha256": "0b472a984137667f4788336a4f7c60e07a8893f47317b2a158aeea39920d729f"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4107,
+     "sha256": "8fe56b192838dafdf7ff4737cf1e5555d3295cbca49c1ab83568281ee188153c"
+    },
+    "sound/cyber/cybidle.wav": {
+     "bytes": 11894,
+     "sha256": "af7b96ed2eb5bc55900957b3e4136bd5dd93a72dcebca3bc2eb67cdc5186d32c"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8122,
+     "sha256": "3ea23b8d7a68e754211a10a5338b0c8d65df6e2138d4cfe06cc053b9a0f601ae"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13081,
+     "sha256": "a5ec6d4eaa707ad0246b7a7e7737b1007043ea5e5634f6f63661ecc20c27c459"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48508,
+     "sha256": "b7aac875623f8dca7597eff3dcab5910453d043fd1f9df20da89232ce8bf9306"
+    },
+    "sound/darklord/death.wav": {
+     "bytes": 10761,
+     "sha256": "7f32e12c649aa4fc4c2edb773c45b6b4258d048176d95e060390834ee7b52493"
+    },
+    "sound/darklord/idle1.wav": {
+     "bytes": 5632,
+     "sha256": "c151a3cf537f5c3668fc116e6ef5c70c9286e8a12097f376ecdf8a04774926a1"
+    },
+    "sound/darklord/pain.wav": {
+     "bytes": 12684,
+     "sha256": "f332a8cdf67fe414966f59d46714154c94de7ebcca3880a47ef5bbdad2c03ef0"
+    },
+    "sound/darklord/sight.wav": {
+     "bytes": 16832,
+     "sha256": "9710267844facf1c627ea0a8f0df458d847eb899dccd9c570e9d967acc64fa07"
+    },
+    "sound/darklord/sword1.wav": {
+     "bytes": 15982,
+     "sha256": "d36670980603c18a67d500707de9db5a8d54128601d6a6c67f7f29677244aebc"
+    },
+    "sound/darklord/sword2.wav": {
+     "bytes": 12434,
+     "sha256": "f7730881c690e0ee6a440756f74630a21241239fd1fd3bbdfd88000c7e57d1cc"
+    },
+    "sound/doomcube/dsbospit.wav": {
+     "bytes": 43719,
+     "sha256": "97f61cb588bb405cd235e242bfca6fe1108171625a7aa4f2573d63682ac42e32"
+    },
+    "sound/doomcube/dsbossit.wav": {
+     "bytes": 57109,
+     "sha256": "5843548ad38c8eea72548481b5833590fbb7fb990daebd0ede4aaac93475f461"
+    },
+    "sound/dragon/acid.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/active.wav": {
+     "bytes": 16118,
+     "sha256": "5c8762ad62bcb65e1a6fa3362393141a8564fca3ad28ea896a18545c5ebfe6ad"
+    },
+    "sound/dragon/attack1.wav": {
+     "bytes": 25054,
+     "sha256": "c96520801f27bc933928d7f793c2c28ff2dc7b36a86450f6372a9c8a668b4f58"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 63766,
+     "sha256": "55eb476a990e479c06b4c9a12b71c595d8ada35e813e512986709650ef0e54d1"
+    },
+    "sound/dragon/death1.wav": {
+     "bytes": 18358,
+     "sha256": "645baa1cccaf1dfbcd628d17fd8ea290f42f1bc40903e26c79a536a6d1528a2a"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/fly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/fly1.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/dragon/flywater.wav": {
+     "bytes": 11034,
+     "sha256": "68cac399467a55df3c80331696869309eea2339467df0ba94408be4fa2afeb3e"
+    },
+    "sound/dragon/ice.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/icehit.wav": {
+     "bytes": 9370,
+     "sha256": "089c07d0352678106aaa1c47f015792393d5aa01b4bd64fa35e798c4ee09108b"
+    },
+    "sound/dragon/idle1.wav": {
+     "bytes": 34068,
+     "sha256": "3a125f0bcf2908e4ba3af298b117f71c0efa43be4077e53c791b2805cce6a038"
+    },
+    "sound/dragon/idle2.wav": {
+     "bytes": 21474,
+     "sha256": "e1101ff0121687511a9c978d0a30a945421d0a2a30b7d139e4427d41dcc17628"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 28302,
+     "sha256": "60a99d79b6922a14e27ed63313e82ff17b127bda008bd614d8e9ed86f0f2cc3a"
+    },
+    "sound/dragon/pain1.wav": {
+     "bytes": 6524,
+     "sha256": "6cdce2fde3a1eb328007e0667c5dfe705e87bcd526e416ac948fa11a36448ac0"
+    },
+    "sound/dragon/pain2.wav": {
+     "bytes": 6875,
+     "sha256": "3238b77aafcc60c634cbdbd47ae1eec99bb969e2161b72ce5623398e6a451d2a"
+    },
+    "sound/dragon/see.wav": {
+     "bytes": 39640,
+     "sha256": "e8202c360287700da28f96d6a14fef6bdea04374ea911f2b3e41183cd8a136ba"
+    },
+    "sound/dragon/sight1.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/sight2.wav": {
+     "bytes": 15205,
+     "sha256": "197238a35261e6792c40a4da38ba7b3827116ac1af5f143e092768346605b470"
+    },
+    "sound/drone/drnblip.wav": {
+     "bytes": 2106,
+     "sha256": "b372ece13de5edfb22d88ff147a9eccfddfe446c9403607d89daae09fc7c8b68"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/force/force1.wav": {
+     "bytes": 30022,
+     "sha256": "b609981695694648cab0f2ed521dbf3d6f31b6c2e8c3e8502ab4740c7a105557"
+    },
+    "sound/force/force2.wav": {
+     "bytes": 10252,
+     "sha256": "32c0342dbc9e63220db18fa706ac0fc1afe9a86f4d488e509e1f52bee955e3cd"
+    },
+    "sound/force/force3.wav": {
+     "bytes": 10252,
+     "sha256": "0317e18dab002184b5ce11a2b86f3263d2606c40f2dc435c824bbd075c1b621b"
+    },
+    "sound/force/fusein.wav": {
+     "bytes": 13669,
+     "sha256": "53192c25adab70ebcf471204aa194ef9d34c4161138c728d95f84cf08310a879"
+    },
+    "sound/force/fuseout.wav": {
+     "bytes": 15379,
+     "sha256": "f515c6b48204f2ba158e99c10a9da60cc45756ea5dca716e256ffbe54a017512"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/goblin/death1.wav": {
+     "bytes": 13890,
+     "sha256": "bed0d074d9aeee8f046ec7b3a9d33e02d157374ddf6af1296bd1ca7bebf30f10"
+    },
+    "sound/goblin/death2.wav": {
+     "bytes": 10280,
+     "sha256": "9cc07020579d50185ea401835e41edbd1c8f007065e39a6306c7aab4f32e7781"
+    },
+    "sound/goblin/idle1.wav": {
+     "bytes": 9802,
+     "sha256": "6c5a8c36eedb0ac5bddacfdf68250c36fe472f9d87e8969b4f95a863a99b77ce"
+    },
+    "sound/goblin/idle2.wav": {
+     "bytes": 9242,
+     "sha256": "5850c885e59ef04ae90be0579dd6f6b7cc26c282045ccb163dab2c9e19fea704"
+    },
+    "sound/goblin/pain1.wav": {
+     "bytes": 5118,
+     "sha256": "8afd94fcaa2d20e7c6626eda0c6cd5463670a1dbed0eeea36da588b28196c8a2"
+    },
+    "sound/goblin/pain2.wav": {
+     "bytes": 7898,
+     "sha256": "ad1f3b63b4ae35e4bfe010447bbd18bb85cd2bbf966ea7e1370afb0e924e699c"
+    },
+    "sound/goblin/sight1.wav": {
+     "bytes": 12716,
+     "sha256": "1c20028239d217f31af57649da5d1a6def576569ef5fc7e7033c2acbef7f9345"
+    },
+    "sound/goblin/sight2.wav": {
+     "bytes": 19356,
+     "sha256": "c9182325cacd9734bfedd48cb5d8076d5823b7a94baa40d32b02de9504474b48"
+    },
+    "sound/goblin/sight3.wav": {
+     "bytes": 8526,
+     "sha256": "796b2f9f0a1c20d672382c6681e9a6ea200fee2cfcacb5b3d3faa72c8e2537d4"
+    },
+    "sound/goblin/sight4.wav": {
+     "bytes": 8668,
+     "sha256": "c0a60baf2b9918a6df5fc32cd8b58c9fa7cfed923a4cb21c841f04f7a544782e"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 27521,
+     "sha256": "424ceef852229e94dbbbc879f1546a8dfda90db93c6263700cf4973805e4bea7"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 16192,
+     "sha256": "98d55bc63eff48521faeed1046064569e932986e734168ba0973c184aa2f5d12"
+    },
+    "sound/golem/step.wav": {
+     "bytes": 11226,
+     "sha256": "851e243a2e6ecf4cb637f8c4368b0f25443d4f9d104733eecfa886c40ee92bcc"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 47176,
+     "sha256": "87f013eb50cb30a967a183f0cfa41b4848f9269afd13dbe1ab5053458bfc5f0e"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 10768,
+     "sha256": "c48f2415db3a5067dfbd99ad580e3f4809532743d653eafe2fdb924fb0bb832e"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 47502,
+     "sha256": "a0c0bd639af614c7714388009c9388f6db9a694e7ecd8fac38653609d6958f61"
+    },
+    "sound/gunner/death1.wav": {
+     "bytes": 67190,
+     "sha256": "14f89744b8f7225e0eefd9e291aee533fd9f759b6351b57d357d9597dba90956"
+    },
+    "sound/gunner/death2.wav": {
+     "bytes": 48066,
+     "sha256": "693d0d1142dfa12ce2dd1d7b959094c201f3bf783114064c29a572dffe2fcfe0"
+    },
+    "sound/gunner/idle.wav": {
+     "bytes": 18376,
+     "sha256": "6c5b1f1d39f1cc78e87cdbf584b8a508fadc99fc2b8b85d21d0e088d134a8b2b"
+    },
+    "sound/gunner/pain1.wav": {
+     "bytes": 17292,
+     "sha256": "afee7d4ac4f872716fe3deb5adced9a99bd3744784329bd12608d051b81ebfc7"
+    },
+    "sound/gunner/pain2.wav": {
+     "bytes": 20282,
+     "sha256": "38d472d2eaaa7638f7980a06a36043353e86d99aa7e86e0132c52639738c87b2"
+    },
+    "sound/gunner/sight.wav": {
+     "bytes": 22572,
+     "sha256": "395e28b6a4684ce2fa10f085f67d58d025421c594e65a0c2a1b67aeab2ee2569"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hkboss/iceball.wav": {
+     "bytes": 14990,
+     "sha256": "6aec96fda55dfb0120f106064cd324ea6e059bab3fdbb2d81cda297f9a82e02b"
+    },
+    "sound/imp/die.wav": {
+     "bytes": 8448,
+     "sha256": "a8b0e037b88829b978d3dbd3d5e657c7f775c73662d554f6247a387ba333d4bb"
+    },
+    "sound/imp/diebig.wav": {
+     "bytes": 14956,
+     "sha256": "d44d390ba11f8850105fd9601f026cb66525a415de7fc363d3574c86b72d22c4"
+    },
+    "sound/imp/fireball.wav": {
+     "bytes": 5492,
+     "sha256": "6362b59ded89655fa8b8877ed2639eca1a7aae1847306bbc3843fa98bedcbdaf"
+    },
+    "sound/imp/fly.wav": {
+     "bytes": 9204,
+     "sha256": "8036ccb256978c17234aa171267fb0332f1911b5f0dad7b9f74bba9378c39a37"
+    },
+    "sound/imp/flybig.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/imp/flywater.wav": {
+     "bytes": 9800,
+     "sha256": "c80045609b62ceb61bd8fb1a18a53c0f2fd5443502a802b0d6d3c61e9a1db4c0"
+    },
+    "sound/imp/shard.wav": {
+     "bytes": 10678,
+     "sha256": "f806167fe23f37826964c0cc345c438ff0e79c3ffb1fed2c85451c675448cae4"
+    },
+    "sound/imp/swoop.wav": {
+     "bytes": 10842,
+     "sha256": "100eacded51635de912cee171f093e869d24589c44f68887497fe751cf9b1e4d"
+    },
+    "sound/imp/swoopbig.wav": {
+     "bytes": 14012,
+     "sha256": "65d4de49684f2f9e2655abf8e4bf042a08bd706ec4971e6397f264f7274e2b63"
+    },
+    "sound/imp/swoophit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/imp/up.wav": {
+     "bytes": 12500,
+     "sha256": "874b533da43f713a1be27fbccadda8b6392fa8e689c8c4d17dac4b0d380f5822"
+    },
+    "sound/imp/upbig.wav": {
+     "bytes": 21472,
+     "sha256": "36c7bc087935cf7cd33482a50a75df75fc2bfbe53ca0ebcd9797a8bdbde73652"
+    },
+    "sound/items/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items/equalize.wav": {
+     "bytes": 13008,
+     "sha256": "933046049bae4d866250ad9a6e0a4b2a9385caffb4156daaca39ff7110a71126"
+    },
+    "sound/items/levitate.wav": {
+     "bytes": 44236,
+     "sha256": "8a04ce4a97dc22d095bc52d08111bcaaf5f57482f580ccbe0c61bdf8fd18913f"
+    },
+    "sound/items/life_up.wav": {
+     "bytes": 8660,
+     "sha256": "2712bd978343d4170bc1757706597d4de3940a07b6847977cbf117fa92f14c31"
+    },
+    "sound/items/money.wav": {
+     "bytes": 5100,
+     "sha256": "e4ac299499340c1be250f5d5e0824440d9e539de8a1d5b01e303056719cf822f"
+    },
+    "sound/items/optimize.wav": {
+     "bytes": 14854,
+     "sha256": "508d89890db17f828cde9511ebd97241ecfe07bbb6e5cba8c7538ab02e31b19f"
+    },
+    "sound/items/quaff.wav": {
+     "bytes": 3748,
+     "sha256": "ebaa4ecc17dc67d3fbc5fe1a7541e4e19769ce941d043922f8572cb2da8d3cdd"
+    },
+    "sound/items/reflect.wav": {
+     "bytes": 14936,
+     "sha256": "90dd50b25175c8d514a52165429e9ca6b90c45dddbb0f301e5873146b4a4a06c"
+    },
+    "sound/items/reflect2.wav": {
+     "bytes": 33119,
+     "sha256": "5fb5afe50e0f5fa24f1c4481b3060ae222f40138ca81052cea047a57aa6b03e8"
+    },
+    "sound/items/reflect3.wav": {
+     "bytes": 7804,
+     "sha256": "a079e5aef6ed9fb7d5c992b0ef8e11932a9efa192eedac2bc530098e0550984a"
+    },
+    "sound/items/regen.wav": {
+     "bytes": 7984,
+     "sha256": "1e125e8e7c19f29eaf09b7ad301fdfe5126d922dfa84ba2af267cdf3351b6498"
+    },
+    "sound/items/shambler.wav": {
+     "bytes": 20182,
+     "sha256": "f0cdf78367b770c97b3b89abedb7c4fb0a9ee10d742acc8c98b3daba46cfc215"
+    },
+    "sound/items/tomepow.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/items/tomepow2.wav": {
+     "bytes": 33119,
+     "sha256": "1e2e62a6f251722741b7f0adeb38c59a1d05917d0f84c8f48922efece97f02e2"
+    },
+    "sound/items/treasure.wav": {
+     "bytes": 5554,
+     "sha256": "c86f66148e8dc99af2c8e877d64d06dc1c35d0caa9c6dc5c8092b268960b8edd"
+    },
+    "sound/items/zerkhelm.wav": {
+     "bytes": 8298,
+     "sha256": "ef7b98bd965660df91ee34920806b48428a8b5c17c0ec4fdecb48d7fe28e3ba2"
+    },
+    "sound/laugh.wav": {
+     "bytes": 71573,
+     "sha256": "cb8e1381c70240a93233b8571d792e21950d00b1285f867cbc0ed1237dac1df7"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/b_rot2.wav": {
+     "bytes": 15436,
+     "sha256": "62c86077b7a29f48f5c872c68d262c03b73b57f876b718a05f2fc6b24b9a9ef4"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/bellring.wav": {
+     "bytes": 27600,
+     "sha256": "fe3b2972c722171144eaba160757803292a42342e737d6acdbd0b14802e686f2"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/dsslop.wav": {
+     "bytes": 11163,
+     "sha256": "b6a9f6e74b222169c87e6c56b47d2e7995b23b8b045f16be968f43290f22cf9d"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/met2wd.wav": {
+     "bytes": 3968,
+     "sha256": "a3ce3e10b609f7ae28fc6f39f1f5d55a7c99a41143fb161de7e4e47b7f40f100"
+    },
+    "sound/misc/metalbrk.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/mgboat.wav": {
+     "bytes": 26866,
+     "sha256": "666016e2aa958ea621ba03bee4339518f2ccc72aa3ee2d0838ef9032e8ffc981"
+    },
+    "sound/misc/pushmetl.wav": {
+     "bytes": 14042,
+     "sha256": "2657b0006f51ecb7077b5861b1b282e0bb8bef3bdd5ccb68b3bdd6794361099e"
+    },
+    "sound/misc/pushston.wav": {
+     "bytes": 11490,
+     "sha256": "f457b95dad6131472475ab22d9c260adf5d389e74629cd8ea36ca05ad7d4e749"
+    },
+    "sound/misc/pushwood.wav": {
+     "bytes": 13602,
+     "sha256": "7c3fa06978f8c7b632d12bbf1031a5ac316b44fdc5efd93338ab0a0a162bdf3a"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/rublexp.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/secret2.wav": {
+     "bytes": 87440,
+     "sha256": "36e9d9617a14daefd510e72308b9e85718a473e2b25a06b66026d463d6bbb519"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/misc/woodbrk.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/music/pkdream.wav": {
+     "bytes": 154898,
+     "sha256": "df8857901002ce9dde3c558743c94967db11cae4af3d9a0cdc00c8cc09e6a910"
+    },
+    "sound/necro/att_a.wav": {
+     "bytes": 8522,
+     "sha256": "a946c060cab5ee1bfff2d1af87cd71c9ccf63840a2751fd46fd32f387bee2c35"
+    },
+    "sound/necro/att_a2.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/necro/att_w.wav": {
+     "bytes": 26298,
+     "sha256": "9ae481ad41d16610b597989e82a8bbf9c35a74fe03a8e27900d72ff8b52e3c94"
+    },
+    "sound/necro/curse.wav": {
+     "bytes": 16852,
+     "sha256": "d3729c83c468d9320cf1f8914c8b52d446e818852c955d8d86a093c35c196b58"
+    },
+    "sound/necro/death1.wav": {
+     "bytes": 24010,
+     "sha256": "302e58b0f701ad07ade4a46d5cd3bd9c2186b2df3eb39e36c361918a72ccd24d"
+    },
+    "sound/necro/death2.wav": {
+     "bytes": 23594,
+     "sha256": "05f15a8430885b6688587eba5e249107c3e6df36d7937a3ddd2411d275e8842b"
+    },
+    "sound/necro/idle1.wav": {
+     "bytes": 49212,
+     "sha256": "737f382e89a40fc098214b77e9165e16f2a06323c07e910f336f2616b6ca87b4"
+    },
+    "sound/necro/idle2.wav": {
+     "bytes": 47120,
+     "sha256": "18893e7b31ff448831a7b7a5aa9a5d31b2dcd6e49ae8b58d5eea8b44683415dc"
+    },
+    "sound/necro/pain1.wav": {
+     "bytes": 19412,
+     "sha256": "f37e247a9e1436e4a86b78fe71e1ea6da43323e60943e86784ac87fc4393333b"
+    },
+    "sound/necro/pop.wav": {
+     "bytes": 18996,
+     "sha256": "22aff5a83ec82e759004d82308b2e210f824ac59bd3180d6b688c9d0134ca18e"
+    },
+    "sound/necro/pop1.wav": {
+     "bytes": 10836,
+     "sha256": "d5e9b7ce5a638a419eef07bba492ce75fb3d8002bd66b40d36b4dd89ad859e1c"
+    },
+    "sound/necro/pop2.wav": {
+     "bytes": 11228,
+     "sha256": "10947cad6cd5bcc0e0bc00fdbeccccd53b70bff1fda1a220c72ddc7e2b152b08"
+    },
+    "sound/necro/pop3.wav": {
+     "bytes": 11228,
+     "sha256": "56c4219dc0ecfb7ee8ff6d31fdf6c8c53c2b6990ce1b94ed956caee3c7cf83db"
+    },
+    "sound/necro/pop4.wav": {
+     "bytes": 10836,
+     "sha256": "451b660c65ebd2c7c89134896ed882d738c685f787810e1245587c0c28c38141"
+    },
+    "sound/necro/raise.wav": {
+     "bytes": 9688,
+     "sha256": "1c841e33f22cdcd5276bba9018aec5dae8c0f842da07eb261f48f1a6cc4c8314"
+    },
+    "sound/necro/sight1.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/necro/summon.wav": {
+     "bytes": 16308,
+     "sha256": "b7fc855d38431ac04e09389d7caf04bf0032d2b4edf86ebd795f1ab38d9feaf5"
+    },
+    "sound/nemesant/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/nemesant/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/nemesant/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/nemesant/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/nemesant/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/nemesant/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/nemesant/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/nemesant/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/nemesant/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/nemesant/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/nemesant/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    },
+    "sound/pendulum/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/plasma/explode.wav": {
+     "bytes": 29598,
+     "sha256": "7a95a8337c7ad87faccc1cae98ad7840352b08608fba08aff87a1b33610f9190"
+    },
+    "sound/plasma/fire.wav": {
+     "bytes": 22422,
+     "sha256": "7350d1e99f93a79bee84e94561e080dcb8448a3549a42742633cf604377a5097"
+    },
+    "sound/plasma/flight.wav": {
+     "bytes": 17494,
+     "sha256": "a03b46f31df3495a1b7a2b2f1a09f3e5223d4c0ab65aa0ed936e1445e893adeb"
+    },
+    "sound/player/boot1.wav": {
+     "bytes": 25624,
+     "sha256": "9b730ff4f811472514297921c78ea3080424c57b57ce7fa30c6c10f94bd8ccc3"
+    },
+    "sound/player/boot2.wav": {
+     "bytes": 25640,
+     "sha256": "23a3cd545ffa3c5c1e4a4c9549aff81dadd2f1ab451e397d5292c97024fc5026"
+    },
+    "sound/player/boot3.wav": {
+     "bytes": 25652,
+     "sha256": "004d267ae3fcce21aa66e566efa34e39e85915f202e3b55922b314cfd6efa2d7"
+    },
+    "sound/player/boot4.wav": {
+     "bytes": 25628,
+     "sha256": "9beb96d9a183cd6a13693961a216b4402350fc076c7a1ff98854d28c30a9f8be"
+    },
+    "sound/power1.wav": {
+     "bytes": 44370,
+     "sha256": "68f9d490b390a2510ff660917ac02fa1620893770a68a1188e06f94c57922523"
+    },
+    "sound/power2.wav": {
+     "bytes": 44370,
+     "sha256": "773aca5e1e60540b2abdc4b9b29c4281a04f6fad3bfc6bea1c029b42a7f0fe9e"
+    },
+    "sound/ranger/idle.wav": {
+     "bytes": 10819,
+     "sha256": "644fbbc14e20684fa31abc7f04969943ac950c33435271b0fa646aa324be4400"
+    },
+    "sound/ranger/sight1.wav": {
+     "bytes": 5379,
+     "sha256": "5023e2483fe5c1c37cd661d382e34c0b68eafe4bae0e35e8f3f7e516e78dcf51"
+    },
+    "sound/ranger/sight2.wav": {
+     "bytes": 11323,
+     "sha256": "3574f035e1a261b9a001d99a54bdb502da31da2639d95e7fc06f96b547c1ac44"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight1.wav": {
+     "bytes": 35068,
+     "sha256": "48db878a4eae15b37ee0ca333aae74d310103a9eaf2e4b35eecd43a89f626b9a"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk1.wav": {
+     "bytes": 19372,
+     "sha256": "42e41297df70202ec9965af7af5fcdabcab7fde43ba515c8ba0a1ee2e4429554"
+    },
+    "sound/shade/death.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/shade/death2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/shade/fly.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/shade/idle.wav": {
+     "bytes": 37192,
+     "sha256": "57b0a0a7a0e75a17df8c4bb68740b23325bd0bf3475d908ee92fa0522c71edf7"
+    },
+    "sound/shade/moan.wav": {
+     "bytes": 33684,
+     "sha256": "3a6644f2c0a6ead5992fa9752ec9b0d898f4c40f5a32b12fd61aa991f75fa0c7"
+    },
+    "sound/shade/pain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/shade/pain2.wav": {
+     "bytes": 8918,
+     "sha256": "c6fa3ba7c659faf38b00af9c9867c37ba730cbc662125f5307f755515243dc4c"
+    },
+    "sound/shade/screech.wav": {
+     "bytes": 28244,
+     "sha256": "55ef2615baa6ce39733892fc9538f702acc567f65250223329f15b191d9b1a47"
+    },
+    "sound/shade/sing.wav": {
+     "bytes": 35654,
+     "sha256": "9de82a1d3124c391466004aea5e8ad066bcc6ede2715e7978a92a2c8f66e3f6b"
+    },
+    "sound/shade/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/shade/taunt.wav": {
+     "bytes": 36418,
+     "sha256": "f556cad612249e63690ac28b17405eba70e3df43560c3a087062b9f330811720"
+    },
+    "sound/shade/taunt2.wav": {
+     "bytes": 28160,
+     "sha256": "a68174008206b79794d8d52fd027daf08767ce005189860c815cda021080363c"
+    },
+    "sound/shamvile/burn.wav": {
+     "bytes": 11316,
+     "sha256": "239c51d5cfb82ee7683075f6cd53d8a16fcc2da608c9db87c27fd7491160a627"
+    },
+    "sound/shamvile/dsvilatk.wav": {
+     "bytes": 16978,
+     "sha256": "f4fc290f121fafbc1d8e5e992b9454b404f9ebbf3c95bc376419ee8ca58425bd"
+    },
+    "sound/shamvile/melee1.wav": {
+     "bytes": 4700,
+     "sha256": "f418a627faa0b4630588914ecdd466c387e1d7d5ac2e09acecafa13baf33f10c"
+    },
+    "sound/shamvile/melee2.wav": {
+     "bytes": 6252,
+     "sha256": "dfeb5bcd8be8d9f1fcf52f89cf0af533ec28066eb0bf74e3ac4b588ca810f372"
+    },
+    "sound/shamvile/melee3.wav": {
+     "bytes": 13236,
+     "sha256": "7102a987921e4c291175ba252628613c2c6ecdb70e9a33e174b6bcf7addc239c"
+    },
+    "sound/shamvile/melee4.wav": {
+     "bytes": 9211,
+     "sha256": "da31a8531703998c06bc33c94639d5dd291c9ba24e6752599ec8e6113d3753b5"
+    },
+    "sound/shamvile/sdeath.wav": {
+     "bytes": 20996,
+     "sha256": "e27d5870c37ce74877a2681b5e9cef437d14b05c501fb93733c8e93d2d2b0931"
+    },
+    "sound/shamvile/shurt2.wav": {
+     "bytes": 3924,
+     "sha256": "541c66bfaf5f30c55d24c4013f4a8859159ebfdf2f054c681eb8b8200dba1c85"
+    },
+    "sound/shamvile/sidle.wav": {
+     "bytes": 5476,
+     "sha256": "ca3edcb476f3992027989a2a79ef21a7f8951965c8a0e77f89f0a0505f2d2b52"
+    },
+    "sound/shamvile/sidle2.wav": {
+     "bytes": 21511,
+     "sha256": "0e46d4e53c003136881723f59de4d706151b845d57608cd87361018acb7ef050"
+    },
+    "sound/shamvile/ssight.wav": {
+     "bytes": 15564,
+     "sha256": "5a5343f95ee503f1b481ef05499e023b681402b922600979367788f2fb91397c"
+    },
+    "sound/shamvile/ssight2.wav": {
+     "bytes": 27204,
+     "sha256": "2b22c0912485569f7ec87a32a29c88563c0cb8261b4428335540fc96f7e7cb52"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 19642,
+     "sha256": "91eba6c478e8475696f07079502af32d1817e3fb86418c32801846582f27561d"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 18166,
+     "sha256": "91301f18c459286798989dd164ae08f5e77433ac7a0b5c71522cf59e49bf1a30"
+    },
+    "sound/skullwiz/blinkspk.wav": {
+     "bytes": 31420,
+     "sha256": "48a4dbd2add9021727d4572af9ac4c6f333a9e2ace5fe7127ddd42c84a2ae1f4"
+    },
+    "sound/skullwiz/blnkspk2.wav": {
+     "bytes": 41834,
+     "sha256": "fc2602275102b7e1a577c30b7ab3ac2709881eb3a8798664577f8a65a9132754"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 23034,
+     "sha256": "0eb20419acddee8a5814ecad8888348f90a14db997af1045b02b6052dccd5fd1"
+    },
+    "sound/skullwiz/death2.wav": {
+     "bytes": 32314,
+     "sha256": "3b1d2ed146a334ba5cf77027faa47addbf45c51159ff9c7278a97dda8ed7ef82"
+    },
+    "sound/skullwiz/firemisl.wav": {
+     "bytes": 12186,
+     "sha256": "3583544b6d7105d5b029a490cb0730190ae9e8dc5ca8f9da1deae4ea0335e964"
+    },
+    "sound/skullwiz/gate.wav": {
+     "bytes": 16156,
+     "sha256": "5797c6450d14f363133be23d93c829a660f9b7692c07f905b5a723cda8075c55"
+    },
+    "sound/skullwiz/gatespk.wav": {
+     "bytes": 30092,
+     "sha256": "f9fc90ba497d650acfad76c42ed531314828093f114c69c28fd1611d326fab2e"
+    },
+    "sound/skullwiz/growl.wav": {
+     "bytes": 18944,
+     "sha256": "de58ed34dd69dc3e871d09ac6a5db81ef26d69e234f0834e72c6cd68501ead21"
+    },
+    "sound/skullwiz/growl2.wav": {
+     "bytes": 24954,
+     "sha256": "0cf747c71a6fad9a085c39456cd14ffd972d2d454b4bafc2781ce4464917cfa4"
+    },
+    "sound/skullwiz/pain.wav": {
+     "bytes": 6106,
+     "sha256": "0f85b6180cbfe8d26f8d174f25c109b9d8b78d0fa53735e0494280bc8a19803b"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 8890,
+     "sha256": "6d48429e7fc4b80be16afd80097b7096a94cb1a88922a62bdfdff64172526a0f"
+    },
+    "sound/skullwiz/push.wav": {
+     "bytes": 8812,
+     "sha256": "91398e953b648ab23c037940fb7996f3d77727003a60757ea50686328c05cd69"
+    },
+    "sound/skullwiz/scream.wav": {
+     "bytes": 31734,
+     "sha256": "6df299b2a59aa94a9640c83684b65259e4619e0ed2a2fd1ce518dffaa060fd43"
+    },
+    "sound/skullwiz/scream2.wav": {
+     "bytes": 13980,
+     "sha256": "adca10198e279db0789a1a026124387c40e36fc1914f3f3da315b49b6e290386"
+    },
+    "sound/spider/attack.wav": {
+     "bytes": 6576,
+     "sha256": "82593fdd5be8198a9774c163872f89a088d8d0ca10e91f1c8f846ecac92b2d81"
+    },
+    "sound/spider/bite.wav": {
+     "bytes": 4552,
+     "sha256": "abd0b64743c825661f4598b7d5b70b781452a6b7747f9eb8b53f7239b0f9b9cb"
+    },
+    "sound/spider/death.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/gib1.wav": {
+     "bytes": 10516,
+     "sha256": "bbe1a437bd05a71f9d7bba953a79886891bfc526399c67cfc8964308c91786d0"
+    },
+    "sound/spider/pain.wav": {
+     "bytes": 7576,
+     "sha256": "386e11cfd8063b6bb692ab4b90246be98288f72f29614f2e38765df9e6eaad79"
+    },
+    "sound/spider/step1.wav": {
+     "bytes": 2780,
+     "sha256": "06ee408dace817630645b0d390c496e692844fb42cc85adcaa021efeb60fae9b"
+    },
+    "sound/spider/step2.wav": {
+     "bytes": 2620,
+     "sha256": "66e802d6361a17e637f5e38366e4b0912dbb0f65e647041bed57cfda772c0770"
+    },
+    "sound/spider/step3.wav": {
+     "bytes": 1786,
+     "sha256": "418b2c536f19a5bcd0b1a8ff4aae13febc8c4f8fa6787372e9e869c45a17f54c"
+    },
+    "sound/trog/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/tur_arm.wav": {
+     "bytes": 23794,
+     "sha256": "24b428117ebd7e82865b41dcfc74a75a048c4d126d7505a6c23dd243bc054a05"
+    },
+    "sound/vomitus/death.wav": {
+     "bytes": 13236,
+     "sha256": "fa2cad86ac0ce1326132c5e378aed6a9ff5615d043df1d4d48e0b2691f8d3bde"
+    },
+    "sound/vomitus/flesh1.wav": {
+     "bytes": 8412,
+     "sha256": "9ac5a8ac2155e7d9b65144e7f65525c4660ff5959fe3a0277fab347e202b6f46"
+    },
+    "sound/vomitus/flesh2.wav": {
+     "bytes": 12788,
+     "sha256": "3fc22e2aa2c3c0bdc6501388ac18abb5e58c5fd5deba39d1cc2f7e8d48fcc869"
+    },
+    "sound/vomitus/groan.wav": {
+     "bytes": 13224,
+     "sha256": "3632e43615714e5fc1be8277881a913bf1bd79b276544418cbf1b159016f0d03"
+    },
+    "sound/weapons/axhit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/weapons/axhitwal.wav": {
+     "bytes": 6694,
+     "sha256": "0f14ba18076b25a7b8ee510b38adb282eb5c4f2fc94168baf1f8a658e1da684f"
+    },
+    "sound/weapons/block1.wav": {
+     "bytes": 5484,
+     "sha256": "ccb284becb454f395de702a263bfda1561b8bd38117893d33b5ebbb9eb7b6865"
+    },
+    "sound/weapons/block2.wav": {
+     "bytes": 5612,
+     "sha256": "62da8e44f3b1200b99f76a3bdb31d9d09a9e74c04a449c0afc482c6677a94bc2"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/weapons/clang.wav": {
+     "bytes": 7198,
+     "sha256": "634a88cf26b4de688bed392cf108d5468749f212ce67015c71baa942e8e88502"
+    },
+    "sound/weapons/dsshotgn.wav": {
+     "bytes": 9490,
+     "sha256": "98c228b3549d4908c313c783d5b0aec38b93efea1c6a65d7355767bdbb4b87e8"
+    },
+    "sound/weapons/freeze.wav": {
+     "bytes": 20619,
+     "sha256": "48689ba550c116dd8b10a138bc0f78eb6f169d6828a49aaafe12f807930eb934"
+    },
+    "sound/weapons/fwall.wav": {
+     "bytes": 40140,
+     "sha256": "e269c07608f322518e709925d5b13daded150460d19d3091f15152ce4c06c9bf"
+    },
+    "sound/weapons/fwallhit.wav": {
+     "bytes": 9426,
+     "sha256": "7b9f4da432e6fa44fbf721ed9ef753e6ceb41df59b8265b58f73764b2901224a"
+    },
+    "sound/weapons/fwalltap.wav": {
+     "bytes": 8316,
+     "sha256": "879b9970dfc3bc609ff384a0edea13b594ea6a82b5c56d33c8549cd36cccda0b"
+    },
+    "sound/weapons/icehit.wav": {
+     "bytes": 10710,
+     "sha256": "9ed8ed177a6cfcad97f8adcf94b9f3114a955e7b3abb397c6b17c44073c07b19"
+    },
+    "sound/weapons/icewall.wav": {
+     "bytes": 6124,
+     "sha256": "9668486027e07f525a27830dc3217cde36bcbcc956b21437d2637e00df368dd4"
+    },
+    "sound/weapons/mirv1.wav": {
+     "bytes": 89538,
+     "sha256": "7d60062f61d5929f5f927526d81920f24684520d230a5f2611c128b832d3357e"
+    },
+    "sound/weapons/mirv2.wav": {
+     "bytes": 18478,
+     "sha256": "67311180da390517f2ef71d161a0cf7b770548dcd4a7dda7e679cb9b58025b4b"
+    },
+    "sound/weapons/nova.wav": {
+     "bytes": 10020,
+     "sha256": "d41c8433fa1b964fafa1cdb2fec301fb4d398f1fce201b4d80b29fab7a59d7e7"
+    },
+    "sound/weapons/pkup2.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/weapons/plasma1.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/plasma2.wav": {
+     "bytes": 8350,
+     "sha256": "de03da8d300ddaf56b063584226f5673b0033a8258209e4c8c5f82a4d40b630a"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/weapons/r_exp3a.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/shatter.wav": {
+     "bytes": 20899,
+     "sha256": "31ddbef0dc746eabea23cd7cd2fb97a1f949a014b664630d7f04e6c237aafc03"
+    },
+    "sound/weapons/sheath.wav": {
+     "bytes": 7031,
+     "sha256": "8f28a1daa16db234ce77d91e688c7acbc9541c296d30af9e1f940b6d45eaf72d"
+    },
+    "sound/weapons/sprocket.wav": {
+     "bytes": 7126,
+     "sha256": "8b5c3bdc625b4954c6b504ee242591f0121d1ab64f2aceab54dd85fecadef8a4"
+    },
+    "sound/weapons/ssg.wav": {
+     "bytes": 17176,
+     "sha256": "c3307bb283499155691c01fe783d86992946475fd3b9a4839ba37cdca7ede6a4"
+    },
+    "sound/weapons/stunfire.wav": {
+     "bytes": 9902,
+     "sha256": "7214cc44e4c0bfb801209f025b591d838542a3110f770e5614b0f549a055286a"
+    },
+    "sound/weapons/sword1.wav": {
+     "bytes": 3532,
+     "sha256": "572074b68af2132285aa9fd2ac6852f52ffb6c5e56eed44b1af21e0e78171e17"
+    },
+    "sound/weapons/sword2.wav": {
+     "bytes": 3055,
+     "sha256": "b176a257409b659d80df90560bbac4da5539971576aaf1107bb88bc016558085"
+    },
+    "sound/weapons/sword3.wav": {
+     "bytes": 3012,
+     "sha256": "eaca19c8a10b7942d4a279974df6e1cf076c362d5408e439b26286126852bedf"
+    },
+    "sound/weapons/thump.wav": {
+     "bytes": 30904,
+     "sha256": "ef0aa85fbc7ff6915aa5382c80e6f571ddacd50116faff495e3d5638bace8a49"
+    },
+    "sound/weapons/unsheath.wav": {
+     "bytes": 8060,
+     "sha256": "45d9bc6b9dcaf8e0dc9b2ede7da69a872f50f7819462a71bc16b9d76a70be06b"
+    },
+    "sound/weapons/xbowdraw.wav": {
+     "bytes": 19114,
+     "sha256": "4bb73eb7161ba561970e8f2e7f5aad0e42b3419fe2b02a5953a7289c46d1442b"
+    },
+    "sound/weapons/zap1.wav": {
+     "bytes": 7648,
+     "sha256": "1ee462bf6169537cc96fa7f95ef30b782fa1be473bd6ddc297fb3a7a6aa21ad0"
+    },
+    "sound/weapons/zap2.wav": {
+     "bytes": 7178,
+     "sha256": "8ece0064dc470a86c00906c1c50a54afd3a64eb13582071b9960581a1b72f4ff"
+    },
+    "sound/wraith/call.wav": {
+     "bytes": 12328,
+     "sha256": "9ace8a0ff79d035d36b6bdfb8726054ceaf8f852d25f3c1b235616abf4646ef2"
+    },
+    "sound/wraith/die.wav": {
+     "bytes": 14024,
+     "sha256": "3f166e024c07124cc5b5c5469904f5a8b3e48d4cb50fd949be8d79b4df2e375c"
+    },
+    "sound/wraith/drain.wav": {
+     "bytes": 14094,
+     "sha256": "d767951e9630b6179fb05a80136acbdeeb530f350b1953bea62e8493f3fe67ce"
+    },
+    "sound/wraith/growl2.wav": {
+     "bytes": 24966,
+     "sha256": "1c757955bb103e0f589ec373d1517dbacb8fe7e274f7aa0928503c9f5b009b10"
+    },
+    "sound/wraith/idle.wav": {
+     "bytes": 23702,
+     "sha256": "760a4a215fa2adb6f531b15acc06a4b46daa84c85fc08691ff4fe13f17e09ee8"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 20442,
+     "sha256": "d55cb931cef7d9c336fb7bbc3fa0408ea23eff69f46e25ac377ebbc880fa5025"
+    },
+    "sound/wraith/return.wav": {
+     "bytes": 39162,
+     "sha256": "0439588ad2003732fe7f946a5597bf80b2b89d6395476671b0e050b91c49cca7"
+    },
+    "sound/wraith/rych1.wav": {
+     "bytes": 24482,
+     "sha256": "baec568f339f688ea475e37ef3fc51a36de78a52a553e85aaa3f8011e1240d13"
+    },
+    "sound/wraith/select.wav": {
+     "bytes": 29326,
+     "sha256": "1e86b92dd1d82f4f74cd7fe14a75484e6cddb4fe968d2bb3dbaf850414c6dacb"
+    },
+    "sound/wraith/soul.wav": {
+     "bytes": 70524,
+     "sha256": "612bf73a6ebe0526efa2ef3d22915bcd87bed0b0eb5e52fc4eb0e62c5e4a3039"
+    },
+    "sound/wraith/soul2.wav": {
+     "bytes": 20562,
+     "sha256": "d3701420c157109793576ac7af7c7b132ffd0897375ec99701f4cd54798d9579"
+    },
+    "sound/wraith/speak.wav": {
+     "bytes": 25630,
+     "sha256": "6d1e5b395938692d57de3ec8ef9a8b5e4ccdab920a1f247e5bcdc1f0906dfcb8"
+    },
+    "sound/wraith/talk1.wav": {
+     "bytes": 16654,
+     "sha256": "6a625383c12f7fb5979ca8977a51d40f183051d551bd0b1b4ccc8a3f43a0322a"
+    },
+    "sound/wraith/talk3.wav": {
+     "bytes": 9832,
+     "sha256": "28ecc66c85bc722059b147a1354d226fbaf3022b79aed937a4759958d52c0fab"
+    },
+    "sound/wraith/weird.wav": {
+     "bytes": 3028,
+     "sha256": "1cfcd24daeb0665dce9d68ec353377ef84a88c78d1fdfcb429f2d0cc2b7f4b78"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    },
+    "sound/yakman/big1.wav": {
+     "bytes": 21636,
+     "sha256": "16c1632682aeb4b4075006d5b8b13a7e3f8821b6f59f8eb61ad78308b0d68366"
+    },
+    "sound/yakman/big3.wav": {
+     "bytes": 25096,
+     "sha256": "2cbbc5dc1249a92b9a31a6f3fa7ff654dd6339511fc99e4c552ad6a34218a4c2"
+    },
+    "sound/yakman/breathe1.wav": {
+     "bytes": 45712,
+     "sha256": "53730dabf839c183028fbdf909df8ae7ef936828c51c58a957617444872224d4"
+    },
+    "sound/yakman/breathe3.wav": {
+     "bytes": 50728,
+     "sha256": "fd923c891934046d9770c089dfe16021373a392b429531ef9698fbd2f759c42a"
+    },
+    "sound/yakman/crash.wav": {
+     "bytes": 17808,
+     "sha256": "068f6ea04f13016615f9534e74e969a62eda98c7def921df76731c5afbd73cf2"
+    },
+    "sound/yakman/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/yakman/expsmall.wav": {
+     "bytes": 8732,
+     "sha256": "18825b9644c01ff0a488887185ac14d6fb4fd983254620009ba3ecc96c44d465"
+    },
+    "sound/yakman/firefblt.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/yakman/pain.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/yakman/slam.wav": {
+     "bytes": 6372,
+     "sha256": "2c6ff4782b389777c98f09fa6ac86e6c75a848ad800db6dc32f8ea9362706e96"
+    },
+    "sound/yakman/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/yakman/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    }
+   },
    "sha256": "22d57e211cdb714ba3df19083c1514b08e5c84650545bc1a4092b383fb72a3f9",
    "timestamp": "2011-06-12T19:56:02.000Z"
   },
   "pak2.pak": {
    "bytes": 4748118,
+   "files": {
+    "progs/brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/drlbomb.mdl": {
+     "bytes": 20355,
+     "sha256": "5c1db489f43cba73fce265db642267775245d044866cdd48396b1f1260a28237"
+    },
+    "progs/drole.mdl": {
+     "bytes": 241648,
+     "sha256": "5067b7ca5323754fe563d6696025525645a2cbd3aaf7f79232634608f9fb987a"
+    },
+    "progs/g_fx.mdl": {
+     "bytes": 32260,
+     "sha256": "ac99d4e641af0bb1495ed38ba9f3a7c1195bda19e5cf0d3a68f04defe6178ab8"
+    },
+    "progs/gaunt.mdl": {
+     "bytes": 156740,
+     "sha256": "0b532ee4b4e087960d1af3b079e9ab5681841ed46696418869e491e02e2cf1db"
+    },
+    "progs/gug.mdl": {
+     "bytes": 482020,
+     "sha256": "2cd097236a235aedf717a86b7312bd7d1b3caa6f0b25980c82eee2463fee2274"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 16854,
+     "sha256": "00f3263f1c3e0daadaaf03eea447080d727ea7d9ee1a88f2b42e060d748e1566"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 61251,
+     "sha256": "dec5afe666eba8db6e32d7535fffa3d0e4ed9344ba107b73418526ebebac574b"
+    },
+    "progs/longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/marsh.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/marshsm.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/snowflak.mdl": {
+     "bytes": 36372,
+     "sha256": "d7cdcca5767160408a43bd6b51313f9b68b696aa06eafdb0af4762513325d1a9"
+    },
+    "progs/spore.mdl": {
+     "bytes": 13469,
+     "sha256": "fc9fbb97f0d4f1a9f843769cd43fb7270ba2b351cdf3b4b624d27616980457c4"
+    },
+    "progs/vermis.mdl": {
+     "bytes": 656752,
+     "sha256": "d7060475e290482c61c122b3a477085b1aad002fd71d8293cc4a4f8bde1baec9"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/explode3.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/sight2.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 83982,
+     "sha256": "4b0d8db882ab1c9fc2109effeaf125ec46fb23a91ac2242201103e0d3da96944"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gug/bile.wav": {
+     "bytes": 54572,
+     "sha256": "e06787585ef0369798a938a1a9585d24b60aa7b5c65acda3a5fb6f2c7ab65aca"
+    },
+    "sound/gug/bileatk.wav": {
+     "bytes": 50040,
+     "sha256": "b4b05e2907789a78391ccfe8ced3902821f1097ecd1f894b12ba9278d31a8717"
+    },
+    "sound/gug/death.wav": {
+     "bytes": 132396,
+     "sha256": "20bf209a832381b77d37c54a84ab1819b6c71e2147c5d122ac62668c070167a5"
+    },
+    "sound/gug/gquake.wav": {
+     "bytes": 43350,
+     "sha256": "d232ae13b55cb5b10b8903db43c037a5c6c4cdfea1f84f9399133484df6e0175"
+    },
+    "sound/gug/idle.wav": {
+     "bytes": 50580,
+     "sha256": "ff33c63696dec5c582ff9a4537814299b47ce2480d6cc53c116721d793576fda"
+    },
+    "sound/gug/pain.wav": {
+     "bytes": 22064,
+     "sha256": "e559f2b372fe771207aeef4b1c3a71baca542863493776558ae3f933f3878c29"
+    },
+    "sound/gug/quakeatk.wav": {
+     "bytes": 65882,
+     "sha256": "2c07b7690356bd9233a79c1f8b5f4e146cbabc367a19c138d6719a1e0d09328e"
+    },
+    "sound/gug/sight.wav": {
+     "bytes": 76426,
+     "sha256": "210ed86a5d6f9d4e791954fc3a4e4b4b6dc5839d02f7c19d468493a2f87dca64"
+    },
+    "sound/gug/step1.wav": {
+     "bytes": 15494,
+     "sha256": "4e2ce285991bc0d4337c77fdbb029507697ecb4dbf6543ddefe976ea114c4214"
+    },
+    "sound/gug/step2.wav": {
+     "bytes": 15502,
+     "sha256": "27f6f770a52fce5ae04836706e63ef455555de086019a2f9e44d4da1fc99b03d"
+    },
+    "sound/gug/step3.wav": {
+     "bytes": 15502,
+     "sha256": "fcc7ab38a8ec28509d0aa062a3cb93aee6da6a0ae364e4fe0dfad791f54558af"
+    },
+    "sound/gug/step4.wav": {
+     "bytes": 15502,
+     "sha256": "fc52cad29cca2e1fc36f5c6ac7f955ed897d6da4fb5dcf4eefd052e0652d93e7"
+    },
+    "sound/gug/swipe.wav": {
+     "bytes": 16064,
+     "sha256": "90bb5831dfd19f65df19e97f76d858ec940d8e33e0a2ed8fad89a23947e430e5"
+    },
+    "sound/gug/throw.wav": {
+     "bytes": 23180,
+     "sha256": "5e901b94e7be364536603273f18791ab571c46c2fc74263774c0e312f873a281"
+    },
+    "sound/vermis/death.wav": {
+     "bytes": 148016,
+     "sha256": "44b26a9dca5ec8d5e8a7ef2b5e38196b74e4f606cd37b906ee2b2e5b5a85b08f"
+    },
+    "sound/vermis/grab.wav": {
+     "bytes": 88122,
+     "sha256": "09528bd0d49d5cac0c03fe7994b57e572eb89aa8bce63cd0a591130e4b2126ae"
+    },
+    "sound/vermis/grabbed.wav": {
+     "bytes": 51630,
+     "sha256": "99583c88b8ec2959a0d69448aee16ec86b3d9feee6df7841fc32759598349376"
+    },
+    "sound/vermis/grndhit.wav": {
+     "bytes": 36428,
+     "sha256": "1f0e78fa08efb4617b6967a6cc218c56af227c7fd6bf039420d8f106d74fca72"
+    },
+    "sound/vermis/pop.wav": {
+     "bytes": 131420,
+     "sha256": "6284ab02e604b44c5b07225b2a0544c8707517d5fec0024c127bdafef2704f70"
+    },
+    "sound/vermis/sight.wav": {
+     "bytes": 137772,
+     "sha256": "d892117e4602595b6dfb65563b8fa7a3ad2171851791f7c6f47ea4bfece76296"
+    },
+    "sound/vermis/sight2.wav": {
+     "bytes": 106780,
+     "sha256": "6132e2d0db5cfb7a1a064e708d97f7258e2c6ac15c6f4ea8d520641e0ad10f9d"
+    },
+    "sound/vermis/splash1.wav": {
+     "bytes": 30710,
+     "sha256": "f931a2927c13cdb2523dde4550c0af993cc08cbea6e332739f9cf6fe3bd1ff8b"
+    },
+    "sound/vermis/splash2.wav": {
+     "bytes": 25332,
+     "sha256": "b91c69ee695bd71537ed018800f7d89e5e7d95332124f69adee39261d84d7c13"
+    },
+    "sound/vermis/splash3.wav": {
+     "bytes": 25590,
+     "sha256": "99fad2f3815a30ef645a2162ea24e54b4302ba00d7551af9299fde74ecce98e8"
+    },
+    "sound/vermis/spore.wav": {
+     "bytes": 44204,
+     "sha256": "d01a27af99745725dae124d30af18458b2ef323bce93c3cad939310e0f47f6c7"
+    },
+    "sound/weapons/railgf1a.wav": {
+     "bytes": 66260,
+     "sha256": "a3a7edd9c470077682bde595f95d88546d416f300202ae96bd6c6371ec19cf09"
+    },
+    "sound/weapons/railgr1a.wav": {
+     "bytes": 51566,
+     "sha256": "40ce379a835e11561573be1dfdf1806a9bcb27192b94333a126cc721e38bbde4"
+    }
+   },
    "sha256": "552586d1a880768c17e134cfdf2b21fb05938eff4b67fa02acd6857e69f06801",
    "timestamp": "2011-10-24T16:47:00.000Z"
   },

--- a/json/by-sha256/9d/9d59768b7e0c7731161e95b768d82e8e5d09a503546e078ab38379620f4eff59.json
+++ b/json/by-sha256/9d/9d59768b7e0c7731161e95b768d82e8e5d09a503546e078ab38379620f4eff59.json
@@ -20,6 +20,63 @@
   },
   "smqe08a_rudl.zip": {
    "bytes": 1435486,
+   "files": {
+    "dreamscaperudl.txt": {
+     "bytes": 86,
+     "sha256": "f43879420d265ebb00aecd133611a5e15e1a0ca3efe8102ad0efe3f0a059eb38",
+     "timestamp": "2008-08-16T13:44:52.000Z"
+    },
+    "gfx/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2008-08-16T13:37:12.000Z"
+    },
+    "gfx/env/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2008-08-16T13:37:14.000Z"
+    },
+    "gfx/env/hellsky5bk.tga": {
+     "bytes": 786450,
+     "sha256": "73fd32d337e782645fd34afecdb2e31ffdc52ee66952a2cb11470e04a221ed02",
+     "timestamp": "2008-06-08T11:49:10.000Z"
+    },
+    "gfx/env/hellsky5dn.tga": {
+     "bytes": 786450,
+     "sha256": "4d86789ac951b1019c2fbee01c2ffc9c17cef913373983fefb571be62823998d",
+     "timestamp": "2008-06-08T11:49:28.000Z"
+    },
+    "gfx/env/hellsky5ft.tga": {
+     "bytes": 786450,
+     "sha256": "e20e37f9f341b04359018ce26fbc04dc285c11e29a515c5c19668cc859d09c6e",
+     "timestamp": "2008-06-08T11:49:44.000Z"
+    },
+    "gfx/env/hellsky5lf.tga": {
+     "bytes": 786450,
+     "sha256": "9321c94054b90c2229b549e30b108faac59f8f0c3358d6ecf30fa7475dbe2684",
+     "timestamp": "2008-06-08T11:49:56.000Z"
+    },
+    "gfx/env/hellsky5rt.tga": {
+     "bytes": 786450,
+     "sha256": "b136d1dba1fd5bf1dbb25b7edae9a5c16fb0db89e26cd0f093c638e716d20aaa",
+     "timestamp": "2008-06-08T11:50:08.000Z"
+    },
+    "gfx/env/hellsky5up.tga": {
+     "bytes": 786450,
+     "sha256": "1f6bf0d77a8fea3db187d1988ec4b24a702aca218d8bd2c2b01fdbffbf72597e",
+     "timestamp": "2008-06-08T11:50:22.000Z"
+    },
+    "maps/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2008-08-16T13:37:58.000Z"
+    },
+    "maps/dreamscaperudl.bsp": {
+     "bytes": 851212,
+     "sha256": "8154aeffbfd9121ec8dae31f66c84b76b63ff26dec89fb326aa40de1cd866059",
+     "timestamp": "2008-08-16T13:42:22.000Z"
+    }
+   },
    "sha256": "24e2f44591e0bdd35e262616c0ad7fb7422d716f057aae469b10156641473ae6",
    "timestamp": "2008-08-16T14:16:36.000Z"
   },

--- a/json/by-sha256/9d/9dacf0389b907eef8d0b388ce9ad07719d4926c21f4687ae70e0ebda0b493979.json
+++ b/json/by-sha256/9d/9dacf0389b907eef8d0b388ce9ad07719d4926c21f4687ae70e0ebda0b493979.json
@@ -12,6 +12,64 @@
   },
   "Maelstrm/pak0.pak": {
    "bytes": 7494090,
+   "files": {
+    "demo1.dem": {
+     "bytes": 390677,
+     "sha256": "3c736018414a05c2c61a61b0dc4a334de31cd889b17a83b6db19808f32b12809"
+    },
+    "demo2.dem": {
+     "bytes": 172537,
+     "sha256": "912fef5f55ea42b86cdaf142f828772ee137cc30297d201ad166d3754050f68a"
+    },
+    "demo3.dem": {
+     "bytes": 475569,
+     "sha256": "58e8c410e3f864a96fcf722b34d5615a093dd4b1d700d51b9adc93440dcc2f2d"
+    },
+    "maps/mtstart.bsp": {
+     "bytes": 841648,
+     "sha256": "d3dfb74e2e51d3f3ce51686df93c1adf915761fe2d6f1527ed0a69b5f6385d00"
+    },
+    "maps/p1l1.bsp": {
+     "bytes": 1786436,
+     "sha256": "288589cba18963c6bab541928805019c2923ba01479e520f96ed18dacbfcb680"
+    },
+    "maps/p1l2.bsp": {
+     "bytes": 505448,
+     "sha256": "cbca21622c8f2fb6b2e57f90d69902b6033d3a1a091ae57aef76196e9fad590e"
+    },
+    "maps/p1l3.bsp": {
+     "bytes": 2303940,
+     "sha256": "7f44e86d9e8b9bebf3fa549ad9f7debb640757a445c0b2d8e6cf05cd928b511b"
+    },
+    "maps/p1l4.bsp": {
+     "bytes": 468376,
+     "sha256": "f5cef93e453548c5a3c48a9f57735a34cb1bde35ca3e90de124e208eaf1ccdf7"
+    },
+    "progs.dat": {
+     "bytes": 415000,
+     "sha256": "df7c63419b82f83283b07d5e231d7b63bb740eada519511ecea67ddc6a89020e"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "cab92c51cc2d2c553075d38247bfda0fd514ffeb94579c44c47bc1f0e17209ba"
+    },
+    "progs/suprshld.mdl": {
+     "bytes": 17425,
+     "sha256": "f5fcb8bcc4853296fb9307384b66e1ad8200eb28ee198cafef2bd1f0ce8f6219"
+    },
+    "sound/ambient/running.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambient/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambient/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    }
+   },
    "sha256": "47d091d24488b72e78878053ebfec263b08af6c30702aa9b49ec16aa38de2238",
    "timestamp": "1997-07-19T14:19:26.000Z"
   }

--- a/json/by-sha256/9e/9e36f588f2e02ce9da5d0aada8ab279e1664e6bb433c4450b5b25136fdef7716.json
+++ b/json/by-sha256/9e/9e36f588f2e02ce9da5d0aada8ab279e1664e6bb433c4450b5b25136fdef7716.json
@@ -22,6 +22,328 @@
   },
   "necro/pak0.pak": {
    "bytes": 8251844,
+   "files": {
+    "maps/necro.bsp": {
+     "bytes": 1686136,
+     "sha256": "ea951800cd3c05a86efb1a61b5b00fd2f35a0aa2d9d0fda4dd26c13cc81495ef"
+    },
+    "maps/necro2.bsp": {
+     "bytes": 1481092,
+     "sha256": "5c32cd153ea558a00632e63e2f27112337bc7011f3c4de51e2ecff20afbffb28"
+    },
+    "maps/necro3.bsp": {
+     "bytes": 1164260,
+     "sha256": "42c513bfebd98f2611fbacb8c8f0072202a6f4b140924117d2f5224318b4ae7f"
+    },
+    "progs.dat": {
+     "bytes": 695080,
+     "sha256": "669e9d991a3f737f21fae3c2ab368a958a0d499e6b45f2b6486a1bfa7755f8c4"
+    },
+    "progs/armor.mdl": {
+     "bytes": 44076,
+     "sha256": "0e16c3f0ba370dbb172af676540ce2f4a58b151d8a6dd10c1c353748257c82d3"
+    },
+    "progs/bball.mdl": {
+     "bytes": 130008,
+     "sha256": "6fc43ee5d3e26268cb4e9be521b4b514f21bfe3556f8189ccb8c96a44c71b115"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 160688,
+     "sha256": "a7f70dc7da0492b6cb9ed4df3cc3119b983bcd3cb7e2a86142fb25c329f1e2c5"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 34884,
+     "sha256": "bb00e3b94ff9d97964cf206f8b099c2fb4ba2bba82f9c524f9041b866a81d875"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 228400,
+     "sha256": "33ece572d802f3757abc2ff7b624e02800113ec7a240edbdae2793d2e4eff135"
+    },
+    "progs/knight.mdl": {
+     "bytes": 153400,
+     "sha256": "5f38a3c2dce73b22837f93cc153edfef09341ef0634071170e31c1b84ac3fb8f"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "191d098bd32b06e22b11ce18b8ccd3489976128501a7d30ba24e6c94d6d5ba78"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 146288,
+     "sha256": "afb94866564dca06c1bb7723fe0ce9f51e66f13d1f6c16970787140ab430dd9b"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "sound/alkamb/demonwind01.wav": {
+     "bytes": 89228,
+     "sha256": "1a44a8cf17be9fe6e8aaecfc9c65ec0ef761eb27ea6df77e016cebf01cf62216"
+    },
+    "sound/alkamb/drips.wav": {
+     "bytes": 80712,
+     "sha256": "96f7890d2fea2f1f6443d0e75bb6084f39931e7c5399a6e75787dec4eaba5033"
+    },
+    "sound/alkamb/fan4.wav": {
+     "bytes": 71762,
+     "sha256": "b64616ef550e919c0a4a4d16a6841fc05fa2db07914130e7ec16f83313201bb4"
+    },
+    "sound/alkamb/klaxon1.wav": {
+     "bytes": 93356,
+     "sha256": "83002ea7c8c52bde9c76c56bdee69b10ed19c034b2233bd6d8cac91e39880bd2"
+    },
+    "sound/alkamb/machinerydrone01.wav": {
+     "bytes": 53852,
+     "sha256": "6b462ea6a9e8f2ad1f267a882efe270a8a7999b6ca681340a31cc70a88e8cb83"
+    },
+    "sound/alkamb/machinerydrone02.wav": {
+     "bytes": 30264,
+     "sha256": "6516ae7c7cd4a19509df3eac586da72dfa2e1670d349c13a65e962d57fa93446"
+    },
+    "sound/alkamb/suck1.wav": {
+     "bytes": 51436,
+     "sha256": "3d99d5630e91c603fef397453136634562f7877f42379ae744ffe57570d3eb42"
+    },
+    "sound/alkamb/tim_drone1.wav": {
+     "bytes": 51052,
+     "sha256": "41625a678d072cb8df72098beafc6e8928ef8fea56a99f41d2efdb9be788a889"
+    },
+    "sound/alkamb/wind_deep.wav": {
+     "bytes": 35606,
+     "sha256": "2ebb1e71f3283c7c15d3770f46a244a35de0c448d46f058d1d662ca06d31d1cf"
+    },
+    "sound/alkamb/wind_med.wav": {
+     "bytes": 32212,
+     "sha256": "005616904ebfec049860ca33b790903e76c75615f3048dba17ce8d85cd6c65f5"
+    },
+    "sound/alkamb/wind_rumb.wav": {
+     "bytes": 63234,
+     "sha256": "24760cbf8622bb933fcd59e847067de3581f6a3d54db72bcb3f864d2cf508a36"
+    },
+    "sound/alkamb/wind_rumb2.wav": {
+     "bytes": 32872,
+     "sha256": "9c77014eb35b692af657a524f1e7eb82b1b1ebe9d95c62462e6f6925baf4153a"
+    },
+    "sound/alkamb/wind_xen.wav": {
+     "bytes": 91138,
+     "sha256": "ffc3f8d7386db7766c885706a1247926f870957d4a3e55cd51dbe4d55416338f"
+    },
+    "sound/alkamb/windeerie.wav": {
+     "bytes": 58476,
+     "sha256": "0759ad526d301c3bb14c467818bacdbe3a64237657c45a435e06cb166b570b85"
+    },
+    "sound/alkamb/windnoisy.wav": {
+     "bytes": 25852,
+     "sha256": "02d097f0a58cc65826bde1ebe5c3450a4ab92d09b16e85ad916f62dca82936c9"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 12202,
+     "sha256": "2e0f2a66e528175f8636b4b832b1f5241c09237fc09081e46e6ec3e536e69162"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    }
+   },
    "sha256": "5b8f98f5440696f106e135b40befb744b9e286dbfdfbbee62d50b9edd9a7fb03",
    "timestamp": "2002-02-16T19:37:20.000Z"
   }

--- a/json/by-sha256/9e/9e4e3f1c9d2a4d0a8feafdc208e9f361e34879db46d83b503e8de307bd53e905.json
+++ b/json/by-sha256/9e/9e4e3f1c9d2a4d0a8feafdc208e9f361e34879db46d83b503e8de307bd53e905.json
@@ -3830,6 +3830,6176 @@
   },
   "pak0.pak": {
    "bytes": 126719139,
+   "files": {
+    "effectinfo.txt": {
+     "bytes": 157535,
+     "sha256": "8dbc7cf30b0bef166f0ce58a59c0f3ce1dcadd9a13867f8430541793fd723cf8"
+    },
+    "effectvanilla.txt": {
+     "bytes": 4612,
+     "sha256": "efd47c12bf71b377f3e750f46d5e242b3337ece446ba9a44cc0750a9bbf9c758"
+    },
+    "gfx/ad_blank.lmp": {
+     "bytes": 584,
+     "sha256": "37b5a1e7d0b3882eb7504e3626f8040a19a6d403e0e761dccd65db935401144f"
+    },
+    "gfx/ad_ibar0a.lmp": {
+     "bytes": 2568,
+     "sha256": "7a66fbbaa742e59d3fdd939ce35befa0f633492482912f4fa91f16d0788276e6"
+    },
+    "gfx/ad_ibar0b.lmp": {
+     "bytes": 5128,
+     "sha256": "5a955a32f0227e4d3e90e908e650c7dc53138b5db2d5bcb3eb4a14fe5c568760"
+    },
+    "gfx/ad_ibar1a.lmp": {
+     "bytes": 4616,
+     "sha256": "eb1c6337becc5c245b873b3d9a6ba5e9c458147f48826a4580ea0ffdf57e9759"
+    },
+    "gfx/ad_ibar1b.lmp": {
+     "bytes": 3080,
+     "sha256": "34e3eec992a3f567d4ac83c98d5fc53ca0a90c02764d45a40eea08d2f94c733b"
+    },
+    "gfx/ad_ibar2a.lmp": {
+     "bytes": 4616,
+     "sha256": "eec2d035f2857fc03083ccf0384ac6446f71b1aa45ed0e2409b8d4ba42c135f6"
+    },
+    "gfx/ad_ibar2b.lmp": {
+     "bytes": 3080,
+     "sha256": "17c35d1d02833d1fe900b1c2beaf77ffe1948a3f17ae790e9f0da1c1057b460c"
+    },
+    "gfx/ad_ibar4a.lmp": {
+     "bytes": 3080,
+     "sha256": "2507c6ce0a53ed62ce73b1bb0ee7e76e9c245757dee54415aeef78767bace887"
+    },
+    "gfx/ad_ibar4b.lmp": {
+     "bytes": 3080,
+     "sha256": "d977ecb360eff9b19827e956d32687234bed64f830adc5e506334a597daa7eaa"
+    },
+    "gfx/ad_ibar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "9d0d2c1eb7e665d0a28130bed09fb8bd698a6a1b246842fa353e3b0e1f5b445d"
+    },
+    "gfx/ad_ibar5b.lmp": {
+     "bytes": 4616,
+     "sha256": "26902c5879207315a7b732e8799f95bdcd45801a8086a902371808a594fa5515"
+    },
+    "gfx/ad_ibar6a.lmp": {
+     "bytes": 7688,
+     "sha256": "cfcce1c48cda88ccd405b1398576476bae52b3cdf7154a0b902a47655dd282cd"
+    },
+    "gfx/ad_ibar6b.lmp": {
+     "bytes": 7688,
+     "sha256": "49487400a56db767d37656f8ccb9e1660f470d8f989619a86bec5c296dcb77f9"
+    },
+    "gfx/ad_ibar7a.lmp": {
+     "bytes": 6152,
+     "sha256": "0d4ababef9a115ca7f6739a01d288d237e22a859ee16c5682d97dcabc4d7aa0b"
+    },
+    "gfx/ad_ibar7b.lmp": {
+     "bytes": 5832,
+     "sha256": "f9292e8d1fff09bde28baf932f11617e27247d4e9af191b89c30811e92110bca"
+    },
+    "gfx/ad_ibar7c.lmp": {
+     "bytes": 4104,
+     "sha256": "0e77dc6602c4945d5d4ec2a12f8003173430945bf7891d979c3c80b0c9212b40"
+    },
+    "gfx/ad_ibar_cell1.lmp": {
+     "bytes": 392,
+     "sha256": "5a4409731e4302bca5245f385a1cab9b91e0a2677d52336bbe3650fdcf070b05"
+    },
+    "gfx/ad_ibar_cell2.lmp": {
+     "bytes": 72,
+     "sha256": "6a519b1e8eed1d7a5365231162fcf1beaf31a6fd1c39b07de09bb0e66dc38303"
+    },
+    "gfx/ad_ibar_nail1.lmp": {
+     "bytes": 392,
+     "sha256": "850189c70ac92f3e8ee79ed9ff6e31ee73d33b5616964461373b37e3a29e60b6"
+    },
+    "gfx/ad_ibar_nail2.lmp": {
+     "bytes": 72,
+     "sha256": "b36d5196c807c6325816db9efad9a16fd7e38433f277b0ad9e6d3551f95c0ceb"
+    },
+    "gfx/ad_ibar_rock1.lmp": {
+     "bytes": 392,
+     "sha256": "f74ce0037116022557ec3a50d368442e73cb48492990a07e93503ad9aeeaa225"
+    },
+    "gfx/ad_ibar_rock2.lmp": {
+     "bytes": 72,
+     "sha256": "081911a352b3d75a4be7812082eee782c41127e70bc4a06585b163d385230a65"
+    },
+    "gfx/ad_ibar_shell1.lmp": {
+     "bytes": 392,
+     "sha256": "733750fbc8235b236f7a2a4246d6112c0a09ce2f75529e359382e25dab92ee10"
+    },
+    "gfx/ad_ibar_shell2.lmp": {
+     "bytes": 72,
+     "sha256": "22fc2a46e85e76836fa38db9868820322833b45e0473407d69378dc09b43e9a5"
+    },
+    "gfx/ad_sbar0.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar1.lmp": {
+     "bytes": 7688,
+     "sha256": "557afb26d50649fae0d862db7259766167caf68a53b8aa3da0475bcb9b7f3e69"
+    },
+    "gfx/ad_sbar4a.lmp": {
+     "bytes": 4616,
+     "sha256": "5ecbd1e480e4c04e2efe956dcd49e609f0c5a2038f03759b9af848b3cf7dd613"
+    },
+    "gfx/ad_sbar4b.lmp": {
+     "bytes": 4616,
+     "sha256": "8fdfe5e6ffba2c209386580adc196acce9d5601fb529f651267e7186610cc392"
+    },
+    "gfx/ad_sbar5a.lmp": {
+     "bytes": 3080,
+     "sha256": "40c7f9e7ba975d500d3861d0c5a7e592da1ce09fdc31583488fd4c78d823e20e"
+    },
+    "gfx/ad_sbar5b.lmp": {
+     "bytes": 2312,
+     "sha256": "86ff0d9678a52e5428089afe0bb9cdddc9f7688798cee45a396e4d13bf00b60d"
+    },
+    "gfx/ad_sbar6.lmp": {
+     "bytes": 9992,
+     "sha256": "5b47dbc1ae645c429627f563355c43b1fb9145d195d02606d0a7a49791034a28"
+    },
+    "gfx/ad_sbar7a.lmp": {
+     "bytes": 3464,
+     "sha256": "8773683e2edb20dfdea61775d6f955a766a15b7b733ae07212dec922d853f6ba"
+    },
+    "gfx/ad_sbar7b.lmp": {
+     "bytes": 3528,
+     "sha256": "1103f097b9896700ef5a722df927cbe71c76531a09eda9e55e5702d3b4d3b370"
+    },
+    "gfx/ad_scorebar0.lmp": {
+     "bytes": 7688,
+     "sha256": "7c479c4969b9f437c57d710edbdd6b2ce1936aa95adb559c9dd3048680868cdb"
+    },
+    "gfx/adf_1.lmp": {
+     "bytes": 584,
+     "sha256": "5b1b35dc96ad9c2f62602caab6be13d8698fe6cc14865293d11c6b9eee64dd51"
+    },
+    "gfx/adf_2.lmp": {
+     "bytes": 584,
+     "sha256": "8cbc05801d49423bd5f14bd459e8ed5cff7841e7f2d5e44d0f4dfe0f0f7ee851"
+    },
+    "gfx/adf_3.lmp": {
+     "bytes": 584,
+     "sha256": "f0155a41ad9290c8df9fabe0faae6dde4d04772dd2a425653766ec36da76140f"
+    },
+    "gfx/adf_4.lmp": {
+     "bytes": 584,
+     "sha256": "d74c9370ce323ffdc9c3dd124dcbbf9c15fc94e58e20d15789975dd8701a74da"
+    },
+    "gfx/adf_5.lmp": {
+     "bytes": 584,
+     "sha256": "f97a78ede874ff45176e5bb85abdbed93e22dab28bc0965065927c7b215ea36f"
+    },
+    "gfx/adf_evil.lmp": {
+     "bytes": 584,
+     "sha256": "42445b083abae6e9f4ff009efd7a38d2ddd664ac5e47f97ad30c88a603c64c35"
+    },
+    "gfx/adf_evilinv.lmp": {
+     "bytes": 584,
+     "sha256": "ff0d8b9203d7cfae6d075ef5bfad60cdcf66b1e24bb6fd02be0cada1b7f1c82f"
+    },
+    "gfx/adf_evilpent.lmp": {
+     "bytes": 584,
+     "sha256": "0b0029bc964ed68f1b46ccf0b4bd5e527e33e76c0904a1d06e623c47ca589e56"
+    },
+    "gfx/adf_evilquad.lmp": {
+     "bytes": 584,
+     "sha256": "a511796cca84df8149ea6d3d280880e425fdd486315159462168d32f06a17822"
+    },
+    "gfx/adf_inv2.lmp": {
+     "bytes": 584,
+     "sha256": "a6caf84d4e2c125e80aefb51aaa1af707ccf689e641141dd3736f101a66c8fa0"
+    },
+    "gfx/adf_invis.lmp": {
+     "bytes": 584,
+     "sha256": "70117297f381fd1778e5d26e5b832af86c6013ca9a55632c24c057e0aaa1e48f"
+    },
+    "gfx/adf_invul1.lmp": {
+     "bytes": 584,
+     "sha256": "453b67ccc01b32101e1051a9407b84b5c93416ae30c3b3200e25b96868c3f6e5"
+    },
+    "gfx/adf_invul2.lmp": {
+     "bytes": 584,
+     "sha256": "c70f600538aa1d1cc121ea76602e564d0af5ce5ea67a2c1ba01ac5fe44439bd4"
+    },
+    "gfx/adf_p1.lmp": {
+     "bytes": 584,
+     "sha256": "f6da35fd9699239c060f034738615ecead6111294a419a82e503bdbdd9ed46b1"
+    },
+    "gfx/adf_p2.lmp": {
+     "bytes": 584,
+     "sha256": "431539dd9656e09c6d4007c86bad37c30447e596575d803619b14371329f9acb"
+    },
+    "gfx/adf_p3.lmp": {
+     "bytes": 584,
+     "sha256": "b832a2d2143805f8701eec7eec465d67fa692e2e87714e87fa3ac3a2c2682659"
+    },
+    "gfx/adf_p4.lmp": {
+     "bytes": 584,
+     "sha256": "40f6d70d3ebf248c1c38e90b95cec42516b3a61fd17bd866df964af8e657487f"
+    },
+    "gfx/adf_p5.lmp": {
+     "bytes": 584,
+     "sha256": "d7d4768f7324d1eca2b8cb95fd250d8c6065dcfc5c392c6f2bc6adc8c2a7579a"
+    },
+    "gfx/adf_quad.lmp": {
+     "bytes": 584,
+     "sha256": "da9a83f464049832cd049205a22d832a228b00cbd0d1e7e24d347d5ed34c4ffb"
+    },
+    "gfx/adib_atank.lmp": {
+     "bytes": 264,
+     "sha256": "8d963c818c0554d73d14b251eeed0321cf854777f29eddf5a82ee3fb3fde8035"
+    },
+    "gfx/adib_axe1.lmp": {
+     "bytes": 264,
+     "sha256": "90b6817aa64570e9bfc36a13e6dd1930e81468f931ceac9f2ae3790f99f2dca2"
+    },
+    "gfx/adib_axe2.lmp": {
+     "bytes": 264,
+     "sha256": "2b0821038185e41c711e399dcfff37fd54aa8f7473ba81754c379fae558a5a1d"
+    },
+    "gfx/adib_bbelt.lmp": {
+     "bytes": 264,
+     "sha256": "8b50ea739ca8ab52baefe65f90ea5943fcc4f05b63b214a36b3ae6fa4feb55a8"
+    },
+    "gfx/adib_ckey1.lmp": {
+     "bytes": 136,
+     "sha256": "8525e145fdc72947ac6d4599ae0304b84793475d44f0113c925905d715c2da8e"
+    },
+    "gfx/adib_ckey10.lmp": {
+     "bytes": 136,
+     "sha256": "a2e14b68c10109e48e86bd095775beb68f03640dfdb12d1c28b6d32abd1fa329"
+    },
+    "gfx/adib_ckey11.lmp": {
+     "bytes": 136,
+     "sha256": "2b9191d85075d6a6c06d8b295c48546ecc0bd1c91a860308f6f953dcf324604c"
+    },
+    "gfx/adib_ckey12.lmp": {
+     "bytes": 136,
+     "sha256": "9b04f101468d96f4c39d97da0be44f7152179e4a8d6a05762ca693c9f84db317"
+    },
+    "gfx/adib_ckey13.lmp": {
+     "bytes": 136,
+     "sha256": "35fa377dbf162d691de012a61458b5ec29c28b776cd3ee0e0f9ab0ad57b67c8f"
+    },
+    "gfx/adib_ckey14.lmp": {
+     "bytes": 136,
+     "sha256": "ea6b831467c97fb0ba18d97a549c54304b133830e1567ae300e83514bdbb2919"
+    },
+    "gfx/adib_ckey2.lmp": {
+     "bytes": 136,
+     "sha256": "5c80cec0c7808ed141fff4f6863eccfa71b06a7405e871c75912d5d065b4ff21"
+    },
+    "gfx/adib_ckey3.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adib_ckey4.lmp": {
+     "bytes": 136,
+     "sha256": "51ea09fa8db26de3ce6ea6c1a5abecf4c31c3877ab6c508811ea9b271f40f1fc"
+    },
+    "gfx/adib_ckey5.lmp": {
+     "bytes": 136,
+     "sha256": "e03ed662e981530264f6dcf6f6dda91fd8406c0941d0f7c4370a89e0c4f467bc"
+    },
+    "gfx/adib_ckey6.lmp": {
+     "bytes": 136,
+     "sha256": "6f4f61addc77e3492c08cd382291eaf3f8c28a7499137591dcd2c6706bb1ec57"
+    },
+    "gfx/adib_ckey7.lmp": {
+     "bytes": 136,
+     "sha256": "38c3473948f4769e4309bdbb390afd0663fc093f1f76c9fbf10d818c6f89c72b"
+    },
+    "gfx/adib_ckey8.lmp": {
+     "bytes": 136,
+     "sha256": "d0c43a81abfb623b7c3392a07b484b6bf9137fede67d78dc67864848ecbc1c12"
+    },
+    "gfx/adib_ckey9.lmp": {
+     "bytes": 136,
+     "sha256": "042cdb7aef3e06a5679158b4f33fc66ca2d97dd6cf9e7e2657b1e85e444ed006"
+    },
+    "gfx/adib_invis.lmp": {
+     "bytes": 264,
+     "sha256": "f4f1be9a2ef88b75fd9971d72796a35f7de1ed04fc2cfc3a4c35225976f21eca"
+    },
+    "gfx/adib_invuln.lmp": {
+     "bytes": 264,
+     "sha256": "87b8312e4d7fc20d6ae9df6d1f8cb616392f3a2adaf7208dd2372eefc19888a3"
+    },
+    "gfx/adib_jboots.lmp": {
+     "bytes": 264,
+     "sha256": "206ad9d67636b46418e6afa6b6e75a12df76bd3ad84b0178e86b8d140b9c3afc"
+    },
+    "gfx/adib_lshield.lmp": {
+     "bytes": 264,
+     "sha256": "79a78f4402a301d381bef260b895ba56757b779ae89b7ae5a49f8146f2a7a54a"
+    },
+    "gfx/adib_nailp.lmp": {
+     "bytes": 264,
+     "sha256": "fe59667c80612fd2e7f5d95dd0a208f3909d93eeaaab7e4580405fe153469fde"
+    },
+    "gfx/adib_quad.lmp": {
+     "bytes": 264,
+     "sha256": "915832c8c822daf8cfa1c5d88548f24da7d182be6746b265e7ae6e1d735082cd"
+    },
+    "gfx/adib_sharp.lmp": {
+     "bytes": 264,
+     "sha256": "18987634aa43dced4e06e1d5a9a3f9b1f51c7738f59fae64168bd94ab9cd6198"
+    },
+    "gfx/adib_sigil1.lmp": {
+     "bytes": 136,
+     "sha256": "34b11b26dcdf5b91f3e6e08bbe6edb83f62ba054e9eef28459cef09b742e1456"
+    },
+    "gfx/adib_sigil10.lmp": {
+     "bytes": 136,
+     "sha256": "af31a42ef81449aa656327dfe00fc1e1d744f90212ac228bd05a6d79f5048683"
+    },
+    "gfx/adib_sigil11.lmp": {
+     "bytes": 136,
+     "sha256": "9fb90ba79d5c34e2b0afdbcec8bc528fd7d3d8f2645191d95a67a65e242bd3c6"
+    },
+    "gfx/adib_sigil12.lmp": {
+     "bytes": 136,
+     "sha256": "d7c9c3c7c1167ea0791b2790d678d6bd25144adcba79d6f7c5d93302fc28119d"
+    },
+    "gfx/adib_sigil13.lmp": {
+     "bytes": 136,
+     "sha256": "0003389cd694c55fa36f1d18d38261d279c5c7ef23dd5d41c3852ad8c95e5a49"
+    },
+    "gfx/adib_sigil14.lmp": {
+     "bytes": 136,
+     "sha256": "8ac47a2e1d45d94fb1f222811320c5f07e39e65698b7436515afa29de6e1204e"
+    },
+    "gfx/adib_sigil15.lmp": {
+     "bytes": 136,
+     "sha256": "153627403fd3e3856aa34e8740fdebb5ddb26e201cd590dd76cbfc12c36e49c6"
+    },
+    "gfx/adib_sigil16.lmp": {
+     "bytes": 136,
+     "sha256": "fa95a1a372ce30516252fff8dbcda8f8f55e3cc558b4a1e7015b79838ff0cda1"
+    },
+    "gfx/adib_sigil2.lmp": {
+     "bytes": 136,
+     "sha256": "0a0c22f027e980014a246daa629b6f84f425ccfd828f75a93ef777d9616c9191"
+    },
+    "gfx/adib_sigil3.lmp": {
+     "bytes": 136,
+     "sha256": "9e5daafbe4cc032824f732ebdac3897d804df43efaff9901c315ae661af8cd31"
+    },
+    "gfx/adib_sigil4.lmp": {
+     "bytes": 136,
+     "sha256": "fd1d3791d53ab40881a2d86a0bc67b3b532ef10b201a166a3937b105c63e3c9b"
+    },
+    "gfx/adib_sigil5.lmp": {
+     "bytes": 136,
+     "sha256": "947d5088b18a12d06a93fe66a0500e5b6ae93e04cebc748858139d569693d42d"
+    },
+    "gfx/adib_sigil6.lmp": {
+     "bytes": 136,
+     "sha256": "5a2356a7479f887b20f10e03ee2f42478bdfa75febe2d802b3dbfcd25b39d744"
+    },
+    "gfx/adib_sigil7.lmp": {
+     "bytes": 136,
+     "sha256": "507011b2a191e096fadcd678590636e4033de2ffcf35cef31785539bf3f9fb4f"
+    },
+    "gfx/adib_sigil8.lmp": {
+     "bytes": 136,
+     "sha256": "2a49a4653b2ed11353c6aaca950420c38c8e7b2aa8cc82ecd746a4e73fb7aa00"
+    },
+    "gfx/adib_sigil9.lmp": {
+     "bytes": 136,
+     "sha256": "df168192d5c065c7247cff03b10da51eba431bdc4f76d2c913646bb23084d639"
+    },
+    "gfx/adib_suit.lmp": {
+     "bytes": 264,
+     "sha256": "030bf62f7f45667310f1a74bd88881e2aa8d6c7ba5355bda4bc7c87d64a3d082"
+    },
+    "gfx/adn_0.lmp": {
+     "bytes": 584,
+     "sha256": "0895fe0acba04a4e17ef64fe62c56765c4fef5933c4af09dfcb242e984e8d163"
+    },
+    "gfx/adn_1.lmp": {
+     "bytes": 584,
+     "sha256": "fc0391c514808f9cb54e0bb0bbd63edccb0bea66a7620b81d04497edd099f5b1"
+    },
+    "gfx/adn_2.lmp": {
+     "bytes": 584,
+     "sha256": "d70ca75a162f7203067f314eee6460dc9180383e5bd1a19c69a984d8f4c699ae"
+    },
+    "gfx/adn_3.lmp": {
+     "bytes": 584,
+     "sha256": "40fbf34b86a4e5d264fac3c875ad74a52b62f5868d01a7580107a52998cbe4ac"
+    },
+    "gfx/adn_4.lmp": {
+     "bytes": 584,
+     "sha256": "5c9f781b8fb46cff0bb69db9817936be10cc4e34d677a5a49f117baa1d414aef"
+    },
+    "gfx/adn_5.lmp": {
+     "bytes": 584,
+     "sha256": "f2b1a90d1f4e1e3c6eb04dd1d87f084b2bc932b76b6eabcc5a4ee12db939971e"
+    },
+    "gfx/adn_6.lmp": {
+     "bytes": 584,
+     "sha256": "ec90a75650252feb45f325815498caf518058d141c7660e594397e0e05e35cfc"
+    },
+    "gfx/adn_7.lmp": {
+     "bytes": 584,
+     "sha256": "c292389fee1e91c2c4178099a8c9b2ad193f74346adec126ae10a4383f96c6de"
+    },
+    "gfx/adn_8.lmp": {
+     "bytes": 584,
+     "sha256": "4df870d66977eddbb7c4f87ffe4b94a032f2f13ad8fa38a98fde607d7aa7b06d"
+    },
+    "gfx/adn_9.lmp": {
+     "bytes": 584,
+     "sha256": "fd7f393a0fea9c0bc9fec90492a8f074a75275fde2ce211379b098176729622d"
+    },
+    "gfx/adn_a0.lmp": {
+     "bytes": 584,
+     "sha256": "7221532ee9af2c3a2fa3d19e4ccae78458d7a1f3025627e6da45dcb4aefd6820"
+    },
+    "gfx/adn_a1.lmp": {
+     "bytes": 584,
+     "sha256": "8f594ea65757fdaa62105b5eb68d4519b96b93e12dba110a723c4bf99470d408"
+    },
+    "gfx/adn_a2.lmp": {
+     "bytes": 584,
+     "sha256": "738cd71a2344da4b1733b639e6cdef1fb412104c388d2edee0b4539655ed9fec"
+    },
+    "gfx/adn_a3.lmp": {
+     "bytes": 584,
+     "sha256": "00c7040d33a445656f33c373077564116a764142f4625b5df7fae6516817f893"
+    },
+    "gfx/adn_a4.lmp": {
+     "bytes": 584,
+     "sha256": "7fbde831e189692c1c5d048873e7098a7d017ff7e22fc57a724a2c2fcbcc8db4"
+    },
+    "gfx/adn_a5.lmp": {
+     "bytes": 584,
+     "sha256": "ecb1a8036b03abc3c95a145081762ebf8b04516bc438053e570b989195687615"
+    },
+    "gfx/adn_a6.lmp": {
+     "bytes": 584,
+     "sha256": "8495247be5584836815824b182f448348d3de924236e254c5ebffd8132a1b7ae"
+    },
+    "gfx/adn_a7.lmp": {
+     "bytes": 584,
+     "sha256": "76a1b4a37c14cf3c53047129e14bb3f2217142ca5405ebceb95b892bed49cb77"
+    },
+    "gfx/adn_a8.lmp": {
+     "bytes": 584,
+     "sha256": "943ae9da4710dfb8a8b7b22eb8ecc6131e7c4586f279701323997f931bdd486f"
+    },
+    "gfx/adn_a9.lmp": {
+     "bytes": 584,
+     "sha256": "4381c6e590644e7c7e3d64e89adb1d438802e1a81380de8f08b31669780f07ed"
+    },
+    "gfx/adn_aminus.lmp": {
+     "bytes": 584,
+     "sha256": "903c3e6081e934fb4a9b0ae4564265b0339d2289fea17720c7bac77d00155258"
+    },
+    "gfx/adn_colon.lmp": {
+     "bytes": 392,
+     "sha256": "a06510a33f355c24fc16d7591323523f13920ae6fa903c3155b5edef9e4059a9"
+    },
+    "gfx/adn_minus.lmp": {
+     "bytes": 584,
+     "sha256": "1e04325b97c5052e64187e0882b8c2f87473bd66f3e70b5a419d983b0a62ed81"
+    },
+    "gfx/adn_s0.lmp": {
+     "bytes": 264,
+     "sha256": "6a5cac8d7c8076aa42055c3b64f3fde4b1e7750b2bb143b12af07dec892c9ccc"
+    },
+    "gfx/adn_s1.lmp": {
+     "bytes": 264,
+     "sha256": "723ec3e0b6225419fa5fb8010896674d91d19eeafd8e2c9bbbec2d23fbb85792"
+    },
+    "gfx/adn_s2.lmp": {
+     "bytes": 264,
+     "sha256": "cff9bff09933ccbf43a1419d6f566807c2aee9a4aca448a86bf261394b3ca7b3"
+    },
+    "gfx/adn_s3.lmp": {
+     "bytes": 264,
+     "sha256": "8d7cf6b3f2db7463e962fd7b70b2ef7c36b0882b1e80d90b02fa1a609d09513f"
+    },
+    "gfx/adn_s4.lmp": {
+     "bytes": 264,
+     "sha256": "2bc5fa316cc366f4d1a4f1831ac3b8ced65caf89157e796ff5d673fa3955ac1c"
+    },
+    "gfx/adn_s5.lmp": {
+     "bytes": 264,
+     "sha256": "98cbff3f1b98977b8fc19523fc2e644e763fc52dba708fc5024dfbeaa1f00d6d"
+    },
+    "gfx/adn_s6.lmp": {
+     "bytes": 264,
+     "sha256": "1578d854415aaf5b68a25a0fb37057b019d12055b61c3d7402eae811a9359e1f"
+    },
+    "gfx/adn_s7.lmp": {
+     "bytes": 264,
+     "sha256": "609059534b0a59c9d5ab1180f25f0b2a952719a0ccade29d05559dfc6223f1d9"
+    },
+    "gfx/adn_s8.lmp": {
+     "bytes": 264,
+     "sha256": "7327dd480225a52c642320336ade17100228d2c1ade5f1b640cbff18e37fbe2d"
+    },
+    "gfx/adn_s9.lmp": {
+     "bytes": 264,
+     "sha256": "b8ad416098543b34c286565e3a0d7756eea7ab18c8b50145e7ddbc45fd28851a"
+    },
+    "gfx/adn_slash.lmp": {
+     "bytes": 392,
+     "sha256": "2500358f0d4bf9856c04b7be940ab41012faad597005837c99dfef93da1f3ca6"
+    },
+    "gfx/adsb_armor0.lmp": {
+     "bytes": 584,
+     "sha256": "01228bb8947103a70c9f536b168eefacda9dc5a08e1fa64ee963be44d4a9af9c"
+    },
+    "gfx/adsb_armor1.lmp": {
+     "bytes": 584,
+     "sha256": "85956c2a17460229a374e8a6e1cf22ad4ff663929dba06c9daa9d95d1582ba53"
+    },
+    "gfx/adsb_armor2.lmp": {
+     "bytes": 584,
+     "sha256": "e8e64ea8d90241677315bb9a9e25714856827642a0e331077dc6fa2b827036fc"
+    },
+    "gfx/adsb_armor3.lmp": {
+     "bytes": 584,
+     "sha256": "db6523d7c99bb15c14ad9fd1d665a24e4eab985dfa095d316f20fe5e96e9c320"
+    },
+    "gfx/adsb_axe1.lmp": {
+     "bytes": 584,
+     "sha256": "ebcafdd02b84a9bd21658a349205a09e5e242fa39013207fe6aab9697df2884f"
+    },
+    "gfx/adsb_axe2.lmp": {
+     "bytes": 584,
+     "sha256": "12caae98c176f1176a5222f7730709dcb9164a5db63984fe6f8982e8b17915e6"
+    },
+    "gfx/adsb_cells.lmp": {
+     "bytes": 584,
+     "sha256": "08da91ae0bca3d7bd546d92f7688061b7fbc8d86b84e309510ee3feeb3f63e92"
+    },
+    "gfx/adsb_key0.lmp": {
+     "bytes": 392,
+     "sha256": "49e4cda132ff7237a4b7244892fa1e059ff2d77698ec855cb4c02e08867899e2"
+    },
+    "gfx/adsb_key1.lmp": {
+     "bytes": 136,
+     "sha256": "ae3c6db0a322d5f969ad5c11bbe1c7d35e0814005e95217b056bca0388193fb9"
+    },
+    "gfx/adsb_key2.lmp": {
+     "bytes": 136,
+     "sha256": "46a6561c191c47e9445ef85c2bebdc881f330ca49afe562d7bb2a59c5442c73e"
+    },
+    "gfx/adsb_nails.lmp": {
+     "bytes": 584,
+     "sha256": "77fb4c0c61d824fafba54e91d6b23e702ae54565d7708ee0e404aff804555b73"
+    },
+    "gfx/adsb_pent.lmp": {
+     "bytes": 584,
+     "sha256": "8066cd0ef3d3ed9add280937fa51d6dd13a7eaf606ad0567366e86c51ddb7d62"
+    },
+    "gfx/adsb_rocks.lmp": {
+     "bytes": 584,
+     "sha256": "2e79b7c3e3fb6b4118a3ddedd7d9a1186f12c2df2efdbcf5300cacc51fe64744"
+    },
+    "gfx/adsb_shells.lmp": {
+     "bytes": 584,
+     "sha256": "f185cb1b1a48a8499d110e6371f2bb102ad89fda9875a267adcc6f3c8a5e613c"
+    },
+    "gfx/adw_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "ee32ef4cb14c02b9516f245fe9eae50021962ebdee3ef843076b9dbe20f038fb"
+    },
+    "gfx/adw_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "0f8884976f5ef05d5c3d7ab7c7b22bddeba9ee922664d23c6dfe835c5673ad9f"
+    },
+    "gfx/adw_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "2c1f7b1b0a5c27da9f01c84a38571901fb3636a04485102f44cb19d715e7f627"
+    },
+    "gfx/adw_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "a9802bea98b2fb57ab97784caeebf1ab2312fab73146503459c7c8021249ccef"
+    },
+    "gfx/adw_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "0c92aaf91afe914f4d06e5d2fa91bf926a0b43294d49021755b93c049e15a99d"
+    },
+    "gfx/adw_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "155eeca532e2f6d08b7575697020eebd4f492987392c68f09c66bb6522c0336b"
+    },
+    "gfx/adw_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "02d55707616bd6eae995c93d5eca3e788f227811001e2e8137c07cafe85409a4"
+    },
+    "gfx/adw_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "0d4cba204d9ea74665e164d46ead9167095cceb64a795861dfb21fcfd2b3e9ac"
+    },
+    "gfx/adw_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "3d354bd9336125ea758f2b5b56b1ecdf2a2afea4e8bb8d6edeb058448f9627e7"
+    },
+    "gfx/adws_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "457f6682e5a8b3d7b1075148c05093df1ec96c59e85057dfca80f66f4ad25815"
+    },
+    "gfx/adws_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "127d3759679f91a8633557a27abcb8425b3f8fd8b9888e029f761cff9fa20e47"
+    },
+    "gfx/adws_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd1e14b26cfa3915c23502e22413328d37749e0a77ac75508238fbaa375c7555"
+    },
+    "gfx/adws_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "424a425e24162a3a1a23e7308b8b46f4d25f1c9f11ac3b427117c596dafeb006"
+    },
+    "gfx/adws_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "41dc9eb1fb806500b41d832786a0bce0c6863c6caa3bcc7491892e25d04a81d4"
+    },
+    "gfx/adws_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "30a22fc8975b5a696ff31e859290fd780553f1857e424b1d5ecfa057277d155a"
+    },
+    "gfx/adws_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "50c5e9c358023dbbb65cc79346d99af6797af556faded31df95e2b7191aeb3f0"
+    },
+    "gfx/adws_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "94cef7136e718532b4d00b9ed8804da60be979206bde676a328270321286851a"
+    },
+    "gfx/adws_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "8259db2f3f7ddd075e6192d6e0581a2321c108232d67980fab85059fcbfe47df"
+    },
+    "gfx/adx1_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx1_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "e4d0714014c5a1c0d9874bf1ce2c0232352be1e0c90ffe927dc2d86d448f7e47"
+    },
+    "gfx/adx1_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx1_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "9da68076978e9bc4d35e2b40e972c578e0839c379c86d44bf15c033f164fc9e9"
+    },
+    "gfx/adx1_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx1_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx1_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx1_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx1_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "9341894f953061deffb42e12370fd05b7f8008e2a1caee149630a8bcd40fac10"
+    },
+    "gfx/adx2_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "c5f2e4352837eca0a67b1fe6eb5d437672f365efffd7c297848dcdbfca6fea7f"
+    },
+    "gfx/adx2_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "b627ea70b6a7a5debddd4710f31ca137c3baf01dd6109cc2cee7da968a020049"
+    },
+    "gfx/adx2_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bd7a15d826f6565c97f638ff541d76e409b9cc69febbb78906c5ddbbad2e0f02"
+    },
+    "gfx/adx2_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "8239bfd1d494fae52f97d5f620bf6c9cace057a27975cddf7d0f557b5a797cb6"
+    },
+    "gfx/adx2_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "6adf5220508ec39cedaf8cc8208c8b7bff5f44f18401bc5ee7a39e91419376ab"
+    },
+    "gfx/adx2_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "f300febb1aad7dc16d592f1e1aef2cc5a8870ad08ebbb2bc15b43009122259ae"
+    },
+    "gfx/adx2_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "e15bf6fb56eca5640d521dfdbe0c20f9e3ce6fb6fc7a2e39922f0fc8cfc7d002"
+    },
+    "gfx/adx2_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "c781852ce141a1d5fb84451e1bef2b021c937d0658d7ca8f8b2a1d5cc3737a66"
+    },
+    "gfx/adx2_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "aaaac2a8b4dfaae3d02705c2fbffa38621187cc28f4246a591f38b2bec79f693"
+    },
+    "gfx/adx3_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "20209da4ccb0dbeffc6520aee7958b33bcfa728ed376b1f5f987c8305fb70d3e"
+    },
+    "gfx/adx3_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "eb13bcc843d95abf3c90c140c95aa95803a42a6afeb100e11a5e0d80c72caf8b"
+    },
+    "gfx/adx3_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "483f85f7e5a0e881f6511f2b16a25d1945dcc2fa5365e4417cb58ec6a87f062d"
+    },
+    "gfx/adx3_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5e1f15716b826a8a25e61415e675a6c94888ae4030462e1190653c4d93768743"
+    },
+    "gfx/adx3_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "99d58b01e578c88924699f85614b021dcc5ce32798c96680fb5120e8d58837c2"
+    },
+    "gfx/adx3_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "4eae7b9a7119e883d3b6d3b8b336398beca8b7cf4ed2b9b498e13d90b7743ccc"
+    },
+    "gfx/adx3_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "8568e0c106e3155b9cef3dc3bd55ce821ed151560abab4080fcf6534850b153c"
+    },
+    "gfx/adx3_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "b8764c3198aa863d67e4f7c3c19db89aab6aa4f4076abe83d50b88710eb85446"
+    },
+    "gfx/adx3_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "fbb92c8a0853070604e84da82a5232c93747f3571ba05e88ecb4e59649125838"
+    },
+    "gfx/adx4_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "4e8da401756d091a913d4a0a5618aee7eeddad1bcd8c78774bc229195bd96943"
+    },
+    "gfx/adx4_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "c68cec0c6064b7ceaad60028ed1e8f7834a6484d9fde249649d7b94addc6544a"
+    },
+    "gfx/adx4_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "386eadd2ee00c5a53179729c2b23cf56f0629c3e7ad8e5b3a739f1fd8d489d34"
+    },
+    "gfx/adx4_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "5179dcb2b82032c81d02dfb35d130ed8196d5b726c7a8265c2823c3f2edde2a8"
+    },
+    "gfx/adx4_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1156e8a090be24e24605153b059646bd7d8b9d33c6e175bc9b05843eb626ce38"
+    },
+    "gfx/adx4_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "8881a5fe764d90c1113e1df7215c6520988c23601a969ea3e7b9abf8d7d4ef0c"
+    },
+    "gfx/adx4_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "7b55d6f2071d101db2a87c5958aadcdcf618f8f0eab53b19691125c1e8b6d8ad"
+    },
+    "gfx/adx4_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "199a6be6977bbebfe0aac0005466b10bfcdd9d26a764d18e56e28ee6f6f8f5ee"
+    },
+    "gfx/adx4_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "924cd9a6ac66660db99821b558a21e8dd0b02e85bb2a5415c2e24daace249663"
+    },
+    "gfx/adx5_grenade.lmp": {
+     "bytes": 392,
+     "sha256": "6db1b8eaf85a83d6ed0bf0547905147f3133d4c66a98897968b81b1ddc408631"
+    },
+    "gfx/adx5_lightng.lmp": {
+     "bytes": 520,
+     "sha256": "9405034666f0f1247a58a97b86e5c451f0b2a315501389f43043da55493db8de"
+    },
+    "gfx/adx5_nailgun.lmp": {
+     "bytes": 392,
+     "sha256": "57c0c5335c4acd555c4c785ca1e3c6924a072fac3ab3bb0e959db44d97e839a9"
+    },
+    "gfx/adx5_plasma.lmp": {
+     "bytes": 520,
+     "sha256": "6c529185a7cc6dc8d066080c4246f80c7bf1fd0ea808fc0be5be63c8cff7c2b3"
+    },
+    "gfx/adx5_rocket.lmp": {
+     "bytes": 392,
+     "sha256": "1bcaf3731e9a806d44f4db69871c887e2901f99163b8a6e426397d64e065c08c"
+    },
+    "gfx/adx5_shotgun.lmp": {
+     "bytes": 392,
+     "sha256": "5751b8e5d52a9069714fa2eea1def4fdeef6fbd860c35e3801a8c9a7b6cee638"
+    },
+    "gfx/adx5_snailgun.lmp": {
+     "bytes": 392,
+     "sha256": "bbf105a41d8543bd8b589a75b9bbdd38acef70e142b02e923725ab8322a8d496"
+    },
+    "gfx/adx5_sshotgun.lmp": {
+     "bytes": 392,
+     "sha256": "ae013b3953e5091843052db15302f9fa07c01cedf3dacdfb93fa937d845dcf15"
+    },
+    "gfx/adx5_widowm.lmp": {
+     "bytes": 392,
+     "sha256": "bb8e065bc9d9935d7fab8e9d0d0554948e2ab2622a54e86f70c1d8c3c9a0f178"
+    },
+    "gfx/env/adgreenskybk.tga": {
+     "bytes": 1520289,
+     "sha256": "6a7fa2cdc97237658a3f2c73a8a5d879feadf4a31e84fb8585aeba96f3f8fb61"
+    },
+    "gfx/env/adgreenskydn.tga": {
+     "bytes": 1565620,
+     "sha256": "d4fabe617a431169df1bbc37e48404fc34718a1bbf5a1ee45d5b3a0ddda5cc6c"
+    },
+    "gfx/env/adgreenskyft.tga": {
+     "bytes": 1704063,
+     "sha256": "c6cfbbd8b09846eaea719a5e65744cdd4fddced0c277f4584c743f2639882d50"
+    },
+    "gfx/env/adgreenskylf.tga": {
+     "bytes": 1576943,
+     "sha256": "c83f24917ccb67af83602236d03e57096f73b36b7fc64da6206afe989944b4a4"
+    },
+    "gfx/env/adgreenskyrt.tga": {
+     "bytes": 1706213,
+     "sha256": "7b85287d2ce5e4d3a9ce63a560183086e812ceca9232d07eb61f63a24d678e10"
+    },
+    "gfx/env/adgreenskyup.tga": {
+     "bytes": 1798684,
+     "sha256": "703e4449b5b9ff967610dbc81d7e27c089788927d82fdb31267490cfb30ed0e3"
+    },
+    "gfx/env/black_bk.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_dn.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_ft.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_lf.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_rt.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/black_up.tga": {
+     "bytes": 3116,
+     "sha256": "255d56f8ed4fa4967705155ecf47d00e8832950bb33f737551e92bdb9ca5eba4"
+    },
+    "gfx/env/moonhigh_bk.tga": {
+     "bytes": 1048620,
+     "sha256": "5f361bf5a352c1df5a6caef9cf42bd35fed8406c6949af480b0425c193c18b3a"
+    },
+    "gfx/env/moonhigh_dn.tga": {
+     "bytes": 1048620,
+     "sha256": "02e2b36863c1181a85aa675c53fc14a301f38dc6e0c6735098bb6d8723af02b3"
+    },
+    "gfx/env/moonhigh_ft.tga": {
+     "bytes": 1048620,
+     "sha256": "3158735bdd6f4f467a5b29639aa4f622d1136ea463967684b739b0002bec6526"
+    },
+    "gfx/env/moonhigh_lf.tga": {
+     "bytes": 1048620,
+     "sha256": "5cdaabd99655152689e40832643690d7b1c5f8e414f3126a7c0c9224f2250704"
+    },
+    "gfx/env/moonhigh_rt.tga": {
+     "bytes": 1048620,
+     "sha256": "e08a374ac19c8b8cffa6c939515cde9570b44bbc044c12d06b0c5d94aa7469bc"
+    },
+    "gfx/env/moonhigh_up.tga": {
+     "bytes": 1048620,
+     "sha256": "c0465fd6a0b069e5ff78f3e561084bf3e23b796cac9b5214a6cd4045310d36fe"
+    },
+    "particles/fte_weather.cfg": {
+     "bytes": 2758,
+     "sha256": "e0d383b0222f14edbd2bc04c1269206bbcdca22cdeac6840b5d831c042ff698e"
+    },
+    "particles/particlefont.tga": {
+     "bytes": 4194348,
+     "sha256": "bf90d469b3b41c2393f5ed0f58b4411cc8825f452341bbe3ba848c3cc855639e"
+    },
+    "particles/particlefont.txt": {
+     "bytes": 9872,
+     "sha256": "9e84ef35b813211196f8dfc8f89a420fd9d847ea514e43d0c3246ee666000b88"
+    },
+    "progs/ammo_battery0.mdl": {
+     "bytes": 10552,
+     "sha256": "06d4f0235faedd3430e57d602ec29a2a91c0b23bdc30debc069212264a0faf54"
+    },
+    "progs/ammo_battery1.mdl": {
+     "bytes": 10552,
+     "sha256": "0cee39ac60c3eda7b5f1d1efde52f8be19c9e4f425972f16ba6d6362d646afb6"
+    },
+    "progs/ammo_cells0.mdl": {
+     "bytes": 27228,
+     "sha256": "b6f5a07c9fd48cf27f0873320589dda1e20afe7d64cd40b6c950e5f892a34fa2"
+    },
+    "progs/ammo_cells0_edit.mdl": {
+     "bytes": 27228,
+     "sha256": "47ffc9eb8ec352ab2fa479f35ee5b6ec0e0ac8f472a06fbe00e8298e9d683ed5"
+    },
+    "progs/ammo_cells1.mdl": {
+     "bytes": 29836,
+     "sha256": "c23b4e85e9edd68fec2d751af85cff391a11848bd4338a3c59a2c055508cfce9"
+    },
+    "progs/ammo_lidlarge.mdl": {
+     "bytes": 25252,
+     "sha256": "d941a1c520e49694d66598f3430420541b318cea3e1cf02d3957e06d010681a7"
+    },
+    "progs/ammo_lidsmall.mdl": {
+     "bytes": 25252,
+     "sha256": "221b3aaa2324bea668276d3de521c4945004a71368983fc74c50c4b53425c436"
+    },
+    "progs/ammo_nails0.mdl": {
+     "bytes": 14072,
+     "sha256": "1090a9c50a943c2bf04302914f69b835ecf79fbf3013f259a12668ebd57aad5a"
+    },
+    "progs/ammo_nails1.mdl": {
+     "bytes": 15976,
+     "sha256": "8dd339507f4e18953ceefe3922d04ca513728bf2b0745813723873427843213b"
+    },
+    "progs/ammo_rockets0.mdl": {
+     "bytes": 24836,
+     "sha256": "9f272b2f1cb52fcf38983f63052db653e8208b2ee1eedf053e99dca6e439c7d8"
+    },
+    "progs/ammo_rockets1.mdl": {
+     "bytes": 27672,
+     "sha256": "46d85f10a260cf13d6711420f11a235089536a3725363be0717c2ee3e7e8a18b"
+    },
+    "progs/ammo_shells0.mdl": {
+     "bytes": 14072,
+     "sha256": "053e466f1666314cbfc0cd6f67821850ad39505a6a0bbf37c80b127e6887e5c5"
+    },
+    "progs/ammo_shells1.mdl": {
+     "bytes": 15976,
+     "sha256": "6183880b36171b6784cecf74b50aea2e1fdbc17b1b0b304a89125e964d63fd1f"
+    },
+    "progs/armour.mdl": {
+     "bytes": 76144,
+     "sha256": "b6e297062cffd435d6ce5cc17854e25a49ff09750ee1eaec6d5004266884099a"
+    },
+    "progs/artifact_airtank.mdl": {
+     "bytes": 50184,
+     "sha256": "4702b7be1baa517669edd24f5b67377f532382bfedebd77b5d77f9a499f3f08b"
+    },
+    "progs/artifact_blastbelt.mdl": {
+     "bytes": 28436,
+     "sha256": "a935de1300f6fc4f03b6fc57bf43791ac32b74d55c5509eda84339dc33f0bf48"
+    },
+    "progs/artifact_envsuit.mdl": {
+     "bytes": 260844,
+     "sha256": "09192fca32cf5b7632cf0fe9cccd9b4b1313c0e92708e85f840b0971aca5d274"
+    },
+    "progs/artifact_invis.mdl": {
+     "bytes": 7108,
+     "sha256": "f6b0b925b584402d85a623e1924c50a4fb3f3a4994cb1d2f05a169a3af2e39dc"
+    },
+    "progs/artifact_jumpboots.mdl": {
+     "bytes": 37428,
+     "sha256": "668d649addf958be26f2bcff31baf3afa5ff176a178ef15073c87cc7cb57e2b8"
+    },
+    "progs/artifact_lavashield.mdl": {
+     "bytes": 469773,
+     "sha256": "2e3027df661ca197750df97599084442afda131fbf1b545ea38d40e93afff908"
+    },
+    "progs/artifact_pent.mdl": {
+     "bytes": 21412,
+     "sha256": "7ae90fc895f23f57952dacf4d8af125f99347e09edf6f0287c7e508faad67b46"
+    },
+    "progs/artifact_piercer.mdl": {
+     "bytes": 19012,
+     "sha256": "fd73ca18d93904647df923f2d0383958386c7deb9cf27547beda74c61a9f8831"
+    },
+    "progs/artifact_quad.mdl": {
+     "bytes": 22052,
+     "sha256": "bf6d2253210784391ee1ab9b38d2b6fd661a520434bb127d293f4d202040d1b5"
+    },
+    "progs/artifact_sharp.mdl": {
+     "bytes": 49248,
+     "sha256": "505fc06618d7cecb83c03ad7d7762011ff8cff025eecf007b200d87fcc2483cf"
+    },
+    "progs/artifact_tome.mdl": {
+     "bytes": 21412,
+     "sha256": "ee8cf94e2c87ff6c0d4aa8777da2f0ddb79605bf790fb8f9ed2f49c6c1f9b9cf"
+    },
+    "progs/beam.mdl": {
+     "bytes": 26020,
+     "sha256": "bd06e42c7f0d911a4ef1077c95d474b86f62bca4da02183449687c23879e8c6d"
+    },
+    "progs/brk_pot1a.mdl": {
+     "bytes": 93352,
+     "sha256": "5612b9539e9663e06397f315968674b1de6ab50db7cdf673baadcd4652cedcd5"
+    },
+    "progs/brk_pot1aflr.mdl": {
+     "bytes": 93352,
+     "sha256": "02fd1feb7dc24b456e31f26f142aafb9adf491a16ea4caf2c4ec237e465260a5"
+    },
+    "progs/brk_pot1b.mdl": {
+     "bytes": 93352,
+     "sha256": "47c4053f0c0c941674a9d7c15a07e05c7ed648b2bf8ffbd1defb7264c151b47a"
+    },
+    "progs/brk_pot1c.mdl": {
+     "bytes": 83968,
+     "sha256": "a408707cc6793c337d0e76d86c5362de39a1f2109c23affe5def6e8194e0f4e8"
+    },
+    "progs/brk_pot1d.mdl": {
+     "bytes": 74024,
+     "sha256": "c31abc1e9e5af2cb86614f68a8be55f6192e05baba8b93479e2b2590b1e0ef1d"
+    },
+    "progs/brk_pot1part1.mdl": {
+     "bytes": 33768,
+     "sha256": "2dd32863b6006dda74b60f05a43df13e7df052ddcdb652309ba0ab29fa5352e5"
+    },
+    "progs/brk_pot1part2.mdl": {
+     "bytes": 34072,
+     "sha256": "550cae5c8893c63520c324610950eeb5b9fe842dc8ea1f07f6a217953f6e743e"
+    },
+    "progs/brk_pot1part3.mdl": {
+     "bytes": 33464,
+     "sha256": "819cf0e720637e7c5e187ccc67ae032eca217ee2f07076aefee1a8b7de894852"
+    },
+    "progs/brk_pot1part4.mdl": {
+     "bytes": 33496,
+     "sha256": "a3cc47c7f7410bb0ca2308e45144b29bc3b678600e0f288b15d8e64525585e43"
+    },
+    "progs/brk_pot2a.mdl": {
+     "bytes": 77348,
+     "sha256": "ffcf5e5f3d0b81143e2b2b387cde7b13b2d36b71345d63456f288eb036993a2b"
+    },
+    "progs/brk_pot2aflr.mdl": {
+     "bytes": 77348,
+     "sha256": "37420048a9f72abc5982f5f6813602dbc4b82ef8e788a0e309df7ff13066ea62"
+    },
+    "progs/brk_pot2b.mdl": {
+     "bytes": 77348,
+     "sha256": "40eb2c849cd06d9b985b0efc2b9d1090ec1648b0de53d0a07bd6fd5fe2af6733"
+    },
+    "progs/brk_pot2c.mdl": {
+     "bytes": 77348,
+     "sha256": "3774ade6790fc2b597c44c5206deeb3d5d3d20a23331e3fb622e1e90f833c7d4"
+    },
+    "progs/brk_pot2d.mdl": {
+     "bytes": 79004,
+     "sha256": "2af25d81ae0f1d8724f3047e95ff2f1d1700061a536b3f9ffda5522cf7e8dd13"
+    },
+    "progs/brk_pot2part1.mdl": {
+     "bytes": 34456,
+     "sha256": "13547d9ca8c36bbcc95354df03dfbdc14f19f74251ff1dc8c417436846b396bc"
+    },
+    "progs/brk_pot2part2.mdl": {
+     "bytes": 34680,
+     "sha256": "7f9824c52b01664c2dd1ccc5c1dc9e7ff2a5567dd2d0a8e9c3bf1a8bd00400e7"
+    },
+    "progs/brk_pot2part3.mdl": {
+     "bytes": 34008,
+     "sha256": "52fdc17879e0b6fb8697e1e9fffba092f1b5aa8d3cee5d657b405eb4119e8e87"
+    },
+    "progs/brk_pot2part4.mdl": {
+     "bytes": 33304,
+     "sha256": "b40cf2b029a4bfac52a80f5aef6587f3eb66e08be1fe5f40cd3f97e93133ad3b"
+    },
+    "progs/brk_vase1.mdl": {
+     "bytes": 27992,
+     "sha256": "28a8b9a0d367f17c2c265271d99b019f1762831a11ba794e2884fc7f7a8a2368"
+    },
+    "progs/brk_vase1part1.mdl": {
+     "bytes": 5524,
+     "sha256": "b8c0bef8f5d6a427f57282f086a75f39e91ad6ab035d4f1d437da97794e52f9e"
+    },
+    "progs/brk_vase1part2.mdl": {
+     "bytes": 5556,
+     "sha256": "8e1df7795140732953af83a1ef2158299a2cc393163041b6d3243478b6b644e1"
+    },
+    "progs/brk_vase1part3.mdl": {
+     "bytes": 5556,
+     "sha256": "c2e3da479defb1c3bd5130555e33dd47afc6a3b4ef7f74d4f0184cb02a02a46d"
+    },
+    "progs/brk_vase1part4.mdl": {
+     "bytes": 5524,
+     "sha256": "986c51c2cb3832f597f9dac89c6044d090b10933306814acc36a0c4ab5a04b93"
+    },
+    "progs/corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "839b70bb6be7fac8c25e6069b999e076b04bdd3dbc7a9320924713cf75c2cadb"
+    },
+    "progs/corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "cb994b390584e1776ad1f0e60d95186a0dc54cd160a2cb8284d1a15b4fe1a35d"
+    },
+    "progs/corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "b19faa9afe7cf957ae7abf6439799e5001ff42817290f4b464aa3f7ae4e3377f"
+    },
+    "progs/dance_player.mdl": {
+     "bytes": 465924,
+     "sha256": "d07f23e6a40743aeac01084a1da9670ea9a635339d86be46149e9f0ee74661e0"
+    },
+    "progs/explode_box1.mdl": {
+     "bytes": 49888,
+     "sha256": "c8a7e667c5e20735db9a816b7a11b5a1c67bf4e176d1553a79cc56bcaa9ff35b"
+    },
+    "progs/explode_box2.mdl": {
+     "bytes": 49888,
+     "sha256": "649dbfabde0a875a0c35b0109261515dc9eb287d0cc7f41ca3712283e62509c1"
+    },
+    "progs/flame.mdl": {
+     "bytes": 41668,
+     "sha256": "d6cb4dc28d5101538b44ed53fe1cf84c9d5f8547a91eb74fc6c6bdd3645ffa17"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 74548,
+     "sha256": "f03dd3b7f94a86c4d91ffb002723a16f30321a0c2189b673dd4f12f547245816"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 71268,
+     "sha256": "b1e734caec73b941b1c033fbb49ffc0f947aa8e1d47250c2d8cec0f244870fc8"
+    },
+    "progs/g_ghook.mdl": {
+     "bytes": 64684,
+     "sha256": "9cdd8bccab5f11ea7f8ea6480a4ea05c9d749bc4746cc19a6452a2e0356edfc6"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 32404,
+     "sha256": "b195b37f7e96274ea7db8e70dcf5971275bafdd0c9c10c29f2dc540c38641953"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 35876,
+     "sha256": "8ee090222c89209eec97120d5542d69a9f75b8a8aa896cd4df256d438ce83495"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 25316,
+     "sha256": "261a8479de0d5df9aea9931a62b1b93dbb7bfcff4f4467920cbebcc9c2c25381"
+    },
+    "progs/g_shadaxe.mdl": {
+     "bytes": 398968,
+     "sha256": "19d6f210a771748da589282e63a222c6c9c41a21085ed3f57f70d7f5aa20bd66"
+    },
+    "progs/g_shot1.mdl": {
+     "bytes": 24580,
+     "sha256": "72913fa948f1618347adaa91ceb98203186d2fc7bd3b9c84af00f7f637928058"
+    },
+    "progs/g_shot2.mdl": {
+     "bytes": 15876,
+     "sha256": "8ae318a3e697e4c85f60a4e5997b673e8e48f17e295551c2b0b5d0c643b3ac24"
+    },
+    "progs/g_shot3.mdl": {
+     "bytes": 156216,
+     "sha256": "8a602686e322d7357a102e0c8e91907c8b3975a8b6d36ba19f3c645e450285da"
+    },
+    "progs/g_zershot.mdl": {
+     "bytes": 68020,
+     "sha256": "3439ce2faa846bd2b3ca50e33b55092454ed83caaf8fe654d8381e107aa3520a"
+    },
+    "progs/gib_1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib_2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib_3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/gib_4.mdl": {
+     "bytes": 7468,
+     "sha256": "29f9cfa3d86121e1e349de9c3a39e620b9d6ba2cd98640536923e581f7ae28bd"
+    },
+    "progs/gib_5.mdl": {
+     "bytes": 85308,
+     "sha256": "2023ae2fd305843640266ec6679511d134e1b84ac54de245a390e483557050bd"
+    },
+    "progs/gib_blclaw1.mdl": {
+     "bytes": 32860,
+     "sha256": "303c38aea48534d4ce34f3c2082a21c7408c1e4a4cd848bc7e4acadfaaddbdc0"
+    },
+    "progs/gib_blclaw1b.mdl": {
+     "bytes": 32860,
+     "sha256": "c22db765c594ee28a0863cf70e354c651a2b9282e1df7e3a57b35ce62932920d"
+    },
+    "progs/gib_blclaw2.mdl": {
+     "bytes": 32860,
+     "sha256": "c7d70c4c067aa297fbebc3d26a2068a62f307c7f00f8d15d0bf76ed9519967c8"
+    },
+    "progs/gib_blclaw2b.mdl": {
+     "bytes": 32860,
+     "sha256": "96a96606a74eb3093d88f1f946d66caf77bd57fde0a4ec44840c95fa12130551"
+    },
+    "progs/gib_blfoot1.mdl": {
+     "bytes": 32860,
+     "sha256": "74e05efa33fc9036399a1f1d484a3816129fe0e379aee579b923cf3316e5ab84"
+    },
+    "progs/gib_blfoot1b.mdl": {
+     "bytes": 32860,
+     "sha256": "2d23324414f3f1a25ee24afe914679d07df244c9c0e48139331f084b8c369054"
+    },
+    "progs/gib_blfoot2.mdl": {
+     "bytes": 32860,
+     "sha256": "c2ce3b46d8762b042d201608271c3441b975b93e6329790ca5cba61294f71e45"
+    },
+    "progs/gib_blfoot2b.mdl": {
+     "bytes": 32860,
+     "sha256": "de945be28e0b05dc380a0a2cfff6907f14a5e4b9756385874fddd712df095bb6"
+    },
+    "progs/gib_dmclaw1.mdl": {
+     "bytes": 49248,
+     "sha256": "be5f2bb9174ce47f6d3df06685ac728c852c3a028f6aeb1632e709eb69c20ee2"
+    },
+    "progs/gib_dmclaw2.mdl": {
+     "bytes": 49248,
+     "sha256": "ff6cc88ef9123812b9d8e09235074f4c7fcad47077e6fffee334f15e3f71eb27"
+    },
+    "progs/gib_dmleg1.mdl": {
+     "bytes": 49248,
+     "sha256": "106990e4d9e2746303d09ae6c481914702af0242d8cf0fc9d430d0fa5329813c"
+    },
+    "progs/gib_dmleg2.mdl": {
+     "bytes": 49248,
+     "sha256": "8308124b7c4dca218af9e8ef7042ddcb0ca2fcb30e7f86866b1a28a73ab94db2"
+    },
+    "progs/gib_dmtail.mdl": {
+     "bytes": 49248,
+     "sha256": "6b60c464ee0e7ace54313550ac5be2f4949cc6f8dd539b38459c4a6c395e6704"
+    },
+    "progs/gib_drolearm1.mdl": {
+     "bytes": 18324,
+     "sha256": "a6b0f55da1b1d8e519b3cb9a53afe229279c760ffab3862866d8c4e7a52f267e"
+    },
+    "progs/gib_drolearm2.mdl": {
+     "bytes": 18212,
+     "sha256": "aff67984dc3198d24d2184c35748e829d7f867c38227f1fa898a1986f12ac767"
+    },
+    "progs/gib_droleleg1.mdl": {
+     "bytes": 18436,
+     "sha256": "ab69d8c271f44998ccdfd10d70ccd06caa3c2674f46e4cf94285b380d08db501"
+    },
+    "progs/gib_floyd1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/gib_freddiejunk.mdl": {
+     "bytes": 71364,
+     "sha256": "13763a8cec3b643acb9b8165f1850ffae003131c84a2ac225777822a88462498"
+    },
+    "progs/gib_gargwing1.mdl": {
+     "bytes": 92088,
+     "sha256": "3979718d2403ca7cf75aad4004a56100c1bf358f2cb9ae68595e5d69f6774f47"
+    },
+    "progs/gib_gargwing2.mdl": {
+     "bytes": 92024,
+     "sha256": "7554ef45a88db1f2e457dd7071770e42bf864123827b9819435a628b412ecb32"
+    },
+    "progs/gib_judgeboot.mdl": {
+     "bytes": 199308,
+     "sha256": "557eadb703666c4868e1b231cb1c21fbff5e59e2ec0cb8ade85cd3839fd714cb"
+    },
+    "progs/gib_judgeshould.mdl": {
+     "bytes": 199132,
+     "sha256": "69e4958866a47d5c63a6385db4843a6a5011f149b25e67720291d2db63945ed8"
+    },
+    "progs/gib_justiceboot.mdl": {
+     "bytes": 264848,
+     "sha256": "b727239a7bf232c7c6164d0f9fc0961a6c692cb0c0919b17429ade6f62bdd71c"
+    },
+    "progs/gib_justiceshould.mdl": {
+     "bytes": 264672,
+     "sha256": "2fcafb2b2a19b8ae16009e827f13fea14cb389317ec476b7f58fb2fef1163180"
+    },
+    "progs/gib_knfoot_l.mdl": {
+     "bytes": 18288,
+     "sha256": "8ffcc7ce931662f2eefa0703642b140e18a99c02252ffa3ddeb71f6ebbbe360f"
+    },
+    "progs/gib_knfoot_r.mdl": {
+     "bytes": 18288,
+     "sha256": "4d503f422ac01a8565453ba4bd8268338c3a9802480785eebd27fc0487e46753"
+    },
+    "progs/gib_metal1.mdl": {
+     "bytes": 5172,
+     "sha256": "b0951de4d869e0b779aeb3f7a96f56b22a82a58d267a56b1247f0c3e667c25ad"
+    },
+    "progs/gib_metal2.mdl": {
+     "bytes": 6292,
+     "sha256": "3df78c49abb572095d3b70efbb99bccb63caf2ffd30bb3ee434c945084acb5a0"
+    },
+    "progs/gib_metal3.mdl": {
+     "bytes": 6036,
+     "sha256": "88f8a1f941e38f8528ec27a168559946cc0b69f2abce1cbf6858b813e09c5f51"
+    },
+    "progs/gib_metal4.mdl": {
+     "bytes": 6580,
+     "sha256": "fbde734f29a6691d51c58a40a89e45f81dece2f20218353a6137a2362acbe3a9"
+    },
+    "progs/gib_minoclaw1.mdl": {
+     "bytes": 135544,
+     "sha256": "1188f73d5a6319bef5e506ca994bfcf63074a4267a5a189cb92db94160310fca"
+    },
+    "progs/gib_minoclaw2.mdl": {
+     "bytes": 135544,
+     "sha256": "511bb72c8382f4cc3cc9fa3bea4adf2390dcca1e2dcd42ef8f8287765875fa99"
+    },
+    "progs/gib_minoleg1.mdl": {
+     "bytes": 135448,
+     "sha256": "f07ce357d83d3ab0f39109d93f2f6996ded4ff19a4372fd5ddc9d9fa1a0ce8d3"
+    },
+    "progs/gib_minoleg2.mdl": {
+     "bytes": 136392,
+     "sha256": "7ba78149bc60a05ceff9090ecc2bdf013ff2d55420dfdebc553a254ac0bd08fb"
+    },
+    "progs/gib_ogfoot1.mdl": {
+     "bytes": 5956,
+     "sha256": "144e2fdfbccceee039243ef343df02ce181b666070e2d0a1825c056634f2a632"
+    },
+    "progs/gib_ogfoot2.mdl": {
+     "bytes": 5956,
+     "sha256": "9997dff0bdb2622ef6ee2530c27835fd249aee04437e70486e76255f979bec25"
+    },
+    "progs/gib_p1.mdl": {
+     "bytes": 7712,
+     "sha256": "709c49c205b27793f589eab17e8356a108345069716f9095dc07dd6447be7894"
+    },
+    "progs/gib_p2.mdl": {
+     "bytes": 21216,
+     "sha256": "50d99c7fec3b8ef01bbb19c32c88dac40a372cb6a7d39c349e0ff4909360626f"
+    },
+    "progs/gib_p3.mdl": {
+     "bytes": 18176,
+     "sha256": "d53659aa99de418793337b7e878db7bd7836883ad43528d648475589aa30d85d"
+    },
+    "progs/gib_p4.mdl": {
+     "bytes": 7468,
+     "sha256": "71ad4dcc06038f0a175605a3906b1506d0144b56b238e7df178160d9ab876b8d"
+    },
+    "progs/gib_p5.mdl": {
+     "bytes": 19756,
+     "sha256": "adf63c881ff5703b8112f714140929375b5c10be957f01cfdfa131d89af3cacf"
+    },
+    "progs/gib_s1.mdl": {
+     "bytes": 7712,
+     "sha256": "31faee0daaf399feccc1ec942ff7fe85a1a790ebd93c3b8a1fcfde9bcc06da1d"
+    },
+    "progs/gib_s2.mdl": {
+     "bytes": 21216,
+     "sha256": "c85f7dbc8eec508951893253bba5eec169a87865c995ba1d0e5c083fed9e03ca"
+    },
+    "progs/gib_s3.mdl": {
+     "bytes": 18176,
+     "sha256": "ec23effca60ef407bf294a814003213928f21f05e6da501fbe996345b6171013"
+    },
+    "progs/gib_s4.mdl": {
+     "bytes": 7468,
+     "sha256": "5001ef206e1a36cc792d7b94054b2bab4c6dfbed60e0ee0d3afd240d1af88d13"
+    },
+    "progs/gib_s5.mdl": {
+     "bytes": 19756,
+     "sha256": "9e1a112412d38c559974c628649a7773ad445ba7d24a1804c5f3fe5f50ecef7f"
+    },
+    "progs/gib_scorpclaw.mdl": {
+     "bytes": 66816,
+     "sha256": "ecaf582e92d77a1722eded2c5564d2fb9575065510ff1bc9632538345ed18329"
+    },
+    "progs/gib_scorpleg.mdl": {
+     "bytes": 66304,
+     "sha256": "399067acf8f082301f6629d2b124b0d34a7d934db55c922205a96772a85a8a1c"
+    },
+    "progs/gib_scorptail.mdl": {
+     "bytes": 66864,
+     "sha256": "0831c04d7a73c6f58329b0be0f6d371f727ea880b49e5b6e16f7cdc56c124df2"
+    },
+    "progs/gib_seekarm.mdl": {
+     "bytes": 265688,
+     "sha256": "6ee70b2f4f39d8a1fd99113c7c8df5481c421960f160afea4e622ed5b3113014"
+    },
+    "progs/gib_seekchunk.mdl": {
+     "bytes": 265420,
+     "sha256": "a70331a8e43075b026cf21d364cf2341e79e7e60c5fca4777d10aabd57ce0323"
+    },
+    "progs/gib_shclaw1.mdl": {
+     "bytes": 22964,
+     "sha256": "20b29bf40dd02dce0204c14c34b0b5806d8eef580406851d73383a631ac8f2a7"
+    },
+    "progs/gib_shclaw2.mdl": {
+     "bytes": 23060,
+     "sha256": "8dcf777d5ffd2e83edf5b6f936881eaf9d384fe8fc980721c9f5881d3e6da0c3"
+    },
+    "progs/gib_shfoot1.mdl": {
+     "bytes": 23268,
+     "sha256": "634d7cbb9e2b718167fe74112e6dd4f53cfe1cffc32f75cd80e711a24cd2f983"
+    },
+    "progs/gib_shfoot2.mdl": {
+     "bytes": 23124,
+     "sha256": "aaa2393cb65fb33a8885bfdd9b808732c0aa17f0dd461d3b04e84eb27f0fe61d"
+    },
+    "progs/gib_soldfoot1.mdl": {
+     "bytes": 51148,
+     "sha256": "09357cfed1e6c9c25e0d133d95f2c2b36693cbed1010146a982bca685cb370ed"
+    },
+    "progs/gib_soldfoot2.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/gib_spidbodyb.mdl": {
+     "bytes": 17652,
+     "sha256": "313dc78de70f02de9a49c71a1fd5ddb5ae4247f90a1a04f0ab84f44797be1946"
+    },
+    "progs/gib_spidbodyg.mdl": {
+     "bytes": 17652,
+     "sha256": "5439ca0812bc2627f22fd995237607755708f7615782785093793c11497973e5"
+    },
+    "progs/gib_spidlegb.mdl": {
+     "bytes": 18560,
+     "sha256": "66dc12710dec1bd4827497e4ed28b6a4965e1f68b48d5f0903a96ecf632e7f4e"
+    },
+    "progs/gib_spidlegg.mdl": {
+     "bytes": 18560,
+     "sha256": "3474de5b97c2b424f8ec4b8d93a1457f13adca106bdbe15234492376708810f9"
+    },
+    "progs/gib_steelbody.mdl": {
+     "bytes": 17652,
+     "sha256": "2a833de4b00f439041d27d97b3660d4df1cc9e3b454dba5ac5533e5c855e8d90"
+    },
+    "progs/gib_steelleg.mdl": {
+     "bytes": 18560,
+     "sha256": "ae926ada1c4ef7b695764f2daa0b4704102bf5eebc103b9f6a56813337f43165"
+    },
+    "progs/gib_swampleg.mdl": {
+     "bytes": 4820,
+     "sha256": "2b549fd3a74b0fd6b94c71c9e397b466e2c7f823917ffe717ce1af43769e1961"
+    },
+    "progs/gib_swamplegp.mdl": {
+     "bytes": 4820,
+     "sha256": "b5cf22240bf6474cc8ea57c40ddb70f80e792c23cb87835bee94825cb645578a"
+    },
+    "progs/gib_voreleg.mdl": {
+     "bytes": 4820,
+     "sha256": "19ec59cb3436d66a8ac9d8f40480a9c83aef879f0f1e58ddb834710e2bbc4d9d"
+    },
+    "progs/gib_vorelegp.mdl": {
+     "bytes": 4820,
+     "sha256": "341679c553a719be40022fc4a3573ff68116fee7ae05df511b9083a410af5e7f"
+    },
+    "progs/gib_wraith1.mdl": {
+     "bytes": 5300,
+     "sha256": "a0642c84b36288a3d0cef22ac32e0c681c422a034204932671729624f19d0b2b"
+    },
+    "progs/gib_wraith2.mdl": {
+     "bytes": 6292,
+     "sha256": "d20a17e624d16e4c8552ac9a291cd735aeae670effc2c9865b37fbc7bcd22220"
+    },
+    "progs/gib_wraith3.mdl": {
+     "bytes": 2516,
+     "sha256": "63f10b068c6df0a80729362c094f72d0bcf90f74de97636bc5e4a630c13e741b"
+    },
+    "progs/gib_wzarm1.mdl": {
+     "bytes": 12384,
+     "sha256": "9b6f5469bfc6ae49d2bd51fb6d35e686c4e79e5691e2fb80fa7ee556bf547e04"
+    },
+    "progs/gib_wzarm2.mdl": {
+     "bytes": 12384,
+     "sha256": "2ff539f467ca9b0f23c40cb2547221a484afbe7e07a812558ec1595e5cbd0217"
+    },
+    "progs/gib_wztail.mdl": {
+     "bytes": 12384,
+     "sha256": "fb90123980ff4510e744ea2b21509492b7ff9c131527ffe5c7b80bbbf881bf41"
+    },
+    "progs/h_boglord.mdl": {
+     "bytes": 98400,
+     "sha256": "119279b2ffdf928d34ef1470ae6c14f875cb59edc6d8b107a90bbea122c9acdc"
+    },
+    "progs/h_boglordb.mdl": {
+     "bytes": 98400,
+     "sha256": "25af0d0ea45857e64549686bb58e5f69a0754ff6e43c26ce735e58aaac3d534e"
+    },
+    "progs/h_centurion.mdl": {
+     "bytes": 63592,
+     "sha256": "2e64af530a4f5f36001ad922bb56a941738e7fe2c67c0ad0e3f06fa5854c4b08"
+    },
+    "progs/h_dcrossbow.mdl": {
+     "bytes": 25700,
+     "sha256": "0354fdb96bd5490bc18527d68813a43a41f943a05f7edca26c1aea7b943185be"
+    },
+    "progs/h_deflector.mdl": {
+     "bytes": 22232,
+     "sha256": "56de00c315543073bfda7e8a5ad3c3996f549351fa1e660e676516f4122cdeac"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 67688,
+     "sha256": "ff73d5f8fcab46a806c47377679ec5473cdc0ea93a0fda6dda8b5dba8cfa4b97"
+    },
+    "progs/h_dfury.mdl": {
+     "bytes": 14036,
+     "sha256": "3753a68126ff7caee3219c31533a1731ae9a80623c6af69315c7526f5c92669d"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 19296,
+     "sha256": "6b0867e61635543a7bb3b02647855f1384961095cd06dfc786a537b11eb926ae"
+    },
+    "progs/h_dguardq.mdl": {
+     "bytes": 4920,
+     "sha256": "337f2723daab9d1375b78cb017512ce8281087ff8df9c33b04a6c613cea3590c"
+    },
+    "progs/h_dknight.mdl": {
+     "bytes": 32144,
+     "sha256": "30af2418019b946f3582f70d2356357a97dff0391f86a9fb0abd5218cc799020"
+    },
+    "progs/h_dlord.mdl": {
+     "bytes": 18699,
+     "sha256": "bc5a92be1c5f3d06dc0238ec7bafe6a3c25826cc50edc6214ed5aa19b0075987"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 27652,
+     "sha256": "49f28b9a13867ed4a88fcac541b8a9cbabddcc594557b3490951179b3d479509"
+    },
+    "progs/h_dprince.mdl": {
+     "bytes": 19336,
+     "sha256": "77855cfc2667ed68c61d389a44ed312abc3ad1e029ea003d03e78e7131fb803c"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 14032,
+     "sha256": "bd5da6afddc520999d9c572a679c3bc8c43635ce2c73f8789603eb6a83c15aa1"
+    },
+    "progs/h_eel.mdl": {
+     "bytes": 156904,
+     "sha256": "a859ee09044d9afcd05ee2af3f1ea8c7b4ae3abc01273922dbebd5aa67b12d74"
+    },
+    "progs/h_enforcer.mdl": {
+     "bytes": 94612,
+     "sha256": "21046f6878f5f4173206debcb912d9fdee0b1f5c66d820a4355c7df8e2eb1860"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_gargoyle.mdl": {
+     "bytes": 30152,
+     "sha256": "bbcf207c44814f5e665944db03800934eab9046a0d0d86f4c982a3116f855791"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 59888,
+     "sha256": "f57daa1ab6a721a9feb696aaeeb597c720b639cd0a027a1b1da8cdd68ad1d1f0"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 30552,
+     "sha256": "edf8a4ccc52bfd9545fda8da9360e536c026079f8d2fd9756191fc934bd55683"
+    },
+    "progs/h_hogre.mdl": {
+     "bytes": 23688,
+     "sha256": "6f21e95518cd085d20b1023951ddf4d738285210bc95c6e2b3d2e82566478776"
+    },
+    "progs/h_hogreham.mdl": {
+     "bytes": 22776,
+     "sha256": "3d3e43d16c4babcbca358b44dc03ad1a212e22ea3a10ee9e639b5f4c2e95f670"
+    },
+    "progs/h_judge.mdl": {
+     "bytes": 203276,
+     "sha256": "be57ef7327fbf3ea6fb55c02bcccc4ec207b3781bb9d2e383939f3840e1ef91a"
+    },
+    "progs/h_justice.mdl": {
+     "bytes": 268816,
+     "sha256": "01d3011001c297b85a139ecb2861f188d15b96cd1ae02f08cb1604565f2d2ee3"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 42068,
+     "sha256": "aa979e22745c960cd100e814bce62018f2b992481e57838548f0ddf4816c27a8"
+    },
+    "progs/h_minotaur.mdl": {
+     "bytes": 138264,
+     "sha256": "c5e13818c813680fd29a94b408518731aa4e9007c23d004ec874f099c9ced6b1"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "4967d418f4810e9273732bbd4c690a1f9478243f7fe3807497134eb2994da0eb"
+    },
+    "progs/h_pyro.mdl": {
+     "bytes": 42912,
+     "sha256": "5359fd85e71cde1ab716d8d50a8618a347dd42b4ad4692805bf41c1903d55c18"
+    },
+    "progs/h_scorpion.mdl": {
+     "bytes": 67408,
+     "sha256": "d68d09c35c00d9bafb302fb7f3baeef90ee5d60de1ad8a7627f979c3561f5965"
+    },
+    "progs/h_seeker.mdl": {
+     "bytes": 9060,
+     "sha256": "9e9d601441532e16aee253b5e94ea9c32563f880782794d16ce496a580698bd8"
+    },
+    "progs/h_shalrath.mdl": {
+     "bytes": 78156,
+     "sha256": "f478f17ea9ee6843be2ebe3c487d0036657c94ace52a800fa44e0160d02a522d"
+    },
+    "progs/h_shambler.mdl": {
+     "bytes": 98400,
+     "sha256": "6508f7b05b65f230b7f1280d2023e9ed200663715db1709c43e7e187e3ed841c"
+    },
+    "progs/h_skullwiz.mdl": {
+     "bytes": 234304,
+     "sha256": "625c991e231d6836c36ae0c6651ec06f05541e9a7be605654fb43fba65bcc3d4"
+    },
+    "progs/h_soldier.mdl": {
+     "bytes": 166488,
+     "sha256": "0a4e322fbac8f98755adb9a4bf5ecff24d58aab30fcb1c9def3e97a0f686445e"
+    },
+    "progs/h_spiderb.mdl": {
+     "bytes": 18564,
+     "sha256": "d51c7764fccc4512db6d79ddcf03ffe42cf2817a66d6be02be0cba6551ee1206"
+    },
+    "progs/h_spiderg.mdl": {
+     "bytes": 18564,
+     "sha256": "70bec9669f3a7f3662320e32d29c38d535092db56617d5033e11669038472e2b"
+    },
+    "progs/h_steelclaw.mdl": {
+     "bytes": 18564,
+     "sha256": "be9adcdf9cf9407a729cfa9abcd692f46a55ffcf25c1878a7b2f5572fd591f8c"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "63b8a0b90691ae9a3c50a94f02943a1b94946f89402cc4e1da74c6806bd953ba"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 23516,
+     "sha256": "5a933ecbc067b8d6cbb57f71ae1614844b6e55170a206d278b3d15fe619c9cfd"
+    },
+    "progs/h_zombiek.mdl": {
+     "bytes": 4920,
+     "sha256": "9b8b3af67bdec6160ecd3880acc072b833886f7fc11d1e64ffcf06184f9ba80e"
+    },
+    "progs/health_100.mdl": {
+     "bytes": 6948,
+     "sha256": "6c6646f6081ab00ed1c309de3b697009c825d64360b06c741a533b718e0ab8d7"
+    },
+    "progs/health_100b.mdl": {
+     "bytes": 23248,
+     "sha256": "d82148af4482e3c0ff07389ebb5b09cdefda373e31105aeb7308b4126b353a97"
+    },
+    "progs/health_15.mdl": {
+     "bytes": 6788,
+     "sha256": "838b0cb6fd11ff7fdf268b1607a1999e5dce0dea11386afe5ff207e6ff734aeb"
+    },
+    "progs/health_15b.mdl": {
+     "bytes": 10948,
+     "sha256": "eb1bb584805aea34a0f0ab846a758cdc359b730e144e141dcd756da23b5831e1"
+    },
+    "progs/health_25.mdl": {
+     "bytes": 7332,
+     "sha256": "ce8260929500cac3b57617345b2c6b5a75e763afdbd10120982e7d7fa55be27a"
+    },
+    "progs/health_25b.mdl": {
+     "bytes": 23248,
+     "sha256": "7aba68839958035319b2167369f3fcd08c9d49140969cff7fb523b7023362e00"
+    },
+    "progs/health_5.mdl": {
+     "bytes": 6164,
+     "sha256": "a8ba7ece01b3cb58b2f94ca20a9f4511871d26ec894b54c04e433f29fc7c3bef"
+    },
+    "progs/key_base.mdl": {
+     "bytes": 54436,
+     "sha256": "fb25488fa2fc16c7c4df260a20fd905a821607a675fd0907a6e65f9d534fd367"
+    },
+    "progs/key_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "2632cb327c1175b351d026e88a4e456c45779a0dcdae01381b24200769c8743f"
+    },
+    "progs/key_gold.mdl": {
+     "bytes": 9332,
+     "sha256": "e93ed2c4263bf7631efcbace2c36ed6f240bfcc2b49491751f6d6ce55db8c098"
+    },
+    "progs/key_medieval.mdl": {
+     "bytes": 58532,
+     "sha256": "0810c558e40c5833c19283eb849ba80ac5dd3499e0f077b724057c51730ee097"
+    },
+    "progs/key_rune1.mdl": {
+     "bytes": 18900,
+     "sha256": "90ac269965d42da0205307eeeaddfa5b282598b5218af8650d2d8854621ca950"
+    },
+    "progs/key_rune2.mdl": {
+     "bytes": 19828,
+     "sha256": "4a6644f0b583c85aa41362fb4533cda5f8f762bd4429e5007b3ab57e5e24ae57"
+    },
+    "progs/key_rune3.mdl": {
+     "bytes": 19700,
+     "sha256": "9b33cc0feed9fc27ea647f6d127941933aa5378b52a3f75b9331714fa9d2ff31"
+    },
+    "progs/key_rune4.mdl": {
+     "bytes": 19220,
+     "sha256": "515534b8fdaa0ef99621f0f7d59d268c0c244562372e23c13e9ce05a44e0a68a"
+    },
+    "progs/key_runic.mdl": {
+     "bytes": 57444,
+     "sha256": "e0e31948c1e172c3c9117a8ccd72900c6ebd7a7e73882ae525dd116230f054e2"
+    },
+    "progs/key_silver.mdl": {
+     "bytes": 9332,
+     "sha256": "dd54032e82de32cf1b78a25f862a82a73e9dc0926d89ca7a4279b45d367a8478"
+    },
+    "progs/misc_bmkdigit.mdl": {
+     "bytes": 3328,
+     "sha256": "1a7f2f762ef3a052a91db7c74cf8d980db47a56685fc61184a15be2152e843b8"
+    },
+    "progs/misc_bmkdigit2.mdl": {
+     "bytes": 3328,
+     "sha256": "2e690ffe1af05f5ad88fe90c180785adeeffdb2b330aa34c6f4fb9885285cd1e"
+    },
+    "progs/misc_bonepile.mdl": {
+     "bytes": 110796,
+     "sha256": "0f8061359681f3c11660e472c517599590447c7631edfe5a36debd9645acdec6"
+    },
+    "progs/misc_book1c.mdl": {
+     "bytes": 40096,
+     "sha256": "92b976437673f56cb890f0e1b90a550ea00939d01ee12b0df0f218b35b42953e"
+    },
+    "progs/misc_brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/misc_braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/misc_broken.mdl": {
+     "bytes": 744,
+     "sha256": "828998b238e1c5471461edc3b9d2d7fada2beab6229272041dff13a94c1d73ec"
+    },
+    "progs/misc_cable.mdl": {
+     "bytes": 57780,
+     "sha256": "bed2cca38ef4cbefa9e645eb5e9ffadffac6ebb4f2ac5f6da4bb8f354de22a48"
+    },
+    "progs/misc_candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/misc_candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/misc_candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/misc_chain.mdl": {
+     "bytes": 231184,
+     "sha256": "845fc3117f7d9860f2d0aa4a398103a13f327516144a96db508189ae1be5788c"
+    },
+    "progs/misc_circuit.mdl": {
+     "bytes": 6964,
+     "sha256": "3337f2cfe739c22d50edde7bff18c026d4336bceb207dacf8b0284ab0a5366cf"
+    },
+    "progs/misc_corner1.mdl": {
+     "bytes": 21668,
+     "sha256": "7abf8d5ca497d5e8c8ddcc09c710c0401edb71b11f9de77a2daa81b1267e5698"
+    },
+    "progs/misc_corner2.mdl": {
+     "bytes": 21348,
+     "sha256": "369c874a37ef1da8c9a79432ba2ab9484a5be0df120131b8cbac81e1786adf47"
+    },
+    "progs/misc_deadtree.mdl": {
+     "bytes": 195728,
+     "sha256": "d267db8cfc35b01430590cec643570b38f8df5872c9c3e43df31dc0f3a954e5b"
+    },
+    "progs/misc_digit.mdl": {
+     "bytes": 3328,
+     "sha256": "60f16b89c1e9b8fb8bea0c0aeb96d2dbcfc14a719c130aaa34a581b26e653416"
+    },
+    "progs/misc_doomhelm.mdl": {
+     "bytes": 70104,
+     "sha256": "1b801d032daa163fab361a39631a16c501b86cc9e9b1a52a3f1454e50cdb8c8d"
+    },
+    "progs/misc_dpull_s.mdl": {
+     "bytes": 12900,
+     "sha256": "77fed0a028829fc7120db625131f855faf9b35f97f6ce0591e224bfae0fa78e6"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_fixture1.mdl": {
+     "bytes": 9768,
+     "sha256": "c10980d00e0479f8e65ab633f19ee62ace4c0697c2193f7aea8d266e2be5fc2d"
+    },
+    "progs/misc_flag.mdl": {
+     "bytes": 16052,
+     "sha256": "f2670312a8d16dd16e42fd02a39dfd285e6ffea624e729597b773c86140631d1"
+    },
+    "progs/misc_flame_big.mdl": {
+     "bytes": 244895,
+     "sha256": "09adba1308cdf22d2f07e226cb13a35e51f4d54866f84f41e2074dc7a40371d5"
+    },
+    "progs/misc_flame_med.mdl": {
+     "bytes": 175400,
+     "sha256": "31c94bc48e6c6d6bc31bd14b8e257c4e74d45aaec3a4d5d5bf83587a08ac7c00"
+    },
+    "progs/misc_giantbell.mdl": {
+     "bytes": 74016,
+     "sha256": "0d1b0e150de4ac59c599deae96d6b21e4ceb2300e7d410a1d802385dad99560b"
+    },
+    "progs/misc_heart.mdl": {
+     "bytes": 3512,
+     "sha256": "827ce2bbf2037aa26259901f4152d114cdf38312652e65e53f64ebbad9ea0849"
+    },
+    "progs/misc_impact.mdl": {
+     "bytes": 880,
+     "sha256": "93029307003bd0437071e0a89d0d4c2b699f2cde6ba34242c321cba8243f36b9"
+    },
+    "progs/misc_jstatue_01.mdl": {
+     "bytes": 1057632,
+     "sha256": "c583186f8bd56fd5ac356a8ed34956090eaad6e78506884bd520307e8f5e5698"
+    },
+    "progs/misc_jstatue_02.mdl": {
+     "bytes": 100260,
+     "sha256": "e4f3e702073a7f76ffddb79921a2bbb880d25edc0bdd6a6f115dfebcf99dbae2"
+    },
+    "progs/misc_jstatue_03.mdl": {
+     "bytes": 100244,
+     "sha256": "587cbce564e4da156a0ae20a87bd551046427f894f34959590573ce96fdf5c31"
+    },
+    "progs/misc_lantern.mdl": {
+     "bytes": 28836,
+     "sha256": "d84e36232543a053f2772b1070b221dc23da1b34cd08ea551a982b5e9f168ea5"
+    },
+    "progs/misc_levels.mdl": {
+     "bytes": 35732,
+     "sha256": "7cf9a4c1e556e60dd4e593cad4a2be0b45bea8893d9b5232ecc7febca4bbf5fe"
+    },
+    "progs/misc_lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/misc_lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/misc_longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/misc_madfish.mdl": {
+     "bytes": 84104,
+     "sha256": "30c19dadb42a53c7ccd35f992c5841aee13a86796157ea5e0453a4cb1586a1be"
+    },
+    "progs/misc_mooring.mdl": {
+     "bytes": 6676,
+     "sha256": "29b20cf17c62dddb4f0c1be758add7b15d6b22fd738fd9e2cd7533ac5d5475f8"
+    },
+    "progs/misc_mushroom.mdl": {
+     "bytes": 10804,
+     "sha256": "5570faa6e7828e4e12f568656226b0756a87d633cbdc461af472e0982a88a549"
+    },
+    "progs/misc_oscill.mdl": {
+     "bytes": 50660,
+     "sha256": "cdc96265a646f9e9fb4c1717fa90edb13e42130fadc4dc774b60aeb94b89eac4"
+    },
+    "progs/misc_player.mdl": {
+     "bytes": 562960,
+     "sha256": "83bbcf4cb5858aa9ac03323b461b3e3b09a28f56e212645472219d7d0b0979d8"
+    },
+    "progs/misc_plinth1.mdl": {
+     "bytes": 6196,
+     "sha256": "1ce0b7f49153f717e04436b27863c75f90a73b027c4cb7e36ce094fa037eded4"
+    },
+    "progs/misc_plinth2.mdl": {
+     "bytes": 6164,
+     "sha256": "e06edd50af1748235b251fe6e4217551c58d45c1f73161014dc0e9fd40099249"
+    },
+    "progs/misc_qwindow.mdl": {
+     "bytes": 77168,
+     "sha256": "facf489ac59158a3013118ca196f11a25a543f26559d5b72eef44968aa05008f"
+    },
+    "progs/misc_radar128.mdl": {
+     "bytes": 19492,
+     "sha256": "ef004e28e51e3227121a92432375531fca26d1e44894696f3d2a950fa65aef28"
+    },
+    "progs/misc_radar64.mdl": {
+     "bytes": 19492,
+     "sha256": "b9468012707ad484c1292cbe984c54811cb8fa43542e68e18a52ef93cb37d52a"
+    },
+    "progs/misc_radar96.mdl": {
+     "bytes": 19492,
+     "sha256": "6239d117263f49b79a2a66e62f2dbd6a7f0cd15ce412c1939dd69b4a1d8fce78"
+    },
+    "progs/misc_seaweed.mdl": {
+     "bytes": 16100,
+     "sha256": "dfbd38a439d392870c7c4c7ebea4475827b716004ca47bfa7f13b47daf07d774"
+    },
+    "progs/misc_shard.mdl": {
+     "bytes": 22388,
+     "sha256": "06c126f77ad931084d38f0e04d8f4341a5db3e3fa827e30de7d05bc60afd1c1d"
+    },
+    "progs/misc_skull.mdl": {
+     "bytes": 59892,
+     "sha256": "94600327093fe22acc113b8e89c8863a5548b170c9c9897bd2af8a4ff63beb5a"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 31792,
+     "sha256": "8d39b97460c9967ee36b33ea1ef1e92e89277fc410b44f054c5e06b8dc8a079c"
+    },
+    "progs/misc_spark.mdl": {
+     "bytes": 12672,
+     "sha256": "42afca9aeac1b05590b4821872cb79ebfbb4ee7264e914316d880e13f69c2b41"
+    },
+    "progs/misc_starfield.mdl": {
+     "bytes": 23548,
+     "sha256": "5b3563017939382680228e933a2a87d3edb030e75e65c51fe42c4a6889e42e15"
+    },
+    "progs/misc_stickskull1.mdl": {
+     "bytes": 87900,
+     "sha256": "38e63e10bc351ba5a48dfb6195ac5f78e5d61e67ae851f2ba50ba20255d7a37e"
+    },
+    "progs/misc_stickskull2.mdl": {
+     "bytes": 116364,
+     "sha256": "464fbee370b512d1c8057ea5a1dc3ecff69378474593919f0bbd8970419d69a5"
+    },
+    "progs/misc_tape.mdl": {
+     "bytes": 9240,
+     "sha256": "2b6a08ca3be4dd7a669e5b6d1585276759e1fb0edbe0691dd7ecbc7e41f0b189"
+    },
+    "progs/misc_textbook.mdl": {
+     "bytes": 74212,
+     "sha256": "e17e39efdf252a3da8c0574fdf272a800095671f42e71a17a3733673202dbfab"
+    },
+    "progs/misc_tree.mdl": {
+     "bytes": 120248,
+     "sha256": "888eca3c464ac068c7cdc5d7cf8f67fbcc70eb13c0079202a4f8d347f5f3bcd3"
+    },
+    "progs/misc_tree2.mdl": {
+     "bytes": 404432,
+     "sha256": "f14f3b046b58e5485afd11d396b4d358eb0598ea8cca1cbc6a70a8e629aee3f3"
+    },
+    "progs/misc_tutstatue.mdl": {
+     "bytes": 178480,
+     "sha256": "d178ba96d99b02113fe70d32f1672c1490d5f570aecf11d168e58f1bb7e8c17e"
+    },
+    "progs/misc_xmastree.mdl": {
+     "bytes": 479516,
+     "sha256": "59a89b398caa908ff6dd777cb42d0d7dfde930ac5569fdab4bc4f10dd8137584"
+    },
+    "progs/mon_boil.mdl": {
+     "bytes": 307068,
+     "sha256": "b8a79df258bf71f273dc29887c3782377bf890d43e32b690ebf2ef707eead6de"
+    },
+    "progs/mon_bossboglord.mdl": {
+     "bytes": 401092,
+     "sha256": "6fb5e0aa99fc9269b21e3a7c86e7ed70bf1f7e0150b629a39a4cf6647d0c9a1f"
+    },
+    "progs/mon_bosschthon.mdl": {
+     "bytes": 328244,
+     "sha256": "7fc4005959377598747d3accec535b52c81154b17b00221e2cd5410670223538"
+    },
+    "progs/mon_bosseidolon.mdl": {
+     "bytes": 1847180,
+     "sha256": "e08c763865b25851703f71e973755d5a7b446c8004f7d97c09fab04175373c10"
+    },
+    "progs/mon_bossicegolem.mdl": {
+     "bytes": 632584,
+     "sha256": "2a03c71a0451c389dc29374fa3a465fb0d8e9366309cbaeffb68057c928562ec"
+    },
+    "progs/mon_bossnour.mdl": {
+     "bytes": 200036,
+     "sha256": "732041ff70ec350c664194f90a9545b23b6736e729dd128f4482a0cca3ab7966"
+    },
+    "progs/mon_centurion.mdl": {
+     "bytes": 824572,
+     "sha256": "e638ad3021c5c77a1ad78fd798017fbb7a0ffa49ca2fc4a60570ba00e349d532"
+    },
+    "progs/mon_dcrossbow.mdl": {
+     "bytes": 1335168,
+     "sha256": "b38a7967cf800fdb45f9df9aa717ebc1c069fc8686a8e3e414f1c81d51f81d14"
+    },
+    "progs/mon_deflector.mdl": {
+     "bytes": 300016,
+     "sha256": "2bba37156abcde4ad2e7fc532a92b8139d4fc8041b565cd1e487829dc581341f"
+    },
+    "progs/mon_demon.mdl": {
+     "bytes": 156640,
+     "sha256": "9f1714fe997a78c9d3948e593a73fa3fe5704e11809ba095b8f564fca36b36c0"
+    },
+    "progs/mon_dfury.mdl": {
+     "bytes": 1495580,
+     "sha256": "0cb312b27bc1c9a7f9ac3d8c14e1e0d422d9968d4a9db0853d73185a19d6839d"
+    },
+    "progs/mon_dfury_glow.mdl": {
+     "bytes": 155140,
+     "sha256": "f743168f636c9e56475d73b3f8e139e5391e2abf0da4a6657174a7adc0f74238"
+    },
+    "progs/mon_dguard.mdl": {
+     "bytes": 724744,
+     "sha256": "1babb2976f1f86c2e499d3b8e83f4e4c04e434151bcb96a932a99a89b2bf3699"
+    },
+    "progs/mon_dguardq.mdl": {
+     "bytes": 176648,
+     "sha256": "f2f92ef84411d83c7e8c158f62b1415d8fc6aa56d77f21760dcd3080424cf6c8"
+    },
+    "progs/mon_dknight.mdl": {
+     "bytes": 1124632,
+     "sha256": "437c54ecfed53e34891b981a565c9b4f772c19702e1c099bba5ac40aabbed917"
+    },
+    "progs/mon_dknight_glow.mdl": {
+     "bytes": 971020,
+     "sha256": "22888d6171fc8df336fe686f4ffdfb0683bdb744e59cf81af9484b700666f6cf"
+    },
+    "progs/mon_dlord.mdl": {
+     "bytes": 1142583,
+     "sha256": "fb2ce7f5fbe369307f3eaefe0a74fffb2004657bec058dae50db651bc2fbc70f"
+    },
+    "progs/mon_dog.mdl": {
+     "bytes": 460652,
+     "sha256": "52cf8cb501f4b1ed457961b798eccd86974720af29f559723be82a0886824fd9"
+    },
+    "progs/mon_dprince.mdl": {
+     "bytes": 1022224,
+     "sha256": "aadd9ea12f307f0ef2b600a4a78d73082b8ea2eadd408f1fbe298082f4d03374"
+    },
+    "progs/mon_drole.mdl": {
+     "bytes": 241648,
+     "sha256": "2d5524d75cd52f12b42a5dfdd37bb33af27233394ec60bc234f79545d1cf13b4"
+    },
+    "progs/mon_dsergeant.mdl": {
+     "bytes": 1431784,
+     "sha256": "1affce6e3cbae9b5df1986672030fd869aa020972872767518f18ccc495c7432"
+    },
+    "progs/mon_eel.mdl": {
+     "bytes": 177368,
+     "sha256": "6acb4804e51e7de33404a4519d7f12b2413c921f61e33107345cb111ff156f96"
+    },
+    "progs/mon_enforcer.mdl": {
+     "bytes": 622480,
+     "sha256": "0e32f70f205a74995936d56e22259d1ccde591ed8a533577cd276419c5f60013"
+    },
+    "progs/mon_fish.mdl": {
+     "bytes": 311132,
+     "sha256": "40351e57dec8fad0aa34e5e5da233274e007a3beb80a291c9a2aa40ed43f8f00"
+    },
+    "progs/mon_floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/mon_freddie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/mon_fumigator.mdl": {
+     "bytes": 415072,
+     "sha256": "31bb90976e7489693c68fd6713ed5f1baf9645e3d7871922901dd093e8243da3"
+    },
+    "progs/mon_gargoyle.mdl": {
+     "bytes": 388132,
+     "sha256": "fe8134f2305858519445eb513b22f1f3382a1a6f334cf9549ddf1efe0b88435c"
+    },
+    "progs/mon_gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/mon_gaunt_elec.mdl": {
+     "bytes": 7164,
+     "sha256": "05129692bea7b62f2f5b7285cf133590e9356bfa0f6162ef6e3fc44508b29d8b"
+    },
+    "progs/mon_golem.mdl": {
+     "bytes": 632584,
+     "sha256": "c345c57eca380796f5dbcbdf7df80975c24e856d6d70ed1e9c11678f5d162c44"
+    },
+    "progs/mon_hknight.mdl": {
+     "bytes": 275836,
+     "sha256": "e32a90ca707224a389b7b0d3ecde76220e23f7746c2bc4e6397fe0d3a601844a"
+    },
+    "progs/mon_hknight_glow.mdl": {
+     "bytes": 212112,
+     "sha256": "60c24cb1dceeda2c64efb66e03cb8337717402c8070c0a19e1d9a6b5e0363d89"
+    },
+    "progs/mon_hogre.mdl": {
+     "bytes": 897896,
+     "sha256": "f8e0d054c44cf83bde03ee51ca8eb558dad7da336be8caf1383cf51d5b813da9"
+    },
+    "progs/mon_hogreham.mdl": {
+     "bytes": 979960,
+     "sha256": "d4ffb64b6112d48696002baf1bf8df0c686f404d1523ae409a9d01d237573e90"
+    },
+    "progs/mon_hogremac.mdl": {
+     "bytes": 901388,
+     "sha256": "daeed66878bbe85c45d2415de4270a8526be175ac74734ff55cf9750bf7c4875"
+    },
+    "progs/mon_jim.mdl": {
+     "bytes": 331872,
+     "sha256": "a49a51562fc5875509e39b62de550c4cebba65569708e1f63d0a54a6b8497448"
+    },
+    "progs/mon_jimrock.mdl": {
+     "bytes": 357748,
+     "sha256": "6c7e4a4f9b1b4392cf6e465be50e0a637a2a9b9b44b41e97a62acfc7b889f662"
+    },
+    "progs/mon_judge.mdl": {
+     "bytes": 1184920,
+     "sha256": "4e281291b8b6728bc6801c775defa987698a0f402a3a5553a32cf61865857040"
+    },
+    "progs/mon_justice.mdl": {
+     "bytes": 1287408,
+     "sha256": "bdd6b6ad28da26701dcef14503d148e96251575e04f583bef1f362455ab12497"
+    },
+    "progs/mon_knight.mdl": {
+     "bytes": 474244,
+     "sha256": "b279d87d180d237a71beddad02ecfaa87be42c990b91ee823f15f905fbb19b55"
+    },
+    "progs/mon_lostsoul.mdl": {
+     "bytes": 172216,
+     "sha256": "51c6d042ac9c670926d11743a09b294cbc992204077eae28b7b440570a7b0b4c"
+    },
+    "progs/mon_minotaur.mdl": {
+     "bytes": 669648,
+     "sha256": "3016ee951f60eb90a659c641546bc6aee80b1e2e9500b125c9c1343d625deb54"
+    },
+    "progs/mon_ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "ca0b6aee92201fa3ebeb226e7767c7a0f29495496d86bd384c327ff897b3557b"
+    },
+    "progs/mon_ogrefish.mdl": {
+     "bytes": 560428,
+     "sha256": "25edf562fbf71533ae0102832d92b7e138d056e1f90c9c681e5387659cd3160e"
+    },
+    "progs/mon_pyro.mdl": {
+     "bytes": 415072,
+     "sha256": "11a7efe7358b1477867a1263fd6e13a8531f557d1a8d0e0bfc5a1e9e6eab273a"
+    },
+    "progs/mon_scorpion.mdl": {
+     "bytes": 338288,
+     "sha256": "5d8a1b194cfc741b8dd194694dce305c35b0dca0bdf1c8d96897a085ad0eaf85"
+    },
+    "progs/mon_seeker.mdl": {
+     "bytes": 594628,
+     "sha256": "ab23bfb0c8b22c67b8d4b7b1658b445fb546fcc4f1ddb1f5c4990eb860434f3a"
+    },
+    "progs/mon_seeker_glow.mdl": {
+     "bytes": 594628,
+     "sha256": "122441a3be654d0198ba368ff9fd24d7f3fecb71fbafad6edfe80e3f57103ca8"
+    },
+    "progs/mon_sentinel.mdl": {
+     "bytes": 290664,
+     "sha256": "573efd78767922b2bbb3e5dab2b16cd8f90c2cb1709ecf4a315a141f4df77d09"
+    },
+    "progs/mon_shalrath.mdl": {
+     "bytes": 163336,
+     "sha256": "50b11e859246abf75af63b858d00b436690c9ed02562c0a7a3f434ed350c3a79"
+    },
+    "progs/mon_shambler.mdl": {
+     "bytes": 401092,
+     "sha256": "8f29b2ceddebcb9e69adbf12eb36c3924468cfaa1ff54cea31e6f289ab30e54a"
+    },
+    "progs/mon_skullwiz.mdl": {
+     "bytes": 980064,
+     "sha256": "c7637f2310ae9f173de872ea4aaf4380332f3d8d32782a8523f1d5d0a5ee3e45"
+    },
+    "progs/mon_soldier.mdl": {
+     "bytes": 931376,
+     "sha256": "8a67babdf47ecc69739e067d18b2629814469aec923851bd6c1133feae6ac56b"
+    },
+    "progs/mon_spiderb.mdl": {
+     "bytes": 228508,
+     "sha256": "209ee4dabf0f9b5619408cedcd8eaec7f8d4e48a8e1b51ca667bf5f8fea02dd6"
+    },
+    "progs/mon_spiderg.mdl": {
+     "bytes": 228508,
+     "sha256": "ffac4cf5b2d42df5b8a9674dc87c30ec925d6013d9ff0d29cb109c30047bcbd6"
+    },
+    "progs/mon_steelclaw.mdl": {
+     "bytes": 228508,
+     "sha256": "06fae126b984b1ed7b0ffa029b64e9b3df3a6269f01e8aba4b953bbafaa2c536"
+    },
+    "progs/mon_stinger.mdl": {
+     "bytes": 203428,
+     "sha256": "9d867b8a3d69a94d9a049c6cfcf0fa808b200ea3befe3b2518f1165881b9ad23"
+    },
+    "progs/mon_swampling.mdl": {
+     "bytes": 45332,
+     "sha256": "c7b379fcc17af3fbfaff1976ea8c14e9562093495dac01cd647c50863c4dec50"
+    },
+    "progs/mon_swamplingp.mdl": {
+     "bytes": 45332,
+     "sha256": "f1bd1496b4b9c90493f469bf81c6da0a1697290cd6374db15fd459ebab649cea"
+    },
+    "progs/mon_tarbaby.mdl": {
+     "bytes": 511008,
+     "sha256": "a9b9b6a49090bbf7d7d3a23618c3c21b2123e007488702d96b80531c563cdd4c"
+    },
+    "progs/mon_voreling.mdl": {
+     "bytes": 45332,
+     "sha256": "af233d21d6f0ea66267ba1c562ba223e1077bd07894333327ce12a6202938411"
+    },
+    "progs/mon_vorelingp.mdl": {
+     "bytes": 45332,
+     "sha256": "dadf32a61ef1ec6361606fc7173bab53f6c42e62dea9a3100a2073ffc5afaa58"
+    },
+    "progs/mon_wizard.mdl": {
+     "bytes": 106596,
+     "sha256": "aa93bbe4e7fd1686fcea4d6c49a982bb8b3defea2ca85c3177b86000ba8ba8e4"
+    },
+    "progs/mon_wraith.mdl": {
+     "bytes": 374256,
+     "sha256": "f2ec454f0e2896252204a99b18c16a5e61ae783220503a6b0ec75e149d1b25f7"
+    },
+    "progs/mon_wraith_glow.mdl": {
+     "bytes": 133676,
+     "sha256": "bc630a16b46ae0ef1fba35acaf4e41bc46dee4070305d32e9215692a18ae5705"
+    },
+    "progs/mon_youngone.mdl": {
+     "bytes": 103208,
+     "sha256": "de6f7f98d021ae2839cc81490886e6f29dfa31b5b45216d15ffb7f74edf1eb36"
+    },
+    "progs/mon_zombie.mdl": {
+     "bytes": 381660,
+     "sha256": "2dfc9832316861cff07f1c86da0f8809de95395a9dac718155bdbd06f739acaf"
+    },
+    "progs/mon_zombiek.mdl": {
+     "bytes": 228232,
+     "sha256": "431f57d3241b1253a1346ff1aa2bd7135f67c3e6fd5031140e07a7b4a0e861a2"
+    },
+    "progs/player.mdl": {
+     "bytes": 976432,
+     "sha256": "137eab1a3853f9a6f7f84c05442f7066268cac430bf73053cc7f806555a98925"
+    },
+    "progs/proj_balllava.mdl": {
+     "bytes": 18356,
+     "sha256": "f2a1de49bd215b4c7a1f424f1c644fe5cdb52df3c2d664c24b75cd2f389ae559"
+    },
+    "progs/proj_ballslime.mdl": {
+     "bytes": 18356,
+     "sha256": "d17f20cd8db385b724d58beaac1c3ed6b2597d51d00f1996b8b02bdb8a5e3ba1"
+    },
+    "progs/proj_blord1b.mdl": {
+     "bytes": 11472,
+     "sha256": "6c05b0f8790b77d3362166b2b304379942f56d498ae8fc365dbee6fcd6031f67"
+    },
+    "progs/proj_blord1s.mdl": {
+     "bytes": 8284,
+     "sha256": "5527dd12f00911fb333c2424994c0a95881caa72612d5e8236c8ce75530f6ae0"
+    },
+    "progs/proj_blord2b.mdl": {
+     "bytes": 11472,
+     "sha256": "fce6943e84bac672bf110d986ce2ed1ccb511128cb28508fb6aca53c7655806b"
+    },
+    "progs/proj_blord2s.mdl": {
+     "bytes": 8284,
+     "sha256": "a0d0ac315e46f784c35a0eac902f625e0337e79275b9f02ecb56002848202734"
+    },
+    "progs/proj_blordbeam1.mdl": {
+     "bytes": 12244,
+     "sha256": "e01c569bf66e75acdcbbfdbb50062eb24dd09f0415e6cb79148eab960f6a6f0f"
+    },
+    "progs/proj_blordbeam2.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/proj_blordbolt1.mdl": {
+     "bytes": 7868,
+     "sha256": "2ea0a49a8a75d1174151c36851ae21212b4df2df3473be5e73cc4cf293332d0f"
+    },
+    "progs/proj_blordbolt2.mdl": {
+     "bytes": 7868,
+     "sha256": "919dda70fe618cd37f57ef1e0dbc00b339ed082e2661ca024febee3ed49576f2"
+    },
+    "progs/proj_bolt1.mdl": {
+     "bytes": 1556,
+     "sha256": "890f6cd6faf7c36954185c4566a2cca619e627d5b365f05e1bffc7e12ac00ace"
+    },
+    "progs/proj_bolt2.mdl": {
+     "bytes": 1748,
+     "sha256": "ba4a6ffa3785b0e41c15045df9621a5a33f094eae2161064d472ea939654e229"
+    },
+    "progs/proj_bolt3.mdl": {
+     "bytes": 1748,
+     "sha256": "cf255497525c53162b019fe3df536314c4661a2d270f6bb847fe39a158b7f4e8"
+    },
+    "progs/proj_chthon1.mdl": {
+     "bytes": 65636,
+     "sha256": "92a964527d72ef1c40bbcfe0e915b56df81a0dcc2165ca4be47db44a8d644eb1"
+    },
+    "progs/proj_dguardq.mdl": {
+     "bytes": 12660,
+     "sha256": "ba5cba46edc108572d78e66166f5ed0405a48dcf672e7a569d14a4397f85f285"
+    },
+    "progs/proj_diam1.mdl": {
+     "bytes": 3292,
+     "sha256": "e7cbd736a84791c5234caa14713b3e0f6077409509845ae0b1993f38c2f1e1b9"
+    },
+    "progs/proj_diam2.mdl": {
+     "bytes": 2748,
+     "sha256": "b23586b1d570a9f516f6b83ea0af6ec1d8fe5693f8cd1279b251b031ba142d8c"
+    },
+    "progs/proj_dk.mdl": {
+     "bytes": 5172,
+     "sha256": "e861a125a60c82b88c7b3c23184a1485c967d0e127b4536213b7f46a97a6430e"
+    },
+    "progs/proj_dkgrn.mdl": {
+     "bytes": 5172,
+     "sha256": "820d2dac7255db7220889f6d8c3a2c97a7f77f75cd9ffbec6319b0ee257b3984"
+    },
+    "progs/proj_dlord1.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_dprince1b.mdl": {
+     "bytes": 6644,
+     "sha256": "7bcea6065d9f6c4e8a3a7c8a1dcd61252ff8baee01b7c04ecce0a7cfbc6d690d"
+    },
+    "progs/proj_dprince1r.mdl": {
+     "bytes": 6644,
+     "sha256": "5e3cc794f6b980e5e22adf011eead8768c88dcd84d74be9a8d34caebf33bf2ba"
+    },
+    "progs/proj_dprince2b.mdl": {
+     "bytes": 7468,
+     "sha256": "e81b4f767d1bba042464f1d35314ef4f2d30f7c552aaada2f772aba61fc5d62a"
+    },
+    "progs/proj_dprince2r.mdl": {
+     "bytes": 7468,
+     "sha256": "b967299e12983dacd0fcca1672818281483e6f89746422de285002cb043e1e24"
+    },
+    "progs/proj_drole.mdl": {
+     "bytes": 20796,
+     "sha256": "fbe9acdd31f7be2321df29b6add3d287d4e86ea2581e56ace5d7e9d185e28127"
+    },
+    "progs/proj_drolegrn.mdl": {
+     "bytes": 20796,
+     "sha256": "efbede1f5d565c56a535bb6392b5e638133c99b1df8bf93b1a1918d01c790123"
+    },
+    "progs/proj_eidolonrock1.mdl": {
+     "bytes": 14084,
+     "sha256": "e085fa791a83489e41c19c623ae84f80c7bc5f767cbbf691baa4665d3f85b273"
+    },
+    "progs/proj_flesh.mdl": {
+     "bytes": 19768,
+     "sha256": "8ff3f0f61001ac8e67317e4e01d03d905f15ef4104c141ba07b5ddb0c972390e"
+    },
+    "progs/proj_fleshp.mdl": {
+     "bytes": 10196,
+     "sha256": "3def912801c4b1b9b4c0f8ceea0690241493a5dd5f17e098cd6c37cefd927893"
+    },
+    "progs/proj_fury1.mdl": {
+     "bytes": 6644,
+     "sha256": "ce55af61fbd87b8daeb14151b3f77ac64713c4b53fcca89b2150d7f5cdfe886d"
+    },
+    "progs/proj_fury2.mdl": {
+     "bytes": 5748,
+     "sha256": "deb557248017e92f5501698355577cebb91c0d825b77a79f828589769a41ece7"
+    },
+    "progs/proj_gaplasma.mdl": {
+     "bytes": 2328,
+     "sha256": "dd3b4559cb4e4439ae87255ab2958c6c2cd3796ebbd27aaf1c6abc768ad4f8ad"
+    },
+    "progs/proj_gaplasmagrn.mdl": {
+     "bytes": 2328,
+     "sha256": "ecd2fdf0eb904f8be43c41821b06443d32a581b768ce8f776b07670b49cdd9af"
+    },
+    "progs/proj_gargball.mdl": {
+     "bytes": 18184,
+     "sha256": "b4b6bd7646bf80aa6f481616ba2b531dbccd3568cacc54885ebf020a166dbadd"
+    },
+    "progs/proj_gargballgrn.mdl": {
+     "bytes": 18184,
+     "sha256": "467a44838d83a94d5716c9af6f8c860cd8ec583ddb5f260cb0dd16e9bd04b957"
+    },
+    "progs/proj_gargoyle.mdl": {
+     "bytes": 5748,
+     "sha256": "774f52126fe6598f6a01a032691a36de26a0669e93d47508689d08fe85f46c21"
+    },
+    "progs/proj_gargoylegrn.mdl": {
+     "bytes": 5748,
+     "sha256": "b293b5e8696098e77602eb065f68f8a8e15c82af1c9890d36de48f29afbf43fe"
+    },
+    "progs/proj_ghook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/proj_golemrock1.mdl": {
+     "bytes": 7468,
+     "sha256": "5a2f0435dbcbfea724fe6bd8f6a76296359dbf4d874d15feec82b50a9275da74"
+    },
+    "progs/proj_golemrock2.mdl": {
+     "bytes": 19756,
+     "sha256": "41cc9bc49d6ae2018b7cf5345bbfe52517db2da060fce23fe57300ebcf643f98"
+    },
+    "progs/proj_golemshard.mdl": {
+     "bytes": 8596,
+     "sha256": "4a4a59362f5c5ecc2c4ce56419088982d5ed79a02d3c5b5a49bafd4c21c85e42"
+    },
+    "progs/proj_grenade.mdl": {
+     "bytes": 3508,
+     "sha256": "a7916ab1f9872689a0cfbea62543974b37dae5b3ec7ae3165eecd81c2c0d6617"
+    },
+    "progs/proj_grenadegrn.mdl": {
+     "bytes": 3508,
+     "sha256": "896f7a740acb59351891e752e6cc92725fcc6e26ea4bd5d1eb3219c8443db743"
+    },
+    "progs/proj_judger.mdl": {
+     "bytes": 7868,
+     "sha256": "a12f1f0bf494bc027c43e5aa89e54e055a571226499fbddce0f6b9e2bdb63766"
+    },
+    "progs/proj_laz.mdl": {
+     "bytes": 4724,
+     "sha256": "94e8c7d09857559ad9e5aaf6361b596afbcf100cf0ce8abf0107318af28c7943"
+    },
+    "progs/proj_lazblue.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/proj_lazgrn.mdl": {
+     "bytes": 4724,
+     "sha256": "d07d736b788aa512a5e57f39596c187644e69491026382800994378d3e849a6f"
+    },
+    "progs/proj_lightning2.mdl": {
+     "bytes": 11860,
+     "sha256": "c9cebc8d6f4836e7c302d51d0f942fde3da0960dae38733ccc3a851776e71520"
+    },
+    "progs/proj_minoball.mdl": {
+     "bytes": 18184,
+     "sha256": "756d8e9ecd60abc23954a792833c565ee1b5c905106ad2bd98143f56b0410391"
+    },
+    "progs/proj_minoblood.mdl": {
+     "bytes": 8284,
+     "sha256": "badd72734b86dd9bc11c5469bef944b6aea6b84071b07b44703c1ca62dd4dee2"
+    },
+    "progs/proj_minoplasma.mdl": {
+     "bytes": 8284,
+     "sha256": "cd79d0dce08293ded22b08b3a7134d8e52fc4cff10e07ee691e6ab53011a9ea9"
+    },
+    "progs/proj_minopoison.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_ng.mdl": {
+     "bytes": 1364,
+     "sha256": "cff312dd07f629847dd5e37b6ab00243d51ff7e40fc795f3612e68614cfbbe24"
+    },
+    "progs/proj_ngred.mdl": {
+     "bytes": 1364,
+     "sha256": "a1ec22733cc292a470c23990b8d0929bf5ee88844190d7174d9053109443d0dd"
+    },
+    "progs/proj_nour1.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_nour2b.mdl": {
+     "bytes": 14084,
+     "sha256": "9c7650dba595e8f8b2bacf3141252a5a2917e0204d3326661d6b9608fc8df2b3"
+    },
+    "progs/proj_nour2p.mdl": {
+     "bytes": 13152,
+     "sha256": "4051fc3dec1155a9efbc6bc5aab947447cebff83bec38d8c1e43dd1bd51f4611"
+    },
+    "progs/proj_nour2s.mdl": {
+     "bytes": 7468,
+     "sha256": "285570bdd658dfed133399c16f1586e2b2389f537a9d4b54d2dd5c1f8f6f1aa9"
+    },
+    "progs/proj_pgplasma.mdl": {
+     "bytes": 13152,
+     "sha256": "3c04f32bbf6f0623fc4101a31a0ce2d40c93354430433d91c2caed263284531e"
+    },
+    "progs/proj_plasma.mdl": {
+     "bytes": 4724,
+     "sha256": "6c4399ddc7653a9aa7834162d38dce6368dc271fec46a7830b73939351d7142a"
+    },
+    "progs/proj_plasmagrn.mdl": {
+     "bytes": 4724,
+     "sha256": "b2941e69d90a5e97c98a03a98bd52c4e047aa23dd2a1abd9ab6d3938f595732f"
+    },
+    "progs/proj_ringblast.mdl": {
+     "bytes": 135704,
+     "sha256": "e6de9bfd15db4bbf16fdd41b50204c5090ce09adbe132b1453435d3c8646cb4d"
+    },
+    "progs/proj_ringshock.mdl": {
+     "bytes": 18928,
+     "sha256": "f1a0a77edc79f2466b866a5486b29f92b696368137eb7eff9b137b6b66d65952"
+    },
+    "progs/proj_rocket.mdl": {
+     "bytes": 7812,
+     "sha256": "52d549b217c6f34e1d68248899ec5f5f550ef729929910e5953e114a53b3c251"
+    },
+    "progs/proj_rocketgrn.mdl": {
+     "bytes": 7812,
+     "sha256": "313f381553df0d8468ccb981441bf415130c9c730377d877e397511b8cc864f7"
+    },
+    "progs/proj_scorpion.mdl": {
+     "bytes": 6612,
+     "sha256": "1a2fa47a30a7e8026bacefa1f52580a04e10c48571318effab3e0623ebcc919e"
+    },
+    "progs/proj_serg.mdl": {
+     "bytes": 6644,
+     "sha256": "321f89f29584d1302d4053ded1a02cb2566364158f4e78bfb45db9e71f22df40"
+    },
+    "progs/proj_shal.mdl": {
+     "bytes": 6644,
+     "sha256": "dc62e9641d1328b1cfd20ac4f4df7e56b2f42bd40a22eea186f2784d1f5bc4ba"
+    },
+    "progs/proj_shalball.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalegg.mdl": {
+     "bytes": 9984,
+     "sha256": "a7a4d6daf06489f82c76a0d9f0a0e5d5e85f577fbf46117e00b05e0d463815d9"
+    },
+    "progs/proj_shalgrn.mdl": {
+     "bytes": 6644,
+     "sha256": "6dfdef0a204aded86ef24730985f13acc5076d1bbb4b9ec1140b7333a70f4d0e"
+    },
+    "progs/proj_shalhome.mdl": {
+     "bytes": 8632,
+     "sha256": "e882b1dc5d01882f429b3a88f752431d3b38dad297861209b589330e3507f37e"
+    },
+    "progs/proj_shalhomegrn.mdl": {
+     "bytes": 8632,
+     "sha256": "d84be851bd87603186bf907506eabb9ce110c5a265c1cc884d18923361fdf4d9"
+    },
+    "progs/proj_shalshell.mdl": {
+     "bytes": 7468,
+     "sha256": "8c1591cc767fadabad655bfaf3a80362b264f51e0a1be67476b9272c2401afbd"
+    },
+    "progs/proj_shamlit.mdl": {
+     "bytes": 35240,
+     "sha256": "787c23ca986d469080879953e49b193cf0b2d22dff050a1d781ba039fcc594e4"
+    },
+    "progs/proj_shellcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/proj_shub1.mdl": {
+     "bytes": 18932,
+     "sha256": "c1a04846b791a123ecb367f11b35f4c1cc1e7e62e1d0f62ff1dd75978a712495"
+    },
+    "progs/proj_shub2.mdl": {
+     "bytes": 32860,
+     "sha256": "3d22df8151caf23c1ad7f3e28f83f97ca7503164977f1994dca2cc2ee54f84b9"
+    },
+    "progs/proj_skullball.mdl": {
+     "bytes": 9984,
+     "sha256": "41b3c1225070dcfca79f1bf19a2833e3d68144945fba51c8ce44d8029379906b"
+    },
+    "progs/proj_skullwiz.mdl": {
+     "bytes": 33588,
+     "sha256": "ff00ce3fbf9d0d55f6488a3a0a6bf15d2105b6e94489eec296a5851bf9f4f890"
+    },
+    "progs/proj_skullwizp.mdl": {
+     "bytes": 33588,
+     "sha256": "45fe8396037d88852d3e6937749bade4ef7c00d3c8240eeb0ecba4b56e831df3"
+    },
+    "progs/proj_smoke.mdl": {
+     "bytes": 244,
+     "sha256": "816e888f8242af86812bd581c9e93212c28f108699b70eb10d3e025f27a2818e"
+    },
+    "progs/proj_sng.mdl": {
+     "bytes": 1396,
+     "sha256": "b2a8656aee7ff508737afe1fdbf1a93d6958b33a0c31bae247a3979c616bdfe1"
+    },
+    "progs/proj_spider.mdl": {
+     "bytes": 7468,
+     "sha256": "76be6023b50a3b57c73f08c5758a693098ce8762eb92b55540d8bff2680fde4d"
+    },
+    "progs/proj_swampling.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_voreling.mdl": {
+     "bytes": 7468,
+     "sha256": "ab16a7fc8bf36827f4944ebe6919876acb5b2eaf869ff59f89ed237565a7ca9a"
+    },
+    "progs/proj_wiz.mdl": {
+     "bytes": 5748,
+     "sha256": "3798e9cc0558342d29484fa336c3577e92a1a2ac0a8ce1eecc20ba4479ea0d7b"
+    },
+    "progs/proj_wraithball.mdl": {
+     "bytes": 22284,
+     "sha256": "24d62690c6347f9ab71ef5900c70d256346c2dfdc26e5488c3b91f220224c923"
+    },
+    "progs/proj_wraithbone.mdl": {
+     "bytes": 6612,
+     "sha256": "8fa994dd2c7a5e9d7140ae394d07d368d083f4cee6808f6d9d026ec464804503"
+    },
+    "progs/proj_wraithegg.mdl": {
+     "bytes": 9984,
+     "sha256": "5b888e26f90cfe26800cd50d422b4ef75487dde61d63fd34965506591b326a8f"
+    },
+    "progs/proj_wraithpoison.mdl": {
+     "bytes": 6612,
+     "sha256": "02a06fdccb8f7ba595ea71f227e5b256995e782bcc9ce75bcb85a31ed0333256"
+    },
+    "progs/proj_wraithshell.mdl": {
+     "bytes": 7468,
+     "sha256": "99ac7959a5f931d9ce5f611088eb0fbcbdd0c6f083bd4c56c9d0aab3f4c64bb2"
+    },
+    "progs/proj_wraithtrail.mdl": {
+     "bytes": 24544,
+     "sha256": "23ee065ea4a542ee7348d9bc08e052ffca4e272418b81937105d14730aab705e"
+    },
+    "progs/s_bookrune1.spr": {
+     "bytes": 1140,
+     "sha256": "b9fc52d2ca728fffa4c282d818b68aeec3555a0dbad3cd1507199d534db1f047"
+    },
+    "progs/s_bookrune2.spr": {
+     "bytes": 1140,
+     "sha256": "400a620928e3581891e8a71b338c8a53b6387e0acdc3fda3f10ae27596ae6bbc"
+    },
+    "progs/s_bubble_blue1.spr": {
+     "bytes": 1140,
+     "sha256": "27cb0d1f52e3ecd4b7ae0d9dc96078a7554bde09839f1a2ee2d9772ac5d67981"
+    },
+    "progs/s_bubble_blue2.spr": {
+     "bytes": 1140,
+     "sha256": "d540bb04a7835ec3bd7490904fbafde0f3aa64ba559bb6bd99ab538568ec0cae"
+    },
+    "progs/s_bubble_brnd1.spr": {
+     "bytes": 1140,
+     "sha256": "43591346d87a547454b387220b3c32693e7f1563b6ae4152ff7ee96c24936b84"
+    },
+    "progs/s_bubble_brnd2.spr": {
+     "bytes": 1140,
+     "sha256": "2f185b37bd1cd5a8d6b472885469dbdb3f1b0fdeba2a6d620de09b17646b4fc2"
+    },
+    "progs/s_bubble_brnl1.spr": {
+     "bytes": 1140,
+     "sha256": "370ed3a9f77291522c31ac1d0ce414078d9b3eb40a9157c08ad5cf87d6428897"
+    },
+    "progs/s_bubble_brnl2.spr": {
+     "bytes": 1140,
+     "sha256": "1b3d4f0ac00fa7cbce076d334f4b210b9059afbf2c4b07a0e98e88fe57356351"
+    },
+    "progs/s_bubble_grey.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_grn1.spr": {
+     "bytes": 1140,
+     "sha256": "efa8692bb74428af2753b415f8f08edbfc2b2cbe75cc59f6545985d289d6016f"
+    },
+    "progs/s_bubble_grn2.spr": {
+     "bytes": 1140,
+     "sha256": "3062ba1064da37ecf7dad074a9b0437352865fa43aecf783e4afe8a6c8c104c2"
+    },
+    "progs/s_bubble_pinkyel.spr": {
+     "bytes": 312,
+     "sha256": "5376726ffdf2132d3ab712ba23b408e8068500485f11adff85d0fd90c08248c6"
+    },
+    "progs/s_bubble_purp1.spr": {
+     "bytes": 1140,
+     "sha256": "2e4b7b23b08b6e89d2dc46f26b12b9ad1ee8f91ea868aeb9916d2adb42e00b75"
+    },
+    "progs/s_bubble_purp2.spr": {
+     "bytes": 1140,
+     "sha256": "ae21a26ad7897b9c5d201a1eb248e1358ee84eafdbfd899d679558e9aa5a1a66"
+    },
+    "progs/s_bubble_red1.spr": {
+     "bytes": 1140,
+     "sha256": "2a52f2c4dfdae381deeca608e5d007afe9dc245bbe16fea88c88f39c10ff7dc6"
+    },
+    "progs/s_bubble_red2.spr": {
+     "bytes": 1140,
+     "sha256": "fffcc0e03f9acc75e05636ab67f5f647568c81d0bcf4623e64d487c04d9cd5eb"
+    },
+    "progs/s_bubble_wht.spr": {
+     "bytes": 1140,
+     "sha256": "d4ef765e90c3abe05f5a8afcfba688b015f4a7a2465cf0a8594ffe63d0b4e3cc"
+    },
+    "progs/s_bubble_yell.spr": {
+     "bytes": 1140,
+     "sha256": "9dcce864ad255b17d7d45e5c5531114f6a66c4e9cb549fc8b31aef0af5a9157f"
+    },
+    "progs/s_burst_flame.spr": {
+     "bytes": 22128,
+     "sha256": "66511ada8a299b0882e2939c09d3fb726d3ce52ecb93a884584a9ce11915a6c0"
+    },
+    "progs/s_burst_flamedp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_poison.spr": {
+     "bytes": 22128,
+     "sha256": "d8245e0460efc4e939a187912126f44422c39b1fe4b553c2c15da91833e8549d"
+    },
+    "progs/s_burst_poisondp.spr": {
+     "bytes": 22128,
+     "sha256": "888ffb2e89117bbd16113c889093ea1848be791752e48ff43443ecb7e3a36d55"
+    },
+    "progs/s_burst_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_burst_steam.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_dotmed_blue.spr": {
+     "bytes": 1140,
+     "sha256": "0b3160c5a4ae42216ddb7aaa7ae4726f6b2507c914328abe3c69f2d12fd921f8"
+    },
+    "progs/s_dotmed_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "6e28b69544f8aa13ccbb9a66893e4ab86b83639ee3f81dbbe1b94290ca9b03ef"
+    },
+    "progs/s_dotmed_grey.spr": {
+     "bytes": 1140,
+     "sha256": "77c226763e90a54b4d6835bd877c08c501605e516e64177c915c422e7b36c207"
+    },
+    "progs/s_dotmed_grn.spr": {
+     "bytes": 1140,
+     "sha256": "d1a9800a8b5cad01fa1dc93e57162e9960c4a8478e7e427d66cdbfe6a6797266"
+    },
+    "progs/s_dotmed_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "6113140f371b08cda9addcf68282c1fc16692da7498fa2fdfe2b99662e345d67"
+    },
+    "progs/s_dotmed_purp.spr": {
+     "bytes": 1140,
+     "sha256": "8b2cfa67ac86841f59409e184b4f3a253218e5930a5e3f241caef39dc1baa8de"
+    },
+    "progs/s_dotmed_red.spr": {
+     "bytes": 1140,
+     "sha256": "4ae92a280e0df01c0acd0a904214af485bb60919e5ded4573aa12f86875182d4"
+    },
+    "progs/s_dotmed_tor1.spr": {
+     "bytes": 1140,
+     "sha256": "eddd46a4818dfa92a9817df82e893d6bf6513160164a74b95bdd42fb7cac2f75"
+    },
+    "progs/s_dotmed_tor2.spr": {
+     "bytes": 1140,
+     "sha256": "dcb87897de0f54a6d8f78e9194a15c11261eb88455f058b334f8648a363159a9"
+    },
+    "progs/s_dotmed_yell.spr": {
+     "bytes": 1140,
+     "sha256": "e6b72aac439291d7719ee78d9520c1a1def36212ac7f61ba333fa87d5265c63f"
+    },
+    "progs/s_dotsml_black.spr": {
+     "bytes": 632,
+     "sha256": "2ae7fa13584d12f04b337fbbd774e74fbe54a6fcbd354239e97fecce931bd377"
+    },
+    "progs/s_dotsml_blue.spr": {
+     "bytes": 1140,
+     "sha256": "c0149109ae73a72da49bfaf9ba00cf2edadbe0f053928d09319083e6247883ad"
+    },
+    "progs/s_dotsml_dblue.spr": {
+     "bytes": 1140,
+     "sha256": "f95fe813ecce2c69d2b72e5bf870d045037519c89f3da9a300e7453754cd1503"
+    },
+    "progs/s_dotsml_gold.spr": {
+     "bytes": 1140,
+     "sha256": "3833e80c32da39063b5069638ade52c4aee51b7db7206b4911cb48f321e25bdc"
+    },
+    "progs/s_dotsml_grey.spr": {
+     "bytes": 1140,
+     "sha256": "2e16d9ff8ceca2994a609703f405b1efbb7b49e02c8dbb9e77d0cdcaf3318b98"
+    },
+    "progs/s_dotsml_grn.spr": {
+     "bytes": 1140,
+     "sha256": "a2735123addacfa03f2666969e476af0d9f1cfefbef75a7ac9599d48f86226b1"
+    },
+    "progs/s_dotsml_lgrn.spr": {
+     "bytes": 1140,
+     "sha256": "ebf62caae17163587aaa3652300f1003c008ed21041b838a14cfff7672f87d90"
+    },
+    "progs/s_dotsml_purp.spr": {
+     "bytes": 1140,
+     "sha256": "476042db782f7f81cb53d91e9518881f28eb34d3a2a535c11d9c22f65518bce4"
+    },
+    "progs/s_dotsml_red.spr": {
+     "bytes": 1140,
+     "sha256": "94c0403ee7f1e6f6c4d6bc9b99e73e48143845fe35d0d6b3de246842241b12cb"
+    },
+    "progs/s_dotsml_wht.spr": {
+     "bytes": 1140,
+     "sha256": "7ac2d5b9b1e14a1799b951ace16bcc1addb7fefc2470dec23ef2ca110a934bf5"
+    },
+    "progs/s_dotsml_yell.spr": {
+     "bytes": 1140,
+     "sha256": "686f220b937040b91b6ff4f05efd41525d40eb80a61ff8138809d550bfa99959"
+    },
+    "progs/s_dripblue.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/s_dripgreen.spr": {
+     "bytes": 60,
+     "sha256": "805935ef90e14eda0f0ec89cc7e03acf52df768eb9e09140629bc1067a658774"
+    },
+    "progs/s_dripred.spr": {
+     "bytes": 60,
+     "sha256": "2dc81cd44438e124dedef0b656c31a066b7879940fcdbc39a0cfd57a6d2985e5"
+    },
+    "progs/s_dripsplblue.spr": {
+     "bytes": 828,
+     "sha256": "6b960ccc7a877bf2b4b67467400c0eaa1bb88d8c8a524458b9bf8d1aa1a6e29f"
+    },
+    "progs/s_dripsplgreen.spr": {
+     "bytes": 828,
+     "sha256": "397ac392598027c27240d71079f79eb9c90306724bc54c5d9854e14939059b6c"
+    },
+    "progs/s_dripsplred.spr": {
+     "bytes": 828,
+     "sha256": "268b48b87a0f352b671c04a1f7325af43372578a6d73269356389280eb7ef232"
+    },
+    "progs/s_exp_big.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_exp_electric.spr": {
+     "bytes": 5256,
+     "sha256": "ed01b728b6656a68acffe258d644712eba3b786434ab6b3e6d90434031e90d96"
+    },
+    "progs/s_exp_ice_big.spr": {
+     "bytes": 164076,
+     "sha256": "bf7317d811349602db7a020da3e77065ffd8158a3104e83ddca3b166566df18c"
+    },
+    "progs/s_exp_med.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_exp_plasma_big.spr": {
+     "bytes": 213288,
+     "sha256": "fe99a489e169ccf56f0412c2e83a7c5aea7b75b7cee0501402c62fcbd7ca969c"
+    },
+    "progs/s_exp_plasma_small.spr": {
+     "bytes": 53544,
+     "sha256": "555e39e88cedaf9e9dd1215ad1325b32019a6bf2654d53736b1f362506548150"
+    },
+    "progs/s_exp_poison_med.spr": {
+     "bytes": 72892,
+     "sha256": "60b7a8c194f3a6cd2241edd6223ac1da1f57811d7f5416216c70a2797d1baf20"
+    },
+    "progs/s_exp_poison_small.spr": {
+     "bytes": 53544,
+     "sha256": "2a54104dec9381afe338574d66bcc19bd2776caa0d46031c743cd24782098d3f"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "a9476d95ea10fbd2317c174272864efa4bb6e939893f3a3de520aeea3e3522d9"
+    },
+    "progs/s_flamemed.spr": {
+     "bytes": 43324,
+     "sha256": "3c645e305673693089fe48cc7a22f694eeaf7881cfc94ff7b1c4b05b718342cc"
+    },
+    "progs/s_flamesml.spr": {
+     "bytes": 21820,
+     "sha256": "5e60165461c34a3a25cbe6b0bb5e36131bb4a81fef384f1db4a7236f30e7ba95"
+    },
+    "progs/s_flametiny.spr": {
+     "bytes": 11068,
+     "sha256": "9d2c0af6139f3d194e73dbcb7880aa0a6f2a04019f94818ce9844691399b551b"
+    },
+    "progs/s_judgemagic.spr": {
+     "bytes": 12564,
+     "sha256": "6d08d5ada6bac219927edb39a93302f98b7b1a357e6648fc1abb49fd5cc3bd4c"
+    },
+    "progs/s_marsh_med.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/s_marsh_small.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/targd_hull2.mdl": {
+     "bytes": 3380,
+     "sha256": "520c82906942d582c6b64da4dca32ca8ed236694607c3a19ec71b89136e0c757"
+    },
+    "progs/targd_massive.mdl": {
+     "bytes": 17076,
+     "sha256": "099ed67733ea3a461c2247d6f07d3dadcc5a6968bcd6a03398507c653d174395"
+    },
+    "progs/targd_short.mdl": {
+     "bytes": 4788,
+     "sha256": "c883300477d3978469aabc35ef3969c14645c1111997c64452634fc8b4a978e1"
+    },
+    "progs/targd_tall.mdl": {
+     "bytes": 4788,
+     "sha256": "bab77599f9cbbe1cf0856a642612ae30b08fed9ae27a209abda30f6dc8c07129"
+    },
+    "progs/targd_wide.mdl": {
+     "bytes": 17076,
+     "sha256": "d40a00625196f67fe26f3611cd91dd33484ddbf3db273766f8a5fac38db07b07"
+    },
+    "progs/trap_pendlong.mdl": {
+     "bytes": 44900,
+     "sha256": "62d3b86fea6e2336dfc5c7b93514e096eba05992a3bd3e0c6571e4c4a27be684"
+    },
+    "progs/trap_pendshort.mdl": {
+     "bytes": 44900,
+     "sha256": "efb3e395093e34d7b16c92ed73abb199a28d0bc653522c13d4e720030f547713"
+    },
+    "progs/trap_sawblade.mdl": {
+     "bytes": 28716,
+     "sha256": "759bd7e1f7629b4d87ecb9e53a9f2d66e3e81b9103bc4eab3f85bd598eba36f6"
+    },
+    "progs/v_ghook.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "5b6b84edc6e6c58128a6e830ec35424cc83e69fab7b1337c4c681d8d0ed81e74"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 48964,
+     "sha256": "d073c7fad7dee2c4664aa401d744024b623abcd65e60a4c7066721b988838aff"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 54940,
+     "sha256": "c0a6b7d9664b0ab5a0c77732b22592dedfefbf65c624c05bec7aa8d60835f74d"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 39668,
+     "sha256": "78fc36ddbd33fb77192ef100547f1a1a0f70a38fdaac7094df67f2df33ca9237"
+    },
+    "progs/v_shadaxe0.mdl": {
+     "bytes": 97860,
+     "sha256": "598f555a854590a749eee83870a869ebfa8dfd3c84ad447b7fe3fb796ea1da80"
+    },
+    "progs/v_shadaxe1.mdl": {
+     "bytes": 97860,
+     "sha256": "2ffbb3026a21d70a73a091222cc4f2ea2ba6abd706fbffc276f027b9475abfaa"
+    },
+    "progs/v_shadaxe2.mdl": {
+     "bytes": 97860,
+     "sha256": "cd2a7a188f73c5b841183885663470c53c3af5646491f44811a4a0f192381ed7"
+    },
+    "progs/v_shadaxe3.mdl": {
+     "bytes": 97860,
+     "sha256": "b1c0dd11ce314003de5051f8a3b9581ee3eda5ea347d3d3371eea43051820197"
+    },
+    "progs/v_shadaxe4.mdl": {
+     "bytes": 97860,
+     "sha256": "81108f8b2484d24e54e9ab3ee5b707be5ea28adb142159412aa773ae01e593c1"
+    },
+    "progs/v_shadaxe5.mdl": {
+     "bytes": 97860,
+     "sha256": "0d3ca1664ee82ab2aed6261c262fdc455db981ecd2d62371595e520756d7bb22"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 22260,
+     "sha256": "bf79b703708665b9e65556bf68c0fe9d177097b2b96b11563d7b8bf84485a81b"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 22764,
+     "sha256": "5a51ba87bcdf37463bb8f34dd7259ea2be54d540fbc59798bb62dc24b2d3e777"
+    },
+    "progs/v_shot3.mdl": {
+     "bytes": 77868,
+     "sha256": "5b08bebaeb2fa054e6bb37d51c716cfac0e4da843b0db158a4a9769fa04ad13f"
+    },
+    "progs/v_zershot.mdl": {
+     "bytes": 62604,
+     "sha256": "4173bb2b84f9adce1957a87251cca591d968c3a54e801b170a87aae82539a2b1"
+    },
+    "progs/w_backpack.mdl": {
+     "bytes": 138832,
+     "sha256": "78d86e7bc605746990a1b10644b12542f3380375693d4fb015884e42269314a0"
+    },
+    "progs/w_blueflail.mdl": {
+     "bytes": 17236,
+     "sha256": "3b645ebcb5d2249c9cf904e17006b85aa05963efda33f45f5b6f6fc3ea188d26"
+    },
+    "progs/w_chainsaw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/w_dcrossbow.mdl": {
+     "bytes": 14388,
+     "sha256": "52b14c48ec77acb261f18e1d7903e360eb96acb5c22a0702dfde90c66b103064"
+    },
+    "progs/w_dfurysword1.mdl": {
+     "bytes": 8916,
+     "sha256": "16521de90d0e71090ef4e6b5904252f3ae2d4a38ebe99eff9dc758ea009b0f90"
+    },
+    "progs/w_dfurysword2.mdl": {
+     "bytes": 8916,
+     "sha256": "2e42b37254cf8d85b098e58143fd77d86bed2f3568f630196326841298d07187"
+    },
+    "progs/w_dguardsword.mdl": {
+     "bytes": 8404,
+     "sha256": "74b884b8fd0a785fc2c1dcc29428b8d4c8725de6963bccf7ec80c396e002fa38"
+    },
+    "progs/w_dknightsword.mdl": {
+     "bytes": 8404,
+     "sha256": "1e6729ae15dd1520fff7f4c1c30260c35b637bd0b23b8fb3a5a476b175a39165"
+    },
+    "progs/w_dprincesword.mdl": {
+     "bytes": 19296,
+     "sha256": "89e5ef1382e980b68e812f7e8f6a9b6fba34af42bb2def457b7a2f6f8d7388b7"
+    },
+    "progs/w_enforcergun.mdl": {
+     "bytes": 42612,
+     "sha256": "fbbfd121a3d085d654aab512cfebb0b6890daf3c403f25ca372edc3c53039375"
+    },
+    "progs/w_hknightsword.mdl": {
+     "bytes": 20504,
+     "sha256": "a8dffdc9e400d45fcea617255a8731d752cfa83df40b923128d5dbae6839492c"
+    },
+    "progs/w_judgesword.mdl": {
+     "bytes": 199388,
+     "sha256": "c822984ba5a12948ca389f4b8536c3aa6644993242362b10ac7f6ff2e2332590"
+    },
+    "progs/w_justicesword.mdl": {
+     "bytes": 264928,
+     "sha256": "0fc111a637bdaf5372c02c53439497c2adfc0914845b947ecc9ad70ace1e1b3d"
+    },
+    "progs/w_knightsword.mdl": {
+     "bytes": 14328,
+     "sha256": "4740ee2b171380cd9481ba07f284fe720c5b49b0980dc19cb145b2356205fc0a"
+    },
+    "progs/w_ogregl.mdl": {
+     "bytes": 8260,
+     "sha256": "8071cb814b6158c8af563494687e3994192818ccc2aa80f4766bbf6912d559ee"
+    },
+    "progs/w_ogreham.mdl": {
+     "bytes": 29996,
+     "sha256": "11c1ec322889a971b7f930a7c653f13e69714e6de77b7afa4ded1fdec39145de"
+    },
+    "progs/w_ogremac.mdl": {
+     "bytes": 29324,
+     "sha256": "2f9086da6b43becab1d54e47bcb299421b1bdc1e1e71c41e581b367a75f52919"
+    },
+    "progs/w_skullbook.mdl": {
+     "bytes": 25580,
+     "sha256": "e99379e980169501931eb029f36d05b41ba52f8597a6022bf195b08dba88c70e"
+    },
+    "progs/w_soldiergun.mdl": {
+     "bytes": 36120,
+     "sha256": "9c89a19d7c5fa69783d8bcf59b46b18a0c80c37e280b18731564952faf1d6523"
+    },
+    "progs/w_zombiesword.mdl": {
+     "bytes": 14328,
+     "sha256": "e4ac73fc149fa581e64fb5f2016ce58c99ab1c9a76502ede78a525ab7f344b0c"
+    },
+    "sound/ambience/bell_ring1.wav": {
+     "bytes": 61586,
+     "sha256": "b9169a48fd032d7c2b0cadb61540ac5db42ca6384cb2c74818bd46bae3fc7db1"
+    },
+    "sound/ambience/bigmachine_loop_02.wav": {
+     "bytes": 92760,
+     "sha256": "4d6dd03883ac4462c7f1741c022a3e8fd9e2c65cd54d5d126f58c00b3bfe7df3"
+    },
+    "sound/ambience/chimes.wav": {
+     "bytes": 250476,
+     "sha256": "d1060cd75d8a520b748047790d33c9a4ab5fd626330ebf1242d318d308c165db"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/distant_gears.wav": {
+     "bytes": 72502,
+     "sha256": "760d34131249ff3c4bccdab0cd3df69874728a6db3e1b4545177e5ce381e5e80"
+    },
+    "sound/ambience/drone6.wav": {
+     "bytes": 36820,
+     "sha256": "ab0cc1d617b06169d20b42bddc31078c0c7a1b8b15793fe6cfea6dbc96b4129e"
+    },
+    "sound/ambience/fan_finish.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/fan_loop.wav": {
+     "bytes": 288110,
+     "sha256": "d7459b4f1087aa1e002f41fc0274e4cb2f313dff5af2eecaa9de5225bcdcd729"
+    },
+    "sound/ambience/fan_start1s.wav": {
+     "bytes": 96044,
+     "sha256": "b0bad8ae3cd81dc4bbd76591e29f9c43610cb6e0311d4822213e400a6b99dd9f"
+    },
+    "sound/ambience/fan_start2s.wav": {
+     "bytes": 192044,
+     "sha256": "6716a803f246e44416fc414ca2f51744fc1ed79178f79fe3baf7a986c820c020"
+    },
+    "sound/ambience/fan_stop.wav": {
+     "bytes": 192044,
+     "sha256": "ee8607922387eeb594c18096ef6dd4003990a5fe47414dee331921f6d03be6b7"
+    },
+    "sound/ambience/fire1.wav": {
+     "bytes": 47906,
+     "sha256": "c1370a7c177aa21de219578cc64716bc800007e2ac86ae106affac01f8edc470"
+    },
+    "sound/ambience/flames1.wav": {
+     "bytes": 132406,
+     "sha256": "8ac99a7ace2ec9cc98a38fd5777973eb484e9193cf93dfcd6a51ea4f0f9d0f00"
+    },
+    "sound/ambience/flames2.wav": {
+     "bytes": 132406,
+     "sha256": "31e76d131cb4ad3c0602e2559c949feb7a8749c639363f1fd7df53136616fdd1"
+    },
+    "sound/ambience/flames3.wav": {
+     "bytes": 132406,
+     "sha256": "b4008d1da182bc0886f8bad53e5a700d8e04050920aa27ceb0922be938eb7c96"
+    },
+    "sound/ambience/flames4.wav": {
+     "bytes": 132406,
+     "sha256": "222222e080566c899a48df9e40006d0ee36575c03250c44845fb10a94c5cead9"
+    },
+    "sound/ambience/gargoyles.wav": {
+     "bytes": 136816,
+     "sha256": "16f09404b6043aaacb4b6b2bb00143ab72b5e185f02e610d780ea7d311d2df6c"
+    },
+    "sound/ambience/gearopen.wav": {
+     "bytes": 49708,
+     "sha256": "39b73c8ada1b06c7ba07099447b9b0d75911f08df09ced3826bcff136af5b0ee"
+    },
+    "sound/ambience/generator_gas.wav": {
+     "bytes": 529314,
+     "sha256": "6710075453fde424951171823e87f3711d53fd434149ddecc14a14ce721de04a"
+    },
+    "sound/ambience/ind_lift1.wav": {
+     "bytes": 158906,
+     "sha256": "c722fa19c7851d2c7b4307489911b885527e31fd3e4de44d5a184bd786714049"
+    },
+    "sound/ambience/ind_lift2.wav": {
+     "bytes": 156008,
+     "sha256": "c404881a9758f839fd055dd69a82f04bf7e5d5b98538a4a87b2ee741d8b4956d"
+    },
+    "sound/ambience/light_hum1.wav": {
+     "bytes": 100022,
+     "sha256": "cb2f04b81297621ffddbfb028dc5021a665e3285deb7c80757a47add8294f032"
+    },
+    "sound/ambience/liquid_bubble.wav": {
+     "bytes": 129688,
+     "sha256": "838ec1e72b2c433408a342a48518987edcb2124932eeb477d59653540b13d6ea"
+    },
+    "sound/ambience/liquid_burnlong.wav": {
+     "bytes": 710182,
+     "sha256": "9c9c77941f88416e3f20dfc4f028cc6c9719dd7f58a15dfc6124f1bb5a17f61a"
+    },
+    "sound/ambience/liquid_burnshort.wav": {
+     "bytes": 89464,
+     "sha256": "4ea16997389f1aa35549869a338f2093f40d14df030c381a7659cc7e3cbf8bfc"
+    },
+    "sound/ambience/liquid_drain.wav": {
+     "bytes": 220464,
+     "sha256": "e86a6012c8fc3a795791fc344ef636bb1854a602cd609e2df751531e89277cf9"
+    },
+    "sound/ambience/lowboom.wav": {
+     "bytes": 666640,
+     "sha256": "ad591a6f574f48e654e32dacee6b7d862df8b47e20ef116f84415ad9aa515559"
+    },
+    "sound/ambience/machine_loop1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/ambience/machine_loop2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/moo.wav": {
+     "bytes": 265502,
+     "sha256": "35b7924115bc4cdf94e9cbb274a4d9ca251d6878817834bec08aaa176f2ddc9b"
+    },
+    "sound/ambience/mystery_drone.wav": {
+     "bytes": 1350258,
+     "sha256": "eb3fbb28dda2a6204af07d08fa993ed09513f9915142dd6f4af808204b6b8c9e"
+    },
+    "sound/ambience/power_drone.wav": {
+     "bytes": 36700,
+     "sha256": "4307c01076cb5e076d27546b17bd6b11e2369a67b59dbbd64f2607d8b262a8c2"
+    },
+    "sound/ambience/power_off.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/ambience/power_on.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/ambience/power_shutdown.wav": {
+     "bytes": 1118464,
+     "sha256": "e0ab1a0f67a2d37a525f7a73e8ee8c3a26f746e027fa1501f6648f5586ea2048"
+    },
+    "sound/ambience/power_switch.wav": {
+     "bytes": 66382,
+     "sha256": "5c006bb7315e6eb6d2367ae30a78f0abec8ae2a1e2b6a2c9af88354962b0f33f"
+    },
+    "sound/ambience/rain1_nl.wav": {
+     "bytes": 154394,
+     "sha256": "45d8c08ff4a9a2dd6ff8362fea7c22f9c3ea64a3a8d7b6c81c8cad88265f327a"
+    },
+    "sound/ambience/rain2_fade.wav": {
+     "bytes": 198550,
+     "sha256": "3cf300a4f785d416656838bd3a68120bf6a48d16f928ca74e2e0890ec9f8b426"
+    },
+    "sound/ambience/rain2_nl.wav": {
+     "bytes": 66250,
+     "sha256": "f2735ae8a7b1ae5ab5ce3b8ed66d8c61d00a65f2e66d8c565f4abe718d57ab67"
+    },
+    "sound/ambience/rain2_org.wav": {
+     "bytes": 132400,
+     "sha256": "4c1f820b2c8f4bea08b8357fb8409e9f30a98fd0faf1413a1953ea697b84b507"
+    },
+    "sound/ambience/rumble1.wav": {
+     "bytes": 403620,
+     "sha256": "47afe820548bcf248b7760f7a66a61ea65b5fb79f70d47e3b03cf8211bb4c5f3"
+    },
+    "sound/ambience/rumble2.wav": {
+     "bytes": 99104,
+     "sha256": "9c3d5418c7e5bac60c365f0e8b7ea496dd2b51c72c13b0e5a6640e2ef880433a"
+    },
+    "sound/ambience/rumble3.wav": {
+     "bytes": 209242,
+     "sha256": "864f373dbd75172e1c8f31373188f38c31a80af46592f6b2e92cf5f576e5e0e1"
+    },
+    "sound/ambience/s1_stop.wav": {
+     "bytes": 16162,
+     "sha256": "9a35adf9361aa033b413762fea7d04b2cf7392b363f2aa187a81905f65a44b61"
+    },
+    "sound/ambience/switch_1.wav": {
+     "bytes": 35324,
+     "sha256": "9f73f07313ba4995247d82901111b5aea4200c48de6641dddb145dfadcac40c9"
+    },
+    "sound/ambience/switch_2.wav": {
+     "bytes": 61488,
+     "sha256": "1de1969449b8bc57c75f0a5e9552c676c5b4d522171e592dbd1bbdcba9f60960"
+    },
+    "sound/ambience/switch_3.wav": {
+     "bytes": 17576,
+     "sha256": "33b6ed57b0255840415df4db607f86b1183b564f4b1f2dcab6d45d4d75231b8c"
+    },
+    "sound/ambience/switch_4.wav": {
+     "bytes": 44348,
+     "sha256": "bfebdf2afdbab57bd5be3fe0996ce19ff46d983eea4d1511d85af2e4f7d0db00"
+    },
+    "sound/ambience/switch_5.wav": {
+     "bytes": 79992,
+     "sha256": "78bb8cb9ab7202657495a0ca14340886af901912850b9951b0da159f55c2cb20"
+    },
+    "sound/ambience/switch_6off.wav": {
+     "bytes": 141466,
+     "sha256": "999d3b02b7224586d5c487c2666981f054aa091f0569671c72455bff458c9a2a"
+    },
+    "sound/ambience/switch_6on.wav": {
+     "bytes": 176192,
+     "sha256": "7a67fa5d4ee042c6afd271868682a1a34908c2593e5ea9e868ecb6d3e154b55b"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 220548,
+     "sha256": "2cec0b03aa7047110862de21f8f6c77e4d98901ecaf5e405a473c2ddc922528a"
+    },
+    "sound/ambience/thunder2b.wav": {
+     "bytes": 286716,
+     "sha256": "44095eceb307b5f2f1093051597ea0e48bc7abe165accd5badf99c4ad692c6df"
+    },
+    "sound/ambience/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/ambience/windgust2.wav": {
+     "bytes": 110284,
+     "sha256": "b818f61172795942402ff0ca0d1295a91c36a245edc80689c35fe64a8ac1a4e2"
+    },
+    "sound/ambience/windgust3.wav": {
+     "bytes": 110030,
+     "sha256": "fdbb85f091cd9447f1500173aff70236abcdb947ba0758711816da59c5293344"
+    },
+    "sound/ambience/windgust4.wav": {
+     "bytes": 198502,
+     "sha256": "9a5c5a3da44f981c9deb8b437f57b3e3a35f2bcab318a1a3223f0a18fa4d2101"
+    },
+    "sound/ambience/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/ambience/windgust6.wav": {
+     "bytes": 396944,
+     "sha256": "27a19679e7164a6e7bb8e4d6bc42cc8c12a5cd56bba45218e2ec5f1dc528da0d"
+    },
+    "sound/ambience/woodcreak2a.wav": {
+     "bytes": 352834,
+     "sha256": "24d3f57839910934eb61b74a91cf47ee4ab48b38f58f060ca05bde7547e8813c"
+    },
+    "sound/ambience/woodcreak2b.wav": {
+     "bytes": 352838,
+     "sha256": "574401233bff93169d452f4af748a289cfaff5d4e6319884e3cfb4dbd205d0a4"
+    },
+    "sound/ambience/woodcreak2c.wav": {
+     "bytes": 308746,
+     "sha256": "02deb62b856b7be5c3304a0bf745f79019b0b408a8cfcc4e1edede397ba09c7d"
+    },
+    "sound/ambience/woodcreak2d.wav": {
+     "bytes": 352856,
+     "sha256": "6d35975964b2fa32ece681a9d0cfa13202cde02bc315f32af0690f7437352452"
+    },
+    "sound/ambience/woodcreak2e.wav": {
+     "bytes": 308766,
+     "sha256": "54eb41e3f5c2a0103d07e70e83cf82b51014da3673fb770cf6ada3df669c328e"
+    },
+    "sound/bal/bc7_waterfall.wav": {
+     "bytes": 137846,
+     "sha256": "51dcfb96c94678cbb01e0c985240e853a01c6fc3c4f2376de177c0be59bfcfe6"
+    },
+    "sound/boglord/attack2.wav": {
+     "bytes": 8036,
+     "sha256": "efa18dec8f6d5066b8d494a232ca9c98c27a4a9130130086a9b0a27ffccb34ed"
+    },
+    "sound/boglord/bangdoor1.wav": {
+     "bytes": 30968,
+     "sha256": "b267e602e76fe1d8e854e2873e06008af15612ed1a31ec41feeb4461d52fc478"
+    },
+    "sound/boglord/bangdoor2.wav": {
+     "bytes": 39828,
+     "sha256": "f904a5423580c118de1d732fff714565f1dd8d8d1556b3b58bf39d2c59fa4272"
+    },
+    "sound/boglord/bolt_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/boglord/death1.wav": {
+     "bytes": 39758,
+     "sha256": "a9e0e36b1a51d88a5b542dd2c1f79f1dbea402b3ceb18ee13606c03126f1a874"
+    },
+    "sound/boglord/idle1.wav": {
+     "bytes": 15532,
+     "sha256": "5339e3429b0510f7e8016e6ece9895df6f202b5809f739b317211a081401f202"
+    },
+    "sound/boglord/idle2.wav": {
+     "bytes": 18586,
+     "sha256": "52f8bddb2d5095f4077eb1f753d75bce94f906f1b3064067a54c875ae16d1a5c"
+    },
+    "sound/boglord/melee1.wav": {
+     "bytes": 9326,
+     "sha256": "e2f5808115d0a93dde1063db6f2d38f6ab7ff333f83d95741a8948f44ae4ace9"
+    },
+    "sound/boglord/melee2.wav": {
+     "bytes": 11746,
+     "sha256": "e299e39467c9f94730c21d1321455fdccf3aefbb0352d528b6d413639210e715"
+    },
+    "sound/boglord/melee3.wav": {
+     "bytes": 18776,
+     "sha256": "c066200b5ddb81aa0c0cc0462939681703549ac15dd6aa83db8a23ae54ce6317"
+    },
+    "sound/boglord/pain1.wav": {
+     "bytes": 11094,
+     "sha256": "6ca5a44043add6b389827e5aca8bc0c9e9c7b0cc0c7b4a5d3df292a78da0064f"
+    },
+    "sound/boglord/pain2.wav": {
+     "bytes": 11094,
+     "sha256": "7e11818fbae5354177add1e236b6f3e0f4665d50193154fbb15fead4bb4d7908"
+    },
+    "sound/boglord/sboom.wav": {
+     "bytes": 22172,
+     "sha256": "89899521eac11f922cdd4606a0fe08bc080a63a73ec4b4a502027e33f08b225b"
+    },
+    "sound/boglord/sight.wav": {
+     "bytes": 28734,
+     "sha256": "8b020b0f07a7461f5f520b8385e38828d66b3cb1fc46d7db08b845fa8ff62ad8"
+    },
+    "sound/boglord/slime_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/boglord/slime_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/boglord/thud.wav": {
+     "bytes": 22140,
+     "sha256": "f5d7b5f65e24d6a5edd04404b93a8c5a2db45cc6c142012638f050158bb783ba"
+    },
+    "sound/boglord/thud2.wav": {
+     "bytes": 105882,
+     "sha256": "7e8826a38df07d0d2b85d6d39b8b664bb2ef8a0686846573802b77811682e957"
+    },
+    "sound/break/ceramic_i1.wav": {
+     "bytes": 11106,
+     "sha256": "ed731319eb09044fe672f5d8681395a11a7449fe7b57b9a46040c717e714cf40"
+    },
+    "sound/break/ceramic_i2.wav": {
+     "bytes": 11126,
+     "sha256": "88c29d649471f031aa1049ee087cf866e1d9ea53183effd14cfabc81ecff9502"
+    },
+    "sound/break/ceramic_i3.wav": {
+     "bytes": 11144,
+     "sha256": "420d00d7884a22dd2baf9cdd1e059689858b47fb3adb2ad5ae29c80bd74b5dc5"
+    },
+    "sound/break/ceramic_i4.wav": {
+     "bytes": 17678,
+     "sha256": "0b7da87d046aeb3a52de305da60b2400c8cbf3480364235fb0bba3a0595f13dd"
+    },
+    "sound/break/ceramic_impact.wav": {
+     "bytes": 37584,
+     "sha256": "e6d2ada5c51a2787548468ad393e2497ef84b47ca487cd523f3ef6b283626226"
+    },
+    "sound/break/ceramic_impact2.wav": {
+     "bytes": 35380,
+     "sha256": "508725e20a999c339501dddb045a2ca6a51032905dccc68fe2a3fb9e9e1d0649"
+    },
+    "sound/break/ceramic_impact3.wav": {
+     "bytes": 26560,
+     "sha256": "ca4d7876a6e33cc285186d1432670878b54cc62c01e3dc4c650727069bfdb8ee"
+    },
+    "sound/break/ceramic_impact4.wav": {
+     "bytes": 37584,
+     "sha256": "e71b0559ac5d76dcd2016d07f8999ae1200d82ca7b658509339cf303c918f777"
+    },
+    "sound/break/ceramic_impact5.wav": {
+     "bytes": 37584,
+     "sha256": "1c6b3457c9d3aab209cd3b8977df579cdbe01158c1b4e5c07c2b5b227c96fb6d"
+    },
+    "sound/break/ceramic_impact6.wav": {
+     "bytes": 37584,
+     "sha256": "fac4857865a750a03f74e556f44186381315068ec1975c775fcd14ae4a7b3c7b"
+    },
+    "sound/break/flesh_impact.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/break/glass_i1.wav": {
+     "bytes": 13268,
+     "sha256": "63ec32f660d085c64274747b704bcbeb7261062b5fcbb570598d64e742dc7164"
+    },
+    "sound/break/glass_i2.wav": {
+     "bytes": 30950,
+     "sha256": "8b2ae028e6237cf06241739e3533ef3bf651194dfbef028fd648a6f06e8996de"
+    },
+    "sound/break/glass_i3.wav": {
+     "bytes": 8848,
+     "sha256": "ec97346c02431717927e2dd3712bd82428ea05960ffa027422fbaafab96b4170"
+    },
+    "sound/break/glass_i4.wav": {
+     "bytes": 4442,
+     "sha256": "b4144a008122e52aed45339e11ccf7cb1cd2e92f07e4169d029059a4ca01f5fa"
+    },
+    "sound/break/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/break/metal_i1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/break/metal_i2.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/break/metal_i3.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/break/metal_i4.wav": {
+     "bytes": 79928,
+     "sha256": "d2b35ba352f32ceae469acf9cfa04f7dcc0a462ff69e3649f5c0adf55ae2ea78"
+    },
+    "sound/break/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/break/rock_i1.wav": {
+     "bytes": 30534,
+     "sha256": "5cb61e93ebcf9bbcd3be1f6e282b51e9102d56b6650cffc0db93918b11b42322"
+    },
+    "sound/break/rock_i2.wav": {
+     "bytes": 29254,
+     "sha256": "9fdf4f489834452fce33b1fbe69bce9d4920a117c3d0d93b4fb530a7117bf160"
+    },
+    "sound/break/rock_i3.wav": {
+     "bytes": 25264,
+     "sha256": "59b506a84e018b11e9ba30a6ad299c2d8cf24d5907dc95cf30e578cd386e28bf"
+    },
+    "sound/break/rock_i4.wav": {
+     "bytes": 27244,
+     "sha256": "7a2c24ce52e272998ca035c967860873c92fbb14227a190ac82b761843680ffd"
+    },
+    "sound/break/rock_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/break/wood_i1.wav": {
+     "bytes": 28074,
+     "sha256": "6249449664f5ae509164ae3fd8588c905bea9daf5b1d919d9917b91aadf675bb"
+    },
+    "sound/break/wood_i2.wav": {
+     "bytes": 25158,
+     "sha256": "d51e731bdf895c84ec9927c496fc0a7fb6e7a37cbfbc2f6b55f54f716d804d08"
+    },
+    "sound/break/wood_i3.wav": {
+     "bytes": 17644,
+     "sha256": "8e1967cf42a7e31668d94e1b0cb7c6de4d36c6ec735d67ab01ac4e00dfb0853c"
+    },
+    "sound/break/wood_i4.wav": {
+     "bytes": 11516,
+     "sha256": "fb0908f1a2bdff824d27fa92f15690cb9f86805185119fbc7f7876547495bf45"
+    },
+    "sound/break/wood_impact.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/chthon/attack1.wav": {
+     "bytes": 22116,
+     "sha256": "91df4f5be21c6a80d31a050192b04a760f25c7f88a4b0ceeb2802fe8b8499d21"
+    },
+    "sound/chthon/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/chthon/death1.wav": {
+     "bytes": 55120,
+     "sha256": "b6eeee788b9aa49ca9698d2d7977748f142053fd3f47e2828d1781d7db7ec986"
+    },
+    "sound/chthon/idle1.wav": {
+     "bytes": 24322,
+     "sha256": "6a0a9b5a0b2e74fce8cbfa9ede97c2059884c0db81b2c68fc0ec7bb1da2a4009"
+    },
+    "sound/chthon/lavasplash.wav": {
+     "bytes": 100546,
+     "sha256": "a533653ff77e2dfc443377a1f055b6abd7af3c639f0e5634b0a47fd1f040ed76"
+    },
+    "sound/chthon/pain1.wav": {
+     "bytes": 35320,
+     "sha256": "f964bdd08ffc66f9f229aacb3b584ffefdcfbacf7da0f0075a9af752569c641c"
+    },
+    "sound/chthon/sight1.wav": {
+     "bytes": 49454,
+     "sha256": "533adf244fa2c2dca72765560e823ceead8d5a0f3832ba18d4fa2928154b12c8"
+    },
+    "sound/deflector/death1.wav": {
+     "bytes": 22150,
+     "sha256": "593140594353d4d25fe6b5e455afc0f3c2cdd6874bc1d545ea03f779454cd799"
+    },
+    "sound/deflector/death2.wav": {
+     "bytes": 41334,
+     "sha256": "4295a9a79fec3bf611c25f97553420d0e42b987ad8091930db9137b93a3e8f06"
+    },
+    "sound/deflector/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/deflector/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/deflector/idle1.wav": {
+     "bytes": 7668,
+     "sha256": "76455fc9d5fc53cf5a70900a9d875ba3ac839e1c3179eccc5287619a70523e6e"
+    },
+    "sound/deflector/melee_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/deflector/pain1.wav": {
+     "bytes": 6452,
+     "sha256": "e0905dc6c945663a97119f2c1522d5a8ebd1596ed26f33650fcb63b185959517"
+    },
+    "sound/deflector/pain2.wav": {
+     "bytes": 9598,
+     "sha256": "011d69ef5153dca029bcb1c3d60b3c3f0e1263bd9ca34a02d4d14e6ab508a0d4"
+    },
+    "sound/deflector/pain3.wav": {
+     "bytes": 12014,
+     "sha256": "08f5ac27626e862b7193f101a6d0b77dc6568c4e93ef3000199934769666b1ec"
+    },
+    "sound/deflector/rocket_fire.wav": {
+     "bytes": 15482,
+     "sha256": "a08e5f83d20b5d1eb585cf782f08a4a692b0f8c95e461b9a321814d099a89d79"
+    },
+    "sound/deflector/rocket_hit.wav": {
+     "bytes": 13274,
+     "sha256": "4dbcd0bad68272848a32a997bb235c4324cd55b1df0b96b1876fb96ea8ca6a90"
+    },
+    "sound/deflector/rocket_load.wav": {
+     "bytes": 6882,
+     "sha256": "1dbddae67f93c586ea3290ed65e1234cf8ccfd076847b1b418693e97fb5768d1"
+    },
+    "sound/deflector/shield_off.wav": {
+     "bytes": 10684,
+     "sha256": "5c3ea84c12abf632d777f90972966c4a50dde4ee7363d257e3c0f89e68027b5f"
+    },
+    "sound/deflector/shield_on.wav": {
+     "bytes": 10464,
+     "sha256": "340196ba32a9d3f672cbc3db86765eb1517550b00f2f97ed76cb519da1b93962"
+    },
+    "sound/deflector/sight1.wav": {
+     "bytes": 16106,
+     "sha256": "3ec7f00e859c52846b244e69cc3ed7321175746a44eb373fe4bd3cb07612dcf3"
+    },
+    "sound/deflector/sight2.wav": {
+     "bytes": 14432,
+     "sha256": "e8c0c1367969b0346bf5fdc94665a10480636629a71a6a35e47da3d7fb7cb463"
+    },
+    "sound/deflector/sight3.wav": {
+     "bytes": 17184,
+     "sha256": "11748c58e67305ad4e1cd7a2e2c084f9c41184cd2b4f756adfd18adcc22dbc2d"
+    },
+    "sound/dguard/death1.wav": {
+     "bytes": 30610,
+     "sha256": "af3809501261ec4d0afa6ea7301c11a5c7bbc1cc3e06b8c88172ee0214c30969"
+    },
+    "sound/dguard/death2.wav": {
+     "bytes": 43636,
+     "sha256": "93a70fc0d6fee819c723a435a3954b3fd3be86e358698ce85db1062990d1575e"
+    },
+    "sound/dguard/fire.wav": {
+     "bytes": 60820,
+     "sha256": "f5e5d4f6ccc0778c1396c66d327564a0b1892773f2c23d2e30590abf0c758bd2"
+    },
+    "sound/dguard/hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/dguard/idle.wav": {
+     "bytes": 20498,
+     "sha256": "45b2f208b9796d19d7aeb0cba64e4b0e5fd2ed7c980123f7c41ca10d17785021"
+    },
+    "sound/dguard/pain1.wav": {
+     "bytes": 10380,
+     "sha256": "9a367afb7cde241099c58c999e225ba939be39f21be818b16444f5a810049960"
+    },
+    "sound/dguard/pain2.wav": {
+     "bytes": 14892,
+     "sha256": "827a1e4d3c9983f61fffd61de33054274c144bddd9a68460b496fd6281cf9406"
+    },
+    "sound/dguard/sight1.wav": {
+     "bytes": 18124,
+     "sha256": "9cb3d960261d90ec16c9883f4326c905356b6ff4e99cdf48ab5913b098588016"
+    },
+    "sound/dguard/sight2.wav": {
+     "bytes": 18022,
+     "sha256": "35ee4b7ec6715c8c9fdc24f90ad0b5d90a0ae7a4986168cf40670e87c325d5db"
+    },
+    "sound/dguard/sight3.wav": {
+     "bytes": 19948,
+     "sha256": "c6818770267626dea27f4a72ce2249771f6968924022c2275a5a96abfa485044"
+    },
+    "sound/dguard/sight4.wav": {
+     "bytes": 20332,
+     "sha256": "7affcdbdc62f13e492a15b54fe642fe045641f5551f570cc3c8d5f7ee29521fd"
+    },
+    "sound/dguard/slash.wav": {
+     "bytes": 22942,
+     "sha256": "44b60d785ff03f033e183b6fbce69e526351187d28efdeb308f6f8bea930d450"
+    },
+    "sound/dguard/slhit.wav": {
+     "bytes": 31956,
+     "sha256": "0f07a131640f21337cd89a772588ecfc707d6a729f96b54c21920b809cd620e4"
+    },
+    "sound/dguard/slmiss1.wav": {
+     "bytes": 10458,
+     "sha256": "e32d5cb070a13fad979b021e84a727f71242305ade1af7bfe18c255f0f6dd548"
+    },
+    "sound/dguard/slmiss2.wav": {
+     "bytes": 13840,
+     "sha256": "f6b3aee08c25434d2fda7468cacf35a0912b182653a45991149b54a0fc4be537"
+    },
+    "sound/dknight/dcross_idle.wav": {
+     "bytes": 176610,
+     "sha256": "a7eba673532dad555f879ba77091e3cb9e44558608b83c36d8639e51d71b660a"
+    },
+    "sound/dknight/dcross_idlecom.wav": {
+     "bytes": 58910,
+     "sha256": "bba45bd9fc02e1d580a80596d6a1744bb8fb993ed73a7bfdf3b712670cccf989"
+    },
+    "sound/dknight/dfury_grunt1.wav": {
+     "bytes": 19702,
+     "sha256": "8d3709e913b8e26d8e094fddd9c60d74cc71b742e16276d4982c9636db05209e"
+    },
+    "sound/dknight/dfury_grunt2.wav": {
+     "bytes": 54294,
+     "sha256": "f7ca0d5970322629cc47f8c26489d5c916a570525ded20c73823c27f2834609c"
+    },
+    "sound/dknight/dfury_grunt3.wav": {
+     "bytes": 62054,
+     "sha256": "6eae53c32568ce90083dab528c18475ef840f9f684c43cdba7bfcc1c63435ba6"
+    },
+    "sound/dknight/dfury_grunt4.wav": {
+     "bytes": 28914,
+     "sha256": "0def63c77d0f116eabb77cc462ba6a57bc6523fad469946c6f1f11d786100819"
+    },
+    "sound/dknight/dfury_leap.wav": {
+     "bytes": 102756,
+     "sha256": "f288dc9324b2ccace32ce86cffaf0c042a59bf5b56b20657c018859f1038243a"
+    },
+    "sound/dknight/dfury_sight.wav": {
+     "bytes": 69602,
+     "sha256": "443887e91ca71dbba299b37a81bdbd3bb34b491c6c3e13fe73bb5c921019d1ea"
+    },
+    "sound/dknight/dprince_miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/dknight/dserg_hbreath.wav": {
+     "bytes": 185884,
+     "sha256": "c8181d4844ac4b2bb7dc47bbc28bd2ae9fc2737120d6745292de4d594f40d406"
+    },
+    "sound/dknight/dserg_magic.wav": {
+     "bytes": 34768,
+     "sha256": "adcb0810b7e8b23d91d31f5727c480b35c7b59a90d9f7933f69c00e7eccd1f3e"
+    },
+    "sound/dknight/dserg_sight.wav": {
+     "bytes": 15210,
+     "sha256": "d4f7c5b6f64d48606d1d3e1889794a22107f3d5914b37c81c405fdfb1133a7eb"
+    },
+    "sound/dknight/ghost_idle1.wav": {
+     "bytes": 110292,
+     "sha256": "878416a0151a1a71891a84db2565d1e8a2b2e37f03f1822d7f9411a98b42b528"
+    },
+    "sound/dknight/ghost_idle2.wav": {
+     "bytes": 110290,
+     "sha256": "048f79f7fa8f9e49f97dad9f5cb468933be1713726ba95d3ab10d9811cbb5f2f"
+    },
+    "sound/dlord/death.wav": {
+     "bytes": 32022,
+     "sha256": "0188f6a3dd88686e15311f8c39c4277078e55bc0ec75497e2eb534af717abcdb"
+    },
+    "sound/dlord/idle.wav": {
+     "bytes": 9906,
+     "sha256": "c0ee37f80013dad1aaeb285a11a33c4d7c2ff2de0b2a94c2943d3fbe1c241bcd"
+    },
+    "sound/dlord/pain.wav": {
+     "bytes": 8632,
+     "sha256": "230ed5c7d024bfa90b973649aa79d9e9327eaf401b1632e4a1334fb4a9eb075c"
+    },
+    "sound/dlord/sight.wav": {
+     "bytes": 28028,
+     "sha256": "d82aa0028754e826705961040e1ab27f007c572a28c63dbcaeefeb681bc3ca85"
+    },
+    "sound/doors/rattle1.wav": {
+     "bytes": 88274,
+     "sha256": "c524d12100f1067bb30ecdf83e18e5d85124fef834929cfd2a2ade14f83ad730"
+    },
+    "sound/doors/rattle2.wav": {
+     "bytes": 123526,
+     "sha256": "e8decabe8df10f704814bf2f432b3fc6d5542022d465af336b0680793f6163ea"
+    },
+    "sound/doors/rattle6.wav": {
+     "bytes": 97072,
+     "sha256": "0aef6aac51a4e3528e5f2019bf113ee2f0e5096a708d31483a526c447ebdb00c"
+    },
+    "sound/doors/rattle_tech1.wav": {
+     "bytes": 61784,
+     "sha256": "18610e64612241e6936f2d0ebe746c957652c4ce8e37c668515281712f6a1e39"
+    },
+    "sound/doors/rattle_tech2.wav": {
+     "bytes": 88244,
+     "sha256": "de39aa8b59c988b02bf6c13a716e225b7ee029f2553357b8646aef92a2792c3e"
+    },
+    "sound/doors/rattle_tech3.wav": {
+     "bytes": 52844,
+     "sha256": "a29e8144cdab34467250f040feaad044aff784a2775b50bd220e967b39f39b3c"
+    },
+    "sound/doors/rattle_tech4.wav": {
+     "bytes": 76844,
+     "sha256": "ba34a641758a2e2cb9ef5358a398482c2b34526fc4b0c49db590c9679c732ef4"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/enrage.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/r_explode.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/eel/attack1.wav": {
+     "bytes": 27740,
+     "sha256": "8c84b2a5e7fd0754dca3611a8300a8cc9656295ea73617ff0c85d167b28459df"
+    },
+    "sound/eel/death1.wav": {
+     "bytes": 34264,
+     "sha256": "a0f8eab92db10e8fa9342f725743297fd8384e2aca1decc1189109196f3b960e"
+    },
+    "sound/eel/idle1.wav": {
+     "bytes": 53110,
+     "sha256": "c059a4f2bee33543b377803f2af1fc7e2ee205cd02d987859af18087246ae46c"
+    },
+    "sound/eel/impact1.wav": {
+     "bytes": 70632,
+     "sha256": "13cea2f7d66f40511add17d846ab6142345497ddd7cff5ebfc5e2e70a7eb1fbe"
+    },
+    "sound/eel/pain1.wav": {
+     "bytes": 13316,
+     "sha256": "569a6bf9383820e90e431db5c0b82cd0201e10fd2081d228f81a0c76a0e88d1b"
+    },
+    "sound/eel/sight1.wav": {
+     "bytes": 32074,
+     "sha256": "90786a043f5ec1bd0b761c5c8378dc2783e3b1d8e3ac95a9312f55a7c5b3baea"
+    },
+    "sound/eidolon/attacka.wav": {
+     "bytes": 27660,
+     "sha256": "a7bb5c16014c814d379585eb4c6752a91240a5856ad7f3af5f86af037bef91e6"
+    },
+    "sound/eidolon/attackc.wav": {
+     "bytes": 220544,
+     "sha256": "9815d26814c687618b7bbae4a5353570afe497c5d57fb77c083f695d102234c9"
+    },
+    "sound/eidolon/attacke.wav": {
+     "bytes": 46400,
+     "sha256": "39ad467257004bc6d2a17003abe4ef8df89d0668ec03fc8570aa755cbdf94c6c"
+    },
+    "sound/eidolon/death.wav": {
+     "bytes": 264696,
+     "sha256": "bc055e1315073c78e5571c99d29894bc89abfd64b6a258bdabc79849f81c50a0"
+    },
+    "sound/eidolon/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/eidolon/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/eidolon/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/eidolon/footstep1.wav": {
+     "bytes": 52384,
+     "sha256": "e228c0503d89118be55eafaf3a3bfa0a13e3bdcbe4a043f4a9bb31c9e96cf3dc"
+    },
+    "sound/eidolon/footstep2.wav": {
+     "bytes": 46128,
+     "sha256": "1a3b867c93932411f1c3dedf4a8f1553f19caabae438cb7989095307d1a6c5c5"
+    },
+    "sound/eidolon/footstep3.wav": {
+     "bytes": 43774,
+     "sha256": "4119d9c31e359bd48b52bff2842e51c441064896289194f04db44e2d7860cccc"
+    },
+    "sound/eidolon/footstep4.wav": {
+     "bytes": 41758,
+     "sha256": "6b97f80545d9587580a7b445f13e5a38300627e497ed85357f9448c7a910864b"
+    },
+    "sound/eidolon/growl.wav": {
+     "bytes": 44380,
+     "sha256": "f9f404c4590f2af8fa9a1cd0de34e1d031e66d88ccf553dba228396f0d8fb012"
+    },
+    "sound/eidolon/idle1.wav": {
+     "bytes": 28778,
+     "sha256": "61f423068b79bba82fb3ae3fca3957a8f059802068edf272f2695e6caab89271"
+    },
+    "sound/eidolon/idle2.wav": {
+     "bytes": 33172,
+     "sha256": "1bdd3d6862ed0b74aecae1917f09a65acf4db7fca49a0ccd21a7fbc2eea5f02b"
+    },
+    "sound/eidolon/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/eidolon/pain.wav": {
+     "bytes": 17744,
+     "sha256": "6a308180389e3fb98cc00c70dad1c6600988778b34628e04363e7ca54e5bf679"
+    },
+    "sound/eidolon/rock_hit1.wav": {
+     "bytes": 97066,
+     "sha256": "d31741c09309b240d294ba9b310b694aae1d71f823ac9ef28b27a8b5fff14405"
+    },
+    "sound/eidolon/rock_hit2.wav": {
+     "bytes": 123526,
+     "sha256": "a3d1247db98535829392172110a40fde19113dd493ab603c4b6a9a36dd743150"
+    },
+    "sound/eidolon/sight.wav": {
+     "bytes": 53044,
+     "sha256": "04c124f683e75e4d14374b7a044eeea288dd02a845ccab3ffd670f1c15799ebb"
+    },
+    "sound/enforcer/cent_hover.wav": {
+     "bytes": 103796,
+     "sha256": "a5616566072a5cdc9339e3722d6fee9e652796e9cc8f76e27dbd9aee13986f4e"
+    },
+    "sound/enforcer/death1.wav": {
+     "bytes": 9290,
+     "sha256": "f62aad2ae903808a0caecfc6bdfe13e5fdebb1df14d330c6ac4eda9b577b25bf"
+    },
+    "sound/enforcer/def_idle1.wav": {
+     "bytes": 32676,
+     "sha256": "7b673b07828790504caca013c18bf697fd53b758a3638b949b433cf2d72f03f3"
+    },
+    "sound/enforcer/def_idle2.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/enforcer/def_sight1.wav": {
+     "bytes": 18260,
+     "sha256": "7d57825c28cf4f93189261d76cccab676aeba097920114d5d3f48d7eddaaa1cd"
+    },
+    "sound/enforcer/def_ssg_fire.wav": {
+     "bytes": 14206,
+     "sha256": "494a6d493c3c298c1b9cc0051ce4c1f9e129293ea7ec283b62915c49d8c249c3"
+    },
+    "sound/enforcer/def_ssg_load.wav": {
+     "bytes": 5274,
+     "sha256": "db4f62f8d76a68f2e4d3e7a29a22d3ddc5d6ae9bb296e6e800e937b73b5a4dea"
+    },
+    "sound/enforcer/elim_idle1.wav": {
+     "bytes": 39084,
+     "sha256": "2ccaa3ba4f987d031a22b8048ca23e97900fca9def362ff92943b73a99ed7844"
+    },
+    "sound/enforcer/elim_idle2.wav": {
+     "bytes": 36204,
+     "sha256": "9232028e1a93c409c7000348bfadc269c49a333e8d65d904973efb547c7af805"
+    },
+    "sound/enforcer/elim_idle3.wav": {
+     "bytes": 38222,
+     "sha256": "93034d568db5c304a165c3d89cb03ffe5d97e8157755e944a863697007eb27fc"
+    },
+    "sound/enforcer/elim_pg_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/enforcer/elim_sight1.wav": {
+     "bytes": 31468,
+     "sha256": "2268ee0ad0c77a081b289a550a1dae24b274b2e3f06d156a67beca80df8ee919"
+    },
+    "sound/enforcer/enfire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/enforcer/enfstop.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/enforcer/fum_poisonoff.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/enforcer/fum_poisonon.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/enforcer/idle1.wav": {
+     "bytes": 15810,
+     "sha256": "cec388af73dff076ea3af7c754ef0939f989f3412b0359c0fb668cd91bd4abaf"
+    },
+    "sound/enforcer/pain1.wav": {
+     "bytes": 5478,
+     "sha256": "d8692021777495825974f8406e23c74ed249f9a80a9bc944c79b1722c35f64e0"
+    },
+    "sound/enforcer/pain2.wav": {
+     "bytes": 4580,
+     "sha256": "e48a524482ce67ff94ce00fe4d8a1190aed38e9c7c24cfee3607f0f2827049e6"
+    },
+    "sound/enforcer/pyro_flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/enforcer/pyro_flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 5870,
+     "sha256": "92dc64154602e29e95d40aa68d3544fe21cb21ce24192f1e8ffefc6b5d31b8cc"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 6574,
+     "sha256": "52b1991141ed9452fe6c7ebe219cc544fba443058f179b8eec5a5cbfb9aacf3d"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 6158,
+     "sha256": "d3b9e689b2b43ae74ae14fdb26680d3646d658107664965db97420ae032d74b0"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 5166,
+     "sha256": "815e05c3b14858209fee01316848c117ad89af9f0aab190fc0ca0239367373ac"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/freddie/death.wav": {
+     "bytes": 88244,
+     "sha256": "2e3de0875dd3245a98614829ab848cc1dfc34a95827aa4cfc174884977ecddf0"
+    },
+    "sound/freddie/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/freddie/idle1.wav": {
+     "bytes": 88280,
+     "sha256": "673ac7c26a9be2b1ea37b152ce48442ff40089cc7dc015c014eb42534db2c306"
+    },
+    "sound/freddie/mangle.wav": {
+     "bytes": 48548,
+     "sha256": "ee318d6849ca9dda4569db6009210a6909279bd2ffe9b31543d47134b51c1533"
+    },
+    "sound/freddie/pain.wav": {
+     "bytes": 38640,
+     "sha256": "ffe05b43444a209084c95c166b0776d33f9ba8af15ef998d3ed5c09aa0b03c3d"
+    },
+    "sound/freddie/painshrt.wav": {
+     "bytes": 8868,
+     "sha256": "31e08c51909022a6b0ad7f01f1f8dae196269b8b105e57e555025393cdc278d9"
+    },
+    "sound/freddie/sawstart.wav": {
+     "bytes": 41938,
+     "sha256": "90f83017a7ff5f2bd2824be1e122eab7d8171ab63a9025adf1fc03ee3e7a44aa"
+    },
+    "sound/freddie/sight.wav": {
+     "bytes": 55170,
+     "sha256": "3f73e5b30cef3038102ffa9ab0faf89e71af43ed2ee5a0758319c072c151c123"
+    },
+    "sound/freddie/step.wav": {
+     "bytes": 19898,
+     "sha256": "121818aa6200c770a70c2c02844bbc0351a62f166c31f9d85765896b426f610e"
+    },
+    "sound/freddie/step2.wav": {
+     "bytes": 19870,
+     "sha256": "7e33eb621ee356cbe4affe6218b988f477259dae705d57eea12d7fe10b5d4510"
+    },
+    "sound/freddie/step3.wav": {
+     "bytes": 19898,
+     "sha256": "a005232c4c0608092c7d697c6d24566892b74adfe7566030360c96996bd39357"
+    },
+    "sound/freddie/stfire.wav": {
+     "bytes": 27598,
+     "sha256": "597fa6e0e8c4da4fd85e9e26ecd7f95f3dc242846ec9b962cf2beb324e5a4fdc"
+    },
+    "sound/gargoyle/attack1.wav": {
+     "bytes": 28712,
+     "sha256": "cab70a44f7ec34343a1608ca8c13dd2b501065cade08e94b574f98436aabeadf"
+    },
+    "sound/gargoyle/death1.wav": {
+     "bytes": 41662,
+     "sha256": "07043eb3fcbcc9c8cf53b07c10b349a9f3beb471dc240a6d70d8f2b5a57e85b0"
+    },
+    "sound/gargoyle/death2.wav": {
+     "bytes": 28768,
+     "sha256": "c363613cd476d5099dbdced656244db0d704da5eeb54fe5b880f2202f6f465b2"
+    },
+    "sound/gargoyle/idle1.wav": {
+     "bytes": 72868,
+     "sha256": "90885fa6cae946ecfedec8a150911bcfdad8ef326254e1fb1bf44ca5c5af4eb0"
+    },
+    "sound/gargoyle/pain100.wav": {
+     "bytes": 26510,
+     "sha256": "d53f1e64f4c9f5e13e03cfee2681ef6dff370e95e9dd8668c7c06b79762e7773"
+    },
+    "sound/gargoyle/pain75.wav": {
+     "bytes": 28720,
+     "sha256": "78d5d0f1c5df4e1a565eeda076d5f8b3bb3582e551909b31fa8e36c292903826"
+    },
+    "sound/gargoyle/perch1.wav": {
+     "bytes": 26506,
+     "sha256": "5eab54a566e4c1136c40fbfbd636188a7a9c4aa6b278e51fb965e1761764cbff"
+    },
+    "sound/gargoyle/perch2.wav": {
+     "bytes": 30924,
+     "sha256": "745b5c5f1fd04a73a7581373925aa70cd3f35ab899df5f5fd2c610d07bf95bdd"
+    },
+    "sound/gargoyle/sight1.wav": {
+     "bytes": 35142,
+     "sha256": "1097300e4bca9ef61a7041e7f4ff403fe67c4fc0e687b30892a6bdf35bf45c09"
+    },
+    "sound/gargoyle/swoop1.wav": {
+     "bytes": 21056,
+     "sha256": "ef6b4b672dd984e846294e0be57d81df3abcb521b1f88f6afaf2f5cc2d4e91d4"
+    },
+    "sound/gargoyle/swoop1hit.wav": {
+     "bytes": 11078,
+     "sha256": "6a624e3f46e2c45f5e2d6f42ee18643a17268a6b0df2493fe6ffdba4be0c9057"
+    },
+    "sound/gargoyle/swoop2.wav": {
+     "bytes": 24364,
+     "sha256": "f98d41f9df7244e8f77c435ae4071a4e4595ec7005b7c72e44456fe7baca425e"
+    },
+    "sound/gargoyle/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 22094,
+     "sha256": "142b725ff5515cb438a592288a69e01331b3fd0bbb7311abf1dbaf90f95417ef"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/plasma_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/gaunt/plasma_start.wav": {
+     "bytes": 66270,
+     "sha256": "ad404715612b802a7d4f72f2d14abb47c338ac414af56c19ffc8dc2873f33452"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gaunt/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gibs/gib1.wav": {
+     "bytes": 21292,
+     "sha256": "d8c76f302722e05a4e5fd7c16fc082ac12bf3bbbbf0643891ca3008ad28c7375"
+    },
+    "sound/gibs/gib3.wav": {
+     "bytes": 33256,
+     "sha256": "10a19291ed8af8893b6cdbd80416425b27e5a197d39aa8d0557320752d78cf11"
+    },
+    "sound/gibs/gib5.wav": {
+     "bytes": 15490,
+     "sha256": "2d7603a9fc0c055ed3529bd4dfd511984c71b93f4719b605813eb5139d02c6d9"
+    },
+    "sound/gibs/gibacid.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/gibs/gibchain.wav": {
+     "bytes": 15938,
+     "sha256": "c6b2a37424a51810017bd5ee4764a014329467686f73bb2f48ad2704592176f3"
+    },
+    "sound/gibs/gibheavy.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/gibs/gibheavy1.wav": {
+     "bytes": 11110,
+     "sha256": "0a1313f08fa22e4df8a1beb15ffdb6e7b1906187f63042357e4a43631ef5e93a"
+    },
+    "sound/gibs/gibheavy2.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/gibs/gibhit1.wav": {
+     "bytes": 22150,
+     "sha256": "d2a73e2f9e31b9fefda789e49b17ec9bd18df0335c31f871514a282cf550829a"
+    },
+    "sound/gibs/gibhit2.wav": {
+     "bytes": 22150,
+     "sha256": "210477e93743dc6c0541bc158032d46251c6aeff551efcf515d6e7db87bb8a53"
+    },
+    "sound/gibs/gibhit3.wav": {
+     "bytes": 22150,
+     "sha256": "40db6dbb033d59dd458e5fb6102dba6d6ecf5bc5739d9fc35a3be68cc977da53"
+    },
+    "sound/gibs/gibhit4.wav": {
+     "bytes": 22150,
+     "sha256": "0bd1e29d68e41cbf2d753730df678918a38fc886b4690991fbd7e8fb3e13e055"
+    },
+    "sound/gibs/gibhit5.wav": {
+     "bytes": 22150,
+     "sha256": "4adf7a8249ee913aeb9e91120b1f6b9e529b1e1a3eadb75185589cf7c3ff910e"
+    },
+    "sound/gibs/gibmetal1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/gibs/gibmetal3.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/gibs/gibmetal5.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/gibs/gibmetala.wav": {
+     "bytes": 18474,
+     "sha256": "2c057e772307ef647b4313975cec75bacfd522bbc5dd27ae83a867065562635f"
+    },
+    "sound/gibs/gibmetalb.wav": {
+     "bytes": 30756,
+     "sha256": "fbcfa9e6cd5aa68c6fffd6699c8dc87ec3707a4281358f229afce57f3278c800"
+    },
+    "sound/gibs/gibstone1.wav": {
+     "bytes": 52956,
+     "sha256": "962dd735a1823905243700eb3f4e0caacc1be71a1f367ccad4f21dd82b4e99e1"
+    },
+    "sound/gibs/gibstone2.wav": {
+     "bytes": 22104,
+     "sha256": "04f070fa9873f382ded03a5139ce2c7da2013d8ef9221a8d10a64c3b5f912591"
+    },
+    "sound/gibs/gibstone3.wav": {
+     "bytes": 35344,
+     "sha256": "16262de5a0b703468f2c3f1e49ffa0c225eb81b89984b468b7bc95948ed890c0"
+    },
+    "sound/gibs/gibstone4.wav": {
+     "bytes": 8832,
+     "sha256": "75179beed6fb6f581944f5e7db153bea4d9ecc65899628468efd48710a392013"
+    },
+    "sound/gibs/gibstone5.wav": {
+     "bytes": 22130,
+     "sha256": "0aaff5c363ac29a9b50d83b4b04fcd7264c614a93d0c9bc7941c9704a6b4b499"
+    },
+    "sound/gibs/gibwood.wav": {
+     "bytes": 61708,
+     "sha256": "d9b53ab4d53f1265dd2083d341cd92f19729694946ff00ad15fa6d96965e63e8"
+    },
+    "sound/gibs/stonedeath.wav": {
+     "bytes": 76750,
+     "sha256": "26d0eb67357d292043fd494b1646f8ce005ba692d98610429bceedfc831d2325"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 374654,
+     "sha256": "de356a2581884e9008ef798775f82049c465aec242cad0f6024b510d33e11764"
+    },
+    "sound/golem/groundslam.wav": {
+     "bytes": 132412,
+     "sha256": "f557ad378642a77a2f31433db5fe9315cf33f5fc350018e2bd26d32359ec8617"
+    },
+    "sound/golem/iceshard1.wav": {
+     "bytes": 53022,
+     "sha256": "41e523122aa4168298b247748bbe4201928582e974e673a83e717ea33f8656a8"
+    },
+    "sound/golem/iceshard2.wav": {
+     "bytes": 53012,
+     "sha256": "4b4e457f75d051a7aa3525bf82338f8b6d2f9460583c09e63d82b202cb11d03f"
+    },
+    "sound/golem/iceshard3.wav": {
+     "bytes": 53038,
+     "sha256": "8134080a7c6478463f9ea8c368eb6e0563dacb35bb3941b1e08e2cf0763d83ab"
+    },
+    "sound/golem/iceshard_impact.wav": {
+     "bytes": 176470,
+     "sha256": "ac850565ac7cfaa8ec2e55f535603aaf131605b9399f08f1b17f7c08920f7bda"
+    },
+    "sound/golem/icestorm.wav": {
+     "bytes": 61802,
+     "sha256": "2e8129333bc1a677591f9c4838a5f8c8e9ff63050fe6a47f212380f2497ae706"
+    },
+    "sound/golem/idle1a.wav": {
+     "bytes": 88238,
+     "sha256": "d238c43b6e83c044ba70352ed9362e50d68caf606f500c7d79f5c03d1e6a432e"
+    },
+    "sound/golem/idle1b.wav": {
+     "bytes": 88242,
+     "sha256": "93e3ca1ec51345da6e06a53f71bcd1271c911c9a6272246de9f58bef93c904dc"
+    },
+    "sound/golem/idle2a.wav": {
+     "bytes": 44166,
+     "sha256": "d0ceeb0ee1681127f9f426ccaa0ddb75c6ef32594618c972536871544e8d5748"
+    },
+    "sound/golem/idle2b.wav": {
+     "bytes": 44178,
+     "sha256": "94fb43b50445dbe7a8fe6cc06ea745b729cf5bf61c33cc543123f751e4a9cdf7"
+    },
+    "sound/golem/melee_pound.wav": {
+     "bytes": 17672,
+     "sha256": "23ff4f485f3adb3ba5227ba59824e226e91005846d2879077ffbe04141bab78b"
+    },
+    "sound/golem/melee_punch.wav": {
+     "bytes": 17702,
+     "sha256": "21cbd6ca5b9c8d95a43c39b360b12ee8033dca1aaf11d4c1164d4bc9ce83b7d3"
+    },
+    "sound/golem/melee_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/golem/pain1.wav": {
+     "bytes": 27948,
+     "sha256": "388150975b33e271db5402f502c6a36899731ec85cb9b16cdcc4b427b206a3f2"
+    },
+    "sound/golem/pain2.wav": {
+     "bytes": 32940,
+     "sha256": "b3908c02406bcb8c379f345f80a825aa270a54ae02fe0356e02330620d9cf437"
+    },
+    "sound/golem/rockstorm.wav": {
+     "bytes": 264676,
+     "sha256": "c57be8195f675560b879c3fc4e23c49f021d0c45aa81f2a84b74303f111d7c7a"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 76762,
+     "sha256": "965d1107adbc9a068d1d2af16fc783855833569dcc3a6030fa920019c30a4083"
+    },
+    "sound/golem/wakestatue.wav": {
+     "bytes": 250454,
+     "sha256": "630505eb8c9c84511f39d2e77096cafcbab044f73569934cda127a4b6f37f138"
+    },
+    "sound/items/airtank.wav": {
+     "bytes": 22160,
+     "sha256": "9b8f5c5deb886800c91d46809ecf82fb114467eb8a395b9c980d47c6b35f6b17"
+    },
+    "sound/items/airtank2.wav": {
+     "bytes": 66286,
+     "sha256": "76156f8f89e2bedbfaee9ee3340adb6bfe8639f242051178c2655e04cdab5198"
+    },
+    "sound/items/airtank3.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/items/airtank3out.wav": {
+     "bytes": 176494,
+     "sha256": "672a866c27c64f7eda1e05775cea6b4373c289c39fd423a519d39198d10a9c89"
+    },
+    "sound/items/armor1.wav": {
+     "bytes": 15122,
+     "sha256": "54c25fca46991ea142e9fdf5309e690ce3ff977df89aa7d14a8938ff386a237e"
+    },
+    "sound/items/backpack_ammo.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/backpack_armour.wav": {
+     "bytes": 20612,
+     "sha256": "438a08f094f47fac5f0b959fdde0f941be50bac12abdaa159f6f727975021aec"
+    },
+    "sound/items/blastbelt1.wav": {
+     "bytes": 43442,
+     "sha256": "a85924de58caed8e32d2849838afa0f248ec26eb295c9fc82eff818bc292f28b"
+    },
+    "sound/items/blastbelt2.wav": {
+     "bytes": 74978,
+     "sha256": "e4747a55ed0d66b6ce3bfe4ad0a4cfa75308657a155ebd9396ada78e0fd46bac"
+    },
+    "sound/items/blastbelt3.wav": {
+     "bytes": 49028,
+     "sha256": "4a2f6e7f65cbbc19c4bd5facf821017f7e60c41b9c164575de5255a40de2ba53"
+    },
+    "sound/items/health0.wav": {
+     "bytes": 8718,
+     "sha256": "cd277cc4fc98dbf9d5b0ba3ab784e468ba77a5aec78fe6086bd125512b6d1dbc"
+    },
+    "sound/items/health1.wav": {
+     "bytes": 13316,
+     "sha256": "ed9a43a3506afd8073e0d5225f3fa43116bb922b84d2216c2053d58f597544e6"
+    },
+    "sound/items/itembk2.wav": {
+     "bytes": 18884,
+     "sha256": "2b5601380dcc36753327eea905d15d2e0fd0f016d9559a2f8924f6f34b8045d5"
+    },
+    "sound/items/jumpboots1.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jumpboots2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/jumpboots3a.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jumpboots3b.wav": {
+     "bytes": 85590,
+     "sha256": "8eda0e57fdadfb61a414b4dae8c567a2bf10d9dabc44db7cf5589f00bba16250"
+    },
+    "sound/items/jumpboots3c.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/lavashield1.wav": {
+     "bytes": 30884,
+     "sha256": "e79050c462eeefcdbe6be0d79ff3042e80e5654c4060cf5377eee366cb4d6b43"
+    },
+    "sound/items/lavashield2.wav": {
+     "bytes": 49190,
+     "sha256": "17e93e45d150704bab8debd86ee8e9c600e9b08fefa70b16e1fe712dfdbd0c23"
+    },
+    "sound/items/lavashield3.wav": {
+     "bytes": 22094,
+     "sha256": "d94735d5df3c5850d2308972cb2495a9c9ec87e57c434c3ff0c160da659b051f"
+    },
+    "sound/items/nailp.wav": {
+     "bytes": 97394,
+     "sha256": "eb786846675412ba7bfb892fa0d5d356b67ec83ad3a551de8b423a874c3608d1"
+    },
+    "sound/items/nailp2.wav": {
+     "bytes": 132454,
+     "sha256": "2a01a3beb92154c7275c3c2ad39f648f8ecad7fd32ef7264d7404b917e0147dc"
+    },
+    "sound/items/nailp3.wav": {
+     "bytes": 45268,
+     "sha256": "0ea4502763119419b226d830b5b0147d6cfbe78996749e330d652d5b538dbb7b"
+    },
+    "sound/items/protect.wav": {
+     "bytes": 44176,
+     "sha256": "1bc5895a71225e8a385ebc900952d3b41f3d9541eefb8affcf15804ca96e5ab4"
+    },
+    "sound/items/protect2.wav": {
+     "bytes": 66286,
+     "sha256": "80b2a47fb1158f252e888bc692d352f224170c2d18177163dfea5c8110688e65"
+    },
+    "sound/items/protect3.wav": {
+     "bytes": 44176,
+     "sha256": "4aab23bd1683c733c5c85e7d55a93b27746860bd3c1a707e8c5a6439e35b5fd2"
+    },
+    "sound/items/r_item1.wav": {
+     "bytes": 12272,
+     "sha256": "3b569e1a8210563a64045dc1629a243b382c49cf24722cbddbdae348d5fa75d7"
+    },
+    "sound/items/r_item2.wav": {
+     "bytes": 14462,
+     "sha256": "088bb9013c0d2201997d3c566b95cc91f0419ba0bc89173c9e532659ccb4e886"
+    },
+    "sound/items/sharp.wav": {
+     "bytes": 100592,
+     "sha256": "c86d353daa830fffcf5ded77b73d6b8871d15a47a857a977ebaf7cbddb6cb587"
+    },
+    "sound/items/sharp2.wav": {
+     "bytes": 264608,
+     "sha256": "95d9e49c2c69d72751bd6a356a471d3f7055cedb8827184fe6cd7b5bea863ec9"
+    },
+    "sound/items/sharp3.wav": {
+     "bytes": 46584,
+     "sha256": "6318f7079e79929ff0439a570c5f806ec9c2cce8a8447eddb666dee0c2211336"
+    },
+    "sound/items/sharpa.wav": {
+     "bytes": 97394,
+     "sha256": "cd0d8dc72f736b38ab9c4a473798f0dd32e2074c14a310892c3fdf6515ff53be"
+    },
+    "sound/items/sharpa2.wav": {
+     "bytes": 132454,
+     "sha256": "2545c58a3682c1e8459389dc728a39fe0d76e6ce14a9c816a4826e327ab9bddc"
+    },
+    "sound/items/sharpa3.wav": {
+     "bytes": 45268,
+     "sha256": "083cc822d4cd6819d2dfd6e125ea4ca8ef3230c1ac1c4a5f5e3fe22e4d3d36d9"
+    },
+    "sound/items/suit.wav": {
+     "bytes": 31568,
+     "sha256": "a9b13127acef0c8e617cf5e510d5654227db9049a2b06b7544eb9e3030146ee7"
+    },
+    "sound/items/suit2.wav": {
+     "bytes": 66368,
+     "sha256": "34f0ba1b415ab62f2eb3b7a59bda6fe6fbbf3e519c7d2fab29a42ce29eb073c3"
+    },
+    "sound/jim/death1.wav": {
+     "bytes": 14348,
+     "sha256": "7f97f27dfda78f9fe6fc5265e512b651e57ae466752d56cfe0dccd6d08478ed8"
+    },
+    "sound/jim/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/jim/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/jim/gunidle.wav": {
+     "bytes": 13260,
+     "sha256": "46441335fe896cb993368bb12cedc1ddd4886b5933298bb6a0d6b7ba430cdfe5"
+    },
+    "sound/jim/gunidle2.wav": {
+     "bytes": 48540,
+     "sha256": "08d3577b66ab4b4c65ae7b01e4590e8d985605cc51a939bae0b43967472208c6"
+    },
+    "sound/jim/idle1.wav": {
+     "bytes": 44460,
+     "sha256": "7bc2df6cdd0f9a06cc441c656664edb3c686ab5803dab70948cc27bbba968494"
+    },
+    "sound/jim/idle1r.wav": {
+     "bytes": 44460,
+     "sha256": "7549a540858b1a829ac010930b848474c2f2200b910371368c99e35641f24644"
+    },
+    "sound/jim/idle2.wav": {
+     "bytes": 44460,
+     "sha256": "90d55e9ac8db5523255ec80384abd2508f005890f4fb66a654f4d783435afb4d"
+    },
+    "sound/jim/idle3.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/jim/laser_load.wav": {
+     "bytes": 36040,
+     "sha256": "5f39b9f60c5de5c9c3ac25a5149f1fef557e66c09d7d1a760ed6770082c5a914"
+    },
+    "sound/jim/pain1.wav": {
+     "bytes": 27006,
+     "sha256": "27522940f1db4eb098388e049a63d3a608e4beb2fa248d1232ae45d38a944e85"
+    },
+    "sound/jim/pain2.wav": {
+     "bytes": 30850,
+     "sha256": "6d1988d75f430287ad3e8766e9aafa8c8c85e2f2ebf53395b0fc2eb0fb26d788"
+    },
+    "sound/jim/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/jim/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/jim/rocket_load.wav": {
+     "bytes": 23416,
+     "sha256": "e3820aad09060be13927e56fc0e21112c22161b50b7d5be9cf59b98f84c5a231"
+    },
+    "sound/jim/sight1.wav": {
+     "bytes": 14892,
+     "sha256": "1a0db2b8c8d763f9aae09913d1cd3548fa0e30eb03949e24ef511a70acfda303"
+    },
+    "sound/judge/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/judge/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/judge/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/judge/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/judge/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/judge/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/judge/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/judge/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/judge/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/judge/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/judge/smash_ground.wav": {
+     "bytes": 66250,
+     "sha256": "f29f17426d2bd961d4f166e25fb951c8e12a37314bbc49722f0ae34c2beae233"
+    },
+    "sound/judge/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/judge/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/judge/smash_roar.wav": {
+     "bytes": 61784,
+     "sha256": "24b26a6b00a8731693bafd8ef67a5f0e2a4bbad20e722ec14f6fefd13047dc78"
+    },
+    "sound/judge/summon.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/judge/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/judge/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/justice/death1.wav": {
+     "bytes": 61784,
+     "sha256": "39587bdb48642373b1d34b26fc79fd8f23ea5209137594268ea9ea8fda3e4b67"
+    },
+    "sound/justice/flame_attack.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/justice/flame_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/justice/flame_fire.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/idle1.wav": {
+     "bytes": 9998,
+     "sha256": "a98b3238c681349a984cac688288818d713339c551f6af4ff89f5f0fcda109b5"
+    },
+    "sound/justice/leap1.wav": {
+     "bytes": 96044,
+     "sha256": "6ba3d20cb966702af9852a6664d6ac6450c25ed4d05c1b69b8c9bea05509c612"
+    },
+    "sound/justice/magic_attack.wav": {
+     "bytes": 13274,
+     "sha256": "4e79789bbcd8bbf9f6c57ec716fb5cfa6517dc584f105cebf8a958fb397e79d1"
+    },
+    "sound/justice/magic_fire.wav": {
+     "bytes": 15070,
+     "sha256": "862bd21aa54cb05efe1dcfd7ae4fc9eebbaac82d426d12e419708b350e391141"
+    },
+    "sound/justice/magic_hit.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/justice/pain1.wav": {
+     "bytes": 22126,
+     "sha256": "ac02c92a9ab892c4d7b2ed68f37dba7d6f737b8e53ae92549faa50779491308d"
+    },
+    "sound/justice/sight1.wav": {
+     "bytes": 53058,
+     "sha256": "bb7626b220ef234bd886e4b11f12e2f8d6256a242f193c174b48059e647768d2"
+    },
+    "sound/justice/smash_hit.wav": {
+     "bytes": 17260,
+     "sha256": "5e3ba11e8e423597f97726335a62855ad2700c84713f4d2838663a8a6c942324"
+    },
+    "sound/justice/smash_hitheavy.wav": {
+     "bytes": 11100,
+     "sha256": "99246db4f002f21f97fe6d7806819b88f0f2ead2cc90cff32483b0b263240fb8"
+    },
+    "sound/justice/sword_draw.wav": {
+     "bytes": 20992,
+     "sha256": "784bde923b84db8d94be07957f1baef7d37f374f281913b49e0c4302560abedc"
+    },
+    "sound/justice/sword_sheath.wav": {
+     "bytes": 9966,
+     "sha256": "3fb1bc0812fd25eca60e398e57a547222eaca0d846f41924b0baa89e0ae7f6c4"
+    },
+    "sound/lostsoul/bite.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/lostsoul/charge.wav": {
+     "bytes": 114682,
+     "sha256": "327cf4f521c92b3af6ff7cf50d1bfa6d101d06dee52350f123473e56e72626e3"
+    },
+    "sound/lostsoul/death.wav": {
+     "bytes": 151916,
+     "sha256": "08b6f8d3a50465e7deb346bc8902605bfc8bafc134cfac38aeb1d9fa5d1d2863"
+    },
+    "sound/lostsoul/idle1.wav": {
+     "bytes": 132332,
+     "sha256": "aac9bd66ea75d4778a20ba07b248baaa4f446beb60e5b5be76d04be36df1a1db"
+    },
+    "sound/lostsoul/idle2.wav": {
+     "bytes": 132332,
+     "sha256": "963c18a04a41d49ced0c820fd6ec51c885e7828a2a09bd47c15227555b6d4ada"
+    },
+    "sound/lostsoul/pain1.wav": {
+     "bytes": 14948,
+     "sha256": "baccaed4fd7c4e504214eb7241d3e8ea3e187739a781c30de57c8b5af6dbe6d0"
+    },
+    "sound/markie/dronebell1.wav": {
+     "bytes": 410346,
+     "sha256": "c7b65065ba9279c8131a83b642523e4193b8611f7b14430af2d52c831082340a"
+    },
+    "sound/markie/dronehum1.wav": {
+     "bytes": 156754,
+     "sha256": "9542c51342398a1281476da03114adb01012367dac58d2a08b50c684a1a98093"
+    },
+    "sound/markie/dronehum2.wav": {
+     "bytes": 183654,
+     "sha256": "03545ae0f88b788e69e09c0aae2cccfa727a2609ef224c7d1d3451f0e6172709"
+    },
+    "sound/markie/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/markie/dronespace1.wav": {
+     "bytes": 151808,
+     "sha256": "2c9c7f38a2023d3452a48db3e5f98d11fa218315991d907f8e3fa95d128d4f76"
+    },
+    "sound/markie/dronewind1.wav": {
+     "bytes": 110328,
+     "sha256": "f65fd70b6c398e1a17975eff7d92bde89ac17bc8d5cf0e9c6dcb17934311e3a6"
+    },
+    "sound/markie/morte1.wav": {
+     "bytes": 529280,
+     "sha256": "c338e404901bbf094c5946e50cbd922580c077dc3f3e5369ab962cb07a70d855"
+    },
+    "sound/markie/morte2.wav": {
+     "bytes": 529280,
+     "sha256": "58e598c9da2ced85f6973eb897f578e0f29a13fa0eaefebfe14c8942a33c77ed"
+    },
+    "sound/markie/ritual1.wav": {
+     "bytes": 273266,
+     "sha256": "fe9b4b53f899a88321707330bb2454442d74e5098328e35549b9f0a8ff840cba"
+    },
+    "sound/markie/ritual2.wav": {
+     "bytes": 273246,
+     "sha256": "d38ee880af55413aa7c180b8c1935df71177502081ee1c376c37b572af3d9352"
+    },
+    "sound/markie/stingwhisper1.wav": {
+     "bytes": 132380,
+     "sha256": "fc6eebd33c0c99c0f4537a9727698181acb4d23d077f06b3da1ebbcb104c870c"
+    },
+    "sound/markie/stingwhisper2.wav": {
+     "bytes": 132380,
+     "sha256": "ae7319c28e0a4e492623b7ddb48634978da043c16d4450f86b8edf7e60fa283c"
+    },
+    "sound/markie/stingwhisper3.wav": {
+     "bytes": 151672,
+     "sha256": "e5dd9dcfd44dedf7b0cd4a0a94a519a0bbd84477e54293548a37aa16d3f1e428"
+    },
+    "sound/markie/watercreek1.wav": {
+     "bytes": 184884,
+     "sha256": "f0c3ac87d6f073cea0d1a9218c4e53327be7af07a8c8be00cd73f254f6c0ba03"
+    },
+    "sound/minotaur/attack1end.wav": {
+     "bytes": 19936,
+     "sha256": "eceb47163a0f495037bd067fcfe852dbd0cf8cc7c376c536f5e4bda8569d3f5c"
+    },
+    "sound/minotaur/attack1expl.wav": {
+     "bytes": 15554,
+     "sha256": "a8344e4036b9377a6c8e3d69c2e86c7f5fc157fb0034d6e0e190d5b9fc444ca7"
+    },
+    "sound/minotaur/attack1long.wav": {
+     "bytes": 42000,
+     "sha256": "bb901880112ff159b380b8bfaf19fc511f4b1217f08d55a05276a3500f6cd4c7"
+    },
+    "sound/minotaur/attack1start.wav": {
+     "bytes": 19944,
+     "sha256": "33dafc2b20be70d6da51321f9910a392535e6a31cbbd3c8d0d880307a18adb3a"
+    },
+    "sound/minotaur/bolt_fire.wav": {
+     "bytes": 17738,
+     "sha256": "2f8ea56413270eef58b56ae4c4f7af2506ee89fda82aab90c0426f4560baa80a"
+    },
+    "sound/minotaur/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/minotaur/idle1.wav": {
+     "bytes": 17686,
+     "sha256": "d213130ad4b58b5b55553da46d358526411916210e90caf082c5a93b499e2f81"
+    },
+    "sound/minotaur/idle1com.wav": {
+     "bytes": 15564,
+     "sha256": "0f8054eb2c16284a098f680dcdc65f5a4b8b971f8cceaca6adebe8c377d6117f"
+    },
+    "sound/minotaur/idle2.wav": {
+     "bytes": 15470,
+     "sha256": "390c82c79532878751bcddca11aa37dbd86018757860e46d0c950a09fee347d9"
+    },
+    "sound/minotaur/idle2com.wav": {
+     "bytes": 17764,
+     "sha256": "8369884de2f4f144b9e323f11e95f47723834b529b62100c908fef5e74391a93"
+    },
+    "sound/minotaur/jump1.wav": {
+     "bytes": 22160,
+     "sha256": "1aa935c4c76818dbe7faed7aee0d9acb9e98ad553a747bf00b83b811d141e886"
+    },
+    "sound/minotaur/pain1.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/minotaur/pain2.wav": {
+     "bytes": 41488,
+     "sha256": "bc9ffeb193379c6738ad2897ab582aa92e278a11d7f1fbb77563ca367987ff76"
+    },
+    "sound/minotaur/sight1.wav": {
+     "bytes": 48610,
+     "sha256": "8d0a5c1a31e525416430f8d45b8482b091d3bb9f6030ac2656bdeb231ddab5e9"
+    },
+    "sound/minotaur/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/minotaur/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    },
+    "sound/minotaur/strike1.wav": {
+     "bytes": 11142,
+     "sha256": "69b1419eed136c384deac99d31827825d3d57fc965ba80604faf9de3e85fd9b8"
+    },
+    "sound/minotaur/strike2.wav": {
+     "bytes": 11142,
+     "sha256": "ab12dc8ab3c9dc603e2ecd58a99beb9c1f551fb79eb6124bdba493efe7595a92"
+    },
+    "sound/minotaur/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 19940,
+     "sha256": "0798d1a1122171f06fd6b92e3f91881725c05f40e1eeb3494a5a1a1aa8a86e58"
+    },
+    "sound/misc/drip1.wav": {
+     "bytes": 12172,
+     "sha256": "9499c277eab2210ba491b61263b71410e5e8f4b2a68403ec6eb81bef687da04a"
+    },
+    "sound/misc/drip2.wav": {
+     "bytes": 15596,
+     "sha256": "410c25c5c459362849c7d3d0ad736e006b65a949e77c094fe248e803b357d5e0"
+    },
+    "sound/misc/drip3.wav": {
+     "bytes": 15164,
+     "sha256": "9ddf50265efafde7736fb7d03419988caab691245b32d986549ef6d643d2768c"
+    },
+    "sound/misc/flies1.wav": {
+     "bytes": 44168,
+     "sha256": "ca5cf0a4d661bf7440cd81dcd45ad7118c54c8ae58672755ee958ec6e50f7152"
+    },
+    "sound/misc/flies2.wav": {
+     "bytes": 44166,
+     "sha256": "09e6d74986b0f0ec9503d9e111f8d1436d7d6c5c4c0c87ec7808e3fca5b964b1"
+    },
+    "sound/misc/flies3.wav": {
+     "bytes": 44182,
+     "sha256": "2b5fb337ba88bd25e10c86bb6355723aea160b0ef6a6d43b30cbbd446444ed8e"
+    },
+    "sound/misc/gibf_fire1.wav": {
+     "bytes": 14376,
+     "sha256": "804f8524135d058d3a635e6567e3369b8b9ef2ecc808bf6e216c4d65609b86a3"
+    },
+    "sound/misc/gibf_fire2.wav": {
+     "bytes": 25842,
+     "sha256": "354b551ac38a19370126f67e3975ab795953bd7beb2c597f0a01a0de6286b7c1"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/laseron.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/misc/poweroff.wav": {
+     "bytes": 88310,
+     "sha256": "8c1c8b8722e32e7a6727bf41d7d54d1534186e83df4a7093bcd5f9e3bb3dcc84"
+    },
+    "sound/misc/poweron.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/misc/rumbleloop.wav": {
+     "bytes": 106060,
+     "sha256": "fafcaa92b4a2174045e3826885d14e434a409bf559d1a1d519c4d50ec8939789"
+    },
+    "sound/misc/rumbleoff.wav": {
+     "bytes": 105990,
+     "sha256": "46728daf18b142575d50049188030a153c0e3e994dc83ea375c43ba6da171b3c"
+    },
+    "sound/misc/secret3.wav": {
+     "bytes": 302444,
+     "sha256": "75682a08b790af46c2b9f746e5772999ba1de333b567832f4a3a8414c6a0185a"
+    },
+    "sound/misc/spaceship_fadein.wav": {
+     "bytes": 231712,
+     "sha256": "d6c905eb002532087273eadb5a577db443068532795fd509571179a354c56a9f"
+    },
+    "sound/misc/spaceship_fadeout.wav": {
+     "bytes": 495982,
+     "sha256": "9e5286b29adeb9cf7b3af489bb2ea539c8eed7b26a28ec1f34cd5f78c33e521c"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 13270,
+     "sha256": "14d74e6c01df6db6f92b8684527b31a7544de8d4dd9d123ebae554989e76facc"
+    },
+    "sound/misc/torchoff.wav": {
+     "bytes": 54160,
+     "sha256": "d49cf5f2100d9b5afbf76a662019a9e3a66fcd5fb40c2b2600ceab107227cbf3"
+    },
+    "sound/misc/torchon1.wav": {
+     "bytes": 88680,
+     "sha256": "ecb211c777393fe3c7012bf0a35cc157af94ccb4742cac3ca7ab6daa5546a4ac"
+    },
+    "sound/misc/torchon2.wav": {
+     "bytes": 84764,
+     "sha256": "b7d885df1c70b226a77a3cc8842565fa9ebf51561158daec4b12e9629a515986"
+    },
+    "sound/misc/torchon3.wav": {
+     "bytes": 97484,
+     "sha256": "25058a3354df07a90b8660640682f7091fa40da6f8abf178c7de71d547a8b0c1"
+    },
+    "sound/nour/attack1.wav": {
+     "bytes": 50794,
+     "sha256": "7f22a1569d59bcd406efd7828ed605d71bfbc8cea01606eedb78d33037655f77"
+    },
+    "sound/nour/attack2.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/nour/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/nour/death.wav": {
+     "bytes": 39772,
+     "sha256": "2e2d15b95fc35738108d83a2b5aefded93772134d2a8124d1b937b6bfcfd74c5"
+    },
+    "sound/nour/elec_arch1.wav": {
+     "bytes": 88278,
+     "sha256": "7f7c61e64dee8e52a8dc6e2626d0eb2bab3be21ed141520ead6c4d0606b79873"
+    },
+    "sound/nour/elec_arch2.wav": {
+     "bytes": 88260,
+     "sha256": "289afa99709c867479a7a59ddcd35854d7ad8dcfe3fa67e61642e7b011cae7ad"
+    },
+    "sound/nour/explode2.wav": {
+     "bytes": 22168,
+     "sha256": "654a50eb01d1c6c64bb8df4b85669448cc08b580ffc44616da854bd3cb339ea1"
+    },
+    "sound/nour/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/nour/idle1.wav": {
+     "bytes": 24332,
+     "sha256": "c77ef8ce85720e3bf0ea97937992b5aa7cc6b63149c951e71b4d3ead14fc21af"
+    },
+    "sound/nour/idle2.wav": {
+     "bytes": 44176,
+     "sha256": "e87bd537a35c005b06ffd28f66adde24d52af338d3956d4fab455d682e78eec9"
+    },
+    "sound/nour/implode_death.wav": {
+     "bytes": 35324,
+     "sha256": "9c46001ee080026931c978b011cdd645e04941ea834bc50c22ee2fb633a6cac1"
+    },
+    "sound/nour/pain.wav": {
+     "bytes": 8686,
+     "sha256": "073044c582c2de6f336130aeb9503fa6edf1da4eed216a4b407b2cd18d5f9995"
+    },
+    "sound/nour/projbomb_burn.wav": {
+     "bytes": 26518,
+     "sha256": "a3d05a8fdc5d1d3561c315285f8204321aec34043a20045a4b6670b48eb6ad8d"
+    },
+    "sound/nour/reveal.wav": {
+     "bytes": 39780,
+     "sha256": "6dd892d207fa31eb93c5a033ab44bba4952b3aed892aa409e6a49e2059381cdb"
+    },
+    "sound/nour/sight.wav": {
+     "bytes": 48612,
+     "sha256": "252c0bf76b928f7fe998f82bf148816e88cdc24f812bd8c8d3a591c1c4ec3d7d"
+    },
+    "sound/nour/sight2.wav": {
+     "bytes": 48612,
+     "sha256": "18b8e9450c00d6a9308adffa2046e747b8ed7bb5547f868ed146cca75b260b87"
+    },
+    "sound/ogre/ham_hit.wav": {
+     "bytes": 52014,
+     "sha256": "20f7ec214fdf8a342ac8c3be7d3ed04c7b7b3479f9c74138a8a052ba7674ee46"
+    },
+    "sound/ogre/ham_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/ogre/ham_wave.wav": {
+     "bytes": 132316,
+     "sha256": "d957285dc74a4e067f600465112ed41d69d14554f8e87ad6b0372b9ca8af4b25"
+    },
+    "sound/ogre/nail_fire.wav": {
+     "bytes": 26504,
+     "sha256": "80263cd2de86b9dcfd054782aab6eb4d939f60e6fe5a881c8ef5800b0f76ad66"
+    },
+    "sound/ogre/ogidle.wav": {
+     "bytes": 25706,
+     "sha256": "54915681452970c56f1ef405b182e90fa7ee3c4d4d80e32583a38abc7c1db713"
+    },
+    "sound/ogre/ogidle2.wav": {
+     "bytes": 22426,
+     "sha256": "2ed241e576a709285f7ea8a9671f6032da5a8db96e094e9007f60617cad491fa"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 28742,
+     "sha256": "738af1bbf36d5b3287c45e7815d87ea7f5c1a0487c804de7272091fdbb7faac2"
+    },
+    "sound/ogre/ogpull.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/ogre/ogrefish_flappy.wav": {
+     "bytes": 51262,
+     "sha256": "79a9eafef5edf45851a1c391e301c6f515536922c297b904e148b337e7f54a08"
+    },
+    "sound/ogre/ogrefish_idle.wav": {
+     "bytes": 27552,
+     "sha256": "5abf50694e67aa1e805a598a464d5d3b1f0625677a2873761cae139c4b21d524"
+    },
+    "sound/ogre/ogrefish_in.wav": {
+     "bytes": 6678,
+     "sha256": "dd5fc9aecb5b6933252739047aa5d3f775797ad7bf6ddb5652ffd26ea9ead3e2"
+    },
+    "sound/ogre/ogrefish_out.wav": {
+     "bytes": 15502,
+     "sha256": "2610f025057ee0a6682b574567b7400f83ba9f6665b9f7f3b9e76cff75b8be53"
+    },
+    "sound/player/h2ojump.wav": {
+     "bytes": 22126,
+     "sha256": "dd2d3629970814e719be6c9650a497edd219f31fb1554927b9770a1b0dfcdc60"
+    },
+    "sound/player/heartbeat.wav": {
+     "bytes": 70640,
+     "sha256": "a68fd895a3212f967a4686e94df2749fa3f58392ab2228aa880697e25b548147"
+    },
+    "sound/player/inh2o.wav": {
+     "bytes": 22126,
+     "sha256": "4c4d55502ab63ddbc9beb64b0459ad4d7a2992fe41e76144d3bbd3333af4a570"
+    },
+    "sound/player/ladmetal1.wav": {
+     "bytes": 95952,
+     "sha256": "6cd990509a965ff251ffb33ff7c22b6eb708cec5f7b7b82e2196b1fb3d3cb1c2"
+    },
+    "sound/player/ladmetal2.wav": {
+     "bytes": 96116,
+     "sha256": "a477162fc355efc88568b9e18d668b7b0e8e99af460b88c755bd1ed57da35006"
+    },
+    "sound/player/ladmetal3.wav": {
+     "bytes": 96008,
+     "sha256": "20ea0c70bcc3c951bb067cb65b938c63267bba0a1eda3a335df525dc9432d234"
+    },
+    "sound/player/ladmetal4.wav": {
+     "bytes": 96126,
+     "sha256": "d2a6bede3a9c499d01a0b0b9620d4bd1935f9477ecb9c59a8d73f3133699ea45"
+    },
+    "sound/player/ladrope1.wav": {
+     "bytes": 70706,
+     "sha256": "6713acc390790d4723df21b0702796958132af34ce5ec0a85fca5edc36ccd728"
+    },
+    "sound/player/ladrope2.wav": {
+     "bytes": 70792,
+     "sha256": "384b8c3ad3749fa9963ff3210d7cb312858771cca85082b6a8ad13179ad92da3"
+    },
+    "sound/player/ladrope3.wav": {
+     "bytes": 70760,
+     "sha256": "ed397a0308ecacd0ba9774f082aec5e681bcffb219c8d9127b7d7606a6fbb02d"
+    },
+    "sound/player/ladrope4.wav": {
+     "bytes": 70758,
+     "sha256": "e1a4327f1c458f408abd6ff713d11e0aee8daaa9c876002b693135d8e64b68fe"
+    },
+    "sound/player/ladwood1.wav": {
+     "bytes": 48084,
+     "sha256": "bd68f3af0f6cd429d08aa44168e14435ed9e2e2ec0d6a038f83e2dd683cb7e74"
+    },
+    "sound/player/ladwood2.wav": {
+     "bytes": 48086,
+     "sha256": "bb687ec2183f460ac4240acfcd2f3da2f8bd9da043ba705f6e32c3439e4845b9"
+    },
+    "sound/player/ladwood3.wav": {
+     "bytes": 48088,
+     "sha256": "7271136b6398602c7b4bdbd610a37b5a82a66195842030a21de08a89808b4026"
+    },
+    "sound/player/ladwood4.wav": {
+     "bytes": 48086,
+     "sha256": "3b7580b31dee8a86e636c5fd17d92566d147417f98764d51097ad53ff0d19d29"
+    },
+    "sound/pushable/brick_m1.wav": {
+     "bytes": 44144,
+     "sha256": "7572ac5d03045552dfee673293722da8c663d072cc7b57e44adb2e3884ea33c9"
+    },
+    "sound/pushable/brick_m2.wav": {
+     "bytes": 44144,
+     "sha256": "209e22e4693184c7b0c022e650b156e255cfa76b18c1066fe20255e285b4e80b"
+    },
+    "sound/pushable/brick_m3.wav": {
+     "bytes": 44144,
+     "sha256": "edafb8bf0915badb97edd078aa129c10a29e8fc428f4e9143f5926f9aa336e43"
+    },
+    "sound/pushable/glass_m1.wav": {
+     "bytes": 48044,
+     "sha256": "66a5944b16e3fe59cf9f8632f92bd85f81b79dc8711337558c45078c91a13c46"
+    },
+    "sound/pushable/glass_m2.wav": {
+     "bytes": 48044,
+     "sha256": "d462bac59390f89facc7c00d8aaee6e71b529ae9f177514a5f2f0533c78d5a0e"
+    },
+    "sound/pushable/glass_m3.wav": {
+     "bytes": 48044,
+     "sha256": "1a2efd7875486d15df811135d589135c807ba0149c877085f165932eb2770320"
+    },
+    "sound/pushable/metal_m1.wav": {
+     "bytes": 44144,
+     "sha256": "91420caf0e2de995681ac09b2be26cc9d0759edc06498571527528419de407d1"
+    },
+    "sound/pushable/metal_m2.wav": {
+     "bytes": 44144,
+     "sha256": "72f018c79b343538fd90de944ed54e8e3351b3da0a6c198f28403d25fc8fb140"
+    },
+    "sound/pushable/metal_m3.wav": {
+     "bytes": 44144,
+     "sha256": "c26b3aff129d573a1175fb618186db3b7ede8976e134c563c1678f48eaf8e302"
+    },
+    "sound/pushable/rock_m1.wav": {
+     "bytes": 48044,
+     "sha256": "9fb6ebeae45b4c47b1e42af1f00441d0e0bb88fbb53f85ea875341f9db55efb4"
+    },
+    "sound/pushable/rock_m2.wav": {
+     "bytes": 48044,
+     "sha256": "b57d0f760bb318b1159293e38811e5607bae8ff244d8bbf56223b355ef7c5b39"
+    },
+    "sound/pushable/rock_m3.wav": {
+     "bytes": 48044,
+     "sha256": "5e6514c241bb11d6194d9762d5369fb2a8da287b3d4c08e67f23da84fdb26b04"
+    },
+    "sound/pushable/wood_m1.wav": {
+     "bytes": 48044,
+     "sha256": "e672209779ee47996ca93e60d30e572da3cced5381db3f34c14a709629a5f4d2"
+    },
+    "sound/pushable/wood_m2.wav": {
+     "bytes": 48044,
+     "sha256": "c76b7db5faf1cbf21c07dacec615436a95f34c0e16e68628b62ec89a89b12f83"
+    },
+    "sound/pushable/wood_m3.wav": {
+     "bytes": 48044,
+     "sha256": "d6751d9e67c49458df6c076d9b6be9619f845213a263cb76330f51700f8a632c"
+    },
+    "sound/scorpion/clawattack1.wav": {
+     "bytes": 13360,
+     "sha256": "b0daf0605690db89f34a19936f1c20ad25676a4e6cd9dfad0e5757cf81dc4f7d"
+    },
+    "sound/scorpion/clawattack2.wav": {
+     "bytes": 13360,
+     "sha256": "06da85e6d6035704932fdc1ef449de529e17853571d017c5a42b253b5ed71a94"
+    },
+    "sound/scorpion/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/scorpion/hiss.wav": {
+     "bytes": 26664,
+     "sha256": "9d9fae97f3996ff3c0616f7acda952166d5eced9227d15a8fbe9d285095e7936"
+    },
+    "sound/scorpion/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/scorpion/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/scorpion/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/scorpion/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/scorpion/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/scorpion/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/scorpion/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/scorpion/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/scorpion/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/scorpion/tailattack1.wav": {
+     "bytes": 25858,
+     "sha256": "61e6c65b4c68813925e594b96ebad8a945c87d51f2cd23f301e80e231e53033d"
+    },
+    "sound/scorpion/tailattack2.wav": {
+     "bytes": 19650,
+     "sha256": "aab86f97eed636ebfb79ae7b92e4b7f7a3436b0146ad75519edd4358716169c7"
+    },
+    "sound/scorpion/tailfire1.wav": {
+     "bytes": 8924,
+     "sha256": "1f41bd184aa58b9f2f1b2f1197f3b7827c55d523d03a354dd1fb6d469cf129c8"
+    },
+    "sound/scorpion/tailfire2.wav": {
+     "bytes": 8948,
+     "sha256": "40a126ab5cba6c291d69606eddb7e2ab63ab640b1347b2e78ab4b0f7aca90c5c"
+    },
+    "sound/scorpion/warning1.wav": {
+     "bytes": 76930,
+     "sha256": "ae19faeebc0d3ec8c9f136bba205e634a29425ec86c3036016e5f2d9cd550817"
+    },
+    "sound/scorpion/warning2.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/seeker/death1.wav": {
+     "bytes": 397272,
+     "sha256": "35d8a1091032f24ed6a65efa99a7618f32bc0def24779efb51752b75a9e31ca1"
+    },
+    "sound/seeker/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/seeker/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/seeker/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/seeker/footstep1.wav": {
+     "bytes": 96092,
+     "sha256": "e5cd4f907a1b70ec72048b2dd5a5062022e7058676c3d90d05b7426e189a5073"
+    },
+    "sound/seeker/footstep2.wav": {
+     "bytes": 96076,
+     "sha256": "f3c8ba8d65257ddfa73e3e54c737c49de5dcc5c17bb088feb3511c3d69d21ac4"
+    },
+    "sound/seeker/footstep3.wav": {
+     "bytes": 96092,
+     "sha256": "c6fa111be092592a253815826c499b9b1f18a0c536910e2a82eebec7fb7f817d"
+    },
+    "sound/seeker/idle1.wav": {
+     "bytes": 141126,
+     "sha256": "10693a1d5fc1d710e54a0d57ce10d71400de192b874d6776ffe176c2b399a6b5"
+    },
+    "sound/seeker/idle2.wav": {
+     "bytes": 97420,
+     "sha256": "c24b439701d9ec3cf055702f23a3eb23623320ae89b9d46ab98a791f08898573"
+    },
+    "sound/seeker/melee1.wav": {
+     "bytes": 106252,
+     "sha256": "addfb5fab225a77f08d5c126b13f929fa31aa1c9094fc79202121ca891933fb9"
+    },
+    "sound/seeker/pain1.wav": {
+     "bytes": 19884,
+     "sha256": "ccaca64b8c1ab87d7d70896333cbec22c3b61c443a36cd8f253ad0eafc2d7ae1"
+    },
+    "sound/seeker/pain2.wav": {
+     "bytes": 19884,
+     "sha256": "8c3be23111a5ef53a7b66c7b74e32404ff0e6989d7de835543e0a65645e3f793"
+    },
+    "sound/seeker/punch1.wav": {
+     "bytes": 19940,
+     "sha256": "e4bf6b7deb14b5d614b4d5b7d4eeee36059372c913cc906589e1048d4484259d"
+    },
+    "sound/seeker/range_laser.wav": {
+     "bytes": 88246,
+     "sha256": "ee9f13af042a2a98fb75fa33873a1e861f3418f598ddb390f15ab44fcf93fcbf"
+    },
+    "sound/seeker/range_plasma.wav": {
+     "bytes": 79782,
+     "sha256": "9b1d38a4e1937023536d5ab5de035c97e1ef69131d58822b194cab2a3aa340b3"
+    },
+    "sound/seeker/range_rocket.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/seeker/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/seeker/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/seeker/sight1.wav": {
+     "bytes": 163526,
+     "sha256": "ca06541f54bcc297ab19ee133de5c782e978cf7afc2fab34b3789c4c56044d30"
+    },
+    "sound/sentinel/laser.wav": {
+     "bytes": 9712,
+     "sha256": "c5f90e1823a04b48f7f24ac5b8792e1b42030a8b07970db5847dc1e74be094c2"
+    },
+    "sound/sentinel/nail.wav": {
+     "bytes": 13750,
+     "sha256": "7acc3ac05b7218abc6fef2d2397771d90fce6fa39415e33824be7e771d30e288"
+    },
+    "sound/sentinel/widle1.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/widle2.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/wpain.wav": {
+     "bytes": 19596,
+     "sha256": "bc7b6536a1c67aa89295eeacea2d9b36cb0bf783b5fb7cc6aaf4fa01a0edb3fd"
+    },
+    "sound/sentinel/wsight.wav": {
+     "bytes": 27322,
+     "sha256": "83bca2103d60c68435e27f0660e3ecd5bffb058e796382e7bdb43efabdfb9889"
+    },
+    "sound/shalrath/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/shalrath/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/attack1.wav": {
+     "bytes": 44184,
+     "sha256": "91f50e3b69909213e23149b6a3e9622c4367d77f871da5f01e6e4aea3badf648"
+    },
+    "sound/shub/attack2.wav": {
+     "bytes": 33174,
+     "sha256": "d4928f711f7e8fc1d8ba050a87b4e1c2d48ffc24af6a454637629dfae8902e3f"
+    },
+    "sound/shub/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/shub/death1.wav": {
+     "bytes": 107440,
+     "sha256": "1551554be1b7896ee39156ce258bf68ac5dace891994788020ee95083ae33e77"
+    },
+    "sound/shub/explode_death.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/shub/idle1.wav": {
+     "bytes": 75072,
+     "sha256": "9d33c61470d0c4269c8d113b4476b84236fa00e6ee3be061865e242c988093af"
+    },
+    "sound/shub/idle2.wav": {
+     "bytes": 75000,
+     "sha256": "21b063438744def5f79a50709c567cc9f3e3a28c39e58456068a3d4ae362617f"
+    },
+    "sound/shub/idle3.wav": {
+     "bytes": 75096,
+     "sha256": "310c4ff969da63c77e7ebb5b319aca0f17a10802ee942b21174349d5e5a79d72"
+    },
+    "sound/shub/pain1.wav": {
+     "bytes": 83880,
+     "sha256": "1d1536a51822b67106ea72bcb537efbf5f69e4a4592904f6feedee06ef5084df"
+    },
+    "sound/shub/pain2.wav": {
+     "bytes": 83886,
+     "sha256": "71c30d3f41e0f99cffcf5037b482c1da7bf028b477051219f6e605ceef28ae38"
+    },
+    "sound/shub/sight0.wav": {
+     "bytes": 83880,
+     "sha256": "6d4d96fc663db248cf9279c0b028c11b451b133c6e2c38364c13e105f8fa377f"
+    },
+    "sound/shub/sight1.wav": {
+     "bytes": 83880,
+     "sha256": "ecaf1595f3acbfe2e771a193c69bd6de5e6e3bd957405fdf4bcf59a2288bdb05"
+    },
+    "sound/skullwiz/attack.wav": {
+     "bytes": 15484,
+     "sha256": "ca662d909cb3b96bdfb93197092ed8e8a5d1ed27772a91a4a6ae5e9d3063017a"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 33166,
+     "sha256": "5d1ccd5b97bd38eaf46d1e0798009765d46d58ba17e7e6efc36350b0adaa22f7"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 33178,
+     "sha256": "dd77e90760bd85fc872a96c2eaa808b094a461ab2871bd8ab6a5372861560512"
+    },
+    "sound/skullwiz/blinkspk1.wav": {
+     "bytes": 44200,
+     "sha256": "ade109f32810094922f77bc3c03f02d33e98d855d3dcaf79ceab4cb200efaa65"
+    },
+    "sound/skullwiz/blinkspk2.wav": {
+     "bytes": 44204,
+     "sha256": "16d3b1296e1ed9c3bdc06dd25f5d9db3569cf3486794d29858d5ad227741dd1a"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 33166,
+     "sha256": "bc83800a91fad273e7f84f3cec2fa2787c902f4cd97fd5495f73dc9fb6d2c368"
+    },
+    "sound/skullwiz/fadeaway.wav": {
+     "bytes": 43092,
+     "sha256": "dd67d3ffe5a592b4e449d6bb00eee3c525ede786b0a2d9089832981311bfd61e"
+    },
+    "sound/skullwiz/idle1.wav": {
+     "bytes": 88252,
+     "sha256": "1834b946ff68aab07ade01b68d95d822d0b2a1baa51c1ceba7e66c73b8b6211e"
+    },
+    "sound/skullwiz/idle2.wav": {
+     "bytes": 88240,
+     "sha256": "57c49c7fd4f52b870a658e2e854e16c67389e9d79f9a1db5928f12d74741a1da"
+    },
+    "sound/skullwiz/pain1.wav": {
+     "bytes": 11132,
+     "sha256": "125e06cdfacd6aa78a90034d3f94086736734dd1dd9d170fef3a512b42e34cd0"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 15540,
+     "sha256": "ac5a56dbff28fa4724bd8766d8443090e3026007f6f4051cfecd2869b3f5ecb9"
+    },
+    "sound/skullwiz/poison_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/skullwiz/sight.wav": {
+     "bytes": 36484,
+     "sha256": "3051df89bfdce6b80c49c3513cfcbd679bf1f71c5562430d7738737e44f04f26"
+    },
+    "sound/skullwiz/skull1.wav": {
+     "bytes": 22144,
+     "sha256": "3a43bc5e1079740b61199ff21518f75cc1e4db7cdc9e25b57631b38b04d651a2"
+    },
+    "sound/skullwiz/skull2.wav": {
+     "bytes": 22158,
+     "sha256": "fed613207dc7691118ea5b62626df8773bda59816b008bfd2aeaa4d2f26a4b7b"
+    },
+    "sound/skullwiz/summon.wav": {
+     "bytes": 97022,
+     "sha256": "bf74e3dfbb330f481790f7bbc2b88e74b1654f7d5b327235c3d00bee3f62a06a"
+    },
+    "sound/soldier/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/soldier/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/soldier/rocket_load.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/spider/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/spider/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/spider/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/hiss1.wav": {
+     "bytes": 17802,
+     "sha256": "c56fcae8a01af94c07807730857b4b367f2c70c35869505528504faa29a17ade"
+    },
+    "sound/spider/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/spider/hiss3.wav": {
+     "bytes": 22582,
+     "sha256": "1a3c71b1e4ac2389c98c4af9db88e81b51a602c681bd00a1812995654863e2d4"
+    },
+    "sound/spider/idle1.wav": {
+     "bytes": 20922,
+     "sha256": "8a6d25359bbbc1f5e4f6962f4ce1742160537c6bb8bf8b806a0df96adfae819d"
+    },
+    "sound/spider/jumpland.wav": {
+     "bytes": 6038,
+     "sha256": "3c46bc58c52a61480c1a8dc2034aa240545521baf5e0027372992a9458796919"
+    },
+    "sound/spider/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/spider/pain1.wav": {
+     "bytes": 6108,
+     "sha256": "728cd94a64b27dea4d845a9e27e1ba09cfb286bff80128a67d1da0431b6b0c20"
+    },
+    "sound/spider/pain2.wav": {
+     "bytes": 10460,
+     "sha256": "736f0a768c0f52b22a301fc6a15f18f2f60e5579d3b27c2b78bcb7bed8e0c577"
+    },
+    "sound/statue/comidle.wav": {
+     "bytes": 17722,
+     "sha256": "3567914304c8fcf224e31bc302039432cd17833daabc2ed9f83053b01fef4f7c"
+    },
+    "sound/statue/death.wav": {
+     "bytes": 13472,
+     "sha256": "b030aeac3d806bc77fddaed4bb32684cfd2bbd707fe85e2500a3346c5931ec68"
+    },
+    "sound/statue/hurt.wav": {
+     "bytes": 8012,
+     "sha256": "9193f4e976675042409db103f7e3b26f667a56e913e96a37f223f1c606323246"
+    },
+    "sound/statue/idle1.wav": {
+     "bytes": 13304,
+     "sha256": "0b5d3bcbd00e846d38986f8919ff4fa7bcce92e45e5ba5949edd0e81b741b69c"
+    },
+    "sound/statue/idle2.wav": {
+     "bytes": 13316,
+     "sha256": "45469f14a25fd434ba1ed987fd20835ac058496d41df5a6aa543dec454670f36"
+    },
+    "sound/statue/sight.wav": {
+     "bytes": 9584,
+     "sha256": "84ab06d320f9953eebda7c4dd25a0e0de3369957de01c64af10a8b3ca886241e"
+    },
+    "sound/steelclaw/attackmunch.wav": {
+     "bytes": 11084,
+     "sha256": "bc405c7311fe6fc4c0b6883a673743a3dac6a488416f81a3e91be6806e1a3f99"
+    },
+    "sound/steelclaw/attacktear.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/steelclaw/death1.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/steelclaw/idle1.wav": {
+     "bytes": 34498,
+     "sha256": "5c499c4f71364b55bb42721779d0358e440607ebc24aebc0644d7a0bbc9f3087"
+    },
+    "sound/steelclaw/idle2.wav": {
+     "bytes": 27010,
+     "sha256": "b7693ab202bad70804e14a77d6c9e27335a152d06d4150f6aace39f9093adcb7"
+    },
+    "sound/steelclaw/jumpattack1.wav": {
+     "bytes": 35762,
+     "sha256": "d1823f5a771d4cc228346a1f4ebce929aa0a8243c2b019031be35e2d63366dc2"
+    },
+    "sound/steelclaw/jumpattack2.wav": {
+     "bytes": 43886,
+     "sha256": "8ec46b5b905fa3d20b6fe7b8eecf7494a8ea32e331a6a168e78b6bf2de3486aa"
+    },
+    "sound/steelclaw/jumphit.wav": {
+     "bytes": 30494,
+     "sha256": "dd4cba78f89f300aabccd3702d4af8472216bbd23100991462e996ec3e9360cb"
+    },
+    "sound/steelclaw/jumpland.wav": {
+     "bytes": 17068,
+     "sha256": "bd5e36af76a41808b37d6400e3ee7fffc19e7893570fbaded95b8f3eed15d919"
+    },
+    "sound/steelclaw/pain1.wav": {
+     "bytes": 24322,
+     "sha256": "c651404583ed2a687e1f73185126784f746fd28007beb78ceb38351b3aecbf48"
+    },
+    "sound/steelclaw/pain2.wav": {
+     "bytes": 30914,
+     "sha256": "b5e4af0e78c62b8a752887ae463ac692f6da406c90c2636fae0b7860569878e5"
+    },
+    "sound/steelclaw/sight1.wav": {
+     "bytes": 49026,
+     "sha256": "abbcb006d5a940698a2f4d9d861b81cd05b092a386fed9f8b179662c7aa1d7c5"
+    },
+    "sound/steps/drag1.wav": {
+     "bytes": 13586,
+     "sha256": "db069e08b7de4c5074cc4dd56f3b1cd2b6d77fe7869e1e03f5dddddcf9aad530"
+    },
+    "sound/steps/drag2.wav": {
+     "bytes": 13572,
+     "sha256": "b2ac07fe014e7c5afd4a5974c5d290b34a880a52f33668030a97a345d5811db9"
+    },
+    "sound/steps/drag3.wav": {
+     "bytes": 14690,
+     "sha256": "a29ee6f0977b205d146f81ee5be2f9b2f12ca76f177aaab9e35e556c4f555fa9"
+    },
+    "sound/steps/drag4.wav": {
+     "bytes": 13584,
+     "sha256": "1b5628a4272837ccf9c4044371a1d45eef23439b164be445b6f2ca90952e3487"
+    },
+    "sound/steps/drag5.wav": {
+     "bytes": 13584,
+     "sha256": "6dec9033ece2a02ce65c437e1b7e58512fd04d41a327487704de71cdf39b99dd"
+    },
+    "sound/steps/giant1.wav": {
+     "bytes": 33140,
+     "sha256": "d28f78c1514f215c64b6a3de38b5ffb5b891341ed95dc0277b1b3dba498cc64a"
+    },
+    "sound/steps/giant2.wav": {
+     "bytes": 33138,
+     "sha256": "7936f32a0ae371e216a195c3110b24db372a15091ea5c80e78875951f874d3b0"
+    },
+    "sound/steps/giant3.wav": {
+     "bytes": 33126,
+     "sha256": "58f79749cbdaaa608e6aacc368b74e0ac1e2ecf2ef45967c7f1f7b7a3e99c8fd"
+    },
+    "sound/steps/giant4.wav": {
+     "bytes": 33136,
+     "sha256": "4ffa741a70225aa31078f73a5612cf7d5ad9f9007163f0a5aeda749da099f9bd"
+    },
+    "sound/steps/giant5.wav": {
+     "bytes": 33138,
+     "sha256": "a2706d4dd9856cccdc3980156a77702883e36d86df54221b31a781c8e5e767e3"
+    },
+    "sound/steps/heavy1.wav": {
+     "bytes": 13282,
+     "sha256": "603679f83cc5095d2fa81d945285b2980195ba50ee2615fed85487493f0a536d"
+    },
+    "sound/steps/heavy2.wav": {
+     "bytes": 10870,
+     "sha256": "384f160ad4816b6984ef6b3b59c4bc1e8a2a3e05f9aaa80ee8b30ada2645669f"
+    },
+    "sound/steps/heavy3.wav": {
+     "bytes": 12828,
+     "sha256": "936417bc5ec9d30db8a74a9798328436259ffd704b11e1155d3fa79dc829e462"
+    },
+    "sound/steps/heavy4.wav": {
+     "bytes": 11050,
+     "sha256": "8d4879d40eda9182ff45fb18130c7979997d326581c14edeedc9cab440531e00"
+    },
+    "sound/steps/heavy5.wav": {
+     "bytes": 10198,
+     "sha256": "4e2e9892dee74d3472a45ecda889ae8d2f836786b44a55e5d1436690c7dadd5e"
+    },
+    "sound/steps/large1.wav": {
+     "bytes": 33118,
+     "sha256": "c387d084a10b28329610d8e3ad3e377f43087013e802be42af79f254276d00dd"
+    },
+    "sound/steps/large2.wav": {
+     "bytes": 24960,
+     "sha256": "ab91b4605671dd16da59963959cda3368a065612d8ed1776847da310b1e7b5fd"
+    },
+    "sound/steps/large3.wav": {
+     "bytes": 24280,
+     "sha256": "3e6a5ef0d8cbaba2e976f199d8d1ffa073fe8e83dacee709137335d42ddd7558"
+    },
+    "sound/steps/large4.wav": {
+     "bytes": 22092,
+     "sha256": "f2bde1b715f679cf814c2cd1375442170cf9f6e56d8ea1756900f81f1d1df453"
+    },
+    "sound/steps/large5.wav": {
+     "bytes": 24320,
+     "sha256": "c15b388bbed461461bac2c22b3a88ff272c04ad070e4791b7ce35c1559d16f77"
+    },
+    "sound/steps/light1.wav": {
+     "bytes": 8872,
+     "sha256": "f034fe2692c0fceb6de1c00e15facbcbd31ccd1fcf72510fd1e3cb6bdcc28795"
+    },
+    "sound/steps/light2.wav": {
+     "bytes": 6654,
+     "sha256": "998f665b4a7ccbc995096697606a91d208db024b0882df75ebaaac015f0d4ef6"
+    },
+    "sound/steps/light3.wav": {
+     "bytes": 6670,
+     "sha256": "b25e020a10ac6a7883fd584cff4895d6d785f8577daea15a30d2b745e146c1c6"
+    },
+    "sound/steps/light4.wav": {
+     "bytes": 4472,
+     "sha256": "a111052881024eef6e97393c1388e8ae538227b85c9b8cf0a73704abb2a504b1"
+    },
+    "sound/steps/light5.wav": {
+     "bytes": 3588,
+     "sha256": "55fb54e5ba2f8ec6249761ae6f07c12de6133457b51c584759e8841fb14cb46f"
+    },
+    "sound/steps/medium1.wav": {
+     "bytes": 8872,
+     "sha256": "38e731803a49be7d8018dd7b44060b578b5418f2f7aefb04d1c74c968ced187a"
+    },
+    "sound/steps/medium2.wav": {
+     "bytes": 8852,
+     "sha256": "e8701598e07f43a20aebebd1d1a5043213018199d50472dea37672e6dce4a2b3"
+    },
+    "sound/steps/medium3.wav": {
+     "bytes": 11068,
+     "sha256": "3ed07795c2363552554e6da1da5749be08e460fc6cd4c7266b9fa514732abb2f"
+    },
+    "sound/steps/medium4.wav": {
+     "bytes": 8872,
+     "sha256": "008992cd7972e7e1e6f0b785b40e398a8efe744a3f3f57e47370936796c3d6b5"
+    },
+    "sound/steps/medium5.wav": {
+     "bytes": 8864,
+     "sha256": "ccd26430fd354c0e87750e02d92c40071ef9dccadae5bdeebc7e0d2a2ec4eba7"
+    },
+    "sound/steps/slow1.wav": {
+     "bytes": 8878,
+     "sha256": "15614044d9d277fa3359edb07e7af74b9d7875150fddde5ab1fdceb0143337bb"
+    },
+    "sound/steps/slow2.wav": {
+     "bytes": 8856,
+     "sha256": "a8b16b688d12812a61127a885bf43c360adc2b84ae7806cc107b433c6f4635ee"
+    },
+    "sound/steps/slow3.wav": {
+     "bytes": 8852,
+     "sha256": "3a2a57e1a37d378c1ee73d5732840f6d20e588d794216c33896bf25879807600"
+    },
+    "sound/steps/slow4.wav": {
+     "bytes": 8868,
+     "sha256": "78bdea66991184043001262cc6ef5f1148cf0eb11b5f88fc51ff948311156e5f"
+    },
+    "sound/steps/slow5.wav": {
+     "bytes": 11076,
+     "sha256": "f63c868bd87926f017bec092749bd61c763b0b18635456ed56b660e53bf581af"
+    },
+    "sound/steps/water1.wav": {
+     "bytes": 63814,
+     "sha256": "01ed631b0d92dab11086b1106acc278ffd92522e2e46d21a0650fd29a79780f2"
+    },
+    "sound/steps/water2.wav": {
+     "bytes": 71994,
+     "sha256": "1b53561f02f60da1e1b6c8b72f722ba12e549c318725b974745b38666efa8e56"
+    },
+    "sound/steps/water3.wav": {
+     "bytes": 71802,
+     "sha256": "bbc0778017ccb579a9d531316b8af46585e91a100a251707ac34f4dbddf6922d"
+    },
+    "sound/steps/water4.wav": {
+     "bytes": 61448,
+     "sha256": "d3604afcb7751d987a78a0ee8ee4ca3593315cc6cf2f1909a9f7748535ccea50"
+    },
+    "sound/swampling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/swampling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/swampling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/swampling/idle1.wav": {
+     "bytes": 132044,
+     "sha256": "418eae21e001c1ae065df9357ebf2ad331f761062d75f345f12e99d9aec8cfb5"
+    },
+    "sound/swampling/idle2.wav": {
+     "bytes": 70444,
+     "sha256": "4026b4b56ffa9a207e1457e03ec94a8eb9042cfebf1c042fa291ba2bbbf1c4b5"
+    },
+    "sound/swampling/idle3.wav": {
+     "bytes": 171644,
+     "sha256": "fa54eaf040baf965f994b328bfb1a55cd90d1741d57ed580c1d44c51e9c125f8"
+    },
+    "sound/swampling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/swampling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/swampling/pain3.wav": {
+     "bytes": 67244,
+     "sha256": "4b186834bbec7d2ef9873f55d5df980da3b3fd2f19f76e54fd835d1aaf40fedd"
+    },
+    "sound/swampling/sight2.wav": {
+     "bytes": 88044,
+     "sha256": "6989ba3aca0c5f5e12d30d9958c6ab169f5c6c96f36f4843a9a19bab0e5d0c4c"
+    },
+    "sound/swampling/spit4.wav": {
+     "bytes": 76848,
+     "sha256": "6855555e2a188ed9ae0a1cd307c7715e54c6f3c10ac0fee9edbba2edf1a48d16"
+    },
+    "sound/traps/flame_loop.wav": {
+     "bytes": 28560,
+     "sha256": "661d8325af92fb37235952e2668578dbf57d844b7359627b4a2c25d15127bff7"
+    },
+    "sound/traps/flame_off.wav": {
+     "bytes": 28496,
+     "sha256": "ebc40d62265aad20813acd189511be0bac063ecc00d7ae712863de3dbdb84c94"
+    },
+    "sound/traps/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/traps/laser_hit.wav": {
+     "bytes": 4358,
+     "sha256": "0840d9fa27bfd2bcb86c2f0174810ae3eb9baa6a43867d27de1e074f7cd75e2c"
+    },
+    "sound/traps/pend_hit.wav": {
+     "bytes": 11908,
+     "sha256": "6fec8fd4edb67e8905d9ad0d7dce5ee5a9b4f43b724b75cb449e88b508384e11"
+    },
+    "sound/traps/pend_swing.wav": {
+     "bytes": 22142,
+     "sha256": "d20bbaf323c5aa0ee2aa21222f2a9f5fc956c0317e65c05e9d003bb08d80a9ae"
+    },
+    "sound/traps/saw_end2.wav": {
+     "bytes": 99808,
+     "sha256": "2a129f2d5fe3c9fd60873c336e2eed799b3d2ebc91bc8bf5a0860b45a6b83ceb"
+    },
+    "sound/traps/saw_loop2.wav": {
+     "bytes": 173082,
+     "sha256": "b4ca1bfeaab62c73bfc10f7daa2750738874d721af9e637479e8242f5220294c"
+    },
+    "sound/traps/saw_loop2f.wav": {
+     "bytes": 132748,
+     "sha256": "03a3e77feb8775a7b486363ed1d46d04fb9294f5507040e458ed8a05c37f0de8"
+    },
+    "sound/traps/saw_start2.wav": {
+     "bytes": 217184,
+     "sha256": "49f1dd84a7be0c4d0b1293aa587ab786d69f4cb463ce5a03f09da816eb22d384"
+    },
+    "sound/traps/sawblade_off.wav": {
+     "bytes": 15276,
+     "sha256": "44924313561cf32ea95c50ef80366ba79a2c86ff2f218fc89404c82617ce2c84"
+    },
+    "sound/traps/sawblade_on.wav": {
+     "bytes": 37582,
+     "sha256": "097635d29859ce28ea37da2d51ec346b8d5239435bb6be0bf5f094a555c110e8"
+    },
+    "sound/traps/sawstrike1.wav": {
+     "bytes": 30836,
+     "sha256": "489d8cdea78b2c333771b316741d7960d5c0da6845ea15b94991ece94837367a"
+    },
+    "sound/traps/steam_loop.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/traps/steam_off.wav": {
+     "bytes": 11146,
+     "sha256": "7af5b33467568a4418ee820d618a562a65dc0425016a79bb731dbee6c8c5c4e2"
+    },
+    "sound/voreling/attackmunch.wav": {
+     "bytes": 17798,
+     "sha256": "be7d018ae5b5f906a6cf2e4b12138f7c1407c98c3485599cb4442ceb59ee1c94"
+    },
+    "sound/voreling/attacktear.wav": {
+     "bytes": 8918,
+     "sha256": "2aa7029f8be106777c0e51e4b237ad705c120bcab74c5695547af29475b1f5fb"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 17694,
+     "sha256": "119475b1b21df8c965a526be27a266035b3b8cde44df3759eb4a40a83f730baf"
+    },
+    "sound/voreling/hiss2.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28354,
+     "sha256": "8c9ef55e309a43b1df1f08b66192b4ab262ba07e9315d3a70f4a9cf9dee9d51a"
+    },
+    "sound/voreling/jumpland.wav": {
+     "bytes": 4518,
+     "sha256": "078af531f8d493aae57b71b8bdcef4c5f9b9b8394be9bc1e113873458ec09525"
+    },
+    "sound/voreling/miss.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "5035bd555e9a6439c87e6b661a2da86633f7234503d52551e68f61e9504af86d"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 44162,
+     "sha256": "ccca790ed18e3705c083259f48db7d46d26310cf80c16cd2bad191d333fec5ba"
+    },
+    "sound/weapons/axe_ceramic.wav": {
+     "bytes": 24620,
+     "sha256": "53b6e873318f84424129f1486f0a715c9b1f46e9521c97858d3ddbd94ef4dc10"
+    },
+    "sound/weapons/axe_flesh.wav": {
+     "bytes": 7754,
+     "sha256": "8d0046355ea843f56d5260f581c89d2f885b553c97cfc7e01a93f6da487e03de"
+    },
+    "sound/weapons/axe_glass.wav": {
+     "bytes": 13306,
+     "sha256": "7fd4f7f02edf972c17cf64fea9ecfecca2e0a2d69da9828c1a1e2ce726dd9a79"
+    },
+    "sound/weapons/axe_metal.wav": {
+     "bytes": 28844,
+     "sha256": "d77bc0204c9f406f50ddf01241ff3a3cb34bd571f8a038a483fe49fba81fb160"
+    },
+    "sound/weapons/axe_swoosh1.wav": {
+     "bytes": 26524,
+     "sha256": "1ee4079e691b1e3e8eca8e6fe3098ee053f99b2a0028e725442771c84dc07e49"
+    },
+    "sound/weapons/axe_swoosh2.wav": {
+     "bytes": 13284,
+     "sha256": "a28435309759dd35576099d23a36dc378d9703db9f0778fba63efa3558cfc19d"
+    },
+    "sound/weapons/axe_wood.wav": {
+     "bytes": 7776,
+     "sha256": "ce5bd1465d66aa4aad5249c387f7f537b45b4f8a0e4bf76f37f8efc2a22bd9d9"
+    },
+    "sound/weapons/bolt_hit1.wav": {
+     "bytes": 12698,
+     "sha256": "07d2b6078f7936781a641f88e6ed02ab84f248da8f19e73713c1a71ac56cf42c"
+    },
+    "sound/weapons/bolt_hit2.wav": {
+     "bytes": 10658,
+     "sha256": "27ef878b7dfc0878140a19e3a0227ba389e5d0dc2b86df386852e2da2ebc5c93"
+    },
+    "sound/weapons/bolt_hit3.wav": {
+     "bytes": 11600,
+     "sha256": "06298d7bc8d7bce64f9473ae9530e0b42ea3de0ca5895f3476f9b00b5ed566f9"
+    },
+    "sound/weapons/bolt_hit4.wav": {
+     "bytes": 15460,
+     "sha256": "814b1a71efc9b58c90ad7f116c47e6f3dceeb8eae6d0ecbca5f1cd02dd247cb6"
+    },
+    "sound/weapons/crossbow_fire.wav": {
+     "bytes": 26536,
+     "sha256": "2a6ba54090412a53471c59b3edf6e8559d424dab25729e67a78f9ada5e13e8ac"
+    },
+    "sound/weapons/crossbow_hit1.wav": {
+     "bytes": 60782,
+     "sha256": "be1e78c92c13749e988d26912fba6c23f3700df0d7cc48d724f0da1f2608d006"
+    },
+    "sound/weapons/crossbow_hit2.wav": {
+     "bytes": 32472,
+     "sha256": "30a4ef9f23b2239371d32385e55487b279ca4f8f91366d4251cf4d9abdce200a"
+    },
+    "sound/weapons/crossbow_rdy.wav": {
+     "bytes": 37532,
+     "sha256": "321eac310a291cd9cdcbd2dcafb27687a12057e778e12704d8b4388d4eb6e4df"
+    },
+    "sound/weapons/crossbow_swipe.wav": {
+     "bytes": 40216,
+     "sha256": "f908e95c127faa417b848d835c55db04597714b17bddd18a8e44e282e5866425"
+    },
+    "sound/weapons/ghook_fire.wav": {
+     "bytes": 11526,
+     "sha256": "6e29f4524c0be70d8bf3b1201e737712b271c9bc963ad46c1815972b6addc22e"
+    },
+    "sound/weapons/gl_loadlong.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/weapons/gl_loadshort.wav": {
+     "bytes": 7758,
+     "sha256": "c97236bbfd211dfcad8130974413a8666cdbcf646d364abd8801b3d6ba5bf9c4"
+    },
+    "sound/weapons/laser_fire.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/weapons/laser_hit.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/weapons/laser_richotet.wav": {
+     "bytes": 12888,
+     "sha256": "bcc0498060e71b059d1d6ec45628048b0f29a7a0509b736a519196338b5df20d"
+    },
+    "sound/weapons/nofire.wav": {
+     "bytes": 1400,
+     "sha256": "217c42718548de32b5df972d117ffc1a0e1dde5f03a7a173bd91d0b4551248c9"
+    },
+    "sound/weapons/plasma_expl.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/plasma_fire.wav": {
+     "bytes": 88288,
+     "sha256": "6a0ad4930da39ff590c79f9d26b434bb1001536d33d880735df76e9354f90e94"
+    },
+    "sound/weapons/plasma_hit.wav": {
+     "bytes": 54406,
+     "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b"
+    },
+    "sound/weapons/plasma_load.wav": {
+     "bytes": 15494,
+     "sha256": "ff237360f0c982e1b9460d24a3f0bb1228e4c2cfe2bdd20879682048ce45c9cb"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 8864,
+     "sha256": "f971a9aaa8626894132d1d3d7139e0f06b01f3beb894f680f5033eccfbbcd969"
+    },
+    "sound/weapons/r_exp3b.wav": {
+     "bytes": 34830,
+     "sha256": "a1abb7cedfa6576205f043c2e5f562606b039f65f6f996f5ffbb758d7855f2a2"
+    },
+    "sound/weapons/resist_rocket.wav": {
+     "bytes": 19938,
+     "sha256": "1e5170aaf1d6f144e7ea77c251d15ee85c9a70eb1f50b12e4ba5a93971ad1955"
+    },
+    "sound/weapons/ric1.wav": {
+     "bytes": 5650,
+     "sha256": "49223498fbf29b97f712537e6417917befc4e4f5c725bbf2e3d463580c15454d"
+    },
+    "sound/weapons/ric2.wav": {
+     "bytes": 11146,
+     "sha256": "5fa462f4ab3184cf70bf33f923a2b7e4392db517d34f8531a381864d78c352a6"
+    },
+    "sound/weapons/ric3.wav": {
+     "bytes": 11138,
+     "sha256": "1761926b96108fd0b0ee55270ee711fbd2f394f1b5e93da4af96e42c69fa3946"
+    },
+    "sound/weapons/riotgun.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "sound/weapons/sg1.wav": {
+     "bytes": 28718,
+     "sha256": "49074c95da2a619d82dee9d45e28dc910f9a8e16141270a76c81b396a41a6a3e"
+    },
+    "sound/weapons/sg2.wav": {
+     "bytes": 28718,
+     "sha256": "279b1bb969837073c46c176fe62782e60658a6614a8e094b9722cbabdca81fe6"
+    },
+    "sound/weapons/sgun1.wav": {
+     "bytes": 45840,
+     "sha256": "3ac6c4b3ded00fa48810f09afc95b4a8375dc3e8d52e04cd9cba18dfeee20087"
+    },
+    "sound/weapons/shellc.wav": {
+     "bytes": 21006,
+     "sha256": "45a2f8bd652307b9ebd37115c27166d03a4d7055f3054a215036fbc342e22f6d"
+    },
+    "sound/weapons/ssg1.wav": {
+     "bytes": 17244,
+     "sha256": "3e5b9cc1cd0cb86602391e4ddedbc98bb020e44b937eec4d3c5b053ff98c98f2"
+    },
+    "sound/weapons/ssg2.wav": {
+     "bytes": 75024,
+     "sha256": "248a021818f578ec3d96b9fe59d8f839242f4d5f8140a66a500b523b137d1977"
+    },
+    "sound/weapons/sword1a.wav": {
+     "bytes": 11184,
+     "sha256": "22bc8b25a67f1ab0752f9fbc68c2eb0958d2807c9e95bc8ee35d1d1bc9c6552d"
+    },
+    "sound/weapons/sword1b.wav": {
+     "bytes": 13272,
+     "sha256": "dca39f0c4776994c1bbe5255893d50dd86a634a370ea6046fd4e851117dec726"
+    },
+    "sound/weapons/sword2a.wav": {
+     "bytes": 11150,
+     "sha256": "aa381f8c68f5753cecbd889bc184a784c934c78c8fefe3b1ba4026a99112da51"
+    },
+    "sound/weapons/sword2b.wav": {
+     "bytes": 13232,
+     "sha256": "9460973ef948f8712be967d412774d32aeefb8e68b11959c28909eb16d9e8afc"
+    },
+    "sound/weapons/widow1a.wav": {
+     "bytes": 64644,
+     "sha256": "b4ccd6b235784f7ff53ccf0d726ecbbc789d2ddcca057b40df769b7925e3b32d"
+    },
+    "sound/weapons/widow1b.wav": {
+     "bytes": 66186,
+     "sha256": "0da0346e80cdcb405ffb8f9dbe048197cd9d303130f35b2546b4f7652bd06ca6"
+    },
+    "sound/weapons/widow1c.wav": {
+     "bytes": 66186,
+     "sha256": "eb054b4b1b2784bb098e24574ced6b8c2114e3344fc73e9beb23285adfa086a8"
+    },
+    "sound/wraith/attack1.wav": {
+     "bytes": 26560,
+     "sha256": "7d24cf2d3cec234d3d56c30aab5dbcca9f898d7c15be010d074fb7a2fd16a855"
+    },
+    "sound/wraith/attack1_explode.wav": {
+     "bytes": 149986,
+     "sha256": "4d726e1dbb19a0974162f2fb1910270e7064cf1566cc340a496e17f7945ea202"
+    },
+    "sound/wraith/attack2.wav": {
+     "bytes": 88200,
+     "sha256": "bdf849b4e138fa587df136a327c71ceed1176cbbb4ecb873434766d53da35a3b"
+    },
+    "sound/wraith/attack3.wav": {
+     "bytes": 11072,
+     "sha256": "635fd259e0790fb03e1d8c0ea4c0c0366c81603113e5ff181c6629e30b96af10"
+    },
+    "sound/wraith/bounce.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/wraith/death1.wav": {
+     "bytes": 19960,
+     "sha256": "c0e5e05b46e4cf4afebfe5d0ef1801fc16fe8308a7f859ff347a77871b0a9339"
+    },
+    "sound/wraith/idle1.wav": {
+     "bytes": 51556,
+     "sha256": "e91f12463417df25badbbdfe817560362370d9e1e31712766bccb086e06d966f"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 82792,
+     "sha256": "b843d1124acc61be2aae27a7c8a9aca8f6bd471689703b41d59f1450e70e360c"
+    },
+    "sound/wraith/idle3.wav": {
+     "bytes": 55228,
+     "sha256": "3393943b38a0760c2b048c87c6b11ef743b0c968397ae7e434434b8b21fe12f9"
+    },
+    "sound/wraith/pain1.wav": {
+     "bytes": 18184,
+     "sha256": "a448cf5aed2909700e4da1f3ea3158b55e288198eee771eddacf211f4b274dbe"
+    },
+    "sound/wraith/sight1.wav": {
+     "bytes": 34390,
+     "sha256": "91494295e94c54c8da0307df8a51ea10d166fb18a78ede909a710f72ffe81c4f"
+    },
+    "sound/zombie/boil_explode.wav": {
+     "bytes": 38012,
+     "sha256": "210dac94ab0e4efb5eb3bdbfa5d7100094b1bfef917a8d5abb2ae186252c0a27"
+    },
+    "sound/zombie/boil_idle1.wav": {
+     "bytes": 33204,
+     "sha256": "e2b717040d436ba2a659ceb1e5b74dfeaad57577297a9827957733e00ce7cb34"
+    },
+    "sound/zombie/boil_idle2.wav": {
+     "bytes": 33206,
+     "sha256": "8bd584597f2c54e6f8ecca5c0a83e44b0b5a09a745026e41cc2cad8ded6f729a"
+    },
+    "sound/zombie/boil_sight.wav": {
+     "bytes": 33192,
+     "sha256": "0e285e98dc66cd49af507dae9ab5281aaec55eaf9d401810a8d230d93539123a"
+    },
+    "sound/zombie/boil_squirt.wav": {
+     "bytes": 14582,
+     "sha256": "9640df8ca3d5181a0a1c310c052deafc5e82afb469faf68511698664f4e46dae"
+    },
+    "sound/zombie/boil_windup.wav": {
+     "bytes": 22094,
+     "sha256": "3790791943ea03add95bc303df34470c534f9c2c76e4343831609eaee761633d"
+    },
+    "sound/zombie/zk_sight.wav": {
+     "bytes": 26916,
+     "sha256": "8fe4d5fea16bd7c3661a968d26782ea8c4741157e16e22f33317619229b10637"
+    }
+   },
    "sha256": "3ac1bca8e905cbe36c24f986167eb767f1d5eb1212509cd8234fa5b7ac4b875b",
    "timestamp": "2021-12-12T19:59:06.000Z"
   },

--- a/json/by-sha256/9e/9efb783db0d413d272c9a95a2aca1c37bad452276d6a55f12bd4cc9cfdb58d5f.json
+++ b/json/by-sha256/9e/9efb783db0d413d272c9a95a2aca1c37bad452276d6a55f12bd4cc9cfdb58d5f.json
@@ -17,6 +17,88 @@
   },
   "vestige/PAK0.pak": {
    "bytes": 63011548,
+   "files": {
+    "expanisons.wad": {
+     "bytes": 7010272,
+     "sha256": "36a5ab7fac9c68cb65e3baa5be17c3bd79bc8ffb2b7012443322ecd45fa4fbf0"
+    },
+    "mapdb.json": {
+     "bytes": 1155,
+     "sha256": "1dd438fe98f0dc1b4aae7d13d268201a0e4ca374e1593f40a470f59ee929303d"
+    },
+    "maps/eld1m1.bsp": {
+     "bytes": 4363656,
+     "sha256": "65734ae9d03ad741d224a2f84ece89f61f4c8f0431c5c5db98c602125b3ce00c"
+    },
+    "maps/eld1m1.lit": {
+     "bytes": 1341404,
+     "sha256": "b47eb0de7c5af4d69c5243d3b8aaed3ff2e6d5b427af9db88ff0edb58de40d54"
+    },
+    "maps/eld1m2.bsp": {
+     "bytes": 4455056,
+     "sha256": "df9c00dccff3651c4213c59be7e30ebbac280ae52073c03e352c8fe2d1791b58"
+    },
+    "maps/eld1m2.lit": {
+     "bytes": 1296302,
+     "sha256": "9425c5cbf59b0e67d6e9aca7f5f27096f7229cc62efbc90271aa297cc13e9ec0"
+    },
+    "maps/eld1m3.bsp": {
+     "bytes": 3203776,
+     "sha256": "c039005591c20fe2b610683c66a7fb48f0bb5ac2c85d4542ee00b8db948485b4"
+    },
+    "maps/eld1m3.lit": {
+     "bytes": 1395722,
+     "sha256": "1483bf6668f0d46c7bfe2890916ff8b511136fe2ffbcca4b1d5964e4a172ab74"
+    },
+    "maps/eld1m4.bsp": {
+     "bytes": 2178328,
+     "sha256": "434889c00b1b5d298322d5c01c7eaa019ab3303aadd8b2603669b41936f6566c"
+    },
+    "maps/eld1m4.lit": {
+     "bytes": 783182,
+     "sha256": "336fb747471d127475b17515ffb004fbc0fded2c397f36598bf94d8366ae34df"
+    },
+    "maps/start.bsp": {
+     "bytes": 1145808,
+     "sha256": "8359dbf80e6d77eb3b3653fde1b4c89324492c366292b748f83680417683dd34"
+    },
+    "maps/start.lit": {
+     "bytes": 235652,
+     "sha256": "b4bc736ac94b5630a6ecd0a4e8dee39d547be57aa5c406e2e4c398a403c444ce"
+    },
+    "mg1.wad": {
+     "bytes": 3321924,
+     "sha256": "dc291199f139e2d26cd7d8b4a1f34e2ed058fe39758886a7f972ac019549f70e"
+    },
+    "music/track02.ogg": {
+     "bytes": 7339899,
+     "sha256": "19088385e6096ba37b111646e3b29a40e444120ca0aa2e04c6bf94f915b6cfc9"
+    },
+    "music/track03.ogg": {
+     "bytes": 2929576,
+     "sha256": "9e61ab6e40b490c20a360954d61535aa11dfad959531542a926be5d24547cec7"
+    },
+    "music/track04.ogg": {
+     "bytes": 3418846,
+     "sha256": "32ffa4cc8318b9b5282c59bab30532158e2bc28dc154d1585be86128691db0ca"
+    },
+    "music/track05.ogg": {
+     "bytes": 7728800,
+     "sha256": "fbdc8867217a41760bd9b39793107946f26d56e83123064a092025ffea3a14c8"
+    },
+    "music/track06.ogg": {
+     "bytes": 7084234,
+     "sha256": "44d4dc527033ab9a7b414d4fcbb5a45d4aa320dd8944986d494b9347a81678f8"
+    },
+    "music/track07.ogg": {
+     "bytes": 3436962,
+     "sha256": "d2690a6f3a2157ff8dacf0d60f86b1495ce2683860e35c42bda21864cfcff81f"
+    },
+    "progs.dat": {
+     "bytes": 339702,
+     "sha256": "18f6fdc7f63e9394e4ac6b7ca9abd040caf91792a69bbc63b20ddbbaf7b4fafd"
+    }
+   },
    "sha256": "b6fcfcd84407fefca304afee3caafc926fec9e1774ffa9a8e764e9d345abf154",
    "timestamp": "2023-11-07T19:06:28.000Z"
   },

--- a/json/by-sha256/9f/9f0f090c6e6f48e8afacba6a0a8f23217ba159c226f678ab3fcdc5bfee479b08.json
+++ b/json/by-sha256/9f/9f0f090c6e6f48e8afacba6a0a8f23217ba159c226f678ab3fcdc5bfee479b08.json
@@ -7,6 +7,232 @@
  "files": {
   "pak0.pak": {
    "bytes": 19030168,
+   "files": {
+    "gfx/env/satbk.tga": {
+     "bytes": 786971,
+     "sha256": "0b4a792847376df7350fada08c9788fd7e345f176b79a725b0128ec913bd4e09"
+    },
+    "gfx/env/satdn.tga": {
+     "bytes": 786450,
+     "sha256": "096cc0e7bcbef18e3aedcb637aec067831d37372a1e7efc00a007e9e5a22c38a"
+    },
+    "gfx/env/satft.tga": {
+     "bytes": 786971,
+     "sha256": "b46edeb1ebd3173f82c87af6a115395bb00a132bca1217de1d70d67b7ff65c05"
+    },
+    "gfx/env/satlf.tga": {
+     "bytes": 786971,
+     "sha256": "d6156589706bf2448dbdcf10820aaed11b8f3b63ef82f98a843a40a2f8e89bb1"
+    },
+    "gfx/env/satrt.tga": {
+     "bytes": 786971,
+     "sha256": "d1063a365100d9e0502c7044bf9fe5e69e3b21590d4c4c1103229cc2926fa70e"
+    },
+    "gfx/env/satup.tga": {
+     "bytes": 786971,
+     "sha256": "1e8c52ff8687dc4524adfecea4928cbc410693c70c54acf7ff9449c5bcf17b19"
+    },
+    "maps/sparcus10.bsp": {
+     "bytes": 5619488,
+     "sha256": "79952d8fcea571de4a70a33362fe1d316b85a9e036fadcb444d8f43cf775f1e9"
+    },
+    "maps/sparcus207.qkm": {
+     "bytes": 1427578,
+     "sha256": "c2dbf18627b7c8f65f6e52f0f235fea100f6edfc7ad8d21d4c3f74a9c6f3d3c5"
+    },
+    "progs/amph04.mdl": {
+     "bytes": 321976,
+     "sha256": "b5b820489840cf4a3d984c099d3534ff5043eb01703593da7ffa5de48c93bbec"
+    },
+    "progs/amph05.mdl": {
+     "bytes": 321976,
+     "sha256": "afc8c6a15424745e87e1f3e3a4938d5000613d7755c606893a8439735ccd5fe5"
+    },
+    "progs/amph4.mdl": {
+     "bytes": 321976,
+     "sha256": "59a24ce0373de7916d50005de8763c4be87cbac1d4837db8c403a2b5ae553d19"
+    },
+    "progs/amph5.mdl": {
+     "bytes": 321976,
+     "sha256": "0825f5657c059b001f9551d8af96c11348e65b5dbe544ddc3429e2d666dc53c7"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 32271,
+     "sha256": "9c1a7f6492ade5e3a92fdc06d90486e3a7118fc662856e4fe54ac21beedd697a"
+    },
+    "progs/b_head.mdl": {
+     "bytes": 210320,
+     "sha256": "7945b48445e7de45cf90d8d75a61a52cbabd5113536ad7278dc2889d9cdde868"
+    },
+    "progs/beanes.mdl": {
+     "bytes": 208612,
+     "sha256": "64cb51e8573108311b865be04ab17fdfea13e1f74a1cebd49c09fc61e597c173"
+    },
+    "progs/bonepak.mdl": {
+     "bytes": 212658,
+     "sha256": "76464f9d8865bb5a996ec355be574b5cb698669edcea8f2c9c5bc93240bcab29"
+    },
+    "progs/bones.mdl": {
+     "bytes": 384572,
+     "sha256": "7d1f86ccbba7a8bc3416df4c09f52dc48568937bfee9707f8fbc9d2917861e0d"
+    },
+    "progs/dat/progs.dat": {
+     "bytes": 461076,
+     "sha256": "a3bebb6dca930bf4dd8da8a8e669a9948b31c0bf20e0607c2cdaa2f6440ef823"
+    },
+    "progs/dat/vvfqc.zip": {
+     "bytes": 124695,
+     "sha256": "d4c7aee6fd840de437b8eaef6fd591d2c5643a4683ab46b6fa412c34c31fd3bc"
+    },
+    "progs/granito.mdl": {
+     "bytes": 369889,
+     "sha256": "ae5518f25a3bce10e020a300081a62b899c8f9ada7c9867b26f7ef32de53bbd3"
+    },
+    "progs/knight2.mdl": {
+     "bytes": 906092,
+     "sha256": "2eab67477ec888e389a7d7ee6706ffc1a628e9dfa56a58642e2bb1d336d66495"
+    },
+    "progs/rock.mdl": {
+     "bytes": 48589,
+     "sha256": "a31d125a0a00bf12813c9f7eca832c81935729c3da6087b129250fde99a12df0"
+    },
+    "progs/rocks.mdl": {
+     "bytes": 108046,
+     "sha256": "f29398ff7ac7adbb48ab3b6bd951af4e64e50dd543313b644c7089d37a5708aa"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/stand.mdl": {
+     "bytes": 74571,
+     "sha256": "9ce394ac01ca08a1a174c3536505fafe3ee0dca475adea88f9a875665f15e15e"
+    },
+    "progs/stand0.mdl": {
+     "bytes": 74571,
+     "sha256": "8fedfb673c235e47718b6735305f125ad7018085c42207b09275fe2f25829f0a"
+    },
+    "progs/street.mdl": {
+     "bytes": 65175,
+     "sha256": "cb040b4c29dd77273cc0ce6e7785f794d449f62fff5bf13c57af5f88f6065642"
+    },
+    "progs/tbone.spr": {
+     "bytes": 56920,
+     "sha256": "dedf5f165c73a773a1098a57677e467a30a21ca9710b004a513e8e12be4c412b"
+    },
+    "progs/terra0.mdl": {
+     "bytes": 130047,
+     "sha256": "d60f14f92fa037e02e3169f4dce056cf0f4388874bb8f96e127ecd5d1d730144"
+    },
+    "progs/terra04.mdl": {
+     "bytes": 166393,
+     "sha256": "599eb89e88a557649561219dc33d392d8aba55c0640759e15edeb1457d0f8fc1"
+    },
+    "progs/terra07.mdl": {
+     "bytes": 159399,
+     "sha256": "dd87261d155ede72924243f369136f5fcaa2f45dadf6ec6cc082d4d295d3ed66"
+    },
+    "progs/terra070.mdl": {
+     "bytes": 152872,
+     "sha256": "20af90b06bdfaa4f09d4c2dc0316dbe90baecb636f1aa25f29e9a3f291baef3a"
+    },
+    "progs/terra08.mdl": {
+     "bytes": 152328,
+     "sha256": "f8bb4bd548cf196277e77673292105cbf20c43681a4b8eea7632f7f97e1625e8"
+    },
+    "progs/terra09.mdl": {
+     "bytes": 152872,
+     "sha256": "c23fab67886e03654e5873edc9e495762c29bbedbe16f5f78243d0ac7b166b87"
+    },
+    "progs/terra10.mdl": {
+     "bytes": 152872,
+     "sha256": "2977acdf87ec4d47a885e2e6020f5d7792d28b8254c1313c065eaaa8a3c47e07"
+    },
+    "progs/terra3.mdl": {
+     "bytes": 130047,
+     "sha256": "f78630ce780cbda48e88a8d6b3e5fd0607db73e4eb0661e1f34a89a4e22c5765"
+    },
+    "progs/terra4.mdl": {
+     "bytes": 152872,
+     "sha256": "280083780023ec84dfa1214158afe305bf98296f9b14fccce910d86bcb451bcb"
+    },
+    "progs/terra40.mdl": {
+     "bytes": 152872,
+     "sha256": "f6e88a625b202fcf8d78964d8b6ea346e6883476e85ca4c873f31beac9b426db"
+    },
+    "sound/bones/death1.wav": {
+     "bytes": 16330,
+     "sha256": "92ebbc39ae0da38fad1ab43105c53ce9a6459153a8a4bb2d9199b7014d6f5f42"
+    },
+    "sound/bones/death2.wav": {
+     "bytes": 15590,
+     "sha256": "fccadd7a04a58352b9287abb531061363c33657642bfb902d29e9238292c1c96"
+    },
+    "sound/bones/idle.wav": {
+     "bytes": 44310,
+     "sha256": "b824bc08c7f981c0ea86f1d4d947ebbabae81c4d5d97fca83c2325e1d9d0fe6a"
+    },
+    "sound/bones/pain1.wav": {
+     "bytes": 13690,
+     "sha256": "8e4f93877c7a9f8bdbcca51f6a65ea1a7dc53e8a93c27cd12fbad817fed91b92"
+    },
+    "sound/bones/pain2.wav": {
+     "bytes": 7156,
+     "sha256": "1ba93cf533e1be9b4aac334dd5e3e6c6796fbfec9ecd12554adda6551900137a"
+    },
+    "sound/bones/taunt.wav": {
+     "bytes": 29510,
+     "sha256": "4e13da72b7319e10fa4ba32c6276a4e3777ec90f4d7c98e9b354361751ce4880"
+    },
+    "sound/granito/beat1.wav": {
+     "bytes": 18002,
+     "sha256": "ae8f7961857da0a8cbcc5d10c93136daa3571edf5b33c24b66901e308706faca"
+    },
+    "sound/granito/ddeath.wav": {
+     "bytes": 16686,
+     "sha256": "ed15a613cc9722b56940c144581b97a059817df0aa6d4729eeee07acc35a25ec"
+    },
+    "sound/granito/dpain1.wav": {
+     "bytes": 30364,
+     "sha256": "f630bb31b7b2bca6c64f18e3c3c50d8264f4fe043a1c99f3fc1a3ee54d41059d"
+    },
+    "sound/granito/idle1.wav": {
+     "bytes": 55556,
+     "sha256": "44760eb0a7748696a5fdef23dc891ad771ce62c8ba622c9456540361dd1654c7"
+    },
+    "sound/granito/rock01.wav": {
+     "bytes": 62076,
+     "sha256": "df91491ff15142a9544299b8f816d53841c82646672e998fbc11733d7e7b7c37"
+    },
+    "sound/granito/rock02.wav": {
+     "bytes": 123262,
+     "sha256": "d7f2c76924e498085124d119ae2fe44fea46065081300edfa8a0e105d06997ea"
+    },
+    "sound/granito/rumble1.wav": {
+     "bytes": 27748,
+     "sha256": "cd4755b75fcac1a41d2cfae2eaed6713fc90e2e5413a4935a0cdb87aed67a4c6"
+    },
+    "sound/granito/sight1.wav": {
+     "bytes": 61080,
+     "sha256": "0c03f8de301767cee6456fcc22914136ef3e646920439a6fe57a9d15b5bc02ee"
+    },
+    "sound/weapons/cbow.wav": {
+     "bytes": 18930,
+     "sha256": "fb6b0ea2e7168fe33e0d456d9b7058209a5f8a0852d7f28a3a6089a1a8b96e79"
+    },
+    "sound/weapons/pling.wav": {
+     "bytes": 15730,
+     "sha256": "4e839d9db32215b408e185dbae706c570f484b936687e0e09995da3fa12c7878"
+    }
+   },
    "sha256": "9cde8bec24716bb5fa03d82ac59d6b4fa1e45e4b353a09de68c85e7d1b5b5ca0",
    "timestamp": "2010-08-30T22:39:28.000Z"
   },

--- a/json/by-sha256/9f/9f9bf9d09ad716b77e0bb4d6c0cce7aea6ef14f937adf18bbd0ceb647b9e44bc.json
+++ b/json/by-sha256/9f/9f9bf9d09ad716b77e0bb4d6c0cce7aea6ef14f937adf18bbd0ceb647b9e44bc.json
@@ -7,6 +7,352 @@
  "files": {
   "PAK0.PAK": {
    "bytes": 18122087,
+   "files": {
+    "maps/fc1.bsp": {
+     "bytes": 1016240,
+     "sha256": "753393cffb98cf1bbe11d8a67f354efadc8fa810233f58b3a3f7fe58400aa5c4"
+    },
+    "maps/fc1m1.bsp": {
+     "bytes": 2173720,
+     "sha256": "7ce13219cc0a0a0c6eef26a439723ab95e17525581a26d1c5017cb5ee16e8d0b"
+    },
+    "maps/fc1m2.bsp": {
+     "bytes": 2883560,
+     "sha256": "fa79f488e960c0a1dc5af767aa37c3ad03ce4cd77d732bcce3a71c36c0e54c9b"
+    },
+    "maps/fc1m3.bsp": {
+     "bytes": 2174352,
+     "sha256": "89f546ab52188deea38b44510737c21552bd7261fe41516399b3f2f169c31db1"
+    },
+    "maps/fc1m4.bsp": {
+     "bytes": 3782864,
+     "sha256": "c135021eab6b79d996de070cecd35cd7519d62fc10d1023932c281d538960b9b"
+    },
+    "maps/fc1m6.bsp": {
+     "bytes": 1172876,
+     "sha256": "3ca29b0d94b93e311a250c899d313b2f607fa7c88667e364f17e851bf465075f"
+    },
+    "progs.dat": {
+     "bytes": 494336,
+     "sha256": "3a5a741e01a1a6bd5a4271cdea57fbe838b0139d495e88a4e81730e9540691ad"
+    },
+    "progs/archer.mdl": {
+     "bytes": 345872,
+     "sha256": "6c466d568b2877776d1cbc959a14101e8842066889e348bad3469665fc6d2458"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 10644,
+     "sha256": "e5bf299e7c6dbca3ee4c3c9dbb3649600d5caa8204ede96fb158547676728e29"
+    },
+    "progs/bag.mdl": {
+     "bytes": 27124,
+     "sha256": "7e9354788d3e63de070e2c2aac7f4f9c0cd964f99deb6cde96fa1d27582ec632"
+    },
+    "progs/barrel.mdl": {
+     "bytes": 40408,
+     "sha256": "ade0144aa201463a1aa5ad8719a69d74b36ba8e6f17ab8d4a06a5d4329f8bcaf"
+    },
+    "progs/bench.mdl": {
+     "bytes": 32852,
+     "sha256": "f50bb4d1cfd9b6eaf882a4ee5281c2093f8f25f2967ad71661f7f39bf09b086c"
+    },
+    "progs/bush1.mdl": {
+     "bytes": 31556,
+     "sha256": "5ebc40065f4e8db7efca9bb36f33f0fca69d1f8cf50e3c5018e8ed8c5e1bcec8"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/cauldron.mdl": {
+     "bytes": 11040,
+     "sha256": "6c081225f130ce85b6a3d1bdd836aba5b90985634a596fe808fdf4baa28d37ff"
+    },
+    "progs/cbowman.mdl": {
+     "bytes": 270604,
+     "sha256": "a051b232fc0e4679ac83e4b6f074e8f5371f72c4b9a3fa09d8620df1835f2759"
+    },
+    "progs/chair.mdl": {
+     "bytes": 9364,
+     "sha256": "ef2e4cc1c31f169782502119e62236b64aafcf2451211fb51db70bda6eed6ba7"
+    },
+    "progs/chest1.mdl": {
+     "bytes": 19352,
+     "sha256": "41c0eb4dcf1ad9ec78b7969005b5fc02a5a2083d28d134cfd1a361fdfa4d6446"
+    },
+    "progs/chest2.mdl": {
+     "bytes": 42400,
+     "sha256": "ef265a200d982713176c44334348cdd0e93450570794d14456a784ec5942793d"
+    },
+    "progs/chest3.mdl": {
+     "bytes": 13164,
+     "sha256": "4f64cd7772380bd96fff0e8ddc748dc9aa48d98f7fb67d676d30d1363aea2e53"
+    },
+    "progs/crusader.mdl": {
+     "bytes": 588488,
+     "sha256": "f99a9b0872054f80b8297f868db30c59c963fb10151744e8904b5cc3c74224d2"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/knight.mdl": {
+     "bytes": 153400,
+     "sha256": "e98c538b3eb42a472361f7398abcf279f444ab36cff2f60fafe53507ae47e095"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 69835,
+     "sha256": "f53ab3e269295e00aa91e3bdc5181febc028b61184d5707a0d03bde84ff3d66d"
+    },
+    "progs/plantgen.mdl": {
+     "bytes": 23544,
+     "sha256": "a0920f607c518c6c6832bfdc08ccc0989681bd2b38f8a64689fbc9c4f2d10af0"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 200848,
+     "sha256": "4c0653e3adba99be4d581c92a928fd6e8c27b0a2159a97f7ec5e885478249b8d"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/stool.mdl": {
+     "bytes": 7196,
+     "sha256": "ddce6076cd5121799d018e652ed39b8c283a595afb9e19d9bfba8219b77c6553"
+    },
+    "progs/tree.mdl": {
+     "bytes": 61692,
+     "sha256": "0515f7330eda93b99ca0ed4820e911be0a0a1f81126f7667ab4969e3014c1c2e"
+    },
+    "progs/tree2.mdl": {
+     "bytes": 157908,
+     "sha256": "a2262cae715af4ebe00808f10bd2181d8e7caf4025dbd4f3c2c95f3efbc0e737"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "ba9f52e66ac380306d443e07ee4f1fac92793cba55394c01590c3dd088042e78"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 133676,
+     "sha256": "0a57ee912df3142c5e17183d5f6bd461021b141d53f7534014d59eda97e6bfa6"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 218680,
+     "sha256": "4816db0344c711561b16a208bfa14b6099459ebbac42b5e7178398587c670c17"
+    },
+    "sound/ambience/amb24.wav": {
+     "bytes": 23564,
+     "sha256": "a2cc72283abbb674019a3f583a19af11e4a7c0299f70fb5df5a7148cd5fd1c58"
+    },
+    "sound/ambience/atmos.wav": {
+     "bytes": 28868,
+     "sha256": "a6cec6a63dca9fda317f925dd846d09c536020378b859aede9881d2a18f0bc1c"
+    },
+    "sound/ambience/creak.wav": {
+     "bytes": 54650,
+     "sha256": "2d654ec42d41ca32599c2f371002f2726aa4a14905c23b4c7fc52d58486069cb"
+    },
+    "sound/ambience/floorcr2.wav": {
+     "bytes": 4446,
+     "sha256": "df59e476e42feeec2d3b24abb10ac27b0da87b15bd1763e0ef5a271b1eb2bdf8"
+    },
+    "sound/ambience/pump3.wav": {
+     "bytes": 40435,
+     "sha256": "ae8ca71a1ce41bb3fa02d993930b4f100db3827ef5768326a91e61f7857370bf"
+    },
+    "sound/ambience/rain.wav": {
+     "bytes": 33302,
+     "sha256": "849c1138ef26069dd0b04d0c4d3452a3f3add23800273961cc1656844afcabeb"
+    },
+    "sound/ambience/rattle.wav": {
+     "bytes": 51194,
+     "sha256": "c52c603be7bb057188eaa43dc95578029248d244a6da4cc072649eaf8cd17c0b"
+    },
+    "sound/ambience/rockfall.wav": {
+     "bytes": 24764,
+     "sha256": "db0910e1f2468508cd300b62cb367bcc8812edc30fc5b2435b41eb6a04a9f8b8"
+    },
+    "sound/ambience/rocks.wav": {
+     "bytes": 32438,
+     "sha256": "ffcb14e290eda3f9df6ac9b8f098b84dd11d2dd03709dd381e05e74de8ff4a56"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 43908,
+     "sha256": "f8972646a9313e91db32d6abc055ee524f5e8d2d5bca4228e3dd3841b3ac95d2"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 140440,
+     "sha256": "1b0e669098e76f5777b0177c888e6ab5597c7e1f089155435d8fe24b548aea71"
+    },
+    "sound/ambience/windfly.wav": {
+     "bytes": 106165,
+     "sha256": "4637506dd0a499fc5540a0c996e45472e8e2ce53e7807f197745733f3bbe8e97"
+    },
+    "sound/duke/dthgroan.wav": {
+     "bytes": 35002,
+     "sha256": "34adffc88c927a2468a8cbf330247cbb1e5bc49771e6bd4691802da14e17b49d"
+    },
+    "sound/duke/idle.wav": {
+     "bytes": 11062,
+     "sha256": "0dab92db72595d0a9191813ac7b9ee104019939065acb4b94e48b4e7f9992261"
+    },
+    "sound/duke/palpain1.wav": {
+     "bytes": 3836,
+     "sha256": "f06c625a12c983808c01bdc2510b9380cc6c9c3cee1352ae3f64611faf75835e"
+    },
+    "sound/duke/palpain2.wav": {
+     "bytes": 4444,
+     "sha256": "eaa6e738d2787208dd4920f5d60ad4285827950e75c8df82c698f440b0f0e840"
+    },
+    "sound/duke/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/duke/vorpswng.wav": {
+     "bytes": 4672,
+     "sha256": "10efcd16502ec8f56f4d4474947eb293f0bd231068523531f0f860dd6444c004"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/misc/bshatter.wav": {
+     "bytes": 15790,
+     "sha256": "d3c628dd512353c15d4718b81b4fe04d3bd82d757b1a3f97b1361efd1ac9e05c"
+    },
+    "sound/misc/ddoor2.wav": {
+     "bytes": 7780,
+     "sha256": "ee774d11d971550165e2098739238ccf7dc982e99ad7c1b5dfe1e2caffdb173a"
+    },
+    "sound/misc/dooropen.wav": {
+     "bytes": 5212,
+     "sha256": "273a42458893bf448c0fe8577338ed1f4d34c5073c9e28cf28cf561115231fd6"
+    },
+    "sound/misc/gauntht1.wav": {
+     "bytes": 4104,
+     "sha256": "5ab8c2b51baa9109b74028424bb7f79aee4ef67a0f3af43aac82459a7d3823c4"
+    },
+    "sound/misc/gong01.wav": {
+     "bytes": 349628,
+     "sha256": "e156fa7ea758a333ab4660f0b68098515004a514e0c18955aa92295bca7b1399"
+    },
+    "sound/misc/pushwood.wav": {
+     "bytes": 13602,
+     "sha256": "7c3fa06978f8c7b632d12bbf1031a5ac316b44fdc5efd93338ab0a0a162bdf3a"
+    },
+    "sound/misc/talk1.wav": {
+     "bytes": 1810,
+     "sha256": "05bbf733dcb2b3d3b11a9181aefde455e2ca952c753bf512b50625ff869f1cbb"
+    },
+    "sound/misc/tel_1.wav": {
+     "bytes": 117872,
+     "sha256": "b3bf4c145e65e6be4d5dc9c8c4dca291ff95ae12b643004cb5fe38cf231b3dc5"
+    },
+    "sound/misc/tel_2.wav": {
+     "bytes": 117086,
+     "sha256": "52a870c013d481adadd4dda4c1e31505e3a0ee73af4cec9cfac5889fc560b01d"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/s_wrath/swrath1.wav": {
+     "bytes": 6028,
+     "sha256": "7d2290479c4b8fe3cbf14b8e1bddbd6a874b5e9d5f436233eec562f35ca8cfb3"
+    },
+    "sound/s_wrath/swrath2.wav": {
+     "bytes": 4052,
+     "sha256": "7f9ae2dcb54b6e59c67705c20179a963bb8218d4c96db4323d1fedfb4ad39afb"
+    },
+    "sound/weapons/blund.wav": {
+     "bytes": 17592,
+     "sha256": "a142ad8e8ccc7c86ace43a15de7549b815a482dc6ee4a34e5d1b4e4d7b004b24"
+    },
+    "sound/weapons/bow.wav": {
+     "bytes": 5276,
+     "sha256": "64e183f35ac14d5c918e35adb997443370d82fec5f687309d81221d6025ba6b8"
+    },
+    "sound/weapons/bowhit.wav": {
+     "bytes": 4452,
+     "sha256": "48038121b7b8d24aec7fb8b2f6a48e761a0cabe6c107dc3d87b45011704bb425"
+    },
+    "sound/weapons/cock.wav": {
+     "bytes": 5120,
+     "sha256": "b0ef85c2fd8a34cde10fb65717c5d5eadbd0a35d7c026800994603b018ea6ff1"
+    },
+    "sound/weapons/crossbow.wav": {
+     "bytes": 9354,
+     "sha256": "da48c791fd4306762a4e0970dbc5db401881f123e73b654a04b4eee52ce5e8a2"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    }
+   },
    "sha256": "93eda599d779a50a646469ceb932439d90f197697e46214ad8ff24badd3f59ae",
    "timestamp": "2004-06-22T16:30:58.000Z"
   },

--- a/json/by-sha256/9f/9fce1af35ef7f635990be949d75f7faa18cc198bc19d9adc7d0575e234ab1139.json
+++ b/json/by-sha256/9f/9fce1af35ef7f635990be949d75f7faa18cc198bc19d9adc7d0575e234ab1139.json
@@ -15,16 +15,2002 @@
   },
   "pak0.pak": {
    "bytes": 48226771,
+   "files": {
+    "coop.dem": {
+     "bytes": 2575532,
+     "sha256": "214de04930a259e6a37101fb8a8838d7af07e6bc79efaf7525ca3b68610d5a3b"
+    },
+    "gfx.wad": {
+     "bytes": 128932,
+     "sha256": "6f7878b23deb09b151a58b8357f8a5b966cc87dce24a52407d931ceef885fbc5"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "d3608be2643c55487f8a90c2bbfb72f7aa8a0fcaa72cd4e156943a59fbeae68b"
+    },
+    "gfx/env/bseabk.tga": {
+     "bytes": 786450,
+     "sha256": "d00b39ceb291dc3a56f1b65cb40d90cabd49495785cf7754ee93920985e8946c"
+    },
+    "gfx/env/bseadn.tga": {
+     "bytes": 786450,
+     "sha256": "ac81fbab4610004d3b8f9f26fccce1aa9bf013414f714b261177eb7a23730c9f"
+    },
+    "gfx/env/bseaft.tga": {
+     "bytes": 786450,
+     "sha256": "cd36bc74f3f779b70c05e9394f74d0dd62655fbff8206e4828d9e1d669b05416"
+    },
+    "gfx/env/bsealf.tga": {
+     "bytes": 786450,
+     "sha256": "94ad30078b5516ff4baaffe003f73fdfd10a9446ab1c5239474a6fe46bcb588c"
+    },
+    "gfx/env/bseart.tga": {
+     "bytes": 786450,
+     "sha256": "ffa0b7fc5b127c82c3a73dc576bea00cd95b9b7697db377ea457fe9275a38290"
+    },
+    "gfx/env/bseaup.tga": {
+     "bytes": 786450,
+     "sha256": "5c69640f2d24cf1f39fe632a3315e4e810628725e77fa967bda7a215e76df9f7"
+    },
+    "gfx/env/duskbk.tga": {
+     "bytes": 786971,
+     "sha256": "c6ff35f38b5262c301fafd7857305cf80636efd9b67c72f511a2e93a2648d220"
+    },
+    "gfx/env/duskdn.tga": {
+     "bytes": 786971,
+     "sha256": "5a844ff50a7e7cb3115c94cf97c36fb55a998baf8a3e38118bc4524f03d533fb"
+    },
+    "gfx/env/duskft.tga": {
+     "bytes": 786971,
+     "sha256": "c1142a0e3bba1d2b65f887c000b6b5e450fe08474d6a5d026532b63e73d03a01"
+    },
+    "gfx/env/dusklf.tga": {
+     "bytes": 786971,
+     "sha256": "1735e4c258ab8d18b971345b43c79991bf76c2c178344739c26d79d7658128e4"
+    },
+    "gfx/env/duskrt.tga": {
+     "bytes": 786971,
+     "sha256": "4cdc3edcc8c0c1ec938ef7e4297931cf1bc4ebd804660011725bc7f3abc61ddb"
+    },
+    "gfx/env/duskup.tga": {
+     "bytes": 786971,
+     "sha256": "320e8dd8e6adc4453d894d15d20ba3ad02f176af3dd4ab1baab695e0a4accfef"
+    },
+    "gfx/env/fodrianbk.tga": {
+     "bytes": 438466,
+     "sha256": "023a119b49e2a3630b156cf622fdf0d9efe6a8144d1128542dad3a36852d571f"
+    },
+    "gfx/env/fodriandn.tga": {
+     "bytes": 526472,
+     "sha256": "ece0abbb9d478368c9b80fca7fe03ab2cfd349d0d087e134b2ac7d5f8c61ba89"
+    },
+    "gfx/env/fodrianft.tga": {
+     "bytes": 491268,
+     "sha256": "1914f73da39bd55a6a167508a3e0474cdf8f9047b59fbf74113c50cb1a682d0b"
+    },
+    "gfx/env/fodrianlf.tga": {
+     "bytes": 502698,
+     "sha256": "c75d67a6f12f9e96fe5af60ec6f7a6d93778371d3bf141f28e750ff6113945a7"
+    },
+    "gfx/env/fodrianrt.tga": {
+     "bytes": 468382,
+     "sha256": "aad1a02a8c636463fbee3178aaa69b90380b96d8550c581ab74fc91ec05f6e9c"
+    },
+    "gfx/env/fodrianup.tga": {
+     "bytes": 538367,
+     "sha256": "31a61f7f5f476a81a2191153794770fbcab42c61e9f32253daffe78f38585b75"
+    },
+    "gfx/env/graynightbk.tga": {
+     "bytes": 786971,
+     "sha256": "3cd8f98206a4267c0cbd7a8028dd55a2869e4a0840a45c89e4a03d1300d970bf"
+    },
+    "gfx/env/graynightdn.tga": {
+     "bytes": 786971,
+     "sha256": "2d2e929246612062e871629464e8508a0dc9fe35680015e90a441c6c20e1a936"
+    },
+    "gfx/env/graynightft.tga": {
+     "bytes": 786971,
+     "sha256": "387759c32fdce1b459b7fad63f47ca35c5755794aa960c8486b2e4de24c59949"
+    },
+    "gfx/env/graynightlf.tga": {
+     "bytes": 786971,
+     "sha256": "16654901eabc2f4da7ac602c240932acd73cc5831e29afc4dafc51cd2daaa9b4"
+    },
+    "gfx/env/graynightrt.tga": {
+     "bytes": 786971,
+     "sha256": "4f13113e77b85644febb7baff162c19cc353f4257322826389974e516ffd77a6"
+    },
+    "gfx/env/graynightup.tga": {
+     "bytes": 786971,
+     "sha256": "178c815e62bb236b75d967e502ed4a93eba64cd12818081f6f41591860b3d4da"
+    },
+    "gfx/env/starsbk.tga": {
+     "bytes": 51294,
+     "sha256": "7292194bfe9a6444173b6c4949568ec42cd6900883dcc444da0f2344fe3d4d69"
+    },
+    "gfx/env/starsdn.tga": {
+     "bytes": 51322,
+     "sha256": "59e645a79cd93b98c05de9c2f8a136394ab561ce0b9978aad4de17c6508da60b"
+    },
+    "gfx/env/starsft.tga": {
+     "bytes": 51685,
+     "sha256": "2dc8d4ab7cdd655c2a63bfe7059815bedc56692a5c1867191d12433958f633c5"
+    },
+    "gfx/env/starslf.tga": {
+     "bytes": 50756,
+     "sha256": "f74f36da6239c9b011b6ecf1f0fabf7c40f3372fe3841d2168473a31e16e646c"
+    },
+    "gfx/env/starsrt.tga": {
+     "bytes": 52319,
+     "sha256": "9ce812f2efe3dd4fb077bc751fc8209de661c04544e54c3271b956316b7c162e"
+    },
+    "gfx/env/starsup.tga": {
+     "bytes": 51416,
+     "sha256": "d31b6a617776b2ccd90662ec1196267ac4c8be85696b9702ec39c41386f2fc47"
+    },
+    "gfx/env/voidbk.tga": {
+     "bytes": 603,
+     "sha256": "6e095aecdb2ee0ebb2636b48ce7f7754ee357b217f32a83025830db3d9a87fdc"
+    },
+    "gfx/env/voiddn.tga": {
+     "bytes": 603,
+     "sha256": "0c7a0cf2c30d6d87f21567c4e4dacedccc3840fb82b37bfd8c0949315526cc46"
+    },
+    "gfx/env/voidft.tga": {
+     "bytes": 603,
+     "sha256": "bc18cbf4e5c4036b64203d6a165aa18edf24d86bcee9b6e7c183bd54f456550e"
+    },
+    "gfx/env/voidlf.tga": {
+     "bytes": 603,
+     "sha256": "a350d7da744018421f60d6b95edc609f36d059ad27fe0621599c018e6ccbf3d7"
+    },
+    "gfx/env/voidrt.tga": {
+     "bytes": 603,
+     "sha256": "6447fc6c5ddb2a696fccd2611323758ce44be8a236ec9602ed9947b800d1240a"
+    },
+    "gfx/env/voidup.tga": {
+     "bytes": 603,
+     "sha256": "76c1a1a57bfc1099bde3814a7d998b842ad6f8b619d3e4e1169ab7ab8850f133"
+    },
+    "maps/e1m1quoth.bsp": {
+     "bytes": 4120260,
+     "sha256": "7ae26353d1d578c660fc399a5e46836a35477f772fb08039a1c75e5b409610f8"
+    },
+    "maps/kelltest1.bsp": {
+     "bytes": 896456,
+     "sha256": "a913e05c0b4b5fc09257ace118d55205b3e34f2f9e44e6184828a7150c7a6618"
+    },
+    "maps/kelltest2.bsp": {
+     "bytes": 507808,
+     "sha256": "f3874478333d08938247cff6dd23a9717763b42af87ed5283b31f85515404c07"
+    },
+    "maps/kelltest3.bsp": {
+     "bytes": 405700,
+     "sha256": "3e2497ca1bf2cd3aae0a0616066ab89288fa777ffacab11e1981f74f5ed8385d"
+    },
+    "maps/kelltest4.bsp": {
+     "bytes": 306912,
+     "sha256": "36639ed4b47a30328f358c1e63067020b273d8d831bc47dec4b24cc1599159f5"
+    },
+    "maps/ne_basetest.bsp": {
+     "bytes": 1196080,
+     "sha256": "1477ebc35c85b4d81ffc4bc623a75757c28b2d3a36c934763735b5947b656c47"
+    },
+    "maps/start.bsp": {
+     "bytes": 1927828,
+     "sha256": "4c452be3b25eed55d3df7e03baab033c5963cb82e09dc4e157299bec75fc792f"
+    },
+    "progs/air.mdl": {
+     "bytes": 5076,
+     "sha256": "930e21887f0c482f353d5009efe1f5ef3f88e18d7a4f2e1232978cb2e8f73932"
+    },
+    "progs/beam.mdl": {
+     "bytes": 3307,
+     "sha256": "18295a66ab4a4da70b5dc0558d5cac7622afd65e9937ebe8d2c5321a67a418ee"
+    },
+    "progs/bigexp.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/bilebomb.mdl": {
+     "bytes": 13469,
+     "sha256": "2f77d07f24b62edc095facdee8c670711cc189a85258a631ada71cd4746e26ac"
+    },
+    "progs/bilefrag.mdl": {
+     "bytes": 9216,
+     "sha256": "34e6ed3456aef2c89d4ab9d857a173bfa98c17381be380f9665d496791f6f814"
+    },
+    "progs/bob.mdl": {
+     "bytes": 177959,
+     "sha256": "173f9aa590a0b23e0525c86b6945f3b8d565b865f2376daea00ac8f88791abc1"
+    },
+    "progs/bobblaster.mdl": {
+     "bytes": 27556,
+     "sha256": "3aa3e956183dc641fe601edaae52b7f2d5c92d90d00e8994e106dde4c0c25092"
+    },
+    "progs/boom.mdl": {
+     "bytes": 77388,
+     "sha256": "c0b2d8695564dbb1ef37aef9a9e226160ff8f5ab40de7a6d7129a66675096179"
+    },
+    "progs/brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "0287c3e7886bd2d6d1cbb504529d9e11038d0f8232ee624528eb0ccb78733c53"
+    },
+    "progs/corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "22f82f29d0a88af204f7b97eef887b963bd940e7277b6f5cef5e6f3610f2ea51"
+    },
+    "progs/corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "41e90f1a84e9779eb12541d923ab0a66e69deef3a9dbc82259ab84cb71b68dcc"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/dguard.mdl": {
+     "bytes": 176648,
+     "sha256": "f2f92ef84411d83c7e8c158f62b1415d8fc6aa56d77f21760dcd3080424cf6c8"
+    },
+    "progs/drlbomb.mdl": {
+     "bytes": 20355,
+     "sha256": "5c1db489f43cba73fce265db642267775245d044866cdd48396b1f1260a28237"
+    },
+    "progs/drole.mdl": {
+     "bytes": 241648,
+     "sha256": "5067b7ca5323754fe563d6696025525645a2cbd3aaf7f79232634608f9fb987a"
+    },
+    "progs/dspike.mdl": {
+     "bytes": 13684,
+     "sha256": "05bc998adf950efaeba0f0216e008ec8d6fa732d5eb726dbe70ff07e088275c6"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 333860,
+     "sha256": "230181ce6ea00c8e80c7d59189340424424ba5d99d71230b309907e206e07682"
+    },
+    "progs/fireball.mdl": {
+     "bytes": 12660,
+     "sha256": "ba5cba46edc108572d78e66166f5ed0405a48dcf672e7a569d14a4397f85f285"
+    },
+    "progs/fish.mdl": {
+     "bytes": 90636,
+     "sha256": "037ebaf6566f8fed7609b4e2c79eb36c4c78c49d914b225e7aa37fd4e3d6fa17"
+    },
+    "progs/g_bomb.mdl": {
+     "bytes": 50176,
+     "sha256": "33bc7cbf807cdae850d42cd11af0d332a7ca140741a3d29353e558bd8468aaa3"
+    },
+    "progs/g_fx.mdl": {
+     "bytes": 32260,
+     "sha256": "ac99d4e641af0bb1495ed38ba9f3a7c1195bda19e5cf0d3a68f04defe6178ab8"
+    },
+    "progs/g_ham.mdl": {
+     "bytes": 71639,
+     "sha256": "424bd4ecf03e0f364f57448b7c426924e1e0ccd06dad40294c00a23a645b8c0a"
+    },
+    "progs/g_lance.mdl": {
+     "bytes": 32906,
+     "sha256": "6eab37228d67437eccd9735de6e7933c79576a921c23479ad317e7c3db5b1f0d"
+    },
+    "progs/gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/greenexp.spr": {
+     "bytes": 24732,
+     "sha256": "8cd2c8f20214cc1f8de491785a27d3aafa924819c9f56078d2bdb219d4f16f5e"
+    },
+    "progs/gug.mdl": {
+     "bytes": 482020,
+     "sha256": "2cd097236a235aedf717a86b7312bd7d1b3caa6f0b25980c82eee2463fee2274"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 4920,
+     "sha256": "337f2723daab9d1375b78cb017512ce8281087ff8df9c33b04a6c613cea3590c"
+    },
+    "progs/h_dlord.mdl": {
+     "bytes": 18699,
+     "sha256": "bc5a92be1c5f3d06dc0238ec7bafe6a3c25826cc50edc6214ed5aa19b0075987"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 16854,
+     "sha256": "00f3263f1c3e0daadaaf03eea447080d727ea7d9ee1a88f2b42e060d748e1566"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 61251,
+     "sha256": "dec5afe666eba8db6e32d7535fffa3d0e4ed9344ba107b73418526ebebac574b"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 10663,
+     "sha256": "819b7cd0c4c38edb9725dffa46913ed89d75276aac3ea34b2bc683daedd5db0e"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 32629,
+     "sha256": "d69f21f26e13276272bb6b59352e66082a224534e8a0e46753037136927e0929"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 23239,
+     "sha256": "00117347d1acc46beb4972853572e14ce3e9d6dca25b883540896fcd873f3e3a"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 1142583,
+     "sha256": "2c3d4002e7c5f1682367c3f649e67333303d1763e6da0b3cfdce8c7519dfc2dc"
+    },
+    "progs/keybase.mdl": {
+     "bytes": 11407,
+     "sha256": "5fed79622ad6f6751b2c771ddff06b88dcf049719336c228520bc84f0db441cd"
+    },
+    "progs/keyeye.mdl": {
+     "bytes": 37528,
+     "sha256": "a4612e183f026ea63161377682c1001b178b9e0f94f6b9a801b983962162dbbc"
+    },
+    "progs/keymed.mdl": {
+     "bytes": 13247,
+     "sha256": "e147a4e527b9b797680732c33cc0ebe3503bcd6e2c8a5b0917701cdd41f99297"
+    },
+    "progs/keyrune.mdl": {
+     "bytes": 25643,
+     "sha256": "f06fafe1b92a172a2cebcbc68ad5e2a8aafdfc99d13ce6d5bf5b36f25ca48f73"
+    },
+    "progs/knight.mdl": {
+     "bytes": 342850,
+     "sha256": "9e23eca66dbe332f49a1a82ceef197d5ee980abb24145050ea3088e05468dd4b"
+    },
+    "progs/longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/marsh.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/marshsm.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 3542,
+     "sha256": "2f3efa19a64b60d480fbef7c10e8f2a56e90d656e8fcb8bcd656932f8686f482"
+    },
+    "progs/polyp.mdl": {
+     "bytes": 211928,
+     "sha256": "36268021903129e7e0e81600072ff3b38229cb6851cc6800945d9810510fad0b"
+    },
+    "progs/polyp_t1.mdl": {
+     "bytes": 66925,
+     "sha256": "82f5f86f210e8cfc541259a3a9efe7b0b4a046f5b5240c5d39ab08a021a4e2ee"
+    },
+    "progs/polyp_t2.mdl": {
+     "bytes": 65473,
+     "sha256": "130699464f89836047b7bf6b4ad0ac7feee810dd31da5add2892e1f61ed07a30"
+    },
+    "progs/polyp_t3.mdl": {
+     "bytes": 64069,
+     "sha256": "72a5a60e71e09a4a0e73dba0658b301540b3d871ec4ea88e24ace135db19d046"
+    },
+    "progs/polypgib.mdl": {
+     "bytes": 5716,
+     "sha256": "dc2aae40f92f8c75057a664b583f9d790d010289e858b218adfc92de6d6be878"
+    },
+    "progs/s_bubble.spr": {
+     "bytes": 396,
+     "sha256": "f7efaea9964c8ad347f170dcfd2a6dbe5bfcf8dc074cffc385cfbf28f991c13d"
+    },
+    "progs/s_light.spr": {
+     "bytes": 7344,
+     "sha256": "45ae7c364a43b76d834476f49fe6c35423330cce41d8f3dbc90780f561bb51e7"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/s_plas.spr": {
+     "bytes": 5256,
+     "sha256": "ed01b728b6656a68acffe258d644712eba3b786434ab6b3e6d90434031e90d96"
+    },
+    "progs/shockwave.mdl": {
+     "bytes": 167520,
+     "sha256": "861ee3b0ab6edd5233740a609c4367c5ebe4108ffb03124861bf85047a314f5e"
+    },
+    "progs/smlexp.spr": {
+     "bytes": 105148,
+     "sha256": "ce4938c9e813e648404b25b82245cad4400682d885d044b9d353a8039cfdceb7"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 565441,
+     "sha256": "9d3da38ea15726d8543413120414d4178efd900fd131a7fd84eff5a305df21f5"
+    },
+    "progs/spore.mdl": {
+     "bytes": 13469,
+     "sha256": "fc9fbb97f0d4f1a9f843769cd43fb7270ba2b351cdf3b4b624d27616980457c4"
+    },
+    "progs/trinity.mdl": {
+     "bytes": 13249,
+     "sha256": "3e0d4636dfd20112bd5415e92c1d8f85fdda65a9a33b09111cca2bbf4561f349"
+    },
+    "progs/v_bomb.mdl": {
+     "bytes": 80804,
+     "sha256": "48c2393efb079787f56be5ab6fd0dc3e748b5ef009ba15830fe0f9898ad94b7b"
+    },
+    "progs/v_ham.mdl": {
+     "bytes": 84563,
+     "sha256": "76f03b4e5d8222c2c3b3d2f0e1156ac90708a42f4997f6a4555c01073dab49dd"
+    },
+    "progs/v_lance.mdl": {
+     "bytes": 87209,
+     "sha256": "5c50ded5952ab06ca91ff413edf17a167b21bed88b027571e643ffc515a71560"
+    },
+    "progs/vermis.mdl": {
+     "bytes": 656752,
+     "sha256": "d7060475e290482c61c122b3a477085b1aad002fd71d8293cc4a4f8bde1baec9"
+    },
+    "progs/vleg.mdl": {
+     "bytes": 4904,
+     "sha256": "cc9ac24012d342ed54eb1a3241bcc6baf16e40fb95a904a789845ed76b8606ba"
+    },
+    "progs/voreling.mdl": {
+     "bytes": 41852,
+     "sha256": "b10f3623291b5182ab6b987cef1c40abc362aae41638b8481709660e923cc46b"
+    },
+    "sound/ambience/nightmare.wav": {
+     "bytes": 34284,
+     "sha256": "2caac27dfee5758eb293e0c76bf86baf82b0522c6f71281160e805c6ec282f96"
+    },
+    "sound/ambience/thrum.wav": {
+     "bytes": 220542,
+     "sha256": "c925d73ef744b0a8c56507ff6fb18888de7ab803ea1f743060f8f9782180dcc7"
+    },
+    "sound/bob/death.wav": {
+     "bytes": 14348,
+     "sha256": "7f97f27dfda78f9fe6fc5265e512b651e57ae466752d56cfe0dccd6d08478ed8"
+    },
+    "sound/bob/explode.wav": {
+     "bytes": 36898,
+     "sha256": "e00cd6cf71662de858fd0b8f63409217c957d6e3dea571b759fe97aec9d58724"
+    },
+    "sound/bob/fire.wav": {
+     "bytes": 36040,
+     "sha256": "5f39b9f60c5de5c9c3ac25a5149f1fef557e66c09d7d1a760ed6770082c5a914"
+    },
+    "sound/bob/hover.wav": {
+     "bytes": 13260,
+     "sha256": "46441335fe896cb993368bb12cedc1ddd4886b5933298bb6a0d6b7ba430cdfe5"
+    },
+    "sound/bob/idle1.wav": {
+     "bytes": 44460,
+     "sha256": "de548d73ab2d96ea9d550b86e264d430b8c0429cd99dd10404f52780bda6c683"
+    },
+    "sound/bob/pain.wav": {
+     "bytes": 27006,
+     "sha256": "d5d07123eb3c15917dc265cfa6df8971ab215f4408847225827359e1c175ee6b"
+    },
+    "sound/bob/s_explode.wav": {
+     "bytes": 30700,
+     "sha256": "94f9b780d25154f8c04cbe297a4aeda13fb0669c0a21e48e2b46f0102c35375e"
+    },
+    "sound/bob/sight.wav": {
+     "bytes": 14892,
+     "sha256": "1a0db2b8c8d763f9aae09913d1cd3548fa0e30eb03949e24ef511a70acfda303"
+    },
+    "sound/defender/blip.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/defender/breathe.wav": {
+     "bytes": 32676,
+     "sha256": "7b673b07828790504caca013c18bf697fd53b758a3638b949b433cf2d72f03f3"
+    },
+    "sound/defender/sight1.wav": {
+     "bytes": 18260,
+     "sha256": "7d57825c28cf4f93189261d76cccab676aeba097920114d5d3f48d7eddaaa1cd"
+    },
+    "sound/defender/sight2.wav": {
+     "bytes": 18248,
+     "sha256": "b8b54fffdc7e2bfea51172cb8147407576f799181c1e6c2402433a546d8ee1c2"
+    },
+    "sound/defender/sight3.wav": {
+     "bytes": 17064,
+     "sha256": "25b7fc4212184996a7027211c543018f1dff539d3f9355f82a8da498d52b7a33"
+    },
+    "sound/defender/sight4.wav": {
+     "bytes": 16714,
+     "sha256": "deee8172ce02140002369c9807c513421a312240221113d86244e36300866758"
+    },
+    "sound/defender/ssg.wav": {
+     "bytes": 38828,
+     "sha256": "5c4e3a9baeec3f714ed00f2585d04256ac33582db911a026fdc56dea7f0a7dfa"
+    },
+    "sound/dguard/death1.wav": {
+     "bytes": 30610,
+     "sha256": "af3809501261ec4d0afa6ea7301c11a5c7bbc1cc3e06b8c88172ee0214c30969"
+    },
+    "sound/dguard/death2.wav": {
+     "bytes": 43636,
+     "sha256": "93a70fc0d6fee819c723a435a3954b3fd3be86e358698ce85db1062990d1575e"
+    },
+    "sound/dguard/fire.wav": {
+     "bytes": 60820,
+     "sha256": "f5e5d4f6ccc0778c1396c66d327564a0b1892773f2c23d2e30590abf0c758bd2"
+    },
+    "sound/dguard/hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/dguard/idle.wav": {
+     "bytes": 20498,
+     "sha256": "45b2f208b9796d19d7aeb0cba64e4b0e5fd2ed7c980123f7c41ca10d17785021"
+    },
+    "sound/dguard/pain1.wav": {
+     "bytes": 10380,
+     "sha256": "9a367afb7cde241099c58c999e225ba939be39f21be818b16444f5a810049960"
+    },
+    "sound/dguard/pain2.wav": {
+     "bytes": 14892,
+     "sha256": "827a1e4d3c9983f61fffd61de33054274c144bddd9a68460b496fd6281cf9406"
+    },
+    "sound/dguard/sight1.wav": {
+     "bytes": 18124,
+     "sha256": "9cb3d960261d90ec16c9883f4326c905356b6ff4e99cdf48ab5913b098588016"
+    },
+    "sound/dguard/sight2.wav": {
+     "bytes": 18022,
+     "sha256": "35ee4b7ec6715c8c9fdc24f90ad0b5d90a0ae7a4986168cf40670e87c325d5db"
+    },
+    "sound/dguard/sight3.wav": {
+     "bytes": 19948,
+     "sha256": "c6818770267626dea27f4a72ce2249771f6968924022c2275a5a96abfa485044"
+    },
+    "sound/dguard/sight4.wav": {
+     "bytes": 20332,
+     "sha256": "7affcdbdc62f13e492a15b54fe642fe045641f5551f570cc3c8d5f7ee29521fd"
+    },
+    "sound/dguard/slash.wav": {
+     "bytes": 22942,
+     "sha256": "44b60d785ff03f033e183b6fbce69e526351187d28efdeb308f6f8bea930d450"
+    },
+    "sound/dguard/slhit.wav": {
+     "bytes": 31956,
+     "sha256": "0f07a131640f21337cd89a772588ecfc707d6a729f96b54c21920b809cd620e4"
+    },
+    "sound/dguard/slmiss1.wav": {
+     "bytes": 10458,
+     "sha256": "e32d5cb070a13fad979b021e84a727f71242305ade1af7bfe18c255f0f6dd548"
+    },
+    "sound/dguard/slmiss2.wav": {
+     "bytes": 13840,
+     "sha256": "f6b3aee08c25434d2fda7468cacf35a0912b182653a45991149b54a0fc4be537"
+    },
+    "sound/dlord/death.wav": {
+     "bytes": 32022,
+     "sha256": "0188f6a3dd88686e15311f8c39c4277078e55bc0ec75497e2eb534af717abcdb"
+    },
+    "sound/dlord/idle.wav": {
+     "bytes": 9906,
+     "sha256": "c0ee37f80013dad1aaeb285a11a33c4d7c2ff2de0b2a94c2943d3fbe1c241bcd"
+    },
+    "sound/dlord/pain.wav": {
+     "bytes": 8632,
+     "sha256": "230ed5c7d024bfa90b973649aa79d9e9327eaf401b1632e4a1334fb4a9eb075c"
+    },
+    "sound/dlord/sight.wav": {
+     "bytes": 28028,
+     "sha256": "d82aa0028754e826705961040e1ab27f007c572a28c63dbcaeefeb681bc3ca85"
+    },
+    "sound/doors/eldertry.wav": {
+     "bytes": 76358,
+     "sha256": "769f4e43083dfa153a2cfdfb11c09920757a407c871f82957dbc9120de140230"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/explode3.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/sight2.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 83982,
+     "sha256": "4b0d8db882ab1c9fc2109effeaf125ec46fb23a91ac2242201103e0d3da96944"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gug/bile.wav": {
+     "bytes": 54572,
+     "sha256": "e06787585ef0369798a938a1a9585d24b60aa7b5c65acda3a5fb6f2c7ab65aca"
+    },
+    "sound/gug/bileatk.wav": {
+     "bytes": 50040,
+     "sha256": "b4b05e2907789a78391ccfe8ced3902821f1097ecd1f894b12ba9278d31a8717"
+    },
+    "sound/gug/death.wav": {
+     "bytes": 132396,
+     "sha256": "20bf209a832381b77d37c54a84ab1819b6c71e2147c5d122ac62668c070167a5"
+    },
+    "sound/gug/gquake.wav": {
+     "bytes": 43350,
+     "sha256": "d232ae13b55cb5b10b8903db43c037a5c6c4cdfea1f84f9399133484df6e0175"
+    },
+    "sound/gug/idle.wav": {
+     "bytes": 50580,
+     "sha256": "ff33c63696dec5c582ff9a4537814299b47ce2480d6cc53c116721d793576fda"
+    },
+    "sound/gug/pain.wav": {
+     "bytes": 22064,
+     "sha256": "e559f2b372fe771207aeef4b1c3a71baca542863493776558ae3f933f3878c29"
+    },
+    "sound/gug/quakeatk.wav": {
+     "bytes": 65882,
+     "sha256": "2c07b7690356bd9233a79c1f8b5f4e146cbabc367a19c138d6719a1e0d09328e"
+    },
+    "sound/gug/sight.wav": {
+     "bytes": 76426,
+     "sha256": "210ed86a5d6f9d4e791954fc3a4e4b4b6dc5839d02f7c19d468493a2f87dca64"
+    },
+    "sound/gug/step1.wav": {
+     "bytes": 15494,
+     "sha256": "4e2ce285991bc0d4337c77fdbb029507697ecb4dbf6543ddefe976ea114c4214"
+    },
+    "sound/gug/step2.wav": {
+     "bytes": 15502,
+     "sha256": "27f6f770a52fce5ae04836706e63ef455555de086019a2f9e44d4da1fc99b03d"
+    },
+    "sound/gug/step3.wav": {
+     "bytes": 15502,
+     "sha256": "fcc7ab38a8ec28509d0aa062a3cb93aee6da6a0ae364e4fe0dfad791f54558af"
+    },
+    "sound/gug/step4.wav": {
+     "bytes": 15502,
+     "sha256": "fc52cad29cca2e1fc36f5c6ac7f955ed897d6da4fb5dcf4eefd052e0652d93e7"
+    },
+    "sound/gug/swipe.wav": {
+     "bytes": 16064,
+     "sha256": "90bb5831dfd19f65df19e97f76d858ec940d8e33e0a2ed8fad89a23947e430e5"
+    },
+    "sound/gug/throw.wav": {
+     "bytes": 23180,
+     "sha256": "5e901b94e7be364536603273f18791ab571c46c2fc74263774c0e312f873a281"
+    },
+    "sound/items2/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items2/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items2/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items2/trinend.wav": {
+     "bytes": 79450,
+     "sha256": "6edc4b653c671187012e5ad6a95f777a861ab18a1d27b69a10912b459dab2577"
+    },
+    "sound/items2/trintake.wav": {
+     "bytes": 73428,
+     "sha256": "b26c0f0af98016163bf1fc7c4376ca90dfa4ad447e31a04fff9d8c9d820cda86"
+    },
+    "sound/items2/trinuse.wav": {
+     "bytes": 16990,
+     "sha256": "ea0b2b20b8137da8388bab00812218a47049183a7d4eb031449b975289de4ed4"
+    },
+    "sound/misc/elderkey.wav": {
+     "bytes": 55212,
+     "sha256": "70af94f89ca397badfe01eadc36b1375f3d219ecd8c19f691a4a6cd257cf9e7b"
+    },
+    "sound/necros/dias.wav": {
+     "bytes": 412204,
+     "sha256": "2de75ccc9f971c3c56b87c145ac96cfc7d3e13a758c89081133389d13399606f"
+    },
+    "sound/necros/drivshft.wav": {
+     "bytes": 385808,
+     "sha256": "a84800586cff4027335aa94cc05e0f5a0d88ab2404cba7a5ccc40c3581ffb981"
+    },
+    "sound/necros/forebode.wav": {
+     "bytes": 97960,
+     "sha256": "5dc4a7a6c7c2444595c0a7511ec8e1d5913211591202cd9a0e478588e1939c0e"
+    },
+    "sound/necros/gen.wav": {
+     "bytes": 136482,
+     "sha256": "f0d4932c1bc41d8701dee215fe04ec5f8667ac1de980d9d6158eef7f9e3e7fe0"
+    },
+    "sound/necros/gen_fire.wav": {
+     "bytes": 182316,
+     "sha256": "da244c2acc4a6b496330f1b7202a3f3d68ff61bc0e7e1c0a66a4208fdb66e9db"
+    },
+    "sound/necros/highwind.wav": {
+     "bytes": 158882,
+     "sha256": "41decf2ffe971f07420ab67deb227a285246d92eb01f77284920f01cc3652284"
+    },
+    "sound/necros/irulan.wav": {
+     "bytes": 196396,
+     "sha256": "52fc652f8b7814d4d28252f421e7ecebad629dd4c613e73adc643d67dabab3d5"
+    },
+    "sound/necros/sgatehum.wav": {
+     "bytes": 128670,
+     "sha256": "1a06f2e664cf213248990ee27ec117a46a4ba6ea6067b114c896cc9500f4fa99"
+    },
+    "sound/necros/strongwind.wav": {
+     "bytes": 133538,
+     "sha256": "fbc3ce4f537ebaf9603c6c4de350f06b2373f420e5c47a300668942ecd1a9064"
+    },
+    "sound/necros/tld_stop.wav": {
+     "bytes": 72304,
+     "sha256": "b58180629cb28e31b5fa0e00fc74c2c75841dbdcb778674509877d40abdf51df"
+    },
+    "sound/necros/tld_strt.wav": {
+     "bytes": 101584,
+     "sha256": "66ae791b7a06a8aa233d59bafb63d7b4ecb71be8b6ffc50c6794ea71807fbefa"
+    },
+    "sound/necros/tshaft.wav": {
+     "bytes": 221356,
+     "sha256": "95690f3dca8be51dcf789f5cb8977f37c20257b9b7bc84a4c57caa3aba0316a7"
+    },
+    "sound/necros/wat_amb.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/necros/water6.wav": {
+     "bytes": 45870,
+     "sha256": "d7505b517d6573f661739d765222c33d9ac1a86da362328d5635fc8634c9d823"
+    },
+    "sound/necros/woodmve.wav": {
+     "bytes": 70716,
+     "sha256": "bc27833a4d5b60b2212311cfefa7e8e04333e7a0c1efec939048a050bef4ab15"
+    },
+    "sound/necros/woodstp.wav": {
+     "bytes": 58554,
+     "sha256": "a86696cbcc070443f939497ba76c1e2c101bea2534dcc0993523031c6f500a2e"
+    },
+    "sound/polyp/blast.wav": {
+     "bytes": 25036,
+     "sha256": "0c3942daeedfa438ba36bd31481f7b24b067cab3d167c9e5cfd1cf3c498bf367"
+    },
+    "sound/polyp/cloak.wav": {
+     "bytes": 46252,
+     "sha256": "31cb79048b0c511ad0d40989785d835584c4c808025b8eb8060a74b36c9bca39"
+    },
+    "sound/polyp/decloak.wav": {
+     "bytes": 91152,
+     "sha256": "e2ee4693b0e466c5bc229db186257254c381c6a6985e71b02b20838859bcb5ae"
+    },
+    "sound/polyp/gibsplt1.wav": {
+     "bytes": 19580,
+     "sha256": "e9b7b73242aa04fdb6aed5de1c343ced81b15d6f78dde07097826b78bb1f87a0"
+    },
+    "sound/polyp/idle.wav": {
+     "bytes": 17750,
+     "sha256": "4edd47fe2508cb818ce36916a16c6e4c7cea4f61ff0310b7195e74bccc4f5d2b"
+    },
+    "sound/polyp/idle2.wav": {
+     "bytes": 22210,
+     "sha256": "b07894dd93545ed0c54fabae04f139c371a8b36ab84fc399f870f813b535000c"
+    },
+    "sound/polyp/sight.wav": {
+     "bytes": 11664,
+     "sha256": "a9c414ba4ca74fa3e08018af695674ede79a2f63aab26be0566dda9426eaef43"
+    },
+    "sound/soldier/load.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/soldier/rocket.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/vermis/death.wav": {
+     "bytes": 148016,
+     "sha256": "44b26a9dca5ec8d5e8a7ef2b5e38196b74e4f606cd37b906ee2b2e5b5a85b08f"
+    },
+    "sound/vermis/grab.wav": {
+     "bytes": 88122,
+     "sha256": "09528bd0d49d5cac0c03fe7994b57e572eb89aa8bce63cd0a591130e4b2126ae"
+    },
+    "sound/vermis/grabbed.wav": {
+     "bytes": 51630,
+     "sha256": "99583c88b8ec2959a0d69448aee16ec86b3d9feee6df7841fc32759598349376"
+    },
+    "sound/vermis/grndhit.wav": {
+     "bytes": 36428,
+     "sha256": "1f0e78fa08efb4617b6967a6cc218c56af227c7fd6bf039420d8f106d74fca72"
+    },
+    "sound/vermis/pop.wav": {
+     "bytes": 131420,
+     "sha256": "6284ab02e604b44c5b07225b2a0544c8707517d5fec0024c127bdafef2704f70"
+    },
+    "sound/vermis/sight.wav": {
+     "bytes": 137772,
+     "sha256": "d892117e4602595b6dfb65563b8fa7a3ad2171851791f7c6f47ea4bfece76296"
+    },
+    "sound/vermis/sight2.wav": {
+     "bytes": 106780,
+     "sha256": "6132e2d0db5cfb7a1a064e708d97f7258e2c6ac15c6f4ea8d520641e0ad10f9d"
+    },
+    "sound/vermis/splash1.wav": {
+     "bytes": 30710,
+     "sha256": "f931a2927c13cdb2523dde4550c0af993cc08cbea6e332739f9cf6fe3bd1ff8b"
+    },
+    "sound/vermis/splash2.wav": {
+     "bytes": 25332,
+     "sha256": "b91c69ee695bd71537ed018800f7d89e5e7d95332124f69adee39261d84d7c13"
+    },
+    "sound/vermis/splash3.wav": {
+     "bytes": 25590,
+     "sha256": "99fad2f3815a30ef645a2162ea24e54b4302ba00d7551af9299fde74ecce98e8"
+    },
+    "sound/vermis/spore.wav": {
+     "bytes": 44204,
+     "sha256": "d01a27af99745725dae124d30af18458b2ef323bce93c3cad939310e0f47f6c7"
+    },
+    "sound/voreling/bite.wav": {
+     "bytes": 8920,
+     "sha256": "a5bbebd7178205c400115846314709fa22c4db390fafbf3abaee2e33342e1a0c"
+    },
+    "sound/voreling/bitestrt.wav": {
+     "bytes": 11132,
+     "sha256": "be72b6a15a73bda266331309046229fd6f94b0856f4dfc306204e6266ad1cb59"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 19584,
+     "sha256": "e5bc7634816b927c305679e9b0ff3e4f33a2d09cb5e80db3c5dd04373ba452e5"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28378,
+     "sha256": "b9daf80e6bc998d521cd35f6d8ef74295f39fafbb71f6d6cfe8f0e7c1fb3f0ba"
+    },
+    "sound/voreling/land.wav": {
+     "bytes": 6154,
+     "sha256": "92f08d203711dbd3bc2049ba61a62938b4eb34a9c7285c26406da3b29bbdfba2"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "0b6c021bc7301757918201ad1175387eabfc0af4f6e8b94e273ba22a2aa6c53c"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 55972,
+     "sha256": "9aaaebf47f82cd7a521800aa9d81d14bd2747735481cb15b88ce104cf1568b6f"
+    },
+    "sound/weapons/bomb.wav": {
+     "bytes": 141228,
+     "sha256": "6fa171d6bbb3dc07f9c0fb422ceb2e3e20934e9a0465589717dfdc14c92b016c"
+    },
+    "sound/weapons/bombfar.wav": {
+     "bytes": 246316,
+     "sha256": "12334d1af40522f124564f354acf44f419d1e1477cdef97d0f790ab52a38d765"
+    },
+    "sound/weapons/dryfire.wav": {
+     "bytes": 47872,
+     "sha256": "d119284b7e97ab626587b20349eb5c2a90489b37df85a1fec52c98962185da06"
+    },
+    "sound/weapons/expl1.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/hamhit.wav": {
+     "bytes": 2434,
+     "sha256": "7754c2ab32c5d34473e4fe4977f9aa1b326a622431b44b599c798c7a0fbe2b60"
+    },
+    "sound/weapons/lancfire.wav": {
+     "bytes": 6520,
+     "sha256": "be8d154ba1404462776ec3f5fbbda0e974970dd5d61d97cf296c3711ede5bb84"
+    },
+    "sound/weapons/plasexpl.wav": {
+     "bytes": 54406,
+     "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 164,
+     "sha256": "ba0d9dbe33691183ef2549fdd006a02e21ac209f1d51271018e9bf565793c1cf"
+    },
+    "textures/+0bfall.tga": {
+     "bytes": 24594,
+     "sha256": "e16452c0adf12a064b2c78dfc9c10965fde399cac99076f29486bd434865d20f"
+    },
+    "textures/+0wall58.tga": {
+     "bytes": 24594,
+     "sha256": "dc10523848dd691e477cb7dc3c8f8926bcaff43df0bc8aca5b4814ec9e416ca0"
+    },
+    "textures/+1bfall.tga": {
+     "bytes": 24594,
+     "sha256": "f0ccb330e0668af52906c3bb8ca56513e49ec4b7d3a10a1af8fa1e552c12aa9e"
+    },
+    "textures/+1wall58.tga": {
+     "bytes": 24594,
+     "sha256": "6a3071293d6c5833f71dd9dc6400a8971a42fa08d975139286412863a2afa15c"
+    },
+    "textures/+2bfall.tga": {
+     "bytes": 24594,
+     "sha256": "5a4839cf5a9bfaa3e0eaf6419502aa9b68941a76a82aaffcbb42ccc16b7251ad"
+    },
+    "textures/+2wall58.tga": {
+     "bytes": 24594,
+     "sha256": "2e21abc263631a86253f1c7c3d85b1e1706656a8ee2a4946c083d4da188e6c98"
+    },
+    "textures/+3bfall.tga": {
+     "bytes": 24594,
+     "sha256": "0cd9f7f04e1d94c5aeac21a22be9b085364b76f80255d2111f080d25b9571272"
+    },
+    "textures/dem1_5.tga": {
+     "bytes": 12306,
+     "sha256": "3c7981d83daaf54eac8c7fc3eb917f3b37206f04f7217c5f61c72ddcfa4e4e7c"
+    },
+    "textures/dem1_6.tga": {
+     "bytes": 12306,
+     "sha256": "c605259684bfcdda9c7439aeb1625b753b39ec326b199b79708aeed4e94192c6"
+    },
+    "textures/door11_1.tga": {
+     "bytes": 49170,
+     "sha256": "e41bbe8d0b3c06e3e63335e54e76a9ff46f746d97521d423d26e843e1c73339e"
+    },
+    "textures/mwall1_1.tga": {
+     "bytes": 49170,
+     "sha256": "74618ddeed744fa78d55d52332bba75e3e8e4bb10801968c4e7fa434a3145424"
+    },
+    "textures/mwall1_2.tga": {
+     "bytes": 49170,
+     "sha256": "ef9f0957aab307dfd959a2fbdfba0746590bf72543e3e9c267e82825a4153df9"
+    },
+    "textures/mwall2_1.tga": {
+     "bytes": 49170,
+     "sha256": "8aaff86f44b797ac6744f13e99935f89ae7220f47ad640a376c0f65e0c2a0ac9"
+    },
+    "textures/mwall2_1_red.tga": {
+     "bytes": 49196,
+     "sha256": "9e8e232605d1e957cc37436c1bf6fe16c733aed297e2b2f821cc98d1f03d2611"
+    },
+    "textures/mwall2_1_red_tr.tga": {
+     "bytes": 12332,
+     "sha256": "95fe8beaead00d82042e00c633772c98512448b8ede744f8dd19e6d073e8ac2f"
+    },
+    "textures/mwall3_1.tga": {
+     "bytes": 49170,
+     "sha256": "7177eaddb4df53978e97d461bdb3691bf5cfa85f37518975577702f2e1018aad"
+    },
+    "textures/mwall3_1_red.tga": {
+     "bytes": 49196,
+     "sha256": "4382c35808a81d43b349482e135f7362748a059e7f0d12c564c9907e10c634ba"
+    },
+    "textures/mwall4_1.tga": {
+     "bytes": 49170,
+     "sha256": "e9692306843a29a826fe2d680cd120f6f2503cce23c8e2dac9709459e892268f"
+    },
+    "textures/mwall4_2.tga": {
+     "bytes": 49170,
+     "sha256": "60a8569f93461c4180be984e37adfe2ca24f3d04daab19d492953dcbc16f8055"
+    },
+    "textures/mwall5_1.tga": {
+     "bytes": 49170,
+     "sha256": "fb7d723160581302ff0dd079e93d8a8dc54b2a6304a1fecdc77934b19b1e15ef"
+    },
+    "textures/rw15_1.tga": {
+     "bytes": 24594,
+     "sha256": "d1becff2637e213ef94cef4134429ae3cdeb821f3e84aab230dbacb94c6518c2"
+    },
+    "textures/rw15_2.tga": {
+     "bytes": 24594,
+     "sha256": "91ab56c9f1621de1c386fabdb6aac1814ab0154d88452fee0c4a1bab89d653bf"
+    },
+    "textures/rw15_3.tga": {
+     "bytes": 24594,
+     "sha256": "abe1fda7a20c0aea206ad57beaf736829e2024509b2e8cc8164a9b23177a623e"
+    },
+    "textures/rw15_4.tga": {
+     "bytes": 24594,
+     "sha256": "745948c0cd48e6e01068a0f1305481c1c806e3e838ae22c3d142bf0e91c0943d"
+    },
+    "textures/rw21_1.tga": {
+     "bytes": 12306,
+     "sha256": "935b7aacfa98763e85ed7d6775a742815ec6112aede7a5ff148d90b52a6dcfa9"
+    },
+    "textures/rw21_2.tga": {
+     "bytes": 6162,
+     "sha256": "42fb2832ac2eec8cd73a3444cb75c0021581e899b02e94ea333c98fb112c9829"
+    },
+    "textures/rw21_3.tga": {
+     "bytes": 24594,
+     "sha256": "4f8537864f72db12061ce70d9baab17c98031e781e058e4adf38e0ac34a21ea8"
+    },
+    "textures/rw21_4.tga": {
+     "bytes": 24594,
+     "sha256": "fc2677db2925f405ea9225d4c6d8e5c0e2f5e713f9074deaa78a8d491aa6f1bc"
+    },
+    "textures/rw21_5.tga": {
+     "bytes": 24594,
+     "sha256": "a7527f4ad249827052c1ca3415a36c5a965975cae2d6aff799236e7eb5a59cbf"
+    },
+    "textures/rw26_1.tga": {
+     "bytes": 24594,
+     "sha256": "ba91b31bb38fe81f0ef7e08f32b6d7ee27f4ef2d54909bed9c7302d823198864"
+    },
+    "textures/rw26_2.tga": {
+     "bytes": 24594,
+     "sha256": "686fd937365107bc99daaf6c8d419cee027ffa9da50eb70b5e10cb8cc5398dea"
+    },
+    "textures/rw26_3.tga": {
+     "bytes": 24594,
+     "sha256": "ca4cb9d2d9637f9f676aeb9178a2b4f8a8c084bd1678d9787a88a159e7513f93"
+    },
+    "textures/rw26_4.tga": {
+     "bytes": 24594,
+     "sha256": "735df64fc6e627139b4f76228e49831c051948cc7c0a734924680d3472087f16"
+    },
+    "textures/rw7_2.tga": {
+     "bytes": 24594,
+     "sha256": "caba2d8cf9ef2d9c90c0aae3b43b2ec2f86d1c14bc085ef5e78a63edbc437c2c"
+    },
+    "textures/rw7_3.tga": {
+     "bytes": 24594,
+     "sha256": "b0daa16c1e9a25055618e3692a5fe0fc766e3d66b0a8ab19022744112bf4a340"
+    },
+    "textures/w105_1.tga": {
+     "bytes": 49170,
+     "sha256": "2830a744ca1a7c6ce8ad63675d71ec545e87c7ed5c18a3f8a9af4defedb4dffa"
+    },
+    "textures/wall30_2.tga": {
+     "bytes": 24594,
+     "sha256": "d14e42b6469b059bf66c766ccca4a1ad11140d48ea35068f58ec0ffd46384950"
+    },
+    "textures/wall30_2_red.tga": {
+     "bytes": 24620,
+     "sha256": "49c5e077694909aceff34f9e192b7e7d3c9d3ff18e3018d4b03e60970d366d60"
+    },
+    "textures/wall30_3.tga": {
+     "bytes": 24594,
+     "sha256": "04a5bfd1dbf4254e63e3a2ca206bff20deccfe4902195a4037cc1c340a5e5ea0"
+    },
+    "textures/wall30_3_red.tga": {
+     "bytes": 24620,
+     "sha256": "146f5aa381d2649d9f7104c749642e400e5b3912ce568eb48bd966e58817bdd6"
+    },
+    "textures/wall30_4.tga": {
+     "bytes": 24594,
+     "sha256": "e6d90bebd4adb579791a718b9190a4a6603c82f0b41db1658c1fccb3ebd9dc8b"
+    },
+    "textures/wall30_4_red.tga": {
+     "bytes": 24620,
+     "sha256": "f4afc3527f258ea27cadb656314716bca6d3d16286539694572dea795be361ba"
+    },
+    "textures/wall48_1.tga": {
+     "bytes": 98322,
+     "sha256": "bcae8399e797e1c6413de7c7bde9435cee13d77f100e948444153201232083e9"
+    },
+    "textures/wall48_1_red.tga": {
+     "bytes": 98348,
+     "sha256": "73f1c4781c0c7c639d6779138060e394e525ace2e61e7fa84f5611beabef11a3"
+    },
+    "textures/wall48_vine.tga": {
+     "bytes": 98348,
+     "sha256": "d7de6acf61f49c1cfbe5d59436835b67cd5d1250e8b667b80b08d87a84e5381a"
+    },
+    "textures/wall59_1.tga": {
+     "bytes": 98322,
+     "sha256": "a3f2bf922132dd358fdbb2a6d501bff14ad38c7a762ffd9068048ceba6d1dfeb"
+    },
+    "textures/wrcka1x.tga": {
+     "bytes": 196652,
+     "sha256": "c78a5aea451c6915b26f7e3327581c270a65420bf23ce8b8c3dbd9bc9d664318"
+    },
+    "vongug.dem": {
+     "bytes": 1079956,
+     "sha256": "5228133bc5b5e3e0a11747b93eb0f5bca355e65be0b60527304a54cdc32d9e2a"
+    }
+   },
    "sha256": "ddace91ad8a3e3d436c95efea430f5dbd8a319f511a6f7d2d05ac6fffc68ffe6",
    "timestamp": "2008-02-06T20:38:00.000Z"
   },
   "pak1.pak": {
    "bytes": 84961704,
+   "files": {
+    "coop2.dem": {
+     "bytes": 1974743,
+     "sha256": "45c35c4ccf3eb06cd98d33e7aa17003b2f242c8271034036b0d4d3d41bf5cdff"
+    },
+    "gfx.wad": {
+     "bytes": 128932,
+     "sha256": "b9b298830f1c48cdc378d83b84e3b308f0ca3052c278d6b4afeb70fa4035ab7d"
+    },
+    "gfx/env/dawnbk.tga": {
+     "bytes": 791801,
+     "sha256": "3a415bd258f1d81bfddc5091dd67829e7b9c2d247c7d69ea263a6e743e3971e5"
+    },
+    "gfx/env/dawndn.tga": {
+     "bytes": 1032293,
+     "sha256": "33c9b1bc0ae74eeae43a90f44397cb3d2747ec40190f5b0bf28ce62d0943cf98"
+    },
+    "gfx/env/dawnft.tga": {
+     "bytes": 1206497,
+     "sha256": "1947bb641b84fd09cd9b0c17256f809fc13c81eca40520576d1ea3e2c57ea9b4"
+    },
+    "gfx/env/dawnlf.tga": {
+     "bytes": 1141280,
+     "sha256": "cc68776448bb864875e8e4ea181f6aa83800fa00ad15fca9f9ae3ac24b35d320"
+    },
+    "gfx/env/dawnrt.tga": {
+     "bytes": 1031739,
+     "sha256": "24be76b64c71f5a589f219ceccad23a68fc4e26f45a2a8a4183792bdbe7fc71f"
+    },
+    "gfx/env/dawnup.tga": {
+     "bytes": 1426811,
+     "sha256": "e4f5dabd8690dc8460d0032fba1d633d69222a242749803e960643d3cdd25454"
+    },
+    "gfx/env/daybk.tga": {
+     "bytes": 1885848,
+     "sha256": "81598177219150a0700e3ba1847157bbf1c7995d001989f64b6aa9a43f30559e"
+    },
+    "gfx/env/daydn.tga": {
+     "bytes": 1009895,
+     "sha256": "7bce7500395ecda3e1d82d30f7da1a5a7deeb78ccdd11cfd72a4e08114d2c0e9"
+    },
+    "gfx/env/dayft.tga": {
+     "bytes": 1997325,
+     "sha256": "40c45bca3df588c07cb5bad2783e4a4d2eddafb82d2a508993d8a0ef9374bd4d"
+    },
+    "gfx/env/daylf.tga": {
+     "bytes": 1914168,
+     "sha256": "f860f4796a517fb3280223cdbf4599bb77e681b27bd721d6fb50a98aafbaf19e"
+    },
+    "gfx/env/dayrt.tga": {
+     "bytes": 2080059,
+     "sha256": "dda11898b40d60a21e09d08bc31a785a02abe5a848da2b87d528d2b434c5a031"
+    },
+    "gfx/env/dayup.tga": {
+     "bytes": 1246252,
+     "sha256": "aedf3ba21436941882432c44cb791a4fc941409f229b256725d5c1c1b625329e"
+    },
+    "gfx/env/duskbk.tga": {
+     "bytes": 1364708,
+     "sha256": "2372a2a60805d3ef0d727edbe5b203d082b4b608c417e671b2ee39d40178bcbf"
+    },
+    "gfx/env/duskdn.tga": {
+     "bytes": 1310868,
+     "sha256": "1e96211accd4c0cc40c6ba54c22d1f1fee27433598f4cf74b7a242eed4dfcf06"
+    },
+    "gfx/env/duskft.tga": {
+     "bytes": 1367663,
+     "sha256": "9c7331e1f7ef1959776af623594fc2186b15362b300a67f8eb1e0fda4f4188a8"
+    },
+    "gfx/env/dusklf.tga": {
+     "bytes": 1426730,
+     "sha256": "65819e48a62862cdea4bce2f5dab063c8cc3b8ab2dd44d90e4f7fe329fbe55c7"
+    },
+    "gfx/env/duskrt.tga": {
+     "bytes": 1400147,
+     "sha256": "ec17749d0c623b05142fb4cadff8b29950ca8fb92a8e6ab02576a7d8a8be3077"
+    },
+    "gfx/env/duskup.tga": {
+     "bytes": 1327551,
+     "sha256": "2a40691f8439cd706cffe9b3d777dfb272a5c7306ab02912af0d19b151dda815"
+    },
+    "gfx/env/epiphanybk.tga": {
+     "bytes": 2336400,
+     "sha256": "520320d2d4bd655138753f1d036494129761ad93cfcca0b1e5a814d30c2828e7"
+    },
+    "gfx/env/epiphanydn.tga": {
+     "bytes": 2299843,
+     "sha256": "f95ab44b70525f6fc83737ab572de3a17308ac47ca28bb0bc938e7854659141c"
+    },
+    "gfx/env/epiphanyft.tga": {
+     "bytes": 2612108,
+     "sha256": "99aae0dea453bf26bd1622ef5136558833605054d38eb359dcaf451bb99d938d"
+    },
+    "gfx/env/epiphanylf.tga": {
+     "bytes": 2377534,
+     "sha256": "b44b482a9b308f8d6b7f12c2b359242ce22ec3a9d398dcd9afb446adb2f2703e"
+    },
+    "gfx/env/epiphanyrt.tga": {
+     "bytes": 2490366,
+     "sha256": "5b07aa824bb0c583c65576edef3f76a2bceb78bf4754d24e3ae349ce937eadcf"
+    },
+    "gfx/env/epiphanyup.tga": {
+     "bytes": 2350734,
+     "sha256": "08b91d998c2fe5279960c5d6c83c3bc79fa7600a10e6a8dd2a5fd678e5a34c8c"
+    },
+    "gfx/env/fodrianbk.tga": {
+     "bytes": 1218431,
+     "sha256": "3d8a751a50330bff69af3a63d772485bfc4e9ef9640076d98d4ddb5943201695"
+    },
+    "gfx/env/fodriandn.tga": {
+     "bytes": 752376,
+     "sha256": "58e65c036e28b02d9149f180919c9676343627e5f76ad87a2a27c8d3e114a34a"
+    },
+    "gfx/env/fodrianft.tga": {
+     "bytes": 996781,
+     "sha256": "699b065c4840785136c4cb969fda73e6b2ad9bc0f5f0c384f8076baf4196e5b2"
+    },
+    "gfx/env/fodrianlf.tga": {
+     "bytes": 1052142,
+     "sha256": "a5794f3e893c615505d5ddeffd48f25246a34341167670c304273bf812a35056"
+    },
+    "gfx/env/fodrianrt.tga": {
+     "bytes": 1011425,
+     "sha256": "c8cdb878f4d8ae894dd2531030132b92306a54cf7e7fab047e616cc8a0c3f063"
+    },
+    "gfx/env/fodrianup.tga": {
+     "bytes": 783041,
+     "sha256": "03e6c3eb578d533c5b46c8fd7bdb67a9e3d0cd1d6eb241b26feb353d4e1e6a23"
+    },
+    "gfx/env/graynightbk.tga": {
+     "bytes": 1771903,
+     "sha256": "d1173e9781c585cbf525374abcd1067cfd498c9dadb1d7d4febe69b890b9fa0b"
+    },
+    "gfx/env/graynightdn.tga": {
+     "bytes": 1901023,
+     "sha256": "fd464ebaa459ae2722860ad39fb613d44ac35f0afd914d52b5a9a4817fb81dce"
+    },
+    "gfx/env/graynightft.tga": {
+     "bytes": 1800892,
+     "sha256": "69b4ebc470c36ae1f0cb41824f981911503d2932bc0ee82f730254bfe59cc140"
+    },
+    "gfx/env/graynightlf.tga": {
+     "bytes": 1769279,
+     "sha256": "e988f1f6169479ce3515c046cc989e96fc5182d41faaa4c3af3ea9065a581557"
+    },
+    "gfx/env/graynightrt.tga": {
+     "bytes": 1788173,
+     "sha256": "1a969121d5e25cf04cd8bc059838ef74ba83f448d0e97aee22dba574bb802a8d"
+    },
+    "gfx/env/graynightup.tga": {
+     "bytes": 1660412,
+     "sha256": "2b282f7996ee8bc97d2140ead34ee6b5a62922c8b5ea30e147ffceb8a2b29e49"
+    },
+    "gfx/env/predatorbk.tga": {
+     "bytes": 1048179,
+     "sha256": "89021e04d172d32461f2eaff8aac30c750a9bac5bd165bb39b9b6210b374a3f0"
+    },
+    "gfx/env/predatordn.tga": {
+     "bytes": 1062175,
+     "sha256": "fb8b1483d01cb885165f3fe9468b568c278dbec2b07d2ad81c0574f5756336eb"
+    },
+    "gfx/env/predatorft.tga": {
+     "bytes": 953806,
+     "sha256": "09a5bcf66a64056b18d447a2799d090e8b4d1c5c6e54e1d6e6b6f5ea9f5f303a"
+    },
+    "gfx/env/predatorlf.tga": {
+     "bytes": 1007515,
+     "sha256": "3c5b93eabc11e727f24365ab0102b954d7a5f1eec8998776573fade8be49fa23"
+    },
+    "gfx/env/predatorrt.tga": {
+     "bytes": 1090878,
+     "sha256": "22ce280760e9330ca9c4a6c85994c0c98b7c83e7182562715032635d2956167e"
+    },
+    "gfx/env/predatorup.tga": {
+     "bytes": 1307351,
+     "sha256": "3ef7374f2b8a6ef6098f9ed07f85325b495917c1adb699df503b25a3fa5ebe0f"
+    },
+    "gfx/env/starsbk.tga": {
+     "bytes": 532751,
+     "sha256": "e74499e2d2fca2e86a1c1fa29a49a0074ee68bb02d6a4ad14a722087de83ffba"
+    },
+    "gfx/env/starsdn.tga": {
+     "bytes": 516841,
+     "sha256": "6e922014e7e2a7382c3b2c7c89af2b2a134722ab5838108efe881e9752a5a8cb"
+    },
+    "gfx/env/starsft.tga": {
+     "bytes": 545250,
+     "sha256": "b9d0a03dc6728f92db7572170a0f2bd49fe0d2e375578750ebca88f48d68262e"
+    },
+    "gfx/env/starslf.tga": {
+     "bytes": 540900,
+     "sha256": "e6aa8b634f0335fef501864ed21b24c1a7949c353eed10adca493bd7eb808ba8"
+    },
+    "gfx/env/starsrt.tga": {
+     "bytes": 528742,
+     "sha256": "e6ff0c6f8228e0890a722fb25457e7248729e407336f225bb6ff6d9f2aadd218"
+    },
+    "gfx/env/starsup.tga": {
+     "bytes": 540621,
+     "sha256": "629e2b1d4d8eb74014652b6e5e7c9fcebfe60b68d97fb6c25bb57c980e4436b9"
+    },
+    "maps/breakable.bsp": {
+     "bytes": 1924412,
+     "sha256": "1b7c46e6581380db7416e943ee4c31763de08159bc08aa1e1ccc0fb2eaf8f810"
+    },
+    "maps/e1m2quoth.bsp": {
+     "bytes": 4255536,
+     "sha256": "3d3cfa7ceceb18ca198270aa9df8da45988d1dd583759a5e41d5c3c0a691832a"
+    },
+    "maps/kellbase1.bsp": {
+     "bytes": 2346024,
+     "sha256": "8b84da3a5946a7b37dec18e5c6b3eaea4d536789ce9ec691c326ca365b95f86c"
+    },
+    "maps/kellbase1_fan.bsp": {
+     "bytes": 15508,
+     "sha256": "e018283c4f7ae64147a13f64ddced6e0f4f597492d677fa4e9758455d0ed6520"
+    },
+    "maps/kelltest5.bsp": {
+     "bytes": 539264,
+     "sha256": "4b9f25060b13bbbbe623e2b53c7cb5d0397e2362ac4dabf10486e676baafed1a"
+    },
+    "progs.dat": {
+     "bytes": 761082,
+     "sha256": "028ee957df11e12c26c6bb8bcf2f58e4b099a59797b78beebbce65a4f41d4cc6"
+    },
+    "progs/b_bio_l.bsp": {
+     "bytes": 11572,
+     "sha256": "e076780538e320d1a5ffcac210668e95edf63fce95edba192acdbbf0f634649a"
+    },
+    "progs/b_bio_s.bsp": {
+     "bytes": 6028,
+     "sha256": "1609a5f827eef414efe184ef62e8a7a7191208bef9e1593bd67724f19948b84d"
+    },
+    "progs/b_plas_l.bsp": {
+     "bytes": 11572,
+     "sha256": "5ab7b0e25b37c65ea87743bcbfdb482f5556d0595bae15eecb95ab8f1c8c2edf"
+    },
+    "progs/b_plas_s.bsp": {
+     "bytes": 6028,
+     "sha256": "58adae5e3ec3f32d65abbf74fb7fdad9bf19d6f33f2a4f2fe621b46867261322"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 331328,
+     "sha256": "046d34a681439138dca323f54e54d358e225d2d958b21b36ee564fe6d4be7b82"
+    },
+    "progs/brick.mdl": {
+     "bytes": 108308,
+     "sha256": "b566efdd77a56bc38866eb95d167b2e53b8453d4194dd641efe6a15a6d22a6ad"
+    },
+    "progs/c_ham.mdl": {
+     "bytes": 78908,
+     "sha256": "3ef97f78252e0c2aec063649102aad9765eb320fe172c24db29d8c08fac5951c"
+    },
+    "progs/c_lance.mdl": {
+     "bytes": 48404,
+     "sha256": "03d923d70944814497b47312137221bec8ed46c2e8f6681ebac07dfb5b5517c7"
+    },
+    "progs/c_light.mdl": {
+     "bytes": 63500,
+     "sha256": "d0c16e23a406b1833408e216e34759a5060b202e603889ac8c39cac92d6d9434"
+    },
+    "progs/c_nail.mdl": {
+     "bytes": 63324,
+     "sha256": "b98d0281f8958d5b7a50e795711cb9e7b04d73e417dfae13f64f17d1ffc52228"
+    },
+    "progs/c_nail2.mdl": {
+     "bytes": 79328,
+     "sha256": "088e8d8994344e46918df796a38e87d0dbe2ba0baf1ad9359e072ee538902551"
+    },
+    "progs/c_rock.mdl": {
+     "bytes": 67924,
+     "sha256": "c0d3b99d6edde1329011a6754f65caa55888421c94669cee26beda3c1525bb63"
+    },
+    "progs/c_rock2.mdl": {
+     "bytes": 65932,
+     "sha256": "6fa52810c7164815d909085f80d27e3cf60f2a9dc48547c877947ebfc045fd4e"
+    },
+    "progs/c_shot2.mdl": {
+     "bytes": 58572,
+     "sha256": "381c796447399a343a4dff310ba58942eb45168708ef3899a2043ceaefc86c14"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/flame_pyre.mdl": {
+     "bytes": 85180,
+     "sha256": "9df2ae13e72ffe5a305a6ce877b0284023520d5d34df751498a2003c3e420ebc"
+    },
+    "progs/flashlight.mdl": {
+     "bytes": 35596,
+     "sha256": "8442b889437acf210587a7d567ad71c839b978e7dcf27a580503a05983368c70"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41908,
+     "sha256": "52eeb2cb3923bccdf6960abbea3f39cee9c8e504c984c5ccaa7e218627fdb882"
+    },
+    "progs/glass.mdl": {
+     "bytes": 127788,
+     "sha256": "f1e6a01f984e742bfd4d6428878e356e736251b7d18ac65e84aae63fa807fc69"
+    },
+    "progs/greenexp.spr": {
+     "bytes": 24732,
+     "sha256": "52b354786534248048d517a16fea53ad54c39ff7c82185c45067daba31dbb522"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/grill128.spr": {
+     "bytes": 492156,
+     "sha256": "c1ffd3a6680099e228605480d83bc5929ecd5730c01d24cfbcff3f195b509b51"
+    },
+    "progs/grill64.spr": {
+     "bytes": 123516,
+     "sha256": "c8d559303231ce4a7a1c246bea0a24c322d249f3b1cea61114fc0816a73cc781"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 43931,
+     "sha256": "f87f4d5b690c6ca434e5ff904d02f33cae0ac9e44bac4350b9631f47e29f6287"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 28501,
+     "sha256": "24f0d69fa8e5aa9cf70fd2653dab9bbd59fff7985b895234f8b07d1a4546998a"
+    },
+    "progs/lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/medexp.spr": {
+     "bytes": 72892,
+     "sha256": "d9887be2c9837d713d3aef856c1fc9245a4628b76ecd9e4e50a28d0deee1a679"
+    },
+    "progs/metal.mdl": {
+     "bytes": 246933,
+     "sha256": "07c0bb9ff1aa1639a62e5a84fca28d48c0fc738f4d22f8e3d8a5a029790d870e"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "e0bd8b2d3da7f2d8bdd59c4664b9202f00fa6dbe8c6321fd3651b3e857edd6c3"
+    },
+    "progs/pickup.mdl": {
+     "bytes": 36332,
+     "sha256": "7d0e5cac5f2a9f5ce879d81499c770b246ce5fcce049e2661fb35d2b15cbd2b1"
+    },
+    "progs/plank.mdl": {
+     "bytes": 19967,
+     "sha256": "d0fd70c3bd6dc93d13b229d4e0fa804a32a6688ef9640b4cc6340d9dab5fbd3d"
+    },
+    "progs/plasmabox.spr": {
+     "bytes": 14472,
+     "sha256": "89432660fdfbbdd90c72639152666f38ea6e7016a1d13171bf2d2e63bd2f4e89"
+    },
+    "progs/reed1.mdl": {
+     "bytes": 95281,
+     "sha256": "65773f37e26d41dd72ec1cf9849c663c1475923cb77d0f4c599bc3301368373f"
+    },
+    "progs/rock.mdl": {
+     "bytes": 136476,
+     "sha256": "0f80e53002bee59dad6dfe6f73b1ba2287700bea1cdade8e1dd4c35ec9d212a8"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "0350089b0bcf3a63a5d7b1e0bd070ac993be60f652f9bf9e3cf48957d31d561b"
+    },
+    "progs/sentinel.mdl": {
+     "bytes": 290664,
+     "sha256": "573efd78767922b2bbb3e5dab2b16cd8f90c2cb1709ecf4a315a141f4df77d09"
+    },
+    "progs/smlexp.spr": {
+     "bytes": 105148,
+     "sha256": "ce4938c9e813e648404b25b82245cad4400682d885d044b9d353a8039cfdceb7"
+    },
+    "progs/tree1.mdl": {
+     "bytes": 57621,
+     "sha256": "8e450cd50b8dac1912e96ec78ff4a16e0b9065138d181fa58257973c2ee96578"
+    },
+    "progs/veg.spr": {
+     "bytes": 8340,
+     "sha256": "4248f027adca723fb0101abf5c51b604ca6aabf80d4ccd9aa305cd34e072a682"
+    },
+    "progs/wreckage.mdl": {
+     "bytes": 71364,
+     "sha256": "13763a8cec3b643acb9b8165f1850ffae003131c84a2ac225777822a88462498"
+    },
+    "quake.rc": {
+     "bytes": 1173,
+     "sha256": "882eb84a6273cd0e47677a09c4ee33109124ae253190b2400314fdafda6c1b9e"
+    },
+    "sound/defender/ssgcock.wav": {
+     "bytes": 5274,
+     "sha256": "db4f62f8d76a68f2e4d3e7a29a22d3ddc5d6ae9bb296e6e800e937b73b5a4dea"
+    },
+    "sound/defender/ssgfire.wav": {
+     "bytes": 14206,
+     "sha256": "494a6d493c3c298c1b9cc0051ce4c1f9e129293ea7ec283b62915c49d8c249c3"
+    },
+    "sound/doors/blocks2.wav": {
+     "bytes": 38638,
+     "sha256": "12df7d5a55311ad33e5d3cf1efbad53f2209b7598c59d4e4715ef18d9e4532e0"
+    },
+    "sound/doors/blockse1m2.wav": {
+     "bytes": 91858,
+     "sha256": "12e39c7592dc01f13b7be34306c6b77c13e8d0429219fa46402752e5e6f62ca8"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eliminator/acknow.wav": {
+     "bytes": 77318,
+     "sha256": "5eceea3e5c2d77b919ad0e05375f7c891e6a7192192b5c1f7bde3f999adf8649"
+    },
+    "sound/eliminator/hesdown.wav": {
+     "bytes": 188790,
+     "sha256": "43688ea2cda3a2edb9f9d575eea9e8b2bb8e962bcd989bdfa5a8962eb2c74480"
+    },
+    "sound/eliminator/hostile.wav": {
+     "bytes": 100856,
+     "sha256": "03ee39ba5581da66909d721f4f40a259ccea095501dcbaeff47ab9d2e8044bc2"
+    },
+    "sound/eliminator/idle1.wav": {
+     "bytes": 39084,
+     "sha256": "2ccaa3ba4f987d031a22b8048ca23e97900fca9def362ff92943b73a99ed7844"
+    },
+    "sound/eliminator/idle2.wav": {
+     "bytes": 36204,
+     "sha256": "9232028e1a93c409c7000348bfadc269c49a333e8d65d904973efb547c7af805"
+    },
+    "sound/eliminator/idle3.wav": {
+     "bytes": 38222,
+     "sha256": "93034d568db5c304a165c3d89cb03ffe5d97e8157755e944a863697007eb27fc"
+    },
+    "sound/eliminator/sight.wav": {
+     "bytes": 31468,
+     "sha256": "2268ee0ad0c77a081b289a550a1dae24b274b2e3f06d156a67beca80df8ee919"
+    },
+    "sound/eliminator/target.wav": {
+     "bytes": 159480,
+     "sha256": "f2c8c4e9f515d682387ec9b4ba40102917355cffc58ad95dcc935b9805742cbe"
+    },
+    "sound/impact/gib_i2.wav": {
+     "bytes": 19252,
+     "sha256": "6a5ddcd321e9543960098d000255abc76b2f502e0e2da798dba4dc6fdd076e3b"
+    },
+    "sound/impact/gib_i3.wav": {
+     "bytes": 14956,
+     "sha256": "e6a2eb024a5101846479865d49ea5ba551d3972567eee70f1a9db3bc6687ccbc"
+    },
+    "sound/impact/gib_i4.wav": {
+     "bytes": 32782,
+     "sha256": "59b447c5e03b7ebc2914704f0e3caaa6b65e393e25d6f19b0a14f2f570676caa"
+    },
+    "sound/impact/glass_bk.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/impact/glass_i1.wav": {
+     "bytes": 13526,
+     "sha256": "e57ff2304e1ed3b85bca5803ab3309f74b115669527ad7c54371bc4377aa3f60"
+    },
+    "sound/impact/glass_i2.wav": {
+     "bytes": 34624,
+     "sha256": "1e403adc1d18b90440d2b10793c0c356617b138be309ed7b9774b9de86d23a8e"
+    },
+    "sound/impact/glass_i3.wav": {
+     "bytes": 9520,
+     "sha256": "250f438c593fed13a5493edc2b4a88c6a4cb22034f81dd7571ba2db7bfee9fa5"
+    },
+    "sound/impact/glass_i4.wav": {
+     "bytes": 6192,
+     "sha256": "05b2dcf83bdcf50f0ac1b6a341d85380293bb519948da38a07a842df53e8e774"
+    },
+    "sound/impact/mach_bk.wav": {
+     "bytes": 124920,
+     "sha256": "642a3ef399d357428f0800ac39557a6e841301aa47263f2f0f3e1b719a4d3923"
+    },
+    "sound/impact/metal_bk.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/impact/metal_i1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/impact/metal_i2.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/impact/metal_i3.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/impact/metal_i4.wav": {
+     "bytes": 79928,
+     "sha256": "d2b35ba352f32ceae469acf9cfa04f7dcc0a462ff69e3649f5c0adf55ae2ea78"
+    },
+    "sound/impact/rock1.wav": {
+     "bytes": 30534,
+     "sha256": "5cb61e93ebcf9bbcd3be1f6e282b51e9102d56b6650cffc0db93918b11b42322"
+    },
+    "sound/impact/rock2.wav": {
+     "bytes": 29254,
+     "sha256": "9fdf4f489834452fce33b1fbe69bce9d4920a117c3d0d93b4fb530a7117bf160"
+    },
+    "sound/impact/rock3.wav": {
+     "bytes": 25264,
+     "sha256": "59b506a84e018b11e9ba30a6ad299c2d8cf24d5907dc95cf30e578cd386e28bf"
+    },
+    "sound/impact/rock4.wav": {
+     "bytes": 27244,
+     "sha256": "7a2c24ce52e272998ca035c967860873c92fbb14227a190ac82b761843680ffd"
+    },
+    "sound/impact/rockbrk.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/impact/wood_bk.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/impact/wood_bk_old.wav": {
+     "bytes": 61250,
+     "sha256": "f9cff6955830b4219b3cfa01e04f41f311f7fbbadbc2738c92bf21808f1e7800"
+    },
+    "sound/impact/wood_i1.wav": {
+     "bytes": 28074,
+     "sha256": "6249449664f5ae509164ae3fd8588c905bea9daf5b1d919d9917b91aadf675bb"
+    },
+    "sound/impact/wood_i2.wav": {
+     "bytes": 25158,
+     "sha256": "d51e731bdf895c84ec9927c496fc0a7fb6e7a37cbfbc2f6b55f54f716d804d08"
+    },
+    "sound/impact/wood_i3.wav": {
+     "bytes": 17644,
+     "sha256": "8e1967cf42a7e31668d94e1b0cb7c6de4d36c6ec735d67ab01ac4e00dfb0853c"
+    },
+    "sound/impact/wood_i4.wav": {
+     "bytes": 11516,
+     "sha256": "fb0908f1a2bdff824d27fa92f15690cb9f86805185119fbc7f7876547495bf45"
+    },
+    "sound/items/click.wav": {
+     "bytes": 6534,
+     "sha256": "fab804dd505a2d823b062b348f126788bb3ce6c6399e8e76b1b7e39ffc8c82e3"
+    },
+    "sound/ogre/flakfire.wav": {
+     "bytes": 25932,
+     "sha256": "d00213964c69abe9c1661aa2cd2ae9305b0bdacb46a3e0945763883fb2d991b6"
+    },
+    "sound/ogre/flakhit.wav": {
+     "bytes": 11846,
+     "sha256": "a7c4a0b04c8c39de0bfb560283ac872e6bb6b240fdeef9a1565d314eb99cbefb"
+    },
+    "sound/player/ftladmet.wav": {
+     "bytes": 67720,
+     "sha256": "7cd7028d84b16700661848a36a866a2602bcf50185b79ca94d5a2eb541fb1294"
+    },
+    "sound/player/ftladwd.wav": {
+     "bytes": 35760,
+     "sha256": "b09b57b7da9ae84b359260d7c600b70a05ed2314597af6cfd38999f664568d65"
+    },
+    "sound/pyro/death1.wav": {
+     "bytes": 18468,
+     "sha256": "f69cb5d6086c78c8e7bdb9d8fcb9365e6500ece5156810b568a2cf2d0acdc126"
+    },
+    "sound/pyro/flame.wav": {
+     "bytes": 44268,
+     "sha256": "44aa350cb7efbe578f785820ba28bf6aec29561a7d150072ebe841966adcc45d"
+    },
+    "sound/pyro/fstop.wav": {
+     "bytes": 44268,
+     "sha256": "50a724e76295283a5cca503ac1b46d5ca97a33055e0c8e85bcfdfc0c90d5169d"
+    },
+    "sound/pyro/sight.wav": {
+     "bytes": 88918,
+     "sha256": "39d9c5460096478952c203bfc358ee52c5f2147e742b937f2e8517b45843c360"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sentinel/laser.wav": {
+     "bytes": 9712,
+     "sha256": "c5f90e1823a04b48f7f24ac5b8792e1b42030a8b07970db5847dc1e74be094c2"
+    },
+    "sound/sentinel/nail.wav": {
+     "bytes": 13750,
+     "sha256": "7acc3ac05b7218abc6fef2d2397771d90fce6fa39415e33824be7e771d30e288"
+    },
+    "sound/sentinel/widle1.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/widle2.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/wpain.wav": {
+     "bytes": 19596,
+     "sha256": "bc7b6536a1c67aa89295eeacea2d9b36cb0bf783b5fb7cc6aaf4fa01a0edb3fd"
+    },
+    "sound/sentinel/wsight.wav": {
+     "bytes": 27322,
+     "sha256": "83bca2103d60c68435e27f0660e3ecd5bffb058e796382e7bdb43efabdfb9889"
+    },
+    "sound/weapons/dryfire.wav": {
+     "bytes": 11268,
+     "sha256": "43e10c707d097c577f465c89fe9444c59b5ff4cdaf7c8d6619bcf61568d39bf2"
+    },
+    "sound/weapons/plasexp2.wav": {
+     "bytes": 112340,
+     "sha256": "92ea6112b21e65d625d34fbe1ec6abc592c2cf7c28f1b55c5999a8a56daebe8b"
+    },
+    "sound/weapons/slime.wav": {
+     "bytes": 57132,
+     "sha256": "88ce5f10c8acb0e51d54a4066ef8faf1643c5baf75edeafb82d350c733131215"
+    }
+   },
    "sha256": "fdc0703ba7a16def597892eacb384bbe137c20ef6034f5038d9f748791f5c14c",
    "timestamp": "2008-03-08T18:54:00.000Z"
   },
   "pak2.pak": {
    "bytes": 8035385,
+   "files": {
+    "base.dem": {
+     "bytes": 1166121,
+     "sha256": "f861f97f1575aa21efb675f8477fe96313f2ceec270273044fc34bdb8277c098"
+    },
+    "default.cfg": {
+     "bytes": 2025,
+     "sha256": "3227f12ce7edbb4235d5b8b4d3f69206a9b8fd8715f939ca0601325e52ea15a4"
+    },
+    "gfx/env/moonbk.tga": {
+     "bytes": 440145,
+     "sha256": "215264c71fcfdcda4fd9470adb3b1e1e803cd5af1d8df035c3244646dbfeac2f"
+    },
+    "gfx/env/moondn.tga": {
+     "bytes": 603,
+     "sha256": "4a83e798c3d0637f03b1effe28df9998bf249831b3dccecef074ff5cd8b631df"
+    },
+    "gfx/env/moonft.tga": {
+     "bytes": 410588,
+     "sha256": "4fbbdf05866d78de6ab4bfc9867227007fc87073cc96678e0c08bbc6d9717ce5"
+    },
+    "gfx/env/moonlf.tga": {
+     "bytes": 421955,
+     "sha256": "ea304d8972653bd38c0aee88e6dd434d719360c423344d16b5db9c398af260d7"
+    },
+    "gfx/env/moonrt.tga": {
+     "bytes": 453367,
+     "sha256": "8ee2a2b97267326d4831d96c879c6238a63c485fc8865d91503adb6d7da878bd"
+    },
+    "gfx/env/moonup.tga": {
+     "bytes": 1335652,
+     "sha256": "91e764d1d7780818e58f1c30d7c8825df2adbf17c7da630acfa3dd70b29d27db"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "faa7c77704959d1ad9bb5280449b22e8c4b9425fc628b4f2037900c49e73fc9e"
+    },
+    "optout.cfg": {
+     "bytes": 1564,
+     "sha256": "51efd87218e766df5c8b5c643ccabcecacfa855ee60deaf8dde8420a02c157c8"
+    },
+    "progs.dat": {
+     "bytes": 737572,
+     "sha256": "988aea9295972e13bc2b7ceabf2c72e4eda5e3ff095090701beb65f697647a96"
+    },
+    "progs/bolt3.mdl": {
+     "bytes": 15772,
+     "sha256": "6fabed3901bab1b145e418300d333c30016070e57ede07476884283a5ef7e380"
+    },
+    "progs/box_l.bsp": {
+     "bytes": 21639,
+     "sha256": "9a20404c31446ffc497113892dc293b0e59c6bb2cd9ab4a1f0bee11cc1f61a5c"
+    },
+    "progs/box_s.bsp": {
+     "bytes": 21541,
+     "sha256": "47b3f0a947272241184b9f65aa46d694fdd8facb8a9a36509d6f11f844f3917f"
+    },
+    "progs/c_ham.mdl": {
+     "bytes": 76800,
+     "sha256": "6bdd3e6b4c8253e6aeb6e293093b88fe6b3a9254135d285c8574acb6be9de9e1"
+    },
+    "progs/c_lance.mdl": {
+     "bytes": 44164,
+     "sha256": "6925fa7f462edb6c863bef65dcbe7d5c69544454c6fc1435a98c2890b08cc757"
+    },
+    "progs/c_light.mdl": {
+     "bytes": 76388,
+     "sha256": "9f0cdcc8e56d0614e058a3e922f3f64b0de33ab2ba6fe390c4154a3cbeceff5b"
+    },
+    "progs/c_nail.mdl": {
+     "bytes": 45336,
+     "sha256": "afe38a23bd9d6ec01a386047c3030f95732a986211eb0c6aafa83e12eb300a53"
+    },
+    "progs/c_nail2.mdl": {
+     "bytes": 81136,
+     "sha256": "c2e9e328af078538722ba4894801b5e4c5334a4629faff83b11510aa0a987b21"
+    },
+    "progs/c_rock.mdl": {
+     "bytes": 74404,
+     "sha256": "058de704ba8b0c2a47c2b83fd1b767a8220b9af87460bf114b14528db57ce096"
+    },
+    "progs/c_rock2.mdl": {
+     "bytes": 73544,
+     "sha256": "c922fdbfcd8175d196cc16f2134c8d9852c788ca76c198337aa71bf0bfde5e56"
+    },
+    "progs/c_shot2.mdl": {
+     "bytes": 42636,
+     "sha256": "02226bf370133fb1c4479c56a9a3c544cb89a0e87ba4cabe3247f9ddc9994b9a"
+    },
+    "progs/dspike.mdl": {
+     "bytes": 25324,
+     "sha256": "c2c89f690e21e34bee37db5011493f3457240e22fcaa3cdcdf04ef4bf9f44ae1"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51272,
+     "sha256": "0244bf38ec29f251b425bc1cc4f1a0e003316b3699c869cea38ec553e1f96acc"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "d45e10e4002fb17b2a1aa4077d1d4e599babd5083c0f7da914f8e98b61cb2537"
+    },
+    "progs/polyp.mdl": {
+     "bytes": 343144,
+     "sha256": "a135ee3b29dd230d06babc0e80c691b35e33599a48eb152d2c2c4902d424d4ec"
+    },
+    "progs/s_vp_pll.spr": {
+     "bytes": 272700,
+     "sha256": "024935ca88793c432ac5d6c6f52a51cb82638c86e9c27cac8d87e926673012db"
+    },
+    "progs/slime.mdl": {
+     "bytes": 25976,
+     "sha256": "53b07ceca49f5c637dc5bbe1cf1393db74e3d057624039efb8d7fd2341b5466a"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "aa9165056656a1d0810d741c91e5e14b1aebf3020a95ebc0dc1f48a3a1243074"
+    },
+    "progs/waterfall.mdl": {
+     "bytes": 43588,
+     "sha256": "c4bf6157c6f3a580a6cc7a76c8d5ea6a9af00f9c53b0615bf47b6574dc5bd54c"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 845237,
+     "sha256": "ee9db9fb4e224227574067dffb1b9c49af5b9536f8cea0527282d851aab81e73"
+    },
+    "quake.rc": {
+     "bytes": 1248,
+     "sha256": "dac6aec78b770451be757493c744ffd4a3ef9fb64be379044d1de57936a746be"
+    },
+    "sound/ambience/grinder.wav": {
+     "bytes": 264572,
+     "sha256": "70789db5c6e505292dd6031241aff19bd7b327677033cac5f98c1dcfeed5c6db"
+    },
+    "sound/ambience/teeth.wav": {
+     "bytes": 51600,
+     "sha256": "9649cc3a15c66b851da286bfbfe085196e851a9a493c299b03d9874dc04431e4"
+    },
+    "sound/doors/er_stop.wav": {
+     "bytes": 51846,
+     "sha256": "f674272aa55db0cb05651c5edfa76422370d138c44789b179bc6e943a22f0d28"
+    },
+    "sound/doors/er_strt.wav": {
+     "bytes": 99372,
+     "sha256": "afb23446ab200aa3bd540bc1ac517713dbf2d7fc099283254f7b8a4480a90092"
+    },
+    "sound/doors/ir_stop.wav": {
+     "bytes": 81054,
+     "sha256": "c5ae31d19bb638cd61771f365beca5998d5795ff035929863a19148d39907904"
+    },
+    "sound/doors/ir_strt.wav": {
+     "bytes": 86616,
+     "sha256": "8e2767cf7d483ab898c7eb561834b0a7af90669976499dfe42c8f7e09560aeb9"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/wfend.wav": {
+     "bytes": 9060,
+     "sha256": "1d8381b51b40e54a47ee76a9115b95a49285fc59385ff20b941b0fc8b7cd16b7"
+    },
+    "sound/misc/wfstart.wav": {
+     "bytes": 77838,
+     "sha256": "c85b517926832c1a7ef3a04de2995a7bd58a161620b4341a3f57d556c50d7ea0"
+    }
+   },
    "sha256": "4a62df0587cb93ae080807614a5428f1bf26c83770c6fd4e7168e9ef7a4c3e77",
    "timestamp": "2016-11-11T20:03:14.000Z"
   },

--- a/json/by-sha256/a0/a04aee22a146df6dd97db37932c7c96028307dab4f6f96e15944bd0e5006bd5b.json
+++ b/json/by-sha256/a0/a04aee22a146df6dd97db37932c7c96028307dab4f6f96e15944bd0e5006bd5b.json
@@ -338,16 +338,1434 @@
   },
   "immortal/pak0.pak": {
    "bytes": 17730124,
+   "files": {
+    "gfx.wad": {
+     "bytes": 128932,
+     "sha256": "6f7878b23deb09b151a58b8357f8a5b966cc87dce24a52407d931ceef885fbc5"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 921608,
+     "sha256": "1202e3013a0e94db8d629ba330127d9cc741e77ebc9f0bb9f8a2ff2f28f12ab4"
+    },
+    "progs/air.mdl": {
+     "bytes": 5076,
+     "sha256": "930e21887f0c482f353d5009efe1f5ef3f88e18d7a4f2e1232978cb2e8f73932"
+    },
+    "progs/beam.mdl": {
+     "bytes": 3307,
+     "sha256": "18295a66ab4a4da70b5dc0558d5cac7622afd65e9937ebe8d2c5321a67a418ee"
+    },
+    "progs/bigexp.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/bilebomb.mdl": {
+     "bytes": 13469,
+     "sha256": "2f77d07f24b62edc095facdee8c670711cc189a85258a631ada71cd4746e26ac"
+    },
+    "progs/bilefrag.mdl": {
+     "bytes": 9216,
+     "sha256": "34e6ed3456aef2c89d4ab9d857a173bfa98c17381be380f9665d496791f6f814"
+    },
+    "progs/bob.mdl": {
+     "bytes": 177959,
+     "sha256": "173f9aa590a0b23e0525c86b6945f3b8d565b865f2376daea00ac8f88791abc1"
+    },
+    "progs/bobblaster.mdl": {
+     "bytes": 27556,
+     "sha256": "3aa3e956183dc641fe601edaae52b7f2d5c92d90d00e8994e106dde4c0c25092"
+    },
+    "progs/boom.mdl": {
+     "bytes": 77388,
+     "sha256": "c0b2d8695564dbb1ef37aef9a9e226160ff8f5ab40de7a6d7129a66675096179"
+    },
+    "progs/brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "0287c3e7886bd2d6d1cbb504529d9e11038d0f8232ee624528eb0ccb78733c53"
+    },
+    "progs/corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "22f82f29d0a88af204f7b97eef887b963bd940e7277b6f5cef5e6f3610f2ea51"
+    },
+    "progs/corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "41e90f1a84e9779eb12541d923ab0a66e69deef3a9dbc82259ab84cb71b68dcc"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/dguard.mdl": {
+     "bytes": 176648,
+     "sha256": "f2f92ef84411d83c7e8c158f62b1415d8fc6aa56d77f21760dcd3080424cf6c8"
+    },
+    "progs/drlbomb.mdl": {
+     "bytes": 20355,
+     "sha256": "5c1db489f43cba73fce265db642267775245d044866cdd48396b1f1260a28237"
+    },
+    "progs/drole.mdl": {
+     "bytes": 241648,
+     "sha256": "5067b7ca5323754fe563d6696025525645a2cbd3aaf7f79232634608f9fb987a"
+    },
+    "progs/dspike.mdl": {
+     "bytes": 13684,
+     "sha256": "05bc998adf950efaeba0f0216e008ec8d6fa732d5eb726dbe70ff07e088275c6"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 333860,
+     "sha256": "230181ce6ea00c8e80c7d59189340424424ba5d99d71230b309907e206e07682"
+    },
+    "progs/fireball.mdl": {
+     "bytes": 12660,
+     "sha256": "ba5cba46edc108572d78e66166f5ed0405a48dcf672e7a569d14a4397f85f285"
+    },
+    "progs/fish.mdl": {
+     "bytes": 90636,
+     "sha256": "037ebaf6566f8fed7609b4e2c79eb36c4c78c49d914b225e7aa37fd4e3d6fa17"
+    },
+    "progs/g_bomb.mdl": {
+     "bytes": 50176,
+     "sha256": "33bc7cbf807cdae850d42cd11af0d332a7ca140741a3d29353e558bd8468aaa3"
+    },
+    "progs/g_fx.mdl": {
+     "bytes": 32260,
+     "sha256": "ac99d4e641af0bb1495ed38ba9f3a7c1195bda19e5cf0d3a68f04defe6178ab8"
+    },
+    "progs/g_ham.mdl": {
+     "bytes": 71639,
+     "sha256": "424bd4ecf03e0f364f57448b7c426924e1e0ccd06dad40294c00a23a645b8c0a"
+    },
+    "progs/g_lance.mdl": {
+     "bytes": 32906,
+     "sha256": "6eab37228d67437eccd9735de6e7933c79576a921c23479ad317e7c3db5b1f0d"
+    },
+    "progs/gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/greenexp.spr": {
+     "bytes": 24732,
+     "sha256": "8cd2c8f20214cc1f8de491785a27d3aafa924819c9f56078d2bdb219d4f16f5e"
+    },
+    "progs/gug.mdl": {
+     "bytes": 482020,
+     "sha256": "2cd097236a235aedf717a86b7312bd7d1b3caa6f0b25980c82eee2463fee2274"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 4920,
+     "sha256": "337f2723daab9d1375b78cb017512ce8281087ff8df9c33b04a6c613cea3590c"
+    },
+    "progs/h_dlord.mdl": {
+     "bytes": 18699,
+     "sha256": "bc5a92be1c5f3d06dc0238ec7bafe6a3c25826cc50edc6214ed5aa19b0075987"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 16854,
+     "sha256": "00f3263f1c3e0daadaaf03eea447080d727ea7d9ee1a88f2b42e060d748e1566"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 61251,
+     "sha256": "dec5afe666eba8db6e32d7535fffa3d0e4ed9344ba107b73418526ebebac574b"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 10663,
+     "sha256": "819b7cd0c4c38edb9725dffa46913ed89d75276aac3ea34b2bc683daedd5db0e"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 32629,
+     "sha256": "d69f21f26e13276272bb6b59352e66082a224534e8a0e46753037136927e0929"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 23239,
+     "sha256": "00117347d1acc46beb4972853572e14ce3e9d6dca25b883540896fcd873f3e3a"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 1142583,
+     "sha256": "2c3d4002e7c5f1682367c3f649e67333303d1763e6da0b3cfdce8c7519dfc2dc"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 8356,
+     "sha256": "b00951cd72bb5fb03c19a1d60943162652fe149b9ee60fd2e630a076d52956fb"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/keybase.mdl": {
+     "bytes": 11407,
+     "sha256": "5fed79622ad6f6751b2c771ddff06b88dcf049719336c228520bc84f0db441cd"
+    },
+    "progs/keyeye.mdl": {
+     "bytes": 37528,
+     "sha256": "a4612e183f026ea63161377682c1001b178b9e0f94f6b9a801b983962162dbbc"
+    },
+    "progs/keymed.mdl": {
+     "bytes": 13247,
+     "sha256": "e147a4e527b9b797680732c33cc0ebe3503bcd6e2c8a5b0917701cdd41f99297"
+    },
+    "progs/keyrune.mdl": {
+     "bytes": 25643,
+     "sha256": "f06fafe1b92a172a2cebcbc68ad5e2a8aafdfc99d13ce6d5bf5b36f25ca48f73"
+    },
+    "progs/knight.mdl": {
+     "bytes": 342850,
+     "sha256": "9e23eca66dbe332f49a1a82ceef197d5ee980abb24145050ea3088e05468dd4b"
+    },
+    "progs/longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/marsh.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/marshsm.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 3542,
+     "sha256": "2f3efa19a64b60d480fbef7c10e8f2a56e90d656e8fcb8bcd656932f8686f482"
+    },
+    "progs/polyp.mdl": {
+     "bytes": 211928,
+     "sha256": "36268021903129e7e0e81600072ff3b38229cb6851cc6800945d9810510fad0b"
+    },
+    "progs/polyp_t1.mdl": {
+     "bytes": 66925,
+     "sha256": "82f5f86f210e8cfc541259a3a9efe7b0b4a046f5b5240c5d39ab08a021a4e2ee"
+    },
+    "progs/polyp_t2.mdl": {
+     "bytes": 65473,
+     "sha256": "130699464f89836047b7bf6b4ad0ac7feee810dd31da5add2892e1f61ed07a30"
+    },
+    "progs/polyp_t3.mdl": {
+     "bytes": 64069,
+     "sha256": "72a5a60e71e09a4a0e73dba0658b301540b3d871ec4ea88e24ace135db19d046"
+    },
+    "progs/polypgib.mdl": {
+     "bytes": 5716,
+     "sha256": "dc2aae40f92f8c75057a664b583f9d790d010289e858b218adfc92de6d6be878"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/s_bubble.spr": {
+     "bytes": 396,
+     "sha256": "f7efaea9964c8ad347f170dcfd2a6dbe5bfcf8dc074cffc385cfbf28f991c13d"
+    },
+    "progs/s_light.spr": {
+     "bytes": 7344,
+     "sha256": "45ae7c364a43b76d834476f49fe6c35423330cce41d8f3dbc90780f561bb51e7"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/s_plas.spr": {
+     "bytes": 5256,
+     "sha256": "ed01b728b6656a68acffe258d644712eba3b786434ab6b3e6d90434031e90d96"
+    },
+    "progs/shockwave.mdl": {
+     "bytes": 167520,
+     "sha256": "861ee3b0ab6edd5233740a609c4367c5ebe4108ffb03124861bf85047a314f5e"
+    },
+    "progs/smlexp.spr": {
+     "bytes": 105148,
+     "sha256": "ce4938c9e813e648404b25b82245cad4400682d885d044b9d353a8039cfdceb7"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 565441,
+     "sha256": "9d3da38ea15726d8543413120414d4178efd900fd131a7fd84eff5a305df21f5"
+    },
+    "progs/spore.mdl": {
+     "bytes": 13469,
+     "sha256": "fc9fbb97f0d4f1a9f843769cd43fb7270ba2b351cdf3b4b624d27616980457c4"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 313448,
+     "sha256": "fc63e6f62c83975ab2756f0a844d012b887491a6c73d9350dfcb04a6e0355b3c"
+    },
+    "progs/trinity.mdl": {
+     "bytes": 13249,
+     "sha256": "3e0d4636dfd20112bd5415e92c1d8f85fdda65a9a33b09111cca2bbf4561f349"
+    },
+    "progs/v_bomb.mdl": {
+     "bytes": 80804,
+     "sha256": "48c2393efb079787f56be5ab6fd0dc3e748b5ef009ba15830fe0f9898ad94b7b"
+    },
+    "progs/v_ham.mdl": {
+     "bytes": 84563,
+     "sha256": "76f03b4e5d8222c2c3b3d2f0e1156ac90708a42f4997f6a4555c01073dab49dd"
+    },
+    "progs/v_lance.mdl": {
+     "bytes": 87209,
+     "sha256": "5c50ded5952ab06ca91ff413edf17a167b21bed88b027571e643ffc515a71560"
+    },
+    "progs/vermis.mdl": {
+     "bytes": 656752,
+     "sha256": "d7060475e290482c61c122b3a477085b1aad002fd71d8293cc4a4f8bde1baec9"
+    },
+    "progs/vleg.mdl": {
+     "bytes": 4904,
+     "sha256": "cc9ac24012d342ed54eb1a3241bcc6baf16e40fb95a904a789845ed76b8606ba"
+    },
+    "progs/voreling.mdl": {
+     "bytes": 41852,
+     "sha256": "b10f3623291b5182ab6b987cef1c40abc362aae41638b8481709660e923cc46b"
+    },
+    "sound/ambience/nightmare.wav": {
+     "bytes": 34284,
+     "sha256": "2caac27dfee5758eb293e0c76bf86baf82b0522c6f71281160e805c6ec282f96"
+    },
+    "sound/ambience/thrum.wav": {
+     "bytes": 220542,
+     "sha256": "c925d73ef744b0a8c56507ff6fb18888de7ab803ea1f743060f8f9782180dcc7"
+    },
+    "sound/bob/death.wav": {
+     "bytes": 14348,
+     "sha256": "7f97f27dfda78f9fe6fc5265e512b651e57ae466752d56cfe0dccd6d08478ed8"
+    },
+    "sound/bob/explode.wav": {
+     "bytes": 36898,
+     "sha256": "e00cd6cf71662de858fd0b8f63409217c957d6e3dea571b759fe97aec9d58724"
+    },
+    "sound/bob/fire.wav": {
+     "bytes": 36040,
+     "sha256": "5f39b9f60c5de5c9c3ac25a5149f1fef557e66c09d7d1a760ed6770082c5a914"
+    },
+    "sound/bob/hover.wav": {
+     "bytes": 13260,
+     "sha256": "46441335fe896cb993368bb12cedc1ddd4886b5933298bb6a0d6b7ba430cdfe5"
+    },
+    "sound/bob/idle1.wav": {
+     "bytes": 44460,
+     "sha256": "de548d73ab2d96ea9d550b86e264d430b8c0429cd99dd10404f52780bda6c683"
+    },
+    "sound/bob/pain.wav": {
+     "bytes": 27006,
+     "sha256": "d5d07123eb3c15917dc265cfa6df8971ab215f4408847225827359e1c175ee6b"
+    },
+    "sound/bob/s_explode.wav": {
+     "bytes": 30700,
+     "sha256": "94f9b780d25154f8c04cbe297a4aeda13fb0669c0a21e48e2b46f0102c35375e"
+    },
+    "sound/bob/sight.wav": {
+     "bytes": 14892,
+     "sha256": "1a0db2b8c8d763f9aae09913d1cd3548fa0e30eb03949e24ef511a70acfda303"
+    },
+    "sound/defender/blip.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/defender/breathe.wav": {
+     "bytes": 32676,
+     "sha256": "7b673b07828790504caca013c18bf697fd53b758a3638b949b433cf2d72f03f3"
+    },
+    "sound/defender/sight1.wav": {
+     "bytes": 14026,
+     "sha256": "7a059f5c95936c1e51e96c28b9f30fbe6d66c27b1271b6f077eddd6611e15882"
+    },
+    "sound/defender/sight2.wav": {
+     "bytes": 8192,
+     "sha256": "780230c4697dea0189ff81f731394696893d321ce7f3600370cca5ae2e81822d"
+    },
+    "sound/defender/sight3.wav": {
+     "bytes": 10442,
+     "sha256": "cc71b100be0fb44e58b396e5e7e3d602e646545d8b368e804469ff083ed687c1"
+    },
+    "sound/defender/sight4.wav": {
+     "bytes": 9918,
+     "sha256": "bd959168eff294104f04b5b1b736c722518fbf0d8f13fdbd8c4b695f14838aea"
+    },
+    "sound/defender/ssg.wav": {
+     "bytes": 38828,
+     "sha256": "5c4e3a9baeec3f714ed00f2585d04256ac33582db911a026fdc56dea7f0a7dfa"
+    },
+    "sound/dguard/death1.wav": {
+     "bytes": 30610,
+     "sha256": "af3809501261ec4d0afa6ea7301c11a5c7bbc1cc3e06b8c88172ee0214c30969"
+    },
+    "sound/dguard/death2.wav": {
+     "bytes": 43636,
+     "sha256": "93a70fc0d6fee819c723a435a3954b3fd3be86e358698ce85db1062990d1575e"
+    },
+    "sound/dguard/fire.wav": {
+     "bytes": 60820,
+     "sha256": "f5e5d4f6ccc0778c1396c66d327564a0b1892773f2c23d2e30590abf0c758bd2"
+    },
+    "sound/dguard/hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/dguard/idle.wav": {
+     "bytes": 20498,
+     "sha256": "45b2f208b9796d19d7aeb0cba64e4b0e5fd2ed7c980123f7c41ca10d17785021"
+    },
+    "sound/dguard/pain1.wav": {
+     "bytes": 10380,
+     "sha256": "9a367afb7cde241099c58c999e225ba939be39f21be818b16444f5a810049960"
+    },
+    "sound/dguard/pain2.wav": {
+     "bytes": 14892,
+     "sha256": "827a1e4d3c9983f61fffd61de33054274c144bddd9a68460b496fd6281cf9406"
+    },
+    "sound/dguard/sight1.wav": {
+     "bytes": 18124,
+     "sha256": "9cb3d960261d90ec16c9883f4326c905356b6ff4e99cdf48ab5913b098588016"
+    },
+    "sound/dguard/sight2.wav": {
+     "bytes": 18022,
+     "sha256": "35ee4b7ec6715c8c9fdc24f90ad0b5d90a0ae7a4986168cf40670e87c325d5db"
+    },
+    "sound/dguard/sight3.wav": {
+     "bytes": 19948,
+     "sha256": "c6818770267626dea27f4a72ce2249771f6968924022c2275a5a96abfa485044"
+    },
+    "sound/dguard/sight4.wav": {
+     "bytes": 20332,
+     "sha256": "7affcdbdc62f13e492a15b54fe642fe045641f5551f570cc3c8d5f7ee29521fd"
+    },
+    "sound/dguard/slash.wav": {
+     "bytes": 22942,
+     "sha256": "44b60d785ff03f033e183b6fbce69e526351187d28efdeb308f6f8bea930d450"
+    },
+    "sound/dguard/slhit.wav": {
+     "bytes": 31956,
+     "sha256": "0f07a131640f21337cd89a772588ecfc707d6a729f96b54c21920b809cd620e4"
+    },
+    "sound/dguard/slmiss1.wav": {
+     "bytes": 10458,
+     "sha256": "e32d5cb070a13fad979b021e84a727f71242305ade1af7bfe18c255f0f6dd548"
+    },
+    "sound/dguard/slmiss2.wav": {
+     "bytes": 13840,
+     "sha256": "f6b3aee08c25434d2fda7468cacf35a0912b182653a45991149b54a0fc4be537"
+    },
+    "sound/dlord/death.wav": {
+     "bytes": 32022,
+     "sha256": "0188f6a3dd88686e15311f8c39c4277078e55bc0ec75497e2eb534af717abcdb"
+    },
+    "sound/dlord/idle.wav": {
+     "bytes": 9906,
+     "sha256": "c0ee37f80013dad1aaeb285a11a33c4d7c2ff2de0b2a94c2943d3fbe1c241bcd"
+    },
+    "sound/dlord/pain.wav": {
+     "bytes": 8632,
+     "sha256": "230ed5c7d024bfa90b973649aa79d9e9327eaf401b1632e4a1334fb4a9eb075c"
+    },
+    "sound/dlord/sight.wav": {
+     "bytes": 28028,
+     "sha256": "d82aa0028754e826705961040e1ab27f007c572a28c63dbcaeefeb681bc3ca85"
+    },
+    "sound/doors/eldertry.wav": {
+     "bytes": 76358,
+     "sha256": "769f4e43083dfa153a2cfdfb11c09920757a407c871f82957dbc9120de140230"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/explode3.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/sight2.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 14026,
+     "sha256": "7a059f5c95936c1e51e96c28b9f30fbe6d66c27b1271b6f077eddd6611e15882"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 8192,
+     "sha256": "780230c4697dea0189ff81f731394696893d321ce7f3600370cca5ae2e81822d"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 10442,
+     "sha256": "cc71b100be0fb44e58b396e5e7e3d602e646545d8b368e804469ff083ed687c1"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 9918,
+     "sha256": "bd959168eff294104f04b5b1b736c722518fbf0d8f13fdbd8c4b695f14838aea"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 83982,
+     "sha256": "4b0d8db882ab1c9fc2109effeaf125ec46fb23a91ac2242201103e0d3da96944"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gug/bile.wav": {
+     "bytes": 54572,
+     "sha256": "e06787585ef0369798a938a1a9585d24b60aa7b5c65acda3a5fb6f2c7ab65aca"
+    },
+    "sound/gug/bileatk.wav": {
+     "bytes": 50040,
+     "sha256": "b4b05e2907789a78391ccfe8ced3902821f1097ecd1f894b12ba9278d31a8717"
+    },
+    "sound/gug/death.wav": {
+     "bytes": 132396,
+     "sha256": "20bf209a832381b77d37c54a84ab1819b6c71e2147c5d122ac62668c070167a5"
+    },
+    "sound/gug/gquake.wav": {
+     "bytes": 43350,
+     "sha256": "d232ae13b55cb5b10b8903db43c037a5c6c4cdfea1f84f9399133484df6e0175"
+    },
+    "sound/gug/idle.wav": {
+     "bytes": 50580,
+     "sha256": "ff33c63696dec5c582ff9a4537814299b47ce2480d6cc53c116721d793576fda"
+    },
+    "sound/gug/pain.wav": {
+     "bytes": 22064,
+     "sha256": "e559f2b372fe771207aeef4b1c3a71baca542863493776558ae3f933f3878c29"
+    },
+    "sound/gug/quakeatk.wav": {
+     "bytes": 65882,
+     "sha256": "2c07b7690356bd9233a79c1f8b5f4e146cbabc367a19c138d6719a1e0d09328e"
+    },
+    "sound/gug/sight.wav": {
+     "bytes": 76426,
+     "sha256": "210ed86a5d6f9d4e791954fc3a4e4b4b6dc5839d02f7c19d468493a2f87dca64"
+    },
+    "sound/gug/step1.wav": {
+     "bytes": 15494,
+     "sha256": "4e2ce285991bc0d4337c77fdbb029507697ecb4dbf6543ddefe976ea114c4214"
+    },
+    "sound/gug/step2.wav": {
+     "bytes": 15502,
+     "sha256": "27f6f770a52fce5ae04836706e63ef455555de086019a2f9e44d4da1fc99b03d"
+    },
+    "sound/gug/step3.wav": {
+     "bytes": 15502,
+     "sha256": "fcc7ab38a8ec28509d0aa062a3cb93aee6da6a0ae364e4fe0dfad791f54558af"
+    },
+    "sound/gug/step4.wav": {
+     "bytes": 15502,
+     "sha256": "fc52cad29cca2e1fc36f5c6ac7f955ed897d6da4fb5dcf4eefd052e0652d93e7"
+    },
+    "sound/gug/swipe.wav": {
+     "bytes": 16064,
+     "sha256": "90bb5831dfd19f65df19e97f76d858ec940d8e33e0a2ed8fad89a23947e430e5"
+    },
+    "sound/gug/throw.wav": {
+     "bytes": 23180,
+     "sha256": "5e901b94e7be364536603273f18791ab571c46c2fc74263774c0e312f873a281"
+    },
+    "sound/items2/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items2/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items2/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items2/trinend.wav": {
+     "bytes": 79450,
+     "sha256": "6edc4b653c671187012e5ad6a95f777a861ab18a1d27b69a10912b459dab2577"
+    },
+    "sound/items2/trintake.wav": {
+     "bytes": 73428,
+     "sha256": "b26c0f0af98016163bf1fc7c4376ca90dfa4ad447e31a04fff9d8c9d820cda86"
+    },
+    "sound/items2/trinuse.wav": {
+     "bytes": 16990,
+     "sha256": "ea0b2b20b8137da8388bab00812218a47049183a7d4eb031449b975289de4ed4"
+    },
+    "sound/misc/elderkey.wav": {
+     "bytes": 55212,
+     "sha256": "70af94f89ca397badfe01eadc36b1375f3d219ecd8c19f691a4a6cd257cf9e7b"
+    },
+    "sound/necros/dias.wav": {
+     "bytes": 412204,
+     "sha256": "2de75ccc9f971c3c56b87c145ac96cfc7d3e13a758c89081133389d13399606f"
+    },
+    "sound/necros/drivshft.wav": {
+     "bytes": 385808,
+     "sha256": "a84800586cff4027335aa94cc05e0f5a0d88ab2404cba7a5ccc40c3581ffb981"
+    },
+    "sound/necros/forebode.wav": {
+     "bytes": 97960,
+     "sha256": "5dc4a7a6c7c2444595c0a7511ec8e1d5913211591202cd9a0e478588e1939c0e"
+    },
+    "sound/necros/gen.wav": {
+     "bytes": 136482,
+     "sha256": "f0d4932c1bc41d8701dee215fe04ec5f8667ac1de980d9d6158eef7f9e3e7fe0"
+    },
+    "sound/necros/gen_fire.wav": {
+     "bytes": 182316,
+     "sha256": "da244c2acc4a6b496330f1b7202a3f3d68ff61bc0e7e1c0a66a4208fdb66e9db"
+    },
+    "sound/necros/highwind.wav": {
+     "bytes": 158882,
+     "sha256": "41decf2ffe971f07420ab67deb227a285246d92eb01f77284920f01cc3652284"
+    },
+    "sound/necros/irulan.wav": {
+     "bytes": 196396,
+     "sha256": "52fc652f8b7814d4d28252f421e7ecebad629dd4c613e73adc643d67dabab3d5"
+    },
+    "sound/necros/sgatehum.wav": {
+     "bytes": 128670,
+     "sha256": "1a06f2e664cf213248990ee27ec117a46a4ba6ea6067b114c896cc9500f4fa99"
+    },
+    "sound/necros/strongwind.wav": {
+     "bytes": 133538,
+     "sha256": "fbc3ce4f537ebaf9603c6c4de350f06b2373f420e5c47a300668942ecd1a9064"
+    },
+    "sound/necros/tld_stop.wav": {
+     "bytes": 72304,
+     "sha256": "b58180629cb28e31b5fa0e00fc74c2c75841dbdcb778674509877d40abdf51df"
+    },
+    "sound/necros/tld_strt.wav": {
+     "bytes": 101584,
+     "sha256": "66ae791b7a06a8aa233d59bafb63d7b4ecb71be8b6ffc50c6794ea71807fbefa"
+    },
+    "sound/necros/tshaft.wav": {
+     "bytes": 221356,
+     "sha256": "95690f3dca8be51dcf789f5cb8977f37c20257b9b7bc84a4c57caa3aba0316a7"
+    },
+    "sound/necros/wat_amb.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/necros/water6.wav": {
+     "bytes": 45870,
+     "sha256": "d7505b517d6573f661739d765222c33d9ac1a86da362328d5635fc8634c9d823"
+    },
+    "sound/necros/woodmve.wav": {
+     "bytes": 70716,
+     "sha256": "bc27833a4d5b60b2212311cfefa7e8e04333e7a0c1efec939048a050bef4ab15"
+    },
+    "sound/necros/woodstp.wav": {
+     "bytes": 58554,
+     "sha256": "a86696cbcc070443f939497ba76c1e2c101bea2534dcc0993523031c6f500a2e"
+    },
+    "sound/polyp/blast.wav": {
+     "bytes": 25036,
+     "sha256": "0c3942daeedfa438ba36bd31481f7b24b067cab3d167c9e5cfd1cf3c498bf367"
+    },
+    "sound/polyp/cloak.wav": {
+     "bytes": 46252,
+     "sha256": "31cb79048b0c511ad0d40989785d835584c4c808025b8eb8060a74b36c9bca39"
+    },
+    "sound/polyp/decloak.wav": {
+     "bytes": 91152,
+     "sha256": "e2ee4693b0e466c5bc229db186257254c381c6a6985e71b02b20838859bcb5ae"
+    },
+    "sound/polyp/gibsplt1.wav": {
+     "bytes": 19580,
+     "sha256": "e9b7b73242aa04fdb6aed5de1c343ced81b15d6f78dde07097826b78bb1f87a0"
+    },
+    "sound/polyp/idle.wav": {
+     "bytes": 17750,
+     "sha256": "4edd47fe2508cb818ce36916a16c6e4c7cea4f61ff0310b7195e74bccc4f5d2b"
+    },
+    "sound/polyp/idle2.wav": {
+     "bytes": 22210,
+     "sha256": "b07894dd93545ed0c54fabae04f139c371a8b36ab84fc399f870f813b535000c"
+    },
+    "sound/polyp/sight.wav": {
+     "bytes": 11664,
+     "sha256": "a9c414ba4ca74fa3e08018af695674ede79a2f63aab26be0566dda9426eaef43"
+    },
+    "sound/soldier/load.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/soldier/rocket.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/vermis/death.wav": {
+     "bytes": 148016,
+     "sha256": "44b26a9dca5ec8d5e8a7ef2b5e38196b74e4f606cd37b906ee2b2e5b5a85b08f"
+    },
+    "sound/vermis/grab.wav": {
+     "bytes": 88122,
+     "sha256": "09528bd0d49d5cac0c03fe7994b57e572eb89aa8bce63cd0a591130e4b2126ae"
+    },
+    "sound/vermis/grabbed.wav": {
+     "bytes": 51630,
+     "sha256": "99583c88b8ec2959a0d69448aee16ec86b3d9feee6df7841fc32759598349376"
+    },
+    "sound/vermis/grndhit.wav": {
+     "bytes": 36428,
+     "sha256": "1f0e78fa08efb4617b6967a6cc218c56af227c7fd6bf039420d8f106d74fca72"
+    },
+    "sound/vermis/pop.wav": {
+     "bytes": 131420,
+     "sha256": "6284ab02e604b44c5b07225b2a0544c8707517d5fec0024c127bdafef2704f70"
+    },
+    "sound/vermis/sight.wav": {
+     "bytes": 137772,
+     "sha256": "d892117e4602595b6dfb65563b8fa7a3ad2171851791f7c6f47ea4bfece76296"
+    },
+    "sound/vermis/sight2.wav": {
+     "bytes": 106780,
+     "sha256": "6132e2d0db5cfb7a1a064e708d97f7258e2c6ac15c6f4ea8d520641e0ad10f9d"
+    },
+    "sound/vermis/splash1.wav": {
+     "bytes": 30710,
+     "sha256": "f931a2927c13cdb2523dde4550c0af993cc08cbea6e332739f9cf6fe3bd1ff8b"
+    },
+    "sound/vermis/splash2.wav": {
+     "bytes": 25332,
+     "sha256": "b91c69ee695bd71537ed018800f7d89e5e7d95332124f69adee39261d84d7c13"
+    },
+    "sound/vermis/splash3.wav": {
+     "bytes": 25590,
+     "sha256": "99fad2f3815a30ef645a2162ea24e54b4302ba00d7551af9299fde74ecce98e8"
+    },
+    "sound/vermis/spore.wav": {
+     "bytes": 44204,
+     "sha256": "d01a27af99745725dae124d30af18458b2ef323bce93c3cad939310e0f47f6c7"
+    },
+    "sound/voreling/bite.wav": {
+     "bytes": 8920,
+     "sha256": "a5bbebd7178205c400115846314709fa22c4db390fafbf3abaee2e33342e1a0c"
+    },
+    "sound/voreling/bitestrt.wav": {
+     "bytes": 11132,
+     "sha256": "be72b6a15a73bda266331309046229fd6f94b0856f4dfc306204e6266ad1cb59"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 19584,
+     "sha256": "e5bc7634816b927c305679e9b0ff3e4f33a2d09cb5e80db3c5dd04373ba452e5"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28378,
+     "sha256": "b9daf80e6bc998d521cd35f6d8ef74295f39fafbb71f6d6cfe8f0e7c1fb3f0ba"
+    },
+    "sound/voreling/land.wav": {
+     "bytes": 6154,
+     "sha256": "92f08d203711dbd3bc2049ba61a62938b4eb34a9c7285c26406da3b29bbdfba2"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "0b6c021bc7301757918201ad1175387eabfc0af4f6e8b94e273ba22a2aa6c53c"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 55972,
+     "sha256": "9aaaebf47f82cd7a521800aa9d81d14bd2747735481cb15b88ce104cf1568b6f"
+    },
+    "sound/weapons/bomb.wav": {
+     "bytes": 141228,
+     "sha256": "6fa171d6bbb3dc07f9c0fb422ceb2e3e20934e9a0465589717dfdc14c92b016c"
+    },
+    "sound/weapons/bombfar.wav": {
+     "bytes": 246316,
+     "sha256": "12334d1af40522f124564f354acf44f419d1e1477cdef97d0f790ab52a38d765"
+    },
+    "sound/weapons/dryfire.wav": {
+     "bytes": 47872,
+     "sha256": "d119284b7e97ab626587b20349eb5c2a90489b37df85a1fec52c98962185da06"
+    },
+    "sound/weapons/expl1.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/hamhit.wav": {
+     "bytes": 2434,
+     "sha256": "7754c2ab32c5d34473e4fe4977f9aa1b326a622431b44b599c798c7a0fbe2b60"
+    },
+    "sound/weapons/lancfire.wav": {
+     "bytes": 6520,
+     "sha256": "be8d154ba1404462776ec3f5fbbda0e974970dd5d61d97cf296c3711ede5bb84"
+    },
+    "sound/weapons/lhit.wav": {
+     "bytes": 149718,
+     "sha256": "1261ce565a67862e00a611789482feefebfd97340c03ec4f7eeaffb50adab57d"
+    },
+    "sound/weapons/lstart.wav": {
+     "bytes": 338900,
+     "sha256": "6cb11e08faa41a99e1223875f2f465b97304e9fa04efbbe4a2213634069fdb09"
+    },
+    "sound/weapons/plasexpl.wav": {
+     "bytes": 54406,
+     "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 164,
+     "sha256": "ba0d9dbe33691183ef2549fdd006a02e21ac209f1d51271018e9bf565793c1cf"
+    },
+    "sound/weapons/shotgn2.wav": {
+     "bytes": 75024,
+     "sha256": "248a021818f578ec3d96b9fe59d8f839242f4d5f8140a66a500b523b137d1977"
+    }
+   },
    "sha256": "0ad2132bced06216d27060ae5bcb39747b47dbc90ccd2b2cc0c1a55807551693",
    "timestamp": "2024-06-28T11:51:30.000Z"
   },
   "immortal/pak1.pak": {
    "bytes": 8293265,
+   "files": {
+    "gfx.wad": {
+     "bytes": 128932,
+     "sha256": "b9b298830f1c48cdc378d83b84e3b308f0ca3052c278d6b4afeb70fa4035ab7d"
+    },
+    "progs.dat": {
+     "bytes": 761082,
+     "sha256": "028ee957df11e12c26c6bb8bcf2f58e4b099a59797b78beebbce65a4f41d4cc6"
+    },
+    "progs/b_bio_l.bsp": {
+     "bytes": 11572,
+     "sha256": "e076780538e320d1a5ffcac210668e95edf63fce95edba192acdbbf0f634649a"
+    },
+    "progs/b_bio_s.bsp": {
+     "bytes": 6028,
+     "sha256": "1609a5f827eef414efe184ef62e8a7a7191208bef9e1593bd67724f19948b84d"
+    },
+    "progs/b_plas_l.bsp": {
+     "bytes": 11572,
+     "sha256": "5ab7b0e25b37c65ea87743bcbfdb482f5556d0595bae15eecb95ab8f1c8c2edf"
+    },
+    "progs/b_plas_s.bsp": {
+     "bytes": 6028,
+     "sha256": "58adae5e3ec3f32d65abbf74fb7fdad9bf19d6f33f2a4f2fe621b46867261322"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 331328,
+     "sha256": "046d34a681439138dca323f54e54d358e225d2d958b21b36ee564fe6d4be7b82"
+    },
+    "progs/brick.mdl": {
+     "bytes": 108308,
+     "sha256": "b566efdd77a56bc38866eb95d167b2e53b8453d4194dd641efe6a15a6d22a6ad"
+    },
+    "progs/c_ham.mdl": {
+     "bytes": 78908,
+     "sha256": "3ef97f78252e0c2aec063649102aad9765eb320fe172c24db29d8c08fac5951c"
+    },
+    "progs/c_lance.mdl": {
+     "bytes": 48404,
+     "sha256": "03d923d70944814497b47312137221bec8ed46c2e8f6681ebac07dfb5b5517c7"
+    },
+    "progs/c_light.mdl": {
+     "bytes": 63500,
+     "sha256": "d0c16e23a406b1833408e216e34759a5060b202e603889ac8c39cac92d6d9434"
+    },
+    "progs/c_nail.mdl": {
+     "bytes": 63324,
+     "sha256": "b98d0281f8958d5b7a50e795711cb9e7b04d73e417dfae13f64f17d1ffc52228"
+    },
+    "progs/c_nail2.mdl": {
+     "bytes": 79328,
+     "sha256": "088e8d8994344e46918df796a38e87d0dbe2ba0baf1ad9359e072ee538902551"
+    },
+    "progs/c_rock.mdl": {
+     "bytes": 67924,
+     "sha256": "c0d3b99d6edde1329011a6754f65caa55888421c94669cee26beda3c1525bb63"
+    },
+    "progs/c_rock2.mdl": {
+     "bytes": 65932,
+     "sha256": "6fa52810c7164815d909085f80d27e3cf60f2a9dc48547c877947ebfc045fd4e"
+    },
+    "progs/c_shot2.mdl": {
+     "bytes": 58572,
+     "sha256": "381c796447399a343a4dff310ba58942eb45168708ef3899a2043ceaefc86c14"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/flame_pyre.mdl": {
+     "bytes": 85180,
+     "sha256": "9df2ae13e72ffe5a305a6ce877b0284023520d5d34df751498a2003c3e420ebc"
+    },
+    "progs/flashlight.mdl": {
+     "bytes": 35596,
+     "sha256": "8442b889437acf210587a7d567ad71c839b978e7dcf27a580503a05983368c70"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41908,
+     "sha256": "52eeb2cb3923bccdf6960abbea3f39cee9c8e504c984c5ccaa7e218627fdb882"
+    },
+    "progs/glass.mdl": {
+     "bytes": 127788,
+     "sha256": "f1e6a01f984e742bfd4d6428878e356e736251b7d18ac65e84aae63fa807fc69"
+    },
+    "progs/greenexp.spr": {
+     "bytes": 24732,
+     "sha256": "52b354786534248048d517a16fea53ad54c39ff7c82185c45067daba31dbb522"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/grill128.spr": {
+     "bytes": 492156,
+     "sha256": "c1ffd3a6680099e228605480d83bc5929ecd5730c01d24cfbcff3f195b509b51"
+    },
+    "progs/grill64.spr": {
+     "bytes": 123516,
+     "sha256": "c8d559303231ce4a7a1c246bea0a24c322d249f3b1cea61114fc0816a73cc781"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 43931,
+     "sha256": "f87f4d5b690c6ca434e5ff904d02f33cae0ac9e44bac4350b9631f47e29f6287"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 28501,
+     "sha256": "24f0d69fa8e5aa9cf70fd2653dab9bbd59fff7985b895234f8b07d1a4546998a"
+    },
+    "progs/lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/medexp.spr": {
+     "bytes": 72892,
+     "sha256": "d9887be2c9837d713d3aef856c1fc9245a4628b76ecd9e4e50a28d0deee1a679"
+    },
+    "progs/metal.mdl": {
+     "bytes": 246933,
+     "sha256": "07c0bb9ff1aa1639a62e5a84fca28d48c0fc738f4d22f8e3d8a5a029790d870e"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "e0bd8b2d3da7f2d8bdd59c4664b9202f00fa6dbe8c6321fd3651b3e857edd6c3"
+    },
+    "progs/pickup.mdl": {
+     "bytes": 36332,
+     "sha256": "7d0e5cac5f2a9f5ce879d81499c770b246ce5fcce049e2661fb35d2b15cbd2b1"
+    },
+    "progs/plank.mdl": {
+     "bytes": 19967,
+     "sha256": "d0fd70c3bd6dc93d13b229d4e0fa804a32a6688ef9640b4cc6340d9dab5fbd3d"
+    },
+    "progs/plasmabox.spr": {
+     "bytes": 14472,
+     "sha256": "89432660fdfbbdd90c72639152666f38ea6e7016a1d13171bf2d2e63bd2f4e89"
+    },
+    "progs/reed1.mdl": {
+     "bytes": 95281,
+     "sha256": "65773f37e26d41dd72ec1cf9849c663c1475923cb77d0f4c599bc3301368373f"
+    },
+    "progs/rock.mdl": {
+     "bytes": 136476,
+     "sha256": "0f80e53002bee59dad6dfe6f73b1ba2287700bea1cdade8e1dd4c35ec9d212a8"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "0350089b0bcf3a63a5d7b1e0bd070ac993be60f652f9bf9e3cf48957d31d561b"
+    },
+    "progs/sentinel.mdl": {
+     "bytes": 290664,
+     "sha256": "573efd78767922b2bbb3e5dab2b16cd8f90c2cb1709ecf4a315a141f4df77d09"
+    },
+    "progs/smlexp.spr": {
+     "bytes": 105148,
+     "sha256": "ce4938c9e813e648404b25b82245cad4400682d885d044b9d353a8039cfdceb7"
+    },
+    "progs/tree1.mdl": {
+     "bytes": 57621,
+     "sha256": "8e450cd50b8dac1912e96ec78ff4a16e0b9065138d181fa58257973c2ee96578"
+    },
+    "progs/veg.spr": {
+     "bytes": 8340,
+     "sha256": "4248f027adca723fb0101abf5c51b604ca6aabf80d4ccd9aa305cd34e072a682"
+    },
+    "progs/wreckage.mdl": {
+     "bytes": 71364,
+     "sha256": "13763a8cec3b643acb9b8165f1850ffae003131c84a2ac225777822a88462498"
+    },
+    "quake.rc": {
+     "bytes": 1184,
+     "sha256": "ab29f4784413223ea5fd84a2f983eded94275051dc132bbe0ddf8debc9d2b97e"
+    },
+    "sound/defender/ssgcock.wav": {
+     "bytes": 5274,
+     "sha256": "db4f62f8d76a68f2e4d3e7a29a22d3ddc5d6ae9bb296e6e800e937b73b5a4dea"
+    },
+    "sound/defender/ssgfire.wav": {
+     "bytes": 14206,
+     "sha256": "494a6d493c3c298c1b9cc0051ce4c1f9e129293ea7ec283b62915c49d8c249c3"
+    },
+    "sound/doors/blocks2.wav": {
+     "bytes": 38638,
+     "sha256": "12df7d5a55311ad33e5d3cf1efbad53f2209b7598c59d4e4715ef18d9e4532e0"
+    },
+    "sound/doors/blockse1m2.wav": {
+     "bytes": 91858,
+     "sha256": "12e39c7592dc01f13b7be34306c6b77c13e8d0429219fa46402752e5e6f62ca8"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eliminator/acknow.wav": {
+     "bytes": 77318,
+     "sha256": "5eceea3e5c2d77b919ad0e05375f7c891e6a7192192b5c1f7bde3f999adf8649"
+    },
+    "sound/eliminator/hesdown.wav": {
+     "bytes": 188790,
+     "sha256": "43688ea2cda3a2edb9f9d575eea9e8b2bb8e962bcd989bdfa5a8962eb2c74480"
+    },
+    "sound/eliminator/hostile.wav": {
+     "bytes": 100856,
+     "sha256": "03ee39ba5581da66909d721f4f40a259ccea095501dcbaeff47ab9d2e8044bc2"
+    },
+    "sound/eliminator/idle1.wav": {
+     "bytes": 39084,
+     "sha256": "2ccaa3ba4f987d031a22b8048ca23e97900fca9def362ff92943b73a99ed7844"
+    },
+    "sound/eliminator/idle2.wav": {
+     "bytes": 36204,
+     "sha256": "9232028e1a93c409c7000348bfadc269c49a333e8d65d904973efb547c7af805"
+    },
+    "sound/eliminator/idle3.wav": {
+     "bytes": 38222,
+     "sha256": "93034d568db5c304a165c3d89cb03ffe5d97e8157755e944a863697007eb27fc"
+    },
+    "sound/eliminator/sight.wav": {
+     "bytes": 31468,
+     "sha256": "2268ee0ad0c77a081b289a550a1dae24b274b2e3f06d156a67beca80df8ee919"
+    },
+    "sound/eliminator/target.wav": {
+     "bytes": 159480,
+     "sha256": "f2c8c4e9f515d682387ec9b4ba40102917355cffc58ad95dcc935b9805742cbe"
+    },
+    "sound/impact/gib_i2.wav": {
+     "bytes": 19252,
+     "sha256": "6a5ddcd321e9543960098d000255abc76b2f502e0e2da798dba4dc6fdd076e3b"
+    },
+    "sound/impact/gib_i3.wav": {
+     "bytes": 14956,
+     "sha256": "e6a2eb024a5101846479865d49ea5ba551d3972567eee70f1a9db3bc6687ccbc"
+    },
+    "sound/impact/gib_i4.wav": {
+     "bytes": 32782,
+     "sha256": "59b447c5e03b7ebc2914704f0e3caaa6b65e393e25d6f19b0a14f2f570676caa"
+    },
+    "sound/impact/glass_bk.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/impact/glass_i1.wav": {
+     "bytes": 13526,
+     "sha256": "e57ff2304e1ed3b85bca5803ab3309f74b115669527ad7c54371bc4377aa3f60"
+    },
+    "sound/impact/glass_i2.wav": {
+     "bytes": 34624,
+     "sha256": "1e403adc1d18b90440d2b10793c0c356617b138be309ed7b9774b9de86d23a8e"
+    },
+    "sound/impact/glass_i3.wav": {
+     "bytes": 9520,
+     "sha256": "250f438c593fed13a5493edc2b4a88c6a4cb22034f81dd7571ba2db7bfee9fa5"
+    },
+    "sound/impact/glass_i4.wav": {
+     "bytes": 6192,
+     "sha256": "05b2dcf83bdcf50f0ac1b6a341d85380293bb519948da38a07a842df53e8e774"
+    },
+    "sound/impact/mach_bk.wav": {
+     "bytes": 124920,
+     "sha256": "642a3ef399d357428f0800ac39557a6e841301aa47263f2f0f3e1b719a4d3923"
+    },
+    "sound/impact/metal_bk.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/impact/metal_i1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/impact/metal_i2.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/impact/metal_i3.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/impact/metal_i4.wav": {
+     "bytes": 79928,
+     "sha256": "d2b35ba352f32ceae469acf9cfa04f7dcc0a462ff69e3649f5c0adf55ae2ea78"
+    },
+    "sound/impact/rock1.wav": {
+     "bytes": 30534,
+     "sha256": "5cb61e93ebcf9bbcd3be1f6e282b51e9102d56b6650cffc0db93918b11b42322"
+    },
+    "sound/impact/rock2.wav": {
+     "bytes": 29254,
+     "sha256": "9fdf4f489834452fce33b1fbe69bce9d4920a117c3d0d93b4fb530a7117bf160"
+    },
+    "sound/impact/rock3.wav": {
+     "bytes": 25264,
+     "sha256": "59b506a84e018b11e9ba30a6ad299c2d8cf24d5907dc95cf30e578cd386e28bf"
+    },
+    "sound/impact/rock4.wav": {
+     "bytes": 27244,
+     "sha256": "7a2c24ce52e272998ca035c967860873c92fbb14227a190ac82b761843680ffd"
+    },
+    "sound/impact/rockbrk.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/impact/wood_bk.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/impact/wood_bk_old.wav": {
+     "bytes": 61250,
+     "sha256": "f9cff6955830b4219b3cfa01e04f41f311f7fbbadbc2738c92bf21808f1e7800"
+    },
+    "sound/impact/wood_i1.wav": {
+     "bytes": 28074,
+     "sha256": "6249449664f5ae509164ae3fd8588c905bea9daf5b1d919d9917b91aadf675bb"
+    },
+    "sound/impact/wood_i2.wav": {
+     "bytes": 25158,
+     "sha256": "d51e731bdf895c84ec9927c496fc0a7fb6e7a37cbfbc2f6b55f54f716d804d08"
+    },
+    "sound/impact/wood_i3.wav": {
+     "bytes": 17644,
+     "sha256": "8e1967cf42a7e31668d94e1b0cb7c6de4d36c6ec735d67ab01ac4e00dfb0853c"
+    },
+    "sound/impact/wood_i4.wav": {
+     "bytes": 11516,
+     "sha256": "fb0908f1a2bdff824d27fa92f15690cb9f86805185119fbc7f7876547495bf45"
+    },
+    "sound/items/click.wav": {
+     "bytes": 6534,
+     "sha256": "fab804dd505a2d823b062b348f126788bb3ce6c6399e8e76b1b7e39ffc8c82e3"
+    },
+    "sound/ogre/flakfire.wav": {
+     "bytes": 25932,
+     "sha256": "d00213964c69abe9c1661aa2cd2ae9305b0bdacb46a3e0945763883fb2d991b6"
+    },
+    "sound/ogre/flakhit.wav": {
+     "bytes": 11846,
+     "sha256": "a7c4a0b04c8c39de0bfb560283ac872e6bb6b240fdeef9a1565d314eb99cbefb"
+    },
+    "sound/player/ftladmet.wav": {
+     "bytes": 67720,
+     "sha256": "7cd7028d84b16700661848a36a866a2602bcf50185b79ca94d5a2eb541fb1294"
+    },
+    "sound/player/ftladwd.wav": {
+     "bytes": 35760,
+     "sha256": "b09b57b7da9ae84b359260d7c600b70a05ed2314597af6cfd38999f664568d65"
+    },
+    "sound/pyro/death1.wav": {
+     "bytes": 18468,
+     "sha256": "f69cb5d6086c78c8e7bdb9d8fcb9365e6500ece5156810b568a2cf2d0acdc126"
+    },
+    "sound/pyro/flame.wav": {
+     "bytes": 44268,
+     "sha256": "44aa350cb7efbe578f785820ba28bf6aec29561a7d150072ebe841966adcc45d"
+    },
+    "sound/pyro/fstop.wav": {
+     "bytes": 44268,
+     "sha256": "50a724e76295283a5cca503ac1b46d5ca97a33055e0c8e85bcfdfc0c90d5169d"
+    },
+    "sound/pyro/sight.wav": {
+     "bytes": 88918,
+     "sha256": "39d9c5460096478952c203bfc358ee52c5f2147e742b937f2e8517b45843c360"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sentinel/laser.wav": {
+     "bytes": 9712,
+     "sha256": "c5f90e1823a04b48f7f24ac5b8792e1b42030a8b07970db5847dc1e74be094c2"
+    },
+    "sound/sentinel/nail.wav": {
+     "bytes": 13750,
+     "sha256": "7acc3ac05b7218abc6fef2d2397771d90fce6fa39415e33824be7e771d30e288"
+    },
+    "sound/sentinel/widle1.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/widle2.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/wpain.wav": {
+     "bytes": 19596,
+     "sha256": "bc7b6536a1c67aa89295eeacea2d9b36cb0bf783b5fb7cc6aaf4fa01a0edb3fd"
+    },
+    "sound/sentinel/wsight.wav": {
+     "bytes": 27322,
+     "sha256": "83bca2103d60c68435e27f0660e3ecd5bffb058e796382e7bdb43efabdfb9889"
+    },
+    "sound/weapons/dryfire.wav": {
+     "bytes": 11268,
+     "sha256": "43e10c707d097c577f465c89fe9444c59b5ff4cdaf7c8d6619bcf61568d39bf2"
+    },
+    "sound/weapons/plasexp2.wav": {
+     "bytes": 112340,
+     "sha256": "92ea6112b21e65d625d34fbe1ec6abc592c2cf7c28f1b55c5999a8a56daebe8b"
+    },
+    "sound/weapons/slime.wav": {
+     "bytes": 57132,
+     "sha256": "88ce5f10c8acb0e51d54a4066ef8faf1643c5baf75edeafb82d350c733131215"
+    }
+   },
    "sha256": "7f71aba85e7d160bbff4e195f9a992d52cc99ec685954418f55b920319b60b9b",
    "timestamp": "2024-06-22T19:50:56.000Z"
   },
   "immortal/pak2.pak": {
    "bytes": 3806519,
+   "files": {
+    "default.cfg": {
+     "bytes": 2025,
+     "sha256": "3227f12ce7edbb4235d5b8b4d3f69206a9b8fd8715f939ca0601325e52ea15a4"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "faa7c77704959d1ad9bb5280449b22e8c4b9425fc628b4f2037900c49e73fc9e"
+    },
+    "optout.cfg": {
+     "bytes": 1564,
+     "sha256": "51efd87218e766df5c8b5c643ccabcecacfa855ee60deaf8dde8420a02c157c8"
+    },
+    "progs.dat": {
+     "bytes": 737572,
+     "sha256": "988aea9295972e13bc2b7ceabf2c72e4eda5e3ff095090701beb65f697647a96"
+    },
+    "progs/bolt3.mdl": {
+     "bytes": 15772,
+     "sha256": "6fabed3901bab1b145e418300d333c30016070e57ede07476884283a5ef7e380"
+    },
+    "progs/box_l.bsp": {
+     "bytes": 21639,
+     "sha256": "9a20404c31446ffc497113892dc293b0e59c6bb2cd9ab4a1f0bee11cc1f61a5c"
+    },
+    "progs/box_s.bsp": {
+     "bytes": 21541,
+     "sha256": "47b3f0a947272241184b9f65aa46d694fdd8facb8a9a36509d6f11f844f3917f"
+    },
+    "progs/c_ham.mdl": {
+     "bytes": 76800,
+     "sha256": "6bdd3e6b4c8253e6aeb6e293093b88fe6b3a9254135d285c8574acb6be9de9e1"
+    },
+    "progs/c_lance.mdl": {
+     "bytes": 44164,
+     "sha256": "6925fa7f462edb6c863bef65dcbe7d5c69544454c6fc1435a98c2890b08cc757"
+    },
+    "progs/c_light.mdl": {
+     "bytes": 76388,
+     "sha256": "9f0cdcc8e56d0614e058a3e922f3f64b0de33ab2ba6fe390c4154a3cbeceff5b"
+    },
+    "progs/c_nail.mdl": {
+     "bytes": 45336,
+     "sha256": "afe38a23bd9d6ec01a386047c3030f95732a986211eb0c6aafa83e12eb300a53"
+    },
+    "progs/c_nail2.mdl": {
+     "bytes": 81136,
+     "sha256": "c2e9e328af078538722ba4894801b5e4c5334a4629faff83b11510aa0a987b21"
+    },
+    "progs/c_rock.mdl": {
+     "bytes": 74404,
+     "sha256": "058de704ba8b0c2a47c2b83fd1b767a8220b9af87460bf114b14528db57ce096"
+    },
+    "progs/c_rock2.mdl": {
+     "bytes": 73544,
+     "sha256": "c922fdbfcd8175d196cc16f2134c8d9852c788ca76c198337aa71bf0bfde5e56"
+    },
+    "progs/c_shot2.mdl": {
+     "bytes": 42636,
+     "sha256": "02226bf370133fb1c4479c56a9a3c544cb89a0e87ba4cabe3247f9ddc9994b9a"
+    },
+    "progs/dspike.mdl": {
+     "bytes": 25324,
+     "sha256": "c2c89f690e21e34bee37db5011493f3457240e22fcaa3cdcdf04ef4bf9f44ae1"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51272,
+     "sha256": "0244bf38ec29f251b425bc1cc4f1a0e003316b3699c869cea38ec553e1f96acc"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "d45e10e4002fb17b2a1aa4077d1d4e599babd5083c0f7da914f8e98b61cb2537"
+    },
+    "progs/polyp.mdl": {
+     "bytes": 343144,
+     "sha256": "a135ee3b29dd230d06babc0e80c691b35e33599a48eb152d2c2c4902d424d4ec"
+    },
+    "progs/s_vp_pll.spr": {
+     "bytes": 272700,
+     "sha256": "024935ca88793c432ac5d6c6f52a51cb82638c86e9c27cac8d87e926673012db"
+    },
+    "progs/slime.mdl": {
+     "bytes": 25976,
+     "sha256": "53b07ceca49f5c637dc5bbe1cf1393db74e3d057624039efb8d7fd2341b5466a"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "aa9165056656a1d0810d741c91e5e14b1aebf3020a95ebc0dc1f48a3a1243074"
+    },
+    "progs/waterfall.mdl": {
+     "bytes": 43588,
+     "sha256": "c4bf6157c6f3a580a6cc7a76c8d5ea6a9af00f9c53b0615bf47b6574dc5bd54c"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 845237,
+     "sha256": "ee9db9fb4e224227574067dffb1b9c49af5b9536f8cea0527282d851aab81e73"
+    },
+    "quake.rc": {
+     "bytes": 1261,
+     "sha256": "27e799866073f0b3d8431b2826693a4e91b2c86e3d4046f8cea0df26f406450f"
+    },
+    "sound/ambience/grinder.wav": {
+     "bytes": 264572,
+     "sha256": "70789db5c6e505292dd6031241aff19bd7b327677033cac5f98c1dcfeed5c6db"
+    },
+    "sound/ambience/teeth.wav": {
+     "bytes": 51600,
+     "sha256": "9649cc3a15c66b851da286bfbfe085196e851a9a493c299b03d9874dc04431e4"
+    },
+    "sound/doors/er_stop.wav": {
+     "bytes": 51846,
+     "sha256": "f674272aa55db0cb05651c5edfa76422370d138c44789b179bc6e943a22f0d28"
+    },
+    "sound/doors/er_strt.wav": {
+     "bytes": 99372,
+     "sha256": "afb23446ab200aa3bd540bc1ac517713dbf2d7fc099283254f7b8a4480a90092"
+    },
+    "sound/doors/ir_stop.wav": {
+     "bytes": 81054,
+     "sha256": "c5ae31d19bb638cd61771f365beca5998d5795ff035929863a19148d39907904"
+    },
+    "sound/doors/ir_strt.wav": {
+     "bytes": 86616,
+     "sha256": "8e2767cf7d483ab898c7eb561834b0a7af90669976499dfe42c8f7e09560aeb9"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/wfend.wav": {
+     "bytes": 9060,
+     "sha256": "1d8381b51b40e54a47ee76a9115b95a49285fc59385ff20b941b0fc8b7cd16b7"
+    },
+    "sound/misc/wfstart.wav": {
+     "bytes": 77838,
+     "sha256": "c85b517926832c1a7ef3a04de2995a7bd58a161620b4341a3f57d556c50d7ea0"
+    }
+   },
    "sha256": "84dbc0e70d6140017eae03349595f04569a54569655b4cde92aeb069bc46f091",
    "timestamp": "2024-06-22T19:51:02.000Z"
   },

--- a/json/by-sha256/a0/a0521809e3fd8e93c3a131a88f7d361958864a83e741f4483834da3fa2e73f75.json
+++ b/json/by-sha256/a0/a0521809e3fd8e93c3a131a88f7d361958864a83e741f4483834da3fa2e73f75.json
@@ -22,6 +22,280 @@
   },
   "alk15/pak0.pak": {
    "bytes": 4870700,
+   "files": {
+    "maps/alk15.bsp": {
+     "bytes": 1851120,
+     "sha256": "a4b2399bc16f6783ca85b1e65fc2dcc9fec82b2f6fa8aafee339f7eff6a5e3f5"
+    },
+    "maps/alk15b.bsp": {
+     "bytes": 720864,
+     "sha256": "90ce3db223163c3274f287b5294875e30dc7084dca14096ce84f767ea08afb67"
+    },
+    "progs/demon.mdl": {
+     "bytes": 102120,
+     "sha256": "f3e7c35b6d9ec22ab548a681ba91886e09b9675b9d46e069f8e71d5a433c2ed1"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "b7e303e4cc1d9bfcaf8a8d3505b3ef87a5781ede398b3dca6244d5362852264c"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 228400,
+     "sha256": "8e7b40efbba024c66931efe170638c0fe7effca02136eb48359130e143be6c82"
+    },
+    "progs/knight.mdl": {
+     "bytes": 153400,
+     "sha256": "53e3b24c3be2886c6627525adc325b9a14f8c6ee8dcf885d02e604da434654a1"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 162036,
+     "sha256": "0cfaee1276d5312dfb986670e07f9f77c8ad31fd86a03613d8fd803a151837ca"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 80648,
+     "sha256": "e6f10025af936a7dfec3200276d1259eae517941754fdbf5c4171e6efd33f95a"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 98556,
+     "sha256": "b8b756c73b193addd1927f00b9e4f34fa7cc333a501eef5c3a368664ba0f331c"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 64472,
+     "sha256": "6ef610257a67aa81eb1c4f8a91bcbdbb4464c4d3bdea53f32dde03e93ba546b3"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/player/h2ojump.wav": {
+     "bytes": 22374,
+     "sha256": "bff10747b81c46e452105fa641bbde23b8949c44c17a799db9dc8ac25ac9bc7e"
+    },
+    "sound/weapons/rocket1i.wav": {
+     "bytes": 43560,
+     "sha256": "9b23cfaee14d7a577250a5c5c2473a4d6ab3e6641c34f477b967dbcca5a29633"
+    }
+   },
    "sha256": "d2673f5ae508aecd92f24ae6ece90c5460a5c9639c114879837905f916a32eb1",
    "timestamp": "2001-09-27T21:00:14.000Z"
   },

--- a/json/by-sha256/a1/a1137e6e1faec22f1ddbc584cbfd77357e79d63ae14241b6fbb9ccfe997d6a2e.json
+++ b/json/by-sha256/a1/a1137e6e1faec22f1ddbc584cbfd77357e79d63ae14241b6fbb9ccfe997d6a2e.json
@@ -138,11 +138,2971 @@
   },
   "pak0.pak": {
    "bytes": 25051624,
+   "files": {
+    "maps/b_barrel.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/b_wbh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_wbh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "progs/acidbal1.mdl": {
+     "bytes": 8788,
+     "sha256": "8a9c956f1952fb8d9ea51119c1c8c758d3ca3b3bf3bb0e8b63131bf88325f5a9"
+    },
+    "progs/acidbal2.mdl": {
+     "bytes": 8788,
+     "sha256": "eceba377145b62b4721927e55de75423daaac83f9667852b16dd1bfff3beff01"
+    },
+    "progs/akarrow.mdl": {
+     "bytes": 23072,
+     "sha256": "4e0e1c007453dbc432533dab09dfbafa943c4f43f7897848c91a516bf0de43a0"
+    },
+    "progs/am_super.mdl": {
+     "bytes": 8976,
+     "sha256": "55d561bf2f73b2c6482dcb5649da1b31d4bbf40aef6e21cca3518dc6a0c5709b"
+    },
+    "progs/anglstat.mdl": {
+     "bytes": 164396,
+     "sha256": "ce4644a5e22e0ff39790a293754501add2a4ad8afa26cfbdd13205c3b833e923"
+    },
+    "progs/archer.mdl": {
+     "bytes": 581920,
+     "sha256": "858ad8a4d0d27e1a9989ad7d87a9a4404ff8adbde33b07868725d34fd2146f6d"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 141992,
+     "sha256": "9a3c9afb3c47ed9c683ce6b0fdaef6ee6d1cf74c60509f1a82f8599318e71d08"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 25752,
+     "sha256": "57518dd89a3dbf6e712ad204b0a6f41fd7fdc9bfc03cf4c17e222f9d31d72b93"
+    },
+    "progs/arrow2.mdl": {
+     "bytes": 68764,
+     "sha256": "0bc41c13a4332f6d13e7884248b2d1a83b487bc2f4e1d5cbbdcd1c81512a4579"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 290592,
+     "sha256": "f0d1dc967de929d0f0faaa61aa51239d1f262c63da83013be094a4ed99e3028c"
+    },
+    "progs/bandit.mdl": {
+     "bytes": 226380,
+     "sha256": "7cc68b0c9a4950b4d3b97353227a6b8845104417efebfd00348b7fb24986d557"
+    },
+    "progs/baron.mdl": {
+     "bytes": 426204,
+     "sha256": "09a4b10b43c2cb4847330ce3660eab93c16a97a7db0c9e1c1447e938689627d1"
+    },
+    "progs/bbg.mdl": {
+     "bytes": 190836,
+     "sha256": "3bac35175b2808bad33e3b7e7c2c54b3d9181c5b3743aa68d803dbe58edf0eea"
+    },
+    "progs/beam.mdl": {
+     "bytes": 1460,
+     "sha256": "9e9531de6f4e6f2f6274ea6612ef00bd0642c0cc05a7fdc866805fa1be851b73"
+    },
+    "progs/bellring.mdl": {
+     "bytes": 74016,
+     "sha256": "9a8131071ca927803140ce6478b8912c6eb52856861250d6b6bfa1d32cfb9cd9"
+    },
+    "progs/blood.mdl": {
+     "bytes": 184,
+     "sha256": "06825646d627df610b374a31c9265a88c9c1c45864c6e3b9d273a14dc4d745a5"
+    },
+    "progs/blood_gr.mdl": {
+     "bytes": 184,
+     "sha256": "84caed23ff1b8cabec8c5d9e5c6792c30a6d9cc57c36a9746369012015462208"
+    },
+    "progs/bloodcb.mdl": {
+     "bytes": 28036,
+     "sha256": "83f0de29aa0f9e9f1d383895da374a5313aa2252edb306eb7bd69bd71660321c"
+    },
+    "progs/bookclos.mdl": {
+     "bytes": 3420,
+     "sha256": "a129ba5428a5fbef209010b893b4407c99a3d3a9e936d9d41247af5a75fc922b"
+    },
+    "progs/bookopen.mdl": {
+     "bytes": 6188,
+     "sha256": "d57ab7e96181b3fe70bc9c0c002ed6671fe14adfd454b680cd39be10b2315a05"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/chest1.mdl": {
+     "bytes": 19352,
+     "sha256": "239f897e3a390ad44acc5ffd19784f8b78232c5af2be67165581c2f6073ecc9f"
+    },
+    "progs/coin.mdl": {
+     "bytes": 44036,
+     "sha256": "c3d65aac43713c9102f8924ef7ed1cf90297ff17cfe8aface7936e9579b4ec57"
+    },
+    "progs/courage.mdl": {
+     "bytes": 14940,
+     "sha256": "4141933fbb8682ee28277826bd0f882580025def71b96c02cb9b53aa412906c0"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "7829e2cbaa4816577c77ba12a91933eee5dcf9d899f3f4d9717f6f8fc0319a23"
+    },
+    "progs/demon.mdl": {
+     "bytes": 355000,
+     "sha256": "3bb7fc1b1f89de1d66f99de4065d71e35dec87940d47c98b24d3be074d8bf70a"
+    },
+    "progs/dog.mdl": {
+     "bytes": 269016,
+     "sha256": "9a60157b0504891c71fbaece5a729e9b954a5e2dffe92e1e1a1ab51c6d912b77"
+    },
+    "progs/doll03.mdl": {
+     "bytes": 52064,
+     "sha256": "b2962f3954740ad7f9b5ee329d3a189ed5c95ccbb279bb63dc77508c94e4fb28"
+    },
+    "progs/doomcube.mdl": {
+     "bytes": 8884,
+     "sha256": "c4d31e7a4f2a9c01c1c502fec3653d8e0b14fc6ec790d8edebb1737a6116a471"
+    },
+    "progs/dr1_head.mdl": {
+     "bytes": 7476,
+     "sha256": "06f28a6f55ba29f12965e7ca10d99147a9432c851a2747d1e861cd45c07d958f"
+    },
+    "progs/dr1_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "c208f5473b2954fb4af094119b5a63b3a205e7a26e94c0c122b1f06870db6f78"
+    },
+    "progs/dr1_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "258da574e4de9d144d4f6a71db72a8bd566ecc6b0672efeb5cacaf59c7dd969d"
+    },
+    "progs/dr1_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "698d06c98e8e9ab99b6ddf808bb32a4994299c9596354bf8f811cda0f4042588"
+    },
+    "progs/dr2_head.mdl": {
+     "bytes": 7476,
+     "sha256": "551d47f807e21d11aba52f66207515e0988e8a424012f204e517c8c6720514d0"
+    },
+    "progs/dr2_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "f636b0786ab159a368b9fa580f1a0a31dc7873f21edb1bc454eb9e64c2c27a14"
+    },
+    "progs/dr2_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "533c0d631c78c22f5ff7632e7dc19f5da1acee56225a5a1497bf34d10fc07344"
+    },
+    "progs/dr2_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "5f5eace00eef74eeaa9db48887636e08ab43c85ad0d05816745c04a4710f34d3"
+    },
+    "progs/draco.mdl": {
+     "bytes": 235148,
+     "sha256": "0b51fd9b782891c4b8b410db6ac1361dfa0f53d634366709434a926e0c7285b5"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 262688,
+     "sha256": "d27bb0ed21b8f0e8161f347cb5bba89c8c5223324f462596f972478efdacb366"
+    },
+    "progs/dragon1.mdl": {
+     "bytes": 258260,
+     "sha256": "4dbf09c018ea9f703d4daf48c0a5e504208547d5d172bf26187b8eeac8a94a02"
+    },
+    "progs/dragon2.mdl": {
+     "bytes": 258260,
+     "sha256": "fa2b5d9467299634cddcff9c7ca87c2006c8c9631f45cbf66f74a8abfd5df347"
+    },
+    "progs/dragonpl.mdl": {
+     "bytes": 77764,
+     "sha256": "57db3cbef92a0f96cd8ef1be17ce77586f9541bbffcea2e7747e43b35c50effa"
+    },
+    "progs/drggib01.mdl": {
+     "bytes": 63320,
+     "sha256": "0a2571dc74871a4d43c8c780a62d36ce4d17dd83b6819c773bfb22a247b8bcbb"
+    },
+    "progs/drggib02.mdl": {
+     "bytes": 83352,
+     "sha256": "c3ec2317e0f0f156237b7ed36d1ab3329a874a11f7a2fb343afac021a50f777b"
+    },
+    "progs/drggib03.mdl": {
+     "bytes": 58824,
+     "sha256": "9dfdc32e9616b40b82c410ca75f007bc11a9b18697d4edc82745bcda1b3313ed"
+    },
+    "progs/drilbomb.mdl": {
+     "bytes": 5396,
+     "sha256": "6615fa32cb3b464b665093296ff63fd0c624eea5ec595247d8c66941e1c8d071"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "718b8c2842877345426247148dd6ce1ebe7fecc13e969a0fa0ed6dbebc388099"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "0a386b6381824b01852910519490ac3f6e3309a96091820384ee6b9a5b452e7a"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bef43e6c7bc067d3b35dd05a793c08d7d700fbb2013606ac9ffeac8772d0997e"
+    },
+    "progs/drp_head.mdl": {
+     "bytes": 2340,
+     "sha256": "b87cb902d796dd76c03e9fc79576f368d23022fbd5b5155c8910cd315046e32a"
+    },
+    "progs/drp_lw.mdl": {
+     "bytes": 7116,
+     "sha256": "ad483731fddede05ebf1a9a3c20f735f6ec341f156669833ed1077460dac8e5c"
+    },
+    "progs/drp_rw.mdl": {
+     "bytes": 8056,
+     "sha256": "b57363de0be61e45b355d1cceccadd42fdd1b8f91fc4380847dacf186d7560df"
+    },
+    "progs/drp_tail.mdl": {
+     "bytes": 2604,
+     "sha256": "b8ad65168755d4f31b657a80c78e2e0f51316c48f4ebd10ddae0b6971c7c6e89"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/ember.mdl": {
+     "bytes": 8788,
+     "sha256": "91d6f4dfbeba0711d0864b94bb372b602959644c5c841fd659ddedb8f8e6980c"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "13d14261d863f5170fb8e64e57b8ef344c435183313ffb1127ab6ce51176d262"
+    },
+    "progs/end_bane.mdl": {
+     "bytes": 52980,
+     "sha256": "4a86fd7bd59c4ecea934e3adcec4b17d627cdfac5223976a52b5739143c37f27"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 241252,
+     "sha256": "9ae37ced89200daf2d44795bef4230c5b725226a820c28cda7908f43bbdaa747"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 414484,
+     "sha256": "3d146be46cd90ce477006354b3ed627541fc4ecdb52ff6de2b4f3159c61e1390"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 68804,
+     "sha256": "f3c760ecdbb530ff651c46f516228c588f37585315acdab199408911c2c8414b"
+    },
+    "progs/flame2a.mdl": {
+     "bytes": 68804,
+     "sha256": "e02210f2f6851cea4b9520476cfe36c31745dc2d84248f6a75132358d6d43035"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 56532,
+     "sha256": "36d304e1442ede2048036d832d36ef4624fe4e90ba16628c20c819e7b4477da5"
+    },
+    "progs/g_grpple.mdl": {
+     "bytes": 149440,
+     "sha256": "fc148b3a840b84b65488658ec26a27621a86a196feb90723269534929ee0352e"
+    },
+    "progs/g_gun.mdl": {
+     "bytes": 35580,
+     "sha256": "0d6cbc684d5c5f1112d0111e29405e73721993ad57854c936e676025b7bfbc1c"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 38004,
+     "sha256": "cf67c0a7ad3e853fa4af7544d0399fc0a3795a61d625f5e78104e659e2db0eed"
+    },
+    "progs/g_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "3e4a1e9dc2bff162612e218a25e2040b57d063d198df2e301eaa8fa9542af098"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/g_rocks.mdl": {
+     "bytes": 47732,
+     "sha256": "d6539141be1597673eb1f8c78286d6efdeefa91f9723926d61b9a81e2f433c71"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 158116,
+     "sha256": "127e4fefafc5015f03a6cd1288cab9da325ed5b5a93c9f6b90b6da9d8273ef9f"
+    },
+    "progs/g_wand.mdl": {
+     "bytes": 13684,
+     "sha256": "99212b7901c31b723704e7c62b1c5f70b6a2f7320c349605a3943f3091e962de"
+    },
+    "progs/g_xbow.mdl": {
+     "bytes": 22476,
+     "sha256": "bf1cd180a66f74da4e625a2167bf66527cebd0d4009fabeed48297018db8a4fe"
+    },
+    "progs/gem1.mdl": {
+     "bytes": 42612,
+     "sha256": "0b71e525b19e25f98dad53ce766751de8e0c9f18434582bb86242296bb7a402e"
+    },
+    "progs/gem2.mdl": {
+     "bytes": 62672,
+     "sha256": "721459e22aab0d2cece430053734b889918bde4db879ffc94084289a7b6d4d8c"
+    },
+    "progs/gem3.mdl": {
+     "bytes": 42072,
+     "sha256": "3bc3a1018cc432b694f9ec45de06775776ef55d21b4e117dd1b2c7c0d7b850a2"
+    },
+    "progs/gemini.mdl": {
+     "bytes": 35188,
+     "sha256": "fa05498ce8034d51377953db7c650f9367b072a9d614812f4f67ad15eace909e"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/gr_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "3f5b6d67b80e5f2e5bb7c129500c79dc345141133f8d415005f9384b0d2d9661"
+    },
+    "progs/gr_gib1.mdl": {
+     "bytes": 6501,
+     "sha256": "3f715cbfdcd77caef11b904aa12d2063cbb973d4a9d61c27492690344c14fb1b"
+    },
+    "progs/gr_gib2.mdl": {
+     "bytes": 17553,
+     "sha256": "c6166eb6132a3e87f51fcf48f4e9eebb719b3f1819d22640582b23d61bde4a16"
+    },
+    "progs/gr_gib3.mdl": {
+     "bytes": 22933,
+     "sha256": "0e40e5b960924ca642690c26b239c89aea6bae18badcb945e96d2102cad69622"
+    },
+    "progs/grem.mdl": {
+     "bytes": 202672,
+     "sha256": "3df027b9f674f1f3d3cd775c877fe225029f1b814ff3358f98f932cf8bb0a604"
+    },
+    "progs/h_archer.mdl": {
+     "bytes": 22128,
+     "sha256": "034d829e2ad34eeff8f5d60b8e2064f08caee64fb7f064900298f9405e9399d8"
+    },
+    "progs/h_axeman.mdl": {
+     "bytes": 18400,
+     "sha256": "e15391056ec618b412d1341914d2e6f05a759de92500ef249cc5d1789b3ab6d6"
+    },
+    "progs/h_bandit.mdl": {
+     "bytes": 9752,
+     "sha256": "cc79629b169c0560905eae7ea9a02e5ec546af8cfa07743922e0b1dc829b29ca"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 7444,
+     "sha256": "68bc1db4875fe84f25ff3d6c53e4e9e2c023ef52bf3c89b439493f2e5c5c0e19"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "53539bc39fc87627a46b75b0d86ade5e6116a0079b032b1df137b2425b7186cc"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 166100,
+     "sha256": "0484f334f5722736248531a726e9a91c69e708a882e6d581db3d4e2a54d6db94"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 68796,
+     "sha256": "57a646b291c29b490faa38e3b72d7f074d9d071946d9b9c6068095999a11ce77"
+    },
+    "progs/h_drake.mdl": {
+     "bytes": 28792,
+     "sha256": "be0bcf5fc725dbb09a82becc2339d91824a14a547ce3013deabeece662658dcf"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 30072,
+     "sha256": "e88bac12b670f6790f3e053e1547569e88f0befa7a07abfc6a3fd2ad33b9d9a3"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 22724,
+     "sha256": "905ed9f78c83e29a31b6283b5a377053763469ae048bdcc3aede9213bda80873"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 100172,
+     "sha256": "27311a59a95ab735d79e5198318d0507da7e377584702ba9e5bf673c0972e065"
+    },
+    "progs/h_hkolem.mdl": {
+     "bytes": 30552,
+     "sha256": "38b2082ead97b90f59a5fdcf24d4077ab067c55655598d023f8ec38818c914b1"
+    },
+    "progs/h_imp.mdl": {
+     "bytes": 73564,
+     "sha256": "24944207a9867d67fa24961516dc2810a5d1b33d341d5190ac1666d58c8252f4"
+    },
+    "progs/h_imp2.mdl": {
+     "bytes": 73284,
+     "sha256": "f01cd8331b8774495258e3ab85ba6434a0deef19b1b953b6ccf93252649e01fc"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 19644,
+     "sha256": "1accd89ba95db3627cee4f06f94ab3bc9d146ebf566da24b570c733f2f902c1a"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "72455aab2067fd8f887e8a8e9c61d2b943699ce90fbcb85937fbb358c9e5678e"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 53188,
+     "sha256": "6e1c28d5c53f24901ebd0aa199a1003ef4fe3c8306c5ab28191cccd14bf25f45"
+    },
+    "progs/h_necro.mdl": {
+     "bytes": 14296,
+     "sha256": "fc9c468465d0e8982fc2d6207ce94b2f400f0f37cbe88cff2a4aa64719b91f40"
+    },
+    "progs/h_nemes.mdl": {
+     "bytes": 78156,
+     "sha256": "6f350692b44907984c02779d0114576bbafb6a3ada673e1f55d1cf02fd062c18"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/h_rebel.mdl": {
+     "bytes": 5428,
+     "sha256": "b189ff3ae1596da7596f21d8f555603951fadf8e7884e96f89c8b2b5789028a5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 53096,
+     "sha256": "ff1d940222f28765b975828528016332b04423a4001a507e07cde6414847add5"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 108204,
+     "sha256": "dd7dc5c90255da868b96ac553d8a8f68b6723da6b25114bc087fd019966a023f"
+    },
+    "progs/h_vomit.mdl": {
+     "bytes": 16952,
+     "sha256": "9822885036229871594a21643f4acd3a9b4c27d141b9021464b5062dfaf410f9"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "7ff66f881f85884aea56396da7b756da32c04df163a1e1f739485e77e61279df"
+    },
+    "progs/h_yak.mdl": {
+     "bytes": 73116,
+     "sha256": "eb2cf314618ef6dbc44ab46807237e59b68470edf24780e4ccd4c5b513f91196"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "2f6fd7256662a5a4b4b907b0ac68bf7d787ebd55cf54e352da5f1b363a2b2397"
+    },
+    "progs/hero.mdl": {
+     "bytes": 66388,
+     "sha256": "ea4f359a328b6416588e5debe13a87fc2eccd8a65263ae23683d71a58b39a116"
+    },
+    "progs/hk_golem.mdl": {
+     "bytes": 179204,
+     "sha256": "972f27eb2bf8a6cc4433e1f904097ca5393312d47a75e396b0323723beff58fa"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 534604,
+     "sha256": "10058c95eca9a063c7990d919d353d3573d252eb39f00c5f471a7f22f0b5fefa"
+    },
+    "progs/hook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/ice.mdl": {
+     "bytes": 2580,
+     "sha256": "30c4853e26d51d0ca4d3df5a40ec6d8861f48e9420f10560b5de0c19e6c15ab0"
+    },
+    "progs/ice_cube.mdl": {
+     "bytes": 3192,
+     "sha256": "bf96c8c1533fa537582bd4cf7bddadb7f5ddeebafbce9ef29007a5acd5a909b0"
+    },
+    "progs/iceball.mdl": {
+     "bytes": 24632,
+     "sha256": "802fa6260e9af5abb74bab0a76f35ae3e2af2373e61091c725325aa41051be7a"
+    },
+    "progs/imp.mdl": {
+     "bytes": 583036,
+     "sha256": "299777bbf58641a6674c0877423efd9f0995421a1bfb946fe21d1f2bdb41714f"
+    },
+    "progs/imp_lord.mdl": {
+     "bytes": 583036,
+     "sha256": "0b26574642cc72b73d349881543752a1f7d7f34f00561c4b039bef83e7191b10"
+    },
+    "progs/imp_rock.mdl": {
+     "bytes": 2352,
+     "sha256": "dbe190f471f5738779e103b496117ec40e2adc9e5f593d2470172bcbd7ade0f6"
+    },
+    "progs/imp_wing.mdl": {
+     "bytes": 93932,
+     "sha256": "a0100af8c072112afde45cc2f69e40de4aacffbdb4515de107892c39a00f5eb5"
+    },
+    "progs/impwing.mdl": {
+     "bytes": 93932,
+     "sha256": "5b986189f2f28ffe6c3fc23d40bc194bda2ab636826a9d41ffc9199727cc2f49"
+    },
+    "progs/impwing2.mdl": {
+     "bytes": 93932,
+     "sha256": "0d08640bcd5c6e6336b9cedb635a6152ba479065a56b296557476a6f5e9b1e4c"
+    },
+    "progs/k_ball.mdl": {
+     "bytes": 31300,
+     "sha256": "f93346ffeed3fd5d9866fb80d1a08216759bb27757d49a1851e471aadf757ec1"
+    },
+    "progs/key_b.mdl": {
+     "bytes": 10616,
+     "sha256": "d1333d74b7e194f6587d0f5ed1fca28887cd0414734b4bd4cbb7e715ab897629"
+    },
+    "progs/key_m.mdl": {
+     "bytes": 23160,
+     "sha256": "ea2feb6eb54823668dcb112f42c3441e563e18e3cc1806b5ce509044e6c0b448"
+    },
+    "progs/key_w.mdl": {
+     "bytes": 11576,
+     "sha256": "72da64d2b29d69605c453e9ee0e5fa8ecef91a94cc541103cb24fbad96c7946d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 232536,
+     "sha256": "e3e618799612c6e521f68234a061d9a46036ef556677b0c1651e7647258ffb56"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 27960,
+     "sha256": "5877b37cc4f98a53467c412e7d06d1f7ec6b60f5c0f2088514aa51c9d2c51769"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "210e159ea4c9bf1f2431213fd95902f4ea75ecee6a67a22bed7e93366f1f2732"
+    },
+    "progs/levitate.mdl": {
+     "bytes": 15876,
+     "sha256": "03e77b0d4b8ee7b3b224cbe0cfba63e8bd27d0391bd5069981e5435287f66645"
+    },
+    "progs/life_up.mdl": {
+     "bytes": 34676,
+     "sha256": "502716aa1b0f6cb8f929fe7ee2a74024a5fa007898256e15ca495e126888c584"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 57796,
+     "sha256": "e8b38ca8f28a89f65ffc652e082e8a9aaf6a1a9db8302e961b9ceac1c8f60e8c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/morph_eg.mdl": {
+     "bytes": 300592,
+     "sha256": "14468fccffaa1508c03610dd58fb51cd9058ca3bab036bca18f7a41cb37c195b"
+    },
+    "progs/nec_rod1.mdl": {
+     "bytes": 16072,
+     "sha256": "2eded5df9441aca7a243bf6c2a831c62374cabf7bba1acd64a84803441d77fc2"
+    },
+    "progs/nec_rod2.mdl": {
+     "bytes": 4564,
+     "sha256": "60b0923cade4c8ab9a476cae75c7c73f71c1d13799ac7901d0be4db5d5038895"
+    },
+    "progs/nec_rod3.mdl": {
+     "bytes": 4132,
+     "sha256": "459edf5ee6ecf0c52ec83e055a2c12ad39d3d3a42a4774c442ccc686e298da47"
+    },
+    "progs/nec_rune.mdl": {
+     "bytes": 19524,
+     "sha256": "cea5c89dd0034465a54a8434bc9367554f0244c2e38ec9220cd28a5a53a444a9"
+    },
+    "progs/necro.mdl": {
+     "bytes": 577208,
+     "sha256": "a0e43517f3cb579e38baf9ee4b5058ed59036b69599c0fe3ffeff9c00ba843f8"
+    },
+    "progs/needle.mdl": {
+     "bytes": 16688,
+     "sha256": "5f714f6b43cc28ca1de1246cc0175ea2e07040f73c9d0a623dbe4b4577559c14"
+    },
+    "progs/nehjet.mdl": {
+     "bytes": 19956,
+     "sha256": "fd0346c9c37d2ca7d3e696a9ce0694652722f63326376ad3b8189fb81a68f5c3"
+    },
+    "progs/nemesant.mdl": {
+     "bytes": 202492,
+     "sha256": "099c26752c7160144a25716e0af0f30f8ff179766db4a05371a0392166f85c42"
+    },
+    "progs/null_256.spr": {
+     "bytes": 5412,
+     "sha256": "c52813b634ef1ab641fdd4c3a9739ad758f1b5c39ba5e10acbbf034ee0ff850b"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 230152,
+     "sha256": "b7c88ae295ef8fc8d17b4fd6facedbb8e464ee665039a884af8e215a3929f24a"
+    },
+    "progs/oldone.mdl": {
+     "bytes": 560224,
+     "sha256": "5690a29cb0ae1a4889bc398676db8477275b0953e2ab7bbb75b717509d93c985"
+    },
+    "progs/pl_oum.mdl": {
+     "bytes": 331236,
+     "sha256": "6939a925af5510ecece22c3cee3de418d3ba532f4eb17409ca1453d253de328c"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 55676,
+     "sha256": "c9810eaac822215e7c84f11e55bb614121d17a79a02aa162fb430b5f37664ade"
+    },
+    "progs/plasma1.mdl": {
+     "bytes": 9120,
+     "sha256": "78a81a8eaaf95f85cd0fb7bc31dfa45c30e660fc5265168178b50776afc96563"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/playham0.mdl": {
+     "bytes": 99756,
+     "sha256": "1016d24c984994843af5d086e36e548c55590018f1f6b2d78799e25a40271ec4"
+    },
+    "progs/playsaw.mdl": {
+     "bytes": 87340,
+     "sha256": "b53cffd1807a3710f03b350370d78dfdbb2b057455fcac9f00d1b0baaabbf8c9"
+    },
+    "progs/potion.mdl": {
+     "bytes": 53272,
+     "sha256": "6ee1b1294f1ff41bdf265d06d80fa22a89ff579acb70bd2544986a0235ebd6e7"
+    },
+    "progs/potion2.mdl": {
+     "bytes": 195484,
+     "sha256": "c4f0f920521bd6e1caa6072b19d11ba57f4d493ffc2d6a395190170c9bec702a"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 47008,
+     "sha256": "e7ba606cf1cc11d9ad5baef5aef9dfa9239b7550a1c12937965a562bc815e6a0"
+    },
+    "progs/pur_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "dbc2bf835db1c1789c329504f86802990a19288f67d9560f32cfe5a8d5a62885"
+    },
+    "progs/r_bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "2d776e4acdf20cd117f3f4d6be3647fb9d0e117756069cbfc52ece716fdbb251"
+    },
+    "progs/rain.mdl": {
+     "bytes": 39276,
+     "sha256": "9a13a2ff68c8d8eb27426cee38330a6237de8ceb9ba9ecb9b71071512b190a94"
+    },
+    "progs/rain20.mdl": {
+     "bytes": 42620,
+     "sha256": "192d3d8197976f98eb053e54a00536ca9ccc8769692e9c483990b64afa4e1d8d"
+    },
+    "progs/ranger.mdl": {
+     "bytes": 232148,
+     "sha256": "21e690b07a7d3b2b0fb630480a5fd52ea23b41a8571c3618d16ea1ab7508e52f"
+    },
+    "progs/rebel.mdl": {
+     "bytes": 215292,
+     "sha256": "433596df8d06be0882f00a2c1fad0ea49a8ae42ef148d32e0ae7c06c420322aa"
+    },
+    "progs/red_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/reflect.mdl": {
+     "bytes": 10224,
+     "sha256": "3e8b08d02c11ee9e5546c96c014c8e698ca9097046ff3873012033c0bcac8df9"
+    },
+    "progs/regen.mdl": {
+     "bytes": 50808,
+     "sha256": "1c2422c4124c235e29570580b0c1bfeb55613d6c8152c78dfb6d073ea316f122"
+    },
+    "progs/regen2.mdl": {
+     "bytes": 50040,
+     "sha256": "b8da16335e855c502b7ff0c5b6875050b73c01ff0eb5b5627fc890d155cbe013"
+    },
+    "progs/rocket1.mdl": {
+     "bytes": 34260,
+     "sha256": "c9412482647d681e08f74eb0c0260ffded91dfc67378996b86b720ef3cd2fd47"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 17204,
+     "sha256": "0dab5b94c60d92d55df3e44a8d8ea2dc0f949e98897a6525ee0be3f49a019b08"
+    },
+    "progs/s_expbig.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 165212,
+     "sha256": "5b78b324e252f95ef8f4a9fd4fb19f855c40f74fd1f93aae9b84ed822e9c3585"
+    },
+    "progs/s_fancy.spr": {
+     "bytes": 432120,
+     "sha256": "2dcb35ecb5312709ae4b295ebcf209e74a34e385823f54603e6fe0eb8999556b"
+    },
+    "progs/s_kinn.spr": {
+     "bytes": 45624,
+     "sha256": "c6412ac75ec56533cbf0487223c2c8a23a3d3518b0e3f7ed8af73b81cb6ecbba"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 8016,
+     "sha256": "fa366e4076268de137e0eecd88d02e3aac99f38c48c6ad0d0a74c88c95e8d4d4"
+    },
+    "progs/s_wave.spr": {
+     "bytes": 373212,
+     "sha256": "c2a3b258b2809f22247596b6e0505829853e9a5fd60fed7c471fd663cf9e9402"
+    },
+    "progs/s_wave2.spr": {
+     "bytes": 39480,
+     "sha256": "a0fbc773e66385a8bc3c16195ce14215050cbec7caa118fecae1a0c2a2c59d50"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 333284,
+     "sha256": "90757e506c9f0e49e4e9897708df4825e1b27774ff46abd9c113738380dfde62"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shade.mdl": {
+     "bytes": 83644,
+     "sha256": "080ad2839fafadfdbbe5412ac53061a917af3158f33e16f5df4b4f3dbe422ccb"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 128012,
+     "sha256": "94aca4b876e4794684f4f2b9e66f1c34f7b3935b0d35d406311b63aba17ea3c2"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 176048,
+     "sha256": "7ea0c1007179eb7a45112aaf38d8042213e8b644e6e79b9b1a8d4402c3843b47"
+    },
+    "progs/shotty.mdl": {
+     "bytes": 16984,
+     "sha256": "42f2e1a71e00db26092b7fb9c633daff43bfebdcb46ced46526bee057464cc88"
+    },
+    "progs/shubdome.mdl": {
+     "bytes": 97512,
+     "sha256": "3b92e43bc942b2cfba8c7b4e1206ad858484564d86bd7faa069db592f98c7232"
+    },
+    "progs/shubstar.mdl": {
+     "bytes": 14760,
+     "sha256": "ee5f914d7f3f930db06b1ead8d314dec0413e5182b7de24cc808076d117f3cda"
+    },
+    "progs/skulbook.mdl": {
+     "bytes": 15572,
+     "sha256": "794768c4237a3efedf0c13026213aa417dec5be7eba7971f6e1113b5167fb904"
+    },
+    "progs/skulhead.mdl": {
+     "bytes": 50688,
+     "sha256": "d0733746c8b7cfccdb8d0f30f9454c8863a470e6d56e8359828dbb450aade77a"
+    },
+    "progs/skullwiz.mdl": {
+     "bytes": 726948,
+     "sha256": "0736c202c56cde1cfeaa10b62ca3747f85f08ae3a9cb5daa924456166664e4c4"
+    },
+    "progs/skullwz2.mdl": {
+     "bytes": 726948,
+     "sha256": "ba9f6f478a92ef3f6eec11a1d9c72e4bacf01e755e7f68dae4f6cf2856ff5504"
+    },
+    "progs/skulshot.mdl": {
+     "bytes": 63400,
+     "sha256": "73d6d8e5411b9ae3cf815c3b0cf695a5633cedd5d586565880a9146a1a5db5c2"
+    },
+    "progs/smartbal.mdl": {
+     "bytes": 27924,
+     "sha256": "288e2d54afcbdc5242ab831f3ef611710317c52432e4585a938a12df80b7a07d"
+    },
+    "progs/smoke.mdl": {
+     "bytes": 184,
+     "sha256": "2086abd9950bc643446309a80d9df86b4ebe3f2086f75e799ce943a8454c77d7"
+    },
+    "progs/smoke2.mdl": {
+     "bytes": 184,
+     "sha256": "cdae24fb7cf8efc6ec5271c297f18b04e8c69554ac4c4aedbccd7d3dd39089be"
+    },
+    "progs/soe_coin.mdl": {
+     "bytes": 26364,
+     "sha256": "5769371db409969600bd51d573162c663fb75d358c507fcff9a4aaea95fed4dc"
+    },
+    "progs/soe_gem.mdl": {
+     "bytes": 165236,
+     "sha256": "788f32633f1f3a9f6dd2e0c2dccb76871e02fc6e002db82a219f077dcc493c3f"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 409548,
+     "sha256": "8127b55dec92682e7de27ce1619b5fc8a727413b3cdf2125510138be249a1281"
+    },
+    "progs/soul.mdl": {
+     "bytes": 8436,
+     "sha256": "eb4dc0dae8aed7c92d328096fd9633566b658c9cc65777211ade1e67c6e0ff64"
+    },
+    "progs/sp_gib.mdl": {
+     "bytes": 22228,
+     "sha256": "e902ce3a5e4be26cb781d29178b6e808c480f9e898bc50ecfa78ddf12d774238"
+    },
+    "progs/sp_gib2.mdl": {
+     "bytes": 22228,
+     "sha256": "be98f64e7c2cffce98e28d99b36856762cc15caf761015067fde234390e6b302"
+    },
+    "progs/spider.mdl": {
+     "bytes": 355540,
+     "sha256": "6b32cacff38987b0b4a5efe585dce71ce64ee03e12c4bb1243b1be350f1f3b03"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "078b774958c598bdf1503934d51a1393aeb9aadebcde806db2272b04b233c6a2"
+    },
+    "progs/spikes32.mdl": {
+     "bytes": 7668,
+     "sha256": "983176e5f12571f9b38c9c5d100841e480fe8ccf143889a0e48292a5bca8bf63"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/st_baron.mdl": {
+     "bytes": 185964,
+     "sha256": "7c00af263c1349b9dda2b1a6706bcce7034e9b0793697d67a1bfa83963ba127f"
+    },
+    "progs/st_gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "813d52c557a1eb519d801652b4bd63acdc4ec18d62db53d843ca3dcaa88e87e8"
+    },
+    "progs/st_gib2.mdl": {
+     "bytes": 16228,
+     "sha256": "2d40c1eb75eeb6f5e1781ee9db7a0be10e0d07297d563f9035a8965c4c8c3d01"
+    },
+    "progs/st_gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "d44a77787c5ff633593ad9741ddfbe28809431daf3d32fbe92f8512871b9018a"
+    },
+    "progs/t_coin.mdl": {
+     "bytes": 35040,
+     "sha256": "ed7a18cfce56a630c9adaa37757e270419fca318b3fa655fea18002b089441b0"
+    },
+    "progs/t_gem.mdl": {
+     "bytes": 165364,
+     "sha256": "955761ccf88ef8f6adcd635fb70ae5d8e434b19394a15124acc4370e614f2409"
+    },
+    "progs/tar_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "1ef69998430a54ba662abb46a0ef303b3bf0066f53e84b166065e79d58a72bef"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 313448,
+     "sha256": "fc63e6f62c83975ab2756f0a844d012b887491a6c73d9350dfcb04a6e0355b3c"
+    },
+    "progs/throwax2.mdl": {
+     "bytes": 34872,
+     "sha256": "11a22371cc72adf001e21d04e1b8b65e01497f56410867aa42ea21c0ff304e48"
+    },
+    "progs/throwaxe.mdl": {
+     "bytes": 56532,
+     "sha256": "0ebedab9ab397ba15dc3f0d90df703af2984d1c070eabc08ba781c308968150e"
+    },
+    "progs/throwham.mdl": {
+     "bytes": 7072,
+     "sha256": "f161fedb096a34db55fe57e84acd2bc42295ffea688549235c762b9a70430b35"
+    },
+    "progs/tome_pow.mdl": {
+     "bytes": 2612,
+     "sha256": "40a792071152640897de449d672a693229a87a11bf5e37ab05fd1656be22b6cb"
+    },
+    "progs/tree.mdl": {
+     "bytes": 237576,
+     "sha256": "f1f85524e4018552188aa58979154ce5544381d7bfd5ae05da521e55efdc25e5"
+    },
+    "progs/tree_zer.mdl": {
+     "bytes": 145444,
+     "sha256": "e87574f4e067fe99704d235ec155118736e0e69d9554f8622a1f1ee1c4f831cf"
+    },
+    "progs/treetall.mdl": {
+     "bytes": 120532,
+     "sha256": "e74e7c38099ccc833fadf3c7b7e97f746878d07102dad8cc5926546b344cb982"
+    },
+    "progs/uberpack.mdl": {
+     "bytes": 19348,
+     "sha256": "810cd3f895ef65e11f70fe00e195026308af02248b0f1442da5e816b7d6a7d9a"
+    },
+    "progs/v_grpple.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserb.mdl": {
+     "bytes": 35492,
+     "sha256": "cd2dcfa0fc848499235735fc5c7c5efdc631a779747f71441ff05403272bd9ea"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 93080,
+     "sha256": "05655920347b597feff05a74725b20cb88693ac78fdccb3730918a01cc4e6811"
+    },
+    "progs/v_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "a2d573bdf52015bce7a571a2263a3e8d938daf0bc1b5e4589f84580cab7da2d4"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 35492,
+     "sha256": "2f5a6e74998e4783d9b3d458d167aed31f32cd49b362f01b8d9ec0e94f90de63"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/v_rocks.mdl": {
+     "bytes": 58548,
+     "sha256": "87d0958027fadf417616cc48367b19ef6f9215a0685edc239c751b59e2b6368d"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 165540,
+     "sha256": "abd6787fff37c452fa01f4bbc9eb9594311eaf4a794f161caeb5a501ab9e103f"
+    },
+    "progs/v_sword.mdl": {
+     "bytes": 94416,
+     "sha256": "74b2fd6983cfb317ce136eeef6029d0cda063efe4706abc12057ba32cb0e988a"
+    },
+    "progs/v_wand.mdl": {
+     "bytes": 27388,
+     "sha256": "b46ba82a45a24fe4833dfdfd3c9457b98096a5800d6620d6eae11895653a6698"
+    },
+    "progs/v_xbow.mdl": {
+     "bytes": 95168,
+     "sha256": "e65f7cfe84cfa7c84c34147dadcc8b5ceea9416c7e378bd2110961fd76348e70"
+    },
+    "progs/vomitus.mdl": {
+     "bytes": 79724,
+     "sha256": "03dffcc3405c63f0e0c11301a74da5403d957b66171a6f34eaf8998e4ba31550"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "7758aaf42d0d1617e4fb172ce842be4316073f63250aba46dad441327cccb2e6"
+    },
+    "progs/wanted.mdl": {
+     "bytes": 27860,
+     "sha256": "03337a468db14377fcd36842037d2a27dfb97c3d5d5f45fcfe408e79050a5839"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 67956,
+     "sha256": "39c4a5daef1cfafc1bbfff1ca8eebb5c75d27f953f31d29f249205762605a56f"
+    },
+    "progs/wings2.mdl": {
+     "bytes": 28980,
+     "sha256": "5342d6191f59e69eb830a5e833473ac253b3a7750063d5519f6d2da2b82f5573"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 109380,
+     "sha256": "d78cd5ac1d667ec808fc7664071e060cea40179a0ba094e2f4c119d5ef7a79ba"
+    },
+    "progs/wr_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "1bfb049cf920973e32d78cbf7cf8b6c0c18f8dde55006ee43798ead4b99af9a7"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 238732,
+     "sha256": "5d0f3d6b32bfec300894dbf066a15bd9e34b985919423446232ad85d2ad6d6b7"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "progs/yakman.mdl": {
+     "bytes": 736212,
+     "sha256": "91595b5866d8f85fe67f349d22fb0c4735a4255894ca7368b10bc06618b98a3c"
+    },
+    "progs/yakman2.mdl": {
+     "bytes": 265228,
+     "sha256": "caba3ad0554bc09c10855592447424ac93beff1665803b2e5c605bd36b28cbdb"
+    },
+    "progs/zerkhelm.mdl": {
+     "bytes": 47604,
+     "sha256": "07fe43e56af442776c52da95902eda56c0bb197783fc5279ca350fc0dd34c4c5"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 226776,
+     "sha256": "f4d35645fa47d159cf7dee47a1652ff239cbe7a7b3df8567b865c6d44536abf4"
+    }
+   },
    "sha256": "9a229082e446dc3991778b3364ec5aeba9b6767e5905406767f753862997295a",
    "timestamp": "2011-06-12T21:18:08.000Z"
   },
   "pak1.pak": {
    "bytes": 11698993,
+   "files": {
+    "sound/ambience/amb21.wav": {
+     "bytes": 80716,
+     "sha256": "d664ea08d9df7e7dd135eb0726c1bc142878dcc53d13564dd3dcc5562180201a"
+    },
+    "sound/ambience/amb22.wav": {
+     "bytes": 92716,
+     "sha256": "f444289984b285a1497f55e566fbbf1896a04fa38e291efaa3ec1a0720204811"
+    },
+    "sound/ambience/amb23.wav": {
+     "bytes": 40180,
+     "sha256": "e451997ac7f37d08bd8434d708f45ee2967693317684b947ce511c9df84828b3"
+    },
+    "sound/ambience/amb24.wav": {
+     "bytes": 42282,
+     "sha256": "ead78c8507a7a6a7d6c61e913a2319964f6a8f70b5f7f720c162725edd9cd5aa"
+    },
+    "sound/ambience/brik_hit.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/brikhit2.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/chant3.wav": {
+     "bytes": 116346,
+     "sha256": "5d71f12940688414ab8cabc0d88e323dc961b60aac66f17887712133f1cb8b29"
+    },
+    "sound/ambience/current1.wav": {
+     "bytes": 50906,
+     "sha256": "dabe357d48586dccb8e1ed18c49828797c9f7a8c02c7a588ddc76a62c9b1d3e4"
+    },
+    "sound/ambience/drip_amb.wav": {
+     "bytes": 105444,
+     "sha256": "b282bc6082754011ee21a82aedb490a856c0f694f57991992296554c13149b02"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/heart.wav": {
+     "bytes": 8190,
+     "sha256": "a5b42c46cca24da59c324bb28ce6887b3a2a3baafcc18b0db2b2485f1189a4e0"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 177840,
+     "sha256": "9daec0732dcc821670b8910a1371153e3829e604b6957bf95931bea416af6074"
+    },
+    "sound/ambience/mov_watr.wav": {
+     "bytes": 44432,
+     "sha256": "9d6721844fd5559ab4f53902e70ad9789a90710dde082d222bd814a36c00ab67"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/spark2.wav": {
+     "bytes": 61640,
+     "sha256": "7eb18b00cd5e7913fea7a85ec5b1db159d1d001d24d4f687bfdb5685cb163c8e"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 106286,
+     "sha256": "056f37dfd1d5f4eba1d1911245dc0930bb0c46a84d72d867a286e5a9540248a0"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 87710,
+     "sha256": "2bb46f7c8f70fd28f0ca47b294824bcca7689047291b6c5259eebe76ad6aecfa"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 140630,
+     "sha256": "5a4dccd168cbd9f759ac468d7aa879dbcdbe5637e0fd0521f641ba1d60f61817"
+    },
+    "sound/ambience/th_clap.wav": {
+     "bytes": 570992,
+     "sha256": "5b93e5d878621c2a92e66d6214b0fa8acf8ad5a35f4120f456ddf5678e941d94"
+    },
+    "sound/ambience/th_clap1.wav": {
+     "bytes": 72062,
+     "sha256": "1fc3146d501953545b2f2f261cd2fc398959a79c753a291702609b4cdd2e8682"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/wall01.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 28798,
+     "sha256": "f66c76f07eef275e904fcc76d7ca9fc2011f3de8c61ce0b3ad035464beb7a86c"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 110578,
+     "sha256": "c3e1ccb091b9d8a06b83530b5e29b9f26f5ad8b9dcd082f3da976c3d44944b87"
+    },
+    "sound/ambience/wingend.wav": {
+     "bytes": 90874,
+     "sha256": "63e435d896b097d4dc413fb1afccc2078f1d101a4f7bfc18c4e593ca9e8b344f"
+    },
+    "sound/ambience/wingget.wav": {
+     "bytes": 65148,
+     "sha256": "533bdbd7beffa4c71c66239e3ac417f2177b20a60ed39c379c59a10b2222b367"
+    },
+    "sound/ambience/wings1.wav": {
+     "bytes": 6028,
+     "sha256": "c9e05f66a1d728a88289bc213c9f3551f1e54a4f3e8ef23ab03f8d5019e7b2c5"
+    },
+    "sound/ambience/z1m2mus.wav": {
+     "bytes": 103768,
+     "sha256": "d54261d4c9a4a8a9fe0c51eeae343c6a5b381727af88d0bae6f9b40605b8e5d3"
+    },
+    "sound/ambience/zend1.wav": {
+     "bytes": 123618,
+     "sha256": "2df6c267197b2e82241e47ce4985b04d14e1ce3cff46cebf3177369057302bb6"
+    },
+    "sound/ambience/zend2.wav": {
+     "bytes": 73742,
+     "sha256": "0ea00395004f11d41ab60352517bf5ff5c88a73b8ff2ddb3f32b5085967e3003"
+    },
+    "sound/ambience/zend6.wav": {
+     "bytes": 252626,
+     "sha256": "3f3c412e55bc7534c423c0d1bec2d817e3aea06338b4d6c3f78c4b80e55d509f"
+    },
+    "sound/ambience/zend8.wav": {
+     "bytes": 112122,
+     "sha256": "27cef28aa3d6c3ea86f0c54168db07055abfc7af284bc5a35bf53a0e53f8d677"
+    },
+    "sound/ambient/amb2.wav": {
+     "bytes": 38416,
+     "sha256": "21a4f41fb5efb52587e60395f23824ef330674a8d9499fe2cda1c91603093bfc"
+    },
+    "sound/ambient/amb7.wav": {
+     "bytes": 43020,
+     "sha256": "de7f4a0d15c711c9ca63f74ee38acf78e4ce41800900e0193a43c3e55e4efde6"
+    },
+    "sound/ambient/comphum1.wav": {
+     "bytes": 20456,
+     "sha256": "af10cad0f193d07be9c98f0dd889840fad0f54f40a61d12a1325b78033a68c8e"
+    },
+    "sound/ambient/comphum2.wav": {
+     "bytes": 72367,
+     "sha256": "fbf1ff8677cf36d78e381437f3b8e758a589a108a50c92f24c514eda06ede3f2"
+    },
+    "sound/ambient/comphum3.wav": {
+     "bytes": 116441,
+     "sha256": "62d9624940b93bcd1897abb809cb9d6f2cb3872cfd6af9a792260fb17f800150"
+    },
+    "sound/ambient/fan.wav": {
+     "bytes": 54275,
+     "sha256": "6cdc6a19b0c740d5607fa9076f749dc485483362445630877c6b59ec67085a2d"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/l_hum1.wav": {
+     "bytes": 20790,
+     "sha256": "f1b8bb19b32258ca1b126d52eb98b17c2753a255eba60864f8ad325f564681c7"
+    },
+    "sound/ambient/music1.wav": {
+     "bytes": 213944,
+     "sha256": "bf498e0cf6541b3559abd978ac420c5cb19d6542d89f19f59bdba8019dc46688"
+    },
+    "sound/ambient/pump3.wav": {
+     "bytes": 40435,
+     "sha256": "ae8ca71a1ce41bb3fa02d993930b4f100db3827ef5768326a91e61f7857370bf"
+    },
+    "sound/archer/arr2flsh.wav": {
+     "bytes": 5464,
+     "sha256": "e9a0c059430744c6546a6be4be3a1e4ac775ea6c5e6440d14611ecd8c8447d19"
+    },
+    "sound/archer/arr2wood.wav": {
+     "bytes": 5458,
+     "sha256": "97c5106007e703618291242bf1c6db9853a9d625189fc26ec9c4864436b560e3"
+    },
+    "sound/archer/arrow1.wav": {
+     "bytes": 2296,
+     "sha256": "4aeac8630ff6036f095a251a018eea5baad7a59bd7e46f624dbfec793e44d7b4"
+    },
+    "sound/archer/arrow2.wav": {
+     "bytes": 3196,
+     "sha256": "0a2734df5a69f6407ffc34ab05d8655da5d7dc0e487627932390fa6cec022083"
+    },
+    "sound/archer/arrow3.wav": {
+     "bytes": 2156,
+     "sha256": "1b866280829cb7ac051f90609baa8db285f3bfa3a27b5814e72b021b7cc05785"
+    },
+    "sound/archer/arrowbrk.wav": {
+     "bytes": 5002,
+     "sha256": "f72e35d5232f40e503192ff0ee26fe152eb42e5ee7141b2bea33a9f12f38aa2b"
+    },
+    "sound/archer/arrowg.wav": {
+     "bytes": 15132,
+     "sha256": "8ec5ee520f81c69ba367ae549a06d5ea1643b43f81dea7d8345561c94c8412ed"
+    },
+    "sound/archer/arrowmet1.wav": {
+     "bytes": 2638,
+     "sha256": "87e6ef50bfe4dabf48a1fba18ad0138bbd298965f1a9d06e2b059019e6f74b60"
+    },
+    "sound/archer/arrowmet2.wav": {
+     "bytes": 3118,
+     "sha256": "2797466dafd51473b8b6b5fd3d02a5baa4fe92a1bf9342fb038a299230037138"
+    },
+    "sound/archer/arrowmet3.wav": {
+     "bytes": 2804,
+     "sha256": "1e77951ec2218add2a8bc1633a925e4a96d2ca247d7b5dfaaaefd7a9a4f2363f"
+    },
+    "sound/archer/arrowr.wav": {
+     "bytes": 9458,
+     "sha256": "10e4bef745e55fddd004ea78d24edb9d3d9edc1ce3053c377be07be27a4da144"
+    },
+    "sound/archer/crash.wav": {
+     "bytes": 11069,
+     "sha256": "60e704bdfdb0a97863b00f3514130a172b95a86bebbf89642b65a6e757a74259"
+    },
+    "sound/archer/death.wav": {
+     "bytes": 9526,
+     "sha256": "e824b3d7d66e8bfc3ce30cc3116eab1b2d2dbc09c6311f91ff25d3e7eaef19f5"
+    },
+    "sound/archer/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/archer/draw.wav": {
+     "bytes": 6874,
+     "sha256": "c94e5cec38dc40102beebd067554c91e63b86e5c1ef11dc17976733bd9f08ce3"
+    },
+    "sound/archer/explode.wav": {
+     "bytes": 17788,
+     "sha256": "1f7d6debef492f0861ee24049ad637a11b85d595cdf3f6d6aac422b7a0376d14"
+    },
+    "sound/archer/growl.wav": {
+     "bytes": 9240,
+     "sha256": "7bdbbd23b3fe056cd1d904124824aa0044acf3aa19ec88f65e092fd13e4b9437"
+    },
+    "sound/archer/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/archer/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/archer/pain.wav": {
+     "bytes": 5082,
+     "sha256": "5347daf1a9263320f25b2a191895fbf6c85278f1fde6ca5962c09ed38e0b37b0"
+    },
+    "sound/archer/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/archer/sight.wav": {
+     "bytes": 16866,
+     "sha256": "bcd12d078e7bc34f0bdea7ae9a34ccd2c9bacb049617329b44f8301c34fffeb0"
+    },
+    "sound/archer/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/bane/death.wav": {
+     "bytes": 10935,
+     "sha256": "7e4775bc543acfb421a446a00efff6d9d5669fafb2387464cb1e1ae3db91efe8"
+    },
+    "sound/bane/growl.wav": {
+     "bytes": 9045,
+     "sha256": "86e7b3d2e685d7c20e503bdffe676727426b606ef069f4b70f182601e910ec4e"
+    },
+    "sound/bane/hit.wav": {
+     "bytes": 3884,
+     "sha256": "228faf88857d697f4d5fb9b9c03f000af4dbc8b254791e18e973fd48cc96db9b"
+    },
+    "sound/bane/laugh.wav": {
+     "bytes": 22108,
+     "sha256": "ae8e8d13e00f41bce729977f09a92806c8451ebe5cb4e8618a6b79df4d70296c"
+    },
+    "sound/bane/laugh2.wav": {
+     "bytes": 31560,
+     "sha256": "5cc5ff4c3be35eec90eaaa6579a55fa843843ad658e2e4bbb258a77f6e410020"
+    },
+    "sound/bane/pain.wav": {
+     "bytes": 9325,
+     "sha256": "1d4cfac1f9dfa1ec6958b18014ec7be18dc2615e64888d3c584d50bb48e51013"
+    },
+    "sound/bane/sight.wav": {
+     "bytes": 22962,
+     "sha256": "fbaabe115d9ca4b985c4481ccc71e6b6f55931394a29a6c51ec97e752ed3d5be"
+    },
+    "sound/bane/thunder.wav": {
+     "bytes": 43130,
+     "sha256": "cb355478e38df678e859557a0f983120a4d4275272d8ebedcae7c9cccf659bc4"
+    },
+    "sound/baron/bpain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/death.wav": {
+     "bytes": 8576,
+     "sha256": "3dd3a23d5a913548d0d0aa6ee1b455017648fcd4830f204539a1626c2ec8e1c9"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/fireball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/icefire.wav": {
+     "bytes": 8858,
+     "sha256": "b529a958de192b59438989c6b98eb50f858273febab53a238b651c70a3c92098"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/shard.wav": {
+     "bytes": 14324,
+     "sha256": "313428dd2cb681a38ad89983ab39b18979f64b3e398104b1ad80f3dc9726616c"
+    },
+    "sound/baron/sight.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/tornado.wav": {
+     "bytes": 11469,
+     "sha256": "9ede270665956ce33daf9d3b49447c09e198275f640ccaf77af4f44273bd3f64"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/bishop/conjure.wav": {
+     "bytes": 54627,
+     "sha256": "532d4b7d5db6a654aa73dfe18fa0f6a71623acfd804a848f106b0af699022bc4"
+    },
+    "sound/bishop/journey.wav": {
+     "bytes": 42051,
+     "sha256": "0995e55661447c53c3a36ae4552ea2e0bb7ec8b178bf52cdabe9d28b4deaa50c"
+    },
+    "sound/bishop/rip.wav": {
+     "bytes": 31906,
+     "sha256": "7070871da7ec08da6260a65f1a98ed1bf9682b1c95c51cea262a4b88a63fb6ca"
+    },
+    "sound/bishop/rot.wav": {
+     "bytes": 22463,
+     "sha256": "866b836874ba611d70675e5e3b83eac059c927bef0e0d1396f2183ea01bcc203"
+    },
+    "sound/bishop/skull.wav": {
+     "bytes": 34293,
+     "sha256": "48836a4d60ed8962ed0f11bffdcca95a200645e3b2cfa49a598d6392e10dc153"
+    },
+    "sound/boss1/explode.wav": {
+     "bytes": 27690,
+     "sha256": "b7eebbb64696612ee18d8d1e25b9c5cc334a4562cb99758a446a22490215f349"
+    },
+    "sound/boss1/explode2.wav": {
+     "bytes": 14798,
+     "sha256": "4c6b14b163905823f629644fbec088f37f712cf7f76e10e2f91ef23f2b573ae6"
+    },
+    "sound/boss1/explode3.wav": {
+     "bytes": 19028,
+     "sha256": "69ef0c65811704d8996b726d6e2cbcf70528d3ca7b2f28ec8814c20e7ab76ad7"
+    },
+    "sound/boss2/pain.wav": {
+     "bytes": 84796,
+     "sha256": "b9c255890f61771966327ad49994306a1e3de4b702163a079b5a733b4016810a"
+    },
+    "sound/cube/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/cube/bc_attck.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/cube/bc_gulp.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/cube/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/curse/x_armor.wav": {
+     "bytes": 17988,
+     "sha256": "61b518c8ad8410a17eaca28ee190d96a0c3d1dc755593872d7ec5429c8c19157"
+    },
+    "sound/curse/x_damage.wav": {
+     "bytes": 14772,
+     "sha256": "f74f64e3f47cee7c9b424b94a426f93c133d8acc1e6cb15551a72ab361fe95c4"
+    },
+    "sound/curse/x_leech.wav": {
+     "bytes": 16692,
+     "sha256": "78aacf297df09e21645c2e04ccf181266c35c8e52303ecb498c90db33e8c7b27"
+    },
+    "sound/curse/x_muddle.wav": {
+     "bytes": 18932,
+     "sha256": "b85810135fb3eca3f141047a08cd42a0e527d6da6e9fcfca3887a15f89edad6b"
+    },
+    "sound/curse/x_slow.wav": {
+     "bytes": 16728,
+     "sha256": "0477b046f163d36e9e41c8686ca7538659d0327668d938c0b2405f3a1e6dab3c"
+    },
+    "sound/curse/x_weaken.wav": {
+     "bytes": 15946,
+     "sha256": "f98441764b5f258ee875090c73e5841f4c8f97decbfbd8d9da836a7aac30f430"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15692,
+     "sha256": "72e737f04f1d34044dfd812c6b0e233cd38a91e6b089633e312678756952de87"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16625,
+     "sha256": "bd4cd7902712282ef8f2f749e6fcf805c2ac5212994fbb1c22fc0fe0ea5d08e2"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15527,
+     "sha256": "0b472a984137667f4788336a4f7c60e07a8893f47317b2a158aeea39920d729f"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4107,
+     "sha256": "8fe56b192838dafdf7ff4737cf1e5555d3295cbca49c1ab83568281ee188153c"
+    },
+    "sound/cyber/cybidle.wav": {
+     "bytes": 11894,
+     "sha256": "af7b96ed2eb5bc55900957b3e4136bd5dd93a72dcebca3bc2eb67cdc5186d32c"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8122,
+     "sha256": "3ea23b8d7a68e754211a10a5338b0c8d65df6e2138d4cfe06cc053b9a0f601ae"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13081,
+     "sha256": "a5ec6d4eaa707ad0246b7a7e7737b1007043ea5e5634f6f63661ecc20c27c459"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48508,
+     "sha256": "b7aac875623f8dca7597eff3dcab5910453d043fd1f9df20da89232ce8bf9306"
+    },
+    "sound/darklord/death.wav": {
+     "bytes": 10761,
+     "sha256": "7f32e12c649aa4fc4c2edb773c45b6b4258d048176d95e060390834ee7b52493"
+    },
+    "sound/darklord/idle1.wav": {
+     "bytes": 5632,
+     "sha256": "c151a3cf537f5c3668fc116e6ef5c70c9286e8a12097f376ecdf8a04774926a1"
+    },
+    "sound/darklord/pain.wav": {
+     "bytes": 12684,
+     "sha256": "f332a8cdf67fe414966f59d46714154c94de7ebcca3880a47ef5bbdad2c03ef0"
+    },
+    "sound/darklord/sight.wav": {
+     "bytes": 16832,
+     "sha256": "9710267844facf1c627ea0a8f0df458d847eb899dccd9c570e9d967acc64fa07"
+    },
+    "sound/darklord/sword1.wav": {
+     "bytes": 15982,
+     "sha256": "d36670980603c18a67d500707de9db5a8d54128601d6a6c67f7f29677244aebc"
+    },
+    "sound/darklord/sword2.wav": {
+     "bytes": 12434,
+     "sha256": "f7730881c690e0ee6a440756f74630a21241239fd1fd3bbdfd88000c7e57d1cc"
+    },
+    "sound/doomcube/dsbospit.wav": {
+     "bytes": 43719,
+     "sha256": "97f61cb588bb405cd235e242bfca6fe1108171625a7aa4f2573d63682ac42e32"
+    },
+    "sound/doomcube/dsbossit.wav": {
+     "bytes": 57109,
+     "sha256": "5843548ad38c8eea72548481b5833590fbb7fb990daebd0ede4aaac93475f461"
+    },
+    "sound/dragon/acid.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/active.wav": {
+     "bytes": 16118,
+     "sha256": "5c8762ad62bcb65e1a6fa3362393141a8564fca3ad28ea896a18545c5ebfe6ad"
+    },
+    "sound/dragon/attack1.wav": {
+     "bytes": 25054,
+     "sha256": "c96520801f27bc933928d7f793c2c28ff2dc7b36a86450f6372a9c8a668b4f58"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 63766,
+     "sha256": "55eb476a990e479c06b4c9a12b71c595d8ada35e813e512986709650ef0e54d1"
+    },
+    "sound/dragon/death1.wav": {
+     "bytes": 18358,
+     "sha256": "645baa1cccaf1dfbcd628d17fd8ea290f42f1bc40903e26c79a536a6d1528a2a"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/fly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/fly1.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/dragon/flywater.wav": {
+     "bytes": 11034,
+     "sha256": "68cac399467a55df3c80331696869309eea2339467df0ba94408be4fa2afeb3e"
+    },
+    "sound/dragon/ice.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/icehit.wav": {
+     "bytes": 9370,
+     "sha256": "089c07d0352678106aaa1c47f015792393d5aa01b4bd64fa35e798c4ee09108b"
+    },
+    "sound/dragon/idle1.wav": {
+     "bytes": 34068,
+     "sha256": "3a125f0bcf2908e4ba3af298b117f71c0efa43be4077e53c791b2805cce6a038"
+    },
+    "sound/dragon/idle2.wav": {
+     "bytes": 21474,
+     "sha256": "e1101ff0121687511a9c978d0a30a945421d0a2a30b7d139e4427d41dcc17628"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 28302,
+     "sha256": "60a99d79b6922a14e27ed63313e82ff17b127bda008bd614d8e9ed86f0f2cc3a"
+    },
+    "sound/dragon/pain1.wav": {
+     "bytes": 6524,
+     "sha256": "6cdce2fde3a1eb328007e0667c5dfe705e87bcd526e416ac948fa11a36448ac0"
+    },
+    "sound/dragon/pain2.wav": {
+     "bytes": 6875,
+     "sha256": "3238b77aafcc60c634cbdbd47ae1eec99bb969e2161b72ce5623398e6a451d2a"
+    },
+    "sound/dragon/see.wav": {
+     "bytes": 39640,
+     "sha256": "e8202c360287700da28f96d6a14fef6bdea04374ea911f2b3e41183cd8a136ba"
+    },
+    "sound/dragon/sight1.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/sight2.wav": {
+     "bytes": 15205,
+     "sha256": "197238a35261e6792c40a4da38ba7b3827116ac1af5f143e092768346605b470"
+    },
+    "sound/drone/drnblip.wav": {
+     "bytes": 2106,
+     "sha256": "b372ece13de5edfb22d88ff147a9eccfddfe446c9403607d89daae09fc7c8b68"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/force/force1.wav": {
+     "bytes": 30022,
+     "sha256": "b609981695694648cab0f2ed521dbf3d6f31b6c2e8c3e8502ab4740c7a105557"
+    },
+    "sound/force/force2.wav": {
+     "bytes": 10252,
+     "sha256": "32c0342dbc9e63220db18fa706ac0fc1afe9a86f4d488e509e1f52bee955e3cd"
+    },
+    "sound/force/force3.wav": {
+     "bytes": 10252,
+     "sha256": "0317e18dab002184b5ce11a2b86f3263d2606c40f2dc435c824bbd075c1b621b"
+    },
+    "sound/force/fusein.wav": {
+     "bytes": 13669,
+     "sha256": "53192c25adab70ebcf471204aa194ef9d34c4161138c728d95f84cf08310a879"
+    },
+    "sound/force/fuseout.wav": {
+     "bytes": 15379,
+     "sha256": "f515c6b48204f2ba158e99c10a9da60cc45756ea5dca716e256ffbe54a017512"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/goblin/death1.wav": {
+     "bytes": 13890,
+     "sha256": "bed0d074d9aeee8f046ec7b3a9d33e02d157374ddf6af1296bd1ca7bebf30f10"
+    },
+    "sound/goblin/death2.wav": {
+     "bytes": 10280,
+     "sha256": "9cc07020579d50185ea401835e41edbd1c8f007065e39a6306c7aab4f32e7781"
+    },
+    "sound/goblin/idle1.wav": {
+     "bytes": 9802,
+     "sha256": "6c5a8c36eedb0ac5bddacfdf68250c36fe472f9d87e8969b4f95a863a99b77ce"
+    },
+    "sound/goblin/idle2.wav": {
+     "bytes": 9242,
+     "sha256": "5850c885e59ef04ae90be0579dd6f6b7cc26c282045ccb163dab2c9e19fea704"
+    },
+    "sound/goblin/pain1.wav": {
+     "bytes": 5118,
+     "sha256": "8afd94fcaa2d20e7c6626eda0c6cd5463670a1dbed0eeea36da588b28196c8a2"
+    },
+    "sound/goblin/pain2.wav": {
+     "bytes": 7898,
+     "sha256": "ad1f3b63b4ae35e4bfe010447bbd18bb85cd2bbf966ea7e1370afb0e924e699c"
+    },
+    "sound/goblin/sight1.wav": {
+     "bytes": 12716,
+     "sha256": "1c20028239d217f31af57649da5d1a6def576569ef5fc7e7033c2acbef7f9345"
+    },
+    "sound/goblin/sight2.wav": {
+     "bytes": 19356,
+     "sha256": "c9182325cacd9734bfedd48cb5d8076d5823b7a94baa40d32b02de9504474b48"
+    },
+    "sound/goblin/sight3.wav": {
+     "bytes": 8526,
+     "sha256": "796b2f9f0a1c20d672382c6681e9a6ea200fee2cfcacb5b3d3faa72c8e2537d4"
+    },
+    "sound/goblin/sight4.wav": {
+     "bytes": 8668,
+     "sha256": "c0a60baf2b9918a6df5fc32cd8b58c9fa7cfed923a4cb21c841f04f7a544782e"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 27521,
+     "sha256": "424ceef852229e94dbbbc879f1546a8dfda90db93c6263700cf4973805e4bea7"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 16192,
+     "sha256": "98d55bc63eff48521faeed1046064569e932986e734168ba0973c184aa2f5d12"
+    },
+    "sound/golem/step.wav": {
+     "bytes": 11226,
+     "sha256": "851e243a2e6ecf4cb637f8c4368b0f25443d4f9d104733eecfa886c40ee92bcc"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 47176,
+     "sha256": "87f013eb50cb30a967a183f0cfa41b4848f9269afd13dbe1ab5053458bfc5f0e"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 10768,
+     "sha256": "c48f2415db3a5067dfbd99ad580e3f4809532743d653eafe2fdb924fb0bb832e"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 47502,
+     "sha256": "a0c0bd639af614c7714388009c9388f6db9a694e7ecd8fac38653609d6958f61"
+    },
+    "sound/gunner/death1.wav": {
+     "bytes": 67190,
+     "sha256": "14f89744b8f7225e0eefd9e291aee533fd9f759b6351b57d357d9597dba90956"
+    },
+    "sound/gunner/death2.wav": {
+     "bytes": 48066,
+     "sha256": "693d0d1142dfa12ce2dd1d7b959094c201f3bf783114064c29a572dffe2fcfe0"
+    },
+    "sound/gunner/idle.wav": {
+     "bytes": 18376,
+     "sha256": "6c5b1f1d39f1cc78e87cdbf584b8a508fadc99fc2b8b85d21d0e088d134a8b2b"
+    },
+    "sound/gunner/pain1.wav": {
+     "bytes": 17292,
+     "sha256": "afee7d4ac4f872716fe3deb5adced9a99bd3744784329bd12608d051b81ebfc7"
+    },
+    "sound/gunner/pain2.wav": {
+     "bytes": 20282,
+     "sha256": "38d472d2eaaa7638f7980a06a36043353e86d99aa7e86e0132c52639738c87b2"
+    },
+    "sound/gunner/sight.wav": {
+     "bytes": 22572,
+     "sha256": "395e28b6a4684ce2fa10f085f67d58d025421c594e65a0c2a1b67aeab2ee2569"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hkboss/iceball.wav": {
+     "bytes": 14990,
+     "sha256": "6aec96fda55dfb0120f106064cd324ea6e059bab3fdbb2d81cda297f9a82e02b"
+    },
+    "sound/imp/die.wav": {
+     "bytes": 8448,
+     "sha256": "a8b0e037b88829b978d3dbd3d5e657c7f775c73662d554f6247a387ba333d4bb"
+    },
+    "sound/imp/diebig.wav": {
+     "bytes": 14956,
+     "sha256": "d44d390ba11f8850105fd9601f026cb66525a415de7fc363d3574c86b72d22c4"
+    },
+    "sound/imp/fireball.wav": {
+     "bytes": 5492,
+     "sha256": "6362b59ded89655fa8b8877ed2639eca1a7aae1847306bbc3843fa98bedcbdaf"
+    },
+    "sound/imp/fly.wav": {
+     "bytes": 9204,
+     "sha256": "8036ccb256978c17234aa171267fb0332f1911b5f0dad7b9f74bba9378c39a37"
+    },
+    "sound/imp/flybig.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/imp/flywater.wav": {
+     "bytes": 9800,
+     "sha256": "c80045609b62ceb61bd8fb1a18a53c0f2fd5443502a802b0d6d3c61e9a1db4c0"
+    },
+    "sound/imp/shard.wav": {
+     "bytes": 10678,
+     "sha256": "f806167fe23f37826964c0cc345c438ff0e79c3ffb1fed2c85451c675448cae4"
+    },
+    "sound/imp/swoop.wav": {
+     "bytes": 10842,
+     "sha256": "100eacded51635de912cee171f093e869d24589c44f68887497fe751cf9b1e4d"
+    },
+    "sound/imp/swoopbig.wav": {
+     "bytes": 14012,
+     "sha256": "65d4de49684f2f9e2655abf8e4bf042a08bd706ec4971e6397f264f7274e2b63"
+    },
+    "sound/imp/swoophit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/imp/up.wav": {
+     "bytes": 12500,
+     "sha256": "874b533da43f713a1be27fbccadda8b6392fa8e689c8c4d17dac4b0d380f5822"
+    },
+    "sound/imp/upbig.wav": {
+     "bytes": 21472,
+     "sha256": "36c7bc087935cf7cd33482a50a75df75fc2bfbe53ca0ebcd9797a8bdbde73652"
+    },
+    "sound/items/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items/equalize.wav": {
+     "bytes": 13008,
+     "sha256": "933046049bae4d866250ad9a6e0a4b2a9385caffb4156daaca39ff7110a71126"
+    },
+    "sound/items/levitate.wav": {
+     "bytes": 44236,
+     "sha256": "8a04ce4a97dc22d095bc52d08111bcaaf5f57482f580ccbe0c61bdf8fd18913f"
+    },
+    "sound/items/life_up.wav": {
+     "bytes": 8660,
+     "sha256": "2712bd978343d4170bc1757706597d4de3940a07b6847977cbf117fa92f14c31"
+    },
+    "sound/items/money.wav": {
+     "bytes": 5100,
+     "sha256": "e4ac299499340c1be250f5d5e0824440d9e539de8a1d5b01e303056719cf822f"
+    },
+    "sound/items/optimize.wav": {
+     "bytes": 14854,
+     "sha256": "508d89890db17f828cde9511ebd97241ecfe07bbb6e5cba8c7538ab02e31b19f"
+    },
+    "sound/items/quaff.wav": {
+     "bytes": 3748,
+     "sha256": "ebaa4ecc17dc67d3fbc5fe1a7541e4e19769ce941d043922f8572cb2da8d3cdd"
+    },
+    "sound/items/reflect.wav": {
+     "bytes": 14936,
+     "sha256": "90dd50b25175c8d514a52165429e9ca6b90c45dddbb0f301e5873146b4a4a06c"
+    },
+    "sound/items/reflect2.wav": {
+     "bytes": 33119,
+     "sha256": "5fb5afe50e0f5fa24f1c4481b3060ae222f40138ca81052cea047a57aa6b03e8"
+    },
+    "sound/items/reflect3.wav": {
+     "bytes": 7804,
+     "sha256": "a079e5aef6ed9fb7d5c992b0ef8e11932a9efa192eedac2bc530098e0550984a"
+    },
+    "sound/items/regen.wav": {
+     "bytes": 7984,
+     "sha256": "1e125e8e7c19f29eaf09b7ad301fdfe5126d922dfa84ba2af267cdf3351b6498"
+    },
+    "sound/items/shambler.wav": {
+     "bytes": 20182,
+     "sha256": "f0cdf78367b770c97b3b89abedb7c4fb0a9ee10d742acc8c98b3daba46cfc215"
+    },
+    "sound/items/tomepow.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/items/tomepow2.wav": {
+     "bytes": 33119,
+     "sha256": "1e2e62a6f251722741b7f0adeb38c59a1d05917d0f84c8f48922efece97f02e2"
+    },
+    "sound/items/treasure.wav": {
+     "bytes": 5554,
+     "sha256": "c86f66148e8dc99af2c8e877d64d06dc1c35d0caa9c6dc5c8092b268960b8edd"
+    },
+    "sound/items/zerkhelm.wav": {
+     "bytes": 8298,
+     "sha256": "ef7b98bd965660df91ee34920806b48428a8b5c17c0ec4fdecb48d7fe28e3ba2"
+    },
+    "sound/laugh.wav": {
+     "bytes": 71573,
+     "sha256": "cb8e1381c70240a93233b8571d792e21950d00b1285f867cbc0ed1237dac1df7"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/b_rot2.wav": {
+     "bytes": 15436,
+     "sha256": "62c86077b7a29f48f5c872c68d262c03b73b57f876b718a05f2fc6b24b9a9ef4"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/bellring.wav": {
+     "bytes": 27600,
+     "sha256": "fe3b2972c722171144eaba160757803292a42342e737d6acdbd0b14802e686f2"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/dsslop.wav": {
+     "bytes": 11163,
+     "sha256": "b6a9f6e74b222169c87e6c56b47d2e7995b23b8b045f16be968f43290f22cf9d"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/met2wd.wav": {
+     "bytes": 3968,
+     "sha256": "a3ce3e10b609f7ae28fc6f39f1f5d55a7c99a41143fb161de7e4e47b7f40f100"
+    },
+    "sound/misc/metalbrk.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/mgboat.wav": {
+     "bytes": 26866,
+     "sha256": "666016e2aa958ea621ba03bee4339518f2ccc72aa3ee2d0838ef9032e8ffc981"
+    },
+    "sound/misc/pushmetl.wav": {
+     "bytes": 14042,
+     "sha256": "2657b0006f51ecb7077b5861b1b282e0bb8bef3bdd5ccb68b3bdd6794361099e"
+    },
+    "sound/misc/pushston.wav": {
+     "bytes": 11490,
+     "sha256": "f457b95dad6131472475ab22d9c260adf5d389e74629cd8ea36ca05ad7d4e749"
+    },
+    "sound/misc/pushwood.wav": {
+     "bytes": 13602,
+     "sha256": "7c3fa06978f8c7b632d12bbf1031a5ac316b44fdc5efd93338ab0a0a162bdf3a"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/rublexp.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/secret2.wav": {
+     "bytes": 87440,
+     "sha256": "36e9d9617a14daefd510e72308b9e85718a473e2b25a06b66026d463d6bbb519"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/misc/woodbrk.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/music/pkdream.wav": {
+     "bytes": 154898,
+     "sha256": "df8857901002ce9dde3c558743c94967db11cae4af3d9a0cdc00c8cc09e6a910"
+    },
+    "sound/necro/att_a.wav": {
+     "bytes": 8522,
+     "sha256": "a946c060cab5ee1bfff2d1af87cd71c9ccf63840a2751fd46fd32f387bee2c35"
+    },
+    "sound/necro/att_a2.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/necro/att_w.wav": {
+     "bytes": 26298,
+     "sha256": "9ae481ad41d16610b597989e82a8bbf9c35a74fe03a8e27900d72ff8b52e3c94"
+    },
+    "sound/necro/curse.wav": {
+     "bytes": 16852,
+     "sha256": "d3729c83c468d9320cf1f8914c8b52d446e818852c955d8d86a093c35c196b58"
+    },
+    "sound/necro/death1.wav": {
+     "bytes": 24010,
+     "sha256": "302e58b0f701ad07ade4a46d5cd3bd9c2186b2df3eb39e36c361918a72ccd24d"
+    },
+    "sound/necro/death2.wav": {
+     "bytes": 23594,
+     "sha256": "05f15a8430885b6688587eba5e249107c3e6df36d7937a3ddd2411d275e8842b"
+    },
+    "sound/necro/idle1.wav": {
+     "bytes": 49212,
+     "sha256": "737f382e89a40fc098214b77e9165e16f2a06323c07e910f336f2616b6ca87b4"
+    },
+    "sound/necro/idle2.wav": {
+     "bytes": 47120,
+     "sha256": "18893e7b31ff448831a7b7a5aa9a5d31b2dcd6e49ae8b58d5eea8b44683415dc"
+    },
+    "sound/necro/pain1.wav": {
+     "bytes": 19412,
+     "sha256": "f37e247a9e1436e4a86b78fe71e1ea6da43323e60943e86784ac87fc4393333b"
+    },
+    "sound/necro/pop.wav": {
+     "bytes": 18996,
+     "sha256": "22aff5a83ec82e759004d82308b2e210f824ac59bd3180d6b688c9d0134ca18e"
+    },
+    "sound/necro/pop1.wav": {
+     "bytes": 10836,
+     "sha256": "d5e9b7ce5a638a419eef07bba492ce75fb3d8002bd66b40d36b4dd89ad859e1c"
+    },
+    "sound/necro/pop2.wav": {
+     "bytes": 11228,
+     "sha256": "10947cad6cd5bcc0e0bc00fdbeccccd53b70bff1fda1a220c72ddc7e2b152b08"
+    },
+    "sound/necro/pop3.wav": {
+     "bytes": 11228,
+     "sha256": "56c4219dc0ecfb7ee8ff6d31fdf6c8c53c2b6990ce1b94ed956caee3c7cf83db"
+    },
+    "sound/necro/pop4.wav": {
+     "bytes": 10836,
+     "sha256": "451b660c65ebd2c7c89134896ed882d738c685f787810e1245587c0c28c38141"
+    },
+    "sound/necro/raise.wav": {
+     "bytes": 9688,
+     "sha256": "1c841e33f22cdcd5276bba9018aec5dae8c0f842da07eb261f48f1a6cc4c8314"
+    },
+    "sound/necro/sight1.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/necro/summon.wav": {
+     "bytes": 16308,
+     "sha256": "b7fc855d38431ac04e09389d7caf04bf0032d2b4edf86ebd795f1ab38d9feaf5"
+    },
+    "sound/nemesant/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/nemesant/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/nemesant/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/nemesant/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/nemesant/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/nemesant/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/nemesant/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/nemesant/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/nemesant/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/nemesant/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/nemesant/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    },
+    "sound/pendulum/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/plasma/explode.wav": {
+     "bytes": 29598,
+     "sha256": "7a95a8337c7ad87faccc1cae98ad7840352b08608fba08aff87a1b33610f9190"
+    },
+    "sound/plasma/fire.wav": {
+     "bytes": 22422,
+     "sha256": "7350d1e99f93a79bee84e94561e080dcb8448a3549a42742633cf604377a5097"
+    },
+    "sound/plasma/flight.wav": {
+     "bytes": 17494,
+     "sha256": "a03b46f31df3495a1b7a2b2f1a09f3e5223d4c0ab65aa0ed936e1445e893adeb"
+    },
+    "sound/player/boot1.wav": {
+     "bytes": 25624,
+     "sha256": "9b730ff4f811472514297921c78ea3080424c57b57ce7fa30c6c10f94bd8ccc3"
+    },
+    "sound/player/boot2.wav": {
+     "bytes": 25640,
+     "sha256": "23a3cd545ffa3c5c1e4a4c9549aff81dadd2f1ab451e397d5292c97024fc5026"
+    },
+    "sound/player/boot3.wav": {
+     "bytes": 25652,
+     "sha256": "004d267ae3fcce21aa66e566efa34e39e85915f202e3b55922b314cfd6efa2d7"
+    },
+    "sound/player/boot4.wav": {
+     "bytes": 25628,
+     "sha256": "9beb96d9a183cd6a13693961a216b4402350fc076c7a1ff98854d28c30a9f8be"
+    },
+    "sound/power1.wav": {
+     "bytes": 44370,
+     "sha256": "68f9d490b390a2510ff660917ac02fa1620893770a68a1188e06f94c57922523"
+    },
+    "sound/power2.wav": {
+     "bytes": 44370,
+     "sha256": "773aca5e1e60540b2abdc4b9b29c4281a04f6fad3bfc6bea1c029b42a7f0fe9e"
+    },
+    "sound/ranger/idle.wav": {
+     "bytes": 10819,
+     "sha256": "644fbbc14e20684fa31abc7f04969943ac950c33435271b0fa646aa324be4400"
+    },
+    "sound/ranger/sight1.wav": {
+     "bytes": 5379,
+     "sha256": "5023e2483fe5c1c37cd661d382e34c0b68eafe4bae0e35e8f3f7e516e78dcf51"
+    },
+    "sound/ranger/sight2.wav": {
+     "bytes": 11323,
+     "sha256": "3574f035e1a261b9a001d99a54bdb502da31da2639d95e7fc06f96b547c1ac44"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight1.wav": {
+     "bytes": 35068,
+     "sha256": "48db878a4eae15b37ee0ca333aae74d310103a9eaf2e4b35eecd43a89f626b9a"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk1.wav": {
+     "bytes": 19372,
+     "sha256": "42e41297df70202ec9965af7af5fcdabcab7fde43ba515c8ba0a1ee2e4429554"
+    },
+    "sound/shade/death.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/shade/death2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/shade/fly.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/shade/idle.wav": {
+     "bytes": 37192,
+     "sha256": "57b0a0a7a0e75a17df8c4bb68740b23325bd0bf3475d908ee92fa0522c71edf7"
+    },
+    "sound/shade/moan.wav": {
+     "bytes": 33684,
+     "sha256": "3a6644f2c0a6ead5992fa9752ec9b0d898f4c40f5a32b12fd61aa991f75fa0c7"
+    },
+    "sound/shade/pain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/shade/pain2.wav": {
+     "bytes": 8918,
+     "sha256": "c6fa3ba7c659faf38b00af9c9867c37ba730cbc662125f5307f755515243dc4c"
+    },
+    "sound/shade/screech.wav": {
+     "bytes": 28244,
+     "sha256": "55ef2615baa6ce39733892fc9538f702acc567f65250223329f15b191d9b1a47"
+    },
+    "sound/shade/sing.wav": {
+     "bytes": 35654,
+     "sha256": "9de82a1d3124c391466004aea5e8ad066bcc6ede2715e7978a92a2c8f66e3f6b"
+    },
+    "sound/shade/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/shade/taunt.wav": {
+     "bytes": 36418,
+     "sha256": "f556cad612249e63690ac28b17405eba70e3df43560c3a087062b9f330811720"
+    },
+    "sound/shade/taunt2.wav": {
+     "bytes": 28160,
+     "sha256": "a68174008206b79794d8d52fd027daf08767ce005189860c815cda021080363c"
+    },
+    "sound/shamvile/burn.wav": {
+     "bytes": 11316,
+     "sha256": "239c51d5cfb82ee7683075f6cd53d8a16fcc2da608c9db87c27fd7491160a627"
+    },
+    "sound/shamvile/dsvilatk.wav": {
+     "bytes": 16978,
+     "sha256": "f4fc290f121fafbc1d8e5e992b9454b404f9ebbf3c95bc376419ee8ca58425bd"
+    },
+    "sound/shamvile/melee1.wav": {
+     "bytes": 4700,
+     "sha256": "f418a627faa0b4630588914ecdd466c387e1d7d5ac2e09acecafa13baf33f10c"
+    },
+    "sound/shamvile/melee2.wav": {
+     "bytes": 6252,
+     "sha256": "dfeb5bcd8be8d9f1fcf52f89cf0af533ec28066eb0bf74e3ac4b588ca810f372"
+    },
+    "sound/shamvile/melee3.wav": {
+     "bytes": 13236,
+     "sha256": "7102a987921e4c291175ba252628613c2c6ecdb70e9a33e174b6bcf7addc239c"
+    },
+    "sound/shamvile/melee4.wav": {
+     "bytes": 9211,
+     "sha256": "da31a8531703998c06bc33c94639d5dd291c9ba24e6752599ec8e6113d3753b5"
+    },
+    "sound/shamvile/sdeath.wav": {
+     "bytes": 20996,
+     "sha256": "e27d5870c37ce74877a2681b5e9cef437d14b05c501fb93733c8e93d2d2b0931"
+    },
+    "sound/shamvile/shurt2.wav": {
+     "bytes": 3924,
+     "sha256": "541c66bfaf5f30c55d24c4013f4a8859159ebfdf2f054c681eb8b8200dba1c85"
+    },
+    "sound/shamvile/sidle.wav": {
+     "bytes": 5476,
+     "sha256": "ca3edcb476f3992027989a2a79ef21a7f8951965c8a0e77f89f0a0505f2d2b52"
+    },
+    "sound/shamvile/sidle2.wav": {
+     "bytes": 21511,
+     "sha256": "0e46d4e53c003136881723f59de4d706151b845d57608cd87361018acb7ef050"
+    },
+    "sound/shamvile/ssight.wav": {
+     "bytes": 15564,
+     "sha256": "5a5343f95ee503f1b481ef05499e023b681402b922600979367788f2fb91397c"
+    },
+    "sound/shamvile/ssight2.wav": {
+     "bytes": 27204,
+     "sha256": "2b22c0912485569f7ec87a32a29c88563c0cb8261b4428335540fc96f7e7cb52"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 19642,
+     "sha256": "91eba6c478e8475696f07079502af32d1817e3fb86418c32801846582f27561d"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 18166,
+     "sha256": "91301f18c459286798989dd164ae08f5e77433ac7a0b5c71522cf59e49bf1a30"
+    },
+    "sound/skullwiz/blinkspk.wav": {
+     "bytes": 31420,
+     "sha256": "48a4dbd2add9021727d4572af9ac4c6f333a9e2ace5fe7127ddd42c84a2ae1f4"
+    },
+    "sound/skullwiz/blnkspk2.wav": {
+     "bytes": 41834,
+     "sha256": "fc2602275102b7e1a577c30b7ab3ac2709881eb3a8798664577f8a65a9132754"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 23034,
+     "sha256": "0eb20419acddee8a5814ecad8888348f90a14db997af1045b02b6052dccd5fd1"
+    },
+    "sound/skullwiz/death2.wav": {
+     "bytes": 32314,
+     "sha256": "3b1d2ed146a334ba5cf77027faa47addbf45c51159ff9c7278a97dda8ed7ef82"
+    },
+    "sound/skullwiz/firemisl.wav": {
+     "bytes": 12186,
+     "sha256": "3583544b6d7105d5b029a490cb0730190ae9e8dc5ca8f9da1deae4ea0335e964"
+    },
+    "sound/skullwiz/gate.wav": {
+     "bytes": 16156,
+     "sha256": "5797c6450d14f363133be23d93c829a660f9b7692c07f905b5a723cda8075c55"
+    },
+    "sound/skullwiz/gatespk.wav": {
+     "bytes": 30092,
+     "sha256": "f9fc90ba497d650acfad76c42ed531314828093f114c69c28fd1611d326fab2e"
+    },
+    "sound/skullwiz/growl.wav": {
+     "bytes": 18944,
+     "sha256": "de58ed34dd69dc3e871d09ac6a5db81ef26d69e234f0834e72c6cd68501ead21"
+    },
+    "sound/skullwiz/growl2.wav": {
+     "bytes": 24954,
+     "sha256": "0cf747c71a6fad9a085c39456cd14ffd972d2d454b4bafc2781ce4464917cfa4"
+    },
+    "sound/skullwiz/pain.wav": {
+     "bytes": 6106,
+     "sha256": "0f85b6180cbfe8d26f8d174f25c109b9d8b78d0fa53735e0494280bc8a19803b"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 8890,
+     "sha256": "6d48429e7fc4b80be16afd80097b7096a94cb1a88922a62bdfdff64172526a0f"
+    },
+    "sound/skullwiz/push.wav": {
+     "bytes": 8812,
+     "sha256": "91398e953b648ab23c037940fb7996f3d77727003a60757ea50686328c05cd69"
+    },
+    "sound/skullwiz/scream.wav": {
+     "bytes": 31734,
+     "sha256": "6df299b2a59aa94a9640c83684b65259e4619e0ed2a2fd1ce518dffaa060fd43"
+    },
+    "sound/skullwiz/scream2.wav": {
+     "bytes": 13980,
+     "sha256": "adca10198e279db0789a1a026124387c40e36fc1914f3f3da315b49b6e290386"
+    },
+    "sound/spider/attack.wav": {
+     "bytes": 6576,
+     "sha256": "82593fdd5be8198a9774c163872f89a088d8d0ca10e91f1c8f846ecac92b2d81"
+    },
+    "sound/spider/bite.wav": {
+     "bytes": 4552,
+     "sha256": "abd0b64743c825661f4598b7d5b70b781452a6b7747f9eb8b53f7239b0f9b9cb"
+    },
+    "sound/spider/death.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/gib1.wav": {
+     "bytes": 10516,
+     "sha256": "bbe1a437bd05a71f9d7bba953a79886891bfc526399c67cfc8964308c91786d0"
+    },
+    "sound/spider/pain.wav": {
+     "bytes": 7576,
+     "sha256": "386e11cfd8063b6bb692ab4b90246be98288f72f29614f2e38765df9e6eaad79"
+    },
+    "sound/spider/step1.wav": {
+     "bytes": 2780,
+     "sha256": "06ee408dace817630645b0d390c496e692844fb42cc85adcaa021efeb60fae9b"
+    },
+    "sound/spider/step2.wav": {
+     "bytes": 2620,
+     "sha256": "66e802d6361a17e637f5e38366e4b0912dbb0f65e647041bed57cfda772c0770"
+    },
+    "sound/spider/step3.wav": {
+     "bytes": 1786,
+     "sha256": "418b2c536f19a5bcd0b1a8ff4aae13febc8c4f8fa6787372e9e869c45a17f54c"
+    },
+    "sound/trog/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/tur_arm.wav": {
+     "bytes": 23794,
+     "sha256": "24b428117ebd7e82865b41dcfc74a75a048c4d126d7505a6c23dd243bc054a05"
+    },
+    "sound/vomitus/death.wav": {
+     "bytes": 13236,
+     "sha256": "fa2cad86ac0ce1326132c5e378aed6a9ff5615d043df1d4d48e0b2691f8d3bde"
+    },
+    "sound/vomitus/flesh1.wav": {
+     "bytes": 8412,
+     "sha256": "9ac5a8ac2155e7d9b65144e7f65525c4660ff5959fe3a0277fab347e202b6f46"
+    },
+    "sound/vomitus/flesh2.wav": {
+     "bytes": 12788,
+     "sha256": "3fc22e2aa2c3c0bdc6501388ac18abb5e58c5fd5deba39d1cc2f7e8d48fcc869"
+    },
+    "sound/vomitus/groan.wav": {
+     "bytes": 13224,
+     "sha256": "3632e43615714e5fc1be8277881a913bf1bd79b276544418cbf1b159016f0d03"
+    },
+    "sound/weapons/axhit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/weapons/axhitwal.wav": {
+     "bytes": 6694,
+     "sha256": "0f14ba18076b25a7b8ee510b38adb282eb5c4f2fc94168baf1f8a658e1da684f"
+    },
+    "sound/weapons/block1.wav": {
+     "bytes": 5484,
+     "sha256": "ccb284becb454f395de702a263bfda1561b8bd38117893d33b5ebbb9eb7b6865"
+    },
+    "sound/weapons/block2.wav": {
+     "bytes": 5612,
+     "sha256": "62da8e44f3b1200b99f76a3bdb31d9d09a9e74c04a449c0afc482c6677a94bc2"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/weapons/clang.wav": {
+     "bytes": 7198,
+     "sha256": "634a88cf26b4de688bed392cf108d5468749f212ce67015c71baa942e8e88502"
+    },
+    "sound/weapons/dsshotgn.wav": {
+     "bytes": 9490,
+     "sha256": "98c228b3549d4908c313c783d5b0aec38b93efea1c6a65d7355767bdbb4b87e8"
+    },
+    "sound/weapons/freeze.wav": {
+     "bytes": 20619,
+     "sha256": "48689ba550c116dd8b10a138bc0f78eb6f169d6828a49aaafe12f807930eb934"
+    },
+    "sound/weapons/fwall.wav": {
+     "bytes": 40140,
+     "sha256": "e269c07608f322518e709925d5b13daded150460d19d3091f15152ce4c06c9bf"
+    },
+    "sound/weapons/fwallhit.wav": {
+     "bytes": 9426,
+     "sha256": "7b9f4da432e6fa44fbf721ed9ef753e6ceb41df59b8265b58f73764b2901224a"
+    },
+    "sound/weapons/fwalltap.wav": {
+     "bytes": 8316,
+     "sha256": "879b9970dfc3bc609ff384a0edea13b594ea6a82b5c56d33c8549cd36cccda0b"
+    },
+    "sound/weapons/icehit.wav": {
+     "bytes": 10710,
+     "sha256": "9ed8ed177a6cfcad97f8adcf94b9f3114a955e7b3abb397c6b17c44073c07b19"
+    },
+    "sound/weapons/icewall.wav": {
+     "bytes": 6124,
+     "sha256": "9668486027e07f525a27830dc3217cde36bcbcc956b21437d2637e00df368dd4"
+    },
+    "sound/weapons/mirv1.wav": {
+     "bytes": 89538,
+     "sha256": "7d60062f61d5929f5f927526d81920f24684520d230a5f2611c128b832d3357e"
+    },
+    "sound/weapons/mirv2.wav": {
+     "bytes": 18478,
+     "sha256": "67311180da390517f2ef71d161a0cf7b770548dcd4a7dda7e679cb9b58025b4b"
+    },
+    "sound/weapons/nova.wav": {
+     "bytes": 10020,
+     "sha256": "d41c8433fa1b964fafa1cdb2fec301fb4d398f1fce201b4d80b29fab7a59d7e7"
+    },
+    "sound/weapons/pkup2.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/weapons/plasma1.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/plasma2.wav": {
+     "bytes": 8350,
+     "sha256": "de03da8d300ddaf56b063584226f5673b0033a8258209e4c8c5f82a4d40b630a"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/weapons/r_exp3a.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/shatter.wav": {
+     "bytes": 20899,
+     "sha256": "31ddbef0dc746eabea23cd7cd2fb97a1f949a014b664630d7f04e6c237aafc03"
+    },
+    "sound/weapons/sheath.wav": {
+     "bytes": 7031,
+     "sha256": "8f28a1daa16db234ce77d91e688c7acbc9541c296d30af9e1f940b6d45eaf72d"
+    },
+    "sound/weapons/sprocket.wav": {
+     "bytes": 7126,
+     "sha256": "8b5c3bdc625b4954c6b504ee242591f0121d1ab64f2aceab54dd85fecadef8a4"
+    },
+    "sound/weapons/ssg.wav": {
+     "bytes": 17176,
+     "sha256": "c3307bb283499155691c01fe783d86992946475fd3b9a4839ba37cdca7ede6a4"
+    },
+    "sound/weapons/stunfire.wav": {
+     "bytes": 9902,
+     "sha256": "7214cc44e4c0bfb801209f025b591d838542a3110f770e5614b0f549a055286a"
+    },
+    "sound/weapons/sword1.wav": {
+     "bytes": 3532,
+     "sha256": "572074b68af2132285aa9fd2ac6852f52ffb6c5e56eed44b1af21e0e78171e17"
+    },
+    "sound/weapons/sword2.wav": {
+     "bytes": 3055,
+     "sha256": "b176a257409b659d80df90560bbac4da5539971576aaf1107bb88bc016558085"
+    },
+    "sound/weapons/sword3.wav": {
+     "bytes": 3012,
+     "sha256": "eaca19c8a10b7942d4a279974df6e1cf076c362d5408e439b26286126852bedf"
+    },
+    "sound/weapons/thump.wav": {
+     "bytes": 30904,
+     "sha256": "ef0aa85fbc7ff6915aa5382c80e6f571ddacd50116faff495e3d5638bace8a49"
+    },
+    "sound/weapons/unsheath.wav": {
+     "bytes": 8060,
+     "sha256": "45d9bc6b9dcaf8e0dc9b2ede7da69a872f50f7819462a71bc16b9d76a70be06b"
+    },
+    "sound/weapons/xbowdraw.wav": {
+     "bytes": 19114,
+     "sha256": "4bb73eb7161ba561970e8f2e7f5aad0e42b3419fe2b02a5953a7289c46d1442b"
+    },
+    "sound/weapons/zap1.wav": {
+     "bytes": 7648,
+     "sha256": "1ee462bf6169537cc96fa7f95ef30b782fa1be473bd6ddc297fb3a7a6aa21ad0"
+    },
+    "sound/weapons/zap2.wav": {
+     "bytes": 7178,
+     "sha256": "8ece0064dc470a86c00906c1c50a54afd3a64eb13582071b9960581a1b72f4ff"
+    },
+    "sound/wraith/call.wav": {
+     "bytes": 12328,
+     "sha256": "9ace8a0ff79d035d36b6bdfb8726054ceaf8f852d25f3c1b235616abf4646ef2"
+    },
+    "sound/wraith/die.wav": {
+     "bytes": 14024,
+     "sha256": "3f166e024c07124cc5b5c5469904f5a8b3e48d4cb50fd949be8d79b4df2e375c"
+    },
+    "sound/wraith/drain.wav": {
+     "bytes": 14094,
+     "sha256": "d767951e9630b6179fb05a80136acbdeeb530f350b1953bea62e8493f3fe67ce"
+    },
+    "sound/wraith/growl2.wav": {
+     "bytes": 24966,
+     "sha256": "1c757955bb103e0f589ec373d1517dbacb8fe7e274f7aa0928503c9f5b009b10"
+    },
+    "sound/wraith/idle.wav": {
+     "bytes": 23702,
+     "sha256": "760a4a215fa2adb6f531b15acc06a4b46daa84c85fc08691ff4fe13f17e09ee8"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 20442,
+     "sha256": "d55cb931cef7d9c336fb7bbc3fa0408ea23eff69f46e25ac377ebbc880fa5025"
+    },
+    "sound/wraith/return.wav": {
+     "bytes": 39162,
+     "sha256": "0439588ad2003732fe7f946a5597bf80b2b89d6395476671b0e050b91c49cca7"
+    },
+    "sound/wraith/rych1.wav": {
+     "bytes": 24482,
+     "sha256": "baec568f339f688ea475e37ef3fc51a36de78a52a553e85aaa3f8011e1240d13"
+    },
+    "sound/wraith/select.wav": {
+     "bytes": 29326,
+     "sha256": "1e86b92dd1d82f4f74cd7fe14a75484e6cddb4fe968d2bb3dbaf850414c6dacb"
+    },
+    "sound/wraith/soul.wav": {
+     "bytes": 70524,
+     "sha256": "612bf73a6ebe0526efa2ef3d22915bcd87bed0b0eb5e52fc4eb0e62c5e4a3039"
+    },
+    "sound/wraith/soul2.wav": {
+     "bytes": 20562,
+     "sha256": "d3701420c157109793576ac7af7c7b132ffd0897375ec99701f4cd54798d9579"
+    },
+    "sound/wraith/speak.wav": {
+     "bytes": 25630,
+     "sha256": "6d1e5b395938692d57de3ec8ef9a8b5e4ccdab920a1f247e5bcdc1f0906dfcb8"
+    },
+    "sound/wraith/talk1.wav": {
+     "bytes": 16654,
+     "sha256": "6a625383c12f7fb5979ca8977a51d40f183051d551bd0b1b4ccc8a3f43a0322a"
+    },
+    "sound/wraith/talk3.wav": {
+     "bytes": 9832,
+     "sha256": "28ecc66c85bc722059b147a1354d226fbaf3022b79aed937a4759958d52c0fab"
+    },
+    "sound/wraith/weird.wav": {
+     "bytes": 3028,
+     "sha256": "1cfcd24daeb0665dce9d68ec353377ef84a88c78d1fdfcb429f2d0cc2b7f4b78"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    },
+    "sound/yakman/big1.wav": {
+     "bytes": 21636,
+     "sha256": "16c1632682aeb4b4075006d5b8b13a7e3f8821b6f59f8eb61ad78308b0d68366"
+    },
+    "sound/yakman/big3.wav": {
+     "bytes": 25096,
+     "sha256": "2cbbc5dc1249a92b9a31a6f3fa7ff654dd6339511fc99e4c552ad6a34218a4c2"
+    },
+    "sound/yakman/breathe1.wav": {
+     "bytes": 45712,
+     "sha256": "53730dabf839c183028fbdf909df8ae7ef936828c51c58a957617444872224d4"
+    },
+    "sound/yakman/breathe3.wav": {
+     "bytes": 50728,
+     "sha256": "fd923c891934046d9770c089dfe16021373a392b429531ef9698fbd2f759c42a"
+    },
+    "sound/yakman/crash.wav": {
+     "bytes": 17808,
+     "sha256": "068f6ea04f13016615f9534e74e969a62eda98c7def921df76731c5afbd73cf2"
+    },
+    "sound/yakman/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/yakman/expsmall.wav": {
+     "bytes": 8732,
+     "sha256": "18825b9644c01ff0a488887185ac14d6fb4fd983254620009ba3ecc96c44d465"
+    },
+    "sound/yakman/firefblt.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/yakman/pain.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/yakman/slam.wav": {
+     "bytes": 6372,
+     "sha256": "2c6ff4782b389777c98f09fa6ac86e6c75a848ad800db6dc32f8ea9362706e96"
+    },
+    "sound/yakman/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/yakman/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    }
+   },
    "sha256": "22d57e211cdb714ba3df19083c1514b08e5c84650545bc1a4092b383fb72a3f9",
    "timestamp": "2011-06-12T20:56:02.000Z"
   },

--- a/json/by-sha256/a1/a1b5066e8e570d4758606ab1a84a21c770808d4fbbaaf526f48ceeb7d127becb.json
+++ b/json/by-sha256/a1/a1b5066e8e570d4758606ab1a84a21c770808d4fbbaaf526f48ceeb7d127becb.json
@@ -60,6 +60,52 @@
   },
   "tsd/pak0.pak": {
    "bytes": 13309526,
+   "files": {
+    "Quake.rc": {
+     "bytes": 579,
+     "sha256": "a9a4e28df3bf8340d3c6470c965891bb40d3098146dfb3dde349ea25a9a6c89b"
+    },
+    "autoexec.cfg": {
+     "bytes": 44,
+     "sha256": "711bdcedda45d54e91bc9cfaed55647470850bfb080484536900a3d6e2950923"
+    },
+    "config.cfg": {
+     "bytes": 1799,
+     "sha256": "1dd2e5993f8a6156a6549729cc2ee61d00ecb12638ef6deeaea0acbcd37aa9ea"
+    },
+    "default.cfg": {
+     "bytes": 1954,
+     "sha256": "ae1e3d4b7ff76ed5bbae92b53f5f8ad207b08a4e6e79139018a6e415c3b96c7f"
+    },
+    "maps/vxmas1.bsp": {
+     "bytes": 3085752,
+     "sha256": "3e8f3d602a6e5f6e24ea5aafd403410e6065a158af1f429f5ab748dd0c0de643"
+    },
+    "maps/vxmas2.bsp": {
+     "bytes": 3036524,
+     "sha256": "3b096484c2a58bad0ccaa127b84db34796ff0d4f739f26cdc8316887417fb456"
+    },
+    "maps/vxmas3.bsp": {
+     "bytes": 2356332,
+     "sha256": "02b0547dc69aa22d3bb121c0b1f7da72d264661e1cccef01cd4ffd82fba9c32e"
+    },
+    "sound/Music/TSDCrd.wav": {
+     "bytes": 1132600,
+     "sha256": "fc0699cf2c43c0e3327b768543f9e726fa17acda8f67baad908415f7bd778de3"
+    },
+    "sound/Music/TSDm1.wav": {
+     "bytes": 965178,
+     "sha256": "6e6d602c3dfa4187de100dcfaeaa875440702ee442e8caea3d14d6592f362d21"
+    },
+    "sound/Music/TSDm2.wav": {
+     "bytes": 1353270,
+     "sha256": "8195fa6dd546e3b9ed3a7d54d6c044ef2ace4d8c7ff39048b7de2d8b536038b3"
+    },
+    "sound/Music/TSDm3.wav": {
+     "bytes": 1374778,
+     "sha256": "c3243a37536e8ade269ce4bc91f4957158060cac72f949bbddb320a4b838b16e"
+    }
+   },
    "sha256": "d8c99612b5b2eafaadc2244b961b2357ba24b6258f4b891390cdaec7158ba651",
    "timestamp": "2005-11-24T19:08:28.000Z"
   },

--- a/json/by-sha256/a4/a4bfe55888c006e18782f9bdb99d136765296e291dff5979acc7af057cab3768.json
+++ b/json/by-sha256/a4/a4bfe55888c006e18782f9bdb99d136765296e291dff5979acc7af057cab3768.json
@@ -53,11 +53,2855 @@
   },
   "pak0.pak": {
    "bytes": 21411654,
+   "files": {
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "ca1f749a989a7ae7517464f60da05d58e43bfdb18694b08533aff2eea47c8d54"
+    },
+    "maps/b_barrel.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/b_wbh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_wbh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "progs/aagba.mdl": {
+     "bytes": 47520,
+     "sha256": "3d241c4ef67ff5f72727a47f2a0dbd47e458eb1dadda598a2a51d6a7e317c254"
+    },
+    "progs/aagtb.mdl": {
+     "bytes": 65761,
+     "sha256": "dce6af4135b595aeaa53d8afddb55d5fce2d1f249a9a0511492f5905d170c769"
+    },
+    "progs/acidbal1.mdl": {
+     "bytes": 8788,
+     "sha256": "8a9c956f1952fb8d9ea51119c1c8c758d3ca3b3bf3bb0e8b63131bf88325f5a9"
+    },
+    "progs/acidbal2.mdl": {
+     "bytes": 8788,
+     "sha256": "eceba377145b62b4721927e55de75423daaac83f9667852b16dd1bfff3beff01"
+    },
+    "progs/akarrow.mdl": {
+     "bytes": 23072,
+     "sha256": "4e0e1c007453dbc432533dab09dfbafa943c4f43f7897848c91a516bf0de43a0"
+    },
+    "progs/amgba.mdl": {
+     "bytes": 49912,
+     "sha256": "6bae1615f796fea252e0dee7f7fd1c1198e7051b6efa27b573bda7f32983be3d"
+    },
+    "progs/amgtb.mdl": {
+     "bytes": 56468,
+     "sha256": "d6ead6677454299061d0d5c031ab86ee2bc8a110e5a3b0318e08ba6171c6625c"
+    },
+    "progs/anglstat.mdl": {
+     "bytes": 164396,
+     "sha256": "ce4644a5e22e0ff39790a293754501add2a4ad8afa26cfbdd13205c3b833e923"
+    },
+    "progs/archer.mdl": {
+     "bytes": 581920,
+     "sha256": "f25f30a912f3722f9b239ad5809e9361348f90bb45c15102c92e7f513c27d598"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 58064,
+     "sha256": "db1681b9fa142d49137b665aa3b39d94de6df271dfe500569c3e93027aba98a0"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 15472,
+     "sha256": "9312dbd3fd1bcc480e985a31f3cd2e6168960a99cbeda9ebb1c92c4d629d0344"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 282336,
+     "sha256": "f93a9baa9c282b1ce99cdf6fe8b522ccb4f3d5390ad1465cc57a95e472a54af2"
+    },
+    "progs/bandit.mdl": {
+     "bytes": 226380,
+     "sha256": "8a1357e1faf7fce183513fcd39c4f7fca5bba832841c847579f56a268df464ef"
+    },
+    "progs/baron.mdl": {
+     "bytes": 426204,
+     "sha256": "09a4b10b43c2cb4847330ce3660eab93c16a97a7db0c9e1c1447e938689627d1"
+    },
+    "progs/bbg.mdl": {
+     "bytes": 190836,
+     "sha256": "3bac35175b2808bad33e3b7e7c2c54b3d9181c5b3743aa68d803dbe58edf0eea"
+    },
+    "progs/beam.mdl": {
+     "bytes": 1460,
+     "sha256": "9e9531de6f4e6f2f6274ea6612ef00bd0642c0cc05a7fdc866805fa1be851b73"
+    },
+    "progs/bellring.mdl": {
+     "bytes": 74016,
+     "sha256": "9a8131071ca927803140ce6478b8912c6eb52856861250d6b6bfa1d32cfb9cd9"
+    },
+    "progs/blood.mdl": {
+     "bytes": 184,
+     "sha256": "06825646d627df610b374a31c9265a88c9c1c45864c6e3b9d273a14dc4d745a5"
+    },
+    "progs/blood_gr.mdl": {
+     "bytes": 184,
+     "sha256": "84caed23ff1b8cabec8c5d9e5c6792c30a6d9cc57c36a9746369012015462208"
+    },
+    "progs/bloodcb.mdl": {
+     "bytes": 28036,
+     "sha256": "83f0de29aa0f9e9f1d383895da374a5313aa2252edb306eb7bd69bd71660321c"
+    },
+    "progs/bookopen.mdl": {
+     "bytes": 6188,
+     "sha256": "c02484d2b0cde19c2110f474f4809fc4cd24dae5e7b5ce1f3a59aeaa5779005b"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/chest1.mdl": {
+     "bytes": 19352,
+     "sha256": "239f897e3a390ad44acc5ffd19784f8b78232c5af2be67165581c2f6073ecc9f"
+    },
+    "progs/coin.mdl": {
+     "bytes": 44036,
+     "sha256": "c3d65aac43713c9102f8924ef7ed1cf90297ff17cfe8aface7936e9579b4ec57"
+    },
+    "progs/courage.mdl": {
+     "bytes": 14940,
+     "sha256": "4141933fbb8682ee28277826bd0f882580025def71b96c02cb9b53aa412906c0"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "7829e2cbaa4816577c77ba12a91933eee5dcf9d899f3f4d9717f6f8fc0319a23"
+    },
+    "progs/demon.mdl": {
+     "bytes": 245960,
+     "sha256": "b24014d5f453a854793b2753c11bda3130dd63c26edf12324bc376ecc9feb71a"
+    },
+    "progs/dog.mdl": {
+     "bytes": 269016,
+     "sha256": "9a60157b0504891c71fbaece5a729e9b954a5e2dffe92e1e1a1ab51c6d912b77"
+    },
+    "progs/doll03.mdl": {
+     "bytes": 52064,
+     "sha256": "b2962f3954740ad7f9b5ee329d3a189ed5c95ccbb279bb63dc77508c94e4fb28"
+    },
+    "progs/dr1_head.mdl": {
+     "bytes": 7476,
+     "sha256": "06f28a6f55ba29f12965e7ca10d99147a9432c851a2747d1e861cd45c07d958f"
+    },
+    "progs/dr1_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "c208f5473b2954fb4af094119b5a63b3a205e7a26e94c0c122b1f06870db6f78"
+    },
+    "progs/dr1_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "258da574e4de9d144d4f6a71db72a8bd566ecc6b0672efeb5cacaf59c7dd969d"
+    },
+    "progs/dr1_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "698d06c98e8e9ab99b6ddf808bb32a4994299c9596354bf8f811cda0f4042588"
+    },
+    "progs/dr2_head.mdl": {
+     "bytes": 7476,
+     "sha256": "551d47f807e21d11aba52f66207515e0988e8a424012f204e517c8c6720514d0"
+    },
+    "progs/dr2_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "f636b0786ab159a368b9fa580f1a0a31dc7873f21edb1bc454eb9e64c2c27a14"
+    },
+    "progs/dr2_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "533c0d631c78c22f5ff7632e7dc19f5da1acee56225a5a1497bf34d10fc07344"
+    },
+    "progs/dr2_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "5f5eace00eef74eeaa9db48887636e08ab43c85ad0d05816745c04a4710f34d3"
+    },
+    "progs/draco.mdl": {
+     "bytes": 235148,
+     "sha256": "0b51fd9b782891c4b8b410db6ac1361dfa0f53d634366709434a926e0c7285b5"
+    },
+    "progs/dragon1.mdl": {
+     "bytes": 258260,
+     "sha256": "4dbf09c018ea9f703d4daf48c0a5e504208547d5d172bf26187b8eeac8a94a02"
+    },
+    "progs/dragon2.mdl": {
+     "bytes": 258260,
+     "sha256": "fa2b5d9467299634cddcff9c7ca87c2006c8c9631f45cbf66f74a8abfd5df347"
+    },
+    "progs/dragonpl.mdl": {
+     "bytes": 77764,
+     "sha256": "57db3cbef92a0f96cd8ef1be17ce77586f9541bbffcea2e7747e43b35c50effa"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "718b8c2842877345426247148dd6ce1ebe7fecc13e969a0fa0ed6dbebc388099"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "0a386b6381824b01852910519490ac3f6e3309a96091820384ee6b9a5b452e7a"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bef43e6c7bc067d3b35dd05a793c08d7d700fbb2013606ac9ffeac8772d0997e"
+    },
+    "progs/drp_head.mdl": {
+     "bytes": 2340,
+     "sha256": "b87cb902d796dd76c03e9fc79576f368d23022fbd5b5155c8910cd315046e32a"
+    },
+    "progs/drp_lw.mdl": {
+     "bytes": 7116,
+     "sha256": "ad483731fddede05ebf1a9a3c20f735f6ec341f156669833ed1077460dac8e5c"
+    },
+    "progs/drp_rw.mdl": {
+     "bytes": 8056,
+     "sha256": "b57363de0be61e45b355d1cceccadd42fdd1b8f91fc4380847dacf186d7560df"
+    },
+    "progs/drp_tail.mdl": {
+     "bytes": 2604,
+     "sha256": "b8ad65168755d4f31b657a80c78e2e0f51316c48f4ebd10ddae0b6971c7c6e89"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/ember.mdl": {
+     "bytes": 8788,
+     "sha256": "91d6f4dfbeba0711d0864b94bb372b602959644c5c841fd659ddedb8f8e6980c"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/end_bane.mdl": {
+     "bytes": 52980,
+     "sha256": "4a86fd7bd59c4ecea934e3adcec4b17d627cdfac5223976a52b5739143c37f27"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 241252,
+     "sha256": "9ae37ced89200daf2d44795bef4230c5b725226a820c28cda7908f43bbdaa747"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 356760,
+     "sha256": "6ed7909a7a193f7e25bc623f1919d5c4cd45d5bd0fb5de1c13e9636a68cd9dcc"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 68804,
+     "sha256": "f3c760ecdbb530ff651c46f516228c588f37585315acdab199408911c2c8414b"
+    },
+    "progs/flame2a.mdl": {
+     "bytes": 68804,
+     "sha256": "e02210f2f6851cea4b9520476cfe36c31745dc2d84248f6a75132358d6d43035"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 56532,
+     "sha256": "36d304e1442ede2048036d832d36ef4624fe4e90ba16628c20c819e7b4477da5"
+    },
+    "progs/g_dshot.mdl": {
+     "bytes": 71894,
+     "sha256": "9f5973b2db81e67569d498ae880c4ebdf1f886fac695df50ebd93cfe5b79da0c"
+    },
+    "progs/g_grpple.mdl": {
+     "bytes": 78456,
+     "sha256": "6062e2038ad83c0427a57c832af3e95f3385bd2fdc0af3635bbd83d20edf49d4"
+    },
+    "progs/g_gun.mdl": {
+     "bytes": 24344,
+     "sha256": "f6aa476d8352bf5b7010c68387fe53121f886b26e331d8dc32b9cfabf52067b9"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_horn.mdl": {
+     "bytes": 28900,
+     "sha256": "8b7ba660f1f9878433d90f1cdfd0024944523af38f317e659217833cba1fe3b2"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 38004,
+     "sha256": "cf67c0a7ad3e853fa4af7544d0399fc0a3795a61d625f5e78104e659e2db0eed"
+    },
+    "progs/g_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "3e4a1e9dc2bff162612e218a25e2040b57d063d198df2e301eaa8fa9542af098"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 158116,
+     "sha256": "127e4fefafc5015f03a6cd1288cab9da325ed5b5a93c9f6b90b6da9d8273ef9f"
+    },
+    "progs/g_wand.mdl": {
+     "bytes": 13684,
+     "sha256": "99212b7901c31b723704e7c62b1c5f70b6a2f7320c349605a3943f3091e962de"
+    },
+    "progs/g_xbow.mdl": {
+     "bytes": 22476,
+     "sha256": "bf1cd180a66f74da4e625a2167bf66527cebd0d4009fabeed48297018db8a4fe"
+    },
+    "progs/gem1.mdl": {
+     "bytes": 42612,
+     "sha256": "0b71e525b19e25f98dad53ce766751de8e0c9f18434582bb86242296bb7a402e"
+    },
+    "progs/gem2.mdl": {
+     "bytes": 62672,
+     "sha256": "721459e22aab0d2cece430053734b889918bde4db879ffc94084289a7b6d4d8c"
+    },
+    "progs/gem3.mdl": {
+     "bytes": 42072,
+     "sha256": "3bc3a1018cc432b694f9ec45de06775776ef55d21b4e117dd1b2c7c0d7b850a2"
+    },
+    "progs/gemini.mdl": {
+     "bytes": 35188,
+     "sha256": "fa05498ce8034d51377953db7c650f9367b072a9d614812f4f67ad15eace909e"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/gr_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "3f5b6d67b80e5f2e5bb7c129500c79dc345141133f8d415005f9384b0d2d9661"
+    },
+    "progs/gr_gib1.mdl": {
+     "bytes": 6501,
+     "sha256": "3f715cbfdcd77caef11b904aa12d2063cbb973d4a9d61c27492690344c14fb1b"
+    },
+    "progs/gr_gib2.mdl": {
+     "bytes": 17553,
+     "sha256": "c6166eb6132a3e87f51fcf48f4e9eebb719b3f1819d22640582b23d61bde4a16"
+    },
+    "progs/gr_gib3.mdl": {
+     "bytes": 22933,
+     "sha256": "0e40e5b960924ca642690c26b239c89aea6bae18badcb945e96d2102cad69622"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_archer.mdl": {
+     "bytes": 22128,
+     "sha256": "d537366677c6348012792a358117da9257f7e00cda2ccf7a6d4ba535e3699dfe"
+    },
+    "progs/h_axeman.mdl": {
+     "bytes": 18400,
+     "sha256": "e15391056ec618b412d1341914d2e6f05a759de92500ef249cc5d1789b3ab6d6"
+    },
+    "progs/h_bandit.mdl": {
+     "bytes": 9752,
+     "sha256": "cc79629b169c0560905eae7ea9a02e5ec546af8cfa07743922e0b1dc829b29ca"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 7444,
+     "sha256": "68bc1db4875fe84f25ff3d6c53e4e9e2c023ef52bf3c89b439493f2e5c5c0e19"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "53539bc39fc87627a46b75b0d86ade5e6116a0079b032b1df137b2425b7186cc"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 100492,
+     "sha256": "91201d4628cec7ea434747972c1183eb677c1395099895fb45ba328cc245631b"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 68796,
+     "sha256": "57a646b291c29b490faa38e3b72d7f074d9d071946d9b9c6068095999a11ce77"
+    },
+    "progs/h_drake.mdl": {
+     "bytes": 28792,
+     "sha256": "be0bcf5fc725dbb09a82becc2339d91824a14a547ce3013deabeece662658dcf"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 9752,
+     "sha256": "8974b166a431397d09b393ddc08dbd30a9e5bd1fb3421145d5b819984967d6ea"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 100172,
+     "sha256": "27311a59a95ab735d79e5198318d0507da7e377584702ba9e5bf673c0972e065"
+    },
+    "progs/h_hkolem.mdl": {
+     "bytes": 30552,
+     "sha256": "38b2082ead97b90f59a5fdcf24d4077ab067c55655598d023f8ec38818c914b1"
+    },
+    "progs/h_imp.mdl": {
+     "bytes": 73284,
+     "sha256": "d8146383fe6d31374c67718ff235e83d3891ebee5a0e44539b536ce049c9ce70"
+    },
+    "progs/h_imp2.mdl": {
+     "bytes": 73284,
+     "sha256": "8d41d426350d60fe2779154a4ff240c54b56e408fae7701a1e2904a210baebb3"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 19644,
+     "sha256": "1accd89ba95db3627cee4f06f94ab3bc9d146ebf566da24b570c733f2f902c1a"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "72455aab2067fd8f887e8a8e9c61d2b943699ce90fbcb85937fbb358c9e5678e"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 42848,
+     "sha256": "8f8c58d63873025f157eb37951d2a02c9d2d0cfeabaace76db7bdba303e35d18"
+    },
+    "progs/h_necro.mdl": {
+     "bytes": 14296,
+     "sha256": "fc9c468465d0e8982fc2d6207ce94b2f400f0f37cbe88cff2a4aa64719b91f40"
+    },
+    "progs/h_nemes.mdl": {
+     "bytes": 78156,
+     "sha256": "6f350692b44907984c02779d0114576bbafb6a3ada673e1f55d1cf02fd062c18"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/h_rebel.mdl": {
+     "bytes": 5428,
+     "sha256": "b189ff3ae1596da7596f21d8f555603951fadf8e7884e96f89c8b2b5789028a5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 53096,
+     "sha256": "ff1d940222f28765b975828528016332b04423a4001a507e07cde6414847add5"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 108204,
+     "sha256": "dd7dc5c90255da868b96ac553d8a8f68b6723da6b25114bc087fd019966a023f"
+    },
+    "progs/h_snake.mdl": {
+     "bytes": 7220,
+     "sha256": "56202130d5c6cde3b652db91ceae45a2448421b5237cbf4fe5838849fe296f9f"
+    },
+    "progs/h_vomit.mdl": {
+     "bytes": 16952,
+     "sha256": "9822885036229871594a21643f4acd3a9b4c27d141b9021464b5062dfaf410f9"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "7ff66f881f85884aea56396da7b756da32c04df163a1e1f739485e77e61279df"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "2f6fd7256662a5a4b4b907b0ac68bf7d787ebd55cf54e352da5f1b363a2b2397"
+    },
+    "progs/hero.mdl": {
+     "bytes": 66388,
+     "sha256": "ea4f359a328b6416588e5debe13a87fc2eccd8a65263ae23683d71a58b39a116"
+    },
+    "progs/hk_golem.mdl": {
+     "bytes": 179204,
+     "sha256": "972f27eb2bf8a6cc4433e1f904097ca5393312d47a75e396b0323723beff58fa"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 534604,
+     "sha256": "10058c95eca9a063c7990d919d353d3573d252eb39f00c5f471a7f22f0b5fefa"
+    },
+    "progs/hook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/ice.mdl": {
+     "bytes": 2580,
+     "sha256": "30c4853e26d51d0ca4d3df5a40ec6d8861f48e9420f10560b5de0c19e6c15ab0"
+    },
+    "progs/ice_cube.mdl": {
+     "bytes": 3192,
+     "sha256": "bf96c8c1533fa537582bd4cf7bddadb7f5ddeebafbce9ef29007a5acd5a909b0"
+    },
+    "progs/iceball.mdl": {
+     "bytes": 24632,
+     "sha256": "802fa6260e9af5abb74bab0a76f35ae3e2af2373e61091c725325aa41051be7a"
+    },
+    "progs/imp.mdl": {
+     "bytes": 583036,
+     "sha256": "ca8746396a834b96eb3b6a5a2f7fe7d3930d1341a32aa528e58fc81053713a18"
+    },
+    "progs/imp_lord.mdl": {
+     "bytes": 583036,
+     "sha256": "6186f04775a695540a60543f48aad03b1d280c575399b8b68a9f69d799df74e7"
+    },
+    "progs/imp_rock.mdl": {
+     "bytes": 2352,
+     "sha256": "dbe190f471f5738779e103b496117ec40e2adc9e5f593d2470172bcbd7ade0f6"
+    },
+    "progs/imp_wing.mdl": {
+     "bytes": 93932,
+     "sha256": "d727c88da33bdcd3875509f8bf96af0cbcb31b25aa5f5b03ce1584aa0cec2047"
+    },
+    "progs/impwing2.mdl": {
+     "bytes": 93932,
+     "sha256": "6efe1dfb3290a80bc02bd47c1726a8aefc7956fa22d2e1867fbbd0557cc8ffd2"
+    },
+    "progs/k_ball.mdl": {
+     "bytes": 31300,
+     "sha256": "f93346ffeed3fd5d9866fb80d1a08216759bb27757d49a1851e471aadf757ec1"
+    },
+    "progs/key_b.mdl": {
+     "bytes": 10616,
+     "sha256": "d1333d74b7e194f6587d0f5ed1fca28887cd0414734b4bd4cbb7e715ab897629"
+    },
+    "progs/key_m.mdl": {
+     "bytes": 23160,
+     "sha256": "ea2feb6eb54823668dcb112f42c3441e563e18e3cc1806b5ce509044e6c0b448"
+    },
+    "progs/key_w.mdl": {
+     "bytes": 11576,
+     "sha256": "72da64d2b29d69605c453e9ee0e5fa8ecef91a94cc541103cb24fbad96c7946d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 232536,
+     "sha256": "e3e618799612c6e521f68234a061d9a46036ef556677b0c1651e7647258ffb56"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 27960,
+     "sha256": "5877b37cc4f98a53467c412e7d06d1f7ec6b60f5c0f2088514aa51c9d2c51769"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "210e159ea4c9bf1f2431213fd95902f4ea75ecee6a67a22bed7e93366f1f2732"
+    },
+    "progs/levitate.mdl": {
+     "bytes": 15876,
+     "sha256": "03e77b0d4b8ee7b3b224cbe0cfba63e8bd27d0391bd5069981e5435287f66645"
+    },
+    "progs/life_up.mdl": {
+     "bytes": 34676,
+     "sha256": "502716aa1b0f6cb8f929fe7ee2a74024a5fa007898256e15ca495e126888c584"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 57796,
+     "sha256": "e8b38ca8f28a89f65ffc652e082e8a9aaf6a1a9db8302e961b9ceac1c8f60e8c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/morph_eg.mdl": {
+     "bytes": 300592,
+     "sha256": "14468fccffaa1508c03610dd58fb51cd9058ca3bab036bca18f7a41cb37c195b"
+    },
+    "progs/nec_rod1.mdl": {
+     "bytes": 16072,
+     "sha256": "2eded5df9441aca7a243bf6c2a831c62374cabf7bba1acd64a84803441d77fc2"
+    },
+    "progs/nec_rod2.mdl": {
+     "bytes": 4564,
+     "sha256": "60b0923cade4c8ab9a476cae75c7c73f71c1d13799ac7901d0be4db5d5038895"
+    },
+    "progs/nec_rod3.mdl": {
+     "bytes": 4132,
+     "sha256": "459edf5ee6ecf0c52ec83e055a2c12ad39d3d3a42a4774c442ccc686e298da47"
+    },
+    "progs/nec_rune.mdl": {
+     "bytes": 19524,
+     "sha256": "cea5c89dd0034465a54a8434bc9367554f0244c2e38ec9220cd28a5a53a444a9"
+    },
+    "progs/necro.mdl": {
+     "bytes": 577208,
+     "sha256": "a0e43517f3cb579e38baf9ee4b5058ed59036b69599c0fe3ffeff9c00ba843f8"
+    },
+    "progs/needle.mdl": {
+     "bytes": 16688,
+     "sha256": "5f714f6b43cc28ca1de1246cc0175ea2e07040f73c9d0a623dbe4b4577559c14"
+    },
+    "progs/nehjet.mdl": {
+     "bytes": 19956,
+     "sha256": "fd0346c9c37d2ca7d3e696a9ce0694652722f63326376ad3b8189fb81a68f5c3"
+    },
+    "progs/nemesant.mdl": {
+     "bytes": 202492,
+     "sha256": "099c26752c7160144a25716e0af0f30f8ff179766db4a05371a0392166f85c42"
+    },
+    "progs/null_256.spr": {
+     "bytes": 5412,
+     "sha256": "c52813b634ef1ab641fdd4c3a9739ad758f1b5c39ba5e10acbbf034ee0ff850b"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 230152,
+     "sha256": "b7c88ae295ef8fc8d17b4fd6facedbb8e464ee665039a884af8e215a3929f24a"
+    },
+    "progs/oldone.mdl": {
+     "bytes": 560224,
+     "sha256": "5690a29cb0ae1a4889bc398676db8477275b0953e2ab7bbb75b717509d93c985"
+    },
+    "progs/pl_oum.mdl": {
+     "bytes": 331236,
+     "sha256": "6939a925af5510ecece22c3cee3de418d3ba532f4eb17409ca1453d253de328c"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 55676,
+     "sha256": "c9810eaac822215e7c84f11e55bb614121d17a79a02aa162fb430b5f37664ade"
+    },
+    "progs/plasma1.mdl": {
+     "bytes": 9120,
+     "sha256": "78a81a8eaaf95f85cd0fb7bc31dfa45c30e660fc5265168178b50776afc96563"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/playham0.mdl": {
+     "bytes": 99756,
+     "sha256": "1016d24c984994843af5d086e36e548c55590018f1f6b2d78799e25a40271ec4"
+    },
+    "progs/playsaw.mdl": {
+     "bytes": 87340,
+     "sha256": "b53cffd1807a3710f03b350370d78dfdbb2b057455fcac9f00d1b0baaabbf8c9"
+    },
+    "progs/potion.mdl": {
+     "bytes": 6316,
+     "sha256": "0e66a6ced7f31e5eb23459433908995241e78835776b02037109b8aef6dad2a0"
+    },
+    "progs/potion2.mdl": {
+     "bytes": 16228,
+     "sha256": "30a97f9d1e82eccfaa88396a82ae2e21fcff08ae095b2eb17941aa1a66e69353"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 47008,
+     "sha256": "e7ba606cf1cc11d9ad5baef5aef9dfa9239b7550a1c12937965a562bc815e6a0"
+    },
+    "progs/pur_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "dbc2bf835db1c1789c329504f86802990a19288f67d9560f32cfe5a8d5a62885"
+    },
+    "progs/r_bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "2d776e4acdf20cd117f3f4d6be3647fb9d0e117756069cbfc52ece716fdbb251"
+    },
+    "progs/rain.mdl": {
+     "bytes": 39276,
+     "sha256": "9a13a2ff68c8d8eb27426cee38330a6237de8ceb9ba9ecb9b71071512b190a94"
+    },
+    "progs/rain20.mdl": {
+     "bytes": 42620,
+     "sha256": "192d3d8197976f98eb053e54a00536ca9ccc8769692e9c483990b64afa4e1d8d"
+    },
+    "progs/ranger.mdl": {
+     "bytes": 232148,
+     "sha256": "21e690b07a7d3b2b0fb630480a5fd52ea23b41a8571c3618d16ea1ab7508e52f"
+    },
+    "progs/rebel.mdl": {
+     "bytes": 215292,
+     "sha256": "433596df8d06be0882f00a2c1fad0ea49a8ae42ef148d32e0ae7c06c420322aa"
+    },
+    "progs/red_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/reflect.mdl": {
+     "bytes": 10224,
+     "sha256": "72da6cffa3556503bf43f4ccdcc9f3bc8329b20dc70f38d20fedbabc3fa280ca"
+    },
+    "progs/regen.mdl": {
+     "bytes": 50040,
+     "sha256": "9f887be71c06ab25ada96cf8c1c2a6abb68ac9610378d9e3a2abaf2fab16af86"
+    },
+    "progs/rocket1.mdl": {
+     "bytes": 34260,
+     "sha256": "c9412482647d681e08f74eb0c0260ffded91dfc67378996b86b720ef3cd2fd47"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 17204,
+     "sha256": "0dab5b94c60d92d55df3e44a8d8ea2dc0f949e98897a6525ee0be3f49a019b08"
+    },
+    "progs/s_expbig.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 165212,
+     "sha256": "5b78b324e252f95ef8f4a9fd4fb19f855c40f74fd1f93aae9b84ed822e9c3585"
+    },
+    "progs/s_fancy.spr": {
+     "bytes": 432120,
+     "sha256": "2dcb35ecb5312709ae4b295ebcf209e74a34e385823f54603e6fe0eb8999556b"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 8016,
+     "sha256": "fa366e4076268de137e0eecd88d02e3aac99f38c48c6ad0d0a74c88c95e8d4d4"
+    },
+    "progs/s_wave.spr": {
+     "bytes": 373212,
+     "sha256": "c2a3b258b2809f22247596b6e0505829853e9a5fd60fed7c471fd663cf9e9402"
+    },
+    "progs/s_wave2.spr": {
+     "bytes": 39480,
+     "sha256": "a0fbc773e66385a8bc3c16195ce14215050cbec7caa118fecae1a0c2a2c59d50"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 333284,
+     "sha256": "90757e506c9f0e49e4e9897708df4825e1b27774ff46abd9c113738380dfde62"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/samba.mdl": {
+     "bytes": 43020,
+     "sha256": "39dba9d8cffde787d988a9754fe5bdb174ac95a4828dc3ad8db3d28501bee056"
+    },
+    "progs/samtb.mdl": {
+     "bytes": 46340,
+     "sha256": "b9b0bc86545710de58d86ea5367bd1fd2040a3670b4dc89321d56024ad92aa82"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shade.mdl": {
+     "bytes": 83644,
+     "sha256": "080ad2839fafadfdbbe5412ac53061a917af3158f33e16f5df4b4f3dbe422ccb"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 128012,
+     "sha256": "94aca4b876e4794684f4f2b9e66f1c34f7b3935b0d35d406311b63aba17ea3c2"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 176048,
+     "sha256": "7ea0c1007179eb7a45112aaf38d8042213e8b644e6e79b9b1a8d4402c3843b47"
+    },
+    "progs/shubdome.mdl": {
+     "bytes": 97512,
+     "sha256": "3b92e43bc942b2cfba8c7b4e1206ad858484564d86bd7faa069db592f98c7232"
+    },
+    "progs/shubstar.mdl": {
+     "bytes": 14760,
+     "sha256": "ee5f914d7f3f930db06b1ead8d314dec0413e5182b7de24cc808076d117f3cda"
+    },
+    "progs/skulbook.mdl": {
+     "bytes": 23008,
+     "sha256": "c6e6486a3d695d8edba2b0f48fc025c1197e6411c9dae1629fd41434a5cce0e6"
+    },
+    "progs/skulhead.mdl": {
+     "bytes": 50688,
+     "sha256": "d0733746c8b7cfccdb8d0f30f9454c8863a470e6d56e8359828dbb450aade77a"
+    },
+    "progs/skullwiz.mdl": {
+     "bytes": 614880,
+     "sha256": "dd9a03586c722860a5af98510a84a9b182060187134242d1f57db1adb6c7415f"
+    },
+    "progs/skulshot.mdl": {
+     "bytes": 63400,
+     "sha256": "73d6d8e5411b9ae3cf815c3b0cf695a5633cedd5d586565880a9146a1a5db5c2"
+    },
+    "progs/smartbal.mdl": {
+     "bytes": 27924,
+     "sha256": "288e2d54afcbdc5242ab831f3ef611710317c52432e4585a938a12df80b7a07d"
+    },
+    "progs/smoke.mdl": {
+     "bytes": 184,
+     "sha256": "2086abd9950bc643446309a80d9df86b4ebe3f2086f75e799ce943a8454c77d7"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 143668,
+     "sha256": "d91fe049aaeec7fee2ce0f11795889a872d7743df773aa5cf3b9be4d817a3fd5"
+    },
+    "progs/soe_coin.mdl": {
+     "bytes": 26364,
+     "sha256": "5769371db409969600bd51d573162c663fb75d358c507fcff9a4aaea95fed4dc"
+    },
+    "progs/soe_gem.mdl": {
+     "bytes": 165236,
+     "sha256": "788f32633f1f3a9f6dd2e0c2dccb76871e02fc6e002db82a219f077dcc493c3f"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 234936,
+     "sha256": "c5900e7784535c5eda950cfdfe2cbf3d2d304b8902c2f8bd4987df87d7039cc3"
+    },
+    "progs/soul.mdl": {
+     "bytes": 8436,
+     "sha256": "eb4dc0dae8aed7c92d328096fd9633566b658c9cc65777211ade1e67c6e0ff64"
+    },
+    "progs/sp_gib.mdl": {
+     "bytes": 22228,
+     "sha256": "e902ce3a5e4be26cb781d29178b6e808c480f9e898bc50ecfa78ddf12d774238"
+    },
+    "progs/sp_gib2.mdl": {
+     "bytes": 22228,
+     "sha256": "be98f64e7c2cffce98e28d99b36856762cc15caf761015067fde234390e6b302"
+    },
+    "progs/spider.mdl": {
+     "bytes": 355540,
+     "sha256": "f791981a4d5b3fdf0f1088ea5f2ecf132107a71474052d8453204de9e3bc47c5"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "078b774958c598bdf1503934d51a1393aeb9aadebcde806db2272b04b233c6a2"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/st_gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "813d52c557a1eb519d801652b4bd63acdc4ec18d62db53d843ca3dcaa88e87e8"
+    },
+    "progs/st_gib2.mdl": {
+     "bytes": 16228,
+     "sha256": "2d40c1eb75eeb6f5e1781ee9db7a0be10e0d07297d563f9035a8965c4c8c3d01"
+    },
+    "progs/st_gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "d44a77787c5ff633593ad9741ddfbe28809431daf3d32fbe92f8512871b9018a"
+    },
+    "progs/tar_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "1ef69998430a54ba662abb46a0ef303b3bf0066f53e84b166065e79d58a72bef"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 313448,
+     "sha256": "fc63e6f62c83975ab2756f0a844d012b887491a6c73d9350dfcb04a6e0355b3c"
+    },
+    "progs/throwax2.mdl": {
+     "bytes": 34872,
+     "sha256": "11a22371cc72adf001e21d04e1b8b65e01497f56410867aa42ea21c0ff304e48"
+    },
+    "progs/throwaxe.mdl": {
+     "bytes": 56532,
+     "sha256": "0ebedab9ab397ba15dc3f0d90df703af2984d1c070eabc08ba781c308968150e"
+    },
+    "progs/throwham.mdl": {
+     "bytes": 7072,
+     "sha256": "f161fedb096a34db55fe57e84acd2bc42295ffea688549235c762b9a70430b35"
+    },
+    "progs/tome_pow.mdl": {
+     "bytes": 3068,
+     "sha256": "ebb189a77468ace8aa21bc1351b9ed5fdc97d423d5a0f48daa92fa040b364d07"
+    },
+    "progs/tree.mdl": {
+     "bytes": 126509,
+     "sha256": "7705f8b4e337bd370dbd0392d33da437f08768723e6d43725ddbb07ac3662b9b"
+    },
+    "progs/tree_zer.mdl": {
+     "bytes": 101704,
+     "sha256": "f5dad886e64ef946b0ad0aba3a06da419579911c5248ee856d2d503e40c4beab"
+    },
+    "progs/treetall.mdl": {
+     "bytes": 120532,
+     "sha256": "e74e7c38099ccc833fadf3c7b7e97f746878d07102dad8cc5926546b344cb982"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "92a88337ebfbbb81ae0ffb96e97ad9c859422db93f59e2e220578baaa6caf446"
+    },
+    "progs/v_dshot.mdl": {
+     "bytes": 77102,
+     "sha256": "8b54bab3a0fc20bbe27ed1ef204fc4dc21c8c6ab0d9a6efa82038d570de5aacf"
+    },
+    "progs/v_grpple.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_horn.mdl": {
+     "bytes": 31980,
+     "sha256": "0345396a7c52551427f5210e91745a21d822673c51fa4d1adc6625acf37563b0"
+    },
+    "progs/v_laserb.mdl": {
+     "bytes": 43852,
+     "sha256": "67e854c43efe348faffcc1aed8415a8e68fe2069ec94447a3610b580b72f3f88"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 47252,
+     "sha256": "86cb778c5e84f2523a8d47a8d1d021e46e9a6af343fd69b84805e783c800b033"
+    },
+    "progs/v_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "a2d573bdf52015bce7a571a2263a3e8d938daf0bc1b5e4589f84580cab7da2d4"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 165540,
+     "sha256": "abd6787fff37c452fa01f4bbc9eb9594311eaf4a794f161caeb5a501ab9e103f"
+    },
+    "progs/v_wand.mdl": {
+     "bytes": 27388,
+     "sha256": "b46ba82a45a24fe4833dfdfd3c9457b98096a5800d6620d6eae11895653a6698"
+    },
+    "progs/v_xbow.mdl": {
+     "bytes": 95168,
+     "sha256": "e65f7cfe84cfa7c84c34147dadcc8b5ceea9416c7e378bd2110961fd76348e70"
+    },
+    "progs/vomitus.mdl": {
+     "bytes": 79724,
+     "sha256": "03dffcc3405c63f0e0c11301a74da5403d957b66171a6f34eaf8998e4ba31550"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "7758aaf42d0d1617e4fb172ce842be4316073f63250aba46dad441327cccb2e6"
+    },
+    "progs/wanted.mdl": {
+     "bytes": 27860,
+     "sha256": "03337a468db14377fcd36842037d2a27dfb97c3d5d5f45fcfe408e79050a5839"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 67956,
+     "sha256": "39c4a5daef1cfafc1bbfff1ca8eebb5c75d27f953f31d29f249205762605a56f"
+    },
+    "progs/wings2.mdl": {
+     "bytes": 28980,
+     "sha256": "5342d6191f59e69eb830a5e833473ac253b3a7750063d5519f6d2da2b82f5573"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 109380,
+     "sha256": "d78cd5ac1d667ec808fc7664071e060cea40179a0ba094e2f4c119d5ef7a79ba"
+    },
+    "progs/wr_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "1bfb049cf920973e32d78cbf7cf8b6c0c18f8dde55006ee43798ead4b99af9a7"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 238732,
+     "sha256": "5d0f3d6b32bfec300894dbf066a15bd9e34b985919423446232ad85d2ad6d6b7"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 226776,
+     "sha256": "f4d35645fa47d159cf7dee47a1652ff239cbe7a7b3df8567b865c6d44536abf4"
+    }
+   },
    "sha256": "7eab132e93a20671d78132b667f58fadc099e2a197ad66d453ac01d190280100",
    "timestamp": "2009-09-05T15:10:00.000Z"
   },
   "pak1.pak": {
    "bytes": 11029957,
+   "files": {
+    "sound/ambience/amb21.wav": {
+     "bytes": 80716,
+     "sha256": "d664ea08d9df7e7dd135eb0726c1bc142878dcc53d13564dd3dcc5562180201a"
+    },
+    "sound/ambience/amb22.wav": {
+     "bytes": 92716,
+     "sha256": "f444289984b285a1497f55e566fbbf1896a04fa38e291efaa3ec1a0720204811"
+    },
+    "sound/ambience/amb23.wav": {
+     "bytes": 40180,
+     "sha256": "e451997ac7f37d08bd8434d708f45ee2967693317684b947ce511c9df84828b3"
+    },
+    "sound/ambience/amb24.wav": {
+     "bytes": 42282,
+     "sha256": "ead78c8507a7a6a7d6c61e913a2319964f6a8f70b5f7f720c162725edd9cd5aa"
+    },
+    "sound/ambience/brik_hit.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/brikhit2.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/chant3.wav": {
+     "bytes": 116346,
+     "sha256": "5d71f12940688414ab8cabc0d88e323dc961b60aac66f17887712133f1cb8b29"
+    },
+    "sound/ambience/current1.wav": {
+     "bytes": 50906,
+     "sha256": "dabe357d48586dccb8e1ed18c49828797c9f7a8c02c7a588ddc76a62c9b1d3e4"
+    },
+    "sound/ambience/drip_amb.wav": {
+     "bytes": 105444,
+     "sha256": "b282bc6082754011ee21a82aedb490a856c0f694f57991992296554c13149b02"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/heart.wav": {
+     "bytes": 8190,
+     "sha256": "a5b42c46cca24da59c324bb28ce6887b3a2a3baafcc18b0db2b2485f1189a4e0"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 177840,
+     "sha256": "9daec0732dcc821670b8910a1371153e3829e604b6957bf95931bea416af6074"
+    },
+    "sound/ambience/mov_watr.wav": {
+     "bytes": 44432,
+     "sha256": "9d6721844fd5559ab4f53902e70ad9789a90710dde082d222bd814a36c00ab67"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/spark2.wav": {
+     "bytes": 61640,
+     "sha256": "7eb18b00cd5e7913fea7a85ec5b1db159d1d001d24d4f687bfdb5685cb163c8e"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 106286,
+     "sha256": "056f37dfd1d5f4eba1d1911245dc0930bb0c46a84d72d867a286e5a9540248a0"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 87710,
+     "sha256": "2bb46f7c8f70fd28f0ca47b294824bcca7689047291b6c5259eebe76ad6aecfa"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 140630,
+     "sha256": "5a4dccd168cbd9f759ac468d7aa879dbcdbe5637e0fd0521f641ba1d60f61817"
+    },
+    "sound/ambience/th_clap.wav": {
+     "bytes": 570992,
+     "sha256": "5b93e5d878621c2a92e66d6214b0fa8acf8ad5a35f4120f456ddf5678e941d94"
+    },
+    "sound/ambience/th_clap1.wav": {
+     "bytes": 72062,
+     "sha256": "1fc3146d501953545b2f2f261cd2fc398959a79c753a291702609b4cdd2e8682"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/wall01.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 28798,
+     "sha256": "f66c76f07eef275e904fcc76d7ca9fc2011f3de8c61ce0b3ad035464beb7a86c"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 110578,
+     "sha256": "c3e1ccb091b9d8a06b83530b5e29b9f26f5ad8b9dcd082f3da976c3d44944b87"
+    },
+    "sound/ambience/wingend.wav": {
+     "bytes": 90874,
+     "sha256": "63e435d896b097d4dc413fb1afccc2078f1d101a4f7bfc18c4e593ca9e8b344f"
+    },
+    "sound/ambience/wingget.wav": {
+     "bytes": 65148,
+     "sha256": "533bdbd7beffa4c71c66239e3ac417f2177b20a60ed39c379c59a10b2222b367"
+    },
+    "sound/ambience/wings1.wav": {
+     "bytes": 6028,
+     "sha256": "c9e05f66a1d728a88289bc213c9f3551f1e54a4f3e8ef23ab03f8d5019e7b2c5"
+    },
+    "sound/ambience/z1m2mus.wav": {
+     "bytes": 103768,
+     "sha256": "d54261d4c9a4a8a9fe0c51eeae343c6a5b381727af88d0bae6f9b40605b8e5d3"
+    },
+    "sound/ambience/zend1.wav": {
+     "bytes": 123618,
+     "sha256": "2df6c267197b2e82241e47ce4985b04d14e1ce3cff46cebf3177369057302bb6"
+    },
+    "sound/ambience/zend2.wav": {
+     "bytes": 73742,
+     "sha256": "0ea00395004f11d41ab60352517bf5ff5c88a73b8ff2ddb3f32b5085967e3003"
+    },
+    "sound/ambience/zend6.wav": {
+     "bytes": 252626,
+     "sha256": "3f3c412e55bc7534c423c0d1bec2d817e3aea06338b4d6c3f78c4b80e55d509f"
+    },
+    "sound/ambience/zend8.wav": {
+     "bytes": 112122,
+     "sha256": "27cef28aa3d6c3ea86f0c54168db07055abfc7af284bc5a35bf53a0e53f8d677"
+    },
+    "sound/ambient/amb2.wav": {
+     "bytes": 38416,
+     "sha256": "21a4f41fb5efb52587e60395f23824ef330674a8d9499fe2cda1c91603093bfc"
+    },
+    "sound/ambient/amb7.wav": {
+     "bytes": 43020,
+     "sha256": "de7f4a0d15c711c9ca63f74ee38acf78e4ce41800900e0193a43c3e55e4efde6"
+    },
+    "sound/ambient/comphum1.wav": {
+     "bytes": 20456,
+     "sha256": "af10cad0f193d07be9c98f0dd889840fad0f54f40a61d12a1325b78033a68c8e"
+    },
+    "sound/ambient/comphum2.wav": {
+     "bytes": 72367,
+     "sha256": "fbf1ff8677cf36d78e381437f3b8e758a589a108a50c92f24c514eda06ede3f2"
+    },
+    "sound/ambient/comphum3.wav": {
+     "bytes": 116441,
+     "sha256": "62d9624940b93bcd1897abb809cb9d6f2cb3872cfd6af9a792260fb17f800150"
+    },
+    "sound/ambient/fan.wav": {
+     "bytes": 54275,
+     "sha256": "6cdc6a19b0c740d5607fa9076f749dc485483362445630877c6b59ec67085a2d"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/l_hum1.wav": {
+     "bytes": 20790,
+     "sha256": "f1b8bb19b32258ca1b126d52eb98b17c2753a255eba60864f8ad325f564681c7"
+    },
+    "sound/ambient/music1.wav": {
+     "bytes": 213944,
+     "sha256": "bf498e0cf6541b3559abd978ac420c5cb19d6542d89f19f59bdba8019dc46688"
+    },
+    "sound/ambient/pump3.wav": {
+     "bytes": 40435,
+     "sha256": "ae8ca71a1ce41bb3fa02d993930b4f100db3827ef5768326a91e61f7857370bf"
+    },
+    "sound/archer/arr2flsh.wav": {
+     "bytes": 5464,
+     "sha256": "e9a0c059430744c6546a6be4be3a1e4ac775ea6c5e6440d14611ecd8c8447d19"
+    },
+    "sound/archer/arr2wood.wav": {
+     "bytes": 5458,
+     "sha256": "97c5106007e703618291242bf1c6db9853a9d625189fc26ec9c4864436b560e3"
+    },
+    "sound/archer/arrow1.wav": {
+     "bytes": 2296,
+     "sha256": "4aeac8630ff6036f095a251a018eea5baad7a59bd7e46f624dbfec793e44d7b4"
+    },
+    "sound/archer/arrow2.wav": {
+     "bytes": 3196,
+     "sha256": "0a2734df5a69f6407ffc34ab05d8655da5d7dc0e487627932390fa6cec022083"
+    },
+    "sound/archer/arrow3.wav": {
+     "bytes": 2156,
+     "sha256": "1b866280829cb7ac051f90609baa8db285f3bfa3a27b5814e72b021b7cc05785"
+    },
+    "sound/archer/arrowbrk.wav": {
+     "bytes": 5002,
+     "sha256": "f72e35d5232f40e503192ff0ee26fe152eb42e5ee7141b2bea33a9f12f38aa2b"
+    },
+    "sound/archer/arrowg.wav": {
+     "bytes": 15132,
+     "sha256": "8ec5ee520f81c69ba367ae549a06d5ea1643b43f81dea7d8345561c94c8412ed"
+    },
+    "sound/archer/arrowmet1.wav": {
+     "bytes": 2638,
+     "sha256": "87e6ef50bfe4dabf48a1fba18ad0138bbd298965f1a9d06e2b059019e6f74b60"
+    },
+    "sound/archer/arrowmet2.wav": {
+     "bytes": 3118,
+     "sha256": "2797466dafd51473b8b6b5fd3d02a5baa4fe92a1bf9342fb038a299230037138"
+    },
+    "sound/archer/arrowmet3.wav": {
+     "bytes": 2804,
+     "sha256": "1e77951ec2218add2a8bc1633a925e4a96d2ca247d7b5dfaaaefd7a9a4f2363f"
+    },
+    "sound/archer/arrowr.wav": {
+     "bytes": 9458,
+     "sha256": "10e4bef745e55fddd004ea78d24edb9d3d9edc1ce3053c377be07be27a4da144"
+    },
+    "sound/archer/crash.wav": {
+     "bytes": 11069,
+     "sha256": "60e704bdfdb0a97863b00f3514130a172b95a86bebbf89642b65a6e757a74259"
+    },
+    "sound/archer/death.wav": {
+     "bytes": 9526,
+     "sha256": "e824b3d7d66e8bfc3ce30cc3116eab1b2d2dbc09c6311f91ff25d3e7eaef19f5"
+    },
+    "sound/archer/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/archer/draw.wav": {
+     "bytes": 6874,
+     "sha256": "c94e5cec38dc40102beebd067554c91e63b86e5c1ef11dc17976733bd9f08ce3"
+    },
+    "sound/archer/explode.wav": {
+     "bytes": 17788,
+     "sha256": "1f7d6debef492f0861ee24049ad637a11b85d595cdf3f6d6aac422b7a0376d14"
+    },
+    "sound/archer/growl.wav": {
+     "bytes": 9240,
+     "sha256": "7bdbbd23b3fe056cd1d904124824aa0044acf3aa19ec88f65e092fd13e4b9437"
+    },
+    "sound/archer/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/archer/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/archer/pain.wav": {
+     "bytes": 5082,
+     "sha256": "5347daf1a9263320f25b2a191895fbf6c85278f1fde6ca5962c09ed38e0b37b0"
+    },
+    "sound/archer/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/archer/sight.wav": {
+     "bytes": 16866,
+     "sha256": "bcd12d078e7bc34f0bdea7ae9a34ccd2c9bacb049617329b44f8301c34fffeb0"
+    },
+    "sound/archer/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/bane/death.wav": {
+     "bytes": 10935,
+     "sha256": "7e4775bc543acfb421a446a00efff6d9d5669fafb2387464cb1e1ae3db91efe8"
+    },
+    "sound/bane/growl.wav": {
+     "bytes": 9045,
+     "sha256": "86e7b3d2e685d7c20e503bdffe676727426b606ef069f4b70f182601e910ec4e"
+    },
+    "sound/bane/hit.wav": {
+     "bytes": 3884,
+     "sha256": "228faf88857d697f4d5fb9b9c03f000af4dbc8b254791e18e973fd48cc96db9b"
+    },
+    "sound/bane/laugh.wav": {
+     "bytes": 22108,
+     "sha256": "ae8e8d13e00f41bce729977f09a92806c8451ebe5cb4e8618a6b79df4d70296c"
+    },
+    "sound/bane/laugh2.wav": {
+     "bytes": 31560,
+     "sha256": "5cc5ff4c3be35eec90eaaa6579a55fa843843ad658e2e4bbb258a77f6e410020"
+    },
+    "sound/bane/pain.wav": {
+     "bytes": 9325,
+     "sha256": "1d4cfac1f9dfa1ec6958b18014ec7be18dc2615e64888d3c584d50bb48e51013"
+    },
+    "sound/bane/sight.wav": {
+     "bytes": 22962,
+     "sha256": "fbaabe115d9ca4b985c4481ccc71e6b6f55931394a29a6c51ec97e752ed3d5be"
+    },
+    "sound/bane/thunder.wav": {
+     "bytes": 43130,
+     "sha256": "cb355478e38df678e859557a0f983120a4d4275272d8ebedcae7c9cccf659bc4"
+    },
+    "sound/baron/bpain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/death.wav": {
+     "bytes": 8576,
+     "sha256": "3dd3a23d5a913548d0d0aa6ee1b455017648fcd4830f204539a1626c2ec8e1c9"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/fireball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/icefire.wav": {
+     "bytes": 8858,
+     "sha256": "b529a958de192b59438989c6b98eb50f858273febab53a238b651c70a3c92098"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/shard.wav": {
+     "bytes": 14324,
+     "sha256": "313428dd2cb681a38ad89983ab39b18979f64b3e398104b1ad80f3dc9726616c"
+    },
+    "sound/baron/sight.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/bishop/conjure.wav": {
+     "bytes": 54627,
+     "sha256": "532d4b7d5db6a654aa73dfe18fa0f6a71623acfd804a848f106b0af699022bc4"
+    },
+    "sound/bishop/journey.wav": {
+     "bytes": 42051,
+     "sha256": "0995e55661447c53c3a36ae4552ea2e0bb7ec8b178bf52cdabe9d28b4deaa50c"
+    },
+    "sound/bishop/rip.wav": {
+     "bytes": 31906,
+     "sha256": "7070871da7ec08da6260a65f1a98ed1bf9682b1c95c51cea262a4b88a63fb6ca"
+    },
+    "sound/bishop/rot.wav": {
+     "bytes": 22463,
+     "sha256": "866b836874ba611d70675e5e3b83eac059c927bef0e0d1396f2183ea01bcc203"
+    },
+    "sound/bishop/skull.wav": {
+     "bytes": 34293,
+     "sha256": "48836a4d60ed8962ed0f11bffdcca95a200645e3b2cfa49a598d6392e10dc153"
+    },
+    "sound/boss1/explode.wav": {
+     "bytes": 27690,
+     "sha256": "b7eebbb64696612ee18d8d1e25b9c5cc334a4562cb99758a446a22490215f349"
+    },
+    "sound/boss1/explode2.wav": {
+     "bytes": 14798,
+     "sha256": "4c6b14b163905823f629644fbec088f37f712cf7f76e10e2f91ef23f2b573ae6"
+    },
+    "sound/boss1/explode3.wav": {
+     "bytes": 19028,
+     "sha256": "69ef0c65811704d8996b726d6e2cbcf70528d3ca7b2f28ec8814c20e7ab76ad7"
+    },
+    "sound/boss2/pain.wav": {
+     "bytes": 84796,
+     "sha256": "b9c255890f61771966327ad49994306a1e3de4b702163a079b5a733b4016810a"
+    },
+    "sound/cube/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/cube/bc_attck.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/cube/bc_gulp.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/cube/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15692,
+     "sha256": "72e737f04f1d34044dfd812c6b0e233cd38a91e6b089633e312678756952de87"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16625,
+     "sha256": "bd4cd7902712282ef8f2f749e6fcf805c2ac5212994fbb1c22fc0fe0ea5d08e2"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15527,
+     "sha256": "0b472a984137667f4788336a4f7c60e07a8893f47317b2a158aeea39920d729f"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4107,
+     "sha256": "8fe56b192838dafdf7ff4737cf1e5555d3295cbca49c1ab83568281ee188153c"
+    },
+    "sound/cyber/cybidle.wav": {
+     "bytes": 11894,
+     "sha256": "af7b96ed2eb5bc55900957b3e4136bd5dd93a72dcebca3bc2eb67cdc5186d32c"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8122,
+     "sha256": "3ea23b8d7a68e754211a10a5338b0c8d65df6e2138d4cfe06cc053b9a0f601ae"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13081,
+     "sha256": "a5ec6d4eaa707ad0246b7a7e7737b1007043ea5e5634f6f63661ecc20c27c459"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48508,
+     "sha256": "b7aac875623f8dca7597eff3dcab5910453d043fd1f9df20da89232ce8bf9306"
+    },
+    "sound/darklord/death.wav": {
+     "bytes": 10761,
+     "sha256": "7f32e12c649aa4fc4c2edb773c45b6b4258d048176d95e060390834ee7b52493"
+    },
+    "sound/darklord/idle1.wav": {
+     "bytes": 5632,
+     "sha256": "c151a3cf537f5c3668fc116e6ef5c70c9286e8a12097f376ecdf8a04774926a1"
+    },
+    "sound/darklord/pain.wav": {
+     "bytes": 12684,
+     "sha256": "f332a8cdf67fe414966f59d46714154c94de7ebcca3880a47ef5bbdad2c03ef0"
+    },
+    "sound/darklord/sight.wav": {
+     "bytes": 16832,
+     "sha256": "9710267844facf1c627ea0a8f0df458d847eb899dccd9c570e9d967acc64fa07"
+    },
+    "sound/darklord/sword1.wav": {
+     "bytes": 15982,
+     "sha256": "d36670980603c18a67d500707de9db5a8d54128601d6a6c67f7f29677244aebc"
+    },
+    "sound/darklord/sword2.wav": {
+     "bytes": 12434,
+     "sha256": "f7730881c690e0ee6a440756f74630a21241239fd1fd3bbdfd88000c7e57d1cc"
+    },
+    "sound/dragon/acid.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/death1.wav": {
+     "bytes": 18358,
+     "sha256": "645baa1cccaf1dfbcd628d17fd8ea290f42f1bc40903e26c79a536a6d1528a2a"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/fly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/flywater.wav": {
+     "bytes": 11034,
+     "sha256": "68cac399467a55df3c80331696869309eea2339467df0ba94408be4fa2afeb3e"
+    },
+    "sound/dragon/ice.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/icehit.wav": {
+     "bytes": 9370,
+     "sha256": "089c07d0352678106aaa1c47f015792393d5aa01b4bd64fa35e798c4ee09108b"
+    },
+    "sound/dragon/idle1.wav": {
+     "bytes": 34068,
+     "sha256": "3a125f0bcf2908e4ba3af298b117f71c0efa43be4077e53c791b2805cce6a038"
+    },
+    "sound/dragon/idle2.wav": {
+     "bytes": 21474,
+     "sha256": "e1101ff0121687511a9c978d0a30a945421d0a2a30b7d139e4427d41dcc17628"
+    },
+    "sound/dragon/pain1.wav": {
+     "bytes": 6524,
+     "sha256": "6cdce2fde3a1eb328007e0667c5dfe705e87bcd526e416ac948fa11a36448ac0"
+    },
+    "sound/dragon/pain2.wav": {
+     "bytes": 6875,
+     "sha256": "3238b77aafcc60c634cbdbd47ae1eec99bb969e2161b72ce5623398e6a451d2a"
+    },
+    "sound/dragon/sight1.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/sight2.wav": {
+     "bytes": 15205,
+     "sha256": "197238a35261e6792c40a4da38ba7b3827116ac1af5f143e092768346605b470"
+    },
+    "sound/drone/drnblip.wav": {
+     "bytes": 2106,
+     "sha256": "b372ece13de5edfb22d88ff147a9eccfddfe446c9403607d89daae09fc7c8b68"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/force/force1.wav": {
+     "bytes": 30022,
+     "sha256": "b609981695694648cab0f2ed521dbf3d6f31b6c2e8c3e8502ab4740c7a105557"
+    },
+    "sound/force/force2.wav": {
+     "bytes": 10252,
+     "sha256": "32c0342dbc9e63220db18fa706ac0fc1afe9a86f4d488e509e1f52bee955e3cd"
+    },
+    "sound/force/force3.wav": {
+     "bytes": 10252,
+     "sha256": "0317e18dab002184b5ce11a2b86f3263d2606c40f2dc435c824bbd075c1b621b"
+    },
+    "sound/force/fusein.wav": {
+     "bytes": 13669,
+     "sha256": "53192c25adab70ebcf471204aa194ef9d34c4161138c728d95f84cf08310a879"
+    },
+    "sound/force/fuseout.wav": {
+     "bytes": 15379,
+     "sha256": "f515c6b48204f2ba158e99c10a9da60cc45756ea5dca716e256ffbe54a017512"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/goblin/death1.wav": {
+     "bytes": 13890,
+     "sha256": "bed0d074d9aeee8f046ec7b3a9d33e02d157374ddf6af1296bd1ca7bebf30f10"
+    },
+    "sound/goblin/death2.wav": {
+     "bytes": 10280,
+     "sha256": "9cc07020579d50185ea401835e41edbd1c8f007065e39a6306c7aab4f32e7781"
+    },
+    "sound/goblin/idle1.wav": {
+     "bytes": 9802,
+     "sha256": "6c5a8c36eedb0ac5bddacfdf68250c36fe472f9d87e8969b4f95a863a99b77ce"
+    },
+    "sound/goblin/idle2.wav": {
+     "bytes": 9242,
+     "sha256": "5850c885e59ef04ae90be0579dd6f6b7cc26c282045ccb163dab2c9e19fea704"
+    },
+    "sound/goblin/pain1.wav": {
+     "bytes": 5118,
+     "sha256": "8afd94fcaa2d20e7c6626eda0c6cd5463670a1dbed0eeea36da588b28196c8a2"
+    },
+    "sound/goblin/pain2.wav": {
+     "bytes": 7898,
+     "sha256": "ad1f3b63b4ae35e4bfe010447bbd18bb85cd2bbf966ea7e1370afb0e924e699c"
+    },
+    "sound/goblin/sight1.wav": {
+     "bytes": 12716,
+     "sha256": "1c20028239d217f31af57649da5d1a6def576569ef5fc7e7033c2acbef7f9345"
+    },
+    "sound/goblin/sight2.wav": {
+     "bytes": 19356,
+     "sha256": "c9182325cacd9734bfedd48cb5d8076d5823b7a94baa40d32b02de9504474b48"
+    },
+    "sound/goblin/sight3.wav": {
+     "bytes": 8526,
+     "sha256": "796b2f9f0a1c20d672382c6681e9a6ea200fee2cfcacb5b3d3faa72c8e2537d4"
+    },
+    "sound/goblin/sight4.wav": {
+     "bytes": 8668,
+     "sha256": "c0a60baf2b9918a6df5fc32cd8b58c9fa7cfed923a4cb21c841f04f7a544782e"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 27521,
+     "sha256": "424ceef852229e94dbbbc879f1546a8dfda90db93c6263700cf4973805e4bea7"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 16192,
+     "sha256": "98d55bc63eff48521faeed1046064569e932986e734168ba0973c184aa2f5d12"
+    },
+    "sound/golem/step.wav": {
+     "bytes": 11226,
+     "sha256": "851e243a2e6ecf4cb637f8c4368b0f25443d4f9d104733eecfa886c40ee92bcc"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 47176,
+     "sha256": "87f013eb50cb30a967a183f0cfa41b4848f9269afd13dbe1ab5053458bfc5f0e"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 10768,
+     "sha256": "c48f2415db3a5067dfbd99ad580e3f4809532743d653eafe2fdb924fb0bb832e"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 47502,
+     "sha256": "a0c0bd639af614c7714388009c9388f6db9a694e7ecd8fac38653609d6958f61"
+    },
+    "sound/gunner/death1.wav": {
+     "bytes": 67190,
+     "sha256": "14f89744b8f7225e0eefd9e291aee533fd9f759b6351b57d357d9597dba90956"
+    },
+    "sound/gunner/death2.wav": {
+     "bytes": 48066,
+     "sha256": "693d0d1142dfa12ce2dd1d7b959094c201f3bf783114064c29a572dffe2fcfe0"
+    },
+    "sound/gunner/idle.wav": {
+     "bytes": 18376,
+     "sha256": "6c5b1f1d39f1cc78e87cdbf584b8a508fadc99fc2b8b85d21d0e088d134a8b2b"
+    },
+    "sound/gunner/pain1.wav": {
+     "bytes": 17292,
+     "sha256": "afee7d4ac4f872716fe3deb5adced9a99bd3744784329bd12608d051b81ebfc7"
+    },
+    "sound/gunner/pain2.wav": {
+     "bytes": 20282,
+     "sha256": "38d472d2eaaa7638f7980a06a36043353e86d99aa7e86e0132c52639738c87b2"
+    },
+    "sound/gunner/sight.wav": {
+     "bytes": 22572,
+     "sha256": "395e28b6a4684ce2fa10f085f67d58d025421c594e65a0c2a1b67aeab2ee2569"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hkboss/iceball.wav": {
+     "bytes": 14990,
+     "sha256": "6aec96fda55dfb0120f106064cd324ea6e059bab3fdbb2d81cda297f9a82e02b"
+    },
+    "sound/imp/die.wav": {
+     "bytes": 8448,
+     "sha256": "a8b0e037b88829b978d3dbd3d5e657c7f775c73662d554f6247a387ba333d4bb"
+    },
+    "sound/imp/diebig.wav": {
+     "bytes": 14956,
+     "sha256": "d44d390ba11f8850105fd9601f026cb66525a415de7fc363d3574c86b72d22c4"
+    },
+    "sound/imp/fireball.wav": {
+     "bytes": 5492,
+     "sha256": "6362b59ded89655fa8b8877ed2639eca1a7aae1847306bbc3843fa98bedcbdaf"
+    },
+    "sound/imp/fly.wav": {
+     "bytes": 9204,
+     "sha256": "8036ccb256978c17234aa171267fb0332f1911b5f0dad7b9f74bba9378c39a37"
+    },
+    "sound/imp/flybig.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/imp/flywater.wav": {
+     "bytes": 9800,
+     "sha256": "c80045609b62ceb61bd8fb1a18a53c0f2fd5443502a802b0d6d3c61e9a1db4c0"
+    },
+    "sound/imp/shard.wav": {
+     "bytes": 10678,
+     "sha256": "f806167fe23f37826964c0cc345c438ff0e79c3ffb1fed2c85451c675448cae4"
+    },
+    "sound/imp/swoop.wav": {
+     "bytes": 10842,
+     "sha256": "100eacded51635de912cee171f093e869d24589c44f68887497fe751cf9b1e4d"
+    },
+    "sound/imp/swoopbig.wav": {
+     "bytes": 14012,
+     "sha256": "65d4de49684f2f9e2655abf8e4bf042a08bd706ec4971e6397f264f7274e2b63"
+    },
+    "sound/imp/swoophit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/imp/up.wav": {
+     "bytes": 12500,
+     "sha256": "874b533da43f713a1be27fbccadda8b6392fa8e689c8c4d17dac4b0d380f5822"
+    },
+    "sound/imp/upbig.wav": {
+     "bytes": 21472,
+     "sha256": "36c7bc087935cf7cd33482a50a75df75fc2bfbe53ca0ebcd9797a8bdbde73652"
+    },
+    "sound/items/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items/equalize.wav": {
+     "bytes": 13008,
+     "sha256": "933046049bae4d866250ad9a6e0a4b2a9385caffb4156daaca39ff7110a71126"
+    },
+    "sound/items/levitate.wav": {
+     "bytes": 44236,
+     "sha256": "8a04ce4a97dc22d095bc52d08111bcaaf5f57482f580ccbe0c61bdf8fd18913f"
+    },
+    "sound/items/life_up.wav": {
+     "bytes": 8660,
+     "sha256": "2712bd978343d4170bc1757706597d4de3940a07b6847977cbf117fa92f14c31"
+    },
+    "sound/items/money.wav": {
+     "bytes": 5100,
+     "sha256": "e4ac299499340c1be250f5d5e0824440d9e539de8a1d5b01e303056719cf822f"
+    },
+    "sound/items/quaff.wav": {
+     "bytes": 3748,
+     "sha256": "ebaa4ecc17dc67d3fbc5fe1a7541e4e19769ce941d043922f8572cb2da8d3cdd"
+    },
+    "sound/items/reflect.wav": {
+     "bytes": 14936,
+     "sha256": "90dd50b25175c8d514a52165429e9ca6b90c45dddbb0f301e5873146b4a4a06c"
+    },
+    "sound/items/reflect2.wav": {
+     "bytes": 33119,
+     "sha256": "5fb5afe50e0f5fa24f1c4481b3060ae222f40138ca81052cea047a57aa6b03e8"
+    },
+    "sound/items/reflect3.wav": {
+     "bytes": 7804,
+     "sha256": "a079e5aef6ed9fb7d5c992b0ef8e11932a9efa192eedac2bc530098e0550984a"
+    },
+    "sound/items/regen.wav": {
+     "bytes": 7984,
+     "sha256": "1e125e8e7c19f29eaf09b7ad301fdfe5126d922dfa84ba2af267cdf3351b6498"
+    },
+    "sound/items/shambler.wav": {
+     "bytes": 20182,
+     "sha256": "f0cdf78367b770c97b3b89abedb7c4fb0a9ee10d742acc8c98b3daba46cfc215"
+    },
+    "sound/items/tomepow.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/items/tomepow2.wav": {
+     "bytes": 33119,
+     "sha256": "1e2e62a6f251722741b7f0adeb38c59a1d05917d0f84c8f48922efece97f02e2"
+    },
+    "sound/items/treasure.wav": {
+     "bytes": 5554,
+     "sha256": "c86f66148e8dc99af2c8e877d64d06dc1c35d0caa9c6dc5c8092b268960b8edd"
+    },
+    "sound/laugh.wav": {
+     "bytes": 71573,
+     "sha256": "cb8e1381c70240a93233b8571d792e21950d00b1285f867cbc0ed1237dac1df7"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/b_rot2.wav": {
+     "bytes": 15436,
+     "sha256": "62c86077b7a29f48f5c872c68d262c03b73b57f876b718a05f2fc6b24b9a9ef4"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/bellring.wav": {
+     "bytes": 27600,
+     "sha256": "fe3b2972c722171144eaba160757803292a42342e737d6acdbd0b14802e686f2"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/dsslop.wav": {
+     "bytes": 11163,
+     "sha256": "b6a9f6e74b222169c87e6c56b47d2e7995b23b8b045f16be968f43290f22cf9d"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/met2wd.wav": {
+     "bytes": 3968,
+     "sha256": "a3ce3e10b609f7ae28fc6f39f1f5d55a7c99a41143fb161de7e4e47b7f40f100"
+    },
+    "sound/misc/metalbrk.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/mgboat.wav": {
+     "bytes": 26866,
+     "sha256": "666016e2aa958ea621ba03bee4339518f2ccc72aa3ee2d0838ef9032e8ffc981"
+    },
+    "sound/misc/pushmetl.wav": {
+     "bytes": 14042,
+     "sha256": "2657b0006f51ecb7077b5861b1b282e0bb8bef3bdd5ccb68b3bdd6794361099e"
+    },
+    "sound/misc/pushston.wav": {
+     "bytes": 11490,
+     "sha256": "f457b95dad6131472475ab22d9c260adf5d389e74629cd8ea36ca05ad7d4e749"
+    },
+    "sound/misc/pushwood.wav": {
+     "bytes": 13602,
+     "sha256": "7c3fa06978f8c7b632d12bbf1031a5ac316b44fdc5efd93338ab0a0a162bdf3a"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/rublexp.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/misc/woodbrk.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/music/pkdream.wav": {
+     "bytes": 154898,
+     "sha256": "df8857901002ce9dde3c558743c94967db11cae4af3d9a0cdc00c8cc09e6a910"
+    },
+    "sound/necro/att_a.wav": {
+     "bytes": 8522,
+     "sha256": "a946c060cab5ee1bfff2d1af87cd71c9ccf63840a2751fd46fd32f387bee2c35"
+    },
+    "sound/necro/att_a2.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/necro/att_w.wav": {
+     "bytes": 26298,
+     "sha256": "9ae481ad41d16610b597989e82a8bbf9c35a74fe03a8e27900d72ff8b52e3c94"
+    },
+    "sound/necro/curse.wav": {
+     "bytes": 16852,
+     "sha256": "d3729c83c468d9320cf1f8914c8b52d446e818852c955d8d86a093c35c196b58"
+    },
+    "sound/necro/death1.wav": {
+     "bytes": 24010,
+     "sha256": "302e58b0f701ad07ade4a46d5cd3bd9c2186b2df3eb39e36c361918a72ccd24d"
+    },
+    "sound/necro/death2.wav": {
+     "bytes": 23594,
+     "sha256": "05f15a8430885b6688587eba5e249107c3e6df36d7937a3ddd2411d275e8842b"
+    },
+    "sound/necro/idle1.wav": {
+     "bytes": 49212,
+     "sha256": "737f382e89a40fc098214b77e9165e16f2a06323c07e910f336f2616b6ca87b4"
+    },
+    "sound/necro/idle2.wav": {
+     "bytes": 47120,
+     "sha256": "18893e7b31ff448831a7b7a5aa9a5d31b2dcd6e49ae8b58d5eea8b44683415dc"
+    },
+    "sound/necro/pain1.wav": {
+     "bytes": 19412,
+     "sha256": "f37e247a9e1436e4a86b78fe71e1ea6da43323e60943e86784ac87fc4393333b"
+    },
+    "sound/necro/pop.wav": {
+     "bytes": 18996,
+     "sha256": "22aff5a83ec82e759004d82308b2e210f824ac59bd3180d6b688c9d0134ca18e"
+    },
+    "sound/necro/pop1.wav": {
+     "bytes": 10836,
+     "sha256": "d5e9b7ce5a638a419eef07bba492ce75fb3d8002bd66b40d36b4dd89ad859e1c"
+    },
+    "sound/necro/pop2.wav": {
+     "bytes": 11228,
+     "sha256": "10947cad6cd5bcc0e0bc00fdbeccccd53b70bff1fda1a220c72ddc7e2b152b08"
+    },
+    "sound/necro/pop3.wav": {
+     "bytes": 11228,
+     "sha256": "56c4219dc0ecfb7ee8ff6d31fdf6c8c53c2b6990ce1b94ed956caee3c7cf83db"
+    },
+    "sound/necro/pop4.wav": {
+     "bytes": 10836,
+     "sha256": "451b660c65ebd2c7c89134896ed882d738c685f787810e1245587c0c28c38141"
+    },
+    "sound/necro/raise.wav": {
+     "bytes": 9688,
+     "sha256": "1c841e33f22cdcd5276bba9018aec5dae8c0f842da07eb261f48f1a6cc4c8314"
+    },
+    "sound/necro/sight1.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/necro/summon.wav": {
+     "bytes": 16308,
+     "sha256": "b7fc855d38431ac04e09389d7caf04bf0032d2b4edf86ebd795f1ab38d9feaf5"
+    },
+    "sound/necro/x_armor.wav": {
+     "bytes": 17988,
+     "sha256": "61b518c8ad8410a17eaca28ee190d96a0c3d1dc755593872d7ec5429c8c19157"
+    },
+    "sound/necro/x_damage.wav": {
+     "bytes": 14772,
+     "sha256": "f74f64e3f47cee7c9b424b94a426f93c133d8acc1e6cb15551a72ab361fe95c4"
+    },
+    "sound/necro/x_leech.wav": {
+     "bytes": 16692,
+     "sha256": "78aacf297df09e21645c2e04ccf181266c35c8e52303ecb498c90db33e8c7b27"
+    },
+    "sound/necro/x_muddle.wav": {
+     "bytes": 18932,
+     "sha256": "b85810135fb3eca3f141047a08cd42a0e527d6da6e9fcfca3887a15f89edad6b"
+    },
+    "sound/necro/x_weaken.wav": {
+     "bytes": 15946,
+     "sha256": "f98441764b5f258ee875090c73e5841f4c8f97decbfbd8d9da836a7aac30f430"
+    },
+    "sound/nemesant/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/nemesant/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/nemesant/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/nemesant/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/nemesant/push.wav": {
+     "bytes": 8812,
+     "sha256": "91398e953b648ab23c037940fb7996f3d77727003a60757ea50686328c05cd69"
+    },
+    "sound/nemesant/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/nemesant/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/nemesant/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/nemesant/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/nemesant/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/nemesant/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/nemesant/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    },
+    "sound/pendulum/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/plasma/explode.wav": {
+     "bytes": 29598,
+     "sha256": "7a95a8337c7ad87faccc1cae98ad7840352b08608fba08aff87a1b33610f9190"
+    },
+    "sound/plasma/fire.wav": {
+     "bytes": 22422,
+     "sha256": "7350d1e99f93a79bee84e94561e080dcb8448a3549a42742633cf604377a5097"
+    },
+    "sound/plasma/flight.wav": {
+     "bytes": 17494,
+     "sha256": "a03b46f31df3495a1b7a2b2f1a09f3e5223d4c0ab65aa0ed936e1445e893adeb"
+    },
+    "sound/ra/1.wav": {
+     "bytes": 7098,
+     "sha256": "6f41307a1d8a57f67917520d9c517df7b5e403f6e4f27b8c4b464ae1a57a4945"
+    },
+    "sound/ra/2.wav": {
+     "bytes": 6138,
+     "sha256": "6db176165cca16a7bd0538b77cf5dc6a68343ce13be3c5e716b61c7e5fc8840f"
+    },
+    "sound/ra/3.wav": {
+     "bytes": 8298,
+     "sha256": "bb0395f548fff802c76a113a521f0fc7a31029f7c701cd4ac4c6b954452286f3"
+    },
+    "sound/ra/fight.wav": {
+     "bytes": 10218,
+     "sha256": "69b9e0165290de5760a4ade9cba2b412d2a8f5777ece37f1f80a82e6cdf2b979"
+    },
+    "sound/ranger/idle.wav": {
+     "bytes": 10819,
+     "sha256": "644fbbc14e20684fa31abc7f04969943ac950c33435271b0fa646aa324be4400"
+    },
+    "sound/ranger/sight1.wav": {
+     "bytes": 5379,
+     "sha256": "5023e2483fe5c1c37cd661d382e34c0b68eafe4bae0e35e8f3f7e516e78dcf51"
+    },
+    "sound/ranger/sight2.wav": {
+     "bytes": 11323,
+     "sha256": "3574f035e1a261b9a001d99a54bdb502da31da2639d95e7fc06f96b547c1ac44"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight1.wav": {
+     "bytes": 35068,
+     "sha256": "48db878a4eae15b37ee0ca333aae74d310103a9eaf2e4b35eecd43a89f626b9a"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk1.wav": {
+     "bytes": 19372,
+     "sha256": "42e41297df70202ec9965af7af5fcdabcab7fde43ba515c8ba0a1ee2e4429554"
+    },
+    "sound/shade/death.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/shade/death2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/shade/fly.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/shade/idle.wav": {
+     "bytes": 37192,
+     "sha256": "57b0a0a7a0e75a17df8c4bb68740b23325bd0bf3475d908ee92fa0522c71edf7"
+    },
+    "sound/shade/moan.wav": {
+     "bytes": 33684,
+     "sha256": "3a6644f2c0a6ead5992fa9752ec9b0d898f4c40f5a32b12fd61aa991f75fa0c7"
+    },
+    "sound/shade/pain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/shade/pain2.wav": {
+     "bytes": 8918,
+     "sha256": "c6fa3ba7c659faf38b00af9c9867c37ba730cbc662125f5307f755515243dc4c"
+    },
+    "sound/shade/screech.wav": {
+     "bytes": 28244,
+     "sha256": "55ef2615baa6ce39733892fc9538f702acc567f65250223329f15b191d9b1a47"
+    },
+    "sound/shade/sing.wav": {
+     "bytes": 35654,
+     "sha256": "9de82a1d3124c391466004aea5e8ad066bcc6ede2715e7978a92a2c8f66e3f6b"
+    },
+    "sound/shade/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/shade/taunt.wav": {
+     "bytes": 36418,
+     "sha256": "f556cad612249e63690ac28b17405eba70e3df43560c3a087062b9f330811720"
+    },
+    "sound/shade/taunt2.wav": {
+     "bytes": 28160,
+     "sha256": "a68174008206b79794d8d52fd027daf08767ce005189860c815cda021080363c"
+    },
+    "sound/shamvile/burn.wav": {
+     "bytes": 11316,
+     "sha256": "239c51d5cfb82ee7683075f6cd53d8a16fcc2da608c9db87c27fd7491160a627"
+    },
+    "sound/shamvile/melee1.wav": {
+     "bytes": 4700,
+     "sha256": "f418a627faa0b4630588914ecdd466c387e1d7d5ac2e09acecafa13baf33f10c"
+    },
+    "sound/shamvile/melee2.wav": {
+     "bytes": 6252,
+     "sha256": "dfeb5bcd8be8d9f1fcf52f89cf0af533ec28066eb0bf74e3ac4b588ca810f372"
+    },
+    "sound/shamvile/melee3.wav": {
+     "bytes": 13236,
+     "sha256": "7102a987921e4c291175ba252628613c2c6ecdb70e9a33e174b6bcf7addc239c"
+    },
+    "sound/shamvile/melee4.wav": {
+     "bytes": 9211,
+     "sha256": "da31a8531703998c06bc33c94639d5dd291c9ba24e6752599ec8e6113d3753b5"
+    },
+    "sound/shamvile/sdeath.wav": {
+     "bytes": 20996,
+     "sha256": "e27d5870c37ce74877a2681b5e9cef437d14b05c501fb93733c8e93d2d2b0931"
+    },
+    "sound/shamvile/shurt2.wav": {
+     "bytes": 3924,
+     "sha256": "541c66bfaf5f30c55d24c4013f4a8859159ebfdf2f054c681eb8b8200dba1c85"
+    },
+    "sound/shamvile/sidle.wav": {
+     "bytes": 5476,
+     "sha256": "ca3edcb476f3992027989a2a79ef21a7f8951965c8a0e77f89f0a0505f2d2b52"
+    },
+    "sound/shamvile/sidle2.wav": {
+     "bytes": 21511,
+     "sha256": "0e46d4e53c003136881723f59de4d706151b845d57608cd87361018acb7ef050"
+    },
+    "sound/shamvile/ssight.wav": {
+     "bytes": 15564,
+     "sha256": "5a5343f95ee503f1b481ef05499e023b681402b922600979367788f2fb91397c"
+    },
+    "sound/shamvile/ssight2.wav": {
+     "bytes": 27204,
+     "sha256": "2b22c0912485569f7ec87a32a29c88563c0cb8261b4428335540fc96f7e7cb52"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 19642,
+     "sha256": "91eba6c478e8475696f07079502af32d1817e3fb86418c32801846582f27561d"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 18166,
+     "sha256": "91301f18c459286798989dd164ae08f5e77433ac7a0b5c71522cf59e49bf1a30"
+    },
+    "sound/skullwiz/blinkspk.wav": {
+     "bytes": 31420,
+     "sha256": "48a4dbd2add9021727d4572af9ac4c6f333a9e2ace5fe7127ddd42c84a2ae1f4"
+    },
+    "sound/skullwiz/blnkspk2.wav": {
+     "bytes": 41834,
+     "sha256": "fc2602275102b7e1a577c30b7ab3ac2709881eb3a8798664577f8a65a9132754"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 23034,
+     "sha256": "0eb20419acddee8a5814ecad8888348f90a14db997af1045b02b6052dccd5fd1"
+    },
+    "sound/skullwiz/death2.wav": {
+     "bytes": 32314,
+     "sha256": "3b1d2ed146a334ba5cf77027faa47addbf45c51159ff9c7278a97dda8ed7ef82"
+    },
+    "sound/skullwiz/firemisl.wav": {
+     "bytes": 12186,
+     "sha256": "3583544b6d7105d5b029a490cb0730190ae9e8dc5ca8f9da1deae4ea0335e964"
+    },
+    "sound/skullwiz/gate.wav": {
+     "bytes": 16156,
+     "sha256": "5797c6450d14f363133be23d93c829a660f9b7692c07f905b5a723cda8075c55"
+    },
+    "sound/skullwiz/gatespk.wav": {
+     "bytes": 30092,
+     "sha256": "f9fc90ba497d650acfad76c42ed531314828093f114c69c28fd1611d326fab2e"
+    },
+    "sound/skullwiz/growl.wav": {
+     "bytes": 18944,
+     "sha256": "de58ed34dd69dc3e871d09ac6a5db81ef26d69e234f0834e72c6cd68501ead21"
+    },
+    "sound/skullwiz/growl2.wav": {
+     "bytes": 24954,
+     "sha256": "0cf747c71a6fad9a085c39456cd14ffd972d2d454b4bafc2781ce4464917cfa4"
+    },
+    "sound/skullwiz/pain.wav": {
+     "bytes": 6106,
+     "sha256": "0f85b6180cbfe8d26f8d174f25c109b9d8b78d0fa53735e0494280bc8a19803b"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 8890,
+     "sha256": "6d48429e7fc4b80be16afd80097b7096a94cb1a88922a62bdfdff64172526a0f"
+    },
+    "sound/skullwiz/push.wav": {
+     "bytes": 8812,
+     "sha256": "91398e953b648ab23c037940fb7996f3d77727003a60757ea50686328c05cd69"
+    },
+    "sound/skullwiz/scream.wav": {
+     "bytes": 31734,
+     "sha256": "6df299b2a59aa94a9640c83684b65259e4619e0ed2a2fd1ce518dffaa060fd43"
+    },
+    "sound/skullwiz/scream2.wav": {
+     "bytes": 13980,
+     "sha256": "adca10198e279db0789a1a026124387c40e36fc1914f3f3da315b49b6e290386"
+    },
+    "sound/snake/death.wav": {
+     "bytes": 17578,
+     "sha256": "7d8e2f12369ad5fe3eb025d6ce4fefdfa10fbcff2b5b87974a1c8ddde4f851bc"
+    },
+    "sound/snake/idle.wav": {
+     "bytes": 27111,
+     "sha256": "6a69f3635136303676e168088af4a55442cb77f914e2e82f77e06e07339f0f4e"
+    },
+    "sound/snake/pain.wav": {
+     "bytes": 13882,
+     "sha256": "3737842df2079f4a2af87787bc8c4d34642249fb891a2bf3ee4d4ac95f97a182"
+    },
+    "sound/snake/sight.wav": {
+     "bytes": 13808,
+     "sha256": "296c74493be791f96b3676551df7ec4ad4c13cbb1eb484509c46fb44ee6f76b1"
+    },
+    "sound/spider/attack.wav": {
+     "bytes": 6576,
+     "sha256": "82593fdd5be8198a9774c163872f89a088d8d0ca10e91f1c8f846ecac92b2d81"
+    },
+    "sound/spider/bite.wav": {
+     "bytes": 4552,
+     "sha256": "abd0b64743c825661f4598b7d5b70b781452a6b7747f9eb8b53f7239b0f9b9cb"
+    },
+    "sound/spider/death.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/gib1.wav": {
+     "bytes": 10516,
+     "sha256": "bbe1a437bd05a71f9d7bba953a79886891bfc526399c67cfc8964308c91786d0"
+    },
+    "sound/spider/pain.wav": {
+     "bytes": 7576,
+     "sha256": "386e11cfd8063b6bb692ab4b90246be98288f72f29614f2e38765df9e6eaad79"
+    },
+    "sound/spider/step1.wav": {
+     "bytes": 2780,
+     "sha256": "06ee408dace817630645b0d390c496e692844fb42cc85adcaa021efeb60fae9b"
+    },
+    "sound/spider/step2.wav": {
+     "bytes": 2620,
+     "sha256": "66e802d6361a17e637f5e38366e4b0912dbb0f65e647041bed57cfda772c0770"
+    },
+    "sound/spider/step3.wav": {
+     "bytes": 1786,
+     "sha256": "418b2c536f19a5bcd0b1a8ff4aae13febc8c4f8fa6787372e9e869c45a17f54c"
+    },
+    "sound/trog/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/tur_arm.wav": {
+     "bytes": 23794,
+     "sha256": "24b428117ebd7e82865b41dcfc74a75a048c4d126d7505a6c23dd243bc054a05"
+    },
+    "sound/vomitus/death.wav": {
+     "bytes": 13236,
+     "sha256": "fa2cad86ac0ce1326132c5e378aed6a9ff5615d043df1d4d48e0b2691f8d3bde"
+    },
+    "sound/vomitus/flesh1.wav": {
+     "bytes": 8412,
+     "sha256": "9ac5a8ac2155e7d9b65144e7f65525c4660ff5959fe3a0277fab347e202b6f46"
+    },
+    "sound/vomitus/flesh2.wav": {
+     "bytes": 12788,
+     "sha256": "3fc22e2aa2c3c0bdc6501388ac18abb5e58c5fd5deba39d1cc2f7e8d48fcc869"
+    },
+    "sound/vomitus/groan.wav": {
+     "bytes": 13224,
+     "sha256": "3632e43615714e5fc1be8277881a913bf1bd79b276544418cbf1b159016f0d03"
+    },
+    "sound/weapons/axhit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/weapons/axhitwal.wav": {
+     "bytes": 6694,
+     "sha256": "0f14ba18076b25a7b8ee510b38adb282eb5c4f2fc94168baf1f8a658e1da684f"
+    },
+    "sound/weapons/block1.wav": {
+     "bytes": 5484,
+     "sha256": "ccb284becb454f395de702a263bfda1561b8bd38117893d33b5ebbb9eb7b6865"
+    },
+    "sound/weapons/block2.wav": {
+     "bytes": 5612,
+     "sha256": "62da8e44f3b1200b99f76a3bdb31d9d09a9e74c04a449c0afc482c6677a94bc2"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/weapons/clang.wav": {
+     "bytes": 7198,
+     "sha256": "634a88cf26b4de688bed392cf108d5468749f212ce67015c71baa942e8e88502"
+    },
+    "sound/weapons/dsshotgn.wav": {
+     "bytes": 6418,
+     "sha256": "452efbbaafcb29edde6f5d089fb2389e046635b1f715201ae750b3b7e849f378"
+    },
+    "sound/weapons/freeze.wav": {
+     "bytes": 20619,
+     "sha256": "48689ba550c116dd8b10a138bc0f78eb6f169d6828a49aaafe12f807930eb934"
+    },
+    "sound/weapons/fwall.wav": {
+     "bytes": 40140,
+     "sha256": "e269c07608f322518e709925d5b13daded150460d19d3091f15152ce4c06c9bf"
+    },
+    "sound/weapons/fwallhit.wav": {
+     "bytes": 9426,
+     "sha256": "7b9f4da432e6fa44fbf721ed9ef753e6ceb41df59b8265b58f73764b2901224a"
+    },
+    "sound/weapons/fwalltap.wav": {
+     "bytes": 8316,
+     "sha256": "879b9970dfc3bc609ff384a0edea13b594ea6a82b5c56d33c8549cd36cccda0b"
+    },
+    "sound/weapons/gldhit.wav": {
+     "bytes": 5842,
+     "sha256": "e19a73febbcafb1f3fc8774ea07fa51e8716c1ad29285a4d3cb5c6aeb4c1d5f7"
+    },
+    "sound/weapons/icehit.wav": {
+     "bytes": 10710,
+     "sha256": "9ed8ed177a6cfcad97f8adcf94b9f3114a955e7b3abb397c6b17c44073c07b19"
+    },
+    "sound/weapons/icewall.wav": {
+     "bytes": 6124,
+     "sha256": "9668486027e07f525a27830dc3217cde36bcbcc956b21437d2637e00df368dd4"
+    },
+    "sound/weapons/mirv1.wav": {
+     "bytes": 89538,
+     "sha256": "7d60062f61d5929f5f927526d81920f24684520d230a5f2611c128b832d3357e"
+    },
+    "sound/weapons/mirv2.wav": {
+     "bytes": 18478,
+     "sha256": "67311180da390517f2ef71d161a0cf7b770548dcd4a7dda7e679cb9b58025b4b"
+    },
+    "sound/weapons/nova.wav": {
+     "bytes": 10020,
+     "sha256": "d41c8433fa1b964fafa1cdb2fec301fb4d398f1fce201b4d80b29fab7a59d7e7"
+    },
+    "sound/weapons/pkup2.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/weapons/r_exp3a.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/rc1.wav": {
+     "bytes": 9138,
+     "sha256": "9ae6db1e39fd88810ca19d4618fa89fc4e09054ed05009e3adf3643da9418f09"
+    },
+    "sound/weapons/rg_fire.wav": {
+     "bytes": 66260,
+     "sha256": "a3a7edd9c470077682bde595f95d88546d416f300202ae96bd6c6371ec19cf09"
+    },
+    "sound/weapons/rg_hum.wav": {
+     "bytes": 51244,
+     "sha256": "84b348b10921b5f7c6539a20ead4de132e0f7988ab8f1464669fbe6ce0a20c2e"
+    },
+    "sound/weapons/rg_power.wav": {
+     "bytes": 51566,
+     "sha256": "40ce379a835e11561573be1dfdf1806a9bcb27192b94333a126cc721e38bbde4"
+    },
+    "sound/weapons/riotgun.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/shatter.wav": {
+     "bytes": 20899,
+     "sha256": "31ddbef0dc746eabea23cd7cd2fb97a1f949a014b664630d7f04e6c237aafc03"
+    },
+    "sound/weapons/sheath.wav": {
+     "bytes": 7031,
+     "sha256": "8f28a1daa16db234ce77d91e688c7acbc9541c296d30af9e1f940b6d45eaf72d"
+    },
+    "sound/weapons/stunfire.wav": {
+     "bytes": 9902,
+     "sha256": "7214cc44e4c0bfb801209f025b591d838542a3110f770e5614b0f549a055286a"
+    },
+    "sound/weapons/sword1.wav": {
+     "bytes": 3532,
+     "sha256": "572074b68af2132285aa9fd2ac6852f52ffb6c5e56eed44b1af21e0e78171e17"
+    },
+    "sound/weapons/sword2.wav": {
+     "bytes": 3055,
+     "sha256": "b176a257409b659d80df90560bbac4da5539971576aaf1107bb88bc016558085"
+    },
+    "sound/weapons/sword3.wav": {
+     "bytes": 3012,
+     "sha256": "eaca19c8a10b7942d4a279974df6e1cf076c362d5408e439b26286126852bedf"
+    },
+    "sound/weapons/unsheath.wav": {
+     "bytes": 8060,
+     "sha256": "45d9bc6b9dcaf8e0dc9b2ede7da69a872f50f7819462a71bc16b9d76a70be06b"
+    },
+    "sound/weapons/xbowdraw.wav": {
+     "bytes": 19114,
+     "sha256": "4bb73eb7161ba561970e8f2e7f5aad0e42b3419fe2b02a5953a7289c46d1442b"
+    },
+    "sound/weapons/zap1.wav": {
+     "bytes": 7648,
+     "sha256": "1ee462bf6169537cc96fa7f95ef30b782fa1be473bd6ddc297fb3a7a6aa21ad0"
+    },
+    "sound/weapons/zap2.wav": {
+     "bytes": 7178,
+     "sha256": "8ece0064dc470a86c00906c1c50a54afd3a64eb13582071b9960581a1b72f4ff"
+    },
+    "sound/wraith/call.wav": {
+     "bytes": 12328,
+     "sha256": "9ace8a0ff79d035d36b6bdfb8726054ceaf8f852d25f3c1b235616abf4646ef2"
+    },
+    "sound/wraith/die.wav": {
+     "bytes": 14024,
+     "sha256": "3f166e024c07124cc5b5c5469904f5a8b3e48d4cb50fd949be8d79b4df2e375c"
+    },
+    "sound/wraith/drain.wav": {
+     "bytes": 14094,
+     "sha256": "d767951e9630b6179fb05a80136acbdeeb530f350b1953bea62e8493f3fe67ce"
+    },
+    "sound/wraith/growl2.wav": {
+     "bytes": 24966,
+     "sha256": "1c757955bb103e0f589ec373d1517dbacb8fe7e274f7aa0928503c9f5b009b10"
+    },
+    "sound/wraith/idle.wav": {
+     "bytes": 23702,
+     "sha256": "760a4a215fa2adb6f531b15acc06a4b46daa84c85fc08691ff4fe13f17e09ee8"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 20442,
+     "sha256": "d55cb931cef7d9c336fb7bbc3fa0408ea23eff69f46e25ac377ebbc880fa5025"
+    },
+    "sound/wraith/return.wav": {
+     "bytes": 39162,
+     "sha256": "0439588ad2003732fe7f946a5597bf80b2b89d6395476671b0e050b91c49cca7"
+    },
+    "sound/wraith/rych1.wav": {
+     "bytes": 24482,
+     "sha256": "baec568f339f688ea475e37ef3fc51a36de78a52a553e85aaa3f8011e1240d13"
+    },
+    "sound/wraith/select.wav": {
+     "bytes": 29326,
+     "sha256": "1e86b92dd1d82f4f74cd7fe14a75484e6cddb4fe968d2bb3dbaf850414c6dacb"
+    },
+    "sound/wraith/soul.wav": {
+     "bytes": 70524,
+     "sha256": "612bf73a6ebe0526efa2ef3d22915bcd87bed0b0eb5e52fc4eb0e62c5e4a3039"
+    },
+    "sound/wraith/soul2.wav": {
+     "bytes": 20562,
+     "sha256": "d3701420c157109793576ac7af7c7b132ffd0897375ec99701f4cd54798d9579"
+    },
+    "sound/wraith/speak.wav": {
+     "bytes": 25630,
+     "sha256": "6d1e5b395938692d57de3ec8ef9a8b5e4ccdab920a1f247e5bcdc1f0906dfcb8"
+    },
+    "sound/wraith/talk1.wav": {
+     "bytes": 16654,
+     "sha256": "6a625383c12f7fb5979ca8977a51d40f183051d551bd0b1b4ccc8a3f43a0322a"
+    },
+    "sound/wraith/talk3.wav": {
+     "bytes": 9832,
+     "sha256": "28ecc66c85bc722059b147a1354d226fbaf3022b79aed937a4759958d52c0fab"
+    },
+    "sound/wraith/weird.wav": {
+     "bytes": 3028,
+     "sha256": "1cfcd24daeb0665dce9d68ec353377ef84a88c78d1fdfcb429f2d0cc2b7f4b78"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    }
+   },
    "sha256": "9441a02102869c233676b53d0b6a415857dc9dc39fe35c6d2ff340658f39d5c8",
    "timestamp": "2009-09-05T14:18:00.000Z"
   },

--- a/json/by-sha256/a6/a6c8789e985b110718aa249a9f53565c507ff57831498def218ea9939324d5f1.json
+++ b/json/by-sha256/a6/a6c8789e985b110718aa249a9f53565c507ff57831498def218ea9939324d5f1.json
@@ -262,6 +262,408 @@
   },
   "bv/pak0.pak": {
    "bytes": 5123450,
+   "files": {
+    "gfx.wad": {
+     "bytes": 152468,
+     "sha256": "50d94651f3e0b0b6a29e0110ce9ff260c9f3114060b08b6d1ae19054b8024335"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "31c4858fe496187dc1bac21c02aff8cf83cbc51e0b4ee5738d6118c328b299d2"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "ed0f79285d93d0ef35644ecaf9ab36f3b2c6ffd223c577b25fff2ea17f90080d"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "e9c210ab88f6e98965cd2f8470f084e32ef15b3ad3912cb1e9eb0363c6204eb7"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b56880e2f720a89dcd055f5278abb21a21514322d4a31b77b46c8b509b9f3be3"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "89c3ac6fd91cdcf15c20b0d15b4c01c153e0a820c660f9222b5c8f63d43af5b2"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "8b83ffaf6b5309d371f0107ebb1340a8a09cd1a52c6a5581b7c9c4a7afcefa77"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/debris1.mdl": {
+     "bytes": 33768,
+     "sha256": "3498dffa0c3522b011a76ada880dfae64de3ca1583c94474e1e07adbc220d981"
+    },
+    "progs/debris2.mdl": {
+     "bytes": 33944,
+     "sha256": "d6d535173bb4a3a2d469be9c63bf36a01b1e2b80dd6a71636d20178d813e443c"
+    },
+    "progs/debris3.mdl": {
+     "bytes": 34136,
+     "sha256": "d6b0a2b6353c4462196d2af116652b47d464a7bc1f161509aa8ee5dbe859f98b"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 17812,
+     "sha256": "74cd41d8d5a67570cdaca34a08e9868f3476d8c4ac4a645cfaf9e91cf778c793"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "4f5ca2553db07d5cc93987b11e9f9ff054d51b96488e2bcc35c9f03ed3040d42"
+    },
+    "progs/h_zombnm.mdl": {
+     "bytes": 3220,
+     "sha256": "9c1620004701df1a560bff33375ab3f925fa81671b036188cde9f0687552a2c5"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "b00951cd72bb5fb03c19a1d60943162652fe149b9ee60fd2e630a076d52956fb"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/k_spike2.mdl": {
+     "bytes": 17716,
+     "sha256": "e456eb93934dab43a83305988db82ab1954e66491c256fad3ef1451d0ecf97c2"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 36496,
+     "sha256": "a001c379917628354adfb62b698856b33f4eea5f22e7d8e232e640faf15d8465"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133936,
+     "sha256": "e2d6b9de9b879327f72d97ef3c07e0b7e35cf844747208f6e615015be84157e5"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "f414f3fd07b0278bd59dd90954770f81a5ffad7f46af5f5d0abee124905dcc17"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "progs/w_spike2.mdl": {
+     "bytes": 5816,
+     "sha256": "b07808c532059133c31be2ed2bc4e9bb9b01b75d5d23401768058cacc3192068"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 74976,
+     "sha256": "545d70abb8d44be8e12da24a3d09fb56f87ff960c41963148682fbbd9d47e417"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 218680,
+     "sha256": "6782603eadacc7cb4bd09c11d3b6326e0d2e69205f724fe2f6e533ee398f5a16"
+    },
+    "progs/zombienm.mdl": {
+     "bytes": 224900,
+     "sha256": "f4d1ce9667ebb36088bfb59a12c9a8d93c1aefa36515b51f388cffec5132f5b2"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    },
+    "sound/zombie/z_res.wav": {
+     "bytes": 23266,
+     "sha256": "10b2962ce2817fa8a250811313307cf0dfa93ad5257a669452fe3fc834ced976"
+    }
+   },
    "sha256": "c6072b6d4166203cf9d9cd7fe67b45db468420690d25ef5d5cb70f6be16bfb9e",
    "timestamp": "2023-10-24T05:42:52.000Z"
   },

--- a/json/by-sha256/a8/a888d9625e2bb5e0a0860c79ccedaf46a4049620f555cba594597c11e5f942bd.json
+++ b/json/by-sha256/a8/a888d9625e2bb5e0a0860c79ccedaf46a4049620f555cba594597c11e5f942bd.json
@@ -8,6 +8,72 @@
  "files": {
   "Pak0.pak": {
    "bytes": 2265080,
+   "files": {
+    "maps/b_bh10.bsp": {
+     "bytes": 3944,
+     "sha256": "101b7b1e6475248544817476495687e752784e4eb4e2a99c6b600b19c71567ad"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 3944,
+     "sha256": "a68ba8750253096808d70991b26a27fd6f9dc9d290330a947eecdb11b3fbe397"
+    },
+    "maps/b_explob.bsp": {
+     "bytes": 17528,
+     "sha256": "a65a3d3125869c55dcdae46e3e5d09fe07fa8a488367f5c81051ea6fb16e60aa"
+    },
+    "maps/shadow.bsp": {
+     "bytes": 1478920,
+     "sha256": "7c506875b3bb2d7c6d3ce6fb9c374ec076d90b816b84a8db5f9cb9ebf0de8cda"
+    },
+    "progs/demon.mdl": {
+     "bytes": 102120,
+     "sha256": "fc86ed76ee03cbc80ad963999341d5a634c9421739ec20d7ce9367c04d3ea4b4"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 34884,
+     "sha256": "8d48117d355ffd648d1b8498966f2ae61ded8d6e0a695b7f296564d8cf235ae0"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 7156,
+     "sha256": "2df7b7aa12e4a497327473c4ee07fe7d46ade3c7232454c774aaa48dfee2df62"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 28036,
+     "sha256": "f3ddd93b167bae4528364e5b23c3c06aa95dce81bf3f7c801c8f27d2fc3e10b1"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 37060,
+     "sha256": "a5fe96718d348b02299fcf04d1e02e0bb973df1519a493b8ee50eda297bf536b"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 14804,
+     "sha256": "a4e5899509bc262decc152a6756df8e457d7e6bcf49886cda55a7d62d5acdf23"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "d53ae9fa2b43f4150756734011e85639a5d428a2539f7a3e39f01c6353445f7d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 101404,
+     "sha256": "2688f53741a21c1a5d0520b21d99257d884e293175d2707ceeae3823d8848f63"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 80648,
+     "sha256": "aca8e867c6fb3b3ef8ed5c8fb84629375393b0d7cab9e6a5c0852f8d003f1959"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 98556,
+     "sha256": "2a7ba1a647d15522eccfbc7586ad20128d250eb63055854bbfbf817496c0d25a"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 64472,
+     "sha256": "b2f9a9897231521ef6b4087c81d1018468c50073dacce5f424f83a11e36e5ca3"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 186084,
+     "sha256": "05b8bcaa335c50ad9f74f511767ac2016fdc96cfd60071e2c66d294487be6c2c"
+    }
+   },
    "sha256": "18a93e8dec18fc72278602a2102a2211aa9aba67daeabe8d3005a457b4ebffcf",
    "timestamp": "2001-09-02T13:10:34.000Z"
   },

--- a/json/by-sha256/a9/a93e1031b474ae33e1ed16c98ede2a839449d8ff5644ca9678cfb5073af6b180.json
+++ b/json/by-sha256/a9/a93e1031b474ae33e1ed16c98ede2a839449d8ff5644ca9678cfb5073af6b180.json
@@ -266,11 +266,1055 @@
   },
   "sm224/pak0.pak": {
    "bytes": 4393664,
+   "files": {
+    "gfx.wad": {
+     "bytes": 121132,
+     "sha256": "fdcc42f0dad313b297845f4a4daa79dffb541dc7fdfd13c6e8610df9fd614f72"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "898d694265db0f933feecfd2a843557a6954a5f2aea05ecf9a852314119dab61"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "03e0973ee5d434c037699f9568228ab80be0df882ca77c88a9835b2d2edf0649"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "2a28a9f4861c149ebff65a36456836b694e7b4437664518d1ca5e27da0e82a16",
    "timestamp": "2022-11-23T19:55:48.000Z"
   },
   "sm224/pak1.pak": {
    "bytes": 12486850,
+   "files": {
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "4ff90c6ad036c32327767e9867c8d99245b72ff70d72990389b72a26b22a60b5"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "fdd1489559a745f0bab6fa797e3cba1af6242d5c181dae78a7c3ed50d84a5e07"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "5b4a27c40aa506d0d7c8f07cb87fbc9046730dd481cb7c1370c5b0291328dac5"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "1964d06e719f8f4d4ec53a1fbc4d81d06a5674edfb02410f932e8e846b08e79b"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "0c994c39b18f5400f0de6ac2c8c219bae63c541e61db63b51b6082f2bd13849a"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "3d4367f1a224016ecdffd6f5bbe99094f23a454eeb5e6e30bb987f00b0c705ed"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "c78708ba276f233296829e0c3d30da3d87140a0572c246009b56574de17925b3"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "872f0c8c3c4aeb2179e196765c8f528ba387a5ee8ea2fe28866a64cc740ad444"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "becf427327bbd99a8f54ad1a7f890f0e0990602463b1c6ad0267b1bf03effc2a"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "ab228bc7c5f311e586c21732cc4b748722bcef2622b188d043a9f5d8a6715e07"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "ccc4d3bff22aeb8a735a41c8d1d2113d33ff620f77bdf232e5fe5d4586e519c4"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "816175ae99d2c0bb2b03ee0493cb0aeb412fcb7eb9041332fc5d85155718f6f3"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "9ccf75b04ff8d4eb413dc6f4487664b5b80fa9bccdaa6b92471b95955b67a089"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "b60ac54c9023a05c2ebf3a6f7eaad3f36c3146ba76533c1ffe1b4a2b8cc0a62b"
+    },
+    "gfx/dim_drct.lmp": {
+     "bytes": 3352,
+     "sha256": "63f37062f02fb36cacdb034667b9e7b5f36eba8d209bcc8a75bc8414f9e67449"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "0304e534928ab12a66aa81e2a7305ff79d64156c9effaf947b138c164e634d3b"
+    },
+    "gfx/dim_modm.lmp": {
+     "bytes": 3352,
+     "sha256": "7a2a930b453a7f6699e42d5353fe0a1bd84e5b00125fab0113d8e48338ce8c42"
+    },
+    "gfx/dim_mult.lmp": {
+     "bytes": 3352,
+     "sha256": "e2f07053fdee8d7e887b6d7ad5ac210d7306683233baac1a8505e625e3418ecc"
+    },
+    "gfx/dim_tcp.lmp": {
+     "bytes": 3352,
+     "sha256": "6448c390fc0c4217c4d6e6e17454d21cf96ef05aecc9722314a59c8bc32acf23"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "82608fd8d3ae3ac8873f945f43d50f044115d051a623009f8b297df4df5db58a"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "b6e3459c5f862136024fb9f8f7741225704ddd76705658e513691ed8dee46260"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "69783b94f563d95d9e532bdcd246e7747f362ed8cd28f9e91d5ff2a0fd7437a8"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "3eed5a2e248271ed3898347082775cace9ef2da5a4aafe691cb7f9d1f914c308"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "34bf1d259c37d6ec1afad57701287fe8ee13af5dd04886e36291385a518824f4"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "eb2b947cd9009874e6e31ab0f6c2b77cf4cb3c9adae056f935a2035936499cbb"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "daa29b02b787ca1b4b3a0bfb413f35cfd64fa72717782c8ba2832f20d43b25b5"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "618b141492142a9b4c9f14a99419cb7d7c4daca0c16c463210428a989e0bbc55"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "c682c1a188e6e56549c2e479415c234493b78e5fbc8bca443482840555e37c44"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "121eaa64ab2fb48dd94cfc55ebcaaa6c4c088626797d62f5ad70af264cbc15fc"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "5c07f7c6629b27aa2cb449717adabeec04dea33edb195e6394ee4c02cb07ce3e"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "878b82292661d84d133d1f52736bc141cdd794ce6b8d52cf1a56177d62d9fab6"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "229c6e4884b31429934c4d79cdb403b435d09fe45cbdf318ebf1ab2c09cdd85d"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "c58191313dda1be89fe6211531ef0b041c230f13872bbaa6b7e49da222c331a5"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "31d7e9e736f37aefa42e1564d916d517dfb89f1a43249f507c5703e7d59eefae"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "52c2c556b76a1164e7fc73d646f6a56978bf65aa404cbb0fe5737f926876d533"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "ab2543a4d17789f3254ab2db73934c9147cd4f3118053c62d20c419c2859e7dc"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "5332b5acd0638c28830e16a72502eaafe3c2acd9d4ef2b76d7cb9f1604d51e9d"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "b0159fb1381ec36193d12ccdf9fb524fce8e4277255eb5ad1a5012197addb428"
+    },
+    "gfx/netmen1.lmp": {
+     "bytes": 3352,
+     "sha256": "7a2a930b453a7f6699e42d5353fe0a1bd84e5b00125fab0113d8e48338ce8c42"
+    },
+    "gfx/netmen2.lmp": {
+     "bytes": 3352,
+     "sha256": "63f37062f02fb36cacdb034667b9e7b5f36eba8d209bcc8a75bc8414f9e67449"
+    },
+    "gfx/netmen3.lmp": {
+     "bytes": 3352,
+     "sha256": "0304e534928ab12a66aa81e2a7305ff79d64156c9effaf947b138c164e634d3b"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6448c390fc0c4217c4d6e6e17454d21cf96ef05aecc9722314a59c8bc32acf23"
+    },
+    "gfx/netmen5.lmp": {
+     "bytes": 3352,
+     "sha256": "e2f07053fdee8d7e887b6d7ad5ac210d7306683233baac1a8505e625e3418ecc"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "1ed456c540e7c07c3b4b3447dd9ba0b9c3e13a09ec52b3686c5a147a526d381a"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "01a9d0b251a746dd4fe4c74f8da5f6dece86531df34d16f5660d033b687ac73b"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "a2b8d9df9f220170a463f03e37614cd6b65fd9d8c29a680272b94fa6fca23f40"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "0e7518892f9a86c7f437b011088afe71cc4bcdc4a103fae6ab1b96793727c066"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "76434e876ac6462fb3b9bc33ba9e4202e789f76ddaf7102e964ea4440f3c54d7"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "b882e22264a4a2b5bed8dcb136820c2b7b4833ac3746ed4e5c95089539c6e37a"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "12c9b67b5a7ce9833f7441cdc90c79c968aa50a08b7364611da946f4af47cf4b"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "2f6eb67baf39105b47bef784ba025d1ecc00ebd3d0ccda5d462edd296792008c"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "620d001639dcd79e81dd4ed974cdc3486e63db5bf1bac56f555a46797a851ae4"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "4d19eb254f62a63f2b49fd6a5de0985197e227cb034ef05ca28447b080c5497d"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "9f0d0d597c3f036960f2afd9241d626fef989e09de8113f4a2f0294b835ab2f0"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "672b7ac99807a6d79b7d0132730ad3d76deb7afa3253bfada87b5ecabac1f5d1"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "090c3bfb8a55f7fb880a108f0e1f77eaf0897a56bfdbb8cd53f10921fffbaab4"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 5540,
+     "sha256": "d9c03300f0870d9c86c097580fa3002df2bb7e142dd91709977a9631a8e287cb"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6132,
+     "sha256": "8857b1159c7354d6ad3b99ff51362d2d8d2e98ddcffcd7e225524b102b0c37c4"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 3992,
+     "sha256": "4b8291a4e397046ed4f2a963e7f8d8e2ef41db88cc03798149f2494d719d6084"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 8940,
+     "sha256": "ad7caa76d94e44b654cd0dcb201118547b15205aee2f392cb6228a1f32313a8c"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 8928,
+     "sha256": "369fbd257ed09e63d8169cdcaa00fe920e36d9883626dbba630573f4051dced2"
+    },
+    "maps/b_exbox2.bsp": {
+     "bytes": 4728,
+     "sha256": "2d05c923db40032c46d123d804958c44d0b4e1d2fc64755a6830a70036ea1465"
+    },
+    "maps/b_explob.bsp": {
+     "bytes": 10272,
+     "sha256": "fe6105c5379037bd46277f587de62786e3da4ff79eb5b658e234bc468677b0c4"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 5540,
+     "sha256": "a51ba5d254aa8e4db6d0740837f7dc0b3cf04a01ca171d11897f447623998a69"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6132,
+     "sha256": "7ec0c1e7294e2f5dfb23a871368c63607c9b8d7ac7bfbd7a3d5187787077a028"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 5200,
+     "sha256": "4e10980e81e02058f6c330184d7af389d655581ccac540eb117e947842b2e761"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 6132,
+     "sha256": "0081f9ba70f1130822ae79960e0950477c175668a73ab70a6ecc0aca435ef836"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 5540,
+     "sha256": "c290320789b4f207568ba1acc0f3425fe9f9dd1aab0fa6b510b4a0ce008e1b98"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6132,
+     "sha256": "d57784b5fb62e7bdada82c55a931f8b6960a3bd7f63d1e20573e5f37f67cf685"
+    },
+    "progs/armor.mdl": {
+     "bytes": 176444,
+     "sha256": "f9308bf41d12f09b6abf252c02cd4f85b1c5937e32ef072b3c13d0ba7a5afb35"
+    },
+    "progs/b_g_key.mdl": {
+     "bytes": 4996,
+     "sha256": "ea9828bffa21231fa0808481f3157aa64a2665855dbabf1373d1d14912b377ef"
+    },
+    "progs/b_s_key.mdl": {
+     "bytes": 4996,
+     "sha256": "bc2b27d2d3e8de809508733e27f1578eb94ea7b9156f78ca0dab49a33fa65b57"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 24496,
+     "sha256": "97efb3ba79059e1b3dc2b35f90e0b000d2f322dd5bebb6fce3a7ecb08d61a871"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 58644,
+     "sha256": "8c501b8fa22dd1d110292c098d7ad90ea1188f347d2930c5d3e36d730ce1217c"
+    },
+    "progs/bolt2.mdl": {
+     "bytes": 58644,
+     "sha256": "1c48af2233e67b0f93ec404b6feda091ef4a035f3db86ae933c1752f61f2f05d"
+    },
+    "progs/bolt3.mdl": {
+     "bytes": 58644,
+     "sha256": "508482019995baa9f7668a767cda2a1f5c529dfb3627369dfaec268f8d726b2f"
+    },
+    "progs/boss.mdl": {
+     "bytes": 396956,
+     "sha256": "a582359b3b5b269bcc3ffec6a020b54071df5e7fe765ea20ccf227f156e3364b"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 84825,
+     "sha256": "d420d0af47a221a46830ca7a2b7b416243746611f60edf52f1fd5110073237c1"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 84825,
+     "sha256": "e73ea260b701db0f3c9207a7fa8baf7da15ae1faa4cf1a0227ee8086d98e37ec"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 84825,
+     "sha256": "d5aca0f85d593450a55a64d4b6a28be46cf44ca2dc16337293001edc341ac01c"
+    },
+    "progs/demon.mdl": {
+     "bytes": 181220,
+     "sha256": "20cddd47239db6d54004bc271953e836663d110e58e7267c1e4f20906a5fdb3d"
+    },
+    "progs/dog.mdl": {
+     "bytes": 243844,
+     "sha256": "c006582533ad2244d10bfc70fe5a515eb3ab1cbbfecc886951a91fa683c6b40c"
+    },
+    "progs/end1.mdl": {
+     "bytes": 60436,
+     "sha256": "936ba0249acf1f62a34532b814b230d47489c7551b8d0eb35fb599ae5d82a318"
+    },
+    "progs/end2.mdl": {
+     "bytes": 61076,
+     "sha256": "94056137cea29311182bb13435fe46c52e5ecdbd66236fd348121d4074531538"
+    },
+    "progs/end3.mdl": {
+     "bytes": 61172,
+     "sha256": "3002a0f36af64a01d9792c528a2cd0fbfa6aedb3f52f085ee175ca23159ea7f6"
+    },
+    "progs/end4.mdl": {
+     "bytes": 61428,
+     "sha256": "09c33a01ba3643acd2ebd8039a9bd7de83db8ac7bcc1584c8376b6689b19a0f8"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 350408,
+     "sha256": "080a5b15c34e323f43f6ef6f7080c36449e4d75d19c5a4ab16256b803b2b83f3"
+    },
+    "progs/eyes.mdl": {
+     "bytes": 58484,
+     "sha256": "36068d4f83cbc6a2f2095f422fe2444eff91ba5aadf8d1c63aa7ebea3cc00f3d"
+    },
+    "progs/fish.mdl": {
+     "bytes": 111140,
+     "sha256": "5c3680bb761502b28c4b6071b500fe541ca01a74540d4d281ef3ee0429ca7a82"
+    },
+    "progs/flame.mdl": {
+     "bytes": 136808,
+     "sha256": "1b49f1864f7e28161f6f16d2e0b0fae1f6ee6d0c50c1d4f55bce1aefa3909bab"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 176293,
+     "sha256": "3ffc02b1dc7a0ae17db7e8d26eea5c23c816352b26ae9e641899eb449978372f"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 65620,
+     "sha256": "9dabe194a5df8657287ef9d0e6dadbda4d4a14c6a33b670ee89ce5f87ffb06e4"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 65460,
+     "sha256": "c09b98f73856db309dffb656f7c052ae1ca7ef02ee96711d04806b5071693246"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 65892,
+     "sha256": "83886a628d597b9caf02d5d8baa4dfb5e3c4e61c8331fe023db2d2a09d2a66d6"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 63364,
+     "sha256": "8d501b5fa564463f1b32562555b1449a7d9770a83bd5a8a045cd967400594e17"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 63908,
+     "sha256": "f75cbfbfff108b6115902dd4a87361d0875d5bfda068203af165d28d10c36823"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 60692,
+     "sha256": "68eeb05fac14801e04574e309899e568c43206e3686fcfa56f26252e028730d2"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 61380,
+     "sha256": "c3a641677f15aefb14d15916e7f86fa1940653e4b91fa4964b4e0ff7b4fcee1e"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 58900,
+     "sha256": "ab0e9cafd610f110b0d6c7ad5120abb06a76b29cc671ed3bbf96ca2fb5ade2d7"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 60740,
+     "sha256": "d7a88421464cbfbbda770168b41699308fbc19a39cbc172d17e42e4f37386780"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 58404,
+     "sha256": "05c050586ba91153e6ed9953d3de4fd1d93be1673e65c020888aafc6725d49e0"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 58836,
+     "sha256": "3107fa4adcdaddfdd06fe453167b8b319f50347d1447346f90d75446674c916f"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 60916,
+     "sha256": "398af65b5611e3dd6f3af81f023cc1a89edf88d8906c61b08844d9329872383e"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 61364,
+     "sha256": "a010d0ca0c405e8b01fad03212c8c60183b54f6be37be50e5d8f580390d4473f"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 59268,
+     "sha256": "0a1390035357ce2f1f568c402582962aac8b58052a58e78557afc737546c0141"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 60948,
+     "sha256": "5864658e084daf18eb389dc15ff8c49a4fbb5f822d772a9bb89846d27f7b490f"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 232944,
+     "sha256": "3d8992ff8e68e8f55a5ca3d1e6904e89603a20437441ae0187ac61d443dd22f6"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 59908,
+     "sha256": "20ec9a717d7c104818c369c9f6a56ac4deeb160378fd8c550fbf584694446701"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 59060,
+     "sha256": "fcf5790d3bed57b926c2deb14f554a62d15db20f6490580b67c5c5e62356211b"
+    },
+    "progs/h_player.mdl": {
+     "bytes": 59348,
+     "sha256": "3dc5f22fe3247c999d385d7d2286f868c2e568bce7c7a256045ce38d9a2ecd96"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 62180,
+     "sha256": "b73f2e743903d3e4b938c3f35528a995721c8eae099e30ed1ad780709a539f26"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 59812,
+     "sha256": "69f18ab465ba11cbfc279914407231a1966694534c19a14f6a281bf4d8b65b3b"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 58996,
+     "sha256": "a1085a866c3b0101422b24b8c503a592ddf734d9483297d1a697c742463ae057"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 59588,
+     "sha256": "e524d57934167612a3785652709c926e69cdcf715616f372c829e7b58afa7232"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 510996,
+     "sha256": "0e009be5684b229494333d56c07ab01a4a1f0ca8e657d6127052f335f50372c1"
+    },
+    "progs/invis.mdl": {
+     "bytes": 63668,
+     "sha256": "25dfc1b223e713fc922c9b868f9182cc16c7d08c4426564f55cca895bfd1027c"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 60452,
+     "sha256": "ef8de45e7014ce04d08a400d02678a4d868ad98fdeaedc3fa9892f9fcbefd5b2"
+    },
+    "progs/invul.mdl": {
+     "bytes": 65716,
+     "sha256": "634bdb4aac11c4933288d24081283abb3230a0dd39599fcc2fbc9eee34fda2b5"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 62164,
+     "sha256": "886399b1a66a56818d1fbce5ad17f32ec9592c23f3445e099dc2c92d30d2a51a"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 59028,
+     "sha256": "39395b949e6de8f89add5e3b1b7a88de191f39c354fefba94b1c6ff237d08a3d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 2787095,
+     "sha256": "0691191a6dcee05d1d90b797d94f1694469981e19b05ebb5f0779d9a256b0596"
+    },
+    "progs/laser.mdl": {
+     "bytes": 58228,
+     "sha256": "9d147fe8799aea3ada61ce26023153c54c631b8e883c2e8616ae095a8abe43aa"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 120847,
+     "sha256": "618483102a020f34bc18d7a2711e08855c12c9575b664f169c326dd94d398730"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "d597420e067301fc4ee09a65871b36bdeebe2b62f87f4b72aac420d8243a6720"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2839cba1b1a3b9c1e424a21dcdf012d02d482b6ff8cf20d009008a03cc089ff7"
+    },
+    "progs/m_g_key.mdl": {
+     "bytes": 7748,
+     "sha256": "d724c89dd036d774be07b164e5bfa25a688cba0035d9d00bcd6936c69578b742"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 4852,
+     "sha256": "9e3aa7e43062e3128e0cdf264623572e2e7badc507338ca3874fea5371dce1fe"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 4212,
+     "sha256": "eaaaa17ad0a00e2a08600fb052d4bcb9f55fcc3fba211bbe155d6f5954cc813c"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 4212,
+     "sha256": "ed222209122c732a386456833d71e088c4dec7d19495a321e80a7deb7736e15c"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 32976,
+     "sha256": "ba688016f77145c791bd226eeab611a2e7dcb1999d4b6aa1b75a27acc0af06be"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "a45f4883a35e6823da74780edc1cb05f1984e5eb6832d45af377846dd7ab8379"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "9180c8e65386b481e0443817d5252c3f4d77f8858ae3aa500d29541782b25bf0"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3508,
+     "sha256": "d72e81e98366d3478f62e97ea38ef4add3e36a33ca32725de9657c21ca46efe6"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4852,
+     "sha256": "8435333ff912c5a0f4189a8fb2ce2ae386ec08998b2b155208bc47d6ec7c293a"
+    },
+    "progs/m_s_key.mdl": {
+     "bytes": 7748,
+     "sha256": "6287226e87d9e3c44ffae8800fe4009e6ac04fd3f73b7236dec90c12c8c799b2"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "178d0bdd563d51040338731876e89529ccce1cf05311fdc7a2068cbe4803498c"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "3a26c1b2e5a9c152ef355e04a91707f93070d73825a1cdd07ab811a018374719"
+    },
+    "progs/missile.mdl": {
+     "bytes": 60356,
+     "sha256": "e97834f825b0cdb7299f2c965649aa1ef9b54f65a9f3e6b55cfc422fd3c52d29"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 373020,
+     "sha256": "d20bd332b5a3a6605a4ddcde51cc5a95b0bea5833b9989d6e72d6834553d6693"
+    },
+    "progs/oldone.mdl": {
+     "bytes": 167804,
+     "sha256": "4bcf12aaac57d7a2c5d7f35cd7923cebc8bc8064d42cffa1e06a056f24981f02"
+    },
+    "progs/player.mdl": {
+     "bytes": 385332,
+     "sha256": "607242751c8f8db6dd9c8e5ca87cd531fc213a1fa83ee40d03d43ccceeacefd8"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 63732,
+     "sha256": "7a73f9d8fabae77e09829a2de35f24bcd051fdb6c8d037b18200e7a383e2838b"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 32464,
+     "sha256": "812eb0c29cb5ab10c9fd65a2a829f8c0dfde64c10f221380f92a13786e59552e"
+    },
+    "progs/s_bubble.spr": {
+     "bytes": 588,
+     "sha256": "a1ec8ee908f9df96edb9081f2da0876a71213a5a372e577c7147e09c4d1eab50"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 24732,
+     "sha256": "1b2dda05d14b1186571b20a37c4f81689d812035fb3b46f8b483fd3f21809ebe"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 24732,
+     "sha256": "cf680b97c93bbb1859fd40106607b3ba3fed2ad4406e63b23d66202224f98560"
+    },
+    "progs/s_light.mdl": {
+     "bytes": 60164,
+     "sha256": "3aa9e7ae327d9a7a86874361c4dffaed4ac708ec9310ba41ac1465fe5dacf9b2"
+    },
+    "progs/s_light.spr": {
+     "bytes": 1080,
+     "sha256": "8ebc91a4a20c34dbf4de7f23c683b6bac2eba437147c7a09d04215eb91589498"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 57972,
+     "sha256": "1e6ff42f6ad17198758a0c5dd783909cca4814d24202500ad69b96a08bec77d2"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 150412,
+     "sha256": "5aa37a406099cd53f39463d71c9c7433bba58434d767e9c6fd228a734e228be7"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 233256,
+     "sha256": "c1012e1709fab1131aec6d2b391d2cff9c94ac6dadc85010afe5b71f2e1f46de"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 270176,
+     "sha256": "83ee1d511edba62ed758566e74323070dccd5a577139647c773437ad1441332c"
+    },
+    "progs/spike.mdl": {
+     "bytes": 11180,
+     "sha256": "bb13821af43c6aea3d6d76303f4684c44a5f296e8cdfad0eb4335b4fdb3e9a7f"
+    },
+    "progs/suit.mdl": {
+     "bytes": 69828,
+     "sha256": "b5b000631bc6f512ddcf2d5744d2c77c386ef7786d868d3275e00ba171a6ba9c"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 136708,
+     "sha256": "e9f6e8374bdf8f14fb5dd71b1a1c65b4ac62a06a4e88f5eebbd59277588e12ad"
+    },
+    "progs/teleport.mdl": {
+     "bytes": 62180,
+     "sha256": "1b59d70e74776b672531b12c1873c810a06c11d5d174fa532d31607a2a38ed73"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 69908,
+     "sha256": "4a3b5f64763321319788bec1fec45808ea771aad0bf3cff04882c09150d2e93f"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 113692,
+     "sha256": "c7f93b14929d7efdea9cfb4742b4a0a9301e06f820d2fc2b8f708bb61a63f905"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 66916,
+     "sha256": "0b67a151fdc68a2a0f4a04ef6672bc34ec7d96fbcca29b09ee35353050dcb19e"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 71012,
+     "sha256": "6ec2e11f711af639f7016ed9eca9f8ab9b5ce95cba817d8de5d337b41021ae59"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 71204,
+     "sha256": "0bd0e38bac0307661eafcf73855d548bb00b0a30b65e8781d5b2946b03595c10"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 60868,
+     "sha256": "d7e2e8ccec479995d636913996edbd0ea811d635be320dd6c7beeac15b925484"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 66428,
+     "sha256": "eed4de6642c474a1c038f51fd8e130f89a573697c44a48c5aa8cc739bd7c6b77"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 65972,
+     "sha256": "18d2eb0d3dc1e458daec373475557bce871395d2a9920f4a8d70eaf1bde646ef"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 66276,
+     "sha256": "b922954f67c7bc3f63be0b3edd0afd9b4ff199bc8cf430ea030513a667e6ecbc"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 61220,
+     "sha256": "a50d0830a7161cb7aeaf0d41a5899591fc140acdefb4a5d7a8aa2772454a45ff"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 8260,
+     "sha256": "db085ef90ea899c42e431712679639c33e872d126478efadc4003ef998b69f35"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 33488,
+     "sha256": "9fbb2d8f6139816299d682db871e185641b98f87f7408c0a34406b0258cfc42e"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 62988,
+     "sha256": "231e6e1e3af512934c13c10d2df46ef037d2b215dcd620600d978985b12b4a9b"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 122116,
+     "sha256": "32bf13e8d491f99bc0e3d5a3155753ad88b0d3bdba76f8e10f3304c5aca16fdc"
+    },
+    "progs/zom_gib.mdl": {
+     "bytes": 58356,
+     "sha256": "2dfcafb542dbb7d802f324e41d506d4318abb50eaf4bb3ed2e594de86cef1f22"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 402428,
+     "sha256": "988d8d764a5e16e96c4e6dc6bdfb907146f55f5510c9a5ae6db0a07b6bde6d15"
+    }
+   },
    "sha256": "db83788c9de2fab79a71de3a9cb6b648f184978e1898c6a099d99d2583c00158",
    "timestamp": "2023-04-29T13:01:06.000Z"
   },

--- a/json/by-sha256/ab/ab0218a90b7fb62a00c5b349ba8780406656c1c51eb1faac5e7edac585d51244.json
+++ b/json/by-sha256/ab/ab0218a90b7fb62a00c5b349ba8780406656c1c51eb1faac5e7edac585d51244.json
@@ -102,6 +102,360 @@
   },
   "fear/pak0.pak": {
    "bytes": 4393664,
+   "files": {
+    "gfx.wad": {
+     "bytes": 121132,
+     "sha256": "fdcc42f0dad313b297845f4a4daa79dffb541dc7fdfd13c6e8610df9fd614f72"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "898d694265db0f933feecfd2a843557a6954a5f2aea05ecf9a852314119dab61"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "03e0973ee5d434c037699f9568228ab80be0df882ca77c88a9835b2d2edf0649"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "2a28a9f4861c149ebff65a36456836b694e7b4437664518d1ca5e27da0e82a16",
    "timestamp": "2022-11-23T15:55:46.000Z"
   },

--- a/json/by-sha256/ab/ab3f580150df193cb467203ff4c267b423375581041e79b0240acb3a0a484587.json
+++ b/json/by-sha256/ab/ab3f580150df193cb467203ff4c267b423375581041e79b0240acb3a0a484587.json
@@ -21,11 +21,263 @@
   },
   "pak0.pak": {
    "bytes": 41896745,
+   "files": {
+    "gfx/env/grimmnight_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "59be3026e6030ebcb4f301dc27569da94866569bd264990d5b68c0c0470be470"
+    },
+    "gfx/env/grimmnight_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "6d9b33f83ccf56f92abdf2b1197ce5fa8a3979f8b40793a73219618b8f46c33d"
+    },
+    "gfx/env/grimmnight_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "0e1892d4675a0630cde9a1a1453fb936b5fd4f62c97a91fde60778d94bced01f"
+    },
+    "gfx/env/grimmnight_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "c69dca07d21151d7ea43527494687f3951715d692ed616af3a059f01481204cc"
+    },
+    "gfx/env/grimmnight_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "bf2c9897af366d36efc11de39c051f3345ceeb6d38845be71b712c9403d726e7"
+    },
+    "gfx/env/grimmnight_up.tga": {
+     "bytes": 3145772,
+     "sha256": "e4e35e286d93770157119d60889ff0d2df08fa13ccafa32ea26884e31a1344bc"
+    },
+    "gfx/env/moonbk.tga": {
+     "bytes": 440145,
+     "sha256": "215264c71fcfdcda4fd9470adb3b1e1e803cd5af1d8df035c3244646dbfeac2f"
+    },
+    "gfx/env/moondn.tga": {
+     "bytes": 32812,
+     "sha256": "620e85506507cea8985ab3a231c0a41625c3f48a492ad0f9efffaa0d0e4fe6c4"
+    },
+    "gfx/env/moonft.tga": {
+     "bytes": 410588,
+     "sha256": "4fbbdf05866d78de6ab4bfc9867227007fc87073cc96678e0c08bbc6d9717ce5"
+    },
+    "gfx/env/moonlf.tga": {
+     "bytes": 421955,
+     "sha256": "ea304d8972653bd38c0aee88e6dd434d719360c423344d16b5db9c398af260d7"
+    },
+    "gfx/env/moonrt.tga": {
+     "bytes": 453367,
+     "sha256": "8ee2a2b97267326d4831d96c879c6238a63c485fc8865d91503adb6d7da878bd"
+    },
+    "gfx/env/moonup.tga": {
+     "bytes": 1335652,
+     "sha256": "91e764d1d7780818e58f1c30d7c8825df2adbf17c7da630acfa3dd70b29d27db"
+    },
+    "gfx/env/red_bk.tga": {
+     "bytes": 619027,
+     "sha256": "3462c68f4adacd5aa2321bcc6ccf733e79f574cdb98b08f4df8317bc349ea7e1"
+    },
+    "gfx/env/red_dn.tga": {
+     "bytes": 672467,
+     "sha256": "8ddba1e1ed2e0bd3ba0a6a8658ef46f0420898c25d8295927fc282df8f24976a"
+    },
+    "gfx/env/red_ft.tga": {
+     "bytes": 664453,
+     "sha256": "764f9a16e9faa015f1815ddfe29a20a0fa38b1327ad29ef3fe2feb65319a995f"
+    },
+    "gfx/env/red_lf.tga": {
+     "bytes": 634654,
+     "sha256": "71510165184795e4bd36f51f5824516f7fc1615c452087c261ce7f2f78d7c007"
+    },
+    "gfx/env/red_rt.tga": {
+     "bytes": 630646,
+     "sha256": "333c1f18a4b8f3b1281aefba222acd9bf318505f9db4b2049cbf4e151255c18a"
+    },
+    "gfx/env/red_up.tga": {
+     "bytes": 446254,
+     "sha256": "084a9a4ae3f2823a8dd0f2ec1fb1e4ca612d6f5d46afa2d8bf938892a3cb60fe"
+    },
+    "gfx/env/snowmoon_bk.tga": {
+     "bytes": 707878,
+     "sha256": "f4c61c3a622a2dabfc2aa2748c3bba9ab52bf018c5c24b5aac6bd682b6d938de"
+    },
+    "gfx/env/snowmoon_dn.tga": {
+     "bytes": 754863,
+     "sha256": "a6f29123dc3da6df244c6878d1a355b9ba7c093b9a38b94e8f9253d317de846c"
+    },
+    "gfx/env/snowmoon_ft.tga": {
+     "bytes": 630095,
+     "sha256": "c10f65b43cff087a7044946f8105d24072bbcb33668bb485f501fc0bdcb7e293"
+    },
+    "gfx/env/snowmoon_lf.tga": {
+     "bytes": 671066,
+     "sha256": "8025d6d72582a374583dc4c80d15de546b1ebea3f378cc55b084483778d8f985"
+    },
+    "gfx/env/snowmoon_rt.tga": {
+     "bytes": 636559,
+     "sha256": "339a1a1a36ffafa6bb49ae5bffcb73c81d4304f0f6d40d5fe470654c0db56037"
+    },
+    "gfx/env/snowmoon_up.tga": {
+     "bytes": 410341,
+     "sha256": "f08c76ef2c7c2338b64615543ffa1217edab3ca41bc79cb74b20bc42d329e82c"
+    },
+    "maps/retrojam1_ericw.bsp": {
+     "bytes": 1465900,
+     "sha256": "62998fa1f79d1814359e9ed07171209bc17474fe242ada7edbeba6d5819ef77b"
+    },
+    "maps/retrojam1_ericw.lit": {
+     "bytes": 593681,
+     "sha256": "7e0e86d57560c44ccc488ab715b2598267da0bb7ed8c638e94a4b44e788e68c8"
+    },
+    "maps/retrojam1_mfx.bsp": {
+     "bytes": 2644832,
+     "sha256": "fb26f5956e126bce6cfe5d730abc6a9cb7d7270fbb1cb537a9fa50116569f89f"
+    },
+    "maps/retrojam1_mfx.lit": {
+     "bytes": 1166339,
+     "sha256": "3a526843961b7189031b5447b21c5213ce45846363c539ab5772b4d51b0e5ea5"
+    },
+    "maps/retrojam1_scampie.bsp": {
+     "bytes": 593866,
+     "sha256": "3a06bb12933eb325815a1788073d21658b8b12039627ad349a792641baaed4fc"
+    },
+    "maps/retrojam1_scampie.lit": {
+     "bytes": 265550,
+     "sha256": "5512377f4a0f1c83fbc4bc919f9c51a1afd5044805bc0ba662f4e81c815faa33"
+    },
+    "maps/retrojam1_skacky.bsp": {
+     "bytes": 2139465,
+     "sha256": "d703b975d5597e2930b0dce9e5b52fbc79d3b5d2ca9fc2358374f6b5c4495787"
+    },
+    "maps/retrojam1_skacky.lit": {
+     "bytes": 617015,
+     "sha256": "860a651cc5a944f70de36763d848c9091e38cdd131b5a04ce11bfb7a2e3e5d2c"
+    },
+    "maps/retrojam1_sock.bsp": {
+     "bytes": 2120648,
+     "sha256": "dd5ce4784c62235ac35fe27527e4b6154e6250a72256c08d185d795622e2139e"
+    },
+    "maps/retrojam1_sock.lit": {
+     "bytes": 839885,
+     "sha256": "2c695371f4e09c307556179111bafb96d2c80bc4dedd5c933984ed286c84db40"
+    }
+   },
    "sha256": "8fe0de60028d971525e389969df9773a270981165f4295fb3b738e4535eb687d",
    "timestamp": "2014-11-23T18:36:16.000Z"
   },
   "pak1.pak": {
    "bytes": 273011,
+   "files": {
+    "maps/b_batt0.bsp": {
+     "bytes": 6980,
+     "sha256": "0d481a2e2cd7a23e4ef19c19622195007bd6c9a67135ef739b0944a02d46fcd7"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6964,
+     "sha256": "34709c1c06ca34305a8ba1d4799d1cdc07e44ff33f3c7fa11c3d5933cb942579"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 7124,
+     "sha256": "d3371655bed274070fa98fb32b408bab4a22fe754f5158c8c94a072749a5d24d"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 7764,
+     "sha256": "abdfe383c13da6d5dd7a9409fa5d3db2c4bac78482eb75c2c2b42da7811ec3ca"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 8788,
+     "sha256": "2343448faac29720e3a690650b70623852710dcae002917ae5772fa597117e17"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 5604,
+     "sha256": "66ea23f1cdd6225afdd1b7cf1247b93d174562193e0807561b96b659429f2bf0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6820,
+     "sha256": "366ece777ae71ecfebaa9f4bebafe2074b5336e7939900f46bd9521886f9f42d"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 7092,
+     "sha256": "56a66aa3d1364a0436ff8ce880268b2a9c2c396ab02f0c6277535d5b99eae31a"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 7636,
+     "sha256": "ddd60cec57d8e3954c1ffce616ae862edb784417a6b6622cc001d408383a6cb9"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 5396,
+     "sha256": "fe60bd7880da73571e29fa4075968cccb06e913bd2b9475868ce31c69b1a8c19"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 8436,
+     "sha256": "6a2c2c3fa6f88d425ae5b9568e5d8224ee901a1d8faa8363b88fff569b7d0e5f"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 25812,
+     "sha256": "1ba9d3176bb2e03a0457427fd9394d8c15eb9ebae8af9462e955e9c6c6068513"
+    },
+    "progs/end3.mdl": {
+     "bytes": 19700,
+     "sha256": "445af16e28fff506ad65fac16b09dad1672e218ffe0183880aff565578b315b8"
+    },
+    "progs/end4.mdl": {
+     "bytes": 19220,
+     "sha256": "cf52525422a102760bfcabd6e8dd5c5df7c2028daea5baa2a1b1717648dd143e"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 3860,
+     "sha256": "256412b0d88c020fb03efc5e914c5dd721c9dfe8d6a36ce4a7b01e7597d7e7d5"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 7108,
+     "sha256": "d4c5b6316aa02d600951c6a8ec1f4682568b9e877e988cf4cedd77c0e95cf663"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 21412,
+     "sha256": "1274fcabffa89a786b29c9238cf84e95a8557369239b4a9eb813e3dbe37d35ac"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 5492,
+     "sha256": "ecf293b2e8146a33de7bc8bb3cded80bb785b931012b40dca204db3dad50e776"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 22052,
+     "sha256": "c5657b558522e46f0833b7827520c1a5c1f1674dffd52c12609779d5bcd75462"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 1396,
+     "sha256": "945ad552ad86e5193ef9c007dbe23686fbe89be1060063f57ea693b89e5df229"
+    },
+    "progs/spike.mdl": {
+     "bytes": 1396,
+     "sha256": "c5e6afcfbfe35ffde5bda7eaf91e2a583c3f20cf8f3175b4f4e0ad03b358983c"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 9012,
+     "sha256": "06e8f32092cbc0b5ba4d26227df9ac2d10f3a76d9a63bc7928af147b4ade12d7"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 6356,
+     "sha256": "40d9d29c58df57ece6892d71d0464022eb5939aa45699e98eae22136b973c4c8"
+    },
+    "progs/zom_gib.mdl": {
+     "bytes": 19768,
+     "sha256": "2175cca881b4a73adf3742933a5d3e91116c774ddd3db9b6ac2a7f863194d4a8"
+    },
+    "quake.rc": {
+     "bytes": 1319,
+     "sha256": "23d89f55c4aeec778b24e215ce38088b1ad23525c006f09a18ea433d93a03380"
+    }
+   },
    "sha256": "b1f60d3240e39106bef8e314f045e84c1bb26120900a4c41c33865707a98fe99",
    "timestamp": "2014-11-23T18:35:20.000Z"
   },

--- a/json/by-sha256/ab/abadc40fb6f22c5499ce92b9b7948e556f6fa0402d1cf8a04bbd4944e38f18e6.json
+++ b/json/by-sha256/ab/abadc40fb6f22c5499ce92b9b7948e556f6fa0402d1cf8a04bbd4944e38f18e6.json
@@ -12,6 +12,296 @@
   },
   "terracity/pak0.pak": {
    "bytes": 9024953,
+   "files": {
+    "maps/terracity.bsp": {
+     "bytes": 5411332,
+     "sha256": "61b2d5d5a86a1a64b0eacb46ed1b452dba8c9f5a59102135ab846772a9573219"
+    },
+    "progs.dat": {
+     "bytes": 631612,
+     "sha256": "85b217f85f441f20c5759cb727f7965b3ddd9fc0542b08af8881590b40493b82"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 44076,
+     "sha256": "c7c0c6fea1a1d8b575388f3045b7dded09953d13ec070c8182e9b28b0506408d"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 19348,
+     "sha256": "4aaef7b8d28caa52dc230bed11cdea22f55c00b9b90aae400e1c19f7bf3dbbb6"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/fogspr1.spr": {
+     "bytes": 3192,
+     "sha256": "15be3c9f6f1d68efa821ff8d4f29a2e969b0c2944e3c71cc36626c4b471a991b"
+    },
+    "progs/foliage_bush1.spr": {
+     "bytes": 4152,
+     "sha256": "673e2a4f5ada41dbdba72191b7a82f89148279091643d41e3a7db50771b355cf"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/horn.mdl": {
+     "bytes": 589640,
+     "sha256": "37e201448c56afc84da453d653ec0661d7e2c656533665cbb6c74dd7c30c7746"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavaman.mdl": {
+     "bytes": 190588,
+     "sha256": "b81bb7f5cebb2889cfd2f431f743200f672d0195b05fe3faa98b50163fed7fb1"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/s_light.mdl": {
+     "bytes": 27596,
+     "sha256": "88e4f9751b4c6b5baf80cbd5343753fb7b99c183755d3c8ed82b682513d42d4b"
+    },
+    "progs/s_light.spr": {
+     "bytes": 6300,
+     "sha256": "fa7101abc901511d99a045b45567524aa25b079115e86efee4adf0327c69af87"
+    },
+    "progs/s_light2.spr": {
+     "bytes": 1080,
+     "sha256": "4b9c1ff3b30b5900b512548c089513eae872e5b2256aeb4c14596c5aa837bfe2"
+    },
+    "progs/s_light3.spr": {
+     "bytes": 1080,
+     "sha256": "0cb6c5d37ea58d988b5aa068240482e06336446f0a3b9e94ed66d06ee155c735"
+    },
+    "progs/s_light4.spr": {
+     "bytes": 1080,
+     "sha256": "fab888789e06b7253dc00fcab3cf0bff67366136df32a6d33d5c382d8469de8a"
+    },
+    "progs/s_light5.spr": {
+     "bytes": 1080,
+     "sha256": "e5444684412840aa0be2c454e5cb238e6f20ada7a79f9da8016a392465a5ab96"
+    },
+    "progs/s_light6.spr": {
+     "bytes": 1080,
+     "sha256": "dbd4c3e1a777997fb3f67c0abb5fc3670ab77686e83600e41737c3628eb3b1a8"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "ce6c16618f236e72f00965a69a8284395b3157788ca988ba5c7b258cdaf2b929"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/suit.mdl": {
+     "bytes": 51236,
+     "sha256": "17d57805138e93283f133d1d4f42ffe5b61bedb946b62bb96cce6f5c1a7f9acf"
+    },
+    "progs/sword.mdl": {
+     "bytes": 37060,
+     "sha256": "a72818767602e676cb08aa19db1780df9ee71b1f5c650f24c4f7ad2f761360d2"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 186084,
+     "sha256": "76430f4aebfb39e918f524d81d5012051e49d0749f6f9a692ae7445a15cc8dfe"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambient/wat_amb.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/ambient/wind1.wav": {
+     "bytes": 308910,
+     "sha256": "aa1c42b3a8ca30b9e9a459e96db5200137eba5df44dada9362425fa7c1d1fc16"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/equake/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hknight/hit.wav": {
+     "bytes": 6260,
+     "sha256": "5d71ec8489d54c6cc0814c1216054e0e7e22f67ab8d0eb5c73edcb792123748c"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    }
+   },
    "sha256": "a5bc44cc7244f5d016eb87c62e09c0a209f60291c116ebac024b282ca060e26b",
    "timestamp": "2013-05-11T22:29:44.000Z"
   },

--- a/json/by-sha256/ac/ac8bd9410af3db914b2b4b942188fbc5f07e11ab4f19083b29e587d3f8e6893d.json
+++ b/json/by-sha256/ac/ac8bd9410af3db914b2b4b942188fbc5f07e11ab4f19083b29e587d3f8e6893d.json
@@ -13,6 +13,236 @@
   },
   "pak0.pak": {
    "bytes": 9660259,
+   "files": {
+    "demo1.dem": {
+     "bytes": 311252,
+     "sha256": "4b92779e2f9cf416825c4b08381b3c9392045ff5691224d139ad8c01927099b4"
+    },
+    "demo2.dem": {
+     "bytes": 357498,
+     "sha256": "114120022ebe2113e77c33ed213f672e652de5b0481b50623f8351d9e0c888ee"
+    },
+    "demo3.dem": {
+     "bytes": 590085,
+     "sha256": "210cbb575f8236c0486cd61e343a73d5d5acefef987fb8cb049e2406f4405f2c"
+    },
+    "maps/coe1.bsp": {
+     "bytes": 1488064,
+     "sha256": "3bbf2414787c5bd1e94d3b3d2971eba6a4c4f1ea7d07fcbb14ea99cc58bfe615"
+    },
+    "maps/coe2.bsp": {
+     "bytes": 1450996,
+     "sha256": "57406815230321b7e8d1c7b4a5ebddbd35ff0473a39b73ced3d6ea31c56754bf"
+    },
+    "maps/coe3.bsp": {
+     "bytes": 1440776,
+     "sha256": "70d62a4269ed3304585f4611bcfaf18be0ca3141bd2d0b80ac84db0b09bf1bcd"
+    },
+    "maps/coe4.bsp": {
+     "bytes": 678600,
+     "sha256": "f321e3c5edd3ed13f20331fcab9942fbcd8fe25c00293b24f5e402be75cbe0a9"
+    },
+    "maps/coe_m.bsp": {
+     "bytes": 218356,
+     "sha256": "59f1ff90bacbdc5ba649af919633c86bac55ca91eaf6ad6216c73b092a29a1ab"
+    },
+    "maps/coeexit.bsp": {
+     "bytes": 242552,
+     "sha256": "044bd6cabed0ca519fad905fd364f38c70c651ec2402aa4c3e604e680f4394d3"
+    },
+    "maps/coestart.bsp": {
+     "bytes": 643544,
+     "sha256": "de1c3956d7ba95b7824c45338958a66fe42bde7b7800c440617af278f1f99d70"
+    },
+    "progs.dat": {
+     "bytes": 468896,
+     "sha256": "b305c8f7bd063f2345fc9a4c513cff298d41db725aab05796cb966702e00b9eb"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 106244,
+     "sha256": "2ca415ec913b3c05038c6db21f9235edf7eefe7cf41120edead53efb90ff0ef4"
+    },
+    "progs/fbolt2.mdl": {
+     "bytes": 11860,
+     "sha256": "2d776e4acdf20cd117f3f4d6be3647fb9d0e117756069cbfc52ece716fdbb251"
+    },
+    "progs/fragwiz.mdl": {
+     "bytes": 221076,
+     "sha256": "4301fe35d26baccb59526a6885335cd033b6c8c0271ffe36f3d25fd0de1cf57a"
+    },
+    "progs/h_trog.mdl": {
+     "bytes": 28778,
+     "sha256": "13302ec9240863651316e87733455f5fb5753f35278d8600bc9f6961e11b0238"
+    },
+    "progs/hlord.mdl": {
+     "bytes": 228400,
+     "sha256": "5c6584f39fe2be96a601a4bcac860128cb98986b7b3053e4e7d5554eb38f9ddc"
+    },
+    "progs/knight.mdl": {
+     "bytes": 153400,
+     "sha256": "26576f139d258b3c236faa6552d8ba09ef6e14480d4a2e2dc9e3e2c4df5177b6"
+    },
+    "progs/trogball.mdl": {
+     "bytes": 136671,
+     "sha256": "e0f0ac46b0173ddf761210d34334dc1b07196f0b8941d6027a5831355f7bd0e8"
+    },
+    "progs/troglod.mdl": {
+     "bytes": 98400,
+     "sha256": "48bb6420c135f3348c944fad00fb428b1403c697895e2b4cd40cbd9cf4fc7dd3"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 76043,
+     "sha256": "ed80eddf26e304083cd1a08349a900b9e0b4c9c91ea4e9d49d75a838b916916d"
+    },
+    "sound/axeman/adeath.wav": {
+     "bytes": 11714,
+     "sha256": "c6d2e6a1107eddcb49ca41776da1c7f8a3b27766b66dbf4bd9186fba2780cb2c"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/apain.wav": {
+     "bytes": 3302,
+     "sha256": "788466ee8cc368bcac8b07c4eeca5509ccddc30addf5a322b31a605d90bf0392"
+    },
+    "sound/axeman/asight.wav": {
+     "bytes": 8528,
+     "sha256": "d5d1a9125b9a015186d6d5e9fbd9f9d9db3fb220bdf9139f5aa73b9019d37126"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/fwiz/dsbospit.wav": {
+     "bytes": 43718,
+     "sha256": "e78640cf0bf9d1c22f489a01358385555acd40e17e7641f80c69aceb48dcbc18"
+    },
+    "sound/fwiz/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/fwiz/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/fwiz/fwiz_d1.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/fwiz/fwiz_i1.wav": {
+     "bytes": 21194,
+     "sha256": "08454d31d601d329fd9ebed7d16a78bd64efdd6c36741f68602537b990099f9e"
+    },
+    "sound/fwiz/fwiz_i2.wav": {
+     "bytes": 17618,
+     "sha256": "c61c969fb71f68d2de2b9e0a895eb3147183cdc98acb2b9f1abbff0e8e6ac4b5"
+    },
+    "sound/fwiz/fwiz_i3.wav": {
+     "bytes": 12252,
+     "sha256": "a94fdd14816c001bdbc135207a9fa8486d4e36d668c68ab94b3faf087bdd9115"
+    },
+    "sound/fwiz/fwiz_p1.wav": {
+     "bytes": 19412,
+     "sha256": "f37e247a9e1436e4a86b78fe71e1ea6da43323e60943e86784ac87fc4393333b"
+    },
+    "sound/fwiz/fwiz_s1.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/hknight/death1.wav": {
+     "bytes": 15468,
+     "sha256": "b0e9cfdd68223d49820d03c2f8e5f59ab94e0f284d6865f492ae1a9d4fb13473"
+    },
+    "sound/hknight/pain1.wav": {
+     "bytes": 14568,
+     "sha256": "a069f8260f241acecc313dd0d2e688763052cf65c32597c5779d4776497fd6fd"
+    },
+    "sound/hknight/sboom.wav": {
+     "bytes": 56376,
+     "sha256": "1df051b49aaec9b19e1f49348aaf6d9c19aad3e4591c12b18c4fcbf3c0a73218"
+    },
+    "sound/hknight/sboom2.wav": {
+     "bytes": 14764,
+     "sha256": "b30e18bbc0a12db2032fa95d5d0504ea63eaa13b3bea34e3b42ec59f3ca4d815"
+    },
+    "sound/knight/kdeath.wav": {
+     "bytes": 17854,
+     "sha256": "b712871a7316df7f6341719d488d67e65344f20d8561c97ae3115dde67cf0bfe"
+    },
+    "sound/knight/khurt.wav": {
+     "bytes": 7198,
+     "sha256": "634a88cf26b4de688bed392cf108d5468749f212ce67015c71baa942e8e88502"
+    },
+    "sound/lord/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/lord/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/lord/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/lord/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/lord/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/trog/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/trog/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/trog/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/trog/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/trog/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/trog/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/trog/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/trog/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/trog/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/trog/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/trog/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    }
+   },
    "sha256": "335aa77c31d1833cf158982fde161a49043f8db6a420d8b01bb61857a5bd72bc",
    "timestamp": "2000-12-07T15:15:08.000Z"
   }

--- a/json/by-sha256/ac/acf882ba1e9fc68fb183f7ae3720947f48614128f46f1f9171f76f8400aa07c5.json
+++ b/json/by-sha256/ac/acf882ba1e9fc68fb183f7ae3720947f48614128f46f1f9171f76f8400aa07c5.json
@@ -67,6 +67,356 @@
   },
   "savetheworld-package/copper/pak0.pak": {
    "bytes": 4227276,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "591744734a43a1563ee0e419fb2464783c70a3245c14e09ff5c3f022418f1e4c"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "1bbe11eff4ef46f43af7bbc7be43c69cf76543ce7fae26931939a541cb8cdae6"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "fc226280c4948249790f00f97dd9b39e912131fc904ec75adb90308ba8763afc"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "9eee444c1db402805bcff09378344c5a048b6c23ff6054edbfff16dd60b76f0d",
    "timestamp": "2021-08-25T15:58:24.000Z"
   },

--- a/json/by-sha256/ad/ad6e99063403ba3191b0300ba57dc0a89ee019be9f6f35dcc8ecb45be76bbec3.json
+++ b/json/by-sha256/ad/ad6e99063403ba3191b0300ba57dc0a89ee019be9f6f35dcc8ecb45be76bbec3.json
@@ -78,6 +78,2224 @@
   },
   "alkjam/pak0.pak": {
    "bytes": 295721033,
+   "files": {
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "a82933959a7965cbd825f0152c674ef9b4ad36c58ef92c92519c0e722741b992"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "6072bd63a691625de201f3f3da060b5df433753d7ac2878c48b87e9d0dd08b94"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "ac11a967228e1c7d1a936859b82807cea239d80380fb6204d67af7a86c5c82e3"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "4cb99cf1b515b6547f012b6e44174c245261b058168a8bc4303d08b98e1805b6"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2c37b7697aebedb5bbf6637d4b8e158f70da6b7245195ff0e91a6ba7aa24e828"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "219002fe962a017600a37dcdcaaa0f777aad42044619f945cb70c68007763a97"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "e251893ed49aeb677096d380d4246907a039e0e21a4849f97f343b0b13faead2"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "64ec646cbab7ebca11f6af4f0b75d9706f438baa7b23059de87f8685f4686640"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "03c7cdc618e4404e2b9364c690b0a447b4be99dc5af112c66e6e2079902c76cd"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "9cf2683f2a6d22693a8c0cf35898bc5900a96afc771878df9f8a8a88f3d581c9"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "f232da5cf35acc557f3f312911e6a856cffaaf9f8078ca2ac5ef7e6f6e5e3515"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "13b70ee6751f20eb32bf86678a3bbf0ae34dfe810b0feb9f21a488efe0fa099a"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "873af58b7244d6e82feb1af26ac044c9beb43c2865bc51d0485054a562ce861e"
+    },
+    "gfx/env/ares_bk.tga": {
+     "bytes": 481498,
+     "sha256": "907a96e8feaada0ea37d72d99070961883ccdfba8a6b3914dcbb9afc472d18a8"
+    },
+    "gfx/env/ares_dn.tga": {
+     "bytes": 763001,
+     "sha256": "fcc51de57b71899ef969b8380ebd22269aa1e9957bba845413cb4f5394cbe49a"
+    },
+    "gfx/env/ares_ft.tga": {
+     "bytes": 490443,
+     "sha256": "8c109f48b7240f7138353a19017921660ccef0260945ae4a4792ba12c7bf3730"
+    },
+    "gfx/env/ares_lf.tga": {
+     "bytes": 503381,
+     "sha256": "ce0a40f558e72dba7653fe7f693d7e0406afa50aed1fcaac6cda2e857ac55a46"
+    },
+    "gfx/env/ares_rt.tga": {
+     "bytes": 497671,
+     "sha256": "a8033bcdb9db86386582caa29e8aa53946821266da730e17b775869a5458cbbf"
+    },
+    "gfx/env/ares_up.tga": {
+     "bytes": 106191,
+     "sha256": "d0489c8c9606a31fa3d929c1f2c561a162116333edda74f9236203eeadb1a74b"
+    },
+    "gfx/env/doom2016_hell_titan_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "f1bec0f5fca61e0aa38c0bfefc735a5f467c026b80f1c5c30afddb947156979d"
+    },
+    "gfx/env/doom2016_hell_titan_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "1c99590f1ddf7b57869207492c2e2b154d3b554a32dc22ab259cab05bb291ca6"
+    },
+    "gfx/env/doom2016_hell_titan_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "978806bbb9c5c22898dc8c23f78f06f63438a89109f03caa8a81c3aa14340ed6"
+    },
+    "gfx/env/doom2016_hell_titan_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "94e8b8d1cdd39db025e3f24c3be11a19c641794512950cc0e52938e612fe516e"
+    },
+    "gfx/env/doom2016_hell_titan_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "930e85c98df23c9a4a400561b206fee3e6de2ce1947609416d3a31524ed5cd4a"
+    },
+    "gfx/env/doom2016_hell_titan_up.tga": {
+     "bytes": 3145772,
+     "sha256": "8f42929d4c744fc8e07dae7b342e6dde9d3b77637dd79463d5ddb4e865743c36"
+    },
+    "gfx/env/mak_ring2_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "366334e7918afc60210a1917ddfab286f841610228e9fdc01f7f74e4a451a451"
+    },
+    "gfx/env/mak_ring2_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "8a90a4a7916d43ac701fd47efbd9d70c60447758d061f9940562eb2b6ee38f16"
+    },
+    "gfx/env/mak_ring2_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "485c5ed87396397fe0559d708f9dec0843ac13ab743c95d83b9644f2ab5ef490"
+    },
+    "gfx/env/mak_ring2_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "9fcdca9f520fa9146ec2adedc0f952e5af24eaa729eb685981f2002f6c8364cd"
+    },
+    "gfx/env/mak_ring2_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "8bed9150a72db53c80c95b65adf1afedf0392c67fb4293abc6cef895d6c912ea"
+    },
+    "gfx/env/mak_ring2_up.tga": {
+     "bytes": 3145772,
+     "sha256": "46a43a11f4ae5c1d5005a086b722619d5025146d73ff6fe8ce21c339369106c8"
+    },
+    "gfx/env/moonhigh_bk.tga": {
+     "bytes": 1048620,
+     "sha256": "5f361bf5a352c1df5a6caef9cf42bd35fed8406c6949af480b0425c193c18b3a"
+    },
+    "gfx/env/moonhigh_dn.tga": {
+     "bytes": 1048620,
+     "sha256": "02e2b36863c1181a85aa675c53fc14a301f38dc6e0c6735098bb6d8723af02b3"
+    },
+    "gfx/env/moonhigh_ft.tga": {
+     "bytes": 1048620,
+     "sha256": "3158735bdd6f4f467a5b29639aa4f622d1136ea463967684b739b0002bec6526"
+    },
+    "gfx/env/moonhigh_lf.tga": {
+     "bytes": 1048620,
+     "sha256": "5cdaabd99655152689e40832643690d7b1c5f8e414f3126a7c0c9224f2250704"
+    },
+    "gfx/env/moonhigh_rt.tga": {
+     "bytes": 1048620,
+     "sha256": "e08a374ac19c8b8cffa6c939515cde9570b44bbc044c12d06b0c5d94aa7469bc"
+    },
+    "gfx/env/moonhigh_up.tga": {
+     "bytes": 1048620,
+     "sha256": "c0465fd6a0b069e5ff78f3e561084bf3e23b796cac9b5214a6cd4045310d36fe"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "ba75badfe057b499d33168032dd5dc5a4fd0dcbaef9cbbd27efdb3f056cbfc00"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "55ac1377921460aeb691f86e7a5051e3a5481f24b93cc8578cffdab2854ba0c3"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "9600a66391996cff88d48890adfa516660fce6a32397ba4f54973159785cff4b"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9f03351fa7f31a23b63e6c13d2a643ed1ae3fd3df0cf2b0db336424eb17016dd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b7617428e8d1d74be7b770ef24c744d16c2503efce9c17facf1107cce08f5ed9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3036afb422cd299cb09532a20847ef35aaf87bb36e34ce9ce75b5e7aaf9a1ec3"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "7aa61257bd3083c00959776eb36aac86a7ca8da2bacbb4c8a41d9a5fb0b1ab97"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "cfe83953875acfe9afda11b75407ed9883eeb284b0a67b9ff6e07df85d50d9fe"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "d3b4091b83837da5a45445cd00b90267c62050e010e2a045461034ac9c48be33"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "de004dcecdff1973597a977ab63c671ad7d3f52387bdcff4be560924e3d4d17e"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "078c56d685ff1fb84b322f7a76e485c2637fb09efc61f4e44d5d067b3ef9a42d"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "9df9672c8da61ae769409e9ea741a1b8f9a4f108b5f0fa6637ff65601c535843"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "fef6b9be45d5b384d061a47f133075d1cfe0b60d93cf7e3da9ee5529f661964c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "1b1254c1f5764affca85448c4a3c2fefdb938f35bc50f44142a8e9b692ba7d64"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "39a06ff92831e1e2fd20c1bdd20e0f234cd0b3aed94e6c9909d059a20479ce3e"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "def061c922fb91a7e58850e89bb6baa9e09dcf93de7a94288a90511ecd9a114d"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "f897535531fe4b821d41d859a4085fd7d25c679493645a2ef7448f62073523c4"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d070636562a967d1abff330dcd1ea504ac7b9b29099a98994add1d9ae47e44e9"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6d92547a27d839f3c9d7a1da786fb33547cd93b7f19560b6c4bcdc12064545bd"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "e932416c58fc5de16e6d05aa737e56d3811e540bfd9e6acd1bf114ccd8bf34ac"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "bda55d4b2d7bc3f180dafd62424ee5830896563f5a5ac576dfa08894f5e17e44"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "513955ecc96eb1f0d44b340b47f79c02bb7bfa7f3b0a884a65fe111429ddb2b4"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "2faa4c1f61d175ad28b7f54540af3f87abc6e56dc20f2da5fc8a7737a0302c97"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "dcfe5287432b3a1124d032250ccc4bf25c73540521c77601ab746287ef3a0179"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "00654b7bec9981508cd9ae8eac167637926c023e7bca011a3cf37585b7e168a8"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "74c50b895f1e71ec6a569fba0e991fde8cf136ea734d6914435aaf9b2735d7fe"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "aecab7a199a4db72242659e6d1ced192d39b2619f67c7e5eaafa72a5efef3aef"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "d075eb0c8c00d30b01eae539720c20b73bb57066c6ea5e8180a4d851d9167add"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "d03aa05e24552d961ea9ca278d743860e34a97e2ffcee52fded05ad4b4740bd9"
+    },
+    "maps/alkjam_alexunder.bsp": {
+     "bytes": 41355328,
+     "sha256": "9cc16a0fb885f04b50e3e9d6fdb984510c985a5b697d01524682ebb931d8afb4"
+    },
+    "maps/alkjam_alexunder.lit": {
+     "bytes": 4823789,
+     "sha256": "1af572e88db22884da2c9f4559170f568124c3d61946c42ca2faf6a719c11d84"
+    },
+    "maps/alkjam_daizenzetsu.bsp": {
+     "bytes": 3456416,
+     "sha256": "5f3d8889616e4636d4beb242345ea0e132bb9e21c8fcdd3e52e5934a1817dfb4"
+    },
+    "maps/alkjam_daizenzetsu.lit": {
+     "bytes": 2048633,
+     "sha256": "aa93512114739335b51458333681cc9ae6d134c4a734cf5ad0a0cf35ea640f7b"
+    },
+    "maps/alkjam_dfl.bsp": {
+     "bytes": 5968892,
+     "sha256": "8901143c57e1cfbf2f1dcb30dcbbdb5463776ab79d70883df0439840648c2516"
+    },
+    "maps/alkjam_dfl.lit": {
+     "bytes": 2258159,
+     "sha256": "479318ebbaaa94771b9de7e843eb12c478723d5e9536e887963bf9da04ee76c0"
+    },
+    "maps/alkjam_emeraldtiger.bsp": {
+     "bytes": 6713300,
+     "sha256": "76a56060c7cb3fb410e8ec70e8111d07fe2b764454321ed8a79f3befeae210ab"
+    },
+    "maps/alkjam_emeraldtiger.lit": {
+     "bytes": 3199955,
+     "sha256": "f63ada764e9b43d0df064822c7e7f75dfa64d0e44226c76ea18a6f67160dcc02"
+    },
+    "maps/alkjam_greenwood.bsp": {
+     "bytes": 7137484,
+     "sha256": "40cef87a9ad16c9f8296561912275902ca232fde02cb5efc00d8bd6cbf55ee85"
+    },
+    "maps/alkjam_greenwood.lit": {
+     "bytes": 1537796,
+     "sha256": "aeb853801874435ef33586cc8e2588021c81c6d68d9bb923f79d06e0e8dc009c"
+    },
+    "maps/alkjam_ionous.bsp": {
+     "bytes": 4246836,
+     "sha256": "8c4f3c7a8e0b633720aea059bcf3922ef307f6b1549d8c32654f4d32648a40f9"
+    },
+    "maps/alkjam_myki.bsp": {
+     "bytes": 22476140,
+     "sha256": "eac7724fa41ff88da5785dbc85408754ebd347951bb58468e1101360793fa8e1"
+    },
+    "maps/alkjam_myki.lit": {
+     "bytes": 466625,
+     "sha256": "fd13e9280cf439180e7e5fc0ba8b518b4cd5affa9178be2529bd9bb580b8a977"
+    },
+    "maps/alkjam_plaw.bsp": {
+     "bytes": 24702988,
+     "sha256": "cc3d7d9e9348d3299d65ea363c02000b5509549f3d08b997f9536ee44db66a2d"
+    },
+    "maps/alkjam_plaw.lit": {
+     "bytes": 5483210,
+     "sha256": "9fca654e862e6013806cdd87b4d6694c7bb8ed02d35f1f44152b9f12b6bc7a75"
+    },
+    "maps/alkjam_radiatoryang.bsp": {
+     "bytes": 11634660,
+     "sha256": "bf334c1fb096451cdfc246bb3cf21a0b3e08b294bfcdd3b607d51a2dd0aa05cb"
+    },
+    "maps/alkjam_radiatoryang.lit": {
+     "bytes": 3670289,
+     "sha256": "1c7145e257d1d3ee9c1b94eee253313d31938da4b1b2b52f66cb6fe53f98b3fd"
+    },
+    "maps/alkjam_shades.bsp": {
+     "bytes": 21351588,
+     "sha256": "ecdd38f73057a706ce87c06d3f0e72e5f744cfa946e7850f3afca36e8b90751d"
+    },
+    "maps/alkjam_shades.lit": {
+     "bytes": 772109,
+     "sha256": "6b9fb509868575ccfbf9580c7b0070fb2f471860f495370b0a3ddab2311d06f3"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 20040,
+     "sha256": "61c46ac5672c1e671c0c38a6498158176feaa62b074621c2a3d74e5dfc68e2f3"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/enemytest.bsp": {
+     "bytes": 663076,
+     "sha256": "2f315bf648b83be0fbe07a12399ef8ba5c4c2c06e7c9a57b0c48d18beb788e99"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "maps/start.bsp": {
+     "bytes": 6898328,
+     "sha256": "e7174dd39039a8d2687e3268d4855982f846c163ca496cf1e0a8de33a7a33d36"
+    },
+    "maps/start.lit": {
+     "bytes": 1014608,
+     "sha256": "1a219c4171cda9474b6fdbc329cb7305ba8b6292b44ec15e8b2d94cf62fef66e"
+    },
+    "models/wings2.mdl": {
+     "bytes": 28980,
+     "sha256": "5342d6191f59e69eb830a5e833473ac253b3a7750063d5519f6d2da2b82f5573"
+    },
+    "models/wingsBig.mdl": {
+     "bytes": 28980,
+     "sha256": "911029356852f1d839f729af0ce1c570e68197071b41970311043575f064c15c"
+    },
+    "music/Track06.ogg": {
+     "bytes": 3223426,
+     "sha256": "acea2a2073c88f1bea8f35c90cfe3f68cb52a0a79d940dae89148a64352733d1"
+    },
+    "music/track03.mp3": {
+     "bytes": 3334103,
+     "sha256": "301569d9acb6ea22a7f70399bd8dc7492b3a37460639f8a81f216c870f5e38f7"
+    },
+    "music/track05.ogg": {
+     "bytes": 4877264,
+     "sha256": "d012b82c3bb9b3a567038bca72e85ad22bdde857fc7246e4ca2a9258b8615747"
+    },
+    "music/track08.ogg": {
+     "bytes": 3352457,
+     "sha256": "0edf3cae4f07765263eb23e1c659e1ea77f26b77a9adc998454a9912c2271b67"
+    },
+    "music/track09.ogg": {
+     "bytes": 4288381,
+     "sha256": "959cc98c9b38e6abb8b75d0bd44cd8d40c8381a78da67a68ce8d0c77fbe0a5a4"
+    },
+    "music/track11.ogg": {
+     "bytes": 2290360,
+     "sha256": "11a45a41a65a0dcb60a123e351c3116a1034554cfa10546f1b4d94fa54f28f51"
+    },
+    "music/track13.ogg": {
+     "bytes": 1445065,
+     "sha256": "12cb7ffd706ae9c61b161ee01a43f8ae744bc2c182bd15988c13c299b8f3119f"
+    },
+    "music/track69.ogg": {
+     "bytes": 6652174,
+     "sha256": "d2ef8b16bfa35f25d49734e3d99e107c94632408f18ebf1eb36a4be01f08b9e0"
+    },
+    "music/track77.ogg": {
+     "bytes": 3711921,
+     "sha256": "8a2f05cf83aae81d6d9e6064413bb970ac573573b2326e6aa1cd99adf2156427"
+    },
+    "progs.dat": {
+     "bytes": 833950,
+     "sha256": "53a5bd4923bee2fec389f157a18a91be128ad0356a9adbb89f7d8f8c44ca87af"
+    },
+    "progs/alkaline_logo_spin.mdl": {
+     "bytes": 73332,
+     "sha256": "882ef8ece61bf786d146859e516c854d87ee48a497736ba6ebebaf84cdaa4b7b"
+    },
+    "progs/arachnofloyd.mdl": {
+     "bytes": 741212,
+     "sha256": "554bd2ad34a830fa01a61dd4972f432812fb61f7815ec81d8a8d7e87bfad6b02"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 164224,
+     "sha256": "35314143b9c7a9a0e26e52a865072a6e73862466e640c6bbd58be3075c4d93ff"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 191852,
+     "sha256": "01dbaa1f54fff28ce64d70aab05f73853332952b76deb2f7f48fb137fce3ff27"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bambler.mdl": {
+     "bytes": 128044,
+     "sha256": "c8ac9dbcf99f0e6efd30496ac414383c26b8d241fbaff56cfa81dfb545dfb0c8"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "698bf740683ad182feae2246526361948be6da2e144f1bd0202eafa748213ec2"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "b662513bc3a8e0e967344c55b536bd33012340dbeb79a8db1281d2c84e36d338"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b2cf62d8e989789bd76e27193b2f5205a93d4172a4e25c89aa1b30f75bebe60e"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigcranea1.mdl": {
+     "bytes": 92792,
+     "sha256": "81f6a5b55d3a585d5e9c73b088d1d20e0fb328707c1539ef41e52c460555f651"
+    },
+    "progs/bigcraneb1.mdl": {
+     "bytes": 21940,
+     "sha256": "e02faff0bb6c84c781f6b534a5a06ac1f977a028fbdcca176be2932f91e9e8ec"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 221936,
+     "sha256": "6e8e12db297f9f70cbe00fe2087be79a0011dc31344e642d8f309947e63cad8d"
+    },
+    "progs/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/chain2.mdl": {
+     "bytes": 141764,
+     "sha256": "9334a3ec04716ce0068154bf7abb4c1e3ee6de14fb159982dd547314935d7854"
+    },
+    "progs/chinok.mdl": {
+     "bytes": 43544,
+     "sha256": "861cbe8bcf369e55d9687fd791b5b3e5813c1511522e594b9094f7614559af0d"
+    },
+    "progs/cyberscrag.mdl": {
+     "bytes": 599104,
+     "sha256": "446468a97edf90c58b04ea703ad0cc0eabe8ee66a35544907bab0b0d084395a5"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon.mdl": {
+     "bytes": 102120,
+     "sha256": "2635e03bd1e78e3e6d3f9f78c2dd4dda7614a3eb4dabd750a772ed80565ebdb2"
+    },
+    "progs/dog_alk.mdl": {
+     "bytes": 199324,
+     "sha256": "a16e350fcd247908c75ecd0c93e94d3b700b67bb0f66dd45d665d171a55d42b6"
+    },
+    "progs/dread.mdl": {
+     "bytes": 183400,
+     "sha256": "efb1827edaced94142bb040b179cff11de98c097aab7fe13c80efadadc742314"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "3a2df91993fd0447d87bc26da842a359df862a12d9993ec7dc1d7aa79c6565ec"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 5172,
+     "sha256": "b0951de4d869e0b779aeb3f7a96f56b22a82a58d267a56b1247f0c3e667c25ad"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 6036,
+     "sha256": "88f8a1f941e38f8528ec27a168559946cc0b69f2abce1cbf6858b813e09c5f51"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bcc6396dc638003480dba8c36cafaf32df2cfcf49bd460b001d0d74a164f9011"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 224812,
+     "sha256": "a10322aa1fee438e6a9f271db2858f5afaf9a560458764425074c2fa1aaf277b"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "ddcf759804fffd97e62c55f67f962e24e8cd646fd982215ac8aefd3e49f67660"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 160688,
+     "sha256": "01eee88d78a0fe8014b86c57b45c235b59548bccc3436c97d8f59c420e865677"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f6c43a5d21e1675e4ad95acbc1a47a3be07ccb74fffcb53574f00945d5b06cf9"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flag2.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flagbig.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 133216,
+     "sha256": "3dc8399722b957bd7afeac28b7b01985d2fbc08ce127a739a9cac1dc945a875f"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/fromitz_still.mdl": {
+     "bytes": 6964,
+     "sha256": "63204597e828e001c957e9316878995e161da0502764276b90285accadf6a222"
+    },
+    "progs/g_axe_alk.mdl": {
+     "bytes": 50460,
+     "sha256": "92988e970870f2b977f7490d2ea4ee040d338fa4bdc470e8d68f2e5a856a7a28"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "15f390e39e02c8524e575ca8fadf63187b641c58210ee9587b13a0ca94c29cc2"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 199076,
+     "sha256": "8e2c3987f1aaf87b1181fcd975ce4cdc8a36738a2802d3535e2cce465fb55975"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "8b05b8ca87ea867c2a2397d238311fda2441f5c0e1cde130ba487b0dbd17a8e5"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_arach.mdl": {
+     "bytes": 60292,
+     "sha256": "daca6412383bec28809cee42c4ebf01085cf83ed6ff289114ba0f842b4005251"
+    },
+    "progs/h_bams.mdl": {
+     "bytes": 37316,
+     "sha256": "58c4644a2ed3e5f10741dff2ad1a8bb161f7eb205ba3fd8c5fc9b7e4ffc571dc"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_cyberscrag.mdl": {
+     "bytes": 62036,
+     "sha256": "b7d18a73dc3d2589224988049c0bf4b0f1c5e274568158e7dd01ca43ae72ed26"
+    },
+    "progs/h_dog_alk.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/h_sabrkn.mdl": {
+     "bytes": 11828,
+     "sha256": "2472f8139353f10017eb9a5cfa1edcdf0d8a42b419213a14deefd3f34556a1ac"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shams_alk.mdl": {
+     "bytes": 37268,
+     "sha256": "25970e45c0433b8f87eeece110d3509decbd3f81cf415ef173bfc7d422537b59"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 37012,
+     "sha256": "e3c6cbabfe6c6723101f2e59f50fc99ee0e360571c95885d2d56c85eefade15d"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/k_laserspike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 8372,
+     "sha256": "9b6a8f7a49fb7a1f5d4d409b708663c579d433e978d898b9bdf00291a59b4e6c"
+    },
+    "progs/misc_barrel.mdl": {
+     "bytes": 43684,
+     "sha256": "8382db232b9a8a6cf6f11009bd8d1806b52ee840c520cea72cfbf5b57c240f26"
+    },
+    "progs/misc_barrel2.mdl": {
+     "bytes": 130972,
+     "sha256": "cc8ebfd0da975358077a6933cdcb4f7ab627ad02c7bd8612f05eb1c873926c23"
+    },
+    "progs/misc_barrelq2.mdl": {
+     "bytes": 60380,
+     "sha256": "04c87c0210d772c53ffc134a5a2a065394dc32f5b36b30c5f24d927bacc24633"
+    },
+    "progs/misc_bigflag.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/misc_cable.mdl": {
+     "bytes": 57780,
+     "sha256": "bed2cca38ef4cbefa9e645eb5e9ffadffac6ebb4f2ac5f6da4bb8f354de22a48"
+    },
+    "progs/misc_cables.mdl": {
+     "bytes": 433607,
+     "sha256": "03c41af692903bb854cc5c05c0a8a665f312a04955737ecbac1a65a4113f6d50"
+    },
+    "progs/misc_chain.mdl": {
+     "bytes": 231184,
+     "sha256": "845fc3117f7d9860f2d0aa4a398103a13f327516144a96db508189ae1be5788c"
+    },
+    "progs/misc_charger.mdl": {
+     "bytes": 117672,
+     "sha256": "a64a62cd67894222e1b2ed25332db70961c18d0cbdffe32b17f0dbac93bb2ceb"
+    },
+    "progs/misc_corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "0287c3e7886bd2d6d1cbb504529d9e11038d0f8232ee624528eb0ccb78733c53"
+    },
+    "progs/misc_corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "22f82f29d0a88af204f7b97eef887b963bd940e7277b6f5cef5e6f3610f2ea51"
+    },
+    "progs/misc_corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "41e90f1a84e9779eb12541d923ab0a66e69deef3a9dbc82259ab84cb71b68dcc"
+    },
+    "progs/misc_deadplayer.mdl": {
+     "bytes": 562960,
+     "sha256": "83bbcf4cb5858aa9ac03323b461b3e3b09a28f56e212645472219d7d0b0979d8"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_extngshr.mdl": {
+     "bytes": 25732,
+     "sha256": "fc8dec001f22c4666f6c5ca65e8aba18d5b22ed8aabbf0534d03913e821e3120"
+    },
+    "progs/misc_flame_big.mdl": {
+     "bytes": 244895,
+     "sha256": "09adba1308cdf22d2f07e226cb13a35e51f4d54866f84f41e2074dc7a40371d5"
+    },
+    "progs/misc_flame_med.mdl": {
+     "bytes": 175400,
+     "sha256": "31c94bc48e6c6d6bc31bd14b8e257c4e74d45aaec3a4d5d5bf83587a08ac7c00"
+    },
+    "progs/misc_gen1.mdl": {
+     "bytes": 256884,
+     "sha256": "7a9124bf7628dfcfc1c43ab6624bd8cef4ac5ecbdd8a00a00e8f957f0d177ec5"
+    },
+    "progs/misc_gen2.mdl": {
+     "bytes": 74708,
+     "sha256": "c93a3f7fbda97841c0c9c7c9b2603d9e388390ab30861c4b1553285985f761a2"
+    },
+    "progs/misc_gen3.mdl": {
+     "bytes": 472728,
+     "sha256": "29032f4dcf60216906ef601d5a6bf20dba71ed5b7ff8260e7f61159b6b8ea1e0"
+    },
+    "progs/misc_hangman.mdl": {
+     "bytes": 96500,
+     "sha256": "feb2473a29e56ee278e4cdc9676306fdf3aa609b527ea4aff23bb86e3900a2d3"
+    },
+    "progs/misc_heating.mdl": {
+     "bytes": 243876,
+     "sha256": "a6ab88ce55f16b670b9ba8e42e96c9ea49acc71f124ce20c0de5fc2c0232e2f0"
+    },
+    "progs/misc_helijet.mdl": {
+     "bytes": 102656,
+     "sha256": "9dc737185928f080758e5a662ea8fd189fcad1aed4fe4547f76d73983bec9c72"
+    },
+    "progs/misc_helijet_pilot.mdl": {
+     "bytes": 105556,
+     "sha256": "8ee41a7ac244289b007921b70fd34f322b4451172f35b0c5b33400064d1c3a2f"
+    },
+    "progs/misc_hummer.mdl": {
+     "bytes": 180541,
+     "sha256": "c41208ecff2f7ea0b037f378aad5fa309af5d946eae009ace2478a294aea9b45"
+    },
+    "progs/misc_levels.mdl": {
+     "bytes": 35732,
+     "sha256": "7cf9a4c1e556e60dd4e593cad4a2be0b45bea8893d9b5232ecc7febca4bbf5fe"
+    },
+    "progs/misc_lightpod.mdl": {
+     "bytes": 81780,
+     "sha256": "e16ac3a669ace065c4cd1806ea0a21a59510d936a3a4c9d74c3ef2ef56e9d4f3"
+    },
+    "progs/misc_lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/misc_lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/misc_metal.mdl": {
+     "bytes": 246933,
+     "sha256": "07c0bb9ff1aa1639a62e5a84fca28d48c0fc738f4d22f8e3d8a5a029790d870e"
+    },
+    "progs/misc_oscill.mdl": {
+     "bytes": 50660,
+     "sha256": "cdc96265a646f9e9fb4c1717fa90edb13e42130fadc4dc774b60aeb94b89eac4"
+    },
+    "progs/misc_pallet.mdl": {
+     "bytes": 509927,
+     "sha256": "1b9c50111cedb48559424870b46a3d19cb1ac5b43ef3f165fbe928a3f7e90883"
+    },
+    "progs/misc_player_legs.mdl": {
+     "bytes": 76918,
+     "sha256": "8e54ec3002d5b0f70408f17941087e595cb20933a08c40eb934cb25e8804d5a0"
+    },
+    "progs/misc_puddle.mdl": {
+     "bytes": 38164,
+     "sha256": "ddb936aa0192e06767d1c1d1407c6ca0145011ebf985c7cc77a49796416cf119"
+    },
+    "progs/misc_radar128.mdl": {
+     "bytes": 19492,
+     "sha256": "ef004e28e51e3227121a92432375531fca26d1e44894696f3d2a950fa65aef28"
+    },
+    "progs/misc_radar64.mdl": {
+     "bytes": 19492,
+     "sha256": "b9468012707ad484c1292cbe984c54811cb8fa43542e68e18a52ef93cb37d52a"
+    },
+    "progs/misc_radar96.mdl": {
+     "bytes": 19492,
+     "sha256": "6239d117263f49b79a2a66e62f2dbd6a7f0cd15ce412c1939dd69b4a1d8fce78"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "cb378259d9ee3b622e52bf1aed10595a8eeb77a9e7873ef8e8bf92e166184c9a"
+    },
+    "progs/misc_seaweed.mdl": {
+     "bytes": 16100,
+     "sha256": "dfbd38a439d392870c7c4c7ebea4475827b716004ca47bfa7f13b47daf07d774"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 31792,
+     "sha256": "8d39b97460c9967ee36b33ea1ef1e92e89277fc410b44f054c5e06b8dc8a079c"
+    },
+    "progs/misc_starfield.mdl": {
+     "bytes": 23548,
+     "sha256": "5b3563017939382680228e933a2a87d3edb030e75e65c51fe42c4a6889e42e15"
+    },
+    "progs/misc_stool.mdl": {
+     "bytes": 85612,
+     "sha256": "12914ff8acc41ef1656aef291edef6d3b0975e994808b8e4e921edcc4927e517"
+    },
+    "progs/misc_tape.mdl": {
+     "bytes": 9240,
+     "sha256": "2b6a08ca3be4dd7a669e5b6d1585276759e1fb0edbe0691dd7ecbc7e41f0b189"
+    },
+    "progs/misc_turbine.mdl": {
+     "bytes": 53615,
+     "sha256": "57cf73dbf14b5b22795033f5b597b30b978aeb6ee037e09648d0cebd029f987e"
+    },
+    "progs/misc_victim.mdl": {
+     "bytes": 1432944,
+     "sha256": "c5d2a99ba39e82bef21cdff5f682b6b80d601f9b54fe0d58d94aae3544b5303b"
+    },
+    "progs/misc_workbench.mdl": {
+     "bytes": 87092,
+     "sha256": "89cb978aaabc4372bacc88ce577c9aefa2a5a4597aada45aa499861150bfe07e"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/nsoldier_alk.mdl": {
+     "bytes": 1349247,
+     "sha256": "6c1571cee6a330f22b0861869b5db7b656138802ebebee23444afb6e7596fd55"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 162036,
+     "sha256": "5792430724562eaf1df08f8d18db34a6e62b27b1836931f2269febe17caa9e52"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 192180,
+     "sha256": "ed04d7428d2947bad6f32d0e2c482161866d58ef5c09ba0447aa02f4be83d4cb"
+    },
+    "progs/ogrem.mdl": {
+     "bytes": 162036,
+     "sha256": "513e1b93bf80dd3e295759bbfad273191bc7746efd65c5f07ce661a3b20fe9f0"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/probebod.mdl": {
+     "bytes": 84296,
+     "sha256": "0afcb661e2091077c6c573b63a270c808f374038d1b29ecddb621f841adb5c79"
+    },
+    "progs/probedom.mdl": {
+     "bytes": 77148,
+     "sha256": "6a386663a961708f1084453e2ca5135dbf4b7dd18a172f8dd146ddc81edc4c08"
+    },
+    "progs/progib1.mdl": {
+     "bytes": 67240,
+     "sha256": "86bb66a12935e910f21a938f7f17c341b399ab4b299693273e4b12d9cee3a4e1"
+    },
+    "progs/progib2.mdl": {
+     "bytes": 61448,
+     "sha256": "d5da8c749192c87e3dc5eb3c365ea2a4e30cc1ca1179f9740598ea28edb8fab4"
+    },
+    "progs/progib3.mdl": {
+     "bytes": 60744,
+     "sha256": "3d5d5da002f8a86eddd3df5f2fbb3b83535f8982ea99bce984d851be7bb1172a"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/rail.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/regen2.mdl": {
+     "bytes": 25460,
+     "sha256": "7f4c06f4a7046908317a61bee2a5810eae03fe99f09018455f1fa0a62f45c5e0"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 200152,
+     "sha256": "a564fba381d24e3084bc9aa0a026381c83e6b889632c8bebdf69c08c8a6bb9f2"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "f65ba83d82e90808af589ded17378f1baf37f105fa14f2b157227ee22583d25d"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shambler_alk.mdl": {
+     "bytes": 502148,
+     "sha256": "bcf685fcd1f4062dc382924d39eae073fc4d44cd2dcb5bc4ca3797fe0b342b71"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "662d6a7cd68bca7a9c5e88838d190de6a501252a14b6994a191d0bc91f1f331c"
+    },
+    "progs/sknight.mdl": {
+     "bytes": 909361,
+     "sha256": "f8ad2dc18653e36630eae567633d84b2e03a52a6cd8c125edafce1c87ff18c8c"
+    },
+    "progs/soldier_alk.mdl": {
+     "bytes": 204492,
+     "sha256": "1297e68fbe701d327f87f51fd492c901ba3f82c75ecda1f2aac81bf8b54ad615"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/supbkpack.mdl": {
+     "bytes": 44408,
+     "sha256": "781c6b5f424fb58e06b2a84b1fb7e980778decde6b3ed257e224db0b1f250173"
+    },
+    "progs/trifecta.mdl": {
+     "bytes": 25460,
+     "sha256": "2c9196af0806c48354f5522a8b7f6fa57e6390f8dfb51718fb71b8a2d4d7447a"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/v_axe_alk.mdl": {
+     "bytes": 55820,
+     "sha256": "80ad34cf2612f8fa9121f2be0ada92c1e05613ae2b35b2a1be25a4c694dd2147"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 141180,
+     "sha256": "bf682cf5cd5fcf5bbfd880cc9c30d395afbec00d8a8c10554c3498fca6b90cb6"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 48964,
+     "sha256": "98a239b4fcfcf78c68079de14984bb8c30b251418044f63c9097c5c16f64da09"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "c9b1d92376ee404102776c630a4fc6fda972c9130fb0f461983c1b6e217a14ce"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 39668,
+     "sha256": "68e38e54cf4aad130c6b3ad2d8ce12ba20e4ffcd4c5a866aae85b69e56ce50c3"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 326464,
+     "sha256": "c015e3606a6ffea0daf3c16481ec1c4b00d167cc8805f21dfb5e989783141018"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 21908,
+     "sha256": "ade58867dac49427ce1a66c498f5dd7327685db0daac1409b80e0a341df59283"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 21804,
+     "sha256": "06a1f7cef5d1d3f8c377addc4026523b656b8f77986495f96048a1a6ea94549c"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "quake.rc": {
+     "bytes": 776,
+     "sha256": "c120b542e2b482918d32924e833dd694b52e53c993c640a20b97059a49185cc3"
+    },
+    "sound/alk_emt/ac1.wav": {
+     "bytes": 342374,
+     "sha256": "73752cd2b6407cb48ac651ba06b1b44b3bce2dc2187439f56fa12b947f4414b5"
+    },
+    "sound/alk_emt/bossrumble.wav": {
+     "bytes": 1095644,
+     "sha256": "592d71188f710d27bf5e4f84b987aed8be2aba11541536890996242f04724bb7"
+    },
+    "sound/alk_emt/bubblinglava.wav": {
+     "bytes": 596204,
+     "sha256": "ef18c72355b574f305e48e92566bd33719c766123d719e65b09ac89c258cf856"
+    },
+    "sound/alk_emt/hangar1.wav": {
+     "bytes": 714082,
+     "sha256": "15f0c87013e445065066cd68cec281331fbcd6501b7bd3f825ef908d85518f97"
+    },
+    "sound/alk_emt/klaxon1.wav": {
+     "bytes": 131116,
+     "sha256": "82a4ac7e620cc51bd63d20dfc256212fa9cabf384cd7431684402525ae5d3b43"
+    },
+    "sound/alk_emt/luggagescanner.wav": {
+     "bytes": 221032,
+     "sha256": "44c66ccc872a675cebe9b84ae16e2005005e3fbee36f0eacf3639a88e4168048"
+    },
+    "sound/alk_emt/movingplat.wav": {
+     "bytes": 81326,
+     "sha256": "2caad748f987b13e2ae9c2fefa62ad34a350ce11d77add0b4ee85e0a44b4d8c0"
+    },
+    "sound/alk_emt/smasher.wav": {
+     "bytes": 124588,
+     "sha256": "0609c379a0aa35df478e90942a000b8a8fbe170a26ce695e83acc421b7da4865"
+    },
+    "sound/alk_gw/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/alk_gw/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/alk_mh/cranestop.wav": {
+     "bytes": 10278,
+     "sha256": "92ecc69bba538b1f624cdce0c0e45c663c6e070320546123519bc3622b0a0196"
+    },
+    "sound/ambient/aramb1.wav": {
+     "bytes": 44476,
+     "sha256": "4c6440672b87575dd8ac5a267621881b9c70e48722cf9a4aa75a4a9b384fea5b"
+    },
+    "sound/ambient/arcohum1.wav": {
+     "bytes": 20418,
+     "sha256": "3b42cb1b62f62acabdc8ef8612ab4343b71b165c3525552701ef769f90020960"
+    },
+    "sound/ambient/arhum1.wav": {
+     "bytes": 20740,
+     "sha256": "e374f3d90564808e019abe09f4464b704512cf85ff0f3b4bb3c955b4153184e3"
+    },
+    "sound/ambient/arpump1.wav": {
+     "bytes": 18262,
+     "sha256": "11ae2c08c7d5f7f777eade75770a1623386d0e0096a19076fff13e9ddec6318c"
+    },
+    "sound/ambient/arwind.wav": {
+     "bytes": 30408,
+     "sha256": "34248569bb7ab66f5e1d874e15c7a91d89fd2b70d27e5521456b2589581fe1e6"
+    },
+    "sound/ambient/chatter.wav": {
+     "bytes": 190760,
+     "sha256": "59197f823b479c66c41163d82fed6dc13a715aef429b5e551ba80ca6f7c229fb"
+    },
+    "sound/ambient/comp.wav": {
+     "bytes": 12164,
+     "sha256": "ab8e3b13981bb432cca44ad4b7467734f52d01927018e72c99e7c4d052dc7874"
+    },
+    "sound/ambient/conveyor1.wav": {
+     "bytes": 348058,
+     "sha256": "ca68f9d44a06155fec7a886675c825b247d2b21996e92daeb76d9f47db2cf2a7"
+    },
+    "sound/ambient/crickets.wav": {
+     "bytes": 12236,
+     "sha256": "d5cf6e56884a8e43469408d4788ec6e573167901586df259a938cd088c998ef9"
+    },
+    "sound/ambient/drone.wav": {
+     "bytes": 30902,
+     "sha256": "81993d96ab337f78c2778cecffe4767605fed210e0ac2303a46ac898979eea13"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/hum02.wav": {
+     "bytes": 37836,
+     "sha256": "8b2ee1b91fa663b6111de9251011142475831ece70ee091022b800b715f1bfa2"
+    },
+    "sound/ambient/intake.wav": {
+     "bytes": 25682,
+     "sha256": "e6d13169ce4680dd83903473897fd6e7ce1e51fab00c6df2127ea993321c05b0"
+    },
+    "sound/ambient/lonoise.wav": {
+     "bytes": 32876,
+     "sha256": "1e0f99ffadead8460a7a4bed1c6b2c16cddd70050e1524e9cdaf6724a9dc81b5"
+    },
+    "sound/ambient/motor1.wav": {
+     "bytes": 52340,
+     "sha256": "c48511a37143e9ed50ae7c1d1f28235b007762949d3d18549fc545cc670c0a24"
+    },
+    "sound/ambient/motor2.wav": {
+     "bytes": 52014,
+     "sha256": "7f36cda5c01aea4e6b356ae4d0b31b68ca15d7606eefd30f4739a64fc4e86e6c"
+    },
+    "sound/ambient/rain.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambient/siren.wav": {
+     "bytes": 62412,
+     "sha256": "ad55eb212b66467220a77d4a5f99ab2d507299a68f1d1c4946046bd069397ee6"
+    },
+    "sound/arachnofloyd/death1.wav": {
+     "bytes": 119460,
+     "sha256": "d16c7ff30e9df62fbcda102befbd61fe234532f6aef30d0b34c25330679682bc"
+    },
+    "sound/arachnofloyd/death2.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/arachnofloyd/idle1.wav": {
+     "bytes": 34254,
+     "sha256": "35d6991a10637251ec0d6b830f7f57f394e4eed06e7a9dced86f0128ba5bc49e"
+    },
+    "sound/arachnofloyd/idle2.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/arachnofloyd/leap.wav": {
+     "bytes": 70884,
+     "sha256": "f47323f618db14755c57e9e25213267dcffc501fbaa9a201176ab99db6cda928"
+    },
+    "sound/arachnofloyd/pain1.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/arachnofloyd/pain2.wav": {
+     "bytes": 15906,
+     "sha256": "9c4bdc81c73787cb67677e0021b71d9e24734ef3ce272d9020dc6611a1d87842"
+    },
+    "sound/arachnofloyd/sight.wav": {
+     "bytes": 48620,
+     "sha256": "97a055dbb8e5935190348b2c2d50c6d99ab35c29f3ebcd0f66d6263bdb5485e4"
+    },
+    "sound/arachnofloyd/step1.wav": {
+     "bytes": 74932,
+     "sha256": "a8744a3e50dccf9ee391da2f381c2ecf6701a76441406929ee4581c7717b880f"
+    },
+    "sound/arachnofloyd/step2.wav": {
+     "bytes": 34478,
+     "sha256": "22ce43aa18537f7b04e31263a46dd02e181d538fdf5918d55f8ce0acbb930676"
+    },
+    "sound/arachnofloyd/whirr1.wav": {
+     "bytes": 19762,
+     "sha256": "9e2029071248e6d45f1b0d518983bad5bc5f841cda6bcfba09486e111add10de"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/bambler/melee1.wav": {
+     "bytes": 4175,
+     "sha256": "4e0e2567b9d64b3ff86b33d95fa0158bf72372aeb4968a0c2489df942f9f7c4d"
+    },
+    "sound/bambler/melee2.wav": {
+     "bytes": 5283,
+     "sha256": "4bb91991bccfc33576eff19037e12666e9825348272d3dca40199e208bc00700"
+    },
+    "sound/bambler/sdeath.wav": {
+     "bytes": 14048,
+     "sha256": "c5253af82d203e75d132a00bbb555de055d2e356106d460f34cb8c9a2ee5e643"
+    },
+    "sound/bambler/shurt2.wav": {
+     "bytes": 3736,
+     "sha256": "0f1a51e0ff72f23a4de7684d4408344b7b7bd2cb805609168d2f2459e1b8660d"
+    },
+    "sound/bambler/sidle.wav": {
+     "bytes": 4907,
+     "sha256": "ea2232ba791e306cc86f58303413d8f3fbc7dd38091281698f4d846b6cafa483"
+    },
+    "sound/bambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/bambler/ssight.wav": {
+     "bytes": 11376,
+     "sha256": "de766aa056ca5f7dc6d179e6a220ef906ceacc0341b5cb3d91a4d0e75ff55338"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/cyberscrag/hit.wav": {
+     "bytes": 22334,
+     "sha256": "a16ef33d94d56fb6984b2a3d06104a3cc292bdb38ec6ee22c8b10457b2cb415f"
+    },
+    "sound/cyberscrag/wattack.wav": {
+     "bytes": 25912,
+     "sha256": "6bed724b7ef9bdd480448396ed4498c75f848bf2a1e6d2879cb2b2484cdd1a7b"
+    },
+    "sound/cyberscrag/wdeath.wav": {
+     "bytes": 20684,
+     "sha256": "24602233cca209122250ba7c284933992aa2393795ea5c528a57b9986e2fc319"
+    },
+    "sound/cyberscrag/widle1.wav": {
+     "bytes": 13465,
+     "sha256": "8902628d2201eda9396c0dc134ebda8b8d5c37dabddcd286f8387aadc6532750"
+    },
+    "sound/cyberscrag/widle2.wav": {
+     "bytes": 23094,
+     "sha256": "76af020e5c25f40ab3020bbd065a9b83b9b0a51120d47d137a7abff4eb43e193"
+    },
+    "sound/cyberscrag/wpain.wav": {
+     "bytes": 8687,
+     "sha256": "af2e8589d381e634f607048ce71200df832c9e3a32147891b5bdd2efe2ff5bf0"
+    },
+    "sound/cyberscrag/wsight.wav": {
+     "bytes": 13079,
+     "sha256": "2f9178f6515eb4cd518b418441c40d1376aeaf6f42f7791533f5f4b6da87fd68"
+    },
+    "sound/doors/q2door1.wav": {
+     "bytes": 30572,
+     "sha256": "3f05bddf76379933970c532656b6350bc53820319ce1cb9d4ea9288210427eee"
+    },
+    "sound/doors/q2door2.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 110256,
+     "sha256": "895cfb57c0d27369530fd5e9b29abd491a989ad0a63ddb00f05dd9e4777a5cdb"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/frogman/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 32638,
+     "sha256": "3cf3933f34c7baef52df54d5b03db40424e9f7ee72e5aa5a4dba489d71be2af7"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 27662,
+     "sha256": "ec38e73fd1ffc33cd25aa065e5f5897c21a494e380763ff80b6be482689b5e33"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 44186,
+     "sha256": "7600cd32fe980646fddcf5a9077d8d43df1bca1f2ed05bd92ce8cca273ad6636"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/trifecta.wav": {
+     "bytes": 16412,
+     "sha256": "00baad51adaa3f5d6664e85ae5442221db6818bfd85124c164324d22f6723ab2"
+    },
+    "sound/items/trifecta2.wav": {
+     "bytes": 32778,
+     "sha256": "f742a9cee4a53ef52fce55d5e9ddaae9c6b20d2127e16c0def6cd11b3d2d6380"
+    },
+    "sound/items/trifecta3.wav": {
+     "bytes": 10728,
+     "sha256": "a78bfc9fa4fbf0c3c1e85bee273ee053598989a09146bd29e97dda811c49a473"
+    },
+    "sound/lieut/alert.wav": {
+     "bytes": 8700,
+     "sha256": "7ebbe83ae1b5d159c9f0a0ae5f3dea126650ed5d6f98a22d1512dcfcb19a23ca"
+    },
+    "sound/lieut/objective.wav": {
+     "bytes": 10052,
+     "sha256": "aa7d6726a458eaa48bf2e20446c57360b82ac23bfbd06bad7b6e01ae95ca8b0d"
+    },
+    "sound/lieut/target.wav": {
+     "bytes": 6754,
+     "sha256": "eebd50c75585894c7d5305f6c066aaef1efaca9a59e27b80d03e8ae4d69caa69"
+    },
+    "sound/lieut/you.wav": {
+     "bytes": 7126,
+     "sha256": "6bfb031b0d69b8ae4ef2e9b201da43c523ae88de344907648d4064e07477ee1c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/conc_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/misc/door_closed.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/misc/ebell.wav": {
+     "bytes": 15220,
+     "sha256": "1693337ed8873f1159e56c2925afaa210f5c28bee4e2c42d27e29bee8e06cb5f"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 4054,
+     "sha256": "b9c44f73c8bdbc900af4f06600e0d6456a040b296612b7d0fe53391285976a44"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 4098,
+     "sha256": "4fad66341514c9aa2b31b4c2fde7563369090da9b0b3a51e08bca3100f2ec282"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5054,
+     "sha256": "d158ddc35360bc43934b7a8a9b7cc830f7510e6bb3a640813157822b27b5217a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 9726,
+     "sha256": "73b74099c8cb43ab2fb09b28b72ddd9f73f2d2a4f8a00a8e835490f366680c92"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 3226,
+     "sha256": "48551cc717e5011df78a38c6a71bb001e4f62a1858a3952311499653ff423a07"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 5802,
+     "sha256": "751050f97456a0c07e88a249d40dde96c2d14640e21670ccdde983502998dbba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/rail.wav": {
+     "bytes": 97196,
+     "sha256": "396a85e1e2083f2b1eaae89a3f33a21145a643f3f50419523497719ef8e7598a"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/rider/sight.wav": {
+     "bytes": 26356,
+     "sha256": "40ace6f3beeb920ba1bbdb197f8ece18d312762a71e494726289e16703d75d91"
+    },
+    "sound/rider/step.wav": {
+     "bytes": 40524,
+     "sha256": "a43e24ecbc62d44bce466b1e682ebf64c230e03f4d79449406ce021dc8276a9a"
+    },
+    "sound/rider/thump.wav": {
+     "bytes": 15444,
+     "sha256": "af29f4e8f6debb1223aeb5d840add4ae01cb5e9f6bd9a26efeadff518f34380d"
+    },
+    "sound/scientist/allnominal.wav": {
+     "bytes": 23778,
+     "sha256": "e26f9bb3c24d9a9e0da38395048f6dacffe82d800da49d56378027250393d69a"
+    },
+    "sound/scientist/alright.wav": {
+     "bytes": 9666,
+     "sha256": "372c1aa91e6841bec2441215c894b7d149bdeaef33f907d23bb7eaf637520ce3"
+    },
+    "sound/scientist/asexpected.wav": {
+     "bytes": 15982,
+     "sha256": "306933848b673bd14d7074d59e45a8c97bc00a2897601509e52e5835e2ffc997"
+    },
+    "sound/scientist/c1a0_sci_crit2a.wav": {
+     "bytes": 28364,
+     "sha256": "f972684c74eeb51872873cc2b7053448c6cdd716b8c3535929fdbcc508d62ef5"
+    },
+    "sound/scientist/c1a0_sci_stall.wav": {
+     "bytes": 13704,
+     "sha256": "541c192ad5e8a68c76706ec17b3deceafbdc607bfc372ddfd300532f8aa1eaef"
+    },
+    "sound/scientist/cantbeserious.wav": {
+     "bytes": 13236,
+     "sha256": "fc4a8a379f70e33db79a49c667dcd9f1622de29d7b32ef3973c4ffdb5d80ee44"
+    },
+    "sound/scientist/cough.wav": {
+     "bytes": 14878,
+     "sha256": "b4e620259623347a5be3f7eaf3c531e6ea9ef2e97ac42997dd78cfee9327f7bf"
+    },
+    "sound/scientist/sci_die1.wav": {
+     "bytes": 15558,
+     "sha256": "c2306d7f9fa58f99961c347b06ef26305b99ac43ec27b2b222962e1f3a9ccce9"
+    },
+    "sound/scientist/sci_die2.wav": {
+     "bytes": 5402,
+     "sha256": "14deecb570d1e315b772713d54b7250043bb0dd5f3d5538cd0636e39a523c54f"
+    },
+    "sound/scientist/sci_die3.wav": {
+     "bytes": 3104,
+     "sha256": "075cdbc5837d91b61ad7599cdb3abf9323872816f8966c83deab9c0a6e04d7d2"
+    },
+    "sound/scientist/sci_die4.wav": {
+     "bytes": 4024,
+     "sha256": "e6ca0d4f18ac6c1246926646568618057cb70b5cee995c1c2dd69f0179b892ad"
+    },
+    "sound/scientist/sci_dragoff.wav": {
+     "bytes": 8986,
+     "sha256": "0c6a21cd5edf01e495e1258e9a76c05d62c0e3cd697e787fd43fd4bd9126483b"
+    },
+    "sound/scientist/sci_fear13.wav": {
+     "bytes": 4534,
+     "sha256": "dabce7a6c12980f947f7504da264fabb67a804d2e478b7f252ab527fb21a92d0"
+    },
+    "sound/scientist/sci_fear15.wav": {
+     "bytes": 4764,
+     "sha256": "f0d23c680ad138c3cc12da78a3e45cbf3daa47e5da9bc62a1dbb3b27389565a5"
+    },
+    "sound/scientist/sci_fear6.wav": {
+     "bytes": 5588,
+     "sha256": "ff2702b2b9e517b90ea0c2853775a4a95160edfae5af0a7f9208f07624d84281"
+    },
+    "sound/scientist/sci_fear7.wav": {
+     "bytes": 8458,
+     "sha256": "f2a39185c2d39a03b39afd7fe6f942b2f35fd17135ade8ceb4c31968c768aafa"
+    },
+    "sound/scientist/sci_fear8.wav": {
+     "bytes": 5804,
+     "sha256": "4455a29590d5f42ebbf06e600d8ba3f45acfd5000a6b8045891cbecf1d937970"
+    },
+    "sound/scientist/scream01.wav": {
+     "bytes": 14666,
+     "sha256": "b738de99aefbe3a45724914dd6eb79c0f8c219aaf733554a8a5eb94836c22320"
+    },
+    "sound/scientist/scream06.wav": {
+     "bytes": 13938,
+     "sha256": "dee8ac2058635d00458e2e74402d1cfcb5362c64259fc2c4f3b6bba31bdf6337"
+    },
+    "sound/scientist/scream08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/scientist/scream09.wav": {
+     "bytes": 6130,
+     "sha256": "85947649f5fb1491732365849a3025bf5c76c791b395cfdf421fbbd6ec58d351"
+    },
+    "sound/scientist/scream10.wav": {
+     "bytes": 5392,
+     "sha256": "fff4c0735f9c312be7cda848fc2867590437ffe9758fe685e3b4c94678ca1f48"
+    },
+    "sound/scientist/scream14.wav": {
+     "bytes": 4824,
+     "sha256": "dcb7dfb0e307b813476b2e55dceb59d8ae2b9514b1ef02034ea255fa5f086b05"
+    },
+    "sound/scientist/scream15.wav": {
+     "bytes": 3048,
+     "sha256": "37d26fe2d2b8a39d0fec0eceec0ca974ec3dd7fed33bae0d3230a934954105f0"
+    },
+    "sound/scientist/scream16.wav": {
+     "bytes": 2328,
+     "sha256": "4ff04ce8ff07af708c84dacc8df114b68620d47e8e4e4c78dfc4fd33a8a9b98d"
+    },
+    "sound/scientist/scream17.wav": {
+     "bytes": 3836,
+     "sha256": "82fb51224e06db5022adfa58f0b02353c333229ed3312f86dd9ec4f04813c37c"
+    },
+    "sound/scientist/scream18.wav": {
+     "bytes": 3066,
+     "sha256": "bfefcf745ab8d30db11f9113ecf9ba1c5bc6d9b2351c53f3f46d66e03cbea3fe"
+    },
+    "sound/scientist/scream19.wav": {
+     "bytes": 2504,
+     "sha256": "47cc414d201aadb7ba2fe0ce0567ff5360e90fd9de4a167520988513f358ed41"
+    },
+    "sound/scientist/scream20.wav": {
+     "bytes": 21310,
+     "sha256": "124cb45d3d5533572e3cfe4b42bddad2a03dc0d8de1c89a42ea57433432e3a6e"
+    },
+    "sound/scientist/scream22.wav": {
+     "bytes": 15206,
+     "sha256": "6e0a509eb2468466591622e74724c31103b8b60f5d8f29514fb57e9d9d12c9d4"
+    },
+    "sound/scientist/scream23.wav": {
+     "bytes": 21988,
+     "sha256": "8521907e8cecc22e6924d23295a5e8d31333d265ca27a9533b083b68e9da6d12"
+    },
+    "sound/scientist/scream24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/scientist/scream25.wav": {
+     "bytes": 8122,
+     "sha256": "38281749deffb4e567896f71e7bcb75d7b2e253e404a953a5eea6eeb989f156a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    }
+   },
    "sha256": "c296a24aaab343085fc47f4e2f35da7709deb5a68261d365bbb07c7e33cccc00",
    "timestamp": "2021-09-03T19:08:00.000Z"
   }

--- a/json/by-sha256/ae/ae3caad65425741d64ca0d489d676482712412d9b8774776655c1817c0ec146c.json
+++ b/json/by-sha256/ae/ae3caad65425741d64ca0d489d676482712412d9b8774776655c1817c0ec146c.json
@@ -9,11 +9,243 @@
  "files": {
   "pak0.pak": {
    "bytes": 81899534,
+   "files": {
+    "gfx/env/interstellar_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "861352b7f4dc030af28b483d09ad88b4cbb7b8e23e5cd3cf512d2feae9640b22"
+    },
+    "gfx/env/interstellar_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "b16b2e272b7e74513f6a1961d68270dd82fa0667d6ea267a2d22c45a2bdc2fcc"
+    },
+    "gfx/env/interstellar_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "11730f0982cbadc7691ea38e57510b2b7e77484e108d591aece8f970cfdca08f"
+    },
+    "gfx/env/interstellar_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "5bf0a5999e7ea85e68291ab7b36d7f6be5104f8932a2fe46d257484e84dab4fc"
+    },
+    "gfx/env/interstellar_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "051204c9fb8a430c17fb337d84132e0d7058b88f070e457278be99d78a73e5c2"
+    },
+    "gfx/env/interstellar_up.tga": {
+     "bytes": 3145772,
+     "sha256": "d8b19a66cb5dad2f34c9059860ac24a8632ba5575ac06ca3076d57a70c47b5b0"
+    },
+    "gfx/env/inthecloudsbk.tga": {
+     "bytes": 575025,
+     "sha256": "46728836729b8e692e03f573be06036599d7135e27cd320432757ded61c77f20"
+    },
+    "gfx/env/inthecloudsdn.tga": {
+     "bytes": 436519,
+     "sha256": "f698a2be0effd53ad399d707de850f89993a709d685f4ba808808538ef7ee806"
+    },
+    "gfx/env/inthecloudsft.tga": {
+     "bytes": 534713,
+     "sha256": "63b5ef18c0c1f38e832a5b8c9cc75081fcce2776182d21383f58c6753e8075f9"
+    },
+    "gfx/env/inthecloudslf.tga": {
+     "bytes": 508530,
+     "sha256": "63421b48964a2fc0347b42b6cc2a9f7bdeb017719d462793f752549d4054eebe"
+    },
+    "gfx/env/inthecloudsrt.tga": {
+     "bytes": 575213,
+     "sha256": "2ab0360278823ad34074fae40d064951f70785448218fe578aa124fa0f5a3f89"
+    },
+    "gfx/env/inthecloudsup.tga": {
+     "bytes": 215489,
+     "sha256": "2837d0ae6f86c6914cb6f4b30b232a1c67b52343202d95b83d2dee54c8257731"
+    },
+    "gfx/env/stormydays_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "d898c7641be8fbb8eff1e3b32a8a4e6f02e13154ed7a88cc90ceabedae1fa235"
+    },
+    "gfx/env/stormydays_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "70fe4ba19d17e46d62b70582916924e7c20229ecfc5c1bf700bcb6ccb9c563d4"
+    },
+    "gfx/env/stormydays_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "4d68b33f5da78b7fa5c4d4eb61d41b8520a24ce5a70de85f5edb909e52f65bf4"
+    },
+    "gfx/env/stormydays_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "20bb6daf7a6d309cb5e66dcb2c8e8ebf2fe78dd64c0c1cdced5349580e35c6e5"
+    },
+    "gfx/env/stormydays_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "c81e6989c52170220598f5d0ff276d2486ebdca67daa257755371ca2765343f5"
+    },
+    "gfx/env/stormydays_up.tga": {
+     "bytes": 3145746,
+     "sha256": "672d5c37dcfcd47604a4be21c748b6927e89b3e8fc6571653d5c38475e1572d1"
+    },
+    "maps/retrojam2_rickyt23.bsp": {
+     "bytes": 3275556,
+     "sha256": "c332ebf09671a6f5d9d00e9b25ddc767dce89c779b9b397229022edbcd1a25f6"
+    },
+    "maps/retrojam2_rickyt23.lit": {
+     "bytes": 3603311,
+     "sha256": "79ac2cf2e7b61580e37386255025ef70ac93bd5091ddccb2ff00f078982892bb"
+    },
+    "maps/retrojam2_skacky.bsp": {
+     "bytes": 4305514,
+     "sha256": "f16491bb4bc7c7ea14f0c63283772484e34fafeb73203c6e6988b84c7a2c8afd"
+    },
+    "maps/retrojam2_skacky.lit": {
+     "bytes": 1631507,
+     "sha256": "46daf3bd676802d36d606fca308496e402b953ab46f4bcaabca1b023ee30b2dc"
+    },
+    "maps/retrojam2_sock.bsp": {
+     "bytes": 7026416,
+     "sha256": "6d34e41337f2b9e07f1a0ec738072eb03d9548486ad708f4a2f0488ce15b66c5"
+    },
+    "maps/retrojam2_sock.lit": {
+     "bytes": 2301938,
+     "sha256": "66784fdd87183f2963f48cb69a214b567945f7dd847359e0f606efc1e80af27d"
+    },
+    "source/retrojam2_rickyt23.map": {
+     "bytes": 2849400,
+     "sha256": "72b58fcd4231297fe2f1c58378518adc942d201c31546f5284b0c1bc840e85d9"
+    },
+    "source/retrojam2_rickyt23.rmf": {
+     "bytes": 10238668,
+     "sha256": "4f08dc195c930283ab57c2df96c095e57e5441807f223dec93dd45a125e68fed"
+    },
+    "source/retrojam2_skacky.map": {
+     "bytes": 3378832,
+     "sha256": "18980719cbe1bf155b2a908410c1e0e92dd594898e636936c1c2d7e1174da3af"
+    },
+    "source/retrojam2_sock.map": {
+     "bytes": 2692121,
+     "sha256": "a4b54269580dd30d3943bed5192234f135ab6749abbaff525b816fa238125b01"
+    }
+   },
    "sha256": "d4f1a15af88ddd47c74ddcbc5c3f04624e48342a0c5f18d5c5e8264a23f92b5b",
    "timestamp": "2014-12-04T19:13:34.000Z"
   },
   "pak1.pak": {
    "bytes": 733727,
+   "files": {
+    "maps/b_batt0.bsp": {
+     "bytes": 6980,
+     "sha256": "0d481a2e2cd7a23e4ef19c19622195007bd6c9a67135ef739b0944a02d46fcd7"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6964,
+     "sha256": "34709c1c06ca34305a8ba1d4799d1cdc07e44ff33f3c7fa11c3d5933cb942579"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 7124,
+     "sha256": "d3371655bed274070fa98fb32b408bab4a22fe754f5158c8c94a072749a5d24d"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 7764,
+     "sha256": "abdfe383c13da6d5dd7a9409fa5d3db2c4bac78482eb75c2c2b42da7811ec3ca"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 8788,
+     "sha256": "2343448faac29720e3a690650b70623852710dcae002917ae5772fa597117e17"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 5604,
+     "sha256": "66ea23f1cdd6225afdd1b7cf1247b93d174562193e0807561b96b659429f2bf0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6820,
+     "sha256": "366ece777ae71ecfebaa9f4bebafe2074b5336e7939900f46bd9521886f9f42d"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 7092,
+     "sha256": "56a66aa3d1364a0436ff8ce880268b2a9c2c396ab02f0c6277535d5b99eae31a"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 7636,
+     "sha256": "ddd60cec57d8e3954c1ffce616ae862edb784417a6b6622cc001d408383a6cb9"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 5396,
+     "sha256": "fe60bd7880da73571e29fa4075968cccb06e913bd2b9475868ce31c69b1a8c19"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 8436,
+     "sha256": "6a2c2c3fa6f88d425ae5b9568e5d8224ee901a1d8faa8363b88fff569b7d0e5f"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 25812,
+     "sha256": "1ba9d3176bb2e03a0457427fd9394d8c15eb9ebae8af9462e955e9c6c6068513"
+    },
+    "progs/dog.mdl": {
+     "bytes": 460652,
+     "sha256": "52cf8cb501f4b1ed457961b798eccd86974720af29f559723be82a0886824fd9"
+    },
+    "progs/end3.mdl": {
+     "bytes": 19700,
+     "sha256": "445af16e28fff506ad65fac16b09dad1672e218ffe0183880aff565578b315b8"
+    },
+    "progs/end4.mdl": {
+     "bytes": 19220,
+     "sha256": "cf52525422a102760bfcabd6e8dd5c5df7c2028daea5baa2a1b1717648dd143e"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 3860,
+     "sha256": "256412b0d88c020fb03efc5e914c5dd721c9dfe8d6a36ce4a7b01e7597d7e7d5"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 7108,
+     "sha256": "d4c5b6316aa02d600951c6a8ec1f4682568b9e877e988cf4cedd77c0e95cf663"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 21412,
+     "sha256": "1274fcabffa89a786b29c9238cf84e95a8557369239b4a9eb813e3dbe37d35ac"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 5492,
+     "sha256": "ecf293b2e8146a33de7bc8bb3cded80bb785b931012b40dca204db3dad50e776"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 22052,
+     "sha256": "c5657b558522e46f0833b7827520c1a5c1f1674dffd52c12609779d5bcd75462"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 1396,
+     "sha256": "945ad552ad86e5193ef9c007dbe23686fbe89be1060063f57ea693b89e5df229"
+    },
+    "progs/spike.mdl": {
+     "bytes": 1396,
+     "sha256": "c5e6afcfbfe35ffde5bda7eaf91e2a583c3f20cf8f3175b4f4e0ad03b358983c"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 9012,
+     "sha256": "06e8f32092cbc0b5ba4d26227df9ac2d10f3a76d9a63bc7928af147b4ade12d7"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 6356,
+     "sha256": "40d9d29c58df57ece6892d71d0464022eb5939aa45699e98eae22136b973c4c8"
+    },
+    "progs/zom_gib.mdl": {
+     "bytes": 19768,
+     "sha256": "2175cca881b4a73adf3742933a5d3e91116c774ddd3db9b6ac2a7f863194d4a8"
+    },
+    "quake.rc": {
+     "bytes": 1319,
+     "sha256": "23d89f55c4aeec778b24e215ce38088b1ad23525c006f09a18ea433d93a03380"
+    }
+   },
    "sha256": "3187c1ca1a70b1a57c64d69c6d04237eca38722b8281200bb9cc209b5c77b9b8",
    "timestamp": "2014-11-29T18:38:26.000Z"
   },

--- a/json/by-sha256/af/aff4eab971e06a5f6800e277d72bdbfec36e3ba40c08fedba2dffb5161e9b0a8.json
+++ b/json/by-sha256/af/aff4eab971e06a5f6800e277d72bdbfec36e3ba40c08fedba2dffb5161e9b0a8.json
@@ -122,6 +122,364 @@
   },
   "tainted/pak0.pak": {
    "bytes": 5025855,
+   "files": {
+    "gfx.wad": {
+     "bytes": 121132,
+     "sha256": "fdcc42f0dad313b297845f4a4daa79dffb541dc7fdfd13c6e8610df9fd614f72"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 360008,
+     "sha256": "bc11b8c9ab2e1c44ef045c3325521f4bade278c2c4461cf7643282e3f2d4339e"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "898d694265db0f933feecfd2a843557a6954a5f2aea05ecf9a852314119dab61"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "03e0973ee5d434c037699f9568228ab80be0df882ca77c88a9835b2d2edf0649"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "gfx/waves-on-the-shore-road.mp3": {
+     "bytes": 336127,
+     "sha256": "2c06f59c0efddbf80f5236103c3a3f26517cc6f59a5111e9b3b735f48c9962fb"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "14c9b7e1eea3672840a58941e8b7e14de30974cb14eeceb4a1acfff38ee8f8ad",
    "timestamp": "2023-07-02T13:22:14.000Z"
   },

--- a/json/by-sha256/b1/b17fbfd4d5b93e75b418ed1038f0ca8a0c529ebb26cc87fc55c60baa6fc49cc3.json
+++ b/json/by-sha256/b1/b17fbfd4d5b93e75b418ed1038f0ca8a0c529ebb26cc87fc55c60baa6fc49cc3.json
@@ -251,16 +251,1942 @@
   },
   "pak0.pak": {
    "bytes": 17821679,
+   "files": {
+    "default.cfg": {
+     "bytes": 2434,
+     "sha256": "5e141f885b9b506aaeea64dfcdc515d68d0769ade1f10c0224f28301b038a31d"
+    },
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "cdf5126cb2540e259aa849d2987865d405098630bd86b396b756f3b058cde3eb"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "cd4fd0bb82d287759263d208a9a07111959ec02895659e8f2963de30f16ec358"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "30a08cb79ea26870b4d057b5444d836d75f8b17dac571779d6d6102d97d7d39a"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "29fc15856c976e0d85a68e9dc2fb59ec09556d2044ddfd9d7ca9b78bfb8f8d3d"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "e05ac577ab7fbfda2b7a3e30689d85b639f97dd6354d4b63f233f86c46f966a8"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "7383e478c8cbb8f7c2e123d4931e804c61c0a39c77a593a52091410dd454586c"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "c06dfacff2da67af44840387e1acf177f46ec793817330965673ae17ddc78185"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "c06dfacff2da67af44840387e1acf177f46ec793817330965673ae17ddc78185"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "86ee3f02a733e2e9bbaf15ff375156b033a612fd7804996fbbc323a7d92f61d8"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "71e5fc89f7713f2df9696d22b2755f1c6fb1bc5588b7d90a2d2fa7d6628fa834"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "9c96da346fd9589bdc4ac83b303061b7f995207c4052f47f54bdfd3e182e9293"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "5fe8ca6d3298b84eefbc08dd3a7092975871b1ef2f1fec8c2c08326dcd68c8df"
+    },
+    "gfx/colormap.lmp": {
+     "bytes": 16385,
+     "sha256": "15b93b09eadf22efd399fc62b9b2ac46d9ef610761590ce40921b51433d54846"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "ca015b70aa8e17b9670d947715de5fd3472488b7b634c7ec316ecd3d4ee24a68"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "1f3a251bbb8f115e2589452fd34f0e0efc00eaddb24db6b4ae95b271ad4ed0dc"
+    },
+    "gfx/damage.pal": {
+     "bytes": 2742,
+     "sha256": "bf0e3b2a726c2a4e36ae0d8502c13c1ed26ea79ff573dcf76c3c0b495aeda338"
+    },
+    "gfx/dim_drct.lmp": {
+     "bytes": 3352,
+     "sha256": "b29d03271efe873e461f47b7317c3f307a455b4ac25fb3e04e98c2787683a5b6"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "305925608ced1b8e2f981e365546ef4f5e46b5962f017be7cc188485f89a9ed3"
+    },
+    "gfx/dim_modm.lmp": {
+     "bytes": 3352,
+     "sha256": "c7ce8d37d928a13ec0395dd533d6d2ae80269741c85c1405f6c94382549801e2"
+    },
+    "gfx/dim_tcp.lmp": {
+     "bytes": 3352,
+     "sha256": "7a6a9898e81759eb80537cf787b40f1470725fadb6a2b8038f1431191a3379ac"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "1647ab35e9e148ed8101136360eb7f052aef55da68abfb562e422a97f5598d29"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "5f4b2137e1b7d394ec45abab973f2ba2fd9a54b5cfe4cd8dbda2b2345b575857"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "67239a8e3cffa9799aa6a4fcae59cb0d155e9f7e885e8412839cc62c0c62a023"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "e6944c9380ff33fc24b5d8582af318f54e9ff7eff7a1924bd5ae42189ea478ba"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "269831ecc31c8db07f2e9371471e34f097e85dc1720a096e2ebf6462b750ff0b"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "e00bf69c463a051a179341d37d6877144bcfe206858723c5e72403d1d88c671b"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "c30c10dfffccab54f417a14ee16bf36f7042c75190ec0b9d4fc4a1fbf9ccb82c"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "06c74bfff8e3f36ed365e01fbaa41d3c7aef58752e96d874bdfe75266fb20c6e"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "ba056edfc10c36e829f1c23f14560c657a837f694e002949711c8658e6288f7c"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "1e6981fe3eb95efe9b56af812d3d27fb2c741d552338ede7ffb76fc877439855"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "a8df9ddc71d8ab99893a8c5047a9d3d6a07fd41e4f5c2e65b31466ce95bbb274"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "7111567663df0c0bc18b4ec74cc86bd93d14816e078c7d7dde844014d57a0f1e"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "374474839e14c2f5f6b5be630c1e46a99e364952e57e053e6b66b2837ae6c564"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "ae68a0ad99905249a7b65729090f50a8195146701c74dcba1ff7d001852032c6"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "52f83355d31454a83dc310e860a0e992ac7e814b78980966b00289f5cdd44a10"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "b37a79af991a83ce55c63bb0e22938e54f6541aed92ac7d208ce2795136f4e91"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "4ce7ff3c24e37604b2719d3676a36901a4a25bad345c8d611d9306831ec442ee"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "896044fae7fe880abb88445d2885d62bf396d29d60ea849ebd3d52aefe970392"
+    },
+    "gfx/netmen1.lmp": {
+     "bytes": 3352,
+     "sha256": "c7ce8d37d928a13ec0395dd533d6d2ae80269741c85c1405f6c94382549801e2"
+    },
+    "gfx/netmen2.lmp": {
+     "bytes": 3352,
+     "sha256": "b29d03271efe873e461f47b7317c3f307a455b4ac25fb3e04e98c2787683a5b6"
+    },
+    "gfx/netmen3.lmp": {
+     "bytes": 3352,
+     "sha256": "305925608ced1b8e2f981e365546ef4f5e46b5962f017be7cc188485f89a9ed3"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "7a6a9898e81759eb80537cf787b40f1470725fadb6a2b8038f1431191a3379ac"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "34b31084060a4075255c58ec1d82ed5197a66f30f9ec9840ffb45e491ee48335"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5216,
+     "sha256": "b12d52bcd23da9b01bf1b516bdb40d05f51a2ce274df610721d05e9014dd1d1b"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "6e328d4f212c8d3340b0d07da9c7e1e7bfbe6e47c9c1e69914d6a4b81c0a52fe"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "eb751d1bb37a6308ff024b5aaaf3f08493f92bd6a679dd5a926b864e620cdae1"
+    },
+    "gfx/palette.lmp": {
+     "bytes": 768,
+     "sha256": "61146dec8f3bb34a989c2cd1678c37bd70ccc6f30bc03246b3ec0d32e30bf7d3"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "7f6fa98cc2c93d402b81825e47a9dfdc42b4de07114f41e3a0f4619296e6f26a"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "750780d1c1c5427beb90aa85a3aa48ec76371484df44e3256b90c98ef85e9cc2"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "96855f92fe4753a604cd02e498d6854e2b35b9c5aafef1685cd7689b7efd153b"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "175c83e4ccd65e810302005e959c00c4ab2e83bb9a41c0afef03fb2b304cd9d8"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "3c32920e0a0a56a602a76c07eeca64d561539df76553dc4178e801d5f2d5c1b5"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "4f768d2eb3c377d909b3fcb7d77f50288e6cbe60de7b7ea10a763d055ad4cf05"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "50a530f03914102bc0aa916919f58b8ebfbacc5857b7e9b1da8e97e81ad484d5"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5216,
+     "sha256": "4e7949abbc884d73b8fb15f719e3572e486c930b7c7acbc6aba75150c566ce25"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 13380,
+     "sha256": "cb84c9bd4067fda49b1ba42656e6722591b4aea0bbdcaf17c53c2971d6b7c6b4"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 16212,
+     "sha256": "59a2185a1201979e7f31ebc7a572d8fe308f3d647a86e81655447a4c05cdf291"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6928,
+     "sha256": "0ba1439a32f2c973d094d39c6151ddfe33557cdb60f1ef2341ee179ae779ff1a"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 8016,
+     "sha256": "4a513f3d111c38e8839529329289a60431e636ac66f3faa3a67a2090c202e14b"
+    },
+    "maps/b_bh25_s.bsp": {
+     "bytes": 11332,
+     "sha256": "ee9cee62e4bc54e759695a8c9b574a0dbb1f413b59868ed4bb577ecec8b1821e"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9088,
+     "sha256": "7078b9974b0547a68ba8bf9a6ac94097d6516726fefa5d542cc04aa2ae66bfde"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12232,
+     "sha256": "7f871a1373ee13fcbfc05446eacaabdde9d013585445791a4eb659fafaade55c"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 12652,
+     "sha256": "b4ff3caca1e066d8515bc507e58d3520fb5fa601fdd8caefef5270f4340b68f6"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 7536,
+     "sha256": "2f5abaf3e863525241408ab5fefb3a201e43efb5833ceabb98fe3bef77e781ab"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6312,
+     "sha256": "26c1f30ddbbd10eda0045327cd60055442086f2e2a7d3d0955387f9157ff7bee"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 10328,
+     "sha256": "673068ab998ca57ea287afb4a662a24f510b4c3bbf82a06e4cad8d1eb07b65cb"
+    },
+    "mdemo1.dem": {
+     "bytes": 591654,
+     "sha256": "fa68c2be12297623f0332477331ff07fadd934d36202074178f47ad870dcd0d8"
+    },
+    "mdemo2.dem": {
+     "bytes": 933771,
+     "sha256": "8de671743420b62e557188e3d3fc7122a3f9acb00dc0b1bee7b0f05fb09958a5"
+    },
+    "mdemo3.dem": {
+     "bytes": 367931,
+     "sha256": "baaf4cbc87a951e57a6c10f2d2479421484cf63c3d9652f86a4afa903d1d1bf8"
+    },
+    "progs/b_g_key.mdl": {
+     "bytes": 22592,
+     "sha256": "59c867676f2f3281048833bd434135536acfb6248c12da6567010e7bfe48c5cb"
+    },
+    "progs/b_s_key.mdl": {
+     "bytes": 22592,
+     "sha256": "65d30316a430ee18f5162b1614adb31933ea7efd1024eb9f2cb70975b8f8d6a2"
+    },
+    "progs/baboon.mdl": {
+     "bytes": 135172,
+     "sha256": "9ecae2dc7b0945b228b5e631297c1253e6a39e8790c843b0ab6e4f6c09f389bd"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 44408,
+     "sha256": "fba2158fd4dbe65982bc3dbe9c1ab3f6bd9a7462f3ab5faf65dc607a4c3ffffe"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "8cafc424173c05239c0feb6bb03b911d2d742051c9411eeb387042f3b2dcd363"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "3d09f4f81eebe0a2b2b2472d6d2613f422b3b62eeabb97ea4695d6f2aa219951"
+    },
+    "progs/baracuda.mdl": {
+     "bytes": 95844,
+     "sha256": "e17b8489665809e72e77d5ebd2cf48e6b2ccadf239424e0f6ecf45f32a3e6438"
+    },
+    "progs/barrel.mdl": {
+     "bytes": 36416,
+     "sha256": "893a914be04aefa3a75713fe852aead8ba7353b801ae299e7c51ba91a546ec16"
+    },
+    "progs/barrel2.mdl": {
+     "bytes": 36416,
+     "sha256": "3d1088a40e38c656b433744fa159c1233a7c8cf936bd890195bba004ad437426"
+    },
+    "progs/bdrop.mdl": {
+     "bytes": 20996,
+     "sha256": "b1071997957b86b86623dbff522b05d498e93ecb9691c47cde0d72528fc6b9f3"
+    },
+    "progs/blowfish.mdl": {
+     "bytes": 143828,
+     "sha256": "77f738010f8e7bb6671a5e64ea41d153feba1450dd753076240907e54be8d485"
+    },
+    "progs/bossman.mdl": {
+     "bytes": 116924,
+     "sha256": "5ff7feb50aa69c6580d81f1671fa28e87e18f95d8041db77ccd28140f54f29ba"
+    },
+    "progs/bshell1.mdl": {
+     "bytes": 32480,
+     "sha256": "874a29b25a8e23f73c5150828a7f4d1180b218fc643e620f0d19cdd5b4f49a39"
+    },
+    "progs/bulb.mdl": {
+     "bytes": 65672,
+     "sha256": "4de6490ccf0f60393200bb8fcec7c9a1ebba47e259af38d4f102ef1d7ebf8aec"
+    },
+    "progs/bulcase.mdl": {
+     "bytes": 13588,
+     "sha256": "1b0270b4f62df413e413df0a278a81b2c1d362f96d2887cecfd6c9ebd58045c8"
+    },
+    "progs/celshel.mdl": {
+     "bytes": 122324,
+     "sha256": "a1ff82a223f63a206b9b0b3b5accad858791c8b59d913e3bb3105b77326804ff"
+    },
+    "progs/chinok.mdl": {
+     "bytes": 43544,
+     "sha256": "861cbe8bcf369e55d9687fd791b5b3e5813c1511522e594b9094f7614559af0d"
+    },
+    "progs/chute.mdl": {
+     "bytes": 31680,
+     "sha256": "b42a9b9d0660e5b8f4e194b55b7f61a285f5067ef80a11b8a67a19c08ad61564"
+    },
+    "progs/comet.mdl": {
+     "bytes": 10668,
+     "sha256": "2f139f6c9fb86298f3a30d28d23824ea29d356870de95252599acfeb73ba9326"
+    },
+    "progs/crate.bsp": {
+     "bytes": 7404,
+     "sha256": "ea9bb350f6ec45442257f4b1dd2cff2a51ddfccbeec937e83c11bffb76a8f936"
+    },
+    "progs/crate2.bsp": {
+     "bytes": 7484,
+     "sha256": "39b43352f72b68bbe8e0cbc9d6cdb8a43866c2a59e7b3cb272be8861153e9424"
+    },
+    "progs/credit1.mdl": {
+     "bytes": 11364,
+     "sha256": "4c8800030aaac7268680113cd6310f8666a01c62a318e824a799c50da5954caa"
+    },
+    "progs/credit2.mdl": {
+     "bytes": 12388,
+     "sha256": "bb7093b7f604541ed72cf4843f8d6b2d09f0d799983c6f264490c491934da970"
+    },
+    "progs/credit3.mdl": {
+     "bytes": 16228,
+     "sha256": "aca5398fafc6ac5e907239802d8869a9f9bb6a97858ee9add3af514a2707c33c"
+    },
+    "progs/credit4.mdl": {
+     "bytes": 24868,
+     "sha256": "1eaf7c8c769f4c43259ee8da924d6b5f7958f86004a4ed7d62c99cc626f7f8fe"
+    },
+    "progs/credit5.mdl": {
+     "bytes": 15076,
+     "sha256": "4e6fadf0529439e935436425c0ecdf1f28568ad5dce22d9bc4c398cf42d40c82"
+    },
+    "progs/credit6.mdl": {
+     "bytes": 20196,
+     "sha256": "353a8c7a099374aa35f04b3be542c2b3719dd713a758d9350f3e046e238ea74e"
+    },
+    "progs/d_bag.mdl": {
+     "bytes": 362284,
+     "sha256": "2578c501517b98e75799f30ef1a0354781119ad696e3abd269516bd7fc9c251d"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/d_hover.mdl": {
+     "bytes": 277796,
+     "sha256": "13ff8bdb3919baa012571ec85dc7607d2519575c6ea2cc166228a49a3e16bbf8"
+    },
+    "progs/d_scuba.mdl": {
+     "bytes": 300676,
+     "sha256": "9b0197f393603895928c80473ca1223df69fc1d73766c32a943b3add587ae2da"
+    },
+    "progs/damact.mdl": {
+     "bytes": 260668,
+     "sha256": "55b6a085fa342757d26ad5f96307699e1bdcd44ef6d72b6ea97765f611740b3b"
+    },
+    "progs/damact2.mdl": {
+     "bytes": 494496,
+     "sha256": "2f43ef68539a2e09110e954974bfedab37c53886c5bdad350bea0c7c2b486736"
+    },
+    "progs/damage.mdl": {
+     "bytes": 265692,
+     "sha256": "eed5508ea593776afc77eac2de8f260ce8e61de402765ec655a431d438de73e5"
+    },
+    "progs/dancer.mdl": {
+     "bytes": 243764,
+     "sha256": "0c9755865d9959cc9c4231f6830d4cd78b123be5ffc13494fc968a3c7cd1467d"
+    },
+    "progs/discob.mdl": {
+     "bytes": 47499,
+     "sha256": "ca457dc2268fde661fdafcfdb06376ddc75a2ebf419adcff0a9ae7470511aa4a"
+    },
+    "progs/extngshr.mdl": {
+     "bytes": 25732,
+     "sha256": "fc8dec001f22c4666f6c5ca65e8aba18d5b22ed8aabbf0534d03913e821e3120"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 133216,
+     "sha256": "7fa928f1261e6db17f2b3dcaf34f4c5457e4fbe52b482eb168ab662208e84c3f"
+    },
+    "progs/glass1.mdl": {
+     "bytes": 5844,
+     "sha256": "d2e20822dc2d2faf2620f57f329954cb970c30415a33c681c16bef305c5e8a2b"
+    },
+    "progs/glass2.mdl": {
+     "bytes": 5844,
+     "sha256": "36c0a4a5976745ed00750bc2025b8062873890a5a275873e811d2604eff2e7e5"
+    },
+    "progs/grushad.mdl": {
+     "bytes": 141852,
+     "sha256": "8abf7464a279f2c0147b0cd0b09c94ee2d983f02dceb82b15646a78c17ef9097"
+    },
+    "progs/h_frogmn.mdl": {
+     "bytes": 5484,
+     "sha256": "18fb52370349b0858bd7514d88b08322c3b41801bf41ca93abb813a6463ae3c0"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 3100,
+     "sha256": "e9708bb98379f7b3c0e10c3df2efbb9ac688934ecc00b6969ad36edc5cb17a79"
+    },
+    "progs/h_merc.mdl": {
+     "bytes": 4916,
+     "sha256": "6ed9c0878b3e590b0873b90632fcceff2232e2dc0c2ef2a37d3b83a2727e8f3e"
+    },
+    "progs/h_player.mdl": {
+     "bytes": 2860,
+     "sha256": "6c341d5fb8aaa818e797218619f9e3d953e9aac400b62e4357b152c32c0892cf"
+    },
+    "progs/h_riot.mdl": {
+     "bytes": 3100,
+     "sha256": "e9708bb98379f7b3c0e10c3df2efbb9ac688934ecc00b6969ad36edc5cb17a79"
+    },
+    "progs/h_swat.mdl": {
+     "bytes": 3184,
+     "sha256": "07cb6cb5787ed94a52384553f59e2cf8e55f38a45c37c03fb45814d0e874611f"
+    },
+    "progs/h_torch.mdl": {
+     "bytes": 4288,
+     "sha256": "65928994dedcdd4a7811388c550db497df0837673cea375c536eec12abe0af06"
+    },
+    "progs/h_vasque.mdl": {
+     "bytes": 6092,
+     "sha256": "046a20b314eb12ea64915986a0d6690bb26c0bb468176b0e9edabdba544c31d0"
+    },
+    "progs/hanger.mdl": {
+     "bytes": 88960,
+     "sha256": "d147c3b9fec6b2f668191cd27c4b8a1d80e26713e2e158573ab2a535f54225fc"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hntact.mdl": {
+     "bytes": 252792,
+     "sha256": "9e5ecee8e008e8a8050b698c4363fc90ca731b7b703327abb35ef4bf5f3710b4"
+    },
+    "progs/hoverbrd.mdl": {
+     "bytes": 33253,
+     "sha256": "6230ffd37351e5ab13ce059a9334282549eddedc29710084d5eb7ebb78f6e633"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 169012,
+     "sha256": "33132695a027fac27af42a02f0c64a9f37de70a6cc9db2bf0fd93c8b3574e8fa"
+    },
+    "progs/m_bag.mdl": {
+     "bytes": 9980,
+     "sha256": "5517efa42263ca32bd1b3ed4b93e2282e554165f01ae80d76558e04dd75bc76f"
+    },
+    "progs/m_hell.mdl": {
+     "bytes": 43532,
+     "sha256": "477e4ce519c63f7bc4aff8adb933902ba595e39a60ece90175c38f9fef381580"
+    },
+    "progs/m_mini.mdl": {
+     "bytes": 67648,
+     "sha256": "46acc2d83c6980ce15304d39b1872c72dad5d408a426de88ee93e5c025785b9f"
+    },
+    "progs/m_morter.mdl": {
+     "bytes": 53860,
+     "sha256": "6381998daeafee2f61b668463d86a075bae06f17fd774b3d1965fb377eeadaaf"
+    },
+    "progs/m_punish.mdl": {
+     "bytes": 62940,
+     "sha256": "1b1794fd2030c7d1ccb008eb182d72b3b03c4b3c3f5801b1adcdec7c975fa006"
+    },
+    "progs/m_rocket.mdl": {
+     "bytes": 96005,
+     "sha256": "e5cbc2108b18452a9c350f7c0b2cc18e44996c8a891757b850551dedcfb81071"
+    },
+    "progs/m_shot2.mdl": {
+     "bytes": 47420,
+     "sha256": "21db1f4c05567556d6e55a28e4e80ed406dbde75303b29c173d10ac42fb694b7"
+    },
+    "progs/m_uzi.mdl": {
+     "bytes": 50164,
+     "sha256": "1e5670529ca429ed334ea649ddfe7c31db8d9e8388159fa3c1a23a67aac1a129"
+    },
+    "progs/mercbabe.mdl": {
+     "bytes": 211068,
+     "sha256": "b8192d6218a8a6af997a00985bdf6c930b456ec6806f410ed7693b308200fef1"
+    },
+    "progs/mini-sub.mdl": {
+     "bytes": 40500,
+     "sha256": "173fc702950d46ca4cb0ef043a6bb5a67fc3d6830f7a648fd2f3536dfe517b47"
+    },
+    "progs/missile.mdl": {
+     "bytes": 57796,
+     "sha256": "e8c019f443b842c1b77dfcbed76ebfd2c937fb880ad31ae10f94dce10c2fbe32"
+    },
+    "progs/morter.mdl": {
+     "bytes": 21812,
+     "sha256": "188be02190e2da59d8bca532c4a39721ebbdf9a322b04b390c57df76ad6ac5d5"
+    },
+    "progs/mortshel.mdl": {
+     "bytes": 21812,
+     "sha256": "57aef6b762f1e880d4e30d76f5ab6c23aad441a4dc492fbd4ab40d27ea44d289"
+    },
+    "progs/nail2.mdl": {
+     "bytes": 5748,
+     "sha256": "888f8f05c2b3bf6bae5e83f7dabf614bd9efc916e0d6499e3b25bf29a9ecf402"
+    },
+    "progs/null.mdl": {
+     "bytes": 5748,
+     "sha256": "cabc28487cdaf6dcce164815eb90f38609a22a30dc8fc0270072e09509b27457"
+    },
+    "progs/null.spr": {
+     "bytes": 57,
+     "sha256": "dc67fb2f31bd717353b8138f02bdc8ef2d70ace433c9fd91e3adc909fda513a3"
+    },
+    "progs/plans.mdl": {
+     "bytes": 26324,
+     "sha256": "6b669da5bacdfc41296f12925457efb6e499381f4c3365743dc8027e17b8059a"
+    },
+    "progs/plant.mdl": {
+     "bytes": 58832,
+     "sha256": "254a3a005a348683ce8c231eb9c2c87376e760ee745b567a666b781284816294"
+    },
+    "progs/player.mdl": {
+     "bytes": 265692,
+     "sha256": "6586eca63b2799cd63e5c466b5f15ada0c11265f38329913c0fdc103ede0a325"
+    },
+    "progs/probe.mdl": {
+     "bytes": 46312,
+     "sha256": "6f775e10d80212384ac2fd97b7ebc90c8c63c738fe3ec1f87f0cdd3340b34527"
+    },
+    "progs/probebod.mdl": {
+     "bytes": 84296,
+     "sha256": "22d4999a77dd13d60da2fe1bebcf51279f137beefb40b70e8a64bc35bb20aa5f"
+    },
+    "progs/probedom.mdl": {
+     "bytes": 77148,
+     "sha256": "cab6080dacf9e9d7b32fcd2b670320a43fcd4e63671b1d8e2e37473516dfaf53"
+    },
+    "progs/probemod.mdl": {
+     "bytes": 13156,
+     "sha256": "02171d66fab41556f6230b732c9336e637a7431b37f63d8b540b738b211e3971"
+    },
+    "progs/pyramid.mdl": {
+     "bytes": 32480,
+     "sha256": "874a29b25a8e23f73c5150828a7f4d1180b218fc643e620f0d19cdd5b4f49a39"
+    },
+    "progs/rain.mdl": {
+     "bytes": 3680,
+     "sha256": "6f8f761a31111eef3985588e93c74f3728da9df6250a054b3d8af3b444bce6bc"
+    },
+    "progs/rat.mdl": {
+     "bytes": 172776,
+     "sha256": "92dd621543645fba1ebd1052edd5e445f95888fd5ac4c30a23101c9e829fcd3c"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 149736,
+     "sha256": "291b01384e45f128d02cbd31cc6292d32c9d413e7ac7ea41d01712c6c641f4c8"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "32737110de27dde627f353c2806f33a2d57a3ac5be72b78532c59815908075df"
+    },
+    "progs/riot.mdl": {
+     "bytes": 214920,
+     "sha256": "d0bc25c277c1f0315397e271db1b0605fc70f7aac0a8f708d1ab5bbdc8c50f34"
+    },
+    "progs/rocket.mdl": {
+     "bytes": 43140,
+     "sha256": "24182456bb01d04c03d139e20a9cdda300693aff3c55ee3ab97d82f29ea2c0ea"
+    },
+    "progs/rope.mdl": {
+     "bytes": 20348,
+     "sha256": "071717c04c744c88c7eda2983a85988646baab1c42f67ee7d00ed2cf94a9ce16"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5748,
+     "sha256": "5686c9f2c37341f1e37528b612dcb83de387a6cf6cef7d2007aad70cd3f14f54"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 3572,
+     "sha256": "04077971e7df2110ba4dc632bede9bc67e4b0c513752724c4fc333c6d6b966c6"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 5844,
+     "sha256": "dc172a67f644b4746938260e61d17414c820caf31f64286c303cb0e3e5d8e691"
+    },
+    "progs/s_bubble.spr": {
+     "bytes": 588,
+     "sha256": "578fedfed87c2eb2764542d7111a99618e6945417ba5f898d8aafdd0cfa3bd59"
+    },
+    "progs/s_co2.spr": {
+     "bytes": 5356,
+     "sha256": "9104badf81925d92b0afd0d774c5e00c80ee67db95be297285216d9e04796fde"
+    },
+    "progs/s_expbak.spr": {
+     "bytes": 82924,
+     "sha256": "91e64453ff55af8b5ebee1aa6c9e7b51ae100a6480c8113633646ad1a9a492b4"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 41096,
+     "sha256": "5ff48e45c3e7d6c1c64848bc8e05d63c637c7508202f3b39aa67ec0ea6108275"
+    },
+    "progs/s_expshl.spr": {
+     "bytes": 7373,
+     "sha256": "ffa3c2fed70b70c0448445d9ffada394c699d69f089f2a77067dc4f8c6361e88"
+    },
+    "progs/s_flame1.spr": {
+     "bytes": 49864,
+     "sha256": "d707dfec198779bf6fe946da2ba9ac016fadc5cded95286322f6d0ac3230e015"
+    },
+    "progs/s_flame2.spr": {
+     "bytes": 24973,
+     "sha256": "d5a4ba52be8195ee4e1fa07737c2eaa740dd406a9d14e071ec72577c47e9012e"
+    },
+    "progs/s_plas.spr": {
+     "bytes": 3471,
+     "sha256": "8b04070b1ab7bf287bd149a7c16421bcb686a86812b87e03a32095e105e84835"
+    },
+    "progs/s_plasx.spr": {
+     "bytes": 526,
+     "sha256": "2e735e299f2ac2308697cc0a97c8cceb9e93a8893b9151095331c6d679ca481d"
+    },
+    "progs/s_punbak.spr": {
+     "bytes": 82155,
+     "sha256": "2135f46c3ba05149535ab585a75e9ab6cd778a25d10e34c1a0c478c4c4f40ee3"
+    },
+    "progs/s_punish.spr": {
+     "bytes": 9596,
+     "sha256": "194771e7990628aeae4ea6c00711e9db445f3bf699d02e6e0da8d003c6f814a8"
+    },
+    "progs/s_shadow.spr": {
+     "bytes": 4229,
+     "sha256": "1153ac582a56c8f58cc60d8cbf1ec49065a7fadfbd1e48fd7f01f7f1ceb009d6"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 109996,
+     "sha256": "f384fbd4bbd45d21c66655ca1fecdde15c561f6d512a2e420e0c24dc72a017a2"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 18972,
+     "sha256": "e081c3397de38d85001a08141b6881a19932d734d5e955fb1fadfdeeffcc3b03"
+    },
+    "progs/s_splash.spr": {
+     "bytes": 870,
+     "sha256": "860ad378d89ca0a9748cdc14b3a57f26efe4c0368b2fbbe4020a9d21239a405d"
+    },
+    "progs/scuba.mdl": {
+     "bytes": 15028,
+     "sha256": "dcd713c74b96a8b62ae650c067a16c27a5555164a3ebfcf54e20351f04ff4e22"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 13588,
+     "sha256": "5134e46b5a6a3ee3929a6c477f2a208022030fda99d932f988e0408352ef66ce"
+    },
+    "progs/shroom.spr": {
+     "bytes": 86830,
+     "sha256": "b7f908e3629af8dd9f3c765fa2a86643218478dabbc7cc8cfb839c4e08a2fd84"
+    },
+    "progs/shute.mdl": {
+     "bytes": 21484,
+     "sha256": "66b48d9146e44b22a9ea437f68087cc4e07384eefabdce96ae9611be590cd773"
+    },
+    "progs/sight.mdl": {
+     "bytes": 4752,
+     "sha256": "3e62786b801dcd999613c38b417b057339fd63915b6dcb26b2ac02c7087b84f9"
+    },
+    "progs/siren.mdl": {
+     "bytes": 22708,
+     "sha256": "8aec1ad129586a9c2ef890f19ceceec88d25e3033392abd63af3778add65908f"
+    },
+    "progs/subpit.mdl": {
+     "bytes": 124560,
+     "sha256": "2cd2fccc69eb67d60e8c2e06ec63fb6c16c4ba9ed6c20e301a4bd09d5d79879f"
+    },
+    "progs/swat.mdl": {
+     "bytes": 230320,
+     "sha256": "3f8c5133588b679f8bc28e7e1c3254ce209f3b95b1ff16fb6ab7472ace78f285"
+    },
+    "progs/torch2.mdl": {
+     "bytes": 247376,
+     "sha256": "935f5a511bed597a88718add4c1fb05a553b9dd7af0396332efa3767a35c67c8"
+    },
+    "progs/torpedo.mdl": {
+     "bytes": 11992,
+     "sha256": "fd6eb595e9175f0ddb127c446c2495e2a799e9a12c5b89ebca3b68d8748d8f62"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/turret.mdl": {
+     "bytes": 120168,
+     "sha256": "56cfa9bf6c90f5b2daf99512bbe24bed3ab3ba5d0ba9698f59267dacfcad18ff"
+    },
+    "progs/vasqact.mdl": {
+     "bytes": 527584,
+     "sha256": "f2f412041288e0757809c19a6ad82cf7f2e71d2ec7dfc63240dad267fff4f8b0"
+    },
+    "progs/vasquez.mdl": {
+     "bytes": 281024,
+     "sha256": "ddc730662ce869c543fd6ac0b02cf84a242ae0727aedc9932dfd3b85a8b54ec6"
+    },
+    "progs/w_44.mdl": {
+     "bytes": 123196,
+     "sha256": "19b3c9f44b043fb6d872a59dbbe2d6c4080ceb9885e36e8d557cba2bd47e7f8b"
+    },
+    "progs/w_bag.mdl": {
+     "bytes": 174356,
+     "sha256": "622bc152ef5f69c55971141beaf9de9330cf9f6ae3ec886026bc3f7fce814f99"
+    },
+    "progs/w_mini.mdl": {
+     "bytes": 78964,
+     "sha256": "5a7799f5fc7ca2726fce7815c47111eba19d29262ec6cfb39e4108bb42a311b5"
+    },
+    "progs/w_morter.mdl": {
+     "bytes": 155740,
+     "sha256": "848897c29a1bdb9e16b438c00b8f078524b2aa87e05909f55fa437b4a046d98e"
+    },
+    "progs/w_null.mdl": {
+     "bytes": 5748,
+     "sha256": "cabc28487cdaf6dcce164815eb90f38609a22a30dc8fc0270072e09509b27457"
+    },
+    "progs/w_punish.mdl": {
+     "bytes": 106380,
+     "sha256": "81f083256cb182602575542d72c20922b022aa78c40aab4e99ca0f19ba00c6c6"
+    },
+    "progs/w_rocket.mdl": {
+     "bytes": 103112,
+     "sha256": "f78e066c2faad72b9c93bd9245569fef21d8363788f17adeb16224ac568cc90a"
+    },
+    "progs/w_shot.mdl": {
+     "bytes": 211216,
+     "sha256": "75f73ec6ddda657bc149565607b807048e1b9784b3f8b52980d66badc1dbbc19"
+    },
+    "progs/w_shot2.mdl": {
+     "bytes": 162086,
+     "sha256": "212bc88a549928f0955cf5ad30a7644c8fab9e7b7ff5adc1caec72cbdb3b85df"
+    },
+    "progs/w_uzi.mdl": {
+     "bytes": 177044,
+     "sha256": "f54f063515a3194a1c2b5fe444a9a004a54e3db53b8c30c1f47e7da0f2fe1554"
+    },
+    "progs/where.mdl": {
+     "bytes": 52498,
+     "sha256": "d549ab649c33ae67f8b782a915786918a071c340bbb76b65312b04ea4e0b9780"
+    },
+    "quake.rc": {
+     "bytes": 593,
+     "sha256": "4cb2019db882d86d4e5b930c25d68386fcdb0fed6d94348df0ce89eda2031365"
+    },
+    "sound/ambience/calcul82.wav": {
+     "bytes": 54786,
+     "sha256": "7660b94256adf29eb4993ba19dc346e1b11c4d45dc4e3f1c3ff3f1561d49fa2e"
+    },
+    "sound/ambience/comp1.wav": {
+     "bytes": 79262,
+     "sha256": "7fba7d1c9c022aa220d30f2f2726aef03da310beef36623caff71e8ce1f77a3b"
+    },
+    "sound/ambience/disco.wav": {
+     "bytes": 156896,
+     "sha256": "80ef88906dc9230e2b8ec8c99b8e17c8bbd8baa60b9a6bbe96bdbf40c1fc1cf1"
+    },
+    "sound/ambience/disco2.wav": {
+     "bytes": 169568,
+     "sha256": "d195c2906c9c3d3b6dcb7fa7bf243d20ce39b77f4c07f395e8b7081c1e888249"
+    },
+    "sound/ambience/eerie.wav": {
+     "bytes": 57606,
+     "sha256": "af4ae97062c4285166faab7b60ffcbbcf8572db0608721ceb50dbc110a6c37d4"
+    },
+    "sound/ambience/fl_hum1.wav": {
+     "bytes": 54786,
+     "sha256": "aab9e0127220e386e0e2e0bd928610493f8f218325069f880882f693075886d5"
+    },
+    "sound/ambience/hi-tech.wav": {
+     "bytes": 105582,
+     "sha256": "a5fd28a60382e9b9c1e90ab9c34d877dbee5bd4f1a70791387aaa2becd9c0e82"
+    },
+    "sound/ambience/hum1.wav": {
+     "bytes": 61748,
+     "sha256": "1ca80f80b64de3697d4a30a0ce322feb47ade9a232ae6903f2b2b17c17567203"
+    },
+    "sound/ambience/machine1.wav": {
+     "bytes": 102066,
+     "sha256": "a46c7a3bb66e6c6dd9b5c9db6787c71a01f12c86fa224d08c49c80438d96117f"
+    },
+    "sound/ambience/pulse8.wav": {
+     "bytes": 53448,
+     "sha256": "035e5a9bfc8731fa40f829e7407b8f9be902a7d8e2292c252edc57d90afe1986"
+    },
+    "sound/ambience/siren.wav": {
+     "bytes": 6892,
+     "sha256": "70ed1a06245be7ea45bdc11e37596cbe894231d1c1eaf20b65970b37b3f312f5"
+    },
+    "sound/ambience/stormy1.wav": {
+     "bytes": 82836,
+     "sha256": "319cf22c4a5883210c3a008f381994a0c3ee2d4a1a8f98af6d237de509c6570f"
+    },
+    "sound/ambience/stormy2.wav": {
+     "bytes": 47278,
+     "sha256": "3247c358467f53f28836b5f147dad9979f584b3aaee9b410e93945d9d1d383c6"
+    },
+    "sound/ambience/subaqua.wav": {
+     "bytes": 62810,
+     "sha256": "b3c970835c887a1f534e9f93fbe1658be8274fb8fb39028eb0119f4a8a847c21"
+    },
+    "sound/ambience/subaqua2.wav": {
+     "bytes": 63012,
+     "sha256": "1ba8d25c654bb18969c796144281ebb964b082c306b780de7d05be8e1a5c68e4"
+    },
+    "sound/ambience/water1.wav": {
+     "bytes": 63110,
+     "sha256": "8a7a2050db35caf8a99b223149734ead48308733ae0223b06038d201a9244df2"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 66890,
+     "sha256": "16d3c695d9f9933eb6feff6c393695b9edc73fc02fc1a681ccaf157e6cda52a5"
+    },
+    "sound/ambience/windx.wav": {
+     "bytes": 44914,
+     "sha256": "fc8d6e82a26c2f3cbd39426aa1e761e3f678a45b62e122aec0dff4e476035433"
+    },
+    "sound/baboon/dhit1.wav": {
+     "bytes": 3168,
+     "sha256": "3656e0e8788adcd45a028861e517704ab0fb292d7dc77e19f19f63ff48082961"
+    },
+    "sound/baboon/dhit2.wav": {
+     "bytes": 2274,
+     "sha256": "48d451474744b9f77a0dbc2878e033fa23d8b0eeac8ac4cf782e76c868088754"
+    },
+    "sound/baboon/dpain1.wav": {
+     "bytes": 7846,
+     "sha256": "b1c2a51027f815869f80f8b82807a745381c61915b4d8da385a0a41a60c5a99a"
+    },
+    "sound/baboon/monst10.wav": {
+     "bytes": 8828,
+     "sha256": "dfeb5ece8fdc9a1f689db116bf11dce1feef3614e5b5b5bffdad5c76ff8d3c1f"
+    },
+    "sound/baboon/monst18.wav": {
+     "bytes": 21230,
+     "sha256": "8541bfb729234b3db15023bb3e462c47329dadfa13336cfad69bddf4a4c8f04d"
+    },
+    "sound/baboon/wail2.wav": {
+     "bytes": 24812,
+     "sha256": "cbd1ffdaa1c4526aa06fac123f50025a390075242ec18d1c16c5dc0c884c7bf8"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/blowfish/death.wav": {
+     "bytes": 24086,
+     "sha256": "1dcab9630d34fc6421dd7610deb1ef9f22424a4f3641f87cbb972be2af969db8"
+    },
+    "sound/blowfish/idle.wav": {
+     "bytes": 39608,
+     "sha256": "cbbccb150b213f783b60bc545bf8dbc065893266e5495a00415fedb16ec8bafb"
+    },
+    "sound/blowfish/idle2.wav": {
+     "bytes": 55408,
+     "sha256": "e45059b99fd2fa9ddab036a3465f85f2a7af9bea919e26b2922b36fdb893339d"
+    },
+    "sound/blowfish/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/blowfish/pain.wav": {
+     "bytes": 24044,
+     "sha256": "b40b3bec98075e7fbd270ac2320dd7d5dc8f531a6d3aac5da3c4964abb5a2da5"
+    },
+    "sound/blowfish/roam.wav": {
+     "bytes": 13588,
+     "sha256": "17185aa3775a0cf81ac03d18b37dda7c407ad153982386ee4d92cffa63dafaa2"
+    },
+    "sound/blowfish/roam2.wav": {
+     "bytes": 14734,
+     "sha256": "3eb5816c23d2d6cdea94c96a8320c850173d19940f72c5b8caa033963079d999"
+    },
+    "sound/blowfish/venom.wav": {
+     "bytes": 2600,
+     "sha256": "9b4d63d858e72c17d6f8d1657f0683fb5f59d26cd07c9245be58237fee5c6aa6"
+    },
+    "sound/bossman/death.wav": {
+     "bytes": 26140,
+     "sha256": "e85e75d160032d98cda80b5f41b536b835f8199ecadd52c5c089632b3d0a0409"
+    },
+    "sound/bossman/death2.wav": {
+     "bytes": 12872,
+     "sha256": "24504c1da30c316927e3415895e67d9cf4bb4bb8b0df032b588cb82889fdd1a9"
+    },
+    "sound/bossman/jets.wav": {
+     "bytes": 5538,
+     "sha256": "82a753824a2bca44c92e6678811f1a6a344d40cd5438107585ef8a75d3f9f8ac"
+    },
+    "sound/bossman/pain1.wav": {
+     "bytes": 7236,
+     "sha256": "3d95a43f20feb26be9a1a4be4472596a669b0a8f1d74f19a0ef74509967aeba3"
+    },
+    "sound/bossman/pain2.wav": {
+     "bytes": 5900,
+     "sha256": "d09cfb4c757f596a1b3576bd98096557251ecaad6035147eed60b84af6b9d21d"
+    },
+    "sound/bossman/pain3.wav": {
+     "bytes": 5516,
+     "sha256": "895f15de1057bb591d8a13c6ee584326aafca45391c8679cfe3bd7bf187bb79e"
+    },
+    "sound/bossman/pain4.wav": {
+     "bytes": 10026,
+     "sha256": "bc69bd6b3bf28bee8d187c9aec84ed7d679119fef03b1bec09029fbddd78d20f"
+    },
+    "sound/bossman/sight.wav": {
+     "bytes": 61476,
+     "sha256": "87cbf9e6a361775c0c184c54af2be3c3b40e9ffd93e694f57fd0c763f21fc6f0"
+    },
+    "sound/buttons/airbut1.wav": {
+     "bytes": 8758,
+     "sha256": "288d3c7e5db16c5c63ce93c70152cf46ae50c9901c38af38b16fe999e828e1e0"
+    },
+    "sound/buttons/switch02.wav": {
+     "bytes": 10104,
+     "sha256": "8a8d3629dd6a50514516c63ac9f01bcfef32f638bf0bf441a6cc0b137c8e0343"
+    },
+    "sound/buttons/switch04.wav": {
+     "bytes": 7908,
+     "sha256": "e54faff0afb3538e9938e9c993d045acc4fd0818da23b89754957a02b295d17e"
+    },
+    "sound/buttons/switch21.wav": {
+     "bytes": 3126,
+     "sha256": "6112f1ea0931375bf36363bd638654e43a17d0c9a3a981e49cb355e88d86e729"
+    },
+    "sound/damage/death1.wav": {
+     "bytes": 16304,
+     "sha256": "17e315bf99f60a399e1f5bf76c15c4543ebe0c855dadebc2a4191c37d64a84dd"
+    },
+    "sound/damage/death2.wav": {
+     "bytes": 10046,
+     "sha256": "058c096c9413d8b36e3f4d3c2ad9884222a14a58b7563f38ece591b038e8c28e"
+    },
+    "sound/damage/death3.wav": {
+     "bytes": 9046,
+     "sha256": "07701aa0d0928c8b965fd3362f1f19f7ddfafe4a35cc7b21f882c544adc853e2"
+    },
+    "sound/damage/death4.wav": {
+     "bytes": 13718,
+     "sha256": "c7a7af146c001b1d26c64dab2f5d7d3337168289d038f8bb8c913df3b82098e4"
+    },
+    "sound/damage/death5.wav": {
+     "bytes": 13170,
+     "sha256": "fea13b3ab0379072229dec367b8a350be8aeec2530e02e84dd17be37695b8dfb"
+    },
+    "sound/damage/death6.wav": {
+     "bytes": 14836,
+     "sha256": "80ed721e32e2d07b8510a26a080a8f4970f215320223f0b7474c0fe498c4b392"
+    },
+    "sound/damage/fall1.wav": {
+     "bytes": 56192,
+     "sha256": "941918700d9848e3992471ac49858d596129185b81ed42a4be0ae5234e4f2325"
+    },
+    "sound/damage/fall2.wav": {
+     "bytes": 52792,
+     "sha256": "057a5b4f3051d09ad96c398fa82ebc0d4d0e3b1a37b477a5902026c425839aca"
+    },
+    "sound/damage/pain1.wav": {
+     "bytes": 4772,
+     "sha256": "0b90048436c0bd0e725fffd2e8dd646a635595a0cedf48b4e31b9f85429adf3d"
+    },
+    "sound/damage/pain10.wav": {
+     "bytes": 16188,
+     "sha256": "29eb15947ee6d3bfc77e01ab275c117a894ad8c9b02001e9761fc8abf7aa55cb"
+    },
+    "sound/damage/pain2.wav": {
+     "bytes": 6678,
+     "sha256": "3fd4705a7bb89da27b4783a61f9cb43568a744ea1e0be317ca2ce8e00fafcd2d"
+    },
+    "sound/damage/pain3.wav": {
+     "bytes": 14836,
+     "sha256": "328b6508768ac305595ca975ecb22ddaec4ca935138163b8ff917442ea296835"
+    },
+    "sound/damage/pain4.wav": {
+     "bytes": 8252,
+     "sha256": "f81822d40528b5f51d6a4be9338abd69eac1bb7092beb918ecde1e4e444ac3aa"
+    },
+    "sound/damage/pain5.wav": {
+     "bytes": 3120,
+     "sha256": "7ea9551a9bdc02b675f50ac63241d4caba05bad9659253d5209c7421b19785be"
+    },
+    "sound/damage/pain6.wav": {
+     "bytes": 5424,
+     "sha256": "8c3a58569d8acfd8909221b0caf102ba76dfc593868d7ecdaf68bd72762d4252"
+    },
+    "sound/damage/pain7.wav": {
+     "bytes": 3968,
+     "sha256": "2a4f925590534c67eea8b234d0d7b0ab2a2fc751f0fc572ff5055a886f8c3e65"
+    },
+    "sound/damage/pain8.wav": {
+     "bytes": 5676,
+     "sha256": "03a8ca0aab3610a13a87c53bb5d2e21c76bfd936416a2d5658601b170bafa2a1"
+    },
+    "sound/damage/pain9.wav": {
+     "bytes": 5426,
+     "sha256": "6fc341d55c8bce23cdbbe2e524a0b1873da3411cc6818295f242b3e703842adf"
+    },
+    "sound/damage/plant.wav": {
+     "bytes": 9280,
+     "sha256": "1387a6c49c4622ce362b972e5339e0aff62433937f7eec323d39343c4335f4d8"
+    },
+    "sound/damage/scuba.wav": {
+     "bytes": 42452,
+     "sha256": "70a113f5ba0312d09856dee625b6c032096c01d3b9481ee191d5cb29b5adf6dc"
+    },
+    "sound/damage/subpain.wav": {
+     "bytes": 8288,
+     "sha256": "4c67cd52c8f4906286252838572ff1acdf3b153f4a36f2c096c08d413a35ec9a"
+    },
+    "sound/demon/dland2.wav": {
+     "bytes": 1710,
+     "sha256": "b752a4856556b1ba0868cadc3bf3044a3b950892a23445dbb00c722f39377ee9"
+    },
+    "sound/doors/basetry.wav": {
+     "bytes": 6516,
+     "sha256": "316c201dd7a44b79f6bf07db8d03003bc07d61b754a8d940c733e3dca58fcbf3"
+    },
+    "sound/doors/baseuse.wav": {
+     "bytes": 8450,
+     "sha256": "9a9acc536618770ed9448cb64d975c0b010d3cf1c7fd1a5d499476d1f24a9dd8"
+    },
+    "sound/doors/bay1.wav": {
+     "bytes": 43814,
+     "sha256": "3ac20df7652ddd02b1695a175dbf4ffb83ab2b9cecbba4d04ea5b008bf1cf6bc"
+    },
+    "sound/doors/bay2.wav": {
+     "bytes": 5582,
+     "sha256": "99c4e2100335a5c217d370277dd218602a2419e12afc6f2fd9974ae81b7cc9ca"
+    },
+    "sound/doors/doormv1.wav": {
+     "bytes": 43818,
+     "sha256": "729ad30245f7b9036d197f742c067c741ab4513992322f1e844a8bc5411d54d6"
+    },
+    "sound/doors/drclos4.wav": {
+     "bytes": 5582,
+     "sha256": "99c4e2100335a5c217d370277dd218602a2419e12afc6f2fd9974ae81b7cc9ca"
+    },
+    "sound/doors/hydro2.wav": {
+     "bytes": 18420,
+     "sha256": "1d3a8e3151c52582d9f1032a6756dbd8d62f0974f3b95386265bdbc426a36eef"
+    },
+    "sound/doors/mech1.wav": {
+     "bytes": 34896,
+     "sha256": "b5e0edf6e887644a32771c0e8bb030b359f2d5ea4e9ecece2385d10e457ae1e6"
+    },
+    "sound/doors/mech2.wav": {
+     "bytes": 4086,
+     "sha256": "0c4acad4750c3a14b32e815743f0b31d601da35ff56b29557fd0e701adfeb5d8"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 11070,
+     "sha256": "e34d85e6fc303e278c86527a7b7d17449c8b548026d0027fbc791c4fa8dd9047"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 24422,
+     "sha256": "1ca5284f3120e32c9aca599f4342bdc634b049937c779aa59ae51a8f830f7e7b"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 8016,
+     "sha256": "fe607a3612eba54bb4bab9a1af8c3031f2082d267996b5c45b747aae24f579ba"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 7950,
+     "sha256": "2f4fd31d3d646ce265a98cfd3d0ac8d5464513a418396d8f7cd4b60fba786150"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 6956,
+     "sha256": "90091c042b183213441434999b3db973aec6c1c0497cc32524c5b6c078e037a5"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/hunter/basegun.wav": {
+     "bytes": 23254,
+     "sha256": "f2bd84fc5a839ce6bda0edc7f968b16c3d5c69002e20659b78d916e9c8f88b6c"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 42860,
+     "sha256": "22a534f13b8838d5d0843753abc7debd975c6fded116eea42b9dc6f966b4bfc6"
+    },
+    "sound/hunter/idle1.wav": {
+     "bytes": 8660,
+     "sha256": "71c5308333234f4d448a2d45ed7594c986b44a512898fddb8d89f500957c2e7c"
+    },
+    "sound/hunter/led.wav": {
+     "bytes": 2106,
+     "sha256": "4ec99b08ecf64f57eee5ab0ed71ee77ce71484f6e484b91e470f4fe69e28e729"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 25642,
+     "sha256": "dce2dd9ac3925472c5cb92e87ef95932878d332ff76edb839324ab72f1ddfa0a"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 9992,
+     "sha256": "945c2b2202ec4738427381df4406fcea52d432662d9177337ab3026563fff52c"
+    },
+    "sound/hunter/sight1.wav": {
+     "bytes": 10264,
+     "sha256": "195491537b2b721821cdd704d28502c412f08aa1ae023af7a26bd4b1387af030"
+    },
+    "sound/hunter/sight2.wav": {
+     "bytes": 12384,
+     "sha256": "926ebbbf074e20bcd3205ce44f2e427bcd5c0eebc3114b6ba5e48978d837ab1e"
+    },
+    "sound/hunter/stomp.wav": {
+     "bytes": 10040,
+     "sha256": "01e677a8b877015afa1eb09823c715be24cb1e954a464ebf501885b7320c0850"
+    },
+    "sound/items/health1.wav": {
+     "bytes": 10322,
+     "sha256": "2061c8964f2c3b1052473fe15e86cdb7324ee95107ccd16b7b5c687440833fd1"
+    },
+    "sound/items/r_item1.wav": {
+     "bytes": 13650,
+     "sha256": "c9b3becb2d4c5550e30a974388f87ddd9378a4b77d5b05c61aa7240288da667f"
+    },
+    "sound/items/r_item2.wav": {
+     "bytes": 14488,
+     "sha256": "a0c3d214508970d2f47f2b07d4b1c7c87f94d4e9e2eb659feaa6120bd7ddc83d"
+    },
+    "sound/mercbabe/death1.wav": {
+     "bytes": 8856,
+     "sha256": "663fcd16df6c845fc318a6181b2eece0678f9f3980a90ea3d34f0592e61e6087"
+    },
+    "sound/mercbabe/idle.wav": {
+     "bytes": 23194,
+     "sha256": "af1c2534c69cfb3f07e160cd39f66fcfbe9d64580cb9fcfc43520637c6931532"
+    },
+    "sound/mercbabe/pain1.wav": {
+     "bytes": 7748,
+     "sha256": "b9a2527347e2272a676390b3a6bce4cf623f233a11b27d932e340ed67e72823d"
+    },
+    "sound/mercbabe/pain2.wav": {
+     "bytes": 4872,
+     "sha256": "76d5ae6f0532eb1a43493330c90966be651e05ba9eed2a994a9afaf28c73de78"
+    },
+    "sound/mercbabe/pain3.wav": {
+     "bytes": 6474,
+     "sha256": "776a81059bc7fd0f8c998f5e8e05837686d1578c8860aad77901665c31370caf"
+    },
+    "sound/mercbabe/scream.wav": {
+     "bytes": 16132,
+     "sha256": "76dc830e9b5c85dc33c823968a76aaa63ca49153a6eada7af70f4e9000bf6ec1"
+    },
+    "sound/mercbabe/sight1.wav": {
+     "bytes": 11356,
+     "sha256": "8c6609a6ea9d85f10cda8dd2aa2d0fb77f5e9690698cbafbc213eb5d4f2b6f5d"
+    },
+    "sound/misc/basekey.wav": {
+     "bytes": 7386,
+     "sha256": "70a46f1f523d62da00f7a46fe5ade4d6e2479e36d5638dfd430b1c872a33d529"
+    },
+    "sound/misc/crate.wav": {
+     "bytes": 7214,
+     "sha256": "7b275aa872a8c6f987bdc2baf288d0fde087735e2c3c5d8d14b996a6334a2f87"
+    },
+    "sound/misc/crumble.wav": {
+     "bytes": 10678,
+     "sha256": "da14ccb64162e4597c494b140d947af0a8056dc70937d73964edc4ab0670389e"
+    },
+    "sound/misc/discharg.wav": {
+     "bytes": 25670,
+     "sha256": "a2cf75f9b88e883744552d2e9fc1a0ddbcd655ee4ec7422fc0a080427d37166d"
+    },
+    "sound/misc/glass1.wav": {
+     "bytes": 29110,
+     "sha256": "29c9a1dd9f55cc4e9cdcadc7ed3c22693fdd6f6729dc574160f2bb61be0872ab"
+    },
+    "sound/misc/hiss.wav": {
+     "bytes": 7422,
+     "sha256": "f4d23a4146cb2591ef0879663f742a5a38cc5be06d57d235cd47b0e4edca937e"
+    },
+    "sound/misc/intense.wav": {
+     "bytes": 45320,
+     "sha256": "9032c888f655244d4afc57290a7794402e81280ee7e85a3bf7c1a91f6284730c"
+    },
+    "sound/misc/ion.wav": {
+     "bytes": 7550,
+     "sha256": "7684698b9898dad1a0c01a8da6758a8f9a17819113eaa0491a22ec6c8855b2ce"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 4208,
+     "sha256": "28234c6605a498f99a95b741d34d08051eee59f102c3224a917abe9be96ac806"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 22378,
+     "sha256": "f4773b6e6c1bac2c495c844ee62b31adc9f37a0c548cd955ea14e6a59144b111"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 1878,
+     "sha256": "22d7f833f81c5dae3fedb8a746fec1670fd909d9996a9d1384f7b88f4e45b015"
+    },
+    "sound/misc/motor.wav": {
+     "bytes": 21008,
+     "sha256": "a06fc10683d13101e105fe569329614d331ec6dc452635fa64257245e746f218"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/misc/r_tele1.wav": {
+     "bytes": 12404,
+     "sha256": "dc5266aa66ac28f101e2aedb123b9b1e00cce2cfda9ceb69f3857fb685021543"
+    },
+    "sound/misc/secret.wav": {
+     "bytes": 7634,
+     "sha256": "413bd14551986a3e1e827e185e78fc20424e93e08d4eb6ba061ca1595125b678"
+    },
+    "sound/misc/step1.wav": {
+     "bytes": 27042,
+     "sha256": "fc485f8365abf042f2abb94ba4a21f077f688419e252a50fe9cfba2f55fd280a"
+    },
+    "sound/misc/stepstop.wav": {
+     "bytes": 6102,
+     "sha256": "79ec338698b2f8bfde44e0b5e8e31ca3d34e140ca88a45eb81c7c72b7ca31134"
+    },
+    "sound/misc/talk.wav": {
+     "bytes": 3648,
+     "sha256": "0bb914958a4c962efcca964c62fd9876ce11814bd0c7b21ff049c60dee43f27e"
+    },
+    "sound/misc/talk1.wav": {
+     "bytes": 6358,
+     "sha256": "cf547000f737b8c9f8571b47608dcd3b601b75ba6940550b8a2c13299077f3a6"
+    },
+    "sound/misc/talk2.wav": {
+     "bytes": 7248,
+     "sha256": "0cd00a8fb18dbac0d4e0c3f911ee8548692923ab261fcf2c868e09ec6ab39506"
+    },
+    "sound/misc/talk3.wav": {
+     "bytes": 8418,
+     "sha256": "c49eb8d740cbf62059b89f94b83843ff797a2ef2c43e9e98489edd06dee6e972"
+    },
+    "sound/misc/thud.wav": {
+     "bytes": 10040,
+     "sha256": "beaed74203d90db31179bef1a2e249177f1781bca9d040b8fa614b0db23ae4fc"
+    },
+    "sound/misc/turret.wav": {
+     "bytes": 5380,
+     "sha256": "012ef8efc5f9b9f9f24747e36fca99df3a7c302bf092505cfb05e017a6c757bc"
+    },
+    "sound/misc/vinity.wav": {
+     "bytes": 54436,
+     "sha256": "3dbbb2006ec93a8876d3e2c48d671f2c2a81c572941dbb4b39d01cf16a2cf4fd"
+    },
+    "sound/misc/warning.wav": {
+     "bytes": 5154,
+     "sha256": "7948cb157e342093369d35b211266ff10df22d04cba435efd7cf183313386a48"
+    },
+    "sound/plats/plat1.wav": {
+     "bytes": 34894,
+     "sha256": "b2e21affbec8cf3784627d4556b439269253ff68e28359570b6238f7c7fbd0c2"
+    },
+    "sound/plats/plat1y.wav": {
+     "bytes": 38690,
+     "sha256": "2c691a78650dec47a2ea0e3ef697a1af06ed86019e0756b7df3b9ca9d4135dbc"
+    },
+    "sound/plats/plat2.wav": {
+     "bytes": 4086,
+     "sha256": "0c4acad4750c3a14b32e815743f0b31d601da35ff56b29557fd0e701adfeb5d8"
+    },
+    "sound/plats/plat2y.wav": {
+     "bytes": 11602,
+     "sha256": "0e8585808da24f28484f56a28c89a0e5938fe4044d5a8d796ed6fc3cfa7f79ff"
+    },
+    "sound/plats/train1.wav": {
+     "bytes": 35518,
+     "sha256": "0a9bf0bd96d22dcbce55ff6c4a4feffe160502da4852d00f523501bb5a5445e6"
+    },
+    "sound/player/drown1.wav": {
+     "bytes": 4802,
+     "sha256": "e9859f1ef673137f6f1b8d7e0eea5ccda846bc28ff13bce2babf25937854073e"
+    },
+    "sound/player/drown2.wav": {
+     "bytes": 16750,
+     "sha256": "73a15650b23d26e3b52e4ad99d6904a5ffc9ec5088bd22adc76cd431fde8baa4"
+    },
+    "sound/player/gasp1.wav": {
+     "bytes": 24020,
+     "sha256": "d624f8fc853ea483bf60e80ca2225dd4dd6ce6851078b7c35f15d95590a5f602"
+    },
+    "sound/player/gasp2.wav": {
+     "bytes": 21434,
+     "sha256": "343a9bed8fe72cab115bb23b178b52aa46475e9980259fb6f37f65e395581d67"
+    },
+    "sound/player/h2odeath.wav": {
+     "bytes": 13730,
+     "sha256": "01e9f0341cc9cbd797c6f784db91d2f13b9b0fc48edffe3042088fdc90113902"
+    },
+    "sound/player/inh2o.wav": {
+     "bytes": 38600,
+     "sha256": "7066d80d6b5ad60a859b9976f78f621523a54767baa1221dca35c20a8128cf78"
+    },
+    "sound/player/land.wav": {
+     "bytes": 4492,
+     "sha256": "3862c130ae8f4d873e57cd29bcf35a074b792bbd70f05a3c62435aa7454834f6"
+    },
+    "sound/player/land2.wav": {
+     "bytes": 7860,
+     "sha256": "841672051004c6077bd6d02a334cc01e83f0eae3e96442e17893f3ff5ab018a8"
+    },
+    "sound/player/plyrjmp8.wav": {
+     "bytes": 4022,
+     "sha256": "110244442ccf461f62be5590aab4cc4e828fe84d75113ac8570b454980c09de5"
+    },
+    "sound/player/udeath.wav": {
+     "bytes": 16404,
+     "sha256": "0469e8dc434a5052b028bcdba084225c20881bfc417d3d7bbde0d9784d37a8a9"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rat/eep1.wav": {
+     "bytes": 7416,
+     "sha256": "4305843557969a33519479c52e4e3045125c92313819d46595bf48ae5d2c7160"
+    },
+    "sound/rat/eep2.wav": {
+     "bytes": 5008,
+     "sha256": "8051ab1634aafa8d1ded4c8b9e38332f9cff0fa7ca989bad4b8bda8215ea37a9"
+    },
+    "sound/rat/squish.wav": {
+     "bytes": 6484,
+     "sha256": "4fc801bd6707c59edc18e80aabe49a1bef4ab809f83063860947d60c13a6ff74"
+    },
+    "sound/rat/squish1.wav": {
+     "bytes": 6250,
+     "sha256": "b502779f4a38eebb14d3093c8ab5bacb36718a83f2f4bd96cdbc8875b138a7f7"
+    },
+    "sound/rat/squish2.wav": {
+     "bytes": 6450,
+     "sha256": "9dbcb91ba2824e9a2dfa0bf6b401403ea95cbad2d7fce7340035421c07c35804"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/riot/attack.wav": {
+     "bytes": 8564,
+     "sha256": "87d13b8a60bcc597d9ac0788f5e37785c6bfd388e6d55a77ff3e28e2fdc48185"
+    },
+    "sound/riot/die1.wav": {
+     "bytes": 19508,
+     "sha256": "52fc0f40ac127c9dd71d6d59494b4b678702868557d8668da982277639216297"
+    },
+    "sound/riot/grunt1.wav": {
+     "bytes": 5748,
+     "sha256": "f16ca6b0fd080b5c890b88bc2d8099761b07a73ab8e54a72615c57248890e1ab"
+    },
+    "sound/riot/grunt2.wav": {
+     "bytes": 4730,
+     "sha256": "fa5cd3ed5c4863361990b676ed376aa0505bf7f7db5e03ebe71f3e646e598dae"
+    },
+    "sound/riot/idle1.wav": {
+     "bytes": 11448,
+     "sha256": "1834eaabef77ad3a8b93d97de48c09367b8121be5ad54fb2fa40af2ff5618574"
+    },
+    "sound/riot/idle2.wav": {
+     "bytes": 11794,
+     "sha256": "4241410520bd91b8df7a3cfd0b60db20f421cf814fd0d8a03b87442ef3550e3c"
+    },
+    "sound/riot/pain1.wav": {
+     "bytes": 3420,
+     "sha256": "9e9a296d8a9fd132532ff41454178c984795bf6931a5959053bc2fd225af2abc"
+    },
+    "sound/riot/pain2.wav": {
+     "bytes": 6364,
+     "sha256": "3daaed69aa5f1038f54b2a95ab0cd573a5339d11134c81cccd118111f10268ed"
+    },
+    "sound/sub/locked.wav": {
+     "bytes": 10090,
+     "sha256": "acba769af21666d08d96617a29952abac00fac0251620babcc76ba119c826e77"
+    },
+    "sound/sub/lockon.wav": {
+     "bytes": 2214,
+     "sha256": "6021c5409dffa3f30d32c3e04581019a41c72b1d55c04fa19f72e11a6b9c4502"
+    },
+    "sound/sub/ping.wav": {
+     "bytes": 29834,
+     "sha256": "0348b730aaa8aeb5154d61d2253c214e919fc6c5cbf041a99a99b311852c2eac"
+    },
+    "sound/sub/throttle.wav": {
+     "bytes": 19048,
+     "sha256": "9c7bb02203abb120d5b29cae3fa48881830d988f74e21b9022dcb712d3fcc3cf"
+    },
+    "sound/swat/arms.wav": {
+     "bytes": 19498,
+     "sha256": "1b8036484f9f2a2d43055a9815c07d9d3f315ba0d852f3a5bc89b2f451d5fb31"
+    },
+    "sound/swat/death1.wav": {
+     "bytes": 9668,
+     "sha256": "4df3ca5b89784f5260fa2ab825666df21c9735c88fcebfc80cef454457b9edcc"
+    },
+    "sound/swat/death2.wav": {
+     "bytes": 12244,
+     "sha256": "732ff17f8ce04f584fbfc47b65c73900c403a0351f3e3630997ac3694b831dcf"
+    },
+    "sound/swat/death3.wav": {
+     "bytes": 5904,
+     "sha256": "b35bcdac516312c929c80b5b5d7d00df4be50b5f658c2b923d3122fe07ee1284"
+    },
+    "sound/swat/idle1.wav": {
+     "bytes": 4692,
+     "sha256": "015f58dad755c332ff78964458c0ab58e0db7ce8c51e2481fea0d8e7b8cf1069"
+    },
+    "sound/swat/idle2.wav": {
+     "bytes": 4014,
+     "sha256": "fbe275511a9142ed079a71cfa4da2e7fe9241f4ccf4c9c2b15ff37b65fad2917"
+    },
+    "sound/swat/idle3.wav": {
+     "bytes": 6422,
+     "sha256": "bd6930b788abf2eafa128bbeef6810affe90a100baef9a03b8c42f8559af5a48"
+    },
+    "sound/swat/jug.wav": {
+     "bytes": 32376,
+     "sha256": "c705d527e8935dbcd7cdbf5412cbf882dff54ae0d85e65ef33e065d93ea29ed6"
+    },
+    "sound/swat/pain1.wav": {
+     "bytes": 5184,
+     "sha256": "0ed17a3680b6b36b1a75e9d16df80132bbafa0f3aecca5be83ce90909a794fc2"
+    },
+    "sound/swat/pain2.wav": {
+     "bytes": 2090,
+     "sha256": "f66d6d98122a66e7a5a603840655999c3fa31ea3fe574a4ea4e247cdbe0680c0"
+    },
+    "sound/swat/pain3.wav": {
+     "bytes": 2088,
+     "sha256": "436da59c0d1150fc7f28bab5286be772237ae251b731c91e9904b4d3860d73eb"
+    },
+    "sound/swat/sight1.wav": {
+     "bytes": 5126,
+     "sha256": "187bfdb362eebfdf1081c23ab5cb7ba7bf69b321d85deb2b48a0c8a3f35021d0"
+    },
+    "sound/swat/sight2.wav": {
+     "bytes": 8956,
+     "sha256": "7c83d67522230f265850d7843fcda9e014432fb6c8836c87557949728a5b01d7"
+    },
+    "sound/swat/uzim.wav": {
+     "bytes": 1878,
+     "sha256": "db84fc5df9ca343335de7606326694e5c2687feea5a548c20b224f1e99566d18"
+    },
+    "sound/torcher/death.wav": {
+     "bytes": 22570,
+     "sha256": "dd0b4659448d1cf145725dc796f4c0aaac68464df6c3ca63856951eecd71903c"
+    },
+    "sound/torcher/idle.wav": {
+     "bytes": 13008,
+     "sha256": "25505b248e9dfb3e5b55757bc5e35f91dd8591ce1dc6413654e9a5570de3af63"
+    },
+    "sound/torcher/idle2.wav": {
+     "bytes": 14860,
+     "sha256": "b2b399060ea4fcabaa3b2059e745e27535a47046fd2f0bda0f988b3d4cc0c21d"
+    },
+    "sound/torcher/pain.wav": {
+     "bytes": 4002,
+     "sha256": "ee0acf2fa190e6126e069ac10845a7f8d573e4e27b7c018ccf6c368be5f2647a"
+    },
+    "sound/torcher/pain2.wav": {
+     "bytes": 4578,
+     "sha256": "4d0501c506517f5c3973cf10ccc617dbccd4279f9e3147deb1b9b2a312821bb5"
+    },
+    "sound/torcher/stop.wav": {
+     "bytes": 8354,
+     "sha256": "827ef187afd326fa48fc91f9d92bd07fbf4554fe9ce424b5086b116f3eda2597"
+    },
+    "sound/turbine/fanblow.wav": {
+     "bytes": 5458,
+     "sha256": "4a3b6efb844582d84692f8b884ad452e7343959042c770bcb14b35177a7251a5"
+    },
+    "sound/utils/hoveroff.wav": {
+     "bytes": 15568,
+     "sha256": "d94909a6a5c37cb37a3072f0f43887bb08dbc27cc4ab10529fcf1f7f0f8f8547"
+    },
+    "sound/utils/hoveron.wav": {
+     "bytes": 21204,
+     "sha256": "bd7fdb0bb4c4420445b33190ba7724a7b64c71169e975559ad05cb9e53acc92e"
+    },
+    "sound/utils/hovrboot.wav": {
+     "bytes": 7166,
+     "sha256": "d3a023fed29279af98f6f64c6a6bc1f6f9da08e894abb4a8307067f522e598db"
+    },
+    "sound/utils/hovrjmp8.wav": {
+     "bytes": 2354,
+     "sha256": "2e2f1caf7824c70400e08110079fd55e4d270197b4d1f4e0be2babeb0acbacdf"
+    },
+    "sound/utils/paraland.wav": {
+     "bytes": 12020,
+     "sha256": "74baba719cf68fdf3e2dc7821dfe95a546b407910d5f4e4bd650e58ffa540973"
+    },
+    "sound/utils/pick7.wav": {
+     "bytes": 9598,
+     "sha256": "cd54e3d6580496f4393c87dba7f99ff6a16549a0ce94fddf3d4a65e2cc19b0aa"
+    },
+    "sound/utils/pickup.wav": {
+     "bytes": 12848,
+     "sha256": "50c4677e7e457af255d352fe4e586fc2a74734fbd4cf4d54e48d1d263d2781a4"
+    },
+    "sound/utils/pullcord.wav": {
+     "bytes": 8060,
+     "sha256": "ef3345d55c5721e7c7381510b625ec90d64c909ef6037812cac29116309f6727"
+    },
+    "sound/utils/putout.wav": {
+     "bytes": 8898,
+     "sha256": "597611daefcd233e51a102d3d6f967c7d103fdc37fbb9545a5c7fb54cf6634bd"
+    },
+    "sound/utils/receive.wav": {
+     "bytes": 1366,
+     "sha256": "14b5520599e929b669ec992bb5e86e15b6b1fe9324c1a0d126bcc76ee989f5df"
+    },
+    "sound/utils/send.wav": {
+     "bytes": 5662,
+     "sha256": "452e84219ae6dde247c44720674c7099961e16ba6c48814f595851b866f08fc3"
+    },
+    "sound/vasquez/death1.wav": {
+     "bytes": 15200,
+     "sha256": "5788dec8718bb1a6cc6e8efa2e378266d9d5a852833101b95717e51b313ea068"
+    },
+    "sound/vasquez/death2.wav": {
+     "bytes": 35402,
+     "sha256": "7c252b18e434d6860cf842b2fea6d01d5ba6b1d557ebdb729a282e34eb03f686"
+    },
+    "sound/vasquez/death3.wav": {
+     "bytes": 7172,
+     "sha256": "a6d255a91d6f88fc6e97428a98a2c46ce632b0ea2c8e069d3fe393ff05f88403"
+    },
+    "sound/vasquez/pain1.wav": {
+     "bytes": 5026,
+     "sha256": "89991b8d25e2fe7d0c929eaa888a14e82a8365817cd0f6652958fca1cbbae5c5"
+    },
+    "sound/vasquez/pain2.wav": {
+     "bytes": 4770,
+     "sha256": "ea31cfeddb151cfa160d00b04b3fc9711212da119db0731cbc2650683a58db25"
+    },
+    "sound/vasquez/sight1.wav": {
+     "bytes": 11438,
+     "sha256": "4322a7589852d1e8e594ca05180e6ddb091fd7a146d943b96f730b2991d394bb"
+    },
+    "sound/weapons/casehit1.wav": {
+     "bytes": 3498,
+     "sha256": "2dd8169f787604157def5a9a06ec0841494e2f097b16f92fe130c73e138ba4ca"
+    },
+    "sound/weapons/casehit2.wav": {
+     "bytes": 1798,
+     "sha256": "dd3d665c306cd479fc5f072ca252f12a759741eadb9fe61ace11b67b318196bf"
+    },
+    "sound/weapons/casehit3.wav": {
+     "bytes": 1116,
+     "sha256": "254605c2f905ffaf93fdbe11829cf9a6e70dcf1e2cd3b04a6c90c80b080d5823"
+    },
+    "sound/weapons/death.wav": {
+     "bytes": 11578,
+     "sha256": "8a032b98af42823e827169e160b1af9f00de8c91167d7ada7a71b86718818643"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/hellfire.wav": {
+     "bytes": 18310,
+     "sha256": "68599f4d314725bfc944be408fb015cc04904a31612217e007858ab87b0b22bd"
+    },
+    "sound/weapons/loadrock.wav": {
+     "bytes": 9426,
+     "sha256": "32dd0c144ee4b4444594c14b023a11f89f0fd21aa6f86cdd1feb01327ad6782c"
+    },
+    "sound/weapons/lock4.wav": {
+     "bytes": 1630,
+     "sha256": "3dc158cbe592566a52668a10a34bc0f3c70daca6cc87924ebe5ef3585ea21658"
+    },
+    "sound/weapons/minback.wav": {
+     "bytes": 58510,
+     "sha256": "29960964d9d0950aa6ec36feabab0d08cf67fdd8392bb8980dfb985d6e869153"
+    },
+    "sound/weapons/mini1.wav": {
+     "bytes": 15348,
+     "sha256": "fbd8de6e92284d3b7887135f40c6710e06e91b206a43cdbd8881999caf37ffc9"
+    },
+    "sound/weapons/mini2.wav": {
+     "bytes": 16374,
+     "sha256": "feb434c78b73208ff5d9c98b95dcd98fc35ada7e90f53423e28727b7ec5c846f"
+    },
+    "sound/weapons/mini3.wav": {
+     "bytes": 7994,
+     "sha256": "bc7c53b0440402a0c09e2129eff29147b3820ca37c9dd752f9f061b11bbc6eb8"
+    },
+    "sound/weapons/minidown.wav": {
+     "bytes": 14722,
+     "sha256": "2227949b79a115bfba4abc692fc68dbc62c741511ae7f0eb9155d99c9adc363c"
+    },
+    "sound/weapons/misfire1.wav": {
+     "bytes": 1616,
+     "sha256": "079ff25341731b6e95ae3fca23d1c46c1500d76866e14493ed86a782d3605e72"
+    },
+    "sound/weapons/misfire2.wav": {
+     "bytes": 2594,
+     "sha256": "e24da5aa277c688113860e6de1701ad6612d938bab614bd8fd78c53c783b57bc"
+    },
+    "sound/weapons/morter1.wav": {
+     "bytes": 18632,
+     "sha256": "b1d933a7d6e959bc756cc450e091c5d1f25139d1b60a2a6a4e0b2c7f9c1e3b57"
+    },
+    "sound/weapons/morthit.wav": {
+     "bytes": 3912,
+     "sha256": "3a8f7a8854e3cb1602be33f9cef9b5fb3b4e99037abf9158a6f54b397bcaf54a"
+    },
+    "sound/weapons/plasma.wav": {
+     "bytes": 8098,
+     "sha256": "19a86e0030413494640844ee9ce338582fee14fcc76e851c87fb4ef8da97549e"
+    },
+    "sound/weapons/punish.wav": {
+     "bytes": 28640,
+     "sha256": "19095d7d8e824d40502b8da8af2faa6b6c7bd7edc6896ff3e9ca7920e49a388d"
+    },
+    "sound/weapons/punish2.wav": {
+     "bytes": 15052,
+     "sha256": "100ca38d684f841b4a8e41bb118d215bd7e400f067a22bef634f99a0776eafcb"
+    },
+    "sound/weapons/punish3.wav": {
+     "bytes": 15052,
+     "sha256": "33a7abb2fc907c30cdbef9ebec2e97c9f1c101654df6ccce3e3b4118e2759396"
+    },
+    "sound/weapons/punish4.wav": {
+     "bytes": 14982,
+     "sha256": "b7d13c4e662ef75e77d926d460fada5c68b0fefa18081ca7766b39dd83febc2d"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 16292,
+     "sha256": "867374815e8c853db0a5824e4945074845df3aa3350dd6b8a21e15754f8b27a9"
+    },
+    "sound/weapons/reload1.wav": {
+     "bytes": 12330,
+     "sha256": "6363992c9131147400af74706cc347f610f4c09515ad253948d582714a6b1024"
+    },
+    "sound/weapons/reload11.wav": {
+     "bytes": 4552,
+     "sha256": "d64f4681bc926e71cf2b602755d02b13306c55147addb3e8bf0bf4789289f0d3"
+    },
+    "sound/weapons/reload2.wav": {
+     "bytes": 6140,
+     "sha256": "6c2483fe81631f5fba28ac5236580abfd79ac1ffff3934092154a8d1ebc04a09"
+    },
+    "sound/weapons/reload3.wav": {
+     "bytes": 6032,
+     "sha256": "5481ead97a685183598953bb349728bb3bc70285aad6d5e2751702d78b93283e"
+    },
+    "sound/weapons/reload4.wav": {
+     "bytes": 3654,
+     "sha256": "ec7eaec0347f6345c78439280ead17069438b998c2bbd48af3b563ec3ec1852d"
+    },
+    "sound/weapons/ric1.wav": {
+     "bytes": 11218,
+     "sha256": "f660e436f67f789f36b33da77c97f5c879a0506fcfbeebbefafd71e3ac9651d0"
+    },
+    "sound/weapons/ric2.wav": {
+     "bytes": 11218,
+     "sha256": "f660e436f67f789f36b33da77c97f5c879a0506fcfbeebbefafd71e3ac9651d0"
+    },
+    "sound/weapons/ric3.wav": {
+     "bytes": 11218,
+     "sha256": "f660e436f67f789f36b33da77c97f5c879a0506fcfbeebbefafd71e3ac9651d0"
+    },
+    "sound/weapons/sgun1.wav": {
+     "bytes": 54232,
+     "sha256": "09ec4782205bee183049348863a61498a05fcd9dabe75a2743c253a7239bf9aa"
+    },
+    "sound/weapons/shell1.wav": {
+     "bytes": 4746,
+     "sha256": "b66bb29ac37a6d57521d7168d089c8b820124df9ac770e5c65343096f73ae7a4"
+    },
+    "sound/weapons/shell2.wav": {
+     "bytes": 2308,
+     "sha256": "e5131023f7a72c0b07f2f39db9b5d1f275a210e0cdae9bf4c52ac4e608730816"
+    },
+    "sound/weapons/shell3.wav": {
+     "bytes": 2718,
+     "sha256": "c70d3d6835937c6a8603b1d0244f5970b98f409f9e3c18b7e9f9e700d4b3fdae"
+    },
+    "sound/weapons/shellhit.wav": {
+     "bytes": 3414,
+     "sha256": "b82ece7f51d3b627ac9230543cd8e5da540105b4a8389d3ef077cdd69c8bdd0f"
+    },
+    "sound/weapons/shot1.wav": {
+     "bytes": 16700,
+     "sha256": "384194bdee6b9d3f8cb761321eedcbb37ae2c3148c2131389e974260b2510a70"
+    },
+    "sound/weapons/shot1b.wav": {
+     "bytes": 11674,
+     "sha256": "33f852f676ea6c1fff51c79e6d0aea657b0420b505be0742a2fb210b8d7cf96f"
+    },
+    "sound/weapons/shot2.wav": {
+     "bytes": 20938,
+     "sha256": "729a7e06dd971ca473ab2e272b237687afa03e3ebceb90ea92f975633d91f473"
+    },
+    "sound/weapons/skull.wav": {
+     "bytes": 7174,
+     "sha256": "a521c05c2aaed8abbb38fd31ade85185717155bdd79aa9019d863f183bc45c98"
+    },
+    "sound/weapons/sniper.wav": {
+     "bytes": 3262,
+     "sha256": "d6b83b45a66f581b9b053859157cc39d2e3cc0ce20f26e25081bba6a8ff08975"
+    },
+    "sound/weapons/tink1.wav": {
+     "bytes": 11218,
+     "sha256": "f660e436f67f789f36b33da77c97f5c879a0506fcfbeebbefafd71e3ac9651d0"
+    },
+    "sound/weapons/torpedo.wav": {
+     "bytes": 21708,
+     "sha256": "8182d8a8a04a1325a6d53fd46e83cf51e518e7510a5fa9fef060376ad91ae757"
+    },
+    "sound/weapons/uzim.wav": {
+     "bytes": 1878,
+     "sha256": "db84fc5df9ca343335de7606326694e5c2687feea5a548c20b224f1e99566d18"
+    }
+   },
    "sha256": "1141f0428a33efece16cd251a6aa2bf28ca3a62af114d5d17d749bc02e7c915d",
    "timestamp": "2024-05-17T02:33:02.000Z"
   },
   "pak1.pak": {
    "bytes": 771948,
+   "files": {
+    "default.cfg": {
+     "bytes": 2465,
+     "sha256": "e5b743bc1882bea16f27c94162d6f992c7d7c2176f9f56683fdd67ed14e2b9e0"
+    },
+    "progs.dat": {
+     "bytes": 593484,
+     "sha256": "5c732e19c44ff30a99c5f7f7abea42deb9d83a49fd361549f414ffac7a9255a6"
+    },
+    "progs/h_baboon.mdl": {
+     "bytes": 25140,
+     "sha256": "b186df41b3d07f0f2bc378d1455f0acd930b47cad39351c06433a25d2dc79501"
+    },
+    "progs/null.spr": {
+     "bytes": 57,
+     "sha256": "dc67fb2f31bd717353b8138f02bdc8ef2d70ace433c9fd91e3adc909fda513a3"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 70545,
+     "sha256": "71afab0009ee6fb10c63b3619e1d89646cb4370fefa06bd3b0110c9bbd7111af"
+    },
+    "progs/w_mini.mdl": {
+     "bytes": 78964,
+     "sha256": "e673bc817fc83265c46ecc37666abf7eef7ba0b772f06f0ddd02ba2e54c6eb5c"
+    },
+    "quake.rc": {
+     "bytes": 833,
+     "sha256": "3186cb2ca06cf32d96ddc76bcc37e11796ef2b1f04a4d3d682fc50e98a8e9d84"
+    }
+   },
    "sha256": "259de92c1ceb2fdee23664e38d65158b1172aa270d76f0368167a21723a6fe0c",
    "timestamp": "2024-05-11T23:49:58.000Z"
   },
   "pak3.pak": {
    "bytes": 248860,
+   "files": {
+    "maps/tank3.bsp": {
+     "bytes": 97336,
+     "sha256": "9b5a3f9fa2a8fae929bb924579f1747e68c5c89218ba1e12453d65133a88e8a6"
+    },
+    "maps/tank4.bsp": {
+     "bytes": 75660,
+     "sha256": "35d4bcc5589102b111f4a8996f5021fcb0c4ed280505faee72f622f4117bd26b"
+    },
+    "maps/tank5.bsp": {
+     "bytes": 75660,
+     "sha256": "35d4bcc5589102b111f4a8996f5021fcb0c4ed280505faee72f622f4117bd26b"
+    }
+   },
    "sha256": "e97a9a14bd308cf0fc927b60b298b8bed2f7642e7b71210b50b2526227cea6ca",
    "timestamp": "2024-04-29T23:57:50.000Z"
   },

--- a/json/by-sha256/b1/b19b1e63b66a2961f6b59d97ebda8c45b851be0101db16b31939a9aec5bbb9a5.json
+++ b/json/by-sha256/b1/b19b1e63b66a2961f6b59d97ebda8c45b851be0101db16b31939a9aec5bbb9a5.json
@@ -7,11 +7,335 @@
  "files": {
   "monsters.zip": {
    "bytes": 12882,
+   "files": {
+    "BAZOOKA.TXT": {
+     "bytes": 4512,
+     "sha256": "ea6ec68b8465524d034f9fbb33919e75c22bbc177300f255d53cb1f87dabec9f",
+     "timestamp": "1996-11-26T15:38:38.000Z"
+    },
+    "BLARG.TXT": {
+     "bytes": 2917,
+     "sha256": "fb551d35661d8ca597df97b73c8cd35dedf8ad01d54d52a913af2244c229e798",
+     "timestamp": "1996-12-24T23:23:42.000Z"
+    },
+    "DRONE.TXT": {
+     "bytes": 3326,
+     "sha256": "3d584637ba86d4c5df2be4792ca5e2133cae703716a10de901625c3f240e8a3e",
+     "timestamp": "1996-12-24T22:33:36.000Z"
+    },
+    "SNAKEMAN.TXT": {
+     "bytes": 4744,
+     "sha256": "cc988702d85165b6f9cf05830cf8ebe39a907b140c723799813fa14638c2d7f2",
+     "timestamp": "1996-10-24T12:17:36.000Z"
+    },
+    "manga.txt": {
+     "bytes": 2019,
+     "sha256": "2e3c3b3e22ddcbb1ad804b6ae33144a4daee18ced4d8d17720e2412a4498ea2a",
+     "timestamp": "1996-11-03T23:57:58.000Z"
+    },
+    "raptor.txt": {
+     "bytes": 2225,
+     "sha256": "f5446bf7515326ce2fc705e904f8094e4e69fc3f19700461a681caaf31a017d7",
+     "timestamp": "1997-02-08T03:31:26.000Z"
+    },
+    "spider.txt": {
+     "bytes": 2615,
+     "sha256": "7a9b72c10b4d279d1fd349dbd6130e6088e96a0e5f22e7eb3177506955e57a7f",
+     "timestamp": "1996-10-09T05:52:48.000Z"
+    },
+    "wyvern93.txt": {
+     "bytes": 4032,
+     "sha256": "803cfa5fa3f4cd245dee990a2845c72b9299c920a5eba963c06dc0d6aaea145a",
+     "timestamp": "1996-11-25T01:39:50.000Z"
+    }
+   },
    "sha256": "f499c6af625a76b795f315863f828c49d351d8b42ec4ca71872ac422c2ce8fed",
    "timestamp": "1997-05-15T09:28:28.000Z"
   },
   "pak1.pak": {
    "bytes": 6228196,
+   "files": {
+    "maps/tef_io.bsp": {
+     "bytes": 1332956,
+     "sha256": "dec96d257dbf147a37275dcb450b8a3c0031760e987851c15f05ab34d59b5855"
+    },
+    "maps/tef_no.bsp": {
+     "bytes": 1137236,
+     "sha256": "6eb24f7b0c1df0fc4c59279c1a3e10378edbfa57ef893f6fca4d941961bac9b2"
+    },
+    "maps/tefsm1.bsp": {
+     "bytes": 548664,
+     "sha256": "6518646d1f9c59531e21ee1ec5a3d01e646d59825314f789af8ae4893698518b"
+    },
+    "progs.dat": {
+     "bytes": 765388,
+     "sha256": "d56004319e98727f23d1607c5301c78fbb478148c66dcb2b9fe6568980d523c1"
+    },
+    "progs/bazooka.mdl": {
+     "bytes": 143952,
+     "sha256": "fcee6fd34a295b108ac7adc3da70156b6bb6c4ee6aef4eb06e9f9394611e0376"
+    },
+    "progs/blarg.mdl": {
+     "bytes": 123740,
+     "sha256": "1eabc36dc559cfe8a0c1a712d3de429787df488bbeea133fbf4ffffe547716ba"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "c6461c3dcf90e4213f4eab64d89d20a27a22dd344100cded0576396a80636af9"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "718b8c2842877345426247148dd6ce1ebe7fecc13e969a0fa0ed6dbebc388099"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "0a386b6381824b01852910519490ac3f6e3309a96091820384ee6b9a5b452e7a"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "ebd3e614ca2afdead497209fcf79f304218f4cff2bd3bca7d3e3a6c542f63362"
+    },
+    "progs/fball.mdl": {
+     "bytes": 16072,
+     "sha256": "43a219fe3b25ed86f92904503b6bda8d9af33a7704eb0c8cf14303b050ce59ef"
+    },
+    "progs/h_babe.mdl": {
+     "bytes": 26804,
+     "sha256": "61b34a2d1599e86932f0e5c1db8ee0054f8e52f02716a7cf889b9b75ab7667b2"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "5f770e264c3854f89f3f9ffc67810ba0127629a66825337b695ba16898f5d6e9"
+    },
+    "progs/h_raptor.mdl": {
+     "bytes": 51290,
+     "sha256": "47889ba0fd80d5b67bccea1818bd043f9c77891fc6510c7f0081d8c5e3a69a33"
+    },
+    "progs/h_wyvern.mdl": {
+     "bytes": 40540,
+     "sha256": "4252231b58390c2caa83092f51f9698f156291f5e3b8ebbdf8611ac0f4dec719"
+    },
+    "progs/kikbull.mdl": {
+     "bytes": 116900,
+     "sha256": "562feae2b4cc03ea82dfe15f3b56123f1ac9886249158780f05c491d30b8cfcf"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "c85c8e627e9a3be2e9d3c15e3a571fb21117e8dc208fdf2fe23868ac0a6cacf5"
+    },
+    "progs/manga3.mdl": {
+     "bytes": 96256,
+     "sha256": "81bb691947f88dda5672ab1e1af689098d08a9b5bea9d31c38197db909fe3b76"
+    },
+    "progs/pulse.mdl": {
+     "bytes": 15988,
+     "sha256": "83ad42783fe9a5dd2e2085bb6dcb3e551db7fd7ac683326943e6c5423f8131e4"
+    },
+    "progs/raptor.mdl": {
+     "bytes": 331607,
+     "sha256": "700d67c4a95965453d8da6cdb45277d4af6053d0073f9dc602ca2979a3f909fd"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 132028,
+     "sha256": "bf1332c393639c6ef55b5b55e126f8d21c50226116dbc860e256dd3d5dad6a74"
+    },
+    "progs/spider.mdl": {
+     "bytes": 94492,
+     "sha256": "df40e58bdf6465e68e5ef33cbcb77c42cc99e50c9dd842c8c3906c2fd04bfc8f"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "744af1fafaacb751cf2e5ce4bb15a0fc1fb938ae519469de6f0dccfe9f320414"
+    },
+    "progs/wyvern.mdl": {
+     "bytes": 120940,
+     "sha256": "c6ccef4d1d27cec45c5de9b508b521440d52ecc9b4410cf5ff8641eaaab397b6"
+    },
+    "progs/wyvflame.mdl": {
+     "bytes": 64572,
+     "sha256": "a309cd446d9be5b7ab02fd0063566c71a305f9e36d0a6fddfba8bbe4c7aafd20"
+    },
+    "sound/bazooka/ahaia.wav": {
+     "bytes": 7748,
+     "sha256": "b9a2527347e2272a676390b3a6bce4cf623f233a11b27d932e340ed67e72823d"
+    },
+    "sound/bazooka/die.wav": {
+     "bytes": 9260,
+     "sha256": "0bae4e5baa31c64ba4fc94df64e0dca08c06a732baea03ae4167b75e00318e9b"
+    },
+    "sound/bazooka/dies1.wav": {
+     "bytes": 8856,
+     "sha256": "663fcd16df6c845fc318a6181b2eece0678f9f3980a90ea3d34f0592e61e6087"
+    },
+    "sound/bazooka/dies2.wav": {
+     "bytes": 9212,
+     "sha256": "93f2868e3bbda78b74970a8912e8bad6f50e130692c4ce066aacdb5d51811e48"
+    },
+    "sound/bazooka/dies3.wav": {
+     "bytes": 9752,
+     "sha256": "439d327515f423fe662a8930b6a1d07d693f43331996119e05d32efc5d44457c"
+    },
+    "sound/bazooka/grrr.wav": {
+     "bytes": 11356,
+     "sha256": "8c6609a6ea9d85f10cda8dd2aa2d0fb77f5e9690698cbafbc213eb5d4f2b6f5d"
+    },
+    "sound/bazooka/ooaa.wav": {
+     "bytes": 4872,
+     "sha256": "76d5ae6f0532eb1a43493330c90966be651e05ba9eed2a994a9afaf28c73de78"
+    },
+    "sound/bazooka/step1.wav": {
+     "bytes": 27042,
+     "sha256": "fc485f8365abf042f2abb94ba4a21f077f688419e252a50fe9cfba2f55fd280a"
+    },
+    "sound/bazooka/stepstop.wav": {
+     "bytes": 6102,
+     "sha256": "79ec338698b2f8bfde44e0b5e8e31ca3d34e140ca88a45eb81c7c72b7ca31134"
+    },
+    "sound/bazooka/when.wav": {
+     "bytes": 23194,
+     "sha256": "af1c2534c69cfb3f07e160cd39f66fcfbe9d64580cb9fcfc43520637c6931532"
+    },
+    "sound/bazooka/yeow.wav": {
+     "bytes": 6474,
+     "sha256": "776a81059bc7fd0f8c998f5e8e05837686d1578c8860aad77901665c31370caf"
+    },
+    "sound/blarg/bidle.wav": {
+     "bytes": 25832,
+     "sha256": "2f57c1c5ce363e090853eff5622131a1f978dbc62aa5998472ef9cedb041c4f5"
+    },
+    "sound/blarg/bidle2.wav": {
+     "bytes": 23488,
+     "sha256": "958724313246d20cad51194f35d539927556b3c7917f983d5344b8886bafb759"
+    },
+    "sound/blarg/bjump.wav": {
+     "bytes": 23646,
+     "sha256": "3b2c6d6e536a756323fd056083eb0093a3330bbf4c829e0354f401a9074f22fb"
+    },
+    "sound/blarg/bjump2.wav": {
+     "bytes": 6908,
+     "sha256": "1c6406eff6b00c029baa2b8d5a1c84a13bc21f47be0a84e80d852c4c7d10df4c"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15692,
+     "sha256": "72e737f04f1d34044dfd812c6b0e233cd38a91e6b089633e312678756952de87"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16625,
+     "sha256": "bd4cd7902712282ef8f2f749e6fcf805c2ac5212994fbb1c22fc0fe0ea5d08e2"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15527,
+     "sha256": "0b472a984137667f4788336a4f7c60e07a8893f47317b2a158aeea39920d729f"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4107,
+     "sha256": "8fe56b192838dafdf7ff4737cf1e5555d3295cbca49c1ab83568281ee188153c"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8122,
+     "sha256": "3ea23b8d7a68e754211a10a5338b0c8d65df6e2138d4cfe06cc053b9a0f601ae"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13081,
+     "sha256": "a5ec6d4eaa707ad0246b7a7e7737b1007043ea5e5634f6f63661ecc20c27c459"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48508,
+     "sha256": "b7aac875623f8dca7597eff3dcab5910453d043fd1f9df20da89232ce8bf9306"
+    },
+    "sound/died.wav": {
+     "bytes": 24492,
+     "sha256": "3ce14cdac970a150f567dbd07cf1763f695245c34f5bf4e31ec07bfeb232db30"
+    },
+    "sound/ha.wav": {
+     "bytes": 2708,
+     "sha256": "ba2108ad5070860873887308293efd3a9635a6c4dcb3fb39357a9e16f89f97b5"
+    },
+    "sound/hiyaa.wav": {
+     "bytes": 36876,
+     "sha256": "1446e8afbfdf48a08ca6727604b33585efdd67a6d14b4b1c96bb05c6ccd5ac3a"
+    },
+    "sound/kungfu.wav": {
+     "bytes": 29008,
+     "sha256": "025b6eed19d193bd6be4c4f8f2bc7b9fb14e5c127257e570fd9fc98fd464f2a3"
+    },
+    "sound/ohdju.wav": {
+     "bytes": 12588,
+     "sha256": "346d38c12edad612ec4915d3361ebfbb81b06bee9cdb73eb9b9e0d2cc2ea6d10"
+    },
+    "sound/raptor/ddeath.wav": {
+     "bytes": 24916,
+     "sha256": "d051c976822a8a7bfb3613d5e67aeaa514ac9baa7a460047b49a7b95a5f3a006"
+    },
+    "sound/raptor/djump.wav": {
+     "bytes": 22202,
+     "sha256": "e4c0d9a121f35afaf68f2607b4df2b4f8de606805e3b67e825f6d09960215ee1"
+    },
+    "sound/raptor/dpain1.wav": {
+     "bytes": 7630,
+     "sha256": "3e4c4a133fd5387f75f554b36ad6a93887305157a903a70fddede0ed4b72d51c"
+    },
+    "sound/raptor/idle1.wav": {
+     "bytes": 11174,
+     "sha256": "a09e00aef702e4d538da805bb39d35f11c2fcd058f89a0bb453a57daad45310c"
+    },
+    "sound/raptor/sight2.wav": {
+     "bytes": 38642,
+     "sha256": "7f6fd555f897cef6cdc53dd5a60af74af5b3dba315f86903d4814773934f0b19"
+    },
+    "sound/tchak.wav": {
+     "bytes": 10166,
+     "sha256": "f77d88ab76f7a092a7a5d40fb0aaf9530dc6da8e45559fcf1a1b5ea2aa88029b"
+    },
+    "sound/wyvern/death.wav": {
+     "bytes": 10996,
+     "sha256": "7f06513eb69a2d9833c49bfcf79c3cbc3f3735b31eeefa74231196bfb6b4babe"
+    },
+    "sound/wyvern/fire.wav": {
+     "bytes": 6506,
+     "sha256": "b92b80c187a996e4915baa2d54089d3c42d10e7ed9d5693aee60fb74edaba7a6"
+    },
+    "sound/wyvern/flapdown.wav": {
+     "bytes": 7760,
+     "sha256": "74ecee2aa45752a9987a61f830c90d6ad9d4e0fb43fe3b2bddebd1b13a0ecf26"
+    },
+    "sound/wyvern/flapup.wav": {
+     "bytes": 7756,
+     "sha256": "5f1da797afc4bec37343338d58078ce2c091c7651f23555671ac8b4d672719af"
+    },
+    "sound/wyvern/growl1.wav": {
+     "bytes": 16710,
+     "sha256": "f887cd1264c6748d150f3bf37f22cf2c68ee8ac9aca37f2475216eb7c0d81ba6"
+    },
+    "sound/wyvern/growl2.wav": {
+     "bytes": 12008,
+     "sha256": "a6f30e3f4fa7f343831a72853eb2955ae0b56dac5839b40d45a54417000c920a"
+    },
+    "sound/wyvern/growl3.wav": {
+     "bytes": 19770,
+     "sha256": "aa290426d0a97b5efea04c3797db6a557d3dd5306ca1f8d8f7c91267099b96c3"
+    },
+    "sound/wyvern/pain.wav": {
+     "bytes": 6230,
+     "sha256": "160e6d81f3f049abf9e713a1834be94d3b20265ba8ec39d92a1207c0333dca76"
+    },
+    "sound/wyvern/sight.wav": {
+     "bytes": 10966,
+     "sha256": "d254690739a2170c90106bf8c7e6be419bb31e35bcceb593d69b09eb1353cf40"
+    },
+    "sound/wyvern/sting.wav": {
+     "bytes": 14652,
+     "sha256": "9d57e90109287340a541e02bf4df9d2e583697c5ec79f4c1755d558fd4151385"
+    }
+   },
    "sha256": "20c79f4276a8a98fbe540df505843ecacba94639fc7ff95923cfe84379bf45c9",
    "timestamp": "1997-07-01T10:38:26.000Z"
   },

--- a/json/by-sha256/b2/b2d7f5da7fc460261c12f9a3456a108678cc7a3a9d2fc576e9f99c525ec1f848.json
+++ b/json/by-sha256/b2/b2d7f5da7fc460261c12f9a3456a108678cc7a3a9d2fc576e9f99c525ec1f848.json
@@ -47,6 +47,464 @@
   },
   "TheMyths/pak0.pak": {
    "bytes": 13207054,
+   "files": {
+    "Quake.rc": {
+     "bytes": 585,
+     "sha256": "cb9be9ff0dc9cc0931c8d03e0793487dbd1e66a9fe744e5ee7d6c2828940fb94"
+    },
+    "default.cfg": {
+     "bytes": 2153,
+     "sha256": "8258bb749adbf73bb3bb9edb2b6abe426f624648515571ea576f9bba02586e6d"
+    },
+    "end2.bin": {
+     "bytes": 4000,
+     "sha256": "36d8f77b625ad89baa726960a3bcbc660bea388d0ad883b6b4cce82a05493e43"
+    },
+    "gfx.wad": {
+     "bytes": 126244,
+     "sha256": "ba1811634fe30a143a00e38f7c7cf737121d625349d3e5540eae75d92d314a42"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92df84df7c81d1741cfcd5e42ac894319dda5616827b73918038976dbebb0c84"
+    },
+    "maps/myth1.bsp": {
+     "bytes": 1468332,
+     "sha256": "055890723b8fa1b7d704adc1f19a68cf4b9f27ee7aa07c266b03a7837489609c"
+    },
+    "maps/myth2.bsp": {
+     "bytes": 1632320,
+     "sha256": "32ea598df9b9954957fb62d12ac64b74d7f37ca15db5e22635705253b774ed15"
+    },
+    "maps/myth3.bsp": {
+     "bytes": 3220308,
+     "sha256": "e5555f868117c438b28ced3aa89e2acda2fa28bff149db20cea9c15cd3e10a63"
+    },
+    "maps/myth4.bsp": {
+     "bytes": 1481648,
+     "sha256": "e5ccb5bc7c10df3c98d52784f520256661efec994a1fda340482802212abc9e0"
+    },
+    "maps/myth5.bsp": {
+     "bytes": 1045264,
+     "sha256": "c1524dafc1b02ada42206f4e0ec25ddf25d28a865739ff08cc851d8e880b5023"
+    },
+    "maps/myth6.bsp": {
+     "bytes": 880136,
+     "sha256": "26b0db6404dc76772516a429f33792f68bbc4c71c390c77b225bb230c434b7fe"
+    },
+    "progs.dat": {
+     "bytes": 748448,
+     "sha256": "bb35503575871efaa6a1097b66e18472c5b423760abca8cdb17ef2e139a1353d"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 60583,
+     "sha256": "c0031bff165881be1d0c26be434f4b1eeecc3e3c56c9b9fcf75b84b8da2c8ce5"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shell.mdl": {
+     "bytes": 2644,
+     "sha256": "6bbdfb9ef33cc0b5d3a9f304b72e6125902eb177c0cd177ede9a95a01faad567"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/t_drag.mdl": {
+     "bytes": 12736,
+     "sha256": "daa3fb42ac8bca1ea5d46b1be4422b895715021d9efd6e53420f154e864cbf7e"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/w_drag.mdl": {
+     "bytes": 36636,
+     "sha256": "785216ead72dc301b2e6c09b91ff3a399f58400d08523d4078cd47190ce74315"
+    },
+    "progs/wetsuit.mdl": {
+     "bytes": 55156,
+     "sha256": "4e4dc7331c374d2345c3d755ff34b61850c289741314b10fa36c461db3844e99"
+    },
+    "sound/ambient/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambient/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambient/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambient/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambient/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/doors/techopen.wav": {
+     "bytes": 14752,
+     "sha256": "3b82abdc7d218cd891d6e89f96756bd0a54884859e8ff1267075fb0f1c49d4e8"
+    },
+    "sound/dragon/attack.wav": {
+     "bytes": 4920,
+     "sha256": "6a5697e1dd9eca555bfda713101cdda800065e201f00ca333796f1bd4e7217ae"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 16944,
+     "sha256": "0fe255bd36c64acf75a53b97851b995517e70468b3818ff0ccecc4c7be5fc055"
+    },
+    "sound/dragon/hit.wav": {
+     "bytes": 4566,
+     "sha256": "b36e7581fe973d854b6f59947c5fe30b7118c94e7973f93b54a0c17423ce3fdc"
+    },
+    "sound/dragon/idlefly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 13848,
+     "sha256": "e71858c4de3e9ddcad1cba4ec0a6f5ec437b06c813b263ec73f853846d15a984"
+    },
+    "sound/dragon/sight.wav": {
+     "bytes": 21760,
+     "sha256": "fc36ea92a398c0c001010e5122d2574f1f42d9a2a5c77c58161c1f7134c105b2"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    }
+   },
    "sha256": "50893e74191c948884186b182c5889935232ab386de834565271b775b8f14a35",
    "timestamp": "2006-08-10T23:59:44.000Z"
   },

--- a/json/by-sha256/b3/b31b6b6d59c60e2c83d52d8c861d3dfac64f3fdc4dcd906cca47402e8bc26474.json
+++ b/json/by-sha256/b3/b31b6b6d59c60e2c83d52d8c861d3dfac64f3fdc4dcd906cca47402e8bc26474.json
@@ -712,11 +712,1063 @@
   },
   "sm220/pak0.pak": {
    "bytes": 4227276,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "591744734a43a1563ee0e419fb2464783c70a3245c14e09ff5c3f022418f1e4c"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "1bbe11eff4ef46f43af7bbc7be43c69cf76543ce7fae26931939a541cb8cdae6"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "fc226280c4948249790f00f97dd9b39e912131fc904ec75adb90308ba8763afc"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "9eee444c1db402805bcff09378344c5a048b6c23ff6054edbfff16dd60b76f0d",
    "timestamp": "2021-08-25T16:58:24.000Z"
   },
   "sm220/pak1.pak": {
    "bytes": 12537174,
+   "files": {
+    "SM220   Menu Artwork   ptoing/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "SM220   Prototype TC   Kebby_/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "VANILLA AND COPPER COMBINED/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "534c925c8af3aa1d5ff3db1431d405c23c0f9da834ef21716dd216466057ba47"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "fdd1489559a745f0bab6fa797e3cba1af6242d5c181dae78a7c3ed50d84a5e07"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "5b4a27c40aa506d0d7c8f07cb87fbc9046730dd481cb7c1370c5b0291328dac5"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "1964d06e719f8f4d4ec53a1fbc4d81d06a5674edfb02410f932e8e846b08e79b"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "0c994c39b18f5400f0de6ac2c8c219bae63c541e61db63b51b6082f2bd13849a"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "3d4367f1a224016ecdffd6f5bbe99094f23a454eeb5e6e30bb987f00b0c705ed"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "c78708ba276f233296829e0c3d30da3d87140a0572c246009b56574de17925b3"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "872f0c8c3c4aeb2179e196765c8f528ba387a5ee8ea2fe28866a64cc740ad444"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "becf427327bbd99a8f54ad1a7f890f0e0990602463b1c6ad0267b1bf03effc2a"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "ab228bc7c5f311e586c21732cc4b748722bcef2622b188d043a9f5d8a6715e07"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "ccc4d3bff22aeb8a735a41c8d1d2113d33ff620f77bdf232e5fe5d4586e519c4"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "816175ae99d2c0bb2b03ee0493cb0aeb412fcb7eb9041332fc5d85155718f6f3"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "665533711afacd6a332470ddfb8d18a65b4490a1f47922d912623bb4e0446799"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "ce299c9232238e095d7e3dd74422c212d07ee2b5dbcb0161029a03b595f3716d"
+    },
+    "gfx/dim_drct.lmp": {
+     "bytes": 3352,
+     "sha256": "2a37b7160096585ef6921dc77f2d14a9213fe228dc56c44e07f53de436dcc4a5"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "acdb656c8cea4ba19e1d30c045f1fbee4acf5a308320722ba90fc19fd39e797a"
+    },
+    "gfx/dim_modm.lmp": {
+     "bytes": 3352,
+     "sha256": "6e57c25ab93991cf6a44958f2d74c8a365c0334f5983660dc91869de64277c52"
+    },
+    "gfx/dim_mult.lmp": {
+     "bytes": 3352,
+     "sha256": "6096108541c71b61a649e99fc8911c526fc9864f69c54fd8ca12c85c958d0794"
+    },
+    "gfx/dim_tcp.lmp": {
+     "bytes": 3352,
+     "sha256": "e54ae21204c0be5f5d7d51cc06eaff7ae801fb35d9cf7ed513e42f858d3eec9f"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8ee6682665b636deb895cc6505cc64d865b55978149e9c89a3e97bff563d8d6c"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "2b59a46cf9690ce9010e9fd955276bf30b6bbbcfeb49ced1d66302045a5dc333"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "fd6ea43d1b34b6722a837b817541cf28a8b128d4ba3e75929c251bb0b0921517"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "2da4cc3505d63fd4776ad0114042190908101bc298823b07c93188e88bf0c902"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "5b25e6a420a1c49ab03ba0f1920c12198d040c7640338f2e9da65864d820ed21"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "0e958ecee176d1e99ff4bfe540c266c442a04465e290cf7cab34d715a7b1101e"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "f44086000a25c5add18454e53e5e25252685f3891c9bd7df7d6cf53bc79d759d"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "a63dacf7e61ce2c696a5615eb1178e37de2d84b11d379e2504e3b2d251aee118"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "0c94ef83996b148edc3363b303264fee74d75234611e22c67508e175b2ac57ed"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "67afe5e274724fa1c70a2f091367da097557cc07242611c639bd8089317a6969"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "e68eaf31382e58445859dc9e734f5da4effdc558c3b686e55cdd25f6a7c45ea1"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "21f54015a54a97124aec151ac4a9fdfdd1470a4fe4f21eecd8aa428eb6f1e33d"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "f023308221866e86e50caac6d2e679f4302af506569fdc3a57bcc3c447332eb8"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "d2f431c9f3a602cd816cff2fbae23749ad4c35ff351f9f8db5ee865d0c79d153"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "4d7c3a4073ef5798b134c662234d4e7d957428f6093b53162a5ded2d3dfc8b08"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "5f37ffb26fe1a8d9f71079ad32402f5c765ce5b12eb2d48dc7c7fcf7ede69e5c"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "d18a2c1fffd2fe6ac6d9efc9186059d271981d5c669a6ab9f7401248dd214aec"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "a727b614e7fd3cf10ba1b4f96b25ce59d6dee222adae73a408315600a250bd26"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "2794c06783d73cf170161bc0e43e0db806de367032585f26845eb4b8e4aadc32"
+    },
+    "gfx/netmen1.lmp": {
+     "bytes": 3352,
+     "sha256": "ce7bf598ad4716cb491d458ca7b0e3c4f5f9512205ed5c6fa58a3d20f2d8c6a8"
+    },
+    "gfx/netmen2.lmp": {
+     "bytes": 3352,
+     "sha256": "c39d33cae1ccb2ce6d7f65ba128fdbff970162fea9fe1354b770df8874b3e211"
+    },
+    "gfx/netmen3.lmp": {
+     "bytes": 3352,
+     "sha256": "e5bba6bca104ad8d7f0513de29275d5785588477f5749e72a5d174ca37856d5c"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "44399f889707bad2fc1764e7bbad47168aff29f659d05684f073d2e0fc7da275"
+    },
+    "gfx/netmen5.lmp": {
+     "bytes": 3352,
+     "sha256": "15bf2a2cdf1e19a67218acea133895e7e8aa99ff572bb0f5a03fea84d2721c76"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "c229e5a145167fc81436025cfcd0138c8b0a76938bc5ba47b4c398927b5ea97a"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "d51130c9da7b58e55b4aa3995d8bfea2977e36bec344e768ce1bc9bed951f948"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "b07c882733cd497a7a517f5ceffe27a6cbe89fac26896bd4adfb38fd7b871b4e"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "2dcb9d60f33bc744df9c5b78f191811172273191a953202f0fb1a5046b7c0942"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "f6255ef51fe85bf157a9cdba069ca6a635877b70183c530847e104cab82f8168"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "c639b8b4aed7313a5af8119daa50c232306beaf700adf454a4a1eeceb2cbfdb5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "9e6b455be67425220cef487a3523a94acfb82dc50fd3cad04f05dcf9ab86eb6a"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "2f6eb67baf39105b47bef784ba025d1ecc00ebd3d0ccda5d462edd296792008c"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "8bfeb2148223050a74257937efa5cb1e5a5c866448840e705dfbc18742b736b2"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "6d6e7cdbcc2c3470d3f983f9eebe0545e2ba581cc6304e67dc6e8309ce747a6b"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "813192091bbf1360171636258958c060f33f40f3c08863c0e8d8e07f96ca947b"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "875d3b5b594307161befe1ba9b467ce3edbb7e4206339d8626f588b831fa149f"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "400e53c32c04f05419ee91ca8431f5d35f5c11cd0014e97eff3ac1cf1c0e7772"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6240,
+     "sha256": "70243ff636fa63d4fa30828142ca77680fbe0e72e4ae5e5e9b7e02d7d9b6b083"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6240,
+     "sha256": "6186931ca0902824c38b43c1c121693a519fc631aa95df652fa0bc53a3016b88"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 3992,
+     "sha256": "4b8291a4e397046ed4f2a963e7f8d8e2ef41db88cc03798149f2494d719d6084"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 8940,
+     "sha256": "ad7caa76d94e44b654cd0dcb201118547b15205aee2f392cb6228a1f32313a8c"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 9032,
+     "sha256": "0df8cf4a101701308f5cd240b7c34588edee33732c35bc2bee204a0da858f426"
+    },
+    "maps/b_exbox2.bsp": {
+     "bytes": 4728,
+     "sha256": "2d05c923db40032c46d123d804958c44d0b4e1d2fc64755a6830a70036ea1465"
+    },
+    "maps/b_explob.bsp": {
+     "bytes": 10272,
+     "sha256": "fe6105c5379037bd46277f587de62786e3da4ff79eb5b658e234bc468677b0c4"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6240,
+     "sha256": "7672a237f0d2d0d105bb7706b97db5fd7cdff8e694dc8b55969102ad92bd4708"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6240,
+     "sha256": "96e3a94c1c2afc653a6a907bbdb9a3ad6f1529064e4971c5a05eb31eb8f1bcd5"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6160,
+     "sha256": "66805f88a6276dc191e08c83c342680070da8887124242111d0b5b66a03b9eec"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 6200,
+     "sha256": "80ffbf965d098f335977ebc6ca888239e67daa77f1e0cdfadbc4f518055dba9e"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6240,
+     "sha256": "86b69f934b76034e0dbbf0a3964f6479ad5ce3db8d1ca3086c3d4435306bf7a1"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6160,
+     "sha256": "d438a3a65f44b191b3208dde393f905486c65b1fa7016dd7900a0402c4e1dfbf"
+    },
+    "progs/armor.mdl": {
+     "bytes": 176444,
+     "sha256": "f9308bf41d12f09b6abf252c02cd4f85b1c5937e32ef072b3c13d0ba7a5afb35"
+    },
+    "progs/b_g_key.mdl": {
+     "bytes": 8733,
+     "sha256": "96e4690f8c7cac5ba27193501ff02bf06a461861c2d4ca581c35f7badb16e110"
+    },
+    "progs/b_s_key.mdl": {
+     "bytes": 8733,
+     "sha256": "104b4353d6b431ff7dc1255cf62aa859cb9aed395864150de6fa40723719eaa1"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 24496,
+     "sha256": "97efb3ba79059e1b3dc2b35f90e0b000d2f322dd5bebb6fce3a7ecb08d61a871"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 58644,
+     "sha256": "8c501b8fa22dd1d110292c098d7ad90ea1188f347d2930c5d3e36d730ce1217c"
+    },
+    "progs/bolt2.mdl": {
+     "bytes": 58644,
+     "sha256": "1c48af2233e67b0f93ec404b6feda091ef4a035f3db86ae933c1752f61f2f05d"
+    },
+    "progs/bolt3.mdl": {
+     "bytes": 58644,
+     "sha256": "508482019995baa9f7668a767cda2a1f5c529dfb3627369dfaec268f8d726b2f"
+    },
+    "progs/boss.mdl": {
+     "bytes": 396956,
+     "sha256": "a582359b3b5b269bcc3ffec6a020b54071df5e7fe765ea20ccf227f156e3364b"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 84825,
+     "sha256": "d420d0af47a221a46830ca7a2b7b416243746611f60edf52f1fd5110073237c1"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 84825,
+     "sha256": "e73ea260b701db0f3c9207a7fa8baf7da15ae1faa4cf1a0227ee8086d98e37ec"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 84825,
+     "sha256": "d5aca0f85d593450a55a64d4b6a28be46cf44ca2dc16337293001edc341ac01c"
+    },
+    "progs/demon.mdl": {
+     "bytes": 181220,
+     "sha256": "20cddd47239db6d54004bc271953e836663d110e58e7267c1e4f20906a5fdb3d"
+    },
+    "progs/dog.mdl": {
+     "bytes": 243844,
+     "sha256": "c006582533ad2244d10bfc70fe5a515eb3ab1cbbfecc886951a91fa683c6b40c"
+    },
+    "progs/end1.mdl": {
+     "bytes": 60436,
+     "sha256": "936ba0249acf1f62a34532b814b230d47489c7551b8d0eb35fb599ae5d82a318"
+    },
+    "progs/end2.mdl": {
+     "bytes": 61076,
+     "sha256": "94056137cea29311182bb13435fe46c52e5ecdbd66236fd348121d4074531538"
+    },
+    "progs/end3.mdl": {
+     "bytes": 61172,
+     "sha256": "3002a0f36af64a01d9792c528a2cd0fbfa6aedb3f52f085ee175ca23159ea7f6"
+    },
+    "progs/end4.mdl": {
+     "bytes": 61428,
+     "sha256": "09c33a01ba3643acd2ebd8039a9bd7de83db8ac7bcc1584c8376b6689b19a0f8"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 350408,
+     "sha256": "080a5b15c34e323f43f6ef6f7080c36449e4d75d19c5a4ab16256b803b2b83f3"
+    },
+    "progs/eyes.mdl": {
+     "bytes": 58484,
+     "sha256": "36068d4f83cbc6a2f2095f422fe2444eff91ba5aadf8d1c63aa7ebea3cc00f3d"
+    },
+    "progs/fish.mdl": {
+     "bytes": 111140,
+     "sha256": "5c3680bb761502b28c4b6071b500fe541ca01a74540d4d281ef3ee0429ca7a82"
+    },
+    "progs/flame.mdl": {
+     "bytes": 136808,
+     "sha256": "1b49f1864f7e28161f6f16d2e0b0fae1f6ee6d0c50c1d4f55bce1aefa3909bab"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 176293,
+     "sha256": "3ffc02b1dc7a0ae17db7e8d26eea5c23c816352b26ae9e641899eb449978372f"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 65620,
+     "sha256": "9dabe194a5df8657287ef9d0e6dadbda4d4a14c6a33b670ee89ce5f87ffb06e4"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 65460,
+     "sha256": "c09b98f73856db309dffb656f7c052ae1ca7ef02ee96711d04806b5071693246"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 65892,
+     "sha256": "83886a628d597b9caf02d5d8baa4dfb5e3c4e61c8331fe023db2d2a09d2a66d6"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 63364,
+     "sha256": "8d501b5fa564463f1b32562555b1449a7d9770a83bd5a8a045cd967400594e17"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 63908,
+     "sha256": "f75cbfbfff108b6115902dd4a87361d0875d5bfda068203af165d28d10c36823"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 60692,
+     "sha256": "68eeb05fac14801e04574e309899e568c43206e3686fcfa56f26252e028730d2"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 61380,
+     "sha256": "c3a641677f15aefb14d15916e7f86fa1940653e4b91fa4964b4e0ff7b4fcee1e"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 58900,
+     "sha256": "ab0e9cafd610f110b0d6c7ad5120abb06a76b29cc671ed3bbf96ca2fb5ade2d7"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 60740,
+     "sha256": "d7a88421464cbfbbda770168b41699308fbc19a39cbc172d17e42e4f37386780"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 58404,
+     "sha256": "05c050586ba91153e6ed9953d3de4fd1d93be1673e65c020888aafc6725d49e0"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 58836,
+     "sha256": "3107fa4adcdaddfdd06fe453167b8b319f50347d1447346f90d75446674c916f"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 60916,
+     "sha256": "398af65b5611e3dd6f3af81f023cc1a89edf88d8906c61b08844d9329872383e"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 61364,
+     "sha256": "a010d0ca0c405e8b01fad03212c8c60183b54f6be37be50e5d8f580390d4473f"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 59268,
+     "sha256": "0a1390035357ce2f1f568c402582962aac8b58052a58e78557afc737546c0141"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 60948,
+     "sha256": "5864658e084daf18eb389dc15ff8c49a4fbb5f822d772a9bb89846d27f7b490f"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 232944,
+     "sha256": "3d8992ff8e68e8f55a5ca3d1e6904e89603a20437441ae0187ac61d443dd22f6"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 59908,
+     "sha256": "20ec9a717d7c104818c369c9f6a56ac4deeb160378fd8c550fbf584694446701"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 59060,
+     "sha256": "fcf5790d3bed57b926c2deb14f554a62d15db20f6490580b67c5c5e62356211b"
+    },
+    "progs/h_player.mdl": {
+     "bytes": 59348,
+     "sha256": "3dc5f22fe3247c999d385d7d2286f868c2e568bce7c7a256045ce38d9a2ecd96"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 62180,
+     "sha256": "b73f2e743903d3e4b938c3f35528a995721c8eae099e30ed1ad780709a539f26"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 59812,
+     "sha256": "69f18ab465ba11cbfc279914407231a1966694534c19a14f6a281bf4d8b65b3b"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 58996,
+     "sha256": "a1085a866c3b0101422b24b8c503a592ddf734d9483297d1a697c742463ae057"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 59588,
+     "sha256": "e524d57934167612a3785652709c926e69cdcf715616f372c829e7b58afa7232"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 510996,
+     "sha256": "0e009be5684b229494333d56c07ab01a4a1f0ca8e657d6127052f335f50372c1"
+    },
+    "progs/invis.mdl": {
+     "bytes": 63668,
+     "sha256": "25dfc1b223e713fc922c9b868f9182cc16c7d08c4426564f55cca895bfd1027c"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 60452,
+     "sha256": "ef8de45e7014ce04d08a400d02678a4d868ad98fdeaedc3fa9892f9fcbefd5b2"
+    },
+    "progs/invul.mdl": {
+     "bytes": 65716,
+     "sha256": "634bdb4aac11c4933288d24081283abb3230a0dd39599fcc2fbc9eee34fda2b5"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 62164,
+     "sha256": "886399b1a66a56818d1fbce5ad17f32ec9592c23f3445e099dc2c92d30d2a51a"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 59028,
+     "sha256": "39395b949e6de8f89add5e3b1b7a88de191f39c354fefba94b1c6ff237d08a3d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 2787095,
+     "sha256": "0691191a6dcee05d1d90b797d94f1694469981e19b05ebb5f0779d9a256b0596"
+    },
+    "progs/laser.mdl": {
+     "bytes": 58228,
+     "sha256": "9d147fe8799aea3ada61ce26023153c54c631b8e883c2e8616ae095a8abe43aa"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 120847,
+     "sha256": "618483102a020f34bc18d7a2711e08855c12c9575b664f169c326dd94d398730"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "1e47e2877998b44fad8a06289ec8c33d776ada855cf798ad230a6c2b1129f4d5"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "165a0748b64d3712ac16cc094da7f684f60305e0779b597fceb408fcc09ac6c9"
+    },
+    "progs/m_g_key.mdl": {
+     "bytes": 18797,
+     "sha256": "ab5e7665d31d7cdea8ff6d24894a4b30695aed3b47bfc6be0e3502d267dffe80"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 4852,
+     "sha256": "9e3aa7e43062e3128e0cdf264623572e2e7badc507338ca3874fea5371dce1fe"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 4212,
+     "sha256": "eaaaa17ad0a00e2a08600fb052d4bcb9f55fcc3fba211bbe155d6f5954cc813c"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 4212,
+     "sha256": "adeca6687e6599e84f57cfc866f434be708eb0dfe0d30cc299ddd4b0fd3e5a2f"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 32976,
+     "sha256": "ba688016f77145c791bd226eeab611a2e7dcb1999d4b6aa1b75a27acc0af06be"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "a45f4883a35e6823da74780edc1cb05f1984e5eb6832d45af377846dd7ab8379"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "9180c8e65386b481e0443817d5252c3f4d77f8858ae3aa500d29541782b25bf0"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3508,
+     "sha256": "a97df47e76709a8bdd2d1860fa7c0fd43d703f6686b994a194f6dd9b3a4c984b"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4852,
+     "sha256": "8b5329bbde23b29a6751bf6b4110c45f06893561531084cbdb077aa6e10d095f"
+    },
+    "progs/m_s_key.mdl": {
+     "bytes": 18797,
+     "sha256": "2fa7746b0494af6f5355a9ce34c5a5a4378f4251797e7ea786a0aae8cc03bb08"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "c0c2b4dd03b1ce61375d88fbc8bca742b2528e3cbf13d51903e116a540457584"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "014e7fa8b272b10f3149ba938efa3b86581f56bbe92ca487135a0fa815eb185d"
+    },
+    "progs/missile.mdl": {
+     "bytes": 60356,
+     "sha256": "e97834f825b0cdb7299f2c965649aa1ef9b54f65a9f3e6b55cfc422fd3c52d29"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 373020,
+     "sha256": "d20bd332b5a3a6605a4ddcde51cc5a95b0bea5833b9989d6e72d6834553d6693"
+    },
+    "progs/oldone.mdl": {
+     "bytes": 167804,
+     "sha256": "4bcf12aaac57d7a2c5d7f35cd7923cebc8bc8064d42cffa1e06a056f24981f02"
+    },
+    "progs/player.mdl": {
+     "bytes": 385332,
+     "sha256": "607242751c8f8db6dd9c8e5ca87cd531fc213a1fa83ee40d03d43ccceeacefd8"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 63732,
+     "sha256": "7a73f9d8fabae77e09829a2de35f24bcd051fdb6c8d037b18200e7a383e2838b"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 32464,
+     "sha256": "812eb0c29cb5ab10c9fd65a2a829f8c0dfde64c10f221380f92a13786e59552e"
+    },
+    "progs/s_bubble.spr": {
+     "bytes": 588,
+     "sha256": "a1ec8ee908f9df96edb9081f2da0876a71213a5a372e577c7147e09c4d1eab50"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 24732,
+     "sha256": "1b2dda05d14b1186571b20a37c4f81689d812035fb3b46f8b483fd3f21809ebe"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 24732,
+     "sha256": "cf680b97c93bbb1859fd40106607b3ba3fed2ad4406e63b23d66202224f98560"
+    },
+    "progs/s_light.mdl": {
+     "bytes": 60164,
+     "sha256": "3aa9e7ae327d9a7a86874361c4dffaed4ac708ec9310ba41ac1465fe5dacf9b2"
+    },
+    "progs/s_light.spr": {
+     "bytes": 1080,
+     "sha256": "8ebc91a4a20c34dbf4de7f23c683b6bac2eba437147c7a09d04215eb91589498"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 57972,
+     "sha256": "1e6ff42f6ad17198758a0c5dd783909cca4814d24202500ad69b96a08bec77d2"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 150412,
+     "sha256": "5aa37a406099cd53f39463d71c9c7433bba58434d767e9c6fd228a734e228be7"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 233256,
+     "sha256": "c1012e1709fab1131aec6d2b391d2cff9c94ac6dadc85010afe5b71f2e1f46de"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 270176,
+     "sha256": "83ee1d511edba62ed758566e74323070dccd5a577139647c773437ad1441332c"
+    },
+    "progs/spike.mdl": {
+     "bytes": 11180,
+     "sha256": "bb13821af43c6aea3d6d76303f4684c44a5f296e8cdfad0eb4335b4fdb3e9a7f"
+    },
+    "progs/suit.mdl": {
+     "bytes": 69828,
+     "sha256": "b5b000631bc6f512ddcf2d5744d2c77c386ef7786d868d3275e00ba171a6ba9c"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 136708,
+     "sha256": "e9f6e8374bdf8f14fb5dd71b1a1c65b4ac62a06a4e88f5eebbd59277588e12ad"
+    },
+    "progs/teleport.mdl": {
+     "bytes": 62180,
+     "sha256": "1b59d70e74776b672531b12c1873c810a06c11d5d174fa532d31607a2a38ed73"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 69908,
+     "sha256": "4a3b5f64763321319788bec1fec45808ea771aad0bf3cff04882c09150d2e93f"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 113692,
+     "sha256": "c7f93b14929d7efdea9cfb4742b4a0a9301e06f820d2fc2b8f708bb61a63f905"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 66916,
+     "sha256": "0b67a151fdc68a2a0f4a04ef6672bc34ec7d96fbcca29b09ee35353050dcb19e"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 71012,
+     "sha256": "6ec2e11f711af639f7016ed9eca9f8ab9b5ce95cba817d8de5d337b41021ae59"
+    },
+    "progs/v_nail2.mdl": {
+     "bytes": 71204,
+     "sha256": "0bd0e38bac0307661eafcf73855d548bb00b0a30b65e8781d5b2946b03595c10"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 60868,
+     "sha256": "d7e2e8ccec479995d636913996edbd0ea811d635be320dd6c7beeac15b925484"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 66428,
+     "sha256": "eed4de6642c474a1c038f51fd8e130f89a573697c44a48c5aa8cc739bd7c6b77"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 65972,
+     "sha256": "18d2eb0d3dc1e458daec373475557bce871395d2a9920f4a8d70eaf1bde646ef"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 66276,
+     "sha256": "b922954f67c7bc3f63be0b3edd0afd9b4ff199bc8cf430ea030513a667e6ecbc"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 61220,
+     "sha256": "a50d0830a7161cb7aeaf0d41a5899591fc140acdefb4a5d7a8aa2772454a45ff"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 16781,
+     "sha256": "2d87c67e4ef71cb6dc694d5c98234c1258d958753823ecb82d00b95efe29dd46"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 42051,
+     "sha256": "5c9595e77fd442a9e30b34e428e069852468dbbe43914a199a122da224e5b36a"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 62988,
+     "sha256": "231e6e1e3af512934c13c10d2df46ef037d2b215dcd620600d978985b12b4a9b"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 122116,
+     "sha256": "32bf13e8d491f99bc0e3d5a3155753ad88b0d3bdba76f8e10f3304c5aca16fdc"
+    },
+    "progs/zom_gib.mdl": {
+     "bytes": 58356,
+     "sha256": "2dfcafb542dbb7d802f324e41d506d4318abb50eaf4bb3ed2e594de86cef1f22"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 402428,
+     "sha256": "988d8d764a5e16e96c4e6dc6bdfb907146f55f5510c9a5ae6db0a07b6bde6d15"
+    }
+   },
    "sha256": "cc24a7e6170ce6d88b19aed3a991dda08439e3b6d79460052d18a2a125bf8cba",
    "timestamp": "2022-08-31T21:51:18.000Z"
   },

--- a/json/by-sha256/b3/b34226b81be95bffaae3c219988ca209c76e23d1d070d559b32985ad60cda4c9.json
+++ b/json/by-sha256/b3/b34226b81be95bffaae3c219988ca209c76e23d1d070d559b32985ad60cda4c9.json
@@ -7,6 +7,788 @@
  "files": {
   "Pak0.pak": {
    "bytes": 20687895,
+   "files": {
+    "gfx/env/dragonmarch_bk.tga": {
+     "bytes": 713872,
+     "sha256": "d76065d522d718ed405ca152eb59f5ef9b5c050134a785f500124ecb0181569e"
+    },
+    "gfx/env/dragonmarch_dn.tga": {
+     "bytes": 785870,
+     "sha256": "afa2b880d35793453e6e59c29a47fae3759cf7665c7de0a764da8a0675227723"
+    },
+    "gfx/env/dragonmarch_ft.tga": {
+     "bytes": 628373,
+     "sha256": "4d639ffa187701b7d0d3478e3f673fbe9d765dd8a2b1d38aec46f9f53edcec16"
+    },
+    "gfx/env/dragonmarch_lf.tga": {
+     "bytes": 629950,
+     "sha256": "0bae63fe4c2e0e0f76ee251a27a271e4d34f4a57cb6bb5516f42bf5ca9e79def"
+    },
+    "gfx/env/dragonmarch_rt.tga": {
+     "bytes": 665194,
+     "sha256": "df384c5c2d1191016923918f4fe77a1c084e9674173fe4eaeea6930e10702bd0"
+    },
+    "gfx/env/dragonmarch_up.tga": {
+     "bytes": 316226,
+     "sha256": "b85c6967cdb97581e1fd7541aff84a68e95a5314a6479644941903269b4d3ae7"
+    },
+    "gfx/env/thumbs.db": {
+     "bytes": 14848,
+     "sha256": "1175cc1de95570132333c9a5182bd880e31c1ea3949fd929599fc6f42e469e07"
+    },
+    "gfx/palette.lmp": {
+     "bytes": 768,
+     "sha256": "dd8e71ab28a5b43b8a01d1a91bf1fadf21614cf3e829016a564e879d3fb379e0"
+    },
+    "maps/bod.bsp": {
+     "bytes": 8672652,
+     "sha256": "d5872d90357bbbc1169c029f6f98918dc72bb1e6a67d5ba6de8324883864f83a"
+    },
+    "progs.dat": {
+     "bytes": 711580,
+     "sha256": "81e0dda14283c443cafb420ef2d247d9c712dfa9072f8b6fe124b8cb5d97f42e"
+    },
+    "progs/bellring.mdl": {
+     "bytes": 74016,
+     "sha256": "0d1b0e150de4ac59c599deae96d6b21e4ceb2300e7d410a1d802385dad99560b"
+    },
+    "progs/flag10fps.mdl": {
+     "bytes": 16052,
+     "sha256": "f2670312a8d16dd16e42fd02a39dfd285e6ffea624e729597b773c86140631d1"
+    },
+    "progs/flak.mdl": {
+     "bytes": 1684,
+     "sha256": "5ef83ea57cc9922dacdf8720e56451a9b121346669ff5ec5bf99b7290da6b8b0"
+    },
+    "progs/flamebig.mdl": {
+     "bytes": 85180,
+     "sha256": "9df2ae13e72ffe5a305a6ce877b0284023520d5d34df751498a2003c3e420ebc"
+    },
+    "progs/flamecan.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/flameltn.mdl": {
+     "bytes": 27960,
+     "sha256": "5877b37cc4f98a53467c412e7d06d1f7ec6b60f5c0f2088514aa51c9d2c51769"
+    },
+    "progs/gauroch.mdl": {
+     "bytes": 669648,
+     "sha256": "352403dfe4d7665fddacacbc12fce6b1cac81097cbc733bca59785e6ba0bac4c"
+    },
+    "progs/h_imp.mdl": {
+     "bytes": 15892,
+     "sha256": "ecf5c25157468f7fa9aed625e12401e14cd5aea76ece8cac83c09e7863efdbe1"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/imp.mdl": {
+     "bytes": 331084,
+     "sha256": "bb8dba578896471f42313bf0bbb532b14f5541c0abbfdf9e60254de95d4b3768"
+    },
+    "progs/knight.mdl": {
+     "bytes": 101404,
+     "sha256": "7f8e8b9d441955aec4e771628292b140c0ceee9f3d6f4936a28f94c4b04270b2"
+    },
+    "progs/metlchk1.mdl": {
+     "bytes": 2388,
+     "sha256": "107d02bd9b8e89e7ed03b7a15471643d615102769afb9856730cb700080b7ab7"
+    },
+    "progs/metlchk2.mdl": {
+     "bytes": 3356,
+     "sha256": "0017c82d98823d6099fd7dd1eeb22a67c49310612dc68aa74f987fc021e610a1"
+    },
+    "progs/metlchk3.mdl": {
+     "bytes": 2964,
+     "sha256": "1b2d7647dec07291d2bacb23bdb9400e14051bd2f0e4ed4b57abd1ecb8f220f0"
+    },
+    "progs/metlchk4.mdl": {
+     "bytes": 2980,
+     "sha256": "e8b121caaf095191282331c3f21485e0402b1c7c15670b6cdabbe954f24514e7"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "2bd7b6633d2c95627cca8b216ad2c84057e800778a94e0fa97f3a14f86420732"
+    },
+    "progs/q2gib1.mdl": {
+     "bytes": 8148,
+     "sha256": "1a17417bf310d3069d84123171b258c7ea237ed00c69f02bd5e26c1e5d913d70"
+    },
+    "progs/q2gib3.mdl": {
+     "bytes": 10836,
+     "sha256": "3ae4ca501e6e3042af69bf1c0b5f537849be23e294b060dce17d23f32c30876d"
+    },
+    "progs/q2gib4.mdl": {
+     "bytes": 4188,
+     "sha256": "014d3e1cf4cf1ef1131247c05d95545a9debde4cf38e40fbf70564cc3bdb230b"
+    },
+    "progs/schunk1.mdl": {
+     "bytes": 3392,
+     "sha256": "eecbb635587336bd38f849cd461ec72b282840b8eb3d9551f1c8d87eb284a5a9"
+    },
+    "progs/schunk2.mdl": {
+     "bytes": 3872,
+     "sha256": "55030f999eea0a4b0d0d751e51af28224e1159bb7b05a9ffb90b7a488e9b6b41"
+    },
+    "progs/schunk3.mdl": {
+     "bytes": 3392,
+     "sha256": "76b80dfd7ab8878207b4aac70001f3f720620e0a78ec6249022f333dabee4f3b"
+    },
+    "progs/schunk4.mdl": {
+     "bytes": 3624,
+     "sha256": "1fe18332fb3e4d6330b3bb77bb669dbb9f7b07527c3bbc72e53ab34a096ae36b"
+    },
+    "progs/spider.mdl": {
+     "bytes": 180748,
+     "sha256": "7e8068c8f34d1d1b92f4ca13f237eff560149e4f56e5ae06d4ef7b758fe30444"
+    },
+    "progs/tree.mdl": {
+     "bytes": 61692,
+     "sha256": "f585cc2684a6f031499f5597c9477233d55a4ec2babf642a46dc1f8c6c02f301"
+    },
+    "progs/wood1.mdl": {
+     "bytes": 4461,
+     "sha256": "16bf20036f822962f481368276369ce830177a64ae71c143e218b1f7d919a517"
+    },
+    "progs/wood2.mdl": {
+     "bytes": 2847,
+     "sha256": "a7bef80af5e2ae1af04ae1a7654fca867b89044cb0008c6934991d923a2b4716"
+    },
+    "progs/wood3.mdl": {
+     "bytes": 3617,
+     "sha256": "cd6cad2482192c31552bcfdd0d4ccaea0a126de8e25f8c4b3971977f602394e5"
+    },
+    "progs/wood4.mdl": {
+     "bytes": 4463,
+     "sha256": "9823233c41b58c8d6380e83c0eac5e31ccc2fec9efdf6868b78cebd293cdec39"
+    },
+    "sound/1shot/goatmare.wav": {
+     "bytes": 713482,
+     "sha256": "be38427732d0b8219d4957d8ffbd03d634a919ad04a786ea2ebdc94846e2e02a"
+    },
+    "sound/1shot/squitch1.wav": {
+     "bytes": 80556,
+     "sha256": "e3418629fb987828e919bae2558139b280f71e5e24d77e5ee05ed5a1d6793bda"
+    },
+    "sound/1shot/squitch2.wav": {
+     "bytes": 80528,
+     "sha256": "93968c23a050255b87daf15425d3812cf9d9894270fbba7f85457f3a3eb6904b"
+    },
+    "sound/ambience/cave1.wav": {
+     "bytes": 58476,
+     "sha256": "0759ad526d301c3bb14c467818bacdbe3a64237657c45a435e06cb166b570b85"
+    },
+    "sound/ambience/cave2.wav": {
+     "bytes": 63706,
+     "sha256": "c9c25ee33f9eb396fd9c553cb4da9eebf05f83367f95387c8c3ee21a5ab2d9e5"
+    },
+    "sound/ambience/fburn_bg.wav": {
+     "bytes": 22758,
+     "sha256": "c2159ed015cf92024dd06efb5fd583004e7641205be9fc8e037bb61caea209d8"
+    },
+    "sound/ambience/gurgle.wav": {
+     "bytes": 44252,
+     "sha256": "79e421db998007f05aa30e42f2f7b021303431f9bd42d89cb7bf9807c03b19fc"
+    },
+    "sound/ambience/subaqua.wav": {
+     "bytes": 62902,
+     "sha256": "ee3cc0c0a40642ce9ce22caaaeed6c5bbdd63cf3be461eb430a0e2a46e65f443"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 32212,
+     "sha256": "005616904ebfec049860ca33b790903e76c75615f3048dba17ce8d85cd6c65f5"
+    },
+    "sound/ambience/wind3.wav": {
+     "bytes": 47692,
+     "sha256": "b2fab4abc53a105484a21e9f9442076805dc0cf806d07ab7dcfad3e0f3ddcf2f"
+    },
+    "sound/bdwsound/basss.wav": {
+     "bytes": 302444,
+     "sha256": "75682a08b790af46c2b9f746e5772999ba1de333b567832f4a3a8414c6a0185a"
+    },
+    "sound/bdwsound/demiwind.wav": {
+     "bytes": 357636,
+     "sha256": "2744eaae8e03367a28a1bdc56f68494eb4cfa325c794d159eff56a2295e12912"
+    },
+    "sound/bdwsound/windmill.wav": {
+     "bytes": 40682,
+     "sha256": "f323d5e1e9bab0ebf7a7c3ace51f3721b954bfbf7a6c86e9b9df6c3b271bf6c6"
+    },
+    "sound/debris/metal1.wav": {
+     "bytes": 6672,
+     "sha256": "92eff1af875d0bb0538101956b6de55680ecc4e9532cc8b7ee6522e801b95d66"
+    },
+    "sound/debris/metal2.wav": {
+     "bytes": 5312,
+     "sha256": "e9c65c9534173a7ec4c18ddef10e0090bfeb70957d3ce7e4d289410a84c6267c"
+    },
+    "sound/debris/metal3.wav": {
+     "bytes": 6160,
+     "sha256": "bf3a70dd20ebeaac02fece31b962cbcdcb9091924b705a014dabd2d4e3a2821e"
+    },
+    "sound/gibs/gib1.wav": {
+     "bytes": 10682,
+     "sha256": "270c9f71b691904654039d49cca03407a91fc3d600b84e7fff3f8ecdfed94644"
+    },
+    "sound/gibs/gib2.wav": {
+     "bytes": 24740,
+     "sha256": "eb6b1f1596203e69fae5a707160779211a1776503c78d4b811a69205c8028da0"
+    },
+    "sound/gibs/gib3.wav": {
+     "bytes": 21552,
+     "sha256": "de4ca18cf6b6350d30c5b81be02745ff5ec6c3432939ba615affe0ad1fe7cb1a"
+    },
+    "sound/gibs/gib4.wav": {
+     "bytes": 9772,
+     "sha256": "b4fcc19c46a06bbbfb7803fccd33c6971c6fe5bac22299dfb6343d96358664d3"
+    },
+    "sound/gibs/gib5.wav": {
+     "bytes": 7782,
+     "sha256": "a0d9fa598637a4a2de5c2f1413835ad0215cc179de9f59e640b2e59f7c1942ed"
+    },
+    "sound/gibs/gibhit1.wav": {
+     "bytes": 9434,
+     "sha256": "3ee95e544edf6556c3389a5eef9f6cc0a0549e378c4433aa9617441602e3cf19"
+    },
+    "sound/gibs/gibhit2.wav": {
+     "bytes": 7772,
+     "sha256": "56bec98427e268141eae83a5873d12af966f6fe0302af2f84d2ffe412199e484"
+    },
+    "sound/gibs/gibhit3.wav": {
+     "bytes": 5402,
+     "sha256": "5782279b0c75441b2ee2ced9d7df2ac2ce08bb0cc5a451b2d90c20eb4a1aba73"
+    },
+    "sound/gibs/gibhit4.wav": {
+     "bytes": 3210,
+     "sha256": "19168dc337036a3deb524fdbbe965a7b2acdf0f204480b4a43acb80dc37b7a87"
+    },
+    "sound/gibs/gibhit5.wav": {
+     "bytes": 4294,
+     "sha256": "ef5115aca1b19ea0c48bf56c5eec8a6d22e95b6be5426247f58a3ad90c3a00bc"
+    },
+    "sound/gibs/hlhit1.wav": {
+     "bytes": 1468,
+     "sha256": "e907185147dbe42a4fac79c0b73d618c27f00c4edf9e48b23dd0226f8894e7ea"
+    },
+    "sound/gibs/hlhit2.wav": {
+     "bytes": 2170,
+     "sha256": "efdbee496456e118061ef9041c16c9d076aafd8cd055177a89d333014eec8b22"
+    },
+    "sound/gibs/hlhit3.wav": {
+     "bytes": 3506,
+     "sha256": "d70b60b22a44992365349e008b60616eee4097fc23d5dda7424e3b9d2698970d"
+    },
+    "sound/gibs/hlhit4.wav": {
+     "bytes": 2088,
+     "sha256": "d7a9505defc2e6bce40d11bb9e7bfef1b7099d327a856e2347b5fe2ab49231b8"
+    },
+    "sound/gibs/sofimp1.wav": {
+     "bytes": 4776,
+     "sha256": "77fdb4eaf4cd9422c1412969d12d2924024401862b3ef9f5cacb54e3bbe7daf4"
+    },
+    "sound/gibs/sofimp2.wav": {
+     "bytes": 4616,
+     "sha256": "4e885521c3bae0dcf93f7c8478750010d30402f904c459424c769825c0917693"
+    },
+    "sound/gibs/sofimp3.wav": {
+     "bytes": 5380,
+     "sha256": "646b3942e46dcdde73ad1ef6b737faa673e4a961175067e0bfeec37fede3a095"
+    },
+    "sound/gibs/thump.wav": {
+     "bytes": 8682,
+     "sha256": "558dcb80efdbe289c8c10ed9b116edc8d5e147b555b1a6289747951faaf60f48"
+    },
+    "sound/gibs/ut2bone1.wav": {
+     "bytes": 5960,
+     "sha256": "cf2ff12a824ffcbc975e56241ec112354bd970ab92f15f31ec06362ae0b5f862"
+    },
+    "sound/gibs/ut2bone2.wav": {
+     "bytes": 3470,
+     "sha256": "449ea8d8bf17e5ac4c8b91885527252cc070d99a16e7b2c8c43eb5152060ce72"
+    },
+    "sound/gibs/ut2bone3.wav": {
+     "bytes": 5452,
+     "sha256": "f3213b070e3fdeeea707b145dcc0ad0181d67a89693d87c34b6233b2448361ba"
+    },
+    "sound/gibs/ut2bone4.wav": {
+     "bytes": 5280,
+     "sha256": "7069fa9200c816f275c5ab950616481580795bf22099d247cfe12dba5cf7fa03"
+    },
+    "sound/gibs/ut2gib1.wav": {
+     "bytes": 17808,
+     "sha256": "068f6ea04f13016615f9534e74e969a62eda98c7def921df76731c5afbd73cf2"
+    },
+    "sound/gibs/ut2gib2.wav": {
+     "bytes": 18378,
+     "sha256": "274ed4c06d175a7a71dd925b94eedd9c172c6ba833c0a2a1bcde859fb682032a"
+    },
+    "sound/gibs/ut2gib3.wav": {
+     "bytes": 18342,
+     "sha256": "0b128fb8ee1c3946dab688820b032172e1c3281ff9d6552b21d7507a075a5bc4"
+    },
+    "sound/imp/dsbgact.wav": {
+     "bytes": 10068,
+     "sha256": "f7148ecbbb2701c185363b53dde53eb70be18bf9ceac84412e6ac6e7e9e6f4ac"
+    },
+    "sound/imp/dsbgsit1.wav": {
+     "bytes": 13670,
+     "sha256": "542352396ce81183b8164b942e078645bccc4a6b391b40592b330459c14f4397"
+    },
+    "sound/imp/dsbgsit2.wav": {
+     "bytes": 16119,
+     "sha256": "b69e1b6e716d95959345761682b79075d7fdb64e3afd16aec184c238e9f23b75"
+    },
+    "sound/imp/dsfirsht.wav": {
+     "bytes": 14784,
+     "sha256": "3d2d1c510a43e4bdf2a634ad74b587d48c5ad8258d72a232c3a2d1efb3f8dadc"
+    },
+    "sound/imp/gk_amb.wav": {
+     "bytes": 75472,
+     "sha256": "5b5dccca7e3ba16070611b4ee4e3c1bfe9847ca01c2674e6ec0a67aa89e8ee31"
+    },
+    "sound/imp/gk_deth1.wav": {
+     "bytes": 20912,
+     "sha256": "e8eeeb416d55bf6c18db8780cf822b667ae4ff22a29a24b765b8ea3082683e8f"
+    },
+    "sound/imp/gk_idle1.wav": {
+     "bytes": 39494,
+     "sha256": "83c406936f24e4014fb93f964963af6df872920e3d5dcd3921b58f0b6d20ea4b"
+    },
+    "sound/imp/gk_pain1.wav": {
+     "bytes": 6634,
+     "sha256": "a7fae0c331802ee37bef8dc3d7fa2fca4803a2eade63193c9279ab07e64cf850"
+    },
+    "sound/imp/gk_sght1.wav": {
+     "bytes": 17652,
+     "sha256": "f4f5960f9a0fd02ee7a0f0b7246e264a756adacd3c8b14a9c5684328e4e04720"
+    },
+    "sound/imp/pain100_1.wav": {
+     "bytes": 18162,
+     "sha256": "73a4a1dccfebbaae69191919cb04c04a4ae0d686ecc5b2d3d3acf32e92743609"
+    },
+    "sound/imp/pain75_1.wav": {
+     "bytes": 24402,
+     "sha256": "b5231d777bd2488da806806c3fa29c51a47159eed562cce5a851af7c20e4090f"
+    },
+    "sound/misc/bell1.wav": {
+     "bytes": 30872,
+     "sha256": "f6d17fb4d29a21667978d124784b3c26cdba1507d2ea5971d8db3551ed22e2be"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/h2ohit1.wav": {
+     "bytes": 20694,
+     "sha256": "12a512322e5dab9b15dff23a3253b008071868ea8d1632ca2535cbdfda98fbbc"
+    },
+    "sound/misc/metalbrk.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/woodbrk.wav": {
+     "bytes": 17036,
+     "sha256": "c8ae4ed3efe401d58f27ef333aca388851f704b6871cf6da916efde6d438963c"
+    },
+    "sound/ogre/wnalfire.wav": {
+     "bytes": 16492,
+     "sha256": "d4b26734bd9c1f29c657893d62a3d2f084bbeca421f0ab35bd75a453e4720bf8"
+    },
+    "sound/plats/wheelpt1.wav": {
+     "bytes": 18742,
+     "sha256": "a958c1a48242ac02a10a3af018f2d86705dbf6904aa5a6bd90c2f00599ee9431"
+    },
+    "sound/plats/wheelpt2.wav": {
+     "bytes": 8346,
+     "sha256": "2fe0cff30eb82673cbd8dcddf9e04e927f3fc1cfcf921ecdd9c68484e6b4dc02"
+    },
+    "sound/shuffler/big1.wav": {
+     "bytes": 21636,
+     "sha256": "16c1632682aeb4b4075006d5b8b13a7e3f8821b6f59f8eb61ad78308b0d68366"
+    },
+    "sound/shuffler/big3.wav": {
+     "bytes": 25096,
+     "sha256": "2cbbc5dc1249a92b9a31a6f3fa7ff654dd6339511fc99e4c552ad6a34218a4c2"
+    },
+    "sound/shuffler/breathe1.wav": {
+     "bytes": 45712,
+     "sha256": "53730dabf839c183028fbdf909df8ae7ef936828c51c58a957617444872224d4"
+    },
+    "sound/shuffler/breathe3.wav": {
+     "bytes": 50728,
+     "sha256": "fd923c891934046d9770c089dfe16021373a392b429531ef9698fbd2f759c42a"
+    },
+    "sound/shuffler/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/shuffler/expsmall.wav": {
+     "bytes": 8732,
+     "sha256": "18825b9644c01ff0a488887185ac14d6fb4fd983254620009ba3ecc96c44d465"
+    },
+    "sound/shuffler/firefblt.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/shuffler/pain.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/shuffler/slam.wav": {
+     "bytes": 6372,
+     "sha256": "2c6ff4782b389777c98f09fa6ac86e6c75a848ad800db6dc32f8ea9362706e96"
+    },
+    "sound/shuffler/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/shuffler/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    },
+    "sound/spider/death.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/death1pp.wav": {
+     "bytes": 10460,
+     "sha256": "736f0a768c0f52b22a301fc6a15f18f2f60e5579d3b27c2b78bcb7bed8e0c577"
+    },
+    "sound/spider/hiss1pp.wav": {
+     "bytes": 17802,
+     "sha256": "c56fcae8a01af94c07807730857b4b367f2c70c35869505528504faa29a17ade"
+    },
+    "sound/spider/hiss2pp.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/spider/hiss3pp.wav": {
+     "bytes": 22582,
+     "sha256": "1a3c71b1e4ac2389c98c4af9db88e81b51a602c681bd00a1812995654863e2d4"
+    },
+    "sound/spider/injur1pp.wav": {
+     "bytes": 6108,
+     "sha256": "728cd94a64b27dea4d845a9e27e1ba09cfb286bff80128a67d1da0431b6b0c20"
+    },
+    "sound/spider/munch1p.wav": {
+     "bytes": 5578,
+     "sha256": "b3af9e39836b0d5593a7be2ffe786fd2584d8dd2e894c100071cbc5f9de501f8"
+    },
+    "sound/spider/roam1pp.wav": {
+     "bytes": 20922,
+     "sha256": "8a6d25359bbbc1f5e4f6962f4ce1742160537c6bb8bf8b806a0df96adfae819d"
+    },
+    "sound/spider/tear1pp.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/spider/thumppp.wav": {
+     "bytes": 6038,
+     "sha256": "3c46bc58c52a61480c1a8dc2034aa240545521baf5e0027372992a9458796919"
+    },
+    "sound/weapons/noammo.wav": {
+     "bytes": 1400,
+     "sha256": "217c42718548de32b5df972d117ffc1a0e1dde5f03a7a173bd91d0b4551248c9"
+    },
+    "sound/weapons/plasexpl.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/q3ric1.wav": {
+     "bytes": 4910,
+     "sha256": "70f9619ddeedd4e2c73ccbf7aeed888ccf293fe23150b50f3c75bacf7c5d5fed"
+    },
+    "sound/weapons/q3ric2.wav": {
+     "bytes": 11832,
+     "sha256": "295919613b1f9d4a6b4fb74618361870130ce23c54902fb1b6ab3468d52da01b"
+    },
+    "sound/weapons/q3ric3.wav": {
+     "bytes": 12078,
+     "sha256": "59813f27cddcc4fc5e3c8693f653973436163f99fa0be282d5a49f6e3b4d3acc"
+    },
+    "sound/weapons/skotch.wav": {
+     "bytes": 2564,
+     "sha256": "f953f6a75919af7a6947d9c60d3f55ca8cfb851886f1de766a9a53d2070e7ab9"
+    },
+    "sound/weapons/slash.wav": {
+     "bytes": 5904,
+     "sha256": "458fa17f4a55682147371b91fa63db12a9c7f1cdb8415d3d97c4ef70dc0a4f49"
+    },
+    "sprites/blue_exp/blue_exp.spr": {
+     "bytes": 213288,
+     "sha256": "fe99a489e169ccf56f0412c2e83a7c5aea7b75b7cee0501402c62fcbd7ca969c"
+    },
+    "sprites/blue_exp/blue_exp.spr_0.tga": {
+     "bytes": 65554,
+     "sha256": "e701273306728f2f13aeff5632a1d4721fb9cf584e304b8e6d3356253adb78d5"
+    },
+    "sprites/blue_exp/blue_exp.spr_1.tga": {
+     "bytes": 65554,
+     "sha256": "fabb4579cdce97ed16d31849cd118ed705ba439260fd967846c7ec87ee711176"
+    },
+    "sprites/blue_exp/blue_exp.spr_10.tga": {
+     "bytes": 65554,
+     "sha256": "50b363992127422c00bf5bc8b00983399453eb135838ac0662d3310e33fe00db"
+    },
+    "sprites/blue_exp/blue_exp.spr_11.tga": {
+     "bytes": 65554,
+     "sha256": "3120bd7fbe101ae1936f6c974daf631d73b2763b70a7a53a69b1cd23546ac4d2"
+    },
+    "sprites/blue_exp/blue_exp.spr_12.tga": {
+     "bytes": 65554,
+     "sha256": "faa7122c01bff9c720b10f4e630faec0612eccb6878c5ca2decf280721b8127a"
+    },
+    "sprites/blue_exp/blue_exp.spr_2.tga": {
+     "bytes": 65554,
+     "sha256": "97b12bdb5613dd1f93a263922f9beb68170bf8df484985a2705f44128a3902a4"
+    },
+    "sprites/blue_exp/blue_exp.spr_3.tga": {
+     "bytes": 65554,
+     "sha256": "9358cbf83e3cc950aa70c4dcd7b58343f6050749b12b2c1d298bcdc05e6b4928"
+    },
+    "sprites/blue_exp/blue_exp.spr_4.tga": {
+     "bytes": 65554,
+     "sha256": "9d9246a2dd136cdff09cb164a94f3e3339327282a19fb706fb8fedcebd260038"
+    },
+    "sprites/blue_exp/blue_exp.spr_5.tga": {
+     "bytes": 65554,
+     "sha256": "e016212932edbc7c9b48e74e08e20380ccc34325e53c82cfc58ab40d0895c738"
+    },
+    "sprites/blue_exp/blue_exp.spr_6.tga": {
+     "bytes": 65554,
+     "sha256": "be6fd0ff2159b27d82e2291c52b4c1f9e38c82de90a85ec588f9febda98453a6"
+    },
+    "sprites/blue_exp/blue_exp.spr_7.tga": {
+     "bytes": 65554,
+     "sha256": "e844813bc2941eb86d3d13afb6f74ef2e8a3505339e4b1aba261b28b2eb6913c"
+    },
+    "sprites/blue_exp/blue_exp.spr_8.tga": {
+     "bytes": 65554,
+     "sha256": "07d8c3df60ae468868357a38033cb83c287a248881b2a8935d4c82d711150d16"
+    },
+    "sprites/blue_exp/blue_exp.spr_9.tga": {
+     "bytes": 65554,
+     "sha256": "ba5af001e3d42cd6e34734acc941a61f197ad158f4ad137b8c826dfb91189775"
+    },
+    "sprites/imp/impball.spr": {
+     "bytes": 6308,
+     "sha256": "7297fbdac1c592ba4b3a575b11a99f5e49eedffc76cced7fc53a5a8adc8808ee"
+    },
+    "sprites/imp/impball.spr_0_0.tga": {
+     "bytes": 12332,
+     "sha256": "5bbda99c4170f7a547255b766dd70d9cabe218de49a2d1d8d568338e566beb6a"
+    },
+    "sprites/imp/impball.spr_0_1.tga": {
+     "bytes": 12332,
+     "sha256": "aa972603cba8a0d69b269564683128366fb60f47e51d48a7ca5cfde9fad31c00"
+    },
+    "sprites/imp/impball.spr_0_2.tga": {
+     "bytes": 12332,
+     "sha256": "2409891736de545ebb596b22d681c16f2ef876940a68b6f29761e8f922ce91af"
+    },
+    "sprites/imp/impball.spr_0_3.tga": {
+     "bytes": 12332,
+     "sha256": "61e1f6da8d46f4f2b20c489cc67cbd11cae544733ced3e23279856728829fe26"
+    },
+    "sprites/imp/impball.spr_0_4.tga": {
+     "bytes": 12332,
+     "sha256": "7ccf7b8e0fc4fbc4c0f86d1f9da1fde8d022f93ad7cdde705aae182dd12eed4c"
+    },
+    "sprites/imp/impball.spr_0_5.tga": {
+     "bytes": 12332,
+     "sha256": "57bf40342d9fe00fbf51ecd39b1d89fd85c6ac0b0dadb85b16fee2a7e9329f40"
+    },
+    "sprites/imp/impexp.spr": {
+     "bytes": 24732,
+     "sha256": "76ee636f798e401975d75d6ce3eed424195d86151d4f197412dd4f81d47d65be"
+    },
+    "sprites/imp/impexp.spr_0.tga": {
+     "bytes": 49196,
+     "sha256": "5370bedf7b96dced77630bdf68522605cbc9dfa84a169920c02526408ca2638f"
+    },
+    "sprites/imp/impexp.spr_1.tga": {
+     "bytes": 49196,
+     "sha256": "d5be7206700f64b32603ed137bbb0433339a42a7ed6a5c0f786f8af441a805c5"
+    },
+    "sprites/imp/impexp.spr_2.tga": {
+     "bytes": 49196,
+     "sha256": "1f358f20103d7abae4205bc1c4687bf09a56338346d7268060936104afee3138"
+    },
+    "sprites/imp/impexp.spr_3.tga": {
+     "bytes": 49196,
+     "sha256": "d6350a1c10b19efa0a4839a4ab97aa10c9bff89a65b6f615a3616ef86e1e234c"
+    },
+    "sprites/imp/impexp.spr_4.tga": {
+     "bytes": 49196,
+     "sha256": "a36f0daad5eadac84c52eb5b51a4f6f3f0cb0c56cc8b77782b9c906487e5cbf0"
+    },
+    "sprites/imp/impexp.spr_5.tga": {
+     "bytes": 49196,
+     "sha256": "29b4d7a01f0177a7a6ff69eaa7912e96d47e6cf02af9112f66f7d2785b2c5ea4"
+    },
+    "sprites/misc/s_null.spr": {
+     "bytes": 57,
+     "sha256": "dc67fb2f31bd717353b8138f02bdc8ef2d70ace433c9fd91e3adc909fda513a3"
+    },
+    "sprites/misc/select_b.spr": {
+     "bytes": 4220,
+     "sha256": "d8c9af8233049df696ce2d851ee6429d17056dc23c92668017ac1b1cc3c891ed"
+    },
+    "sprites/misc/select_r.spr": {
+     "bytes": 4220,
+     "sha256": "1489b5a153cdcfb3e200a5e925520ced638d8d147a6bf332dd991258aab1ebdb"
+    },
+    "sprites/misc/select_y.spr": {
+     "bytes": 4220,
+     "sha256": "9fec23a2ac82c79be45731f1dcc8b13e0d9b4e92726d1588094d69bff8e7ae73"
+    },
+    "sprites/shalrath/s_vore.spr": {
+     "bytes": 6300,
+     "sha256": "f1f774aad9c4eae8d802fd02ef4dc378aa51d34363d2470460f5c1b9bb9f2764"
+    },
+    "sprites/starb/starb_b.spr": {
+     "bytes": 3620,
+     "sha256": "4d09e772f240bc7507ec4795845e2b28b5bda160df10e524c7a0a2fee203807a"
+    },
+    "sprites/starb/starb_b.spr_0_0.tga": {
+     "bytes": 6956,
+     "sha256": "d029db1ad6c659c8328d4954f0b646380201f0630760f1990311f18128ea1c4a"
+    },
+    "sprites/starb/starb_b.spr_0_1.tga": {
+     "bytes": 6956,
+     "sha256": "8eddc6431393d8c25e9d73a1e01e20dff1738917923c3b8e20c8fd7085b26633"
+    },
+    "sprites/starb/starb_b.spr_0_2.tga": {
+     "bytes": 6956,
+     "sha256": "4dbe4d1c44cfe304fb8da58a3084373d5a0a489d88c99683ba98c7f140fe4ebe"
+    },
+    "sprites/starb/starb_b.spr_0_3.tga": {
+     "bytes": 6956,
+     "sha256": "ef31c793c9a0fc7fd66aa37529f0d6c933218e48c642bb3c1edd37a31537e443"
+    },
+    "sprites/starb/starb_b.spr_0_4.tga": {
+     "bytes": 6956,
+     "sha256": "033c663fae38e4bfb46e71513e3f7657e04e7c340af81d876eca279a08ed89a5"
+    },
+    "sprites/starb/starb_b.spr_0_5.tga": {
+     "bytes": 6956,
+     "sha256": "4a886a73c0749d154c81ed3a8e735e29ee545706268a2d64de19bc25b3bb35e5"
+    },
+    "sprites/starb/starb_eb.spr": {
+     "bytes": 11656,
+     "sha256": "dd6451332d5f0b472e98d82636bbcd43d38172ba62ed5b68233fc43467d91d08"
+    },
+    "sprites/starb/starb_eb.spr_0.tga": {
+     "bytes": 27692,
+     "sha256": "b3d62a0f34ce72ea91ece2159b24774ae7e31cbe5ff472100704d1a5cd63417b"
+    },
+    "sprites/starb/starb_eb.spr_1.tga": {
+     "bytes": 27692,
+     "sha256": "87fc03da003f61af09863a66cd15d9009a6c1f1e1aa5bb8f129c2c96faddb1c9"
+    },
+    "sprites/starb/starb_eb.spr_2.tga": {
+     "bytes": 27692,
+     "sha256": "550b2e8c32d237b0d33743d291150b82b5ff8691a43941a0c665eb6780bfe66a"
+    },
+    "sprites/starb/starb_eb.spr_3.tga": {
+     "bytes": 27692,
+     "sha256": "d9a024325c4e0e9eeb0db48bd413c94e8470a8e59c7248d71c78d9b204f7d367"
+    },
+    "sprites/starb/starb_eb.spr_4.tga": {
+     "bytes": 27692,
+     "sha256": "229fe6cad18b9322159f02383b6f8030b30ecc37cdffa35b0b234ba26145368d"
+    },
+    "sprites/starb/starb_eg.spr": {
+     "bytes": 11656,
+     "sha256": "63dc20b8eda63a1e7bdef0280ce5a6bef35ebb7c6fa0e09e7ca32bb5729e8993"
+    },
+    "sprites/starb/starb_eg.spr_0.tga": {
+     "bytes": 27692,
+     "sha256": "af557889c32cb1bcbab072825fa6365a6e6d93d2b62f6481f177c6dc08b6a4e3"
+    },
+    "sprites/starb/starb_eg.spr_1.tga": {
+     "bytes": 27692,
+     "sha256": "a385232fb2d5fab52f31fdc1fa915d58dbf4405eda2c8b9a5db2f4a21d28f75b"
+    },
+    "sprites/starb/starb_eg.spr_2.tga": {
+     "bytes": 27692,
+     "sha256": "e71b287f88a6cecb2d73b472a3ba055c10dd1ba66f01ae279262789e923354d0"
+    },
+    "sprites/starb/starb_eg.spr_3.tga": {
+     "bytes": 27692,
+     "sha256": "d135bd7f453b5b60c64c704d7641c7889a12c0ceba2f3405436042afbc4614cd"
+    },
+    "sprites/starb/starb_eg.spr_4.tga": {
+     "bytes": 27692,
+     "sha256": "05345f8b4aef4bf97060f6f40006057b9bcaca20c8b7e5433cb70d4342716b9f"
+    },
+    "sprites/starb/starb_g.spr": {
+     "bytes": 3620,
+     "sha256": "a81ff819b478a5f3e25b404f7de06a180c5cab322c46a4664489879289bd7fe2"
+    },
+    "sprites/starb/starb_g.spr_0_0.tga": {
+     "bytes": 6956,
+     "sha256": "ba9b0efd8c06c70be58bb93755e71dc3697d62d7b797fa760cd74cae8023e3ba"
+    },
+    "sprites/starb/starb_g.spr_0_1.tga": {
+     "bytes": 6956,
+     "sha256": "169bb4ddb46bee7ba6e52bf50ab6585ccfeb2e2ba6d57a34277554a7abf97c36"
+    },
+    "sprites/starb/starb_g.spr_0_2.tga": {
+     "bytes": 6956,
+     "sha256": "63f3d68cd97d90748e14e43e17dd622191f0c3f419961334dec04f85f3a89447"
+    },
+    "sprites/starb/starb_g.spr_0_3.tga": {
+     "bytes": 6956,
+     "sha256": "8f2725f3e0f74ac6fe98899bb7061fa06a11868de61e82393a405d01ed11863b"
+    },
+    "sprites/starb/starb_g.spr_0_4.tga": {
+     "bytes": 6956,
+     "sha256": "a90770ccca06eb3d220d45b0e6a971ab506b8c421af6381fc41efc0b132221d5"
+    },
+    "sprites/starb/starb_g.spr_0_5.tga": {
+     "bytes": 6956,
+     "sha256": "6df01fead59b6eea56836c8fd5e349bee440648a1b72c20b7295c0828764c972"
+    },
+    "sprites/vortfire/vortfire.spr": {
+     "bytes": 55460,
+     "sha256": "b7893f5b894b7d2181efcf3ba97c43b23c9205dac6f8a230de6a29ca6919145e"
+    },
+    "sprites/vortfire/vortfire.spr_0_0.tga": {
+     "bytes": 110636,
+     "sha256": "a1c7f2fe56caa4849c2500ecae05b977f1543306243ebe4a837354d104eab962"
+    },
+    "sprites/vortfire/vortfire.spr_0_1.tga": {
+     "bytes": 110636,
+     "sha256": "aac0244f2e593b76b9ec7f33dcb6ec86dc9ce14b3e06bded01198e4bc2dae3d7"
+    },
+    "sprites/vortfire/vortfire.spr_0_2.tga": {
+     "bytes": 110636,
+     "sha256": "90ee481bc37b7aaf337374433754d589509cfca704b2ec5d41cdb7957276d17b"
+    },
+    "sprites/vortfire/vortfire.spr_0_3.tga": {
+     "bytes": 110636,
+     "sha256": "62dc246d470586509259c819d35fdbdf7de54bc6634ec2d72bb70ecb05000795"
+    },
+    "sprites/vortfire/vortfire.spr_0_4.tga": {
+     "bytes": 110636,
+     "sha256": "cce1fbb15e712ad5dccf27f65703220a51a1a7d99726530755dd1724882aa95b"
+    },
+    "sprites/vortfire/vortfire.spr_0_5.tga": {
+     "bytes": 110636,
+     "sha256": "3d83952a6a0ecfbcbf6602b2cb525ebba9b91b3a8c0c69398b59c78b056e65ec"
+    }
+   },
    "sha256": "828090e6aea93f73b2d9be9b2e811999ea3d2f7b9a832ec469078b7e918c90d3",
    "timestamp": "2008-05-02T14:50:20.000Z"
   },

--- a/json/by-sha256/b4/b47343b667bde1e3e9a863ac43f83acba0742622b03f044974e71fde40a7c706.json
+++ b/json/by-sha256/b4/b47343b667bde1e3e9a863ac43f83acba0742622b03f044974e71fde40a7c706.json
@@ -18,6 +18,13 @@
   },
   "sm130_neg!ke_src.zip": {
    "bytes": 22094,
+   "files": {
+    "sm130_neg!ke.map": {
+     "bytes": 197465,
+     "sha256": "fd0b7d275969a6b66a8d6be22699620c5121ac4c6e479ad562a5bc3b685cb6b3",
+     "timestamp": "2006-12-10T17:54:48.000Z"
+    }
+   },
    "sha256": "1badde58ead4d60a6a66d30bc800247e74a8307ad48973b78266cf388a31e39b",
    "timestamp": "2006-12-11T16:28:10.000Z"
   },
@@ -33,6 +40,18 @@
   },
   "sm130_spirit_src.zip": {
    "bytes": 34740,
+   "files": {
+    "sm130_spirit.map": {
+     "bytes": 194169,
+     "sha256": "8bd04c5d335770c1420a68f575823601c05f659eb9ffc6da68bc843696a41eb6",
+     "timestamp": "2006-11-27T11:06:56.000Z"
+    },
+    "sm130_spirit.qkm": {
+     "bytes": 147983,
+     "sha256": "e646201f669875b166bc4f6aface35eedd70f383b92cb8ba1d1cfce1a64f2f35",
+     "timestamp": "2006-11-27T11:06:50.000Z"
+    }
+   },
    "sha256": "833397dcad08f9533f0cba689a6aa25d955853cd35dc5bea40e0d5b126252dc9",
    "timestamp": "2006-11-27T11:07:40.000Z"
   }

--- a/json/by-sha256/b5/b58c9a10f70e05ff8a1e8486f94228a3b8834fce34215052737295ae7509a790.json
+++ b/json/by-sha256/b5/b58c9a10f70e05ff8a1e8486f94228a3b8834fce34215052737295ae7509a790.json
@@ -27,6 +27,340 @@
   },
   "copper/pak0.pak": {
    "bytes": 4085208,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "b1deebb2268d373683100cc9df4c9dcbf817f9bdb0e3f2cd13edde0037609b53"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "11454a7ec41855cc66adc9b80e60b1c76b0af873656d46cc20543ea4d2a7ef8c"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "d2a59d07042577c9c5a5ceace5ad0e3893ba3ac2d206f039f11cf282ead3945e"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "63f869e1e553ccae238279e4b78c902463505a3d1dd7c5d21d4f4acbb56857ee"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "6e3d8ed0cf22d78c0e05bf75837214a12f647fda33da1fa1ad1195cff3cb9681"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "35db83f82066ac1db85f4094dc9710e313b638e019d8e4d6fb5abf0457d506af"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "7b3838322dc860c3ea5dec5e246e9ecac4b0f75182edeff7b719e16f4f33d874",
    "timestamp": "2020-11-14T23:48:56.000Z"
   },

--- a/json/by-sha256/b5/b58f870ff22e91e863ec89f220d73a8e1b1717c847fa5edab9e35215904249e2.json
+++ b/json/by-sha256/b5/b58f870ff22e91e863ec89f220d73a8e1b1717c847fa5edab9e35215904249e2.json
@@ -36,6 +36,13 @@
   },
   "fbj/READMEs/VG9tbXk=.zip": {
    "bytes": 2012,
+   "files": {
+    "Y3JvbXVsZW50IGZ1Y2tjcnVzdGFibGU=": {
+     "bytes": 3770,
+     "sha256": "405208e8c4288148e571ace9d0eaf3671255a902a54fd690384a642b47f90b4a",
+     "timestamp": "2023-08-19T03:06:38.000Z"
+    }
+   },
    "sha256": "ca82e11601e97d16d638af3da8bde246117db36b41a56a473ce07ebae42ec65d",
    "timestamp": "2023-08-19T03:07:00.000Z"
   },
@@ -341,6 +348,268 @@
   },
   "fbj/pak0.pak": {
    "bytes": 62293781,
+   "files": {
+    "demo1.dem": {
+     "bytes": 611972,
+     "sha256": "ad9459533cddbcfaf5fddbead3e72021eb317aa583926cd28a821f5b4e5052a1"
+    },
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "de615c3f93f1089835b78045d6048e32d93c16acb1d1bae6a29f8157de4c2cc6"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "de3f5506c2f38372c714ffb9bf5a006fa44e1c2c81c9ba9f691e5abb5df076be"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "652a64f503dd18d107affd42d2b14f2bcbd7bfd491f8da39b8f1ce340bc04540"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "03cd7b70fbbb24730f6ab7f0d3743734f1d9deb7929385900bf60a477d49acd8"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2d88a3ddbc51c2e9fd764d2229156b51974af607cab93b6983658ef3adf8f386"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "0741983bea08669e755611d8e7ab81c1aa35ee0663081829b61ce3618b91f1bb"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "67e0a13ea28f7c469bc1c98b277da0ff776805da9aec2ecb9ba41fc5cb78673c"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "520c8764f9885771d24677c2ac29d494124389d8129ed6d4f8386e7631cfda57"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "6b90710a7ba4ad47023be22e82190b821d11a5cde8438c188989b5008ba28436"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "540a3ad5d0e674737cc89b4900ca1a3dcea62132b2ddcd562ffced075461505b"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "535922ac16f460da936ea5f7ac148b1dabc1e98b76f0a162b7192591867b5bc3"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "e1b40601df0fd9d6742d799cf80fb4089901334c1c859028a398be31853186ca"
+    },
+    "gfx/colormap.lmp": {
+     "bytes": 16385,
+     "sha256": "663526184d592951b7155c7420ee8a383c4298af7768eb543b3a1f71f2d1c701"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "4ce8254127ecbce046a93d8ae07f46095a9d694645ed69830909b110b248bc17"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "bf3068335a34a52ff25edcc5d6593a9070eb28edffb14b872a0b72cc88f4be9d"
+    },
+    "gfx/dim_drct.lmp": {
+     "bytes": 3352,
+     "sha256": "95aef5fed25bb354e44b802f9a712adaaa42c559c0860a2418bb56387b185054"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "14f86cf1e7d2926b08b3071c934ec1d1c587aeca8f9da5b823240eccd18eded7"
+    },
+    "gfx/dim_modm.lmp": {
+     "bytes": 3352,
+     "sha256": "88ebd8435a6a17e80793fba2c3cfb6592f068b1beac1d4b76c4130b5edeea5b9"
+    },
+    "gfx/dim_mult.lmp": {
+     "bytes": 3352,
+     "sha256": "ac133a9af68ba07c40b611213101360dd4ff8343f6ac999a941ecb1d292fb415"
+    },
+    "gfx/dim_tcp.lmp": {
+     "bytes": 3352,
+     "sha256": "df0f1515ee85aa26838ec217f39eccfb6eeea106402362c81805dfe62f9b178f"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "609fde2e31eba5c85bb54113093c6101bd70819ce847fef023e21b60395a0c32"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "c6e3450c6b01dd5d8824d65777d4b8a062e3d48c370080f1bdec4da707a35fd8"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "aa57d00ebe4fe7ca87431770506ad1cd8541b90c4705ae87a242a1279d8999ff"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "fef0550dcd1db6f5d24387374ae372239399180b4583f6eb1e5f19ec98562cdd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "1daef6064509b8c9bc2c84137227198911269adc2e48678b04cfec75cb173c3c"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "bbe6beb37e29c76f7699a512b2dd26d87142f871fb985c78c95180724da2984a"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "918407020b3ffaa37fab27189c78d754f203abc7700e18bc26ab5215071c0614"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "a7679e7898b233a737bca7ae8a77e58a04ee9be0f2e9994740073efb65706631"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "2dfe0332f7585f6fa9237125935569222a454bb73a1c6a7028efa20f05d5ffa4"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "2dc559980fbdd2145ab849917c10adda8c8efcd322aa825d810760f990891f11"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "655d79f3bc52888619559d1849dc8e6ac05aa008955c0c8e3d8c4cca154a5a5b"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "ce1c93eba29c7ddf494ffad230cb7aaf9dc48667948bb0bd59ace6cd8716d2f4"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "5abdc3ebb508c1f3ba1442b077d29f8d901faaf180aa8d19698d165117f31bd4"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "db401e01a7d771b1f1886b8c85edee72c594825c898a3e5692fc0ac23d2a4d31"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "7145b1c3c211cea02e6e755d273772181ce029d0c7c6f6ff98eadaf2a0dac3a3"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "f0172715fac25349cdc27c61fccf0b93e9f2b396899ddd2aacd07bf1d9e6d197"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "705874cad5c8b0ee324f50fb498f4a59e8a4896f4b55c02f542d4fae49fb6de8"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "38aafc0e2ebc205cb3ebcfc8f410779d837a17c395e718c62594482d2bf9fa33"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "94d65c81f1ff34e69c9a1867fe9675c209d16c297fbc3eb654658c0301115adb"
+    },
+    "gfx/netmen1.lmp": {
+     "bytes": 3352,
+     "sha256": "378852aa6c0ced84192a31f549f8204cf34003a3b51417fa8061f4e70ff6fc5c"
+    },
+    "gfx/netmen2.lmp": {
+     "bytes": 3352,
+     "sha256": "19a324fdff8f2c716beeb9da110b52ed6f9388b4b2744d69cf1fbd4d36c72f46"
+    },
+    "gfx/netmen3.lmp": {
+     "bytes": 3352,
+     "sha256": "90b2f08d1ec391bccac1d4e80ce92eb8ae0385880a26f7789742d89d32874bde"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "e7ef108bc8a7233b2a22d9c19a40078e5b23f65099f259811ceff4d7e184c01f"
+    },
+    "gfx/netmen5.lmp": {
+     "bytes": 3352,
+     "sha256": "e16f2ce2d4e76de19f9b7b3e2670454b33b889eb8e1236c406537c5d8d86b434"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "486b5dedb96d5f917b4123f0ef6dbdfc66de3d911af078b1969ae491096e8e1a"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "df14925eaefa1e1ab5fb7059427c0784ac6551a9e59c49d431cf33e9cd6b65b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "1dffbc572bbc8b18825881f6cc04c69eaddb47173cc264000d06a04fcb89996f"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "ec2373d71c1631a7bc8ff6ce51c0136b1e90cc7d14859081193e2da70ee2d99f"
+    },
+    "gfx/palette.lmp": {
+     "bytes": 768,
+     "sha256": "6b20b5bc4ea965ef1852b05670d043ca16148a0ecad4e63028121c8aebc268fe"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "81a58d90842ba263e30fafcdb1c41bf9e908bd615a570bb84337a59430d4f036"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "a9621da7a56c13931f5aacf586ba3c357cb7ff5a3ff850f74bd984314e253f9d"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "1940bc99abed2409ac4687bcc80e78ec9dde5b2ac984d1d7bb5906ae0f0d9e3a"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "7f5fefbedf883ae22bacba9c5ba28acab5fd71ca014e48e1e542561a478bf782"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "8aadc2e8a2988f82f303f8fe0182911c12aac017d6fe7804f08c31c8a48f174e"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "9390cdc020f19ba246b91a0bd94ff1629eed8461137f3061b514a6a36f505e0d"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "641aa9f442bb1250de1aad36c984dfa9e9a35db6d5964e50871661c0e0de6855"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "215ea8b054dc3a3cb31d6ef8cd43cae73b9b4f970bb9fa999acb19188d93cea7"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "cc5d4b36999a0efe41cbc5e2364487eaf65446f74190417250e527d275313266"
+    },
+    "maps/fbj_cc2.bsp": {
+     "bytes": 12202908,
+     "sha256": "f7a2250d7c39ca389926cc853b107fb6f623f04fa26765d3d99323bffbc4a9e2"
+    },
+    "maps/fbj_cc2.lit": {
+     "bytes": 1496066,
+     "sha256": "61ba5ae7a97328c86a315f9b88e4899e6765ff2af06d8db89c67a06a6a340c4b"
+    },
+    "progs/boss.mdl": {
+     "bytes": 288572,
+     "sha256": "0ed37555306e19ec2097ddd32a721df74057111fff4a85278864040183d57221"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 109924,
+     "sha256": "c38bca4bcca2be4fb8ed84dba5e8da7cca97978b136066341dafd2954a9f39a0"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 14932,
+     "sha256": "d0ca3e00d9c04db87e3ee7fa420bf7cd557ed5dccdd7d373c40fb7359fce94e0"
+    },
+    "quake.rc": {
+     "bytes": 293,
+     "sha256": "ba663420fe80019bb267b5817de2cc96fc1c42c2c723fd61b97a0ae8553d0d18"
+    }
+   },
    "sha256": "f7fdd98785765517b4eb5309dca463f38487b32b132ed125b857e7d2d728b7ee",
    "timestamp": "2023-08-22T16:51:52.000Z"
   },

--- a/json/by-sha256/b6/b6c5eb96ddb7d9e559bb400edcf7c3d090d1897dfee5f2e6e2ee1a99160e30c2.json
+++ b/json/by-sha256/b6/b6c5eb96ddb7d9e559bb400edcf7c3d090d1897dfee5f2e6e2ee1a99160e30c2.json
@@ -7,6 +7,80 @@
  "files": {
   "Pak0.PAK": {
    "bytes": 1906630,
+   "files": {
+    "maps/b_bh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 8820,
+     "sha256": "74aa7b2f080562dae303a3601872df9a684c5b52e71c8fed2460bbb47ff190c7"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "maps/b_explob.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/gc.bsp": {
+     "bytes": 1592560,
+     "sha256": "1d58600932e341ee70b1aea28ad58db4159eaaea33be17fbe73a7ce02d801099"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 160688,
+     "sha256": "df1991fc90a4176013b374b75acd262b34ee4ca2a88f19c19b99eb2cd08c6810"
+    },
+    "progs/laser.mdl": {
+     "bytes": 1684,
+     "sha256": "5e3be5dff13ec94951aacbd4a453dcbd9c2aebe7e4e6bded2dd70d49d1ddd695"
+    },
+    "sound/enforcer/death1.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/enforcer/enfire.wav": {
+     "bytes": 14302,
+     "sha256": "2c3db752aed909b06eea687b8ba8c0507502158faf2ba29ecab99984206f9840"
+    },
+    "sound/enforcer/enfstop.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/enforcer/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/enforcer/idle1.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/enforcer/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/enforcer/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/enforcer/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/enforcer/sight2.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/enforcer/sight3.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/enforcer/sight4.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    }
+   },
    "sha256": "37b54ad90065a26816f28e52d40a226e6d8aa4abe1e52b4fc74263d7b8c8df22",
    "timestamp": "2001-12-30T00:32:26.000Z"
   },

--- a/json/by-sha256/b7/b7fcd229cb05e4bda5e2cbffbedb02a6bad43684cbc8596d596cde2342d96697.json
+++ b/json/by-sha256/b7/b7fcd229cb05e4bda5e2cbffbedb02a6bad43684cbc8596d596cde2342d96697.json
@@ -52,6 +52,84 @@
   },
   "jzspq2/pak0.PAK": {
    "bytes": 3160274,
+   "files": {
+    "default.cfg": {
+     "bytes": 1914,
+     "sha256": "8a749a09561a2b453458a1a5d98917a3cbc3d00b49ac94ede96a8e9f58a83824"
+    },
+    "demo1.dem": {
+     "bytes": 26546,
+     "sha256": "04c0cc506330a4649afd3d54e16d45c8c061c34f897d70730205f748425bf348"
+    },
+    "demo2.dem": {
+     "bytes": 207696,
+     "sha256": "dec8ba7587ad69ff1d422e8c05e689a7270bf16e374ba9b70390bee0372f2570"
+    },
+    "demo3.dem": {
+     "bytes": 118769,
+     "sha256": "49efb95dc44f130b7813ef3e4599fddd83a9ce90e626e1ead426f09f3c730905"
+    },
+    "maps/jzblue_1.bsp": {
+     "bytes": 343788,
+     "sha256": "51d8dc6c98d8505ea68db7f24c6e4a6d2f4bcaf2a179e694b9ae2192aa67e255"
+    },
+    "maps/jzblue_2.bsp": {
+     "bytes": 416372,
+     "sha256": "bc60052f0bef4429297486859c07a541b11ec27ae32d661d7fbe61dbfbf56654"
+    },
+    "maps/jzblue_3.bsp": {
+     "bytes": 365192,
+     "sha256": "0e4bf951dffee12cb1237eb5026749a50e7c4f8419c314087280952b0bcb135f"
+    },
+    "maps/jzblue_4.bsp": {
+     "bytes": 499848,
+     "sha256": "21acb9f86bd05e7f28bd570db89c7a0a06264671bde215ad7cbc1a3649b3b9e4"
+    },
+    "maps/jzblue_5.bsp": {
+     "bytes": 301060,
+     "sha256": "6155df022b6e4c6f2e2a4ad77fe9fc826f65d52bd0cc5853f59d9c69463d12e7"
+    },
+    "maps/start.bsp": {
+     "bytes": 281964,
+     "sha256": "e9c63392d41367427707e1444138c759e83315e43e1d8c80d59e655257a9f333"
+    },
+    "progs.dat": {
+     "bytes": 420748,
+     "sha256": "464658a87ae0d8181c80d45941670f8f9d2e518ccc181649a09ed8b3af43c3e2"
+    },
+    "progs/h_boss.mdl": {
+     "bytes": 61060,
+     "sha256": "30bf06acfcb3b32bf8f940187e712e87355fc7d8cc5ba8f36c128774cf20846d"
+    },
+    "src/ai.qc": {
+     "bytes": 15610,
+     "sha256": "e6966be39c2d65ee76f102d2af36f0e441241410053bfd809f010ee45518a4cc"
+    },
+    "src/boss.qc": {
+     "bytes": 18872,
+     "sha256": "69acea7d6b0ef916841829d4de76762f4563a9ff3dad12d708349f07aab87a6e"
+    },
+    "src/client.qc": {
+     "bytes": 34014,
+     "sha256": "c8614869f6e650cc7edb48d0c731ee30c0aa67074fb7f276d3041bea2f7eef91"
+    },
+    "src/combat.qc": {
+     "bytes": 6916,
+     "sha256": "037bd597baf8a8fc07fdd981e2e18a49ad862833ca3806a09c8cbe6adc107f74"
+    },
+    "src/progs.src": {
+     "bytes": 502,
+     "sha256": "5d72d988cc793e75f2aa20af5b581dc9b1e42aa58873710ca9ae6c91c679ecd4"
+    },
+    "src/weapons.qc": {
+     "bytes": 25918,
+     "sha256": "462ecfa159b86a381d0c3aece642aa8aaec074dcf37deb3e763d1b8143ca76b4"
+    },
+    "src/world.qc": {
+     "bytes": 12257,
+     "sha256": "9e016432cb8ffc25c7e8c64a0504b8f2fa215ddee44f5b44903a14552aa1b158"
+    }
+   },
    "sha256": "2532aeda32bb0f03a0933bb1427b4c6fb99334cbbcb65307fc7b48baeb40dde0",
    "timestamp": "1998-02-02T19:29:22.000Z"
   }

--- a/json/by-sha256/b8/b822648bbac7a2a46e091d0ca38698d190252d814fd4ddb207fe823be1520399.json
+++ b/json/by-sha256/b8/b822648bbac7a2a46e091d0ca38698d190252d814fd4ddb207fe823be1520399.json
@@ -14,16 +14,2002 @@
   },
   "pak0.pak": {
    "bytes": 48226771,
+   "files": {
+    "coop.dem": {
+     "bytes": 2575532,
+     "sha256": "214de04930a259e6a37101fb8a8838d7af07e6bc79efaf7525ca3b68610d5a3b"
+    },
+    "gfx.wad": {
+     "bytes": 128932,
+     "sha256": "6f7878b23deb09b151a58b8357f8a5b966cc87dce24a52407d931ceef885fbc5"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "d3608be2643c55487f8a90c2bbfb72f7aa8a0fcaa72cd4e156943a59fbeae68b"
+    },
+    "gfx/env/bseabk.tga": {
+     "bytes": 786450,
+     "sha256": "d00b39ceb291dc3a56f1b65cb40d90cabd49495785cf7754ee93920985e8946c"
+    },
+    "gfx/env/bseadn.tga": {
+     "bytes": 786450,
+     "sha256": "ac81fbab4610004d3b8f9f26fccce1aa9bf013414f714b261177eb7a23730c9f"
+    },
+    "gfx/env/bseaft.tga": {
+     "bytes": 786450,
+     "sha256": "cd36bc74f3f779b70c05e9394f74d0dd62655fbff8206e4828d9e1d669b05416"
+    },
+    "gfx/env/bsealf.tga": {
+     "bytes": 786450,
+     "sha256": "94ad30078b5516ff4baaffe003f73fdfd10a9446ab1c5239474a6fe46bcb588c"
+    },
+    "gfx/env/bseart.tga": {
+     "bytes": 786450,
+     "sha256": "ffa0b7fc5b127c82c3a73dc576bea00cd95b9b7697db377ea457fe9275a38290"
+    },
+    "gfx/env/bseaup.tga": {
+     "bytes": 786450,
+     "sha256": "5c69640f2d24cf1f39fe632a3315e4e810628725e77fa967bda7a215e76df9f7"
+    },
+    "gfx/env/duskbk.tga": {
+     "bytes": 786971,
+     "sha256": "c6ff35f38b5262c301fafd7857305cf80636efd9b67c72f511a2e93a2648d220"
+    },
+    "gfx/env/duskdn.tga": {
+     "bytes": 786971,
+     "sha256": "5a844ff50a7e7cb3115c94cf97c36fb55a998baf8a3e38118bc4524f03d533fb"
+    },
+    "gfx/env/duskft.tga": {
+     "bytes": 786971,
+     "sha256": "c1142a0e3bba1d2b65f887c000b6b5e450fe08474d6a5d026532b63e73d03a01"
+    },
+    "gfx/env/dusklf.tga": {
+     "bytes": 786971,
+     "sha256": "1735e4c258ab8d18b971345b43c79991bf76c2c178344739c26d79d7658128e4"
+    },
+    "gfx/env/duskrt.tga": {
+     "bytes": 786971,
+     "sha256": "4cdc3edcc8c0c1ec938ef7e4297931cf1bc4ebd804660011725bc7f3abc61ddb"
+    },
+    "gfx/env/duskup.tga": {
+     "bytes": 786971,
+     "sha256": "320e8dd8e6adc4453d894d15d20ba3ad02f176af3dd4ab1baab695e0a4accfef"
+    },
+    "gfx/env/fodrianbk.tga": {
+     "bytes": 438466,
+     "sha256": "023a119b49e2a3630b156cf622fdf0d9efe6a8144d1128542dad3a36852d571f"
+    },
+    "gfx/env/fodriandn.tga": {
+     "bytes": 526472,
+     "sha256": "ece0abbb9d478368c9b80fca7fe03ab2cfd349d0d087e134b2ac7d5f8c61ba89"
+    },
+    "gfx/env/fodrianft.tga": {
+     "bytes": 491268,
+     "sha256": "1914f73da39bd55a6a167508a3e0474cdf8f9047b59fbf74113c50cb1a682d0b"
+    },
+    "gfx/env/fodrianlf.tga": {
+     "bytes": 502698,
+     "sha256": "c75d67a6f12f9e96fe5af60ec6f7a6d93778371d3bf141f28e750ff6113945a7"
+    },
+    "gfx/env/fodrianrt.tga": {
+     "bytes": 468382,
+     "sha256": "aad1a02a8c636463fbee3178aaa69b90380b96d8550c581ab74fc91ec05f6e9c"
+    },
+    "gfx/env/fodrianup.tga": {
+     "bytes": 538367,
+     "sha256": "31a61f7f5f476a81a2191153794770fbcab42c61e9f32253daffe78f38585b75"
+    },
+    "gfx/env/graynightbk.tga": {
+     "bytes": 786971,
+     "sha256": "3cd8f98206a4267c0cbd7a8028dd55a2869e4a0840a45c89e4a03d1300d970bf"
+    },
+    "gfx/env/graynightdn.tga": {
+     "bytes": 786971,
+     "sha256": "2d2e929246612062e871629464e8508a0dc9fe35680015e90a441c6c20e1a936"
+    },
+    "gfx/env/graynightft.tga": {
+     "bytes": 786971,
+     "sha256": "387759c32fdce1b459b7fad63f47ca35c5755794aa960c8486b2e4de24c59949"
+    },
+    "gfx/env/graynightlf.tga": {
+     "bytes": 786971,
+     "sha256": "16654901eabc2f4da7ac602c240932acd73cc5831e29afc4dafc51cd2daaa9b4"
+    },
+    "gfx/env/graynightrt.tga": {
+     "bytes": 786971,
+     "sha256": "4f13113e77b85644febb7baff162c19cc353f4257322826389974e516ffd77a6"
+    },
+    "gfx/env/graynightup.tga": {
+     "bytes": 786971,
+     "sha256": "178c815e62bb236b75d967e502ed4a93eba64cd12818081f6f41591860b3d4da"
+    },
+    "gfx/env/starsbk.tga": {
+     "bytes": 51294,
+     "sha256": "7292194bfe9a6444173b6c4949568ec42cd6900883dcc444da0f2344fe3d4d69"
+    },
+    "gfx/env/starsdn.tga": {
+     "bytes": 51322,
+     "sha256": "59e645a79cd93b98c05de9c2f8a136394ab561ce0b9978aad4de17c6508da60b"
+    },
+    "gfx/env/starsft.tga": {
+     "bytes": 51685,
+     "sha256": "2dc8d4ab7cdd655c2a63bfe7059815bedc56692a5c1867191d12433958f633c5"
+    },
+    "gfx/env/starslf.tga": {
+     "bytes": 50756,
+     "sha256": "f74f36da6239c9b011b6ecf1f0fabf7c40f3372fe3841d2168473a31e16e646c"
+    },
+    "gfx/env/starsrt.tga": {
+     "bytes": 52319,
+     "sha256": "9ce812f2efe3dd4fb077bc751fc8209de661c04544e54c3271b956316b7c162e"
+    },
+    "gfx/env/starsup.tga": {
+     "bytes": 51416,
+     "sha256": "d31b6a617776b2ccd90662ec1196267ac4c8be85696b9702ec39c41386f2fc47"
+    },
+    "gfx/env/voidbk.tga": {
+     "bytes": 603,
+     "sha256": "6e095aecdb2ee0ebb2636b48ce7f7754ee357b217f32a83025830db3d9a87fdc"
+    },
+    "gfx/env/voiddn.tga": {
+     "bytes": 603,
+     "sha256": "0c7a0cf2c30d6d87f21567c4e4dacedccc3840fb82b37bfd8c0949315526cc46"
+    },
+    "gfx/env/voidft.tga": {
+     "bytes": 603,
+     "sha256": "bc18cbf4e5c4036b64203d6a165aa18edf24d86bcee9b6e7c183bd54f456550e"
+    },
+    "gfx/env/voidlf.tga": {
+     "bytes": 603,
+     "sha256": "a350d7da744018421f60d6b95edc609f36d059ad27fe0621599c018e6ccbf3d7"
+    },
+    "gfx/env/voidrt.tga": {
+     "bytes": 603,
+     "sha256": "6447fc6c5ddb2a696fccd2611323758ce44be8a236ec9602ed9947b800d1240a"
+    },
+    "gfx/env/voidup.tga": {
+     "bytes": 603,
+     "sha256": "76c1a1a57bfc1099bde3814a7d998b842ad6f8b619d3e4e1169ab7ab8850f133"
+    },
+    "maps/e1m1quoth.bsp": {
+     "bytes": 4120260,
+     "sha256": "7ae26353d1d578c660fc399a5e46836a35477f772fb08039a1c75e5b409610f8"
+    },
+    "maps/kelltest1.bsp": {
+     "bytes": 896456,
+     "sha256": "a913e05c0b4b5fc09257ace118d55205b3e34f2f9e44e6184828a7150c7a6618"
+    },
+    "maps/kelltest2.bsp": {
+     "bytes": 507808,
+     "sha256": "f3874478333d08938247cff6dd23a9717763b42af87ed5283b31f85515404c07"
+    },
+    "maps/kelltest3.bsp": {
+     "bytes": 405700,
+     "sha256": "3e2497ca1bf2cd3aae0a0616066ab89288fa777ffacab11e1981f74f5ed8385d"
+    },
+    "maps/kelltest4.bsp": {
+     "bytes": 306912,
+     "sha256": "36639ed4b47a30328f358c1e63067020b273d8d831bc47dec4b24cc1599159f5"
+    },
+    "maps/ne_basetest.bsp": {
+     "bytes": 1196080,
+     "sha256": "1477ebc35c85b4d81ffc4bc623a75757c28b2d3a36c934763735b5947b656c47"
+    },
+    "maps/start.bsp": {
+     "bytes": 1927828,
+     "sha256": "4c452be3b25eed55d3df7e03baab033c5963cb82e09dc4e157299bec75fc792f"
+    },
+    "progs/air.mdl": {
+     "bytes": 5076,
+     "sha256": "930e21887f0c482f353d5009efe1f5ef3f88e18d7a4f2e1232978cb2e8f73932"
+    },
+    "progs/beam.mdl": {
+     "bytes": 3307,
+     "sha256": "18295a66ab4a4da70b5dc0558d5cac7622afd65e9937ebe8d2c5321a67a418ee"
+    },
+    "progs/bigexp.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/bilebomb.mdl": {
+     "bytes": 13469,
+     "sha256": "2f77d07f24b62edc095facdee8c670711cc189a85258a631ada71cd4746e26ac"
+    },
+    "progs/bilefrag.mdl": {
+     "bytes": 9216,
+     "sha256": "34e6ed3456aef2c89d4ab9d857a173bfa98c17381be380f9665d496791f6f814"
+    },
+    "progs/bob.mdl": {
+     "bytes": 177959,
+     "sha256": "173f9aa590a0b23e0525c86b6945f3b8d565b865f2376daea00ac8f88791abc1"
+    },
+    "progs/bobblaster.mdl": {
+     "bytes": 27556,
+     "sha256": "3aa3e956183dc641fe601edaae52b7f2d5c92d90d00e8994e106dde4c0c25092"
+    },
+    "progs/boom.mdl": {
+     "bytes": 77388,
+     "sha256": "c0b2d8695564dbb1ef37aef9a9e226160ff8f5ab40de7a6d7129a66675096179"
+    },
+    "progs/brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "0287c3e7886bd2d6d1cbb504529d9e11038d0f8232ee624528eb0ccb78733c53"
+    },
+    "progs/corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "22f82f29d0a88af204f7b97eef887b963bd940e7277b6f5cef5e6f3610f2ea51"
+    },
+    "progs/corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "41e90f1a84e9779eb12541d923ab0a66e69deef3a9dbc82259ab84cb71b68dcc"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/dguard.mdl": {
+     "bytes": 176648,
+     "sha256": "f2f92ef84411d83c7e8c158f62b1415d8fc6aa56d77f21760dcd3080424cf6c8"
+    },
+    "progs/drlbomb.mdl": {
+     "bytes": 20355,
+     "sha256": "5c1db489f43cba73fce265db642267775245d044866cdd48396b1f1260a28237"
+    },
+    "progs/drole.mdl": {
+     "bytes": 241648,
+     "sha256": "5067b7ca5323754fe563d6696025525645a2cbd3aaf7f79232634608f9fb987a"
+    },
+    "progs/dspike.mdl": {
+     "bytes": 13684,
+     "sha256": "05bc998adf950efaeba0f0216e008ec8d6fa732d5eb726dbe70ff07e088275c6"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 333860,
+     "sha256": "230181ce6ea00c8e80c7d59189340424424ba5d99d71230b309907e206e07682"
+    },
+    "progs/fireball.mdl": {
+     "bytes": 12660,
+     "sha256": "ba5cba46edc108572d78e66166f5ed0405a48dcf672e7a569d14a4397f85f285"
+    },
+    "progs/fish.mdl": {
+     "bytes": 90636,
+     "sha256": "037ebaf6566f8fed7609b4e2c79eb36c4c78c49d914b225e7aa37fd4e3d6fa17"
+    },
+    "progs/g_bomb.mdl": {
+     "bytes": 50176,
+     "sha256": "33bc7cbf807cdae850d42cd11af0d332a7ca140741a3d29353e558bd8468aaa3"
+    },
+    "progs/g_fx.mdl": {
+     "bytes": 32260,
+     "sha256": "ac99d4e641af0bb1495ed38ba9f3a7c1195bda19e5cf0d3a68f04defe6178ab8"
+    },
+    "progs/g_ham.mdl": {
+     "bytes": 71639,
+     "sha256": "424bd4ecf03e0f364f57448b7c426924e1e0ccd06dad40294c00a23a645b8c0a"
+    },
+    "progs/g_lance.mdl": {
+     "bytes": 32906,
+     "sha256": "6eab37228d67437eccd9735de6e7933c79576a921c23479ad317e7c3db5b1f0d"
+    },
+    "progs/gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/greenexp.spr": {
+     "bytes": 24732,
+     "sha256": "8cd2c8f20214cc1f8de491785a27d3aafa924819c9f56078d2bdb219d4f16f5e"
+    },
+    "progs/gug.mdl": {
+     "bytes": 482020,
+     "sha256": "2cd097236a235aedf717a86b7312bd7d1b3caa6f0b25980c82eee2463fee2274"
+    },
+    "progs/h_dguard.mdl": {
+     "bytes": 4920,
+     "sha256": "337f2723daab9d1375b78cb017512ce8281087ff8df9c33b04a6c613cea3590c"
+    },
+    "progs/h_dlord.mdl": {
+     "bytes": 18699,
+     "sha256": "bc5a92be1c5f3d06dc0238ec7bafe6a3c25826cc50edc6214ed5aa19b0075987"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 16854,
+     "sha256": "00f3263f1c3e0daadaaf03eea447080d727ea7d9ee1a88f2b42e060d748e1566"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 61251,
+     "sha256": "dec5afe666eba8db6e32d7535fffa3d0e4ed9344ba107b73418526ebebac574b"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 10663,
+     "sha256": "819b7cd0c4c38edb9725dffa46913ed89d75276aac3ea34b2bc683daedd5db0e"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 32629,
+     "sha256": "d69f21f26e13276272bb6b59352e66082a224534e8a0e46753037136927e0929"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 23239,
+     "sha256": "00117347d1acc46beb4972853572e14ce3e9d6dca25b883540896fcd873f3e3a"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 1142583,
+     "sha256": "2c3d4002e7c5f1682367c3f649e67333303d1763e6da0b3cfdce8c7519dfc2dc"
+    },
+    "progs/keybase.mdl": {
+     "bytes": 11407,
+     "sha256": "5fed79622ad6f6751b2c771ddff06b88dcf049719336c228520bc84f0db441cd"
+    },
+    "progs/keyeye.mdl": {
+     "bytes": 37528,
+     "sha256": "a4612e183f026ea63161377682c1001b178b9e0f94f6b9a801b983962162dbbc"
+    },
+    "progs/keymed.mdl": {
+     "bytes": 13247,
+     "sha256": "e147a4e527b9b797680732c33cc0ebe3503bcd6e2c8a5b0917701cdd41f99297"
+    },
+    "progs/keyrune.mdl": {
+     "bytes": 25643,
+     "sha256": "f06fafe1b92a172a2cebcbc68ad5e2a8aafdfc99d13ce6d5bf5b36f25ca48f73"
+    },
+    "progs/knight.mdl": {
+     "bytes": 342850,
+     "sha256": "9e23eca66dbe332f49a1a82ceef197d5ee980abb24145050ea3088e05468dd4b"
+    },
+    "progs/longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/marsh.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/marshsm.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 3542,
+     "sha256": "2f3efa19a64b60d480fbef7c10e8f2a56e90d656e8fcb8bcd656932f8686f482"
+    },
+    "progs/polyp.mdl": {
+     "bytes": 211928,
+     "sha256": "36268021903129e7e0e81600072ff3b38229cb6851cc6800945d9810510fad0b"
+    },
+    "progs/polyp_t1.mdl": {
+     "bytes": 66925,
+     "sha256": "82f5f86f210e8cfc541259a3a9efe7b0b4a046f5b5240c5d39ab08a021a4e2ee"
+    },
+    "progs/polyp_t2.mdl": {
+     "bytes": 65473,
+     "sha256": "130699464f89836047b7bf6b4ad0ac7feee810dd31da5add2892e1f61ed07a30"
+    },
+    "progs/polyp_t3.mdl": {
+     "bytes": 64069,
+     "sha256": "72a5a60e71e09a4a0e73dba0658b301540b3d871ec4ea88e24ace135db19d046"
+    },
+    "progs/polypgib.mdl": {
+     "bytes": 5716,
+     "sha256": "dc2aae40f92f8c75057a664b583f9d790d010289e858b218adfc92de6d6be878"
+    },
+    "progs/s_bubble.spr": {
+     "bytes": 396,
+     "sha256": "f7efaea9964c8ad347f170dcfd2a6dbe5bfcf8dc074cffc385cfbf28f991c13d"
+    },
+    "progs/s_light.spr": {
+     "bytes": 7344,
+     "sha256": "45ae7c364a43b76d834476f49fe6c35423330cce41d8f3dbc90780f561bb51e7"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/s_plas.spr": {
+     "bytes": 5256,
+     "sha256": "ed01b728b6656a68acffe258d644712eba3b786434ab6b3e6d90434031e90d96"
+    },
+    "progs/shockwave.mdl": {
+     "bytes": 167520,
+     "sha256": "861ee3b0ab6edd5233740a609c4367c5ebe4108ffb03124861bf85047a314f5e"
+    },
+    "progs/smlexp.spr": {
+     "bytes": 105148,
+     "sha256": "ce4938c9e813e648404b25b82245cad4400682d885d044b9d353a8039cfdceb7"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 565441,
+     "sha256": "9d3da38ea15726d8543413120414d4178efd900fd131a7fd84eff5a305df21f5"
+    },
+    "progs/spore.mdl": {
+     "bytes": 13469,
+     "sha256": "fc9fbb97f0d4f1a9f843769cd43fb7270ba2b351cdf3b4b624d27616980457c4"
+    },
+    "progs/trinity.mdl": {
+     "bytes": 13249,
+     "sha256": "3e0d4636dfd20112bd5415e92c1d8f85fdda65a9a33b09111cca2bbf4561f349"
+    },
+    "progs/v_bomb.mdl": {
+     "bytes": 80804,
+     "sha256": "48c2393efb079787f56be5ab6fd0dc3e748b5ef009ba15830fe0f9898ad94b7b"
+    },
+    "progs/v_ham.mdl": {
+     "bytes": 84563,
+     "sha256": "76f03b4e5d8222c2c3b3d2f0e1156ac90708a42f4997f6a4555c01073dab49dd"
+    },
+    "progs/v_lance.mdl": {
+     "bytes": 87209,
+     "sha256": "5c50ded5952ab06ca91ff413edf17a167b21bed88b027571e643ffc515a71560"
+    },
+    "progs/vermis.mdl": {
+     "bytes": 656752,
+     "sha256": "d7060475e290482c61c122b3a477085b1aad002fd71d8293cc4a4f8bde1baec9"
+    },
+    "progs/vleg.mdl": {
+     "bytes": 4904,
+     "sha256": "cc9ac24012d342ed54eb1a3241bcc6baf16e40fb95a904a789845ed76b8606ba"
+    },
+    "progs/voreling.mdl": {
+     "bytes": 41852,
+     "sha256": "b10f3623291b5182ab6b987cef1c40abc362aae41638b8481709660e923cc46b"
+    },
+    "sound/ambience/nightmare.wav": {
+     "bytes": 34284,
+     "sha256": "2caac27dfee5758eb293e0c76bf86baf82b0522c6f71281160e805c6ec282f96"
+    },
+    "sound/ambience/thrum.wav": {
+     "bytes": 220542,
+     "sha256": "c925d73ef744b0a8c56507ff6fb18888de7ab803ea1f743060f8f9782180dcc7"
+    },
+    "sound/bob/death.wav": {
+     "bytes": 14348,
+     "sha256": "7f97f27dfda78f9fe6fc5265e512b651e57ae466752d56cfe0dccd6d08478ed8"
+    },
+    "sound/bob/explode.wav": {
+     "bytes": 36898,
+     "sha256": "e00cd6cf71662de858fd0b8f63409217c957d6e3dea571b759fe97aec9d58724"
+    },
+    "sound/bob/fire.wav": {
+     "bytes": 36040,
+     "sha256": "5f39b9f60c5de5c9c3ac25a5149f1fef557e66c09d7d1a760ed6770082c5a914"
+    },
+    "sound/bob/hover.wav": {
+     "bytes": 13260,
+     "sha256": "46441335fe896cb993368bb12cedc1ddd4886b5933298bb6a0d6b7ba430cdfe5"
+    },
+    "sound/bob/idle1.wav": {
+     "bytes": 44460,
+     "sha256": "de548d73ab2d96ea9d550b86e264d430b8c0429cd99dd10404f52780bda6c683"
+    },
+    "sound/bob/pain.wav": {
+     "bytes": 27006,
+     "sha256": "d5d07123eb3c15917dc265cfa6df8971ab215f4408847225827359e1c175ee6b"
+    },
+    "sound/bob/s_explode.wav": {
+     "bytes": 30700,
+     "sha256": "94f9b780d25154f8c04cbe297a4aeda13fb0669c0a21e48e2b46f0102c35375e"
+    },
+    "sound/bob/sight.wav": {
+     "bytes": 14892,
+     "sha256": "1a0db2b8c8d763f9aae09913d1cd3548fa0e30eb03949e24ef511a70acfda303"
+    },
+    "sound/defender/blip.wav": {
+     "bytes": 23416,
+     "sha256": "b9b7bd7024eee0611a3a2ba545482e49a22ab59ead62ccccbc15762a753c58da"
+    },
+    "sound/defender/breathe.wav": {
+     "bytes": 32676,
+     "sha256": "7b673b07828790504caca013c18bf697fd53b758a3638b949b433cf2d72f03f3"
+    },
+    "sound/defender/sight1.wav": {
+     "bytes": 18260,
+     "sha256": "7d57825c28cf4f93189261d76cccab676aeba097920114d5d3f48d7eddaaa1cd"
+    },
+    "sound/defender/sight2.wav": {
+     "bytes": 18248,
+     "sha256": "b8b54fffdc7e2bfea51172cb8147407576f799181c1e6c2402433a546d8ee1c2"
+    },
+    "sound/defender/sight3.wav": {
+     "bytes": 17064,
+     "sha256": "25b7fc4212184996a7027211c543018f1dff539d3f9355f82a8da498d52b7a33"
+    },
+    "sound/defender/sight4.wav": {
+     "bytes": 16714,
+     "sha256": "deee8172ce02140002369c9807c513421a312240221113d86244e36300866758"
+    },
+    "sound/defender/ssg.wav": {
+     "bytes": 38828,
+     "sha256": "5c4e3a9baeec3f714ed00f2585d04256ac33582db911a026fdc56dea7f0a7dfa"
+    },
+    "sound/dguard/death1.wav": {
+     "bytes": 30610,
+     "sha256": "af3809501261ec4d0afa6ea7301c11a5c7bbc1cc3e06b8c88172ee0214c30969"
+    },
+    "sound/dguard/death2.wav": {
+     "bytes": 43636,
+     "sha256": "93a70fc0d6fee819c723a435a3954b3fd3be86e358698ce85db1062990d1575e"
+    },
+    "sound/dguard/fire.wav": {
+     "bytes": 60820,
+     "sha256": "f5e5d4f6ccc0778c1396c66d327564a0b1892773f2c23d2e30590abf0c758bd2"
+    },
+    "sound/dguard/hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/dguard/idle.wav": {
+     "bytes": 20498,
+     "sha256": "45b2f208b9796d19d7aeb0cba64e4b0e5fd2ed7c980123f7c41ca10d17785021"
+    },
+    "sound/dguard/pain1.wav": {
+     "bytes": 10380,
+     "sha256": "9a367afb7cde241099c58c999e225ba939be39f21be818b16444f5a810049960"
+    },
+    "sound/dguard/pain2.wav": {
+     "bytes": 14892,
+     "sha256": "827a1e4d3c9983f61fffd61de33054274c144bddd9a68460b496fd6281cf9406"
+    },
+    "sound/dguard/sight1.wav": {
+     "bytes": 18124,
+     "sha256": "9cb3d960261d90ec16c9883f4326c905356b6ff4e99cdf48ab5913b098588016"
+    },
+    "sound/dguard/sight2.wav": {
+     "bytes": 18022,
+     "sha256": "35ee4b7ec6715c8c9fdc24f90ad0b5d90a0ae7a4986168cf40670e87c325d5db"
+    },
+    "sound/dguard/sight3.wav": {
+     "bytes": 19948,
+     "sha256": "c6818770267626dea27f4a72ce2249771f6968924022c2275a5a96abfa485044"
+    },
+    "sound/dguard/sight4.wav": {
+     "bytes": 20332,
+     "sha256": "7affcdbdc62f13e492a15b54fe642fe045641f5551f570cc3c8d5f7ee29521fd"
+    },
+    "sound/dguard/slash.wav": {
+     "bytes": 22942,
+     "sha256": "44b60d785ff03f033e183b6fbce69e526351187d28efdeb308f6f8bea930d450"
+    },
+    "sound/dguard/slhit.wav": {
+     "bytes": 31956,
+     "sha256": "0f07a131640f21337cd89a772588ecfc707d6a729f96b54c21920b809cd620e4"
+    },
+    "sound/dguard/slmiss1.wav": {
+     "bytes": 10458,
+     "sha256": "e32d5cb070a13fad979b021e84a727f71242305ade1af7bfe18c255f0f6dd548"
+    },
+    "sound/dguard/slmiss2.wav": {
+     "bytes": 13840,
+     "sha256": "f6b3aee08c25434d2fda7468cacf35a0912b182653a45991149b54a0fc4be537"
+    },
+    "sound/dlord/death.wav": {
+     "bytes": 32022,
+     "sha256": "0188f6a3dd88686e15311f8c39c4277078e55bc0ec75497e2eb534af717abcdb"
+    },
+    "sound/dlord/idle.wav": {
+     "bytes": 9906,
+     "sha256": "c0ee37f80013dad1aaeb285a11a33c4d7c2ff2de0b2a94c2943d3fbe1c241bcd"
+    },
+    "sound/dlord/pain.wav": {
+     "bytes": 8632,
+     "sha256": "230ed5c7d024bfa90b973649aa79d9e9327eaf401b1632e4a1334fb4a9eb075c"
+    },
+    "sound/dlord/sight.wav": {
+     "bytes": 28028,
+     "sha256": "d82aa0028754e826705961040e1ab27f007c572a28c63dbcaeefeb681bc3ca85"
+    },
+    "sound/doors/eldertry.wav": {
+     "bytes": 76358,
+     "sha256": "769f4e43083dfa153a2cfdfb11c09920757a407c871f82957dbc9120de140230"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/explode3.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/sight2.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 83982,
+     "sha256": "4b0d8db882ab1c9fc2109effeaf125ec46fb23a91ac2242201103e0d3da96944"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gug/bile.wav": {
+     "bytes": 54572,
+     "sha256": "e06787585ef0369798a938a1a9585d24b60aa7b5c65acda3a5fb6f2c7ab65aca"
+    },
+    "sound/gug/bileatk.wav": {
+     "bytes": 50040,
+     "sha256": "b4b05e2907789a78391ccfe8ced3902821f1097ecd1f894b12ba9278d31a8717"
+    },
+    "sound/gug/death.wav": {
+     "bytes": 132396,
+     "sha256": "20bf209a832381b77d37c54a84ab1819b6c71e2147c5d122ac62668c070167a5"
+    },
+    "sound/gug/gquake.wav": {
+     "bytes": 43350,
+     "sha256": "d232ae13b55cb5b10b8903db43c037a5c6c4cdfea1f84f9399133484df6e0175"
+    },
+    "sound/gug/idle.wav": {
+     "bytes": 50580,
+     "sha256": "ff33c63696dec5c582ff9a4537814299b47ce2480d6cc53c116721d793576fda"
+    },
+    "sound/gug/pain.wav": {
+     "bytes": 22064,
+     "sha256": "e559f2b372fe771207aeef4b1c3a71baca542863493776558ae3f933f3878c29"
+    },
+    "sound/gug/quakeatk.wav": {
+     "bytes": 65882,
+     "sha256": "2c07b7690356bd9233a79c1f8b5f4e146cbabc367a19c138d6719a1e0d09328e"
+    },
+    "sound/gug/sight.wav": {
+     "bytes": 76426,
+     "sha256": "210ed86a5d6f9d4e791954fc3a4e4b4b6dc5839d02f7c19d468493a2f87dca64"
+    },
+    "sound/gug/step1.wav": {
+     "bytes": 15494,
+     "sha256": "4e2ce285991bc0d4337c77fdbb029507697ecb4dbf6543ddefe976ea114c4214"
+    },
+    "sound/gug/step2.wav": {
+     "bytes": 15502,
+     "sha256": "27f6f770a52fce5ae04836706e63ef455555de086019a2f9e44d4da1fc99b03d"
+    },
+    "sound/gug/step3.wav": {
+     "bytes": 15502,
+     "sha256": "fcc7ab38a8ec28509d0aa062a3cb93aee6da6a0ae364e4fe0dfad791f54558af"
+    },
+    "sound/gug/step4.wav": {
+     "bytes": 15502,
+     "sha256": "fc52cad29cca2e1fc36f5c6ac7f955ed897d6da4fb5dcf4eefd052e0652d93e7"
+    },
+    "sound/gug/swipe.wav": {
+     "bytes": 16064,
+     "sha256": "90bb5831dfd19f65df19e97f76d858ec940d8e33e0a2ed8fad89a23947e430e5"
+    },
+    "sound/gug/throw.wav": {
+     "bytes": 23180,
+     "sha256": "5e901b94e7be364536603273f18791ab571c46c2fc74263774c0e312f873a281"
+    },
+    "sound/items2/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items2/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items2/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items2/trinend.wav": {
+     "bytes": 79450,
+     "sha256": "6edc4b653c671187012e5ad6a95f777a861ab18a1d27b69a10912b459dab2577"
+    },
+    "sound/items2/trintake.wav": {
+     "bytes": 73428,
+     "sha256": "b26c0f0af98016163bf1fc7c4376ca90dfa4ad447e31a04fff9d8c9d820cda86"
+    },
+    "sound/items2/trinuse.wav": {
+     "bytes": 16990,
+     "sha256": "ea0b2b20b8137da8388bab00812218a47049183a7d4eb031449b975289de4ed4"
+    },
+    "sound/misc/elderkey.wav": {
+     "bytes": 55212,
+     "sha256": "70af94f89ca397badfe01eadc36b1375f3d219ecd8c19f691a4a6cd257cf9e7b"
+    },
+    "sound/necros/dias.wav": {
+     "bytes": 412204,
+     "sha256": "2de75ccc9f971c3c56b87c145ac96cfc7d3e13a758c89081133389d13399606f"
+    },
+    "sound/necros/drivshft.wav": {
+     "bytes": 385808,
+     "sha256": "a84800586cff4027335aa94cc05e0f5a0d88ab2404cba7a5ccc40c3581ffb981"
+    },
+    "sound/necros/forebode.wav": {
+     "bytes": 97960,
+     "sha256": "5dc4a7a6c7c2444595c0a7511ec8e1d5913211591202cd9a0e478588e1939c0e"
+    },
+    "sound/necros/gen.wav": {
+     "bytes": 136482,
+     "sha256": "f0d4932c1bc41d8701dee215fe04ec5f8667ac1de980d9d6158eef7f9e3e7fe0"
+    },
+    "sound/necros/gen_fire.wav": {
+     "bytes": 182316,
+     "sha256": "da244c2acc4a6b496330f1b7202a3f3d68ff61bc0e7e1c0a66a4208fdb66e9db"
+    },
+    "sound/necros/highwind.wav": {
+     "bytes": 158882,
+     "sha256": "41decf2ffe971f07420ab67deb227a285246d92eb01f77284920f01cc3652284"
+    },
+    "sound/necros/irulan.wav": {
+     "bytes": 196396,
+     "sha256": "52fc652f8b7814d4d28252f421e7ecebad629dd4c613e73adc643d67dabab3d5"
+    },
+    "sound/necros/sgatehum.wav": {
+     "bytes": 128670,
+     "sha256": "1a06f2e664cf213248990ee27ec117a46a4ba6ea6067b114c896cc9500f4fa99"
+    },
+    "sound/necros/strongwind.wav": {
+     "bytes": 133538,
+     "sha256": "fbc3ce4f537ebaf9603c6c4de350f06b2373f420e5c47a300668942ecd1a9064"
+    },
+    "sound/necros/tld_stop.wav": {
+     "bytes": 72304,
+     "sha256": "b58180629cb28e31b5fa0e00fc74c2c75841dbdcb778674509877d40abdf51df"
+    },
+    "sound/necros/tld_strt.wav": {
+     "bytes": 101584,
+     "sha256": "66ae791b7a06a8aa233d59bafb63d7b4ecb71be8b6ffc50c6794ea71807fbefa"
+    },
+    "sound/necros/tshaft.wav": {
+     "bytes": 221356,
+     "sha256": "95690f3dca8be51dcf789f5cb8977f37c20257b9b7bc84a4c57caa3aba0316a7"
+    },
+    "sound/necros/wat_amb.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/necros/water6.wav": {
+     "bytes": 45870,
+     "sha256": "d7505b517d6573f661739d765222c33d9ac1a86da362328d5635fc8634c9d823"
+    },
+    "sound/necros/woodmve.wav": {
+     "bytes": 70716,
+     "sha256": "bc27833a4d5b60b2212311cfefa7e8e04333e7a0c1efec939048a050bef4ab15"
+    },
+    "sound/necros/woodstp.wav": {
+     "bytes": 58554,
+     "sha256": "a86696cbcc070443f939497ba76c1e2c101bea2534dcc0993523031c6f500a2e"
+    },
+    "sound/polyp/blast.wav": {
+     "bytes": 25036,
+     "sha256": "0c3942daeedfa438ba36bd31481f7b24b067cab3d167c9e5cfd1cf3c498bf367"
+    },
+    "sound/polyp/cloak.wav": {
+     "bytes": 46252,
+     "sha256": "31cb79048b0c511ad0d40989785d835584c4c808025b8eb8060a74b36c9bca39"
+    },
+    "sound/polyp/decloak.wav": {
+     "bytes": 91152,
+     "sha256": "e2ee4693b0e466c5bc229db186257254c381c6a6985e71b02b20838859bcb5ae"
+    },
+    "sound/polyp/gibsplt1.wav": {
+     "bytes": 19580,
+     "sha256": "e9b7b73242aa04fdb6aed5de1c343ced81b15d6f78dde07097826b78bb1f87a0"
+    },
+    "sound/polyp/idle.wav": {
+     "bytes": 17750,
+     "sha256": "4edd47fe2508cb818ce36916a16c6e4c7cea4f61ff0310b7195e74bccc4f5d2b"
+    },
+    "sound/polyp/idle2.wav": {
+     "bytes": 22210,
+     "sha256": "b07894dd93545ed0c54fabae04f139c371a8b36ab84fc399f870f813b535000c"
+    },
+    "sound/polyp/sight.wav": {
+     "bytes": 11664,
+     "sha256": "a9c414ba4ca74fa3e08018af695674ede79a2f63aab26be0566dda9426eaef43"
+    },
+    "sound/soldier/load.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/soldier/rocket.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/vermis/death.wav": {
+     "bytes": 148016,
+     "sha256": "44b26a9dca5ec8d5e8a7ef2b5e38196b74e4f606cd37b906ee2b2e5b5a85b08f"
+    },
+    "sound/vermis/grab.wav": {
+     "bytes": 88122,
+     "sha256": "09528bd0d49d5cac0c03fe7994b57e572eb89aa8bce63cd0a591130e4b2126ae"
+    },
+    "sound/vermis/grabbed.wav": {
+     "bytes": 51630,
+     "sha256": "99583c88b8ec2959a0d69448aee16ec86b3d9feee6df7841fc32759598349376"
+    },
+    "sound/vermis/grndhit.wav": {
+     "bytes": 36428,
+     "sha256": "1f0e78fa08efb4617b6967a6cc218c56af227c7fd6bf039420d8f106d74fca72"
+    },
+    "sound/vermis/pop.wav": {
+     "bytes": 131420,
+     "sha256": "6284ab02e604b44c5b07225b2a0544c8707517d5fec0024c127bdafef2704f70"
+    },
+    "sound/vermis/sight.wav": {
+     "bytes": 137772,
+     "sha256": "d892117e4602595b6dfb65563b8fa7a3ad2171851791f7c6f47ea4bfece76296"
+    },
+    "sound/vermis/sight2.wav": {
+     "bytes": 106780,
+     "sha256": "6132e2d0db5cfb7a1a064e708d97f7258e2c6ac15c6f4ea8d520641e0ad10f9d"
+    },
+    "sound/vermis/splash1.wav": {
+     "bytes": 30710,
+     "sha256": "f931a2927c13cdb2523dde4550c0af993cc08cbea6e332739f9cf6fe3bd1ff8b"
+    },
+    "sound/vermis/splash2.wav": {
+     "bytes": 25332,
+     "sha256": "b91c69ee695bd71537ed018800f7d89e5e7d95332124f69adee39261d84d7c13"
+    },
+    "sound/vermis/splash3.wav": {
+     "bytes": 25590,
+     "sha256": "99fad2f3815a30ef645a2162ea24e54b4302ba00d7551af9299fde74ecce98e8"
+    },
+    "sound/vermis/spore.wav": {
+     "bytes": 44204,
+     "sha256": "d01a27af99745725dae124d30af18458b2ef323bce93c3cad939310e0f47f6c7"
+    },
+    "sound/voreling/bite.wav": {
+     "bytes": 8920,
+     "sha256": "a5bbebd7178205c400115846314709fa22c4db390fafbf3abaee2e33342e1a0c"
+    },
+    "sound/voreling/bitestrt.wav": {
+     "bytes": 11132,
+     "sha256": "be72b6a15a73bda266331309046229fd6f94b0856f4dfc306204e6266ad1cb59"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 19584,
+     "sha256": "e5bc7634816b927c305679e9b0ff3e4f33a2d09cb5e80db3c5dd04373ba452e5"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28378,
+     "sha256": "b9daf80e6bc998d521cd35f6d8ef74295f39fafbb71f6d6cfe8f0e7c1fb3f0ba"
+    },
+    "sound/voreling/land.wav": {
+     "bytes": 6154,
+     "sha256": "92f08d203711dbd3bc2049ba61a62938b4eb34a9c7285c26406da3b29bbdfba2"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "0b6c021bc7301757918201ad1175387eabfc0af4f6e8b94e273ba22a2aa6c53c"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 55972,
+     "sha256": "9aaaebf47f82cd7a521800aa9d81d14bd2747735481cb15b88ce104cf1568b6f"
+    },
+    "sound/weapons/bomb.wav": {
+     "bytes": 141228,
+     "sha256": "6fa171d6bbb3dc07f9c0fb422ceb2e3e20934e9a0465589717dfdc14c92b016c"
+    },
+    "sound/weapons/bombfar.wav": {
+     "bytes": 246316,
+     "sha256": "12334d1af40522f124564f354acf44f419d1e1477cdef97d0f790ab52a38d765"
+    },
+    "sound/weapons/dryfire.wav": {
+     "bytes": 47872,
+     "sha256": "d119284b7e97ab626587b20349eb5c2a90489b37df85a1fec52c98962185da06"
+    },
+    "sound/weapons/expl1.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/hamhit.wav": {
+     "bytes": 2434,
+     "sha256": "7754c2ab32c5d34473e4fe4977f9aa1b326a622431b44b599c798c7a0fbe2b60"
+    },
+    "sound/weapons/lancfire.wav": {
+     "bytes": 6520,
+     "sha256": "be8d154ba1404462776ec3f5fbbda0e974970dd5d61d97cf296c3711ede5bb84"
+    },
+    "sound/weapons/plasexpl.wav": {
+     "bytes": 54406,
+     "sha256": "961fb4304057542e630f7394dfbe5a0682b2eb1398abb7d312a712a178a5c75b"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 164,
+     "sha256": "ba0d9dbe33691183ef2549fdd006a02e21ac209f1d51271018e9bf565793c1cf"
+    },
+    "textures/+0bfall.tga": {
+     "bytes": 24594,
+     "sha256": "e16452c0adf12a064b2c78dfc9c10965fde399cac99076f29486bd434865d20f"
+    },
+    "textures/+0wall58.tga": {
+     "bytes": 24594,
+     "sha256": "dc10523848dd691e477cb7dc3c8f8926bcaff43df0bc8aca5b4814ec9e416ca0"
+    },
+    "textures/+1bfall.tga": {
+     "bytes": 24594,
+     "sha256": "f0ccb330e0668af52906c3bb8ca56513e49ec4b7d3a10a1af8fa1e552c12aa9e"
+    },
+    "textures/+1wall58.tga": {
+     "bytes": 24594,
+     "sha256": "6a3071293d6c5833f71dd9dc6400a8971a42fa08d975139286412863a2afa15c"
+    },
+    "textures/+2bfall.tga": {
+     "bytes": 24594,
+     "sha256": "5a4839cf5a9bfaa3e0eaf6419502aa9b68941a76a82aaffcbb42ccc16b7251ad"
+    },
+    "textures/+2wall58.tga": {
+     "bytes": 24594,
+     "sha256": "2e21abc263631a86253f1c7c3d85b1e1706656a8ee2a4946c083d4da188e6c98"
+    },
+    "textures/+3bfall.tga": {
+     "bytes": 24594,
+     "sha256": "0cd9f7f04e1d94c5aeac21a22be9b085364b76f80255d2111f080d25b9571272"
+    },
+    "textures/dem1_5.tga": {
+     "bytes": 12306,
+     "sha256": "3c7981d83daaf54eac8c7fc3eb917f3b37206f04f7217c5f61c72ddcfa4e4e7c"
+    },
+    "textures/dem1_6.tga": {
+     "bytes": 12306,
+     "sha256": "c605259684bfcdda9c7439aeb1625b753b39ec326b199b79708aeed4e94192c6"
+    },
+    "textures/door11_1.tga": {
+     "bytes": 49170,
+     "sha256": "e41bbe8d0b3c06e3e63335e54e76a9ff46f746d97521d423d26e843e1c73339e"
+    },
+    "textures/mwall1_1.tga": {
+     "bytes": 49170,
+     "sha256": "74618ddeed744fa78d55d52332bba75e3e8e4bb10801968c4e7fa434a3145424"
+    },
+    "textures/mwall1_2.tga": {
+     "bytes": 49170,
+     "sha256": "ef9f0957aab307dfd959a2fbdfba0746590bf72543e3e9c267e82825a4153df9"
+    },
+    "textures/mwall2_1.tga": {
+     "bytes": 49170,
+     "sha256": "8aaff86f44b797ac6744f13e99935f89ae7220f47ad640a376c0f65e0c2a0ac9"
+    },
+    "textures/mwall2_1_red.tga": {
+     "bytes": 49196,
+     "sha256": "9e8e232605d1e957cc37436c1bf6fe16c733aed297e2b2f821cc98d1f03d2611"
+    },
+    "textures/mwall2_1_red_tr.tga": {
+     "bytes": 12332,
+     "sha256": "95fe8beaead00d82042e00c633772c98512448b8ede744f8dd19e6d073e8ac2f"
+    },
+    "textures/mwall3_1.tga": {
+     "bytes": 49170,
+     "sha256": "7177eaddb4df53978e97d461bdb3691bf5cfa85f37518975577702f2e1018aad"
+    },
+    "textures/mwall3_1_red.tga": {
+     "bytes": 49196,
+     "sha256": "4382c35808a81d43b349482e135f7362748a059e7f0d12c564c9907e10c634ba"
+    },
+    "textures/mwall4_1.tga": {
+     "bytes": 49170,
+     "sha256": "e9692306843a29a826fe2d680cd120f6f2503cce23c8e2dac9709459e892268f"
+    },
+    "textures/mwall4_2.tga": {
+     "bytes": 49170,
+     "sha256": "60a8569f93461c4180be984e37adfe2ca24f3d04daab19d492953dcbc16f8055"
+    },
+    "textures/mwall5_1.tga": {
+     "bytes": 49170,
+     "sha256": "fb7d723160581302ff0dd079e93d8a8dc54b2a6304a1fecdc77934b19b1e15ef"
+    },
+    "textures/rw15_1.tga": {
+     "bytes": 24594,
+     "sha256": "d1becff2637e213ef94cef4134429ae3cdeb821f3e84aab230dbacb94c6518c2"
+    },
+    "textures/rw15_2.tga": {
+     "bytes": 24594,
+     "sha256": "91ab56c9f1621de1c386fabdb6aac1814ab0154d88452fee0c4a1bab89d653bf"
+    },
+    "textures/rw15_3.tga": {
+     "bytes": 24594,
+     "sha256": "abe1fda7a20c0aea206ad57beaf736829e2024509b2e8cc8164a9b23177a623e"
+    },
+    "textures/rw15_4.tga": {
+     "bytes": 24594,
+     "sha256": "745948c0cd48e6e01068a0f1305481c1c806e3e838ae22c3d142bf0e91c0943d"
+    },
+    "textures/rw21_1.tga": {
+     "bytes": 12306,
+     "sha256": "935b7aacfa98763e85ed7d6775a742815ec6112aede7a5ff148d90b52a6dcfa9"
+    },
+    "textures/rw21_2.tga": {
+     "bytes": 6162,
+     "sha256": "42fb2832ac2eec8cd73a3444cb75c0021581e899b02e94ea333c98fb112c9829"
+    },
+    "textures/rw21_3.tga": {
+     "bytes": 24594,
+     "sha256": "4f8537864f72db12061ce70d9baab17c98031e781e058e4adf38e0ac34a21ea8"
+    },
+    "textures/rw21_4.tga": {
+     "bytes": 24594,
+     "sha256": "fc2677db2925f405ea9225d4c6d8e5c0e2f5e713f9074deaa78a8d491aa6f1bc"
+    },
+    "textures/rw21_5.tga": {
+     "bytes": 24594,
+     "sha256": "a7527f4ad249827052c1ca3415a36c5a965975cae2d6aff799236e7eb5a59cbf"
+    },
+    "textures/rw26_1.tga": {
+     "bytes": 24594,
+     "sha256": "ba91b31bb38fe81f0ef7e08f32b6d7ee27f4ef2d54909bed9c7302d823198864"
+    },
+    "textures/rw26_2.tga": {
+     "bytes": 24594,
+     "sha256": "686fd937365107bc99daaf6c8d419cee027ffa9da50eb70b5e10cb8cc5398dea"
+    },
+    "textures/rw26_3.tga": {
+     "bytes": 24594,
+     "sha256": "ca4cb9d2d9637f9f676aeb9178a2b4f8a8c084bd1678d9787a88a159e7513f93"
+    },
+    "textures/rw26_4.tga": {
+     "bytes": 24594,
+     "sha256": "735df64fc6e627139b4f76228e49831c051948cc7c0a734924680d3472087f16"
+    },
+    "textures/rw7_2.tga": {
+     "bytes": 24594,
+     "sha256": "caba2d8cf9ef2d9c90c0aae3b43b2ec2f86d1c14bc085ef5e78a63edbc437c2c"
+    },
+    "textures/rw7_3.tga": {
+     "bytes": 24594,
+     "sha256": "b0daa16c1e9a25055618e3692a5fe0fc766e3d66b0a8ab19022744112bf4a340"
+    },
+    "textures/w105_1.tga": {
+     "bytes": 49170,
+     "sha256": "2830a744ca1a7c6ce8ad63675d71ec545e87c7ed5c18a3f8a9af4defedb4dffa"
+    },
+    "textures/wall30_2.tga": {
+     "bytes": 24594,
+     "sha256": "d14e42b6469b059bf66c766ccca4a1ad11140d48ea35068f58ec0ffd46384950"
+    },
+    "textures/wall30_2_red.tga": {
+     "bytes": 24620,
+     "sha256": "49c5e077694909aceff34f9e192b7e7d3c9d3ff18e3018d4b03e60970d366d60"
+    },
+    "textures/wall30_3.tga": {
+     "bytes": 24594,
+     "sha256": "04a5bfd1dbf4254e63e3a2ca206bff20deccfe4902195a4037cc1c340a5e5ea0"
+    },
+    "textures/wall30_3_red.tga": {
+     "bytes": 24620,
+     "sha256": "146f5aa381d2649d9f7104c749642e400e5b3912ce568eb48bd966e58817bdd6"
+    },
+    "textures/wall30_4.tga": {
+     "bytes": 24594,
+     "sha256": "e6d90bebd4adb579791a718b9190a4a6603c82f0b41db1658c1fccb3ebd9dc8b"
+    },
+    "textures/wall30_4_red.tga": {
+     "bytes": 24620,
+     "sha256": "f4afc3527f258ea27cadb656314716bca6d3d16286539694572dea795be361ba"
+    },
+    "textures/wall48_1.tga": {
+     "bytes": 98322,
+     "sha256": "bcae8399e797e1c6413de7c7bde9435cee13d77f100e948444153201232083e9"
+    },
+    "textures/wall48_1_red.tga": {
+     "bytes": 98348,
+     "sha256": "73f1c4781c0c7c639d6779138060e394e525ace2e61e7fa84f5611beabef11a3"
+    },
+    "textures/wall48_vine.tga": {
+     "bytes": 98348,
+     "sha256": "d7de6acf61f49c1cfbe5d59436835b67cd5d1250e8b667b80b08d87a84e5381a"
+    },
+    "textures/wall59_1.tga": {
+     "bytes": 98322,
+     "sha256": "a3f2bf922132dd358fdbb2a6d501bff14ad38c7a762ffd9068048ceba6d1dfeb"
+    },
+    "textures/wrcka1x.tga": {
+     "bytes": 196652,
+     "sha256": "c78a5aea451c6915b26f7e3327581c270a65420bf23ce8b8c3dbd9bc9d664318"
+    },
+    "vongug.dem": {
+     "bytes": 1079956,
+     "sha256": "5228133bc5b5e3e0a11747b93eb0f5bca355e65be0b60527304a54cdc32d9e2a"
+    }
+   },
    "sha256": "ddace91ad8a3e3d436c95efea430f5dbd8a319f511a6f7d2d05ac6fffc68ffe6",
    "timestamp": "2008-02-06T21:38:00.000Z"
   },
   "pak1.pak": {
    "bytes": 84961704,
+   "files": {
+    "coop2.dem": {
+     "bytes": 1974743,
+     "sha256": "45c35c4ccf3eb06cd98d33e7aa17003b2f242c8271034036b0d4d3d41bf5cdff"
+    },
+    "gfx.wad": {
+     "bytes": 128932,
+     "sha256": "b9b298830f1c48cdc378d83b84e3b308f0ca3052c278d6b4afeb70fa4035ab7d"
+    },
+    "gfx/env/dawnbk.tga": {
+     "bytes": 791801,
+     "sha256": "3a415bd258f1d81bfddc5091dd67829e7b9c2d247c7d69ea263a6e743e3971e5"
+    },
+    "gfx/env/dawndn.tga": {
+     "bytes": 1032293,
+     "sha256": "33c9b1bc0ae74eeae43a90f44397cb3d2747ec40190f5b0bf28ce62d0943cf98"
+    },
+    "gfx/env/dawnft.tga": {
+     "bytes": 1206497,
+     "sha256": "1947bb641b84fd09cd9b0c17256f809fc13c81eca40520576d1ea3e2c57ea9b4"
+    },
+    "gfx/env/dawnlf.tga": {
+     "bytes": 1141280,
+     "sha256": "cc68776448bb864875e8e4ea181f6aa83800fa00ad15fca9f9ae3ac24b35d320"
+    },
+    "gfx/env/dawnrt.tga": {
+     "bytes": 1031739,
+     "sha256": "24be76b64c71f5a589f219ceccad23a68fc4e26f45a2a8a4183792bdbe7fc71f"
+    },
+    "gfx/env/dawnup.tga": {
+     "bytes": 1426811,
+     "sha256": "e4f5dabd8690dc8460d0032fba1d633d69222a242749803e960643d3cdd25454"
+    },
+    "gfx/env/daybk.tga": {
+     "bytes": 1885848,
+     "sha256": "81598177219150a0700e3ba1847157bbf1c7995d001989f64b6aa9a43f30559e"
+    },
+    "gfx/env/daydn.tga": {
+     "bytes": 1009895,
+     "sha256": "7bce7500395ecda3e1d82d30f7da1a5a7deeb78ccdd11cfd72a4e08114d2c0e9"
+    },
+    "gfx/env/dayft.tga": {
+     "bytes": 1997325,
+     "sha256": "40c45bca3df588c07cb5bad2783e4a4d2eddafb82d2a508993d8a0ef9374bd4d"
+    },
+    "gfx/env/daylf.tga": {
+     "bytes": 1914168,
+     "sha256": "f860f4796a517fb3280223cdbf4599bb77e681b27bd721d6fb50a98aafbaf19e"
+    },
+    "gfx/env/dayrt.tga": {
+     "bytes": 2080059,
+     "sha256": "dda11898b40d60a21e09d08bc31a785a02abe5a848da2b87d528d2b434c5a031"
+    },
+    "gfx/env/dayup.tga": {
+     "bytes": 1246252,
+     "sha256": "aedf3ba21436941882432c44cb791a4fc941409f229b256725d5c1c1b625329e"
+    },
+    "gfx/env/duskbk.tga": {
+     "bytes": 1364708,
+     "sha256": "2372a2a60805d3ef0d727edbe5b203d082b4b608c417e671b2ee39d40178bcbf"
+    },
+    "gfx/env/duskdn.tga": {
+     "bytes": 1310868,
+     "sha256": "1e96211accd4c0cc40c6ba54c22d1f1fee27433598f4cf74b7a242eed4dfcf06"
+    },
+    "gfx/env/duskft.tga": {
+     "bytes": 1367663,
+     "sha256": "9c7331e1f7ef1959776af623594fc2186b15362b300a67f8eb1e0fda4f4188a8"
+    },
+    "gfx/env/dusklf.tga": {
+     "bytes": 1426730,
+     "sha256": "65819e48a62862cdea4bce2f5dab063c8cc3b8ab2dd44d90e4f7fe329fbe55c7"
+    },
+    "gfx/env/duskrt.tga": {
+     "bytes": 1400147,
+     "sha256": "ec17749d0c623b05142fb4cadff8b29950ca8fb92a8e6ab02576a7d8a8be3077"
+    },
+    "gfx/env/duskup.tga": {
+     "bytes": 1327551,
+     "sha256": "2a40691f8439cd706cffe9b3d777dfb272a5c7306ab02912af0d19b151dda815"
+    },
+    "gfx/env/epiphanybk.tga": {
+     "bytes": 2336400,
+     "sha256": "520320d2d4bd655138753f1d036494129761ad93cfcca0b1e5a814d30c2828e7"
+    },
+    "gfx/env/epiphanydn.tga": {
+     "bytes": 2299843,
+     "sha256": "f95ab44b70525f6fc83737ab572de3a17308ac47ca28bb0bc938e7854659141c"
+    },
+    "gfx/env/epiphanyft.tga": {
+     "bytes": 2612108,
+     "sha256": "99aae0dea453bf26bd1622ef5136558833605054d38eb359dcaf451bb99d938d"
+    },
+    "gfx/env/epiphanylf.tga": {
+     "bytes": 2377534,
+     "sha256": "b44b482a9b308f8d6b7f12c2b359242ce22ec3a9d398dcd9afb446adb2f2703e"
+    },
+    "gfx/env/epiphanyrt.tga": {
+     "bytes": 2490366,
+     "sha256": "5b07aa824bb0c583c65576edef3f76a2bceb78bf4754d24e3ae349ce937eadcf"
+    },
+    "gfx/env/epiphanyup.tga": {
+     "bytes": 2350734,
+     "sha256": "08b91d998c2fe5279960c5d6c83c3bc79fa7600a10e6a8dd2a5fd678e5a34c8c"
+    },
+    "gfx/env/fodrianbk.tga": {
+     "bytes": 1218431,
+     "sha256": "3d8a751a50330bff69af3a63d772485bfc4e9ef9640076d98d4ddb5943201695"
+    },
+    "gfx/env/fodriandn.tga": {
+     "bytes": 752376,
+     "sha256": "58e65c036e28b02d9149f180919c9676343627e5f76ad87a2a27c8d3e114a34a"
+    },
+    "gfx/env/fodrianft.tga": {
+     "bytes": 996781,
+     "sha256": "699b065c4840785136c4cb969fda73e6b2ad9bc0f5f0c384f8076baf4196e5b2"
+    },
+    "gfx/env/fodrianlf.tga": {
+     "bytes": 1052142,
+     "sha256": "a5794f3e893c615505d5ddeffd48f25246a34341167670c304273bf812a35056"
+    },
+    "gfx/env/fodrianrt.tga": {
+     "bytes": 1011425,
+     "sha256": "c8cdb878f4d8ae894dd2531030132b92306a54cf7e7fab047e616cc8a0c3f063"
+    },
+    "gfx/env/fodrianup.tga": {
+     "bytes": 783041,
+     "sha256": "03e6c3eb578d533c5b46c8fd7bdb67a9e3d0cd1d6eb241b26feb353d4e1e6a23"
+    },
+    "gfx/env/graynightbk.tga": {
+     "bytes": 1771903,
+     "sha256": "d1173e9781c585cbf525374abcd1067cfd498c9dadb1d7d4febe69b890b9fa0b"
+    },
+    "gfx/env/graynightdn.tga": {
+     "bytes": 1901023,
+     "sha256": "fd464ebaa459ae2722860ad39fb613d44ac35f0afd914d52b5a9a4817fb81dce"
+    },
+    "gfx/env/graynightft.tga": {
+     "bytes": 1800892,
+     "sha256": "69b4ebc470c36ae1f0cb41824f981911503d2932bc0ee82f730254bfe59cc140"
+    },
+    "gfx/env/graynightlf.tga": {
+     "bytes": 1769279,
+     "sha256": "e988f1f6169479ce3515c046cc989e96fc5182d41faaa4c3af3ea9065a581557"
+    },
+    "gfx/env/graynightrt.tga": {
+     "bytes": 1788173,
+     "sha256": "1a969121d5e25cf04cd8bc059838ef74ba83f448d0e97aee22dba574bb802a8d"
+    },
+    "gfx/env/graynightup.tga": {
+     "bytes": 1660412,
+     "sha256": "2b282f7996ee8bc97d2140ead34ee6b5a62922c8b5ea30e147ffceb8a2b29e49"
+    },
+    "gfx/env/predatorbk.tga": {
+     "bytes": 1048179,
+     "sha256": "89021e04d172d32461f2eaff8aac30c750a9bac5bd165bb39b9b6210b374a3f0"
+    },
+    "gfx/env/predatordn.tga": {
+     "bytes": 1062175,
+     "sha256": "fb8b1483d01cb885165f3fe9468b568c278dbec2b07d2ad81c0574f5756336eb"
+    },
+    "gfx/env/predatorft.tga": {
+     "bytes": 953806,
+     "sha256": "09a5bcf66a64056b18d447a2799d090e8b4d1c5c6e54e1d6e6b6f5ea9f5f303a"
+    },
+    "gfx/env/predatorlf.tga": {
+     "bytes": 1007515,
+     "sha256": "3c5b93eabc11e727f24365ab0102b954d7a5f1eec8998776573fade8be49fa23"
+    },
+    "gfx/env/predatorrt.tga": {
+     "bytes": 1090878,
+     "sha256": "22ce280760e9330ca9c4a6c85994c0c98b7c83e7182562715032635d2956167e"
+    },
+    "gfx/env/predatorup.tga": {
+     "bytes": 1307351,
+     "sha256": "3ef7374f2b8a6ef6098f9ed07f85325b495917c1adb699df503b25a3fa5ebe0f"
+    },
+    "gfx/env/starsbk.tga": {
+     "bytes": 532751,
+     "sha256": "e74499e2d2fca2e86a1c1fa29a49a0074ee68bb02d6a4ad14a722087de83ffba"
+    },
+    "gfx/env/starsdn.tga": {
+     "bytes": 516841,
+     "sha256": "6e922014e7e2a7382c3b2c7c89af2b2a134722ab5838108efe881e9752a5a8cb"
+    },
+    "gfx/env/starsft.tga": {
+     "bytes": 545250,
+     "sha256": "b9d0a03dc6728f92db7572170a0f2bd49fe0d2e375578750ebca88f48d68262e"
+    },
+    "gfx/env/starslf.tga": {
+     "bytes": 540900,
+     "sha256": "e6aa8b634f0335fef501864ed21b24c1a7949c353eed10adca493bd7eb808ba8"
+    },
+    "gfx/env/starsrt.tga": {
+     "bytes": 528742,
+     "sha256": "e6ff0c6f8228e0890a722fb25457e7248729e407336f225bb6ff6d9f2aadd218"
+    },
+    "gfx/env/starsup.tga": {
+     "bytes": 540621,
+     "sha256": "629e2b1d4d8eb74014652b6e5e7c9fcebfe60b68d97fb6c25bb57c980e4436b9"
+    },
+    "maps/breakable.bsp": {
+     "bytes": 1924412,
+     "sha256": "1b7c46e6581380db7416e943ee4c31763de08159bc08aa1e1ccc0fb2eaf8f810"
+    },
+    "maps/e1m2quoth.bsp": {
+     "bytes": 4255536,
+     "sha256": "3d3cfa7ceceb18ca198270aa9df8da45988d1dd583759a5e41d5c3c0a691832a"
+    },
+    "maps/kellbase1.bsp": {
+     "bytes": 2346024,
+     "sha256": "8b84da3a5946a7b37dec18e5c6b3eaea4d536789ce9ec691c326ca365b95f86c"
+    },
+    "maps/kellbase1_fan.bsp": {
+     "bytes": 15508,
+     "sha256": "e018283c4f7ae64147a13f64ddced6e0f4f597492d677fa4e9758455d0ed6520"
+    },
+    "maps/kelltest5.bsp": {
+     "bytes": 539264,
+     "sha256": "4b9f25060b13bbbbe623e2b53c7cb5d0397e2362ac4dabf10486e676baafed1a"
+    },
+    "progs.dat": {
+     "bytes": 761082,
+     "sha256": "028ee957df11e12c26c6bb8bcf2f58e4b099a59797b78beebbce65a4f41d4cc6"
+    },
+    "progs/b_bio_l.bsp": {
+     "bytes": 11572,
+     "sha256": "e076780538e320d1a5ffcac210668e95edf63fce95edba192acdbbf0f634649a"
+    },
+    "progs/b_bio_s.bsp": {
+     "bytes": 6028,
+     "sha256": "1609a5f827eef414efe184ef62e8a7a7191208bef9e1593bd67724f19948b84d"
+    },
+    "progs/b_plas_l.bsp": {
+     "bytes": 11572,
+     "sha256": "5ab7b0e25b37c65ea87743bcbfdb482f5556d0595bae15eecb95ab8f1c8c2edf"
+    },
+    "progs/b_plas_s.bsp": {
+     "bytes": 6028,
+     "sha256": "58adae5e3ec3f32d65abbf74fb7fdad9bf19d6f33f2a4f2fe621b46867261322"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 331328,
+     "sha256": "046d34a681439138dca323f54e54d358e225d2d958b21b36ee564fe6d4be7b82"
+    },
+    "progs/brick.mdl": {
+     "bytes": 108308,
+     "sha256": "b566efdd77a56bc38866eb95d167b2e53b8453d4194dd641efe6a15a6d22a6ad"
+    },
+    "progs/c_ham.mdl": {
+     "bytes": 78908,
+     "sha256": "3ef97f78252e0c2aec063649102aad9765eb320fe172c24db29d8c08fac5951c"
+    },
+    "progs/c_lance.mdl": {
+     "bytes": 48404,
+     "sha256": "03d923d70944814497b47312137221bec8ed46c2e8f6681ebac07dfb5b5517c7"
+    },
+    "progs/c_light.mdl": {
+     "bytes": 63500,
+     "sha256": "d0c16e23a406b1833408e216e34759a5060b202e603889ac8c39cac92d6d9434"
+    },
+    "progs/c_nail.mdl": {
+     "bytes": 63324,
+     "sha256": "b98d0281f8958d5b7a50e795711cb9e7b04d73e417dfae13f64f17d1ffc52228"
+    },
+    "progs/c_nail2.mdl": {
+     "bytes": 79328,
+     "sha256": "088e8d8994344e46918df796a38e87d0dbe2ba0baf1ad9359e072ee538902551"
+    },
+    "progs/c_rock.mdl": {
+     "bytes": 67924,
+     "sha256": "c0d3b99d6edde1329011a6754f65caa55888421c94669cee26beda3c1525bb63"
+    },
+    "progs/c_rock2.mdl": {
+     "bytes": 65932,
+     "sha256": "6fa52810c7164815d909085f80d27e3cf60f2a9dc48547c877947ebfc045fd4e"
+    },
+    "progs/c_shot2.mdl": {
+     "bytes": 58572,
+     "sha256": "381c796447399a343a4dff310ba58942eb45168708ef3899a2043ceaefc86c14"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/flame_pyre.mdl": {
+     "bytes": 85180,
+     "sha256": "9df2ae13e72ffe5a305a6ce877b0284023520d5d34df751498a2003c3e420ebc"
+    },
+    "progs/flashlight.mdl": {
+     "bytes": 35596,
+     "sha256": "8442b889437acf210587a7d567ad71c839b978e7dcf27a580503a05983368c70"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41908,
+     "sha256": "52eeb2cb3923bccdf6960abbea3f39cee9c8e504c984c5ccaa7e218627fdb882"
+    },
+    "progs/glass.mdl": {
+     "bytes": 127788,
+     "sha256": "f1e6a01f984e742bfd4d6428878e356e736251b7d18ac65e84aae63fa807fc69"
+    },
+    "progs/greenexp.spr": {
+     "bytes": 24732,
+     "sha256": "52b354786534248048d517a16fea53ad54c39ff7c82185c45067daba31dbb522"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/grill128.spr": {
+     "bytes": 492156,
+     "sha256": "c1ffd3a6680099e228605480d83bc5929ecd5730c01d24cfbcff3f195b509b51"
+    },
+    "progs/grill64.spr": {
+     "bytes": 123516,
+     "sha256": "c8d559303231ce4a7a1c246bea0a24c322d249f3b1cea61114fc0816a73cc781"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 43931,
+     "sha256": "f87f4d5b690c6ca434e5ff904d02f33cae0ac9e44bac4350b9631f47e29f6287"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 28501,
+     "sha256": "24f0d69fa8e5aa9cf70fd2653dab9bbd59fff7985b895234f8b07d1a4546998a"
+    },
+    "progs/lightpost.mdl": {
+     "bytes": 44717,
+     "sha256": "bb226da110f4005ddbfd965ac52e4fa61192831bbbca4ec1f93529978a78e359"
+    },
+    "progs/lighttube.mdl": {
+     "bytes": 97042,
+     "sha256": "27fbc5b7625e6297507778c7e48c4d26303c7e15cb0febf4d7592a844522fc77"
+    },
+    "progs/medexp.spr": {
+     "bytes": 72892,
+     "sha256": "d9887be2c9837d713d3aef856c1fc9245a4628b76ecd9e4e50a28d0deee1a679"
+    },
+    "progs/metal.mdl": {
+     "bytes": 246933,
+     "sha256": "07c0bb9ff1aa1639a62e5a84fca28d48c0fc738f4d22f8e3d8a5a029790d870e"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "e0bd8b2d3da7f2d8bdd59c4664b9202f00fa6dbe8c6321fd3651b3e857edd6c3"
+    },
+    "progs/pickup.mdl": {
+     "bytes": 36332,
+     "sha256": "7d0e5cac5f2a9f5ce879d81499c770b246ce5fcce049e2661fb35d2b15cbd2b1"
+    },
+    "progs/plank.mdl": {
+     "bytes": 19967,
+     "sha256": "d0fd70c3bd6dc93d13b229d4e0fa804a32a6688ef9640b4cc6340d9dab5fbd3d"
+    },
+    "progs/plasmabox.spr": {
+     "bytes": 14472,
+     "sha256": "89432660fdfbbdd90c72639152666f38ea6e7016a1d13171bf2d2e63bd2f4e89"
+    },
+    "progs/reed1.mdl": {
+     "bytes": 95281,
+     "sha256": "65773f37e26d41dd72ec1cf9849c663c1475923cb77d0f4c599bc3301368373f"
+    },
+    "progs/rock.mdl": {
+     "bytes": 136476,
+     "sha256": "0f80e53002bee59dad6dfe6f73b1ba2287700bea1cdade8e1dd4c35ec9d212a8"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "0350089b0bcf3a63a5d7b1e0bd070ac993be60f652f9bf9e3cf48957d31d561b"
+    },
+    "progs/sentinel.mdl": {
+     "bytes": 290664,
+     "sha256": "573efd78767922b2bbb3e5dab2b16cd8f90c2cb1709ecf4a315a141f4df77d09"
+    },
+    "progs/smlexp.spr": {
+     "bytes": 105148,
+     "sha256": "ce4938c9e813e648404b25b82245cad4400682d885d044b9d353a8039cfdceb7"
+    },
+    "progs/tree1.mdl": {
+     "bytes": 57621,
+     "sha256": "8e450cd50b8dac1912e96ec78ff4a16e0b9065138d181fa58257973c2ee96578"
+    },
+    "progs/veg.spr": {
+     "bytes": 8340,
+     "sha256": "4248f027adca723fb0101abf5c51b604ca6aabf80d4ccd9aa305cd34e072a682"
+    },
+    "progs/wreckage.mdl": {
+     "bytes": 71364,
+     "sha256": "13763a8cec3b643acb9b8165f1850ffae003131c84a2ac225777822a88462498"
+    },
+    "quake.rc": {
+     "bytes": 1173,
+     "sha256": "882eb84a6273cd0e47677a09c4ee33109124ae253190b2400314fdafda6c1b9e"
+    },
+    "sound/defender/ssgcock.wav": {
+     "bytes": 5274,
+     "sha256": "db4f62f8d76a68f2e4d3e7a29a22d3ddc5d6ae9bb296e6e800e937b73b5a4dea"
+    },
+    "sound/defender/ssgfire.wav": {
+     "bytes": 14206,
+     "sha256": "494a6d493c3c298c1b9cc0051ce4c1f9e129293ea7ec283b62915c49d8c249c3"
+    },
+    "sound/doors/blocks2.wav": {
+     "bytes": 38638,
+     "sha256": "12df7d5a55311ad33e5d3cf1efbad53f2209b7598c59d4e4715ef18d9e4532e0"
+    },
+    "sound/doors/blockse1m2.wav": {
+     "bytes": 91858,
+     "sha256": "12e39c7592dc01f13b7be34306c6b77c13e8d0429219fa46402752e5e6f62ca8"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eliminator/acknow.wav": {
+     "bytes": 77318,
+     "sha256": "5eceea3e5c2d77b919ad0e05375f7c891e6a7192192b5c1f7bde3f999adf8649"
+    },
+    "sound/eliminator/hesdown.wav": {
+     "bytes": 188790,
+     "sha256": "43688ea2cda3a2edb9f9d575eea9e8b2bb8e962bcd989bdfa5a8962eb2c74480"
+    },
+    "sound/eliminator/hostile.wav": {
+     "bytes": 100856,
+     "sha256": "03ee39ba5581da66909d721f4f40a259ccea095501dcbaeff47ab9d2e8044bc2"
+    },
+    "sound/eliminator/idle1.wav": {
+     "bytes": 39084,
+     "sha256": "2ccaa3ba4f987d031a22b8048ca23e97900fca9def362ff92943b73a99ed7844"
+    },
+    "sound/eliminator/idle2.wav": {
+     "bytes": 36204,
+     "sha256": "9232028e1a93c409c7000348bfadc269c49a333e8d65d904973efb547c7af805"
+    },
+    "sound/eliminator/idle3.wav": {
+     "bytes": 38222,
+     "sha256": "93034d568db5c304a165c3d89cb03ffe5d97e8157755e944a863697007eb27fc"
+    },
+    "sound/eliminator/sight.wav": {
+     "bytes": 31468,
+     "sha256": "2268ee0ad0c77a081b289a550a1dae24b274b2e3f06d156a67beca80df8ee919"
+    },
+    "sound/eliminator/target.wav": {
+     "bytes": 159480,
+     "sha256": "f2c8c4e9f515d682387ec9b4ba40102917355cffc58ad95dcc935b9805742cbe"
+    },
+    "sound/impact/gib_i2.wav": {
+     "bytes": 19252,
+     "sha256": "6a5ddcd321e9543960098d000255abc76b2f502e0e2da798dba4dc6fdd076e3b"
+    },
+    "sound/impact/gib_i3.wav": {
+     "bytes": 14956,
+     "sha256": "e6a2eb024a5101846479865d49ea5ba551d3972567eee70f1a9db3bc6687ccbc"
+    },
+    "sound/impact/gib_i4.wav": {
+     "bytes": 32782,
+     "sha256": "59b447c5e03b7ebc2914704f0e3caaa6b65e393e25d6f19b0a14f2f570676caa"
+    },
+    "sound/impact/glass_bk.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/impact/glass_i1.wav": {
+     "bytes": 13526,
+     "sha256": "e57ff2304e1ed3b85bca5803ab3309f74b115669527ad7c54371bc4377aa3f60"
+    },
+    "sound/impact/glass_i2.wav": {
+     "bytes": 34624,
+     "sha256": "1e403adc1d18b90440d2b10793c0c356617b138be309ed7b9774b9de86d23a8e"
+    },
+    "sound/impact/glass_i3.wav": {
+     "bytes": 9520,
+     "sha256": "250f438c593fed13a5493edc2b4a88c6a4cb22034f81dd7571ba2db7bfee9fa5"
+    },
+    "sound/impact/glass_i4.wav": {
+     "bytes": 6192,
+     "sha256": "05b2dcf83bdcf50f0ac1b6a341d85380293bb519948da38a07a842df53e8e774"
+    },
+    "sound/impact/mach_bk.wav": {
+     "bytes": 124920,
+     "sha256": "642a3ef399d357428f0800ac39557a6e841301aa47263f2f0f3e1b719a4d3923"
+    },
+    "sound/impact/metal_bk.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/impact/metal_i1.wav": {
+     "bytes": 47864,
+     "sha256": "ab490d2a834e23d353a18a81111e55bb93a9ac5d63bddc81441c7b6eadf47ce2"
+    },
+    "sound/impact/metal_i2.wav": {
+     "bytes": 36848,
+     "sha256": "6d443bb3e925d2c6b7c171e23f26d8285d421949ad3ad38bb43afc913bfa9731"
+    },
+    "sound/impact/metal_i3.wav": {
+     "bytes": 69612,
+     "sha256": "6ec0dd8b2a6fef73cc3539e4e24045ddc8fb461be90bbb29a9cd53b20d7727a9"
+    },
+    "sound/impact/metal_i4.wav": {
+     "bytes": 79928,
+     "sha256": "d2b35ba352f32ceae469acf9cfa04f7dcc0a462ff69e3649f5c0adf55ae2ea78"
+    },
+    "sound/impact/rock1.wav": {
+     "bytes": 30534,
+     "sha256": "5cb61e93ebcf9bbcd3be1f6e282b51e9102d56b6650cffc0db93918b11b42322"
+    },
+    "sound/impact/rock2.wav": {
+     "bytes": 29254,
+     "sha256": "9fdf4f489834452fce33b1fbe69bce9d4920a117c3d0d93b4fb530a7117bf160"
+    },
+    "sound/impact/rock3.wav": {
+     "bytes": 25264,
+     "sha256": "59b506a84e018b11e9ba30a6ad299c2d8cf24d5907dc95cf30e578cd386e28bf"
+    },
+    "sound/impact/rock4.wav": {
+     "bytes": 27244,
+     "sha256": "7a2c24ce52e272998ca035c967860873c92fbb14227a190ac82b761843680ffd"
+    },
+    "sound/impact/rockbrk.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/impact/wood_bk.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/impact/wood_bk_old.wav": {
+     "bytes": 61250,
+     "sha256": "f9cff6955830b4219b3cfa01e04f41f311f7fbbadbc2738c92bf21808f1e7800"
+    },
+    "sound/impact/wood_i1.wav": {
+     "bytes": 28074,
+     "sha256": "6249449664f5ae509164ae3fd8588c905bea9daf5b1d919d9917b91aadf675bb"
+    },
+    "sound/impact/wood_i2.wav": {
+     "bytes": 25158,
+     "sha256": "d51e731bdf895c84ec9927c496fc0a7fb6e7a37cbfbc2f6b55f54f716d804d08"
+    },
+    "sound/impact/wood_i3.wav": {
+     "bytes": 17644,
+     "sha256": "8e1967cf42a7e31668d94e1b0cb7c6de4d36c6ec735d67ab01ac4e00dfb0853c"
+    },
+    "sound/impact/wood_i4.wav": {
+     "bytes": 11516,
+     "sha256": "fb0908f1a2bdff824d27fa92f15690cb9f86805185119fbc7f7876547495bf45"
+    },
+    "sound/items/click.wav": {
+     "bytes": 6534,
+     "sha256": "fab804dd505a2d823b062b348f126788bb3ce6c6399e8e76b1b7e39ffc8c82e3"
+    },
+    "sound/ogre/flakfire.wav": {
+     "bytes": 25932,
+     "sha256": "d00213964c69abe9c1661aa2cd2ae9305b0bdacb46a3e0945763883fb2d991b6"
+    },
+    "sound/ogre/flakhit.wav": {
+     "bytes": 11846,
+     "sha256": "a7c4a0b04c8c39de0bfb560283ac872e6bb6b240fdeef9a1565d314eb99cbefb"
+    },
+    "sound/player/ftladmet.wav": {
+     "bytes": 67720,
+     "sha256": "7cd7028d84b16700661848a36a866a2602bcf50185b79ca94d5a2eb541fb1294"
+    },
+    "sound/player/ftladwd.wav": {
+     "bytes": 35760,
+     "sha256": "b09b57b7da9ae84b359260d7c600b70a05ed2314597af6cfd38999f664568d65"
+    },
+    "sound/pyro/death1.wav": {
+     "bytes": 18468,
+     "sha256": "f69cb5d6086c78c8e7bdb9d8fcb9365e6500ece5156810b568a2cf2d0acdc126"
+    },
+    "sound/pyro/flame.wav": {
+     "bytes": 44268,
+     "sha256": "44aa350cb7efbe578f785820ba28bf6aec29561a7d150072ebe841966adcc45d"
+    },
+    "sound/pyro/fstop.wav": {
+     "bytes": 44268,
+     "sha256": "50a724e76295283a5cca503ac1b46d5ca97a33055e0c8e85bcfdfc0c90d5169d"
+    },
+    "sound/pyro/sight.wav": {
+     "bytes": 88918,
+     "sha256": "39d9c5460096478952c203bfc358ee52c5f2147e742b937f2e8517b45843c360"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sentinel/laser.wav": {
+     "bytes": 9712,
+     "sha256": "c5f90e1823a04b48f7f24ac5b8792e1b42030a8b07970db5847dc1e74be094c2"
+    },
+    "sound/sentinel/nail.wav": {
+     "bytes": 13750,
+     "sha256": "7acc3ac05b7218abc6fef2d2397771d90fce6fa39415e33824be7e771d30e288"
+    },
+    "sound/sentinel/widle1.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/widle2.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/wpain.wav": {
+     "bytes": 19596,
+     "sha256": "bc7b6536a1c67aa89295eeacea2d9b36cb0bf783b5fb7cc6aaf4fa01a0edb3fd"
+    },
+    "sound/sentinel/wsight.wav": {
+     "bytes": 27322,
+     "sha256": "83bca2103d60c68435e27f0660e3ecd5bffb058e796382e7bdb43efabdfb9889"
+    },
+    "sound/weapons/dryfire.wav": {
+     "bytes": 11268,
+     "sha256": "43e10c707d097c577f465c89fe9444c59b5ff4cdaf7c8d6619bcf61568d39bf2"
+    },
+    "sound/weapons/plasexp2.wav": {
+     "bytes": 112340,
+     "sha256": "92ea6112b21e65d625d34fbe1ec6abc592c2cf7c28f1b55c5999a8a56daebe8b"
+    },
+    "sound/weapons/slime.wav": {
+     "bytes": 57132,
+     "sha256": "88ce5f10c8acb0e51d54a4066ef8faf1643c5baf75edeafb82d350c733131215"
+    }
+   },
    "sha256": "fdc0703ba7a16def597892eacb384bbe137c20ef6034f5038d9f748791f5c14c",
    "timestamp": "2008-03-08T19:54:00.000Z"
   },
   "pak2.pak": {
    "bytes": 8021749,
+   "files": {
+    "base.dem": {
+     "bytes": 1166121,
+     "sha256": "f861f97f1575aa21efb675f8477fe96313f2ceec270273044fc34bdb8277c098"
+    },
+    "default.cfg": {
+     "bytes": 2025,
+     "sha256": "3227f12ce7edbb4235d5b8b4d3f69206a9b8fd8715f939ca0601325e52ea15a4"
+    },
+    "gfx/env/moonbk.tga": {
+     "bytes": 440145,
+     "sha256": "215264c71fcfdcda4fd9470adb3b1e1e803cd5af1d8df035c3244646dbfeac2f"
+    },
+    "gfx/env/moondn.tga": {
+     "bytes": 603,
+     "sha256": "4a83e798c3d0637f03b1effe28df9998bf249831b3dccecef074ff5cd8b631df"
+    },
+    "gfx/env/moonft.tga": {
+     "bytes": 410588,
+     "sha256": "4fbbdf05866d78de6ab4bfc9867227007fc87073cc96678e0c08bbc6d9717ce5"
+    },
+    "gfx/env/moonlf.tga": {
+     "bytes": 421955,
+     "sha256": "ea304d8972653bd38c0aee88e6dd434d719360c423344d16b5db9c398af260d7"
+    },
+    "gfx/env/moonrt.tga": {
+     "bytes": 453367,
+     "sha256": "8ee2a2b97267326d4831d96c879c6238a63c485fc8865d91503adb6d7da878bd"
+    },
+    "gfx/env/moonup.tga": {
+     "bytes": 1335652,
+     "sha256": "91e764d1d7780818e58f1c30d7c8825df2adbf17c7da630acfa3dd70b29d27db"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "faa7c77704959d1ad9bb5280449b22e8c4b9425fc628b4f2037900c49e73fc9e"
+    },
+    "optout.cfg": {
+     "bytes": 1564,
+     "sha256": "51efd87218e766df5c8b5c643ccabcecacfa855ee60deaf8dde8420a02c157c8"
+    },
+    "progs.dat": {
+     "bytes": 723936,
+     "sha256": "940b86822b2ff00d4488839e61de516fbc381f1ac19d132356b1c00d3ee4bcf9"
+    },
+    "progs/bolt3.mdl": {
+     "bytes": 15772,
+     "sha256": "6fabed3901bab1b145e418300d333c30016070e57ede07476884283a5ef7e380"
+    },
+    "progs/box_l.bsp": {
+     "bytes": 21639,
+     "sha256": "9a20404c31446ffc497113892dc293b0e59c6bb2cd9ab4a1f0bee11cc1f61a5c"
+    },
+    "progs/box_s.bsp": {
+     "bytes": 21541,
+     "sha256": "47b3f0a947272241184b9f65aa46d694fdd8facb8a9a36509d6f11f844f3917f"
+    },
+    "progs/c_ham.mdl": {
+     "bytes": 76800,
+     "sha256": "6bdd3e6b4c8253e6aeb6e293093b88fe6b3a9254135d285c8574acb6be9de9e1"
+    },
+    "progs/c_lance.mdl": {
+     "bytes": 44164,
+     "sha256": "6925fa7f462edb6c863bef65dcbe7d5c69544454c6fc1435a98c2890b08cc757"
+    },
+    "progs/c_light.mdl": {
+     "bytes": 76388,
+     "sha256": "9f0cdcc8e56d0614e058a3e922f3f64b0de33ab2ba6fe390c4154a3cbeceff5b"
+    },
+    "progs/c_nail.mdl": {
+     "bytes": 45336,
+     "sha256": "afe38a23bd9d6ec01a386047c3030f95732a986211eb0c6aafa83e12eb300a53"
+    },
+    "progs/c_nail2.mdl": {
+     "bytes": 81136,
+     "sha256": "c2e9e328af078538722ba4894801b5e4c5334a4629faff83b11510aa0a987b21"
+    },
+    "progs/c_rock.mdl": {
+     "bytes": 74404,
+     "sha256": "058de704ba8b0c2a47c2b83fd1b767a8220b9af87460bf114b14528db57ce096"
+    },
+    "progs/c_rock2.mdl": {
+     "bytes": 73544,
+     "sha256": "c922fdbfcd8175d196cc16f2134c8d9852c788ca76c198337aa71bf0bfde5e56"
+    },
+    "progs/c_shot2.mdl": {
+     "bytes": 42636,
+     "sha256": "02226bf370133fb1c4479c56a9a3c544cb89a0e87ba4cabe3247f9ddc9994b9a"
+    },
+    "progs/dspike.mdl": {
+     "bytes": 25324,
+     "sha256": "c2c89f690e21e34bee37db5011493f3457240e22fcaa3cdcdf04ef4bf9f44ae1"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51272,
+     "sha256": "0244bf38ec29f251b425bc1cc4f1a0e003316b3699c869cea38ec553e1f96acc"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "d45e10e4002fb17b2a1aa4077d1d4e599babd5083c0f7da914f8e98b61cb2537"
+    },
+    "progs/polyp.mdl": {
+     "bytes": 343144,
+     "sha256": "a135ee3b29dd230d06babc0e80c691b35e33599a48eb152d2c2c4902d424d4ec"
+    },
+    "progs/s_vp_pll.spr": {
+     "bytes": 272700,
+     "sha256": "024935ca88793c432ac5d6c6f52a51cb82638c86e9c27cac8d87e926673012db"
+    },
+    "progs/slime.mdl": {
+     "bytes": 25976,
+     "sha256": "53b07ceca49f5c637dc5bbe1cf1393db74e3d057624039efb8d7fd2341b5466a"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "aa9165056656a1d0810d741c91e5e14b1aebf3020a95ebc0dc1f48a3a1243074"
+    },
+    "progs/waterfall.mdl": {
+     "bytes": 43588,
+     "sha256": "c4bf6157c6f3a580a6cc7a76c8d5ea6a9af00f9c53b0615bf47b6574dc5bd54c"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 845237,
+     "sha256": "ee9db9fb4e224227574067dffb1b9c49af5b9536f8cea0527282d851aab81e73"
+    },
+    "quake.rc": {
+     "bytes": 1248,
+     "sha256": "dac6aec78b770451be757493c744ffd4a3ef9fb64be379044d1de57936a746be"
+    },
+    "sound/ambience/grinder.wav": {
+     "bytes": 264572,
+     "sha256": "70789db5c6e505292dd6031241aff19bd7b327677033cac5f98c1dcfeed5c6db"
+    },
+    "sound/ambience/teeth.wav": {
+     "bytes": 51600,
+     "sha256": "9649cc3a15c66b851da286bfbfe085196e851a9a493c299b03d9874dc04431e4"
+    },
+    "sound/doors/er_stop.wav": {
+     "bytes": 51846,
+     "sha256": "f674272aa55db0cb05651c5edfa76422370d138c44789b179bc6e943a22f0d28"
+    },
+    "sound/doors/er_strt.wav": {
+     "bytes": 99372,
+     "sha256": "afb23446ab200aa3bd540bc1ac517713dbf2d7fc099283254f7b8a4480a90092"
+    },
+    "sound/doors/ir_stop.wav": {
+     "bytes": 81054,
+     "sha256": "c5ae31d19bb638cd61771f365beca5998d5795ff035929863a19148d39907904"
+    },
+    "sound/doors/ir_strt.wav": {
+     "bytes": 86616,
+     "sha256": "8e2767cf7d483ab898c7eb561834b0a7af90669976499dfe42c8f7e09560aeb9"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/wfend.wav": {
+     "bytes": 9060,
+     "sha256": "1d8381b51b40e54a47ee76a9115b95a49285fc59385ff20b941b0fc8b7cd16b7"
+    },
+    "sound/misc/wfstart.wav": {
+     "bytes": 77838,
+     "sha256": "c85b517926832c1a7ef3a04de2995a7bd58a161620b4341a3f57d556c50d7ea0"
+    }
+   },
    "sha256": "be17936386a4f842d59cb8f509348acce924e6da64ec4b999f7079cdca9cbd83",
    "timestamp": "2014-05-03T12:24:10.000Z"
   },

--- a/json/by-sha256/b8/b8764eb32c3066e9b15aa2c2fd7fe8f0164b81df2aaf523b32cbf2ad234143e5.json
+++ b/json/by-sha256/b8/b8764eb32c3066e9b15aa2c2fd7fe8f0164b81df2aaf523b32cbf2ad234143e5.json
@@ -17,6 +17,36 @@
   },
   "Pak0.pak": {
    "bytes": 4783152,
+   "files": {
+    "maps/redrum.bsp": {
+     "bytes": 1698148,
+     "sha256": "e205bd502da87f42c4f93424fd3260ae9eb0b57d94eb8cf0b0ffdd1ae52e8cdd"
+    },
+    "maps/wind.bsp": {
+     "bytes": 2794500,
+     "sha256": "2f29c2e630b37d2553bf26ada10b941723b939dcac1db2bb68588ca00b929e21"
+    },
+    "sound/ambience/comp1.wav": {
+     "bytes": 93644,
+     "sha256": "34afc2c54c4524da10adc3d3265cfec15ea9447f23b9455bcf50ac20cd8a8c17"
+    },
+    "sound/ambience/drone6.wav": {
+     "bytes": 16680,
+     "sha256": "40b31039222c39b94fae63a40d7db601a73c45bae768a3699500fb29e08b8425"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 94277,
+     "sha256": "12de3165b87ed0b8442d92d35181820d9e03c753535afe92f2fefbcae77fc4e6"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 58332,
+     "sha256": "576034c9b3592f9471c3bcd76d671532ea5fee11bbfcf4478e661962786e442c"
+    },
+    "sound/shalrath/idle1.wav": {
+     "bytes": 27111,
+     "sha256": "6a69f3635136303676e168088af4a55442cb77f914e2e82f77e06e07339f0f4e"
+    }
+   },
    "sha256": "8dd4df5f1988ee9f389c3a5fa742868a89e3238123e66c320e77cc0fb6122249",
    "timestamp": "1997-07-25T19:07:54.000Z"
   },

--- a/json/by-sha256/b9/b936d086fece844fbf88dc0681011b80513f92aa3542474e3d8d2b6540cec409.json
+++ b/json/by-sha256/b9/b936d086fece844fbf88dc0681011b80513f92aa3542474e3d8d2b6540cec409.json
@@ -823,11 +823,2907 @@
   },
   "limjam/pak0.pak": {
    "bytes": 54653051,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 52058,
+     "sha256": "367e453b2ea9b4282990f595c446c70f16b4ca36717b1fd0c3220ec34e90326b"
+    },
+    "gfx.wad": {
+     "bytes": 210484,
+     "sha256": "9072806ee7e43f2ce712cbe7bd68355dd659447258c7e35e1005d71df7ad5baf"
+    },
+    "gfx/bg_ammo.lmp": {
+     "bytes": 1928,
+     "sha256": "754dc8ea867ba7dcd60407764b51a1eccac068456c38787744387a4c59cbce62"
+    },
+    "gfx/bg_runes.lmp": {
+     "bytes": 520,
+     "sha256": "6b69fad1c89ac2085dcc7b8153d1f19ae353bbd0572b05aace1afc02e8e984df"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "6072bd63a691625de201f3f3da060b5df433753d7ac2878c48b87e9d0dd08b94"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "ac11a967228e1c7d1a936859b82807cea239d80380fb6204d67af7a86c5c82e3"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "4cb99cf1b515b6547f012b6e44174c245261b058168a8bc4303d08b98e1805b6"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2c37b7697aebedb5bbf6637d4b8e158f70da6b7245195ff0e91a6ba7aa24e828"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "219002fe962a017600a37dcdcaaa0f777aad42044619f945cb70c68007763a97"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "e251893ed49aeb677096d380d4246907a039e0e21a4849f97f343b0b13faead2"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "64ec646cbab7ebca11f6af4f0b75d9706f438baa7b23059de87f8685f4686640"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "03c7cdc618e4404e2b9364c690b0a447b4be99dc5af112c66e6e2079902c76cd"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "9cf2683f2a6d22693a8c0cf35898bc5900a96afc771878df9f8a8a88f3d581c9"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "f232da5cf35acc557f3f312911e6a856cffaaf9f8078ca2ac5ef7e6f6e5e3515"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "b57ad9ad9d6240a0e035ca7a64e706e3031b8293c27355c9a95495a84972af4a"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "873af58b7244d6e82feb1af26ac044c9beb43c2865bc51d0485054a562ce861e"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "ba75badfe057b499d33168032dd5dc5a4fd0dcbaef9cbbd27efdb3f056cbfc00"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "55ac1377921460aeb691f86e7a5051e3a5481f24b93cc8578cffdab2854ba0c3"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "9600a66391996cff88d48890adfa516660fce6a32397ba4f54973159785cff4b"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9f03351fa7f31a23b63e6c13d2a643ed1ae3fd3df0cf2b0db336424eb17016dd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b7617428e8d1d74be7b770ef24c744d16c2503efce9c17facf1107cce08f5ed9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3036afb422cd299cb09532a20847ef35aaf87bb36e34ce9ce75b5e7aaf9a1ec3"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "7aa61257bd3083c00959776eb36aac86a7ca8da2bacbb4c8a41d9a5fb0b1ab97"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "cfe83953875acfe9afda11b75407ed9883eeb284b0a67b9ff6e07df85d50d9fe"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "d3b4091b83837da5a45445cd00b90267c62050e010e2a045461034ac9c48be33"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "de004dcecdff1973597a977ab63c671ad7d3f52387bdcff4be560924e3d4d17e"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "078c56d685ff1fb84b322f7a76e485c2637fb09efc61f4e44d5d067b3ef9a42d"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "9df9672c8da61ae769409e9ea741a1b8f9a4f108b5f0fa6637ff65601c535843"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "fef6b9be45d5b384d061a47f133075d1cfe0b60d93cf7e3da9ee5529f661964c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "1b1254c1f5764affca85448c4a3c2fefdb938f35bc50f44142a8e9b692ba7d64"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "39a06ff92831e1e2fd20c1bdd20e0f234cd0b3aed94e6c9909d059a20479ce3e"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "def061c922fb91a7e58850e89bb6baa9e09dcf93de7a94288a90511ecd9a114d"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "3220d953bab793165178f2666e67032398a6bd0e0510f6b92eef4fcab377ee1e"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "f897535531fe4b821d41d859a4085fd7d25c679493645a2ef7448f62073523c4"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d070636562a967d1abff330dcd1ea504ac7b9b29099a98994add1d9ae47e44e9"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6d92547a27d839f3c9d7a1da786fb33547cd93b7f19560b6c4bcdc12064545bd"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "e932416c58fc5de16e6d05aa737e56d3811e540bfd9e6acd1bf114ccd8bf34ac"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "bda55d4b2d7bc3f180dafd62424ee5830896563f5a5ac576dfa08894f5e17e44"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "513955ecc96eb1f0d44b340b47f79c02bb7bfa7f3b0a884a65fe111429ddb2b4"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "2faa4c1f61d175ad28b7f54540af3f87abc6e56dc20f2da5fc8a7737a0302c97"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "dcfe5287432b3a1124d032250ccc4bf25c73540521c77601ab746287ef3a0179"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/skillmenu.lmp": {
+     "bytes": 14408,
+     "sha256": "dbf40f0e5faedb181e84d4a822ecc9316711ae89530a30bd50cf4fba45aa8251"
+    },
+    "gfx/sp_maps.lmp": {
+     "bytes": 2248,
+     "sha256": "024bfb2d05f1c52bab1a856cbc532d06fdf4e8d96fb486f74bf451472311ebcf"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "00654b7bec9981508cd9ae8eac167637926c023e7bca011a3cf37585b7e168a8"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "74c50b895f1e71ec6a569fba0e991fde8cf136ea734d6914435aaf9b2735d7fe"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "aecab7a199a4db72242659e6d1ced192d39b2619f67c7e5eaafa72a5efef3aef"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "d075eb0c8c00d30b01eae539720c20b73bb57066c6ea5e8180a4d851d9167add"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "d03aa05e24552d961ea9ca278d743860e34a97e2ffcee52fded05ad4b4740bd9"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "maps/wood07.bsp": {
+     "bytes": 7135,
+     "sha256": "8e07e7e5f5b641c644d28c9c4026efc95aa50345074f5c42acd39a3b94261344"
+    },
+    "progs.dat": {
+     "bytes": 1195538,
+     "sha256": "e28dba3261e561246ff12c5678ebcea1dc6720798c3400277fcc6e40666b9eeb"
+    },
+    "progs/alkturret_base_v2.mdl": {
+     "bytes": 87768,
+     "sha256": "4b1969201052a4506509bb606eb7c395daf9332cf4605036ab50190495dcfbf3"
+    },
+    "progs/alkturret_main_v2.mdl": {
+     "bytes": 116620,
+     "sha256": "11a2564f7daa19625e4514c284650242c8b3831df947f183243adafb958a1333"
+    },
+    "progs/arachnofloyd.mdl": {
+     "bytes": 741212,
+     "sha256": "554bd2ad34a830fa01a61dd4972f432812fb61f7815ec81d8a8d7e87bfad6b02"
+    },
+    "progs/arm_foot.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 164224,
+     "sha256": "35314143b9c7a9a0e26e52a865072a6e73862466e640c6bbd58be3075c4d93ff"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 497408,
+     "sha256": "40cc63b599cedb54f04c937ce407e7119c1cf4d5d35fd04bc18f247584e9899f"
+    },
+    "progs/b_p_key.mdl": {
+     "bytes": 5940,
+     "sha256": "051b2e8fa67cae7aa24490a18444400f773d4a9d353542ebf979b0a22a1771ef"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bambler.mdl": {
+     "bytes": 128044,
+     "sha256": "c8ac9dbcf99f0e6efd30496ac414383c26b8d241fbaff56cfa81dfb545dfb0c8"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "698bf740683ad182feae2246526361948be6da2e144f1bd0202eafa748213ec2"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "b662513bc3a8e0e967344c55b536bd33012340dbeb79a8db1281d2c84e36d338"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b2cf62d8e989789bd76e27193b2f5205a93d4172a4e25c89aa1b30f75bebe60e"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigcranea1.mdl": {
+     "bytes": 92792,
+     "sha256": "81f6a5b55d3a585d5e9c73b088d1d20e0fb328707c1539ef41e52c460555f651"
+    },
+    "progs/bigcraneb1.mdl": {
+     "bytes": 21940,
+     "sha256": "e02faff0bb6c84c781f6b534a5a06ac1f977a028fbdcca176be2932f91e9e8ec"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/brz_saw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 575288,
+     "sha256": "f571bdf504537ce01ca2b6a78b57575a36c391f9c786625d880d956fb17390a7"
+    },
+    "progs/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/chain2.mdl": {
+     "bytes": 141764,
+     "sha256": "9334a3ec04716ce0068154bf7abb4c1e3ee6de14fb159982dd547314935d7854"
+    },
+    "progs/cyberscrag.mdl": {
+     "bytes": 306936,
+     "sha256": "868d1394e186b1e7f4fc58134c338a413814723f406fa609e2d7cb87dc2496cb"
+    },
+    "progs/cyberscrag_gib1.mdl": {
+     "bytes": 60500,
+     "sha256": "3db8b13bfa5a5eda07acea695cae6ffb92354053da9bed199ef29cd445317faf"
+    },
+    "progs/cyberscrag_gib2.mdl": {
+     "bytes": 58932,
+     "sha256": "ef20c0de15fe2fc2514c10b0023d14009a4871ed40311077ba107350c313f7ce"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon_alk.mdl": {
+     "bytes": 191716,
+     "sha256": "11f33f19ae0a46d3dcc6c1fee46235fb6ad201456120502b603fe4fb7cee14ac"
+    },
+    "progs/demon_old.mdl": {
+     "bytes": 272684,
+     "sha256": "538d5d01833d6910d4400f8795be582c3427748eb2a162fcec2c17d6707c57e5"
+    },
+    "progs/dog_alk.mdl": {
+     "bytes": 199324,
+     "sha256": "a16e350fcd247908c75ecd0c93e94d3b700b67bb0f66dd45d665d171a55d42b6"
+    },
+    "progs/dread.mdl": {
+     "bytes": 415072,
+     "sha256": "dcea570331c5cf4348c40451c6242bf35ecaaea2a348f12254a13c1b76b13d7c"
+    },
+    "progs/drip.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17284,
+     "sha256": "444692074359310be0520b1caa057ae2e084df826f7ecc9bcb0d258ea1d80373"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35988,
+     "sha256": "91aa79805577466147bd4811614b0387b3635aba8383fc2e16b178d7b63ebdf1"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42436,
+     "sha256": "93839bd6f50323f7ac5ae46037de0c6a10a533374f714229dd511ee62b88ca3c"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bcc6396dc638003480dba8c36cafaf32df2cfcf49bd460b001d0d74a164f9011"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/enf_gun.mdl": {
+     "bytes": 58684,
+     "sha256": "39ef1788b39a15f86c8d54b81c43f4126e8361ff80d386c44358f17ddc93769f"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 450424,
+     "sha256": "ecf603c4ebc56438e96d1706a451af8bbe9b090db9c48e38e758ec630a393570"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "ddcf759804fffd97e62c55f67f962e24e8cd646fd982215ac8aefd3e49f67660"
+    },
+    "progs/enforcer_alk.mdl": {
+     "bytes": 333860,
+     "sha256": "85fb5cb9eb1435da65ce0aa6940241b7b4b5fa13e7444713a75c6ec301cc8b97"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish_small.mdl": {
+     "bytes": 221279,
+     "sha256": "34b883e3bf73a520f301cced68629e0d95e88f96c03a23230f12d02aa49c247c"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flag2.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flagbig.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 451032,
+     "sha256": "1a311e7e74f9a67c9f7468252aedc8c19804f65375d229e90afbec2f93849823"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/fromitz_still.mdl": {
+     "bytes": 6964,
+     "sha256": "63204597e828e001c957e9316878995e161da0502764276b90285accadf6a222"
+    },
+    "progs/g_axe_alk.mdl": {
+     "bytes": 50460,
+     "sha256": "92988e970870f2b977f7490d2ea4ee040d338fa4bdc470e8d68f2e5a856a7a28"
+    },
+    "progs/g_axe_alk2.mdl": {
+     "bytes": 50460,
+     "sha256": "e448b2a7540ba959453592b2472d0ae498142a77242c91fd5991ca23a7973f4a"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_mine.mdl": {
+     "bytes": 37780,
+     "sha256": "5057c7736e8c722270c781e47584972f42e7ebdd5860596403a9ce7688d0b5cc"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "15f390e39e02c8524e575ca8fadf63187b641c58210ee9587b13a0ca94c29cc2"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 199076,
+     "sha256": "7ddca6fb95082d0cc7ffe5aa3ba896ea987a80b1bd5867db97b2a84b9d8da9f6"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "8b05b8ca87ea867c2a2397d238311fda2441f5c0e1cde130ba487b0dbd17a8e5"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_arach.mdl": {
+     "bytes": 60292,
+     "sha256": "daca6412383bec28809cee42c4ebf01085cf83ed6ff289114ba0f842b4005251"
+    },
+    "progs/h_bams.mdl": {
+     "bytes": 37316,
+     "sha256": "58c4644a2ed3e5f10741dff2ad1a8bb161f7eb205ba3fd8c5fc9b7e4ffc571dc"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_cyberscrag.mdl": {
+     "bytes": 62036,
+     "sha256": "df7d6bccc97bd5c184d9d6160005b370175aacc16a34bd06ab14c7d69ff60419"
+    },
+    "progs/h_demon_alk.mdl": {
+     "bytes": 72644,
+     "sha256": "22a9e01cdccb2e274c63c277e6dcd61986fa7556426ee3562fe11af2babea289"
+    },
+    "progs/h_dog_alk.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_mutant.mdl": {
+     "bytes": 110240,
+     "sha256": "f1f9c665b659a8c145550605ef9abddf27779d0917c897baa344d65673770875"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/h_sabrkn.mdl": {
+     "bytes": 11828,
+     "sha256": "050fcc93189211aba943674a326ddd898dc980b83fb551ee11fec3dd39973483"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shams_alk.mdl": {
+     "bytes": 37268,
+     "sha256": "9fcace6cfb38473763a5cf96007ccc5e0ec4786352d4d1063410d63157298b45"
+    },
+    "progs/h_torm.mdl": {
+     "bytes": 62056,
+     "sha256": "db0ddda0c4d2283cd3c58eb45397cfb57095acba1eb6dd38571ca23ebffe9946"
+    },
+    "progs/h_wizard_alk.mdl": {
+     "bytes": 14948,
+     "sha256": "5f6c27ba255b87718d993b29cff526bd025c0e7a4991722a96fe3c0f98d83408"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hknight_old.mdl": {
+     "bytes": 418144,
+     "sha256": "40bd5757499a2bf7e6f60a78b0039665107c9603c2557f6bc73208e080111464"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 37012,
+     "sha256": "e3c6cbabfe6c6723101f2e59f50fc99ee0e360571c95885d2d56c85eefade15d"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/jumpblue.mdl": {
+     "bytes": 37428,
+     "sha256": "be4e85e5fc643e91377d69794b997ad4dc927ae3866dfef5288d704dbc0f16d7"
+    },
+    "progs/jumpgold.mdl": {
+     "bytes": 37428,
+     "sha256": "4c543d82c88009cab7fcf6230feea0a21518a98f430636194fdbf5c1e526cc13"
+    },
+    "progs/k_laserspike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/kamikaze_grunt_small.mdl": {
+     "bytes": 203376,
+     "sha256": "550aaee63a82db7de25eb3329c368a8bf98ad0aee8af169ee41a857d9087c0f1"
+    },
+    "progs/knight_old.mdl": {
+     "bytes": 208068,
+     "sha256": "5cca43e29392051c9ba95838a58cc1038560411e6c0d2aff61867a428b119e2a"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "63220c0ebb6e266576cb3107a44be16bda10d69fa524d0462514edff9d80328c"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "29bc55efafbea3e15a385598750ba4d9242d0a87803a6bc3430ed772ec1785c3"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "f1e799e7feac3c340676bb60f6cc7a2a7d1e121b196d1f6d0e23edea3a614ed6"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "92370f5b196dc00460d73697975d14279ef659c87c7fc1613b9cbfb68e6c299c"
+    },
+    "progs/m_p_key.mdl": {
+     "bytes": 13428,
+     "sha256": "581a23ac3e2bf0960a7a8b1c4693efd1913d9d17a1f4fa405a1b8c6d89105f91"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "4c5db792da6876f935f8a98a74f51708d52ca03f04975f28518051494660bf65"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "781837a3557c1a8b89c15fa8f477989cb4b77d8cff09c8c13d071090a4df9c1b"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "2feb7ce08070b314d163cbc7f2e2eae0986400c482f752d305ddba268639b3d8"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "04f7fc8b0c2be7ea93021819770145eaf828b2313c4fc591a5f2aa783ca97e61"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 8372,
+     "sha256": "9b6a8f7a49fb7a1f5d4d409b708663c579d433e978d898b9bdf00291a59b4e6c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "fa5d7a5e2410ac7faa5dd0a8e17873c972c6e5cfeacc94118f22db1b4b17477c"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/mutant.mdl": {
+     "bytes": 352720,
+     "sha256": "262ffca22e0c7308950076c2789436a891399862ea25afbd06040158ec9f7984"
+    },
+    "progs/mvore_bomb.mdl": {
+     "bytes": 12653,
+     "sha256": "dd54f975b770db899ef71174d8b05cd98af99739e9506fc4eb354ee8d7e820b8"
+    },
+    "progs/nephrenka.mdl": {
+     "bytes": 807192,
+     "sha256": "e1efdf4467614012164148e6af70c5a3076438e990fc1f48bc4fafb49f681340"
+    },
+    "progs/nephrenka_shield.mdl": {
+     "bytes": 807192,
+     "sha256": "5c7a3957118c7c7370ba1b7ef8fe00b97813bff193dda6ed2c7029e72d8c1c70"
+    },
+    "progs/nsoldier_alk.mdl": {
+     "bytes": 563108,
+     "sha256": "6071d7cecf231f0a83f2e1c7df533b4a32beb6e75969d17703446a67d011695a"
+    },
+    "progs/ogr_gun.mdl": {
+     "bytes": 52452,
+     "sha256": "eaa6e0fe01255450d578f151c06c5aeb6a9cd5ed90edbbe4f52d305069ed6825"
+    },
+    "progs/ogre_alk.mdl": {
+     "bytes": 315696,
+     "sha256": "31e9986373dc1a8cba00e09ba9b0278cf766bbd074524a891ed22329f697d643"
+    },
+    "progs/ogre_old.mdl": {
+     "bytes": 315696,
+     "sha256": "53317e9b684701e7722bea342af1a6dba5dd31e72cdbcfa5b097382516d1c6a3"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 487968,
+     "sha256": "ae0abff3ea3fc7ca8c7f80c5d8825553795a1c1ebb80127d46fa52b20905abc4"
+    },
+    "progs/ogrem.mdl": {
+     "bytes": 378296,
+     "sha256": "2bb999bf580d16fb9ee4246dea7897236d6d118232c78a6168f641dc32778fb5"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/pellet_tracer_short.mdl": {
+     "bytes": 58148,
+     "sha256": "5b24b67ce9d9b2634d9a0f31319a977e1e3ec6352d491367941a0e5bf2ae10ff"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/probegren_body.mdl": {
+     "bytes": 139044,
+     "sha256": "da0ddf337c3e2515688f2b143adf55d4ecbbfa32955a78aea01ed16e067b0065"
+    },
+    "progs/probegren_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "4f292b6f157d226e763ff28dad682ce95cfb8a3a21b4badf0ca48db4900cdd70"
+    },
+    "progs/probegren_gib1.mdl": {
+     "bytes": 63788,
+     "sha256": "0efb081efa87c9db990d984f9974f10078890a51894a3e0a6fbe76cc3c4cb5a7"
+    },
+    "progs/probegren_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "7843ddefa22b7d5beb37f889c606c6361792508c2bea202f3dadf9f3ffce73de"
+    },
+    "progs/probegren_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "7baac250aa8c27ef3158de59b536ebf59509e39b1f7bf6be1c24fd5b1e29cae0"
+    },
+    "progs/probelasr_body.mdl": {
+     "bytes": 84296,
+     "sha256": "ac545d0f545488628c864df6e464d10fbd51cb41a2cb76c46dd91233ecd11a6f"
+    },
+    "progs/probelasr_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "cec7b847c9b05f2653113454348799b9bf09c2a74c8e1760cca0ff52c1dfc18c"
+    },
+    "progs/probelasr_gib1.mdl": {
+     "bytes": 58700,
+     "sha256": "ae9f298abc0bb1d09cea3c04bf02216b0a1c3749f8c8a822d973b4c2091cd649"
+    },
+    "progs/probelasr_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "07d6defee5ce4e747daf8b397a5d207a1a42e3c3acffbdfc18d6720c88ec635c"
+    },
+    "progs/probelasr_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "8b8f376afa56e7a9f311e58a076f1fa3a52c88064887a8e0960fdb6daaf5265e"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12653,
+     "sha256": "162632bc16838f66f29e0b788845a6421b7fce708003e9fa6f4eb8ae7aa8e5be"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/rail.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 200152,
+     "sha256": "a564fba381d24e3084bc9aa0a026381c83e6b889632c8bebdf69c08c8a6bb9f2"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "f65ba83d82e90808af589ded17378f1baf37f105fa14f2b157227ee22583d25d"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 288,
+     "sha256": "6ff2797f9dc4e66f2113475a5f3e0e96f23dacbddd18fe47c8b5e12e712f0e75"
+    },
+    "progs/s_bullet_new.spr": {
+     "bytes": 708,
+     "sha256": "a07fa61f4a838ac9ad8ec85ae525d70fb934d383effd1948c0775497be713043"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "b3f1971bd28f96c623c5712e2a47f54f16c99a50d460a944cdcdf29e6eb03963"
+    },
+    "progs/s_exp_small_2.spr": {
+     "bytes": 201720,
+     "sha256": "f7fdba9e2b9b5d318cdff33a06fad4e91e46ba3a241fe7ced4bfbcf0bcb0e873"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_plasma_new.spr": {
+     "bytes": 13980,
+     "sha256": "5474060e55af3c462d0ef7aad043f331c1f5b642915d906c1785bb94595cc68c"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 2820,
+     "sha256": "ea66402d248232b0b6a77bffe024d4a62881be47becf37acb42328661b7f23ef"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shalrath_newer.mdl": {
+     "bytes": 228496,
+     "sha256": "93601de7ff47f552ac9d441ddf1faf312417ca914de99529b17bdf7522e7478c"
+    },
+    "progs/shalrath_old.mdl": {
+     "bytes": 211576,
+     "sha256": "409cda15df7b271bd95a895f058a521d43eca63f37c7ac9df175e5b478229bb9"
+    },
+    "progs/shambler_alk.mdl": {
+     "bytes": 502148,
+     "sha256": "bcf685fcd1f4062dc382924d39eae073fc4d44cd2dcb5bc4ca3797fe0b342b71"
+    },
+    "progs/shard.mdl": {
+     "bytes": 10132,
+     "sha256": "0219a0f08bdc1f604ebe1ea2243cd1b27a2b1ab85bedba3a11298f2d22e9b38c"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "662d6a7cd68bca7a9c5e88838d190de6a501252a14b6994a191d0bc91f1f331c"
+    },
+    "progs/sknight.mdl": {
+     "bytes": 460932,
+     "sha256": "9213f6898a60cdc20a7a144c61c13f8d64f1432382dca44b636524edf737dac8"
+    },
+    "progs/soldier_alk.mdl": {
+     "bytes": 359276,
+     "sha256": "623374e5a553c3d886738c9cc0b22c0b3f3435b3dc1b3f473079a1dd1661fc8a"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spiderbot.mdl": {
+     "bytes": 82476,
+     "sha256": "e85556a194664a5f69e70b42aa863d9e67689a418a3afa51e50816174a6fe8ac"
+    },
+    "progs/spiderbot_gib.mdl": {
+     "bytes": 19444,
+     "sha256": "96ee732ac1199a89c675880700c24e1f09521c35ad478f73aaf4278a398454f6"
+    },
+    "progs/spike.mdl": {
+     "bytes": 2820,
+     "sha256": "783d711b408498dbb34581c9a0ae74ed325dc5c68fa67873745b02c8a926a201"
+    },
+    "progs/spike_old.mdl": {
+     "bytes": 1684,
+     "sha256": "5e3be5dff13ec94951aacbd4a453dcbd9c2aebe7e4e6bded2dd70d49d1ddd695"
+    },
+    "progs/supbkpack.mdl": {
+     "bytes": 44408,
+     "sha256": "781c6b5f424fb58e06b2a84b1fb7e980778decde6b3ed257e224db0b1f250173"
+    },
+    "progs/torm_largeshot.mdl": {
+     "bytes": 37852,
+     "sha256": "ce3a87be213e39b48bc71a6fbf5e1fe9e3f5209901ca45801f27d8f297e04a01"
+    },
+    "progs/tormentor.mdl": {
+     "bytes": 461080,
+     "sha256": "df302dea113f54df908f97c26de844d1235004c08aefcf5c349f3af4b0957d41"
+    },
+    "progs/trifecta.mdl": {
+     "bytes": 25460,
+     "sha256": "2c9196af0806c48354f5522a8b7f6fa57e6390f8dfb51718fb71b8a2d4d7447a"
+    },
+    "progs/trifecta_big.mdl": {
+     "bytes": 25460,
+     "sha256": "9633a10c7c20f77b9202befad3cb363aefe710b166e581f80967ad94b5c6b6eb"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/v_alkaxe20fps.mdl": {
+     "bytes": 96428,
+     "sha256": "4405242db772d86c66f1012b140ba409bee86682fa5f4a6ca12c3e6f94eb9fcc"
+    },
+    "progs/v_axe_alk.mdl": {
+     "bytes": 55820,
+     "sha256": "80ad34cf2612f8fa9121f2be0ada92c1e05613ae2b35b2a1be25a4c694dd2147"
+    },
+    "progs/v_laserg40fps.mdl": {
+     "bytes": 142580,
+     "sha256": "b897ecb5868e3125597d51f970075af04782cba47ed8a42d7b17775dff01f536"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_mine_40fps.mdl": {
+     "bytes": 332920,
+     "sha256": "0039956e96a804229359aaf082b9cf66515d52360867b86c3dca884d19caf8b4"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail3.mdl": {
+     "bytes": 124944,
+     "sha256": "19045e9a5154299b68377744ad946fc3e7f2bd290497c8291a2247ed8cc572ad"
+    },
+    "progs/v_nail_alk40fps.mdl": {
+     "bytes": 44692,
+     "sha256": "402b3dc06f1e5e756cfd50cab17cca49e17e261994c5007cfd46c466a08d3dad"
+    },
+    "progs/v_nephrenka.mdl": {
+     "bytes": 13684,
+     "sha256": "a6b22faa92528d6341547677c04b058c3374e2a1b3499ae73861418746c2b1ba"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 260692,
+     "sha256": "0982368440a5d20d65ec511207590c2bfb63e9a60376a5d753b209f2b047c58b"
+    },
+    "progs/v_rock2_40fps.mdl": {
+     "bytes": 139668,
+     "sha256": "89257b7580ac3f48fc775f121eef3508c326eba1369e6aacae83144f8fdfca15"
+    },
+    "progs/v_rock_20fps.mdl": {
+     "bytes": 39556,
+     "sha256": "ebdd6245e1ff65bd95eaed7fa189ac87b51818408f091a32de3f4a477b90f2f8"
+    },
+    "progs/v_rock_40fps.mdl": {
+     "bytes": 43828,
+     "sha256": "f3c32a1c37d4fc3115a8da00ba9507cdd508a98f65e2ddccbcbdc8a0ba0bf2ea"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 326464,
+     "sha256": "dd389cc337d8b7675d9a7b983fd9f53f0c59d597a9759367bd1e1beba375eaaa"
+    },
+    "progs/v_shot2_40fps.mdl": {
+     "bytes": 29076,
+     "sha256": "37ae91c018183faef847aad217da537c97b5a2430ab27a860388bffc1f4514f6"
+    },
+    "progs/v_shot40fps.mdl": {
+     "bytes": 29252,
+     "sha256": "87a47e2debbc27fd6c18a8a38a9a373e7b73ba707458e6346f069c1572df47b4"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_p_key.mdl": {
+     "bytes": 10580,
+     "sha256": "fb3db38e23feda2ca9a8ee1400bdd0b452332f07bf9455db3eac0e52af1e3c22"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/wizard_alk.mdl": {
+     "bytes": 158508,
+     "sha256": "aab430eb2dc0f5c50ca7b4492a7ccc427f2a12011f54ece1b81d4beb66acb4a9"
+    },
+    "progs/zombie2.mdl": {
+     "bytes": 130148,
+     "sha256": "a06c8cff768f0e5491e2a5a0d22671b525d841df7081036ab2d63507eb17881c"
+    },
+    "quake.rc": {
+     "bytes": 2267,
+     "sha256": "f8afdd93f845a9cd25fb22b5fe9d2be5d18ca453ba994804f105fa65a92cda87"
+    },
+    "sound/alk_emt/ac1.wav": {
+     "bytes": 342374,
+     "sha256": "73752cd2b6407cb48ac651ba06b1b44b3bce2dc2187439f56fa12b947f4414b5"
+    },
+    "sound/alk_emt/hangar1.wav": {
+     "bytes": 714082,
+     "sha256": "15f0c87013e445065066cd68cec281331fbcd6501b7bd3f825ef908d85518f97"
+    },
+    "sound/alk_emt/klaxon1.wav": {
+     "bytes": 131116,
+     "sha256": "82a4ac7e620cc51bd63d20dfc256212fa9cabf384cd7431684402525ae5d3b43"
+    },
+    "sound/alk_emt/smasher.wav": {
+     "bytes": 124588,
+     "sha256": "0609c379a0aa35df478e90942a000b8a8fbe170a26ce695e83acc421b7da4865"
+    },
+    "sound/alk_gw/choppa.wav": {
+     "bytes": 82726,
+     "sha256": "caf182035ddb397a69755780032ff46e39b34111e13015dad38b0f3015ca96c1"
+    },
+    "sound/alk_juz/flyby1.wav": {
+     "bytes": 260406,
+     "sha256": "3fb54dce36de4164173ff68f2eed3a5b24a81c784b7d0758c29ba27620c11378"
+    },
+    "sound/alk_mh/alarm.wav": {
+     "bytes": 4198,
+     "sha256": "79094546244d3b2672134d40970512cbc9c260ba6501939f90623dcfa7836042"
+    },
+    "sound/alk_mh/drone.wav": {
+     "bytes": 34230,
+     "sha256": "042fd60360482b1aed17df4ae5a5bfe096282ddc173b4f47e82384c4c5ed1782"
+    },
+    "sound/alk_mh/emove.wav": {
+     "bytes": 33182,
+     "sha256": "0f9de23e794e7fcff8dcfd0397c92404d51dd0e299d0b909ef16afcc4615b00e"
+    },
+    "sound/alk_mh/rotor.wav": {
+     "bytes": 84212,
+     "sha256": "6cd09e076bca0871c75e13a9c73f9d3b172c3d36e8ed979bf680b035c3b724fd"
+    },
+    "sound/alk_zigi/huuto08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/alk_zigi/huuto24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/alk_zigi/kone.wav": {
+     "bytes": 190760,
+     "sha256": "59197f823b479c66c41163d82fed6dc13a715aef429b5e551ba80ca6f7c229fb"
+    },
+    "sound/alk_zigi/laf1.wav": {
+     "bytes": 126074,
+     "sha256": "a320badd6eb1189349ca484ae7f0dd005fb3f86be89618f22fcaca61f46e9b55"
+    },
+    "sound/alk_zigi/rumble2.wav": {
+     "bytes": 66200,
+     "sha256": "b2ca38e13253361aa1780c05269652c4aed4094f274948e865be6849d4a3b908"
+    },
+    "sound/alk_zigi/rumble7.wav": {
+     "bytes": 639494,
+     "sha256": "e19851eeca4d295a1e42cfece3fcced40779f14f73a4e923e3768f2cb0553a76"
+    },
+    "sound/alk_zigi/tuuletin.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/alk_zigi/valo.wav": {
+     "bytes": 26356,
+     "sha256": "c8203b1d67aa1e2458a5ac8e3edb9e7b79498b04251abd01c33356e65ad1681f"
+    },
+    "sound/alk_zigi/vent1.wav": {
+     "bytes": 153876,
+     "sha256": "0ac26f5ec7c080562c73ca3dae0fe0a705136912b641919f91f3f701875a76bb"
+    },
+    "sound/alk_zigi/ventsu.wav": {
+     "bytes": 32876,
+     "sha256": "1e0f99ffadead8460a7a4bed1c6b2c16cddd70050e1524e9cdaf6724a9dc81b5"
+    },
+    "sound/ambient/aramb1.wav": {
+     "bytes": 44476,
+     "sha256": "4c6440672b87575dd8ac5a267621881b9c70e48722cf9a4aa75a4a9b384fea5b"
+    },
+    "sound/ambient/arcohum1.wav": {
+     "bytes": 20418,
+     "sha256": "3b42cb1b62f62acabdc8ef8612ab4343b71b165c3525552701ef769f90020960"
+    },
+    "sound/ambient/arhum1.wav": {
+     "bytes": 20740,
+     "sha256": "e374f3d90564808e019abe09f4464b704512cf85ff0f3b4bb3c955b4153184e3"
+    },
+    "sound/ambient/arpump1.wav": {
+     "bytes": 18262,
+     "sha256": "11ae2c08c7d5f7f777eade75770a1623386d0e0096a19076fff13e9ddec6318c"
+    },
+    "sound/ambient/arwind.wav": {
+     "bytes": 30408,
+     "sha256": "34248569bb7ab66f5e1d874e15c7a91d89fd2b70d27e5521456b2589581fe1e6"
+    },
+    "sound/ambient/chatter.wav": {
+     "bytes": 190760,
+     "sha256": "59197f823b479c66c41163d82fed6dc13a715aef429b5e551ba80ca6f7c229fb"
+    },
+    "sound/ambient/comp.wav": {
+     "bytes": 12164,
+     "sha256": "ab8e3b13981bb432cca44ad4b7467734f52d01927018e72c99e7c4d052dc7874"
+    },
+    "sound/ambient/crickets.wav": {
+     "bytes": 12236,
+     "sha256": "d5cf6e56884a8e43469408d4788ec6e573167901586df259a938cd088c998ef9"
+    },
+    "sound/ambient/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambient/drone.wav": {
+     "bytes": 30902,
+     "sha256": "81993d96ab337f78c2778cecffe4767605fed210e0ac2303a46ac898979eea13"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/hum02.wav": {
+     "bytes": 37836,
+     "sha256": "8b2ee1b91fa663b6111de9251011142475831ece70ee091022b800b715f1bfa2"
+    },
+    "sound/ambient/intake.wav": {
+     "bytes": 25682,
+     "sha256": "e6d13169ce4680dd83903473897fd6e7ce1e51fab00c6df2127ea993321c05b0"
+    },
+    "sound/ambient/lava1.wav": {
+     "bytes": 926316,
+     "sha256": "41964be60ef167936d0ef74f47fdfa3c2b147f7ec1f5f26fbb312ee71be3a6bd"
+    },
+    "sound/ambient/lonoise.wav": {
+     "bytes": 32876,
+     "sha256": "1e0f99ffadead8460a7a4bed1c6b2c16cddd70050e1524e9cdaf6724a9dc81b5"
+    },
+    "sound/ambient/motor1.wav": {
+     "bytes": 52340,
+     "sha256": "c48511a37143e9ed50ae7c1d1f28235b007762949d3d18549fc545cc670c0a24"
+    },
+    "sound/ambient/motor2.wav": {
+     "bytes": 52014,
+     "sha256": "7f36cda5c01aea4e6b356ae4d0b31b68ca15d7606eefd30f4739a64fc4e86e6c"
+    },
+    "sound/ambient/rain.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/arachnofloyd/death1.wav": {
+     "bytes": 119460,
+     "sha256": "d16c7ff30e9df62fbcda102befbd61fe234532f6aef30d0b34c25330679682bc"
+    },
+    "sound/arachnofloyd/death2.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/arachnofloyd/idle1.wav": {
+     "bytes": 34254,
+     "sha256": "35d6991a10637251ec0d6b830f7f57f394e4eed06e7a9dced86f0128ba5bc49e"
+    },
+    "sound/arachnofloyd/idle2.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/arachnofloyd/leap.wav": {
+     "bytes": 70884,
+     "sha256": "f47323f618db14755c57e9e25213267dcffc501fbaa9a201176ab99db6cda928"
+    },
+    "sound/arachnofloyd/pain1.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/arachnofloyd/pain2.wav": {
+     "bytes": 15906,
+     "sha256": "9c4bdc81c73787cb67677e0021b71d9e24734ef3ce272d9020dc6611a1d87842"
+    },
+    "sound/arachnofloyd/sight.wav": {
+     "bytes": 48620,
+     "sha256": "97a055dbb8e5935190348b2c2d50c6d99ab35c29f3ebcd0f66d6263bdb5485e4"
+    },
+    "sound/arachnofloyd/step1.wav": {
+     "bytes": 74932,
+     "sha256": "a8744a3e50dccf9ee391da2f381c2ecf6701a76441406929ee4581c7717b880f"
+    },
+    "sound/arachnofloyd/step2.wav": {
+     "bytes": 34478,
+     "sha256": "22ce43aa18537f7b04e31263a46dd02e181d538fdf5918d55f8ce0acbb930676"
+    },
+    "sound/arachnofloyd/whirr1.wav": {
+     "bytes": 19762,
+     "sha256": "9e2029071248e6d45f1b0d518983bad5bc5f841cda6bcfba09486e111add10de"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axegrunt/axgdeath.wav": {
+     "bytes": 20214,
+     "sha256": "e5ed762afcc516058acc1b3884b4d08e67fd36e3a5bacf711d3504363bf8136e"
+    },
+    "sound/axegrunt/axgpain.wav": {
+     "bytes": 12636,
+     "sha256": "4699951fa58fdf15ab819b13d70904fc9a1a86a4db02193d621dfad3878d17bf"
+    },
+    "sound/axegrunt/axgsight.wav": {
+     "bytes": 17712,
+     "sha256": "e7b23208831c1d83793ba06f3b8855430c92017600cd8315341afbcb6ec6c8f0"
+    },
+    "sound/bambler/melee1.wav": {
+     "bytes": 4175,
+     "sha256": "4e0e2567b9d64b3ff86b33d95fa0158bf72372aeb4968a0c2489df942f9f7c4d"
+    },
+    "sound/bambler/melee2.wav": {
+     "bytes": 5283,
+     "sha256": "4bb91991bccfc33576eff19037e12666e9825348272d3dca40199e208bc00700"
+    },
+    "sound/bambler/sdeath.wav": {
+     "bytes": 14048,
+     "sha256": "c5253af82d203e75d132a00bbb555de055d2e356106d460f34cb8c9a2ee5e643"
+    },
+    "sound/bambler/shurt2.wav": {
+     "bytes": 3736,
+     "sha256": "0f1a51e0ff72f23a4de7684d4408344b7b7bd2cb805609168d2f2459e1b8660d"
+    },
+    "sound/bambler/sidle.wav": {
+     "bytes": 4907,
+     "sha256": "ea2232ba791e306cc86f58303413d8f3fbc7dd38091281698f4d846b6cafa483"
+    },
+    "sound/bambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/bambler/ssight.wav": {
+     "bytes": 11376,
+     "sha256": "de766aa056ca5f7dc6d179e6a220ef906ceacc0341b5cb3d91a4d0e75ff55338"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/bmfbr/alarm.wav": {
+     "bytes": 21058,
+     "sha256": "539cb807f9fdd4c93c24ad09f57249d600c109dfdd78a7f90f294ffb4c7e8b6b"
+    },
+    "sound/bmfbr/barmusic.wav": {
+     "bytes": 77898,
+     "sha256": "af57a7b9b00323f6395f9f81af4fb5971657ad764665552036b057442c7c18e7"
+    },
+    "sound/bmfbr/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/bmfbr/rain1_nl.wav": {
+     "bytes": 154490,
+     "sha256": "ab83161b01f9299cad8af7142f688c4f2f36e16e973eb42fa6faa13a7a6cc51d"
+    },
+    "sound/bmfbr/reactor1.wav": {
+     "bytes": 207486,
+     "sha256": "71b3bb44e623638db55b899c9847ca8c05d5c9c16c0897c28044b64c8060dc25"
+    },
+    "sound/cyberscrag/fall1.wav": {
+     "bytes": 23396,
+     "sha256": "162fc0be1cd0eadfc93c35f1e1ba9b8dfc7e8df8ee53afb2a14db73e69f20ce8"
+    },
+    "sound/cyberscrag/hit.wav": {
+     "bytes": 22334,
+     "sha256": "a16ef33d94d56fb6984b2a3d06104a3cc292bdb38ec6ee22c8b10457b2cb415f"
+    },
+    "sound/cyberscrag/wattack.wav": {
+     "bytes": 25912,
+     "sha256": "6bed724b7ef9bdd480448396ed4498c75f848bf2a1e6d2879cb2b2484cdd1a7b"
+    },
+    "sound/cyberscrag/wdeath.wav": {
+     "bytes": 20684,
+     "sha256": "24602233cca209122250ba7c284933992aa2393795ea5c528a57b9986e2fc319"
+    },
+    "sound/cyberscrag/widle1.wav": {
+     "bytes": 13465,
+     "sha256": "8902628d2201eda9396c0dc134ebda8b8d5c37dabddcd286f8387aadc6532750"
+    },
+    "sound/cyberscrag/widle2.wav": {
+     "bytes": 23094,
+     "sha256": "76af020e5c25f40ab3020bbd065a9b83b9b0a51120d47d137a7abff4eb43e193"
+    },
+    "sound/cyberscrag/wpain.wav": {
+     "bytes": 8687,
+     "sha256": "af2e8589d381e634f607048ce71200df832c9e3a32147891b5bdd2efe2ff5bf0"
+    },
+    "sound/cyberscrag/wsight.wav": {
+     "bytes": 13079,
+     "sha256": "2f9178f6515eb4cd518b418441c40d1376aeaf6f42f7791533f5f4b6da87fd68"
+    },
+    "sound/doors/alka_doorlocked.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/q2door1.wav": {
+     "bytes": 30572,
+     "sha256": "3f05bddf76379933970c532656b6350bc53820319ce1cb9d4ea9288210427eee"
+    },
+    "sound/doors/q2door2.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/dread/dread_death.wav": {
+     "bytes": 49692,
+     "sha256": "22000ff613ff52eab0605418681affaf7aeef4acc420d3dddd50a9031ac1ca38"
+    },
+    "sound/dread/dread_pain1.wav": {
+     "bytes": 29220,
+     "sha256": "67e443f78043cb9fc4213bbfbc3cd847785a66849fb7b36dd6467494487e0aec"
+    },
+    "sound/dread/dread_pain2.wav": {
+     "bytes": 23380,
+     "sha256": "914fffe3ad6c02fb78be873ee96405a40df22cd321beee2d673d0b6ebbafcde4"
+    },
+    "sound/dread/dread_sight.wav": {
+     "bytes": 70792,
+     "sha256": "50449a772b2ac778b810a69de58cb63c8bbdea529091720a41a1052b7196632e"
+    },
+    "sound/dread/dread_sight2.wav": {
+     "bytes": 58420,
+     "sha256": "f7952137b648f6376a1ba4e968679abb17fc648ede87bb0dd32f633271ad80ee"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 110256,
+     "sha256": "895cfb57c0d27369530fd5e9b29abd491a989ad0a63ddb00f05dd9e4777a5cdb"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/frogman/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 32638,
+     "sha256": "3cf3933f34c7baef52df54d5b03db40424e9f7ee72e5aa5a4dba489d71be2af7"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 27662,
+     "sha256": "ec38e73fd1ffc33cd25aa065e5f5897c21a494e380763ff80b6be482689b5e33"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 44186,
+     "sha256": "7600cd32fe980646fddcf5a9077d8d43df1bca1f2ed05bd92ce8cca273ad6636"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 132344,
+     "sha256": "9247347179344c541a627bc8ff74e5ce43744e47f5f3a02181402791257b675a"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 33120,
+     "sha256": "9fbfa3f46a27f850615fb4ea4cd760f6ee5817ddad856b44ec51a84138ec91dc"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 54336,
+     "sha256": "1e6a0c92fa9902238e01b4e8a1ff5b9fbe1a37d71cdff7e31f97c0f630d76a20"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/armor_denied.wav": {
+     "bytes": 15854,
+     "sha256": "2ec14677f483d1a1b869af64cc30fb0dbd90a640fc071fdf2ae493d27cd746e1"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/items/shard_pickup.wav": {
+     "bytes": 18260,
+     "sha256": "388923a63b48720647b9e0f2862c35bb1d5cad2e162ace343845b3fe36b48af4"
+    },
+    "sound/items/trifecta.wav": {
+     "bytes": 16412,
+     "sha256": "00baad51adaa3f5d6664e85ae5442221db6818bfd85124c164324d22f6723ab2"
+    },
+    "sound/items/trifecta2.wav": {
+     "bytes": 32778,
+     "sha256": "f742a9cee4a53ef52fce55d5e9ddaae9c6b20d2127e16c0def6cd11b3d2d6380"
+    },
+    "sound/items/trifecta3.wav": {
+     "bytes": 10728,
+     "sha256": "a78bfc9fa4fbf0c3c1e85bee273ee053598989a09146bd29e97dda811c49a473"
+    },
+    "sound/lieut/alert.wav": {
+     "bytes": 8700,
+     "sha256": "7ebbe83ae1b5d159c9f0a0ae5f3dea126650ed5d6f98a22d1512dcfcb19a23ca"
+    },
+    "sound/lieut/objective.wav": {
+     "bytes": 10052,
+     "sha256": "aa7d6726a458eaa48bf2e20446c57360b82ac23bfbd06bad7b6e01ae95ca8b0d"
+    },
+    "sound/lieut/target.wav": {
+     "bytes": 6754,
+     "sha256": "eebd50c75585894c7d5305f6c066aaef1efaca9a59e27b80d03e8ae4d69caa69"
+    },
+    "sound/lieut/you.wav": {
+     "bytes": 7126,
+     "sha256": "6bfb031b0d69b8ae4ef2e9b201da43c523ae88de344907648d4064e07477ee1c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/mechavore/attack.wav": {
+     "bytes": 66460,
+     "sha256": "fc2a8b0e2a72aebe2858b8337d5ef0638e3e04d5b60e9a62d46ac124072705f9"
+    },
+    "sound/mechavore/death.wav": {
+     "bytes": 37504,
+     "sha256": "bbdf8369941f8c2ab302fe3a55de3bf04e1d28e32a575ffd3c24009d76bebc8f"
+    },
+    "sound/mechavore/idle.wav": {
+     "bytes": 64972,
+     "sha256": "5cd8253f1abe5baf08f1852d12393ca820c34fc0f2febf6c1c8f9d4c3326b2c5"
+    },
+    "sound/mechavore/mv_attack.wav": {
+     "bytes": 67046,
+     "sha256": "af133ede9ab5627f3ea75b12716653b11dd813982cab4a6aad0792371ba58006"
+    },
+    "sound/mechavore/mv_death_a.wav": {
+     "bytes": 125364,
+     "sha256": "7a51ba5587b4c8ccd4bd0e93b105f277f4f093a1cd90f684afb33cf0bbfc812e"
+    },
+    "sound/mechavore/mv_idle_a.wav": {
+     "bytes": 61484,
+     "sha256": "463f1bd23c4bf5d2953ce2f7ee980c9fb28725a0bdc92bc1f03dab8e139a2f14"
+    },
+    "sound/mechavore/mv_pain2_a.wav": {
+     "bytes": 41004,
+     "sha256": "18e27023c1ea7ce306f49559a8f303f62fcc206f05f94878bd1898e204972ebd"
+    },
+    "sound/mechavore/mv_pain_a.wav": {
+     "bytes": 49196,
+     "sha256": "7e2a98060c2ebe14313c831e8d3d410aacd70d7bffa9ef45b0f98845cebdfab1"
+    },
+    "sound/mechavore/mv_sight_b.wav": {
+     "bytes": 57388,
+     "sha256": "2212706950e66000184352238f479d659ea37062186b595e6834bb4d1d910c7f"
+    },
+    "sound/mechavore/pain.wav": {
+     "bytes": 36444,
+     "sha256": "9f9368fdd53aec80fd43a6d3b6680e04aae72685d1cfbdf49d55dc1070e8c546"
+    },
+    "sound/mechavore/sight.wav": {
+     "bytes": 116312,
+     "sha256": "112613b44d88046653b29f21aa5fced5d4b5bfcaff037dfa5f246729e45a6968"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/conc_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/misc/door_closed.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/misc/ebell.wav": {
+     "bytes": 15220,
+     "sha256": "1693337ed8873f1159e56c2925afaa210f5c28bee4e2c42d27e29bee8e06cb5f"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/jumppad.wav": {
+     "bytes": 31485,
+     "sha256": "cfc06af995406d853cae30df8db02c340bf7c775f955f5a02de60dc20c66fc0f"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 4054,
+     "sha256": "b9c44f73c8bdbc900af4f06600e0d6456a040b296612b7d0fe53391285976a44"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 4098,
+     "sha256": "4fad66341514c9aa2b31b4c2fde7563369090da9b0b3a51e08bca3100f2ec282"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5054,
+     "sha256": "d158ddc35360bc43934b7a8a9b7cc830f7510e6bb3a640813157822b27b5217a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 9726,
+     "sha256": "73b74099c8cb43ab2fb09b28b72ddd9f73f2d2a4f8a00a8e835490f366680c92"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 3226,
+     "sha256": "48551cc717e5011df78a38c6a71bb001e4f62a1858a3952311499653ff423a07"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 5802,
+     "sha256": "751050f97456a0c07e88a249d40dde96c2d14640e21670ccdde983502998dbba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/singledrip1.wav": {
+     "bytes": 26546,
+     "sha256": "b9193092eaa02003c7ea409663dc1213f0a18a120471a76d298ce847448059b6"
+    },
+    "sound/misc/singledrip2.wav": {
+     "bytes": 25478,
+     "sha256": "562ac78cd1d84805723e3bb24f66c60197d03bab081d7ee8402bf2b59bc7bf0c"
+    },
+    "sound/misc/singledrip3.wav": {
+     "bytes": 44558,
+     "sha256": "55ae1b970143af2553b845503363d94aa917a1cdb8aa1e48edec7869660007c3"
+    },
+    "sound/misc/singledrip4.wav": {
+     "bytes": 45492,
+     "sha256": "db0126239cf71ce69f6c06eb5c5418889b96e52e6741f6b172a146887e6815ef"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/misc/wood_impact.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/mutant/mutatck1.wav": {
+     "bytes": 6116,
+     "sha256": "410f926534f21705e78a804ce048b0c15e62fe0c68a45aae1b3741fb227551f7"
+    },
+    "sound/mutant/mutatck2.wav": {
+     "bytes": 18260,
+     "sha256": "66009d09adf71f10117c74f5004c995fd48362b2f4fcfaaa3bc2da01e66d115f"
+    },
+    "sound/mutant/mutatck3.wav": {
+     "bytes": 28840,
+     "sha256": "2dd8a615ca2be248c8370d7480f5a8ca9375d31e6af41bba603df660d31883a1"
+    },
+    "sound/mutant/mutdeth1.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/mutant/mutidle1.wav": {
+     "bytes": 81004,
+     "sha256": "8c7e8ad544d7e2470bd61d88c5cd8be1a0eb66f57aaf113f82d990ee00450073"
+    },
+    "sound/mutant/mutpain1.wav": {
+     "bytes": 56716,
+     "sha256": "49ff5f97fedc87c1ac06dc43d4ff0a0fd09fb481354b6373d607bfabc9a57a6a"
+    },
+    "sound/mutant/mutpain2.wav": {
+     "bytes": 58740,
+     "sha256": "b79f1cce60226daa3e3ca8c134da968d54ad51abd9c37ffebdf3d46c5d9f91c6"
+    },
+    "sound/mutant/mutsght1.wav": {
+     "bytes": 107316,
+     "sha256": "7e15e392edc3f2d5ae9e3bde3dfe65595a85728022245f74b81f072d75dce798"
+    },
+    "sound/mutant/mutsrch1.wav": {
+     "bytes": 101244,
+     "sha256": "44484ef4c189511fb0a8d0f2bea83e443e1f1bd51cef04f518f3820e58e88a69"
+    },
+    "sound/mutant/step1.wav": {
+     "bytes": 8140,
+     "sha256": "0d9af35156c84213ac7ffbde54d0f2518fe9d39bba4edc48c94e71bed4f7ec4d"
+    },
+    "sound/mutant/step2.wav": {
+     "bytes": 14212,
+     "sha256": "f7c81df1bff56c8aeb49891fa822c37ddcb019e97a654738a9fb8ee351d19eac"
+    },
+    "sound/mutant/step3.wav": {
+     "bytes": 4092,
+     "sha256": "89856afec31f800219c45253514d0fdf5b5bd800c32f87ba74dd0c21df181550"
+    },
+    "sound/mutant/thud1.wav": {
+     "bytes": 32428,
+     "sha256": "20ed5f20729a068801d06904365e46c9d692dec835710a9b8090d0a1956d6919"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    },
+    "sound/ogre/rogre_alert.wav": {
+     "bytes": 71728,
+     "sha256": "4f3e921b6ee236289660f7ca2ee8a4689e719423266d26a3f8b91ae29d02c6a5"
+    },
+    "sound/ogre/rogre_idle1.wav": {
+     "bytes": 110330,
+     "sha256": "a07df4a53c9e8de310b9d963bfb9c841c51e502565f39dc543bf1c025edd41d6"
+    },
+    "sound/ogre/rogre_idle2.wav": {
+     "bytes": 79416,
+     "sha256": "862258641dc3c90d2a9e5f9e2a4418eb0037eedf22cde798682a169a84f13a44"
+    },
+    "sound/player/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/player/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/player/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/player/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/player/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/player/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/player/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/rail.wav": {
+     "bytes": 97196,
+     "sha256": "396a85e1e2083f2b1eaae89a3f33a21145a643f3f50419523497719ef8e7598a"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/rider/sight.wav": {
+     "bytes": 26356,
+     "sha256": "40ace6f3beeb920ba1bbdb197f8ece18d312762a71e494726289e16703d75d91"
+    },
+    "sound/rider/step.wav": {
+     "bytes": 40524,
+     "sha256": "a43e24ecbc62d44bce466b1e682ebf64c230e03f4d79449406ce021dc8276a9a"
+    },
+    "sound/rider/thump.wav": {
+     "bytes": 15444,
+     "sha256": "af29f4e8f6debb1223aeb5d840add4ae01cb5e9f6bd9a26efeadff518f34380d"
+    },
+    "sound/scientist/allnominal.wav": {
+     "bytes": 23778,
+     "sha256": "e26f9bb3c24d9a9e0da38395048f6dacffe82d800da49d56378027250393d69a"
+    },
+    "sound/scientist/alright.wav": {
+     "bytes": 9666,
+     "sha256": "372c1aa91e6841bec2441215c894b7d149bdeaef33f907d23bb7eaf637520ce3"
+    },
+    "sound/scientist/asexpected.wav": {
+     "bytes": 15982,
+     "sha256": "306933848b673bd14d7074d59e45a8c97bc00a2897601509e52e5835e2ffc997"
+    },
+    "sound/scientist/c1a0_sci_crit2a.wav": {
+     "bytes": 28364,
+     "sha256": "f972684c74eeb51872873cc2b7053448c6cdd716b8c3535929fdbcc508d62ef5"
+    },
+    "sound/scientist/c1a0_sci_stall.wav": {
+     "bytes": 13704,
+     "sha256": "541c192ad5e8a68c76706ec17b3deceafbdc607bfc372ddfd300532f8aa1eaef"
+    },
+    "sound/scientist/cantbeserious.wav": {
+     "bytes": 13236,
+     "sha256": "fc4a8a379f70e33db79a49c667dcd9f1622de29d7b32ef3973c4ffdb5d80ee44"
+    },
+    "sound/scientist/cough.wav": {
+     "bytes": 14878,
+     "sha256": "b4e620259623347a5be3f7eaf3c531e6ea9ef2e97ac42997dd78cfee9327f7bf"
+    },
+    "sound/scientist/sci_die1.wav": {
+     "bytes": 15558,
+     "sha256": "c2306d7f9fa58f99961c347b06ef26305b99ac43ec27b2b222962e1f3a9ccce9"
+    },
+    "sound/scientist/sci_die2.wav": {
+     "bytes": 5402,
+     "sha256": "14deecb570d1e315b772713d54b7250043bb0dd5f3d5538cd0636e39a523c54f"
+    },
+    "sound/scientist/sci_die3.wav": {
+     "bytes": 3104,
+     "sha256": "075cdbc5837d91b61ad7599cdb3abf9323872816f8966c83deab9c0a6e04d7d2"
+    },
+    "sound/scientist/sci_die4.wav": {
+     "bytes": 4024,
+     "sha256": "e6ca0d4f18ac6c1246926646568618057cb70b5cee995c1c2dd69f0179b892ad"
+    },
+    "sound/scientist/sci_dragoff.wav": {
+     "bytes": 8986,
+     "sha256": "0c6a21cd5edf01e495e1258e9a76c05d62c0e3cd697e787fd43fd4bd9126483b"
+    },
+    "sound/scientist/sci_fear13.wav": {
+     "bytes": 4534,
+     "sha256": "dabce7a6c12980f947f7504da264fabb67a804d2e478b7f252ab527fb21a92d0"
+    },
+    "sound/scientist/sci_fear15.wav": {
+     "bytes": 4764,
+     "sha256": "f0d23c680ad138c3cc12da78a3e45cbf3daa47e5da9bc62a1dbb3b27389565a5"
+    },
+    "sound/scientist/sci_fear6.wav": {
+     "bytes": 5588,
+     "sha256": "ff2702b2b9e517b90ea0c2853775a4a95160edfae5af0a7f9208f07624d84281"
+    },
+    "sound/scientist/sci_fear7.wav": {
+     "bytes": 8458,
+     "sha256": "f2a39185c2d39a03b39afd7fe6f942b2f35fd17135ade8ceb4c31968c768aafa"
+    },
+    "sound/scientist/sci_fear8.wav": {
+     "bytes": 5804,
+     "sha256": "4455a29590d5f42ebbf06e600d8ba3f45acfd5000a6b8045891cbecf1d937970"
+    },
+    "sound/scientist/scream01.wav": {
+     "bytes": 14666,
+     "sha256": "b738de99aefbe3a45724914dd6eb79c0f8c219aaf733554a8a5eb94836c22320"
+    },
+    "sound/scientist/scream06.wav": {
+     "bytes": 13938,
+     "sha256": "dee8ac2058635d00458e2e74402d1cfcb5362c64259fc2c4f3b6bba31bdf6337"
+    },
+    "sound/scientist/scream08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/scientist/scream09.wav": {
+     "bytes": 6130,
+     "sha256": "85947649f5fb1491732365849a3025bf5c76c791b395cfdf421fbbd6ec58d351"
+    },
+    "sound/scientist/scream10.wav": {
+     "bytes": 5392,
+     "sha256": "fff4c0735f9c312be7cda848fc2867590437ffe9758fe685e3b4c94678ca1f48"
+    },
+    "sound/scientist/scream14.wav": {
+     "bytes": 4824,
+     "sha256": "dcb7dfb0e307b813476b2e55dceb59d8ae2b9514b1ef02034ea255fa5f086b05"
+    },
+    "sound/scientist/scream15.wav": {
+     "bytes": 3048,
+     "sha256": "37d26fe2d2b8a39d0fec0eceec0ca974ec3dd7fed33bae0d3230a934954105f0"
+    },
+    "sound/scientist/scream16.wav": {
+     "bytes": 2328,
+     "sha256": "4ff04ce8ff07af708c84dacc8df114b68620d47e8e4e4c78dfc4fd33a8a9b98d"
+    },
+    "sound/scientist/scream17.wav": {
+     "bytes": 3836,
+     "sha256": "82fb51224e06db5022adfa58f0b02353c333229ed3312f86dd9ec4f04813c37c"
+    },
+    "sound/scientist/scream18.wav": {
+     "bytes": 3066,
+     "sha256": "bfefcf745ab8d30db11f9113ecf9ba1c5bc6d9b2351c53f3f46d66e03cbea3fe"
+    },
+    "sound/scientist/scream19.wav": {
+     "bytes": 2504,
+     "sha256": "47cc414d201aadb7ba2fe0ce0567ff5360e90fd9de4a167520988513f358ed41"
+    },
+    "sound/scientist/scream20.wav": {
+     "bytes": 21310,
+     "sha256": "124cb45d3d5533572e3cfe4b42bddad2a03dc0d8de1c89a42ea57433432e3a6e"
+    },
+    "sound/scientist/scream22.wav": {
+     "bytes": 15206,
+     "sha256": "6e0a509eb2468466591622e74724c31103b8b60f5d8f29514fb57e9d9d12c9d4"
+    },
+    "sound/scientist/scream23.wav": {
+     "bytes": 21988,
+     "sha256": "8521907e8cecc22e6924d23295a5e8d31333d265ca27a9533b083b68e9da6d12"
+    },
+    "sound/scientist/scream24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/scientist/scream25.wav": {
+     "bytes": 8122,
+     "sha256": "38281749deffb4e567896f71e7bcb75d7b2e253e404a953a5eea6eeb989f156a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/spiderbot/sactiv.wav": {
+     "bytes": 17066,
+     "sha256": "f21587ba9bfd159e48c5b3aa1c6e94eac7157053e4e5699459233fb28c2631c8"
+    },
+    "sound/spiderbot/scharge.wav": {
+     "bytes": 7300,
+     "sha256": "b58064dac4e12bd6685edbfe61417a530cde1e5175336193b2fa7a292aca8ef7"
+    },
+    "sound/spiderbot/swalk.wav": {
+     "bytes": 12636,
+     "sha256": "5534fe1b11fea5406aada214681dba031ec4a01e4b660c405b679131ba07a7cc"
+    },
+    "sound/tormentor/angry1.wav": {
+     "bytes": 88890,
+     "sha256": "60f757f523a9cbb3a57c335bbeda8cedbf990b9d20a5b359e610b712a1344b4b"
+    },
+    "sound/tormentor/angry2.wav": {
+     "bytes": 90912,
+     "sha256": "2f38dddb69cf0df2c1e5b028ca06ea22d979e637afa927919e9a93876dc955d6"
+    },
+    "sound/tormentor/death.wav": {
+     "bytes": 176628,
+     "sha256": "7060ecdadac0b1c9eb3574284444932573e4af13082f01374ed8a4633387bb66"
+    },
+    "sound/tormentor/fire2.wav": {
+     "bytes": 52092,
+     "sha256": "4133a00c7ef157d291d800524a148c188a314eb5ca14246958b8ddfeb0d4fe41"
+    },
+    "sound/tormentor/idle1.wav": {
+     "bytes": 115740,
+     "sha256": "78feebc847dccab66478718b66971870f11246c416e2f2c1e9830c459e4c0347"
+    },
+    "sound/tormentor/idle2.wav": {
+     "bytes": 122218,
+     "sha256": "0270712fe40851bb21d959932b4f8f75bbe8b985e2ff383319059c656ac0ce56"
+    },
+    "sound/tormentor/pain1.wav": {
+     "bytes": 67334,
+     "sha256": "03f255d6ee0d6fb83f2a643491f4cd24d9c5ff86444a51b3cf8b5a0de3d86bbc"
+    },
+    "sound/tormentor/punch_hit.wav": {
+     "bytes": 76614,
+     "sha256": "e524d16b000237615bae3b8fed7b74726823cd4258561196f4641728047aaa26"
+    },
+    "sound/tormentor/punch_swoosh.wav": {
+     "bytes": 33044,
+     "sha256": "d0ef38ef4bf33d0c2f92b22c2a767c4efd66eefaa724df50b394958a7be5a705"
+    },
+    "sound/tormentor/sight.wav": {
+     "bytes": 94334,
+     "sha256": "34a13e6469c5e0ce2f6d18721b0cdd634731b9a9f8910a8bb8b685f63dadfaac"
+    },
+    "sound/tormentor/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/tormentor/sting2.wav": {
+     "bytes": 21674,
+     "sha256": "dd2d40459c7aa9d374efe2f219c34773f390df9f5177a83dbfa5fd638a13c542"
+    },
+    "sound/turret/alarm.wav": {
+     "bytes": 22126,
+     "sha256": "20a8a83d73a55dcc3d8a6fcb79b4ff8ecba0b5887cf3bdcdc96303f069b062ce"
+    },
+    "sound/turret/beep.wav": {
+     "bytes": 22126,
+     "sha256": "89f0e2ba68562cfc3e20272f995777c174c2681cfcf29d2ef337974009b42460"
+    },
+    "sound/turret/deploy.wav": {
+     "bytes": 105260,
+     "sha256": "5bb8c1fa8ffdf22e58ac5fb7a337916a457b9d021661742fcdbbdd7ce188c6dd"
+    },
+    "sound/turret/deploy2.wav": {
+     "bytes": 54208,
+     "sha256": "ec26b9451b67dae2929488687b7b9344a96f7538ab5c4f69e8a85602804dffc2"
+    },
+    "sound/turret/disable.wav": {
+     "bytes": 57180,
+     "sha256": "d8767dcce34c1c7f660f5868c23938da4cc379cb4001b88a10ec1aebbf9e557c"
+    },
+    "sound/turret/idle.wav": {
+     "bytes": 35784,
+     "sha256": "fba6bc2ff517ef95a999e3910c74e3594e054ede298c7b3a5659a2c31565d37c"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/weapons/dsplasma2.wav": {
+     "bytes": 45596,
+     "sha256": "87a1b465c16610b012abe83da7851993f9dd756cc764abca0221d31a09aba156"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 43820,
+     "sha256": "32082cd1d44903409e97de782e5d9295272840e13280665a0ef3ff862b187f0f"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 47570,
+     "sha256": "0dd8defb8ecfb1ea72e6ac70ab182573775812e2d7990dd2897d02d3c38464f5"
+    },
+    "sound/weapons/spindn_click.wav": {
+     "bytes": 9986,
+     "sha256": "b84866cddb7e61eea9ca49208d427c2289d63e6e3e2f59d4d51e302573079bc7"
+    },
+    "sound/zombie2/attack1.wav": {
+     "bytes": 22914,
+     "sha256": "da5345280208ea48855526989299927268566cef77ee187035bbe969076d6605"
+    },
+    "sound/zombie2/attack2.wav": {
+     "bytes": 24072,
+     "sha256": "59245700b47794e239563cc94e3ff045fcd7dad795bcfe343d8574ec3ac525b6"
+    },
+    "sound/zombie2/attack3.wav": {
+     "bytes": 15400,
+     "sha256": "0113aad711264c05a9e43bf8dba915bc89661444d7d802efabe8d61ebb3ba13f"
+    },
+    "sound/zombie2/attack4.wav": {
+     "bytes": 20922,
+     "sha256": "0aac55ae62b62cefece56103cd7079beeb433c3764f590641876e149c4328ecc"
+    },
+    "sound/zombie2/attack5.wav": {
+     "bytes": 26086,
+     "sha256": "b58c97928b535e79973e0390512b09d3d0adea79b1b1b5a8de59bc2cde40c412"
+    },
+    "sound/zombie2/attack6.wav": {
+     "bytes": 22272,
+     "sha256": "58c429256e2f5abb9d97c99ceedb78088d8ac977eca94e994b6d1eee8bb3eb8f"
+    },
+    "sound/zombie2/attack7.wav": {
+     "bytes": 34384,
+     "sha256": "d68e81783b6583738227eac608ab7af1a4b1e1b085c1e46bd9c0d029eab4fdde"
+    },
+    "sound/zombie2/death1.wav": {
+     "bytes": 46548,
+     "sha256": "a1b9e2bcebf9c56fb56405d1ec7fe4166ac10d2b6e1acc6f01e58aec9fd63e87"
+    },
+    "sound/zombie2/death2.wav": {
+     "bytes": 47048,
+     "sha256": "5964a3c1a665c70de8302052b2b6d72ea46b0a5e07ba22cc9919e1a0ffefcca3"
+    },
+    "sound/zombie2/death3.wav": {
+     "bytes": 52636,
+     "sha256": "5c76f8bc55ecea263df880e6b683b07066b37c9f62ff589b0e999534d3c256b0"
+    },
+    "sound/zombie2/footstep1.wav": {
+     "bytes": 12966,
+     "sha256": "2a85309bea05b7c7c90a82df071822828e413cce17646a9686fa4f1264d75e48"
+    },
+    "sound/zombie2/footstep2.wav": {
+     "bytes": 16880,
+     "sha256": "d1d9e9c3811b39b67c9a6966851873ff7edf8d1407c5d9b90782b233196a4872"
+    },
+    "sound/zombie2/footstep3.wav": {
+     "bytes": 20904,
+     "sha256": "b12e9ea9b9478428b886fcaab504856393a57abd8cfdfc5ba5357ad745ee3455"
+    },
+    "sound/zombie2/footstep4.wav": {
+     "bytes": 15796,
+     "sha256": "6f82ac60991e64c8c48a3208a161b46f5b916587cb41863992dc1acb08268889"
+    },
+    "sound/zombie2/footstep5.wav": {
+     "bytes": 17800,
+     "sha256": "ca12f6ade73e5d5ba4ec1bdf680ce25afe3270bb88d702e1493b75619ec088d9"
+    },
+    "sound/zombie2/idle1.wav": {
+     "bytes": 143832,
+     "sha256": "aa203b0beb2db12beb6929fbc3646f7f119d4d31ede66b13af0412d396f7dd6d"
+    },
+    "sound/zombie2/idle2.wav": {
+     "bytes": 277026,
+     "sha256": "9496f3179e875bbb4d7442c252eac0eb2b9ef6d2269d43c141e01242ed2de7ee"
+    },
+    "sound/zombie2/idle3.wav": {
+     "bytes": 234026,
+     "sha256": "4820b03de8cebdee6fe787b5bf60724c17a0e133fdd5451176a202043f730f8e"
+    },
+    "sound/zombie2/idle4.wav": {
+     "bytes": 166352,
+     "sha256": "a515e5dc0e4fe1412a7936df5fab0f57a48c385db4fa357c1a4120671ac99617"
+    },
+    "sound/zombie2/idle5.wav": {
+     "bytes": 62782,
+     "sha256": "c6e4e2f26769400b7ca3b08339af089ba28bc063447d642e10cffffc6e03a485"
+    },
+    "sound/zombie2/idle6.wav": {
+     "bytes": 47274,
+     "sha256": "9ad1ced551cb42764fd88baf26ee09dc72d1852fa2da7405fde370d3e4d69a01"
+    },
+    "sound/zombie2/idle7.wav": {
+     "bytes": 45614,
+     "sha256": "41783a7682d5f8bb91aff8308b8657504cc8f0460b5ca436a5d0fb1c93357c85"
+    },
+    "sound/zombie2/idle8.wav": {
+     "bytes": 73070,
+     "sha256": "8f390d861feda3fb3950b0f33ce3efbfa8eda214533324674ac40b6e227b6975"
+    },
+    "sound/zombie2/punch1.wav": {
+     "bytes": 9218,
+     "sha256": "db6787efe0a0b8df5da690b91afe46a2199911b661fc9de1cfffc00b6bb8c46c"
+    },
+    "sound/zombie2/punch2.wav": {
+     "bytes": 8032,
+     "sha256": "747aabd6237176ae1bc62669cb08c7ec65fb26aa2147f6a3e1ab43f02ace7322"
+    },
+    "sound/zombie2/punch3.wav": {
+     "bytes": 13076,
+     "sha256": "05bb75533252d15983a944263789de5ee51187e518f4544fd1915b57ba726c7e"
+    },
+    "sound/zombie2/punch4.wav": {
+     "bytes": 13198,
+     "sha256": "d07556e7fc774958a6105564a990c51a0dab64fcf9508475617921a0ac5b961c"
+    },
+    "sound/zombie2/sight1.wav": {
+     "bytes": 73234,
+     "sha256": "387534044f10592ca6bc7a96b8e782c7b51de87b907e79a8f410d535e17d37ee"
+    },
+    "sound/zombie2/sight2.wav": {
+     "bytes": 52224,
+     "sha256": "cbc95608d4553d0bae66411d69875210e6fc6d728bd30deb6bbce7aabbacb773"
+    },
+    "sound/zombie2/sight3.wav": {
+     "bytes": 63072,
+     "sha256": "cbbcdb6da59d830a3be66095053259b17a90cc6501728ed1aa50d9524818f99b"
+    }
+   },
    "sha256": "1d6b4d236a5b9bc98f3290bb8333ffa68646412611d8e1ff6b185a59ff690613",
    "timestamp": "2024-06-03T14:10:10.000Z"
   },
   "limjam/pak1.pak": {
    "bytes": 1136350,
+   "files": {
+    "VHS HUD Kebby.txt": {
+     "bytes": 277,
+     "sha256": "3f7e351548808fd063ecdf9c08dd67b48c4b8219f61531e04147b730c71e1b67"
+    },
+    "gfx.wad": {
+     "bytes": 210484,
+     "sha256": "2b368727fafc7de8480b5f39a369f293dd6b239a8562f0a735cf89565a9e7d24"
+    },
+    "gfx/bg_ammo.lmp": {
+     "bytes": 1928,
+     "sha256": "b50966401fef09cc4b73ddf6146c43b1482493c9390e5febaf13eae9989da02b"
+    },
+    "gfx/bg_runes.lmp": {
+     "bytes": 520,
+     "sha256": "6958314b3a4a2f84c9ecc82e4d35ef43bb5a8a81ce0533ee0b78f677d6d2fba7"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "ed169bb0aba1dd15a821b5aca6989a34b21bb023626dc18448fe916d134752c9"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "24139e37d00db70a34a6d5d947330f1c91f879942074679014caeeb55b9f5689"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "7b2f370fd5c5a8a6e9b9f81d61349171a6ce4c3866f7eb0ff98f745e1e697905"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "ef153ad5b00a6d9fee31f285d5636edfda6ae1adfa468390b053d07464dd6f56"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "db194baf0d8efee04eb4d31066ec90239720c741c63093cdc680bfc6663c773d"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "c06dfacff2da67af44840387e1acf177f46ec793817330965673ae17ddc78185"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "c06dfacff2da67af44840387e1acf177f46ec793817330965673ae17ddc78185"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "4d0db23e357f370d59b84c644d94862ba258a41b371a2f8de94efacfed753014"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "321699c4c0087e7bf89ce9e79ea4ee16bd0960c2dd2d8a93b93cbc6744b50cb7"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "c8bc747eae7c2b17b4301bd8a2d64e4139accbfbbea7caeb4e2e3488bede6535"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "5f191a9df325f9f0e9367895d934c980f3b5ed063bb1499052fd1556853240a8"
+    },
+    "gfx/colormap.lmp": {
+     "bytes": 16385,
+     "sha256": "663526184d592951b7155c7420ee8a383c4298af7768eb543b3a1f71f2d1c701"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "d3a579a4379ec8967b7efe1d57f39b6e4e07a58b60d489080e236f197ba8b632"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "ce8e8ca5c4383856b600d24ced1472bb7b85a3d46f3472c9b7c85a3bce285275"
+    },
+    "gfx/dim_drct.lmp": {
+     "bytes": 3352,
+     "sha256": "1a2ddbc88aeeb28044b80d45a818e535bd1f1c0b8ec81a888d5d21f70036fe99"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "06a02f09cbbe8b15933bdd2caed1db7c56dcaecb26ad3b5169473b3ced40b879"
+    },
+    "gfx/dim_modm.lmp": {
+     "bytes": 3352,
+     "sha256": "bb821f8074e9c081078bc3b0d34cefef9e0d96e2f8db2005828461a61acfd4f2"
+    },
+    "gfx/dim_mult.lmp": {
+     "bytes": 3352,
+     "sha256": "ad9cd190ae1991393f9ef09b4e65c14172d9364732ef2595b086e1749c65d5f7"
+    },
+    "gfx/dim_tcp.lmp": {
+     "bytes": 3352,
+     "sha256": "d580fbe4f5b114e8bfee3d86c0f8101b1bd8a3f342b17d88254a48b70f9cbcd3"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "87a7435d0f9ab37a7162e3382e59033f52a4780f0269da1118955255f7c34d34"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "2b20db74d1b8cf7c515980e43de37928a2592f45f85a74cd521419e0c52214fb"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "2b20db74d1b8cf7c515980e43de37928a2592f45f85a74cd521419e0c52214fb"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "ca5d0cf321ae748e079d2efdcaec80b02623dcc7fb348f1117257fb1993f36f9"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "3f9dac7eff3dee4eab04ab1304a46754fe7e24b102df3b11cf186de46507fe34"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3f9dac7eff3dee4eab04ab1304a46754fe7e24b102df3b11cf186de46507fe34"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "6883e3bdf2acf7916ac74e80f45cac621b2408e56435d81a506b3e3dcd9f47b2"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "bd8e4942b15e2b8216f5813e4bc2fab3ae258d953e3f3b75a361d7439b9becbd"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "dc13af43fa3114642673474a66f5ac6d2c4064d9567d6a52544577505ef2019a"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "20867d6372206b355a5e96692a0d5d3200cbb9e769a39eeaca91e7104b3c78da"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "2401d10470e44d556413db3c70f125b627961e9d7d7f0cf50a43163c8a09f98c"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "2401d10470e44d556413db3c70f125b627961e9d7d7f0cf50a43163c8a09f98c"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "2401d10470e44d556413db3c70f125b627961e9d7d7f0cf50a43163c8a09f98c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "2401d10470e44d556413db3c70f125b627961e9d7d7f0cf50a43163c8a09f98c"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "2401d10470e44d556413db3c70f125b627961e9d7d7f0cf50a43163c8a09f98c"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "2401d10470e44d556413db3c70f125b627961e9d7d7f0cf50a43163c8a09f98c"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "d6eb3b8aa5ce42495353fb7b18333c89d91a9b86982044825bb235b9b68f29b7"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "ec30fe33eca5c14ecd9cf57108c1619586b61a1110fbb5e880a76f6af7cd57f5"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "33e467e75ea073b00b857937a31d72ffd390bb759249cdba7a54b1a67382b2d9"
+    },
+    "gfx/netmen1.lmp": {
+     "bytes": 3352,
+     "sha256": "f6548fd8aa561c64fabe4be147eda461bcf07a67d9c124406ffc013739637a79"
+    },
+    "gfx/netmen2.lmp": {
+     "bytes": 3352,
+     "sha256": "eb832b23781eccbae96c535401dc6b455da01dfd632b4ab02c18df04726cb94d"
+    },
+    "gfx/netmen3.lmp": {
+     "bytes": 3352,
+     "sha256": "ca5c7894a7c44c6a2221a0aac09937f01ab22d29a315c6e9685f98bcfe41758f"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6fa5a343e2b58716463e5258604022ea07f6909c146d1a74c1455345f6d1cc3c"
+    },
+    "gfx/netmen5.lmp": {
+     "bytes": 3352,
+     "sha256": "d5d2c2d157aa49dbe351b6a518853389e7da7c8618f8441ffbff60fe4c1c64bf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "6d5e423eeccd3a98cf120c6a21341061ffebd97c4eb05ef03d608e688060bafd"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "122c6fcbed6c060a39ff8bf699c69041d9802606b77cd702fa09c68daa602cc0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "1a1a1473dfb2ca124c3a4e42c5be0308dd17e2eb0b498a2ca58a3574d2953e93"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "9a657a16550b68d57a8f0bc3775d894203283816badc56b8f5e5c7d4cbf9365a"
+    },
+    "gfx/palette.lmp": {
+     "bytes": 768,
+     "sha256": "6b20b5bc4ea965ef1852b05670d043ca16148a0ecad4e63028121c8aebc268fe"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "ac8e0c4ca1ebd8aafe16d6a4baa932d34e4c10a85aaf52fc2f421b9bc35c367c"
+    },
+    "gfx/pop.lmp": {
+     "bytes": 256,
+     "sha256": "59a7a58a257ae6a231ca4201a8330fa9d90779ea5e230e07d530f2478521bb9a"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 4040,
+     "sha256": "b391e278cb8358135b9b34525c33ac0ce91437576cdb170ac70273c5fbab2059"
+    },
+    "gfx/sell.lmp": {
+     "bytes": 64008,
+     "sha256": "9b1198150bedc39d1a912644e37890753b0dab4e9e5b2d061d2b7ad6290ab35b"
+    },
+    "gfx/skillmenu.lmp": {
+     "bytes": 14408,
+     "sha256": "60970c1fc9b42e159da4ef94ae6b2f43b8c97c4ef59074ef9a555cef8c34f329"
+    },
+    "gfx/sp_maps.lmp": {
+     "bytes": 2248,
+     "sha256": "8fb31507c2538032b9c9c5735aefd4695eeb46b6fdc78e016b728aa1568b4929"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "91b17bf5b0ef670aeeb6844a25b2ee532f1ea09452195f080088ef1526a92778"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "6aea5f75b34b0a66de61b14679bb453170ac435da07d3851a5df8498cab84f42"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "ccffaa95f1f64084bfa89137c34cadd68e1da9e2d242be9ed6252565cc6ce35f"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "897be1e43927ce554388058cf7e58851c9772be8a5414a621a7050fd87a77d93"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5000,
+     "sha256": "cd01e0061ad70c434e895a7d1b22c2f24d86c5072d619ef2202c852237e1a762"
+    }
+   },
    "sha256": "81eb9293615554d70773c2b57a139602ab84d0aa7d9f0971dcd835c3b35b1ab5",
    "timestamp": "2024-05-15T11:47:38.000Z"
   },

--- a/json/by-sha256/ba/ba1865cb8401ff0bfbec2933ec981dfc3c3090747b6d03a1daabb368afddd98c.json
+++ b/json/by-sha256/ba/ba1865cb8401ff0bfbec2933ec981dfc3c3090747b6d03a1daabb368afddd98c.json
@@ -12,6 +12,444 @@
   },
   "bastion/Pak0.pak": {
    "bytes": 12131574,
+   "files": {
+    "gfx/env/ofelas_bk.jpg": {
+     "bytes": 98700,
+     "sha256": "680e6de398c0fa4e70b607a0116c3a53d79a283e32cabcb7a19f5e2ce9491ecd"
+    },
+    "gfx/env/ofelas_dn.jpg": {
+     "bytes": 132151,
+     "sha256": "638d1ab0bac7e95c97bef47ab9dafd9c89597fdd0381d2357ead03bec4ca19bf"
+    },
+    "gfx/env/ofelas_ft.jpg": {
+     "bytes": 110749,
+     "sha256": "5aa08e97269716b8f39290257261f5e48698b511f024619fd3c9e1d9d8666441"
+    },
+    "gfx/env/ofelas_lf.jpg": {
+     "bytes": 91435,
+     "sha256": "49bf5f76364355e6f9c29cf29b91bdc9dcf1bb5d85a133df823e1a8192c5a680"
+    },
+    "gfx/env/ofelas_rt.jpg": {
+     "bytes": 118548,
+     "sha256": "36fd002fb4363ab04c50989683a7d27deb62e943d66fed40e9017f7949a863e1"
+    },
+    "gfx/env/ofelas_up.jpg": {
+     "bytes": 5772,
+     "sha256": "461fa2fb095151c090f39fcbce68ee4755a6857b7699b3bf3cb84b773ea81a39"
+    },
+    "gfx/env/thumbs.db": {
+     "bytes": 39424,
+     "sha256": "a95ae00c9b3dd47e3c4b408a3f4c80a30de88c93030558022859ba10514bb25d"
+    },
+    "maps/bastion.bsp": {
+     "bytes": 5354544,
+     "sha256": "002bdb44755c3c42aaf2be596a4644d8584a274889b0352f2e6704496a7744a9"
+    },
+    "models/shuffler/yakman.mdl": {
+     "bytes": 736212,
+     "sha256": "c2fb529476b4dbb7d3bea1c7905c203d01ce642d5c0e0b084ea11bf75e04f073"
+    },
+    "progs.dat": {
+     "bytes": 691256,
+     "sha256": "18a4991f46913eb0754a72479c48651bf1c5c28370bd09069447e8f58f9324b6"
+    },
+    "progs/flak.mdl": {
+     "bytes": 1684,
+     "sha256": "5ef83ea57cc9922dacdf8720e56451a9b121346669ff5ec5bf99b7290da6b8b0"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 8148,
+     "sha256": "1a17417bf310d3069d84123171b258c7ea237ed00c69f02bd5e26c1e5d913d70"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 10836,
+     "sha256": "3ae4ca501e6e3042af69bf1c0b5f537849be23e294b060dce17d23f32c30876d"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 4188,
+     "sha256": "014d3e1cf4cf1ef1131247c05d95545a9debde4cf38e40fbf70564cc3bdb230b"
+    },
+    "progs/h2stuff/newfire.mdl": {
+     "bytes": 85180,
+     "sha256": "9df2ae13e72ffe5a305a6ce877b0284023520d5d34df751498a2003c3e420ebc"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/knight.mdl": {
+     "bytes": 101404,
+     "sha256": "7f8e8b9d441955aec4e771628292b140c0ceee9f3d6f4936a28f94c4b04270b2"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "2bd7b6633d2c95627cca8b216ad2c84057e800778a94e0fa97f3a14f86420732"
+    },
+    "progs/q2items/barrel.mdl": {
+     "bytes": 60380,
+     "sha256": "04c87c0210d772c53ffc134a5a2a065394dc32f5b36b30c5f24d927bacc24633"
+    },
+    "progs/q2misc/bone.mdl": {
+     "bytes": 10836,
+     "sha256": "3ae4ca501e6e3042af69bf1c0b5f537849be23e294b060dce17d23f32c30876d"
+    },
+    "progs/q2misc/bone2.mdl": {
+     "bytes": 8148,
+     "sha256": "1a17417bf310d3069d84123171b258c7ea237ed00c69f02bd5e26c1e5d913d70"
+    },
+    "progs/q2misc/chest.mdl": {
+     "bytes": 37892,
+     "sha256": "c8898e13266a233ebbe63d59b5b6de882613e889eab85a420929733450b29a60"
+    },
+    "progs/q2misc/gear.mdl": {
+     "bytes": 6500,
+     "sha256": "3c79afa51feabb3f5f9d005c2314dc7d6ddd3f74d9794957912207d7553bd4a5"
+    },
+    "progs/q2misc/head2.mdl": {
+     "bytes": 16484,
+     "sha256": "bdb0fde04d157edc89daa526742560fe681185a73113c3fe7012c754cf6754b4"
+    },
+    "progs/q2misc/sm_meat.mdl": {
+     "bytes": 4188,
+     "sha256": "014d3e1cf4cf1ef1131247c05d95545a9debde4cf38e40fbf70564cc3bdb230b"
+    },
+    "progs/q2misc/sm_metal.mdl": {
+     "bytes": 3252,
+     "sha256": "d9f8da16377c902ac9af799481101b7baf99826aa5dffbd12ea51abf695179fa"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/sgrunt.mdl": {
+     "bytes": 414336,
+     "sha256": "103a1960f157dbfca58ae2febaf21671569a1539bdaeed5ede9b7c329fa2387e"
+    },
+    "sound/bdwsound/1shot/drone3.wav": {
+     "bytes": 296092,
+     "sha256": "56db5560ac9debaf0bc0e02b08fb1c42d19d812bdf32a5c810213cea94c91935"
+    },
+    "sound/bdwsound/basss.wav": {
+     "bytes": 302444,
+     "sha256": "75682a08b790af46c2b9f746e5772999ba1de333b567832f4a3a8414c6a0185a"
+    },
+    "sound/bdwsound/ghosty1.wav": {
+     "bytes": 302444,
+     "sha256": "1b1c68a9af22a26926cc7e62614a484fcb808e5916f562397d3763b101a98090"
+    },
+    "sound/bdwsound/ghosty2.wav": {
+     "bytes": 302444,
+     "sha256": "03d2c9480089611bc71f9942b8393d67accd88a3c294c4c05ab533c2d24911fa"
+    },
+    "sound/bdwsound/ghosty3.wav": {
+     "bytes": 302444,
+     "sha256": "323d239db99555c6e3007898f2da7b52bff498aa8560630e54f47a96d93c3487"
+    },
+    "sound/bdwsound/ghosty4.wav": {
+     "bytes": 302444,
+     "sha256": "50c17cf76f6ca13accab790eb1759366720a30d49dba1ee52e37dd3e79b1fbe5"
+    },
+    "sound/bdwsound/ghosty5.wav": {
+     "bytes": 302444,
+     "sha256": "949ba7efc6af06f0e6d726a6d1a50f5518b251dd17279ec5ed8ba518e4fbe5c9"
+    },
+    "sound/bdwsound/windmill.wav": {
+     "bytes": 40682,
+     "sha256": "f323d5e1e9bab0ebf7a7c3ace51f3721b954bfbf7a6c86e9b9df6c3b271bf6c6"
+    },
+    "sound/doors/metswng2.wav": {
+     "bytes": 42236,
+     "sha256": "d64e7e80ab30fdd430a332c60e408a1fb9dad968e3aaedaa2af329a12804ebcd"
+    },
+    "sound/gibs/gib1.wav": {
+     "bytes": 10682,
+     "sha256": "270c9f71b691904654039d49cca03407a91fc3d600b84e7fff3f8ecdfed94644"
+    },
+    "sound/gibs/gib2.wav": {
+     "bytes": 24740,
+     "sha256": "eb6b1f1596203e69fae5a707160779211a1776503c78d4b811a69205c8028da0"
+    },
+    "sound/gibs/gib3.wav": {
+     "bytes": 21552,
+     "sha256": "de4ca18cf6b6350d30c5b81be02745ff5ec6c3432939ba615affe0ad1fe7cb1a"
+    },
+    "sound/gibs/gib4.wav": {
+     "bytes": 9772,
+     "sha256": "b4fcc19c46a06bbbfb7803fccd33c6971c6fe5bac22299dfb6343d96358664d3"
+    },
+    "sound/gibs/gib5.wav": {
+     "bytes": 7782,
+     "sha256": "a0d9fa598637a4a2de5c2f1413835ad0215cc179de9f59e640b2e59f7c1942ed"
+    },
+    "sound/gibs/gibhit1.wav": {
+     "bytes": 9434,
+     "sha256": "3ee95e544edf6556c3389a5eef9f6cc0a0549e378c4433aa9617441602e3cf19"
+    },
+    "sound/gibs/gibhit2.wav": {
+     "bytes": 7772,
+     "sha256": "56bec98427e268141eae83a5873d12af966f6fe0302af2f84d2ffe412199e484"
+    },
+    "sound/gibs/gibhit3.wav": {
+     "bytes": 5402,
+     "sha256": "5782279b0c75441b2ee2ced9d7df2ac2ce08bb0cc5a451b2d90c20eb4a1aba73"
+    },
+    "sound/gibs/gibhit4.wav": {
+     "bytes": 3210,
+     "sha256": "19168dc337036a3deb524fdbbe965a7b2acdf0f204480b4a43acb80dc37b7a87"
+    },
+    "sound/gibs/gibhit5.wav": {
+     "bytes": 4294,
+     "sha256": "ef5115aca1b19ea0c48bf56c5eec8a6d22e95b6be5426247f58a3ad90c3a00bc"
+    },
+    "sound/gibs/hlhit1.wav": {
+     "bytes": 1468,
+     "sha256": "e907185147dbe42a4fac79c0b73d618c27f00c4edf9e48b23dd0226f8894e7ea"
+    },
+    "sound/gibs/hlhit2.wav": {
+     "bytes": 2170,
+     "sha256": "efdbee496456e118061ef9041c16c9d076aafd8cd055177a89d333014eec8b22"
+    },
+    "sound/gibs/hlhit3.wav": {
+     "bytes": 3506,
+     "sha256": "d70b60b22a44992365349e008b60616eee4097fc23d5dda7424e3b9d2698970d"
+    },
+    "sound/gibs/hlhit4.wav": {
+     "bytes": 2088,
+     "sha256": "d7a9505defc2e6bce40d11bb9e7bfef1b7099d327a856e2347b5fe2ab49231b8"
+    },
+    "sound/gibs/thump.wav": {
+     "bytes": 8682,
+     "sha256": "558dcb80efdbe289c8c10ed9b116edc8d5e147b555b1a6289747951faaf60f48"
+    },
+    "sound/gibs/ut2gib1.wav": {
+     "bytes": 17808,
+     "sha256": "068f6ea04f13016615f9534e74e969a62eda98c7def921df76731c5afbd73cf2"
+    },
+    "sound/gibs/ut2gib2.wav": {
+     "bytes": 18378,
+     "sha256": "274ed4c06d175a7a71dd925b94eedd9c172c6ba833c0a2a1bcde859fb682032a"
+    },
+    "sound/gibs/ut2gib3.wav": {
+     "bytes": 18342,
+     "sha256": "0b128fb8ee1c3946dab688820b032172e1c3281ff9d6552b21d7507a075a5bc4"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/h2ohit1.wav": {
+     "bytes": 20694,
+     "sha256": "12a512322e5dab9b15dff23a3253b008071868ea8d1632ca2535cbdfda98fbbc"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/ogre/wnalfire.wav": {
+     "bytes": 16492,
+     "sha256": "d4b26734bd9c1f29c657893d62a3d2f084bbeca421f0ab35bd75a453e4720bf8"
+    },
+    "sound/plats/wheelpt1.wav": {
+     "bytes": 18742,
+     "sha256": "a958c1a48242ac02a10a3af018f2d86705dbf6904aa5a6bd90c2f00599ee9431"
+    },
+    "sound/plats/wheelpt2.wav": {
+     "bytes": 8346,
+     "sha256": "2fe0cff30eb82673cbd8dcddf9e04e927f3fc1cfcf921ecdd9c68484e6b4dc02"
+    },
+    "sound/q3world/gong.wav": {
+     "bytes": 144258,
+     "sha256": "a85395fd0531a2958377dc91434ec02db8537d92e2fdb3b1f5bee5d6353a9e27"
+    },
+    "sound/sgrunt/hovatck1.wav": {
+     "bytes": 5620,
+     "sha256": "205ca4dfb7c694fef46d1d490dfe3123968bed527365c8290a0a74b0a7c18de1"
+    },
+    "sound/sgrunt/infatck1.wav": {
+     "bytes": 1070,
+     "sha256": "fe1da7ff2eea8aa20bb8def266d9512eca4b8f856d7eb3e337615cab698e1d44"
+    },
+    "sound/sgrunt/infatck2.wav": {
+     "bytes": 4102,
+     "sha256": "17e4261be177e6a5b481b17e2c23c78eec0fa3fc64fbb3a814ea04a3894f17dc"
+    },
+    "sound/sgrunt/infatck3.wav": {
+     "bytes": 3600,
+     "sha256": "4863d0045639486eb571c195fecc1a7c6cb58360019faafcc758fa517df09f01"
+    },
+    "sound/sgrunt/infdeth1.wav": {
+     "bytes": 20800,
+     "sha256": "a339e6b6d27d23bf85792cb72e25cb99b6571541ebe36220d5791276f787d827"
+    },
+    "sound/sgrunt/infdeth2.wav": {
+     "bytes": 19282,
+     "sha256": "1207f250763b2c0f356226de280d4fa28ded2b22b37542da881b90de1e67598f"
+    },
+    "sound/sgrunt/infidle1.wav": {
+     "bytes": 30920,
+     "sha256": "8a040ce630f0fb9d79b58ab067b9e2d50cef3ddfb9719575c7ac854973968533"
+    },
+    "sound/sgrunt/infpain1.wav": {
+     "bytes": 6130,
+     "sha256": "662db85db3590f40a663be97cbd86130508beae8b05cc43c8da1986b4ff52617"
+    },
+    "sound/sgrunt/infpain2.wav": {
+     "bytes": 9672,
+     "sha256": "4c0a29a2bbc7f08dd9289c73e309ab2290f2c036c912c120b9a90434903e6da1"
+    },
+    "sound/sgrunt/infsght1.wav": {
+     "bytes": 4612,
+     "sha256": "1e0cc42898697452ec5f3b3395b0c2efb8192edd4ae1ecbfee45ec8b9a3f1162"
+    },
+    "sound/sgrunt/infsrch1.wav": {
+     "bytes": 11692,
+     "sha256": "151466b389c6b641ebb4c033ccd98e8edaf09fda355802cae949ae1ad802992c"
+    },
+    "sound/sgrunt/melee2.wav": {
+     "bytes": 4102,
+     "sha256": "d6069aad14a8517ca8c520f5be03e85689b6eda2b80d1ab6d6fe7e0332af91e2"
+    },
+    "sound/shuffler/big1.wav": {
+     "bytes": 21636,
+     "sha256": "16c1632682aeb4b4075006d5b8b13a7e3f8821b6f59f8eb61ad78308b0d68366"
+    },
+    "sound/shuffler/big3.wav": {
+     "bytes": 25096,
+     "sha256": "2cbbc5dc1249a92b9a31a6f3fa7ff654dd6339511fc99e4c552ad6a34218a4c2"
+    },
+    "sound/shuffler/breathe1.wav": {
+     "bytes": 45712,
+     "sha256": "53730dabf839c183028fbdf909df8ae7ef936828c51c58a957617444872224d4"
+    },
+    "sound/shuffler/breathe3.wav": {
+     "bytes": 50728,
+     "sha256": "fd923c891934046d9770c089dfe16021373a392b429531ef9698fbd2f759c42a"
+    },
+    "sound/shuffler/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/shuffler/expsmall.wav": {
+     "bytes": 8732,
+     "sha256": "18825b9644c01ff0a488887185ac14d6fb4fd983254620009ba3ecc96c44d465"
+    },
+    "sound/shuffler/firefblt.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/shuffler/pain.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/shuffler/slam.wav": {
+     "bytes": 6372,
+     "sha256": "2c6ff4782b389777c98f09fa6ac86e6c75a848ad800db6dc32f8ea9362706e96"
+    },
+    "sound/shuffler/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/shuffler/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    },
+    "sound/weapons/noammo.wav": {
+     "bytes": 1400,
+     "sha256": "217c42718548de32b5df972d117ffc1a0e1dde5f03a7a173bd91d0b4551248c9"
+    },
+    "sound/weapons/plasexpl.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/q3ric1.wav": {
+     "bytes": 4910,
+     "sha256": "70f9619ddeedd4e2c73ccbf7aeed888ccf293fe23150b50f3c75bacf7c5d5fed"
+    },
+    "sound/weapons/q3ric2.wav": {
+     "bytes": 11832,
+     "sha256": "295919613b1f9d4a6b4fb74618361870130ce23c54902fb1b6ab3468d52da01b"
+    },
+    "sound/weapons/q3ric3.wav": {
+     "bytes": 12078,
+     "sha256": "59813f27cddcc4fc5e3c8693f653973436163f99fa0be282d5a49f6e3b4d3acc"
+    },
+    "sound/weapons/skotch.wav": {
+     "bytes": 2564,
+     "sha256": "f953f6a75919af7a6947d9c60d3f55ca8cfb851886f1de766a9a53d2070e7ab9"
+    },
+    "sound/weapons/slash.wav": {
+     "bytes": 5904,
+     "sha256": "458fa17f4a55682147371b91fa63db12a9c7f1cdb8415d3d97c4ef70dc0a4f49"
+    },
+    "sprites/blue_exp/blue_exp.spr": {
+     "bytes": 410136,
+     "sha256": "71eb4877e7406c7783466fc3db20bc4d059f241280a4ea639aa836a11a562e08"
+    },
+    "sprites/misc/s_null.spr": {
+     "bytes": 57,
+     "sha256": "dc67fb2f31bd717353b8138f02bdc8ef2d70ace433c9fd91e3adc909fda513a3"
+    },
+    "sprites/plasma/plasmabig.spr": {
+     "bytes": 24732,
+     "sha256": "efd794d417a2960107bb6bfb5c267ab4db3695aba89f8a3121548a36a41da29e"
+    },
+    "sprites/plasma/s_plasex.spr": {
+     "bytes": 13980,
+     "sha256": "0fc733de7ed0170a2a83bacde6f50d1e7b4c23c24993007b0f5dcb73b77b8240"
+    },
+    "sprites/plasma/s_plasgr.spr": {
+     "bytes": 3612,
+     "sha256": "a9db67752963345b685e3bfaeccbc1742d9e22919208b62e6f0d1b9376fef4ea"
+    },
+    "sprites/plasma/s_plasgx.spr": {
+     "bytes": 13980,
+     "sha256": "0fc733de7ed0170a2a83bacde6f50d1e7b4c23c24993007b0f5dcb73b77b8240"
+    },
+    "sprites/plasma/s_plasma.spr": {
+     "bytes": 3612,
+     "sha256": "a9db67752963345b685e3bfaeccbc1742d9e22919208b62e6f0d1b9376fef4ea"
+    },
+    "sprites/shalrath/s_vore.spr": {
+     "bytes": 6300,
+     "sha256": "f1f774aad9c4eae8d802fd02ef4dc378aa51d34363d2470460f5c1b9bb9f2764"
+    },
+    "sprites/starb/starb_b.spr": {
+     "bytes": 3620,
+     "sha256": "4d09e772f240bc7507ec4795845e2b28b5bda160df10e524c7a0a2fee203807a"
+    },
+    "sprites/starb/starb_eb.spr": {
+     "bytes": 11656,
+     "sha256": "dd6451332d5f0b472e98d82636bbcd43d38172ba62ed5b68233fc43467d91d08"
+    },
+    "sprites/starb/starb_eg.spr": {
+     "bytes": 11656,
+     "sha256": "63dc20b8eda63a1e7bdef0280ce5a6bef35ebb7c6fa0e09e7ca32bb5729e8993"
+    },
+    "sprites/starb/starb_er.spr": {
+     "bytes": 11656,
+     "sha256": "8f07abeb750ae0ec50bc1a7826cd5cb6daf3029f38b323ccad759d4451134a24"
+    },
+    "sprites/starb/starb_g.spr": {
+     "bytes": 3620,
+     "sha256": "a81ff819b478a5f3e25b404f7de06a180c5cab322c46a4664489879289bd7fe2"
+    },
+    "sprites/starb/starb_r.spr": {
+     "bytes": 3620,
+     "sha256": "80f5ea8cc43e9367b69895328ab344335898aec9c9eeb4d393f620279c9b47ab"
+    }
+   },
    "sha256": "2a39f35579bf93017330f6c9c3febb5a92d3fa3c44874f2cf1d5b9b5e77aa141",
    "timestamp": "2004-05-20T14:53:50.000Z"
   },

--- a/json/by-sha256/bb/bb63f959b8627df8b067fba12286964364b2de8043fb3e9f9ec8ff316db5c97b.json
+++ b/json/by-sha256/bb/bb63f959b8627df8b067fba12286964364b2de8043fb3e9f9ec8ff316db5c97b.json
@@ -12,6 +12,172 @@
   },
   "strom/Pak0.pak": {
    "bytes": 8455713,
+   "files": {
+    "demo1.dem": {
+     "bytes": 161736,
+     "sha256": "074426491e5474a674eb68141e0efa22e2ddba06d161c4fec822daf7483d0dcc"
+    },
+    "demo2.dem": {
+     "bytes": 133247,
+     "sha256": "55bfe9c1fab1d0712f083305ca6ab85024cfc724a5e6f8d4a306ae79f75cbc17"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "49dad8797031fd004ebfdd73ea4c5de8914deaef0c785db369f4f3c8b2a57afc"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "95c3d55a4fe93234228cf3537f55755ba2beebad24fd03fd831ef64aed9d06c5"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "899fdea2a84727771e90d16db5d6a96d1e1a499612f6b45ef89aa02ae3b29304"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "d04c7b7755f7ff059c05c86c13c183f3291b0d267026a0761a23afefac2955d1"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "7ccd9c7a1548f6204df3b6d67620a8985e98ab67413b68ea7b4dfa2453fd25c2"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "785e0beeb5f0118f4faf803ee480c9a8ca240c0040043c6ae15cf1f8a6782002"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "e35f5f8e1223c6bcc02355b7c99dc1c5d7eaf074d24a99d1b353fc108deda0b8"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "786cc2017da3f821b326827babf76885eb2a8b33aae37126001a24885e12419b"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "0de49268b138a00c4b709802647a184280b3799302c465f1dbba135f0488e018"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "4897c4665b810a1d0848d5fe1f343ba732fdae80d023b8649449c543fd2b0422"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "26b160a6a1176542e0a6b26a3feca456d58a239c1a45587511072f6095bd9e1a"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "376fd81edc040513931eda6846f148fdff324b1a53c2f57225c54ac50d8e9c0f"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "fe7bdadd0d164f40b5197e5027771e9e494d9434a81f6b5c14d5674929d6535f"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "35192a076c437f44ff7b3c8df2bd75f3380f6fe2b4a5382df2c169b473817578"
+    },
+    "maps/cats.bsp": {
+     "bytes": 761424,
+     "sha256": "aba7f441fff466c62ac158003004120ad98a1c5090eb0ab0d79a7ea8646d039d"
+    },
+    "maps/fish.bsp": {
+     "bytes": 134308,
+     "sha256": "b722831d91ea0332ba63328e1bd4089aa7168faebcbdaf3da331119fcc53a11c"
+    },
+    "maps/love.bsp": {
+     "bytes": 588344,
+     "sha256": "95d07ed868d5d0fdc8728a95233444bf8df99d9a36e9b41df64602f5dd52b16b"
+    },
+    "maps/owls.bsp": {
+     "bytes": 1006720,
+     "sha256": "11201de4a9238758dd502a264364608b7fdb98529e7efb0fa3feeaaaa930ef1b"
+    },
+    "maps/penis.bsp": {
+     "bytes": 1548252,
+     "sha256": "185629353fe609e068929ec0bbfdd1c271cb5fab07dd6b69a0dfd6f610a8aee9"
+    },
+    "maps/rats.bsp": {
+     "bytes": 1368832,
+     "sha256": "776237f0fd5d8769989469198cff030ddc2bd3632c999cf9bea04c292797d84e"
+    },
+    "maps/reds.bsp": {
+     "bytes": 573276,
+     "sha256": "2cbcd2d868d2aeec7b83c490ecec201092692a491157880133ade91030412312"
+    },
+    "maps/slugs.bsp": {
+     "bytes": 461292,
+     "sha256": "ff0bf198fb06bf26aa51bb49171aed27adcbf5c180a9463fb5f9556d59ea7e0b"
+    },
+    "maps/start.bsp": {
+     "bytes": 576156,
+     "sha256": "107b97543c7433b036ab4e2b9708d19ccfa6cb7feb015b2bb6504bf2ce6ad5cf"
+    },
+    "progs.dat": {
+     "bytes": 425320,
+     "sha256": "d19a631c24287dfc5cc60b16959424f3b195a81b6b33d011cb4eb97e208d6751"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "280ccc27482f5eb5f19a2f283a54d0602ffafa3c4ca697b451f4a054a6fc939f"
+    },
+    "progs/ogre2.mdl": {
+     "bytes": 162036,
+     "sha256": "6b7d2a9011bce6df6ee28dae5b1ff684afd53b273eae6619f3d67addfc2456d1"
+    },
+    "progs/s_rain.spr": {
+     "bytes": 37196,
+     "sha256": "cc6facb55b73827c89b9459665a1969468119a9e4465debc741da1c892373a4b"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 146288,
+     "sha256": "7f7aa6bda2197d6bb73d62ca886e55e91ba9df083c68d9b041cee2b90efe1829"
+    },
+    "progs/star.mdl": {
+     "bytes": 37876,
+     "sha256": "4ccf452b5ca324bdd3ecac2b7578402085874ada7940765a298810d597aa0763"
+    },
+    "progs/v_star.mdl": {
+     "bytes": 56996,
+     "sha256": "1fe995359a8da40ac1df2f25fcc5d99092594607d5bcf0e7a7b54482f9c9c0de"
+    },
+    "quake.rc": {
+     "bytes": 298,
+     "sha256": "a33d6bc621bbf8a9350e5bbed78ed3d9a9ab471c38ebbfd9f926ec4ef5b7101a"
+    },
+    "sound/ambience/rain.wav": {
+     "bytes": 91202,
+     "sha256": "a196a2fc8a052368f9e8f7efe853391d1a99dfb1f6afae4fc7038222f2eb6fda"
+    },
+    "sound/ambience/z_song.wav": {
+     "bytes": 61546,
+     "sha256": "0cf2c771199f4a2e283177b88e65d5258fe8e74947e1b94fa199383635c3b6af"
+    },
+    "sound/soldier/d_grunt.wav": {
+     "bytes": 9910,
+     "sha256": "0d502b41dac6081a357a0d8922f39f323ce4d5202aaafe755c575e29e4a6ea9e"
+    },
+    "sound/weapons/bounce2.wav": {
+     "bytes": 7960,
+     "sha256": "d2da688ec5fc64f24b798b645eb80b8cdd60c6e7d44cb68a7e05e2264e1e69d5"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 3368,
+     "sha256": "2b62c292f87665f9b6dbbc716c24875e67d4206c548440b79443a14fa9ee7ba8"
+    },
+    "sound/weapons/chain2.wav": {
+     "bytes": 3192,
+     "sha256": "e0991b1a92351720cf85030db91bb1a896c5aa3f7ed01bcb73c7534ca798b32e"
+    },
+    "sound/weapons/chain3.wav": {
+     "bytes": 6172,
+     "sha256": "cc1bdca575e0dd0fe1986fe590b85f6c27dca84a3de89e20306e61c4677686fd"
+    },
+    "sound/weapons/gotcha.wav": {
+     "bytes": 7374,
+     "sha256": "e17abe393fd473c69b202286c2ae3079a32f90504a5292bc5e9e38888ed07cc1"
+    }
+   },
    "sha256": "012ad5f0be8e757d7a14700475578c3144061e6042ed0f162527f9d36d11c639",
    "timestamp": "1997-04-12T10:27:00.000Z"
   },

--- a/json/by-sha256/bc/bcbc6a3d6b8caa52757ed133752730a96334bc57192143c89c4c291f0c004611.json
+++ b/json/by-sha256/bc/bcbc6a3d6b8caa52757ed133752730a96334bc57192143c89c4c291f0c004611.json
@@ -12,6 +12,64 @@
   },
   "PAK0.PAK": {
    "bytes": 3051350,
+   "files": {
+    "maps/mexx8.bsp": {
+     "bytes": 1573292,
+     "sha256": "6f4286b269cd9ae847b1f12ef5a770615d9c8ed0210b5b8f75638c36e9e3e283"
+    },
+    "maps/mexx8b.bsp": {
+     "bytes": 588164,
+     "sha256": "2f7760e8b914a9290772ecb3362214f239539dbe0036ca44ec09e00f26be23ca"
+    },
+    "progs.dat": {
+     "bytes": 452884,
+     "sha256": "8f39d1652ac7c227ef843de3d535123fc088ba9a6fcfce0bc8588c3de20bbd4b"
+    },
+    "sound/misc/aeh1.wav": {
+     "bytes": 31949,
+     "sha256": "63f367f7d63f2347986e623aaa0349ea556ca5d2708b7ce792694d23e5f3a17b"
+    },
+    "sound/misc/aeh2.wav": {
+     "bytes": 31706,
+     "sha256": "abcb49f79b747f992ef45c40779eac3e8b69598f3c1fc6456a010ab8a98f670e"
+    },
+    "sound/misc/aeh3.wav": {
+     "bytes": 30593,
+     "sha256": "57e950f98bad8bf32d14b01b4a4b9a8aa2b667f07ab77222a5db28f2cded7999"
+    },
+    "sound/misc/aeh4.wav": {
+     "bytes": 44052,
+     "sha256": "508f20081986d5c8c0847f51f566e53da4bf53ffd39ac895b0d1067dfc2e4b9e"
+    },
+    "sound/misc/callmord.wav": {
+     "bytes": 46671,
+     "sha256": "fa1a189a0433213afcc62cf1ad9f83de8abee4c34ee0b21d6eb15e3a5fb0b6c8"
+    },
+    "sound/misc/enterga.wav": {
+     "bytes": 55981,
+     "sha256": "7cf9eab172580fbb5e28dffab609f2dd66aaf7c8eb023e2ab25d347b3235bbfc"
+    },
+    "sound/misc/failedme.wav": {
+     "bytes": 33579,
+     "sha256": "3546f80387fd85a0fb01a2d06d9935f3496447dc39718a0e3b996bdb860a9537"
+    },
+    "sound/misc/lavafall.wav": {
+     "bytes": 20435,
+     "sha256": "461fc51c3e9de2096bb46c9daf16c9a5345f42ac6cbcb86e506a5303bf1078b0"
+    },
+    "sound/misc/mexxbell.wav": {
+     "bytes": 94183,
+     "sha256": "abbaeaf9096d6bcfc470559e80d9d5c4344f68969e3c4e7d2d725a10a6cbf378"
+    },
+    "sound/misc/morddie.wav": {
+     "bytes": 24490,
+     "sha256": "b43756212a160f4419f807beb6675faeeb65bef8d48b0f120c4b9f005a818300"
+    },
+    "sound/misc/rot.wav": {
+     "bytes": 22463,
+     "sha256": "866b836874ba611d70675e5e3b83eac059c927bef0e0d1396f2183ea01bcc203"
+    }
+   },
    "sha256": "45babc9860050c25436ebabcabf8c854115f159505aa9582051c799c7eed0d62",
    "timestamp": "1997-04-25T16:24:46.000Z"
   }

--- a/json/by-sha256/be/bea8c6ffb5ee2649db2805ef3bee8e976285affc0a20415da5aa7f3880bbdd36.json
+++ b/json/by-sha256/be/bea8c6ffb5ee2649db2805ef3bee8e976285affc0a20415da5aa7f3880bbdd36.json
@@ -27,6 +27,340 @@
   },
   "copper/pak0.pak": {
    "bytes": 4085208,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "b1deebb2268d373683100cc9df4c9dcbf817f9bdb0e3f2cd13edde0037609b53"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "11454a7ec41855cc66adc9b80e60b1c76b0af873656d46cc20543ea4d2a7ef8c"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "d2a59d07042577c9c5a5ceace5ad0e3893ba3ac2d206f039f11cf282ead3945e"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "63f869e1e553ccae238279e4b78c902463505a3d1dd7c5d21d4f4acbb56857ee"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "6e3d8ed0cf22d78c0e05bf75837214a12f647fda33da1fa1ad1195cff3cb9681"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "35db83f82066ac1db85f4094dc9710e313b638e019d8e4d6fb5abf0457d506af"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "7b3838322dc860c3ea5dec5e246e9ecac4b0f75182edeff7b719e16f4f33d874",
    "timestamp": "2020-11-14T23:48:56.000Z"
   },

--- a/json/by-sha256/c0/c03235e804a9c8f23c6cc65eb340a2d45d033eb8c9f221b18ceb332dfe852342.json
+++ b/json/by-sha256/c0/c03235e804a9c8f23c6cc65eb340a2d45d033eb8c9f221b18ceb332dfe852342.json
@@ -390,6 +390,344 @@
   },
   "sm217/pak0.pak": {
    "bytes": 4110228,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "b1deebb2268d373683100cc9df4c9dcbf817f9bdb0e3f2cd13edde0037609b53"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "11454a7ec41855cc66adc9b80e60b1c76b0af873656d46cc20543ea4d2a7ef8c"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "d2a59d07042577c9c5a5ceace5ad0e3893ba3ac2d206f039f11cf282ead3945e"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "63f869e1e553ccae238279e4b78c902463505a3d1dd7c5d21d4f4acbb56857ee"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "6e3d8ed0cf22d78c0e05bf75837214a12f647fda33da1fa1ad1195cff3cb9681"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "35db83f82066ac1db85f4094dc9710e313b638e019d8e4d6fb5abf0457d506af"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "0191d8c540203ac186f94012d21a474c77a048c040cecfed00fc9f6f63a57dbe",
    "timestamp": "2021-08-25T16:58:24.000Z"
   },

--- a/json/by-sha256/c0/c0921652cf0f392ad2aadb05777ab06a9e929f8ed61cd49db586b27f0b526076.json
+++ b/json/by-sha256/c0/c0921652cf0f392ad2aadb05777ab06a9e929f8ed61cd49db586b27f0b526076.json
@@ -12,6 +12,736 @@
  "files": {
   "pak0.pak": {
    "bytes": 100036539,
+   "files": {
+    "demo1.dem": {
+     "bytes": 200320,
+     "sha256": "236b5a151a89c171ea6b2b169c768c763e0df3e3e5b47221978dae7e22542794"
+    },
+    "demo2.dem": {
+     "bytes": 1221608,
+     "sha256": "ee99a57fc84602621ec320af652d013977ae4e0a6196871e6888eee40b0cfd3b"
+    },
+    "demo3.dem": {
+     "bytes": 1007773,
+     "sha256": "d29234c5cbb55dfee8ba6b8c6c3d2f587105d8c86d68cc73aba7eb21f9f07e3a"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "2b5442a27a546a63eabd1a0acdc582cd928600bc9d2d670fb421e1c71ed99969"
+    },
+    "gfx/env/captivation-blue_bk.tga": {
+     "bytes": 287340,
+     "sha256": "66388d44641bd20eb7841f3de7a84a6ba46ae791e3915fb911f081d1b95105c0"
+    },
+    "gfx/env/captivation-blue_dn.tga": {
+     "bytes": 130432,
+     "sha256": "1d32504d07ccfd1f89334ab0a67d58561c9a48aa5f1747a66608f6dc9441a49b"
+    },
+    "gfx/env/captivation-blue_ft.tga": {
+     "bytes": 277718,
+     "sha256": "436b5ae399cb45374e93af48141094491c2280e56d4868298268064eb52882c4"
+    },
+    "gfx/env/captivation-blue_lf.tga": {
+     "bytes": 314328,
+     "sha256": "8aa10e1db46e743431b705f34091e9e8738531e7124fbaa1d155b769e2a19f2b"
+    },
+    "gfx/env/captivation-blue_rt.tga": {
+     "bytes": 287035,
+     "sha256": "4a19b968130b7d49851aed65c5d5a1a53e2a5449d45b7a38559c0d7a31ba7e82"
+    },
+    "gfx/env/captivation-blue_up.tga": {
+     "bytes": 154528,
+     "sha256": "3b3d9bb9d9ed9de69be7368489cbf822d0c05f762e816c4aa47dcea8a35607bd"
+    },
+    "gfx/env/duskbk.tga": {
+     "bytes": 786971,
+     "sha256": "c6ff35f38b5262c301fafd7857305cf80636efd9b67c72f511a2e93a2648d220"
+    },
+    "gfx/env/duskdn.tga": {
+     "bytes": 786971,
+     "sha256": "5a844ff50a7e7cb3115c94cf97c36fb55a998baf8a3e38118bc4524f03d533fb"
+    },
+    "gfx/env/duskft.tga": {
+     "bytes": 786971,
+     "sha256": "c1142a0e3bba1d2b65f887c000b6b5e450fe08474d6a5d026532b63e73d03a01"
+    },
+    "gfx/env/dusklf.tga": {
+     "bytes": 786971,
+     "sha256": "1735e4c258ab8d18b971345b43c79991bf76c2c178344739c26d79d7658128e4"
+    },
+    "gfx/env/duskrt.tga": {
+     "bytes": 786971,
+     "sha256": "4cdc3edcc8c0c1ec938ef7e4297931cf1bc4ebd804660011725bc7f3abc61ddb"
+    },
+    "gfx/env/duskup.tga": {
+     "bytes": 786971,
+     "sha256": "320e8dd8e6adc4453d894d15d20ba3ad02f176af3dd4ab1baab695e0a4accfef"
+    },
+    "gfx/env/miramar_bk.tga": {
+     "bytes": 609525,
+     "sha256": "a81a8d35eef83ef631238f3836b84837fe60263ee2120b9199cf9903d21421f7"
+    },
+    "gfx/env/miramar_dn.tga": {
+     "bytes": 8236,
+     "sha256": "4a8a01a5df0e2c656acaa290a5a077f0ba83154ae482932f203de2d9fc58030a"
+    },
+    "gfx/env/miramar_ft.tga": {
+     "bytes": 588195,
+     "sha256": "48e1b42c3a4f10696146e220ceff25c06543715d8d6446cae040e37afbe6e216"
+    },
+    "gfx/env/miramar_lf.tga": {
+     "bytes": 546427,
+     "sha256": "e50b8ea9715560bc6d6f167c0bec368b7f1e29d2c7ee47d76de74046c519693d"
+    },
+    "gfx/env/miramar_rt.tga": {
+     "bytes": 572307,
+     "sha256": "d9e0c9a3a3449bf48e7d16c17b81a20701d54ab81a248f9439a64872b08b81e3"
+    },
+    "gfx/env/miramar_up.tga": {
+     "bytes": 333522,
+     "sha256": "badb8d590024d06e3829698466af445ff360f313d8c2063ad6a5fbf4fc686600"
+    },
+    "gfx/env/qt_predator_bk.tga": {
+     "bytes": 237864,
+     "sha256": "1c5795442a6106a6bfb5e9a764e80064a794231d7de0af14315eca2c2130a362"
+    },
+    "gfx/env/qt_predator_dn.tga": {
+     "bytes": 91419,
+     "sha256": "362f16cacbbfb8bcc0f1e201dd2d9355a5903cb72453fa7ae95299543d2656e2"
+    },
+    "gfx/env/qt_predator_ft.tga": {
+     "bytes": 219174,
+     "sha256": "798bf7cc1f98f59b81d2d62e753196320d15749a69e5a02d5d1f29ea3bf2451c"
+    },
+    "gfx/env/qt_predator_lf.tga": {
+     "bytes": 293406,
+     "sha256": "3cd2e24ff3372ae17e9ae94cc134d304a697db444b6337806d6fe755f31ead17"
+    },
+    "gfx/env/qt_predator_rt.tga": {
+     "bytes": 293718,
+     "sha256": "e9f281eb64e13f655d5268448c08f6fad8d743340bee6d631ef64a76980d3f66"
+    },
+    "gfx/env/qt_predator_up.tga": {
+     "bytes": 495665,
+     "sha256": "bffb3c0f298d1f46f8e33205a981d99635d451ab3924b64e38860320074fd7f3"
+    },
+    "gfx/env/starsbk.tga": {
+     "bytes": 51294,
+     "sha256": "7292194bfe9a6444173b6c4949568ec42cd6900883dcc444da0f2344fe3d4d69"
+    },
+    "gfx/env/starsdn.tga": {
+     "bytes": 51322,
+     "sha256": "59e645a79cd93b98c05de9c2f8a136394ab561ce0b9978aad4de17c6508da60b"
+    },
+    "gfx/env/starsft.tga": {
+     "bytes": 51685,
+     "sha256": "2dc8d4ab7cdd655c2a63bfe7059815bedc56692a5c1867191d12433958f633c5"
+    },
+    "gfx/env/starslf.tga": {
+     "bytes": 50756,
+     "sha256": "f74f36da6239c9b011b6ecf1f0fabf7c40f3372fe3841d2168473a31e16e646c"
+    },
+    "gfx/env/starsrt.tga": {
+     "bytes": 52319,
+     "sha256": "9ce812f2efe3dd4fb077bc751fc8209de661c04544e54c3271b956316b7c162e"
+    },
+    "gfx/env/starsup.tga": {
+     "bytes": 51416,
+     "sha256": "d31b6a617776b2ccd90662ec1196267ac4c8be85696b9702ec39c41386f2fc47"
+    },
+    "gfx/env/voidbk.tga": {
+     "bytes": 603,
+     "sha256": "6e095aecdb2ee0ebb2636b48ce7f7754ee357b217f32a83025830db3d9a87fdc"
+    },
+    "gfx/env/voiddn.tga": {
+     "bytes": 603,
+     "sha256": "0c7a0cf2c30d6d87f21567c4e4dacedccc3840fb82b37bfd8c0949315526cc46"
+    },
+    "gfx/env/voidft.tga": {
+     "bytes": 603,
+     "sha256": "bc18cbf4e5c4036b64203d6a165aa18edf24d86bcee9b6e7c183bd54f456550e"
+    },
+    "gfx/env/voidlf.tga": {
+     "bytes": 603,
+     "sha256": "a350d7da744018421f60d6b95edc609f36d059ad27fe0621599c018e6ccbf3d7"
+    },
+    "gfx/env/voidrt.tga": {
+     "bytes": 603,
+     "sha256": "6447fc6c5ddb2a696fccd2611323758ce44be8a236ec9602ed9947b800d1240a"
+    },
+    "gfx/env/voidup.tga": {
+     "bytes": 603,
+     "sha256": "76c1a1a57bfc1099bde3814a7d998b842ad6f8b619d3e4e1169ab7ab8850f133"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 5096,
+     "sha256": "928ddcb3db80fffa1b6929bad90b5ec4315c6bf921051875db7cc9be6dbc6e2b"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 4672,
+     "sha256": "c65b5d09abbfa759720c5794dc5daf83881aa23ed5ce454968e8cd4b111134e0"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 3976,
+     "sha256": "5184056211a9d165855bcd12b8a3b1359a342b2a7e180b5214bd5fe930d8bca0"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 8884,
+     "sha256": "339a11aa94a733439f651a6788a84a47d9ae6cb549d846b0bc347d0fc60e69d4"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 8912,
+     "sha256": "98f33dc4afbbef18764af46f628f16991a1bab67dfb989ee5d67dcbcef78c98e"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 5096,
+     "sha256": "d9485b714fdadebfb630dbf04e57d0dca725866b275d4a1230ceb47743233172"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 5096,
+     "sha256": "f66a6d330701a1bde3c2b7b2632fd1e0f17003e6841f8aefdf02d365c12fc958"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 2940,
+     "sha256": "020e9f34425924743bdb2b2a78c828ce640e2e9ce7e65d921bb5f2aafa69c822"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 2956,
+     "sha256": "4c1879f27c9566e4afb0a448641c90c5190a20fa5cbeef4875a8d159e30360d2"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 5096,
+     "sha256": "3777fbc228c2f88bdc168ef7519db3f3b9b57cab3778e943a123e97ec447c247"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 5096,
+     "sha256": "d2ca27d373f49a6ef0087970ad59f3a0b68628f536a65ab797432aa215dfdc5f"
+    },
+    "maps/qtdm1.bsp": {
+     "bytes": 2107020,
+     "sha256": "ac77484fb860843a5bbc59b528d4419f28bca090939ad7f78836fda1cd36388e"
+    },
+    "maps/qtdm2.bsp": {
+     "bytes": 1859888,
+     "sha256": "77b6690816f2478f4094bd914ab90ff3d085d4e0349f36bd81b422d993ab56d3"
+    },
+    "maps/qtdm2_ffa.bsp": {
+     "bytes": 1310868,
+     "sha256": "cfac76d197d351f8beade4aad1079cb413346d5c7b32d0d51705099ddcf21f76"
+    },
+    "maps/qtdm3.bsp": {
+     "bytes": 1304384,
+     "sha256": "642bff3ee396bd32d6d406a1f17f3bbcacc962d4095d933d5ba759aa38f7d719"
+    },
+    "maps/qte1m1.bsp": {
+     "bytes": 5606868,
+     "sha256": "e170dde88aec9c0ac0743b147bf795b8b881f3076fb5ae55e0ba399b30c18420"
+    },
+    "maps/qte1m2.bsp": {
+     "bytes": 5144952,
+     "sha256": "522714c5d01f0c4d08b2fd956aad19f861aa8a84e825b6706b1e0b43d78db602"
+    },
+    "maps/qte1m3.bsp": {
+     "bytes": 5876940,
+     "sha256": "a90270c57cfe52b3c39efa156812a180d046a3c8a67c462246187838cc632a65"
+    },
+    "maps/qte1m4.bsp": {
+     "bytes": 5919276,
+     "sha256": "2267d65dd5268b3fb41fe622040626f400d37bd5c63ca1090f22936e7aea3650"
+    },
+    "maps/qte1m5.bsp": {
+     "bytes": 3870720,
+     "sha256": "fa0d2ee4f5343c0dd60a45c303cdb5fb279f9788858af225690a281b70aa3da0"
+    },
+    "maps/qte2m1.bsp": {
+     "bytes": 6155188,
+     "sha256": "c357b4ddb8bbbf591f391eea0764c75396d963bc7f31404d5e605f909e008349"
+    },
+    "maps/qte2m2.bsp": {
+     "bytes": 5912272,
+     "sha256": "8fa99b15c61ed5a157eab14be36e6876cf59c5a2e477adffbcb7d3ff5bd3c72b"
+    },
+    "maps/qte2m3.bsp": {
+     "bytes": 6855388,
+     "sha256": "238cf0087a29bc794292d90b72a11b8c5083d77545af45a00ad0140dcbce36b4"
+    },
+    "maps/qte2m4.bsp": {
+     "bytes": 2717072,
+     "sha256": "b3375a0c29bed542d4b46156d40ed5ea84904b90b0faa7de9b4497db36f60904"
+    },
+    "maps/qte2m5.bsp": {
+     "bytes": 4789544,
+     "sha256": "86a109ed45cc371663816628cd90b2643731d53da1ec4715a7b4864e40d71fc3"
+    },
+    "maps/qte2m6.bsp": {
+     "bytes": 5872892,
+     "sha256": "568db8c3e1c619b4be2fd6da77b448ac380d46d0ec4aacfca3a1ab25a0304166"
+    },
+    "maps/qtfin1.bsp": {
+     "bytes": 3254384,
+     "sha256": "e620bba46fee925b8c9af0b9784efbfe86b6fd7393b75b589adf40cc705e6aab"
+    },
+    "maps/qtfin2.bsp": {
+     "bytes": 2609528,
+     "sha256": "9f1371919a2208c8e3a883a4dc193825b16a0e835b56cd04fc72e4f0e73f9f5b"
+    },
+    "maps/qtfin3.bsp": {
+     "bytes": 5693276,
+     "sha256": "74212e734a8df7629dd1ffc924738924179088debf9d1b647d80a157f8d8e470"
+    },
+    "maps/start.bsp": {
+     "bytes": 3066044,
+     "sha256": "e91cf75f508bfa922c806b20b72ea61b38345838c933e2d640585d5b0ca00c62"
+    },
+    "progs.dat": {
+     "bytes": 652890,
+     "sha256": "f6937c3b2ddde295518be5bafe299810fd3adf7f6b44e8e89bfd7d034877f36d"
+    },
+    "progs/a_jugg.mdl": {
+     "bytes": 9684,
+     "sha256": "87808db33bdfdf19ca8c3a7899d32e58dec361b55d53b6f47810804079dd4a5f"
+    },
+    "progs/a_jugg2.mdl": {
+     "bytes": 9684,
+     "sha256": "87808db33bdfdf19ca8c3a7899d32e58dec361b55d53b6f47810804079dd4a5f"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 191852,
+     "sha256": "9a1094db9a9a1018fef5103ac9641ea2ade6fe493bd9b44fe59576ae5f51a2b2"
+    },
+    "progs/azoth.mdl": {
+     "bytes": 894884,
+     "sha256": "f93a33ad1b13f39e8a541434ba14c6aa3c2df7d60a93405a67d8dd7a2310a64c"
+    },
+    "progs/azothgib.mdl": {
+     "bytes": 92380,
+     "sha256": "9e9ced25ce9572fb923ba34ed2aec874268a5137594d3f5800b24afdd63ecc95"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 276136,
+     "sha256": "82bdcd3b2bba43872e2d0488118df4bde6b0122c8ceb489c1d90008431c792d6"
+    },
+    "progs/exbox2.mdl": {
+     "bytes": 2748,
+     "sha256": "56f911ff54903de831343d20549bccb513adbe1d90f13b1cc95b947faf8700eb"
+    },
+    "progs/explob.mdl": {
+     "bytes": 4796,
+     "sha256": "7bf773ece3849d28aaadb862376498c85726216b2c9bdd4655e00518b6d2dde6"
+    },
+    "progs/g_dshot.mdl": {
+     "bytes": 68020,
+     "sha256": "b55d9f3ae0f3c45969f4c64c3423019af302b578913b05630f9d8936bf7b7267"
+    },
+    "progs/h_jugg.mdl": {
+     "bytes": 10068,
+     "sha256": "5a9b66665e8b545cf022c2de11574de22c08ad32ab384355c2b0bf373de0edee"
+    },
+    "progs/h_jugg2.mdl": {
+     "bytes": 10068,
+     "sha256": "5a9b66665e8b545cf022c2de11574de22c08ad32ab384355c2b0bf373de0edee"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 32508,
+     "sha256": "499672202f3c38a8ab706d213d484adf2788b32d22c4fd8c2d61009786befa4e"
+    },
+    "progs/jugg.mdl": {
+     "bytes": 237604,
+     "sha256": "2c4379c84c5334643029613becb02db5964baf9c1e25fb65aec7d96cdbd5f844"
+    },
+    "progs/jugg2.mdl": {
+     "bytes": 237604,
+     "sha256": "2c4379c84c5334643029613becb02db5964baf9c1e25fb65aec7d96cdbd5f844"
+    },
+    "progs/laser2.mdl": {
+     "bytes": 11348,
+     "sha256": "bf2a07924612bc136d63d881fddb82926dbb66af12ecd3716389e96ffde90759"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/rift.mdl": {
+     "bytes": 76248,
+     "sha256": "d6e5ebc02ebd71e7a70d4529248948d1c8dee98f346d737fd68dc01cb9e99086"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 2784,
+     "sha256": "693b856aa9cf05c1fbcf650f0acbd4a5725a7080619f620f7d83529be46e6e64"
+    },
+    "progs/shockwav.mdl": {
+     "bytes": 6396,
+     "sha256": "b307ba844a8a7ccb5e00db6f3e56ced5469c2ebc5b7150dc9950d8a925f06e71"
+    },
+    "progs/skull.mdl": {
+     "bytes": 3348,
+     "sha256": "aaddd5985ac873fa12bef74401842c65f98a17e225f37f0ed2b737f5dbd72fd6"
+    },
+    "progs/sky.mdl": {
+     "bytes": 68708,
+     "sha256": "36632b1ab11738fafb1d9032ab465a4b857b3c2e199ac23926190f5a114d2411"
+    },
+    "progs/spider.mdl": {
+     "bytes": 148496,
+     "sha256": "46f9faf31904f5aa104cfe908760ff0779828916aa617c32b17c6eb3d158121e"
+    },
+    "progs/tree1.mdl": {
+     "bytes": 232924,
+     "sha256": "7cb8b341835b99c393aa56e69a804ceeddd38a2ee5b95738aca894205875640b"
+    },
+    "progs/tree2.mdl": {
+     "bytes": 210540,
+     "sha256": "b72a4b46b655aee9b290ea43faa3845cabf9ef566e07f458bbb8220c47eaba21"
+    },
+    "progs/tree3.mdl": {
+     "bytes": 186004,
+     "sha256": "5fe6a11b3f502457ae3d60f9a0695382bf6850feddc548f6208b4b8b21ece53d"
+    },
+    "progs/tree4.mdl": {
+     "bytes": 267676,
+     "sha256": "7f64dbad8d7bbd932690b34ed8479d69f5bbd5ab77bc1061b7fe9ab6dd7d1636"
+    },
+    "progs/trinity.mdl": {
+     "bytes": 13249,
+     "sha256": "3e0d4636dfd20112bd5415e92c1d8f85fdda65a9a33b09111cca2bbf4561f349"
+    },
+    "progs/uberscrag.mdl": {
+     "bytes": 596028,
+     "sha256": "bb41807125a82e4e8258572aff97bc7cf03aa1a95c3812cbe5f70d82c9b40f78"
+    },
+    "progs/uberskinflap.mdl": {
+     "bytes": 23216,
+     "sha256": "1def9d0a232fff6289135be0d9dafb35062a16c645ef62bc20b402ebc36932ad"
+    },
+    "progs/utele.mdl": {
+     "bytes": 25112,
+     "sha256": "79b5af43a2ea0e81a656b9e149c9d428ac44c638c342a3cdd4fe15108b7b278e"
+    },
+    "progs/v_dshot.mdl": {
+     "bytes": 61660,
+     "sha256": "2b62ca5897eeddfb3a41b6f0c2448a5355100178d009535ff6c4a7ce02c3ccd8"
+    },
+    "sound/ambience/bublfals.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/hevifals.wav": {
+     "bytes": 240964,
+     "sha256": "197a5b8be8ca0394264a763b13dcb9001818e3af2ea0a920769e697df19bc4ba"
+    },
+    "sound/ambience/lavagurg.wav": {
+     "bytes": 44252,
+     "sha256": "79e421db998007f05aa30e42f2f7b021303431f9bd42d89cb7bf9807c03b19fc"
+    },
+    "sound/azoth/awake.wav": {
+     "bytes": 27326,
+     "sha256": "1b8cc5a56853e1cbcdc593b6f4292ca5142f1011a628cf75d079669b39f95aa4"
+    },
+    "sound/azoth/crunch.wav": {
+     "bytes": 39138,
+     "sha256": "810a82fdcbdc02dd1ce9fba574a9befbc1bd16646fa16f8511a0dc3642cd00b1"
+    },
+    "sound/azoth/fire.wav": {
+     "bytes": 15184,
+     "sha256": "ce770d79ccc04025b836221b3c9c9ad01e86252d9fd5cf942b55b5e49ac2b80a"
+    },
+    "sound/azoth/flap.wav": {
+     "bytes": 4676,
+     "sha256": "e843ea8624668ed2415f853fa5b082e3355d61138ab7b8b86f73a8f95c5a0dc8"
+    },
+    "sound/azoth/pain.wav": {
+     "bytes": 17944,
+     "sha256": "fac762778c1cd4870ea9ffaf3bbde7f4a354f4a4546409d8dda32028b602df7d"
+    },
+    "sound/azoth/portal.wav": {
+     "bytes": 24236,
+     "sha256": "37939c6996e1621fb174b99eb865c6a57d6481b09d6c75a7b621e29b9deaddc7"
+    },
+    "sound/azoth/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/azoth/thud.wav": {
+     "bytes": 7808,
+     "sha256": "0fba9da22bdc36399fb7aae4114de89c61fc434884668c18d59fc11243d18e28"
+    },
+    "sound/azoth/thwack.wav": {
+     "bytes": 15470,
+     "sha256": "93aca2b3d23d89786a2a14dd7b9d498c5f4f889c6904e9c9983154f8e3d6d246"
+    },
+    "sound/enforcer/me_fire1.wav": {
+     "bytes": 35136,
+     "sha256": "eb601f114e636ae62c255d9b6567dd83682400e428d20f9f9087967bebf88e1f"
+    },
+    "sound/enforcer/ue_die1.wav": {
+     "bytes": 50988,
+     "sha256": "df6fa72f6b54f58c03430a2f9de837cd752c3e2090d52e5a3574759fb94e501d"
+    },
+    "sound/enforcer/ue_die2.wav": {
+     "bytes": 43192,
+     "sha256": "6b606f051603226c71df2f5f699c5b1f2041febb9da9aedc2366ce2c5f058cc8"
+    },
+    "sound/enforcer/ue_die3.wav": {
+     "bytes": 45058,
+     "sha256": "3e2267a6996e7b80e7f590c3219a46665ef68c3652d428d6e757d76d62fd1505"
+    },
+    "sound/enforcer/ue_fire1.wav": {
+     "bytes": 26306,
+     "sha256": "04fc98e42709c9a5d1a8bbd52aff9114b4922da324e30d21859bcf8209e55b4f"
+    },
+    "sound/enforcer/ue_pain1.wav": {
+     "bytes": 33530,
+     "sha256": "1c253421e2e841f0c5ae0b53167c21260fffeebda2d5eadbcf2e24417668f98f"
+    },
+    "sound/enforcer/ue_pain2.wav": {
+     "bytes": 36056,
+     "sha256": "6c04ce0b1340bad65a2a032c021cc94b9a55645adb0f4789dab9611c559f2db6"
+    },
+    "sound/enforcer/ue_pain3.wav": {
+     "bytes": 27162,
+     "sha256": "3fa2c91e936e493a2ac5dc8e625b027d0024144f176174c0264a6a538fd91ed6"
+    },
+    "sound/enforcer/ue_site1.wav": {
+     "bytes": 46266,
+     "sha256": "d57a6987bcd84ad008c41299a58ce7b84cd82fdfac929f37101e484829a12742"
+    },
+    "sound/enforcer/ue_site2.wav": {
+     "bytes": 22662,
+     "sha256": "c4308c42f3e35c98753c47ed5be6b6e2f76631e8e3b6951d1bb535ea030db18a"
+    },
+    "sound/enforcer/ue_site3.wav": {
+     "bytes": 32432,
+     "sha256": "fab4607eb2d36c3e6bb947e348a8c7c0ea4729da65c1c953a7c00060124c79be"
+    },
+    "sound/enforcer/ue_site4.wav": {
+     "bytes": 33640,
+     "sha256": "fbd7ee02ccc2dd3ed093c1b31bfc7199b7d8c93490fe6709da31e18e1a969639"
+    },
+    "sound/enforcer/ue_site5.wav": {
+     "bytes": 32432,
+     "sha256": "4bfc80e04d56996b8b4c1929bb14b8d0b2916db9750106525159b9bd930d0ea6"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/items2/trinend.wav": {
+     "bytes": 79450,
+     "sha256": "6edc4b653c671187012e5ad6a95f777a861ab18a1d27b69a10912b459dab2577"
+    },
+    "sound/items2/trintake.wav": {
+     "bytes": 73428,
+     "sha256": "b26c0f0af98016163bf1fc7c4376ca90dfa4ad447e31a04fff9d8c9d820cda86"
+    },
+    "sound/items2/trinuse.wav": {
+     "bytes": 16990,
+     "sha256": "ea0b2b20b8137da8388bab00812218a47049183a7d4eb031449b975289de4ed4"
+    },
+    "sound/monsters/juggers/jbent.wav": {
+     "bytes": 7036,
+     "sha256": "18da56b750203a2a61a3fc0297b9dafb1b8fb1f4a120b5589d060005013d6275"
+    },
+    "sound/monsters/juggers/jfalls.wav": {
+     "bytes": 25754,
+     "sha256": "a399115538d013cfaf2e802dc5e85e2a9bea0afe5bd5a02e93065e89702d2900"
+    },
+    "sound/monsters/juggers/jgib.wav": {
+     "bytes": 22124,
+     "sha256": "e11d5c8785e0c792803ca1bcc2a57a75b8cd6d11407f55bace002bfcf533077a"
+    },
+    "sound/monsters/juggers/jhydro1.wav": {
+     "bytes": 7626,
+     "sha256": "dda0b1a06528bda40e43242e156c6b2e509d0c0219b8e2a2e6ae5aed89bf91cc"
+    },
+    "sound/monsters/juggers/jhydro2.wav": {
+     "bytes": 25030,
+     "sha256": "4dd294c650d8cb6367baca7bc27148c9fb6373c2b385562991ef0afd6b577319"
+    },
+    "sound/monsters/juggers/jhydro3.wav": {
+     "bytes": 16564,
+     "sha256": "3fe3d988825febff0de671aa46d620147a0f6132f6f42ec4f96027173b6e1fdf"
+    },
+    "sound/monsters/juggers/jidle.wav": {
+     "bytes": 44068,
+     "sha256": "f728abafff13693a0650fc03a6abdef6b48818b453d00f316c6917f3965939d9"
+    },
+    "sound/monsters/juggers/jlocked.wav": {
+     "bytes": 3948,
+     "sha256": "9b996407fb4d1d96b76643765a298489aea77eeede938313b9cd591722563970"
+    },
+    "sound/monsters/juggers/jshort1.wav": {
+     "bytes": 8778,
+     "sha256": "030e809d08562b4fa21c1dc7270504ef4a4b3d582d8c4598259755873096d19c"
+    },
+    "sound/monsters/juggers/jshort2.wav": {
+     "bytes": 11870,
+     "sha256": "4dd5f5cca2e729eef666e290a2ffcc6942602be60fd28b483696a206e9d7090c"
+    },
+    "sound/monsters/juggers/jshort3.wav": {
+     "bytes": 8962,
+     "sha256": "9f691551c7adaada28d27a63776bc0c11c9c4c952a48e40193e7ff4018ca85b8"
+    },
+    "sound/monsters/juggers/jshort4.wav": {
+     "bytes": 10338,
+     "sha256": "3fd4b07b2d8616e2b82c9a16f48f91dd1f46589f4cfe3d898b7bc9af38d84ca1"
+    },
+    "sound/monsters/juggers/jshot.wav": {
+     "bytes": 2004,
+     "sha256": "81a5a21ea9ddaf51cc67062a2db70a3b09093194f9fe4870f52fe49e5926ad46"
+    },
+    "sound/monsters/juggers/jstep1.wav": {
+     "bytes": 8042,
+     "sha256": "a0093642fa03a403171c04362717a164687fd1172f2c9ff02cc46fef1bd9e4b0"
+    },
+    "sound/monsters/juggers/jstep2.wav": {
+     "bytes": 8828,
+     "sha256": "6fb3d5d205d3ccb6f0d89cde0253bc491ba2df7a711ffcea613f7736aa6fed4e"
+    },
+    "sound/monsters/juggers/jstep3.wav": {
+     "bytes": 7354,
+     "sha256": "8575b89812f6b238149b054b2e755236e9f36c1d8e84b2356fd83d75454e30ef"
+    },
+    "sound/monsters/juggers/jswipe1.wav": {
+     "bytes": 2742,
+     "sha256": "d0f5082a2d40372e9c5f101699c8087daee5dd1fbe1287d025cfb6051ce20a48"
+    },
+    "sound/monsters/juggers/jswipe2.wav": {
+     "bytes": 3208,
+     "sha256": "544f22587d0b866dcc33964814bb70703c8eceb4c68302cd02d95b9a805caa98"
+    },
+    "sound/monsters/juggers/jswipe3.wav": {
+     "bytes": 2218,
+     "sha256": "8c2c0ffb45efa98780f69a2e9fd5d48a204e0b0e6caa79619fd9a888348aa246"
+    },
+    "sound/monsters/juggers/jwhap1.wav": {
+     "bytes": 15690,
+     "sha256": "f31ad559ced2013b53e7e1562995f47be4cc5c701bf3720e2a1ec9826f3b7cc3"
+    },
+    "sound/monsters/juggers/jwhap2.wav": {
+     "bytes": 14486,
+     "sha256": "e7d433c6ec0c7773f0085a55dd5fa404a8eaa31ff5345c9ac459f216af2e786c"
+    },
+    "sound/monsters/juggers/jwhap3.wav": {
+     "bytes": 18824,
+     "sha256": "4c5fda7dc457490807752cd883df0cdbfd95cf362e5549c9e7f6a0f57f504bde"
+    },
+    "sound/monsters/juggers/jwhir.wav": {
+     "bytes": 11110,
+     "sha256": "9fcccd411b11f0e08c1074de056509e60cd2bfdd67d3f325168b542478f94371"
+    },
+    "sound/spider/sattack.wav": {
+     "bytes": 9428,
+     "sha256": "0c9842e14ecbfaaa69a8ebefe6d3c47b0d0f8749d4ac3d0042c1561defa75757"
+    },
+    "sound/spider/sattack2.wav": {
+     "bytes": 6024,
+     "sha256": "209052f761b7ca6d0a245b1bf9b9c02cca84d2f22651f9ce9e9b12e4db0f202f"
+    },
+    "sound/spider/sdeath.wav": {
+     "bytes": 22184,
+     "sha256": "a1c403b367b095864f35961e544e3648e522e777945c7ec7688d61cf10b222a4"
+    },
+    "sound/spider/shit.wav": {
+     "bytes": 2816,
+     "sha256": "1c0c92d9c0168889d01d1e0ba3983235750f479556394c7474cf14970734c57f"
+    },
+    "sound/spider/sidle.wav": {
+     "bytes": 110916,
+     "sha256": "0b2987ce8dfc60b45a63853d20c34169b70c726207163e242b971480fe55bdf8"
+    },
+    "sound/spider/spain.wav": {
+     "bytes": 8410,
+     "sha256": "3234bb7fa76a5efcc6b67738b9d9ff59bac8a2582ca24a55c46e175c7dc1fe54"
+    },
+    "sound/spider/ssight.wav": {
+     "bytes": 22184,
+     "sha256": "5a42f88b16c99c2214eeb3eb9629461f3c0128124d967ad145249255251b529c"
+    },
+    "sound/spider/swalk.wav": {
+     "bytes": 2824,
+     "sha256": "98ac5f7ac9c824fd6c632738ddbf55afef9d50ad10457e96eb8cf7f80aeb9382"
+    },
+    "sound/ubs/attack1.wav": {
+     "bytes": 29075,
+     "sha256": "8e4d91b1b871ee89e617280292b9783afa999270ea73873afa891d5805615332"
+    },
+    "sound/ubs/elec.wav": {
+     "bytes": 22176,
+     "sha256": "8233141c4cd98df65c6fdbff736c1e5752eb57dc382fbb161fa1229e9a6890e4"
+    },
+    "sound/ubs/hit.wav": {
+     "bytes": 7297,
+     "sha256": "a3b21357aa55e4626106905201006dd1dfaa506a3a6f56403a378ae93dee6461"
+    },
+    "sound/ubs/spawnfr.wav": {
+     "bytes": 82504,
+     "sha256": "bc3e8b91c89119802a505aff19c54dbef8d33bef03384cd92403d455cb44f07f"
+    },
+    "sound/ubs/spawnst.wav": {
+     "bytes": 17512,
+     "sha256": "f645a5ca6d6acb93f424e0780bf37d811d8364c3077976c499da2e1643402df0"
+    },
+    "sound/ubs/wdeath.wav": {
+     "bytes": 71798,
+     "sha256": "96e28410c7cdb6ce1a5a1adf7fd148ae823c30f2d97f6095da002e724cc11bf3"
+    },
+    "sound/ubs/wdeath1.wav": {
+     "bytes": 22854,
+     "sha256": "12188225a6b79956a53d26b31353ead3c7f36f45e37bb2001a2e2fdc3613bcb4"
+    },
+    "sound/ubs/wdeath2.wav": {
+     "bytes": 49270,
+     "sha256": "f774999360024419a48594efc727bae94d02939d88ed6efc3f037cd5763b6897"
+    },
+    "sound/ubs/widle1.wav": {
+     "bytes": 13938,
+     "sha256": "b3c0bc9cf0b5b01956996584265b2c52901eacd52c6bfbd26f93fe240ccf5cb3"
+    },
+    "sound/ubs/widle2.wav": {
+     "bytes": 23567,
+     "sha256": "bb762a4acf41d2fc90551e3cd4d9292e23bb276659a17c39a63a1e0f55f0f3b6"
+    },
+    "sound/ubs/wpain.wav": {
+     "bytes": 9160,
+     "sha256": "48ebfc7de3164f23d043ebbde87e008bc9093a9681aec2b9b97e115acc147752"
+    },
+    "sound/ubs/wsight.wav": {
+     "bytes": 22598,
+     "sha256": "e9caf8fdd46404839b0e3795d5bae073160d1748e88c9c3d00fb5c28da5286e7"
+    },
+    "sound/weapons/zer_rc.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "texts/miramar.txt": {
+     "bytes": 293,
+     "sha256": "d7a6e438a6f4673c52768bd573d2fef6e4b0f32a50355b7115f0dc41bbe4fb49"
+    },
+    "texts/skies-kothic.html": {
+     "bytes": 6533,
+     "sha256": "b7d1d9b8a0b60008b927aab100b5b063babadb914db45c647d8a16233536955a"
+    },
+    "texts/travail.txt": {
+     "bytes": 21301,
+     "sha256": "5509a5ae210dc1afaef4bcf9c037110112910f920e83f76da12f1a409fab180d"
+    }
+   },
    "sha256": "545388af6f61f749c25240b818791cec680bebed3fb62c6149224e21ba95adef",
    "timestamp": "2007-07-09T11:13:02.000Z"
   },

--- a/json/by-sha256/c2/c2d00dddc98fe7d65c0f10ee995423ed69ffbad8309834b8ce885aec7e337e85.json
+++ b/json/by-sha256/c2/c2d00dddc98fe7d65c0f10ee995423ed69ffbad8309834b8ce885aec7e337e85.json
@@ -77,6 +77,2424 @@
   },
   "aqualus/pak0.pak": {
    "bytes": 34544010,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 52014,
+     "sha256": "b00eb8dfeae62cc27fb8a0603c2a8056b602d4b53710a42af869d8c0d32761f7"
+    },
+    "gfx.wad": {
+     "bytes": 210484,
+     "sha256": "9072806ee7e43f2ce712cbe7bd68355dd659447258c7e35e1005d71df7ad5baf"
+    },
+    "gfx/bg_ammo.lmp": {
+     "bytes": 1928,
+     "sha256": "754dc8ea867ba7dcd60407764b51a1eccac068456c38787744387a4c59cbce62"
+    },
+    "gfx/bg_runes.lmp": {
+     "bytes": 520,
+     "sha256": "6b69fad1c89ac2085dcc7b8153d1f19ae353bbd0572b05aace1afc02e8e984df"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "6072bd63a691625de201f3f3da060b5df433753d7ac2878c48b87e9d0dd08b94"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "ac11a967228e1c7d1a936859b82807cea239d80380fb6204d67af7a86c5c82e3"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "4cb99cf1b515b6547f012b6e44174c245261b058168a8bc4303d08b98e1805b6"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2c37b7697aebedb5bbf6637d4b8e158f70da6b7245195ff0e91a6ba7aa24e828"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "219002fe962a017600a37dcdcaaa0f777aad42044619f945cb70c68007763a97"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "e251893ed49aeb677096d380d4246907a039e0e21a4849f97f343b0b13faead2"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "64ec646cbab7ebca11f6af4f0b75d9706f438baa7b23059de87f8685f4686640"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "03c7cdc618e4404e2b9364c690b0a447b4be99dc5af112c66e6e2079902c76cd"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "9cf2683f2a6d22693a8c0cf35898bc5900a96afc771878df9f8a8a88f3d581c9"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "f232da5cf35acc557f3f312911e6a856cffaaf9f8078ca2ac5ef7e6f6e5e3515"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "b57ad9ad9d6240a0e035ca7a64e706e3031b8293c27355c9a95495a84972af4a"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "873af58b7244d6e82feb1af26ac044c9beb43c2865bc51d0485054a562ce861e"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "ba75badfe057b499d33168032dd5dc5a4fd0dcbaef9cbbd27efdb3f056cbfc00"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "55ac1377921460aeb691f86e7a5051e3a5481f24b93cc8578cffdab2854ba0c3"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "9600a66391996cff88d48890adfa516660fce6a32397ba4f54973159785cff4b"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9f03351fa7f31a23b63e6c13d2a643ed1ae3fd3df0cf2b0db336424eb17016dd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b7617428e8d1d74be7b770ef24c744d16c2503efce9c17facf1107cce08f5ed9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3036afb422cd299cb09532a20847ef35aaf87bb36e34ce9ce75b5e7aaf9a1ec3"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "7aa61257bd3083c00959776eb36aac86a7ca8da2bacbb4c8a41d9a5fb0b1ab97"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "cfe83953875acfe9afda11b75407ed9883eeb284b0a67b9ff6e07df85d50d9fe"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "d3b4091b83837da5a45445cd00b90267c62050e010e2a045461034ac9c48be33"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "de004dcecdff1973597a977ab63c671ad7d3f52387bdcff4be560924e3d4d17e"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "078c56d685ff1fb84b322f7a76e485c2637fb09efc61f4e44d5d067b3ef9a42d"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "9df9672c8da61ae769409e9ea741a1b8f9a4f108b5f0fa6637ff65601c535843"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "fef6b9be45d5b384d061a47f133075d1cfe0b60d93cf7e3da9ee5529f661964c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "1b1254c1f5764affca85448c4a3c2fefdb938f35bc50f44142a8e9b692ba7d64"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "39a06ff92831e1e2fd20c1bdd20e0f234cd0b3aed94e6c9909d059a20479ce3e"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "def061c922fb91a7e58850e89bb6baa9e09dcf93de7a94288a90511ecd9a114d"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "3220d953bab793165178f2666e67032398a6bd0e0510f6b92eef4fcab377ee1e"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "f897535531fe4b821d41d859a4085fd7d25c679493645a2ef7448f62073523c4"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d070636562a967d1abff330dcd1ea504ac7b9b29099a98994add1d9ae47e44e9"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6d92547a27d839f3c9d7a1da786fb33547cd93b7f19560b6c4bcdc12064545bd"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "e932416c58fc5de16e6d05aa737e56d3811e540bfd9e6acd1bf114ccd8bf34ac"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "bda55d4b2d7bc3f180dafd62424ee5830896563f5a5ac576dfa08894f5e17e44"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "513955ecc96eb1f0d44b340b47f79c02bb7bfa7f3b0a884a65fe111429ddb2b4"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "2faa4c1f61d175ad28b7f54540af3f87abc6e56dc20f2da5fc8a7737a0302c97"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "dcfe5287432b3a1124d032250ccc4bf25c73540521c77601ab746287ef3a0179"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/skillmenu.lmp": {
+     "bytes": 14408,
+     "sha256": "dbf40f0e5faedb181e84d4a822ecc9316711ae89530a30bd50cf4fba45aa8251"
+    },
+    "gfx/sp_maps.lmp": {
+     "bytes": 2248,
+     "sha256": "024bfb2d05f1c52bab1a856cbc532d06fdf4e8d96fb486f74bf451472311ebcf"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "00654b7bec9981508cd9ae8eac167637926c023e7bca011a3cf37585b7e168a8"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "74c50b895f1e71ec6a569fba0e991fde8cf136ea734d6914435aaf9b2735d7fe"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "aecab7a199a4db72242659e6d1ced192d39b2619f67c7e5eaafa72a5efef3aef"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "d075eb0c8c00d30b01eae539720c20b73bb57066c6ea5e8180a4d851d9167add"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "d03aa05e24552d961ea9ca278d743860e34a97e2ffcee52fded05ad4b4740bd9"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "progs.dat": {
+     "bytes": 1123258,
+     "sha256": "6feb4578285cd1faa37798124a165e8b928c9c5a8651c307695903d2218b6589"
+    },
+    "progs/alkturret_base_v2.mdl": {
+     "bytes": 87768,
+     "sha256": "4b1969201052a4506509bb606eb7c395daf9332cf4605036ab50190495dcfbf3"
+    },
+    "progs/alkturret_main_v2.mdl": {
+     "bytes": 116620,
+     "sha256": "11a2564f7daa19625e4514c284650242c8b3831df947f183243adafb958a1333"
+    },
+    "progs/arachnofloyd.mdl": {
+     "bytes": 741212,
+     "sha256": "554bd2ad34a830fa01a61dd4972f432812fb61f7815ec81d8a8d7e87bfad6b02"
+    },
+    "progs/arm_foot.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 164224,
+     "sha256": "35314143b9c7a9a0e26e52a865072a6e73862466e640c6bbd58be3075c4d93ff"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 497408,
+     "sha256": "40cc63b599cedb54f04c937ce407e7119c1cf4d5d35fd04bc18f247584e9899f"
+    },
+    "progs/b_p_key.mdl": {
+     "bytes": 5940,
+     "sha256": "051b2e8fa67cae7aa24490a18444400f773d4a9d353542ebf979b0a22a1771ef"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bambler.mdl": {
+     "bytes": 128044,
+     "sha256": "c8ac9dbcf99f0e6efd30496ac414383c26b8d241fbaff56cfa81dfb545dfb0c8"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "698bf740683ad182feae2246526361948be6da2e144f1bd0202eafa748213ec2"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "b662513bc3a8e0e967344c55b536bd33012340dbeb79a8db1281d2c84e36d338"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b2cf62d8e989789bd76e27193b2f5205a93d4172a4e25c89aa1b30f75bebe60e"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigcranea1.mdl": {
+     "bytes": 92792,
+     "sha256": "81f6a5b55d3a585d5e9c73b088d1d20e0fb328707c1539ef41e52c460555f651"
+    },
+    "progs/bigcraneb1.mdl": {
+     "bytes": 21940,
+     "sha256": "e02faff0bb6c84c781f6b534a5a06ac1f977a028fbdcca176be2932f91e9e8ec"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/brz_saw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 575288,
+     "sha256": "f571bdf504537ce01ca2b6a78b57575a36c391f9c786625d880d956fb17390a7"
+    },
+    "progs/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/chain2.mdl": {
+     "bytes": 141764,
+     "sha256": "9334a3ec04716ce0068154bf7abb4c1e3ee6de14fb159982dd547314935d7854"
+    },
+    "progs/cyberscrag.mdl": {
+     "bytes": 306936,
+     "sha256": "868d1394e186b1e7f4fc58134c338a413814723f406fa609e2d7cb87dc2496cb"
+    },
+    "progs/cyberscrag_gib1.mdl": {
+     "bytes": 60500,
+     "sha256": "3db8b13bfa5a5eda07acea695cae6ffb92354053da9bed199ef29cd445317faf"
+    },
+    "progs/cyberscrag_gib2.mdl": {
+     "bytes": 58932,
+     "sha256": "ef20c0de15fe2fc2514c10b0023d14009a4871ed40311077ba107350c313f7ce"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon_alk.mdl": {
+     "bytes": 191716,
+     "sha256": "11f33f19ae0a46d3dcc6c1fee46235fb6ad201456120502b603fe4fb7cee14ac"
+    },
+    "progs/demon_old.mdl": {
+     "bytes": 272684,
+     "sha256": "538d5d01833d6910d4400f8795be582c3427748eb2a162fcec2c17d6707c57e5"
+    },
+    "progs/dog_alk.mdl": {
+     "bytes": 199324,
+     "sha256": "a16e350fcd247908c75ecd0c93e94d3b700b67bb0f66dd45d665d171a55d42b6"
+    },
+    "progs/dread.mdl": {
+     "bytes": 415072,
+     "sha256": "dcea570331c5cf4348c40451c6242bf35ecaaea2a348f12254a13c1b76b13d7c"
+    },
+    "progs/drip.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17284,
+     "sha256": "444692074359310be0520b1caa057ae2e084df826f7ecc9bcb0d258ea1d80373"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35988,
+     "sha256": "91aa79805577466147bd4811614b0387b3635aba8383fc2e16b178d7b63ebdf1"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42436,
+     "sha256": "93839bd6f50323f7ac5ae46037de0c6a10a533374f714229dd511ee62b88ca3c"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bcc6396dc638003480dba8c36cafaf32df2cfcf49bd460b001d0d74a164f9011"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/enf_gun.mdl": {
+     "bytes": 58684,
+     "sha256": "39ef1788b39a15f86c8d54b81c43f4126e8361ff80d386c44358f17ddc93769f"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 450424,
+     "sha256": "ecf603c4ebc56438e96d1706a451af8bbe9b090db9c48e38e758ec630a393570"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "ddcf759804fffd97e62c55f67f962e24e8cd646fd982215ac8aefd3e49f67660"
+    },
+    "progs/enforcer_alk.mdl": {
+     "bytes": 333860,
+     "sha256": "85fb5cb9eb1435da65ce0aa6940241b7b4b5fa13e7444713a75c6ec301cc8b97"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish_small.mdl": {
+     "bytes": 221279,
+     "sha256": "34b883e3bf73a520f301cced68629e0d95e88f96c03a23230f12d02aa49c247c"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flag2.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flagbig.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 451032,
+     "sha256": "1a311e7e74f9a67c9f7468252aedc8c19804f65375d229e90afbec2f93849823"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/fromitz_still.mdl": {
+     "bytes": 6964,
+     "sha256": "63204597e828e001c957e9316878995e161da0502764276b90285accadf6a222"
+    },
+    "progs/g_axe_alk.mdl": {
+     "bytes": 50460,
+     "sha256": "92988e970870f2b977f7490d2ea4ee040d338fa4bdc470e8d68f2e5a856a7a28"
+    },
+    "progs/g_axe_alk2.mdl": {
+     "bytes": 50460,
+     "sha256": "e448b2a7540ba959453592b2472d0ae498142a77242c91fd5991ca23a7973f4a"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_mine.mdl": {
+     "bytes": 37780,
+     "sha256": "5057c7736e8c722270c781e47584972f42e7ebdd5860596403a9ce7688d0b5cc"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "15f390e39e02c8524e575ca8fadf63187b641c58210ee9587b13a0ca94c29cc2"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 199076,
+     "sha256": "7ddca6fb95082d0cc7ffe5aa3ba896ea987a80b1bd5867db97b2a84b9d8da9f6"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "8b05b8ca87ea867c2a2397d238311fda2441f5c0e1cde130ba487b0dbd17a8e5"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_arach.mdl": {
+     "bytes": 60292,
+     "sha256": "daca6412383bec28809cee42c4ebf01085cf83ed6ff289114ba0f842b4005251"
+    },
+    "progs/h_bams.mdl": {
+     "bytes": 37316,
+     "sha256": "58c4644a2ed3e5f10741dff2ad1a8bb161f7eb205ba3fd8c5fc9b7e4ffc571dc"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_cyberscrag.mdl": {
+     "bytes": 62036,
+     "sha256": "df7d6bccc97bd5c184d9d6160005b370175aacc16a34bd06ab14c7d69ff60419"
+    },
+    "progs/h_demon_alk.mdl": {
+     "bytes": 72644,
+     "sha256": "22a9e01cdccb2e274c63c277e6dcd61986fa7556426ee3562fe11af2babea289"
+    },
+    "progs/h_dog_alk.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_mutant.mdl": {
+     "bytes": 110240,
+     "sha256": "f1f9c665b659a8c145550605ef9abddf27779d0917c897baa344d65673770875"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/h_sabrkn.mdl": {
+     "bytes": 11828,
+     "sha256": "050fcc93189211aba943674a326ddd898dc980b83fb551ee11fec3dd39973483"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shams_alk.mdl": {
+     "bytes": 37268,
+     "sha256": "9fcace6cfb38473763a5cf96007ccc5e0ec4786352d4d1063410d63157298b45"
+    },
+    "progs/h_torm.mdl": {
+     "bytes": 62056,
+     "sha256": "db0ddda0c4d2283cd3c58eb45397cfb57095acba1eb6dd38571ca23ebffe9946"
+    },
+    "progs/h_wizard_alk.mdl": {
+     "bytes": 14948,
+     "sha256": "5f6c27ba255b87718d993b29cff526bd025c0e7a4991722a96fe3c0f98d83408"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hknight_old.mdl": {
+     "bytes": 418144,
+     "sha256": "40bd5757499a2bf7e6f60a78b0039665107c9603c2557f6bc73208e080111464"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 37012,
+     "sha256": "e3c6cbabfe6c6723101f2e59f50fc99ee0e360571c95885d2d56c85eefade15d"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/jumpblue.mdl": {
+     "bytes": 37428,
+     "sha256": "be4e85e5fc643e91377d69794b997ad4dc927ae3866dfef5288d704dbc0f16d7"
+    },
+    "progs/jumpgold.mdl": {
+     "bytes": 37428,
+     "sha256": "4c543d82c88009cab7fcf6230feea0a21518a98f430636194fdbf5c1e526cc13"
+    },
+    "progs/k_laserspike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/knight_old.mdl": {
+     "bytes": 208068,
+     "sha256": "5cca43e29392051c9ba95838a58cc1038560411e6c0d2aff61867a428b119e2a"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "63220c0ebb6e266576cb3107a44be16bda10d69fa524d0462514edff9d80328c"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "29bc55efafbea3e15a385598750ba4d9242d0a87803a6bc3430ed772ec1785c3"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "f1e799e7feac3c340676bb60f6cc7a2a7d1e121b196d1f6d0e23edea3a614ed6"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "92370f5b196dc00460d73697975d14279ef659c87c7fc1613b9cbfb68e6c299c"
+    },
+    "progs/m_p_key.mdl": {
+     "bytes": 13428,
+     "sha256": "581a23ac3e2bf0960a7a8b1c4693efd1913d9d17a1f4fa405a1b8c6d89105f91"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "4c5db792da6876f935f8a98a74f51708d52ca03f04975f28518051494660bf65"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "781837a3557c1a8b89c15fa8f477989cb4b77d8cff09c8c13d071090a4df9c1b"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "2feb7ce08070b314d163cbc7f2e2eae0986400c482f752d305ddba268639b3d8"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "04f7fc8b0c2be7ea93021819770145eaf828b2313c4fc591a5f2aa783ca97e61"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 8372,
+     "sha256": "9b6a8f7a49fb7a1f5d4d409b708663c579d433e978d898b9bdf00291a59b4e6c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "fa5d7a5e2410ac7faa5dd0a8e17873c972c6e5cfeacc94118f22db1b4b17477c"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/mutant.mdl": {
+     "bytes": 352720,
+     "sha256": "262ffca22e0c7308950076c2789436a891399862ea25afbd06040158ec9f7984"
+    },
+    "progs/mvore_bomb.mdl": {
+     "bytes": 12653,
+     "sha256": "dd54f975b770db899ef71174d8b05cd98af99739e9506fc4eb354ee8d7e820b8"
+    },
+    "progs/nsoldier_alk.mdl": {
+     "bytes": 563108,
+     "sha256": "6071d7cecf231f0a83f2e1c7df533b4a32beb6e75969d17703446a67d011695a"
+    },
+    "progs/ogr_gun.mdl": {
+     "bytes": 52452,
+     "sha256": "eaa6e0fe01255450d578f151c06c5aeb6a9cd5ed90edbbe4f52d305069ed6825"
+    },
+    "progs/ogre_alk.mdl": {
+     "bytes": 315696,
+     "sha256": "31e9986373dc1a8cba00e09ba9b0278cf766bbd074524a891ed22329f697d643"
+    },
+    "progs/ogre_old.mdl": {
+     "bytes": 315696,
+     "sha256": "53317e9b684701e7722bea342af1a6dba5dd31e72cdbcfa5b097382516d1c6a3"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 487968,
+     "sha256": "ae0abff3ea3fc7ca8c7f80c5d8825553795a1c1ebb80127d46fa52b20905abc4"
+    },
+    "progs/ogrem.mdl": {
+     "bytes": 378296,
+     "sha256": "2bb999bf580d16fb9ee4246dea7897236d6d118232c78a6168f641dc32778fb5"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/pellet_tracer_short.mdl": {
+     "bytes": 58148,
+     "sha256": "5b24b67ce9d9b2634d9a0f31319a977e1e3ec6352d491367941a0e5bf2ae10ff"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/probegren_body.mdl": {
+     "bytes": 139044,
+     "sha256": "da0ddf337c3e2515688f2b143adf55d4ecbbfa32955a78aea01ed16e067b0065"
+    },
+    "progs/probegren_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "4f292b6f157d226e763ff28dad682ce95cfb8a3a21b4badf0ca48db4900cdd70"
+    },
+    "progs/probegren_gib1.mdl": {
+     "bytes": 63788,
+     "sha256": "0efb081efa87c9db990d984f9974f10078890a51894a3e0a6fbe76cc3c4cb5a7"
+    },
+    "progs/probegren_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "7843ddefa22b7d5beb37f889c606c6361792508c2bea202f3dadf9f3ffce73de"
+    },
+    "progs/probegren_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "7baac250aa8c27ef3158de59b536ebf59509e39b1f7bf6be1c24fd5b1e29cae0"
+    },
+    "progs/probelasr_body.mdl": {
+     "bytes": 84296,
+     "sha256": "ac545d0f545488628c864df6e464d10fbd51cb41a2cb76c46dd91233ecd11a6f"
+    },
+    "progs/probelasr_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "cec7b847c9b05f2653113454348799b9bf09c2a74c8e1760cca0ff52c1dfc18c"
+    },
+    "progs/probelasr_gib1.mdl": {
+     "bytes": 58700,
+     "sha256": "ae9f298abc0bb1d09cea3c04bf02216b0a1c3749f8c8a822d973b4c2091cd649"
+    },
+    "progs/probelasr_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "07d6defee5ce4e747daf8b397a5d207a1a42e3c3acffbdfc18d6720c88ec635c"
+    },
+    "progs/probelasr_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "8b8f376afa56e7a9f311e58a076f1fa3a52c88064887a8e0960fdb6daaf5265e"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12653,
+     "sha256": "162632bc16838f66f29e0b788845a6421b7fce708003e9fa6f4eb8ae7aa8e5be"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/rail.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 200152,
+     "sha256": "a564fba381d24e3084bc9aa0a026381c83e6b889632c8bebdf69c08c8a6bb9f2"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "f65ba83d82e90808af589ded17378f1baf37f105fa14f2b157227ee22583d25d"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 288,
+     "sha256": "6ff2797f9dc4e66f2113475a5f3e0e96f23dacbddd18fe47c8b5e12e712f0e75"
+    },
+    "progs/s_bullet_new.spr": {
+     "bytes": 708,
+     "sha256": "a07fa61f4a838ac9ad8ec85ae525d70fb934d383effd1948c0775497be713043"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "b3f1971bd28f96c623c5712e2a47f54f16c99a50d460a944cdcdf29e6eb03963"
+    },
+    "progs/s_exp_small_2.spr": {
+     "bytes": 201720,
+     "sha256": "f7fdba9e2b9b5d318cdff33a06fad4e91e46ba3a241fe7ced4bfbcf0bcb0e873"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_plasma_new.spr": {
+     "bytes": 13980,
+     "sha256": "5474060e55af3c462d0ef7aad043f331c1f5b642915d906c1785bb94595cc68c"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 2820,
+     "sha256": "ea66402d248232b0b6a77bffe024d4a62881be47becf37acb42328661b7f23ef"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shalrath_newer.mdl": {
+     "bytes": 228496,
+     "sha256": "93601de7ff47f552ac9d441ddf1faf312417ca914de99529b17bdf7522e7478c"
+    },
+    "progs/shalrath_old.mdl": {
+     "bytes": 211576,
+     "sha256": "409cda15df7b271bd95a895f058a521d43eca63f37c7ac9df175e5b478229bb9"
+    },
+    "progs/shambler_alk.mdl": {
+     "bytes": 502148,
+     "sha256": "bcf685fcd1f4062dc382924d39eae073fc4d44cd2dcb5bc4ca3797fe0b342b71"
+    },
+    "progs/shard.mdl": {
+     "bytes": 10132,
+     "sha256": "0219a0f08bdc1f604ebe1ea2243cd1b27a2b1ab85bedba3a11298f2d22e9b38c"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "662d6a7cd68bca7a9c5e88838d190de6a501252a14b6994a191d0bc91f1f331c"
+    },
+    "progs/sknight.mdl": {
+     "bytes": 460932,
+     "sha256": "9213f6898a60cdc20a7a144c61c13f8d64f1432382dca44b636524edf737dac8"
+    },
+    "progs/soldier_alk.mdl": {
+     "bytes": 359276,
+     "sha256": "623374e5a553c3d886738c9cc0b22c0b3f3435b3dc1b3f473079a1dd1661fc8a"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spiderbot.mdl": {
+     "bytes": 82476,
+     "sha256": "e85556a194664a5f69e70b42aa863d9e67689a418a3afa51e50816174a6fe8ac"
+    },
+    "progs/spiderbot_gib.mdl": {
+     "bytes": 19444,
+     "sha256": "96ee732ac1199a89c675880700c24e1f09521c35ad478f73aaf4278a398454f6"
+    },
+    "progs/spike.mdl": {
+     "bytes": 2820,
+     "sha256": "783d711b408498dbb34581c9a0ae74ed325dc5c68fa67873745b02c8a926a201"
+    },
+    "progs/spike_old.mdl": {
+     "bytes": 1684,
+     "sha256": "5e3be5dff13ec94951aacbd4a453dcbd9c2aebe7e4e6bded2dd70d49d1ddd695"
+    },
+    "progs/supbkpack.mdl": {
+     "bytes": 44408,
+     "sha256": "781c6b5f424fb58e06b2a84b1fb7e980778decde6b3ed257e224db0b1f250173"
+    },
+    "progs/torm_largeshot.mdl": {
+     "bytes": 37852,
+     "sha256": "ce3a87be213e39b48bc71a6fbf5e1fe9e3f5209901ca45801f27d8f297e04a01"
+    },
+    "progs/tormentor.mdl": {
+     "bytes": 461080,
+     "sha256": "df302dea113f54df908f97c26de844d1235004c08aefcf5c349f3af4b0957d41"
+    },
+    "progs/trifecta.mdl": {
+     "bytes": 25460,
+     "sha256": "2c9196af0806c48354f5522a8b7f6fa57e6390f8dfb51718fb71b8a2d4d7447a"
+    },
+    "progs/trifecta_big.mdl": {
+     "bytes": 25460,
+     "sha256": "9633a10c7c20f77b9202befad3cb363aefe710b166e581f80967ad94b5c6b6eb"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/v_alkaxe20fps.mdl": {
+     "bytes": 96428,
+     "sha256": "4405242db772d86c66f1012b140ba409bee86682fa5f4a6ca12c3e6f94eb9fcc"
+    },
+    "progs/v_axe_alk.mdl": {
+     "bytes": 55820,
+     "sha256": "80ad34cf2612f8fa9121f2be0ada92c1e05613ae2b35b2a1be25a4c694dd2147"
+    },
+    "progs/v_laserg40fps.mdl": {
+     "bytes": 142580,
+     "sha256": "b897ecb5868e3125597d51f970075af04782cba47ed8a42d7b17775dff01f536"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_mine_40fps.mdl": {
+     "bytes": 332920,
+     "sha256": "0039956e96a804229359aaf082b9cf66515d52360867b86c3dca884d19caf8b4"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail3.mdl": {
+     "bytes": 124944,
+     "sha256": "19045e9a5154299b68377744ad946fc3e7f2bd290497c8291a2247ed8cc572ad"
+    },
+    "progs/v_nail_alk40fps.mdl": {
+     "bytes": 44692,
+     "sha256": "402b3dc06f1e5e756cfd50cab17cca49e17e261994c5007cfd46c466a08d3dad"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 260692,
+     "sha256": "0982368440a5d20d65ec511207590c2bfb63e9a60376a5d753b209f2b047c58b"
+    },
+    "progs/v_rock2_40fps.mdl": {
+     "bytes": 139668,
+     "sha256": "89257b7580ac3f48fc775f121eef3508c326eba1369e6aacae83144f8fdfca15"
+    },
+    "progs/v_rock_20fps.mdl": {
+     "bytes": 39556,
+     "sha256": "ebdd6245e1ff65bd95eaed7fa189ac87b51818408f091a32de3f4a477b90f2f8"
+    },
+    "progs/v_rock_40fps.mdl": {
+     "bytes": 43828,
+     "sha256": "f3c32a1c37d4fc3115a8da00ba9507cdd508a98f65e2ddccbcbdc8a0ba0bf2ea"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 326464,
+     "sha256": "dd389cc337d8b7675d9a7b983fd9f53f0c59d597a9759367bd1e1beba375eaaa"
+    },
+    "progs/v_shot2_40fps.mdl": {
+     "bytes": 29076,
+     "sha256": "37ae91c018183faef847aad217da537c97b5a2430ab27a860388bffc1f4514f6"
+    },
+    "progs/v_shot40fps.mdl": {
+     "bytes": 29252,
+     "sha256": "87a47e2debbc27fd6c18a8a38a9a373e7b73ba707458e6346f069c1572df47b4"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_p_key.mdl": {
+     "bytes": 10580,
+     "sha256": "fb3db38e23feda2ca9a8ee1400bdd0b452332f07bf9455db3eac0e52af1e3c22"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/wizard_alk.mdl": {
+     "bytes": 158508,
+     "sha256": "aab430eb2dc0f5c50ca7b4492a7ccc427f2a12011f54ece1b81d4beb66acb4a9"
+    },
+    "progs/zombie2.mdl": {
+     "bytes": 130148,
+     "sha256": "185336c7bffe32e496e93f6828278287f89b672c71f2439918ac5e220ae8b868"
+    },
+    "quake.rc": {
+     "bytes": 2052,
+     "sha256": "b791b9736f5ee57b06dc0bcdc156b13dda9144bb0a972ee5b5069de73c10e55d"
+    },
+    "sound/arachnofloyd/death1.wav": {
+     "bytes": 119460,
+     "sha256": "d16c7ff30e9df62fbcda102befbd61fe234532f6aef30d0b34c25330679682bc"
+    },
+    "sound/arachnofloyd/death2.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/arachnofloyd/idle1.wav": {
+     "bytes": 34254,
+     "sha256": "35d6991a10637251ec0d6b830f7f57f394e4eed06e7a9dced86f0128ba5bc49e"
+    },
+    "sound/arachnofloyd/idle2.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/arachnofloyd/leap.wav": {
+     "bytes": 70884,
+     "sha256": "f47323f618db14755c57e9e25213267dcffc501fbaa9a201176ab99db6cda928"
+    },
+    "sound/arachnofloyd/pain1.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/arachnofloyd/pain2.wav": {
+     "bytes": 15906,
+     "sha256": "9c4bdc81c73787cb67677e0021b71d9e24734ef3ce272d9020dc6611a1d87842"
+    },
+    "sound/arachnofloyd/sight.wav": {
+     "bytes": 48620,
+     "sha256": "97a055dbb8e5935190348b2c2d50c6d99ab35c29f3ebcd0f66d6263bdb5485e4"
+    },
+    "sound/arachnofloyd/step1.wav": {
+     "bytes": 74932,
+     "sha256": "a8744a3e50dccf9ee391da2f381c2ecf6701a76441406929ee4581c7717b880f"
+    },
+    "sound/arachnofloyd/step2.wav": {
+     "bytes": 34478,
+     "sha256": "22ce43aa18537f7b04e31263a46dd02e181d538fdf5918d55f8ce0acbb930676"
+    },
+    "sound/arachnofloyd/whirr1.wav": {
+     "bytes": 19762,
+     "sha256": "9e2029071248e6d45f1b0d518983bad5bc5f841cda6bcfba09486e111add10de"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axegrunt/axgdeath.wav": {
+     "bytes": 20214,
+     "sha256": "e5ed762afcc516058acc1b3884b4d08e67fd36e3a5bacf711d3504363bf8136e"
+    },
+    "sound/axegrunt/axgpain.wav": {
+     "bytes": 12636,
+     "sha256": "4699951fa58fdf15ab819b13d70904fc9a1a86a4db02193d621dfad3878d17bf"
+    },
+    "sound/axegrunt/axgsight.wav": {
+     "bytes": 17712,
+     "sha256": "e7b23208831c1d83793ba06f3b8855430c92017600cd8315341afbcb6ec6c8f0"
+    },
+    "sound/bambler/melee1.wav": {
+     "bytes": 4175,
+     "sha256": "4e0e2567b9d64b3ff86b33d95fa0158bf72372aeb4968a0c2489df942f9f7c4d"
+    },
+    "sound/bambler/melee2.wav": {
+     "bytes": 5283,
+     "sha256": "4bb91991bccfc33576eff19037e12666e9825348272d3dca40199e208bc00700"
+    },
+    "sound/bambler/sdeath.wav": {
+     "bytes": 14048,
+     "sha256": "c5253af82d203e75d132a00bbb555de055d2e356106d460f34cb8c9a2ee5e643"
+    },
+    "sound/bambler/shurt2.wav": {
+     "bytes": 3736,
+     "sha256": "0f1a51e0ff72f23a4de7684d4408344b7b7bd2cb805609168d2f2459e1b8660d"
+    },
+    "sound/bambler/sidle.wav": {
+     "bytes": 4907,
+     "sha256": "ea2232ba791e306cc86f58303413d8f3fbc7dd38091281698f4d846b6cafa483"
+    },
+    "sound/bambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/bambler/ssight.wav": {
+     "bytes": 11376,
+     "sha256": "de766aa056ca5f7dc6d179e6a220ef906ceacc0341b5cb3d91a4d0e75ff55338"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/cyberscrag/fall1.wav": {
+     "bytes": 23396,
+     "sha256": "162fc0be1cd0eadfc93c35f1e1ba9b8dfc7e8df8ee53afb2a14db73e69f20ce8"
+    },
+    "sound/cyberscrag/hit.wav": {
+     "bytes": 22334,
+     "sha256": "a16ef33d94d56fb6984b2a3d06104a3cc292bdb38ec6ee22c8b10457b2cb415f"
+    },
+    "sound/cyberscrag/wattack.wav": {
+     "bytes": 25912,
+     "sha256": "6bed724b7ef9bdd480448396ed4498c75f848bf2a1e6d2879cb2b2484cdd1a7b"
+    },
+    "sound/cyberscrag/wdeath.wav": {
+     "bytes": 20684,
+     "sha256": "24602233cca209122250ba7c284933992aa2393795ea5c528a57b9986e2fc319"
+    },
+    "sound/cyberscrag/widle1.wav": {
+     "bytes": 13465,
+     "sha256": "8902628d2201eda9396c0dc134ebda8b8d5c37dabddcd286f8387aadc6532750"
+    },
+    "sound/cyberscrag/widle2.wav": {
+     "bytes": 23094,
+     "sha256": "76af020e5c25f40ab3020bbd065a9b83b9b0a51120d47d137a7abff4eb43e193"
+    },
+    "sound/cyberscrag/wpain.wav": {
+     "bytes": 8687,
+     "sha256": "af2e8589d381e634f607048ce71200df832c9e3a32147891b5bdd2efe2ff5bf0"
+    },
+    "sound/cyberscrag/wsight.wav": {
+     "bytes": 13079,
+     "sha256": "2f9178f6515eb4cd518b418441c40d1376aeaf6f42f7791533f5f4b6da87fd68"
+    },
+    "sound/doors/alka_doorlocked.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/q2door1.wav": {
+     "bytes": 30572,
+     "sha256": "3f05bddf76379933970c532656b6350bc53820319ce1cb9d4ea9288210427eee"
+    },
+    "sound/doors/q2door2.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/dread/dread_death.wav": {
+     "bytes": 49692,
+     "sha256": "22000ff613ff52eab0605418681affaf7aeef4acc420d3dddd50a9031ac1ca38"
+    },
+    "sound/dread/dread_pain1.wav": {
+     "bytes": 29220,
+     "sha256": "67e443f78043cb9fc4213bbfbc3cd847785a66849fb7b36dd6467494487e0aec"
+    },
+    "sound/dread/dread_pain2.wav": {
+     "bytes": 23380,
+     "sha256": "914fffe3ad6c02fb78be873ee96405a40df22cd321beee2d673d0b6ebbafcde4"
+    },
+    "sound/dread/dread_sight.wav": {
+     "bytes": 70792,
+     "sha256": "50449a772b2ac778b810a69de58cb63c8bbdea529091720a41a1052b7196632e"
+    },
+    "sound/dread/dread_sight2.wav": {
+     "bytes": 58420,
+     "sha256": "f7952137b648f6376a1ba4e968679abb17fc648ede87bb0dd32f633271ad80ee"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 110256,
+     "sha256": "895cfb57c0d27369530fd5e9b29abd491a989ad0a63ddb00f05dd9e4777a5cdb"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/frogman/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 32638,
+     "sha256": "3cf3933f34c7baef52df54d5b03db40424e9f7ee72e5aa5a4dba489d71be2af7"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 27662,
+     "sha256": "ec38e73fd1ffc33cd25aa065e5f5897c21a494e380763ff80b6be482689b5e33"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 44186,
+     "sha256": "7600cd32fe980646fddcf5a9077d8d43df1bca1f2ed05bd92ce8cca273ad6636"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/armor_denied.wav": {
+     "bytes": 15854,
+     "sha256": "2ec14677f483d1a1b869af64cc30fb0dbd90a640fc071fdf2ae493d27cd746e1"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/items/shard_pickup.wav": {
+     "bytes": 18260,
+     "sha256": "388923a63b48720647b9e0f2862c35bb1d5cad2e162ace343845b3fe36b48af4"
+    },
+    "sound/items/trifecta.wav": {
+     "bytes": 16412,
+     "sha256": "00baad51adaa3f5d6664e85ae5442221db6818bfd85124c164324d22f6723ab2"
+    },
+    "sound/items/trifecta2.wav": {
+     "bytes": 32778,
+     "sha256": "f742a9cee4a53ef52fce55d5e9ddaae9c6b20d2127e16c0def6cd11b3d2d6380"
+    },
+    "sound/items/trifecta3.wav": {
+     "bytes": 10728,
+     "sha256": "a78bfc9fa4fbf0c3c1e85bee273ee053598989a09146bd29e97dda811c49a473"
+    },
+    "sound/lieut/alert.wav": {
+     "bytes": 8700,
+     "sha256": "7ebbe83ae1b5d159c9f0a0ae5f3dea126650ed5d6f98a22d1512dcfcb19a23ca"
+    },
+    "sound/lieut/objective.wav": {
+     "bytes": 10052,
+     "sha256": "aa7d6726a458eaa48bf2e20446c57360b82ac23bfbd06bad7b6e01ae95ca8b0d"
+    },
+    "sound/lieut/target.wav": {
+     "bytes": 6754,
+     "sha256": "eebd50c75585894c7d5305f6c066aaef1efaca9a59e27b80d03e8ae4d69caa69"
+    },
+    "sound/lieut/you.wav": {
+     "bytes": 7126,
+     "sha256": "6bfb031b0d69b8ae4ef2e9b201da43c523ae88de344907648d4064e07477ee1c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/mechavore/attack.wav": {
+     "bytes": 66460,
+     "sha256": "fc2a8b0e2a72aebe2858b8337d5ef0638e3e04d5b60e9a62d46ac124072705f9"
+    },
+    "sound/mechavore/death.wav": {
+     "bytes": 37504,
+     "sha256": "bbdf8369941f8c2ab302fe3a55de3bf04e1d28e32a575ffd3c24009d76bebc8f"
+    },
+    "sound/mechavore/idle.wav": {
+     "bytes": 64972,
+     "sha256": "5cd8253f1abe5baf08f1852d12393ca820c34fc0f2febf6c1c8f9d4c3326b2c5"
+    },
+    "sound/mechavore/mv_attack.wav": {
+     "bytes": 67046,
+     "sha256": "af133ede9ab5627f3ea75b12716653b11dd813982cab4a6aad0792371ba58006"
+    },
+    "sound/mechavore/mv_death_a.wav": {
+     "bytes": 125364,
+     "sha256": "7a51ba5587b4c8ccd4bd0e93b105f277f4f093a1cd90f684afb33cf0bbfc812e"
+    },
+    "sound/mechavore/mv_idle_a.wav": {
+     "bytes": 61484,
+     "sha256": "463f1bd23c4bf5d2953ce2f7ee980c9fb28725a0bdc92bc1f03dab8e139a2f14"
+    },
+    "sound/mechavore/mv_pain2_a.wav": {
+     "bytes": 41004,
+     "sha256": "18e27023c1ea7ce306f49559a8f303f62fcc206f05f94878bd1898e204972ebd"
+    },
+    "sound/mechavore/mv_pain_a.wav": {
+     "bytes": 49196,
+     "sha256": "7e2a98060c2ebe14313c831e8d3d410aacd70d7bffa9ef45b0f98845cebdfab1"
+    },
+    "sound/mechavore/mv_sight_b.wav": {
+     "bytes": 57388,
+     "sha256": "2212706950e66000184352238f479d659ea37062186b595e6834bb4d1d910c7f"
+    },
+    "sound/mechavore/pain.wav": {
+     "bytes": 36444,
+     "sha256": "9f9368fdd53aec80fd43a6d3b6680e04aae72685d1cfbdf49d55dc1070e8c546"
+    },
+    "sound/mechavore/sight.wav": {
+     "bytes": 116312,
+     "sha256": "112613b44d88046653b29f21aa5fced5d4b5bfcaff037dfa5f246729e45a6968"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/conc_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/misc/door_closed.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/misc/ebell.wav": {
+     "bytes": 15220,
+     "sha256": "1693337ed8873f1159e56c2925afaa210f5c28bee4e2c42d27e29bee8e06cb5f"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 4054,
+     "sha256": "b9c44f73c8bdbc900af4f06600e0d6456a040b296612b7d0fe53391285976a44"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 4098,
+     "sha256": "4fad66341514c9aa2b31b4c2fde7563369090da9b0b3a51e08bca3100f2ec282"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5054,
+     "sha256": "d158ddc35360bc43934b7a8a9b7cc830f7510e6bb3a640813157822b27b5217a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 9726,
+     "sha256": "73b74099c8cb43ab2fb09b28b72ddd9f73f2d2a4f8a00a8e835490f366680c92"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 3226,
+     "sha256": "48551cc717e5011df78a38c6a71bb001e4f62a1858a3952311499653ff423a07"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 5802,
+     "sha256": "751050f97456a0c07e88a249d40dde96c2d14640e21670ccdde983502998dbba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/singledrip1.wav": {
+     "bytes": 26546,
+     "sha256": "b9193092eaa02003c7ea409663dc1213f0a18a120471a76d298ce847448059b6"
+    },
+    "sound/misc/singledrip2.wav": {
+     "bytes": 25478,
+     "sha256": "562ac78cd1d84805723e3bb24f66c60197d03bab081d7ee8402bf2b59bc7bf0c"
+    },
+    "sound/misc/singledrip3.wav": {
+     "bytes": 44558,
+     "sha256": "55ae1b970143af2553b845503363d94aa917a1cdb8aa1e48edec7869660007c3"
+    },
+    "sound/misc/singledrip4.wav": {
+     "bytes": 45492,
+     "sha256": "db0126239cf71ce69f6c06eb5c5418889b96e52e6741f6b172a146887e6815ef"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/mutant/mutatck1.wav": {
+     "bytes": 6116,
+     "sha256": "410f926534f21705e78a804ce048b0c15e62fe0c68a45aae1b3741fb227551f7"
+    },
+    "sound/mutant/mutatck2.wav": {
+     "bytes": 18260,
+     "sha256": "66009d09adf71f10117c74f5004c995fd48362b2f4fcfaaa3bc2da01e66d115f"
+    },
+    "sound/mutant/mutatck3.wav": {
+     "bytes": 28840,
+     "sha256": "2dd8a615ca2be248c8370d7480f5a8ca9375d31e6af41bba603df660d31883a1"
+    },
+    "sound/mutant/mutdeth1.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/mutant/mutidle1.wav": {
+     "bytes": 81004,
+     "sha256": "8c7e8ad544d7e2470bd61d88c5cd8be1a0eb66f57aaf113f82d990ee00450073"
+    },
+    "sound/mutant/mutpain1.wav": {
+     "bytes": 56716,
+     "sha256": "49ff5f97fedc87c1ac06dc43d4ff0a0fd09fb481354b6373d607bfabc9a57a6a"
+    },
+    "sound/mutant/mutpain2.wav": {
+     "bytes": 58740,
+     "sha256": "b79f1cce60226daa3e3ca8c134da968d54ad51abd9c37ffebdf3d46c5d9f91c6"
+    },
+    "sound/mutant/mutsght1.wav": {
+     "bytes": 107316,
+     "sha256": "7e15e392edc3f2d5ae9e3bde3dfe65595a85728022245f74b81f072d75dce798"
+    },
+    "sound/mutant/mutsrch1.wav": {
+     "bytes": 101244,
+     "sha256": "44484ef4c189511fb0a8d0f2bea83e443e1f1bd51cef04f518f3820e58e88a69"
+    },
+    "sound/mutant/step1.wav": {
+     "bytes": 8140,
+     "sha256": "0d9af35156c84213ac7ffbde54d0f2518fe9d39bba4edc48c94e71bed4f7ec4d"
+    },
+    "sound/mutant/step2.wav": {
+     "bytes": 14212,
+     "sha256": "f7c81df1bff56c8aeb49891fa822c37ddcb019e97a654738a9fb8ee351d19eac"
+    },
+    "sound/mutant/step3.wav": {
+     "bytes": 4092,
+     "sha256": "89856afec31f800219c45253514d0fdf5b5bd800c32f87ba74dd0c21df181550"
+    },
+    "sound/mutant/thud1.wav": {
+     "bytes": 32428,
+     "sha256": "20ed5f20729a068801d06904365e46c9d692dec835710a9b8090d0a1956d6919"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    },
+    "sound/ogre/rogre_alert.wav": {
+     "bytes": 71728,
+     "sha256": "4f3e921b6ee236289660f7ca2ee8a4689e719423266d26a3f8b91ae29d02c6a5"
+    },
+    "sound/ogre/rogre_idle1.wav": {
+     "bytes": 110330,
+     "sha256": "a07df4a53c9e8de310b9d963bfb9c841c51e502565f39dc543bf1c025edd41d6"
+    },
+    "sound/ogre/rogre_idle2.wav": {
+     "bytes": 79416,
+     "sha256": "862258641dc3c90d2a9e5f9e2a4418eb0037eedf22cde798682a169a84f13a44"
+    },
+    "sound/player/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/player/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/player/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/player/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/player/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/player/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/player/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/rail.wav": {
+     "bytes": 97196,
+     "sha256": "396a85e1e2083f2b1eaae89a3f33a21145a643f3f50419523497719ef8e7598a"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/rider/sight.wav": {
+     "bytes": 26356,
+     "sha256": "40ace6f3beeb920ba1bbdb197f8ece18d312762a71e494726289e16703d75d91"
+    },
+    "sound/rider/step.wav": {
+     "bytes": 40524,
+     "sha256": "a43e24ecbc62d44bce466b1e682ebf64c230e03f4d79449406ce021dc8276a9a"
+    },
+    "sound/rider/thump.wav": {
+     "bytes": 15444,
+     "sha256": "af29f4e8f6debb1223aeb5d840add4ae01cb5e9f6bd9a26efeadff518f34380d"
+    },
+    "sound/scientist/allnominal.wav": {
+     "bytes": 23778,
+     "sha256": "e26f9bb3c24d9a9e0da38395048f6dacffe82d800da49d56378027250393d69a"
+    },
+    "sound/scientist/alright.wav": {
+     "bytes": 9666,
+     "sha256": "372c1aa91e6841bec2441215c894b7d149bdeaef33f907d23bb7eaf637520ce3"
+    },
+    "sound/scientist/asexpected.wav": {
+     "bytes": 15982,
+     "sha256": "306933848b673bd14d7074d59e45a8c97bc00a2897601509e52e5835e2ffc997"
+    },
+    "sound/scientist/c1a0_sci_crit2a.wav": {
+     "bytes": 28364,
+     "sha256": "f972684c74eeb51872873cc2b7053448c6cdd716b8c3535929fdbcc508d62ef5"
+    },
+    "sound/scientist/c1a0_sci_stall.wav": {
+     "bytes": 13704,
+     "sha256": "541c192ad5e8a68c76706ec17b3deceafbdc607bfc372ddfd300532f8aa1eaef"
+    },
+    "sound/scientist/cantbeserious.wav": {
+     "bytes": 13236,
+     "sha256": "fc4a8a379f70e33db79a49c667dcd9f1622de29d7b32ef3973c4ffdb5d80ee44"
+    },
+    "sound/scientist/cough.wav": {
+     "bytes": 14878,
+     "sha256": "b4e620259623347a5be3f7eaf3c531e6ea9ef2e97ac42997dd78cfee9327f7bf"
+    },
+    "sound/scientist/sci_die1.wav": {
+     "bytes": 15558,
+     "sha256": "c2306d7f9fa58f99961c347b06ef26305b99ac43ec27b2b222962e1f3a9ccce9"
+    },
+    "sound/scientist/sci_die2.wav": {
+     "bytes": 5402,
+     "sha256": "14deecb570d1e315b772713d54b7250043bb0dd5f3d5538cd0636e39a523c54f"
+    },
+    "sound/scientist/sci_die3.wav": {
+     "bytes": 3104,
+     "sha256": "075cdbc5837d91b61ad7599cdb3abf9323872816f8966c83deab9c0a6e04d7d2"
+    },
+    "sound/scientist/sci_die4.wav": {
+     "bytes": 4024,
+     "sha256": "e6ca0d4f18ac6c1246926646568618057cb70b5cee995c1c2dd69f0179b892ad"
+    },
+    "sound/scientist/sci_dragoff.wav": {
+     "bytes": 8986,
+     "sha256": "0c6a21cd5edf01e495e1258e9a76c05d62c0e3cd697e787fd43fd4bd9126483b"
+    },
+    "sound/scientist/sci_fear13.wav": {
+     "bytes": 4534,
+     "sha256": "dabce7a6c12980f947f7504da264fabb67a804d2e478b7f252ab527fb21a92d0"
+    },
+    "sound/scientist/sci_fear15.wav": {
+     "bytes": 4764,
+     "sha256": "f0d23c680ad138c3cc12da78a3e45cbf3daa47e5da9bc62a1dbb3b27389565a5"
+    },
+    "sound/scientist/sci_fear6.wav": {
+     "bytes": 5588,
+     "sha256": "ff2702b2b9e517b90ea0c2853775a4a95160edfae5af0a7f9208f07624d84281"
+    },
+    "sound/scientist/sci_fear7.wav": {
+     "bytes": 8458,
+     "sha256": "f2a39185c2d39a03b39afd7fe6f942b2f35fd17135ade8ceb4c31968c768aafa"
+    },
+    "sound/scientist/sci_fear8.wav": {
+     "bytes": 5804,
+     "sha256": "4455a29590d5f42ebbf06e600d8ba3f45acfd5000a6b8045891cbecf1d937970"
+    },
+    "sound/scientist/scream01.wav": {
+     "bytes": 14666,
+     "sha256": "b738de99aefbe3a45724914dd6eb79c0f8c219aaf733554a8a5eb94836c22320"
+    },
+    "sound/scientist/scream06.wav": {
+     "bytes": 13938,
+     "sha256": "dee8ac2058635d00458e2e74402d1cfcb5362c64259fc2c4f3b6bba31bdf6337"
+    },
+    "sound/scientist/scream08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/scientist/scream09.wav": {
+     "bytes": 6130,
+     "sha256": "85947649f5fb1491732365849a3025bf5c76c791b395cfdf421fbbd6ec58d351"
+    },
+    "sound/scientist/scream10.wav": {
+     "bytes": 5392,
+     "sha256": "fff4c0735f9c312be7cda848fc2867590437ffe9758fe685e3b4c94678ca1f48"
+    },
+    "sound/scientist/scream14.wav": {
+     "bytes": 4824,
+     "sha256": "dcb7dfb0e307b813476b2e55dceb59d8ae2b9514b1ef02034ea255fa5f086b05"
+    },
+    "sound/scientist/scream15.wav": {
+     "bytes": 3048,
+     "sha256": "37d26fe2d2b8a39d0fec0eceec0ca974ec3dd7fed33bae0d3230a934954105f0"
+    },
+    "sound/scientist/scream16.wav": {
+     "bytes": 2328,
+     "sha256": "4ff04ce8ff07af708c84dacc8df114b68620d47e8e4e4c78dfc4fd33a8a9b98d"
+    },
+    "sound/scientist/scream17.wav": {
+     "bytes": 3836,
+     "sha256": "82fb51224e06db5022adfa58f0b02353c333229ed3312f86dd9ec4f04813c37c"
+    },
+    "sound/scientist/scream18.wav": {
+     "bytes": 3066,
+     "sha256": "bfefcf745ab8d30db11f9113ecf9ba1c5bc6d9b2351c53f3f46d66e03cbea3fe"
+    },
+    "sound/scientist/scream19.wav": {
+     "bytes": 2504,
+     "sha256": "47cc414d201aadb7ba2fe0ce0567ff5360e90fd9de4a167520988513f358ed41"
+    },
+    "sound/scientist/scream20.wav": {
+     "bytes": 21310,
+     "sha256": "124cb45d3d5533572e3cfe4b42bddad2a03dc0d8de1c89a42ea57433432e3a6e"
+    },
+    "sound/scientist/scream22.wav": {
+     "bytes": 15206,
+     "sha256": "6e0a509eb2468466591622e74724c31103b8b60f5d8f29514fb57e9d9d12c9d4"
+    },
+    "sound/scientist/scream23.wav": {
+     "bytes": 21988,
+     "sha256": "8521907e8cecc22e6924d23295a5e8d31333d265ca27a9533b083b68e9da6d12"
+    },
+    "sound/scientist/scream24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/scientist/scream25.wav": {
+     "bytes": 8122,
+     "sha256": "38281749deffb4e567896f71e7bcb75d7b2e253e404a953a5eea6eeb989f156a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/spiderbot/sactiv.wav": {
+     "bytes": 17066,
+     "sha256": "f21587ba9bfd159e48c5b3aa1c6e94eac7157053e4e5699459233fb28c2631c8"
+    },
+    "sound/spiderbot/scharge.wav": {
+     "bytes": 7300,
+     "sha256": "b58064dac4e12bd6685edbfe61417a530cde1e5175336193b2fa7a292aca8ef7"
+    },
+    "sound/spiderbot/swalk.wav": {
+     "bytes": 12636,
+     "sha256": "5534fe1b11fea5406aada214681dba031ec4a01e4b660c405b679131ba07a7cc"
+    },
+    "sound/tormentor/angry1.wav": {
+     "bytes": 88890,
+     "sha256": "60f757f523a9cbb3a57c335bbeda8cedbf990b9d20a5b359e610b712a1344b4b"
+    },
+    "sound/tormentor/angry2.wav": {
+     "bytes": 90912,
+     "sha256": "2f38dddb69cf0df2c1e5b028ca06ea22d979e637afa927919e9a93876dc955d6"
+    },
+    "sound/tormentor/death.wav": {
+     "bytes": 176628,
+     "sha256": "7060ecdadac0b1c9eb3574284444932573e4af13082f01374ed8a4633387bb66"
+    },
+    "sound/tormentor/fire2.wav": {
+     "bytes": 52092,
+     "sha256": "4133a00c7ef157d291d800524a148c188a314eb5ca14246958b8ddfeb0d4fe41"
+    },
+    "sound/tormentor/idle1.wav": {
+     "bytes": 115740,
+     "sha256": "78feebc847dccab66478718b66971870f11246c416e2f2c1e9830c459e4c0347"
+    },
+    "sound/tormentor/idle2.wav": {
+     "bytes": 122218,
+     "sha256": "0270712fe40851bb21d959932b4f8f75bbe8b985e2ff383319059c656ac0ce56"
+    },
+    "sound/tormentor/pain1.wav": {
+     "bytes": 67334,
+     "sha256": "03f255d6ee0d6fb83f2a643491f4cd24d9c5ff86444a51b3cf8b5a0de3d86bbc"
+    },
+    "sound/tormentor/punch_hit.wav": {
+     "bytes": 76614,
+     "sha256": "e524d16b000237615bae3b8fed7b74726823cd4258561196f4641728047aaa26"
+    },
+    "sound/tormentor/punch_swoosh.wav": {
+     "bytes": 33044,
+     "sha256": "d0ef38ef4bf33d0c2f92b22c2a767c4efd66eefaa724df50b394958a7be5a705"
+    },
+    "sound/tormentor/sight.wav": {
+     "bytes": 94334,
+     "sha256": "34a13e6469c5e0ce2f6d18721b0cdd634731b9a9f8910a8bb8b685f63dadfaac"
+    },
+    "sound/tormentor/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/tormentor/sting2.wav": {
+     "bytes": 21674,
+     "sha256": "dd2d40459c7aa9d374efe2f219c34773f390df9f5177a83dbfa5fd638a13c542"
+    },
+    "sound/turret/alarm.wav": {
+     "bytes": 22126,
+     "sha256": "20a8a83d73a55dcc3d8a6fcb79b4ff8ecba0b5887cf3bdcdc96303f069b062ce"
+    },
+    "sound/turret/beep.wav": {
+     "bytes": 22126,
+     "sha256": "89f0e2ba68562cfc3e20272f995777c174c2681cfcf29d2ef337974009b42460"
+    },
+    "sound/turret/deploy.wav": {
+     "bytes": 105260,
+     "sha256": "5bb8c1fa8ffdf22e58ac5fb7a337916a457b9d021661742fcdbbdd7ce188c6dd"
+    },
+    "sound/turret/deploy2.wav": {
+     "bytes": 54208,
+     "sha256": "ec26b9451b67dae2929488687b7b9344a96f7538ab5c4f69e8a85602804dffc2"
+    },
+    "sound/turret/disable.wav": {
+     "bytes": 57180,
+     "sha256": "d8767dcce34c1c7f660f5868c23938da4cc379cb4001b88a10ec1aebbf9e557c"
+    },
+    "sound/turret/idle.wav": {
+     "bytes": 35784,
+     "sha256": "fba6bc2ff517ef95a999e3910c74e3594e054ede298c7b3a5659a2c31565d37c"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 43820,
+     "sha256": "32082cd1d44903409e97de782e5d9295272840e13280665a0ef3ff862b187f0f"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 47570,
+     "sha256": "0dd8defb8ecfb1ea72e6ac70ab182573775812e2d7990dd2897d02d3c38464f5"
+    },
+    "sound/weapons/spindn_click.wav": {
+     "bytes": 9986,
+     "sha256": "b84866cddb7e61eea9ca49208d427c2289d63e6e3e2f59d4d51e302573079bc7"
+    },
+    "sound/zombie2/attack1.wav": {
+     "bytes": 22914,
+     "sha256": "da5345280208ea48855526989299927268566cef77ee187035bbe969076d6605"
+    },
+    "sound/zombie2/attack2.wav": {
+     "bytes": 24072,
+     "sha256": "59245700b47794e239563cc94e3ff045fcd7dad795bcfe343d8574ec3ac525b6"
+    },
+    "sound/zombie2/attack3.wav": {
+     "bytes": 15400,
+     "sha256": "0113aad711264c05a9e43bf8dba915bc89661444d7d802efabe8d61ebb3ba13f"
+    },
+    "sound/zombie2/attack4.wav": {
+     "bytes": 20922,
+     "sha256": "0aac55ae62b62cefece56103cd7079beeb433c3764f590641876e149c4328ecc"
+    },
+    "sound/zombie2/attack5.wav": {
+     "bytes": 26086,
+     "sha256": "b58c97928b535e79973e0390512b09d3d0adea79b1b1b5a8de59bc2cde40c412"
+    },
+    "sound/zombie2/attack6.wav": {
+     "bytes": 22272,
+     "sha256": "58c429256e2f5abb9d97c99ceedb78088d8ac977eca94e994b6d1eee8bb3eb8f"
+    },
+    "sound/zombie2/attack7.wav": {
+     "bytes": 34384,
+     "sha256": "d68e81783b6583738227eac608ab7af1a4b1e1b085c1e46bd9c0d029eab4fdde"
+    },
+    "sound/zombie2/death1.wav": {
+     "bytes": 46548,
+     "sha256": "a1b9e2bcebf9c56fb56405d1ec7fe4166ac10d2b6e1acc6f01e58aec9fd63e87"
+    },
+    "sound/zombie2/death2.wav": {
+     "bytes": 47048,
+     "sha256": "5964a3c1a665c70de8302052b2b6d72ea46b0a5e07ba22cc9919e1a0ffefcca3"
+    },
+    "sound/zombie2/death3.wav": {
+     "bytes": 52636,
+     "sha256": "5c76f8bc55ecea263df880e6b683b07066b37c9f62ff589b0e999534d3c256b0"
+    },
+    "sound/zombie2/footstep1.wav": {
+     "bytes": 12966,
+     "sha256": "2a85309bea05b7c7c90a82df071822828e413cce17646a9686fa4f1264d75e48"
+    },
+    "sound/zombie2/footstep2.wav": {
+     "bytes": 16880,
+     "sha256": "d1d9e9c3811b39b67c9a6966851873ff7edf8d1407c5d9b90782b233196a4872"
+    },
+    "sound/zombie2/footstep3.wav": {
+     "bytes": 20904,
+     "sha256": "b12e9ea9b9478428b886fcaab504856393a57abd8cfdfc5ba5357ad745ee3455"
+    },
+    "sound/zombie2/footstep4.wav": {
+     "bytes": 15796,
+     "sha256": "6f82ac60991e64c8c48a3208a161b46f5b916587cb41863992dc1acb08268889"
+    },
+    "sound/zombie2/footstep5.wav": {
+     "bytes": 17800,
+     "sha256": "ca12f6ade73e5d5ba4ec1bdf680ce25afe3270bb88d702e1493b75619ec088d9"
+    },
+    "sound/zombie2/idle1.wav": {
+     "bytes": 143832,
+     "sha256": "aa203b0beb2db12beb6929fbc3646f7f119d4d31ede66b13af0412d396f7dd6d"
+    },
+    "sound/zombie2/idle2.wav": {
+     "bytes": 277026,
+     "sha256": "9496f3179e875bbb4d7442c252eac0eb2b9ef6d2269d43c141e01242ed2de7ee"
+    },
+    "sound/zombie2/idle3.wav": {
+     "bytes": 234026,
+     "sha256": "4820b03de8cebdee6fe787b5bf60724c17a0e133fdd5451176a202043f730f8e"
+    },
+    "sound/zombie2/idle4.wav": {
+     "bytes": 166352,
+     "sha256": "a515e5dc0e4fe1412a7936df5fab0f57a48c385db4fa357c1a4120671ac99617"
+    },
+    "sound/zombie2/idle5.wav": {
+     "bytes": 62782,
+     "sha256": "c6e4e2f26769400b7ca3b08339af089ba28bc063447d642e10cffffc6e03a485"
+    },
+    "sound/zombie2/idle6.wav": {
+     "bytes": 47274,
+     "sha256": "9ad1ced551cb42764fd88baf26ee09dc72d1852fa2da7405fde370d3e4d69a01"
+    },
+    "sound/zombie2/idle7.wav": {
+     "bytes": 45614,
+     "sha256": "41783a7682d5f8bb91aff8308b8657504cc8f0460b5ca436a5d0fb1c93357c85"
+    },
+    "sound/zombie2/idle8.wav": {
+     "bytes": 73070,
+     "sha256": "8f390d861feda3fb3950b0f33ce3efbfa8eda214533324674ac40b6e227b6975"
+    },
+    "sound/zombie2/punch1.wav": {
+     "bytes": 9218,
+     "sha256": "db6787efe0a0b8df5da690b91afe46a2199911b661fc9de1cfffc00b6bb8c46c"
+    },
+    "sound/zombie2/punch2.wav": {
+     "bytes": 8032,
+     "sha256": "747aabd6237176ae1bc62669cb08c7ec65fb26aa2147f6a3e1ab43f02ace7322"
+    },
+    "sound/zombie2/punch3.wav": {
+     "bytes": 13076,
+     "sha256": "05bb75533252d15983a944263789de5ee51187e518f4544fd1915b57ba726c7e"
+    },
+    "sound/zombie2/punch4.wav": {
+     "bytes": 13198,
+     "sha256": "d07556e7fc774958a6105564a990c51a0dab64fcf9508475617921a0ac5b961c"
+    },
+    "sound/zombie2/sight1.wav": {
+     "bytes": 73234,
+     "sha256": "387534044f10592ca6bc7a96b8e782c7b51de87b907e79a8f410d535e17d37ee"
+    },
+    "sound/zombie2/sight2.wav": {
+     "bytes": 52224,
+     "sha256": "cbc95608d4553d0bae66411d69875210e6fc6d728bd30deb6bbce7aabbacb773"
+    },
+    "sound/zombie2/sight3.wav": {
+     "bytes": 63072,
+     "sha256": "cbbcdb6da59d830a3be66095053259b17a90cc6501728ed1aa50d9524818f99b"
+    }
+   },
    "sha256": "955b55aa56dde477637305ef146bc84e48f2e09a474c7bacec61d1a7dd3a13ad",
    "timestamp": "2023-08-22T22:52:42.000Z"
   },

--- a/json/by-sha256/c3/c38af7e50ee791b94accbfe97285499571b6b212ad09142fff44ea9c9c18349e.json
+++ b/json/by-sha256/c3/c38af7e50ee791b94accbfe97285499571b6b212ad09142fff44ea9c9c18349e.json
@@ -13,6 +13,136 @@
   },
   "pak0.pak": {
    "bytes": 9295949,
+   "files": {
+    "gfx.wad": {
+     "bytes": 126244,
+     "sha256": "ba1811634fe30a143a00e38f7c7cf737121d625349d3e5540eae75d92d314a42"
+    },
+    "maps/masque.bsp": {
+     "bytes": 6188816,
+     "sha256": "813e0b81a4d865ed5ef285d7371defe3faba0ca851a0290c582c5dda4420444d"
+    },
+    "maps/masquestart.bsp": {
+     "bytes": 1598512,
+     "sha256": "5184782e6c89f2478fc45c5e8b9f44211791addc82f50f751eeeab84b440c0fc"
+    },
+    "progs.dat": {
+     "bytes": 651032,
+     "sha256": "0e496de8c5431d215bd81a6c1c966b9d3441c15679209bc5a7c9c2bf3f9641a6"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/laugh.wav": {
+     "bytes": 71573,
+     "sha256": "cb8e1381c70240a93233b8571d792e21950d00b1285f867cbc0ed1237dac1df7"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    }
+   },
    "sha256": "a323338233e48911b9b10e8a48454b9782a9346573d9f9601406bd0c7cd58b02",
    "timestamp": "2006-10-13T00:36:40.000Z"
   }

--- a/json/by-sha256/c5/c53a92180f58d643cc4cdb06d81f2006575e92891fde19a3bfcf8f1f6d570777.json
+++ b/json/by-sha256/c5/c53a92180f58d643cc4cdb06d81f2006575e92891fde19a3bfcf8f1f6d570777.json
@@ -17,6 +17,148 @@
   },
   "PAK0.PAK": {
    "bytes": 15831694,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "c6c173872de3c5f6d61f925eb5326de0fe71a9826cd159260186294ed2c0ba0f"
+    },
+    "maps/castle.bsp": {
+     "bytes": 1263580,
+     "sha256": "2a5a0aa5cdb3b2da205cb171e3a798c2019c3f52abb8a85c3e7a3c9d2809e6f5"
+    },
+    "maps/cemetary.bsp": {
+     "bytes": 809252,
+     "sha256": "5cb75358d2a376039d834e6fb9cc70eb3fe2a6d08aa6b8184c66347a0ddaca8e"
+    },
+    "maps/church.bsp": {
+     "bytes": 1329708,
+     "sha256": "a25bd66d6c0c1b97bfc6cae1bc5034f79ff657c699fd6fcc340bd3faa78e457e"
+    },
+    "maps/dunend.bsp": {
+     "bytes": 345236,
+     "sha256": "83bccbf2255230850883f44755684c9d9923ec307b750519ef490b59eca98d8e"
+    },
+    "maps/dungeon.bsp": {
+     "bytes": 1710900,
+     "sha256": "27e3ef6b6695a0f8948db7cc3158d7063d88aa30878277995a32952d204d8a10"
+    },
+    "maps/farm.bsp": {
+     "bytes": 1330220,
+     "sha256": "ead42df6f5977611ad0f83ee05be50b9d364714d071314722037e01f87526b71"
+    },
+    "maps/final.bsp": {
+     "bytes": 616356,
+     "sha256": "0e4b8822c4d0d2274f73f7012d3bd19f5b549d6bae45e6fddb0d5a5fb0195def"
+    },
+    "maps/forest.bsp": {
+     "bytes": 1139592,
+     "sha256": "3bc1c23cb7328a6f7847cc4a77138d6157c3b5eb854e4e924886cca6a9966ea0"
+    },
+    "maps/home.bsp": {
+     "bytes": 108896,
+     "sha256": "9a6d94afdee4b64b899ae4c85f8737a7f89b42488f0e023107015d895277ca25"
+    },
+    "maps/inchurch.bsp": {
+     "bytes": 1291100,
+     "sha256": "78d032dd885803716bc22aa03e1a6b65d970f9c3a804630d4846e5237baa051b"
+    },
+    "maps/start.bsp": {
+     "bytes": 752352,
+     "sha256": "816e2aa0e73e822c19d842db407058019c59db4fa8e78f4572f1b0e0904c07f7"
+    },
+    "maps/tower.bsp": {
+     "bytes": 1596216,
+     "sha256": "dbca755383e4f60a60b522a0b448c97fc72709c04c1f4c84bb2565a79474a714"
+    },
+    "maps/town.bsp": {
+     "bytes": 1617068,
+     "sha256": "4d09edcd56145e1e2351e51b408d013bcb5337c4cc73c78751b86f6bfa38b45b"
+    },
+    "progs.dat": {
+     "bytes": 496180,
+     "sha256": "5d739dc51bc7de0ffc2dbafea353ede7295c1c5bebd68398497e4ea52443e589"
+    },
+    "progs/bloody.mdl": {
+     "bytes": 138352,
+     "sha256": "ce009656cb0b8eef4e13e9df82488163609184089dff9c84189c45c5b9b01b35"
+    },
+    "progs/dking.mdl": {
+     "bytes": 102120,
+     "sha256": "835f60bb82ef9edefbd07eee4b30860e3f7259936d589f6a42b1b0ac60e37238"
+    },
+    "progs/fragwiz.mdl": {
+     "bytes": 157072,
+     "sha256": "014bef65dcefb39dd434984c607de15698befbe8fa391ddd48e5fdb54ef8a288"
+    },
+    "progs/key.mdl": {
+     "bytes": 212534,
+     "sha256": "ad07d0c0c23740be5b590f4460d4eef26bd68248ab8704127cfb9b728de382d0"
+    },
+    "progs/mushroom.mdl": {
+     "bytes": 30174,
+     "sha256": "27ea60f9d2bd6c31b02ad4309dc5cf6a466b1cc954a6e80d0c3255689cc8ba87"
+    },
+    "progs/pig.mdl": {
+     "bytes": 109099,
+     "sha256": "3c38a13c444f87c5c8e7374e20a406f7b5d06ac17ad546bb916292b05c747451"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 138352,
+     "sha256": "ce009656cb0b8eef4e13e9df82488163609184089dff9c84189c45c5b9b01b35"
+    },
+    "progs/village.mdl": {
+     "bytes": 138352,
+     "sha256": "dd096867512a9ba1cfcdcd80f817e7b4a19ea6e76382bd9d19ab927131f31155"
+    },
+    "sound/demon/dkdie.wav": {
+     "bytes": 12767,
+     "sha256": "83d579d5e73a5aabd29b04b1b44622e92b67cdd9fe873bf262efa710c0930ebc"
+    },
+    "sound/demon/dkidle.wav": {
+     "bytes": 6752,
+     "sha256": "d5e8869c4fc6a231ae3515656a2e0e63d462441363082fb697979525a1a2828e"
+    },
+    "sound/demon/dkidle2.wav": {
+     "bytes": 9460,
+     "sha256": "75d44e65bcf142860d7b80b24efb587e037286c4878c6b539cd557deb3af9d9e"
+    },
+    "sound/demon/dkjump1.wav": {
+     "bytes": 12935,
+     "sha256": "ff399342c712c967c31226aeb6a9021f9d3addd736fc6733fda65eb30a17af63"
+    },
+    "sound/demon/dkjump2.wav": {
+     "bytes": 12712,
+     "sha256": "8d65e765f1d2d2dfe425ecec082adfca7844ee2fc8d863fc8f6491b4cb87f3f7"
+    },
+    "sound/demon/dkpain.wav": {
+     "bytes": 8136,
+     "sha256": "4acac0ccddd3bdfdc080401d86caabe26256b60e07a35b17a2bbf926b75dc53d"
+    },
+    "sound/demon/dksight.wav": {
+     "bytes": 12651,
+     "sha256": "7b8e28f11268731c0bfe0ffa0999b3ee17fa687f5d32922aeddba768ad9bfbbb"
+    },
+    "sound/wiz/wizblast.wav": {
+     "bytes": 13287,
+     "sha256": "9e76101b57a46fd6d0fad96eb2e684b05e6a4af4cd9c5c6d8d05fd74882f13cf"
+    },
+    "sound/wiz/wizidle.wav": {
+     "bytes": 94500,
+     "sha256": "100baabb5c66a28c337933c0a4f34394338af2f07245663958a8cd0ca718c38f"
+    },
+    "sound/wiz/wizidle2.wav": {
+     "bytes": 20764,
+     "sha256": "5ec434f508da4f58dad527fcbb9fa6e95d67a845bf628c1ae6bf2e946a67563b"
+    },
+    "sound/wiz/wizidle3.wav": {
+     "bytes": 124274,
+     "sha256": "48898bc03fffed60675fbcabf678988ed25144749d0b73bec852562490d56146"
+    },
+    "sound/wiz/wizlllll.wav": {
+     "bytes": 4485,
+     "sha256": "9559d45c5d339b2d4d528cda638fc0a3ed0b36d7053f8c6b8f9af3e07b3cc1a0"
+    }
+   },
    "sha256": "a184913f151c9ae9115fe3d33da3506159764c505259dd8d25e74e3d32cd95a2",
    "timestamp": "1997-09-14T23:38:10.000Z"
   },

--- a/json/by-sha256/c7/c78c2116529263b1dbdc06a78d05867bfc9f9cbd1357da331f82a23b0bec1068.json
+++ b/json/by-sha256/c7/c78c2116529263b1dbdc06a78d05867bfc9f9cbd1357da331f82a23b0bec1068.json
@@ -22,6 +22,500 @@
  "files": {
   "sm223/pak0.pak": {
    "bytes": 74591634,
+   "files": {
+    "gfx.wad": {
+     "bytes": 121132,
+     "sha256": "fdcc42f0dad313b297845f4a4daa79dffb541dc7fdfd13c6e8610df9fd614f72"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "914ec79ac9c3a2fbf15081911f3f27f1f91facb9142274f283b8072f67ec79e4"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "898d694265db0f933feecfd2a843557a6954a5f2aea05ecf9a852314119dab61"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "03e0973ee5d434c037699f9568228ab80be0df882ca77c88a9835b2d2edf0649"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "maps/sm223_66ppt99.bsp": {
+     "bytes": 983400,
+     "sha256": "754b52a686f756ac105406f35b517b4957da056d32469c22755ef0427fd606f4"
+    },
+    "maps/sm223_bizz.bsp": {
+     "bytes": 3092164,
+     "sha256": "8e0cbaae3ca81e44141eb6bf6989e509cf6572a73d73e4c8718b92cccd9eb327"
+    },
+    "maps/sm223_fw.bsp": {
+     "bytes": 8504192,
+     "sha256": "7dd5d47218e16b375908e0e5bf653fd7a1905fc18e47044f4f04f56478ff50d3"
+    },
+    "maps/sm223_fw.lit": {
+     "bytes": 4754864,
+     "sha256": "c784a0d3383d98a49829396c320fb2bd3fb5c334fd63d2036452c261591eccd0"
+    },
+    "maps/sm223_grash.bsp": {
+     "bytes": 452024,
+     "sha256": "60785394658fa035378efd40c47b3e231435e7d515dbc56cbb8ec084d1e84311"
+    },
+    "maps/sm223_grash.lit": {
+     "bytes": 184199,
+     "sha256": "4360394b38d7aee411d1ecc0d02d4f2fde2c818f67b6f2f6ac3e39e90c89000d"
+    },
+    "maps/sm223_gw.bsp": {
+     "bytes": 3699284,
+     "sha256": "fa4db714550f80cfc135e03620ad86ec8e45f3b6ba300c71f157c7dc5a226303"
+    },
+    "maps/sm223_gw.lit": {
+     "bytes": 1492424,
+     "sha256": "a1e300370ae1114003f01ec4b847f0ab81977aef6356f728d38a2007bf6a4396"
+    },
+    "maps/sm223_hcm.bsp": {
+     "bytes": 2827752,
+     "sha256": "6527bc14c4c7b233a410059db1f8b8ca4309055579d53899e0e6261b919116e8"
+    },
+    "maps/sm223_hcm.lit": {
+     "bytes": 2064701,
+     "sha256": "e73bbad482c3e42f81aa8666e768b78336dee1b2e659d1f7c80eacf62f86742e"
+    },
+    "maps/sm223_holden.bsp": {
+     "bytes": 335156,
+     "sha256": "6d23ad4afebfa8ebe75f1c58c41dbaa8e581bf38f159d663b56b5b672becc60b"
+    },
+    "maps/sm223_holden.lit": {
+     "bytes": 125780,
+     "sha256": "3dac073c7b53b23419bc53657cb3663bb5515ea6e26c2ca5903db469dd70c19a"
+    },
+    "maps/sm223_ish.bsp": {
+     "bytes": 1574684,
+     "sha256": "5b90cc3938472a3895e196bb111239993016b4a3817fea67690248e9fbef9662"
+    },
+    "maps/sm223_ish.lit": {
+     "bytes": 2867066,
+     "sha256": "7bcae0d567425f6547ce21c524a7575e228977c973cc44b3c1ff6d91785466b8"
+    },
+    "maps/sm223_iyago.bsp": {
+     "bytes": 2962768,
+     "sha256": "9c1a1b479705d7ff982e31b51882262c955dda8d30c48e96fd40434f937567e0"
+    },
+    "maps/sm223_konig.bsp": {
+     "bytes": 2371664,
+     "sha256": "65c9836450b988b3e2ffb244c1dcd3d2e3f0cd853daddd09c6d383e896470cf2"
+    },
+    "maps/sm223_konig.lit": {
+     "bytes": 507188,
+     "sha256": "d95428c2b82754fcf67f15d3a2cc8ddfd62adba86e9768a20102652b43d7b8a0"
+    },
+    "maps/sm223_nicco.bsp": {
+     "bytes": 1036748,
+     "sha256": "0bd2ae3bd669d90bec008b57e1c758a7308d20ed27099a81084fbc7e7037cacf"
+    },
+    "maps/sm223_nicco.lit": {
+     "bytes": 440792,
+     "sha256": "7bdb5dd6e6ab88d763ed715d40a68b88a6bc4ce890204be50024c5e43d6a3e63"
+    },
+    "maps/sm223_pinchy.bsp": {
+     "bytes": 3475400,
+     "sha256": "0be102af232b0bbfde393413071dbc28e22c7f6f8737ea556c1a616a90e7acaa"
+    },
+    "maps/sm223_pinchy.lit": {
+     "bytes": 1891394,
+     "sha256": "be0c9bdeacb0a23b74421ac03aee0d47f57482e627eee25adef72a6fd50cf7b0"
+    },
+    "maps/sm223_recoj.bsp": {
+     "bytes": 3207972,
+     "sha256": "f9a6426e82c5f88590d9b9a423ac727449a64c62c2f77831d33c15de86a65dab"
+    },
+    "maps/sm223_recoj.lit": {
+     "bytes": 1916702,
+     "sha256": "2ba96246eaed009f8be6e3c83ca2f23092c1daa1a0bb242c0c21a36855b95062"
+    },
+    "maps/sm223_repator.bsp": {
+     "bytes": 3034936,
+     "sha256": "49e006b8cf4684e663f5657f6e564d653db89d85318d6abf12f942ba2791791c"
+    },
+    "maps/sm223_repator.lit": {
+     "bytes": 900458,
+     "sha256": "2236f49550f88175aaadcbcd72ed343a5cbd121599249d444e180751b3f48b6b"
+    },
+    "maps/sm223_riktoi.bsp": {
+     "bytes": 444228,
+     "sha256": "ea707353ce9596a0bb01baa7f69c1c0a6af93535f4579992889246f953fc4cfe"
+    },
+    "maps/sm223_spoot.bsp": {
+     "bytes": 6520148,
+     "sha256": "3bbbc2c31c78001bc76b4105e900fcbdc172c8d147053ea3795f24f9f4f80aee"
+    },
+    "maps/sm223_spoot.lit": {
+     "bytes": 6326171,
+     "sha256": "bf6489ac81de3650aedb1b973d38636f9ca314d6e152fa73bd842cac569ca476"
+    },
+    "maps/start.bsp": {
+     "bytes": 836684,
+     "sha256": "e6215ab7aa8985e2910cca79ae6fb0493935cca5749ead3880b6279959f40e52"
+    },
+    "maps/start.lit": {
+     "bytes": 419936,
+     "sha256": "6a888f9eb3451f1e72c1890367581113b323fd7086cdeb345e81f192ca96476a"
+    },
+    "progs.dat": {
+     "bytes": 552818,
+     "sha256": "465549a622672cf60c4b8d3b6d12b69bf1cb1b90e4ae0e06af7a89bc8cf1077d"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/dog.mdl": {
+     "bytes": 173720,
+     "sha256": "a9b6aa0d4b2a9b5d6b8de3f8be19fd8162834325f1b59277f709bdf74be9f05c"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 186184,
+     "sha256": "accfb31cb38984ab4f871070181968610c5accd245b425dd2243de75394a58a8"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "quake.rc": {
+     "bytes": 1101,
+     "sha256": "1c446020b2307115167556cebfce76e1488fcfd30f07a87cc29e3a3e5a7ab269"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "a0c07f6ddc894ee2d95a5d1a4fc2a7f3137ca7aa3501b5048642c5bb41912766",
    "timestamp": "2023-03-10T19:51:30.000Z"
   },

--- a/json/by-sha256/c7/c7c83d93826d090fac07e6a5b6229e850e020d482b8f8bc6e91834b514c1fcc0.json
+++ b/json/by-sha256/c7/c7c83d93826d090fac07e6a5b6229e850e020d482b8f8bc6e91834b514c1fcc0.json
@@ -10,6 +10,64 @@
  "files": {
   "pak1.pak": {
    "bytes": 3042807,
+   "files": {
+    "maps/sof2.bsp": {
+     "bytes": 1000320,
+     "sha256": "4a72761487a4d062609c9865f85ed4f1e264ccdb4219aad58629d099f5e43185"
+    },
+    "maps/sof3.bsp": {
+     "bytes": 1425796,
+     "sha256": "a455950704c1f9cb7228590109dfe6bc76186ec5f1a617b03e7d324505cc3a03"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 160688,
+     "sha256": "560ebbb3c8d99419f962cdac1d0afd82ce5a75de25f85287d67d851651ec1f55"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 11828,
+     "sha256": "f70250a42d2d78c15d17378b1700a51a4bb968c9c5197d653af3f7cb3d9550b6"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 14804,
+     "sha256": "a624bfdb2200defca02e2a7995b784ed1313f72feebe55deae2f0d63a3eea570"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 64472,
+     "sha256": "fc3753268943520b44d6f803f3c9258de90d7539f68e15312620cce1654fa312"
+    },
+    "sound/misc/cartmove.wav": {
+     "bytes": 64174,
+     "sha256": "19b761c9bd70caf27c2e9e4817c940ff7bcba4de56ca8e7fb49b6fcb46d239b3"
+    },
+    "sound/misc/cartstop.wav": {
+     "bytes": 10394,
+     "sha256": "d0c27d50f89c026621adf54a10cd0fb77c481427f79194a307b50247bfe8591a"
+    },
+    "sound/misc/dale.wav": {
+     "bytes": 103196,
+     "sha256": "dc5e50ad846f2ddac6300951e86af38df3c9560f533a278d1788c72fa55e88f6"
+    },
+    "sound/misc/escape.wav": {
+     "bytes": 48049,
+     "sha256": "deebae0479841de28f1728ab4f34efd55ee33494dadf745dcad27964aad32baa"
+    },
+    "sound/misc/forklift.wav": {
+     "bytes": 55627,
+     "sha256": "56b7b2b1a490c04af596a0067e603349c1040c2a2ce5ce7b0b0754b3c4dc2548"
+    },
+    "sound/misc/glass.wav": {
+     "bytes": 31602,
+     "sha256": "31ed1a84b918350a680fd71bb6c4e8948afe690593cc0b29c9e2f70bac631935"
+    },
+    "sound/misc/ignition.wav": {
+     "bytes": 32099,
+     "sha256": "cd593b896482ed4ab267ed4b10566c6e605ed42022fd4c284422bc7d9d571ab0"
+    },
+    "sound/misc/wbreak.wav": {
+     "bytes": 18850,
+     "sha256": "9ef0444bb4e4ea6126f955d8010efadea34bbb93b7d6ca464f7ec5816c4e7bbb"
+    }
+   },
    "sha256": "b275f1c8d6f3001e3a5d0fb961c0ada76044f26015e1521774d21a53cbd0170f",
    "timestamp": "1997-11-10T21:43:32.000Z"
   },

--- a/json/by-sha256/c7/c7d37c19b532a211eb973565133e6fcdcb41ee283119cd7e8100340dc175a7cc.json
+++ b/json/by-sha256/c7/c7d37c19b532a211eb973565133e6fcdcb41ee283119cd7e8100340dc175a7cc.json
@@ -17,6 +17,120 @@
   },
   "guncotton/pak0.pak": {
    "bytes": 6876462,
+   "files": {
+    "maps/gun.bsp": {
+     "bytes": 1357660,
+     "sha256": "d457c2271eb11acce97d16d5fbd8423d797f4259f3a3ce89172112e249f541b5"
+    },
+    "maps/gun2.bsp": {
+     "bytes": 2001836,
+     "sha256": "6bd0c6b6ffaee87be74fff62077550fc166bf7247b188178730d7412e8226791"
+    },
+    "maps/start.bsp": {
+     "bytes": 417512,
+     "sha256": "17bb6010cb39b9ea63377d9056f599d5349f8b09230760fac8577947d8953fd4"
+    },
+    "progs.dat": {
+     "bytes": 755048,
+     "sha256": "b6f7947ac0f7dbd9888ad5d10f6d21785f5fd6e9e835dcce7a8517811f20eaff"
+    },
+    "progs/armor.mdl": {
+     "bytes": 44076,
+     "sha256": "0e16c3f0ba370dbb172af676540ce2f4a58b151d8a6dd10c1c353748257c82d3"
+    },
+    "progs/beam.mdl": {
+     "bytes": 10608,
+     "sha256": "2165a66ba1d40fa378df735835b014791e769cb8bc56e06977aefdf134bb61d5"
+    },
+    "progs/beamhit.spr": {
+     "bytes": 5320,
+     "sha256": "bdfe3464c0bea904c3d35135b6d242f486298447ea45c3f96cce7ac6b71a3e54"
+    },
+    "progs/dring.spr": {
+     "bytes": 387832,
+     "sha256": "94adc8ada163983eae9ccb924bd4ef4d8ebb2613bd23705d2e8a7bb73e7657d1"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 218412,
+     "sha256": "8c376eb7c9ff2ef3698105178b57d2d157cbb6790312d560864ae1a00766b05d"
+    },
+    "progs/expl.spr": {
+     "bytes": 127672,
+     "sha256": "553b80901ee3d765c147ecce187a53989ded3991532e02f53c5b0cbb42aad5d4"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 18400,
+     "sha256": "d050647124b27e773ba04aff2ec1e2ff3865099124b7f113d414b4189ecee776"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 22168,
+     "sha256": "d3440a84d4f62b19a9b7635ba50fafd047fb5c8360898531e80628dafc3010a1"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 218888,
+     "sha256": "15008aeb2f80eee0ba4bf113d230f5b115fa2157724d9727b5f3988cf9430983"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 320900,
+     "sha256": "03564bf6702e4a228fab341f9ac649a294b61bfc86a377c4c85e7bd7e94260f1"
+    },
+    "progs/v_beam.mdl": {
+     "bytes": 75588,
+     "sha256": "c00fe7872cb2c88626e63d99c3cc00b83f9968803344cd2021e8fc26bd25ccba"
+    },
+    "progs/v_beam2.mdl": {
+     "bytes": 75588,
+     "sha256": "95b3a260450ca784bda0885da994a5a857cf9948581ed1e68c4b202c51dae670"
+    },
+    "sound/alkamb/demonwind01.wav": {
+     "bytes": 89228,
+     "sha256": "1a44a8cf17be9fe6e8aaecfc9c65ec0ef761eb27ea6df77e016cebf01cf62216"
+    },
+    "sound/alkamb/drips.wav": {
+     "bytes": 80712,
+     "sha256": "96f7890d2fea2f1f6443d0e75bb6084f39931e7c5399a6e75787dec4eaba5033"
+    },
+    "sound/alkamb/fan4.wav": {
+     "bytes": 71762,
+     "sha256": "b64616ef550e919c0a4a4d16a6841fc05fa2db07914130e7ec16f83313201bb4"
+    },
+    "sound/alkamb/moans2.wav": {
+     "bytes": 275802,
+     "sha256": "279a5b7190aa28d598930d7cfef6f5fd611dac51fb5297058b7714e1f6fdd0e9"
+    },
+    "sound/alkamb/moans3.wav": {
+     "bytes": 162450,
+     "sha256": "6b46ddb6560b63b16a7493abeea49c7bff4afe430830a7115959e8db89a91bdb"
+    },
+    "sound/alkamb/suck1.wav": {
+     "bytes": 51436,
+     "sha256": "3d99d5630e91c603fef397453136634562f7877f42379ae744ffe57570d3eb42"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/steps/lowecho.wav": {
+     "bytes": 10598,
+     "sha256": "fdbfe2cbca53ab8e8bd173e1bc96e1c98d0cdff361b56771453be56adc11d7d4"
+    },
+    "sound/turret/beamchrg.wav": {
+     "bytes": 3962,
+     "sha256": "d02bd7d2c4754fe3159fac83b4f0898f8b2e1f8996ce7e6cfdaa4a9d75a24fb1"
+    },
+    "sound/turret/beamhit.wav": {
+     "bytes": 8644,
+     "sha256": "35e5e5f28a3695ed27c2b0887a1bf118643d769c457d3642016e887248fa8ca9"
+    }
+   },
    "sha256": "8085ee848661a8440a908318f23bb29b34cccab9c7f8a3b599b7566a0d245c49",
    "timestamp": "2002-07-17T17:43:30.000Z"
   }

--- a/json/by-sha256/c8/c849d7d59b951d80d745ba25caf923e22144a9f65b73a9055ccd300efaa01e10.json
+++ b/json/by-sha256/c8/c849d7d59b951d80d745ba25caf923e22144a9f65b73a9055ccd300efaa01e10.json
@@ -1365,6 +1365,356 @@
   },
   "qbj_1.05/qbj/pak0.pak": {
    "bytes": 4573196,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 409928,
+     "sha256": "71ad832c75c329ef3ea08f053e37651259f0f6eaaf4dd210fb2825832fd969a3"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "591744734a43a1563ee0e419fb2464783c70a3245c14e09ff5c3f022418f1e4c"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "1bbe11eff4ef46f43af7bbc7be43c69cf76543ce7fae26931939a541cb8cdae6"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "fc226280c4948249790f00f97dd9b39e912131fc904ec75adb90308ba8763afc"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "57652410a57165593b98386d4d8490acf723e10a4ce60e9e6ca6e687628ba31e",
    "timestamp": "2022-09-23T06:21:48.000Z"
   },

--- a/json/by-sha256/c9/c9f685423e0281d70e59cff4cc4cc479be00fe3cd6b4c8256afe5a500ed73ff7.json
+++ b/json/by-sha256/c9/c9f685423e0281d70e59cff4cc4cc479be00fe3cd6b4c8256afe5a500ed73ff7.json
@@ -17,11 +17,275 @@
   },
   "pak0.pak": {
    "bytes": 5379354,
+   "files": {
+    "demo1.dem": {
+     "bytes": 663667,
+     "sha256": "fbb77c5f9384632b5b866899b1ab2db60a9f663de05bd581375c9535fab261ff"
+    },
+    "demo2.dem": {
+     "bytes": 1182703,
+     "sha256": "f020d8ada671febf894c33d05c86dac4c02a18dbc502810d1116270cbd04f78a"
+    },
+    "demo3.dem": {
+     "bytes": 1033913,
+     "sha256": "14e2d3f108c809f3c2ea2e46a9fb63f84ed52628e6aa3c610e30f6423c4810e7"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "e63efa8fabf395f090a735b805d4113b0af34a46cc86425a37852a0c577bfddb"
+    },
+    "intro.dem": {
+     "bytes": 226574,
+     "sha256": "94d90f324953f063ed05233dfc11a2b4f97c5568aafb87b3db850e4bf0da83b7"
+    },
+    "maps/des_itr1.bsp": {
+     "bytes": 139248,
+     "sha256": "6845c9e40f72531f2b82ab4d057800b58bfe54c48f81467245e0d024dc178cd1"
+    },
+    "progs.dat": {
+     "bytes": 469104,
+     "sha256": "301e8ba96b37f1b11758daa8c8c200829997dce79f0caa304d9afa4c2c344c79"
+    },
+    "progs/bk_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "ac6ed176b4e01ac28d23781464e4fb7da01798ddceee2771eea0e01844870777"
+    },
+    "progs/bknight.mdl": {
+     "bytes": 228400,
+     "sha256": "7f777eca9e8bb9406efc7cc989c0cb2fd73c95b6d9aa744d64b702d80144c255"
+    },
+    "progs/deflect.mdl": {
+     "bytes": 23920,
+     "sha256": "a6de381a156a928b1be710dfd24e44bc027948e14772581f945ec1a622d77bfb"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 50276,
+     "sha256": "4fef4688a1e52aeedb945660041bf48c04e9098b8ebd20662f7bffe1fe78fffb"
+    },
+    "progs/g_nail3.mdl": {
+     "bytes": 30720,
+     "sha256": "411d33d898d273f0ddfe5ee6cebd49dd8202de0fea708fcf1f8921b9518ccc9a"
+    },
+    "progs/h_bknght.mdl": {
+     "bytes": 16628,
+     "sha256": "7a169ef493f0105c02d9bb77517336176d6731d65de5a4594bd467be44193cf1"
+    },
+    "progs/h_qshal.mdl": {
+     "bytes": 28036,
+     "sha256": "69529a98ed891a24719196d811d411c797e30cd0eee4c1264a4fa0abaa7465c2"
+    },
+    "progs/h_swiz.mdl": {
+     "bytes": 14804,
+     "sha256": "15100d74a6b34c01eff59e1ce04823bf691f61c6ef9b49c72047df1e86c1a1e6"
+    },
+    "progs/lb_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "37eadfbfab86161f2779a1d65c22baf410e977a125ef81c723d7dac699ceb788"
+    },
+    "progs/qshal.mdl": {
+     "bytes": 80648,
+     "sha256": "f2c6f487b13b3c58118d6aa41da0fb4b201898eec9acf670f54fd982d1e65f8d"
+    },
+    "progs/s_gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "a37ab22450955de03cd4dc3f46fff77979e45f62ce7227203b930bdb0ed50491"
+    },
+    "progs/s_gib2.mdl": {
+     "bytes": 16228,
+     "sha256": "545c9efe87dff7d3d79290827304de89f1b3ca5485e48bc216b4c0742c6e1bc0"
+    },
+    "progs/s_gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "cc82e60d52563f15aa58b6b2eecf78e5afb8de1e7206aa9fff1108f7a50b0190"
+    },
+    "progs/s_qshal.mdl": {
+     "bytes": 51408,
+     "sha256": "679475edeae36ec0224ee38958d4248ee99c8d2859aea074d6d05095da80ed70"
+    },
+    "progs/sh_qshal.mdl": {
+     "bytes": 28036,
+     "sha256": "eb96f4b533321b1fb3823ccae53501aad761b7121d1c3368642b750578b1f53e"
+    },
+    "progs/sw_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "db70166cf98d1dd4c11c1d923008b70a5a62233c64df93a2640a0515df185f9b"
+    },
+    "progs/swizard.mdl": {
+     "bytes": 64472,
+     "sha256": "c536d7d8c21c1e77cf1df3ede8d1b9411056557e83f2d6b467da87dcacff1fa3"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 56204,
+     "sha256": "ca64e717869a9675c7fa750114283063c12b62c1da14ac52071f92ebdbb2fac2"
+    },
+    "progs/v_nail3.mdl": {
+     "bytes": 68732,
+     "sha256": "632aca7b2668b43318fc3681de6dfdded3a1c566cb128ab4086217b93ed01fef"
+    },
+    "quake.rc": {
+     "bytes": 371,
+     "sha256": "90acedfee7a9d4627bbcfc0bea6e0580021473929c59599f7274cc54193073ee"
+    },
+    "qwprogs.dat": {
+     "bytes": 208532,
+     "sha256": "5e083ff3c871f286f7ddbbab2bbfcc2296ef96d65f5e06dc4feaa73a72ea9d5b"
+    },
+    "sound/ambience/windfly.wav": {
+     "bytes": 110696,
+     "sha256": "b6deba9c2fd5fdda7268828e21845e12dad56c682eebd0c67df87f002f5fea6e"
+    },
+    "sound/bknight/attack1.wav": {
+     "bytes": 9808,
+     "sha256": "f5f3306d239f16fa9bf2caa355c87be5f9308b35641f9da7ae78735ad31f056f"
+    },
+    "sound/bknight/death1.wav": {
+     "bytes": 41504,
+     "sha256": "f572ead8dc1f4e4c3df8a42bf582f53c2a385139a99778365e6d6981468aec80"
+    },
+    "sound/bknight/grunt.wav": {
+     "bytes": 4876,
+     "sha256": "c842b376ab8e146f1a9f7f342a8f7dc2ee53875d9a0a40e29fca2153c9de35ff"
+    },
+    "sound/bknight/idle.wav": {
+     "bytes": 5056,
+     "sha256": "542c206c55627911b29371b210f5d5daad5ebd202b7aca8718743d705d0f4fda"
+    },
+    "sound/bknight/pain1.wav": {
+     "bytes": 7414,
+     "sha256": "673f778d8154bb8cab689370ab3d007a6c9efafdd4ab1cd9c77ac0b94f3f8ea7"
+    },
+    "sound/bknight/sight1.wav": {
+     "bytes": 13526,
+     "sha256": "211f30dfdab803d322bd3685902ad06c7d2ea28d8a7bdd3a5d68a731b99b96fa"
+    },
+    "sound/bknight/slash1.wav": {
+     "bytes": 2342,
+     "sha256": "648f17db035ec311579816fb314044b596777d20b2fdedd010d6abae32421e3b"
+    },
+    "sound/items/deflect.wav": {
+     "bytes": 22548,
+     "sha256": "6a54868494809f462e860f33e6b86e9bb4195d0a8599ea810865331751e2e217"
+    },
+    "sound/items/deflect2.wav": {
+     "bytes": 34024,
+     "sha256": "8ad6ec0f05b2afe21d318babba844167099c208fd88f6a76dca8cbdf9f916f78"
+    },
+    "sound/items/deflect3.wav": {
+     "bytes": 23344,
+     "sha256": "d4606f1e6eb4255fbedf1e037006f7f8195070aaa2337a971a43bca39874e6ef"
+    },
+    "sound/qshal/attack.wav": {
+     "bytes": 16674,
+     "sha256": "40a1a3036359f886780fe5d540a0a6da59f3a4d9e155cf1563d407b5c0eec6e8"
+    },
+    "sound/qshal/attack2.wav": {
+     "bytes": 10908,
+     "sha256": "dc434710f47f414a50c626a0d8548fa99134dbe028b7931562184134cb650e93"
+    },
+    "sound/qshal/death.wav": {
+     "bytes": 11548,
+     "sha256": "d679aa4cc475808df710e6c36cd0e79d362e601bfc92d49b89e946605091b7f9"
+    },
+    "sound/qshal/idle.wav": {
+     "bytes": 16314,
+     "sha256": "317ba3d62be50621aab050607ef0e815f45980c76518eb33a597fee23d17eda5"
+    },
+    "sound/qshal/pain.wav": {
+     "bytes": 9148,
+     "sha256": "23ad1b305ad006fdc185880226cc27d7979b372da94c78e7eb2d66ca2f0940aa"
+    },
+    "sound/qshal/sight.wav": {
+     "bytes": 26522,
+     "sha256": "9566b73c88f672fa3aafb663667f1b80b3cd4d92823685c3f20805cf7b40490b"
+    },
+    "sound/statue/statexpl.wav": {
+     "bytes": 27574,
+     "sha256": "2d3e8f853de63dbbbbbaf44cac4bc6b59c06fec045e4e43500f875e5fa3e928b"
+    },
+    "sound/swizard/hit.wav": {
+     "bytes": 7332,
+     "sha256": "9e176ecbed57b5d30dc647010f576f15bf48bfc0f72e37d0a2d7de80a07ead1e"
+    },
+    "sound/swizard/wattack.wav": {
+     "bytes": 25924,
+     "sha256": "5f0f1b17da582ccb92b9c129d77dc3ecb6baa425f6800e4b423950caf9a7833e"
+    },
+    "sound/swizard/wdeath.wav": {
+     "bytes": 41504,
+     "sha256": "a3863e8818e59c96361499b1e7166cdf320a9cefe281596c3505c121b337e9ff"
+    },
+    "sound/swizard/widle1.wav": {
+     "bytes": 13476,
+     "sha256": "b60ee65e8e3ff34bbe7f441a477548083270a2ab2184e70280c102d975ea1514"
+    },
+    "sound/swizard/widle2.wav": {
+     "bytes": 23106,
+     "sha256": "a1aa071e3b495c9e078ac896d8fc1e16a5ad4a7fb23c65bb8e0d562089969c69"
+    },
+    "sound/swizard/wpain.wav": {
+     "bytes": 8698,
+     "sha256": "0a01195b18a939aa4a00d8336260f4d6b1795357c095a187470f750203891bda"
+    },
+    "sound/swizard/wsight.wav": {
+     "bytes": 13538,
+     "sha256": "32b266eaebeaf26c45f7907ca3ec11f522c4afa15b3eb34998edeb3beee61487"
+    },
+    "sound/weapons/bolt2.wav": {
+     "bytes": 10920,
+     "sha256": "6ddbb389c9650e3de2bab119f9b5f5b898a6a64587a49a97e8373bc9c58709b5"
+    },
+    "sound/weapons/spike3.wav": {
+     "bytes": 12654,
+     "sha256": "749f103540fb1e8afc94eb17a69aa15ddba5591da21fb210932231e6e3a9c026"
+    }
+   },
    "sha256": "164f6aa35efc3eb880a8fe98a26571e9372ea0bc71751be805f339331502948e",
    "timestamp": "2000-03-23T18:39:04.000Z"
   },
   "pak1.pak": {
    "bytes": 17149624,
+   "files": {
+    "maps/des1m1.bsp": {
+     "bytes": 1259236,
+     "sha256": "e9696b22e2ec8d956931ef13a1d662fb900b89703075b19d176386e6291bb568"
+    },
+    "maps/des1m2.bsp": {
+     "bytes": 1333364,
+     "sha256": "7277532d33408c49a10dbd05154ceb66b28d8d51c4a21959b1d2b06d65b2331a"
+    },
+    "maps/des1m3.bsp": {
+     "bytes": 1465016,
+     "sha256": "0d928a0949b7fa675b5d643647aa956815506cb9cf75fb7df7cc42b2a5458280"
+    },
+    "maps/des1m4.bsp": {
+     "bytes": 2019404,
+     "sha256": "07c68044007a6c17263bea47cb6a62a92d509364ed4830850108c2695efdfa43"
+    },
+    "maps/des1m5.bsp": {
+     "bytes": 2269500,
+     "sha256": "437c79d417c5d5c8e38df3fac209508693014cb66b0e575422b1aa2a78d6e7f1"
+    },
+    "maps/des1m6.bsp": {
+     "bytes": 2092076,
+     "sha256": "b9957320d029887fa603cb49193f059128744b1a9e30b3ef9e3478db50cce509"
+    },
+    "maps/des1m7.bsp": {
+     "bytes": 2109808,
+     "sha256": "e1417124a7a293aa99b13ed6c2523ca2955030a6c711c587eda09d4cdcb4cf1e"
+    },
+    "maps/des1m8.bsp": {
+     "bytes": 1843228,
+     "sha256": "8cc2b47a6c8d962826fee36b79c89a0bcbfaa62c0cbcbe85694ec9570e16d1f6"
+    },
+    "maps/desend.bsp": {
+     "bytes": 2126544,
+     "sha256": "c0b8451ce662c52282ad4a200624f5ed5caf3851ed6f3514bca4d217ae329cb8"
+    },
+    "maps/start.bsp": {
+     "bytes": 630796,
+     "sha256": "77a36a7b77972c5df8f5051d890f982928b93bed55073d402c7b042980734155"
+    }
+   },
    "sha256": "ed2ddc07abcacedc816fd9ef875bd22a86f305364b4a309a37743d725100316d",
    "timestamp": "2000-03-23T18:39:32.000Z"
   }

--- a/json/by-sha256/cc/cc3ca281ca612d64872b5322a82f51b50a74281e8f0b7707b9b683af019adbbd.json
+++ b/json/by-sha256/cc/cc3ca281ca612d64872b5322a82f51b50a74281e8f0b7707b9b683af019adbbd.json
@@ -32,6 +32,492 @@
   },
   "jpqm13/pak0.pak": {
    "bytes": 32708955,
+   "files": {
+    "maps/debris/brick01.bsp": {
+     "bytes": 7912,
+     "sha256": "c11880924b195ed38908cbf50f9cd16f071918df0a94a19c7254b93dddb1e62d"
+    },
+    "maps/debris/wood1.bsp": {
+     "bytes": 7584,
+     "sha256": "c39390e3757553352941fcc255da6498be4c25a87575871e360a0166fac592bc"
+    },
+    "maps/jpqm13.bsp": {
+     "bytes": 18138948,
+     "sha256": "344b32fc15c710c921cc6eadffbf39fccfa7fc352d87ba90c079ebb685c3e46d"
+    },
+    "maps/jpqm13.lit": {
+     "bytes": 5781068,
+     "sha256": "d29df98d6a1517d6834b85cb1a955f31875708ffdf23c5b783ba26c6e1f7e0fe"
+    },
+    "progs.dat": {
+     "bytes": 749842,
+     "sha256": "cf5045e62b6668ef38eece435e868c67dcc3051212d1fab442c2413a71e57f41"
+    },
+    "progs/a_mdls/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "1cdfc2b54dd883efe9215499603e341bfa72e800740a2e874e9bcf3b0afc68ba"
+    },
+    "progs/a_mdls/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "8cb54159eeaa410b98478e9190bd2d33340d3a2e98a61d32ce1afaf4e99031a0"
+    },
+    "progs/a_mdls/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ac361970fb1cbbb87ad4593afecd6d8973a65ea4f14e5f7b565c8f38c181fa9d"
+    },
+    "progs/a_mdls/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "0870b633f95bda895074e8d423631ee8805c3923f36a1c7f09938710783e8f99"
+    },
+    "progs/a_mdls/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "146955794f29c02f6570eed83e1d4b0013b0b4341897bcbc91cc9ffea6957ff4"
+    },
+    "progs/a_mdls/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "59988afc3603b83ccfadf0a9af423a113bf15ed969d4a62db9073e3061bc0fdc"
+    },
+    "progs/a_mdls/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "696594c11dd6dbd2e60ac6923d82a55f8f5b16e93b93f7914abe5fd4df74299f"
+    },
+    "progs/a_mdls/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "b558ee2dfd0078c7e3075079fb40368f53e7dfb162aaefcd20e53f562e405b1b"
+    },
+    "progs/armshr.mdl": {
+     "bytes": 20012,
+     "sha256": "1873523424395b404ffafeb447383185e033826e33bf0a001efc34604ece95da"
+    },
+    "progs/candle.mdl": {
+     "bytes": 24135,
+     "sha256": "5027f8712c36de87b3967e4e623fbc64d4e99644f5b805f7e21ec38b1532cc74"
+    },
+    "progs/debris.mdl": {
+     "bytes": 263072,
+     "sha256": "2b60cba9cbb454e3524d174edc0e1a540f2b2e91fa0b35fc2ab20ccb7fabd8d1"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 472208,
+     "sha256": "3345599ba081d346c163f5c239815bd65b134ccf342601f42a31e60a45044f39"
+    },
+    "progs/g_shotgu.mdl": {
+     "bytes": 29076,
+     "sha256": "4a8866ab410a93522a3d3221e0f3b45889a488b54c0551329f09493273e09840"
+    },
+    "progs/h_boss.mdl": {
+     "bytes": 24028,
+     "sha256": "b41e2302e15d7cb47bf1eb4ee1df29e7e8d773a3dfc6059f5b1f8ce18685bba6"
+    },
+    "progs/h_mdls/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "2e7fac7418838a721d80e80370000f3e400b21248b22c8d3555588d4f8437a5b"
+    },
+    "progs/h_mdls/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "1f4b0791be3156763c15521fbf2e747744ce3355d90d630b01c2227770314771"
+    },
+    "progs/h_mdls/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "6f792b9a80f34e31bceb4258e1d2c8f22d405a7ae1198b31bb285f502c720cfe"
+    },
+    "progs/h_mdls/pd_vial.mdl": {
+     "bytes": 8292,
+     "sha256": "035673048c98991e790abe484c2403b56dfe5ea1f5fb185c1b7a657d918668e8"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 42048,
+     "sha256": "52760ce1f6e8f657e782846571baf9fde80859f5342d07a684fa8218f96f68db"
+    },
+    "progs/k_spike2.mdl": {
+     "bytes": 444704,
+     "sha256": "e466e7afa95868ec1a3b3bfc770573d93dc20c2d881a73d2b9b0e35f1dfa6d9b"
+    },
+    "progs/lspike.mdl": {
+     "bytes": 1684,
+     "sha256": "59264317258f19955b967177f0dbc5be1733e4ca07c4c7b3cc333bb88bc0c46e"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 366916,
+     "sha256": "29fa9866dd4862b99ebb9944ddb0bf24a6d0bb4bf00e26a94d3622cead9b6315"
+    },
+    "progs/pd_b_key.mdl": {
+     "bytes": 128440,
+     "sha256": "c5aff23b766037ab550636516d7fe0235dacf566ddb966541d640092bcb62349"
+    },
+    "progs/pd_bpack.mdl": {
+     "bytes": 216724,
+     "sha256": "1839c92899197344935eca44d7b4c70e903af84ab633259786f8c12c39905149"
+    },
+    "progs/pd_r_key.mdl": {
+     "bytes": 269528,
+     "sha256": "7ef6894b955c4ca34bf3e2ebdc6288f55cc3b1285478444a81ca769866e1a119"
+    },
+    "progs/pd_w_key.mdl": {
+     "bytes": 170680,
+     "sha256": "73f06fc10a53c93db25d67f20bad7672bc5f4e14bf3a6b5115d68f00696b536a"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 47856,
+     "sha256": "99fc3f91856aa6df2f25494a945e17b64b59ddc3faed424a6fcd73062a677fcc"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "e306ec0fbf0f5e4306c6683f7c7b87674bb0a168ef32a2b1118dcffb083deeff"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 320900,
+     "sha256": "e3321220ed34292da63fac94af63360c6544c055edd1eceed35d75eb26685e9b"
+    },
+    "progs/spark.mdl": {
+     "bytes": 2544,
+     "sha256": "77d081c51af9bd6c82d2d51dcb955a2fca5189cda4eb09a138bfa2e2b521fb05"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4416,
+     "sha256": "8c70353304b2d111260102565745a5504144568f932787906eaf50de742aa62c"
+    },
+    "progs/teleport.mdl": {
+     "bytes": 1058800,
+     "sha256": "98eeb63a1ded2d7a1d3788562478aff891af1be4ef1c552bcdb913cb338387b6"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 1058816,
+     "sha256": "ac4d47130af263cb6fd861d70ac09ebf758ab1a76da0b697e268382c65ae1a16"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 311493,
+     "sha256": "add013a5a6686ffd76ec0f2b2b3413757432ba4a8564ffd81aeb7eb2c5a98398"
+    },
+    "quake.rc": {
+     "bytes": 469,
+     "sha256": "490877c3d81446c26fd36f25b358a0e0e109e6b3566f23a6a2d41c8319849750"
+    },
+    "quakec src/LICENSE": {
+     "bytes": 18431,
+     "sha256": "189b1af95d661151e054cea10c91b3d754e4de4d3fecfb074c1fb29476f7167b"
+    },
+    "quakec src/ai.qc": {
+     "bytes": 18597,
+     "sha256": "bcd2d7de7ce600d39bbc9b189a2d9a6bde75cdcd0800e46bb14994424b287b26"
+    },
+    "quakec src/boss.qc": {
+     "bytes": 13803,
+     "sha256": "41ca279d62544cdb718df7bc2905e7bb5df06706c54ef348d2d478470a4d5515"
+    },
+    "quakec src/boss2.qc": {
+     "bytes": 16431,
+     "sha256": "d495677614d54635fe5f12d0f0d3fd88b88486d42ff2cc1cb467111390e79a84"
+    },
+    "quakec src/buttons.qc": {
+     "bytes": 4446,
+     "sha256": "58ff5453eac2d012d5514d6c10babe85187744e1bd293720b2c1bda1109ebe04"
+    },
+    "quakec src/changelog.txt": {
+     "bytes": 14317,
+     "sha256": "392ca6557e6c056f260904e815143403d98ecb8b6dde96d34cd98fc5504995fb"
+    },
+    "quakec src/client.qc": {
+     "bytes": 35005,
+     "sha256": "84ad056d736b796c3ca4000c41c5dc9cd487489bc4fd35eb2914c3c65f19c63b"
+    },
+    "quakec src/combat.qc": {
+     "bytes": 9118,
+     "sha256": "287c8d9d90a5dae838f6e2ced580bd306e545f255484a94308331a20d1c01d9b"
+    },
+    "quakec src/cshift.qc": {
+     "bytes": 1747,
+     "sha256": "b3442a5eb8b04cfdcd2020dcc0099883e22f04153560308f793d0fcad8b3efbb"
+    },
+    "quakec src/custom_mdls.qc": {
+     "bytes": 2275,
+     "sha256": "74f7e0e8bb25b8a70d54f1168ee90c773ee1bd909b15e045128f61e018716cc4"
+    },
+    "quakec src/customsounds.qc": {
+     "bytes": 5564,
+     "sha256": "26bce1b876f3a8a709a2b61298d1f65de5f568f24ac66db713e8585afc694f5d"
+    },
+    "quakec src/cutscene.qc": {
+     "bytes": 30738,
+     "sha256": "7b4d2fd6a7ffd2c2da115447e9f348a552d20c59728a072c7ced6308d31c0130"
+    },
+    "quakec src/defs.qc": {
+     "bytes": 28880,
+     "sha256": "7cabf435fd377fcdce5895ee1d0a27e91c46a002a4b1689df712dc8b06546a57"
+    },
+    "quakec src/demon.qc": {
+     "bytes": 15607,
+     "sha256": "14a99a3a771dfb5c0ddc4393a3cb520994a98fd16573f8ac6d6056a5b336f4f6"
+    },
+    "quakec src/doelightning.qc": {
+     "bytes": 4955,
+     "sha256": "4b6233156f3792d7529d714de7f992c066a927d5f9109d9947caa2a7a2341c57"
+    },
+    "quakec src/doeplats.qc": {
+     "bytes": 15495,
+     "sha256": "754e13c54f3d8ffc76ba80a1a7fbb3825ad5b300d9ff7f48195a7c6773036e80"
+    },
+    "quakec src/dog.qc": {
+     "bytes": 15129,
+     "sha256": "3434cfe57a78759e0295ba717cafee2514ac01ae737732be046b7708e23da988"
+    },
+    "quakec src/doors.qc": {
+     "bytes": 21714,
+     "sha256": "123edcc73083fd893140f1f4e5c337ca5925b923aa8f46862d1029ea1142afbe"
+    },
+    "quakec src/dtmisc.qc": {
+     "bytes": 30024,
+     "sha256": "f383fb5017b305923ddbe5a71868e20567128c1fd4b66d5a9a761d7e3ee1e510"
+    },
+    "quakec src/dtquake.qc": {
+     "bytes": 2654,
+     "sha256": "170b5464e0092f6a2f261910108381fd93fdb7fb5dd7bc047863f7bcc462dd9a"
+    },
+    "quakec src/elevatr.qc": {
+     "bytes": 3624,
+     "sha256": "eb6a260d53ca8f7b69f20a8cc42341c597d5e06ea18bca86e6aabff71bbc892b"
+    },
+    "quakec src/enforcer.qc": {
+     "bytes": 32786,
+     "sha256": "42de3a45a987bf7cf1921cc27d1d2a94129a43a4f8bb8b1de361e68968983ed7"
+    },
+    "quakec src/fight.qc": {
+     "bytes": 9867,
+     "sha256": "0c2b4e3afe48260206e086c9742bf99c34f4c83993a368c0cfca764a84813add"
+    },
+    "quakec src/fish.qc": {
+     "bytes": 11993,
+     "sha256": "d360b27d2e57192c2ebbaacd8532cdf7cd0330d63592032671c3b2efe5e41276"
+    },
+    "quakec src/fog.qc": {
+     "bytes": 15746,
+     "sha256": "8e89fb2fa6a035620617bf155a531cff3261c60711a5c8237283970383ab2727"
+    },
+    "quakec src/func_bob.qc": {
+     "bytes": 5676,
+     "sha256": "5fe11638fd89f509759c83748c519b98dc5fe5856b09fab1f6247518b9836143"
+    },
+    "quakec src/func_brush.qc": {
+     "bytes": 1471,
+     "sha256": "cec99401fbecf0b4b07c81d79f13f3ea05a0f13296e75ddc3fcab4fff0dbd1f8"
+    },
+    "quakec src/func_fall2.qc": {
+     "bytes": 8668,
+     "sha256": "eed5a376c5bc5a9262d2a6d08d46c67b3cae39a89830912a37d015e02e52d692"
+    },
+    "quakec src/hipcount.qc": {
+     "bytes": 5217,
+     "sha256": "da5c096495966fa9ef5315ba00b315987349a817c889b974d8a91f506e6aee1d"
+    },
+    "quakec src/hippart.qc": {
+     "bytes": 7983,
+     "sha256": "730ed584b4de9dd49283502419a8bcafb99e2f1a3d146e05afee0ab2547751c3"
+    },
+    "quakec src/hiptrig.qc": {
+     "bytes": 6589,
+     "sha256": "4a5b1c58309c0a2c2d44d6d1a455263decba46bd965d71dd4e600aebb07c47e9"
+    },
+    "quakec src/hknight.qc": {
+     "bytes": 30265,
+     "sha256": "1588171c8243cb9b71676cc35bb26cbfebe05e6577ea7a38c4cab8b7107ff3d0"
+    },
+    "quakec src/intermission.qc": {
+     "bytes": 11029,
+     "sha256": "a3f031f373dffa837a1988445fffd7d9b979af9a675d2cba7f4e2bccc8f0a486"
+    },
+    "quakec src/items.qc": {
+     "bytes": 66714,
+     "sha256": "85e2b7e7afcf5b0dab8db0f88187c5858c5790bffd98c44abd4269799e813c3d"
+    },
+    "quakec src/keydata.qc": {
+     "bytes": 5639,
+     "sha256": "5902993c9755a2851ef424e48572a9806d20d3aae67a8f9d01446c4aad09a91a"
+    },
+    "quakec src/keylock.qc": {
+     "bytes": 5884,
+     "sha256": "26751c63554a6e73da84138ee45871f501d3bb5250cbfa137a524087bc204e39"
+    },
+    "quakec src/knight.qc": {
+     "bytes": 14999,
+     "sha256": "b03ffc882929eece408722163dd9c5d25f34d8096417c3288c276c5e6778dde9"
+    },
+    "quakec src/lights.qc": {
+     "bytes": 16031,
+     "sha256": "5dc78d48aaafe3abdc220c3db75be4828bfba85fc25bbd62e799a29f4532a173"
+    },
+    "quakec src/math.qc": {
+     "bytes": 4317,
+     "sha256": "961dd24bcc4b1941fc249a6d148e2a562e24fda4efc9e47e1040b516f8d86c2f"
+    },
+    "quakec src/misc.qc": {
+     "bytes": 55326,
+     "sha256": "68871a011e43233445b6753cbceff302be8e570b8fb9049eeab2c032f1204681"
+    },
+    "quakec src/misc_model.qc": {
+     "bytes": 5082,
+     "sha256": "9b7e616256997b563c1e5ab44918cd4b936606e2d26d2cb79f7e3b270623546c"
+    },
+    "quakec src/mobot.qc": {
+     "bytes": 14723,
+     "sha256": "4d60beb5060a27a82d33ad6bcb5977e116bb9b93d9311aa7a30f925283b29be8"
+    },
+    "quakec src/monsters.qc": {
+     "bytes": 12877,
+     "sha256": "4f5e2c7356a11bbd1465e1148b554fd732c249360c68f32efd6baa3bec0a1114"
+    },
+    "quakec src/newflags.qc": {
+     "bytes": 5870,
+     "sha256": "192bf31eb0f13e6e55342801a42608caf797bfdfbdf27750c78ae67b1c1c5568"
+    },
+    "quakec src/ogre.qc": {
+     "bytes": 48366,
+     "sha256": "ac649ea8a41b1d4b4246f2e9c14bbc1cb7439381eba1b588c57545980f161930"
+    },
+    "quakec src/oldone.qc": {
+     "bytes": 10467,
+     "sha256": "33ce6342a7c06ab06af995f235ab8170917db359a956d6fd96d00709c54a08c6"
+    },
+    "quakec src/oldone2.qc": {
+     "bytes": 15136,
+     "sha256": "bad10c7974544972a4cdf8821eb745ea32a61de8bfa26c31b445ff1f619557c1"
+    },
+    "quakec src/plats.qc": {
+     "bytes": 22678,
+     "sha256": "6ce695f58b859c09c7d79ae741b31246ca49a322515bbad54898dc19e0a5e448"
+    },
+    "quakec src/player.qc": {
+     "bytes": 21779,
+     "sha256": "4c3935e710456c022c681ccf312109337616157bdebb7a72152f2ba37ec4cdce"
+    },
+    "quakec src/progs.src": {
+     "bytes": 2033,
+     "sha256": "539b2dd5c36d69491e26a508c772d2f751529753f44465f48c52ce73cd8402d0"
+    },
+    "quakec src/rotate.qc": {
+     "bytes": 31520,
+     "sha256": "ad5eee063eafd078f60ed3d247c19be9fc88887fd4c5aa307953c72089b53c6a"
+    },
+    "quakec src/rubicon2.qc": {
+     "bytes": 29182,
+     "sha256": "aef0904a68af683fb3002effa918306ddfbe4230a18fd3470af107bd34105357"
+    },
+    "quakec src/shalrath.qc": {
+     "bytes": 15839,
+     "sha256": "032b2f1eae78332de56603af833af57d78fa47ac29bf6eaf0a72c588b9e5c5df"
+    },
+    "quakec src/shambler.qc": {
+     "bytes": 26084,
+     "sha256": "782cdf07726bb5c9b63fe93d880b39b9a6657463d4b145b53d26fb21290e8453"
+    },
+    "quakec src/soldier.qc": {
+     "bytes": 21847,
+     "sha256": "28e94fd02188befb535bd16512cd6e7f4af3bdb5ef4a4cd6431965d8caf82474"
+    },
+    "quakec src/spawn.qc": {
+     "bytes": 10642,
+     "sha256": "51571dd7851c2daf9d657b19350e05f5d10f85a212afcdd06757e1a27df7ef83"
+    },
+    "quakec src/subs.qc": {
+     "bytes": 18016,
+     "sha256": "a7636b244cf1b7b8646feff48300c0ba8dd2d4e4169e18f14971de6904169880"
+    },
+    "quakec src/triggers.qc": {
+     "bytes": 51080,
+     "sha256": "0fa737b126deb2e312b3f42bbd7f82281fbcf1f35df6faf4f19d6a0259f07bf5"
+    },
+    "quakec src/utility.qc": {
+     "bytes": 4842,
+     "sha256": "a29fb47736072ad009a77ac4e063f9f7f4f854327b6c829a8e0403f4756c9994"
+    },
+    "quakec src/weapons.qc": {
+     "bytes": 41766,
+     "sha256": "faceddfc37e7b414656a4660b9f951d2eb90424a01599ec02c9f7e912cc693a8"
+    },
+    "quakec src/wizard.qc": {
+     "bytes": 16699,
+     "sha256": "02e4dfd2e264fd5901aaa3bb0a0ceb6381fc67027ddbba795c3702056a83cda2"
+    },
+    "quakec src/world.qc": {
+     "bytes": 21577,
+     "sha256": "37578572550ac480bf0ace9d44b0082768115490950dee14731782dfc41cde16"
+    },
+    "quakec src/zombie.qc": {
+     "bytes": 39679,
+     "sha256": "f2f4e0d2328c396087f9c4a06823861e5095f1c1ed7ec7a4163c8de350126fa4"
+    },
+    "sound/ambience/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/ambience/laseron.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/ambience/rumble2.wav": {
+     "bytes": 99104,
+     "sha256": "9c3d5418c7e5bac60c365f0e8b7ea496dd2b51c72c13b0e5a6640e2ef880433a"
+    },
+    "sound/ambience/tornadosiren.wav": {
+     "bytes": 409132,
+     "sha256": "793bb573cfa13890fed938c1e8259b2218480f2e4769c56e9060010d5d5c4270"
+    },
+    "sound/break/bricks1.wav": {
+     "bytes": 49956,
+     "sha256": "302547c290609bc311098f9f63643199bee0164e907edf0e2b9289ccbce2a4e2"
+    },
+    "sound/break/metal1.wav": {
+     "bytes": 70054,
+     "sha256": "c178f8f52631b1ff353fbeb3557e04e8bd574646ed47f78a3003350b67540979"
+    },
+    "sound/break/metal2.wav": {
+     "bytes": 65948,
+     "sha256": "7438b112d81fb92c285a507ebfbde5b15dbddcd90a85f51ecaae2df3ef83480c"
+    },
+    "sound/break/stones1.wav": {
+     "bytes": 69380,
+     "sha256": "1b58b722e55c4e2d25f65e820e279699a7b236a02685fbc6a41a40e573df1928"
+    },
+    "sound/break/wood1.wav": {
+     "bytes": 53720,
+     "sha256": "026e35d7108347603453765f66311fec99097ff9f82e2d2703f69b7d80ae07c9"
+    },
+    "sound/break/wood2.wav": {
+     "bytes": 59252,
+     "sha256": "4488c91dc44e526beb95d33ad200e07e484a6f2fea59578784f3417a00df81f7"
+    },
+    "sound/dump/armsh1.wav": {
+     "bytes": 22610,
+     "sha256": "46801976a87d548c2cb7b1548f12dfd0b3f1d246aa9d86944574fa3216c6d6d1"
+    },
+    "sound/dump/elec22k.wav": {
+     "bytes": 178736,
+     "sha256": "d56ff98d1d41511833c35b5a8b5311f00b7e13932591eee53f9e2adf788569e1"
+    },
+    "sound/dump/magic_01.wav": {
+     "bytes": 125944,
+     "sha256": "3ea2bab80feccbe0f0b518ec613f45093aa76b0128752f454e239c75175cb4e0"
+    },
+    "sound/dump/pd_water.wav": {
+     "bytes": 92708,
+     "sha256": "0402b1fb2501dafb33bd43fa9c49c0f6a3fff615a200693cb7953852305c49f4"
+    },
+    "sound/dump/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/dump/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/oldone2/pd_pop2.wav": {
+     "bytes": 42108,
+     "sha256": "1eec3103cd2eb70fa8ba63ce8ce721842a64a99e9c373f5a8abe5508273ce285"
+    }
+   },
    "sha256": "8b9a8e0ac15f756a1178997fe3b0b0efbd97644ab0d8a1b49f9bb43c211e3ef2",
    "timestamp": "2022-10-16T21:42:14.000Z"
   },

--- a/json/by-sha256/cc/cc614914fc11e452e048301325f520a3cb3da6e530b6789f666f0f070fb45034.json
+++ b/json/by-sha256/cc/cc614914fc11e452e048301325f520a3cb3da6e530b6789f666f0f070fb45034.json
@@ -12,6 +12,124 @@
   },
   "pak0.PAK": {
    "bytes": 4366721,
+   "files": {
+    "glquake/draco.ms2": {
+     "bytes": 3156,
+     "sha256": "b373a645e55797a023441fa696b2c1a73c1f63ba49bcbf4b892ada40f5b608e4"
+    },
+    "glquake/dragon.ms2": {
+     "bytes": 3156,
+     "sha256": "b373a645e55797a023441fa696b2c1a73c1f63ba49bcbf4b892ada40f5b608e4"
+    },
+    "glquake/dragon2.ms2": {
+     "bytes": 3156,
+     "sha256": "b373a645e55797a023441fa696b2c1a73c1f63ba49bcbf4b892ada40f5b608e4"
+    },
+    "glquake/lwing.ms2": {
+     "bytes": 384,
+     "sha256": "7ac037a1745c6fdaa8b7de6ce5dcad4b67c0d456b69c8feebd9959f5ecaa1980"
+    },
+    "glquake/rwing.ms2": {
+     "bytes": 384,
+     "sha256": "3e142b95ecba140f8fbb5f5fa380506b4ee5b9c88c5eeddf50aca2d1db4b8aab"
+    },
+    "glquake/tail.ms2": {
+     "bytes": 584,
+     "sha256": "35f969166f54c83b77ea1c4443e41ea90efb04243fb3980a8eba807f2b3e694b"
+    },
+    "maps/mospq1.bsp": {
+     "bytes": 2292564,
+     "sha256": "4b378a8a734bb990990f357b801600e91891f08849fc207df8c94b69646fb514"
+    },
+    "progs.dat": {
+     "bytes": 655956,
+     "sha256": "2cfa2d2970f19f5d7375c1cf252cdad825af38e68193c7d388fae3793a0df6fc"
+    },
+    "progs/draco.mdl": {
+     "bytes": 304349,
+     "sha256": "806bdcd54dbba90f571a3f6207100f5494f6469d3ba038430233fc4d97842bc8"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 301816,
+     "sha256": "b5c3af1c5329aa0445a2aa5fe9315f07f4643ad93a860b2f3dc3ec0e958d553e"
+    },
+    "progs/dragon2.mdl": {
+     "bytes": 301816,
+     "sha256": "52b92800f35c1c99e8205b16f7e12707b9ec0ba87d0894d25950c4b113a088c9"
+    },
+    "progs/lwing.mdl": {
+     "bytes": 41603,
+     "sha256": "8febff0f7d189e0bb3d152dc6f0a1a78a0276507f3acba6b3ce71128ee42c160"
+    },
+    "progs/rwing.mdl": {
+     "bytes": 47243,
+     "sha256": "c88795a8e84e3ac2c00b73bef573177e34b0c3bd3b1b6680bb8c2db4237769fa"
+    },
+    "progs/tail.mdl": {
+     "bytes": 12811,
+     "sha256": "b50f08fdb0513f68a62251cede6184f6250f34832f9fdfea9d65bbfdbff2eccd"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 16944,
+     "sha256": "0fe255bd36c64acf75a53b97851b995517e70468b3818ff0ccecc4c7be5fc055"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/idlefly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/niteact.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/dragon/niteact2.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/dragon/niteact3.wav": {
+     "bytes": 17021,
+     "sha256": "577923d423f85a510a6700530325c4cf16861a39bf923e6747958de77c036578"
+    },
+    "sound/dragon/nitepain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 13848,
+     "sha256": "e71858c4de3e9ddcad1cba4ec0a6f5ec437b06c813b263ec73f853846d15a984"
+    },
+    "sound/dragon/sight.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/spike.wav": {
+     "bytes": 14990,
+     "sha256": "6aec96fda55dfb0120f106064cd324ea6e059bab3fdbb2d81cda297f9a82e02b"
+    },
+    "sound/dragon/spit.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/thunder.wav": {
+     "bytes": 14764,
+     "sha256": "b30e18bbc0a12db2032fa95d5d0504ea63eaa13b3bea34e3b42ec59f3ca4d815"
+    },
+    "wyrm.mdl": {
+     "bytes": 192313,
+     "sha256": "83e4792c9276bf6be9e359e3ff5076f3926aee9372cbf964121318116a05320b"
+    }
+   },
    "sha256": "1c539214dad331f5a159e5a957d9f61bc88847c4a82e3829441d689dc36d5dd3",
    "timestamp": "1999-10-08T22:23:40.000Z"
   },

--- a/json/by-sha256/cc/cc8005e4aa7df6b1f1a33c60a1060cf1e0e4314f5710dbbe6f21d72dcbd6b174.json
+++ b/json/by-sha256/cc/cc8005e4aa7df6b1f1a33c60a1060cf1e0e4314f5710dbbe6f21d72dcbd6b174.json
@@ -22,6 +22,780 @@
   },
   "marcher/Pak0.pak": {
    "bytes": 19401351,
+   "files": {
+    "gfx/env/dragonmarch_bk.tga": {
+     "bytes": 713872,
+     "sha256": "d76065d522d718ed405ca152eb59f5ef9b5c050134a785f500124ecb0181569e"
+    },
+    "gfx/env/dragonmarch_dn.tga": {
+     "bytes": 785870,
+     "sha256": "afa2b880d35793453e6e59c29a47fae3759cf7665c7de0a764da8a0675227723"
+    },
+    "gfx/env/dragonmarch_ft.tga": {
+     "bytes": 628373,
+     "sha256": "4d639ffa187701b7d0d3478e3f673fbe9d765dd8a2b1d38aec46f9f53edcec16"
+    },
+    "gfx/env/dragonmarch_lf.tga": {
+     "bytes": 629950,
+     "sha256": "0bae63fe4c2e0e0f76ee251a27a271e4d34f4a57cb6bb5516f42bf5ca9e79def"
+    },
+    "gfx/env/dragonmarch_rt.tga": {
+     "bytes": 665194,
+     "sha256": "df384c5c2d1191016923918f4fe77a1c084e9674173fe4eaeea6930e10702bd0"
+    },
+    "gfx/env/dragonmarch_up.tga": {
+     "bytes": 316226,
+     "sha256": "b85c6967cdb97581e1fd7541aff84a68e95a5314a6479644941903269b4d3ae7"
+    },
+    "gfx/env/thumbs.db": {
+     "bytes": 14848,
+     "sha256": "1175cc1de95570132333c9a5182bd880e31c1ea3949fd929599fc6f42e469e07"
+    },
+    "maps/marcher.bsp": {
+     "bytes": 7393304,
+     "sha256": "ee04bf9d9f5fa89b487d74d87258404e08b851c9172dfd0778a58e5df07cab6e"
+    },
+    "progs.dat": {
+     "bytes": 711580,
+     "sha256": "81e0dda14283c443cafb420ef2d247d9c712dfa9072f8b6fe124b8cb5d97f42e"
+    },
+    "progs/bellring.mdl": {
+     "bytes": 74016,
+     "sha256": "0d1b0e150de4ac59c599deae96d6b21e4ceb2300e7d410a1d802385dad99560b"
+    },
+    "progs/flag10fps.mdl": {
+     "bytes": 16052,
+     "sha256": "f2670312a8d16dd16e42fd02a39dfd285e6ffea624e729597b773c86140631d1"
+    },
+    "progs/flak.mdl": {
+     "bytes": 1684,
+     "sha256": "5ef83ea57cc9922dacdf8720e56451a9b121346669ff5ec5bf99b7290da6b8b0"
+    },
+    "progs/flamebig.mdl": {
+     "bytes": 85180,
+     "sha256": "9df2ae13e72ffe5a305a6ce877b0284023520d5d34df751498a2003c3e420ebc"
+    },
+    "progs/flamecan.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/flameltn.mdl": {
+     "bytes": 27960,
+     "sha256": "5877b37cc4f98a53467c412e7d06d1f7ec6b60f5c0f2088514aa51c9d2c51769"
+    },
+    "progs/gauroch.mdl": {
+     "bytes": 669648,
+     "sha256": "352403dfe4d7665fddacacbc12fce6b1cac81097cbc733bca59785e6ba0bac4c"
+    },
+    "progs/h_imp.mdl": {
+     "bytes": 15892,
+     "sha256": "ecf5c25157468f7fa9aed625e12401e14cd5aea76ece8cac83c09e7863efdbe1"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/imp.mdl": {
+     "bytes": 331084,
+     "sha256": "bb8dba578896471f42313bf0bbb532b14f5541c0abbfdf9e60254de95d4b3768"
+    },
+    "progs/knight.mdl": {
+     "bytes": 101404,
+     "sha256": "7f8e8b9d441955aec4e771628292b140c0ceee9f3d6f4936a28f94c4b04270b2"
+    },
+    "progs/metlchk1.mdl": {
+     "bytes": 2388,
+     "sha256": "107d02bd9b8e89e7ed03b7a15471643d615102769afb9856730cb700080b7ab7"
+    },
+    "progs/metlchk2.mdl": {
+     "bytes": 3356,
+     "sha256": "0017c82d98823d6099fd7dd1eeb22a67c49310612dc68aa74f987fc021e610a1"
+    },
+    "progs/metlchk3.mdl": {
+     "bytes": 2964,
+     "sha256": "1b2d7647dec07291d2bacb23bdb9400e14051bd2f0e4ed4b57abd1ecb8f220f0"
+    },
+    "progs/metlchk4.mdl": {
+     "bytes": 2980,
+     "sha256": "e8b121caaf095191282331c3f21485e0402b1c7c15670b6cdabbe954f24514e7"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "2bd7b6633d2c95627cca8b216ad2c84057e800778a94e0fa97f3a14f86420732"
+    },
+    "progs/q2gib1.mdl": {
+     "bytes": 8148,
+     "sha256": "1a17417bf310d3069d84123171b258c7ea237ed00c69f02bd5e26c1e5d913d70"
+    },
+    "progs/q2gib3.mdl": {
+     "bytes": 10836,
+     "sha256": "3ae4ca501e6e3042af69bf1c0b5f537849be23e294b060dce17d23f32c30876d"
+    },
+    "progs/q2gib4.mdl": {
+     "bytes": 4188,
+     "sha256": "014d3e1cf4cf1ef1131247c05d95545a9debde4cf38e40fbf70564cc3bdb230b"
+    },
+    "progs/schunk1.mdl": {
+     "bytes": 3392,
+     "sha256": "eecbb635587336bd38f849cd461ec72b282840b8eb3d9551f1c8d87eb284a5a9"
+    },
+    "progs/schunk2.mdl": {
+     "bytes": 3872,
+     "sha256": "55030f999eea0a4b0d0d751e51af28224e1159bb7b05a9ffb90b7a488e9b6b41"
+    },
+    "progs/schunk3.mdl": {
+     "bytes": 3392,
+     "sha256": "76b80dfd7ab8878207b4aac70001f3f720620e0a78ec6249022f333dabee4f3b"
+    },
+    "progs/schunk4.mdl": {
+     "bytes": 3624,
+     "sha256": "1fe18332fb3e4d6330b3bb77bb669dbb9f7b07527c3bbc72e53ab34a096ae36b"
+    },
+    "progs/spider.mdl": {
+     "bytes": 180748,
+     "sha256": "7e8068c8f34d1d1b92f4ca13f237eff560149e4f56e5ae06d4ef7b758fe30444"
+    },
+    "progs/tree.mdl": {
+     "bytes": 61692,
+     "sha256": "f585cc2684a6f031499f5597c9477233d55a4ec2babf642a46dc1f8c6c02f301"
+    },
+    "progs/wood1.mdl": {
+     "bytes": 4461,
+     "sha256": "16bf20036f822962f481368276369ce830177a64ae71c143e218b1f7d919a517"
+    },
+    "progs/wood2.mdl": {
+     "bytes": 2847,
+     "sha256": "a7bef80af5e2ae1af04ae1a7654fca867b89044cb0008c6934991d923a2b4716"
+    },
+    "progs/wood3.mdl": {
+     "bytes": 3617,
+     "sha256": "cd6cad2482192c31552bcfdd0d4ccaea0a126de8e25f8c4b3971977f602394e5"
+    },
+    "progs/wood4.mdl": {
+     "bytes": 4463,
+     "sha256": "9823233c41b58c8d6380e83c0eac5e31ccc2fec9efdf6868b78cebd293cdec39"
+    },
+    "sound/1shot/goatmare.wav": {
+     "bytes": 713482,
+     "sha256": "be38427732d0b8219d4957d8ffbd03d634a919ad04a786ea2ebdc94846e2e02a"
+    },
+    "sound/1shot/squitch1.wav": {
+     "bytes": 80556,
+     "sha256": "e3418629fb987828e919bae2558139b280f71e5e24d77e5ee05ed5a1d6793bda"
+    },
+    "sound/1shot/squitch2.wav": {
+     "bytes": 80528,
+     "sha256": "93968c23a050255b87daf15425d3812cf9d9894270fbba7f85457f3a3eb6904b"
+    },
+    "sound/ambience/cave1.wav": {
+     "bytes": 58476,
+     "sha256": "0759ad526d301c3bb14c467818bacdbe3a64237657c45a435e06cb166b570b85"
+    },
+    "sound/ambience/cave2.wav": {
+     "bytes": 63706,
+     "sha256": "c9c25ee33f9eb396fd9c553cb4da9eebf05f83367f95387c8c3ee21a5ab2d9e5"
+    },
+    "sound/ambience/fburn_bg.wav": {
+     "bytes": 22758,
+     "sha256": "c2159ed015cf92024dd06efb5fd583004e7641205be9fc8e037bb61caea209d8"
+    },
+    "sound/ambience/gurgle.wav": {
+     "bytes": 44252,
+     "sha256": "79e421db998007f05aa30e42f2f7b021303431f9bd42d89cb7bf9807c03b19fc"
+    },
+    "sound/ambience/subaqua.wav": {
+     "bytes": 62902,
+     "sha256": "ee3cc0c0a40642ce9ce22caaaeed6c5bbdd63cf3be461eb430a0e2a46e65f443"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 32212,
+     "sha256": "005616904ebfec049860ca33b790903e76c75615f3048dba17ce8d85cd6c65f5"
+    },
+    "sound/ambience/wind3.wav": {
+     "bytes": 47692,
+     "sha256": "b2fab4abc53a105484a21e9f9442076805dc0cf806d07ab7dcfad3e0f3ddcf2f"
+    },
+    "sound/bdwsound/basss.wav": {
+     "bytes": 302444,
+     "sha256": "75682a08b790af46c2b9f746e5772999ba1de333b567832f4a3a8414c6a0185a"
+    },
+    "sound/bdwsound/demiwind.wav": {
+     "bytes": 357636,
+     "sha256": "2744eaae8e03367a28a1bdc56f68494eb4cfa325c794d159eff56a2295e12912"
+    },
+    "sound/bdwsound/windmill.wav": {
+     "bytes": 40682,
+     "sha256": "f323d5e1e9bab0ebf7a7c3ace51f3721b954bfbf7a6c86e9b9df6c3b271bf6c6"
+    },
+    "sound/debris/metal1.wav": {
+     "bytes": 6672,
+     "sha256": "92eff1af875d0bb0538101956b6de55680ecc4e9532cc8b7ee6522e801b95d66"
+    },
+    "sound/debris/metal2.wav": {
+     "bytes": 5312,
+     "sha256": "e9c65c9534173a7ec4c18ddef10e0090bfeb70957d3ce7e4d289410a84c6267c"
+    },
+    "sound/debris/metal3.wav": {
+     "bytes": 6160,
+     "sha256": "bf3a70dd20ebeaac02fece31b962cbcdcb9091924b705a014dabd2d4e3a2821e"
+    },
+    "sound/gibs/gib1.wav": {
+     "bytes": 10682,
+     "sha256": "270c9f71b691904654039d49cca03407a91fc3d600b84e7fff3f8ecdfed94644"
+    },
+    "sound/gibs/gib2.wav": {
+     "bytes": 24740,
+     "sha256": "eb6b1f1596203e69fae5a707160779211a1776503c78d4b811a69205c8028da0"
+    },
+    "sound/gibs/gib3.wav": {
+     "bytes": 21552,
+     "sha256": "de4ca18cf6b6350d30c5b81be02745ff5ec6c3432939ba615affe0ad1fe7cb1a"
+    },
+    "sound/gibs/gib4.wav": {
+     "bytes": 9772,
+     "sha256": "b4fcc19c46a06bbbfb7803fccd33c6971c6fe5bac22299dfb6343d96358664d3"
+    },
+    "sound/gibs/gib5.wav": {
+     "bytes": 7782,
+     "sha256": "a0d9fa598637a4a2de5c2f1413835ad0215cc179de9f59e640b2e59f7c1942ed"
+    },
+    "sound/gibs/gibhit1.wav": {
+     "bytes": 9434,
+     "sha256": "3ee95e544edf6556c3389a5eef9f6cc0a0549e378c4433aa9617441602e3cf19"
+    },
+    "sound/gibs/gibhit2.wav": {
+     "bytes": 7772,
+     "sha256": "56bec98427e268141eae83a5873d12af966f6fe0302af2f84d2ffe412199e484"
+    },
+    "sound/gibs/gibhit3.wav": {
+     "bytes": 5402,
+     "sha256": "5782279b0c75441b2ee2ced9d7df2ac2ce08bb0cc5a451b2d90c20eb4a1aba73"
+    },
+    "sound/gibs/gibhit4.wav": {
+     "bytes": 3210,
+     "sha256": "19168dc337036a3deb524fdbbe965a7b2acdf0f204480b4a43acb80dc37b7a87"
+    },
+    "sound/gibs/gibhit5.wav": {
+     "bytes": 4294,
+     "sha256": "ef5115aca1b19ea0c48bf56c5eec8a6d22e95b6be5426247f58a3ad90c3a00bc"
+    },
+    "sound/gibs/hlhit1.wav": {
+     "bytes": 1468,
+     "sha256": "e907185147dbe42a4fac79c0b73d618c27f00c4edf9e48b23dd0226f8894e7ea"
+    },
+    "sound/gibs/hlhit2.wav": {
+     "bytes": 2170,
+     "sha256": "efdbee496456e118061ef9041c16c9d076aafd8cd055177a89d333014eec8b22"
+    },
+    "sound/gibs/hlhit3.wav": {
+     "bytes": 3506,
+     "sha256": "d70b60b22a44992365349e008b60616eee4097fc23d5dda7424e3b9d2698970d"
+    },
+    "sound/gibs/hlhit4.wav": {
+     "bytes": 2088,
+     "sha256": "d7a9505defc2e6bce40d11bb9e7bfef1b7099d327a856e2347b5fe2ab49231b8"
+    },
+    "sound/gibs/sofimp1.wav": {
+     "bytes": 4776,
+     "sha256": "77fdb4eaf4cd9422c1412969d12d2924024401862b3ef9f5cacb54e3bbe7daf4"
+    },
+    "sound/gibs/sofimp2.wav": {
+     "bytes": 4616,
+     "sha256": "4e885521c3bae0dcf93f7c8478750010d30402f904c459424c769825c0917693"
+    },
+    "sound/gibs/sofimp3.wav": {
+     "bytes": 5380,
+     "sha256": "646b3942e46dcdde73ad1ef6b737faa673e4a961175067e0bfeec37fede3a095"
+    },
+    "sound/gibs/thump.wav": {
+     "bytes": 8682,
+     "sha256": "558dcb80efdbe289c8c10ed9b116edc8d5e147b555b1a6289747951faaf60f48"
+    },
+    "sound/gibs/ut2bone1.wav": {
+     "bytes": 5960,
+     "sha256": "cf2ff12a824ffcbc975e56241ec112354bd970ab92f15f31ec06362ae0b5f862"
+    },
+    "sound/gibs/ut2bone2.wav": {
+     "bytes": 3470,
+     "sha256": "449ea8d8bf17e5ac4c8b91885527252cc070d99a16e7b2c8c43eb5152060ce72"
+    },
+    "sound/gibs/ut2bone3.wav": {
+     "bytes": 5452,
+     "sha256": "f3213b070e3fdeeea707b145dcc0ad0181d67a89693d87c34b6233b2448361ba"
+    },
+    "sound/gibs/ut2bone4.wav": {
+     "bytes": 5280,
+     "sha256": "7069fa9200c816f275c5ab950616481580795bf22099d247cfe12dba5cf7fa03"
+    },
+    "sound/gibs/ut2gib1.wav": {
+     "bytes": 17808,
+     "sha256": "068f6ea04f13016615f9534e74e969a62eda98c7def921df76731c5afbd73cf2"
+    },
+    "sound/gibs/ut2gib2.wav": {
+     "bytes": 18378,
+     "sha256": "274ed4c06d175a7a71dd925b94eedd9c172c6ba833c0a2a1bcde859fb682032a"
+    },
+    "sound/gibs/ut2gib3.wav": {
+     "bytes": 18342,
+     "sha256": "0b128fb8ee1c3946dab688820b032172e1c3281ff9d6552b21d7507a075a5bc4"
+    },
+    "sound/imp/dsbgact.wav": {
+     "bytes": 10068,
+     "sha256": "f7148ecbbb2701c185363b53dde53eb70be18bf9ceac84412e6ac6e7e9e6f4ac"
+    },
+    "sound/imp/dsbgsit1.wav": {
+     "bytes": 13670,
+     "sha256": "542352396ce81183b8164b942e078645bccc4a6b391b40592b330459c14f4397"
+    },
+    "sound/imp/dsbgsit2.wav": {
+     "bytes": 16119,
+     "sha256": "b69e1b6e716d95959345761682b79075d7fdb64e3afd16aec184c238e9f23b75"
+    },
+    "sound/imp/dsfirsht.wav": {
+     "bytes": 14784,
+     "sha256": "3d2d1c510a43e4bdf2a634ad74b587d48c5ad8258d72a232c3a2d1efb3f8dadc"
+    },
+    "sound/imp/gk_amb.wav": {
+     "bytes": 75472,
+     "sha256": "5b5dccca7e3ba16070611b4ee4e3c1bfe9847ca01c2674e6ec0a67aa89e8ee31"
+    },
+    "sound/imp/gk_deth1.wav": {
+     "bytes": 20912,
+     "sha256": "e8eeeb416d55bf6c18db8780cf822b667ae4ff22a29a24b765b8ea3082683e8f"
+    },
+    "sound/imp/gk_idle1.wav": {
+     "bytes": 39494,
+     "sha256": "83c406936f24e4014fb93f964963af6df872920e3d5dcd3921b58f0b6d20ea4b"
+    },
+    "sound/imp/gk_pain1.wav": {
+     "bytes": 6634,
+     "sha256": "a7fae0c331802ee37bef8dc3d7fa2fca4803a2eade63193c9279ab07e64cf850"
+    },
+    "sound/imp/gk_sght1.wav": {
+     "bytes": 17652,
+     "sha256": "f4f5960f9a0fd02ee7a0f0b7246e264a756adacd3c8b14a9c5684328e4e04720"
+    },
+    "sound/imp/pain100_1.wav": {
+     "bytes": 18162,
+     "sha256": "73a4a1dccfebbaae69191919cb04c04a4ae0d686ecc5b2d3d3acf32e92743609"
+    },
+    "sound/imp/pain75_1.wav": {
+     "bytes": 24402,
+     "sha256": "b5231d777bd2488da806806c3fa29c51a47159eed562cce5a851af7c20e4090f"
+    },
+    "sound/misc/bell1.wav": {
+     "bytes": 30872,
+     "sha256": "f6d17fb4d29a21667978d124784b3c26cdba1507d2ea5971d8db3551ed22e2be"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/h2ohit1.wav": {
+     "bytes": 20694,
+     "sha256": "12a512322e5dab9b15dff23a3253b008071868ea8d1632ca2535cbdfda98fbbc"
+    },
+    "sound/misc/metalbrk.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/woodbrk.wav": {
+     "bytes": 17036,
+     "sha256": "c8ae4ed3efe401d58f27ef333aca388851f704b6871cf6da916efde6d438963c"
+    },
+    "sound/ogre/wnalfire.wav": {
+     "bytes": 16492,
+     "sha256": "d4b26734bd9c1f29c657893d62a3d2f084bbeca421f0ab35bd75a453e4720bf8"
+    },
+    "sound/plats/wheelpt1.wav": {
+     "bytes": 18742,
+     "sha256": "a958c1a48242ac02a10a3af018f2d86705dbf6904aa5a6bd90c2f00599ee9431"
+    },
+    "sound/plats/wheelpt2.wav": {
+     "bytes": 8346,
+     "sha256": "2fe0cff30eb82673cbd8dcddf9e04e927f3fc1cfcf921ecdd9c68484e6b4dc02"
+    },
+    "sound/shuffler/big1.wav": {
+     "bytes": 21636,
+     "sha256": "16c1632682aeb4b4075006d5b8b13a7e3f8821b6f59f8eb61ad78308b0d68366"
+    },
+    "sound/shuffler/big3.wav": {
+     "bytes": 25096,
+     "sha256": "2cbbc5dc1249a92b9a31a6f3fa7ff654dd6339511fc99e4c552ad6a34218a4c2"
+    },
+    "sound/shuffler/breathe1.wav": {
+     "bytes": 45712,
+     "sha256": "53730dabf839c183028fbdf909df8ae7ef936828c51c58a957617444872224d4"
+    },
+    "sound/shuffler/breathe3.wav": {
+     "bytes": 50728,
+     "sha256": "fd923c891934046d9770c089dfe16021373a392b429531ef9698fbd2f759c42a"
+    },
+    "sound/shuffler/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/shuffler/expsmall.wav": {
+     "bytes": 8732,
+     "sha256": "18825b9644c01ff0a488887185ac14d6fb4fd983254620009ba3ecc96c44d465"
+    },
+    "sound/shuffler/firefblt.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/shuffler/pain.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/shuffler/slam.wav": {
+     "bytes": 6372,
+     "sha256": "2c6ff4782b389777c98f09fa6ac86e6c75a848ad800db6dc32f8ea9362706e96"
+    },
+    "sound/shuffler/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/shuffler/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    },
+    "sound/spider/death.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/death1pp.wav": {
+     "bytes": 10460,
+     "sha256": "736f0a768c0f52b22a301fc6a15f18f2f60e5579d3b27c2b78bcb7bed8e0c577"
+    },
+    "sound/spider/hiss1pp.wav": {
+     "bytes": 17802,
+     "sha256": "c56fcae8a01af94c07807730857b4b367f2c70c35869505528504faa29a17ade"
+    },
+    "sound/spider/hiss2pp.wav": {
+     "bytes": 22468,
+     "sha256": "7d9ca51e9078dc3b66ce9a1783bef2c2d60587a1c4e1b4ae2571af0294f20010"
+    },
+    "sound/spider/hiss3pp.wav": {
+     "bytes": 22582,
+     "sha256": "1a3c71b1e4ac2389c98c4af9db88e81b51a602c681bd00a1812995654863e2d4"
+    },
+    "sound/spider/injur1pp.wav": {
+     "bytes": 6108,
+     "sha256": "728cd94a64b27dea4d845a9e27e1ba09cfb286bff80128a67d1da0431b6b0c20"
+    },
+    "sound/spider/munch1p.wav": {
+     "bytes": 5578,
+     "sha256": "b3af9e39836b0d5593a7be2ffe786fd2584d8dd2e894c100071cbc5f9de501f8"
+    },
+    "sound/spider/roam1pp.wav": {
+     "bytes": 20922,
+     "sha256": "8a6d25359bbbc1f5e4f6962f4ce1742160537c6bb8bf8b806a0df96adfae819d"
+    },
+    "sound/spider/tear1pp.wav": {
+     "bytes": 10778,
+     "sha256": "6fbbf367e9cc81f50ee8af60fc0621ddb538db62adf9c7873a8cfbe4a07cd574"
+    },
+    "sound/spider/thumppp.wav": {
+     "bytes": 6038,
+     "sha256": "3c46bc58c52a61480c1a8dc2034aa240545521baf5e0027372992a9458796919"
+    },
+    "sound/weapons/noammo.wav": {
+     "bytes": 1400,
+     "sha256": "217c42718548de32b5df972d117ffc1a0e1dde5f03a7a173bd91d0b4551248c9"
+    },
+    "sound/weapons/plasexpl.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/q3ric1.wav": {
+     "bytes": 4910,
+     "sha256": "70f9619ddeedd4e2c73ccbf7aeed888ccf293fe23150b50f3c75bacf7c5d5fed"
+    },
+    "sound/weapons/q3ric2.wav": {
+     "bytes": 11832,
+     "sha256": "295919613b1f9d4a6b4fb74618361870130ce23c54902fb1b6ab3468d52da01b"
+    },
+    "sound/weapons/q3ric3.wav": {
+     "bytes": 12078,
+     "sha256": "59813f27cddcc4fc5e3c8693f653973436163f99fa0be282d5a49f6e3b4d3acc"
+    },
+    "sound/weapons/skotch.wav": {
+     "bytes": 2564,
+     "sha256": "f953f6a75919af7a6947d9c60d3f55ca8cfb851886f1de766a9a53d2070e7ab9"
+    },
+    "sound/weapons/slash.wav": {
+     "bytes": 5904,
+     "sha256": "458fa17f4a55682147371b91fa63db12a9c7f1cdb8415d3d97c4ef70dc0a4f49"
+    },
+    "sprites/blue_exp/blue_exp.spr": {
+     "bytes": 213288,
+     "sha256": "fe99a489e169ccf56f0412c2e83a7c5aea7b75b7cee0501402c62fcbd7ca969c"
+    },
+    "sprites/blue_exp/blue_exp.spr_0.tga": {
+     "bytes": 65554,
+     "sha256": "e701273306728f2f13aeff5632a1d4721fb9cf584e304b8e6d3356253adb78d5"
+    },
+    "sprites/blue_exp/blue_exp.spr_1.tga": {
+     "bytes": 65554,
+     "sha256": "fabb4579cdce97ed16d31849cd118ed705ba439260fd967846c7ec87ee711176"
+    },
+    "sprites/blue_exp/blue_exp.spr_10.tga": {
+     "bytes": 65554,
+     "sha256": "50b363992127422c00bf5bc8b00983399453eb135838ac0662d3310e33fe00db"
+    },
+    "sprites/blue_exp/blue_exp.spr_11.tga": {
+     "bytes": 65554,
+     "sha256": "3120bd7fbe101ae1936f6c974daf631d73b2763b70a7a53a69b1cd23546ac4d2"
+    },
+    "sprites/blue_exp/blue_exp.spr_12.tga": {
+     "bytes": 65554,
+     "sha256": "faa7122c01bff9c720b10f4e630faec0612eccb6878c5ca2decf280721b8127a"
+    },
+    "sprites/blue_exp/blue_exp.spr_2.tga": {
+     "bytes": 65554,
+     "sha256": "97b12bdb5613dd1f93a263922f9beb68170bf8df484985a2705f44128a3902a4"
+    },
+    "sprites/blue_exp/blue_exp.spr_3.tga": {
+     "bytes": 65554,
+     "sha256": "9358cbf83e3cc950aa70c4dcd7b58343f6050749b12b2c1d298bcdc05e6b4928"
+    },
+    "sprites/blue_exp/blue_exp.spr_4.tga": {
+     "bytes": 65554,
+     "sha256": "9d9246a2dd136cdff09cb164a94f3e3339327282a19fb706fb8fedcebd260038"
+    },
+    "sprites/blue_exp/blue_exp.spr_5.tga": {
+     "bytes": 65554,
+     "sha256": "e016212932edbc7c9b48e74e08e20380ccc34325e53c82cfc58ab40d0895c738"
+    },
+    "sprites/blue_exp/blue_exp.spr_6.tga": {
+     "bytes": 65554,
+     "sha256": "be6fd0ff2159b27d82e2291c52b4c1f9e38c82de90a85ec588f9febda98453a6"
+    },
+    "sprites/blue_exp/blue_exp.spr_7.tga": {
+     "bytes": 65554,
+     "sha256": "e844813bc2941eb86d3d13afb6f74ef2e8a3505339e4b1aba261b28b2eb6913c"
+    },
+    "sprites/blue_exp/blue_exp.spr_8.tga": {
+     "bytes": 65554,
+     "sha256": "07d8c3df60ae468868357a38033cb83c287a248881b2a8935d4c82d711150d16"
+    },
+    "sprites/blue_exp/blue_exp.spr_9.tga": {
+     "bytes": 65554,
+     "sha256": "ba5af001e3d42cd6e34734acc941a61f197ad158f4ad137b8c826dfb91189775"
+    },
+    "sprites/imp/impball.spr": {
+     "bytes": 6308,
+     "sha256": "7297fbdac1c592ba4b3a575b11a99f5e49eedffc76cced7fc53a5a8adc8808ee"
+    },
+    "sprites/imp/impball.spr_0_0.tga": {
+     "bytes": 12332,
+     "sha256": "5bbda99c4170f7a547255b766dd70d9cabe218de49a2d1d8d568338e566beb6a"
+    },
+    "sprites/imp/impball.spr_0_1.tga": {
+     "bytes": 12332,
+     "sha256": "aa972603cba8a0d69b269564683128366fb60f47e51d48a7ca5cfde9fad31c00"
+    },
+    "sprites/imp/impball.spr_0_2.tga": {
+     "bytes": 12332,
+     "sha256": "2409891736de545ebb596b22d681c16f2ef876940a68b6f29761e8f922ce91af"
+    },
+    "sprites/imp/impball.spr_0_3.tga": {
+     "bytes": 12332,
+     "sha256": "61e1f6da8d46f4f2b20c489cc67cbd11cae544733ced3e23279856728829fe26"
+    },
+    "sprites/imp/impball.spr_0_4.tga": {
+     "bytes": 12332,
+     "sha256": "7ccf7b8e0fc4fbc4c0f86d1f9da1fde8d022f93ad7cdde705aae182dd12eed4c"
+    },
+    "sprites/imp/impball.spr_0_5.tga": {
+     "bytes": 12332,
+     "sha256": "57bf40342d9fe00fbf51ecd39b1d89fd85c6ac0b0dadb85b16fee2a7e9329f40"
+    },
+    "sprites/imp/impexp.spr": {
+     "bytes": 24732,
+     "sha256": "76ee636f798e401975d75d6ce3eed424195d86151d4f197412dd4f81d47d65be"
+    },
+    "sprites/imp/impexp.spr_0.tga": {
+     "bytes": 49196,
+     "sha256": "5370bedf7b96dced77630bdf68522605cbc9dfa84a169920c02526408ca2638f"
+    },
+    "sprites/imp/impexp.spr_1.tga": {
+     "bytes": 49196,
+     "sha256": "d5be7206700f64b32603ed137bbb0433339a42a7ed6a5c0f786f8af441a805c5"
+    },
+    "sprites/imp/impexp.spr_2.tga": {
+     "bytes": 49196,
+     "sha256": "1f358f20103d7abae4205bc1c4687bf09a56338346d7268060936104afee3138"
+    },
+    "sprites/imp/impexp.spr_3.tga": {
+     "bytes": 49196,
+     "sha256": "d6350a1c10b19efa0a4839a4ab97aa10c9bff89a65b6f615a3616ef86e1e234c"
+    },
+    "sprites/imp/impexp.spr_4.tga": {
+     "bytes": 49196,
+     "sha256": "a36f0daad5eadac84c52eb5b51a4f6f3f0cb0c56cc8b77782b9c906487e5cbf0"
+    },
+    "sprites/imp/impexp.spr_5.tga": {
+     "bytes": 49196,
+     "sha256": "29b4d7a01f0177a7a6ff69eaa7912e96d47e6cf02af9112f66f7d2785b2c5ea4"
+    },
+    "sprites/misc/s_null.spr": {
+     "bytes": 57,
+     "sha256": "dc67fb2f31bd717353b8138f02bdc8ef2d70ace433c9fd91e3adc909fda513a3"
+    },
+    "sprites/misc/select_b.spr": {
+     "bytes": 4220,
+     "sha256": "d8c9af8233049df696ce2d851ee6429d17056dc23c92668017ac1b1cc3c891ed"
+    },
+    "sprites/misc/select_r.spr": {
+     "bytes": 4220,
+     "sha256": "1489b5a153cdcfb3e200a5e925520ced638d8d147a6bf332dd991258aab1ebdb"
+    },
+    "sprites/misc/select_y.spr": {
+     "bytes": 4220,
+     "sha256": "9fec23a2ac82c79be45731f1dcc8b13e0d9b4e92726d1588094d69bff8e7ae73"
+    },
+    "sprites/starb/starb_b.spr": {
+     "bytes": 3620,
+     "sha256": "4d09e772f240bc7507ec4795845e2b28b5bda160df10e524c7a0a2fee203807a"
+    },
+    "sprites/starb/starb_b.spr_0_0.tga": {
+     "bytes": 6956,
+     "sha256": "d029db1ad6c659c8328d4954f0b646380201f0630760f1990311f18128ea1c4a"
+    },
+    "sprites/starb/starb_b.spr_0_1.tga": {
+     "bytes": 6956,
+     "sha256": "8eddc6431393d8c25e9d73a1e01e20dff1738917923c3b8e20c8fd7085b26633"
+    },
+    "sprites/starb/starb_b.spr_0_2.tga": {
+     "bytes": 6956,
+     "sha256": "4dbe4d1c44cfe304fb8da58a3084373d5a0a489d88c99683ba98c7f140fe4ebe"
+    },
+    "sprites/starb/starb_b.spr_0_3.tga": {
+     "bytes": 6956,
+     "sha256": "ef31c793c9a0fc7fd66aa37529f0d6c933218e48c642bb3c1edd37a31537e443"
+    },
+    "sprites/starb/starb_b.spr_0_4.tga": {
+     "bytes": 6956,
+     "sha256": "033c663fae38e4bfb46e71513e3f7657e04e7c340af81d876eca279a08ed89a5"
+    },
+    "sprites/starb/starb_b.spr_0_5.tga": {
+     "bytes": 6956,
+     "sha256": "4a886a73c0749d154c81ed3a8e735e29ee545706268a2d64de19bc25b3bb35e5"
+    },
+    "sprites/starb/starb_eb.spr": {
+     "bytes": 11656,
+     "sha256": "dd6451332d5f0b472e98d82636bbcd43d38172ba62ed5b68233fc43467d91d08"
+    },
+    "sprites/starb/starb_eb.spr_0.tga": {
+     "bytes": 27692,
+     "sha256": "b3d62a0f34ce72ea91ece2159b24774ae7e31cbe5ff472100704d1a5cd63417b"
+    },
+    "sprites/starb/starb_eb.spr_1.tga": {
+     "bytes": 27692,
+     "sha256": "87fc03da003f61af09863a66cd15d9009a6c1f1e1aa5bb8f129c2c96faddb1c9"
+    },
+    "sprites/starb/starb_eb.spr_2.tga": {
+     "bytes": 27692,
+     "sha256": "550b2e8c32d237b0d33743d291150b82b5ff8691a43941a0c665eb6780bfe66a"
+    },
+    "sprites/starb/starb_eb.spr_3.tga": {
+     "bytes": 27692,
+     "sha256": "d9a024325c4e0e9eeb0db48bd413c94e8470a8e59c7248d71c78d9b204f7d367"
+    },
+    "sprites/starb/starb_eb.spr_4.tga": {
+     "bytes": 27692,
+     "sha256": "229fe6cad18b9322159f02383b6f8030b30ecc37cdffa35b0b234ba26145368d"
+    },
+    "sprites/starb/starb_eg.spr": {
+     "bytes": 11656,
+     "sha256": "63dc20b8eda63a1e7bdef0280ce5a6bef35ebb7c6fa0e09e7ca32bb5729e8993"
+    },
+    "sprites/starb/starb_eg.spr_0.tga": {
+     "bytes": 27692,
+     "sha256": "af557889c32cb1bcbab072825fa6365a6e6d93d2b62f6481f177c6dc08b6a4e3"
+    },
+    "sprites/starb/starb_eg.spr_1.tga": {
+     "bytes": 27692,
+     "sha256": "a385232fb2d5fab52f31fdc1fa915d58dbf4405eda2c8b9a5db2f4a21d28f75b"
+    },
+    "sprites/starb/starb_eg.spr_2.tga": {
+     "bytes": 27692,
+     "sha256": "e71b287f88a6cecb2d73b472a3ba055c10dd1ba66f01ae279262789e923354d0"
+    },
+    "sprites/starb/starb_eg.spr_3.tga": {
+     "bytes": 27692,
+     "sha256": "d135bd7f453b5b60c64c704d7641c7889a12c0ceba2f3405436042afbc4614cd"
+    },
+    "sprites/starb/starb_eg.spr_4.tga": {
+     "bytes": 27692,
+     "sha256": "05345f8b4aef4bf97060f6f40006057b9bcaca20c8b7e5433cb70d4342716b9f"
+    },
+    "sprites/starb/starb_g.spr": {
+     "bytes": 3620,
+     "sha256": "a81ff819b478a5f3e25b404f7de06a180c5cab322c46a4664489879289bd7fe2"
+    },
+    "sprites/starb/starb_g.spr_0_0.tga": {
+     "bytes": 6956,
+     "sha256": "ba9b0efd8c06c70be58bb93755e71dc3697d62d7b797fa760cd74cae8023e3ba"
+    },
+    "sprites/starb/starb_g.spr_0_1.tga": {
+     "bytes": 6956,
+     "sha256": "169bb4ddb46bee7ba6e52bf50ab6585ccfeb2e2ba6d57a34277554a7abf97c36"
+    },
+    "sprites/starb/starb_g.spr_0_2.tga": {
+     "bytes": 6956,
+     "sha256": "63f3d68cd97d90748e14e43e17dd622191f0c3f419961334dec04f85f3a89447"
+    },
+    "sprites/starb/starb_g.spr_0_3.tga": {
+     "bytes": 6956,
+     "sha256": "8f2725f3e0f74ac6fe98899bb7061fa06a11868de61e82393a405d01ed11863b"
+    },
+    "sprites/starb/starb_g.spr_0_4.tga": {
+     "bytes": 6956,
+     "sha256": "a90770ccca06eb3d220d45b0e6a971ab506b8c421af6381fc41efc0b132221d5"
+    },
+    "sprites/starb/starb_g.spr_0_5.tga": {
+     "bytes": 6956,
+     "sha256": "6df01fead59b6eea56836c8fd5e349bee440648a1b72c20b7295c0828764c972"
+    },
+    "sprites/vortfire/vortfire.spr": {
+     "bytes": 55460,
+     "sha256": "b7893f5b894b7d2181efcf3ba97c43b23c9205dac6f8a230de6a29ca6919145e"
+    },
+    "sprites/vortfire/vortfire.spr_0_0.tga": {
+     "bytes": 110636,
+     "sha256": "a1c7f2fe56caa4849c2500ecae05b977f1543306243ebe4a837354d104eab962"
+    },
+    "sprites/vortfire/vortfire.spr_0_1.tga": {
+     "bytes": 110636,
+     "sha256": "aac0244f2e593b76b9ec7f33dcb6ec86dc9ce14b3e06bded01198e4bc2dae3d7"
+    },
+    "sprites/vortfire/vortfire.spr_0_2.tga": {
+     "bytes": 110636,
+     "sha256": "90ee481bc37b7aaf337374433754d589509cfca704b2ec5d41cdb7957276d17b"
+    },
+    "sprites/vortfire/vortfire.spr_0_3.tga": {
+     "bytes": 110636,
+     "sha256": "62dc246d470586509259c819d35fdbdf7de54bc6634ec2d72bb70ecb05000795"
+    },
+    "sprites/vortfire/vortfire.spr_0_4.tga": {
+     "bytes": 110636,
+     "sha256": "cce1fbb15e712ad5dccf27f65703220a51a1a7d99726530755dd1724882aa95b"
+    },
+    "sprites/vortfire/vortfire.spr_0_5.tga": {
+     "bytes": 110636,
+     "sha256": "3d83952a6a0ecfbcbf6602b2cb525ebba9b91b3a8c0c69398b59c78b056e65ec"
+    }
+   },
    "sha256": "1a2e5d692de45366a307029161d8987dde70f6a08040310ecc7d154f5599e77d",
    "timestamp": "2005-01-09T12:27:42.000Z"
   },

--- a/json/by-sha256/cc/cc9d348b4a116ce60cbaa89c8deb2b95e9e0ef78c0a26a297d7ad5a7927e0317.json
+++ b/json/by-sha256/cc/cc9d348b4a116ce60cbaa89c8deb2b95e9e0ef78c0a26a297d7ad5a7927e0317.json
@@ -77,6 +77,2468 @@
   },
   "rotus/pak0.pak": {
    "bytes": 36834524,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 52014,
+     "sha256": "a161f873ea245634b66c07454afd1bf89615e42081727ad71ac421573de2a2f5"
+    },
+    "gfx.wad": {
+     "bytes": 210484,
+     "sha256": "9072806ee7e43f2ce712cbe7bd68355dd659447258c7e35e1005d71df7ad5baf"
+    },
+    "gfx/bg_ammo.lmp": {
+     "bytes": 1928,
+     "sha256": "754dc8ea867ba7dcd60407764b51a1eccac068456c38787744387a4c59cbce62"
+    },
+    "gfx/bg_runes.lmp": {
+     "bytes": 520,
+     "sha256": "6b69fad1c89ac2085dcc7b8153d1f19ae353bbd0572b05aace1afc02e8e984df"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "6072bd63a691625de201f3f3da060b5df433753d7ac2878c48b87e9d0dd08b94"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "ac11a967228e1c7d1a936859b82807cea239d80380fb6204d67af7a86c5c82e3"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "4cb99cf1b515b6547f012b6e44174c245261b058168a8bc4303d08b98e1805b6"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2c37b7697aebedb5bbf6637d4b8e158f70da6b7245195ff0e91a6ba7aa24e828"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "219002fe962a017600a37dcdcaaa0f777aad42044619f945cb70c68007763a97"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "e251893ed49aeb677096d380d4246907a039e0e21a4849f97f343b0b13faead2"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "64ec646cbab7ebca11f6af4f0b75d9706f438baa7b23059de87f8685f4686640"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "03c7cdc618e4404e2b9364c690b0a447b4be99dc5af112c66e6e2079902c76cd"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "9cf2683f2a6d22693a8c0cf35898bc5900a96afc771878df9f8a8a88f3d581c9"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "f232da5cf35acc557f3f312911e6a856cffaaf9f8078ca2ac5ef7e6f6e5e3515"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "b57ad9ad9d6240a0e035ca7a64e706e3031b8293c27355c9a95495a84972af4a"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "873af58b7244d6e82feb1af26ac044c9beb43c2865bc51d0485054a562ce861e"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "ba75badfe057b499d33168032dd5dc5a4fd0dcbaef9cbbd27efdb3f056cbfc00"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "55ac1377921460aeb691f86e7a5051e3a5481f24b93cc8578cffdab2854ba0c3"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "9600a66391996cff88d48890adfa516660fce6a32397ba4f54973159785cff4b"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9f03351fa7f31a23b63e6c13d2a643ed1ae3fd3df0cf2b0db336424eb17016dd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b7617428e8d1d74be7b770ef24c744d16c2503efce9c17facf1107cce08f5ed9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3036afb422cd299cb09532a20847ef35aaf87bb36e34ce9ce75b5e7aaf9a1ec3"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "7aa61257bd3083c00959776eb36aac86a7ca8da2bacbb4c8a41d9a5fb0b1ab97"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "cfe83953875acfe9afda11b75407ed9883eeb284b0a67b9ff6e07df85d50d9fe"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "d3b4091b83837da5a45445cd00b90267c62050e010e2a045461034ac9c48be33"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "de004dcecdff1973597a977ab63c671ad7d3f52387bdcff4be560924e3d4d17e"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "078c56d685ff1fb84b322f7a76e485c2637fb09efc61f4e44d5d067b3ef9a42d"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "9df9672c8da61ae769409e9ea741a1b8f9a4f108b5f0fa6637ff65601c535843"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "fef6b9be45d5b384d061a47f133075d1cfe0b60d93cf7e3da9ee5529f661964c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "1b1254c1f5764affca85448c4a3c2fefdb938f35bc50f44142a8e9b692ba7d64"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "39a06ff92831e1e2fd20c1bdd20e0f234cd0b3aed94e6c9909d059a20479ce3e"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "def061c922fb91a7e58850e89bb6baa9e09dcf93de7a94288a90511ecd9a114d"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "3220d953bab793165178f2666e67032398a6bd0e0510f6b92eef4fcab377ee1e"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "f897535531fe4b821d41d859a4085fd7d25c679493645a2ef7448f62073523c4"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d070636562a967d1abff330dcd1ea504ac7b9b29099a98994add1d9ae47e44e9"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6d92547a27d839f3c9d7a1da786fb33547cd93b7f19560b6c4bcdc12064545bd"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "e932416c58fc5de16e6d05aa737e56d3811e540bfd9e6acd1bf114ccd8bf34ac"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "bda55d4b2d7bc3f180dafd62424ee5830896563f5a5ac576dfa08894f5e17e44"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "513955ecc96eb1f0d44b340b47f79c02bb7bfa7f3b0a884a65fe111429ddb2b4"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "2faa4c1f61d175ad28b7f54540af3f87abc6e56dc20f2da5fc8a7737a0302c97"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "dcfe5287432b3a1124d032250ccc4bf25c73540521c77601ab746287ef3a0179"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/skillmenu.lmp": {
+     "bytes": 14408,
+     "sha256": "dbf40f0e5faedb181e84d4a822ecc9316711ae89530a30bd50cf4fba45aa8251"
+    },
+    "gfx/sp_maps.lmp": {
+     "bytes": 2248,
+     "sha256": "024bfb2d05f1c52bab1a856cbc532d06fdf4e8d96fb486f74bf451472311ebcf"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "00654b7bec9981508cd9ae8eac167637926c023e7bca011a3cf37585b7e168a8"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "74c50b895f1e71ec6a569fba0e991fde8cf136ea734d6914435aaf9b2735d7fe"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "aecab7a199a4db72242659e6d1ced192d39b2619f67c7e5eaafa72a5efef3aef"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "d075eb0c8c00d30b01eae539720c20b73bb57066c6ea5e8180a4d851d9167add"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "d03aa05e24552d961ea9ca278d743860e34a97e2ffcee52fded05ad4b4740bd9"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "maps/wood07.bsp": {
+     "bytes": 7135,
+     "sha256": "8e07e7e5f5b641c644d28c9c4026efc95aa50345074f5c42acd39a3b94261344"
+    },
+    "progs.dat": {
+     "bytes": 1192866,
+     "sha256": "127f8b118c545cb7cd5ae2c74dbfec5a58c1a3bc5399f1b821893f053ca38fa3"
+    },
+    "progs/alkturret_base_v2.mdl": {
+     "bytes": 87768,
+     "sha256": "4b1969201052a4506509bb606eb7c395daf9332cf4605036ab50190495dcfbf3"
+    },
+    "progs/alkturret_main_v2.mdl": {
+     "bytes": 116620,
+     "sha256": "11a2564f7daa19625e4514c284650242c8b3831df947f183243adafb958a1333"
+    },
+    "progs/arachnofloyd.mdl": {
+     "bytes": 741212,
+     "sha256": "554bd2ad34a830fa01a61dd4972f432812fb61f7815ec81d8a8d7e87bfad6b02"
+    },
+    "progs/arm_foot.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 164224,
+     "sha256": "35314143b9c7a9a0e26e52a865072a6e73862466e640c6bbd58be3075c4d93ff"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 497408,
+     "sha256": "40cc63b599cedb54f04c937ce407e7119c1cf4d5d35fd04bc18f247584e9899f"
+    },
+    "progs/b_p_key.mdl": {
+     "bytes": 5940,
+     "sha256": "051b2e8fa67cae7aa24490a18444400f773d4a9d353542ebf979b0a22a1771ef"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bambler.mdl": {
+     "bytes": 128044,
+     "sha256": "c8ac9dbcf99f0e6efd30496ac414383c26b8d241fbaff56cfa81dfb545dfb0c8"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "698bf740683ad182feae2246526361948be6da2e144f1bd0202eafa748213ec2"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "b662513bc3a8e0e967344c55b536bd33012340dbeb79a8db1281d2c84e36d338"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b2cf62d8e989789bd76e27193b2f5205a93d4172a4e25c89aa1b30f75bebe60e"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigcranea1.mdl": {
+     "bytes": 92792,
+     "sha256": "81f6a5b55d3a585d5e9c73b088d1d20e0fb328707c1539ef41e52c460555f651"
+    },
+    "progs/bigcraneb1.mdl": {
+     "bytes": 21940,
+     "sha256": "e02faff0bb6c84c781f6b534a5a06ac1f977a028fbdcca176be2932f91e9e8ec"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/brz_saw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 575288,
+     "sha256": "f571bdf504537ce01ca2b6a78b57575a36c391f9c786625d880d956fb17390a7"
+    },
+    "progs/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/chain2.mdl": {
+     "bytes": 141764,
+     "sha256": "9334a3ec04716ce0068154bf7abb4c1e3ee6de14fb159982dd547314935d7854"
+    },
+    "progs/cyberscrag.mdl": {
+     "bytes": 306936,
+     "sha256": "868d1394e186b1e7f4fc58134c338a413814723f406fa609e2d7cb87dc2496cb"
+    },
+    "progs/cyberscrag_gib1.mdl": {
+     "bytes": 60500,
+     "sha256": "3db8b13bfa5a5eda07acea695cae6ffb92354053da9bed199ef29cd445317faf"
+    },
+    "progs/cyberscrag_gib2.mdl": {
+     "bytes": 58932,
+     "sha256": "ef20c0de15fe2fc2514c10b0023d14009a4871ed40311077ba107350c313f7ce"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon_alk.mdl": {
+     "bytes": 191716,
+     "sha256": "11f33f19ae0a46d3dcc6c1fee46235fb6ad201456120502b603fe4fb7cee14ac"
+    },
+    "progs/demon_old.mdl": {
+     "bytes": 272684,
+     "sha256": "538d5d01833d6910d4400f8795be582c3427748eb2a162fcec2c17d6707c57e5"
+    },
+    "progs/dog_alk.mdl": {
+     "bytes": 199324,
+     "sha256": "a16e350fcd247908c75ecd0c93e94d3b700b67bb0f66dd45d665d171a55d42b6"
+    },
+    "progs/dread.mdl": {
+     "bytes": 415072,
+     "sha256": "dcea570331c5cf4348c40451c6242bf35ecaaea2a348f12254a13c1b76b13d7c"
+    },
+    "progs/drip.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17284,
+     "sha256": "444692074359310be0520b1caa057ae2e084df826f7ecc9bcb0d258ea1d80373"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35988,
+     "sha256": "91aa79805577466147bd4811614b0387b3635aba8383fc2e16b178d7b63ebdf1"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42436,
+     "sha256": "93839bd6f50323f7ac5ae46037de0c6a10a533374f714229dd511ee62b88ca3c"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bcc6396dc638003480dba8c36cafaf32df2cfcf49bd460b001d0d74a164f9011"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/enf_gun.mdl": {
+     "bytes": 58684,
+     "sha256": "39ef1788b39a15f86c8d54b81c43f4126e8361ff80d386c44358f17ddc93769f"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 450424,
+     "sha256": "ecf603c4ebc56438e96d1706a451af8bbe9b090db9c48e38e758ec630a393570"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "ddcf759804fffd97e62c55f67f962e24e8cd646fd982215ac8aefd3e49f67660"
+    },
+    "progs/enforcer_alk.mdl": {
+     "bytes": 333860,
+     "sha256": "85fb5cb9eb1435da65ce0aa6940241b7b4b5fa13e7444713a75c6ec301cc8b97"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish_small.mdl": {
+     "bytes": 221279,
+     "sha256": "34b883e3bf73a520f301cced68629e0d95e88f96c03a23230f12d02aa49c247c"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flag2.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flagbig.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 451032,
+     "sha256": "1a311e7e74f9a67c9f7468252aedc8c19804f65375d229e90afbec2f93849823"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/fromitz_still.mdl": {
+     "bytes": 6964,
+     "sha256": "63204597e828e001c957e9316878995e161da0502764276b90285accadf6a222"
+    },
+    "progs/g_axe_alk.mdl": {
+     "bytes": 50460,
+     "sha256": "92988e970870f2b977f7490d2ea4ee040d338fa4bdc470e8d68f2e5a856a7a28"
+    },
+    "progs/g_axe_alk2.mdl": {
+     "bytes": 50460,
+     "sha256": "e448b2a7540ba959453592b2472d0ae498142a77242c91fd5991ca23a7973f4a"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_mine.mdl": {
+     "bytes": 37780,
+     "sha256": "5057c7736e8c722270c781e47584972f42e7ebdd5860596403a9ce7688d0b5cc"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "15f390e39e02c8524e575ca8fadf63187b641c58210ee9587b13a0ca94c29cc2"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 199076,
+     "sha256": "7ddca6fb95082d0cc7ffe5aa3ba896ea987a80b1bd5867db97b2a84b9d8da9f6"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "8b05b8ca87ea867c2a2397d238311fda2441f5c0e1cde130ba487b0dbd17a8e5"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_arach.mdl": {
+     "bytes": 60292,
+     "sha256": "daca6412383bec28809cee42c4ebf01085cf83ed6ff289114ba0f842b4005251"
+    },
+    "progs/h_bams.mdl": {
+     "bytes": 37316,
+     "sha256": "58c4644a2ed3e5f10741dff2ad1a8bb161f7eb205ba3fd8c5fc9b7e4ffc571dc"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_cyberscrag.mdl": {
+     "bytes": 62036,
+     "sha256": "df7d6bccc97bd5c184d9d6160005b370175aacc16a34bd06ab14c7d69ff60419"
+    },
+    "progs/h_demon_alk.mdl": {
+     "bytes": 72644,
+     "sha256": "22a9e01cdccb2e274c63c277e6dcd61986fa7556426ee3562fe11af2babea289"
+    },
+    "progs/h_dog_alk.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_mutant.mdl": {
+     "bytes": 110240,
+     "sha256": "f1f9c665b659a8c145550605ef9abddf27779d0917c897baa344d65673770875"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/h_sabrkn.mdl": {
+     "bytes": 11828,
+     "sha256": "050fcc93189211aba943674a326ddd898dc980b83fb551ee11fec3dd39973483"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shams_alk.mdl": {
+     "bytes": 37268,
+     "sha256": "9fcace6cfb38473763a5cf96007ccc5e0ec4786352d4d1063410d63157298b45"
+    },
+    "progs/h_torm.mdl": {
+     "bytes": 62056,
+     "sha256": "db0ddda0c4d2283cd3c58eb45397cfb57095acba1eb6dd38571ca23ebffe9946"
+    },
+    "progs/h_wizard_alk.mdl": {
+     "bytes": 14948,
+     "sha256": "5f6c27ba255b87718d993b29cff526bd025c0e7a4991722a96fe3c0f98d83408"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hknight_old.mdl": {
+     "bytes": 418144,
+     "sha256": "40bd5757499a2bf7e6f60a78b0039665107c9603c2557f6bc73208e080111464"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 37012,
+     "sha256": "e3c6cbabfe6c6723101f2e59f50fc99ee0e360571c95885d2d56c85eefade15d"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/jumpblue.mdl": {
+     "bytes": 37428,
+     "sha256": "be4e85e5fc643e91377d69794b997ad4dc927ae3866dfef5288d704dbc0f16d7"
+    },
+    "progs/jumpgold.mdl": {
+     "bytes": 37428,
+     "sha256": "4c543d82c88009cab7fcf6230feea0a21518a98f430636194fdbf5c1e526cc13"
+    },
+    "progs/k_laserspike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/kamikaze_grunt_small.mdl": {
+     "bytes": 203376,
+     "sha256": "550aaee63a82db7de25eb3329c368a8bf98ad0aee8af169ee41a857d9087c0f1"
+    },
+    "progs/knight_old.mdl": {
+     "bytes": 208068,
+     "sha256": "5cca43e29392051c9ba95838a58cc1038560411e6c0d2aff61867a428b119e2a"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "63220c0ebb6e266576cb3107a44be16bda10d69fa524d0462514edff9d80328c"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "29bc55efafbea3e15a385598750ba4d9242d0a87803a6bc3430ed772ec1785c3"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "f1e799e7feac3c340676bb60f6cc7a2a7d1e121b196d1f6d0e23edea3a614ed6"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "92370f5b196dc00460d73697975d14279ef659c87c7fc1613b9cbfb68e6c299c"
+    },
+    "progs/m_p_key.mdl": {
+     "bytes": 13428,
+     "sha256": "581a23ac3e2bf0960a7a8b1c4693efd1913d9d17a1f4fa405a1b8c6d89105f91"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "4c5db792da6876f935f8a98a74f51708d52ca03f04975f28518051494660bf65"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "781837a3557c1a8b89c15fa8f477989cb4b77d8cff09c8c13d071090a4df9c1b"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "2feb7ce08070b314d163cbc7f2e2eae0986400c482f752d305ddba268639b3d8"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "04f7fc8b0c2be7ea93021819770145eaf828b2313c4fc591a5f2aa783ca97e61"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 8372,
+     "sha256": "9b6a8f7a49fb7a1f5d4d409b708663c579d433e978d898b9bdf00291a59b4e6c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "fa5d7a5e2410ac7faa5dd0a8e17873c972c6e5cfeacc94118f22db1b4b17477c"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/mutant.mdl": {
+     "bytes": 352720,
+     "sha256": "262ffca22e0c7308950076c2789436a891399862ea25afbd06040158ec9f7984"
+    },
+    "progs/mvore_bomb.mdl": {
+     "bytes": 12653,
+     "sha256": "dd54f975b770db899ef71174d8b05cd98af99739e9506fc4eb354ee8d7e820b8"
+    },
+    "progs/nephrenka.mdl": {
+     "bytes": 807192,
+     "sha256": "e1efdf4467614012164148e6af70c5a3076438e990fc1f48bc4fafb49f681340"
+    },
+    "progs/nephrenka_shield.mdl": {
+     "bytes": 807192,
+     "sha256": "5c7a3957118c7c7370ba1b7ef8fe00b97813bff193dda6ed2c7029e72d8c1c70"
+    },
+    "progs/nsoldier_alk.mdl": {
+     "bytes": 563108,
+     "sha256": "6071d7cecf231f0a83f2e1c7df533b4a32beb6e75969d17703446a67d011695a"
+    },
+    "progs/ogr_gun.mdl": {
+     "bytes": 52452,
+     "sha256": "eaa6e0fe01255450d578f151c06c5aeb6a9cd5ed90edbbe4f52d305069ed6825"
+    },
+    "progs/ogre_alk.mdl": {
+     "bytes": 315696,
+     "sha256": "31e9986373dc1a8cba00e09ba9b0278cf766bbd074524a891ed22329f697d643"
+    },
+    "progs/ogre_old.mdl": {
+     "bytes": 315696,
+     "sha256": "53317e9b684701e7722bea342af1a6dba5dd31e72cdbcfa5b097382516d1c6a3"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 487968,
+     "sha256": "ae0abff3ea3fc7ca8c7f80c5d8825553795a1c1ebb80127d46fa52b20905abc4"
+    },
+    "progs/ogrem.mdl": {
+     "bytes": 378296,
+     "sha256": "2bb999bf580d16fb9ee4246dea7897236d6d118232c78a6168f641dc32778fb5"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/pellet_tracer_short.mdl": {
+     "bytes": 58148,
+     "sha256": "5b24b67ce9d9b2634d9a0f31319a977e1e3ec6352d491367941a0e5bf2ae10ff"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/probegren_body.mdl": {
+     "bytes": 139044,
+     "sha256": "da0ddf337c3e2515688f2b143adf55d4ecbbfa32955a78aea01ed16e067b0065"
+    },
+    "progs/probegren_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "4f292b6f157d226e763ff28dad682ce95cfb8a3a21b4badf0ca48db4900cdd70"
+    },
+    "progs/probegren_gib1.mdl": {
+     "bytes": 63788,
+     "sha256": "0efb081efa87c9db990d984f9974f10078890a51894a3e0a6fbe76cc3c4cb5a7"
+    },
+    "progs/probegren_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "7843ddefa22b7d5beb37f889c606c6361792508c2bea202f3dadf9f3ffce73de"
+    },
+    "progs/probegren_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "7baac250aa8c27ef3158de59b536ebf59509e39b1f7bf6be1c24fd5b1e29cae0"
+    },
+    "progs/probelasr_body.mdl": {
+     "bytes": 84296,
+     "sha256": "ac545d0f545488628c864df6e464d10fbd51cb41a2cb76c46dd91233ecd11a6f"
+    },
+    "progs/probelasr_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "cec7b847c9b05f2653113454348799b9bf09c2a74c8e1760cca0ff52c1dfc18c"
+    },
+    "progs/probelasr_gib1.mdl": {
+     "bytes": 58700,
+     "sha256": "ae9f298abc0bb1d09cea3c04bf02216b0a1c3749f8c8a822d973b4c2091cd649"
+    },
+    "progs/probelasr_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "07d6defee5ce4e747daf8b397a5d207a1a42e3c3acffbdfc18d6720c88ec635c"
+    },
+    "progs/probelasr_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "8b8f376afa56e7a9f311e58a076f1fa3a52c88064887a8e0960fdb6daaf5265e"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12653,
+     "sha256": "162632bc16838f66f29e0b788845a6421b7fce708003e9fa6f4eb8ae7aa8e5be"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/rail.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 200152,
+     "sha256": "a564fba381d24e3084bc9aa0a026381c83e6b889632c8bebdf69c08c8a6bb9f2"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "f65ba83d82e90808af589ded17378f1baf37f105fa14f2b157227ee22583d25d"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 288,
+     "sha256": "6ff2797f9dc4e66f2113475a5f3e0e96f23dacbddd18fe47c8b5e12e712f0e75"
+    },
+    "progs/s_bullet_new.spr": {
+     "bytes": 708,
+     "sha256": "a07fa61f4a838ac9ad8ec85ae525d70fb934d383effd1948c0775497be713043"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "b3f1971bd28f96c623c5712e2a47f54f16c99a50d460a944cdcdf29e6eb03963"
+    },
+    "progs/s_exp_small_2.spr": {
+     "bytes": 201720,
+     "sha256": "f7fdba9e2b9b5d318cdff33a06fad4e91e46ba3a241fe7ced4bfbcf0bcb0e873"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_plasma_new.spr": {
+     "bytes": 13980,
+     "sha256": "5474060e55af3c462d0ef7aad043f331c1f5b642915d906c1785bb94595cc68c"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 2820,
+     "sha256": "ea66402d248232b0b6a77bffe024d4a62881be47becf37acb42328661b7f23ef"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shalrath_newer.mdl": {
+     "bytes": 228496,
+     "sha256": "93601de7ff47f552ac9d441ddf1faf312417ca914de99529b17bdf7522e7478c"
+    },
+    "progs/shalrath_old.mdl": {
+     "bytes": 211576,
+     "sha256": "409cda15df7b271bd95a895f058a521d43eca63f37c7ac9df175e5b478229bb9"
+    },
+    "progs/shambler_alk.mdl": {
+     "bytes": 502148,
+     "sha256": "bcf685fcd1f4062dc382924d39eae073fc4d44cd2dcb5bc4ca3797fe0b342b71"
+    },
+    "progs/shard.mdl": {
+     "bytes": 10132,
+     "sha256": "0219a0f08bdc1f604ebe1ea2243cd1b27a2b1ab85bedba3a11298f2d22e9b38c"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "662d6a7cd68bca7a9c5e88838d190de6a501252a14b6994a191d0bc91f1f331c"
+    },
+    "progs/sknight.mdl": {
+     "bytes": 460932,
+     "sha256": "9213f6898a60cdc20a7a144c61c13f8d64f1432382dca44b636524edf737dac8"
+    },
+    "progs/soldier_alk.mdl": {
+     "bytes": 359276,
+     "sha256": "623374e5a553c3d886738c9cc0b22c0b3f3435b3dc1b3f473079a1dd1661fc8a"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spiderbot.mdl": {
+     "bytes": 82476,
+     "sha256": "e85556a194664a5f69e70b42aa863d9e67689a418a3afa51e50816174a6fe8ac"
+    },
+    "progs/spiderbot_gib.mdl": {
+     "bytes": 19444,
+     "sha256": "96ee732ac1199a89c675880700c24e1f09521c35ad478f73aaf4278a398454f6"
+    },
+    "progs/spike.mdl": {
+     "bytes": 2820,
+     "sha256": "783d711b408498dbb34581c9a0ae74ed325dc5c68fa67873745b02c8a926a201"
+    },
+    "progs/spike_old.mdl": {
+     "bytes": 1684,
+     "sha256": "5e3be5dff13ec94951aacbd4a453dcbd9c2aebe7e4e6bded2dd70d49d1ddd695"
+    },
+    "progs/supbkpack.mdl": {
+     "bytes": 44408,
+     "sha256": "781c6b5f424fb58e06b2a84b1fb7e980778decde6b3ed257e224db0b1f250173"
+    },
+    "progs/torm_largeshot.mdl": {
+     "bytes": 37852,
+     "sha256": "ce3a87be213e39b48bc71a6fbf5e1fe9e3f5209901ca45801f27d8f297e04a01"
+    },
+    "progs/tormentor.mdl": {
+     "bytes": 461080,
+     "sha256": "df302dea113f54df908f97c26de844d1235004c08aefcf5c349f3af4b0957d41"
+    },
+    "progs/trifecta.mdl": {
+     "bytes": 25460,
+     "sha256": "2c9196af0806c48354f5522a8b7f6fa57e6390f8dfb51718fb71b8a2d4d7447a"
+    },
+    "progs/trifecta_big.mdl": {
+     "bytes": 25460,
+     "sha256": "9633a10c7c20f77b9202befad3cb363aefe710b166e581f80967ad94b5c6b6eb"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/v_alkaxe20fps.mdl": {
+     "bytes": 96428,
+     "sha256": "4405242db772d86c66f1012b140ba409bee86682fa5f4a6ca12c3e6f94eb9fcc"
+    },
+    "progs/v_axe_alk.mdl": {
+     "bytes": 55820,
+     "sha256": "80ad34cf2612f8fa9121f2be0ada92c1e05613ae2b35b2a1be25a4c694dd2147"
+    },
+    "progs/v_laserg40fps.mdl": {
+     "bytes": 142580,
+     "sha256": "b897ecb5868e3125597d51f970075af04782cba47ed8a42d7b17775dff01f536"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_mine_40fps.mdl": {
+     "bytes": 332920,
+     "sha256": "0039956e96a804229359aaf082b9cf66515d52360867b86c3dca884d19caf8b4"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail3.mdl": {
+     "bytes": 124944,
+     "sha256": "19045e9a5154299b68377744ad946fc3e7f2bd290497c8291a2247ed8cc572ad"
+    },
+    "progs/v_nail_alk40fps.mdl": {
+     "bytes": 44692,
+     "sha256": "402b3dc06f1e5e756cfd50cab17cca49e17e261994c5007cfd46c466a08d3dad"
+    },
+    "progs/v_nephrenka.mdl": {
+     "bytes": 13684,
+     "sha256": "a6b22faa92528d6341547677c04b058c3374e2a1b3499ae73861418746c2b1ba"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 260692,
+     "sha256": "0982368440a5d20d65ec511207590c2bfb63e9a60376a5d753b209f2b047c58b"
+    },
+    "progs/v_rock2_40fps.mdl": {
+     "bytes": 139668,
+     "sha256": "89257b7580ac3f48fc775f121eef3508c326eba1369e6aacae83144f8fdfca15"
+    },
+    "progs/v_rock_20fps.mdl": {
+     "bytes": 39556,
+     "sha256": "ebdd6245e1ff65bd95eaed7fa189ac87b51818408f091a32de3f4a477b90f2f8"
+    },
+    "progs/v_rock_40fps.mdl": {
+     "bytes": 43828,
+     "sha256": "f3c32a1c37d4fc3115a8da00ba9507cdd508a98f65e2ddccbcbdc8a0ba0bf2ea"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 326464,
+     "sha256": "dd389cc337d8b7675d9a7b983fd9f53f0c59d597a9759367bd1e1beba375eaaa"
+    },
+    "progs/v_shot2_40fps.mdl": {
+     "bytes": 29076,
+     "sha256": "37ae91c018183faef847aad217da537c97b5a2430ab27a860388bffc1f4514f6"
+    },
+    "progs/v_shot40fps.mdl": {
+     "bytes": 29252,
+     "sha256": "87a47e2debbc27fd6c18a8a38a9a373e7b73ba707458e6346f069c1572df47b4"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_p_key.mdl": {
+     "bytes": 10580,
+     "sha256": "fb3db38e23feda2ca9a8ee1400bdd0b452332f07bf9455db3eac0e52af1e3c22"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/wizard_alk.mdl": {
+     "bytes": 158508,
+     "sha256": "aab430eb2dc0f5c50ca7b4492a7ccc427f2a12011f54ece1b81d4beb66acb4a9"
+    },
+    "progs/zombie2.mdl": {
+     "bytes": 130148,
+     "sha256": "a06c8cff768f0e5491e2a5a0d22671b525d841df7081036ab2d63507eb17881c"
+    },
+    "quake.rc": {
+     "bytes": 2052,
+     "sha256": "b791b9736f5ee57b06dc0bcdc156b13dda9144bb0a972ee5b5069de73c10e55d"
+    },
+    "sound/arachnofloyd/death1.wav": {
+     "bytes": 119460,
+     "sha256": "d16c7ff30e9df62fbcda102befbd61fe234532f6aef30d0b34c25330679682bc"
+    },
+    "sound/arachnofloyd/death2.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/arachnofloyd/idle1.wav": {
+     "bytes": 34254,
+     "sha256": "35d6991a10637251ec0d6b830f7f57f394e4eed06e7a9dced86f0128ba5bc49e"
+    },
+    "sound/arachnofloyd/idle2.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/arachnofloyd/leap.wav": {
+     "bytes": 70884,
+     "sha256": "f47323f618db14755c57e9e25213267dcffc501fbaa9a201176ab99db6cda928"
+    },
+    "sound/arachnofloyd/pain1.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/arachnofloyd/pain2.wav": {
+     "bytes": 15906,
+     "sha256": "9c4bdc81c73787cb67677e0021b71d9e24734ef3ce272d9020dc6611a1d87842"
+    },
+    "sound/arachnofloyd/sight.wav": {
+     "bytes": 48620,
+     "sha256": "97a055dbb8e5935190348b2c2d50c6d99ab35c29f3ebcd0f66d6263bdb5485e4"
+    },
+    "sound/arachnofloyd/step1.wav": {
+     "bytes": 74932,
+     "sha256": "a8744a3e50dccf9ee391da2f381c2ecf6701a76441406929ee4581c7717b880f"
+    },
+    "sound/arachnofloyd/step2.wav": {
+     "bytes": 34478,
+     "sha256": "22ce43aa18537f7b04e31263a46dd02e181d538fdf5918d55f8ce0acbb930676"
+    },
+    "sound/arachnofloyd/whirr1.wav": {
+     "bytes": 19762,
+     "sha256": "9e2029071248e6d45f1b0d518983bad5bc5f841cda6bcfba09486e111add10de"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axegrunt/axgdeath.wav": {
+     "bytes": 20214,
+     "sha256": "e5ed762afcc516058acc1b3884b4d08e67fd36e3a5bacf711d3504363bf8136e"
+    },
+    "sound/axegrunt/axgpain.wav": {
+     "bytes": 12636,
+     "sha256": "4699951fa58fdf15ab819b13d70904fc9a1a86a4db02193d621dfad3878d17bf"
+    },
+    "sound/axegrunt/axgsight.wav": {
+     "bytes": 17712,
+     "sha256": "e7b23208831c1d83793ba06f3b8855430c92017600cd8315341afbcb6ec6c8f0"
+    },
+    "sound/bambler/melee1.wav": {
+     "bytes": 4175,
+     "sha256": "4e0e2567b9d64b3ff86b33d95fa0158bf72372aeb4968a0c2489df942f9f7c4d"
+    },
+    "sound/bambler/melee2.wav": {
+     "bytes": 5283,
+     "sha256": "4bb91991bccfc33576eff19037e12666e9825348272d3dca40199e208bc00700"
+    },
+    "sound/bambler/sdeath.wav": {
+     "bytes": 14048,
+     "sha256": "c5253af82d203e75d132a00bbb555de055d2e356106d460f34cb8c9a2ee5e643"
+    },
+    "sound/bambler/shurt2.wav": {
+     "bytes": 3736,
+     "sha256": "0f1a51e0ff72f23a4de7684d4408344b7b7bd2cb805609168d2f2459e1b8660d"
+    },
+    "sound/bambler/sidle.wav": {
+     "bytes": 4907,
+     "sha256": "ea2232ba791e306cc86f58303413d8f3fbc7dd38091281698f4d846b6cafa483"
+    },
+    "sound/bambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/bambler/ssight.wav": {
+     "bytes": 11376,
+     "sha256": "de766aa056ca5f7dc6d179e6a220ef906ceacc0341b5cb3d91a4d0e75ff55338"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/cyberscrag/fall1.wav": {
+     "bytes": 23396,
+     "sha256": "162fc0be1cd0eadfc93c35f1e1ba9b8dfc7e8df8ee53afb2a14db73e69f20ce8"
+    },
+    "sound/cyberscrag/hit.wav": {
+     "bytes": 22334,
+     "sha256": "a16ef33d94d56fb6984b2a3d06104a3cc292bdb38ec6ee22c8b10457b2cb415f"
+    },
+    "sound/cyberscrag/wattack.wav": {
+     "bytes": 25912,
+     "sha256": "6bed724b7ef9bdd480448396ed4498c75f848bf2a1e6d2879cb2b2484cdd1a7b"
+    },
+    "sound/cyberscrag/wdeath.wav": {
+     "bytes": 20684,
+     "sha256": "24602233cca209122250ba7c284933992aa2393795ea5c528a57b9986e2fc319"
+    },
+    "sound/cyberscrag/widle1.wav": {
+     "bytes": 13465,
+     "sha256": "8902628d2201eda9396c0dc134ebda8b8d5c37dabddcd286f8387aadc6532750"
+    },
+    "sound/cyberscrag/widle2.wav": {
+     "bytes": 23094,
+     "sha256": "76af020e5c25f40ab3020bbd065a9b83b9b0a51120d47d137a7abff4eb43e193"
+    },
+    "sound/cyberscrag/wpain.wav": {
+     "bytes": 8687,
+     "sha256": "af2e8589d381e634f607048ce71200df832c9e3a32147891b5bdd2efe2ff5bf0"
+    },
+    "sound/cyberscrag/wsight.wav": {
+     "bytes": 13079,
+     "sha256": "2f9178f6515eb4cd518b418441c40d1376aeaf6f42f7791533f5f4b6da87fd68"
+    },
+    "sound/doors/alka_doorlocked.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/q2door1.wav": {
+     "bytes": 30572,
+     "sha256": "3f05bddf76379933970c532656b6350bc53820319ce1cb9d4ea9288210427eee"
+    },
+    "sound/doors/q2door2.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/dread/dread_death.wav": {
+     "bytes": 49692,
+     "sha256": "22000ff613ff52eab0605418681affaf7aeef4acc420d3dddd50a9031ac1ca38"
+    },
+    "sound/dread/dread_pain1.wav": {
+     "bytes": 29220,
+     "sha256": "67e443f78043cb9fc4213bbfbc3cd847785a66849fb7b36dd6467494487e0aec"
+    },
+    "sound/dread/dread_pain2.wav": {
+     "bytes": 23380,
+     "sha256": "914fffe3ad6c02fb78be873ee96405a40df22cd321beee2d673d0b6ebbafcde4"
+    },
+    "sound/dread/dread_sight.wav": {
+     "bytes": 70792,
+     "sha256": "50449a772b2ac778b810a69de58cb63c8bbdea529091720a41a1052b7196632e"
+    },
+    "sound/dread/dread_sight2.wav": {
+     "bytes": 58420,
+     "sha256": "f7952137b648f6376a1ba4e968679abb17fc648ede87bb0dd32f633271ad80ee"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 110256,
+     "sha256": "895cfb57c0d27369530fd5e9b29abd491a989ad0a63ddb00f05dd9e4777a5cdb"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/frogman/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 32638,
+     "sha256": "3cf3933f34c7baef52df54d5b03db40424e9f7ee72e5aa5a4dba489d71be2af7"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 27662,
+     "sha256": "ec38e73fd1ffc33cd25aa065e5f5897c21a494e380763ff80b6be482689b5e33"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 44186,
+     "sha256": "7600cd32fe980646fddcf5a9077d8d43df1bca1f2ed05bd92ce8cca273ad6636"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 132344,
+     "sha256": "9247347179344c541a627bc8ff74e5ce43744e47f5f3a02181402791257b675a"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 33120,
+     "sha256": "9fbfa3f46a27f850615fb4ea4cd760f6ee5817ddad856b44ec51a84138ec91dc"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 54336,
+     "sha256": "1e6a0c92fa9902238e01b4e8a1ff5b9fbe1a37d71cdff7e31f97c0f630d76a20"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/armor_denied.wav": {
+     "bytes": 15854,
+     "sha256": "2ec14677f483d1a1b869af64cc30fb0dbd90a640fc071fdf2ae493d27cd746e1"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/items/shard_pickup.wav": {
+     "bytes": 18260,
+     "sha256": "388923a63b48720647b9e0f2862c35bb1d5cad2e162ace343845b3fe36b48af4"
+    },
+    "sound/items/trifecta.wav": {
+     "bytes": 16412,
+     "sha256": "00baad51adaa3f5d6664e85ae5442221db6818bfd85124c164324d22f6723ab2"
+    },
+    "sound/items/trifecta2.wav": {
+     "bytes": 32778,
+     "sha256": "f742a9cee4a53ef52fce55d5e9ddaae9c6b20d2127e16c0def6cd11b3d2d6380"
+    },
+    "sound/items/trifecta3.wav": {
+     "bytes": 10728,
+     "sha256": "a78bfc9fa4fbf0c3c1e85bee273ee053598989a09146bd29e97dda811c49a473"
+    },
+    "sound/lieut/alert.wav": {
+     "bytes": 8700,
+     "sha256": "7ebbe83ae1b5d159c9f0a0ae5f3dea126650ed5d6f98a22d1512dcfcb19a23ca"
+    },
+    "sound/lieut/objective.wav": {
+     "bytes": 10052,
+     "sha256": "aa7d6726a458eaa48bf2e20446c57360b82ac23bfbd06bad7b6e01ae95ca8b0d"
+    },
+    "sound/lieut/target.wav": {
+     "bytes": 6754,
+     "sha256": "eebd50c75585894c7d5305f6c066aaef1efaca9a59e27b80d03e8ae4d69caa69"
+    },
+    "sound/lieut/you.wav": {
+     "bytes": 7126,
+     "sha256": "6bfb031b0d69b8ae4ef2e9b201da43c523ae88de344907648d4064e07477ee1c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/mechavore/attack.wav": {
+     "bytes": 66460,
+     "sha256": "fc2a8b0e2a72aebe2858b8337d5ef0638e3e04d5b60e9a62d46ac124072705f9"
+    },
+    "sound/mechavore/death.wav": {
+     "bytes": 37504,
+     "sha256": "bbdf8369941f8c2ab302fe3a55de3bf04e1d28e32a575ffd3c24009d76bebc8f"
+    },
+    "sound/mechavore/idle.wav": {
+     "bytes": 64972,
+     "sha256": "5cd8253f1abe5baf08f1852d12393ca820c34fc0f2febf6c1c8f9d4c3326b2c5"
+    },
+    "sound/mechavore/mv_attack.wav": {
+     "bytes": 67046,
+     "sha256": "af133ede9ab5627f3ea75b12716653b11dd813982cab4a6aad0792371ba58006"
+    },
+    "sound/mechavore/mv_death_a.wav": {
+     "bytes": 125364,
+     "sha256": "7a51ba5587b4c8ccd4bd0e93b105f277f4f093a1cd90f684afb33cf0bbfc812e"
+    },
+    "sound/mechavore/mv_idle_a.wav": {
+     "bytes": 61484,
+     "sha256": "463f1bd23c4bf5d2953ce2f7ee980c9fb28725a0bdc92bc1f03dab8e139a2f14"
+    },
+    "sound/mechavore/mv_pain2_a.wav": {
+     "bytes": 41004,
+     "sha256": "18e27023c1ea7ce306f49559a8f303f62fcc206f05f94878bd1898e204972ebd"
+    },
+    "sound/mechavore/mv_pain_a.wav": {
+     "bytes": 49196,
+     "sha256": "7e2a98060c2ebe14313c831e8d3d410aacd70d7bffa9ef45b0f98845cebdfab1"
+    },
+    "sound/mechavore/mv_sight_b.wav": {
+     "bytes": 57388,
+     "sha256": "2212706950e66000184352238f479d659ea37062186b595e6834bb4d1d910c7f"
+    },
+    "sound/mechavore/pain.wav": {
+     "bytes": 36444,
+     "sha256": "9f9368fdd53aec80fd43a6d3b6680e04aae72685d1cfbdf49d55dc1070e8c546"
+    },
+    "sound/mechavore/sight.wav": {
+     "bytes": 116312,
+     "sha256": "112613b44d88046653b29f21aa5fced5d4b5bfcaff037dfa5f246729e45a6968"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/conc_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/misc/door_closed.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/misc/ebell.wav": {
+     "bytes": 15220,
+     "sha256": "1693337ed8873f1159e56c2925afaa210f5c28bee4e2c42d27e29bee8e06cb5f"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/jumppad.wav": {
+     "bytes": 31485,
+     "sha256": "cfc06af995406d853cae30df8db02c340bf7c775f955f5a02de60dc20c66fc0f"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 4054,
+     "sha256": "b9c44f73c8bdbc900af4f06600e0d6456a040b296612b7d0fe53391285976a44"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 4098,
+     "sha256": "4fad66341514c9aa2b31b4c2fde7563369090da9b0b3a51e08bca3100f2ec282"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5054,
+     "sha256": "d158ddc35360bc43934b7a8a9b7cc830f7510e6bb3a640813157822b27b5217a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 9726,
+     "sha256": "73b74099c8cb43ab2fb09b28b72ddd9f73f2d2a4f8a00a8e835490f366680c92"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 3226,
+     "sha256": "48551cc717e5011df78a38c6a71bb001e4f62a1858a3952311499653ff423a07"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 5802,
+     "sha256": "751050f97456a0c07e88a249d40dde96c2d14640e21670ccdde983502998dbba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/singledrip1.wav": {
+     "bytes": 26546,
+     "sha256": "b9193092eaa02003c7ea409663dc1213f0a18a120471a76d298ce847448059b6"
+    },
+    "sound/misc/singledrip2.wav": {
+     "bytes": 25478,
+     "sha256": "562ac78cd1d84805723e3bb24f66c60197d03bab081d7ee8402bf2b59bc7bf0c"
+    },
+    "sound/misc/singledrip3.wav": {
+     "bytes": 44558,
+     "sha256": "55ae1b970143af2553b845503363d94aa917a1cdb8aa1e48edec7869660007c3"
+    },
+    "sound/misc/singledrip4.wav": {
+     "bytes": 45492,
+     "sha256": "db0126239cf71ce69f6c06eb5c5418889b96e52e6741f6b172a146887e6815ef"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/misc/wood_impact.wav": {
+     "bytes": 84742,
+     "sha256": "12cb1f72bd55e19c175b23cbf6ae2f39e539b46c8199963e8d49abac35d91ca8"
+    },
+    "sound/mutant/mutatck1.wav": {
+     "bytes": 6116,
+     "sha256": "410f926534f21705e78a804ce048b0c15e62fe0c68a45aae1b3741fb227551f7"
+    },
+    "sound/mutant/mutatck2.wav": {
+     "bytes": 18260,
+     "sha256": "66009d09adf71f10117c74f5004c995fd48362b2f4fcfaaa3bc2da01e66d115f"
+    },
+    "sound/mutant/mutatck3.wav": {
+     "bytes": 28840,
+     "sha256": "2dd8a615ca2be248c8370d7480f5a8ca9375d31e6af41bba603df660d31883a1"
+    },
+    "sound/mutant/mutdeth1.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/mutant/mutidle1.wav": {
+     "bytes": 81004,
+     "sha256": "8c7e8ad544d7e2470bd61d88c5cd8be1a0eb66f57aaf113f82d990ee00450073"
+    },
+    "sound/mutant/mutpain1.wav": {
+     "bytes": 56716,
+     "sha256": "49ff5f97fedc87c1ac06dc43d4ff0a0fd09fb481354b6373d607bfabc9a57a6a"
+    },
+    "sound/mutant/mutpain2.wav": {
+     "bytes": 58740,
+     "sha256": "b79f1cce60226daa3e3ca8c134da968d54ad51abd9c37ffebdf3d46c5d9f91c6"
+    },
+    "sound/mutant/mutsght1.wav": {
+     "bytes": 107316,
+     "sha256": "7e15e392edc3f2d5ae9e3bde3dfe65595a85728022245f74b81f072d75dce798"
+    },
+    "sound/mutant/mutsrch1.wav": {
+     "bytes": 101244,
+     "sha256": "44484ef4c189511fb0a8d0f2bea83e443e1f1bd51cef04f518f3820e58e88a69"
+    },
+    "sound/mutant/step1.wav": {
+     "bytes": 8140,
+     "sha256": "0d9af35156c84213ac7ffbde54d0f2518fe9d39bba4edc48c94e71bed4f7ec4d"
+    },
+    "sound/mutant/step2.wav": {
+     "bytes": 14212,
+     "sha256": "f7c81df1bff56c8aeb49891fa822c37ddcb019e97a654738a9fb8ee351d19eac"
+    },
+    "sound/mutant/step3.wav": {
+     "bytes": 4092,
+     "sha256": "89856afec31f800219c45253514d0fdf5b5bd800c32f87ba74dd0c21df181550"
+    },
+    "sound/mutant/thud1.wav": {
+     "bytes": 32428,
+     "sha256": "20ed5f20729a068801d06904365e46c9d692dec835710a9b8090d0a1956d6919"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    },
+    "sound/ogre/rogre_alert.wav": {
+     "bytes": 71728,
+     "sha256": "4f3e921b6ee236289660f7ca2ee8a4689e719423266d26a3f8b91ae29d02c6a5"
+    },
+    "sound/ogre/rogre_idle1.wav": {
+     "bytes": 110330,
+     "sha256": "a07df4a53c9e8de310b9d963bfb9c841c51e502565f39dc543bf1c025edd41d6"
+    },
+    "sound/ogre/rogre_idle2.wav": {
+     "bytes": 79416,
+     "sha256": "862258641dc3c90d2a9e5f9e2a4418eb0037eedf22cde798682a169a84f13a44"
+    },
+    "sound/player/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/player/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/player/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/player/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/player/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/player/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/player/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/rail.wav": {
+     "bytes": 97196,
+     "sha256": "396a85e1e2083f2b1eaae89a3f33a21145a643f3f50419523497719ef8e7598a"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/rider/sight.wav": {
+     "bytes": 26356,
+     "sha256": "40ace6f3beeb920ba1bbdb197f8ece18d312762a71e494726289e16703d75d91"
+    },
+    "sound/rider/step.wav": {
+     "bytes": 40524,
+     "sha256": "a43e24ecbc62d44bce466b1e682ebf64c230e03f4d79449406ce021dc8276a9a"
+    },
+    "sound/rider/thump.wav": {
+     "bytes": 15444,
+     "sha256": "af29f4e8f6debb1223aeb5d840add4ae01cb5e9f6bd9a26efeadff518f34380d"
+    },
+    "sound/scientist/allnominal.wav": {
+     "bytes": 23778,
+     "sha256": "e26f9bb3c24d9a9e0da38395048f6dacffe82d800da49d56378027250393d69a"
+    },
+    "sound/scientist/alright.wav": {
+     "bytes": 9666,
+     "sha256": "372c1aa91e6841bec2441215c894b7d149bdeaef33f907d23bb7eaf637520ce3"
+    },
+    "sound/scientist/asexpected.wav": {
+     "bytes": 15982,
+     "sha256": "306933848b673bd14d7074d59e45a8c97bc00a2897601509e52e5835e2ffc997"
+    },
+    "sound/scientist/c1a0_sci_crit2a.wav": {
+     "bytes": 28364,
+     "sha256": "f972684c74eeb51872873cc2b7053448c6cdd716b8c3535929fdbcc508d62ef5"
+    },
+    "sound/scientist/c1a0_sci_stall.wav": {
+     "bytes": 13704,
+     "sha256": "541c192ad5e8a68c76706ec17b3deceafbdc607bfc372ddfd300532f8aa1eaef"
+    },
+    "sound/scientist/cantbeserious.wav": {
+     "bytes": 13236,
+     "sha256": "fc4a8a379f70e33db79a49c667dcd9f1622de29d7b32ef3973c4ffdb5d80ee44"
+    },
+    "sound/scientist/cough.wav": {
+     "bytes": 14878,
+     "sha256": "b4e620259623347a5be3f7eaf3c531e6ea9ef2e97ac42997dd78cfee9327f7bf"
+    },
+    "sound/scientist/sci_die1.wav": {
+     "bytes": 15558,
+     "sha256": "c2306d7f9fa58f99961c347b06ef26305b99ac43ec27b2b222962e1f3a9ccce9"
+    },
+    "sound/scientist/sci_die2.wav": {
+     "bytes": 5402,
+     "sha256": "14deecb570d1e315b772713d54b7250043bb0dd5f3d5538cd0636e39a523c54f"
+    },
+    "sound/scientist/sci_die3.wav": {
+     "bytes": 3104,
+     "sha256": "075cdbc5837d91b61ad7599cdb3abf9323872816f8966c83deab9c0a6e04d7d2"
+    },
+    "sound/scientist/sci_die4.wav": {
+     "bytes": 4024,
+     "sha256": "e6ca0d4f18ac6c1246926646568618057cb70b5cee995c1c2dd69f0179b892ad"
+    },
+    "sound/scientist/sci_dragoff.wav": {
+     "bytes": 8986,
+     "sha256": "0c6a21cd5edf01e495e1258e9a76c05d62c0e3cd697e787fd43fd4bd9126483b"
+    },
+    "sound/scientist/sci_fear13.wav": {
+     "bytes": 4534,
+     "sha256": "dabce7a6c12980f947f7504da264fabb67a804d2e478b7f252ab527fb21a92d0"
+    },
+    "sound/scientist/sci_fear15.wav": {
+     "bytes": 4764,
+     "sha256": "f0d23c680ad138c3cc12da78a3e45cbf3daa47e5da9bc62a1dbb3b27389565a5"
+    },
+    "sound/scientist/sci_fear6.wav": {
+     "bytes": 5588,
+     "sha256": "ff2702b2b9e517b90ea0c2853775a4a95160edfae5af0a7f9208f07624d84281"
+    },
+    "sound/scientist/sci_fear7.wav": {
+     "bytes": 8458,
+     "sha256": "f2a39185c2d39a03b39afd7fe6f942b2f35fd17135ade8ceb4c31968c768aafa"
+    },
+    "sound/scientist/sci_fear8.wav": {
+     "bytes": 5804,
+     "sha256": "4455a29590d5f42ebbf06e600d8ba3f45acfd5000a6b8045891cbecf1d937970"
+    },
+    "sound/scientist/scream01.wav": {
+     "bytes": 14666,
+     "sha256": "b738de99aefbe3a45724914dd6eb79c0f8c219aaf733554a8a5eb94836c22320"
+    },
+    "sound/scientist/scream06.wav": {
+     "bytes": 13938,
+     "sha256": "dee8ac2058635d00458e2e74402d1cfcb5362c64259fc2c4f3b6bba31bdf6337"
+    },
+    "sound/scientist/scream08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/scientist/scream09.wav": {
+     "bytes": 6130,
+     "sha256": "85947649f5fb1491732365849a3025bf5c76c791b395cfdf421fbbd6ec58d351"
+    },
+    "sound/scientist/scream10.wav": {
+     "bytes": 5392,
+     "sha256": "fff4c0735f9c312be7cda848fc2867590437ffe9758fe685e3b4c94678ca1f48"
+    },
+    "sound/scientist/scream14.wav": {
+     "bytes": 4824,
+     "sha256": "dcb7dfb0e307b813476b2e55dceb59d8ae2b9514b1ef02034ea255fa5f086b05"
+    },
+    "sound/scientist/scream15.wav": {
+     "bytes": 3048,
+     "sha256": "37d26fe2d2b8a39d0fec0eceec0ca974ec3dd7fed33bae0d3230a934954105f0"
+    },
+    "sound/scientist/scream16.wav": {
+     "bytes": 2328,
+     "sha256": "4ff04ce8ff07af708c84dacc8df114b68620d47e8e4e4c78dfc4fd33a8a9b98d"
+    },
+    "sound/scientist/scream17.wav": {
+     "bytes": 3836,
+     "sha256": "82fb51224e06db5022adfa58f0b02353c333229ed3312f86dd9ec4f04813c37c"
+    },
+    "sound/scientist/scream18.wav": {
+     "bytes": 3066,
+     "sha256": "bfefcf745ab8d30db11f9113ecf9ba1c5bc6d9b2351c53f3f46d66e03cbea3fe"
+    },
+    "sound/scientist/scream19.wav": {
+     "bytes": 2504,
+     "sha256": "47cc414d201aadb7ba2fe0ce0567ff5360e90fd9de4a167520988513f358ed41"
+    },
+    "sound/scientist/scream20.wav": {
+     "bytes": 21310,
+     "sha256": "124cb45d3d5533572e3cfe4b42bddad2a03dc0d8de1c89a42ea57433432e3a6e"
+    },
+    "sound/scientist/scream22.wav": {
+     "bytes": 15206,
+     "sha256": "6e0a509eb2468466591622e74724c31103b8b60f5d8f29514fb57e9d9d12c9d4"
+    },
+    "sound/scientist/scream23.wav": {
+     "bytes": 21988,
+     "sha256": "8521907e8cecc22e6924d23295a5e8d31333d265ca27a9533b083b68e9da6d12"
+    },
+    "sound/scientist/scream24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/scientist/scream25.wav": {
+     "bytes": 8122,
+     "sha256": "38281749deffb4e567896f71e7bcb75d7b2e253e404a953a5eea6eeb989f156a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/spiderbot/sactiv.wav": {
+     "bytes": 17066,
+     "sha256": "f21587ba9bfd159e48c5b3aa1c6e94eac7157053e4e5699459233fb28c2631c8"
+    },
+    "sound/spiderbot/scharge.wav": {
+     "bytes": 7300,
+     "sha256": "b58064dac4e12bd6685edbfe61417a530cde1e5175336193b2fa7a292aca8ef7"
+    },
+    "sound/spiderbot/swalk.wav": {
+     "bytes": 12636,
+     "sha256": "5534fe1b11fea5406aada214681dba031ec4a01e4b660c405b679131ba07a7cc"
+    },
+    "sound/tormentor/angry1.wav": {
+     "bytes": 88890,
+     "sha256": "60f757f523a9cbb3a57c335bbeda8cedbf990b9d20a5b359e610b712a1344b4b"
+    },
+    "sound/tormentor/angry2.wav": {
+     "bytes": 90912,
+     "sha256": "2f38dddb69cf0df2c1e5b028ca06ea22d979e637afa927919e9a93876dc955d6"
+    },
+    "sound/tormentor/death.wav": {
+     "bytes": 176628,
+     "sha256": "7060ecdadac0b1c9eb3574284444932573e4af13082f01374ed8a4633387bb66"
+    },
+    "sound/tormentor/fire2.wav": {
+     "bytes": 52092,
+     "sha256": "4133a00c7ef157d291d800524a148c188a314eb5ca14246958b8ddfeb0d4fe41"
+    },
+    "sound/tormentor/idle1.wav": {
+     "bytes": 115740,
+     "sha256": "78feebc847dccab66478718b66971870f11246c416e2f2c1e9830c459e4c0347"
+    },
+    "sound/tormentor/idle2.wav": {
+     "bytes": 122218,
+     "sha256": "0270712fe40851bb21d959932b4f8f75bbe8b985e2ff383319059c656ac0ce56"
+    },
+    "sound/tormentor/pain1.wav": {
+     "bytes": 67334,
+     "sha256": "03f255d6ee0d6fb83f2a643491f4cd24d9c5ff86444a51b3cf8b5a0de3d86bbc"
+    },
+    "sound/tormentor/punch_hit.wav": {
+     "bytes": 76614,
+     "sha256": "e524d16b000237615bae3b8fed7b74726823cd4258561196f4641728047aaa26"
+    },
+    "sound/tormentor/punch_swoosh.wav": {
+     "bytes": 33044,
+     "sha256": "d0ef38ef4bf33d0c2f92b22c2a767c4efd66eefaa724df50b394958a7be5a705"
+    },
+    "sound/tormentor/sight.wav": {
+     "bytes": 94334,
+     "sha256": "34a13e6469c5e0ce2f6d18721b0cdd634731b9a9f8910a8bb8b685f63dadfaac"
+    },
+    "sound/tormentor/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/tormentor/sting2.wav": {
+     "bytes": 21674,
+     "sha256": "dd2d40459c7aa9d374efe2f219c34773f390df9f5177a83dbfa5fd638a13c542"
+    },
+    "sound/turret/alarm.wav": {
+     "bytes": 22126,
+     "sha256": "20a8a83d73a55dcc3d8a6fcb79b4ff8ecba0b5887cf3bdcdc96303f069b062ce"
+    },
+    "sound/turret/beep.wav": {
+     "bytes": 22126,
+     "sha256": "89f0e2ba68562cfc3e20272f995777c174c2681cfcf29d2ef337974009b42460"
+    },
+    "sound/turret/deploy.wav": {
+     "bytes": 105260,
+     "sha256": "5bb8c1fa8ffdf22e58ac5fb7a337916a457b9d021661742fcdbbdd7ce188c6dd"
+    },
+    "sound/turret/deploy2.wav": {
+     "bytes": 54208,
+     "sha256": "ec26b9451b67dae2929488687b7b9344a96f7538ab5c4f69e8a85602804dffc2"
+    },
+    "sound/turret/disable.wav": {
+     "bytes": 57180,
+     "sha256": "d8767dcce34c1c7f660f5868c23938da4cc379cb4001b88a10ec1aebbf9e557c"
+    },
+    "sound/turret/idle.wav": {
+     "bytes": 35784,
+     "sha256": "fba6bc2ff517ef95a999e3910c74e3594e054ede298c7b3a5659a2c31565d37c"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/weapons/dsplasma2.wav": {
+     "bytes": 45596,
+     "sha256": "87a1b465c16610b012abe83da7851993f9dd756cc764abca0221d31a09aba156"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 43820,
+     "sha256": "32082cd1d44903409e97de782e5d9295272840e13280665a0ef3ff862b187f0f"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 47570,
+     "sha256": "0dd8defb8ecfb1ea72e6ac70ab182573775812e2d7990dd2897d02d3c38464f5"
+    },
+    "sound/weapons/spindn_click.wav": {
+     "bytes": 9986,
+     "sha256": "b84866cddb7e61eea9ca49208d427c2289d63e6e3e2f59d4d51e302573079bc7"
+    },
+    "sound/zombie2/attack1.wav": {
+     "bytes": 22914,
+     "sha256": "da5345280208ea48855526989299927268566cef77ee187035bbe969076d6605"
+    },
+    "sound/zombie2/attack2.wav": {
+     "bytes": 24072,
+     "sha256": "59245700b47794e239563cc94e3ff045fcd7dad795bcfe343d8574ec3ac525b6"
+    },
+    "sound/zombie2/attack3.wav": {
+     "bytes": 15400,
+     "sha256": "0113aad711264c05a9e43bf8dba915bc89661444d7d802efabe8d61ebb3ba13f"
+    },
+    "sound/zombie2/attack4.wav": {
+     "bytes": 20922,
+     "sha256": "0aac55ae62b62cefece56103cd7079beeb433c3764f590641876e149c4328ecc"
+    },
+    "sound/zombie2/attack5.wav": {
+     "bytes": 26086,
+     "sha256": "b58c97928b535e79973e0390512b09d3d0adea79b1b1b5a8de59bc2cde40c412"
+    },
+    "sound/zombie2/attack6.wav": {
+     "bytes": 22272,
+     "sha256": "58c429256e2f5abb9d97c99ceedb78088d8ac977eca94e994b6d1eee8bb3eb8f"
+    },
+    "sound/zombie2/attack7.wav": {
+     "bytes": 34384,
+     "sha256": "d68e81783b6583738227eac608ab7af1a4b1e1b085c1e46bd9c0d029eab4fdde"
+    },
+    "sound/zombie2/death1.wav": {
+     "bytes": 46548,
+     "sha256": "a1b9e2bcebf9c56fb56405d1ec7fe4166ac10d2b6e1acc6f01e58aec9fd63e87"
+    },
+    "sound/zombie2/death2.wav": {
+     "bytes": 47048,
+     "sha256": "5964a3c1a665c70de8302052b2b6d72ea46b0a5e07ba22cc9919e1a0ffefcca3"
+    },
+    "sound/zombie2/death3.wav": {
+     "bytes": 52636,
+     "sha256": "5c76f8bc55ecea263df880e6b683b07066b37c9f62ff589b0e999534d3c256b0"
+    },
+    "sound/zombie2/footstep1.wav": {
+     "bytes": 12966,
+     "sha256": "2a85309bea05b7c7c90a82df071822828e413cce17646a9686fa4f1264d75e48"
+    },
+    "sound/zombie2/footstep2.wav": {
+     "bytes": 16880,
+     "sha256": "d1d9e9c3811b39b67c9a6966851873ff7edf8d1407c5d9b90782b233196a4872"
+    },
+    "sound/zombie2/footstep3.wav": {
+     "bytes": 20904,
+     "sha256": "b12e9ea9b9478428b886fcaab504856393a57abd8cfdfc5ba5357ad745ee3455"
+    },
+    "sound/zombie2/footstep4.wav": {
+     "bytes": 15796,
+     "sha256": "6f82ac60991e64c8c48a3208a161b46f5b916587cb41863992dc1acb08268889"
+    },
+    "sound/zombie2/footstep5.wav": {
+     "bytes": 17800,
+     "sha256": "ca12f6ade73e5d5ba4ec1bdf680ce25afe3270bb88d702e1493b75619ec088d9"
+    },
+    "sound/zombie2/idle1.wav": {
+     "bytes": 143832,
+     "sha256": "aa203b0beb2db12beb6929fbc3646f7f119d4d31ede66b13af0412d396f7dd6d"
+    },
+    "sound/zombie2/idle2.wav": {
+     "bytes": 277026,
+     "sha256": "9496f3179e875bbb4d7442c252eac0eb2b9ef6d2269d43c141e01242ed2de7ee"
+    },
+    "sound/zombie2/idle3.wav": {
+     "bytes": 234026,
+     "sha256": "4820b03de8cebdee6fe787b5bf60724c17a0e133fdd5451176a202043f730f8e"
+    },
+    "sound/zombie2/idle4.wav": {
+     "bytes": 166352,
+     "sha256": "a515e5dc0e4fe1412a7936df5fab0f57a48c385db4fa357c1a4120671ac99617"
+    },
+    "sound/zombie2/idle5.wav": {
+     "bytes": 62782,
+     "sha256": "c6e4e2f26769400b7ca3b08339af089ba28bc063447d642e10cffffc6e03a485"
+    },
+    "sound/zombie2/idle6.wav": {
+     "bytes": 47274,
+     "sha256": "9ad1ced551cb42764fd88baf26ee09dc72d1852fa2da7405fde370d3e4d69a01"
+    },
+    "sound/zombie2/idle7.wav": {
+     "bytes": 45614,
+     "sha256": "41783a7682d5f8bb91aff8308b8657504cc8f0460b5ca436a5d0fb1c93357c85"
+    },
+    "sound/zombie2/idle8.wav": {
+     "bytes": 73070,
+     "sha256": "8f390d861feda3fb3950b0f33ce3efbfa8eda214533324674ac40b6e227b6975"
+    },
+    "sound/zombie2/punch1.wav": {
+     "bytes": 9218,
+     "sha256": "db6787efe0a0b8df5da690b91afe46a2199911b661fc9de1cfffc00b6bb8c46c"
+    },
+    "sound/zombie2/punch2.wav": {
+     "bytes": 8032,
+     "sha256": "747aabd6237176ae1bc62669cb08c7ec65fb26aa2147f6a3e1ab43f02ace7322"
+    },
+    "sound/zombie2/punch3.wav": {
+     "bytes": 13076,
+     "sha256": "05bb75533252d15983a944263789de5ee51187e518f4544fd1915b57ba726c7e"
+    },
+    "sound/zombie2/punch4.wav": {
+     "bytes": 13198,
+     "sha256": "d07556e7fc774958a6105564a990c51a0dab64fcf9508475617921a0ac5b961c"
+    },
+    "sound/zombie2/sight1.wav": {
+     "bytes": 73234,
+     "sha256": "387534044f10592ca6bc7a96b8e782c7b51de87b907e79a8f410d535e17d37ee"
+    },
+    "sound/zombie2/sight2.wav": {
+     "bytes": 52224,
+     "sha256": "cbc95608d4553d0bae66411d69875210e6fc6d728bd30deb6bbce7aabbacb773"
+    },
+    "sound/zombie2/sight3.wav": {
+     "bytes": 63072,
+     "sha256": "cbbcdb6da59d830a3be66095053259b17a90cc6501728ed1aa50d9524818f99b"
+    }
+   },
    "sha256": "5707c6fef6bd126fbf7803736c2014c74fe27611e583dc58af9d1416c8cc7c80",
    "timestamp": "2024-02-03T19:55:56.000Z"
   },

--- a/json/by-sha256/cd/cd91ed6329b963af434a99963543b9353d3ab9a269ea1ac2cf693b8e38f81cfa.json
+++ b/json/by-sha256/cd/cd91ed6329b963af434a99963543b9353d3ab9a269ea1ac2cf693b8e38f81cfa.json
@@ -32,6 +32,692 @@
   },
   "chapters/pak0.pak": {
    "bytes": 41693519,
+   "files": {
+    "gfx.wad": {
+     "bytes": 126244,
+     "sha256": "fe0f5953d0fa64721107ee7718ed8c4d804a89a8236d573051db3bc0356ee382"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "c74dcc9c67198bf3ec2560261a8d164f8b2ec9cbe1d2d58443ea188cacff31c7"
+    },
+    "gfx/env/fodrianbk.tga": {
+     "bytes": 438466,
+     "sha256": "023a119b49e2a3630b156cf622fdf0d9efe6a8144d1128542dad3a36852d571f"
+    },
+    "gfx/env/fodriandn.tga": {
+     "bytes": 526472,
+     "sha256": "ece0abbb9d478368c9b80fca7fe03ab2cfd349d0d087e134b2ac7d5f8c61ba89"
+    },
+    "gfx/env/fodrianft.tga": {
+     "bytes": 491268,
+     "sha256": "1914f73da39bd55a6a167508a3e0474cdf8f9047b59fbf74113c50cb1a682d0b"
+    },
+    "gfx/env/fodrianlf.tga": {
+     "bytes": 502698,
+     "sha256": "c75d67a6f12f9e96fe5af60ec6f7a6d93778371d3bf141f28e750ff6113945a7"
+    },
+    "gfx/env/fodrianrt.tga": {
+     "bytes": 468382,
+     "sha256": "aad1a02a8c636463fbee3178aaa69b90380b96d8550c581ab74fc91ec05f6e9c"
+    },
+    "gfx/env/fodrianup.tga": {
+     "bytes": 538367,
+     "sha256": "31a61f7f5f476a81a2191153794770fbcab42c61e9f32253daffe78f38585b75"
+    },
+    "gfx/env/starsbk.tga": {
+     "bytes": 51294,
+     "sha256": "7292194bfe9a6444173b6c4949568ec42cd6900883dcc444da0f2344fe3d4d69"
+    },
+    "gfx/env/starsdn.tga": {
+     "bytes": 51322,
+     "sha256": "59e645a79cd93b98c05de9c2f8a136394ab561ce0b9978aad4de17c6508da60b"
+    },
+    "gfx/env/starsft.tga": {
+     "bytes": 51685,
+     "sha256": "2dc8d4ab7cdd655c2a63bfe7059815bedc56692a5c1867191d12433958f633c5"
+    },
+    "gfx/env/starslf.tga": {
+     "bytes": 50756,
+     "sha256": "f74f36da6239c9b011b6ecf1f0fabf7c40f3372fe3841d2168473a31e16e646c"
+    },
+    "gfx/env/starsrt.tga": {
+     "bytes": 52319,
+     "sha256": "9ce812f2efe3dd4fb077bc751fc8209de661c04544e54c3271b956316b7c162e"
+    },
+    "gfx/env/starsup.tga": {
+     "bytes": 51416,
+     "sha256": "d31b6a617776b2ccd90662ec1196267ac4c8be85696b9702ec39c41386f2fc47"
+    },
+    "gfx/env/voidbk.tga": {
+     "bytes": 603,
+     "sha256": "6e095aecdb2ee0ebb2636b48ce7f7754ee357b217f32a83025830db3d9a87fdc"
+    },
+    "gfx/env/voiddn.tga": {
+     "bytes": 603,
+     "sha256": "0c7a0cf2c30d6d87f21567c4e4dacedccc3840fb82b37bfd8c0949315526cc46"
+    },
+    "gfx/env/voidft.tga": {
+     "bytes": 603,
+     "sha256": "bc18cbf4e5c4036b64203d6a165aa18edf24d86bcee9b6e7c183bd54f456550e"
+    },
+    "gfx/env/voidlf.tga": {
+     "bytes": 603,
+     "sha256": "a350d7da744018421f60d6b95edc609f36d059ad27fe0621599c018e6ccbf3d7"
+    },
+    "gfx/env/voidrt.tga": {
+     "bytes": 603,
+     "sha256": "6447fc6c5ddb2a696fccd2611323758ce44be8a236ec9602ed9947b800d1240a"
+    },
+    "gfx/env/voidup.tga": {
+     "bytes": 603,
+     "sha256": "76c1a1a57bfc1099bde3814a7d998b842ad6f8b619d3e4e1169ab7ab8850f133"
+    },
+    "glquake/air.ms2": {
+     "bytes": 52,
+     "sha256": "67d71c32a4193c8cba913f2595f1500fa0775a392d376c6b6bde0fa0178742dd"
+    },
+    "glquake/brazshrt.ms2": {
+     "bytes": 4676,
+     "sha256": "01bef792c288470949396e39ef5b3c95d6f9b3eb40abd5f557521122621ced42"
+    },
+    "glquake/braztall.ms2": {
+     "bytes": 6584,
+     "sha256": "9592c8229731111fba21f2d565c1b8e4bc90fe07e46f468ce57ad750665c3d14"
+    },
+    "glquake/corpsec1.ms2": {
+     "bytes": 5656,
+     "sha256": "a7264910aa8743247419f7377e74af9ec747e0b65b01848cf90ac58889314a85"
+    },
+    "glquake/corpsec2.ms2": {
+     "bytes": 5656,
+     "sha256": "a7264910aa8743247419f7377e74af9ec747e0b65b01848cf90ac58889314a85"
+    },
+    "glquake/corpsef2.ms2": {
+     "bytes": 5968,
+     "sha256": "b438732c7dc0be034b186e573d95493a45723e9ab40a6f352cda697e69e4084c"
+    },
+    "glquake/corpsef3.ms2": {
+     "bytes": 5968,
+     "sha256": "b438732c7dc0be034b186e573d95493a45723e9ab40a6f352cda697e69e4084c"
+    },
+    "glquake/corpsef4.ms2": {
+     "bytes": 5968,
+     "sha256": "b438732c7dc0be034b186e573d95493a45723e9ab40a6f352cda697e69e4084c"
+    },
+    "glquake/corpseh1.ms2": {
+     "bytes": 5968,
+     "sha256": "b438732c7dc0be034b186e573d95493a45723e9ab40a6f352cda697e69e4084c"
+    },
+    "glquake/corpseh2.ms2": {
+     "bytes": 5968,
+     "sha256": "b438732c7dc0be034b186e573d95493a45723e9ab40a6f352cda697e69e4084c"
+    },
+    "glquake/corpseh3.ms2": {
+     "bytes": 5968,
+     "sha256": "b438732c7dc0be034b186e573d95493a45723e9ab40a6f352cda697e69e4084c"
+    },
+    "glquake/corpsib3.ms2": {
+     "bytes": 5656,
+     "sha256": "a7264910aa8743247419f7377e74af9ec747e0b65b01848cf90ac58889314a85"
+    },
+    "glquake/corpsif1.ms2": {
+     "bytes": 5656,
+     "sha256": "a7264910aa8743247419f7377e74af9ec747e0b65b01848cf90ac58889314a85"
+    },
+    "glquake/corpsif2.ms2": {
+     "bytes": 5656,
+     "sha256": "a7264910aa8743247419f7377e74af9ec747e0b65b01848cf90ac58889314a85"
+    },
+    "glquake/corpsif3.ms2": {
+     "bytes": 5656,
+     "sha256": "a7264910aa8743247419f7377e74af9ec747e0b65b01848cf90ac58889314a85"
+    },
+    "glquake/corpsih1.ms2": {
+     "bytes": 5656,
+     "sha256": "a7264910aa8743247419f7377e74af9ec747e0b65b01848cf90ac58889314a85"
+    },
+    "glquake/corpsih2.ms2": {
+     "bytes": 5656,
+     "sha256": "a7264910aa8743247419f7377e74af9ec747e0b65b01848cf90ac58889314a85"
+    },
+    "glquake/corpsih3.ms2": {
+     "bytes": 5656,
+     "sha256": "a7264910aa8743247419f7377e74af9ec747e0b65b01848cf90ac58889314a85"
+    },
+    "glquake/corpsih4.ms2": {
+     "bytes": 5656,
+     "sha256": "a7264910aa8743247419f7377e74af9ec747e0b65b01848cf90ac58889314a85"
+    },
+    "glquake/corpsiv1.ms2": {
+     "bytes": 5656,
+     "sha256": "a7264910aa8743247419f7377e74af9ec747e0b65b01848cf90ac58889314a85"
+    },
+    "glquake/corpsiv2.ms2": {
+     "bytes": 5656,
+     "sha256": "a7264910aa8743247419f7377e74af9ec747e0b65b01848cf90ac58889314a85"
+    },
+    "glquake/corpsiv3.ms2": {
+     "bytes": 5656,
+     "sha256": "85bed2a4f80210979f4fbf07a571409ab110e2a38a67eb64e67b250988581297"
+    },
+    "glquake/cross.ms2": {
+     "bytes": 3076,
+     "sha256": "aad73dc230e19872c5c7b9442d6a31946c7f9c71d6c85670547b324595554ff0"
+    },
+    "glquake/drlbomb.ms2": {
+     "bytes": 2012,
+     "sha256": "01e4145d685c17ce69532bdde786c9961db13258ffcc43726df1a92e4c6aa3df"
+    },
+    "glquake/drole.ms2": {
+     "bytes": 7716,
+     "sha256": "50a3ca7e7efd949ac6fddf0bdef9f79c751646ea8856a04a375c6adaa3051706"
+    },
+    "glquake/g_ham.ms2": {
+     "bytes": 1872,
+     "sha256": "eacbb09816a4a31bc5efa98eee237511549be757a40e66c787316b8e50c3fa43"
+    },
+    "glquake/h_drole.ms2": {
+     "bytes": 1096,
+     "sha256": "a95970f5cbb4b095edcd2c3551de2d20676ee494147550dd4c7e972197d495d2"
+    },
+    "glquake/longtrch.ms2": {
+     "bytes": 13016,
+     "sha256": "92f247f73887587dddec48fef89d96e6f4224bb7f45027b1245f79226aa485f6"
+    },
+    "glquake/polyp.ms2": {
+     "bytes": 5100,
+     "sha256": "c7c9601f91c31ac301350684a0ce52a9b17874b2a7bf4f965203a1adee243498"
+    },
+    "glquake/polyp_t1.ms2": {
+     "bytes": 4632,
+     "sha256": "e45d8f99d29cf59b4b21a5e9db33744698916b899f180216f49163b211b76442"
+    },
+    "glquake/polyp_t2.ms2": {
+     "bytes": 3368,
+     "sha256": "93fbad84fa125774c147e77cf64bebfa38b15dd9284ec2827ff96bee8183d7c0"
+    },
+    "glquake/polyp_t3.ms2": {
+     "bytes": 1876,
+     "sha256": "4bff1e628f4678b3f9e8293b2f5083f1d6a28c55080bcf5ead69192f72c45a2f"
+    },
+    "glquake/polypgib.ms2": {
+     "bytes": 600,
+     "sha256": "ad5e1d7dfdc332920d79b9c4f2c64a2c3ec2498fa8eb2eefc785df5a40711e47"
+    },
+    "glquake/s_light.ms2": {
+     "bytes": 1084,
+     "sha256": "33a4667df97f5d8dab3e586d3f307aa1c8043072318ef445c9af9c0c62205668"
+    },
+    "glquake/spore.ms2": {
+     "bytes": 420,
+     "sha256": "0959a3dc7b4a2ea6d8d4d602f915c7e0afcdb5a7b3b343bbf01f54ad334832c4"
+    },
+    "glquake/trinity.ms2": {
+     "bytes": 1140,
+     "sha256": "44342189a95e0f4b61c4fdb32aee2fe809c38c2cb655539d69cc6644434122bd"
+    },
+    "glquake/v_ham.ms2": {
+     "bytes": 4800,
+     "sha256": "cd8c55ecb55f0c0554fba450e4c75e2e1aeab0506bc5dba950286540348f5075"
+    },
+    "glquake/vermis.ms2": {
+     "bytes": 6452,
+     "sha256": "84145e70ee1cfda6b139acdf1b0a8bc12c2ad2bf254ce3b32fab2cb1e88c4991"
+    },
+    "glquake/vleg.ms2": {
+     "bytes": 524,
+     "sha256": "4ff6d6a100242e83fcff8a74e92380d7028bb0f5d721e88f61b7a6e9a572c14d"
+    },
+    "glquake/voreling.ms2": {
+     "bytes": 3116,
+     "sha256": "5b67d1e90801e52fd9857d6393163881f53b3bd4abb19a289e4d118f535fdd73"
+    },
+    "maps/chapter_esw.bsp": {
+     "bytes": 3922624,
+     "sha256": "376c41854c40b5804397ed3aa2a11eb47d9ef36bba0acda8feffbee222858850"
+    },
+    "maps/chapter_esw.lit": {
+     "bytes": 1809221,
+     "sha256": "68d693b3eae5db0ed580cd688692050fa34188e8bb635a5a8b6e203604de83ca"
+    },
+    "maps/chapter_finale.bsp": {
+     "bytes": 1753788,
+     "sha256": "63d0a69cabe938f02b103c94e5dcc1b8ff5972fb74088be5a10af100eb69ea7e"
+    },
+    "maps/chapter_ionous.bsp": {
+     "bytes": 1467792,
+     "sha256": "7a729b5a57c25761514bf881a6e29038baa7ebf4c5055d1c09661e785e7d2e76"
+    },
+    "maps/chapter_kell.bsp": {
+     "bytes": 3048936,
+     "sha256": "a1c4078e34bd9938351604468bad83c890f728d264a6b41efd89fd6b41eec2a4"
+    },
+    "maps/chapter_necros.bsp": {
+     "bytes": 2826320,
+     "sha256": "639c3f9616097ff0821dd974f0789392c37bdade5ff29ae76bfe8f03773900c8"
+    },
+    "maps/chapter_secret.bsp": {
+     "bytes": 3054100,
+     "sha256": "00764e9c6b99cdd37230bdc6d50fb1f4596668a2fc8bb37c395123bf048a550b"
+    },
+    "maps/chapter_vondur.bsp": {
+     "bytes": 1664400,
+     "sha256": "1dd7c1f18db70b2e99aeacc7fb13ea90609c394b46b780af15c806ad32eb0695"
+    },
+    "maps/chapter_zwei.bsp": {
+     "bytes": 1583680,
+     "sha256": "eba751ad458a36401f354e6f81c592615e362a5813d119d5bad4f160f237cd63"
+    },
+    "maps/droletest.bsp": {
+     "bytes": 389544,
+     "sha256": "83685a458f6823b3b4786dc8f1c849789777d7727bc2fa8ebc8ccba2fee9e3f5"
+    },
+    "maps/shamblertest.bsp": {
+     "bytes": 389556,
+     "sha256": "5aacb6e94ecb6200c05bb9f2852572b738d790c5a4619de4b08fc22431b4c31a"
+    },
+    "maps/start.bsp": {
+     "bytes": 2882248,
+     "sha256": "75c24bfca0591bae7d02fa458bf2f87cd313791e265e51909505984ca0b30af9"
+    },
+    "maps/wormtest1.bsp": {
+     "bytes": 480824,
+     "sha256": "e69b947bfe51b67d7288995cb5c5054b24e711ba2479dbf4e9ffa5e3dbec196e"
+    },
+    "maps/wormtest2.bsp": {
+     "bytes": 895008,
+     "sha256": "626effa5373994abbe79faf5d2dcedacd8497008a032a81dbc6053e3bfc5f249"
+    },
+    "progs.dat": {
+     "bytes": 619412,
+     "sha256": "0c0d28bd4e0a8918a8f411390557446691fad55b36c857278c6b21fd3befd294"
+    },
+    "progs/air.mdl": {
+     "bytes": 5076,
+     "sha256": "930e21887f0c482f353d5009efe1f5ef3f88e18d7a4f2e1232978cb2e8f73932"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b5193bcdb6753cda8a1881049f5af56bbb16898ffaa7a8a2a70a5c45003c520c"
+    },
+    "progs/brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/corpsec1.mdl": {
+     "bytes": 68794,
+     "sha256": "348159d977de40a296a03e99ed9298ca9d8ced224c2ee945b4bf161fda8db6f2"
+    },
+    "progs/corpsec2.mdl": {
+     "bytes": 68794,
+     "sha256": "51867bd0c377934aad11f07aa6da2b730031c4a0698eaa516371f35c3de1fd85"
+    },
+    "progs/corpsef1.mdl": {
+     "bytes": 89670,
+     "sha256": "c9e4dc77461b6f1219c0ed2ca414cc75e6312aabfae70ad347923da38dc49a3e"
+    },
+    "progs/corpsef2.mdl": {
+     "bytes": 89670,
+     "sha256": "86b555a098cf4e603ea6582fe2adbb2885afa6c33a95d10fd4675ae3629dc3d5"
+    },
+    "progs/corpsef3.mdl": {
+     "bytes": 89670,
+     "sha256": "4a55b0c85171af0953a7ab5e8f4f6299b2cec6dafb9a30334d27b62f575483e7"
+    },
+    "progs/corpsef4.mdl": {
+     "bytes": 89670,
+     "sha256": "bbca34dc0857efa3017ba3e711a22880364bbfc19ab2ff5ad49c5583bb6d3741"
+    },
+    "progs/corpseh1.mdl": {
+     "bytes": 89670,
+     "sha256": "60d4dd01637944a1cbf56dcc203135ef2c139621d74b5a09f6594326d2143796"
+    },
+    "progs/corpseh2.mdl": {
+     "bytes": 89670,
+     "sha256": "ca16cd0f33c6dfca246b6cbf1ff7a37eb47b30d88838a4343549162114fbc1e8"
+    },
+    "progs/corpseh3.mdl": {
+     "bytes": 89670,
+     "sha256": "677c2b6dda0fb33f83b51f7020cc9ae2bb9eebf3e98141b9ed6c41c7983a42a8"
+    },
+    "progs/corpsib1.mdl": {
+     "bytes": 68794,
+     "sha256": "530f412f2d8a3d6cef6ae8ab076be63422c9084a64a8ab9e43fc6b52b318dee4"
+    },
+    "progs/corpsib2.mdl": {
+     "bytes": 68794,
+     "sha256": "c513dcbe42d019637c9184a3408684d92fa22cb91a805bbdfccb0da5cdb3ff70"
+    },
+    "progs/corpsib3.mdl": {
+     "bytes": 68794,
+     "sha256": "eb626376cf4c98c9da19fa663988e7a8893d9a4bde6a4f9b4be552d12929daca"
+    },
+    "progs/corpsif1.mdl": {
+     "bytes": 68794,
+     "sha256": "0956fb7ac5d1789a03c1997f6a18511ae9eb39a3df1ebb9e41ccd9ef9ca15737"
+    },
+    "progs/corpsif2.mdl": {
+     "bytes": 68794,
+     "sha256": "69e9b5a731c744a54db5e0cb24977512a17ec34d0fbaea41bf2fd97455af1b19"
+    },
+    "progs/corpsif3.mdl": {
+     "bytes": 68794,
+     "sha256": "3b5c7a236264aff9e62ef1391cc9ad4dbea4e08b30668b86d46db40c775954ff"
+    },
+    "progs/corpsih1.mdl": {
+     "bytes": 68794,
+     "sha256": "f58a0e5734c7bf7483de47b6baee56710d7e1cb2417fe51c186e9e161723929e"
+    },
+    "progs/corpsih2.mdl": {
+     "bytes": 68794,
+     "sha256": "8d349033e1978d12998fe3f210daa499f40b1f6713ce9c150e8c7c8da6fa71f5"
+    },
+    "progs/corpsih3.mdl": {
+     "bytes": 68794,
+     "sha256": "a2adc72106dad06a7cf64726992f46db65495160a1657a662b4229f3bea003e4"
+    },
+    "progs/corpsih4.mdl": {
+     "bytes": 68794,
+     "sha256": "bd20fbe51a474868aed95a57914dd84783eaaacc7bebd70ac9a25c8058610af8"
+    },
+    "progs/corpsiv1.mdl": {
+     "bytes": 68794,
+     "sha256": "32692ba22b1630dc12fbb1e01b2fa2aaaf338925f0b6190ea4ea97c1243d90cb"
+    },
+    "progs/corpsiv2.mdl": {
+     "bytes": 68794,
+     "sha256": "454b16c2a56d6d2569ce0a435c23b1beb72198d6fe4f847fa1b5a1b58d870a7a"
+    },
+    "progs/corpsiv3.mdl": {
+     "bytes": 68794,
+     "sha256": "3e5730608153fd66c0158cb252a93a2c0173b99aa707e1c8f644b6add5e5b8ad"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/drlbomb.mdl": {
+     "bytes": 20355,
+     "sha256": "5c1db489f43cba73fce265db642267775245d044866cdd48396b1f1260a28237"
+    },
+    "progs/drole.mdl": {
+     "bytes": 372728,
+     "sha256": "1417b6491738c07fabec68acaa9b42fb4285045a777ca7bdfa1de9d1c3566586"
+    },
+    "progs/g_ham.mdl": {
+     "bytes": 71639,
+     "sha256": "424bd4ecf03e0f364f57448b7c426924e1e0ccd06dad40294c00a23a645b8c0a"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 16854,
+     "sha256": "00f3263f1c3e0daadaaf03eea447080d727ea7d9ee1a88f2b42e060d748e1566"
+    },
+    "progs/knight.mdl": {
+     "bytes": 342850,
+     "sha256": "9e23eca66dbe332f49a1a82ceef197d5ee980abb24145050ea3088e05468dd4b"
+    },
+    "progs/longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/marsh.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/marshsm.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/polyp.mdl": {
+     "bytes": 582679,
+     "sha256": "7173d31d2afd560866a623376b870e25abf05446a23889236d4b089282c3ba1e"
+    },
+    "progs/polyp_t1.mdl": {
+     "bytes": 66925,
+     "sha256": "82f5f86f210e8cfc541259a3a9efe7b0b4a046f5b5240c5d39ab08a021a4e2ee"
+    },
+    "progs/polyp_t2.mdl": {
+     "bytes": 65473,
+     "sha256": "130699464f89836047b7bf6b4ad0ac7feee810dd31da5add2892e1f61ed07a30"
+    },
+    "progs/polyp_t3.mdl": {
+     "bytes": 64069,
+     "sha256": "72a5a60e71e09a4a0e73dba0658b301540b3d871ec4ea88e24ace135db19d046"
+    },
+    "progs/polypgib.mdl": {
+     "bytes": 5716,
+     "sha256": "dc2aae40f92f8c75057a664b583f9d790d010289e858b218adfc92de6d6be878"
+    },
+    "progs/s_light.spr": {
+     "bytes": 7344,
+     "sha256": "45ae7c364a43b76d834476f49fe6c35423330cce41d8f3dbc90780f561bb51e7"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/spore.mdl": {
+     "bytes": 13469,
+     "sha256": "fc9fbb97f0d4f1a9f843769cd43fb7270ba2b351cdf3b4b624d27616980457c4"
+    },
+    "progs/trinity.mdl": {
+     "bytes": 13249,
+     "sha256": "3e0d4636dfd20112bd5415e92c1d8f85fdda65a9a33b09111cca2bbf4561f349"
+    },
+    "progs/v_ham.mdl": {
+     "bytes": 84563,
+     "sha256": "76f03b4e5d8222c2c3b3d2f0e1156ac90708a42f4997f6a4555c01073dab49dd"
+    },
+    "progs/vermis.mdl": {
+     "bytes": 656752,
+     "sha256": "d7060475e290482c61c122b3a477085b1aad002fd71d8293cc4a4f8bde1baec9"
+    },
+    "progs/vleg.mdl": {
+     "bytes": 6093,
+     "sha256": "8777e423dc49261b86b1e2097e3cf030a8627b7fc734d0f9ca7b60d4d65776c0"
+    },
+    "progs/voreling.mdl": {
+     "bytes": 185663,
+     "sha256": "7014e0c1a4d4817b2e2867101175055831c2f36680f5ad1bf9fd7cd8278aa8df"
+    },
+    "sound/ambience/nightmare.wav": {
+     "bytes": 34284,
+     "sha256": "2caac27dfee5758eb293e0c76bf86baf82b0522c6f71281160e805c6ec282f96"
+    },
+    "sound/ambience/thrum.wav": {
+     "bytes": 220542,
+     "sha256": "c925d73ef744b0a8c56507ff6fb18888de7ab803ea1f743060f8f9782180dcc7"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/explode3.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/sight2.sfk": {
+     "bytes": 180,
+     "sha256": "7898038a47c10c7584f714fbce24a14371d50b363a8c81ecb81d3a85e73384c3"
+    },
+    "sound/drole/sight2.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/items2/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items2/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items2/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items2/trinend.wav": {
+     "bytes": 79450,
+     "sha256": "6edc4b653c671187012e5ad6a95f777a861ab18a1d27b69a10912b459dab2577"
+    },
+    "sound/items2/trintake.wav": {
+     "bytes": 73428,
+     "sha256": "b26c0f0af98016163bf1fc7c4376ca90dfa4ad447e31a04fff9d8c9d820cda86"
+    },
+    "sound/items2/trinuse.wav": {
+     "bytes": 16990,
+     "sha256": "ea0b2b20b8137da8388bab00812218a47049183a7d4eb031449b975289de4ed4"
+    },
+    "sound/polyp/blast.wav": {
+     "bytes": 25036,
+     "sha256": "0c3942daeedfa438ba36bd31481f7b24b067cab3d167c9e5cfd1cf3c498bf367"
+    },
+    "sound/polyp/cloak.wav": {
+     "bytes": 46252,
+     "sha256": "31cb79048b0c511ad0d40989785d835584c4c808025b8eb8060a74b36c9bca39"
+    },
+    "sound/polyp/decloak.wav": {
+     "bytes": 91152,
+     "sha256": "e2ee4693b0e466c5bc229db186257254c381c6a6985e71b02b20838859bcb5ae"
+    },
+    "sound/polyp/gibsplt1.wav": {
+     "bytes": 19580,
+     "sha256": "e9b7b73242aa04fdb6aed5de1c343ced81b15d6f78dde07097826b78bb1f87a0"
+    },
+    "sound/polyp/idle.wav": {
+     "bytes": 17750,
+     "sha256": "4edd47fe2508cb818ce36916a16c6e4c7cea4f61ff0310b7195e74bccc4f5d2b"
+    },
+    "sound/polyp/idle2.wav": {
+     "bytes": 22210,
+     "sha256": "b07894dd93545ed0c54fabae04f139c371a8b36ab84fc399f870f813b535000c"
+    },
+    "sound/polyp/sight.wav": {
+     "bytes": 11664,
+     "sha256": "a9c414ba4ca74fa3e08018af695674ede79a2f63aab26be0566dda9426eaef43"
+    },
+    "sound/vermis/death.wav": {
+     "bytes": 148016,
+     "sha256": "44b26a9dca5ec8d5e8a7ef2b5e38196b74e4f606cd37b906ee2b2e5b5a85b08f"
+    },
+    "sound/vermis/grab.wav": {
+     "bytes": 352300,
+     "sha256": "add5afcf20b785bff205c613716087a53159b2fe338801a47d6830bc7dbd7d2f"
+    },
+    "sound/vermis/grabbed.wav": {
+     "bytes": 51630,
+     "sha256": "99583c88b8ec2959a0d69448aee16ec86b3d9feee6df7841fc32759598349376"
+    },
+    "sound/vermis/grndhit.wav": {
+     "bytes": 36428,
+     "sha256": "1f0e78fa08efb4617b6967a6cc218c56af227c7fd6bf039420d8f106d74fca72"
+    },
+    "sound/vermis/pop.wav": {
+     "bytes": 131420,
+     "sha256": "6284ab02e604b44c5b07225b2a0544c8707517d5fec0024c127bdafef2704f70"
+    },
+    "sound/vermis/sight.wav": {
+     "bytes": 137772,
+     "sha256": "d892117e4602595b6dfb65563b8fa7a3ad2171851791f7c6f47ea4bfece76296"
+    },
+    "sound/vermis/sight2.wav": {
+     "bytes": 106780,
+     "sha256": "6132e2d0db5cfb7a1a064e708d97f7258e2c6ac15c6f4ea8d520641e0ad10f9d"
+    },
+    "sound/vermis/splash1.wav": {
+     "bytes": 30710,
+     "sha256": "f931a2927c13cdb2523dde4550c0af993cc08cbea6e332739f9cf6fe3bd1ff8b"
+    },
+    "sound/vermis/splash2.wav": {
+     "bytes": 25332,
+     "sha256": "b91c69ee695bd71537ed018800f7d89e5e7d95332124f69adee39261d84d7c13"
+    },
+    "sound/vermis/splash3.wav": {
+     "bytes": 25590,
+     "sha256": "99fad2f3815a30ef645a2162ea24e54b4302ba00d7551af9299fde74ecce98e8"
+    },
+    "sound/vermis/spore.wav": {
+     "bytes": 44204,
+     "sha256": "d01a27af99745725dae124d30af18458b2ef323bce93c3cad939310e0f47f6c7"
+    },
+    "sound/voreling/bite.wav": {
+     "bytes": 8920,
+     "sha256": "a5bbebd7178205c400115846314709fa22c4db390fafbf3abaee2e33342e1a0c"
+    },
+    "sound/voreling/bitestrt.wav": {
+     "bytes": 11132,
+     "sha256": "be72b6a15a73bda266331309046229fd6f94b0856f4dfc306204e6266ad1cb59"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 19584,
+     "sha256": "e5bc7634816b927c305679e9b0ff3e4f33a2d09cb5e80db3c5dd04373ba452e5"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28378,
+     "sha256": "b9daf80e6bc998d521cd35f6d8ef74295f39fafbb71f6d6cfe8f0e7c1fb3f0ba"
+    },
+    "sound/voreling/land.wav": {
+     "bytes": 6154,
+     "sha256": "92f08d203711dbd3bc2049ba61a62938b4eb34a9c7285c26406da3b29bbdfba2"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "0b6c021bc7301757918201ad1175387eabfc0af4f6e8b94e273ba22a2aa6c53c"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 55972,
+     "sha256": "9aaaebf47f82cd7a521800aa9d81d14bd2747735481cb15b88ce104cf1568b6f"
+    },
+    "sound/weapons/expl1.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/hamhit.wav": {
+     "bytes": 2434,
+     "sha256": "7754c2ab32c5d34473e4fe4977f9aa1b326a622431b44b599c798c7a0fbe2b60"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 164,
+     "sha256": "ba0d9dbe33691183ef2549fdd006a02e21ac209f1d51271018e9bf565793c1cf"
+    },
+    "vondur.dem": {
+     "bytes": 3377271,
+     "sha256": "40d0ed68ef7b2c1c468cb7b06aeaa6ef6c3ffe2f41702bbf1d30682d2ef64191"
+    }
+   },
    "sha256": "c673b81abd1b78bc6518cae1502ddd57f1162000292e7a93f64554cc30397485",
    "timestamp": "2005-05-29T03:15:58.000Z"
   }

--- a/json/by-sha256/ce/cebfbab9db68954e505b7775f1769dd107a7ee19e932cc5ef022d7cf1ae5aa70.json
+++ b/json/by-sha256/ce/cebfbab9db68954e505b7775f1769dd107a7ee19e932cc5ef022d7cf1ae5aa70.json
@@ -7,6 +7,48 @@
  "files": {
   "zerdem/pak0.pak": {
    "bytes": 2105521,
+   "files": {
+    "autoexec.cfg": {
+     "bytes": 142,
+     "sha256": "d932419ea82e5aeecb0def37474ded00b1589fd826b7d18cfe0abf79a91cafab"
+    },
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "66db82ad5244af6078feb25c92092d4e097f0aecc5b15b64ffb543a2eb2464c1"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "c913f97706b3425e4e3df50c9105a9f1cfdc450de81b2763298b183a5c0fa3bb"
+    },
+    "maps/zerdem.bsp": {
+     "bytes": 1109172,
+     "sha256": "eb528d8eb4b13228c69d4c286fdf1fe818d7bdf49ae55f551664e59478c28272"
+    },
+    "progs.dat": {
+     "bytes": 425088,
+     "sha256": "15b87520c50f3d8c5ded3bf967d6a09bc6e22f8bb3d1e642717ed7dd9024477d"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 56543,
+     "sha256": "a6d2e51f5617f8edb35cf0ad7ddba23906d953e3fd91f7e3d7461c4e3c8667a5"
+    },
+    "sound/ambience/comp1.wav": {
+     "bytes": 103768,
+     "sha256": "d54261d4c9a4a8a9fe0c51eeae343c6a5b381727af88d0bae6f9b40605b8e5d3"
+    },
+    "sound/ambience/drip1.wav": {
+     "bytes": 33730,
+     "sha256": "87f83298d8c6eca12ba151bea6dca32e81082158fa62ef55d288c70cb1656206"
+    },
+    "sound/ambience/rain.wav": {
+     "bytes": 91202,
+     "sha256": "a196a2fc8a052368f9e8f7efe853391d1a99dfb1f6afae4fc7038222f2eb6fda"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    }
+   },
    "sha256": "8b29976efa14dae49852c21b5d2c57b598e12430630e8690ad9c3207d29e4b2f",
    "timestamp": "1997-06-07T14:09:22.000Z"
   },

--- a/json/by-sha256/d1/d1fd80b5f6a94c99a51b8c082e3417948fa5c20071b37a5b5f3580be246b8ec9.json
+++ b/json/by-sha256/d1/d1fd80b5f6a94c99a51b8c082e3417948fa5c20071b37a5b5f3580be246b8ec9.json
@@ -15,6 +15,40 @@
   },
   "pak4.pak": {
    "bytes": 15716108,
+   "files": {
+    "gfx/env/etacarinaebk.tga": {
+     "bytes": 515841,
+     "sha256": "bde74478ee581f801c3cedd5d1d8e410333e5629175535d742a5c2695053cdcb"
+    },
+    "gfx/env/etacarinaedn.tga": {
+     "bytes": 395751,
+     "sha256": "2d2e6e06776f815fdf6b0e0996291bfb086d07b97ef348f537d5d871700fa972"
+    },
+    "gfx/env/etacarinaeft.tga": {
+     "bytes": 424392,
+     "sha256": "76e21d15c829fec00541ae106ebc76c32154a3fb9cdf216540abe166ef764551"
+    },
+    "gfx/env/etacarinaelf.tga": {
+     "bytes": 123060,
+     "sha256": "36f2e842c2af0fdcd8e9181d140dfd1ff34dbd4142145bfb395c07cbc0666a1a"
+    },
+    "gfx/env/etacarinaert.tga": {
+     "bytes": 556503,
+     "sha256": "95f662389f25cb3cf69b85646e02131e515488d5536033abc1fa1954e7553521"
+    },
+    "gfx/env/etacarinaeup.tga": {
+     "bytes": 133121,
+     "sha256": "98199dee3afbfef51dd01ca859552a1f4f290ae73462edec0dc2ef3b40c2eb24"
+    },
+    "maps/nyar.bsp": {
+     "bytes": 5267388,
+     "sha256": "0092dfa2c7bb7e270893a2a33032c3e949dd898ef77ccdfd684092942c87b686"
+    },
+    "maps/nyar2.bsp": {
+     "bytes": 8299528,
+     "sha256": "99de000316dc11a7e290cb7d487afdc3194aa274292d5b0adb1284f50e442dd1"
+    }
+   },
    "sha256": "81b67f79a40713d296e27a2e9f9c89418cc345cfb88ac74c9c8174f24e7e1d76",
    "timestamp": "2013-12-08T17:28:46.000Z"
   }

--- a/json/by-sha256/d2/d20d6537efead2954ef637f77f02f2181a69074403e2d26da7f2b248757c8831.json
+++ b/json/by-sha256/d2/d20d6537efead2954ef637f77f02f2181a69074403e2d26da7f2b248757c8831.json
@@ -32,6 +32,472 @@
   },
   "jpqm7/pak0.pak": {
    "bytes": 28030648,
+   "files": {
+    "maps/debris/brick01.bsp": {
+     "bytes": 7912,
+     "sha256": "c11880924b195ed38908cbf50f9cd16f071918df0a94a19c7254b93dddb1e62d"
+    },
+    "maps/debris/wood1.bsp": {
+     "bytes": 7584,
+     "sha256": "c39390e3757553352941fcc255da6498be4c25a87575871e360a0166fac592bc"
+    },
+    "maps/jpqm7.bsp": {
+     "bytes": 13216264,
+     "sha256": "dee1e93b6cce7b87305b1caa34a637fd35edae7d2a9338a6d1536f32eb435943"
+    },
+    "maps/jpqm7.lit": {
+     "bytes": 8689580,
+     "sha256": "267a87e08e564898079516ebcdcd9126e55c742937e9daa74441cddb5937a77a"
+    },
+    "progs.dat": {
+     "bytes": 629374,
+     "sha256": "958d1e69318d8fcc9b87cf5ec4caf7bc054fef4380d8b4c146b125deaa314294"
+    },
+    "progs/a_mdls/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "1cdfc2b54dd883efe9215499603e341bfa72e800740a2e874e9bcf3b0afc68ba"
+    },
+    "progs/a_mdls/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "8cb54159eeaa410b98478e9190bd2d33340d3a2e98a61d32ce1afaf4e99031a0"
+    },
+    "progs/a_mdls/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ac361970fb1cbbb87ad4593afecd6d8973a65ea4f14e5f7b565c8f38c181fa9d"
+    },
+    "progs/a_mdls/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "0870b633f95bda895074e8d423631ee8805c3923f36a1c7f09938710783e8f99"
+    },
+    "progs/a_mdls/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "146955794f29c02f6570eed83e1d4b0013b0b4341897bcbc91cc9ffea6957ff4"
+    },
+    "progs/a_mdls/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "59988afc3603b83ccfadf0a9af423a113bf15ed969d4a62db9073e3061bc0fdc"
+    },
+    "progs/a_mdls/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "696594c11dd6dbd2e60ac6923d82a55f8f5b16e93b93f7914abe5fd4df74299f"
+    },
+    "progs/a_mdls/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "b558ee2dfd0078c7e3075079fb40368f53e7dfb162aaefcd20e53f562e405b1b"
+    },
+    "progs/candle.mdl": {
+     "bytes": 24135,
+     "sha256": "5027f8712c36de87b3967e4e623fbc64d4e99644f5b805f7e21ec38b1532cc74"
+    },
+    "progs/debris.mdl": {
+     "bytes": 270552,
+     "sha256": "714b4fc3ce6675f0f4edc6ed7022e817f3922cde1877eb5418e4ddf60d798724"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 472208,
+     "sha256": "3345599ba081d346c163f5c239815bd65b134ccf342601f42a31e60a45044f39"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/g_shotty.mdl": {
+     "bytes": 23380,
+     "sha256": "b919bbcba3f7f03fb8b82fa6d3b1464ca41e81cf29417cfea0de09658c698cfb"
+    },
+    "progs/h_boss.mdl": {
+     "bytes": 63532,
+     "sha256": "320aff68d374f002ed468bf17ddeca4d95f59ef68c7dd3a17287fef2da1f0b46"
+    },
+    "progs/h_mdls/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "2e7fac7418838a721d80e80370000f3e400b21248b22c8d3555588d4f8437a5b"
+    },
+    "progs/h_mdls/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "1f4b0791be3156763c15521fbf2e747744ce3355d90d630b01c2227770314771"
+    },
+    "progs/h_mdls/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "6f792b9a80f34e31bceb4258e1d2c8f22d405a7ae1198b31bb285f502c720cfe"
+    },
+    "progs/h_mdls/pd_vial.mdl": {
+     "bytes": 24396,
+     "sha256": "aab843270d62a97b563b274d08c67c8d5de697e766ba1e928f190b7c7baaf108"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 42048,
+     "sha256": "52760ce1f6e8f657e782846571baf9fde80859f5342d07a684fa8218f96f68db"
+    },
+    "progs/lspike.mdl": {
+     "bytes": 1684,
+     "sha256": "59264317258f19955b967177f0dbc5be1733e4ca07c4c7b3cc333bb88bc0c46e"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 315696,
+     "sha256": "bbfc76137aa7beb3d16231499e041d51e156ef619607c660efa46438cce45891"
+    },
+    "progs/pd_armor_sh.mdl": {
+     "bytes": 31508,
+     "sha256": "46b9de8235f07190e18d67e147ed00be6dc322cd112ccde33bf4fc1f9a77e074"
+    },
+    "progs/pd_base_key.mdl": {
+     "bytes": 21219,
+     "sha256": "320ec52018f501f8fe428dd46f44693787e545289be883a49f3bd6476974cf46"
+    },
+    "progs/pd_bpack.mdl": {
+     "bytes": 216452,
+     "sha256": "cf13d3a5239b9f6028b2a848f564769d97fcec164b56f266bbcf2657af5127df"
+    },
+    "progs/pd_rune_key.mdl": {
+     "bytes": 46335,
+     "sha256": "c4fe9bd66394231ace3127635f057987ecbf4b13b00d84501127caacb5db03fc"
+    },
+    "progs/pd_wiz_key.mdl": {
+     "bytes": 21907,
+     "sha256": "36b50211f687813b85648a46bd32a1d543a8f2af84e9d4223f8b5843f885e1bc"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 29224,
+     "sha256": "a9c150fb5c19e6e0bf7ead5dcf6ae87d8e9745f4a439779266d0a258e16b6890"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 320900,
+     "sha256": "e3321220ed34292da63fac94af63360c6544c055edd1eceed35d75eb26685e9b"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4416,
+     "sha256": "8c70353304b2d111260102565745a5504144568f932787906eaf50de742aa62c"
+    },
+    "quakec src/LICENSE": {
+     "bytes": 18431,
+     "sha256": "189b1af95d661151e054cea10c91b3d754e4de4d3fecfb074c1fb29476f7167b"
+    },
+    "quakec src/README.md": {
+     "bytes": 239,
+     "sha256": "2be824d72bdef25ec9f90b9b55b63a24334282d53d83ec79ac273249821bc79c"
+    },
+    "quakec src/ai.qc": {
+     "bytes": 16106,
+     "sha256": "afe7fd0dab4c5acbb35b6dc2e25f9f019b45a714b07f3c677a2e77124cc296c6"
+    },
+    "quakec src/boss.qc": {
+     "bytes": 13622,
+     "sha256": "f3a9aa39d57adda1b897908fd26c28e0151eaaa2920ed6a082b18b46b94a33e3"
+    },
+    "quakec src/boss2.qc": {
+     "bytes": 15987,
+     "sha256": "4aa8179663b52698079673aa46f263f9e2769e3d657a725897023bfc414c331b"
+    },
+    "quakec src/buttons.qc": {
+     "bytes": 3249,
+     "sha256": "1a814605af733bb3fc6ae250d7af5cb0b2d40bd3b37f5522b6d928126dd6eac9"
+    },
+    "quakec src/changelog.txt": {
+     "bytes": 9966,
+     "sha256": "3cd20bfb967d6cdfc724b1da9caaf77365c158d73c092d5ae932fe337f183324"
+    },
+    "quakec src/client.qc": {
+     "bytes": 42633,
+     "sha256": "d0ecb904610a814c60e20194b1fc42287f36e9ad23ff04f2ad60a332a6e005b4"
+    },
+    "quakec src/combat.qc": {
+     "bytes": 7192,
+     "sha256": "c1b5774a0b11c50cf5e6508e11349aa38c6bc8b468fad60fe7c0a4a1d30c9cc0"
+    },
+    "quakec src/custom_mdls.qc": {
+     "bytes": 2167,
+     "sha256": "3798f019c4c7151be89ccbebb560120101e69357a1da645a497b90fcb9bbbba3"
+    },
+    "quakec src/customsounds.qc": {
+     "bytes": 5564,
+     "sha256": "26bce1b876f3a8a709a2b61298d1f65de5f568f24ac66db713e8585afc694f5d"
+    },
+    "quakec src/cutscene.qc": {
+     "bytes": 30669,
+     "sha256": "b9ec452e62de479c53c05ac56a943c79d89ac7d6ee3d3bb3c68fb203656ac5cd"
+    },
+    "quakec src/defs.qc": {
+     "bytes": 25275,
+     "sha256": "01844d4c5c8ab85a9e4276900c1aed7e6d5a4260aa4e646f6dc8d057d06ee4a8"
+    },
+    "quakec src/demon.qc": {
+     "bytes": 14554,
+     "sha256": "c86075c879715287caad3d5a014eef446ad77b438fd0756905f0f95dd202bd33"
+    },
+    "quakec src/doelightning.qc": {
+     "bytes": 4955,
+     "sha256": "4b6233156f3792d7529d714de7f992c066a927d5f9109d9947caa2a7a2341c57"
+    },
+    "quakec src/doeplats.qc": {
+     "bytes": 14879,
+     "sha256": "dcca85f99b803fbbafea7ecd0b12ae8cf02e9dc48422a28e6d70335f749eafe3"
+    },
+    "quakec src/dog.qc": {
+     "bytes": 14108,
+     "sha256": "ca8ce0d87fd1eda73eeeee13ace5eebd0bc183f7dc610cc1d6fce01c163bcb08"
+    },
+    "quakec src/doors.qc": {
+     "bytes": 18041,
+     "sha256": "539a978d92e7120db67fb89116f94744bd82333751a575c364955e8e0895cea1"
+    },
+    "quakec src/dtmisc.qc": {
+     "bytes": 29848,
+     "sha256": "8392b74d997a79b88866506c47215b50adc7a05bbb0c8bfc9cbbf5bbfb33881e"
+    },
+    "quakec src/dtquake.qc": {
+     "bytes": 2654,
+     "sha256": "170b5464e0092f6a2f261910108381fd93fdb7fb5dd7bc047863f7bcc462dd9a"
+    },
+    "quakec src/elevatr.qc": {
+     "bytes": 3624,
+     "sha256": "eb6a260d53ca8f7b69f20a8cc42341c597d5e06ea18bca86e6aabff71bbc892b"
+    },
+    "quakec src/enforcer.qc": {
+     "bytes": 24697,
+     "sha256": "55419fb7e3c912b0e47396304e3abe2fa219be8ba9b9da361d44c03dafc7b61d"
+    },
+    "quakec src/fight.qc": {
+     "bytes": 7568,
+     "sha256": "301de69f7dad8a34fb361ab90e2a907c62b4633c7dde410b9e4bd6b81c017500"
+    },
+    "quakec src/fish.qc": {
+     "bytes": 11627,
+     "sha256": "2a2a72686b7177527bbfa43304fcc126b8f66ff4724f1b0da57f93f2ebe693a5"
+    },
+    "quakec src/func_bob.qc": {
+     "bytes": 5676,
+     "sha256": "5fe11638fd89f509759c83748c519b98dc5fe5856b09fab1f6247518b9836143"
+    },
+    "quakec src/func_fall2.qc": {
+     "bytes": 5632,
+     "sha256": "11cb67e867005f519f2df4e382f6330aa2218f3c10a612911caa22cf6d69ae99"
+    },
+    "quakec src/hipcount.qc": {
+     "bytes": 5217,
+     "sha256": "da5c096495966fa9ef5315ba00b315987349a817c889b974d8a91f506e6aee1d"
+    },
+    "quakec src/hippart.qc": {
+     "bytes": 7983,
+     "sha256": "730ed584b4de9dd49283502419a8bcafb99e2f1a3d146e05afee0ab2547751c3"
+    },
+    "quakec src/hiptrig.qc": {
+     "bytes": 6260,
+     "sha256": "e0292ef23ab7c669257e30525897fa1ae64e3c0870002863e5fa98e8de95aca1"
+    },
+    "quakec src/hknight.qc": {
+     "bytes": 23977,
+     "sha256": "1c84fb40236ba7b067081570db4e0dcc1a669416efafc5c4dd99d1ffd488768f"
+    },
+    "quakec src/items.qc": {
+     "bytes": 67829,
+     "sha256": "a14256e3807beeeebb309c59092820445b226069f2927e373c08b4608b8afed8"
+    },
+    "quakec src/keydata.qc": {
+     "bytes": 5639,
+     "sha256": "5902993c9755a2851ef424e48572a9806d20d3aae67a8f9d01446c4aad09a91a"
+    },
+    "quakec src/keylock.qc": {
+     "bytes": 5884,
+     "sha256": "26751c63554a6e73da84138ee45871f501d3bb5250cbfa137a524087bc204e39"
+    },
+    "quakec src/knight.qc": {
+     "bytes": 14633,
+     "sha256": "8048aafb27c52ad8fb92bec060401a9702c0cf9918b34e2bdc49ae2b423705a1"
+    },
+    "quakec src/lights.qc": {
+     "bytes": 15369,
+     "sha256": "eb7bcc93ccdb36c7df4aa49bb370f4d37eb598cbc51c8a9c2ff668769194bcae"
+    },
+    "quakec src/math.qc": {
+     "bytes": 1813,
+     "sha256": "9d5303c03ed58760bedbeb3f017ddebd5bc0c27de43a1e62ea3b5ae8bab2b927"
+    },
+    "quakec src/misc.qc": {
+     "bytes": 39913,
+     "sha256": "fe61ad291552bea62f41c977ec823c96a8342bd026241a1bdae564942cfcaaa6"
+    },
+    "quakec src/misc_model.qc": {
+     "bytes": 1712,
+     "sha256": "1a070d9cc274f76c2032b2cc459a002df8ce76103aa9f318d100e577a204df21"
+    },
+    "quakec src/mobot.qc": {
+     "bytes": 13931,
+     "sha256": "b9e698b47980f8ca795cdc928b7e107a2897ad3578cc172eab45dcc38c96982b"
+    },
+    "quakec src/monsters.qc": {
+     "bytes": 10018,
+     "sha256": "335d8da10275b61aa57b939a022eb8995d3a745609ef83d321bf52731e94ef11"
+    },
+    "quakec src/newflags.qc": {
+     "bytes": 5870,
+     "sha256": "192bf31eb0f13e6e55342801a42608caf797bfdfbdf27750c78ae67b1c1c5568"
+    },
+    "quakec src/ogre.qc": {
+     "bytes": 39928,
+     "sha256": "37aaeb400bd87453aa8d3d5b9d399dcb7e9ca90b911d018167152d8058e7e860"
+    },
+    "quakec src/oldone.qc": {
+     "bytes": 10263,
+     "sha256": "71f269418437ca5dc5cdb1ebe917a1a7252fde104ca92011c0079fa7769aa740"
+    },
+    "quakec src/oldone2.qc": {
+     "bytes": 14736,
+     "sha256": "6a3cb7559241c34c69ca053780b8d2e156eef260e0e54a2d575ca3a690aaf357"
+    },
+    "quakec src/plats.qc": {
+     "bytes": 14266,
+     "sha256": "545511c895c06cc2676cfa33f953415b4ee33ad72f2292c7d0b70026fa77d3ac"
+    },
+    "quakec src/player.qc": {
+     "bytes": 20579,
+     "sha256": "5612eef978278acf038f2a24b9050f237ea966a79a02fe79e78f4687b527c541"
+    },
+    "quakec src/progs.src": {
+     "bytes": 1907,
+     "sha256": "9f39f79f6601938cb94f93831f5dbf7e14b974a25f7d86554cc417aba66f20d9"
+    },
+    "quakec src/rotate.qc": {
+     "bytes": 31330,
+     "sha256": "63103ad2bb9f6cf0479863d22188bfef46acc674d27ec00863b9c7f098d3c6af"
+    },
+    "quakec src/rubicon2.qc": {
+     "bytes": 28533,
+     "sha256": "6ef16da656ddbbe1550284da2f594be13623a1ac3ff5f0034df7c862e62d4e29"
+    },
+    "quakec src/shalrath.qc": {
+     "bytes": 13109,
+     "sha256": "a0f1b2be13a2a3cb3ba41b413669ed67419a8a3a26108771fe910065192cbb46"
+    },
+    "quakec src/shambler.qc": {
+     "bytes": 18148,
+     "sha256": "96c483b3af04299fd0368c430022082141ba10af96a1dc25771dfb4bc830b513"
+    },
+    "quakec src/soldier.qc": {
+     "bytes": 18710,
+     "sha256": "220d51eeb811a417c47eb999ca4b0d69c417444265f941913d1badbd898d9f99"
+    },
+    "quakec src/subs.qc": {
+     "bytes": 14185,
+     "sha256": "d0e5649ffd317bf70b4c85d686d7f7035ce68a7c616733039788746974a9554c"
+    },
+    "quakec src/tarbaby.qc": {
+     "bytes": 9855,
+     "sha256": "c81c6071648a0acb0d5f7dac6fc49b78661d43bc114ab3c11194bdeec9b199d2"
+    },
+    "quakec src/triggers.qc": {
+     "bytes": 39079,
+     "sha256": "1d057a55361fe573a3035524b44571a7f12cfd2b8be83f9c65948cf0932feb35"
+    },
+    "quakec src/weapons.qc": {
+     "bytes": 38077,
+     "sha256": "b1ba08d39931a7cd06adb497016be6a4cbbc585d507f1a86e8aa967ddda6b0a0"
+    },
+    "quakec src/wizard.qc": {
+     "bytes": 15610,
+     "sha256": "0ecf27e676b25de687da14413f82f535d6614719099fdd8775f6d7793c7d64b3"
+    },
+    "quakec src/world.qc": {
+     "bytes": 20871,
+     "sha256": "7be5e3b9e534fdd61250d1376b5c66531642b57d9edf996c7e8f365ea0e17b57"
+    },
+    "quakec src/zombie.qc": {
+     "bytes": 33395,
+     "sha256": "053eab38bec4d63e2c020b28bdf27a580de513c206d41b59cff7e49fa833e89c"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/distant_gears.wav": {
+     "bytes": 72502,
+     "sha256": "760d34131249ff3c4bccdab0cd3df69874728a6db3e1b4545177e5ce381e5e80"
+    },
+    "sound/ambience/lowboom.wav": {
+     "bytes": 666640,
+     "sha256": "ad591a6f574f48e654e32dacee6b7d862df8b47e20ef116f84415ad9aa515559"
+    },
+    "sound/ambience/moo.wav": {
+     "bytes": 265502,
+     "sha256": "35b7924115bc4cdf94e9cbb274a4d9ca251d6878817834bec08aaa176f2ddc9b"
+    },
+    "sound/break/pd_bricks1.wav": {
+     "bytes": 61786,
+     "sha256": "3829842a9cb395f99d07546be38263eaf0ee5bbed71841aa8c93864d55a7fb94"
+    },
+    "sound/break/pd_metal1.wav": {
+     "bytes": 44146,
+     "sha256": "c0111b94231bc3870cbb95ec03f13b2b44ac407a5d18b35668ccf231303cc8aa"
+    },
+    "sound/break/pd_metal2.wav": {
+     "bytes": 70722,
+     "sha256": "ce8250482e831c270cc3c8e9211b74a627b3e29159c2c8ee720dd11cafd365c1"
+    },
+    "sound/break/pd_stones1.wav": {
+     "bytes": 75150,
+     "sha256": "632d15db23ff70c23c199595b41a153ded67f664de46b7d0cbfa0228f071156e"
+    },
+    "sound/break/pd_wood1.wav": {
+     "bytes": 34526,
+     "sha256": "621865f52fc27fb10108027ce3eea18aaf17181751a3ba1ceee0c9c99da9f375"
+    },
+    "sound/break/pd_wood2.wav": {
+     "bytes": 33342,
+     "sha256": "77282f2c533b9aec72b232aace9078534db3f255f418efafdf769c7361a28e05"
+    },
+    "sound/dump/elec22k.wav": {
+     "bytes": 82784,
+     "sha256": "dd63a8517e33bbe7a75cd0d6ccb16835b73f83af8d31c0ae0277b7304f7d502b"
+    },
+    "sound/dump/pd_armor1_sh.wav": {
+     "bytes": 12410,
+     "sha256": "3b80fc8000fe624ffbe4f119faf41a77406b83bd350020c7782bc03fd51a1799"
+    },
+    "sound/dump/pd_magic_01.wav": {
+     "bytes": 125944,
+     "sha256": "3ea2bab80feccbe0f0b518ec613f45093aa76b0128752f454e239c75175cb4e0"
+    },
+    "sound/dump/pd_quake_end.wav": {
+     "bytes": 37248,
+     "sha256": "3ecb621fbf5a3f2ab090ebc0f3036069292181b11ab366689b3dfa0f19dd372a"
+    },
+    "sound/dump/pd_quake_full.wav": {
+     "bytes": 156278,
+     "sha256": "872e0b0847fd366c59341d672cba9da0faaf85a881f8d4d5471a664923c8440e"
+    },
+    "sound/dump/pd_quake_loop1.wav": {
+     "bytes": 159956,
+     "sha256": "52a330a12c35191347008f4c546b1c83b4e387f3f33c9b60c3a5e8e545b0517e"
+    },
+    "sound/dump/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/dump/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/dump/water_59_02.wav": {
+     "bytes": 40038,
+     "sha256": "25aa667940a737e46da0a829d9cb94922972b9b19726664d1a1133a666dc1439"
+    },
+    "sound/oldone2/pd_pop2.wav": {
+     "bytes": 42108,
+     "sha256": "1eec3103cd2eb70fa8ba63ce8ce721842a64a99e9c373f5a8abe5508273ce285"
+    }
+   },
    "sha256": "7b74110af09ddd58059b9da585658913bd80276398810f0f119deba36452523b",
    "timestamp": "2021-05-01T16:19:46.000Z"
   },

--- a/json/by-sha256/d2/d2489b4b26e65b81676112dcbed4eac2eb87f017f0f3de18b871e357da3b0bad.json
+++ b/json/by-sha256/d2/d2489b4b26e65b81676112dcbed4eac2eb87f017f0f3de18b871e357da3b0bad.json
@@ -7,6 +7,12 @@
  "files": {
   "PAK1.PAK": {
    "bytes": 509691,
+   "files": {
+    "progs.dat": {
+     "bytes": 509596,
+     "sha256": "815ab1c79f59947006b07f2473bb7c0fad4a75a94e526a6a063bcbe4ddd3ce16"
+    }
+   },
    "sha256": "72930aa770d91b37742800a6ef266e42111c089ba27a289be2d84ec6d08a7c43",
    "timestamp": "2000-03-30T21:16:16.000Z"
   },

--- a/json/by-sha256/d2/d270bdc48ee9db7f2bc79d7c4b9c433df7cc6f64ee3d90a32c0b393c6f4d1dc7.json
+++ b/json/by-sha256/d2/d270bdc48ee9db7f2bc79d7c4b9c433df7cc6f64ee3d90a32c0b393c6f4d1dc7.json
@@ -518,6 +518,116 @@
   },
   "retrojam6/pak0.pak": {
    "bytes": 271628,
+   "files": {
+    "maps/b_batt0.bsp": {
+     "bytes": 6980,
+     "sha256": "0d481a2e2cd7a23e4ef19c19622195007bd6c9a67135ef739b0944a02d46fcd7"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6964,
+     "sha256": "34709c1c06ca34305a8ba1d4799d1cdc07e44ff33f3c7fa11c3d5933cb942579"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 7124,
+     "sha256": "d3371655bed274070fa98fb32b408bab4a22fe754f5158c8c94a072749a5d24d"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 7764,
+     "sha256": "abdfe383c13da6d5dd7a9409fa5d3db2c4bac78482eb75c2c2b42da7811ec3ca"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 8788,
+     "sha256": "2343448faac29720e3a690650b70623852710dcae002917ae5772fa597117e17"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 5604,
+     "sha256": "66ea23f1cdd6225afdd1b7cf1247b93d174562193e0807561b96b659429f2bf0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6820,
+     "sha256": "366ece777ae71ecfebaa9f4bebafe2074b5336e7939900f46bd9521886f9f42d"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 7092,
+     "sha256": "56a66aa3d1364a0436ff8ce880268b2a9c2c396ab02f0c6277535d5b99eae31a"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 7636,
+     "sha256": "ddd60cec57d8e3954c1ffce616ae862edb784417a6b6622cc001d408383a6cb9"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 5396,
+     "sha256": "fe60bd7880da73571e29fa4075968cccb06e913bd2b9475868ce31c69b1a8c19"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 8436,
+     "sha256": "6a2c2c3fa6f88d425ae5b9568e5d8224ee901a1d8faa8363b88fff569b7d0e5f"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 25812,
+     "sha256": "1ba9d3176bb2e03a0457427fd9394d8c15eb9ebae8af9462e955e9c6c6068513"
+    },
+    "progs/end3.mdl": {
+     "bytes": 19700,
+     "sha256": "445af16e28fff506ad65fac16b09dad1672e218ffe0183880aff565578b315b8"
+    },
+    "progs/end4.mdl": {
+     "bytes": 19220,
+     "sha256": "cf52525422a102760bfcabd6e8dd5c5df7c2028daea5baa2a1b1717648dd143e"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 3860,
+     "sha256": "256412b0d88c020fb03efc5e914c5dd721c9dfe8d6a36ce4a7b01e7597d7e7d5"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 7108,
+     "sha256": "d4c5b6316aa02d600951c6a8ec1f4682568b9e877e988cf4cedd77c0e95cf663"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 21412,
+     "sha256": "1274fcabffa89a786b29c9238cf84e95a8557369239b4a9eb813e3dbe37d35ac"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 5492,
+     "sha256": "ecf293b2e8146a33de7bc8bb3cded80bb785b931012b40dca204db3dad50e776"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 22052,
+     "sha256": "c5657b558522e46f0833b7827520c1a5c1f1674dffd52c12609779d5bcd75462"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 1396,
+     "sha256": "945ad552ad86e5193ef9c007dbe23686fbe89be1060063f57ea693b89e5df229"
+    },
+    "progs/spike.mdl": {
+     "bytes": 1396,
+     "sha256": "c5e6afcfbfe35ffde5bda7eaf91e2a583c3f20cf8f3175b4f4e0ad03b358983c"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 9012,
+     "sha256": "06e8f32092cbc0b5ba4d26227df9ac2d10f3a76d9a63bc7928af147b4ade12d7"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 6356,
+     "sha256": "40d9d29c58df57ece6892d71d0464022eb5939aa45699e98eae22136b973c4c8"
+    },
+    "progs/zom_gib.mdl": {
+     "bytes": 19768,
+     "sha256": "2175cca881b4a73adf3742933a5d3e91116c774ddd3db9b6ac2a7f863194d4a8"
+    }
+   },
    "sha256": "71941eabf9224d83cb7106a4c98950fff0439a6c73534e6fca8ba99e8469a277",
    "timestamp": "2017-01-01T12:44:28.000Z"
   },

--- a/json/by-sha256/d4/d45ec45b52d113d5d50c596b6d14eac4c5f840dc4cfbdfd987b76feb5b373ea1.json
+++ b/json/by-sha256/d4/d45ec45b52d113d5d50c596b6d14eac4c5f840dc4cfbdfd987b76feb5b373ea1.json
@@ -7,6 +7,28 @@
  "files": {
   "shoot/pak0.pak": {
    "bytes": 2560581,
+   "files": {
+    "demo1.dem": {
+     "bytes": 736852,
+     "sha256": "ea1c7cee1ddf70d0ddcb0ce22ca064513a23fa4da8622ad72f16bf476deaa875"
+    },
+    "demo2.dem": {
+     "bytes": 426899,
+     "sha256": "be9973a4ee619688af4d11827735afc5208dbab4d9e254df3fd851d54db68257"
+    },
+    "demo3.dem": {
+     "bytes": 484518,
+     "sha256": "cd036d91a5a91d656858d073d183e60c2d1b41ab516bc6e165faa2bd4a21437e"
+    },
+    "maps/shoot.bsp": {
+     "bytes": 680028,
+     "sha256": "e0e562106f8dace25f8baa29afaa94bc1d58caac65decb5523c27bd27ba5425a"
+    },
+    "maps/start.bsp": {
+     "bytes": 231952,
+     "sha256": "f1ed5e701c329227ceb5fd84f313c58bbe5e33abc47335a9a0a647a390d659f8"
+    }
+   },
    "sha256": "8d80727766eb0fd8c2447cc459a52174e22db1af66f74ccad7fde4fd2bca0421",
    "timestamp": "1997-12-28T16:58:58.000Z"
   },
@@ -22,6 +44,38 @@
   },
   "shoot/source.zip": {
    "bytes": 253248,
+   "files": {
+    "shoot.map": {
+     "bytes": 205578,
+     "sha256": "2f3922207a28a8cb88c2fe6924d23a68051542e8126b8b078e3c88f7bfa7b6c5",
+     "timestamp": "1998-01-05T14:40:54.000Z"
+    },
+    "shoot.qle": {
+     "bytes": 395539,
+     "sha256": "f18c0edb9a1542549a0ec51087416ff1a01814e719a74294db2f96594b97b5f1",
+     "timestamp": "1997-12-26T17:59:00.000Z"
+    },
+    "shoot.wad": {
+     "bytes": 361584,
+     "sha256": "6d9e4b3da0511da0903c33f8bfa5d454f562adddb34d6f2c96c28585834186ab",
+     "timestamp": "1998-01-05T14:40:56.000Z"
+    },
+    "start.map": {
+     "bytes": 62904,
+     "sha256": "63b245213dc64f374d55c3713383f15ff9722fbd29d9047726da7bb056b334b9",
+     "timestamp": "1998-01-05T14:41:50.000Z"
+    },
+    "start.qle": {
+     "bytes": 118028,
+     "sha256": "85fa4a4988fabad8f4fcd39b92bf6a36a34de46df875b2ae71e2b7c45ee7c22f",
+     "timestamp": "1998-01-05T14:41:36.000Z"
+    },
+    "start.wad": {
+     "bytes": 66160,
+     "sha256": "1a391cade1118a9a47755a94327f8e9d284d09f0e5f90fc27176e3a13e967368",
+     "timestamp": "1998-01-05T14:41:52.000Z"
+    }
+   },
    "sha256": "929bfcc6971fc1b130ad39ee42e3056a1caf2e89632d95d61a8c0ca8d47a99d9",
    "timestamp": "1998-01-05T14:45:06.000Z"
   },

--- a/json/by-sha256/d4/d4e45c20a816ce13c49c5f717c492b4acc9181ed969505aa34548da1d7e28f55.json
+++ b/json/by-sha256/d4/d4e45c20a816ce13c49c5f717c492b4acc9181ed969505aa34548da1d7e28f55.json
@@ -132,6 +132,2424 @@
   },
   "lamothe/pak0.pak": {
    "bytes": 34544010,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 52014,
+     "sha256": "b00eb8dfeae62cc27fb8a0603c2a8056b602d4b53710a42af869d8c0d32761f7"
+    },
+    "gfx.wad": {
+     "bytes": 210484,
+     "sha256": "9072806ee7e43f2ce712cbe7bd68355dd659447258c7e35e1005d71df7ad5baf"
+    },
+    "gfx/bg_ammo.lmp": {
+     "bytes": 1928,
+     "sha256": "754dc8ea867ba7dcd60407764b51a1eccac068456c38787744387a4c59cbce62"
+    },
+    "gfx/bg_runes.lmp": {
+     "bytes": 520,
+     "sha256": "6b69fad1c89ac2085dcc7b8153d1f19ae353bbd0572b05aace1afc02e8e984df"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "6072bd63a691625de201f3f3da060b5df433753d7ac2878c48b87e9d0dd08b94"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "ac11a967228e1c7d1a936859b82807cea239d80380fb6204d67af7a86c5c82e3"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "4cb99cf1b515b6547f012b6e44174c245261b058168a8bc4303d08b98e1805b6"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2c37b7697aebedb5bbf6637d4b8e158f70da6b7245195ff0e91a6ba7aa24e828"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "219002fe962a017600a37dcdcaaa0f777aad42044619f945cb70c68007763a97"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "e251893ed49aeb677096d380d4246907a039e0e21a4849f97f343b0b13faead2"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "64ec646cbab7ebca11f6af4f0b75d9706f438baa7b23059de87f8685f4686640"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "03c7cdc618e4404e2b9364c690b0a447b4be99dc5af112c66e6e2079902c76cd"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "9cf2683f2a6d22693a8c0cf35898bc5900a96afc771878df9f8a8a88f3d581c9"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "f232da5cf35acc557f3f312911e6a856cffaaf9f8078ca2ac5ef7e6f6e5e3515"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "b57ad9ad9d6240a0e035ca7a64e706e3031b8293c27355c9a95495a84972af4a"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "873af58b7244d6e82feb1af26ac044c9beb43c2865bc51d0485054a562ce861e"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "ba75badfe057b499d33168032dd5dc5a4fd0dcbaef9cbbd27efdb3f056cbfc00"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "55ac1377921460aeb691f86e7a5051e3a5481f24b93cc8578cffdab2854ba0c3"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "9600a66391996cff88d48890adfa516660fce6a32397ba4f54973159785cff4b"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9f03351fa7f31a23b63e6c13d2a643ed1ae3fd3df0cf2b0db336424eb17016dd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b7617428e8d1d74be7b770ef24c744d16c2503efce9c17facf1107cce08f5ed9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3036afb422cd299cb09532a20847ef35aaf87bb36e34ce9ce75b5e7aaf9a1ec3"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "7aa61257bd3083c00959776eb36aac86a7ca8da2bacbb4c8a41d9a5fb0b1ab97"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "cfe83953875acfe9afda11b75407ed9883eeb284b0a67b9ff6e07df85d50d9fe"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "d3b4091b83837da5a45445cd00b90267c62050e010e2a045461034ac9c48be33"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "de004dcecdff1973597a977ab63c671ad7d3f52387bdcff4be560924e3d4d17e"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "078c56d685ff1fb84b322f7a76e485c2637fb09efc61f4e44d5d067b3ef9a42d"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "9df9672c8da61ae769409e9ea741a1b8f9a4f108b5f0fa6637ff65601c535843"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "fef6b9be45d5b384d061a47f133075d1cfe0b60d93cf7e3da9ee5529f661964c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "1b1254c1f5764affca85448c4a3c2fefdb938f35bc50f44142a8e9b692ba7d64"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "39a06ff92831e1e2fd20c1bdd20e0f234cd0b3aed94e6c9909d059a20479ce3e"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "def061c922fb91a7e58850e89bb6baa9e09dcf93de7a94288a90511ecd9a114d"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "3220d953bab793165178f2666e67032398a6bd0e0510f6b92eef4fcab377ee1e"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "f897535531fe4b821d41d859a4085fd7d25c679493645a2ef7448f62073523c4"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d070636562a967d1abff330dcd1ea504ac7b9b29099a98994add1d9ae47e44e9"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6d92547a27d839f3c9d7a1da786fb33547cd93b7f19560b6c4bcdc12064545bd"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "e932416c58fc5de16e6d05aa737e56d3811e540bfd9e6acd1bf114ccd8bf34ac"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "bda55d4b2d7bc3f180dafd62424ee5830896563f5a5ac576dfa08894f5e17e44"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "513955ecc96eb1f0d44b340b47f79c02bb7bfa7f3b0a884a65fe111429ddb2b4"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "2faa4c1f61d175ad28b7f54540af3f87abc6e56dc20f2da5fc8a7737a0302c97"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "dcfe5287432b3a1124d032250ccc4bf25c73540521c77601ab746287ef3a0179"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/skillmenu.lmp": {
+     "bytes": 14408,
+     "sha256": "dbf40f0e5faedb181e84d4a822ecc9316711ae89530a30bd50cf4fba45aa8251"
+    },
+    "gfx/sp_maps.lmp": {
+     "bytes": 2248,
+     "sha256": "024bfb2d05f1c52bab1a856cbc532d06fdf4e8d96fb486f74bf451472311ebcf"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "00654b7bec9981508cd9ae8eac167637926c023e7bca011a3cf37585b7e168a8"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "74c50b895f1e71ec6a569fba0e991fde8cf136ea734d6914435aaf9b2735d7fe"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "aecab7a199a4db72242659e6d1ced192d39b2619f67c7e5eaafa72a5efef3aef"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "d075eb0c8c00d30b01eae539720c20b73bb57066c6ea5e8180a4d851d9167add"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "d03aa05e24552d961ea9ca278d743860e34a97e2ffcee52fded05ad4b4740bd9"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "progs.dat": {
+     "bytes": 1123258,
+     "sha256": "6feb4578285cd1faa37798124a165e8b928c9c5a8651c307695903d2218b6589"
+    },
+    "progs/alkturret_base_v2.mdl": {
+     "bytes": 87768,
+     "sha256": "4b1969201052a4506509bb606eb7c395daf9332cf4605036ab50190495dcfbf3"
+    },
+    "progs/alkturret_main_v2.mdl": {
+     "bytes": 116620,
+     "sha256": "11a2564f7daa19625e4514c284650242c8b3831df947f183243adafb958a1333"
+    },
+    "progs/arachnofloyd.mdl": {
+     "bytes": 741212,
+     "sha256": "554bd2ad34a830fa01a61dd4972f432812fb61f7815ec81d8a8d7e87bfad6b02"
+    },
+    "progs/arm_foot.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 164224,
+     "sha256": "35314143b9c7a9a0e26e52a865072a6e73862466e640c6bbd58be3075c4d93ff"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 497408,
+     "sha256": "40cc63b599cedb54f04c937ce407e7119c1cf4d5d35fd04bc18f247584e9899f"
+    },
+    "progs/b_p_key.mdl": {
+     "bytes": 5940,
+     "sha256": "051b2e8fa67cae7aa24490a18444400f773d4a9d353542ebf979b0a22a1771ef"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bambler.mdl": {
+     "bytes": 128044,
+     "sha256": "c8ac9dbcf99f0e6efd30496ac414383c26b8d241fbaff56cfa81dfb545dfb0c8"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "698bf740683ad182feae2246526361948be6da2e144f1bd0202eafa748213ec2"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "b662513bc3a8e0e967344c55b536bd33012340dbeb79a8db1281d2c84e36d338"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b2cf62d8e989789bd76e27193b2f5205a93d4172a4e25c89aa1b30f75bebe60e"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigcranea1.mdl": {
+     "bytes": 92792,
+     "sha256": "81f6a5b55d3a585d5e9c73b088d1d20e0fb328707c1539ef41e52c460555f651"
+    },
+    "progs/bigcraneb1.mdl": {
+     "bytes": 21940,
+     "sha256": "e02faff0bb6c84c781f6b534a5a06ac1f977a028fbdcca176be2932f91e9e8ec"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/brz_saw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 575288,
+     "sha256": "f571bdf504537ce01ca2b6a78b57575a36c391f9c786625d880d956fb17390a7"
+    },
+    "progs/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/chain2.mdl": {
+     "bytes": 141764,
+     "sha256": "9334a3ec04716ce0068154bf7abb4c1e3ee6de14fb159982dd547314935d7854"
+    },
+    "progs/cyberscrag.mdl": {
+     "bytes": 306936,
+     "sha256": "868d1394e186b1e7f4fc58134c338a413814723f406fa609e2d7cb87dc2496cb"
+    },
+    "progs/cyberscrag_gib1.mdl": {
+     "bytes": 60500,
+     "sha256": "3db8b13bfa5a5eda07acea695cae6ffb92354053da9bed199ef29cd445317faf"
+    },
+    "progs/cyberscrag_gib2.mdl": {
+     "bytes": 58932,
+     "sha256": "ef20c0de15fe2fc2514c10b0023d14009a4871ed40311077ba107350c313f7ce"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon_alk.mdl": {
+     "bytes": 191716,
+     "sha256": "11f33f19ae0a46d3dcc6c1fee46235fb6ad201456120502b603fe4fb7cee14ac"
+    },
+    "progs/demon_old.mdl": {
+     "bytes": 272684,
+     "sha256": "538d5d01833d6910d4400f8795be582c3427748eb2a162fcec2c17d6707c57e5"
+    },
+    "progs/dog_alk.mdl": {
+     "bytes": 199324,
+     "sha256": "a16e350fcd247908c75ecd0c93e94d3b700b67bb0f66dd45d665d171a55d42b6"
+    },
+    "progs/dread.mdl": {
+     "bytes": 415072,
+     "sha256": "dcea570331c5cf4348c40451c6242bf35ecaaea2a348f12254a13c1b76b13d7c"
+    },
+    "progs/drip.spr": {
+     "bytes": 60,
+     "sha256": "318b639393297fda1f569a1997ae685385fbcf2ec67793b1a6a05ef04cf5f6c4"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17284,
+     "sha256": "444692074359310be0520b1caa057ae2e084df826f7ecc9bcb0d258ea1d80373"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35988,
+     "sha256": "91aa79805577466147bd4811614b0387b3635aba8383fc2e16b178d7b63ebdf1"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42436,
+     "sha256": "93839bd6f50323f7ac5ae46037de0c6a10a533374f714229dd511ee62b88ca3c"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bcc6396dc638003480dba8c36cafaf32df2cfcf49bd460b001d0d74a164f9011"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/enf_gun.mdl": {
+     "bytes": 58684,
+     "sha256": "39ef1788b39a15f86c8d54b81c43f4126e8361ff80d386c44358f17ddc93769f"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 450424,
+     "sha256": "ecf603c4ebc56438e96d1706a451af8bbe9b090db9c48e38e758ec630a393570"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "ddcf759804fffd97e62c55f67f962e24e8cd646fd982215ac8aefd3e49f67660"
+    },
+    "progs/enforcer_alk.mdl": {
+     "bytes": 333860,
+     "sha256": "85fb5cb9eb1435da65ce0aa6940241b7b4b5fa13e7444713a75c6ec301cc8b97"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish_small.mdl": {
+     "bytes": 221279,
+     "sha256": "34b883e3bf73a520f301cced68629e0d95e88f96c03a23230f12d02aa49c247c"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flag2.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flagbig.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 451032,
+     "sha256": "1a311e7e74f9a67c9f7468252aedc8c19804f65375d229e90afbec2f93849823"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/fromitz_still.mdl": {
+     "bytes": 6964,
+     "sha256": "63204597e828e001c957e9316878995e161da0502764276b90285accadf6a222"
+    },
+    "progs/g_axe_alk.mdl": {
+     "bytes": 50460,
+     "sha256": "92988e970870f2b977f7490d2ea4ee040d338fa4bdc470e8d68f2e5a856a7a28"
+    },
+    "progs/g_axe_alk2.mdl": {
+     "bytes": 50460,
+     "sha256": "e448b2a7540ba959453592b2472d0ae498142a77242c91fd5991ca23a7973f4a"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_mine.mdl": {
+     "bytes": 37780,
+     "sha256": "5057c7736e8c722270c781e47584972f42e7ebdd5860596403a9ce7688d0b5cc"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "15f390e39e02c8524e575ca8fadf63187b641c58210ee9587b13a0ca94c29cc2"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 199076,
+     "sha256": "7ddca6fb95082d0cc7ffe5aa3ba896ea987a80b1bd5867db97b2a84b9d8da9f6"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "8b05b8ca87ea867c2a2397d238311fda2441f5c0e1cde130ba487b0dbd17a8e5"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_arach.mdl": {
+     "bytes": 60292,
+     "sha256": "daca6412383bec28809cee42c4ebf01085cf83ed6ff289114ba0f842b4005251"
+    },
+    "progs/h_bams.mdl": {
+     "bytes": 37316,
+     "sha256": "58c4644a2ed3e5f10741dff2ad1a8bb161f7eb205ba3fd8c5fc9b7e4ffc571dc"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_cyberscrag.mdl": {
+     "bytes": 62036,
+     "sha256": "df7d6bccc97bd5c184d9d6160005b370175aacc16a34bd06ab14c7d69ff60419"
+    },
+    "progs/h_demon_alk.mdl": {
+     "bytes": 72644,
+     "sha256": "22a9e01cdccb2e274c63c277e6dcd61986fa7556426ee3562fe11af2babea289"
+    },
+    "progs/h_dog_alk.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_mutant.mdl": {
+     "bytes": 110240,
+     "sha256": "f1f9c665b659a8c145550605ef9abddf27779d0917c897baa344d65673770875"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/h_sabrkn.mdl": {
+     "bytes": 11828,
+     "sha256": "050fcc93189211aba943674a326ddd898dc980b83fb551ee11fec3dd39973483"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shams_alk.mdl": {
+     "bytes": 37268,
+     "sha256": "9fcace6cfb38473763a5cf96007ccc5e0ec4786352d4d1063410d63157298b45"
+    },
+    "progs/h_torm.mdl": {
+     "bytes": 62056,
+     "sha256": "db0ddda0c4d2283cd3c58eb45397cfb57095acba1eb6dd38571ca23ebffe9946"
+    },
+    "progs/h_wizard_alk.mdl": {
+     "bytes": 14948,
+     "sha256": "5f6c27ba255b87718d993b29cff526bd025c0e7a4991722a96fe3c0f98d83408"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hknight_old.mdl": {
+     "bytes": 418144,
+     "sha256": "40bd5757499a2bf7e6f60a78b0039665107c9603c2557f6bc73208e080111464"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 37012,
+     "sha256": "e3c6cbabfe6c6723101f2e59f50fc99ee0e360571c95885d2d56c85eefade15d"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/jumpblue.mdl": {
+     "bytes": 37428,
+     "sha256": "be4e85e5fc643e91377d69794b997ad4dc927ae3866dfef5288d704dbc0f16d7"
+    },
+    "progs/jumpgold.mdl": {
+     "bytes": 37428,
+     "sha256": "4c543d82c88009cab7fcf6230feea0a21518a98f430636194fdbf5c1e526cc13"
+    },
+    "progs/k_laserspike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/knight_old.mdl": {
+     "bytes": 208068,
+     "sha256": "5cca43e29392051c9ba95838a58cc1038560411e6c0d2aff61867a428b119e2a"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "63220c0ebb6e266576cb3107a44be16bda10d69fa524d0462514edff9d80328c"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "29bc55efafbea3e15a385598750ba4d9242d0a87803a6bc3430ed772ec1785c3"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "f1e799e7feac3c340676bb60f6cc7a2a7d1e121b196d1f6d0e23edea3a614ed6"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "92370f5b196dc00460d73697975d14279ef659c87c7fc1613b9cbfb68e6c299c"
+    },
+    "progs/m_p_key.mdl": {
+     "bytes": 13428,
+     "sha256": "581a23ac3e2bf0960a7a8b1c4693efd1913d9d17a1f4fa405a1b8c6d89105f91"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "4c5db792da6876f935f8a98a74f51708d52ca03f04975f28518051494660bf65"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "781837a3557c1a8b89c15fa8f477989cb4b77d8cff09c8c13d071090a4df9c1b"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "2feb7ce08070b314d163cbc7f2e2eae0986400c482f752d305ddba268639b3d8"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "04f7fc8b0c2be7ea93021819770145eaf828b2313c4fc591a5f2aa783ca97e61"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 8372,
+     "sha256": "9b6a8f7a49fb7a1f5d4d409b708663c579d433e978d898b9bdf00291a59b4e6c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "fa5d7a5e2410ac7faa5dd0a8e17873c972c6e5cfeacc94118f22db1b4b17477c"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/mutant.mdl": {
+     "bytes": 352720,
+     "sha256": "262ffca22e0c7308950076c2789436a891399862ea25afbd06040158ec9f7984"
+    },
+    "progs/mvore_bomb.mdl": {
+     "bytes": 12653,
+     "sha256": "dd54f975b770db899ef71174d8b05cd98af99739e9506fc4eb354ee8d7e820b8"
+    },
+    "progs/nsoldier_alk.mdl": {
+     "bytes": 563108,
+     "sha256": "6071d7cecf231f0a83f2e1c7df533b4a32beb6e75969d17703446a67d011695a"
+    },
+    "progs/ogr_gun.mdl": {
+     "bytes": 52452,
+     "sha256": "eaa6e0fe01255450d578f151c06c5aeb6a9cd5ed90edbbe4f52d305069ed6825"
+    },
+    "progs/ogre_alk.mdl": {
+     "bytes": 315696,
+     "sha256": "31e9986373dc1a8cba00e09ba9b0278cf766bbd074524a891ed22329f697d643"
+    },
+    "progs/ogre_old.mdl": {
+     "bytes": 315696,
+     "sha256": "53317e9b684701e7722bea342af1a6dba5dd31e72cdbcfa5b097382516d1c6a3"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 487968,
+     "sha256": "ae0abff3ea3fc7ca8c7f80c5d8825553795a1c1ebb80127d46fa52b20905abc4"
+    },
+    "progs/ogrem.mdl": {
+     "bytes": 378296,
+     "sha256": "2bb999bf580d16fb9ee4246dea7897236d6d118232c78a6168f641dc32778fb5"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/pellet_tracer_short.mdl": {
+     "bytes": 58148,
+     "sha256": "5b24b67ce9d9b2634d9a0f31319a977e1e3ec6352d491367941a0e5bf2ae10ff"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/probegren_body.mdl": {
+     "bytes": 139044,
+     "sha256": "da0ddf337c3e2515688f2b143adf55d4ecbbfa32955a78aea01ed16e067b0065"
+    },
+    "progs/probegren_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "4f292b6f157d226e763ff28dad682ce95cfb8a3a21b4badf0ca48db4900cdd70"
+    },
+    "progs/probegren_gib1.mdl": {
+     "bytes": 63788,
+     "sha256": "0efb081efa87c9db990d984f9974f10078890a51894a3e0a6fbe76cc3c4cb5a7"
+    },
+    "progs/probegren_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "7843ddefa22b7d5beb37f889c606c6361792508c2bea202f3dadf9f3ffce73de"
+    },
+    "progs/probegren_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "7baac250aa8c27ef3158de59b536ebf59509e39b1f7bf6be1c24fd5b1e29cae0"
+    },
+    "progs/probelasr_body.mdl": {
+     "bytes": 84296,
+     "sha256": "ac545d0f545488628c864df6e464d10fbd51cb41a2cb76c46dd91233ecd11a6f"
+    },
+    "progs/probelasr_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "cec7b847c9b05f2653113454348799b9bf09c2a74c8e1760cca0ff52c1dfc18c"
+    },
+    "progs/probelasr_gib1.mdl": {
+     "bytes": 58700,
+     "sha256": "ae9f298abc0bb1d09cea3c04bf02216b0a1c3749f8c8a822d973b4c2091cd649"
+    },
+    "progs/probelasr_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "07d6defee5ce4e747daf8b397a5d207a1a42e3c3acffbdfc18d6720c88ec635c"
+    },
+    "progs/probelasr_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "8b8f376afa56e7a9f311e58a076f1fa3a52c88064887a8e0960fdb6daaf5265e"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12653,
+     "sha256": "162632bc16838f66f29e0b788845a6421b7fce708003e9fa6f4eb8ae7aa8e5be"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/rail.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 200152,
+     "sha256": "a564fba381d24e3084bc9aa0a026381c83e6b889632c8bebdf69c08c8a6bb9f2"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "f65ba83d82e90808af589ded17378f1baf37f105fa14f2b157227ee22583d25d"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 288,
+     "sha256": "6ff2797f9dc4e66f2113475a5f3e0e96f23dacbddd18fe47c8b5e12e712f0e75"
+    },
+    "progs/s_bullet_new.spr": {
+     "bytes": 708,
+     "sha256": "a07fa61f4a838ac9ad8ec85ae525d70fb934d383effd1948c0775497be713043"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "b3f1971bd28f96c623c5712e2a47f54f16c99a50d460a944cdcdf29e6eb03963"
+    },
+    "progs/s_exp_small_2.spr": {
+     "bytes": 201720,
+     "sha256": "f7fdba9e2b9b5d318cdff33a06fad4e91e46ba3a241fe7ced4bfbcf0bcb0e873"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_plasma_new.spr": {
+     "bytes": 13980,
+     "sha256": "5474060e55af3c462d0ef7aad043f331c1f5b642915d906c1785bb94595cc68c"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 2820,
+     "sha256": "ea66402d248232b0b6a77bffe024d4a62881be47becf37acb42328661b7f23ef"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shalrath_newer.mdl": {
+     "bytes": 228496,
+     "sha256": "93601de7ff47f552ac9d441ddf1faf312417ca914de99529b17bdf7522e7478c"
+    },
+    "progs/shalrath_old.mdl": {
+     "bytes": 211576,
+     "sha256": "409cda15df7b271bd95a895f058a521d43eca63f37c7ac9df175e5b478229bb9"
+    },
+    "progs/shambler_alk.mdl": {
+     "bytes": 502148,
+     "sha256": "bcf685fcd1f4062dc382924d39eae073fc4d44cd2dcb5bc4ca3797fe0b342b71"
+    },
+    "progs/shard.mdl": {
+     "bytes": 10132,
+     "sha256": "0219a0f08bdc1f604ebe1ea2243cd1b27a2b1ab85bedba3a11298f2d22e9b38c"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "662d6a7cd68bca7a9c5e88838d190de6a501252a14b6994a191d0bc91f1f331c"
+    },
+    "progs/sknight.mdl": {
+     "bytes": 460932,
+     "sha256": "9213f6898a60cdc20a7a144c61c13f8d64f1432382dca44b636524edf737dac8"
+    },
+    "progs/soldier_alk.mdl": {
+     "bytes": 359276,
+     "sha256": "623374e5a553c3d886738c9cc0b22c0b3f3435b3dc1b3f473079a1dd1661fc8a"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spiderbot.mdl": {
+     "bytes": 82476,
+     "sha256": "e85556a194664a5f69e70b42aa863d9e67689a418a3afa51e50816174a6fe8ac"
+    },
+    "progs/spiderbot_gib.mdl": {
+     "bytes": 19444,
+     "sha256": "96ee732ac1199a89c675880700c24e1f09521c35ad478f73aaf4278a398454f6"
+    },
+    "progs/spike.mdl": {
+     "bytes": 2820,
+     "sha256": "783d711b408498dbb34581c9a0ae74ed325dc5c68fa67873745b02c8a926a201"
+    },
+    "progs/spike_old.mdl": {
+     "bytes": 1684,
+     "sha256": "5e3be5dff13ec94951aacbd4a453dcbd9c2aebe7e4e6bded2dd70d49d1ddd695"
+    },
+    "progs/supbkpack.mdl": {
+     "bytes": 44408,
+     "sha256": "781c6b5f424fb58e06b2a84b1fb7e980778decde6b3ed257e224db0b1f250173"
+    },
+    "progs/torm_largeshot.mdl": {
+     "bytes": 37852,
+     "sha256": "ce3a87be213e39b48bc71a6fbf5e1fe9e3f5209901ca45801f27d8f297e04a01"
+    },
+    "progs/tormentor.mdl": {
+     "bytes": 461080,
+     "sha256": "df302dea113f54df908f97c26de844d1235004c08aefcf5c349f3af4b0957d41"
+    },
+    "progs/trifecta.mdl": {
+     "bytes": 25460,
+     "sha256": "2c9196af0806c48354f5522a8b7f6fa57e6390f8dfb51718fb71b8a2d4d7447a"
+    },
+    "progs/trifecta_big.mdl": {
+     "bytes": 25460,
+     "sha256": "9633a10c7c20f77b9202befad3cb363aefe710b166e581f80967ad94b5c6b6eb"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/v_alkaxe20fps.mdl": {
+     "bytes": 96428,
+     "sha256": "4405242db772d86c66f1012b140ba409bee86682fa5f4a6ca12c3e6f94eb9fcc"
+    },
+    "progs/v_axe_alk.mdl": {
+     "bytes": 55820,
+     "sha256": "80ad34cf2612f8fa9121f2be0ada92c1e05613ae2b35b2a1be25a4c694dd2147"
+    },
+    "progs/v_laserg40fps.mdl": {
+     "bytes": 142580,
+     "sha256": "b897ecb5868e3125597d51f970075af04782cba47ed8a42d7b17775dff01f536"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_mine_40fps.mdl": {
+     "bytes": 332920,
+     "sha256": "0039956e96a804229359aaf082b9cf66515d52360867b86c3dca884d19caf8b4"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail3.mdl": {
+     "bytes": 124944,
+     "sha256": "19045e9a5154299b68377744ad946fc3e7f2bd290497c8291a2247ed8cc572ad"
+    },
+    "progs/v_nail_alk40fps.mdl": {
+     "bytes": 44692,
+     "sha256": "402b3dc06f1e5e756cfd50cab17cca49e17e261994c5007cfd46c466a08d3dad"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 260692,
+     "sha256": "0982368440a5d20d65ec511207590c2bfb63e9a60376a5d753b209f2b047c58b"
+    },
+    "progs/v_rock2_40fps.mdl": {
+     "bytes": 139668,
+     "sha256": "89257b7580ac3f48fc775f121eef3508c326eba1369e6aacae83144f8fdfca15"
+    },
+    "progs/v_rock_20fps.mdl": {
+     "bytes": 39556,
+     "sha256": "ebdd6245e1ff65bd95eaed7fa189ac87b51818408f091a32de3f4a477b90f2f8"
+    },
+    "progs/v_rock_40fps.mdl": {
+     "bytes": 43828,
+     "sha256": "f3c32a1c37d4fc3115a8da00ba9507cdd508a98f65e2ddccbcbdc8a0ba0bf2ea"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 326464,
+     "sha256": "dd389cc337d8b7675d9a7b983fd9f53f0c59d597a9759367bd1e1beba375eaaa"
+    },
+    "progs/v_shot2_40fps.mdl": {
+     "bytes": 29076,
+     "sha256": "37ae91c018183faef847aad217da537c97b5a2430ab27a860388bffc1f4514f6"
+    },
+    "progs/v_shot40fps.mdl": {
+     "bytes": 29252,
+     "sha256": "87a47e2debbc27fd6c18a8a38a9a373e7b73ba707458e6346f069c1572df47b4"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_p_key.mdl": {
+     "bytes": 10580,
+     "sha256": "fb3db38e23feda2ca9a8ee1400bdd0b452332f07bf9455db3eac0e52af1e3c22"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/wizard_alk.mdl": {
+     "bytes": 158508,
+     "sha256": "aab430eb2dc0f5c50ca7b4492a7ccc427f2a12011f54ece1b81d4beb66acb4a9"
+    },
+    "progs/zombie2.mdl": {
+     "bytes": 130148,
+     "sha256": "185336c7bffe32e496e93f6828278287f89b672c71f2439918ac5e220ae8b868"
+    },
+    "quake.rc": {
+     "bytes": 2052,
+     "sha256": "b791b9736f5ee57b06dc0bcdc156b13dda9144bb0a972ee5b5069de73c10e55d"
+    },
+    "sound/arachnofloyd/death1.wav": {
+     "bytes": 119460,
+     "sha256": "d16c7ff30e9df62fbcda102befbd61fe234532f6aef30d0b34c25330679682bc"
+    },
+    "sound/arachnofloyd/death2.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/arachnofloyd/idle1.wav": {
+     "bytes": 34254,
+     "sha256": "35d6991a10637251ec0d6b830f7f57f394e4eed06e7a9dced86f0128ba5bc49e"
+    },
+    "sound/arachnofloyd/idle2.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/arachnofloyd/leap.wav": {
+     "bytes": 70884,
+     "sha256": "f47323f618db14755c57e9e25213267dcffc501fbaa9a201176ab99db6cda928"
+    },
+    "sound/arachnofloyd/pain1.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/arachnofloyd/pain2.wav": {
+     "bytes": 15906,
+     "sha256": "9c4bdc81c73787cb67677e0021b71d9e24734ef3ce272d9020dc6611a1d87842"
+    },
+    "sound/arachnofloyd/sight.wav": {
+     "bytes": 48620,
+     "sha256": "97a055dbb8e5935190348b2c2d50c6d99ab35c29f3ebcd0f66d6263bdb5485e4"
+    },
+    "sound/arachnofloyd/step1.wav": {
+     "bytes": 74932,
+     "sha256": "a8744a3e50dccf9ee391da2f381c2ecf6701a76441406929ee4581c7717b880f"
+    },
+    "sound/arachnofloyd/step2.wav": {
+     "bytes": 34478,
+     "sha256": "22ce43aa18537f7b04e31263a46dd02e181d538fdf5918d55f8ce0acbb930676"
+    },
+    "sound/arachnofloyd/whirr1.wav": {
+     "bytes": 19762,
+     "sha256": "9e2029071248e6d45f1b0d518983bad5bc5f841cda6bcfba09486e111add10de"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axegrunt/axgdeath.wav": {
+     "bytes": 20214,
+     "sha256": "e5ed762afcc516058acc1b3884b4d08e67fd36e3a5bacf711d3504363bf8136e"
+    },
+    "sound/axegrunt/axgpain.wav": {
+     "bytes": 12636,
+     "sha256": "4699951fa58fdf15ab819b13d70904fc9a1a86a4db02193d621dfad3878d17bf"
+    },
+    "sound/axegrunt/axgsight.wav": {
+     "bytes": 17712,
+     "sha256": "e7b23208831c1d83793ba06f3b8855430c92017600cd8315341afbcb6ec6c8f0"
+    },
+    "sound/bambler/melee1.wav": {
+     "bytes": 4175,
+     "sha256": "4e0e2567b9d64b3ff86b33d95fa0158bf72372aeb4968a0c2489df942f9f7c4d"
+    },
+    "sound/bambler/melee2.wav": {
+     "bytes": 5283,
+     "sha256": "4bb91991bccfc33576eff19037e12666e9825348272d3dca40199e208bc00700"
+    },
+    "sound/bambler/sdeath.wav": {
+     "bytes": 14048,
+     "sha256": "c5253af82d203e75d132a00bbb555de055d2e356106d460f34cb8c9a2ee5e643"
+    },
+    "sound/bambler/shurt2.wav": {
+     "bytes": 3736,
+     "sha256": "0f1a51e0ff72f23a4de7684d4408344b7b7bd2cb805609168d2f2459e1b8660d"
+    },
+    "sound/bambler/sidle.wav": {
+     "bytes": 4907,
+     "sha256": "ea2232ba791e306cc86f58303413d8f3fbc7dd38091281698f4d846b6cafa483"
+    },
+    "sound/bambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/bambler/ssight.wav": {
+     "bytes": 11376,
+     "sha256": "de766aa056ca5f7dc6d179e6a220ef906ceacc0341b5cb3d91a4d0e75ff55338"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/cyberscrag/fall1.wav": {
+     "bytes": 23396,
+     "sha256": "162fc0be1cd0eadfc93c35f1e1ba9b8dfc7e8df8ee53afb2a14db73e69f20ce8"
+    },
+    "sound/cyberscrag/hit.wav": {
+     "bytes": 22334,
+     "sha256": "a16ef33d94d56fb6984b2a3d06104a3cc292bdb38ec6ee22c8b10457b2cb415f"
+    },
+    "sound/cyberscrag/wattack.wav": {
+     "bytes": 25912,
+     "sha256": "6bed724b7ef9bdd480448396ed4498c75f848bf2a1e6d2879cb2b2484cdd1a7b"
+    },
+    "sound/cyberscrag/wdeath.wav": {
+     "bytes": 20684,
+     "sha256": "24602233cca209122250ba7c284933992aa2393795ea5c528a57b9986e2fc319"
+    },
+    "sound/cyberscrag/widle1.wav": {
+     "bytes": 13465,
+     "sha256": "8902628d2201eda9396c0dc134ebda8b8d5c37dabddcd286f8387aadc6532750"
+    },
+    "sound/cyberscrag/widle2.wav": {
+     "bytes": 23094,
+     "sha256": "76af020e5c25f40ab3020bbd065a9b83b9b0a51120d47d137a7abff4eb43e193"
+    },
+    "sound/cyberscrag/wpain.wav": {
+     "bytes": 8687,
+     "sha256": "af2e8589d381e634f607048ce71200df832c9e3a32147891b5bdd2efe2ff5bf0"
+    },
+    "sound/cyberscrag/wsight.wav": {
+     "bytes": 13079,
+     "sha256": "2f9178f6515eb4cd518b418441c40d1376aeaf6f42f7791533f5f4b6da87fd68"
+    },
+    "sound/doors/alka_doorlocked.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/q2door1.wav": {
+     "bytes": 30572,
+     "sha256": "3f05bddf76379933970c532656b6350bc53820319ce1cb9d4ea9288210427eee"
+    },
+    "sound/doors/q2door2.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/dread/dread_death.wav": {
+     "bytes": 49692,
+     "sha256": "22000ff613ff52eab0605418681affaf7aeef4acc420d3dddd50a9031ac1ca38"
+    },
+    "sound/dread/dread_pain1.wav": {
+     "bytes": 29220,
+     "sha256": "67e443f78043cb9fc4213bbfbc3cd847785a66849fb7b36dd6467494487e0aec"
+    },
+    "sound/dread/dread_pain2.wav": {
+     "bytes": 23380,
+     "sha256": "914fffe3ad6c02fb78be873ee96405a40df22cd321beee2d673d0b6ebbafcde4"
+    },
+    "sound/dread/dread_sight.wav": {
+     "bytes": 70792,
+     "sha256": "50449a772b2ac778b810a69de58cb63c8bbdea529091720a41a1052b7196632e"
+    },
+    "sound/dread/dread_sight2.wav": {
+     "bytes": 58420,
+     "sha256": "f7952137b648f6376a1ba4e968679abb17fc648ede87bb0dd32f633271ad80ee"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 110256,
+     "sha256": "895cfb57c0d27369530fd5e9b29abd491a989ad0a63ddb00f05dd9e4777a5cdb"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/frogman/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 32638,
+     "sha256": "3cf3933f34c7baef52df54d5b03db40424e9f7ee72e5aa5a4dba489d71be2af7"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 27662,
+     "sha256": "ec38e73fd1ffc33cd25aa065e5f5897c21a494e380763ff80b6be482689b5e33"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 44186,
+     "sha256": "7600cd32fe980646fddcf5a9077d8d43df1bca1f2ed05bd92ce8cca273ad6636"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/armor_denied.wav": {
+     "bytes": 15854,
+     "sha256": "2ec14677f483d1a1b869af64cc30fb0dbd90a640fc071fdf2ae493d27cd746e1"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/items/shard_pickup.wav": {
+     "bytes": 18260,
+     "sha256": "388923a63b48720647b9e0f2862c35bb1d5cad2e162ace343845b3fe36b48af4"
+    },
+    "sound/items/trifecta.wav": {
+     "bytes": 16412,
+     "sha256": "00baad51adaa3f5d6664e85ae5442221db6818bfd85124c164324d22f6723ab2"
+    },
+    "sound/items/trifecta2.wav": {
+     "bytes": 32778,
+     "sha256": "f742a9cee4a53ef52fce55d5e9ddaae9c6b20d2127e16c0def6cd11b3d2d6380"
+    },
+    "sound/items/trifecta3.wav": {
+     "bytes": 10728,
+     "sha256": "a78bfc9fa4fbf0c3c1e85bee273ee053598989a09146bd29e97dda811c49a473"
+    },
+    "sound/lieut/alert.wav": {
+     "bytes": 8700,
+     "sha256": "7ebbe83ae1b5d159c9f0a0ae5f3dea126650ed5d6f98a22d1512dcfcb19a23ca"
+    },
+    "sound/lieut/objective.wav": {
+     "bytes": 10052,
+     "sha256": "aa7d6726a458eaa48bf2e20446c57360b82ac23bfbd06bad7b6e01ae95ca8b0d"
+    },
+    "sound/lieut/target.wav": {
+     "bytes": 6754,
+     "sha256": "eebd50c75585894c7d5305f6c066aaef1efaca9a59e27b80d03e8ae4d69caa69"
+    },
+    "sound/lieut/you.wav": {
+     "bytes": 7126,
+     "sha256": "6bfb031b0d69b8ae4ef2e9b201da43c523ae88de344907648d4064e07477ee1c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/mechavore/attack.wav": {
+     "bytes": 66460,
+     "sha256": "fc2a8b0e2a72aebe2858b8337d5ef0638e3e04d5b60e9a62d46ac124072705f9"
+    },
+    "sound/mechavore/death.wav": {
+     "bytes": 37504,
+     "sha256": "bbdf8369941f8c2ab302fe3a55de3bf04e1d28e32a575ffd3c24009d76bebc8f"
+    },
+    "sound/mechavore/idle.wav": {
+     "bytes": 64972,
+     "sha256": "5cd8253f1abe5baf08f1852d12393ca820c34fc0f2febf6c1c8f9d4c3326b2c5"
+    },
+    "sound/mechavore/mv_attack.wav": {
+     "bytes": 67046,
+     "sha256": "af133ede9ab5627f3ea75b12716653b11dd813982cab4a6aad0792371ba58006"
+    },
+    "sound/mechavore/mv_death_a.wav": {
+     "bytes": 125364,
+     "sha256": "7a51ba5587b4c8ccd4bd0e93b105f277f4f093a1cd90f684afb33cf0bbfc812e"
+    },
+    "sound/mechavore/mv_idle_a.wav": {
+     "bytes": 61484,
+     "sha256": "463f1bd23c4bf5d2953ce2f7ee980c9fb28725a0bdc92bc1f03dab8e139a2f14"
+    },
+    "sound/mechavore/mv_pain2_a.wav": {
+     "bytes": 41004,
+     "sha256": "18e27023c1ea7ce306f49559a8f303f62fcc206f05f94878bd1898e204972ebd"
+    },
+    "sound/mechavore/mv_pain_a.wav": {
+     "bytes": 49196,
+     "sha256": "7e2a98060c2ebe14313c831e8d3d410aacd70d7bffa9ef45b0f98845cebdfab1"
+    },
+    "sound/mechavore/mv_sight_b.wav": {
+     "bytes": 57388,
+     "sha256": "2212706950e66000184352238f479d659ea37062186b595e6834bb4d1d910c7f"
+    },
+    "sound/mechavore/pain.wav": {
+     "bytes": 36444,
+     "sha256": "9f9368fdd53aec80fd43a6d3b6680e04aae72685d1cfbdf49d55dc1070e8c546"
+    },
+    "sound/mechavore/sight.wav": {
+     "bytes": 116312,
+     "sha256": "112613b44d88046653b29f21aa5fced5d4b5bfcaff037dfa5f246729e45a6968"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/conc_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/misc/door_closed.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/misc/ebell.wav": {
+     "bytes": 15220,
+     "sha256": "1693337ed8873f1159e56c2925afaa210f5c28bee4e2c42d27e29bee8e06cb5f"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 4054,
+     "sha256": "b9c44f73c8bdbc900af4f06600e0d6456a040b296612b7d0fe53391285976a44"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 4098,
+     "sha256": "4fad66341514c9aa2b31b4c2fde7563369090da9b0b3a51e08bca3100f2ec282"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5054,
+     "sha256": "d158ddc35360bc43934b7a8a9b7cc830f7510e6bb3a640813157822b27b5217a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 9726,
+     "sha256": "73b74099c8cb43ab2fb09b28b72ddd9f73f2d2a4f8a00a8e835490f366680c92"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 3226,
+     "sha256": "48551cc717e5011df78a38c6a71bb001e4f62a1858a3952311499653ff423a07"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 5802,
+     "sha256": "751050f97456a0c07e88a249d40dde96c2d14640e21670ccdde983502998dbba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/singledrip1.wav": {
+     "bytes": 26546,
+     "sha256": "b9193092eaa02003c7ea409663dc1213f0a18a120471a76d298ce847448059b6"
+    },
+    "sound/misc/singledrip2.wav": {
+     "bytes": 25478,
+     "sha256": "562ac78cd1d84805723e3bb24f66c60197d03bab081d7ee8402bf2b59bc7bf0c"
+    },
+    "sound/misc/singledrip3.wav": {
+     "bytes": 44558,
+     "sha256": "55ae1b970143af2553b845503363d94aa917a1cdb8aa1e48edec7869660007c3"
+    },
+    "sound/misc/singledrip4.wav": {
+     "bytes": 45492,
+     "sha256": "db0126239cf71ce69f6c06eb5c5418889b96e52e6741f6b172a146887e6815ef"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/mutant/mutatck1.wav": {
+     "bytes": 6116,
+     "sha256": "410f926534f21705e78a804ce048b0c15e62fe0c68a45aae1b3741fb227551f7"
+    },
+    "sound/mutant/mutatck2.wav": {
+     "bytes": 18260,
+     "sha256": "66009d09adf71f10117c74f5004c995fd48362b2f4fcfaaa3bc2da01e66d115f"
+    },
+    "sound/mutant/mutatck3.wav": {
+     "bytes": 28840,
+     "sha256": "2dd8a615ca2be248c8370d7480f5a8ca9375d31e6af41bba603df660d31883a1"
+    },
+    "sound/mutant/mutdeth1.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/mutant/mutidle1.wav": {
+     "bytes": 81004,
+     "sha256": "8c7e8ad544d7e2470bd61d88c5cd8be1a0eb66f57aaf113f82d990ee00450073"
+    },
+    "sound/mutant/mutpain1.wav": {
+     "bytes": 56716,
+     "sha256": "49ff5f97fedc87c1ac06dc43d4ff0a0fd09fb481354b6373d607bfabc9a57a6a"
+    },
+    "sound/mutant/mutpain2.wav": {
+     "bytes": 58740,
+     "sha256": "b79f1cce60226daa3e3ca8c134da968d54ad51abd9c37ffebdf3d46c5d9f91c6"
+    },
+    "sound/mutant/mutsght1.wav": {
+     "bytes": 107316,
+     "sha256": "7e15e392edc3f2d5ae9e3bde3dfe65595a85728022245f74b81f072d75dce798"
+    },
+    "sound/mutant/mutsrch1.wav": {
+     "bytes": 101244,
+     "sha256": "44484ef4c189511fb0a8d0f2bea83e443e1f1bd51cef04f518f3820e58e88a69"
+    },
+    "sound/mutant/step1.wav": {
+     "bytes": 8140,
+     "sha256": "0d9af35156c84213ac7ffbde54d0f2518fe9d39bba4edc48c94e71bed4f7ec4d"
+    },
+    "sound/mutant/step2.wav": {
+     "bytes": 14212,
+     "sha256": "f7c81df1bff56c8aeb49891fa822c37ddcb019e97a654738a9fb8ee351d19eac"
+    },
+    "sound/mutant/step3.wav": {
+     "bytes": 4092,
+     "sha256": "89856afec31f800219c45253514d0fdf5b5bd800c32f87ba74dd0c21df181550"
+    },
+    "sound/mutant/thud1.wav": {
+     "bytes": 32428,
+     "sha256": "20ed5f20729a068801d06904365e46c9d692dec835710a9b8090d0a1956d6919"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    },
+    "sound/ogre/rogre_alert.wav": {
+     "bytes": 71728,
+     "sha256": "4f3e921b6ee236289660f7ca2ee8a4689e719423266d26a3f8b91ae29d02c6a5"
+    },
+    "sound/ogre/rogre_idle1.wav": {
+     "bytes": 110330,
+     "sha256": "a07df4a53c9e8de310b9d963bfb9c841c51e502565f39dc543bf1c025edd41d6"
+    },
+    "sound/ogre/rogre_idle2.wav": {
+     "bytes": 79416,
+     "sha256": "862258641dc3c90d2a9e5f9e2a4418eb0037eedf22cde798682a169a84f13a44"
+    },
+    "sound/player/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/player/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/player/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/player/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/player/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/player/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/player/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/rail.wav": {
+     "bytes": 97196,
+     "sha256": "396a85e1e2083f2b1eaae89a3f33a21145a643f3f50419523497719ef8e7598a"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/rider/sight.wav": {
+     "bytes": 26356,
+     "sha256": "40ace6f3beeb920ba1bbdb197f8ece18d312762a71e494726289e16703d75d91"
+    },
+    "sound/rider/step.wav": {
+     "bytes": 40524,
+     "sha256": "a43e24ecbc62d44bce466b1e682ebf64c230e03f4d79449406ce021dc8276a9a"
+    },
+    "sound/rider/thump.wav": {
+     "bytes": 15444,
+     "sha256": "af29f4e8f6debb1223aeb5d840add4ae01cb5e9f6bd9a26efeadff518f34380d"
+    },
+    "sound/scientist/allnominal.wav": {
+     "bytes": 23778,
+     "sha256": "e26f9bb3c24d9a9e0da38395048f6dacffe82d800da49d56378027250393d69a"
+    },
+    "sound/scientist/alright.wav": {
+     "bytes": 9666,
+     "sha256": "372c1aa91e6841bec2441215c894b7d149bdeaef33f907d23bb7eaf637520ce3"
+    },
+    "sound/scientist/asexpected.wav": {
+     "bytes": 15982,
+     "sha256": "306933848b673bd14d7074d59e45a8c97bc00a2897601509e52e5835e2ffc997"
+    },
+    "sound/scientist/c1a0_sci_crit2a.wav": {
+     "bytes": 28364,
+     "sha256": "f972684c74eeb51872873cc2b7053448c6cdd716b8c3535929fdbcc508d62ef5"
+    },
+    "sound/scientist/c1a0_sci_stall.wav": {
+     "bytes": 13704,
+     "sha256": "541c192ad5e8a68c76706ec17b3deceafbdc607bfc372ddfd300532f8aa1eaef"
+    },
+    "sound/scientist/cantbeserious.wav": {
+     "bytes": 13236,
+     "sha256": "fc4a8a379f70e33db79a49c667dcd9f1622de29d7b32ef3973c4ffdb5d80ee44"
+    },
+    "sound/scientist/cough.wav": {
+     "bytes": 14878,
+     "sha256": "b4e620259623347a5be3f7eaf3c531e6ea9ef2e97ac42997dd78cfee9327f7bf"
+    },
+    "sound/scientist/sci_die1.wav": {
+     "bytes": 15558,
+     "sha256": "c2306d7f9fa58f99961c347b06ef26305b99ac43ec27b2b222962e1f3a9ccce9"
+    },
+    "sound/scientist/sci_die2.wav": {
+     "bytes": 5402,
+     "sha256": "14deecb570d1e315b772713d54b7250043bb0dd5f3d5538cd0636e39a523c54f"
+    },
+    "sound/scientist/sci_die3.wav": {
+     "bytes": 3104,
+     "sha256": "075cdbc5837d91b61ad7599cdb3abf9323872816f8966c83deab9c0a6e04d7d2"
+    },
+    "sound/scientist/sci_die4.wav": {
+     "bytes": 4024,
+     "sha256": "e6ca0d4f18ac6c1246926646568618057cb70b5cee995c1c2dd69f0179b892ad"
+    },
+    "sound/scientist/sci_dragoff.wav": {
+     "bytes": 8986,
+     "sha256": "0c6a21cd5edf01e495e1258e9a76c05d62c0e3cd697e787fd43fd4bd9126483b"
+    },
+    "sound/scientist/sci_fear13.wav": {
+     "bytes": 4534,
+     "sha256": "dabce7a6c12980f947f7504da264fabb67a804d2e478b7f252ab527fb21a92d0"
+    },
+    "sound/scientist/sci_fear15.wav": {
+     "bytes": 4764,
+     "sha256": "f0d23c680ad138c3cc12da78a3e45cbf3daa47e5da9bc62a1dbb3b27389565a5"
+    },
+    "sound/scientist/sci_fear6.wav": {
+     "bytes": 5588,
+     "sha256": "ff2702b2b9e517b90ea0c2853775a4a95160edfae5af0a7f9208f07624d84281"
+    },
+    "sound/scientist/sci_fear7.wav": {
+     "bytes": 8458,
+     "sha256": "f2a39185c2d39a03b39afd7fe6f942b2f35fd17135ade8ceb4c31968c768aafa"
+    },
+    "sound/scientist/sci_fear8.wav": {
+     "bytes": 5804,
+     "sha256": "4455a29590d5f42ebbf06e600d8ba3f45acfd5000a6b8045891cbecf1d937970"
+    },
+    "sound/scientist/scream01.wav": {
+     "bytes": 14666,
+     "sha256": "b738de99aefbe3a45724914dd6eb79c0f8c219aaf733554a8a5eb94836c22320"
+    },
+    "sound/scientist/scream06.wav": {
+     "bytes": 13938,
+     "sha256": "dee8ac2058635d00458e2e74402d1cfcb5362c64259fc2c4f3b6bba31bdf6337"
+    },
+    "sound/scientist/scream08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/scientist/scream09.wav": {
+     "bytes": 6130,
+     "sha256": "85947649f5fb1491732365849a3025bf5c76c791b395cfdf421fbbd6ec58d351"
+    },
+    "sound/scientist/scream10.wav": {
+     "bytes": 5392,
+     "sha256": "fff4c0735f9c312be7cda848fc2867590437ffe9758fe685e3b4c94678ca1f48"
+    },
+    "sound/scientist/scream14.wav": {
+     "bytes": 4824,
+     "sha256": "dcb7dfb0e307b813476b2e55dceb59d8ae2b9514b1ef02034ea255fa5f086b05"
+    },
+    "sound/scientist/scream15.wav": {
+     "bytes": 3048,
+     "sha256": "37d26fe2d2b8a39d0fec0eceec0ca974ec3dd7fed33bae0d3230a934954105f0"
+    },
+    "sound/scientist/scream16.wav": {
+     "bytes": 2328,
+     "sha256": "4ff04ce8ff07af708c84dacc8df114b68620d47e8e4e4c78dfc4fd33a8a9b98d"
+    },
+    "sound/scientist/scream17.wav": {
+     "bytes": 3836,
+     "sha256": "82fb51224e06db5022adfa58f0b02353c333229ed3312f86dd9ec4f04813c37c"
+    },
+    "sound/scientist/scream18.wav": {
+     "bytes": 3066,
+     "sha256": "bfefcf745ab8d30db11f9113ecf9ba1c5bc6d9b2351c53f3f46d66e03cbea3fe"
+    },
+    "sound/scientist/scream19.wav": {
+     "bytes": 2504,
+     "sha256": "47cc414d201aadb7ba2fe0ce0567ff5360e90fd9de4a167520988513f358ed41"
+    },
+    "sound/scientist/scream20.wav": {
+     "bytes": 21310,
+     "sha256": "124cb45d3d5533572e3cfe4b42bddad2a03dc0d8de1c89a42ea57433432e3a6e"
+    },
+    "sound/scientist/scream22.wav": {
+     "bytes": 15206,
+     "sha256": "6e0a509eb2468466591622e74724c31103b8b60f5d8f29514fb57e9d9d12c9d4"
+    },
+    "sound/scientist/scream23.wav": {
+     "bytes": 21988,
+     "sha256": "8521907e8cecc22e6924d23295a5e8d31333d265ca27a9533b083b68e9da6d12"
+    },
+    "sound/scientist/scream24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/scientist/scream25.wav": {
+     "bytes": 8122,
+     "sha256": "38281749deffb4e567896f71e7bcb75d7b2e253e404a953a5eea6eeb989f156a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/spiderbot/sactiv.wav": {
+     "bytes": 17066,
+     "sha256": "f21587ba9bfd159e48c5b3aa1c6e94eac7157053e4e5699459233fb28c2631c8"
+    },
+    "sound/spiderbot/scharge.wav": {
+     "bytes": 7300,
+     "sha256": "b58064dac4e12bd6685edbfe61417a530cde1e5175336193b2fa7a292aca8ef7"
+    },
+    "sound/spiderbot/swalk.wav": {
+     "bytes": 12636,
+     "sha256": "5534fe1b11fea5406aada214681dba031ec4a01e4b660c405b679131ba07a7cc"
+    },
+    "sound/tormentor/angry1.wav": {
+     "bytes": 88890,
+     "sha256": "60f757f523a9cbb3a57c335bbeda8cedbf990b9d20a5b359e610b712a1344b4b"
+    },
+    "sound/tormentor/angry2.wav": {
+     "bytes": 90912,
+     "sha256": "2f38dddb69cf0df2c1e5b028ca06ea22d979e637afa927919e9a93876dc955d6"
+    },
+    "sound/tormentor/death.wav": {
+     "bytes": 176628,
+     "sha256": "7060ecdadac0b1c9eb3574284444932573e4af13082f01374ed8a4633387bb66"
+    },
+    "sound/tormentor/fire2.wav": {
+     "bytes": 52092,
+     "sha256": "4133a00c7ef157d291d800524a148c188a314eb5ca14246958b8ddfeb0d4fe41"
+    },
+    "sound/tormentor/idle1.wav": {
+     "bytes": 115740,
+     "sha256": "78feebc847dccab66478718b66971870f11246c416e2f2c1e9830c459e4c0347"
+    },
+    "sound/tormentor/idle2.wav": {
+     "bytes": 122218,
+     "sha256": "0270712fe40851bb21d959932b4f8f75bbe8b985e2ff383319059c656ac0ce56"
+    },
+    "sound/tormentor/pain1.wav": {
+     "bytes": 67334,
+     "sha256": "03f255d6ee0d6fb83f2a643491f4cd24d9c5ff86444a51b3cf8b5a0de3d86bbc"
+    },
+    "sound/tormentor/punch_hit.wav": {
+     "bytes": 76614,
+     "sha256": "e524d16b000237615bae3b8fed7b74726823cd4258561196f4641728047aaa26"
+    },
+    "sound/tormentor/punch_swoosh.wav": {
+     "bytes": 33044,
+     "sha256": "d0ef38ef4bf33d0c2f92b22c2a767c4efd66eefaa724df50b394958a7be5a705"
+    },
+    "sound/tormentor/sight.wav": {
+     "bytes": 94334,
+     "sha256": "34a13e6469c5e0ce2f6d18721b0cdd634731b9a9f8910a8bb8b685f63dadfaac"
+    },
+    "sound/tormentor/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/tormentor/sting2.wav": {
+     "bytes": 21674,
+     "sha256": "dd2d40459c7aa9d374efe2f219c34773f390df9f5177a83dbfa5fd638a13c542"
+    },
+    "sound/turret/alarm.wav": {
+     "bytes": 22126,
+     "sha256": "20a8a83d73a55dcc3d8a6fcb79b4ff8ecba0b5887cf3bdcdc96303f069b062ce"
+    },
+    "sound/turret/beep.wav": {
+     "bytes": 22126,
+     "sha256": "89f0e2ba68562cfc3e20272f995777c174c2681cfcf29d2ef337974009b42460"
+    },
+    "sound/turret/deploy.wav": {
+     "bytes": 105260,
+     "sha256": "5bb8c1fa8ffdf22e58ac5fb7a337916a457b9d021661742fcdbbdd7ce188c6dd"
+    },
+    "sound/turret/deploy2.wav": {
+     "bytes": 54208,
+     "sha256": "ec26b9451b67dae2929488687b7b9344a96f7538ab5c4f69e8a85602804dffc2"
+    },
+    "sound/turret/disable.wav": {
+     "bytes": 57180,
+     "sha256": "d8767dcce34c1c7f660f5868c23938da4cc379cb4001b88a10ec1aebbf9e557c"
+    },
+    "sound/turret/idle.wav": {
+     "bytes": 35784,
+     "sha256": "fba6bc2ff517ef95a999e3910c74e3594e054ede298c7b3a5659a2c31565d37c"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 43820,
+     "sha256": "32082cd1d44903409e97de782e5d9295272840e13280665a0ef3ff862b187f0f"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 47570,
+     "sha256": "0dd8defb8ecfb1ea72e6ac70ab182573775812e2d7990dd2897d02d3c38464f5"
+    },
+    "sound/weapons/spindn_click.wav": {
+     "bytes": 9986,
+     "sha256": "b84866cddb7e61eea9ca49208d427c2289d63e6e3e2f59d4d51e302573079bc7"
+    },
+    "sound/zombie2/attack1.wav": {
+     "bytes": 22914,
+     "sha256": "da5345280208ea48855526989299927268566cef77ee187035bbe969076d6605"
+    },
+    "sound/zombie2/attack2.wav": {
+     "bytes": 24072,
+     "sha256": "59245700b47794e239563cc94e3ff045fcd7dad795bcfe343d8574ec3ac525b6"
+    },
+    "sound/zombie2/attack3.wav": {
+     "bytes": 15400,
+     "sha256": "0113aad711264c05a9e43bf8dba915bc89661444d7d802efabe8d61ebb3ba13f"
+    },
+    "sound/zombie2/attack4.wav": {
+     "bytes": 20922,
+     "sha256": "0aac55ae62b62cefece56103cd7079beeb433c3764f590641876e149c4328ecc"
+    },
+    "sound/zombie2/attack5.wav": {
+     "bytes": 26086,
+     "sha256": "b58c97928b535e79973e0390512b09d3d0adea79b1b1b5a8de59bc2cde40c412"
+    },
+    "sound/zombie2/attack6.wav": {
+     "bytes": 22272,
+     "sha256": "58c429256e2f5abb9d97c99ceedb78088d8ac977eca94e994b6d1eee8bb3eb8f"
+    },
+    "sound/zombie2/attack7.wav": {
+     "bytes": 34384,
+     "sha256": "d68e81783b6583738227eac608ab7af1a4b1e1b085c1e46bd9c0d029eab4fdde"
+    },
+    "sound/zombie2/death1.wav": {
+     "bytes": 46548,
+     "sha256": "a1b9e2bcebf9c56fb56405d1ec7fe4166ac10d2b6e1acc6f01e58aec9fd63e87"
+    },
+    "sound/zombie2/death2.wav": {
+     "bytes": 47048,
+     "sha256": "5964a3c1a665c70de8302052b2b6d72ea46b0a5e07ba22cc9919e1a0ffefcca3"
+    },
+    "sound/zombie2/death3.wav": {
+     "bytes": 52636,
+     "sha256": "5c76f8bc55ecea263df880e6b683b07066b37c9f62ff589b0e999534d3c256b0"
+    },
+    "sound/zombie2/footstep1.wav": {
+     "bytes": 12966,
+     "sha256": "2a85309bea05b7c7c90a82df071822828e413cce17646a9686fa4f1264d75e48"
+    },
+    "sound/zombie2/footstep2.wav": {
+     "bytes": 16880,
+     "sha256": "d1d9e9c3811b39b67c9a6966851873ff7edf8d1407c5d9b90782b233196a4872"
+    },
+    "sound/zombie2/footstep3.wav": {
+     "bytes": 20904,
+     "sha256": "b12e9ea9b9478428b886fcaab504856393a57abd8cfdfc5ba5357ad745ee3455"
+    },
+    "sound/zombie2/footstep4.wav": {
+     "bytes": 15796,
+     "sha256": "6f82ac60991e64c8c48a3208a161b46f5b916587cb41863992dc1acb08268889"
+    },
+    "sound/zombie2/footstep5.wav": {
+     "bytes": 17800,
+     "sha256": "ca12f6ade73e5d5ba4ec1bdf680ce25afe3270bb88d702e1493b75619ec088d9"
+    },
+    "sound/zombie2/idle1.wav": {
+     "bytes": 143832,
+     "sha256": "aa203b0beb2db12beb6929fbc3646f7f119d4d31ede66b13af0412d396f7dd6d"
+    },
+    "sound/zombie2/idle2.wav": {
+     "bytes": 277026,
+     "sha256": "9496f3179e875bbb4d7442c252eac0eb2b9ef6d2269d43c141e01242ed2de7ee"
+    },
+    "sound/zombie2/idle3.wav": {
+     "bytes": 234026,
+     "sha256": "4820b03de8cebdee6fe787b5bf60724c17a0e133fdd5451176a202043f730f8e"
+    },
+    "sound/zombie2/idle4.wav": {
+     "bytes": 166352,
+     "sha256": "a515e5dc0e4fe1412a7936df5fab0f57a48c385db4fa357c1a4120671ac99617"
+    },
+    "sound/zombie2/idle5.wav": {
+     "bytes": 62782,
+     "sha256": "c6e4e2f26769400b7ca3b08339af089ba28bc063447d642e10cffffc6e03a485"
+    },
+    "sound/zombie2/idle6.wav": {
+     "bytes": 47274,
+     "sha256": "9ad1ced551cb42764fd88baf26ee09dc72d1852fa2da7405fde370d3e4d69a01"
+    },
+    "sound/zombie2/idle7.wav": {
+     "bytes": 45614,
+     "sha256": "41783a7682d5f8bb91aff8308b8657504cc8f0460b5ca436a5d0fb1c93357c85"
+    },
+    "sound/zombie2/idle8.wav": {
+     "bytes": 73070,
+     "sha256": "8f390d861feda3fb3950b0f33ce3efbfa8eda214533324674ac40b6e227b6975"
+    },
+    "sound/zombie2/punch1.wav": {
+     "bytes": 9218,
+     "sha256": "db6787efe0a0b8df5da690b91afe46a2199911b661fc9de1cfffc00b6bb8c46c"
+    },
+    "sound/zombie2/punch2.wav": {
+     "bytes": 8032,
+     "sha256": "747aabd6237176ae1bc62669cb08c7ec65fb26aa2147f6a3e1ab43f02ace7322"
+    },
+    "sound/zombie2/punch3.wav": {
+     "bytes": 13076,
+     "sha256": "05bb75533252d15983a944263789de5ee51187e518f4544fd1915b57ba726c7e"
+    },
+    "sound/zombie2/punch4.wav": {
+     "bytes": 13198,
+     "sha256": "d07556e7fc774958a6105564a990c51a0dab64fcf9508475617921a0ac5b961c"
+    },
+    "sound/zombie2/sight1.wav": {
+     "bytes": 73234,
+     "sha256": "387534044f10592ca6bc7a96b8e782c7b51de87b907e79a8f410d535e17d37ee"
+    },
+    "sound/zombie2/sight2.wav": {
+     "bytes": 52224,
+     "sha256": "cbc95608d4553d0bae66411d69875210e6fc6d728bd30deb6bbce7aabbacb773"
+    },
+    "sound/zombie2/sight3.wav": {
+     "bytes": 63072,
+     "sha256": "cbbcdb6da59d830a3be66095053259b17a90cc6501728ed1aa50d9524818f99b"
+    }
+   },
    "sha256": "955b55aa56dde477637305ef146bc84e48f2e09a474c7bacec61d1a7dd3a13ad",
    "timestamp": "2024-01-10T20:38:56.000Z"
   },

--- a/json/by-sha256/d5/d51d980d60fefcf6befabf0e8602282d8ed5e74ce94896e1c324e9077ee62be2.json
+++ b/json/by-sha256/d5/d51d980d60fefcf6befabf0e8602282d8ed5e74ce94896e1c324e9077ee62be2.json
@@ -37,6 +37,344 @@
   },
   "forsaken/pak0.pak": {
    "bytes": 4110228,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "b1deebb2268d373683100cc9df4c9dcbf817f9bdb0e3f2cd13edde0037609b53"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "11454a7ec41855cc66adc9b80e60b1c76b0af873656d46cc20543ea4d2a7ef8c"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "d2a59d07042577c9c5a5ceace5ad0e3893ba3ac2d206f039f11cf282ead3945e"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "63f869e1e553ccae238279e4b78c902463505a3d1dd7c5d21d4f4acbb56857ee"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "6e3d8ed0cf22d78c0e05bf75837214a12f647fda33da1fa1ad1195cff3cb9681"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "35db83f82066ac1db85f4094dc9710e313b638e019d8e4d6fb5abf0457d506af"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "0191d8c540203ac186f94012d21a474c77a048c040cecfed00fc9f6f63a57dbe",
    "timestamp": "2021-08-25T16:58:22.000Z"
   },

--- a/json/by-sha256/d5/d57c65c2c6f32dcc7b5a98b8bec6751cd3ca599e24b47dc147ea3a3c01f78d32.json
+++ b/json/by-sha256/d5/d57c65c2c6f32dcc7b5a98b8bec6751cd3ca599e24b47dc147ea3a3c01f78d32.json
@@ -17,6 +17,220 @@
   },
   "araivo/pak0.pak": {
    "bytes": 6081739,
+   "files": {
+    "maps/araivo.bsp": {
+     "bytes": 4105188,
+     "sha256": "f25bde606c2ff295582d34c494f862ccf3963a6e8b19484161d48d8b8fdbb3fd"
+    },
+    "progs.dat": {
+     "bytes": 665784,
+     "sha256": "266f976e0fdc3453e6c4d2351a151c44e69cdf2292349f8d52d985488cb0947e"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 224812,
+     "sha256": "af9095cffbc74edc9d98d4e4e341736e304404df52983be33616da84d6463c87"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 12416,
+     "sha256": "2fff2f36173080827a298870a956fb11ad30f34aa0342ba5ca2c8bd6509edf57"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 59078,
+     "sha256": "6a7022fa8210771be206034a2b0ebeb59f6fc79719d499ac01811a4ff32eb08a"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "sound/ambience/aramb1.wav": {
+     "bytes": 44476,
+     "sha256": "4c6440672b87575dd8ac5a267621881b9c70e48722cf9a4aa75a4a9b384fea5b"
+    },
+    "sound/ambience/arcohum1.wav": {
+     "bytes": 20418,
+     "sha256": "3b42cb1b62f62acabdc8ef8612ab4343b71b165c3525552701ef769f90020960"
+    },
+    "sound/ambience/arhum1.wav": {
+     "bytes": 20740,
+     "sha256": "e374f3d90564808e019abe09f4464b704512cf85ff0f3b4bb3c955b4153184e3"
+    },
+    "sound/ambience/arpump1.wav": {
+     "bytes": 18262,
+     "sha256": "11ae2c08c7d5f7f777eade75770a1623386d0e0096a19076fff13e9ddec6318c"
+    },
+    "sound/ambience/arwind.wav": {
+     "bytes": 30408,
+     "sha256": "34248569bb7ab66f5e1d874e15c7a91d89fd2b70d27e5521456b2589581fe1e6"
+    },
+    "sound/ambience/water1.wav": {
+     "bytes": 8322,
+     "sha256": "eb9de7ee8b9ae2445fa62c058f2801fd14519e591cac68c71a173a4aa1697bcf"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 8322,
+     "sha256": "eb9de7ee8b9ae2445fa62c058f2801fd14519e591cac68c71a173a4aa1697bcf"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/lighton.wav": {
+     "bytes": 13670,
+     "sha256": "f3b7747478617bf4bae243e2e606d6f974617a3c772932c08ef9e624d3651ae3"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    }
+   },
    "sha256": "526082b1553bca4c3d901c17e5f472ebcea4f3511f35a4bcabbaba277465cd73",
    "timestamp": "2005-01-05T00:17:34.000Z"
   }

--- a/json/by-sha256/d7/d7c8731c8ac5351950c4a7b2eb2ab1fb41f9167d6a826428ffc841b0a2e0c816.json
+++ b/json/by-sha256/d7/d7c8731c8ac5351950c4a7b2eb2ab1fb41f9167d6a826428ffc841b0a2e0c816.json
@@ -12,6 +12,48 @@
   },
   "Pak0.PAK": {
    "bytes": 1888562,
+   "files": {
+    "maps/3oc.bsp": {
+     "bytes": 1653884,
+     "sha256": "840b53bf419849b51567e6816673d284868e1e3543638a4ed4336659113440b6"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 11348,
+     "sha256": "a0bb622ff3c22f9902f12a6d823635af7ff46077c97e9d8ee39de04ca337d5fd"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 160688,
+     "sha256": "1813d80a0de37d8a6202f7fdd83900d000585fb731d1cf27f703d04eff520e2f"
+    },
+    "sound/wizard/hit.wav": {
+     "bytes": 4360,
+     "sha256": "78f664ac8c3795722e5a2fe0356bd13d51d8cf584048093f18b463bb1447bfc2"
+    },
+    "sound/wizard/wattack.wav": {
+     "bytes": 7430,
+     "sha256": "fbf6b511e0c87fd3964ca7ef9f59e8e907b4eabcc8c69121243e0b7285e27a52"
+    },
+    "sound/wizard/wdeath.wav": {
+     "bytes": 9290,
+     "sha256": "f62aad2ae903808a0caecfc6bdfe13e5fdebb1df14d330c6ac4eda9b577b25bf"
+    },
+    "sound/wizard/widle1.wav": {
+     "bytes": 13464,
+     "sha256": "b41e9c8b4f2beb3825f83cdabe10dce27153c1d0d18a1908b2f715ea0ac1e76d"
+    },
+    "sound/wizard/widle2.wav": {
+     "bytes": 15810,
+     "sha256": "cec388af73dff076ea3af7c754ef0939f989f3412b0359c0fb668cd91bd4abaf"
+    },
+    "sound/wizard/wpain.wav": {
+     "bytes": 5478,
+     "sha256": "d8692021777495825974f8406e23c74ed249f9a80a9bc944c79b1722c35f64e0"
+    },
+    "sound/wizard/wsight.wav": {
+     "bytes": 6158,
+     "sha256": "d3b9e689b2b43ae74ae14fdb26680d3646d658107664965db97420ae032d74b0"
+    }
+   },
    "sha256": "fe0fb04a6ea16feeb5e3d233a7adaa9b8f6ecf380b0b933717ea26729ec6bc43",
    "timestamp": "1997-06-27T13:09:48.000Z"
   }

--- a/json/by-sha256/d8/d8666c21f5130f3df5d882328cf26f11abd5d050bde2227dd4d9346e562d14a8.json
+++ b/json/by-sha256/d8/d8666c21f5130f3df5d882328cf26f11abd5d050bde2227dd4d9346e562d14a8.json
@@ -7,6 +7,580 @@
  "files": {
   "pak0.pak": {
    "bytes": 8112672,
+   "files": {
+    "autoexec.cfg": {
+     "bytes": 26,
+     "sha256": "804ffe97578e151f6032d5d5f74654fa2f06d9f949d174a3cb34dab218abdfcb"
+    },
+    "config.cfg": {
+     "bytes": 2287,
+     "sha256": "afee421a2c6c9b27df43708068586de360a620ad56ca7f2fbf716440027683dd"
+    },
+    "end2.bin": {
+     "bytes": 4000,
+     "sha256": "36d8f77b625ad89baa726960a3bcbc660bea388d0ad883b6b4cce82a05493e43"
+    },
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "17d84b8d582a1f8b895fd32db7b9a2c515041e94c8fd3a8a8a3ae681c330a1c8"
+    },
+    "gfx/completed.lmp": {
+     "bytes": 4616,
+     "sha256": "1b3031784e4edc0be5c2f035f772a62c7fed53e8a3f13fd33585c23e71032c90"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "58b1fdf76a5b9c54f2cf80f2917a81735d92eb8a1d2f7f067b97ac8620f44295"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "e9e7f446b98a299b08a70a49cffa192b5e8f7e254cb8194d82d50e7efbab7d27"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "100f0973364d001639ae934c335195116e2ee896e21cfe2beb21b49f273536d3"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "3c2e0a59427adb179ad440e1d4b68e9fb012f231cbb5e18a22ee1371bef72d1e"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 1032,
+     "sha256": "57e407bbd9404af8b44e3a9a0fb00b88c88b6a7231d3e891aee388216d6b7d70"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 1032,
+     "sha256": "57e407bbd9404af8b44e3a9a0fb00b88c88b6a7231d3e891aee388216d6b7d70"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 1032,
+     "sha256": "57e407bbd9404af8b44e3a9a0fb00b88c88b6a7231d3e891aee388216d6b7d70"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 1032,
+     "sha256": "57e407bbd9404af8b44e3a9a0fb00b88c88b6a7231d3e891aee388216d6b7d70"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 1032,
+     "sha256": "57e407bbd9404af8b44e3a9a0fb00b88c88b6a7231d3e891aee388216d6b7d70"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 1032,
+     "sha256": "57e407bbd9404af8b44e3a9a0fb00b88c88b6a7231d3e891aee388216d6b7d70"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "85ce5e9bb7c4e7cc4e9ea40044bb747779fc5bb41e74f9e9d25403fd70cceb22"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "9c4c63ac6bd0264f9f36a8fa49f335840b6f971eeef6231e05319e8042e6f5f1"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "d9600f0f930d3fd039f2b8faf37810e57560bf0fb96d3dff52038cbd274e1842"
+    },
+    "gfx/paused.lmp": {
+     "bytes": 3080,
+     "sha256": "01bc02ef2523dd97d273cd4557175c780a1f8201ec762305a5be5fe474984c26"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "f0ca106ccda6ae5eefe23e29b7c121785d9935230b2b42efbb4765a5d179d347"
+    },
+    "gfx/sp_menu(2).lmp": {
+     "bytes": 14856,
+     "sha256": "5d1e2ffa480d8a5bca9b471a070ef2ca075fc7857fb7b0787f46c1fff90b7383"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "5d1e2ffa480d8a5bca9b471a070ef2ca075fc7857fb7b0787f46c1fff90b7383"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "50d6086a675dd21d0313506ff4834ae36510f6156595f143b30a11612eabe8f2"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "cd40407c62e6daf474158ebb380e35da2efc4625fc3521815a4a2018820b12d3"
+    },
+    "maps/se1a.bsp.bsp": {
+     "bytes": 298260,
+     "sha256": "8b1d4777d7887ecd0e5e8632cd221dd66c0ccb05cd918f2ab787b6be91d0decd"
+    },
+    "maps/seaview.bsp": {
+     "bytes": 3143268,
+     "sha256": "d92a004040d76da9fb0007ed890ed44ca1c5ff86f3425cf72f40764211d9fd49"
+    },
+    "progs.dat": {
+     "bytes": 652752,
+     "sha256": "1af100448275516b3e23f424ddf3adb62a94fd70f9893b54688f8ab166d57a41"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 218412,
+     "sha256": "8878b79bb9fee049b0e75314433ad9ef90fc9a7dc3b148c9e02835d0a0ab66b9"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/s_null.spr": {
+     "bytes": 56,
+     "sha256": "29e9c18546413f0abc9c6f507c61952f33afa6507b52d1c2197b57e3be7870a9"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 146288,
+     "sha256": "8d38139342c6451537be026badcb9d562f7c8f593e939e40e8a06937b4df346e"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/wetsuit.mdl": {
+     "bytes": 55156,
+     "sha256": "4e4dc7331c374d2345c3d755ff34b61850c289741314b10fa36c461db3844e99"
+    },
+    "sound/ambient/comp1.wav": {
+     "bytes": 40702,
+     "sha256": "6a82962242729acc4efbce19e525d9e03c8adcf754d158964324c82b8a233bea"
+    },
+    "sound/ambient/drone6.wav": {
+     "bytes": 29044,
+     "sha256": "4caace7efee0535a545e462902d3aab1989f9ddfc9d5b6bbdce344a113585fc5"
+    },
+    "sound/ambient/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambient/humming.wav": {
+     "bytes": 19928,
+     "sha256": "8a92fa1f6395560d1d36a8fbd656429a28f181afa0d26e760b5328b0062debfe"
+    },
+    "sound/ambient/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 55784,
+     "sha256": "29053dac56750c7808a556d223b75b88f47d773efb776cbef33f6f976a284892"
+    },
+    "sound/ambient/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambient/spark7.wav": {
+     "bytes": 16155,
+     "sha256": "84a5b344a875aa17889b30709e8aebb88fcad167a07d27ced1c8c4764c27563e"
+    },
+    "sound/ambient/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/buttons/switch02.wav": {
+     "bytes": 16878,
+     "sha256": "2c570ade5d8a84ddcc3e9293b15b6e3be079ab4b7dbde923490542c1f42b0281"
+    },
+    "sound/buttons/switch04.wav": {
+     "bytes": 16878,
+     "sha256": "2c570ade5d8a84ddcc3e9293b15b6e3be079ab4b7dbde923490542c1f42b0281"
+    },
+    "sound/buttons/switch21.wav": {
+     "bytes": 16878,
+     "sha256": "2c570ade5d8a84ddcc3e9293b15b6e3be079ab4b7dbde923490542c1f42b0281"
+    },
+    "sound/doors/basesec1.wav": {
+     "bytes": 7306,
+     "sha256": "1e828e61cce84e8adcec55e7e6e97332afef908134a44e932ef00ebd3e4cc882"
+    },
+    "sound/doors/basesec2.wav": {
+     "bytes": 7998,
+     "sha256": "e9379901190bf0af773033ecbde810829320ba8876e76d4b1ebaca6a1c61c5e7"
+    },
+    "sound/doors/techopen.wav": {
+     "bytes": 14752,
+     "sha256": "3b82abdc7d218cd891d6e89f96756bd0a54884859e8ff1267075fb0f1c49d4e8"
+    },
+    "sound/enforcer/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/misc/20.wav": {
+     "bytes": 160012,
+     "sha256": "2cd6261c8f9cce093ecc92a9166546688905811ff29b66cc13bc8329d459fbc6"
+    },
+    "sound/misc/21.wav": {
+     "bytes": 301891,
+     "sha256": "3e04a45f90c3d3c372425db73589979bf80ae9a8358c2f50c371f4e5bb07fc2a"
+    },
+    "sound/misc/22.wav": {
+     "bytes": 123046,
+     "sha256": "77e1120de962723d6cc6d3c256e58ee96de655eac5fd0c2a3797746f228aa904"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/soldier/sattck1.wav": {
+     "bytes": 30413,
+     "sha256": "36d251252367ce80a8547002dd2efef84087100781d4e9947efdd6a4e0f0a342"
+    },
+    "sound/weapons/pc_exp.wav": {
+     "bytes": 35314,
+     "sha256": "ba81a9534ba1da310ec277a807aa31de8bdcfa36a061e80d8eff9b4581bb85ea"
+    },
+    "sound/weapons/rocket1i.wav": {
+     "bytes": 26306,
+     "sha256": "04fc98e42709c9a5d1a8bbd52aff9114b4922da324e30d21859bcf8209e55b4f"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/shotgn2.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "sound/weapons/stunfire.wav": {
+     "bytes": 9902,
+     "sha256": "7214cc44e4c0bfb801209f025b591d838542a3110f770e5614b0f549a055286a"
+    }
+   },
    "sha256": "2c2244be8dbdad24314a909a81185baf0b600c62ae007d82ef2f0963d3a6959e",
    "timestamp": "1997-12-12T23:48:02.000Z"
   },

--- a/json/by-sha256/d9/d92b993b0366d9984229e334730139659d05c044bd3a6194d0d1aca622eb61b0.json
+++ b/json/by-sha256/d9/d92b993b0366d9984229e334730139659d05c044bd3a6194d0d1aca622eb61b0.json
@@ -12,6 +12,96 @@
   },
   "pak0.pak": {
    "bytes": 19416397,
+   "files": {
+    "demo1.dem": {
+     "bytes": 710825,
+     "sha256": "0e2a43b52f9ea2c76d399e7846c858a9d8eb5582a7f328a71344d918399c18e7"
+    },
+    "kell.cfg": {
+     "bytes": 2720,
+     "sha256": "c6ecdaa1ff9ec383494048608ea44413a5e6ac4268ac34814aed131ce2ec8cfe"
+    },
+    "maps/k1m1.bsp": {
+     "bytes": 3532008,
+     "sha256": "2f2d7d7348b9514b31cafa8c7dbb7b2ab3b9594f5591c6092721664167890c4a"
+    },
+    "maps/k1m10.bsp": {
+     "bytes": 3931224,
+     "sha256": "1a1e9d5775e8f8a5a8c8eb5903c730fea18e84ef1821d02237434a3000c29100"
+    },
+    "maps/k1m2.bsp": {
+     "bytes": 3064084,
+     "sha256": "d26fa72536bc3f93d3e57a69d61f8eacd9bddf36ccf2c127a409a146561cea92"
+    },
+    "maps/k1m3.bsp": {
+     "bytes": 4172532,
+     "sha256": "024a98faca1b12bd2903cc2a992a48dc1130b2e4273b09f3c4859abd3dd7151d"
+    },
+    "maps/start.bsp": {
+     "bytes": 3079148,
+     "sha256": "9872a220c9fa4566abc06f636476a0994ee9e3166c83fd5b6390cfb3f813bae8"
+    },
+    "progs/end1.mdl": {
+     "bytes": 20820,
+     "sha256": "2155d92a5244e4ddb237e46e64e38f09bb47141fcacf4ac1a06df1553f830858"
+    },
+    "progs/end2.mdl": {
+     "bytes": 40980,
+     "sha256": "f46f9a8f6f036fb66210ade338f9e76729d286fe8f73e1ae23a065382567de9a"
+    },
+    "progs/end3.mdl": {
+     "bytes": 19924,
+     "sha256": "c35c0c65e52b5de27175137fafb68751e3132675db529a1e80707eceb5dd6aec"
+    },
+    "progs/end4.mdl": {
+     "bytes": 26932,
+     "sha256": "001a69b25785d05678348ff2edea63e125c8ee07cb379fd03fe66bd720d5962e"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 2244,
+     "sha256": "343c84307bb7c3f6f0e2d23965ef797f9711c26640371c23845f91cfff58da2a"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 39992,
+     "sha256": "33aa3cb25d9dd2a40fa6082e7a8bcb3102c79fecdef2d945566b28ca6bbc3869"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 98148,
+     "sha256": "4936d42d121421090e8353010e0eb9ed89a53871a8e440a960b7cff049f948dc"
+    },
+    "sound/ambience/buzz1.wav": {
+     "bytes": 273352,
+     "sha256": "a4e2f8a7c0ac3c5d8e7ce1485147bc820b1270e3e3f13712b4cc7d2afbeee31d"
+    },
+    "sound/ambience/fl_hum1.wav": {
+     "bytes": 220542,
+     "sha256": "c925d73ef744b0a8c56507ff6fb18888de7ab803ea1f743060f8f9782180dcc7"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 57040,
+     "sha256": "7641643c47254d8bc72331ff90dee511cddfcbf03aaaa43f0cc7f35a4329ecdb"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5570,
+     "sha256": "c404a7d2f09b9e269a9df6d19396efe57b281f8eb79457b69ea4ab88a7d0f55a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 33108,
+     "sha256": "1504f451e4b8e02b8080014f79b11a34bdbcaab0b8e11a0427c0c5a7572ed796"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 16288,
+     "sha256": "1ef4281197016a2025b5471143ae5f5b8fd98c0fa8def4ebd6e89fa362753ae9"
+    },
+    "sound/misc/trigger1.wav": {
+     "bytes": 34284,
+     "sha256": "2caac27dfee5758eb293e0c76bf86baf82b0522c6f71281160e805c6ec282f96"
+    },
+    "sound/zombie/idle_w2.wav": {
+     "bytes": 33212,
+     "sha256": "24b56a0dbea4fbbd43ed1fbbeff5d946c9269569284659ec72dc665b18076a3a"
+    }
+   },
    "sha256": "cdf65d807fa869cf8c4040a8433a5819e3fc67714a6aa7b228a2ae7c8862343e",
    "timestamp": "2002-06-15T16:47:10.000Z"
   }

--- a/json/by-sha256/d9/d9da205924368c5c0ce2876f2f0d5a6406f3e8767e2e284e0bc86f83055299c6.json
+++ b/json/by-sha256/d9/d9da205924368c5c0ce2876f2f0d5a6406f3e8767e2e284e0bc86f83055299c6.json
@@ -193,6 +193,340 @@
   },
   "pak0.pak": {
    "bytes": 4085208,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "b1deebb2268d373683100cc9df4c9dcbf817f9bdb0e3f2cd13edde0037609b53"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "11454a7ec41855cc66adc9b80e60b1c76b0af873656d46cc20543ea4d2a7ef8c"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "d2a59d07042577c9c5a5ceace5ad0e3893ba3ac2d206f039f11cf282ead3945e"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "63f869e1e553ccae238279e4b78c902463505a3d1dd7c5d21d4f4acbb56857ee"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "6e3d8ed0cf22d78c0e05bf75837214a12f647fda33da1fa1ad1195cff3cb9681"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "35db83f82066ac1db85f4094dc9710e313b638e019d8e4d6fb5abf0457d506af"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 19700,
+     "sha256": "e8c8e2d8a8901e67b68bcb63b3121e9209153cb43257b54bca4a6814ed718202"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 19700,
+     "sha256": "2dcf8e2c3ae1d1d361ac32d22000b1cb168398b7dfbd0e691b4519317e6708cd"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 19700,
+     "sha256": "97e5a4179934c6912c1414bfefc8f104ff3b2c5a4cbfeb9e8a8c2f0dd88d91c1"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "7b3838322dc860c3ea5dec5e246e9ecac4b0f75182edeff7b719e16f4f33d874",
    "timestamp": "2021-02-25T16:12:20.000Z"
   },

--- a/json/by-sha256/dc/dc048ecdbc1eba11d83e398f6d4d42eb53b4f4438894ebd2811f09dde5ac3f3a.json
+++ b/json/by-sha256/dc/dc048ecdbc1eba11d83e398f6d4d42eb53b4f4438894ebd2811f09dde5ac3f3a.json
@@ -15,6 +15,184 @@
   },
   "pak0.pak": {
    "bytes": 9990682,
+   "files": {
+    "maps/128gr_x.bsp": {
+     "bytes": 98436,
+     "sha256": "1dfd7381e5a3204e39b8ced70358a11a21a98c739032ba8766caac93af19712f"
+    },
+    "maps/128gr_y.bsp": {
+     "bytes": 97628,
+     "sha256": "c634e0dec8ad3e09a8a4f71d834ec39dbca4a627502adb62132e5888fcff8e9d"
+    },
+    "maps/128gr_z.bsp": {
+     "bytes": 103408,
+     "sha256": "79e92a98f5dd383300c15f40a499a55066a96ffb2a25925e7abd3b3176d04398"
+    },
+    "maps/256gr_x.bsp": {
+     "bytes": 113952,
+     "sha256": "a69f70b643786b8cff0c10d688ba987916b567008107bc6063bac9c968074b16"
+    },
+    "maps/hiris1_y.bsp": {
+     "bytes": 25652,
+     "sha256": "e37b9b4663b35caa6f2c7ef9bbd2c769efc253d09437c278e560db724f4e2e91"
+    },
+    "maps/hiris2_y.bsp": {
+     "bytes": 25664,
+     "sha256": "241a14978447e5664a82e9cdb1241c2c3a18f1d5718c93ef3b3c517a2816af32"
+    },
+    "maps/hiris3_y.bsp": {
+     "bytes": 25656,
+     "sha256": "025b0e9cb3d8700ab14b203c57c1e4c464faec9c929091b3110cb9dda0ebffad"
+    },
+    "maps/hiris4_y.bsp": {
+     "bytes": 25628,
+     "sha256": "0212f396c474427c93e5f2d939dac467a53e824183287fb672f831f608a1ea88"
+    },
+    "maps/ne_tower.bsp": {
+     "bytes": 5667548,
+     "sha256": "d01310ee943c39d761513e5f4683b58c0320e922fda36e56c48fc894bc76a3e8"
+    },
+    "progs/ne_tower/32grthin.mdl": {
+     "bytes": 37840,
+     "sha256": "d098ef14503952b865ca1c41ca399a9e195d7d8bcedfd573034a5c02595f685c"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 1282054,
+     "sha256": "3dc3ccb29f6c601ad610545a3cf509a488fafb36a214b612b5109ad10c455246"
+    },
+    "sound/doors/er_stop.wav": {
+     "bytes": 51846,
+     "sha256": "f674272aa55db0cb05651c5edfa76422370d138c44789b179bc6e943a22f0d28"
+    },
+    "sound/doors/er_strt.wav": {
+     "bytes": 99372,
+     "sha256": "afb23446ab200aa3bd540bc1ac517713dbf2d7fc099283254f7b8a4480a90092"
+    },
+    "sound/doors/ir_stop.wav": {
+     "bytes": 81054,
+     "sha256": "c5ae31d19bb638cd61771f365beca5998d5795ff035929863a19148d39907904"
+    },
+    "sound/doors/ir_strt.wav": {
+     "bytes": 86616,
+     "sha256": "8e2767cf7d483ab898c7eb561834b0a7af90669976499dfe42c8f7e09560aeb9"
+    },
+    "sound/necros/tower/button01.wav": {
+     "bytes": 26086,
+     "sha256": "1027118149cd69f58e561a956ec8ba8bea843267cc44674f913f23933b67dfad"
+    },
+    "sound/necros/tower/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/necros/tower/dl_beam.wav": {
+     "bytes": 91664,
+     "sha256": "346287127fa17808a350dc270a52f58db4381b37ef8c243fafd4de3aaffc1ab2"
+    },
+    "sound/necros/tower/g_rez1.wav": {
+     "bytes": 171646,
+     "sha256": "2678e6d5a5e47a7077480d1f067d331ceb0d8451f3cfaf98a213df5213ebb5aa"
+    },
+    "sound/necros/tower/g_rez2.wav": {
+     "bytes": 43734,
+     "sha256": "c6a5c28331fc6a448d9de177764ee917ad069f2756c863b44057e874fb173b59"
+    },
+    "sound/necros/tower/gearopen.wav": {
+     "bytes": 49708,
+     "sha256": "39b73c8ada1b06c7ba07099447b9b0d75911f08df09ced3826bcff136af5b0ee"
+    },
+    "sound/necros/tower/gearopn2.wav": {
+     "bytes": 52204,
+     "sha256": "70afe914f7b256714de02c56d8c4ff05554f3c602a363368ef7a234bd6ea59fd"
+    },
+    "sound/necros/tower/machloop.wav": {
+     "bytes": 114314,
+     "sha256": "30b0390ff4fa000bab0f912d67c283621df3d34707a97d19a4864bc49d4e4c9c"
+    },
+    "sound/necros/tower/machpre.wav": {
+     "bytes": 221548,
+     "sha256": "93bd729920ad9834709e7b7183ffa03f6b18ac6f768df4c359a362bbe68675fd"
+    },
+    "sound/necros/tower/machstop.wav": {
+     "bytes": 124342,
+     "sha256": "e35b2ec09ca186631e36a4c86927d8220ce386d9e00868fa483daa654682f7bd"
+    },
+    "sound/necros/tower/machstrt.wav": {
+     "bytes": 231396,
+     "sha256": "86ed29d33c712852afb3b06fdf23f29b01151d84228717900c8aaa2c9f3f769e"
+    },
+    "sound/necros/tower/mladder.wav": {
+     "bytes": 10576,
+     "sha256": "9a6aeefbdb7aed5a9d5ea23fe9fb0fba4c7923a35e1b49e7c18a7c42b6ea6dbc"
+    },
+    "sound/necros/tower/ne_hum5.wav": {
+     "bytes": 61584,
+     "sha256": "03a29e971736696b4140932e807e3aafe475cbfeca146b497ecc6cd7c742c52c"
+    },
+    "sound/necros/tower/physics/blockhit1.wav": {
+     "bytes": 24840,
+     "sha256": "2c398ff2875279f209c28107e430b3f6d27f592bc2fc3fafc7a27bc5421509a2"
+    },
+    "sound/necros/tower/physics/blockhit2.wav": {
+     "bytes": 20336,
+     "sha256": "500a4f089688f3c40b61c1d18b46696a814c90f3c47a3edd88e2f5014ede9774"
+    },
+    "sound/necros/tower/physics/blockhit3.wav": {
+     "bytes": 22826,
+     "sha256": "44333f5422dd4bca98d332f19b0713eb93ddfec4af5d101f66aeb65a049ca710"
+    },
+    "sound/necros/tower/physics/blockhit4.wav": {
+     "bytes": 22576,
+     "sha256": "b7b4fdcf83e231cfcf608759dcd01b24de0e1076d4c5ffab2d9074309a0e1f50"
+    },
+    "sound/necros/tower/physics/stnhvbrk.wav": {
+     "bytes": 41478,
+     "sha256": "b2673c05206bb375bfb78dad1c164e680804b2e9ac4d8dba4eae2645f39f1f6a"
+    },
+    "sound/necros/tower/physics/stnlibrk.wav": {
+     "bytes": 32096,
+     "sha256": "834a1c97114a579e1cf01078054faa0234da416557c3c8b6999752f4f80d2378"
+    },
+    "sound/necros/tower/rndpebl1.wav": {
+     "bytes": 14344,
+     "sha256": "3c281509e945081ca7c674fb501992a7ce71ac3cce91bd0f48514bc03f60cb86"
+    },
+    "sound/necros/tower/rndpebl2.wav": {
+     "bytes": 20652,
+     "sha256": "63d098044c67ed0a3f8bbc794d91a39908dc93fb7d3fb2da33bd70d93eb64d61"
+    },
+    "sound/necros/tower/rndpebl3.wav": {
+     "bytes": 15724,
+     "sha256": "e11a57fa8437f877ef91292fc3d8e375655f7fb43ce0d5c9f84f37465b61bc1e"
+    },
+    "sound/necros/tower/rndpebl4.wav": {
+     "bytes": 12322,
+     "sha256": "f24c38ba9d26918d5f2a39ba643d96487716dd0293a6dfeb668e89fb236b7caf"
+    },
+    "sound/necros/tower/s1_stop.wav": {
+     "bytes": 16162,
+     "sha256": "9a35adf9361aa033b413762fea7d04b2cf7392b363f2aa187a81905f65a44b61"
+    },
+    "sound/necros/tower/s1_strt.wav": {
+     "bytes": 64074,
+     "sha256": "d36511a654d68c9b30c3f3b23b3a022e5ad5aac75d2862a1fbf35f5567c2843a"
+    },
+    "sound/necros/tower/thit.wav": {
+     "bytes": 38668,
+     "sha256": "4badb57891f6620f55bd465ab8924173408967effc0c5eca5ac7c6916acb9841"
+    },
+    "sound/necros/tower/tlaunch.wav": {
+     "bytes": 45154,
+     "sha256": "c2e43db7a3f9c8b24f29b0209df8d564fa9d5bb964611bd962c692f0b704d539"
+    },
+    "sound/necros/tower/vlingeat.wav": {
+     "bytes": 56720,
+     "sha256": "210f1e7c263fc747f983b0164e07be76b0e13957a8ce9550217965b74c46ac6f"
+    },
+    "sound/necros/tower/wat_cave.wav": {
+     "bytes": 117614,
+     "sha256": "8fd860006e3d2746d6497e95d886e99e62323a38870ee57960eeda430e25e85e"
+    }
+   },
    "sha256": "df7f22f7764a7994e055c8d71d83b1c9f3e151021e38ae70144f93021149eefa",
    "timestamp": "2009-07-01T15:03:38.000Z"
   }

--- a/json/by-sha256/dc/dca10cb648213706cc4c843b8a3e80c86da799ae0fc8004fd2e0a59d04fc50df.json
+++ b/json/by-sha256/dc/dca10cb648213706cc4c843b8a3e80c86da799ae0fc8004fd2e0a59d04fc50df.json
@@ -27,6 +27,300 @@
   },
   "copper/pak0.pak": {
    "bytes": 3627440,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "9a43288e327e421ec6c002b46fa59454bc459b39c78ec040ca061ef885baa875",
    "timestamp": "2020-07-13T10:30:32.000Z"
   },

--- a/json/by-sha256/dd/dd6e0601e0d306aaf93a374a5acebdc199d1bb5c49d44aa9662d5a3b826ab239.json
+++ b/json/by-sha256/dd/dd6e0601e0d306aaf93a374a5acebdc199d1bb5c49d44aa9662d5a3b826ab239.json
@@ -72,21 +72,3465 @@
   },
   "pak0.pak": {
    "bytes": 25051624,
+   "files": {
+    "maps/b_barrel.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/b_wbh10.bsp": {
+     "bytes": 3936,
+     "sha256": "3007b06221e67398a3194fa9190bc8f2b087236ff259e43787553b06650dedf3"
+    },
+    "maps/b_wbh25.bsp": {
+     "bytes": 3936,
+     "sha256": "54ed7974a414d6e75ec3077a336382d9815107d34fc42ff13ce5c0782ad4c5e2"
+    },
+    "progs/acidbal1.mdl": {
+     "bytes": 8788,
+     "sha256": "8a9c956f1952fb8d9ea51119c1c8c758d3ca3b3bf3bb0e8b63131bf88325f5a9"
+    },
+    "progs/acidbal2.mdl": {
+     "bytes": 8788,
+     "sha256": "eceba377145b62b4721927e55de75423daaac83f9667852b16dd1bfff3beff01"
+    },
+    "progs/akarrow.mdl": {
+     "bytes": 23072,
+     "sha256": "4e0e1c007453dbc432533dab09dfbafa943c4f43f7897848c91a516bf0de43a0"
+    },
+    "progs/am_super.mdl": {
+     "bytes": 8976,
+     "sha256": "55d561bf2f73b2c6482dcb5649da1b31d4bbf40aef6e21cca3518dc6a0c5709b"
+    },
+    "progs/anglstat.mdl": {
+     "bytes": 164396,
+     "sha256": "ce4644a5e22e0ff39790a293754501add2a4ad8afa26cfbdd13205c3b833e923"
+    },
+    "progs/archer.mdl": {
+     "bytes": 581920,
+     "sha256": "858ad8a4d0d27e1a9989ad7d87a9a4404ff8adbde33b07868725d34fd2146f6d"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 141992,
+     "sha256": "9a3c9afb3c47ed9c683ce6b0fdaef6ee6d1cf74c60509f1a82f8599318e71d08"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 25752,
+     "sha256": "57518dd89a3dbf6e712ad204b0a6f41fd7fdc9bfc03cf4c17e222f9d31d72b93"
+    },
+    "progs/arrow2.mdl": {
+     "bytes": 68764,
+     "sha256": "0bc41c13a4332f6d13e7884248b2d1a83b487bc2f4e1d5cbbdcd1c81512a4579"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 290592,
+     "sha256": "f0d1dc967de929d0f0faaa61aa51239d1f262c63da83013be094a4ed99e3028c"
+    },
+    "progs/bandit.mdl": {
+     "bytes": 226380,
+     "sha256": "7cc68b0c9a4950b4d3b97353227a6b8845104417efebfd00348b7fb24986d557"
+    },
+    "progs/baron.mdl": {
+     "bytes": 426204,
+     "sha256": "09a4b10b43c2cb4847330ce3660eab93c16a97a7db0c9e1c1447e938689627d1"
+    },
+    "progs/bbg.mdl": {
+     "bytes": 190836,
+     "sha256": "3bac35175b2808bad33e3b7e7c2c54b3d9181c5b3743aa68d803dbe58edf0eea"
+    },
+    "progs/beam.mdl": {
+     "bytes": 1460,
+     "sha256": "9e9531de6f4e6f2f6274ea6612ef00bd0642c0cc05a7fdc866805fa1be851b73"
+    },
+    "progs/bellring.mdl": {
+     "bytes": 74016,
+     "sha256": "9a8131071ca927803140ce6478b8912c6eb52856861250d6b6bfa1d32cfb9cd9"
+    },
+    "progs/blood.mdl": {
+     "bytes": 184,
+     "sha256": "06825646d627df610b374a31c9265a88c9c1c45864c6e3b9d273a14dc4d745a5"
+    },
+    "progs/blood_gr.mdl": {
+     "bytes": 184,
+     "sha256": "84caed23ff1b8cabec8c5d9e5c6792c30a6d9cc57c36a9746369012015462208"
+    },
+    "progs/bloodcb.mdl": {
+     "bytes": 28036,
+     "sha256": "83f0de29aa0f9e9f1d383895da374a5313aa2252edb306eb7bd69bd71660321c"
+    },
+    "progs/bookclos.mdl": {
+     "bytes": 3420,
+     "sha256": "a129ba5428a5fbef209010b893b4407c99a3d3a9e936d9d41247af5a75fc922b"
+    },
+    "progs/bookopen.mdl": {
+     "bytes": 6188,
+     "sha256": "d57ab7e96181b3fe70bc9c0c002ed6671fe14adfd454b680cd39be10b2315a05"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/chest1.mdl": {
+     "bytes": 19352,
+     "sha256": "239f897e3a390ad44acc5ffd19784f8b78232c5af2be67165581c2f6073ecc9f"
+    },
+    "progs/coin.mdl": {
+     "bytes": 44036,
+     "sha256": "c3d65aac43713c9102f8924ef7ed1cf90297ff17cfe8aface7936e9579b4ec57"
+    },
+    "progs/courage.mdl": {
+     "bytes": 14940,
+     "sha256": "4141933fbb8682ee28277826bd0f882580025def71b96c02cb9b53aa412906c0"
+    },
+    "progs/cross.mdl": {
+     "bytes": 17850,
+     "sha256": "c2ca5774a0f81ed5a8cd6057c6ea14b3842801594ecf45e81ce2eca7701da13a"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "7829e2cbaa4816577c77ba12a91933eee5dcf9d899f3f4d9717f6f8fc0319a23"
+    },
+    "progs/demon.mdl": {
+     "bytes": 355000,
+     "sha256": "3bb7fc1b1f89de1d66f99de4065d71e35dec87940d47c98b24d3be074d8bf70a"
+    },
+    "progs/dog.mdl": {
+     "bytes": 269016,
+     "sha256": "9a60157b0504891c71fbaece5a729e9b954a5e2dffe92e1e1a1ab51c6d912b77"
+    },
+    "progs/doll03.mdl": {
+     "bytes": 52064,
+     "sha256": "b2962f3954740ad7f9b5ee329d3a189ed5c95ccbb279bb63dc77508c94e4fb28"
+    },
+    "progs/doomcube.mdl": {
+     "bytes": 8884,
+     "sha256": "c4d31e7a4f2a9c01c1c502fec3653d8e0b14fc6ec790d8edebb1737a6116a471"
+    },
+    "progs/dr1_head.mdl": {
+     "bytes": 7476,
+     "sha256": "06f28a6f55ba29f12965e7ca10d99147a9432c851a2747d1e861cd45c07d958f"
+    },
+    "progs/dr1_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "c208f5473b2954fb4af094119b5a63b3a205e7a26e94c0c122b1f06870db6f78"
+    },
+    "progs/dr1_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "258da574e4de9d144d4f6a71db72a8bd566ecc6b0672efeb5cacaf59c7dd969d"
+    },
+    "progs/dr1_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "698d06c98e8e9ab99b6ddf808bb32a4994299c9596354bf8f811cda0f4042588"
+    },
+    "progs/dr2_head.mdl": {
+     "bytes": 7476,
+     "sha256": "551d47f807e21d11aba52f66207515e0988e8a424012f204e517c8c6720514d0"
+    },
+    "progs/dr2_lw.mdl": {
+     "bytes": 33532,
+     "sha256": "f636b0786ab159a368b9fa580f1a0a31dc7873f21edb1bc454eb9e64c2c27a14"
+    },
+    "progs/dr2_rw.mdl": {
+     "bytes": 38232,
+     "sha256": "533c0d631c78c22f5ff7632e7dc19f5da1acee56225a5a1497bf34d10fc07344"
+    },
+    "progs/dr2_tail.mdl": {
+     "bytes": 9116,
+     "sha256": "5f5eace00eef74eeaa9db48887636e08ab43c85ad0d05816745c04a4710f34d3"
+    },
+    "progs/draco.mdl": {
+     "bytes": 235148,
+     "sha256": "0b51fd9b782891c4b8b410db6ac1361dfa0f53d634366709434a926e0c7285b5"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 262688,
+     "sha256": "d27bb0ed21b8f0e8161f347cb5bba89c8c5223324f462596f972478efdacb366"
+    },
+    "progs/dragon1.mdl": {
+     "bytes": 258260,
+     "sha256": "4dbf09c018ea9f703d4daf48c0a5e504208547d5d172bf26187b8eeac8a94a02"
+    },
+    "progs/dragon2.mdl": {
+     "bytes": 258260,
+     "sha256": "fa2b5d9467299634cddcff9c7ca87c2006c8c9631f45cbf66f74a8abfd5df347"
+    },
+    "progs/dragonpl.mdl": {
+     "bytes": 77764,
+     "sha256": "57db3cbef92a0f96cd8ef1be17ce77586f9541bbffcea2e7747e43b35c50effa"
+    },
+    "progs/drggib01.mdl": {
+     "bytes": 63320,
+     "sha256": "0a2571dc74871a4d43c8c780a62d36ce4d17dd83b6819c773bfb22a247b8bcbb"
+    },
+    "progs/drggib02.mdl": {
+     "bytes": 83352,
+     "sha256": "c3ec2317e0f0f156237b7ed36d1ab3329a874a11f7a2fb343afac021a50f777b"
+    },
+    "progs/drggib03.mdl": {
+     "bytes": 58824,
+     "sha256": "9dfdc32e9616b40b82c410ca75f007bc11a9b18697d4edc82745bcda1b3313ed"
+    },
+    "progs/drilbomb.mdl": {
+     "bytes": 5396,
+     "sha256": "6615fa32cb3b464b665093296ff63fd0c624eea5ec595247d8c66941e1c8d071"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "718b8c2842877345426247148dd6ce1ebe7fecc13e969a0fa0ed6dbebc388099"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35656,
+     "sha256": "0a386b6381824b01852910519490ac3f6e3309a96091820384ee6b9a5b452e7a"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42196,
+     "sha256": "c9d01a6049159bf8ac0328b49a296c4b8851d3e2e432168675f9e8b1b2ac75d7"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bef43e6c7bc067d3b35dd05a793c08d7d700fbb2013606ac9ffeac8772d0997e"
+    },
+    "progs/drp_head.mdl": {
+     "bytes": 2340,
+     "sha256": "b87cb902d796dd76c03e9fc79576f368d23022fbd5b5155c8910cd315046e32a"
+    },
+    "progs/drp_lw.mdl": {
+     "bytes": 7116,
+     "sha256": "ad483731fddede05ebf1a9a3c20f735f6ec341f156669833ed1077460dac8e5c"
+    },
+    "progs/drp_rw.mdl": {
+     "bytes": 8056,
+     "sha256": "b57363de0be61e45b355d1cceccadd42fdd1b8f91fc4380847dacf186d7560df"
+    },
+    "progs/drp_tail.mdl": {
+     "bytes": 2604,
+     "sha256": "b8ad65168755d4f31b657a80c78e2e0f51316c48f4ebd10ddae0b6971c7c6e89"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/ember.mdl": {
+     "bytes": 8788,
+     "sha256": "91d6f4dfbeba0711d0864b94bb372b602959644c5c841fd659ddedb8f8e6980c"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "13d14261d863f5170fb8e64e57b8ef344c435183313ffb1127ab6ce51176d262"
+    },
+    "progs/end_bane.mdl": {
+     "bytes": 52980,
+     "sha256": "4a86fd7bd59c4ecea934e3adcec4b17d627cdfac5223976a52b5739143c37f27"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 241252,
+     "sha256": "9ae37ced89200daf2d44795bef4230c5b725226a820c28cda7908f43bbdaa747"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 414484,
+     "sha256": "3d146be46cd90ce477006354b3ed627541fc4ecdb52ff6de2b4f3159c61e1390"
+    },
+    "progs/flame2.mdl": {
+     "bytes": 68804,
+     "sha256": "f3c760ecdbb530ff651c46f516228c588f37585315acdab199408911c2c8414b"
+    },
+    "progs/flame2a.mdl": {
+     "bytes": 68804,
+     "sha256": "e02210f2f6851cea4b9520476cfe36c31745dc2d84248f6a75132358d6d43035"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 56532,
+     "sha256": "36d304e1442ede2048036d832d36ef4624fe4e90ba16628c20c819e7b4477da5"
+    },
+    "progs/g_grpple.mdl": {
+     "bytes": 149440,
+     "sha256": "fc148b3a840b84b65488658ec26a27621a86a196feb90723269534929ee0352e"
+    },
+    "progs/g_gun.mdl": {
+     "bytes": 35580,
+     "sha256": "0d6cbc684d5c5f1112d0111e29405e73721993ad57854c936e676025b7bfbc1c"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 38004,
+     "sha256": "cf67c0a7ad3e853fa4af7544d0399fc0a3795a61d625f5e78104e659e2db0eed"
+    },
+    "progs/g_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "3e4a1e9dc2bff162612e218a25e2040b57d063d198df2e301eaa8fa9542af098"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/g_rocks.mdl": {
+     "bytes": 47732,
+     "sha256": "d6539141be1597673eb1f8c78286d6efdeefa91f9723926d61b9a81e2f433c71"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 158116,
+     "sha256": "127e4fefafc5015f03a6cd1288cab9da325ed5b5a93c9f6b90b6da9d8273ef9f"
+    },
+    "progs/g_wand.mdl": {
+     "bytes": 13684,
+     "sha256": "99212b7901c31b723704e7c62b1c5f70b6a2f7320c349605a3943f3091e962de"
+    },
+    "progs/g_xbow.mdl": {
+     "bytes": 22476,
+     "sha256": "bf1cd180a66f74da4e625a2167bf66527cebd0d4009fabeed48297018db8a4fe"
+    },
+    "progs/gem1.mdl": {
+     "bytes": 42612,
+     "sha256": "0b71e525b19e25f98dad53ce766751de8e0c9f18434582bb86242296bb7a402e"
+    },
+    "progs/gem2.mdl": {
+     "bytes": 62672,
+     "sha256": "721459e22aab0d2cece430053734b889918bde4db879ffc94084289a7b6d4d8c"
+    },
+    "progs/gem3.mdl": {
+     "bytes": 42072,
+     "sha256": "3bc3a1018cc432b694f9ec45de06775776ef55d21b4e117dd1b2c7c0d7b850a2"
+    },
+    "progs/gemini.mdl": {
+     "bytes": 35188,
+     "sha256": "fa05498ce8034d51377953db7c650f9367b072a9d614812f4f67ad15eace909e"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/gr_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "3f5b6d67b80e5f2e5bb7c129500c79dc345141133f8d415005f9384b0d2d9661"
+    },
+    "progs/gr_gib1.mdl": {
+     "bytes": 6501,
+     "sha256": "3f715cbfdcd77caef11b904aa12d2063cbb973d4a9d61c27492690344c14fb1b"
+    },
+    "progs/gr_gib2.mdl": {
+     "bytes": 17553,
+     "sha256": "c6166eb6132a3e87f51fcf48f4e9eebb719b3f1819d22640582b23d61bde4a16"
+    },
+    "progs/gr_gib3.mdl": {
+     "bytes": 22933,
+     "sha256": "0e40e5b960924ca642690c26b239c89aea6bae18badcb945e96d2102cad69622"
+    },
+    "progs/grem.mdl": {
+     "bytes": 202672,
+     "sha256": "3df027b9f674f1f3d3cd775c877fe225029f1b814ff3358f98f932cf8bb0a604"
+    },
+    "progs/h_archer.mdl": {
+     "bytes": 22128,
+     "sha256": "034d829e2ad34eeff8f5d60b8e2064f08caee64fb7f064900298f9405e9399d8"
+    },
+    "progs/h_axeman.mdl": {
+     "bytes": 18400,
+     "sha256": "e15391056ec618b412d1341914d2e6f05a759de92500ef249cc5d1789b3ab6d6"
+    },
+    "progs/h_bandit.mdl": {
+     "bytes": 9752,
+     "sha256": "cc79629b169c0560905eae7ea9a02e5ec546af8cfa07743922e0b1dc829b29ca"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 7444,
+     "sha256": "68bc1db4875fe84f25ff3d6c53e4e9e2c023ef52bf3c89b439493f2e5c5c0e19"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "53539bc39fc87627a46b75b0d86ade5e6116a0079b032b1df137b2425b7186cc"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 166100,
+     "sha256": "0484f334f5722736248531a726e9a91c69e708a882e6d581db3d4e2a54d6db94"
+    },
+    "progs/h_dog.mdl": {
+     "bytes": 68796,
+     "sha256": "57a646b291c29b490faa38e3b72d7f074d9d071946d9b9c6068095999a11ce77"
+    },
+    "progs/h_drake.mdl": {
+     "bytes": 28792,
+     "sha256": "be0bcf5fc725dbb09a82becc2339d91824a14a547ce3013deabeece662658dcf"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 30072,
+     "sha256": "e88bac12b670f6790f3e053e1547569e88f0befa7a07abfc6a3fd2ad33b9d9a3"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 22724,
+     "sha256": "905ed9f78c83e29a31b6283b5a377053763469ae048bdcc3aede9213bda80873"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 100172,
+     "sha256": "27311a59a95ab735d79e5198318d0507da7e377584702ba9e5bf673c0972e065"
+    },
+    "progs/h_hkolem.mdl": {
+     "bytes": 30552,
+     "sha256": "38b2082ead97b90f59a5fdcf24d4077ab067c55655598d023f8ec38818c914b1"
+    },
+    "progs/h_imp.mdl": {
+     "bytes": 73564,
+     "sha256": "24944207a9867d67fa24961516dc2810a5d1b33d341d5190ac1666d58c8252f4"
+    },
+    "progs/h_imp2.mdl": {
+     "bytes": 73284,
+     "sha256": "f01cd8331b8774495258e3ab85ba6434a0deef19b1b953b6ccf93252649e01fc"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 19644,
+     "sha256": "1accd89ba95db3627cee4f06f94ab3bc9d146ebf566da24b570c733f2f902c1a"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "72455aab2067fd8f887e8a8e9c61d2b943699ce90fbcb85937fbb358c9e5678e"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 53188,
+     "sha256": "6e1c28d5c53f24901ebd0aa199a1003ef4fe3c8306c5ab28191cccd14bf25f45"
+    },
+    "progs/h_necro.mdl": {
+     "bytes": 14296,
+     "sha256": "fc9c468465d0e8982fc2d6207ce94b2f400f0f37cbe88cff2a4aa64719b91f40"
+    },
+    "progs/h_nemes.mdl": {
+     "bytes": 78156,
+     "sha256": "6f350692b44907984c02779d0114576bbafb6a3ada673e1f55d1cf02fd062c18"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 28888,
+     "sha256": "2c0a6d80c28b94c335164561cb07ab95fef251ae52562686ca422f565394cabb"
+    },
+    "progs/h_rebel.mdl": {
+     "bytes": 5428,
+     "sha256": "b189ff3ae1596da7596f21d8f555603951fadf8e7884e96f89c8b2b5789028a5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 53096,
+     "sha256": "ff1d940222f28765b975828528016332b04423a4001a507e07cde6414847add5"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 108204,
+     "sha256": "dd7dc5c90255da868b96ac553d8a8f68b6723da6b25114bc087fd019966a023f"
+    },
+    "progs/h_vomit.mdl": {
+     "bytes": 16952,
+     "sha256": "9822885036229871594a21643f4acd3a9b4c27d141b9021464b5062dfaf410f9"
+    },
+    "progs/h_wizard.mdl": {
+     "bytes": 28792,
+     "sha256": "7ff66f881f85884aea56396da7b756da32c04df163a1e1f739485e77e61279df"
+    },
+    "progs/h_yak.mdl": {
+     "bytes": 73116,
+     "sha256": "eb2cf314618ef6dbc44ab46807237e59b68470edf24780e4ccd4c5b513f91196"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "2f6fd7256662a5a4b4b907b0ac68bf7d787ebd55cf54e352da5f1b363a2b2397"
+    },
+    "progs/hero.mdl": {
+     "bytes": 66388,
+     "sha256": "ea4f359a328b6416588e5debe13a87fc2eccd8a65263ae23683d71a58b39a116"
+    },
+    "progs/hk_golem.mdl": {
+     "bytes": 179204,
+     "sha256": "972f27eb2bf8a6cc4433e1f904097ca5393312d47a75e396b0323723beff58fa"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 534604,
+     "sha256": "10058c95eca9a063c7990d919d353d3573d252eb39f00c5f471a7f22f0b5fefa"
+    },
+    "progs/hook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/ice.mdl": {
+     "bytes": 2580,
+     "sha256": "30c4853e26d51d0ca4d3df5a40ec6d8861f48e9420f10560b5de0c19e6c15ab0"
+    },
+    "progs/ice_cube.mdl": {
+     "bytes": 3192,
+     "sha256": "bf96c8c1533fa537582bd4cf7bddadb7f5ddeebafbce9ef29007a5acd5a909b0"
+    },
+    "progs/iceball.mdl": {
+     "bytes": 24632,
+     "sha256": "802fa6260e9af5abb74bab0a76f35ae3e2af2373e61091c725325aa41051be7a"
+    },
+    "progs/imp.mdl": {
+     "bytes": 583036,
+     "sha256": "299777bbf58641a6674c0877423efd9f0995421a1bfb946fe21d1f2bdb41714f"
+    },
+    "progs/imp_lord.mdl": {
+     "bytes": 583036,
+     "sha256": "0b26574642cc72b73d349881543752a1f7d7f34f00561c4b039bef83e7191b10"
+    },
+    "progs/imp_rock.mdl": {
+     "bytes": 2352,
+     "sha256": "dbe190f471f5738779e103b496117ec40e2adc9e5f593d2470172bcbd7ade0f6"
+    },
+    "progs/imp_wing.mdl": {
+     "bytes": 93932,
+     "sha256": "a0100af8c072112afde45cc2f69e40de4aacffbdb4515de107892c39a00f5eb5"
+    },
+    "progs/impwing.mdl": {
+     "bytes": 93932,
+     "sha256": "5b986189f2f28ffe6c3fc23d40bc194bda2ab636826a9d41ffc9199727cc2f49"
+    },
+    "progs/impwing2.mdl": {
+     "bytes": 93932,
+     "sha256": "0d08640bcd5c6e6336b9cedb635a6152ba479065a56b296557476a6f5e9b1e4c"
+    },
+    "progs/k_ball.mdl": {
+     "bytes": 31300,
+     "sha256": "f93346ffeed3fd5d9866fb80d1a08216759bb27757d49a1851e471aadf757ec1"
+    },
+    "progs/key_b.mdl": {
+     "bytes": 10616,
+     "sha256": "d1333d74b7e194f6587d0f5ed1fca28887cd0414734b4bd4cbb7e715ab897629"
+    },
+    "progs/key_m.mdl": {
+     "bytes": 23160,
+     "sha256": "ea2feb6eb54823668dcb112f42c3441e563e18e3cc1806b5ce509044e6c0b448"
+    },
+    "progs/key_w.mdl": {
+     "bytes": 11576,
+     "sha256": "72da64d2b29d69605c453e9ee0e5fa8ecef91a94cc541103cb24fbad96c7946d"
+    },
+    "progs/knight.mdl": {
+     "bytes": 232536,
+     "sha256": "e3e618799612c6e521f68234a061d9a46036ef556677b0c1651e7647258ffb56"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 27960,
+     "sha256": "5877b37cc4f98a53467c412e7d06d1f7ec6b60f5c0f2088514aa51c9d2c51769"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "210e159ea4c9bf1f2431213fd95902f4ea75ecee6a67a22bed7e93366f1f2732"
+    },
+    "progs/levitate.mdl": {
+     "bytes": 15876,
+     "sha256": "03e77b0d4b8ee7b3b224cbe0cfba63e8bd27d0391bd5069981e5435287f66645"
+    },
+    "progs/life_up.mdl": {
+     "bytes": 34676,
+     "sha256": "502716aa1b0f6cb8f929fe7ee2a74024a5fa007898256e15ca495e126888c584"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 57796,
+     "sha256": "e8b38ca8f28a89f65ffc652e082e8a9aaf6a1a9db8302e961b9ceac1c8f60e8c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/morph_eg.mdl": {
+     "bytes": 300592,
+     "sha256": "14468fccffaa1508c03610dd58fb51cd9058ca3bab036bca18f7a41cb37c195b"
+    },
+    "progs/nec_rod1.mdl": {
+     "bytes": 16072,
+     "sha256": "2eded5df9441aca7a243bf6c2a831c62374cabf7bba1acd64a84803441d77fc2"
+    },
+    "progs/nec_rod2.mdl": {
+     "bytes": 4564,
+     "sha256": "60b0923cade4c8ab9a476cae75c7c73f71c1d13799ac7901d0be4db5d5038895"
+    },
+    "progs/nec_rod3.mdl": {
+     "bytes": 4132,
+     "sha256": "459edf5ee6ecf0c52ec83e055a2c12ad39d3d3a42a4774c442ccc686e298da47"
+    },
+    "progs/nec_rune.mdl": {
+     "bytes": 19524,
+     "sha256": "cea5c89dd0034465a54a8434bc9367554f0244c2e38ec9220cd28a5a53a444a9"
+    },
+    "progs/necro.mdl": {
+     "bytes": 577208,
+     "sha256": "a0e43517f3cb579e38baf9ee4b5058ed59036b69599c0fe3ffeff9c00ba843f8"
+    },
+    "progs/needle.mdl": {
+     "bytes": 16688,
+     "sha256": "5f714f6b43cc28ca1de1246cc0175ea2e07040f73c9d0a623dbe4b4577559c14"
+    },
+    "progs/nehjet.mdl": {
+     "bytes": 19956,
+     "sha256": "fd0346c9c37d2ca7d3e696a9ce0694652722f63326376ad3b8189fb81a68f5c3"
+    },
+    "progs/nemesant.mdl": {
+     "bytes": 202492,
+     "sha256": "099c26752c7160144a25716e0af0f30f8ff179766db4a05371a0392166f85c42"
+    },
+    "progs/null_256.spr": {
+     "bytes": 5412,
+     "sha256": "c52813b634ef1ab641fdd4c3a9739ad758f1b5c39ba5e10acbbf034ee0ff850b"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 230152,
+     "sha256": "b7c88ae295ef8fc8d17b4fd6facedbb8e464ee665039a884af8e215a3929f24a"
+    },
+    "progs/oldone.mdl": {
+     "bytes": 560224,
+     "sha256": "5690a29cb0ae1a4889bc398676db8477275b0953e2ab7bbb75b717509d93c985"
+    },
+    "progs/pl_oum.mdl": {
+     "bytes": 331236,
+     "sha256": "6939a925af5510ecece22c3cee3de418d3ba532f4eb17409ca1453d253de328c"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 55676,
+     "sha256": "c9810eaac822215e7c84f11e55bb614121d17a79a02aa162fb430b5f37664ade"
+    },
+    "progs/plasma1.mdl": {
+     "bytes": 9120,
+     "sha256": "78a81a8eaaf95f85cd0fb7bc31dfa45c30e660fc5265168178b50776afc96563"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/playham0.mdl": {
+     "bytes": 99756,
+     "sha256": "1016d24c984994843af5d086e36e548c55590018f1f6b2d78799e25a40271ec4"
+    },
+    "progs/playsaw.mdl": {
+     "bytes": 87340,
+     "sha256": "b53cffd1807a3710f03b350370d78dfdbb2b057455fcac9f00d1b0baaabbf8c9"
+    },
+    "progs/potion.mdl": {
+     "bytes": 53272,
+     "sha256": "6ee1b1294f1ff41bdf265d06d80fa22a89ff579acb70bd2544986a0235ebd6e7"
+    },
+    "progs/potion2.mdl": {
+     "bytes": 195484,
+     "sha256": "c4f0f920521bd6e1caa6072b19d11ba57f4d493ffc2d6a395190170c9bec702a"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 47008,
+     "sha256": "e7ba606cf1cc11d9ad5baef5aef9dfa9239b7550a1c12937965a562bc815e6a0"
+    },
+    "progs/pur_gib.mdl": {
+     "bytes": 10196,
+     "sha256": "dbc2bf835db1c1789c329504f86802990a19288f67d9560f32cfe5a8d5a62885"
+    },
+    "progs/r_bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "2d776e4acdf20cd117f3f4d6be3647fb9d0e117756069cbfc52ece716fdbb251"
+    },
+    "progs/rain.mdl": {
+     "bytes": 39276,
+     "sha256": "9a13a2ff68c8d8eb27426cee38330a6237de8ceb9ba9ecb9b71071512b190a94"
+    },
+    "progs/rain20.mdl": {
+     "bytes": 42620,
+     "sha256": "192d3d8197976f98eb053e54a00536ca9ccc8769692e9c483990b64afa4e1d8d"
+    },
+    "progs/ranger.mdl": {
+     "bytes": 232148,
+     "sha256": "21e690b07a7d3b2b0fb630480a5fd52ea23b41a8571c3618d16ea1ab7508e52f"
+    },
+    "progs/rebel.mdl": {
+     "bytes": 215292,
+     "sha256": "433596df8d06be0882f00a2c1fad0ea49a8ae42ef148d32e0ae7c06c420322aa"
+    },
+    "progs/red_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "ddea3b805f061c042d84c680676068347cda55101517851c10c629fe32711ad8"
+    },
+    "progs/reflect.mdl": {
+     "bytes": 10224,
+     "sha256": "3e8b08d02c11ee9e5546c96c014c8e698ca9097046ff3873012033c0bcac8df9"
+    },
+    "progs/regen.mdl": {
+     "bytes": 50808,
+     "sha256": "1c2422c4124c235e29570580b0c1bfeb55613d6c8152c78dfb6d073ea316f122"
+    },
+    "progs/regen2.mdl": {
+     "bytes": 50040,
+     "sha256": "b8da16335e855c502b7ff0c5b6875050b73c01ff0eb5b5627fc890d155cbe013"
+    },
+    "progs/rocket1.mdl": {
+     "bytes": 34260,
+     "sha256": "c9412482647d681e08f74eb0c0260ffded91dfc67378996b86b720ef3cd2fd47"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 17204,
+     "sha256": "0dab5b94c60d92d55df3e44a8d8ea2dc0f949e98897a6525ee0be3f49a019b08"
+    },
+    "progs/s_expbig.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 165212,
+     "sha256": "5b78b324e252f95ef8f4a9fd4fb19f855c40f74fd1f93aae9b84ed822e9c3585"
+    },
+    "progs/s_fancy.spr": {
+     "bytes": 432120,
+     "sha256": "2dcb35ecb5312709ae4b295ebcf209e74a34e385823f54603e6fe0eb8999556b"
+    },
+    "progs/s_kinn.spr": {
+     "bytes": 45624,
+     "sha256": "c6412ac75ec56533cbf0487223c2c8a23a3d3518b0e3f7ed8af73b81cb6ecbba"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 8016,
+     "sha256": "fa366e4076268de137e0eecd88d02e3aac99f38c48c6ad0d0a74c88c95e8d4d4"
+    },
+    "progs/s_wave.spr": {
+     "bytes": 373212,
+     "sha256": "c2a3b258b2809f22247596b6e0505829853e9a5fd60fed7c471fd663cf9e9402"
+    },
+    "progs/s_wave2.spr": {
+     "bytes": 39480,
+     "sha256": "a0fbc773e66385a8bc3c16195ce14215050cbec7caa118fecae1a0c2a2c59d50"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 333284,
+     "sha256": "90757e506c9f0e49e4e9897708df4825e1b27774ff46abd9c113738380dfde62"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shade.mdl": {
+     "bytes": 83644,
+     "sha256": "080ad2839fafadfdbbe5412ac53061a917af3158f33e16f5df4b4f3dbe422ccb"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 128012,
+     "sha256": "94aca4b876e4794684f4f2b9e66f1c34f7b3935b0d35d406311b63aba17ea3c2"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 176048,
+     "sha256": "7ea0c1007179eb7a45112aaf38d8042213e8b644e6e79b9b1a8d4402c3843b47"
+    },
+    "progs/shotty.mdl": {
+     "bytes": 16984,
+     "sha256": "42f2e1a71e00db26092b7fb9c633daff43bfebdcb46ced46526bee057464cc88"
+    },
+    "progs/shubdome.mdl": {
+     "bytes": 97512,
+     "sha256": "3b92e43bc942b2cfba8c7b4e1206ad858484564d86bd7faa069db592f98c7232"
+    },
+    "progs/shubstar.mdl": {
+     "bytes": 14760,
+     "sha256": "ee5f914d7f3f930db06b1ead8d314dec0413e5182b7de24cc808076d117f3cda"
+    },
+    "progs/skulbook.mdl": {
+     "bytes": 15572,
+     "sha256": "794768c4237a3efedf0c13026213aa417dec5be7eba7971f6e1113b5167fb904"
+    },
+    "progs/skulhead.mdl": {
+     "bytes": 50688,
+     "sha256": "d0733746c8b7cfccdb8d0f30f9454c8863a470e6d56e8359828dbb450aade77a"
+    },
+    "progs/skullwiz.mdl": {
+     "bytes": 726948,
+     "sha256": "0736c202c56cde1cfeaa10b62ca3747f85f08ae3a9cb5daa924456166664e4c4"
+    },
+    "progs/skullwz2.mdl": {
+     "bytes": 726948,
+     "sha256": "ba9f6f478a92ef3f6eec11a1d9c72e4bacf01e755e7f68dae4f6cf2856ff5504"
+    },
+    "progs/skulshot.mdl": {
+     "bytes": 63400,
+     "sha256": "73d6d8e5411b9ae3cf815c3b0cf695a5633cedd5d586565880a9146a1a5db5c2"
+    },
+    "progs/smartbal.mdl": {
+     "bytes": 27924,
+     "sha256": "288e2d54afcbdc5242ab831f3ef611710317c52432e4585a938a12df80b7a07d"
+    },
+    "progs/smoke.mdl": {
+     "bytes": 184,
+     "sha256": "2086abd9950bc643446309a80d9df86b4ebe3f2086f75e799ce943a8454c77d7"
+    },
+    "progs/smoke2.mdl": {
+     "bytes": 184,
+     "sha256": "cdae24fb7cf8efc6ec5271c297f18b04e8c69554ac4c4aedbccd7d3dd39089be"
+    },
+    "progs/soe_coin.mdl": {
+     "bytes": 26364,
+     "sha256": "5769371db409969600bd51d573162c663fb75d358c507fcff9a4aaea95fed4dc"
+    },
+    "progs/soe_gem.mdl": {
+     "bytes": 165236,
+     "sha256": "788f32633f1f3a9f6dd2e0c2dccb76871e02fc6e002db82a219f077dcc493c3f"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 409548,
+     "sha256": "8127b55dec92682e7de27ce1619b5fc8a727413b3cdf2125510138be249a1281"
+    },
+    "progs/soul.mdl": {
+     "bytes": 8436,
+     "sha256": "eb4dc0dae8aed7c92d328096fd9633566b658c9cc65777211ade1e67c6e0ff64"
+    },
+    "progs/sp_gib.mdl": {
+     "bytes": 22228,
+     "sha256": "e902ce3a5e4be26cb781d29178b6e808c480f9e898bc50ecfa78ddf12d774238"
+    },
+    "progs/sp_gib2.mdl": {
+     "bytes": 22228,
+     "sha256": "be98f64e7c2cffce98e28d99b36856762cc15caf761015067fde234390e6b302"
+    },
+    "progs/spider.mdl": {
+     "bytes": 355540,
+     "sha256": "6b32cacff38987b0b4a5efe585dce71ce64ee03e12c4bb1243b1be350f1f3b03"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3128,
+     "sha256": "078b774958c598bdf1503934d51a1393aeb9aadebcde806db2272b04b233c6a2"
+    },
+    "progs/spikes32.mdl": {
+     "bytes": 7668,
+     "sha256": "983176e5f12571f9b38c9c5d100841e480fe8ccf143889a0e48292a5bca8bf63"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/st_baron.mdl": {
+     "bytes": 185964,
+     "sha256": "7c00af263c1349b9dda2b1a6706bcce7034e9b0793697d67a1bfa83963ba127f"
+    },
+    "progs/st_gib1.mdl": {
+     "bytes": 5716,
+     "sha256": "813d52c557a1eb519d801652b4bd63acdc4ec18d62db53d843ca3dcaa88e87e8"
+    },
+    "progs/st_gib2.mdl": {
+     "bytes": 16228,
+     "sha256": "2d40c1eb75eeb6f5e1781ee9db7a0be10e0d07297d563f9035a8965c4c8c3d01"
+    },
+    "progs/st_gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "d44a77787c5ff633593ad9741ddfbe28809431daf3d32fbe92f8512871b9018a"
+    },
+    "progs/t_coin.mdl": {
+     "bytes": 35040,
+     "sha256": "ed7a18cfce56a630c9adaa37757e270419fca318b3fa655fea18002b089441b0"
+    },
+    "progs/t_gem.mdl": {
+     "bytes": 165364,
+     "sha256": "955761ccf88ef8f6adcd635fb70ae5d8e434b19394a15124acc4370e614f2409"
+    },
+    "progs/tar_gib.mdl": {
+     "bytes": 8788,
+     "sha256": "1ef69998430a54ba662abb46a0ef303b3bf0066f53e84b166065e79d58a72bef"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 313448,
+     "sha256": "fc63e6f62c83975ab2756f0a844d012b887491a6c73d9350dfcb04a6e0355b3c"
+    },
+    "progs/throwax2.mdl": {
+     "bytes": 34872,
+     "sha256": "11a22371cc72adf001e21d04e1b8b65e01497f56410867aa42ea21c0ff304e48"
+    },
+    "progs/throwaxe.mdl": {
+     "bytes": 56532,
+     "sha256": "0ebedab9ab397ba15dc3f0d90df703af2984d1c070eabc08ba781c308968150e"
+    },
+    "progs/throwham.mdl": {
+     "bytes": 7072,
+     "sha256": "f161fedb096a34db55fe57e84acd2bc42295ffea688549235c762b9a70430b35"
+    },
+    "progs/tome_pow.mdl": {
+     "bytes": 2612,
+     "sha256": "40a792071152640897de449d672a693229a87a11bf5e37ab05fd1656be22b6cb"
+    },
+    "progs/tree.mdl": {
+     "bytes": 237576,
+     "sha256": "f1f85524e4018552188aa58979154ce5544381d7bfd5ae05da521e55efdc25e5"
+    },
+    "progs/tree_zer.mdl": {
+     "bytes": 145444,
+     "sha256": "e87574f4e067fe99704d235ec155118736e0e69d9554f8622a1f1ee1c4f831cf"
+    },
+    "progs/treetall.mdl": {
+     "bytes": 120532,
+     "sha256": "e74e7c38099ccc833fadf3c7b7e97f746878d07102dad8cc5926546b344cb982"
+    },
+    "progs/uberpack.mdl": {
+     "bytes": 19348,
+     "sha256": "810cd3f895ef65e11f70fe00e195026308af02248b0f1442da5e816b7d6a7d9a"
+    },
+    "progs/v_grpple.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserb.mdl": {
+     "bytes": 35492,
+     "sha256": "cd2dcfa0fc848499235735fc5c7c5efdc631a779747f71441ff05403272bd9ea"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 93080,
+     "sha256": "05655920347b597feff05a74725b20cb88693ac78fdccb3730918a01cc4e6811"
+    },
+    "progs/v_mirv.mdl": {
+     "bytes": 39484,
+     "sha256": "a2d573bdf52015bce7a571a2263a3e8d938daf0bc1b5e4589f84580cab7da2d4"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 35492,
+     "sha256": "2f5a6e74998e4783d9b3d458d167aed31f32cd49b362f01b8d9ec0e94f90de63"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/v_rocks.mdl": {
+     "bytes": 58548,
+     "sha256": "87d0958027fadf417616cc48367b19ef6f9215a0685edc239c751b59e2b6368d"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 165540,
+     "sha256": "abd6787fff37c452fa01f4bbc9eb9594311eaf4a794f161caeb5a501ab9e103f"
+    },
+    "progs/v_sword.mdl": {
+     "bytes": 94416,
+     "sha256": "74b2fd6983cfb317ce136eeef6029d0cda063efe4706abc12057ba32cb0e988a"
+    },
+    "progs/v_wand.mdl": {
+     "bytes": 27388,
+     "sha256": "b46ba82a45a24fe4833dfdfd3c9457b98096a5800d6620d6eae11895653a6698"
+    },
+    "progs/v_xbow.mdl": {
+     "bytes": 95168,
+     "sha256": "e65f7cfe84cfa7c84c34147dadcc8b5ceea9416c7e378bd2110961fd76348e70"
+    },
+    "progs/vomitus.mdl": {
+     "bytes": 79724,
+     "sha256": "03dffcc3405c63f0e0c11301a74da5403d957b66171a6f34eaf8998e4ba31550"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "7758aaf42d0d1617e4fb172ce842be4316073f63250aba46dad441327cccb2e6"
+    },
+    "progs/wanted.mdl": {
+     "bytes": 27860,
+     "sha256": "03337a468db14377fcd36842037d2a27dfb97c3d5d5f45fcfe408e79050a5839"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 67956,
+     "sha256": "39c4a5daef1cfafc1bbfff1ca8eebb5c75d27f953f31d29f249205762605a56f"
+    },
+    "progs/wings2.mdl": {
+     "bytes": 28980,
+     "sha256": "5342d6191f59e69eb830a5e833473ac253b3a7750063d5519f6d2da2b82f5573"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 109380,
+     "sha256": "d78cd5ac1d667ec808fc7664071e060cea40179a0ba094e2f4c119d5ef7a79ba"
+    },
+    "progs/wr_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "1bfb049cf920973e32d78cbf7cf8b6c0c18f8dde55006ee43798ead4b99af9a7"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 238732,
+     "sha256": "5d0f3d6b32bfec300894dbf066a15bd9e34b985919423446232ad85d2ad6d6b7"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "progs/yakman.mdl": {
+     "bytes": 736212,
+     "sha256": "91595b5866d8f85fe67f349d22fb0c4735a4255894ca7368b10bc06618b98a3c"
+    },
+    "progs/yakman2.mdl": {
+     "bytes": 265228,
+     "sha256": "caba3ad0554bc09c10855592447424ac93beff1665803b2e5c605bd36b28cbdb"
+    },
+    "progs/zerkhelm.mdl": {
+     "bytes": 47604,
+     "sha256": "07fe43e56af442776c52da95902eda56c0bb197783fc5279ca350fc0dd34c4c5"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 226776,
+     "sha256": "f4d35645fa47d159cf7dee47a1652ff239cbe7a7b3df8567b865c6d44536abf4"
+    }
+   },
    "sha256": "9a229082e446dc3991778b3364ec5aeba9b6767e5905406767f753862997295a",
    "timestamp": "2011-06-12T21:18:08.000Z"
   },
   "pak1.pak": {
    "bytes": 11698993,
+   "files": {
+    "sound/ambience/amb21.wav": {
+     "bytes": 80716,
+     "sha256": "d664ea08d9df7e7dd135eb0726c1bc142878dcc53d13564dd3dcc5562180201a"
+    },
+    "sound/ambience/amb22.wav": {
+     "bytes": 92716,
+     "sha256": "f444289984b285a1497f55e566fbbf1896a04fa38e291efaa3ec1a0720204811"
+    },
+    "sound/ambience/amb23.wav": {
+     "bytes": 40180,
+     "sha256": "e451997ac7f37d08bd8434d708f45ee2967693317684b947ce511c9df84828b3"
+    },
+    "sound/ambience/amb24.wav": {
+     "bytes": 42282,
+     "sha256": "ead78c8507a7a6a7d6c61e913a2319964f6a8f70b5f7f720c162725edd9cd5aa"
+    },
+    "sound/ambience/brik_hit.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/brikhit2.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/chant3.wav": {
+     "bytes": 116346,
+     "sha256": "5d71f12940688414ab8cabc0d88e323dc961b60aac66f17887712133f1cb8b29"
+    },
+    "sound/ambience/current1.wav": {
+     "bytes": 50906,
+     "sha256": "dabe357d48586dccb8e1ed18c49828797c9f7a8c02c7a588ddc76a62c9b1d3e4"
+    },
+    "sound/ambience/drip_amb.wav": {
+     "bytes": 105444,
+     "sha256": "b282bc6082754011ee21a82aedb490a856c0f694f57991992296554c13149b02"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/heart.wav": {
+     "bytes": 8190,
+     "sha256": "a5b42c46cca24da59c324bb28ce6887b3a2a3baafcc18b0db2b2485f1189a4e0"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 177840,
+     "sha256": "9daec0732dcc821670b8910a1371153e3829e604b6957bf95931bea416af6074"
+    },
+    "sound/ambience/mov_watr.wav": {
+     "bytes": 44432,
+     "sha256": "9d6721844fd5559ab4f53902e70ad9789a90710dde082d222bd814a36c00ab67"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/spark2.wav": {
+     "bytes": 61640,
+     "sha256": "7eb18b00cd5e7913fea7a85ec5b1db159d1d001d24d4f687bfdb5685cb163c8e"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 106286,
+     "sha256": "056f37dfd1d5f4eba1d1911245dc0930bb0c46a84d72d867a286e5a9540248a0"
+    },
+    "sound/ambience/swamp1.wav": {
+     "bytes": 87710,
+     "sha256": "2bb46f7c8f70fd28f0ca47b294824bcca7689047291b6c5259eebe76ad6aecfa"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 140630,
+     "sha256": "5a4dccd168cbd9f759ac468d7aa879dbcdbe5637e0fd0521f641ba1d60f61817"
+    },
+    "sound/ambience/th_clap.wav": {
+     "bytes": 570992,
+     "sha256": "5b93e5d878621c2a92e66d6214b0fa8acf8ad5a35f4120f456ddf5678e941d94"
+    },
+    "sound/ambience/th_clap1.wav": {
+     "bytes": 72062,
+     "sha256": "1fc3146d501953545b2f2f261cd2fc398959a79c753a291702609b4cdd2e8682"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/wall01.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind1.wav": {
+     "bytes": 28798,
+     "sha256": "f66c76f07eef275e904fcc76d7ca9fc2011f3de8c61ce0b3ad035464beb7a86c"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 110578,
+     "sha256": "c3e1ccb091b9d8a06b83530b5e29b9f26f5ad8b9dcd082f3da976c3d44944b87"
+    },
+    "sound/ambience/wingend.wav": {
+     "bytes": 90874,
+     "sha256": "63e435d896b097d4dc413fb1afccc2078f1d101a4f7bfc18c4e593ca9e8b344f"
+    },
+    "sound/ambience/wingget.wav": {
+     "bytes": 65148,
+     "sha256": "533bdbd7beffa4c71c66239e3ac417f2177b20a60ed39c379c59a10b2222b367"
+    },
+    "sound/ambience/wings1.wav": {
+     "bytes": 6028,
+     "sha256": "c9e05f66a1d728a88289bc213c9f3551f1e54a4f3e8ef23ab03f8d5019e7b2c5"
+    },
+    "sound/ambience/z1m2mus.wav": {
+     "bytes": 103768,
+     "sha256": "d54261d4c9a4a8a9fe0c51eeae343c6a5b381727af88d0bae6f9b40605b8e5d3"
+    },
+    "sound/ambience/zend1.wav": {
+     "bytes": 123618,
+     "sha256": "2df6c267197b2e82241e47ce4985b04d14e1ce3cff46cebf3177369057302bb6"
+    },
+    "sound/ambience/zend2.wav": {
+     "bytes": 73742,
+     "sha256": "0ea00395004f11d41ab60352517bf5ff5c88a73b8ff2ddb3f32b5085967e3003"
+    },
+    "sound/ambience/zend6.wav": {
+     "bytes": 252626,
+     "sha256": "3f3c412e55bc7534c423c0d1bec2d817e3aea06338b4d6c3f78c4b80e55d509f"
+    },
+    "sound/ambience/zend8.wav": {
+     "bytes": 112122,
+     "sha256": "27cef28aa3d6c3ea86f0c54168db07055abfc7af284bc5a35bf53a0e53f8d677"
+    },
+    "sound/ambient/amb2.wav": {
+     "bytes": 38416,
+     "sha256": "21a4f41fb5efb52587e60395f23824ef330674a8d9499fe2cda1c91603093bfc"
+    },
+    "sound/ambient/amb7.wav": {
+     "bytes": 43020,
+     "sha256": "de7f4a0d15c711c9ca63f74ee38acf78e4ce41800900e0193a43c3e55e4efde6"
+    },
+    "sound/ambient/comphum1.wav": {
+     "bytes": 20456,
+     "sha256": "af10cad0f193d07be9c98f0dd889840fad0f54f40a61d12a1325b78033a68c8e"
+    },
+    "sound/ambient/comphum2.wav": {
+     "bytes": 72367,
+     "sha256": "fbf1ff8677cf36d78e381437f3b8e758a589a108a50c92f24c514eda06ede3f2"
+    },
+    "sound/ambient/comphum3.wav": {
+     "bytes": 116441,
+     "sha256": "62d9624940b93bcd1897abb809cb9d6f2cb3872cfd6af9a792260fb17f800150"
+    },
+    "sound/ambient/fan.wav": {
+     "bytes": 54275,
+     "sha256": "6cdc6a19b0c740d5607fa9076f749dc485483362445630877c6b59ec67085a2d"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/l_hum1.wav": {
+     "bytes": 20790,
+     "sha256": "f1b8bb19b32258ca1b126d52eb98b17c2753a255eba60864f8ad325f564681c7"
+    },
+    "sound/ambient/music1.wav": {
+     "bytes": 213944,
+     "sha256": "bf498e0cf6541b3559abd978ac420c5cb19d6542d89f19f59bdba8019dc46688"
+    },
+    "sound/ambient/pump3.wav": {
+     "bytes": 40435,
+     "sha256": "ae8ca71a1ce41bb3fa02d993930b4f100db3827ef5768326a91e61f7857370bf"
+    },
+    "sound/archer/arr2flsh.wav": {
+     "bytes": 5464,
+     "sha256": "e9a0c059430744c6546a6be4be3a1e4ac775ea6c5e6440d14611ecd8c8447d19"
+    },
+    "sound/archer/arr2wood.wav": {
+     "bytes": 5458,
+     "sha256": "97c5106007e703618291242bf1c6db9853a9d625189fc26ec9c4864436b560e3"
+    },
+    "sound/archer/arrow1.wav": {
+     "bytes": 2296,
+     "sha256": "4aeac8630ff6036f095a251a018eea5baad7a59bd7e46f624dbfec793e44d7b4"
+    },
+    "sound/archer/arrow2.wav": {
+     "bytes": 3196,
+     "sha256": "0a2734df5a69f6407ffc34ab05d8655da5d7dc0e487627932390fa6cec022083"
+    },
+    "sound/archer/arrow3.wav": {
+     "bytes": 2156,
+     "sha256": "1b866280829cb7ac051f90609baa8db285f3bfa3a27b5814e72b021b7cc05785"
+    },
+    "sound/archer/arrowbrk.wav": {
+     "bytes": 5002,
+     "sha256": "f72e35d5232f40e503192ff0ee26fe152eb42e5ee7141b2bea33a9f12f38aa2b"
+    },
+    "sound/archer/arrowg.wav": {
+     "bytes": 15132,
+     "sha256": "8ec5ee520f81c69ba367ae549a06d5ea1643b43f81dea7d8345561c94c8412ed"
+    },
+    "sound/archer/arrowmet1.wav": {
+     "bytes": 2638,
+     "sha256": "87e6ef50bfe4dabf48a1fba18ad0138bbd298965f1a9d06e2b059019e6f74b60"
+    },
+    "sound/archer/arrowmet2.wav": {
+     "bytes": 3118,
+     "sha256": "2797466dafd51473b8b6b5fd3d02a5baa4fe92a1bf9342fb038a299230037138"
+    },
+    "sound/archer/arrowmet3.wav": {
+     "bytes": 2804,
+     "sha256": "1e77951ec2218add2a8bc1633a925e4a96d2ca247d7b5dfaaaefd7a9a4f2363f"
+    },
+    "sound/archer/arrowr.wav": {
+     "bytes": 9458,
+     "sha256": "10e4bef745e55fddd004ea78d24edb9d3d9edc1ce3053c377be07be27a4da144"
+    },
+    "sound/archer/crash.wav": {
+     "bytes": 11069,
+     "sha256": "60e704bdfdb0a97863b00f3514130a172b95a86bebbf89642b65a6e757a74259"
+    },
+    "sound/archer/death.wav": {
+     "bytes": 9526,
+     "sha256": "e824b3d7d66e8bfc3ce30cc3116eab1b2d2dbc09c6311f91ff25d3e7eaef19f5"
+    },
+    "sound/archer/death2.wav": {
+     "bytes": 26618,
+     "sha256": "17e9e7588623ae7c3adf2d7354cd82efe9281f8beb15093738021190c0c79f0b"
+    },
+    "sound/archer/draw.wav": {
+     "bytes": 6874,
+     "sha256": "c94e5cec38dc40102beebd067554c91e63b86e5c1ef11dc17976733bd9f08ce3"
+    },
+    "sound/archer/explode.wav": {
+     "bytes": 17788,
+     "sha256": "1f7d6debef492f0861ee24049ad637a11b85d595cdf3f6d6aac422b7a0376d14"
+    },
+    "sound/archer/growl.wav": {
+     "bytes": 9240,
+     "sha256": "7bdbbd23b3fe056cd1d904124824aa0044acf3aa19ec88f65e092fd13e4b9437"
+    },
+    "sound/archer/growl2.wav": {
+     "bytes": 18298,
+     "sha256": "2d61948884b88feec7ea53d43e842d38fb317a7811ddac4c054b5bdf6a1c01ca"
+    },
+    "sound/archer/growl3.wav": {
+     "bytes": 27002,
+     "sha256": "e81a6c258d7b15538e75294b7d0d5831206ecb19e6d2f312c98b38acff9032bf"
+    },
+    "sound/archer/pain.wav": {
+     "bytes": 5082,
+     "sha256": "5347daf1a9263320f25b2a191895fbf6c85278f1fde6ca5962c09ed38e0b37b0"
+    },
+    "sound/archer/pain2.wav": {
+     "bytes": 4136,
+     "sha256": "e73414ac39fef61472e998972142a4f15ae678a7ee4b60dcb5e0ea0a0708612d"
+    },
+    "sound/archer/sight.wav": {
+     "bytes": 16866,
+     "sha256": "bcd12d078e7bc34f0bdea7ae9a34ccd2c9bacb049617329b44f8301c34fffeb0"
+    },
+    "sound/archer/sight2.wav": {
+     "bytes": 29434,
+     "sha256": "8ea174a90032c8fcf37ed758f462ef470c64dd8c741b206ba4d04364e5291f5f"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/bane/death.wav": {
+     "bytes": 10935,
+     "sha256": "7e4775bc543acfb421a446a00efff6d9d5669fafb2387464cb1e1ae3db91efe8"
+    },
+    "sound/bane/growl.wav": {
+     "bytes": 9045,
+     "sha256": "86e7b3d2e685d7c20e503bdffe676727426b606ef069f4b70f182601e910ec4e"
+    },
+    "sound/bane/hit.wav": {
+     "bytes": 3884,
+     "sha256": "228faf88857d697f4d5fb9b9c03f000af4dbc8b254791e18e973fd48cc96db9b"
+    },
+    "sound/bane/laugh.wav": {
+     "bytes": 22108,
+     "sha256": "ae8e8d13e00f41bce729977f09a92806c8451ebe5cb4e8618a6b79df4d70296c"
+    },
+    "sound/bane/laugh2.wav": {
+     "bytes": 31560,
+     "sha256": "5cc5ff4c3be35eec90eaaa6579a55fa843843ad658e2e4bbb258a77f6e410020"
+    },
+    "sound/bane/pain.wav": {
+     "bytes": 9325,
+     "sha256": "1d4cfac1f9dfa1ec6958b18014ec7be18dc2615e64888d3c584d50bb48e51013"
+    },
+    "sound/bane/sight.wav": {
+     "bytes": 22962,
+     "sha256": "fbaabe115d9ca4b985c4481ccc71e6b6f55931394a29a6c51ec97e752ed3d5be"
+    },
+    "sound/bane/thunder.wav": {
+     "bytes": 43130,
+     "sha256": "cb355478e38df678e859557a0f983120a4d4275272d8ebedcae7c9cccf659bc4"
+    },
+    "sound/baron/bpain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/death.wav": {
+     "bytes": 8576,
+     "sha256": "3dd3a23d5a913548d0d0aa6ee1b455017648fcd4830f204539a1626c2ec8e1c9"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/fireball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/icefire.wav": {
+     "bytes": 8858,
+     "sha256": "b529a958de192b59438989c6b98eb50f858273febab53a238b651c70a3c92098"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/shard.wav": {
+     "bytes": 14324,
+     "sha256": "313428dd2cb681a38ad89983ab39b18979f64b3e398104b1ad80f3dc9726616c"
+    },
+    "sound/baron/sight.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/tornado.wav": {
+     "bytes": 11469,
+     "sha256": "9ede270665956ce33daf9d3b49447c09e198275f640ccaf77af4f44273bd3f64"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/bishop/conjure.wav": {
+     "bytes": 54627,
+     "sha256": "532d4b7d5db6a654aa73dfe18fa0f6a71623acfd804a848f106b0af699022bc4"
+    },
+    "sound/bishop/journey.wav": {
+     "bytes": 42051,
+     "sha256": "0995e55661447c53c3a36ae4552ea2e0bb7ec8b178bf52cdabe9d28b4deaa50c"
+    },
+    "sound/bishop/rip.wav": {
+     "bytes": 31906,
+     "sha256": "7070871da7ec08da6260a65f1a98ed1bf9682b1c95c51cea262a4b88a63fb6ca"
+    },
+    "sound/bishop/rot.wav": {
+     "bytes": 22463,
+     "sha256": "866b836874ba611d70675e5e3b83eac059c927bef0e0d1396f2183ea01bcc203"
+    },
+    "sound/bishop/skull.wav": {
+     "bytes": 34293,
+     "sha256": "48836a4d60ed8962ed0f11bffdcca95a200645e3b2cfa49a598d6392e10dc153"
+    },
+    "sound/boss1/explode.wav": {
+     "bytes": 27690,
+     "sha256": "b7eebbb64696612ee18d8d1e25b9c5cc334a4562cb99758a446a22490215f349"
+    },
+    "sound/boss1/explode2.wav": {
+     "bytes": 14798,
+     "sha256": "4c6b14b163905823f629644fbec088f37f712cf7f76e10e2f91ef23f2b573ae6"
+    },
+    "sound/boss1/explode3.wav": {
+     "bytes": 19028,
+     "sha256": "69ef0c65811704d8996b726d6e2cbcf70528d3ca7b2f28ec8814c20e7ab76ad7"
+    },
+    "sound/boss2/pain.wav": {
+     "bytes": 84796,
+     "sha256": "b9c255890f61771966327ad49994306a1e3de4b702163a079b5a733b4016810a"
+    },
+    "sound/cube/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/cube/bc_attck.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/cube/bc_gulp.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/cube/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/curse/x_armor.wav": {
+     "bytes": 17988,
+     "sha256": "61b518c8ad8410a17eaca28ee190d96a0c3d1dc755593872d7ec5429c8c19157"
+    },
+    "sound/curse/x_damage.wav": {
+     "bytes": 14772,
+     "sha256": "f74f64e3f47cee7c9b424b94a426f93c133d8acc1e6cb15551a72ab361fe95c4"
+    },
+    "sound/curse/x_leech.wav": {
+     "bytes": 16692,
+     "sha256": "78aacf297df09e21645c2e04ccf181266c35c8e52303ecb498c90db33e8c7b27"
+    },
+    "sound/curse/x_muddle.wav": {
+     "bytes": 18932,
+     "sha256": "b85810135fb3eca3f141047a08cd42a0e527d6da6e9fcfca3887a15f89edad6b"
+    },
+    "sound/curse/x_slow.wav": {
+     "bytes": 16728,
+     "sha256": "0477b046f163d36e9e41c8686ca7538659d0327668d938c0b2405f3a1e6dab3c"
+    },
+    "sound/curse/x_weaken.wav": {
+     "bytes": 15946,
+     "sha256": "f98441764b5f258ee875090c73e5841f4c8f97decbfbd8d9da836a7aac30f430"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15692,
+     "sha256": "72e737f04f1d34044dfd812c6b0e233cd38a91e6b089633e312678756952de87"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16625,
+     "sha256": "bd4cd7902712282ef8f2f749e6fcf805c2ac5212994fbb1c22fc0fe0ea5d08e2"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15527,
+     "sha256": "0b472a984137667f4788336a4f7c60e07a8893f47317b2a158aeea39920d729f"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4107,
+     "sha256": "8fe56b192838dafdf7ff4737cf1e5555d3295cbca49c1ab83568281ee188153c"
+    },
+    "sound/cyber/cybidle.wav": {
+     "bytes": 11894,
+     "sha256": "af7b96ed2eb5bc55900957b3e4136bd5dd93a72dcebca3bc2eb67cdc5186d32c"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8122,
+     "sha256": "3ea23b8d7a68e754211a10a5338b0c8d65df6e2138d4cfe06cc053b9a0f601ae"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13081,
+     "sha256": "a5ec6d4eaa707ad0246b7a7e7737b1007043ea5e5634f6f63661ecc20c27c459"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48508,
+     "sha256": "b7aac875623f8dca7597eff3dcab5910453d043fd1f9df20da89232ce8bf9306"
+    },
+    "sound/darklord/death.wav": {
+     "bytes": 10761,
+     "sha256": "7f32e12c649aa4fc4c2edb773c45b6b4258d048176d95e060390834ee7b52493"
+    },
+    "sound/darklord/idle1.wav": {
+     "bytes": 5632,
+     "sha256": "c151a3cf537f5c3668fc116e6ef5c70c9286e8a12097f376ecdf8a04774926a1"
+    },
+    "sound/darklord/pain.wav": {
+     "bytes": 12684,
+     "sha256": "f332a8cdf67fe414966f59d46714154c94de7ebcca3880a47ef5bbdad2c03ef0"
+    },
+    "sound/darklord/sight.wav": {
+     "bytes": 16832,
+     "sha256": "9710267844facf1c627ea0a8f0df458d847eb899dccd9c570e9d967acc64fa07"
+    },
+    "sound/darklord/sword1.wav": {
+     "bytes": 15982,
+     "sha256": "d36670980603c18a67d500707de9db5a8d54128601d6a6c67f7f29677244aebc"
+    },
+    "sound/darklord/sword2.wav": {
+     "bytes": 12434,
+     "sha256": "f7730881c690e0ee6a440756f74630a21241239fd1fd3bbdfd88000c7e57d1cc"
+    },
+    "sound/doomcube/dsbospit.wav": {
+     "bytes": 43719,
+     "sha256": "97f61cb588bb405cd235e242bfca6fe1108171625a7aa4f2573d63682ac42e32"
+    },
+    "sound/doomcube/dsbossit.wav": {
+     "bytes": 57109,
+     "sha256": "5843548ad38c8eea72548481b5833590fbb7fb990daebd0ede4aaac93475f461"
+    },
+    "sound/dragon/acid.wav": {
+     "bytes": 12477,
+     "sha256": "ccac1dc5e6edb11092237e24e0749b91f31ce7deb5b63f71791199db67c22314"
+    },
+    "sound/dragon/active.wav": {
+     "bytes": 16118,
+     "sha256": "5c8762ad62bcb65e1a6fa3362393141a8564fca3ad28ea896a18545c5ebfe6ad"
+    },
+    "sound/dragon/attack1.wav": {
+     "bytes": 25054,
+     "sha256": "c96520801f27bc933928d7f793c2c28ff2dc7b36a86450f6372a9c8a668b4f58"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 63766,
+     "sha256": "55eb476a990e479c06b4c9a12b71c595d8ada35e813e512986709650ef0e54d1"
+    },
+    "sound/dragon/death1.wav": {
+     "bytes": 18358,
+     "sha256": "645baa1cccaf1dfbcd628d17fd8ea290f42f1bc40903e26c79a536a6d1528a2a"
+    },
+    "sound/dragon/fire.wav": {
+     "bytes": 11998,
+     "sha256": "a2a678fa4485af0e45edcaba632f0a0248f0f65802f02f10ab0a83ce428b0872"
+    },
+    "sound/dragon/firehit.wav": {
+     "bytes": 6294,
+     "sha256": "09c55af058e624be74d806eb4826a334db038cc2d4410140b80effb160210dcc"
+    },
+    "sound/dragon/fly.wav": {
+     "bytes": 5596,
+     "sha256": "f4b73e9887a6920bb9247bc4c121d369d4cf4881ae2a21f5176f289b430081e9"
+    },
+    "sound/dragon/fly1.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/dragon/flywater.wav": {
+     "bytes": 11034,
+     "sha256": "68cac399467a55df3c80331696869309eea2339467df0ba94408be4fa2afeb3e"
+    },
+    "sound/dragon/ice.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/dragon/icehit.wav": {
+     "bytes": 9370,
+     "sha256": "089c07d0352678106aaa1c47f015792393d5aa01b4bd64fa35e798c4ee09108b"
+    },
+    "sound/dragon/idle1.wav": {
+     "bytes": 34068,
+     "sha256": "3a125f0bcf2908e4ba3af298b117f71c0efa43be4077e53c791b2805cce6a038"
+    },
+    "sound/dragon/idle2.wav": {
+     "bytes": 21474,
+     "sha256": "e1101ff0121687511a9c978d0a30a945421d0a2a30b7d139e4427d41dcc17628"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 28302,
+     "sha256": "60a99d79b6922a14e27ed63313e82ff17b127bda008bd614d8e9ed86f0f2cc3a"
+    },
+    "sound/dragon/pain1.wav": {
+     "bytes": 6524,
+     "sha256": "6cdce2fde3a1eb328007e0667c5dfe705e87bcd526e416ac948fa11a36448ac0"
+    },
+    "sound/dragon/pain2.wav": {
+     "bytes": 6875,
+     "sha256": "3238b77aafcc60c634cbdbd47ae1eec99bb969e2161b72ce5623398e6a451d2a"
+    },
+    "sound/dragon/see.wav": {
+     "bytes": 39640,
+     "sha256": "e8202c360287700da28f96d6a14fef6bdea04374ea911f2b3e41183cd8a136ba"
+    },
+    "sound/dragon/sight1.wav": {
+     "bytes": 27557,
+     "sha256": "b904bc59e7a4aafae9db8171a8274ddd6b9ce126b4d9ca1a3ccff8aaf84a8c84"
+    },
+    "sound/dragon/sight2.wav": {
+     "bytes": 15205,
+     "sha256": "197238a35261e6792c40a4da38ba7b3827116ac1af5f143e092768346605b470"
+    },
+    "sound/drone/drnblip.wav": {
+     "bytes": 2106,
+     "sha256": "b372ece13de5edfb22d88ff147a9eccfddfe446c9403607d89daae09fc7c8b68"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/force/force1.wav": {
+     "bytes": 30022,
+     "sha256": "b609981695694648cab0f2ed521dbf3d6f31b6c2e8c3e8502ab4740c7a105557"
+    },
+    "sound/force/force2.wav": {
+     "bytes": 10252,
+     "sha256": "32c0342dbc9e63220db18fa706ac0fc1afe9a86f4d488e509e1f52bee955e3cd"
+    },
+    "sound/force/force3.wav": {
+     "bytes": 10252,
+     "sha256": "0317e18dab002184b5ce11a2b86f3263d2606c40f2dc435c824bbd075c1b621b"
+    },
+    "sound/force/fusein.wav": {
+     "bytes": 13669,
+     "sha256": "53192c25adab70ebcf471204aa194ef9d34c4161138c728d95f84cf08310a879"
+    },
+    "sound/force/fuseout.wav": {
+     "bytes": 15379,
+     "sha256": "f515c6b48204f2ba158e99c10a9da60cc45756ea5dca716e256ffbe54a017512"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/goblin/death1.wav": {
+     "bytes": 13890,
+     "sha256": "bed0d074d9aeee8f046ec7b3a9d33e02d157374ddf6af1296bd1ca7bebf30f10"
+    },
+    "sound/goblin/death2.wav": {
+     "bytes": 10280,
+     "sha256": "9cc07020579d50185ea401835e41edbd1c8f007065e39a6306c7aab4f32e7781"
+    },
+    "sound/goblin/idle1.wav": {
+     "bytes": 9802,
+     "sha256": "6c5a8c36eedb0ac5bddacfdf68250c36fe472f9d87e8969b4f95a863a99b77ce"
+    },
+    "sound/goblin/idle2.wav": {
+     "bytes": 9242,
+     "sha256": "5850c885e59ef04ae90be0579dd6f6b7cc26c282045ccb163dab2c9e19fea704"
+    },
+    "sound/goblin/pain1.wav": {
+     "bytes": 5118,
+     "sha256": "8afd94fcaa2d20e7c6626eda0c6cd5463670a1dbed0eeea36da588b28196c8a2"
+    },
+    "sound/goblin/pain2.wav": {
+     "bytes": 7898,
+     "sha256": "ad1f3b63b4ae35e4bfe010447bbd18bb85cd2bbf966ea7e1370afb0e924e699c"
+    },
+    "sound/goblin/sight1.wav": {
+     "bytes": 12716,
+     "sha256": "1c20028239d217f31af57649da5d1a6def576569ef5fc7e7033c2acbef7f9345"
+    },
+    "sound/goblin/sight2.wav": {
+     "bytes": 19356,
+     "sha256": "c9182325cacd9734bfedd48cb5d8076d5823b7a94baa40d32b02de9504474b48"
+    },
+    "sound/goblin/sight3.wav": {
+     "bytes": 8526,
+     "sha256": "796b2f9f0a1c20d672382c6681e9a6ea200fee2cfcacb5b3d3faa72c8e2537d4"
+    },
+    "sound/goblin/sight4.wav": {
+     "bytes": 8668,
+     "sha256": "c0a60baf2b9918a6df5fc32cd8b58c9fa7cfed923a4cb21c841f04f7a544782e"
+    },
+    "sound/golem/death.wav": {
+     "bytes": 27521,
+     "sha256": "424ceef852229e94dbbbc879f1546a8dfda90db93c6263700cf4973805e4bea7"
+    },
+    "sound/golem/sight.wav": {
+     "bytes": 16192,
+     "sha256": "98d55bc63eff48521faeed1046064569e932986e734168ba0973c184aa2f5d12"
+    },
+    "sound/golem/step.wav": {
+     "bytes": 11226,
+     "sha256": "851e243a2e6ecf4cb637f8c4368b0f25443d4f9d104733eecfa886c40ee92bcc"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 47176,
+     "sha256": "87f013eb50cb30a967a183f0cfa41b4848f9269afd13dbe1ab5053458bfc5f0e"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 10768,
+     "sha256": "c48f2415db3a5067dfbd99ad580e3f4809532743d653eafe2fdb924fb0bb832e"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 47502,
+     "sha256": "a0c0bd639af614c7714388009c9388f6db9a694e7ecd8fac38653609d6958f61"
+    },
+    "sound/gunner/death1.wav": {
+     "bytes": 67190,
+     "sha256": "14f89744b8f7225e0eefd9e291aee533fd9f759b6351b57d357d9597dba90956"
+    },
+    "sound/gunner/death2.wav": {
+     "bytes": 48066,
+     "sha256": "693d0d1142dfa12ce2dd1d7b959094c201f3bf783114064c29a572dffe2fcfe0"
+    },
+    "sound/gunner/idle.wav": {
+     "bytes": 18376,
+     "sha256": "6c5b1f1d39f1cc78e87cdbf584b8a508fadc99fc2b8b85d21d0e088d134a8b2b"
+    },
+    "sound/gunner/pain1.wav": {
+     "bytes": 17292,
+     "sha256": "afee7d4ac4f872716fe3deb5adced9a99bd3744784329bd12608d051b81ebfc7"
+    },
+    "sound/gunner/pain2.wav": {
+     "bytes": 20282,
+     "sha256": "38d472d2eaaa7638f7980a06a36043353e86d99aa7e86e0132c52639738c87b2"
+    },
+    "sound/gunner/sight.wav": {
+     "bytes": 22572,
+     "sha256": "395e28b6a4684ce2fa10f085f67d58d025421c594e65a0c2a1b67aeab2ee2569"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hkboss/iceball.wav": {
+     "bytes": 14990,
+     "sha256": "6aec96fda55dfb0120f106064cd324ea6e059bab3fdbb2d81cda297f9a82e02b"
+    },
+    "sound/imp/die.wav": {
+     "bytes": 8448,
+     "sha256": "a8b0e037b88829b978d3dbd3d5e657c7f775c73662d554f6247a387ba333d4bb"
+    },
+    "sound/imp/diebig.wav": {
+     "bytes": 14956,
+     "sha256": "d44d390ba11f8850105fd9601f026cb66525a415de7fc363d3574c86b72d22c4"
+    },
+    "sound/imp/fireball.wav": {
+     "bytes": 5492,
+     "sha256": "6362b59ded89655fa8b8877ed2639eca1a7aae1847306bbc3843fa98bedcbdaf"
+    },
+    "sound/imp/fly.wav": {
+     "bytes": 9204,
+     "sha256": "8036ccb256978c17234aa171267fb0332f1911b5f0dad7b9f74bba9378c39a37"
+    },
+    "sound/imp/flybig.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/imp/flywater.wav": {
+     "bytes": 9800,
+     "sha256": "c80045609b62ceb61bd8fb1a18a53c0f2fd5443502a802b0d6d3c61e9a1db4c0"
+    },
+    "sound/imp/shard.wav": {
+     "bytes": 10678,
+     "sha256": "f806167fe23f37826964c0cc345c438ff0e79c3ffb1fed2c85451c675448cae4"
+    },
+    "sound/imp/swoop.wav": {
+     "bytes": 10842,
+     "sha256": "100eacded51635de912cee171f093e869d24589c44f68887497fe751cf9b1e4d"
+    },
+    "sound/imp/swoopbig.wav": {
+     "bytes": 14012,
+     "sha256": "65d4de49684f2f9e2655abf8e4bf042a08bd706ec4971e6397f264f7274e2b63"
+    },
+    "sound/imp/swoophit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/imp/up.wav": {
+     "bytes": 12500,
+     "sha256": "874b533da43f713a1be27fbccadda8b6392fa8e689c8c4d17dac4b0d380f5822"
+    },
+    "sound/imp/upbig.wav": {
+     "bytes": 21472,
+     "sha256": "36c7bc087935cf7cd33482a50a75df75fc2bfbe53ca0ebcd9797a8bdbde73652"
+    },
+    "sound/items/crosend.wav": {
+     "bytes": 76002,
+     "sha256": "57fc3d08d10a87e788abbb52bc12220b2b145e37e02b97047506339ef53010be"
+    },
+    "sound/items/crostake.wav": {
+     "bytes": 42722,
+     "sha256": "555a360e37c54b16ca8d42fecb5b26f4e272003e2572ddd92b9794693afb06d4"
+    },
+    "sound/items/crosuse.wav": {
+     "bytes": 15010,
+     "sha256": "e6f44a5a8d7026f01ed9531511a36b619d402df4aae5fa9b4b3d40432ca5cf34"
+    },
+    "sound/items/equalize.wav": {
+     "bytes": 13008,
+     "sha256": "933046049bae4d866250ad9a6e0a4b2a9385caffb4156daaca39ff7110a71126"
+    },
+    "sound/items/levitate.wav": {
+     "bytes": 44236,
+     "sha256": "8a04ce4a97dc22d095bc52d08111bcaaf5f57482f580ccbe0c61bdf8fd18913f"
+    },
+    "sound/items/life_up.wav": {
+     "bytes": 8660,
+     "sha256": "2712bd978343d4170bc1757706597d4de3940a07b6847977cbf117fa92f14c31"
+    },
+    "sound/items/money.wav": {
+     "bytes": 5100,
+     "sha256": "e4ac299499340c1be250f5d5e0824440d9e539de8a1d5b01e303056719cf822f"
+    },
+    "sound/items/optimize.wav": {
+     "bytes": 14854,
+     "sha256": "508d89890db17f828cde9511ebd97241ecfe07bbb6e5cba8c7538ab02e31b19f"
+    },
+    "sound/items/quaff.wav": {
+     "bytes": 3748,
+     "sha256": "ebaa4ecc17dc67d3fbc5fe1a7541e4e19769ce941d043922f8572cb2da8d3cdd"
+    },
+    "sound/items/reflect.wav": {
+     "bytes": 14936,
+     "sha256": "90dd50b25175c8d514a52165429e9ca6b90c45dddbb0f301e5873146b4a4a06c"
+    },
+    "sound/items/reflect2.wav": {
+     "bytes": 33119,
+     "sha256": "5fb5afe50e0f5fa24f1c4481b3060ae222f40138ca81052cea047a57aa6b03e8"
+    },
+    "sound/items/reflect3.wav": {
+     "bytes": 7804,
+     "sha256": "a079e5aef6ed9fb7d5c992b0ef8e11932a9efa192eedac2bc530098e0550984a"
+    },
+    "sound/items/regen.wav": {
+     "bytes": 7984,
+     "sha256": "1e125e8e7c19f29eaf09b7ad301fdfe5126d922dfa84ba2af267cdf3351b6498"
+    },
+    "sound/items/shambler.wav": {
+     "bytes": 20182,
+     "sha256": "f0cdf78367b770c97b3b89abedb7c4fb0a9ee10d742acc8c98b3daba46cfc215"
+    },
+    "sound/items/tomepow.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/items/tomepow2.wav": {
+     "bytes": 33119,
+     "sha256": "1e2e62a6f251722741b7f0adeb38c59a1d05917d0f84c8f48922efece97f02e2"
+    },
+    "sound/items/treasure.wav": {
+     "bytes": 5554,
+     "sha256": "c86f66148e8dc99af2c8e877d64d06dc1c35d0caa9c6dc5c8092b268960b8edd"
+    },
+    "sound/items/zerkhelm.wav": {
+     "bytes": 8298,
+     "sha256": "ef7b98bd965660df91ee34920806b48428a8b5c17c0ec4fdecb48d7fe28e3ba2"
+    },
+    "sound/laugh.wav": {
+     "bytes": 71573,
+     "sha256": "cb8e1381c70240a93233b8571d792e21950d00b1285f867cbc0ed1237dac1df7"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/b_rot2.wav": {
+     "bytes": 15436,
+     "sha256": "62c86077b7a29f48f5c872c68d262c03b73b57f876b718a05f2fc6b24b9a9ef4"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/bellring.wav": {
+     "bytes": 27600,
+     "sha256": "fe3b2972c722171144eaba160757803292a42342e737d6acdbd0b14802e686f2"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/dsslop.wav": {
+     "bytes": 11163,
+     "sha256": "b6a9f6e74b222169c87e6c56b47d2e7995b23b8b045f16be968f43290f22cf9d"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/met2wd.wav": {
+     "bytes": 3968,
+     "sha256": "a3ce3e10b609f7ae28fc6f39f1f5d55a7c99a41143fb161de7e4e47b7f40f100"
+    },
+    "sound/misc/metalbrk.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/mgboat.wav": {
+     "bytes": 26866,
+     "sha256": "666016e2aa958ea621ba03bee4339518f2ccc72aa3ee2d0838ef9032e8ffc981"
+    },
+    "sound/misc/pushmetl.wav": {
+     "bytes": 14042,
+     "sha256": "2657b0006f51ecb7077b5861b1b282e0bb8bef3bdd5ccb68b3bdd6794361099e"
+    },
+    "sound/misc/pushston.wav": {
+     "bytes": 11490,
+     "sha256": "f457b95dad6131472475ab22d9c260adf5d389e74629cd8ea36ca05ad7d4e749"
+    },
+    "sound/misc/pushwood.wav": {
+     "bytes": 13602,
+     "sha256": "7c3fa06978f8c7b632d12bbf1031a5ac316b44fdc5efd93338ab0a0a162bdf3a"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/rublexp.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/secret2.wav": {
+     "bytes": 87440,
+     "sha256": "36e9d9617a14daefd510e72308b9e85718a473e2b25a06b66026d463d6bbb519"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/misc/woodbrk.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/music/pkdream.wav": {
+     "bytes": 154898,
+     "sha256": "df8857901002ce9dde3c558743c94967db11cae4af3d9a0cdc00c8cc09e6a910"
+    },
+    "sound/necro/att_a.wav": {
+     "bytes": 8522,
+     "sha256": "a946c060cab5ee1bfff2d1af87cd71c9ccf63840a2751fd46fd32f387bee2c35"
+    },
+    "sound/necro/att_a2.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/necro/att_w.wav": {
+     "bytes": 26298,
+     "sha256": "9ae481ad41d16610b597989e82a8bbf9c35a74fe03a8e27900d72ff8b52e3c94"
+    },
+    "sound/necro/curse.wav": {
+     "bytes": 16852,
+     "sha256": "d3729c83c468d9320cf1f8914c8b52d446e818852c955d8d86a093c35c196b58"
+    },
+    "sound/necro/death1.wav": {
+     "bytes": 24010,
+     "sha256": "302e58b0f701ad07ade4a46d5cd3bd9c2186b2df3eb39e36c361918a72ccd24d"
+    },
+    "sound/necro/death2.wav": {
+     "bytes": 23594,
+     "sha256": "05f15a8430885b6688587eba5e249107c3e6df36d7937a3ddd2411d275e8842b"
+    },
+    "sound/necro/idle1.wav": {
+     "bytes": 49212,
+     "sha256": "737f382e89a40fc098214b77e9165e16f2a06323c07e910f336f2616b6ca87b4"
+    },
+    "sound/necro/idle2.wav": {
+     "bytes": 47120,
+     "sha256": "18893e7b31ff448831a7b7a5aa9a5d31b2dcd6e49ae8b58d5eea8b44683415dc"
+    },
+    "sound/necro/pain1.wav": {
+     "bytes": 19412,
+     "sha256": "f37e247a9e1436e4a86b78fe71e1ea6da43323e60943e86784ac87fc4393333b"
+    },
+    "sound/necro/pop.wav": {
+     "bytes": 18996,
+     "sha256": "22aff5a83ec82e759004d82308b2e210f824ac59bd3180d6b688c9d0134ca18e"
+    },
+    "sound/necro/pop1.wav": {
+     "bytes": 10836,
+     "sha256": "d5e9b7ce5a638a419eef07bba492ce75fb3d8002bd66b40d36b4dd89ad859e1c"
+    },
+    "sound/necro/pop2.wav": {
+     "bytes": 11228,
+     "sha256": "10947cad6cd5bcc0e0bc00fdbeccccd53b70bff1fda1a220c72ddc7e2b152b08"
+    },
+    "sound/necro/pop3.wav": {
+     "bytes": 11228,
+     "sha256": "56c4219dc0ecfb7ee8ff6d31fdf6c8c53c2b6990ce1b94ed956caee3c7cf83db"
+    },
+    "sound/necro/pop4.wav": {
+     "bytes": 10836,
+     "sha256": "451b660c65ebd2c7c89134896ed882d738c685f787810e1245587c0c28c38141"
+    },
+    "sound/necro/raise.wav": {
+     "bytes": 9688,
+     "sha256": "1c841e33f22cdcd5276bba9018aec5dae8c0f842da07eb261f48f1a6cc4c8314"
+    },
+    "sound/necro/sight1.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/necro/summon.wav": {
+     "bytes": 16308,
+     "sha256": "b7fc855d38431ac04e09389d7caf04bf0032d2b4edf86ebd795f1ab38d9feaf5"
+    },
+    "sound/nemesant/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/nemesant/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/nemesant/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/nemesant/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/nemesant/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/nemesant/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/nemesant/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/nemesant/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/nemesant/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/nemesant/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/nemesant/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    },
+    "sound/pendulum/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/plasma/explode.wav": {
+     "bytes": 29598,
+     "sha256": "7a95a8337c7ad87faccc1cae98ad7840352b08608fba08aff87a1b33610f9190"
+    },
+    "sound/plasma/fire.wav": {
+     "bytes": 22422,
+     "sha256": "7350d1e99f93a79bee84e94561e080dcb8448a3549a42742633cf604377a5097"
+    },
+    "sound/plasma/flight.wav": {
+     "bytes": 17494,
+     "sha256": "a03b46f31df3495a1b7a2b2f1a09f3e5223d4c0ab65aa0ed936e1445e893adeb"
+    },
+    "sound/player/boot1.wav": {
+     "bytes": 25624,
+     "sha256": "9b730ff4f811472514297921c78ea3080424c57b57ce7fa30c6c10f94bd8ccc3"
+    },
+    "sound/player/boot2.wav": {
+     "bytes": 25640,
+     "sha256": "23a3cd545ffa3c5c1e4a4c9549aff81dadd2f1ab451e397d5292c97024fc5026"
+    },
+    "sound/player/boot3.wav": {
+     "bytes": 25652,
+     "sha256": "004d267ae3fcce21aa66e566efa34e39e85915f202e3b55922b314cfd6efa2d7"
+    },
+    "sound/player/boot4.wav": {
+     "bytes": 25628,
+     "sha256": "9beb96d9a183cd6a13693961a216b4402350fc076c7a1ff98854d28c30a9f8be"
+    },
+    "sound/power1.wav": {
+     "bytes": 44370,
+     "sha256": "68f9d490b390a2510ff660917ac02fa1620893770a68a1188e06f94c57922523"
+    },
+    "sound/power2.wav": {
+     "bytes": 44370,
+     "sha256": "773aca5e1e60540b2abdc4b9b29c4281a04f6fad3bfc6bea1c029b42a7f0fe9e"
+    },
+    "sound/ranger/idle.wav": {
+     "bytes": 10819,
+     "sha256": "644fbbc14e20684fa31abc7f04969943ac950c33435271b0fa646aa324be4400"
+    },
+    "sound/ranger/sight1.wav": {
+     "bytes": 5379,
+     "sha256": "5023e2483fe5c1c37cd661d382e34c0b68eafe4bae0e35e8f3f7e516e78dcf51"
+    },
+    "sound/ranger/sight2.wav": {
+     "bytes": 11323,
+     "sha256": "3574f035e1a261b9a001d99a54bdb502da31da2639d95e7fc06f96b547c1ac44"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight1.wav": {
+     "bytes": 35068,
+     "sha256": "48db878a4eae15b37ee0ca333aae74d310103a9eaf2e4b35eecd43a89f626b9a"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk1.wav": {
+     "bytes": 19372,
+     "sha256": "42e41297df70202ec9965af7af5fcdabcab7fde43ba515c8ba0a1ee2e4429554"
+    },
+    "sound/shade/death.wav": {
+     "bytes": 18808,
+     "sha256": "17a1141f43c4953685b828db18b131c463583999f0d9bc621d8cc35746a5e4fc"
+    },
+    "sound/shade/death2.wav": {
+     "bytes": 17916,
+     "sha256": "bfc89fc5f307448536e87ac1bc235e2959c9c042d58ab71fc55bd52c294fc4db"
+    },
+    "sound/shade/fly.wav": {
+     "bytes": 9204,
+     "sha256": "ae05cefad6463c4315ef4bf3b483a5aa4fb56ead7dd66060111730d9bcd32180"
+    },
+    "sound/shade/idle.wav": {
+     "bytes": 37192,
+     "sha256": "57b0a0a7a0e75a17df8c4bb68740b23325bd0bf3475d908ee92fa0522c71edf7"
+    },
+    "sound/shade/moan.wav": {
+     "bytes": 33684,
+     "sha256": "3a6644f2c0a6ead5992fa9752ec9b0d898f4c40f5a32b12fd61aa991f75fa0c7"
+    },
+    "sound/shade/pain.wav": {
+     "bytes": 12683,
+     "sha256": "d4624392b9c5717a91a3d7c51b43a01df949d89878eb7103ce747e26ca0aa126"
+    },
+    "sound/shade/pain2.wav": {
+     "bytes": 8918,
+     "sha256": "c6fa3ba7c659faf38b00af9c9867c37ba730cbc662125f5307f755515243dc4c"
+    },
+    "sound/shade/screech.wav": {
+     "bytes": 28244,
+     "sha256": "55ef2615baa6ce39733892fc9538f702acc567f65250223329f15b191d9b1a47"
+    },
+    "sound/shade/sing.wav": {
+     "bytes": 35654,
+     "sha256": "9de82a1d3124c391466004aea5e8ad066bcc6ede2715e7978a92a2c8f66e3f6b"
+    },
+    "sound/shade/spawn.wav": {
+     "bytes": 12666,
+     "sha256": "fc495cd1155d4f93594e24ef087dd46244955053c1babf673a14d7b4825b68d6"
+    },
+    "sound/shade/taunt.wav": {
+     "bytes": 36418,
+     "sha256": "f556cad612249e63690ac28b17405eba70e3df43560c3a087062b9f330811720"
+    },
+    "sound/shade/taunt2.wav": {
+     "bytes": 28160,
+     "sha256": "a68174008206b79794d8d52fd027daf08767ce005189860c815cda021080363c"
+    },
+    "sound/shamvile/burn.wav": {
+     "bytes": 11316,
+     "sha256": "239c51d5cfb82ee7683075f6cd53d8a16fcc2da608c9db87c27fd7491160a627"
+    },
+    "sound/shamvile/dsvilatk.wav": {
+     "bytes": 16978,
+     "sha256": "f4fc290f121fafbc1d8e5e992b9454b404f9ebbf3c95bc376419ee8ca58425bd"
+    },
+    "sound/shamvile/melee1.wav": {
+     "bytes": 4700,
+     "sha256": "f418a627faa0b4630588914ecdd466c387e1d7d5ac2e09acecafa13baf33f10c"
+    },
+    "sound/shamvile/melee2.wav": {
+     "bytes": 6252,
+     "sha256": "dfeb5bcd8be8d9f1fcf52f89cf0af533ec28066eb0bf74e3ac4b588ca810f372"
+    },
+    "sound/shamvile/melee3.wav": {
+     "bytes": 13236,
+     "sha256": "7102a987921e4c291175ba252628613c2c6ecdb70e9a33e174b6bcf7addc239c"
+    },
+    "sound/shamvile/melee4.wav": {
+     "bytes": 9211,
+     "sha256": "da31a8531703998c06bc33c94639d5dd291c9ba24e6752599ec8e6113d3753b5"
+    },
+    "sound/shamvile/sdeath.wav": {
+     "bytes": 20996,
+     "sha256": "e27d5870c37ce74877a2681b5e9cef437d14b05c501fb93733c8e93d2d2b0931"
+    },
+    "sound/shamvile/shurt2.wav": {
+     "bytes": 3924,
+     "sha256": "541c66bfaf5f30c55d24c4013f4a8859159ebfdf2f054c681eb8b8200dba1c85"
+    },
+    "sound/shamvile/sidle.wav": {
+     "bytes": 5476,
+     "sha256": "ca3edcb476f3992027989a2a79ef21a7f8951965c8a0e77f89f0a0505f2d2b52"
+    },
+    "sound/shamvile/sidle2.wav": {
+     "bytes": 21511,
+     "sha256": "0e46d4e53c003136881723f59de4d706151b845d57608cd87361018acb7ef050"
+    },
+    "sound/shamvile/ssight.wav": {
+     "bytes": 15564,
+     "sha256": "5a5343f95ee503f1b481ef05499e023b681402b922600979367788f2fb91397c"
+    },
+    "sound/shamvile/ssight2.wav": {
+     "bytes": 27204,
+     "sha256": "2b22c0912485569f7ec87a32a29c88563c0cb8261b4428335540fc96f7e7cb52"
+    },
+    "sound/skullwiz/blinkin.wav": {
+     "bytes": 19642,
+     "sha256": "91eba6c478e8475696f07079502af32d1817e3fb86418c32801846582f27561d"
+    },
+    "sound/skullwiz/blinkout.wav": {
+     "bytes": 18166,
+     "sha256": "91301f18c459286798989dd164ae08f5e77433ac7a0b5c71522cf59e49bf1a30"
+    },
+    "sound/skullwiz/blinkspk.wav": {
+     "bytes": 31420,
+     "sha256": "48a4dbd2add9021727d4572af9ac4c6f333a9e2ace5fe7127ddd42c84a2ae1f4"
+    },
+    "sound/skullwiz/blnkspk2.wav": {
+     "bytes": 41834,
+     "sha256": "fc2602275102b7e1a577c30b7ab3ac2709881eb3a8798664577f8a65a9132754"
+    },
+    "sound/skullwiz/death.wav": {
+     "bytes": 23034,
+     "sha256": "0eb20419acddee8a5814ecad8888348f90a14db997af1045b02b6052dccd5fd1"
+    },
+    "sound/skullwiz/death2.wav": {
+     "bytes": 32314,
+     "sha256": "3b1d2ed146a334ba5cf77027faa47addbf45c51159ff9c7278a97dda8ed7ef82"
+    },
+    "sound/skullwiz/firemisl.wav": {
+     "bytes": 12186,
+     "sha256": "3583544b6d7105d5b029a490cb0730190ae9e8dc5ca8f9da1deae4ea0335e964"
+    },
+    "sound/skullwiz/gate.wav": {
+     "bytes": 16156,
+     "sha256": "5797c6450d14f363133be23d93c829a660f9b7692c07f905b5a723cda8075c55"
+    },
+    "sound/skullwiz/gatespk.wav": {
+     "bytes": 30092,
+     "sha256": "f9fc90ba497d650acfad76c42ed531314828093f114c69c28fd1611d326fab2e"
+    },
+    "sound/skullwiz/growl.wav": {
+     "bytes": 18944,
+     "sha256": "de58ed34dd69dc3e871d09ac6a5db81ef26d69e234f0834e72c6cd68501ead21"
+    },
+    "sound/skullwiz/growl2.wav": {
+     "bytes": 24954,
+     "sha256": "0cf747c71a6fad9a085c39456cd14ffd972d2d454b4bafc2781ce4464917cfa4"
+    },
+    "sound/skullwiz/pain.wav": {
+     "bytes": 6106,
+     "sha256": "0f85b6180cbfe8d26f8d174f25c109b9d8b78d0fa53735e0494280bc8a19803b"
+    },
+    "sound/skullwiz/pain2.wav": {
+     "bytes": 8890,
+     "sha256": "6d48429e7fc4b80be16afd80097b7096a94cb1a88922a62bdfdff64172526a0f"
+    },
+    "sound/skullwiz/push.wav": {
+     "bytes": 8812,
+     "sha256": "91398e953b648ab23c037940fb7996f3d77727003a60757ea50686328c05cd69"
+    },
+    "sound/skullwiz/scream.wav": {
+     "bytes": 31734,
+     "sha256": "6df299b2a59aa94a9640c83684b65259e4619e0ed2a2fd1ce518dffaa060fd43"
+    },
+    "sound/skullwiz/scream2.wav": {
+     "bytes": 13980,
+     "sha256": "adca10198e279db0789a1a026124387c40e36fc1914f3f3da315b49b6e290386"
+    },
+    "sound/spider/attack.wav": {
+     "bytes": 6576,
+     "sha256": "82593fdd5be8198a9774c163872f89a088d8d0ca10e91f1c8f846ecac92b2d81"
+    },
+    "sound/spider/bite.wav": {
+     "bytes": 4552,
+     "sha256": "abd0b64743c825661f4598b7d5b70b781452a6b7747f9eb8b53f7239b0f9b9cb"
+    },
+    "sound/spider/death.wav": {
+     "bytes": 10370,
+     "sha256": "3e0d8ef9912e34cc9096023bdf2949377772c56dca74a9d2efb4dacdcc115b40"
+    },
+    "sound/spider/gib1.wav": {
+     "bytes": 10516,
+     "sha256": "bbe1a437bd05a71f9d7bba953a79886891bfc526399c67cfc8964308c91786d0"
+    },
+    "sound/spider/pain.wav": {
+     "bytes": 7576,
+     "sha256": "386e11cfd8063b6bb692ab4b90246be98288f72f29614f2e38765df9e6eaad79"
+    },
+    "sound/spider/step1.wav": {
+     "bytes": 2780,
+     "sha256": "06ee408dace817630645b0d390c496e692844fb42cc85adcaa021efeb60fae9b"
+    },
+    "sound/spider/step2.wav": {
+     "bytes": 2620,
+     "sha256": "66e802d6361a17e637f5e38366e4b0912dbb0f65e647041bed57cfda772c0770"
+    },
+    "sound/spider/step3.wav": {
+     "bytes": 1786,
+     "sha256": "418b2c536f19a5bcd0b1a8ff4aae13febc8c4f8fa6787372e9e869c45a17f54c"
+    },
+    "sound/trog/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/tur_arm.wav": {
+     "bytes": 23794,
+     "sha256": "24b428117ebd7e82865b41dcfc74a75a048c4d126d7505a6c23dd243bc054a05"
+    },
+    "sound/vomitus/death.wav": {
+     "bytes": 13236,
+     "sha256": "fa2cad86ac0ce1326132c5e378aed6a9ff5615d043df1d4d48e0b2691f8d3bde"
+    },
+    "sound/vomitus/flesh1.wav": {
+     "bytes": 8412,
+     "sha256": "9ac5a8ac2155e7d9b65144e7f65525c4660ff5959fe3a0277fab347e202b6f46"
+    },
+    "sound/vomitus/flesh2.wav": {
+     "bytes": 12788,
+     "sha256": "3fc22e2aa2c3c0bdc6501388ac18abb5e58c5fd5deba39d1cc2f7e8d48fcc869"
+    },
+    "sound/vomitus/groan.wav": {
+     "bytes": 13224,
+     "sha256": "3632e43615714e5fc1be8277881a913bf1bd79b276544418cbf1b159016f0d03"
+    },
+    "sound/weapons/axhit.wav": {
+     "bytes": 5612,
+     "sha256": "1d4af555ef369a41dabbacceb4d28a102645a3486eeabf00b785342f33e97f7a"
+    },
+    "sound/weapons/axhitwal.wav": {
+     "bytes": 6694,
+     "sha256": "0f14ba18076b25a7b8ee510b38adb282eb5c4f2fc94168baf1f8a658e1da684f"
+    },
+    "sound/weapons/block1.wav": {
+     "bytes": 5484,
+     "sha256": "ccb284becb454f395de702a263bfda1561b8bd38117893d33b5ebbb9eb7b6865"
+    },
+    "sound/weapons/block2.wav": {
+     "bytes": 5612,
+     "sha256": "62da8e44f3b1200b99f76a3bdb31d9d09a9e74c04a449c0afc482c6677a94bc2"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/weapons/clang.wav": {
+     "bytes": 7198,
+     "sha256": "634a88cf26b4de688bed392cf108d5468749f212ce67015c71baa942e8e88502"
+    },
+    "sound/weapons/dsshotgn.wav": {
+     "bytes": 9490,
+     "sha256": "98c228b3549d4908c313c783d5b0aec38b93efea1c6a65d7355767bdbb4b87e8"
+    },
+    "sound/weapons/freeze.wav": {
+     "bytes": 20619,
+     "sha256": "48689ba550c116dd8b10a138bc0f78eb6f169d6828a49aaafe12f807930eb934"
+    },
+    "sound/weapons/fwall.wav": {
+     "bytes": 40140,
+     "sha256": "e269c07608f322518e709925d5b13daded150460d19d3091f15152ce4c06c9bf"
+    },
+    "sound/weapons/fwallhit.wav": {
+     "bytes": 9426,
+     "sha256": "7b9f4da432e6fa44fbf721ed9ef753e6ceb41df59b8265b58f73764b2901224a"
+    },
+    "sound/weapons/fwalltap.wav": {
+     "bytes": 8316,
+     "sha256": "879b9970dfc3bc609ff384a0edea13b594ea6a82b5c56d33c8549cd36cccda0b"
+    },
+    "sound/weapons/icehit.wav": {
+     "bytes": 10710,
+     "sha256": "9ed8ed177a6cfcad97f8adcf94b9f3114a955e7b3abb397c6b17c44073c07b19"
+    },
+    "sound/weapons/icewall.wav": {
+     "bytes": 6124,
+     "sha256": "9668486027e07f525a27830dc3217cde36bcbcc956b21437d2637e00df368dd4"
+    },
+    "sound/weapons/mirv1.wav": {
+     "bytes": 89538,
+     "sha256": "7d60062f61d5929f5f927526d81920f24684520d230a5f2611c128b832d3357e"
+    },
+    "sound/weapons/mirv2.wav": {
+     "bytes": 18478,
+     "sha256": "67311180da390517f2ef71d161a0cf7b770548dcd4a7dda7e679cb9b58025b4b"
+    },
+    "sound/weapons/nova.wav": {
+     "bytes": 10020,
+     "sha256": "d41c8433fa1b964fafa1cdb2fec301fb4d398f1fce201b4d80b29fab7a59d7e7"
+    },
+    "sound/weapons/pkup2.wav": {
+     "bytes": 16010,
+     "sha256": "e110961352339cf5b8c865fdf7885a8ce89270f7ab8f79334e16a1d3826594e4"
+    },
+    "sound/weapons/plasma1.wav": {
+     "bytes": 13912,
+     "sha256": "ce5c88f2599120793ec9f4985a9d0b9668734fbc9fd60484c3ff348084f8408f"
+    },
+    "sound/weapons/plasma2.wav": {
+     "bytes": 8350,
+     "sha256": "de03da8d300ddaf56b063584226f5673b0033a8258209e4c8c5f82a4d40b630a"
+    },
+    "sound/weapons/r_exp3.wav": {
+     "bytes": 1244,
+     "sha256": "5271b9aa2961809f47fadecb693be2eebde2dbed62fbc4f5f4889fcd8c4a65f8"
+    },
+    "sound/weapons/r_exp3a.wav": {
+     "bytes": 17478,
+     "sha256": "52d9ec58596312b7b88b0127226c168aabaaa6f377a1895b5ead7c26c6c03957"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/shatter.wav": {
+     "bytes": 20899,
+     "sha256": "31ddbef0dc746eabea23cd7cd2fb97a1f949a014b664630d7f04e6c237aafc03"
+    },
+    "sound/weapons/sheath.wav": {
+     "bytes": 7031,
+     "sha256": "8f28a1daa16db234ce77d91e688c7acbc9541c296d30af9e1f940b6d45eaf72d"
+    },
+    "sound/weapons/sprocket.wav": {
+     "bytes": 7126,
+     "sha256": "8b5c3bdc625b4954c6b504ee242591f0121d1ab64f2aceab54dd85fecadef8a4"
+    },
+    "sound/weapons/ssg.wav": {
+     "bytes": 17176,
+     "sha256": "c3307bb283499155691c01fe783d86992946475fd3b9a4839ba37cdca7ede6a4"
+    },
+    "sound/weapons/stunfire.wav": {
+     "bytes": 9902,
+     "sha256": "7214cc44e4c0bfb801209f025b591d838542a3110f770e5614b0f549a055286a"
+    },
+    "sound/weapons/sword1.wav": {
+     "bytes": 3532,
+     "sha256": "572074b68af2132285aa9fd2ac6852f52ffb6c5e56eed44b1af21e0e78171e17"
+    },
+    "sound/weapons/sword2.wav": {
+     "bytes": 3055,
+     "sha256": "b176a257409b659d80df90560bbac4da5539971576aaf1107bb88bc016558085"
+    },
+    "sound/weapons/sword3.wav": {
+     "bytes": 3012,
+     "sha256": "eaca19c8a10b7942d4a279974df6e1cf076c362d5408e439b26286126852bedf"
+    },
+    "sound/weapons/thump.wav": {
+     "bytes": 30904,
+     "sha256": "ef0aa85fbc7ff6915aa5382c80e6f571ddacd50116faff495e3d5638bace8a49"
+    },
+    "sound/weapons/unsheath.wav": {
+     "bytes": 8060,
+     "sha256": "45d9bc6b9dcaf8e0dc9b2ede7da69a872f50f7819462a71bc16b9d76a70be06b"
+    },
+    "sound/weapons/xbowdraw.wav": {
+     "bytes": 19114,
+     "sha256": "4bb73eb7161ba561970e8f2e7f5aad0e42b3419fe2b02a5953a7289c46d1442b"
+    },
+    "sound/weapons/zap1.wav": {
+     "bytes": 7648,
+     "sha256": "1ee462bf6169537cc96fa7f95ef30b782fa1be473bd6ddc297fb3a7a6aa21ad0"
+    },
+    "sound/weapons/zap2.wav": {
+     "bytes": 7178,
+     "sha256": "8ece0064dc470a86c00906c1c50a54afd3a64eb13582071b9960581a1b72f4ff"
+    },
+    "sound/wraith/call.wav": {
+     "bytes": 12328,
+     "sha256": "9ace8a0ff79d035d36b6bdfb8726054ceaf8f852d25f3c1b235616abf4646ef2"
+    },
+    "sound/wraith/die.wav": {
+     "bytes": 14024,
+     "sha256": "3f166e024c07124cc5b5c5469904f5a8b3e48d4cb50fd949be8d79b4df2e375c"
+    },
+    "sound/wraith/drain.wav": {
+     "bytes": 14094,
+     "sha256": "d767951e9630b6179fb05a80136acbdeeb530f350b1953bea62e8493f3fe67ce"
+    },
+    "sound/wraith/growl2.wav": {
+     "bytes": 24966,
+     "sha256": "1c757955bb103e0f589ec373d1517dbacb8fe7e274f7aa0928503c9f5b009b10"
+    },
+    "sound/wraith/idle.wav": {
+     "bytes": 23702,
+     "sha256": "760a4a215fa2adb6f531b15acc06a4b46daa84c85fc08691ff4fe13f17e09ee8"
+    },
+    "sound/wraith/idle2.wav": {
+     "bytes": 20442,
+     "sha256": "d55cb931cef7d9c336fb7bbc3fa0408ea23eff69f46e25ac377ebbc880fa5025"
+    },
+    "sound/wraith/return.wav": {
+     "bytes": 39162,
+     "sha256": "0439588ad2003732fe7f946a5597bf80b2b89d6395476671b0e050b91c49cca7"
+    },
+    "sound/wraith/rych1.wav": {
+     "bytes": 24482,
+     "sha256": "baec568f339f688ea475e37ef3fc51a36de78a52a553e85aaa3f8011e1240d13"
+    },
+    "sound/wraith/select.wav": {
+     "bytes": 29326,
+     "sha256": "1e86b92dd1d82f4f74cd7fe14a75484e6cddb4fe968d2bb3dbaf850414c6dacb"
+    },
+    "sound/wraith/soul.wav": {
+     "bytes": 70524,
+     "sha256": "612bf73a6ebe0526efa2ef3d22915bcd87bed0b0eb5e52fc4eb0e62c5e4a3039"
+    },
+    "sound/wraith/soul2.wav": {
+     "bytes": 20562,
+     "sha256": "d3701420c157109793576ac7af7c7b132ffd0897375ec99701f4cd54798d9579"
+    },
+    "sound/wraith/speak.wav": {
+     "bytes": 25630,
+     "sha256": "6d1e5b395938692d57de3ec8ef9a8b5e4ccdab920a1f247e5bcdc1f0906dfcb8"
+    },
+    "sound/wraith/talk1.wav": {
+     "bytes": 16654,
+     "sha256": "6a625383c12f7fb5979ca8977a51d40f183051d551bd0b1b4ccc8a3f43a0322a"
+    },
+    "sound/wraith/talk3.wav": {
+     "bytes": 9832,
+     "sha256": "28ecc66c85bc722059b147a1354d226fbaf3022b79aed937a4759958d52c0fab"
+    },
+    "sound/wraith/weird.wav": {
+     "bytes": 3028,
+     "sha256": "1cfcd24daeb0665dce9d68ec353377ef84a88c78d1fdfcb429f2d0cc2b7f4b78"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    },
+    "sound/yakman/big1.wav": {
+     "bytes": 21636,
+     "sha256": "16c1632682aeb4b4075006d5b8b13a7e3f8821b6f59f8eb61ad78308b0d68366"
+    },
+    "sound/yakman/big3.wav": {
+     "bytes": 25096,
+     "sha256": "2cbbc5dc1249a92b9a31a6f3fa7ff654dd6339511fc99e4c552ad6a34218a4c2"
+    },
+    "sound/yakman/breathe1.wav": {
+     "bytes": 45712,
+     "sha256": "53730dabf839c183028fbdf909df8ae7ef936828c51c58a957617444872224d4"
+    },
+    "sound/yakman/breathe3.wav": {
+     "bytes": 50728,
+     "sha256": "fd923c891934046d9770c089dfe16021373a392b429531ef9698fbd2f759c42a"
+    },
+    "sound/yakman/crash.wav": {
+     "bytes": 17808,
+     "sha256": "068f6ea04f13016615f9534e74e969a62eda98c7def921df76731c5afbd73cf2"
+    },
+    "sound/yakman/death.wav": {
+     "bytes": 43288,
+     "sha256": "55a8bbe65fafec181974ed1f1a5ddd302be900f8aef6f719312b8200867a245e"
+    },
+    "sound/yakman/expsmall.wav": {
+     "bytes": 8732,
+     "sha256": "18825b9644c01ff0a488887185ac14d6fb4fd983254620009ba3ecc96c44d465"
+    },
+    "sound/yakman/firefblt.wav": {
+     "bytes": 9962,
+     "sha256": "f4b1d44189e057bbb01c285a9d72cd93ebe23e5c91ee31655155671b58b0c69d"
+    },
+    "sound/yakman/pain.wav": {
+     "bytes": 30704,
+     "sha256": "3e61edf90bd75621928be20e04e7fff71c59a04c19c5644625ef052a98bf572b"
+    },
+    "sound/yakman/slam.wav": {
+     "bytes": 6372,
+     "sha256": "2c6ff4782b389777c98f09fa6ac86e6c75a848ad800db6dc32f8ea9362706e96"
+    },
+    "sound/yakman/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/yakman/step2.wav": {
+     "bytes": 11744,
+     "sha256": "79879fbf1e0be6bfe5dc2113cbc4f4a66646fda16e1dc5d9d84d750c17a72bd2"
+    }
+   },
    "sha256": "22d57e211cdb714ba3df19083c1514b08e5c84650545bc1a4092b383fb72a3f9",
    "timestamp": "2011-06-12T20:56:02.000Z"
   },
   "pak2.pak": {
    "bytes": 4813402,
+   "files": {
+    "progs/brazshrt.mdl": {
+     "bytes": 261243,
+     "sha256": "d599a5ada4c7482810b92bc57b4ed37e7a3ae4829e6c1060d17320f2912bec36"
+    },
+    "progs/braztall.mdl": {
+     "bytes": 290037,
+     "sha256": "87086160d4bb98489b64d79ad469407b9425a9c642a8cb20fd143f31a0d797f3"
+    },
+    "progs/drlbomb.mdl": {
+     "bytes": 20355,
+     "sha256": "5c1db489f43cba73fce265db642267775245d044866cdd48396b1f1260a28237"
+    },
+    "progs/drole.mdl": {
+     "bytes": 241648,
+     "sha256": "5067b7ca5323754fe563d6696025525645a2cbd3aaf7f79232634608f9fb987a"
+    },
+    "progs/g_fx.mdl": {
+     "bytes": 32260,
+     "sha256": "ac99d4e641af0bb1495ed38ba9f3a7c1195bda19e5cf0d3a68f04defe6178ab8"
+    },
+    "progs/gaunt.mdl": {
+     "bytes": 222024,
+     "sha256": "d805c09223a651d6650ad75464cba53ae0fb7f8de1066307efd21d0079c14f5c"
+    },
+    "progs/gug.mdl": {
+     "bytes": 482020,
+     "sha256": "2cd097236a235aedf717a86b7312bd7d1b3caa6f0b25980c82eee2463fee2274"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 16854,
+     "sha256": "00f3263f1c3e0daadaaf03eea447080d727ea7d9ee1a88f2b42e060d748e1566"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 61251,
+     "sha256": "dec5afe666eba8db6e32d7535fffa3d0e4ed9344ba107b73418526ebebac574b"
+    },
+    "progs/longtrch.mdl": {
+     "bytes": 257355,
+     "sha256": "0577c1092d4482f749dc250b25b25bc8e1a58f45888548c556cb013cb2d0fcfe"
+    },
+    "progs/marsh.spr": {
+     "bytes": 1968,
+     "sha256": "b1f0f966424d152eb773ad2373a8f1476d52c6b893bc792221add55d18fe8a0a"
+    },
+    "progs/marshsm.spr": {
+     "bytes": 1968,
+     "sha256": "5ffd48ff0247475c6d6160ee4f2c73422d0f5c1dfbd6e23b82a7b913cae39543"
+    },
+    "progs/snowflak.mdl": {
+     "bytes": 36372,
+     "sha256": "d7cdcca5767160408a43bd6b51313f9b68b696aa06eafdb0af4762513325d1a9"
+    },
+    "progs/spore.mdl": {
+     "bytes": 13469,
+     "sha256": "fc9fbb97f0d4f1a9f843769cd43fb7270ba2b351cdf3b4b624d27616980457c4"
+    },
+    "progs/vermis.mdl": {
+     "bytes": 656752,
+     "sha256": "d7060475e290482c61c122b3a477085b1aad002fd71d8293cc4a4f8bde1baec9"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/explode3.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/sight2.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 83982,
+     "sha256": "4b0d8db882ab1c9fc2109effeaf125ec46fb23a91ac2242201103e0d3da96944"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gug/bile.wav": {
+     "bytes": 54572,
+     "sha256": "e06787585ef0369798a938a1a9585d24b60aa7b5c65acda3a5fb6f2c7ab65aca"
+    },
+    "sound/gug/bileatk.wav": {
+     "bytes": 50040,
+     "sha256": "b4b05e2907789a78391ccfe8ced3902821f1097ecd1f894b12ba9278d31a8717"
+    },
+    "sound/gug/death.wav": {
+     "bytes": 132396,
+     "sha256": "20bf209a832381b77d37c54a84ab1819b6c71e2147c5d122ac62668c070167a5"
+    },
+    "sound/gug/gquake.wav": {
+     "bytes": 43350,
+     "sha256": "d232ae13b55cb5b10b8903db43c037a5c6c4cdfea1f84f9399133484df6e0175"
+    },
+    "sound/gug/idle.wav": {
+     "bytes": 50580,
+     "sha256": "ff33c63696dec5c582ff9a4537814299b47ce2480d6cc53c116721d793576fda"
+    },
+    "sound/gug/pain.wav": {
+     "bytes": 22064,
+     "sha256": "e559f2b372fe771207aeef4b1c3a71baca542863493776558ae3f933f3878c29"
+    },
+    "sound/gug/quakeatk.wav": {
+     "bytes": 65882,
+     "sha256": "2c07b7690356bd9233a79c1f8b5f4e146cbabc367a19c138d6719a1e0d09328e"
+    },
+    "sound/gug/sight.wav": {
+     "bytes": 76426,
+     "sha256": "210ed86a5d6f9d4e791954fc3a4e4b4b6dc5839d02f7c19d468493a2f87dca64"
+    },
+    "sound/gug/step1.wav": {
+     "bytes": 15494,
+     "sha256": "4e2ce285991bc0d4337c77fdbb029507697ecb4dbf6543ddefe976ea114c4214"
+    },
+    "sound/gug/step2.wav": {
+     "bytes": 15502,
+     "sha256": "27f6f770a52fce5ae04836706e63ef455555de086019a2f9e44d4da1fc99b03d"
+    },
+    "sound/gug/step3.wav": {
+     "bytes": 15502,
+     "sha256": "fcc7ab38a8ec28509d0aa062a3cb93aee6da6a0ae364e4fe0dfad791f54558af"
+    },
+    "sound/gug/step4.wav": {
+     "bytes": 15502,
+     "sha256": "fc52cad29cca2e1fc36f5c6ac7f955ed897d6da4fb5dcf4eefd052e0652d93e7"
+    },
+    "sound/gug/swipe.wav": {
+     "bytes": 16064,
+     "sha256": "90bb5831dfd19f65df19e97f76d858ec940d8e33e0a2ed8fad89a23947e430e5"
+    },
+    "sound/gug/throw.wav": {
+     "bytes": 23180,
+     "sha256": "5e901b94e7be364536603273f18791ab571c46c2fc74263774c0e312f873a281"
+    },
+    "sound/vermis/death.wav": {
+     "bytes": 148016,
+     "sha256": "44b26a9dca5ec8d5e8a7ef2b5e38196b74e4f606cd37b906ee2b2e5b5a85b08f"
+    },
+    "sound/vermis/grab.wav": {
+     "bytes": 88122,
+     "sha256": "09528bd0d49d5cac0c03fe7994b57e572eb89aa8bce63cd0a591130e4b2126ae"
+    },
+    "sound/vermis/grabbed.wav": {
+     "bytes": 51630,
+     "sha256": "99583c88b8ec2959a0d69448aee16ec86b3d9feee6df7841fc32759598349376"
+    },
+    "sound/vermis/grndhit.wav": {
+     "bytes": 36428,
+     "sha256": "1f0e78fa08efb4617b6967a6cc218c56af227c7fd6bf039420d8f106d74fca72"
+    },
+    "sound/vermis/pop.wav": {
+     "bytes": 131420,
+     "sha256": "6284ab02e604b44c5b07225b2a0544c8707517d5fec0024c127bdafef2704f70"
+    },
+    "sound/vermis/sight.wav": {
+     "bytes": 137772,
+     "sha256": "d892117e4602595b6dfb65563b8fa7a3ad2171851791f7c6f47ea4bfece76296"
+    },
+    "sound/vermis/sight2.wav": {
+     "bytes": 106780,
+     "sha256": "6132e2d0db5cfb7a1a064e708d97f7258e2c6ac15c6f4ea8d520641e0ad10f9d"
+    },
+    "sound/vermis/splash1.wav": {
+     "bytes": 30710,
+     "sha256": "f931a2927c13cdb2523dde4550c0af993cc08cbea6e332739f9cf6fe3bd1ff8b"
+    },
+    "sound/vermis/splash2.wav": {
+     "bytes": 25332,
+     "sha256": "b91c69ee695bd71537ed018800f7d89e5e7d95332124f69adee39261d84d7c13"
+    },
+    "sound/vermis/splash3.wav": {
+     "bytes": 25590,
+     "sha256": "99fad2f3815a30ef645a2162ea24e54b4302ba00d7551af9299fde74ecce98e8"
+    },
+    "sound/vermis/spore.wav": {
+     "bytes": 44204,
+     "sha256": "d01a27af99745725dae124d30af18458b2ef323bce93c3cad939310e0f47f6c7"
+    },
+    "sound/weapons/railgf1a.wav": {
+     "bytes": 66260,
+     "sha256": "a3a7edd9c470077682bde595f95d88546d416f300202ae96bd6c6371ec19cf09"
+    },
+    "sound/weapons/railgr1a.wav": {
+     "bytes": 51566,
+     "sha256": "40ce379a835e11561573be1dfdf1806a9bcb27192b94333a126cc721e38bbde4"
+    }
+   },
    "sha256": "8bf25c19172e0f7a63ad30fa14b1a93d335e50270bb1d3bd110d63adae53a3b5",
    "timestamp": "2012-12-11T07:04:08.000Z"
   },
   "pak3.pak": {
    "bytes": 6506790,
+   "files": {
+    "progs/bone1.mdl": {
+     "bytes": 6328,
+     "sha256": "9a00fdc313c40d06b9bb936c5ed0f97b2174cfc6494598cba42fb212d80dfcfd"
+    },
+    "progs/bone2.mdl": {
+     "bytes": 2940,
+     "sha256": "fc25694231ef3cb7567db44cbd080e416526fba73509781eb45c5e9841aa542e"
+    },
+    "progs/bone3.mdl": {
+     "bytes": 34368,
+     "sha256": "9f7a6f1d708b1efe687d675b459c4274143a7da6dd551ed8db83e01700375e17"
+    },
+    "progs/bone4.mdl": {
+     "bytes": 6676,
+     "sha256": "4587bdd40928b25698e89c437624c77cc2c77f32af929ca51a2122d069c8c8b2"
+    },
+    "progs/hive.mdl": {
+     "bytes": 9576,
+     "sha256": "24d505825f72178d41174d481b4ddc1981871a25f5a8d2a6bb12800dbfb57b81"
+    },
+    "progs/rider1.mdl": {
+     "bytes": 1595708,
+     "sha256": "207bb926fefd34b57bb14ec3d9d9a3106bfd58cce3201f1cb5b0d754140f79ff"
+    },
+    "progs/rider2.mdl": {
+     "bytes": 545600,
+     "sha256": "8414d8d62214848b26da3e56e3bb0ac0fc59792e9e473a9f9a4c62bfc0ae3699"
+    },
+    "progs/rider3.mdl": {
+     "bytes": 1110232,
+     "sha256": "6ca363430c2dd5a7484020cdc1e5c0936f544f51bee05d6a569c41efb6ca478e"
+    },
+    "progs/rider4.mdl": {
+     "bytes": 1454524,
+     "sha256": "14c64b22aaec0069b201982e3f126bde71683876ed80f737047f87a4dec6e86a"
+    },
+    "progs/swarm.mdl": {
+     "bytes": 127844,
+     "sha256": "eac005f0b9ff31650bfc81963b0cc3291732fa8366e31c56c5b0d809c880cc17"
+    },
+    "progs/waraxe.mdl": {
+     "bytes": 35856,
+     "sha256": "8b18a468baac0ff4201c63aea1bb2caf4a9f4a327f818567dcdb1c2cf395e570"
+    },
+    "sound/rider/death/clop.wav": {
+     "bytes": 4580,
+     "sha256": "6028b9d195ad93a68ceefcb8aec4370e950a897981989de0b665069c486a281a"
+    },
+    "sound/rider/death/clop1.wav": {
+     "bytes": 4580,
+     "sha256": "28696cdc4d6b356c6ffc1cac5d002bc651aab5b589394883e36d3ccf7f631ffd"
+    },
+    "sound/rider/death/clop2.wav": {
+     "bytes": 4580,
+     "sha256": "b2b9cc8663468d85eebbf71c404b708bed34924e9ca3271b827bc52cca67f20e"
+    },
+    "sound/rider/death/clop3.wav": {
+     "bytes": 4580,
+     "sha256": "b7bb0249d011f6dc154528919a16439a9ded749854b6d6c48bff3e1bc0c1f506"
+    },
+    "sound/rider/death/dthdie.wav": {
+     "bytes": 83066,
+     "sha256": "6625da36c6812b89e44fc5233f919cdb043e975ba63c28e432e6cc98d4d4093f"
+    },
+    "sound/rider/death/dthfire.wav": {
+     "bytes": 70778,
+     "sha256": "c9e9a417835472e4c27063b19f83e051d7311f0cce9321bd5c247f381db1a2cd"
+    },
+    "sound/rider/death/dthlaugh.wav": {
+     "bytes": 25658,
+     "sha256": "86f355417fc2e8bd9609847546ee20163dd0ce9fc9cfb3d153dcb96f212ad188"
+    },
+    "sound/rider/death/fout.wav": {
+     "bytes": 9820,
+     "sha256": "2cdb50e8f08ad8bcf06f49e853ab0ca1fb5cc98b5dd5f3aa008fdc62f2f047a3"
+    },
+    "sound/rider/death/shot.wav": {
+     "bytes": 30278,
+     "sha256": "e563c20fe5cbc6ac4b38775efc4f970d6e8ce3fa62cc2da94b6c2b91e8c196d5"
+    },
+    "sound/rider/death/victory.wav": {
+     "bytes": 38298,
+     "sha256": "d023b32dff8c6c6b4d95649eab7a3ffbaf4b1e05c9e3175ee4f112761e07e3ef"
+    },
+    "sound/rider/famine/_pull.wav": {
+     "bytes": 57686,
+     "sha256": "52106aee04a0248ca5276c8a8e1c82f416c591f2dac08083add05e5218b74e30"
+    },
+    "sound/rider/famine/clop1.wav": {
+     "bytes": 4580,
+     "sha256": "6028b9d195ad93a68ceefcb8aec4370e950a897981989de0b665069c486a281a"
+    },
+    "sound/rider/famine/clop2.wav": {
+     "bytes": 4580,
+     "sha256": "03b337ea1a348380e148ad03e99179fab0dbd1efc7820d45a74e863cdcf36cb1"
+    },
+    "sound/rider/famine/clop3.wav": {
+     "bytes": 4580,
+     "sha256": "afd07556f44f35222216a90235beccb149d74ac6a7cfcd7fbccd77cd76d8534c"
+    },
+    "sound/rider/famine/die.wav": {
+     "bytes": 57028,
+     "sha256": "9abd0716561549eae9b2ab444be276049c530a77e9c087dc9292fc18e0afb285"
+    },
+    "sound/rider/famine/flashdie.wav": {
+     "bytes": 248954,
+     "sha256": "2d8942ef8b88dd64239cddc8b4957d76d647543e50b95115bd76ddbec1f11a2b"
+    },
+    "sound/rider/famine/laugh.wav": {
+     "bytes": 45050,
+     "sha256": "efe0051a1e53d8328ae47901778f0cd19f1db793ef2a8d1c98c92bb71662fb7f"
+    },
+    "sound/rider/famine/pull.wav": {
+     "bytes": 58064,
+     "sha256": "998853d60e5f97150e266e97671c71328bb2dbf8659f9d3653a5684d05158132"
+    },
+    "sound/rider/famine/shot.wav": {
+     "bytes": 30278,
+     "sha256": "e563c20fe5cbc6ac4b38775efc4f970d6e8ce3fa62cc2da94b6c2b91e8c196d5"
+    },
+    "sound/rider/famine/snort.wav": {
+     "bytes": 25850,
+     "sha256": "06f92fc701f8f071c2892cdaf2a1d2ac94c5429033de326a46ef5523cc9d2b50"
+    },
+    "sound/rider/famine/whinny.wav": {
+     "bytes": 26362,
+     "sha256": "404de44803c2ec34721ae2fd6b0bc22b6baaa9d3c27ef88c896a1275846c7cae"
+    },
+    "sound/rider/moan1.wav": {
+     "bytes": 37224,
+     "sha256": "e86190319c4ed1fc539497e010874070b0920ee45abe960baaafabe74df09db1"
+    },
+    "sound/rider/moan2.wav": {
+     "bytes": 33598,
+     "sha256": "aa9dc4112e9343941f146d955227a1114f1d1911556db66e73fed4e39e981832"
+    },
+    "sound/rider/moan3.wav": {
+     "bytes": 35436,
+     "sha256": "b398a3f40b10b73cf63d041ad2de34e83a6c006ef5c50485c377e855fe373e65"
+    },
+    "sound/rider/pest/buzz.wav": {
+     "bytes": 21754,
+     "sha256": "957f1781514ab8e37909ea16813763357839c3d78e6eba2e5b630d3c92c389c4"
+    },
+    "sound/rider/pest/charge.wav": {
+     "bytes": 22844,
+     "sha256": "8c2a74463d2f5c6b32a5ad7f4c4654ca9f786556eafbf7e558b45c6b703415c0"
+    },
+    "sound/rider/pest/clop1.wav": {
+     "bytes": 4580,
+     "sha256": "6028b9d195ad93a68ceefcb8aec4370e950a897981989de0b665069c486a281a"
+    },
+    "sound/rider/pest/clop2.wav": {
+     "bytes": 4580,
+     "sha256": "03b337ea1a348380e148ad03e99179fab0dbd1efc7820d45a74e863cdcf36cb1"
+    },
+    "sound/rider/pest/clop3.wav": {
+     "bytes": 4580,
+     "sha256": "afd07556f44f35222216a90235beccb149d74ac6a7cfcd7fbccd77cd76d8534c"
+    },
+    "sound/rider/pest/die.wav": {
+     "bytes": 50746,
+     "sha256": "aa792d7d708de73ebe752c073376b40528ea2ab955d7b286cd8cdf933a4896ce"
+    },
+    "sound/rider/pest/gallop.wav": {
+     "bytes": 21114,
+     "sha256": "c8e5b5fbe216bcd1a59d5946ca3852302956fd5a6b4d1a7f97a73fc6859376a8"
+    },
+    "sound/rider/pest/hivehit.wav": {
+     "bytes": 16098,
+     "sha256": "ce85b2ec50191cd32697a24ef3afb62a70163116de8c185c2de4d219e2d3f26d"
+    },
+    "sound/rider/pest/laugh.wav": {
+     "bytes": 32980,
+     "sha256": "ba8aaa258dc7b21b52a2aa8316392f9f1edd8429b14253203ca0bbba128eac30"
+    },
+    "sound/rider/pest/sight.wav": {
+     "bytes": 22252,
+     "sha256": "6b4cb4b209546f52a749843ddb18767689159117e9e29f8eb7f1706c3811f022"
+    },
+    "sound/rider/pest/snort.wav": {
+     "bytes": 7150,
+     "sha256": "5af4c6e77675a0f27bcb62779205538e2e6ce4971a84361a494840c555c6b408"
+    },
+    "sound/rider/pest/snort2.wav": {
+     "bytes": 16376,
+     "sha256": "c8df6c3268bd3f2c8ddf0f9db33b410e61b550b2b6c1fc5ad0b4d20383dabe83"
+    },
+    "sound/rider/pest/sting1.wav": {
+     "bytes": 12218,
+     "sha256": "d37886f958b95e15096315a6b83bcf5f735ff5c7bf49c6654d4080978531687a"
+    },
+    "sound/rider/pest/sting2.wav": {
+     "bytes": 11482,
+     "sha256": "185692d83e0565bd5d6e7a15d533ea9032895c7863140275f4d2009e79ff6ad7"
+    },
+    "sound/rider/pest/sting3.wav": {
+     "bytes": 9758,
+     "sha256": "e6f4f6bb9742a7220d06b38c8068d7efbd9708ced0455473840e30a5c0bab740"
+    },
+    "sound/rider/pest/xbowfire.wav": {
+     "bytes": 15450,
+     "sha256": "548adc1347e3f72e83fe31bac1d3ad02efe912d49e96512afbc94ca377d0ac0e"
+    },
+    "sound/rider/pest/xbowhit.wav": {
+     "bytes": 10066,
+     "sha256": "03d93c412e226d7e71077be790ff62afff9fa4306b5335f4e0338b6fd3dc47dd"
+    },
+    "sound/rider/war/die.wav": {
+     "bytes": 75642,
+     "sha256": "16185e29265e20db7fc35836b2adc2ff5ca7ed203a25139f7656244aa8abe238"
+    },
+    "sound/rider/war/fire.wav": {
+     "bytes": 84474,
+     "sha256": "48bddc52358fb6ae4fd362ba0efb103638f9f8ab7776dd0461fd33546b50b3ed"
+    },
+    "sound/rider/war/fire_big.wav": {
+     "bytes": 32762,
+     "sha256": "2fb163e76fe46d966326879399155e045fc35063b2b8a2e55746e082e4bfbee7"
+    },
+    "sound/rider/war/laugh.wav": {
+     "bytes": 31012,
+     "sha256": "a80094ae1273615c5683e4a949a3adbdfce927635af5f5132cc46403a11d9596"
+    },
+    "sound/rider/war/laugh_sm.wav": {
+     "bytes": 20328,
+     "sha256": "9c515335988177e563d7fffb8f77c99790fdaed6631566e94ad0cd3dc74819fc"
+    },
+    "sound/rider/war/whinbig.wav": {
+     "bytes": 50940,
+     "sha256": "871b0b4b5bd3346747587cc435090d6afc978da07711cd819858b911358b1b6a"
+    },
+    "sound/rider/war/whinny.wav": {
+     "bytes": 20762,
+     "sha256": "a6b16598912d06b03c6e1f974c2b8ab4d8e1486f8785e25d68336d2e22ec55ca"
+    },
+    "sound/rider/wartrot1.wav": {
+     "bytes": 7478,
+     "sha256": "abac0cfb4bf02364e795b83197ca563c2e158d93eb9f6999cc258c12fc8a1ecb"
+    },
+    "sound/rider/wartrot2.wav": {
+     "bytes": 8920,
+     "sha256": "83f6abaced3124b50f760c666c5902abcb57309f951308ad30d0fbc7f8cf562e"
+    },
+    "sound/rider/wartrot3.wav": {
+     "bytes": 11324,
+     "sha256": "42af6fefd6b10d38f42d9987be5ccb71d595440a881fca4f492a5562f50e4bda"
+    }
+   },
    "sha256": "9a58d294e79806fc15293163ba9954f7d842238c3040aa753f497c5fec2e8473",
    "timestamp": "2012-12-11T07:01:28.000Z"
   },

--- a/json/by-sha256/dd/dd700f32518fc592a9f47d022d4b939d5fef17f1b400b33ee77041a7a0ffe007.json
+++ b/json/by-sha256/dd/dd700f32518fc592a9f47d022d4b939d5fef17f1b400b33ee77041a7a0ffe007.json
@@ -7,6 +7,120 @@
  "files": {
   "pak0.pak": {
    "bytes": 18477212,
+   "files": {
+    "gfx/env/deubk.tga": {
+     "bytes": 786450,
+     "sha256": "0777779dd36dcaf44a180b8ddf6135c562fb25ebb1707616cab2247e78416cc8"
+    },
+    "gfx/env/deudn.tga": {
+     "bytes": 786450,
+     "sha256": "3464ada3df673379f46cf31b889b076a52dcd079f4993a0a12c0f7a3a21c2331"
+    },
+    "gfx/env/deuft.tga": {
+     "bytes": 786450,
+     "sha256": "f95219e9bbdd25c339c5dbb8f3bb927c8f379987c0276474826eed4dde4b5d8a"
+    },
+    "gfx/env/deulf.tga": {
+     "bytes": 786450,
+     "sha256": "f24b7a01b3ecd3cd0011b5d6ac9112ce721bc899fa26242b501a8f83390d49e4"
+    },
+    "gfx/env/deurt.tga": {
+     "bytes": 786450,
+     "sha256": "55652278a6b55df50cbdc0b56e8c27e1d3842557efd06db5921d6fdb235ddd6c"
+    },
+    "gfx/env/deuup.tga": {
+     "bytes": 786450,
+     "sha256": "9c7b8e56b652a3f2ccb582d40d1f65c11a54d5a3d1af385873603ee419b15025"
+    },
+    "maps/gorge858.map": {
+     "bytes": 1479898,
+     "sha256": "ecd70046723294ab1bd6221a6d3c7f0e926faa3c9aceaa0a2d26a222d0d5fa45"
+    },
+    "maps/q1gorge.bsp": {
+     "bytes": 8574960,
+     "sha256": "258cd15a632e9970fa7e04b5fff9127a6774dd46f558c72f35a2d79d895d66ab"
+    },
+    "maps/q1gorge.lit": {
+     "bytes": 1666316,
+     "sha256": "0342a7778ed4d3e2eb7e93347b754aa9808c661004859f3a644cbc455e0f119a"
+    },
+    "progs.dat": {
+     "bytes": 352766,
+     "sha256": "901d1d8c731848de356f9cfc3803fc9e9aa08531bec944454f6e802f48d02bfd"
+    },
+    "progs.lno": {
+     "bytes": 85896,
+     "sha256": "e99e08c54baf22ce044fca543869241240af062eb4dfc879b89196fd7203c4ba"
+    },
+    "progs/bubel.mdl": {
+     "bytes": 109235,
+     "sha256": "f9c9842956ca54e1067a2a476b21454d516910986aa63f722768bb0082ad1c57"
+    },
+    "progs/misin.mdl": {
+     "bytes": 429764,
+     "sha256": "77db69edafd2918d6338c372caa6a1ecb4129a6654a49758f171151dd4299868"
+    },
+    "progs/tree3.mdl": {
+     "bytes": 137832,
+     "sha256": "7d8742450d22cafdf685b948314c5fa7d456b9a624406d2fa8022dfa8aad702e"
+    },
+    "progs/tree4.mdl": {
+     "bytes": 87908,
+     "sha256": "033354ad919b04c37398a57d10fb74ae73cabef8b9f0c0ebf7b836047aee03f3"
+    },
+    "progs/tree6.mdl": {
+     "bytes": 157084,
+     "sha256": "55cfce4e704e93e3a285822e2b0d33869cfbc07fda5d09789941cb3307b64536"
+    },
+    "progs/tubel.mdl": {
+     "bytes": 170397,
+     "sha256": "1d6d047e651b2ebd7e00b13d73dd5be446b360e1a5e1b8796ba496d250b60488"
+    },
+    "progs/wubel.mdl": {
+     "bytes": 158740,
+     "sha256": "b2f0a27ae49a7eebbbdc4f5d9d09d97b477f2d3fa42fe1163431e4fc4a38bf79"
+    },
+    "q1gorge.txt": {
+     "bytes": 1784,
+     "sha256": "18dda74c71636194cd08ced0d1c4ac907fbe5bb27ec55004e3c70ddf7e0b0e08"
+    },
+    "qcc/q1gorge_qcc.zip": {
+     "bytes": 146156,
+     "sha256": "1bcab653a9b3e55c77640f75f1740547ff67bd90d11664fe2441e4fd0366c2c2"
+    },
+    "sound/equake/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/sin/atk.wav": {
+     "bytes": 17176,
+     "sha256": "1f316bfedf73c322e6251397606234d8b48ac7aedb40bb60f45563d179856665"
+    },
+    "sound/sin/death.wav": {
+     "bytes": 32854,
+     "sha256": "f666cdc6766f7636a5c85dd63e68dd6fa573efd54869c5cc0f57dd1a8e9fc31f"
+    },
+    "sound/sin/death1.wav": {
+     "bytes": 9121,
+     "sha256": "cf30e73392c6cf504e890b5f2a11ce1de74c2480248fe5d59f869541dfaa537b"
+    },
+    "sound/sin/iksfire.wav": {
+     "bytes": 14212,
+     "sha256": "8b12d997a1f15e6a580337ba632b10979eac6d6880069d16af67bddb507c5ad3"
+    },
+    "sound/sin/pain1.wav": {
+     "bytes": 21452,
+     "sha256": "7b76a34d9ef74c01fb8961db5fb862ff3497ac706073185c7af51f47c8839b9c"
+    },
+    "sound/sin/pain2.wav": {
+     "bytes": 29306,
+     "sha256": "d651c83af105244da1e89cd307ed0473b1e881f71b8d86a07969dfcb59767c41"
+    },
+    "sound/sin/pain3.wav": {
+     "bytes": 20754,
+     "sha256": "53c7ec0de897d95874e46f6d694d9969f85f1ce1c09c91257ada0b35508340f4"
+    }
+   },
    "sha256": "36d3c47ddd5a2848496a6f0787f98dcb08be46bbbfb764d80b76e142b66f8319",
    "timestamp": "2022-08-02T22:03:12.000Z"
   },

--- a/json/by-sha256/e0/e0077b17abd891c78595adeda87b86e153af158271b3abdd79858b0aca1e0411.json
+++ b/json/by-sha256/e0/e0077b17abd891c78595adeda87b86e153af158271b3abdd79858b0aca1e0411.json
@@ -13,6 +13,24 @@
   },
   "PAK0.PAK": {
    "bytes": 1659132,
+   "files": {
+    "maps/enterhos.bsp": {
+     "bytes": 491164,
+     "sha256": "5e0f7f3ac40faf70315667c9e1c063f3a33d64dd5a6ca0b2fe74ded01e987fb5"
+    },
+    "maps/housp.bsp": {
+     "bytes": 652236,
+     "sha256": "a43b9ddf7aa0e2176243621c0640f4fd726db228a98ecbcd3a5718746dbfe316"
+    },
+    "progs.dat": {
+     "bytes": 420972,
+     "sha256": "89fdff934b6e1e41b071559aed5939f3d70e7a0808a3ea19ca0469ce1f58ee4e"
+    },
+    "progs/spider.mdl": {
+     "bytes": 94492,
+     "sha256": "df40e58bdf6465e68e5ef33cbcb77c42cc99e50c9dd842c8c3906c2fd04bfc8f"
+    }
+   },
    "sha256": "77d46335c74b5f09703351c6a18345e0a8f1c747c2c106b7b8224a9298e5d188",
    "timestamp": "1996-11-20T11:42:34.000Z"
   },

--- a/json/by-sha256/e0/e007c4c6c1c03b6bcc01dd2c081795110d4f77538a3e72f9ac91904328274dbe.json
+++ b/json/by-sha256/e0/e007c4c6c1c03b6bcc01dd2c081795110d4f77538a3e72f9ac91904328274dbe.json
@@ -78,6 +78,2308 @@
   },
   "rd1m4rmx/pak0.pak": {
    "bytes": 33287670,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 42302,
+     "sha256": "6c76f934d1132be338362ee9c465b64a12f79ca40ad475f2c65a8c958b9f4eb9"
+    },
+    "gfx.wad": {
+     "bytes": 204788,
+     "sha256": "8b97daeae64f4feb693905206ff585590e7e6e10d93c2ba5b6503cad3fc3ef4d"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "6072bd63a691625de201f3f3da060b5df433753d7ac2878c48b87e9d0dd08b94"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "ac11a967228e1c7d1a936859b82807cea239d80380fb6204d67af7a86c5c82e3"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "4cb99cf1b515b6547f012b6e44174c245261b058168a8bc4303d08b98e1805b6"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2c37b7697aebedb5bbf6637d4b8e158f70da6b7245195ff0e91a6ba7aa24e828"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "219002fe962a017600a37dcdcaaa0f777aad42044619f945cb70c68007763a97"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "e251893ed49aeb677096d380d4246907a039e0e21a4849f97f343b0b13faead2"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "64ec646cbab7ebca11f6af4f0b75d9706f438baa7b23059de87f8685f4686640"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "03c7cdc618e4404e2b9364c690b0a447b4be99dc5af112c66e6e2079902c76cd"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "9cf2683f2a6d22693a8c0cf35898bc5900a96afc771878df9f8a8a88f3d581c9"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "f232da5cf35acc557f3f312911e6a856cffaaf9f8078ca2ac5ef7e6f6e5e3515"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "b57ad9ad9d6240a0e035ca7a64e706e3031b8293c27355c9a95495a84972af4a"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "873af58b7244d6e82feb1af26ac044c9beb43c2865bc51d0485054a562ce861e"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "ba75badfe057b499d33168032dd5dc5a4fd0dcbaef9cbbd27efdb3f056cbfc00"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "55ac1377921460aeb691f86e7a5051e3a5481f24b93cc8578cffdab2854ba0c3"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "9600a66391996cff88d48890adfa516660fce6a32397ba4f54973159785cff4b"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9f03351fa7f31a23b63e6c13d2a643ed1ae3fd3df0cf2b0db336424eb17016dd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b7617428e8d1d74be7b770ef24c744d16c2503efce9c17facf1107cce08f5ed9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3036afb422cd299cb09532a20847ef35aaf87bb36e34ce9ce75b5e7aaf9a1ec3"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "7aa61257bd3083c00959776eb36aac86a7ca8da2bacbb4c8a41d9a5fb0b1ab97"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "cfe83953875acfe9afda11b75407ed9883eeb284b0a67b9ff6e07df85d50d9fe"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "d3b4091b83837da5a45445cd00b90267c62050e010e2a045461034ac9c48be33"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "de004dcecdff1973597a977ab63c671ad7d3f52387bdcff4be560924e3d4d17e"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "078c56d685ff1fb84b322f7a76e485c2637fb09efc61f4e44d5d067b3ef9a42d"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "9df9672c8da61ae769409e9ea741a1b8f9a4f108b5f0fa6637ff65601c535843"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "fef6b9be45d5b384d061a47f133075d1cfe0b60d93cf7e3da9ee5529f661964c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "1b1254c1f5764affca85448c4a3c2fefdb938f35bc50f44142a8e9b692ba7d64"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "39a06ff92831e1e2fd20c1bdd20e0f234cd0b3aed94e6c9909d059a20479ce3e"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "def061c922fb91a7e58850e89bb6baa9e09dcf93de7a94288a90511ecd9a114d"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "f897535531fe4b821d41d859a4085fd7d25c679493645a2ef7448f62073523c4"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d070636562a967d1abff330dcd1ea504ac7b9b29099a98994add1d9ae47e44e9"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6d92547a27d839f3c9d7a1da786fb33547cd93b7f19560b6c4bcdc12064545bd"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "e932416c58fc5de16e6d05aa737e56d3811e540bfd9e6acd1bf114ccd8bf34ac"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "bda55d4b2d7bc3f180dafd62424ee5830896563f5a5ac576dfa08894f5e17e44"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "513955ecc96eb1f0d44b340b47f79c02bb7bfa7f3b0a884a65fe111429ddb2b4"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "2faa4c1f61d175ad28b7f54540af3f87abc6e56dc20f2da5fc8a7737a0302c97"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "dcfe5287432b3a1124d032250ccc4bf25c73540521c77601ab746287ef3a0179"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "00654b7bec9981508cd9ae8eac167637926c023e7bca011a3cf37585b7e168a8"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "74c50b895f1e71ec6a569fba0e991fde8cf136ea734d6914435aaf9b2735d7fe"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "aecab7a199a4db72242659e6d1ced192d39b2619f67c7e5eaafa72a5efef3aef"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "d075eb0c8c00d30b01eae539720c20b73bb57066c6ea5e8180a4d851d9167add"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "d03aa05e24552d961ea9ca278d743860e34a97e2ffcee52fded05ad4b4740bd9"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 20040,
+     "sha256": "61c46ac5672c1e671c0c38a6498158176feaa62b074621c2a3d74e5dfc68e2f3"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "progs.dat": {
+     "bytes": 1101670,
+     "sha256": "2d72239dd484e94e7680d1fefbfe73838a8aa77023b030f3f8ed269fa3d6a00d"
+    },
+    "progs/alkturret_base_v2.mdl": {
+     "bytes": 87768,
+     "sha256": "4b1969201052a4506509bb606eb7c395daf9332cf4605036ab50190495dcfbf3"
+    },
+    "progs/alkturret_main_v2.mdl": {
+     "bytes": 116620,
+     "sha256": "11a2564f7daa19625e4514c284650242c8b3831df947f183243adafb958a1333"
+    },
+    "progs/arachnofloyd.mdl": {
+     "bytes": 741212,
+     "sha256": "554bd2ad34a830fa01a61dd4972f432812fb61f7815ec81d8a8d7e87bfad6b02"
+    },
+    "progs/arm_foot.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 164224,
+     "sha256": "35314143b9c7a9a0e26e52a865072a6e73862466e640c6bbd58be3075c4d93ff"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 497408,
+     "sha256": "40cc63b599cedb54f04c937ce407e7119c1cf4d5d35fd04bc18f247584e9899f"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bambler.mdl": {
+     "bytes": 128044,
+     "sha256": "c8ac9dbcf99f0e6efd30496ac414383c26b8d241fbaff56cfa81dfb545dfb0c8"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "698bf740683ad182feae2246526361948be6da2e144f1bd0202eafa748213ec2"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "b662513bc3a8e0e967344c55b536bd33012340dbeb79a8db1281d2c84e36d338"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b2cf62d8e989789bd76e27193b2f5205a93d4172a4e25c89aa1b30f75bebe60e"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigcranea1.mdl": {
+     "bytes": 92792,
+     "sha256": "81f6a5b55d3a585d5e9c73b088d1d20e0fb328707c1539ef41e52c460555f651"
+    },
+    "progs/bigcraneb1.mdl": {
+     "bytes": 21940,
+     "sha256": "e02faff0bb6c84c781f6b534a5a06ac1f977a028fbdcca176be2932f91e9e8ec"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/brz_saw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 575288,
+     "sha256": "f571bdf504537ce01ca2b6a78b57575a36c391f9c786625d880d956fb17390a7"
+    },
+    "progs/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/chain2.mdl": {
+     "bytes": 141764,
+     "sha256": "9334a3ec04716ce0068154bf7abb4c1e3ee6de14fb159982dd547314935d7854"
+    },
+    "progs/cyberscrag.mdl": {
+     "bytes": 311084,
+     "sha256": "307e8133ce4f48d4c3dad5ef1b9d32900a3457e91aade778b7fbbc6d8a4741e1"
+    },
+    "progs/cyberscrag_gib1.mdl": {
+     "bytes": 60500,
+     "sha256": "3db8b13bfa5a5eda07acea695cae6ffb92354053da9bed199ef29cd445317faf"
+    },
+    "progs/cyberscrag_gib2.mdl": {
+     "bytes": 58932,
+     "sha256": "ef20c0de15fe2fc2514c10b0023d14009a4871ed40311077ba107350c313f7ce"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon_alk.mdl": {
+     "bytes": 191716,
+     "sha256": "11f33f19ae0a46d3dcc6c1fee46235fb6ad201456120502b603fe4fb7cee14ac"
+    },
+    "progs/demon_old.mdl": {
+     "bytes": 272684,
+     "sha256": "538d5d01833d6910d4400f8795be582c3427748eb2a162fcec2c17d6707c57e5"
+    },
+    "progs/dog_alk.mdl": {
+     "bytes": 199324,
+     "sha256": "a16e350fcd247908c75ecd0c93e94d3b700b67bb0f66dd45d665d171a55d42b6"
+    },
+    "progs/dread.mdl": {
+     "bytes": 415072,
+     "sha256": "dcea570331c5cf4348c40451c6242bf35ecaaea2a348f12254a13c1b76b13d7c"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17284,
+     "sha256": "444692074359310be0520b1caa057ae2e084df826f7ecc9bcb0d258ea1d80373"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35988,
+     "sha256": "91aa79805577466147bd4811614b0387b3635aba8383fc2e16b178d7b63ebdf1"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42436,
+     "sha256": "93839bd6f50323f7ac5ae46037de0c6a10a533374f714229dd511ee62b88ca3c"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bcc6396dc638003480dba8c36cafaf32df2cfcf49bd460b001d0d74a164f9011"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/enf_gun.mdl": {
+     "bytes": 58684,
+     "sha256": "39ef1788b39a15f86c8d54b81c43f4126e8361ff80d386c44358f17ddc93769f"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 450424,
+     "sha256": "ecf603c4ebc56438e96d1706a451af8bbe9b090db9c48e38e758ec630a393570"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "ddcf759804fffd97e62c55f67f962e24e8cd646fd982215ac8aefd3e49f67660"
+    },
+    "progs/enforcer_alk.mdl": {
+     "bytes": 333860,
+     "sha256": "85fb5cb9eb1435da65ce0aa6940241b7b4b5fa13e7444713a75c6ec301cc8b97"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish_small.mdl": {
+     "bytes": 221279,
+     "sha256": "34b883e3bf73a520f301cced68629e0d95e88f96c03a23230f12d02aa49c247c"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flag2.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flagbig.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 451032,
+     "sha256": "1a311e7e74f9a67c9f7468252aedc8c19804f65375d229e90afbec2f93849823"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/fromitz_still.mdl": {
+     "bytes": 6964,
+     "sha256": "63204597e828e001c957e9316878995e161da0502764276b90285accadf6a222"
+    },
+    "progs/g_axe_alk.mdl": {
+     "bytes": 50460,
+     "sha256": "92988e970870f2b977f7490d2ea4ee040d338fa4bdc470e8d68f2e5a856a7a28"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_mine.mdl": {
+     "bytes": 37780,
+     "sha256": "5057c7736e8c722270c781e47584972f42e7ebdd5860596403a9ce7688d0b5cc"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "15f390e39e02c8524e575ca8fadf63187b641c58210ee9587b13a0ca94c29cc2"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 199076,
+     "sha256": "7ddca6fb95082d0cc7ffe5aa3ba896ea987a80b1bd5867db97b2a84b9d8da9f6"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "8b05b8ca87ea867c2a2397d238311fda2441f5c0e1cde130ba487b0dbd17a8e5"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_arach.mdl": {
+     "bytes": 60292,
+     "sha256": "daca6412383bec28809cee42c4ebf01085cf83ed6ff289114ba0f842b4005251"
+    },
+    "progs/h_bams.mdl": {
+     "bytes": 37316,
+     "sha256": "58c4644a2ed3e5f10741dff2ad1a8bb161f7eb205ba3fd8c5fc9b7e4ffc571dc"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_cyberscrag.mdl": {
+     "bytes": 62036,
+     "sha256": "df7d6bccc97bd5c184d9d6160005b370175aacc16a34bd06ab14c7d69ff60419"
+    },
+    "progs/h_demon_alk.mdl": {
+     "bytes": 72644,
+     "sha256": "22a9e01cdccb2e274c63c277e6dcd61986fa7556426ee3562fe11af2babea289"
+    },
+    "progs/h_dog_alk.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_mutant.mdl": {
+     "bytes": 110240,
+     "sha256": "f1f9c665b659a8c145550605ef9abddf27779d0917c897baa344d65673770875"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/h_sabrkn.mdl": {
+     "bytes": 11828,
+     "sha256": "050fcc93189211aba943674a326ddd898dc980b83fb551ee11fec3dd39973483"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shams_alk.mdl": {
+     "bytes": 37268,
+     "sha256": "9fcace6cfb38473763a5cf96007ccc5e0ec4786352d4d1063410d63157298b45"
+    },
+    "progs/h_torm.mdl": {
+     "bytes": 62056,
+     "sha256": "db0ddda0c4d2283cd3c58eb45397cfb57095acba1eb6dd38571ca23ebffe9946"
+    },
+    "progs/h_wizard_alk.mdl": {
+     "bytes": 14948,
+     "sha256": "5f6c27ba255b87718d993b29cff526bd025c0e7a4991722a96fe3c0f98d83408"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hknight_old.mdl": {
+     "bytes": 418144,
+     "sha256": "40bd5757499a2bf7e6f60a78b0039665107c9603c2557f6bc73208e080111464"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 37012,
+     "sha256": "e3c6cbabfe6c6723101f2e59f50fc99ee0e360571c95885d2d56c85eefade15d"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/jumpblue.mdl": {
+     "bytes": 37428,
+     "sha256": "be4e85e5fc643e91377d69794b997ad4dc927ae3866dfef5288d704dbc0f16d7"
+    },
+    "progs/jumpgold.mdl": {
+     "bytes": 37428,
+     "sha256": "4c543d82c88009cab7fcf6230feea0a21518a98f430636194fdbf5c1e526cc13"
+    },
+    "progs/k_laserspike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/knight_old.mdl": {
+     "bytes": 208068,
+     "sha256": "5cca43e29392051c9ba95838a58cc1038560411e6c0d2aff61867a428b119e2a"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "63220c0ebb6e266576cb3107a44be16bda10d69fa524d0462514edff9d80328c"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "29bc55efafbea3e15a385598750ba4d9242d0a87803a6bc3430ed772ec1785c3"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "f1e799e7feac3c340676bb60f6cc7a2a7d1e121b196d1f6d0e23edea3a614ed6"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "92370f5b196dc00460d73697975d14279ef659c87c7fc1613b9cbfb68e6c299c"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "4c5db792da6876f935f8a98a74f51708d52ca03f04975f28518051494660bf65"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "781837a3557c1a8b89c15fa8f477989cb4b77d8cff09c8c13d071090a4df9c1b"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "2feb7ce08070b314d163cbc7f2e2eae0986400c482f752d305ddba268639b3d8"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "04f7fc8b0c2be7ea93021819770145eaf828b2313c4fc591a5f2aa783ca97e61"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 8372,
+     "sha256": "9b6a8f7a49fb7a1f5d4d409b708663c579d433e978d898b9bdf00291a59b4e6c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "fa5d7a5e2410ac7faa5dd0a8e17873c972c6e5cfeacc94118f22db1b4b17477c"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/mutant.mdl": {
+     "bytes": 352720,
+     "sha256": "262ffca22e0c7308950076c2789436a891399862ea25afbd06040158ec9f7984"
+    },
+    "progs/nsoldier_alk.mdl": {
+     "bytes": 563108,
+     "sha256": "6071d7cecf231f0a83f2e1c7df533b4a32beb6e75969d17703446a67d011695a"
+    },
+    "progs/ogr_gun.mdl": {
+     "bytes": 52452,
+     "sha256": "eaa6e0fe01255450d578f151c06c5aeb6a9cd5ed90edbbe4f52d305069ed6825"
+    },
+    "progs/ogre_alk.mdl": {
+     "bytes": 315696,
+     "sha256": "31e9986373dc1a8cba00e09ba9b0278cf766bbd074524a891ed22329f697d643"
+    },
+    "progs/ogre_old.mdl": {
+     "bytes": 315696,
+     "sha256": "53317e9b684701e7722bea342af1a6dba5dd31e72cdbcfa5b097382516d1c6a3"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 487968,
+     "sha256": "ae0abff3ea3fc7ca8c7f80c5d8825553795a1c1ebb80127d46fa52b20905abc4"
+    },
+    "progs/ogrem.mdl": {
+     "bytes": 378296,
+     "sha256": "2bb999bf580d16fb9ee4246dea7897236d6d118232c78a6168f641dc32778fb5"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/pellet_tracer_short.mdl": {
+     "bytes": 58148,
+     "sha256": "5b24b67ce9d9b2634d9a0f31319a977e1e3ec6352d491367941a0e5bf2ae10ff"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/probegren_body.mdl": {
+     "bytes": 139044,
+     "sha256": "da0ddf337c3e2515688f2b143adf55d4ecbbfa32955a78aea01ed16e067b0065"
+    },
+    "progs/probegren_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "4f292b6f157d226e763ff28dad682ce95cfb8a3a21b4badf0ca48db4900cdd70"
+    },
+    "progs/probegren_gib1.mdl": {
+     "bytes": 63788,
+     "sha256": "0efb081efa87c9db990d984f9974f10078890a51894a3e0a6fbe76cc3c4cb5a7"
+    },
+    "progs/probegren_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "7843ddefa22b7d5beb37f889c606c6361792508c2bea202f3dadf9f3ffce73de"
+    },
+    "progs/probegren_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "7baac250aa8c27ef3158de59b536ebf59509e39b1f7bf6be1c24fd5b1e29cae0"
+    },
+    "progs/probelasr_body.mdl": {
+     "bytes": 84296,
+     "sha256": "ac545d0f545488628c864df6e464d10fbd51cb41a2cb76c46dd91233ecd11a6f"
+    },
+    "progs/probelasr_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "cec7b847c9b05f2653113454348799b9bf09c2a74c8e1760cca0ff52c1dfc18c"
+    },
+    "progs/probelasr_gib1.mdl": {
+     "bytes": 58700,
+     "sha256": "ae9f298abc0bb1d09cea3c04bf02216b0a1c3749f8c8a822d973b4c2091cd649"
+    },
+    "progs/probelasr_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "07d6defee5ce4e747daf8b397a5d207a1a42e3c3acffbdfc18d6720c88ec635c"
+    },
+    "progs/probelasr_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "8b8f376afa56e7a9f311e58a076f1fa3a52c88064887a8e0960fdb6daaf5265e"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12653,
+     "sha256": "162632bc16838f66f29e0b788845a6421b7fce708003e9fa6f4eb8ae7aa8e5be"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/rail.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 200152,
+     "sha256": "a564fba381d24e3084bc9aa0a026381c83e6b889632c8bebdf69c08c8a6bb9f2"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "f65ba83d82e90808af589ded17378f1baf37f105fa14f2b157227ee22583d25d"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 288,
+     "sha256": "6ff2797f9dc4e66f2113475a5f3e0e96f23dacbddd18fe47c8b5e12e712f0e75"
+    },
+    "progs/s_bullet_new.spr": {
+     "bytes": 708,
+     "sha256": "a07fa61f4a838ac9ad8ec85ae525d70fb934d383effd1948c0775497be713043"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "b3f1971bd28f96c623c5712e2a47f54f16c99a50d460a944cdcdf29e6eb03963"
+    },
+    "progs/s_exp_small_2.spr": {
+     "bytes": 201720,
+     "sha256": "f7fdba9e2b9b5d318cdff33a06fad4e91e46ba3a241fe7ced4bfbcf0bcb0e873"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_plasma_new.spr": {
+     "bytes": 13980,
+     "sha256": "5474060e55af3c462d0ef7aad043f331c1f5b642915d906c1785bb94595cc68c"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 2820,
+     "sha256": "ea66402d248232b0b6a77bffe024d4a62881be47becf37acb42328661b7f23ef"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shalrath_old.mdl": {
+     "bytes": 211576,
+     "sha256": "409cda15df7b271bd95a895f058a521d43eca63f37c7ac9df175e5b478229bb9"
+    },
+    "progs/shambler_alk.mdl": {
+     "bytes": 502148,
+     "sha256": "bcf685fcd1f4062dc382924d39eae073fc4d44cd2dcb5bc4ca3797fe0b342b71"
+    },
+    "progs/shard.mdl": {
+     "bytes": 10132,
+     "sha256": "0f756f280c09f44ef1e9f36fdd678566b4a5782b349a3e9fe1309c3fcd9ab19b"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "662d6a7cd68bca7a9c5e88838d190de6a501252a14b6994a191d0bc91f1f331c"
+    },
+    "progs/sknight.mdl": {
+     "bytes": 460932,
+     "sha256": "9213f6898a60cdc20a7a144c61c13f8d64f1432382dca44b636524edf737dac8"
+    },
+    "progs/soldier_alk.mdl": {
+     "bytes": 359276,
+     "sha256": "623374e5a553c3d886738c9cc0b22c0b3f3435b3dc1b3f473079a1dd1661fc8a"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spiderbot.mdl": {
+     "bytes": 82476,
+     "sha256": "e85556a194664a5f69e70b42aa863d9e67689a418a3afa51e50816174a6fe8ac"
+    },
+    "progs/spiderbot_gib.mdl": {
+     "bytes": 19444,
+     "sha256": "96ee732ac1199a89c675880700c24e1f09521c35ad478f73aaf4278a398454f6"
+    },
+    "progs/spike.mdl": {
+     "bytes": 2820,
+     "sha256": "783d711b408498dbb34581c9a0ae74ed325dc5c68fa67873745b02c8a926a201"
+    },
+    "progs/supbkpack.mdl": {
+     "bytes": 44408,
+     "sha256": "781c6b5f424fb58e06b2a84b1fb7e980778decde6b3ed257e224db0b1f250173"
+    },
+    "progs/torm_largeshot.mdl": {
+     "bytes": 37852,
+     "sha256": "ce3a87be213e39b48bc71a6fbf5e1fe9e3f5209901ca45801f27d8f297e04a01"
+    },
+    "progs/tormentor.mdl": {
+     "bytes": 461080,
+     "sha256": "df302dea113f54df908f97c26de844d1235004c08aefcf5c349f3af4b0957d41"
+    },
+    "progs/trifecta.mdl": {
+     "bytes": 25460,
+     "sha256": "2c9196af0806c48354f5522a8b7f6fa57e6390f8dfb51718fb71b8a2d4d7447a"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/v_alkaxe20fps.mdl": {
+     "bytes": 96428,
+     "sha256": "4405242db772d86c66f1012b140ba409bee86682fa5f4a6ca12c3e6f94eb9fcc"
+    },
+    "progs/v_axe_alk.mdl": {
+     "bytes": 55820,
+     "sha256": "80ad34cf2612f8fa9121f2be0ada92c1e05613ae2b35b2a1be25a4c694dd2147"
+    },
+    "progs/v_laserg40fps.mdl": {
+     "bytes": 142580,
+     "sha256": "b897ecb5868e3125597d51f970075af04782cba47ed8a42d7b17775dff01f536"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_mine_40fps.mdl": {
+     "bytes": 332920,
+     "sha256": "0039956e96a804229359aaf082b9cf66515d52360867b86c3dca884d19caf8b4"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail3.mdl": {
+     "bytes": 124944,
+     "sha256": "19045e9a5154299b68377744ad946fc3e7f2bd290497c8291a2247ed8cc572ad"
+    },
+    "progs/v_nail_alk40fps.mdl": {
+     "bytes": 44692,
+     "sha256": "402b3dc06f1e5e756cfd50cab17cca49e17e261994c5007cfd46c466a08d3dad"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 260692,
+     "sha256": "0982368440a5d20d65ec511207590c2bfb63e9a60376a5d753b209f2b047c58b"
+    },
+    "progs/v_rock2_40fps.mdl": {
+     "bytes": 139668,
+     "sha256": "89257b7580ac3f48fc775f121eef3508c326eba1369e6aacae83144f8fdfca15"
+    },
+    "progs/v_rock_20fps.mdl": {
+     "bytes": 39556,
+     "sha256": "ebdd6245e1ff65bd95eaed7fa189ac87b51818408f091a32de3f4a477b90f2f8"
+    },
+    "progs/v_rock_40fps.mdl": {
+     "bytes": 43828,
+     "sha256": "f3c32a1c37d4fc3115a8da00ba9507cdd508a98f65e2ddccbcbdc8a0ba0bf2ea"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 326464,
+     "sha256": "dd389cc337d8b7675d9a7b983fd9f53f0c59d597a9759367bd1e1beba375eaaa"
+    },
+    "progs/v_shot2_40fps.mdl": {
+     "bytes": 29076,
+     "sha256": "37ae91c018183faef847aad217da537c97b5a2430ab27a860388bffc1f4514f6"
+    },
+    "progs/v_shot40fps.mdl": {
+     "bytes": 29252,
+     "sha256": "87a47e2debbc27fd6c18a8a38a9a373e7b73ba707458e6346f069c1572df47b4"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/wizard_alk.mdl": {
+     "bytes": 158508,
+     "sha256": "aab430eb2dc0f5c50ca7b4492a7ccc427f2a12011f54ece1b81d4beb66acb4a9"
+    },
+    "progs/zombie2.mdl": {
+     "bytes": 130148,
+     "sha256": "185336c7bffe32e496e93f6828278287f89b672c71f2439918ac5e220ae8b868"
+    },
+    "quake.rc": {
+     "bytes": 1273,
+     "sha256": "b43f856e56c166cca4dd6d89da538218610b740d0b2a6113ebdcfd89352824a0"
+    },
+    "sound/arachnofloyd/death1.wav": {
+     "bytes": 119460,
+     "sha256": "d16c7ff30e9df62fbcda102befbd61fe234532f6aef30d0b34c25330679682bc"
+    },
+    "sound/arachnofloyd/death2.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/arachnofloyd/idle1.wav": {
+     "bytes": 34254,
+     "sha256": "35d6991a10637251ec0d6b830f7f57f394e4eed06e7a9dced86f0128ba5bc49e"
+    },
+    "sound/arachnofloyd/idle2.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/arachnofloyd/leap.wav": {
+     "bytes": 70884,
+     "sha256": "f47323f618db14755c57e9e25213267dcffc501fbaa9a201176ab99db6cda928"
+    },
+    "sound/arachnofloyd/pain1.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/arachnofloyd/pain2.wav": {
+     "bytes": 15906,
+     "sha256": "9c4bdc81c73787cb67677e0021b71d9e24734ef3ce272d9020dc6611a1d87842"
+    },
+    "sound/arachnofloyd/sight.wav": {
+     "bytes": 48620,
+     "sha256": "97a055dbb8e5935190348b2c2d50c6d99ab35c29f3ebcd0f66d6263bdb5485e4"
+    },
+    "sound/arachnofloyd/step1.wav": {
+     "bytes": 74932,
+     "sha256": "a8744a3e50dccf9ee391da2f381c2ecf6701a76441406929ee4581c7717b880f"
+    },
+    "sound/arachnofloyd/step2.wav": {
+     "bytes": 34478,
+     "sha256": "22ce43aa18537f7b04e31263a46dd02e181d538fdf5918d55f8ce0acbb930676"
+    },
+    "sound/arachnofloyd/whirr1.wav": {
+     "bytes": 19762,
+     "sha256": "9e2029071248e6d45f1b0d518983bad5bc5f841cda6bcfba09486e111add10de"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axegrunt/axgdeath.wav": {
+     "bytes": 20214,
+     "sha256": "e5ed762afcc516058acc1b3884b4d08e67fd36e3a5bacf711d3504363bf8136e"
+    },
+    "sound/axegrunt/axgpain.wav": {
+     "bytes": 12636,
+     "sha256": "4699951fa58fdf15ab819b13d70904fc9a1a86a4db02193d621dfad3878d17bf"
+    },
+    "sound/axegrunt/axgsight.wav": {
+     "bytes": 17712,
+     "sha256": "e7b23208831c1d83793ba06f3b8855430c92017600cd8315341afbcb6ec6c8f0"
+    },
+    "sound/bambler/melee1.wav": {
+     "bytes": 4175,
+     "sha256": "4e0e2567b9d64b3ff86b33d95fa0158bf72372aeb4968a0c2489df942f9f7c4d"
+    },
+    "sound/bambler/melee2.wav": {
+     "bytes": 5283,
+     "sha256": "4bb91991bccfc33576eff19037e12666e9825348272d3dca40199e208bc00700"
+    },
+    "sound/bambler/sdeath.wav": {
+     "bytes": 14048,
+     "sha256": "c5253af82d203e75d132a00bbb555de055d2e356106d460f34cb8c9a2ee5e643"
+    },
+    "sound/bambler/shurt2.wav": {
+     "bytes": 3736,
+     "sha256": "0f1a51e0ff72f23a4de7684d4408344b7b7bd2cb805609168d2f2459e1b8660d"
+    },
+    "sound/bambler/sidle.wav": {
+     "bytes": 4907,
+     "sha256": "ea2232ba791e306cc86f58303413d8f3fbc7dd38091281698f4d846b6cafa483"
+    },
+    "sound/bambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/bambler/ssight.wav": {
+     "bytes": 11376,
+     "sha256": "de766aa056ca5f7dc6d179e6a220ef906ceacc0341b5cb3d91a4d0e75ff55338"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/cyberscrag/fall1.wav": {
+     "bytes": 23396,
+     "sha256": "162fc0be1cd0eadfc93c35f1e1ba9b8dfc7e8df8ee53afb2a14db73e69f20ce8"
+    },
+    "sound/cyberscrag/hit.wav": {
+     "bytes": 22334,
+     "sha256": "a16ef33d94d56fb6984b2a3d06104a3cc292bdb38ec6ee22c8b10457b2cb415f"
+    },
+    "sound/cyberscrag/wattack.wav": {
+     "bytes": 25912,
+     "sha256": "6bed724b7ef9bdd480448396ed4498c75f848bf2a1e6d2879cb2b2484cdd1a7b"
+    },
+    "sound/cyberscrag/wdeath.wav": {
+     "bytes": 20684,
+     "sha256": "24602233cca209122250ba7c284933992aa2393795ea5c528a57b9986e2fc319"
+    },
+    "sound/cyberscrag/widle1.wav": {
+     "bytes": 13465,
+     "sha256": "8902628d2201eda9396c0dc134ebda8b8d5c37dabddcd286f8387aadc6532750"
+    },
+    "sound/cyberscrag/widle2.wav": {
+     "bytes": 23094,
+     "sha256": "76af020e5c25f40ab3020bbd065a9b83b9b0a51120d47d137a7abff4eb43e193"
+    },
+    "sound/cyberscrag/wpain.wav": {
+     "bytes": 8687,
+     "sha256": "af2e8589d381e634f607048ce71200df832c9e3a32147891b5bdd2efe2ff5bf0"
+    },
+    "sound/cyberscrag/wsight.wav": {
+     "bytes": 13079,
+     "sha256": "2f9178f6515eb4cd518b418441c40d1376aeaf6f42f7791533f5f4b6da87fd68"
+    },
+    "sound/doors/alka_doorlocked.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/q2door1.wav": {
+     "bytes": 30572,
+     "sha256": "3f05bddf76379933970c532656b6350bc53820319ce1cb9d4ea9288210427eee"
+    },
+    "sound/doors/q2door2.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/dread/dread_death.wav": {
+     "bytes": 49692,
+     "sha256": "22000ff613ff52eab0605418681affaf7aeef4acc420d3dddd50a9031ac1ca38"
+    },
+    "sound/dread/dread_pain1.wav": {
+     "bytes": 29220,
+     "sha256": "67e443f78043cb9fc4213bbfbc3cd847785a66849fb7b36dd6467494487e0aec"
+    },
+    "sound/dread/dread_pain2.wav": {
+     "bytes": 23380,
+     "sha256": "914fffe3ad6c02fb78be873ee96405a40df22cd321beee2d673d0b6ebbafcde4"
+    },
+    "sound/dread/dread_sight.wav": {
+     "bytes": 70792,
+     "sha256": "50449a772b2ac778b810a69de58cb63c8bbdea529091720a41a1052b7196632e"
+    },
+    "sound/dread/dread_sight2.wav": {
+     "bytes": 58420,
+     "sha256": "f7952137b648f6376a1ba4e968679abb17fc648ede87bb0dd32f633271ad80ee"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 110256,
+     "sha256": "895cfb57c0d27369530fd5e9b29abd491a989ad0a63ddb00f05dd9e4777a5cdb"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/frogman/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 32638,
+     "sha256": "3cf3933f34c7baef52df54d5b03db40424e9f7ee72e5aa5a4dba489d71be2af7"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 27662,
+     "sha256": "ec38e73fd1ffc33cd25aa065e5f5897c21a494e380763ff80b6be482689b5e33"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 44186,
+     "sha256": "7600cd32fe980646fddcf5a9077d8d43df1bca1f2ed05bd92ce8cca273ad6636"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/armor_denied.wav": {
+     "bytes": 15854,
+     "sha256": "2ec14677f483d1a1b869af64cc30fb0dbd90a640fc071fdf2ae493d27cd746e1"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/items/shard_pickup.wav": {
+     "bytes": 18260,
+     "sha256": "388923a63b48720647b9e0f2862c35bb1d5cad2e162ace343845b3fe36b48af4"
+    },
+    "sound/items/trifecta.wav": {
+     "bytes": 16412,
+     "sha256": "00baad51adaa3f5d6664e85ae5442221db6818bfd85124c164324d22f6723ab2"
+    },
+    "sound/items/trifecta2.wav": {
+     "bytes": 32778,
+     "sha256": "f742a9cee4a53ef52fce55d5e9ddaae9c6b20d2127e16c0def6cd11b3d2d6380"
+    },
+    "sound/items/trifecta3.wav": {
+     "bytes": 10728,
+     "sha256": "a78bfc9fa4fbf0c3c1e85bee273ee053598989a09146bd29e97dda811c49a473"
+    },
+    "sound/lieut/alert.wav": {
+     "bytes": 8700,
+     "sha256": "7ebbe83ae1b5d159c9f0a0ae5f3dea126650ed5d6f98a22d1512dcfcb19a23ca"
+    },
+    "sound/lieut/objective.wav": {
+     "bytes": 10052,
+     "sha256": "aa7d6726a458eaa48bf2e20446c57360b82ac23bfbd06bad7b6e01ae95ca8b0d"
+    },
+    "sound/lieut/target.wav": {
+     "bytes": 6754,
+     "sha256": "eebd50c75585894c7d5305f6c066aaef1efaca9a59e27b80d03e8ae4d69caa69"
+    },
+    "sound/lieut/you.wav": {
+     "bytes": 7126,
+     "sha256": "6bfb031b0d69b8ae4ef2e9b201da43c523ae88de344907648d4064e07477ee1c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/conc_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/misc/door_closed.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/misc/ebell.wav": {
+     "bytes": 15220,
+     "sha256": "1693337ed8873f1159e56c2925afaa210f5c28bee4e2c42d27e29bee8e06cb5f"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 4054,
+     "sha256": "b9c44f73c8bdbc900af4f06600e0d6456a040b296612b7d0fe53391285976a44"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 4098,
+     "sha256": "4fad66341514c9aa2b31b4c2fde7563369090da9b0b3a51e08bca3100f2ec282"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5054,
+     "sha256": "d158ddc35360bc43934b7a8a9b7cc830f7510e6bb3a640813157822b27b5217a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 9726,
+     "sha256": "73b74099c8cb43ab2fb09b28b72ddd9f73f2d2a4f8a00a8e835490f366680c92"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 3226,
+     "sha256": "48551cc717e5011df78a38c6a71bb001e4f62a1858a3952311499653ff423a07"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 5802,
+     "sha256": "751050f97456a0c07e88a249d40dde96c2d14640e21670ccdde983502998dbba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/mutant/mutatck1.wav": {
+     "bytes": 6116,
+     "sha256": "410f926534f21705e78a804ce048b0c15e62fe0c68a45aae1b3741fb227551f7"
+    },
+    "sound/mutant/mutatck2.wav": {
+     "bytes": 18260,
+     "sha256": "66009d09adf71f10117c74f5004c995fd48362b2f4fcfaaa3bc2da01e66d115f"
+    },
+    "sound/mutant/mutatck3.wav": {
+     "bytes": 28840,
+     "sha256": "2dd8a615ca2be248c8370d7480f5a8ca9375d31e6af41bba603df660d31883a1"
+    },
+    "sound/mutant/mutdeth1.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/mutant/mutidle1.wav": {
+     "bytes": 81004,
+     "sha256": "8c7e8ad544d7e2470bd61d88c5cd8be1a0eb66f57aaf113f82d990ee00450073"
+    },
+    "sound/mutant/mutpain1.wav": {
+     "bytes": 56716,
+     "sha256": "49ff5f97fedc87c1ac06dc43d4ff0a0fd09fb481354b6373d607bfabc9a57a6a"
+    },
+    "sound/mutant/mutpain2.wav": {
+     "bytes": 58740,
+     "sha256": "b79f1cce60226daa3e3ca8c134da968d54ad51abd9c37ffebdf3d46c5d9f91c6"
+    },
+    "sound/mutant/mutsght1.wav": {
+     "bytes": 107316,
+     "sha256": "7e15e392edc3f2d5ae9e3bde3dfe65595a85728022245f74b81f072d75dce798"
+    },
+    "sound/mutant/mutsrch1.wav": {
+     "bytes": 101244,
+     "sha256": "44484ef4c189511fb0a8d0f2bea83e443e1f1bd51cef04f518f3820e58e88a69"
+    },
+    "sound/mutant/step1.wav": {
+     "bytes": 8140,
+     "sha256": "0d9af35156c84213ac7ffbde54d0f2518fe9d39bba4edc48c94e71bed4f7ec4d"
+    },
+    "sound/mutant/step2.wav": {
+     "bytes": 14212,
+     "sha256": "f7c81df1bff56c8aeb49891fa822c37ddcb019e97a654738a9fb8ee351d19eac"
+    },
+    "sound/mutant/step3.wav": {
+     "bytes": 4092,
+     "sha256": "89856afec31f800219c45253514d0fdf5b5bd800c32f87ba74dd0c21df181550"
+    },
+    "sound/mutant/thud1.wav": {
+     "bytes": 32428,
+     "sha256": "20ed5f20729a068801d06904365e46c9d692dec835710a9b8090d0a1956d6919"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    },
+    "sound/ogre/rogre_alert.wav": {
+     "bytes": 71728,
+     "sha256": "4f3e921b6ee236289660f7ca2ee8a4689e719423266d26a3f8b91ae29d02c6a5"
+    },
+    "sound/ogre/rogre_idle1.wav": {
+     "bytes": 110330,
+     "sha256": "a07df4a53c9e8de310b9d963bfb9c841c51e502565f39dc543bf1c025edd41d6"
+    },
+    "sound/ogre/rogre_idle2.wav": {
+     "bytes": 79416,
+     "sha256": "862258641dc3c90d2a9e5f9e2a4418eb0037eedf22cde798682a169a84f13a44"
+    },
+    "sound/player/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/player/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/player/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/player/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/player/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/player/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/player/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/rail.wav": {
+     "bytes": 97196,
+     "sha256": "396a85e1e2083f2b1eaae89a3f33a21145a643f3f50419523497719ef8e7598a"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/rider/sight.wav": {
+     "bytes": 26356,
+     "sha256": "40ace6f3beeb920ba1bbdb197f8ece18d312762a71e494726289e16703d75d91"
+    },
+    "sound/rider/step.wav": {
+     "bytes": 40524,
+     "sha256": "a43e24ecbc62d44bce466b1e682ebf64c230e03f4d79449406ce021dc8276a9a"
+    },
+    "sound/rider/thump.wav": {
+     "bytes": 15444,
+     "sha256": "af29f4e8f6debb1223aeb5d840add4ae01cb5e9f6bd9a26efeadff518f34380d"
+    },
+    "sound/scientist/allnominal.wav": {
+     "bytes": 23778,
+     "sha256": "e26f9bb3c24d9a9e0da38395048f6dacffe82d800da49d56378027250393d69a"
+    },
+    "sound/scientist/alright.wav": {
+     "bytes": 9666,
+     "sha256": "372c1aa91e6841bec2441215c894b7d149bdeaef33f907d23bb7eaf637520ce3"
+    },
+    "sound/scientist/asexpected.wav": {
+     "bytes": 15982,
+     "sha256": "306933848b673bd14d7074d59e45a8c97bc00a2897601509e52e5835e2ffc997"
+    },
+    "sound/scientist/c1a0_sci_crit2a.wav": {
+     "bytes": 28364,
+     "sha256": "f972684c74eeb51872873cc2b7053448c6cdd716b8c3535929fdbcc508d62ef5"
+    },
+    "sound/scientist/c1a0_sci_stall.wav": {
+     "bytes": 13704,
+     "sha256": "541c192ad5e8a68c76706ec17b3deceafbdc607bfc372ddfd300532f8aa1eaef"
+    },
+    "sound/scientist/cantbeserious.wav": {
+     "bytes": 13236,
+     "sha256": "fc4a8a379f70e33db79a49c667dcd9f1622de29d7b32ef3973c4ffdb5d80ee44"
+    },
+    "sound/scientist/cough.wav": {
+     "bytes": 14878,
+     "sha256": "b4e620259623347a5be3f7eaf3c531e6ea9ef2e97ac42997dd78cfee9327f7bf"
+    },
+    "sound/scientist/sci_die1.wav": {
+     "bytes": 15558,
+     "sha256": "c2306d7f9fa58f99961c347b06ef26305b99ac43ec27b2b222962e1f3a9ccce9"
+    },
+    "sound/scientist/sci_die2.wav": {
+     "bytes": 5402,
+     "sha256": "14deecb570d1e315b772713d54b7250043bb0dd5f3d5538cd0636e39a523c54f"
+    },
+    "sound/scientist/sci_die3.wav": {
+     "bytes": 3104,
+     "sha256": "075cdbc5837d91b61ad7599cdb3abf9323872816f8966c83deab9c0a6e04d7d2"
+    },
+    "sound/scientist/sci_die4.wav": {
+     "bytes": 4024,
+     "sha256": "e6ca0d4f18ac6c1246926646568618057cb70b5cee995c1c2dd69f0179b892ad"
+    },
+    "sound/scientist/sci_dragoff.wav": {
+     "bytes": 8986,
+     "sha256": "0c6a21cd5edf01e495e1258e9a76c05d62c0e3cd697e787fd43fd4bd9126483b"
+    },
+    "sound/scientist/sci_fear13.wav": {
+     "bytes": 4534,
+     "sha256": "dabce7a6c12980f947f7504da264fabb67a804d2e478b7f252ab527fb21a92d0"
+    },
+    "sound/scientist/sci_fear15.wav": {
+     "bytes": 4764,
+     "sha256": "f0d23c680ad138c3cc12da78a3e45cbf3daa47e5da9bc62a1dbb3b27389565a5"
+    },
+    "sound/scientist/sci_fear6.wav": {
+     "bytes": 5588,
+     "sha256": "ff2702b2b9e517b90ea0c2853775a4a95160edfae5af0a7f9208f07624d84281"
+    },
+    "sound/scientist/sci_fear7.wav": {
+     "bytes": 8458,
+     "sha256": "f2a39185c2d39a03b39afd7fe6f942b2f35fd17135ade8ceb4c31968c768aafa"
+    },
+    "sound/scientist/sci_fear8.wav": {
+     "bytes": 5804,
+     "sha256": "4455a29590d5f42ebbf06e600d8ba3f45acfd5000a6b8045891cbecf1d937970"
+    },
+    "sound/scientist/scream01.wav": {
+     "bytes": 14666,
+     "sha256": "b738de99aefbe3a45724914dd6eb79c0f8c219aaf733554a8a5eb94836c22320"
+    },
+    "sound/scientist/scream06.wav": {
+     "bytes": 13938,
+     "sha256": "dee8ac2058635d00458e2e74402d1cfcb5362c64259fc2c4f3b6bba31bdf6337"
+    },
+    "sound/scientist/scream08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/scientist/scream09.wav": {
+     "bytes": 6130,
+     "sha256": "85947649f5fb1491732365849a3025bf5c76c791b395cfdf421fbbd6ec58d351"
+    },
+    "sound/scientist/scream10.wav": {
+     "bytes": 5392,
+     "sha256": "fff4c0735f9c312be7cda848fc2867590437ffe9758fe685e3b4c94678ca1f48"
+    },
+    "sound/scientist/scream14.wav": {
+     "bytes": 4824,
+     "sha256": "dcb7dfb0e307b813476b2e55dceb59d8ae2b9514b1ef02034ea255fa5f086b05"
+    },
+    "sound/scientist/scream15.wav": {
+     "bytes": 3048,
+     "sha256": "37d26fe2d2b8a39d0fec0eceec0ca974ec3dd7fed33bae0d3230a934954105f0"
+    },
+    "sound/scientist/scream16.wav": {
+     "bytes": 2328,
+     "sha256": "4ff04ce8ff07af708c84dacc8df114b68620d47e8e4e4c78dfc4fd33a8a9b98d"
+    },
+    "sound/scientist/scream17.wav": {
+     "bytes": 3836,
+     "sha256": "82fb51224e06db5022adfa58f0b02353c333229ed3312f86dd9ec4f04813c37c"
+    },
+    "sound/scientist/scream18.wav": {
+     "bytes": 3066,
+     "sha256": "bfefcf745ab8d30db11f9113ecf9ba1c5bc6d9b2351c53f3f46d66e03cbea3fe"
+    },
+    "sound/scientist/scream19.wav": {
+     "bytes": 2504,
+     "sha256": "47cc414d201aadb7ba2fe0ce0567ff5360e90fd9de4a167520988513f358ed41"
+    },
+    "sound/scientist/scream20.wav": {
+     "bytes": 21310,
+     "sha256": "124cb45d3d5533572e3cfe4b42bddad2a03dc0d8de1c89a42ea57433432e3a6e"
+    },
+    "sound/scientist/scream22.wav": {
+     "bytes": 15206,
+     "sha256": "6e0a509eb2468466591622e74724c31103b8b60f5d8f29514fb57e9d9d12c9d4"
+    },
+    "sound/scientist/scream23.wav": {
+     "bytes": 21988,
+     "sha256": "8521907e8cecc22e6924d23295a5e8d31333d265ca27a9533b083b68e9da6d12"
+    },
+    "sound/scientist/scream24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/scientist/scream25.wav": {
+     "bytes": 8122,
+     "sha256": "38281749deffb4e567896f71e7bcb75d7b2e253e404a953a5eea6eeb989f156a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/spiderbot/sactiv.wav": {
+     "bytes": 17066,
+     "sha256": "f21587ba9bfd159e48c5b3aa1c6e94eac7157053e4e5699459233fb28c2631c8"
+    },
+    "sound/spiderbot/scharge.wav": {
+     "bytes": 7300,
+     "sha256": "b58064dac4e12bd6685edbfe61417a530cde1e5175336193b2fa7a292aca8ef7"
+    },
+    "sound/spiderbot/swalk.wav": {
+     "bytes": 12636,
+     "sha256": "5534fe1b11fea5406aada214681dba031ec4a01e4b660c405b679131ba07a7cc"
+    },
+    "sound/tormentor/angry1.wav": {
+     "bytes": 88890,
+     "sha256": "60f757f523a9cbb3a57c335bbeda8cedbf990b9d20a5b359e610b712a1344b4b"
+    },
+    "sound/tormentor/angry2.wav": {
+     "bytes": 90912,
+     "sha256": "2f38dddb69cf0df2c1e5b028ca06ea22d979e637afa927919e9a93876dc955d6"
+    },
+    "sound/tormentor/death.wav": {
+     "bytes": 176628,
+     "sha256": "7060ecdadac0b1c9eb3574284444932573e4af13082f01374ed8a4633387bb66"
+    },
+    "sound/tormentor/fire2.wav": {
+     "bytes": 52092,
+     "sha256": "4133a00c7ef157d291d800524a148c188a314eb5ca14246958b8ddfeb0d4fe41"
+    },
+    "sound/tormentor/idle1.wav": {
+     "bytes": 115740,
+     "sha256": "78feebc847dccab66478718b66971870f11246c416e2f2c1e9830c459e4c0347"
+    },
+    "sound/tormentor/idle2.wav": {
+     "bytes": 122218,
+     "sha256": "0270712fe40851bb21d959932b4f8f75bbe8b985e2ff383319059c656ac0ce56"
+    },
+    "sound/tormentor/pain1.wav": {
+     "bytes": 67334,
+     "sha256": "03f255d6ee0d6fb83f2a643491f4cd24d9c5ff86444a51b3cf8b5a0de3d86bbc"
+    },
+    "sound/tormentor/punch_hit.wav": {
+     "bytes": 76614,
+     "sha256": "e524d16b000237615bae3b8fed7b74726823cd4258561196f4641728047aaa26"
+    },
+    "sound/tormentor/punch_swoosh.wav": {
+     "bytes": 33044,
+     "sha256": "d0ef38ef4bf33d0c2f92b22c2a767c4efd66eefaa724df50b394958a7be5a705"
+    },
+    "sound/tormentor/sight.wav": {
+     "bytes": 94334,
+     "sha256": "34a13e6469c5e0ce2f6d18721b0cdd634731b9a9f8910a8bb8b685f63dadfaac"
+    },
+    "sound/tormentor/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/tormentor/sting2.wav": {
+     "bytes": 21674,
+     "sha256": "dd2d40459c7aa9d374efe2f219c34773f390df9f5177a83dbfa5fd638a13c542"
+    },
+    "sound/turret/alarm.wav": {
+     "bytes": 22126,
+     "sha256": "20a8a83d73a55dcc3d8a6fcb79b4ff8ecba0b5887cf3bdcdc96303f069b062ce"
+    },
+    "sound/turret/beep.wav": {
+     "bytes": 22126,
+     "sha256": "89f0e2ba68562cfc3e20272f995777c174c2681cfcf29d2ef337974009b42460"
+    },
+    "sound/turret/deploy.wav": {
+     "bytes": 105260,
+     "sha256": "5bb8c1fa8ffdf22e58ac5fb7a337916a457b9d021661742fcdbbdd7ce188c6dd"
+    },
+    "sound/turret/deploy2.wav": {
+     "bytes": 54208,
+     "sha256": "ec26b9451b67dae2929488687b7b9344a96f7538ab5c4f69e8a85602804dffc2"
+    },
+    "sound/turret/disable.wav": {
+     "bytes": 57180,
+     "sha256": "d8767dcce34c1c7f660f5868c23938da4cc379cb4001b88a10ec1aebbf9e557c"
+    },
+    "sound/turret/idle.wav": {
+     "bytes": 35784,
+     "sha256": "fba6bc2ff517ef95a999e3910c74e3594e054ede298c7b3a5659a2c31565d37c"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 43820,
+     "sha256": "32082cd1d44903409e97de782e5d9295272840e13280665a0ef3ff862b187f0f"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 47570,
+     "sha256": "0dd8defb8ecfb1ea72e6ac70ab182573775812e2d7990dd2897d02d3c38464f5"
+    },
+    "sound/weapons/spindn_click.wav": {
+     "bytes": 9986,
+     "sha256": "b84866cddb7e61eea9ca49208d427c2289d63e6e3e2f59d4d51e302573079bc7"
+    },
+    "sound/zombie2/attack1.wav": {
+     "bytes": 22914,
+     "sha256": "da5345280208ea48855526989299927268566cef77ee187035bbe969076d6605"
+    },
+    "sound/zombie2/attack2.wav": {
+     "bytes": 24072,
+     "sha256": "59245700b47794e239563cc94e3ff045fcd7dad795bcfe343d8574ec3ac525b6"
+    },
+    "sound/zombie2/attack3.wav": {
+     "bytes": 15400,
+     "sha256": "0113aad711264c05a9e43bf8dba915bc89661444d7d802efabe8d61ebb3ba13f"
+    },
+    "sound/zombie2/attack4.wav": {
+     "bytes": 20922,
+     "sha256": "0aac55ae62b62cefece56103cd7079beeb433c3764f590641876e149c4328ecc"
+    },
+    "sound/zombie2/attack5.wav": {
+     "bytes": 26086,
+     "sha256": "b58c97928b535e79973e0390512b09d3d0adea79b1b1b5a8de59bc2cde40c412"
+    },
+    "sound/zombie2/attack6.wav": {
+     "bytes": 22272,
+     "sha256": "58c429256e2f5abb9d97c99ceedb78088d8ac977eca94e994b6d1eee8bb3eb8f"
+    },
+    "sound/zombie2/attack7.wav": {
+     "bytes": 34384,
+     "sha256": "d68e81783b6583738227eac608ab7af1a4b1e1b085c1e46bd9c0d029eab4fdde"
+    },
+    "sound/zombie2/death1.wav": {
+     "bytes": 46548,
+     "sha256": "a1b9e2bcebf9c56fb56405d1ec7fe4166ac10d2b6e1acc6f01e58aec9fd63e87"
+    },
+    "sound/zombie2/death2.wav": {
+     "bytes": 47048,
+     "sha256": "5964a3c1a665c70de8302052b2b6d72ea46b0a5e07ba22cc9919e1a0ffefcca3"
+    },
+    "sound/zombie2/death3.wav": {
+     "bytes": 52636,
+     "sha256": "5c76f8bc55ecea263df880e6b683b07066b37c9f62ff589b0e999534d3c256b0"
+    },
+    "sound/zombie2/footstep1.wav": {
+     "bytes": 12966,
+     "sha256": "2a85309bea05b7c7c90a82df071822828e413cce17646a9686fa4f1264d75e48"
+    },
+    "sound/zombie2/footstep2.wav": {
+     "bytes": 16880,
+     "sha256": "d1d9e9c3811b39b67c9a6966851873ff7edf8d1407c5d9b90782b233196a4872"
+    },
+    "sound/zombie2/footstep3.wav": {
+     "bytes": 20904,
+     "sha256": "b12e9ea9b9478428b886fcaab504856393a57abd8cfdfc5ba5357ad745ee3455"
+    },
+    "sound/zombie2/footstep4.wav": {
+     "bytes": 15796,
+     "sha256": "6f82ac60991e64c8c48a3208a161b46f5b916587cb41863992dc1acb08268889"
+    },
+    "sound/zombie2/footstep5.wav": {
+     "bytes": 17800,
+     "sha256": "ca12f6ade73e5d5ba4ec1bdf680ce25afe3270bb88d702e1493b75619ec088d9"
+    },
+    "sound/zombie2/idle1.wav": {
+     "bytes": 143832,
+     "sha256": "aa203b0beb2db12beb6929fbc3646f7f119d4d31ede66b13af0412d396f7dd6d"
+    },
+    "sound/zombie2/idle2.wav": {
+     "bytes": 277026,
+     "sha256": "9496f3179e875bbb4d7442c252eac0eb2b9ef6d2269d43c141e01242ed2de7ee"
+    },
+    "sound/zombie2/idle3.wav": {
+     "bytes": 234026,
+     "sha256": "4820b03de8cebdee6fe787b5bf60724c17a0e133fdd5451176a202043f730f8e"
+    },
+    "sound/zombie2/idle4.wav": {
+     "bytes": 166352,
+     "sha256": "a515e5dc0e4fe1412a7936df5fab0f57a48c385db4fa357c1a4120671ac99617"
+    },
+    "sound/zombie2/idle5.wav": {
+     "bytes": 62782,
+     "sha256": "c6e4e2f26769400b7ca3b08339af089ba28bc063447d642e10cffffc6e03a485"
+    },
+    "sound/zombie2/idle6.wav": {
+     "bytes": 47274,
+     "sha256": "9ad1ced551cb42764fd88baf26ee09dc72d1852fa2da7405fde370d3e4d69a01"
+    },
+    "sound/zombie2/idle7.wav": {
+     "bytes": 45614,
+     "sha256": "41783a7682d5f8bb91aff8308b8657504cc8f0460b5ca436a5d0fb1c93357c85"
+    },
+    "sound/zombie2/idle8.wav": {
+     "bytes": 73070,
+     "sha256": "8f390d861feda3fb3950b0f33ce3efbfa8eda214533324674ac40b6e227b6975"
+    },
+    "sound/zombie2/punch1.wav": {
+     "bytes": 9218,
+     "sha256": "db6787efe0a0b8df5da690b91afe46a2199911b661fc9de1cfffc00b6bb8c46c"
+    },
+    "sound/zombie2/punch2.wav": {
+     "bytes": 8032,
+     "sha256": "747aabd6237176ae1bc62669cb08c7ec65fb26aa2147f6a3e1ab43f02ace7322"
+    },
+    "sound/zombie2/punch3.wav": {
+     "bytes": 13076,
+     "sha256": "05bb75533252d15983a944263789de5ee51187e518f4544fd1915b57ba726c7e"
+    },
+    "sound/zombie2/punch4.wav": {
+     "bytes": 13198,
+     "sha256": "d07556e7fc774958a6105564a990c51a0dab64fcf9508475617921a0ac5b961c"
+    },
+    "sound/zombie2/sight1.wav": {
+     "bytes": 73234,
+     "sha256": "387534044f10592ca6bc7a96b8e782c7b51de87b907e79a8f410d535e17d37ee"
+    },
+    "sound/zombie2/sight2.wav": {
+     "bytes": 52224,
+     "sha256": "cbc95608d4553d0bae66411d69875210e6fc6d728bd30deb6bbce7aabbacb773"
+    },
+    "sound/zombie2/sight3.wav": {
+     "bytes": 63072,
+     "sha256": "cbbcdb6da59d830a3be66095053259b17a90cc6501728ed1aa50d9524818f99b"
+    }
+   },
    "sha256": "e5de412650faace357cc258869903e068d95711cf7d57a425e0ec5643b11e188",
    "timestamp": "2022-11-18T17:02:06.000Z"
   },

--- a/json/by-sha256/e1/e1f7b48e210e56c793105497439c88dc2ada1bd2bbb8be5947ec2f99f0965797.json
+++ b/json/by-sha256/e1/e1f7b48e210e56c793105497439c88dc2ada1bd2bbb8be5947ec2f99f0965797.json
@@ -13,6 +13,413 @@
   },
   "DEVKIT.ZIP": {
    "bytes": 247510,
+   "files": {
+    "SRC/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "1997-04-26T01:56:08.000Z"
+    },
+    "SRC/AI.QC": {
+     "bytes": 15070,
+     "sha256": "1bc5ac7d3a8c24c72b9696f2ba45acb75998e76fc72faaa591b92c62ce4cb904",
+     "timestamp": "1997-09-10T23:32:18.000Z"
+    },
+    "SRC/AMTEST.QC": {
+     "bytes": 1697,
+     "sha256": "8dd158020b8c0be6988b0f1fbe03990372fb769442dbaf85248ef8c0e18645ee",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "SRC/BLOODCB.QC": {
+     "bytes": 13403,
+     "sha256": "c8426c9b81642080c6ba4047b555281486dc5bc4ecce17b73c399690959eebeb",
+     "timestamp": "1997-09-27T11:40:28.000Z"
+    },
+    "SRC/BOSS.QC": {
+     "bytes": 12411,
+     "sha256": "674893303bff9280f134066f168b06dd2dd1d58591c42acc2c70c6e2a4b9ba82",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "SRC/BUTTONS.QC": {
+     "bytes": 2967,
+     "sha256": "bac8945458742087851cc134ec1bfc7e62fd2f1393be566e1cc359e2f53279ab",
+     "timestamp": "1997-08-23T14:46:42.000Z"
+    },
+    "SRC/CHAINLIT.QC": {
+     "bytes": 4523,
+     "sha256": "3f2e1d1dc0e3838eef175cab6781e71800e3bd4f28d64c99ef536df35c486ead",
+     "timestamp": "1997-09-18T22:37:44.000Z"
+    },
+    "SRC/CLIENT.QC": {
+     "bytes": 36221,
+     "sha256": "08219cbacc0fa3ebc130f011bc862c1e30baf3961e430313f979790a67f6996c",
+     "timestamp": "1997-09-27T13:36:42.000Z"
+    },
+    "SRC/COMBAT.QC": {
+     "bytes": 7108,
+     "sha256": "1c38842c474482bdbafcf671a12ca05c7aab706515301995d23212f74d985d17",
+     "timestamp": "1997-09-27T11:09:36.000Z"
+    },
+    "SRC/CUTSCENE.QC": {
+     "bytes": 19468,
+     "sha256": "627192de96ea27d7473991607a0b3b46bba8be5bde3d47ee8f3d6abb8bb698bb",
+     "timestamp": "1997-09-21T17:37:50.000Z"
+    },
+    "SRC/DEFS.QC": {
+     "bytes": 18821,
+     "sha256": "dfd25f8e5721fc0002a4d1ca0378be6381de440c87d0b982d5a5264364838f82",
+     "timestamp": "1997-09-26T00:25:06.000Z"
+    },
+    "SRC/DEMON.QC": {
+     "bytes": 12403,
+     "sha256": "086f718a104f09d7c9cb23e378d915958c136e486e78a459da68d79bea48d72c",
+     "timestamp": "1997-05-03T19:46:42.000Z"
+    },
+    "SRC/DOG.QC": {
+     "bytes": 12854,
+     "sha256": "8b208bf968fc9743ca3ec8ec7b9b193f40829831e6ece4095147507bc23aaf3b",
+     "timestamp": "1997-05-03T19:47:18.000Z"
+    },
+    "SRC/DOORS.QC": {
+     "bytes": 17122,
+     "sha256": "9748d0948c9ed5dc403e4503d05fdb77905a7b56792db5f978407275088daacd",
+     "timestamp": "1997-08-25T23:32:50.000Z"
+    },
+    "SRC/ENFORCE2.QC": {
+     "bytes": 16286,
+     "sha256": "12fd55e4e0fc3f789c353e16543bee606d161bcfce058077be3a3b86d568e1b8",
+     "timestamp": "1997-09-26T22:51:14.000Z"
+    },
+    "SRC/ENFORCER.QC": {
+     "bytes": 11451,
+     "sha256": "453afe2c5f329ebcd1cc1e0a119c345c05ac91054755b1e607abc77a2945157c",
+     "timestamp": "1997-06-13T23:12:44.000Z"
+    },
+    "SRC/FIGHT.QC": {
+     "bytes": 7208,
+     "sha256": "c68c3310e794200ef61c79ed9665490b3e893ff7d2d6243e5f6aeda7d9885925",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "SRC/FISH.QC": {
+     "bytes": 8793,
+     "sha256": "1aed4cbc4c77928e830293cee46b13d0b370a91555707130f73f6f7a0a7afef5",
+     "timestamp": "1997-05-26T22:47:48.000Z"
+    },
+    "SRC/FLAG.QC": {
+     "bytes": 141,
+     "sha256": "143f0b896c7515dcdaaf5b436d130fe1ffb6fa67cad2a34ad4639724201b3445",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "SRC/FRAMES.QC": {
+     "bytes": 6746,
+     "sha256": "7a24c295dfdff3c1aab79e1d55a89c1ee2002d96f25792ef655151814d98565f",
+     "timestamp": "1997-09-18T01:29:16.000Z"
+    },
+    "SRC/HIPSOUND.QC": {
+     "bytes": 2335,
+     "sha256": "9f46fad432d22a32c83e7180ad2fc3883815aa3431ff9eb95ad75068cb795cbc",
+     "timestamp": "1997-05-23T19:39:34.000Z"
+    },
+    "SRC/HIPSUBS.QC": {
+     "bytes": 644,
+     "sha256": "8be7e852d0627f32c027e31197143584254c4e03dfc09523443e1b91443c9cbd",
+     "timestamp": "1997-03-21T22:08:16.000Z"
+    },
+    "SRC/HKNIGHT.QC": {
+     "bytes": 21137,
+     "sha256": "cde24b006b271d39e399875386d126520cc1e50c2f00ae5e93047039084f5c01",
+     "timestamp": "1997-08-28T21:30:02.000Z"
+    },
+    "SRC/HOSTAGE.QC": {
+     "bytes": 16100,
+     "sha256": "7ebd74c5cbd278c04115812021e9e82ab9f391cdfc9fa7df40f8cd4d669fb108",
+     "timestamp": "1997-09-27T13:39:08.000Z"
+    },
+    "SRC/ITEMS.QC": {
+     "bytes": 35610,
+     "sha256": "f480817037f36facdb17f3b1e45f0abf8dc635112d1dfd2a70c2d55ea4f86c1b",
+     "timestamp": "1997-09-27T14:25:42.000Z"
+    },
+    "SRC/JCTEST.QC": {
+     "bytes": 222,
+     "sha256": "0b356238bdae38139e36fb7f9ed5a72e65accee92b48f25035b79ec315a7da06",
+     "timestamp": "1996-09-26T11:15:38.000Z"
+    },
+    "SRC/KNIGHT.QC": {
+     "bytes": 10404,
+     "sha256": "8e941d6a87b04532a982c10a3468a4d2a2b93b82263567cc4203264e19a76716",
+     "timestamp": "1997-05-03T19:51:00.000Z"
+    },
+    "SRC/MISC.QC": {
+     "bytes": 30809,
+     "sha256": "2aaf51da324f3d87c2bc38f62f82bf2a69559d64da7e2ded63c6b3291a54ca21",
+     "timestamp": "1997-09-27T09:54:46.000Z"
+    },
+    "SRC/MODELS.QC": {
+     "bytes": 8996,
+     "sha256": "d11fd0939293244962c5a40766e1dce246bde98eb0d42c87eb530a58d6eca64d",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "SRC/MONSTERS.QC": {
+     "bytes": 5403,
+     "sha256": "b5c7313f649593e50eb9c3695f7791269674f1e6867b6fa48d4d2c43e16304e0",
+     "timestamp": "1997-08-16T12:40:00.000Z"
+    },
+    "SRC/OGRE.QC": {
+     "bytes": 17695,
+     "sha256": "dcffdc70f882ae7b4262380848b9870a2b944d65bd1271e2aa59770d0b351e14",
+     "timestamp": "1997-06-14T23:24:50.000Z"
+    },
+    "SRC/OLDONE.QC": {
+     "bytes": 9571,
+     "sha256": "9ab9a4bc0acd255cd45515e2645026174cdfc38ec656b7e46319bd0e8b76d14c",
+     "timestamp": "1997-03-21T23:14:22.000Z"
+    },
+    "SRC/PBEAM.QC": {
+     "bytes": 4440,
+     "sha256": "5c3e3a8f0cb46341bd5678710e8cca1a1ceab1b8a7c8866a5af867135e6ca42e",
+     "timestamp": "1997-09-27T10:57:30.000Z"
+    },
+    "SRC/PLATS.QC": {
+     "bytes": 11418,
+     "sha256": "6caee29a961ea619e7bd0f9778ee361cec3329272b32be47b473233e507408fb",
+     "timestamp": "1997-09-21T13:51:22.000Z"
+    },
+    "SRC/PLAYER.QC": {
+     "bytes": 27918,
+     "sha256": "8001495da354517a6dbb39fc6e70c59ac10c24200f3f1e1b6e373e7458620f09",
+     "timestamp": "1997-09-27T10:42:58.000Z"
+    },
+    "SRC/PROGDEFS.H": {
+     "bytes": 2598,
+     "sha256": "99e562ac15081804245e7c7018956f2241cffa00a024a954c97183248bd00ea4",
+     "timestamp": "1997-09-27T14:26:12.000Z"
+    },
+    "SRC/PROGS.SRC": {
+     "bytes": 959,
+     "sha256": "d3280293fe595e48d05a85f76558cbb1ceb30cf73d869fb1c8f69f00949d650c",
+     "timestamp": "1997-09-21T13:48:54.000Z"
+    },
+    "SRC/SHALRATH.QC": {
+     "bytes": 8661,
+     "sha256": "95c89baacc293f33c3e4b7c35a57a87b9fe706dc0ea94e6f099a1fcb107f717b",
+     "timestamp": "1997-05-03T19:43:46.000Z"
+    },
+    "SRC/SHAMBLER.QC": {
+     "bytes": 15204,
+     "sha256": "976c9cd5c8784c9194d67a5f56795bc38179f9e424d70d64a002d9148d1202c9",
+     "timestamp": "1997-07-09T23:59:44.000Z"
+    },
+    "SRC/SOLDIER.QC": {
+     "bytes": 10537,
+     "sha256": "c867444ae1ccdecc181681848aa5c2fdf8513370752972ba22388e659bb7b111",
+     "timestamp": "1997-05-03T19:42:48.000Z"
+    },
+    "SRC/SPEAR.QC": {
+     "bytes": 5415,
+     "sha256": "1bad1cdd5328673a385b34fad1dea7493bb69a7de4326a770fee5db2b07854f7",
+     "timestamp": "1997-02-24T19:18:34.000Z"
+    },
+    "SRC/SPRITES.QC": {
+     "bytes": 450,
+     "sha256": "c00564e7ca0ab70d7891931ff333461ff90aa6052f46e8ebb02f59de6e03787d",
+     "timestamp": "1996-09-26T11:15:40.000Z"
+    },
+    "SRC/STUNNER.QC": {
+     "bytes": 6028,
+     "sha256": "cda9d13fd93549f345d2a443528f05e63be1e0266a208cd56a8a6dbf273e4761",
+     "timestamp": "1997-06-25T21:38:56.000Z"
+    },
+    "SRC/SUBS.QC": {
+     "bytes": 6063,
+     "sha256": "8d1f8223ff025eb3341971f629d200f44dea03a0ae9093e87a7ce7d11294fb67",
+     "timestamp": "1997-05-29T22:20:40.000Z"
+    },
+    "SRC/TARBABY.QC": {
+     "bytes": 7792,
+     "sha256": "ad2807bda6611ba90035be53f689290f7e6514ec86990560965a9c72ecd2ccd9",
+     "timestamp": "1997-05-03T19:44:40.000Z"
+    },
+    "SRC/TRIGGERS.QC": {
+     "bytes": 17235,
+     "sha256": "4bf0214b5f7da671420ead56e0b9ff87e622903e95a2142ab3502870d2b7a7fc",
+     "timestamp": "1997-09-21T19:33:22.000Z"
+    },
+    "SRC/TROG.QC": {
+     "bytes": 18248,
+     "sha256": "9682b8c37486a51d2533fe9fbf8964de9421a670f4ed60118cf0949f2e44ec6d",
+     "timestamp": "1997-09-18T22:50:14.000Z"
+    },
+    "SRC/TURRET.QC": {
+     "bytes": 4859,
+     "sha256": "7420821496da7f67ece62eaf5d169b9ddadcb91daa7e4acafd2a2f860c021e0a",
+     "timestamp": "1997-09-22T23:28:58.000Z"
+    },
+    "SRC/WALL.QC": {
+     "bytes": 5848,
+     "sha256": "42448cca057ec874f5b6358e3ecbf9a3fb29a398202c929edf0e9a3bc3084102",
+     "timestamp": "1997-09-15T23:09:32.000Z"
+    },
+    "SRC/WEAPONS.QC": {
+     "bytes": 35643,
+     "sha256": "6b14c7e1d194cb9fc17f892b46ba18d35507e9927b00cea3c90d729adadc28fe",
+     "timestamp": "1997-09-27T11:52:02.000Z"
+    },
+    "SRC/WIZARD.QC": {
+     "bytes": 11591,
+     "sha256": "abfedaafc4759566d80fba20239c50afe53a2f9a3a36c3cf19dff6b538b83df4",
+     "timestamp": "1997-09-27T09:32:20.000Z"
+    },
+    "SRC/WORLD.QC": {
+     "bytes": 12742,
+     "sha256": "71dc087633493af3eae486d128bc87501484f2d83184b0f38a2107ad270f8ec9",
+     "timestamp": "1997-09-27T09:27:00.000Z"
+    },
+    "SRC/ZERST.QC": {
+     "bytes": 2371,
+     "sha256": "6b4e81436031e199ce89a42a6bbb9625e5956fe3dde7c118547f970fe0ab7bbc",
+     "timestamp": "1997-09-21T17:49:14.000Z"
+    },
+    "SRC/ZOMBIE.QC": {
+     "bytes": 27492,
+     "sha256": "ec17f24b1a8f11d64236b27a7c41eea30f06e3cfd0621f6e66ef280c32db232c",
+     "timestamp": "1997-09-22T23:39:10.000Z"
+    },
+    "SRCQW/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "1997-07-28T21:10:10.000Z"
+    },
+    "SRCQW/BLOODCB.QC": {
+     "bytes": 13145,
+     "sha256": "1bd9eadf61ed00a0ea12a945abb49a34f63a367da3b0426beb4ca830721ceef8",
+     "timestamp": "1997-09-27T11:40:24.000Z"
+    },
+    "SRCQW/BUTTONS.QC": {
+     "bytes": 2966,
+     "sha256": "14c379b1989d5ff71604e07497e7b07aca44a773b36dbc6a1f9d37810dd7cdf4",
+     "timestamp": "1997-08-23T15:28:24.000Z"
+    },
+    "SRCQW/CHAINLIT.QC": {
+     "bytes": 5011,
+     "sha256": "3cf0baf29473cf0786f8e19ea913349ffa8ec92edd4e00ee9e8b3f8ba6eedbf4",
+     "timestamp": "1997-09-18T22:37:50.000Z"
+    },
+    "SRCQW/CLIENT.QC": {
+     "bytes": 36029,
+     "sha256": "ccd2beee6d471bd3608bdf999136e56d7a3ab03d9ec87cf8eaea73061d968dec",
+     "timestamp": "1997-09-27T13:30:22.000Z"
+    },
+    "SRCQW/COMBAT.QC": {
+     "bytes": 7956,
+     "sha256": "1059bff0421faaabe26a9966ff0cb3589d2ea3d4402b5ed2ce403374030c15e6",
+     "timestamp": "1997-09-27T11:09:32.000Z"
+    },
+    "SRCQW/DEFS.QC": {
+     "bytes": 26113,
+     "sha256": "3ab794eda73e1eb89c666fc614eba42198a94bba904d20512faaf32ddbfe19d0",
+     "timestamp": "1997-09-27T11:14:28.000Z"
+    },
+    "SRCQW/DOORS.QC": {
+     "bytes": 17200,
+     "sha256": "56fce7bd427cb0cebc0e63466eabc197d4f326e087ca1ceb03b1ff6bf9ac500b",
+     "timestamp": "1997-08-16T13:42:08.000Z"
+    },
+    "SRCQW/FRAMES.QC": {
+     "bytes": 6784,
+     "sha256": "5f7e16a0e5c5c209f8e4be62fac95ff0569e31bb471dbd1f286a926f6387f63f",
+     "timestamp": "1997-03-15T14:03:50.000Z"
+    },
+    "SRCQW/HIPSOUND.QC": {
+     "bytes": 2335,
+     "sha256": "9f46fad432d22a32c83e7180ad2fc3883815aa3431ff9eb95ad75068cb795cbc",
+     "timestamp": "1997-05-23T19:39:34.000Z"
+    },
+    "SRCQW/ITEMS.QC": {
+     "bytes": 45004,
+     "sha256": "47310faa9ae7f2a273bfd279a7e8012da82fc67f9970016649ebafc582867f81",
+     "timestamp": "1997-09-27T13:17:16.000Z"
+    },
+    "SRCQW/MISC.QC": {
+     "bytes": 27585,
+     "sha256": "c1b3a778cf05de2cad657d56ce273209cf6d21d638c4cc18492b28bb72eae813",
+     "timestamp": "1997-08-18T00:06:00.000Z"
+    },
+    "SRCQW/MODELS.QC": {
+     "bytes": 9788,
+     "sha256": "777610df9cb20bcdff5cac02db6021d9da21f4dce18b93efa00495a4feee86c0",
+     "timestamp": "1996-12-05T19:24:42.000Z"
+    },
+    "SRCQW/PBEAM.QC": {
+     "bytes": 4799,
+     "sha256": "2c937c892a8b826481e8afdbb4e7896863fd9b4abbcaf43b8a3d60c461719768",
+     "timestamp": "1997-09-27T10:57:36.000Z"
+    },
+    "SRCQW/PLATS.QC": {
+     "bytes": 11314,
+     "sha256": "d529bfcf277b58ad97a2fed3885f94b37e5b6fffd83c8a9173fceea231d31b20",
+     "timestamp": "1997-09-27T11:13:32.000Z"
+    },
+    "SRCQW/PLAYER.QC": {
+     "bytes": 30155,
+     "sha256": "780c6b4c8996e6c8ae489441311f4a9f08c54828cf9435a9348f7c1118003975",
+     "timestamp": "1997-09-27T10:42:52.000Z"
+    },
+    "SRCQW/PROGDEFS.H": {
+     "bytes": 2541,
+     "sha256": "a96dc6284f00d401a209e2ee61c479a088320bf5237dc1fd157d8888c308daca",
+     "timestamp": "1997-09-27T13:30:38.000Z"
+    },
+    "SRCQW/PROGS.SRC": {
+     "bytes": 396,
+     "sha256": "d60b86cb175bd25a4a29a732350bf6368e93a9ad696a72d3d9be59798547c3dc",
+     "timestamp": "1997-09-27T11:15:02.000Z"
+    },
+    "SRCQW/SERVER.QC": {
+     "bytes": 2845,
+     "sha256": "86065de6e882dde75a527b4cecc8800663fe766d8180ef8c8864adeac121c8f2",
+     "timestamp": "1997-08-18T00:38:30.000Z"
+    },
+    "SRCQW/SPEAR.QC": {
+     "bytes": 5415,
+     "sha256": "1bad1cdd5328673a385b34fad1dea7493bb69a7de4326a770fee5db2b07854f7",
+     "timestamp": "1997-02-24T19:18:34.000Z"
+    },
+    "SRCQW/SPECTATE.QC": {
+     "bytes": 2048,
+     "sha256": "568efb5926b7f523b3dd7d4b3dd0f84dd2736f2de625632561a7f6b0db451524",
+     "timestamp": "1997-08-11T15:17:36.000Z"
+    },
+    "SRCQW/SPRITES.QC": {
+     "bytes": 486,
+     "sha256": "b1732d66da320e788f55f3eb2f43f086ae1ecfc41b35536d0dc2a5fbf6146d47",
+     "timestamp": "1996-12-05T19:24:44.000Z"
+    },
+    "SRCQW/SUBS.QC": {
+     "bytes": 6409,
+     "sha256": "6143a305e6592276376c1999569e0d4dc1394c18051b29615a78d5c8b5f77121",
+     "timestamp": "1997-08-11T22:21:52.000Z"
+    },
+    "SRCQW/TRIGGERS.QC": {
+     "bytes": 16892,
+     "sha256": "aaedc7c5a4dd7f1296bc3ac666a1dbab592208de9f850cafef0f410ee904c277",
+     "timestamp": "1997-08-16T13:11:54.000Z"
+    },
+    "SRCQW/WALL.QC": {
+     "bytes": 5722,
+     "sha256": "21d816f709f911140998863643b1d0768ebb51e75c64c37014d3257aa417d90a",
+     "timestamp": "1997-08-11T22:56:48.000Z"
+    },
+    "SRCQW/WEAPONS.QC": {
+     "bytes": 37115,
+     "sha256": "3c524cd5f1204cba0c3a8bd1b2f73a2090a96203500139db9bda8c68ed08e376",
+     "timestamp": "1997-09-27T11:52:08.000Z"
+    },
+    "SRCQW/WORLD.QC": {
+     "bytes": 12192,
+     "sha256": "6e9c162a157a808b9242f05c356034b8ac54aabf18e941a188eab06d7812ebbe",
+     "timestamp": "1997-08-16T13:15:20.000Z"
+    }
+   },
    "sha256": "4a2e7433137bdda380cb0740f9d3f35bab1e83c183aa2cadc9192e92e17b7161",
    "timestamp": "1997-09-27T14:42:06.000Z"
   },
@@ -23,6 +430,512 @@
   },
   "PAK0.PAK": {
    "bytes": 25139055,
+   "files": {
+    "autoexec.cfg": {
+     "bytes": 24,
+     "sha256": "477c03475016ff97e85fa2d60f58bcfc16873bc5a21ee4a5330c403460b881d9"
+    },
+    "gfx.wad": {
+     "bytes": 116836,
+     "sha256": "ebe8807ee56f282afabd53ac885d71b66a5d07ee2d511f1f08b173208d2bcf68"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "c913f97706b3425e4e3df50c9105a9f1cfdc450de81b2763298b183a5c0fa3bb"
+    },
+    "maps/start.bsp": {
+     "bytes": 760484,
+     "sha256": "b0c08384fcc8813e89f041f0aa46c8bd09b1a3eabf0e035cad2f9c418e461a0d"
+    },
+    "maps/zer1m1.bsp": {
+     "bytes": 1166340,
+     "sha256": "801d31585b3786966c29059c6a8d24001cf73735704ad8804f27094eea2138e9"
+    },
+    "maps/zer1m2.bsp": {
+     "bytes": 423856,
+     "sha256": "20b5749cc420fa59694795fdaf6f42e34811966a6c9264ca4ddc6bd49332ef0c"
+    },
+    "maps/zer1m3.bsp": {
+     "bytes": 2579106,
+     "sha256": "4b9809257ee3aa6757a6847932b316cafb4b823db369ba47bfa4deee39651e40"
+    },
+    "maps/zer1m4.bsp": {
+     "bytes": 1985644,
+     "sha256": "e056bcbe4afc74e8e74826e5d1fd1d844aae550ac6e4554cf97c7f58a0279e70"
+    },
+    "maps/zer1m5.bsp": {
+     "bytes": 1404988,
+     "sha256": "1a61d62e0a0d375ba54bb1f88736ecece61b3cb37b6516604692df0cc5fa3120"
+    },
+    "maps/zer1m6.bsp": {
+     "bytes": 2051484,
+     "sha256": "eb737d4f61af98e0841ca91cb8ca37bf4eaeee5771569ede3631514d68fad15a"
+    },
+    "maps/zer1m7.bsp": {
+     "bytes": 2776660,
+     "sha256": "53ea9228a88031d56a9aae28c4265df3edcacde3dd46e59787a0f41e3f01bc30"
+    },
+    "maps/zerdm1.bsp": {
+     "bytes": 1096836,
+     "sha256": "6c995b3603ff0c548226f1188059eb1468fc366410263edea87a5b2d83343109"
+    },
+    "maps/zerdm2.bsp": {
+     "bytes": 1787388,
+     "sha256": "dd9becf466c8bd8e6f4058124653ff9e700a789426937c11ccd9fc4637b877c6"
+    },
+    "maps/zerdm3.bsp": {
+     "bytes": 1416170,
+     "sha256": "89c9df2019e0e9d40797ace92b6580a70b3bd4f804e6614e542db2c5bb2b01e9"
+    },
+    "maps/zerdm4.bsp": {
+     "bytes": 394170,
+     "sha256": "9f77b8f1edd202e8996cbcad95620a5f7bbf3faac971e720b3718036501b08f7"
+    },
+    "maps/zerdm5.bsp": {
+     "bytes": 256970,
+     "sha256": "3d5c2e19c38ba7a6aed8947b37a0dad1eac6a0f7fb3320df5177fa4793703d08"
+    },
+    "maps/zerend.bsp": {
+     "bytes": 586764,
+     "sha256": "f049e9afe473b2cd93603b8818861714d8e63f272889a14867271423fcedb6da"
+    },
+    "progs/bbg.mdl": {
+     "bytes": 190836,
+     "sha256": "3bac35175b2808bad33e3b7e7c2c54b3d9181c5b3743aa68d803dbe58edf0eea"
+    },
+    "progs/bloodcb.mdl": {
+     "bytes": 28036,
+     "sha256": "83f0de29aa0f9e9f1d383895da374a5313aa2252edb306eb7bd69bd71660321c"
+    },
+    "progs/buzzsaw.mdl": {
+     "bytes": 10498,
+     "sha256": "8173fd2a525fbe11f95f5e98a17bb532c94eb74dfef3a513eed4d2273747576d"
+    },
+    "progs/courage.mdl": {
+     "bytes": 27964,
+     "sha256": "7044d59eec04c623bad8b04f1cd7066558920fb44c4f029ff15c3cebdd5512b7"
+    },
+    "progs/demon.mdl": {
+     "bytes": 184933,
+     "sha256": "57b29f15b1e1c506ab509b9ed02e2a06c08d09fc62e9a676c13c1fd8da36fed7"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 224812,
+     "sha256": "af9095cffbc74edc9d98d4e4e341736e304404df52983be33616da84d6463c87"
+    },
+    "progs/g_cgun.mdl": {
+     "bytes": 73603,
+     "sha256": "e17c3e884c66fae33057d3682f6f5f71f94f971fa3c56a695dc8687be3aad80d"
+    },
+    "progs/g_dshot.mdl": {
+     "bytes": 71894,
+     "sha256": "9f5973b2db81e67569d498ae880c4ebdf1f886fac695df50ebd93cfe5b79da0c"
+    },
+    "progs/g_light2.mdl": {
+     "bytes": 165257,
+     "sha256": "a303ab4e92b2290f99b1ed0db2fd7ac81100537de147afacee54b268ad3d1608"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 161064,
+     "sha256": "b182cf8e7915d1860f37634a610905359c7a325f4ac13f1ef5b6fc2393efe182"
+    },
+    "progs/g_stun.mdl": {
+     "bytes": 80285,
+     "sha256": "78742513c85f6104386c1ede3e0b9d40decb04044c50a3ce5f6ea97941d30820"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 59539,
+     "sha256": "c66cc4f2c8aee10b9b9dfde86a12819eea6df55880763bf6e0e0fc312cde016b"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 12416,
+     "sha256": "2fff2f36173080827a298870a956fb11ad30f34aa0342ba5ca2c8bd6509edf57"
+    },
+    "progs/h_player.mdl": {
+     "bytes": 16985,
+     "sha256": "225852fddce81fed5e7590c269a14a91166f5ea00f3cac6a74ff496b4c0fb8f4"
+    },
+    "progs/h_trog.mdl": {
+     "bytes": 28778,
+     "sha256": "13302ec9240863651316e87733455f5fb5753f35278d8600bc9f6961e11b0238"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 492976,
+     "sha256": "1cd65b15a2c368df6ea231eb17f05ba5e40e046c1ac59b6e891fa690c244ac07"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 59078,
+     "sha256": "6a7022fa8210771be206034a2b0ebeb59f6fc79719d499ac01811a4ff32eb08a"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "b4116dd10673155069d7d326fe16439596cbfbb2f6c8c5b31001fcf7e70355e1"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 16228,
+     "sha256": "16a1b41734ec932fe749051b31bd8b577af097e28bcaa930783fb84f5d51610d"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 22228,
+     "sha256": "71ceb28d923fa713eb1537c898e84e1b2bb94c17955fc39946255ea5673dfa0c"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 6047,
+     "sha256": "582f7203c44ef28a0f8a51a13b7191ea2909e121e16d51819b5b5f607b672a2a"
+    },
+    "progs/s_cg_1.spr": {
+     "bytes": 864,
+     "sha256": "f39783767087d9f02e8b09797b4ccece6ae19aaee7136291dd33e522da0149f5"
+    },
+    "progs/s_cg_2.spr": {
+     "bytes": 864,
+     "sha256": "c7191728de66e5d167df59d0b204ce96b8ba9b032b44c1befd2c854277cde7e0"
+    },
+    "progs/s_cg_3.spr": {
+     "bytes": 864,
+     "sha256": "5c4a2ceaa07fd633cbe5497e8604e553de6890245c9ff631f0520f438aa15aab"
+    },
+    "progs/s_rain.spr": {
+     "bytes": 33100,
+     "sha256": "4c0bf4b61b6cd263d3f0453f7f050c94a30708f3d9604a44d50cfca1c232444b"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 153429,
+     "sha256": "f9d50e7819ba91cf29454d6ff4905d5e6f9c0454b351252db7e3db427ce79588"
+    },
+    "progs/stunner.mdl": {
+     "bytes": 13472,
+     "sha256": "e6648c7cc191a58f9fda4309a4e08162d3513cdc31fba68b8623db1721b1be36"
+    },
+    "progs/tgib1.mdl": {
+     "bytes": 19760,
+     "sha256": "1939b9cfed1c4d82cfb7034d3d9fc4b3dfa1233126ff2e4962533bdcf9ea3ba1"
+    },
+    "progs/tgib2.mdl": {
+     "bytes": 53712,
+     "sha256": "f6e2e84f7bdb837f3b9f4bd0a3dff363985293a141d23ecbf33fb5997b3835df"
+    },
+    "progs/tgib3.mdl": {
+     "bytes": 64372,
+     "sha256": "a26e8802c5c0662ad0562ad49f487282ef43751ba0a70a3fe4ff794982bed19a"
+    },
+    "progs/tgib4.mdl": {
+     "bytes": 20484,
+     "sha256": "f7ec6242209753a3655557f8459de2516f6205e666cf7a6cc09a465eeac15230"
+    },
+    "progs/tgib5.mdl": {
+     "bytes": 2545,
+     "sha256": "b7756a235ce35f96d1ba0681207441ed0ffa60628b8663dc52d880cc3ba4726f"
+    },
+    "progs/tracer.mdl": {
+     "bytes": 11973,
+     "sha256": "928bc71a3bf560377bf08d0b38e7e0060e02d0f3f12ce49fe3fa8686021f8295"
+    },
+    "progs/tree.mdl": {
+     "bytes": 101704,
+     "sha256": "f5dad886e64ef946b0ad0aba3a06da419579911c5248ee856d2d503e40c4beab"
+    },
+    "progs/trogball.mdl": {
+     "bytes": 136671,
+     "sha256": "e0f0ac46b0173ddf761210d34334dc1b07196f0b8941d6027a5831355f7bd0e8"
+    },
+    "progs/troglod.mdl": {
+     "bytes": 155623,
+     "sha256": "93d01da2c0aa7d0ff26d685a5230cffa9a4f2d732f4a84192e2199949a224281"
+    },
+    "progs/turlaser.mdl": {
+     "bytes": 22264,
+     "sha256": "d47b2690710787999c2c565610de70a9a262176a0652f230530041cd293943f2"
+    },
+    "progs/turret.mdl": {
+     "bytes": 218092,
+     "sha256": "d68136641c97b0680939bf154dd98d79528f02ecfa27e11a723ee413565c4081"
+    },
+    "progs/v_cgun.mdl": {
+     "bytes": 62283,
+     "sha256": "c0803b83613ae3c91061f45b71b9a183269ed3afc02baab895957cfc57494562"
+    },
+    "progs/v_dshot.mdl": {
+     "bytes": 77102,
+     "sha256": "8b54bab3a0fc20bbe27ed1ef204fc4dc21c8c6ab0d9a6efa82038d570de5aacf"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 178333,
+     "sha256": "37d41f62604af8f7cedd55d84e02988b5d06e2604cb636f81d505835e493844f"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 184952,
+     "sha256": "d113effd0d5b436c468269c245647e369f26b569f3fb9031f874a7f6a5dde574"
+    },
+    "progs/v_stun.mdl": {
+     "bytes": 62074,
+     "sha256": "2e293a149a9afbb9e6e61a1aeae8af25891d2909264ce5b6e687648f61f5db7c"
+    },
+    "progs/warp2.mdl": {
+     "bytes": 76043,
+     "sha256": "ed80eddf26e304083cd1a08349a900b9e0b4c9c91ea4e9d49d75a838b916916d"
+    },
+    "progs/wings.mdl": {
+     "bytes": 116760,
+     "sha256": "d462a4c2ec13e85ba68cac60e8ed10cc863e7862a41744e4bc396163ae000dca"
+    },
+    "progs/zerlogo.mdl": {
+     "bytes": 33380,
+     "sha256": "b305250e2c537f616557219eb81ac571f76588ff6f57525a36fc3d38114ee11a"
+    },
+    "sound/ambience/brik_hit.wav": {
+     "bytes": 6820,
+     "sha256": "499804fd15edb24a5fa931163e19c5569a45ce93ad74d313c58b2382cbf35d7f"
+    },
+    "sound/ambience/brikhit2.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/chant3.wav": {
+     "bytes": 116346,
+     "sha256": "5d71f12940688414ab8cabc0d88e323dc961b60aac66f17887712133f1cb8b29"
+    },
+    "sound/ambience/equake.wav": {
+     "bytes": 47148,
+     "sha256": "dcc45d2ef0703ecaa022c83cd66ae4992021ac379c11fc9da4401e184a191c93"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/monster1.wav": {
+     "bytes": 86142,
+     "sha256": "b93677c4793930e26e12444064cf9b74fc3e49da9ddd7df7d569ba02a3cb10fd"
+    },
+    "sound/ambience/monster2.wav": {
+     "bytes": 85116,
+     "sha256": "6fe159639935a8986685fbe2cdf02f80d4e226dea8365da516713c333ed5d0a4"
+    },
+    "sound/ambience/monster3.wav": {
+     "bytes": 99962,
+     "sha256": "310a864ee470264ac6f6c0829f1dd508632e03fd594d30c3820e26a161d1dff0"
+    },
+    "sound/ambience/rain.wav": {
+     "bytes": 91202,
+     "sha256": "a196a2fc8a052368f9e8f7efe853391d1a99dfb1f6afae4fc7038222f2eb6fda"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/torchign.wav": {
+     "bytes": 12268,
+     "sha256": "7d5e4e5a897c456b4b43173b1b796b4a3af6df66447cf7d0c8ebcd2dfad00e86"
+    },
+    "sound/ambience/wall01.wav": {
+     "bytes": 67890,
+     "sha256": "b5035fafa3e000b2e51cccf2e39404905cda1f55e42a64799ae677decb03ab19"
+    },
+    "sound/ambience/wingend.wav": {
+     "bytes": 90874,
+     "sha256": "63e435d896b097d4dc413fb1afccc2078f1d101a4f7bfc18c4e593ca9e8b344f"
+    },
+    "sound/ambience/wingget.wav": {
+     "bytes": 65148,
+     "sha256": "533bdbd7beffa4c71c66239e3ac417f2177b20a60ed39c379c59a10b2222b367"
+    },
+    "sound/ambience/wings1.wav": {
+     "bytes": 6028,
+     "sha256": "c9e05f66a1d728a88289bc213c9f3551f1e54a4f3e8ef23ab03f8d5019e7b2c5"
+    },
+    "sound/ambience/z1m2mus.wav": {
+     "bytes": 103768,
+     "sha256": "d54261d4c9a4a8a9fe0c51eeae343c6a5b381727af88d0bae6f9b40605b8e5d3"
+    },
+    "sound/ambience/zend1.wav": {
+     "bytes": 123618,
+     "sha256": "2df6c267197b2e82241e47ce4985b04d14e1ce3cff46cebf3177369057302bb6"
+    },
+    "sound/ambience/zend2.wav": {
+     "bytes": 73742,
+     "sha256": "0ea00395004f11d41ab60352517bf5ff5c88a73b8ff2ddb3f32b5085967e3003"
+    },
+    "sound/ambience/zend6.wav": {
+     "bytes": 252626,
+     "sha256": "3f3c412e55bc7534c423c0d1bec2d817e3aea06338b4d6c3f78c4b80e55d509f"
+    },
+    "sound/ambience/zend8.wav": {
+     "bytes": 112122,
+     "sha256": "27cef28aa3d6c3ea86f0c54168db07055abfc7af284bc5a35bf53a0e53f8d677"
+    },
+    "sound/cube/bc_activ.wav": {
+     "bytes": 36464,
+     "sha256": "635b91649a592106f181949245c76b4b41af95222140158d190b356a59e9839d"
+    },
+    "sound/cube/bc_attck.wav": {
+     "bytes": 6232,
+     "sha256": "89a3d06aaee35951257389c269620cc8188d83382055fd7fd1b5570971e64bf6"
+    },
+    "sound/cube/bc_gulp.wav": {
+     "bytes": 25922,
+     "sha256": "64d243d8f1da4930c9689a4c68cc6ff36d99d0c19b68ab7b2ef8780c4354e7d7"
+    },
+    "sound/cube/bc_hngry.wav": {
+     "bytes": 37754,
+     "sha256": "c53d35c94a7fee43c38620798d736d5cf0aeb491ff6dd0923ae126c70714a56a"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/trog/bigboom.wav": {
+     "bytes": 15964,
+     "sha256": "ea71337b208f58a41cc4d9bbdde1224050ac30808afae0015c04ab31f3b96b1a"
+    },
+    "sound/trog/charge.wav": {
+     "bytes": 17612,
+     "sha256": "b6d8e0111eb99f35674305cdf0a6a18a2cbb519c5d17affb052eb4f6ae03cf82"
+    },
+    "sound/trog/frblatck.wav": {
+     "bytes": 8222,
+     "sha256": "ff0bbeb818443ca32da7b5d6b886594b166e806ce0ff5af2383f1b1efa0cbb51"
+    },
+    "sound/trog/frblfly.wav": {
+     "bytes": 25196,
+     "sha256": "52ac1153649ced24dda3d40a025348aa110a10a60ff52eb09b904eb3f1dffad2"
+    },
+    "sound/trog/tdeath1.wav": {
+     "bytes": 15868,
+     "sha256": "1f22bbd0cd63fe650cc96ee2909f18448d7b42ec85be05bb9ccee896ea52581e"
+    },
+    "sound/trog/tdeath2.wav": {
+     "bytes": 16796,
+     "sha256": "a3b292dae738dd460d388d1fc23cb574a8c848b59a56762b0eb72b58f249863c"
+    },
+    "sound/trog/tidle1.wav": {
+     "bytes": 27900,
+     "sha256": "f51b7d3ef7fdbeef32f97ca968474441f310c79346dd5eb7c3c45b60402b6975"
+    },
+    "sound/trog/tidle2.wav": {
+     "bytes": 56572,
+     "sha256": "f4bd899e183af8dc26481e0c5294b29efae049832376d9fc50313820bde25d52"
+    },
+    "sound/trog/tpain.wav": {
+     "bytes": 8702,
+     "sha256": "ee564a82e4d5feb54821a78a87d8078421614410003b2f9ddc0f26f04de3997d"
+    },
+    "sound/trog/tsight1.wav": {
+     "bytes": 11186,
+     "sha256": "7ef8a806ade4c1ab9ebd4f10dd56e0bc6beae3b573c55bbb16a2b9af60da4880"
+    },
+    "sound/trog/tsight2.wav": {
+     "bytes": 20034,
+     "sha256": "4ceb336ddc3f6d7965585bec8b37e1e2936fbfef13c42d47f2f15668b3a5f95d"
+    },
+    "sound/turret/tur_gib.wav": {
+     "bytes": 14686,
+     "sha256": "41e04d4b8199e0e484f6fba8b9bd410d475bfc3908a5b58ea3cfdcbf223ab1cc"
+    },
+    "sound/turret/tur_move.wav": {
+     "bytes": 20602,
+     "sha256": "b31f1cafb7309cfcf302c662f7e0c41f4ed1d203f60bc3348da9483af80d85fd"
+    },
+    "sound/weapons/pc_exp.wav": {
+     "bytes": 35314,
+     "sha256": "ba81a9534ba1da310ec277a807aa31de8bdcfa36a061e80d8eff9b4581bb85ea"
+    },
+    "sound/weapons/rocket1i.wav": {
+     "bytes": 26306,
+     "sha256": "04fc98e42709c9a5d1a8bbd52aff9114b4922da324e30d21859bcf8209e55b4f"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/shotgn2.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "sound/weapons/stunfire.wav": {
+     "bytes": 9902,
+     "sha256": "7214cc44e4c0bfb801209f025b591d838542a3110f770e5614b0f549a055286a"
+    }
+   },
    "sha256": "796d73388fcf2942466e72800ba570553a7fb13aabb6afc4a38ef08eeaf9bd00",
    "timestamp": "1997-09-27T14:35:46.000Z"
   },

--- a/json/by-sha256/e2/e2448380850a83e95aea1b248997bd0c4870bf50cb180ff73a88ba2ce5167343.json
+++ b/json/by-sha256/e2/e2448380850a83e95aea1b248997bd0c4870bf50cb180ff73a88ba2ce5167343.json
@@ -12,6 +12,176 @@
   },
   "PAK0.PAK": {
    "bytes": 11164214,
+   "files": {
+    "maps/mexx9.bsp": {
+     "bytes": 1703876,
+     "sha256": "2c8b42b649d1bebd3d1212fef3f5dd37cc29844d14a82128165086fbf956897a"
+    },
+    "maps/mexx9a.bsp": {
+     "bytes": 1896020,
+     "sha256": "59b35a0d260b4e480deacd7396dca9931d70402322c415c6ead869d4f3c69f67"
+    },
+    "maps/mexx9b.bsp": {
+     "bytes": 2066856,
+     "sha256": "2f732dcc565fe6c5f24d938657a9fcb800d23b6986da9226ed99646cec3f3d00"
+    },
+    "maps/mexx9c.bsp": {
+     "bytes": 1846656,
+     "sha256": "7baa3e9a506ddebbe31c7131e889f5f621befdc6cb02f87a3ca06c402475f1f7"
+    },
+    "maps/mexx9d.bsp": {
+     "bytes": 1802500,
+     "sha256": "032d5f4f840e9b3329585097528da29b357603c76107746e103e39c488c14b89"
+    },
+    "progs.dat": {
+     "bytes": 669304,
+     "sha256": "74846c916dc224896c38f06fde7faf30635d460f0a892e7cedfe29c60730ce53"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "sound/bishop/allow.wav": {
+     "bytes": 45421,
+     "sha256": "8a8b1a56b327189dd665f3d491f91dac6fef1ad857871275a8f7d97fc68bfb98"
+    },
+    "sound/bishop/catatrap.wav": {
+     "bytes": 20246,
+     "sha256": "26f99a4f11ce055813d5c6a3557428c3220826a1b093067238cfa04f5386c4b0"
+    },
+    "sound/bishop/cheater.wav": {
+     "bytes": 14113,
+     "sha256": "7ae8b44b10a6d09fa86df5da735a854dccc97791f87da283940a5740c8dcbf31"
+    },
+    "sound/bishop/conjur2.wav": {
+     "bytes": 17980,
+     "sha256": "e5f195a50237e3a3ea94bdf233b8a7d0af1086b90c8f10eb7398108e7f30ea87"
+    },
+    "sound/bishop/conjure.wav": {
+     "bytes": 54627,
+     "sha256": "532d4b7d5db6a654aa73dfe18fa0f6a71623acfd804a848f106b0af699022bc4"
+    },
+    "sound/bishop/cure.wav": {
+     "bytes": 52182,
+     "sha256": "2e5738851a760f546cadbb2de5d13b2a60bf777f7eabca0e4a4d4a135526ca41"
+    },
+    "sound/bishop/foiled.wav": {
+     "bytes": 76775,
+     "sha256": "16199768f88037472f11d70a5a78a7275eb7f51847d0f1fe49436ec75d1d9903"
+    },
+    "sound/bishop/journey.wav": {
+     "bytes": 42051,
+     "sha256": "0995e55661447c53c3a36ae4552ea2e0bb7ec8b178bf52cdabe9d28b4deaa50c"
+    },
+    "sound/bishop/maryanne.wav": {
+     "bytes": 51817,
+     "sha256": "a0cd48b66179e36a8d96da06a0b176de4580693eb7be91c041793243bed4d27e"
+    },
+    "sound/bishop/meetdoom.wav": {
+     "bytes": 32218,
+     "sha256": "3a47cd7ce2cebc958486917a85f29d6d1d15087cfd43f0cbf55943ff4573fd9d"
+    },
+    "sound/bishop/meetmose.wav": {
+     "bytes": 27999,
+     "sha256": "11cc8355984e6554f80903eecd346268651f668a0d4e5d6effef1a42b8eba692"
+    },
+    "sound/bishop/mindstep.wav": {
+     "bytes": 24947,
+     "sha256": "ea92215ef48e23169fd05edd5d9365dbbf851f3053785b6105c72525f613ade1"
+    },
+    "sound/bishop/notdone.wav": {
+     "bytes": 31744,
+     "sha256": "09608a2f7ce6b3f1b656b52dfdf87f4a308295e4858b5af9057a4fea31e0f495"
+    },
+    "sound/bishop/patience.wav": {
+     "bytes": 37512,
+     "sha256": "b4531390226a7b85b06291eb9ad675960c94db18de33522961d80b6a2317b0dc"
+    },
+    "sound/bishop/playfood.wav": {
+     "bytes": 33072,
+     "sha256": "0661a2c8160455b59bd6f5573ea6509caa723ce8c1e6964795fcf8b90b913822"
+    },
+    "sound/bishop/pleasure.wav": {
+     "bytes": 45455,
+     "sha256": "14a1fcbc07da3bb55565058893bdeae0c50b9aa320855c391184ac07e0521526"
+    },
+    "sound/bishop/reward.wav": {
+     "bytes": 30607,
+     "sha256": "458a6118f69e308ad624115f9954e5b08a9b2ad82f5da4fb86b16b36bc9fb699"
+    },
+    "sound/bishop/rip.wav": {
+     "bytes": 31906,
+     "sha256": "7070871da7ec08da6260a65f1a98ed1bf9682b1c95c51cea262a4b88a63fb6ca"
+    },
+    "sound/bishop/skull.wav": {
+     "bytes": 34293,
+     "sha256": "48836a4d60ed8962ed0f11bffdcca95a200645e3b2cfa49a598d6392e10dc153"
+    },
+    "sound/bishop/wcastle.wav": {
+     "bytes": 35697,
+     "sha256": "443bee1b5f971d5f5609776e5c415c893f505f19b9a76a2939d0cd22d80298dd"
+    },
+    "sound/misc/charge.wav": {
+     "bytes": 22526,
+     "sha256": "88bcd59a89853f69b74b610e2949f49c266d7298046986f01bd7fcb4263260e4"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/prayer/chant1.wav": {
+     "bytes": 49212,
+     "sha256": "737f382e89a40fc098214b77e9165e16f2a06323c07e910f336f2616b6ca87b4"
+    },
+    "sound/prayer/kneel.wav": {
+     "bytes": 22957,
+     "sha256": "a6c1602ba8961eb2b62ff81667aa5f1538d65da1df4ffec904644b587fb8d24c"
+    },
+    "sound/prayer/sight.wav": {
+     "bytes": 22962,
+     "sha256": "fbaabe115d9ca4b985c4481ccc71e6b6f55931394a29a6c51ec97e752ed3d5be"
+    },
+    "sound/sgod/die.wav": {
+     "bytes": 21190,
+     "sha256": "4539fa8c9658301120b325ef69bbfe9c1a881fd98469f73674bdef4982eea0fe"
+    },
+    "sound/sgod/sight2.wav": {
+     "bytes": 39046,
+     "sha256": "e6e1e94e4c12446c5f17670965c1d7eb9524ebd1c1fdce4476b8e27ff2cecf17"
+    },
+    "sound/sgod/stand1.wav": {
+     "bytes": 27783,
+     "sha256": "153ced495ae52bc207f50e06a699528feb2b2c97e5a87dcb789262e84fbd86bf"
+    },
+    "sound/sgod/stand2.wav": {
+     "bytes": 15055,
+     "sha256": "ab8f576d5d793af7493faee208a87c60a4947f4ac4fc0554f8ce04a56c4181a1"
+    },
+    "sound/slasher/death.wav": {
+     "bytes": 10935,
+     "sha256": "7e4775bc543acfb421a446a00efff6d9d5669fafb2387464cb1e1ae3db91efe8"
+    },
+    "sound/slasher/growl.wav": {
+     "bytes": 9045,
+     "sha256": "86e7b3d2e685d7c20e503bdffe676727426b606ef069f4b70f182601e910ec4e"
+    },
+    "sound/slasher/pain.wav": {
+     "bytes": 9325,
+     "sha256": "1d4cfac1f9dfa1ec6958b18014ec7be18dc2615e64888d3c584d50bb48e51013"
+    }
+   },
    "sha256": "674784b7dc042f57b074c41b7e3993e275eb4cdc323666a8e418b5b8c191d2d0",
    "timestamp": "1997-09-12T01:03:10.000Z"
   }

--- a/json/by-sha256/e3/e3dc35680395de81f7b63d5abe638e2f9525c96a37a3343132e620d263a413af.json
+++ b/json/by-sha256/e3/e3dc35680395de81f7b63d5abe638e2f9525c96a37a3343132e620d263a413af.json
@@ -23,6 +23,164 @@
   },
   "sop/pak0.pak": {
    "bytes": 15580537,
+   "files": {
+    "autoexec.cfg": {
+     "bytes": 1018,
+     "sha256": "6b267090cb6b1777be2720faf3786d92a04f7f096d528cd1a42ea3aeffe7622c"
+    },
+    "gfx.wad": {
+     "bytes": 112828,
+     "sha256": "ebef3ea1999d057a8e7c463f2f7a447ec8f4d782b5dd1da86c32e1bb2e1fd702"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64648,
+     "sha256": "44a2a86c39bfc80785df59290e26eeed3ce8159970377b86f5eb1344cef23fbd"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64512,
+     "sha256": "9a3757b58f26b80135b041182f64430d4ec76c1c6b4b868282173af3a57a2fd7"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64512,
+     "sha256": "bb5e88e97cb2ff8f1978495191fb060bcf98dd19074170ee17a70cfd07bfeacd"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64512,
+     "sha256": "f9e77faa48bf851842b75fe7bd39be46467deac8b3b1e729426d78da22d0e35a"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64648,
+     "sha256": "e95aa0452cf479fdb0aa8ad841ecc92c148172ce4bf5f5cedd95be5506832a50"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64512,
+     "sha256": "2d976713fc08bd79c0d60f2d66453cf66f4dd6fedfa7c94f2fb156b22c2fe329"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64512,
+     "sha256": "ca4495c64100840fa4901193817a9db49723a44f8837484f86e6077dd639d9cd"
+    },
+    "gfx/temp.tmp": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "intro.dem": {
+     "bytes": 770087,
+     "sha256": "b59f425c22eccf1280c2a4961c955bf775053dbb2b784dbc8b406e55dfbc4761"
+    },
+    "maps/demo.bsp": {
+     "bytes": 649788,
+     "sha256": "6126b9803420e13415be960f3a7cf1db80d5df6064cc1fe050b715fed0ed576f"
+    },
+    "maps/sop1.bsp": {
+     "bytes": 1919348,
+     "sha256": "beb3b3440ca5a5bdc6a8591a08be4fc1c9e2a603e9266dac02da1206aaf1b7b7"
+    },
+    "maps/sop2.bsp": {
+     "bytes": 2558020,
+     "sha256": "57d209ab8fb53873f6678db485072d99c26d9ff87f270a0536531d4ecb29b193"
+    },
+    "maps/sop3.bsp": {
+     "bytes": 2626796,
+     "sha256": "ee29cb912276f9c1dd56636f3b652cfe39266751a2c484a58b3e059038eca33c"
+    },
+    "maps/start.bsp": {
+     "bytes": 1010952,
+     "sha256": "04dd42c5893dae3284a6815d891876a201d2812bf901a2dac5650f184abb26ad"
+    },
+    "progs.dat": {
+     "bytes": 748392,
+     "sha256": "bdac5749f1536dd206066d775ab5bdd071f99d68a9ea79f6e8f8309478339273"
+    },
+    "sound/1minmy~1.wav": {
+     "bytes": 667102,
+     "sha256": "d9546ef5ceb098df0733f2a7035d0abf97e70e2f294aea9dbf466b355593104a"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/dwrinto.wav": {
+     "bytes": 1324314,
+     "sha256": "767016a2da943abedacf9ae6578dd8736ebdfe8ebaa4139051d6861e648ff7f5"
+    },
+    "sound/dwrrep.wav": {
+     "bytes": 1160404,
+     "sha256": "8f52017194a4ad7caadaabbec28be43ca8bb68fd845b5005540a36e100ceddb2"
+    },
+    "sound/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/mech/mechstep.wav": {
+     "bytes": 11310,
+     "sha256": "253862ad17886c0c0467f2600f185e11fdb49156500919258c7bdf1f51f5bb98"
+    },
+    "sound/mech/metal.wav": {
+     "bytes": 5442,
+     "sha256": "12f478674e401a0e8b3fa696dc87239bd25c75d543eab4cdc7dcb846cd62731f"
+    },
+    "sound/mech/pow_dn.wav": {
+     "bytes": 42904,
+     "sha256": "bcbbdf2a6c196dd3d21cb552e00cd903bde38b94d79860804b5d00f88dc05c3b"
+    },
+    "sound/mech/pow_up.wav": {
+     "bytes": 32670,
+     "sha256": "e0b232135f7db271c3f6e5f6f49eae7d948cfa3afc20d372d5cccb4fa7481663"
+    },
+    "sound/midintro.wav": {
+     "bytes": 662214,
+     "sha256": "4ea7d01836fe4d1c6c390235ad0790d5bceceb8c05774899d9799fc8aaf14a9e"
+    },
+    "sound/midrep.wav": {
+     "bytes": 352926,
+     "sha256": "daa244911559c8526c085df8a71d53da48284e61fa148119f9bdcf14b17db896"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/thud.wav": {
+     "bytes": 12814,
+     "sha256": "3339425267d81adf2186e4dbca724804e918d1e3b12f462497a2f8f0aa07c9d8"
+    },
+    "sound/turret/beamchrg.wav": {
+     "bytes": 3962,
+     "sha256": "d02bd7d2c4754fe3159fac83b4f0898f8b2e1f8996ce7e6cfdaa4a9d75a24fb1"
+    },
+    "sound/turret/beamhit.wav": {
+     "bytes": 8644,
+     "sha256": "35e5e5f28a3695ed27c2b0887a1bf118643d769c457d3642016e887248fa8ca9"
+    },
+    "sound/voice1.wav": {
+     "bytes": 73110,
+     "sha256": "71a421c069e6db60393ad676d0ca29844f2ed2fc84c6d2498438f80a53d75089"
+    },
+    "sound/wall/wall.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/wave1.wav": {
+     "bytes": 183008,
+     "sha256": "0928e73f02e678a3d10f3e25e32c5f8104f64f089fe01fd3a5ad5ba34e1546c4"
+    },
+    "sound/weapons/arrowhit.wav": {
+     "bytes": 3644,
+     "sha256": "7348632798578416b240951489cf027abcaa04ac7f1190a22581349c8b06ede3"
+    },
+    "sound/weapons/lncharow.wav": {
+     "bytes": 2872,
+     "sha256": "546ef60ffa1d6f311f24093af551514ef4f4b9832d4481e4ae78fd0bf6e273b2"
+    }
+   },
    "sha256": "1ab9fb99424c00d851720ec99000fc8e094d47b2380d0e40bf60e851aac967ce",
    "timestamp": "1999-08-01T17:22:48.000Z"
   },

--- a/json/by-sha256/e4/e486baa14210ef8c5fa20b06598d6855f3cbc82b8093f804023e5cfffe45149c.json
+++ b/json/by-sha256/e4/e486baa14210ef8c5fa20b06598d6855f3cbc82b8093f804023e5cfffe45149c.json
@@ -22,6 +22,112 @@
   },
   "pak0.pak": {
    "bytes": 1706070,
+   "files": {
+    "maps/foxyzoo.bsp": {
+     "bytes": 440944,
+     "sha256": "e5284619f297ba038a02e7ef01135cec2167751892983e3efb415730e85d2d3a"
+    },
+    "progs.dat": {
+     "bytes": 461404,
+     "sha256": "3f1ad2a9419c1711e120cc80f67e88b5468bb1360a5df4f45ee2c7aaf3e327da"
+    },
+    "progs/bazooka.mdl": {
+     "bytes": 143952,
+     "sha256": "fcee6fd34a295b108ac7adc3da70156b6bb6c4ee6aef4eb06e9f9394611e0376"
+    },
+    "progs/h_babe.mdl": {
+     "bytes": 26804,
+     "sha256": "61b34a2d1599e86932f0e5c1db8ee0054f8e52f02716a7cf889b9b75ab7667b2"
+    },
+    "progs/manga3.mdl": {
+     "bytes": 96256,
+     "sha256": "81bb691947f88dda5672ab1e1af689098d08a9b5bea9d31c38197db909fe3b76"
+    },
+    "progs/pulse.mdl": {
+     "bytes": 15988,
+     "sha256": "83ad42783fe9a5dd2e2085bb6dcb3e551db7fd7ac683326943e6c5423f8131e4"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 132028,
+     "sha256": "8824603b325f37bbba424f55c3ff900c21ccf61c77ba97e636e91ef99202364a"
+    },
+    "progs/spider.mdl": {
+     "bytes": 94492,
+     "sha256": "df40e58bdf6465e68e5ef33cbcb77c42cc99e50c9dd842c8c3906c2fd04bfc8f"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "744af1fafaacb751cf2e5ce4bb15a0fc1fb938ae519469de6f0dccfe9f320414"
+    },
+    "sound/bazooka/ahaia.wav": {
+     "bytes": 7748,
+     "sha256": "b9a2527347e2272a676390b3a6bce4cf623f233a11b27d932e340ed67e72823d"
+    },
+    "sound/bazooka/die.wav": {
+     "bytes": 9260,
+     "sha256": "0bae4e5baa31c64ba4fc94df64e0dca08c06a732baea03ae4167b75e00318e9b"
+    },
+    "sound/bazooka/dies1.wav": {
+     "bytes": 8856,
+     "sha256": "663fcd16df6c845fc318a6181b2eece0678f9f3980a90ea3d34f0592e61e6087"
+    },
+    "sound/bazooka/dies2.wav": {
+     "bytes": 9212,
+     "sha256": "93f2868e3bbda78b74970a8912e8bad6f50e130692c4ce066aacdb5d51811e48"
+    },
+    "sound/bazooka/dies3.wav": {
+     "bytes": 9752,
+     "sha256": "439d327515f423fe662a8930b6a1d07d693f43331996119e05d32efc5d44457c"
+    },
+    "sound/bazooka/grrr.wav": {
+     "bytes": 11356,
+     "sha256": "8c6609a6ea9d85f10cda8dd2aa2d0fb77f5e9690698cbafbc213eb5d4f2b6f5d"
+    },
+    "sound/bazooka/ooaa.wav": {
+     "bytes": 4872,
+     "sha256": "76d5ae6f0532eb1a43493330c90966be651e05ba9eed2a994a9afaf28c73de78"
+    },
+    "sound/bazooka/step1.wav": {
+     "bytes": 27042,
+     "sha256": "fc485f8365abf042f2abb94ba4a21f077f688419e252a50fe9cfba2f55fd280a"
+    },
+    "sound/bazooka/stepstop.wav": {
+     "bytes": 6102,
+     "sha256": "79ec338698b2f8bfde44e0b5e8e31ca3d34e140ca88a45eb81c7c72b7ca31134"
+    },
+    "sound/bazooka/when.wav": {
+     "bytes": 23194,
+     "sha256": "af1c2534c69cfb3f07e160cd39f66fcfbe9d64580cb9fcfc43520637c6931532"
+    },
+    "sound/bazooka/yeow.wav": {
+     "bytes": 6474,
+     "sha256": "776a81059bc7fd0f8c998f5e8e05837686d1578c8860aad77901665c31370caf"
+    },
+    "sound/died.wav": {
+     "bytes": 24492,
+     "sha256": "3ce14cdac970a150f567dbd07cf1763f695245c34f5bf4e31ec07bfeb232db30"
+    },
+    "sound/ha.wav": {
+     "bytes": 2708,
+     "sha256": "ba2108ad5070860873887308293efd3a9635a6c4dcb3fb39357a9e16f89f97b5"
+    },
+    "sound/hiyaa.wav": {
+     "bytes": 36876,
+     "sha256": "1446e8afbfdf48a08ca6727604b33585efdd67a6d14b4b1c96bb05c6ccd5ac3a"
+    },
+    "sound/kungfu.wav": {
+     "bytes": 29008,
+     "sha256": "025b6eed19d193bd6be4c4f8f2bc7b9fb14e5c127257e570fd9fc98fd464f2a3"
+    },
+    "sound/ohdju.wav": {
+     "bytes": 12588,
+     "sha256": "346d38c12edad612ec4915d3361ebfbb81b06bee9cdb73eb9b9e0d2cc2ea6d10"
+    },
+    "sound/tchak.wav": {
+     "bytes": 10166,
+     "sha256": "f77d88ab76f7a092a7a5d40fb0aaf9530dc6da8e45559fcf1a1b5ea2aa88029b"
+    }
+   },
    "sha256": "c159a2540f454d8376f4a63288e42e438e0890ad9cb66b77867ebfc6c7b5dbf6",
    "timestamp": "1997-01-14T03:17:22.000Z"
   },
@@ -37,6 +143,43 @@
   },
   "src.ZIP": {
    "bytes": 25875,
+   "files": {
+    "src/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "1997-01-14T03:19:28.000Z"
+    },
+    "src/bazooka.qc": {
+     "bytes": 13090,
+     "sha256": "ebeb356a1df38ce230ef6a62a6693f3d13f424a62708f036dcb11f5931347ce5",
+     "timestamp": "1996-11-21T02:22:32.000Z"
+    },
+    "src/foxyzoo.map": {
+     "bytes": 150721,
+     "sha256": "d9165d74bdf53376f24aba810ca5565979b4c3dfd1ac32e88a5fdecbcd972054",
+     "timestamp": "1997-01-14T01:46:40.000Z"
+    },
+    "src/manga.qc": {
+     "bytes": 11750,
+     "sha256": "dcff569a2cbe6399b3e6e14e654773b5d3fa6b4dffc0c203be534c161213987a",
+     "timestamp": "1996-11-02T23:31:26.000Z"
+    },
+    "src/progs.src": {
+     "bytes": 490,
+     "sha256": "c8955976b417de92b34c2d58b4ffe487845a27425e041292a0bf68b0d32c492f",
+     "timestamp": "1997-01-13T01:53:42.000Z"
+    },
+    "src/snakeman.qc": {
+     "bytes": 9899,
+     "sha256": "c6078ffb73bbbdc17d81cbf83b11507e79efc5b642e7d19ba1e05ec57d5e05ac",
+     "timestamp": "1996-10-24T12:09:18.000Z"
+    },
+    "src/spider.qc": {
+     "bytes": 7559,
+     "sha256": "044e93f430cfb1466c66e8f8e84ecc1fa35ffa88498a6afad1c45d04f23d43ef",
+     "timestamp": "1996-10-09T05:59:54.000Z"
+    }
+   },
    "sha256": "4cc79089e63e0d21590016a8c06bff8814364716e81aa17861c7799130f79d72",
    "timestamp": "1997-01-14T03:19:50.000Z"
   }

--- a/json/by-sha256/e5/e5959ff6b5d58c3fdad1ad8e253448549aa23268919ac3040e4a9b8b928bac89.json
+++ b/json/by-sha256/e5/e5959ff6b5d58c3fdad1ad8e253448549aa23268919ac3040e4a9b8b928bac89.json
@@ -7,6 +7,96 @@
  "files": {
   "PAK0.PAK": {
    "bytes": 10729712,
+   "files": {
+    "maps/bario1.bsp": {
+     "bytes": 2497756,
+     "sha256": "f2442f880f16426491a9394f52429700d8fc20c7871b1995fc0b49e78c914c61"
+    },
+    "maps/bario2.bsp": {
+     "bytes": 2669532,
+     "sha256": "5b50b5e0bf1e530431656973acec10c4162c152184b9b52be68cd50a72b1e34a"
+    },
+    "maps/bario3.bsp": {
+     "bytes": 1765472,
+     "sha256": "584fe2a371d45a5f89b7817901b042424838cbe966db0f3d330d8c2442b41107"
+    },
+    "maps/bario4.bsp": {
+     "bytes": 1948420,
+     "sha256": "934a43b37a9a21544a174b2b7d29283dde2b4e3dc35e181a950979d4945bddba"
+    },
+    "progs.dat": {
+     "bytes": 625012,
+     "sha256": "4ed46c4a58872321db2967e264341b7c76981f51d15a9033ca5f843695e206f3"
+    },
+    "progs/demon.mdl": {
+     "bytes": 102120,
+     "sha256": "e1adf9a41616ab2ad4707a6c5b71e23c7874733bc41c065d2d0cfe8f303c8679"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 160688,
+     "sha256": "903dab34e226fd76403a573a7c4f33c3c33c1c57e4b76f05e108e2961f8c9f99"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 34884,
+     "sha256": "cc06660e15c44f5e82778350d46979572f98597965b1f38a2b76622c3c3b8e5f"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 16628,
+     "sha256": "8691e71df580b186d72579b38fc47208b5f034425e20f2a928276800baa39ada"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 7156,
+     "sha256": "2df7b7aa12e4a497327473c4ee07fe7d46ade3c7232454c774aaa48dfee2df62"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 22168,
+     "sha256": "a41589f3ca0e412dd4127a4efecf44855fb8044da2d8a0086a79370200e8a5e5"
+    },
+    "progs/h_shal.mdl": {
+     "bytes": 28036,
+     "sha256": "f3ddd93b167bae4528364e5b23c3c06aa95dce81bf3f7c801c8f27d2fc3e10b1"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 37060,
+     "sha256": "a5fe96718d348b02299fcf04d1e02e0bb973df1519a493b8ee50eda297bf536b"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "d53ae9fa2b43f4150756734011e85639a5d428a2539f7a3e39f01c6353445f7d"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 228400,
+     "sha256": "1b77fcbef61606f02b2b33a8ee3eb78d65f27c4f65abbdd08a0b4e7fc8ef96d9"
+    },
+    "progs/knight.mdl": {
+     "bytes": 101404,
+     "sha256": "2688f53741a21c1a5d0520b21d99257d884e293175d2707ceeae3823d8848f63"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 80648,
+     "sha256": "aca8e867c6fb3b3ef8ed5c8fb84629375393b0d7cab9e6a5c0852f8d003f1959"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 98556,
+     "sha256": "2a7ba1a647d15522eccfbc7586ad20128d250eb63055854bbfbf817496c0d25a"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 186084,
+     "sha256": "05b8bcaa335c50ad9f74f511767ac2016fdc96cfd60071e2c66d294487be6c2c"
+    },
+    "sound/items/damage.wav": {
+     "bytes": 22782,
+     "sha256": "adfcdd1490943a74b4010129fa4b85f05f9bcae9efca7e26bd2b49303ae6018a"
+    },
+    "sound/items/damage2.wav": {
+     "bytes": 68220,
+     "sha256": "1341e467498df437b9f971c7c945d3c58895019f3f3e5eeca3c152f895e3b674"
+    },
+    "sound/items/damage3.wav": {
+     "bytes": 22782,
+     "sha256": "521bb20b81554e900af3e39a54cb2c88b6d287f9882877d1564cd1f8cd412ced"
+    }
+   },
    "sha256": "2caf9ac3712562d5d324ed3605a1d8bcffa8f5ef3754f04a4c061398e55b9bd9",
    "timestamp": "1997-11-30T02:11:48.000Z"
   },

--- a/json/by-sha256/e5/e5a21dd119f14272d9926f064b9418cc16112c8ee86ba6d82434dde5c68b7cc9.json
+++ b/json/by-sha256/e5/e5a21dd119f14272d9926f064b9418cc16112c8ee86ba6d82434dde5c68b7cc9.json
@@ -35,6 +35,2968 @@
   },
   "alk1.1/pak0.pak": {
    "bytes": 504210543,
+   "files": {
+    "gfx.wad": {
+     "bytes": 204788,
+     "sha256": "231ee3aaec405032e496c58381ea0a12c720cb67f9170776fa207f5c9fa0cf76"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "6072bd63a691625de201f3f3da060b5df433753d7ac2878c48b87e9d0dd08b94"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "ac11a967228e1c7d1a936859b82807cea239d80380fb6204d67af7a86c5c82e3"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "4cb99cf1b515b6547f012b6e44174c245261b058168a8bc4303d08b98e1805b6"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2c37b7697aebedb5bbf6637d4b8e158f70da6b7245195ff0e91a6ba7aa24e828"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "219002fe962a017600a37dcdcaaa0f777aad42044619f945cb70c68007763a97"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "e251893ed49aeb677096d380d4246907a039e0e21a4849f97f343b0b13faead2"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "64ec646cbab7ebca11f6af4f0b75d9706f438baa7b23059de87f8685f4686640"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "03c7cdc618e4404e2b9364c690b0a447b4be99dc5af112c66e6e2079902c76cd"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "9cf2683f2a6d22693a8c0cf35898bc5900a96afc771878df9f8a8a88f3d581c9"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "f232da5cf35acc557f3f312911e6a856cffaaf9f8078ca2ac5ef7e6f6e5e3515"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "b57ad9ad9d6240a0e035ca7a64e706e3031b8293c27355c9a95495a84972af4a"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "873af58b7244d6e82feb1af26ac044c9beb43c2865bc51d0485054a562ce861e"
+    },
+    "gfx/env/abrut1_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "ffc96027930f197262bf224619f4f793b3f9792ca5ed0ad4a810de0469146bb4"
+    },
+    "gfx/env/abrut1_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "12aba296663e41f26d229f62baf24161fca2d06874944fdd738d452cfed12e22"
+    },
+    "gfx/env/abrut1_ft.tga": {
+     "bytes": 2216388,
+     "sha256": "1ffb28d2baf5809ff3ddd4dac1123e39568af6060f33671cbaa5b9366eb093f1"
+    },
+    "gfx/env/abrut1_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "40610c9f33267572a0979b37d1d01fe214254045adb80cda9303d1c4fd09d77d"
+    },
+    "gfx/env/abrut1_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "26df0c46008298c0570712f5a62fd8208dc3e319bca4bcc849a4fcdd61d9e52c"
+    },
+    "gfx/env/abrut1_up.tga": {
+     "bytes": 3145746,
+     "sha256": "8155aa7bb051a2887d74ff4a94cea6007ecd20fd5dfc33856d43dae7547ee77e"
+    },
+    "gfx/env/ares_bk.tga": {
+     "bytes": 481498,
+     "sha256": "907a96e8feaada0ea37d72d99070961883ccdfba8a6b3914dcbb9afc472d18a8"
+    },
+    "gfx/env/ares_dn.tga": {
+     "bytes": 763001,
+     "sha256": "fcc51de57b71899ef969b8380ebd22269aa1e9957bba845413cb4f5394cbe49a"
+    },
+    "gfx/env/ares_ft.tga": {
+     "bytes": 490443,
+     "sha256": "8c109f48b7240f7138353a19017921660ccef0260945ae4a4792ba12c7bf3730"
+    },
+    "gfx/env/ares_lf.tga": {
+     "bytes": 503381,
+     "sha256": "ce0a40f558e72dba7653fe7f693d7e0406afa50aed1fcaac6cda2e857ac55a46"
+    },
+    "gfx/env/ares_rt.tga": {
+     "bytes": 497671,
+     "sha256": "a8033bcdb9db86386582caa29e8aa53946821266da730e17b775869a5458cbbf"
+    },
+    "gfx/env/ares_up.tga": {
+     "bytes": 106191,
+     "sha256": "d0489c8c9606a31fa3d929c1f2c561a162116333edda74f9236203eeadb1a74b"
+    },
+    "gfx/env/bal_goldensun01_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "8dd0cf560f2de9833865050d4fa50c486273ecf2db7168cac9cd2f1166cdb806"
+    },
+    "gfx/env/bal_goldensun01_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "611e10e6e603f6ea3734cd9316b8d3698e25cac289beb48b3e76c13cb4f79066"
+    },
+    "gfx/env/bal_goldensun01_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "612c6bfe6d6a3d395b46e3e2626e1b23a4b3ae92ed167fd0191236671a0bf3cb"
+    },
+    "gfx/env/bal_goldensun01_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "09583bed6543dfa818632ae73c9afd3dea4b0bc9547db6feef0d421dc7f8f243"
+    },
+    "gfx/env/bal_goldensun01_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "95792a9157b001f70c55bd3904ae370db3a9b96201616b4e57dc8cc67c5bc1f3"
+    },
+    "gfx/env/bal_goldensun01_up.tga": {
+     "bytes": 3145772,
+     "sha256": "54697cce6de2daf89657816d2f8f6ceffe2008c329b1e8fc726b82e28d726955"
+    },
+    "gfx/env/boneyardice_bk.tga": {
+     "bytes": 786476,
+     "sha256": "b8a186188b46e6932fa24bbf012b1bd53267aff1f58d2ef0d297e9e1c3631e1a"
+    },
+    "gfx/env/boneyardice_dn.tga": {
+     "bytes": 786476,
+     "sha256": "332fc0e2269b5784bd41b143e574c74b39d45c3a8ebc0d13252a3954b75d49fa"
+    },
+    "gfx/env/boneyardice_ft.tga": {
+     "bytes": 786476,
+     "sha256": "1bc33dc6cdcecff03894561f75aed65b83245b33d00970bdd50bb247a562a076"
+    },
+    "gfx/env/boneyardice_lf.tga": {
+     "bytes": 786476,
+     "sha256": "db1ed21e01bfe16c5c7874e9d51b885ad457ac6272fd99c4ce9df5ce9746bbf0"
+    },
+    "gfx/env/boneyardice_rt.tga": {
+     "bytes": 786476,
+     "sha256": "184b5b29b91c9d615d6ebc9a858295c0a6f42016736e8cf94c8f61e541687a19"
+    },
+    "gfx/env/boneyardice_up.tga": {
+     "bytes": 786476,
+     "sha256": "9ded4acb817419cb76968bfe1a20935c27da1f8b60cc5b7a50229d9e8fd624a3"
+    },
+    "gfx/env/cloudedsunglow_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "bad4922c68c66ceadfbe265a9f1963cd665273884c1c9e8937afbfc06f638c08"
+    },
+    "gfx/env/cloudedsunglow_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "4b4734557cc066c27d4a1ce2ce0cfe4bf77046f6d0faaa33b2ee80f3c97da4cc"
+    },
+    "gfx/env/cloudedsunglow_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "7a7712db51baecce806e5685611bf870adfe4ab52077a91b955f17f052d6edb0"
+    },
+    "gfx/env/cloudedsunglow_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "ee6c2afb805bda6280fbfacbe512487032e5056b54c4a1032f5cd24e281edbbd"
+    },
+    "gfx/env/cloudedsunglow_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "1122c6e10b539b2bba2f906a10e54a116e34e10959714d5e6266a574eaa74ade"
+    },
+    "gfx/env/cloudedsunglow_up.tga": {
+     "bytes": 3145772,
+     "sha256": "38d210fc9dafc0cb375831c139b618020a26603bc6170cea88aa51e35fda738e"
+    },
+    "gfx/env/nebulabk.tga": {
+     "bytes": 786476,
+     "sha256": "9f39d79a62c92fa382872342bab06b300b7db15e337acd2c97ae8f2f629173e6"
+    },
+    "gfx/env/nebuladn.tga": {
+     "bytes": 786476,
+     "sha256": "283ccd8776d60b0f5241033ef905914c58888270bd9cbd4c49115fc6055bffc4"
+    },
+    "gfx/env/nebulaft.tga": {
+     "bytes": 786476,
+     "sha256": "abb8ed2d7664344f053231f1be6311eba3f4319d801ae4218a235c8e6cd4b67d"
+    },
+    "gfx/env/nebulalf.tga": {
+     "bytes": 786476,
+     "sha256": "c5be0fd1bb66ae32f2063811a2fd0dac080aa61838d7588e1ef5552f6c348674"
+    },
+    "gfx/env/nebulart.tga": {
+     "bytes": 786476,
+     "sha256": "f5acb0f7e12b10242ef98d9ffe07bb3bf68016ab68d6f80208f528e689ab5cbc"
+    },
+    "gfx/env/nebulaup.tga": {
+     "bytes": 786476,
+     "sha256": "7a7c9424022598d8d74f68aad4f0b73f0858ae57a5725fd53a860a9f6aae050f"
+    },
+    "gfx/env/oz/ozymandias_bk.tga": {
+     "bytes": 786476,
+     "sha256": "98b447eb25cd2cc53362f7900c4452ce9ceb4901ec263df56a4520a4e39bddae"
+    },
+    "gfx/env/oz/ozymandias_dn.tga": {
+     "bytes": 786971,
+     "sha256": "2354852349f537cc4eb1567f1e7c71b8b5891bbfa03d4350708296cab505abc2"
+    },
+    "gfx/env/oz/ozymandias_ft.tga": {
+     "bytes": 786476,
+     "sha256": "cda9321e88d17c9e8d8ed9295d9047e8b3dabb290e2fe90af05321bf6b05c973"
+    },
+    "gfx/env/oz/ozymandias_lf.tga": {
+     "bytes": 786476,
+     "sha256": "4a8ae725bdea8a0355cdcc09b690d0d556c31240344232bc90fcae71ab605599"
+    },
+    "gfx/env/oz/ozymandias_rt.tga": {
+     "bytes": 786476,
+     "sha256": "16fe8a636eafd70c8d5833ca54b9c4da7f6d4a196f1126c781d79805b87e268d"
+    },
+    "gfx/env/oz/ozymandias_up.tga": {
+     "bytes": 786971,
+     "sha256": "88a59bff68e1ba4cd29e66ff25c88d3cfbbcf2f5089fb82e9addae1edf2c5566"
+    },
+    "gfx/env/yellowozymandias_bk.tga": {
+     "bytes": 786971,
+     "sha256": "8a35fde493dc59cf93bbffe5be0009f4ad55f5d308b89fdcf1bc5eb576e437be"
+    },
+    "gfx/env/yellowozymandias_dn.tga": {
+     "bytes": 786971,
+     "sha256": "74a6578af6cabf5ca00ded9140507df3e2381d2ffa6a3c4248b6c9251d931108"
+    },
+    "gfx/env/yellowozymandias_ft.tga": {
+     "bytes": 786971,
+     "sha256": "c3a5318ec7d8a342fe8d740926d83a1b6c8e13fb138cba854addbe8fdb36ec82"
+    },
+    "gfx/env/yellowozymandias_lf.tga": {
+     "bytes": 786971,
+     "sha256": "b316cf00da8bd01752d04b53c093467490a31d964cf33c1b50eae11e942a3003"
+    },
+    "gfx/env/yellowozymandias_rt.tga": {
+     "bytes": 786971,
+     "sha256": "0eb644c5c01e47da3b70aed3dad8873cb9e39ac4b4893adfa564f7a7a8ad1e5f"
+    },
+    "gfx/env/yellowozymandias_up.tga": {
+     "bytes": 786971,
+     "sha256": "9806eb94899fede2fabaa6474e98ee43c73d83e3df8ace7046e0041a537d0ece"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "ba75badfe057b499d33168032dd5dc5a4fd0dcbaef9cbbd27efdb3f056cbfc00"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "55ac1377921460aeb691f86e7a5051e3a5481f24b93cc8578cffdab2854ba0c3"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "9600a66391996cff88d48890adfa516660fce6a32397ba4f54973159785cff4b"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9f03351fa7f31a23b63e6c13d2a643ed1ae3fd3df0cf2b0db336424eb17016dd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b7617428e8d1d74be7b770ef24c744d16c2503efce9c17facf1107cce08f5ed9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3036afb422cd299cb09532a20847ef35aaf87bb36e34ce9ce75b5e7aaf9a1ec3"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "7aa61257bd3083c00959776eb36aac86a7ca8da2bacbb4c8a41d9a5fb0b1ab97"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "cfe83953875acfe9afda11b75407ed9883eeb284b0a67b9ff6e07df85d50d9fe"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "d3b4091b83837da5a45445cd00b90267c62050e010e2a045461034ac9c48be33"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "de004dcecdff1973597a977ab63c671ad7d3f52387bdcff4be560924e3d4d17e"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "078c56d685ff1fb84b322f7a76e485c2637fb09efc61f4e44d5d067b3ef9a42d"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "9df9672c8da61ae769409e9ea741a1b8f9a4f108b5f0fa6637ff65601c535843"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "fef6b9be45d5b384d061a47f133075d1cfe0b60d93cf7e3da9ee5529f661964c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "1b1254c1f5764affca85448c4a3c2fefdb938f35bc50f44142a8e9b692ba7d64"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "39a06ff92831e1e2fd20c1bdd20e0f234cd0b3aed94e6c9909d059a20479ce3e"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "def061c922fb91a7e58850e89bb6baa9e09dcf93de7a94288a90511ecd9a114d"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "f897535531fe4b821d41d859a4085fd7d25c679493645a2ef7448f62073523c4"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d070636562a967d1abff330dcd1ea504ac7b9b29099a98994add1d9ae47e44e9"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6d92547a27d839f3c9d7a1da786fb33547cd93b7f19560b6c4bcdc12064545bd"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "e932416c58fc5de16e6d05aa737e56d3811e540bfd9e6acd1bf114ccd8bf34ac"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "bda55d4b2d7bc3f180dafd62424ee5830896563f5a5ac576dfa08894f5e17e44"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "513955ecc96eb1f0d44b340b47f79c02bb7bfa7f3b0a884a65fe111429ddb2b4"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "2faa4c1f61d175ad28b7f54540af3f87abc6e56dc20f2da5fc8a7737a0302c97"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "dcfe5287432b3a1124d032250ccc4bf25c73540521c77601ab746287ef3a0179"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "00654b7bec9981508cd9ae8eac167637926c023e7bca011a3cf37585b7e168a8"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "74c50b895f1e71ec6a569fba0e991fde8cf136ea734d6914435aaf9b2735d7fe"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "aecab7a199a4db72242659e6d1ced192d39b2619f67c7e5eaafa72a5efef3aef"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "d075eb0c8c00d30b01eae539720c20b73bb57066c6ea5e8180a4d851d9167add"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "d03aa05e24552d961ea9ca278d743860e34a97e2ffcee52fded05ad4b4740bd9"
+    },
+    "maps/alk_bdown.bsp": {
+     "bytes": 12110228,
+     "sha256": "e800f3fc1300cd4ea8a4c50af1560a7d927f2c4f07c33c6f249dc3bf5ede2f66"
+    },
+    "maps/alk_bdown.lit": {
+     "bytes": 4579112,
+     "sha256": "ae3c7b8e6695f16c0edc366968561b909df9f99dd33ae93e1e7e1fa981a6b3bd"
+    },
+    "maps/alk_central.bsp": {
+     "bytes": 7778356,
+     "sha256": "06512082a8204f5f2d0dd3842261e4df92d7299111ea64a6eaeca8ef7b8b9187"
+    },
+    "maps/alk_central.lit": {
+     "bytes": 2567540,
+     "sha256": "2032e89bc7fdc4e4129ebbb5a227b8122cd5483de3e0784ae3416c9f3aea2370"
+    },
+    "maps/alk_chaos.bsp": {
+     "bytes": 6837580,
+     "sha256": "05ba9a786ae10aeb2ea874e1a0655a2b74606e77c4356acb769367b1c5b78d4f"
+    },
+    "maps/alk_chaos.lit": {
+     "bytes": 3208025,
+     "sha256": "26fbac410532f43ee5d8ed35af2e190ecb574ce8def90952cc3ab04556531312"
+    },
+    "maps/alk_core.bsp": {
+     "bytes": 8861344,
+     "sha256": "d580937b77c67ce2c335461d385565199a8f198ae5e5e581d8a8c3b12cd39b34"
+    },
+    "maps/alk_core.lit": {
+     "bytes": 4184984,
+     "sha256": "00af1b4cc1529348744666a15a1b4f31283a3b7290eaed6640fce2afe4c56066"
+    },
+    "maps/alk_corrupt.bsp": {
+     "bytes": 17491232,
+     "sha256": "b40827ce3fd926ca9a2124c3926b045739012246310277d64dfe3a65ac24aa31"
+    },
+    "maps/alk_corrupt.lit": {
+     "bytes": 10774796,
+     "sha256": "6725e52f0417e8d960ecbb0615d2395bd376a91756f385eddcc944e46921e626"
+    },
+    "maps/alk_dancing.bsp": {
+     "bytes": 22789352,
+     "sha256": "ca71723a8c5771e99053527cb92da6e46388679083d2b9393bed33ce18e45c32"
+    },
+    "maps/alk_dancing.lit": {
+     "bytes": 6922232,
+     "sha256": "22922ba1cd8149c96527b898c5de155817e1273809f08f04bd50f0ccdac5ad6a"
+    },
+    "maps/alk_derelict.bsp": {
+     "bytes": 26280388,
+     "sha256": "7f486b1fa93af6bca71e7bba1587b12f2f73388f529a461ef386cbdc3288c54c"
+    },
+    "maps/alk_derelict.lit": {
+     "bytes": 6077090,
+     "sha256": "4cdd4d29db2c4eb90fa2047f6e901374686cb7bc9908c4d6e627e17079e7f46c"
+    },
+    "maps/alk_eclipse.bsp": {
+     "bytes": 9689996,
+     "sha256": "da3c681ec4d501d5e8798239cfe73c270e967b3c630ec2c8a121db272275cdbb"
+    },
+    "maps/alk_eclipse.lit": {
+     "bytes": 3096308,
+     "sha256": "a881bc8759c9d75d83754cce814c92298bc55e73867491415ee974c9e919228a"
+    },
+    "maps/alk_geo.bsp": {
+     "bytes": 14348068,
+     "sha256": "5d6c3e0948d21effb27f45c0ac17958cd5da4ba530874ce244a9977fc57a42b5"
+    },
+    "maps/alk_geo.lit": {
+     "bytes": 5907128,
+     "sha256": "e5a462dcc185e193d7df340ad0da2ee53067a84eb891076d634e89f41b67fb76"
+    },
+    "maps/alk_mania.bsp": {
+     "bytes": 7788592,
+     "sha256": "da0ead24bbae33a453c63d011e10b321df951ce3fc68d9876c12a0c1305d2884"
+    },
+    "maps/alk_mania.lit": {
+     "bytes": 3258992,
+     "sha256": "90fd1ccc166232ff5adc13f9e7fc2ac6b0ac2027f38a2724ff8e679c28dcebe3"
+    },
+    "maps/alk_pipes.bsp": {
+     "bytes": 7633392,
+     "sha256": "1d2c8787c5bceb6655d0ae06fb2d5f0fe2be6b12d815c3946e95b9884c9c7613"
+    },
+    "maps/alk_pipes.lit": {
+     "bytes": 2465870,
+     "sha256": "d1aed63cd319a63571c26f172bc1f7390e1e67bade734842a1e2f614a299f92c"
+    },
+    "maps/alk_sickness.bsp": {
+     "bytes": 2243144,
+     "sha256": "a6e0fc5045192f551952a64fa4e43731b673f2b8e8f15d6eaac523f1d0ae14f1"
+    },
+    "maps/alk_sickness.lit": {
+     "bytes": 601958,
+     "sha256": "c18873a9e5aff44fe126d2159d08961cbc246cb606fd7175d5da8a40c79413e3"
+    },
+    "maps/alk_tellus.bsp": {
+     "bytes": 21314324,
+     "sha256": "dd0284e2405889b15d2f529c006624b7411e4093ea4ae231e3d51d2b411130fd"
+    },
+    "maps/alk_tellus.lit": {
+     "bytes": 7701911,
+     "sha256": "8f67dd0241b68392bae40b66f8fa488e955668557ced3fd98d122799d75e7313"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 20040,
+     "sha256": "61c46ac5672c1e671c0c38a6498158176feaa62b074621c2a3d74e5dfc68e2f3"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/enemytest.bsp": {
+     "bytes": 908792,
+     "sha256": "73c803f34b5c61dd1c5faa5d1ce16c8193e0cdf3e7ffc6c437186c472c8b65a8"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "maps/start.bsp": {
+     "bytes": 31215876,
+     "sha256": "657fcbeeeb6adb7fde5c124c09fa59f923b7c47817e2673155ec8632a3d7d7a4"
+    },
+    "maps/start.lit": {
+     "bytes": 5391464,
+     "sha256": "3936d03f9b784050e6f2411b69774d07fbab33bd5f7095f32283951e7563e84a"
+    },
+    "music/track00.mp3": {
+     "bytes": 10141908,
+     "sha256": "612b384d5efaea97fce9a2684550966177ca42d45ed87c0eebaa0aeb13e2de0f"
+    },
+    "music/track03.mp3": {
+     "bytes": 3334309,
+     "sha256": "ab0d724636cdc8b8eb6ef170fac78b5c55d5b76315b84a4d9d4e14ba134be64c"
+    },
+    "music/track111.mp3": {
+     "bytes": 6863642,
+     "sha256": "34d6193f5839e3b21c7253b9814b92a2f498429c2591f4415eb9beda17694422"
+    },
+    "music/track12.mp3": {
+     "bytes": 6494707,
+     "sha256": "68d8364897fef4f8217beb381412297cd0213d22a30bd93d38fcd8efaf474db3"
+    },
+    "music/track17.mp3": {
+     "bytes": 7796883,
+     "sha256": "a1b2b6a3eec21719400cdfc3e716fc774939a9a0f14b7f4986aa48601b1eeb3d"
+    },
+    "music/track19.mp3": {
+     "bytes": 7178071,
+     "sha256": "2f1824299d0673dc8e50461eaca509408421b90ead4a7e9a24cae26ef9bde365"
+    },
+    "music/track23.mp3": {
+     "bytes": 3058894,
+     "sha256": "e30dfdf84a34aa24506c6019f429bf6187fb6a85b17e5bb16d3589362877a6dd"
+    },
+    "music/track24.mp3": {
+     "bytes": 2108767,
+     "sha256": "f7d7188e767865ec29ee42cf7189781e62f2ac369d530552786f4ba36e7ae382"
+    },
+    "music/track37.mp3": {
+     "bytes": 6798774,
+     "sha256": "95b55a27a06e3841157a78167627ae9a74d68505b784a9955530c9c1f6e0f557"
+    },
+    "music/track38.mp3": {
+     "bytes": 6953831,
+     "sha256": "7edad95cfb1657a6acfc4db2f901704e19dfc337038675eb844bfb0fd905cd13"
+    },
+    "music/track39.mp3": {
+     "bytes": 7103878,
+     "sha256": "84d4213e4e0ab447e47594a62271ce207ffd21123123496059567802fa97850d"
+    },
+    "music/track44.mp3": {
+     "bytes": 4594207,
+     "sha256": "3046432076ac4fbe4e695a2a0d5f0b153aa787554e289e89370e053e867b9aa3"
+    },
+    "music/track51.mp3": {
+     "bytes": 6497925,
+     "sha256": "dcbaa3243af62109b162e775b6f8877650c50abc933843712ee833030bc1fa13"
+    },
+    "music/track68.mp3": {
+     "bytes": 7361764,
+     "sha256": "0c138ae9931860ee5dcfb18cb5975520abf6c67546240cb545b67f714b2d0592"
+    },
+    "music/track69.mp3": {
+     "bytes": 3237010,
+     "sha256": "ee32915337042fff0ed82d4e5e4236885562e8942c7c3378a7a365387b32e268"
+    },
+    "music/track77.mp3": {
+     "bytes": 7280262,
+     "sha256": "386667e944a74e20a822dc565b4da93858c447ed94c2c7bb15a336295d8ffa3a"
+    },
+    "music/track87.mp3": {
+     "bytes": 7425712,
+     "sha256": "1677b2b1c065d123b4bdfc331a0c82818b60a02190e814742725b72a37726c81"
+    },
+    "music/track90.mp3": {
+     "bytes": 6568059,
+     "sha256": "d9cfed0338fa83b10cf4ad269a18a2433d6a476968ae48d7c201319fe3a5c3e9"
+    },
+    "progs/arachnofloyd.mdl": {
+     "bytes": 741212,
+     "sha256": "554bd2ad34a830fa01a61dd4972f432812fb61f7815ec81d8a8d7e87bfad6b02"
+    },
+    "progs/arm_foot.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 164224,
+     "sha256": "35314143b9c7a9a0e26e52a865072a6e73862466e640c6bbd58be3075c4d93ff"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 364136,
+     "sha256": "1b8f642154d81d3e5c758a8cf3fc9a18e3d2c2e78ba5ee57d59f66d871d4dfa2"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bambler.mdl": {
+     "bytes": 128044,
+     "sha256": "c8ac9dbcf99f0e6efd30496ac414383c26b8d241fbaff56cfa81dfb545dfb0c8"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "698bf740683ad182feae2246526361948be6da2e144f1bd0202eafa748213ec2"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "b662513bc3a8e0e967344c55b536bd33012340dbeb79a8db1281d2c84e36d338"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b2cf62d8e989789bd76e27193b2f5205a93d4172a4e25c89aa1b30f75bebe60e"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigcranea1.mdl": {
+     "bytes": 92792,
+     "sha256": "81f6a5b55d3a585d5e9c73b088d1d20e0fb328707c1539ef41e52c460555f651"
+    },
+    "progs/bigcraneb1.mdl": {
+     "bytes": 21940,
+     "sha256": "e02faff0bb6c84c781f6b534a5a06ac1f977a028fbdcca176be2932f91e9e8ec"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/bloodshot/energy_beam.mdl": {
+     "bytes": 11244,
+     "sha256": "f318ce49a12ef1cabf5ce0eedf1cd3319e11a15fd1aeca1e1ddbde5d591a8e22"
+    },
+    "progs/bloodshot/turbine.mdl": {
+     "bytes": 48692,
+     "sha256": "68a5c5860542617cd93541509e0d7fe17d18eb3e9453e217566909daea5ddfe1"
+    },
+    "progs/brz_saw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 575288,
+     "sha256": "f571bdf504537ce01ca2b6a78b57575a36c391f9c786625d880d956fb17390a7"
+    },
+    "progs/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/chain2.mdl": {
+     "bytes": 141764,
+     "sha256": "9334a3ec04716ce0068154bf7abb4c1e3ee6de14fb159982dd547314935d7854"
+    },
+    "progs/cyberscrag.mdl": {
+     "bytes": 311084,
+     "sha256": "307e8133ce4f48d4c3dad5ef1b9d32900a3457e91aade778b7fbbc6d8a4741e1"
+    },
+    "progs/cyberscrag_gib1.mdl": {
+     "bytes": 60500,
+     "sha256": "3db8b13bfa5a5eda07acea695cae6ffb92354053da9bed199ef29cd445317faf"
+    },
+    "progs/cyberscrag_gib2.mdl": {
+     "bytes": 58932,
+     "sha256": "ef20c0de15fe2fc2514c10b0023d14009a4871ed40311077ba107350c313f7ce"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon_alk.mdl": {
+     "bytes": 191716,
+     "sha256": "11f33f19ae0a46d3dcc6c1fee46235fb6ad201456120502b603fe4fb7cee14ac"
+    },
+    "progs/dog_alk.mdl": {
+     "bytes": 199324,
+     "sha256": "a16e350fcd247908c75ecd0c93e94d3b700b67bb0f66dd45d665d171a55d42b6"
+    },
+    "progs/dread.mdl": {
+     "bytes": 415072,
+     "sha256": "dcea570331c5cf4348c40451c6242bf35ecaaea2a348f12254a13c1b76b13d7c"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17204,
+     "sha256": "3a2df91993fd0447d87bc26da842a359df862a12d9993ec7dc1d7aa79c6565ec"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 5172,
+     "sha256": "b0951de4d869e0b779aeb3f7a96f56b22a82a58d267a56b1247f0c3e667c25ad"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 6036,
+     "sha256": "88f8a1f941e38f8528ec27a168559946cc0b69f2abce1cbf6858b813e09c5f51"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bcc6396dc638003480dba8c36cafaf32df2cfcf49bd460b001d0d74a164f9011"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/enf_gun.mdl": {
+     "bytes": 58684,
+     "sha256": "39ef1788b39a15f86c8d54b81c43f4126e8361ff80d386c44358f17ddc93769f"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 450424,
+     "sha256": "ecf603c4ebc56438e96d1706a451af8bbe9b090db9c48e38e758ec630a393570"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "ddcf759804fffd97e62c55f67f962e24e8cd646fd982215ac8aefd3e49f67660"
+    },
+    "progs/enforcer_alk.mdl": {
+     "bytes": 333860,
+     "sha256": "85fb5cb9eb1435da65ce0aa6940241b7b4b5fa13e7444713a75c6ec301cc8b97"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f6c43a5d21e1675e4ad95acbc1a47a3be07ccb74fffcb53574f00945d5b06cf9"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flag2.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flagbig.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 451032,
+     "sha256": "1a311e7e74f9a67c9f7468252aedc8c19804f65375d229e90afbec2f93849823"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/fromitz_still.mdl": {
+     "bytes": 6964,
+     "sha256": "63204597e828e001c957e9316878995e161da0502764276b90285accadf6a222"
+    },
+    "progs/g_axe_alk.mdl": {
+     "bytes": 50460,
+     "sha256": "92988e970870f2b977f7490d2ea4ee040d338fa4bdc470e8d68f2e5a856a7a28"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_mine.mdl": {
+     "bytes": 37780,
+     "sha256": "67495e6183f1d689c52659837138a2a2a145feec9c7c69ac60d083c8704cb6af"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "15f390e39e02c8524e575ca8fadf63187b641c58210ee9587b13a0ca94c29cc2"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 199076,
+     "sha256": "7ddca6fb95082d0cc7ffe5aa3ba896ea987a80b1bd5867db97b2a84b9d8da9f6"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "8b05b8ca87ea867c2a2397d238311fda2441f5c0e1cde130ba487b0dbd17a8e5"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_arach.mdl": {
+     "bytes": 60292,
+     "sha256": "daca6412383bec28809cee42c4ebf01085cf83ed6ff289114ba0f842b4005251"
+    },
+    "progs/h_bams.mdl": {
+     "bytes": 37316,
+     "sha256": "58c4644a2ed3e5f10741dff2ad1a8bb161f7eb205ba3fd8c5fc9b7e4ffc571dc"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_cyberscrag.mdl": {
+     "bytes": 62036,
+     "sha256": "df7d6bccc97bd5c184d9d6160005b370175aacc16a34bd06ab14c7d69ff60419"
+    },
+    "progs/h_demon_alk.mdl": {
+     "bytes": 72644,
+     "sha256": "22a9e01cdccb2e274c63c277e6dcd61986fa7556426ee3562fe11af2babea289"
+    },
+    "progs/h_dog_alk.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_mutant.mdl": {
+     "bytes": 110240,
+     "sha256": "f1f9c665b659a8c145550605ef9abddf27779d0917c897baa344d65673770875"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/h_sabrkn.mdl": {
+     "bytes": 11828,
+     "sha256": "050fcc93189211aba943674a326ddd898dc980b83fb551ee11fec3dd39973483"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shams_alk.mdl": {
+     "bytes": 37268,
+     "sha256": "9fcace6cfb38473763a5cf96007ccc5e0ec4786352d4d1063410d63157298b45"
+    },
+    "progs/h_torm.mdl": {
+     "bytes": 62056,
+     "sha256": "db0ddda0c4d2283cd3c58eb45397cfb57095acba1eb6dd38571ca23ebffe9946"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 37012,
+     "sha256": "e3c6cbabfe6c6723101f2e59f50fc99ee0e360571c95885d2d56c85eefade15d"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/jumpblue.mdl": {
+     "bytes": 37428,
+     "sha256": "be4e85e5fc643e91377d69794b997ad4dc927ae3866dfef5288d704dbc0f16d7"
+    },
+    "progs/jumpgold.mdl": {
+     "bytes": 37428,
+     "sha256": "4c543d82c88009cab7fcf6230feea0a21518a98f430636194fdbf5c1e526cc13"
+    },
+    "progs/k_laserspike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "63220c0ebb6e266576cb3107a44be16bda10d69fa524d0462514edff9d80328c"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "29bc55efafbea3e15a385598750ba4d9242d0a87803a6bc3430ed772ec1785c3"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "f1e799e7feac3c340676bb60f6cc7a2a7d1e121b196d1f6d0e23edea3a614ed6"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "92370f5b196dc00460d73697975d14279ef659c87c7fc1613b9cbfb68e6c299c"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "4c5db792da6876f935f8a98a74f51708d52ca03f04975f28518051494660bf65"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "781837a3557c1a8b89c15fa8f477989cb4b77d8cff09c8c13d071090a4df9c1b"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "2feb7ce08070b314d163cbc7f2e2eae0986400c482f752d305ddba268639b3d8"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "04f7fc8b0c2be7ea93021819770145eaf828b2313c4fc591a5f2aa783ca97e61"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 8372,
+     "sha256": "9b6a8f7a49fb7a1f5d4d409b708663c579d433e978d898b9bdf00291a59b4e6c"
+    },
+    "progs/misc_barrelq2.mdl": {
+     "bytes": 60380,
+     "sha256": "04c87c0210d772c53ffc134a5a2a065394dc32f5b36b30c5f24d927bacc24633"
+    },
+    "progs/misc_cable.mdl": {
+     "bytes": 57780,
+     "sha256": "bed2cca38ef4cbefa9e645eb5e9ffadffac6ebb4f2ac5f6da4bb8f354de22a48"
+    },
+    "progs/misc_cables.mdl": {
+     "bytes": 433607,
+     "sha256": "03c41af692903bb854cc5c05c0a8a665f312a04955737ecbac1a65a4113f6d50"
+    },
+    "progs/misc_chain.mdl": {
+     "bytes": 231184,
+     "sha256": "845fc3117f7d9860f2d0aa4a398103a13f327516144a96db508189ae1be5788c"
+    },
+    "progs/misc_charger.mdl": {
+     "bytes": 117672,
+     "sha256": "a64a62cd67894222e1b2ed25332db70961c18d0cbdffe32b17f0dbac93bb2ceb"
+    },
+    "progs/misc_corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "22f82f29d0a88af204f7b97eef887b963bd940e7277b6f5cef5e6f3610f2ea51"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_extngshr.mdl": {
+     "bytes": 25732,
+     "sha256": "fc8dec001f22c4666f6c5ca65e8aba18d5b22ed8aabbf0534d03913e821e3120"
+    },
+    "progs/misc_flame_big.mdl": {
+     "bytes": 244895,
+     "sha256": "09adba1308cdf22d2f07e226cb13a35e51f4d54866f84f41e2074dc7a40371d5"
+    },
+    "progs/misc_flame_med.mdl": {
+     "bytes": 175400,
+     "sha256": "31c94bc48e6c6d6bc31bd14b8e257c4e74d45aaec3a4d5d5bf83587a08ac7c00"
+    },
+    "progs/misc_gen2.mdl": {
+     "bytes": 74708,
+     "sha256": "c93a3f7fbda97841c0c9c7c9b2603d9e388390ab30861c4b1553285985f761a2"
+    },
+    "progs/misc_gen3.mdl": {
+     "bytes": 472728,
+     "sha256": "29032f4dcf60216906ef601d5a6bf20dba71ed5b7ff8260e7f61159b6b8ea1e0"
+    },
+    "progs/misc_heating.mdl": {
+     "bytes": 243876,
+     "sha256": "a6ab88ce55f16b670b9ba8e42e96c9ea49acc71f124ce20c0de5fc2c0232e2f0"
+    },
+    "progs/misc_helijet_pilot.mdl": {
+     "bytes": 105556,
+     "sha256": "8ee41a7ac244289b007921b70fd34f322b4451172f35b0c5b33400064d1c3a2f"
+    },
+    "progs/misc_levels.mdl": {
+     "bytes": 35732,
+     "sha256": "7cf9a4c1e556e60dd4e593cad4a2be0b45bea8893d9b5232ecc7febca4bbf5fe"
+    },
+    "progs/misc_lightpod.mdl": {
+     "bytes": 81780,
+     "sha256": "e16ac3a669ace065c4cd1806ea0a21a59510d936a3a4c9d74c3ef2ef56e9d4f3"
+    },
+    "progs/misc_oscill.mdl": {
+     "bytes": 50660,
+     "sha256": "cdc96265a646f9e9fb4c1717fa90edb13e42130fadc4dc774b60aeb94b89eac4"
+    },
+    "progs/misc_pallet.mdl": {
+     "bytes": 509927,
+     "sha256": "1b9c50111cedb48559424870b46a3d19cb1ac5b43ef3f165fbe928a3f7e90883"
+    },
+    "progs/misc_player_legs.mdl": {
+     "bytes": 76918,
+     "sha256": "8e54ec3002d5b0f70408f17941087e595cb20933a08c40eb934cb25e8804d5a0"
+    },
+    "progs/misc_puddle.mdl": {
+     "bytes": 38164,
+     "sha256": "ddb936aa0192e06767d1c1d1407c6ca0145011ebf985c7cc77a49796416cf119"
+    },
+    "progs/misc_radar128.mdl": {
+     "bytes": 19492,
+     "sha256": "ef004e28e51e3227121a92432375531fca26d1e44894696f3d2a950fa65aef28"
+    },
+    "progs/misc_radar96.mdl": {
+     "bytes": 19492,
+     "sha256": "6239d117263f49b79a2a66e62f2dbd6a7f0cd15ce412c1939dd69b4a1d8fce78"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "fa5d7a5e2410ac7faa5dd0a8e17873c972c6e5cfeacc94118f22db1b4b17477c"
+    },
+    "progs/misc_seaweed.mdl": {
+     "bytes": 16100,
+     "sha256": "dfbd38a439d392870c7c4c7ebea4475827b716004ca47bfa7f13b47daf07d774"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 31792,
+     "sha256": "8d39b97460c9967ee36b33ea1ef1e92e89277fc410b44f054c5e06b8dc8a079c"
+    },
+    "progs/misc_starfield.mdl": {
+     "bytes": 23548,
+     "sha256": "5b3563017939382680228e933a2a87d3edb030e75e65c51fe42c4a6889e42e15"
+    },
+    "progs/misc_stool.mdl": {
+     "bytes": 85612,
+     "sha256": "12914ff8acc41ef1656aef291edef6d3b0975e994808b8e4e921edcc4927e517"
+    },
+    "progs/misc_turbine.mdl": {
+     "bytes": 53615,
+     "sha256": "57cf73dbf14b5b22795033f5b597b30b978aeb6ee037e09648d0cebd029f987e"
+    },
+    "progs/misc_workbench.mdl": {
+     "bytes": 87092,
+     "sha256": "89cb978aaabc4372bacc88ce577c9aefa2a5a4597aada45aa499861150bfe07e"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/mutant.mdl": {
+     "bytes": 352720,
+     "sha256": "262ffca22e0c7308950076c2789436a891399862ea25afbd06040158ec9f7984"
+    },
+    "progs/nsoldier.mdl": {
+     "bytes": 146288,
+     "sha256": "ce36f7893cd00de08f200717a333ddc3963e3ad126ec16e442def19c79717ce2"
+    },
+    "progs/nsoldier_alk.mdl": {
+     "bytes": 563108,
+     "sha256": "6071d7cecf231f0a83f2e1c7df533b4a32beb6e75969d17703446a67d011695a"
+    },
+    "progs/nsoldier_nogun.mdl": {
+     "bytes": 563108,
+     "sha256": "cfc3c7ba56010c720607f7d81aae51f0429bfa229f20ac8fdc8ee011eea8c498"
+    },
+    "progs/ogr_gun.mdl": {
+     "bytes": 52452,
+     "sha256": "eaa6e0fe01255450d578f151c06c5aeb6a9cd5ed90edbbe4f52d305069ed6825"
+    },
+    "progs/ogre_alk.mdl": {
+     "bytes": 315696,
+     "sha256": "31e9986373dc1a8cba00e09ba9b0278cf766bbd074524a891ed22329f697d643"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 487968,
+     "sha256": "ae0abff3ea3fc7ca8c7f80c5d8825553795a1c1ebb80127d46fa52b20905abc4"
+    },
+    "progs/ogrem.mdl": {
+     "bytes": 315696,
+     "sha256": "a46b1fff7c6c446da81a734ec6bfdffbb7db315a59745feb7349fd9a73c248ac"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/probegren_body.mdl": {
+     "bytes": 139044,
+     "sha256": "da0ddf337c3e2515688f2b143adf55d4ecbbfa32955a78aea01ed16e067b0065"
+    },
+    "progs/probegren_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "4f292b6f157d226e763ff28dad682ce95cfb8a3a21b4badf0ca48db4900cdd70"
+    },
+    "progs/probegren_gib1.mdl": {
+     "bytes": 63788,
+     "sha256": "0efb081efa87c9db990d984f9974f10078890a51894a3e0a6fbe76cc3c4cb5a7"
+    },
+    "progs/probegren_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "7843ddefa22b7d5beb37f889c606c6361792508c2bea202f3dadf9f3ffce73de"
+    },
+    "progs/probegren_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "7baac250aa8c27ef3158de59b536ebf59509e39b1f7bf6be1c24fd5b1e29cae0"
+    },
+    "progs/probelasr_body.mdl": {
+     "bytes": 84296,
+     "sha256": "ac545d0f545488628c864df6e464d10fbd51cb41a2cb76c46dd91233ecd11a6f"
+    },
+    "progs/probelasr_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "cec7b847c9b05f2653113454348799b9bf09c2a74c8e1760cca0ff52c1dfc18c"
+    },
+    "progs/probelasr_gib1.mdl": {
+     "bytes": 58700,
+     "sha256": "ae9f298abc0bb1d09cea3c04bf02216b0a1c3749f8c8a822d973b4c2091cd649"
+    },
+    "progs/probelasr_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "07d6defee5ce4e747daf8b397a5d207a1a42e3c3acffbdfc18d6720c88ec635c"
+    },
+    "progs/probelasr_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "8b8f376afa56e7a9f311e58a076f1fa3a52c88064887a8e0960fdb6daaf5265e"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12653,
+     "sha256": "162632bc16838f66f29e0b788845a6421b7fce708003e9fa6f4eb8ae7aa8e5be"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/rail.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/regen2.mdl": {
+     "bytes": 25460,
+     "sha256": "7f4c06f4a7046908317a61bee2a5810eae03fe99f09018455f1fa0a62f45c5e0"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 200152,
+     "sha256": "a564fba381d24e3084bc9aa0a026381c83e6b889632c8bebdf69c08c8a6bb9f2"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "f65ba83d82e90808af589ded17378f1baf37f105fa14f2b157227ee22583d25d"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 288,
+     "sha256": "6ff2797f9dc4e66f2113475a5f3e0e96f23dacbddd18fe47c8b5e12e712f0e75"
+    },
+    "progs/s_bullet_new.spr": {
+     "bytes": 708,
+     "sha256": "a07fa61f4a838ac9ad8ec85ae525d70fb934d383effd1948c0775497be713043"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_plasma_new.spr": {
+     "bytes": 13980,
+     "sha256": "5474060e55af3c462d0ef7aad043f331c1f5b642915d906c1785bb94595cc68c"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shambler_alk.mdl": {
+     "bytes": 502148,
+     "sha256": "bcf685fcd1f4062dc382924d39eae073fc4d44cd2dcb5bc4ca3797fe0b342b71"
+    },
+    "progs/shard.mdl": {
+     "bytes": 10132,
+     "sha256": "0f756f280c09f44ef1e9f36fdd678566b4a5782b349a3e9fe1309c3fcd9ab19b"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "662d6a7cd68bca7a9c5e88838d190de6a501252a14b6994a191d0bc91f1f331c"
+    },
+    "progs/sknight.mdl": {
+     "bytes": 460932,
+     "sha256": "9213f6898a60cdc20a7a144c61c13f8d64f1432382dca44b636524edf737dac8"
+    },
+    "progs/soldier_alk.mdl": {
+     "bytes": 359276,
+     "sha256": "623374e5a553c3d886738c9cc0b22c0b3f3435b3dc1b3f473079a1dd1661fc8a"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spiderbot.mdl": {
+     "bytes": 82476,
+     "sha256": "e85556a194664a5f69e70b42aa863d9e67689a418a3afa51e50816174a6fe8ac"
+    },
+    "progs/spiderbot_gib.mdl": {
+     "bytes": 19444,
+     "sha256": "96ee732ac1199a89c675880700c24e1f09521c35ad478f73aaf4278a398454f6"
+    },
+    "progs/spike.mdl": {
+     "bytes": 1684,
+     "sha256": "5e3be5dff13ec94951aacbd4a453dcbd9c2aebe7e4e6bded2dd70d49d1ddd695"
+    },
+    "progs/supbkpack.mdl": {
+     "bytes": 44408,
+     "sha256": "781c6b5f424fb58e06b2a84b1fb7e980778decde6b3ed257e224db0b1f250173"
+    },
+    "progs/torm_largeshot.mdl": {
+     "bytes": 37852,
+     "sha256": "ce3a87be213e39b48bc71a6fbf5e1fe9e3f5209901ca45801f27d8f297e04a01"
+    },
+    "progs/tormentor.mdl": {
+     "bytes": 461080,
+     "sha256": "df302dea113f54df908f97c26de844d1235004c08aefcf5c349f3af4b0957d41"
+    },
+    "progs/trifecta.mdl": {
+     "bytes": 25460,
+     "sha256": "2c9196af0806c48354f5522a8b7f6fa57e6390f8dfb51718fb71b8a2d4d7447a"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/v_axe_alk.mdl": {
+     "bytes": 55820,
+     "sha256": "80ad34cf2612f8fa9121f2be0ada92c1e05613ae2b35b2a1be25a4c694dd2147"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 141180,
+     "sha256": "bf682cf5cd5fcf5bbfd880cc9c30d395afbec00d8a8c10554c3498fca6b90cb6"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_mine.mdl": {
+     "bytes": 164860,
+     "sha256": "f3bd45a52c8ea00e77d1e633fdfc6eb1ad2557a076d527f4045a69fd54ec7c31"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail3.mdl": {
+     "bytes": 124944,
+     "sha256": "19045e9a5154299b68377744ad946fc3e7f2bd290497c8291a2247ed8cc572ad"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "c9b1d92376ee404102776c630a4fc6fda972c9130fb0f461983c1b6e217a14ce"
+    },
+    "progs/v_rock.mdl": {
+     "bytes": 37420,
+     "sha256": "99125057c1ca5cbbe1dbb5e9978baaa9f4f60a6eb976d9eb06d97497e7b7d7be"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 95124,
+     "sha256": "986246477d8779ebcda7c58cbf90fdb88b39666cff4fcfb18a2cade0a6f303d8"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 326464,
+     "sha256": "dd389cc337d8b7675d9a7b983fd9f53f0c59d597a9759367bd1e1beba375eaaa"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 21908,
+     "sha256": "ade58867dac49427ce1a66c498f5dd7327685db0daac1409b80e0a341df59283"
+    },
+    "progs/v_shot2.mdl": {
+     "bytes": 21804,
+     "sha256": "06a1f7cef5d1d3f8c377addc4026523b656b8f77986495f96048a1a6ea94549c"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "quake.rc": {
+     "bytes": 889,
+     "sha256": "9260661b9d55fd31e583a4761fad47a3cb0f83c55c024307381436977c9be69e"
+    },
+    "sound/alk_emt/ac1.wav": {
+     "bytes": 342374,
+     "sha256": "73752cd2b6407cb48ac651ba06b1b44b3bce2dc2187439f56fa12b947f4414b5"
+    },
+    "sound/alk_emt/bossrumble.wav": {
+     "bytes": 1095644,
+     "sha256": "592d71188f710d27bf5e4f84b987aed8be2aba11541536890996242f04724bb7"
+    },
+    "sound/alk_emt/bubblinglava.wav": {
+     "bytes": 596204,
+     "sha256": "ef18c72355b574f305e48e92566bd33719c766123d719e65b09ac89c258cf856"
+    },
+    "sound/alk_emt/hangar1.wav": {
+     "bytes": 714082,
+     "sha256": "15f0c87013e445065066cd68cec281331fbcd6501b7bd3f825ef908d85518f97"
+    },
+    "sound/alk_emt/klaxon1.wav": {
+     "bytes": 131116,
+     "sha256": "82a4ac7e620cc51bd63d20dfc256212fa9cabf384cd7431684402525ae5d3b43"
+    },
+    "sound/alk_emt/luggagescanner.wav": {
+     "bytes": 221032,
+     "sha256": "44c66ccc872a675cebe9b84ae16e2005005e3fbee36f0eacf3639a88e4168048"
+    },
+    "sound/alk_emt/movingplat.wav": {
+     "bytes": 81326,
+     "sha256": "2caad748f987b13e2ae9c2fefa62ad34a350ce11d77add0b4ee85e0a44b4d8c0"
+    },
+    "sound/alk_emt/smasher.wav": {
+     "bytes": 124588,
+     "sha256": "0609c379a0aa35df478e90942a000b8a8fbe170a26ce695e83acc421b7da4865"
+    },
+    "sound/alk_grome/alarm_et.wav": {
+     "bytes": 438392,
+     "sha256": "0d33440f3daf79f42f888a18e2eeaaeba4862b7968d734b58754e237020a9bf3"
+    },
+    "sound/alk_grome/alarm_et2.wav": {
+     "bytes": 876644,
+     "sha256": "35f1ff6583478db5d0173a51b5274285815b841249384e5fde277b3b20e1eb5c"
+    },
+    "sound/alk_grome/aramb_windup.wav": {
+     "bytes": 118068,
+     "sha256": "00184ed2487eb79fce6a41833b0c3deb0c12db4bf75cd30680eda900ad42e1c3"
+    },
+    "sound/alk_grome/arpump1.wav": {
+     "bytes": 18262,
+     "sha256": "11ae2c08c7d5f7f777eade75770a1623386d0e0096a19076fff13e9ddec6318c"
+    },
+    "sound/alk_grome/base_ambientloop1.wav": {
+     "bytes": 3480328,
+     "sha256": "e4970d2e679e7ddfdb6da696ceabb9d2ab0d6005d17ef2e56dd61eb6370f58d2"
+    },
+    "sound/alk_grome/basetry.wav": {
+     "bytes": 10518,
+     "sha256": "9f180f7bb823b1e7138fbe6f2d6acc9e9055a736223535c8dcb0f3e2e32a3c0f"
+    },
+    "sound/alk_grome/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/alk_grome/default_stop_hl2.wav": {
+     "bytes": 98836,
+     "sha256": "3dfe2f3c4e1c450ce6bbbd401a0d22f9829ffc39da7883f69019484d07298f8c"
+    },
+    "sound/alk_grome/demonwind.wav": {
+     "bytes": 357574,
+     "sha256": "8bca3e8f399d9b6e2b8a7c4e0a21c462e8a5bb1ff5044fc4e0255d6081cecbec"
+    },
+    "sound/alk_grome/drone.wav": {
+     "bytes": 30902,
+     "sha256": "81993d96ab337f78c2778cecffe4767605fed210e0ac2303a46ac898979eea13"
+    },
+    "sound/alk_grome/drone6.wav": {
+     "bytes": 18522,
+     "sha256": "dccccac054680ac00f16dd87a2f303bd9653578736ba18a56311fe55256c1176"
+    },
+    "sound/alk_grome/keyboard.wav": {
+     "bytes": 66850,
+     "sha256": "2dddfabc3ca827a9f908a00cdc6b35784b18ca1912c86337dbdd39900bbf686a"
+    },
+    "sound/alk_grome/ma1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/alk_grome/power_on.wav": {
+     "bytes": 77722,
+     "sha256": "690023a6a8a145b78a5c2a2eff2e15e4ea6f606fbeb7469a9a083101df255e99"
+    },
+    "sound/alk_grome/power_shutdown.wav": {
+     "bytes": 1118464,
+     "sha256": "e0ab1a0f67a2d37a525f7a73e8ee8c3a26f746e027fa1501f6648f5586ea2048"
+    },
+    "sound/alk_grome/rumble2loop.wav": {
+     "bytes": 99166,
+     "sha256": "d2247f41caa1b7540e883c7f6bd8abb59c05ef9269d5aa963469e903940a5915"
+    },
+    "sound/alk_grome/suck1.wav": {
+     "bytes": 110392,
+     "sha256": "99fec7fb4632a06fe033df49b65eefc1426dce1e4d23adc7d8788d4e9065280c"
+    },
+    "sound/alk_grome/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/alk_grome/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/alk_gw/choppa.wav": {
+     "bytes": 82726,
+     "sha256": "caf182035ddb397a69755780032ff46e39b34111e13015dad38b0f3015ca96c1"
+    },
+    "sound/alk_gw/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/alk_gw/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/alk_juz/dronehum2.wav": {
+     "bytes": 183654,
+     "sha256": "03545ae0f88b788e69e09c0aae2cccfa727a2609ef224c7d1d3451f0e6172709"
+    },
+    "sound/alk_juz/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/alk_juz/flyby1.wav": {
+     "bytes": 260406,
+     "sha256": "3fb54dce36de4164173ff68f2eed3a5b24a81c784b7d0758c29ba27620c11378"
+    },
+    "sound/alk_juz/radiostatic1.wav": {
+     "bytes": 102196,
+     "sha256": "3f1a71599802c66c63e53f5bafc8b660734fd8b623b41eb1870f26adf96a1146"
+    },
+    "sound/alk_mh/alarm.wav": {
+     "bytes": 4198,
+     "sha256": "79094546244d3b2672134d40970512cbc9c260ba6501939f90623dcfa7836042"
+    },
+    "sound/alk_mh/cranemove.wav": {
+     "bytes": 7710,
+     "sha256": "64cac7908811572bda114bcfa66d8b1470b894df1a5c6074f246ce5477666bc3"
+    },
+    "sound/alk_mh/cranestop.wav": {
+     "bytes": 10278,
+     "sha256": "92ecc69bba538b1f624cdce0c0e45c663c6e070320546123519bc3622b0a0196"
+    },
+    "sound/alk_mh/drone.wav": {
+     "bytes": 34230,
+     "sha256": "042fd60360482b1aed17df4ae5a5bfe096282ddc173b4f47e82384c4c5ed1782"
+    },
+    "sound/alk_mh/emove.wav": {
+     "bytes": 33182,
+     "sha256": "0f9de23e794e7fcff8dcfd0397c92404d51dd0e299d0b909ef16afcc4615b00e"
+    },
+    "sound/alk_mh/industrial.wav": {
+     "bytes": 32030,
+     "sha256": "c994aced4e1a944e04653e6d3a3f284d11f9974528dda2f0918a3b62791d1f64"
+    },
+    "sound/alk_mh/rotor.wav": {
+     "bytes": 84212,
+     "sha256": "6cd09e076bca0871c75e13a9c73f9d3b172c3d36e8ed979bf680b035c3b724fd"
+    },
+    "sound/alk_zigi/amb16test.wav": {
+     "bytes": 184128,
+     "sha256": "5c029ad6bc9c66c2f6d4c45a43b1bc15cf11d1b12a68276711e60865e4fea814"
+    },
+    "sound/alk_zigi/forcefield.wav": {
+     "bytes": 67928,
+     "sha256": "feb389e023228507b3c8e1718a57ebabec36af1f474d051b9ee950c4c6a806f4"
+    },
+    "sound/alk_zigi/huuto08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/alk_zigi/huuto24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/alk_zigi/kone.wav": {
+     "bytes": 190760,
+     "sha256": "59197f823b479c66c41163d82fed6dc13a715aef429b5e551ba80ca6f7c229fb"
+    },
+    "sound/alk_zigi/laf1.wav": {
+     "bytes": 126074,
+     "sha256": "a320badd6eb1189349ca484ae7f0dd005fb3f86be89618f22fcaca61f46e9b55"
+    },
+    "sound/alk_zigi/rumble2.wav": {
+     "bytes": 66200,
+     "sha256": "b2ca38e13253361aa1780c05269652c4aed4094f274948e865be6849d4a3b908"
+    },
+    "sound/alk_zigi/rumble7.wav": {
+     "bytes": 639494,
+     "sha256": "e19851eeca4d295a1e42cfece3fcced40779f14f73a4e923e3768f2cb0553a76"
+    },
+    "sound/alk_zigi/tuuletin.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/alk_zigi/valo.wav": {
+     "bytes": 26356,
+     "sha256": "c8203b1d67aa1e2458a5ac8e3edb9e7b79498b04251abd01c33356e65ad1681f"
+    },
+    "sound/alk_zigi/vent1.wav": {
+     "bytes": 153876,
+     "sha256": "0ac26f5ec7c080562c73ca3dae0fe0a705136912b641919f91f3f701875a76bb"
+    },
+    "sound/alk_zigi/ventsu.wav": {
+     "bytes": 32876,
+     "sha256": "1e0f99ffadead8460a7a4bed1c6b2c16cddd70050e1524e9cdaf6724a9dc81b5"
+    },
+    "sound/ambient/aramb1.wav": {
+     "bytes": 44476,
+     "sha256": "4c6440672b87575dd8ac5a267621881b9c70e48722cf9a4aa75a4a9b384fea5b"
+    },
+    "sound/ambient/arcohum1.wav": {
+     "bytes": 20418,
+     "sha256": "3b42cb1b62f62acabdc8ef8612ab4343b71b165c3525552701ef769f90020960"
+    },
+    "sound/ambient/arhum1.wav": {
+     "bytes": 20740,
+     "sha256": "e374f3d90564808e019abe09f4464b704512cf85ff0f3b4bb3c955b4153184e3"
+    },
+    "sound/ambient/arpump1.wav": {
+     "bytes": 18262,
+     "sha256": "11ae2c08c7d5f7f777eade75770a1623386d0e0096a19076fff13e9ddec6318c"
+    },
+    "sound/ambient/arwind.wav": {
+     "bytes": 30408,
+     "sha256": "34248569bb7ab66f5e1d874e15c7a91d89fd2b70d27e5521456b2589581fe1e6"
+    },
+    "sound/ambient/chatter.wav": {
+     "bytes": 190760,
+     "sha256": "59197f823b479c66c41163d82fed6dc13a715aef429b5e551ba80ca6f7c229fb"
+    },
+    "sound/ambient/comp.wav": {
+     "bytes": 12164,
+     "sha256": "ab8e3b13981bb432cca44ad4b7467734f52d01927018e72c99e7c4d052dc7874"
+    },
+    "sound/ambient/conveyor1.wav": {
+     "bytes": 348058,
+     "sha256": "ca68f9d44a06155fec7a886675c825b247d2b21996e92daeb76d9f47db2cf2a7"
+    },
+    "sound/ambient/crickets.wav": {
+     "bytes": 12236,
+     "sha256": "d5cf6e56884a8e43469408d4788ec6e573167901586df259a938cd088c998ef9"
+    },
+    "sound/ambient/drone.wav": {
+     "bytes": 30902,
+     "sha256": "81993d96ab337f78c2778cecffe4767605fed210e0ac2303a46ac898979eea13"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/hum02.wav": {
+     "bytes": 37836,
+     "sha256": "8b2ee1b91fa663b6111de9251011142475831ece70ee091022b800b715f1bfa2"
+    },
+    "sound/ambient/intake.wav": {
+     "bytes": 25682,
+     "sha256": "e6d13169ce4680dd83903473897fd6e7ce1e51fab00c6df2127ea993321c05b0"
+    },
+    "sound/ambient/lava1.wav": {
+     "bytes": 926316,
+     "sha256": "41964be60ef167936d0ef74f47fdfa3c2b147f7ec1f5f26fbb312ee71be3a6bd"
+    },
+    "sound/ambient/lonoise.wav": {
+     "bytes": 32876,
+     "sha256": "1e0f99ffadead8460a7a4bed1c6b2c16cddd70050e1524e9cdaf6724a9dc81b5"
+    },
+    "sound/ambient/motor1.wav": {
+     "bytes": 52340,
+     "sha256": "c48511a37143e9ed50ae7c1d1f28235b007762949d3d18549fc545cc670c0a24"
+    },
+    "sound/ambient/motor2.wav": {
+     "bytes": 52014,
+     "sha256": "7f36cda5c01aea4e6b356ae4d0b31b68ca15d7606eefd30f4739a64fc4e86e6c"
+    },
+    "sound/ambient/rain.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/arachnofloyd/death1.wav": {
+     "bytes": 119460,
+     "sha256": "d16c7ff30e9df62fbcda102befbd61fe234532f6aef30d0b34c25330679682bc"
+    },
+    "sound/arachnofloyd/death2.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/arachnofloyd/idle1.wav": {
+     "bytes": 34254,
+     "sha256": "35d6991a10637251ec0d6b830f7f57f394e4eed06e7a9dced86f0128ba5bc49e"
+    },
+    "sound/arachnofloyd/idle2.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/arachnofloyd/leap.wav": {
+     "bytes": 70884,
+     "sha256": "f47323f618db14755c57e9e25213267dcffc501fbaa9a201176ab99db6cda928"
+    },
+    "sound/arachnofloyd/pain1.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/arachnofloyd/pain2.wav": {
+     "bytes": 15906,
+     "sha256": "9c4bdc81c73787cb67677e0021b71d9e24734ef3ce272d9020dc6611a1d87842"
+    },
+    "sound/arachnofloyd/sight.wav": {
+     "bytes": 48620,
+     "sha256": "97a055dbb8e5935190348b2c2d50c6d99ab35c29f3ebcd0f66d6263bdb5485e4"
+    },
+    "sound/arachnofloyd/step1.wav": {
+     "bytes": 74932,
+     "sha256": "a8744a3e50dccf9ee391da2f381c2ecf6701a76441406929ee4581c7717b880f"
+    },
+    "sound/arachnofloyd/step2.wav": {
+     "bytes": 34478,
+     "sha256": "22ce43aa18537f7b04e31263a46dd02e181d538fdf5918d55f8ce0acbb930676"
+    },
+    "sound/arachnofloyd/whirr1.wav": {
+     "bytes": 19762,
+     "sha256": "9e2029071248e6d45f1b0d518983bad5bc5f841cda6bcfba09486e111add10de"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/bal/markiejumppad.wav": {
+     "bytes": 20045,
+     "sha256": "6b2743edcbc6325a93aec78c15d209829d92d75fc9535f88fafc437380bc6b57"
+    },
+    "sound/bambler/melee1.wav": {
+     "bytes": 4175,
+     "sha256": "4e0e2567b9d64b3ff86b33d95fa0158bf72372aeb4968a0c2489df942f9f7c4d"
+    },
+    "sound/bambler/melee2.wav": {
+     "bytes": 5283,
+     "sha256": "4bb91991bccfc33576eff19037e12666e9825348272d3dca40199e208bc00700"
+    },
+    "sound/bambler/sdeath.wav": {
+     "bytes": 14048,
+     "sha256": "c5253af82d203e75d132a00bbb555de055d2e356106d460f34cb8c9a2ee5e643"
+    },
+    "sound/bambler/shurt2.wav": {
+     "bytes": 3736,
+     "sha256": "0f1a51e0ff72f23a4de7684d4408344b7b7bd2cb805609168d2f2459e1b8660d"
+    },
+    "sound/bambler/sidle.wav": {
+     "bytes": 4907,
+     "sha256": "ea2232ba791e306cc86f58303413d8f3fbc7dd38091281698f4d846b6cafa483"
+    },
+    "sound/bambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/bambler/ssight.wav": {
+     "bytes": 11376,
+     "sha256": "de766aa056ca5f7dc6d179e6a220ef906ceacc0341b5cb3d91a4d0e75ff55338"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/bloodshot/bomb.wav": {
+     "bytes": 141228,
+     "sha256": "6fa171d6bbb3dc07f9c0fb422ceb2e3e20934e9a0465589717dfdc14c92b016c"
+    },
+    "sound/bloodshot/doormv1.wav": {
+     "bytes": 43818,
+     "sha256": "729ad30245f7b9036d197f742c067c741ab4513992322f1e844a8bc5411d54d6"
+    },
+    "sound/bloodshot/drclos4.wav": {
+     "bytes": 5582,
+     "sha256": "99c4e2100335a5c217d370277dd218602a2419e12afc6f2fd9974ae81b7cc9ca"
+    },
+    "sound/bloodshot/error.wav": {
+     "bytes": 6516,
+     "sha256": "316c201dd7a44b79f6bf07db8d03003bc07d61b754a8d940c733e3dca58fcbf3"
+    },
+    "sound/bloodshot/fan4.wav": {
+     "bytes": 19502,
+     "sha256": "5bde811e4ffba54790ec5f4d4fbc922c0d2bd5f7b0b229d21233f83c39b80e5c"
+    },
+    "sound/bloodshot/hydro2.wav": {
+     "bytes": 18420,
+     "sha256": "1d3a8e3151c52582d9f1032a6756dbd8d62f0974f3b95386265bdbc426a36eef"
+    },
+    "sound/bloodshot/liquid_bubble.wav": {
+     "bytes": 129688,
+     "sha256": "838ec1e72b2c433408a342a48518987edcb2124932eeb477d59653540b13d6ea"
+    },
+    "sound/bloodshot/liquid_burnshort.wav": {
+     "bytes": 89464,
+     "sha256": "4ea16997389f1aa35549869a338f2093f40d14df030c381a7659cc7e3cbf8bfc"
+    },
+    "sound/bloodshot/plat1y.wav": {
+     "bytes": 38690,
+     "sha256": "2c691a78650dec47a2ea0e3ef697a1af06ed86019e0756b7df3b9ca9d4135dbc"
+    },
+    "sound/bloodshot/plat2y.wav": {
+     "bytes": 11602,
+     "sha256": "0e8585808da24f28484f56a28c89a0e5938fe4044d5a8d796ed6fc3cfa7f79ff"
+    },
+    "sound/bloodshot/power_switch.wav": {
+     "bytes": 66382,
+     "sha256": "5c006bb7315e6eb6d2367ae30a78f0abec8ae2a1e2b6a2c9af88354962b0f33f"
+    },
+    "sound/bloodshot/reactor.wav": {
+     "bytes": 204254,
+     "sha256": "2fb09312579dbb219eea83d2320a0ab8bf8b8aaa93a449a05a9d60c6e393ecbd"
+    },
+    "sound/bloodshot/slimepump.wav": {
+     "bytes": 92716,
+     "sha256": "248e6507a0ef5aa3dd166df7aa2e6254cb4fbfff6f4f1eca7fca4738e9f05e10"
+    },
+    "sound/bloodshot/truck1.wav": {
+     "bytes": 6908,
+     "sha256": "2daf8d56e43cccae533efc5b8c1dfaa14eb3327cb8e5d4ab542fdbc7683aa1d1"
+    },
+    "sound/bloodshot/truck_drive.wav": {
+     "bytes": 1245432,
+     "sha256": "9516a14cd76e18dfe12d8766015344bb810961e0e12747674efde43c9f607c37"
+    },
+    "sound/bmfbr/alarm.wav": {
+     "bytes": 21058,
+     "sha256": "539cb807f9fdd4c93c24ad09f57249d600c109dfdd78a7f90f294ffb4c7e8b6b"
+    },
+    "sound/bmfbr/barmusic.wav": {
+     "bytes": 77898,
+     "sha256": "af57a7b9b00323f6395f9f81af4fb5971657ad764665552036b057442c7c18e7"
+    },
+    "sound/bmfbr/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/bmfbr/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/bmfbr/dronesewer1.wav": {
+     "bytes": 345280,
+     "sha256": "ee8cd803398a007f2f3b412dd2401098586e1d38f558daa748ea4e86f10267ad"
+    },
+    "sound/bmfbr/farambient_l.wav": {
+     "bytes": 330958,
+     "sha256": "4c65d4dd9c8111a0b13d625a86a30f1a6ff97b0acfb03423009fc57100981547"
+    },
+    "sound/bmfbr/farambient_r.wav": {
+     "bytes": 330890,
+     "sha256": "a843e4b6958b198fa7de5f54fc8902040c7257f151df89f23dadae77920da960"
+    },
+    "sound/bmfbr/industrialbuzz.wav": {
+     "bytes": 57112,
+     "sha256": "ac872a81a917704e4e418d7f83f2b7cdb35d3f35671e11261634727dfb7cfca9"
+    },
+    "sound/bmfbr/machine_loop1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/bmfbr/machine_loop2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/bmfbr/rain1_nl.wav": {
+     "bytes": 154490,
+     "sha256": "ab83161b01f9299cad8af7142f688c4f2f36e16e973eb42fa6faa13a7a6cc51d"
+    },
+    "sound/bmfbr/reactor1.wav": {
+     "bytes": 207486,
+     "sha256": "71b3bb44e623638db55b899c9847ca8c05d5c9c16c0897c28044b64c8060dc25"
+    },
+    "sound/bmfbr/rumblelong.wav": {
+     "bytes": 105990,
+     "sha256": "46728daf18b142575d50049188030a153c0e3e994dc83ea375c43ba6da171b3c"
+    },
+    "sound/bmfbr/rumbleshort.wav": {
+     "bytes": 33500,
+     "sha256": "6b389aa1afcebdd8838bb0e900c2bbd32e409a7cfcc19553e1d007d89404310c"
+    },
+    "sound/cyberscrag/hit.wav": {
+     "bytes": 22334,
+     "sha256": "a16ef33d94d56fb6984b2a3d06104a3cc292bdb38ec6ee22c8b10457b2cb415f"
+    },
+    "sound/cyberscrag/wattack.wav": {
+     "bytes": 25912,
+     "sha256": "6bed724b7ef9bdd480448396ed4498c75f848bf2a1e6d2879cb2b2484cdd1a7b"
+    },
+    "sound/cyberscrag/wdeath.wav": {
+     "bytes": 20684,
+     "sha256": "24602233cca209122250ba7c284933992aa2393795ea5c528a57b9986e2fc319"
+    },
+    "sound/cyberscrag/widle1.wav": {
+     "bytes": 13465,
+     "sha256": "8902628d2201eda9396c0dc134ebda8b8d5c37dabddcd286f8387aadc6532750"
+    },
+    "sound/cyberscrag/widle2.wav": {
+     "bytes": 23094,
+     "sha256": "76af020e5c25f40ab3020bbd065a9b83b9b0a51120d47d137a7abff4eb43e193"
+    },
+    "sound/cyberscrag/wpain.wav": {
+     "bytes": 8687,
+     "sha256": "af2e8589d381e634f607048ce71200df832c9e3a32147891b5bdd2efe2ff5bf0"
+    },
+    "sound/cyberscrag/wsight.wav": {
+     "bytes": 13079,
+     "sha256": "2f9178f6515eb4cd518b418441c40d1376aeaf6f42f7791533f5f4b6da87fd68"
+    },
+    "sound/doors/alka_doorlocked.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/doors/q2door1.wav": {
+     "bytes": 30572,
+     "sha256": "3f05bddf76379933970c532656b6350bc53820319ce1cb9d4ea9288210427eee"
+    },
+    "sound/doors/q2door2.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/dread/dread_death.wav": {
+     "bytes": 49692,
+     "sha256": "22000ff613ff52eab0605418681affaf7aeef4acc420d3dddd50a9031ac1ca38"
+    },
+    "sound/dread/dread_pain1.wav": {
+     "bytes": 29220,
+     "sha256": "67e443f78043cb9fc4213bbfbc3cd847785a66849fb7b36dd6467494487e0aec"
+    },
+    "sound/dread/dread_pain2.wav": {
+     "bytes": 23380,
+     "sha256": "914fffe3ad6c02fb78be873ee96405a40df22cd321beee2d673d0b6ebbafcde4"
+    },
+    "sound/dread/dread_sight.wav": {
+     "bytes": 70792,
+     "sha256": "50449a772b2ac778b810a69de58cb63c8bbdea529091720a41a1052b7196632e"
+    },
+    "sound/dread/dread_sight2.wav": {
+     "bytes": 58420,
+     "sha256": "f7952137b648f6376a1ba4e968679abb17fc648ede87bb0dd32f633271ad80ee"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 110256,
+     "sha256": "895cfb57c0d27369530fd5e9b29abd491a989ad0a63ddb00f05dd9e4777a5cdb"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/frogman/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 32638,
+     "sha256": "3cf3933f34c7baef52df54d5b03db40424e9f7ee72e5aa5a4dba489d71be2af7"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 27662,
+     "sha256": "ec38e73fd1ffc33cd25aa065e5f5897c21a494e380763ff80b6be482689b5e33"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 44186,
+     "sha256": "7600cd32fe980646fddcf5a9077d8d43df1bca1f2ed05bd92ce8cca273ad6636"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/items/shard_pickup.wav": {
+     "bytes": 18260,
+     "sha256": "388923a63b48720647b9e0f2862c35bb1d5cad2e162ace343845b3fe36b48af4"
+    },
+    "sound/items/trifecta.wav": {
+     "bytes": 16412,
+     "sha256": "00baad51adaa3f5d6664e85ae5442221db6818bfd85124c164324d22f6723ab2"
+    },
+    "sound/items/trifecta2.wav": {
+     "bytes": 32778,
+     "sha256": "f742a9cee4a53ef52fce55d5e9ddaae9c6b20d2127e16c0def6cd11b3d2d6380"
+    },
+    "sound/items/trifecta3.wav": {
+     "bytes": 10728,
+     "sha256": "a78bfc9fa4fbf0c3c1e85bee273ee053598989a09146bd29e97dda811c49a473"
+    },
+    "sound/items/trifecta_sounds_v2.zip": {
+     "bytes": 29483,
+     "sha256": "693e53f4d59daa0df6448a8d3b5f23ce2a99047689e0071c0986ae6d008d1ebb"
+    },
+    "sound/lieut/alert.wav": {
+     "bytes": 8700,
+     "sha256": "7ebbe83ae1b5d159c9f0a0ae5f3dea126650ed5d6f98a22d1512dcfcb19a23ca"
+    },
+    "sound/lieut/objective.wav": {
+     "bytes": 10052,
+     "sha256": "aa7d6726a458eaa48bf2e20446c57360b82ac23bfbd06bad7b6e01ae95ca8b0d"
+    },
+    "sound/lieut/target.wav": {
+     "bytes": 6754,
+     "sha256": "eebd50c75585894c7d5305f6c066aaef1efaca9a59e27b80d03e8ae4d69caa69"
+    },
+    "sound/lieut/you.wav": {
+     "bytes": 7126,
+     "sha256": "6bfb031b0d69b8ae4ef2e9b201da43c523ae88de344907648d4064e07477ee1c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/conc_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/misc/door_closed.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/misc/ebell.wav": {
+     "bytes": 15220,
+     "sha256": "1693337ed8873f1159e56c2925afaa210f5c28bee4e2c42d27e29bee8e06cb5f"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 4054,
+     "sha256": "b9c44f73c8bdbc900af4f06600e0d6456a040b296612b7d0fe53391285976a44"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 4098,
+     "sha256": "4fad66341514c9aa2b31b4c2fde7563369090da9b0b3a51e08bca3100f2ec282"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5054,
+     "sha256": "d158ddc35360bc43934b7a8a9b7cc830f7510e6bb3a640813157822b27b5217a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 9726,
+     "sha256": "73b74099c8cb43ab2fb09b28b72ddd9f73f2d2a4f8a00a8e835490f366680c92"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 3226,
+     "sha256": "48551cc717e5011df78a38c6a71bb001e4f62a1858a3952311499653ff423a07"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 5802,
+     "sha256": "751050f97456a0c07e88a249d40dde96c2d14640e21670ccdde983502998dbba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/mutant/mutatck1.wav": {
+     "bytes": 6116,
+     "sha256": "410f926534f21705e78a804ce048b0c15e62fe0c68a45aae1b3741fb227551f7"
+    },
+    "sound/mutant/mutatck2.wav": {
+     "bytes": 18260,
+     "sha256": "66009d09adf71f10117c74f5004c995fd48362b2f4fcfaaa3bc2da01e66d115f"
+    },
+    "sound/mutant/mutatck3.wav": {
+     "bytes": 28840,
+     "sha256": "2dd8a615ca2be248c8370d7480f5a8ca9375d31e6af41bba603df660d31883a1"
+    },
+    "sound/mutant/mutdeth1.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/mutant/mutidle1.wav": {
+     "bytes": 81004,
+     "sha256": "8c7e8ad544d7e2470bd61d88c5cd8be1a0eb66f57aaf113f82d990ee00450073"
+    },
+    "sound/mutant/mutpain1.wav": {
+     "bytes": 56716,
+     "sha256": "49ff5f97fedc87c1ac06dc43d4ff0a0fd09fb481354b6373d607bfabc9a57a6a"
+    },
+    "sound/mutant/mutpain2.wav": {
+     "bytes": 58740,
+     "sha256": "b79f1cce60226daa3e3ca8c134da968d54ad51abd9c37ffebdf3d46c5d9f91c6"
+    },
+    "sound/mutant/mutsght1.wav": {
+     "bytes": 107316,
+     "sha256": "7e15e392edc3f2d5ae9e3bde3dfe65595a85728022245f74b81f072d75dce798"
+    },
+    "sound/mutant/mutsrch1.wav": {
+     "bytes": 101244,
+     "sha256": "44484ef4c189511fb0a8d0f2bea83e443e1f1bd51cef04f518f3820e58e88a69"
+    },
+    "sound/mutant/step1.wav": {
+     "bytes": 8140,
+     "sha256": "0d9af35156c84213ac7ffbde54d0f2518fe9d39bba4edc48c94e71bed4f7ec4d"
+    },
+    "sound/mutant/step2.wav": {
+     "bytes": 14212,
+     "sha256": "f7c81df1bff56c8aeb49891fa822c37ddcb019e97a654738a9fb8ee351d19eac"
+    },
+    "sound/mutant/step3.wav": {
+     "bytes": 4092,
+     "sha256": "89856afec31f800219c45253514d0fdf5b5bd800c32f87ba74dd0c21df181550"
+    },
+    "sound/mutant/thud1.wav": {
+     "bytes": 32428,
+     "sha256": "20ed5f20729a068801d06904365e46c9d692dec835710a9b8090d0a1956d6919"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    },
+    "sound/player/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/player/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/player/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/player/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/player/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/player/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/player/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/rail.wav": {
+     "bytes": 97196,
+     "sha256": "396a85e1e2083f2b1eaae89a3f33a21145a643f3f50419523497719ef8e7598a"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/rider/sight.wav": {
+     "bytes": 26356,
+     "sha256": "40ace6f3beeb920ba1bbdb197f8ece18d312762a71e494726289e16703d75d91"
+    },
+    "sound/rider/step.wav": {
+     "bytes": 40524,
+     "sha256": "a43e24ecbc62d44bce466b1e682ebf64c230e03f4d79449406ce021dc8276a9a"
+    },
+    "sound/rider/thump.wav": {
+     "bytes": 15444,
+     "sha256": "af29f4e8f6debb1223aeb5d840add4ae01cb5e9f6bd9a26efeadff518f34380d"
+    },
+    "sound/scientist/allnominal.wav": {
+     "bytes": 23778,
+     "sha256": "e26f9bb3c24d9a9e0da38395048f6dacffe82d800da49d56378027250393d69a"
+    },
+    "sound/scientist/alright.wav": {
+     "bytes": 9666,
+     "sha256": "372c1aa91e6841bec2441215c894b7d149bdeaef33f907d23bb7eaf637520ce3"
+    },
+    "sound/scientist/asexpected.wav": {
+     "bytes": 15982,
+     "sha256": "306933848b673bd14d7074d59e45a8c97bc00a2897601509e52e5835e2ffc997"
+    },
+    "sound/scientist/c1a0_sci_crit2a.wav": {
+     "bytes": 28364,
+     "sha256": "f972684c74eeb51872873cc2b7053448c6cdd716b8c3535929fdbcc508d62ef5"
+    },
+    "sound/scientist/c1a0_sci_stall.wav": {
+     "bytes": 13704,
+     "sha256": "541c192ad5e8a68c76706ec17b3deceafbdc607bfc372ddfd300532f8aa1eaef"
+    },
+    "sound/scientist/cantbeserious.wav": {
+     "bytes": 13236,
+     "sha256": "fc4a8a379f70e33db79a49c667dcd9f1622de29d7b32ef3973c4ffdb5d80ee44"
+    },
+    "sound/scientist/cough.wav": {
+     "bytes": 14878,
+     "sha256": "b4e620259623347a5be3f7eaf3c531e6ea9ef2e97ac42997dd78cfee9327f7bf"
+    },
+    "sound/scientist/sci_die1.wav": {
+     "bytes": 15558,
+     "sha256": "c2306d7f9fa58f99961c347b06ef26305b99ac43ec27b2b222962e1f3a9ccce9"
+    },
+    "sound/scientist/sci_die2.wav": {
+     "bytes": 5402,
+     "sha256": "14deecb570d1e315b772713d54b7250043bb0dd5f3d5538cd0636e39a523c54f"
+    },
+    "sound/scientist/sci_die3.wav": {
+     "bytes": 3104,
+     "sha256": "075cdbc5837d91b61ad7599cdb3abf9323872816f8966c83deab9c0a6e04d7d2"
+    },
+    "sound/scientist/sci_die4.wav": {
+     "bytes": 4024,
+     "sha256": "e6ca0d4f18ac6c1246926646568618057cb70b5cee995c1c2dd69f0179b892ad"
+    },
+    "sound/scientist/sci_dragoff.wav": {
+     "bytes": 8986,
+     "sha256": "0c6a21cd5edf01e495e1258e9a76c05d62c0e3cd697e787fd43fd4bd9126483b"
+    },
+    "sound/scientist/sci_fear13.wav": {
+     "bytes": 4534,
+     "sha256": "dabce7a6c12980f947f7504da264fabb67a804d2e478b7f252ab527fb21a92d0"
+    },
+    "sound/scientist/sci_fear15.wav": {
+     "bytes": 4764,
+     "sha256": "f0d23c680ad138c3cc12da78a3e45cbf3daa47e5da9bc62a1dbb3b27389565a5"
+    },
+    "sound/scientist/sci_fear6.wav": {
+     "bytes": 5588,
+     "sha256": "ff2702b2b9e517b90ea0c2853775a4a95160edfae5af0a7f9208f07624d84281"
+    },
+    "sound/scientist/sci_fear7.wav": {
+     "bytes": 8458,
+     "sha256": "f2a39185c2d39a03b39afd7fe6f942b2f35fd17135ade8ceb4c31968c768aafa"
+    },
+    "sound/scientist/sci_fear8.wav": {
+     "bytes": 5804,
+     "sha256": "4455a29590d5f42ebbf06e600d8ba3f45acfd5000a6b8045891cbecf1d937970"
+    },
+    "sound/scientist/scream01.wav": {
+     "bytes": 14666,
+     "sha256": "b738de99aefbe3a45724914dd6eb79c0f8c219aaf733554a8a5eb94836c22320"
+    },
+    "sound/scientist/scream06.wav": {
+     "bytes": 13938,
+     "sha256": "dee8ac2058635d00458e2e74402d1cfcb5362c64259fc2c4f3b6bba31bdf6337"
+    },
+    "sound/scientist/scream08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/scientist/scream09.wav": {
+     "bytes": 6130,
+     "sha256": "85947649f5fb1491732365849a3025bf5c76c791b395cfdf421fbbd6ec58d351"
+    },
+    "sound/scientist/scream10.wav": {
+     "bytes": 5392,
+     "sha256": "fff4c0735f9c312be7cda848fc2867590437ffe9758fe685e3b4c94678ca1f48"
+    },
+    "sound/scientist/scream14.wav": {
+     "bytes": 4824,
+     "sha256": "dcb7dfb0e307b813476b2e55dceb59d8ae2b9514b1ef02034ea255fa5f086b05"
+    },
+    "sound/scientist/scream15.wav": {
+     "bytes": 3048,
+     "sha256": "37d26fe2d2b8a39d0fec0eceec0ca974ec3dd7fed33bae0d3230a934954105f0"
+    },
+    "sound/scientist/scream16.wav": {
+     "bytes": 2328,
+     "sha256": "4ff04ce8ff07af708c84dacc8df114b68620d47e8e4e4c78dfc4fd33a8a9b98d"
+    },
+    "sound/scientist/scream17.wav": {
+     "bytes": 3836,
+     "sha256": "82fb51224e06db5022adfa58f0b02353c333229ed3312f86dd9ec4f04813c37c"
+    },
+    "sound/scientist/scream18.wav": {
+     "bytes": 3066,
+     "sha256": "bfefcf745ab8d30db11f9113ecf9ba1c5bc6d9b2351c53f3f46d66e03cbea3fe"
+    },
+    "sound/scientist/scream19.wav": {
+     "bytes": 2504,
+     "sha256": "47cc414d201aadb7ba2fe0ce0567ff5360e90fd9de4a167520988513f358ed41"
+    },
+    "sound/scientist/scream20.wav": {
+     "bytes": 21310,
+     "sha256": "124cb45d3d5533572e3cfe4b42bddad2a03dc0d8de1c89a42ea57433432e3a6e"
+    },
+    "sound/scientist/scream22.wav": {
+     "bytes": 15206,
+     "sha256": "6e0a509eb2468466591622e74724c31103b8b60f5d8f29514fb57e9d9d12c9d4"
+    },
+    "sound/scientist/scream23.wav": {
+     "bytes": 21988,
+     "sha256": "8521907e8cecc22e6924d23295a5e8d31333d265ca27a9533b083b68e9da6d12"
+    },
+    "sound/scientist/scream24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/scientist/scream25.wav": {
+     "bytes": 8122,
+     "sha256": "38281749deffb4e567896f71e7bcb75d7b2e253e404a953a5eea6eeb989f156a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/spiderbot/sactiv.wav": {
+     "bytes": 17066,
+     "sha256": "f21587ba9bfd159e48c5b3aa1c6e94eac7157053e4e5699459233fb28c2631c8"
+    },
+    "sound/spiderbot/scharge.wav": {
+     "bytes": 7300,
+     "sha256": "b58064dac4e12bd6685edbfe61417a530cde1e5175336193b2fa7a292aca8ef7"
+    },
+    "sound/spiderbot/swalk.wav": {
+     "bytes": 12636,
+     "sha256": "5534fe1b11fea5406aada214681dba031ec4a01e4b660c405b679131ba07a7cc"
+    },
+    "sound/tormentor/angry1.wav": {
+     "bytes": 88890,
+     "sha256": "60f757f523a9cbb3a57c335bbeda8cedbf990b9d20a5b359e610b712a1344b4b"
+    },
+    "sound/tormentor/angry2.wav": {
+     "bytes": 90912,
+     "sha256": "2f38dddb69cf0df2c1e5b028ca06ea22d979e637afa927919e9a93876dc955d6"
+    },
+    "sound/tormentor/death.wav": {
+     "bytes": 176628,
+     "sha256": "7060ecdadac0b1c9eb3574284444932573e4af13082f01374ed8a4633387bb66"
+    },
+    "sound/tormentor/fire2.wav": {
+     "bytes": 52092,
+     "sha256": "4133a00c7ef157d291d800524a148c188a314eb5ca14246958b8ddfeb0d4fe41"
+    },
+    "sound/tormentor/idle1.wav": {
+     "bytes": 115740,
+     "sha256": "78feebc847dccab66478718b66971870f11246c416e2f2c1e9830c459e4c0347"
+    },
+    "sound/tormentor/idle2.wav": {
+     "bytes": 122218,
+     "sha256": "0270712fe40851bb21d959932b4f8f75bbe8b985e2ff383319059c656ac0ce56"
+    },
+    "sound/tormentor/pain1.wav": {
+     "bytes": 67334,
+     "sha256": "03f255d6ee0d6fb83f2a643491f4cd24d9c5ff86444a51b3cf8b5a0de3d86bbc"
+    },
+    "sound/tormentor/punch_hit.wav": {
+     "bytes": 76614,
+     "sha256": "e524d16b000237615bae3b8fed7b74726823cd4258561196f4641728047aaa26"
+    },
+    "sound/tormentor/punch_swoosh.wav": {
+     "bytes": 33044,
+     "sha256": "d0ef38ef4bf33d0c2f92b22c2a767c4efd66eefaa724df50b394958a7be5a705"
+    },
+    "sound/tormentor/sight.wav": {
+     "bytes": 94334,
+     "sha256": "34a13e6469c5e0ce2f6d18721b0cdd634731b9a9f8910a8bb8b685f63dadfaac"
+    },
+    "sound/tormentor/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/tormentor/sting2.wav": {
+     "bytes": 21674,
+     "sha256": "dd2d40459c7aa9d374efe2f219c34773f390df9f5177a83dbfa5fd638a13c542"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 43820,
+     "sha256": "32082cd1d44903409e97de782e5d9295272840e13280665a0ef3ff862b187f0f"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 47570,
+     "sha256": "0dd8defb8ecfb1ea72e6ac70ab182573775812e2d7990dd2897d02d3c38464f5"
+    },
+    "sound/weapons/spindn_click.wav": {
+     "bytes": 9986,
+     "sha256": "b84866cddb7e61eea9ca49208d427c2289d63e6e3e2f59d4d51e302573079bc7"
+    }
+   },
    "sha256": "c58fa9330dd4af61898c8551a22c9c32cb500a0f89493c886800d12e9fa73d2a",
    "timestamp": "2021-12-03T16:32:16.000Z"
   },

--- a/json/by-sha256/e6/e6a2da9f31c222bbcd169502bc30bfbb569f33bb739e830ca0a9b07824d4c5d1.json
+++ b/json/by-sha256/e6/e6a2da9f31c222bbcd169502bc30bfbb569f33bb739e830ca0a9b07824d4c5d1.json
@@ -12,6 +12,48 @@
   },
   "kpcn2014/PAK0.pak": {
    "bytes": 11225224,
+   "files": {
+    "maps/kpcn.bsp": {
+     "bytes": 10603384,
+     "sha256": "c49fba8dbc5b994d57454bffcc9728a64feec494c91d7fb3f3d015d9c244a318"
+    },
+    "progs.dat": {
+     "bytes": 392600,
+     "sha256": "b1e23f1c48012541143bd3ab33da4085318796bdfe8dbc56efffa6a919fe777d"
+    },
+    "sound/misc/r_tele1.wav": {
+     "bytes": 33910,
+     "sha256": "f46866709eba7f3295bcbf4b76f82ab67c164cde157c28cc7d078f52f7e47b47"
+    },
+    "sound/misc/r_tele2.wav": {
+     "bytes": 16044,
+     "sha256": "cbbfc92424d4fb331ecff09cb7cdd0c19be4e1707f6fa1dee0d5d2e9b7d74a07"
+    },
+    "sound/misc/r_tele3.wav": {
+     "bytes": 24030,
+     "sha256": "72221e0d7698e88ab85bcfae05c4fd744051d5645f10dbb85c2913f09d88dc1b"
+    },
+    "sound/misc/r_tele4.wav": {
+     "bytes": 26886,
+     "sha256": "f780efa5456494fd1c46132ca56b82962c5de1d8d5d44bf28ee027843dc29aac"
+    },
+    "sound/misc/r_tele5.wav": {
+     "bytes": 34166,
+     "sha256": "723214fe0824a18445da9652ffa188580815db66de90dcdee435e7d5d56017cc"
+    },
+    "sound/misc/secret.wav": {
+     "bytes": 61532,
+     "sha256": "0da18b9c30b1d6505374b08d86d257a97f7e54279441d50cbbb63704385feb7e"
+    },
+    "sound/shambler/sattck1.wav": {
+     "bytes": 8274,
+     "sha256": "ce0dee3958612dada12836d64c6508a04e33e4fe60f91b4402c891485ff436df"
+    },
+    "sound/shambler/sboom.wav": {
+     "bytes": 23746,
+     "sha256": "d600374ca6ccb64e60d72644ce331c9045fb3bf7b2b87867439bec32a7defbb8"
+    }
+   },
    "sha256": "2e2104107cf7a1357c97f250bb1f06b346ba592169e10b8c4fa638fead456683",
    "timestamp": "2014-07-03T00:44:24.000Z"
   },
@@ -22,6 +64,43 @@
   },
   "kpcn2014/src.zip": {
    "bytes": 3074630,
+   "files": {
+    "src/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2014-07-02T18:46:00.000Z"
+    },
+    "src/entities.ent": {
+     "bytes": 50741,
+     "sha256": "788386ebb051eee7be9d7aa57169afaa9ea85201a5e68d75ea641663ec2fbb58",
+     "timestamp": "2014-05-03T18:01:10.000Z"
+    },
+    "src/id_base.wad": {
+     "bytes": 8759084,
+     "sha256": "f09baedff098cafbc5b8886559c796aaea2bac8e8034ce140c135a108e7d3c69",
+     "timestamp": "2006-07-25T23:47:50.000Z"
+    },
+    "src/kp.ent": {
+     "bytes": 3986,
+     "sha256": "941c53d1bb65b8f7b03e8df3f0bbb892f5451c684923f0b044409863423eebfe",
+     "timestamp": "2014-05-03T18:01:10.000Z"
+    },
+    "src/kpcn.map": {
+     "bytes": 3889344,
+     "sha256": "1e9b02de7b3bdda66379cb917db88967998d74c581aee5a235383d18f7a7c63c",
+     "timestamp": "2014-07-02T16:45:30.000Z"
+    },
+    "src/kpcn.wad": {
+     "bytes": 3674692,
+     "sha256": "dc4d58b20222da9abb1d60ff3709672730e86205fe53412c41ee209256aa2b74",
+     "timestamp": "2014-06-02T23:36:18.000Z"
+    },
+    "src/teh_sauce.txt": {
+     "bytes": 43,
+     "sha256": "6b88572272e5d8a2370383891822e65fc6ea5627c45fa2f7152d8260a5e86066",
+     "timestamp": "2014-07-02T16:04:34.000Z"
+    }
+   },
    "sha256": "2ca09ccf3281edfb1e4d852d80b774d25edfa1f8ee756f84299d895d0a2be958",
    "timestamp": "2014-07-02T18:46:30.000Z"
   }

--- a/json/by-sha256/e6/e6ee551a480f5752503510dfef78d1bcf607b17aeab688a5112d085bc8f99ca7.json
+++ b/json/by-sha256/e6/e6ee551a480f5752503510dfef78d1bcf607b17aeab688a5112d085bc8f99ca7.json
@@ -27,6 +27,324 @@
   },
   "nesp09/pak0.pak": {
    "bytes": 14149494,
+   "files": {
+    "maps/ne_os1.bsp": {
+     "bytes": 1677800,
+     "sha256": "cee5f1cd686b7f9977c661032c608222712a584f28e20637eea567e86743d07b"
+    },
+    "maps/nesp09.bsp": {
+     "bytes": 5913044,
+     "sha256": "e80caab190957cdb6bd5a0c830e16c4a11bd1eaf2a0ee48c39e2cd8229a993af"
+    },
+    "nesp09.cfg": {
+     "bytes": 371,
+     "sha256": "46a4c9f1c965911093c1e5aa187b1f467369780ae50c19da469d7eb034cb2e0e"
+    },
+    "progs.dat": {
+     "bytes": 543536,
+     "sha256": "9d43828dae026ed5d41cbfc00fca2631a504e94369b3899e03cc06e2f210ad45"
+    },
+    "progs/b_key.mdl": {
+     "bytes": 12820,
+     "sha256": "937fcd77d89f3184e656a26feac68e8e512e94442ef58bbfdabe2b03c093ec1e"
+    },
+    "progs/ballexpl.spr": {
+     "bytes": 4152,
+     "sha256": "c5b4e3d57663340b7ecebbab694efbcfeac4714f1d443ee5da145ec4730bd641"
+    },
+    "progs/beam.mdl": {
+     "bytes": 20644,
+     "sha256": "8765febc701a518d5ce23c7e0cb06a3090f647b83cf9749ca08850c10c707447"
+    },
+    "progs/demon.mdl": {
+     "bytes": 156640,
+     "sha256": "28d61c4827ccd1a2e1ad1e9bbe275be1263caec3c9fab7df9ad3aa88482493ca"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 207552,
+     "sha256": "1ba01029d4113cc832aa5ab551c7bf060b5f7a4eb1afde35607564413bfee2ec"
+    },
+    "progs/explode.spr": {
+     "bytes": 278904,
+     "sha256": "f9362544773e228355cc48adc9cd638b95fd6eb83c60e3cf715c63821b26a2a3"
+    },
+    "progs/flames.mdl": {
+     "bytes": 63068,
+     "sha256": "18482cf5c9a47a448aaeabceadca70c91b5c18f70e556164736da048b72572e5"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 23220,
+     "sha256": "02cd8f73e07a9a8dd156cc241bd553f0351b42aad6fae722905e14c716abe084"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 67688,
+     "sha256": "9dd923e25645f427190bfbc68b85c59f867598ad8ba75aea87acbc78d10e9686"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 108204,
+     "sha256": "53f1e920c7c866d349167a8bff62eb0b614c5628de89d51774b3b8e88d17a0d9"
+    },
+    "progs/hkball.mdl": {
+     "bytes": 45876,
+     "sha256": "9ccbfd59b35936fb771a7ccc1ae12cf54fead8e36f315382a7cffc56a7fde3d7"
+    },
+    "progs/hkball.spr": {
+     "bytes": 105148,
+     "sha256": "ce4938c9e813e648404b25b82245cad4400682d885d044b9d353a8039cfdceb7"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 323272,
+     "sha256": "7a071d70cd76a1b4e19e6450815a2cc41a32cfbc40d3f25f78b9424ec3bff97c"
+    },
+    "progs/nevir.mdl": {
+     "bytes": 57164,
+     "sha256": "5dbc362fa1583df6f6faa85c6729812ece51f2901eb5c9126ce11e1da1175161"
+    },
+    "progs/oldone.mdl": {
+     "bytes": 103208,
+     "sha256": "7e0c89b69dd19069bec6abffe425388c1a1039f3aaf5f835548540efbefadca6"
+    },
+    "progs/plasball.spr": {
+     "bytes": 6300,
+     "sha256": "cee2a846ad7bc1e94ff646a2e2845ed7f67eab19663c7b60014597459deb6b06"
+    },
+    "progs/plasexpl.spr": {
+     "bytes": 457856,
+     "sha256": "77f823e91d72a68ade80dad7c5084d6c9e3c663a38b17d9320024134a267ab16"
+    },
+    "progs/plasma_1.spr": {
+     "bytes": 864,
+     "sha256": "51db0898cbd66894673b120a33c35524cc62e1e645b9530fc6670e7fdc722827"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 12820,
+     "sha256": "7ece7b32827a8193a22f357cd49e44d044319f1f300bda43b1a3067a5203bfb4"
+    },
+    "progs/s_fire.mdl": {
+     "bytes": 27596,
+     "sha256": "a75b33454397b9cdcdd55ab1ae4a6bce0552abaa75c639426ec79966555b76fe"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/shamball.mdl": {
+     "bytes": 8788,
+     "sha256": "80b41d7a040956668c8436fa3ad7e43e5b3c0cede923975b5bcee1b4dd629787"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 169404,
+     "sha256": "5492386814e9142d4d385d4e985f1b207dc7cdf5de4ef7e3526a69ca2131c83a"
+    },
+    "progs/t_drag.mdl": {
+     "bytes": 12736,
+     "sha256": "108d7c3eb1b2f4893d6d4147d1c66c8d93d6094c2f629fee90442155844ec407"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 24516,
+     "sha256": "fd2bcd20d2746a6f04c609b2078035803b6bef105aa606320d562521773fcd9c"
+    },
+    "progs/w_drag.mdl": {
+     "bytes": 36636,
+     "sha256": "82facf32c6a8c3fbda1d4e4e6fcf01112f9a1e65eef7be7d46ea66b497a8aaae"
+    },
+    "quake.rc": {
+     "bytes": 276,
+     "sha256": "cea69b124de89a2f7cb558110b09c631ab44c461f9a9e626997d4dd3917060d7"
+    },
+    "sound/amb/wat_amb.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/amb/wat_drip.wav": {
+     "bytes": 172196,
+     "sha256": "67981b8c9bf711f49ab7ec276872613bd5e1f8e68301d0d7998c190e0d49cde6"
+    },
+    "sound/amb/wat_fall.wav": {
+     "bytes": 118946,
+     "sha256": "f294768ec6843365659f3dee5a33a1c9f2c19b35d1d6d12db3a8701da5aeb2cb"
+    },
+    "sound/ambience/birds.wav": {
+     "bytes": 161962,
+     "sha256": "9a4b9237b3e7dd5e328201e19564dfcdb34fdf5bb7a6fbe1335fec69a4b26d5c"
+    },
+    "sound/ambience/highwind.wav": {
+     "bytes": 158882,
+     "sha256": "41decf2ffe971f07420ab67deb227a285246d92eb01f77284920f01cc3652284"
+    },
+    "sound/ambience/lava.wav": {
+     "bytes": 21526,
+     "sha256": "5b176c3f2dff2c31607b5008c41c8f7a69e51a5d7d12bc1856f6c6a77a2ddece"
+    },
+    "sound/ambience/lava2.wav": {
+     "bytes": 56056,
+     "sha256": "7c58858b1b8bc1576c8c650749da2931b8f5946c90ab61b51877bffae50d2abe"
+    },
+    "sound/ambience/lavafall.wav": {
+     "bytes": 29690,
+     "sha256": "64087063a190b5f07479c8da533549c4d01e66dc2a9d4f01c879158672216c70"
+    },
+    "sound/ambience/metal.wav": {
+     "bytes": 583412,
+     "sha256": "08ef60128461fdc97284c18bc3dee8032a6d6e17db90f76811533780134f34ba"
+    },
+    "sound/ambience/mine.wav": {
+     "bytes": 146448,
+     "sha256": "1153b0ca91386d0f8818722480ba1e2032e8beb5229300c710203ecbdedaef5f"
+    },
+    "sound/ambience/under.wav": {
+     "bytes": 179502,
+     "sha256": "afadedb77f99ee3cb48427d803a12a9704023c4d4a8824a4db4b0e325e911a96"
+    },
+    "sound/boss1/throw.wav": {
+     "bytes": 35012,
+     "sha256": "9bb193a34961037c3a1e51a736e8b0530ebe82689a032106c2179d4a4d6f89ad"
+    },
+    "sound/demon/ddeath.wav": {
+     "bytes": 9140,
+     "sha256": "12f5dc4a16ad825e2363a176c303ee934f1467d19ea9db0361ff4288d7b9a3fe"
+    },
+    "sound/demon/ddeath2.wav": {
+     "bytes": 12296,
+     "sha256": "7297dc22813ce3211dc685e41e6bf6cd8d2a8aa441183f71115e030cd62fe553"
+    },
+    "sound/demon/sight1.wav": {
+     "bytes": 11052,
+     "sha256": "afc4e2ce38d97fcc5014739156f367d5b4f13fcbb60e8c4ede5c7e7922a6cdfb"
+    },
+    "sound/demon/sight2.wav": {
+     "bytes": 8804,
+     "sha256": "5059fa6539cfd92e6064b1c57385f4606c1d2ff769df42ade62ed3be4b39a0b7"
+    },
+    "sound/hknight/attack2.wav": {
+     "bytes": 43612,
+     "sha256": "a0a7f18bb08548b093efca29f9816da5d84056615783083637c50b7cad46a625"
+    },
+    "sound/hknight/ballexpl.wav": {
+     "bytes": 13288,
+     "sha256": "de2b63849f48a91646064a19d9cd71e4b81bbc4b0a1561e7b50fc52deef7f73f"
+    },
+    "sound/hknight/omega.wav": {
+     "bytes": 8960,
+     "sha256": "d9de409b60d06566bbb5ecc548a5afe029c2e723176d3666b7ae735fcd856b34"
+    },
+    "sound/hknight/sight2.wav": {
+     "bytes": 12712,
+     "sha256": "07ba881ba9f65ae2ad1c918e50581c2709527fc0d121b46cfa3a25eec30947a0"
+    },
+    "sound/misc/glass1.wav": {
+     "bytes": 20744,
+     "sha256": "8e7c43ae8cd50bbaa2c271491c7f94a1490e3a19b99fed5268eb33cd57575826"
+    },
+    "sound/misc/nesp09.wav": {
+     "bytes": 1088830,
+     "sha256": "b015da35ec5b485782ae29d18d0b1b8aab7812f4b7401ab8cb55aa6a494926db"
+    },
+    "sound/nevir/hit.wav": {
+     "bytes": 17124,
+     "sha256": "4362084f00fac96f48546b21cb11d98ead63a565ce74144cef40621f31acf7cc"
+    },
+    "sound/nevir/wattack.wav": {
+     "bytes": 12142,
+     "sha256": "9b42e7d90846b9d9f40f3d8fd521f0bb215448b348080124472fd6cd2bea7b22"
+    },
+    "sound/nevir/wdeath.wav": {
+     "bytes": 12802,
+     "sha256": "bea231f6155d75051731330239446f69ed2812ba9664ccdc29d6d0bece89b2fe"
+    },
+    "sound/nevir/widle1.wav": {
+     "bytes": 12270,
+     "sha256": "d82c6c7b6b63575cf2c740ca82c382497d1f130ea6a538f86c316d7c2f9c1b5c"
+    },
+    "sound/nevir/widle2.wav": {
+     "bytes": 12342,
+     "sha256": "c1321628bafbfe926e5ec55056c242b398e263e1e866df35ee21c0faebebc80e"
+    },
+    "sound/nevir/wpain.wav": {
+     "bytes": 12334,
+     "sha256": "58a3f200ece0b6cf803d69015a05d8c18b537d29c359593002a9fb226c550cb2"
+    },
+    "sound/nevir/wsight.wav": {
+     "bytes": 15246,
+     "sha256": "aae53f85a3777e767e75261b64f0408df0fbfa5a53093ab104f7a2c0c7ebf3e2"
+    },
+    "sound/ogre/chaingun.wav": {
+     "bytes": 9490,
+     "sha256": "eae9abbf73b904061625e5a1a9b5a4c6b3f365efe7478fd57d97771d9e8c3a84"
+    },
+    "sound/saffron/attack.wav": {
+     "bytes": 12250,
+     "sha256": "bb8e94b297a5f731e1be6f8127513519ed77636799faed24ae38562241bc8644"
+    },
+    "sound/saffron/death.wav": {
+     "bytes": 30190,
+     "sha256": "c075e6105b1ab837651b42684c8c05007be8c9d75a58cb601ec6934e07ba603e"
+    },
+    "sound/saffron/death2.wav": {
+     "bytes": 21038,
+     "sha256": "7023c2d88304ebae5bb26cf2432f28ccc798ace6e59313941b9fddb71cb35f13"
+    },
+    "sound/saffron/death3.wav": {
+     "bytes": 18734,
+     "sha256": "398d6d83a539fa583cccff4396e8579fe303232d2de24ed4fc3d9de870d477d3"
+    },
+    "sound/saffron/explode.wav": {
+     "bytes": 27690,
+     "sha256": "b7eebbb64696612ee18d8d1e25b9c5cc334a4562cb99758a446a22490215f349"
+    },
+    "sound/saffron/explode2.wav": {
+     "bytes": 14798,
+     "sha256": "4c6b14b163905823f629644fbec088f37f712cf7f76e10e2f91ef23f2b573ae6"
+    },
+    "sound/saffron/explode3.wav": {
+     "bytes": 19028,
+     "sha256": "69ef0c65811704d8996b726d6e2cbcf70528d3ca7b2f28ec8814c20e7ab76ad7"
+    },
+    "sound/saffron/fire.wav": {
+     "bytes": 19790,
+     "sha256": "9931252a0f6fe77fc2044c6cee204889f988b74d96135b41bc0bcabf5ab09456"
+    },
+    "sound/saffron/idle1.wav": {
+     "bytes": 30190,
+     "sha256": "75efb7b979a740905bdbda7707f51f44f8585bc3515b99787e5c9a3244134468"
+    },
+    "sound/saffron/idle2.wav": {
+     "bytes": 33826,
+     "sha256": "10c03a2cc4db9b8d5aefbce9d596d767119e9fb69435fd721951c2788e06862c"
+    },
+    "sound/saffron/pain.wav": {
+     "bytes": 11936,
+     "sha256": "e7b476f5d719dc1906d70ab0c368b20f981700b3a0e5ee3736eb92cccfde484f"
+    },
+    "sound/saffron/sight.wav": {
+     "bytes": 21038,
+     "sha256": "c8dea8b9efad421984b50316cd355121ca27cc53e2d0708dca44a2f55a5d4757"
+    },
+    "sound/shambler/s1die.wav": {
+     "bytes": 21663,
+     "sha256": "b96dfc4791bc8cc99be9d72fb25dbeb4715b7b8598b28fa1eecbf5648768c007"
+    },
+    "sound/shambler/s2die.wav": {
+     "bytes": 21301,
+     "sha256": "de2054b277caa8d15718f85fdd1d4ebb1e8a6759ce7a03a9040b242743db742b"
+    },
+    "sound/shambler/sfire.wav": {
+     "bytes": 14598,
+     "sha256": "6a478fffe74cca67345903c4b08ed4889864db5446f7d7bfe661415ca8298b6d"
+    },
+    "sound/shambler/ssight1.wav": {
+     "bytes": 13081,
+     "sha256": "fb45ca50d2750378793c5dfe5447d520550b5787ab12cbfe134f0f4de6c9cf19"
+    },
+    "sound/shambler/ssight2.wav": {
+     "bytes": 26248,
+     "sha256": "127c34371425feceff7fb1d0ac847474015640140a4ae1675ebd677f8b8a9680"
+    },
+    "sound/weapons/lzap.wav": {
+     "bytes": 17804,
+     "sha256": "c0bcdeb399a90907b1f535d7dc9962718980d4c2ea76541da2c7a853341fb5b8"
+    }
+   },
    "sha256": "422456a403b491cd0a8652b527eda9262357b7df1d85c00f179023a6a1ebc420",
    "timestamp": "2003-07-09T14:54:30.000Z"
   },

--- a/json/by-sha256/e8/e8ae95cbf8baee5e566c62aa4ba98a79ccba62075bd3fcbecd131a5a4491de9e.json
+++ b/json/by-sha256/e8/e8ae95cbf8baee5e566c62aa4ba98a79ccba62075bd3fcbecd131a5a4491de9e.json
@@ -98,6 +98,2820 @@
   },
   "rm1.2/pak0.pak": {
    "bytes": 1148726306,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 256008,
+     "sha256": "99c64cf1c7dd5d513a59733bd769c9ebfeea696fd96eb6d4adf0aae74ed9c920"
+    },
+    "gfx/env/atsea_bk.tga": {
+     "bytes": 632859,
+     "sha256": "0170bac6e1114edec6fd9add7dd474b24dc047d4a1e05518b9bd5eb03444e827"
+    },
+    "gfx/env/atsea_dn.tga": {
+     "bytes": 574894,
+     "sha256": "0c1498451cd053afe41d6409ba14b156608623d316708d6a7e49383355b93fbd"
+    },
+    "gfx/env/atsea_ft.tga": {
+     "bytes": 578784,
+     "sha256": "9542abd9f7b51885b945f184e779caf83722f49dcbd1d623aba5424302fc07eb"
+    },
+    "gfx/env/atsea_lf.tga": {
+     "bytes": 603631,
+     "sha256": "a97250f90147c6633efdfe4a81234cf488a8e4b67f64352e8b009f3542be94e5"
+    },
+    "gfx/env/atsea_rt.tga": {
+     "bytes": 661491,
+     "sha256": "171aff8c805afccb39a373b4b41263650313082e00d8c1e9b6370b5a7b535e9f"
+    },
+    "gfx/env/atsea_up.tga": {
+     "bytes": 634513,
+     "sha256": "1bad6c1b80666490aefcedbc46821cbecec2c2c766197fb15b90954a0be21b0e"
+    },
+    "gfx/env/balebs4_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "286b4d71078131f41bbeed2d954f30d10c9f9eace766d65b6ebae437e509f65e"
+    },
+    "gfx/env/balebs4_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "e3375333742e6ec9d74be35cd53b7524840df3701dd1456df66a00fbdeb75b03"
+    },
+    "gfx/env/balebs4_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "4810d53912eea1504b961dfc256d160bbd0e0c31406a8a37a4bca9b23b891344"
+    },
+    "gfx/env/balebs4_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "f14e66a1bea217d05b31446612ffd7e91cc736f268668a59e607e97df7ecf89d"
+    },
+    "gfx/env/balebs4_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "2a8c407d732681308e72ea0216cff0d89ae735a3dda93a2dee7b31336a224c8a"
+    },
+    "gfx/env/balebs4_up.tga": {
+     "bytes": 3145772,
+     "sha256": "ec8ab3fa13db2193ed087441470d91fefeeca2db61d5ff47c1d5c97d79e33cc9"
+    },
+    "gfx/env/city_bk.tga": {
+     "bytes": 786476,
+     "sha256": "ae85a323970ca02fd920c5d0fd76ee365bd197530ba652b5e9b4eb9a2044a14c"
+    },
+    "gfx/env/city_dn.tga": {
+     "bytes": 786476,
+     "sha256": "0eb22f580b9b2f9d52a87ceca69ab576aacb6dd97fc983eadbb77577f5e3072f"
+    },
+    "gfx/env/city_ft.tga": {
+     "bytes": 786476,
+     "sha256": "83deb5cc238ead25db579228346f2c15364c18c8a1100fec03ef10ffc1e697d1"
+    },
+    "gfx/env/city_lf.tga": {
+     "bytes": 786476,
+     "sha256": "6e0318d60ba46915e1ec7cb066452b2dece51ec24ba4b47eabc276cf6cc67c28"
+    },
+    "gfx/env/city_rt.tga": {
+     "bytes": 786476,
+     "sha256": "5b01d8904170c202b9c8341cda6d707c63eb359ad77c9a369e2a417b8a165614"
+    },
+    "gfx/env/city_up.tga": {
+     "bytes": 786476,
+     "sha256": "26c264fba13d6a0e065282d9c05fc15e1b1f49c8c4b3b1046afbe5e3cca4af5b"
+    },
+    "gfx/env/desert_bk.tga": {
+     "bytes": 701188,
+     "sha256": "f1f711036366b486e074d0ef142c0719f5c3d42dd0eb76e1c98a7d35a8a39457"
+    },
+    "gfx/env/desert_dn.tga": {
+     "bytes": 779658,
+     "sha256": "2793a401717ce1206f91a8fb299df4e3c333e135511c1f5ed4d60a37f6e9f766"
+    },
+    "gfx/env/desert_ft.tga": {
+     "bytes": 631806,
+     "sha256": "49f9b6cef91ece307739a3b4413ba3104f5502b995117512f1f83d1bbc4d6334"
+    },
+    "gfx/env/desert_lf.tga": {
+     "bytes": 655314,
+     "sha256": "4d7226db424e55d993c7b30bed74106f3091a3b56345ca73bfa4ba7ecf04a41d"
+    },
+    "gfx/env/desert_rt.tga": {
+     "bytes": 649417,
+     "sha256": "6978740a2bc4b7bb4cf87d0a3ace4b302a28bbdbf2a4dae009f19b860ffaa93d"
+    },
+    "gfx/env/desert_up.tga": {
+     "bytes": 341983,
+     "sha256": "88f8980804bfbe03147a79b2186697af75631057ceb172d36c294f0eb16941b2"
+    },
+    "gfx/env/dustball_bk.tga": {
+     "bytes": 594799,
+     "sha256": "24725393d9b76aa828fff30bc58b663937f304ee51635b30042cda6fd8511a0b"
+    },
+    "gfx/env/dustball_dn.tga": {
+     "bytes": 708318,
+     "sha256": "61feba9593935653b134ba82eb25607f14df99682991e61bb83bfad621b31778"
+    },
+    "gfx/env/dustball_ft.tga": {
+     "bytes": 539992,
+     "sha256": "f20ee10a1e001717d67a63ff3c319b9d4ef65222b6b946fa527f014d538e6bf9"
+    },
+    "gfx/env/dustball_lf.tga": {
+     "bytes": 606109,
+     "sha256": "29e77ed6d358d9a957303688ee8130beddbbe2b705f004ea51f75f1b88d8e994"
+    },
+    "gfx/env/dustball_rt.tga": {
+     "bytes": 576947,
+     "sha256": "9e9db490f918e2762d8063d01a7d58c8d179325f3f1e95588886dd2339dc0dee"
+    },
+    "gfx/env/dustball_up.tga": {
+     "bytes": 498270,
+     "sha256": "1f3911e2426cddd2bb44feaf3fb77b38d4d8b4b5bd8084da26e676e59e344843"
+    },
+    "gfx/env/ep1_toxic_bk.png": {
+     "bytes": 2336206,
+     "sha256": "8f2c9230c98b4150c305d792e70874bbaeff7202e3dee0ee4138a1a8aa1718d6"
+    },
+    "gfx/env/ep1_toxic_dn.png": {
+     "bytes": 3569379,
+     "sha256": "92c2a1570a763a93f06dde5720fe1769f518c11abbfde60c932de0fade982919"
+    },
+    "gfx/env/ep1_toxic_ft.png": {
+     "bytes": 2712171,
+     "sha256": "49ebf277e67bf8b03234e1e15c22c492531523d199d7738992c69a734b8ef1f4"
+    },
+    "gfx/env/ep1_toxic_lf.png": {
+     "bytes": 2861509,
+     "sha256": "113448e784d37e477a1fd36e35893f63778f3405a3749d343aa1a719b493191b"
+    },
+    "gfx/env/ep1_toxic_rt.png": {
+     "bytes": 2525793,
+     "sha256": "b6b91435503ab93361a9c8cce15ed33a1d04f3f5e8e8bc6c553be240c99229d2"
+    },
+    "gfx/env/ep1_toxic_up.png": {
+     "bytes": 2601572,
+     "sha256": "68c7b7fbdbd4ed5f9f5b609b29f02e2e1adfac02e6b397d62fb2bf545e793ea2"
+    },
+    "gfx/env/mak_beksinskisky1_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "3da19e6822edcc3870072409d0aeb3b4b470a6c59c74a5f9b8bfeefe655f3405"
+    },
+    "gfx/env/mak_beksinskisky1_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "cbf8de3af603a9fc91d7533619ed72ade3cbfde856c8f4f273c1f8b12af72a13"
+    },
+    "gfx/env/mak_beksinskisky1_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "aff0502b2d2260de6c7dc4b10bb8765b11e85062fdb2fa3224d41e5d21d1513c"
+    },
+    "gfx/env/mak_beksinskisky1_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "b7efde04b48e6bde158c4a760e6c7a6ccc9563011fc8d9cb8b5502971871952b"
+    },
+    "gfx/env/mak_beksinskisky1_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "578aa512cad9015b90d5288147d36464b6deaad31341b206d0296b7f0e8751b8"
+    },
+    "gfx/env/mak_beksinskisky1_up.tga": {
+     "bytes": 3145772,
+     "sha256": "4d23ac2745f30032a2904e0143e2d7900698fbb60b9a42fc72e7b3106a10848f"
+    },
+    "gfx/env/mak_nebulacyan_bk.tga": {
+     "bytes": 3145772,
+     "sha256": "0b73edc6a3fb95ec09bb8660fa5ee0370cd46f520e83e6434f7a6921a2851e40"
+    },
+    "gfx/env/mak_nebulacyan_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "0f23f07004cd21e8665a3f5ccc4c8d333d826a340e564fbda4645f61c248db40"
+    },
+    "gfx/env/mak_nebulacyan_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "2f13d175459a8011565dbbfbaec9edafe2d2c9a95a37af23655ba3662635125f"
+    },
+    "gfx/env/mak_nebulacyan_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "f69cbf49089278bb1f29f1d5cb15c9cf14b1a8ffab4ae781c6f73576cd67dd66"
+    },
+    "gfx/env/mak_nebulacyan_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "5e9a46853fc1ccfb302d2ec260df1f9113cac99018ff3555840ba2ba32d247b5"
+    },
+    "gfx/env/mak_nebulacyan_up.tga": {
+     "bytes": 3145772,
+     "sha256": "74f5dd91b6a4c5ac4224e44df0e50b8d904221df8b04cb615fb6b2bbf9302df7"
+    },
+    "gfx/env/mars_bk.tga": {
+     "bytes": 786450,
+     "sha256": "c89b8882101cea7dce890e1afb75048ce6f525de3d05e8edffee264c894b14c0"
+    },
+    "gfx/env/mars_dn.tga": {
+     "bytes": 786450,
+     "sha256": "79be864fb91098e7e162938b56608557e4767852ee1a0c7212f58714242137c0"
+    },
+    "gfx/env/mars_ft.tga": {
+     "bytes": 786450,
+     "sha256": "d328319bc92b57cb74934dc6ec29c773994603ada8c0d7663407c0539f53a516"
+    },
+    "gfx/env/mars_lf.tga": {
+     "bytes": 786450,
+     "sha256": "81e0331ef5883d70ba9588cee8f52e0984b6a403491242ba4268e207e86d74cb"
+    },
+    "gfx/env/mars_rt.tga": {
+     "bytes": 786450,
+     "sha256": "11ed1e93813b4faf407631709e257c3a551ab868e37aca9ab34ba6e4b81f32db"
+    },
+    "gfx/env/mars_up.tga": {
+     "bytes": 786450,
+     "sha256": "6c50889b41d1760827c2871952fa9944c99499c1d9a9f6ba735cea5ef5f89087"
+    },
+    "gfx/env/morning_bk.tga": {
+     "bytes": 716529,
+     "sha256": "9eed6f2193fbbfe3ea6b50c7d36c2bcdc387f6805d7e2ebefd79c849af9d73a9"
+    },
+    "gfx/env/morning_dn.tga": {
+     "bytes": 781318,
+     "sha256": "554843bb20e9af1cc7236460c8ecee0ce5cc6fef12e301871ee13e8209633c0c"
+    },
+    "gfx/env/morning_ft.tga": {
+     "bytes": 706691,
+     "sha256": "0a3b31ed93c78a8a833ef251ea9773c00a35f324699a40a859fee14d2a17b5df"
+    },
+    "gfx/env/morning_lf.tga": {
+     "bytes": 766964,
+     "sha256": "90fe9aa82c50eb44552cc44f28b371fd942c5e1e89e3e5512d060b23a3e98bbe"
+    },
+    "gfx/env/morning_rt.tga": {
+     "bytes": 732806,
+     "sha256": "c4219a950b02c7186c992ab2cb72940e21c9c4c9814c7c02f79a4d791ebaf0ca"
+    },
+    "gfx/env/morning_up.tga": {
+     "bytes": 703696,
+     "sha256": "11893da767dd1740a40f4242f747f2f4568f699b06e56bd00b533325a5a0be74"
+    },
+    "gfx/env/nightball_bk.tga": {
+     "bytes": 505093,
+     "sha256": "0176f518ad1fff1fc5326589da5ddcd30cb7598f787f7c531cf921ee5f9e369e"
+    },
+    "gfx/env/nightball_dn.tga": {
+     "bytes": 488801,
+     "sha256": "12ab5bfb82651c2a551259870f6f8afd152d6f7c9fd208fd9a932da8f61b7ec4"
+    },
+    "gfx/env/nightball_ft.tga": {
+     "bytes": 385599,
+     "sha256": "32aa17db6421fe771223aa27be3943f18e7ac5c05b13d23309e2a100b859b4c9"
+    },
+    "gfx/env/nightball_lf.tga": {
+     "bytes": 485058,
+     "sha256": "4faa4ededd3767adfc1cb545b0258dbf251662974c14fde9f91ffb30726a7e0e"
+    },
+    "gfx/env/nightball_rt.tga": {
+     "bytes": 500886,
+     "sha256": "2b3a747a23855bc6c6f389304947400e54c72f9c2cd0ec8bd4cb05209ba92a75"
+    },
+    "gfx/env/nightball_up.tga": {
+     "bytes": 448166,
+     "sha256": "c10bdca66aab106e2e5d56046bd375205eae06dca75df74cd444ec01ce39bb05"
+    },
+    "gfx/env/rm_carcosa/carcosa_bk.tga": {
+     "bytes": 394975,
+     "sha256": "f982c67b9e94605d215d9bf96ac57d52b85ec923e1ea3ba10b3f4aae273b02a8"
+    },
+    "gfx/env/rm_carcosa/carcosa_dn.tga": {
+     "bytes": 607451,
+     "sha256": "ee337207b500097b76d82e156ec61fb41f373bb85814d7c67b37c760d77c16f7"
+    },
+    "gfx/env/rm_carcosa/carcosa_ft.tga": {
+     "bytes": 555607,
+     "sha256": "3f25efb0c7691249749d6f01d82a3479ac09f66137febf9bbd07e1f2c75534b7"
+    },
+    "gfx/env/rm_carcosa/carcosa_lf.tga": {
+     "bytes": 389080,
+     "sha256": "96d1123edbfc27dc530638600aa4d7bcd8ac40c8309b149afe1246a5c6294086"
+    },
+    "gfx/env/rm_carcosa/carcosa_rt.tga": {
+     "bytes": 402360,
+     "sha256": "7a204bffd56fca37ca0d769bc8bef9826634fbedfc4a234c890c6ce8e1e01b85"
+    },
+    "gfx/env/rm_carcosa/carcosa_up.tga": {
+     "bytes": 169870,
+     "sha256": "ce8af8ec60aa93ea04ae94f6461e64868f82aa58b28c9fbe09d451e53b40ffc2"
+    },
+    "gfx/env/rm_carcosa/mak_stellarinky_bk.tga": {
+     "bytes": 4194348,
+     "sha256": "4d0947b5805bada32bb9673cf5919b81e976e97e22c76cf42fe78ce65fd98e55"
+    },
+    "gfx/env/rm_carcosa/mak_stellarinky_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "4bb32dac85e4e032bc2b5fca85dd432250302ac89102e663f1a1fc84197f30b1"
+    },
+    "gfx/env/rm_carcosa/mak_stellarinky_ft.tga": {
+     "bytes": 3145772,
+     "sha256": "a513d9adc30487c3da2031ef856f92a3aaeef7655f88de8c3aab2a1067db12ff"
+    },
+    "gfx/env/rm_carcosa/mak_stellarinky_lf.tga": {
+     "bytes": 3145772,
+     "sha256": "a27f7a0a84aebe5725c207171761f9d14f1574b888575fbbc58503d385cc743b"
+    },
+    "gfx/env/rm_carcosa/mak_stellarinky_rt.tga": {
+     "bytes": 3145772,
+     "sha256": "21f2f011793e08f700fad5758a37783672edd878e18b568a3be6171088953c68"
+    },
+    "gfx/env/rm_carcosa/mak_stellarinky_up.tga": {
+     "bytes": 3145772,
+     "sha256": "43717f37c22837673b9893615aca5d96adaa2ea3a1d98ec6393775de2b1e7c75"
+    },
+    "gfx/env/rm_carcosa/mak_stellarinky_wind.cfg": {
+     "bytes": 77,
+     "sha256": "149a39823479b0bb4f6f2481dfb0cb7aa11fc90dacd4d0951543fd0cda822954"
+    },
+    "gfx/env/sea.pk3": {
+     "bytes": 1045062,
+     "sha256": "c02057a67471c098849d9f3ffd5254090158c574929ce57cc7b73dac8361160c"
+    },
+    "gfx/env/shol/shol_bk.tga": {
+     "bytes": 1048594,
+     "sha256": "128fe562f4209a0d12e0214b252dc758d2ceaac131c260865d32cf67fdb62e8e"
+    },
+    "gfx/env/shol/shol_dn.tga": {
+     "bytes": 1048594,
+     "sha256": "ddcee6f597e6abd4aa2a86a876557f1610d14595091e02850c6a0d8608cc8088"
+    },
+    "gfx/env/shol/shol_ft.tga": {
+     "bytes": 1048594,
+     "sha256": "0f06ed592759c064c95b9272810635d59f4896a75887feddca92310f98b850ed"
+    },
+    "gfx/env/shol/shol_lf.tga": {
+     "bytes": 1048594,
+     "sha256": "ded289b042a5fd2c0ada8fc0339c72d1313131f6d572689202adaef25bf9e9aa"
+    },
+    "gfx/env/shol/shol_rt.tga": {
+     "bytes": 1048594,
+     "sha256": "f28089efd3515d03ef7e9550c85e192d037229789efa78ddd049f597c2c0cf5b"
+    },
+    "gfx/env/shol/shol_up.tga": {
+     "bytes": 1048594,
+     "sha256": "edcc48632ab330f63c4bce3fc11abbc8c2f566984cffc3c78978a0d5f2cdaf95"
+    },
+    "gfx/env/violent180_bk.tga": {
+     "bytes": 4194348,
+     "sha256": "6c3035fb694ca65151528f713f92aa0828b19bc9d8d3c7103aa7eed48d7f07be"
+    },
+    "gfx/env/violent180_dn.tga": {
+     "bytes": 3145772,
+     "sha256": "a3b344abf47fae67c831aaa8d8b2ab7ff56ff1ed93091c6869139902060777ff"
+    },
+    "gfx/env/violent180_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "964ce0226b139a1af96de0c422e927d35917ad30f0c4027c1c386c7c32cc30db"
+    },
+    "gfx/env/violent180_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "b9cc1ef464535f9a911d56fb503a2e1aa68e6d07c7091cb62c42442a7d62ceaa"
+    },
+    "gfx/env/violent180_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "263af4a0d5b2e61303d8165d6b8a8b7e55d0c8dd79157ff133a5d50128d5f21b"
+    },
+    "gfx/env/violent180_up.tga": {
+     "bytes": 3145772,
+     "sha256": "3a9aae357ac1a8e8767e151024dab60845283422f204a354913282873f181413"
+    },
+    "gfx/env/violent180_wind.cfg": {
+     "bytes": 77,
+     "sha256": "b88d6646c7886eb2d5c521aa6fa567b8976a0ce10bc6859aeb8afb4ce285df8c"
+    },
+    "gfx/puzzle.spr": {
+     "bytes": 5624,
+     "sha256": "d1646c09f75fe07116cbc9029388b8eabe4be4cb9d2f7275e7bb911251295acf"
+    },
+    "lspike.mdl": {
+     "bytes": 1684,
+     "sha256": "59264317258f19955b967177f0dbc5be1733e4ca07c4c7b3cc333bb88bc0c46e"
+    },
+    "maps/autohook.bsp": {
+     "bytes": 532040,
+     "sha256": "d5c0aa110199264ffced6acc71a7e78d5d90f288c62c7ed799920e21d9fcae60"
+    },
+    "maps/autohook.lit": {
+     "bytes": 140708,
+     "sha256": "1e25ccb11692d4609fae6756d62b53dc08782c034379cdc0487029280b465dbf"
+    },
+    "maps/examples.bsp": {
+     "bytes": 1412460,
+     "sha256": "9ac7ab997e30edc951b826b7033f73dbde75f41ed8c0dfacf7129d286985b39b"
+    },
+    "maps/examples.lit": {
+     "bytes": 976016,
+     "sha256": "ad3e4082138932ebffac3d55c01295c3fc663ad657a8d7149986334fbe7a6af7"
+    },
+    "maps/examples.map": {
+     "bytes": 485840,
+     "sha256": "648eeac27e6b41c5d22b2e927958b422558b9be063d8ccea47823d6c44df6ff7"
+    },
+    "maps/inventory.bsp": {
+     "bytes": 125724,
+     "sha256": "4b0c99e8f014476d48042fedd389fd7ea1fad45981a4f31ed6a72e28e936b30f"
+    },
+    "maps/inventory.map": {
+     "bytes": 19894,
+     "sha256": "94edbbc12c05452f889bce1340f66694fd451b49367153f370d35979e0ef1fa9"
+    },
+    "maps/magnets.bsp": {
+     "bytes": 289048,
+     "sha256": "53046135efa0a3ae72dd70463afc47dfdcfe15f0a683bc0c9279b9a37b5ae84d"
+    },
+    "maps/magnets.lit": {
+     "bytes": 149276,
+     "sha256": "95d9342e81d9effdfd8d09fbfdc993b40a642a562b7118422308a09e025eeaa8"
+    },
+    "maps/magnets.map": {
+     "bytes": 70161,
+     "sha256": "a8852d097308887c3317200aec0cbafd2ba9de2aae9531f9fee8b6797e72bd3d"
+    },
+    "maps/rm_cabin.bsp": {
+     "bytes": 40086232,
+     "sha256": "e91422c989290d08da8d2ab773847d4a83aeb1fcdb445b165b8636ba36efcc02"
+    },
+    "maps/rm_cabin.lit": {
+     "bytes": 14327276,
+     "sha256": "d2b6e69e2d707cdfd83fc8a15efaa5128959f822b258b69c35b602b8256a4f72"
+    },
+    "maps/rm_cabin.map": {
+     "bytes": 18980682,
+     "sha256": "ef4a1d4972b0b3a769027c656424a80ca8ecc0d46a7fb6a2b9241c8d3be9ad12"
+    },
+    "maps/rm_carcosa.bsp": {
+     "bytes": 20080924,
+     "sha256": "a2094862f5145e4e15c3da18e6e23b1a130f3a2b1a0150ebf7cb7e4f3cf503c8"
+    },
+    "maps/rm_carcosa.lit": {
+     "bytes": 7070120,
+     "sha256": "22743761d376c4b05e171fbd8c7f46b4d5e90c120fe47857a1fc43c4f9de221b"
+    },
+    "maps/rm_carcosa_bandit.bsp": {
+     "bytes": 13576,
+     "sha256": "97b4867b0c231c537b131e55cceb554579a8cc328e466e731a254f3a8bdb2a9f"
+    },
+    "maps/rm_carcosa_bandit.lit": {
+     "bytes": 236,
+     "sha256": "b8d238230b9a17c31a50823363c99262e9ff67731affd38de9bc337deb380a34"
+    },
+    "maps/rm_carcosa_turret.bsp": {
+     "bytes": 131940,
+     "sha256": "acb0a1998758e03aebab1005c17f138a2a9eb355def623d8cefd857e63a078e0"
+    },
+    "maps/rm_carcosa_turret.lit": {
+     "bytes": 4844,
+     "sha256": "9754fdd61b698724c07b5370c44703290c84415773592d5fbc7aa25cbf8a9702"
+    },
+    "maps/rm_civic.bsp": {
+     "bytes": 43636520,
+     "sha256": "a60d6e62b2fecd1155ac56c144a7dd731debb185703131e25c9bf7da172cecbf"
+    },
+    "maps/rm_civic.lit": {
+     "bytes": 1783181,
+     "sha256": "209025fce6d3c1feaa27d854ce7f27c93618d6b89197091aab1d34cde76f5b67"
+    },
+    "maps/rm_directions.bsp": {
+     "bytes": 2920184,
+     "sha256": "531437ca634704f04e7cee9fdaf6761acb6c72b9708dfff20779cd83f28c117a"
+    },
+    "maps/rm_directions.lit": {
+     "bytes": 1612604,
+     "sha256": "733dd4739396d06413bcba07d08c7032f438372393882db2328c222330e50715"
+    },
+    "maps/rm_dynamics.bsp": {
+     "bytes": 5515204,
+     "sha256": "b75a5ca9d0e5e785fdc5a4de61f2d0e4b800a2bbfbafff82cc17e3c37a22abde"
+    },
+    "maps/rm_dynamics.lit": {
+     "bytes": 2007863,
+     "sha256": "4f629e278fa34dd40a8234aec33b15bcbb74a7295a363ab943c6ab78acf40463"
+    },
+    "maps/rm_dynamics.map": {
+     "bytes": 4613396,
+     "sha256": "119e84e63dc169dba0d44eea512b4f43c35d13c5971c334f4ddbd7c21704a4b5"
+    },
+    "maps/rm_echoes.bsp": {
+     "bytes": 11995044,
+     "sha256": "a03e8a85ff0e5240ee3d484cdbdf8ab64a2f3a8926300eb45ef62eca2611d5de"
+    },
+    "maps/rm_echoes.lit": {
+     "bytes": 4003919,
+     "sha256": "a15a87477a2514e4b9c11369202a4e544ee957c3ecb4c9dd4f17fd96fdcc89a3"
+    },
+    "maps/rm_heretics.bsp": {
+     "bytes": 78577876,
+     "sha256": "f1dbdf32b8b433cf5eb0ffc875fea90ae42f982c53cb94017e4948253b207edd"
+    },
+    "maps/rm_heretics.lit": {
+     "bytes": 10974020,
+     "sha256": "8929b062312ae0007c84efd82a611d14b337badf8434101cc26c6c1eef7d3db0"
+    },
+    "maps/rm_maahes.bsp": {
+     "bytes": 7488608,
+     "sha256": "c2eaf8dc221649ca56ed5f7f4390f0a556f347b0abb57ce472c080a2fb1f44cf"
+    },
+    "maps/rm_maahes.lit": {
+     "bytes": 2959004,
+     "sha256": "5410c3d9938cc22329456f9b0e6d66640ba19386594cd1a9fbc8f55547ff3c2a"
+    },
+    "maps/rm_maahes.map": {
+     "bytes": 5290281,
+     "sha256": "2fb422657289f55aad68a39b3752f62066de51ae63a024236c952c8b1ef690f6"
+    },
+    "maps/rm_minak.bsp": {
+     "bytes": 52111292,
+     "sha256": "519afcabdcfae6a8516691a305ed38dfb1e1be81d7f7eab1271553c4152e78ec"
+    },
+    "maps/rm_minak.lit": {
+     "bytes": 5216336,
+     "sha256": "5c5831211948b30aeae0f4392955d7b919a1613a1342b884e4abdc2b8dfafadb"
+    },
+    "maps/rm_minak.map": {
+     "bytes": 5817762,
+     "sha256": "f80063269710246a042cb28dde7c1d45b39ea06cb57bea60453cc6b432435626"
+    },
+    "maps/rm_moon.bsp": {
+     "bytes": 3286404,
+     "sha256": "d85fa0400a994b5c7f31d8bb99172fd7e5fc19be2b1c45cece29af938ad233cf"
+    },
+    "maps/rm_moon.lit": {
+     "bytes": 1517900,
+     "sha256": "44c8e49131d436aec802e6b08e9ef5c509928473e2bdc25eec4693587ab28964"
+    },
+    "maps/rm_myopia.bsp": {
+     "bytes": 22747480,
+     "sha256": "d6c2b26047a89e0b237378398d8d0dc631fffe89aad963ed37212e98e96ad346"
+    },
+    "maps/rm_myopia.lit": {
+     "bytes": 2409788,
+     "sha256": "487bffa76f3acd8ad057dacfb93c2daa2d00c4fa86df7f6a782a94e138fe70f7"
+    },
+    "maps/rm_myopia.map": {
+     "bytes": 6183270,
+     "sha256": "86ed014de5395bb423e6482fbd39c4702756469ae695373a3a4d41f967a9f862"
+    },
+    "maps/rm_peak.bsp": {
+     "bytes": 5043664,
+     "sha256": "93b7c1dc58195a64f18312814a1a1084ab5bea174c7bf7771913131a5b95f044"
+    },
+    "maps/rm_peak.lit": {
+     "bytes": 1153724,
+     "sha256": "0a54dadee9ee3d84b519edf9a4b5b79fadbdfe12bab010d533964c49e40036fb"
+    },
+    "maps/rm_polarity.bsp": {
+     "bytes": 4999528,
+     "sha256": "a6237f32767d44e73ff9ebbeb6b5741bd49942186cdbbc67c6a04a6cd26a99c4"
+    },
+    "maps/rm_polarity.lit": {
+     "bytes": 2385224,
+     "sha256": "c42427f89a7bed3032fef794a4c9fa76d5e226f8b914e9fe0532058dcfe0a444"
+    },
+    "maps/rm_re1m8.bsp": {
+     "bytes": 3754816,
+     "sha256": "23fc5416fc5754f217db4292fd783a7bdfd6edc8e8ab0c94bbb44793c67c0402"
+    },
+    "maps/rm_re1m8.lit": {
+     "bytes": 1777148,
+     "sha256": "be5202b2f01b59ba585c8f90d45b05786201ba5271a715741af11efa57a006e3"
+    },
+    "maps/rm_re2m6.bsp": {
+     "bytes": 9172212,
+     "sha256": "d0791762ab93526b5581cee91451b7e4cf5aa0bdb85931b0890987172bc4b901"
+    },
+    "maps/rm_re2m6.lit": {
+     "bytes": 3206276,
+     "sha256": "9f02b3daa3bfaf2fcefb2c7a9667ffebb26f636b56c2c00368ce64a02f52c5fb"
+    },
+    "maps/rm_respiration.bsp": {
+     "bytes": 23517164,
+     "sha256": "8a404d9c3110d18bd6427f5c9f6d98fbedeac719fcfabced27959b7172c910d5"
+    },
+    "maps/rm_respiration.lit": {
+     "bytes": 3736736,
+     "sha256": "35166fb8b05e5774d7dae2427c0a871e9ba1bd772c4728dd37aebc95ab4bf424"
+    },
+    "maps/rm_resurgence.bsp": {
+     "bytes": 88491440,
+     "sha256": "b812631789f041ff315ff00c47b6639e693b68630185c32a71c33720394bc03a"
+    },
+    "maps/rm_resurgence.lit": {
+     "bytes": 18724196,
+     "sha256": "c369c2b236603dfc9b8b9b134e768f5b8549a29554214dbc8944f9abab1a7638"
+    },
+    "maps/rm_resurgence.map": {
+     "bytes": 17391972,
+     "sha256": "f13ea9457504c82270120bc7819ba7d5cd49c2d4296f74068828ba75783a8683"
+    },
+    "maps/rm_substratum.bsp": {
+     "bytes": 6186276,
+     "sha256": "5adcefc10a9165bda18e692369735d90a1c43f13973b0c700214a2cc5f28b1c1"
+    },
+    "maps/rm_substratum.lit": {
+     "bytes": 2213408,
+     "sha256": "102f9d24b96d65a02d6b7a65bd7fcdd1ac87c11a4323c615c12895d77660bbfb"
+    },
+    "maps/rm_urn.bsp": {
+     "bytes": 20374684,
+     "sha256": "ce872fc51bbe56abbedce741c73b28c6685f926ad5bdb03b34d5783a146b04df"
+    },
+    "maps/rm_urn.lit": {
+     "bytes": 2132576,
+     "sha256": "3cf875e680289f9e5b583dfa0f8950c7a2798ad6e36214de5e5c692d29a6e2cb"
+    },
+    "maps/rm_waterfront.bsp": {
+     "bytes": 6501788,
+     "sha256": "7e6f9555582751c4f937c82c88274c68c6182848b7e1f81c7f78596381722c10"
+    },
+    "maps/rm_waterfront.lit": {
+     "bytes": 2831225,
+     "sha256": "1946c046227dc7807517ac62facc1c5c9bd8cedb51e8f1329fa92f094024bd8b"
+    },
+    "maps/rm_waterfront.map": {
+     "bytes": 4702785,
+     "sha256": "fe8393a5a24e4a3f3f2464cd3865f20af52241bb5f5cae7bd0daae8c2f10fb1a"
+    },
+    "maps/rm_yawning.bsp": {
+     "bytes": 4661268,
+     "sha256": "786fda9506c8fe4daf504d2fd57cb67c4a34a5b39cfcc6670b06c105c59ba5a7"
+    },
+    "maps/rm_yawning.lit": {
+     "bytes": 2137472,
+     "sha256": "d66b94f34b20b78cd8a99c360bafd842288980a6ce0b9bcd34674167dfa64be6"
+    },
+    "maps/settings.bsp": {
+     "bytes": 1038316,
+     "sha256": "70b5abb197ecb087623357280c054828cc0a47f3204ac96dbc6e26a3f2136664"
+    },
+    "maps/settings.lit": {
+     "bytes": 537587,
+     "sha256": "39d69a36c6a0f413ceccb12863fe99c0e2f5f521025f0b8caf28136159a81079"
+    },
+    "maps/settings.map": {
+     "bytes": 299347,
+     "sha256": "a6813e6933f882e9382fb1cb5d32c51d3d492b0db796ca396b52b5ff26d05be9"
+    },
+    "maps/start.bsp": {
+     "bytes": 63198836,
+     "sha256": "a8197fbf942d5f6b88824933a7220a057d1bcaa11cd580969ede222b6007d424"
+    },
+    "maps/start.lit": {
+     "bytes": 2686916,
+     "sha256": "2acdc28759cbb528575faede0401168752201b17cc47492b952d7881e948ad5b"
+    },
+    "maps/start.map": {
+     "bytes": 6794574,
+     "sha256": "45264059f0592c925adde444b00e987940192f63d184b70f879e417fa8afc183"
+    },
+    "models/break/stainYelGrnFB.mdl": {
+     "bytes": 50004,
+     "sha256": "7833f6e2abdb1805611f2e8f9e957d2df53f588d2a92168bfea54aba53bf7fad"
+    },
+    "models/monsters/arma_body.mdl": {
+     "bytes": 106512,
+     "sha256": "f50d36f2a3a38f4ee47f00922054fb2cb7afbf7719c3b5b2ad77c4caab9f40b9"
+    },
+    "models/monsters/arma_legs.mdl": {
+     "bytes": 51580,
+     "sha256": "c1d2c701521ec30e8d3d311f807e33bd63c21fc76eababf40dfb2e231d41008a"
+    },
+    "models/monsters/big_spike.mdl": {
+     "bytes": 1058816,
+     "sha256": "451458023db62875117f633b232d59b3b71a310ee2a7fd494e95db026b929bc7"
+    },
+    "models/monsters/enforce3.mdl": {
+     "bytes": 278028,
+     "sha256": "e867fd04bf2063e71f300fde2393ccad3d7c330dcf08c1bf61b231f53ab45f89"
+    },
+    "models/monsters/h_scourge.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "models/monsters/mon_lavamini.mdl": {
+     "bytes": 486920,
+     "sha256": "9d4cde267ac7995ce1330d09f28dcab59a7a25c0d5ddfffdcb2d9da005d7857c"
+    },
+    "models/monsters/scourge_arms.mdl": {
+     "bytes": 244804,
+     "sha256": "1473f5b3196c9ed4e7b709e8c744dc166ed2224a6073b771ce56c8a1db6d6fae"
+    },
+    "models/monsters/scourge_tail.mdl": {
+     "bytes": 244804,
+     "sha256": "67d4dd1b8376698b41efb4c3ba10085b5d49ddddb54243bb36859081390facbe"
+    },
+    "models/monsters/spectre_fiend.mdl": {
+     "bytes": 265688,
+     "sha256": "70f14b71b28e646f777bc24a79ad8ea4ffafb7a785360a0401a10e978308a5a7"
+    },
+    "models/monsters/techogrea.mdl": {
+     "bytes": 162036,
+     "sha256": "5792430724562eaf1df08f8d18db34a6e62b27b1836931f2269febe17caa9e52"
+    },
+    "models/monsters/techogreb.mdl": {
+     "bytes": 192180,
+     "sha256": "ed04d7428d2947bad6f32d0e2c482161866d58ef5c09ba0447aa02f4be83d4cb"
+    },
+    "models/monsters/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "models/monsters/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "models/monsters/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "music/track100.ogg": {
+     "bytes": 7984478,
+     "sha256": "a2d2d88fdef08317c6b87597a002cfc0288c83fcf2fa335f69a55e1bfe79b8b0"
+    },
+    "music/track102.mp3": {
+     "bytes": 4445599,
+     "sha256": "da9027e93d3985c9a3f3e1c5f72108ffcf6a81a64421e3efeb1e9ebc6c9a3cf8"
+    },
+    "music/track120.mp3": {
+     "bytes": 6146507,
+     "sha256": "0ba436852b82bdf85f0ef00242269b5727d45004d6ece09b52cd7554288d4ddd"
+    },
+    "music/track121.ogg": {
+     "bytes": 4907095,
+     "sha256": "187aeab4715f59991c05322efafd0362b8c543b1a423b1dac1a1c22525c1efe3"
+    },
+    "music/track124.mp3": {
+     "bytes": 4335072,
+     "sha256": "29cb994b64e2ca60c31e6d8cc9badc1a0407fc0410d8a8791b4e18f00a8e0953"
+    },
+    "music/track14.ogg": {
+     "bytes": 3518561,
+     "sha256": "10c7d37ac58683ee72ef067028f7ef0a50c2feeeb68e02d6dcc15f916d607b8b"
+    },
+    "music/track142.ogg": {
+     "bytes": 3770540,
+     "sha256": "53949723a50e965dd8abc45d01c14cdd05ccf84c9e81c992eb3a6d0adca77d7c"
+    },
+    "music/track192.mp3": {
+     "bytes": 15677888,
+     "sha256": "519005daab249738d6bd3dfee313d5ba26b2f7e7662ef098f6b27493ce6504cf"
+    },
+    "music/track195.mp3": {
+     "bytes": 5822847,
+     "sha256": "9214e53319e7b319374f1364bc3f29cc62cf1941570e902359557672f8533b00"
+    },
+    "music/track196.mp3": {
+     "bytes": 7234860,
+     "sha256": "805c3ded8f561fcccd96ba90a321660461899515c3d538f8d260a40db39ef1f5"
+    },
+    "music/track199.flac": {
+     "bytes": 8080764,
+     "sha256": "e200f2b3cd742c8bf2c956d23a8b8f2e9c5e4f0034a93db93478cfb3f23cbbab"
+    },
+    "music/track27.mp3": {
+     "bytes": 8219833,
+     "sha256": "839773153deb159a99bdcb3d95d28ef5c6bf34329edcfbb8004d5f90c7aefc41"
+    },
+    "music/track28.mp3": {
+     "bytes": 5637710,
+     "sha256": "a7e85c6b728a0ae18f086ae47b89626459b73de554262cef459b345b30719ccb"
+    },
+    "music/track29.ogg": {
+     "bytes": 3352457,
+     "sha256": "0edf3cae4f07765263eb23e1c659e1ea77f26b77a9adc998454a9912c2271b67"
+    },
+    "music/track30.ogg": {
+     "bytes": 2583885,
+     "sha256": "ab74853273d014e151b8da90147c141ca7de1043aa7f23dedef9098bbf072fa1"
+    },
+    "music/track39.mp3": {
+     "bytes": 5078313,
+     "sha256": "1a2b75caa4cd5d5175a98e79d9aab1a15114e0c705b6355919496305ef26b2b3"
+    },
+    "music/track50.mp3": {
+     "bytes": 10562872,
+     "sha256": "399fa3c6fe62efdd8a4198abed77fc58e21066ad38d7e0baa221235049f46dd3"
+    },
+    "music/track54.mp3": {
+     "bytes": 18285713,
+     "sha256": "94d154bbec206c2292a6f0322138f3c621c76e4ce23b2058b57c221f4d878c77"
+    },
+    "music/track55.mp3": {
+     "bytes": 1804537,
+     "sha256": "28d8efbdd33d46eb58b56d3bffa040a52f9c069e261d32c54e39f9b7f1c925e5"
+    },
+    "music/track56.mp3": {
+     "bytes": 16440423,
+     "sha256": "eb31aa2c1d3845e5a733df6035966e3f066694a58fed39f9d2622023635db097"
+    },
+    "music/track57.mp3": {
+     "bytes": 9839803,
+     "sha256": "88a6be78803ff3ccda10face856c353d390632e91ac96f085534491b3b115ed8"
+    },
+    "music/track64.ogg": {
+     "bytes": 34677839,
+     "sha256": "d876f8c16abe34346a87091b518a3368de22e8687bbb2b4af0a472a67e13755d"
+    },
+    "music/track67.ogg": {
+     "bytes": 2071602,
+     "sha256": "42a3debdb80d7f7626850b7b1896876cf73869d7eda38dd7d935bca089af495c"
+    },
+    "music/track69.ogg": {
+     "bytes": 4063017,
+     "sha256": "913b4745085a93540172ba7ab44a6bc8f018372fb55e2ba699c764fd97c99bfe"
+    },
+    "music/track71.ogg": {
+     "bytes": 34222945,
+     "sha256": "4221cc6d86f4cda184e8cb75a089e99d21c998c18b84ee4f15c57e7a3c986753"
+    },
+    "music/track99.ogg": {
+     "bytes": 50630,
+     "sha256": "74a294d5c958f9284d68ce2c667f233e87c9f57ef0abe3e7471bea257823c0b7"
+    },
+    "progs/a_mdls/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "1cdfc2b54dd883efe9215499603e341bfa72e800740a2e874e9bcf3b0afc68ba"
+    },
+    "progs/a_mdls/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "8cb54159eeaa410b98478e9190bd2d33340d3a2e98a61d32ce1afaf4e99031a0"
+    },
+    "progs/a_mdls/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ac361970fb1cbbb87ad4593afecd6d8973a65ea4f14e5f7b565c8f38c181fa9d"
+    },
+    "progs/a_mdls/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "0870b633f95bda895074e8d423631ee8805c3923f36a1c7f09938710783e8f99"
+    },
+    "progs/a_mdls/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "146955794f29c02f6570eed83e1d4b0013b0b4341897bcbc91cc9ffea6957ff4"
+    },
+    "progs/a_mdls/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "59988afc3603b83ccfadf0a9af423a113bf15ed969d4a62db9073e3061bc0fdc"
+    },
+    "progs/a_mdls/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "696594c11dd6dbd2e60ac6923d82a55f8f5b16e93b93f7914abe5fd4df74299f"
+    },
+    "progs/a_mdls/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "b558ee2dfd0078c7e3075079fb40368f53e7dfb162aaefcd20e53f562e405b1b"
+    },
+    "progs/alexunder/enforcer_y.mdl": {
+     "bytes": 472208,
+     "sha256": "95c01940921e1539dd13ca26e96ab1f0f416790cc8e92c4a0bf30261b95ca421"
+    },
+    "progs/alexunder/soldier_y.mdl": {
+     "bytes": 320900,
+     "sha256": "fe03c2266fde22596cb3e4f8ad3f836cd392b0260ec1363c401e9acce3bbabd9"
+    },
+    "progs/angel_01.mdl": {
+     "bytes": 284884,
+     "sha256": "a021ce23b75eeb64c960711d23509740d5a0389bcfd0419adc63dc312132d26b"
+    },
+    "progs/armshr.mdl": {
+     "bytes": 20012,
+     "sha256": "1873523424395b404ffafeb447383185e033826e33bf0a001efc34604ece95da"
+    },
+    "progs/beam.mdl": {
+     "bytes": 85496,
+     "sha256": "414259b1c9cb4b23c6cb4e560008287857dc438627138d4806a8fd7d0554f75a"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 85496,
+     "sha256": "74f83a584737f82af2f358b2ee37a9cd02a8acea23b7a1d8e0728af36703a404"
+    },
+    "progs/bolt1.mdl": {
+     "bytes": 85496,
+     "sha256": "ccb45187c4d9561258588d1d616dec1fb086782de173f83e38476f0ae0d7287c"
+    },
+    "progs/bolt3.mdl": {
+     "bytes": 85496,
+     "sha256": "2291b1d8da40d6acd9a0b21771417e0b8a68051b114785997ffefca7636bc61e"
+    },
+    "progs/candle.mdl": {
+     "bytes": 24135,
+     "sha256": "5027f8712c36de87b3967e4e623fbc64d4e99644f5b805f7e21ec38b1532cc74"
+    },
+    "progs/debris.mdl": {
+     "bytes": 263072,
+     "sha256": "2b60cba9cbb454e3524d174edc0e1a540f2b2e91fa0b35fc2ab20ccb7fabd8d1"
+    },
+    "progs/elemshambler_f.mdl": {
+     "bytes": 163468,
+     "sha256": "c86980d098e1564495b2ecbb279c74f834e058c1ad8cee459ca5eaf2316c3e54"
+    },
+    "progs/elemshambler_i.mdl": {
+     "bytes": 269740,
+     "sha256": "25c5e9a258255b7a0ee8442f6eed00eaa6c5b5d22d3494c9ca1e48c4fc94efd1"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 472208,
+     "sha256": "3345599ba081d346c163f5c239815bd65b134ccf342601f42a31e60a45044f39"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/g_shotgu.mdl": {
+     "bytes": 29076,
+     "sha256": "4a8866ab410a93522a3d3221e0f3b45889a488b54c0551329f09493273e09840"
+    },
+    "progs/g_shotty.mdl": {
+     "bytes": 23380,
+     "sha256": "b919bbcba3f7f03fb8b82fa6d3b1464ca41e81cf29417cfea0de09658c698cfb"
+    },
+    "progs/gwx9/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/gwx9/corpse_flay.mdl": {
+     "bytes": 509231,
+     "sha256": "0287c3e7886bd2d6d1cbb504529d9e11038d0f8232ee624528eb0ccb78733c53"
+    },
+    "progs/gwx9/corpse_imp.mdl": {
+     "bytes": 536924,
+     "sha256": "22f82f29d0a88af204f7b97eef887b963bd940e7277b6f5cef5e6f3610f2ea51"
+    },
+    "progs/gwx9/corpse_lynch.mdl": {
+     "bytes": 276420,
+     "sha256": "41e90f1a84e9779eb12541d923ab0a66e69deef3a9dbc82259ab84cb71b68dcc"
+    },
+    "progs/gwx9/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "d7fc256175268c45b18039d475c19297329c07cafb952c72dd4964d2730537b3"
+    },
+    "progs/gwx9/flame.mdl": {
+     "bytes": 41668,
+     "sha256": "d6cb4dc28d5101538b44ed53fe1cf84c9d5f8547a91eb74fc6c6bdd3645ffa17"
+    },
+    "progs/gwx9/flame2.mdl": {
+     "bytes": 74548,
+     "sha256": "f03dd3b7f94a86c4d91ffb002723a16f30321a0c2189b673dd4f12f547245816"
+    },
+    "progs/gwx9/flame_pyre.mdl": {
+     "bytes": 85180,
+     "sha256": "9df2ae13e72ffe5a305a6ce877b0284023520d5d34df751498a2003c3e420ebc"
+    },
+    "progs/gwx9/ghgwx9.bsp": {
+     "bytes": 141364,
+     "sha256": "c5c167e6e27ce035db2717eda1a5a2446c2d9efe6b6e02a4441b160c72f9aa40"
+    },
+    "progs/gwx9/hknight.mdl": {
+     "bytes": 1142583,
+     "sha256": "2c3d4002e7c5f1682367c3f649e67333303d1763e6da0b3cfdce8c7519dfc2dc"
+    },
+    "progs/gwx9/jcgwx9.bsp": {
+     "bytes": 31296,
+     "sha256": "b0137836ce5e76cf7d33fb41c698190b8336aed19c7c97f32d6304e99b134e38"
+    },
+    "progs/gwx9/lgwx9.bsp": {
+     "bytes": 367228,
+     "sha256": "4e1800a68e8ed6f0079e546dcc7d229ce5e3bf07baf9fadcffc5b96334b1ff0c"
+    },
+    "progs/gwx9/misc_hangman.mdl": {
+     "bytes": 96500,
+     "sha256": "feb2473a29e56ee278e4cdc9676306fdf3aa609b527ea4aff23bb86e3900a2d3"
+    },
+    "progs/gwx9/mokaboil.mdl": {
+     "bytes": 41464,
+     "sha256": "45df314260eb83d4a1775f55b2da6b8f2019cde4997867584f9a739ba0b63f39"
+    },
+    "progs/gwx9/mon_demon.mdl": {
+     "bytes": 402320,
+     "sha256": "0d903f74920053dcb825b02632467bcbbfa30d2d4e3e5dff32c00ada06333000"
+    },
+    "progs/gwx9/mon_dog.mdl": {
+     "bytes": 460652,
+     "sha256": "52cf8cb501f4b1ed457961b798eccd86974720af29f559723be82a0886824fd9"
+    },
+    "progs/gwx9/mon_enforcer.mdl": {
+     "bytes": 853376,
+     "sha256": "9615c23e3bff85f8e819ef4581d775d82475348dcbf283483702561b42981204"
+    },
+    "progs/gwx9/mon_shambler.mdl": {
+     "bytes": 401092,
+     "sha256": "8f29b2ceddebcb9e69adbf12eb36c3924468cfaa1ff54cea31e6f289ab30e54a"
+    },
+    "progs/gwx9/nsoldier.mdl": {
+     "bytes": 146288,
+     "sha256": "346728a302961730fca382ea915d2590702e59220eee5a9345326089cca9626b"
+    },
+    "progs/gwx9/pd_s_key.mdl": {
+     "bytes": 177092,
+     "sha256": "1002b0f8c06669ca0c506f94c04d65f873d41a72768308b9fc5fa8c107df01ae"
+    },
+    "progs/gwx9/pentfloor.mdl": {
+     "bytes": 21172,
+     "sha256": "fb10c551bc21b9f470adad2e7804cd85cac1dfa117a9b55699289297e1a41017"
+    },
+    "progs/gwx9/rrgwx9.bsp": {
+     "bytes": 56488,
+     "sha256": "9ee4f69b3817fd1db17e7caee4d86b78e3e153ba340837bfc7141fb96b9faa7b"
+    },
+    "progs/gwx9/smgwx9.bsp": {
+     "bytes": 18052,
+     "sha256": "99678e329673a78824a48a526d4e6b6fab55acf0137b51b9ab9dc5a7d6b7ed78"
+    },
+    "progs/gwx9/stgwx9.bsp": {
+     "bytes": 50932,
+     "sha256": "7879bca3f5375b3d4f3d5c4bfd9922fe6753cff707ce377a46ad1ff6be74c221"
+    },
+    "progs/gwx9/xgb_cc.bsp": {
+     "bytes": 11528,
+     "sha256": "b349d533a0c94bceba0c1f485675bfe4ecd19a1b86f3ff950565e920d57ee7cf"
+    },
+    "progs/h_boss.mdl": {
+     "bytes": 24028,
+     "sha256": "b41e2302e15d7cb47bf1eb4ee1df29e7e8d773a3dfc6059f5b1f8ce18685bba6"
+    },
+    "progs/h_mdls/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "2e7fac7418838a721d80e80370000f3e400b21248b22c8d3555588d4f8437a5b"
+    },
+    "progs/h_mdls/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "1f4b0791be3156763c15521fbf2e747744ce3355d90d630b01c2227770314771"
+    },
+    "progs/h_mdls/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "6f792b9a80f34e31bceb4258e1d2c8f22d405a7ae1198b31bb285f502c720cfe"
+    },
+    "progs/h_mdls/pd_vial.mdl": {
+     "bytes": 8292,
+     "sha256": "035673048c98991e790abe484c2403b56dfe5ea1f5fb185c1b7a657d918668e8"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 42048,
+     "sha256": "52760ce1f6e8f657e782846571baf9fde80859f5342d07a684fa8218f96f68db"
+    },
+    "progs/h_shambler.mdl": {
+     "bytes": 98400,
+     "sha256": "6508f7b05b65f230b7f1280d2023e9ed200663715db1709c43e7e187e3ed841c"
+    },
+    "progs/health_5.mdl": {
+     "bytes": 6164,
+     "sha256": "a8ba7ece01b3cb58b2f94ca20a9f4511871d26ec894b54c04e433f29fc7c3bef"
+    },
+    "progs/hook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/hydra.mdl": {
+     "bytes": 280660,
+     "sha256": "877701e8a786b437fb786310dffd9eb4977426e92b1263869e1ab25b8d4b1757"
+    },
+    "progs/hydragib.mdl": {
+     "bytes": 85248,
+     "sha256": "86b7743cf3905e75a66e65278bd78dabb69086566d1d24b6aa8c4873d327a050"
+    },
+    "progs/k_spike2.mdl": {
+     "bytes": 444704,
+     "sha256": "e466e7afa95868ec1a3b3bfc770573d93dc20c2d881a73d2b9b0e35f1dfa6d9b"
+    },
+    "progs/lspike.mdl": {
+     "bytes": 1684,
+     "sha256": "59264317258f19955b967177f0dbc5be1733e4ca07c4c7b3cc333bb88bc0c46e"
+    },
+    "progs/maahes/misc_maahesstatue8.mdl": {
+     "bytes": 53188,
+     "sha256": "252c422e6f25d46a494f46ec8182c649f782df95b886d783f60075e53769b88d"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/misc_bonepile.mdl": {
+     "bytes": 110796,
+     "sha256": "0f8061359681f3c11660e472c517599590447c7631edfe5a36debd9645acdec6"
+    },
+    "progs/misc_cable.mdl": {
+     "bytes": 57780,
+     "sha256": "bed2cca38ef4cbefa9e645eb5e9ffadffac6ebb4f2ac5f6da4bb8f354de22a48"
+    },
+    "progs/misc_cables.mdl": {
+     "bytes": 433607,
+     "sha256": "03c41af692903bb854cc5c05c0a8a665f312a04955737ecbac1a65a4113f6d50"
+    },
+    "progs/misc_fixture1.mdl": {
+     "bytes": 9768,
+     "sha256": "c10980d00e0479f8e65ab633f19ee62ace4c0697c2193f7aea8d266e2be5fc2d"
+    },
+    "progs/misc_flame_big.mdl": {
+     "bytes": 244895,
+     "sha256": "09adba1308cdf22d2f07e226cb13a35e51f4d54866f84f41e2074dc7a40371d5"
+    },
+    "progs/misc_lantern.mdl": {
+     "bytes": 28836,
+     "sha256": "d84e36232543a053f2772b1070b221dc23da1b34cd08ea551a982b5e9f168ea5"
+    },
+    "progs/misc_seaweed.mdl": {
+     "bytes": 16100,
+     "sha256": "dfbd38a439d392870c7c4c7ebea4475827b716004ca47bfa7f13b47daf07d774"
+    },
+    "progs/misc_seaweed2.mdl": {
+     "bytes": 95281,
+     "sha256": "65773f37e26d41dd72ec1cf9849c663c1475923cb77d0f4c599bc3301368373f"
+    },
+    "progs/misc_skull.mdl": {
+     "bytes": 59892,
+     "sha256": "94600327093fe22acc113b8e89c8863a5548b170c9c9897bd2af8a4ff63beb5a"
+    },
+    "progs/misc_smoke.mdl": {
+     "bytes": 31792,
+     "sha256": "8d39b97460c9967ee36b33ea1ef1e92e89277fc410b44f054c5e06b8dc8a079c"
+    },
+    "progs/null.spr": {
+     "bytes": 57,
+     "sha256": "dc67fb2f31bd717353b8138f02bdc8ef2d70ace433c9fd91e3adc909fda513a3"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 366916,
+     "sha256": "29fa9866dd4862b99ebb9944ddb0bf24a6d0bb4bf00e26a94d3622cead9b6315"
+    },
+    "progs/pd_armor_sh.mdl": {
+     "bytes": 31508,
+     "sha256": "46b9de8235f07190e18d67e147ed00be6dc322cd112ccde33bf4fc1f9a77e074"
+    },
+    "progs/pd_b_key.mdl": {
+     "bytes": 128440,
+     "sha256": "c5aff23b766037ab550636516d7fe0235dacf566ddb966541d640092bcb62349"
+    },
+    "progs/pd_base_key.mdl": {
+     "bytes": 21219,
+     "sha256": "320ec52018f501f8fe428dd46f44693787e545289be883a49f3bd6476974cf46"
+    },
+    "progs/pd_bpack.mdl": {
+     "bytes": 216724,
+     "sha256": "1839c92899197344935eca44d7b4c70e903af84ab633259786f8c12c39905149"
+    },
+    "progs/pd_r_key.mdl": {
+     "bytes": 269528,
+     "sha256": "7ef6894b955c4ca34bf3e2ebdc6288f55cc3b1285478444a81ca769866e1a119"
+    },
+    "progs/pd_rune_key.mdl": {
+     "bytes": 46335,
+     "sha256": "c4fe9bd66394231ace3127635f057987ecbf4b13b00d84501127caacb5db03fc"
+    },
+    "progs/pd_w_key.mdl": {
+     "bytes": 170680,
+     "sha256": "73f06fc10a53c93db25d67f20bad7672bc5f4e14bf3a6b5115d68f00696b536a"
+    },
+    "progs/pd_wiz_key.mdl": {
+     "bytes": 21907,
+     "sha256": "36b50211f687813b85648a46bd32a1d543a8f2af84e9d4223f8b5843f885e1bc"
+    },
+    "progs/pritchard_chair.mdl": {
+     "bytes": 81316,
+     "sha256": "3ee0b690213e2508dbd3e7445a9761eea439140e566e7779956be62bdb6a943c"
+    },
+    "progs/puzzle/cyaegha.mdl": {
+     "bytes": 20604,
+     "sha256": "e0134ba9b54fb67bf252a0cfc81af23cda71d1d5b3ce55c82e0fb69e7fc8f718"
+    },
+    "progs/puzzle/cyaegha.spr": {
+     "bytes": 1400,
+     "sha256": "5e47d02105ece3c9c15ee85778a6f07de8e100aae0cd30f7d1d9db6453162af3"
+    },
+    "progs/puzzle/pallid.mdl": {
+     "bytes": 23260,
+     "sha256": "e0a723f1c00ac85a86018419a9046058b77d09e5cad656fa949e25b98e1f3301"
+    },
+    "progs/puzzle/pallid.spr": {
+     "bytes": 1400,
+     "sha256": "edf63f7ea0774e0a5a6825dd9689c3224dc19abf158b8b347b5768748cb9f159"
+    },
+    "progs/puzzle/swampkey.mdl": {
+     "bytes": 18660,
+     "sha256": "63d435e8942c98adfc9307f6276cf8206ec063b5e32a05e09c5e388efa512c33"
+    },
+    "progs/puzzle/swampkey.spr": {
+     "bytes": 1400,
+     "sha256": "d5dec992ccba32e8d9c8bc381e96d6771b27cbb3dd6a1adf018a710ac53a1fd0"
+    },
+    "progs/rm_carcosa/bandit.bsp": {
+     "bytes": 13704,
+     "sha256": "0441c4c8b9e3f1674cd4c596fbb967b0c68db6d6f0404b752548c303df489b12"
+    },
+    "progs/rm_carcosa/boatee.mdl": {
+     "bytes": 237540,
+     "sha256": "edd64d1697011a5cbbc11ba9c241ce110aba2204483c3756a2ef026b1c30c604"
+    },
+    "progs/rm_carcosa/bookopen.mdl": {
+     "bytes": 6188,
+     "sha256": "eedde4ccb29ebb305ac02c4512afc4fe3b41a1028ef94b5cdf30ee51f1e02e70"
+    },
+    "progs/rm_carcosa/boy.mdl": {
+     "bytes": 347880,
+     "sha256": "a868caffe2f6009f072f0fa218274140523caa68e3b390a11fdaef5ac9c25a7b"
+    },
+    "progs/rm_carcosa/burner.mdl": {
+     "bytes": 50884,
+     "sha256": "768a5c4194d3bc77be2262b43b9bf4f58dd0cae284c341f16295dbb1e138a6be"
+    },
+    "progs/rm_carcosa/burnerh.mdl": {
+     "bytes": 31456,
+     "sha256": "3e49bb2b8b0207737411d0508b24077a92907b5c93edd9621f8193685570a65f"
+    },
+    "progs/rm_carcosa/candelabrum.mdl": {
+     "bytes": 23804,
+     "sha256": "7c2e11eff04bba20b22cbe5ca88a6f0ab41ec04c3a01b0d8d27cc5594dd60ed5"
+    },
+    "progs/rm_carcosa/cashier.mdl": {
+     "bytes": 168900,
+     "sha256": "d6e89f4f2c3b426fb9180cb2d0e3ce272318a2d7d4ddeb4dd2c42dff2f9ca8ed"
+    },
+    "progs/rm_carcosa/chandelier.mdl": {
+     "bytes": 28852,
+     "sha256": "629c64dee0c60a5d525f1c1ce2434db73a33315b53ca42332093e2e858693334"
+    },
+    "progs/rm_carcosa/cherub_small.mdl": {
+     "bytes": 126628,
+     "sha256": "c13a7e90d0f60f205458efe3a22fe4b86d61e62a576d7e3cdf4652b86da9f4ae"
+    },
+    "progs/rm_carcosa/cupid.mdl": {
+     "bytes": 129180,
+     "sha256": "b62ae66a3cfb2854100e995ad0ddff1eb259bf6343d4255b1aab86033b42f254"
+    },
+    "progs/rm_carcosa/debris.mdl": {
+     "bytes": 41652,
+     "sha256": "76b5d9412afa47d12657d779ddb91f987e46662fa6190c3721512fa3410316e9"
+    },
+    "progs/rm_carcosa/dragonhead.mdl": {
+     "bytes": 25892,
+     "sha256": "ad218cc7f37e236b689af0b1cebd6a721bb3f25de827754d96874748e26f6eb8"
+    },
+    "progs/rm_carcosa/ferryman.mdl": {
+     "bytes": 75284,
+     "sha256": "d76501bc93581caf0f875d14bf89ab2e2ae4e4ba2ba691e39b2c60040904176e"
+    },
+    "progs/rm_carcosa/g_shotgu.mdl": {
+     "bytes": 29076,
+     "sha256": "381fe8e0f41e3364ff667755506e88d6639f74d59033bc11f3b31c46b8aeaf46"
+    },
+    "progs/rm_carcosa/globe.mdl": {
+     "bytes": 68452,
+     "sha256": "1f0927b6f1a7cef5bbc4215e9138d352e9fa38c767627b7e5c00d1ff735b0c35"
+    },
+    "progs/rm_carcosa/globe_nospin.mdl": {
+     "bytes": 68452,
+     "sha256": "b74a00d297e9506797ff2f1cdbe8c518300684ec20f8c697bf4de437c644f3ef"
+    },
+    "progs/rm_carcosa/globebottom.mdl": {
+     "bytes": 26468,
+     "sha256": "d68c691d64a86f3e1dbd46461e97a14be1c8521c3cedc8604f76886299c47541"
+    },
+    "progs/rm_carcosa/globetop.mdl": {
+     "bytes": 78308,
+     "sha256": "cebee136d2578c987f95e6ee3b5b27f240ef82f0ff0af206a8dead7bd3cc08a6"
+    },
+    "progs/rm_carcosa/halberd.mdl": {
+     "bytes": 22324,
+     "sha256": "82ce4521247d90b3852468064b910bf0842c690f0ed55668f491a4d4fa6000ef"
+    },
+    "progs/rm_carcosa/hedge1.mdl": {
+     "bytes": 34232,
+     "sha256": "83bf757e09a98dd8658022d6232057a7a4babc9dc8dd87aed1ca41635e7f52a9"
+    },
+    "progs/rm_carcosa/hedge2.mdl": {
+     "bytes": 25356,
+     "sha256": "7113965e19ec6b2d2e8da17a9322211ed4f4d7a3b6f14d95333867a7509fdeb5"
+    },
+    "progs/rm_carcosa/hedge3.mdl": {
+     "bytes": 25708,
+     "sha256": "78ade31c936c195eab523e7f45371e510aa784f9e0d8af193307c76cafde36ea"
+    },
+    "progs/rm_carcosa/knight.mdl": {
+     "bytes": 89508,
+     "sha256": "3a779e632fdc2c54e6a48aa09a87e55a39db81da6fcd91647534f3761f53959e"
+    },
+    "progs/rm_carcosa/mathuz/flag2.mdl": {
+     "bytes": 81472,
+     "sha256": "2f91b03b9520781c6d9258261b843c015ad4f82f75aadfc03c327d3129f339e2"
+    },
+    "progs/rm_carcosa/misc_textbook.mdl": {
+     "bytes": 45512,
+     "sha256": "2a7744e787226c0ed73e7d44e8ccf742565f86ad3cd34053d9635cf0b88578dd"
+    },
+    "progs/rm_carcosa/monsters/elemshambler_f.mdl": {
+     "bytes": 163468,
+     "sha256": "c86980d098e1564495b2ecbb279c74f834e058c1ad8cee459ca5eaf2316c3e54"
+    },
+    "progs/rm_carcosa/monsters/elemshambler_i.mdl": {
+     "bytes": 269740,
+     "sha256": "25c5e9a258255b7a0ee8442f6eed00eaa6c5b5d22d3494c9ca1e48c4fc94efd1"
+    },
+    "progs/rm_carcosa/monsters/gib1_i.mdl": {
+     "bytes": 5876,
+     "sha256": "948ce4f477c9b0c44f3f90bbc3d1c4f9eca552f50bc0f30fbc42bbb6d39b4bee"
+    },
+    "progs/rm_carcosa/monsters/gib2_i.mdl": {
+     "bytes": 16564,
+     "sha256": "d8c12494605dcd53ac61ea40c926ba13b0ff93dd1c2bda941209500334ad0b49"
+    },
+    "progs/rm_carcosa/monsters/gib3_i.mdl": {
+     "bytes": 22356,
+     "sha256": "d4b0b70423637c1cf56a8458c39749f11f179a054c99558f265581b8f7c5a8da"
+    },
+    "progs/rm_carcosa/monsters/gkrokon.mdl": {
+     "bytes": 298216,
+     "sha256": "38e4ba39acfa2830aa93973ae1d89176a81609206d233f1e7720ab16e8fef230"
+    },
+    "progs/rm_carcosa/monsters/h_elemshambler_f.mdl": {
+     "bytes": 37316,
+     "sha256": "c2fb45095a9c7df922b2251cee0b7c2f356f84109d6b7ce6616f4645b18b3ad6"
+    },
+    "progs/rm_carcosa/monsters/h_elemshambler_i.mdl": {
+     "bytes": 37316,
+     "sha256": "9f29fe86868a479c2bf36723590209fcd260eb83655ae7ab0633c8ed04e17e27"
+    },
+    "progs/rm_carcosa/monsters/h_swambler.mdl": {
+     "bytes": 39940,
+     "sha256": "46ee53c5d5b6945d785de73a63f87a07bbe8ced993a0b01b9f9b122ca1ca8205"
+    },
+    "progs/rm_carcosa/monsters/lavaball_i.mdl": {
+     "bytes": 8916,
+     "sha256": "6c2dd678b047a4fabd932c42ddbc30fe2918436deba7750d6b43c784609917e4"
+    },
+    "progs/rm_carcosa/monsters/lrkbody.mdl": {
+     "bytes": 936252,
+     "sha256": "2757800618974e216462f7571ede51b2241cc02c7bdcede914a8edbf545a4ea4"
+    },
+    "progs/rm_carcosa/monsters/lrkeye.mdl": {
+     "bytes": 39016,
+     "sha256": "90e1d8b5bd4234df9c211a2fed9a54bf3bc714e3b0d913915ce5d2061f97a404"
+    },
+    "progs/rm_carcosa/monsters/lrkglobe - backup.mdl": {
+     "bytes": 19484,
+     "sha256": "b3c1879ea85c86801b0fdedc6a2171ef9b00a9036566365529a42e27c2a2e8b4"
+    },
+    "progs/rm_carcosa/monsters/lrkglobe.mdl": {
+     "bytes": 19484,
+     "sha256": "62cf7fa08b52c621f5c5310852f8719ce6f1c7a662e247b822f5b2d2175dddf7"
+    },
+    "progs/rm_carcosa/monsters/swambler.mdl": {
+     "bytes": 401092,
+     "sha256": "80d6fc685f3f92ea230e3605bad01bf282d198cbc3844ad0336d38356aabb1ab"
+    },
+    "progs/rm_carcosa/monsters/turreteer.mdl": {
+     "bytes": 331064,
+     "sha256": "f11bb1de608d43ce65fbfa5eca85e83d0b509e087c37ace74a82ed9bacf75401"
+    },
+    "progs/rm_carcosa/puzzle/cyaegha.mdl": {
+     "bytes": 20604,
+     "sha256": "e0134ba9b54fb67bf252a0cfc81af23cda71d1d5b3ce55c82e0fb69e7fc8f718"
+    },
+    "progs/rm_carcosa/puzzle/cyaegha.spr": {
+     "bytes": 2168,
+     "sha256": "a4bf943e912697f1fdd6aa72f46fa09bbb323cf2c00ddc5a9809852a99c56a5b"
+    },
+    "progs/rm_carcosa/puzzle/elderkey.mdl": {
+     "bytes": 18944,
+     "sha256": "e64a64d4f4878e74bed9e0b3a09366ea0e7bac9e9084ddb4b70dd52653280848"
+    },
+    "progs/rm_carcosa/puzzle/goldbar.mdl": {
+     "bytes": 12020,
+     "sha256": "6e1cf73947dda58c9c5f5971f87ce11ce2e3b20c5d6b927a511213ec91cc1fbc"
+    },
+    "progs/rm_carcosa/puzzle/goldbar.spr": {
+     "bytes": 1400,
+     "sha256": "3b515d5e1817de6efc095d3a380888b5a6e439da09b3bfae63c7553087089eee"
+    },
+    "progs/rm_carcosa/puzzle/goldbar2.mdl": {
+     "bytes": 22932,
+     "sha256": "59ce61ecc79f4a343337316a0cdf2655cd91d2fa8205c9065512ef2b0893d1af"
+    },
+    "progs/rm_carcosa/puzzle/gravekey.mdl": {
+     "bytes": 18620,
+     "sha256": "bc2d925560dab2c0763e462bd6057f58cd761aa48245522fd8e74ad368189acc"
+    },
+    "progs/rm_carcosa/puzzle/gravekey.spr": {
+     "bytes": 1208,
+     "sha256": "2659335d95f84091bd6ccaa8dc267cf41208317e11e3960465a40decc81ac49a"
+    },
+    "progs/rm_carcosa/puzzle/pallid.mdl": {
+     "bytes": 23260,
+     "sha256": "e0a723f1c00ac85a86018419a9046058b77d09e5cad656fa949e25b98e1f3301"
+    },
+    "progs/rm_carcosa/puzzle/pallid.spr": {
+     "bytes": 1400,
+     "sha256": "edf63f7ea0774e0a5a6825dd9689c3224dc19abf158b8b347b5768748cb9f159"
+    },
+    "progs/rm_carcosa/puzzle/swampkey.mdl": {
+     "bytes": 18660,
+     "sha256": "63d435e8942c98adfc9307f6276cf8206ec063b5e32a05e09c5e388efa512c33"
+    },
+    "progs/rm_carcosa/puzzle/swampkey.spr": {
+     "bytes": 1400,
+     "sha256": "d5dec992ccba32e8d9c8bc381e96d6771b27cbb3dd6a1adf018a710ac53a1fd0"
+    },
+    "progs/rm_carcosa/puzzle/trapezohedron.mdl": {
+     "bytes": 17576,
+     "sha256": "59e4bf74796b0ad51217729429fde1bab977b20736c735ddbc80419deec2e33a"
+    },
+    "progs/rm_carcosa/puzzle/trapezohedron.spr": {
+     "bytes": 1720,
+     "sha256": "43c6d29f8f247ff8c7c43beb31c7f8ff9506d561ab1b00ef03595fba735e0ab6"
+    },
+    "progs/rm_carcosa/redfield/animcurtain.mdl": {
+     "bytes": 79956,
+     "sha256": "d8952739dfad16215ada9db0930ceb8a68c8f656370dc24cbcca843a7c851e2d"
+    },
+    "progs/rm_carcosa/redfield/animcurtain2B.mdl": {
+     "bytes": 76476,
+     "sha256": "86992821c91d18e932d8848233b856b99960b40bf457e4df39bebcab91c504ef"
+    },
+    "progs/rm_carcosa/redfield/curtains.mdl": {
+     "bytes": 724496,
+     "sha256": "9f3d580318398509e13dabc504dde429c47fe6c5c3de3a95a870a5f017976838"
+    },
+    "progs/rm_carcosa/redfield/sail.mdl": {
+     "bytes": 137920,
+     "sha256": "4d3bf4faaa987dca91c31de091a733351691d2b4851eb825f81a23f478eb42d5"
+    },
+    "progs/rm_carcosa/shard1.mdl": {
+     "bytes": 5784,
+     "sha256": "086b98924977853e5e8fb66fe7b7964866575bc782632890329c7c34e0406a4a"
+    },
+    "progs/rm_carcosa/shard2.mdl": {
+     "bytes": 4384,
+     "sha256": "94b1bdd548128b4bb0a4eb089355c10de8e2a7799e8bb55d1efc27bd1a48e149"
+    },
+    "progs/rm_carcosa/shard3.mdl": {
+     "bytes": 3896,
+     "sha256": "3b0741e92ccedc74e33d780ef102131d67db972ef3065d14181c1dc7709fd3af"
+    },
+    "progs/rm_carcosa/shard4.mdl": {
+     "bytes": 3872,
+     "sha256": "72737a431373db7b1e5dd9d58aaca99e978f9bb6761128fb4c38ce518900d0f3"
+    },
+    "progs/rm_carcosa/shard5.mdl": {
+     "bytes": 2280,
+     "sha256": "fd88776bfe9fe26f8dc9c538824aa7ad75b75d498a13759b411002b43c7b302e"
+    },
+    "progs/rm_carcosa/sheep.mdl": {
+     "bytes": 561604,
+     "sha256": "426b4a9512a4389e1bd633f689e35eef28161984662750912729eaf9ee6af08c"
+    },
+    "progs/rm_carcosa/speech.spr": {
+     "bytes": 984,
+     "sha256": "f7a18f463b8aa332112bfd45e57c3259b785426f7dea6d3750e885d088986c8a"
+    },
+    "progs/rm_carcosa/stchain.mdl": {
+     "bytes": 8564,
+     "sha256": "20a9c47eb1a387bd2c6990548a69044a6cd40ef88f1923cdef871ef59345b749"
+    },
+    "progs/rm_carcosa/stillring.mdl": {
+     "bytes": 7364,
+     "sha256": "117f5b80140fb9c47fa34289e5b33139616bf2bae230691895e10f1c29865f35"
+    },
+    "progs/rm_carcosa/test/puzzle.spr": {
+     "bytes": 1080,
+     "sha256": "b87daf0390f9efa3fe38c32827213bd5fc1f0971d69a1dad214bdf32b3db188a"
+    },
+    "progs/rm_carcosa/test/puzzle_custom.spr": {
+     "bytes": 5624,
+     "sha256": "697398f7327323ca6c6b599b2e23cd10429758989a84261b0cc98b13927848b3"
+    },
+    "progs/rm_carcosa/test/trapezohedron.mdl": {
+     "bytes": 96768,
+     "sha256": "97f9b474a513eb4c8b7b81c33d55d2435bc4bb8ebe54604764d075052cb8e42c"
+    },
+    "progs/rm_carcosa/test/trapezohedron1.mdl": {
+     "bytes": 18088,
+     "sha256": "3231ab06db44702bf20e87fb702c260277360ab9b63e5df99ca87e33f81970b0"
+    },
+    "progs/rm_carcosa/test/trapezohedron2.mdl": {
+     "bytes": 18088,
+     "sha256": "d18b19c9c9213efb622350ca9eff51f94cb73053f99d0c08b4a91da01553c123"
+    },
+    "progs/rm_carcosa/test/trapezohedron3.mdl": {
+     "bytes": 18088,
+     "sha256": "7f87f9add57eae822f3f2619090d0320e3274d65ec3d9084877615622768b40b"
+    },
+    "progs/rm_carcosa/test/trapezohedron4.mdl": {
+     "bytes": 17576,
+     "sha256": "21126a9f0dc33fda1546b521f8f055c4fda3fbad8dd2f485894b66bd85d32c95"
+    },
+    "progs/rm_carcosa/test/trapezohedron4b.mdl": {
+     "bytes": 17576,
+     "sha256": "8bd45195bbaaf4edb79b41c59c2df6cd44330ea40f5910be00f37d6978e88ade"
+    },
+    "progs/rm_carcosa/test/trapezohedron4c.mdl": {
+     "bytes": 17576,
+     "sha256": "2d4787c6657473d86f0c3c39d1e76d1013832bbae555b3b661406023a797575f"
+    },
+    "progs/rm_carcosa/test/trapezohedron4d.mdl": {
+     "bytes": 17576,
+     "sha256": "59e4bf74796b0ad51217729429fde1bab977b20736c735ddbc80419deec2e33a"
+    },
+    "progs/rm_carcosa/test/trapezohedron5.mdl": {
+     "bytes": 17480,
+     "sha256": "25618fc255044d54aa2a918ce5fb0389f096e3039736d2e0313c6313e1552248"
+    },
+    "progs/rm_carcosa/test/trapezohedron6.mdl": {
+     "bytes": 66632,
+     "sha256": "6dd1c05f76148fa50cce889168ec0294b4a3ec5b0aacdcfe4ce0f9240335a5be"
+    },
+    "progs/rm_carcosa/test/trapezohedron6b.mdl": {
+     "bytes": 66632,
+     "sha256": "10241ba93661298ec99ed8bc6efc5d295e1d8ccecbfae47b191b0b411f6dcb5c"
+    },
+    "progs/rm_carcosa/test/trapezohedron7.mdl": {
+     "bytes": 66632,
+     "sha256": "92408bffcccdf89fab3572dc7e873c49edde2b903fb8138414ea9bf5b2b6cf87"
+    },
+    "progs/rm_carcosa/test/trapezohedron8.mdl": {
+     "bytes": 66632,
+     "sha256": "a1b06aabdc3b9837c9b2dd9fd6d18da9b267a31e87ede615861bc09db4ff57c2"
+    },
+    "progs/rm_carcosa/tombstone3.mdl": {
+     "bytes": 55860,
+     "sha256": "bb8463f04a2c4226386668c8dbd1d785155ea4726c527c07dbb4db24e15639d8"
+    },
+    "progs/rm_carcosa/tracer2.mdl": {
+     "bytes": 68624,
+     "sha256": "b65a7b707c714318c18e3488d2be58bb6ff253cd564f95b1c8d6db0371c44ad7"
+    },
+    "progs/rm_carcosa/tree.mdl": {
+     "bytes": 158404,
+     "sha256": "d79942626e12ab6c66f216610fc6700cc1fd49bb576f680590017ad6a23d5f40"
+    },
+    "progs/rm_carcosa/tree2.mdl": {
+     "bytes": 158404,
+     "sha256": "d79942626e12ab6c66f216610fc6700cc1fd49bb576f680590017ad6a23d5f40"
+    },
+    "progs/rm_carcosa/turret.bsp": {
+     "bytes": 131152,
+     "sha256": "c48072c18f02351cdeaf58956f085ec9ad2d0116a2e73f14b7c6e580056fce04"
+    },
+    "progs/rm_carcosa/wm_gl.mdl": {
+     "bytes": 49252,
+     "sha256": "b26a778fefab0a752588a2eadbc66f39bf9e44d3ff45c8ccba6c270790dcb534"
+    },
+    "progs/rm_carcosa/wm_lg.mdl": {
+     "bytes": 51716,
+     "sha256": "7c176cb43c957ba780b3aa8f1ec468b1ee4b6538ccf7a78a42dbb85956bd32df"
+    },
+    "progs/rm_carcosa/wm_ng.mdl": {
+     "bytes": 36092,
+     "sha256": "d573b19a1785c283f641bc39f299426418741c03ed2dd8f81eef32114897a7b9"
+    },
+    "progs/rm_carcosa/wm_rl.mdl": {
+     "bytes": 41748,
+     "sha256": "04af8e5cd8c05f181d5a1c8e4482a6b5f7f12ab734f8e1de53a7336999d12124"
+    },
+    "progs/rm_carcosa/wm_sg.mdl": {
+     "bytes": 29076,
+     "sha256": "381fe8e0f41e3364ff667755506e88d6639f74d59033bc11f3b31c46b8aeaf46"
+    },
+    "progs/rm_carcosa/wm_sng.mdl": {
+     "bytes": 32064,
+     "sha256": "462c0ff0583692b49e45039d3b9bd29c3d1d2c49c1d70900ed4818009490d4f3"
+    },
+    "progs/rm_carcosa/wm_ssg.mdl": {
+     "bytes": 33524,
+     "sha256": "972e65dd090e8ec2ed93660d25b64807fd02369f967e8a99df1889319a392a72"
+    },
+    "progs/rm_carcosa/yvain/anglstat.mdl": {
+     "bytes": 614880,
+     "sha256": "ff90b7a4f1b5ccb6673c57a66c6269ed6e8a0dbc351f86cfeea31c62e3833229"
+    },
+    "progs/rm_carcosa/yvain/athena.mdl": {
+     "bytes": 130568,
+     "sha256": "a9e27a4a2c505ec3a017806da3acc1517efc52bc8e4a9376dd03f58095d63943"
+    },
+    "progs/rm_carcosa/yvain/athena2.mdl": {
+     "bytes": 128792,
+     "sha256": "ac0a90fcc0f7e4e5565d764e867e43b8866c1147230903bc9f99643bb6daead3"
+    },
+    "progs/rm_carcosa/yvain/athena3.mdl": {
+     "bytes": 127800,
+     "sha256": "6f17a088aead97500eedaaca23c4980d47654c851b4fc4e098e3381b852a8eb0"
+    },
+    "progs/rm_carcosa/yvain/athena4.mdl": {
+     "bytes": 124808,
+     "sha256": "7322fe3173752bb06ed5b15e420204ac1a97aa82e6f4a6c0f98f490cb056ca18"
+    },
+    "progs/rm_carcosa/yvain/caesar.mdl": {
+     "bytes": 105848,
+     "sha256": "5ab19117ec4eabe49d74511e9bd7cd53334b4d1649f17d1866a96b9bb23d651e"
+    },
+    "progs/rm_carcosa/yvain/demon_p.mdl": {
+     "bytes": 124008,
+     "sha256": "255f3fd400dbc6b758b5e694653c03b67413bf2b6f8cd36241ef3c819c1cea30"
+    },
+    "progs/rm_carcosa/yvain/dog_p.mdl": {
+     "bytes": 203016,
+     "sha256": "e2163d6f8dd602fa35c1920c27a605db6341536eeadc4db1ca7a56c95a6cf411"
+    },
+    "progs/rm_carcosa/yvain/fangel.mdl": {
+     "bytes": 603792,
+     "sha256": "b1b2d20f0a4bbcb211f8ff39da482c5e617e1f10ee34ec27317e2a1f89bf6192"
+    },
+    "progs/rm_carcosa/yvain/hknight_p.mdl": {
+     "bytes": 321012,
+     "sha256": "6a89bd0989e7aa06d4254ebe2b4c2a61549e759383da91ce831683613016fb14"
+    },
+    "progs/rm_carcosa/yvain/knight_p.mdl": {
+     "bytes": 126204,
+     "sha256": "f7ce88c65938bd18b54620f9468db31906751a08978614e58202254017d042d0"
+    },
+    "progs/rm_carcosa/yvain/neptune.mdl": {
+     "bytes": 141528,
+     "sha256": "86d4c4fa786a33be47a00a8c482314b82abcbb2fe3bebf8028bc04644caa075e"
+    },
+    "progs/rm_carcosa/yvain/player_p.mdl": {
+     "bytes": 253172,
+     "sha256": "703252edbc50ee6971255760fd5b4bc66acce6080bf5e9a4cfc92e8206abd7a3"
+    },
+    "progs/rm_carcosa/yvain/shambler.mdl": {
+     "bytes": 174352,
+     "sha256": "e1889b4080ceabde1ea7574521bef5c7fd498f2b1b6624021deea42c77740d40"
+    },
+    "progs/rm_carcosa/yvain/shambler_p.mdl": {
+     "bytes": 130768,
+     "sha256": "aaa2d8b338f481fc42fd2584b62db522d474e2521b01b563985fd4e6760d361b"
+    },
+    "progs/rm_carcosa/yvain/stool.mdl": {
+     "bytes": 6964,
+     "sha256": "1d74738fdea7f2b33ecafbad405417177b05a35d8ae0e1c35b150f8a55473c8f"
+    },
+    "progs/rm_carcosa/yvain/sword.mdl": {
+     "bytes": 6792,
+     "sha256": "22d4985c1bdc99a598e10a7a61381255924061c9cc070bf242169d1bb4b97614"
+    },
+    "progs/roj/dog_quad.mdl": {
+     "bytes": 290124,
+     "sha256": "1b75f08692d871806fe02f40b58520a54724d5c144f84e8b6335b86ea404fd83"
+    },
+    "progs/roj/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/roj/h_dog_quad.mdl": {
+     "bytes": 61048,
+     "sha256": "94f8db65e6b6d0df7ffa1456af6d3530c35929b9a46cf1b084c492fc2386f4b8"
+    },
+    "progs/roj/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/roj/h_sabrkn.mdl": {
+     "bytes": 11828,
+     "sha256": "050fcc93189211aba943674a326ddd898dc980b83fb551ee11fec3dd39973483"
+    },
+    "progs/roj/nsoldier_alk.mdl": {
+     "bytes": 563108,
+     "sha256": "6071d7cecf231f0a83f2e1c7df533b4a32beb6e75969d17703446a67d011695a"
+    },
+    "progs/roj/ogrem.mdl": {
+     "bytes": 378296,
+     "sha256": "2bb999bf580d16fb9ee4246dea7897236d6d118232c78a6168f641dc32778fb5"
+    },
+    "progs/roj/sknight.mdl": {
+     "bytes": 460932,
+     "sha256": "9213f6898a60cdc20a7a144c61c13f8d64f1432382dca44b636524edf737dac8"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 47856,
+     "sha256": "99fc3f91856aa6df2f25494a945e17b64b59ddc3faed424a6fcd73062a677fcc"
+    },
+    "progs/s_flame2.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "e306ec0fbf0f5e4306c6683f7c7b87674bb0a168ef32a2b1118dcffb083deeff"
+    },
+    "progs/s_steam.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 320900,
+     "sha256": "e3321220ed34292da63fac94af63360c6544c055edd1eceed35d75eb26685e9b"
+    },
+    "progs/spark.mdl": {
+     "bytes": 2544,
+     "sha256": "77d081c51af9bd6c82d2d51dcb955a2fca5189cda4eb09a138bfa2e2b521fb05"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4416,
+     "sha256": "8c70353304b2d111260102565745a5504144568f932787906eaf50de742aa62c"
+    },
+    "progs/teleport.mdl": {
+     "bytes": 1058800,
+     "sha256": "98eeb63a1ded2d7a1d3788562478aff891af1be4ef1c552bcdb913cb338387b6"
+    },
+    "progs/tracer1.mdl": {
+     "bytes": 68624,
+     "sha256": "c0feddcacc94372041d9e02c744fd266ab6d1fcda8b970be3f5147e43169f38a"
+    },
+    "progs/trap_sawblade.mdl": {
+     "bytes": 28716,
+     "sha256": "759bd7e1f7629b4d87ecb9e53a9f2d66e3e81b9103bc4eab3f85bd598eba36f6"
+    },
+    "progs/v_spike.mdl": {
+     "bytes": 1058816,
+     "sha256": "ac4d47130af263cb6fd861d70ac09ebf758ab1a76da0b697e268382c65ae1a16"
+    },
+    "progs/w_spike.mdl": {
+     "bytes": 311493,
+     "sha256": "add013a5a6686ffd76ec0f2b2b3413757432ba4a8564ffd81aeb7eb2c5a98398"
+    },
+    "rm_peak_moon_assets/elemshambler_f.mdl": {
+     "bytes": 163468,
+     "sha256": "c86980d098e1564495b2ecbb279c74f834e058c1ad8cee459ca5eaf2316c3e54"
+    },
+    "sound/ad/rattle1.wav": {
+     "bytes": 88274,
+     "sha256": "c524d12100f1067bb30ecdf83e18e5d85124fef834929cfd2a2ade14f83ad730"
+    },
+    "sound/ad/windgust6_loop.wav": {
+     "bytes": 99390,
+     "sha256": "aa82daecffa513c9b528f30822534b5075262dc2c4287b0cf75fcd45a61ff9bf"
+    },
+    "sound/alexunder/creaking_fan.wav": {
+     "bytes": 509348,
+     "sha256": "98011803a655711f4aeb27dc09eea1ca96a586997bd068631fe18f20317ec142"
+    },
+    "sound/alexunder/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/alexunder/reactor1end.wav": {
+     "bytes": 48590,
+     "sha256": "0a134d4c8b032b18cb4b90963a8d705f1bd76c27586dc0c11d33b4567e099fde"
+    },
+    "sound/ambience/1shot_creep_04.ogg": {
+     "bytes": 15593,
+     "sha256": "e8eabe23e08c4fe6d94a54aa786aa486c39cb60ac316048b4c93eafd75f02b27"
+    },
+    "sound/ambience/1shot_creep_05.ogg": {
+     "bytes": 12626,
+     "sha256": "bf5864aff4eb0b4ee358e4a089dddb6d25008493d7de25fb86c45aba2445c8db"
+    },
+    "sound/ambience/alarm1-1.wav": {
+     "bytes": 624202,
+     "sha256": "669ac87ff0ae0684449d4f0d214b5aaebd15a61d048067e773484eaf5c9fc2ea"
+    },
+    "sound/ambience/alarmlong.wav": {
+     "bytes": 1376968,
+     "sha256": "d63752389892f6baf6ead41997f5f4e4407d5d89f657da2d1c7a3e449b439f3f"
+    },
+    "sound/ambience/beeps1.wav": {
+     "bytes": 33154,
+     "sha256": "098bc80c7b616c8be9f552aaecc21d82ca333d0a915838d9380b20243b84aba2"
+    },
+    "sound/ambience/computers1.wav": {
+     "bytes": 154566,
+     "sha256": "1bb4c3148fbcbc572f0fe4c1ef5d41cb7a6d0dd05df0f4870842e13e17066877"
+    },
+    "sound/ambience/computers2.wav": {
+     "bytes": 165590,
+     "sha256": "658af7c3df5d0ec73e02d9f5ec9358657650a14213d12e542b8feb0b2046118c"
+    },
+    "sound/ambience/computers3.wav": {
+     "bytes": 207486,
+     "sha256": "652941fd1792e9d3a9a6db8b7502a7ebdddd6d8d3b2cd43f1bf17e4d1080eba7"
+    },
+    "sound/ambience/creak03.ogg": {
+     "bytes": 44240,
+     "sha256": "dbfc17d19e420714ac2cff8103d47b7ec0bc503b42ffc5e743dcb4f7dc77201b"
+    },
+    "sound/ambience/creak_02.wav": {
+     "bytes": 219780,
+     "sha256": "f9c82d1ef0f062b53d71e1dd79fe5bf5c91a9a8a032a10d5fe079a02b058b683"
+    },
+    "sound/ambience/creak_05.wav": {
+     "bytes": 241314,
+     "sha256": "dcad527b86c3d19de623c4f5581710648827b6d17cb00e2b019a638b4823c32e"
+    },
+    "sound/ambience/creak_08.wav": {
+     "bytes": 265474,
+     "sha256": "7439cfdc32fc70358bed54c845871e5b1252a2b9cd0be084ffe18d4e817a2295"
+    },
+    "sound/ambience/drone6.wav": {
+     "bytes": 18440,
+     "sha256": "7b2f13571683f9e38537a07864c710c98238c96d2939e693e8d4a537f4acf850"
+    },
+    "sound/ambience/engineroom1.wav": {
+     "bytes": 223016,
+     "sha256": "1eddbae4469e69f277444851adaf082b60e47f07a945fbb8bf8fab807751cf31"
+    },
+    "sound/ambience/evil.wav": {
+     "bytes": 148396,
+     "sha256": "1a257ee4d36434fec3d53c9446c867956f3e0e9be28689ea58936eee419da121"
+    },
+    "sound/ambience/growl1.wav": {
+     "bytes": 106496,
+     "sha256": "07e2a1b2ed41c613295b36c4b5e030dc133cb93f76cec260da5e8754a8444529"
+    },
+    "sound/ambience/growl2.wav": {
+     "bytes": 142952,
+     "sha256": "47d3a83c741d60fa9d03af3b2309585121b6cd37e858e0264aa075654dcae611"
+    },
+    "sound/ambience/growl3.wav": {
+     "bytes": 77356,
+     "sha256": "dc47e1b4c9500e1499466aa39b828ea3d841e2a60ed272ede4c18e08af5afa0f"
+    },
+    "sound/ambience/lasoff1.wav": {
+     "bytes": 54620,
+     "sha256": "0110fd5b5b0d105f7c9c44250ea903b60f56c4122850b937f528a588d566fb79"
+    },
+    "sound/ambience/laugh.wav": {
+     "bytes": 614444,
+     "sha256": "a2e6d43d7958b72c0a7a80c926a19bade4c22c551d1791c5db71a23d99225080"
+    },
+    "sound/ambience/machinerydrone01.wav": {
+     "bytes": 217820,
+     "sha256": "38f815477837c0f4ce08bc7169f932aa21f1b0d9443ecad56bb142fe2e18aaea"
+    },
+    "sound/ambience/machinerydrone02.wav": {
+     "bytes": 123746,
+     "sha256": "a2178988940a17c993578c128fdb41141f7f3160eb7ef9cd7211c2b6255c1980"
+    },
+    "sound/ambience/machinerydrone1.wav": {
+     "bytes": 217820,
+     "sha256": "38f815477837c0f4ce08bc7169f932aa21f1b0d9443ecad56bb142fe2e18aaea"
+    },
+    "sound/ambience/machinerydrone2.wav": {
+     "bytes": 123746,
+     "sha256": "a2178988940a17c993578c128fdb41141f7f3160eb7ef9cd7211c2b6255c1980"
+    },
+    "sound/ambience/quake.wav": {
+     "bytes": 340848,
+     "sha256": "4816d8282756fcc47cec5f32a1f5a880c45f1e44348cd6cb660b86927090826b"
+    },
+    "sound/ambience/x_rumbledrone.wav": {
+     "bytes": 201028,
+     "sha256": "e379dd59cebfb1e2a111bb3ff186fe50a236509c1f59ab856b544f47282480be"
+    },
+    "sound/ambient/aramb1.wav": {
+     "bytes": 44476,
+     "sha256": "4c6440672b87575dd8ac5a267621881b9c70e48722cf9a4aa75a4a9b384fea5b"
+    },
+    "sound/ambient/arcohum1.wav": {
+     "bytes": 20418,
+     "sha256": "3b42cb1b62f62acabdc8ef8612ab4343b71b165c3525552701ef769f90020960"
+    },
+    "sound/ambient/arhum1.wav": {
+     "bytes": 20740,
+     "sha256": "e374f3d90564808e019abe09f4464b704512cf85ff0f3b4bb3c955b4153184e3"
+    },
+    "sound/ambient/arpump1.wav": {
+     "bytes": 18262,
+     "sha256": "11ae2c08c7d5f7f777eade75770a1623386d0e0096a19076fff13e9ddec6318c"
+    },
+    "sound/ambient/arwind.wav": {
+     "bytes": 30408,
+     "sha256": "34248569bb7ab66f5e1d874e15c7a91d89fd2b70d27e5521456b2589581fe1e6"
+    },
+    "sound/ambient/cavern.wav": {
+     "bytes": 110466,
+     "sha256": "3ccf6482b46b41b4d98f3bb863e84b47b3cec6c7549cad381746110c8dbec526"
+    },
+    "sound/ambient/chatter.wav": {
+     "bytes": 190760,
+     "sha256": "59197f823b479c66c41163d82fed6dc13a715aef429b5e551ba80ca6f7c229fb"
+    },
+    "sound/ambient/comp.wav": {
+     "bytes": 12164,
+     "sha256": "ab8e3b13981bb432cca44ad4b7467734f52d01927018e72c99e7c4d052dc7874"
+    },
+    "sound/ambient/conveyor1.wav": {
+     "bytes": 348058,
+     "sha256": "ca68f9d44a06155fec7a886675c825b247d2b21996e92daeb76d9f47db2cf2a7"
+    },
+    "sound/ambient/creak.wav": {
+     "bytes": 77398,
+     "sha256": "3ab84c316976fabecd33cc6e5556d106a961c80909985db8d6776379790d23b6"
+    },
+    "sound/ambient/creakypipe.wav": {
+     "bytes": 209500,
+     "sha256": "2bfc86c5fc78a17c7422296e78c908f97520c4ff67a4f544c7897a95bcfdcafc"
+    },
+    "sound/ambient/crickets.wav": {
+     "bytes": 12236,
+     "sha256": "d5cf6e56884a8e43469408d4788ec6e573167901586df259a938cd088c998ef9"
+    },
+    "sound/ambient/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambient/drone.wav": {
+     "bytes": 30902,
+     "sha256": "81993d96ab337f78c2778cecffe4767605fed210e0ac2303a46ac898979eea13"
+    },
+    "sound/ambient/dronehum2.wav": {
+     "bytes": 183654,
+     "sha256": "03545ae0f88b788e69e09c0aae2cccfa727a2609ef224c7d1d3451f0e6172709"
+    },
+    "sound/ambient/dronerumble1.wav": {
+     "bytes": 228790,
+     "sha256": "d97972b25a006dbd54c1de9750b838ab52fff7c8aec70fb58115ad831b7efee8"
+    },
+    "sound/ambient/dronesewer1.wav": {
+     "bytes": 345280,
+     "sha256": "ee8cd803398a007f2f3b412dd2401098586e1d38f558daa748ea4e86f10267ad"
+    },
+    "sound/ambient/engineroom1.wav": {
+     "bytes": 223016,
+     "sha256": "1eddbae4469e69f277444851adaf082b60e47f07a945fbb8bf8fab807751cf31"
+    },
+    "sound/ambient/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/ambient/farambient_l.wav": {
+     "bytes": 330958,
+     "sha256": "4c65d4dd9c8111a0b13d625a86a30f1a6ff97b0acfb03423009fc57100981547"
+    },
+    "sound/ambient/farambient_r.wav": {
+     "bytes": 330890,
+     "sha256": "a843e4b6958b198fa7de5f54fc8902040c7257f151df89f23dadae77920da960"
+    },
+    "sound/ambient/hum02.wav": {
+     "bytes": 37836,
+     "sha256": "8b2ee1b91fa663b6111de9251011142475831ece70ee091022b800b715f1bfa2"
+    },
+    "sound/ambient/industrialbuzz.wav": {
+     "bytes": 57112,
+     "sha256": "ac872a81a917704e4e418d7f83f2b7cdb35d3f35671e11261634727dfb7cfca9"
+    },
+    "sound/ambient/intake.wav": {
+     "bytes": 25682,
+     "sha256": "e6d13169ce4680dd83903473897fd6e7ce1e51fab00c6df2127ea993321c05b0"
+    },
+    "sound/ambient/lava1.wav": {
+     "bytes": 926316,
+     "sha256": "41964be60ef167936d0ef74f47fdfa3c2b147f7ec1f5f26fbb312ee71be3a6bd"
+    },
+    "sound/ambient/lonoise.wav": {
+     "bytes": 32876,
+     "sha256": "1e0f99ffadead8460a7a4bed1c6b2c16cddd70050e1524e9cdaf6724a9dc81b5"
+    },
+    "sound/ambient/machine_loop1.wav": {
+     "bytes": 125104,
+     "sha256": "f0e24bbedef87a9fdabeb9b785af9a5fb3baad755e8770f130f4be64e3ccd1e6"
+    },
+    "sound/ambient/machine_loop2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambient/millwheel.wav": {
+     "bytes": 321834,
+     "sha256": "699fac8407d6d3831bcbcc6353dcc2cb78b05ddb24e8bf7d5e37742c84fcf202"
+    },
+    "sound/ambient/motor1.wav": {
+     "bytes": 52340,
+     "sha256": "c48511a37143e9ed50ae7c1d1f28235b007762949d3d18549fc545cc670c0a24"
+    },
+    "sound/ambient/motor2.wav": {
+     "bytes": 52014,
+     "sha256": "7f36cda5c01aea4e6b356ae4d0b31b68ca15d7606eefd30f4739a64fc4e86e6c"
+    },
+    "sound/ambient/pistons.wav": {
+     "bytes": 44612,
+     "sha256": "cea65c6282630b302dc880bca537aa43d5551f229696617d46c25cebc6516b7c"
+    },
+    "sound/ambient/rain.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambient/rumble1.wav": {
+     "bytes": 403620,
+     "sha256": "47afe820548bcf248b7760f7a66a61ea65b5fb79f70d47e3b03cf8211bb4c5f3"
+    },
+    "sound/ambient/rumble2.wav": {
+     "bytes": 99104,
+     "sha256": "9c3d5418c7e5bac60c365f0e8b7ea496dd2b51c72c13b0e5a6640e2ef880433a"
+    },
+    "sound/ambient/rumble3.wav": {
+     "bytes": 209242,
+     "sha256": "864f373dbd75172e1c8f31373188f38c31a80af46592f6b2e92cf5f576e5e0e1"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambient/swampfall.wav": {
+     "bytes": 308752,
+     "sha256": "ef3186ae5a71ef93a4973b8b41a068139fefc3e11b444e583c72aed8d63d3e56"
+    },
+    "sound/ambient/waterpipe.wav": {
+     "bytes": 364356,
+     "sha256": "89b435d61340ceedc20fff0dcec8e6402cda30b54a75f45753b0d6055d248910"
+    },
+    "sound/ambient/waterpipe2.wav": {
+     "bytes": 327106,
+     "sha256": "f0f7237c937801ed707f7a9a98b102c702b633f2132d536bf7fdb1fcec828e7f"
+    },
+    "sound/ambient/windgust1.wav": {
+     "bytes": 110288,
+     "sha256": "be28de40857304c1a9e169dd483795b2cd23356b81633133c7872e5657111c70"
+    },
+    "sound/ambient/windgust2.wav": {
+     "bytes": 110284,
+     "sha256": "b818f61172795942402ff0ca0d1295a91c36a245edc80689c35fe64a8ac1a4e2"
+    },
+    "sound/ambient/windgust3.wav": {
+     "bytes": 110030,
+     "sha256": "fdbb85f091cd9447f1500173aff70236abcdb947ba0758711816da59c5293344"
+    },
+    "sound/ambient/windgust4.wav": {
+     "bytes": 198502,
+     "sha256": "9a5c5a3da44f981c9deb8b437f57b3e3a35f2bcab318a1a3223f0a18fa4d2101"
+    },
+    "sound/ambient/windgust5.wav": {
+     "bytes": 198494,
+     "sha256": "f55fb77a15a80390ef560962f29ad8311c58af1ddf51f39ffebc4784cf837afe"
+    },
+    "sound/ambient/windgust6.wav": {
+     "bytes": 396944,
+     "sha256": "27a19679e7164a6e7bb8e4d6bc42cc8c12a5cd56bba45218e2ec5f1dc528da0d"
+    },
+    "sound/ambient/woodcreak2a.wav": {
+     "bytes": 352834,
+     "sha256": "24d3f57839910934eb61b74a91cf47ee4ab48b38f58f060ca05bde7547e8813c"
+    },
+    "sound/ambient/woodcreak2b.wav": {
+     "bytes": 352838,
+     "sha256": "574401233bff93169d452f4af748a289cfaff5d4e6319884e3cfb4dbd205d0a4"
+    },
+    "sound/ambient/woodcreak2c.wav": {
+     "bytes": 308746,
+     "sha256": "02deb62b856b7be5c3304a0bf745f79019b0b408a8cfcc4e1edede397ba09c7d"
+    },
+    "sound/ambient/woodcreak2d.wav": {
+     "bytes": 352856,
+     "sha256": "6d35975964b2fa32ece681a9d0cfa13202cde02bc315f32af0690f7437352452"
+    },
+    "sound/ambient/woodcreak2e.wav": {
+     "bytes": 308766,
+     "sha256": "54eb41e3f5c2a0103d07e70e83cf82b51014da3673fb770cf6ada3df669c328e"
+    },
+    "sound/ambirds.wav": {
+     "bytes": 1749682,
+     "sha256": "fbb17aad1134d87c79fe1666c146e83a4016088d3e5373621e0bda6a2044839a"
+    },
+    "sound/ambirds2.wav": {
+     "bytes": 2462386,
+     "sha256": "4779f3d30bd518af03b59616be887b5b0a3871cf35de0fca93e13b4d0b5ae601"
+    },
+    "sound/beeps2.wav": {
+     "bytes": 22974,
+     "sha256": "0e254ca28555ae894e5c829733efee45737dc2c968f75fd089ea92c589eb7915"
+    },
+    "sound/break/bricks1.wav": {
+     "bytes": 49956,
+     "sha256": "302547c290609bc311098f9f63643199bee0164e907edf0e2b9289ccbce2a4e2"
+    },
+    "sound/break/glass_impact.wav": {
+     "bytes": 98832,
+     "sha256": "32f51f7e8cb89c6b9a83c12603c4903a77370d9d16f8d3496e7ef22fb7b04a13"
+    },
+    "sound/break/glass_impactSoft.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/break/metal1.wav": {
+     "bytes": 70054,
+     "sha256": "c178f8f52631b1ff353fbeb3557e04e8bd574646ed47f78a3003350b67540979"
+    },
+    "sound/break/metal2.wav": {
+     "bytes": 65948,
+     "sha256": "7438b112d81fb92c285a507ebfbde5b15dbddcd90a85f51ecaae2df3ef83480c"
+    },
+    "sound/break/pd_bricks1.wav": {
+     "bytes": 61786,
+     "sha256": "3829842a9cb395f99d07546be38263eaf0ee5bbed71841aa8c93864d55a7fb94"
+    },
+    "sound/break/pd_metal1.wav": {
+     "bytes": 44146,
+     "sha256": "c0111b94231bc3870cbb95ec03f13b2b44ac407a5d18b35668ccf231303cc8aa"
+    },
+    "sound/break/pd_metal2.wav": {
+     "bytes": 70722,
+     "sha256": "ce8250482e831c270cc3c8e9211b74a627b3e29159c2c8ee720dd11cafd365c1"
+    },
+    "sound/break/pd_stones1.wav": {
+     "bytes": 75150,
+     "sha256": "632d15db23ff70c23c199595b41a153ded67f664de46b7d0cbfa0228f071156e"
+    },
+    "sound/break/pd_wood1.wav": {
+     "bytes": 34526,
+     "sha256": "621865f52fc27fb10108027ce3eea18aaf17181751a3ba1ceee0c9c99da9f375"
+    },
+    "sound/break/pd_wood2.wav": {
+     "bytes": 33342,
+     "sha256": "77282f2c533b9aec72b232aace9078534db3f255f418efafdf769c7361a28e05"
+    },
+    "sound/break/stones1.wav": {
+     "bytes": 69380,
+     "sha256": "1b58b722e55c4e2d25f65e820e279699a7b236a02685fbc6a41a40e573df1928"
+    },
+    "sound/break/wood1.wav": {
+     "bytes": 53720,
+     "sha256": "026e35d7108347603453765f66311fec99097ff9f82e2d2703f69b7d80ae07c9"
+    },
+    "sound/break/wood2.wav": {
+     "bytes": 59252,
+     "sha256": "4488c91dc44e526beb95d33ad200e07e484a6f2fea59578784f3417a00df81f7"
+    },
+    "sound/crickets.wav": {
+     "bytes": 12236,
+     "sha256": "d5cf6e56884a8e43469408d4788ec6e573167901586df259a938cd088c998ef9"
+    },
+    "sound/dump/armsh1.wav": {
+     "bytes": 22610,
+     "sha256": "46801976a87d548c2cb7b1548f12dfd0b3f1d246aa9d86944574fa3216c6d6d1"
+    },
+    "sound/dump/elec22k.wav": {
+     "bytes": 178736,
+     "sha256": "d56ff98d1d41511833c35b5a8b5311f00b7e13932591eee53f9e2adf788569e1"
+    },
+    "sound/dump/magic_01.wav": {
+     "bytes": 125944,
+     "sha256": "3ea2bab80feccbe0f0b518ec613f45093aa76b0128752f454e239c75175cb4e0"
+    },
+    "sound/dump/pd_armor1_sh.wav": {
+     "bytes": 12410,
+     "sha256": "3b80fc8000fe624ffbe4f119faf41a77406b83bd350020c7782bc03fd51a1799"
+    },
+    "sound/dump/pd_magic_01.wav": {
+     "bytes": 125944,
+     "sha256": "3ea2bab80feccbe0f0b518ec613f45093aa76b0128752f454e239c75175cb4e0"
+    },
+    "sound/dump/pd_quake_end.wav": {
+     "bytes": 37248,
+     "sha256": "3ecb621fbf5a3f2ab090ebc0f3036069292181b11ab366689b3dfa0f19dd372a"
+    },
+    "sound/dump/pd_quake_full.wav": {
+     "bytes": 156278,
+     "sha256": "872e0b0847fd366c59341d672cba9da0faaf85a881f8d4d5471a664923c8440e"
+    },
+    "sound/dump/pd_quake_loop1.wav": {
+     "bytes": 159956,
+     "sha256": "52a330a12c35191347008f4c546b1c83b4e387f3f33c9b60c3a5e8e545b0517e"
+    },
+    "sound/dump/pd_water.wav": {
+     "bytes": 92708,
+     "sha256": "0402b1fb2501dafb33bd43fa9c49c0f6a3fff615a200693cb7953852305c49f4"
+    },
+    "sound/dump/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/dump/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/dump/water_59_02.wav": {
+     "bytes": 40038,
+     "sha256": "25aa667940a737e46da0a829d9cb94922972b9b19726664d1a1133a666dc1439"
+    },
+    "sound/elevator-ping.wav": {
+     "bytes": 268390,
+     "sha256": "a58d7ea5e9c524bf132af87ea043fd236e9b35ed5c06bf9ab02f98b856899167"
+    },
+    "sound/flyby1.wav": {
+     "bytes": 260406,
+     "sha256": "3fb54dce36de4164173ff68f2eed3a5b24a81c784b7d0758c29ba27620c11378"
+    },
+    "sound/grapple/gractive.wav": {
+     "bytes": 39606,
+     "sha256": "07326b827e9e9e8adf18c169f61f00f1d0dbe99a3089585c8b10aee1c900e672"
+    },
+    "sound/grapple/grdetach1.wav": {
+     "bytes": 22030,
+     "sha256": "509f831ddd9492bc961a59734afda72f44e1a602149c8139dfc8c4af9744d6db"
+    },
+    "sound/grapple/grhit2.wav": {
+     "bytes": 37912,
+     "sha256": "250cd88a7dbf49feebc457eaa240e7ff9a2e455ef9c0036351b80afc1a7e12c7"
+    },
+    "sound/grapple/mhookactive.wav": {
+     "bytes": 58160,
+     "sha256": "e53815235713a35b567af6c9013dd11f469342476eeba1ec2cefab082e5ae280"
+    },
+    "sound/grapple/mhookattach.wav": {
+     "bytes": 101568,
+     "sha256": "f971d49ba8821f70e83756241c6023d746ecbb10db00e5150cd739b7fe80736c"
+    },
+    "sound/grapple/mhookdetach.wav": {
+     "bytes": 148000,
+     "sha256": "4f3699109728a315f20c2bdfd32d0ba024ed52ae39c57b91ac4830b349e8982a"
+    },
+    "sound/grapple/mhookdisable.wav": {
+     "bytes": 55340,
+     "sha256": "6a0468e2f27e1717a9408cb782d8fe573e5110a52c43a5f980409a5ee679639a"
+    },
+    "sound/grapple/mhookenable.wav": {
+     "bytes": 55340,
+     "sha256": "dc98b548f41ac1fdd6507df62179c8cf289be0c1fa3c1c0a478fee10df09a7c7"
+    },
+    "sound/gwx9/boat1.wav": {
+     "bytes": 108264,
+     "sha256": "59361383fd00395e7a5d68ac0678aa700f68b558d8fd4422c865809da0aa3b9d"
+    },
+    "sound/gwx9/lighter1.wav": {
+     "bytes": 7862,
+     "sha256": "4114345ee4edfd8f1e531dbcbfc2463c396e361ecf06f386ed3bfa88bb4e3d5e"
+    },
+    "sound/gwx9/q_pianoborq.wav": {
+     "bytes": 16394,
+     "sha256": "6129f89358cb4ddb9f0df07a99e0cd7e05f1516e407ff599e2ca5baca11ca689"
+    },
+    "sound/gwx9/qchopper.wav": {
+     "bytes": 214016,
+     "sha256": "4bca59ba9c17079c5fcaa52b69dadf714a481182f2e09a31a5c99083338fe6f0"
+    },
+    "sound/heartbeat1.wav": {
+     "bytes": 99468,
+     "sha256": "77c75c71e7ee17a7674156cbff212243734e093e91b4f4fbc8cd693f3cdd08c9"
+    },
+    "sound/heresy/1shot_greg_01.wav": {
+     "bytes": 377344,
+     "sha256": "915523f2411f5e0361ad147659f46d8ef8dba3edc6b0d44a4edb9fc68c95ae23"
+    },
+    "sound/heresy/rock1.wav": {
+     "bytes": 133700,
+     "sha256": "8a66187ca7d7440f0275fd3631751bae9f6880104399f51e607456949e8e518b"
+    },
+    "sound/heresy/rock2.wav": {
+     "bytes": 73846,
+     "sha256": "b8ece1952ac45f9496765f561fe65bbeb9c2ad41839f9bae8329dac983d1fef9"
+    },
+    "sound/heresy/rock3.wav": {
+     "bytes": 105476,
+     "sha256": "8e5af5c0df108d5633c082d4a98cd7641a7ab122fff90a242ed0109084b0d263"
+    },
+    "sound/heresy/rock4.wav": {
+     "bytes": 93016,
+     "sha256": "5d9285d98f21df4a55494fe254ae129482c7fab2f0edc9bd9fd7aa4d6b7aab6e"
+    },
+    "sound/heresy/splashes.wav": {
+     "bytes": 100392,
+     "sha256": "55025288eb0275574fe12a4616edc0507e2602a81284f630c69ad876a8efc88a"
+    },
+    "sound/heresy/windcave.wav": {
+     "bytes": 253736,
+     "sha256": "0b21c2c2aabb169dcb68b69784be9cb8b28131205154c2a41dc0ff4d93621d60"
+    },
+    "sound/hydra_idle.wav": {
+     "bytes": 15144,
+     "sha256": "33cca7e04a33c746049ebaa44e82db38a65a951890215fcf72067fcad3c1205a"
+    },
+    "sound/journal1.wav": {
+     "bytes": 44180,
+     "sha256": "1eca86da7e50d8e7fa59432e7dab97258ddfbf99773c4455f2d7339235cce540"
+    },
+    "sound/maahes/arrow_back.wav": {
+     "bytes": 53382,
+     "sha256": "95f4397c3a6123d96ff929b76bc46ef86378368167ed8a7fa2099cf6b64c945a"
+    },
+    "sound/maahes/arrow_out.wav": {
+     "bytes": 105516,
+     "sha256": "808d2a46679a2f2280ba486fc189bf048d873c44ab1109bb2ae1d45b9e8c090f"
+    },
+    "sound/maahes/flute.wav": {
+     "bytes": 569838,
+     "sha256": "4f590c39a9c39b282a13b143ea7d56f6fc4c5fba56116a048edca169a6101977"
+    },
+    "sound/maahes/smasher.wav": {
+     "bytes": 124588,
+     "sha256": "0609c379a0aa35df478e90942a000b8a8fbe170a26ce695e83acc421b7da4865"
+    },
+    "sound/maahes/stonemove.wav": {
+     "bytes": 167646,
+     "sha256": "40d4b21a67402bf537656845051205f6068d58b2b6683eae61871ed1d7f8cd4e"
+    },
+    "sound/maahes/tr_secret.wav": {
+     "bytes": 277548,
+     "sha256": "dbfa52c80ab816b5ccb8011b2f4bb6d5a087ca115bf8442fd741fcbe0e9997c6"
+    },
+    "sound/markiev1/waterriver1_loop.wav": {
+     "bytes": 92498,
+     "sha256": "aefd6a04e31aa3edd7e92089d64796a56b05dbf5444a0f748cc4b7bc8f0d20f2"
+    },
+    "sound/markiev1/windysign1.wav": {
+     "bytes": 171102,
+     "sha256": "82fc997830176004345f649684147c9933992d4adbbb58a28597ce64bdf655d9"
+    },
+    "sound/metalscreech1.wav": {
+     "bytes": 107572,
+     "sha256": "d9c8df5609db785ed2debf2977a50564acb211439acdaf82f581be731ff12ee3"
+    },
+    "sound/metalscreech2.wav": {
+     "bytes": 113086,
+     "sha256": "8ba579924922aad695de9a94c7bbd5858b71b30f02adee00c639bb24936c7b95"
+    },
+    "sound/metalscreech3.wav": {
+     "bytes": 118598,
+     "sha256": "29b5f8e1aea057683e7944c331a861038e1f86b96dee6099d3b75439c5fdbfcc"
+    },
+    "sound/metalscreech4.wav": {
+     "bytes": 132380,
+     "sha256": "1d61e744e8770d70fe05f8472980852cabc427150c620d1baef2690360e837da"
+    },
+    "sound/misc/bounce1.wav": {
+     "bytes": 131318,
+     "sha256": "e2ff508502105784b4d4c57866fd51c90e378da512453f2b4f0ec7d3b9c9e05b"
+    },
+    "sound/misc/bounce2.wav": {
+     "bytes": 65748,
+     "sha256": "7aa0dc7f440d26308324203b6b765f17def36e1ff93d848bf6bcfa5757c83575"
+    },
+    "sound/misc/bounce3.wav": {
+     "bytes": 38432,
+     "sha256": "0bc4a8a5ea66240a0626b0f6aa7b89596cc21f1f4661faa10046c14e91a44ca6"
+    },
+    "sound/misc/bounce4.wav": {
+     "bytes": 130190,
+     "sha256": "a6832f4e0bbeacdcfa004b2f58c5f373612d328f4e6cff136a5865b677e47fbe"
+    },
+    "sound/misc/bounce5.wav": {
+     "bytes": 111922,
+     "sha256": "75b43f7f3a81e36a03f30c8fcb9c74ec3ea2802d81ad8c170df0c6c5d687152e"
+    },
+    "sound/misc/bounce6.wav": {
+     "bytes": 90644,
+     "sha256": "61326cbca06fc86291e860ca3cea864ddfe88ad93faab30bcc2626e07f1ed362"
+    },
+    "sound/misc/bounce_c.wav": {
+     "bytes": 49084,
+     "sha256": "b09cbe0dc39101a49153cd2150f1ae77d1bac6449dcdfb6839413721e5492470"
+    },
+    "sound/misc/cushion1.wav": {
+     "bytes": 114818,
+     "sha256": "901643e1c58d71be1bcd30204081b2b35aaa4b48f08df6b6827757ac7ceb7daa"
+    },
+    "sound/misc/cushion2.wav": {
+     "bytes": 69444,
+     "sha256": "081ae22fd9a6447b0331df39b4d0066c3f1275113423a8ed9154b03cd0074ae5"
+    },
+    "sound/misc/cushion3.wav": {
+     "bytes": 18706,
+     "sha256": "bbd10a7fe94c4f17c601663999f7634fd9fc7b91b8ce18091b94e85f63c0a806"
+    },
+    "sound/misc/cushion4.wav": {
+     "bytes": 88320,
+     "sha256": "8e085176b61f2267359942b8408cb5729642b8e3b656f91e8a2b022c57755945"
+    },
+    "sound/misc/cushion5.wav": {
+     "bytes": 135156,
+     "sha256": "725f93e054fbd55e572ce7c69b0cc5a38a5654f74e304341e5e6b784f99b9c9d"
+    },
+    "sound/misc/cushion6.wav": {
+     "bytes": 75530,
+     "sha256": "f9736c287e7adfea7ec5af4ff264eff78d33061f40f0088f4ff4c72d5dc3e214"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/mesh1.wav": {
+     "bytes": 58482,
+     "sha256": "1cc350204f85be52b106ff012e5486c9c7be73d2ad1720028359f854a268b3f9"
+    },
+    "sound/misc/mesh2.wav": {
+     "bytes": 53260,
+     "sha256": "53b48ced37d7002af3af4a06912689ca00d5c2de09ceb12c2d183ddefd25fa0d"
+    },
+    "sound/misc/mesh3.wav": {
+     "bytes": 59688,
+     "sha256": "45e24bb4005871e7f096711eda928c6e8d5ebf52699239c3c16c1b59e060ba5f"
+    },
+    "sound/misc/mesh4.wav": {
+     "bytes": 95440,
+     "sha256": "4f53a83e668f1c2384684c4c8c567b3fbe26506957b57fc927f1eaac5cbf947d"
+    },
+    "sound/misc/mesh5.wav": {
+     "bytes": 315602,
+     "sha256": "b22c95cf3d7751f0a7437768cbff4c314f3faca60c079e3abfaba8bccfb907b1"
+    },
+    "sound/misc/mesh_c.wav": {
+     "bytes": 41282,
+     "sha256": "e507b003e86b197e286a378786fab189721626ed5cf5377d805edc9078510818"
+    },
+    "sound/misc/mesh_c2.wav": {
+     "bytes": 33172,
+     "sha256": "b1614e4039333f2f1746d1ec5453896c81783b614fa524bc28cc393f601259d7"
+    },
+    "sound/misc/mesh_c3.wav": {
+     "bytes": 42992,
+     "sha256": "23b19afcfbb04f236766940ad97d870f7f93d496bcbb4dacf3c6739046c737f5"
+    },
+    "sound/misc/puzzle.wav": {
+     "bytes": 6558,
+     "sha256": "749dc513e6fc6db082153a602bad5574325c1ff6e3d0b58f0f1169116a17c71b"
+    },
+    "sound/misc/puzzleaway.wav": {
+     "bytes": 4694,
+     "sha256": "bba82dd60ddc23bda2c0a905a1b73394bead2a172f78d46f0f192699b880192c"
+    },
+    "sound/misc/retro1.wav": {
+     "bytes": 22462,
+     "sha256": "35bf5034f26b8b5ccfcdbe6d371831a4c279f8ceed79601946219adb63276646"
+    },
+    "sound/misc/sticky1.wav": {
+     "bytes": 29910,
+     "sha256": "fbc3907ec6b9853130e24d768111b091d3123622631b431e538763b30f376520"
+    },
+    "sound/misc/sticky2.wav": {
+     "bytes": 27612,
+     "sha256": "8f6b498800a8c00b0a3254e687314f1d94a232e784c810178e60157991b67c14"
+    },
+    "sound/misc/sticky3.wav": {
+     "bytes": 75530,
+     "sha256": "9e0a442c0e9466eafef10a0a1a2246b6e7c523b323c7c8fd26d2ea084821b47c"
+    },
+    "sound/misc/sticky4.wav": {
+     "bytes": 42054,
+     "sha256": "e27ffc077693b4384c44daedbae19169991b0335aa3f6d79497b4656213e9dcb"
+    },
+    "sound/misc/vines1.wav": {
+     "bytes": 315602,
+     "sha256": "122ac96e09ff9fe5291ee2f8e79d9c1539a350c01ced4e6037ae857453f9f3e4"
+    },
+    "sound/misc/vines2.wav": {
+     "bytes": 244954,
+     "sha256": "924f9faef5ab66e9f32793c266d11d51faecec2dc9b4be369e883ec8d6c167f9"
+    },
+    "sound/misc/vines3.wav": {
+     "bytes": 329732,
+     "sha256": "4acaac46c6ea8fa76e3335e7df1a236fc3b1f97a1fcbfe779f2331889664a749"
+    },
+    "sound/misc/vines4.wav": {
+     "bytes": 202566,
+     "sha256": "576044eba6e7453afb8fcdc35db41107f4917bf61ce018d9fd94710a9f55dc85"
+    },
+    "sound/misc/wood1.wav": {
+     "bytes": 62108,
+     "sha256": "a13beef55a57c6506d1d7c9399c1962966bebd5d7597b0bb98a042ea4244ff4b"
+    },
+    "sound/misc/wood2.wav": {
+     "bytes": 54946,
+     "sha256": "4ddd034f1807ae0d133cbb86cc05cb7aeb7ebd5656b02c962c3eddda403acc8f"
+    },
+    "sound/misc/wood3.wav": {
+     "bytes": 85182,
+     "sha256": "1c91fd493b14935784229613f3024d4410f9b378199aa097ed62a696e4462b0a"
+    },
+    "sound/misc/wood4.wav": {
+     "bytes": 50172,
+     "sha256": "bf7711f7373e8a128216be8079eaac096c1105eff1b83231bcb684809737bea0"
+    },
+    "sound/nickster/creepy1a_11k.wav": {
+     "bytes": 1147040,
+     "sha256": "c5ad3a82aa4cd6ed5a13d4eaba6acf5300d15fb5f04020ca5ff117e5b8fd9d6a"
+    },
+    "sound/nickster/creepy1b_11k.wav": {
+     "bytes": 1147040,
+     "sha256": "4b1869585a910f69a224e63276048235dead64faeaa0074ae517605632bff8d1"
+    },
+    "sound/nickster/mach_hum1_11k.wav": {
+     "bytes": 573600,
+     "sha256": "99d47807ab6aff53ec1ef73039d7b9269faf986e943518930bea154ba5524373"
+    },
+    "sound/nickster/mufscr1a_11k.wav": {
+     "bytes": 102142,
+     "sha256": "b62a7d227f7190440e28397c53ad9dd30a53e29a2709fc9806b9a2f2641ec045"
+    },
+    "sound/nickster/mufscr1b_11k.wav": {
+     "bytes": 102142,
+     "sha256": "88c23e990e1c6edfe845a3a024449546505b27d828fbcaac3280dd8af3b9213e"
+    },
+    "sound/oldone2/pd_pop2.wav": {
+     "bytes": 42108,
+     "sha256": "1eec3103cd2eb70fa8ba63ce8ce721842a64a99e9c373f5a8abe5508273ce285"
+    },
+    "sound/pendulum/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/pendulum/swing.wav": {
+     "bytes": 12960,
+     "sha256": "68da54f9541808bdaa1f070218bd53ffce0cfccee46b460fd9181a366440952a"
+    },
+    "sound/phone.wav": {
+     "bytes": 44148,
+     "sha256": "f636ac97a0550e8b70c8c1ed57e62045dfb3f04ae2ad2e93b78863a4a08d2e06"
+    },
+    "sound/radiostatic2.wav": {
+     "bytes": 138028,
+     "sha256": "edd3b0e1e318f7c48d83e8755a5fe4952ec4ecebd2a00223f73c074f6b6b1e0a"
+    },
+    "sound/riktoi/steam_leak.wav": {
+     "bytes": 13122,
+     "sha256": "e5200da86f5726b2ee73f042b59c543fcae414b83d33ac91bd9629561add4538"
+    },
+    "sound/rm_carcosa/alarmbell.wav": {
+     "bytes": 42386,
+     "sha256": "21cbe537dccb4c3aec5f4f04b7f24b931086b40c5cc9d398ebbeaa1db6e7a16b"
+    },
+    "sound/rm_carcosa/antigrav.wav": {
+     "bytes": 46748,
+     "sha256": "c0e81f58862805d0b3602e87492fab275c0f3cbe5894eb4c9b10f3856329c42c"
+    },
+    "sound/rm_carcosa/axe.wav": {
+     "bytes": 17474,
+     "sha256": "26a01b095ecfeb8d731b436c966b55947dede52b3d2d271eb213a63b562d233b"
+    },
+    "sound/rm_carcosa/baddoor.wav": {
+     "bytes": 4194,
+     "sha256": "9e4f6da93a65a2d134d96f748e2b143ad9bbec551aa6ce0c9130431b4fe3d8bb"
+    },
+    "sound/rm_carcosa/canopy.wav": {
+     "bytes": 75172,
+     "sha256": "7c771fd3c6bd735d3a7e7bfda9217ec1d09d76011a0c8c1efe42957a75df5a97"
+    },
+    "sound/rm_carcosa/chnswch8.wav": {
+     "bytes": 7452,
+     "sha256": "ad8557c3edabeae5dcbce4ac1dab74fa640efa5d1adeb7ba2e6d28422d50af32"
+    },
+    "sound/rm_carcosa/dsbdcls.wav": {
+     "bytes": 4208,
+     "sha256": "9c1553ca3ad8c8511151b5e0311fe028f06469e63181fa87c887b23418dbf167"
+    },
+    "sound/rm_carcosa/dsbdopn.wav": {
+     "bytes": 4194,
+     "sha256": "d6529bf62023070e1c60117497b613ac6b2a25f3ae9ed56e020e98a1b60a207a"
+    },
+    "sound/rm_carcosa/dsswtchn.wav": {
+     "bytes": 6268,
+     "sha256": "52ad7f46f457978e56753f74890336fb01148eb118c540819f10b67dca52191c"
+    },
+    "sound/rm_carcosa/flap.wav": {
+     "bytes": 1492,
+     "sha256": "90098aabe10cc4975733041794ab571a833e621a4525671898ce8ac95326a4f0"
+    },
+    "sound/rm_carcosa/fountain.wav": {
+     "bytes": 40472,
+     "sha256": "7364a33f42e22feeb22c428ad774f92e522f811f42fc7498ec84ad4deecffcca"
+    },
+    "sound/rm_carcosa/gear1.wav": {
+     "bytes": 220016,
+     "sha256": "f5f2a2f1b93bbb0ef52e7e26b7ab1840957fd71c1faeed7fe525ebd03605558d"
+    },
+    "sound/rm_carcosa/gear2.wav": {
+     "bytes": 200702,
+     "sha256": "c148a81c94f2008a7546805902599dc3fd6fff2871e4cce2b75f9cfa49b4a4d0"
+    },
+    "sound/rm_carcosa/gear3.wav": {
+     "bytes": 182804,
+     "sha256": "15bf9e08b4e88699dc42681a008cc82c9e7b83544649a65c74cbc574434fa7e9"
+    },
+    "sound/rm_carcosa/gkrokon/death.wav": {
+     "bytes": 22280,
+     "sha256": "b3409ce585af5f3424c4ba80e26e8ce254212831310278396435c4db3c404a47"
+    },
+    "sound/rm_carcosa/gkrokon/hit.wav": {
+     "bytes": 5636,
+     "sha256": "306b4dc4dac6f76938adc032603b5eb8c0644466c0d5087cf39da1fe07194b22"
+    },
+    "sound/rm_carcosa/gkrokon/idle.wav": {
+     "bytes": 17092,
+     "sha256": "8206ae086e797a74d6a9d3406428163d2483f7fa14e173e0722223d38e224db3"
+    },
+    "sound/rm_carcosa/gkrokon/jump.wav": {
+     "bytes": 17144,
+     "sha256": "0b9ee2f07f41643dd0e5d24707639b4f0f96f4231a7603f9ee6087f85d7a4074"
+    },
+    "sound/rm_carcosa/gkrokon/pain.wav": {
+     "bytes": 7900,
+     "sha256": "8ed1671f82bfafd5f8b56ec0960a5ce8f6bf679ee4882feb63c2f4b0187ea518"
+    },
+    "sound/rm_carcosa/gkrokon/sight.wav": {
+     "bytes": 18858,
+     "sha256": "9aa10bba819837f7d2249c07a68ff5823776643b8409e9f0568a667f573922c0"
+    },
+    "sound/rm_carcosa/glass.wav": {
+     "bytes": 31240,
+     "sha256": "d367db8cdc3a043fa615d8fd66952810060967050679628d57e7b9285b67c4ad"
+    },
+    "sound/rm_carcosa/knight.wav": {
+     "bytes": 89162,
+     "sha256": "3c2f8d67c7f47a9101fa76764a1d90de1439d804f5bad32da896ba4c24fd2e3e"
+    },
+    "sound/rm_carcosa/leafbrk.wav": {
+     "bytes": 18110,
+     "sha256": "a387703920ee5aa16aabc27a6721f28eaf5512cf1e4c276ba9e6cb6641fd4516"
+    },
+    "sound/rm_carcosa/lrkdeath1.wav": {
+     "bytes": 13776,
+     "sha256": "68f67f4865f5089fc4e82d33f16d20f2480baba0b8dff57fdf2e65f031b853a7"
+    },
+    "sound/rm_carcosa/lrkdeath2.wav": {
+     "bytes": 10350,
+     "sha256": "7829fcd2f195ca88479c03bba3985b2d5817da2807dee7d1a5b0fa3853f80eb4"
+    },
+    "sound/rm_carcosa/lrklight.wav": {
+     "bytes": 12466,
+     "sha256": "4bb9f27bde6ae6eeaf7ca138c1a5cb6ce40721dde0f7075d921f7d7f3ea19738"
+    },
+    "sound/rm_carcosa/lrkrearm.wav": {
+     "bytes": 16038,
+     "sha256": "29fd45187d36e63f47721fb1790abcf4cebcc7fcb1fe4e25858c5d333a448731"
+    },
+    "sound/rm_carcosa/lrkwoosh.wav": {
+     "bytes": 14752,
+     "sha256": "4094d3376657bbb31914b5eddb6c4d3950472772d1797ed6dd8ae1bc3856dbb8"
+    },
+    "sound/rm_carcosa/melt.wav": {
+     "bytes": 37872,
+     "sha256": "9fd07632bc872fc37df6ad5711c46bfb5b51c0cf47add0ffd77b5bc98306fdae"
+    },
+    "sound/rm_carcosa/mtlslide.wav": {
+     "bytes": 39292,
+     "sha256": "da1e3d92ae9c7ea9e1ac75553f5efa495b5c90e20093a4d4eeebddf2023c39df"
+    },
+    "sound/rm_carcosa/puzslv.wav": {
+     "bytes": 22308,
+     "sha256": "0eb28f48d1a8897803ace74968de7120c8765fa02d6c9c4d36ca001fa458c2b1"
+    },
+    "sound/rm_carcosa/rockfall.wav": {
+     "bytes": 24764,
+     "sha256": "db0910e1f2468508cd300b62cb367bcc8812edc30fc5b2435b41eb6a04a9f8b8"
+    },
+    "sound/rm_carcosa/sheep1.wav": {
+     "bytes": 19768,
+     "sha256": "8f0ffc73cc6a4c02ad409b942d329f6a581d3cee6551af2233473d4e9fa7a131"
+    },
+    "sound/rm_carcosa/sheep2.wav": {
+     "bytes": 18434,
+     "sha256": "10a2a1f8043eea5c1e6f3320dd614e6ddf7b57ab0843440d6b3a53e8136b13fa"
+    },
+    "sound/rm_carcosa/sheep3.wav": {
+     "bytes": 26744,
+     "sha256": "66c8d531d91694714c959be16e318148adecb813817ef080e2176d4630672a36"
+    },
+    "sound/rm_carcosa/sheepdth.wav": {
+     "bytes": 8136,
+     "sha256": "0f9f0cd9b58082a925a44192e97b74f99be719209da799b891f4a5e9d6d0a588"
+    },
+    "sound/rm_carcosa/squish.wav": {
+     "bytes": 22788,
+     "sha256": "2dc0726d0ba746d3b691371b2647ada0547382d73c439da01cf34b42f0ffac7d"
+    },
+    "sound/rm_carcosa/squish2.wav": {
+     "bytes": 22788,
+     "sha256": "1959b4d1c2d1e0cd39e09f49d3edbeab26297236c78a7789291b265014d9cae6"
+    },
+    "sound/rm_carcosa/stonslid.wav": {
+     "bytes": 22624,
+     "sha256": "966ab7ef302dd76e877c99985e0ebdcb1bd9c47929b435aae892590ba4ea97c7"
+    },
+    "sound/rm_carcosa/treefall.wav": {
+     "bytes": 130834,
+     "sha256": "2a48d13cde25b1617568118e1c21a903a8564f64df93e10989ec206c8e833810"
+    },
+    "sound/rm_carcosa/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/rm_carcosa/wdslid.wav": {
+     "bytes": 34202,
+     "sha256": "a87170e894ce358070b36e76aaeeacde3e7dd730465994603b6ac5c77404a026"
+    },
+    "sound/rm_carcosa/wheelstop.wav": {
+     "bytes": 6010,
+     "sha256": "e4495a0ee8d1c1eaafae1019be5ac2a77b28f58b0ea09c95bf32bc404f644797"
+    },
+    "sound/rm_carcosa/win.wav": {
+     "bytes": 55998,
+     "sha256": "cc66b90095b39f010538c0d693b6f7cc34ebe67d4f97d9406913195bcef57a90"
+    },
+    "sound/rm_carcosa/wswng.wav": {
+     "bytes": 34962,
+     "sha256": "2307633f2f9701eb962f6dabecdfe10e852a55860c962f0ef10d94bdc2057b1b"
+    },
+    "sound/rm_carcosa/wswngstop.wav": {
+     "bytes": 3518,
+     "sha256": "f3c79209f9358fc30dd08f1c286db256a158934d0b70c79c6c33ae74acda5743"
+    },
+    "sound/roj/comp.wav": {
+     "bytes": 12164,
+     "sha256": "ab8e3b13981bb432cca44ad4b7467734f52d01927018e72c99e7c4d052dc7874"
+    },
+    "sound/roj/fan1.wav": {
+     "bytes": 53404,
+     "sha256": "97627e69c307e0befb93deff9175a17a8d43138c80ee91be3bb03aafd7785808"
+    },
+    "sound/roj/rogre_alert.wav": {
+     "bytes": 71728,
+     "sha256": "4f3e921b6ee236289660f7ca2ee8a4689e719423266d26a3f8b91ae29d02c6a5"
+    },
+    "sound/roj/sknight_sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/roj/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/scourge/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/traps/flame_loop.wav": {
+     "bytes": 28560,
+     "sha256": "661d8325af92fb37235952e2668578dbf57d844b7359627b4a2c25d15127bff7"
+    },
+    "sound/traps/saw_loop2.wav": {
+     "bytes": 37582,
+     "sha256": "097635d29859ce28ea37da2d51ec346b8d5239435bb6be0bf5f094a555c110e8"
+    },
+    "sound/traps/sawstrike1.wav": {
+     "bytes": 30836,
+     "sha256": "489d8cdea78b2c333771b316741d7960d5c0da6845ea15b94991ece94837367a"
+    },
+    "sound/traps/steam_loop.wav": {
+     "bytes": 22222,
+     "sha256": "3695271fdd2a33e06d92060a1d950be4a80f1a287d8855e00d19d95e8851c7ee"
+    },
+    "sound/tv-static-03-mono.wav": {
+     "bytes": 480044,
+     "sha256": "1c7d897bd75f6059084e7f23a631a10a0952b89df8b0bc9fb9cba55c5c2b1b27"
+    },
+    "sound/waterclose_end.wav": {
+     "bytes": 69704,
+     "sha256": "f94c0a80f01d15fb2199b440de975ace28e37e2a6c454240d03b3fea905505b0"
+    },
+    "sound/waterclose_loop.wav": {
+     "bytes": 246506,
+     "sha256": "f2b7d2f4070b74600613fbcce8a2f617acfe75ffc6a553292eaead803fc4e866"
+    },
+    "sound/waterpipe.wav": {
+     "bytes": 458538,
+     "sha256": "05659d9acf75a12383954319157377d48ce26a81b4ce452babe1fda09de1841c"
+    },
+    "sound/waterpipe2.wav": {
+     "bytes": 327106,
+     "sha256": "f0f7237c937801ed707f7a9a98b102c702b633f2132d536bf7fdb1fcec828e7f"
+    },
+    "sound/waterstrong_end.wav": {
+     "bytes": 41042,
+     "sha256": "1c806f64310394da9c844ac5c79b97c87e352a918e844469224fe6a5e408180e"
+    },
+    "sound/waterstrong_loop.wav": {
+     "bytes": 192524,
+     "sha256": "ca48da15893acbaeb4b7b84419b22d4bdf133501cce370e470202d7ffc6941a1"
+    },
+    "sound/watertunnel2_l.wav": {
+     "bytes": 290116,
+     "sha256": "fd2859dc8fe2fbf6a9bbef3cb213312b95fb8bdc8c383d91cc15ece6cf16776d"
+    },
+    "sound/watertunnel2_r.wav": {
+     "bytes": 290116,
+     "sha256": "44922a8c38fa663fae52cd3bf0f8c496a91b3e8fd46f6b63286cdf7816968ea4"
+    },
+    "sound/watertunnel_l.wav": {
+     "bytes": 459248,
+     "sha256": "59aa0253aaad7b739f84e13bddfd340c9889963785819fe38e41fca30b324822"
+    },
+    "sound/watertunnel_r.wav": {
+     "bytes": 459248,
+     "sha256": "c97dd123a9f8bc4fa09daead64cd45ed970a52fa551f082f0e6cfc848e95bcb6"
+    }
+   },
    "sha256": "b450e17fd905627f051b759586504bf78c3e4acbb0b1f69b806235634ef17f9b",
    "timestamp": "2024-07-06T11:22:04.000Z"
   },

--- a/json/by-sha256/e8/e8b117bef537422adfd5c06d7543d2bfcaa60c1a54fb70721358ea23f4e09e31.json
+++ b/json/by-sha256/e8/e8b117bef537422adfd5c06d7543d2bfcaa60c1a54fb70721358ea23f4e09e31.json
@@ -65,6 +65,2852 @@
   },
   "vr/pak0.pak": {
    "bytes": 418296622,
+   "files": {
+    "demo1.dem": {
+     "bytes": 7277876,
+     "sha256": "834ef6f5179e51b973cae5ac0e7b1152a64f56d8830c06bbd2042d9c7f3b9ffd"
+    },
+    "gfx.wad": {
+     "bytes": 126244,
+     "sha256": "ba1811634fe30a143a00e38f7c7cf737121d625349d3e5540eae75d92d314a42"
+    },
+    "gfx/IBAR1.lmp": {
+     "bytes": 5128,
+     "sha256": "1aedb8f10e677219ad5f4da3c2772240ede3703f110fb3b73b08c252a816877e"
+    },
+    "gfx/IBAR2_1.lmp": {
+     "bytes": 4616,
+     "sha256": "239bf45ef9aad5beebbce1a874aa6dbb629b8e94be66e499926fab4c47b06a39"
+    },
+    "gfx/IBAR2_2.lmp": {
+     "bytes": 4616,
+     "sha256": "880a5d0ba76ca4f44082f754ef2fe81026f964117ae6a60a1e63c00e33e813c8"
+    },
+    "gfx/INV2_LASER.lmp": {
+     "bytes": 392,
+     "sha256": "e780d4221b381224257be742f0b5897ed8f1a93e3c1857060b62ecc955c089d5"
+    },
+    "gfx/INV2_LR.lmp": {
+     "bytes": 392,
+     "sha256": "d27b83e6cb575d58b020a7378a42dd556b10a3abe522401d8710407584ded782"
+    },
+    "gfx/INV2_MJOLNIR.lmp": {
+     "bytes": 392,
+     "sha256": "dae7df9f234825f796eae2156375a7ff13aeb899a29730f63a3cc54633759849"
+    },
+    "gfx/INV2_PROX_GREN.lmp": {
+     "bytes": 392,
+     "sha256": "a239a4e7fed16a58493033fd86d41ac6625251319513e58cadd8ad907606f414"
+    },
+    "gfx/INV2_RG.lmp": {
+     "bytes": 392,
+     "sha256": "e36fbacd2213b3584e6646c20f7d57bf170fb90c995e84f39f35962e686ec70c"
+    },
+    "gfx/INVA1_LASER.lmp": {
+     "bytes": 392,
+     "sha256": "51ec324699d0e3710013401b398227298a7ee33e9d05622954f02b6cb2a2e0e4"
+    },
+    "gfx/INVA1_MJOLNIR.lmp": {
+     "bytes": 392,
+     "sha256": "dae7df9f234825f796eae2156375a7ff13aeb899a29730f63a3cc54633759849"
+    },
+    "gfx/INVA2_LASER.lmp": {
+     "bytes": 392,
+     "sha256": "147055559e6a6a3c5b37014270c7f353669a4895e172f7429e46bf23b27ba971"
+    },
+    "gfx/INVA2_MJOLNIR.lmp": {
+     "bytes": 392,
+     "sha256": "41cb5dcae0e0593f23e53ce93cdca9ed62d445561472a10e76badcd5f500b07e"
+    },
+    "gfx/INVA3_LASER.lmp": {
+     "bytes": 392,
+     "sha256": "6342d52e674b204d5dee9bb68300d9748f702ba900d9668acdece27dca7e6578"
+    },
+    "gfx/INVA3_MJOLNIR.lmp": {
+     "bytes": 392,
+     "sha256": "3e853ca300d8195f364ca06f47806c21da9c18b2b44ca74dcd7c989dac319a05"
+    },
+    "gfx/INVA4_LASER.lmp": {
+     "bytes": 392,
+     "sha256": "1cac4efbb39b168e52fd0278cc24c8d96724a301f55aa06c41d370dc30b57e08"
+    },
+    "gfx/INVA4_MJOLNIR.lmp": {
+     "bytes": 392,
+     "sha256": "b47ea4d64ea53c348aad258ab5f26f15cd6e41653c92ea4b2030871fe9a27fa2"
+    },
+    "gfx/INVA5_LASER.lmp": {
+     "bytes": 392,
+     "sha256": "e780d4221b381224257be742f0b5897ed8f1a93e3c1857060b62ecc955c089d5"
+    },
+    "gfx/INVA5_MJOLNIR.lmp": {
+     "bytes": 392,
+     "sha256": "dae7df9f234825f796eae2156375a7ff13aeb899a29730f63a3cc54633759849"
+    },
+    "gfx/INV_LASER.lmp": {
+     "bytes": 392,
+     "sha256": "954931ffb7b90683cdeea5737f42a57d4e93a134c4d4a6c90d476366d609709c"
+    },
+    "gfx/INV_MJOLNIR.lmp": {
+     "bytes": 392,
+     "sha256": "e5f171dab7299dbac22bd3e1919343f06149d2250859fc24820950985ad63236"
+    },
+    "gfx/RAILCROSS.lmp": {
+     "bytes": 16392,
+     "sha256": "8a91bed5b691d96423ad011fbf635be0148fbbf1510eadc6996ef9bb483d5a75"
+    },
+    "gfx/R_AGRAV1.lmp": {
+     "bytes": 264,
+     "sha256": "5514b76c39136d924329c11d07acc7305ab2e920c6f9ffa16d1ede1df35b5a63"
+    },
+    "gfx/R_AMMOLAVA.lmp": {
+     "bytes": 584,
+     "sha256": "a088300f09e70aad5970cb7d3dd071858ed5e8b30694db4896ccd77c27a60a6a"
+    },
+    "gfx/R_AMMOMULTI.lmp": {
+     "bytes": 584,
+     "sha256": "608c024345c38b805bffd30fa7f456b69f4bd503dca298deff88258351c28a70"
+    },
+    "gfx/R_AMMOPLASMA.lmp": {
+     "bytes": 584,
+     "sha256": "8ee14137f9ec8b11056ebc0c61abdaabb8b7894e25cad271efaddc6b5f0cdfcf"
+    },
+    "gfx/R_GREN.lmp": {
+     "bytes": 392,
+     "sha256": "b0eecfcdb6dd7d2dd96ddbb19a6f74277e9586de1f736d46fdadce8bfe704d20"
+    },
+    "gfx/R_LAVA.lmp": {
+     "bytes": 392,
+     "sha256": "8f9b6a57ac7c63e05bd0ff4307d7ec98ddc56b080d208a6ef3caa29749279dec"
+    },
+    "gfx/R_MULTIROCK.lmp": {
+     "bytes": 392,
+     "sha256": "1d64e1368863949c7fadd43c5ab28f87510d3deecd805c60c5ab2efcb6734322"
+    },
+    "gfx/R_PLASMA.lmp": {
+     "bytes": 776,
+     "sha256": "ef5a098a925a23a8a3eb4c322439af2ab213cfdd0f95d229597d72f1694da20d"
+    },
+    "gfx/R_SHIELD1.lmp": {
+     "bytes": 264,
+     "sha256": "e122fb465ae1e616f343b21ae475dae2a86a6da5d1b1234176e2800082b83542"
+    },
+    "gfx/R_SUPERLAVA.lmp": {
+     "bytes": 392,
+     "sha256": "0f8d8914f281b826e33e8d76f1328e1a75091bdcf8bcfa1d7b4c66a868be6472"
+    },
+    "gfx/SB_ESHLD.lmp": {
+     "bytes": 264,
+     "sha256": "5dc8b3195e1938026882158f7efd039c911cd6dff2dc4dc68bad9ac81e85a9f0"
+    },
+    "gfx/SB_WSUIT.lmp": {
+     "bytes": 264,
+     "sha256": "3ab480b8789671c23c3f373b6ee30314d91b981662886f68abe09de2377b2066"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "09902ae9167d6862adcfe73f4770619192286655e13d289962ff7c191f2209bb"
+    },
+    "gfx/env/stars_bk.tga": {
+     "bytes": 314136,
+     "sha256": "a72c484075133cdb522c03102a2721e301792197e5599940d3f6affa7392f8e3"
+    },
+    "gfx/env/stars_dn.tga": {
+     "bytes": 317615,
+     "sha256": "ef2f1edf1ec682f1ab279ef40dc9239d209f9286e4f164df824974d498d59534"
+    },
+    "gfx/env/stars_ft.tga": {
+     "bytes": 312780,
+     "sha256": "9579b00a19bab9570474598b999b3bfb68a39307f786ff311fb85a335fdf1f0d"
+    },
+    "gfx/env/stars_lf.tga": {
+     "bytes": 317421,
+     "sha256": "37e9c71cb88bbc1cc7c4c14ef5c022e96be0fe9c096b16246c334dab65c2bb10"
+    },
+    "gfx/env/stars_rt.tga": {
+     "bytes": 317085,
+     "sha256": "7e533ece72e55fd5576ae2d5feec1c3e9d726bc0165f16a1eba156f36966471a"
+    },
+    "gfx/env/stars_up.tga": {
+     "bytes": 317212,
+     "sha256": "771f39fdf8dcd6e5337363fa0c87fb08c9c84edf20c611628fa5f4d041355c49"
+    },
+    "gfx/env/stormydays_bk.tga": {
+     "bytes": 3145746,
+     "sha256": "d898c7641be8fbb8eff1e3b32a8a4e6f02e13154ed7a88cc90ceabedae1fa235"
+    },
+    "gfx/env/stormydays_dn.tga": {
+     "bytes": 3145746,
+     "sha256": "70fe4ba19d17e46d62b70582916924e7c20229ecfc5c1bf700bcb6ccb9c563d4"
+    },
+    "gfx/env/stormydays_ft.tga": {
+     "bytes": 3145746,
+     "sha256": "4d68b33f5da78b7fa5c4d4eb61d41b8520a24ce5a70de85f5edb909e52f65bf4"
+    },
+    "gfx/env/stormydays_lf.tga": {
+     "bytes": 3145746,
+     "sha256": "20bb6daf7a6d309cb5e66dcb2c8e8ebf2fe78dd64c0c1cdced5349580e35c6e5"
+    },
+    "gfx/env/stormydays_rt.tga": {
+     "bytes": 3145746,
+     "sha256": "c81e6989c52170220598f5d0ff276d2486ebdca67daa257755371ca2765343f5"
+    },
+    "gfx/env/stormydays_up.tga": {
+     "bytes": 3145746,
+     "sha256": "672d5c37dcfcd47604a4be21c748b6927e89b3e8fc6571653d5c38475e1572d1"
+    },
+    "gfx/gp/GRAPHOOK.lmp": {
+     "bytes": 4104,
+     "sha256": "167be09d678688112b6d3028bd4d75c5c3f877263c6329bf3553b40fcc58b8d2"
+    },
+    "gfx/gp/GRAPICON.lmp": {
+     "bytes": 4104,
+     "sha256": "28fdd54f65f233e729a49fe0deb307077254f8036b59698983eba9c92165b003"
+    },
+    "gfx/gp/GRAPL1.lmp": {
+     "bytes": 4104,
+     "sha256": "b8b44cc3001a9d83fcb6fcf7b90086da662268d810f042d595f625c63d3f40bc"
+    },
+    "gfx/gp/GRAPL2.lmp": {
+     "bytes": 4104,
+     "sha256": "59ea395b2042a7e308dfb1382c01df8a3a55ddcedfe5a043e7503a64174d7518"
+    },
+    "gfx/gp/GRAPL3.lmp": {
+     "bytes": 4104,
+     "sha256": "c0c0284755e01d0215237be98a1d0beea8962651671fcc0d039a1420c39d23b4"
+    },
+    "gfx/gp/GRAPSHADOW.lmp": {
+     "bytes": 4104,
+     "sha256": "ba2368ddc8f0579358660883c0c01982afca84ab198bae896ee22a8d08082296"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "fd1714c339652708fc1b06d6fa144168adb06e6aa840c1e1a9ffb861226234c6"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "266db3e5624dcca494d578884a1ad132f404501ac18fd6d8906f04edbf8d47e2"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "6183fe00a568f0cc1dcd1043d2f8c4917207748dd2714ee90bec7477ef0ca8a5"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "5cf2100caf21dfb6f712c98c67107cb6b1c709337cb88b72412442c4499573cc"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "5837bfbcf3e1d42946d57822f31b36fb526ce709d54208cccb3ee7f9aad5a9a2"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "af13d69616bef7ca9883bb132aa2137ed8e684e801aa943d44f88ec86abe5fd8"
+    },
+    "gfx/jb/JBOOTS.lmp": {
+     "bytes": 4104,
+     "sha256": "db7ced519d7c87efa589e39f05e7f27f9d4c58432e450eef4d0df6bb6a4cca00"
+    },
+    "gfx/jb/JBOOTSTIMED.lmp": {
+     "bytes": 4104,
+     "sha256": "e6dd181db3214c56893f89212fc4996e3cf876f819f4853757150f3b54016108"
+    },
+    "gfx/jb/JBSHADOW.lmp": {
+     "bytes": 4104,
+     "sha256": "843d826edd8478a4b2775a2e5301fc3e676665fd24a3ae619e2f3113b120015c"
+    },
+    "gfx/jb/JOUT1.lmp": {
+     "bytes": 4104,
+     "sha256": "10959f076e69b55da9bc6dd4d0e1288f236021e4e6b9aa8debf6ee2558107023"
+    },
+    "gfx/jb/JOUT2.lmp": {
+     "bytes": 4104,
+     "sha256": "b64b731da0e3314bd7753c200d2b4b4f043dd540d45593a1136573705f052224"
+    },
+    "gfx/jb/JOUT3.lmp": {
+     "bytes": 4104,
+     "sha256": "23b3fcec2a0b3db58d673071851a5338c5ac11b4763da64252eff1ed6b9b662d"
+    },
+    "gfx/jb/JOUTTIMED.lmp": {
+     "bytes": 4104,
+     "sha256": "cd25bba19e3c27aced298db1081ae96f80b3eb0f47a51caa1ce4cdd46c02add7"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "0c0f93942a90285d84ac19bd9118311d4dcd4af2a43f46068bb9f92cc23f5ca6"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "9592248abf44349cdb6c32179dee040f9f87be03bc6d108570cbb8da58adca16"
+    },
+    "maps/b_lnail0.bsp": {
+     "bytes": 13472,
+     "sha256": "7cdb69c1793fed2d01c4284c87b314f4e44022ddc83990cb15ea9c7ad59d16df"
+    },
+    "maps/b_lnail1.bsp": {
+     "bytes": 13472,
+     "sha256": "f220c616a09f3a156ddfe54f72982765d91c404ce94b3321ca96c05b8422ea69"
+    },
+    "maps/b_mrock0.bsp": {
+     "bytes": 2964,
+     "sha256": "cb748a9359bbabfc2ed3d393f762c56d5bdfcf5c3c395383f99827c1f8c4d941"
+    },
+    "maps/b_mrock1.bsp": {
+     "bytes": 2952,
+     "sha256": "948fd6275abb79680c7650ba758cd4e712bfcdec94dc6d94746b95e0b93881a8"
+    },
+    "maps/b_plas0.bsp": {
+     "bytes": 7328,
+     "sha256": "b3feecba45273a9a57081e43f1d7f14dafa5feb64a12b8e590ba1f36b1b84c48"
+    },
+    "maps/b_plas1.bsp": {
+     "bytes": 6144,
+     "sha256": "ffe49c95fb1b630dd8d3ee155b032d3b00af6de4cc675b5063638e0c3a07627b"
+    },
+    "maps/beho.bsp": {
+     "bytes": 8500400,
+     "sha256": "9ce2918f9fe41449822bf6ca848d88b4e0c0e11075ad32d526b171607c49e42a"
+    },
+    "maps/beho.vis": {
+     "bytes": 18657757,
+     "sha256": "7a19ae54a8ab2d82a23a60ea28aa6b8f969128a9c6e9ca11643dbd2b6019e6e9"
+    },
+    "maps/ct.bsp": {
+     "bytes": 8974036,
+     "sha256": "d30c1d1e1905b50a37517235a801fbdef8115a7ba475c0e3fab0562c61f734b8"
+    },
+    "maps/debris/brick01.bsp": {
+     "bytes": 7912,
+     "sha256": "c11880924b195ed38908cbf50f9cd16f071918df0a94a19c7254b93dddb1e62d"
+    },
+    "maps/debris/wood1.bsp": {
+     "bytes": 7584,
+     "sha256": "c39390e3757553352941fcc255da6498be4c25a87575871e360a0166fac592bc"
+    },
+    "maps/impco.bsp": {
+     "bytes": 9559192,
+     "sha256": "bc6ac9d3076432ff8156452152ea572b5e7a12b451aa8c40baf3844b9274abbe"
+    },
+    "maps/impco.lit": {
+     "bytes": 4189376,
+     "sha256": "a8659cdcbd9384f4ac0f1feb10e2cc7ad25bbfb7bd66f15ccc828d0adf3ae84b"
+    },
+    "maps/miasma.bsp": {
+     "bytes": 6121876,
+     "sha256": "bd8fc78b1571f678c424da76fc231918321fd37be8a2e30c382fa0625fd045d1"
+    },
+    "maps/miasma.lit": {
+     "bytes": 3297689,
+     "sha256": "8ea1a889de941119097ad8b217eeca4b174c992339593720324c229493552bb6"
+    },
+    "maps/nbabs.bsp": {
+     "bytes": 20872548,
+     "sha256": "bf0e6da5676afe3276487b92027d7b85dda98145f7dcf1fb6a601078d424b14b"
+    },
+    "maps/nbabs.ent": {
+     "bytes": 276561,
+     "sha256": "f075be4c75a9284238ea258abd27ee324051fc2d166679eec90f2b7b7440d717"
+    },
+    "maps/nbabs.lit": {
+     "bytes": 5767940,
+     "sha256": "ad535f52ed642b62a5874cba22787ae6203076bf23e5067136f4f21b67e4ad08"
+    },
+    "maps/rastr.bsp": {
+     "bytes": 42581740,
+     "sha256": "b3e93181e00558423a64a2691ed6718ca07bedf907101e2feb0f2f82717fd807"
+    },
+    "maps/rastr.lit": {
+     "bytes": 9578078,
+     "sha256": "4ba7c7d2dc43c53edacdffe2ecbf23bf9a6046fc07ff964b75898fab9676a047"
+    },
+    "maps/rbb.bsp": {
+     "bytes": 6548736,
+     "sha256": "3af037cfb9c93f4106e269365eec8563c70f0da98941762912ace4fd88393842"
+    },
+    "maps/rbb.lit": {
+     "bytes": 4053080,
+     "sha256": "558d12ad21721c907479a65d3d81b5315c79b7804f1089b0a0edd4a96d26df0a"
+    },
+    "maps/secret.bsp": {
+     "bytes": 5202988,
+     "sha256": "cf56601e6e3d972dd973a8efca88833bf518a750645fd30a633f21f1943c49ec"
+    },
+    "maps/secret.lit": {
+     "bytes": 2090645,
+     "sha256": "837341255bcd70e00aaca02dfc5181542e80942befc6bb086b1677dbb8d03003"
+    },
+    "maps/shubswager.bsp": {
+     "bytes": 4099020,
+     "sha256": "48cb3f57f76ea6bee8ff971c5497de07161617ef36aa9dbdd37eddea3d099da5"
+    },
+    "maps/shubswager.lit": {
+     "bytes": 858740,
+     "sha256": "d114536caebe6ca4d578730ab654c01ff2f7c376cd0ed7640fd2e2f9555bfe9f"
+    },
+    "maps/start.bsp": {
+     "bytes": 9172160,
+     "sha256": "e0d6a2d1a1dd37450f36e84105a89057820c714df818380ca26539d3eebdafb3"
+    },
+    "maps/start.lit": {
+     "bytes": 3074618,
+     "sha256": "6d07d722c44e9cb6d1df998480e4f8a87d586a935a4f32c1e0e7b57af3c7fed7"
+    },
+    "maps/test.bsp": {
+     "bytes": 5301512,
+     "sha256": "ade59e6a74252a28e723c749d3710efc7798c70fdf80a64e002a44e0a62c8088"
+    },
+    "maps/test.lit": {
+     "bytes": 1284134,
+     "sha256": "4d549c5d31e600b7705c388f2ad90bccaceffde08ed3c60e1f831237adb68253"
+    },
+    "maps/uc.bsp": {
+     "bytes": 6180756,
+     "sha256": "2b7319b766ab9627e44575b4d2db93949a3bce56f0a23d29d20cc457b3dd104d"
+    },
+    "maps/uc.vis": {
+     "bytes": 11260836,
+     "sha256": "7a7e7dd2a2133a90e13d4afa3bc9733fbf25e5d7beae5944ee1e0dab424c74a6"
+    },
+    "music/track12.mp3": {
+     "bytes": 6128631,
+     "sha256": "15f128fe0d0bd0ddfe25c7916674f9b286a2a5c8b8e4284bc56168785c190b0c"
+    },
+    "music/track12.ogg": {
+     "bytes": 6066339,
+     "sha256": "561b85e4cc24c5f05c56f529325a5b63870a1d9b5fcf34c4591c026186ebe801"
+    },
+    "music/track19.mp3": {
+     "bytes": 5591346,
+     "sha256": "d74e8bb6cac65d263a606baaf579536ba99b20ea2901ae9bb46b0f69ffa912de"
+    },
+    "music/track19.ogg": {
+     "bytes": 4984200,
+     "sha256": "b538a640b74510c1aba759cd4c1485d079553029ebdaf29f4010285f1c8b292b"
+    },
+    "music/track24.mp3": {
+     "bytes": 5930629,
+     "sha256": "51df155a91fb10a34075ffb3aa345a1520fb76206d3b8e296fc9de06371bd84c"
+    },
+    "music/track24.ogg": {
+     "bytes": 5741190,
+     "sha256": "b181ed2adee06be1ba2fd08dab9ce138edb9e8033dd2d787b4c64f537f53e8f2"
+    },
+    "music/track25.mp3": {
+     "bytes": 5923653,
+     "sha256": "b70f123ca1623efed196e6f54156193688410eecfce44fd2801f200ca2d0cce7"
+    },
+    "music/track25.ogg": {
+     "bytes": 5668564,
+     "sha256": "faa1ab37ae0daa6ab5d55216f764d31d601a73fa51581978267d1c71fcfd5e33"
+    },
+    "music/track30.mp3": {
+     "bytes": 5259135,
+     "sha256": "fd49c08ea14dad233321117252e8e150b1ca0e24b4871a9261b54051dfca19a5"
+    },
+    "music/track30.ogg": {
+     "bytes": 2574653,
+     "sha256": "a6dd3fe5045f30efc76d924f5553d9a3962005fbf46ace80717e36c9904230e7"
+    },
+    "music/track33.mp3": {
+     "bytes": 1182681,
+     "sha256": "46801c838b0680fead7e3bfe2bd86de60e036c3fbb2aec3c182b6aaf96c3ebf1"
+    },
+    "music/track33.ogg": {
+     "bytes": 741204,
+     "sha256": "b517f0daad207787ed780c78fb7a94fa52a84190bc8543045bbe710ad707275e"
+    },
+    "music/track66.mp3": {
+     "bytes": 20615020,
+     "sha256": "53275256748f6a50a233db7ac010711c58722ab5eb583bdbe018c9167adb60d4"
+    },
+    "music/track66.ogg": {
+     "bytes": 21138219,
+     "sha256": "2ea1f9365f56d0d70d6ea44eeb23b738697104593552ef2843c8d685ee4c0f44"
+    },
+    "music/track69.mp3": {
+     "bytes": 11906711,
+     "sha256": "1e36ecc51ca326a848d693ff41ba4ea920bdbe0da6d8ec00f12dd0edce8c7747"
+    },
+    "music/track69.ogg": {
+     "bytes": 16201329,
+     "sha256": "646b95487634b0139ebd0b57d8684a6b47166ea20cd048650f88fc402500a464"
+    },
+    "music/track99.mp3": {
+     "bytes": 7710528,
+     "sha256": "f3025480ae6ef70773c5c7ef1c228155d8203c6d9df4c612d21ac0abfcf84c2f"
+    },
+    "music/track99.ogg": {
+     "bytes": 6560091,
+     "sha256": "d98d83da24ba2e5f1ee7f4e9dafa2a0a855ca2ff94771a11965f2b30ae816d5c"
+    },
+    "progs.dat": {
+     "bytes": 1272922,
+     "sha256": "ac2d82459cd98d2753cbbea23bea6940f2247a23d6b29a252dd474699be9bae7"
+    },
+    "progs/a_mdls/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "1cdfc2b54dd883efe9215499603e341bfa72e800740a2e874e9bcf3b0afc68ba"
+    },
+    "progs/a_mdls/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "8cb54159eeaa410b98478e9190bd2d33340d3a2e98a61d32ce1afaf4e99031a0"
+    },
+    "progs/a_mdls/m_lnails1.mdl": {
+     "bytes": 12820,
+     "sha256": "0d4c99e9906e9d9fa67a8f114b1233e40650cb457560de954f8147a28d31b0cd"
+    },
+    "progs/a_mdls/m_lnails2.mdl": {
+     "bytes": 20436,
+     "sha256": "6ac8d9aa8578ce855a260a65d7fb656a6f1048d8d3869094ebf721c2cb7b5ea2"
+    },
+    "progs/a_mdls/m_mrock1.mdl": {
+     "bytes": 1460,
+     "sha256": "2db260c6ad0b583583ea6034f28a4624b1bbc961862078a74d0bd81f2e8649e9"
+    },
+    "progs/a_mdls/m_mrock2.mdl": {
+     "bytes": 1844,
+     "sha256": "0deccfe38b41f6e995e122277c58a261e31b1fadc25262b9c0ead83c4b33091b"
+    },
+    "progs/a_mdls/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ac361970fb1cbbb87ad4593afecd6d8973a65ea4f14e5f7b565c8f38c181fa9d"
+    },
+    "progs/a_mdls/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "0870b633f95bda895074e8d423631ee8805c3923f36a1c7f09938710783e8f99"
+    },
+    "progs/a_mdls/m_plas1.mdl": {
+     "bytes": 6980,
+     "sha256": "a7e8296ed1fde1f47c85aba4b61f5111ae92036d95019e2420983cbe5f47cd8e"
+    },
+    "progs/a_mdls/m_plas2.mdl": {
+     "bytes": 6084,
+     "sha256": "6cfe7161ef1b2a51289567c910a6d92ad521cb4dc31cc09655f343b479295348"
+    },
+    "progs/a_mdls/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "146955794f29c02f6570eed83e1d4b0013b0b4341897bcbc91cc9ffea6957ff4"
+    },
+    "progs/a_mdls/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "59988afc3603b83ccfadf0a9af423a113bf15ed969d4a62db9073e3061bc0fdc"
+    },
+    "progs/a_mdls/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "696594c11dd6dbd2e60ac6923d82a55f8f5b16e93b93f7914abe5fd4df74299f"
+    },
+    "progs/a_mdls/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "b558ee2dfd0078c7e3075079fb40368f53e7dfb162aaefcd20e53f562e405b1b"
+    },
+    "progs/air.mdl": {
+     "bytes": 5076,
+     "sha256": "a506a2a0a8f932f62ac18abe490967c6d8db0d1c2af77b31723158c2592a6948"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 290592,
+     "sha256": "f0d1dc967de929d0f0faaa61aa51239d1f262c63da83013be094a4ed99e3028c"
+    },
+    "progs/beam.mdl": {
+     "bytes": 26532,
+     "sha256": "e3c72c9d1529e9f34fb20bd66eb46e4e1332f1f044e25d3003ab0489df6ac27a"
+    },
+    "progs/beltup.mdl": {
+     "bytes": 37012,
+     "sha256": "42c99e9b3adb6929a4c6cac3537607204ba625c2fa3d60a16681f50e419215c0"
+    },
+    "progs/bigexp.spr": {
+     "bytes": 278904,
+     "sha256": "4c97cbcdc1a263c04b991f42ea108bc1e98418aa90f8504cac903afc32c6da49"
+    },
+    "progs/bilebomb.mdl": {
+     "bytes": 13469,
+     "sha256": "2f77d07f24b62edc095facdee8c670711cc189a85258a631ada71cd4746e26ac"
+    },
+    "progs/bilefrag.mdl": {
+     "bytes": 9216,
+     "sha256": "34e6ed3456aef2c89d4ab9d857a173bfa98c17381be380f9665d496791f6f814"
+    },
+    "progs/bob.mdl": {
+     "bytes": 154552,
+     "sha256": "bdfc5b2f901ea2a7eb30a6fcee174f9e33008d421de812f5a607c6f2a54133de"
+    },
+    "progs/bobblaster.mdl": {
+     "bytes": 25744,
+     "sha256": "a11e6cf74063b104fa88438e41aa50796511ecb69bd2e22f483a40559ccd3d10"
+    },
+    "progs/bobzooka.mdl": {
+     "bytes": 25744,
+     "sha256": "2f261d69793973846a2014af3f72d40610810f91977b6d24b64654786db7ec49"
+    },
+    "progs/buzzsaw.mdl": {
+     "bytes": 28716,
+     "sha256": "9b85232f930a7e34ef4cd1abfa266bcfa09b8da9e3f96f875d89e56ff702b403"
+    },
+    "progs/candle.mdl": {
+     "bytes": 24135,
+     "sha256": "5027f8712c36de87b3967e4e623fbc64d4e99644f5b805f7e21ec38b1532cc74"
+    },
+    "progs/commando.mdl": {
+     "bytes": 1382800,
+     "sha256": "d74ecfde88d8fbe14da7bd003a3776fc9f13f8e6bdf2df397342e96776d04e45"
+    },
+    "progs/ctfbase.mdl": {
+     "bytes": 86940,
+     "sha256": "425bee9facfdbca6c1f15858a6ba7580c63b6f80edf148def3173ce74d019256"
+    },
+    "progs/ctfmodel.mdl": {
+     "bytes": 173364,
+     "sha256": "25fa6c1d3a54f637a9edb08f540dc4a137f87dff2f7abafc1ea4cda590ecd19c"
+    },
+    "progs/debris.mdl": {
+     "bytes": 270552,
+     "sha256": "714b4fc3ce6675f0f4edc6ed7022e817f3922cde1877eb5418e4ddf60d798724"
+    },
+    "progs/dgang/balls.spr": {
+     "bytes": 6300,
+     "sha256": "906c41cdfa024b53a172911e4509404ba16835f4beca1f41a86aa85f4d14a03e"
+    },
+    "progs/dgang/demon.mdl": {
+     "bytes": 299312,
+     "sha256": "c674d88a422c09f84095e57d4b0544b09eeb7d193ca48189912c7093d517d701"
+    },
+    "progs/dgang/head.mdl": {
+     "bytes": 5428,
+     "sha256": "45524f639f49464c57bf3c4355bb724857d9f28de6cc5b31fe659a65076232a7"
+    },
+    "progs/dgang/lamp.mdl": {
+     "bytes": 250400,
+     "sha256": "f4096159c2152aead0abce0f1b203facbe1971b22655ef2e65b1c2473fbb98ad"
+    },
+    "progs/dgang/mug.mdl": {
+     "bytes": 6868,
+     "sha256": "518c15ca658ff0852f34ed08c7787a6addf8fc6960962443dba4b6f7fdf074ac"
+    },
+    "progs/dgang/mug_item.mdl": {
+     "bytes": 6868,
+     "sha256": "c98fd4b570eb335875db578637a0166545977a3ec6dbf844b3d517dc035a89ca"
+    },
+    "progs/dgang/mug_item2.mdl": {
+     "bytes": 6868,
+     "sha256": "f68bcfc370bee0983aa926665d384ce5e5c5775c9c0ed8ee64ae0d19578c08d0"
+    },
+    "progs/dgang/nsoldier.mdl": {
+     "bytes": 492572,
+     "sha256": "0c0baaf42249ed66998dc5f6bc594bfc1227c2b7730bc8e9a634aae374bb3b37"
+    },
+    "progs/dgang/soldier.mdl": {
+     "bytes": 320900,
+     "sha256": "f2c602bbbdfae50ac400a08534d4c02a90d77d1f0903d72cedfdb2b3f6928aa1"
+    },
+    "progs/dgang/tarbaby.mdl": {
+     "bytes": 296304,
+     "sha256": "f25aa42419c2951ba05ca651fff62827d6b683e0fa6937616fe818d229e1d2a1"
+    },
+    "progs/dragon.mdl": {
+     "bytes": 207552,
+     "sha256": "1ba01029d4113cc832aa5ab551c7bf060b5f7a4eb1afde35607564413bfee2ec"
+    },
+    "progs/drggib01.mdl": {
+     "bytes": 33676,
+     "sha256": "17b04d931bb2715dae1136fdc0b09d8089aa036e47bfcd49934f2dee6419a23c"
+    },
+    "progs/drggib02.mdl": {
+     "bytes": 42788,
+     "sha256": "03801327858a4df0312f5b1ec231b2396487c5a1c2e148bf1797945c0f954151"
+    },
+    "progs/drggib03.mdl": {
+     "bytes": 30740,
+     "sha256": "b3c8a344124ff5b1c95bb81b887546267e066d40914ab40a25e708ebbec2a489"
+    },
+    "progs/drlbomb.mdl": {
+     "bytes": 20355,
+     "sha256": "5c1db489f43cba73fce265db642267775245d044866cdd48396b1f1260a28237"
+    },
+    "progs/drole.mdl": {
+     "bytes": 241648,
+     "sha256": "b760256494b226bb9b485964d271f63e5d81e1d859ebe87e3d1c6ae76daba47a"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 702580,
+     "sha256": "fd503411d71170d0e25f58a4cdae02ad7d723b70c4485f966a96fc4d78e359e7"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fireball.mdl": {
+     "bytes": 9076,
+     "sha256": "8b9cef5c7ebff01a836d056eeee45278cfbb91c92dc4bba4d4a8d664e8d99b32"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/g_fx.mdl": {
+     "bytes": 5112,
+     "sha256": "d6699fe687ac0757dc1fc25296817eae95118e598c361e274e8dff250c5a9958"
+    },
+    "progs/g_grapple.mdl": {
+     "bytes": 149440,
+     "sha256": "fc148b3a840b84b65488658ec26a27621a86a196feb90723269534929ee0352e"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_laserr.mdl": {
+     "bytes": 70932,
+     "sha256": "74ab22bd46e9f2934e52c1735b357a9190c54f85338d00c2878d4f5b168b871f"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/g_shotty.mdl": {
+     "bytes": 23380,
+     "sha256": "b919bbcba3f7f03fb8b82fa6d3b1464ca41e81cf29417cfea0de09658c698cfb"
+    },
+    "progs/gib_freddiejunk.mdl": {
+     "bytes": 71364,
+     "sha256": "9e28a5172d6f602b67d02b441e2c30e70945df35e3964ffb4d819ffa99dff58c"
+    },
+    "progs/gib_metal1.mdl": {
+     "bytes": 5172,
+     "sha256": "b0951de4d869e0b779aeb3f7a96f56b22a82a58d267a56b1247f0c3e667c25ad"
+    },
+    "progs/gib_metal2.mdl": {
+     "bytes": 6292,
+     "sha256": "3df78c49abb572095d3b70efbb99bccb63caf2ffd30bb3ee434c945084acb5a0"
+    },
+    "progs/gib_metal3.mdl": {
+     "bytes": 6036,
+     "sha256": "88f8a1f941e38f8528ec27a168559946cc0b69f2abce1cbf6858b813e09c5f51"
+    },
+    "progs/gib_metal4.mdl": {
+     "bytes": 6580,
+     "sha256": "fbde734f29a6691d51c58a40a89e45f81dece2f20218353a6137a2362acbe3a9"
+    },
+    "progs/greenexp.spr": {
+     "bytes": 24732,
+     "sha256": "d11f14c56e8befe7a3829d6f11c9c8200a279a3dd9029b8c0818c791ecc3c9e5"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/gug.mdl": {
+     "bytes": 482020,
+     "sha256": "2cd097236a235aedf717a86b7312bd7d1b3caa6f0b25980c82eee2463fee2274"
+    },
+    "progs/h_axeman.mdl": {
+     "bytes": 18400,
+     "sha256": "e15391056ec618b412d1341914d2e6f05a759de92500ef249cc5d1789b3ab6d6"
+    },
+    "progs/h_boss.mdl": {
+     "bytes": 63532,
+     "sha256": "320aff68d374f002ed468bf17ddeca4d95f59ef68c7dd3a17287fef2da1f0b46"
+    },
+    "progs/h_drole.mdl": {
+     "bytes": 14032,
+     "sha256": "e7119edde9c1ae0ff18f2d08dd6fb23835735cff03a93160ee6b1fab04b539b6"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_gaunt.mdl": {
+     "bytes": 59888,
+     "sha256": "c24151b2759f9876a8f9ab1e60949be8d4ff7774dfbd8fb2ee12c462ee4e0cea"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_hellkn.mdl": {
+     "bytes": 30552,
+     "sha256": "d1556063b3a932b3b26375e5789c911cae76aef39ec2550a7e1d82d0cad832a9"
+    },
+    "progs/h_hellscrag.mdl": {
+     "bytes": 14948,
+     "sha256": "7fdfd1749ffa270221b2ba8f9112466bea1f837e6a7a077f66aa85191d538297"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 13400,
+     "sha256": "464825291ecfd070153877ee4a7fa83f97379b2cb9871b4609979161d926ba0c"
+    },
+    "progs/h_lscourg.mdl": {
+     "bytes": 27972,
+     "sha256": "3c8c40728b6500f8d66e3a3bc03251543afde25358dba1608eb059c9786f654c"
+    },
+    "progs/h_mdls/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "2e7fac7418838a721d80e80370000f3e400b21248b22c8d3555588d4f8437a5b"
+    },
+    "progs/h_mdls/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "1f4b0791be3156763c15521fbf2e747744ce3355d90d630b01c2227770314771"
+    },
+    "progs/h_mdls/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "6f792b9a80f34e31bceb4258e1d2c8f22d405a7ae1198b31bb285f502c720cfe"
+    },
+    "progs/h_mdls/pd_vial.mdl": {
+     "bytes": 24396,
+     "sha256": "aab843270d62a97b563b274d08c67c8d5de697e766ba1e928f190b7c7baaf108"
+    },
+    "progs/h_ogre.mdl": {
+     "bytes": 42048,
+     "sha256": "52760ce1f6e8f657e782846571baf9fde80859f5342d07a684fa8218f96f68db"
+    },
+    "progs/h_pogre.mdl": {
+     "bytes": 50556,
+     "sha256": "75a7160e85bbba9b9463abc9eaee77cd19cc84f79398646f0ebe0f41ef037f6d"
+    },
+    "progs/h_rhynch.mdl": {
+     "bytes": 41072,
+     "sha256": "07918c12e743c671df3bbb4d9abd1b6ebeaaef70d58d6c3243c0ec8f953a3200"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/hellgib1.mdl": {
+     "bytes": 5876,
+     "sha256": "1d56bd4158c85f284d1d1fc288e49479914522516cbe42b6133baf235361045d"
+    },
+    "progs/hellgib2.mdl": {
+     "bytes": 16564,
+     "sha256": "acfb1ec980341411a3a81197a723585acb092d62574f5118606e84b1c27d2f80"
+    },
+    "progs/hellgib3.mdl": {
+     "bytes": 22356,
+     "sha256": "e765c08d43b08ab74917770c6734186758c946cf189fc2181506e5522b4933dc"
+    },
+    "progs/hellscrag.mdl": {
+     "bytes": 243008,
+     "sha256": "20c4b98c3bc52def6520ecca695407e5b60bb17794f25ef5e1de45d09c3db5ea"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 275836,
+     "sha256": "ff5e8e7e0339d70fa0edca83a0d082cfc934ae6f60bbbd8f310f32c438646485"
+    },
+    "progs/hook.mdl": {
+     "bytes": 48960,
+     "sha256": "36db8008b5d90cde9c2ba43a732024ad8d74ac679ac59a3d4019f5232f178925"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/jboots.mdl": {
+     "bytes": 48980,
+     "sha256": "7177b54de6b80c30b7aab2e58d63e2378806ac9de5f8744265c85eef9b522a8c"
+    },
+    "progs/jboots_timed.mdl": {
+     "bytes": 48980,
+     "sha256": "16d3825005301cc90b70b74ae1ac9df96fd24c99767d5c51c2b439d240eefee8"
+    },
+    "progs/knight.mdl": {
+     "bytes": 178200,
+     "sha256": "afa1f6a7eb588b0ebdef421f74e23f110d50dda42d854d0fac679b232d056710"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 15092,
+     "sha256": "362ff3c50031d80b46a11c3d1902fe1cc3d442cd13b7db59f6d46c5655fc9351"
+    },
+    "progs/laser.mdl": {
+     "bytes": 12672,
+     "sha256": "8696398eed8e39add86ab02012fc70f6eb3264173b502afac2b73fc65edbbdc8"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavaman.mdl": {
+     "bytes": 190588,
+     "sha256": "b81bb7f5cebb2889cfd2f431f743200f672d0195b05fe3faa98b50163fed7fb1"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/lspike.mdl": {
+     "bytes": 1684,
+     "sha256": "59264317258f19955b967177f0dbc5be1733e4ca07c4c7b3cc333bb88bc0c46e"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/mon_freddie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/mon_gaunt.mdl": {
+     "bytes": 145988,
+     "sha256": "1667f8d0ea1db7275184fd5d56f3921f041db0969cb8fdbc9c0b83a6a824911f"
+    },
+    "progs/mon_gaunt_elec.mdl": {
+     "bytes": 7164,
+     "sha256": "05129692bea7b62f2f5b7285cf133590e9356bfa0f6162ef6e3fc44508b29d8b"
+    },
+    "progs/morph_az.mdl": {
+     "bytes": 300592,
+     "sha256": "98d86ad428b5ab5643e12921f3f41572eb84c2025a8f05c7b882ccce6bdc4a5f"
+    },
+    "progs/morph_eg.mdl": {
+     "bytes": 300592,
+     "sha256": "14468fccffaa1508c03610dd58fb51cd9058ca3bab036bca18f7a41cb37c195b"
+    },
+    "progs/morph_gr.mdl": {
+     "bytes": 300592,
+     "sha256": "662aa03785b4a6d2689670bebc5a9d081c36541347e324fac3957f599eab3be8"
+    },
+    "progs/multiproxbomb.mdl": {
+     "bytes": 12852,
+     "sha256": "04ebccffa2876108b0180f7cc678ded96f30cf8034297469340d1a48dc18186b"
+    },
+    "progs/mummy.mdl": {
+     "bytes": 181668,
+     "sha256": "3926d2dcf2451deaf32e67877016884cfb91a313968beefe514b9274fc30a1d1"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 315696,
+     "sha256": "bbfc76137aa7beb3d16231499e041d51e156ef619607c660efa46438cce45891"
+    },
+    "progs/p_shield.mdl": {
+     "bytes": 95696,
+     "sha256": "2d11a31ce9ab86f2d5d13d1045bf8cd016426e733194cfcea757a71913fdc583"
+    },
+    "progs/pd_armor_sh.mdl": {
+     "bytes": 31508,
+     "sha256": "46b9de8235f07190e18d67e147ed00be6dc322cd112ccde33bf4fc1f9a77e074"
+    },
+    "progs/pd_base_key.mdl": {
+     "bytes": 21219,
+     "sha256": "320ec52018f501f8fe428dd46f44693787e545289be883a49f3bd6476974cf46"
+    },
+    "progs/pd_bpack.mdl": {
+     "bytes": 216452,
+     "sha256": "cf13d3a5239b9f6028b2a848f564769d97fcec164b56f266bbcf2657af5127df"
+    },
+    "progs/pd_rune_key.mdl": {
+     "bytes": 46335,
+     "sha256": "c4fe9bd66394231ace3127635f057987ecbf4b13b00d84501127caacb5db03fc"
+    },
+    "progs/pd_wiz_key.mdl": {
+     "bytes": 21907,
+     "sha256": "36b50211f687813b85648a46bd32a1d543a8f2af84e9d4223f8b5843f885e1bc"
+    },
+    "progs/pendulum.mdl": {
+     "bytes": 44128,
+     "sha256": "0970c838e4246a47d0b39395af03754a06dcb5878830233413e6fc893cf80599"
+    },
+    "progs/plasma.mdl": {
+     "bytes": 54972,
+     "sha256": "1125877c12b76c06281263b16985893a014682bd4c5102adbf07aae320e0bd55"
+    },
+    "progs/player.mdl": {
+     "bytes": 249280,
+     "sha256": "7bd9988aa264d27cea670bbf280d9101d712cf27d87dbe774ac41d363bdf01d2"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/pogre.mdl": {
+     "bytes": 141764,
+     "sha256": "4484582484e0d21e950e90eeb6338bf720ac5d46111b8c5adae5cf8e209e1fc3"
+    },
+    "progs/polyp.mdl": {
+     "bytes": 343144,
+     "sha256": "48f35808e551ee734eb805ee22932cf44ae726791f7e07fc475c6d3c578941dd"
+    },
+    "progs/polyp_t1.mdl": {
+     "bytes": 63860,
+     "sha256": "21322b1090274bf1bfbac2f456484f3d77c8236246aa22f54a9eb40a2502d7be"
+    },
+    "progs/polyp_t2.mdl": {
+     "bytes": 62548,
+     "sha256": "7d01bf82d1f33bca01ed1467f29fc6dd849755e1446fefb4d0ff021182417a40"
+    },
+    "progs/polyp_t3.mdl": {
+     "bytes": 61524,
+     "sha256": "8452694bb2855882ec0d4c812b05b3a6b13eedec9ca1375f2c543439ae7af8c9"
+    },
+    "progs/polypgib.mdl": {
+     "bytes": 5716,
+     "sha256": "dc2aae40f92f8c75057a664b583f9d790d010289e858b218adfc92de6d6be878"
+    },
+    "progs/proj_laz.mdl": {
+     "bytes": 4724,
+     "sha256": "94e8c7d09857559ad9e5aaf6361b596afbcf100cf0ce8abf0107318af28c7943"
+    },
+    "progs/proj_ngred.mdl": {
+     "bytes": 1364,
+     "sha256": "a1ec22733cc292a470c23990b8d0929bf5ee88844190d7174d9053109443d0dd"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/rail.spr": {
+     "bytes": 1692,
+     "sha256": "e542acb92f5e3d67453b1c34ed79608c06bcdcfb433728437f896f8c83005f0c"
+    },
+    "progs/railsegment.mdl": {
+     "bytes": 20484,
+     "sha256": "adf61857002950b7086a0aaa4b1c15ae13e4b56729d88978d0eccf54ea8506f6"
+    },
+    "progs/railspark.spr": {
+     "bytes": 58,
+     "sha256": "4b522d984c95f10966d81225a0e87ce09deb17f44fd4ed5fddc9b641cdeab751"
+    },
+    "progs/rambler.mdl": {
+     "bytes": 163468,
+     "sha256": "df92708678f286c4ecb8c3de646faa215b0ca0338d60233fc18444a582597b27"
+    },
+    "progs/rhynch.mdl": {
+     "bytes": 277972,
+     "sha256": "507c3d0bb3f8f6b483a0cebef35522244c28c2d05fd99a1f1b13962429cff8e7"
+    },
+    "progs/rockup.mdl": {
+     "bytes": 32292,
+     "sha256": "e3dc194e2f865951e2e9efe3c0e36265a9b964c46a43b325a380e258ffcb0efd"
+    },
+    "progs/rockup_d.mdl": {
+     "bytes": 32292,
+     "sha256": "d759325a643f7d1598d25e25530bb36b7b06c0eb8fb3bd20739b00699814fe47"
+    },
+    "progs/rubble.mdl": {
+     "bytes": 8760,
+     "sha256": "b908e0bf677ac9d76eb7831003c854de0048be156dada5e8f9663b166cd6f9e8"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/rumbler1.mdl": {
+     "bytes": 215204,
+     "sha256": "d515e02f0fe3a4b109798dd527815023942eca4dadf16a5e411881d8dab32582"
+    },
+    "progs/rumbler2.mdl": {
+     "bytes": 145884,
+     "sha256": "6a266a82d3916817dda138efeae76104933e398a3eb93ab17bbad08cacdeb4ce"
+    },
+    "progs/rumbler3.mdl": {
+     "bytes": 244052,
+     "sha256": "cd316c6f4e4827dd4e6a8a4277fb9b0eb20e8a965c033a822f597b862d1f9e25"
+    },
+    "progs/rune_n.mdl": {
+     "bytes": 18292,
+     "sha256": "04fdc2834da57db6f7341593de5ed9b853d1a2b0e0b99e5757cb9c7a9eefd2b3"
+    },
+    "progs/rune_n2.mdl": {
+     "bytes": 18068,
+     "sha256": "0b9460faf92dd5ccca554c666e48de35344ce62d29032cd63bf70ab3d70e271e"
+    },
+    "progs/rune_n3.mdl": {
+     "bytes": 21812,
+     "sha256": "38cb7486bdc99c2f0c8e9f194293db248e67c26afc3ee5ed6f6822f9d8eab745"
+    },
+    "progs/rune_n4.mdl": {
+     "bytes": 19604,
+     "sha256": "541d815423fe4e8364be4d2798b48aabc70937a29943b0ea01c9687e11ad0a41"
+    },
+    "progs/rune_n5.mdl": {
+     "bytes": 21460,
+     "sha256": "6037910c21cad3685041563b1eb5428038b8dd351d33c80b47d164a42e6267a8"
+    },
+    "progs/rune_n6.mdl": {
+     "bytes": 18068,
+     "sha256": "9966314ac9a4d9e2b28dd0e31460697cd96611002d06214ed0b419ab0fa86c7f"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "2e6905c47a3719cda45176f02d751138196b3926d18914b51edfd236cdca6724"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "5568b1679d0598572cd989ad8318d787989667b2de171908744a43a399948679"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 29224,
+     "sha256": "a9c150fb5c19e6e0bf7ead5dcf6ae87d8e9745f4a439779266d0a258e16b6890"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/s_wrath.mdl": {
+     "bytes": 200848,
+     "sha256": "4c0653e3adba99be4d581c92a928fd6e8c27b0a2159a97f7ec5e885478249b8d"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 172552,
+     "sha256": "b283abec730b2640e437730fb67e2bd4326e424bc66db4cca8d5d2edc80a4fd9"
+    },
+    "progs/secret/magazine.mdl": {
+     "bytes": 24524,
+     "sha256": "820e37cf07b4b7437465b9feb3079f5ce9fb993d234f2cef05b3d9aa32037d99"
+    },
+    "progs/secret/poster.mdl": {
+     "bytes": 477212,
+     "sha256": "b329560139d40b5339002f71d08a3f3ced8f52b75cb95e7a21636963e6f19e83"
+    },
+    "progs/secret/romeragon.mdl": {
+     "bytes": 161396,
+     "sha256": "cbd6e74e06f9b4e49565734b01ac0bfcb5f60a5fc178b08516fc3994946561e8"
+    },
+    "progs/secret/sandy.spr": {
+     "bytes": 311712,
+     "sha256": "117fe362c734bb41a0ffc46aabbd61ea19d034dcfe2b7ef209b641cd518b1f2a"
+    },
+    "progs/secret/sigil.mdl": {
+     "bytes": 23876,
+     "sha256": "892de4eb996e3c658b07e5209b4af32b4324a13edc68aaa13da59b086a1e33b5"
+    },
+    "progs/secret/spawncube.mdl": {
+     "bytes": 50360,
+     "sha256": "9d02a1ffa960116a4624e147315cb8e09c186cd5c9b30dfb6e89bf8f3f3dfa5d"
+    },
+    "progs/sentinel.mdl": {
+     "bytes": 290664,
+     "sha256": "573efd78767922b2bbb3e5dab2b16cd8f90c2cb1709ecf4a315a141f4df77d09"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 134400,
+     "sha256": "6c32063a8c13657295880e1d9ccdba36571bc4f0c6ea272fc53b3ff2e3576676"
+    },
+    "progs/shield.mdl": {
+     "bytes": 54612,
+     "sha256": "6cebe03621614d8508ce3e8203ad151ad4b3ea5da9003650165e896b032545fd"
+    },
+    "progs/smlexp.spr": {
+     "bytes": 105148,
+     "sha256": "ce4938c9e813e648404b25b82245cad4400682d885d044b9d353a8039cfdceb7"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 534356,
+     "sha256": "581ff384c6a2bd4809b9a171259ce82a8e3b18fbe7b7f7e926cc50fb0f5c5234"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spectre.mdl": {
+     "bytes": 360456,
+     "sha256": "efed2c27d6f7675eada34a731915e6897250b3b1f5345782b224b8bf1c661067"
+    },
+    "progs/sphere.mdl": {
+     "bytes": 124704,
+     "sha256": "8d504bcd05b9f7833b1552f843329bfef671ef5dd4dc8fd0545820f997e9abd0"
+    },
+    "progs/spike.mdl": {
+     "bytes": 3176,
+     "sha256": "fbc3329920b233be1ba802e8dfd5e33edbb39ba753260e7b4aad1783a751e300"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/spore.mdl": {
+     "bytes": 13469,
+     "sha256": "fc9fbb97f0d4f1a9f843769cd43fb7270ba2b351cdf3b4b624d27616980457c4"
+    },
+    "progs/stalactites.spr": {
+     "bytes": 19896,
+     "sha256": "4ec624cd55ba2bd7b09634c01e43a1fc8b0289156ece300ae5d66d45767815cb"
+    },
+    "progs/stalactites_large.spr": {
+     "bytes": 32824,
+     "sha256": "ee75b3fdd504aad93ab7e6675021ef9a58d7cd44d13de557811805c7b164497b"
+    },
+    "progs/statgib1.mdl": {
+     "bytes": 5716,
+     "sha256": "954701d8ae2b220790df57c36e912d8617fb8f1ae4851de66701ca83f047c5f1"
+    },
+    "progs/statgib2.mdl": {
+     "bytes": 16228,
+     "sha256": "f7e96c3c511b0cac8939aa75fa8fb512dac252252710b1421a9a0624670169c5"
+    },
+    "progs/statgib3.mdl": {
+     "bytes": 22228,
+     "sha256": "eef48ccea13117f123b286276a5d250980657ca016f8dd6cce28e541b0360ed4"
+    },
+    "progs/sword.mdl": {
+     "bytes": 37060,
+     "sha256": "a72818767602e676cb08aa19db1780df9ee71b1f5c650f24c4f7ad2f761360d2"
+    },
+    "progs/tarbaby.mdl": {
+     "bytes": 294184,
+     "sha256": "ca1d3f5e5041c1b23b599640078e848982e911dbbac37e08ac86410bc689dcbe"
+    },
+    "progs/throwax2.mdl": {
+     "bytes": 34872,
+     "sha256": "11a22371cc72adf001e21d04e1b8b65e01497f56410867aa42ea21c0ff304e48"
+    },
+    "progs/throwaxe.mdl": {
+     "bytes": 56532,
+     "sha256": "0ebedab9ab397ba15dc3f0d90df703af2984d1c070eabc08ba781c308968150e"
+    },
+    "progs/throwham.mdl": {
+     "bytes": 7072,
+     "sha256": "f161fedb096a34db55fe57e84acd2bc42295ffea688549235c762b9a70430b35"
+    },
+    "progs/timecore.mdl": {
+     "bytes": 62856,
+     "sha256": "63fba42805bc2def1ece543bdb555403d9f6b114e9e7728a92ac795855488d47"
+    },
+    "progs/timegib.mdl": {
+     "bytes": 23140,
+     "sha256": "68256ebeadf735f4d7ad4f97cf0e121b32026cabcc95674bf71628e949485b92"
+    },
+    "progs/timemach.mdl": {
+     "bytes": 158012,
+     "sha256": "8b69189a4886fe3a238d376d0947ab397d48a6c116810954621dfd8e865d1511"
+    },
+    "progs/uk.mdl": {
+     "bytes": 19348,
+     "sha256": "998cf9dae6ee429082b46017319b3fe47b64c009839bfee2621c35416fa091bc"
+    },
+    "progs/v_grpple.mdl": {
+     "bytes": 66772,
+     "sha256": "5003520720172fd94be9220126bf70f11fc6f30612fe396292d2a705402c7a9d"
+    },
+    "progs/v_grpple0.mdl": {
+     "bytes": 69740,
+     "sha256": "f39ac38b43b3cd250e8f8ea2ca400879fc8d2d824e5ccae2fe93c2569a0a6666"
+    },
+    "progs/v_grpple1.mdl": {
+     "bytes": 69740,
+     "sha256": "b7f05588f57fd9e0a0c64fa672533ca56d2d665dfa0c31798aa9e0fc8d8dde0f"
+    },
+    "progs/v_grpple2.mdl": {
+     "bytes": 69740,
+     "sha256": "ff70d5be22431c55d1560f185c8969db51c7b3e6e0f141db4239eecb9a3f779c"
+    },
+    "progs/v_grpple3.mdl": {
+     "bytes": 69740,
+     "sha256": "3ec79c94b9243a1087e41c939ac6bc687a4e700598c5f41a833edd1939ac3f03"
+    },
+    "progs/v_grpplesw.mdl": {
+     "bytes": 66772,
+     "sha256": "cea55604f2f21af60111f0ca85aaf2ea53ce3e5288d84ac4d3f82a0c51c43674"
+    },
+    "progs/v_grpplesw0.mdl": {
+     "bytes": 69740,
+     "sha256": "fc3df11ef968787a07e29cb4180acdf60a3b1a67a68778e2eccd0775b33bb425"
+    },
+    "progs/v_grpplesw1.mdl": {
+     "bytes": 69740,
+     "sha256": "040963b81ba1af62204749fc08800e2bbb436b40a5eb4b794f06ff829783a5e9"
+    },
+    "progs/v_grpplesw2.mdl": {
+     "bytes": 69740,
+     "sha256": "3a8e48f6ba7658d9036d5f16de4ed58db17f61121b5b9e47f212863fef9eb5e7"
+    },
+    "progs/v_grpplesw3.mdl": {
+     "bytes": 69740,
+     "sha256": "ccd129ab09fd9b307feecb02e2b67f6bc3420bf5113cfe7546ab626450316c49"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 73476,
+     "sha256": "e210b1960a6d03dac0f49448e3a82d48e461da40c1f5ba8b95df14eda2420708"
+    },
+    "progs/v_hammerpw.mdl": {
+     "bytes": 260696,
+     "sha256": "4287863358c7f3f0f1bc7feca216040d8c455b9a76c65bbd01920e2a971c9003"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_laserr.mdl": {
+     "bytes": 87844,
+     "sha256": "5e1defb728f801d07bc319489cfc1a120f8c11dfbe95f52ad7d806ed2a5ee0f4"
+    },
+    "progs/v_lava.mdl": {
+     "bytes": 54472,
+     "sha256": "bd5f7cc5aece75d628301783207497155dd769a5e68f2650b9b2f720e3039332"
+    },
+    "progs/v_lava2.mdl": {
+     "bytes": 68732,
+     "sha256": "4229fd511604b327e7a34798dd9bef9de2b42207130729287b67735557c9a22b"
+    },
+    "progs/v_multi.mdl": {
+     "bytes": 58548,
+     "sha256": "ec39e1ef752527c3c49ca8aa3527c029e03da39e142ce2ad486dd654766b2983"
+    },
+    "progs/v_multi2.mdl": {
+     "bytes": 58188,
+     "sha256": "be83265c847c9d1ca475c5928605587c6ff86689b58053a1c037ad3387bbf4da"
+    },
+    "progs/v_multiprox.mdl": {
+     "bytes": 227728,
+     "sha256": "163545466e0aebf3ff497cb176a96282787502dcd1e01143a8491e3e17c2ab1a"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 56204,
+     "sha256": "f075be7ace4c856449fafd99e956dfcd10b2587a18d93dc8ad9fca0ec51a9682"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/v_railg.mdl": {
+     "bytes": 383232,
+     "sha256": "83014a3427f18a8a60aee74065d32d4cf71b0c63787eed2f8b3f3b2408d93828"
+    },
+    "progs/v_star.mdl": {
+     "bytes": 56996,
+     "sha256": "abf29c0250b5cf95fe8237e389fe852222ff121c603fb0a3cd923696a22a7f2e"
+    },
+    "progs/vermis.mdl": {
+     "bytes": 656752,
+     "sha256": "d7060475e290482c61c122b3a477085b1aad002fd71d8293cc4a4f8bde1baec9"
+    },
+    "progs/vleg.mdl": {
+     "bytes": 4904,
+     "sha256": "9f360f72fae7f8e7892469fe04a97ef9b6fcd544b24b70cf11e7cdfb515e30f8"
+    },
+    "progs/voreling.mdl": {
+     "bytes": 41852,
+     "sha256": "b10f3623291b5182ab6b987cef1c40abc362aae41638b8481709660e923cc46b"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "ba9f52e66ac380306d443e07ee4f1fac92793cba55394c01590c3dd088042e78"
+    },
+    "progs/wetsuit.mdl": {
+     "bytes": 55156,
+     "sha256": "4e4dc7331c374d2345c3d755ff34b61850c289741314b10fa36c461db3844e99"
+    },
+    "progs/wrath.mdl": {
+     "bytes": 133676,
+     "sha256": "0a57ee912df3142c5e17183d5f6bd461021b141d53f7534014d59eda97e6bfa6"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 193444,
+     "sha256": "42ab30ec209295b479e29cdf93e08720c778207b20210ff25c04ebf9c3634bae"
+    },
+    "sound/ambient/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambient/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambient/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambient/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambient/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambient/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/arena/crowd.wav": {
+     "bytes": 1260960,
+     "sha256": "5b571f112414571ad442dfc7dcc2c843b96ca6c5da7fb033a64972a368694e81"
+    },
+    "sound/arena/gong.wav": {
+     "bytes": 279450,
+     "sha256": "6f2148a6b2f7be96674626d6e6e6ea57af29e4509522d93c0c25a2befc13d0ac"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/belt/fadeout.wav": {
+     "bytes": 37562,
+     "sha256": "3edaddcc3fa5926123038b2de9847ec7d3eefdebc75c174c80feeff6077d9e26"
+    },
+    "sound/belt/pickup.wav": {
+     "bytes": 21796,
+     "sha256": "c1c6aa3055eec85b2d33ecb47a288d6ad0e7716ee3726dcfaba64e7c238b3cce"
+    },
+    "sound/belt/use.wav": {
+     "bytes": 24588,
+     "sha256": "e6eb4c5e2ed8c91d8241959e954e9000e479065ce766232d3b9dd4ee7541f140"
+    },
+    "sound/blob/deflate.wav": {
+     "bytes": 31238,
+     "sha256": "86818f65dcda6b1b4f3a394b4c22ad41c6a44e10d38a285f9941f6eee7c396a0"
+    },
+    "sound/blob/mytosis.wav": {
+     "bytes": 13438,
+     "sha256": "64aa75f228761178a37ac5b214f3d8b530a100ff38e86aa209a9d1dd74f23d45"
+    },
+    "sound/bob/death.wav": {
+     "bytes": 14348,
+     "sha256": "7f97f27dfda78f9fe6fc5265e512b651e57ae466752d56cfe0dccd6d08478ed8"
+    },
+    "sound/bob/explode.wav": {
+     "bytes": 36898,
+     "sha256": "e00cd6cf71662de858fd0b8f63409217c957d6e3dea571b759fe97aec9d58724"
+    },
+    "sound/bob/fire.wav": {
+     "bytes": 36040,
+     "sha256": "5f39b9f60c5de5c9c3ac25a5149f1fef557e66c09d7d1a760ed6770082c5a914"
+    },
+    "sound/bob/hover.wav": {
+     "bytes": 13260,
+     "sha256": "46441335fe896cb993368bb12cedc1ddd4886b5933298bb6a0d6b7ba430cdfe5"
+    },
+    "sound/bob/idle1.wav": {
+     "bytes": 44460,
+     "sha256": "de548d73ab2d96ea9d550b86e264d430b8c0429cd99dd10404f52780bda6c683"
+    },
+    "sound/bob/pain.wav": {
+     "bytes": 27006,
+     "sha256": "d5d07123eb3c15917dc265cfa6df8971ab215f4408847225827359e1c175ee6b"
+    },
+    "sound/bob/rk_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/bob/rk_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/bob/s_explode.wav": {
+     "bytes": 30700,
+     "sha256": "94f9b780d25154f8c04cbe297a4aeda13fb0669c0a21e48e2b46f0102c35375e"
+    },
+    "sound/bob/sight.wav": {
+     "bytes": 14892,
+     "sha256": "1a0db2b8c8d763f9aae09913d1cd3548fa0e30eb03949e24ef511a70acfda303"
+    },
+    "sound/break/pd_bricks1.wav": {
+     "bytes": 61786,
+     "sha256": "3829842a9cb395f99d07546be38263eaf0ee5bbed71841aa8c93864d55a7fb94"
+    },
+    "sound/break/pd_metal1.wav": {
+     "bytes": 44146,
+     "sha256": "c0111b94231bc3870cbb95ec03f13b2b44ac407a5d18b35668ccf231303cc8aa"
+    },
+    "sound/break/pd_metal2.wav": {
+     "bytes": 70722,
+     "sha256": "ce8250482e831c270cc3c8e9211b74a627b3e29159c2c8ee720dd11cafd365c1"
+    },
+    "sound/break/pd_stones1.wav": {
+     "bytes": 75150,
+     "sha256": "632d15db23ff70c23c199595b41a153ded67f664de46b7d0cbfa0228f071156e"
+    },
+    "sound/break/pd_wood1.wav": {
+     "bytes": 34526,
+     "sha256": "621865f52fc27fb10108027ce3eea18aaf17181751a3ba1ceee0c9c99da9f375"
+    },
+    "sound/break/pd_wood2.wav": {
+     "bytes": 33342,
+     "sha256": "77282f2c533b9aec72b232aace9078534db3f255f418efafdf769c7361a28e05"
+    },
+    "sound/buzz/buzz.wav": {
+     "bytes": 26568,
+     "sha256": "9f6bbc6cd33beb735c81ed86da32356f65fa90aeb2792489aaed97e41b201227"
+    },
+    "sound/buzz/buzz1.wav": {
+     "bytes": 18828,
+     "sha256": "f9aa4cbaef41e71e9711e4d54c3714dd784068ab60993c382e07c684fe456e37"
+    },
+    "sound/dgang/axcopper.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/dgang/axhit1.wav": {
+     "bytes": 8960,
+     "sha256": "e434299a829c37a4f03c608c49eed11f3b55f861e276c8fe2e39e32dfb07c9e2"
+    },
+    "sound/dgang/axhit2.wav": {
+     "bytes": 4488,
+     "sha256": "d8d9efdd6a06c74a34011a1be9815240a2045bd0dca1252f247732011429fe78"
+    },
+    "sound/dgang/death1.wav": {
+     "bytes": 12224,
+     "sha256": "f2ffda0dad07e0fc921f35d3229c69205d0f4dd85075480577d8bae1f751453e"
+    },
+    "sound/dgang/death2.wav": {
+     "bytes": 10080,
+     "sha256": "5a12a0243875d4e4c6f72f33f39cecd314be107a1ceb66e14cbc824f420c6789"
+    },
+    "sound/dgang/death3.wav": {
+     "bytes": 12972,
+     "sha256": "9819d2071ca34d17b607078bfd069b32c3787e24d94ddb3333e409dddb72124e"
+    },
+    "sound/dgang/death4.wav": {
+     "bytes": 16180,
+     "sha256": "b1b688839215d6d02f8f244f35b0d496a9cbb3c54b502320f205ed6f2673ac0b"
+    },
+    "sound/dgang/death5.wav": {
+     "bytes": 17000,
+     "sha256": "1450da4102d14f1420f40385f80b0038b10381b815e147d780ad24023fc13e17"
+    },
+    "sound/dgang/drown1.wav": {
+     "bytes": 10962,
+     "sha256": "ee20031c3b21e4e84eaf06c97243aaae467911701751fd16e479d6854572bb4d"
+    },
+    "sound/dgang/drown2.wav": {
+     "bytes": 5168,
+     "sha256": "e37645dfd29fa3fd9d84feadbc7f455f743204f9a49030268e61680eaf4b5d70"
+    },
+    "sound/dgang/gasp1.wav": {
+     "bytes": 10756,
+     "sha256": "3b119ee35c916db60ebe78c696da56a35f3c9fe19e887e6c8b70670e08a1bcfd"
+    },
+    "sound/dgang/gasp2.wav": {
+     "bytes": 15188,
+     "sha256": "5daf4dc60c5eb0ab55020ee8a32eb1536614bd1d47b1a4b596c7c33639bcbb6f"
+    },
+    "sound/dgang/gib1.wav": {
+     "bytes": 16478,
+     "sha256": "c6b56488e35a7f5fdc112810b7cbb6257fd5139662af185d6f055176721b833f"
+    },
+    "sound/dgang/gib2.wav": {
+     "bytes": 16468,
+     "sha256": "10ed5caa6a896cb676b0c298edc890feff293e88ca33e53eb37896230618eb0f"
+    },
+    "sound/dgang/gib3.wav": {
+     "bytes": 9780,
+     "sha256": "ebf779f91a23c79fddf075edbd7bc963d3eddeb65bf4bc330be5e2d8d1d86797"
+    },
+    "sound/dgang/gib4.wav": {
+     "bytes": 18136,
+     "sha256": "c28c9f7643ba635294b9c5d15e6d1707a5ddacbc5878d03f0746230f531ec4d6"
+    },
+    "sound/dgang/h2odeath.wav": {
+     "bytes": 20158,
+     "sha256": "2b912c9d2969265d11ab425c56b4f7d1f18ca24e21436cbc7213de3c25940221"
+    },
+    "sound/dgang/hehe1.wav": {
+     "bytes": 25570,
+     "sha256": "1c7860f832a05f886d8fe68da76306b582ab1dd34f89f148b5c7f203395d4b86"
+    },
+    "sound/dgang/hehe2.wav": {
+     "bytes": 12346,
+     "sha256": "761b50e2d916ff455e2c05623ffaf53677c6f7aa13365bc745f9d350f6e3b71f"
+    },
+    "sound/dgang/hehe3.wav": {
+     "bytes": 10994,
+     "sha256": "471010bfd834acead5b2623bac9671bf7786552c60f9aa0c7dc02439914512e3"
+    },
+    "sound/dgang/jump.wav": {
+     "bytes": 5942,
+     "sha256": "f9e8c1599a8ff1468baccf64070546ef835fb506517ac92ceedda76b913c13e2"
+    },
+    "sound/dgang/land.wav": {
+     "bytes": 4488,
+     "sha256": "2d704f29072b2237c53f6d942e335d150b1f51e1e940185b2c0b51e89571d88e"
+    },
+    "sound/dgang/land2.wav": {
+     "bytes": 8258,
+     "sha256": "75eb7e5689c982be8d2ca0e70dfb492580b9b1d1a192bbedef3e289ee6c26bbb"
+    },
+    "sound/dgang/lburn1.wav": {
+     "bytes": 8736,
+     "sha256": "ef1c18932731e20c4a4e8c9bcf00367fde7dbc97192880e94c68b8624c9c5ca0"
+    },
+    "sound/dgang/lburn2.wav": {
+     "bytes": 8130,
+     "sha256": "482016208513769085d725d54d007a489deb8dda6fa0644347caddec081d5d29"
+    },
+    "sound/dgang/pain1.wav": {
+     "bytes": 5448,
+     "sha256": "84b26f869c7b057480c2bf0a19b193c09c64f0906c655187abfb180b36d6cfd2"
+    },
+    "sound/dgang/pain2.wav": {
+     "bytes": 4764,
+     "sha256": "45a1446e129d4d9db0aefdf0602347e3e664ef828dcc0791b69d2500432cd8f9"
+    },
+    "sound/dgang/pain3.wav": {
+     "bytes": 6908,
+     "sha256": "3604dbb2bdb89d21dea5e2a21d17d894d8942f44ee5fd8f33619952851544862"
+    },
+    "sound/dgang/pain4.wav": {
+     "bytes": 6894,
+     "sha256": "ca5d994e0aedafa07aed2a1e9017b3d1c4d7c76b2201618bc5597af3b6714c7e"
+    },
+    "sound/dgang/pain5.wav": {
+     "bytes": 10074,
+     "sha256": "324c014998c79cbc116cf29b5542273a99b701a3ab09cdbb0f1189281f798e1e"
+    },
+    "sound/dgang/pain6.wav": {
+     "bytes": 7516,
+     "sha256": "3f85ceaa44b31eab3064a397b611a6c119234ca9338d615f20426b7a11790214"
+    },
+    "sound/dgang/scmr.wav": {
+     "bytes": 10231314,
+     "sha256": "d52e43612fe6b834cd532fd41eb0d23d62555090feed6322f849fca959da0a66"
+    },
+    "sound/dgang/zdrone1.wav": {
+     "bytes": 1140020,
+     "sha256": "37fc6c2f1189338c7cc21d8412cae3bca520f74204c8151ac5dfc1a401971bce"
+    },
+    "sound/dgang/zdrone2.wav": {
+     "bytes": 1061344,
+     "sha256": "2df762c4040e8ee3c749207a2a12c7911b5970ff0cc66d5dc66e257468e1b5d1"
+    },
+    "sound/dgang/zdrone3.wav": {
+     "bytes": 497846,
+     "sha256": "d9e57434d0e3d75bfa2fb319af7bc48d277db3dd074f4a760668100f6a71c0e6"
+    },
+    "sound/dgang/zdrone4.wav": {
+     "bytes": 298768,
+     "sha256": "39149988734c73ba081ba1418b1fe2d954dfc36a1218bc0d81a6b969bc46f150"
+    },
+    "sound/doors/techopen.wav": {
+     "bytes": 14752,
+     "sha256": "3b82abdc7d218cd891d6e89f96756bd0a54884859e8ff1267075fb0f1c49d4e8"
+    },
+    "sound/dragon/active.wav": {
+     "bytes": 16118,
+     "sha256": "5c8762ad62bcb65e1a6fa3362393141a8564fca3ad28ea896a18545c5ebfe6ad"
+    },
+    "sound/dragon/attack.wav": {
+     "bytes": 24688,
+     "sha256": "3b3d3eb1e9e67c7641ead96926959e8ccd86bd4ec6e63e77ef5944616ee3dbc9"
+    },
+    "sound/dragon/death.wav": {
+     "bytes": 63766,
+     "sha256": "55eb476a990e479c06b4c9a12b71c595d8ada35e813e512986709650ef0e54d1"
+    },
+    "sound/dragon/pain.wav": {
+     "bytes": 28302,
+     "sha256": "60a99d79b6922a14e27ed63313e82ff17b127bda008bd614d8e9ed86f0f2cc3a"
+    },
+    "sound/dragon/see.wav": {
+     "bytes": 39640,
+     "sha256": "e8202c360287700da28f96d6a14fef6bdea04374ea911f2b3e41183cd8a136ba"
+    },
+    "sound/drole/death.wav": {
+     "bytes": 66092,
+     "sha256": "474e0c79e95a94d588585352d43d1b20788ecc52a3de8d74b648301b89a1dd67"
+    },
+    "sound/drole/explode3.wav": {
+     "bytes": 38026,
+     "sha256": "716844219b3321df91347494634772f87a72b603cfaa4abe531ab6e8cf07b765"
+    },
+    "sound/drole/fire.wav": {
+     "bytes": 28600,
+     "sha256": "60a6a2894348bdb967cb171efdbe625d3dd53bbaa0ea004150be60426b2e1332"
+    },
+    "sound/drole/idle.wav": {
+     "bytes": 13958,
+     "sha256": "fe54606a29a237d5869b1d14dcbcdcf0ebef530a28efe6d1ac50039d08551d01"
+    },
+    "sound/drole/pain.wav": {
+     "bytes": 24526,
+     "sha256": "75cb2b1de934575abc3fd48edb52859eee5fbd0534fac267ced9266599e154de"
+    },
+    "sound/drole/sight.wav": {
+     "bytes": 28554,
+     "sha256": "dc820980750878acb93ec1801c320387c8ba7c052c3c4bef23ec6acaaa051118"
+    },
+    "sound/drole/sight2.wav": {
+     "bytes": 45820,
+     "sha256": "16ed81719c95a1d7b8a43b285136cd0dda799ad1cb4699b5f82182b873da09a2"
+    },
+    "sound/drole/strike1.wav": {
+     "bytes": 12026,
+     "sha256": "05976c0f91f79b03f0ff4cd8050918ace6c63d2310a092c673a52b582417bd03"
+    },
+    "sound/drole/strike2.wav": {
+     "bytes": 17896,
+     "sha256": "e1da66b6a64f2046e975f518509f56b8cc7d8818380c2eb21cf7cfdf32d03933"
+    },
+    "sound/drole/swipe.wav": {
+     "bytes": 3572,
+     "sha256": "4c94101632fdd7898dc824ca4a583d0a7c937e5d60c8017f8f7c66e5aad0d263"
+    },
+    "sound/dump/elec22k.wav": {
+     "bytes": 82784,
+     "sha256": "dd63a8517e33bbe7a75cd0d6ccb16835b73f83af8d31c0ae0277b7304f7d502b"
+    },
+    "sound/dump/pd_armor1_sh.wav": {
+     "bytes": 12410,
+     "sha256": "3b80fc8000fe624ffbe4f119faf41a77406b83bd350020c7782bc03fd51a1799"
+    },
+    "sound/dump/pd_magic_01.wav": {
+     "bytes": 125944,
+     "sha256": "3ea2bab80feccbe0f0b518ec613f45093aa76b0128752f454e239c75175cb4e0"
+    },
+    "sound/dump/pd_quake_end.wav": {
+     "bytes": 37248,
+     "sha256": "3ecb621fbf5a3f2ab090ebc0f3036069292181b11ab366689b3dfa0f19dd372a"
+    },
+    "sound/dump/pd_quake_full.wav": {
+     "bytes": 156278,
+     "sha256": "872e0b0847fd366c59341d672cba9da0faaf85a881f8d4d5471a664923c8440e"
+    },
+    "sound/dump/pd_quake_loop1.wav": {
+     "bytes": 159956,
+     "sha256": "52a330a12c35191347008f4c546b1c83b4e387f3f33c9b60c3a5e8e545b0517e"
+    },
+    "sound/dump/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/dump/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/dump/water_59_02.wav": {
+     "bytes": 40038,
+     "sha256": "25aa667940a737e46da0a829d9cb94922972b9b19726664d1a1133a666dc1439"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/enforcer/enfire1.wav": {
+     "bytes": 14818,
+     "sha256": "7a2e8646c5284d6980bca340900885fdec6c408e7c1403948e28d5acc6c0d903"
+    },
+    "sound/enforcer/enfire2.wav": {
+     "bytes": 14818,
+     "sha256": "d7610ea4031fa259afaf7663b52b242db9659b68c0d6fb48e308907d71338e9f"
+    },
+    "sound/enforcer/enfire3.wav": {
+     "bytes": 14818,
+     "sha256": "c09b1a4644e95e42445d69c8127413e0e0e84c253c52c2491d4697e780f97425"
+    },
+    "sound/enforcer/enfire4.wav": {
+     "bytes": 14818,
+     "sha256": "561b686c2e6baba5ed0e74ee1ce82b6f7132b75db6a2a3a01dad71d166a8b39c"
+    },
+    "sound/enforcer/enfire5.wav": {
+     "bytes": 14818,
+     "sha256": "ac49ff66d177ed5f8501fe36ed1cef9f1ebf0061472412ced0a9c191467cb04d"
+    },
+    "sound/equake/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/freddie/death.wav": {
+     "bytes": 88244,
+     "sha256": "2e3de0875dd3245a98614829ab848cc1dfc34a95827aa4cfc174884977ecddf0"
+    },
+    "sound/freddie/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/freddie/idle1.wav": {
+     "bytes": 88280,
+     "sha256": "673ac7c26a9be2b1ea37b152ce48442ff40089cc7dc015c014eb42534db2c306"
+    },
+    "sound/freddie/mangle.wav": {
+     "bytes": 48548,
+     "sha256": "ee318d6849ca9dda4569db6009210a6909279bd2ffe9b31543d47134b51c1533"
+    },
+    "sound/freddie/pain.wav": {
+     "bytes": 38640,
+     "sha256": "ffe05b43444a209084c95c166b0776d33f9ba8af15ef998d3ed5c09aa0b03c3d"
+    },
+    "sound/freddie/painshrt.wav": {
+     "bytes": 8868,
+     "sha256": "31e08c51909022a6b0ad7f01f1f8dae196269b8b105e57e555025393cdc278d9"
+    },
+    "sound/freddie/sawstart.wav": {
+     "bytes": 41938,
+     "sha256": "90f83017a7ff5f2bd2824be1e122eab7d8171ab63a9025adf1fc03ee3e7a44aa"
+    },
+    "sound/freddie/sight.wav": {
+     "bytes": 55170,
+     "sha256": "3f73e5b30cef3038102ffa9ab0faf89e71af43ed2ee5a0758319c072c151c123"
+    },
+    "sound/freddie/step.wav": {
+     "bytes": 19898,
+     "sha256": "121818aa6200c770a70c2c02844bbc0351a62f166c31f9d85765896b426f610e"
+    },
+    "sound/freddie/step2.wav": {
+     "bytes": 19870,
+     "sha256": "7e33eb621ee356cbe4affe6218b988f477259dae705d57eea12d7fe10b5d4510"
+    },
+    "sound/freddie/step3.wav": {
+     "bytes": 19898,
+     "sha256": "a005232c4c0608092c7d697c6d24566892b74adfe7566030360c96996bd39357"
+    },
+    "sound/freddie/stfire.wav": {
+     "bytes": 27598,
+     "sha256": "597fa6e0e8c4da4fd85e9e26ecd7f95f3dc242846ec9b962cf2beb324e5a4fdc"
+    },
+    "sound/gaunt/death.wav": {
+     "bytes": 48236,
+     "sha256": "7cd8ccf762e7704d7d9214f493068ef9ab72d74dfedf26935d4bbabf0ebab6bf"
+    },
+    "sound/gaunt/idle1.wav": {
+     "bytes": 79838,
+     "sha256": "8e714e17ed6ce45b52c2e5e323720c98f1bcb41a294f04ea645c530db9126e9a"
+    },
+    "sound/gaunt/idle2.wav": {
+     "bytes": 22094,
+     "sha256": "142b725ff5515cb438a592288a69e01331b3fd0bbb7311abf1dbaf90f95417ef"
+    },
+    "sound/gaunt/idle3.wav": {
+     "bytes": 95246,
+     "sha256": "12f3e9f15c9b0daf5fcfc08884a230311ed20b49de7c8d0af431eaaf88be8849"
+    },
+    "sound/gaunt/pain.wav": {
+     "bytes": 27820,
+     "sha256": "76afb45c26689618ce2fe3c9207307dd419c50f194a86afcb08b33a4587b1437"
+    },
+    "sound/gaunt/plasma_fire.wav": {
+     "bytes": 114694,
+     "sha256": "a7f694a649a3228c583802fd1b6bc562b72f12072741a233fba5a00972cba029"
+    },
+    "sound/gaunt/plasma_start.wav": {
+     "bytes": 66270,
+     "sha256": "ad404715612b802a7d4f72f2d14abb47c338ac414af56c19ffc8dc2873f33452"
+    },
+    "sound/gaunt/sight.wav": {
+     "bytes": 59526,
+     "sha256": "562bab0f3b3b7ea6a539ceac13df4d962ed00f86973c26ae8cc2b9d671dd7857"
+    },
+    "sound/gaunt/wings1.wav": {
+     "bytes": 44172,
+     "sha256": "e5af16d5d889220fa9bedcf3255bc509de8b523f797c583969b1838670163d79"
+    },
+    "sound/gibs/gib5.wav": {
+     "bytes": 15490,
+     "sha256": "2d7603a9fc0c055ed3529bd4dfd511984c71b93f4719b605813eb5139d02c6d9"
+    },
+    "sound/grapple/charge.wav": {
+     "bytes": 4458,
+     "sha256": "e7ae8ddfea4cc193af1a76c92308af4cd955c21d5f1219eebae5ad7164fe2826"
+    },
+    "sound/grapple/uncharged.wav": {
+     "bytes": 6088,
+     "sha256": "210c9b7bb0d26742b6e05c816f49fb933c646df5d8aa1696da9a6fa7a1bf76e5"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/guard/death.wav": {
+     "bytes": 47176,
+     "sha256": "87f013eb50cb30a967a183f0cfa41b4848f9269afd13dbe1ab5053458bfc5f0e"
+    },
+    "sound/guard/pain1.wav": {
+     "bytes": 10768,
+     "sha256": "c48f2415db3a5067dfbd99ad580e3f4809532743d653eafe2fdb924fb0bb832e"
+    },
+    "sound/guard/see1.wav": {
+     "bytes": 47502,
+     "sha256": "a0c0bd639af614c7714388009c9388f6db9a694e7ecd8fac38653609d6958f61"
+    },
+    "sound/gug/bile.wav": {
+     "bytes": 54572,
+     "sha256": "e06787585ef0369798a938a1a9585d24b60aa7b5c65acda3a5fb6f2c7ab65aca"
+    },
+    "sound/gug/bileatk.wav": {
+     "bytes": 50040,
+     "sha256": "b4b05e2907789a78391ccfe8ced3902821f1097ecd1f894b12ba9278d31a8717"
+    },
+    "sound/gug/death.wav": {
+     "bytes": 132396,
+     "sha256": "20bf209a832381b77d37c54a84ab1819b6c71e2147c5d122ac62668c070167a5"
+    },
+    "sound/gug/gquake.wav": {
+     "bytes": 43350,
+     "sha256": "d232ae13b55cb5b10b8903db43c037a5c6c4cdfea1f84f9399133484df6e0175"
+    },
+    "sound/gug/idle.wav": {
+     "bytes": 50580,
+     "sha256": "ff33c63696dec5c582ff9a4537814299b47ce2480d6cc53c116721d793576fda"
+    },
+    "sound/gug/pain.wav": {
+     "bytes": 22064,
+     "sha256": "e559f2b372fe771207aeef4b1c3a71baca542863493776558ae3f933f3878c29"
+    },
+    "sound/gug/quakeatk.wav": {
+     "bytes": 65882,
+     "sha256": "2c07b7690356bd9233a79c1f8b5f4e146cbabc367a19c138d6719a1e0d09328e"
+    },
+    "sound/gug/sight.wav": {
+     "bytes": 76426,
+     "sha256": "210ed86a5d6f9d4e791954fc3a4e4b4b6dc5839d02f7c19d468493a2f87dca64"
+    },
+    "sound/gug/step1.wav": {
+     "bytes": 15494,
+     "sha256": "4e2ce285991bc0d4337c77fdbb029507697ecb4dbf6543ddefe976ea114c4214"
+    },
+    "sound/gug/step2.wav": {
+     "bytes": 15502,
+     "sha256": "27f6f770a52fce5ae04836706e63ef455555de086019a2f9e44d4da1fc99b03d"
+    },
+    "sound/gug/step3.wav": {
+     "bytes": 15502,
+     "sha256": "fcc7ab38a8ec28509d0aa062a3cb93aee6da6a0ae364e4fe0dfad791f54558af"
+    },
+    "sound/gug/step4.wav": {
+     "bytes": 15502,
+     "sha256": "fc52cad29cca2e1fc36f5c6ac7f955ed897d6da4fb5dcf4eefd052e0652d93e7"
+    },
+    "sound/gug/swipe.wav": {
+     "bytes": 16064,
+     "sha256": "90bb5831dfd19f65df19e97f76d858ec940d8e33e0a2ed8fad89a23947e430e5"
+    },
+    "sound/gug/throw.wav": {
+     "bytes": 23180,
+     "sha256": "5e901b94e7be364536603273f18791ab571c46c2fc74263774c0e312f873a281"
+    },
+    "sound/hellscrag/attack.wav": {
+     "bytes": 51782,
+     "sha256": "a0d283cf47807282b260fad484b01bb84daf2907279ebe68bed2bf93285c5066"
+    },
+    "sound/hellscrag/death.wav": {
+     "bytes": 41254,
+     "sha256": "aac33e6fe75f2b65a4f536553c437c4fe460dc9982d422dd91d2dffb93ea9fd5"
+    },
+    "sound/hellscrag/idle1.wav": {
+     "bytes": 47860,
+     "sha256": "41e3348ac7ea678b1f563a4cfabae4dcdef58dce3723850024611b33e3553c8a"
+    },
+    "sound/hellscrag/idle2.wav": {
+     "bytes": 47860,
+     "sha256": "36667de62450d5780edf13dbf0a6ee40bd6eaafcb1f97c491d2ccf06ec89baf8"
+    },
+    "sound/hellscrag/pain.wav": {
+     "bytes": 17332,
+     "sha256": "5080763e22ca43c75e9da085219410bb6b00f2f7028c2b8309b5bf06ba647798"
+    },
+    "sound/hellscrag/sight.wav": {
+     "bytes": 26116,
+     "sha256": "4a5259e25cd11bfa7c6750db739a4a0dbd8f0164d855409d31156452226fff1c"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_g_charge.wav": {
+     "bytes": 28358,
+     "sha256": "db3b36d46abcf402002bdfa10cdc03d19e8d51c25115310b8842546fce4d8070"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/lavagun/snail.wav": {
+     "bytes": 11160,
+     "sha256": "9227d1f6dd9ce3d900336328d23a0f43420099af1b664c33f966d8d453cfb876"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flagcap.wav": {
+     "bytes": 15102,
+     "sha256": "05d5fd00f4d1d8a6c37545fe2eb3a68f2963d9d5705b359c7e98173e552f4d91"
+    },
+    "sound/misc/flagret.wav": {
+     "bytes": 10840,
+     "sha256": "6df4d366ba75eae16216d764a31cb0cb4e3069e96891c5d070602622cb083ff6"
+    },
+    "sound/misc/flagtk.wav": {
+     "bytes": 17930,
+     "sha256": "75bcf514cd0a2819cc030846d0775e05c4ba570eef5787ebc8468c4ea8d08a74"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/neh/pong1.wav": {
+     "bytes": 19906,
+     "sha256": "562d4465eeaea19d1dd6faa910f5aa2baa281bccd5bee8775e21317d550a6a1d"
+    },
+    "sound/oldone2/pd_pop2.wav": {
+     "bytes": 42108,
+     "sha256": "1eec3103cd2eb70fa8ba63ce8ce721842a64a99e9c373f5a8abe5508273ce285"
+    },
+    "sound/pendulum/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/pendulum/swing.wav": {
+     "bytes": 12960,
+     "sha256": "68da54f9541808bdaa1f070218bd53ffce0cfccee46b460fd9181a366440952a"
+    },
+    "sound/plasma/bfgboom.wav": {
+     "bytes": 14519,
+     "sha256": "65ad55fe66fd66d096a09984a646eca75115acfce487dde61198904ded477463"
+    },
+    "sound/plasma/bfgcharge.wav": {
+     "bytes": 18295,
+     "sha256": "a63fd9101364d0abbdfde7908576e8e3c4c31ccbb11b49629598fd9372769224"
+    },
+    "sound/plasma/explode.wav": {
+     "bytes": 29598,
+     "sha256": "7a95a8337c7ad87faccc1cae98ad7840352b08608fba08aff87a1b33610f9190"
+    },
+    "sound/plasma/fire.wav": {
+     "bytes": 22422,
+     "sha256": "7350d1e99f93a79bee84e94561e080dcb8448a3549a42742633cf604377a5097"
+    },
+    "sound/plasma/flight.wav": {
+     "bytes": 17494,
+     "sha256": "a03b46f31df3495a1b7a2b2f1a09f3e5223d4c0ab65aa0ed936e1445e893adeb"
+    },
+    "sound/pogre/ogdrag.wav": {
+     "bytes": 16086,
+     "sha256": "36d74ec32b45516abe4ee249e1d2563024bae24f96ed9012af6659f94f135168"
+    },
+    "sound/pogre/ogsawatk.wav": {
+     "bytes": 22613,
+     "sha256": "efd9a6f25d78290ee9e93d423650c5ed1203e77c2e53e1e7d78174608c6201a6"
+    },
+    "sound/pogre/ogwake.wav": {
+     "bytes": 11676,
+     "sha256": "eba1ea552318e5f416319cd408405ee3d1793353190b65ae030e40dac60737b0"
+    },
+    "sound/polyp/blast.wav": {
+     "bytes": 25036,
+     "sha256": "0c3942daeedfa438ba36bd31481f7b24b067cab3d167c9e5cfd1cf3c498bf367"
+    },
+    "sound/polyp/cloak.wav": {
+     "bytes": 46252,
+     "sha256": "31cb79048b0c511ad0d40989785d835584c4c808025b8eb8060a74b36c9bca39"
+    },
+    "sound/polyp/decloak.wav": {
+     "bytes": 91152,
+     "sha256": "e2ee4693b0e466c5bc229db186257254c381c6a6985e71b02b20838859bcb5ae"
+    },
+    "sound/polyp/gibsplt1.wav": {
+     "bytes": 19580,
+     "sha256": "e9b7b73242aa04fdb6aed5de1c343ced81b15d6f78dde07097826b78bb1f87a0"
+    },
+    "sound/polyp/idle.wav": {
+     "bytes": 17750,
+     "sha256": "4edd47fe2508cb818ce36916a16c6e4c7cea4f61ff0310b7195e74bccc4f5d2b"
+    },
+    "sound/polyp/idle2.wav": {
+     "bytes": 22210,
+     "sha256": "b07894dd93545ed0c54fabae04f139c371a8b36ab84fc399f870f813b535000c"
+    },
+    "sound/polyp/sight.wav": {
+     "bytes": 11664,
+     "sha256": "a9c414ba4ca74fa3e08018af695674ede79a2f63aab26be0566dda9426eaef43"
+    },
+    "sound/q3/fan4.wav": {
+     "bytes": 289204,
+     "sha256": "1d39d7fa6412ad8790e2ac25480a3126998cd5a78a72332ab0161e1e976373f6"
+    },
+    "sound/q3/jumppad.wav": {
+     "bytes": 31485,
+     "sha256": "cfc06af995406d853cae30df8db02c340bf7c775f955f5a02de60dc20c66fc0f"
+    },
+    "sound/q3/lava1.wav": {
+     "bytes": 710250,
+     "sha256": "2b3a899b9477141ee83552cbb289037645a6c19e0902e02e837bb47bb52f3752"
+    },
+    "sound/q3/lava_amb_01_quiet.wav": {
+     "bytes": 129850,
+     "sha256": "371a4a0474602de9683ce86d2734ee26cb44c4b793be856220fe5305a1e60fb6"
+    },
+    "sound/q3/machinerydrone02.wav": {
+     "bytes": 123842,
+     "sha256": "b428d836f9bed5799b086db647a9bb68b3696d27a6a318953a303979ac7c7527"
+    },
+    "sound/q3/nightmare.wav": {
+     "bytes": 713482,
+     "sha256": "ccd8af76284332ef4da4893e4e5c492bc0ed9df1309f191311580da88c799dd4"
+    },
+    "sound/q3/wind1.wav": {
+     "bytes": 104474,
+     "sha256": "62c035cf8e4e01a66c56709e7537a110231f6ec31f9ca07b80cee68a2a05f867"
+    },
+    "sound/q3/wind2.wav": {
+     "bytes": 76476,
+     "sha256": "15d1f94822fe3d88c27f1ad50bca86c6df525764c47303bd9deb87ce1f0e7e25"
+    },
+    "sound/q3/x_bobber.wav": {
+     "bytes": 241168,
+     "sha256": "a0441af8ae600f56c2aed12513af29387d017ee2f161735304ce50fbc7ca2047"
+    },
+    "sound/rhynch/chew1.wav": {
+     "bytes": 32078,
+     "sha256": "4474b37040e9a64c7b6b0233218d8a4e63aad95e3c966e920906b7eccd316834"
+    },
+    "sound/rhynch/chew2.wav": {
+     "bytes": 31552,
+     "sha256": "9c2782cb23d55f4ed73f42a716b2cbfb0844421bcc116bf76f401124bc547fca"
+    },
+    "sound/rhynch/chew3.wav": {
+     "bytes": 20190,
+     "sha256": "7f610ebb6e14943bedca692d54878719f2e31eaf6a2a573a30ad7d78c78fe316"
+    },
+    "sound/rhynch/death1.wav": {
+     "bytes": 171404,
+     "sha256": "b857e5b069ff9fe394b7af373302f7f1628387b925a3277f773b93e8c2e0c1de"
+    },
+    "sound/rhynch/death2.wav": {
+     "bytes": 165484,
+     "sha256": "48278c7d5ebb9dabe7d61eb3dfa04a06f3c6b0a20af47cbdb51295d9a16a2cb0"
+    },
+    "sound/rhynch/idle1.wav": {
+     "bytes": 120472,
+     "sha256": "f8b89e0d28b200efc9fc9f28cff52d1f38dad9a284c9a3898336dc96f57995de"
+    },
+    "sound/rhynch/idle2.wav": {
+     "bytes": 133420,
+     "sha256": "3ebccd2f3a0e7ffaf98d3e8b0151f65117c71fb4c18160107f3e7efa03157456"
+    },
+    "sound/rhynch/launch1.wav": {
+     "bytes": 118526,
+     "sha256": "6ca3f92a196e1b986b53ab5a73341b746f93195281dc5f78ac8cf1a28b9f24ff"
+    },
+    "sound/rhynch/pain1.wav": {
+     "bytes": 74950,
+     "sha256": "6f341cc792b7da07f0f207f45d6d562d5cd8a0897222e8fedb21df6c260dad0f"
+    },
+    "sound/rhynch/pain2.wav": {
+     "bytes": 79652,
+     "sha256": "fce9aed90afa474cc0126bd9c1fa424d79e4d648729f1682a1ca8ab800b0b946"
+    },
+    "sound/rhynch/sight1.wav": {
+     "bytes": 75996,
+     "sha256": "1c9dc940de175dc8317daaa4321f98dac91acd261e731989ebceba55a41d45bd"
+    },
+    "sound/runes/end1.wav": {
+     "bytes": 14936,
+     "sha256": "90dd50b25175c8d514a52165429e9ca6b90c45dddbb0f301e5873146b4a4a06c"
+    },
+    "sound/runes/end2.wav": {
+     "bytes": 13008,
+     "sha256": "933046049bae4d866250ad9a6e0a4b2a9385caffb4156daaca39ff7110a71126"
+    },
+    "sound/runes/end3.wav": {
+     "bytes": 14854,
+     "sha256": "508d89890db17f828cde9511ebd97241ecfe07bbb6e5cba8c7538ab02e31b19f"
+    },
+    "sound/runes/end4.wav": {
+     "bytes": 11514,
+     "sha256": "c66471b98562c0628fe9d8dba43c46d1846d3c4b52b23cea143df933598fc1d5"
+    },
+    "sound/s_wrath/smash.wav": {
+     "bytes": 4052,
+     "sha256": "350f94da784df15dcdf3d005258c8ac1033819c2ef51f7377de69ecd38317c98"
+    },
+    "sound/s_wrath/swrath1.wav": {
+     "bytes": 6028,
+     "sha256": "7d2290479c4b8fe3cbf14b8e1bddbd6a874b5e9d5f436233eec562f35ca8cfb3"
+    },
+    "sound/s_wrath/swrath2.wav": {
+     "bytes": 4052,
+     "sha256": "7f9ae2dcb54b6e59c67705c20179a963bb8218d4c96db4323d1fedfb4ad39afb"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/secret/bossdeath.wav": {
+     "bytes": 41535,
+     "sha256": "dd35afe549efdf080fd916c5c56795818baea166291e09fb591a1352ef7d88b4"
+    },
+    "sound/secret/bossintro.wav": {
+     "bytes": 114172,
+     "sha256": "3ee79621517cee984d72f0e9421e20ab30cdda26931b8abc46b7d65522df278a"
+    },
+    "sound/secret/bosspain.wav": {
+     "bytes": 42984,
+     "sha256": "dff1b8ccbc42bc0d81f86fa570da004b588af4d4b5ab0619946a6bf30d6e7a44"
+    },
+    "sound/secret/cubefly.wav": {
+     "bytes": 12225,
+     "sha256": "175771ead32c6b61f2909c4ec2488e84590e8bc1ba474fa771aeea8923af423f"
+    },
+    "sound/secret/cubespawn.wav": {
+     "bytes": 43718,
+     "sha256": "e78640cf0bf9d1c22f489a01358385555acd40e17e7641f80c69aceb48dcbc18"
+    },
+    "sound/secret/nrune.wav": {
+     "bytes": 289522,
+     "sha256": "d3edb7056335970641df45174cc70cfd8c6494186c25ff1277f31dca325a3b75"
+    },
+    "sound/seeker/death1.wav": {
+     "bytes": 397272,
+     "sha256": "35d8a1091032f24ed6a65efa99a7618f32bc0def24779efb51752b75a9e31ca1"
+    },
+    "sound/seeker/explode_major.wav": {
+     "bytes": 36898,
+     "sha256": "38d78634eae3775c47a59015b395cb3b2580b566f72dcf27ab1e9c49fcb2c05a"
+    },
+    "sound/seeker/explode_minor.wav": {
+     "bytes": 30700,
+     "sha256": "71e73672ec310ad59d10248d3f26a9a32b1eb7ad3d567124ddd95480042d0fa1"
+    },
+    "sound/seeker/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/seeker/footstep1.wav": {
+     "bytes": 96092,
+     "sha256": "e5cd4f907a1b70ec72048b2dd5a5062022e7058676c3d90d05b7426e189a5073"
+    },
+    "sound/seeker/footstep2.wav": {
+     "bytes": 96076,
+     "sha256": "f3c8ba8d65257ddfa73e3e54c737c49de5dcc5c17bb088feb3511c3d69d21ac4"
+    },
+    "sound/seeker/footstep3.wav": {
+     "bytes": 96092,
+     "sha256": "c6fa111be092592a253815826c499b9b1f18a0c536910e2a82eebec7fb7f817d"
+    },
+    "sound/seeker/idle1.wav": {
+     "bytes": 141126,
+     "sha256": "10693a1d5fc1d710e54a0d57ce10d71400de192b874d6776ffe176c2b399a6b5"
+    },
+    "sound/seeker/idle2.wav": {
+     "bytes": 97420,
+     "sha256": "c24b439701d9ec3cf055702f23a3eb23623320ae89b9d46ab98a791f08898573"
+    },
+    "sound/seeker/melee1.wav": {
+     "bytes": 106252,
+     "sha256": "addfb5fab225a77f08d5c126b13f929fa31aa1c9094fc79202121ca891933fb9"
+    },
+    "sound/seeker/pain1.wav": {
+     "bytes": 19884,
+     "sha256": "ccaca64b8c1ab87d7d70896333cbec22c3b61c443a36cd8f253ad0eafc2d7ae1"
+    },
+    "sound/seeker/pain2.wav": {
+     "bytes": 19884,
+     "sha256": "8c3be23111a5ef53a7b66c7b74e32404ff0e6989d7de835543e0a65645e3f793"
+    },
+    "sound/seeker/punch1.wav": {
+     "bytes": 19940,
+     "sha256": "e4bf6b7deb14b5d614b4d5b7d4eeee36059372c913cc906589e1048d4484259d"
+    },
+    "sound/seeker/range_laser.wav": {
+     "bytes": 88246,
+     "sha256": "ee9f13af042a2a98fb75fa33873a1e861f3418f598ddb390f15ab44fcf93fcbf"
+    },
+    "sound/seeker/range_plasma.wav": {
+     "bytes": 79782,
+     "sha256": "9b1d38a4e1937023536d5ab5de035c97e1ef69131d58822b194cab2a3aa340b3"
+    },
+    "sound/seeker/range_rocket.wav": {
+     "bytes": 22422,
+     "sha256": "1752b4963f3715e54df58b7b683466a6f8742f92df94943b9356e7bd47bf8534"
+    },
+    "sound/seeker/rocket_fire.wav": {
+     "bytes": 18124,
+     "sha256": "10cdbf669ba15fb575b11431e47efdcf708ee5e5abcf3dead0f4ee19cd63ba9d"
+    },
+    "sound/seeker/rocket_hit.wav": {
+     "bytes": 39352,
+     "sha256": "a9a06043bb979aad2db216a9d00b993da33c6a5069c6e3b14338afb6e2cb632a"
+    },
+    "sound/seeker/sight1.wav": {
+     "bytes": 163526,
+     "sha256": "ca06541f54bcc297ab19ee133de5c782e978cf7afc2fab34b3789c4c56044d30"
+    },
+    "sound/sentinel/laser.wav": {
+     "bytes": 9712,
+     "sha256": "c5f90e1823a04b48f7f24ac5b8792e1b42030a8b07970db5847dc1e74be094c2"
+    },
+    "sound/sentinel/nail.wav": {
+     "bytes": 13750,
+     "sha256": "7acc3ac05b7218abc6fef2d2397771d90fce6fa39415e33824be7e771d30e288"
+    },
+    "sound/sentinel/widle1.wav": {
+     "bytes": 31802,
+     "sha256": "cfe6801999bd068501ecdd07eb5c9396a24c2d264d35522e243e1b4e8066e884"
+    },
+    "sound/sentinel/wpain.wav": {
+     "bytes": 19596,
+     "sha256": "bc7b6536a1c67aa89295eeacea2d9b36cb0bf783b5fb7cc6aaf4fa01a0edb3fd"
+    },
+    "sound/sentinel/wsight.wav": {
+     "bytes": 27322,
+     "sha256": "83bca2103d60c68435e27f0660e3ecd5bffb058e796382e7bdb43efabdfb9889"
+    },
+    "sound/shield/fadeout.wav": {
+     "bytes": 19732,
+     "sha256": "7b6767d05206abaafdbc4339c2eac31d821cae7f15b47aa6885567140725aa64"
+    },
+    "sound/shield/hit.wav": {
+     "bytes": 6048,
+     "sha256": "0052bfefacadb7616c1ecc976c39b3582648a220e8eef50d760ca883ae3afe8d"
+    },
+    "sound/shield/pickup.wav": {
+     "bytes": 15516,
+     "sha256": "39b303dd20e50754582b33f6085516a632c245725f998b53848e627301614bc9"
+    },
+    "sound/sphere/sphere.wav": {
+     "bytes": 13468,
+     "sha256": "e184e8972228fb383087a8bfa96fda75e4e768c7eafddbccb2520ab75f52485d"
+    },
+    "sound/statue/death.wav": {
+     "bytes": 13472,
+     "sha256": "b030aeac3d806bc77fddaed4bb32684cfd2bbd707fe85e2500a3346c5931ec68"
+    },
+    "sound/statue/idle.wav": {
+     "bytes": 17722,
+     "sha256": "3567914304c8fcf224e31bc302039432cd17833daabc2ed9f83053b01fef4f7c"
+    },
+    "sound/statue/pain.wav": {
+     "bytes": 8012,
+     "sha256": "9193f4e976675042409db103f7e3b26f667a56e913e96a37f223f1c606323246"
+    },
+    "sound/statue/see.wav": {
+     "bytes": 6664,
+     "sha256": "58ca56c21040117cd37c99b648af0195f70a51d0d03ba5665e5f8981d8de255c"
+    },
+    "sound/vermis/death.wav": {
+     "bytes": 148016,
+     "sha256": "44b26a9dca5ec8d5e8a7ef2b5e38196b74e4f606cd37b906ee2b2e5b5a85b08f"
+    },
+    "sound/vermis/grab.wav": {
+     "bytes": 88122,
+     "sha256": "09528bd0d49d5cac0c03fe7994b57e572eb89aa8bce63cd0a591130e4b2126ae"
+    },
+    "sound/vermis/grabbed.wav": {
+     "bytes": 51630,
+     "sha256": "99583c88b8ec2959a0d69448aee16ec86b3d9feee6df7841fc32759598349376"
+    },
+    "sound/vermis/grndhit.wav": {
+     "bytes": 36428,
+     "sha256": "1f0e78fa08efb4617b6967a6cc218c56af227c7fd6bf039420d8f106d74fca72"
+    },
+    "sound/vermis/pop.wav": {
+     "bytes": 131420,
+     "sha256": "6284ab02e604b44c5b07225b2a0544c8707517d5fec0024c127bdafef2704f70"
+    },
+    "sound/vermis/sight.wav": {
+     "bytes": 137772,
+     "sha256": "d892117e4602595b6dfb65563b8fa7a3ad2171851791f7c6f47ea4bfece76296"
+    },
+    "sound/vermis/sight2.wav": {
+     "bytes": 106780,
+     "sha256": "6132e2d0db5cfb7a1a064e708d97f7258e2c6ac15c6f4ea8d520641e0ad10f9d"
+    },
+    "sound/vermis/splash1.wav": {
+     "bytes": 30710,
+     "sha256": "f931a2927c13cdb2523dde4550c0af993cc08cbea6e332739f9cf6fe3bd1ff8b"
+    },
+    "sound/vermis/splash2.wav": {
+     "bytes": 25332,
+     "sha256": "b91c69ee695bd71537ed018800f7d89e5e7d95332124f69adee39261d84d7c13"
+    },
+    "sound/vermis/splash3.wav": {
+     "bytes": 25590,
+     "sha256": "99fad2f3815a30ef645a2162ea24e54b4302ba00d7551af9299fde74ecce98e8"
+    },
+    "sound/vermis/spore.wav": {
+     "bytes": 44204,
+     "sha256": "d01a27af99745725dae124d30af18458b2ef323bce93c3cad939310e0f47f6c7"
+    },
+    "sound/voreling/bite.wav": {
+     "bytes": 8920,
+     "sha256": "a5bbebd7178205c400115846314709fa22c4db390fafbf3abaee2e33342e1a0c"
+    },
+    "sound/voreling/bitestrt.wav": {
+     "bytes": 11132,
+     "sha256": "be72b6a15a73bda266331309046229fd6f94b0856f4dfc306204e6266ad1cb59"
+    },
+    "sound/voreling/death.wav": {
+     "bytes": 19584,
+     "sha256": "e5bc7634816b927c305679e9b0ff3e4f33a2d09cb5e80db3c5dd04373ba452e5"
+    },
+    "sound/voreling/idle.wav": {
+     "bytes": 28378,
+     "sha256": "b9daf80e6bc998d521cd35f6d8ef74295f39fafbb71f6d6cfe8f0e7c1fb3f0ba"
+    },
+    "sound/voreling/land.wav": {
+     "bytes": 6154,
+     "sha256": "92f08d203711dbd3bc2049ba61a62938b4eb34a9c7285c26406da3b29bbdfba2"
+    },
+    "sound/voreling/pain.wav": {
+     "bytes": 15522,
+     "sha256": "0b6c021bc7301757918201ad1175387eabfc0af4f6e8b94e273ba22a2aa6c53c"
+    },
+    "sound/voreling/sight.wav": {
+     "bytes": 55972,
+     "sha256": "9aaaebf47f82cd7a521800aa9d81d14bd2747735481cb15b88ce104cf1568b6f"
+    },
+    "sound/weapons/chain1.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/weapons/dsdshtgn.wav": {
+     "bytes": 8828,
+     "sha256": "ce4bcbb84edabbc89201bf78201bab5dce42c27d3d2628ba6ad6ddc1465243d3"
+    },
+    "sound/weapons/dsshotgn.wav": {
+     "bytes": 9489,
+     "sha256": "80d31a09cb0b6d8e602e11dc1fc269c6410b6777a366180fbe26c229cd8c001f"
+    },
+    "sound/weapons/lasercharge.wav": {
+     "bytes": 66194,
+     "sha256": "c8d7940e138d7604c53fa115f78b59b3e7ba861cfe192853f28c417713dc8274"
+    },
+    "sound/weapons/lnailcombined.wav": {
+     "bytes": 24658,
+     "sha256": "240a6fdb00db1fb63ca2ce7b913a5eb966c58008ecb9ec74ea6e9b6ab5689be3"
+    },
+    "sound/weapons/rail.wav": {
+     "bytes": 35530,
+     "sha256": "e1c624369259c9b8d65ddf6e4b07cd7e20698747741a9017d224a188fd6fd4d2"
+    },
+    "sound/weapons/rzoomin.wav": {
+     "bytes": 6716,
+     "sha256": "4968b8ffc4fb975f546c502e7aa066a58e8c93e42fa83995f526bd347b21e6c7"
+    },
+    "sound/weapons/rzoomout.wav": {
+     "bytes": 7426,
+     "sha256": "7b37f0910fd798725d0ecbae54fffe1faf5d059434b750955dc7be9b9d7a43ef"
+    },
+    "sound/weapons/slnailcombined.wav": {
+     "bytes": 26788,
+     "sha256": "e4f940589a0dfb2f241ab1ee0af242e95723034095b8c5c852fffb6e85363d76"
+    },
+    "sound/wrath/watt.wav": {
+     "bytes": 22374,
+     "sha256": "0aedb709c0769e401f25637e69140ba260035b75e36ae9f22cbb94cbf28f5f81"
+    },
+    "sound/wrath/wdthc.wav": {
+     "bytes": 10580,
+     "sha256": "dd94c0dd5f38cd10395f100004078901754a6993af94e68a06cd154a251a2ee3"
+    },
+    "sound/wrath/wpain.wav": {
+     "bytes": 18208,
+     "sha256": "ccf99194833e0db8af5702126a62c5e011138aa6ba814be51e4207b401183220"
+    },
+    "sound/wrath/wsee.wav": {
+     "bytes": 10412,
+     "sha256": "619c48897129e2352f378e6d959e60f41c1c1d4d31606b2a9577fa186eb5e804"
+    }
+   },
    "sha256": "1dcf714abea9a3f9bdcc8b0c935a8b1296cd89c01617aa2150ba22731e304345",
    "timestamp": "2021-12-05T06:31:44.000Z"
   },

--- a/json/by-sha256/e9/e916c86c14146b8eddedef49053b0e7184966489d7f00b5e23f97aa7b54533d8.json
+++ b/json/by-sha256/e9/e916c86c14146b8eddedef49053b0e7184966489d7f00b5e23f97aa7b54533d8.json
@@ -151,11 +151,60 @@
   },
   "huh/src/RibCage.zip": {
    "bytes": 306698,
+   "files": {
+    "Ribcage.bsp": {
+     "bytes": 702164,
+     "sha256": "bdf1c7824fae3ecdaf426a827f2493566dd2dfdcd1dc68c523da994d5c4ad081",
+     "timestamp": "2019-07-09T23:02:12.000Z"
+    },
+    "Ribcage.map": {
+     "bytes": 200345,
+     "sha256": "4cad9a5b4aaf26ac88a26cf1e8f320e3ab0fd5e3131da95c1b389c8ab29373b5",
+     "timestamp": "2019-07-09T23:02:00.000Z"
+    }
+   },
    "sha256": "50ef2e73302a0bd6ada7f353d530cffdaa33596f45187ea9cd4bba2b7baaac73",
    "timestamp": "2019-07-21T20:56:40.000Z"
   },
   "huh/src/babby.zip": {
    "bytes": 3692110,
+   "files": {
+    "babby/babby.bsp": {
+     "bytes": 1331907,
+     "sha256": "ab6d547ecc6ad474a4d9b9d4beea29ba05944ee9b95944563d66d97b10b368da",
+     "timestamp": "2019-07-14T19:46:42.000Z"
+    },
+    "babby/babby.log": {
+     "bytes": 2043,
+     "sha256": "eee21b2ba3915310415f4a85ff355b76ca6761be7d7a446aeaeeb403a8147fec",
+     "timestamp": "2019-07-14T19:46:30.000Z"
+    },
+    "babby/babby.map": {
+     "bytes": 432659,
+     "sha256": "54741fb9a1f4022cfb111775185249d155d251d6ec185a9b2528aba26f2c6edc",
+     "timestamp": "2019-07-14T19:46:52.000Z"
+    },
+    "babby/babby.prt": {
+     "bytes": 302056,
+     "sha256": "be9ede7718e89925eb1ae87a5d144419b7b2610e8974f5de7c28a52b1f2ec1df",
+     "timestamp": "2019-07-14T19:46:30.000Z"
+    },
+    "babby/indus_ambi.ogg": {
+     "bytes": 3009147,
+     "sha256": "af89a5944d13af20b5b5cc121fc7c7a53fa242088c9bbe00edcc50c5d166b898",
+     "timestamp": "2019-07-14T19:43:42.000Z"
+    },
+    "babby/light.log": {
+     "bytes": 283,
+     "sha256": "bc212d0391923bfc545c4772a4b173d795d53e4c2c6b01615d8d5061a0fb7017",
+     "timestamp": "2019-07-14T19:46:42.000Z"
+    },
+    "babby/vis.log": {
+     "bytes": 421,
+     "sha256": "398bac1fddb53176d31bba158533bcba0043138589036a2f14c54dff38a1b20d",
+     "timestamp": "2019-07-14T19:46:42.000Z"
+    }
+   },
    "sha256": "6a693ddd352790d619ce1e73efbceca83d0c61b24af6749a1bd94af7d965bfcf",
    "timestamp": "2019-07-21T20:58:46.000Z"
   },
@@ -166,21 +215,104 @@
   },
   "huh/src/hangar8_aso3000.zip": {
    "bytes": 1674760,
+   "files": {
+    "README_Hangar8_aso3000.txt": {
+     "bytes": 1596,
+     "sha256": "6a55947314c4d6a1220a1ebf79fb7cb3f85b6af9472074f77e63ebcb97497da4",
+     "timestamp": "2019-07-22T22:15:34.000Z"
+    },
+    "hangar8_aso3000.bsp": {
+     "bytes": 3545548,
+     "sha256": "7a5e6e4032b5bbe69dfcad88879cff1c7fff794d6927b2daac4544a1374f9302",
+     "timestamp": "2019-07-22T21:13:06.000Z"
+    },
+    "hangar8_aso3000.lit": {
+     "bytes": 1594337,
+     "sha256": "c5572574b1c37e17d32d00bdcc31b330c733d675dd0fab92023433cc9346eef2",
+     "timestamp": "2019-07-22T21:13:06.000Z"
+    },
+    "hangar8_aso3000.map": {
+     "bytes": 2070194,
+     "sha256": "98fd38a5d2c542ce0b323c6e5a1be0803e5d581a62ad367fb25d8fabd72a29cc",
+     "timestamp": "2019-07-23T18:17:22.000Z"
+    }
+   },
    "sha256": "d50257408024dc16585ff9a3e155c5c930c80b873d920166e19bb494f3b39304",
    "timestamp": "2019-08-12T00:49:04.000Z"
   },
   "huh/src/q1_technotomb.zip": {
    "bytes": 2652410,
+   "files": {
+    "README_q1_technotomb_aso3000.txt": {
+     "bytes": 1658,
+     "sha256": "b63f0f681bec71c67c3842d3832fb47cf066e1221ab33610308111ce6f1c7a58",
+     "timestamp": "2019-07-10T17:57:30.000Z"
+    },
+    "q1_technotomb_aso3000.bsp": {
+     "bytes": 5581396,
+     "sha256": "fdd42bec5dcc73925dc8777cc5d35d8b84179e961a1740cfc485996e1ad03155",
+     "timestamp": "2019-07-10T17:38:52.000Z"
+    },
+    "q1_technotomb_aso3000.lit": {
+     "bytes": 2840039,
+     "sha256": "4abd32b4879805a79b0b3c6b712e701fb31b7765f059d55efd5d9571f26a574a",
+     "timestamp": "2019-07-10T17:38:52.000Z"
+    },
+    "q1_technotomb_aso3000.map": {
+     "bytes": 2720015,
+     "sha256": "e6f4e806fc21b3f23acc3fd98de39a48ded46162695ec62af073ad40fc5be677",
+     "timestamp": "2019-07-24T10:01:06.000Z"
+    }
+   },
    "sha256": "c0982c7cc3b49245e8b7c31a506a06a1bdaeef4d0f0cfc8d80eee56af13579b2",
    "timestamp": "2019-08-12T00:48:52.000Z"
   },
   "huh/src/runegar.zip": {
    "bytes": 5193479,
+   "files": {
+    "runegar.bsp": {
+     "bytes": 1389328,
+     "sha256": "c37024a5526a76b82be495d9256af5b099745f650b86332c2e03daa2a727bb62",
+     "timestamp": "2019-07-19T16:00:30.000Z"
+    },
+    "runegar.map": {
+     "bytes": 464865,
+     "sha256": "1302cac431d45b86c62b99e534a6904841b83e14b317785674773e6006f5db93",
+     "timestamp": "2019-07-19T16:10:06.000Z"
+    },
+    "runegar_readme.txt": {
+     "bytes": 1893,
+     "sha256": "111eb4d790f83f4cb84cb174182775c2b14076ad4a6ab97294bea03293f04134",
+     "timestamp": "2019-07-19T16:13:04.000Z"
+    },
+    "track15.ogg": {
+     "bytes": 4697792,
+     "sha256": "241eb4120f7515dbc21f8ea65a3203040e2025e83e95c396a172fbf5edd69340",
+     "timestamp": "2019-07-17T18:18:10.000Z"
+    }
+   },
    "sha256": "7b0293eb41a275499bf6d270842d6bd49ad3965e13f0c4a55bcaf53e2c688ba4",
    "timestamp": "2019-07-21T20:59:24.000Z"
   },
   "huh/src/sobersamsom.zip": {
    "bytes": 954581,
+   "files": {
+    "README.txt": {
+     "bytes": 125,
+     "sha256": "5c42ea9e4dbce046cff55e464aeb2ae36f17f586ef1a1fac8b034f697aee3dcf",
+     "timestamp": "2019-07-06T18:31:34.000Z"
+    },
+    "sobersamson.bsp": {
+     "bytes": 2045292,
+     "sha256": "c431dd8347246e66250ce622a7c7f11918fc781e2df0e9aeddf6989babbfe543",
+     "timestamp": "2019-07-06T18:13:26.000Z"
+    },
+    "sobersamson.map": {
+     "bytes": 1256581,
+     "sha256": "00b4e379086f554b59f614968cc764cb8c5390eb02a89d36844f5607448d3cfc",
+     "timestamp": "2019-07-06T18:04:28.000Z"
+    }
+   },
    "sha256": "e1304fd1c3f0a39b2b6348ea1dd21323c54d49eb0044f8554b7d440d2449087d",
    "timestamp": "2019-08-11T20:40:04.000Z"
   },
@@ -191,16 +323,97 @@
   },
   "huh/src/tomb and Tower.zip": {
    "bytes": 433542,
+   "files": {
+    "Tomb and Tower/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2019-07-08T15:25:12.000Z"
+    },
+    "Tomb and Tower/TombAndTower.bsp": {
+     "bytes": 996360,
+     "sha256": "8525e32ead427b6e06f6ed0d18686200837c9dec114267b697e52e5a1c18f78a",
+     "timestamp": "2019-07-08T14:46:14.000Z"
+    },
+    "Tomb and Tower/TombAndTower.pts": {
+     "bytes": 18800,
+     "sha256": "18e0c327c68dcbdb5c3a08456318b0f9e3ad769a2e12dbd715d1b52eeef038bd",
+     "timestamp": "2019-07-08T14:46:14.000Z"
+    },
+    "TombAndTower.map": {
+     "bytes": 159055,
+     "sha256": "85c6198d7c45efb80dde7535deb0075dd3486a8f01960f86dbc18512b8dd1b34",
+     "timestamp": "2019-07-25T15:35:22.000Z"
+    }
+   },
    "sha256": "944efe9229b6c0b57484eda1208dfcf64b92fbda3c50c71fd04089064037cd4c",
    "timestamp": "2019-08-12T00:49:10.000Z"
   },
   "huh/src/tower.zip": {
    "bytes": 597939,
+   "files": {
+    "tower.bsp": {
+     "bytes": 899808,
+     "sha256": "1317ac127278edd68399e2f068e21572dbf1c95b2b7d42740194705a19d352b8",
+     "timestamp": "2019-07-22T19:27:56.000Z"
+    },
+    "tower.lit": {
+     "bytes": 302780,
+     "sha256": "c2ef2bbd9e99bd42b6fc719dc8c2abd0647f6696752f7ec3f2b5d7fe95b37c89",
+     "timestamp": "2019-07-22T19:27:56.000Z"
+    },
+    "tower.map": {
+     "bytes": 596355,
+     "sha256": "6ae4af6b5654cc0561c87159b26b30317364bec7a254243a9af561f90aef9cd3",
+     "timestamp": "2019-07-22T19:28:22.000Z"
+    }
+   },
    "sha256": "5e597c66d64ac5145856ffa1fc501c91a8968feca0f7c263c5576db696a86909",
    "timestamp": "2019-07-23T18:17:02.000Z"
   },
   "huh/src/waydown1_2.zip": {
    "bytes": 4814238,
+   "files": {
+    "MEDIEVAL.WAD": {
+     "bytes": 740804,
+     "sha256": "dd3dc23833fdc435c56b1dc39c4977e7b916d4b8c3d9d7f2c95dee3166b67018",
+     "timestamp": "1996-07-02T14:27:16.000Z"
+    },
+    "aardtex_q1_darker.wad": {
+     "bytes": 319836,
+     "sha256": "352f6cf731ba8fff61e14619afa417995835e84121c91a08acb1544fecc1f1f1",
+     "timestamp": "2001-03-07T19:53:02.000Z"
+    },
+    "apocrypha.wad": {
+     "bytes": 2851932,
+     "sha256": "8664720afb6d766156fbd7501a914813745b847a574924af388da35e1d6c4424",
+     "timestamp": "2002-06-24T03:08:24.000Z"
+    },
+    "chrn_lc1.wad": {
+     "bytes": 677308,
+     "sha256": "25a60ac1a5c8529850f5a93548af0c2554dee4c52ffad2fc70642eb258820165",
+     "timestamp": "2002-01-01T22:03:04.000Z"
+    },
+    "clockwork.wad": {
+     "bytes": 875412,
+     "sha256": "e5ce5e27e9d113f718d63d1d6b2553c4faf900096f118d395388e4b039d10a69",
+     "timestamp": "2001-07-13T00:14:38.000Z"
+    },
+    "purpslime.wad": {
+     "bytes": 16548,
+     "sha256": "d78be2e0ee6fb1325accdddfb51f476c2f5daf8e35c6571c01c8f7d1cc2830ca",
+     "timestamp": "2019-07-12T22:13:20.000Z"
+    },
+    "waydown.bsp": {
+     "bytes": 3823200,
+     "sha256": "5a9a702b70a3551a47247306a68c750c4de6b974f2aa3af3ba0729b057ef002c",
+     "timestamp": "2019-07-16T17:55:56.000Z"
+    },
+    "waydown.map": {
+     "bytes": 1493604,
+     "sha256": "38e7ce162d74dbdfedf790decddf26e0abc4d34707222183813a8fa481a7a655",
+     "timestamp": "2019-07-16T17:54:14.000Z"
+    }
+   },
    "sha256": "81282fabf05fc7047ac4ef3381f19feabd0bd3244cf59fc526a4be20a17b3320",
    "timestamp": "2019-07-21T20:59:06.000Z"
   }

--- a/json/by-sha256/ea/ea7da982ae07dd76f53b9277624b533ca1afd97fb91a2806a577ab30d540fca8.json
+++ b/json/by-sha256/ea/ea7da982ae07dd76f53b9277624b533ca1afd97fb91a2806a577ab30d540fca8.json
@@ -7,6 +7,205 @@
  "files": {
   "deadstuf.zip": {
    "bytes": 233014,
+   "files": {
+    "DEADSTUF.TXT": {
+     "bytes": 1749,
+     "sha256": "508bf7ae49da9ef1b3fbb05ba74f80c11f66abfc385ffda15d584126f9258441",
+     "timestamp": "1997-05-25T16:29:04.000Z"
+    },
+    "PROGS.DAT": {
+     "bytes": 420376,
+     "sha256": "9c25a3cd04f98231bc3a375f41a50d4330c4f793a2274706d5e1be8f3ccdb167",
+     "timestamp": "1997-05-24T21:05:30.000Z"
+    },
+    "SOURCE.ZIP": {
+     "bytes": 107295,
+     "files": {
+      "AI.QC": {
+       "bytes": 15268,
+       "sha256": "77235d6e8c5617dc80239daba6ca45f7c680bf6c317521340f4ec9eacd7e9edb",
+       "timestamp": "1996-07-25T01:51:22.000Z"
+      },
+      "AMTEST.QC": {
+       "bytes": 1776,
+       "sha256": "04d226b4e29b86c0ff3cde7a969124e587ecf0095bf2436bda8e8ea5763c44b8",
+       "timestamp": "1996-07-25T01:51:22.000Z"
+      },
+      "BOSS.QC": {
+       "bytes": 12808,
+       "sha256": "2e3de59b07c29d0ec3af5bcfce2c95472a80b5461bb99cbd1f8a960a5b8f2589",
+       "timestamp": "1996-07-25T01:51:22.000Z"
+      },
+      "BUTTONS.QC": {
+       "bytes": 3051,
+       "sha256": "8b8b796ec93ea224cc8294ab1156c68cf2363c316d4e3460a7964277b36cd659",
+       "timestamp": "1996-07-25T01:51:22.000Z"
+      },
+      "CLIENT.QC": {
+       "bytes": 33573,
+       "sha256": "7be101867c74f7bfd99bbe6ec8a962efbb140d7d4ff18eda8191fa7a6a587f29",
+       "timestamp": "1996-07-25T01:51:22.000Z"
+      },
+      "COMBAT.QC": {
+       "bytes": 6415,
+       "sha256": "19912875de049039914e166350d1db4a0de3a493f3131bdcfcbdd94b6abd8dfb",
+       "timestamp": "1996-07-25T01:51:22.000Z"
+      },
+      "DEFS.QC": {
+       "bytes": 18116,
+       "sha256": "b8217a19f07cee4a0276d7972d4d1b10725901006f96e232c35e9797a417ed23",
+       "timestamp": "1996-07-25T01:51:22.000Z"
+      },
+      "DEMON.QC": {
+       "bytes": 10595,
+       "sha256": "f1b394e5d24d981b57140f4ab919ad5c67fff53afa7ef6420f73005de635a57a",
+       "timestamp": "1997-05-24T18:58:48.000Z"
+      },
+      "DOG.QC": {
+       "bytes": 10227,
+       "sha256": "00481ff76e62ace7e6c5dfd2bf4e92ea7023be56a43dce1f8cb44cc32ed90b77",
+       "timestamp": "1997-05-24T19:01:04.000Z"
+      },
+      "DOORS.QC": {
+       "bytes": 17774,
+       "sha256": "861524312b661df4e71d83a8fd5555cbf21a08ca05d9b99ec852cd89548c7ec9",
+       "timestamp": "1996-07-25T01:51:22.000Z"
+      },
+      "ENFORCER.QC": {
+       "bytes": 11690,
+       "sha256": "e8abad398da3f7a11b02d4118a5d089f11714fc0b1f33e3b8d4874d33962f320",
+       "timestamp": "1997-05-24T19:17:46.000Z"
+      },
+      "FIGHT.QC": {
+       "bytes": 7617,
+       "sha256": "a8f31268f35d1f7822d061f8813e07ffdccbea05c29b278c7e7d48c633eeb976",
+       "timestamp": "1996-07-25T01:51:22.000Z"
+      },
+      "FISH.QC": {
+       "bytes": 7945,
+       "sha256": "15317caaa57a97550836f2c84e64e0dd77e2c9fb84125674b2a4dac684f74ff9",
+       "timestamp": "1996-07-25T01:51:24.000Z"
+      },
+      "HKNIGHT.QC": {
+       "bytes": 19347,
+       "sha256": "675e8fc429de8df168cf2e92b457ab398ce206619f3b810cc120033f2f320817",
+       "timestamp": "1997-05-24T19:32:36.000Z"
+      },
+      "ITEMS.QC": {
+       "bytes": 28772,
+       "sha256": "2694088f7c6b4d5504652526753887ea06721d1dc6948221edbb953c4df9299f",
+       "timestamp": "1996-07-25T01:51:24.000Z"
+      },
+      "JCTEST.QC": {
+       "bytes": 237,
+       "sha256": "952070dc8a6b6266821034314c002870bcfd725ca877b6f3eb196d961652cd47",
+       "timestamp": "1996-07-25T01:51:24.000Z"
+      },
+      "KNIGHT.QC": {
+       "bytes": 10556,
+       "sha256": "51e3501bf834c204dd530f12beb99ca707495e8f58627e7d95185cb7bb2d03c0",
+       "timestamp": "1997-05-24T19:37:50.000Z"
+      },
+      "MISC.QC": {
+       "bytes": 20193,
+       "sha256": "c4ce7f64667b54e7bcc4b95e446f4b545e0e37b3d8a00138771152d80b27671e",
+       "timestamp": "1997-05-24T21:05:04.000Z"
+      },
+      "MODELS.QC": {
+       "bytes": 10373,
+       "sha256": "d156b9a1c3f3b11cda3ace72eb142addf3e0f55878878dc5b9ec4e0e921b5fae",
+       "timestamp": "1996-07-25T01:51:24.000Z"
+      },
+      "MONSTERS.QC": {
+       "bytes": 5034,
+       "sha256": "71d2da5edc4ba02ed9738d953e4a98f28274e6a4dddeacfa655feb00cd696f10",
+       "timestamp": "1996-07-25T01:51:24.000Z"
+      },
+      "OGRE.QC": {
+       "bytes": 15710,
+       "sha256": "7c6503e738003a919be2fac7a0c4ca6b4151a3f1335d1409517801a2b9a44074",
+       "timestamp": "1997-05-24T19:49:20.000Z"
+      },
+      "OLDONE.QC": {
+       "bytes": 9675,
+       "sha256": "5acf409ea907d18d34e09caa51e17235a693688cdb664526fda31cedeee2901f",
+       "timestamp": "1996-07-25T01:51:24.000Z"
+      },
+      "PLATS.QC": {
+       "bytes": 8057,
+       "sha256": "482929446741b421ee5f53171b536f3d0c685733776311580c82b35b39d027e3",
+       "timestamp": "1996-07-25T01:51:24.000Z"
+      },
+      "PLAYER.QC": {
+       "bytes": 19189,
+       "sha256": "dbb8648d9a7b4cb760a26bc02e1128c177851a883ac99e1db88969517b9e87da",
+       "timestamp": "1997-05-24T20:08:50.000Z"
+      },
+      "PROGS.SRC": {
+       "bytes": 441,
+       "sha256": "74a89e692de73ab7a391e4b41a2e31901c82f2c5460d85354ca9319198c2ed3e",
+       "timestamp": "1997-05-24T17:24:04.000Z"
+      },
+      "SHALRATH.QC": {
+       "bytes": 8457,
+       "sha256": "e5080a8b3a606b3177c79c1717ec369c805a2b3b4ed2fd2c3507d70720a0c91b",
+       "timestamp": "1997-05-24T20:14:38.000Z"
+      },
+      "SHAMBLER.QC": {
+       "bytes": 13480,
+       "sha256": "d4d820e9acf44fa27bd85d6b8f9f91150e46c0bc0cd14dd02eda00f30cbec35e",
+       "timestamp": "1997-05-24T18:41:26.000Z"
+      },
+      "SOLDIER.QC": {
+       "bytes": 10725,
+       "sha256": "2d7d92424f358948429bbee173cb78a7b6848d55bf36177ee23162ff90bd7b0f",
+       "timestamp": "1997-05-24T20:32:08.000Z"
+      },
+      "SPRITES.QC": {
+       "bytes": 512,
+       "sha256": "6cfc7737472ff843c3e2e17e8842ec0b765b5e3ea22dfbf8eb7f12a7b1c08337",
+       "timestamp": "1996-07-25T01:51:24.000Z"
+      },
+      "SUBS.QC": {
+       "bytes": 6378,
+       "sha256": "3dcc59fd6e3eb1390c0e9ebe0878be96063f493d8fec326a8fa7a7666302f5f5",
+       "timestamp": "1996-07-25T01:51:24.000Z"
+      },
+      "TARBABY.QC": {
+       "bytes": 7350,
+       "sha256": "620a5c53fc063988ebb95e075391e053f9e5d44f2dd2a295cc8909695b878429",
+       "timestamp": "1996-07-25T01:51:24.000Z"
+      },
+      "TRIGGERS.QC": {
+       "bytes": 14901,
+       "sha256": "9e5ad811c44c67b70a132ddeb1104adc0c87e88847c8d49e045720ff54418071",
+       "timestamp": "1996-07-25T01:51:24.000Z"
+      },
+      "WEAPONS.QC": {
+       "bytes": 25244,
+       "sha256": "c7ad4bf6abfe76b456ca644f74cf55ad8fdafd0ca3d7344ecbc50256b72f17ad",
+       "timestamp": "1996-07-25T01:51:24.000Z"
+      },
+      "WIZARD.QC": {
+       "bytes": 11405,
+       "sha256": "ad083f62716e8666834261fd50505c2ba9aa32bfffe43e1ac8b1c2697c3c7088",
+       "timestamp": "1997-05-24T20:22:44.000Z"
+      },
+      "WORLD.QC": {
+       "bytes": 11451,
+       "sha256": "81ce7ee3d621335c842359f7bb1b9ba43a2ff683f31059ab1a6e8f0ec3537a56",
+       "timestamp": "1996-07-25T01:51:24.000Z"
+      },
+      "ZOMBIE.QC": {
+       "bytes": 20635,
+       "sha256": "fe084c6ddca4ede736d88b19b38cd40abc13c55adf2fad888f2f4ff2a6fb81fd",
+       "timestamp": "1996-07-25T01:51:24.000Z"
+      }
+     },
+     "sha256": "38735310146a33ec3601e55ad7657624c4d8eff2c771017355428e63dbcc00db",
+     "timestamp": "1997-05-25T16:22:18.000Z"
+    }
+   },
    "sha256": "5b2199ecfe5f96d316ab930018858b335b784becde34999378dedecb3e567b41",
    "timestamp": "1997-06-02T10:26:10.000Z"
   },
@@ -17,11 +216,55 @@
   },
   "pak0.pak": {
    "bytes": 2255108,
+   "files": {
+    "glquake/enforcer.ms2": {
+     "bytes": 7616,
+     "sha256": "2f789bbd31106af20017d01650ed75310a99e4f0608015f425644b7fad422164"
+    },
+    "maps/b_explob.bsp": {
+     "bytes": 17420,
+     "sha256": "1b7afa62fa1e6e51bb8f4e6e185532a70983e78cd3a0c53305ec1d8ea710cfc2"
+    },
+    "maps/fromhell.bsp": {
+     "bytes": 1705044,
+     "sha256": "4cc87c482b4993972773385b1ea970fd9f40a845f3625baca8b0be23f3b04378"
+    },
+    "progs.dat": {
+     "bytes": 420376,
+     "sha256": "9c25a3cd04f98231bc3a375f41a50d4330c4f793a2274706d5e1be8f3ccdb167"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 104320,
+     "sha256": "e3751edc424e730a08b3f4c9569d31729188af34d2ed4f2efe38533c75461fe8"
+    }
+   },
    "sha256": "0dc24c9fce7911be59ca08890f2b646df5c72c70b5d3a7c772fd57a03b805ada",
    "timestamp": "1997-10-01T10:24:02.000Z"
   },
   "sexdroid.zip": {
    "bytes": 90987,
+   "files": {
+    "DroidBat.bat": {
+     "bytes": 37,
+     "sha256": "fcc834d2c2c2b091ed1f879bb9b0856c839f99e448158dfd4f29a374c82e07b0",
+     "timestamp": "1997-06-13T20:04:44.000Z"
+    },
+    "Progs/Enforcer.mdl": {
+     "bytes": 182648,
+     "sha256": "43e1a051cf4fd186c0d77a742568472fcc4b326e720d1cb616df89bf8f2e5844",
+     "timestamp": "1997-06-22T17:50:32.000Z"
+    },
+    "Progs/h_mega.MDL": {
+     "bytes": 19012,
+     "sha256": "4d0dda2063720d98c5f9c72bcf2905c26d079ff2cb8778f7f808f8b530ff5a1a",
+     "timestamp": "1997-06-13T15:51:46.000Z"
+    },
+    "Sexdroid.txt": {
+     "bytes": 2776,
+     "sha256": "b1ff8ec5f34d1ca553f3ca6f6e496d3dd7242c5eabe8f49be136f24de237a03a",
+     "timestamp": "1997-06-22T21:46:26.000Z"
+    }
+   },
    "sha256": "30d5d8c1bf1dfdf84ee9e97146bb37752b2b653883f8874c29683e42a99551ce",
    "timestamp": "1997-06-23T13:12:26.000Z"
   }

--- a/json/by-sha256/eb/eb9b1a32679fd9fc3132efe7923b73f40c8d4a1fcf1a210a7f5eed7a623dd3c5.json
+++ b/json/by-sha256/eb/eb9b1a32679fd9fc3132efe7923b73f40c8d4a1fcf1a210a7f5eed7a623dd3c5.json
@@ -22,6 +22,48 @@
   },
   "pak0.pak": {
    "bytes": 6069047,
+   "files": {
+    "demo1.dem": {
+     "bytes": 187572,
+     "sha256": "f974069c3a60c9edab488a4209eb950a0d3ea3fc9dd49657d6b7d29b68ca2237"
+    },
+    "demo2.dem": {
+     "bytes": 258636,
+     "sha256": "1d8e83ea90cd2777419d5b289383e9cbb2c89d7bc177918891929ea2d64af42f"
+    },
+    "demo3.dem": {
+     "bytes": 421259,
+     "sha256": "dc8a632fb44f17a01fd119448fcec4d61d49c6b24c16ef99b5fda03aaca3eafe"
+    },
+    "maps/bfinal.bsp": {
+     "bytes": 509020,
+     "sha256": "cf0422e836e4b0ae9f18904871cdd3c1afb4af278f55cc6818d3b8c0abe63d3a"
+    },
+    "maps/black1.bsp": {
+     "bytes": 1312280,
+     "sha256": "a768e04c0c070b33d9bdfadd3c6231f322e460cab8145fb3a41b774a08a9f2bf"
+    },
+    "maps/black2.bsp": {
+     "bytes": 977692,
+     "sha256": "be60628e359e3e54f5c701a0c8c70b6ef6a3b7ddc33c26a1bedc2c79a40b05cb"
+    },
+    "maps/black3.bsp": {
+     "bytes": 1082720,
+     "sha256": "ba4be1a44ab5f0304419f255f09f43b251ed3bc912028644b26414911b4566af"
+    },
+    "maps/bskill.bsp": {
+     "bytes": 415768,
+     "sha256": "5e2187d7596de5282dcfa4b73d176d0c8f8ede347df691c1e85ed1b281e6667b"
+    },
+    "maps/start.bsp": {
+     "bytes": 903448,
+     "sha256": "0092531cd280e7bf5b1afd00c4330afe9ace693b3a09d6b79c22becbbb3876a3"
+    },
+    "maps/temp.tmp": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+   },
    "sha256": "519b058e9bebd7b2cfef3561e17a9585d3f0d7cb00fb889cb0e10989c9b9aa52",
    "timestamp": "1997-12-17T20:19:16.000Z"
   }

--- a/json/by-sha256/eb/ebafdee1e030a86e52d07b951b58c2a0bc01416415f6d738cad6032abddfd276.json
+++ b/json/by-sha256/eb/ebafdee1e030a86e52d07b951b58c2a0bc01416415f6d738cad6032abddfd276.json
@@ -7,6 +7,60 @@
  "files": {
   "pak0.pak": {
    "bytes": 11840235,
+   "files": {
+    "maps/d1.bsp": {
+     "bytes": 1370619,
+     "sha256": "0409974dfda63ef96c4af025bd87883648e66324f188d0e33a795248f32b230f"
+    },
+    "maps/d2.bsp": {
+     "bytes": 1529552,
+     "sha256": "ec92f09168d422c7bce4e22abe08c6aa1b326591c197c9d98958ef56ce1e1fdd"
+    },
+    "maps/d3.bsp": {
+     "bytes": 1233802,
+     "sha256": "2a5efbdc493301b46c4bb576c1a72504647dd674874adf40c38af6f54c1bd606"
+    },
+    "maps/d4.bsp": {
+     "bytes": 1096063,
+     "sha256": "90925abb535d3b4b317f15d137728725948ef944a3456a9ee0a068e1c8409ff7"
+    },
+    "maps/d5.bsp": {
+     "bytes": 1004217,
+     "sha256": "d72733daa1b914820a8d812e0e2148bd8e602018e6542f214829ef6745da0c26"
+    },
+    "maps/d6.bsp": {
+     "bytes": 1355151,
+     "sha256": "cbcd2bd22de48a2fd50233b9994d45b949306e2ecb8a478b380b38eabd8a119f"
+    },
+    "maps/d7.bsp": {
+     "bytes": 1584212,
+     "sha256": "6d754210fcbb169ef5864dd920ba8eb1078abc7905bef921cdc75fd8b45e6f02"
+    },
+    "maps/ds.bsp": {
+     "bytes": 1135295,
+     "sha256": "dbba7945b240a4383e7fe8d403347ddd79c47f058fb45c28f446632851aff16c"
+    },
+    "maps/start.bsp": {
+     "bytes": 670206,
+     "sha256": "ff7e596e2c6f12a1fc49dcd1e482b6b5896c67d13c10cc38c1191a6f64d8d262"
+    },
+    "progs.dat": {
+     "bytes": 414408,
+     "sha256": "cace0a57bc7f82cc0daf4f5cffedf8a883d733533201d537a6c30b81566b7258"
+    },
+    "progs/renf.mdl": {
+     "bytes": 160688,
+     "sha256": "d0715224e653e4cac0f86b4b2ff3b2bc70d5e895232ec7e753f20db817f34ab6"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/world/ligh_1.wav": {
+     "bytes": 265848,
+     "sha256": "8fd3ad0d8bbf26cd03a5ea686392d02c14b6147e96b5bb936f602311bdaed62c"
+    }
+   },
    "sha256": "b148bc25c9e790a02c22e53b823e269324c6a77b2255bde53df9720935555dde",
    "timestamp": "2006-05-22T09:53:46.000Z"
   },

--- a/json/by-sha256/eb/ebcb2839f78cbcb96b5b76806f92ae0be99171ea0587281f82a2b758292360c1.json
+++ b/json/by-sha256/eb/ebcb2839f78cbcb96b5b76806f92ae0be99171ea0587281f82a2b758292360c1.json
@@ -7,6 +7,20 @@
  "files": {
   "pak0.PAK": {
    "bytes": 3448948,
+   "files": {
+    "maps/v6.bsp": {
+     "bytes": 2619208,
+     "sha256": "61888498da44bfe784eabf52a275e0503674d549b5f4cf384d5d4610ce4b07c0"
+    },
+    "progs.dat": {
+     "bytes": 437952,
+     "sha256": "8be2048832d37285681fcc493949770c7aea38290aa6785fdd1b3bddf35da4ad"
+    },
+    "progs/enforcef.mdl": {
+     "bytes": 391584,
+     "sha256": "4f649d5f70f34d8566ea1abe239ba6c2be5f05df76e07ba92661808a45b3a75e"
+    }
+   },
    "sha256": "3aa867cb4d9fa65c458596d604fd2528834a0db4b03d999d2541dee4bcc4fb97",
    "timestamp": "1997-08-04T10:38:00.000Z"
   },

--- a/json/by-sha256/ed/ed76f7b4edfbb54e556ecf84f543a4ea7f2faf80f44b396d25155f93d7dff722.json
+++ b/json/by-sha256/ed/ed76f7b4edfbb54e556ecf84f543a4ea7f2faf80f44b396d25155f93d7dff722.json
@@ -17,6 +17,140 @@
   },
   "Pak0.pak": {
    "bytes": 10608672,
+   "files": {
+    "maps/nike.bsp": {
+     "bytes": 352448,
+     "sha256": "fb65195d8460cefc0ee3fc26e6a2d8e28723df69406a736909af71fabc5a5994"
+    },
+    "maps/nikead.bsp": {
+     "bytes": 2434808,
+     "sha256": "9cf49e96e0d2ee424ea32b1031013c874dd5b4c64f760d79b1d23b08e60e7df3"
+    },
+    "maps/nikedb.bsp": {
+     "bytes": 1104124,
+     "sha256": "2a03f271458b040b8ed3e1e90d9a9d52d0c62a878f734603219455b09f03dcdc"
+    },
+    "maps/nikel.bsp": {
+     "bytes": 2105468,
+     "sha256": "e99977fa23b7fe7bcf8d4eb6897825074f560e70d602e30392becca3a0ccc4f1"
+    },
+    "maps/nikerad.bsp": {
+     "bytes": 2297260,
+     "sha256": "47819a13b57e8db1776748010593fbf805bfe02a9626bdf1ea2d54d38d8817c7"
+    },
+    "progs.dat": {
+     "bytes": 554536,
+     "sha256": "b0bcc6c6d35217ce042388a13cc20d5876b528962fe9ea98f5918b4627248378"
+    },
+    "progs/arrow.mdl": {
+     "bytes": 12161,
+     "sha256": "41339f3222ee6fc0cd85a58a7b2a6c4330e284ea39ecb7002d97927244c5250a"
+    },
+    "progs/buzzsaw.mdl": {
+     "bytes": 28716,
+     "sha256": "9b85232f930a7e34ef4cd1abfa266bcfa09b8da9e3f96f875d89e56ff702b403"
+    },
+    "progs/candle.mdl": {
+     "bytes": 21476,
+     "sha256": "f3193191ab17b7186f623ef26d1a1bc66c3db35ed7cc63cbce6f910ec1a601b5"
+    },
+    "progs/lantern.mdl": {
+     "bytes": 15092,
+     "sha256": "362ff3c50031d80b46a11c3d1902fe1cc3d442cd13b7db59f6d46c5655fc9351"
+    },
+    "progs/pendulum.mdl": {
+     "bytes": 44128,
+     "sha256": "0970c838e4246a47d0b39395af03754a06dcb5878830233413e6fc893cf80599"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/s_null.spr": {
+     "bytes": 56,
+     "sha256": "29e9c18546413f0abc9c6f507c61952f33afa6507b52d1c2197b57e3be7870a9"
+    },
+    "sound/ambient/diesel.wav": {
+     "bytes": 1388,
+     "sha256": "df01f1198ef4af1a712152d9da47fd4da57a3024d5e6bc86ca7e6ca39d73a494"
+    },
+    "sound/buzz/buzz.wav": {
+     "bytes": 26568,
+     "sha256": "9f6bbc6cd33beb735c81ed86da32356f65fa90aeb2792489aaed97e41b201227"
+    },
+    "sound/buzz/buzz1.wav": {
+     "bytes": 18828,
+     "sha256": "f9aa4cbaef41e71e9711e4d54c3714dd784068ab60993c382e07c684fe456e37"
+    },
+    "sound/misc/duckcover.wav": {
+     "bytes": 676922,
+     "sha256": "f0d73cf0332c4f2e5ff1ce6f691fd3676cb2a205001f71d7eeb5d90c849a0fd6"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu.wav": {
+     "bytes": 3518,
+     "sha256": "9a1757c646ac4a5e29799a5c57780e5ed87bdbb204d84e50c55592cd0ab53199"
+    },
+    "sound/misc/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/misc/pit.wav": {
+     "bytes": 85068,
+     "sha256": "5090b0bbe6409cd92e47ffc92fa316ea2091972e41868aa2f3342596444daefd"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/question.wav": {
+     "bytes": 2944,
+     "sha256": "b5a62d4e78d83cb9e2d163d1d3cf012e34a99ace9425681a4917d1b2e4c9aa64"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/pendulum/hit.wav": {
+     "bytes": 6026,
+     "sha256": "920bf2c124ddc1b58ef12176332a9909974341c5040ccbcc2ac17b0d675a361d"
+    },
+    "sound/pendulum/swing.wav": {
+     "bytes": 12960,
+     "sha256": "68da54f9541808bdaa1f070218bd53ffce0cfccee46b460fd9181a366440952a"
+    },
+    "sound/weapons/arrowhit.wav": {
+     "bytes": 3644,
+     "sha256": "7348632798578416b240951489cf027abcaa04ac7f1190a22581349c8b06ede3"
+    },
+    "sound/weapons/lncharow.wav": {
+     "bytes": 2872,
+     "sha256": "546ef60ffa1d6f311f24093af551514ef4f4b9832d4481e4ae78fd0bf6e273b2"
+    }
+   },
    "sha256": "51e7d849782456aa880c477982cb269fd1354bd89d5992e84e16194e732ff1a8",
    "timestamp": "1998-01-20T10:40:42.000Z"
   },

--- a/json/by-sha256/ed/eddb1f25c3efa7d51e0a49e4466fd96d040bed30e2fdafc6b9e2f647997d8bae.json
+++ b/json/by-sha256/ed/eddb1f25c3efa7d51e0a49e4466fd96d040bed30e2fdafc6b9e2f647997d8bae.json
@@ -13,6 +13,332 @@
   },
   "pak0.pak": {
    "bytes": 16797221,
+   "files": {
+    "autoexec.cfg": {
+     "bytes": 59,
+     "sha256": "8ae7c876b01120bfb2015378c141759a0b03099b3e2e761d0dcb29c8b4d85b00"
+    },
+    "maps/e5m1.bsp": {
+     "bytes": 2518872,
+     "sha256": "f9fe0fdb7522146b167ac7e151af26e2d4009b8fdabb23d385732f4ea7acc415"
+    },
+    "maps/e5m2.bsp": {
+     "bytes": 1239180,
+     "sha256": "7fab14c09a868235e0c3a9d970d57f0300d2ecfd5cc5e76892ea05c9eb323b5a"
+    },
+    "maps/e5m3.bsp": {
+     "bytes": 952660,
+     "sha256": "4b8ff5a486dd8d72dbd5aabaac6dea22b97ebb2a2c26b7fe0d66e208a5ef1090"
+    },
+    "maps/e5m4.bsp": {
+     "bytes": 1606356,
+     "sha256": "31893ebc475b26bc2c3822f83fc122b535ea7deb151449c08a0575102033053c"
+    },
+    "maps/e5m5.bsp": {
+     "bytes": 695656,
+     "sha256": "01b89456ef37201359683c95200dd6aab23d421d976456ffd168355de66a872e"
+    },
+    "maps/partb.bsp": {
+     "bytes": 1209548,
+     "sha256": "8beb2ac4c9ecca27105711352273e2c3f98d2d55ff0b3fc43adcc0c069b1c715"
+    },
+    "maps/partc.bsp": {
+     "bytes": 2154544,
+     "sha256": "94d4744eca5015663d173fc219b5d89ca85796e2bd511879cc24fa4370c6d2a2"
+    },
+    "maps/start0.bsp": {
+     "bytes": 1015176,
+     "sha256": "2bf6328b629a4338bf32587cd852c3f6d62a8d6b6d560787372ce269e031e6ed"
+    },
+    "maps/start1.bsp": {
+     "bytes": 714104,
+     "sha256": "793fee0a837d43f7a1f9498563f61a149af9a7ac0e570a81a629accb3ba57b4b"
+    },
+    "progs.dat": {
+     "bytes": 588880,
+     "sha256": "d7f1d894f348a8f6bd90757938d1c266eb5a663930790b2ce95dbf96ca8b7ec6"
+    },
+    "progs/buzzsaw.mdl": {
+     "bytes": 10498,
+     "sha256": "8173fd2a525fbe11f95f5e98a17bb532c94eb74dfef3a513eed4d2273747576d"
+    },
+    "progs/demon.mdl": {
+     "bytes": 184933,
+     "sha256": "57b29f15b1e1c506ab509b9ed02e2a06c08d09fc62e9a676c13c1fd8da36fed7"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 224812,
+     "sha256": "af9095cffbc74edc9d98d4e4e341736e304404df52983be33616da84d6463c87"
+    },
+    "progs/g_cgun.mdl": {
+     "bytes": 73603,
+     "sha256": "e17c3e884c66fae33057d3682f6f5f71f94f971fa3c56a695dc8687be3aad80d"
+    },
+    "progs/g_dshot.mdl": {
+     "bytes": 71894,
+     "sha256": "9f5973b2db81e67569d498ae880c4ebdf1f886fac695df50ebd93cfe5b79da0c"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 161064,
+     "sha256": "b182cf8e7915d1860f37634a610905359c7a325f4ac13f1ef5b6fc2393efe182"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 59539,
+     "sha256": "c66cc4f2c8aee10b9b9dfde86a12819eea6df55880763bf6e0e0fc312cde016b"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 12416,
+     "sha256": "2fff2f36173080827a298870a956fb11ad30f34aa0342ba5ca2c8bd6509edf57"
+    },
+    "progs/hknight.mdl": {
+     "bytes": 492976,
+     "sha256": "1cd65b15a2c368df6ea231eb17f05ba5e40e046c1ac59b6e891fa690c244ac07"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 59078,
+     "sha256": "6a7022fa8210771be206034a2b0ebeb59f6fc79719d499ac01811a4ff32eb08a"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "b4116dd10673155069d7d326fe16439596cbfbb2f6c8c5b31001fcf7e70355e1"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 16228,
+     "sha256": "16a1b41734ec932fe749051b31bd8b577af097e28bcaa930783fb84f5d51610d"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 22228,
+     "sha256": "71ceb28d923fa713eb1537c898e84e1b2bb94c17955fc39946255ea5673dfa0c"
+    },
+    "progs/rubble4.mdl": {
+     "bytes": 6047,
+     "sha256": "582f7203c44ef28a0f8a51a13b7191ea2909e121e16d51819b5b5f607b672a2a"
+    },
+    "progs/s_cg_1.spr": {
+     "bytes": 864,
+     "sha256": "f39783767087d9f02e8b09797b4ccece6ae19aaee7136291dd33e522da0149f5"
+    },
+    "progs/s_cg_2.spr": {
+     "bytes": 864,
+     "sha256": "c7191728de66e5d167df59d0b204ce96b8ba9b032b44c1befd2c854277cde7e0"
+    },
+    "progs/s_cg_3.spr": {
+     "bytes": 864,
+     "sha256": "5c4a2ceaa07fd633cbe5497e8604e553de6890245c9ff631f0520f438aa15aab"
+    },
+    "progs/s_rain.spr": {
+     "bytes": 33100,
+     "sha256": "4c0bf4b61b6cd263d3f0453f7f050c94a30708f3d9604a44d50cfca1c232444b"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 153429,
+     "sha256": "f9d50e7819ba91cf29454d6ff4905d5e6f9c0454b351252db7e3db427ce79588"
+    },
+    "progs/stunner.mdl": {
+     "bytes": 13472,
+     "sha256": "e6648c7cc191a58f9fda4309a4e08162d3513cdc31fba68b8623db1721b1be36"
+    },
+    "progs/tgib1.mdl": {
+     "bytes": 19760,
+     "sha256": "1939b9cfed1c4d82cfb7034d3d9fc4b3dfa1233126ff2e4962533bdcf9ea3ba1"
+    },
+    "progs/tgib2.mdl": {
+     "bytes": 53712,
+     "sha256": "f6e2e84f7bdb837f3b9f4bd0a3dff363985293a141d23ecbf33fb5997b3835df"
+    },
+    "progs/tgib3.mdl": {
+     "bytes": 64372,
+     "sha256": "a26e8802c5c0662ad0562ad49f487282ef43751ba0a70a3fe4ff794982bed19a"
+    },
+    "progs/tgib4.mdl": {
+     "bytes": 20484,
+     "sha256": "f7ec6242209753a3655557f8459de2516f6205e666cf7a6cc09a465eeac15230"
+    },
+    "progs/tgib5.mdl": {
+     "bytes": 2545,
+     "sha256": "b7756a235ce35f96d1ba0681207441ed0ffa60628b8663dc52d880cc3ba4726f"
+    },
+    "progs/tracer.mdl": {
+     "bytes": 11973,
+     "sha256": "928bc71a3bf560377bf08d0b38e7e0060e02d0f3f12ce49fe3fa8686021f8295"
+    },
+    "progs/tree.mdl": {
+     "bytes": 101704,
+     "sha256": "f5dad886e64ef946b0ad0aba3a06da419579911c5248ee856d2d503e40c4beab"
+    },
+    "progs/v_cgun.mdl": {
+     "bytes": 62283,
+     "sha256": "c0803b83613ae3c91061f45b71b9a183269ed3afc02baab895957cfc57494562"
+    },
+    "progs/v_dshot.mdl": {
+     "bytes": 77102,
+     "sha256": "8b54bab3a0fc20bbe27ed1ef204fc4dc21c8c6ab0d9a6efa82038d570de5aacf"
+    },
+    "progs/v_light2.mdl": {
+     "bytes": 178333,
+     "sha256": "37d41f62604af8f7cedd55d84e02988b5d06e2604cb636f81d505835e493844f"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 184952,
+     "sha256": "d113effd0d5b436c468269c245647e369f26b569f3fb9031f874a7f6a5dde574"
+    },
+    "progs/v_stun.mdl": {
+     "bytes": 62074,
+     "sha256": "2e293a149a9afbb9e6e61a1aeae8af25891d2909264ce5b6e687648f61f5db7c"
+    },
+    "sound/ambience/brik_hit.wav": {
+     "bytes": 6820,
+     "sha256": "499804fd15edb24a5fa931163e19c5569a45ce93ad74d313c58b2382cbf35d7f"
+    },
+    "sound/ambience/brikhit2.wav": {
+     "bytes": 12028,
+     "sha256": "b5b548d61e738ccaf17a82b06993d4eb6ab0bae3d4c15c7465ce2a7b3cbc9bef"
+    },
+    "sound/ambience/equake.wav": {
+     "bytes": 47148,
+     "sha256": "dcc45d2ef0703ecaa022c83cd66ae4992021ac379c11fc9da4401e184a191c93"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/rain.wav": {
+     "bytes": 91202,
+     "sha256": "a196a2fc8a052368f9e8f7efe853391d1a99dfb1f6afae4fc7038222f2eb6fda"
+    },
+    "sound/ambience/thunder2.wav": {
+     "bytes": 108388,
+     "sha256": "c4bf4f36a0362a5506b8479207dde4dcf38d855bb23f53232416ae1411bf4c0a"
+    },
+    "sound/ambience/wall01.wav": {
+     "bytes": 67890,
+     "sha256": "b5035fafa3e000b2e51cccf2e39404905cda1f55e42a64799ae677decb03ab19"
+    },
+    "sound/ambience/wings1.wav": {
+     "bytes": 6028,
+     "sha256": "c9e05f66a1d728a88289bc213c9f3551f1e54a4f3e8ef23ab03f8d5019e7b2c5"
+    },
+    "sound/bell.wav": {
+     "bytes": 94183,
+     "sha256": "abbaeaf9096d6bcfc470559e80d9d5c4344f68969e3c4e7d2d725a10a6cbf378"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    },
+    "sound/heart.wav": {
+     "bytes": 123618,
+     "sha256": "2df6c267197b2e82241e47ce4985b04d14e1ce3cff46cebf3177369057302bb6"
+    },
+    "sound/machine2.wav": {
+     "bytes": 407886,
+     "sha256": "9fa7b8df07ab521039dbc7ff67b7e1fc53bbc48a462c0659535158677895d6fa"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/stinkpaw.wav": {
+     "bytes": 92470,
+     "sha256": "0da6e5e44c706ad2df18b1be94aa3748c5cd2942f4fe402e9a84c33f31e69fd4"
+    },
+    "sound/weapons/pc_exp.wav": {
+     "bytes": 35314,
+     "sha256": "ba81a9534ba1da310ec277a807aa31de8bdcfa36a061e80d8eff9b4581bb85ea"
+    },
+    "sound/weapons/rocket1i.wav": {
+     "bytes": 26306,
+     "sha256": "04fc98e42709c9a5d1a8bbd52aff9114b4922da324e30d21859bcf8209e55b4f"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 50578,
+     "sha256": "1ad6d4575bef663147df78de15279dc77835a79d70b0bdb9a8b40071df7158e1"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 6734,
+     "sha256": "7ef40ee79cc8319c195c0894c83c591bb542fcea3d3e7063216a9cf64997e9f4"
+    },
+    "sound/weapons/shotgn2.wav": {
+     "bytes": 12522,
+     "sha256": "0acd8127028e3109eaba942aab82608c7a35f2efacb9be4740acb2287709207c"
+    },
+    "sound/weapons/stunfire.wav": {
+     "bytes": 9902,
+     "sha256": "7214cc44e4c0bfb801209f025b591d838542a3110f770e5614b0f549a055286a"
+    }
+   },
    "sha256": "b7f99dc693f4c7bd781cd69af4dcade6a8a392279b150dc9aa78cfec3a14dff2",
    "timestamp": "1998-08-01T11:20:18.000Z"
   }

--- a/json/by-sha256/ee/eebbee003427856c49840c64dac14c036d6070ce5e8ad2dbdb76b1e4c400fb5f.json
+++ b/json/by-sha256/ee/eebbee003427856c49840c64dac14c036d6070ce5e8ad2dbdb76b1e4c400fb5f.json
@@ -22,6 +22,36 @@
   },
   "pak0.pak": {
    "bytes": 3202093,
+   "files": {
+    "demo1.dem": {
+     "bytes": 105366,
+     "sha256": "f53318a7e58ca572595516634a5927dc5f4416f1736ac9eca00598b9c347c096"
+    },
+    "demo2.dem": {
+     "bytes": 147267,
+     "sha256": "a0786637200b816c24bb19b5f84d02a27d24d1bb419349d749b44dec7010c351"
+    },
+    "demo3.dem": {
+     "bytes": 114644,
+     "sha256": "3ece4d7339553ec96236e39d3cb7f7cbfb9228cc41c143544effbf0da4234eda"
+    },
+    "maps/last2.bsp": {
+     "bytes": 936212,
+     "sha256": "5d2a74d69ed9b4eee9b8e1be75db39df9d59038ea2cdf9f58a11b206bb79bd5f"
+    },
+    "maps/last3.bsp": {
+     "bytes": 1137740,
+     "sha256": "ac1fb8f54392e8a87775a5f4cc561f5759ec0b372faa2bb1cc9c72d595db8382"
+    },
+    "maps/start.bsp": {
+     "bytes": 760404,
+     "sha256": "4f0658c883f9335e2f1a3de1719305cf74ed5dca39cd333ab7541536fd550a7d"
+    },
+    "maps/temp.tmp": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+   },
    "sha256": "60ea782650f9760c220221367b02c52470f9bc79b3d276e0b0b3a6d8f1e9018d",
    "timestamp": "1998-01-20T00:08:18.000Z"
   }

--- a/json/by-sha256/f0/f0f66dc2330ba4a88eca55975b08027286f7ce2c49f4de88744ae8f4373ee3f8.json
+++ b/json/by-sha256/f0/f0f66dc2330ba4a88eca55975b08027286f7ce2c49f4de88744ae8f4373ee3f8.json
@@ -32,6 +32,360 @@
   },
   "copper/pak0.pak": {
    "bytes": 4393664,
+   "files": {
+    "gfx.wad": {
+     "bytes": 121132,
+     "sha256": "fdcc42f0dad313b297845f4a4daa79dffb541dc7fdfd13c6e8610df9fd614f72"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "898d694265db0f933feecfd2a843557a6954a5f2aea05ecf9a852314119dab61"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "6687bc516bc880e47e8f1e8d049848b2e7dd66575b82a94408ef342e5ef4612a"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "eb873e85eef5f19707a84a520f0c57b52959ba0e4ec0cd8d5dd7d1d25bab222c"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "a08a25e6162f73b30f9cd5f196d97666d98844db588c11c32fa5664d4b4118a9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "8425b25acaefd68eac70243cc0994ad02ec4cc78433bdc5f0d205432aa7718a5"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "03e0973ee5d434c037699f9568228ab80be0df882ca77c88a9835b2d2edf0649"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "82ee9c6c78aceee238cb14116781fc7e8cc1a43c5c66f526d46551e1360aed10"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 35440,
+     "sha256": "be3a6e1ab5a4adee01633d39cf52f31faef004dccf52a703d48aec0a2d30a10f"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133200,
+     "sha256": "773ffd83e71838e3425031c22cca6b30a4d24d7e4d6560269b2071d3f58ad870"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    }
+   },
    "sha256": "2a28a9f4861c149ebff65a36456836b694e7b4437664518d1ca5e27da0e82a16",
    "timestamp": "2022-11-23T15:55:46.000Z"
   },

--- a/json/by-sha256/f3/f34cd718f34efbefadb45bcb159fbdf201acfaa1eeaed37c0eaf1856a5fb3bdb.json
+++ b/json/by-sha256/f3/f34cd718f34efbefadb45bcb159fbdf201acfaa1eeaed37c0eaf1856a5fb3bdb.json
@@ -27,6 +27,572 @@
   },
   "alk12/pak0.pak": {
    "bytes": 9117783,
+   "files": {
+    "maps/alk12.bsp": {
+     "bytes": 1337792,
+     "sha256": "2aa6603229a11897cdbf66176f114db2908c4a7942d0a3cf849cbd4c981b5582"
+    },
+    "maps/alk12b.bsp": {
+     "bytes": 1006924,
+     "sha256": "53b55d09fa2fc749a0289e44ee8872fc837afded13145fc1de377c41c1b9493b"
+    },
+    "maps/alk12c.bsp": {
+     "bytes": 1213760,
+     "sha256": "0b3326189ac691732793a9d53259e4d213bf96af7d6d9d98b284f991deabde91"
+    },
+    "progs.dat": {
+     "bytes": 717752,
+     "sha256": "8b7bcc64fb3e4fb4becc50db903943ccc73f876cb46b34093895ed3e956787fe"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 106244,
+     "sha256": "2ca415ec913b3c05038c6db21f9235edf7eefe7cf41120edead53efb90ff0ef4"
+    },
+    "progs/b_earth1.mdl": {
+     "bytes": 16325,
+     "sha256": "f8721a42dd05178200b3de8fb73502ef46284f7e4e48076fb353980dfea997a2"
+    },
+    "progs/b_earth2.mdl": {
+     "bytes": 65436,
+     "sha256": "59933ccbe1fda467ca4de97ae80587eb85904779e9aa612a3621859bc474dfdc"
+    },
+    "progs/b_ice.mdl": {
+     "bytes": 17584,
+     "sha256": "7805429534fa39fc6be4016eccacdac51fd0b4c2183723e7cc8dbab2aeada925"
+    },
+    "progs/baron.mdl": {
+     "bytes": 405612,
+     "sha256": "68bb69841d1246882360b8e243bd34dc5534989dce1eda8974938ebf7acae652"
+    },
+    "progs/bball.mdl": {
+     "bytes": 130008,
+     "sha256": "6fc43ee5d3e26268cb4e9be521b4b514f21bfe3556f8189ccb8c96a44c71b115"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_baron.mdl": {
+     "bytes": 5349,
+     "sha256": "b1c731745089418075fb565c13db5992d7dd54df6d5ffd38f93e146caa508561"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/hkboss.mdl": {
+     "bytes": 323272,
+     "sha256": "a632782756fbd24959a4db02d1604921b544d8dab0c5bbe3594f5939e3d320be"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/knight.mdl": {
+     "bytes": 153400,
+     "sha256": "26576f139d258b3c236faa6552d8ba09ef6e14480d4a2e2dc9e3e2c4df5177b6"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "fae8fac60b899d78a929ada720c591b7356e78cdea074f1b128f465d47fc4d8a"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.qc": {
+     "bytes": 7330,
+     "sha256": "60b9b2f830d359825647aa829bd0566f3fd8b6727df89926133898512cb10f1b"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "744af1fafaacb751cf2e5ce4bb15a0fc1fb938ae519469de6f0dccfe9f320414"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "ba9f52e66ac380306d443e07ee4f1fac92793cba55394c01590c3dd088042e78"
+    },
+    "progs/wetsuit.mdl": {
+     "bytes": 55156,
+     "sha256": "4e4dc7331c374d2345c3d755ff34b61850c289741314b10fa36c461db3844e99"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "sound/ambience/drips.wav": {
+     "bytes": 80712,
+     "sha256": "96f7890d2fea2f1f6443d0e75bb6084f39931e7c5399a6e75787dec4eaba5033"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 25852,
+     "sha256": "02d097f0a58cc65826bde1ebe5c3450a4ab92d09b16e85ad916f62dca82936c9"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 91138,
+     "sha256": "ffc3f8d7386db7766c885706a1247926f870957d4a3e55cd51dbe4d55416338f"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind.wav": {
+     "bytes": 44582,
+     "sha256": "1b0b9f054d82c238128b821c41bdeba0e81a436f37c1aec92d2e1dfd7be61c6a"
+    },
+    "sound/ambience/wind_high2.wav": {
+     "bytes": 91138,
+     "sha256": "ffc3f8d7386db7766c885706a1247926f870957d4a3e55cd51dbe4d55416338f"
+    },
+    "sound/ambience/wind_low.wav": {
+     "bytes": 58476,
+     "sha256": "0759ad526d301c3bb14c467818bacdbe3a64237657c45a435e06cb166b570b85"
+    },
+    "sound/ambience/wind_med.wav": {
+     "bytes": 32212,
+     "sha256": "005616904ebfec049860ca33b790903e76c75615f3048dba17ce8d85cd6c65f5"
+    },
+    "sound/ambience/wind_rumb.wav": {
+     "bytes": 63234,
+     "sha256": "24760cbf8622bb933fcd59e847067de3581f6a3d54db72bcb3f864d2cf508a36"
+    },
+    "sound/ambience/wind_rumb2.wav": {
+     "bytes": 32872,
+     "sha256": "9c77014eb35b692af657a524f1e7eb82b1b1ebe9d95c62462e6f6925baf4153a"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/adeath.wav": {
+     "bytes": 11714,
+     "sha256": "c6d2e6a1107eddcb49ca41776da1c7f8a3b27766b66dbf4bd9186fba2780cb2c"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/apain.wav": {
+     "bytes": 3302,
+     "sha256": "788466ee8cc368bcac8b07c4eeca5509ccddc30addf5a322b31a605d90bf0392"
+    },
+    "sound/axeman/asight.wav": {
+     "bytes": 8528,
+     "sha256": "d5d1a9125b9a015186d6d5e9fbd9f9d9db3fb220bdf9139f5aa73b9019d37126"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/baron/death1.wav": {
+     "bytes": 68188,
+     "sha256": "0785bad4b7b721f2bb989fa74f7186552ef9bbca016fb2f1a3fe9b52650fe3cb"
+    },
+    "sound/baron/e_hit.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/baron/e_nail.wav": {
+     "bytes": 26306,
+     "sha256": "04fc98e42709c9a5d1a8bbd52aff9114b4922da324e30d21859bcf8209e55b4f"
+    },
+    "sound/baron/e_shower.wav": {
+     "bytes": 10178,
+     "sha256": "6c50b5da79aa99295f9bc3de1445ef76c6e6306b413b9a934122393b6b3a633b"
+    },
+    "sound/baron/f_ball.wav": {
+     "bytes": 5804,
+     "sha256": "d9ce92407aa56e5dd66531f6deaa9c87bd2cbb8ec4ae1ca61ab7cb290ddf7f6c"
+    },
+    "sound/baron/idle.wav": {
+     "bytes": 36612,
+     "sha256": "a6e72130a476101ae80ea88c5dd5cdaa7a8b357c3a2c0dca5f376be6263ab8bd"
+    },
+    "sound/baron/pain1.wav": {
+     "bytes": 11162,
+     "sha256": "290c97801f39bab34a273a2164f043b808b7585ad92a508239b7b3ea0286ccd6"
+    },
+    "sound/baron/sight1.wav": {
+     "bytes": 27466,
+     "sha256": "8e22043e7ef40ff345f1f080be940e02442ce10b60cdf0c703c7bd6b0ad2939e"
+    },
+    "sound/baron/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/baron/sword1.wav": {
+     "bytes": 47712,
+     "sha256": "ff6403d7ec2d2a17cffd1106a36b1b33c6253b155832bbf93759233e65577d16"
+    },
+    "sound/baron/throb.wav": {
+     "bytes": 7694,
+     "sha256": "b5c63d7fe66aabb9892653c6bddd56b817b21f29a8a8f2a2ce2e2e6d4ca49e98"
+    },
+    "sound/baron/woosh.wav": {
+     "bytes": 3132,
+     "sha256": "ffe8d9966d666f964c30e6c46f9e944705d7f059b6678c318db1fc20450165aa"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    }
+   },
    "sha256": "9c05ee11785c8f2515cde80f2f0001b6953f0d26581627d76f6a8e831ad52702",
    "timestamp": "2002-03-09T20:07:58.000Z"
   }

--- a/json/by-sha256/f3/f3f2b055b3b553cf87c053bce8c4a3163d5d3a961d8b4d774d6897e584d4a6a9.json
+++ b/json/by-sha256/f3/f3f2b055b3b553cf87c053bce8c4a3163d5d3a961d8b4d774d6897e584d4a6a9.json
@@ -22,6 +22,144 @@
   },
   "pak0.pak": {
    "bytes": 6846065,
+   "files": {
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "4ce01b9677b264e87b8cdc215ece73145be8145c55f4a5c77d652bded977ff94"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "13a9c6fcb6ba14ea402ef29c351477d9f86b195a2c0fdf1696392abe091288ec"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "b3626155d68916ff35faea09f0a55d6b79745aaa52d35488fa30f86235c89abc"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "8a2347b6b9ce45fea24933e6bb5785d14bcaf048c8ccf5cfccea01f1f7c286fe"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "602618634f726a25dec05fe0403fe87f1eebd7d41523b8d6a25f0523c103a4be"
+    },
+    "gfx/paused.lmp": {
+     "bytes": 3080,
+     "sha256": "ede8fb11ba31852212de75538e72aae3355d5fbe190303298b65219605f4e432"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "8ca8a297dec6a9f7b9449d7ccb78e5706cd08e5651f095c6696fd29759ae5354"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "2d86e45bd797db46f28b60b152203450391a03f821580c909edc6dd7ea0f2d89"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "74186fdf17cc6e929a40671ca927d0bb4429c40dccfc8305031e3bfc2f1d6b68"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "7f9e59a7be278b6d1a3551419e7d0d063c1666c2341900607bd54f184343f989"
+    },
+    "maps/e1m1.bsp": {
+     "bytes": 623348,
+     "sha256": "1461944902200bde182c8057123e3d21c98731451a6857734be0792f7ea3573b"
+    },
+    "maps/e1m2.bsp": {
+     "bytes": 628364,
+     "sha256": "4f8febea9efbfb581c017acb4e5b719886a9eaa36335ad5ddc76bcee79015d8f"
+    },
+    "maps/e1m3.bsp": {
+     "bytes": 883232,
+     "sha256": "ddf27ddacb7d30bf6a3de135844d5a4acc3fda7362cb47720bd1c03b400f6046"
+    },
+    "maps/e1m4.bsp": {
+     "bytes": 753224,
+     "sha256": "825773db46b9576d08c818fc45ae956baf1907080c3b012cce07a3df56396c1d"
+    },
+    "maps/e1m5.bsp": {
+     "bytes": 286476,
+     "sha256": "f6898ec01fbc90eaad1a112dd58b0165c5a69ec86339d1a2c485dfe27a2a3e8e"
+    },
+    "maps/e1m6.bsp": {
+     "bytes": 1145584,
+     "sha256": "c91b738ecac1a3195600cc488d6e2e1142f1d23093460765b845831b37fc6ef8"
+    },
+    "maps/start.bsp": {
+     "bytes": 661484,
+     "sha256": "dac53f8d9f390a47350bb4fa17d598a55350095429ef0428a56dc8cd6320a462"
+    },
+    "progs.dat": {
+     "bytes": 418520,
+     "sha256": "950e44558a7f2ae2527c8ac9067de187eafbf78eee813e408635bc42c8a982e5"
+    },
+    "progs/Gib1.mdl": {
+     "bytes": 22483,
+     "sha256": "11553315aeedcb61c5196922e59c22dbcdaa997d8513042bb477001ee7f5a3af"
+    },
+    "progs/Gib3.mdl": {
+     "bytes": 22228,
+     "sha256": "91e4a4a8024d2e5316a0a41b4623a58dd401257124a0da6a6770ab79507f20ea"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 22292,
+     "sha256": "de3fd4403a49fe98e9f9d10726e74a4683f43a272103d89383e77e5328cf2292"
+    },
+    "progs/demon.mdl": {
+     "bytes": 180708,
+     "sha256": "1bd49ac9c67608d29059467db6ea0b37b3dce7049eda32e3c3959232c743518b"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 44553,
+     "sha256": "175ee0e2e28ebb3a004d1783af2eaad4880a3572fb38c1d24b6281a9ebb4023f"
+    },
+    "progs/knight.mdl": {
+     "bytes": 241188,
+     "sha256": "acce69944694da0ee77427187c327caf67fe6e2314a51b086b448560e09dbfb7"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 146288,
+     "sha256": "84135f3cacc9e00385a56ded56c66b80483bf845f940029bad30754143f2284d"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 207049,
+     "sha256": "36bda51198aa9ddcebb6d3eb9e3d4a4d60630e3859a6a52af832c25faa9e3090"
+    },
+    "progs/v_rock2.mdl": {
+     "bytes": 155864,
+     "sha256": "16c503fb042bbcec8ba228ee748208698c88a552adcaab8ee6bee4b505acb5f5"
+    },
+    "progs/v_shot.mdl": {
+     "bytes": 145704,
+     "sha256": "efe63d3890e0f7cc86ff8e685cdddc55a4985f4ba5b81a64eeb13aa6b7ec72ab"
+    },
+    "sound/demon/ddeath.wav": {
+     "bytes": 24916,
+     "sha256": "d051c976822a8a7bfb3613d5e67aeaa514ac9baa7a460047b49a7b95a5f3a006"
+    },
+    "sound/demon/dhit.wav": {
+     "bytes": 11716,
+     "sha256": "a7e30308a8ad2505cadc647301f2283d19450528f01b5b7e345db97d27050b08"
+    },
+    "sound/demon/djump.wav": {
+     "bytes": 22202,
+     "sha256": "e4c0d9a121f35afaf68f2607b4df2b4f8de606805e3b67e825f6d09960215ee1"
+    },
+    "sound/demon/dpain.wav": {
+     "bytes": 12798,
+     "sha256": "93feac5142cda6fc4596bdcbc0fa3e784a24d6ebc5d4279860d1e67e221a1739"
+    },
+    "sound/demon/idle1.wav": {
+     "bytes": 11174,
+     "sha256": "a09e00aef702e4d538da805bb39d35f11c2fcd058f89a0bb453a57daad45310c"
+    },
+    "sound/demon/sight2.wav": {
+     "bytes": 38642,
+     "sha256": "7f6fd555f897cef6cdc53dd5a60af74af5b3dba315f86903d4814773934f0b19"
+    }
+   },
    "sha256": "fa42544a7470d78441bb03fda022aae99a2f12e9f054bd5cf3095b2bef8a7c02",
    "timestamp": "2001-05-06T19:29:12.000Z"
   },

--- a/json/by-sha256/f4/f40017500e54a222a99ef81abed5d70597ea5e134a44c46b2076cec237836d7a.json
+++ b/json/by-sha256/f4/f40017500e54a222a99ef81abed5d70597ea5e134a44c46b2076cec237836d7a.json
@@ -7,6 +7,116 @@
  "files": {
   "PAK0.PAK": {
    "bytes": 4709736,
+   "files": {
+    "custents.txt": {
+     "bytes": 8297,
+     "sha256": "ae71304b46fca49e604286637ff12e92a15449003e8479ed054200c26ecd71d6"
+    },
+    "entsdefs.txt": {
+     "bytes": 47486,
+     "sha256": "2402a9d9a6879d93d8abdc2ad748c7b75e1af321597f7fd9515cf117bf897a7d"
+    },
+    "gravity.txt": {
+     "bytes": 3543,
+     "sha256": "3b6d84efd04985bed0b2a61bb1f3f8ada023f6a614a8a8c6ef53adc06fb32499"
+    },
+    "history.txt": {
+     "bytes": 23387,
+     "sha256": "1d6617dd950207aa88622fa957c8e079714c0b0624a07a6dc09f474cd71b68cf"
+    },
+    "maps/_mapelec.bsp": {
+     "bytes": 2713680,
+     "sha256": "c5bf523112294c3d08c86a7ac949b0f6a36f7621bda03a8debbd5d98d0c607d0"
+    },
+    "maps/electric.bsp": {
+     "bytes": 207892,
+     "sha256": "7fc7068a0ee4a5cd9e5345a27a1a43ff95b79cf31a4b5909ae464e2f560a538c"
+    },
+    "progs.dat": {
+     "bytes": 562288,
+     "sha256": "01f767ed3db5244b69abaf57d59f78e86ee693e9b958b4ff1035297cc285277d"
+    },
+    "progs/deaddog.mdl": {
+     "bytes": 71077,
+     "sha256": "a09de4693ece4ec22ed89329a4a2aae8729d36906f0d3c924810b197c7135d19"
+    },
+    "progs/deadegg.mdl": {
+     "bytes": 33684,
+     "sha256": "cc885fa4a802a0c7aaaa2d4bc445a067cee930ceaf287ec96e1197516b2be7a3"
+    },
+    "progs/egg.mdl": {
+     "bytes": 33684,
+     "sha256": "9efe1d312a3c90db4f92f05741ebfda7d6afcb2f249e7deb2f640647bdef832b"
+    },
+    "progs/k_spike.mdl": {
+     "bytes": 16756,
+     "sha256": "4bd36f9267f944e8cb74566e29cc75795fe5cf24337ff7aa0b88b396362017aa"
+    },
+    "progs/rag2.mdl": {
+     "bytes": 7588,
+     "sha256": "4a14b1392c21049f693192aa3294169785046728217958e25195007abd9e6a4c"
+    },
+    "progs/redback.mdl": {
+     "bytes": 80720,
+     "sha256": "c91ab52229ad70da45347b931b2f0c18a50fa7e3eb3e6b9755c2ebe01aab0805"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 69839,
+     "sha256": "48951b0bf15ef846c8e657446ec100d69d49f8d15eb62c0837105c6e5171e866"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 200266,
+     "sha256": "3191f808a5b5fb9f4a712a5486348e49e1c1dc2f81e72a74928be4e857c45a77"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 303486,
+     "sha256": "742e55e055dbb61acf51d5f41d8b605cffee4dabc3d93357df8dc1dd9e7ad2ab"
+    },
+    "progs/s_null.spr": {
+     "bytes": 56,
+     "sha256": "29e9c18546413f0abc9c6f507c61952f33afa6507b52d1c2197b57e3be7870a9"
+    },
+    "progs/spider.mdl": {
+     "bytes": 94492,
+     "sha256": "df40e58bdf6465e68e5ef33cbcb77c42cc99e50c9dd842c8c3906c2fd04bfc8f"
+    },
+    "quake.rc": {
+     "bytes": 388,
+     "sha256": "2516c50bb7da57d5560d097509c0ed4377bd9030d606c9883cd3d0296c921cd7"
+    },
+    "quark.cfg": {
+     "bytes": 2,
+     "sha256": "7eb70257593da06f682a3ddda54a9d260d4fc514f645237f5ca74b08f8da61a6"
+    },
+    "sound/door2.wav": {
+     "bytes": 41326,
+     "sha256": "f2490096c1d2381b5cde481739c2d0d389f7ebccbcc60af7b41903bc1172d907"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rumble.wav": {
+     "bytes": 53068,
+     "sha256": "1b0bea88a28404b9082a6b311dd43e1e96c0dd1acb1ac757fbf77c78d7114e6a"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    }
+   },
    "sha256": "f433ffa54b61d823651637b65393bdb53b5ea5c82aa86a1fd0b49bbe1a2e4e17",
    "timestamp": "1997-11-19T15:54:20.000Z"
   },

--- a/json/by-sha256/f4/f47bef2f0b959059610a85a60267c594c9f887e11b8ad2c10fac83ab3bb0b2b6.json
+++ b/json/by-sha256/f4/f47bef2f0b959059610a85a60267c594c9f887e11b8ad2c10fac83ab3bb0b2b6.json
@@ -12,6 +12,32 @@
   },
   "pak0.pak": {
    "bytes": 4284108,
+   "files": {
+    "maps/ovrridn.bsp": {
+     "bytes": 1515932,
+     "sha256": "8029b85635b2e95c5850439b9b13160239eee949f57194ccff91b72ddb714891"
+    },
+    "maps/ovrridn2.bsp": {
+     "bytes": 1848048,
+     "sha256": "1970659c23778991586c3a966c64c9e15fe86900b0609e61cbe486f3a2ba2e41"
+    },
+    "progs.dat": {
+     "bytes": 480868,
+     "sha256": "ca3be4df2003e8b8cd7688682507121f7b67f469d21b4734be8644e7ab1101e8"
+    },
+    "progs/grunt.mdl": {
+     "bytes": 146288,
+     "sha256": "4d3fdb5d119a3bf4f69dd72eb0d0896f9215c3c279d8103f8747454334429aac"
+    },
+    "progs/ngrunt.mdl": {
+     "bytes": 146288,
+     "sha256": "3c8d939e8b1d911709b8cba3ee7a78d8889aeb48bcb091dbf806be5ca65731c3"
+    },
+    "progs/sngrunt.mdl": {
+     "bytes": 146288,
+     "sha256": "7c6f2dce582b0b3e4f353881818d3744ee316102980b9371a6b6fffc36b17278"
+    }
+   },
    "sha256": "a4191fd62ee0b1b10a5f5c007d5b04c7472c893506ddbaf5de0a23b0d521bb6e",
    "timestamp": "1997-05-21T21:13:32.000Z"
   }

--- a/json/by-sha256/f4/f4c2cb39caa3d50a1c8378dd4da8eb413219d45ca8979ca9b594599c990e8073.json
+++ b/json/by-sha256/f4/f4c2cb39caa3d50a1c8378dd4da8eb413219d45ca8979ca9b594599c990e8073.json
@@ -18,6 +18,100 @@
   },
   "seiven/pak0.pak": {
    "bytes": 91890020,
+   "files": {
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "ab4774e93eb7711c384d0dbe8e2afb81e233eafefdd103b770f09920587427be"
+    },
+    "maps/start.bsp": {
+     "bytes": 1313312,
+     "sha256": "a3ac3a6f0aec16270dfaf6a4f8058a15f95c33f88ebd627ebf2b4650f3e23595"
+    },
+    "maps/vm1.bsp": {
+     "bytes": 2426976,
+     "sha256": "b7db4e573a669cb33cc2103c6806ab66214fc73d829346ffbe501942b01811e0"
+    },
+    "maps/vm2.bsp": {
+     "bytes": 4512112,
+     "sha256": "1a4c0cc5a30861ce44be99e1a876dd38c4a6f1a9b78510d53fa821e61f818e84"
+    },
+    "maps/vm3.bsp": {
+     "bytes": 1707884,
+     "sha256": "2f390fe9b7e0f15fbf20acf95891be4efd511a7c42d58e5604d7b928fcac9a86"
+    },
+    "maps/vm4.bsp": {
+     "bytes": 2715984,
+     "sha256": "6d7a0a76128870c7214fc4f0c442541bcd06fc8c2f55e669462701d150323e3f"
+    },
+    "maps/vm5.bsp": {
+     "bytes": 2357984,
+     "sha256": "dc0374b1e05ab061a692f5aa6ce7a7e642bb7547ba9fb6aef8ab0c4a2b4b4498"
+    },
+    "maps/vm6.bsp": {
+     "bytes": 1911844,
+     "sha256": "6ed0385437ae93439d01dc514398224a7bc25b5f5e9cb71138b2731cd4f4f791"
+    },
+    "maps/vm7.bsp": {
+     "bytes": 1763828,
+     "sha256": "9858c7155e15dde22b87156caf18adc2efa7e787385e2e7ed7d3b602670741d8"
+    },
+    "maps/vm8.bsp": {
+     "bytes": 7906200,
+     "sha256": "f737d928dacb45d05cc95dee9b9f97a34bf66e08f9cbabf8c34202752523a2e1"
+    },
+    "maps/vm9.bsp": {
+     "bytes": 2482068,
+     "sha256": "a5a2db85c4e1739f8a96b3d5afb25205693af9a15e7b25d6c92872da7efbfa27"
+    },
+    "music/track03.ogg": {
+     "bytes": 4659994,
+     "sha256": "49a94c28e3c9eabbcb6679c547d194bb903cd848112f1cefde3c43e1ea9fa641"
+    },
+    "music/track20.ogg": {
+     "bytes": 5776436,
+     "sha256": "77850fdb471f254f63a2649c1d22ccd76103ddd249166cc82302c69169bfc8f2"
+    },
+    "music/track21.ogg": {
+     "bytes": 4920753,
+     "sha256": "15a4741f95641cf42d5de9ccd6f32da57d20efcd527fa39203379ee07d1d7a07"
+    },
+    "music/track22.ogg": {
+     "bytes": 5882227,
+     "sha256": "8b90f90960c834fdacd087a1f9865360c0f654814812020770dc20543b03c0a8"
+    },
+    "music/track23.ogg": {
+     "bytes": 4302730,
+     "sha256": "11fbd9432fbc0a0cc0446b790e44042a6b4b8389861a8392fd7000cfaf859180"
+    },
+    "music/track24.ogg": {
+     "bytes": 5768767,
+     "sha256": "159800ef5eb99546a73b582981c3afbb471690d2250912ea70322bb234d62143"
+    },
+    "music/track25.ogg": {
+     "bytes": 6901132,
+     "sha256": "c8cef6680974357499feaf3823bf2c3a08b65be90a31cedeeee7d171f3faaa7e"
+    },
+    "music/track26.ogg": {
+     "bytes": 8920144,
+     "sha256": "49bd3e4c609c4decbfc1110aa5de6a950d27b3202b3fcab595378a11a111901c"
+    },
+    "music/track27.ogg": {
+     "bytes": 4708835,
+     "sha256": "38fb73aa155c8cea018252b4f27bd450353805844ee9e4c92bfbadd28610e3fc"
+    },
+    "music/track28.ogg": {
+     "bytes": 6008196,
+     "sha256": "de42c280d3281a40a123bb7b357d3042b1702bf7ca3eaa1f399d4acf70b6ccd0"
+    },
+    "music/track29.ogg": {
+     "bytes": 4546696,
+     "sha256": "d550d111d4c26d25c9d24780dd93b1e22e8dccddcaa6a70df10520352580284e"
+    },
+    "progs.dat": {
+     "bytes": 330426,
+     "sha256": "d009e79f43e89896888d5b0478ea8f55192acfcefd432e0a0ba3eeb8602d263a"
+    }
+   },
    "sha256": "6e2b420de1a96ac2e3eeb582e8f2571433f0ed772a2b6f3cc64970e8b2fa9368",
    "timestamp": "2024-08-16T19:53:08.000Z"
   },

--- a/json/by-sha256/f5/f56997aa143e503e08a20b840563851075da39f583a42ae42eab9f35a9782a4f.json
+++ b/json/by-sha256/f5/f56997aa143e503e08a20b840563851075da39f583a42ae42eab9f35a9782a4f.json
@@ -102,6 +102,420 @@
   },
   "starslave/pak0.pak": {
    "bytes": 11231782,
+   "files": {
+    "demo_c1.dem": {
+     "bytes": 1854820,
+     "sha256": "8b93e0384ac1505dde19d24a2e337686c065a43da8c8a476bfdadbfdc621928a"
+    },
+    "demo_c2.dem": {
+     "bytes": 2445116,
+     "sha256": "4e4ab2f099e5746565cd19e5695a35cc1252c24d8817b5c8670c1792c187097f"
+    },
+    "demo_c3.dem": {
+     "bytes": 1808204,
+     "sha256": "71476830e6d475ff8bb66fc8f07da76c89f407160ac26ad1ccfced0d6e7e80e2"
+    },
+    "gfx.wad": {
+     "bytes": 152468,
+     "sha256": "50d94651f3e0b0b6a29e0110ce9ff260c9f3114060b08b6d1ae19054b8024335"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4712,
+     "sha256": "4d751e2308e5d7a78a3d011c66677ae66f5df06b19a52c2fe4412b783da97035"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "92458c800796c9c7a460bdd4a387dd6271e8fb3865a390d0c91862ad5fe307b0"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "8e1160429fbb7be0aa5c5e5be84156ce9b74e3fcbc5a8c23ff54a51ab0f68224"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "31c4858fe496187dc1bac21c02aff8cf83cbc51e0b4ee5738d6118c328b299d2"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "ed0f79285d93d0ef35644ecaf9ab36f3b2c6ffd223c577b25fff2ea17f90080d"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "e9c210ab88f6e98965cd2f8470f084e32ef15b3ad3912cb1e9eb0363c6204eb7"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b56880e2f720a89dcd055f5278abb21a21514322d4a31b77b46c8b509b9f3be3"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "89c3ac6fd91cdcf15c20b0d15b4c01c153e0a820c660f9222b5c8f63d43af5b2"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "8b83ffaf6b5309d371f0107ebb1340a8a09cd1a52c6a5581b7c9c4a7afcefa77"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "4d2891882cdba6782c02fda1e0d49a1c802a0734e35ca88a622dcbe4c334991e"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "e41486d3a09da5fd4aed2d208d75e24fbf41d97d9342da9ed666d26a72483224"
+    },
+    "gfx/menumods.lmp": {
+     "bytes": 1688,
+     "sha256": "f08579557ace0d3b64aff6cb1bb37ec10ed0e8f050306f1634937c001ea9ccdf"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 4424,
+     "sha256": "ee84f65a4e9ad4eb166c1790da9fd586fa1237f5400adc08b7656fe568304404"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5096,
+     "sha256": "89477de79105b07d6a1dadc9dd422cbbecbdd220454bd441cf11f5fe192da1b0"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3560,
+     "sha256": "65fd24aed5bf14ab961166cae2d00884583d624b926a46fdef83df3131fcf856"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 4136,
+     "sha256": "ba9faaa1c655cdabbb784cbb3381ffe28f30c601d3020de2e5cf6cfa9c49be6f"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3176,
+     "sha256": "0aa8e7c90081b1ba9809ec2cd30e7d90c99935fba6695ecc6016930c812e1cb5"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "59bf5a3808277804b94785434ef43eadf20ab9283109fb43bb2c873223029da5"
+    },
+    "gfx/ranking.lmp": {
+     "bytes": 3944,
+     "sha256": "e5c4ae88295fc0fa9f383889a1982d23c3c466475a8d67bf422d20a470d25fe5"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4328,
+     "sha256": "b2b6ca588b19f79bc58b41c2acf5c66e23e5c8d6fa347a2f272ad1962bed0ca9"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 4136,
+     "sha256": "a2810c03c5f1f80dfdcf2d575d479d699f8f756d9a2b5ec63694026b3ac85cc7"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 2984,
+     "sha256": "8362ba05650ecb9ae971f76d7d40815b563c0d67baad80f05d29c282a58989de"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5096,
+     "sha256": "f62b7e48be71999d6ae8dc675529a30161524f3288c80e96a6c98b2536acee46"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 6074,
+     "sha256": "ed9f5c7ea499924e02196aa9b68725d0de17c10dc2194956525397d95c6b0d19"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6074,
+     "sha256": "80a4dc9ca61773cf48e71a9971e0f6fdf006a35fef652d3506dbc4e90fd3e370"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 6096,
+     "sha256": "e1e0409af59b435c1483b73c5b5e20018ac66c5ea49902b4643c6a98def8c95a"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 14948,
+     "sha256": "b35da01b7f3c123321e643d80988f0dc907e2659a594a990f09a77eeda14ce9e"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 10316,
+     "sha256": "cc59af1abfe2938e90f72ae6689c22f7bec2e4328e7e383be3c676a0a4d4746c"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 6074,
+     "sha256": "4c78fc9bfa06b04f4498c23676f4aba6d566e7f020d68045a8cc050e3bbb6b4c"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6114,
+     "sha256": "2a33d438a9e6203b5405fa7b8369b7dfd6578f373390a29f508e6ffe1b9c6480"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 8794,
+     "sha256": "6a53f0e3ddb5e0a2da0b3f2362fef221526048263b14666276bb7e15f528d88b"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8794,
+     "sha256": "317f412b80232110cab77c3618287ccc5639c38d67fa1932849560fbe1a0832a"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 6074,
+     "sha256": "9d146681e71d20bde0e988fec2852fac0cc9ad008eb9269f1be5082bea82d2a2"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 6074,
+     "sha256": "8a73f7a255b397defb49ef3f75ae8878674099320d23b15611c07fb55712f354"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 72688,
+     "sha256": "b4695368a9d346714630a3b2d51d2fbe2ac1725d80786b94054e896acd6e712d"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 11860,
+     "sha256": "53f30fa59ab0b943d850851a05ed3bf7c8209ac74136ec1016a1ffd0c9305e47"
+    },
+    "progs/candle1.mdl": {
+     "bytes": 38652,
+     "sha256": "031b4a2e2dc636190b3c21baf3e273fd61363ba9d1722189ecb34b01ae8f4f5a"
+    },
+    "progs/candle2.mdl": {
+     "bytes": 34764,
+     "sha256": "e888cd4c3bc3dc2d73262715df5a1ae95f5802dca17ecb92cee8954cf47685b9"
+    },
+    "progs/candle3.mdl": {
+     "bytes": 30876,
+     "sha256": "629a661b9ccce457fa31ed2c6a2c085386324846f8b36fa16196bc108405a236"
+    },
+    "progs/debris1.mdl": {
+     "bytes": 33768,
+     "sha256": "3498dffa0c3522b011a76ada880dfae64de3ca1583c94474e1e07adbc220d981"
+    },
+    "progs/debris2.mdl": {
+     "bytes": 33944,
+     "sha256": "d6d535173bb4a3a2d469be9c63bf36a01b1e2b80dd6a71636d20178d813e443c"
+    },
+    "progs/debris3.mdl": {
+     "bytes": 34136,
+     "sha256": "d6b0a2b6353c4462196d2af116652b47d464a7bc1f161509aa8ee5dbe859f98b"
+    },
+    "progs/fish.mdl": {
+     "bytes": 81900,
+     "sha256": "f07ff4b29e37e23633243a4eaab71746f9ce0032253902c3df5bb01e122fe2b6"
+    },
+    "progs/g_axe.mdl": {
+     "bytes": 17812,
+     "sha256": "74cd41d8d5a67570cdaca34a08e9868f3476d8c4ac4a645cfaf9e91cf778c793"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 24580,
+     "sha256": "da07d432363ddd8cd709b4ab92e72b22f9b47fe756079fd6627e2c49c36fa0c1"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 22624,
+     "sha256": "bd30397e619d63f4affb8a2705db1585fa71b9fe78cbdab5d10864fad8e8067a"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 7656,
+     "sha256": "4f5ca2553db07d5cc93987b11e9f9ff054d51b96488e2bcc35c9f03ed3040d42"
+    },
+    "progs/h_zombnm.mdl": {
+     "bytes": 3220,
+     "sha256": "45d9dfe5683264edf6f6eb7b8e8d794f84caeb8701e65e8ebe9add2192bbb6fc"
+    },
+    "progs/invis.mdl": {
+     "bytes": 8356,
+     "sha256": "b00951cd72bb5fb03c19a1d60943162652fe149b9ee60fd2e630a076d52956fb"
+    },
+    "progs/invul.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/k_spike2.mdl": {
+     "bytes": 17716,
+     "sha256": "e456eb93934dab43a83305988db82ab1954e66491c256fad3ef1451d0ecf97c2"
+    },
+    "progs/knight.mdl": {
+     "bytes": 248832,
+     "sha256": "44cbab80ebc90ca4002e557eba242c8a79b4a602b87495755080b34610c40c8c"
+    },
+    "progs/lavaball.mdl": {
+     "bytes": 17312,
+     "sha256": "e210fd2f442b52446e3ed97dca82b74e99fb82b5e8e27021f227a9823af3ac8b"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "78360ff39323844dbe5466352285c25caa3d8280330bd7b4896cf5d9c3acd1f0"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "2f4df619cf3c3e55551d62caf70afd2130799cb8961a5523e4cda62de9ec0a0f"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_key.mdl": {
+     "bytes": 36496,
+     "sha256": "a001c379917628354adfb62b698856b33f4eea5f22e7d8e232e640faf15d8465"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "ae9a34463a8ec078b834751903807b7756b08fab9b57d7a7267b2c6686090508"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "818e721ccad82186459530b0390c29e9a78084b578997586dc3c93cc788a8f68"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "23d073419f924f063073342414d62b7047d7ecccb86e2e1406e924d514b9394c"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "7b4c5c14815e505ac8add0eb013aa98afd5de896fb3119883a411203910f2c7c"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "a69c6351bdfbdc30aff19de93e9a006dd358671902bcc86053927d30fb284949"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "ada62e18c957c319cd377dcb1c9586235b790ff8af2d22c580ea9b5c419f2868"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/r_key.mdl": {
+     "bytes": 133936,
+     "sha256": "e2d6b9de9b879327f72d97ef3c07e0b7e35cf844747208f6e615015be84157e5"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "f414f3fd07b0278bd59dd90954770f81a5ffad7f46af5f5d0abee124905dcc17"
+    },
+    "progs/spike.mdl": {
+     "bytes": 4572,
+     "sha256": "993afdf2aaa055ee7c49cc9066a6a8d09d5d309c2694ac46911386f159b63316"
+    },
+    "progs/v_axe2.mdl": {
+     "bytes": 70932,
+     "sha256": "feef26c08c17e6e9bce22bbe8187d345b2956b81f6a7754e389c0fa53d5b4bb6"
+    },
+    "progs/w_spike2.mdl": {
+     "bytes": 5816,
+     "sha256": "b07808c532059133c31be2ed2bc4e9bb9b01b75d5d23401768058cacc3192068"
+    },
+    "progs/wizard.mdl": {
+     "bytes": 74976,
+     "sha256": "545d70abb8d44be8e12da24a3d09fb56f87ff960c41963148682fbbd9d47e417"
+    },
+    "progs/zombie.mdl": {
+     "bytes": 218680,
+     "sha256": "6782603eadacc7cb4bd09c11d3b6326e0d2e69205f724fe2f6e533ee398f5a16"
+    },
+    "progs/zombienm.mdl": {
+     "bytes": 224900,
+     "sha256": "f4d1ce9667ebb36088bfb59a12c9a8d93c1aefa36515b51f388cffec5132f5b2"
+    },
+    "sound/ambience/deep.wav": {
+     "bytes": 401112,
+     "sha256": "3b1c3809233d1bae1196d84db821f401c4e2432ae752a8a4bef2bd4f17e644ce"
+    },
+    "sound/ambience/lava1.wav": {
+     "bytes": 837582,
+     "sha256": "dbaa7dfb1b05df1eef0961b629d8f886899b8499bf595ea001953b10606c66cd"
+    },
+    "sound/ambience/machlp2.wav": {
+     "bytes": 70696,
+     "sha256": "76d173dc724fa0752a345d4d0e406cbf1a38de5675e295ca2dfc81e96e0c016d"
+    },
+    "sound/ambience/underw1.wav": {
+     "bytes": 208538,
+     "sha256": "f8672e5e772aeac9bbc1030aea58088daf1b10ff0a580346ca4208b58861139e"
+    },
+    "sound/ambience/wdribble.wav": {
+     "bytes": 40960,
+     "sha256": "78a0e3a9620e32eea4f6883f1c3bd0ec547007adfaabd93bc1a1e0dd947daec2"
+    },
+    "sound/ambience/wpool.wav": {
+     "bytes": 301220,
+     "sha256": "51a27a6489c5e016a90405e7fe295b495d56c4129010b428ee297cd4f34fdd89"
+    },
+    "sound/blob/idle.wav": {
+     "bytes": 64986,
+     "sha256": "1849fdbfd0a68b07c52d6c21b8f97737577d99270a2eba61a9cccba071239f35"
+    },
+    "sound/boss2/sight.wav": {
+     "bytes": 144484,
+     "sha256": "197e2d357ffe1a4c885b67af9335982fc7795e07ad6052d966d328ae5848c37f"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/locked5.wav": {
+     "bytes": 88280,
+     "sha256": "53c39154bd15246b0dba8f901c79d525a84d45dcccc26e59e23450f2c5c0ed20"
+    },
+    "sound/items/pack.wav": {
+     "bytes": 17740,
+     "sha256": "4f1df82518beee326068e407b6713c32c4b40fe4a99ac94b9be0ca46c107810f"
+    },
+    "sound/items/patch.wav": {
+     "bytes": 19934,
+     "sha256": "4ed1112921417e18e4ceb2cb29b8f0702c945c2bc2e37403fefca19b069d8f17"
+    },
+    "sound/misc/null.wav": {
+     "bytes": 2322,
+     "sha256": "7883f17ce0a86489a7abfc3319b434a60b911bfea999287aec290747952e61ec"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 16616,
+     "sha256": "2a9f86b5f5497822ce5379a05a51ca1816d2471b463ed57635c57dc5702f0eca"
+    },
+    "sound/misc/w_under.wav": {
+     "bytes": 39884,
+     "sha256": "e441a7c33602470db85979142cf0b90166ddeb9f51949a33fbab3998ee1e31e5"
+    },
+    "sound/misc/w_under2.wav": {
+     "bytes": 72616,
+     "sha256": "46d386334de7dc588df6a1f21fc946d8cd39823355b1c59be9eec88183c5b03a"
+    },
+    "sound/player/q3fall.wav": {
+     "bytes": 180380,
+     "sha256": "78ba213bc4972ab6c3f4780690831a6c1da52ca0af444be8ecfc798f45d1f347"
+    },
+    "sound/player/splat1.wav": {
+     "bytes": 36960,
+     "sha256": "49cd19d55a52c31eafe58bf89fde593a6291183ed6e989078b6299c9bb0071ea"
+    },
+    "sound/weapons/axhit1.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit2.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/lavabal1.wav": {
+     "bytes": 26504,
+     "sha256": "a78d8242c12c89304b3a95ea17a9a5743de893e20d7f82b1a75bc08aba045abc"
+    },
+    "sound/weapons/lavabal2.wav": {
+     "bytes": 26504,
+     "sha256": "5c9ed5f64d2d830f1345509ec3081d80f88dcb9e675259e6cd75cb06bc4a8984"
+    },
+    "sound/weapons/lavabal3.wav": {
+     "bytes": 26504,
+     "sha256": "f879dbe8f2e3ac5efe02e8f785c7dea5d8625f96b1a0f5f68e30d0e5a6e61bb6"
+    },
+    "sound/weapons/lavabal4.wav": {
+     "bytes": 26504,
+     "sha256": "96c334d39b9faacf611bf069e724564ee31bfaa4e2db007baf3b024aa4f3a675"
+    },
+    "sound/zombie/z_res.wav": {
+     "bytes": 23266,
+     "sha256": "10b2962ce2817fa8a250811313307cf0dfa93ad5257a669452fe3fc834ced976"
+    }
+   },
    "sha256": "14a746abb95d03032dcf07202d9470cbc450c69a2a713d3a80bcdaeabe4262af",
    "timestamp": "2023-10-31T11:50:00.000Z"
   },

--- a/json/by-sha256/f5/f58f060bf8c1fb27912fba10dcd348c65d940f52d2898ed26b091170029aa56a.json
+++ b/json/by-sha256/f5/f58f060bf8c1fb27912fba10dcd348c65d940f52d2898ed26b091170029aa56a.json
@@ -7,6 +7,60 @@
  "files": {
   "PAK0.PAK": {
    "bytes": 3269870,
+   "files": {
+    "maps/tef_sc.bsp": {
+     "bytes": 1082456,
+     "sha256": "daac611f2fe0a14d2379e1b3ed6fd339f672c1f5eb939316482b7bdb9641150b"
+    },
+    "maps/tef_ww.bsp": {
+     "bytes": 1238048,
+     "sha256": "6f78f060cde00816c88289705958c5e11045ad034ba2ec4086b43aa28ce6b07c"
+    },
+    "progs.dat": {
+     "bytes": 457088,
+     "sha256": "18c4aae735f4e974c0e379622dfd30ceb9266b7c2aaf8cd645418b1a3d1c18d4"
+    },
+    "progs/manga3.mdl": {
+     "bytes": 96256,
+     "sha256": "81bb691947f88dda5672ab1e1af689098d08a9b5bea9d31c38197db909fe3b76"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 132028,
+     "sha256": "8824603b325f37bbba424f55c3ff900c21ccf61c77ba97e636e91ef99202364a"
+    },
+    "progs/spider.mdl": {
+     "bytes": 94492,
+     "sha256": "df40e58bdf6465e68e5ef33cbcb77c42cc99e50c9dd842c8c3906c2fd04bfc8f"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "744af1fafaacb751cf2e5ce4bb15a0fc1fb938ae519469de6f0dccfe9f320414"
+    },
+    "sound/died.wav": {
+     "bytes": 24492,
+     "sha256": "3ce14cdac970a150f567dbd07cf1763f695245c34f5bf4e31ec07bfeb232db30"
+    },
+    "sound/ha.wav": {
+     "bytes": 2708,
+     "sha256": "ba2108ad5070860873887308293efd3a9635a6c4dcb3fb39357a9e16f89f97b5"
+    },
+    "sound/hiyaa.wav": {
+     "bytes": 36876,
+     "sha256": "1446e8afbfdf48a08ca6727604b33585efdd67a6d14b4b1c96bb05c6ccd5ac3a"
+    },
+    "sound/kungfu.wav": {
+     "bytes": 29008,
+     "sha256": "025b6eed19d193bd6be4c4f8f2bc7b9fb14e5c127257e570fd9fc98fd464f2a3"
+    },
+    "sound/ohdju.wav": {
+     "bytes": 12588,
+     "sha256": "346d38c12edad612ec4915d3361ebfbb81b06bee9cdb73eb9b9e0d2cc2ea6d10"
+    },
+    "sound/tchak.wav": {
+     "bytes": 10166,
+     "sha256": "f77d88ab76f7a092a7a5d40fb0aaf9530dc6da8e45559fcf1a1b5ea2aa88029b"
+    }
+   },
    "sha256": "ce42338d172bb7d7cd2f54ebff95f8ebb3f794b300abb9ef7a67f470084c32e8",
    "timestamp": "1996-12-02T10:31:32.000Z"
   },

--- a/json/by-sha256/f6/f6491b937a65f12bdfb66b041568a1efaf3fd0f08ee7f69b3255dada38779c48.json
+++ b/json/by-sha256/f6/f6491b937a65f12bdfb66b041568a1efaf3fd0f08ee7f69b3255dada38779c48.json
@@ -12,11 +12,107 @@
   },
   "pak0.pak": {
    "bytes": 17560716,
+   "files": {
+    "backstein1e_readme.txt": {
+     "bytes": 10447,
+     "sha256": "186d81dccb7e0bc2ef1f30328e0647b26682980b855b207af597d3e001f6293a"
+    },
+    "maps/backstein.bsp": {
+     "bytes": 7228084,
+     "sha256": "c0b0c952c9937a04670c4d31b635d770b282b8a0f9a1115994a2db3ea24ee5f9"
+    },
+    "maps/backstein.lit": {
+     "bytes": 2795678,
+     "sha256": "82cf67817360aa213c2a94bfafe99c3982b3347a20ba68bc777b3bf0088fac15"
+    },
+    "source/backstein1e.map": {
+     "bytes": 6980123,
+     "sha256": "52031ecc598e94b2aa4ce31e19573196e99b01d32da682f237f2c3ef87c425ba"
+    },
+    "source/brickston.wad": {
+     "bytes": 546052,
+     "sha256": "31f8d4c7390de553f4dc7d696382f2c04d46af0231edec162771d1480a5a72fe"
+    }
+   },
    "sha256": "fe28c3817a620fa4d50a6a492a7f01c13734b2a9a086460a2dca51fc1eedabf3",
    "timestamp": "2013-07-06T09:23:30.000Z"
   },
   "pak1.pak": {
    "bytes": 169495,
+   "files": {
+    "maps/b_batt0.bsp": {
+     "bytes": 6980,
+     "sha256": "0d481a2e2cd7a23e4ef19c19622195007bd6c9a67135ef739b0944a02d46fcd7"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 6964,
+     "sha256": "34709c1c06ca34305a8ba1d4799d1cdc07e44ff33f3c7fa11c3d5933cb942579"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 7124,
+     "sha256": "d3371655bed274070fa98fb32b408bab4a22fe754f5158c8c94a072749a5d24d"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 7764,
+     "sha256": "abdfe383c13da6d5dd7a9409fa5d3db2c4bac78482eb75c2c2b42da7811ec3ca"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 8788,
+     "sha256": "2343448faac29720e3a690650b70623852710dcae002917ae5772fa597117e17"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 5604,
+     "sha256": "66ea23f1cdd6225afdd1b7cf1247b93d174562193e0807561b96b659429f2bf0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 6820,
+     "sha256": "366ece777ae71ecfebaa9f4bebafe2074b5336e7939900f46bd9521886f9f42d"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 7092,
+     "sha256": "56a66aa3d1364a0436ff8ce880268b2a9c2c396ab02f0c6277535d5b99eae31a"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 7636,
+     "sha256": "ddd60cec57d8e3954c1ffce616ae862edb784417a6b6622cc001d408383a6cb9"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 5396,
+     "sha256": "fe60bd7880da73571e29fa4075968cccb06e913bd2b9475868ce31c69b1a8c19"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 8436,
+     "sha256": "6a2c2c3fa6f88d425ae5b9568e5d8224ee901a1d8faa8363b88fff569b7d0e5f"
+    },
+    "progs/end3.mdl": {
+     "bytes": 19700,
+     "sha256": "445af16e28fff506ad65fac16b09dad1672e218ffe0183880aff565578b315b8"
+    },
+    "progs/end4.mdl": {
+     "bytes": 19220,
+     "sha256": "cf52525422a102760bfcabd6e8dd5c5df7c2028daea5baa2a1b1717648dd143e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 7108,
+     "sha256": "d4c5b6316aa02d600951c6a8ec1f4682568b9e877e988cf4cedd77c0e95cf663"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 22052,
+     "sha256": "c5657b558522e46f0833b7827520c1a5c1f1674dffd52c12609779d5bcd75462"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "quake.rc": {
+     "bytes": 1319,
+     "sha256": "23d89f55c4aeec778b24e215ce38088b1ad23525c006f09a18ea433d93a03380"
+    }
+   },
    "sha256": "7bc4e8cab0d82f3238f5ed8e70255890da9e43da96184cbff0a74aecfd1f16b5",
    "timestamp": "2013-07-06T09:23:32.000Z"
   }

--- a/json/by-sha256/f6/f67acde1d256af2f04deeb467e7f7c505dfb74caffdea40836f2445d67eee132.json
+++ b/json/by-sha256/f6/f67acde1d256af2f04deeb467e7f7c505dfb74caffdea40836f2445d67eee132.json
@@ -17,6 +17,84 @@
   },
   "nihilore/pak0.pak": {
    "bytes": 6204172,
+   "files": {
+    "maps/nihilore.bsp": {
+     "bytes": 1909264,
+     "sha256": "4daf11641097d07970bbeb86e37f39259f4bcdb935f832bf7cb7f8fed5d57b7b"
+    },
+    "maps/nihilore2.bsp": {
+     "bytes": 1972244,
+     "sha256": "3d522d0e926dc11c2866f873a3369a3162691826c46d365881e1debe8fccc877"
+    },
+    "progs.dat": {
+     "bytes": 748384,
+     "sha256": "1128f420513db0961b46c345a901398ec411ca093734b8da9df1133415220773"
+    },
+    "progs/armor.mdl": {
+     "bytes": 44076,
+     "sha256": "0e16c3f0ba370dbb172af676540ce2f4a58b151d8a6dd10c1c353748257c82d3"
+    },
+    "progs/beam.mdl": {
+     "bytes": 10608,
+     "sha256": "2165a66ba1d40fa378df735835b014791e769cb8bc56e06977aefdf134bb61d5"
+    },
+    "progs/beamhit.spr": {
+     "bytes": 5320,
+     "sha256": "bdfe3464c0bea904c3d35135b6d242f486298447ea45c3f96cce7ac6b71a3e54"
+    },
+    "progs/dring.spr": {
+     "bytes": 387832,
+     "sha256": "94adc8ada163983eae9ccb924bd4ef4d8ebb2613bd23705d2e8a7bb73e7657d1"
+    },
+    "progs/enforcer.mdl": {
+     "bytes": 218412,
+     "sha256": "8c376eb7c9ff2ef3698105178b57d2d157cbb6790312d560864ae1a00766b05d"
+    },
+    "progs/expl.spr": {
+     "bytes": 127672,
+     "sha256": "553b80901ee3d765c147ecce187a53989ded3991532e02f53c5b0cbb42aad5d4"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 18400,
+     "sha256": "d050647124b27e773ba04aff2ec1e2ff3865099124b7f113d414b4189ecee776"
+    },
+    "progs/h_mega.mdl": {
+     "bytes": 22168,
+     "sha256": "d3440a84d4f62b19a9b7635ba50fafd047fb5c8360898531e80628dafc3010a1"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 218888,
+     "sha256": "15008aeb2f80eee0ba4bf113d230f5b115fa2157724d9727b5f3988cf9430983"
+    },
+    "progs/s_null.spr": {
+     "bytes": 1080,
+     "sha256": "f953c35ad78b3d16f9f11281d40349c6b1699d78ba123eb13add4c4262eb64c4"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 320900,
+     "sha256": "03564bf6702e4a228fab341f9ac649a294b61bfc86a377c4c85e7bd7e94260f1"
+    },
+    "progs/v_beam.mdl": {
+     "bytes": 75588,
+     "sha256": "c00fe7872cb2c88626e63d99c3cc00b83f9968803344cd2021e8fc26bd25ccba"
+    },
+    "progs/v_beam2.mdl": {
+     "bytes": 75588,
+     "sha256": "95b3a260450ca784bda0885da994a5a857cf9948581ed1e68c4b202c51dae670"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/turret/beamchrg.wav": {
+     "bytes": 3962,
+     "sha256": "d02bd7d2c4754fe3159fac83b4f0898f8b2e1f8996ce7e6cfdaa4a9d75a24fb1"
+    },
+    "sound/turret/beamhit.wav": {
+     "bytes": 8644,
+     "sha256": "35e5e5f28a3695ed27c2b0887a1bf118643d769c457d3642016e887248fa8ca9"
+    }
+   },
    "sha256": "3c6e83eda9221ef6c749376fb61f0e8a1515398120e039adce931fad3d6c3e94",
    "timestamp": "2002-05-31T18:38:58.000Z"
   }

--- a/json/by-sha256/fa/fa8d9d642cc16049190dc5ae74e6b44b4405699377384d194503e1b4f4d0d569.json
+++ b/json/by-sha256/fa/fa8d9d642cc16049190dc5ae74e6b44b4405699377384d194503e1b4f4d0d569.json
@@ -7,6 +7,60 @@
  "files": {
   "babel.pak": {
    "bytes": 1286781,
+   "files": {
+    "maps/babel.bsp": {
+     "bytes": 550372,
+     "sha256": "67a4a2767d4502430aa2540495fd8beda07a5ed995ad7db9aeb1816d8397f2b8"
+    },
+    "progs.dat": {
+     "bytes": 425632,
+     "sha256": "7f1d8008cc8843ebe9f5ead1f9c746f0216881a6805641a9205d9531afa4c73a"
+    },
+    "progs/cyber.mdl": {
+     "bytes": 84708,
+     "sha256": "6e2fd875956e03ea76f16bc69a43749d87ed2e8216a8653234792b8dbb9fc1c2"
+    },
+    "progs/h_cyber.mdl": {
+     "bytes": 60824,
+     "sha256": "53539bc39fc87627a46b75b0d86ade5e6116a0079b032b1df137b2425b7186cc"
+    },
+    "progs/leg_gib.mdl": {
+     "bytes": 33184,
+     "sha256": "210e159ea4c9bf1f2431213fd95902f4ea75ecee6a67a22bed7e93366f1f2732"
+    },
+    "sound/cyber/boom.wav": {
+     "bytes": 15692,
+     "sha256": "72e737f04f1d34044dfd812c6b0e233cd38a91e6b089633e312678756952de87"
+    },
+    "sound/cyber/cybdie.wav": {
+     "bytes": 16625,
+     "sha256": "bd4cd7902712282ef8f2f749e6fcf805c2ac5212994fbb1c22fc0fe0ea5d08e2"
+    },
+    "sound/cyber/cybfire.wav": {
+     "bytes": 15527,
+     "sha256": "0b472a984137667f4788336a4f7c60e07a8893f47317b2a158aeea39920d729f"
+    },
+    "sound/cyber/cybhoof.wav": {
+     "bytes": 4107,
+     "sha256": "8fe56b192838dafdf7ff4737cf1e5555d3295cbca49c1ab83568281ee188153c"
+    },
+    "sound/cyber/cybmet.wav": {
+     "bytes": 8122,
+     "sha256": "3ea23b8d7a68e754211a10a5338b0c8d65df6e2138d4cfe06cc053b9a0f601ae"
+    },
+    "sound/cyber/cybpain.wav": {
+     "bytes": 9555,
+     "sha256": "ff30aba221d16a42d4aeeef69ca416ba76b5cca5ecbcb328cfe38e2377fed6cd"
+    },
+    "sound/cyber/cybsee.wav": {
+     "bytes": 13081,
+     "sha256": "a5ec6d4eaa707ad0246b7a7e7737b1007043ea5e5634f6f63661ecc20c27c459"
+    },
+    "sound/cyber/servo.wav": {
+     "bytes": 48508,
+     "sha256": "b7aac875623f8dca7597eff3dcab5910453d043fd1f9df20da89232ce8bf9306"
+    }
+   },
    "sha256": "eb68fc639a6252c1eb07664c99c8326efe897c3018af692fdd7868d84cce50a3",
    "timestamp": "1996-10-27T17:43:46.000Z"
   },

--- a/json/by-sha256/fb/fb4d8cfc80075737dbef6b9cb3cb5e8c5169826c1fb8f3a24b3cf36068319fd2.json
+++ b/json/by-sha256/fb/fb4d8cfc80075737dbef6b9cb3cb5e8c5169826c1fb8f3a24b3cf36068319fd2.json
@@ -153,6 +153,203 @@
   },
   "modjam2_4lt/qc-mod-jam-4lt_src-master.zip": {
    "bytes": 117195,
+   "files": {
+    "qc-mod-jam-4lt_src-master/": {
+     "bytes": 0,
+     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/.gitignore": {
+     "bytes": 20,
+     "sha256": "80e26a4cf037eb447a55423dc11f1610abbad5faffb6599639bad0bef5f2af61",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/4lt_math.qc": {
+     "bytes": 2926,
+     "sha256": "75d02e6a95d26c85c9107c07aded4b0459874bf2647e371c6b3bdf1a118bab08",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/4lt_turret.qc": {
+     "bytes": 12011,
+     "sha256": "69f81f2c9ecbe71950739e874ade53d0c1473d71e30886f35c13fbda370f4482",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/Makefile": {
+     "bytes": 586,
+     "sha256": "9f6485abce1b63bcdf80b25e311639575d320b59b538918865d590c5295409bf",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/README.md": {
+     "bytes": 1372,
+     "sha256": "ddcebe4766e1a25c0684d9df4a4a50f1fba72551719ce79da66e6405d13afa2c",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/ai.qc": {
+     "bytes": 15161,
+     "sha256": "23b5fe699b8d8e140849c5d3c920235a94b9c307808157f6ce8b93f3f16d64c0",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/boss.qc": {
+     "bytes": 12796,
+     "sha256": "f2b1278d61487f6333b919f7d3bd74f722a177b43aad2535cb15694965bc7932",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/buttons.qc": {
+     "bytes": 3021,
+     "sha256": "cf5562557d39c41db2f6136e507e6b95d9e3efa0a6af78df08f6749706091a2c",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/client.qc": {
+     "bytes": 34383,
+     "sha256": "23ff6c1163231e4e9a6807ec1171c69d2e17ef292ea95aaa79b0579855597e30",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/combat.qc": {
+     "bytes": 6646,
+     "sha256": "e5da0f2e6beaf4c9f1b3ecb73a643add9d3b95f286852589315040b9a77e886b",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/defs.qc": {
+     "bytes": 18095,
+     "sha256": "bfce1470264d171c2f9cdc56a04af5c1e7c2db943ecdcc48aadd1050ea36633d",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/demon.qc": {
+     "bytes": 10244,
+     "sha256": "2e7d48522aaef30686e78338b11f00fc3a57841abed60a23aa5677105e89adc9",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/dog.qc": {
+     "bytes": 9911,
+     "sha256": "e320ce8aa965d636f887acc89cd4a69ca1e431a15c7907ff35dff5d57d5e5d53",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/doors.qc": {
+     "bytes": 17921,
+     "sha256": "84671dbf67df1e0299db2c3b25844abca4e504206eeec7cc959c9229eea21b42",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/enforcer.qc": {
+     "bytes": 11080,
+     "sha256": "05c437d4c64b2d5c0138e611c75b70e5933eb524371475c38834ab0359e52f2e",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/fight.qc": {
+     "bytes": 7568,
+     "sha256": "301de69f7dad8a34fb361ab90e2a907c62b4633c7dde410b9e4bd6b81c017500",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/fish.qc": {
+     "bytes": 7939,
+     "sha256": "5573f8dacf3f6d7a2821f881cee90aaa1f2bbf7bc59395befa3a1a63173aa31a",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/hknight.qc": {
+     "bytes": 18738,
+     "sha256": "44672dd9d98aa42e48192cf2d6a0804413d04531341d713cd87d7f8ac85ab650",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/items.qc": {
+     "bytes": 29697,
+     "sha256": "0642cc55f3dbf277a26a606d37d47b5f40f4075b1140a45fee76773cd91cc956",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/knight.qc": {
+     "bytes": 9954,
+     "sha256": "0d74091b6b711228d520c1df2bea056f8d5f90b377f67613167d482aab23a077",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/misc.qc": {
+     "bytes": 15735,
+     "sha256": "cf235c259b81f675f4ebc2f890514e34e2d84e76385159e883037ecea650f6b0",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/mj_4lt.fgd": {
+     "bytes": 19727,
+     "sha256": "22395c5fbe35b5a411f18495a8a43672237336641ff9bf2904a219fe6d4b08b1",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/monsters.qc": {
+     "bytes": 4914,
+     "sha256": "9e0382bb03be8632b0368b82219fbee29fe2295139784127e3c94f64bd910310",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/ogre.qc": {
+     "bytes": 15176,
+     "sha256": "ff0f64a47ea239c2100cba4d33b6c2a57325e4c75a5ba6e389d8a3c35869a3db",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/oldone.qc": {
+     "bytes": 9965,
+     "sha256": "8cd5e6e13a2450362a1e3810873bcc238396de894465fcb9734b1cc71900d0be",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/plats.qc": {
+     "bytes": 8036,
+     "sha256": "e217fc3324ea009539884b995ba666b53d4bbb8dcc9214a0b6ec8a40f01f706d",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/player.qc": {
+     "bytes": 18712,
+     "sha256": "18a7d377e022f68ece064dcf42fcbfaee3c11b64fc72b1cfb6ff28c552b8137c",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/progs.src": {
+     "bytes": 488,
+     "sha256": "7ded061abccc6c1b94bf0b8391dfc6b031d815b0f12f00ad3c6ed73b63eb5737",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/shalrath.qc": {
+     "bytes": 8177,
+     "sha256": "19a79584ac48758965a3c52e7a1739ea634bfe7b56356753021d5481407e9fd0",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/shambler.qc": {
+     "bytes": 13092,
+     "sha256": "0c0275940fc2857186c656a9380d3ca91272150585994ab8432f5fc10a82ea41",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/soldier.qc": {
+     "bytes": 10109,
+     "sha256": "a331742f9022e5ba548af65e4c49c696a9a015d641ade494e3025590068a536c",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/subs.qc": {
+     "bytes": 6376,
+     "sha256": "ac977e10b2348a3675a25f3a12ddf365be3c885a71fba421d30cc22acad7551d",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/tarbaby.qc": {
+     "bytes": 7338,
+     "sha256": "f9109dafa4af8c4ed8733f317bb6151f1672fb7a374abb2fca6b9e710fbe8144",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/triggers.qc": {
+     "bytes": 14859,
+     "sha256": "f67690567b2918cb57f79e6da0b8b7b954e834fb6b5ffa8eace485b50815a334",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/weapons.qc": {
+     "bytes": 26462,
+     "sha256": "164c52ff1be923d2fbb3e3d2922286322da71fb27be4e596208dfd47d0d58aec",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/wizard.qc": {
+     "bytes": 11072,
+     "sha256": "6dc95cca764693a3962d6a9b3a4c26fbc6a77e3c79394550c1314bdc761f2ccf",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/world.qc": {
+     "bytes": 11430,
+     "sha256": "7820b99133f1a238645edcaa59cd0a9dba0dba4c81db81f0a88a68511dde1d61",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    },
+    "qc-mod-jam-4lt_src-master/zombie.qc": {
+     "bytes": 20616,
+     "sha256": "7eb669f6d9abda9ec4c8dec9be6dc37fa76d5647054920e01d24d5776425dda7",
+     "timestamp": "2022-01-25T15:03:08.000Z"
+    }
+   },
    "sha256": "874728bc7ec328a150d778b1acee34b6412f226842fef237f4c08dab31ac10df",
    "timestamp": "2022-01-26T00:50:42.000Z"
   },

--- a/json/by-sha256/fb/fb587e766029383a479379bae6be00e14d975361db2a2d34d50bbcf04f21f958.json
+++ b/json/by-sha256/fb/fb587e766029383a479379bae6be00e14d975361db2a2d34d50bbcf04f21f958.json
@@ -7,6 +7,512 @@
  "files": {
   "Pak0.PAK": {
    "bytes": 9362153,
+   "files": {
+    "maps/add2.bsp": {
+     "bytes": 4349040,
+     "sha256": "f8a62cda849413f722e9453763219863afbfb5d5c5cd918626c42a7421e709af"
+    },
+    "progs.dat": {
+     "bytes": 705964,
+     "sha256": "2b7d653d553e5c6122b2b1a8f6fe0f869c1a83ec6950163acc7a19d360414d12"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 133520,
+     "sha256": "e827535032c8e83609fedf07c9989c504e7eaa6772ce0d5cf73788e00980f151"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/axeman.mdl": {
+     "bytes": 106244,
+     "sha256": "2ca415ec913b3c05038c6db21f9235edf7eefe7cf41120edead53efb90ff0ef4"
+    },
+    "progs/empathy.mdl": {
+     "bytes": 43800,
+     "sha256": "5708f7c334f26e08a382735b830339b2505af1eee16ee5e519e7b683dc7e9fdc"
+    },
+    "progs/g_hammer.mdl": {
+     "bytes": 56388,
+     "sha256": "c52961dfeda7127bf9db4d0333fac9391127f21e174230c668a27ac843833204"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_prox.mdl": {
+     "bytes": 48244,
+     "sha256": "e19aef4259a25dd549dd294660509c88c4b84c6e7d86d403d33c5a20c474ffbd"
+    },
+    "progs/grem.mdl": {
+     "bytes": 150616,
+     "sha256": "bdc4443c3a0d0bb30b4302bb7b1d9759344690c6148bea08a747436191325763"
+    },
+    "progs/h_grem.mdl": {
+     "bytes": 15380,
+     "sha256": "b6b3713105cedd0f6cef824ebf2bb994503bc2769c4b4177994393f88bb2bae5"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/hkboss.mdl": {
+     "bytes": 323272,
+     "sha256": "75666ba526027224aa6304af2737a5e957184f4522e12a0476940744d24c5a85"
+    },
+    "progs/horn.mdl": {
+     "bytes": 56140,
+     "sha256": "ba0eb25dd04f983c857649a375be46eb97a39059f6279b0ed0cd2e7656deff2e"
+    },
+    "progs/knight.mdl": {
+     "bytes": 153400,
+     "sha256": "26576f139d258b3c236faa6552d8ba09ef6e14480d4a2e2dc9e3e2c4df5177b6"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/lavarock.mdl": {
+     "bytes": 8788,
+     "sha256": "e8d5fb2127d60351e41440ef7774b137c21c58bd93ef26ced6fa8a47f8703ed1"
+    },
+    "progs/ogre.mdl": {
+     "bytes": 213256,
+     "sha256": "fae8fac60b899d78a929ada720c591b7356e78cdea074f1b128f465d47fc4d8a"
+    },
+    "progs/playham.mdl": {
+     "bytes": 112356,
+     "sha256": "c12b9df6aa6b16226c4123630640e61facfc113baf3cf2278d31efa1f1a39fb9"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12724,
+     "sha256": "8827c874c10315b83d4ab7ba15f175ce457c1e41484383459eb2614947195a4c"
+    },
+    "progs/rubble1.mdl": {
+     "bytes": 5716,
+     "sha256": "0c9c2224352dd01af6741bc988b8af85c4c6f9e90fac93651c70cc5e2c0a6fb5"
+    },
+    "progs/rubble2.mdl": {
+     "bytes": 44460,
+     "sha256": "cb6b4845a617efcea0999fc7d5b5a36eee58453d0771ad84509ca6197b49f69a"
+    },
+    "progs/rubble3.mdl": {
+     "bytes": 65436,
+     "sha256": "72073be3abdad4b92449e54fab7311997c2f2d2429f50f1fb8c41c3915aab675"
+    },
+    "progs/s_blood1.spr": {
+     "bytes": 3192,
+     "sha256": "edd95bb75f7461862fd1f9e5876b66f3dc778548fb2b8db53cd903b55d3b95bf"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 120,
+     "sha256": "bce3194039dc74c5545e6255f771494824e01f24b23dd386f2e1333d52ba7f5d"
+    },
+    "progs/s_wrtgb1.mdl": {
+     "bytes": 62108,
+     "sha256": "b003640a72968d716284188b2666be4ecf6d895002483b395e1e43da5f24d54b"
+    },
+    "progs/s_wrtgb2.mdl": {
+     "bytes": 34872,
+     "sha256": "0b02115fff578f14c84eef3bf63f899b0eae4e2819824d2fdace5d684a62fd58"
+    },
+    "progs/s_wrtgb3.mdl": {
+     "bytes": 32260,
+     "sha256": "9857c167aced5c8aeeb28e828fd86f1209cf7471350f90bedac9401877f5981b"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/snakeman.mdl": {
+     "bytes": 132028,
+     "sha256": "8824603b325f37bbba424f55c3ff900c21ccf61c77ba97e636e91ef99202364a"
+    },
+    "progs/spikmine.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/uzi.mdl": {
+     "bytes": 52820,
+     "sha256": "744af1fafaacb751cf2e5ce4bb15a0fc1fb938ae519469de6f0dccfe9f320414"
+    },
+    "progs/v_axe.mdl": {
+     "bytes": 55572,
+     "sha256": "edf05558cb271d6b08722f1dfee3b5f611f201f5dbd1bb539fd4bf5ea7b313fc"
+    },
+    "progs/v_hammer.mdl": {
+     "bytes": 58404,
+     "sha256": "d5e44a40cddca47f9b0d98ea8f7ee7d7d37a37dd5d55d90e35672d396536b2b6"
+    },
+    "progs/v_laserg.mdl": {
+     "bytes": 51724,
+     "sha256": "34a9a462eabdc8dfd3b8377a6707d6447858249b6477788e1cf962fcbeb73c61"
+    },
+    "progs/v_prox.mdl": {
+     "bytes": 58548,
+     "sha256": "d164192c6c46aed2c1574e5be24041cea381a70fd7805e198fb37a73acc7f3d9"
+    },
+    "progs/w_ball.mdl": {
+     "bytes": 13684,
+     "sha256": "ba9f52e66ac380306d443e07ee4f1fac92793cba55394c01590c3dd088042e78"
+    },
+    "progs/wetsuit.mdl": {
+     "bytes": 55156,
+     "sha256": "4e4dc7331c374d2345c3d755ff34b61850c289741314b10fa36c461db3844e99"
+    },
+    "progs/wrthgib1.mdl": {
+     "bytes": 5300,
+     "sha256": "be341d54e1fe39bfd9239f1a708bb32548902067c80c5643479da30647087229"
+    },
+    "progs/wrthgib2.mdl": {
+     "bytes": 6292,
+     "sha256": "e0f85f9b51c584f30d27c48134dac9a35d25b7b6eb441df7b4b5c442c2b7e142"
+    },
+    "progs/wrthgib3.mdl": {
+     "bytes": 2516,
+     "sha256": "18550030f73726841d57f557d8791d5f2721bd7d7235e08636a960af3765c4e3"
+    },
+    "sound/ambience/comp1.wav": {
+     "bytes": 62734,
+     "sha256": "023903bd93bebc49b2a9c66b17f1f32e533d14fe111d93ea36b362f2e0437b22"
+    },
+    "sound/ambience/drips.wav": {
+     "bytes": 80712,
+     "sha256": "96f7890d2fea2f1f6443d0e75bb6084f39931e7c5399a6e75787dec4eaba5033"
+    },
+    "sound/ambience/fanblow.wav": {
+     "bytes": 12890,
+     "sha256": "b242140bfc7b92006433bf5efcca88efb7dbf838b14f0beedcb14bcc914f05b9"
+    },
+    "sound/ambience/fire1.wav": {
+     "bytes": 24064,
+     "sha256": "db160193d1db0e65b3f014291bba7c10ec2a11dc1844ac1a0288ab30ac3adf22"
+    },
+    "sound/ambience/humming.wav": {
+     "bytes": 7672,
+     "sha256": "bd13a2f20d22fd462762d4115b38d250143b5378e8f1cd997aee92a230b0b079"
+    },
+    "sound/ambience/riftpowr.wav": {
+     "bytes": 3822,
+     "sha256": "60c3ae33de894708a26b5c17891be8225d54909a297efe081d9f22c5ea74e06f"
+    },
+    "sound/ambience/runwater.wav": {
+     "bytes": 64764,
+     "sha256": "a1c4985a92c0edf589e824e2fd161177da99b404c308c2f68cb1997ac7cf832a"
+    },
+    "sound/ambience/rushing.wav": {
+     "bytes": 10556,
+     "sha256": "c991d0d9e1f869400d3de2c3228cff60d8b70302ed98c7617c0b02edc58d7b54"
+    },
+    "sound/ambience/suck1.wav": {
+     "bytes": 25852,
+     "sha256": "02d097f0a58cc65826bde1ebe5c3450a4ab92d09b16e85ad916f62dca82936c9"
+    },
+    "sound/ambience/swamp2.wav": {
+     "bytes": 91138,
+     "sha256": "ffc3f8d7386db7766c885706a1247926f870957d4a3e55cd51dbe4d55416338f"
+    },
+    "sound/ambience/waterfal.wav": {
+     "bytes": 19330,
+     "sha256": "6dba30c793b844acf1b1f8a7496009b966eef8c89659802302e3432a8e5da601"
+    },
+    "sound/ambience/wind.wav": {
+     "bytes": 44582,
+     "sha256": "1b0b9f054d82c238128b821c41bdeba0e81a436f37c1aec92d2e1dfd7be61c6a"
+    },
+    "sound/ambience/wind_high2.wav": {
+     "bytes": 91138,
+     "sha256": "ffc3f8d7386db7766c885706a1247926f870957d4a3e55cd51dbe4d55416338f"
+    },
+    "sound/ambience/wind_low.wav": {
+     "bytes": 58476,
+     "sha256": "0759ad526d301c3bb14c467818bacdbe3a64237657c45a435e06cb166b570b85"
+    },
+    "sound/ambience/wind_med.wav": {
+     "bytes": 32212,
+     "sha256": "005616904ebfec049860ca33b790903e76c75615f3048dba17ce8d85cd6c65f5"
+    },
+    "sound/ambience/wind_rumb.wav": {
+     "bytes": 63234,
+     "sha256": "24760cbf8622bb933fcd59e847067de3581f6a3d54db72bcb3f864d2cf508a36"
+    },
+    "sound/ambience/wind_rumb2.wav": {
+     "bytes": 32872,
+     "sha256": "9c77014eb35b692af657a524f1e7eb82b1b1ebe9d95c62462e6f6925baf4153a"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axeman/adeath.wav": {
+     "bytes": 11714,
+     "sha256": "c6d2e6a1107eddcb49ca41776da1c7f8a3b27766b66dbf4bd9186fba2780cb2c"
+    },
+    "sound/axeman/aidle.wav": {
+     "bytes": 34574,
+     "sha256": "1970dd8c9d4a1f33dfbc4cb5368bd93060f3dda26681f1a128aa121d3adca3ea"
+    },
+    "sound/axeman/apain.wav": {
+     "bytes": 3302,
+     "sha256": "788466ee8cc368bcac8b07c4eeca5509ccddc30addf5a322b31a605d90bf0392"
+    },
+    "sound/axeman/asight.wav": {
+     "bytes": 8528,
+     "sha256": "d5d1a9125b9a015186d6d5e9fbd9f9d9db3fb220bdf9139f5aa73b9019d37126"
+    },
+    "sound/axeman/axe1.wav": {
+     "bytes": 3510,
+     "sha256": "98ee93b6fe7a7faa3d4353337d1c7103ad1538ced8f0a602a46da65a67c7fd87"
+    },
+    "sound/axeman/axe2.wav": {
+     "bytes": 4204,
+     "sha256": "def95be1b222d0e8f97be49b38e7be37cd066df33454787b50c7f908391b9c31"
+    },
+    "sound/grem/attack.wav": {
+     "bytes": 4326,
+     "sha256": "4bc0f357667de80b3562455b04f9b73399082ec0d04200b2c7b8792de78e24a3"
+    },
+    "sound/grem/death.wav": {
+     "bytes": 15470,
+     "sha256": "198003ef0624e9cf184c16eb96a715ccdb741100bfa4ace4f70dbe7eb4d91247"
+    },
+    "sound/grem/idle.wav": {
+     "bytes": 11622,
+     "sha256": "ea7aec1e3e3d18c22848624b1afc24a58f8e4df60a039a96b18a4de0579634d4"
+    },
+    "sound/grem/pain1.wav": {
+     "bytes": 3078,
+     "sha256": "1d909972c66b8e67f50867c141cbbb55796cfcda7314811b40e18f725e39256d"
+    },
+    "sound/grem/pain2.wav": {
+     "bytes": 4068,
+     "sha256": "ddb2935dcb951f8d3c381657a04e26c4df742cb0cb8e08a39e94ec7c402d0323"
+    },
+    "sound/grem/pain3.wav": {
+     "bytes": 3318,
+     "sha256": "88cb89b31186d7183a09867cc4ab244519c7f9184e391cb39edb6d10e021f2ac"
+    },
+    "sound/grem/sight1.wav": {
+     "bytes": 12606,
+     "sha256": "c20f1f90cbb72dfa80bef8d845a76c2772b55235970bc7d801af57ad34351877"
+    },
+    "sound/hipitems/empathy.wav": {
+     "bytes": 13182,
+     "sha256": "07db6fc05ca0012647d22a2121bf43afdbfb18a85d0e87fefcbf82f73070aef6"
+    },
+    "sound/hipitems/empathy2.wav": {
+     "bytes": 5836,
+     "sha256": "bd3af2d911dd44edd6503143fb2b8413faa0e78df4437fc6c7c69812948cd50f"
+    },
+    "sound/hipitems/horn.wav": {
+     "bytes": 18016,
+     "sha256": "36d64e1d661b6c9fe5c7a27aabbe240c97ea23eade4359a5e854276219bf898b"
+    },
+    "sound/hipitems/spikmine.wav": {
+     "bytes": 15566,
+     "sha256": "7ef31a2d349875eca1f1abb538fc2ae305441d4eb957fbc88f5b8ea55120fc8e"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/mjolhit.wav": {
+     "bytes": 33914,
+     "sha256": "90fe4d76505558e612d0d66ec1d4d54a89ac0a35cf298b48e4446b1b41d02a78"
+    },
+    "sound/hipweap/mjolslap.wav": {
+     "bytes": 2926,
+     "sha256": "37316ccf0d6cfb85734bb4533450926808673f2bcdca1b6164c62f96b25cc379"
+    },
+    "sound/hipweap/mjoltap.wav": {
+     "bytes": 11430,
+     "sha256": "707673644ea7993483588ade01ef41679c96aee3e0ef700a09a758a921eba1ef"
+    },
+    "sound/hipweap/mjoltink.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/mjolwam.wav": {
+     "bytes": 3050,
+     "sha256": "aaead2e80ab122ac8835b41966317bcf995faf7a136e6bee1202fa3bf253ece4"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/misc/bell.wav": {
+     "bytes": 30870,
+     "sha256": "ec00ff5286c8182fc7e8dac11fa99f8155754b0aef78ce9b145781dc54152c5a"
+    },
+    "sound/misc/clang.wav": {
+     "bytes": 13182,
+     "sha256": "f3e7843d052f8f1508f2372f73d29c363245f5645ed592510f387223c132f2f4"
+    },
+    "sound/misc/click.wav": {
+     "bytes": 9758,
+     "sha256": "aa2d2373ed91aef05f9a95be15e9ee599dcd051d355fcc6b7fe64269859c20bc"
+    },
+    "sound/misc/deepthud.wav": {
+     "bytes": 13246,
+     "sha256": "8b1f686b2ed9179592ff3136c6c45d0e0a864f3170e7dbe101e0d1a6b62765a5"
+    },
+    "sound/misc/drawbrig.wav": {
+     "bytes": 19892,
+     "sha256": "f16bed62b508695bd892660f081c8ca278fe0f98b98d56ecc16abb25fe702229"
+    },
+    "sound/misc/flys.wav": {
+     "bytes": 77334,
+     "sha256": "fa0d30e7e7d49d1b03c588ac0ec899b5e85d71b439f17dcf9832fe0781e59b05"
+    },
+    "sound/misc/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/misc/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/misc/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/misc/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/misc/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/misc/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/misc/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/misc/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/misc/rockthud.wav": {
+     "bytes": 9742,
+     "sha256": "0aec00acdb3614875914dfd04ed77ef99b4b967d6253bb14df54b348e892030f"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spike.wav": {
+     "bytes": 3542,
+     "sha256": "c9f5ad27267d83bcb704992841ede480a15602d4a39550f90764ca3f96043c32"
+    },
+    "sound/misc/tesla.wav": {
+     "bytes": 22526,
+     "sha256": "05a76add480090c8b15e3e6a33487fa019ab3e579c635e84a5343c4709cefd3d"
+    },
+    "sound/misc/weton.wav": {
+     "bytes": 15808,
+     "sha256": "1db0b74488a1df3c557206dbadbe3311d78d46bdf462e5348930c34c9d6f72a9"
+    },
+    "sound/misc/wetsuit.wav": {
+     "bytes": 49262,
+     "sha256": "32a343c9156b43aca5b1725ff74a1523234359d4bb7c1e77feaf1551e7d6656a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/snakeman/sdeath.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/snakeman/spain.wav": {
+     "bytes": 34452,
+     "sha256": "15b84d6adb80e4ceace4226b5185c578a752adb36f213f2488e80ad2192378aa"
+    }
+   },
    "sha256": "cb3fb290baefac27b365ae4ade8bce683abf6cfc2cf55156180e34c6d7096920",
    "timestamp": "2003-05-07T20:07:48.000Z"
   },

--- a/json/by-sha256/fb/fbcd19b85e2c1942f326c58b7c2496c88cce174a7643a430ae20b6746b5b78e6.json
+++ b/json/by-sha256/fb/fbcd19b85e2c1942f326c58b7c2496c88cce174a7643a430ae20b6746b5b78e6.json
@@ -35,16 +35,722 @@
   },
   "warp/pak0.pak": {
    "bytes": 64411560,
+   "files": {
+    "demo1.dem": {
+     "bytes": 1090328,
+     "sha256": "241d40a8f71c4312739e65d22368a993042a930be93caa440aba5642126016e3"
+    },
+    "demo2.dem": {
+     "bytes": 5242709,
+     "sha256": "c367355d6a78dd019826a038d836149aee0926ae6da136294a52cff9b30c970e"
+    },
+    "demo3.dem": {
+     "bytes": 765477,
+     "sha256": "2d62c38e20ef243e8ea612d31c44cf4024ab317b3e8c4167ace46074ff4b52d8"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 64008,
+     "sha256": "4de1f86b75ffbbbf9b201c3bf1d1f3cab97a926f882b65fc1fcfdaeee9d03db4"
+    },
+    "gfx/env/shol_bk.tga": {
+     "bytes": 286426,
+     "sha256": "afc656e21fdba58ec0df854cd4f0a8681257a993bec6b5185b24821b9b3e73be"
+    },
+    "gfx/env/shol_dn.tga": {
+     "bytes": 139320,
+     "sha256": "aa4b3cf9005975c47096fbacd3041439ab0492025c0756df7d5098192043d53e"
+    },
+    "gfx/env/shol_ft.tga": {
+     "bytes": 280100,
+     "sha256": "9334cced4dfe72e3be40a86f830c6d39444d4bd4aa1df0f26b4fbf359f369520"
+    },
+    "gfx/env/shol_lf.tga": {
+     "bytes": 305263,
+     "sha256": "84e81f9c3d29722d40b2dc3f9bc934d610a1bc7a05903265546e33d3c201383a"
+    },
+    "gfx/env/shol_rt.tga": {
+     "bytes": 303582,
+     "sha256": "b407a22b61b77bd86e1eecdfbb2a64c25acc004b25020318e67e9a179d07c533"
+    },
+    "gfx/env/shol_up.tga": {
+     "bytes": 344881,
+     "sha256": "3eff1076ea76b963355452aefddb7afcee5d75a41a65d1560a375f24f9715660"
+    },
+    "gfx/env/snow2bk.tga": {
+     "bytes": 196944,
+     "sha256": "b1989e218c27590c7b4293e080cc1a67f8d7fe4b7a04b48a9931579c79ecdf59"
+    },
+    "gfx/env/snow2dn.tga": {
+     "bytes": 196944,
+     "sha256": "904bdebc637c33c85dc8c0441d0e04650f41f38a2aa0f0b1641feeb0fe83dc34"
+    },
+    "gfx/env/snow2ft.tga": {
+     "bytes": 196944,
+     "sha256": "41cdc6506fa459d3e49ef0c216de02230c940036e272e710defa1dbc2836e112"
+    },
+    "gfx/env/snow2lf.tga": {
+     "bytes": 196944,
+     "sha256": "edae128777db88318aba2ec530364e2af607a91ebdac544cdf246ebc7c192d92"
+    },
+    "gfx/env/snow2rt.tga": {
+     "bytes": 196944,
+     "sha256": "ac56929ea7e0bac7001b0fa948a49ecc72fe9f7f208e58b74d1b53a3f7e1f3f7"
+    },
+    "gfx/env/snow2up.tga": {
+     "bytes": 196944,
+     "sha256": "35d89f993aff9e4efd80430021c0a1d43dd107618f6e053f8ff060a94f3a0488"
+    },
+    "maps/start.bsp": {
+     "bytes": 1586272,
+     "sha256": "78b40da8faf58684692a21545da3e5c10ab07b6a7a86bf5378a0c55444c358d7"
+    },
+    "maps/warpa.bsp": {
+     "bytes": 2796264,
+     "sha256": "9156eecfd13ac82a91f17e40c85d981b6adaf96b34d08f475c5efd87f3e44c31"
+    },
+    "maps/warpb.bsp": {
+     "bytes": 6324568,
+     "sha256": "b9c2d003e4ee35169cc48dd2cc34a6177265778dc1f705e4ec019dc2fe03cd11"
+    },
+    "maps/warpc.bsp": {
+     "bytes": 10299116,
+     "sha256": "b5b9c524daf7f21b90b0bd26ef81e9f4da7d8de2bcea85ff979229e396ba436d"
+    },
+    "maps/warpd.bsp": {
+     "bytes": 7330684,
+     "sha256": "25fc8e81fa0b6fd2ba62e49af89c603ec5786154f3a7222f6605310be1bdb0ac"
+    },
+    "maps/warpe.bsp": {
+     "bytes": 3478196,
+     "sha256": "031dffc640a2379be8825f352c57f172281c5f64f7628d429ff11860eeb7d3e9"
+    },
+    "maps/warps.bsp": {
+     "bytes": 1073232,
+     "sha256": "2cee6e77002e5d0eb2af00a113def3201a3e038860a5d68156b57e248e13f04c"
+    },
+    "progs.dat": {
+     "bytes": 857348,
+     "sha256": "c6542fd0403bbd26167438d1ac3007087b697e2eba7534fb33e0d985306ac1a0"
+    },
+    "progs/demon.mdl": {
+     "bytes": 261701,
+     "sha256": "538caf1d4649870128b9b2f02d9b2e559d5e3d92b299afe5209e507b7c12ab39"
+    },
+    "progs/g_ham.mdl": {
+     "bytes": 29884,
+     "sha256": "6291cdb0c19884b5308557a32501a1c5d9128fe890f3cf751592249cd470a5e2"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 35697,
+     "sha256": "2c3b46a067de8eeed3419ff9982bcf45d84fa4ec7dfea7b1a455cbb98c883fde"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 29223,
+     "sha256": "9246d501fa1b2ff5e1de906832d6e7bda2e7137f8024c1a397c228563b719d2a"
+    },
+    "progs/h_player.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/player.mdl": {
+     "bytes": 302944,
+     "sha256": "7c5095a48e931d680ef8bfeb93b801da6df37fe06e66d0050a635e58669d88df"
+    },
+    "progs/soldier.mdl": {
+     "bytes": 565437,
+     "sha256": "cf6f00e6a0a6810ff7fd02230d1b6d97213bfa315f27be76b2ebafa9be7032c3"
+    },
+    "progs/teleport.mdl": {
+     "bytes": 68073,
+     "sha256": "6fe06d111e13dfafff923149c4071d25d11b9c7cd999726849562ccbb55fad75"
+    },
+    "progs/v_ham.mdl": {
+     "bytes": 114888,
+     "sha256": "5504c3cd20b296a815438d9572d9712e1d6c2ffc22dbee35fc008a742771ff47"
+    },
+    "sound/ambience/10_0.wav": {
+     "bytes": 461102,
+     "sha256": "d927c866525029132754c2c37a12e58dd9f54e13d5807c5853d6c406915f2327"
+    },
+    "sound/ambience/bigpump.wav": {
+     "bytes": 78818,
+     "sha256": "2c0a2935b33adf1d4c90231b0c1d696608cbeac228d16d499229046fb15843b6"
+    },
+    "sound/ambience/brkglas.wav": {
+     "bytes": 73058,
+     "sha256": "727c7f83c698b24e8b8910dbfd062e9cf5ea354d9846e4b36dcaf1a0f1d8b271"
+    },
+    "sound/ambience/chant.wav": {
+     "bytes": 146966,
+     "sha256": "218c6d5d4172c3b86ce9dfea1fff58bc20613b8dd3fe7b2df2fe1adbbf22272e"
+    },
+    "sound/ambience/demonwind.wav": {
+     "bytes": 357636,
+     "sha256": "2744eaae8e03367a28a1bdc56f68494eb4cfa325c794d159eff56a2295e12912"
+    },
+    "sound/ambience/doomtweet.wav": {
+     "bytes": 49818,
+     "sha256": "e04298e7bb770dacce5d70e39309538b5dbd5c33b9ad613572f3be45e0283615"
+    },
+    "sound/ambience/hammer.wav": {
+     "bytes": 48532,
+     "sha256": "1361c77709785eda131cf37e10af0c6af08d9e1620298e9df7a015bbdb65313f"
+    },
+    "sound/ambience/lava.wav": {
+     "bytes": 710182,
+     "sha256": "9c9c77941f88416e3f20dfc4f028cc6c9719dd7f58a15dfc6124f1bb5a17f61a"
+    },
+    "sound/ambience/machine.wav": {
+     "bytes": 422018,
+     "sha256": "9c17e400683bd2e671b846e9c7740870303a52390803d69cbb769fbd5afd91c0"
+    },
+    "sound/ambience/slime.wav": {
+     "bytes": 176550,
+     "sha256": "4298005d7e9bb23f1da6d4ee832cb00073864c49228ea6313f68c48f8f5d3d4b"
+    },
+    "sound/ambience/thrum.wav": {
+     "bytes": 220542,
+     "sha256": "c925d73ef744b0a8c56507ff6fb18888de7ab803ea1f743060f8f9782180dcc7"
+    },
+    "sound/ambience/wallbrk.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/ambience/whitenoise.wav": {
+     "bytes": 38176,
+     "sha256": "4a3bf21ed13e0804a51ca4f97660f6832cf5d7361a03c60f0b41201aa7acdecd"
+    },
+    "sound/ambience/wind2.wav": {
+     "bytes": 181912,
+     "sha256": "101c41dafaeb001ab21de7c6bbaebf2ce6ccb83c669774b7be3e510b455167d6"
+    },
+    "sound/ambience/windy.wav": {
+     "bytes": 35606,
+     "sha256": "3ea692e4d550a82dc9e815836a8772a25043edb9536e8c794f4ad9032fd5a5bc"
+    },
+    "sound/ambience/x_alarm.wav": {
+     "bytes": 53312,
+     "sha256": "3ceb9632196acf85c435d12a171690eb48b44c35dff6e26fca0cee0b832d0da9"
+    },
+    "sound/ambience/xchoir2.wav": {
+     "bytes": 240056,
+     "sha256": "65dd399e0a78863da823ded1a9fc1be466ac35dcc1cf965de29e794c88c077ce"
+    },
+    "sound/music/readme.txt": {
+     "bytes": 923,
+     "sha256": "8315720d07c180caf1311f4358dd36aea10ff98780b84d1c4dbbb9d326430c2e"
+    },
+    "sound/music/warp.wav": {
+     "bytes": 1400940,
+     "sha256": "55acf963b9bf85a9b9413ac4d947e63089317107e631931780c180990a6386ae"
+    },
+    "sound/music/warpa.wav": {
+     "bytes": 1339500,
+     "sha256": "a0e9a38dbfb03ec879fca46810d44355595fbaf9e0fc9da8ff80b0c3da3d3334"
+    },
+    "sound/music/warpb.wav": {
+     "bytes": 2518936,
+     "sha256": "11836c55e7e4a4a43fd85772222b3a3bc4a878240f49b7065c265f2df70a347e"
+    },
+    "sound/music/warpc.wav": {
+     "bytes": 1783948,
+     "sha256": "950d5db0f7548e8a2b073847d2d00bbc5f910bcbc676c7a4eb5b3120e59c7632"
+    },
+    "sound/music/warpd.wav": {
+     "bytes": 2134956,
+     "sha256": "9d139013199aebc4e32a15bb38b9b8a562d2969a3e1dd5c8fb53f9e25a6f6a86"
+    },
+    "sound/music/warpe.wav": {
+     "bytes": 5206730,
+     "sha256": "a115aa8b0ce7eb50e88ff42f9b6e4fcc799fab2fc274454c43ee2bc0a5c6e8c0"
+    },
+    "sound/music/warps.wav": {
+     "bytes": 1470572,
+     "sha256": "de93a72890b47485019c63b112632ede0eeac66df9378dd093089fba6f7a6fc6"
+    },
+    "sound/player/death1.wav": {
+     "bytes": 8434,
+     "sha256": "37c607021cdf8836ba659a64e052d51960b028bbadd57f6b49e7640508be195c"
+    },
+    "sound/player/pain1.wav": {
+     "bytes": 5000,
+     "sha256": "a8c7b67e3478f25b661566a0da0d42716777e1498305c507a878fca62b9fc316"
+    },
+    "sound/player/pain2.wav": {
+     "bytes": 7838,
+     "sha256": "36619ee7e1a360e8a072ac75ca04b3d5f3fec5e072998f7dbba48ee0725613b3"
+    },
+    "sound/soldier/death1.wav": {
+     "bytes": 14126,
+     "sha256": "ef02329c6c3d935d7e47063a8df917cefb5709eb3fe4b0b28a778eda90c74291"
+    },
+    "sound/soldier/idle.wav": {
+     "bytes": 90,
+     "sha256": "f533d613210a356b0c1be4582f085dc9e6294155e0eeb2afab42369ba55dbec7"
+    },
+    "sound/soldier/pain1.wav": {
+     "bytes": 4840,
+     "sha256": "a76a1af707df0acd2115148a4386888f8e2bf17bb90cd1a2a9201b319cc207c3"
+    },
+    "sound/soldier/pain2.wav": {
+     "bytes": 8020,
+     "sha256": "65f7d671aa9a5a412c3ba691854747f24e93c51be90ea17f3ef8ad4bbabbb2f8"
+    },
+    "sound/soldier/sattck1.wav": {
+     "bytes": 14302,
+     "sha256": "2c3db752aed909b06eea687b8ba8c0507502158faf2ba29ecab99984206f9840"
+    },
+    "sound/soldier/sight1.wav": {
+     "bytes": 5100,
+     "sha256": "f91bc3a6cb5150eeb37e5544d537f9d024cc37cfb6cf20fd2538a3ded01e55c2"
+    }
+   },
    "sha256": "e75cd273313563ec9cf6fb6ab86b89cb676ea3be3940823837a0f6d9a76556c9",
    "timestamp": "2007-05-11T02:59:44.000Z"
   },
   "warp/pak1.pak": {
    "bytes": 20950651,
+   "files": {
+    "textures/models/bob_0.tga": {
+     "bytes": 576032,
+     "sha256": "a27145a92f442afd364238e1b0f861024f6e4376ebccc94ad7d27b453cc4d067"
+    },
+    "textures/models/bobblaster_0.tga": {
+     "bytes": 13186,
+     "sha256": "35c57872a8e81eb3739431d5d848df86e94c639b3c5fb5cb8ccb641a06b56645"
+    },
+    "textures/models/bobblaster_1.tga": {
+     "bytes": 13186,
+     "sha256": "1629b778493274b8a043cbc8ac59afbe845b9820b8aee7682054fafd71b37969"
+    },
+    "textures/models/bobblaster_2.tga": {
+     "bytes": 13186,
+     "sha256": "36c1cc243c369954563f91a34e6240d519b3583831cfaad1bb76c1eb19b71a6d"
+    },
+    "textures/models/boss_0.tga": {
+     "bytes": 2085442,
+     "sha256": "ee5e546375c80addc6fab24318d2f25b3e468e82d4eb74c73531c5bb54a46e5b"
+    },
+    "textures/models/corpse_flay_0.tga": {
+     "bytes": 226505,
+     "sha256": "190c58353f310d55488188fb7f95232ab162008ff1dadd666bd434f8a72098a6"
+    },
+    "textures/models/corpse_flay_1.tga": {
+     "bytes": 226957,
+     "sha256": "3f3be88f6cb3f84b561f4f690221b7abd470cf5e6b28f1fc07babfe8aff67972"
+    },
+    "textures/models/corpse_flay_2.tga": {
+     "bytes": 225135,
+     "sha256": "961ad075179825dcffbf8ef4a1b59b4b5fb8ccfd63f05780419278075dc5d048"
+    },
+    "textures/models/corpse_imp_0.tga": {
+     "bytes": 164907,
+     "sha256": "719c93f2908a93e7659da2032a813e8761353bb4827f7de6a998b772aa973c12"
+    },
+    "textures/models/corpse_imp_1.tga": {
+     "bytes": 166156,
+     "sha256": "b95f69554c7d47ce565fa2d323e2296f2d9823321326bcb8f5699fda14480a3a"
+    },
+    "textures/models/corpse_imp_2.tga": {
+     "bytes": 157297,
+     "sha256": "d0848786159923efc5e3fb3bf353dd29e14351e6d6ab15b5b05cef37f462a72f"
+    },
+    "textures/models/corpse_imp_3.tga": {
+     "bytes": 158450,
+     "sha256": "da1d2300db6a953266ab697f66ffa914cb98784f7ab540930640f686219104cb"
+    },
+    "textures/models/corpse_imp_4.tga": {
+     "bytes": 174776,
+     "sha256": "129a0ad710be2e0bb8d8813c1447c32b8049e1c75094d0916bebb97680e51947"
+    },
+    "textures/models/corpse_imp_5.tga": {
+     "bytes": 153333,
+     "sha256": "38418a17bf74207f0b9fdf3788a4407e5fd7bfc3a0b2d3d16e66c392af8c1b4f"
+    },
+    "textures/models/corpse_imp_6.tga": {
+     "bytes": 162579,
+     "sha256": "4e46c8884856e90576b2c9a3e18d8acc846a517f0411f0caf74488f5cf4f4dec"
+    },
+    "textures/models/corpse_imp_7.tga": {
+     "bytes": 161204,
+     "sha256": "52d4dc09dad929e3980429c46f3b96352d2634064995045f186ac8e3b5698c30"
+    },
+    "textures/models/corpse_imp_8.tga": {
+     "bytes": 170763,
+     "sha256": "2d93c7fa817a1ad69d2414d3266aee954474c9b7b50b1c68249b73a28ba75c8d"
+    },
+    "textures/models/corpse_lynch_0.tga": {
+     "bytes": 235152,
+     "sha256": "a4e19c3cfd02b17b0db412f416ce5e8fed9841c20f9894ae3415721a5954d9a6"
+    },
+    "textures/models/corpse_lynch_1.tga": {
+     "bytes": 235211,
+     "sha256": "cd12214074a0f8319274e09da45583af5fdbaf52538be3e5c8b5a0cf9326f6fd"
+    },
+    "textures/models/corpse_lynch_2.tga": {
+     "bytes": 232128,
+     "sha256": "048573a41369cde7449c1f8a19bf0ab29c433cd15a3c8bd15000215346898961"
+    },
+    "textures/models/demon_0.tga": {
+     "bytes": 249632,
+     "sha256": "66734654ba52c9a4b4691e02bd89daf89c3317e6e0999c73831e47faa9728c2d"
+    },
+    "textures/models/dguard_0.tga": {
+     "bytes": 168764,
+     "sha256": "164764e03ca70b896bf530d1180120ec714ee7d9b016bf9b55efb4697a141668"
+    },
+    "textures/models/dog_0.tga": {
+     "bytes": 181245,
+     "sha256": "9fa526a468fbfe3c61fb0358cf68c06ba32b1abe3cbbc4e28a98ba7e4a0d3aa6"
+    },
+    "textures/models/drole_0.tga": {
+     "bytes": 450276,
+     "sha256": "e600bec0a0e0de91ec92ce57fe6f21ee5f12287de26d8038cf1b37fa528a7b5a"
+    },
+    "textures/models/enforcer_0.tga": {
+     "bytes": 232483,
+     "sha256": "2134fc927d2f56fd15ff303deac4ccc119153dc469b2cf71122e5bc152d9c4a4"
+    },
+    "textures/models/enforcer_1.tga": {
+     "bytes": 254742,
+     "sha256": "173027b02353e4aa08a6b805615a3b39cc97b40b4e9d2255954e1106c465c403"
+    },
+    "textures/models/fish_0.tga": {
+     "bytes": 254524,
+     "sha256": "3cba84a11a5b6e0126e24005c64761d1264063398055a8611e7cedfea7bed74c"
+    },
+    "textures/models/gaunt_0.tga": {
+     "bytes": 234038,
+     "sha256": "020a601b9073027495adcc1d07f28538b2c0f0750af93827ebda4a83e7ae65c2"
+    },
+    "textures/models/gug_0.tga": {
+     "bytes": 895504,
+     "sha256": "892f73f6d4aa6e418fe5348fd39fe49bd9e0c84e8ceeae7a92fc96d99a7b5a2d"
+    },
+    "textures/models/h_demon_0.tga": {
+     "bytes": 83118,
+     "sha256": "19a76341ecdd430647183fd53e5a78886dba9a4afb8c821c9c2ed0516c599d0f"
+    },
+    "textures/models/h_dguard_0.tga": {
+     "bytes": 20631,
+     "sha256": "ae0998c0e001a11ec77dd098db6ed7846517eae89979f2fdb1509739c096f123"
+    },
+    "textures/models/h_dlord_0.tga": {
+     "bytes": 23751,
+     "sha256": "3d297b53feaff6791ae431fba57c147beec3f3dd69d984569313080de38c5b17"
+    },
+    "textures/models/h_dog_0.tga": {
+     "bytes": 116332,
+     "sha256": "08c2bac231f03ffd4aae9c4c0963e56bb24cbdff9c20f8934b80dbb083fa4040"
+    },
+    "textures/models/h_gaunt_0.tga": {
+     "bytes": 107675,
+     "sha256": "c278db814a108be7510b08d572c4614b4633c0d41d34754d4a7d045cca0b3316"
+    },
+    "textures/models/h_hellkn_0.tga": {
+     "bytes": 22324,
+     "sha256": "73cf8a7955c2002c2b1abd75f0e925d2fee624714dd6a6ad9d0b69b6953041a5"
+    },
+    "textures/models/h_hknight_1.tga": {
+     "bytes": 23751,
+     "sha256": "3d297b53feaff6791ae431fba57c147beec3f3dd69d984569313080de38c5b17"
+    },
+    "textures/models/h_knight_0.tga": {
+     "bytes": 49656,
+     "sha256": "afd5ae4435ab334278035b7ef8bd64fae669a08a2f79cc264c4040d921df70ba"
+    },
+    "textures/models/h_mega_0.tga": {
+     "bytes": 45266,
+     "sha256": "193e84f71351231eefc079add6f3b237c16ecbf27f0bb22eb10acc7227cc8fae"
+    },
+    "textures/models/h_mega_1.tga": {
+     "bytes": 45624,
+     "sha256": "9f0246ab6de0c8a7699e6f11e39b8c39fc7698c3207c506b895eabce28d9073a"
+    },
+    "textures/models/h_ogre_0.tga": {
+     "bytes": 54665,
+     "sha256": "0f9760fd1c2b892ebc25316422c54b0545e04ab9e8d2ef1bd37c945f47ab70f6"
+    },
+    "textures/models/h_player_0.tga": {
+     "bytes": 34582,
+     "sha256": "372c21b567bae0fae174d5ef97f559d97fb1f5c9f2e607f8e718b8c60a279792"
+    },
+    "textures/models/h_shal_0.tga": {
+     "bytes": 128650,
+     "sha256": "4736c3c0a276fb6aee62de32ff062279f437042903167cde05f551fdb890147c"
+    },
+    "textures/models/h_shams_0.tga": {
+     "bytes": 243327,
+     "sha256": "bbe155878ec844b0921bfd6f2ac194b3c44bd56526c42247c2875a097f2b1475"
+    },
+    "textures/models/h_wizard_0.tga": {
+     "bytes": 53105,
+     "sha256": "6277905c0b676f0bc9457fe3b0d83811df87f6f5a2198c28f33cdafd0f499bc4"
+    },
+    "textures/models/h_zombie_0.tga": {
+     "bytes": 10401,
+     "sha256": "77b29a31f03f1161336654bb6f36a0c65c9fa9a80c9ac68df93544b8508848c4"
+    },
+    "textures/models/hknight_0.tga": {
+     "bytes": 194884,
+     "sha256": "efb8d725425a7ef4f212020a35185ccd00bb70a49007269dc0f0bd421092e72a"
+    },
+    "textures/models/hknight_1.tga": {
+     "bytes": 196798,
+     "sha256": "8fb26df031cdff642338f8b505c540422b869430de527164d72c212a938aa9b1"
+    },
+    "textures/models/knight_0.tga": {
+     "bytes": 236585,
+     "sha256": "d1cdd8cbf76511629e623ad1ebfe992d32635f7546ecd9c9e84bd79a13ab97aa"
+    },
+    "textures/models/ogre_0.tga": {
+     "bytes": 470930,
+     "sha256": "95a54b26701ffc29884961511443d185fa8de8c509fde1c81d909aa85f20d7a2"
+    },
+    "textures/models/oldone_0.tga": {
+     "bytes": 405649,
+     "sha256": "384997a66db8cb3f7336cb0a7485fbc0f4ec1c9bc05bdbde6f169edffc0f9e3f"
+    },
+    "textures/models/player_0.tga": {
+     "bytes": 845225,
+     "sha256": "e6375f6cbe092b478bdff6387e82dd228e9539b335cd1aa75bcc298c746f4116"
+    },
+    "textures/models/polyp_0.tga": {
+     "bytes": 150615,
+     "sha256": "b0ffb32730c5dba98476f91e81efc4d17a0705234099aa38a717ba262077f5f7"
+    },
+    "textures/models/polyp_t1_0.tga": {
+     "bytes": 150615,
+     "sha256": "b0ffb32730c5dba98476f91e81efc4d17a0705234099aa38a717ba262077f5f7"
+    },
+    "textures/models/polyp_t2_0.tga": {
+     "bytes": 150615,
+     "sha256": "b0ffb32730c5dba98476f91e81efc4d17a0705234099aa38a717ba262077f5f7"
+    },
+    "textures/models/polyp_t3_0.tga": {
+     "bytes": 150615,
+     "sha256": "b0ffb32730c5dba98476f91e81efc4d17a0705234099aa38a717ba262077f5f7"
+    },
+    "textures/models/shalrath_0.tga": {
+     "bytes": 359852,
+     "sha256": "bb358cf609ff8646794a4538efe2db2341a06dc8347e8bbc4f5e9f0710a8736b"
+    },
+    "textures/models/shambler_0.tga": {
+     "bytes": 863865,
+     "sha256": "ee405130775cff7c4a59ed055f2be4d4d4aaffccd2e0670d277cbf101126417c"
+    },
+    "textures/models/soldier_0.tga": {
+     "bytes": 231461,
+     "sha256": "8b65727121626173be2312d8fd3ad92768719bf1749f6a58901df6244d3feb87"
+    },
+    "textures/models/soldier_1.tga": {
+     "bytes": 217140,
+     "sha256": "5a33cc0694ffe15a4472f3636a54aa463ac6db20a631b657390770dd9706adfc"
+    },
+    "textures/models/tarbaby_0.tga": {
+     "bytes": 135998,
+     "sha256": "2726952334413b4110c682a15351dc8eaaa3a4783d5793425602404d7500999b"
+    },
+    "textures/models/teleport_0.tga": {
+     "bytes": 231199,
+     "sha256": "b9d86d40f51e6b33097e3a2b4dda0c22b479ee6d32bf2b042f69f9ac45ad2363"
+    },
+    "textures/models/vermis_0.tga": {
+     "bytes": 1035376,
+     "sha256": "f5d655dab298bb3af4117f46f01c8f8e1b2656126317de635ec2fe4c47e1f513"
+    },
+    "textures/models/vermis_1.tga": {
+     "bytes": 964391,
+     "sha256": "914335a7748d7c52d19b8e3e35e3715fc9c26cee67e2dfa727078e71b4a175ad"
+    },
+    "textures/models/vermis_2.tga": {
+     "bytes": 1034250,
+     "sha256": "40d61a70c7991304479dc04fb2fbe883d743453fecd8b25d800781f93e83d4c2"
+    },
+    "textures/models/vermis_3.tga": {
+     "bytes": 1035307,
+     "sha256": "b6dbda60fec5935bbdbc794b51160103363820bf927e8b3b7d4b855a76c97553"
+    },
+    "textures/models/voreling_0.tga": {
+     "bytes": 24252,
+     "sha256": "538f7d30c25246d349f1a5612b676f26989c65d38db641a29568fa6e24065217"
+    },
+    "textures/models/wizard_0.tga": {
+     "bytes": 232298,
+     "sha256": "19160d93725136a2b1016cda58ed8a7c824d1fc462e8676ac35cd2aef04bf79b"
+    },
+    "textures/models/zombie_0.tga": {
+     "bytes": 489352,
+     "sha256": "44a1c722c8f022563cfa55901f732ecfb2490ebedfbb65c34f6d6c5914ba8421"
+    },
+    "textures/sprites/bigexp_0.tga": {
+     "bytes": 16428,
+     "sha256": "0a60846ca08e9c0f314c0a515800a6b0d151b6e992479780c5887421ab924e38"
+    },
+    "textures/sprites/bigexp_1.tga": {
+     "bytes": 16428,
+     "sha256": "0f3c829404f775468c94605ba1b146391a3e364453c618eea799a50373707864"
+    },
+    "textures/sprites/bigexp_10.tga": {
+     "bytes": 16428,
+     "sha256": "1e3e5eae39accff421bf1759ec034fb4866917c7e0acb3c6d170ea790a101264"
+    },
+    "textures/sprites/bigexp_11.tga": {
+     "bytes": 16428,
+     "sha256": "866869960c94680c51a784603b39f5419cd8e46328cf1dea03575588ce9bc517"
+    },
+    "textures/sprites/bigexp_12.tga": {
+     "bytes": 16428,
+     "sha256": "602e6d81395cf095415baee4dfe7fdb5555abe8c7eab700503e12408c0ff848d"
+    },
+    "textures/sprites/bigexp_13.tga": {
+     "bytes": 16428,
+     "sha256": "c9dbfcfb7b4d0e156b00a3ea044e6fe6d545fddfefa02a178d66cb58400e20b2"
+    },
+    "textures/sprites/bigexp_14.tga": {
+     "bytes": 16428,
+     "sha256": "319503c9802375a9613b8b73def8747197f517012e7a40d98829e44a63000f3b"
+    },
+    "textures/sprites/bigexp_15.tga": {
+     "bytes": 16428,
+     "sha256": "db1f16b4cff1912199d2a85a8c33c7628147a48f2823d65905b0d2660bd87d6a"
+    },
+    "textures/sprites/bigexp_16.tga": {
+     "bytes": 16428,
+     "sha256": "db1f16b4cff1912199d2a85a8c33c7628147a48f2823d65905b0d2660bd87d6a"
+    },
+    "textures/sprites/bigexp_2.tga": {
+     "bytes": 16428,
+     "sha256": "e594089433cb272b1d55aff6aa9f377b71dcb21051b4cb398d575eabda113bef"
+    },
+    "textures/sprites/bigexp_3.tga": {
+     "bytes": 16428,
+     "sha256": "cd1c4a83e529985f64bbdb7da54b80536fb15ba64a8e85839bb068c1edd873fb"
+    },
+    "textures/sprites/bigexp_4.tga": {
+     "bytes": 16428,
+     "sha256": "cd1c4a83e529985f64bbdb7da54b80536fb15ba64a8e85839bb068c1edd873fb"
+    },
+    "textures/sprites/bigexp_5.tga": {
+     "bytes": 16428,
+     "sha256": "71853da716433395a2e72ffe863fffb9648d1c23387a60bdd5e109dde053cb09"
+    },
+    "textures/sprites/bigexp_6.tga": {
+     "bytes": 16428,
+     "sha256": "23e64f479769b410eb13373a11c5a368ffed0f7c4eed3b695dacfea2adaaa0b9"
+    },
+    "textures/sprites/bigexp_7.tga": {
+     "bytes": 16428,
+     "sha256": "8a38e614909d803e756b245559b7ef6748ff1d43d8bcb5e508779371553edc9b"
+    },
+    "textures/sprites/bigexp_8.tga": {
+     "bytes": 16428,
+     "sha256": "6c44998b440c9b41d62321688ac89ff82225f2b5db097de6bb565d3c49da50c7"
+    },
+    "textures/sprites/bigexp_9.tga": {
+     "bytes": 16428,
+     "sha256": "a9fef05f47c073cd19d664f3f5308128282d717fec90f20af05a42fa0702b8e0"
+    },
+    "textures/sprites/s_explod_0.tga": {
+     "bytes": 66086,
+     "sha256": "aca84ae79d847fbf97778952af14bb32f1327772ca96f39762f3a3c279d8642c"
+    },
+    "textures/sprites/s_explod_1.tga": {
+     "bytes": 66086,
+     "sha256": "00232a935dfdc08d2616b6805fd793f40301eb69ee73cad734d3e33415656dc7"
+    },
+    "textures/sprites/s_explod_2.tga": {
+     "bytes": 66086,
+     "sha256": "b06a6c0cf89258c046c21eadec3ad0ad39abe38ad2814a7f20208c39027b6035"
+    },
+    "textures/sprites/s_explod_3.tga": {
+     "bytes": 66086,
+     "sha256": "90544bb8521305f888f165f29977a260cb903c097fd324176b881a98315999fa"
+    },
+    "textures/sprites/s_explod_4.tga": {
+     "bytes": 66086,
+     "sha256": "6fac34e4b658f74f6f0a79d4bf1f392360740e1cf1db1c5009195f7834e0c9f6"
+    },
+    "textures/sprites/s_explod_5.tga": {
+     "bytes": 66086,
+     "sha256": "cc97671a56e02a36c80fec461b3eeb3a72e4ec7d9df9325c66a7ffdaba4fcee7"
+    },
+    "textures/sprites/smlexp_0.tga": {
+     "bytes": 66086,
+     "sha256": "93bef1197b2cdfd46cf35a834945603384772b0d72825b6d0bae3f913ed75ba4"
+    },
+    "textures/sprites/smlexp_1.tga": {
+     "bytes": 66086,
+     "sha256": "c046b1b30699d215bc21c98b4310d141e819c4de1d9f86575edf432ebdf87c3c"
+    },
+    "textures/sprites/smlexp_10.tga": {
+     "bytes": 66086,
+     "sha256": "d044c905c385cad68313af41766b0a97bca443def1e8ff5437f5ce4cbd568e0d"
+    },
+    "textures/sprites/smlexp_11.tga": {
+     "bytes": 66086,
+     "sha256": "7bafa49bad3f8b41d442e545d893b040a111f4b2c21ab016d9d9a82eda503975"
+    },
+    "textures/sprites/smlexp_12.tga": {
+     "bytes": 66086,
+     "sha256": "1139ba508ce8aeacf3136df794fd1144d765f5e426e8bcd3c6f4db6ac9ecdb4d"
+    },
+    "textures/sprites/smlexp_13.tga": {
+     "bytes": 66086,
+     "sha256": "e0db18bd0ef5d2e89044a8a7ce72e1ed816415269d5425ed6da1177e9dc4fbc5"
+    },
+    "textures/sprites/smlexp_2.tga": {
+     "bytes": 66086,
+     "sha256": "1b00dbbdb82e2fb9f387111bfa384fec1c7fe9e138dd471ca291251dcbebce51"
+    },
+    "textures/sprites/smlexp_3.tga": {
+     "bytes": 66086,
+     "sha256": "c2dd337df177c7e34e0279a04da24214570fb2b7c508fac13c37444d0297a2e0"
+    },
+    "textures/sprites/smlexp_4.tga": {
+     "bytes": 66086,
+     "sha256": "944b9eb3298fa43fdea8ed1f48f417eda411c1303f9e74af643cb225fef261d2"
+    },
+    "textures/sprites/smlexp_5.tga": {
+     "bytes": 66086,
+     "sha256": "e5182474c6fd9a82e220486a848bd85572935330cfc3f6347511a4b30620b5ce"
+    },
+    "textures/sprites/smlexp_6.tga": {
+     "bytes": 66086,
+     "sha256": "9a7d51daf918d14d3b2b2e13bc68ef070d0e781e8b74e901abc9c55d917bccda"
+    },
+    "textures/sprites/smlexp_7.tga": {
+     "bytes": 66086,
+     "sha256": "f5c40ecb20a9a5bd1bd0301875cbfcd387cd9d26127fb07557408dbd6c297b18"
+    },
+    "textures/sprites/smlexp_8.tga": {
+     "bytes": 66086,
+     "sha256": "42b465b1ee2d58a8eb167acbd7ea52ef1990c0050233b1dff81fc7cc9bb3eb48"
+    },
+    "textures/sprites/smlexp_9.tga": {
+     "bytes": 66086,
+     "sha256": "abc761da2216652b8b441708468d941142781033524f02b71f59b627e88093ff"
+    }
+   },
    "sha256": "5cfed3c54a43a8bb2d1c712480acb4bb196bf3f84eff9b2caae819a4b5a66471",
    "timestamp": "2007-05-11T02:45:32.000Z"
   },
   "warp/pak2.pak": {
    "bytes": 19266,
+   "files": {
+    "hearing.dz": {
+     "bytes": 56,
+     "sha256": "01206044a6cd6db3bf96bb0b8977c7d9c84cf2053136ee383049c6210f1db40b"
+    },
+    "maps/neh1m4.bsp": {
+     "bytes": 2604,
+     "sha256": "aef0becb2ca7a83ca3c1d5a993dd875b9b9c836b2e312f57727b8ef0ba64a0ad"
+    },
+    "sprites/smoke2.tga": {
+     "bytes": 16402,
+     "sha256": "b0ad419ce2ea88f23e784587f35fb77f1232a5750f443608430e41d5ddbf4fd3"
+    }
+   },
    "sha256": "54db736fce98245a7b491367af22631b1dd06aa0c760d92f3a952515675cdb03",
    "timestamp": "2007-04-20T16:43:30.000Z"
   },

--- a/json/by-sha256/fc/fcffdbb19986c2d83690c7c7faffb492446175fd8aedbff16bf0b9814ee06aaf.json
+++ b/json/by-sha256/fc/fcffdbb19986c2d83690c7c7faffb492446175fd8aedbff16bf0b9814ee06aaf.json
@@ -12,6 +12,36 @@
   },
   "jzspq/Pak0.PAK": {
    "bytes": 2259644,
+   "files": {
+    "demo1.dem": {
+     "bytes": 29402,
+     "sha256": "5e9ca61a7742b83308aaecb3fdc012dede45684429c0baf8313b63ca8ce90aa5"
+    },
+    "demo2.dem": {
+     "bytes": 560710,
+     "sha256": "c43952a3149a634f39eb27517c97f05e31b66ca99f977011f2cdc5bd61c5b082"
+    },
+    "demo3.dem": {
+     "bytes": 295395,
+     "sha256": "25d4656796c0068c10dfb9422d5df01031578b694fff385ab2a7605e92c22254"
+    },
+    "maps/jzdoom.bsp": {
+     "bytes": 613412,
+     "sha256": "44c6eb34873935cc325666ec63489c086f90b32c08da34735d54be014e08743c"
+    },
+    "maps/jzwolf.bsp": {
+     "bytes": 615660,
+     "sha256": "eb9288e8d9a207b9734dbeadbf49d792d1e8c03a6fc8457d62f0f257a5e6ce91"
+    },
+    "maps/start.bsp": {
+     "bytes": 144312,
+     "sha256": "42d60885e10ccf4fcacf592cd3148075d5a4896a222fb1ec58ec255238524859"
+    },
+    "quake.rc": {
+     "bytes": 293,
+     "sha256": "ba663420fe80019bb267b5817de2cc96fc1c42c2c723fd61b97a0ae8553d0d18"
+    }
+   },
    "sha256": "44c9eeeeafd04ddc99a39fa3fcef8b4f7c519b918e5557c76abf86d645d5b98e",
    "timestamp": "1997-12-20T23:11:04.000Z"
   },

--- a/json/by-sha256/fd/fdbdd85f1912da5a86390251d0b16b63349cbc69d80d31e30ad7beaeac7590e5.json
+++ b/json/by-sha256/fd/fdbdd85f1912da5a86390251d0b16b63349cbc69d80d31e30ad7beaeac7590e5.json
@@ -7,6 +7,56 @@
  "files": {
   "Pak0.pak": {
    "bytes": 2580068,
+   "files": {
+    "maps/t1m1.bsp": {
+     "bytes": 1883308,
+     "sha256": "c0638eb7405beec09e2042d75812b6255d9a675f78d85912cb9f896fb3c25d05"
+    },
+    "maps/temple.bsp": {
+     "bytes": 242840,
+     "sha256": "0a658b5cb14a7eda2a2d6d7be8d163af78e266e5a49b87203c96a08dfb0bc37b"
+    },
+    "progs/bolt.mdl": {
+     "bytes": 20644,
+     "sha256": "37fa6ec840593d41ab76bd2fda0ab655faf1c854dd490af4c6a4dbf2ad38db8f"
+    },
+    "progs/bolt2.mdl": {
+     "bytes": 11860,
+     "sha256": "d25a0a7905aed5cc42a401307fa2d1b1804beb364321b03b7295a0dc8f152f1b"
+    },
+    "progs/bolt3.mdl": {
+     "bytes": 11860,
+     "sha256": "e458d7416bf28a6b035b30a1887fc8eaf11fd15d761070e221b95c7dfdeac3cf"
+    },
+    "progs/demon.mdl": {
+     "bytes": 102120,
+     "sha256": "74948788cb18e9baa3e7cd8249d0a0875a21b11129efb778a460e3a3687d05c8"
+    },
+    "progs/h_demon.mdl": {
+     "bytes": 34884,
+     "sha256": "451b1416f9eab7522e86ba651881a4b19bb4e0263ea23a26a9aa05539d1750e7"
+    },
+    "progs/h_knight.mdl": {
+     "bytes": 7156,
+     "sha256": "2784794b43ecbba4abc5c79b34975ae85328416698c4ff92c91d335443d8f1cb"
+    },
+    "progs/h_shams.mdl": {
+     "bytes": 37060,
+     "sha256": "577373e902db2aa17bd5ac4b9ce6feb201c0fa8a69af077675efbef4a53968a5"
+    },
+    "progs/knight.mdl": {
+     "bytes": 101404,
+     "sha256": "a3a23f12b778f0c5d7a24598903b2e641b7b310cc371bcee41ffccc0f9c4a5cd"
+    },
+    "progs/s_light.mdl": {
+     "bytes": 27596,
+     "sha256": "32a1156fc7390c5e66f5e49438d9f310936eff2cfec7f76141f10bcbdc636b74"
+    },
+    "progs/shambler.mdl": {
+     "bytes": 98556,
+     "sha256": "cf09e108fb1b00c5b901df543359f209ec78fee54a8139f82f4698ae746bf007"
+    }
+   },
    "sha256": "d4f8db1d3c587d0d74b270d45ed67c40e1e7e759e14084fabd047a00f29bd5cd",
    "timestamp": "1997-11-06T23:00:14.000Z"
   },

--- a/json/by-sha256/ff/ff4a1016f152ecaa2ab0007e164de4cb8fda4e60f36acd9bca16e6581a180f8c.json
+++ b/json/by-sha256/ff/ff4a1016f152ecaa2ab0007e164de4cb8fda4e60f36acd9bca16e6581a180f8c.json
@@ -554,6 +554,2308 @@
   },
   "pak0.pak": {
    "bytes": 33441605,
+   "files": {
+    "csprogs.dat": {
+     "bytes": 42302,
+     "sha256": "157d09da08fa62ad5ac1e55d63f9353b6229298d1aef31509d9e1027b6b1d79d"
+    },
+    "gfx.wad": {
+     "bytes": 204788,
+     "sha256": "8b97daeae64f4feb693905206ff585590e7e6e10d93c2ba5b6503cad3fc3ef4d"
+    },
+    "gfx/bigbox.lmp": {
+     "bytes": 5192,
+     "sha256": "6072bd63a691625de201f3f3da060b5df433753d7ac2878c48b87e9d0dd08b94"
+    },
+    "gfx/box_bl.lmp": {
+     "bytes": 72,
+     "sha256": "ac11a967228e1c7d1a936859b82807cea239d80380fb6204d67af7a86c5c82e3"
+    },
+    "gfx/box_bm.lmp": {
+     "bytes": 136,
+     "sha256": "4cb99cf1b515b6547f012b6e44174c245261b058168a8bc4303d08b98e1805b6"
+    },
+    "gfx/box_br.lmp": {
+     "bytes": 72,
+     "sha256": "2c37b7697aebedb5bbf6637d4b8e158f70da6b7245195ff0e91a6ba7aa24e828"
+    },
+    "gfx/box_ml.lmp": {
+     "bytes": 72,
+     "sha256": "219002fe962a017600a37dcdcaaa0f777aad42044619f945cb70c68007763a97"
+    },
+    "gfx/box_mm.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mm2.lmp": {
+     "bytes": 136,
+     "sha256": "5da0c0ba2581419c34e9b1ba7e4398baec090d0a55f9abaee07c08fc54bef8f0"
+    },
+    "gfx/box_mr.lmp": {
+     "bytes": 72,
+     "sha256": "e251893ed49aeb677096d380d4246907a039e0e21a4849f97f343b0b13faead2"
+    },
+    "gfx/box_tl.lmp": {
+     "bytes": 72,
+     "sha256": "64ec646cbab7ebca11f6af4f0b75d9706f438baa7b23059de87f8685f4686640"
+    },
+    "gfx/box_tm.lmp": {
+     "bytes": 136,
+     "sha256": "03c7cdc618e4404e2b9364c690b0a447b4be99dc5af112c66e6e2079902c76cd"
+    },
+    "gfx/box_tr.lmp": {
+     "bytes": 72,
+     "sha256": "9cf2683f2a6d22693a8c0cf35898bc5900a96afc771878df9f8a8a88f3d581c9"
+    },
+    "gfx/complete.lmp": {
+     "bytes": 4616,
+     "sha256": "f232da5cf35acc557f3f312911e6a856cffaaf9f8078ca2ac5ef7e6f6e5e3515"
+    },
+    "gfx/conback.lmp": {
+     "bytes": 409928,
+     "sha256": "0785fcf0a7212a577414e31d7927e8c1a6d429429716dcfb671a1e73387d68cd"
+    },
+    "gfx/dim_ipx.lmp": {
+     "bytes": 3352,
+     "sha256": "873af58b7244d6e82feb1af26ac044c9beb43c2865bc51d0485054a562ce861e"
+    },
+    "gfx/finale.lmp": {
+     "bytes": 6920,
+     "sha256": "ba75badfe057b499d33168032dd5dc5a4fd0dcbaef9cbbd27efdb3f056cbfc00"
+    },
+    "gfx/help0.lmp": {
+     "bytes": 64008,
+     "sha256": "55ac1377921460aeb691f86e7a5051e3a5481f24b93cc8578cffdab2854ba0c3"
+    },
+    "gfx/help1.lmp": {
+     "bytes": 64008,
+     "sha256": "9600a66391996cff88d48890adfa516660fce6a32397ba4f54973159785cff4b"
+    },
+    "gfx/help2.lmp": {
+     "bytes": 64008,
+     "sha256": "9f03351fa7f31a23b63e6c13d2a643ed1ae3fd3df0cf2b0db336424eb17016dd"
+    },
+    "gfx/help3.lmp": {
+     "bytes": 64008,
+     "sha256": "b7617428e8d1d74be7b770ef24c744d16c2503efce9c17facf1107cce08f5ed9"
+    },
+    "gfx/help4.lmp": {
+     "bytes": 64008,
+     "sha256": "3036afb422cd299cb09532a20847ef35aaf87bb36e34ce9ce75b5e7aaf9a1ec3"
+    },
+    "gfx/help5.lmp": {
+     "bytes": 64008,
+     "sha256": "7aa61257bd3083c00959776eb36aac86a7ca8da2bacbb4c8a41d9a5fb0b1ab97"
+    },
+    "gfx/inter.lmp": {
+     "bytes": 23048,
+     "sha256": "cfe83953875acfe9afda11b75407ed9883eeb284b0a67b9ff6e07df85d50d9fe"
+    },
+    "gfx/loading.lmp": {
+     "bytes": 3464,
+     "sha256": "d3b4091b83837da5a45445cd00b90267c62050e010e2a045461034ac9c48be33"
+    },
+    "gfx/mainmenu.lmp": {
+     "bytes": 26888,
+     "sha256": "de004dcecdff1973597a977ab63c671ad7d3f52387bdcff4be560924e3d4d17e"
+    },
+    "gfx/menudot1.lmp": {
+     "bytes": 392,
+     "sha256": "078c56d685ff1fb84b322f7a76e485c2637fb09efc61f4e44d5d067b3ef9a42d"
+    },
+    "gfx/menudot2.lmp": {
+     "bytes": 392,
+     "sha256": "9df9672c8da61ae769409e9ea741a1b8f9a4f108b5f0fa6637ff65601c535843"
+    },
+    "gfx/menudot3.lmp": {
+     "bytes": 392,
+     "sha256": "fef6b9be45d5b384d061a47f133075d1cfe0b60d93cf7e3da9ee5529f661964c"
+    },
+    "gfx/menudot4.lmp": {
+     "bytes": 392,
+     "sha256": "1b1254c1f5764affca85448c4a3c2fefdb938f35bc50f44142a8e9b692ba7d64"
+    },
+    "gfx/menudot5.lmp": {
+     "bytes": 392,
+     "sha256": "39a06ff92831e1e2fd20c1bdd20e0f234cd0b3aed94e6c9909d059a20479ce3e"
+    },
+    "gfx/menudot6.lmp": {
+     "bytes": 392,
+     "sha256": "def061c922fb91a7e58850e89bb6baa9e09dcf93de7a94288a90511ecd9a114d"
+    },
+    "gfx/menuplyr.lmp": {
+     "bytes": 2696,
+     "sha256": "f897535531fe4b821d41d859a4085fd7d25c679493645a2ef7448f62073523c4"
+    },
+    "gfx/mp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "d070636562a967d1abff330dcd1ea504ac7b9b29099a98994add1d9ae47e44e9"
+    },
+    "gfx/netmen4.lmp": {
+     "bytes": 3352,
+     "sha256": "6d92547a27d839f3c9d7a1da786fb33547cd93b7f19560b6c4bcdc12064545bd"
+    },
+    "gfx/p_load.lmp": {
+     "bytes": 2504,
+     "sha256": "e932416c58fc5de16e6d05aa737e56d3811e540bfd9e6acd1bf114ccd8bf34ac"
+    },
+    "gfx/p_multi.lmp": {
+     "bytes": 5192,
+     "sha256": "bda55d4b2d7bc3f180dafd62424ee5830896563f5a5ac576dfa08894f5e17e44"
+    },
+    "gfx/p_option.lmp": {
+     "bytes": 3464,
+     "sha256": "513955ecc96eb1f0d44b340b47f79c02bb7bfa7f3b0a884a65fe111429ddb2b4"
+    },
+    "gfx/p_save.lmp": {
+     "bytes": 2120,
+     "sha256": "2faa4c1f61d175ad28b7f54540af3f87abc6e56dc20f2da5fc8a7737a0302c97"
+    },
+    "gfx/pause.lmp": {
+     "bytes": 3080,
+     "sha256": "dcfe5287432b3a1124d032250ccc4bf25c73540521c77601ab746287ef3a0179"
+    },
+    "gfx/qplaque.lmp": {
+     "bytes": 4616,
+     "sha256": "60162286b248619135efc64d3aae14958273b00378233bfcd8f783132e478e87"
+    },
+    "gfx/sp_menu.lmp": {
+     "bytes": 14856,
+     "sha256": "00654b7bec9981508cd9ae8eac167637926c023e7bca011a3cf37585b7e168a8"
+    },
+    "gfx/ttl_cstm.lmp": {
+     "bytes": 4424,
+     "sha256": "74c50b895f1e71ec6a569fba0e991fde8cf136ea734d6914435aaf9b2735d7fe"
+    },
+    "gfx/ttl_main.lmp": {
+     "bytes": 2312,
+     "sha256": "aecab7a199a4db72242659e6d1ced192d39b2619f67c7e5eaafa72a5efef3aef"
+    },
+    "gfx/ttl_sgl.lmp": {
+     "bytes": 3080,
+     "sha256": "d075eb0c8c00d30b01eae539720c20b73bb57066c6ea5e8180a4d851d9167add"
+    },
+    "gfx/vidmodes.lmp": {
+     "bytes": 5192,
+     "sha256": "d03aa05e24552d961ea9ca278d743860e34a97e2ffcee52fded05ad4b4740bd9"
+    },
+    "maps/b_batt0.bsp": {
+     "bytes": 8128,
+     "sha256": "7b9ed3f8f17faf4e114c0ea98cef3c5c314504b0267aeda823e60346ab894671"
+    },
+    "maps/b_batt1.bsp": {
+     "bytes": 8952,
+     "sha256": "2e657135677f7652f02525fbee2a44e1b650c9fc46e7596b8b36506c4fd44f49"
+    },
+    "maps/b_bh10.bsp": {
+     "bytes": 20040,
+     "sha256": "61c46ac5672c1e671c0c38a6498158176feaa62b074621c2a3d74e5dfc68e2f3"
+    },
+    "maps/b_bh100.bsp": {
+     "bytes": 23846,
+     "sha256": "98025db0c093834b07fe0b6db6780bad369f269d37bddddb0b0e76b4855fe8dc"
+    },
+    "maps/b_bh25.bsp": {
+     "bytes": 24896,
+     "sha256": "f23b4439cf15fd39b4784a1618f444b9bbd8310377395b7c391e536f6059700b"
+    },
+    "maps/b_nail0.bsp": {
+     "bytes": 9113,
+     "sha256": "cefd90d5db497be1bd747fa578c6bec490a0b783dc85b9709f79e010a0b245c0"
+    },
+    "maps/b_nail1.bsp": {
+     "bytes": 12694,
+     "sha256": "eb8a863f5b403d3e143b913811cb23c05564400dfc03a0bfabad3b04fb24be66"
+    },
+    "maps/b_rock0.bsp": {
+     "bytes": 6758,
+     "sha256": "bc77230ba171a36b2b6c46c160120227d89e9acd74e3107f237e5ccca8852258"
+    },
+    "maps/b_rock1.bsp": {
+     "bytes": 8606,
+     "sha256": "98b69d75030cbeeda6f5e8cc22c35f0b8ebb7843925771e090af9cf0fa82973b"
+    },
+    "maps/b_shell0.bsp": {
+     "bytes": 10477,
+     "sha256": "7b1283b85dd2887772ec1550f736ad5cc2e474ae93ac7de710d1497c28acd09a"
+    },
+    "maps/b_shell1.bsp": {
+     "bytes": 12709,
+     "sha256": "cdff573741c7f879168ceee6e4fa3fa8fab694530313310d4f4a59766bc34142"
+    },
+    "maps/glass01.bsp": {
+     "bytes": 2336,
+     "sha256": "a186d8e07529fbe09413603e079c2cff2d7a8f83654b15c5e8a4a01c7f6b9126"
+    },
+    "progs.dat": {
+     "bytes": 1101670,
+     "sha256": "79b0b73db03607cb6f63a51bcff341166ad14a5399ed158d1f7c8b1353067154"
+    },
+    "progs/alkturret_base_v2.mdl": {
+     "bytes": 87768,
+     "sha256": "4b1969201052a4506509bb606eb7c395daf9332cf4605036ab50190495dcfbf3"
+    },
+    "progs/alkturret_main_v2.mdl": {
+     "bytes": 116620,
+     "sha256": "11a2564f7daa19625e4514c284650242c8b3831df947f183243adafb958a1333"
+    },
+    "progs/arachnofloyd.mdl": {
+     "bytes": 741212,
+     "sha256": "554bd2ad34a830fa01a61dd4972f432812fb61f7815ec81d8a8d7e87bfad6b02"
+    },
+    "progs/arm_foot.mdl": {
+     "bytes": 51148,
+     "sha256": "3872168c9a37a148f14285f7b8c426a456bd936137191051c3ed10b7d36a049c"
+    },
+    "progs/armabody.mdl": {
+     "bytes": 164224,
+     "sha256": "35314143b9c7a9a0e26e52a865072a6e73862466e640c6bbd58be3075c4d93ff"
+    },
+    "progs/armalegs.mdl": {
+     "bytes": 106288,
+     "sha256": "b33a8f7e4cd3fca9b8c9427d8002a5470da44ce919648e1a0045f3f131f73deb"
+    },
+    "progs/armor.mdl": {
+     "bytes": 59756,
+     "sha256": "a8db38837a15464cd68bc31f07d9966463193463a2a00fd612c6517261393153"
+    },
+    "progs/axegrunt.mdl": {
+     "bytes": 497408,
+     "sha256": "40cc63b599cedb54f04c937ce407e7119c1cf4d5d35fd04bc18f247584e9899f"
+    },
+    "progs/backpack.mdl": {
+     "bytes": 56300,
+     "sha256": "1cd0283e9001acd76551b04b67bf35ec1d6be34382edf25790384741eec31215"
+    },
+    "progs/bambler.mdl": {
+     "bytes": 128044,
+     "sha256": "c8ac9dbcf99f0e6efd30496ac414383c26b8d241fbaff56cfa81dfb545dfb0c8"
+    },
+    "progs/banbody.mdl": {
+     "bytes": 129184,
+     "sha256": "698bf740683ad182feae2246526361948be6da2e144f1bd0202eafa748213ec2"
+    },
+    "progs/banlegs.mdl": {
+     "bytes": 135556,
+     "sha256": "b662513bc3a8e0e967344c55b536bd33012340dbeb79a8db1281d2c84e36d338"
+    },
+    "progs/banner.mdl": {
+     "bytes": 467136,
+     "sha256": "b2cf62d8e989789bd76e27193b2f5205a93d4172a4e25c89aa1b30f75bebe60e"
+    },
+    "progs/beacon.mdl": {
+     "bytes": 43404,
+     "sha256": "e2c7d307b30bcd2342110f446942944455255834b148a8d00db78055680f8633"
+    },
+    "progs/big_bullet.mdl": {
+     "bytes": 14336,
+     "sha256": "bd3d1c4b1e577842602466ef4ba4ca4d8dc6ccbfb6f555eb4851d43769f87b72"
+    },
+    "progs/big_bullet_blast.mdl": {
+     "bytes": 38268,
+     "sha256": "a12aa9acb0ec9d13a5d0fdff9a2cf9889195758f782a7a2c0eff4795408a05e3"
+    },
+    "progs/bigcranea1.mdl": {
+     "bytes": 92792,
+     "sha256": "81f6a5b55d3a585d5e9c73b088d1d20e0fb328707c1539ef41e52c460555f651"
+    },
+    "progs/bigcraneb1.mdl": {
+     "bytes": 21940,
+     "sha256": "e02faff0bb6c84c781f6b534a5a06ac1f977a028fbdcca176be2932f91e9e8ec"
+    },
+    "progs/bit.mdl": {
+     "bytes": 1044,
+     "sha256": "bb3df0c75ff4f6b0cf1437e010c4fa5e1a56cfc26900d12934502bcae3a1fb9d"
+    },
+    "progs/brz_saw.mdl": {
+     "bytes": 18948,
+     "sha256": "1a5f6cd386b324ac30370efcb87c247162584dbb450fc22edaf1a2c86f2a1889"
+    },
+    "progs/c_spike.mdl": {
+     "bytes": 1684,
+     "sha256": "be12eea5a022a7ab6debdf64e39e45cf0201d47cb7b49285025d4c81a4977104"
+    },
+    "progs/cent.mdl": {
+     "bytes": 575288,
+     "sha256": "f571bdf504537ce01ca2b6a78b57575a36c391f9c786625d880d956fb17390a7"
+    },
+    "progs/chain1.mdl": {
+     "bytes": 101258,
+     "sha256": "6e58d56c17c92d241252d586d08cea0c4dd3ab13ea865dc758c0c027fb4f0c27"
+    },
+    "progs/chain2.mdl": {
+     "bytes": 141764,
+     "sha256": "9334a3ec04716ce0068154bf7abb4c1e3ee6de14fb159982dd547314935d7854"
+    },
+    "progs/cyberscrag.mdl": {
+     "bytes": 311084,
+     "sha256": "307e8133ce4f48d4c3dad5ef1b9d32900a3457e91aade778b7fbbc6d8a4741e1"
+    },
+    "progs/cyberscrag_gib1.mdl": {
+     "bytes": 60500,
+     "sha256": "3db8b13bfa5a5eda07acea695cae6ffb92354053da9bed199ef29cd445317faf"
+    },
+    "progs/cyberscrag_gib2.mdl": {
+     "bytes": 58932,
+     "sha256": "ef20c0de15fe2fc2514c10b0023d14009a4871ed40311077ba107350c313f7ce"
+    },
+    "progs/d_explod.spr": {
+     "bytes": 41064,
+     "sha256": "2e477beac43a2c9b42c1fccaf89ae0e026ad21434d380d83a5f7fc544aa2eb95"
+    },
+    "progs/debris.mdl": {
+     "bytes": 26470,
+     "sha256": "0e504dbadf09296b3e7f7e85dc42b1d141a7b4d0d79d8c4027024c50914059a0"
+    },
+    "progs/demon_alk.mdl": {
+     "bytes": 191716,
+     "sha256": "11f33f19ae0a46d3dcc6c1fee46235fb6ad201456120502b603fe4fb7cee14ac"
+    },
+    "progs/demon_old.mdl": {
+     "bytes": 272684,
+     "sha256": "538d5d01833d6910d4400f8795be582c3427748eb2a162fcec2c17d6707c57e5"
+    },
+    "progs/dog_alk.mdl": {
+     "bytes": 199324,
+     "sha256": "a16e350fcd247908c75ecd0c93e94d3b700b67bb0f66dd45d665d171a55d42b6"
+    },
+    "progs/dread.mdl": {
+     "bytes": 415072,
+     "sha256": "dcea570331c5cf4348c40451c6242bf35ecaaea2a348f12254a13c1b76b13d7c"
+    },
+    "progs/drngib1.mdl": {
+     "bytes": 17284,
+     "sha256": "444692074359310be0520b1caa057ae2e084df826f7ecc9bcb0d258ea1d80373"
+    },
+    "progs/drngib2.mdl": {
+     "bytes": 35988,
+     "sha256": "91aa79805577466147bd4811614b0387b3635aba8383fc2e16b178d7b63ebdf1"
+    },
+    "progs/drngib3.mdl": {
+     "bytes": 42436,
+     "sha256": "93839bd6f50323f7ac5ae46037de0c6a10a533374f714229dd511ee62b88ca3c"
+    },
+    "progs/drone1.mdl": {
+     "bytes": 68972,
+     "sha256": "bcc6396dc638003480dba8c36cafaf32df2cfcf49bd460b001d0d74a164f9011"
+    },
+    "progs/edie.mdl": {
+     "bytes": 577028,
+     "sha256": "3c3b7232245433b1a4b71714b0e14eea1d69f0013dfc3a39f100c1a0b7cfaa4a"
+    },
+    "progs/eel2.mdl": {
+     "bytes": 177368,
+     "sha256": "58b9c4a4af9953f8c024158ba8a7cebd33e19834440c09026fd5931cb6b831a7"
+    },
+    "progs/eelgib.mdl": {
+     "bytes": 28844,
+     "sha256": "23363fe79cef4bbb8b1bc4802c4be13ebc4a9c02572d6464806f93824a10c378"
+    },
+    "progs/eelhead.mdl": {
+     "bytes": 51348,
+     "sha256": "cda6bd93c8134b0bc44f7447b1bb327c56bfa58658dca19dd90818b8c42dc1ed"
+    },
+    "progs/enf_gun.mdl": {
+     "bytes": 58684,
+     "sha256": "39ef1788b39a15f86c8d54b81c43f4126e8361ff80d386c44358f17ddc93769f"
+    },
+    "progs/enforce2.mdl": {
+     "bytes": 450424,
+     "sha256": "ecf603c4ebc56438e96d1706a451af8bbe9b090db9c48e38e758ec630a393570"
+    },
+    "progs/enforce3.mdl": {
+     "bytes": 603309,
+     "sha256": "ddcf759804fffd97e62c55f67f962e24e8cd646fd982215ac8aefd3e49f67660"
+    },
+    "progs/enforcer_alk.mdl": {
+     "bytes": 333860,
+     "sha256": "85fb5cb9eb1435da65ce0aa6940241b7b4b5fa13e7444713a75c6ec301cc8b97"
+    },
+    "progs/fgib1.mdl": {
+     "bytes": 9252,
+     "sha256": "35cab9ee2e9af79f9ddf2a3549aa405b7533829b3c9e62279d614accafed3f39"
+    },
+    "progs/fish_small.mdl": {
+     "bytes": 221279,
+     "sha256": "34b883e3bf73a520f301cced68629e0d95e88f96c03a23230f12d02aa49c247c"
+    },
+    "progs/fixture1.mdl": {
+     "bytes": 5848,
+     "sha256": "2e4d2f4fa2d0b62c636cc00fcec1d7408645af015c0d38526d08d6cd606be2dc"
+    },
+    "progs/flag.mdl": {
+     "bytes": 77512,
+     "sha256": "146532c961f0892bd0dea0e74b66f6336d8305f01308cca1f368aabe684beb2d"
+    },
+    "progs/flag2.mdl": {
+     "bytes": 200400,
+     "sha256": "ed03be2f95189e7730a24e4297e2d3f675a9916000ac614f22ef0a5b1a0ed2c7"
+    },
+    "progs/flagbig.mdl": {
+     "bytes": 64852,
+     "sha256": "0ea8d35877463945ad40e9779d50fb7bb4a92c837497e8e71dc270215709fde5"
+    },
+    "progs/flaser.mdl": {
+     "bytes": 11348,
+     "sha256": "2d2b3c26ddac8c790b3a9220e02affe06bd654a7cac4290a7a0b724895d94455"
+    },
+    "progs/floyd.mdl": {
+     "bytes": 345512,
+     "sha256": "4e58c272389ba05734d3acda3f2606f54a6f951b3b3695aa2bb865965af1a241"
+    },
+    "progs/frogman.mdl": {
+     "bytes": 451032,
+     "sha256": "1a311e7e74f9a67c9f7468252aedc8c19804f65375d229e90afbec2f93849823"
+    },
+    "progs/fromitz.mdl": {
+     "bytes": 6964,
+     "sha256": "f9faa3414644b1e829870fcc02eb73fbd9199b4db17579008c7336c9d26471a8"
+    },
+    "progs/fromitz_still.mdl": {
+     "bytes": 6964,
+     "sha256": "63204597e828e001c957e9316878995e161da0502764276b90285accadf6a222"
+    },
+    "progs/g_axe_alk.mdl": {
+     "bytes": 50460,
+     "sha256": "92988e970870f2b977f7490d2ea4ee040d338fa4bdc470e8d68f2e5a856a7a28"
+    },
+    "progs/g_laserg.mdl": {
+     "bytes": 64840,
+     "sha256": "3ea51e8940c4a90018c9364fed078cc03a60d2545cfa572fd3c94f06093352fa"
+    },
+    "progs/g_light.mdl": {
+     "bytes": 41396,
+     "sha256": "5f82b1469ec36524688e122981a5b15232f01ab6d1fea3bdadafd68b1f8f7002"
+    },
+    "progs/g_mine.mdl": {
+     "bytes": 37780,
+     "sha256": "5057c7736e8c722270c781e47584972f42e7ebdd5860596403a9ce7688d0b5cc"
+    },
+    "progs/g_nail.mdl": {
+     "bytes": 25604,
+     "sha256": "de7d3ebaedbeedcba46813ad97447bc257682049109173b48ace94c1d6e01222"
+    },
+    "progs/g_nail2.mdl": {
+     "bytes": 25092,
+     "sha256": "d393edc7877f7a8a6568d9f60b91376e9c121e174e1720857a82554e47e9f0c4"
+    },
+    "progs/g_plasma.mdl": {
+     "bytes": 82420,
+     "sha256": "15f390e39e02c8524e575ca8fadf63187b641c58210ee9587b13a0ca94c29cc2"
+    },
+    "progs/g_rock.mdl": {
+     "bytes": 26932,
+     "sha256": "88d343925240c88502d9f4ac79e9e977429f31824fde12e12e8721cab054acea"
+    },
+    "progs/g_rock2.mdl": {
+     "bytes": 22020,
+     "sha256": "038272689a9c63090a71badde3d05aeb5d1ec89fbab6923db1180b67b4309f18"
+    },
+    "progs/g_saw.mdl": {
+     "bytes": 199076,
+     "sha256": "7ddca6fb95082d0cc7ffe5aa3ba896ea987a80b1bd5867db97b2a84b9d8da9f6"
+    },
+    "progs/g_shot.mdl": {
+     "bytes": 20420,
+     "sha256": "708b04f6821f3630ff622b8bf9a749fb39165c367476b8538ce39dd0467ca43b"
+    },
+    "progs/g_shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "8b05b8ca87ea867c2a2397d238311fda2441f5c0e1cde130ba487b0dbd17a8e5"
+    },
+    "progs/gib.mdl": {
+     "bytes": 41984,
+     "sha256": "61e67473a09faa15e0624fc96224c484315e2eca8904492abe75d29f19ea1159"
+    },
+    "progs/gib1.mdl": {
+     "bytes": 7712,
+     "sha256": "83fb8b33849dc7c38b81e0de21f803a89008a356e84324a94f50b5129ed07829"
+    },
+    "progs/gib2.mdl": {
+     "bytes": 21216,
+     "sha256": "6479902d817ef744a2a471b7e6f4cd4f05866dc0c906d93d49c972e9426613dd"
+    },
+    "progs/gib3.mdl": {
+     "bytes": 18176,
+     "sha256": "c5d7fd1d406c74a8b5735e7f74ac51f4351a1b69ef4776b16da91700fc851c58"
+    },
+    "progs/grenade.mdl": {
+     "bytes": 51108,
+     "sha256": "571b54cec38f5d9e3435971e5cc1ac8c5c341bf2cdfc16ee3f80f38ce6c38f54"
+    },
+    "progs/h_arach.mdl": {
+     "bytes": 60292,
+     "sha256": "daca6412383bec28809cee42c4ebf01085cf83ed6ff289114ba0f842b4005251"
+    },
+    "progs/h_bams.mdl": {
+     "bytes": 37316,
+     "sha256": "58c4644a2ed3e5f10741dff2ad1a8bb161f7eb205ba3fd8c5fc9b7e4ffc571dc"
+    },
+    "progs/h_cent.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_cyberscrag.mdl": {
+     "bytes": 62036,
+     "sha256": "df7d6bccc97bd5c184d9d6160005b370175aacc16a34bd06ab14c7d69ff60419"
+    },
+    "progs/h_demon_alk.mdl": {
+     "bytes": 72644,
+     "sha256": "22a9e01cdccb2e274c63c277e6dcd61986fa7556426ee3562fe11af2babea289"
+    },
+    "progs/h_dog_alk.mdl": {
+     "bytes": 31028,
+     "sha256": "f9661c7732bd9c19b164fc7220bb80c1ca6cfbd11c9728a341f65bacc72714d7"
+    },
+    "progs/h_dread.mdl": {
+     "bytes": 11828,
+     "sha256": "4606d8d99742354d59b0f222d3d589a8c2982837ae6fc32637e03e6c76ca8592"
+    },
+    "progs/h_floyd.mdl": {
+     "bytes": 60072,
+     "sha256": "58bb5251428075b2607a6a8e00fbf7491fac379cfcb3732d357c7944e6079d78"
+    },
+    "progs/h_guard.mdl": {
+     "bytes": 5428,
+     "sha256": "a664e3b12255b48a07ac7191f99126fd038e7c93784731608ac9bcfc3182bf90"
+    },
+    "progs/h_hunter.mdl": {
+     "bytes": 9060,
+     "sha256": "1af8fbc00fd2cb4a4897892650b1806818c8d9d32622525cfdadb827edcfe8b8"
+    },
+    "progs/h_me.mdl": {
+     "bytes": 11828,
+     "sha256": "8e86be042986a544325bf78e92913893c0894626fd0e50d7e22c98aa14a63c9c"
+    },
+    "progs/h_mutant.mdl": {
+     "bytes": 110240,
+     "sha256": "f1f9c665b659a8c145550605ef9abddf27779d0917c897baa344d65673770875"
+    },
+    "progs/h_ogreb.mdl": {
+     "bytes": 14900,
+     "sha256": "c09a880910395c9b5e89d8f795f0749bc70523346df27aab3d6c8be86fbaff9f"
+    },
+    "progs/h_sabrkn.mdl": {
+     "bytes": 11828,
+     "sha256": "050fcc93189211aba943674a326ddd898dc980b83fb551ee11fec3dd39973483"
+    },
+    "progs/h_scourg.mdl": {
+     "bytes": 27796,
+     "sha256": "36f7e656c04f19c91c30977bd4c64d81e0aa1a8b942c93a6a2103f74f86b9c92"
+    },
+    "progs/h_shams_alk.mdl": {
+     "bytes": 37268,
+     "sha256": "9fcace6cfb38473763a5cf96007ccc5e0ec4786352d4d1063410d63157298b45"
+    },
+    "progs/h_torm.mdl": {
+     "bytes": 62056,
+     "sha256": "db0ddda0c4d2283cd3c58eb45397cfb57095acba1eb6dd38571ca23ebffe9946"
+    },
+    "progs/h_wizard_alk.mdl": {
+     "bytes": 14948,
+     "sha256": "5f6c27ba255b87718d993b29cff526bd025c0e7a4991722a96fe3c0f98d83408"
+    },
+    "progs/h_zombie.mdl": {
+     "bytes": 4484,
+     "sha256": "90f40b2289af7c39ddce145cc214091066e108631fd0811d4d0bfa3a7f5f80c0"
+    },
+    "progs/harpoon.mdl": {
+     "bytes": 16520,
+     "sha256": "9183df9e7f9ca87091b1fb576b04760712172be649329c7682870db0f76c02ec"
+    },
+    "progs/hknight_old.mdl": {
+     "bytes": 418144,
+     "sha256": "40bd5757499a2bf7e6f60a78b0039665107c9603c2557f6bc73208e080111464"
+    },
+    "progs/hunter.mdl": {
+     "bytes": 580372,
+     "sha256": "a18eef1474c64a5b1def8e16ade81d204645f731814c96e1fc75b9223c71ee20"
+    },
+    "progs/hunter_gibs.mdl": {
+     "bytes": 265688,
+     "sha256": "daae3cd89c7e87bb1e5f9909a7b4a1a7aa3e5cbf64f1f79b50d859a0773b955e"
+    },
+    "progs/invisibl.mdl": {
+     "bytes": 37012,
+     "sha256": "e3c6cbabfe6c6723101f2e59f50fc99ee0e360571c95885d2d56c85eefade15d"
+    },
+    "progs/invulner.mdl": {
+     "bytes": 24052,
+     "sha256": "74f2afc22dc19b76bb2f880f53e589074e17cdc57bfbc71fba83745e50906cb3"
+    },
+    "progs/jumpblue.mdl": {
+     "bytes": 37428,
+     "sha256": "be4e85e5fc643e91377d69794b997ad4dc927ae3866dfef5288d704dbc0f16d7"
+    },
+    "progs/jumpgold.mdl": {
+     "bytes": 37428,
+     "sha256": "4c543d82c88009cab7fcf6230feea0a21518a98f430636194fdbf5c1e526cc13"
+    },
+    "progs/k_laserspike.mdl": {
+     "bytes": 17584,
+     "sha256": "684936126a27f5d12d09135e5ac17e5dece9b74b1c0a80009b19440fca4e39eb"
+    },
+    "progs/knight_old.mdl": {
+     "bytes": 208068,
+     "sha256": "5cca43e29392051c9ba95838a58cc1038560411e6c0d2aff61867a428b119e2a"
+    },
+    "progs/laser.mdl": {
+     "bytes": 44156,
+     "sha256": "c033f66e7f2336a96f4afdf2af256a7d6cd8a223199c6fcc89c01cab2a9a7d82"
+    },
+    "progs/lasrspik.mdl": {
+     "bytes": 11348,
+     "sha256": "26991bd856edc7384e70ce19ccea146a134742d07ee05261cd32d56c72275ace"
+    },
+    "progs/m_cells1.mdl": {
+     "bytes": 3252,
+     "sha256": "63220c0ebb6e266576cb3107a44be16bda10d69fa524d0462514edff9d80328c"
+    },
+    "progs/m_cells2.mdl": {
+     "bytes": 4532,
+     "sha256": "29bc55efafbea3e15a385598750ba4d9242d0a87803a6bc3430ed772ec1785c3"
+    },
+    "progs/m_h100.mdl": {
+     "bytes": 17992,
+     "sha256": "b4c84d42ad06a5e86b197aeeac636443724012fa2fe2db273ee5f7dadf05e2f4"
+    },
+    "progs/m_h15.mdl": {
+     "bytes": 3252,
+     "sha256": "9bc4debe9c585ced842bf0486c912f45dbca3175b74980f7039c6413d2756b8d"
+    },
+    "progs/m_h25.mdl": {
+     "bytes": 14792,
+     "sha256": "013237ff349a81f05dd84da92ef2f3cc5b7535e50bf004d8bf55f0254c461b03"
+    },
+    "progs/m_nails1.mdl": {
+     "bytes": 3252,
+     "sha256": "f1e799e7feac3c340676bb60f6cc7a2a7d1e121b196d1f6d0e23edea3a614ed6"
+    },
+    "progs/m_nails2.mdl": {
+     "bytes": 4532,
+     "sha256": "92370f5b196dc00460d73697975d14279ef659c87c7fc1613b9cbfb68e6c299c"
+    },
+    "progs/m_rock1.mdl": {
+     "bytes": 3252,
+     "sha256": "4c5db792da6876f935f8a98a74f51708d52ca03f04975f28518051494660bf65"
+    },
+    "progs/m_rock2.mdl": {
+     "bytes": 4532,
+     "sha256": "781837a3557c1a8b89c15fa8f477989cb4b77d8cff09c8c13d071090a4df9c1b"
+    },
+    "progs/m_shell1.mdl": {
+     "bytes": 3252,
+     "sha256": "2feb7ce08070b314d163cbc7f2e2eae0986400c482f752d305ddba268639b3d8"
+    },
+    "progs/m_shell2.mdl": {
+     "bytes": 4532,
+     "sha256": "04f7fc8b0c2be7ea93021819770145eaf828b2313c4fc591a5f2aa783ca97e61"
+    },
+    "progs/memissil.mdl": {
+     "bytes": 8372,
+     "sha256": "9b6a8f7a49fb7a1f5d4d409b708663c579d433e978d898b9bdf00291a59b4e6c"
+    },
+    "progs/mervup.mdl": {
+     "bytes": 32948,
+     "sha256": "3208053440304d6bf1ff0a15dd4f3c23f7f2301a6254045cd12d70ada4cfc899"
+    },
+    "progs/misc_empty.mdl": {
+     "bytes": 856,
+     "sha256": "a2e1fade96aba51f5e7b2acbe571122b9f9a2d43a9fdbc841847eeb821dc1065"
+    },
+    "progs/misc_scientist.mdl": {
+     "bytes": 198644,
+     "sha256": "fa5d7a5e2410ac7faa5dd0a8e17873c972c6e5cfeacc94118f22db1b4b17477c"
+    },
+    "progs/missile.mdl": {
+     "bytes": 8372,
+     "sha256": "5c4b9d831357ad72e5f47c38e13b8e2ab04b80fb9d8ed6ddd3667a5eea9a585a"
+    },
+    "progs/mutant.mdl": {
+     "bytes": 352720,
+     "sha256": "262ffca22e0c7308950076c2789436a891399862ea25afbd06040158ec9f7984"
+    },
+    "progs/nsoldier_alk.mdl": {
+     "bytes": 563108,
+     "sha256": "6071d7cecf231f0a83f2e1c7df533b4a32beb6e75969d17703446a67d011695a"
+    },
+    "progs/ogr_gun.mdl": {
+     "bytes": 52452,
+     "sha256": "eaa6e0fe01255450d578f151c06c5aeb6a9cd5ed90edbbe4f52d305069ed6825"
+    },
+    "progs/ogre_alk.mdl": {
+     "bytes": 315696,
+     "sha256": "31e9986373dc1a8cba00e09ba9b0278cf766bbd074524a891ed22329f697d643"
+    },
+    "progs/ogre_old.mdl": {
+     "bytes": 315696,
+     "sha256": "53317e9b684701e7722bea342af1a6dba5dd31e72cdbcfa5b097382516d1c6a3"
+    },
+    "progs/ogreb.mdl": {
+     "bytes": 487968,
+     "sha256": "ae0abff3ea3fc7ca8c7f80c5d8825553795a1c1ebb80127d46fa52b20905abc4"
+    },
+    "progs/ogrem.mdl": {
+     "bytes": 378296,
+     "sha256": "2bb999bf580d16fb9ee4246dea7897236d6d118232c78a6168f641dc32778fb5"
+    },
+    "progs/pbullet.mdl": {
+     "bytes": 45876,
+     "sha256": "1138a77a7f5898f26756ce32b9fb64772eba419ed71e478d99198a9b6ae9a3a6"
+    },
+    "progs/pellet_tracer_short.mdl": {
+     "bytes": 58148,
+     "sha256": "5b24b67ce9d9b2634d9a0f31319a977e1e3ec6352d491367941a0e5bf2ae10ff"
+    },
+    "progs/player.mdl": {
+     "bytes": 273808,
+     "sha256": "382ed83ac6fca7b41f5f0c4e0f06683a2bb0ac6259ad4af9d7cca12c41967bcd"
+    },
+    "progs/probegren_body.mdl": {
+     "bytes": 139044,
+     "sha256": "da0ddf337c3e2515688f2b143adf55d4ecbbfa32955a78aea01ed16e067b0065"
+    },
+    "progs/probegren_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "4f292b6f157d226e763ff28dad682ce95cfb8a3a21b4badf0ca48db4900cdd70"
+    },
+    "progs/probegren_gib1.mdl": {
+     "bytes": 63788,
+     "sha256": "0efb081efa87c9db990d984f9974f10078890a51894a3e0a6fbe76cc3c4cb5a7"
+    },
+    "progs/probegren_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "7843ddefa22b7d5beb37f889c606c6361792508c2bea202f3dadf9f3ffce73de"
+    },
+    "progs/probegren_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "7baac250aa8c27ef3158de59b536ebf59509e39b1f7bf6be1c24fd5b1e29cae0"
+    },
+    "progs/probelasr_body.mdl": {
+     "bytes": 84296,
+     "sha256": "ac545d0f545488628c864df6e464d10fbd51cb41a2cb76c46dd91233ecd11a6f"
+    },
+    "progs/probelasr_dome.mdl": {
+     "bytes": 77148,
+     "sha256": "cec7b847c9b05f2653113454348799b9bf09c2a74c8e1760cca0ff52c1dfc18c"
+    },
+    "progs/probelasr_gib1.mdl": {
+     "bytes": 58700,
+     "sha256": "ae9f298abc0bb1d09cea3c04bf02216b0a1c3749f8c8a822d973b4c2091cd649"
+    },
+    "progs/probelasr_gib2.mdl": {
+     "bytes": 57164,
+     "sha256": "07d6defee5ce4e747daf8b397a5d207a1a42e3c3acffbdfc18d6720c88ec635c"
+    },
+    "progs/probelasr_gib3.mdl": {
+     "bytes": 57132,
+     "sha256": "8b8f376afa56e7a9f311e58a076f1fa3a52c88064887a8e0960fdb6daaf5265e"
+    },
+    "progs/proxbomb.mdl": {
+     "bytes": 12653,
+     "sha256": "162632bc16838f66f29e0b788845a6421b7fce708003e9fa6f4eb8ae7aa8e5be"
+    },
+    "progs/quaddama.mdl": {
+     "bytes": 9364,
+     "sha256": "f3b7e52f31bbf51ceca2c594af5392b90a5b414171309a0cc11599a93dc5b7a2"
+    },
+    "progs/rail.mdl": {
+     "bytes": 12244,
+     "sha256": "8644a309e4f88774ab5537c94a429a2aec090e45f6ce4a687682481d87afff52"
+    },
+    "progs/ridbody.mdl": {
+     "bytes": 200152,
+     "sha256": "a564fba381d24e3084bc9aa0a026381c83e6b889632c8bebdf69c08c8a6bb9f2"
+    },
+    "progs/ridlegs.mdl": {
+     "bytes": 139676,
+     "sha256": "f65ba83d82e90808af589ded17378f1baf37f105fa14f2b157227ee22583d25d"
+    },
+    "progs/s_bullet.spr": {
+     "bytes": 288,
+     "sha256": "6ff2797f9dc4e66f2113475a5f3e0e96f23dacbddd18fe47c8b5e12e712f0e75"
+    },
+    "progs/s_bullet_new.spr": {
+     "bytes": 708,
+     "sha256": "a07fa61f4a838ac9ad8ec85ae525d70fb934d383effd1948c0775497be713043"
+    },
+    "progs/s_exp_small.spr": {
+     "bytes": 18972,
+     "sha256": "b3f1971bd28f96c623c5712e2a47f54f16c99a50d460a944cdcdf29e6eb03963"
+    },
+    "progs/s_exp_small_2.spr": {
+     "bytes": 201720,
+     "sha256": "f7fdba9e2b9b5d318cdff33a06fad4e91e46ba3a241fe7ced4bfbcf0bcb0e873"
+    },
+    "progs/s_explo2.spr": {
+     "bytes": 13980,
+     "sha256": "428ae8400e17b253335d683a685e20d0e61bf0785c79ada81471532166726c46"
+    },
+    "progs/s_explod.spr": {
+     "bytes": 72892,
+     "sha256": "db5f0490fd88e3b96dc7ea4f2e4c697553f62e3271aa56fd922c49060260330c"
+    },
+    "progs/s_flame.spr": {
+     "bytes": 25284,
+     "sha256": "1d7d679bad0e253d592e84a4e3aead63a722d3dff6e8cdb2d7b8007cb95f4c70"
+    },
+    "progs/s_grate.spr": {
+     "bytes": 24732,
+     "sha256": "ccd119fa3025aa1b1a05ad0bf63d242fa85058945bd8111a3f9d69928c86d1c2"
+    },
+    "progs/s_plasma.spr": {
+     "bytes": 5560,
+     "sha256": "0402e53eba5c6349fecd50ed4c68371794b9fb600866c65fc5117c5a96c90ebb"
+    },
+    "progs/s_plasma_new.spr": {
+     "bytes": 13980,
+     "sha256": "5474060e55af3c462d0ef7aad043f331c1f5b642915d906c1785bb94595cc68c"
+    },
+    "progs/s_smoke.spr": {
+     "bytes": 22128,
+     "sha256": "509fa58c47e873d48d3508a78a8f69a122c4dcbb05f39a0f85cbe1d32f88d3ab"
+    },
+    "progs/s_spark.spr": {
+     "bytes": 297,
+     "sha256": "92a9187b59bc29fb62abd8860b58cbcae53711a79add5d9f42292a3303b0b7b4"
+    },
+    "progs/s_spike.mdl": {
+     "bytes": 2820,
+     "sha256": "ea66402d248232b0b6a77bffe024d4a62881be47becf37acb42328661b7f23ef"
+    },
+    "progs/scor.mdl": {
+     "bytes": 97396,
+     "sha256": "13f3baa6760b38c1a7ba30eea9b581754dd87eeb1875248ce6feb1d1efb3582f"
+    },
+    "progs/shalrath.mdl": {
+     "bytes": 87544,
+     "sha256": "a8f1fa3ce907a0439ee0500082083e0439c88e4e82d292d54106f242028fe551"
+    },
+    "progs/shalrath_old.mdl": {
+     "bytes": 211576,
+     "sha256": "409cda15df7b271bd95a895f058a521d43eca63f37c7ac9df175e5b478229bb9"
+    },
+    "progs/shambler_alk.mdl": {
+     "bytes": 502148,
+     "sha256": "bcf685fcd1f4062dc382924d39eae073fc4d44cd2dcb5bc4ca3797fe0b342b71"
+    },
+    "progs/shard.mdl": {
+     "bytes": 10132,
+     "sha256": "0f756f280c09f44ef1e9f36fdd678566b4a5782b349a3e9fe1309c3fcd9ab19b"
+    },
+    "progs/shelcase.mdl": {
+     "bytes": 5268,
+     "sha256": "11279e2d38e6071c4198839768637c71e8c07c1e561fce6e611419f06af674c9"
+    },
+    "progs/shotgn.mdl": {
+     "bytes": 23380,
+     "sha256": "662d6a7cd68bca7a9c5e88838d190de6a501252a14b6994a191d0bc91f1f331c"
+    },
+    "progs/sknight.mdl": {
+     "bytes": 460932,
+     "sha256": "9213f6898a60cdc20a7a144c61c13f8d64f1432382dca44b636524edf737dac8"
+    },
+    "progs/soldier_alk.mdl": {
+     "bytes": 359276,
+     "sha256": "623374e5a553c3d886738c9cc0b22c0b3f3435b3dc1b3f473079a1dd1661fc8a"
+    },
+    "progs/spark.mdl": {
+     "bytes": 9588,
+     "sha256": "74dc6734e0ce30447942a10e9ec78c7cf43eafb86f290cc772b2a8874702b858"
+    },
+    "progs/spiderbot.mdl": {
+     "bytes": 82476,
+     "sha256": "e85556a194664a5f69e70b42aa863d9e67689a418a3afa51e50816174a6fe8ac"
+    },
+    "progs/spiderbot_gib.mdl": {
+     "bytes": 19444,
+     "sha256": "96ee732ac1199a89c675880700c24e1f09521c35ad478f73aaf4278a398454f6"
+    },
+    "progs/spike.mdl": {
+     "bytes": 2820,
+     "sha256": "783d711b408498dbb34581c9a0ae74ed325dc5c68fa67873745b02c8a926a201"
+    },
+    "progs/supbkpack.mdl": {
+     "bytes": 44408,
+     "sha256": "781c6b5f424fb58e06b2a84b1fb7e980778decde6b3ed257e224db0b1f250173"
+    },
+    "progs/torm_largeshot.mdl": {
+     "bytes": 37852,
+     "sha256": "ce3a87be213e39b48bc71a6fbf5e1fe9e3f5209901ca45801f27d8f297e04a01"
+    },
+    "progs/tormentor.mdl": {
+     "bytes": 461080,
+     "sha256": "df302dea113f54df908f97c26de844d1235004c08aefcf5c349f3af4b0957d41"
+    },
+    "progs/trifecta.mdl": {
+     "bytes": 25460,
+     "sha256": "2c9196af0806c48354f5522a8b7f6fa57e6390f8dfb51718fb71b8a2d4d7447a"
+    },
+    "progs/turbine.mdl": {
+     "bytes": 44156,
+     "sha256": "f55853c41d6dabffd846a18aa42fc396de3d23a59e64600e4fe52d6e745683e0"
+    },
+    "progs/v_alkaxe20fps.mdl": {
+     "bytes": 96428,
+     "sha256": "4405242db772d86c66f1012b140ba409bee86682fa5f4a6ca12c3e6f94eb9fcc"
+    },
+    "progs/v_axe_alk.mdl": {
+     "bytes": 55820,
+     "sha256": "80ad34cf2612f8fa9121f2be0ada92c1e05613ae2b35b2a1be25a4c694dd2147"
+    },
+    "progs/v_laserg40fps.mdl": {
+     "bytes": 142580,
+     "sha256": "b897ecb5868e3125597d51f970075af04782cba47ed8a42d7b17775dff01f536"
+    },
+    "progs/v_light.mdl": {
+     "bytes": 22212,
+     "sha256": "7d5708699359a37f9dec8742ecb91fe382764ec338a0d94917ca7f2101cd45fc"
+    },
+    "progs/v_mine_40fps.mdl": {
+     "bytes": 332920,
+     "sha256": "0039956e96a804229359aaf082b9cf66515d52360867b86c3dca884d19caf8b4"
+    },
+    "progs/v_nail.mdl": {
+     "bytes": 47140,
+     "sha256": "60fcfb73839519938b8176dda6ec4920d8700ef87df9e3a6cfdcfd7f96ed48a6"
+    },
+    "progs/v_nail3.mdl": {
+     "bytes": 124944,
+     "sha256": "19045e9a5154299b68377744ad946fc3e7f2bd290497c8291a2247ed8cc572ad"
+    },
+    "progs/v_nail_alk40fps.mdl": {
+     "bytes": 44692,
+     "sha256": "402b3dc06f1e5e756cfd50cab17cca49e17e261994c5007cfd46c466a08d3dad"
+    },
+    "progs/v_plasma.mdl": {
+     "bytes": 260692,
+     "sha256": "0982368440a5d20d65ec511207590c2bfb63e9a60376a5d753b209f2b047c58b"
+    },
+    "progs/v_rock2_40fps.mdl": {
+     "bytes": 139668,
+     "sha256": "89257b7580ac3f48fc775f121eef3508c326eba1369e6aacae83144f8fdfca15"
+    },
+    "progs/v_rock_20fps.mdl": {
+     "bytes": 39556,
+     "sha256": "ebdd6245e1ff65bd95eaed7fa189ac87b51818408f091a32de3f4a477b90f2f8"
+    },
+    "progs/v_rock_40fps.mdl": {
+     "bytes": 43828,
+     "sha256": "f3c32a1c37d4fc3115a8da00ba9507cdd508a98f65e2ddccbcbdc8a0ba0bf2ea"
+    },
+    "progs/v_saw.mdl": {
+     "bytes": 326464,
+     "sha256": "dd389cc337d8b7675d9a7b983fd9f53f0c59d597a9759367bd1e1beba375eaaa"
+    },
+    "progs/v_shot2_40fps.mdl": {
+     "bytes": 29076,
+     "sha256": "37ae91c018183faef847aad217da537c97b5a2430ab27a860388bffc1f4514f6"
+    },
+    "progs/v_shot40fps.mdl": {
+     "bytes": 29252,
+     "sha256": "87a47e2debbc27fd6c18a8a38a9a373e7b73ba707458e6346f069c1572df47b4"
+    },
+    "progs/w_g_key.mdl": {
+     "bytes": 10196,
+     "sha256": "bf5c4ffac0c77e4e039af048ebef10cc8d68644f13956a75fac65577c840cd8e"
+    },
+    "progs/w_s_key.mdl": {
+     "bytes": 10132,
+     "sha256": "d368ad594376bfa4c3c3b77bb467b91d62296a6385c276b2d76cd44891d1a752"
+    },
+    "progs/wizard_alk.mdl": {
+     "bytes": 158508,
+     "sha256": "aab430eb2dc0f5c50ca7b4492a7ccc427f2a12011f54ece1b81d4beb66acb4a9"
+    },
+    "progs/zombie2.mdl": {
+     "bytes": 130148,
+     "sha256": "185336c7bffe32e496e93f6828278287f89b672c71f2439918ac5e220ae8b868"
+    },
+    "quake.rc": {
+     "bytes": 1288,
+     "sha256": "1a304edb15f6384b5c89276fd0efb8e63614a349cd49d1c0157deb9656171708"
+    },
+    "sound/arachnofloyd/death1.wav": {
+     "bytes": 119460,
+     "sha256": "d16c7ff30e9df62fbcda102befbd61fe234532f6aef30d0b34c25330679682bc"
+    },
+    "sound/arachnofloyd/death2.wav": {
+     "bytes": 99220,
+     "sha256": "b06280b75ef16708444378fa324f5cef097c45816cfa4e38844b493aea7edc8c"
+    },
+    "sound/arachnofloyd/idle1.wav": {
+     "bytes": 34254,
+     "sha256": "35d6991a10637251ec0d6b830f7f57f394e4eed06e7a9dced86f0128ba5bc49e"
+    },
+    "sound/arachnofloyd/idle2.wav": {
+     "bytes": 35118,
+     "sha256": "187d8147ef3b5465f1e6fe8241f91fe66c1243d7da324ab87c081cc50e8a1293"
+    },
+    "sound/arachnofloyd/leap.wav": {
+     "bytes": 70884,
+     "sha256": "f47323f618db14755c57e9e25213267dcffc501fbaa9a201176ab99db6cda928"
+    },
+    "sound/arachnofloyd/pain1.wav": {
+     "bytes": 28048,
+     "sha256": "4c911f3d12df6748758033e518167f938ee76c03a9ef3bc267f19ff8b1150d8a"
+    },
+    "sound/arachnofloyd/pain2.wav": {
+     "bytes": 15906,
+     "sha256": "9c4bdc81c73787cb67677e0021b71d9e24734ef3ce272d9020dc6611a1d87842"
+    },
+    "sound/arachnofloyd/sight.wav": {
+     "bytes": 48620,
+     "sha256": "97a055dbb8e5935190348b2c2d50c6d99ab35c29f3ebcd0f66d6263bdb5485e4"
+    },
+    "sound/arachnofloyd/step1.wav": {
+     "bytes": 74932,
+     "sha256": "a8744a3e50dccf9ee391da2f381c2ecf6701a76441406929ee4581c7717b880f"
+    },
+    "sound/arachnofloyd/step2.wav": {
+     "bytes": 34478,
+     "sha256": "22ce43aa18537f7b04e31263a46dd02e181d538fdf5918d55f8ce0acbb930676"
+    },
+    "sound/arachnofloyd/whirr1.wav": {
+     "bytes": 19762,
+     "sha256": "9e2029071248e6d45f1b0d518983bad5bc5f841cda6bcfba09486e111add10de"
+    },
+    "sound/armagon/death.wav": {
+     "bytes": 44744,
+     "sha256": "037799aa0d798d955287d1c901ab566f470a364ae2f9d163fafe12b7d2600868"
+    },
+    "sound/armagon/footfall.wav": {
+     "bytes": 9264,
+     "sha256": "9d85976c868c20fa76f1aae3598c0cf996d5ca422ff38e3dbbc6a03adb808b23"
+    },
+    "sound/armagon/idle.wav": {
+     "bytes": 7959,
+     "sha256": "c2125e999c1f97b54245fab23e0a2a92580e3c545f1c339bb8fef765d078e7cf"
+    },
+    "sound/armagon/idle1.wav": {
+     "bytes": 9534,
+     "sha256": "caa2e97d05212cf54d7f97652e7a91265165f7498802d33f6cc003fc5f567d89"
+    },
+    "sound/armagon/idle2.wav": {
+     "bytes": 13230,
+     "sha256": "19e6b320700e5620fab10acf97271e222b0867865c8985a47c6d3abf2f2c6767"
+    },
+    "sound/armagon/idle3.wav": {
+     "bytes": 10574,
+     "sha256": "d169b6e88544b24cccbd6cdb057276c6a52e7258179b25483d337a26636e6b02"
+    },
+    "sound/armagon/idle4.wav": {
+     "bytes": 13038,
+     "sha256": "c1a512aed5c670b275fb7ed7c1ce9b3b54188f46b0c428cbfdbc4b79eb0120be"
+    },
+    "sound/armagon/pain.wav": {
+     "bytes": 11342,
+     "sha256": "982f24d1ef9414e3ea280d591e5500328dd491b4a880c41cbe54b5c591096f66"
+    },
+    "sound/armagon/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/armagon/servo.wav": {
+     "bytes": 4158,
+     "sha256": "e558fdee1d311db180c318a492feef946330560ba4fe664dc0a9ed1f64d4e3c6"
+    },
+    "sound/armagon/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/armagon/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/axegrunt/axgdeath.wav": {
+     "bytes": 20214,
+     "sha256": "e5ed762afcc516058acc1b3884b4d08e67fd36e3a5bacf711d3504363bf8136e"
+    },
+    "sound/axegrunt/axgpain.wav": {
+     "bytes": 12636,
+     "sha256": "4699951fa58fdf15ab819b13d70904fc9a1a86a4db02193d621dfad3878d17bf"
+    },
+    "sound/axegrunt/axgsight.wav": {
+     "bytes": 17712,
+     "sha256": "e7b23208831c1d83793ba06f3b8855430c92017600cd8315341afbcb6ec6c8f0"
+    },
+    "sound/bambler/melee1.wav": {
+     "bytes": 4175,
+     "sha256": "4e0e2567b9d64b3ff86b33d95fa0158bf72372aeb4968a0c2489df942f9f7c4d"
+    },
+    "sound/bambler/melee2.wav": {
+     "bytes": 5283,
+     "sha256": "4bb91991bccfc33576eff19037e12666e9825348272d3dca40199e208bc00700"
+    },
+    "sound/bambler/sdeath.wav": {
+     "bytes": 14048,
+     "sha256": "c5253af82d203e75d132a00bbb555de055d2e356106d460f34cb8c9a2ee5e643"
+    },
+    "sound/bambler/shurt2.wav": {
+     "bytes": 3736,
+     "sha256": "0f1a51e0ff72f23a4de7684d4408344b7b7bd2cb805609168d2f2459e1b8660d"
+    },
+    "sound/bambler/sidle.wav": {
+     "bytes": 4907,
+     "sha256": "ea2232ba791e306cc86f58303413d8f3fbc7dd38091281698f4d846b6cafa483"
+    },
+    "sound/bambler/smack.wav": {
+     "bytes": 5300,
+     "sha256": "18d5dd0a3362890d39fa67410bdc04a57777bac8273659860cf656aa428849d5"
+    },
+    "sound/bambler/ssight.wav": {
+     "bytes": 11376,
+     "sha256": "de766aa056ca5f7dc6d179e6a220ef906ceacc0341b5cb3d91a4d0e75ff55338"
+    },
+    "sound/banshee/death.wav": {
+     "bytes": 50442,
+     "sha256": "4b156147c053ba62875e5906607c460494a7abbc93590aaf7236211438328321"
+    },
+    "sound/banshee/footfall.wav": {
+     "bytes": 7010,
+     "sha256": "2f4a7913b950bc9344f77f9aded01ce379c8b96d194becd435a2c8d6a17686ec"
+    },
+    "sound/banshee/idle.wav": {
+     "bytes": 20578,
+     "sha256": "ce9dd0765817bd561ddea0b731359e3fe2828fca1921eccc5ea882ed3bb4f3bb"
+    },
+    "sound/banshee/idle1.wav": {
+     "bytes": 27636,
+     "sha256": "b57d35a273754a004672956854a78acfa890464df5b1f769ec98099fc78284a4"
+    },
+    "sound/banshee/idle2.wav": {
+     "bytes": 20904,
+     "sha256": "980459f9cafece15f969f057bd74b25f57232ebc9592b7ab5cf53fe7cd665569"
+    },
+    "sound/banshee/idle3.wav": {
+     "bytes": 25166,
+     "sha256": "53a130e75b35cb79d7b8fc89a9e2eddbd5d18b05fd695b40fe05f813eac5fb60"
+    },
+    "sound/banshee/idle4.wav": {
+     "bytes": 20498,
+     "sha256": "bed7463fc3014cdb298856442bb694121f61edafda34a9d8b23c3944bf06f080"
+    },
+    "sound/banshee/pain.wav": {
+     "bytes": 15516,
+     "sha256": "7b20c9f8912d25ebeeb7193f7e8b16c70b1b319622d57ac296ba64c6cd433e8a"
+    },
+    "sound/banshee/servo.wav": {
+     "bytes": 2572,
+     "sha256": "64e78660b9c2db27b018588407b147e0dd76c349b07fa94937b8d1ecbc1746c3"
+    },
+    "sound/banshee/sight.wav": {
+     "bytes": 29242,
+     "sha256": "961e40aceffed13310e5335a453e775e74011b857eefdb74e9bce77349905227"
+    },
+    "sound/banshee/sight2.wav": {
+     "bytes": 14344,
+     "sha256": "9f9a57a9929e2a193f7184720452defffdc8f32fbce3fd1aa8d2f6751ca11413"
+    },
+    "sound/cyberscrag/fall1.wav": {
+     "bytes": 23396,
+     "sha256": "162fc0be1cd0eadfc93c35f1e1ba9b8dfc7e8df8ee53afb2a14db73e69f20ce8"
+    },
+    "sound/cyberscrag/hit.wav": {
+     "bytes": 22334,
+     "sha256": "a16ef33d94d56fb6984b2a3d06104a3cc292bdb38ec6ee22c8b10457b2cb415f"
+    },
+    "sound/cyberscrag/wattack.wav": {
+     "bytes": 25912,
+     "sha256": "6bed724b7ef9bdd480448396ed4498c75f848bf2a1e6d2879cb2b2484cdd1a7b"
+    },
+    "sound/cyberscrag/wdeath.wav": {
+     "bytes": 20684,
+     "sha256": "24602233cca209122250ba7c284933992aa2393795ea5c528a57b9986e2fc319"
+    },
+    "sound/cyberscrag/widle1.wav": {
+     "bytes": 13465,
+     "sha256": "8902628d2201eda9396c0dc134ebda8b8d5c37dabddcd286f8387aadc6532750"
+    },
+    "sound/cyberscrag/widle2.wav": {
+     "bytes": 23094,
+     "sha256": "76af020e5c25f40ab3020bbd065a9b83b9b0a51120d47d137a7abff4eb43e193"
+    },
+    "sound/cyberscrag/wpain.wav": {
+     "bytes": 8687,
+     "sha256": "af2e8589d381e634f607048ce71200df832c9e3a32147891b5bdd2efe2ff5bf0"
+    },
+    "sound/cyberscrag/wsight.wav": {
+     "bytes": 13079,
+     "sha256": "2f9178f6515eb4cd518b418441c40d1376aeaf6f42f7791533f5f4b6da87fd68"
+    },
+    "sound/doors/alka_doorlocked.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/doors/locked4.wav": {
+     "bytes": 15048,
+     "sha256": "c34d9d74599f077e7578e57f6a3cabc474df533067f90ba74c6ac6d8925b0d5b"
+    },
+    "sound/doors/q2door1.wav": {
+     "bytes": 30572,
+     "sha256": "3f05bddf76379933970c532656b6350bc53820319ce1cb9d4ea9288210427eee"
+    },
+    "sound/doors/q2door2.wav": {
+     "bytes": 44572,
+     "sha256": "44a9b7668602be3fb6b0d9a0756f5bd3767e041d0836e1a7ad270e03ffc71308"
+    },
+    "sound/dread/dread_death.wav": {
+     "bytes": 49692,
+     "sha256": "22000ff613ff52eab0605418681affaf7aeef4acc420d3dddd50a9031ac1ca38"
+    },
+    "sound/dread/dread_pain1.wav": {
+     "bytes": 29220,
+     "sha256": "67e443f78043cb9fc4213bbfbc3cd847785a66849fb7b36dd6467494487e0aec"
+    },
+    "sound/dread/dread_pain2.wav": {
+     "bytes": 23380,
+     "sha256": "914fffe3ad6c02fb78be873ee96405a40df22cd321beee2d673d0b6ebbafcde4"
+    },
+    "sound/dread/dread_sight.wav": {
+     "bytes": 70792,
+     "sha256": "50449a772b2ac778b810a69de58cb63c8bbdea529091720a41a1052b7196632e"
+    },
+    "sound/dread/dread_sight2.wav": {
+     "bytes": 58420,
+     "sha256": "f7952137b648f6376a1ba4e968679abb17fc648ede87bb0dd32f633271ad80ee"
+    },
+    "sound/dread/flameoff.wav": {
+     "bytes": 8962,
+     "sha256": "436505ff3ed5a8dc84a98bbaa0adf130e8df8267c813f81b3f22476d0bffdbc2"
+    },
+    "sound/dread/flameon.wav": {
+     "bytes": 29410,
+     "sha256": "4de5e523c27642dbd873e64fbd509798657e130b5b83e35c5f5774a67d29dcd4"
+    },
+    "sound/drone/drndeth.wav": {
+     "bytes": 69456,
+     "sha256": "5dcbe9679a95f0383dfe5875143340fafb5286613be64a49d8669757ab15998f"
+    },
+    "sound/drone/drngasp.wav": {
+     "bytes": 5070,
+     "sha256": "e0065525ce00cdddfa7918b9293fc776111493354c7e24339dc36eca124e790a"
+    },
+    "sound/drone/drngasp2.wav": {
+     "bytes": 9694,
+     "sha256": "9a7fd18be5454658642531cd8dcbdbcaa5e073faf0211e4ebd7c938ec4a23f49"
+    },
+    "sound/drone/drnhunt.wav": {
+     "bytes": 3024,
+     "sha256": "e1217faa2340b9d602ab6692ac46376035c63b91cdc8c40725a405a2915407e5"
+    },
+    "sound/drone/drnidle.wav": {
+     "bytes": 26798,
+     "sha256": "d6533ebd383400ea3ab3a6cf9dfb2046dbd93bc18529c9fb9e54a9d098d86dec"
+    },
+    "sound/drone/drnidle2.wav": {
+     "bytes": 104762,
+     "sha256": "0bb5fb81896417b02202191233f9ec77e7dc61a705950bea7e12b50027caefea"
+    },
+    "sound/drone/drnpain.wav": {
+     "bytes": 23762,
+     "sha256": "1c64ff6456a30504b7a54741cdf45d6607c38369b9916b6f1d84e240dcc491b1"
+    },
+    "sound/drone/drnpain2.wav": {
+     "bytes": 30798,
+     "sha256": "d690d35f7535f77d01718297fa1448f3a00c39176cf66145922590b2c043d5f5"
+    },
+    "sound/drone/drnwake.wav": {
+     "bytes": 17346,
+     "sha256": "4f106f38dd65b669dcb1151d5e8d9ab00236c2f2cec62d7a25a7acdd17b812a0"
+    },
+    "sound/drone/enfire.wav": {
+     "bytes": 10642,
+     "sha256": "bcedd360f09ac6a05807c0e6f646641a2173350e45bd98d7eff7d3db21804ebe"
+    },
+    "sound/edie/death.wav": {
+     "bytes": 108076,
+     "sha256": "77b13915238a363c969173f7c7ff990e345ea512fd8a99eb6c4738c726a089fb"
+    },
+    "sound/edie/idle1.wav": {
+     "bytes": 91972,
+     "sha256": "4e05f2e0d6ac56919477ef6d5ac2a4d2b6a25dd58184ba2c08d32e3107930c76"
+    },
+    "sound/edie/mangle.wav": {
+     "bytes": 54800,
+     "sha256": "bb8105d29c313e36ff515fd184c202a40add73d166ca154e3ad3237fc5b44674"
+    },
+    "sound/edie/pain.wav": {
+     "bytes": 39310,
+     "sha256": "f9d64d304452adaf3cb7e54bf438c4812226a6408cb3372b76a7095abc15ae3f"
+    },
+    "sound/edie/painshrt.wav": {
+     "bytes": 9788,
+     "sha256": "20d38a685f4c121cf9735dc787fdd6f98677090698c3c8238fe54c0c41d8524a"
+    },
+    "sound/edie/sawstart.wav": {
+     "bytes": 42636,
+     "sha256": "355255f762f4931407e12e0f69777e27cb2df00ea1450980209610c3b0e37d82"
+    },
+    "sound/edie/sight.wav": {
+     "bytes": 56428,
+     "sha256": "e19f01edc871d0f791a7866a484979e09d4b56786881881fae5714915b698911"
+    },
+    "sound/edie/step.wav": {
+     "bytes": 22186,
+     "sha256": "b537c0956bea34edbb1e0ee2731b38f8fc7602abef5f95060c20f7cf23311cba"
+    },
+    "sound/edie/stfire.wav": {
+     "bytes": 27908,
+     "sha256": "207b27e7fe02174179db371d6dce74ea78b25288846de6812690059dc2de47a2"
+    },
+    "sound/eel/004epan.wav": {
+     "bytes": 3932,
+     "sha256": "ed5830a2c8688d5859e3ebb11edaac954fe1d35b49aee4057c74157cab83b77d"
+    },
+    "sound/eel/005epan.wav": {
+     "bytes": 5218,
+     "sha256": "9f097669f08b6605b9641504d38463b01c3531691befe36891c7d79bd9d1d12b"
+    },
+    "sound/eel/eactive1.wav": {
+     "bytes": 26302,
+     "sha256": "38fd74408b4ba84c81e64552d874fb1f91e06b165b4aab712579c62004be365f"
+    },
+    "sound/eel/eatt1.wav": {
+     "bytes": 13940,
+     "sha256": "9e4e861bb5e682eba7e9d47134a7d4d725d80eeac5aed0169b0d05d43f3c25a1"
+    },
+    "sound/eel/edie3r.wav": {
+     "bytes": 17272,
+     "sha256": "07a508f1933cfae4b890c82e7bff1acfcf855e97ee010546979308a311403562"
+    },
+    "sound/eel/eelc5.wav": {
+     "bytes": 16192,
+     "sha256": "9f6a103d4d0bddb36db1131cfabaad60eee2533eecb4f8db22c955cbedf7f723"
+    },
+    "sound/eel/epain3.wav": {
+     "bytes": 7044,
+     "sha256": "c77aae62f295c4e5a5ac8dc9503b44a39b038f9f8c48c1eaac72d49d6f6ce7a5"
+    },
+    "sound/floyd/death.wav": {
+     "bytes": 14334,
+     "sha256": "c1df00893edb581adda43cc1d608bed644e09143958ce8febfd3148a5c44c47e"
+    },
+    "sound/floyd/fire.wav": {
+     "bytes": 23268,
+     "sha256": "f4c60bf6e9eb09829bfbfdc5f0abe9d306c14a55ec0112e44010148bcb541093"
+    },
+    "sound/floyd/idle.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/pain.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/floyd/sight.wav": {
+     "bytes": 4872,
+     "sha256": "705e26e709ad72331225e6c0486968d37f260afe502e163694faf977519a2b29"
+    },
+    "sound/frogman/death.wav": {
+     "bytes": 110256,
+     "sha256": "895cfb57c0d27369530fd5e9b29abd491a989ad0a63ddb00f05dd9e4777a5cdb"
+    },
+    "sound/frogman/idle.wav": {
+     "bytes": 88310,
+     "sha256": "85d4c5ada38e7a43192a436e8f4dd59ed6d2a86434cf9071a7f3661e26f54e6d"
+    },
+    "sound/frogman/impact.wav": {
+     "bytes": 2672,
+     "sha256": "d5d063817f1ed2ff89c14fc0420ce1d083f03808a1f9448e4412700a5125d769"
+    },
+    "sound/frogman/pain1.wav": {
+     "bytes": 32638,
+     "sha256": "3cf3933f34c7baef52df54d5b03db40424e9f7ee72e5aa5a4dba489d71be2af7"
+    },
+    "sound/frogman/pain2.wav": {
+     "bytes": 27662,
+     "sha256": "ec38e73fd1ffc33cd25aa065e5f5897c21a494e380763ff80b6be482689b5e33"
+    },
+    "sound/frogman/shot3.wav": {
+     "bytes": 6927,
+     "sha256": "08c145053d37189447c28a65d479e57d3fe7890ae96a485d02a4f6bef6a50a47"
+    },
+    "sound/frogman/sight.wav": {
+     "bytes": 44186,
+     "sha256": "7600cd32fe980646fddcf5a9077d8d43df1bca1f2ed05bd92ce8cca273ad6636"
+    },
+    "sound/frogman/swim.wav": {
+     "bytes": 6482,
+     "sha256": "bb302bc160925162e8b1b82100a788835b6de3c847118e171c16f5d5c384866b"
+    },
+    "sound/hipweap/laserg.wav": {
+     "bytes": 9646,
+     "sha256": "0b72f74cfb7e751eb121a36c5cb3430d9fc3cd27221c1755ea6435f5c4a76dfa"
+    },
+    "sound/hipweap/laserric.wav": {
+     "bytes": 13340,
+     "sha256": "599e01aa9667eedc5554d47bb569d16dc510871f23800a7b8022f4cc1cbc326c"
+    },
+    "sound/hipweap/proxbomb.wav": {
+     "bytes": 8378,
+     "sha256": "8cef0010289f42172232ea09f6cb4818f23e5ba26f276282d7b703df8f403ae3"
+    },
+    "sound/hipweap/proxwarn.wav": {
+     "bytes": 2182,
+     "sha256": "aecfce7f424ba2a5b257b2e69b593eb2c2bcd355d55a0392b670273cb6612362"
+    },
+    "sound/hunter/death.wav": {
+     "bytes": 14198,
+     "sha256": "b1a05796c2e24f0c1f541011c30469f35811f1e78fade024a7e683c4f0e0f5cb"
+    },
+    "sound/hunter/fire.wav": {
+     "bytes": 4182,
+     "sha256": "7fa114781f5c5bbd0503e337435efd347fcfbb18e08c08ba9fdcd2068f03f93e"
+    },
+    "sound/hunter/hit.wav": {
+     "bytes": 22882,
+     "sha256": "561b1377cf22e1c95cd4da0fa01da0cef3f267420f545e54ad928933dc1c3278"
+    },
+    "sound/hunter/idle.wav": {
+     "bytes": 18324,
+     "sha256": "1db90d61fe265049544664cf37c32728d46d53e2d97502331dcf71a832b0a28f"
+    },
+    "sound/hunter/melee.wav": {
+     "bytes": 8280,
+     "sha256": "d389d31daa3450e5d01c9f4717324575477727e90f9b9c6317b0c4f740ed4d27"
+    },
+    "sound/hunter/pain1.wav": {
+     "bytes": 7568,
+     "sha256": "bcd180b4099f6156e2cf8af4c6a375322e411410331de9b691542b7b68ee5c0b"
+    },
+    "sound/hunter/pain2.wav": {
+     "bytes": 6144,
+     "sha256": "884f365e9de4ce1850b6fead34567348cbfc2301b4714e69eed7ca78a7a8c7d3"
+    },
+    "sound/hunter/sight.wav": {
+     "bytes": 21018,
+     "sha256": "f717369b9feaef0c6b604f1050ce84e6bf7424a92c06f3e6395309e3871569a0"
+    },
+    "sound/hunter/smash.wav": {
+     "bytes": 7970,
+     "sha256": "2aa413d65d19a2f056089aea0d90a249a4ba78444d3c436f6f6fe9499dffe672"
+    },
+    "sound/hunter/step.wav": {
+     "bytes": 32756,
+     "sha256": "e631331eba96f7a39229f762baf1950a1a494620776f9d4795a6cbb8fb387d8b"
+    },
+    "sound/items/armor_denied.wav": {
+     "bytes": 15854,
+     "sha256": "2ec14677f483d1a1b869af64cc30fb0dbd90a640fc071fdf2ae493d27cd746e1"
+    },
+    "sound/items/jboots_dry.wav": {
+     "bytes": 14842,
+     "sha256": "47ab9b51e521912a95ac75213c92d72551d65d3274e3f95fabdf3af96e3801e7"
+    },
+    "sound/items/jboots_got.wav": {
+     "bytes": 21176,
+     "sha256": "4d04c60240de4e0a5683606ca478fbdc30b6d178d0b01cedf6ab1145bfc36be2"
+    },
+    "sound/items/jboots_got_timed.wav": {
+     "bytes": 41300,
+     "sha256": "cde18c42852e96166e9af0218ab9c2166574a3ca8e20f748f9f4e009acf3dc41"
+    },
+    "sound/items/jboots_plyrjmp0.wav": {
+     "bytes": 5400,
+     "sha256": "fbbaf3f8f99d490252adf6022543640bf6b00ee27078ee1e13f5069114b2b635"
+    },
+    "sound/items/jboots_plyrjmp1.wav": {
+     "bytes": 19938,
+     "sha256": "fe6bb2a66fc7fea1771783ccf4797477d5a54425f6472ea5654c680c1363ba7f"
+    },
+    "sound/items/jboots_timed.wav": {
+     "bytes": 313682,
+     "sha256": "a05f8116e13fe5b0c4726e829e381a1737fd987a35e39c982014a8abd1445394"
+    },
+    "sound/items/shard_pickup.wav": {
+     "bytes": 18260,
+     "sha256": "388923a63b48720647b9e0f2862c35bb1d5cad2e162ace343845b3fe36b48af4"
+    },
+    "sound/items/trifecta.wav": {
+     "bytes": 16412,
+     "sha256": "00baad51adaa3f5d6664e85ae5442221db6818bfd85124c164324d22f6723ab2"
+    },
+    "sound/items/trifecta2.wav": {
+     "bytes": 32778,
+     "sha256": "f742a9cee4a53ef52fce55d5e9ddaae9c6b20d2127e16c0def6cd11b3d2d6380"
+    },
+    "sound/items/trifecta3.wav": {
+     "bytes": 10728,
+     "sha256": "a78bfc9fa4fbf0c3c1e85bee273ee053598989a09146bd29e97dda811c49a473"
+    },
+    "sound/lieut/alert.wav": {
+     "bytes": 8700,
+     "sha256": "7ebbe83ae1b5d159c9f0a0ae5f3dea126650ed5d6f98a22d1512dcfcb19a23ca"
+    },
+    "sound/lieut/objective.wav": {
+     "bytes": 10052,
+     "sha256": "aa7d6726a458eaa48bf2e20446c57360b82ac23bfbd06bad7b6e01ae95ca8b0d"
+    },
+    "sound/lieut/target.wav": {
+     "bytes": 6754,
+     "sha256": "eebd50c75585894c7d5305f6c066aaef1efaca9a59e27b80d03e8ae4d69caa69"
+    },
+    "sound/lieut/you.wav": {
+     "bytes": 7126,
+     "sha256": "6bfb031b0d69b8ae4ef2e9b201da43c523ae88de344907648d4064e07477ee1c"
+    },
+    "sound/me/me_fire1.wav": {
+     "bytes": 3016,
+     "sha256": "2603e46e656da75b80f597a5916ecd62dbd396c3f0036d25b0a5143485076071"
+    },
+    "sound/me/me_fire2.wav": {
+     "bytes": 7674,
+     "sha256": "7e4418c880edcd96c84069d668fe00cd70444b9af2a555611b16a6a98680422c"
+    },
+    "sound/me/me_soff.wav": {
+     "bytes": 5500,
+     "sha256": "4c8e041824c0aacf803b6eb22f0800bdd06ea1ea3290ce1871c2bbc191b64fc2"
+    },
+    "sound/me/me_son.wav": {
+     "bytes": 5308,
+     "sha256": "16ad7f7f93b9814a65317e63090f9873c2209579d9d57bc19b7fdfb52d526d67"
+    },
+    "sound/me/medeath1.wav": {
+     "bytes": 11712,
+     "sha256": "c86be6c64d6a3515c225ccd734322694c1e152027d9375cd26cac5b8c6f8c3af"
+    },
+    "sound/me/medeath2.wav": {
+     "bytes": 20808,
+     "sha256": "fde0b948b861230be1d91859a4d061987bb10fe3c7054595a54a5a872b474560"
+    },
+    "sound/me/meidle.wav": {
+     "bytes": 3908,
+     "sha256": "8170e75a6f424e3d507ca6950a57105aa5216d6a20e493464394d57f593d3bc7"
+    },
+    "sound/me/mepain1.wav": {
+     "bytes": 3300,
+     "sha256": "5f1aad60a8e0acfb81880822412eafeb7cf738f8333e86f240fb9c2ecbcdcb52"
+    },
+    "sound/me/mepain2.wav": {
+     "bytes": 4874,
+     "sha256": "ada3bc3b902924be0bf5f2ed275022d3b86bbc66a6b269af9ca9e614d467efef"
+    },
+    "sound/me/mepain3.wav": {
+     "bytes": 6082,
+     "sha256": "d3cc84b75606ea8ec7311fcceff3cb68c18d220b6c1e362d91ecc695deb5b65e"
+    },
+    "sound/me/mesight1.wav": {
+     "bytes": 8128,
+     "sha256": "a1f1bf4f2e742e755b0ae676278df1bbe7ba9db8918133c4e40b94525b47485d"
+    },
+    "sound/me/mesight2.wav": {
+     "bytes": 8526,
+     "sha256": "69fd72d533823d71cd21af3d97be148b5f2b0f6ae6b57a6c585ff807f81ce63e"
+    },
+    "sound/me/mesight3.wav": {
+     "bytes": 8666,
+     "sha256": "27c6ad5ba5f0e76e071b27918c6c5735e0cbf38bfed85040cc8c1044e32b7ee9"
+    },
+    "sound/misc/airhiss.wav": {
+     "bytes": 11252,
+     "sha256": "03b9ca5c5a8246fee721f648d2402374477dd65da13a949593c44fd7b2065abe"
+    },
+    "sound/misc/airhiss2.wav": {
+     "bytes": 5652,
+     "sha256": "9a23a61a6a3a28f269ad5a63a93c258858765ad7142ca9edee408f59ede2a384"
+    },
+    "sound/misc/break_glass.wav": {
+     "bytes": 21226,
+     "sha256": "ad5978cfee254c3a99c55e4af38630fc6fe33686af44851dc88a5b9bacf80e44"
+    },
+    "sound/misc/break_metal.wav": {
+     "bytes": 16028,
+     "sha256": "469c782d13752abe212b558cf506a72db0e689afddc8c606b423d6e364e9d73f"
+    },
+    "sound/misc/break_rock.wav": {
+     "bytes": 26008,
+     "sha256": "96766396572574531fb0c12b890d0956aa9c5f9605f0de6bca5e0be2cfdd710f"
+    },
+    "sound/misc/break_wood.wav": {
+     "bytes": 21226,
+     "sha256": "43c757ffb3dbf172fce5e758425b8682f29ec42fa8a93ca8b7c099aea41e582c"
+    },
+    "sound/misc/burning.wav": {
+     "bytes": 24062,
+     "sha256": "b86f4c917be3c1af29dd2c8efb4d065022ecef84a3fd762a49ace87da3da7eee"
+    },
+    "sound/misc/burning2.wav": {
+     "bytes": 11087,
+     "sha256": "85abb1cf3b40311b8240eaad56bdc363d06888763067d47150cd94f0c1a2b235"
+    },
+    "sound/misc/comp1.wav": {
+     "bytes": 23404,
+     "sha256": "797df3a959272bb5cc9119565a38ade894fdb9c4fbafac96b71150a51d11e795"
+    },
+    "sound/misc/comp2.wav": {
+     "bytes": 20636,
+     "sha256": "f5f2381aac666a185d56fd560424be8f06fbd5ae4a6b93f146f3868dbdaadfe0"
+    },
+    "sound/misc/conc_impact.wav": {
+     "bytes": 92140,
+     "sha256": "648c62715a1fc7547f566d0e4c3c2bfe71a63f5248da5a0ea5c8a863f7374c7a"
+    },
+    "sound/misc/door_closed.wav": {
+     "bytes": 12089,
+     "sha256": "95f75f5f47ab65a7776eb4111755b77c736937f383cdcc42732ac06b9adc36ad"
+    },
+    "sound/misc/ebell.wav": {
+     "bytes": 15220,
+     "sha256": "1693337ed8873f1159e56c2925afaa210f5c28bee4e2c42d27e29bee8e06cb5f"
+    },
+    "sound/misc/glass_impact.wav": {
+     "bytes": 70828,
+     "sha256": "b9a90a5c6d2f5a64eb95738b67870c90067bc8935670f5e2af2ea7860e11f57c"
+    },
+    "sound/misc/ladder.wav": {
+     "bytes": 4054,
+     "sha256": "b9c44f73c8bdbc900af4f06600e0d6456a040b296612b7d0fe53391285976a44"
+    },
+    "sound/misc/ladder2.wav": {
+     "bytes": 4098,
+     "sha256": "4fad66341514c9aa2b31b4c2fde7563369090da9b0b3a51e08bca3100f2ec282"
+    },
+    "sound/misc/laser_on.wav": {
+     "bytes": 41762,
+     "sha256": "e1a72d5a5aaec9230348910976eb723ad5e7cd24ebd11ad296b0bc5c09de1eac"
+    },
+    "sound/misc/laseroff.wav": {
+     "bytes": 67100,
+     "sha256": "a15f76266e830249d5cfc6ffc020833f84be1d66e25d25d657d0313be64656fb"
+    },
+    "sound/misc/longexpl.wav": {
+     "bytes": 42430,
+     "sha256": "01bfbb4c07e81e97c91e5a85d9a141a376edd0e633d6b47cd16316c00e5ef890"
+    },
+    "sound/misc/menu1.wav": {
+     "bytes": 5054,
+     "sha256": "d158ddc35360bc43934b7a8a9b7cc830f7510e6bb3a640813157822b27b5217a"
+    },
+    "sound/misc/menu2.wav": {
+     "bytes": 9726,
+     "sha256": "73b74099c8cb43ab2fb09b28b72ddd9f73f2d2a4f8a00a8e835490f366680c92"
+    },
+    "sound/misc/menu3.wav": {
+     "bytes": 3226,
+     "sha256": "48551cc717e5011df78a38c6a71bb001e4f62a1858a3952311499653ff423a07"
+    },
+    "sound/misc/metal_impact.wav": {
+     "bytes": 130954,
+     "sha256": "c41ab7854e7beaf589db3b23f535d1d6405b2da587fd00bd180810a577a1b4e8"
+    },
+    "sound/misc/sav.wav": {
+     "bytes": 5802,
+     "sha256": "751050f97456a0c07e88a249d40dde96c2d14640e21670ccdde983502998dbba"
+    },
+    "sound/misc/shortexp.wav": {
+     "bytes": 27562,
+     "sha256": "cf90bda77238ba9633aee88edfd22306128fe5515f2e854c19afdeab733cc2cc"
+    },
+    "sound/misc/spark.wav": {
+     "bytes": 14684,
+     "sha256": "55ba43047ffc794bc65b1002b351b3a13bc271346cb060e01c093f56dd960e7f"
+    },
+    "sound/misc/uwater.wav": {
+     "bytes": 39438,
+     "sha256": "b6bd29c4576d83d6149fb4dc1a67dc20046339427745e5b5f3c2c46593c0e553"
+    },
+    "sound/mutant/mutatck1.wav": {
+     "bytes": 6116,
+     "sha256": "410f926534f21705e78a804ce048b0c15e62fe0c68a45aae1b3741fb227551f7"
+    },
+    "sound/mutant/mutatck2.wav": {
+     "bytes": 18260,
+     "sha256": "66009d09adf71f10117c74f5004c995fd48362b2f4fcfaaa3bc2da01e66d115f"
+    },
+    "sound/mutant/mutatck3.wav": {
+     "bytes": 28840,
+     "sha256": "2dd8a615ca2be248c8370d7480f5a8ca9375d31e6af41bba603df660d31883a1"
+    },
+    "sound/mutant/mutdeth1.wav": {
+     "bytes": 66836,
+     "sha256": "bfa18b48ff82d753c3ed458d0d61152ef3f6672fb65d711990fbca0c5dadca56"
+    },
+    "sound/mutant/mutidle1.wav": {
+     "bytes": 81004,
+     "sha256": "8c7e8ad544d7e2470bd61d88c5cd8be1a0eb66f57aaf113f82d990ee00450073"
+    },
+    "sound/mutant/mutpain1.wav": {
+     "bytes": 56716,
+     "sha256": "49ff5f97fedc87c1ac06dc43d4ff0a0fd09fb481354b6373d607bfabc9a57a6a"
+    },
+    "sound/mutant/mutpain2.wav": {
+     "bytes": 58740,
+     "sha256": "b79f1cce60226daa3e3ca8c134da968d54ad51abd9c37ffebdf3d46c5d9f91c6"
+    },
+    "sound/mutant/mutsght1.wav": {
+     "bytes": 107316,
+     "sha256": "7e15e392edc3f2d5ae9e3bde3dfe65595a85728022245f74b81f072d75dce798"
+    },
+    "sound/mutant/mutsrch1.wav": {
+     "bytes": 101244,
+     "sha256": "44484ef4c189511fb0a8d0f2bea83e443e1f1bd51cef04f518f3820e58e88a69"
+    },
+    "sound/mutant/step1.wav": {
+     "bytes": 8140,
+     "sha256": "0d9af35156c84213ac7ffbde54d0f2518fe9d39bba4edc48c94e71bed4f7ec4d"
+    },
+    "sound/mutant/step2.wav": {
+     "bytes": 14212,
+     "sha256": "f7c81df1bff56c8aeb49891fa822c37ddcb019e97a654738a9fb8ee351d19eac"
+    },
+    "sound/mutant/step3.wav": {
+     "bytes": 4092,
+     "sha256": "89856afec31f800219c45253514d0fdf5b5bd800c32f87ba74dd0c21df181550"
+    },
+    "sound/mutant/thud1.wav": {
+     "bytes": 32428,
+     "sha256": "20ed5f20729a068801d06904365e46c9d692dec835710a9b8090d0a1956d6919"
+    },
+    "sound/ogre/ogleap.wav": {
+     "bytes": 9596,
+     "sha256": "f3a8d42667c197ad003b6717dadd77a897f87344b0a2a87f0e02a0c3a2e0d66f"
+    },
+    "sound/ogre/rogre_alert.wav": {
+     "bytes": 71728,
+     "sha256": "4f3e921b6ee236289660f7ca2ee8a4689e719423266d26a3f8b91ae29d02c6a5"
+    },
+    "sound/ogre/rogre_idle1.wav": {
+     "bytes": 110330,
+     "sha256": "a07df4a53c9e8de310b9d963bfb9c841c51e502565f39dc543bf1c025edd41d6"
+    },
+    "sound/ogre/rogre_idle2.wav": {
+     "bytes": 79416,
+     "sha256": "862258641dc3c90d2a9e5f9e2a4418eb0037eedf22cde798682a169a84f13a44"
+    },
+    "sound/player/foot1.wav": {
+     "bytes": 2474,
+     "sha256": "5913e6df75b7b0e598ac4c231d91a16834229024f009cfa590eb87139324756a"
+    },
+    "sound/player/foot2.wav": {
+     "bytes": 1790,
+     "sha256": "e2994f408d83837c121d67c8dbf290da11b77e43124b32f8e378a28df05591c7"
+    },
+    "sound/player/foot3.wav": {
+     "bytes": 2050,
+     "sha256": "ebb0ef6792df57affc57440361759b15fa115b3d0a4f331ce9dba2cb49a47963"
+    },
+    "sound/player/foot4.wav": {
+     "bytes": 1764,
+     "sha256": "af9824d979fe1fe3cad5c562b6cc348e8e9b7824c88f45c67ad92b28b4b15b62"
+    },
+    "sound/player/foot5.wav": {
+     "bytes": 3158,
+     "sha256": "e8d6e6eb65cda313dc28eafcc3ebb798de2de1162cbe24a53e33d0703c10806b"
+    },
+    "sound/player/foot6.wav": {
+     "bytes": 2858,
+     "sha256": "a9d67538c5c3987ab294357d59a8796b201e5f4213ffc59bddc2e0b2bdddb79e"
+    },
+    "sound/player/foot7.wav": {
+     "bytes": 2020,
+     "sha256": "25a6d796316804be397aaabb41b7199298f2cf3283f5fc9e44981301db5c8a13"
+    },
+    "sound/probe/death.wav": {
+     "bytes": 12400,
+     "sha256": "cee9542b25964923b37864b8bf4ce88b77c88318a82897f1896acaba23abbf7d"
+    },
+    "sound/probe/footfall.wav": {
+     "bytes": 6898,
+     "sha256": "7b97e9cd422299498b770964216ab45685c18855abf41c722e0c68003a22c207"
+    },
+    "sound/probe/idle.wav": {
+     "bytes": 18612,
+     "sha256": "353395c65f73295b1ca6eab57b8a790d02440ccd7b5b5f536622a37b99285f88"
+    },
+    "sound/probe/idle1.wav": {
+     "bytes": 8042,
+     "sha256": "36ff04f06b8c1d86b94eaec19139bbdba1e9ea7a0eef5c52b5fb077961fd9484"
+    },
+    "sound/probe/idle2.wav": {
+     "bytes": 29690,
+     "sha256": "29a99d97eb10e642c1fd85ec8016e4c10c7669ccf4128f3b485deff1cd245c31"
+    },
+    "sound/probe/idle3.wav": {
+     "bytes": 15502,
+     "sha256": "af2c9d6d11f869100624c276bdcb9ac8a1ebbc677f2c66068314f24aea494a59"
+    },
+    "sound/probe/idle4.wav": {
+     "bytes": 4470,
+     "sha256": "b0cd17278d04c0219a2ff420799a822fa30ee306f14d5e5965cbfc83fb0d8f09"
+    },
+    "sound/probe/pain.wav": {
+     "bytes": 5338,
+     "sha256": "08bb222e2da0112fe8611b6feb4078c44a426eb376bdfe52390f9e88f2bc88b6"
+    },
+    "sound/probe/repel.wav": {
+     "bytes": 18914,
+     "sha256": "7b6681adfb9fb1d1a9d34ebe3237c220166f7de29b00c63bfe0a0a12084c7d36"
+    },
+    "sound/probe/servo.wav": {
+     "bytes": 5070,
+     "sha256": "dc23ff28ec2ec3dbedb0936cf28dc96fe73a50a4e930d30e9460a408c47e1e06"
+    },
+    "sound/probe/shoot.wav": {
+     "bytes": 2786,
+     "sha256": "1c0c89767d1875afc486bda3238723f0c7b62222d959a5b60ae03f3a75b8d887"
+    },
+    "sound/probe/sight.wav": {
+     "bytes": 16506,
+     "sha256": "ed618d100d982b347a334f26c4b8c276ad6b90504816829d47b6ca1df3f31f3d"
+    },
+    "sound/probe/sight2.wav": {
+     "bytes": 23228,
+     "sha256": "2e11e1f4d01f4e4730a70a3149523768377ce5d718982ad9ca2678bdbdce36f2"
+    },
+    "sound/rider/death.wav": {
+     "bytes": 14106,
+     "sha256": "3aed872978f82633a46075a4583e9b27beb0c96db20278ff4ff7d063e9073246"
+    },
+    "sound/rider/down.wav": {
+     "bytes": 11517,
+     "sha256": "3acecf7879f9981abe1f0bd824f92b2e4dba251ccf6e53258fa370116a148a1d"
+    },
+    "sound/rider/down2.wav": {
+     "bytes": 3290,
+     "sha256": "870fb598204c269f11938b852f0e0476e97ea2f99e7dc08b025c2e7aa0eff386"
+    },
+    "sound/rider/idle.wav": {
+     "bytes": 18876,
+     "sha256": "3bbd464b1c627ead5744eb1e5d9d92d4855ad2707ffd45f0a1dcc9898667b0ea"
+    },
+    "sound/rider/idle2.wav": {
+     "bytes": 11670,
+     "sha256": "a2de2d497719aa004d0f3c37de6ffe185683c2cedb31c4686cb23d52e030c2e4"
+    },
+    "sound/rider/pain1.wav": {
+     "bytes": 14526,
+     "sha256": "6cc1b1c2c1ba87ada8274372998386fbdb49d295459b493ec7058792c6921652"
+    },
+    "sound/rider/rail.wav": {
+     "bytes": 97196,
+     "sha256": "396a85e1e2083f2b1eaae89a3f33a21145a643f3f50419523497719ef8e7598a"
+    },
+    "sound/rider/shoot.wav": {
+     "bytes": 9942,
+     "sha256": "3d25f8833a4609feebee3a2414734cbc5a118a1315b1b3d8c3ab63829e1668e6"
+    },
+    "sound/rider/sight.wav": {
+     "bytes": 26356,
+     "sha256": "40ace6f3beeb920ba1bbdb197f8ece18d312762a71e494726289e16703d75d91"
+    },
+    "sound/rider/step.wav": {
+     "bytes": 40524,
+     "sha256": "a43e24ecbc62d44bce466b1e682ebf64c230e03f4d79449406ce021dc8276a9a"
+    },
+    "sound/rider/thump.wav": {
+     "bytes": 15444,
+     "sha256": "af29f4e8f6debb1223aeb5d840add4ae01cb5e9f6bd9a26efeadff518f34380d"
+    },
+    "sound/scientist/allnominal.wav": {
+     "bytes": 23778,
+     "sha256": "e26f9bb3c24d9a9e0da38395048f6dacffe82d800da49d56378027250393d69a"
+    },
+    "sound/scientist/alright.wav": {
+     "bytes": 9666,
+     "sha256": "372c1aa91e6841bec2441215c894b7d149bdeaef33f907d23bb7eaf637520ce3"
+    },
+    "sound/scientist/asexpected.wav": {
+     "bytes": 15982,
+     "sha256": "306933848b673bd14d7074d59e45a8c97bc00a2897601509e52e5835e2ffc997"
+    },
+    "sound/scientist/c1a0_sci_crit2a.wav": {
+     "bytes": 28364,
+     "sha256": "f972684c74eeb51872873cc2b7053448c6cdd716b8c3535929fdbcc508d62ef5"
+    },
+    "sound/scientist/c1a0_sci_stall.wav": {
+     "bytes": 13704,
+     "sha256": "541c192ad5e8a68c76706ec17b3deceafbdc607bfc372ddfd300532f8aa1eaef"
+    },
+    "sound/scientist/cantbeserious.wav": {
+     "bytes": 13236,
+     "sha256": "fc4a8a379f70e33db79a49c667dcd9f1622de29d7b32ef3973c4ffdb5d80ee44"
+    },
+    "sound/scientist/cough.wav": {
+     "bytes": 14878,
+     "sha256": "b4e620259623347a5be3f7eaf3c531e6ea9ef2e97ac42997dd78cfee9327f7bf"
+    },
+    "sound/scientist/sci_die1.wav": {
+     "bytes": 15558,
+     "sha256": "c2306d7f9fa58f99961c347b06ef26305b99ac43ec27b2b222962e1f3a9ccce9"
+    },
+    "sound/scientist/sci_die2.wav": {
+     "bytes": 5402,
+     "sha256": "14deecb570d1e315b772713d54b7250043bb0dd5f3d5538cd0636e39a523c54f"
+    },
+    "sound/scientist/sci_die3.wav": {
+     "bytes": 3104,
+     "sha256": "075cdbc5837d91b61ad7599cdb3abf9323872816f8966c83deab9c0a6e04d7d2"
+    },
+    "sound/scientist/sci_die4.wav": {
+     "bytes": 4024,
+     "sha256": "e6ca0d4f18ac6c1246926646568618057cb70b5cee995c1c2dd69f0179b892ad"
+    },
+    "sound/scientist/sci_dragoff.wav": {
+     "bytes": 8986,
+     "sha256": "0c6a21cd5edf01e495e1258e9a76c05d62c0e3cd697e787fd43fd4bd9126483b"
+    },
+    "sound/scientist/sci_fear13.wav": {
+     "bytes": 4534,
+     "sha256": "dabce7a6c12980f947f7504da264fabb67a804d2e478b7f252ab527fb21a92d0"
+    },
+    "sound/scientist/sci_fear15.wav": {
+     "bytes": 4764,
+     "sha256": "f0d23c680ad138c3cc12da78a3e45cbf3daa47e5da9bc62a1dbb3b27389565a5"
+    },
+    "sound/scientist/sci_fear6.wav": {
+     "bytes": 5588,
+     "sha256": "ff2702b2b9e517b90ea0c2853775a4a95160edfae5af0a7f9208f07624d84281"
+    },
+    "sound/scientist/sci_fear7.wav": {
+     "bytes": 8458,
+     "sha256": "f2a39185c2d39a03b39afd7fe6f942b2f35fd17135ade8ceb4c31968c768aafa"
+    },
+    "sound/scientist/sci_fear8.wav": {
+     "bytes": 5804,
+     "sha256": "4455a29590d5f42ebbf06e600d8ba3f45acfd5000a6b8045891cbecf1d937970"
+    },
+    "sound/scientist/scream01.wav": {
+     "bytes": 14666,
+     "sha256": "b738de99aefbe3a45724914dd6eb79c0f8c219aaf733554a8a5eb94836c22320"
+    },
+    "sound/scientist/scream06.wav": {
+     "bytes": 13938,
+     "sha256": "dee8ac2058635d00458e2e74402d1cfcb5362c64259fc2c4f3b6bba31bdf6337"
+    },
+    "sound/scientist/scream08.wav": {
+     "bytes": 24122,
+     "sha256": "e06aa67760f65c485377f37725f3e790fd5bae7562aa621391fdf10b5f1d186a"
+    },
+    "sound/scientist/scream09.wav": {
+     "bytes": 6130,
+     "sha256": "85947649f5fb1491732365849a3025bf5c76c791b395cfdf421fbbd6ec58d351"
+    },
+    "sound/scientist/scream10.wav": {
+     "bytes": 5392,
+     "sha256": "fff4c0735f9c312be7cda848fc2867590437ffe9758fe685e3b4c94678ca1f48"
+    },
+    "sound/scientist/scream14.wav": {
+     "bytes": 4824,
+     "sha256": "dcb7dfb0e307b813476b2e55dceb59d8ae2b9514b1ef02034ea255fa5f086b05"
+    },
+    "sound/scientist/scream15.wav": {
+     "bytes": 3048,
+     "sha256": "37d26fe2d2b8a39d0fec0eceec0ca974ec3dd7fed33bae0d3230a934954105f0"
+    },
+    "sound/scientist/scream16.wav": {
+     "bytes": 2328,
+     "sha256": "4ff04ce8ff07af708c84dacc8df114b68620d47e8e4e4c78dfc4fd33a8a9b98d"
+    },
+    "sound/scientist/scream17.wav": {
+     "bytes": 3836,
+     "sha256": "82fb51224e06db5022adfa58f0b02353c333229ed3312f86dd9ec4f04813c37c"
+    },
+    "sound/scientist/scream18.wav": {
+     "bytes": 3066,
+     "sha256": "bfefcf745ab8d30db11f9113ecf9ba1c5bc6d9b2351c53f3f46d66e03cbea3fe"
+    },
+    "sound/scientist/scream19.wav": {
+     "bytes": 2504,
+     "sha256": "47cc414d201aadb7ba2fe0ce0567ff5360e90fd9de4a167520988513f358ed41"
+    },
+    "sound/scientist/scream20.wav": {
+     "bytes": 21310,
+     "sha256": "124cb45d3d5533572e3cfe4b42bddad2a03dc0d8de1c89a42ea57433432e3a6e"
+    },
+    "sound/scientist/scream22.wav": {
+     "bytes": 15206,
+     "sha256": "6e0a509eb2468466591622e74724c31103b8b60f5d8f29514fb57e9d9d12c9d4"
+    },
+    "sound/scientist/scream23.wav": {
+     "bytes": 21988,
+     "sha256": "8521907e8cecc22e6924d23295a5e8d31333d265ca27a9533b083b68e9da6d12"
+    },
+    "sound/scientist/scream24.wav": {
+     "bytes": 22660,
+     "sha256": "2a5ee0b6a4c8175366e45650912a0f37e984bad7238bc2e6dd46109bfdb5c4ee"
+    },
+    "sound/scientist/scream25.wav": {
+     "bytes": 8122,
+     "sha256": "38281749deffb4e567896f71e7bcb75d7b2e253e404a953a5eea6eeb989f156a"
+    },
+    "sound/scourge/idle.wav": {
+     "bytes": 20838,
+     "sha256": "799076dbfa60e5cbb2f8ab91d351c7a72eed939d5a931dd4e8f5ec926281a284"
+    },
+    "sound/scourge/pain.wav": {
+     "bytes": 7080,
+     "sha256": "a6034d165bd50f406436f4c79cebdb1962e384c4bd48ffe1dd58798649f5589b"
+    },
+    "sound/scourge/pain2.wav": {
+     "bytes": 11584,
+     "sha256": "f5f59b4961d7269aae1ed66ffc6e2156e9fd49bb06eccfc39fc46b2a92d438ec"
+    },
+    "sound/scourge/sight.wav": {
+     "bytes": 35254,
+     "sha256": "e6cea7512fe2035c23f1ad26eebdb40563d8e1d78c71f45ba09bdcf328e1411d"
+    },
+    "sound/scourge/tailswng.wav": {
+     "bytes": 2786,
+     "sha256": "36a0de298b02529fcc5c010baa6b6c222926f59ae8f924311a904898ab9c4c04"
+    },
+    "sound/scourge/walk.wav": {
+     "bytes": 19578,
+     "sha256": "a7dbbbea2b12c661677ad5e8b345356fe731dd36b0f11379fab939f1af3a2dec"
+    },
+    "sound/sknight/sight1.wav": {
+     "bytes": 121627,
+     "sha256": "fc880c6243fddb29a2c1351cbde61298ef0bf06f29b1b9617ac72b72b54ccd27"
+    },
+    "sound/spiderbot/sactiv.wav": {
+     "bytes": 17066,
+     "sha256": "f21587ba9bfd159e48c5b3aa1c6e94eac7157053e4e5699459233fb28c2631c8"
+    },
+    "sound/spiderbot/scharge.wav": {
+     "bytes": 7300,
+     "sha256": "b58064dac4e12bd6685edbfe61417a530cde1e5175336193b2fa7a292aca8ef7"
+    },
+    "sound/spiderbot/swalk.wav": {
+     "bytes": 12636,
+     "sha256": "5534fe1b11fea5406aada214681dba031ec4a01e4b660c405b679131ba07a7cc"
+    },
+    "sound/tormentor/angry1.wav": {
+     "bytes": 88890,
+     "sha256": "60f757f523a9cbb3a57c335bbeda8cedbf990b9d20a5b359e610b712a1344b4b"
+    },
+    "sound/tormentor/angry2.wav": {
+     "bytes": 90912,
+     "sha256": "2f38dddb69cf0df2c1e5b028ca06ea22d979e637afa927919e9a93876dc955d6"
+    },
+    "sound/tormentor/death.wav": {
+     "bytes": 176628,
+     "sha256": "7060ecdadac0b1c9eb3574284444932573e4af13082f01374ed8a4633387bb66"
+    },
+    "sound/tormentor/fire2.wav": {
+     "bytes": 52092,
+     "sha256": "4133a00c7ef157d291d800524a148c188a314eb5ca14246958b8ddfeb0d4fe41"
+    },
+    "sound/tormentor/idle1.wav": {
+     "bytes": 115740,
+     "sha256": "78feebc847dccab66478718b66971870f11246c416e2f2c1e9830c459e4c0347"
+    },
+    "sound/tormentor/idle2.wav": {
+     "bytes": 122218,
+     "sha256": "0270712fe40851bb21d959932b4f8f75bbe8b985e2ff383319059c656ac0ce56"
+    },
+    "sound/tormentor/pain1.wav": {
+     "bytes": 67334,
+     "sha256": "03f255d6ee0d6fb83f2a643491f4cd24d9c5ff86444a51b3cf8b5a0de3d86bbc"
+    },
+    "sound/tormentor/punch_hit.wav": {
+     "bytes": 76614,
+     "sha256": "e524d16b000237615bae3b8fed7b74726823cd4258561196f4641728047aaa26"
+    },
+    "sound/tormentor/punch_swoosh.wav": {
+     "bytes": 33044,
+     "sha256": "d0ef38ef4bf33d0c2f92b22c2a767c4efd66eefaa724df50b394958a7be5a705"
+    },
+    "sound/tormentor/sight.wav": {
+     "bytes": 94334,
+     "sha256": "34a13e6469c5e0ce2f6d18721b0cdd634731b9a9f8910a8bb8b685f63dadfaac"
+    },
+    "sound/tormentor/step1.wav": {
+     "bytes": 11420,
+     "sha256": "65d748fe31cbcb50abc0e8991c755b99cf6506c8a36a2f1a0acf1891ec5f9403"
+    },
+    "sound/tormentor/sting2.wav": {
+     "bytes": 21674,
+     "sha256": "dd2d40459c7aa9d374efe2f219c34773f390df9f5177a83dbfa5fd638a13c542"
+    },
+    "sound/turret/alarm.wav": {
+     "bytes": 22126,
+     "sha256": "20a8a83d73a55dcc3d8a6fcb79b4ff8ecba0b5887cf3bdcdc96303f069b062ce"
+    },
+    "sound/turret/beep.wav": {
+     "bytes": 22126,
+     "sha256": "89f0e2ba68562cfc3e20272f995777c174c2681cfcf29d2ef337974009b42460"
+    },
+    "sound/turret/deploy.wav": {
+     "bytes": 105260,
+     "sha256": "5bb8c1fa8ffdf22e58ac5fb7a337916a457b9d021661742fcdbbdd7ce188c6dd"
+    },
+    "sound/turret/deploy2.wav": {
+     "bytes": 54208,
+     "sha256": "ec26b9451b67dae2929488687b7b9344a96f7538ab5c4f69e8a85602804dffc2"
+    },
+    "sound/turret/disable.wav": {
+     "bytes": 57180,
+     "sha256": "d8767dcce34c1c7f660f5868c23938da4cc379cb4001b88a10ec1aebbf9e557c"
+    },
+    "sound/turret/idle.wav": {
+     "bytes": 35784,
+     "sha256": "fba6bc2ff517ef95a999e3910c74e3594e054ede298c7b3a5659a2c31565d37c"
+    },
+    "sound/weapons/axhit3.wav": {
+     "bytes": 15252,
+     "sha256": "2edf0f7c93f380d1dc9e7dd75618894419379ad1da984121f031859cf24ec30d"
+    },
+    "sound/weapons/axhit4.wav": {
+     "bytes": 12450,
+     "sha256": "c54f233c09f429da884256d72e19759eb28bf38818f6a2ca8192c634b04a8b9f"
+    },
+    "sound/weapons/dsfirxpl.wav": {
+     "bytes": 11737,
+     "sha256": "37bdd29355d23929387176318e88a273d9708ee70b28a02449a3e721f8eec60a"
+    },
+    "sound/weapons/dsplasma.wav": {
+     "bytes": 5738,
+     "sha256": "19cd26033d246d30e47a24fdf0ef3684531e0794a8238e6d380c6a8624d1cd19"
+    },
+    "sound/weapons/fuelexp.wav": {
+     "bytes": 16942,
+     "sha256": "8591deda5caf5f88cda6a3c3e7f144e531486db0389226ee8134682ac73b1b78"
+    },
+    "sound/weapons/sawatck.wav": {
+     "bytes": 8946,
+     "sha256": "55cda855378ea1f1332f0c152c442d6725f2eafe3681fd0aa414be59f1cd4406"
+    },
+    "sound/weapons/sawguts.wav": {
+     "bytes": 4616,
+     "sha256": "702a109353087adead2fab74433e50c8b27f7ee953b46b86c015296d53b1c66c"
+    },
+    "sound/weapons/sawidle.wav": {
+     "bytes": 43820,
+     "sha256": "32082cd1d44903409e97de782e5d9295272840e13280665a0ef3ff862b187f0f"
+    },
+    "sound/weapons/sawridle.wav": {
+     "bytes": 47570,
+     "sha256": "0dd8defb8ecfb1ea72e6ac70ab182573775812e2d7990dd2897d02d3c38464f5"
+    },
+    "sound/weapons/spindn_click.wav": {
+     "bytes": 9986,
+     "sha256": "b84866cddb7e61eea9ca49208d427c2289d63e6e3e2f59d4d51e302573079bc7"
+    },
+    "sound/zombie2/attack1.wav": {
+     "bytes": 22914,
+     "sha256": "da5345280208ea48855526989299927268566cef77ee187035bbe969076d6605"
+    },
+    "sound/zombie2/attack2.wav": {
+     "bytes": 24072,
+     "sha256": "59245700b47794e239563cc94e3ff045fcd7dad795bcfe343d8574ec3ac525b6"
+    },
+    "sound/zombie2/attack3.wav": {
+     "bytes": 15400,
+     "sha256": "0113aad711264c05a9e43bf8dba915bc89661444d7d802efabe8d61ebb3ba13f"
+    },
+    "sound/zombie2/attack4.wav": {
+     "bytes": 20922,
+     "sha256": "0aac55ae62b62cefece56103cd7079beeb433c3764f590641876e149c4328ecc"
+    },
+    "sound/zombie2/attack5.wav": {
+     "bytes": 26086,
+     "sha256": "b58c97928b535e79973e0390512b09d3d0adea79b1b1b5a8de59bc2cde40c412"
+    },
+    "sound/zombie2/attack6.wav": {
+     "bytes": 22272,
+     "sha256": "58c429256e2f5abb9d97c99ceedb78088d8ac977eca94e994b6d1eee8bb3eb8f"
+    },
+    "sound/zombie2/attack7.wav": {
+     "bytes": 34384,
+     "sha256": "d68e81783b6583738227eac608ab7af1a4b1e1b085c1e46bd9c0d029eab4fdde"
+    },
+    "sound/zombie2/death1.wav": {
+     "bytes": 46548,
+     "sha256": "a1b9e2bcebf9c56fb56405d1ec7fe4166ac10d2b6e1acc6f01e58aec9fd63e87"
+    },
+    "sound/zombie2/death2.wav": {
+     "bytes": 47048,
+     "sha256": "5964a3c1a665c70de8302052b2b6d72ea46b0a5e07ba22cc9919e1a0ffefcca3"
+    },
+    "sound/zombie2/death3.wav": {
+     "bytes": 52636,
+     "sha256": "5c76f8bc55ecea263df880e6b683b07066b37c9f62ff589b0e999534d3c256b0"
+    },
+    "sound/zombie2/footstep1.wav": {
+     "bytes": 12966,
+     "sha256": "2a85309bea05b7c7c90a82df071822828e413cce17646a9686fa4f1264d75e48"
+    },
+    "sound/zombie2/footstep2.wav": {
+     "bytes": 16880,
+     "sha256": "d1d9e9c3811b39b67c9a6966851873ff7edf8d1407c5d9b90782b233196a4872"
+    },
+    "sound/zombie2/footstep3.wav": {
+     "bytes": 20904,
+     "sha256": "b12e9ea9b9478428b886fcaab504856393a57abd8cfdfc5ba5357ad745ee3455"
+    },
+    "sound/zombie2/footstep4.wav": {
+     "bytes": 15796,
+     "sha256": "6f82ac60991e64c8c48a3208a161b46f5b916587cb41863992dc1acb08268889"
+    },
+    "sound/zombie2/footstep5.wav": {
+     "bytes": 17800,
+     "sha256": "ca12f6ade73e5d5ba4ec1bdf680ce25afe3270bb88d702e1493b75619ec088d9"
+    },
+    "sound/zombie2/idle1.wav": {
+     "bytes": 143832,
+     "sha256": "aa203b0beb2db12beb6929fbc3646f7f119d4d31ede66b13af0412d396f7dd6d"
+    },
+    "sound/zombie2/idle2.wav": {
+     "bytes": 277026,
+     "sha256": "9496f3179e875bbb4d7442c252eac0eb2b9ef6d2269d43c141e01242ed2de7ee"
+    },
+    "sound/zombie2/idle3.wav": {
+     "bytes": 234026,
+     "sha256": "4820b03de8cebdee6fe787b5bf60724c17a0e133fdd5451176a202043f730f8e"
+    },
+    "sound/zombie2/idle4.wav": {
+     "bytes": 166352,
+     "sha256": "a515e5dc0e4fe1412a7936df5fab0f57a48c385db4fa357c1a4120671ac99617"
+    },
+    "sound/zombie2/idle5.wav": {
+     "bytes": 62782,
+     "sha256": "c6e4e2f26769400b7ca3b08339af089ba28bc063447d642e10cffffc6e03a485"
+    },
+    "sound/zombie2/idle6.wav": {
+     "bytes": 47274,
+     "sha256": "9ad1ced551cb42764fd88baf26ee09dc72d1852fa2da7405fde370d3e4d69a01"
+    },
+    "sound/zombie2/idle7.wav": {
+     "bytes": 45614,
+     "sha256": "41783a7682d5f8bb91aff8308b8657504cc8f0460b5ca436a5d0fb1c93357c85"
+    },
+    "sound/zombie2/idle8.wav": {
+     "bytes": 73070,
+     "sha256": "8f390d861feda3fb3950b0f33ce3efbfa8eda214533324674ac40b6e227b6975"
+    },
+    "sound/zombie2/punch1.wav": {
+     "bytes": 9218,
+     "sha256": "db6787efe0a0b8df5da690b91afe46a2199911b661fc9de1cfffc00b6bb8c46c"
+    },
+    "sound/zombie2/punch2.wav": {
+     "bytes": 8032,
+     "sha256": "747aabd6237176ae1bc62669cb08c7ec65fb26aa2147f6a3e1ab43f02ace7322"
+    },
+    "sound/zombie2/punch3.wav": {
+     "bytes": 13076,
+     "sha256": "05bb75533252d15983a944263789de5ee51187e518f4544fd1915b57ba726c7e"
+    },
+    "sound/zombie2/punch4.wav": {
+     "bytes": 13198,
+     "sha256": "d07556e7fc774958a6105564a990c51a0dab64fcf9508475617921a0ac5b961c"
+    },
+    "sound/zombie2/sight1.wav": {
+     "bytes": 73234,
+     "sha256": "387534044f10592ca6bc7a96b8e782c7b51de87b907e79a8f410d535e17d37ee"
+    },
+    "sound/zombie2/sight2.wav": {
+     "bytes": 52224,
+     "sha256": "cbc95608d4553d0bae66411d69875210e6fc6d728bd30deb6bbce7aabbacb773"
+    },
+    "sound/zombie2/sight3.wav": {
+     "bytes": 63072,
+     "sha256": "cbbcdb6da59d830a3be66095053259b17a90cc6501728ed1aa50d9524818f99b"
+    }
+   },
    "sha256": "d28482c599906c26dda722a5ca2b5d9fcf87f4aa81a8265d11279ffa4c7acc81",
    "timestamp": "2022-11-13T15:51:48.000Z"
   },

--- a/json/by-sha256/ff/ffc58e47d9475ba9896988c33c3ab0bb0dc352a2513deed51922fba544a8da78.json
+++ b/json/by-sha256/ff/ffc58e47d9475ba9896988c33c3ab0bb0dc352a2513deed51922fba544a8da78.json
@@ -7,6 +7,84 @@
  "files": {
   "ttb/pak0.pak": {
    "bytes": 15520105,
+   "files": {
+    "maps/start.bsp": {
+     "bytes": 1456752,
+     "sha256": "a9a577c707c0877a9f5cee2532dda95a6cc0cb1519a89b1f86139a792105c459"
+    },
+    "maps/ttb1.bsp": {
+     "bytes": 2451204,
+     "sha256": "c07a5c4399172b34b167487873c6dde2a6e487252bb2c212696587cc5e20649d"
+    },
+    "maps/ttb2.bsp": {
+     "bytes": 3881992,
+     "sha256": "fc3a38aca913b51a4096c6fdd0f19078db6cb2ca2044922e0069eec2b06b8fbf"
+    },
+    "maps/ttb3.bsp": {
+     "bytes": 1849516,
+     "sha256": "8bddc00f83451c0411845bbbbe2b7a34afec362859c411479890e7f094ed6d70"
+    },
+    "maps/ttb4.bsp": {
+     "bytes": 2010200,
+     "sha256": "4a71b689c4a4a7166a58515b28f78e2d356cbfeb98645e9d85cac8e2aaee9631"
+    },
+    "maps/ttbend.bsp": {
+     "bytes": 2736432,
+     "sha256": "5d11eab21cf617a1de2087775ec08d4a6e9dcc76f71989dfe88224b54a52bd92"
+    },
+    "progs.dat": {
+     "bytes": 425100,
+     "sha256": "056052ba93a1623563a341b3bcfecf52300cdbb36a967c7b8a3d9b52ff7485d9"
+    },
+    "progs/gib4.mdl": {
+     "bytes": 59539,
+     "sha256": "c66cc4f2c8aee10b9b9dfde86a12819eea6df55880763bf6e0e0fc312cde016b"
+    },
+    "sound/ambience/equake.wav": {
+     "bytes": 47148,
+     "sha256": "dcc45d2ef0703ecaa022c83cd66ae4992021ac379c11fc9da4401e184a191c93"
+    },
+    "sound/ambience/fb_fly.wav": {
+     "bytes": 5062,
+     "sha256": "5895619395d371d48387fdef8c71eb82a07b10ad201cbfa4152cd61ee1a1bb83"
+    },
+    "sound/ambience/quake.wav": {
+     "bytes": 34286,
+     "sha256": "3c984d6a11dac8cf9307c008abcaa480c94228e08c2201e1028ce821a246e266"
+    },
+    "sound/ambience/quakeend.wav": {
+     "bytes": 8160,
+     "sha256": "5818c531f9c729413b1afcb14475f16b7bad955c17c54b56d709a6a3bf34cd01"
+    },
+    "sound/ambience/zend1.wav": {
+     "bytes": 123618,
+     "sha256": "2df6c267197b2e82241e47ce4985b04d14e1ce3cff46cebf3177369057302bb6"
+    },
+    "sound/ambience/zend6.wav": {
+     "bytes": 252626,
+     "sha256": "3f3c412e55bc7534c423c0d1bec2d817e3aea06338b4d6c3f78c4b80e55d509f"
+    },
+    "sound/ambience/zend8.wav": {
+     "bytes": 112122,
+     "sha256": "27cef28aa3d6c3ea86f0c54168db07055abfc7af284bc5a35bf53a0e53f8d677"
+    },
+    "sound/gibfnt/gf_plop.wav": {
+     "bytes": 6988,
+     "sha256": "0cae50de463e00ec97e20f6155b5954326230a76315cc922f81935c894701685"
+    },
+    "sound/gibfnt/gf_sbig.wav": {
+     "bytes": 37932,
+     "sha256": "eea4f135fbaef31c99f9c3a837b6135b910af64bedcc2ff5ea42a65a16041d3a"
+    },
+    "sound/gibfnt/gf_sprt1.wav": {
+     "bytes": 7212,
+     "sha256": "12a321a008a89c4a336315aa695f9c345fac0ed820e876e648fc8d41b1cdcbd1"
+    },
+    "sound/gibfnt/gf_sprt2.wav": {
+     "bytes": 12988,
+     "sha256": "477997e36b69effe54190d95aaf0f66de5b92608ef0ac50454ee667aca025ffb"
+    }
+   },
    "sha256": "4a3175dd9325db8d8b19c8f68c5809b333745cad3337f1dcf669ecad4fc38d48",
    "timestamp": "2023-05-03T22:22:10.000Z"
   },


### PR DESCRIPTION
Since the old files mapping is back, we can also have all the files within files again. I recreated this from the current file archive and did _not_ check against the old content in this repo. Should be alright... If there are errors, someone can fix them later.