### PR TITLE
Add filename

### DIFF
--- a/json/by-sha256/d7/d7c21f4c8f6c939eb68e7669333d5f8c7b90cb591fd05ab619763011d462c4b6.json
+++ b/json/by-sha256/d7/d7c21f4c8f6c939eb68e7669333d5f8c7b90cb591fd05ab619763011d462c4b6.json
@@ -5,6 +5,7 @@
  "sha256": "d7c21f4c8f6c939eb68e7669333d5f8c7b90cb591fd05ab619763011d462c4b6",
  "tags": [
   "author=Kell",
+  "filename=2kell_wads.zip",
   "game=quake",
   "type=wad",
   "wad=apoc",


### PR DESCRIPTION
emergency fix because the solr pipeline has stricter requirements than the frontend :grimacing: 